### PR TITLE
fix(engine): preserve unknown vendor execution statuses

### DIFF
--- a/yak-ops-engine-legacy/src/main/java/io/baize/flow/engine/legacy/internal/vendor/LegacyEngineAdapter.java
+++ b/yak-ops-engine-legacy/src/main/java/io/baize/flow/engine/legacy/internal/vendor/LegacyEngineAdapter.java
@@ -33,7 +33,11 @@ public class LegacyEngineAdapter implements EngineGateway, EngineMetricsGateway 
     @Override public void cancel(EngineEndpoint endpoint, String jobId) { try { client.cancel(clientId(endpoint), jobId); } catch (Exception e) { throw SeaTunnelErrorMapper.unavailable("cancel", e); } }
     @Override public JobExecution execution(EngineEndpoint endpoint, String platformId, String jobId) {
         try { SeaTunnelJobResponse info = client.job(clientId(endpoint), jobId); if (info == null) throw SeaTunnelErrorMapper.unavailable("query", new IllegalStateException("empty response"));
-            java.time.Instant now=java.time.Instant.now(); return new JobExecution(platformId, jobId, SeaTunnelExecutionStatusMapper.map(info.status()), null, null, null, now, info.errorMessage(), java.util.Map.of()); }
+            SeaTunnelExecutionStatusMapper.StatusResolution status = SeaTunnelExecutionStatusMapper.resolve(info.status());
+            java.util.Map<String, String> metadata = status.rawStatus() == null
+                    ? java.util.Map.of()
+                    : java.util.Map.of("vendor.raw_status", status.rawStatus());
+            java.time.Instant now=java.time.Instant.now(); return new JobExecution(platformId, jobId, status.status(), null, null, null, now, info.errorMessage(), metadata); }
         catch (EngineContractException e) { throw e; } catch (Exception e) { throw SeaTunnelErrorMapper.unavailable("query", e); }
     }
     @Override public EngineMetrics metrics(EngineEndpoint endpoint, String jobId) { capabilities().require(EngineCapabilities.Capability.METRICS); try { SeaTunnelMetricsResponse response = client.metrics(clientId(endpoint), jobId); if (response == null) throw SeaTunnelErrorMapper.unavailable("metrics", new IllegalStateException("empty response")); return SeaTunnelMetricsMapper.map(response.values()); } catch (EngineContractException e) { throw e; } catch (Exception e) { throw SeaTunnelErrorMapper.unavailable("metrics", e); } }

--- a/yak-ops-engine-legacy/src/main/java/io/baize/flow/engine/legacy/internal/vendor/SeaTunnelExecutionStatusMapper.java
+++ b/yak-ops-engine-legacy/src/main/java/io/baize/flow/engine/legacy/internal/vendor/SeaTunnelExecutionStatusMapper.java
@@ -1,21 +1,40 @@
 package io.baize.flow.engine.legacy.internal.vendor;
 
 import io.baize.flow.engine.api.JobExecutionStatus;
+import java.util.Map;
 import java.util.Locale;
 
 /** The only place where SeaTunnel lifecycle values enter the platform contract. */
 public final class SeaTunnelExecutionStatusMapper {
+    private static final Map<String, JobExecutionStatus> STATUS_MAP = Map.ofEntries(
+            Map.entry("CREATED", JobExecutionStatus.SUBMITTED),
+            Map.entry("SUBMITTED", JobExecutionStatus.SUBMITTED),
+            Map.entry("QUEUED", JobExecutionStatus.SUBMITTED),
+            Map.entry("INITIALIZING", JobExecutionStatus.RUNNING),
+            Map.entry("RUNNING", JobExecutionStatus.RUNNING),
+            Map.entry("RESTARTING", JobExecutionStatus.RUNNING),
+            Map.entry("CANCELLING", JobExecutionStatus.CANCELLING),
+            Map.entry("CANCELING", JobExecutionStatus.CANCELLING),
+            Map.entry("CANCELED", JobExecutionStatus.CANCELED),
+            Map.entry("CANCELLED", JobExecutionStatus.CANCELED),
+            Map.entry("FINISHED", JobExecutionStatus.SUCCEEDED),
+            Map.entry("SUCCESS", JobExecutionStatus.SUCCEEDED),
+            Map.entry("SUCCEEDED", JobExecutionStatus.SUCCEEDED),
+            Map.entry("FAILED", JobExecutionStatus.FAILED),
+            Map.entry("ERROR", JobExecutionStatus.FAILED));
+
     private SeaTunnelExecutionStatusMapper() { }
     public static JobExecutionStatus map(String vendorStatus) {
-        if (vendorStatus == null) return JobExecutionStatus.UNKNOWN;
-        return switch (vendorStatus.toUpperCase(Locale.ROOT)) {
-            case "CREATED", "SUBMITTED", "QUEUED" -> JobExecutionStatus.SUBMITTED;
-            case "INITIALIZING", "RUNNING", "RESTARTING" -> JobExecutionStatus.RUNNING;
-            case "CANCELLING", "CANCELING" -> JobExecutionStatus.CANCELLING;
-            case "CANCELED", "CANCELLED" -> JobExecutionStatus.CANCELED;
-            case "FINISHED", "SUCCESS", "SUCCEEDED" -> JobExecutionStatus.SUCCEEDED;
-            case "FAILED", "ERROR" -> JobExecutionStatus.FAILED;
-            default -> JobExecutionStatus.UNKNOWN;
-        };
+        return resolve(vendorStatus).status();
     }
+
+    /** Resolves only explicitly recognized values and retains the original wire value. */
+    public static StatusResolution resolve(String vendorStatus) {
+        if (vendorStatus == null) return new StatusResolution(JobExecutionStatus.UNKNOWN, null);
+        String normalized = vendorStatus.trim().toUpperCase(Locale.ROOT);
+        return new StatusResolution(
+                STATUS_MAP.getOrDefault(normalized, JobExecutionStatus.UNKNOWN), vendorStatus);
+    }
+
+    public record StatusResolution(JobExecutionStatus status, String rawStatus) { }
 }

--- a/yak-ops-engine-legacy/src/test/java/io/baize/flow/engine/legacy/internal/vendor/SeaTunnelExecutionStatusMapperTest.java
+++ b/yak-ops-engine-legacy/src/test/java/io/baize/flow/engine/legacy/internal/vendor/SeaTunnelExecutionStatusMapperTest.java
@@ -7,6 +7,12 @@ class SeaTunnelExecutionStatusMapperTest {
   assertEquals(JobExecutionStatus.RUNNING, SeaTunnelExecutionStatusMapper.map("RUNNING"));
   assertEquals(JobExecutionStatus.SUCCEEDED, SeaTunnelExecutionStatusMapper.map("FINISHED"));
   assertEquals(JobExecutionStatus.CANCELED, SeaTunnelExecutionStatusMapper.map("CANCELLED"));
-  assertEquals(JobExecutionStatus.UNKNOWN, SeaTunnelExecutionStatusMapper.map("NEW_VENDOR_STATE"));
+ assertEquals(JobExecutionStatus.UNKNOWN, SeaTunnelExecutionStatusMapper.map("NEW_VENDOR_STATE"));
+ }
+ @Test void preservesUnknownWireValueWithoutInferringOutcome() {
+  SeaTunnelExecutionStatusMapper.StatusResolution result =
+          SeaTunnelExecutionStatusMapper.resolve(" New_Vendor_State ");
+  assertEquals(JobExecutionStatus.UNKNOWN, result.status());
+  assertEquals(" New_Vendor_State ", result.rawStatus());
  }
 }


### PR DESCRIPTION
### Motivation

- Replace implicit vendor lifecycle switching with an explicit, immutable mapping so only known vendor statuses are interpreted.  
- Ensure unrecognized vendor values are mapped to `UNKNOWN` and the original wire value is retained for auditing and backfill.  
- Surface the raw vendor status in execution diagnostic metadata so persistence/diagnosis can record the original value without inferring success/failure.

### Description

- Add an explicit `STATUS_MAP` and a `StatusResolution` record with a `resolve(String)` helper to `SeaTunnelExecutionStatusMapper` so resolution is table-driven and preserves the raw vendor string; the previous switch-based mapping is replaced by a call to `resolve` (`yak-ops-engine-legacy/src/main/java/io/baize/flow/engine/legacy/internal/vendor/SeaTunnelExecutionStatusMapper.java`).  
- Change `LegacyEngineAdapter.execution(...)` to use `SeaTunnelExecutionStatusMapper.resolve(...)` and to attach the preserved raw vendor status into execution metadata as `vendor.raw_status` when present (`yak-ops-engine-legacy/src/main/java/io/baize/flow/engine/legacy/internal/vendor/LegacyEngineAdapter.java`).  
- Add a unit test that verifies unknown wire values resolve to `UNKNOWN` while retaining the exact raw value (`yak-ops-engine-legacy/src/test/java/io/baize/flow/engine/legacy/internal/vendor/SeaTunnelExecutionStatusMapperTest.java`).  
- Keep the change focused on mapping behavior only and do not introduce database migrations, package moves, or endpoint-selection changes in this PR.

### Testing

- `python3 tools/check-engine-neutrality.py` executed and passed.  
- `python3 -m unittest tools.tests.test_check_engine_neutrality` executed and passed.  
- `git diff --check` and `git diff --cached --check` were executed and reported no style/check issues.  
- `mvn -pl yak-ops-engine-legacy -am test -DskipTests=false` was attempted but failed due to Maven Central returning HTTP 403 for `spring-boot-dependencies:3.3.13`, preventing full JVM test execution in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a641046673c832689e25e2f9ddbae86)