### PR TITLE
fix: 解耦 dao 与 web contract 并修复模块编译

### DIFF
--- a/yak-ops-application/src/main/java/io/yak/ops/application/service/impl/BatchJobDefinitionServiceImpl.java
+++ b/yak-ops-application/src/main/java/io/yak/ops/application/service/impl/BatchJobDefinitionServiceImpl.java
@@ -22,6 +22,9 @@ import io.yak.ops.dao.entity.JobDefinitionEntity;
 import io.yak.ops.dao.entity.JobSchedule;
 import io.yak.ops.dao.repository.JobDefinitionContentDao;
 import io.yak.ops.dao.repository.JobDefinitionDao;
+import io.yak.ops.dao.model.query.JobDefinitionQuery;
+import io.yak.ops.dao.model.result.JobDefinitionResult;
+import io.yak.ops.common.utils.ConvertUtil;
 import io.yak.ops.web.contract.dto.BatchJobDefinitionQueryDTO;
 import io.yak.ops.web.contract.dto.batch.BatchGuideMultiJobSaveCommand;
 import io.yak.ops.web.contract.dto.batch.BatchGuideSingleJobSaveCommand;
@@ -193,10 +196,13 @@ public class BatchJobDefinitionServiceImpl extends BaseServiceImpl implements Ba
         try {
             int offset = (dto.getPageNo() - 1) * dto.getPageSize();
 
+            JobDefinitionQuery query = ConvertUtil.sourceToTarget(dto, JobDefinitionQuery.class);
+            List<JobDefinitionResult> results =
+                    jobDefinitionDao.selectPageWithLatestInstance(query, offset, dto.getPageSize());
             List<BatchJobDefinitionVO> records =
-                    jobDefinitionDao.selectPageWithLatestInstance(dto, offset, dto.getPageSize());
+                    ConvertUtil.sourceListToTarget(results, BatchJobDefinitionVO.class);
 
-            Long total = jobDefinitionDao.count(dto);
+            Long total = jobDefinitionDao.count(query);
 
             if (records != null) {
                 records.forEach(vo -> fillScheduleFields(vo.getId(), vo));

--- a/yak-ops-application/src/main/java/io/yak/ops/application/service/impl/BatchJobInstanceServiceImpl.java
+++ b/yak-ops-application/src/main/java/io/yak/ops/application/service/impl/BatchJobInstanceServiceImpl.java
@@ -19,6 +19,9 @@ import io.yak.ops.dao.entity.JobInstance;
 import io.yak.ops.dao.repository.JobInstanceDao;
 import io.yak.ops.dao.repository.JobMetricsDao;
 import io.yak.ops.dao.repository.JobTableMetricsDao;
+import io.yak.ops.dao.model.query.JobInstanceQuery;
+import io.yak.ops.dao.model.result.JobInstanceResult;
+import io.yak.ops.dao.model.result.JobTableMetricsResult;
 import io.yak.ops.web.contract.dto.SeaTunnelJobInstanceDTO;
 import io.yak.ops.web.contract.dto.command.JobDefinitionSaveCommand;
 import io.yak.ops.web.contract.response.PaginationResult;
@@ -98,13 +101,16 @@ public class BatchJobInstanceServiceImpl implements BatchJobInstanceService {
         validatePagingRequest(dto);
 
         try {
-            IPage<JobInstanceVO> pageResult = jobInstanceDao.pageWithDefinition(dto);
+            JobInstanceQuery query = ConvertUtil.sourceToTarget(dto, JobInstanceQuery.class);
+            IPage<JobInstanceResult> pageResult = jobInstanceDao.pageWithDefinition(query);
+            List<JobInstanceVO> records = ConvertUtil.sourceListToTarget(
+                    pageResult.getRecords(), JobInstanceVO.class);
 
-            if (pageResult.getRecords() != null) {
-                pageResult.getRecords().forEach(this::maskSensitiveFields);
+            if (records != null) {
+                records.forEach(this::maskSensitiveFields);
             }
 
-            return PaginationResult.buildSuc(pageResult.getRecords(), pageResult);
+            return PaginationResult.buildSuc(records, pageResult);
         } catch (ServiceException e) {
             throw e;
         } catch (Exception e) {
@@ -132,7 +138,9 @@ public class BatchJobInstanceServiceImpl implements BatchJobInstanceService {
         validateInstanceId(id);
 
         try {
-            JobInstanceVO vo = jobInstanceDao.selectDetailById(id);
+            JobInstanceResult result = jobInstanceDao.selectDetailById(id);
+            JobInstanceVO vo = result == null ? null :
+                    ConvertUtil.sourceToTarget(result, JobInstanceVO.class);
             if (vo == null) {
                 throw new ServiceException(Status.BATCH_JOB_INSTANCE_NOT_EXIST);
             }
@@ -249,7 +257,8 @@ public class BatchJobInstanceServiceImpl implements BatchJobInstanceService {
         validateInstanceId(instanceId);
 
         try {
-            return jobTableMetricsDao.selectByInstanceId(instanceId);
+            List<JobTableMetricsResult> results = jobTableMetricsDao.selectByInstanceId(instanceId);
+            return ConvertUtil.sourceListToTarget(results, JobTableMetricsVO.class);
         } catch (Exception e) {
             log.error("Query table metrics failed, instanceId={}", instanceId, e);
             throw new ServiceException(Status.QUERY_BATCH_JOB_INSTANCE_ERROR);

--- a/yak-ops-application/src/main/java/io/yak/ops/application/service/impl/ConnectorParamMetaServiceImpl.java
+++ b/yak-ops-application/src/main/java/io/yak/ops/application/service/impl/ConnectorParamMetaServiceImpl.java
@@ -5,7 +5,9 @@ import javax.annotation.Resource;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import io.yak.ops.application.service.ConnectorParamMetaService;
+import io.yak.ops.common.utils.ConvertUtil;
 import io.yak.ops.domain.exceptions.ServiceException;
+import io.yak.ops.dao.model.query.ConnectorParamMetaQuery;
 import io.yak.ops.dao.entity.ConnectorParamMetaEntity;
 import io.yak.ops.dao.repository.ConnectorParamMetaDao;
 import io.yak.ops.web.contract.dto.ConnectorParamMetaCreateDTO;
@@ -135,7 +137,8 @@ public class ConnectorParamMetaServiceImpl implements ConnectorParamMetaService 
         }
 
         try {
-            IPage<ConnectorParamMetaEntity> pageResult = connectorParamMetaDao.queryPage(dto);
+            ConnectorParamMetaQuery query = ConvertUtil.sourceToTarget(dto, ConnectorParamMetaQuery.class);
+            IPage<ConnectorParamMetaEntity> pageResult = connectorParamMetaDao.queryPage(query);
             List<ConnectorParamMetaVO> records = pageResult.getRecords()
                     .stream()
                     .map(this::toVO)

--- a/yak-ops-application/src/main/java/io/yak/ops/application/service/impl/DataSourceServiceImpl.java
+++ b/yak-ops-application/src/main/java/io/yak/ops/application/service/impl/DataSourceServiceImpl.java
@@ -11,6 +11,7 @@ import io.yak.ops.common.enums.ConnStatus;
 import io.yak.ops.common.utils.ConvertUtil;
 import io.yak.ops.common.utils.JSONUtils;
 import io.yak.ops.domain.exceptions.ServiceException;
+import io.yak.ops.dao.model.query.DataSourceQuery;
 import io.yak.ops.dao.entity.DataSource;
 import io.yak.ops.dao.repository.DataSourceDao;
 import io.yak.ops.dao.repository.JobDefinitionDao;
@@ -131,7 +132,8 @@ public class DataSourceServiceImpl extends BaseServiceImpl implements DataSource
     @Override
     public PaginationResult<DataSourceVO> queryDataSourceListPaging(DataSourceDTO dto) {
         try {
-            IPage<DataSource> pageResult = dataSourceDao.queryPage(dto);
+            DataSourceQuery query = ConvertUtil.sourceToTarget(dto, DataSourceQuery.class);
+            IPage<DataSource> pageResult = dataSourceDao.queryPage(query);
             List<DataSourceVO> records =
                     ConvertUtil.sourceListToTarget(pageResult.getRecords(), DataSourceVO.class);
 

--- a/yak-ops-application/src/main/java/io/yak/ops/application/service/impl/TimeVariableServiceImpl.java
+++ b/yak-ops-application/src/main/java/io/yak/ops/application/service/impl/TimeVariableServiceImpl.java
@@ -7,8 +7,10 @@ import org.apache.commons.lang3.StringUtils;
 import io.yak.ops.application.service.TimeVariableService;
 import io.yak.ops.common.enums.TimeVariableSource;
 import io.yak.ops.common.enums.TimeVariableValueType;
+import io.yak.ops.common.utils.ConvertUtil;
 import io.yak.ops.domain.exceptions.ServiceException;
 import io.yak.ops.application.support.time.TimeExpressionEvaluator;
+import io.yak.ops.dao.model.query.TimeVariablePageQuery;
 import io.yak.ops.dao.entity.TimeVariable;
 import io.yak.ops.dao.repository.TimeVariableDao;
 import io.yak.ops.web.contract.dto.*;
@@ -150,7 +152,8 @@ public class TimeVariableServiceImpl implements TimeVariableService {
         }
 
         try {
-            IPage<TimeVariable> pageResult = timeVariableDao.queryPage(req);
+            TimeVariablePageQuery query = ConvertUtil.sourceToTarget(req, TimeVariablePageQuery.class);
+            IPage<TimeVariable> pageResult = timeVariableDao.queryPage(query);
 
             List<TimeVariableVO> records = pageResult.getRecords()
                     .stream()

--- a/yak-ops-application/src/main/java/io/yak/ops/application/service/impl/client/SeaTunnelClientAssembler.java
+++ b/yak-ops-application/src/main/java/io/yak/ops/application/service/impl/client/SeaTunnelClientAssembler.java
@@ -180,6 +180,23 @@ public class SeaTunnelClientAssembler {
         return dto;
     }
 
+    /** Converts a persisted node to the DAO projection attached to a client record. */
+    public io.yak.ops.dao.model.result.SeaTunnelClientEndpoint toPersistenceEndpoint(
+            SeaTunnelClientNode node) {
+        io.yak.ops.dao.model.result.SeaTunnelClientEndpoint endpoint =
+                new io.yak.ops.dao.model.result.SeaTunnelClientEndpoint();
+        endpoint.setId(node.getId());
+        endpoint.setHost(node.getHost());
+        endpoint.setHostname(node.getHostname());
+        endpoint.setPort(node.getPort());
+        endpoint.setRole(node.getNodeRole());
+        endpoint.setBaseUrl(node.getBaseUrl());
+        endpoint.setActiveMaster(Boolean.TRUE.equals(node.getActiveMaster()));
+        endpoint.setHealthStatus(resolveHealthStatusName(node.getHealthStatus()));
+        endpoint.setLastError(node.getLastError());
+        return endpoint;
+    }
+
     /**
      * Converts a client entity to an option item.
      *

--- a/yak-ops-application/src/main/java/io/yak/ops/application/service/impl/client/SeaTunnelClientQueryAppService.java
+++ b/yak-ops-application/src/main/java/io/yak/ops/application/service/impl/client/SeaTunnelClientQueryAppService.java
@@ -13,6 +13,7 @@ import io.yak.ops.dao.entity.SeaTunnelClientNode;
 import io.yak.ops.dao.repository.SeaTunnelClientDao;
 import io.yak.ops.dao.repository.SeaTunnelClientNodeDao;
 import io.yak.ops.web.contract.dto.SeaTunnelClientEndpointDTO;
+import io.yak.ops.dao.model.result.SeaTunnelClientEndpoint;
 import io.yak.ops.web.contract.dto.SeaTunnelClientPageDTO;
 import io.yak.ops.web.contract.vo.OptionVO;
 import io.yak.ops.plugin.spi.enums.Status;
@@ -139,20 +140,20 @@ public class SeaTunnelClientQueryAppService {
                 continue;
             }
 
-            List<SeaTunnelClientEndpointDTO> masters = nodes.stream()
+            List<SeaTunnelClientEndpoint> masters = nodes.stream()
                     .filter(node -> StringUtils.equalsIgnoreCase(
                             node.getNodeRole(),
                             SeaTunnelClientNodeRole.MASTER
                     ))
-                    .map(assembler::toEndpointDTO)
+                    .map(assembler::toPersistenceEndpoint)
                     .collect(java.util.stream.Collectors.toList());
 
-            List<SeaTunnelClientEndpointDTO> workers = nodes.stream()
+            List<SeaTunnelClientEndpoint> workers = nodes.stream()
                     .filter(node -> StringUtils.equalsIgnoreCase(
                             node.getNodeRole(),
                             SeaTunnelClientNodeRole.WORKER
                     ))
-                    .map(assembler::toEndpointDTO)
+                    .map(assembler::toPersistenceEndpoint)
                     .collect(java.util.stream.Collectors.toList());
 
             client.setMasterEndpoints(masters);

--- a/yak-ops-dao/pom.xml
+++ b/yak-ops-dao/pom.xml
@@ -30,6 +30,14 @@
             <artifactId>mybatis-plus</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.mybatis</groupId>
+            <artifactId>mybatis-spring</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
         </dependency>

--- a/yak-ops-dao/src/main/java/io/yak/ops/dao/DaoConfiguration.java
+++ b/yak-ops-dao/src/main/java/io/yak/ops/dao/DaoConfiguration.java
@@ -1,11 +1,9 @@
 package io.yak.ops.dao;
 
 import org.mybatis.spring.annotation.MapperScan;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@EnableAutoConfiguration
 @MapperScan("io.yak.ops.dao.mapper")
 public class DaoConfiguration {
 }

--- a/yak-ops-dao/src/main/java/io/yak/ops/dao/entity/AlarmChannelEntity.java
+++ b/yak-ops-dao/src/main/java/io/yak/ops/dao/entity/AlarmChannelEntity.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import lombok.EqualsAndHashCode;
 
 /**
  * A configured alarm channel instance (e.g. a specific webhook endpoint).
@@ -13,6 +14,7 @@ import lombok.ToString;
  * {@link org.apache.seatunnel.plugin.alarm.api.AlarmChannel} implementation.
  */
 @Data
+@EqualsAndHashCode(callSuper = true)
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor

--- a/yak-ops-dao/src/main/java/io/yak/ops/dao/entity/AlarmRecordEntity.java
+++ b/yak-ops-dao/src/main/java/io/yak/ops/dao/entity/AlarmRecordEntity.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import lombok.EqualsAndHashCode;
 
 import java.util.Date;
 
@@ -13,6 +14,7 @@ import java.util.Date;
  * Persisted record of an alarm delivery attempt, for auditing and retries.
  */
 @Data
+@EqualsAndHashCode(callSuper = true)
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor

--- a/yak-ops-dao/src/main/java/io/yak/ops/dao/entity/AlarmRuleChannelEntity.java
+++ b/yak-ops-dao/src/main/java/io/yak/ops/dao/entity/AlarmRuleChannelEntity.java
@@ -6,11 +6,13 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import lombok.EqualsAndHashCode;
 
 /**
  * Many-to-many link between an alarm rule and an alarm channel.
  */
 @Data
+@EqualsAndHashCode(callSuper = true)
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor

--- a/yak-ops-dao/src/main/java/io/yak/ops/dao/entity/AlarmRuleEntity.java
+++ b/yak-ops-dao/src/main/java/io/yak/ops/dao/entity/AlarmRuleEntity.java
@@ -6,12 +6,14 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import lombok.EqualsAndHashCode;
 
 /**
  * An alarm rule: which jobs, on which statuses, with which severity, trigger
  * an alarm. Linked to channels through {@link AlarmRuleChannelEntity}.
  */
 @Data
+@EqualsAndHashCode(callSuper = true)
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor

--- a/yak-ops-dao/src/main/java/io/yak/ops/dao/entity/SeaTunnelClient.java
+++ b/yak-ops-dao/src/main/java/io/yak/ops/dao/entity/SeaTunnelClient.java
@@ -5,7 +5,7 @@ import com.baomidou.mybatisplus.annotation.TableName;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import io.yak.ops.web.contract.dto.SeaTunnelClientEndpointDTO;
+import io.yak.ops.dao.model.result.SeaTunnelClientEndpoint;
 
 import java.util.Date;
 import java.util.List;
@@ -57,8 +57,8 @@ public class SeaTunnelClient {
     private Date updateTime;
 
     @TableField(exist = false)
-    private List<SeaTunnelClientEndpointDTO> masterEndpoints;
+    private List<SeaTunnelClientEndpoint> masterEndpoints;
 
     @TableField(exist = false)
-    private List<SeaTunnelClientEndpointDTO> workerEndpoints;
+    private List<SeaTunnelClientEndpoint> workerEndpoints;
 }

--- a/yak-ops-dao/src/main/java/io/yak/ops/dao/mapper/JobDefinitionMapper.java
+++ b/yak-ops-dao/src/main/java/io/yak/ops/dao/mapper/JobDefinitionMapper.java
@@ -4,18 +4,18 @@ import com.baomidou.mybatisplus.core.mapper.BaseMapper;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 import io.yak.ops.dao.entity.JobDefinitionEntity;
-import io.yak.ops.web.contract.dto.BatchJobDefinitionQueryDTO;
-import io.yak.ops.web.contract.vo.BatchJobDefinitionVO;
+import io.yak.ops.dao.model.query.JobDefinitionQuery;
+import io.yak.ops.dao.model.result.JobDefinitionResult;
 
 import java.util.List;
 
 @Mapper
 public interface JobDefinitionMapper extends BaseMapper<JobDefinitionEntity> {
-    List<BatchJobDefinitionVO> selectPageWithLatestInstance(
-            @Param("dto") BatchJobDefinitionQueryDTO dto,
+    List<JobDefinitionResult> selectPageWithLatestInstance(
+            @Param("query") JobDefinitionQuery query,
             @Param("offset") int offset,
             @Param("pageSize") int pageSize
     );
 
-    Long selectDefinitionCount(@Param("dto") BatchJobDefinitionQueryDTO dto);
+    Long selectDefinitionCount(@Param("query") JobDefinitionQuery query);
 }

--- a/yak-ops-dao/src/main/java/io/yak/ops/dao/mapper/JobInstanceMapper.java
+++ b/yak-ops-dao/src/main/java/io/yak/ops/dao/mapper/JobInstanceMapper.java
@@ -6,15 +6,15 @@ import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 import io.yak.ops.dao.entity.JobInstance;
-import io.yak.ops.web.contract.dto.SeaTunnelJobInstanceDTO;
-import io.yak.ops.web.contract.vo.JobInstanceVO;
+import io.yak.ops.dao.model.query.JobInstanceQuery;
+import io.yak.ops.dao.model.result.JobInstanceResult;
 
 @Mapper
 public interface JobInstanceMapper extends BaseMapper<JobInstance> {
-    IPage<JobInstanceVO> pageWithDefinition(
+    IPage<JobInstanceResult> pageWithDefinition(
             Page<?> page,
-            @Param("dto") SeaTunnelJobInstanceDTO dto);
+            @Param("query") JobInstanceQuery query);
 
-    JobInstanceVO selectDetailById(@Param("id") Long id);
+    JobInstanceResult selectDetailById(@Param("id") Long id);
 
 }

--- a/yak-ops-dao/src/main/java/io/yak/ops/dao/mapper/JobTableMetricsMapper.java
+++ b/yak-ops-dao/src/main/java/io/yak/ops/dao/mapper/JobTableMetricsMapper.java
@@ -4,13 +4,13 @@ import com.baomidou.mybatisplus.core.mapper.BaseMapper;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 import io.yak.ops.dao.entity.JobTableMetrics;
-import io.yak.ops.web.contract.vo.JobTableMetricsVO;
+import io.yak.ops.dao.model.result.JobTableMetricsResult;
 
 import java.util.List;
 
 @Mapper
 public interface JobTableMetricsMapper extends BaseMapper<JobTableMetrics> {
-    List<JobTableMetricsVO> selectByInstanceId(@Param("instanceId") Long instanceId);
+    List<JobTableMetricsResult> selectByInstanceId(@Param("instanceId") Long instanceId);
 
     void deleteByDefinitionId(@Param("definitionId") Long definitionId);
 

--- a/yak-ops-dao/src/main/java/io/yak/ops/dao/model/query/ConnectorParamMetaQuery.java
+++ b/yak-ops-dao/src/main/java/io/yak/ops/dao/model/query/ConnectorParamMetaQuery.java
@@ -1,0 +1,14 @@
+package io.yak.ops.dao.model.query;
+
+import lombok.Data;
+
+/** Persistence pagination criteria for connector parameter metadata. */
+@Data
+public class ConnectorParamMetaQuery {
+    private String type;
+    private String connectorName;
+    private String connectorType;
+    private String paramName;
+    private Long pageNum = 1L;
+    private Long pageSize = 10L;
+}

--- a/yak-ops-dao/src/main/java/io/yak/ops/dao/model/query/DataSourceQuery.java
+++ b/yak-ops-dao/src/main/java/io/yak/ops/dao/model/query/DataSourceQuery.java
@@ -1,0 +1,15 @@
+package io.yak.ops.dao.model.query;
+
+import io.yak.ops.common.enums.EnvironmentEnum;
+import io.yak.ops.plugin.spi.enums.DbType;
+import lombok.Data;
+
+/** Persistence pagination criteria for data sources. */
+@Data
+public class DataSourceQuery {
+    private String name;
+    private DbType dbType;
+    private EnvironmentEnum environment;
+    private Integer pageNo = 1;
+    private Integer pageSize = 10;
+}

--- a/yak-ops-dao/src/main/java/io/yak/ops/dao/model/query/JobDefinitionQuery.java
+++ b/yak-ops-dao/src/main/java/io/yak/ops/dao/model/query/JobDefinitionQuery.java
@@ -1,0 +1,24 @@
+package io.yak.ops.dao.model.query;
+
+import io.yak.ops.common.enums.SyncModeEnum;
+import io.yak.ops.domain.enums.JobMode;
+import lombok.Data;
+
+import java.util.Date;
+
+/** Persistence criteria for querying job definitions. */
+@Data
+public class JobDefinitionQuery {
+    private Long id;
+    private String sourceType;
+    private String sinkType;
+    private JobMode jobType;
+    private SyncModeEnum syncMode;
+    private Date createTimeStart;
+    private Date createTimeEnd;
+    private String jobName;
+    private String status;
+    private String sourceTable;
+    private String scheduleConfig;
+    private String sinkTable;
+}

--- a/yak-ops-dao/src/main/java/io/yak/ops/dao/model/query/JobInstanceQuery.java
+++ b/yak-ops-dao/src/main/java/io/yak/ops/dao/model/query/JobInstanceQuery.java
@@ -1,0 +1,22 @@
+package io.yak.ops.dao.model.query;
+
+import io.yak.ops.domain.enums.JobMode;
+import io.yak.ops.domain.enums.RunMode;
+import lombok.Data;
+
+import java.util.Date;
+
+/** Persistence criteria for querying job instances. */
+@Data
+public class JobInstanceQuery {
+    private Long id;
+    private Long jobDefinitionId;
+    private String keyword;
+    private String jobStatus;
+    private Date queryStartTime;
+    private Date queryEndTime;
+    private RunMode runMode;
+    private JobMode jobType;
+    private Integer pageNo = 1;
+    private Integer pageSize = 10;
+}

--- a/yak-ops-dao/src/main/java/io/yak/ops/dao/model/query/TimeVariablePageQuery.java
+++ b/yak-ops-dao/src/main/java/io/yak/ops/dao/model/query/TimeVariablePageQuery.java
@@ -1,0 +1,14 @@
+package io.yak.ops.dao.model.query;
+
+import lombok.Data;
+
+/** Persistence pagination criteria for time variables. */
+@Data
+public class TimeVariablePageQuery {
+    private Integer pageNo = 1;
+    private Integer pageSize = 10;
+    private String keyword;
+    private String variableSource;
+    private String valueType;
+    private Boolean enabled;
+}

--- a/yak-ops-dao/src/main/java/io/yak/ops/dao/model/result/JobDefinitionResult.java
+++ b/yak-ops-dao/src/main/java/io/yak/ops/dao/model/result/JobDefinitionResult.java
@@ -1,0 +1,24 @@
+package io.yak.ops.dao.model.result;
+
+import io.yak.ops.common.enums.*;
+import io.yak.ops.domain.enums.JobMode;
+import io.yak.ops.domain.enums.RunMode;
+import lombok.Data;
+import java.util.Date;
+
+/** Joined persistence projection for a job definition and its latest execution. */
+@Data
+public class JobDefinitionResult {
+    private Long id; private Long instanceId; private String jobName; private String jobDesc;
+    private JobDefinitionMode mode; private JobMode jobType; private ReleaseState releaseState;
+    private Long clientId; private Integer parallelism; private Long duration; private Long qps;
+    private String jobDefinitionInfo; private Integer jobVersion; private String sourceType;
+    private String sourceTable; private SyncModeEnum syncMode; private String sinkType; private String sinkTable;
+    private String lastJobStatus; private Date lastStartTime; private Date lastEndTime; private String errorMessage;
+    private RunMode runMode; private Long readRowCount; private Long writeRowCount; private Long readQps;
+    private Long writeQps; private Long recordDelay; private Date createTime; private Date updateTime;
+    private String scheduleId; private String cronExpression; private ScheduleStatusEnum scheduleStatus;
+    private Date lastScheduleTime; private Date nextScheduleTime; private String scheduleConfig;
+    private Long sourceDatasourceId; private Long sinkDatasourceId; private String sourceDatasourceName;
+    private String sinkDatasourceName;
+}

--- a/yak-ops-dao/src/main/java/io/yak/ops/dao/model/result/JobInstanceResult.java
+++ b/yak-ops-dao/src/main/java/io/yak/ops/dao/model/result/JobInstanceResult.java
@@ -1,0 +1,26 @@
+package io.yak.ops.dao.model.result;
+
+import lombok.Data;
+import java.math.BigDecimal;
+import java.util.Date;
+
+/** Joined persistence projection for a job instance and its definition/metrics. */
+@Data
+public class JobInstanceResult {
+    private Long id; private Long jobDefinitionId; private Long clientId;
+    private String checkpointPath; private String savepointPath; private String runMode;
+    private String jobStatus; private String triggerSource; private Integer retryCount;
+    private String engineJobId; private String runtimeConfig; private String logPath;
+    private String errorMessage; private Date submitTime; private Date startTime; private Date endTime;
+    private Date createTime; private Date updateTime; private String jobName; private String jobDesc;
+    private String definitionMode; private String jobType; private Long definitionClientId;
+    private Integer parallelism; private Integer jobVersion; private String definitionStatus;
+    private String sourceType; private String sinkType; private String sourceTable; private String sinkTable;
+    private Long sourceDatasourceId; private Long sinkDatasourceId;
+    private Long readRowCount; private Long writeRowCount; private BigDecimal readQps; private BigDecimal writeQps;
+    private Long readBytes; private Long writeBytes; private BigDecimal readBps; private BigDecimal writeBps;
+    private Long intermediateQueueSize; private Long lagCount; private BigDecimal lossRate;
+    private Long avgRowSize; private Long recordDelay; private String cronExpression;
+    private String scheduleStatus; private String scheduleConfig; private Date lastScheduleTime;
+    private Date nextScheduleTime;
+}

--- a/yak-ops-dao/src/main/java/io/yak/ops/dao/model/result/JobTableMetricsResult.java
+++ b/yak-ops-dao/src/main/java/io/yak/ops/dao/model/result/JobTableMetricsResult.java
@@ -1,0 +1,15 @@
+package io.yak.ops.dao.model.result;
+
+import lombok.Data;
+import java.math.BigDecimal;
+import java.util.Date;
+
+/** Persistence projection for table-level job metrics. */
+@Data
+public class JobTableMetricsResult {
+    private Long id; private Long jobInstanceId; private Long jobDefinitionId; private Integer pipelineId;
+    private String sourceTable; private String sinkTable; private Long readRowCount; private Long writeRowCount;
+    private BigDecimal readQps; private BigDecimal writeQps; private Long readBytes; private Long writeBytes;
+    private BigDecimal readBps; private BigDecimal writeBps; private Long rowDiff; private String status;
+    private String errorMsg; private Date createTime; private Date updateTime;
+}

--- a/yak-ops-dao/src/main/java/io/yak/ops/dao/model/result/SeaTunnelClientEndpoint.java
+++ b/yak-ops-dao/src/main/java/io/yak/ops/dao/model/result/SeaTunnelClientEndpoint.java
@@ -1,0 +1,15 @@
+package io.yak.ops.dao.model.result;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/** Non-persistent endpoint view attached to a persisted client. */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class SeaTunnelClientEndpoint {
+    private Long id; private String host; private String hostname; private Integer port;
+    private String role; private String healthStatus; private Boolean activeMaster;
+    private String baseUrl; private String lastError;
+}

--- a/yak-ops-dao/src/main/java/io/yak/ops/dao/repository/ConnectorParamMetaDao.java
+++ b/yak-ops-dao/src/main/java/io/yak/ops/dao/repository/ConnectorParamMetaDao.java
@@ -2,7 +2,7 @@ package io.yak.ops.dao.repository;
 
 import com.baomidou.mybatisplus.core.metadata.IPage;
 import io.yak.ops.dao.entity.ConnectorParamMetaEntity;
-import io.yak.ops.web.contract.dto.ConnectorParamMetaQueryDTO;
+import io.yak.ops.dao.model.query.ConnectorParamMetaQuery;
 
 import java.util.List;
 
@@ -12,7 +12,7 @@ public interface ConnectorParamMetaDao extends IDao<ConnectorParamMetaEntity> {
 
     boolean checkDuplicateExcludeId(String type, String connectorName, String paramName, Long id);
 
-    IPage<ConnectorParamMetaEntity> queryPage(ConnectorParamMetaQueryDTO dto);
+    IPage<ConnectorParamMetaEntity> queryPage(ConnectorParamMetaQuery query);
 
     List<ConnectorParamMetaEntity> queryList(String connectorName, String type);
 

--- a/yak-ops-dao/src/main/java/io/yak/ops/dao/repository/DataSourceDao.java
+++ b/yak-ops-dao/src/main/java/io/yak/ops/dao/repository/DataSourceDao.java
@@ -4,7 +4,7 @@ package io.yak.ops.dao.repository;
 import com.baomidou.mybatisplus.core.metadata.IPage;
 import io.yak.ops.common.enums.ConnStatus;
 import io.yak.ops.dao.entity.DataSource;
-import io.yak.ops.web.contract.dto.DataSourceDTO;
+import io.yak.ops.dao.model.query.DataSourceQuery;
 
 import java.util.List;
 
@@ -14,7 +14,7 @@ public interface DataSourceDao extends IDao<DataSource> {
 
     boolean checkNameExcludeId(String name, Long id);
 
-    IPage<DataSource> queryPage(DataSourceDTO dto);
+    IPage<DataSource> queryPage(DataSourceQuery query);
 
     List<DataSource> queryByDbType(String dbType);
 

--- a/yak-ops-dao/src/main/java/io/yak/ops/dao/repository/JobDefinitionDao.java
+++ b/yak-ops-dao/src/main/java/io/yak/ops/dao/repository/JobDefinitionDao.java
@@ -2,8 +2,8 @@ package io.yak.ops.dao.repository;
 
 import io.yak.ops.common.enums.ReleaseState;
 import io.yak.ops.dao.entity.JobDefinitionEntity;
-import io.yak.ops.web.contract.dto.BatchJobDefinitionQueryDTO;
-import io.yak.ops.web.contract.vo.BatchJobDefinitionVO;
+import io.yak.ops.dao.model.query.JobDefinitionQuery;
+import io.yak.ops.dao.model.result.JobDefinitionResult;
 
 import java.util.List;
 
@@ -11,13 +11,13 @@ public interface JobDefinitionDao extends IDao<JobDefinitionEntity> {
 
     boolean saveOrUpdate(JobDefinitionEntity po);
 
-    List<BatchJobDefinitionVO> selectPageWithLatestInstance(
-            BatchJobDefinitionQueryDTO dto,
+    List<JobDefinitionResult> selectPageWithLatestInstance(
+            JobDefinitionQuery query,
             int offset,
             int pageSize
     );
 
-    Long count(BatchJobDefinitionQueryDTO dto);
+    Long count(JobDefinitionQuery query);
 
     boolean updateReleaseState(Long id, ReleaseState releaseState);
 

--- a/yak-ops-dao/src/main/java/io/yak/ops/dao/repository/JobInstanceDao.java
+++ b/yak-ops-dao/src/main/java/io/yak/ops/dao/repository/JobInstanceDao.java
@@ -4,17 +4,17 @@ import com.baomidou.mybatisplus.core.metadata.IPage;
 import io.yak.ops.domain.enums.JobMode;
 import io.yak.ops.domain.enums.JobStatus;
 import io.yak.ops.dao.entity.JobInstance;
-import io.yak.ops.web.contract.dto.SeaTunnelJobInstanceDTO;
-import io.yak.ops.web.contract.vo.JobInstanceVO;
+import io.yak.ops.dao.model.query.JobInstanceQuery;
+import io.yak.ops.dao.model.result.JobInstanceResult;
 
 import java.util.Date;
 import java.util.List;
 
 public interface JobInstanceDao extends IDao<JobInstance> {
 
-    IPage<JobInstanceVO> pageWithDefinition(SeaTunnelJobInstanceDTO dto);
+    IPage<JobInstanceResult> pageWithDefinition(JobInstanceQuery query);
 
-    JobInstanceVO selectDetailById(Long id);
+    JobInstanceResult selectDetailById(Long id);
 
     boolean existsRunningInstance(Long definitionId);
 
@@ -30,7 +30,7 @@ public interface JobInstanceDao extends IDao<JobInstance> {
 
     void updateSubmitResult(Long instanceId, String engineJobId, JobStatus submitStatus, Date submitTime);
 
-    List<JobInstanceVO> listRunningByJobType(JobMode jobMode);
+    List<JobInstance> listRunningByJobType(JobMode jobMode);
 
     List<JobInstance> selectRunningInstanceByDefinitionIds(List<Long> definitionIds);
 }

--- a/yak-ops-dao/src/main/java/io/yak/ops/dao/repository/JobTableMetricsDao.java
+++ b/yak-ops-dao/src/main/java/io/yak/ops/dao/repository/JobTableMetricsDao.java
@@ -2,7 +2,7 @@ package io.yak.ops.dao.repository;
 
 
 import io.yak.ops.dao.entity.JobTableMetrics;
-import io.yak.ops.web.contract.vo.JobTableMetricsVO;
+import io.yak.ops.dao.model.result.JobTableMetricsResult;
 
 import java.util.List;
 
@@ -10,7 +10,7 @@ import java.util.List;
  * DAO for SeaTunnel table level metrics.
  */
 public interface JobTableMetricsDao extends IDao<JobTableMetrics> {
-    List<JobTableMetricsVO> selectByInstanceId(Long instanceId);
+    List<JobTableMetricsResult> selectByInstanceId(Long instanceId);
 
     void deleteByDefinitionId(Long definitionId);
 }

--- a/yak-ops-dao/src/main/java/io/yak/ops/dao/repository/TimeVariableDao.java
+++ b/yak-ops-dao/src/main/java/io/yak/ops/dao/repository/TimeVariableDao.java
@@ -2,7 +2,7 @@ package io.yak.ops.dao.repository;
 
 import com.baomidou.mybatisplus.core.metadata.IPage;
 import io.yak.ops.dao.entity.TimeVariable;
-import io.yak.ops.web.contract.dto.TimeVariablePageReq;
+import io.yak.ops.dao.model.query.TimeVariablePageQuery;
 
 import java.util.List;
 
@@ -12,7 +12,7 @@ public interface TimeVariableDao extends IDao<TimeVariable> {
 
     boolean checkDuplicateExcludeId(String paramName, Long id);
 
-    IPage<TimeVariable> queryPage(TimeVariablePageReq req);
+    IPage<TimeVariable> queryPage(TimeVariablePageQuery req);
 
     List<TimeVariable> queryEnabledList();
 }

--- a/yak-ops-dao/src/main/java/io/yak/ops/dao/repository/impl/ConnectorParamMetaDaoImpl.java
+++ b/yak-ops-dao/src/main/java/io/yak/ops/dao/repository/impl/ConnectorParamMetaDaoImpl.java
@@ -10,7 +10,7 @@ import io.yak.ops.dao.entity.ConnectorParamMetaEntity;
 import io.yak.ops.dao.mapper.ConnectorParamMetaMapper;
 import io.yak.ops.dao.repository.BaseDao;
 import io.yak.ops.dao.repository.ConnectorParamMetaDao;
-import io.yak.ops.web.contract.dto.ConnectorParamMetaQueryDTO;
+import io.yak.ops.dao.model.query.ConnectorParamMetaQuery;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -47,15 +47,15 @@ public class ConnectorParamMetaDaoImpl
     }
 
     @Override
-    public IPage<ConnectorParamMetaEntity> queryPage(ConnectorParamMetaQueryDTO dto) {
+    public IPage<ConnectorParamMetaEntity> queryPage(ConnectorParamMetaQuery query) {
         LambdaQueryWrapper<ConnectorParamMetaEntity> wrapper = new LambdaQueryWrapper<ConnectorParamMetaEntity>()
-                .eq(StringUtils.isNotBlank(dto.getType()), ConnectorParamMetaEntity::getType, dto.getType())
-                .eq(StringUtils.isNotBlank(dto.getConnectorName()), ConnectorParamMetaEntity::getConnectorName, dto.getConnectorName())
-                .like(StringUtils.isNotBlank(dto.getParamName()), ConnectorParamMetaEntity::getParamName, dto.getParamName())
+                .eq(StringUtils.isNotBlank(query.getType()), ConnectorParamMetaEntity::getType, query.getType())
+                .eq(StringUtils.isNotBlank(query.getConnectorName()), ConnectorParamMetaEntity::getConnectorName, query.getConnectorName())
+                .like(StringUtils.isNotBlank(query.getParamName()), ConnectorParamMetaEntity::getParamName, query.getParamName())
                 .orderByDesc(ConnectorParamMetaEntity::getUpdateTime)
                 .orderByDesc(ConnectorParamMetaEntity::getId);
 
-        IPage<ConnectorParamMetaEntity> page = new Page<>(dto.getPageNum(), dto.getPageSize());
+        IPage<ConnectorParamMetaEntity> page = new Page<>(query.getPageNum(), query.getPageSize());
         return connectorParamMetaMapper.selectPage(page, wrapper);
     }
 

--- a/yak-ops-dao/src/main/java/io/yak/ops/dao/repository/impl/DataSourceDaoImpl.java
+++ b/yak-ops-dao/src/main/java/io/yak/ops/dao/repository/impl/DataSourceDaoImpl.java
@@ -11,7 +11,7 @@ import io.yak.ops.dao.entity.DataSource;
 import io.yak.ops.dao.mapper.DataSourceMapper;
 import io.yak.ops.dao.repository.BaseDao;
 import io.yak.ops.dao.repository.DataSourceDao;
-import io.yak.ops.web.contract.dto.DataSourceDTO;
+import io.yak.ops.dao.model.query.DataSourceQuery;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -42,14 +42,14 @@ public class DataSourceDaoImpl extends BaseDao<DataSource, DataSourceMapper> imp
     }
 
     @Override
-    public IPage<DataSource> queryPage(DataSourceDTO dto) {
+    public IPage<DataSource> queryPage(DataSourceQuery query) {
         LambdaQueryWrapper<DataSource> wrapper = new LambdaQueryWrapper<DataSource>()
-                .eq(StringUtils.isNotBlank(dto.getName()), DataSource::getName, dto.getName())
-                .eq(dto.getDbType() != null, DataSource::getDbType, dto.getDbType())
-                .eq(dto.getEnvironment() != null, DataSource::getEnvironment, dto.getEnvironment())
+                .eq(StringUtils.isNotBlank(query.getName()), DataSource::getName, query.getName())
+                .eq(query.getDbType() != null, DataSource::getDbType, query.getDbType())
+                .eq(query.getEnvironment() != null, DataSource::getEnvironment, query.getEnvironment())
                 .orderByDesc(DataSource::getCreateTime);
 
-        IPage<DataSource> page = new Page<>(dto.getPageNo(), dto.getPageSize());
+        IPage<DataSource> page = new Page<>(query.getPageNo(), query.getPageSize());
         return dataSourceMapper.selectPage(page, wrapper);
     }
 

--- a/yak-ops-dao/src/main/java/io/yak/ops/dao/repository/impl/JobDefinitionDaoImpl.java
+++ b/yak-ops-dao/src/main/java/io/yak/ops/dao/repository/impl/JobDefinitionDaoImpl.java
@@ -8,8 +8,8 @@ import io.yak.ops.dao.entity.JobDefinitionEntity;
 import io.yak.ops.dao.mapper.JobDefinitionMapper;
 import io.yak.ops.dao.repository.BaseDao;
 import io.yak.ops.dao.repository.JobDefinitionDao;
-import io.yak.ops.web.contract.dto.BatchJobDefinitionQueryDTO;
-import io.yak.ops.web.contract.vo.BatchJobDefinitionVO;
+import io.yak.ops.dao.model.query.JobDefinitionQuery;
+import io.yak.ops.dao.model.result.JobDefinitionResult;
 import org.springframework.stereotype.Repository;
 
 import java.util.Collections;
@@ -34,17 +34,17 @@ public class JobDefinitionDaoImpl
     }
 
     @Override
-    public List<BatchJobDefinitionVO> selectPageWithLatestInstance(
-            BatchJobDefinitionQueryDTO dto,
+    public List<JobDefinitionResult> selectPageWithLatestInstance(
+            JobDefinitionQuery query,
             int offset,
             int pageSize
     ) {
-        return jobDefinitionMapper.selectPageWithLatestInstance(dto, offset, pageSize);
+        return jobDefinitionMapper.selectPageWithLatestInstance(query, offset, pageSize);
     }
 
     @Override
-    public Long count(BatchJobDefinitionQueryDTO dto) {
-        return jobDefinitionMapper.selectDefinitionCount(dto);
+    public Long count(JobDefinitionQuery query) {
+        return jobDefinitionMapper.selectDefinitionCount(query);
     }
 
     public boolean updateReleaseState(Long id, ReleaseState releaseState) {

--- a/yak-ops-dao/src/main/java/io/yak/ops/dao/repository/impl/JobInstanceDaoImpl.java
+++ b/yak-ops-dao/src/main/java/io/yak/ops/dao/repository/impl/JobInstanceDaoImpl.java
@@ -8,20 +8,18 @@ import javax.annotation.Resource;
 import lombok.NonNull;
 import io.yak.ops.domain.enums.JobMode;
 import io.yak.ops.domain.enums.JobStatus;
-import io.yak.ops.common.utils.ConvertUtil;
 import io.yak.ops.domain.status.JobStatusHelper;
 import io.yak.ops.dao.entity.JobInstance;
 import io.yak.ops.dao.mapper.JobInstanceMapper;
 import io.yak.ops.dao.repository.BaseDao;
 import io.yak.ops.dao.repository.JobInstanceDao;
-import io.yak.ops.web.contract.dto.SeaTunnelJobInstanceDTO;
-import io.yak.ops.web.contract.vo.JobInstanceVO;
+import io.yak.ops.dao.model.query.JobInstanceQuery;
+import io.yak.ops.dao.model.result.JobInstanceResult;
 import org.springframework.stereotype.Repository;
 
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Repository
 public class JobInstanceDaoImpl
@@ -36,12 +34,12 @@ public class JobInstanceDaoImpl
     }
 
     @Override
-    public IPage<JobInstanceVO> pageWithDefinition(SeaTunnelJobInstanceDTO dto) {
-        long pageNo = dto.getPageNo() == null || dto.getPageNo() < 1 ? 1 : dto.getPageNo();
-        long pageSize = dto.getPageSize() == null || dto.getPageSize() < 1 ? 10 : dto.getPageSize();
+    public IPage<JobInstanceResult> pageWithDefinition(JobInstanceQuery query) {
+        long pageNo = query.getPageNo() == null || query.getPageNo() < 1 ? 1 : query.getPageNo();
+        long pageSize = query.getPageSize() == null || query.getPageSize() < 1 ? 10 : query.getPageSize();
 
-        Page<JobInstanceVO> page = new Page<>(pageNo, pageSize);
-        return jobInstanceMapper.pageWithDefinition(page, dto);
+        Page<JobInstanceResult> page = new Page<>(pageNo, pageSize);
+        return jobInstanceMapper.pageWithDefinition(page, query);
     }
 
     @Override
@@ -64,7 +62,7 @@ public class JobInstanceDaoImpl
     }
 
     @Override
-    public JobInstanceVO selectDetailById(Long id) {
+    public JobInstanceResult selectDetailById(Long id) {
         if (id == null || id <= 0) {
             return null;
         }
@@ -175,7 +173,7 @@ public class JobInstanceDaoImpl
     }
 
     @Override
-    public List<JobInstanceVO> listRunningByJobType(JobMode jobMode) {
+    public List<JobInstance> listRunningByJobType(JobMode jobMode) {
         if (jobMode == null) {
             return java.util.Collections.emptyList();
         }
@@ -200,9 +198,7 @@ public class JobInstanceDaoImpl
             return java.util.Collections.emptyList();
         }
 
-        return records.stream()
-                .map(item -> ConvertUtil.sourceToTarget(item, JobInstanceVO.class))
-                .collect(java.util.stream.Collectors.toList());
+        return records;
     }
 
     @Override

--- a/yak-ops-dao/src/main/java/io/yak/ops/dao/repository/impl/JobTableMetricsDaoImpl.java
+++ b/yak-ops-dao/src/main/java/io/yak/ops/dao/repository/impl/JobTableMetricsDaoImpl.java
@@ -6,7 +6,7 @@ import io.yak.ops.dao.entity.JobTableMetrics;
 import io.yak.ops.dao.mapper.JobTableMetricsMapper;
 import io.yak.ops.dao.repository.BaseDao;
 import io.yak.ops.dao.repository.JobTableMetricsDao;
-import io.yak.ops.web.contract.vo.JobTableMetricsVO;
+import io.yak.ops.dao.model.result.JobTableMetricsResult;
 import org.springframework.stereotype.Repository;
 
 import java.util.Collections;
@@ -24,7 +24,7 @@ public class JobTableMetricsDaoImpl extends BaseDao<JobTableMetrics, JobTableMet
     }
 
     @Override
-    public List<JobTableMetricsVO> selectByInstanceId(Long instanceId) {
+    public List<JobTableMetricsResult> selectByInstanceId(Long instanceId) {
         if (instanceId == null || instanceId <= 0) {
             return java.util.Collections.emptyList();
         }

--- a/yak-ops-dao/src/main/java/io/yak/ops/dao/repository/impl/TimeVariableDaoImpl.java
+++ b/yak-ops-dao/src/main/java/io/yak/ops/dao/repository/impl/TimeVariableDaoImpl.java
@@ -10,7 +10,7 @@ import io.yak.ops.dao.entity.TimeVariable;
 import io.yak.ops.dao.mapper.TimeVariableMapper;
 import io.yak.ops.dao.repository.BaseDao;
 import io.yak.ops.dao.repository.TimeVariableDao;
-import io.yak.ops.web.contract.dto.TimeVariablePageReq;
+import io.yak.ops.dao.model.query.TimeVariablePageQuery;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -43,7 +43,7 @@ public class TimeVariableDaoImpl
     }
 
     @Override
-    public IPage<TimeVariable> queryPage(TimeVariablePageReq req) {
+    public IPage<TimeVariable> queryPage(TimeVariablePageQuery req) {
         LambdaQueryWrapper<TimeVariable> wrapper = new LambdaQueryWrapper<>();
 
         if (StringUtils.isNotBlank(req.getKeyword())) {

--- a/yak-ops-dao/src/main/resources/io/yak/ops/dao/mapper/JobDefinitionMapper.xml
+++ b/yak-ops-dao/src/main/resources/io/yak/ops/dao/mapper/JobDefinitionMapper.xml
@@ -5,7 +5,7 @@
 <mapper namespace="io.yak.ops.dao.mapper.JobDefinitionMapper">
 
     <select id="selectPageWithLatestInstance"
-            resultType="io.yak.ops.spi.bean.vo.BatchJobDefinitionVO">
+            resultType="io.yak.ops.dao.model.result.JobDefinitionResult">
 
         SELECT
         d.id AS id,
@@ -60,29 +60,29 @@
         SELECT *
         FROM t_baize_flow_job_definition
         <where>
-            <if test="dto.id != null">
-                AND id = #{dto.id}
+            <if test="query.id != null">
+                AND id = #{query.id}
             </if>
-            <if test="dto.jobName != null and dto.jobName != ''">
-                AND job_name LIKE CONCAT('%', #{dto.jobName}, '%')
+            <if test="query.jobName != null and query.jobName != ''">
+                AND job_name LIKE CONCAT('%', #{query.jobName}, '%')
             </if>
-            <if test="dto.createTimeStart != null">
-                AND create_time <![CDATA[ >= ]]> #{dto.createTimeStart}
+            <if test="query.createTimeStart != null">
+                AND create_time <![CDATA[ >= ]]> #{query.createTimeStart}
             </if>
-            <if test="dto.createTimeEnd != null">
-                AND create_time <![CDATA[ <= ]]> #{dto.createTimeEnd}
+            <if test="query.createTimeEnd != null">
+                AND create_time <![CDATA[ <= ]]> #{query.createTimeEnd}
             </if>
-            <if test="dto.sourceType != null and dto.sourceType != ''">
-                AND source_type = #{dto.sourceType}
+            <if test="query.sourceType != null and query.sourceType != ''">
+                AND source_type = #{query.sourceType}
             </if>
-            <if test="dto.sinkType != null and dto.sinkType != ''">
-                AND sink_type = #{dto.sinkType}
+            <if test="query.sinkType != null and query.sinkType != ''">
+                AND sink_type = #{query.sinkType}
             </if>
-            <if test="dto.sourceTable != null and dto.sourceTable != ''">
-                AND source_table LIKE CONCAT('%', #{dto.sourceTable}, '%')
+            <if test="query.sourceTable != null and query.sourceTable != ''">
+                AND source_table LIKE CONCAT('%', #{query.sourceTable}, '%')
             </if>
-            <if test="dto.sinkTable != null and dto.sinkTable != ''">
-                AND sink_table LIKE CONCAT('%', #{dto.sinkTable}, '%')
+            <if test="query.sinkTable != null and query.sinkTable != ''">
+                AND sink_table LIKE CONCAT('%', #{query.sinkTable}, '%')
             </if>
         </where>
         ORDER BY create_time DESC
@@ -117,8 +117,8 @@
         ON d.sink_datasource_id = ds_sink.id
 
         <where>
-            <if test="dto.status != null and dto.status != ''">
-                AND i.job_status = #{dto.status}
+            <if test="query.status != null and query.status != ''">
+                AND i.job_status = #{query.status}
             </if>
         </where>
 
@@ -152,40 +152,40 @@
         )
 
         <where>
-            <if test="dto.id != null">
-                AND d.id = #{dto.id}
+            <if test="query.id != null">
+                AND d.id = #{query.id}
             </if>
 
-            <if test="dto.jobName != null and dto.jobName != ''">
-                AND d.job_name LIKE CONCAT('%', #{dto.jobName}, '%')
+            <if test="query.jobName != null and query.jobName != ''">
+                AND d.job_name LIKE CONCAT('%', #{query.jobName}, '%')
             </if>
 
-            <if test="dto.createTimeStart != null">
-                AND d.create_time <![CDATA[ >= ]]> #{dto.createTimeStart}
+            <if test="query.createTimeStart != null">
+                AND d.create_time <![CDATA[ >= ]]> #{query.createTimeStart}
             </if>
 
-            <if test="dto.createTimeEnd != null">
-                AND d.create_time <![CDATA[ <= ]]> #{dto.createTimeEnd}
+            <if test="query.createTimeEnd != null">
+                AND d.create_time <![CDATA[ <= ]]> #{query.createTimeEnd}
             </if>
 
-            <if test="dto.status != null and dto.status != ''">
-                AND i.job_status = #{dto.status}
+            <if test="query.status != null and query.status != ''">
+                AND i.job_status = #{query.status}
             </if>
 
-            <if test="dto.sourceType != null and dto.sourceType != ''">
-                AND d.source_type = #{dto.sourceType}
+            <if test="query.sourceType != null and query.sourceType != ''">
+                AND d.source_type = #{query.sourceType}
             </if>
 
-            <if test="dto.sinkType != null and dto.sinkType != ''">
-                AND d.sink_type = #{dto.sinkType}
+            <if test="query.sinkType != null and query.sinkType != ''">
+                AND d.sink_type = #{query.sinkType}
             </if>
 
-            <if test="dto.sourceTable != null and dto.sourceTable != ''">
-                AND d.source_table LIKE CONCAT('%', #{dto.sourceTable}, '%')
+            <if test="query.sourceTable != null and query.sourceTable != ''">
+                AND d.source_table LIKE CONCAT('%', #{query.sourceTable}, '%')
             </if>
 
-            <if test="dto.sinkTable != null and dto.sinkTable != ''">
-                AND d.sink_table LIKE CONCAT('%', #{dto.sinkTable}, '%')
+            <if test="query.sinkTable != null and query.sinkTable != ''">
+                AND d.sink_table LIKE CONCAT('%', #{query.sinkTable}, '%')
             </if>
         </where>
 

--- a/yak-ops-dao/src/main/resources/io/yak/ops/dao/mapper/JobInstanceMapper.xml
+++ b/yak-ops-dao/src/main/resources/io/yak/ops/dao/mapper/JobInstanceMapper.xml
@@ -4,8 +4,8 @@
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="io.yak.ops.dao.mapper.JobInstanceMapper">
 
-    <resultMap id="JobInstancePageVOResultMap"
-               type="io.yak.ops.spi.bean.vo.JobInstanceVO">
+    <resultMap id="JobInstanceResultMap"
+               type="io.yak.ops.dao.model.result.JobInstanceResult">
         <id property="id" column="id"/>
 
         <result property="jobDefinitionId" column="jobDefinitionId"/>
@@ -112,7 +112,7 @@
     </sql>
 
     <select id="selectDetailById"
-            resultMap="JobInstancePageVOResultMap">
+            resultMap="JobInstanceResultMap">
 
         SELECT
         <include refid="BaseSelectColumns"/>
@@ -153,7 +153,7 @@
     </select>
 
     <select id="pageWithDefinition"
-            resultMap="JobInstancePageVOResultMap">
+            resultMap="JobInstanceResultMap">
 
         SELECT
         <include refid="BaseSelectColumns"/>
@@ -188,43 +188,43 @@
         ON i.job_definition_id = s.job_definition_id
 
         <where>
-            <if test="dto != null">
+            <if test="query != null">
 
-                <if test="dto.id != null">
-                    AND i.id = #{dto.id}
+                <if test="query.id != null">
+                    AND i.id = #{query.id}
                 </if>
 
-                <if test="dto.jobDefinitionId != null">
-                    AND i.job_definition_id = #{dto.jobDefinitionId}
+                <if test="query.jobDefinitionId != null">
+                    AND i.job_definition_id = #{query.jobDefinitionId}
                 </if>
 
-                <if test="dto.jobStatus != null and dto.jobStatus != ''">
-                    AND i.job_status = #{dto.jobStatus}
+                <if test="query.jobStatus != null and query.jobStatus != ''">
+                    AND i.job_status = #{query.jobStatus}
                 </if>
 
-                <if test="dto.runMode != null and dto.runMode != ''">
-                    AND i.run_mode = #{dto.runMode}
+                <if test="query.runMode != null and query.runMode != ''">
+                    AND i.run_mode = #{query.runMode}
                 </if>
 
-                <if test="dto.jobType != null and dto.jobType != ''">
-                    AND d.job_type = #{dto.jobType}
+                <if test="query.jobType != null and query.jobType != ''">
+                    AND d.job_type = #{query.jobType}
                 </if>
 
-                <if test="dto.keyword != null and dto.keyword != ''">
+                <if test="query.keyword != null and query.keyword != ''">
                     AND (
-                    d.job_name LIKE CONCAT('%', #{dto.keyword}, '%')
-                    OR CAST(i.engine_job_id AS CHAR) LIKE CONCAT('%', #{dto.keyword}, '%')
-                    OR i.error_message LIKE CONCAT('%', #{dto.keyword}, '%')
-                    OR i.log_path LIKE CONCAT('%', #{dto.keyword}, '%')
+                    d.job_name LIKE CONCAT('%', #{query.keyword}, '%')
+                    OR CAST(i.engine_job_id AS CHAR) LIKE CONCAT('%', #{query.keyword}, '%')
+                    OR i.error_message LIKE CONCAT('%', #{query.keyword}, '%')
+                    OR i.log_path LIKE CONCAT('%', #{query.keyword}, '%')
                     )
                 </if>
 
-                <if test="dto.queryStartTime != null">
-                    AND i.create_time <![CDATA[ >= ]]> #{dto.queryStartTime}
+                <if test="query.queryStartTime != null">
+                    AND i.create_time <![CDATA[ >= ]]> #{query.queryStartTime}
                 </if>
 
-                <if test="dto.queryEndTime != null">
-                    AND i.create_time <![CDATA[ <= ]]> #{dto.queryEndTime}
+                <if test="query.queryEndTime != null">
+                    AND i.create_time <![CDATA[ <= ]]> #{query.queryEndTime}
                 </if>
 
             </if>

--- a/yak-ops-dao/src/main/resources/io/yak/ops/dao/mapper/JobTableMetricsMapper.xml
+++ b/yak-ops-dao/src/main/resources/io/yak/ops/dao/mapper/JobTableMetricsMapper.xml
@@ -5,8 +5,8 @@
 
 <mapper namespace="io.yak.ops.dao.mapper.JobTableMetricsMapper">
 
-    <resultMap id="JobTableMetricsVOResultMap"
-               type="io.yak.ops.spi.bean.vo.JobTableMetricsVO">
+    <resultMap id="JobTableMetricsResultMap"
+               type="io.yak.ops.dao.model.result.JobTableMetricsResult">
         <id property="id" column="id"/>
         <result property="jobInstanceId" column="jobInstanceId"/>
         <result property="jobDefinitionId" column="jobDefinitionId"/>
@@ -27,7 +27,7 @@
         <result property="updateTime" column="updateTime"/>
     </resultMap>
 
-    <select id="selectByInstanceId" resultMap="JobTableMetricsVOResultMap">
+    <select id="selectByInstanceId" resultMap="JobTableMetricsResultMap">
         SELECT
             id AS id,
             job_instance_id AS jobInstanceId,


### PR DESCRIPTION
### Motivation

- 修复 `yak-ops-dao` 模块因直接引用 `yak-ops-web-contract` DTO/VO 导致的编译失败和架构边界违规问题，并避免 DAO 激活 Spring Boot 自动配置。

### Description

- 新增 DAO 专属持久化模型：`io.yak.ops.dao.model.query.*`（Query）和 `io.yak.ops.dao.model.result.*`（Result），并将 Mapper、Repository、Impl 的方法签名切换为使用这些 Query/Result 类型，同时将 MyBatis XML 的 `dto` 参数名改为 `query` 并更新 `resultMap`/`resultType` 指向 DAO Result 类型。
- 将 `SeaTunnelClient` 实体的非持久化端点字段改为使用 DAO 自己的 `SeaTunnelClientEndpoint` 投影，新增 Application 层的转换方法以在适配层完成 DTO ↔ DAO 转换，避免 DAO 依赖 Web Contract 类型。
- 移除 `DaoConfiguration` 中的 `@EnableAutoConfiguration`，并在 `yak-ops-dao/pom.xml` 中显式声明 `mybatis-spring` 和 `spring-context` 为 DAO 所需的直接依赖（版本由 BOM 管理），同时为四个告警实体补充 `@EqualsAndHashCode(callSuper = true)` 注解以明确 equals/hashCode 语义。
- 在 Application 层插入 `ConvertUtil` 驱动的转换：`Web DTO -> DAO Query` 以及 `DAO Result -> Web VO`（更新了若干 ServiceImpl 以保持边界），并修正所有相关 MyBatis XML 与 Java 签名一致性。

### Testing

- 执行 `git diff --check` 与 `git commit` 均通过且已创建提交 `fix: 解耦 dao 与 web contract 并修复模块编译`；`git grep "io.yak.ops.web.contract" -- yak-ops-dao` 返回无结果，证明 DAO 内引用已清零。
- 所有修改过的 Mapper XML 已通过 XML 解析检查（本地文件解析成功）；`git diff --cached --check` 也通过。
- 试运行 `mvn -pl yak-ops-dao -am clean compile -Dexec.skip=true`、`mvn clean compile -Dexec.skip=true` 和 `mvn clean verify` 时均在依赖解析阶段被阻断，因为环境访问 Maven Central 时 `org.springframework.boot:spring-boot-dependencies:2.7.18` 下载返回 HTTP 403，导致 Maven 无法继续到源码编译阶段（非代码错误）。
- 运行 `python3 tools/architecture_check.py` 后：DAO → Web Contract 的引用已被清理，但仓库中仍有既有的 Application-boundary 违规（这些为原有问题，不在本次变更范围内），因此检查器报告仍有违规项。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a643eee6e208326a40c0adf13c36db8)