### PR TITLE
feat: consume Yak Security current user endpoint

### DIFF
--- a/yak-ops-ui/src/app.tsx
+++ b/yak-ops-ui/src/app.tsx
@@ -12,6 +12,19 @@ import HttpUtils from './utils/HttpUtils';
 
 const isDev = process.env.NODE_ENV === 'development';
 const loginPath = '/login';
+const currentUserPath = '/yak-security/api/v1/account/current';
+
+export const toCurrentUser = (user: API.CurrentUserVO): API.CurrentUser => ({
+  ...user,
+  // ProLayout's user widgets use these legacy display fields.
+  name: user.realName?.trim() || user.userName,
+  userid: String(user.id),
+  email: user.email ?? undefined,
+  phone: user.phone ?? undefined,
+  roleList: user.roleList ?? [],
+  permissionCodes: user.permissionCodes ?? [],
+  projectList: user.projectList ?? [],
+});
 
 /**
  * @see https://umijs.org/docs/api/runtime-config#getinitialstate
@@ -24,11 +37,9 @@ export async function getInitialState(): Promise<{
 }> {
   const fetchUserInfo = async () => {
     try {
-      const msg = await HttpUtils.get<API.CurrentUser | undefined>(
-        '/api/v1/users/currentUser',
-      );
+      const msg = await HttpUtils.get<API.CurrentUserVO>(currentUserPath);
 
-      return msg.data;
+      return msg.data ? toCurrentUser(msg.data) : undefined;
     } catch (_error) {
       history.push(loginPath);
     }

--- a/yak-ops-ui/src/services/ant-design-pro/typings.d.ts
+++ b/yak-ops-ui/src/services/ant-design-pro/typings.d.ts
@@ -2,7 +2,38 @@
 /* eslint-disable */
 
 declare namespace API {
+  type RoleBrief = {
+    id: number;
+    roleName: string;
+  };
+
+  type ProjectBrief = {
+    id: number;
+    projectCode: string;
+    projectName: string;
+  };
+
+  /** The authenticated identity returned by Yak Security. */
+  type CurrentUserVO = {
+    id: number;
+    userName: string;
+    realName?: string | null;
+    deptId?: number | null;
+    phone?: string | null;
+    email?: string | null;
+    roleList: RoleBrief[];
+    permissionCodes: string[];
+    projectList: ProjectBrief[];
+  };
+
   type CurrentUser = {
+    id?: number;
+    userName?: string;
+    realName?: string | null;
+    deptId?: number | null;
+    roleList?: RoleBrief[];
+    permissionCodes?: string[];
+    projectList?: ProjectBrief[];
     name?: string;
     avatar?: string;
     userid?: string;


### PR DESCRIPTION
### Motivation

- Ensure the frontend obtains the authenticated identity from a server-validated Session endpoint (`GET /yak-security/api/v1/account/current`) instead of trusting client-supplied headers or cookies. 
- Provide explicit TypeScript shapes for the security response including roles, permission codes and projects to make usage predictable and safe in the UI. 
- Normalize collections (roles, permissionCodes, projectList) to stable arrays and adapt the shape to ProLayout display fields.

### Description

- Added explicit types `CurrentUserVO`, `RoleBrief`, and `ProjectBrief` in `yak-ops-ui/src/services/ant-design-pro/typings.d.ts` to describe the authenticated identity returned by Yak Security and to exclude sensitive fields such as passwords. 
- Updated `yak-ops-ui/src/app.tsx` to fetch the current user via `GET /yak-security/api/v1/account/current` using `HttpUtils.get`, and introduced `toCurrentUser` adapter to map the `CurrentUserVO` into the existing `API.CurrentUser` shape expected by ProLayout. 
- The adapter sets display-friendly fields (`name`, `userid`, `email`, `phone`) and normalizes `roleList`, `permissionCodes`, and `projectList` to empty arrays when absent, and prefers `realName` for display (falling back to `userName`). 
- Client-side code no longer relies on any client-provided identity; identity is taken from the server response only.

### Testing

- Ran lint: `yarn biome lint src/app.tsx src/services/ant-design-pro/typings.d.ts` — succeeded. 
- Ran quick repository check: `git diff --check` — no issues reported by the check run. 
- Ran TypeScript build: `yarn tsc` — blocked by environment issue (`TS2688: Cannot find type definition file for 'minimatch'`) unrelated to the changes in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a66195f9600832696333b8ecbd18823)