### PR TITLE
fix(boot): add Flyway MySQL support module

### DIFF
--- a/yak-ops-boot/pom.xml
+++ b/yak-ops-boot/pom.xml
@@ -47,6 +47,10 @@
             <groupId>org.flywaydb</groupId>
             <artifactId>flyway-core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-mysql</artifactId>
+        </dependency>
         <!-- Select complete plugin families; concrete vendors stay behind aggregators. -->
         <dependency>
             <groupId>io.yak.ops</groupId>


### PR DESCRIPTION
### Motivation
- Add Flyway's MySQL support module so Flyway can recognize MySQL 8.0 and avoid the `Unsupported Database: MySQL 8.0` error while leaving version management to the Spring Boot BOM.

### Description
- Added the dependency `org.flywaydb:flyway-mysql` to `yak-ops-boot/pom.xml` alongside the existing `org.flywaydb:flyway-core` without specifying a version so the Spring Boot 2.7.18 BOM continues to govern Flyway versions.

### Testing
- Verified `yak-ops-boot/pom.xml` parses as XML and `git diff --check` showed no whitespace or patch issues, and attempted `mvn clean install -DskipTests` and `mvn -pl yak-ops-boot dependency:tree -Dincludes=org.flywaydb` but both were blocked from resolving `org.springframework.boot:spring-boot-dependencies:2.7.18` due to a Maven Central HTTP 403, so final dependency tree (`org.flywaydb:flyway-core:8.5.13` and `org.flywaydb:flyway-mysql:8.5.13`) resolution and application startup could not be validated in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6478809ea48326b4b7edaaa33422ea)