### PR TITLE
重构部门管理为左右分栏并修复接口集成

### DIFF
--- a/yak-ops-ui/src/pages/system/departments/ImportModal.tsx
+++ b/yak-ops-ui/src/pages/system/departments/ImportModal.tsx
@@ -1,86 +1,286 @@
-import { InboxOutlined } from '@ant-design/icons';
-import type { UploadFile } from 'antd';
-import { Alert, Button, Descriptions, Modal, message, Upload } from 'antd';
-import { useState } from 'react';
-import { importDepartments } from '@/services/security/departments';
-import type { ImportReport } from '@/services/security/permissions';
+import {
+  FileTextOutlined,
+  UploadOutlined,
+} from '@ant-design/icons';
+import {
+  Alert,
+  Button,
+  Input,
+  Modal,
+  Space,
+  Tag,
+  Typography,
+  Upload,
+  message,
+} from 'antd';
+import { useMemo, useState } from 'react';
+
+import {
+  type DepartmentImportItem,
+  importDepartments,
+} from '@/services/security/departments';
+
+interface DepartmentImportModalProps {
+  open: boolean;
+  onClose: () => void;
+  onImported: () => void;
+}
+
+const EXAMPLE_JSON = JSON.stringify(
+  [
+    {
+      deptName: '技术中心',
+      description: '负责产品研发和技术平台建设',
+      childDeptDTOList: [
+        {
+          deptName: '前端研发部',
+          description: '负责 Web 与移动端研发',
+        },
+        {
+          deptName: '后端研发部',
+          description: '负责服务端与基础架构研发',
+        },
+      ],
+    },
+  ],
+  null,
+  2,
+);
+
+const isRecord = (
+  value: unknown,
+): value is Record<string, unknown> =>
+  typeof value === 'object' &&
+  value !== null &&
+  !Array.isArray(value);
+
+const parseDepartmentNode = (
+  value: unknown,
+  path: string,
+): DepartmentImportItem => {
+  if (!isRecord(value)) {
+    throw new Error(`${path} 必须是 JSON 对象`);
+  }
+
+  const deptName =
+    typeof value.deptName === 'string'
+      ? value.deptName.trim()
+      : '';
+
+  if (!deptName) {
+    throw new Error(`${path} 缺少部门名称 deptName`);
+  }
+
+  if (
+    value.description !== undefined &&
+    typeof value.description !== 'string'
+  ) {
+    throw new Error(`${path}.description 必须是字符串`);
+  }
+
+  const childValue = value.childDeptDTOList;
+  if (childValue !== undefined && !Array.isArray(childValue)) {
+    throw new Error(`${path}.childDeptDTOList 必须是数组`);
+  }
+
+  const children = (childValue ?? []).map((child, index) =>
+    parseDepartmentNode(
+      child,
+      `${path}.childDeptDTOList[${index}]`,
+    ),
+  );
+
+  return {
+    deptName,
+    ...(typeof value.description === 'string' &&
+    value.description.trim()
+      ? { description: value.description.trim() }
+      : {}),
+    ...(children.length > 0
+      ? { childDeptDTOList: children }
+      : {}),
+  };
+};
+
+const parseImportJson = (
+  source: string,
+): DepartmentImportItem[] => {
+  let value: unknown;
+
+  try {
+    value = JSON.parse(source);
+  } catch {
+    throw new Error('JSON 格式不正确，请检查逗号、引号和括号');
+  }
+
+  if (!Array.isArray(value) || value.length === 0) {
+    throw new Error('顶层必须是非空 JSON 数组');
+  }
+
+  return value.map((node, index) =>
+    parseDepartmentNode(node, `[${index}]`),
+  );
+};
+
+const countNodes = (
+  nodes: DepartmentImportItem[],
+): number =>
+  nodes.reduce(
+    (total, node) =>
+      total +
+      1 +
+      countNodes(node.childDeptDTOList ?? []),
+    0,
+  );
+
+const errorText = (error: unknown, fallback: string): string =>
+  error instanceof Error && error.message
+    ? error.message
+    : fallback;
 
 export default function ImportModal({
   open,
   onClose,
   onImported,
-}: {
-  open: boolean;
-  onClose: () => void;
-  onImported: () => void;
-}) {
-  const [files, setFiles] = useState<UploadFile[]>([]);
-  const [loading, setLoading] = useState(false);
-  const [report, setReport] = useState<ImportReport>();
-  const submit = async () => {
-    const file = files[0]?.originFileObj;
-    if (!file) return;
-    setLoading(true);
+}: DepartmentImportModalProps) {
+  const [source, setSource] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  const preview = useMemo(() => {
+    if (!source.trim()) {
+      return {
+        data: undefined,
+        count: 0,
+        error: undefined,
+      };
+    }
+
     try {
-      const result = await importDepartments(file);
-      setReport(result);
-      message.success(`导入完成：成功 ${result.successCount}，失败 ${result.failureCount}`);
+      const data = parseImportJson(source);
+      return {
+        data,
+        count: countNodes(data),
+        error: undefined,
+      };
+    } catch (error) {
+      return {
+        data: undefined,
+        count: 0,
+        error: errorText(error, '部门 JSON 校验失败'),
+      };
+    }
+  }, [source]);
+
+  const close = () => {
+    if (!saving) onClose();
+  };
+
+  const submit = async () => {
+    if (!preview.data || saving) return;
+
+    setSaving(true);
+    try {
+      await importDepartments(preview.data);
+      message.success(`部门导入成功，共 ${preview.count} 个节点`);
+      onClose();
       onImported();
+    } catch (error) {
+      message.error(errorText(error, '部门导入失败'));
     } finally {
-      setLoading(false);
+      setSaving(false);
     }
   };
+
   return (
     <Modal
-      title="导入部门"
       open={open}
-      onCancel={onClose}
-      footer={[
-        <Button key="close" onClick={onClose}>
-          关闭
-        </Button>,
-        <Button key="import" type="primary" loading={loading} disabled={!files.length} onClick={submit}>
-          开始导入
-        </Button>,
-      ]}
+      title="导入部门树"
+      width={760}
+      maskClosable={false}
+      keyboard={!saving}
+      closable={!saving}
+      onCancel={close}
+      afterClose={() => setSource('')}
+      footer={
+        <Space>
+          <Button disabled={saving} onClick={close}>
+            取消
+          </Button>
+          <Button
+            type="primary"
+            loading={saving}
+            disabled={!preview.data}
+            onClick={() => void submit()}
+          >
+            确认导入
+          </Button>
+        </Space>
+      }
     >
       <Alert
-        className="mb-4"
-        type="info"
         showIcon
-        message="请使用服务端约定的导入模板"
-        description="文件中的父部门必须先于子部门；请在导入前检查重复编码和父部门标识。"
+        type="info"
+        className="mb-4"
+        message="后端接收 JSON 部门树"
+        description="请选择 JSON 文件或直接粘贴内容。系统会按层级生成部门 ID 和父子关系；数据库约束冲突会由后端返回错误。"
       />
-      <Upload.Dragger
-        maxCount={1}
-        fileList={files}
-        beforeUpload={() => false}
-        onChange={({ fileList }) => {
-          setFiles(fileList.slice(-1));
-          setReport(undefined);
-        }}
-      >
-        <p className="ant-upload-drag-icon">
-          <InboxOutlined />
-        </p>
-        <p>点击或拖拽部门文件到此处</p>
-      </Upload.Dragger>
-      {report && (
-        <Descriptions className="mt-4" bordered column={2} size="small">
-          <Descriptions.Item label="成功">{report.successCount}</Descriptions.Item>
-          <Descriptions.Item label="失败">{report.failureCount}</Descriptions.Item>
-          {report.failures?.length ? (
-            <Descriptions.Item label="失败明细" span={2}>
-              {report.failures.map((item, index) => (
-                <div key={`${item.row ?? index}-${item.code ?? ''}`}>
-                  {item.row ? `第 ${item.row} 行：` : ''}
-                  {item.message}
-                </div>
-              ))}
-            </Descriptions.Item>
-          ) : null}
-        </Descriptions>
-      )}
+
+      <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+        <Space wrap>
+          <Upload
+            accept=".json,application/json"
+            maxCount={1}
+            showUploadList={false}
+            beforeUpload={(file) => {
+              void file
+                .text()
+                .then(setSource)
+                .catch(() => message.error('JSON 文件读取失败'));
+              return false;
+            }}
+          >
+            <Button icon={<UploadOutlined />}>
+              选择 JSON 文件
+            </Button>
+          </Upload>
+
+          <Button
+            type="link"
+            icon={<FileTextOutlined />}
+            onClick={() => setSource(EXAMPLE_JSON)}
+          >
+            填充示例
+          </Button>
+        </Space>
+
+        {preview.data && (
+          <Tag color="success">
+            已识别 {preview.count} 个部门节点
+          </Tag>
+        )}
+      </div>
+
+      <Input.TextArea
+        value={source}
+        placeholder={EXAMPLE_JSON}
+        autoSize={{ minRows: 14, maxRows: 22 }}
+        className="font-mono text-xs"
+        status={preview.error ? 'error' : undefined}
+        disabled={saving}
+        onChange={(event) => setSource(event.target.value)}
+      />
+
+      <div className="mt-2 min-h-6">
+        {preview.error ? (
+          <Typography.Text type="danger">
+            {preview.error}
+          </Typography.Text>
+        ) : (
+          <Typography.Text type="secondary" className="text-xs">
+            字段：deptName、description、childDeptDTOList。
+          </Typography.Text>
+        )}
+      </div>
     </Modal>
   );
 }

--- a/yak-ops-ui/src/pages/system/departments/index.tsx
+++ b/yak-ops-ui/src/pages/system/departments/index.tsx
@@ -1,131 +1,555 @@
-import { ImportOutlined, ReloadOutlined } from '@ant-design/icons';
-import { Button, Card, Form, Input, Space, Typography } from 'antd';
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import { JsonDetailDrawer, PermissionGuard, TreeSearch } from '@/components/security';
+import {
+  ApartmentOutlined,
+  ImportOutlined,
+  MinusSquareOutlined,
+  PlusSquareOutlined,
+  ReloadOutlined,
+  SearchOutlined,
+} from '@ant-design/icons';
+import type { DataNode } from 'antd/es/tree';
+import {
+  Avatar,
+  Button,
+  Descriptions,
+  Empty,
+  Input,
+  Space,
+  Spin,
+  Tag,
+  Tooltip,
+  Tree,
+  Typography,
+  message,
+} from 'antd';
+import type { Key, ReactNode } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+
+import { PermissionGuard } from '@/components/security';
 import {
   type DepartmentVO,
-  getDepartmentDetail,
   getDepartmentTree,
-  searchDepartments,
 } from '@/services/security/departments';
-import type { TreeId } from '@/services/security/permissions';
-import { retainMatchedAncestors } from '../permissions/tree';
-import ImportModal from './ImportModal';
-import { departmentTreeNodes } from './tree';
 
-const labels = { id: 'ID', name: '名称', code: '编码', parentId: '父部门 ID', leader: '负责人' };
+import ImportModal from './ImportModal';
+import {
+  collectDepartmentIds,
+  filterDepartmentTree,
+  findDepartmentById,
+  findDepartmentPath,
+  getDepartmentForest,
+  getDepartmentTreeStats,
+  getDirectChildren,
+  type DepartmentScope,
+} from './tree';
+
+const errorText = (error: unknown, fallback: string): string =>
+  error instanceof Error && error.message
+    ? error.message
+    : fallback;
+
+const departmentRequirement = (action: string): string =>
+  `security:department:${action}`;
+
+const departmentName = (department?: DepartmentVO): string =>
+  department?.deptName || '未命名部门';
+
+const toTreeData = (
+  departments: DepartmentVO[],
+  path = new Set<string>(),
+): DataNode[] =>
+  departments.flatMap((department) => {
+    const key = String(department.id);
+    if (path.has(key)) return [];
+
+    const nextPath = new Set(path);
+    nextPath.add(key);
+    const children = getDirectChildren(department);
+
+    return [
+      {
+        key: department.id,
+        title: (
+          <div className="min-w-0 py-0.5">
+            <div className="truncate text-sm font-medium text-slate-700">
+              {departmentName(department)}
+            </div>
+            <div className="mt-0.5 truncate text-xs text-slate-400">
+              {department.description ||
+                (children.length > 0
+                  ? `${children.length} 个直属部门`
+                  : `ID ${department.id}`)}
+            </div>
+          </div>
+        ),
+        children: toTreeData(children, nextPath),
+      },
+    ];
+  });
+
+const scopeLabel = (
+  label: string,
+  count: number,
+): ReactNode => (
+  <span>
+    {label}
+    <span className="ml-1 text-xs opacity-60">{count}</span>
+  </span>
+);
 
 export default function DepartmentsPage() {
-  const [tree, setTree] = useState<DepartmentVO[]>([]);
-  const [visibleTree, setVisibleTree] = useState<DepartmentVO[]>([]);
-  const [selectedId, setSelectedId] = useState<TreeId>();
-  const [detail, setDetail] = useState<DepartmentVO>();
-  const [loading, setLoading] = useState(false);
-  const [detailLoading, setDetailLoading] = useState(false);
-  const [drawerOpen, setDrawerOpen] = useState(false);
-  const [importOpen, setImportOpen] = useState(false);
+  const requestSequenceRef = useRef(0);
+
+  const [root, setRoot] = useState<DepartmentVO>();
+  const [selectedId, setSelectedId] = useState<number>();
   const [keyword, setKeyword] = useState('');
-  const [form] = Form.useForm<{ name?: string; code?: string }>();
-  const load = useCallback(async () => {
+  const [scope, setScope] =
+    useState<DepartmentScope>('all');
+  const [expandedKeys, setExpandedKeys] = useState<Key[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [importOpen, setImportOpen] = useState(false);
+
+  const loadTree = useCallback(async () => {
+    const sequence = ++requestSequenceRef.current;
     setLoading(true);
+
     try {
-      const result = await getDepartmentTree();
-      setTree(result ?? []);
-      setVisibleTree(result ?? []);
+      const data = await getDepartmentTree();
+      if (sequence !== requestSequenceRef.current) return;
+      setRoot(data);
+    } catch (error) {
+      if (sequence !== requestSequenceRef.current) return;
+      setRoot(undefined);
+      message.error(errorText(error, '部门树加载失败'));
     } finally {
-      setLoading(false);
+      if (sequence === requestSequenceRef.current) {
+        setLoading(false);
+      }
     }
   }, []);
+
   useEffect(() => {
-    void load();
-  }, [load]);
-  const select = async (id: TreeId) => {
-    setSelectedId(id);
-    setDrawerOpen(true);
-    setDetailLoading(true);
-    try {
-      setDetail(await getDepartmentDetail(id));
-    } finally {
-      setDetailLoading(false);
-    }
-  };
-  const search = async (values: { name?: string; code?: string }) => {
-    if (!values.name?.trim() && !values.code?.trim()) {
-      setVisibleTree(tree);
+    void loadTree();
+  }, [loadTree]);
+
+  const departmentForest = useMemo(
+    () => getDepartmentForest(root),
+    [root],
+  );
+
+  const stats = useMemo(
+    () => getDepartmentTreeStats(departmentForest),
+    [departmentForest],
+  );
+
+  const visibleDepartments = useMemo(
+    () =>
+      filterDepartmentTree(
+        departmentForest,
+        keyword,
+        scope,
+      ),
+    [departmentForest, keyword, scope],
+  );
+
+  const treeData = useMemo(
+    () => toTreeData(visibleDepartments),
+    [visibleDepartments],
+  );
+
+  const selectedDepartment = useMemo(
+    () => findDepartmentById(departmentForest, selectedId),
+    [departmentForest, selectedId],
+  );
+
+  const selectedPath = useMemo(
+    () => findDepartmentPath(departmentForest, selectedId),
+    [departmentForest, selectedId],
+  );
+
+  const selectedChildren = useMemo(
+    () => getDirectChildren(selectedDepartment),
+    [selectedDepartment],
+  );
+
+  const descendantCount = useMemo(
+    () => collectDepartmentIds(selectedChildren).length,
+    [selectedChildren],
+  );
+
+  useEffect(() => {
+    if (loading) return;
+
+    const visibleSelected = findDepartmentById(
+      visibleDepartments,
+      selectedId,
+    );
+
+    if (visibleSelected) return;
+    setSelectedId(visibleDepartments[0]?.id);
+  }, [loading, selectedId, visibleDepartments]);
+
+  useEffect(() => {
+    if (keyword.trim() || scope !== 'all') {
+      setExpandedKeys(
+        collectDepartmentIds(visibleDepartments),
+      );
       return;
     }
-    setLoading(true);
-    try {
-      setVisibleTree(retainMatchedAncestors(tree, await searchDepartments(values)));
-    } finally {
-      setLoading(false);
-    }
-  };
-  const nodes = useMemo(() => departmentTreeNodes(visibleTree), [visibleTree]);
+
+    setExpandedKeys(
+      departmentForest.map((department) => department.id),
+    );
+  }, [
+    departmentForest,
+    keyword,
+    scope,
+    visibleDepartments,
+  ]);
+
+  const scopeOptions: Array<{
+    value: DepartmentScope;
+    label: ReactNode;
+  }> = [
+    {
+      value: 'all',
+      label: scopeLabel('全部', stats.total),
+    },
+    {
+      value: 'group',
+      label: scopeLabel('部门分组', stats.groups),
+    },
+    {
+      value: 'leaf',
+      label: scopeLabel('末级部门', stats.leaves),
+    },
+  ];
+
   return (
-    <section className="m-4 min-h-[calc(100vh-80px)]" aria-labelledby="department-title">
-      <Card>
-        <div className="mb-5 flex flex-wrap items-start justify-between gap-3">
-          <div>
-            <Typography.Title id="department-title" level={4} className="!mb-1">
-              部门管理
-            </Typography.Title>
-            <Typography.Text type="secondary">
-              搜索部门树并查看部门详情；本页不提供后端未开放的编辑或删除操作。
-            </Typography.Text>
-          </div>
-          <Space>
-            <Button icon={<ReloadOutlined />} onClick={() => void load()}>
-              刷新
-            </Button>
-            <PermissionGuard mode="one" permission="system:department:import">
-              <Button type="primary" icon={<ImportOutlined />} onClick={() => setImportOpen(true)}>
-                导入
-              </Button>
-            </PermissionGuard>
-          </Space>
+    <section
+      className="box-border flex min-h-[640px] flex-col overflow-hidden bg-slate-50/50 p-6"
+      style={{ height: 'calc(100vh - 64px)' }}
+      aria-labelledby="department-title"
+    >
+      <h1
+        id="department-title"
+        className="mb-4 shrink-0 font-semibold"
+        style={{ fontSize: 18, color: '#282828' }}
+      >
+        部门管理
+      </h1>
+
+      <div className="mb-4 flex shrink-0 flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+        <div className="flex min-w-0 items-center gap-2 overflow-x-auto pb-1 lg:pb-0">
+          {scopeOptions.map((option) => {
+            const active = scope === option.value;
+
+            return (
+              <button
+                key={option.value}
+                type="button"
+                className={[
+                  'shrink-0 rounded px-3 py-1 text-sm font-medium leading-5 transition-colors',
+                  active
+                    ? 'bg-[#f2f2f4] text-[#FE2C55]'
+                    : 'bg-[#f2f4f7] text-[#667085] hover:bg-[#e8eaef]',
+                ].join(' ')}
+                onClick={() => setScope(option.value)}
+              >
+                {option.label}
+              </button>
+            );
+          })}
         </div>
-        <Form form={form} layout="inline" className="mb-5 gap-y-2" onFinish={search}>
-          <Form.Item name="name" label="名称">
-            <Input allowClear />
-          </Form.Item>
-          <Form.Item name="code" label="编码">
-            <Input allowClear />
-          </Form.Item>
-          <Button type="primary" htmlType="submit">
-            查询
-          </Button>
-          <Button
-            onClick={() => {
-              form.resetFields();
-              setVisibleTree(tree);
-            }}
-          >
-            重置
-          </Button>
-        </Form>
-        <Card size="small" title="部门树">
-          <TreeSearch
-            nodes={nodes}
-            loading={loading}
-            keyword={keyword}
-            onKeywordChange={setKeyword}
-            selectedKey={selectedId}
-            onSelect={(id) => void select(id)}
-            placeholder="在结果中按名称或编码筛选"
+
+        <div className="flex shrink-0 flex-wrap items-center gap-2">
+          <Input
+            allowClear
+            value={keyword}
+            prefix={<SearchOutlined className="text-slate-400" />}
+            placeholder="搜索部门名称、描述或 ID"
+            className="w-[360px] max-w-full"
+            onChange={(event) => setKeyword(event.target.value)}
           />
-        </Card>
-      </Card>
-      <JsonDetailDrawer
-        title="部门详情"
-        open={drawerOpen}
-        loading={detailLoading}
-        data={detail as unknown as Record<string, unknown>}
-        fields={Object.keys(labels)}
-        labels={labels}
-        onClose={() => setDrawerOpen(false)}
+
+          <Tooltip title="刷新部门树">
+            <Button
+              icon={<ReloadOutlined />}
+              loading={loading}
+              onClick={() => void loadTree()}
+            />
+          </Tooltip>
+
+          <PermissionGuard
+            mode="one"
+            permission={departmentRequirement('import')}
+          >
+            <Button
+              type="primary"
+              icon={<ImportOutlined />}
+              onClick={() => setImportOpen(true)}
+            >
+              导入部门
+            </Button>
+          </PermissionGuard>
+        </div>
+      </div>
+
+      <div className="grid min-h-0 flex-1 overflow-hidden rounded-lg border border-slate-200 bg-white lg:grid-cols-[390px_minmax(0,1fr)]">
+        <aside className="flex min-h-0 flex-col border-b border-slate-200 lg:border-b-0 lg:border-r">
+          <div className="flex h-14 shrink-0 items-center justify-between border-b border-slate-100 px-4">
+            <div>
+              <div className="font-medium text-slate-800">
+                部门树
+              </div>
+              <div className="mt-0.5 text-xs text-slate-400">
+                当前显示{' '}
+                {collectDepartmentIds(visibleDepartments).length}{' '}
+                个节点
+              </div>
+            </div>
+
+            <Space size={2}>
+              <Tooltip title="展开全部">
+                <Button
+                  type="text"
+                  size="small"
+                  icon={<PlusSquareOutlined />}
+                  onClick={() =>
+                    setExpandedKeys(
+                      collectDepartmentIds(visibleDepartments),
+                    )
+                  }
+                />
+              </Tooltip>
+              <Tooltip title="收起全部">
+                <Button
+                  type="text"
+                  size="small"
+                  icon={<MinusSquareOutlined />}
+                  onClick={() => setExpandedKeys([])}
+                />
+              </Tooltip>
+            </Space>
+          </div>
+
+          <div className="min-h-0 flex-1 overflow-y-auto px-2 py-3">
+            <Spin spinning={loading}>
+              {!loading && treeData.length === 0 ? (
+                <Empty
+                  className="mt-16"
+                  image={Empty.PRESENTED_IMAGE_SIMPLE}
+                  description={
+                    keyword.trim() || scope !== 'all'
+                      ? '没有匹配的部门'
+                      : '暂无部门数据'
+                  }
+                />
+              ) : (
+                <Tree
+                  blockNode
+                  showLine={{ showLeafIcon: false }}
+                  treeData={treeData}
+                  selectedKeys={
+                    selectedId === undefined ? [] : [selectedId]
+                  }
+                  expandedKeys={expandedKeys}
+                  autoExpandParent={Boolean(
+                    keyword.trim() || scope !== 'all',
+                  )}
+                  onExpand={(keys) => setExpandedKeys(keys)}
+                  onSelect={(keys) => {
+                    const value = Number(keys[0]);
+                    if (Number.isFinite(value)) {
+                      setSelectedId(value);
+                    }
+                  }}
+                />
+              )}
+            </Spin>
+          </div>
+        </aside>
+
+        <main className="min-h-0 overflow-y-auto">
+          {selectedDepartment ? (
+            <div className="min-h-full">
+              <div className="flex min-h-20 items-center gap-3 border-b border-slate-100 px-6 py-4">
+                <Avatar
+                  size={46}
+                  icon={<ApartmentOutlined />}
+                  className="shrink-0 !bg-slate-600"
+                />
+
+                <div className="min-w-0">
+                  <div className="flex min-w-0 flex-wrap items-center gap-2">
+                    <Typography.Title
+                      level={5}
+                      className="!mb-0 !text-slate-800"
+                    >
+                      {departmentName(selectedDepartment)}
+                    </Typography.Title>
+
+                    <Tag>
+                      {selectedDepartment.leaf === false ||
+                      selectedChildren.length > 0
+                        ? '部门分组'
+                        : '末级部门'}
+                    </Tag>
+                  </div>
+
+                  <div className="mt-1 text-xs text-slate-400">
+                    部门 ID：{selectedDepartment.id}
+                  </div>
+                </div>
+              </div>
+
+              <div className="space-y-6 p-6">
+                <div>
+                  <div className="mb-2 text-sm font-medium text-slate-800">
+                    部门路径
+                  </div>
+                  <div className="flex flex-wrap items-center gap-1 rounded-lg border border-slate-200 bg-slate-50/60 px-3 py-2 text-sm text-slate-600">
+                    {selectedPath.map((department, index) => (
+                      <span
+                        key={department.id}
+                        className="flex items-center gap-1"
+                      >
+                        {index > 0 && (
+                          <span className="text-slate-300">/</span>
+                        )}
+                        <button
+                          type="button"
+                          className="rounded px-1 py-0.5 hover:bg-white hover:text-slate-900"
+                          onClick={() =>
+                            setSelectedId(department.id)
+                          }
+                        >
+                          {departmentName(department)}
+                        </button>
+                      </span>
+                    ))}
+                  </div>
+                </div>
+
+                <Descriptions
+                  bordered
+                  size="small"
+                  column={{ xs: 1, sm: 2 }}
+                  items={[
+                    {
+                      key: 'id',
+                      label: '部门 ID',
+                      children: selectedDepartment.id,
+                    },
+                    {
+                      key: 'parentId',
+                      label: '父部门 ID',
+                      children:
+                        selectedDepartment.parentId === undefined ||
+                        selectedDepartment.parentId === null ||
+                        selectedDepartment.parentId === 0
+                          ? '根部门'
+                          : selectedDepartment.parentId,
+                    },
+                    {
+                      key: 'nodeType',
+                      label: '节点类型',
+                      children:
+                        selectedDepartment.leaf === false ||
+                        selectedChildren.length > 0
+                          ? '部门分组'
+                          : '末级部门',
+                    },
+                    {
+                      key: 'children',
+                      label: '直属子部门',
+                      children: `${selectedChildren.length} 个`,
+                    },
+                    {
+                      key: 'descendants',
+                      label: '全部下级部门',
+                      children: `${descendantCount} 个`,
+                    },
+                  ]}
+                />
+
+                <div>
+                  <div className="mb-2 text-sm font-medium text-slate-800">
+                    部门描述
+                  </div>
+                  <div className="min-h-20 rounded-lg border border-slate-200 bg-white px-4 py-3 text-sm leading-6 text-slate-600">
+                    {selectedDepartment.description ||
+                      '暂无部门描述'}
+                  </div>
+                </div>
+
+                <div>
+                  <div className="mb-2 flex items-center justify-between">
+                    <span className="text-sm font-medium text-slate-800">
+                      直属子部门
+                    </span>
+                    <span className="text-xs text-slate-400">
+                      {selectedChildren.length} 个
+                    </span>
+                  </div>
+
+                  <div className="rounded-lg border border-slate-200 bg-white p-3">
+                    {selectedChildren.length === 0 ? (
+                      <span className="text-sm text-slate-400">
+                        当前节点没有子部门
+                      </span>
+                    ) : (
+                      <div className="grid grid-cols-1 gap-2 xl:grid-cols-2">
+                        {selectedChildren.map((child) => (
+                          <button
+                            key={child.id}
+                            type="button"
+                            className="min-w-0 rounded-lg border border-slate-200 px-3 py-2 text-left transition-colors hover:border-slate-300 hover:bg-slate-50"
+                            onClick={() => setSelectedId(child.id)}
+                          >
+                            <div className="truncate text-sm font-medium text-slate-700">
+                              {departmentName(child)}
+                            </div>
+                            <div className="mt-1 truncate text-xs text-slate-400">
+                              {child.description || `ID ${child.id}`}
+                            </div>
+                          </button>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                </div>
+
+                <div className="rounded-lg border border-slate-200 bg-slate-50/70 px-4 py-3 text-sm leading-6 text-slate-600">
+                  当前后端只开放部门树查询和批量导入接口，因此本页暂不提供单个部门的新增、编辑和删除操作。
+                </div>
+              </div>
+            </div>
+          ) : (
+            <div className="flex min-h-full items-center justify-center p-8">
+              <Empty
+                image={Empty.PRESENTED_IMAGE_SIMPLE}
+                description={
+                  keyword.trim() || scope !== 'all'
+                    ? '没有符合条件的部门'
+                    : '请从左侧选择部门节点'
+                }
+              />
+            </div>
+          )}
+        </main>
+      </div>
+
+      <ImportModal
+        open={importOpen}
+        onClose={() => setImportOpen(false)}
+        onImported={() => void loadTree()}
       />
-      <ImportModal open={importOpen} onClose={() => setImportOpen(false)} onImported={() => void load()} />
     </section>
   );
 }

--- a/yak-ops-ui/src/pages/system/departments/tree.ts
+++ b/yak-ops-ui/src/pages/system/departments/tree.ts
@@ -77,9 +77,11 @@ export const filterDepartmentTree = (
       nextPath,
     );
 
-    return matchesScope(node, scope) &&
-      matchesKeyword(node, keyword) ||
-      children.length > 0
+    const matched =
+      matchesScope(node, scope) &&
+      matchesKeyword(node, keyword);
+
+    return matched || children.length > 0
       ? [{ ...node, childList: children }]
       : [];
   });

--- a/yak-ops-ui/src/pages/system/departments/tree.ts
+++ b/yak-ops-ui/src/pages/system/departments/tree.ts
@@ -1,16 +1,203 @@
-import type { SearchTreeNode } from '@/components/security/TreeSearch';
 import type { DepartmentVO } from '@/services/security/departments';
 
-export const departmentTreeNodes = (items: DepartmentVO[], path = new Set<string>()): SearchTreeNode[] =>
-  items.flatMap((item) => {
-    const id = String(item.id);
-    if (path.has(id)) return [];
-    return [
-      {
-        key: item.id,
-        title: item.name,
-        searchText: `${item.name} ${item.code ?? ''}`,
-        children: departmentTreeNodes(item.children ?? [], new Set(path).add(id)),
-      },
-    ];
+export type DepartmentScope = 'all' | 'group' | 'leaf';
+
+export interface DepartmentTreeStats {
+  total: number;
+  groups: number;
+  leaves: number;
+}
+
+const safeChildren = (
+  node?: DepartmentVO,
+): DepartmentVO[] =>
+  Array.isArray(node?.childList) ? node.childList : [];
+
+/** Hide the backend's id=0 virtual root from the management UI. */
+export const getDepartmentForest = (
+  root?: DepartmentVO,
+): DepartmentVO[] => {
+  if (!root) return [];
+
+  const virtualRoot =
+    Number(root.id) === 0 && !root.deptName;
+
+  return virtualRoot ? safeChildren(root) : [root];
+};
+
+const matchesScope = (
+  node: DepartmentVO,
+  scope: DepartmentScope,
+): boolean => {
+  const hasChildren = safeChildren(node).length > 0;
+
+  if (scope === 'group') {
+    return node.leaf === false || hasChildren;
+  }
+
+  if (scope === 'leaf') {
+    return node.leaf !== false && !hasChildren;
+  }
+
+  return true;
+};
+
+const matchesKeyword = (
+  node: DepartmentVO,
+  keyword: string,
+): boolean => {
+  const query = keyword.trim().toLocaleLowerCase();
+  if (!query) return true;
+
+  return [node.id, node.deptName, node.description]
+    .filter((value) => value !== undefined && value !== null)
+    .some((value) =>
+      String(value).toLocaleLowerCase().includes(query),
+    );
+};
+
+/** Keep every ancestor of a matching department so hierarchy stays clear. */
+export const filterDepartmentTree = (
+  nodes: DepartmentVO[],
+  keyword: string,
+  scope: DepartmentScope,
+  path = new Set<string>(),
+): DepartmentVO[] =>
+  nodes.flatMap((node) => {
+    const key = String(node.id);
+    if (path.has(key)) return [];
+
+    const nextPath = new Set(path);
+    nextPath.add(key);
+
+    const children = filterDepartmentTree(
+      safeChildren(node),
+      keyword,
+      scope,
+      nextPath,
+    );
+
+    return matchesScope(node, scope) &&
+      matchesKeyword(node, keyword) ||
+      children.length > 0
+      ? [{ ...node, childList: children }]
+      : [];
   });
+
+export const collectDepartmentIds = (
+  nodes: DepartmentVO[],
+): number[] => {
+  const ids: number[] = [];
+  const visited = new Set<string>();
+
+  const visit = (items: DepartmentVO[]) => {
+    for (const node of items) {
+      const key = String(node.id);
+      if (visited.has(key)) continue;
+
+      visited.add(key);
+      const id = Number(node.id);
+      if (Number.isFinite(id)) ids.push(id);
+      visit(safeChildren(node));
+    }
+  };
+
+  visit(nodes);
+  return ids;
+};
+
+export const findDepartmentById = (
+  nodes: DepartmentVO[],
+  id?: number,
+): DepartmentVO | undefined => {
+  if (id === undefined) return undefined;
+
+  const expected = String(id);
+  const visited = new Set<string>();
+  const queue = [...nodes];
+
+  while (queue.length > 0) {
+    const node = queue.shift();
+    if (!node) continue;
+
+    const key = String(node.id);
+    if (visited.has(key)) continue;
+    visited.add(key);
+
+    if (key === expected) return node;
+    queue.push(...safeChildren(node));
+  }
+
+  return undefined;
+};
+
+export const findDepartmentPath = (
+  nodes: DepartmentVO[],
+  id?: number,
+): DepartmentVO[] => {
+  if (id === undefined) return [];
+  const expected = String(id);
+
+  const visit = (
+    items: DepartmentVO[],
+    ancestors: DepartmentVO[],
+    path: Set<string>,
+  ): DepartmentVO[] | undefined => {
+    for (const node of items) {
+      const key = String(node.id);
+      if (path.has(key)) continue;
+
+      const nextAncestors = [...ancestors, node];
+      if (key === expected) return nextAncestors;
+
+      const nextPath = new Set(path);
+      nextPath.add(key);
+
+      const found = visit(
+        safeChildren(node),
+        nextAncestors,
+        nextPath,
+      );
+      if (found) return found;
+    }
+
+    return undefined;
+  };
+
+  return visit(nodes, [], new Set()) ?? [];
+};
+
+export const getDepartmentTreeStats = (
+  nodes: DepartmentVO[],
+): DepartmentTreeStats => {
+  const stats: DepartmentTreeStats = {
+    total: 0,
+    groups: 0,
+    leaves: 0,
+  };
+  const visited = new Set<string>();
+
+  const visit = (items: DepartmentVO[]) => {
+    for (const node of items) {
+      const key = String(node.id);
+      if (visited.has(key)) continue;
+      visited.add(key);
+
+      stats.total += 1;
+      if (node.leaf === false || safeChildren(node).length > 0) {
+        stats.groups += 1;
+      } else {
+        stats.leaves += 1;
+      }
+
+      visit(safeChildren(node));
+    }
+  };
+
+  visit(nodes);
+  return stats;
+};
+
+export const getDirectChildren = (
+  node?: DepartmentVO,
+): DepartmentVO[] => safeChildren(node);

--- a/yak-ops-ui/src/services/security/departments.ts
+++ b/yak-ops-ui/src/services/security/departments.ts
@@ -1,33 +1,36 @@
-import { securityGetData, securityUploadData } from './client';
-import type { ImportReport, TreeId } from './permissions';
+import {
+  securityGetData,
+  securityPostData,
+} from './client';
 
-const DEPARTMENT_API = '/api/v1/department';
+const DEPARTMENT_API = '/api/v1/dept';
 
+/** Department tree node returned by Yak Security. */
 export interface DepartmentVO {
-  id: TreeId;
-  name: string;
-  code?: string | null;
-  parentId?: TreeId | null;
-  leader?: string | null;
-  children?: DepartmentVO[];
+  id: number;
+  deptName?: string;
+  description?: string | null;
+  parentId?: number | null;
+  leaf?: boolean;
+  childList?: DepartmentVO[];
 }
 
-const queryString = (params: { name?: string; code?: string }) => {
-  const query = new URLSearchParams();
-  if (params.name?.trim()) query.set('name', params.name.trim());
-  if (params.code?.trim()) query.set('code', params.code.trim());
-  const value = query.toString();
-  return value ? `?${value}` : '';
-};
+/** DTO accepted by POST /dept/import. */
+export interface DepartmentImportItem {
+  deptName: string;
+  description?: string;
+  childDeptDTOList?: DepartmentImportItem[];
+}
 
-export const getDepartmentTree = (): Promise<DepartmentVO[]> =>
-  securityGetData<DepartmentVO[]>(`${DEPARTMENT_API}/tree`);
+/** Query the complete department tree, including the backend virtual root. */
+export const getDepartmentTree = (): Promise<DepartmentVO> =>
+  securityGetData<DepartmentVO>(`${DEPARTMENT_API}/tree`);
 
-export const searchDepartments = (params: { name?: string; code?: string }): Promise<DepartmentVO[]> =>
-  securityGetData<DepartmentVO[]>(`${DEPARTMENT_API}/search${queryString(params)}`);
-
-export const getDepartmentDetail = (id: TreeId): Promise<DepartmentVO> =>
-  securityGetData<DepartmentVO>(`${DEPARTMENT_API}/${encodeURIComponent(String(id))}`);
-
-export const importDepartments = (file: File): Promise<ImportReport> =>
-  securityUploadData<ImportReport>(`${DEPARTMENT_API}/import`, file);
+/** Import a JSON department DTO tree. */
+export const importDepartments = (
+  departments: DepartmentImportItem[],
+): Promise<void> =>
+  securityPostData<void>(
+    `${DEPARTMENT_API}/import`,
+    departments,
+  );


### PR DESCRIPTION
## 变更内容

- 将部门管理重构为与权限管理一致的左树右详情布局
- 页面采用固定高度，部门树和详情区域独立滚动
- 左侧支持全部、部门分组、末级部门快捷筛选
- 支持按部门名称、描述和 ID 本地搜索，并保留匹配节点祖先路径
- 增加展开全部、收起全部、刷新部门树操作
- 右侧展示部门路径、节点类型、直属子部门、全部下级部门和部门描述
- 直属子部门支持点击快速切换详情
- 移除详情抽屉，避免遮挡部门树和丢失层级上下文
- 重做部门导入弹窗，支持选择 JSON 文件或直接粘贴 JSON，并在提交前校验结构

## 修复的接口问题

原部门页面与 `yak-security` 后端契约存在多处不一致：

- 后端路径为 `/api/v1/dept`，原前端错误使用 `/api/v1/department`
- 后端只提供 `GET /dept/tree` 和 `POST /dept/import`，原前端调用了不存在的搜索、详情接口
- 后端树接口返回一个带 `childList` 的虚拟根节点，原前端错误按数组和 `children` 处理
- 后端字段为 `deptName`、`description`、`leaf`、`childList`，原前端使用了不存在的 `name`、`code`、`leader`、`children`
- 后端导入接口接收 JSON 数组，原前端错误提交 multipart 文件并期望导入报告
- 部门导入操作权限编码调整为 `security:department:import`

## 实际接入接口

- `GET /yak-security/api/v1/dept/tree`
- `POST /yak-security/api/v1/dept/import`

当前后端没有单部门新增、编辑、删除和详情接口，因此页面保持只读详情与批量导入能力，不虚构写接口。

## 验证

- 已核对 `DeptController`、`DeptDTO`、`DeptTreeVO` 和 `DeptServiceImpl`
- 已静态复核虚拟根节点处理、循环树保护、筛选祖先保留、选中状态和 JSON 导入校验
- 当前执行环境没有完整本地仓库检出，未运行项目级 `npm run tsc` / `npm run build`；建议合并前由本地或 CI 执行一次完整检查
