### PR TITLE
ci: add staged engine-neutrality migration gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,18 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  engine-neutrality:
+    name: Engine neutrality
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Enforce vendor-token ledger
+        run: |
+          rg -i 'seatunnel|zeta' --glob '!tools/engine-neutrality-allowlist.txt' > /tmp/engine-vendor-inventory.txt || true
+          python3 tools/check-engine-neutrality.py
+
   backend:
     name: Backend
     runs-on: ubuntu-latest

--- a/docs/engine-neutralization-ledger.md
+++ b/docs/engine-neutralization-ledger.md
@@ -1,0 +1,41 @@
+# Engine neutralization ledger
+
+The case-insensitive inventory is generated from tracked files so build artifacts cannot hide
+or create findings:
+
+```bash
+python3 tools/check-engine-neutrality.py --inventory > /tmp/engine-neutrality.json
+```
+
+It covers `seatunnel`, `sea_tunnel`, and `zeta`, including occurrences embedded in REST paths
+and status constants. Each matching file is classified as Java, POM, configuration, SQL, UI,
+log, API, documentation, or other. The JSON output is the ledger of record rather than a stale
+hand-maintained list.
+
+## Gates and staged retirement
+
+Domain and engine-contract sources are zero-match gates. Application debt is frozen at its
+current baseline and may only decrease; set its baseline to zero after internal symbol renames
+land. The path allowlist is deliberately restricted to the legacy adapter, compatibility
+migrations, and compatibility API tests. Delete entries as each boundary is retired.
+
+Compatibility rules:
+
+1. Historical HTTP DTOs live only in `yak-ops-web`; controllers immediately translate them to
+   neutral application commands/results, and every legacy response field documents its removal
+   version.
+2. Configuration aliases flow in one direction: `engine.*`, then `legacy.engine.*`, then the
+   deprecated vendor prefix with a once-only warning. Business code never reads deprecated keys.
+3. Schema evolution uses new migrations: expand with `engine_endpoint`, `engine_endpoint_id`, and
+   neutral engine/status columns; backfill and dual-read-validate; switch writes; then contract.
+4. Persistence conversion for historical engine keys and job statuses belongs only in a
+   persistence legacy adapter. Neither domain nor application code interprets vendor values.
+5. The UI uses neutral types, routes, copy, API clients, and state. A historical route may perform
+   one redirect but must not leak its vocabulary into new state.
+
+## Feature deletion audit
+
+Before removing AI, topology, checkpoint, or another apparently unused feature, record searches
+for its controllers, permission identifiers, menu records, scheduled jobs, alert rules, and UI
+imports/routes. Deletion is permitted only when all seven surfaces are empty or migrated and the
+relevant integration tests prove that no compatibility endpoint is still active.

--- a/tools/check-engine-neutrality.py
+++ b/tools/check-engine-neutrality.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Inventory vendor coupling and prevent it from growing during staged removal."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from collections import Counter
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+TOKEN = re.compile(rb"seatunnel|sea_tunnel|zeta", re.IGNORECASE)
+ZERO_SCOPES = ("yak-ops-domain/", "yak-ops-engine-contract/")
+
+
+def tracked_files() -> list[str]:
+    output = subprocess.check_output(["git", "ls-files", "-z"], cwd=ROOT)
+    return [name.decode() for name in output.split(b"\0") if name]
+
+
+def category(path: str) -> str:
+    lower = path.lower()
+    if lower.endswith(".java"):
+        return "API" if any(part in lower for part in ("controller", "/api/", "/web/")) else "Java"
+    if lower.endswith("pom.xml"):
+        return "POM"
+    if lower.endswith(".sql"):
+        return "SQL"
+    if lower.startswith("yak-ops-ui/"):
+        return "UI"
+    if lower.endswith((".yml", ".yaml", ".properties", ".env")) or "compose" in lower:
+        return "Configuration"
+    if lower.endswith((".md", ".adoc", ".txt")):
+        return "Documentation"
+    if "log" in Path(lower).name:
+        return "Log"
+    return "Other"
+
+
+def matches() -> dict[str, int]:
+    result: dict[str, int] = {}
+    for name in tracked_files():
+        try:
+            count = len(TOKEN.findall((ROOT / name).read_bytes()))
+        except OSError:
+            continue
+        if count:
+            result[name] = count
+    return result
+
+
+def load_allowlist() -> list[re.Pattern[str]]:
+    lines = (ROOT / "tools/engine-neutrality-allowlist.txt").read_text().splitlines()
+    return [re.compile(line) for line in lines if line and not line.startswith("#")]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--inventory", action="store_true", help="print the classified ledger")
+    args = parser.parse_args()
+    found = matches()
+    if args.inventory:
+        totals = Counter(category(path) for path in found)
+        print(json.dumps({"categories": dict(sorted(totals.items())), "files": found}, indent=2))
+        return 0
+
+    errors: list[str] = []
+    for scope in ZERO_SCOPES:
+        scoped = [path for path in found if path.startswith(scope)]
+        if scoped:
+            errors.append(f"zero-match scope {scope}: {', '.join(scoped)}")
+
+    # Application is still being migrated. Freeze its current debt so every change can only
+    # reduce it; changing this number requires an explicit review of the generated ledger.
+    application_total = sum(count for path, count in found.items() if path.startswith("yak-ops-application/"))
+    baseline = 595
+    if application_total > baseline:
+        errors.append(f"application vendor-token debt grew: {application_total} > {baseline}")
+
+    allowlist = load_allowlist()
+    for pattern in allowlist:
+        if not any(pattern.search(path) for path in found):
+            errors.append(f"stale allowlist entry: {pattern.pattern}")
+
+    if errors:
+        print("Engine-neutrality gate failed:\n- " + "\n- ".join(errors), file=sys.stderr)
+        return 1
+    print(f"Engine-neutrality gate passed (application staged debt: {application_total}/{baseline}).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/engine-neutrality-allowlist.txt
+++ b/tools/engine-neutrality-allowlist.txt
@@ -1,0 +1,3 @@
+# Every entry is a Python regular expression matched against a repository-relative path.
+# Keep this list limited to the three compatibility boundaries described below.
+^yak-ops-engine-legacy/(src/.*|README\.md)$


### PR DESCRIPTION
### Motivation

- Prevent new vendor-specific tokens (`seatunnel`, `sea_tunnel`, `zeta`) from spreading during a staged neutralization by providing an automated inventory and enforcement gate.  
- Treat domain and engine-contract sources as zero-match gates and freeze the application-layer debt so migration can be progressed in controlled stages.  

### Description

- Add an inventory/enforcement script at `tools/check-engine-neutrality.py` that case-insensitively scans tracked files for `seatunnel|sea_tunnel|zeta`, classifies matches by type (Java, POM, Configuration, SQL, UI, Log, API, Documentation, Other), enforces zero-match scopes `yak-ops-domain/` and `yak-ops-engine-contract/`, and checks an allowlist and a frozen application baseline (set to `595`).  
- Introduce a constrained allowlist at `tools/engine-neutrality-allowlist.txt` limited to the legacy adapter boundary.  
- Add documentation `docs/engine-neutralization-ledger.md` describing the ledger, migration rules (DTO translation, one-way config aliases, schema expansion/backfill/dual-read/write-switch/contract strategy, persistence adapter boundary, UI neutralization, and feature deletion audit).  
- Integrate the check into CI by adding an `engine-neutrality` job in `.github/workflows/ci.yml` that runs a raw `rg -i 'seatunnel|zeta'` inventory (excluding the allowlist) and executes the enforcement script.  

### Testing

- Ran `python3 tools/check-engine-neutrality.py` locally and the final run reported the gate passed with the staged baseline (`Engine-neutrality gate passed (application staged debt: 595/595)`).  
- Generated the ledger JSON with `python3 tools/check-engine-neutrality.py --inventory >/tmp/engine-neutrality.json` to validate classification output.  
- Verified the script is syntactically valid with `python3 -m py_compile tools/check-engine-neutrality.py`.  
- Performed repository checks with `git diff --check` to ensure no formatting/index issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a64098596d08326bb46615b16745a35)