### PR TITLE
refactor: 清理领域层外部依赖并修复模块编译

### DIFF
--- a/yak-ops-application/pom.xml
+++ b/yak-ops-application/pom.xml
@@ -10,6 +10,26 @@
     <dependencies>
         <dependency>
             <groupId>io.yak.ops</groupId>
+            <artifactId>yak-ops-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.cronutils</groupId>
+            <artifactId>cron-utils</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.yak.ops</groupId>
             <artifactId>yak-ops-engine-support</artifactId>
         </dependency>
         <dependency>

--- a/yak-ops-application/src/main/java/io/yak/ops/application/job/handler/multi/GuideMultiHoconBuildService.java
+++ b/yak-ops-application/src/main/java/io/yak/ops/application/job/handler/multi/GuideMultiHoconBuildService.java
@@ -8,7 +8,7 @@ import io.yak.ops.application.support.builder.HoconConfigBuilder;
 import io.yak.ops.domain.dag.DagGraph;
 import io.yak.ops.application.job.handler.JobRuntimeContext;
 import io.yak.ops.application.job.handler.JobRuntimeContextFactory;
-import io.yak.ops.domain.utils.DagUtil;
+import io.yak.ops.application.support.dag.DagUtil;
 import io.yak.ops.web.contract.dto.command.JobDefinitionSaveCommand;
 import io.yak.ops.web.contract.dto.config.GuideMultiJobContent;
 import io.yak.ops.web.contract.dto.config.JobEnvConfig;

--- a/yak-ops-application/src/main/java/io/yak/ops/application/job/handler/single/GuideSingleHoconBuildService.java
+++ b/yak-ops-application/src/main/java/io/yak/ops/application/job/handler/single/GuideSingleHoconBuildService.java
@@ -8,7 +8,7 @@ import io.yak.ops.application.support.builder.HoconConfigBuilder;
 import io.yak.ops.domain.dag.DagGraph;
 import io.yak.ops.application.job.handler.JobRuntimeContext;
 import io.yak.ops.application.job.handler.JobRuntimeContextFactory;
-import io.yak.ops.domain.utils.DagUtil;
+import io.yak.ops.application.support.dag.DagUtil;
 import io.yak.ops.web.contract.dto.command.JobDefinitionSaveCommand;
 import org.springframework.stereotype.Service;
 

--- a/yak-ops-application/src/main/java/io/yak/ops/application/support/builder/HoconConfigBuilder.java
+++ b/yak-ops-application/src/main/java/io/yak/ops/application/support/builder/HoconConfigBuilder.java
@@ -40,7 +40,7 @@ public class HoconConfigBuilder {
     public String build(DagGraph dagGraph, JobEnvConfig envConfig) {
         DagBuildContext context = DagBuildContext.from(dagGraph);
 
-        NodeGroup group = groupNodes(dagGraph.getNodesAsConfig(), context);
+        NodeGroup group = groupNodes(io.yak.ops.application.support.dag.DagConfigMapper.nodes(dagGraph), context);
 
         return SeaTunnelConfigUtil.generateConfig(
                 envConfigBuilder.build(envConfig),
@@ -112,7 +112,7 @@ public class HoconConfigBuilder {
     public String build(DagGraph dagGraph, JobEnvConfig envConfig, JobScheduleConfig scheduleConfig) {
         DagBuildContext context = DagBuildContext.from(dagGraph, scheduleConfig);
 
-        NodeGroup group = groupNodes(dagGraph.getNodesAsConfig(), context);
+        NodeGroup group = groupNodes(io.yak.ops.application.support.dag.DagConfigMapper.nodes(dagGraph), context);
 
         return SeaTunnelConfigUtil.generateConfig(
                 envConfigBuilder.build(envConfig),

--- a/yak-ops-application/src/main/java/io/yak/ops/application/support/builder/context/DagBuildContext.java
+++ b/yak-ops-application/src/main/java/io/yak/ops/application/support/builder/context/DagBuildContext.java
@@ -67,7 +67,7 @@ public class DagBuildContext {
             return empty(scheduleConfig);
         }
 
-        List<Config> nodes = dagGraph.getNodesAsConfig();
+        List<Config> nodes = io.yak.ops.application.support.dag.DagConfigMapper.nodes(dagGraph);
 
         boolean hasTransform = nodes.stream()
                 .map(DagBuildContext::getNodeData)

--- a/yak-ops-application/src/main/java/io/yak/ops/application/support/cron/AbstractCycle.java
+++ b/yak-ops-application/src/main/java/io/yak/ops/application/support/cron/AbstractCycle.java
@@ -1,4 +1,4 @@
-package io.yak.ops.domain.cron;
+package io.yak.ops.application.support.cron;
 
 import com.cronutils.model.Cron;
 import com.cronutils.model.field.CronField;

--- a/yak-ops-application/src/main/java/io/yak/ops/application/support/cron/CronUtils.java
+++ b/yak-ops-application/src/main/java/io/yak/ops/application/support/cron/CronUtils.java
@@ -1,17 +1,15 @@
-package io.yak.ops.domain.cron;
+package io.yak.ops.application.support.cron;
 
 import com.cronutils.model.Cron;
 import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.model.time.ExecutionTime;
 import com.cronutils.parser.CronParser;
 import lombok.NonNull;
-import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import io.yak.ops.common.constants.Constants;
 import io.yak.ops.common.enums.CycleEnum;
 import io.yak.ops.common.lifecycle.ServerLifeCycleManager;
 import io.yak.ops.common.utils.DateUtils;
-import io.yak.ops.dao.entity.JobSchedule;
 import io.yak.ops.domain.exceptions.CronParseException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -24,7 +22,7 @@ import java.util.stream.Collectors;
 import static com.cronutils.model.CronType.QUARTZ;
 import static io.yak.ops.common.constants.CommandKeyConstants.CMD_PARAM_COMPLEMENT_DATA_SCHEDULE_DATE_LIST;
 import static io.yak.ops.common.constants.Constants.COMMA;
-import static io.yak.ops.domain.cron.CycleFactory.*;
+import static io.yak.ops.application.support.cron.CycleFactory.*;
 
 /**
  * // todo: this utils is heavy, it rely on quartz and corn-utils.
@@ -179,11 +177,11 @@ public class CronUtils {
 
     public static List<Date> getSelfFireDateList(@NonNull final Date startTime,
                                                  @NonNull final Date endTime,
-                                                 @NonNull final List<JobSchedule> schedules) throws CronParseException {
+                                                 @NonNull final List<String> cronExpressions) throws CronParseException {
         ZonedDateTime zonedDateTimeStart = ZonedDateTime.ofInstant(startTime.toInstant(), ZoneId.systemDefault());
         ZonedDateTime zonedDateTimeEnd = ZonedDateTime.ofInstant(endTime.toInstant(), ZoneId.systemDefault());
 
-        return getSelfFireDateList(zonedDateTimeStart, zonedDateTimeEnd, schedules).stream()
+        return getSelfFireDateList(zonedDateTimeStart, zonedDateTimeEnd, cronExpressions).stream()
                 .map(zonedDateTime -> new Date(zonedDateTime.toInstant().toEpochMilli()))
                 .collect(java.util.stream.Collectors.toList());
     }
@@ -194,7 +192,7 @@ public class CronUtils {
      */
     public static List<ZonedDateTime> getSelfFireDateList(@NonNull final ZonedDateTime startTime,
                                                           @NonNull final ZonedDateTime endTime,
-                                                          @NonNull final List<JobSchedule> schedules) throws CronParseException {
+                                                          @NonNull final List<String> cronExpressions) throws CronParseException {
         List<ZonedDateTime> result = new ArrayList<>();
         if (startTime.equals(endTime)) {
             result.add(startTime);
@@ -205,15 +203,12 @@ public class CronUtils {
         ZonedDateTime from = startTime.minusSeconds(1L);
         ZonedDateTime to = endTime.plusSeconds(1L);
 
-        List<JobSchedule> listSchedule = new ArrayList<>();
-        listSchedule.addAll(schedules);
-        if (CollectionUtils.isEmpty(listSchedule)) {
-            JobSchedule schedule = new JobSchedule();
-            schedule.setCronExpression(Constants.DEFAULT_CRON_STRING);
-            listSchedule.add(schedule);
+        List<String> expressions = new ArrayList<>(cronExpressions);
+        if (expressions.isEmpty()) {
+            expressions.add(Constants.DEFAULT_CRON_STRING);
         }
-        for (JobSchedule schedule : listSchedule) {
-            result.addAll(CronUtils.getFireDateList(from, to, schedule.getCronExpression()));
+        for (String expression : expressions) {
+            result.addAll(CronUtils.getFireDateList(from, to, expression));
         }
         return result;
     }

--- a/yak-ops-application/src/main/java/io/yak/ops/application/support/cron/CycleFactory.java
+++ b/yak-ops-application/src/main/java/io/yak/ops/application/support/cron/CycleFactory.java
@@ -1,4 +1,4 @@
-package io.yak.ops.domain.cron;
+package io.yak.ops.application.support.cron;
 
 import com.cronutils.model.Cron;
 import com.cronutils.model.field.expression.Always;

--- a/yak-ops-application/src/main/java/io/yak/ops/application/support/cron/CycleLinks.java
+++ b/yak-ops-application/src/main/java/io/yak/ops/application/support/cron/CycleLinks.java
@@ -1,4 +1,4 @@
-package io.yak.ops.domain.cron;
+package io.yak.ops.application.support.cron;
 
 import com.cronutils.model.Cron;
 import io.yak.ops.common.enums.CycleEnum;

--- a/yak-ops-application/src/main/java/io/yak/ops/application/support/dag/DagConfigMapper.java
+++ b/yak-ops-application/src/main/java/io/yak/ops/application/support/dag/DagConfigMapper.java
@@ -1,0 +1,25 @@
+package io.yak.ops.application.support.dag;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import io.yak.ops.domain.dag.DagGraph;
+import io.yak.ops.domain.dag.DagNode;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/** Application adapter from domain DAG nodes to HOCON configuration. */
+public final class DagConfigMapper {
+    private DagConfigMapper() { }
+    public static List<Config> nodes(DagGraph graph) {
+        List<Config> configs = new ArrayList<Config>();
+        for (DagNode node : graph.getNodes()) {
+            Map<String,Object> value = new LinkedHashMap<String,Object>();
+            value.put("id", node.getId());
+            value.put("data", new LinkedHashMap<String,Object>(node.getAttributes()));
+            configs.add(ConfigFactory.parseMap(value));
+        }
+        return configs;
+    }
+}

--- a/yak-ops-application/src/main/java/io/yak/ops/application/support/dag/DagUtil.java
+++ b/yak-ops-application/src/main/java/io/yak/ops/application/support/dag/DagUtil.java
@@ -1,4 +1,4 @@
-package io.yak.ops.domain.utils;
+package io.yak.ops.application.support.dag;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -57,11 +57,7 @@ public final class DagUtil {
 
         ObjectNode dagJson = parseJsonObject(json);
 
-        DagGraph graph = new DagGraph();
-        graph.setNodes(jsonArrayToList(dagJson.get("nodes")));
-        graph.setEdges(jsonArrayToList(dagJson.get("edges")));
-
-        return graph;
+        return toDomainGraph(dagJson);
     }
 
     /**
@@ -79,10 +75,8 @@ public final class DagUtil {
         try {
             ObjectNode dagJson = parseJsonObject(json);
 
-            List<ObjectNode> nodes = jsonArrayToList(dagJson.get("nodes"));
-            List<ObjectNode> edges = jsonArrayToList(dagJson.get("edges"));
-
-            return performValidation(nodes, edges, validators);
+            DagGraph graph = toDomainGraph(dagJson);
+            return performValidation(graph, validators);
 
         } catch (Exception e) {
             DagCheckResult result = new DagCheckResult();
@@ -95,8 +89,7 @@ public final class DagUtil {
      * Execute validators.
      */
     private static DagCheckResult performValidation(
-            List<ObjectNode> nodes,
-            List<ObjectNode> edges,
+            DagGraph graph,
             List<DagValidator> validators) {
 
         DagCheckResult result = new DagCheckResult();
@@ -113,7 +106,7 @@ public final class DagUtil {
             }
 
             try {
-                validator.validate(nodes, edges, result);
+                validator.validate(graph, result);
             } catch (Exception e) {
                 result.addError("Validator execution failed: " + e.getMessage());
                 log.error("Validator {} failed",
@@ -138,29 +131,35 @@ public final class DagUtil {
         return (ObjectNode) node;
     }
 
-    /**
-     * Convert JsonNode array to List<ObjectNode>.
-     */
-    private static List<ObjectNode> jsonArrayToList(JsonNode node) {
-
-        if (node == null || !node.isArray()) {
-            return java.util.Collections.emptyList();
-        }
-
-        ArrayNode array = (ArrayNode) node;
-        List<ObjectNode> list = new ArrayList<>(array.size());
-
-        for (JsonNode element : array) {
-
-            if (!element.isObject()) {
-                continue;
+    private static DagGraph toDomainGraph(ObjectNode root) {
+        List<DagNode> nodes = new ArrayList<DagNode>();
+        JsonNode nodeArray = root.get("nodes");
+        if (nodeArray != null && nodeArray.isArray()) {
+            for (JsonNode item : nodeArray) {
+                if (!item.isObject()) continue;
+                JsonNode data = item.get("data");
+                Map<String, Object> attributes = data == null
+                        ? Collections.<String, Object>emptyMap()
+                        : JSONUtils.parseObject(JSONUtils.toJsonString(data), Map.class);
+                nodes.add(new DagNode(text(item, "id"), first(text(item, "name"), text(data, "title")),
+                        text(data, "nodeType"), attributes));
             }
-
-            list.add((ObjectNode) element);
         }
-
-        return list;
+        List<DagEdge> edges = new ArrayList<DagEdge>();
+        JsonNode edgeArray = root.get("edges");
+        if (edgeArray != null && edgeArray.isArray()) {
+            for (JsonNode item : edgeArray) if (item.isObject())
+                edges.add(new DagEdge(text(item, "id"), text(item, "source"), text(item, "target")));
+        }
+        return new DagGraph(nodes, edges);
     }
+
+    private static String text(JsonNode node, String field) {
+        if (node == null || node.get(field) == null || node.get(field).isNull()) return null;
+        return node.get(field).asText();
+    }
+
+    private static String first(String first, String second) { return first == null ? second : first; }
 
     /**
      * Custom exception for DAG validation failures.

--- a/yak-ops-application/src/main/java/io/yak/ops/application/support/dag/WholeSyncDagAssembler.java
+++ b/yak-ops-application/src/main/java/io/yak/ops/application/support/dag/WholeSyncDagAssembler.java
@@ -1,4 +1,4 @@
-package io.yak.ops.domain.dag;
+package io.yak.ops.application.support.dag;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/yak-ops-domain/pom.xml
+++ b/yak-ops-domain/pom.xml
@@ -13,9 +13,5 @@
             <artifactId>lombok</artifactId>
             <optional>true</optional>
         </dependency>
-        <dependency>
-            <groupId>com.typesafe</groupId>
-            <artifactId>config</artifactId>
-        </dependency>
     </dependencies>
 </project>

--- a/yak-ops-domain/src/main/java/io/yak/ops/domain/dag/CycleDetectionValidator.java
+++ b/yak-ops-domain/src/main/java/io/yak/ops/domain/dag/CycleDetectionValidator.java
@@ -1,173 +1,37 @@
 package io.yak.ops.domain.dag;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import lombok.extern.slf4j.Slf4j;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
 
-import java.util.*;
-
-/**
- * Validator to detect cycles in a Directed Acyclic Graph (DAG).
- * <p>
- * This implementation uses Topological Sort (Kahn's algorithm).
- * If not all nodes can be visited during sorting, a cycle exists.
- */
-@Slf4j
+/** Detects cycles using Kahn's topological-sort algorithm. */
 public class CycleDetectionValidator implements DagValidator {
-
-    /**
-     * JSON key for node ID
-     */
-    private static final String NODE_ID_KEY = "id";
-    /**
-     * JSON key for edge source
-     */
-    private static final String EDGE_SOURCE_KEY = "source";
-    /**
-     * JSON key for edge target
-     */
-    private static final String EDGE_TARGET_KEY = "target";
-
-    /**
-     * Validate whether the DAG contains a cycle.
-     *
-     * @param nodes  list of node definitions
-     * @param edges  list of edge definitions
-     * @param result validation result container
-     */
     @Override
-    public void validate(List<ObjectNode> nodes, List<ObjectNode> edges, DagCheckResult result) {
-        if (nodes == null || edges == null) {
-            return;
+    public void validate(DagGraph graph, DagCheckResult result) {
+        if (graph == null || graph.getNodes().isEmpty() || graph.getEdges().isEmpty()) return;
+        Map<String,List<String>> adjacency = new HashMap<String,List<String>>();
+        Map<String,Integer> degree = new HashMap<String,Integer>();
+        for (DagNode node : graph.getNodes()) { adjacency.put(node.getId(), new ArrayList<String>()); degree.put(node.getId(), 0); }
+        for (DagEdge edge : graph.getEdges()) {
+            if (edge.getSource() == null || edge.getTarget() == null) continue;
+            List<String> targets = adjacency.get(edge.getSource());
+            if (targets == null) { targets = new ArrayList<String>(); adjacency.put(edge.getSource(), targets); }
+            targets.add(edge.getTarget());
+            Integer current = degree.get(edge.getTarget()); degree.put(edge.getTarget(), current == null ? 1 : current + 1);
+            if (!degree.containsKey(edge.getSource())) degree.put(edge.getSource(), 0);
         }
-
-        if (nodes.isEmpty() || edges.isEmpty()) {
-            // Empty DAG cannot have cycles
-            return;
-        }
-
-        try {
-            boolean hasCycle = hasCycleByTopologicalSort(nodes, edges);
-            if (hasCycle) {
-                result.addError("The DAG contains a cycle. Please check the edge connections.");
-                result.setValid(false);
-            }
-        } catch (Exception e) {
-            log.error("Error occurred during cycle detection", e);
-            result.addWarning("Cycle detection failed: " + e.getMessage());
-        }
-    }
-
-    /**
-     * Detect cycles using topological sorting (Kahn's algorithm).
-     *
-     * @param nodes list of nodes
-     * @param edges list of edges
-     * @return true if a cycle exists, false otherwise
-     */
-    private boolean hasCycleByTopologicalSort(List<ObjectNode> nodes, List<ObjectNode> edges) {
-        // Build adjacency list: node -> list of outgoing neighbors
-        Map<String, List<String>> adjacencyList = new HashMap<String, List<String>>();
-        // Map to store in-degree for each node: node -> number of incoming edges
-        Map<String, Integer> inDegreeMap = new HashMap<String, Integer>();
-
-        // Initialize adjacency list and in-degree map
-        for (ObjectNode node : nodes) {
-            String nodeId = getText(node, NODE_ID_KEY);
-            if (nodeId == null) {
-                continue;
-            }
-            adjacencyList.putIfAbsent(nodeId, new ArrayList<String>());
-            inDegreeMap.putIfAbsent(nodeId, 0);
-        }
-
-        // Build the graph from edges
-        for (ObjectNode edge : edges) {
-            String source = getText(edge, EDGE_SOURCE_KEY);
-            String target = getText(edge, EDGE_TARGET_KEY);
-
-            if (source != null && target != null) {
-                adjacencyList.computeIfAbsent(source, k -> new ArrayList<String>()).add(target);
-                inDegreeMap.put(target, inDegreeMap.getOrDefault(target, 0) + 1);
-                inDegreeMap.putIfAbsent(source, 0);
-            }
-        }
-
-        // Queue for nodes with zero in-degree
         Queue<String> queue = new LinkedList<String>();
-        for (Map.Entry<String, Integer> entry : inDegreeMap.entrySet()) {
-            if (entry.getValue() == 0) {
-                queue.offer(entry.getKey());
-            }
-        }
-
-        int visitedCount = 0;
-        List<String> topologicalOrder = new ArrayList<String>();
-
-        // Perform topological sort
+        for (Map.Entry<String,Integer> entry : degree.entrySet()) if (entry.getValue() == 0) queue.offer(entry.getKey());
+        int visited = 0;
         while (!queue.isEmpty()) {
-            String current = queue.poll();
-            topologicalOrder.add(current);
-            visitedCount++;
-
-            List<String> neighbors = adjacencyList.get(current);
-            if (neighbors != null) {
-                for (String neighbor : neighbors) {
-                    int newInDegree = inDegreeMap.get(neighbor) - 1;
-                    inDegreeMap.put(neighbor, newInDegree);
-                    if (newInDegree == 0) {
-                        queue.offer(neighbor);
-                    }
-                }
-            }
+            String current = queue.poll(); visited++;
+            List<String> targets = adjacency.get(current);
+            if (targets == null) continue;
+            for (String target : targets) { int value = degree.get(target) - 1; degree.put(target,value); if (value == 0) queue.offer(target); }
         }
-
-        boolean hasCycle = visitedCount != nodes.size();
-
-        if (hasCycle) {
-            log.warn("Cycle detected: visited {}/{} nodes", visitedCount, nodes.size());
-            log.warn("Topological order result: {}", topologicalOrder);
-
-            List<String> cycleNodes = findCycleNodes(adjacencyList, inDegreeMap);
-            if (!cycleNodes.isEmpty()) {
-                log.warn("Possible cycle nodes: {}", cycleNodes);
-            }
-        }
-
-        return hasCycle;
-    }
-
-    /**
-     * Identify nodes that may be part of a cycle.
-     * <p>
-     * Nodes with remaining in-degree > 0 after topological sorting
-     * are likely involved in a cycle.
-     *
-     * @param adjacencyList adjacency list of the graph
-     * @param inDegreeMap   final in-degree map
-     * @return list of possible cycle nodes
-     */
-    private List<String> findCycleNodes(Map<String, List<String>> adjacencyList,
-                                        Map<String, Integer> inDegreeMap) {
-        List<String> cycleNodes = new ArrayList<String>();
-
-        for (Map.Entry<String, Integer> entry : inDegreeMap.entrySet()) {
-            String node = entry.getKey();
-            int inDegree = entry.getValue();
-            if (inDegree > 0) {
-                List<String> neighbors = adjacencyList.get(node);
-                if (neighbors != null && !neighbors.isEmpty()) {
-                    cycleNodes.add(node);
-                }
-            }
-        }
-
-        return cycleNodes;
-    }
-
-    private String getText(ObjectNode node, String fieldName) {
-        if (node == null || node.get(fieldName) == null || node.get(fieldName).isNull()) {
-            return null;
-        }
-        return node.get(fieldName).asText();
+        if (visited != graph.getNodes().size()) result.addError("The DAG contains a cycle. Please check the edge connections.");
     }
 }

--- a/yak-ops-domain/src/main/java/io/yak/ops/domain/dag/DagCheckResult.java
+++ b/yak-ops-domain/src/main/java/io/yak/ops/domain/dag/DagCheckResult.java
@@ -1,66 +1,17 @@
 package io.yak.ops.domain.dag;
 
-import lombok.Data;
-
 import java.util.ArrayList;
 import java.util.List;
 
-/**
- * Represents the result of a DAG validation process.
- * <p>
- * This class stores validation status, error messages,
- * and warning messages produced during DAG checks.
- */
-@Data
+/** Result of applying domain validation rules to a DAG. */
 public class DagCheckResult {
-
-    /**
-     * Indicates whether the DAG is valid
-     */
     private boolean valid;
-
-    /**
-     * List of validation error messages
-     */
-    private List<String> errors;
-
-    /**
-     * List of validation warning messages
-     */
-    private List<String> warnings;
-
-    /**
-     * Create a new {@code DagCheckResult} instance.
-     * <p>
-     * Errors and warnings lists are initialized as empty.
-     * The {@code valid} flag defaults to {@code false}
-     * until validation logic explicitly sets it otherwise.
-     */
-    public DagCheckResult() {
-        this.errors = new ArrayList<>();
-        this.warnings = new ArrayList<>();
-    }
-
-    /**
-     * Add an error message to the validation result.
-     * <p>
-     * Adding an error will automatically mark the DAG as invalid.
-     *
-     * @param error error message describing the validation failure
-     */
-    public void addError(String error) {
-        this.errors.add(error);
-        this.valid = false;
-    }
-
-    /**
-     * Add a warning message to the validation result.
-     * <p>
-     * Warnings do not affect the overall validity of the DAG.
-     *
-     * @param warning warning message describing a non-critical issue
-     */
-    public void addWarning(String warning) {
-        this.warnings.add(warning);
-    }
+    private final List<String> errors = new ArrayList<String>();
+    private final List<String> warnings = new ArrayList<String>();
+    public boolean isValid() { return valid; }
+    public void setValid(boolean valid) { this.valid = valid; }
+    public List<String> getErrors() { return errors; }
+    public List<String> getWarnings() { return warnings; }
+    public void addError(String error) { errors.add(error); valid = false; }
+    public void addWarning(String warning) { warnings.add(warning); }
 }

--- a/yak-ops-domain/src/main/java/io/yak/ops/domain/dag/DagEdge.java
+++ b/yak-ops-domain/src/main/java/io/yak/ops/domain/dag/DagEdge.java
@@ -1,0 +1,14 @@
+package io.yak.ops.domain.dag;
+
+/** A directed connection between two DAG nodes. */
+public final class DagEdge {
+    private final String id;
+    private final String source;
+    private final String target;
+    public DagEdge(String id, String source, String target) {
+        this.id = id; this.source = source; this.target = target;
+    }
+    public String getId() { return id; }
+    public String getSource() { return source; }
+    public String getTarget() { return target; }
+}

--- a/yak-ops-domain/src/main/java/io/yak/ops/domain/dag/DagGraph.java
+++ b/yak-ops-domain/src/main/java/io/yak/ops/domain/dag/DagGraph.java
@@ -1,64 +1,21 @@
 package io.yak.ops.domain.dag;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.typesafe.config.Config;
-import com.typesafe.config.ConfigFactory;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import io.yak.ops.common.utils.JSONUtils;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
-/**
- * Represents a DAG graph structure.
- * <p>
- * This class holds node and edge definitions in Jackson JSON format
- * and provides utility methods to convert node definitions
- * into Typesafe {@link Config} objects.
- */
-@Data
-@NoArgsConstructor
-public class DagGraph {
-
-    /**
-     * List of node definitions represented as Jackson ObjectNode objects
-     */
-    private List<ObjectNode> nodes;
-
-    /**
-     * List of edge definitions represented as Jackson ObjectNode objects
-     */
-    private List<ObjectNode> edges;
-
-    /**
-     * Convert all node JSON objects into {@link Config} instances.
-     *
-     * @return list of node configurations in Typesafe Config format
-     */
-    public List<Config> getNodesAsConfig() {
-        if (nodes == null || nodes.isEmpty()) {
-            return java.util.Collections.emptyList();
-        }
-
-        List<Config> configs = new ArrayList<>(nodes.size());
-        for (ObjectNode node : nodes) {
-            configs.add(convertJsonNodeToConfig(node));
-        }
-        return configs;
+/** Pure domain representation of a directed acyclic graph. */
+public final class DagGraph {
+    private final List<DagNode> nodes;
+    private final List<DagEdge> edges;
+    public DagGraph(List<DagNode> nodes, List<DagEdge> edges) {
+        this.nodes = immutable(nodes);
+        this.edges = immutable(edges);
     }
-
-    /**
-     * Convert a Jackson {@link ObjectNode} into a Typesafe {@link Config}.
-     *
-     * @param jsonNode node definition in JSON format
-     * @return corresponding Typesafe Config object
-     */
-    private Config convertJsonNodeToConfig(ObjectNode jsonNode) {
-        Map<String, Object> map =
-                JSONUtils.parseObject(JSONUtils.toJsonString(jsonNode), Map.class);
-        return ConfigFactory.parseMap(map);
+    private static <T> List<T> immutable(List<T> values) {
+        return values == null ? Collections.<T>emptyList()
+                : Collections.unmodifiableList(new ArrayList<T>(values));
     }
+    public List<DagNode> getNodes() { return nodes; }
+    public List<DagEdge> getEdges() { return edges; }
 }

--- a/yak-ops-domain/src/main/java/io/yak/ops/domain/dag/DagNode.java
+++ b/yak-ops-domain/src/main/java/io/yak/ops/domain/dag/DagNode.java
@@ -1,0 +1,25 @@
+package io.yak.ops.domain.dag;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/** A framework-independent DAG node. */
+public final class DagNode {
+    private final String id;
+    private final String name;
+    private final String type;
+    private final Map<String, Object> attributes;
+
+    public DagNode(String id, String name, String type, Map<String, Object> attributes) {
+        this.id = id;
+        this.name = name;
+        this.type = type;
+        this.attributes = attributes == null ? Collections.<String, Object>emptyMap()
+                : Collections.unmodifiableMap(new LinkedHashMap<String, Object>(attributes));
+    }
+    public String getId() { return id; }
+    public String getName() { return name; }
+    public String getType() { return type; }
+    public Map<String, Object> getAttributes() { return attributes; }
+}

--- a/yak-ops-domain/src/main/java/io/yak/ops/domain/dag/DagValidator.java
+++ b/yak-ops-domain/src/main/java/io/yak/ops/domain/dag/DagValidator.java
@@ -1,24 +1,5 @@
 package io.yak.ops.domain.dag;
-
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
-import java.util.List;
-
-/**
- * Interface for DAG validation.
- * <p>
- * Implementations of this interface perform specific validation checks
- * on a Directed Acyclic Graph (DAG), such as cycle detection, connectivity
- * validation, or isolated node detection.
- */
+/** A framework-independent domain validation rule. */
 public interface DagValidator {
-
-    /**
-     * Validate the DAG structure and consistency.
-     *
-     * @param nodes  list of node definitions in the DAG
-     * @param edges  list of edge definitions in the DAG
-     * @param result container used to collect validation errors and warnings
-     */
-    void validate(List<ObjectNode> nodes, List<ObjectNode> edges, DagCheckResult result);
+    void validate(DagGraph graph, DagCheckResult result);
 }

--- a/yak-ops-domain/src/main/java/io/yak/ops/domain/dag/GraphConnectivityValidator.java
+++ b/yak-ops-domain/src/main/java/io/yak/ops/domain/dag/GraphConnectivityValidator.java
@@ -1,55 +1,21 @@
 package io.yak.ops.domain.dag;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import org.apache.commons.lang3.StringUtils;
-
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
-/**
- * Validator that checks graph connectivity.
- *
- * <p>This validator ensures that all edges reference existing nodes.
- * If an edge points to a non-existent source or target node,
- * the DAG is considered invalid.</p>
- */
+/** Ensures every edge endpoint references an existing node. */
 public class GraphConnectivityValidator implements DagValidator {
-
     @Override
-    public void validate(List<ObjectNode> nodes, List<ObjectNode> edges, DagCheckResult result) {
-
-        // Skip validation if nodes or edges are empty
-        if (nodes == null || nodes.isEmpty() || edges == null || edges.isEmpty()) {
-            return;
-        }
-
-        // Collect all node ids
-        Set<String> nodeIds = new HashSet<>();
-        for (ObjectNode node : nodes) {
-            String nodeId = node.path("id").asText(null);
-            if (StringUtils.isNotBlank(nodeId)) {
-                nodeIds.add(nodeId);
-            }
-        }
-
-        // Validate edges
-        for (ObjectNode edge : edges) {
-
-            String sourceId = edge.path("source").asText(null);
-            String targetId = edge.path("target").asText(null);
-
-            if (StringUtils.isNotBlank(sourceId) && !nodeIds.contains(sourceId)) {
-                result.addError(
-                        String.format("Edge references a non-existent source node: %s", sourceId)
-                );
-            }
-
-            if (StringUtils.isNotBlank(targetId) && !nodeIds.contains(targetId)) {
-                result.addError(
-                        String.format("Edge references a non-existent target node: %s", targetId)
-                );
-            }
+    public void validate(DagGraph graph, DagCheckResult result) {
+        if (graph == null || graph.getNodes().isEmpty() || graph.getEdges().isEmpty()) return;
+        Set<String> ids = new HashSet<String>();
+        for (DagNode node : graph.getNodes()) if (notBlank(node.getId())) ids.add(node.getId());
+        for (DagEdge edge : graph.getEdges()) {
+            if (notBlank(edge.getSource()) && !ids.contains(edge.getSource()))
+                result.addError("Edge references a non-existent source node: " + edge.getSource());
+            if (notBlank(edge.getTarget()) && !ids.contains(edge.getTarget()))
+                result.addError("Edge references a non-existent target node: " + edge.getTarget());
         }
     }
+    private boolean notBlank(String value) { return value != null && !value.trim().isEmpty(); }
 }

--- a/yak-ops-domain/src/main/java/io/yak/ops/domain/dag/IsolatedNodeValidator.java
+++ b/yak-ops-domain/src/main/java/io/yak/ops/domain/dag/IsolatedNodeValidator.java
@@ -1,91 +1,34 @@
 package io.yak.ops.domain.dag;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import org.apache.commons.lang3.StringUtils;
-
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-/**
- * Validator that detects isolated nodes in a DAG.
- * <p>
- * An isolated node is a node that does not participate in any edge
- * (neither as a source nor as a target).
- */
+/** Detects nodes which participate in no edge. */
 public class IsolatedNodeValidator implements DagValidator {
-
-    /**
-     * Validate whether the DAG contains isolated nodes.
-     *
-     * @param nodes  list of node definitions
-     * @param edges  list of edge definitions
-     * @param result validation result container
-     */
     @Override
-    public void validate(List<ObjectNode> nodes, List<ObjectNode> edges, DagCheckResult result) {
-        // If there are no nodes, the DAG is invalid
-        if (nodes == null || nodes.isEmpty()) {
-            result.addError("The DAG contains no nodes");
-            return;
+    public void validate(DagGraph graph, DagCheckResult result) {
+        if (graph == null || graph.getNodes().isEmpty()) { result.addError("The DAG contains no nodes"); return; }
+        Set<String> connected = new HashSet<String>();
+        for (DagEdge edge : graph.getEdges()) {
+            if (notBlank(edge.getSource())) connected.add(edge.getSource());
+            if (notBlank(edge.getTarget())) connected.add(edge.getTarget());
         }
-
-        // Store IDs of nodes that are connected by at least one edge
-        Set<String> connectedNodes = new HashSet<String>();
-
-        // Collect all source and target node IDs from edges
-        if (edges != null) {
-            for (ObjectNode edge : edges) {
-                String sourceId = getText(edge, "source");
-                String targetId = getText(edge, "target");
-
-                if (StringUtils.isNotBlank(sourceId)) {
-                    connectedNodes.add(sourceId);
-                }
-                if (StringUtils.isNotBlank(targetId)) {
-                    connectedNodes.add(targetId);
-                }
+        List<String> isolated = new ArrayList<String>();
+        for (DagNode node : graph.getNodes()) {
+            if (notBlank(node.getId()) && !connected.contains(node.getId())) {
+                isolated.add(node.getId());
+                result.addError("Isolated node detected: ID=" + node.getId()
+                        + (notBlank(node.getName()) ? ", Name=" + node.getName() : ""));
             }
         }
-
-        // Track IDs of isolated nodes
-        List<String> isolatedNodeIds = new ArrayList<String>();
-
-        // Identify nodes that do not appear in any edge
-        for (ObjectNode node : nodes) {
-            String nodeId = getText(node, "id");
-
-            if (StringUtils.isNotBlank(nodeId) && !connectedNodes.contains(nodeId)) {
-                isolatedNodeIds.add(nodeId);
-
-                String nodeName = getText(node, "name");
-                // Report isolated node with or without a name
-                if (StringUtils.isNotBlank(nodeName)) {
-                    result.addError(
-                            String.format("Isolated node detected: ID=%s, Name=%s", nodeId, nodeName)
-                    );
-                } else {
-                    result.addError(
-                            String.format("Isolated node detected: ID=%s", nodeId)
-                    );
-                }
-            }
-        }
-
-        // Special case:
-        // If the graph contains only one node and no edges,
-        // treat it as a warning instead of an error
-        if (nodes.size() == 1 && isolatedNodeIds.size() == 1) {
-            result.getErrors().removeIf(error -> error.contains("Isolated node"));
+        if (graph.getNodes().size() == 1 && isolated.size() == 1) {
+            java.util.Iterator<String> iterator = result.getErrors().iterator();
+            while (iterator.hasNext()) if (iterator.next().contains("Isolated node")) iterator.remove();
+            result.setValid(true);
             result.addWarning("The graph contains only one node with no connecting edges");
         }
     }
-
-    private String getText(ObjectNode node, String fieldName) {
-        if (node == null || node.get(fieldName) == null || node.get(fieldName).isNull()) {
-            return null;
-        }
-        return node.get(fieldName).asText();
-    }
+    private boolean notBlank(String value) { return value != null && !value.trim().isEmpty(); }
 }

--- a/yak-ops-domain/src/main/java/io/yak/ops/domain/dag/TransformSingleConnectionValidator.java
+++ b/yak-ops-domain/src/main/java/io/yak/ops/domain/dag/TransformSingleConnectionValidator.java
@@ -1,132 +1,27 @@
 package io.yak.ops.domain.dag;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import org.apache.commons.lang3.StringUtils;
-
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
-/**
- * Validator that restricts Transform nodes to a single connection
- * on each side of the graph.
- * <p>
- * Rules:
- * <ul>
- *   <li>A Transform node may have at most one incoming edge (left side)</li>
- *   <li>A Transform node may have at most one outgoing edge (right side)</li>
- * </ul>
- */
+/** Restricts transform nodes to one incoming and one outgoing edge. */
 public class TransformSingleConnectionValidator implements DagValidator {
-
-    /**
-     * Validate that each Transform node has at most one incoming
-     * and one outgoing connection.
-     *
-     * @param nodes  list of node definitions
-     * @param edges  list of edge definitions
-     * @param result validation result container
-     */
     @Override
-    public void validate(List<ObjectNode> nodes, List<ObjectNode> edges, DagCheckResult result) {
-        if (nodes == null || nodes.isEmpty() || edges == null || edges.isEmpty()) {
-            return;
+    public void validate(DagGraph graph, DagCheckResult result) {
+        if (graph == null) return;
+        Map<String, Integer> incoming = new HashMap<String, Integer>();
+        Map<String, Integer> outgoing = new HashMap<String, Integer>();
+        for (DagEdge edge : graph.getEdges()) {
+            increment(outgoing, edge.getSource()); increment(incoming, edge.getTarget());
         }
-
-        // Count incoming edges for each node
-        Map<String, Integer> inDegreeMap = new HashMap<String, Integer>();
-        // Count outgoing edges for each node
-        Map<String, Integer> outDegreeMap = new HashMap<String, Integer>();
-
-        for (ObjectNode edge : edges) {
-            String source = getText(edge, "source");
-            String target = getText(edge, "target");
-
-            if (StringUtils.isNotBlank(source)) {
-                outDegreeMap.put(source, outDegreeMap.getOrDefault(source, 0) + 1);
-            }
-
-            if (StringUtils.isNotBlank(target)) {
-                inDegreeMap.put(target, inDegreeMap.getOrDefault(target, 0) + 1);
-            }
-        }
-
-        // Validate Transform nodes only
-        for (ObjectNode node : nodes) {
-
-            if (!isTransformNode(node)) {
-                continue;
-            }
-
-            String nodeId = getText(node, "id");
-
-            ObjectNode data = getObject(node, "data");
-
-            String nodeName = getText(data, "title");
-
-            int inDegree = inDegreeMap.getOrDefault(nodeId, 0);
-            int outDegree = outDegreeMap.getOrDefault(nodeId, 0);
-
-            if (inDegree > 1) {
-                result.addError(
-                        String.format(
-                                "Transform node has more than one incoming connection (left side): ID=%s, Name=%s",
-                                nodeId,
-                                defaultName(nodeName)
-                        )
-                );
-            }
-
-            if (outDegree > 1) {
-                result.addError(
-                        String.format(
-                                "Transform node has more than one outgoing connection (right side): ID=%s, Name=%s",
-                                nodeId,
-                                defaultName(nodeName)
-                        )
-                );
-            }
+        for (DagNode node : graph.getNodes()) {
+            if (!"transform".equalsIgnoreCase(node.getType())) continue;
+            int in = count(incoming, node.getId()), out = count(outgoing, node.getId());
+            String name = notBlank(node.getName()) ? node.getName() : "N/A";
+            if (in > 1) result.addError(String.format("Transform node has more than one incoming connection (left side): ID=%s, Name=%s", node.getId(), name));
+            if (out > 1) result.addError(String.format("Transform node has more than one outgoing connection (right side): ID=%s, Name=%s", node.getId(), name));
         }
     }
-
-    /**
-     * Determine whether the given node is a Transform node.
-     */
-    private boolean isTransformNode(ObjectNode node) {
-
-        ObjectNode data = getObject(node, "data");
-
-        if (data == null) {
-            return false;
-        }
-
-        String nodeType = getText(data, "nodeType");
-
-        return "transform".equalsIgnoreCase(nodeType);
-    }
-
-    /**
-     * Provide a default display name when node name is missing.
-     */
-    private String defaultName(String name) {
-        return StringUtils.isNotBlank(name) ? name : "N/A";
-    }
-
-    private String getText(ObjectNode node, String field) {
-
-        if (node == null || node.get(field) == null || node.get(field).isNull()) {
-            return null;
-        }
-
-        return node.get(field).asText();
-    }
-
-    private ObjectNode getObject(ObjectNode node, String field) {
-
-        if (node == null || node.get(field) == null || !node.get(field).isObject()) {
-            return null;
-        }
-
-        return (ObjectNode) node.get(field);
-    }
+    private void increment(Map<String,Integer> counts, String id) { if (notBlank(id)) counts.put(id, count(counts,id)+1); }
+    private int count(Map<String,Integer> counts, String id) { Integer value=counts.get(id); return value == null ? 0 : value; }
+    private boolean notBlank(String value) { return value != null && !value.trim().isEmpty(); }
 }

--- a/yak-ops-domain/src/main/java/io/yak/ops/domain/exceptions/DomainErrorCode.java
+++ b/yak-ops-domain/src/main/java/io/yak/ops/domain/exceptions/DomainErrorCode.java
@@ -1,0 +1,7 @@
+package io.yak.ops.domain.exceptions;
+
+/** Error contract owned by the domain and implementable by outer adapters. */
+public interface DomainErrorCode {
+    int getCode();
+    String getMsg();
+}

--- a/yak-ops-domain/src/main/java/io/yak/ops/domain/exceptions/DomainErrors.java
+++ b/yak-ops-domain/src/main/java/io/yak/ops/domain/exceptions/DomainErrors.java
@@ -1,0 +1,11 @@
+package io.yak.ops.domain.exceptions;
+
+/** Generic errors used when no more specific outer error classification is supplied. */
+public enum DomainErrors implements DomainErrorCode {
+    INTERNAL_SERVER_ERROR(10000, "Internal Server Error: {0}");
+    private final int code;
+    private final String msg;
+    DomainErrors(int code, String msg) { this.code = code; this.msg = msg; }
+    public int getCode() { return code; }
+    public String getMsg() { return msg; }
+}

--- a/yak-ops-domain/src/main/java/io/yak/ops/domain/exceptions/ServiceException.java
+++ b/yak-ops-domain/src/main/java/io/yak/ops/domain/exceptions/ServiceException.java
@@ -1,44 +1,20 @@
 package io.yak.ops.domain.exceptions;
 
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import io.yak.ops.plugin.spi.enums.Status;
-
 import java.text.MessageFormat;
 
-@Data
-@EqualsAndHashCode(callSuper = true)
+/** Application-visible exception carrying a domain-owned error contract. */
 public class ServiceException extends RuntimeException {
-
-    private int code;
-
-    public ServiceException() {
-        this(Status.INTERNAL_SERVER_ERROR_ARGS);
+    private final int code;
+    public ServiceException() { this(DomainErrors.INTERNAL_SERVER_ERROR); }
+    public ServiceException(DomainErrorCode error) { this(error.getCode(), error.getMsg()); }
+    public ServiceException(DomainErrorCode error, Object... formatter) {
+        this(error.getCode(), MessageFormat.format(error.getMsg(), formatter));
     }
-
-    public ServiceException(Status status) {
-        this(status.getCode(), status.getMsg());
+    public ServiceException(String message) { this(DomainErrors.INTERNAL_SERVER_ERROR, message); }
+    public ServiceException(int code, String message) { this(code, message, null); }
+    public ServiceException(int code, String message, Exception cause) { super(message, cause); this.code = code; }
+    public ServiceException(String message, Exception cause) {
+        this(DomainErrors.INTERNAL_SERVER_ERROR.getCode(), message, cause);
     }
-
-    public ServiceException(Status status, Object... formatter) {
-        this(status.getCode(), MessageFormat.format(status.getMsg(), formatter));
-    }
-
-    public ServiceException(String message) {
-        this(Status.INTERNAL_SERVER_ERROR_ARGS, message);
-    }
-
-    public ServiceException(int code, String message) {
-        this(code, message, null);
-    }
-
-    public ServiceException(int code, String message, Exception cause) {
-        super(message, cause);
-        this.code = code;
-    }
-
-    public ServiceException(String message, Exception exception) {
-        this(Status.INTERNAL_SERVER_ERROR_ARGS, message, exception);
-    }
-
+    public int getCode() { return code; }
 }

--- a/yak-ops-plugin-spi/pom.xml
+++ b/yak-ops-plugin-spi/pom.xml
@@ -10,6 +10,10 @@
     <dependencies>
         <dependency>
             <groupId>io.yak.ops</groupId>
+            <artifactId>yak-ops-domain</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.yak.ops</groupId>
             <artifactId>yak-ops-common</artifactId>
         </dependency>
         <dependency>

--- a/yak-ops-plugin-spi/src/main/java/io/yak/ops/plugin/spi/enums/Status.java
+++ b/yak-ops-plugin-spi/src/main/java/io/yak/ops/plugin/spi/enums/Status.java
@@ -1,6 +1,7 @@
 package io.yak.ops.plugin.spi.enums;
 
 import lombok.Getter;
+import io.yak.ops.domain.exceptions.DomainErrorCode;
 
 import java.util.Locale;
 import java.util.Optional;
@@ -8,7 +9,7 @@ import java.util.Optional;
 /**
  * status enum
  */
-public enum Status {
+public enum Status implements DomainErrorCode {
 
     SUCCESS(0, "success", "成功"),
 


### PR DESCRIPTION
### Motivation

- `yak-ops-domain` 包含大量与实现绑定的代码（cron-utils、Jackson、Commons、SLF4J、Typesafe Config）并直接引用 DAO 实体和 plugin SPI，违反六边形架构的依赖方向并导致 domain 编译缺少类。
- 需要把实现细节和 JSON/第三方库移出 domain，使 domain 仅包含 JDK 类型与纯领域模型，避免循环依赖并恢复整个 Reactor 的可编译性。

### Description

- 将 cron 相关实现 `AbstractCycle`、`CycleLinks`、`CycleFactory`、`CronUtils` 从 `yak-ops-domain` 迁移到 `yak-ops-application` 的 `io.yak.ops.application.support.cron` 包，且 `CronUtils` 参数由 `List<JobSchedule>` 改为纯 `List<String>` cron 表达式以解除对 DAO 实体的耦合。
- 将 DAG 层从基于 Jackson/Config 的实现改为纯领域模型：新增 `DagNode`、`DagEdge`、不可变 `DagGraph`，并把原来依赖 `ObjectNode` 的校验器改为接收 `DagGraph` 的领域校验器（`DagValidator` 接口签名变更）。
- 把 JSON 解析、WholeSync 组装、`DagUtil`、`DagConfigMapper` 和 HOCON 适配移到 `yak-ops-application`（application adapter/support 层），保持 domain 不依赖 Jackson/Typesafe/commons 等第三方库。
- 将领域异常脱离 plugin SPI：新增 `DomainErrorCode` 与 `DomainErrors`，`ServiceException` 仅依赖领域契约；`yak-ops-plugin-spi` 的 `Status` 枚举实现 `DomainErrorCode`（依赖方向改为 plugin → domain）；同时调整 `pom.xml`，在实际使用第三方库的 application 模块显式声明 `cron-utils`/`jackson`/`commons-lang3`/`slf4j` 等依赖，并从 domain POM 删除 Typesafe Config。

### Testing

- 本地 Java 编译：用 `javac -source 8 -target 8` 编译纯领域 DAG/异常类通过（成功）。
- 代码静态检查：运行 `git diff --cached --check` 与导入检查（`rg`）未发现 domain 中对外部实现的残留 import（成功）。
- 架构检查：运行 `python3 tools/architecture_check.py` 显示未新增 `domain-jdk-only` 或 domain↔reactor 的新违规，但仓库中存在既有的 `application-boundary` 债务（工具报告了既有问题，属于历史债务）。
- Maven 构建：尝试执行 `mvn clean compile -Dexec.skip=true` / `mvn clean compile` 时在项目模型解析阶段被环境阻断（无法下载 Spring Boot BOM），Maven 从 Central 返回 HTTP 403 导致构建无法在当前环境完成（网络/仓库访问问题，非代码错误）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6433b728e48326a8528af202a015b5)