### PR TITLE
Fix boot runtime domain dependency and startup failure propagation

### DIFF
--- a/yak-ops-boot/pom.xml
+++ b/yak-ops-boot/pom.xml
@@ -11,6 +11,12 @@
         <dependency><groupId>io.swagger.core.v3</groupId><artifactId>swagger-models</artifactId></dependency>
         <dependency><groupId>io.yak.ops</groupId><artifactId>yak-ops-web</artifactId></dependency>
         <dependency><groupId>io.yak.ops</groupId><artifactId>yak-ops-infrastructure</artifactId></dependency>
+        <!--
+          Status, which is exposed by web annotations, implements DomainErrorCode.
+          Keep the domain classes as an explicit runtime requirement of the executable
+          module instead of relying on an IDE to retain a multi-hop transitive edge.
+        -->
+        <dependency><groupId>io.yak.ops</groupId><artifactId>yak-ops-domain</artifactId></dependency>
         <!-- Runtime adapters are assembled here rather than leaking into core modules. -->
         <dependency><groupId>io.yak.ops</groupId><artifactId>yak-ops-engine-all</artifactId></dependency>
         <dependency><groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-web</artifactId></dependency>

--- a/yak-ops-boot/src/main/java/io/yak/ops/boot/YakOpsApplication.java
+++ b/yak-ops-boot/src/main/java/io/yak/ops/boot/YakOpsApplication.java
@@ -2,10 +2,12 @@ package io.yak.ops.boot;
 
 import io.yak.ops.dao.DaoConfiguration;
 import org.apache.seatunnel.plugin.datasource.api.plugin.DataSourceProcessorProvider;
+import org.springframework.boot.ApplicationRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.scheduling.annotation.EnableAsync;
 
@@ -25,12 +27,11 @@ import org.springframework.scheduling.annotation.EnableAsync;
 public class YakOpsApplication {
 
     public static void main(String[] args) {
-        try {
-            SpringApplication sa = new SpringApplication(YakOpsApplication.class);
-            sa.run(args);
-            DataSourceProcessorProvider.initialize();
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
+        SpringApplication.run(YakOpsApplication.class, args);
+    }
+
+    @Bean
+    public ApplicationRunner dataSourceProcessorInitializer() {
+        return args -> DataSourceProcessorProvider.initialize();
     }
 }


### PR DESCRIPTION
### Motivation

- 修复 Spring 在扫描 Controller 注解时因缺失 `DomainErrorCode` 导致的 `ClassNotFoundException`，保证启动时 `Status implements DomainErrorCode` 可被解析。 
- 纠正 `main` 方法吞掉异常的问题，使启动失败返回非零退出码并把数据源处理器初始化移到合理的 Spring 生命周期点。 

### Description

- 在 `yak-ops-boot/pom.xml` 中增加显式运行时依赖：`io.yak.ops:yak-ops-domain`，确保可执行模块在打包与运行时包含 domain 模块。 
- 修改 `yak-ops-boot/src/main/java/io/yak/ops/boot/YakOpsApplication.java`：移除 catch-all 吞异常的启动逻辑并改为 `SpringApplication.run(...)`；新增一个 `ApplicationRunner` bean `dataSourceProcessorInitializer()` 用来在容器启动后调用 `DataSourceProcessorProvider.initialize()`。 
- 变更文件清单：`yak-ops-boot/pom.xml`、`yak-ops-boot/src/main/java/io/yak/ops/boot/YakOpsApplication.java`（见已提交 diff）。 
- 变更理由：保证在 IDE 与 Maven 导入/运行时都能稳定获得 domain 类，且将初始化放到 Spring 生命周期中以便异常正常上抛并由 Spring 处理。 

### Testing

- 运行了 `git diff --check`，结果通过（无空白/格式错误）。
- 对关键 POM 文件使用 `python3` 的 `xml.etree.ElementTree.parse()` 做解析完整性检查（`pom.xml`、`yak-ops-plugin-spi/pom.xml`、`yak-ops-application/pom.xml`、`yak-ops-boot/pom.xml`），均成功解析。 
- 验证 `yak-ops-domain` 源文件存在：`yak-ops-domain/src/main/java/io/yak/ops/domain/exceptions/DomainErrorCode.java`（存在）。
- 尝试执行构建和依赖树检查命令（例如 `mvn clean install -DskipTests -Darchitecture.check.skip=true` 和 `mvn -pl yak-ops-boot -am dependency:tree -Dincludes=io.yak.ops:yak-ops-domain`），但本环境在解析 `org.springframework.boot:spring-boot-dependencies:2.7.18` 时遭遇 Maven Central 返回 `403 Forbidden`，导致构建中止，因此无法在该环境完成完整的 Maven build / `spring-boot:run` / 打包验证；网络问题与仓库访问权限阻断是失败原因而非代码修改本身。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6467ec028883269f74bbf354dad54e)