### PR TITLE
feat(ui/http): unify Yak Ops and Security response handling and add Security client

### DIFF
--- a/yak-ops-ui/src/app.tsx
+++ b/yak-ops-ui/src/app.tsx
@@ -2,12 +2,11 @@ import { AvatarDropdown, AvatarName, Footer } from '@/components';
 import type { Settings as LayoutSettings } from '@ant-design/pro-components';
 import { SettingDrawer } from '@ant-design/pro-components';
 import '@ant-design/v5-patch-for-react-19';
-import type { RequestConfig, RunTimeLayoutConfig } from '@umijs/max';
+import type { RunTimeLayoutConfig } from '@umijs/max';
 import { history } from '@umijs/max';
 import 'd3-transition';
 import defaultSettings from '../config/defaultSettings';
 import { GlobalSearch, Knowledge } from './components/RightContent';
-import { errorConfig } from './requestErrorConfig';
 import { getCurrentUser } from './services/security/account';
 import { toCurrentUser } from './services/security/currentIdentity';
 
@@ -157,14 +156,4 @@ export const layout: RunTimeLayoutConfig = ({
     },
     ...initialState?.settings,
   };
-};
-
-/**
- * @name request 配置，可以配置错误处理
- * 它基于 axios 和 ahooks 的 useRequest 提供了一套统一的网络请求和错误处理方案。
- * @doc https://umijs.org/docs/max/request#配置
- */
-export const request: RequestConfig = {
-  baseURL: 'https://proapi.azurewebsites.net',
-  ...errorConfig,
 };

--- a/yak-ops-ui/src/services/http/response.test.ts
+++ b/yak-ops-ui/src/services/http/response.test.ts
@@ -1,0 +1,34 @@
+import {
+  extractErrorMessage,
+  isApiResponse,
+  isSuccessfulResponse,
+  isUnauthenticatedResponse,
+  protocolForUrl,
+} from './response';
+
+describe('API response protocols', () => {
+  it('keeps success codes isolated by namespace', () => {
+    expect(isSuccessfulResponse({ code: 0 }, 'yak-ops')).toBe(true);
+    expect(isSuccessfulResponse({ code: 200 }, 'security')).toBe(true);
+    expect(isSuccessfulResponse({ code: 200 }, 'yak-ops')).toBe(false);
+    expect(isSuccessfulResponse({ code: 0 }, 'security')).toBe(false);
+  });
+
+  it('extracts errors from both envelope variants', () => {
+    expect(extractErrorMessage({ code: 2, msg: 'ops failed' })).toBe('ops failed');
+    expect(extractErrorMessage({ code: 500, message: 'security failed' })).toBe('security failed');
+  });
+
+  it('recognizes business session expiry without treating forbidden as anonymous', () => {
+    expect(isUnauthenticatedResponse({ code: 401 }, 'security')).toBe(true);
+    expect(isUnauthenticatedResponse({ code: 403 }, 'security')).toBe(false);
+    expect(isUnauthenticatedResponse({ code: 9, message: 'session_expired' }, 'security')).toBe(true);
+  });
+
+  it('does not parse arbitrary JSON as an envelope', () => {
+    expect(isApiResponse({ data: { code: 200 } })).toBe(false);
+    expect(protocolForUrl('/yak-security/api/v1/account/current')).toBe('security');
+    expect(protocolForUrl('/api/v1/jobs')).toBe('yak-ops');
+  });
+});
+

--- a/yak-ops-ui/src/services/http/response.ts
+++ b/yak-ops-ui/src/services/http/response.ts
@@ -1,0 +1,54 @@
+export type ApiProtocol = 'yak-ops' | 'security';
+
+export interface ApiResponse<T = unknown> {
+  code: number;
+  data: T;
+  msg?: string;
+  message?: string;
+}
+
+const protocolRules: Record<ApiProtocol, { success: readonly number[]; unauthenticated: readonly number[] }> = {
+  'yak-ops': { success: [0], unauthenticated: [1, 401] },
+  security: { success: [200], unauthenticated: [401] },
+};
+
+const unauthenticatedMessages = new Set([
+  'NOT_LOGIN',
+  'UNAUTHENTICATED',
+  'SESSION_EXPIRED',
+  'SESSION_INVALID',
+]);
+
+export const protocolForUrl = (url?: string): ApiProtocol =>
+  url?.includes('/yak-security/') ? 'security' : 'yak-ops';
+
+export const isApiResponse = (value: unknown): value is ApiResponse => {
+  if (!value || typeof value !== 'object') return false;
+  return typeof (value as Partial<ApiResponse>).code === 'number';
+};
+
+export const isSuccessfulResponse = (
+  response: Partial<ApiResponse> | null | undefined,
+  protocol: ApiProtocol,
+): boolean =>
+  typeof response?.code === 'number' &&
+  protocolRules[protocol].success.includes(response.code);
+
+export const extractErrorMessage = (
+  response: Partial<ApiResponse> | null | undefined,
+  fallback = '操作失败',
+): string => response?.msg?.trim() || response?.message?.trim() || fallback;
+
+export const isUnauthenticatedResponse = (
+  response: Partial<ApiResponse> | null | undefined,
+  protocol: ApiProtocol,
+): boolean => {
+  const message = response?.msg || response?.message;
+  return (
+    (typeof response?.code === 'number' &&
+      protocolRules[protocol].unauthenticated.includes(response.code)) ||
+    (typeof message === 'string' &&
+      unauthenticatedMessages.has(message.trim().toUpperCase()))
+  );
+};
+

--- a/yak-ops-ui/src/services/security/account.ts
+++ b/yak-ops-ui/src/services/security/account.ts
@@ -1,4 +1,4 @@
-import HttpUtils from "@/utils/HttpUtils";
+import { securityGetData, securityPostData } from './client';
 
 /**
  * Yak Security AccountController contract.
@@ -7,7 +7,7 @@ import HttpUtils from "@/utils/HttpUtils";
  * request client sends cookies with `credentials: "include"`; no bearer token
  * is returned or stored by this module.
  */
-const ACCOUNT_API = "/yak-security/api/v1/account";
+const ACCOUNT_API = '/api/v1/account';
 
 /** AccountController's unauthenticated business/HTTP code. */
 export const ACCOUNT_UNAUTHENTICATED_CODE = 401;
@@ -18,10 +18,10 @@ export type AccountLoginDTO = {
 };
 
 export const login = (body: AccountLoginDTO): Promise<void> =>
-  HttpUtils.postData<void>(`${ACCOUNT_API}/login`, body);
+  securityPostData<void>(`${ACCOUNT_API}/login`, body);
 
 export const getCurrentUser = (): Promise<API.CurrentUserVO> =>
-  HttpUtils.getData<API.CurrentUserVO>(`${ACCOUNT_API}/current`);
+  securityGetData<API.CurrentUserVO>(`${ACCOUNT_API}/current`);
 
 export const logout = (): Promise<void> =>
-  HttpUtils.postData<void>(`${ACCOUNT_API}/logout`);
+  securityPostData<void>(`${ACCOUNT_API}/logout`);

--- a/yak-ops-ui/src/services/security/client.ts
+++ b/yak-ops-ui/src/services/security/client.ts
@@ -1,0 +1,45 @@
+import type { ApiResponse } from '@/services/http/response';
+import request from '@/utils/request';
+import type { SecurityProjectContext } from './types/common';
+
+const SECURITY_NAMESPACE = '/yak-security';
+
+export type SecurityRequestOptions = RequestInit & {
+  project?: SecurityProjectContext;
+  skipErrorHandler?: boolean;
+  data?: unknown;
+};
+
+export const securityRequest = <T>(
+  path: string,
+  options: SecurityRequestOptions = {},
+): Promise<ApiResponse<T>> => {
+  const { project, headers: suppliedHeaders, ...requestOptions } = options;
+  const headers = new Headers(suppliedHeaders);
+  if (project) headers.set(project.headerName, String(project.projectId));
+
+  return request<ApiResponse<T>>(`${SECURITY_NAMESPACE}${path}`, {
+    ...requestOptions,
+    headers,
+    credentials: 'include',
+    protocol: 'security',
+  });
+};
+
+export const securityGetData = async <T>(
+  path: string,
+  options?: SecurityRequestOptions,
+): Promise<T> => (await securityRequest<T>(path, { ...options, method: 'GET' })).data;
+
+export const securityPostData = async <T>(
+  path: string,
+  data?: unknown,
+  options?: SecurityRequestOptions,
+): Promise<T> =>
+  (
+    await securityRequest<T>(path, {
+      ...options,
+      method: 'POST',
+      data,
+    })
+  ).data;

--- a/yak-ops-ui/src/services/security/types/common.ts
+++ b/yak-ops-ui/src/services/security/types/common.ts
@@ -1,0 +1,8 @@
+export type SecurityApiResponse<T> = import('@/services/http/response').ApiResponse<T>;
+
+/** Headers are opt-in because only endpoints confirmed in the contract may receive project context. */
+export type SecurityProjectContext = {
+  headerName: string;
+  projectId: string | number;
+};
+

--- a/yak-ops-ui/src/utils/date.ts
+++ b/yak-ops-ui/src/utils/date.ts
@@ -1,0 +1,10 @@
+import dayjs, { type ConfigType, type Dayjs } from 'dayjs';
+
+/** Backend date-time contract: local wall time without an implicit UTC conversion. */
+export const BACKEND_DATE_TIME_FORMAT = 'YYYY-MM-DD HH:mm:ss';
+
+export const parseBackendDateTime = (value: ConfigType): Dayjs => dayjs(value);
+
+export const formatBackendDateTime = (value: ConfigType): string =>
+  dayjs(value).format(BACKEND_DATE_TIME_FORMAT);
+

--- a/yak-ops-ui/src/utils/request.tsx
+++ b/yak-ops-ui/src/utils/request.tsx
@@ -2,6 +2,17 @@
 import { openPrettyNotification } from "@/utils/prettyNotification";
 import { history } from "umi";
 import { extend } from "umi-request";
+import {
+  extractErrorMessage,
+  isApiResponse,
+  isSuccessfulResponse,
+  isUnauthenticatedResponse,
+  protocolForUrl,
+  type ApiProtocol,
+  type ApiResponse,
+} from "@/services/http/response";
+
+export type { ApiProtocol, ApiResponse } from "@/services/http/response";
 
 const codeMessage: Record<number, string> = {
   10000: "系统未知错误，请反馈给管理员",
@@ -22,78 +33,25 @@ const codeMessage: Record<number, string> = {
   504: "网关超时。",
 };
 
-export interface ApiResponse<T = any> {
-  code: number;
-  msg: string;
-  message?: string;
-  data: T;
-}
-
-export type ApiProtocolNamespace = "yak-ops" | "security";
-
-/**
- * Backend response protocols. Keep protocol differences here instead of leaking
- * status-code checks into pages. Yak Security currently uses HTTP-like code 200.
- */
-export const API_PROTOCOLS: Record<
-  ApiProtocolNamespace,
-  { successCodes: readonly number[]; unauthenticatedCodes: readonly number[] }
-> = {
-  "yak-ops": { successCodes: [0], unauthenticatedCodes: [1, 401] },
-  security: { successCodes: [200], unauthenticatedCodes: [1, 401] },
-};
-
-export const getProtocolNamespace = (url?: string): ApiProtocolNamespace =>
-  url?.includes("/yak-security/") ? "security" : "yak-ops";
-
-export const isSuccessfulResponse = (
-  response: Partial<ApiResponse<any>> | null | undefined,
-  namespace: ApiProtocolNamespace = "yak-ops"
-): boolean =>
-  typeof response?.code === "number" &&
-  API_PROTOCOLS[namespace].successCodes.includes(response.code);
-
-export const extractErrorMessage = (
-  response: Partial<ApiResponse<any>> | null | undefined,
-  fallback = "操作失败"
-): string => response?.msg || response?.message || fallback;
-
-const UNAUTHENTICATED_MESSAGES = [
-  "NOT_LOGIN",
-  "UNAUTHENTICATED",
-  "SESSION_EXPIRED",
-  "SESSION_INVALID",
-];
-
-export const isUnauthenticatedResponse = (
-  response: Partial<ApiResponse<any>> | null | undefined,
-  namespace: ApiProtocolNamespace = "yak-ops"
-): boolean => {
-  const message = response?.msg || response?.message;
-  return (
-    (typeof response?.code === "number" &&
-      API_PROTOCOLS[namespace].unauthenticatedCodes.includes(response.code)) ||
-    (typeof message === "string" &&
-      UNAUTHENTICATED_MESSAGES.includes(message.toUpperCase()))
-  );
-};
-
 export class BizError extends Error {
   code?: number;
   response?: ApiResponse<any>;
   skipErrorHandler?: boolean;
+  protocol: ApiProtocol;
 
   constructor(
     message: string,
     code?: number,
     response?: ApiResponse<any>,
-    skipErrorHandler?: boolean
+    skipErrorHandler = false,
+    protocol: ApiProtocol = "yak-ops"
   ) {
     super(message);
     this.name = "BizError";
     this.code = code;
     this.response = response;
     this.skipErrorHandler = skipErrorHandler;
+    this.protocol = protocol;
   }
 }
 
@@ -105,6 +63,18 @@ export const goLogin = () => {
 };
 
 let authenticationFailureHandled = false;
+const recentNotifications = new Map<string, number>();
+
+const notifyOnce = (
+  key: string,
+  notification: Parameters<typeof openPrettyNotification>[0]
+) => {
+  const now = Date.now();
+  const lastShown = recentNotifications.get(key) || 0;
+  if (now - lastShown < 1000) return;
+  recentNotifications.set(key, now);
+  openPrettyNotification(notification);
+};
 
 /** Re-arm expiry handling only after a new Session has been established. */
 export const resetAuthenticationFailure = () => {
@@ -119,7 +89,7 @@ export const handleAuthenticationFailure = () => {
   if (authenticationFailureHandled) return;
 
   authenticationFailureHandled = true;
-  openPrettyNotification({
+  notifyOnce("authentication", {
     type: "warning",
     title: "登录状态失效",
     description: "当前登录信息已过期，请重新登录后继续操作。",
@@ -135,10 +105,10 @@ const errorHandler = (error: any): Response | undefined => {
 
   // 业务异常
   if (error instanceof BizError) {
-    if (isUnauthenticatedResponse(error.response)) {
+    if (isUnauthenticatedResponse(error.response, error.protocol)) {
       handleAuthenticationFailure();
     } else if (!error.skipErrorHandler) {
-      openPrettyNotification({
+      notifyOnce(`business:${error.protocol}:${error.code}:${error.message}`, {
         type: "error",
         title: "操作失败",
         description: error.message || "未知错误",
@@ -160,7 +130,7 @@ const errorHandler = (error: any): Response | undefined => {
 
     const errorText = codeMessage[status] || response.statusText || "请求失败";
 
-    openPrettyNotification({
+    notifyOnce(`http:${status}:${url || ""}`, {
       type: "error",
       title: `请求错误 ${status}`,
       description: (
@@ -186,8 +156,11 @@ const errorHandler = (error: any): Response | undefined => {
     return response;
   }
 
+  // Abort is caller-controlled (navigation, timeout, stale request), not a network fault.
+  if (error?.name === "AbortError" || error?.type === "aborted") throw error;
+
   // 网络异常
-  openPrettyNotification({
+  notifyOnce("network", {
     type: "warning",
     title: "网络异常",
     description: "当前无法连接到服务器，请检查网络或稍后再试。",
@@ -220,6 +193,7 @@ request.interceptors.request.use((url: string, options: any) => {
 
 /** 这里只识别业务异常，不做提示 */
 request.interceptors.response.use(async (response: Response, options: any) => {
+  if (response.status === 204 || options?.responseType === "blob") return response;
   const contentType = response.headers.get("content-type") || "";
 
   if (!contentType.includes("application/json")) {
@@ -227,28 +201,32 @@ request.interceptors.response.use(async (response: Response, options: any) => {
   }
 
   const clonedResponse = response.clone();
-  const res: ApiResponse<any> = await clonedResponse.json();
-  const namespace = getProtocolNamespace(response.url);
+  const res: unknown = await clonedResponse.json();
+  if (!isApiResponse(res)) return response;
+  // Explicit client protocol wins because a reverse proxy may rewrite the URL.
+  const protocol: ApiProtocol = options?.protocol || protocolForUrl(response.url);
 
-  if (isUnauthenticatedResponse(res, namespace)) {
+  if (isUnauthenticatedResponse(res, protocol)) {
     handleAuthenticationFailure();
     throw new BizError(
       extractErrorMessage(res, "登录状态失效"),
       res.code,
       res,
-      true
+      true,
+      protocol
     );
   }
 
   if (
     typeof res?.code !== "undefined" &&
-    !isSuccessfulResponse(res, namespace)
+    !isSuccessfulResponse(res, protocol)
   ) {
     throw new BizError(
       extractErrorMessage(res),
       res.code,
       res,
-      options?.skipErrorHandler
+      options?.skipErrorHandler,
+      protocol
     );
   }
 


### PR DESCRIPTION
### Motivation

- Centralize response protocol rules so pages no longer need to branch on `code===0` vs `code===200` and to keep Yak Security semantics isolated from regular `/api/**` calls.
- Ensure a single, deduplicated authentication failure path for HTTP 401 and business unauthenticated responses so login redirection happens once across concurrent failures.
- Preserve compatibility for non-JSON/204/blob/download responses, and treat caller-initiated aborts (`AbortSignal`) as non-network errors. 
- Provide an opt-in, cookie-backed Security client that can carry a project header only for confirmed Security endpoints.

### Description

- Added a protocol layer in `src/services/http/response.ts` that defines `ApiProtocol`, `ApiResponse`, protocol rules, helpers `isApiResponse`, `isSuccessfulResponse`, `isUnauthenticatedResponse`, and `protocolForUrl`, plus unit tests in `src/services/http/response.test.ts`.
- Refactored the shared request interceptor in `src/utils/request.tsx` to: prefer an explicit client `protocol` option over URL heuristics, avoid parsing non-JSON/204/blob responses, detect and convert business errors into `BizError` with protocol attached, deduplicate notifications via `notifyOnce`, and rethrow caller `AbortError`/`aborted` without showing network notifications.
- Added a namespaced Security client `src/services/security/client.ts` with `securityRequest`, `securityGetData`, and `securityPostData` that always uses `credentials: 'include'`, sets the `protocol: 'security'` for the shared request, and supports an opt-in `project` header type declared in `src/services/security/types/common.ts`.
- Migrated Account session calls in `src/services/security/account.ts` to the new Security client and adjusted the proxied path used by the client to the ingress path (`/api/v1/account`).
- Added backend date-time helpers in `src/utils/date.ts` based on `dayjs` and a canonical format `YYYY-MM-DD HH:mm:ss` for consistent parsing/formatting.
- Removed the example/scaffolded external `request` `baseURL` and token configuration from `src/app.tsx` to avoid conflicting runtime request settings and keep the unified request client authoritative.

### Testing

- Ran linter: `yarn biome:lint src/services/http/response.ts src/services/http/response.test.ts src/services/security/client.ts src/services/security/account.ts src/services/security/types/common.ts src/utils/request.tsx src/utils/date.ts src/app.tsx` which passed for the changed files.
- Ran `git diff --check` to verify whitespace/patch sanity which reported no fixable issues.
- Attempted unit tests: `yarn jest src/services/http/response.test.ts src/services/security/currentIdentity.test.ts --runInBand`, but Jest failed to parse the project test config (`config/config.ts`) in the current workspace so tests could not execute in this environment.
- Attempted TypeScript check: `yarn tsc`, but `tsc` run was blocked by a missing installed type definition (`minimatch`) in the current environment; compilation should succeed once the workspace dependencies are installed consistently.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6627a890b08326a12569de585792d3)