### PR TITLE
Fix Java 8 compilation in infrastructure module

### DIFF
--- a/yak-ops-infrastructure/src/main/java/io/yak/ops/infrastructure/alarm/engine/AlarmConfigParser.java
+++ b/yak-ops-infrastructure/src/main/java/io/yak/ops/infrastructure/alarm/engine/AlarmConfigParser.java
@@ -24,7 +24,8 @@ import java.util.Map;
 @Slf4j
 public final class AlarmConfigParser {
 
-    private static final TypeReference<Map<String, Object>> CONFIG_TYPE = new TypeReference<>() {
+    private static final TypeReference<Map<String, Object>> CONFIG_TYPE =
+            new TypeReference<Map<String, Object>>() {
     };
 
     private AlarmConfigParser() {

--- a/yak-ops-infrastructure/src/main/java/io/yak/ops/infrastructure/scheduler/JobScheduleServiceAdapter.java
+++ b/yak-ops-infrastructure/src/main/java/io/yak/ops/infrastructure/scheduler/JobScheduleServiceAdapter.java
@@ -39,7 +39,7 @@ public class JobScheduleServiceAdapter implements JobScheduleService {
 
     @Override
     @Transactional(rollbackFor = Exception.class)
-    public Long createTaskSchedule(SeaTunnelJobScheduleDTO dto) throws SchedulerException {
+    public Long createTaskSchedule(SeaTunnelJobScheduleDTO dto) {
         log.info("Creating job schedule: {}", dto);
 
         if (dto == null || dto.getJobDefinitionId() == null) {
@@ -70,7 +70,7 @@ public class JobScheduleServiceAdapter implements JobScheduleService {
 
     @Override
     @Transactional(rollbackFor = Exception.class)
-    public boolean updateTaskSchedule(SeaTunnelJobScheduleDTO dto) throws SchedulerException {
+    public boolean updateTaskSchedule(SeaTunnelJobScheduleDTO dto) {
         log.info("Updating task schedule: {}", dto);
 
         if (dto == null || dto.getId() == null) {
@@ -192,7 +192,7 @@ public class JobScheduleServiceAdapter implements JobScheduleService {
     }
 
     @Override
-    public boolean triggerSchedule(Long taskScheduleId) throws SchedulerException {
+    public boolean triggerSchedule(Long taskScheduleId) {
         log.info("Triggering task schedule immediately: {}", taskScheduleId);
 
         JobSchedule taskSchedule = jobScheduleDao.queryById(taskScheduleId);
@@ -201,11 +201,17 @@ public class JobScheduleServiceAdapter implements JobScheduleService {
         }
 
         JobKey jobKey = buildJobKey(taskScheduleId);
-        if (!scheduler.checkExists(jobKey)) {
-            throw new RuntimeException("Schedule has not been started yet");
-        }
+        try {
+            if (!scheduler.checkExists(jobKey)) {
+                throw new RuntimeException("Schedule has not been started yet");
+            }
 
-        scheduler.triggerJob(jobKey);
+            scheduler.triggerJob(jobKey);
+        } catch (SchedulerException e) {
+            log.error("Failed to trigger schedule, scheduleId={}", taskScheduleId, e);
+            throw new IllegalStateException(
+                    "Failed to trigger schedule, scheduleId=" + taskScheduleId, e);
+        }
 
         log.info("Task schedule triggered successfully: {}", taskScheduleId);
         return true;
@@ -213,7 +219,7 @@ public class JobScheduleServiceAdapter implements JobScheduleService {
 
     @Override
     @Transactional(rollbackFor = Exception.class)
-    public boolean updateScheduleTime(Long taskScheduleId, String cronExpression) throws SchedulerException {
+    public boolean updateScheduleTime(Long taskScheduleId, String cronExpression) {
         log.info("Updating schedule time: {}, Cron: {}", taskScheduleId, cronExpression);
 
         if (StringUtils.isBlank(cronExpression)) {


### PR DESCRIPTION
### Motivation

- Fix two Java 8 compilation problems in the infrastructure module: an anonymous `TypeReference` using the diamond operator and implementation methods declaring a Quartz checked exception not present on the interface.
- Preserve layering (application layer must not expose Quartz types) and make minimal changes to restore Java 8 compilation compatibility.

### Description

- `yak-ops-infrastructure/src/main/java/io/yak/ops/infrastructure/alarm/engine/AlarmConfigParser.java`: replaced `new TypeReference<>() {}` with an explicit `new TypeReference<Map<String, Object>>() {}` so the anonymous class compiles on Java 8 and matches the `Map<String, Object>` target type used by Jackson.
- `yak-ops-infrastructure/src/main/java/io/yak/ops/infrastructure/scheduler/JobScheduleServiceAdapter.java`: removed `throws SchedulerException` from the public methods `createTaskSchedule`, `updateTaskSchedule`, `triggerSchedule`, and `updateScheduleTime` so their signatures match `io.yak.ops.application.service.JobScheduleService`; where Quartz `SchedulerException` can be thrown (in `triggerSchedule`) the code now catches `SchedulerException` and rethrows an infrastructure-side runtime exception (`IllegalStateException`) with contextual message; no application-layer interface changes were made.
- No business logic, transaction boundaries, or application-layer APIs were changed; only exception handling and an explicit generic type were adjusted with minimal edits.

### Testing

- Ran `git diff --check` and project diff checks for the modified files (no whitespace/format errors reported). 
- Verified source-level fixes by searching for remaining Java 8 diamond/throws mismatches in the infrastructure scheduler files (no remaining occurrences found). 
- Executed `mvn clean compile -DskipTests -pl :yak-ops-infrastructure -am` and `mvn clean install -DskipTests`, but both builds were blocked during dependency resolution because Maven Central returned HTTP 403 for `org.springframework.boot:spring-boot-dependencies:2.7.18`, preventing a full compile in this environment; this is an external repository access issue and not caused by the code changes.
- Summary: code-level issues identified in the compilation error messages were fixed and static checks passed, but full Maven build could not complete due to external dependency download failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a645ce214dc8326a467c4b69f278a7a)