### PR TITLE
feat(proxy): route Yak Security through Yak Ops

### DIFF
--- a/yak-ops-dist/src/main/conf/nginx/default.conf
+++ b/yak-ops-dist/src/main/conf/nginx/default.conf
@@ -37,6 +37,32 @@ server {
         proxy_redirect off;
     }
 
+    # Yak Security API. The trailing slash strips /yak-security/ upstream.
+    location /yak-security/ {
+        proxy_pass http://yak-ops-api:9527/;
+
+        proxy_http_version 1.1;
+
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Forwarded-Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # Keep the session on the public host and security route. SameSite=Lax
+        # is suitable because browser requests stay same-origin through nginx.
+        proxy_cookie_domain ~.+ $host;
+        proxy_cookie_path / /yak-security/;
+        proxy_cookie_flags ~ samesite=lax;
+
+        proxy_connect_timeout 60s;
+        proxy_send_timeout 3600s;
+        proxy_read_timeout 3600s;
+
+        proxy_buffering off;
+        proxy_redirect off;
+    }
+
     # STOMP / SockJS / WebSocket
     location /ws {
         proxy_pass http://yak-ops-api:9527;

--- a/yak-ops-dist/src/main/conf/nginx/production.conf.example
+++ b/yak-ops-dist/src/main/conf/nginx/production.conf.example
@@ -50,6 +50,30 @@ server {
         proxy_redirect off;
     }
 
+    # The trailing slash strips the ingress-only /yak-security/ prefix.
+    location /yak-security/ {
+        limit_req zone=api_limit burst=120 nodelay;
+        proxy_pass http://yak-ops-api:9527/;
+        proxy_http_version 1.1;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Forwarded-Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # Rewrite an explicit upstream Domain to this public host and keep the
+        # cookie off unrelated routes. SameSite=Lax supports this same-origin flow.
+        proxy_cookie_domain ~.+ $host;
+        proxy_cookie_path / /yak-security/;
+        proxy_cookie_flags ~ samesite=lax secure;
+
+        proxy_connect_timeout 30s;
+        proxy_send_timeout 300s;
+        proxy_read_timeout 300s;
+        proxy_buffering off;
+        proxy_redirect off;
+    }
+
     location /ws {
         proxy_pass http://yak-ops-api:9527;
         proxy_http_version 1.1;

--- a/yak-ops-ui/config/proxy.ts
+++ b/yak-ops-ui/config/proxy.ts
@@ -17,13 +17,24 @@ export default {
       changeOrigin: true,
       pathRewrite: { '^/api': '/api' },
     },
+    // Keep security calls same-origin in development. The prefix is an ingress
+    // concern, so the local backend receives (for example) /api/v1/account.
+    '/yak-security/': {
+      target: 'http://localhost:9527',
+      changeOrigin: true,
+      pathRewrite: { '^/yak-security': '' },
+      // Do not leak an upstream Domain, and scope its session to this ingress.
+      // The backend remains responsible for HttpOnly/Secure and SameSite=Lax.
+      cookieDomainRewrite: '',
+      cookiePathRewrite: { '*': '/yak-security/' },
+    },
     '/profile/avatar/': {
       changeOrigin: true,
       target: 'http://localhost:80',
     },
   },
   '/api/': {
-      test: {
+    test: {
       target: 'http://localhost:80',
       changeOrigin: true,
       pathRewrite: { '^': '' },


### PR DESCRIPTION
### Motivation

- Provide a development-only same-origin proxy for `/yak-security/` so the UI can call the local Yak Ops backend on port `9527` without relying on a separate upstream or embedding the ingress prefix in the frontend build.
- Ensure session cookies issued by the security backend are scoped and normalized at the proxy boundary (domain/path/SameSite) so browser session semantics are consistent through the public ingress route.
- Preserve SPA fallback behavior so front-end routing remains unaffected by the new security route.

### Description

- Add a development proxy entry in `yak-ops-ui/config/proxy.ts` for `'/yak-security/'` that forwards to `http://localhost:9527`, strips the ingress prefix with `pathRewrite`, and rewrites cookie domain/path via `cookieDomainRewrite` and `cookiePathRewrite`.
- Add a `location /yak-security/` block to `yak-ops-dist/src/main/conf/nginx/default.conf` that forwards requests to `http://yak-ops-api:9527/` (trailing slash to strip prefix), forwards standard proxy headers, and rewrites cookies with `proxy_cookie_domain`, `proxy_cookie_path`, and `proxy_cookie_flags samesite=lax`.
- Add the same `location /yak-security/` block to `yak-ops-dist/src/main/conf/nginx/production.conf.example` with rate limiting and `proxy_cookie_flags ... secure` for production example configuration.
- Keep existing SPA `try_files $uri /index.html` fallback and WebSocket (`/ws`) and `/api/` proxy behavior unchanged.

### Testing

- Ran `./node_modules/.bin/biome check config/proxy.ts` which completed successfully for the modified file.
- Ran `git diff --check` and `git diff --cached --check` to validate no diff-check issues, both reported no problems.
- Attempted `./node_modules/.bin/tsc --noEmit` but the run failed with `TS2688` due to a missing `minimatch` type definition in the current environment, so a full TypeScript check could not complete.
- Nginx syntax check was skipped because Docker/nginx is not available in this environment, so runtime nginx validation was not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a66254c31e88326bac25f79db2e3b50)