### PR TITLE
完成部门管理新增编辑删除与后端联调

### DIFF
--- a/yak-ops-ui/src/pages/system/departments/DepartmentEditorDrawer.tsx
+++ b/yak-ops-ui/src/pages/system/departments/DepartmentEditorDrawer.tsx
@@ -1,0 +1,262 @@
+import { ApartmentOutlined } from '@ant-design/icons';
+import {
+  Alert,
+  Button,
+  Drawer,
+  Form,
+  Input,
+  Space,
+  TreeSelect,
+  message,
+} from 'antd';
+import { useEffect, useMemo, useState } from 'react';
+
+import {
+  type DepartmentInput,
+  type DepartmentVO,
+  createDepartment,
+  updateDepartment,
+} from '@/services/security/departments';
+
+import {
+  collectDepartmentIds,
+  getDepartmentForest,
+  getDirectChildren,
+} from './tree';
+
+interface DepartmentEditorDrawerProps {
+  open: boolean;
+  root?: DepartmentVO;
+  department?: DepartmentVO;
+  defaultParentId?: number;
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+interface DepartmentFormValues {
+  deptName: string;
+  description?: string;
+  parentId: number;
+}
+
+interface ParentTreeNode {
+  value: number;
+  title: string;
+  children?: ParentTreeNode[];
+}
+
+const errorText = (error: unknown, fallback: string): string =>
+  error instanceof Error && error.message
+    ? error.message
+    : fallback;
+
+const departmentName = (department?: DepartmentVO): string =>
+  department?.deptName || '未命名部门';
+
+const toParentTreeData = (
+  departments: DepartmentVO[],
+  blockedIds: Set<number>,
+  path = new Set<string>(),
+): ParentTreeNode[] =>
+  departments.flatMap((department) => {
+    const key = String(department.id);
+    if (path.has(key) || blockedIds.has(department.id)) {
+      return [];
+    }
+
+    const nextPath = new Set(path);
+    nextPath.add(key);
+    const children = toParentTreeData(
+      getDirectChildren(department),
+      blockedIds,
+      nextPath,
+    );
+
+    return [
+      {
+        value: department.id,
+        title: departmentName(department),
+        ...(children.length > 0 ? { children } : {}),
+      },
+    ];
+  });
+
+export default function DepartmentEditorDrawer({
+  open,
+  root,
+  department,
+  defaultParentId,
+  onClose,
+  onSuccess,
+}: DepartmentEditorDrawerProps) {
+  const [form] = Form.useForm<DepartmentFormValues>();
+  const [saving, setSaving] = useState(false);
+  const editing = Boolean(department);
+
+  const blockedIds = useMemo(() => {
+    if (!department) return new Set<number>();
+
+    return new Set([
+      department.id,
+      ...collectDepartmentIds(getDirectChildren(department)),
+    ]);
+  }, [department]);
+
+  const parentTreeData = useMemo<ParentTreeNode[]>(
+    () => [
+      {
+        value: 0,
+        title: '根部门',
+        children: toParentTreeData(
+          getDepartmentForest(root),
+          blockedIds,
+        ),
+      },
+    ],
+    [blockedIds, root],
+  );
+
+  useEffect(() => {
+    if (!open) return;
+
+    form.resetFields();
+    form.setFieldsValue({
+      deptName: department?.deptName ?? '',
+      description: department?.description ?? '',
+      parentId:
+        department?.parentId ?? defaultParentId ?? 0,
+    });
+  }, [defaultParentId, department, form, open]);
+
+  const close = () => {
+    if (!saving) onClose();
+  };
+
+  const save = async (values: DepartmentFormValues) => {
+    if (saving) return;
+    setSaving(true);
+
+    try {
+      const body: DepartmentInput = {
+        deptName: values.deptName.trim(),
+        description: values.description?.trim() ?? '',
+        parentId: Number(values.parentId ?? 0),
+      };
+
+      if (department) {
+        await updateDepartment({
+          ...body,
+          id: department.id,
+        });
+      } else {
+        await createDepartment(body);
+      }
+
+      message.success(editing ? '部门已更新' : '部门已创建');
+      onClose();
+      onSuccess();
+    } catch (error) {
+      message.error(
+        errorText(
+          error,
+          editing ? '部门更新失败' : '部门创建失败',
+        ),
+      );
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Drawer
+      open={open}
+      title={editing ? '编辑部门' : '新增部门'}
+      width={520}
+      forceRender
+      maskClosable={false}
+      keyboard={!saving}
+      closable={!saving}
+      onClose={close}
+      extra={
+        <Space>
+          <Button disabled={saving} onClick={close}>
+            取消
+          </Button>
+          <Button
+            type="primary"
+            loading={saving}
+            onClick={() => form.submit()}
+          >
+            {editing ? '更新' : '保存'}
+          </Button>
+        </Space>
+      }
+    >
+      <Alert
+        showIcon
+        type="info"
+        className="mb-5"
+        icon={<ApartmentOutlined />}
+        message={
+          editing
+            ? '修改上级部门时，后端会同步更新当前部门及全部下级部门的层级。'
+            : '可创建根部门，也可以在当前选中部门下新增子部门。'
+        }
+      />
+
+      <Form<DepartmentFormValues>
+        form={form}
+        layout="vertical"
+        preserve={false}
+        disabled={saving}
+        onFinish={(values) => void save(values)}
+      >
+        <Form.Item
+          name="deptName"
+          label="部门名称"
+          rules={[
+            {
+              required: true,
+              whitespace: true,
+              message: '请输入部门名称',
+            },
+          ]}
+        >
+          <Input
+            placeholder="请输入部门名称"
+            maxLength={64}
+            showCount
+          />
+        </Form.Item>
+
+        <Form.Item
+          name="parentId"
+          label="上级部门"
+          rules={[{ required: true, message: '请选择上级部门' }]}
+        >
+          <TreeSelect
+            treeData={parentTreeData}
+            treeDefaultExpandAll
+            showSearch
+            allowClear={false}
+            placeholder="请选择上级部门"
+            filterTreeNode={(input, node) =>
+              String(node.title ?? '')
+                .toLocaleLowerCase()
+                .includes(input.trim().toLocaleLowerCase())
+            }
+          />
+        </Form.Item>
+
+        <Form.Item name="description" label="部门描述">
+          <Input.TextArea
+            placeholder="请输入部门职责或适用范围"
+            maxLength={500}
+            showCount
+            autoSize={{ minRows: 4, maxRows: 8 }}
+          />
+        </Form.Item>
+      </Form>
+    </Drawer>
+  );
+}

--- a/yak-ops-ui/src/pages/system/departments/index.tsx
+++ b/yak-ops-ui/src/pages/system/departments/index.tsx
@@ -1,7 +1,10 @@
 import {
   ApartmentOutlined,
+  DeleteOutlined,
+  EditOutlined,
   ImportOutlined,
   MinusSquareOutlined,
+  PlusOutlined,
   PlusSquareOutlined,
   ReloadOutlined,
   SearchOutlined,
@@ -13,6 +16,7 @@ import {
   Descriptions,
   Empty,
   Input,
+  Modal,
   Space,
   Spin,
   Tag,
@@ -33,9 +37,13 @@ import {
 import { PermissionGuard } from '@/components/security';
 import {
   type DepartmentVO,
+  checkDepartmentBeforeDelete,
+  deleteDepartment,
+  getDepartmentDetail,
   getDepartmentTree,
 } from '@/services/security/departments';
 
+import DepartmentEditorDrawer from './DepartmentEditorDrawer';
 import ImportModal from './ImportModal';
 import {
   collectDepartmentIds,
@@ -102,17 +110,62 @@ const scopeLabel = (
   </span>
 );
 
+const dependencyContent = (
+  childNames: string[],
+  userNames: string[],
+): ReactNode => (
+  <div className="space-y-3">
+    {childNames.length > 0 && (
+      <div className="rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800">
+        <div className="mb-2 font-medium">
+          存在 {childNames.length} 个直属子部门
+        </div>
+        <Space size={[4, 6]} wrap>
+          {childNames.slice(0, 10).map((name) => (
+            <Tag key={name}>{name}</Tag>
+          ))}
+          {childNames.length > 10 && (
+            <Tag>+{childNames.length - 10}</Tag>
+          )}
+        </Space>
+      </div>
+    )}
+
+    {userNames.length > 0 && (
+      <div className="rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800">
+        <div className="mb-2 font-medium">
+          存在 {userNames.length} 个关联用户
+        </div>
+        <Space size={[4, 6]} wrap>
+          {userNames.slice(0, 10).map((name) => (
+            <Tag key={name}>{name}</Tag>
+          ))}
+          {userNames.length > 10 && (
+            <Tag>+{userNames.length - 10}</Tag>
+          )}
+        </Space>
+      </div>
+    )}
+  </div>
+);
+
 export default function DepartmentsPage() {
   const requestSequenceRef = useRef(0);
+  const detailSequenceRef = useRef(0);
 
   const [root, setRoot] = useState<DepartmentVO>();
   const [selectedId, setSelectedId] = useState<number>();
+  const [detail, setDetail] = useState<DepartmentVO>();
   const [keyword, setKeyword] = useState('');
-  const [scope, setScope] =
-    useState<DepartmentScope>('all');
+  const [scope, setScope] = useState<DepartmentScope>('all');
   const [expandedKeys, setExpandedKeys] = useState<Key[]>([]);
   const [loading, setLoading] = useState(false);
+  const [detailLoading, setDetailLoading] = useState(false);
   const [importOpen, setImportOpen] = useState(false);
+  const [editorOpen, setEditorOpen] = useState(false);
+  const [editingDepartment, setEditingDepartment] =
+    useState<DepartmentVO>();
+  const [defaultParentId, setDefaultParentId] = useState(0);
 
   const loadTree = useCallback(async () => {
     const sequence = ++requestSequenceRef.current;
@@ -162,10 +215,23 @@ export default function DepartmentsPage() {
     [visibleDepartments],
   );
 
-  const selectedDepartment = useMemo(
+  const selectedTreeDepartment = useMemo(
     () => findDepartmentById(departmentForest, selectedId),
     [departmentForest, selectedId],
   );
+
+  const selectedDepartment = useMemo(() => {
+    if (!selectedTreeDepartment) return undefined;
+    if (!detail || detail.id !== selectedTreeDepartment.id) {
+      return selectedTreeDepartment;
+    }
+
+    return {
+      ...selectedTreeDepartment,
+      ...detail,
+      childList: selectedTreeDepartment.childList,
+    };
+  }, [detail, selectedTreeDepartment]);
 
   const selectedPath = useMemo(
     () => findDepartmentPath(departmentForest, selectedId),
@@ -173,8 +239,8 @@ export default function DepartmentsPage() {
   );
 
   const selectedChildren = useMemo(
-    () => getDirectChildren(selectedDepartment),
-    [selectedDepartment],
+    () => getDirectChildren(selectedTreeDepartment),
+    [selectedTreeDepartment],
   );
 
   const descendantCount = useMemo(
@@ -211,6 +277,113 @@ export default function DepartmentsPage() {
     scope,
     visibleDepartments,
   ]);
+
+  useEffect(() => {
+    if (selectedId === undefined) {
+      setDetail(undefined);
+      return;
+    }
+
+    const sequence = ++detailSequenceRef.current;
+    setDetailLoading(true);
+
+    void getDepartmentDetail(selectedId)
+      .then((value) => {
+        if (sequence === detailSequenceRef.current) {
+          setDetail(value);
+        }
+      })
+      .catch((error) => {
+        if (sequence === detailSequenceRef.current) {
+          setDetail(undefined);
+          message.error(errorText(error, '部门详情加载失败'));
+        }
+      })
+      .finally(() => {
+        if (sequence === detailSequenceRef.current) {
+          setDetailLoading(false);
+        }
+      });
+  }, [selectedId]);
+
+  const openCreate = useCallback((parentId = 0) => {
+    setEditingDepartment(undefined);
+    setDefaultParentId(parentId);
+    setEditorOpen(true);
+  }, []);
+
+  const openEdit = useCallback((department: DepartmentVO) => {
+    setEditingDepartment(department);
+    setDefaultParentId(department.parentId ?? 0);
+    setEditorOpen(true);
+  }, []);
+
+  const confirmDelete = useCallback(
+    async (department: DepartmentVO) => {
+      try {
+        const check = await checkDepartmentBeforeDelete(
+          department.id,
+        );
+        const childNames = Array.isArray(check.childDeptNameList)
+          ? check.childDeptNameList
+          : [];
+        const userNames = Array.isArray(check.userNameList)
+          ? check.userNameList
+          : [];
+
+        if (!check.deletable) {
+          Modal.warning({
+            title: '当前部门不能删除',
+            width: 520,
+            centered: true,
+            content: dependencyContent(childNames, userNames),
+          });
+          return;
+        }
+
+        Modal.confirm({
+          title: '删除部门',
+          width: 480,
+          centered: true,
+          okText: '删除',
+          cancelText: '取消',
+          okButtonProps: { danger: true },
+          content: (
+            <div className="space-y-3">
+              <div>
+                确定删除部门
+                <span className="mx-1 font-medium text-slate-900">
+                  {departmentName(department)}
+                </span>
+                吗？
+              </div>
+              <div className="rounded-lg border border-red-100 bg-red-50 px-3 py-2 text-sm text-red-700">
+                删除后无法恢复。只有没有子部门且没有关联用户的部门才能删除。
+              </div>
+            </div>
+          ),
+          onOk: async () => {
+            try {
+              await deleteDepartment(department.id);
+              message.success('部门已删除');
+              setSelectedId(
+                department.parentId && department.parentId !== 0
+                  ? department.parentId
+                  : undefined,
+              );
+              await loadTree();
+            } catch (error) {
+              message.error(errorText(error, '部门删除失败'));
+              throw error;
+            }
+          },
+        });
+      } catch (error) {
+        message.error(errorText(error, '部门删除检查失败'));
+      }
+    },
+    [loadTree],
+  );
 
   const scopeOptions: Array<{
     value: DepartmentScope;
@@ -273,7 +446,7 @@ export default function DepartmentsPage() {
             value={keyword}
             prefix={<SearchOutlined className="text-slate-400" />}
             placeholder="搜索部门名称、描述或 ID"
-            className="w-[360px] max-w-full"
+            className="w-[320px] max-w-full"
             onChange={(event) => setKeyword(event.target.value)}
           />
 
@@ -290,11 +463,23 @@ export default function DepartmentsPage() {
             permission={departmentRequirement('import')}
           >
             <Button
-              type="primary"
               icon={<ImportOutlined />}
               onClick={() => setImportOpen(true)}
             >
-              导入部门
+              导入
+            </Button>
+          </PermissionGuard>
+
+          <PermissionGuard
+            mode="one"
+            permission={departmentRequirement('create')}
+          >
+            <Button
+              type="primary"
+              icon={<PlusOutlined />}
+              onClick={() => openCreate(0)}
+            >
+              新增部门
             </Button>
           </PermissionGuard>
         </div>
@@ -377,159 +562,217 @@ export default function DepartmentsPage() {
 
         <main className="min-h-0 overflow-y-auto">
           {selectedDepartment ? (
-            <div className="min-h-full">
-              <div className="flex min-h-20 items-center gap-3 border-b border-slate-100 px-6 py-4">
-                <Avatar
-                  size={46}
-                  icon={<ApartmentOutlined />}
-                  className="shrink-0 !bg-slate-600"
-                />
+            <Spin spinning={detailLoading}>
+              <div className="min-h-full">
+                <div className="flex min-h-20 items-center justify-between gap-4 border-b border-slate-100 px-6 py-4">
+                  <div className="flex min-w-0 items-center gap-3">
+                    <Avatar
+                      size={46}
+                      icon={<ApartmentOutlined />}
+                      className="shrink-0 !bg-slate-600"
+                    />
 
-                <div className="min-w-0">
-                  <div className="flex min-w-0 flex-wrap items-center gap-2">
-                    <Typography.Title
-                      level={5}
-                      className="!mb-0 !text-slate-800"
-                    >
-                      {departmentName(selectedDepartment)}
-                    </Typography.Title>
-
-                    <Tag>
-                      {selectedDepartment.leaf === false ||
-                      selectedChildren.length > 0
-                        ? '部门分组'
-                        : '末级部门'}
-                    </Tag>
-                  </div>
-
-                  <div className="mt-1 text-xs text-slate-400">
-                    部门 ID：{selectedDepartment.id}
-                  </div>
-                </div>
-              </div>
-
-              <div className="space-y-6 p-6">
-                <div>
-                  <div className="mb-2 text-sm font-medium text-slate-800">
-                    部门路径
-                  </div>
-                  <div className="flex flex-wrap items-center gap-1 rounded-lg border border-slate-200 bg-slate-50/60 px-3 py-2 text-sm text-slate-600">
-                    {selectedPath.map((department, index) => (
-                      <span
-                        key={department.id}
-                        className="flex items-center gap-1"
-                      >
-                        {index > 0 && (
-                          <span className="text-slate-300">/</span>
-                        )}
-                        <button
-                          type="button"
-                          className="rounded px-1 py-0.5 hover:bg-white hover:text-slate-900"
-                          onClick={() =>
-                            setSelectedId(department.id)
-                          }
+                    <div className="min-w-0">
+                      <div className="flex min-w-0 flex-wrap items-center gap-2">
+                        <Typography.Title
+                          level={5}
+                          className="!mb-0 !text-slate-800"
                         >
-                          {departmentName(department)}
-                        </button>
-                      </span>
-                    ))}
-                  </div>
-                </div>
+                          {departmentName(selectedDepartment)}
+                        </Typography.Title>
 
-                <Descriptions
-                  bordered
-                  size="small"
-                  column={{ xs: 1, sm: 2 }}
-                  items={[
-                    {
-                      key: 'id',
-                      label: '部门 ID',
-                      children: selectedDepartment.id,
-                    },
-                    {
-                      key: 'parentId',
-                      label: '父部门 ID',
-                      children:
-                        selectedDepartment.parentId === undefined ||
-                        selectedDepartment.parentId === null ||
-                        selectedDepartment.parentId === 0
-                          ? '根部门'
-                          : selectedDepartment.parentId,
-                    },
-                    {
-                      key: 'nodeType',
-                      label: '节点类型',
-                      children:
-                        selectedDepartment.leaf === false ||
-                        selectedChildren.length > 0
-                          ? '部门分组'
-                          : '末级部门',
-                    },
-                    {
-                      key: 'children',
-                      label: '直属子部门',
-                      children: `${selectedChildren.length} 个`,
-                    },
-                    {
-                      key: 'descendants',
-                      label: '全部下级部门',
-                      children: `${descendantCount} 个`,
-                    },
-                  ]}
-                />
-
-                <div>
-                  <div className="mb-2 text-sm font-medium text-slate-800">
-                    部门描述
-                  </div>
-                  <div className="min-h-20 rounded-lg border border-slate-200 bg-white px-4 py-3 text-sm leading-6 text-slate-600">
-                    {selectedDepartment.description ||
-                      '暂无部门描述'}
-                  </div>
-                </div>
-
-                <div>
-                  <div className="mb-2 flex items-center justify-between">
-                    <span className="text-sm font-medium text-slate-800">
-                      直属子部门
-                    </span>
-                    <span className="text-xs text-slate-400">
-                      {selectedChildren.length} 个
-                    </span>
-                  </div>
-
-                  <div className="rounded-lg border border-slate-200 bg-white p-3">
-                    {selectedChildren.length === 0 ? (
-                      <span className="text-sm text-slate-400">
-                        当前节点没有子部门
-                      </span>
-                    ) : (
-                      <div className="grid grid-cols-1 gap-2 xl:grid-cols-2">
-                        {selectedChildren.map((child) => (
-                          <button
-                            key={child.id}
-                            type="button"
-                            className="min-w-0 rounded-lg border border-slate-200 px-3 py-2 text-left transition-colors hover:border-slate-300 hover:bg-slate-50"
-                            onClick={() => setSelectedId(child.id)}
-                          >
-                            <div className="truncate text-sm font-medium text-slate-700">
-                              {departmentName(child)}
-                            </div>
-                            <div className="mt-1 truncate text-xs text-slate-400">
-                              {child.description || `ID ${child.id}`}
-                            </div>
-                          </button>
-                        ))}
+                        <Tag>
+                          {selectedDepartment.leaf === false ||
+                          selectedChildren.length > 0
+                            ? '部门分组'
+                            : '末级部门'}
+                        </Tag>
                       </div>
-                    )}
+
+                      <div className="mt-1 text-xs text-slate-400">
+                        部门 ID：{selectedDepartment.id}
+                      </div>
+                    </div>
                   </div>
+
+                  <Space wrap>
+                    <PermissionGuard
+                      mode="one"
+                      permission={departmentRequirement('create')}
+                    >
+                      <Button
+                        icon={<PlusOutlined />}
+                        onClick={() =>
+                          openCreate(selectedDepartment.id)
+                        }
+                      >
+                        新增子部门
+                      </Button>
+                    </PermissionGuard>
+
+                    <PermissionGuard
+                      mode="one"
+                      permission={departmentRequirement('edit')}
+                    >
+                      <Button
+                        icon={<EditOutlined />}
+                        onClick={() =>
+                          openEdit(selectedTreeDepartment ?? selectedDepartment)
+                        }
+                      >
+                        编辑
+                      </Button>
+                    </PermissionGuard>
+
+                    <PermissionGuard
+                      mode="one"
+                      permission={departmentRequirement('delete')}
+                    >
+                      <Button
+                        danger
+                        icon={<DeleteOutlined />}
+                        onClick={() =>
+                          void confirmDelete(selectedDepartment)
+                        }
+                      >
+                        删除
+                      </Button>
+                    </PermissionGuard>
+                  </Space>
                 </div>
 
-                <div className="rounded-lg border border-slate-200 bg-slate-50/70 px-4 py-3 text-sm leading-6 text-slate-600">
-                  当前后端只开放部门树查询和批量导入接口，因此本页暂不提供单个部门的新增、编辑和删除操作。
+                <div className="space-y-6 p-6">
+                  <div>
+                    <div className="mb-2 text-sm font-medium text-slate-800">
+                      部门路径
+                    </div>
+                    <div className="flex flex-wrap items-center gap-1 rounded-lg border border-slate-200 bg-slate-50/60 px-3 py-2 text-sm text-slate-600">
+                      {selectedPath.map((department, index) => (
+                        <span
+                          key={department.id}
+                          className="flex items-center gap-1"
+                        >
+                          {index > 0 && (
+                            <span className="text-slate-300">/</span>
+                          )}
+                          <button
+                            type="button"
+                            className="rounded px-1 py-0.5 hover:bg-white hover:text-slate-900"
+                            onClick={() =>
+                              setSelectedId(department.id)
+                            }
+                          >
+                            {departmentName(department)}
+                          </button>
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+
+                  <Descriptions
+                    bordered
+                    size="small"
+                    column={{ xs: 1, sm: 2 }}
+                    items={[
+                      {
+                        key: 'id',
+                        label: '部门 ID',
+                        children: selectedDepartment.id,
+                      },
+                      {
+                        key: 'parentId',
+                        label: '父部门 ID',
+                        children:
+                          selectedDepartment.parentId === undefined ||
+                          selectedDepartment.parentId === null ||
+                          selectedDepartment.parentId === 0
+                            ? '根部门'
+                            : selectedDepartment.parentId,
+                      },
+                      {
+                        key: 'level',
+                        label: '部门层级',
+                        children: selectedDepartment.level ?? selectedPath.length,
+                      },
+                      {
+                        key: 'nodeType',
+                        label: '节点类型',
+                        children:
+                          selectedDepartment.leaf === false ||
+                          selectedChildren.length > 0
+                            ? '部门分组'
+                            : '末级部门',
+                      },
+                      {
+                        key: 'children',
+                        label: '直属子部门',
+                        children: `${
+                          selectedDepartment.childDeptCount ??
+                          selectedChildren.length
+                        } 个`,
+                      },
+                      {
+                        key: 'descendants',
+                        label: '全部下级部门',
+                        children: `${descendantCount} 个`,
+                      },
+                      {
+                        key: 'users',
+                        label: '直属用户',
+                        children: `${selectedDepartment.userCount ?? 0} 人`,
+                      },
+                    ]}
+                  />
+
+                  <div>
+                    <div className="mb-2 text-sm font-medium text-slate-800">
+                      部门描述
+                    </div>
+                    <div className="min-h-20 rounded-lg border border-slate-200 bg-white px-4 py-3 text-sm leading-6 text-slate-600">
+                      {selectedDepartment.description ||
+                        '暂无部门描述'}
+                    </div>
+                  </div>
+
+                  <div>
+                    <div className="mb-2 flex items-center justify-between">
+                      <span className="text-sm font-medium text-slate-800">
+                        直属子部门
+                      </span>
+                      <span className="text-xs text-slate-400">
+                        {selectedChildren.length} 个
+                      </span>
+                    </div>
+
+                    <div className="rounded-lg border border-slate-200 bg-white p-3">
+                      {selectedChildren.length === 0 ? (
+                        <span className="text-sm text-slate-400">
+                          当前节点没有子部门
+                        </span>
+                      ) : (
+                        <div className="grid grid-cols-1 gap-2 xl:grid-cols-2">
+                          {selectedChildren.map((child) => (
+                            <button
+                              key={child.id}
+                              type="button"
+                              className="min-w-0 rounded-lg border border-slate-200 px-3 py-2 text-left transition-colors hover:border-slate-300 hover:bg-slate-50"
+                              onClick={() => setSelectedId(child.id)}
+                            >
+                              <div className="truncate text-sm font-medium text-slate-700">
+                                {departmentName(child)}
+                              </div>
+                              <div className="mt-1 truncate text-xs text-slate-400">
+                                {child.description || `ID ${child.id}`}
+                              </div>
+                            </button>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                  </div>
                 </div>
               </div>
-            </div>
+            </Spin>
           ) : (
             <div className="flex min-h-full items-center justify-center p-8">
               <Empty
@@ -544,6 +787,18 @@ export default function DepartmentsPage() {
           )}
         </main>
       </div>
+
+      <DepartmentEditorDrawer
+        open={editorOpen}
+        root={root}
+        department={editingDepartment}
+        defaultParentId={defaultParentId}
+        onClose={() => {
+          setEditorOpen(false);
+          setEditingDepartment(undefined);
+        }}
+        onSuccess={() => void loadTree()}
+      />
 
       <ImportModal
         open={importOpen}


### PR DESCRIPTION
## 变更内容

在已合并的左右分栏部门管理页面上，补齐单部门 CRUD 交互并接入 `yak-security` 新接口。

### 页面能力

- 顶部新增部门
- 在右侧详情中新增子部门
- 编辑部门名称、描述和上级部门
- 上级部门使用树形选择器
- 编辑时自动排除当前部门及全部下级部门，避免形成循环父子关系
- 选中部门后调用详情接口，展示部门层级、直属子部门数量和直属用户数量
- 删除前调用检查接口
- 存在子部门或关联用户时展示具体占用项并阻止删除
- 删除成功后自动选中原父部门并刷新部门树
- 保持左侧部门树、右侧详情的固定分栏布局

## 接入接口

依赖后端 PR：`weifuwan/yak-framework#57`

- `GET /yak-security/api/v1/dept/tree`
- `GET /yak-security/api/v1/dept/{id}`
- `POST /yak-security/api/v1/dept`
- `PUT /yak-security/api/v1/dept`
- `DELETE /yak-security/api/v1/dept/delete/check/{id}`
- `DELETE /yak-security/api/v1/dept/{id}`
- `POST /yak-security/api/v1/dept/import`

## 权限控制

- `security:department:read`
- `security:department:create`
- `security:department:edit`
- `security:department:delete`
- `security:department:import`

## 文件变更

- 新增 `DepartmentEditorDrawer.tsx`
- 更新部门管理主页面，接入详情、创建、编辑和删除流程
- 部门服务层 CRUD 方法已通过 PR #69 合并到主分支

## 验证

- 已静态复核树选中状态、详情请求竞态、上级部门排除规则、删除占用提示和删除后的选中节点恢复
- 当前执行环境无法解析 GitHub 域名，未能本地克隆并执行 TypeScript 构建；合并前建议在 `yak-ops-ui` 执行 `npm run tsc` 和 `npm run build`
