### PR TITLE
chore(ui): align page entries with configured routes

### DIFF
--- a/yak-ops-ui/src/pages/bi/index.tsx
+++ b/yak-ops-ui/src/pages/bi/index.tsx
@@ -1,0 +1,3 @@
+const BiPage = () => null;
+
+export default BiPage;

--- a/yak-ops-ui/src/pages/client/detail/index.tsx
+++ b/yak-ops-ui/src/pages/client/detail/index.tsx
@@ -1,0 +1,3 @@
+const ClientDetailPage = () => null;
+
+export default ClientDetailPage;

--- a/yak-ops-ui/src/pages/connector/detail/index.tsx
+++ b/yak-ops-ui/src/pages/connector/detail/index.tsx
@@ -1,0 +1,3 @@
+const ConnectorDetailPage = () => null;
+
+export default ConnectorDetailPage;

--- a/yak-ops-ui/src/pages/connector/index.tsx
+++ b/yak-ops-ui/src/pages/connector/index.tsx
@@ -1,3 +1,3 @@
-const DataQualityPage = () => <div>good</div>;
+const ConnectorPage = () => null;
 
-export default DataQualityPage;
+export default ConnectorPage;

--- a/yak-ops-ui/src/pages/data-quality/detail/index.tsx
+++ b/yak-ops-ui/src/pages/data-quality/detail/index.tsx
@@ -1,0 +1,3 @@
+const DataQualityDetailPage = () => null;
+
+export default DataQualityDetailPage;

--- a/yak-ops-ui/src/pages/data-quality/index.tsx
+++ b/yak-ops-ui/src/pages/data-quality/index.tsx
@@ -1,3 +1,3 @@
-const DataQualityPage = () => <div>good</div>;
+const DataQualityPage = () => null;
 
 export default DataQualityPage;

--- a/yak-ops-ui/src/pages/data-quality/report/detail/index.tsx
+++ b/yak-ops-ui/src/pages/data-quality/report/detail/index.tsx
@@ -1,0 +1,3 @@
+const DataQualityReportDetailPage = () => null;
+
+export default DataQualityReportDetailPage;

--- a/yak-ops-ui/src/pages/data-quality/report/index.tsx
+++ b/yak-ops-ui/src/pages/data-quality/report/index.tsx
@@ -1,0 +1,3 @@
+const DataQualityReportPage = () => null;
+
+export default DataQualityReportPage;

--- a/yak-ops-ui/src/pages/data-source/detail/index.tsx
+++ b/yak-ops-ui/src/pages/data-source/detail/index.tsx
@@ -1,0 +1,3 @@
+const DataSourceDetailPage = () => null;
+
+export default DataSourceDetailPage;

--- a/yak-ops-ui/src/pages/home/index.tsx
+++ b/yak-ops-ui/src/pages/home/index.tsx
@@ -1,3 +1,3 @@
-const HomePage = () => <div>good</div>;
+const HomePage = () => null;
 
 export default HomePage;

--- a/yak-ops-ui/src/pages/metrics/detail/index.tsx
+++ b/yak-ops-ui/src/pages/metrics/detail/index.tsx
@@ -1,0 +1,3 @@
+const MetricsDetailPage = () => null;
+
+export default MetricsDetailPage;

--- a/yak-ops-ui/src/pages/open-api/index.tsx
+++ b/yak-ops-ui/src/pages/open-api/index.tsx
@@ -1,0 +1,3 @@
+const OpenApiPage = () => null;
+
+export default OpenApiPage;

--- a/yak-ops-ui/src/pages/realtime-link-up/config/index.tsx
+++ b/yak-ops-ui/src/pages/realtime-link-up/config/index.tsx
@@ -1,3 +1,3 @@
-const DataQualityPage = () => <div>good</div>;
+const RealtimeLinkUpConfigPage = () => null;
 
-export default DataQualityPage;
+export default RealtimeLinkUpConfigPage;

--- a/yak-ops-ui/src/pages/realtime-link-up/detail/index.tsx
+++ b/yak-ops-ui/src/pages/realtime-link-up/detail/index.tsx
@@ -1,3 +1,3 @@
-const DataQualityPage = () => <div>good</div>;
+const RealtimeLinkUpDetailPage = () => null;
 
-export default DataQualityPage;
+export default RealtimeLinkUpDetailPage;

--- a/yak-ops-ui/src/pages/realtime-link-up/index.tsx
+++ b/yak-ops-ui/src/pages/realtime-link-up/index.tsx
@@ -1,3 +1,3 @@
-const DataQualityPage = () => <div>good</div>;
+const RealtimeLinkUpPage = () => null;
 
-export default DataQualityPage;
+export default RealtimeLinkUpPage;

--- a/yak-ops-ui/src/pages/workflow-instance/detail/index.tsx
+++ b/yak-ops-ui/src/pages/workflow-instance/detail/index.tsx
@@ -1,0 +1,3 @@
+const WorkflowInstanceDetailPage = () => null;
+
+export default WorkflowInstanceDetailPage;

--- a/yak-ops-ui/src/pages/workflow-instance/index.tsx
+++ b/yak-ops-ui/src/pages/workflow-instance/index.tsx
@@ -1,3 +1,3 @@
-const DataQualityPage = () => <div>good</div>;
+const WorkflowInstancePage = () => null;
 
-export default DataQualityPage;
+export default WorkflowInstancePage;

--- a/yak-ops-ui/src/pages/workflow-management/designer/index.tsx
+++ b/yak-ops-ui/src/pages/workflow-management/designer/index.tsx
@@ -1,0 +1,3 @@
+const WorkflowDesignerPage = () => null;
+
+export default WorkflowDesignerPage;

--- a/yak-ops-ui/src/pages/workflow-management/detail/index.tsx
+++ b/yak-ops-ui/src/pages/workflow-management/detail/index.tsx
@@ -1,0 +1,3 @@
+const WorkflowDetailPage = () => null;
+
+export default WorkflowDetailPage;

--- a/yak-ops-ui/src/pages/workflow-management/index.tsx
+++ b/yak-ops-ui/src/pages/workflow-management/index.tsx
@@ -1,3 +1,3 @@
-const WorkflowManagementPage = () => <div>good</div>;
+const WorkflowManagementPage = () => null;
 
 export default WorkflowManagementPage;

--- a/yak-ops-ui/src/pages/workflow-project/detail/index.tsx
+++ b/yak-ops-ui/src/pages/workflow-project/detail/index.tsx
@@ -1,0 +1,3 @@
+const WorkflowProjectDetailPage = () => null;
+
+export default WorkflowProjectDetailPage;

--- a/yak-ops-ui/src/pages/workflow-project/index.tsx
+++ b/yak-ops-ui/src/pages/workflow-project/index.tsx
@@ -1,3 +1,3 @@
-const DataQualityPage = () => <div>good</div>;
+const WorkflowProjectPage = () => null;
 
-export default DataQualityPage;
+export default WorkflowProjectPage;


### PR DESCRIPTION
### Motivation

- 确保 `yak-ops-ui/src/pages` 的目录与 `yak-ops-ui/src/config/navigation.ts` 中的 `appRoutes.component` 一致，避免运行时路由组件无法解析的问题。

### Description

- 为此前缺失的路由入口新增最小可编译页面文件（语义化组件名且返回 `null`），包括但不限于 `workflow-project/detail`, `workflow-management/designer`, `workflow-management/detail`, `workflow-instance/detail`, `data-source/detail`, `client/detail`, `connector/detail`, `data-quality/report` 等。 
- 将仓内临时占位 `const ... = () => <div>good</div>` 替换为语义化的无渲染占位组件（例如 `const HomePage = () => null;`），以避免不明确的占位内容并保持路由解析一致性。 
- 未对任何页面的 JSX、样式、接口或业务逻辑做修改，且未更改 `appRoutes.component` 或其它导航元数据字段。 
- 没有执行文件复制或移动（未发现可迁移的重复实现），仅新增最小入口并修正占位组件名以恢复路由解析。

### Testing

- 使用脚本逐条解析 `appRoutes.component` 并验证对应 `src/pages/**/index.tsx`，结果为 `32/32` 路由组件均能解析到 `index.tsx`（通过）。
- 运行 `git diff --check -- src/pages` 检查导入/空白错误，检查通过（无 show-stoppers）。
- 执行 `npm run build`（生产构建）成功，构建日志显示 `✓ Built`（通过）。
- 执行 `npm run tsc` 时遇到环境类型依赖问题：TypeScript 报 `TS2688: Cannot find type definition file for 'minimatch'`，尝试通过 `npm install @types/minimatch@5.1.2` 修复但 npm registry 返回 HTTP 403 导致安装失败，因此本地 `tsc` 检查未在本次环境下完成（失败/受限）。

本次变更仅限于页面目录规划与路由入口补齐，明确未进行任何页面功能、UI 或业务逻辑开发。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a64c650650c8326b92052e8db2d96e0)