### PR TITLE
重构权限管理页面并修复接口集成问题

### DIFF
--- a/yak-ops-ui/src/pages/system/permissions/ImportModal.tsx
+++ b/yak-ops-ui/src/pages/system/permissions/ImportModal.tsx
@@ -1,84 +1,307 @@
-import { InboxOutlined } from '@ant-design/icons';
-import type { UploadFile } from 'antd';
-import { Alert, Button, Modal, message, Table, Upload } from 'antd';
-import { useState } from 'react';
-import { type ImportReport, importPermissions } from '@/services/security/permissions';
+import {
+  FileTextOutlined,
+  UploadOutlined,
+} from '@ant-design/icons';
+import {
+  Alert,
+  Button,
+  Input,
+  Modal,
+  Space,
+  Tag,
+  Typography,
+  Upload,
+  message,
+} from 'antd';
+import { useMemo, useState } from 'react';
+
+import {
+  type PermissionImportItem,
+  importPermissions,
+} from '@/services/security/permissions';
+
+interface PermissionImportModalProps {
+  open: boolean;
+  onClose: () => void;
+  onImported: () => void;
+}
+
+const EXAMPLE_JSON = JSON.stringify(
+  [
+    {
+      permissionCode: 'security:example:read',
+      permissionName: '示例模块查看',
+      description: '查看示例模块',
+      childPermissionDTOList: [
+        {
+          permissionCode: 'security:example:create',
+          permissionName: '示例模块新增',
+          description: '新增示例数据',
+        },
+      ],
+    },
+  ],
+  null,
+  2,
+);
+
+const isRecord = (
+  value: unknown,
+): value is Record<string, unknown> =>
+  typeof value === 'object' &&
+  value !== null &&
+  !Array.isArray(value);
+
+const cleanRequiredText = (
+  value: unknown,
+  label: string,
+  path: string,
+): string => {
+  const text = typeof value === 'string' ? value.trim() : '';
+  if (!text) {
+    throw new Error(`${path} 缺少${label}`);
+  }
+  return text;
+};
+
+const parseImportNode = (
+  value: unknown,
+  path: string,
+  permissionCodes: Set<string>,
+): PermissionImportItem => {
+  if (!isRecord(value)) {
+    throw new Error(`${path} 必须是 JSON 对象`);
+  }
+
+  const permissionCode = cleanRequiredText(
+    value.permissionCode,
+    '权限编码 permissionCode',
+    path,
+  );
+  const permissionName = cleanRequiredText(
+    value.permissionName,
+    '权限名称 permissionName',
+    path,
+  );
+
+  if (permissionCodes.has(permissionCode)) {
+    throw new Error(`权限编码重复：${permissionCode}`);
+  }
+  permissionCodes.add(permissionCode);
+
+  if (
+    value.description !== undefined &&
+    typeof value.description !== 'string'
+  ) {
+    throw new Error(`${path}.description 必须是字符串`);
+  }
+
+  const childValue = value.childPermissionDTOList;
+  if (childValue !== undefined && !Array.isArray(childValue)) {
+    throw new Error(
+      `${path}.childPermissionDTOList 必须是数组`,
+    );
+  }
+
+  const children = (childValue ?? []).map((child, index) =>
+    parseImportNode(
+      child,
+      `${path}.childPermissionDTOList[${index}]`,
+      permissionCodes,
+    ),
+  );
+
+  return {
+    permissionCode,
+    permissionName,
+    ...(typeof value.description === 'string' &&
+    value.description.trim()
+      ? { description: value.description.trim() }
+      : {}),
+    ...(children.length > 0
+      ? { childPermissionDTOList: children }
+      : {}),
+  };
+};
+
+const parseImportJson = (
+  source: string,
+): PermissionImportItem[] => {
+  let value: unknown;
+
+  try {
+    value = JSON.parse(source);
+  } catch {
+    throw new Error('JSON 格式不正确，请检查逗号、引号和括号');
+  }
+
+  if (!Array.isArray(value) || value.length === 0) {
+    throw new Error('顶层必须是非空 JSON 数组');
+  }
+
+  const permissionCodes = new Set<string>();
+  return value.map((node, index) =>
+    parseImportNode(node, `[${index}]`, permissionCodes),
+  );
+};
+
+const countImportNodes = (
+  nodes: PermissionImportItem[],
+): number =>
+  nodes.reduce(
+    (total, node) =>
+      total +
+      1 +
+      countImportNodes(node.childPermissionDTOList ?? []),
+    0,
+  );
+
+const errorText = (error: unknown, fallback: string): string =>
+  error instanceof Error && error.message
+    ? error.message
+    : fallback;
 
 export default function ImportModal({
   open,
   onClose,
   onImported,
-}: {
-  open: boolean;
-  onClose: () => void;
-  onImported: () => void;
-}) {
-  const [files, setFiles] = useState<UploadFile[]>([]);
-  const [loading, setLoading] = useState(false);
-  const [report, setReport] = useState<ImportReport>();
-  const submit = async () => {
-    const file = files[0]?.originFileObj;
-    if (!file) return;
-    setLoading(true);
+}: PermissionImportModalProps) {
+  const [source, setSource] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  const preview = useMemo(() => {
+    if (!source.trim()) {
+      return {
+        data: undefined,
+        count: 0,
+        error: undefined,
+      };
+    }
+
     try {
-      const next = await importPermissions(file);
-      setReport(next);
-      message.success(`导入完成：成功 ${next.successCount}，失败 ${next.failureCount}`);
+      const data = parseImportJson(source);
+      return {
+        data,
+        count: countImportNodes(data),
+        error: undefined,
+      };
+    } catch (error) {
+      return {
+        data: undefined,
+        count: 0,
+        error: errorText(error, '权限 JSON 校验失败'),
+      };
+    }
+  }, [source]);
+
+  const close = () => {
+    if (!saving) onClose();
+  };
+
+  const submit = async () => {
+    if (!preview.data || saving) return;
+
+    setSaving(true);
+    try {
+      await importPermissions(preview.data);
+      message.success(`权限导入成功，共 ${preview.count} 个节点`);
+      onClose();
       onImported();
+    } catch (error) {
+      message.error(errorText(error, '权限导入失败'));
     } finally {
-      setLoading(false);
+      setSaving(false);
     }
   };
+
   return (
     <Modal
-      title="导入权限"
       open={open}
-      onCancel={onClose}
-      footer={[
-        <Button key="cancel" onClick={onClose}>
-          关闭
-        </Button>,
-        <Button key="submit" type="primary" loading={loading} disabled={!files.length} onClick={submit}>
-          开始导入
-        </Button>,
-      ]}
+      title="导入权限树"
+      width={760}
+      maskClosable={false}
+      keyboard={!saving}
+      closable={!saving}
+      onCancel={close}
+      afterClose={() => setSource('')}
+      footer={
+        <Space>
+          <Button disabled={saving} onClick={close}>
+            取消
+          </Button>
+          <Button
+            type="primary"
+            loading={saving}
+            disabled={!preview.data}
+            onClick={() => void submit()}
+          >
+            确认导入
+          </Button>
+        </Space>
+      }
     >
       <Alert
-        className="mb-4"
-        type="warning"
         showIcon
-        message="导入语义由服务端决定"
-        description="提交前请确认模板、覆盖/合并规则及重复编码处理方式。"
+        type="info"
+        className="mb-4"
+        message="后端接收 JSON 权限树"
+        description="请选择 JSON 文件或直接粘贴内容。权限编码在本次导入中必须唯一；数据库中已存在的编码或其他约束冲突会由后端返回错误。"
       />
-      <Upload.Dragger
-        maxCount={1}
-        fileList={files}
-        beforeUpload={() => false}
-        onChange={({ fileList }) => {
-          setFiles(fileList.slice(-1));
-          setReport(undefined);
-        }}
-      >
-        <p className="ant-upload-drag-icon">
-          <InboxOutlined />
-        </p>
-        <p>点击或拖拽文件到此处</p>
-      </Upload.Dragger>
-      {report && (
-        <Table
-          className="mt-4"
-          size="small"
-          pagination={false}
-          rowKey={(_, index) => String(index)}
-          dataSource={report.failures ?? []}
-          locale={{ emptyText: `成功 ${report.successCount} 条，无失败明细` }}
-          columns={[
-            { title: '行', dataIndex: 'row', width: 64 },
-            { title: '编码', dataIndex: 'code' },
-            { title: '失败原因', dataIndex: 'message' },
-          ]}
-        />
-      )}
+
+      <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+        <Space wrap>
+          <Upload
+            accept=".json,application/json"
+            maxCount={1}
+            showUploadList={false}
+            beforeUpload={(file) => {
+              void file
+                .text()
+                .then(setSource)
+                .catch(() => message.error('JSON 文件读取失败'));
+              return false;
+            }}
+          >
+            <Button icon={<UploadOutlined />}>
+              选择 JSON 文件
+            </Button>
+          </Upload>
+
+          <Button
+            type="link"
+            icon={<FileTextOutlined />}
+            onClick={() => setSource(EXAMPLE_JSON)}
+          >
+            填充示例
+          </Button>
+        </Space>
+
+        {preview.data && (
+          <Tag color="success">已识别 {preview.count} 个权限节点</Tag>
+        )}
+      </div>
+
+      <Input.TextArea
+        value={source}
+        placeholder={EXAMPLE_JSON}
+        autoSize={{ minRows: 14, maxRows: 22 }}
+        className="font-mono text-xs"
+        status={preview.error ? 'error' : undefined}
+        disabled={saving}
+        onChange={(event) => setSource(event.target.value)}
+      />
+
+      <div className="mt-2 min-h-6">
+        {preview.error ? (
+          <Typography.Text type="danger">
+            {preview.error}
+          </Typography.Text>
+        ) : (
+          <Typography.Text type="secondary" className="text-xs">
+            字段：permissionCode、permissionName、description、childPermissionDTOList。
+          </Typography.Text>
+        )}
+      </div>
     </Modal>
   );
 }

--- a/yak-ops-ui/src/pages/system/permissions/index.tsx
+++ b/yak-ops-ui/src/pages/system/permissions/index.tsx
@@ -1,197 +1,699 @@
-import { DeleteOutlined, ImportOutlined, ReloadOutlined } from '@ant-design/icons';
-import { Button, Card, Descriptions, Form, Input, Modal, message, Select, Space, Tag, Typography } from 'antd';
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import { PermissionGuard, TreeSearch } from '@/components/security';
+import {
+  CheckCircleOutlined,
+  DeleteOutlined,
+  FileProtectOutlined,
+  ImportOutlined,
+  MinusSquareOutlined,
+  PlusSquareOutlined,
+  ReloadOutlined,
+  SearchOutlined,
+  StopOutlined,
+} from '@ant-design/icons';
+import type { DataNode } from 'antd/es/tree';
+import {
+  Avatar,
+  Button,
+  Descriptions,
+  Empty,
+  Input,
+  Modal,
+  Space,
+  Spin,
+  Tag,
+  Tooltip,
+  Tree,
+  Typography,
+  message,
+} from 'antd';
+import type { Key, ReactNode } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+
+import { PermissionGuard } from '@/components/security';
 import {
   deletePermission,
-  getPermissionDetail,
   getPermissionTree,
-  type PermissionSearchParams,
   type PermissionVO,
-  searchPermissions,
-  type TreeId,
 } from '@/services/security/permissions';
-import ImportModal from './ImportModal';
-import { permissionTreeNodes, retainMatchedAncestors } from './tree';
 
-const labels: Record<string, string> = {
-  name: '名称',
-  code: '编码',
-  type: '类型',
-  parentId: '父级 ID',
-  resource: '接口 / 资源描述',
-  description: '描述',
-  sort: '排序',
-  status: '状态',
+import ImportModal from './ImportModal';
+import {
+  collectPermissionIds,
+  filterPermissionTree,
+  findPermissionById,
+  findPermissionPath,
+  getDirectChildren,
+  getPermissionForest,
+  getPermissionTreeStats,
+  type PermissionScope,
+} from './tree';
+
+const errorText = (error: unknown, fallback: string): string =>
+  error instanceof Error && error.message
+    ? error.message
+    : fallback;
+
+const permissionRequirement = (action: string): string =>
+  `security:permission:${action}`;
+
+const permissionName = (permission?: PermissionVO): string =>
+  permission?.permissionName ||
+  permission?.permissionCode ||
+  '未命名权限';
+
+const permissionCode = (permission?: PermissionVO): string =>
+  permission?.permissionCode || '未配置权限编码';
+
+const toTreeData = (
+  permissions: PermissionVO[],
+  path = new Set<string>(),
+): DataNode[] =>
+  permissions.flatMap((permission) => {
+    const key = String(permission.id);
+    if (path.has(key)) return [];
+
+    const nextPath = new Set(path);
+    nextPath.add(key);
+
+    return [
+      {
+        key: permission.id,
+        title: (
+          <div className="min-w-0 py-0.5">
+            <div className="flex min-w-0 items-center gap-2">
+              <span
+                className={[
+                  'truncate text-sm',
+                  permission.active === false
+                    ? 'text-slate-400'
+                    : 'font-medium text-slate-700',
+                ].join(' ')}
+              >
+                {permissionName(permission)}
+              </span>
+
+              {permission.active === false && (
+                <Tag className="!m-0 !border-slate-200 !bg-slate-100 !text-[10px] !leading-4 !text-slate-500">
+                  停用
+                </Tag>
+              )}
+            </div>
+
+            <div className="mt-0.5 truncate text-xs text-slate-400">
+              {permissionCode(permission)}
+            </div>
+          </div>
+        ),
+        children: toTreeData(
+          getDirectChildren(permission),
+          nextPath,
+        ),
+      },
+    ];
+  });
+
+const scopeLabel = (
+  label: string,
+  count: number,
+): ReactNode => (
+  <span>
+    {label}
+    <span className="ml-1 text-xs opacity-60">{count}</span>
+  </span>
+);
+
+const deleteDisabledReason = (
+  permission?: PermissionVO,
+): string | undefined => {
+  if (!permission) return '请先选择权限';
+
+  if (permission.declared === true) {
+    return '声明式权限由后端注册同步，不能在此手工删除';
+  }
+
+  if (
+    permission.leaf === false ||
+    getDirectChildren(permission).length > 0
+  ) {
+    return '该权限包含子节点，请先处理子权限';
+  }
+
+  return undefined;
 };
-const fields = Object.keys(labels);
 
 export default function PermissionsPage() {
-  const [tree, setTree] = useState<PermissionVO[]>([]);
-  const [visibleTree, setVisibleTree] = useState<PermissionVO[]>([]);
-  const [selectedId, setSelectedId] = useState<TreeId>();
-  const [detail, setDetail] = useState<PermissionVO>();
-  const [loading, setLoading] = useState(false);
-  const [detailLoading, setDetailLoading] = useState(false);
+  const requestSequenceRef = useRef(0);
+
+  const [root, setRoot] = useState<PermissionVO>();
+  const [selectedId, setSelectedId] = useState<number>();
   const [keyword, setKeyword] = useState('');
+  const [scope, setScope] =
+    useState<PermissionScope>('all');
+  const [expandedKeys, setExpandedKeys] = useState<Key[]>([]);
+  const [loading, setLoading] = useState(false);
   const [importOpen, setImportOpen] = useState(false);
-  const [form] = Form.useForm<PermissionSearchParams>();
+
   const loadTree = useCallback(async () => {
+    const sequence = ++requestSequenceRef.current;
     setLoading(true);
+
     try {
       const data = await getPermissionTree();
-      setTree(data ?? []);
-      setVisibleTree(data ?? []);
+      if (sequence !== requestSequenceRef.current) return;
+      setRoot(data);
+    } catch (error) {
+      if (sequence !== requestSequenceRef.current) return;
+      setRoot(undefined);
+      message.error(errorText(error, '权限树加载失败'));
     } finally {
-      setLoading(false);
+      if (sequence === requestSequenceRef.current) {
+        setLoading(false);
+      }
     }
   }, []);
+
   useEffect(() => {
     void loadTree();
   }, [loadTree]);
-  const select = async (id: TreeId) => {
-    setSelectedId(id);
-    setDetailLoading(true);
-    try {
-      setDetail(await getPermissionDetail(id));
-    } finally {
-      setDetailLoading(false);
-    }
-  };
-  const search = async (values: PermissionSearchParams) => {
-    const hasQuery = Object.values(values).some((value) => value?.trim());
-    if (!hasQuery) {
-      setVisibleTree(tree);
+
+  const permissionForest = useMemo(
+    () => getPermissionForest(root),
+    [root],
+  );
+
+  const stats = useMemo(
+    () => getPermissionTreeStats(permissionForest),
+    [permissionForest],
+  );
+
+  const visiblePermissions = useMemo(
+    () =>
+      filterPermissionTree(
+        permissionForest,
+        keyword,
+        scope,
+      ),
+    [keyword, permissionForest, scope],
+  );
+
+  const treeData = useMemo(
+    () => toTreeData(visiblePermissions),
+    [visiblePermissions],
+  );
+
+  const selectedPermission = useMemo(
+    () => findPermissionById(permissionForest, selectedId),
+    [permissionForest, selectedId],
+  );
+
+  const selectedPath = useMemo(
+    () => findPermissionPath(permissionForest, selectedId),
+    [permissionForest, selectedId],
+  );
+
+  const selectedChildren = useMemo(
+    () => getDirectChildren(selectedPermission),
+    [selectedPermission],
+  );
+
+  useEffect(() => {
+    if (loading) return;
+
+    const visibleSelected = findPermissionById(
+      visiblePermissions,
+      selectedId,
+    );
+
+    if (visibleSelected) return;
+    setSelectedId(visiblePermissions[0]?.id);
+  }, [loading, selectedId, visiblePermissions]);
+
+  useEffect(() => {
+    if (keyword.trim() || scope !== 'all') {
+      setExpandedKeys(
+        collectPermissionIds(visiblePermissions),
+      );
       return;
     }
-    setLoading(true);
-    try {
-      setVisibleTree(retainMatchedAncestors(tree, await searchPermissions(values)));
-    } finally {
-      setLoading(false);
-    }
-  };
-  const remove = () =>
-    detail &&
-    Modal.confirm({
-      title: `删除权限“${detail.name}”？`,
-      content: '服务端会检查子节点和角色引用；存在引用时不会删除。',
-      okButtonProps: { danger: true },
-      onOk: async () => {
-        try {
-          await deletePermission(detail.id);
-          message.success('删除成功');
-          setDetail(undefined);
-          setSelectedId(undefined);
-          await loadTree();
-        } catch (error) {
-          Modal.error({
-            title: '无法删除权限',
-            content: error instanceof Error ? error.message : '权限存在子节点或角色引用，请解除冲突后重试。',
-          });
-          throw error;
-        }
-      },
-    });
-  const nodes = useMemo(() => permissionTreeNodes(visibleTree), [visibleTree]);
-  return (
-    <section className="m-4 min-h-[calc(100vh-80px)]" aria-labelledby="permission-title">
-      <Card>
-        <div className="mb-5 flex flex-wrap items-start justify-between gap-3">
-          <div>
-            <Typography.Title id="permission-title" level={4} className="!mb-1">
-              权限管理
-            </Typography.Title>
-            <Typography.Text type="secondary">查询权限树、查看真实详情，或从服务端模板导入权限。</Typography.Text>
+
+    setExpandedKeys(
+      permissionForest.map((permission) => permission.id),
+    );
+  }, [keyword, permissionForest, scope, visiblePermissions]);
+
+  const scopeOptions: Array<{
+    value: PermissionScope;
+    label: ReactNode;
+  }> = [
+    {
+      value: 'all',
+      label: scopeLabel('全部', stats.total),
+    },
+    {
+      value: 'active',
+      label: scopeLabel('启用', stats.active),
+    },
+    {
+      value: 'inactive',
+      label: scopeLabel('停用', stats.inactive),
+    },
+    {
+      value: 'declared',
+      label: scopeLabel('声明式', stats.declared),
+    },
+    {
+      value: 'manual',
+      label: scopeLabel('手工导入', stats.manual),
+    },
+  ];
+
+  const removePermission = useCallback(
+    (permission: PermissionVO) => {
+      const disabledReason = deleteDisabledReason(permission);
+      if (disabledReason) {
+        message.warning(disabledReason);
+        return;
+      }
+
+      Modal.confirm({
+        title: '删除权限',
+        width: 480,
+        centered: true,
+        okText: '删除',
+        cancelText: '取消',
+        okButtonProps: { danger: true },
+        content: (
+          <div className="space-y-3">
+            <div>
+              确定删除权限
+              <span className="mx-1 font-medium text-slate-900">
+                {permissionName(permission)}
+              </span>
+              吗？
+            </div>
+
+            <div className="rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800">
+              删除后，该权限与角色之间的授权关系也会被解除，此操作无法撤销。
+            </div>
           </div>
-          <Space>
-            <Button icon={<ReloadOutlined />} onClick={() => void loadTree()}>
-              刷新
-            </Button>
-            <PermissionGuard mode="one" permission="system:permission:import">
-              <Button type="primary" icon={<ImportOutlined />} onClick={() => setImportOpen(true)}>
-                导入
-              </Button>
-            </PermissionGuard>
-          </Space>
+        ),
+        onOk: async () => {
+          try {
+            await deletePermission(permission.id);
+            message.success('权限已删除');
+            setSelectedId(undefined);
+            await loadTree();
+          } catch (error) {
+            message.error(
+              errorText(error, '权限删除失败'),
+            );
+            throw error;
+          }
+        },
+      });
+    },
+    [loadTree],
+  );
+
+  const disabledReason = deleteDisabledReason(
+    selectedPermission,
+  );
+
+  return (
+    <section
+      className="box-border flex min-h-[640px] flex-col overflow-hidden bg-slate-50/50 p-6"
+      style={{ height: 'calc(100vh - 64px)' }}
+      aria-labelledby="permission-title"
+    >
+      <h1
+        id="permission-title"
+        className="mb-4 shrink-0 font-semibold"
+        style={{ fontSize: 18, color: '#282828' }}
+      >
+        权限管理
+      </h1>
+
+      <div className="mb-4 flex shrink-0 flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+        <div className="flex min-w-0 items-center gap-2 overflow-x-auto pb-1 lg:pb-0">
+          {scopeOptions.map((option) => {
+            const active = scope === option.value;
+
+            return (
+              <button
+                key={option.value}
+                type="button"
+                className={[
+                  'shrink-0 rounded px-3 py-1 text-sm font-medium leading-5 transition-colors',
+                  active
+                    ? 'bg-[#f2f2f4] text-[#FE2C55]'
+                    : 'bg-[#f2f4f7] text-[#667085] hover:bg-[#e8eaef]',
+                ].join(' ')}
+                onClick={() => setScope(option.value)}
+              >
+                {option.label}
+              </button>
+            );
+          })}
         </div>
-        <Form form={form} layout="inline" onFinish={search} className="mb-5 gap-y-2">
-          <Form.Item name="name" label="名称">
-            <Input allowClear />
-          </Form.Item>
-          <Form.Item name="code" label="编码">
-            <Input allowClear />
-          </Form.Item>
-          <Form.Item name="type" label="类型">
-            <Select
-              allowClear
-              className="w-32"
-              options={[
-                { value: 'MENU', label: 'MENU' },
-                { value: 'API', label: 'API' },
-                { value: 'BUTTON', label: 'BUTTON' },
-              ]}
-            />
-          </Form.Item>
-          <Button htmlType="submit" type="primary">
-            查询
-          </Button>
-          <Button
-            onClick={() => {
-              form.resetFields();
-              setVisibleTree(tree);
-            }}
-          >
-            重置
-          </Button>
-        </Form>
-        <div className="grid grid-cols-1 gap-5 lg:grid-cols-[360px_1fr]">
-          <Card size="small" title="权限树">
-            <TreeSearch
-              nodes={nodes}
+
+        <div className="flex shrink-0 flex-wrap items-center gap-2">
+          <Input
+            allowClear
+            value={keyword}
+            prefix={<SearchOutlined className="text-slate-400" />}
+            placeholder="搜索权限名称、编码、描述或 ID"
+            className="w-[360px] max-w-full"
+            onChange={(event) => setKeyword(event.target.value)}
+          />
+
+          <Tooltip title="刷新权限树">
+            <Button
+              icon={<ReloadOutlined />}
               loading={loading}
-              keyword={keyword}
-              onKeywordChange={setKeyword}
-              selectedKey={selectedId}
-              onSelect={(id) => void select(id)}
-              placeholder="在结果中按名称、编码、类型筛选"
+              onClick={() => void loadTree()}
             />
-          </Card>
-          <Card
-            size="small"
-            title="权限详情"
-            loading={detailLoading}
-            extra={
-              detail && (
-                <PermissionGuard mode="one" permission="system:permission:delete">
-                  <Button danger icon={<DeleteOutlined />} onClick={remove}>
-                    删除
-                  </Button>
-                </PermissionGuard>
-              )
-            }
+          </Tooltip>
+
+          <PermissionGuard
+            mode="one"
+            permission={permissionRequirement('import')}
           >
-            {detail ? (
-              <Descriptions bordered column={1}>
-                {fields
-                  .filter((field) => field in detail)
-                  .map((field) => (
-                    <Descriptions.Item key={field} label={labels[field]}>
-                      {field === 'status' ? (
-                        <Tag>{String(detail[field as keyof PermissionVO] ?? '-')}</Tag>
-                      ) : (
-                        String(detail[field as keyof PermissionVO] ?? '-')
-                      )}
-                    </Descriptions.Item>
-                  ))}
-              </Descriptions>
-            ) : (
-              <Typography.Text type="secondary">请从左侧选择一个权限节点。</Typography.Text>
-            )}
-          </Card>
+            <Button
+              type="primary"
+              icon={<ImportOutlined />}
+              onClick={() => setImportOpen(true)}
+            >
+              导入权限
+            </Button>
+          </PermissionGuard>
         </div>
-      </Card>
-      <ImportModal open={importOpen} onClose={() => setImportOpen(false)} onImported={() => void loadTree()} />
+      </div>
+
+      <div className="grid min-h-0 flex-1 overflow-hidden rounded-lg border border-slate-200 bg-white lg:grid-cols-[390px_minmax(0,1fr)]">
+        <aside className="flex min-h-0 flex-col border-b border-slate-200 lg:border-b-0 lg:border-r">
+          <div className="flex h-14 shrink-0 items-center justify-between border-b border-slate-100 px-4">
+            <div>
+              <div className="font-medium text-slate-800">
+                权限树
+              </div>
+              <div className="mt-0.5 text-xs text-slate-400">
+                当前显示 {collectPermissionIds(visiblePermissions).length} 个节点
+              </div>
+            </div>
+
+            <Space size={2}>
+              <Tooltip title="展开全部">
+                <Button
+                  type="text"
+                  size="small"
+                  icon={<PlusSquareOutlined />}
+                  onClick={() =>
+                    setExpandedKeys(
+                      collectPermissionIds(visiblePermissions),
+                    )
+                  }
+                />
+              </Tooltip>
+              <Tooltip title="收起全部">
+                <Button
+                  type="text"
+                  size="small"
+                  icon={<MinusSquareOutlined />}
+                  onClick={() => setExpandedKeys([])}
+                />
+              </Tooltip>
+            </Space>
+          </div>
+
+          <div className="min-h-0 flex-1 overflow-y-auto px-2 py-3">
+            <Spin spinning={loading}>
+              {!loading && treeData.length === 0 ? (
+                <Empty
+                  className="mt-16"
+                  image={Empty.PRESENTED_IMAGE_SIMPLE}
+                  description={
+                    keyword.trim() || scope !== 'all'
+                      ? '没有匹配的权限'
+                      : '暂无权限数据'
+                  }
+                />
+              ) : (
+                <Tree
+                  blockNode
+                  showLine={{ showLeafIcon: false }}
+                  treeData={treeData}
+                  selectedKeys={
+                    selectedId === undefined ? [] : [selectedId]
+                  }
+                  expandedKeys={expandedKeys}
+                  autoExpandParent={Boolean(
+                    keyword.trim() || scope !== 'all',
+                  )}
+                  onExpand={(keys) => setExpandedKeys(keys)}
+                  onSelect={(keys) => {
+                    const value = Number(keys[0]);
+                    if (Number.isFinite(value)) {
+                      setSelectedId(value);
+                    }
+                  }}
+                />
+              )}
+            </Spin>
+          </div>
+        </aside>
+
+        <main className="min-h-0 overflow-y-auto">
+          {selectedPermission ? (
+            <div className="min-h-full">
+              <div className="flex min-h-20 items-center justify-between gap-4 border-b border-slate-100 px-6 py-4">
+                <div className="flex min-w-0 items-center gap-3">
+                  <Avatar
+                    size={46}
+                    icon={<FileProtectOutlined />}
+                    className="shrink-0 !bg-slate-600"
+                  />
+
+                  <div className="min-w-0">
+                    <div className="flex min-w-0 flex-wrap items-center gap-2">
+                      <Typography.Title
+                        level={5}
+                        className="!mb-0 !text-slate-800"
+                      >
+                        {permissionName(selectedPermission)}
+                      </Typography.Title>
+
+                      <Tag
+                        icon={
+                          selectedPermission.active === false ? (
+                            <StopOutlined />
+                          ) : (
+                            <CheckCircleOutlined />
+                          )
+                        }
+                        color={
+                          selectedPermission.active === false
+                            ? 'default'
+                            : 'success'
+                        }
+                      >
+                        {selectedPermission.active === false
+                          ? '已停用'
+                          : '已启用'}
+                      </Tag>
+
+                      <Tag>
+                        {selectedPermission.declared === true
+                          ? '声明式权限'
+                          : '手工权限'}
+                      </Tag>
+                    </div>
+
+                    <div className="mt-1 truncate font-mono text-xs text-slate-400">
+                      {permissionCode(selectedPermission)}
+                    </div>
+                  </div>
+                </div>
+
+                <PermissionGuard
+                  mode="one"
+                  permission={permissionRequirement('delete')}
+                >
+                  <Tooltip title={disabledReason || '删除权限'}>
+                    <span>
+                      <Button
+                        danger
+                        icon={<DeleteOutlined />}
+                        disabled={Boolean(disabledReason)}
+                        onClick={() =>
+                          removePermission(selectedPermission)
+                        }
+                      >
+                        删除
+                      </Button>
+                    </span>
+                  </Tooltip>
+                </PermissionGuard>
+              </div>
+
+              <div className="space-y-6 p-6">
+                <div>
+                  <div className="mb-2 text-sm font-medium text-slate-800">
+                    权限路径
+                  </div>
+                  <div className="flex flex-wrap items-center gap-1 rounded-lg border border-slate-200 bg-slate-50/60 px-3 py-2 text-sm text-slate-600">
+                    {selectedPath.map((permission, index) => (
+                      <span
+                        key={permission.id}
+                        className="flex items-center gap-1"
+                      >
+                        {index > 0 && (
+                          <span className="text-slate-300">/</span>
+                        )}
+                        <button
+                          type="button"
+                          className="rounded px-1 py-0.5 hover:bg-white hover:text-slate-900"
+                          onClick={() =>
+                            setSelectedId(permission.id)
+                          }
+                        >
+                          {permissionName(permission)}
+                        </button>
+                      </span>
+                    ))}
+                  </div>
+                </div>
+
+                <Descriptions
+                  bordered
+                  size="small"
+                  column={{ xs: 1, sm: 2 }}
+                  items={[
+                    {
+                      key: 'id',
+                      label: '权限 ID',
+                      children: selectedPermission.id,
+                    },
+                    {
+                      key: 'parentId',
+                      label: '父权限 ID',
+                      children:
+                        selectedPermission.parentId === undefined ||
+                        selectedPermission.parentId === null ||
+                        selectedPermission.parentId === 0
+                          ? '根节点'
+                          : selectedPermission.parentId,
+                    },
+                    {
+                      key: 'nodeType',
+                      label: '节点类型',
+                      children:
+                        selectedPermission.leaf === false ||
+                        selectedChildren.length > 0
+                          ? '权限分组'
+                          : '叶子权限',
+                    },
+                    {
+                      key: 'children',
+                      label: '直属子权限',
+                      children: `${selectedChildren.length} 个`,
+                    },
+                    {
+                      key: 'active',
+                      label: '启用状态',
+                      children:
+                        selectedPermission.active === false
+                          ? '停用'
+                          : '启用',
+                    },
+                    {
+                      key: 'declared',
+                      label: '数据来源',
+                      children:
+                        selectedPermission.declared === true
+                          ? '后端声明同步'
+                          : '手工导入',
+                    },
+                  ]}
+                />
+
+                <div>
+                  <div className="mb-2 text-sm font-medium text-slate-800">
+                    权限描述
+                  </div>
+                  <div className="min-h-20 rounded-lg border border-slate-200 bg-white px-4 py-3 text-sm leading-6 text-slate-600">
+                    {selectedPermission.description || '暂无权限描述'}
+                  </div>
+                </div>
+
+                <div>
+                  <div className="mb-2 flex items-center justify-between">
+                    <span className="text-sm font-medium text-slate-800">
+                      直属子权限
+                    </span>
+                    <span className="text-xs text-slate-400">
+                      {selectedChildren.length} 个
+                    </span>
+                  </div>
+
+                  <div className="rounded-lg border border-slate-200 bg-white p-3">
+                    {selectedChildren.length === 0 ? (
+                      <span className="text-sm text-slate-400">
+                        当前节点没有子权限
+                      </span>
+                    ) : (
+                      <div className="grid grid-cols-1 gap-2 xl:grid-cols-2">
+                        {selectedChildren.map((child) => (
+                          <button
+                            key={child.id}
+                            type="button"
+                            className="min-w-0 rounded-lg border border-slate-200 px-3 py-2 text-left transition-colors hover:border-slate-300 hover:bg-slate-50"
+                            onClick={() => setSelectedId(child.id)}
+                          >
+                            <div className="truncate text-sm font-medium text-slate-700">
+                              {permissionName(child)}
+                            </div>
+                            <div className="mt-1 truncate font-mono text-xs text-slate-400">
+                              {permissionCode(child)}
+                            </div>
+                          </button>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                </div>
+
+                {selectedPermission.declared === true && (
+                  <div className="rounded-lg border border-blue-100 bg-blue-50/70 px-4 py-3 text-sm leading-6 text-blue-700">
+                    该权限由后端声明式注册机制维护。后端同步时可能更新其状态或重新创建记录，因此页面不提供手工删除操作。
+                  </div>
+                )}
+              </div>
+            </div>
+          ) : (
+            <div className="flex min-h-full items-center justify-center p-8">
+              <Empty
+                image={Empty.PRESENTED_IMAGE_SIMPLE}
+                description={
+                  keyword.trim() || scope !== 'all'
+                    ? '没有符合条件的权限'
+                    : '请从左侧选择权限节点'
+                }
+              />
+            </div>
+          )}
+        </main>
+      </div>
+
+      <ImportModal
+        open={importOpen}
+        onClose={() => setImportOpen(false)}
+        onImported={() => void loadTree()}
+      />
     </section>
   );
 }

--- a/yak-ops-ui/src/pages/system/permissions/tree.ts
+++ b/yak-ops-ui/src/pages/system/permissions/tree.ts
@@ -1,116 +1,226 @@
-import type { SearchTreeNode } from '@/components/security/TreeSearch';
 import type {
   PermissionVO,
   TreeId,
-} from '../../../services/security/permissions';
+} from '@/services/security/permissions';
 
-const safeArray = <T>(
-  value: T[] | null | undefined,
-): T[] => (Array.isArray(value) ? value : []);
+export type PermissionScope =
+  | 'all'
+  | 'active'
+  | 'inactive'
+  | 'declared'
+  | 'manual';
 
-export const permissionTreeNodes = (
-  items: PermissionVO[] | null | undefined,
+export interface PermissionTreeStats {
+  total: number;
+  active: number;
+  inactive: number;
+  declared: number;
+  manual: number;
+}
+
+const safeChildren = (
+  node?: PermissionVO,
+): PermissionVO[] =>
+  Array.isArray(node?.childList) ? node.childList : [];
+
+/** Hide the backend's id=0 virtual root from the management UI. */
+export const getPermissionForest = (
+  root?: PermissionVO,
+): PermissionVO[] => {
+  if (!root) return [];
+
+  const virtualRoot =
+    Number(root.id) === 0 &&
+    !root.permissionName &&
+    !root.permissionCode;
+
+  return virtualRoot ? safeChildren(root) : [root];
+};
+
+const matchesScope = (
+  node: PermissionVO,
+  scope: PermissionScope,
+): boolean => {
+  switch (scope) {
+    case 'active':
+      return node.active !== false;
+    case 'inactive':
+      return node.active === false;
+    case 'declared':
+      return node.declared === true;
+    case 'manual':
+      return node.declared !== true;
+    default:
+      return true;
+  }
+};
+
+const matchesKeyword = (
+  node: PermissionVO,
+  keyword: string,
+): boolean => {
+  const query = keyword.trim().toLocaleLowerCase();
+  if (!query) return true;
+
+  return [
+    node.id,
+    node.permissionName,
+    node.permissionCode,
+    node.description,
+  ]
+    .filter((value) => value !== undefined && value !== null)
+    .some((value) =>
+      String(value).toLocaleLowerCase().includes(query),
+    );
+};
+
+/**
+ * Filter nodes locally because the backend exposes one complete tree endpoint.
+ * Every ancestor of a matching node is retained so the hierarchy stays clear.
+ */
+export const filterPermissionTree = (
+  nodes: PermissionVO[],
+  keyword: string,
+  scope: PermissionScope,
   path = new Set<string>(),
-): SearchTreeNode[] =>
-  safeArray(items).flatMap((item) => {
-    const key = String(item.id);
-
-    if (path.has(key)) {
-      return [];
-    }
+): PermissionVO[] =>
+  nodes.flatMap((node) => {
+    const key = String(node.id);
+    if (path.has(key)) return [];
 
     const nextPath = new Set(path);
     nextPath.add(key);
 
-    return [
-      {
-        key: item.id,
-        title: item.name,
-        searchText: [
-          item.name,
-          item.code,
-          item.type,
-        ]
-          .filter(Boolean)
-          .join(' '),
-        children: permissionTreeNodes(
-          item.children,
-          nextPath,
-        ),
-      },
-    ];
+    const children = filterPermissionTree(
+      safeChildren(node),
+      keyword,
+      scope,
+      nextPath,
+    );
+
+    const matched =
+      matchesScope(node, scope) &&
+      matchesKeyword(node, keyword);
+
+    return matched || children.length > 0
+      ? [{ ...node, childList: children }]
+      : [];
   });
 
-export const collectTreeIds = <
-  T extends {
-    id: TreeId;
-    children?: T[];
-  },
->(
-  items: T[] | null | undefined,
-): Set<string> => {
-  const ids = new Set<string>();
+export const collectPermissionIds = (
+  nodes: PermissionVO[],
+): number[] => {
+  const ids: number[] = [];
+  const visited = new Set<string>();
 
-  const visit = (
-    nodes: T[] | null | undefined,
-    path: Set<string>,
-  ) => {
-    for (const node of safeArray(nodes)) {
-      const id = String(node.id);
+  const visit = (items: PermissionVO[]) => {
+    for (const node of items) {
+      const key = String(node.id);
+      if (visited.has(key)) continue;
 
-      if (path.has(id)) {
-        continue;
-      }
-
-      ids.add(id);
-
-      const nextPath = new Set(path);
-      nextPath.add(id);
-
-      visit(node.children, nextPath);
+      visited.add(key);
+      ids.push(Number(node.id));
+      visit(safeChildren(node));
     }
   };
 
-  visit(items, new Set());
-
-  return ids;
+  visit(nodes);
+  return ids.filter(Number.isFinite);
 };
 
-export const retainMatchedAncestors = <
-  T extends {
-    id: TreeId;
-    children?: T[];
-  },
->(
-  tree: T[] | null | undefined,
-  matches: T[] | null | undefined,
-): T[] => {
-  const matchedIds = collectTreeIds(matches);
+export const findPermissionById = (
+  nodes: PermissionVO[],
+  id?: TreeId,
+): PermissionVO | undefined => {
+  if (id === undefined || id === null) return undefined;
+
+  const expected = String(id);
+  const visited = new Set<string>();
+  const queue = [...nodes];
+
+  while (queue.length > 0) {
+    const node = queue.shift();
+    if (!node) continue;
+
+    const key = String(node.id);
+    if (visited.has(key)) continue;
+    visited.add(key);
+
+    if (key === expected) return node;
+    queue.push(...safeChildren(node));
+  }
+
+  return undefined;
+};
+
+export const findPermissionPath = (
+  nodes: PermissionVO[],
+  id?: TreeId,
+): PermissionVO[] => {
+  if (id === undefined || id === null) return [];
+  const expected = String(id);
 
   const visit = (
-    nodes: T[] | null | undefined,
+    items: PermissionVO[],
+    ancestors: PermissionVO[],
     path: Set<string>,
-  ): T[] =>
-    safeArray(nodes).flatMap((node) => {
-      const id = String(node.id);
+  ): PermissionVO[] | undefined => {
+    for (const node of items) {
+      const key = String(node.id);
+      if (path.has(key)) continue;
 
-      if (path.has(id)) {
-        return [];
-      }
+      const nextAncestors = [...ancestors, node];
+      if (key === expected) return nextAncestors;
 
       const nextPath = new Set(path);
-      nextPath.add(id);
-
-      const children = visit(
-        node.children,
+      nextPath.add(key);
+      const found = visit(
+        safeChildren(node),
+        nextAncestors,
         nextPath,
       );
+      if (found) return found;
+    }
 
-      return matchedIds.has(id) ||
-        children.length > 0
-        ? [{ ...node, children }]
-        : [];
-    });
+    return undefined;
+  };
 
-  return visit(tree, new Set());
+  return visit(nodes, [], new Set()) ?? [];
 };
+
+export const getPermissionTreeStats = (
+  nodes: PermissionVO[],
+): PermissionTreeStats => {
+  const stats: PermissionTreeStats = {
+    total: 0,
+    active: 0,
+    inactive: 0,
+    declared: 0,
+    manual: 0,
+  };
+  const visited = new Set<string>();
+
+  const visit = (items: PermissionVO[]) => {
+    for (const node of items) {
+      const key = String(node.id);
+      if (visited.has(key)) continue;
+      visited.add(key);
+
+      stats.total += 1;
+      if (node.active === false) stats.inactive += 1;
+      else stats.active += 1;
+
+      if (node.declared === true) stats.declared += 1;
+      else stats.manual += 1;
+
+      visit(safeChildren(node));
+    }
+  };
+
+  visit(nodes);
+  return stats;
+};
+
+export const getDirectChildren = (
+  node?: PermissionVO,
+): PermissionVO[] => safeChildren(node);

--- a/yak-ops-ui/src/services/security/permissions.ts
+++ b/yak-ops-ui/src/services/security/permissions.ts
@@ -1,52 +1,62 @@
-import { securityDeleteData, securityGetData, securityUploadData } from './client';
+import {
+  securityDeleteData,
+  securityGetData,
+  securityPostData,
+} from './client';
 
 const PERMISSION_API = '/api/v1/permission';
 
 export type TreeId = string | number;
 
+/**
+ * Permission tree node returned by Yak Security.
+ *
+ * The backend returns one virtual root node whose real permissions live in
+ * childList. The virtual root has id=0 and no name/code.
+ */
 export interface PermissionVO {
-  id: TreeId;
-  name: string;
-  code: string;
-  type: string;
-  parentId?: TreeId | null;
-  resource?: string | null;
+  id: number;
+  has?: boolean;
+  permissionCode?: string;
+  permissionName?: string;
+  parentId?: number | null;
+  leaf?: boolean;
   description?: string | null;
-  sort?: number | null;
-  status?: string | number | boolean | null;
-  children?: PermissionVO[];
+  active?: boolean;
+  declared?: boolean;
+  childList?: PermissionVO[];
 }
 
-export interface PermissionSearchParams {
-  name?: string;
-  code?: string;
-  type?: string;
+/** DTO accepted by POST /permission/import. */
+export interface PermissionImportItem {
+  permissionCode: string;
+  permissionName: string;
+  description?: string;
+  childPermissionDTOList?: PermissionImportItem[];
 }
 
-export interface ImportReport {
-  successCount: number;
-  failureCount: number;
-  failures?: Array<{ row?: number; code?: string; message: string }>;
-}
+/** Query the complete permission tree. */
+export const getPermissionTree = (): Promise<PermissionVO> =>
+  securityGetData<PermissionVO>(`${PERMISSION_API}/tree`);
 
-const queryString = (params: PermissionSearchParams) => {
-  const query = new URLSearchParams();
-  for (const [key, value] of Object.entries(params)) if (value?.trim()) query.set(key, value.trim());
-  const value = query.toString();
-  return value ? `?${value}` : '';
-};
+/**
+ * Import a permission DTO tree.
+ *
+ * The backend accepts a JSON array rather than multipart/form-data, so files
+ * are parsed in the browser before this request is sent.
+ */
+export const importPermissions = (
+  permissions: PermissionImportItem[],
+): Promise<void> =>
+  securityPostData<void>(
+    `${PERMISSION_API}/import`,
+    permissions,
+  );
 
-export const getPermissionTree = (): Promise<PermissionVO[]> =>
-  securityGetData<PermissionVO[]>(`${PERMISSION_API}/tree`);
-
-export const searchPermissions = (params: PermissionSearchParams): Promise<PermissionVO[]> =>
-  securityGetData<PermissionVO[]>(`${PERMISSION_API}/search${queryString(params)}`);
-
-export const getPermissionDetail = (id: TreeId): Promise<PermissionVO> =>
-  securityGetData<PermissionVO>(`${PERMISSION_API}/${encodeURIComponent(String(id))}`);
-
-export const importPermissions = (file: File): Promise<ImportReport> =>
-  securityUploadData<ImportReport>(`${PERMISSION_API}/import`, file);
-
-export const deletePermission = (id: TreeId): Promise<void> =>
-  securityDeleteData<void>(`${PERMISSION_API}/${encodeURIComponent(String(id))}`);
+/** Delete one permission and its role-permission relationships. */
+export const deletePermission = (
+  id: TreeId,
+): Promise<void> =>
+  securityDeleteData<void>(
+    `${PERMISSION_API}/${encodeURIComponent(String(id))}`,
+  );


### PR DESCRIPTION
## 变更内容

- 重构权限管理页面，移除多层 Card 堆叠，改为与系统管理页面一致的简洁布局
- 使用固定高度左右分栏，权限树与详情区域独立滚动，避免整页高度和滚动异常
- 增加全部、启用、停用、声明式、手工导入快捷筛选
- 增加按权限名称、编码、描述和 ID 的本地树搜索，并保留匹配节点祖先路径
- 增加权限路径、节点状态、来源、直属子权限等详情展示
- 增加树展开全部、收起全部和刷新操作
- 优化删除提示及安全限制：声明式权限、包含子节点的权限不可手工删除
- 重做权限导入弹窗，支持选择 JSON 文件或直接粘贴 JSON，并在提交前校验结构和重复编码

## 修复的问题

原实现与 `yak-security` 后端接口存在多处不一致：

- 后端 `GET /permission/tree` 返回一个带 `childList` 的虚拟根节点，原前端错误地按数组和 `children` 解析
- 后端字段为 `permissionName`、`permissionCode`、`active`、`declared`，原前端使用了不存在的 `name`、`code`、`type`、`status`
- 原前端调用了后端不存在的 `/permission/search` 和 `GET /permission/{id}` 接口
- 后端导入接口接收 JSON 数组，原前端错误地提交 multipart 文件并期望导入报告
- 原删除提示声称后端会阻止子节点删除，但当前后端只删除指定权限及角色关联；新页面在前端阻止删除权限分组，避免产生孤立节点
- 权限操作编码统一调整为 `security:permission:*`，与路由权限编码保持一致

## 实际接入接口

- `GET /yak-security/api/v1/permission/tree`
- `POST /yak-security/api/v1/permission/import`
- `DELETE /yak-security/api/v1/permission/{permissionId}`

## 验证

- 已逐项核对 `PermissionController`、`PermissionDTO`、`PermissionTreeVO` 和前端请求字段
- 已静态复核树过滤、选中状态、虚拟根节点处理、删除限制和 JSON 导入校验
- 当前执行环境无法访问 GitHub 网络进行本地仓库检出，因此未运行 `npm run tsc` / `npm run build`；建议由 CI 或本地在合并前执行一次完整检查
