### PR TITLE
Refactor boot package and centralize runtime plugin assembly

### DIFF
--- a/yak-ops-boot/pom.xml
+++ b/yak-ops-boot/pom.xml
@@ -7,12 +7,34 @@
     <dependencies>
         <dependency><groupId>io.baize.flow</groupId><artifactId>yak-ops-web</artifactId></dependency>
         <dependency><groupId>io.baize.flow</groupId><artifactId>yak-ops-infrastructure</artifactId></dependency>
-        <dependency><groupId>io.baize.flow</groupId><artifactId>yak-ops-datasource-all</artifactId></dependency>
-        <dependency><groupId>io.baize.flow</groupId><artifactId>yak-ops-alarm-all</artifactId></dependency>
-        <dependency><groupId>io.baize.flow</groupId><artifactId>yak-ops-engine-all</artifactId></dependency>
+        <!-- Runtime adapters are assembled here rather than leaking into core modules. -->
+        <dependency><groupId>io.baize.flow</groupId><artifactId>yak-ops-engine-seatunnel</artifactId></dependency>
         <dependency><groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-web</artifactId></dependency>
         <dependency><groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-webflux</artifactId></dependency>
         <dependency><groupId>org.flywaydb</groupId><artifactId>flyway-core</artifactId></dependency>
     </dependencies>
-    <build><finalName>${project.artifactId}</finalName><plugins><plugin><groupId>org.springframework.boot</groupId><artifactId>spring-boot-maven-plugin</artifactId><configuration><mainClass>io.baize.flow.api.BaizeFlowApplication</mainClass></configuration><executions><execution><goals><goal>repackage</goal></goals></execution></executions></plugin></plugins></build>
+    <profiles>
+        <!-- Fast, self-contained developer runtime: H2 plus the most common plugins. -->
+        <profile>
+            <id>local</id>
+            <activation><activeByDefault>true</activeByDefault></activation>
+            <dependencies>
+                <dependency><groupId>io.baize.flow</groupId><artifactId>yak-ops-dao-h2</artifactId><version>${project.version}</version></dependency>
+                <dependency><groupId>io.baize.flow</groupId><artifactId>yak-ops-datasource-mysql</artifactId></dependency>
+                <dependency><groupId>io.baize.flow</groupId><artifactId>yak-ops-alarm-webhook</artifactId></dependency>
+            </dependencies>
+        </profile>
+        <!-- No optional datasource, alarm, or DAO implementation plugins. -->
+        <profile><id>minimal</id></profile>
+        <!-- Production distribution containing every supported runtime plugin. -->
+        <profile>
+            <id>full</id>
+            <dependencies>
+                <dependency><groupId>io.baize.flow</groupId><artifactId>yak-ops-datasource-all</artifactId></dependency>
+                <dependency><groupId>io.baize.flow</groupId><artifactId>yak-ops-alarm-all</artifactId></dependency>
+                <dependency><groupId>io.baize.flow</groupId><artifactId>yak-ops-dao-plugin-all</artifactId></dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+    <build><finalName>${project.artifactId}</finalName><plugins><plugin><groupId>org.springframework.boot</groupId><artifactId>spring-boot-maven-plugin</artifactId><configuration><mainClass>io.baize.flow.boot.BaizeFlowApplication</mainClass></configuration><executions><execution><goals><goal>repackage</goal></goals></execution></executions></plugin></plugins></build>
 </project>

--- a/yak-ops-boot/src/main/java/io/baize/flow/api/config/SchedulingConfig.java
+++ b/yak-ops-boot/src/main/java/io/baize/flow/api/config/SchedulingConfig.java
@@ -1,9 +1,0 @@
-package io.baize.flow.api.config;
-
-import org.springframework.context.annotation.Configuration;
-import org.springframework.scheduling.annotation.EnableScheduling;
-
-@Configuration
-@EnableScheduling
-public class SchedulingConfig {
-}

--- a/yak-ops-boot/src/main/java/io/baize/flow/boot/BaizeFlowApplication.java
+++ b/yak-ops-boot/src/main/java/io/baize/flow/boot/BaizeFlowApplication.java
@@ -1,19 +1,25 @@
-package io.baize.flow.api;
+package io.baize.flow.boot;
 
-import jakarta.annotation.Resource;
+import io.baize.flow.dao.DaoConfiguration;
 import org.apache.seatunnel.plugin.datasource.api.plugin.DataSourceProcessorProvider;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Import;
 import org.springframework.scheduling.annotation.EnableAsync;
-import org.springframework.scheduling.annotation.EnableScheduling;
 
-
-@SpringBootApplication(scanBasePackages = {"org.apache.seatunnel.*"})
+@SpringBootApplication
+@ComponentScan(basePackages = {
+        "io.baize.flow.api",
+        "io.baize.flow.application",
+        "io.baize.flow.infrastructure",
+        "io.baize.flow.dao",
+        "io.baize.flow.engine",
+        "org.apache.seatunnel.plugin.datasource.api"
+})
+@Import(DaoConfiguration.class)
 @EnableConfigurationProperties
-@EnableScheduling
 @EnableAsync(proxyTargetClass = true)
 public class BaizeFlowApplication {
 
@@ -27,4 +33,3 @@ public class BaizeFlowApplication {
         }
     }
 }
-

--- a/yak-ops-boot/src/main/java/io/baize/flow/boot/config/OpenAPIConfig.java
+++ b/yak-ops-boot/src/main/java/io/baize/flow/boot/config/OpenAPIConfig.java
@@ -1,4 +1,4 @@
-package io.baize.flow.api.config;
+package io.baize.flow.boot.config;
 
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Contact;

--- a/yak-ops-boot/src/main/java/io/baize/flow/boot/config/SchedulingConfig.java
+++ b/yak-ops-boot/src/main/java/io/baize/flow/boot/config/SchedulingConfig.java
@@ -1,0 +1,11 @@
+package io.baize.flow.boot.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+
+@Configuration
+@EnableScheduling
+@ConditionalOnProperty(prefix = "yak-ops.scheduler", name = "enabled", havingValue = "true", matchIfMissing = true)
+public class SchedulingConfig {
+}

--- a/yak-ops-boot/src/main/java/io/baize/flow/boot/config/SeaTunnelClientConfig.java
+++ b/yak-ops-boot/src/main/java/io/baize/flow/boot/config/SeaTunnelClientConfig.java
@@ -1,4 +1,4 @@
-package io.baize.flow.api.config;
+package io.baize.flow.boot.config;
 
 import io.baize.flow.engine.seatunnel.rest.SeaTunnelClientProperties;
 import io.baize.flow.engine.seatunnel.rest.SeaTunnelClientResolver;

--- a/yak-ops-boot/src/main/java/io/baize/flow/boot/config/SecurityConfig.java
+++ b/yak-ops-boot/src/main/java/io/baize/flow/boot/config/SecurityConfig.java
@@ -1,4 +1,4 @@
-package io.baize.flow.api.config;
+package io.baize.flow.boot.config;
 
 import org.apache.commons.lang3.StringUtils;
 import io.baize.flow.api.security.AuthenticationType;

--- a/yak-ops-boot/src/main/java/io/baize/flow/boot/config/WebMvcConfig.java
+++ b/yak-ops-boot/src/main/java/io/baize/flow/boot/config/WebMvcConfig.java
@@ -1,4 +1,4 @@
-package io.baize.flow.api.config;
+package io.baize.flow.boot.config;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;

--- a/yak-ops-boot/src/main/java/io/baize/flow/boot/config/WebSocketConfig.java
+++ b/yak-ops-boot/src/main/java/io/baize/flow/boot/config/WebSocketConfig.java
@@ -1,4 +1,4 @@
-package io.baize.flow.api.config;
+package io.baize.flow.boot.config;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;

--- a/yak-ops-dao/pom.xml
+++ b/yak-ops-dao/pom.xml
@@ -47,10 +47,6 @@
             <artifactId>yak-ops-datasource-support</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.baize.flow</groupId>
-            <artifactId>yak-ops-dao-plugin-all</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.zaxxer</groupId>
             <artifactId>HikariCP</artifactId>
         </dependency>


### PR DESCRIPTION
### Motivation
- Make the boot module the explicit runtime composition root and avoid accidental cross-module package scanning. 
- Consolidate Spring Boot startup class and boot-owned HTTP, security, WebSocket, OpenAPI, client and scheduling configuration under a dedicated `io.baize.flow.boot` package so runtime wiring is explicit.
- Provide clear runtime profiles for local, minimal and full deployments so optional `*-all` bundles are pulled only when intended.

### Description
- Move the Spring Boot entry point and all boot configuration classes from `io.baize.flow.api` to `io.baize.flow.boot` and `io.baize.flow.boot.config`, updating package declarations accordingly and renaming files under `yak-ops-boot/src/main/java`.
- Replace broad package auto-scan with an explicit `@ComponentScan(...)` list and add `@Import(DaoConfiguration.class)` to the boot application to assemble `application`, `web`, `infrastructure`, `dao`, `engine` and `datasource-support` components from the boot entry point.
- Remove the aggregated DAO plugin bundle dependency from `yak-ops-dao` (`yak-ops-dao-plugin-all`) so core DAO does not implicitly bring all implementations.
- Change `yak-ops-boot/pom.xml` to depend on the concrete engine adapter `yak-ops-engine-seatunnel`, add `local`/`minimal`/`full` Maven profiles (with `full` reintroducing `*-all` bundles when requested), and update the Spring Boot Maven plugin `mainClass` to `io.baize.flow.boot.BaizeFlowApplication`.
- Make scheduling configuration conditional via `@ConditionalOnProperty(prefix = "yak-ops.scheduler", name = "enabled", havingValue = "true", matchIfMissing = true)` to allow turning the scheduler on/off per runtime.

### Testing
- Parsed every `pom.xml` with a small `python3` ET.parse script to validate XML structure and the edits applied successfully.
- Verified POM references and `*-all` artifacts with repository searches (`rg`) to ensure `*-all` bundles are only included in boot `full` profile or aggregate modules.
- Ran `git diff --check` and `git diff --cached --check` to validate workspace diffs and found no whitespace/merge conflicts.
- Attempted to run `mvn -pl yak-ops-boot -am -Pminimal -DskipTests package` and wrapper invocation, but the environment failed to resolve external artifacts (Maven Wrapper download and Maven Central parent POM returned HTTP 403), so a full package build could not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a63f8b7c3dc832682b82906ba7933d5)