### PR TITLE
build: skip architecture checks automatically on Windows

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
         <java.version>8</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <file_encoding>UTF-8</file_encoding>
+        <architecture.check.skip>false</architecture.check.skip>
     </properties>
     <!--
       Module migration matrix (old -> owner):
@@ -279,6 +280,7 @@
                             <goal>exec</goal>
                         </goals>
                         <configuration>
+                            <skip>${architecture.check.skip}</skip>
                             <executable>python3</executable>
                             <workingDirectory>${maven.multiModuleProjectDirectory}</workingDirectory>
                             <arguments>
@@ -293,6 +295,7 @@
                             <goal>exec</goal>
                         </goals>
                         <configuration>
+                            <skip>${architecture.check.skip}</skip>
                             <executable>bash</executable>
                             <arguments>
                                 <argument>${maven.multiModuleProjectDirectory}/tools/verify-module-boundaries.sh
@@ -329,4 +332,17 @@
             </plugins>
         </pluginManagement>
     </build>
+    <profiles>
+        <profile>
+            <id>windows</id>
+            <activation>
+                <os>
+                    <family>Windows</family>
+                </os>
+            </activation>
+            <properties>
+                <architecture.check.skip>true</architecture.check.skip>
+            </properties>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
### Motivation
- On Windows the root POM runs two `exec-maven-plugin` executions during `validate` that call `python3` and `bash`, which fail with exit code `9009` when those tools are not present and break `mvn clean compile` / `mvn clean package`.

### Description
- Add a new Maven property `architecture.check.skip` with default value `false` to control the two architecture checks.
- Wire `<skip>${architecture.check.skip}</skip>` into both `exec-maven-plugin` executions that run `tools/architecture_check.py` and `tools/verify-module-boundaries.sh` so those executions can be skipped by the property.
- Add an OS-activated `windows` profile that sets `architecture.check.skip=true` via `<activation><os><family>Windows</family></os></activation>` so Windows builds skip the checks by default while Linux/macOS/CI keep the checks enabled.
- Preserve existing scripts, execution phases, goals and module/dependency layout, and allow manual overrides with `-Darchitecture.check.skip=true` or `-Darchitecture.check.skip=false` on any platform.

### Testing
- Ran XML parse of the modified `pom.xml` with `python3` and `xml.etree.ElementTree` which succeeded and confirmed well-formed XML.
- Searched all project POMs for `architecture.check`, `exec-maven-plugin`, and related execution ids which showed the added property and `skip` wiring and no conflicting overrides were found.
- Executed `git diff --check` and commit which passed cleanly and produced commit `4416e83 build: skip architecture checks on Windows`.
- Attempted `mvn clean validate -Darchitecture.check.skip=true` and `mvn help:...` but full Maven lifecycle verification in this environment failed due to remote resolution errors (Maven Central returned HTTP 403 for `spring-boot-dependencies:2.7.18`), so end-to-end Maven execution could not be completed here; the POM-level changes and skip parameter wiring were validated, but dependency resolution in this container is blocked by the environment rather than by the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6430b04dc8832683b596cbf1c52b50)