### PR TITLE
fix: map numeric user types during login

### DIFF
--- a/yak-ops-application/pom.xml
+++ b/yak-ops-application/pom.xml
@@ -89,5 +89,10 @@
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-crypto</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/yak-ops-application/src/main/java/io/yak/ops/application/service/impl/UsersServiceImpl.java
+++ b/yak-ops-application/src/main/java/io/yak/ops/application/service/impl/UsersServiceImpl.java
@@ -30,13 +30,13 @@ public class UsersServiceImpl implements UsersService {
 
     @Override
     public User getUserInfo(User loginUser) {
-        User User;
+        User user;
         if (loginUser.getUserType() == UserType.ADMIN_USER) {
-            User = loginUser;
+            user = loginUser;
         } else {
-            User = users.findById(loginUser.getId()).orElse(null);
+            user = users.findById(loginUser.getId()).orElse(null);
         }
-        return User;
+        return user;
     }
 
     @Override

--- a/yak-ops-application/src/test/java/io/yak/ops/application/service/impl/UsersServiceImplTest.java
+++ b/yak-ops-application/src/test/java/io/yak/ops/application/service/impl/UsersServiceImplTest.java
@@ -1,0 +1,38 @@
+package io.yak.ops.application.service.impl;
+
+import io.yak.ops.application.model.User;
+import io.yak.ops.application.port.UserRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class UsersServiceImplTest {
+
+    @Test
+    void administratorCanLogInWithBCryptPassword() {
+        User administrator = new User();
+        administrator.setUserName("admin");
+        administrator.setUserPassword(new BCryptPasswordEncoder().encode("yak-password"));
+        UsersServiceImpl service = new UsersServiceImpl(repositoryReturning(administrator));
+
+        assertSame(administrator, service.queryUser("admin", "yak-password"));
+        assertNull(service.queryUser("admin", "wrong-password"));
+    }
+
+    private UserRepository repositoryReturning(final User user) {
+        return new UserRepository() {
+            @Override
+            public Optional<User> findByUserName(String userName) {
+                return Optional.of(user);
+            }
+
+            @Override
+            public Optional<User> findById(int userId) {
+                return Optional.empty();
+            }
+        };
+    }
+}

--- a/yak-ops-common/pom.xml
+++ b/yak-ops-common/pom.xml
@@ -10,6 +10,10 @@
     <version>1.0.0</version>
     <dependencies>
         <dependency>
+            <groupId>com.baomidou</groupId>
+            <artifactId>mybatis-plus-annotation</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.cronutils</groupId>
             <artifactId>cron-utils</artifactId>
         </dependency>
@@ -53,6 +57,11 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/yak-ops-common/src/main/java/io/yak/ops/common/enums/UserType.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/enums/UserType.java
@@ -1,5 +1,6 @@
 package io.yak.ops.common.enums;
 
+import com.baomidou.mybatisplus.annotation.EnumValue;
 
 /**
  * user type
@@ -16,6 +17,7 @@ public enum UserType {
         this.descp = descp;
     }
 
+    @EnumValue
     private final int code;
     private final String descp;
 
@@ -26,5 +28,13 @@ public enum UserType {
     public String getDescp() {
         return descp;
     }
-}
 
+    public static UserType fromCode(int code) {
+        for (UserType userType : values()) {
+            if (userType.code == code) {
+                return userType;
+            }
+        }
+        throw new IllegalArgumentException("Unknown user type code: " + code);
+    }
+}

--- a/yak-ops-common/src/test/java/io/yak/ops/common/enums/UserTypeTest.java
+++ b/yak-ops-common/src/test/java/io/yak/ops/common/enums/UserTypeTest.java
@@ -1,0 +1,31 @@
+package io.yak.ops.common.enums;
+
+import com.baomidou.mybatisplus.annotation.EnumValue;
+import java.lang.reflect.Field;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class UserTypeTest {
+
+    @Test
+    void mapsPersistedCodesToUserTypes() {
+        assertEquals(UserType.ADMIN_USER, UserType.fromCode(0));
+        assertEquals(UserType.GENERAL_USER, UserType.fromCode(1));
+    }
+
+    @Test
+    void rejectsUnknownPersistedCodeWithClearMessage() {
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class, () -> UserType.fromCode(2));
+        assertTrue(exception.getMessage().contains("Unknown user type code: 2"));
+    }
+
+    @Test
+    void codeIsTheMyBatisPlusEnumValue() throws NoSuchFieldException {
+        Field code = UserType.class.getDeclaredField("code");
+        assertTrue(code.isAnnotationPresent(EnumValue.class));
+    }
+}

--- a/yak-ops-web/pom.xml
+++ b/yak-ops-web/pom.xml
@@ -34,5 +34,10 @@
             <artifactId>lombok</artifactId>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/yak-ops-web/src/main/java/io/yak/ops/api/exceptions/ApiExceptionHandler.java
+++ b/yak-ops-web/src/main/java/io/yak/ops/api/exceptions/ApiExceptionHandler.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.HandlerMapping;
+import org.springframework.web.servlet.NoHandlerFoundException;
 
 /**
  * Global Exception Handler
@@ -41,12 +42,26 @@ public class ApiExceptionHandler {
      * Static resource not found
      * Avoid printing ERROR logs repeatedly for wrong swagger/static resource paths
      */
-    @ExceptionHandler(Exception.class)
-    public Result<Object> handleNoResourceFoundException(Exception e,
+    @ExceptionHandler(NoHandlerFoundException.class)
+    public Result<Object> handleNoResourceFoundException(NoHandlerFoundException e,
                                                          HttpServletRequest request) {
         log.warn("Static resource not found, uri={}, resourcePath={}",
                 request.getRequestURI(), e.getMessage());
         return Result.errorWithArgs(Status.INTERNAL_SERVER_ERROR_ARGS, "Resource not found");
+    }
+
+    /**
+     * Internal failures, including persistence and result mapping failures.
+     */
+    @ExceptionHandler(Exception.class)
+    public Result<Object> handleInternalException(Exception e, HttpServletRequest request) {
+        HandlerMethod handlerMethod = getHandlerMethod(request);
+        if (handlerMethod != null) {
+            log.error("{} Meet an internal exception", handlerMethod.getShortLogMessage(), e);
+        } else {
+            log.error("Meet an internal exception, uri={}", request.getRequestURI(), e);
+        }
+        return Result.errorWithArgs(Status.INTERNAL_SERVER_ERROR_ARGS, "Internal server error");
     }
 
     /**

--- a/yak-ops-web/src/main/java/io/yak/ops/api/handler/CustomGlobalExceptionHandler.java
+++ b/yak-ops-web/src/main/java/io/yak/ops/api/handler/CustomGlobalExceptionHandler.java
@@ -71,15 +71,4 @@ public class CustomGlobalExceptionHandler {
         return Result.buildFromRSAndMsg(ResultStatus.FAIL, "Service encountered a null pointer exception");
     }
 
-    /**
-     * Catch-all handler for any other exceptions not explicitly handled.
-     *
-     * @param e the exception
-     * @return Result indicating failure with the exception's message
-     */
-    @ExceptionHandler(Exception.class)
-    public Result<Void> handleException(Exception e) {
-        LOGGER.error("method=handleException || errMsg=exception", e);
-        return Result.buildFromRSAndMsg(ResultStatus.FAIL, e.getMessage());
-    }
 }

--- a/yak-ops-web/src/test/java/io/yak/ops/api/exceptions/ApiExceptionHandlerTest.java
+++ b/yak-ops-web/src/test/java/io/yak/ops/api/exceptions/ApiExceptionHandlerTest.java
@@ -1,0 +1,24 @@
+package io.yak.ops.api.exceptions;
+
+import io.yak.ops.application.model.response.Result;
+import org.apache.ibatis.exceptions.PersistenceException;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ApiExceptionHandlerTest {
+
+    @Test
+    void persistenceFailureIsReportedAsInternalErrorNotMissingResource() {
+        ApiExceptionHandler handler = new ApiExceptionHandler();
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/v1/login");
+
+        Result<Object> result = handler.handleInternalException(
+                new PersistenceException("user result mapping failed"), request);
+
+        assertTrue(result.getMsg().contains("Internal server error"));
+        assertFalse(result.getMsg().contains("Resource not found"));
+    }
+}


### PR DESCRIPTION
### Motivation
- 登录时 MyBatis 默认的枚举转换将数据库中的数字字符串当作枚举名调用 `valueOf` 导致 `No enum constant` 异常，需要把数据库中的 0/1 映射到枚举常量而不改动数据库数据格式。 
- 保持只使用 `spring-security-crypto` 提供的 `PasswordEncoder/BCryptPasswordEncoder` 做密码校验，并清理代码中不规范的变量命名。 
- 将数据库映射/持久化异常与“静态资源不存在”区分开，避免数据库映射错误被误判为缺少静态资源。 

### Description
- 在 `UserType` 的 `code` 字段上添加 MyBatis-Plus 官方注解 `@EnumValue` 并新增 `fromCode(int)` 工厂方法以便对非法编码抛出清晰异常，同时向 `yak-ops-common` 添加轻量级依赖 `mybatis-plus-annotation`。 
- 修正 `UsersServiceImpl` 中变量命名 `User User` -> `User user`，并保持使用 `BCryptPasswordEncoder` 进行匹配校验。 
- 更新全局异常处理：将 `NoHandlerFoundException` 专门视为“资源不存在”，并新增单独的内部异常处理器用于处理 ResultMap/Persistence 等内部错误，从而避免把持久化异常误判为静态资源缺失；同时移除另一个处理器中会与之冲突的泛型 catch-all。 
- 增加单元测试用例覆盖枚举映射（`user_type=0/1`）、非法编码异常、BCrypt 登陆校验和持久化异常被归类为内部错误的行为，并在相关模块 POM 中补充测试依赖（`junit-jupiter`、`spring-boot-starter-test`）。 

### Testing
- 运行 `git diff --check` 以及代码检索（`rg`）确认未重新引入 `spring-boot-starter-security`，这些静态检查通过。 
- 新增的单元测试位于 `yak-ops-common`, `yak-ops-application`, `yak-ops-web` 模块中但在当前执行环境未能运行。 
- 尝试通过 `./mvnw -pl yak-ops-common,yak-ops-application,yak-ops-web -am test` 和 `mvn -pl yak-ops-common,yak-ops-application,yak-ops-web -am test` 执行自动化测试时依赖解析失败（环境上的 Maven Central 代理返回 HTTP 403，且 Maven Wrapper JAR 无法下载），因此自动化测试实际未完成。 
- 建议在目标 JDK 8 环境下执行：`mvn -pl yak-ops-common,yak-ops-application,yak-ops-web -am clean test`，期待所有新增测试通过并验证：`user_type=0/1` 正确映射、非法编码抛出清晰异常、BCrypt 登录行为正确且持久化异常被识别为内部错误。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a64a7a64b308326ae985ab1f5838f60)