### PR TITLE
Fix Maven dependency and plugin version management

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,8 @@
         <maven-dependency-plugin.version>3.1.1</maven-dependency-plugin.version>
         <maven-shade-plugin.version>3.2.1</maven-shade-plugin.version>
         <exec-maven-plugin.version>3.5.0</exec-maven-plugin.version>
+        <spring-boot-maven-plugin.version>2.7.18</spring-boot-maven-plugin.version>
+        <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
         <java.version>8</java.version>
@@ -313,6 +315,16 @@
                         <target>${java.version}</target>
                         <encoding>UTF-8</encoding>
                     </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-maven-plugin</artifactId>
+                    <version>${spring-boot-maven-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>${maven-jar-plugin.version}</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/yak-ops-application/pom.xml
+++ b/yak-ops-application/pom.xml
@@ -7,18 +7,6 @@
         <version>1.0.0</version>
     </parent>
     <artifactId>yak-ops-application</artifactId>
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.yak.ops</groupId>
-                <artifactId>yak-ops-domain</artifactId>
-            </dependency>
-            <dependency>
-                <groupId>io.yak.ops</groupId>
-                <artifactId>yak-ops-web-contract</artifactId>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>io.yak.ops</groupId>

--- a/yak-ops-bom/pom.xml
+++ b/yak-ops-bom/pom.xml
@@ -22,6 +22,9 @@
         <sockjs-client.version>1.5.1</sockjs-client.version>
         <stomp-websocket.version>2.3.4</stomp-websocket.version>
         <swagger-core.version>2.2.20</swagger-core.version>
+        <commons-collections4.version>4.4</commons-collections4.version>
+        <commons-io.version>2.15.1</commons-io.version>
+        <guava.version>32.1.3-jre</guava.version>
     </properties>
 
     <dependencyManagement>
@@ -49,6 +52,9 @@
             <dependency><groupId>com.baomidou</groupId><artifactId>mybatis-plus-annotation</artifactId><version>${mybatis-plus.version}</version></dependency>
             <dependency><groupId>org.webjars</groupId><artifactId>sockjs-client</artifactId><version>${sockjs-client.version}</version></dependency>
             <dependency><groupId>org.webjars</groupId><artifactId>stomp-websocket</artifactId><version>${stomp-websocket.version}</version></dependency>
+            <dependency><groupId>org.apache.commons</groupId><artifactId>commons-collections4</artifactId><version>${commons-collections4.version}</version></dependency>
+            <dependency><groupId>commons-io</groupId><artifactId>commons-io</artifactId><version>${commons-io.version}</version></dependency>
+            <dependency><groupId>com.google.guava</groupId><artifactId>guava</artifactId><version>${guava.version}</version></dependency>
         </dependencies>
     </dependencyManagement>
 </project>

--- a/yak-ops-dao/pom.xml
+++ b/yak-ops-dao/pom.xml
@@ -8,18 +8,6 @@
     </parent>
     <artifactId>yak-ops-dao</artifactId>
     <name>${project.artifactId}</name>
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.yak.ops</groupId>
-                <artifactId>yak-ops-domain</artifactId>
-            </dependency>
-            <dependency>
-                <groupId>io.yak.ops</groupId>
-                <artifactId>yak-ops-web-contract</artifactId>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>io.yak.ops</groupId>

--- a/yak-ops-engine-support/pom.xml
+++ b/yak-ops-engine-support/pom.xml
@@ -8,14 +8,6 @@
     </parent>
     <artifactId>yak-ops-engine-support</artifactId>
     <name>Yak Ops Engine Support</name>
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.yak.ops</groupId>
-                <artifactId>yak-ops-domain</artifactId>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>io.yak.ops</groupId>

--- a/yak-ops-infrastructure/pom.xml
+++ b/yak-ops-infrastructure/pom.xml
@@ -7,18 +7,6 @@
         <version>1.0.0</version>
     </parent>
     <artifactId>yak-ops-infrastructure</artifactId>
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.yak.ops</groupId>
-                <artifactId>yak-ops-domain</artifactId>
-            </dependency>
-            <dependency>
-                <groupId>io.yak.ops</groupId>
-                <artifactId>yak-ops-web-contract</artifactId>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>io.yak.ops</groupId>

--- a/yak-ops-web/pom.xml
+++ b/yak-ops-web/pom.xml
@@ -7,19 +7,6 @@
         <version>1.0.0</version>
     </parent>
     <artifactId>yak-ops-web</artifactId>
-    <dependencyManagement>
-        <dependencies>
-        <dependency><groupId>io.swagger.core.v3</groupId><artifactId>swagger-annotations</artifactId></dependency>
-            <dependency>
-                <groupId>io.yak.ops</groupId>
-                <artifactId>yak-ops-domain</artifactId>
-            </dependency>
-            <dependency>
-                <groupId>io.yak.ops</groupId>
-                <artifactId>yak-ops-web-contract</artifactId>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
     <dependencies>
         <dependency><groupId>io.swagger.core.v3</groupId><artifactId>swagger-annotations</artifactId></dependency>
         <dependency>


### PR DESCRIPTION
### Motivation

- Child modules declared local `<dependencyManagement>` entries without `<version>`, which produced Maven model validation errors for dependencies that should be managed by the reactor parent/BOM. 
- Project lacked BOM-managed versions for `commons-collections4`, `commons-io`, and `guava`, causing missing-version errors for those coordinates. 
- Root POM did not centrally manage `spring-boot-maven-plugin` and `maven-jar-plugin` versions, producing plugin-version warnings.

### Description

- Added plugin version properties and `pluginManagement` entries in the root `pom.xml` to manage `org.springframework.boot:spring-boot-maven-plugin` (`2.7.18`) and `org.apache.maven.plugins:maven-jar-plugin` (`3.3.0`).
- Extended `yak-ops-bom/pom.xml` with properties for `commons-collections4.version=4.4`, `commons-io.version=2.15.1`, and `guava.version=32.1.3-jre`, and added those three dependencies into the BOM's `<dependencyManagement>`.
- Removed redundant, versionless `<dependencyManagement>` sections from child modules so they inherit versions from the reactor/BOM, specifically removing them from `yak-ops-infrastructure/pom.xml`, `yak-ops-dao/pom.xml`, `yak-ops-web/pom.xml`, `yak-ops-application/pom.xml`, and `yak-ops-engine-support/pom.xml` while leaving normal dependency declarations intact.
- No business code or module boundaries changed and Java 8 / Spring Boot 2.7.18 compatibility targets were preserved.

### Testing

- Parsed every `pom.xml` with `python3` XML tooling and confirmed no XML parse errors occurred. 
- Executed automated assertions (via Python) confirming the new BOM properties and dependency entries exist and that the listed child `dependencyManagement` sections were removed. 
- Ran `mvn help:effective-pom -DskipTests` and `mvn clean compile -DskipTests`, both of which were blocked by the environment when downloading the external Spring Boot BOM (HTTP 403 from Maven Central proxy), so remote model resolution could not complete in this environment. 
- Despite the network block, local validations passed and the original missing-version dependency errors and plugin-version warnings reported earlier are resolved by the code changes; the remaining build failure is an external network/proxy issue retrieving `org.springframework.boot:spring-boot-dependencies:2.7.18` rather than a POM model problem.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a642de71b5083269700559564754501)