### PR TITLE
Fix Java 8 compatibility, incorrect imports, and PaginationResult misuse

### DIFF
--- a/yak-ops-application/src/main/java/io/yak/ops/application/client/model/EndpointTopology.java
+++ b/yak-ops-application/src/main/java/io/yak/ops/application/client/model/EndpointTopology.java
@@ -1,7 +1,6 @@
 package io.yak.ops.application.client.model;
 
 import java.util.List;
-import java.util.Objects;
 
 /** Normalized collection of addresses belonging to a logical endpoint. */
 public final class EndpointTopology {
@@ -12,7 +11,7 @@ public final class EndpointTopology {
     public EndpointTopology(List<String> addresses, String preferredAddress) {
         addresses = addresses == null ? java.util.Collections.emptyList() : java.util.Collections.unmodifiableList(new java.util.ArrayList<>(addresses));
         if (addresses.isEmpty()) throw new IllegalArgumentException("topology must contain an address");
-        preferredAddress = Objects.requireNonNullElse(preferredAddress, addresses.get(0));
+        preferredAddress = preferredAddress == null ? addresses.get(0) : preferredAddress;
         if (!addresses.contains(preferredAddress)) throw new IllegalArgumentException("preferred address is not in topology");
         this.addresses = addresses;
         this.preferredAddress = preferredAddress;

--- a/yak-ops-application/src/main/java/io/yak/ops/application/job/handler/multi/GuideMultiJobAnalyzer.java
+++ b/yak-ops-application/src/main/java/io/yak/ops/application/job/handler/multi/GuideMultiJobAnalyzer.java
@@ -15,6 +15,7 @@ import io.yak.ops.application.model.dto.config.GuideMultiJobContent;
 import io.yak.ops.plugin.spi.enums.DbType;
 import org.springframework.stereotype.Component;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -146,12 +147,12 @@ public class GuideMultiJobAnalyzer {
 
     private List<String> resolveTableList(GuideMultiJobContent content) {
         if (content == null || content.getTableMatch() == null) {
-            return java.util.java.util.Collections.emptyList();
+            return Collections.emptyList();
         }
 
         List<String> tables = content.getTableMatch().getTables();
         if (CollectionUtils.isEmpty(tables)) {
-            return java.util.java.util.Collections.emptyList();
+            return Collections.emptyList();
         }
 
         return tables;

--- a/yak-ops-application/src/main/java/io/yak/ops/application/service/impl/BatchJobInstanceServiceImpl.java
+++ b/yak-ops-application/src/main/java/io/yak/ops/application/service/impl/BatchJobInstanceServiceImpl.java
@@ -110,7 +110,11 @@ public class BatchJobInstanceServiceImpl implements BatchJobInstanceService {
                 records.forEach(this::maskSensitiveFields);
             }
 
-            return PaginationResult.buildSuc(records, pageResult);
+            return PaginationResult.buildSuc(
+                    records,
+                    pageResult.getTotal(),
+                    pageResult.getCurrent(),
+                    pageResult.getSize());
         } catch (ServiceException e) {
             throw e;
         } catch (Exception e) {

--- a/yak-ops-application/src/main/java/io/yak/ops/application/service/impl/ConnectorParamMetaServiceImpl.java
+++ b/yak-ops-application/src/main/java/io/yak/ops/application/service/impl/ConnectorParamMetaServiceImpl.java
@@ -144,7 +144,11 @@ public class ConnectorParamMetaServiceImpl implements ConnectorParamMetaService 
                     .map(this::toVO)
                     .collect(java.util.stream.Collectors.toList());
 
-            return PaginationResult.buildSuc(records, pageResult);
+            return PaginationResult.buildSuc(
+                    records,
+                    pageResult.getTotal(),
+                    pageResult.getCurrent(),
+                    pageResult.getSize());
         } catch (ServiceException e) {
             throw e;
         } catch (Exception e) {

--- a/yak-ops-application/src/main/java/io/yak/ops/application/service/impl/DataSourceServiceImpl.java
+++ b/yak-ops-application/src/main/java/io/yak/ops/application/service/impl/DataSourceServiceImpl.java
@@ -139,7 +139,11 @@ public class DataSourceServiceImpl extends BaseServiceImpl implements DataSource
 
             records.forEach(this::fillDerivedFields);
 
-            return PaginationResult.buildSuc(records, pageResult);
+            return PaginationResult.buildSuc(
+                    records,
+                    pageResult.getTotal(),
+                    pageResult.getCurrent(),
+                    pageResult.getSize());
         } catch (ServiceException e) {
             throw e;
         } catch (Exception e) {

--- a/yak-ops-application/src/main/java/io/yak/ops/application/service/impl/TimeVariableServiceImpl.java
+++ b/yak-ops-application/src/main/java/io/yak/ops/application/service/impl/TimeVariableServiceImpl.java
@@ -160,7 +160,11 @@ public class TimeVariableServiceImpl implements TimeVariableService {
                     .map(this::toVO)
                     .collect(java.util.stream.Collectors.toList());
 
-            return PaginationResult.buildSuc(records, pageResult);
+            return PaginationResult.buildSuc(
+                    records,
+                    pageResult.getTotal(),
+                    pageResult.getCurrent(),
+                    pageResult.getSize());
         } catch (ServiceException e) {
             throw e;
         } catch (Exception e) {

--- a/yak-ops-engine-legacy/src/main/java/io/yak/ops/engine/legacy/internal/vendor/LegacyEngineAdapter.java
+++ b/yak-ops-engine-legacy/src/main/java/io/yak/ops/engine/legacy/internal/vendor/LegacyEngineAdapter.java
@@ -25,7 +25,7 @@ public class LegacyEngineAdapter implements EngineGateway, EngineMetricsGateway 
             if (response == null || response.jobId() == null || response.jobId().trim().isEmpty())
                 throw new EngineSubmissionException("SeaTunnel submit response does not contain an execution id", java.util.Collections.unmodifiableMap(new java.util.LinkedHashMap() {{ put("vendor", "seatunnel"); put("vendor.error_code", "INVALID_RESPONSE"); }}));
             java.time.Instant now = java.time.Instant.now();
-            JobExecution execution = new JobExecution(command.idempotencyKey(), response.jobId(), JobExecutionStatus.SUBMITTED, now, null, null, now, null, java.util.java.util.Collections.emptyMap());
+            JobExecution execution = new JobExecution(command.idempotencyKey(), response.jobId(), JobExecutionStatus.SUBMITTED, now, null, null, now, null, java.util.Collections.emptyMap());
             JobExecution raced = idempotentSubmissions.putIfAbsent(submissionKey, execution);
             return raced == null ? execution : raced;
         } catch (EngineContractException e) { throw e; } catch (Exception e) { throw SeaTunnelErrorMapper.submission(e); }
@@ -35,7 +35,7 @@ public class LegacyEngineAdapter implements EngineGateway, EngineMetricsGateway 
         try { SeaTunnelJobResponse info = client.job(clientId(endpoint), jobId); if (info == null) throw SeaTunnelErrorMapper.unavailable("query", new IllegalStateException("empty response"));
             SeaTunnelExecutionStatusMapper.StatusResolution status = SeaTunnelExecutionStatusMapper.resolve(info.status());
             java.util.Map<String, String> metadata = status.rawStatus() == null
-                    ? java.util.java.util.Collections.emptyMap()
+                    ? java.util.Collections.emptyMap()
                     : java.util.Collections.singletonMap("vendor.raw_status", status.rawStatus());
             java.time.Instant now=java.time.Instant.now(); return new JobExecution(platformId, jobId, status.status(), null, null, null, now, info.errorMessage(), metadata); }
         catch (EngineContractException e) { throw e; } catch (Exception e) { throw SeaTunnelErrorMapper.unavailable("query", e); }

--- a/yak-ops-engine-legacy/src/main/java/io/yak/ops/engine/legacy/internal/vendor/rest/SeaTunnelClientResolver.java
+++ b/yak-ops-engine-legacy/src/main/java/io/yak/ops/engine/legacy/internal/vendor/rest/SeaTunnelClientResolver.java
@@ -22,6 +22,6 @@ public class SeaTunnelClientResolver {
     }
     private EngineConnectionConfig connection(Long clientId) {
         if (clientId == null) throw new IllegalArgumentException("SeaTunnel client id must not be null");
-        return connections.connectionFor(new EngineEndpoint(new ExecutionEngine("legacy"), String.valueOf(clientId), null, null, java.util.java.util.Collections.emptyMap()));
+        return connections.connectionFor(new EngineEndpoint(new ExecutionEngine("legacy"), String.valueOf(clientId), null, null, java.util.Collections.emptyMap()));
     }
 }

--- a/yak-ops-infrastructure/src/main/java/io/yak/ops/infrastructure/metrics/BatchJobSubmitter.java
+++ b/yak-ops-infrastructure/src/main/java/io/yak/ops/infrastructure/metrics/BatchJobSubmitter.java
@@ -79,7 +79,7 @@ public class BatchJobSubmitter implements BatchJobSubmissionUseCase {
 
             String filename = "batch-job-" + instanceId + ".conf";
 
-            EngineEndpoint endpoint = new EngineEndpoint(new ExecutionEngine("legacy"), String.valueOf(clientId), null, null, java.util.java.util.Collections.emptyMap());
+            EngineEndpoint endpoint = new EngineEndpoint(new ExecutionEngine("legacy"), String.valueOf(clientId), null, null, java.util.Collections.emptyMap());
             EngineGateway gateway = engineGatewayRegistry.get(endpoint.engine());
             engineId = gateway.submit(new JobSubmitCommand(endpoint, safeConfig(hoconConfig), java.util.Collections.unmodifiableMap(new java.util.LinkedHashMap() {{ put("fileName", filename); put("jobName", instance.getJobName()); }}), "job-instance-" + instanceId)).externalExecutionId();
             submitted = true;
@@ -131,7 +131,7 @@ public class BatchJobSubmitter implements BatchJobSubmissionUseCase {
         log.info("Stopping batch SeaTunnel job: instanceId={}, clientId={}, engineJobId={}",
                 instanceId, clientId, engineJobId);
 
-        EngineEndpoint endpoint = new EngineEndpoint(new ExecutionEngine("legacy"), String.valueOf(clientId), null, null, java.util.java.util.Collections.emptyMap());
+        EngineEndpoint endpoint = new EngineEndpoint(new ExecutionEngine("legacy"), String.valueOf(clientId), null, null, java.util.Collections.emptyMap());
         engineGatewayRegistry.get(endpoint.engine()).cancel(endpoint, engineJobId);
 
         log.info("Stop batch engine job response: instanceId={}, clientId={}, engineJobId={}",

--- a/yak-ops-infrastructure/src/main/java/io/yak/ops/infrastructure/verify/executor/DefaultSeaTunnelTestJobExecutor.java
+++ b/yak-ops-infrastructure/src/main/java/io/yak/ops/infrastructure/verify/executor/DefaultSeaTunnelTestJobExecutor.java
@@ -19,7 +19,7 @@ public class DefaultSeaTunnelTestJobExecutor implements SeaTunnelTestJobExecutor
  @Override public JobExecutionResult executeAndWait(SeaTunnelClient client, ConnectivityTestJob job, long timeoutMs, long pollIntervalMs) {
   long started=System.currentTimeMillis(); JobExecutionResult result=new JobExecutionResult(); String jobId=null;
   try {
-   EngineEndpoint endpoint=new EngineEndpoint(new ExecutionEngine("legacy"), String.valueOf(client.getId()), client.getBaseUrl(), null, java.util.java.util.Collections.emptyMap()); EngineGateway gateway=gateways.get(endpoint.engine());
+   EngineEndpoint endpoint=new EngineEndpoint(new ExecutionEngine("legacy"), String.valueOf(client.getId()), client.getBaseUrl(), null, java.util.Collections.emptyMap()); EngineGateway gateway=gateways.get(endpoint.engine());
    jobId=gateway.submit(new JobSubmitCommand(endpoint,job.getJobConfig(),java.util.Collections.singletonMap("fileName", job.getJobName()+".conf"),"connectivity-"+started)).externalExecutionId(); result.setJobId(jobId);
    long deadline=started+timeoutMs; JobExecutionStatus status=JobExecutionStatus.UNKNOWN;
    while(System.currentTimeMillis()<deadline) { status=gateway.execution(endpoint,"connectivity-"+started,jobId).status(); if(isTerminal(status)) break; Thread.sleep(pollIntervalMs); }


### PR DESCRIPTION
### Motivation
- Eliminate Java 9-only API usage and other repository search-hit patterns that prevented Java 8 builds.  
- Restore correct `Collections` references introduced by an erroneous bulk-replace (`java.util.java.util`) so code compiles.  
- Ensure application response model (`PaginationResult`) is built using explicit pagination metadata rather than passing MyBatis-Plus `IPage` objects.

### Description
- Replace `Objects.requireNonNullElse` with a Java 8-compatible null-selection expression while preserving the original topology validation in `EndpointTopology` (`EndpointTopology.java`).
- Add correct import `import java.util.Collections;` and fix erroneous `java.util.java.util.Collections.emptyList()` occurrences in `GuideMultiJobAnalyzer` (`GuideMultiJobAnalyzer.java`).
- Replace calls that passed `IPage` directly into `PaginationResult.buildSuc` with explicit parameters `records, pageResult.getTotal(), pageResult.getCurrent(), pageResult.getSize()` in the application pagination handlers (`DataSourceServiceImpl.java`, `BatchJobInstanceServiceImpl.java`, `ConnectorParamMetaServiceImpl.java`, `TimeVariableServiceImpl.java`).
- Correct other duplicated `java.util.java.util` references across legacy and infrastructure modules by using `java.util.Collections` (files updated: `LegacyEngineAdapter.java`, `SeaTunnelClientResolver.java`, `BatchJobSubmitter.java`, `DefaultSeaTunnelTestJobExecutor.java`).
- No Java version upgrades, no new cross-module dependencies, and no changes to `PaginationResult` API were made.

### Testing
- Searched repository for problematic patterns with `rg` to confirm fixes: `rg -n "Objects\.requireNonNullElse|java\.util\.java\.util|PaginationResult\.buildSuc\([^,]+,\s*pageResult\)" --glob '*.java' .` (no matches after changes).
- Verified remaining `PaginationResult.buildSuc` usages under `yak-ops-application` to ensure no `IPage` is passed directly with `rg -n -U "PaginationResult\.buildSuc([\s\S]{0,220}?)" --glob '*.java' yak-ops-application/src/main/java` (checked and updated occurrences report only explicit parameterized calls).
- Ran `git diff --check` and static diff checks (no whitespace/format issues detected).
- Attempted module build with `mvn -pl yak-ops-application -am clean compile -Dexec.skip=true` and full reactor build with `mvn clean compile -Dexec.skip=true`, but both terminated during POM resolution because Maven Central returned HTTP 403 while resolving `org.springframework.boot:spring-boot-dependencies:2.7.18`, preventing final compilation verification in this environment.  
- Therefore repository-level compilation could not be completed here, but all code-pattern fixes and local static checks passed; remaining build failure is due to external dependency resolution (HTTP 403) rather than the code edits.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6454b0d0748326a12f9a1cfe739b2c)