### PR TITLE
feat(ui): implement permission and department trees

### DIFF
--- a/yak-ops-ui/src/components/security/JsonDetailDrawer/index.tsx
+++ b/yak-ops-ui/src/components/security/JsonDetailDrawer/index.tsx
@@ -1,0 +1,51 @@
+import { Descriptions, Drawer, Empty, Spin } from 'antd';
+
+interface JsonDetailDrawerProps {
+  title: string;
+  open: boolean;
+  loading?: boolean;
+  data?: Record<string, unknown> | null;
+  labels?: Record<string, string>;
+  fields?: string[];
+  onClose: () => void;
+}
+
+const displayValue = (value: unknown) => {
+  if (value === null || value === undefined || value === '') return '-';
+  if (typeof value === 'boolean') return value ? '是' : '否';
+  if (typeof value === 'object') return JSON.stringify(value, null, 2);
+  return String(value);
+};
+
+export default function JsonDetailDrawer({
+  title,
+  open,
+  loading,
+  data,
+  labels = {},
+  fields,
+  onClose,
+}: JsonDetailDrawerProps) {
+  const entries = data
+    ? (fields ?? Object.keys(data))
+        .filter((field) => field !== 'children' && field in data)
+        .map((field) => [field, data[field]] as const)
+    : [];
+  return (
+    <Drawer title={title} width={520} open={open} onClose={onClose} destroyOnClose>
+      <Spin spinning={Boolean(loading)}>
+        {entries.length ? (
+          <Descriptions bordered column={1} size="small">
+            {entries.map(([key, value]) => (
+              <Descriptions.Item key={key} label={labels[key] ?? key}>
+                <span className="whitespace-pre-wrap break-all">{displayValue(value)}</span>
+              </Descriptions.Item>
+            ))}
+          </Descriptions>
+        ) : (
+          <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="暂无详情" />
+        )}
+      </Spin>
+    </Drawer>
+  );
+}

--- a/yak-ops-ui/src/components/security/TreeSearch/index.tsx
+++ b/yak-ops-ui/src/components/security/TreeSearch/index.tsx
@@ -1,0 +1,70 @@
+import { Empty, Input, Spin, Tree } from 'antd';
+import type { DataNode } from 'antd/es/tree';
+import { useMemo } from 'react';
+
+export interface SearchTreeNode extends DataNode {
+  key: string | number;
+  searchText: string;
+  children?: SearchTreeNode[];
+}
+
+/** Client-side fallback filtering keeps every ancestor of a matching node. */
+export const filterTreeWithAncestors = (nodes: SearchTreeNode[], keyword: string): SearchTreeNode[] => {
+  const query = keyword.trim().toLocaleLowerCase();
+  if (!query) return nodes;
+  return nodes.flatMap((node) => {
+    const children = filterTreeWithAncestors(node.children ?? [], query);
+    return node.searchText.toLocaleLowerCase().includes(query) || children.length ? [{ ...node, children }] : [];
+  });
+};
+
+interface TreeSearchProps {
+  nodes: SearchTreeNode[];
+  loading?: boolean;
+  keyword: string;
+  placeholder?: string;
+  selectedKey?: string | number;
+  onKeywordChange: (keyword: string) => void;
+  onSelect: (key: string | number) => void;
+}
+
+export default function TreeSearch({
+  nodes,
+  loading,
+  keyword,
+  placeholder = '搜索树节点',
+  selectedKey,
+  onKeywordChange,
+  onSelect,
+}: TreeSearchProps) {
+  const visibleNodes = useMemo(() => filterTreeWithAncestors(nodes, keyword), [keyword, nodes]);
+  return (
+    <div>
+      <Input.Search
+        allowClear
+        value={keyword}
+        placeholder={placeholder}
+        onChange={(event) => onKeywordChange(event.target.value)}
+      />
+      <Spin spinning={Boolean(loading)}>
+        {visibleNodes.length ? (
+          <Tree
+            className="mt-4"
+            blockNode
+            defaultExpandAll
+            autoExpandParent
+            treeData={visibleNodes}
+            selectedKeys={selectedKey === undefined ? [] : [selectedKey]}
+            onSelect={(keys) => keys[0] !== undefined && onSelect(keys[0] as string | number)}
+          />
+        ) : (
+          <Empty
+            className="mt-12"
+            image={Empty.PRESENTED_IMAGE_SIMPLE}
+            description={keyword ? '没有匹配节点' : '暂无树数据'}
+          />
+        )}
+      </Spin>
+    </div>
+  );
+}

--- a/yak-ops-ui/src/components/security/index.ts
+++ b/yak-ops-ui/src/components/security/index.ts
@@ -2,3 +2,5 @@ export { default as PermissionGuard } from './PermissionGuard';
 export type { PermissionGuardProps } from './PermissionGuard';
 export { default as RouteAccessBoundary } from './RouteAccessBoundary';
 export type { RouteAccessBoundaryProps } from './RouteAccessBoundary';
+export { default as TreeSearch } from './TreeSearch';
+export { default as JsonDetailDrawer } from './JsonDetailDrawer';

--- a/yak-ops-ui/src/pages/system/departments/ImportModal.tsx
+++ b/yak-ops-ui/src/pages/system/departments/ImportModal.tsx
@@ -1,0 +1,86 @@
+import { InboxOutlined } from '@ant-design/icons';
+import type { UploadFile } from 'antd';
+import { Alert, Button, Descriptions, Modal, message, Upload } from 'antd';
+import { useState } from 'react';
+import { importDepartments } from '@/services/security/departments';
+import type { ImportReport } from '@/services/security/permissions';
+
+export default function ImportModal({
+  open,
+  onClose,
+  onImported,
+}: {
+  open: boolean;
+  onClose: () => void;
+  onImported: () => void;
+}) {
+  const [files, setFiles] = useState<UploadFile[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [report, setReport] = useState<ImportReport>();
+  const submit = async () => {
+    const file = files[0]?.originFileObj;
+    if (!file) return;
+    setLoading(true);
+    try {
+      const result = await importDepartments(file);
+      setReport(result);
+      message.success(`导入完成：成功 ${result.successCount}，失败 ${result.failureCount}`);
+      onImported();
+    } finally {
+      setLoading(false);
+    }
+  };
+  return (
+    <Modal
+      title="导入部门"
+      open={open}
+      onCancel={onClose}
+      footer={[
+        <Button key="close" onClick={onClose}>
+          关闭
+        </Button>,
+        <Button key="import" type="primary" loading={loading} disabled={!files.length} onClick={submit}>
+          开始导入
+        </Button>,
+      ]}
+    >
+      <Alert
+        className="mb-4"
+        type="info"
+        showIcon
+        message="请使用服务端约定的导入模板"
+        description="文件中的父部门必须先于子部门；请在导入前检查重复编码和父部门标识。"
+      />
+      <Upload.Dragger
+        maxCount={1}
+        fileList={files}
+        beforeUpload={() => false}
+        onChange={({ fileList }) => {
+          setFiles(fileList.slice(-1));
+          setReport(undefined);
+        }}
+      >
+        <p className="ant-upload-drag-icon">
+          <InboxOutlined />
+        </p>
+        <p>点击或拖拽部门文件到此处</p>
+      </Upload.Dragger>
+      {report && (
+        <Descriptions className="mt-4" bordered column={2} size="small">
+          <Descriptions.Item label="成功">{report.successCount}</Descriptions.Item>
+          <Descriptions.Item label="失败">{report.failureCount}</Descriptions.Item>
+          {report.failures?.length ? (
+            <Descriptions.Item label="失败明细" span={2}>
+              {report.failures.map((item, index) => (
+                <div key={`${item.row ?? index}-${item.code ?? ''}`}>
+                  {item.row ? `第 ${item.row} 行：` : ''}
+                  {item.message}
+                </div>
+              ))}
+            </Descriptions.Item>
+          ) : null}
+        </Descriptions>
+      )}
+    </Modal>
+  );
+}

--- a/yak-ops-ui/src/pages/system/departments/index.tsx
+++ b/yak-ops-ui/src/pages/system/departments/index.tsx
@@ -1,5 +1,131 @@
-import SystemPageShell from '../SystemPageShell';
+import { ImportOutlined, ReloadOutlined } from '@ant-design/icons';
+import { Button, Card, Form, Input, Space, Typography } from 'antd';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { JsonDetailDrawer, PermissionGuard, TreeSearch } from '@/components/security';
+import {
+  type DepartmentVO,
+  getDepartmentDetail,
+  getDepartmentTree,
+  searchDepartments,
+} from '@/services/security/departments';
+import type { TreeId } from '@/services/security/permissions';
+import { retainMatchedAncestors } from '../permissions/tree';
+import ImportModal from './ImportModal';
+import { departmentTreeNodes } from './tree';
 
-export default function SystemPage() {
-  return <SystemPageShell title='部门管理' description='维护组织部门树和成员关系。' />;
+const labels = { id: 'ID', name: '名称', code: '编码', parentId: '父部门 ID', leader: '负责人' };
+
+export default function DepartmentsPage() {
+  const [tree, setTree] = useState<DepartmentVO[]>([]);
+  const [visibleTree, setVisibleTree] = useState<DepartmentVO[]>([]);
+  const [selectedId, setSelectedId] = useState<TreeId>();
+  const [detail, setDetail] = useState<DepartmentVO>();
+  const [loading, setLoading] = useState(false);
+  const [detailLoading, setDetailLoading] = useState(false);
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [importOpen, setImportOpen] = useState(false);
+  const [keyword, setKeyword] = useState('');
+  const [form] = Form.useForm<{ name?: string; code?: string }>();
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const result = await getDepartmentTree();
+      setTree(result ?? []);
+      setVisibleTree(result ?? []);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+  useEffect(() => {
+    void load();
+  }, [load]);
+  const select = async (id: TreeId) => {
+    setSelectedId(id);
+    setDrawerOpen(true);
+    setDetailLoading(true);
+    try {
+      setDetail(await getDepartmentDetail(id));
+    } finally {
+      setDetailLoading(false);
+    }
+  };
+  const search = async (values: { name?: string; code?: string }) => {
+    if (!values.name?.trim() && !values.code?.trim()) {
+      setVisibleTree(tree);
+      return;
+    }
+    setLoading(true);
+    try {
+      setVisibleTree(retainMatchedAncestors(tree, await searchDepartments(values)));
+    } finally {
+      setLoading(false);
+    }
+  };
+  const nodes = useMemo(() => departmentTreeNodes(visibleTree), [visibleTree]);
+  return (
+    <section className="m-4 min-h-[calc(100vh-80px)]" aria-labelledby="department-title">
+      <Card>
+        <div className="mb-5 flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <Typography.Title id="department-title" level={4} className="!mb-1">
+              部门管理
+            </Typography.Title>
+            <Typography.Text type="secondary">
+              搜索部门树并查看部门详情；本页不提供后端未开放的编辑或删除操作。
+            </Typography.Text>
+          </div>
+          <Space>
+            <Button icon={<ReloadOutlined />} onClick={() => void load()}>
+              刷新
+            </Button>
+            <PermissionGuard mode="one" permission="system:department:import">
+              <Button type="primary" icon={<ImportOutlined />} onClick={() => setImportOpen(true)}>
+                导入
+              </Button>
+            </PermissionGuard>
+          </Space>
+        </div>
+        <Form form={form} layout="inline" className="mb-5 gap-y-2" onFinish={search}>
+          <Form.Item name="name" label="名称">
+            <Input allowClear />
+          </Form.Item>
+          <Form.Item name="code" label="编码">
+            <Input allowClear />
+          </Form.Item>
+          <Button type="primary" htmlType="submit">
+            查询
+          </Button>
+          <Button
+            onClick={() => {
+              form.resetFields();
+              setVisibleTree(tree);
+            }}
+          >
+            重置
+          </Button>
+        </Form>
+        <Card size="small" title="部门树">
+          <TreeSearch
+            nodes={nodes}
+            loading={loading}
+            keyword={keyword}
+            onKeywordChange={setKeyword}
+            selectedKey={selectedId}
+            onSelect={(id) => void select(id)}
+            placeholder="在结果中按名称或编码筛选"
+          />
+        </Card>
+      </Card>
+      <JsonDetailDrawer
+        title="部门详情"
+        open={drawerOpen}
+        loading={detailLoading}
+        data={detail as unknown as Record<string, unknown>}
+        fields={Object.keys(labels)}
+        labels={labels}
+        onClose={() => setDrawerOpen(false)}
+      />
+      <ImportModal open={importOpen} onClose={() => setImportOpen(false)} onImported={() => void load()} />
+    </section>
+  );
 }

--- a/yak-ops-ui/src/pages/system/departments/tree.test.ts
+++ b/yak-ops-ui/src/pages/system/departments/tree.test.ts
@@ -1,0 +1,8 @@
+import { departmentTreeNodes } from './tree';
+
+test('department nodes are searchable by name and optional code', () => {
+  const nodes = departmentTreeNodes([{ id: '10', name: '研发部', code: 'RD' }]);
+  expect(nodes[0]).toMatchObject({ key: '10', searchText: '研发部 RD' });
+});
+
+test('empty department tree stays empty', () => expect(departmentTreeNodes([])).toEqual([]));

--- a/yak-ops-ui/src/pages/system/departments/tree.ts
+++ b/yak-ops-ui/src/pages/system/departments/tree.ts
@@ -1,0 +1,16 @@
+import type { SearchTreeNode } from '@/components/security/TreeSearch';
+import type { DepartmentVO } from '@/services/security/departments';
+
+export const departmentTreeNodes = (items: DepartmentVO[], path = new Set<string>()): SearchTreeNode[] =>
+  items.flatMap((item) => {
+    const id = String(item.id);
+    if (path.has(id)) return [];
+    return [
+      {
+        key: item.id,
+        title: item.name,
+        searchText: `${item.name} ${item.code ?? ''}`,
+        children: departmentTreeNodes(item.children ?? [], new Set(path).add(id)),
+      },
+    ];
+  });

--- a/yak-ops-ui/src/pages/system/permissions/ImportModal.tsx
+++ b/yak-ops-ui/src/pages/system/permissions/ImportModal.tsx
@@ -1,0 +1,84 @@
+import { InboxOutlined } from '@ant-design/icons';
+import type { UploadFile } from 'antd';
+import { Alert, Button, Modal, message, Table, Upload } from 'antd';
+import { useState } from 'react';
+import { type ImportReport, importPermissions } from '@/services/security/permissions';
+
+export default function ImportModal({
+  open,
+  onClose,
+  onImported,
+}: {
+  open: boolean;
+  onClose: () => void;
+  onImported: () => void;
+}) {
+  const [files, setFiles] = useState<UploadFile[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [report, setReport] = useState<ImportReport>();
+  const submit = async () => {
+    const file = files[0]?.originFileObj;
+    if (!file) return;
+    setLoading(true);
+    try {
+      const next = await importPermissions(file);
+      setReport(next);
+      message.success(`导入完成：成功 ${next.successCount}，失败 ${next.failureCount}`);
+      onImported();
+    } finally {
+      setLoading(false);
+    }
+  };
+  return (
+    <Modal
+      title="导入权限"
+      open={open}
+      onCancel={onClose}
+      footer={[
+        <Button key="cancel" onClick={onClose}>
+          关闭
+        </Button>,
+        <Button key="submit" type="primary" loading={loading} disabled={!files.length} onClick={submit}>
+          开始导入
+        </Button>,
+      ]}
+    >
+      <Alert
+        className="mb-4"
+        type="warning"
+        showIcon
+        message="导入语义由服务端决定"
+        description="提交前请确认模板、覆盖/合并规则及重复编码处理方式。"
+      />
+      <Upload.Dragger
+        maxCount={1}
+        fileList={files}
+        beforeUpload={() => false}
+        onChange={({ fileList }) => {
+          setFiles(fileList.slice(-1));
+          setReport(undefined);
+        }}
+      >
+        <p className="ant-upload-drag-icon">
+          <InboxOutlined />
+        </p>
+        <p>点击或拖拽文件到此处</p>
+      </Upload.Dragger>
+      {report && (
+        <Table
+          className="mt-4"
+          size="small"
+          pagination={false}
+          rowKey={(_, index) => String(index)}
+          dataSource={report.failures ?? []}
+          locale={{ emptyText: `成功 ${report.successCount} 条，无失败明细` }}
+          columns={[
+            { title: '行', dataIndex: 'row', width: 64 },
+            { title: '编码', dataIndex: 'code' },
+            { title: '失败原因', dataIndex: 'message' },
+          ]}
+        />
+      )}
+    </Modal>
+  );
+}

--- a/yak-ops-ui/src/pages/system/permissions/index.tsx
+++ b/yak-ops-ui/src/pages/system/permissions/index.tsx
@@ -1,5 +1,197 @@
-import SystemPageShell from '../SystemPageShell';
+import { DeleteOutlined, ImportOutlined, ReloadOutlined } from '@ant-design/icons';
+import { Button, Card, Descriptions, Form, Input, Modal, message, Select, Space, Tag, Typography } from 'antd';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { PermissionGuard, TreeSearch } from '@/components/security';
+import {
+  deletePermission,
+  getPermissionDetail,
+  getPermissionTree,
+  type PermissionSearchParams,
+  type PermissionVO,
+  searchPermissions,
+  type TreeId,
+} from '@/services/security/permissions';
+import ImportModal from './ImportModal';
+import { permissionTreeNodes, retainMatchedAncestors } from './tree';
 
-export default function SystemPage() {
-  return <SystemPageShell title='权限管理' description='维护权限树和权限详情。' />;
+const labels: Record<string, string> = {
+  name: '名称',
+  code: '编码',
+  type: '类型',
+  parentId: '父级 ID',
+  resource: '接口 / 资源描述',
+  description: '描述',
+  sort: '排序',
+  status: '状态',
+};
+const fields = Object.keys(labels);
+
+export default function PermissionsPage() {
+  const [tree, setTree] = useState<PermissionVO[]>([]);
+  const [visibleTree, setVisibleTree] = useState<PermissionVO[]>([]);
+  const [selectedId, setSelectedId] = useState<TreeId>();
+  const [detail, setDetail] = useState<PermissionVO>();
+  const [loading, setLoading] = useState(false);
+  const [detailLoading, setDetailLoading] = useState(false);
+  const [keyword, setKeyword] = useState('');
+  const [importOpen, setImportOpen] = useState(false);
+  const [form] = Form.useForm<PermissionSearchParams>();
+  const loadTree = useCallback(async () => {
+    setLoading(true);
+    try {
+      const data = await getPermissionTree();
+      setTree(data ?? []);
+      setVisibleTree(data ?? []);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+  useEffect(() => {
+    void loadTree();
+  }, [loadTree]);
+  const select = async (id: TreeId) => {
+    setSelectedId(id);
+    setDetailLoading(true);
+    try {
+      setDetail(await getPermissionDetail(id));
+    } finally {
+      setDetailLoading(false);
+    }
+  };
+  const search = async (values: PermissionSearchParams) => {
+    const hasQuery = Object.values(values).some((value) => value?.trim());
+    if (!hasQuery) {
+      setVisibleTree(tree);
+      return;
+    }
+    setLoading(true);
+    try {
+      setVisibleTree(retainMatchedAncestors(tree, await searchPermissions(values)));
+    } finally {
+      setLoading(false);
+    }
+  };
+  const remove = () =>
+    detail &&
+    Modal.confirm({
+      title: `删除权限“${detail.name}”？`,
+      content: '服务端会检查子节点和角色引用；存在引用时不会删除。',
+      okButtonProps: { danger: true },
+      onOk: async () => {
+        try {
+          await deletePermission(detail.id);
+          message.success('删除成功');
+          setDetail(undefined);
+          setSelectedId(undefined);
+          await loadTree();
+        } catch (error) {
+          Modal.error({
+            title: '无法删除权限',
+            content: error instanceof Error ? error.message : '权限存在子节点或角色引用，请解除冲突后重试。',
+          });
+          throw error;
+        }
+      },
+    });
+  const nodes = useMemo(() => permissionTreeNodes(visibleTree), [visibleTree]);
+  return (
+    <section className="m-4 min-h-[calc(100vh-80px)]" aria-labelledby="permission-title">
+      <Card>
+        <div className="mb-5 flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <Typography.Title id="permission-title" level={4} className="!mb-1">
+              权限管理
+            </Typography.Title>
+            <Typography.Text type="secondary">查询权限树、查看真实详情，或从服务端模板导入权限。</Typography.Text>
+          </div>
+          <Space>
+            <Button icon={<ReloadOutlined />} onClick={() => void loadTree()}>
+              刷新
+            </Button>
+            <PermissionGuard mode="one" permission="system:permission:import">
+              <Button type="primary" icon={<ImportOutlined />} onClick={() => setImportOpen(true)}>
+                导入
+              </Button>
+            </PermissionGuard>
+          </Space>
+        </div>
+        <Form form={form} layout="inline" onFinish={search} className="mb-5 gap-y-2">
+          <Form.Item name="name" label="名称">
+            <Input allowClear />
+          </Form.Item>
+          <Form.Item name="code" label="编码">
+            <Input allowClear />
+          </Form.Item>
+          <Form.Item name="type" label="类型">
+            <Select
+              allowClear
+              className="w-32"
+              options={[
+                { value: 'MENU', label: 'MENU' },
+                { value: 'API', label: 'API' },
+                { value: 'BUTTON', label: 'BUTTON' },
+              ]}
+            />
+          </Form.Item>
+          <Button htmlType="submit" type="primary">
+            查询
+          </Button>
+          <Button
+            onClick={() => {
+              form.resetFields();
+              setVisibleTree(tree);
+            }}
+          >
+            重置
+          </Button>
+        </Form>
+        <div className="grid grid-cols-1 gap-5 lg:grid-cols-[360px_1fr]">
+          <Card size="small" title="权限树">
+            <TreeSearch
+              nodes={nodes}
+              loading={loading}
+              keyword={keyword}
+              onKeywordChange={setKeyword}
+              selectedKey={selectedId}
+              onSelect={(id) => void select(id)}
+              placeholder="在结果中按名称、编码、类型筛选"
+            />
+          </Card>
+          <Card
+            size="small"
+            title="权限详情"
+            loading={detailLoading}
+            extra={
+              detail && (
+                <PermissionGuard mode="one" permission="system:permission:delete">
+                  <Button danger icon={<DeleteOutlined />} onClick={remove}>
+                    删除
+                  </Button>
+                </PermissionGuard>
+              )
+            }
+          >
+            {detail ? (
+              <Descriptions bordered column={1}>
+                {fields
+                  .filter((field) => field in detail)
+                  .map((field) => (
+                    <Descriptions.Item key={field} label={labels[field]}>
+                      {field === 'status' ? (
+                        <Tag>{String(detail[field as keyof PermissionVO] ?? '-')}</Tag>
+                      ) : (
+                        String(detail[field as keyof PermissionVO] ?? '-')
+                      )}
+                    </Descriptions.Item>
+                  ))}
+              </Descriptions>
+            ) : (
+              <Typography.Text type="secondary">请从左侧选择一个权限节点。</Typography.Text>
+            )}
+          </Card>
+        </div>
+      </Card>
+      <ImportModal open={importOpen} onClose={() => setImportOpen(false)} onImported={() => void loadTree()} />
+    </section>
+  );
 }

--- a/yak-ops-ui/src/pages/system/permissions/tree.test.ts
+++ b/yak-ops-ui/src/pages/system/permissions/tree.test.ts
@@ -1,0 +1,23 @@
+import { permissionTreeNodes, retainMatchedAncestors } from './tree';
+import type { PermissionVO } from '@/services/security/permissions';
+
+const tree: PermissionVO[] = [
+  {
+    id: 1,
+    name: '系统',
+    code: 'system',
+    type: 'MENU',
+    children: [{ id: '2', name: '查看权限', code: 'system:permission:read', type: 'API' }],
+  },
+];
+
+test('search result keeps its ancestor chain and supports mixed id types', () => {
+  expect(retainMatchedAncestors(tree, [tree[0].children![0]])).toEqual(tree);
+  expect(permissionTreeNodes(tree)[0].children?.[0].searchText).toContain('system:permission:read');
+});
+
+test('cycle-like duplicate node in a path is ignored', () => {
+  const cyclic: any = { id: 1, name: 'A', code: 'a', type: 'MENU', children: [] };
+  cyclic.children.push(cyclic);
+  expect(permissionTreeNodes([cyclic])[0].children).toEqual([]);
+});

--- a/yak-ops-ui/src/pages/system/permissions/tree.ts
+++ b/yak-ops-ui/src/pages/system/permissions/tree.ts
@@ -1,0 +1,44 @@
+import type { SearchTreeNode } from '@/components/security/TreeSearch';
+import type { PermissionVO, TreeId } from '@/services/security/permissions';
+
+export const permissionTreeNodes = (items: PermissionVO[], path = new Set<string>()): SearchTreeNode[] =>
+  items.flatMap((item) => {
+    const key = String(item.id);
+    if (path.has(key)) return [];
+    const nextPath = new Set(path).add(key);
+    return [
+      {
+        key: item.id,
+        title: item.name,
+        searchText: `${item.name} ${item.code} ${item.type}`,
+        children: permissionTreeNodes(item.children ?? [], nextPath),
+      },
+    ];
+  });
+
+export const collectTreeIds = <T extends { id: TreeId; children?: T[] }>(items: T[]): Set<string> => {
+  const ids = new Set<string>();
+  const visit = (nodes: T[], path: Set<string>) => {
+    for (const node of nodes) {
+      const id = String(node.id);
+      if (path.has(id)) continue;
+      ids.add(id);
+      visit(node.children ?? [], new Set(path).add(id));
+    }
+  };
+  visit(items, new Set());
+  return ids;
+};
+
+/** Restrict a full tree to matches returned by search while retaining their ancestor chain. */
+export const retainMatchedAncestors = <T extends { id: TreeId; children?: T[] }>(tree: T[], matches: T[]): T[] => {
+  const matchedIds = collectTreeIds(matches);
+  const visit = (nodes: T[], path: Set<string>): T[] =>
+    nodes.flatMap((node) => {
+      const id = String(node.id);
+      if (path.has(id)) return [];
+      const children = visit(node.children ?? [], new Set(path).add(id));
+      return matchedIds.has(id) || children.length ? [{ ...node, children }] : [];
+    });
+  return visit(tree, new Set());
+};

--- a/yak-ops-ui/src/services/security/client.ts
+++ b/yak-ops-ui/src/services/security/client.ts
@@ -43,3 +43,15 @@ export const securityPostData = async <T>(
       data,
     })
   ).data;
+
+export const securityDeleteData = async <T>(
+  path: string,
+  options?: SecurityRequestOptions,
+): Promise<T> => (await securityRequest<T>(path, { ...options, method: 'DELETE' })).data;
+
+/** Send an import file without forcing a JSON content type or serialising FormData. */
+export const securityUploadData = async <T>(path: string, file: File): Promise<T> => {
+  const body = new FormData();
+  body.append('file', file);
+  return (await securityRequest<T>(path, { method: 'POST', body })).data;
+};

--- a/yak-ops-ui/src/services/security/departments.ts
+++ b/yak-ops-ui/src/services/security/departments.ts
@@ -1,0 +1,33 @@
+import { securityGetData, securityUploadData } from './client';
+import type { ImportReport, TreeId } from './permissions';
+
+const DEPARTMENT_API = '/api/v1/department';
+
+export interface DepartmentVO {
+  id: TreeId;
+  name: string;
+  code?: string | null;
+  parentId?: TreeId | null;
+  leader?: string | null;
+  children?: DepartmentVO[];
+}
+
+const queryString = (params: { name?: string; code?: string }) => {
+  const query = new URLSearchParams();
+  if (params.name?.trim()) query.set('name', params.name.trim());
+  if (params.code?.trim()) query.set('code', params.code.trim());
+  const value = query.toString();
+  return value ? `?${value}` : '';
+};
+
+export const getDepartmentTree = (): Promise<DepartmentVO[]> =>
+  securityGetData<DepartmentVO[]>(`${DEPARTMENT_API}/tree`);
+
+export const searchDepartments = (params: { name?: string; code?: string }): Promise<DepartmentVO[]> =>
+  securityGetData<DepartmentVO[]>(`${DEPARTMENT_API}/search${queryString(params)}`);
+
+export const getDepartmentDetail = (id: TreeId): Promise<DepartmentVO> =>
+  securityGetData<DepartmentVO>(`${DEPARTMENT_API}/${encodeURIComponent(String(id))}`);
+
+export const importDepartments = (file: File): Promise<ImportReport> =>
+  securityUploadData<ImportReport>(`${DEPARTMENT_API}/import`, file);

--- a/yak-ops-ui/src/services/security/permissions.ts
+++ b/yak-ops-ui/src/services/security/permissions.ts
@@ -1,0 +1,52 @@
+import { securityDeleteData, securityGetData, securityUploadData } from './client';
+
+const PERMISSION_API = '/api/v1/permission';
+
+export type TreeId = string | number;
+
+export interface PermissionVO {
+  id: TreeId;
+  name: string;
+  code: string;
+  type: string;
+  parentId?: TreeId | null;
+  resource?: string | null;
+  description?: string | null;
+  sort?: number | null;
+  status?: string | number | boolean | null;
+  children?: PermissionVO[];
+}
+
+export interface PermissionSearchParams {
+  name?: string;
+  code?: string;
+  type?: string;
+}
+
+export interface ImportReport {
+  successCount: number;
+  failureCount: number;
+  failures?: Array<{ row?: number; code?: string; message: string }>;
+}
+
+const queryString = (params: PermissionSearchParams) => {
+  const query = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) if (value?.trim()) query.set(key, value.trim());
+  const value = query.toString();
+  return value ? `?${value}` : '';
+};
+
+export const getPermissionTree = (): Promise<PermissionVO[]> =>
+  securityGetData<PermissionVO[]>(`${PERMISSION_API}/tree`);
+
+export const searchPermissions = (params: PermissionSearchParams): Promise<PermissionVO[]> =>
+  securityGetData<PermissionVO[]>(`${PERMISSION_API}/search${queryString(params)}`);
+
+export const getPermissionDetail = (id: TreeId): Promise<PermissionVO> =>
+  securityGetData<PermissionVO>(`${PERMISSION_API}/${encodeURIComponent(String(id))}`);
+
+export const importPermissions = (file: File): Promise<ImportReport> =>
+  securityUploadData<ImportReport>(`${PERMISSION_API}/import`, file);
+
+export const deletePermission = (id: TreeId): Promise<void> =>
+  securityDeleteData<void>(`${PERMISSION_API}/${encodeURIComponent(String(id))}`);


### PR DESCRIPTION
### Motivation

- Provide Stage-0 front-end support for Security permission and department trees: tree listing, search, import, detail view and backend-allowed deletion without inventing unsupported edit flows.
- Keep UX predictable for large and imperfect trees by preserving ancestor chains in search results and avoiding infinite recursion on cyclic/mixed-id data.

### Description

- Add typed Security clients `src/services/security/permissions.ts` and `src/services/security/departments.ts` with tree/search/detail/import/delete (delete only where backend supports it) and an upload helper `securityUploadData` in `client.ts`.
- Add reusable UI primitives `TreeSearch` (`src/components/security/TreeSearch`) for ancestor-preserving filtering and `JsonDetailDrawer` (`src/components/security/JsonDetailDrawer`) for read-only VO display, and export both from `components/security/index.ts`.
- Implement permission management UI at `src/pages/system/permissions/*` with name/code/type search, tree + right-side detail, guarded `Import` modal that reports successes/failures, and guarded `Delete` action that surfaces backend conflict reasons instead of forcing client-side deletion.
- Implement department management UI at `src/pages/system/departments/*` with searchable tree, detail drawer and guarded import modal and explicitly omit edit/delete actions not provided by the backend.

### Testing

- Ran `./node_modules/.bin/biome check src/components/security/TreeSearch src/components/security/JsonDetailDrawer src/pages/system/permissions src/pages/system/departments` which completed and auto-fixed formatting/organize-import issues for the new files.
- Ran `git diff --check` which reported no index issues for the staged changes.
- Attempted `yarn tsc` which was blocked by a pre-existing missing dev type (`@types/minimatch`) in the environment and did not complete successfully.
- A stricter `tsc` run (`--noEmit --types ...`) and running the full test runner (`yarn jest ...`) were blocked by existing project-level type/config issues (Umi config parsing and repo-wide type errors) unrelated to the new code; unit tests for the new tree helpers are present (`tree.test.ts`) and type issues in those files were addressed during the change.
- `yarn start:no-mock` was attempted but Umi failed to load the workspace config in this environment due to a pre-existing alias/module resolution issue, so live UI verification and screenshots were not produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a66b43de1a88326bc1b26ea9c657f16)