### PR TITLE
feat(ui): implement Yak Security session lifecycle

### DIFF
--- a/yak-ops-ui/src/app.tsx
+++ b/yak-ops-ui/src/app.tsx
@@ -8,11 +8,37 @@ import 'd3-transition';
 import defaultSettings from '../config/defaultSettings';
 import { GlobalSearch, Knowledge } from './components/RightContent';
 import { errorConfig } from './requestErrorConfig';
-import HttpUtils from './utils/HttpUtils';
+import { getCurrentUser } from './services/security/account';
 
 const isDev = process.env.NODE_ENV === 'development';
 const loginPath = '/login';
-const currentUserPath = '/yak-security/api/v1/account/current';
+
+const isLoginPage = (pathname: string) =>
+  pathname.toLowerCase().startsWith(loginPath);
+
+const currentReturnTo = () =>
+  `${window.location.pathname}${window.location.search}${window.location.hash}`;
+
+const redirectAnonymousUser = () => {
+  if (isLoginPage(window.location.pathname)) return;
+
+  const returnTo = currentReturnTo();
+  history.replace(`${loginPath}?returnTo=${encodeURIComponent(returnTo)}`);
+};
+
+const getSafeReturnTo = () => {
+  const requested = new URLSearchParams(window.location.search).get('returnTo');
+  if (!requested) return '/';
+
+  const destination = new URL(requested, window.location.origin);
+  if (
+    destination.origin !== window.location.origin ||
+    isLoginPage(destination.pathname)
+  ) {
+    return '/';
+  }
+  return `${destination.pathname}${destination.search}${destination.hash}`;
+};
 
 export const toCurrentUser = (user: API.CurrentUserVO): API.CurrentUser => ({
   ...user,
@@ -33,30 +59,26 @@ export async function getInitialState(): Promise<{
   settings?: Partial<LayoutSettings>;
   currentUser?: API.CurrentUser;
   loading?: boolean;
+  currentProject?: unknown;
+  securityProject?: unknown;
   fetchUserInfo?: () => Promise<API.CurrentUser | undefined>;
 }> {
   const fetchUserInfo = async () => {
     try {
-      const msg = await HttpUtils.get<API.CurrentUserVO>(currentUserPath);
-
-      return msg.data ? toCurrentUser(msg.data) : undefined;
+      return toCurrentUser(await getCurrentUser());
     } catch (_error) {
-      history.push(loginPath);
+      redirectAnonymousUser();
     }
     return undefined;
   };
-  // 如果不是登录页面，执行
-  const { location } = history;
-  if (![loginPath, '/login'].includes(location.pathname)) {
-    const currentUser = await fetchUserInfo();
-    return {
-      fetchUserInfo,
-      currentUser,
-      settings: defaultSettings as Partial<LayoutSettings>,
-    };
+  // Always probe the cookie-backed Session, including after a reload on login.
+  const currentUser = await fetchUserInfo();
+  if (currentUser && isLoginPage(window.location.pathname)) {
+    history.replace(getSafeReturnTo());
   }
   return {
     fetchUserInfo,
+    currentUser,
     settings: defaultSettings as Partial<LayoutSettings>,
   };
 }
@@ -91,10 +113,9 @@ export const layout: RunTimeLayoutConfig = ({
     footerRender: () => <Footer />,
     onPageChange: () => {
       const { location } = history;
-      console.log(initialState?.currentUser);
       // 如果没有登录，重定向到 login
       if (!initialState?.currentUser && location.pathname !== loginPath) {
-        history.push(loginPath);
+        redirectAnonymousUser();
       }
     },
     bgLayoutImgList: [

--- a/yak-ops-ui/src/components/RightContent/AvatarDropdown.tsx
+++ b/yak-ops-ui/src/components/RightContent/AvatarDropdown.tsx
@@ -1,5 +1,6 @@
-import { useModel } from '@umijs/max';
+import { history, useModel } from '@umijs/max';
 import { createStyles } from 'antd-style';
+import { logout } from '@/services/security/account';
 
 import React, { useEffect, useRef, useState } from 'react';
 import './index.less';
@@ -117,7 +118,28 @@ export const AvatarDropdown: React.FC<GlobalHeaderRightProps> = ({
   children,
 }) => {
   const [open, setOpen] = useState(false);
+  const [loggingOut, setLoggingOut] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
+  const { setInitialState } = useModel('@@initialState');
+
+  const handleLogout = async () => {
+    if (loggingOut) return;
+    setLoggingOut(true);
+    try {
+      await logout();
+    } finally {
+      // Identity, grants and the selected Security project only live in memory.
+      // Clear them even if the server has already invalidated the Session.
+      await setInitialState((state) => ({
+        ...state,
+        currentUser: undefined,
+        currentProject: undefined,
+        securityProject: undefined,
+      }));
+      history.replace('/login');
+      setLoggingOut(false);
+    }
+  };
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
@@ -165,7 +187,7 @@ export const AvatarDropdown: React.FC<GlobalHeaderRightProps> = ({
         className={`
     absolute right-0 top-[calc(100%+14px)]
     z-[1000]
-    flex h-[64px] w-[220px]
+    flex min-h-[64px] w-[220px]
     items-center justify-center
     rounded-[14px]
     border border-[#d1d5db]
@@ -190,13 +212,15 @@ export const AvatarDropdown: React.FC<GlobalHeaderRightProps> = ({
           "
         />
 
-        {/* 一行排列：文字 + 表情 */}
-        <div className="relative z-10 inline-flex flex-row items-center justify-center gap-2 whitespace-nowrap">
-          <span className="text-[15px] font-semibold text-[#475569]">
-            来了你还想走？
-          </span>
+        <button
+          type="button"
+          className="relative z-10 inline-flex cursor-pointer flex-row items-center justify-center gap-2 whitespace-nowrap border-0 bg-transparent text-[15px] font-semibold text-[#475569]"
+          disabled={loggingOut}
+          onClick={handleLogout}
+        >
+          <span>{loggingOut ? '正在退出…' : '退出登录'}</span>
           <PixelCheekyFace />
-        </div>
+        </button>
       </div>
     </div>
   );

--- a/yak-ops-ui/src/pages/login/LoginPanel.tsx
+++ b/yak-ops-ui/src/pages/login/LoginPanel.tsx
@@ -4,9 +4,10 @@ import {App, Button, Checkbox, Form, Input} from "antd";
 import {useForm} from "antd/es/form/Form";
 import React, {useRef, useState} from "react";
 import {flushSync} from "react-dom";
+import {login} from "@/services/security/account";
+import {resetAuthenticationFailure} from "@/utils/request";
 import GoogleLoginButton from "./components/GoogleLoginButton";
 import "./index.less";
-import {loginApi} from "./type";
 
 type ActionType =
   | "BLINK"
@@ -61,40 +62,47 @@ export default function LoginPanel({
     }
   };
 
-  const redirectToHome = () => {
+  const redirectAfterLogin = () => {
     const urlParams = new URL(window.location.href).searchParams;
-    window.location.href = urlParams.get("redirect") || "/";
+    const requested = urlParams.get("returnTo");
+
+    if (requested) {
+      const destination = new URL(requested, window.location.origin);
+      if (destination.origin === window.location.origin &&
+        !destination.pathname.toLowerCase().startsWith("/login")) {
+        window.location.assign(
+          `${destination.pathname}${destination.search}${destination.hash}`
+        );
+        return;
+      }
+    }
+
+    window.location.assign("/");
   };
 
-  const handleAccountLogin = async (values: API.LoginParams) => {
+  const handleAccountLogin = async (values: {
+    userName: string;
+    userPassword: string;
+  }) => {
     try {
       await form.validateFields();
       setLoading(true);
 
-      const data = await loginApi.login({
-        ...values,
-        type: "account",
-      });
+      await login(values);
+      resetAuthenticationFailure();
+      message.success(
+        intl.formatMessage({
+          id: "pages.login.success",
+          defaultMessage: "登录成功！",
+        })
+      );
 
-      if (data?.code === 0) {
-        message.success(
-          intl.formatMessage({
-            id: "pages.login.success",
-            defaultMessage: "登录成功！",
-          })
-        );
+      onFieldFocusChange?.(null);
+      onFire("THANKS");
 
-        onFieldFocusChange?.(null);
-        onFire("THANKS");
-
-        await fetchUserInfo();
-        redirectToHome();
-
-        return;
-      }
-
-      onFire("TILT");
-    } catch (error) {
+      await fetchUserInfo();
+      redirectAfterLogin();
+    } catch (_error) {
       onFire("SHAKE");
     } finally {
       setLoading(false);
@@ -106,7 +114,7 @@ export default function LoginPanel({
     onFire("THANKS");
 
     await fetchUserInfo();
-    redirectToHome();
+    redirectAfterLogin();
   };
 
   return (

--- a/yak-ops-ui/src/services/security/account.ts
+++ b/yak-ops-ui/src/services/security/account.ts
@@ -1,0 +1,27 @@
+import HttpUtils from "@/utils/HttpUtils";
+
+/**
+ * Yak Security AccountController contract.
+ *
+ * Authentication is backed by the server-side HTTP session. The shared
+ * request client sends cookies with `credentials: "include"`; no bearer token
+ * is returned or stored by this module.
+ */
+const ACCOUNT_API = "/yak-security/api/v1/account";
+
+/** AccountController's unauthenticated business/HTTP code. */
+export const ACCOUNT_UNAUTHENTICATED_CODE = 401;
+
+export type AccountLoginDTO = {
+  userName: string;
+  userPassword: string;
+};
+
+export const login = (body: AccountLoginDTO): Promise<void> =>
+  HttpUtils.postData<void>(`${ACCOUNT_API}/login`, body);
+
+export const getCurrentUser = (): Promise<API.CurrentUserVO> =>
+  HttpUtils.getData<API.CurrentUserVO>(`${ACCOUNT_API}/current`);
+
+export const logout = (): Promise<void> =>
+  HttpUtils.postData<void>(`${ACCOUNT_API}/logout`);

--- a/yak-ops-ui/src/utils/request.tsx
+++ b/yak-ops-ui/src/utils/request.tsx
@@ -99,11 +99,17 @@ export class BizError extends Error {
 
 export const goLogin = () => {
   if (!window.location.pathname.toLowerCase().startsWith("/login")) {
-    history.push("/login");
+    const returnTo = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+    history.replace(`/login?returnTo=${encodeURIComponent(returnTo)}`);
   }
 };
 
 let authenticationFailureHandled = false;
+
+/** Re-arm expiry handling only after a new Session has been established. */
+export const resetAuthenticationFailure = () => {
+  authenticationFailureHandled = false;
+};
 
 /** HTTP 401、业务未登录码与 Session 失效的唯一处理出口。 */
 export const handleAuthenticationFailure = () => {
@@ -121,11 +127,6 @@ export const handleAuthenticationFailure = () => {
   });
   goLogin();
 
-  // Keep concurrent failures in the same request burst deduplicated. Resetting
-  // later still allows a future expired session to be reported without reload.
-  window.setTimeout(() => {
-    authenticationFailureHandled = false;
-  }, 1500);
 };
 
 /** 唯一错误出口 */


### PR DESCRIPTION
### Motivation

- Centralize Yak Security account operations (login / current user / logout) behind a typed service to avoid scattering controller paths and DTO construction in pages.
- Restore the server-side cookie-backed Session at startup and preserve a validated same-origin `returnTo` for anonymous users so redirects are safe and predictable.
- Make session-expiry handling one-shot (deduplicated) and keep identity/permissions in memory only, avoiding JWT usage and persisting auth state to `localStorage`.

### Description

- Add `src/services/security/account.ts` which implements typed `login`, `getCurrentUser`, and `logout` against `/yak-security/api/v1/account` and documents the HTTP-session-backed contract. 
- Update `src/app.tsx` to probe the cookie-backed Session at startup via `getCurrentUser`, to record a same-origin `returnTo`, and to redirect anonymous users to `/login?returnTo=...` (with a safe validator `getSafeReturnTo`).
- Update `src/pages/login/LoginPanel.tsx` to call the centralized `login` service, reset expiry handling after a successful login, refresh the current user from the server, and navigate using the validated `returnTo` instead of composing API URLs in-page. 
- Update `src/utils/request.tsx` to deduplicate session-expiry notifications and replace immediate rearming with an explicit `resetAuthenticationFailure` API that is invoked after a successful login. 
- Update `src/components/RightContent/AvatarDropdown.tsx` to call the centralized `logout`, clear in-memory identity, project and security context via `setInitialState`, and then navigate to the login page; the implementation avoids persisting identity/permissions in `localStorage` and avoids JWT use.

### Testing

- Ran repository checks with `git diff --check` and staged/committed the changes; commit created: `feat(ui): implement security session lifecycle` (succeeded).
- Ran unit/test runner with `yarn jest --runInBand --passWithNoTests` which completed successfully (no failing tests).
- Type-check with `yarn tsc` is blocked in this environment due to `TS2688` from an incomplete `@types/minimatch` package; TypeScript reported the missing type-definition error.
- Ran `yarn biome check` and observed pre-existing lint/format warnings in legacy files; the new `src/services/security` path is excluded by the repository Biome configuration so no fixes were applied to the new file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a661f6b874c832696b15b310ee0616c)