### PR TITLE
feat(ui): add missing placeholder pages

### DIFF
--- a/yak-ops-ui/src/config/navigation.ts
+++ b/yak-ops-ui/src/config/navigation.ts
@@ -155,6 +155,28 @@ export const appRoutes: readonly NavigationRoute[] = [
     parentId: 'batch-link-up',
   },
 
+  // 流程编排
+  {
+    id: 'workflow-management',
+    path: '/workflow-management',
+    title: '流程管理',
+    component: './workflow-management',
+    iconKey: 'workflow',
+    menuGroup: 'workflow',
+    order: 10,
+  },
+
+  // 数据质量
+  {
+    id: 'data-quality',
+    path: '/data-quality',
+    title: '质量管理',
+    component: './data-quality',
+    iconKey: 'quality',
+    menuGroup: 'quality',
+    order: 10,
+  },
+
   // 运维中心
   {
     id: 'metrics',

--- a/yak-ops-ui/src/pages/data-quality/index.tsx
+++ b/yak-ops-ui/src/pages/data-quality/index.tsx
@@ -1,0 +1,3 @@
+const DataQualityPage = () => <div>good</div>;
+
+export default DataQualityPage;

--- a/yak-ops-ui/src/pages/home/index.tsx
+++ b/yak-ops-ui/src/pages/home/index.tsx
@@ -1,0 +1,3 @@
+const HomePage = () => <div>good</div>;
+
+export default HomePage;

--- a/yak-ops-ui/src/pages/workflow-management/index.tsx
+++ b/yak-ops-ui/src/pages/workflow-management/index.tsx
@@ -1,0 +1,3 @@
+const WorkflowManagementPage = () => <div>good</div>;
+
+export default WorkflowManagementPage;


### PR DESCRIPTION
### Motivation
- Some routes referenced by the navigation had no corresponding page components, causing missing pages in the frontend; small placeholder pages are added to restore the routes and menu groups.

### Description
- Added simple placeholder pages `yak-ops-ui/src/pages/home/index.tsx`, `yak-ops-ui/src/pages/workflow-management/index.tsx`, and `yak-ops-ui/src/pages/data-quality/index.tsx` that export a minimal component containing `<div>good</div>`.
- Registered the new routes in `yak-ops-ui/src/config/navigation.ts` under the existing `workflow` and `quality` menu groups as `'/workflow-management'` and `'/data-quality'` respectively.
- Changes are limited to adding the three page files and updating the navigation metadata.

### Testing
- Ran `git diff --check` which reported no problems.
- Ran `./node_modules/.bin/biome check src/pages/home/index.tsx src/pages/workflow-management/index.tsx src/pages/data-quality/index.tsx` which completed with no fixes required.
- Ran `./node_modules/.bin/tsc --noEmit` which failed due to a missing type definition for `minimatch` in the environment, so full TypeScript validation is blocked by project dependency configuration.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a64bb1423348326ae1bb00812db3d4d)