### PR TITLE
重构操作日志审计页面并完成后端联调

### DIFF
--- a/yak-ops-ui/src/pages/system/oplogs/components/OperationLogDetailDrawer.tsx
+++ b/yak-ops-ui/src/pages/system/oplogs/components/OperationLogDetailDrawer.tsx
@@ -1,0 +1,271 @@
+import {
+  ClockCircleOutlined,
+  CodeOutlined,
+  GlobalOutlined,
+  UserOutlined,
+} from '@ant-design/icons';
+import {
+  Alert,
+  Descriptions,
+  Drawer,
+  Empty,
+  Space,
+  Spin,
+  Tag,
+  Typography,
+  message,
+} from 'antd';
+import dayjs from 'dayjs';
+import {
+  forwardRef,
+  useCallback,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from 'react';
+
+import {
+  formatJsonText,
+  getOperationLog,
+  isJsonText,
+  type OperationLogDetail,
+} from '@/services/security/operationLogs';
+
+export interface OperationLogDetailDrawerRef {
+  open: (id: number) => Promise<void>;
+}
+
+const errorText = (error: unknown, fallback: string): string =>
+  error instanceof Error && error.message
+    ? error.message
+    : fallback;
+
+const displayTime = (value?: string): string => {
+  if (!value) return '-';
+  const time = dayjs(value);
+  return time.isValid()
+    ? time.format('YYYY-MM-DD HH:mm:ss')
+    : value;
+};
+
+const displayValue = (value?: string | number): string =>
+  value === undefined || value === null || value === ''
+    ? '-'
+    : String(value);
+
+const OperationLogDetailDrawer = forwardRef<
+  OperationLogDetailDrawerRef
+>((_, ref) => {
+  const requestSequenceRef = useRef(0);
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [detail, setDetail] =
+    useState<OperationLogDetail>();
+
+  const show = useCallback(async (id: number) => {
+    const sequence = ++requestSequenceRef.current;
+    setOpen(true);
+    setLoading(true);
+    setDetail(undefined);
+
+    try {
+      const value = await getOperationLog(id);
+      if (sequence === requestSequenceRef.current) {
+        setDetail(value);
+      }
+    } catch (error) {
+      if (sequence === requestSequenceRef.current) {
+        message.error(
+          errorText(error, '操作日志详情加载失败'),
+        );
+      }
+    } finally {
+      if (sequence === requestSequenceRef.current) {
+        setLoading(false);
+      }
+    }
+  }, []);
+
+  useImperativeHandle(ref, () => ({ open: show }), [show]);
+
+  const close = () => {
+    requestSequenceRef.current += 1;
+    setOpen(false);
+    setLoading(false);
+    setDetail(undefined);
+  };
+
+  const formattedDetail = formatJsonText(detail?.detail);
+  const detailIsJson = isJsonText(detail?.detail);
+
+  return (
+    <Drawer
+      open={open}
+      title="操作日志详情"
+      width={760}
+      destroyOnClose
+      onClose={close}
+    >
+      <Spin spinning={loading}>
+        {!loading && !detail ? (
+          <Empty description="暂无日志详情" />
+        ) : detail ? (
+          <div className="space-y-6">
+            <div className="rounded-lg border border-slate-200 bg-slate-50/60 p-4">
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <Space size={8} wrap>
+                    <Typography.Title
+                      level={5}
+                      className="!mb-0 !text-slate-800"
+                    >
+                      {displayValue(detail.operateType)}
+                    </Typography.Title>
+                    {detail.operationMethods && (
+                      <Tag icon={<CodeOutlined />}>
+                        {detail.operationMethods}
+                      </Tag>
+                    )}
+                    {detail.targetType && (
+                      <Tag>{detail.targetType}</Tag>
+                    )}
+                  </Space>
+                  <div className="mt-2 text-sm text-slate-500">
+                    {displayValue(detail.target)}
+                  </div>
+                </div>
+
+                <Typography.Text
+                  type="secondary"
+                  copyable={{ text: String(detail.id) }}
+                >
+                  ID {detail.id}
+                </Typography.Text>
+              </div>
+            </div>
+
+            <Descriptions
+              bordered
+              size="small"
+              column={{ xs: 1, sm: 2 }}
+              items={[
+                {
+                  key: 'operator',
+                  label: (
+                    <Space size={6}>
+                      <UserOutlined />
+                      操作人
+                    </Space>
+                  ),
+                  children: displayValue(detail.operator),
+                },
+                {
+                  key: 'operatorIp',
+                  label: (
+                    <Space size={6}>
+                      <GlobalOutlined />
+                      IP 地址
+                    </Space>
+                  ),
+                  children: detail.operatorIp ? (
+                    <Typography.Text
+                      copyable={{ text: detail.operatorIp }}
+                    >
+                      {detail.operatorIp}
+                    </Typography.Text>
+                  ) : (
+                    '-'
+                  ),
+                },
+                {
+                  key: 'operatePage',
+                  label: '操作页面',
+                  children: displayValue(detail.operatePage),
+                },
+                {
+                  key: 'operationMethods',
+                  label: '操作方法',
+                  children: displayValue(
+                    detail.operationMethods,
+                  ),
+                },
+                {
+                  key: 'targetType',
+                  label: '目标类型',
+                  children: displayValue(detail.targetType),
+                },
+                {
+                  key: 'target',
+                  label: '操作目标',
+                  children: detail.target ? (
+                    <Typography.Text
+                      copyable={{ text: detail.target }}
+                    >
+                      {detail.target}
+                    </Typography.Text>
+                  ) : (
+                    '-'
+                  ),
+                },
+                {
+                  key: 'createTime',
+                  label: (
+                    <Space size={6}>
+                      <ClockCircleOutlined />
+                      操作时间
+                    </Space>
+                  ),
+                  children: displayTime(detail.createTime),
+                },
+                {
+                  key: 'updateTime',
+                  label: '更新时间',
+                  children: displayTime(detail.updateTime),
+                },
+              ]}
+            />
+
+            <div>
+              <div className="mb-2 flex items-center justify-between gap-3">
+                <div className="text-sm font-medium text-slate-800">
+                  操作详情
+                </div>
+                {formattedDetail && (
+                  <Typography.Text
+                    type="secondary"
+                    copyable={{ text: formattedDetail }}
+                  >
+                    复制详情
+                  </Typography.Text>
+                )}
+              </div>
+
+              {!formattedDetail ? (
+                <div className="rounded-lg border border-slate-200 bg-white px-4 py-8 text-center text-sm text-slate-400">
+                  本条日志没有记录操作详情
+                </div>
+              ) : (
+                <pre className="max-h-[420px] overflow-auto whitespace-pre-wrap break-all rounded-lg border border-slate-200 bg-slate-950 px-4 py-3 font-mono text-xs leading-6 text-slate-100">
+                  {formattedDetail}
+                </pre>
+              )}
+            </div>
+
+            {detailIsJson && (
+              <Alert
+                showIcon
+                type="info"
+                message="详情内容已按 JSON 格式化展示"
+              />
+            )}
+          </div>
+        ) : null}
+      </Spin>
+    </Drawer>
+  );
+});
+
+OperationLogDetailDrawer.displayName =
+  'OperationLogDetailDrawer';
+
+export default OperationLogDetailDrawer;

--- a/yak-ops-ui/src/pages/system/oplogs/components/OperationLogFilterBar.tsx
+++ b/yak-ops-ui/src/pages/system/oplogs/components/OperationLogFilterBar.tsx
@@ -1,0 +1,346 @@
+import {
+  FilterOutlined,
+  ReloadOutlined,
+  SearchOutlined,
+} from '@ant-design/icons';
+import {
+  Button,
+  DatePicker,
+  Input,
+  Popover,
+  Select,
+  Space,
+} from 'antd';
+import type { Dayjs } from 'dayjs';
+import { useMemo, useState } from 'react';
+
+import type { OperationLogOptions } from '@/services/security/operationLogs';
+
+export interface OperationLogFilterValues {
+  operateType?: string;
+  operatePage?: string;
+  operationMethods?: string;
+  operator?: string;
+  operatorIp?: string;
+  target?: string;
+  targetType?: string;
+  detail?: string;
+  startTime?: number;
+  endTime?: number;
+}
+
+type SearchField =
+  | 'operator'
+  | 'target'
+  | 'detail'
+  | 'operatorIp';
+
+interface OperationLogFilterBarProps {
+  options: OperationLogOptions;
+  loading?: boolean;
+  onSearch: (values: OperationLogFilterValues) => void;
+  onRefresh: () => void;
+}
+
+interface AdvancedFilters {
+  operateType?: string;
+  operatePage?: string;
+  targetType?: string;
+  timeRange?: [Dayjs, Dayjs];
+}
+
+const SEARCH_FIELDS: Array<{
+  label: string;
+  value: SearchField;
+}> = [
+  { label: '操作人', value: 'operator' },
+  { label: '操作目标', value: 'target' },
+  { label: '操作详情', value: 'detail' },
+  { label: 'IP 地址', value: 'operatorIp' },
+];
+
+const SEARCH_PLACEHOLDERS: Record<SearchField, string> = {
+  operator: '请输入操作人',
+  target: '请输入操作目标',
+  detail: '请输入详情关键字',
+  operatorIp: '请输入 IP 地址',
+};
+
+const clean = (value?: string): string | undefined => {
+  const normalized = value?.trim();
+  return normalized || undefined;
+};
+
+const selectOptions = (values: string[]) =>
+  values.map((value) => ({ label: value, value }));
+
+export default function OperationLogFilterBar({
+  options,
+  loading = false,
+  onSearch,
+  onRefresh,
+}: OperationLogFilterBarProps) {
+  const [searchField, setSearchField] =
+    useState<SearchField>('operator');
+  const [keyword, setKeyword] = useState('');
+  const [method, setMethod] = useState<string>();
+  const [advanced, setAdvanced] =
+    useState<AdvancedFilters>({});
+  const [draftAdvanced, setDraftAdvanced] =
+    useState<AdvancedFilters>({});
+  const [advancedOpen, setAdvancedOpen] = useState(false);
+
+  const methodOptions = useMemo(
+    () => Array.from(new Set(options.operationMethods)),
+    [options.operationMethods],
+  );
+
+  const createFilters = (
+    nextKeyword = keyword,
+    nextField = searchField,
+    nextMethod = method,
+    nextAdvanced = advanced,
+  ): OperationLogFilterValues => {
+    const values: OperationLogFilterValues = {
+      operationMethods: nextMethod,
+      operateType: nextAdvanced.operateType,
+      operatePage: nextAdvanced.operatePage,
+      targetType: nextAdvanced.targetType,
+      startTime: nextAdvanced.timeRange?.[0]
+        ?.startOf('second')
+        .valueOf(),
+      endTime: nextAdvanced.timeRange?.[1]
+        ?.endOf('second')
+        .valueOf(),
+    };
+
+    const normalizedKeyword = clean(nextKeyword);
+    if (normalizedKeyword) {
+      values[nextField] = normalizedKeyword;
+    }
+
+    return values;
+  };
+
+  const submit = () => onSearch(createFilters());
+
+  const changeMethod = (nextMethod?: string) => {
+    setMethod(nextMethod);
+    onSearch(
+      createFilters(keyword, searchField, nextMethod, advanced),
+    );
+  };
+
+  const changeSearchField = (field: SearchField) => {
+    setSearchField(field);
+    setKeyword('');
+    onSearch(createFilters('', field, method, advanced));
+  };
+
+  const applyAdvanced = () => {
+    setAdvanced(draftAdvanced);
+    setAdvancedOpen(false);
+    onSearch(
+      createFilters(
+        keyword,
+        searchField,
+        method,
+        draftAdvanced,
+      ),
+    );
+  };
+
+  const resetAdvanced = () => {
+    const empty: AdvancedFilters = {};
+    setAdvanced(empty);
+    setDraftAdvanced(empty);
+    setAdvancedOpen(false);
+    onSearch(
+      createFilters(keyword, searchField, method, empty),
+    );
+  };
+
+  const advancedCount = [
+    advanced.operateType,
+    advanced.operatePage,
+    advanced.targetType,
+    advanced.timeRange,
+  ].filter(Boolean).length;
+
+  const advancedContent = (
+    <div className="w-[360px] max-w-[calc(100vw-48px)] space-y-4 p-1">
+      <div>
+        <div className="mb-1.5 text-sm text-slate-600">
+          操作类型
+        </div>
+        <Select
+          allowClear
+          showSearch
+          value={draftAdvanced.operateType}
+          options={selectOptions(options.operateTypes)}
+          placeholder="全部操作类型"
+          className="w-full"
+          onChange={(value) =>
+            setDraftAdvanced((current) => ({
+              ...current,
+              operateType: value,
+            }))
+          }
+        />
+      </div>
+
+      <div>
+        <div className="mb-1.5 text-sm text-slate-600">
+          操作页面
+        </div>
+        <Select
+          allowClear
+          showSearch
+          value={draftAdvanced.operatePage}
+          options={selectOptions(options.operatePages)}
+          placeholder="全部操作页面"
+          className="w-full"
+          onChange={(value) =>
+            setDraftAdvanced((current) => ({
+              ...current,
+              operatePage: value,
+            }))
+          }
+        />
+      </div>
+
+      <div>
+        <div className="mb-1.5 text-sm text-slate-600">
+          目标类型
+        </div>
+        <Select
+          allowClear
+          showSearch
+          value={draftAdvanced.targetType}
+          options={selectOptions(options.targetTypes)}
+          placeholder="全部目标类型"
+          className="w-full"
+          onChange={(value) =>
+            setDraftAdvanced((current) => ({
+              ...current,
+              targetType: value,
+            }))
+          }
+        />
+      </div>
+
+      <div>
+        <div className="mb-1.5 text-sm text-slate-600">
+          操作时间
+        </div>
+        <DatePicker.RangePicker
+          showTime
+          value={draftAdvanced.timeRange}
+          className="w-full"
+          onChange={(value) =>
+            setDraftAdvanced((current) => ({
+              ...current,
+              timeRange:
+                value?.[0] && value?.[1]
+                  ? [value[0], value[1]]
+                  : undefined,
+            }))
+          }
+        />
+      </div>
+
+      <div className="flex justify-end gap-2 border-t border-slate-100 pt-3">
+        <Button onClick={resetAdvanced}>重置</Button>
+        <Button type="primary" onClick={applyAdvanced}>
+          应用筛选
+        </Button>
+      </div>
+    </div>
+  );
+
+  return (
+    <div className="mb-4 flex min-w-0 flex-col gap-4 xl:flex-row xl:items-center xl:justify-between">
+      <div className="flex min-w-0 items-center gap-2 overflow-x-auto pb-1 xl:pb-0">
+        {[undefined, ...methodOptions].map((value) => {
+          const active = method === value;
+          return (
+            <button
+              key={value ?? 'all'}
+              type="button"
+              className={[
+                'shrink-0 rounded px-3 py-1 text-sm font-medium leading-5 transition-colors',
+                active
+                  ? 'bg-[#f2f2f4] text-[#FE2C55]'
+                  : 'bg-[#f2f4f7] text-[#667085] hover:bg-[#e8eaef]',
+              ].join(' ')}
+              onClick={() => changeMethod(value)}
+            >
+              {value ?? '全部'}
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="flex shrink-0 flex-wrap items-center gap-2">
+        <div className="flex h-8 w-[330px] max-w-full overflow-hidden rounded-md bg-[#f2f2f4]">
+          <Select<SearchField>
+            value={searchField}
+            options={SEARCH_FIELDS}
+            variant="borderless"
+            popupMatchSelectWidth={120}
+            className="h-8 w-[104px] shrink-0"
+            onChange={changeSearchField}
+          />
+          <div className="my-2 w-px shrink-0 bg-slate-200" />
+          <Input
+            allowClear
+            value={keyword}
+            variant="borderless"
+            placeholder={SEARCH_PLACEHOLDERS[searchField]}
+            suffix={
+              <SearchOutlined
+                className="cursor-pointer text-slate-400 hover:text-slate-700"
+                onClick={submit}
+              />
+            }
+            className="min-w-0 flex-1 !h-8 !bg-transparent !shadow-none"
+            onChange={(event) => {
+              const value = event.target.value;
+              setKeyword(value);
+              if (!value) {
+                onSearch(
+                  createFilters('', searchField, method, advanced),
+                );
+              }
+            }}
+            onPressEnter={submit}
+          />
+        </div>
+
+        <Popover
+          trigger="click"
+          placement="bottomRight"
+          open={advancedOpen}
+          content={advancedContent}
+          onOpenChange={(open) => {
+            setAdvancedOpen(open);
+            if (open) setDraftAdvanced(advanced);
+          }}
+        >
+          <Button icon={<FilterOutlined />}>
+            高级筛选
+            {advancedCount > 0 ? ` (${advancedCount})` : ''}
+          </Button>
+        </Popover>
+
+        <Button
+          icon={<ReloadOutlined />}
+          loading={loading}
+          onClick={onRefresh}
+        >
+          刷新
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/yak-ops-ui/src/pages/system/oplogs/index.tsx
+++ b/yak-ops-ui/src/pages/system/oplogs/index.tsx
@@ -1,86 +1,315 @@
-import type { ActionType, ProColumns } from '@ant-design/pro-components';
-import { Button, Drawer, Empty, Typography } from 'antd';
-import dayjs from 'dayjs';
-import { useRef, useState } from 'react';
-import { SecurityQueryTable } from '@/components/security';
 import {
-  formatJsonText,
-  getOperationLog,
+  EyeOutlined,
+  FileSearchOutlined,
+} from '@ant-design/icons';
+import type { ProColumns } from '@ant-design/pro-components';
+import { Button, Space, Tag, Typography, message } from 'antd';
+import dayjs from 'dayjs';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+
+import {
+  SecurityPagination,
+  SecurityQueryTable,
+} from '@/components/security';
+import {
+  getOperationLogOptions,
   type OperationLog,
-  type OperationLogDetail,
+  type OperationLogOptions,
   pageOperationLogs,
 } from '@/services/security/operationLogs';
 
+import OperationLogDetailDrawer, {
+  type OperationLogDetailDrawerRef,
+} from './components/OperationLogDetailDrawer';
+import OperationLogFilterBar, {
+  type OperationLogFilterValues,
+} from './components/OperationLogFilterBar';
+
+interface PaginationState {
+  current: number;
+  pageSize: number;
+  total: number;
+}
+
+const DEFAULT_PAGINATION: PaginationState = {
+  current: 1,
+  pageSize: 10,
+  total: 0,
+};
+
+const EMPTY_OPTIONS: OperationLogOptions = {
+  operateTypes: [],
+  operatePages: [],
+  operationMethods: [],
+  targetTypes: [],
+};
+
+const errorText = (error: unknown, fallback: string): string =>
+  error instanceof Error && error.message
+    ? error.message
+    : fallback;
+
+const displayTime = (value?: string): string => {
+  if (!value) return '-';
+  const time = dayjs(value);
+  return time.isValid()
+    ? time.format('YYYY-MM-DD HH:mm:ss')
+    : value;
+};
+
+const methodTag = (method?: string) =>
+  method ? <Tag className="!mr-0">{method}</Tag> : null;
+
 export default function OperationLogsPage() {
-  const actionRef = useRef<ActionType>();
-  const [detail, setDetail] = useState<OperationLogDetail>();
-  const columns: ProColumns<OperationLog>[] = [
-    { title: 'ID', dataIndex: 'id', search: false, copyable: true },
-    { title: '操作类型', dataIndex: 'operationType' },
-    { title: '操作人', dataIndex: 'operatorName' },
-    {
-      title: '目标',
-      dataIndex: 'target',
-      render: (_, row) => [row.targetType, row.targetId].filter(Boolean).join(' / ') || '-',
+  const detailRef = useRef<OperationLogDetailDrawerRef>(null);
+  const requestSequenceRef = useRef(0);
+
+  const [logs, setLogs] = useState<OperationLog[]>([]);
+  const [options, setOptions] =
+    useState<OperationLogOptions>(EMPTY_OPTIONS);
+  const [filters, setFilters] =
+    useState<OperationLogFilterValues>({});
+  const [pagination, setPagination] =
+    useState<PaginationState>(DEFAULT_PAGINATION);
+  const [loading, setLoading] = useState(false);
+
+  const loadOptions = useCallback(async () => {
+    try {
+      setOptions(await getOperationLogOptions());
+    } catch (error) {
+      setOptions(EMPTY_OPTIONS);
+      message.warning(
+        errorText(error, '操作日志筛选选项加载失败'),
+      );
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadOptions();
+  }, [loadOptions]);
+
+  const loadLogs = useCallback(async () => {
+    const sequence = ++requestSequenceRef.current;
+    setLoading(true);
+
+    try {
+      const result = await pageOperationLogs({
+        pageNum: pagination.current,
+        pageSize: pagination.pageSize,
+        ...filters,
+      });
+
+      if (sequence !== requestSequenceRef.current) return;
+
+      setLogs(result.records ?? []);
+      setPagination((current) => ({
+        ...current,
+        total: result.total ?? 0,
+      }));
+    } catch (error) {
+      if (sequence !== requestSequenceRef.current) return;
+
+      setLogs([]);
+      setPagination((current) => ({
+        ...current,
+        total: 0,
+      }));
+      message.error(errorText(error, '操作日志查询失败'));
+    } finally {
+      if (sequence === requestSequenceRef.current) {
+        setLoading(false);
+      }
+    }
+  }, [filters, pagination.current, pagination.pageSize]);
+
+  useEffect(() => {
+    void loadLogs();
+  }, [loadLogs]);
+
+  const reload = useCallback(() => {
+    void Promise.all([loadLogs(), loadOptions()]);
+  }, [loadLogs, loadOptions]);
+
+  const handleSearch = useCallback(
+    (values: OperationLogFilterValues) => {
+      setFilters(values);
+      setPagination((current) => ({
+        ...current,
+        current: 1,
+      }));
     },
-    { title: '结果', dataIndex: 'result', search: false },
-    { title: 'IP', dataIndex: 'ip', search: false },
-    {
-      title: '时间',
-      dataIndex: 'operationTime',
-      valueType: 'dateTimeRange',
-      render: (_, row) => row.operationTime ?? '-',
+    [],
+  );
+
+  const handlePageChange = useCallback(
+    (current: number, pageSize: number) => {
+      setPagination((previous) => ({
+        ...previous,
+        current:
+          previous.pageSize === pageSize ? current : 1,
+        pageSize,
+      }));
     },
-    {
-      title: '操作',
-      valueType: 'option',
-      render: (_, row) => (
-        <Button type="link" onClick={async () => setDetail(await getOperationLog(row.id))}>
-          详情
-        </Button>
-      ),
-    },
-  ];
-  return (
-    <section className="p-6">
-      <SecurityQueryTable<OperationLog>
-        actionRef={actionRef}
-        columns={columns}
-        request={async (params) => {
-          const range = params.operationTime as [string, string] | undefined;
-          const result = await pageOperationLogs({
-            pageNum: params.current ?? 1,
-            pageSize: params.pageSize ?? 10,
-            operationType: params.operationType as string,
-            operatorName: params.operatorName as string,
-            target: params.target as string,
-            // Keep the browser's explicit offset so the backend can interpret the same instant.
-            startTime: range?.[0] ? dayjs(range[0]).format() : undefined,
-            endTime: range?.[1] ? dayjs(range[1]).format() : undefined,
-          });
-          return { data: result.records, total: result.total, success: true };
-        }}
-      />
-      <Drawer
-        title="操作日志详情"
-        width={680}
-        open={Boolean(detail)}
-        onClose={() => setDetail(undefined)}
-        destroyOnClose
-      >
-        {detail ? (
-          Object.entries(detail).map(([key, value]) => (
-            <div key={key} className="mb-4">
-              <Typography.Text strong>{key}</Typography.Text>
-              <pre className="mt-1 max-h-80 overflow-auto whitespace-pre-wrap break-all rounded bg-slate-50 p-3">
-                {key.toLowerCase().includes('json') ? formatJsonText(value) : String(value ?? '-')}
-              </pre>
+    [],
+  );
+
+  const columns = useMemo<ProColumns<OperationLog>[]>(
+    () => [
+      {
+        title: '日志 ID',
+        dataIndex: 'id',
+        width: 110,
+        copyable: true,
+        search: false,
+      },
+      {
+        title: '操作',
+        dataIndex: 'operateType',
+        width: 190,
+        search: false,
+        render: (_, row) => (
+          <div className="min-w-0">
+            <div className="truncate font-medium text-slate-700">
+              {row.operateType || '-'}
             </div>
-          ))
-        ) : (
-          <Empty />
-        )}
-      </Drawer>
+            <div className="mt-1">
+              {methodTag(row.operationMethods)}
+            </div>
+          </div>
+        ),
+      },
+      {
+        title: '操作人',
+        dataIndex: 'operator',
+        width: 180,
+        search: false,
+        render: (_, row) => (
+          <div className="min-w-0">
+            <div className="truncate text-slate-700">
+              {row.operator || '-'}
+            </div>
+            <div className="mt-1 truncate font-mono text-xs text-slate-400">
+              {row.operatorIp || '-'}
+            </div>
+          </div>
+        ),
+      },
+      {
+        title: '操作页面',
+        dataIndex: 'operatePage',
+        width: 180,
+        ellipsis: true,
+        search: false,
+        renderText: (value) => value || '-',
+      },
+      {
+        title: '操作对象',
+        dataIndex: 'target',
+        width: 260,
+        search: false,
+        render: (_, row) => (
+          <div className="min-w-0">
+            <Typography.Text
+              ellipsis={{ tooltip: row.target }}
+              copyable={
+                row.target ? { text: row.target } : false
+              }
+              className="max-w-full"
+            >
+              {row.target || '-'}
+            </Typography.Text>
+            <div className="mt-1 text-xs text-slate-400">
+              {row.targetType || '未分类'}
+            </div>
+          </div>
+        ),
+      },
+      {
+        title: '操作时间',
+        dataIndex: 'createTime',
+        width: 175,
+        search: false,
+        renderText: (value) => displayTime(value),
+      },
+      {
+        title: '操作',
+        valueType: 'option',
+        width: 90,
+        fixed: 'right',
+        render: (_, row) => (
+          <Button
+            type="link"
+            size="small"
+            icon={<EyeOutlined />}
+            onClick={() => void detailRef.current?.open(row.id)}
+          >
+            详情
+          </Button>
+        ),
+      },
+    ],
+    [],
+  );
+
+  return (
+    <section
+      className="box-border flex flex-col bg-slate-50/50 p-6"
+      style={{
+        minHeight: 'calc(100vh - 64px)',
+        overflow: 'hidden',
+      }}
+      aria-labelledby="oplog-title"
+    >
+      <div className="shrink-0">
+        <div className="mb-4 flex items-center gap-2">
+          <FileSearchOutlined className="text-slate-500" />
+          <h1
+            id="oplog-title"
+            className="m-0 font-semibold"
+            style={{ fontSize: 18, color: '#282828' }}
+          >
+            操作日志
+          </h1>
+        </div>
+
+        <OperationLogFilterBar
+          options={options}
+          loading={loading}
+          onSearch={handleSearch}
+          onRefresh={reload}
+        />
+
+        <SecurityQueryTable<OperationLog>
+          rowKey="id"
+          columns={columns}
+          dataSource={logs}
+          loading={loading}
+          pagination={false}
+          search={false}
+          options={false}
+          toolBarRender={false}
+          bordered
+          scroll={{ x: 'max-content' }}
+        />
+      </div>
+
+      <div className="min-h-6 flex-1" />
+
+      <SecurityPagination
+        current={pagination.current}
+        pageSize={pagination.pageSize}
+        total={pagination.total}
+        disabled={loading}
+        onChange={handlePageChange}
+      />
+
+      <OperationLogDetailDrawer ref={detailRef} />
     </section>
   );
 }

--- a/yak-ops-ui/src/services/security/operationLogs.ts
+++ b/yak-ops-ui/src/services/security/operationLogs.ts
@@ -1,39 +1,150 @@
-import { securityGetData } from './client';
+import {
+  securityGetData,
+  securityPostData,
+} from './client';
 
 const OPLOG_API = '/api/v1/oplog';
+
 export interface OperationLog {
-  id: number | string;
-  operationType: string;
-  operatorName?: string;
+  id: number;
+  operatorIp?: string;
+  operator?: string;
+  operatePage?: string;
+  operateType?: string;
+  operationMethods?: string;
+  target?: string;
   targetType?: string;
-  targetId?: string;
-  result?: string;
-  ip?: string;
-  operationTime?: string;
+  detail?: string;
+  createTime?: string;
+  updateTime?: string;
 }
-export interface OperationLogDetail extends OperationLog {
-  requestJson?: string | Record<string, unknown>;
-  responseJson?: string | Record<string, unknown>;
-  detailJson?: string | Record<string, unknown>;
+
+export type OperationLogDetail = OperationLog;
+
+export interface OperationLogOptions {
+  operateTypes: string[];
+  operatePages: string[];
+  operationMethods: string[];
+  targetTypes: string[];
 }
-export interface OperationLogPage { records: OperationLog[]; total: number }
+
 export interface OperationLogQuery {
-  pageNum: number; pageSize: number; operationType?: string; operatorName?: string;
-  target?: string; startTime?: string; endTime?: string;
+  pageNum: number;
+  pageSize: number;
+  operateType?: string;
+  operatePage?: string;
+  operationMethods?: string;
+  operator?: string;
+  operatorIp?: string;
+  target?: string;
+  targetType?: string;
+  detail?: string;
+  startTime?: number;
+  endTime?: number;
 }
-const query = (values: object) => {
-  const params = new URLSearchParams();
-  Object.entries(values as Record<string, unknown>).forEach(([key, value]) => {
-    if (value !== undefined && value !== null && value !== '') params.set(key, String(value));
+
+export interface OperationLogPage {
+  records: OperationLog[];
+  total: number;
+}
+
+interface BackendPagingData<T> {
+  bizData?: T[];
+  pagination?: {
+    total?: number;
+    pages?: number;
+    pageNo?: number;
+    pageSize?: number;
+  };
+}
+
+const normalizeOptions = (
+  value?: Partial<OperationLogOptions>,
+): OperationLogOptions => ({
+  operateTypes: Array.isArray(value?.operateTypes)
+    ? value.operateTypes
+    : [],
+  operatePages: Array.isArray(value?.operatePages)
+    ? value.operatePages
+    : [],
+  operationMethods: Array.isArray(value?.operationMethods)
+    ? value.operationMethods
+    : [],
+  targetTypes: Array.isArray(value?.targetTypes)
+    ? value.targetTypes
+    : [],
+});
+
+export const pageOperationLogs = async (
+  params: OperationLogQuery,
+): Promise<OperationLogPage> => {
+  const data = await securityPostData<
+    BackendPagingData<OperationLog>
+  >(`${OPLOG_API}/page`, {
+    page: params.pageNum,
+    size: params.pageSize,
+    operateType: params.operateType,
+    operatePage: params.operatePage,
+    operationMethods: params.operationMethods,
+    operator: params.operator,
+    operatorIp: params.operatorIp,
+    target: params.target,
+    targetType: params.targetType,
+    detail: params.detail,
+    startTime: params.startTime,
+    endTime: params.endTime,
   });
-  return params.toString();
+
+  return {
+    records: Array.isArray(data?.bizData)
+      ? data.bizData
+      : [],
+    total: Number(data?.pagination?.total ?? 0),
+  };
 };
-export const pageOperationLogs = (params: OperationLogQuery) =>
-  securityGetData<OperationLogPage>(`${OPLOG_API}/page?${query(params)}`);
-export const getOperationLog = (id: number | string) =>
-  securityGetData<OperationLogDetail>(`${OPLOG_API}/detail?id=${encodeURIComponent(id)}`);
+
+export const getOperationLog = (
+  id: number | string,
+): Promise<OperationLogDetail> =>
+  securityGetData<OperationLogDetail>(
+    `${OPLOG_API}/${encodeURIComponent(String(id))}`,
+  );
+
+export const getOperationLogOptions = async (): Promise<OperationLogOptions> =>
+  normalizeOptions(
+    await securityGetData<Partial<OperationLogOptions>>(
+      `${OPLOG_API}/options`,
+    ),
+  );
 
 export const formatJsonText = (value: unknown): string => {
-  if (typeof value !== 'string') return JSON.stringify(value ?? '', null, 2);
-  try { return JSON.stringify(JSON.parse(value), null, 2); } catch { return value; }
+  if (value === undefined || value === null || value === '') {
+    return '';
+  }
+
+  if (typeof value !== 'string') {
+    return JSON.stringify(value, null, 2);
+  }
+
+  const text = value.trim();
+  if (!text) return '';
+
+  try {
+    return JSON.stringify(JSON.parse(text), null, 2);
+  } catch {
+    return value;
+  }
+};
+
+export const isJsonText = (value: unknown): boolean => {
+  if (typeof value !== 'string' || !value.trim()) {
+    return false;
+  }
+
+  try {
+    JSON.parse(value);
+    return true;
+  } catch {
+    return false;
+  }
 };


### PR DESCRIPTION
## 变更内容

重构系统管理中的操作日志页面，修复原页面与 `yak-security` 后端接口、字段和时间参数不一致的问题。

### 页面布局

- 采用与用户管理一致的“筛选栏 + 表格 + 独立底部分页”布局
- 表格与分页分离，页面剩余空间自适应
- 列表展示日志 ID、操作类型、操作方法、操作人、IP、操作页面、操作对象、目标类型和操作时间
- 详情使用结构化抽屉展示，不再机械遍历原始对象字段
- JSON 操作详情自动格式化，普通文本保持原样
- 日志 ID、IP、目标和详情支持复制

### 筛选能力

- 操作方法快捷筛选
- 操作人、操作目标、详情关键字、IP 地址搜索
- 操作类型筛选
- 操作页面筛选
- 目标类型筛选
- 操作时间范围筛选
- 筛选选项从后端动态加载

### 接口修复

原前端存在以下错误：

- 错误使用 `GET /oplog/page`，后端实际为 POST
- 错误请求 `/oplog/detail?id=`，后端实际为 `/oplog/{id}`
- 使用不存在的 `operationType`、`operatorName`、`targetId`、`result`、`ip`、`operationTime`
- 时间范围发送 ISO 字符串，后端实际接收 Unix 毫秒时间戳
- 错误假设分页响应为 `{ records, total }`

现已统一为真实字段：

- `operateType`
- `operatePage`
- `operationMethods`
- `operator`
- `operatorIp`
- `target`
- `targetType`
- `detail`
- `createTime`
- `updateTime`

### 接入接口

依赖后端 PR：`weifuwan/yak-framework#58`

- `POST /yak-security/api/v1/oplog/page`
- `GET /yak-security/api/v1/oplog/{id}`
- `GET /yak-security/api/v1/oplog/options`

## 验证

- 保留并兼容现有 `formatJsonText` 单元测试
- 已静态复核分页响应转换、筛选字段清理、毫秒时间戳转换、详情请求竞态和列表请求竞态
- 当前执行环境未检出完整仓库，未实际运行 TypeScript 构建；合并前建议在 `yak-ops-ui` 执行 `npm run tsc`、`npm run build` 和相关测试
