### PR TITLE
feat(ui): complete Security session and project lifecycle

### DIFF
--- a/yak-ops-ui/src/app.tsx
+++ b/yak-ops-ui/src/app.tsx
@@ -9,37 +9,19 @@ import defaultSettings from '../config/defaultSettings';
 import { GlobalSearch, Knowledge } from './components/RightContent';
 import { getCurrentUser } from './services/security/account';
 import { toCurrentUser } from './services/security/currentIdentity';
+import { BizError } from './utils/request';
+import { getCurrentReturnTo, getSafeReturnTo, isLoginPath } from './utils/security/redirect';
 
 export { toCurrentUser } from './services/security/currentIdentity';
 
 const isDev = process.env.NODE_ENV === 'development';
 const loginPath = '/login';
 
-const isLoginPage = (pathname: string) =>
-  pathname.toLowerCase().startsWith(loginPath);
-
-const currentReturnTo = () =>
-  `${window.location.pathname}${window.location.search}${window.location.hash}`;
-
 const redirectAnonymousUser = () => {
-  if (isLoginPage(window.location.pathname)) return;
+  if (isLoginPath(window.location.pathname)) return;
 
-  const returnTo = currentReturnTo();
+  const returnTo = getCurrentReturnTo();
   history.replace(`${loginPath}?returnTo=${encodeURIComponent(returnTo)}`);
-};
-
-const getSafeReturnTo = () => {
-  const requested = new URLSearchParams(window.location.search).get('returnTo');
-  if (!requested) return '/';
-
-  const destination = new URL(requested, window.location.origin);
-  if (
-    destination.origin !== window.location.origin ||
-    isLoginPage(destination.pathname)
-  ) {
-    return '/';
-  }
-  return `${destination.pathname}${destination.search}${destination.hash}`;
 };
 
 /**
@@ -51,24 +33,29 @@ export async function getInitialState(): Promise<{
   loading?: boolean;
   currentProject?: unknown;
   securityProject?: unknown;
+  currentUserLoadError?: boolean;
   fetchUserInfo?: () => Promise<API.CurrentUser | undefined>;
 }> {
-  const fetchUserInfo = async () => {
-    try {
-      return toCurrentUser(await getCurrentUser());
-    } catch (_error) {
-      redirectAnonymousUser();
-    }
-    return undefined;
-  };
+  const fetchUserInfo = async () => toCurrentUser(await getCurrentUser());
   // Always probe the cookie-backed Session, including after a reload on login.
-  const currentUser = await fetchUserInfo();
-  if (currentUser && isLoginPage(window.location.pathname)) {
-    history.replace(getSafeReturnTo());
+  let currentUser: API.CurrentUser | undefined;
+  let currentUserLoadError = false;
+  try {
+    currentUser = await fetchUserInfo();
+  } catch (error) {
+    // Authentication failures redirect; network/server failures retain the
+    // current URL so a transient outage is not misrepresented as logout.
+    if (error instanceof BizError && error.code === 401) redirectAnonymousUser();
+    else currentUserLoadError = true;
+  }
+  if (currentUser && isLoginPath(window.location.pathname)) {
+    const requested = new URLSearchParams(window.location.search).get('returnTo');
+    history.replace(getSafeReturnTo(requested));
   }
   return {
     fetchUserInfo,
     currentUser,
+    currentUserLoadError,
     settings: defaultSettings as Partial<LayoutSettings>,
   };
 }
@@ -104,7 +91,11 @@ export const layout: RunTimeLayoutConfig = ({
     onPageChange: () => {
       const { location } = history;
       // 如果没有登录，重定向到 login
-      if (!initialState?.currentUser && location.pathname !== loginPath) {
+      if (
+        !initialState?.currentUser &&
+        !initialState?.currentUserLoadError &&
+        location.pathname !== loginPath
+      ) {
         redirectAnonymousUser();
       }
     },

--- a/yak-ops-ui/src/components/security/SecurityProjectSwitcher/index.tsx
+++ b/yak-ops-ui/src/components/security/SecurityProjectSwitcher/index.tsx
@@ -1,0 +1,29 @@
+import { useSecurityProject } from "@/contexts/SecurityProjectContext";
+import { Dropdown, Empty } from "antd";
+import { ChevronDown } from "lucide-react";
+
+export default function SecurityProjectSwitcher() {
+  const { projects, currentProject, selectProject } = useSecurityProject();
+  if (!projects.length) {
+    return <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="暂无可用项目" className="m-0 px-3" />;
+  }
+
+  return (
+    <Dropdown
+      menu={{
+        selectable: true,
+        selectedKeys: currentProject ? [String(currentProject.id)] : [],
+        items: projects.map((project) => ({
+          key: String(project.id),
+          label: project.projectName,
+          onClick: () => selectProject(project),
+        })),
+      }}
+    >
+      <button type="button" className="flex items-center gap-1 border-0 bg-transparent px-2 text-sm">
+        <span>{currentProject?.projectName}</span><ChevronDown className="h-3 w-3" />
+      </button>
+    </Dropdown>
+  );
+}
+

--- a/yak-ops-ui/src/contexts/SecurityProjectContext.test.ts
+++ b/yak-ops-ui/src/contexts/SecurityProjectContext.test.ts
@@ -1,0 +1,13 @@
+import { chooseSecurityProject } from "./SecurityProjectContext";
+
+const projects: API.ProjectBrief[] = [
+  { id: 1, projectCode: "one", projectName: "One" },
+  { id: 2, projectCode: "two", projectName: "Two" },
+];
+
+describe("chooseSecurityProject", () => {
+  it("restores an accessible project", () => expect(chooseSecurityProject(projects, "2")).toBe(projects[1]));
+  it("falls back when the saved project was removed", () => expect(chooseSecurityProject(projects, "99")).toBe(projects[0]));
+  it("supports users without projects", () => expect(chooseSecurityProject([], "2")).toBeUndefined());
+});
+

--- a/yak-ops-ui/src/contexts/SecurityProjectContext.tsx
+++ b/yak-ops-ui/src/contexts/SecurityProjectContext.tsx
@@ -1,0 +1,74 @@
+import { useModel } from "@umijs/max";
+import type { ReactNode } from "react";
+import { createContext, useContext, useEffect, useMemo } from "react";
+
+const STORAGE_KEY = "yak-security.current-project-id";
+export const SECURITY_SESSION_EXPIRED_EVENT = "yak-security:session-expired";
+
+export const chooseSecurityProject = (
+  projects: API.ProjectBrief[],
+  persistedId: string | null,
+): API.ProjectBrief | undefined =>
+  projects.find((project) => String(project.id) === persistedId) ?? projects[0];
+
+type SecurityProjectValue = {
+  projects: API.ProjectBrief[];
+  currentProject?: API.ProjectBrief;
+  selectProject: (project: API.ProjectBrief) => void;
+  clearProject: () => void;
+};
+
+const SecurityProjectContext = createContext<SecurityProjectValue | undefined>(undefined);
+
+export function SecurityProjectProvider({ children }: { children: ReactNode }) {
+  const { initialState, setInitialState } = useModel("@@initialState");
+  const projects = initialState?.currentUser?.projectList ?? [];
+  const currentProject = initialState?.securityProject as API.ProjectBrief | undefined;
+
+  const selectProject = (project: API.ProjectBrief) => {
+    if (!projects.some((candidate) => candidate.id === project.id)) return;
+    localStorage.setItem(STORAGE_KEY, String(project.id));
+    setInitialState((state) => ({ ...state, currentProject: project, securityProject: project }));
+  };
+
+  const clearProject = () => {
+    localStorage.removeItem(STORAGE_KEY);
+    setInitialState((state) => ({ ...state, currentProject: undefined, securityProject: undefined }));
+  };
+
+  useEffect(() => {
+    const selected = chooseSecurityProject(projects, localStorage.getItem(STORAGE_KEY));
+    if (selected) {
+      if (selected.id !== currentProject?.id) selectProject(selected);
+    } else if (currentProject) {
+      clearProject();
+    }
+  }, [currentProject?.id, projects]);
+
+  useEffect(() => {
+    const clearSession = () => {
+      localStorage.removeItem(STORAGE_KEY);
+      setInitialState((state) => ({
+        ...state,
+        currentUser: undefined,
+        currentProject: undefined,
+        securityProject: undefined,
+      }));
+    };
+    window.addEventListener(SECURITY_SESSION_EXPIRED_EVENT, clearSession);
+    return () => window.removeEventListener(SECURITY_SESSION_EXPIRED_EVENT, clearSession);
+  }, [setInitialState]);
+
+  const value = useMemo(
+    () => ({ projects, currentProject, selectProject, clearProject }),
+    [projects, currentProject],
+  );
+  return <SecurityProjectContext.Provider value={value}>{children}</SecurityProjectContext.Provider>;
+}
+
+export const useSecurityProject = () => {
+  const value = useContext(SecurityProjectContext);
+  if (!value) throw new Error("useSecurityProject must be used within SecurityProjectProvider");
+  return value;
+};
+

--- a/yak-ops-ui/src/layouts/SiteLayout/index.tsx
+++ b/yak-ops-ui/src/layouts/SiteLayout/index.tsx
@@ -9,6 +9,8 @@ import {
   type NavigationRoute,
 } from "@/config/navigation";
 import { RouteAccessBoundary } from "@/components/security";
+import SecurityProjectSwitcher from "@/components/security/SecurityProjectSwitcher";
+import { SecurityProjectProvider, useSecurityProject } from "@/contexts/SecurityProjectContext";
 import { logout } from "@/services/security/account";
 import { history, Outlet, useLocation, useModel } from "@umijs/max";
 import { Drawer, Dropdown, Empty, type MenuProps } from "antd";
@@ -33,7 +35,6 @@ import {
   PanelLeftOpen,
   Plug,
   Server,
-  ShieldCheck,
   SquarePlus,
   Workflow,
 } from "lucide-react";
@@ -251,7 +252,7 @@ function BrandLogo({ compact }: { compact: boolean }) {
   );
 }
 
-export default function SiteLayout() {
+function SiteLayoutContent() {
   const location = useLocation();
   const { initialState, setInitialState } = useModel("@@initialState");
   const currentUser = initialState?.currentUser;
@@ -282,32 +283,7 @@ export default function SiteLayout() {
   const [notificationOpen, setNotificationOpen] = useState(false);
   const [loggingOut, setLoggingOut] = useState(false);
 
-  const projects = useMemo(
-    () => currentUser?.projectList ?? [],
-    [currentUser?.projectList],
-  );
-  const selectedProject =
-    (initialState?.securityProject as API.ProjectBrief | undefined) ??
-    (initialState?.currentProject as API.ProjectBrief | undefined) ??
-    projects[0];
-
-  const selectProject = (project: API.ProjectBrief) => {
-    setInitialState((state) => ({
-      ...state,
-      currentProject: project,
-      securityProject: project,
-    }));
-  };
-
-  const projectMenuItems = useMemo<MenuProps["items"]>(
-    () =>
-      projects.map((project) => ({
-        key: String(project.id),
-        label: project.projectName,
-        onClick: () => selectProject(project),
-      })),
-    [projects],
-  );
+  const { clearProject } = useSecurityProject();
 
   const handleLogout = async () => {
     if (loggingOut) return;
@@ -315,6 +291,7 @@ export default function SiteLayout() {
     try {
       await logout();
     } finally {
+      clearProject();
       await setInitialState((state) => ({
         ...state,
         currentUser: undefined,
@@ -973,34 +950,7 @@ export default function SiteLayout() {
             onClick={() => setNotificationOpen(true)}
           />
 
-          <Dropdown
-            menu={{
-              items: projectMenuItems,
-              selectable: true,
-              selectedKeys: selectedProject
-                ? [String(selectedProject.id)]
-                : [],
-            }}
-            trigger={["click"]}
-            disabled={projects.length === 0}
-          >
-            <button
-              type="button"
-              aria-label="切换 Security 项目"
-              className="ml-2 flex h-8 max-w-52 items-center gap-2 rounded-md border border-[rgba(28,31,35,0.08)] bg-white px-2.5 text-left text-xs text-[#1c1f23] transition-colors hover:bg-[#f5f5f6]"
-            >
-              <ShieldCheck
-                className="h-4 w-4 shrink-0 text-[#fe2c55]"
-                strokeWidth={1.8}
-              />
-              <span className="min-w-0 truncate">
-                {selectedProject?.projectName ?? "Security"}
-              </span>
-              <ChevronDown
-                className="h-3 w-3 shrink-0 text-[rgba(22,24,35,0.4)]"
-              />
-            </button>
-          </Dropdown>
+          <SecurityProjectSwitcher />
 
           <div
             className="
@@ -1076,4 +1026,8 @@ export default function SiteLayout() {
       </main>
     </div>
   );
+}
+
+export default function SiteLayout() {
+  return <SecurityProjectProvider><SiteLayoutContent /></SecurityProjectProvider>;
 }

--- a/yak-ops-ui/src/pages/login/LoginPanel.tsx
+++ b/yak-ops-ui/src/pages/login/LoginPanel.tsx
@@ -1,11 +1,12 @@
 import {ArrowRightOutlined} from "@ant-design/icons";
-import {useIntl, useModel} from "@umijs/max";
-import {App, Button, Checkbox, Form, Input} from "antd";
+import {history, useIntl, useModel} from "@umijs/max";
+import {App, Button, Form, Input} from "antd";
 import {useForm} from "antd/es/form/Form";
 import React, {useRef, useState} from "react";
 import {flushSync} from "react-dom";
 import {login} from "@/services/security/account";
 import {resetAuthenticationFailure} from "@/utils/request";
+import {getSafeReturnTo} from "@/utils/security/redirect";
 import GoogleLoginButton from "./components/GoogleLoginButton";
 import "./index.less";
 
@@ -60,24 +61,12 @@ export default function LoginPanel({
         }));
       });
     }
+    return userInfo;
   };
 
   const redirectAfterLogin = () => {
-    const urlParams = new URL(window.location.href).searchParams;
-    const requested = urlParams.get("returnTo");
-
-    if (requested) {
-      const destination = new URL(requested, window.location.origin);
-      if (destination.origin === window.location.origin &&
-        !destination.pathname.toLowerCase().startsWith("/login")) {
-        window.location.assign(
-          `${destination.pathname}${destination.search}${destination.hash}`
-        );
-        return;
-      }
-    }
-
-    window.location.assign("/");
+    const requested = new URLSearchParams(window.location.search).get("returnTo");
+    history.replace(getSafeReturnTo(requested));
   };
 
   const handleAccountLogin = async (values: {
@@ -100,7 +89,8 @@ export default function LoginPanel({
       onFieldFocusChange?.(null);
       onFire("THANKS");
 
-      await fetchUserInfo();
+      const userInfo = await fetchUserInfo();
+      if (!userInfo) throw new Error("登录后无法加载当前用户");
       redirectAfterLogin();
     } catch (_error) {
       onFire("SHAKE");
@@ -113,7 +103,8 @@ export default function LoginPanel({
     onFieldFocusChange?.(null);
     onFire("THANKS");
 
-    await fetchUserInfo();
+    const userInfo = await fetchUserInfo();
+    if (!userInfo) return;
     redirectAfterLogin();
   };
 
@@ -183,18 +174,18 @@ export default function LoginPanel({
                   fontFamily: "Inter, sans-serif",
                 }}
               >
-                Email
+                用户名
               </span>
             }
             name="userName"
             style={{marginBottom: 18}}
-            rules={[{required: true, message: "Please enter your Email"}]}
+            rules={[{required: true, message: "请输入用户名"}]}
           >
             <Input
               className="login-input"
               size="large"
-              placeholder="you@example.com"
-              autoComplete="email"
+              placeholder="请输入用户名"
+              autoComplete="username"
               onFocus={() => {
                 onFieldFocusChange?.("userName");
                 fireThrottled("focus_user", "SURPRISE", 1200);
@@ -251,10 +242,6 @@ export default function LoginPanel({
               fontSize: 14,
             }}
           >
-            <Form.Item name="remember" valuePropName="checked" noStyle>
-              <Checkbox>Remember for 30 days</Checkbox>
-            </Form.Item>
-
             <Button type="link" style={{padding: 0}}>
               Forgot password?
             </Button>

--- a/yak-ops-ui/src/pages/login/components/GoogleLoginButton.tsx
+++ b/yak-ops-ui/src/pages/login/components/GoogleLoginButton.tsx
@@ -1,7 +1,7 @@
 import {GoogleOutlined} from "@ant-design/icons";
 import {App, Button} from "antd";
 import React, {useEffect, useRef, useState} from "react";
-import {loginApi} from "../type";
+import {googleLogin} from "../type";
 
 declare global {
   interface Window {
@@ -98,16 +98,8 @@ const GoogleLoginButton: React.FC<GoogleLoginButtonProps> = ({
               setInnerLoading(true);
               onStartRef.current?.();
 
-              const data = await loginApi.googleLogin({
-                credential: response.credential,
-              });
-
-              if (data?.code === 0) {
-                await onSuccessRef.current?.(data);
-                return;
-              }
-
-              onErrorRef.current?.(data);
+              await googleLogin(response.credential);
+              await onSuccessRef.current?.();
             } catch (error) {
               console.error(error);
               onErrorRef.current?.(error);

--- a/yak-ops-ui/src/pages/login/type.ts
+++ b/yak-ops-ui/src/pages/login/type.ts
@@ -1,15 +1,3 @@
-import HttpUtils from '@/utils/HttpUtils';
-
-
-export const apiPrefix = "/api/v1"
-
-export const loginApi = {
-
-  login: (data: any): Promise<{ code: number; data: any; message?: string }> => {
-    return HttpUtils.post(`${apiPrefix}/login`, data);
-  },
-
-  googleLogin: (params: { credential: string }) => {
-    return HttpUtils.post("/api/v1/auth/google/login", params);
-  },
-};
+// Compatibility forwarding module. New login code should import the account
+// service directly so all authentication methods share Security semantics.
+export { googleLogin } from '@/services/security/account';

--- a/yak-ops-ui/src/services/security/account.ts
+++ b/yak-ops-ui/src/services/security/account.ts
@@ -20,6 +20,9 @@ export type AccountLoginDTO = {
 export const login = (body: AccountLoginDTO): Promise<void> =>
   securityPostData<void>(`${ACCOUNT_API}/login`, body);
 
+export const googleLogin = (credential: string): Promise<void> =>
+  securityPostData<void>('/api/v1/auth/google/login', { credential });
+
 export const getCurrentUser = (): Promise<API.CurrentUserVO> =>
   securityGetData<API.CurrentUserVO>(`${ACCOUNT_API}/current`);
 

--- a/yak-ops-ui/src/utils/request.tsx
+++ b/yak-ops-ui/src/utils/request.tsx
@@ -83,6 +83,7 @@ export const resetAuthenticationFailure = () => {
 
 /** HTTP 401、业务未登录码与 Session 失效的唯一处理出口。 */
 export const handleAuthenticationFailure = () => {
+  window.dispatchEvent(new Event("yak-security:session-expired"));
   if (window.location.pathname.toLowerCase().startsWith("/login")) {
     return;
   }

--- a/yak-ops-ui/src/utils/security/redirect.test.ts
+++ b/yak-ops-ui/src/utils/security/redirect.test.ts
@@ -1,0 +1,16 @@
+import { getSafeReturnTo, isLoginPath } from "./redirect";
+
+describe("security redirect", () => {
+  it("preserves a same-origin path including search and hash", () => {
+    expect(getSafeReturnTo("/jobs/42?tab=log#latest", "https://ops.test"))
+      .toBe("/jobs/42?tab=log#latest");
+  });
+
+  it.each(["https://evil.test/x", "//evil.test/x", "/login?returnTo=/x"])(
+    "rejects an unsafe destination: %s",
+    (destination) => expect(getSafeReturnTo(destination, "https://ops.test")).toBe("/"),
+  );
+
+  expect(isLoginPath("/login-help")).toBe(false);
+});
+

--- a/yak-ops-ui/src/utils/security/redirect.ts
+++ b/yak-ops-ui/src/utils/security/redirect.ts
@@ -1,0 +1,27 @@
+const LOGIN_PATH = "/login";
+
+export const isLoginPath = (pathname: string): boolean =>
+  pathname.toLowerCase() === LOGIN_PATH ||
+  pathname.toLowerCase().startsWith(`${LOGIN_PATH}/`);
+
+export const getCurrentReturnTo = (location: Location = window.location) =>
+  `${location.pathname}${location.search}${location.hash}`;
+
+/** Accept only paths on this origin and never return to the login page itself. */
+export const getSafeReturnTo = (
+  requested: string | null | undefined,
+  origin: string = window.location.origin,
+): string => {
+  if (!requested) return "/";
+
+  try {
+    const destination = new URL(requested, origin);
+    if (destination.origin !== origin || isLoginPath(destination.pathname)) {
+      return "/";
+    }
+    return `${destination.pathname}${destination.search}${destination.hash}`;
+  } catch {
+    return "/";
+  }
+};
+


### PR DESCRIPTION
### Motivation

- Restore and preserve the cookie-backed Yak Security session during app bootstrap while distinguishing a 401 anonymous response from transient network/server failures to avoid redirect loops.
- Validate and safely handle `returnTo` redirect targets so login returns only to same-origin in-app paths and never to the login page itself.
- Provide an in-memory/persisted Security project context so the UI can restore/select a current project from the user’s accessible projects and show a clear empty state when no projects exist.
- Ensure logout and global session expiry clear in-memory identity, permissions, and selected project consistently on the client.

### Description

- Add a safe redirect helper in `src/utils/security/redirect.ts` with `getSafeReturnTo`, `getCurrentReturnTo`, and `isLoginPath` to validate same-origin return destinations and unit tests at `src/utils/security/redirect.test.ts`.
- Change initial-state bootstrap in `src/app.tsx` to probe `GET /yak-security/api/v1/account/current`, differentiate 401 vs network failures using `BizError`, avoid redirect loops, and use the safe `returnTo` logic when routing post-login.
- Add a `SecurityProjectContext` in `src/contexts/SecurityProjectContext.tsx` to persist the selected project id, restore a project only if still accessible, auto-fallback if a persisted project is removed, and react to a `yak-security:session-expired` event to clear identity and project state; tests added at `src/contexts/SecurityProjectContext.test.ts`.
- Add `SecurityProjectSwitcher` component at `src/components/security/SecurityProjectSwitcher/index.tsx` and wire the project provider into the site layout by wrapping `SiteLayoutContent` with `SecurityProjectProvider` in `src/layouts/SiteLayout/index.tsx` and replacing inline project menu logic.
- Unify authentication client usage: migrate Google login to the shared Yak Security account client (`src/services/security/account.ts`) and keep a compatibility forwarding module for older login imports in `src/pages/login/type.ts`.
- Emit a global session-expired event from the existing authentication failure path in `src/utils/request.tsx` so the `SecurityProjectContext` can clear persisted project selection and identity when sessions expire.
- Update `src/pages/login/LoginPanel.tsx` to reload `initialState` after successful password or Google login, validate that the current user is available before redirecting, and adjust the login form field labels/placeholders to reflect `userName` (username) rather than email.

### Testing

- Added unit tests for `getSafeReturnTo` and `isLoginPath` in `src/utils/security/redirect.test.ts`, and for project restore/fallback behavior in `src/contexts/SecurityProjectContext.test.ts` which validate same-origin redirect acceptance and persisted-project fallback respectively.
- Ran static sanity checks such as `git diff --check` and repository status to ensure diffs are clean, which passed without errors.
- Attempted to run Jest for the new tests, but execution could not complete because dependency installation failed in this environment due to the configured package registries returning HTTP 403, so test execution is pending until dependencies can be restored.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a662821d98c8326a79dc7317bae3534)