### PR TITLE
feat(ui): unify permission-aware routing and controls

### DIFF
--- a/yak-ops-ui/src/access.ts
+++ b/yak-ops-ui/src/access.ts
@@ -1,3 +1,9 @@
+import {
+  hasAllPermissions as checkAllPermissions,
+  hasAnyPermission as checkAnyPermission,
+  hasPermission as checkPermission,
+} from '@/utils/security/permission';
+
 /**
  * @see https://umijs.org/docs/max/access#access
  * */
@@ -5,7 +11,20 @@ export default function access(
   initialState: { currentUser?: API.CurrentUser } | undefined,
 ) {
   const { currentUser } = initialState ?? {};
+  const permissionCodes = currentUser?.permissionCodes ?? [];
   return {
-    canAdmin: currentUser && currentUser.access === 'admin',
+    canAdmin: Boolean(currentUser && currentUser.access === 'admin'),
+    hasPermission: (permission: string) =>
+      checkPermission(permissionCodes, permission),
+    hasAnyPermission: (permissions: readonly string[]) =>
+      checkAnyPermission(permissionCodes, permissions),
+    hasAllPermissions: (permissions: readonly string[]) =>
+      checkAllPermissions(permissionCodes, permissions),
   };
 }
+
+export {
+  hasAllPermissions,
+  hasAnyPermission,
+  hasPermission,
+} from '@/utils/security/permission';

--- a/yak-ops-ui/src/components/security/PermissionGuard/index.tsx
+++ b/yak-ops-ui/src/components/security/PermissionGuard/index.tsx
@@ -1,0 +1,40 @@
+import { useModel } from '@umijs/max';
+import type { ReactNode } from 'react';
+import {
+  satisfiesPermissionRequirement,
+  type PermissionRequirement,
+} from '@/utils/security/permission';
+
+export interface PermissionGuardProps extends PermissionRequirement {
+  children: ReactNode;
+  fallback?: ReactNode;
+  /** Primarily useful for isolated components and tests. */
+  permissionCodes?: readonly string[];
+}
+
+/**
+ * Hides UI that the current user cannot operate. This is not a security
+ * boundary: the corresponding backend endpoint must still enforce permission.
+ */
+export default function PermissionGuard({
+  children,
+  fallback = null,
+  permissionCodes,
+  permission,
+  anyPermissions,
+  allPermissions,
+  permissions,
+  permissionMode,
+}: PermissionGuardProps) {
+  const { initialState } = useModel('@@initialState');
+  const granted = permissionCodes ?? initialState?.currentUser?.permissionCodes;
+  const allowed = satisfiesPermissionRequirement(granted, {
+    permission,
+    anyPermissions,
+    allPermissions,
+    permissions,
+    permissionMode,
+  });
+
+  return <>{allowed ? children : fallback}</>;
+}

--- a/yak-ops-ui/src/components/security/RouteAccessBoundary/index.tsx
+++ b/yak-ops-ui/src/components/security/RouteAccessBoundary/index.tsx
@@ -1,0 +1,39 @@
+import { getRouteMetadata, canAccessNavigationRoute, type NavigationRoute } from '@/config/navigation';
+import { Result } from 'antd';
+import { useLocation, useModel } from '@umijs/max';
+import type { ReactNode } from 'react';
+
+export interface RouteAccessBoundaryProps {
+  children: ReactNode;
+  fallback?: ReactNode;
+  route?: NavigationRoute;
+  /** Primarily useful for isolated components and tests. */
+  permissionCodes?: readonly string[];
+}
+
+const defaultFallback = (
+  <Result
+    status="403"
+    title="403"
+    subTitle="抱歉，您没有权限访问此页面。"
+  />
+);
+
+/**
+ * Blocks rendering for inaccessible route metadata. It complements, but never
+ * replaces, authorization checks on every backend API endpoint.
+ */
+export default function RouteAccessBoundary({
+  children,
+  fallback = defaultFallback,
+  route,
+  permissionCodes,
+}: RouteAccessBoundaryProps) {
+  const location = useLocation();
+  const { initialState } = useModel('@@initialState');
+  const metadata = route ?? getRouteMetadata(location.pathname);
+  const granted = permissionCodes ?? initialState?.currentUser?.permissionCodes;
+  const allowed = !metadata || canAccessNavigationRoute(metadata, granted);
+
+  return <>{allowed ? children : fallback}</>;
+}

--- a/yak-ops-ui/src/components/security/index.ts
+++ b/yak-ops-ui/src/components/security/index.ts
@@ -1,0 +1,4 @@
+export { default as PermissionGuard } from './PermissionGuard';
+export type { PermissionGuardProps } from './PermissionGuard';
+export { default as RouteAccessBoundary } from './RouteAccessBoundary';
+export type { RouteAccessBoundaryProps } from './RouteAccessBoundary';

--- a/yak-ops-ui/src/config/navigation.test.ts
+++ b/yak-ops-ui/src/config/navigation.test.ts
@@ -1,0 +1,24 @@
+import {
+  canAccessNavigationRoute,
+  getActiveNavigationId,
+  type NavigationRoute,
+} from './navigation';
+
+describe('permission-aware navigation', () => {
+  it('uses route permission metadata for route decisions', () => {
+    const route: NavigationRoute = {
+      id: 'protected-test-route',
+      path: '/protected-test-route',
+      title: 'Protected',
+      component: './protected',
+      anyPermissions: ['protected:read', 'protected:admin'],
+    };
+
+    expect(canAccessNavigationRoute(route, ['protected:read'])).toBe(true);
+    expect(canAccessNavigationRoute(route, ['unrelated:read'])).toBe(false);
+  });
+
+  it('does not activate a route whose metadata denies access', () => {
+    expect(getActiveNavigationId('/home', [])).toBe('home');
+  });
+});

--- a/yak-ops-ui/src/config/navigation.ts
+++ b/yak-ops-ui/src/config/navigation.ts
@@ -1,3 +1,8 @@
+import {
+  satisfiesPermissionRequirement,
+  type PermissionRequirement,
+} from '@/utils/security/permission';
+
 export type NavigationIconKey =
   | 'home'
   | 'database'
@@ -24,7 +29,7 @@ export type NavigationIconKey =
  */
 export type NavigationSectionKey = 'task' | 'management';
 
-export interface NavigationRoute {
+export interface NavigationRoute extends PermissionRequirement {
   id: string;
   path: string;
   title: string;
@@ -403,6 +408,30 @@ const routeMap = new Map(
   appRoutes.map((route) => [route.id, route]),
 );
 
+/**
+ * Applies the same permission decision to routes and their parent navigation
+ * item. This prevents a permitted child from activating an inaccessible parent.
+ */
+export const canAccessNavigationRoute = (
+  route: NavigationRoute,
+  permissionCodes: readonly string[] | null | undefined,
+) => {
+  const visited = new Set<string>();
+  let candidate: NavigationRoute | undefined = route;
+
+  while (candidate && !visited.has(candidate.id)) {
+    visited.add(candidate.id);
+    if (!satisfiesPermissionRequirement(permissionCodes, candidate)) {
+      return false;
+    }
+    candidate = candidate.parentId
+      ? routeMap.get(candidate.parentId)
+      : undefined;
+  }
+
+  return true;
+};
+
 const normalizePath = (path: string) =>
   path.split(/[?#]/, 1)[0].replace(/\/+$/, '') || '/';
 
@@ -437,16 +466,22 @@ export const getRouteMetadata = (
 
 export const getActiveNavigationId = (
   pathname: string,
+  permissionCodes?: readonly string[] | null,
 ) => {
   const route = getRouteMetadata(pathname);
 
-  return route?.parentId ?? route?.id;
+  if (!route || !canAccessNavigationRoute(route, permissionCodes)) {
+    return undefined;
+  }
+
+  return route.parentId ?? route.id;
 };
 
 export const getActiveNavigationGroupId = (
   pathname: string,
+  permissionCodes?: readonly string[] | null,
 ) => {
-  const activeId = getActiveNavigationId(pathname);
+  const activeId = getActiveNavigationId(pathname, permissionCodes);
 
   return activeId
     ? routeMap.get(activeId)?.menuGroup
@@ -456,12 +491,15 @@ export const getActiveNavigationGroupId = (
 /**
  * 首页等独立一级菜单。
  */
-export const getStandaloneNavigationRoutes = () =>
+export const getStandaloneNavigationRoutes = (
+  permissionCodes?: readonly string[] | null,
+) =>
   appRoutes
     .filter(
       (route) =>
         !route.hidden &&
-        !route.menuGroup,
+        !route.menuGroup &&
+        canAccessNavigationRoute(route, permissionCodes),
     )
     .sort(sortByOrder);
 
@@ -469,7 +507,9 @@ export const getStandaloneNavigationRoutes = () =>
  * 分组菜单。
  */
 export const getMainNavigationGroups =
-  (): NavigationGroupWithRoutes[] =>
+  (
+    permissionCodes?: readonly string[] | null,
+  ): NavigationGroupWithRoutes[] =>
     [...navigationGroups]
       .sort(sortByOrder)
       .map((group) => ({
@@ -478,7 +518,8 @@ export const getMainNavigationGroups =
           .filter(
             (route) =>
               !route.hidden &&
-              route.menuGroup === group.id,
+              route.menuGroup === group.id &&
+              canAccessNavigationRoute(route, permissionCodes),
           )
           .sort(sortByOrder),
       }))
@@ -490,10 +531,13 @@ export const getMainNavigationGroups =
 /**
  * 快速创建下拉菜单。
  */
-export const getQuickCreateRoutes = () =>
+export const getQuickCreateRoutes = (
+  permissionCodes?: readonly string[] | null,
+) =>
   appRoutes
     .filter(
       (route) =>
-        Boolean(route.quickCreateLabel),
+        Boolean(route.quickCreateLabel) &&
+        canAccessNavigationRoute(route, permissionCodes),
     )
     .sort(sortByOrder);

--- a/yak-ops-ui/src/layouts/SiteLayout/index.tsx
+++ b/yak-ops-ui/src/layouts/SiteLayout/index.tsx
@@ -8,6 +8,7 @@ import {
   type NavigationIconKey,
   type NavigationRoute,
 } from "@/config/navigation";
+import { RouteAccessBoundary } from "@/components/security";
 import { history, Outlet, useLocation, useModel } from "@umijs/max";
 import {
   Activity,
@@ -142,23 +143,6 @@ const navigationIcons: Record<NavigationIconKey, ReactNode> = {
   ),
 };
 
-const standaloneRoutes = getStandaloneNavigationRoutes();
-const navigationGroups = getMainNavigationGroups();
-const quickCreateRoutes = getQuickCreateRoutes();
-
-/**
- * 首页单独作为第一菜单区域。
- */
-const homeRoutes = standaloneRoutes.filter((route) => route.id === "home");
-
-/**
- * 数据源管理等业务一级菜单，
- * 显示在首页分割线之后、数据集成之前。
- */
-const businessStandaloneRoutes = standaloneRoutes.filter(
-  (route) => route.id !== "home"
-);
-
 interface HeaderActionProps {
   icon: ReactNode;
   label: string;
@@ -267,6 +251,16 @@ function BrandLogo({ compact }: { compact: boolean }) {
 export default function SiteLayout() {
   const location = useLocation();
   const { initialState } = useModel("@@initialState");
+  const currentUser = initialState?.currentUser;
+  const permissionCodes = currentUser?.permissionCodes;
+
+  const standaloneRoutes = getStandaloneNavigationRoutes(permissionCodes);
+  const navigationGroups = getMainNavigationGroups(permissionCodes);
+  const quickCreateRoutes = getQuickCreateRoutes(permissionCodes);
+  const homeRoutes = standaloneRoutes.filter((route) => route.id === "home");
+  const businessStandaloneRoutes = standaloneRoutes.filter(
+    (route) => route.id !== "home"
+  );
 
   const quickCreateRef = useRef<HTMLDivElement>(null);
 
@@ -318,7 +312,10 @@ export default function SiteLayout() {
    * 因此这里不再使用单个 openGroupId。
    */
   const [openGroupIds, setOpenGroupIds] = useState<Set<string>>(() => {
-    const activeGroupId = getActiveNavigationGroupId(location.pathname);
+    const activeGroupId = getActiveNavigationGroupId(
+      location.pathname,
+      permissionCodes
+    );
 
     return activeGroupId ? new Set([activeGroupId]) : new Set();
   });
@@ -340,7 +337,10 @@ export default function SiteLayout() {
   }, []);
 
   useEffect(() => {
-    const activeGroupId = getActiveNavigationGroupId(location.pathname);
+    const activeGroupId = getActiveNavigationGroupId(
+      location.pathname,
+      permissionCodes
+    );
 
     if (!activeGroupId) {
       return;
@@ -356,7 +356,7 @@ export default function SiteLayout() {
 
       return next;
     });
-  }, [location.pathname]);
+  }, [location.pathname, permissionCodes]);
 
   useEffect(() => {
     setQuickCreateOpen(false);
@@ -382,13 +382,14 @@ export default function SiteLayout() {
 
   const sidebarWidth = compact ? COLLAPSED_SIDEBAR_WIDTH : SIDEBAR_WIDTH;
 
-  const activeNavigationId = getActiveNavigationId(location.pathname);
+  const activeNavigationId = getActiveNavigationId(
+    location.pathname,
+    permissionCodes
+  );
 
   const routeMetadata = getRouteMetadata(location.pathname);
 
   const pageTitle = routeMetadata?.title ?? "Yak Ops";
-
-  const currentUser = initialState?.currentUser;
 
   const userInitial = useMemo(() => {
     return currentUser?.name?.trim().slice(0, 1).toUpperCase() || "Y";
@@ -953,7 +954,9 @@ export default function SiteLayout() {
               bg-white
             "
           >
-            <Outlet />
+            <RouteAccessBoundary permissionCodes={permissionCodes}>
+              <Outlet />
+            </RouteAccessBoundary>
           </div>
         </div>
       </main>

--- a/yak-ops-ui/src/utils/security/permission.test.ts
+++ b/yak-ops-ui/src/utils/security/permission.test.ts
@@ -1,0 +1,38 @@
+import {
+  hasAllPermissions,
+  hasAnyPermission,
+  hasPermission,
+  satisfiesPermissionRequirement,
+} from './permission';
+
+describe('permission helpers', () => {
+  const granted = ['task:read', 'task:create'];
+
+  it('checks a single permission', () => {
+    expect(hasPermission(granted, 'task:read')).toBe(true);
+    expect(hasPermission(granted, 'task:delete')).toBe(false);
+  });
+
+  it('checks any and all permissions with explicit empty-set semantics', () => {
+    expect(hasAnyPermission(granted, ['task:delete', 'task:create'])).toBe(true);
+    expect(hasAnyPermission(granted, [])).toBe(false);
+    expect(hasAllPermissions(granted, ['task:read', 'task:create'])).toBe(true);
+    expect(hasAllPermissions(granted, [])).toBe(true);
+  });
+
+  it('combines configured requirement types with AND', () => {
+    expect(
+      satisfiesPermissionRequirement(granted, {
+        permission: 'task:read',
+        anyPermissions: ['task:create', 'task:delete'],
+        allPermissions: ['task:read', 'task:create'],
+      }),
+    ).toBe(true);
+    expect(
+      satisfiesPermissionRequirement(granted, {
+        permission: 'task:read',
+        anyPermissions: [],
+      }),
+    ).toBe(false);
+  });
+});

--- a/yak-ops-ui/src/utils/security/permission.ts
+++ b/yak-ops-ui/src/utils/security/permission.ts
@@ -1,0 +1,63 @@
+export type PermissionCode = string;
+
+export interface PermissionRequirement {
+  /** A permission that must be present. */
+  permission?: PermissionCode;
+  /** At least one of these permissions must be present. */
+  anyPermissions?: readonly PermissionCode[];
+  /** Every one of these permissions must be present. */
+  allPermissions?: readonly PermissionCode[];
+  /** A compact route-friendly list, evaluated using permissionMode. */
+  permissions?: readonly PermissionCode[];
+  permissionMode?: 'any' | 'all';
+}
+
+type GrantedPermissions = readonly PermissionCode[] | null | undefined;
+
+const permissionSet = (permissions: GrantedPermissions) =>
+  new Set(permissions ?? []);
+
+export const hasPermission = (
+  permissions: GrantedPermissions,
+  permission: PermissionCode,
+): boolean => permission.length > 0 && permissionSet(permissions).has(permission);
+
+export const hasAnyPermission = (
+  permissions: GrantedPermissions,
+  requiredPermissions: readonly PermissionCode[],
+): boolean => {
+  if (requiredPermissions.length === 0) return false;
+
+  const granted = permissionSet(permissions);
+  return requiredPermissions.some((permission) => granted.has(permission));
+};
+
+export const hasAllPermissions = (
+  permissions: GrantedPermissions,
+  requiredPermissions: readonly PermissionCode[],
+): boolean => {
+  const granted = permissionSet(permissions);
+  return requiredPermissions.every((permission) => granted.has(permission));
+};
+
+/**
+ * Evaluates every configured constraint. An empty requirement is public; when
+ * multiple constraint types are supplied they are combined with AND.
+ *
+ * This browser-side result only controls presentation and interaction. The API
+ * serving the protected operation must independently authorize every request.
+ */
+export const satisfiesPermissionRequirement = (
+  permissions: GrantedPermissions,
+  requirement: PermissionRequirement,
+): boolean =>
+  (!requirement.permission ||
+    hasPermission(permissions, requirement.permission)) &&
+  (!requirement.anyPermissions ||
+    hasAnyPermission(permissions, requirement.anyPermissions)) &&
+  (!requirement.allPermissions ||
+    hasAllPermissions(permissions, requirement.allPermissions)) &&
+  (!requirement.permissions ||
+    (requirement.permissionMode === 'all'
+      ? hasAllPermissions(permissions, requirement.permissions)
+      : hasAnyPermission(permissions, requirement.permissions)));


### PR DESCRIPTION
### Motivation

- Centralize permission logic so routes, menus, quick-create actions and parent activation share a single decision predicate. 
- Provide presentation-level guards to hide or replace UI elements when the current user lacks permissions while making clear that backend APIs must still enforce authorization.

### Description

- Add reusable permission helpers in `src/utils/security/permission.ts` implementing `hasPermission`, `hasAnyPermission`, `hasAllPermissions` and `satisfiesPermissionRequirement` (supports `permission`, `anyPermissions`, `allPermissions`, and `permissions + permissionMode`).
- Expose user-bound helpers from the runtime access model in `src/access.ts` (`hasPermission`, `hasAnyPermission`, `hasAllPermissions`) backed by the new utils.
- Extend `NavigationRoute` metadata with permission fields and add a single route predicate `canAccessNavigationRoute` in `src/config/navigation.ts`, then drive `getStandaloneNavigationRoutes`, `getMainNavigationGroups`, `getQuickCreateRoutes`, and active-id/group-id logic with the same predicate.
- Add `PermissionGuard` (component-level visibility control) and `RouteAccessBoundary` (route-level 403 rendering) under `src/components/security/` and wire `SiteLayout` to generate menus/quick-create lists with `permissionCodes` and to wrap the route outlet with `RouteAccessBoundary`.
- Include focused unit tests for permission helpers and navigation decisions in `src/utils/security/permission.test.ts` and `src/config/navigation.test.ts`.

### Testing

- Ran lint across affected files with `yarn biome:lint src/access.ts src/utils/security src/config/navigation.ts src/config/navigation.test.ts src/components/security src/layouts/SiteLayout/index.tsx` which succeeded.
- Ran TypeScript check with `yarn tsc` which failed in this environment due to a missing implicit type library (`minimatch`) and prevented a full project type-check pass.
- Ran Jest for the new tests with `yarn jest src/utils/security/permission.test.ts src/config/navigation.test.ts --runInBand` which did not run to completion because Jest in this environment fails while parsing the existing Umi configuration; tests are included and expected to pass when run in a standard developer environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6620d20f0083268fec69eb9efa1a03)