### PR TITLE
refactor: rename database identifiers to yak_ops

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,7 +17,7 @@ YAK_OPS_PORT=9001
 # =========================
 
 MYSQL_ROOT_PASSWORD=seatunnel_root_password
-MYSQL_DATABASE=baize_flow
+MYSQL_DATABASE=yak_ops
 MYSQL_USER=seatunnel
 MYSQL_PASSWORD=seatunnel_password
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,8 +31,8 @@ ENV YAK_OPS_HOME=/opt/yak-ops \
     YAK_OPS_DATABASE_TYPE=mysql \
     YAK_OPS_DATABASE_HOST=mysql \
     YAK_OPS_DATABASE_PORT=3306 \
-    YAK_OPS_DATABASE_NAME=baize_flow \
-    SPRING_DATASOURCE_URL="jdbc:mysql://mysql:3306/baize_flow?useUnicode=true&characterEncoding=utf8&useSSL=false&serverTimezone=GMT%2B8&allowPublicKeyRetrieval=true" \
+    YAK_OPS_DATABASE_NAME=yak_ops \
+    SPRING_DATASOURCE_URL="jdbc:mysql://mysql:3306/yak_ops?useUnicode=true&characterEncoding=utf8&useSSL=false&serverTimezone=GMT%2B8&allowPublicKeyRetrieval=true" \
     SPRING_DATASOURCE_USERNAME=seatunnel \
     SPRING_DATASOURCE_PASSWORD=seatunnel
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -240,7 +240,7 @@ cp .env.without-mysql.example .env.without-mysql
 ```env
 MYSQL_HOST=host.docker.internal
 MYSQL_PORT=3306
-MYSQL_DATABASE=baize_flow
+MYSQL_DATABASE=yak_ops
 MYSQL_USER=seatunnel
 MYSQL_PASSWORD=change_me
 ```
@@ -257,7 +257,7 @@ MySQL 用户必须允许来自 Docker 宿主机的连接，建议创建独立数
 
 ```sql
 CREATE USER IF NOT EXISTS 'seatunnel'@'%' IDENTIFIED BY 'change_me';
-GRANT ALL PRIVILEGES ON baize_flow.* TO 'seatunnel'@'%';
+GRANT ALL PRIVILEGES ON yak_ops.* TO 'seatunnel'@'%';
 FLUSH PRIVILEGES;
 ```
 

--- a/compose.without-mysql.yaml
+++ b/compose.without-mysql.yaml
@@ -20,9 +20,9 @@ services:
       YAK_OPS_DATABASE_TYPE: mysql
       YAK_OPS_DATABASE_HOST: ${MYSQL_HOST:-host.docker.internal}
       YAK_OPS_DATABASE_PORT: ${MYSQL_PORT:-3306}
-      YAK_OPS_DATABASE_NAME: ${MYSQL_DATABASE:-baize_flow}
+      YAK_OPS_DATABASE_NAME: ${MYSQL_DATABASE:-yak_ops}
 
-      SPRING_DATASOURCE_URL: "jdbc:mysql://${MYSQL_HOST:-host.docker.internal}:${MYSQL_PORT:-3306}/${MYSQL_DATABASE:-baize_flow}?useUnicode=true&characterEncoding=utf8&useSSL=false&serverTimezone=GMT%2B8&allowPublicKeyRetrieval=true"
+      SPRING_DATASOURCE_URL: "jdbc:mysql://${MYSQL_HOST:-host.docker.internal}:${MYSQL_PORT:-3306}/${MYSQL_DATABASE:-yak_ops}?useUnicode=true&characterEncoding=utf8&useSSL=false&serverTimezone=GMT%2B8&allowPublicKeyRetrieval=true"
       SPRING_DATASOURCE_USERNAME: ${MYSQL_USER:?set MYSQL_USER}
       SPRING_DATASOURCE_PASSWORD: ${MYSQL_PASSWORD:?set MYSQL_PASSWORD}
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -6,7 +6,7 @@ services:
 
     environment:
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-change_me}
-      MYSQL_DATABASE: ${MYSQL_DATABASE:-baize_flow}
+      MYSQL_DATABASE: ${MYSQL_DATABASE:-yak_ops}
       MYSQL_USER: ${MYSQL_USER:-seatunnel}
       MYSQL_PASSWORD: ${MYSQL_PASSWORD:-change_me}
       TZ: Asia/Shanghai
@@ -63,9 +63,9 @@ services:
       YAK_OPS_DATABASE_TYPE: mysql
       YAK_OPS_DATABASE_HOST: mysql
       YAK_OPS_DATABASE_PORT: 3306
-      YAK_OPS_DATABASE_NAME: ${MYSQL_DATABASE:-baize_flow}
+      YAK_OPS_DATABASE_NAME: ${MYSQL_DATABASE:-yak_ops}
 
-      SPRING_DATASOURCE_URL: "jdbc:mysql://mysql:3306/${MYSQL_DATABASE:-baize_flow}?useUnicode=true&characterEncoding=utf8&useSSL=false&serverTimezone=GMT%2B8&allowPublicKeyRetrieval=true"
+      SPRING_DATASOURCE_URL: "jdbc:mysql://mysql:3306/${MYSQL_DATABASE:-yak_ops}?useUnicode=true&characterEncoding=utf8&useSSL=false&serverTimezone=GMT%2B8&allowPublicKeyRetrieval=true"
       SPRING_DATASOURCE_USERNAME: ${MYSQL_USER:-seatunnel}
       SPRING_DATASOURCE_PASSWORD: ${MYSQL_PASSWORD:-change_me}
 

--- a/tools/database/mysql/legacy_full_init.sql
+++ b/tools/database/mysql/legacy_full_init.sql
@@ -2,12 +2,12 @@
 -- WARNING: this script drops and recreates all Yak Ops and Quartz tables.
 
 CREATE
-DATABASE IF NOT EXISTS `baize_flow`
+DATABASE IF NOT EXISTS `yak_ops`
     DEFAULT CHARACTER SET utf8mb4
     COLLATE utf8mb4_unicode_ci;
 
 USE
-`baize_flow`;
+`yak_ops`;
 
 SET NAMES utf8mb4;
 SET
@@ -17,8 +17,8 @@ FOREIGN_KEY_CHECKS = 0;
 -- 1. Yak Ops business tables
 -- ============================================================
 
-DROP TABLE IF EXISTS `t_baize_flow_connector_param_meta`;
-CREATE TABLE `t_baize_flow_connector_param_meta`
+DROP TABLE IF EXISTS `t_yak_ops_connector_param_meta`;
+CREATE TABLE `t_yak_ops_connector_param_meta`
 (
     `id`             bigint       NOT NULL AUTO_INCREMENT COMMENT '主键ID',
     `type`           varchar(32)  NOT NULL COMMENT '参数类型，如 connector/time',
@@ -41,8 +41,8 @@ CREATE TABLE `t_baize_flow_connector_param_meta`
     KEY              `idx_param_name` (`param_name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='连接器参数元数据表';
 
-DROP TABLE IF EXISTS `t_baize_flow_client`;
-CREATE TABLE `t_baize_flow_client`
+DROP TABLE IF EXISTS `t_yak_ops_client`;
+CREATE TABLE `t_yak_ops_client`
 (
     `id`                    bigint       NOT NULL AUTO_INCREMENT COMMENT '主键ID',
     `client_name`           varchar(128) NOT NULL COMMENT 'Client名称',
@@ -70,8 +70,8 @@ CREATE TABLE `t_baize_flow_client`
     KEY                     `idx_heartbeat_time` (`heartbeat_time`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='SeaTunnel Client 表';
 
-DROP TABLE IF EXISTS `t_baize_flow_client_node`;
-CREATE TABLE `t_baize_flow_client_node`
+DROP TABLE IF EXISTS `t_yak_ops_client_node`;
+CREATE TABLE `t_yak_ops_client_node`
 (
     `id`                  bigint       NOT NULL COMMENT '主键 ID',
     `client_id`           bigint       NOT NULL COMMENT '客户端 ID',
@@ -95,8 +95,8 @@ CREATE TABLE `t_baize_flow_client_node`
     KEY                   `idx_health_status` (`health_status`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='SeaTunnel Client 节点表';
 
-DROP TABLE IF EXISTS `t_baize_flow_datasource`;
-CREATE TABLE `t_baize_flow_datasource`
+DROP TABLE IF EXISTS `t_yak_ops_datasource`;
+CREATE TABLE `t_yak_ops_datasource`
 (
     `id`                bigint NOT NULL COMMENT '主键',
     `name`              varchar(64)   DEFAULT NULL COMMENT '数据源名称',
@@ -111,8 +111,8 @@ CREATE TABLE `t_baize_flow_datasource`
     PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='数据集成-数据源表';
 
-DROP TABLE IF EXISTS `t_baize_flow_datasource_plugin_config`;
-CREATE TABLE `t_baize_flow_datasource_plugin_config`
+DROP TABLE IF EXISTS `t_yak_ops_datasource_plugin_config`;
+CREATE TABLE `t_yak_ops_datasource_plugin_config`
 (
     `id`            varchar(32) NOT NULL COMMENT '主键',
     `plugin_type`   varchar(50) NOT NULL COMMENT '插件类型，如 mysql、postgresql、oracle 等',
@@ -122,8 +122,8 @@ CREATE TABLE `t_baize_flow_datasource_plugin_config`
     PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='数据源插件动态配置表';
 
-DROP TABLE IF EXISTS `t_baize_flow_cdc_server_id_pool`;
-CREATE TABLE `t_baize_flow_cdc_server_id_pool`
+DROP TABLE IF EXISTS `t_yak_ops_cdc_server_id_pool`;
+CREATE TABLE `t_yak_ops_cdc_server_id_pool`
 (
     `id`            bigint                                                        NOT NULL COMMENT 'primary key',
     `datasource_id` bigint                                                        NOT NULL COMMENT 'datasource id for this MySQL CDC server-id pool',
@@ -138,8 +138,8 @@ CREATE TABLE `t_baize_flow_cdc_server_id_pool`
     KEY             `idx_cdc_server_id_pool_datasource` (`datasource_id`) USING BTREE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='MySQL CDC server-id allocation pool';
 
-DROP TABLE IF EXISTS `t_baize_flow_cdc_server_id_allocation`;
-CREATE TABLE `t_baize_flow_cdc_server_id_allocation`
+DROP TABLE IF EXISTS `t_yak_ops_cdc_server_id_allocation`;
+CREATE TABLE `t_yak_ops_cdc_server_id_allocation`
 (
     `id`                bigint                                                       NOT NULL COMMENT 'primary key',
     `pool_id`           bigint                                                       NOT NULL COMMENT 'server-id pool id',
@@ -158,8 +158,8 @@ CREATE TABLE `t_baize_flow_cdc_server_id_allocation`
     KEY                 `idx_cdc_server_id_job_instance` (`job_instance_id`) USING BTREE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='MySQL CDC server-id allocation records';
 
-DROP TABLE IF EXISTS `t_baize_flow_user`;
-CREATE TABLE `t_baize_flow_user`
+DROP TABLE IF EXISTS `t_yak_ops_user`;
+CREATE TABLE `t_yak_ops_user`
 (
     `id`            int NOT NULL COMMENT '用户ID',
     `user_name`     varchar(64)  DEFAULT NULL COMMENT '用户名',
@@ -173,8 +173,8 @@ CREATE TABLE `t_baize_flow_user`
     PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='用户表';
 
-DROP TABLE IF EXISTS `t_baize_flow_session`;
-CREATE TABLE `t_baize_flow_session`
+DROP TABLE IF EXISTS `t_yak_ops_session`;
+CREATE TABLE `t_yak_ops_session`
 (
     `id`              varchar(64) NOT NULL COMMENT '会话ID',
     `user_id`         int         DEFAULT NULL COMMENT '关联用户ID',
@@ -183,8 +183,8 @@ CREATE TABLE `t_baize_flow_session`
     PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='用户会话表';
 
-DROP TABLE IF EXISTS `t_baize_flow_time_variable`;
-CREATE TABLE `t_baize_flow_time_variable`
+DROP TABLE IF EXISTS `t_yak_ops_time_variable`;
+CREATE TABLE `t_yak_ops_time_variable`
 (
     `id`              bigint       NOT NULL COMMENT '主键ID',
     `param_name`      varchar(128) NOT NULL COMMENT '变量名称，如 biz_date、start_time、end_time',
@@ -203,8 +203,8 @@ CREATE TABLE `t_baize_flow_time_variable`
     UNIQUE KEY `uk_param_name` (`param_name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='SeaTunnel时间变量表';
 
-DROP TABLE IF EXISTS `t_baize_flow_job_definition`;
-CREATE TABLE `t_baize_flow_job_definition`
+DROP TABLE IF EXISTS `t_yak_ops_job_definition`;
+CREATE TABLE `t_yak_ops_job_definition`
 (
     `id`                   bigint       NOT NULL COMMENT '主键ID',
     `job_name`             varchar(255) NOT NULL COMMENT '任务名称',
@@ -231,8 +231,8 @@ CREATE TABLE `t_baize_flow_job_definition`
     KEY                    `idx_sink_datasource_id` (`sink_datasource_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='任务定义主表';
 
-DROP TABLE IF EXISTS `t_baize_flow_job_definition_content`;
-CREATE TABLE `t_baize_flow_job_definition_content`
+DROP TABLE IF EXISTS `t_yak_ops_job_definition_content`;
+CREATE TABLE `t_yak_ops_job_definition_content`
 (
     `id`                     bigint      NOT NULL AUTO_INCREMENT COMMENT '主键',
     `job_definition_id`      bigint      NOT NULL COMMENT '任务定义ID',
@@ -247,8 +247,8 @@ CREATE TABLE `t_baize_flow_job_definition_content`
     KEY                      `idx_job_definition_id` (`job_definition_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='任务定义内容版本表';
 
-DROP TABLE IF EXISTS `t_baize_flow_job_instance`;
-CREATE TABLE `t_baize_flow_job_instance`
+DROP TABLE IF EXISTS `t_yak_ops_job_instance`;
+CREATE TABLE `t_yak_ops_job_instance`
 (
     `id`                bigint      NOT NULL COMMENT '主键ID',
     `job_definition_id` bigint      NOT NULL COMMENT '任务定义ID',
@@ -275,8 +275,8 @@ CREATE TABLE `t_baize_flow_job_instance`
     KEY                 `idx_definition_status` (`job_definition_id`, `job_status`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='任务运行实例表';
 
-DROP TABLE IF EXISTS `t_baize_flow_job_schedule`;
-CREATE TABLE `t_baize_flow_job_schedule`
+DROP TABLE IF EXISTS `t_yak_ops_job_schedule`;
+CREATE TABLE `t_yak_ops_job_schedule`
 (
     `id`                 bigint      NOT NULL COMMENT '主键ID',
     `job_definition_id`  bigint      NOT NULL COMMENT '任务定义ID',
@@ -293,8 +293,8 @@ CREATE TABLE `t_baize_flow_job_schedule`
     KEY                  `idx_next_schedule_time` (`next_schedule_time`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='任务调度表';
 
-DROP TABLE IF EXISTS `t_baize_flow_job_metrics`;
-CREATE TABLE `t_baize_flow_job_metrics`
+DROP TABLE IF EXISTS `t_yak_ops_job_metrics`;
+CREATE TABLE `t_yak_ops_job_metrics`
 (
     `id`                      bigint NOT NULL COMMENT '主键ID',
     `job_instance_id`         bigint NOT NULL COMMENT '任务实例ID',
@@ -322,8 +322,8 @@ CREATE TABLE `t_baize_flow_job_metrics`
     KEY                       `idx_create_time` (`create_time`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='任务运行汇总指标表';
 
-DROP TABLE IF EXISTS `t_baize_flow_job_table_metrics`;
-CREATE TABLE `t_baize_flow_job_table_metrics`
+DROP TABLE IF EXISTS `t_yak_ops_job_table_metrics`;
+CREATE TABLE `t_yak_ops_job_table_metrics`
 (
     `id`                bigint NOT NULL COMMENT '主键ID',
     `job_instance_id`   bigint NOT NULL COMMENT '任务实例ID',
@@ -352,8 +352,8 @@ CREATE TABLE `t_baize_flow_job_table_metrics`
     KEY                 `idx_create_time` (`create_time`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='任务表级运行指标表';
 
-DROP TABLE IF EXISTS `t_baize_flow_streaming_job_definition`;
-CREATE TABLE `t_baize_flow_streaming_job_definition`
+DROP TABLE IF EXISTS `t_yak_ops_streaming_job_definition`;
+CREATE TABLE `t_yak_ops_streaming_job_definition`
 (
     `id`                   bigint NOT NULL COMMENT '主键ID',
     `job_name`             varchar(255)  DEFAULT NULL COMMENT '任务名称',
@@ -380,8 +380,8 @@ CREATE TABLE `t_baize_flow_streaming_job_definition`
     KEY                    `idx_streaming_create_time` (`create_time`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='实时任务定义表';
 
-DROP TABLE IF EXISTS `t_baize_flow_streaming_job_definition_content`;
-CREATE TABLE `t_baize_flow_streaming_job_definition_content`
+DROP TABLE IF EXISTS `t_yak_ops_streaming_job_definition_content`;
+CREATE TABLE `t_yak_ops_streaming_job_definition_content`
 (
     `id`                     bigint NOT NULL COMMENT '主键ID',
     `job_definition_id`      bigint NOT NULL COMMENT '任务定义ID',
@@ -400,8 +400,8 @@ CREATE TABLE `t_baize_flow_streaming_job_definition_content`
     KEY                      `idx_streaming_content_create_time` (`create_time`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='实时任务定义内容表';
 
-DROP TABLE IF EXISTS `t_baize_flow_streaming_job_instance`;
-CREATE TABLE `t_baize_flow_streaming_job_instance`
+DROP TABLE IF EXISTS `t_yak_ops_streaming_job_instance`;
+CREATE TABLE `t_yak_ops_streaming_job_instance`
 (
     `id`                bigint      NOT NULL COMMENT '主键ID',
     `job_definition_id` bigint      NOT NULL COMMENT '实时任务定义ID',
@@ -430,8 +430,8 @@ CREATE TABLE `t_baize_flow_streaming_job_instance`
     KEY                 `idx_streaming_instance_definition_status` (`job_definition_id`, `job_status`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='实时任务运行实例表';
 
-DROP TABLE IF EXISTS `t_baize_flow_streaming_job_metrics_current`;
-CREATE TABLE `t_baize_flow_streaming_job_metrics_current`
+DROP TABLE IF EXISTS `t_yak_ops_streaming_job_metrics_current`;
+CREATE TABLE `t_yak_ops_streaming_job_metrics_current`
 (
     `job_instance_id`         bigint         NOT NULL COMMENT 'Web侧实例ID',
     `job_definition_id`       bigint         NOT NULL COMMENT '任务定义ID',
@@ -462,8 +462,8 @@ CREATE TABLE `t_baize_flow_streaming_job_metrics_current`
     KEY                       `idx_streaming_current_update_time` (`update_time`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='实时任务当前汇总指标表';
 
-DROP TABLE IF EXISTS `t_baize_flow_streaming_job_metrics_snapshot`;
-CREATE TABLE `t_baize_flow_streaming_job_metrics_snapshot`
+DROP TABLE IF EXISTS `t_yak_ops_streaming_job_metrics_snapshot`;
+CREATE TABLE `t_yak_ops_streaming_job_metrics_snapshot`
 (
     `collect_time_ms`         bigint         NOT NULL COMMENT '采集时间戳，单位：毫秒',
     `job_instance_id`         bigint         NOT NULL COMMENT 'Web侧实例ID',
@@ -490,8 +490,8 @@ CREATE TABLE `t_baize_flow_streaming_job_metrics_snapshot`
     KEY                       `idx_streaming_metrics_engine_time` (`engine_job_id`, `collect_time_ms`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='实时任务指标快照表';
 
-DROP TABLE IF EXISTS `t_baize_flow_streaming_job_table_metrics_current`;
-CREATE TABLE `t_baize_flow_streaming_job_table_metrics_current`
+DROP TABLE IF EXISTS `t_yak_ops_streaming_job_table_metrics_current`;
+CREATE TABLE `t_yak_ops_streaming_job_table_metrics_current`
 (
     `job_instance_id`      bigint         NOT NULL COMMENT 'Web侧实例ID',
     `job_definition_id`    bigint         NOT NULL COMMENT '任务定义ID',
@@ -676,7 +676,7 @@ CREATE TABLE `QRTZ_LOCKS`
 -- 3. Initial data
 -- ============================================================
 
-INSERT INTO `t_baize_flow_time_variable`
+INSERT INTO `t_yak_ops_time_variable`
 (`id`, `param_name`, `param_desc`, `variable_source`, `value_type`, `time_format`, `default_value`, `expression`,
  `example_value`, `enabled`, `remark`)
 VALUES (10001, 'now', '当前时间', 'SYSTEM', 'DYNAMIC', 'yyyy-MM-dd HH:mm:ss', NULL, 'now', '2026-05-02 09:30:00', 1,
@@ -690,7 +690,7 @@ VALUES (10001, 'now', '当前时间', 'SYSTEM', 'DYNAMIC', 'yyyy-MM-dd HH:mm:ss'
        (10005, 'end_time', '同步结束时间，默认取调度当天零点', 'SYSTEM', 'DYNAMIC', 'yyyy-MM-dd HH:mm:ss', NULL,
         'schedule_time@day_start', '2026-05-02 00:00:00', 1, '系统内置变量');
 
-INSERT INTO `t_baize_flow_user`
+INSERT INTO `t_yak_ops_user`
 (`id`, `user_name`, `user_password`, `user_type`, `email`, `phone`, `create_time`, `update_time`, `state`)
 VALUES (1, 'admin', '$2a$10$7EqJtq98hPqEX7fNZaFWoOhi4iFP1Zc2l1N9CifJmJ4PrGiHeq.8K', 0, NULL, NULL, NULL, NULL, 1);
 
@@ -703,7 +703,7 @@ FOREIGN_KEY_CHECKS = 1;
 -- 生成内容：Jdbc Source + Jdbc Sink
 -- 注意：参数名以用户提供的 SeaTunnel 配置项为准，例如 fetch_size、split.size。
 
-ALTER TABLE `t_baize_flow_connector_param_meta`
+ALTER TABLE `t_yak_ops_connector_param_meta`
 DROP
 INDEX `uk_connector_param`,
   ADD UNIQUE KEY `uk_connector_param`
@@ -712,7 +712,7 @@ INDEX `uk_connector_param`,
 START TRANSACTION;
 
 -- ==================== Jdbc Source：31 个参数 ====================
-INSERT INTO `t_baize_flow_connector_param_meta`
+INSERT INTO `t_yak_ops_connector_param_meta`
 (`type`, `connector_name`, `connector_type`, `param_name`, `param_desc`,
  `param_type`, `required_flag`, `default_value`, `example_value`, `param_context`,
  `remark`, `deleted`)
@@ -825,7 +825,7 @@ VALUES (`remark`),
     `update_time` = CURRENT_TIMESTAMP;
 
 -- ==================== Jdbc Sink：31 个参数 ====================
-INSERT INTO `t_baize_flow_connector_param_meta`
+INSERT INTO `t_yak_ops_connector_param_meta`
 (`type`, `connector_name`, `connector_type`, `param_name`, `param_desc`,
  `param_type`, `required_flag`, `default_value`, `example_value`, `param_context`,
  `remark`, `deleted`)
@@ -948,7 +948,7 @@ COMMIT;
 
 START TRANSACTION;
 
-INSERT INTO `baize_flow`.`t_baize_flow_connector_param_meta`
+INSERT INTO `yak_ops`.`t_yak_ops_connector_param_meta`
 (`type`, `connector_name`, `connector_type`, `param_name`, `param_desc`,
  `param_type`, `required_flag`, `default_value`, `example_value`, `param_context`,
  `remark`, `deleted`)
@@ -1049,7 +1049,7 @@ COMMIT;
 
 -- 校验 MySQL-CDC Source 参数数量
 SELECT `connector_name`, `connector_type`, COUNT(*) AS `param_count`
-FROM `baize_flow`.`t_baize_flow_connector_param_meta`
+FROM `yak_ops`.`t_yak_ops_connector_param_meta`
 WHERE `type` = 'connector'
   AND `connector_name` = 'MySQL-CDC'
   AND `connector_type` = 'source'

--- a/tools/database/mysql/migrate_baize_flow_to_yak_ops.sql
+++ b/tools/database/mysql/migrate_baize_flow_to_yak_ops.sql
@@ -1,0 +1,116 @@
+-- Manual one-time migration from the legacy baize_flow database and table names.
+--
+-- BACK UP THE ENTIRE baize_flow DATABASE AND TEST RESTORE BEFORE RUNNING THIS FILE.
+-- Stop all application instances and writers before migration. Run as an account with
+-- CREATE, ALTER, DROP, and RENAME privileges. This script targets MySQL 8.0+.
+-- MySQL has no atomic RENAME DATABASE statement, so the supported approach is to
+-- create yak_ops and atomically move each table with one RENAME TABLE statement.
+
+-- Preflight: these queries must return the expected source tables and no target tables.
+SELECT TABLE_NAME, TABLE_TYPE
+FROM information_schema.TABLES
+WHERE TABLE_SCHEMA = 'baize_flow'
+ORDER BY TABLE_NAME;
+SELECT TABLE_NAME, TABLE_TYPE
+FROM information_schema.TABLES
+WHERE TABLE_SCHEMA = 'yak_ops'
+ORDER BY TABLE_NAME;
+
+CREATE DATABASE IF NOT EXISTS `yak_ops`
+  DEFAULT CHARACTER SET utf8mb4
+  DEFAULT COLLATE utf8mb4_unicode_ci;
+
+-- Base tables, including Flyway history. A single RENAME TABLE is atomic: if any
+-- named table is absent or a target exists, none of these renames is applied.
+RENAME TABLE
+  `baize_flow`.`t_baize_flow_alarm_channel` TO `yak_ops`.`t_yak_ops_alarm_channel`,
+  `baize_flow`.`t_baize_flow_alarm_record` TO `yak_ops`.`t_yak_ops_alarm_record`,
+  `baize_flow`.`t_baize_flow_alarm_rule` TO `yak_ops`.`t_yak_ops_alarm_rule`,
+  `baize_flow`.`t_baize_flow_alarm_rule_channel` TO `yak_ops`.`t_yak_ops_alarm_rule_channel`,
+  `baize_flow`.`t_baize_flow_cdc_server_id_allocation` TO `yak_ops`.`t_yak_ops_cdc_server_id_allocation`,
+  `baize_flow`.`t_baize_flow_cdc_server_id_pool` TO `yak_ops`.`t_yak_ops_cdc_server_id_pool`,
+  `baize_flow`.`t_baize_flow_client` TO `yak_ops`.`t_yak_ops_client`,
+  `baize_flow`.`t_baize_flow_client_node` TO `yak_ops`.`t_yak_ops_client_node`,
+  `baize_flow`.`t_baize_flow_connector_param_meta` TO `yak_ops`.`t_yak_ops_connector_param_meta`,
+  `baize_flow`.`t_baize_flow_datasource` TO `yak_ops`.`t_yak_ops_datasource`,
+  `baize_flow`.`t_baize_flow_datasource_plugin_config` TO `yak_ops`.`t_yak_ops_datasource_plugin_config`,
+  `baize_flow`.`t_baize_flow_job_definition` TO `yak_ops`.`t_yak_ops_job_definition`,
+  `baize_flow`.`t_baize_flow_job_definition_content` TO `yak_ops`.`t_yak_ops_job_definition_content`,
+  `baize_flow`.`t_baize_flow_job_instance` TO `yak_ops`.`t_yak_ops_job_instance`,
+  `baize_flow`.`t_baize_flow_job_metrics` TO `yak_ops`.`t_yak_ops_job_metrics`,
+  `baize_flow`.`t_baize_flow_job_schedule` TO `yak_ops`.`t_yak_ops_job_schedule`,
+  `baize_flow`.`t_baize_flow_job_table_metrics` TO `yak_ops`.`t_yak_ops_job_table_metrics`,
+  `baize_flow`.`t_baize_flow_schema_history` TO `yak_ops`.`t_yak_ops_schema_history`,
+  `baize_flow`.`t_baize_flow_session` TO `yak_ops`.`t_yak_ops_session`,
+  `baize_flow`.`t_baize_flow_streaming_job_definition` TO `yak_ops`.`t_yak_ops_streaming_job_definition`,
+  `baize_flow`.`t_baize_flow_streaming_job_definition_content` TO `yak_ops`.`t_yak_ops_streaming_job_definition_content`,
+  `baize_flow`.`t_baize_flow_streaming_job_instance` TO `yak_ops`.`t_yak_ops_streaming_job_instance`,
+  `baize_flow`.`t_baize_flow_streaming_job_metrics_current` TO `yak_ops`.`t_yak_ops_streaming_job_metrics_current`,
+  `baize_flow`.`t_baize_flow_streaming_job_metrics_snapshot` TO `yak_ops`.`t_yak_ops_streaming_job_metrics_snapshot`,
+  `baize_flow`.`t_baize_flow_streaming_job_table_metrics_current` TO `yak_ops`.`t_yak_ops_streaming_job_table_metrics_current`,
+  `baize_flow`.`t_baize_flow_time_variable` TO `yak_ops`.`t_yak_ops_time_variable`,
+  `baize_flow`.`t_baize_flow_user` TO `yak_ops`.`t_yak_ops_user`;
+
+-- Validation: compare counts with the backup and inspect all dependent objects.
+SELECT TABLE_NAME, TABLE_ROWS
+FROM information_schema.TABLES
+WHERE TABLE_SCHEMA = 'yak_ops'
+ORDER BY TABLE_NAME;
+SELECT CONSTRAINT_NAME, TABLE_NAME, REFERENCED_TABLE_NAME
+FROM information_schema.REFERENTIAL_CONSTRAINTS
+WHERE CONSTRAINT_SCHEMA = 'yak_ops';
+SELECT TRIGGER_NAME, EVENT_OBJECT_TABLE
+FROM information_schema.TRIGGERS
+WHERE TRIGGER_SCHEMA = 'yak_ops';
+
+-- RENAME TABLE preserves table indexes, table triggers, and foreign-key relationships.
+-- It does not rewrite SQL text stored in views, procedures, functions, or events.
+-- Export their SHOW CREATE output before migration, then recreate them in yak_ops with
+-- yak_ops/t_yak_ops references. MySQL has no standalone sequence objects; if another
+-- database engine is used, rename/recreate sequences and update their OWNED BY/defaults.
+-- Review old-named constraint/index identifiers and rename them separately if naming
+-- policy requires it; their functionality is retained by the table move.
+-- Existing Flyway migrations were intentionally not renumbered or renamed, but their
+-- contents now use the new table names and therefore have new checksums. After backing
+-- up t_yak_ops_schema_history, run Flyway repair exactly once against yak_ops with the
+-- same release artifact, then run validate before application startup. Never delete the
+-- history rows or rerun versioned initialization migrations on the populated database.
+
+-- After validation and application cutover only:
+-- DROP DATABASE `baize_flow`;
+
+-- ROLLBACK (stop writers first). Run only while all listed target tables still exist.
+-- CREATE DATABASE IF NOT EXISTS `baize_flow` DEFAULT CHARACTER SET utf8mb4;
+-- Explicit rollback rename (remove the comment prefixes only after review):
+-- RENAME TABLE
+--   `yak_ops`.`t_yak_ops_alarm_channel` TO `baize_flow`.`t_baize_flow_alarm_channel`,
+--   `yak_ops`.`t_yak_ops_alarm_record` TO `baize_flow`.`t_baize_flow_alarm_record`,
+--   `yak_ops`.`t_yak_ops_alarm_rule` TO `baize_flow`.`t_baize_flow_alarm_rule`,
+--   `yak_ops`.`t_yak_ops_alarm_rule_channel` TO `baize_flow`.`t_baize_flow_alarm_rule_channel`,
+--   `yak_ops`.`t_yak_ops_cdc_server_id_allocation` TO `baize_flow`.`t_baize_flow_cdc_server_id_allocation`,
+--   `yak_ops`.`t_yak_ops_cdc_server_id_pool` TO `baize_flow`.`t_baize_flow_cdc_server_id_pool`,
+--   `yak_ops`.`t_yak_ops_client` TO `baize_flow`.`t_baize_flow_client`,
+--   `yak_ops`.`t_yak_ops_client_node` TO `baize_flow`.`t_baize_flow_client_node`,
+--   `yak_ops`.`t_yak_ops_connector_param_meta` TO `baize_flow`.`t_baize_flow_connector_param_meta`,
+--   `yak_ops`.`t_yak_ops_datasource` TO `baize_flow`.`t_baize_flow_datasource`,
+--   `yak_ops`.`t_yak_ops_datasource_plugin_config` TO `baize_flow`.`t_baize_flow_datasource_plugin_config`,
+--   `yak_ops`.`t_yak_ops_job_definition` TO `baize_flow`.`t_baize_flow_job_definition`,
+--   `yak_ops`.`t_yak_ops_job_definition_content` TO `baize_flow`.`t_baize_flow_job_definition_content`,
+--   `yak_ops`.`t_yak_ops_job_instance` TO `baize_flow`.`t_baize_flow_job_instance`,
+--   `yak_ops`.`t_yak_ops_job_metrics` TO `baize_flow`.`t_baize_flow_job_metrics`,
+--   `yak_ops`.`t_yak_ops_job_schedule` TO `baize_flow`.`t_baize_flow_job_schedule`,
+--   `yak_ops`.`t_yak_ops_job_table_metrics` TO `baize_flow`.`t_baize_flow_job_table_metrics`,
+--   `yak_ops`.`t_yak_ops_schema_history` TO `baize_flow`.`t_baize_flow_schema_history`,
+--   `yak_ops`.`t_yak_ops_session` TO `baize_flow`.`t_baize_flow_session`,
+--   `yak_ops`.`t_yak_ops_streaming_job_definition` TO `baize_flow`.`t_baize_flow_streaming_job_definition`,
+--   `yak_ops`.`t_yak_ops_streaming_job_definition_content` TO `baize_flow`.`t_baize_flow_streaming_job_definition_content`,
+--   `yak_ops`.`t_yak_ops_streaming_job_instance` TO `baize_flow`.`t_baize_flow_streaming_job_instance`,
+--   `yak_ops`.`t_yak_ops_streaming_job_metrics_current` TO `baize_flow`.`t_baize_flow_streaming_job_metrics_current`,
+--   `yak_ops`.`t_yak_ops_streaming_job_metrics_snapshot` TO `baize_flow`.`t_baize_flow_streaming_job_metrics_snapshot`,
+--   `yak_ops`.`t_yak_ops_streaming_job_table_metrics_current` TO `baize_flow`.`t_baize_flow_streaming_job_table_metrics_current`,
+--   `yak_ops`.`t_yak_ops_time_variable` TO `baize_flow`.`t_baize_flow_time_variable`,
+--   `yak_ops`.`t_yak_ops_user` TO `baize_flow`.`t_baize_flow_user`;
+--
+-- Recreate legacy views/routines/events from the pre-migration export and restore the
+-- original application configuration. Restore the backup if post-cutover writes make
+-- a reverse rename unsafe.

--- a/tools/database/mysql/reset.sql
+++ b/tools/database/mysql/reset.sql
@@ -6,9 +6,9 @@
 -- scripts are the single source of truth for schema and seed data.
 
 DROP
-DATABASE IF EXISTS `baize_flow`;
+DATABASE IF EXISTS `yak_ops`;
 
 CREATE
-DATABASE `baize_flow`
+DATABASE `yak_ops`
     DEFAULT CHARACTER SET utf8mb4
     COLLATE utf8mb4_unicode_ci;

--- a/yak-ops-boot/src/main/resources/application-h2.yml
+++ b/yak-ops-boot/src/main/resources/application-h2.yml
@@ -5,7 +5,7 @@ spring:
 
   datasource:
     driver-class-name: org.h2.Driver
-    url: ${SPRING_DATASOURCE_URL:jdbc:h2:mem:baize_flow;MODE=MySQL;DATABASE_TO_UPPER=false}
+    url: ${SPRING_DATASOURCE_URL:jdbc:h2:mem:yak_ops;MODE=MySQL;DATABASE_TO_UPPER=false}
     username: ${SPRING_DATASOURCE_USERNAME:sa}
     password: ${SPRING_DATASOURCE_PASSWORD:}
 

--- a/yak-ops-boot/src/main/resources/application-mysql.yml
+++ b/yak-ops-boot/src/main/resources/application-mysql.yml
@@ -5,7 +5,7 @@ spring:
 
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://127.0.0.1:3306/baize_flow?useUnicode=true&characterEncoding=utf8&useSSL=false&serverTimezone=GMT%2B8&allowPublicKeyRetrieval=true
+    url: jdbc:mysql://127.0.0.1:3306/yak_ops?useUnicode=true&characterEncoding=utf8&useSSL=false&serverTimezone=GMT%2B8&allowPublicKeyRetrieval=true
     username: ${SPRING_DATASOURCE_USERNAME:root}
     password: ${SPRING_DATASOURCE_PASSWORD:123456}
 

--- a/yak-ops-boot/src/main/resources/application-postgresql.yml
+++ b/yak-ops-boot/src/main/resources/application-postgresql.yml
@@ -5,7 +5,7 @@ spring:
 
   datasource:
     driver-class-name: org.postgresql.Driver
-    url: "${SPRING_DATASOURCE_URL:jdbc:postgresql://${YAK_OPS_DATABASE_HOST:127.0.0.1}:${YAK_OPS_DATABASE_PORT:5432}/${YAK_OPS_DATABASE_NAME:baize_flow}}"
+    url: "${SPRING_DATASOURCE_URL:jdbc:postgresql://${YAK_OPS_DATABASE_HOST:127.0.0.1}:${YAK_OPS_DATABASE_PORT:5432}/${YAK_OPS_DATABASE_NAME:yak_ops}}"
     username: ${SPRING_DATASOURCE_USERNAME:seatunnel}
     password: ${SPRING_DATASOURCE_PASSWORD:change_me}
 

--- a/yak-ops-boot/src/main/resources/application.yml
+++ b/yak-ops-boot/src/main/resources/application.yml
@@ -34,7 +34,7 @@ spring:
   flyway:
     enabled: ${SPRING_FLYWAY_ENABLED:true}
     locations: classpath:db/migration/{vendor}
-    table: t_baize_flow_schema_history
+    table: t_yak_ops_schema_history
     validate-on-migrate: true
     out-of-order: false
     clean-disabled: true

--- a/yak-ops-dao/src/main/java/io/yak/ops/dao/entity/AlarmChannelEntity.java
+++ b/yak-ops-dao/src/main/java/io/yak/ops/dao/entity/AlarmChannelEntity.java
@@ -19,7 +19,7 @@ import lombok.EqualsAndHashCode;
 @AllArgsConstructor
 @NoArgsConstructor
 @ToString
-@TableName("t_baize_flow_alarm_channel")
+@TableName("t_yak_ops_alarm_channel")
 public class AlarmChannelEntity extends BaseEntity {
 
     private String name;

--- a/yak-ops-dao/src/main/java/io/yak/ops/dao/entity/AlarmRecordEntity.java
+++ b/yak-ops-dao/src/main/java/io/yak/ops/dao/entity/AlarmRecordEntity.java
@@ -19,7 +19,7 @@ import java.util.Date;
 @AllArgsConstructor
 @NoArgsConstructor
 @ToString
-@TableName("t_baize_flow_alarm_record")
+@TableName("t_yak_ops_alarm_record")
 public class AlarmRecordEntity extends BaseEntity {
 
     private Long ruleId;

--- a/yak-ops-dao/src/main/java/io/yak/ops/dao/entity/AlarmRuleChannelEntity.java
+++ b/yak-ops-dao/src/main/java/io/yak/ops/dao/entity/AlarmRuleChannelEntity.java
@@ -17,7 +17,7 @@ import lombok.EqualsAndHashCode;
 @AllArgsConstructor
 @NoArgsConstructor
 @ToString
-@TableName("t_baize_flow_alarm_rule_channel")
+@TableName("t_yak_ops_alarm_rule_channel")
 public class AlarmRuleChannelEntity extends BaseEntity {
 
     private Long ruleId;

--- a/yak-ops-dao/src/main/java/io/yak/ops/dao/entity/AlarmRuleEntity.java
+++ b/yak-ops-dao/src/main/java/io/yak/ops/dao/entity/AlarmRuleEntity.java
@@ -18,7 +18,7 @@ import lombok.EqualsAndHashCode;
 @AllArgsConstructor
 @NoArgsConstructor
 @ToString
-@TableName("t_baize_flow_alarm_rule")
+@TableName("t_yak_ops_alarm_rule")
 public class AlarmRuleEntity extends BaseEntity {
 
     private String name;

--- a/yak-ops-dao/src/main/java/io/yak/ops/dao/entity/BatchJobDefinition.java
+++ b/yak-ops-dao/src/main/java/io/yak/ops/dao/entity/BatchJobDefinition.java
@@ -14,7 +14,7 @@ import java.util.Date;
 @AllArgsConstructor
 @NoArgsConstructor
 @ToString
-@TableName("t_baize_flow_job_definition")
+@TableName("t_yak_ops_job_definition")
 public class BatchJobDefinition {
 
     @TableId(type = IdType.INPUT)

--- a/yak-ops-dao/src/main/java/io/yak/ops/dao/entity/CdcServerIdAllocation.java
+++ b/yak-ops-dao/src/main/java/io/yak/ops/dao/entity/CdcServerIdAllocation.java
@@ -8,7 +8,7 @@ import java.util.Date;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
-@TableName("t_baize_flow_cdc_server_id_allocation")
+@TableName("t_yak_ops_cdc_server_id_allocation")
 public class CdcServerIdAllocation extends BaseEntity {
 
     private Long poolId;

--- a/yak-ops-dao/src/main/java/io/yak/ops/dao/entity/CdcServerIdPool.java
+++ b/yak-ops-dao/src/main/java/io/yak/ops/dao/entity/CdcServerIdPool.java
@@ -6,7 +6,7 @@ import lombok.EqualsAndHashCode;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
-@TableName("t_baize_flow_cdc_server_id_pool")
+@TableName("t_yak_ops_cdc_server_id_pool")
 public class CdcServerIdPool extends BaseEntity {
 
     private Long datasourceId;

--- a/yak-ops-dao/src/main/java/io/yak/ops/dao/entity/ConnectorParamMetaEntity.java
+++ b/yak-ops-dao/src/main/java/io/yak/ops/dao/entity/ConnectorParamMetaEntity.java
@@ -9,7 +9,7 @@ import java.time.LocalDateTime;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
-@TableName("t_baize_flow_connector_param_meta")
+@TableName("t_yak_ops_connector_param_meta")
 public class ConnectorParamMetaEntity extends BaseEntity implements Serializable {
 
     private static final long serialVersionUID = 1L;

--- a/yak-ops-dao/src/main/java/io/yak/ops/dao/entity/DataSource.java
+++ b/yak-ops-dao/src/main/java/io/yak/ops/dao/entity/DataSource.java
@@ -10,7 +10,7 @@ import io.yak.ops.plugin.spi.enums.DbType;
 
 
 @Data
-@TableName("t_baize_flow_datasource")
+@TableName("t_yak_ops_datasource")
 @EqualsAndHashCode(callSuper = true)
 public class DataSource extends BaseEntity {
 

--- a/yak-ops-dao/src/main/java/io/yak/ops/dao/entity/DataSourcePluginConfig.java
+++ b/yak-ops-dao/src/main/java/io/yak/ops/dao/entity/DataSourcePluginConfig.java
@@ -7,7 +7,7 @@ import lombok.EqualsAndHashCode;
 import io.yak.ops.plugin.spi.enums.DbType;
 
 @Data
-@TableName("t_baize_flow_datasource_plugin_config")
+@TableName("t_yak_ops_datasource_plugin_config")
 @EqualsAndHashCode(callSuper = true)
 public class DataSourcePluginConfig extends BaseEntity {
 

--- a/yak-ops-dao/src/main/java/io/yak/ops/dao/entity/JobDefinitionContentEntity.java
+++ b/yak-ops-dao/src/main/java/io/yak/ops/dao/entity/JobDefinitionContentEntity.java
@@ -13,7 +13,7 @@ import java.util.Date;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@TableName("t_baize_flow_job_definition_content")
+@TableName("t_yak_ops_job_definition_content")
 public class JobDefinitionContentEntity {
 
     private Long id;

--- a/yak-ops-dao/src/main/java/io/yak/ops/dao/entity/JobDefinitionEntity.java
+++ b/yak-ops-dao/src/main/java/io/yak/ops/dao/entity/JobDefinitionEntity.java
@@ -11,7 +11,7 @@ import io.yak.ops.common.enums.ReleaseState;
 @NoArgsConstructor
 @AllArgsConstructor
 @EqualsAndHashCode(callSuper = true)
-@TableName("t_baize_flow_job_definition")
+@TableName("t_yak_ops_job_definition")
 public class JobDefinitionEntity extends BaseEntity {
 
     private String jobName;

--- a/yak-ops-dao/src/main/java/io/yak/ops/dao/entity/JobInstance.java
+++ b/yak-ops-dao/src/main/java/io/yak/ops/dao/entity/JobInstance.java
@@ -15,7 +15,7 @@ import java.util.Date;
 @AllArgsConstructor
 @NoArgsConstructor
 @ToString
-@TableName("t_baize_flow_job_instance")
+@TableName("t_yak_ops_job_instance")
 public class JobInstance {
 
     @TableId(type = IdType.INPUT)

--- a/yak-ops-dao/src/main/java/io/yak/ops/dao/entity/JobMetrics.java
+++ b/yak-ops-dao/src/main/java/io/yak/ops/dao/entity/JobMetrics.java
@@ -10,7 +10,7 @@ import java.util.Date;
  * SeaTunnel job / pipeline level metrics.
  */
 @Data
-@TableName("t_baize_flow_job_metrics")
+@TableName("t_yak_ops_job_metrics")
 public class JobMetrics {
 
     private Long id;

--- a/yak-ops-dao/src/main/java/io/yak/ops/dao/entity/JobSchedule.java
+++ b/yak-ops-dao/src/main/java/io/yak/ops/dao/entity/JobSchedule.java
@@ -11,7 +11,7 @@ import java.util.Date;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
-@TableName("t_baize_flow_job_schedule")
+@TableName("t_yak_ops_job_schedule")
 public class JobSchedule extends BaseEntity {
 
     /**

--- a/yak-ops-dao/src/main/java/io/yak/ops/dao/entity/JobTableMetrics.java
+++ b/yak-ops-dao/src/main/java/io/yak/ops/dao/entity/JobTableMetrics.java
@@ -12,7 +12,7 @@ import java.util.Date;
  * SeaTunnel table level metrics.
  */
 @Data
-@TableName("t_baize_flow_job_table_metrics")
+@TableName("t_yak_ops_job_table_metrics")
 public class JobTableMetrics {
 
     @TableId(value = "id", type = IdType.INPUT)

--- a/yak-ops-dao/src/main/java/io/yak/ops/dao/entity/SeaTunnelClient.java
+++ b/yak-ops-dao/src/main/java/io/yak/ops/dao/entity/SeaTunnelClient.java
@@ -13,7 +13,7 @@ import java.util.List;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
-@TableName("t_baize_flow_client")
+@TableName("t_yak_ops_client")
 public class SeaTunnelClient {
 
     private Long id;

--- a/yak-ops-dao/src/main/java/io/yak/ops/dao/entity/SeaTunnelClientNode.java
+++ b/yak-ops-dao/src/main/java/io/yak/ops/dao/entity/SeaTunnelClientNode.java
@@ -12,7 +12,7 @@ import java.util.Date;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
-@TableName("t_baize_flow_client_node")
+@TableName("t_yak_ops_client_node")
 public class SeaTunnelClientNode {
 
     @TableId(type = IdType.INPUT)

--- a/yak-ops-dao/src/main/java/io/yak/ops/dao/entity/Session.java
+++ b/yak-ops-dao/src/main/java/io/yak/ops/dao/entity/Session.java
@@ -9,7 +9,7 @@ import java.util.Date;
 /**
  * session
  */
-@TableName("t_baize_flow_session")
+@TableName("t_yak_ops_session")
 public class Session {
 
     /**

--- a/yak-ops-dao/src/main/java/io/yak/ops/dao/entity/TimeVariable.java
+++ b/yak-ops-dao/src/main/java/io/yak/ops/dao/entity/TimeVariable.java
@@ -10,7 +10,7 @@ import java.time.LocalDateTime;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
-@TableName("t_baize_flow_time_variable")
+@TableName("t_yak_ops_time_variable")
 public class TimeVariable extends BaseEntity{
 
     @TableId(type = IdType.ASSIGN_ID)

--- a/yak-ops-dao/src/main/java/io/yak/ops/dao/entity/User.java
+++ b/yak-ops-dao/src/main/java/io/yak/ops/dao/entity/User.java
@@ -9,7 +9,7 @@ import io.yak.ops.common.enums.UserType;
 import java.util.Date;
 
 @Data
-@TableName("t_baize_flow_user")
+@TableName("t_yak_ops_user")
 public class User {
 
     @TableId(value = "id", type = IdType.AUTO)

--- a/yak-ops-dao/src/main/java/io/yak/ops/dao/mapper/CdcServerIdAllocationMapper.java
+++ b/yak-ops-dao/src/main/java/io/yak/ops/dao/mapper/CdcServerIdAllocationMapper.java
@@ -10,12 +10,12 @@ import java.util.List;
 
 public interface CdcServerIdAllocationMapper extends BaseMapper<CdcServerIdAllocation> {
 
-    @Update("UPDATE t_baize_flow_cdc_server_id_allocation SET active = NULL, released_time = NOW(), update_time = NOW() WHERE job_definition_id = #{jobDefinitionId} AND active = 1")
+    @Update("UPDATE t_yak_ops_cdc_server_id_allocation SET active = NULL, released_time = NOW(), update_time = NOW() WHERE job_definition_id = #{jobDefinitionId} AND active = 1")
     int releaseActiveByJobDefinitionId(Long jobDefinitionId);
 
     @Select({
             "<script>",
-            "SELECT server_id FROM t_baize_flow_cdc_server_id_allocation",
+            "SELECT server_id FROM t_yak_ops_cdc_server_id_allocation",
             "WHERE pool_id = #{poolId} AND active = 1",
             "<if test='serverIds != null and serverIds.size() > 0'>",
             "AND server_id IN",
@@ -27,6 +27,6 @@ public interface CdcServerIdAllocationMapper extends BaseMapper<CdcServerIdAlloc
     List<Long> selectActiveServerIdsForUpdate(@Param("poolId") Long poolId,
                                               @Param("serverIds") List<Long> serverIds);
 
-    @Select("SELECT server_id FROM t_baize_flow_cdc_server_id_allocation WHERE pool_id = #{poolId} AND active = 1 FOR UPDATE")
+    @Select("SELECT server_id FROM t_yak_ops_cdc_server_id_allocation WHERE pool_id = #{poolId} AND active = 1 FOR UPDATE")
     List<Long> selectActiveServerIdsByPoolForUpdate(Long poolId);
 }

--- a/yak-ops-dao/src/main/java/io/yak/ops/dao/mapper/CdcServerIdPoolMapper.java
+++ b/yak-ops-dao/src/main/java/io/yak/ops/dao/mapper/CdcServerIdPoolMapper.java
@@ -6,6 +6,6 @@ import io.yak.ops.dao.entity.CdcServerIdPool;
 
 public interface CdcServerIdPoolMapper extends BaseMapper<CdcServerIdPool> {
 
-    @Select("SELECT * FROM t_baize_flow_cdc_server_id_pool WHERE datasource_id = #{datasourceId} AND status = 1 LIMIT 1 FOR UPDATE")
+    @Select("SELECT * FROM t_yak_ops_cdc_server_id_pool WHERE datasource_id = #{datasourceId} AND status = 1 LIMIT 1 FOR UPDATE")
     CdcServerIdPool selectEnabledByDatasourceIdForUpdate(Long datasourceId);
 }

--- a/yak-ops-dao/src/main/resources/io/yak/ops/dao/mapper/JobDefinitionMapper.xml
+++ b/yak-ops-dao/src/main/resources/io/yak/ops/dao/mapper/JobDefinitionMapper.xml
@@ -58,7 +58,7 @@
         FROM
         (
         SELECT *
-        FROM t_baize_flow_job_definition
+        FROM t_yak_ops_job_definition
         <where>
             <if test="query.id != null">
                 AND id = #{query.id}
@@ -88,13 +88,13 @@
         ORDER BY create_time DESC
         LIMIT #{offset}, #{pageSize}
         ) d
-        LEFT JOIN t_baize_flow_job_instance i
+        LEFT JOIN t_yak_ops_job_instance i
         ON i.id = (
         SELECT t1.id
-        FROM t_baize_flow_job_instance t1
+        FROM t_yak_ops_job_instance t1
         INNER JOIN (
         SELECT job_definition_id, MAX(start_time) AS max_start_time
-        FROM t_baize_flow_job_instance
+        FROM t_yak_ops_job_instance
         GROUP BY job_definition_id
         ) t2
         ON t1.job_definition_id = t2.job_definition_id
@@ -104,16 +104,16 @@
         LIMIT 1
         )
 
-        LEFT JOIN t_baize_flow_job_metrics m
+        LEFT JOIN t_yak_ops_job_metrics m
         ON i.id = m.job_instance_id
 
-        LEFT JOIN t_baize_flow_job_schedule s
+        LEFT JOIN t_yak_ops_job_schedule s
         ON d.id = s.job_definition_id
 
-        LEFT JOIN t_baize_flow_datasource ds_source
+        LEFT JOIN t_yak_ops_datasource ds_source
         ON d.source_datasource_id = ds_source.id
 
-        LEFT JOIN t_baize_flow_datasource ds_sink
+        LEFT JOIN t_yak_ops_datasource ds_sink
         ON d.sink_datasource_id = ds_sink.id
 
         <where>
@@ -133,15 +133,15 @@
     <select id="selectDefinitionCount" resultType="java.lang.Long">
 
         SELECT COUNT(1)
-        FROM t_baize_flow_job_definition d
+        FROM t_yak_ops_job_definition d
 
-        LEFT JOIN t_baize_flow_job_instance i
+        LEFT JOIN t_yak_ops_job_instance i
         ON i.id = (
         SELECT t1.id
-        FROM t_baize_flow_job_instance t1
+        FROM t_yak_ops_job_instance t1
         INNER JOIN (
         SELECT job_definition_id, MAX(start_time) AS max_start_time
-        FROM t_baize_flow_job_instance
+        FROM t_yak_ops_job_instance
         GROUP BY job_definition_id
         ) t2
         ON t1.job_definition_id = t2.job_definition_id

--- a/yak-ops-dao/src/main/resources/io/yak/ops/dao/mapper/JobInstanceMapper.xml
+++ b/yak-ops-dao/src/main/resources/io/yak/ops/dao/mapper/JobInstanceMapper.xml
@@ -117,9 +117,9 @@
         SELECT
         <include refid="BaseSelectColumns"/>
 
-        FROM t_baize_flow_job_instance i
+        FROM t_yak_ops_job_instance i
 
-        LEFT JOIN t_baize_flow_job_definition d
+        LEFT JOIN t_yak_ops_job_definition d
         ON i.job_definition_id = d.id
 
         LEFT JOIN (
@@ -138,12 +138,12 @@
         AVG(loss_rate) AS loss_rate,
         AVG(avg_row_size) AS avg_row_size,
         MAX(record_delay) AS record_delay
-        FROM t_baize_flow_job_metrics
+        FROM t_yak_ops_job_metrics
         GROUP BY job_instance_id
         ) m
         ON i.id = m.job_instance_id
 
-        LEFT JOIN t_baize_flow_job_schedule s
+        LEFT JOIN t_yak_ops_job_schedule s
         ON i.job_definition_id = s.job_definition_id
 
         WHERE i.id = #{id}
@@ -158,9 +158,9 @@
         SELECT
         <include refid="BaseSelectColumns"/>
 
-        FROM t_baize_flow_job_instance i
+        FROM t_yak_ops_job_instance i
 
-        LEFT JOIN t_baize_flow_job_definition d
+        LEFT JOIN t_yak_ops_job_definition d
         ON i.job_definition_id = d.id
 
         LEFT JOIN (
@@ -179,12 +179,12 @@
         AVG(loss_rate) AS loss_rate,
         AVG(avg_row_size) AS avg_row_size,
         MAX(record_delay) AS record_delay
-        FROM t_baize_flow_job_metrics
+        FROM t_yak_ops_job_metrics
         GROUP BY job_instance_id
         ) m
         ON i.id = m.job_instance_id
 
-        LEFT JOIN t_baize_flow_job_schedule s
+        LEFT JOIN t_yak_ops_job_schedule s
         ON i.job_definition_id = s.job_definition_id
 
         <where>

--- a/yak-ops-dao/src/main/resources/io/yak/ops/dao/mapper/JobMetricsMapper.xml
+++ b/yak-ops-dao/src/main/resources/io/yak/ops/dao/mapper/JobMetricsMapper.xml
@@ -19,7 +19,7 @@
                  SELECT job_instance_id,
                         SUM(write_row_count) AS inc_records,
                         SUM(write_bytes) AS inc_bytes
-                 FROM t_baize_flow_job_metrics
+                 FROM t_yak_ops_job_metrics
                  WHERE update_time &gt;= #{startTime}
                    AND update_time &lt;= #{endTime}
                  GROUP BY job_instance_id
@@ -36,7 +36,7 @@
         AS bucket,
         job_instance_id,
         SUM(read_row_count) AS inc_records
-        FROM t_baize_flow_job_metrics
+        FROM t_yak_ops_job_metrics
         WHERE update_time &gt;= #{startTime}
         AND update_time &lt;= #{endTime}
         GROUP BY bucket, job_instance_id
@@ -55,7 +55,7 @@
         AS bucket,
         job_instance_id,
         SUM(read_bytes) AS inc_bytes
-        FROM t_baize_flow_job_metrics
+        FROM t_yak_ops_job_metrics
         WHERE update_time &gt;= #{startTime}
         AND update_time &lt;= #{endTime}
         GROUP BY bucket, job_instance_id
@@ -69,7 +69,7 @@
         <include refid="BucketExpr"/>
         AS date,
         CAST(AVG(write_qps) AS SIGNED) AS value
-        FROM t_baize_flow_job_metrics
+        FROM t_yak_ops_job_metrics
         WHERE update_time &gt;= #{startTime}
         AND update_time &lt;= #{endTime}
         GROUP BY date
@@ -81,7 +81,7 @@
         <include refid="BucketExpr"/>
         AS date,
         CAST(AVG(write_bps) AS SIGNED) AS value
-        FROM t_baize_flow_job_metrics
+        FROM t_yak_ops_job_metrics
         WHERE update_time &gt;= #{startTime}
         AND update_time &lt;= #{endTime}
         GROUP BY date

--- a/yak-ops-dao/src/main/resources/io/yak/ops/dao/mapper/JobTableMetricsMapper.xml
+++ b/yak-ops-dao/src/main/resources/io/yak/ops/dao/mapper/JobTableMetricsMapper.xml
@@ -47,7 +47,7 @@
             error_msg AS errorMsg,
             create_time AS createTime,
             update_time AS updateTime
-        FROM t_baize_flow_job_table_metrics
+        FROM t_yak_ops_job_table_metrics
         WHERE job_instance_id = #{instanceId}
         ORDER BY
             pipeline_id ASC,
@@ -56,7 +56,7 @@
     </select>
 
     <delete id="deleteByDefinitionId">
-        DELETE FROM t_baize_flow_job_table_metrics
+        DELETE FROM t_yak_ops_job_table_metrics
         WHERE job_definition_id = #{definitionId}
     </delete>
 

--- a/yak-ops-engine-legacy/src/main/resources/db/legacy-seed/mysql/V1_0_1__seatunnel_jdbc_rendering_metadata.sql
+++ b/yak-ops-engine-legacy/src/main/resources/db/legacy-seed/mysql/V1_0_1__seatunnel_jdbc_rendering_metadata.sql
@@ -2,7 +2,7 @@
 -- Generated content: JDBC Source + JDBC Sink
 -- Note: Parameter names follow the SeaTunnel configuration options provided by the user, such as fetch_size and split.size.
 
-ALTER TABLE `t_baize_flow_connector_param_meta`
+ALTER TABLE `t_yak_ops_connector_param_meta`
 DROP INDEX `uk_connector_param`,
   ADD UNIQUE KEY `uk_connector_param`
   (`type`, `connector_name`, `connector_type`, `param_name`, `deleted`);
@@ -10,7 +10,7 @@ DROP INDEX `uk_connector_param`,
 START TRANSACTION;
 
 -- ==================== Jdbc Source：31 个参数 ====================
-INSERT INTO `t_baize_flow_connector_param_meta`
+INSERT INTO `t_yak_ops_connector_param_meta`
 (`type`, `connector_name`, `connector_type`, `param_name`, `param_desc`,
  `param_type`, `required_flag`, `default_value`, `example_value`, `param_context`,
  `remark`, `deleted`)
@@ -51,7 +51,7 @@ ON DUPLICATE KEY UPDATE
                          `update_time` = CURRENT_TIMESTAMP;
 
 -- ==================== Jdbc Sink：31 个参数 ====================
-INSERT INTO `t_baize_flow_connector_param_meta`
+INSERT INTO `t_yak_ops_connector_param_meta`
 (`type`, `connector_name`, `connector_type`, `param_name`, `param_desc`,
  `param_type`, `required_flag`, `default_value`, `example_value`, `param_context`,
  `remark`, `deleted`)

--- a/yak-ops-engine-legacy/src/main/resources/db/legacy-seed/mysql/V1_0_2__seatunnel_mysql_cdc_rendering_metadata.sql
+++ b/yak-ops-engine-legacy/src/main/resources/db/legacy-seed/mysql/V1_0_2__seatunnel_mysql_cdc_rendering_metadata.sql
@@ -8,7 +8,7 @@
 
 START TRANSACTION;
 
-INSERT INTO `t_baize_flow_connector_param_meta`
+INSERT INTO `t_yak_ops_connector_param_meta`
 (`type`, `connector_name`, `connector_type`, `param_name`, `param_desc`,
  `param_type`, `required_flag`, `default_value`, `example_value`, `param_context`,
  `remark`, `deleted`)

--- a/yak-ops-persistence-plugins/yak-ops-persistence-vendor-h2/src/main/resources/db/migration/h2/V1_0_4__job_execution.sql
+++ b/yak-ops-persistence-plugins/yak-ops-persistence-vendor-h2/src/main/resources/db/migration/h2/V1_0_4__job_execution.sql
@@ -4,4 +4,4 @@ CREATE TABLE job_execution (
 CREATE INDEX idx_job_execution_external_job_id ON job_execution(external_job_id);
 CREATE INDEX idx_job_execution_last_synced_at ON job_execution(last_synced_at);
 CREATE INDEX idx_job_execution_status ON job_execution(execution_status);
-ALTER TABLE t_baize_flow_job_instance ALTER COLUMN engine_job_id VARCHAR(255);
+ALTER TABLE t_yak_ops_job_instance ALTER COLUMN engine_job_id VARCHAR(255);

--- a/yak-ops-persistence-plugins/yak-ops-persistence-vendor-mysql/src/main/resources/db/migration/mysql/V1_0_0__init.sql
+++ b/yak-ops-persistence-plugins/yak-ops-persistence-vendor-mysql/src/main/resources/db/migration/mysql/V1_0_0__init.sql
@@ -7,7 +7,7 @@ SET NAMES utf8mb4;
 -- 1. Yak Ops business tables
 -- ============================================================
 
-CREATE TABLE `t_baize_flow_connector_param_meta`
+CREATE TABLE `t_yak_ops_connector_param_meta`
 (
     `id`             bigint       NOT NULL AUTO_INCREMENT COMMENT '主键ID',
     `type`           varchar(32)  NOT NULL COMMENT '参数类型，如 connector/time',
@@ -30,7 +30,7 @@ CREATE TABLE `t_baize_flow_connector_param_meta`
     KEY              `idx_param_name` (`param_name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='连接器参数元数据表';
 
-CREATE TABLE `t_baize_flow_client`
+CREATE TABLE `t_yak_ops_client`
 (
     `id`                    bigint       NOT NULL AUTO_INCREMENT COMMENT '主键ID',
     `client_name`           varchar(128) NOT NULL COMMENT 'Client名称',
@@ -58,7 +58,7 @@ CREATE TABLE `t_baize_flow_client`
     KEY                     `idx_heartbeat_time` (`heartbeat_time`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='SeaTunnel Client 表';
 
-CREATE TABLE `t_baize_flow_client_node`
+CREATE TABLE `t_yak_ops_client_node`
 (
     `id`                  bigint       NOT NULL COMMENT '主键 ID',
     `client_id`           bigint       NOT NULL COMMENT '客户端 ID',
@@ -82,7 +82,7 @@ CREATE TABLE `t_baize_flow_client_node`
     KEY `idx_health_status` (`health_status`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='SeaTunnel Client 节点表';
 
-CREATE TABLE `t_baize_flow_datasource`
+CREATE TABLE `t_yak_ops_datasource`
 (
     `id`                bigint NOT NULL COMMENT '主键',
     `name`              varchar(64)   DEFAULT NULL COMMENT '数据源名称',
@@ -97,7 +97,7 @@ CREATE TABLE `t_baize_flow_datasource`
     PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='数据集成-数据源表';
 
-CREATE TABLE `t_baize_flow_datasource_plugin_config`
+CREATE TABLE `t_yak_ops_datasource_plugin_config`
 (
     `id`            varchar(32) NOT NULL COMMENT '主键',
     `plugin_type`   varchar(50) NOT NULL COMMENT '插件类型，如 mysql、postgresql、oracle 等',
@@ -107,7 +107,7 @@ CREATE TABLE `t_baize_flow_datasource_plugin_config`
     PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='数据源插件动态配置表';
 
-CREATE TABLE `t_baize_flow_cdc_server_id_pool`
+CREATE TABLE `t_yak_ops_cdc_server_id_pool`
 (
     `id`            bigint                                                  NOT NULL COMMENT 'primary key',
     `datasource_id` bigint                                                  NOT NULL COMMENT 'datasource id for this MySQL CDC server-id pool',
@@ -122,7 +122,7 @@ CREATE TABLE `t_baize_flow_cdc_server_id_pool`
     KEY             `idx_cdc_server_id_pool_datasource` (`datasource_id`) USING BTREE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='MySQL CDC server-id allocation pool';
 
-CREATE TABLE `t_baize_flow_cdc_server_id_allocation`
+CREATE TABLE `t_yak_ops_cdc_server_id_allocation`
 (
     `id`                bigint                                                 NOT NULL COMMENT 'primary key',
     `pool_id`           bigint                                                 NOT NULL COMMENT 'server-id pool id',
@@ -141,7 +141,7 @@ CREATE TABLE `t_baize_flow_cdc_server_id_allocation`
     KEY                 `idx_cdc_server_id_job_instance` (`job_instance_id`) USING BTREE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='MySQL CDC server-id allocation records';
 
-CREATE TABLE `t_baize_flow_user`
+CREATE TABLE `t_yak_ops_user`
 (
     `id`            int NOT NULL COMMENT '用户ID',
     `user_name`     varchar(64) DEFAULT NULL COMMENT '用户名',
@@ -155,7 +155,7 @@ CREATE TABLE `t_baize_flow_user`
     PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='用户表';
 
-CREATE TABLE `t_baize_flow_session`
+CREATE TABLE `t_yak_ops_session`
 (
     `id`              varchar(64) NOT NULL COMMENT '会话ID',
     `user_id`         int         DEFAULT NULL COMMENT '关联用户ID',
@@ -164,7 +164,7 @@ CREATE TABLE `t_baize_flow_session`
     PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='用户会话表';
 
-CREATE TABLE `t_baize_flow_time_variable`
+CREATE TABLE `t_yak_ops_time_variable`
 (
     `id`              bigint       NOT NULL COMMENT '主键ID',
     `param_name`      varchar(128) NOT NULL COMMENT '变量名称，如 biz_date、start_time、end_time',
@@ -183,7 +183,7 @@ CREATE TABLE `t_baize_flow_time_variable`
     UNIQUE KEY `uk_param_name` (`param_name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='SeaTunnel时间变量表';
 
-CREATE TABLE `t_baize_flow_job_definition`
+CREATE TABLE `t_yak_ops_job_definition`
 (
     `id`                   bigint       NOT NULL COMMENT '主键ID',
     `job_name`             varchar(255) NOT NULL COMMENT '任务名称',
@@ -210,7 +210,7 @@ CREATE TABLE `t_baize_flow_job_definition`
     KEY                    `idx_sink_datasource_id` (`sink_datasource_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='任务定义主表';
 
-CREATE TABLE `t_baize_flow_job_definition_content`
+CREATE TABLE `t_yak_ops_job_definition_content`
 (
     `id`                     bigint      NOT NULL AUTO_INCREMENT COMMENT '主键',
     `job_definition_id`      bigint      NOT NULL COMMENT '任务定义ID',
@@ -225,7 +225,7 @@ CREATE TABLE `t_baize_flow_job_definition_content`
     KEY                      `idx_job_definition_id` (`job_definition_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='任务定义内容版本表';
 
-CREATE TABLE `t_baize_flow_job_instance`
+CREATE TABLE `t_yak_ops_job_instance`
 (
     `id`                bigint      NOT NULL COMMENT '主键ID',
     `job_definition_id` bigint      NOT NULL COMMENT '任务定义ID',
@@ -252,7 +252,7 @@ CREATE TABLE `t_baize_flow_job_instance`
     KEY                 `idx_definition_status` (`job_definition_id`, `job_status`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='任务运行实例表';
 
-CREATE TABLE `t_baize_flow_job_schedule`
+CREATE TABLE `t_yak_ops_job_schedule`
 (
     `id`                 bigint      NOT NULL COMMENT '主键ID',
     `job_definition_id`  bigint      NOT NULL COMMENT '任务定义ID',
@@ -269,7 +269,7 @@ CREATE TABLE `t_baize_flow_job_schedule`
     KEY                  `idx_next_schedule_time` (`next_schedule_time`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='任务调度表';
 
-CREATE TABLE `t_baize_flow_job_metrics`
+CREATE TABLE `t_yak_ops_job_metrics`
 (
     `id`                      bigint NOT NULL COMMENT '主键ID',
     `job_instance_id`         bigint NOT NULL COMMENT '任务实例ID',
@@ -297,7 +297,7 @@ CREATE TABLE `t_baize_flow_job_metrics`
     KEY                       `idx_create_time` (`create_time`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='任务运行汇总指标表';
 
-CREATE TABLE `t_baize_flow_job_table_metrics`
+CREATE TABLE `t_yak_ops_job_table_metrics`
 (
     `id`                bigint NOT NULL COMMENT '主键ID',
     `job_instance_id`   bigint NOT NULL COMMENT '任务实例ID',
@@ -470,7 +470,7 @@ CREATE TABLE `QRTZ_LOCKS`
 -- 3. Initial data
 -- ============================================================
 
-INSERT INTO `t_baize_flow_time_variable`
+INSERT INTO `t_yak_ops_time_variable`
 (`id`, `param_name`, `param_desc`, `variable_source`, `value_type`, `time_format`, `default_value`, `expression`,
  `example_value`, `enabled`, `remark`)
 VALUES (10001, 'now', '当前时间', 'SYSTEM', 'DYNAMIC', 'yyyy-MM-dd HH:mm:ss', NULL, 'now', '2026-05-02 09:30:00', 1,
@@ -484,6 +484,6 @@ VALUES (10001, 'now', '当前时间', 'SYSTEM', 'DYNAMIC', 'yyyy-MM-dd HH:mm:ss'
        (10005, 'end_time', '同步结束时间，默认取调度当天零点', 'SYSTEM', 'DYNAMIC', 'yyyy-MM-dd HH:mm:ss', NULL,
         'schedule_time@day_start', '2026-05-02 00:00:00', 1, '系统内置变量');
 
-INSERT INTO `t_baize_flow_user`
+INSERT INTO `t_yak_ops_user`
 (`id`, `user_name`, `user_password`, `user_type`, `email`, `phone`, `create_time`, `update_time`, `state`)
 VALUES (1, 'admin', '$2a$10$eAi7g2tWHTf3ukdlyM9uw.d/MIYbkfjZY4B1PIEvfmrlPi7XRvb4K', 0, NULL, NULL, NULL, NULL, 1);

--- a/yak-ops-persistence-plugins/yak-ops-persistence-vendor-mysql/src/main/resources/db/migration/mysql/V1_0_3__init_alarm.sql
+++ b/yak-ops-persistence-plugins/yak-ops-persistence-vendor-mysql/src/main/resources/db/migration/mysql/V1_0_3__init_alarm.sql
@@ -2,7 +2,7 @@
 -- Alarm channels (SPI instances), rules (who/when), rule-channel links, and
 -- delivery records. All tables use utf8mb4 with utf8mb4_unicode_ci.
 
-CREATE TABLE `t_baize_flow_alarm_channel`
+CREATE TABLE `t_yak_ops_alarm_channel`
 (
     `id`          bigint       NOT NULL COMMENT '主键ID',
     `name`        varchar(128) NOT NULL COMMENT '渠道名称',
@@ -17,7 +17,7 @@ CREATE TABLE `t_baize_flow_alarm_channel`
     KEY           `idx_enabled` (`enabled`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='告警渠道实例表';
 
-CREATE TABLE `t_baize_flow_alarm_rule`
+CREATE TABLE `t_yak_ops_alarm_rule`
 (
     `id`                bigint       NOT NULL COMMENT '主键ID',
     `name`              varchar(128) NOT NULL COMMENT '规则名称',
@@ -34,7 +34,7 @@ CREATE TABLE `t_baize_flow_alarm_rule`
     KEY                 `idx_enabled` (`enabled`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='告警规则表';
 
-CREATE TABLE `t_baize_flow_alarm_rule_channel`
+CREATE TABLE `t_yak_ops_alarm_rule_channel`
 (
     `id`          bigint   NOT NULL COMMENT '主键ID',
     `rule_id`     bigint   NOT NULL COMMENT '规则ID',
@@ -46,7 +46,7 @@ CREATE TABLE `t_baize_flow_alarm_rule_channel`
     KEY          `idx_channel_id` (`channel_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='告警规则-渠道关联表';
 
-CREATE TABLE `t_baize_flow_alarm_record`
+CREATE TABLE `t_yak_ops_alarm_record`
 (
     `id`                bigint       NOT NULL COMMENT '主键ID',
     `rule_id`           bigint                DEFAULT NULL COMMENT '规则ID',

--- a/yak-ops-persistence-plugins/yak-ops-persistence-vendor-mysql/src/main/resources/db/migration/mysql/V1_0_4__job_execution.sql
+++ b/yak-ops-persistence-plugins/yak-ops-persistence-vendor-mysql/src/main/resources/db/migration/mysql/V1_0_4__job_execution.sql
@@ -23,4 +23,4 @@ CREATE TABLE `job_execution` (
   KEY `idx_job_execution_status` (`execution_status`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 -- Java has always treated this ID as String; widen legacy numeric projection without losing values.
-ALTER TABLE `t_baize_flow_job_instance` MODIFY COLUMN `engine_job_id` varchar(255) DEFAULT NULL COMMENT 'Latest execution external job ID compatibility projection';
+ALTER TABLE `t_yak_ops_job_instance` MODIFY COLUMN `engine_job_id` varchar(255) DEFAULT NULL COMMENT 'Latest execution external job ID compatibility projection';

--- a/yak-ops-persistence-plugins/yak-ops-persistence-vendor-postgresql/src/main/resources/db/migration/postgresql/V1_0_4__job_execution.sql
+++ b/yak-ops-persistence-plugins/yak-ops-persistence-vendor-postgresql/src/main/resources/db/migration/postgresql/V1_0_4__job_execution.sql
@@ -4,4 +4,4 @@ CREATE TABLE job_execution (
 CREATE INDEX idx_job_execution_external_job_id ON job_execution(external_job_id);
 CREATE INDEX idx_job_execution_last_synced_at ON job_execution(last_synced_at);
 CREATE INDEX idx_job_execution_status ON job_execution(execution_status);
-ALTER TABLE t_baize_flow_job_instance ALTER COLUMN engine_job_id TYPE VARCHAR(255) USING engine_job_id::VARCHAR;
+ALTER TABLE t_yak_ops_job_instance ALTER COLUMN engine_job_id TYPE VARCHAR(255) USING engine_job_id::VARCHAR;

--- a/yak-ops-ui/src/pages/batch-link-up/components/SyncTaskList/components/RunLogDrawer.tsx
+++ b/yak-ops-ui/src/pages/batch-link-up/components/SyncTaskList/components/RunLogDrawer.tsx
@@ -24,7 +24,7 @@ interface RunLogDrawerProps {
 
   /**
    * 任务实例 ID。
-   * 离线任务：t_baize_flow_job_instance.id
+   * 离线任务：t_yak_ops_job_instance.id
    */
   instanceId?: string | number;
 


### PR DESCRIPTION
### Motivation

- Unify the database name, schema, JDBC defaults and table namespace from `baize_flow` to `yak_ops` so code, SQL migrations and deployment configuration are consistent.
- Ensure MyBatis / MyBatis-Plus entity mappings, raw SQL, Flyway migrations and deployment docs reference the new `t_yak_ops_*` table namespace to avoid runtime mismatches. 
- Provide a safe, reviewed one-time migration plan for existing `baize_flow` installations to move data to `yak_ops` without renumbering Flyway scripts.

### Description

- Replaced occurrences of the legacy DB/schema/table namespace with the new names in configuration, code and SQL, including `application.yml`/`application-*.yml`, `Dockerfile`, `compose*.yaml`, `.env.example`, and `README_CN.md` so defaults and JDBC URLs now point at `yak_ops`. 
- Updated MyBatis-Plus annotations and Java mapper SQL to use `t_yak_ops_*` (entities: `@TableName` updates; mapper XML and annotated SQL updated) so runtime mappings match DDL. 
- Rewrote initialization, reset and Flyway/legacy-seed SQL to create and reference `t_yak_ops_*` tables while preserving existing Flyway filenames and version numbers. 
- Added a reviewed, explicit MySQL migration script at `tools/database/mysql/migrate_baize_flow_to_yak_ops.sql` which includes preflight checks, atomic `RENAME TABLE` pairs, validation queries, guidance for dependent objects (views/procedures/triggers), Flyway checksum/repair guidance and an explicit commented rollback mapping. 

### Testing

- Ran a global search for `baize_flow` and verified no remaining references in source, configs or migration folders outside the intentional migration script, and `baize_flow` is only present in the one-time migration/rollback SQL, which is intentional and kept for migration/rollback purposes (check passed). 
- Executed `git diff --cached --check` and repository whitespace/format checks on staged changes and found no blocking issues (passed). 
- Ran a table-reference consistency script that verifies all `t_yak_ops_*` references have corresponding initialization/migration DDL and reported consistency between application references and DDL (passed). 
- Attempted to compile `yak-ops-boot` with Maven but dependency downloads were blocked by the environment (Maven Central returned HTTP 403), so full build validation could not complete (blocked); Docker Compose validation could not run because `docker` is not available in the environment (skipped).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a64737fce3883269995339ae9c14b3f)