### PR TITLE
修复权限重构后的部门管理兼容类型

### DIFF
--- a/yak-ops-ui/src/pages/system/permissions/tree.ts
+++ b/yak-ops-ui/src/pages/system/permissions/tree.ts
@@ -224,3 +224,65 @@ export const getPermissionTreeStats = (
 export const getDirectChildren = (
   node?: PermissionVO,
 ): PermissionVO[] => safeChildren(node);
+
+/**
+ * Compatibility helper shared by department management.
+ *
+ * Search endpoints may return only the matching nodes. This function filters
+ * the original tree while retaining every ancestor of a matched node, so the
+ * result keeps its hierarchy. String-normalized IDs also support mixed numeric
+ * and string identifiers, and the traversal guards against cyclic data.
+ */
+export const retainMatchedAncestors = <
+  T extends {
+    id: TreeId;
+    children?: T[];
+  },
+>(
+  tree: T[] | null | undefined,
+  matches: T[] | null | undefined,
+): T[] => {
+  const safeArray = (
+    value: T[] | null | undefined,
+  ): T[] => (Array.isArray(value) ? value : []);
+
+  const matchedIds = new Set<string>();
+
+  const collectMatchedIds = (
+    nodes: T[] | null | undefined,
+    path: Set<string>,
+  ) => {
+    for (const node of safeArray(nodes)) {
+      const key = String(node.id);
+      if (path.has(key)) continue;
+
+      matchedIds.add(key);
+
+      const nextPath = new Set(path);
+      nextPath.add(key);
+      collectMatchedIds(node.children, nextPath);
+    }
+  };
+
+  collectMatchedIds(matches, new Set());
+
+  const visit = (
+    nodes: T[] | null | undefined,
+    path: Set<string>,
+  ): T[] =>
+    safeArray(nodes).flatMap((node) => {
+      const key = String(node.id);
+      if (path.has(key)) return [];
+
+      const nextPath = new Set(path);
+      nextPath.add(key);
+
+      const children = visit(node.children, nextPath);
+
+      return matchedIds.has(key) || children.length > 0
+        ? [{ ...node, children } as T]
+        : [];
+    });
+
+  return visit(tree, new Set());
+};

--- a/yak-ops-ui/src/services/security/permissions.ts
+++ b/yak-ops-ui/src/services/security/permissions.ts
@@ -6,7 +6,22 @@ import {
 
 const PERMISSION_API = '/api/v1/permission';
 
+/** Shared identifier type used by permission and department trees. */
 export type TreeId = string | number;
+
+/**
+ * Compatibility report used by legacy file-import pages such as department
+ * management. Permission import itself now submits a JSON tree and returns void.
+ */
+export interface ImportReport {
+  successCount: number;
+  failureCount: number;
+  failures?: Array<{
+    row?: number;
+    code?: string;
+    message: string;
+  }>;
+}
 
 /**
  * Permission tree node returned by Yak Security.


### PR DESCRIPTION
## 修复内容

权限管理 PR #66 合并后，部门管理仍复用了权限模块中的部分公共类型和树工具，导致 TypeScript 导入报错。本次补回兼容导出，不改变新权限管理页面的行为。

- 保留并明确导出共享树节点类型 `TreeId`
- 恢复部门导入页面依赖的 `ImportReport`
- 恢复部门搜索依赖的 `retainMatchedAncestors`
- `retainMatchedAncestors` 支持字符串/数字混合 ID、祖先链保留和循环数据保护

## 影响范围

- `src/services/security/permissions.ts`
- `src/pages/system/permissions/tree.ts`

## 对应报错

- `Module has no exported member 'ImportReport'`
- `Module has no exported member 'retainMatchedAncestors'`
- 本地尚未拉取最新主分支时，也可能同时看到 `TreeId` 导入报错；远端主分支本身已包含该类型，本次继续保留。
