### PR TITLE
重构系统配置页面并完成后端联调

### DIFF
--- a/yak-ops-ui/src/pages/system/configs/components/ConfigDetailDrawer.tsx
+++ b/yak-ops-ui/src/pages/system/configs/components/ConfigDetailDrawer.tsx
@@ -1,0 +1,210 @@
+import { SettingOutlined } from '@ant-design/icons';
+import {
+  Avatar,
+  Descriptions,
+  Drawer,
+  Empty,
+  Spin,
+  Tag,
+  Typography,
+  message,
+} from 'antd';
+import dayjs from 'dayjs';
+import {
+  forwardRef,
+  useCallback,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from 'react';
+
+import {
+  type SystemConfig,
+  formatConfigValue,
+  getConfig,
+} from '@/services/security/configs';
+
+export interface ConfigDetailDrawerRef {
+  open: (config: SystemConfig) => void;
+}
+
+const errorText = (error: unknown, fallback: string): string =>
+  error instanceof Error && error.message
+    ? error.message
+    : fallback;
+
+const dateText = (value?: string): string =>
+  value && dayjs(value).isValid()
+    ? dayjs(value).format('YYYY-MM-DD HH:mm:ss')
+    : '-';
+
+const ConfigDetailDrawer = forwardRef<ConfigDetailDrawerRef>(
+  (_, ref) => {
+    const requestSequenceRef = useRef(0);
+    const [open, setOpen] = useState(false);
+    const [loading, setLoading] = useState(false);
+    const [detail, setDetail] = useState<SystemConfig>();
+
+    const show = useCallback((config: SystemConfig) => {
+      const sequence = ++requestSequenceRef.current;
+      setOpen(true);
+      setLoading(true);
+      setDetail(config);
+
+      void getConfig(config.id)
+        .then((value) => {
+          if (sequence === requestSequenceRef.current) {
+            setDetail(value);
+          }
+        })
+        .catch((error) => {
+          if (sequence === requestSequenceRef.current) {
+            message.error(errorText(error, '配置详情加载失败'));
+          }
+        })
+        .finally(() => {
+          if (sequence === requestSequenceRef.current) {
+            setLoading(false);
+          }
+        });
+    }, []);
+
+    useImperativeHandle(ref, () => ({ open: show }), [show]);
+
+    const close = () => {
+      requestSequenceRef.current += 1;
+      setOpen(false);
+      setLoading(false);
+      setDetail(undefined);
+    };
+
+    const formattedValue = formatConfigValue(detail?.value ?? '');
+
+    return (
+      <Drawer
+        open={open}
+        title="配置详情"
+        width={680}
+        destroyOnClose
+        onClose={close}
+      >
+        <Spin spinning={loading}>
+          {detail ? (
+            <div className="space-y-6">
+              <div className="flex items-center gap-3 rounded-lg border border-slate-200 bg-slate-50/60 px-4 py-3">
+                <Avatar
+                  size={44}
+                  icon={<SettingOutlined />}
+                  className="shrink-0 !bg-slate-600"
+                />
+                <div className="min-w-0 flex-1">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <Typography.Title
+                      level={5}
+                      className="!mb-0 !text-slate-800"
+                    >
+                      {detail.valueName || '未命名配置'}
+                    </Typography.Title>
+                    <Tag
+                      color={detail.status === 1 ? 'processing' : 'default'}
+                    >
+                      {detail.status === 1 ? '已启用' : '已停用'}
+                    </Tag>
+                  </div>
+                  <div className="mt-1 text-xs text-slate-400">
+                    {detail.valueGroup || '未分组'} · ID {detail.id}
+                  </div>
+                </div>
+              </div>
+
+              <Descriptions
+                bordered
+                size="small"
+                column={2}
+                items={[
+                  {
+                    key: 'id',
+                    label: '配置 ID',
+                    children: (
+                      <Typography.Text copyable>
+                        {detail.id}
+                      </Typography.Text>
+                    ),
+                  },
+                  {
+                    key: 'status',
+                    label: '配置状态',
+                    children:
+                      detail.status === 1 ? '启用' : '停用',
+                  },
+                  {
+                    key: 'group',
+                    label: '配置分组',
+                    children: detail.valueGroup || '-',
+                  },
+                  {
+                    key: 'name',
+                    label: '配置名称',
+                    children: (
+                      <Typography.Text copyable>
+                        {detail.valueName || '-'}
+                      </Typography.Text>
+                    ),
+                  },
+                  {
+                    key: 'operator',
+                    label: '最后操作人',
+                    children: detail.operator || '-',
+                  },
+                  {
+                    key: 'createTime',
+                    label: '创建时间',
+                    children: dateText(detail.createTime),
+                  },
+                  {
+                    key: 'updateTime',
+                    label: '更新时间',
+                    children: dateText(detail.updateTime),
+                    span: 2,
+                  },
+                ]}
+              />
+
+              <div>
+                <div className="mb-2 flex items-center justify-between gap-3">
+                  <span className="text-sm font-medium text-slate-800">
+                    配置值
+                  </span>
+                  <Typography.Text
+                    copyable={{ text: detail.value ?? '' }}
+                    className="text-xs"
+                  >
+                    复制原值
+                  </Typography.Text>
+                </div>
+                <pre className="max-h-[360px] min-h-24 overflow-auto whitespace-pre-wrap break-all rounded-lg border border-slate-200 bg-slate-950 px-4 py-3 font-mono text-xs leading-6 text-slate-100">
+                  {formattedValue || '(空字符串)'}
+                </pre>
+              </div>
+
+              <div>
+                <div className="mb-2 text-sm font-medium text-slate-800">
+                  备注
+                </div>
+                <div className="min-h-20 whitespace-pre-wrap break-words rounded-lg border border-slate-200 bg-white px-4 py-3 text-sm leading-6 text-slate-600">
+                  {detail.memo || '暂无备注'}
+                </div>
+              </div>
+            </div>
+          ) : (
+            <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} />
+          )}
+        </Spin>
+      </Drawer>
+    );
+  },
+);
+
+ConfigDetailDrawer.displayName = 'ConfigDetailDrawer';
+
+export default ConfigDetailDrawer;

--- a/yak-ops-ui/src/pages/system/configs/components/ConfigEditorModal.tsx
+++ b/yak-ops-ui/src/pages/system/configs/components/ConfigEditorModal.tsx
@@ -187,7 +187,7 @@ const ConfigEditorModal = forwardRef<
       open={open}
       title={editingId !== undefined ? '编辑配置' : '新增配置'}
       width={620}
-      destroyOnClose
+      forceRender
       maskClosable={false}
       keyboard={!saving}
       closable={!saving}

--- a/yak-ops-ui/src/pages/system/configs/components/ConfigEditorModal.tsx
+++ b/yak-ops-ui/src/pages/system/configs/components/ConfigEditorModal.tsx
@@ -7,7 +7,6 @@ import {
   Input,
   Modal,
   Select,
-  Space,
   message,
 } from 'antd';
 import {
@@ -66,6 +65,14 @@ const ConfigEditorModal = forwardRef<
   const [loading, setLoading] = useState(false);
   const [saving, setSaving] = useState(false);
 
+  const resetAndClose = useCallback(() => {
+    requestSequenceRef.current += 1;
+    setOpen(false);
+    setEditingId(undefined);
+    setLoading(false);
+    form.resetFields();
+  }, [form]);
+
   const openCreate = useCallback(() => {
     requestSequenceRef.current += 1;
     setEditingId(undefined);
@@ -119,16 +126,11 @@ const ConfigEditorModal = forwardRef<
   );
 
   const close = () => {
-    if (saving) return;
-    requestSequenceRef.current += 1;
-    setOpen(false);
-    setEditingId(undefined);
-    setLoading(false);
-    form.resetFields();
+    if (!saving) resetAndClose();
   };
 
   const formatValue = () => {
-    const value = form.getFieldValue('value');
+    const value = form.getFieldValue('value') ?? '';
     const formatted = formatConfigValue(value);
 
     if (formatted === value) {
@@ -143,6 +145,7 @@ const ConfigEditorModal = forwardRef<
     if (saving) return;
     setSaving(true);
 
+    const currentEditingId = editingId;
     const body: ConfigInput = {
       valueGroup: values.valueGroup.trim(),
       valueName: values.valueName.trim(),
@@ -152,22 +155,24 @@ const ConfigEditorModal = forwardRef<
     };
 
     try {
-      if (editingId !== undefined) {
-        await updateConfig(editingId, body);
+      if (currentEditingId !== undefined) {
+        await updateConfig(currentEditingId, body);
       } else {
         await createConfig(body);
       }
 
       message.success(
-        editingId !== undefined ? '配置已更新' : '配置已创建',
+        currentEditingId !== undefined
+          ? '配置已更新'
+          : '配置已创建',
       );
-      close();
+      resetAndClose();
       onSuccess();
     } catch (error) {
       message.error(
         errorText(
           error,
-          editingId !== undefined
+          currentEditingId !== undefined
             ? '配置更新失败'
             : '配置创建失败',
         ),
@@ -186,7 +191,7 @@ const ConfigEditorModal = forwardRef<
       maskClosable={false}
       keyboard={!saving}
       closable={!saving}
-      confirmLoading={saving}
+      confirmLoading={saving || loading}
       okText="保存"
       cancelText="取消"
       onCancel={close}
@@ -254,7 +259,7 @@ const ConfigEditorModal = forwardRef<
         <Form.Item
           name="value"
           label={
-            <div className="flex w-full items-center justify-between gap-3">
+            <div className="flex items-center gap-3">
               <span>配置值</span>
               <Button
                 type="link"
@@ -274,27 +279,25 @@ const ConfigEditorModal = forwardRef<
           />
         </Form.Item>
 
-        <Space size={16} align="start" className="w-full">
-          <Form.Item
-            name="status"
-            label="配置状态"
-            className="w-[180px]"
-            rules={[{ required: true, message: '请选择配置状态' }]}
-          >
-            <Select
-              options={[
-                {
-                  value: CONFIG_STATUS_ENABLED,
-                  label: '启用',
-                },
-                {
-                  value: CONFIG_STATUS_DISABLED,
-                  label: '停用',
-                },
-              ]}
-            />
-          </Form.Item>
-        </Space>
+        <Form.Item
+          name="status"
+          label="配置状态"
+          className="w-[180px]"
+          rules={[{ required: true, message: '请选择配置状态' }]}
+        >
+          <Select
+            options={[
+              {
+                value: CONFIG_STATUS_ENABLED,
+                label: '启用',
+              },
+              {
+                value: CONFIG_STATUS_DISABLED,
+                label: '停用',
+              },
+            ]}
+          />
+        </Form.Item>
 
         <Form.Item name="memo" label="备注">
           <Input.TextArea

--- a/yak-ops-ui/src/pages/system/configs/components/ConfigEditorModal.tsx
+++ b/yak-ops-ui/src/pages/system/configs/components/ConfigEditorModal.tsx
@@ -1,0 +1,314 @@
+import { CodeOutlined } from '@ant-design/icons';
+import {
+  Alert,
+  AutoComplete,
+  Button,
+  Form,
+  Input,
+  Modal,
+  Select,
+  Space,
+  message,
+} from 'antd';
+import {
+  forwardRef,
+  useCallback,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from 'react';
+
+import {
+  type ConfigInput,
+  type ConfigStatus,
+  type SystemConfig,
+  createConfig,
+  formatConfigValue,
+  getConfig,
+  updateConfig,
+} from '@/services/security/configs';
+
+const CONFIG_STATUS_ENABLED: ConfigStatus = 1;
+const CONFIG_STATUS_DISABLED: ConfigStatus = 2;
+
+export interface ConfigEditorModalRef {
+  openCreate: () => void;
+  openEdit: (config: SystemConfig) => void;
+}
+
+interface ConfigEditorModalProps {
+  groups: string[];
+  onSuccess: () => void;
+}
+
+const defaultValues: ConfigInput = {
+  valueGroup: '',
+  valueName: '',
+  value: '',
+  status: CONFIG_STATUS_ENABLED,
+  memo: '',
+};
+
+const errorText = (error: unknown, fallback: string): string =>
+  error instanceof Error && error.message
+    ? error.message
+    : fallback;
+
+const ConfigEditorModal = forwardRef<
+  ConfigEditorModalRef,
+  ConfigEditorModalProps
+>(({ groups, onSuccess }, ref) => {
+  const [form] = Form.useForm<ConfigInput>();
+  const requestSequenceRef = useRef(0);
+
+  const [open, setOpen] = useState(false);
+  const [editingId, setEditingId] = useState<number>();
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  const openCreate = useCallback(() => {
+    requestSequenceRef.current += 1;
+    setEditingId(undefined);
+    setLoading(false);
+    form.setFieldsValue(defaultValues);
+    setOpen(true);
+  }, [form]);
+
+  const openEdit = useCallback(
+    (config: SystemConfig) => {
+      const sequence = ++requestSequenceRef.current;
+      setEditingId(config.id);
+      setOpen(true);
+      setLoading(true);
+      form.setFieldsValue({
+        valueGroup: config.valueGroup ?? '',
+        valueName: config.valueName ?? '',
+        value: config.value ?? '',
+        status: config.status ?? CONFIG_STATUS_ENABLED,
+        memo: config.memo ?? '',
+      });
+
+      void getConfig(config.id)
+        .then((detail) => {
+          if (sequence !== requestSequenceRef.current) return;
+          form.setFieldsValue({
+            valueGroup: detail.valueGroup ?? '',
+            valueName: detail.valueName ?? '',
+            value: detail.value ?? '',
+            status: detail.status ?? CONFIG_STATUS_ENABLED,
+            memo: detail.memo ?? '',
+          });
+        })
+        .catch((error) => {
+          if (sequence !== requestSequenceRef.current) return;
+          message.error(errorText(error, '配置详情加载失败'));
+        })
+        .finally(() => {
+          if (sequence === requestSequenceRef.current) {
+            setLoading(false);
+          }
+        });
+    },
+    [form],
+  );
+
+  useImperativeHandle(
+    ref,
+    () => ({ openCreate, openEdit }),
+    [openCreate, openEdit],
+  );
+
+  const close = () => {
+    if (saving) return;
+    requestSequenceRef.current += 1;
+    setOpen(false);
+    setEditingId(undefined);
+    setLoading(false);
+    form.resetFields();
+  };
+
+  const formatValue = () => {
+    const value = form.getFieldValue('value');
+    const formatted = formatConfigValue(value);
+
+    if (formatted === value) {
+      message.info('当前配置值不是可格式化的 JSON，已保持原内容');
+      return;
+    }
+
+    form.setFieldValue('value', formatted);
+  };
+
+  const save = async (values: ConfigInput) => {
+    if (saving) return;
+    setSaving(true);
+
+    const body: ConfigInput = {
+      valueGroup: values.valueGroup.trim(),
+      valueName: values.valueName.trim(),
+      value: values.value ?? '',
+      status: values.status,
+      memo: values.memo?.trim() ?? '',
+    };
+
+    try {
+      if (editingId !== undefined) {
+        await updateConfig(editingId, body);
+      } else {
+        await createConfig(body);
+      }
+
+      message.success(
+        editingId !== undefined ? '配置已更新' : '配置已创建',
+      );
+      close();
+      onSuccess();
+    } catch (error) {
+      message.error(
+        errorText(
+          error,
+          editingId !== undefined
+            ? '配置更新失败'
+            : '配置创建失败',
+        ),
+      );
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Modal
+      open={open}
+      title={editingId !== undefined ? '编辑配置' : '新增配置'}
+      width={620}
+      destroyOnClose
+      maskClosable={false}
+      keyboard={!saving}
+      closable={!saving}
+      confirmLoading={saving}
+      okText="保存"
+      cancelText="取消"
+      onCancel={close}
+      onOk={() => form.submit()}
+    >
+      <Alert
+        showIcon
+        type="info"
+        className="mb-5"
+        message="配置分组与配置名称共同组成唯一配置项"
+        description="修改名称或分组后，读取配置的调用方也需要同步调整。配置值允许为空字符串。"
+      />
+
+      <Form<ConfigInput>
+        form={form}
+        layout="vertical"
+        initialValues={defaultValues}
+        preserve={false}
+        disabled={loading || saving}
+        onFinish={(values) => void save(values)}
+      >
+        <Form.Item
+          name="valueGroup"
+          label="配置分组"
+          rules={[
+            {
+              required: true,
+              whitespace: true,
+              message: '请输入配置分组',
+            },
+          ]}
+        >
+          <AutoComplete
+            options={groups.map((group) => ({
+              value: group,
+              label: group,
+            }))}
+            filterOption={(input, option) =>
+              String(option?.value ?? '')
+                .toLocaleLowerCase()
+                .includes(input.toLocaleLowerCase())
+            }
+            placeholder="请选择或输入配置分组"
+          />
+        </Form.Item>
+
+        <Form.Item
+          name="valueName"
+          label="配置名称"
+          rules={[
+            {
+              required: true,
+              whitespace: true,
+              message: '请输入配置名称',
+            },
+          ]}
+        >
+          <Input
+            placeholder="请输入配置名称"
+            maxLength={128}
+            showCount
+          />
+        </Form.Item>
+
+        <Form.Item
+          name="value"
+          label={
+            <div className="flex w-full items-center justify-between gap-3">
+              <span>配置值</span>
+              <Button
+                type="link"
+                size="small"
+                icon={<CodeOutlined />}
+                className="!h-auto !p-0"
+                onClick={formatValue}
+              >
+                格式化 JSON
+              </Button>
+            </div>
+          }
+        >
+          <Input.TextArea
+            autoSize={{ minRows: 5, maxRows: 12 }}
+            placeholder="请输入配置值，允许为空字符串"
+          />
+        </Form.Item>
+
+        <Space size={16} align="start" className="w-full">
+          <Form.Item
+            name="status"
+            label="配置状态"
+            className="w-[180px]"
+            rules={[{ required: true, message: '请选择配置状态' }]}
+          >
+            <Select
+              options={[
+                {
+                  value: CONFIG_STATUS_ENABLED,
+                  label: '启用',
+                },
+                {
+                  value: CONFIG_STATUS_DISABLED,
+                  label: '停用',
+                },
+              ]}
+            />
+          </Form.Item>
+        </Space>
+
+        <Form.Item name="memo" label="备注">
+          <Input.TextArea
+            autoSize={{ minRows: 3, maxRows: 6 }}
+            maxLength={500}
+            showCount
+            placeholder="请输入配置用途、影响范围或修改注意事项"
+          />
+        </Form.Item>
+      </Form>
+    </Modal>
+  );
+});
+
+ConfigEditorModal.displayName = 'ConfigEditorModal';
+
+export default ConfigEditorModal;

--- a/yak-ops-ui/src/pages/system/configs/components/ConfigFilterBar.tsx
+++ b/yak-ops-ui/src/pages/system/configs/components/ConfigFilterBar.tsx
@@ -1,0 +1,247 @@
+import {
+  PlusOutlined,
+  ReloadOutlined,
+  SearchOutlined,
+} from '@ant-design/icons';
+import { Button, Input, Select, Tooltip } from 'antd';
+import { useState } from 'react';
+
+import { PermissionGuard } from '@/components/security';
+import type { ConfigStatus } from '@/services/security/configs';
+
+export interface ConfigFilterValues {
+  id?: number;
+  valueGroup?: string;
+  valueName?: string;
+  status?: ConfigStatus;
+  memo?: string;
+  operator?: string;
+}
+
+type ConfigSearchField =
+  | 'valueName'
+  | 'memo'
+  | 'operator'
+  | 'id';
+
+interface ConfigFilterBarProps {
+  groups: string[];
+  loading?: boolean;
+  onSearch: (values: ConfigFilterValues) => void;
+  onRefresh: () => void;
+  onCreate: () => void;
+}
+
+const CONFIG_STATUS_ENABLED: ConfigStatus = 1;
+const CONFIG_STATUS_DISABLED: ConfigStatus = 2;
+
+const SEARCH_FIELD_OPTIONS: Array<{
+  label: string;
+  value: ConfigSearchField;
+}> = [
+  { label: '配置名称', value: 'valueName' },
+  { label: '备注', value: 'memo' },
+  { label: '操作人', value: 'operator' },
+  { label: '配置 ID', value: 'id' },
+];
+
+const SEARCH_PLACEHOLDERS: Record<ConfigSearchField, string> = {
+  valueName: '请输入配置名称',
+  memo: '请输入备注关键字',
+  operator: '请输入操作人',
+  id: '请输入配置 ID',
+};
+
+const configPermission = (action: string): string =>
+  `security:config:${action}`;
+
+const clean = (value?: string): string | undefined => {
+  const normalized = value?.trim();
+  return normalized || undefined;
+};
+
+export default function ConfigFilterBar({
+  groups,
+  loading = false,
+  onSearch,
+  onRefresh,
+  onCreate,
+}: ConfigFilterBarProps) {
+  const [status, setStatus] = useState<ConfigStatus>();
+  const [valueGroup, setValueGroup] = useState<string>();
+  const [searchField, setSearchField] =
+    useState<ConfigSearchField>('valueName');
+  const [keyword, setKeyword] = useState('');
+
+  const createFilters = (
+    nextKeyword = keyword,
+    nextField = searchField,
+    nextStatus = status,
+    nextGroup = valueGroup,
+  ): ConfigFilterValues => {
+    const filters: ConfigFilterValues = {
+      status: nextStatus,
+      valueGroup: nextGroup,
+    };
+    const normalizedKeyword = clean(nextKeyword);
+
+    if (!normalizedKeyword) return filters;
+
+    if (nextField === 'id') {
+      const id = Number(normalizedKeyword);
+      if (Number.isSafeInteger(id) && id > 0) {
+        filters.id = id;
+      }
+      return filters;
+    }
+
+    filters[nextField] = normalizedKeyword;
+    return filters;
+  };
+
+  const changeStatus = (nextStatus?: ConfigStatus) => {
+    setStatus(nextStatus);
+    onSearch(
+      createFilters(keyword, searchField, nextStatus, valueGroup),
+    );
+  };
+
+  const changeGroup = (nextGroup?: string) => {
+    setValueGroup(nextGroup);
+    onSearch(
+      createFilters(keyword, searchField, status, nextGroup),
+    );
+  };
+
+  const changeSearchField = (nextField: ConfigSearchField) => {
+    setSearchField(nextField);
+    setKeyword('');
+    onSearch({ status, valueGroup });
+  };
+
+  const changeKeyword = (
+    event: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    const nextKeyword = event.target.value;
+    setKeyword(nextKeyword);
+
+    if (!nextKeyword) {
+      onSearch({ status, valueGroup });
+    }
+  };
+
+  const submit = () => {
+    onSearch(createFilters());
+  };
+
+  const statusOptions: Array<{
+    key: string;
+    label: string;
+    value?: ConfigStatus;
+  }> = [
+    { key: 'all', label: '全部', value: undefined },
+    {
+      key: 'enabled',
+      label: '已启用',
+      value: CONFIG_STATUS_ENABLED,
+    },
+    {
+      key: 'disabled',
+      label: '已停用',
+      value: CONFIG_STATUS_DISABLED,
+    },
+  ];
+
+  return (
+    <div className="mb-4 flex min-w-0 flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+      <div className="flex min-w-0 items-center gap-2 overflow-x-auto pb-1 lg:pb-0">
+        {statusOptions.map((option) => {
+          const active = status === option.value;
+
+          return (
+            <button
+              key={option.key}
+              type="button"
+              className={[
+                'shrink-0 rounded px-3 py-1 text-sm font-medium leading-5 transition-colors',
+                active
+                  ? 'bg-[#f2f2f4] text-[#FE2C55]'
+                  : 'bg-[#f2f4f7] text-[#667085] hover:bg-[#e8eaef]',
+              ].join(' ')}
+              onClick={() => changeStatus(option.value)}
+            >
+              {option.label}
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="flex shrink-0 flex-wrap items-center gap-2">
+        <Select<string>
+          allowClear
+          showSearch
+          value={valueGroup}
+          placeholder="全部分组"
+          optionFilterProp="label"
+          className="w-[150px]"
+          options={groups.map((group) => ({
+            value: group,
+            label: group,
+          }))}
+          onChange={changeGroup}
+        />
+
+        <div className="flex h-8 w-[330px] max-w-full overflow-hidden rounded-md bg-[#f2f2f4]">
+          <Select<ConfigSearchField>
+            value={searchField}
+            options={SEARCH_FIELD_OPTIONS}
+            variant="borderless"
+            popupMatchSelectWidth={120}
+            className="h-8 w-[105px] shrink-0 [&_.ant-select-selection-item]:!leading-[30px] [&_.ant-select-selector]:!h-8 [&_.ant-select-selector]:!bg-transparent [&_.ant-select-selector]:!px-3"
+            onChange={changeSearchField}
+          />
+
+          <div className="my-2 w-px shrink-0 bg-slate-200" />
+
+          <Input
+            allowClear
+            value={keyword}
+            variant="borderless"
+            inputMode={searchField === 'id' ? 'numeric' : 'text'}
+            placeholder={SEARCH_PLACEHOLDERS[searchField]}
+            suffix={
+              <SearchOutlined
+                className="cursor-pointer text-slate-400 transition-colors hover:text-slate-700"
+                onClick={submit}
+              />
+            }
+            className="!h-8 min-w-0 flex-1 !bg-transparent !py-0 !shadow-none [&_.ant-input]:!bg-transparent"
+            onChange={changeKeyword}
+            onPressEnter={submit}
+          />
+        </div>
+
+        <Tooltip title="刷新配置列表">
+          <Button
+            icon={<ReloadOutlined />}
+            loading={loading}
+            onClick={onRefresh}
+          />
+        </Tooltip>
+
+        <PermissionGuard
+          mode="one"
+          permission={configPermission('create')}
+        >
+          <Button
+            type="primary"
+            icon={<PlusOutlined />}
+            onClick={onCreate}
+          >
+            新增配置
+          </Button>
+        </PermissionGuard>
+      </div>
+    </div>
+  );
+}

--- a/yak-ops-ui/src/pages/system/configs/index.tsx
+++ b/yak-ops-ui/src/pages/system/configs/index.tsx
@@ -1,18 +1,19 @@
-import type {
-  ActionType,
-  ProColumns,
-} from '@ant-design/pro-components';
 import {
-  AutoComplete,
+  DeleteOutlined,
+  EditOutlined,
+  EyeOutlined,
+} from '@ant-design/icons';
+import type { ProColumns } from '@ant-design/pro-components';
+import {
   Button,
-  Form,
-  Input,
   Modal,
-  Select,
   Space,
   Switch,
+  Tag,
+  Typography,
   message,
 } from 'antd';
+import dayjs from 'dayjs';
 import {
   useCallback,
   useEffect,
@@ -23,350 +24,361 @@ import {
 
 import {
   PermissionGuard,
+  SecurityPagination,
   SecurityQueryTable,
 } from '@/components/security';
 import {
-  type ConfigInput,
   type ConfigStatus,
-  createConfig,
+  type SystemConfig,
   deleteConfig,
   listConfigGroups,
   pageConfigs,
-  type SystemConfig,
   toggleConfig,
-  updateConfig,
 } from '@/services/security/configs';
 
-/**
- * 系统配置权限编码。
- */
-const permission = (
-  action: string,
-): string => `security:config:${action}`;
+import ConfigDetailDrawer, {
+  type ConfigDetailDrawerRef,
+} from './components/ConfigDetailDrawer';
+import ConfigEditorModal, {
+  type ConfigEditorModalRef,
+} from './components/ConfigEditorModal';
+import ConfigFilterBar, {
+  type ConfigFilterValues,
+} from './components/ConfigFilterBar';
 
-/**
- * 后端配置状态：
- *
- * 1：正常
- * 2：禁用
- */
+interface ConfigPaginationState {
+  current: number;
+  pageSize: number;
+  total: number;
+}
+
+const DEFAULT_PAGINATION: ConfigPaginationState = {
+  current: 1,
+  pageSize: 10,
+  total: 0,
+};
+
 const CONFIG_STATUS_ENABLED: ConfigStatus = 1;
 const CONFIG_STATUS_DISABLED: ConfigStatus = 2;
 
-/**
- * 新增配置默认值。
- */
-const initialValues: ConfigInput = {
-  valueGroup: '',
-  valueName: '',
-  value: '',
-  status: CONFIG_STATUS_ENABLED,
-  memo: '',
-};
+const configPermission = (action: string): string =>
+  `security:config:${action}`;
 
-/**
- * 将表格搜索参数中的状态转换为后端需要的数字状态。
- */
-const normalizeStatus = (
-  value: unknown,
-): ConfigStatus | undefined => {
-  const status = Number(value);
+const errorText = (error: unknown, fallback: string): string =>
+  error instanceof Error && error.message
+    ? error.message
+    : fallback;
 
-  if (
-    status === CONFIG_STATUS_ENABLED ||
-    status === CONFIG_STATUS_DISABLED
-  ) {
-    return status as ConfigStatus;
-  }
-
-  return undefined;
-};
+const dateText = (value?: string): string =>
+  value && dayjs(value).isValid()
+    ? dayjs(value).format('YYYY-MM-DD HH:mm:ss')
+    : '-';
 
 export default function ConfigsPage() {
-  const actionRef = useRef<ActionType>();
-  const [form] = Form.useForm<ConfigInput>();
+  const editorRef = useRef<ConfigEditorModalRef>(null);
+  const detailRef = useRef<ConfigDetailDrawerRef>(null);
+  const requestSequenceRef = useRef(0);
 
-  const [groups, setGroups] =
-    useState<string[]>([]);
-  const [editing, setEditing] =
-    useState<SystemConfig>();
-  const [open, setOpen] =
-    useState(false);
-  const [saving, setSaving] =
-    useState(false);
+  const [configs, setConfigs] = useState<SystemConfig[]>([]);
+  const [groups, setGroups] = useState<string[]>([]);
+  const [filters, setFilters] = useState<ConfigFilterValues>({});
+  const [pagination, setPagination] =
+    useState<ConfigPaginationState>(DEFAULT_PAGINATION);
+  const [loading, setLoading] = useState(false);
+  const [switchingIds, setSwitchingIds] = useState<Set<number>>(
+    () => new Set(),
+  );
 
-  /**
-   * 查询配置分组。
-   */
   const loadGroups = useCallback(async () => {
     try {
-      const data =
-        await listConfigGroups();
-
-      const normalizedGroups =
-        Array.isArray(data)
-          ? data
-              .filter(
-                (
-                  value,
-                ): value is string =>
-                  typeof value ===
-                    'string' &&
-                  value.trim().length >
-                    0,
-              )
-              .map((value) =>
-                value.trim(),
-              )
-          : [];
-
-      setGroups([
-        ...new Set(
-          normalizedGroups,
-        ),
-      ]);
+      setGroups(await listConfigGroups());
     } catch {
       setGroups([]);
     }
   }, []);
 
+  const loadConfigs = useCallback(async () => {
+    const sequence = ++requestSequenceRef.current;
+    setLoading(true);
+
+    try {
+      const result = await pageConfigs({
+        pageNum: pagination.current,
+        pageSize: pagination.pageSize,
+        id: filters.id,
+        valueGroup: filters.valueGroup,
+        valueName: filters.valueName,
+        status: filters.status,
+        memo: filters.memo,
+        operator: filters.operator,
+      });
+
+      if (sequence !== requestSequenceRef.current) return;
+
+      setConfigs(result.records ?? []);
+      setPagination((current) => ({
+        ...current,
+        total: result.total ?? 0,
+      }));
+    } catch (error) {
+      if (sequence !== requestSequenceRef.current) return;
+
+      setConfigs([]);
+      setPagination((current) => ({
+        ...current,
+        total: 0,
+      }));
+      message.error(errorText(error, '系统配置加载失败'));
+    } finally {
+      if (sequence === requestSequenceRef.current) {
+        setLoading(false);
+      }
+    }
+  }, [
+    filters,
+    pagination.current,
+    pagination.pageSize,
+  ]);
+
   useEffect(() => {
     void loadGroups();
   }, [loadGroups]);
 
-  /**
-   * 分组下拉选项。
-   */
-  const groupOptions = useMemo(
-    () =>
-      (
-        Array.isArray(groups)
-          ? groups
-          : []
-      ).map((value) => ({
-        value,
-        label: value,
-      })),
-    [groups],
-  );
+  useEffect(() => {
+    void loadConfigs();
+  }, [loadConfigs]);
 
-  /**
-   * 刷新分页表格。
-   */
   const reload = useCallback(() => {
-    actionRef.current?.reload();
+    void loadConfigs();
+  }, [loadConfigs]);
+
+  const reloadAll = useCallback(() => {
+    void Promise.all([loadConfigs(), loadGroups()]);
+  }, [loadConfigs, loadGroups]);
+
+  const handleSearch = useCallback((values: ConfigFilterValues) => {
+    setFilters(values);
+    setPagination((current) => ({
+      ...current,
+      current: 1,
+    }));
   }, []);
 
-  /**
-   * 关闭编辑弹窗。
-   */
-  const closeForm = () => {
-    setOpen(false);
-    setEditing(undefined);
-    form.resetFields();
-  };
+  const handlePageChange = useCallback(
+    (nextCurrent: number, nextPageSize: number) => {
+      setPagination((current) => {
+        const pageSizeChanged = current.pageSize !== nextPageSize;
 
-  /**
-   * 打开新增或编辑弹窗。
-   */
-  const showForm = (
-    row?: SystemConfig,
-  ) => {
-    setEditing(row);
-
-    if (row) {
-      form.setFieldsValue({
-        valueGroup:
-          row.valueGroup ?? '',
-        valueName:
-          row.valueName ?? '',
-        value: row.value ?? '',
-        status:
-          row.status ??
-          CONFIG_STATUS_ENABLED,
-        memo: row.memo ?? '',
+        return {
+          ...current,
+          current: pageSizeChanged ? 1 : nextCurrent,
+          pageSize: nextPageSize,
+        };
       });
-    } else {
-      form.setFieldsValue(
-        initialValues,
-      );
-    }
+    },
+    [],
+  );
 
-    setOpen(true);
-  };
+  const showDetail = useCallback((config: SystemConfig) => {
+    detailRef.current?.open(config);
+  }, []);
 
-  /**
-   * 删除配置。
-   */
-  const remove = (
-    row: SystemConfig,
-  ) => {
-    Modal.confirm({
-      title: `删除配置“${row.valueName}”？`,
-      content:
-        '删除后无法恢复，请确认该配置已经不再使用。',
-      okText: '删除',
-      cancelText: '取消',
-      okButtonProps: {
-        danger: true,
-      },
-      onOk: async () => {
-        try {
-          await deleteConfig(
-            row.id,
-          );
+  const showEdit = useCallback((config: SystemConfig) => {
+    editorRef.current?.openEdit(config);
+  }, []);
 
-          message.success(
-            '配置已删除',
-          );
+  const changeStatus = useCallback(
+    async (config: SystemConfig, checked: boolean) => {
+      if (switchingIds.has(config.id)) return;
 
-          reload();
-          await loadGroups();
-        } catch (error) {
-          Modal.error({
-            title: '删除配置失败',
-            content:
-              error instanceof Error
-                ? error.message
-                : '删除配置时发生异常，请稍后重试。',
-          });
+      setSwitchingIds((current) => {
+        const next = new Set(current);
+        next.add(config.id);
+        return next;
+      });
 
-          throw error;
-        }
-      },
-    });
-  };
+      try {
+        await toggleConfig(
+          config.id,
+          checked
+            ? CONFIG_STATUS_ENABLED
+            : CONFIG_STATUS_DISABLED,
+        );
+        message.success(
+          checked ? '配置已启用' : '配置已停用',
+        );
+        reload();
+      } catch (error) {
+        message.error(errorText(error, '配置状态更新失败'));
+      } finally {
+        setSwitchingIds((current) => {
+          const next = new Set(current);
+          next.delete(config.id);
+          return next;
+        });
+      }
+    },
+    [reload, switchingIds],
+  );
 
-  /**
-   * 配置表格列。
-   */
-  const columns: ProColumns<SystemConfig>[] =
-    [
-      {
-        title: '配置分组',
-        dataIndex: 'valueGroup',
-        valueType: 'select',
-        fieldProps: {
-          options: groupOptions,
-          showSearch: true,
-          allowClear: true,
-          optionFilterProp:
-            'label',
+  const remove = useCallback(
+    (config: SystemConfig) => {
+      Modal.confirm({
+        title: '删除系统配置',
+        width: 500,
+        centered: true,
+        okText: '删除',
+        cancelText: '取消',
+        okButtonProps: { danger: true },
+        content: (
+          <div className="space-y-3">
+            <div>
+              确定删除配置
+              <span className="mx-1 font-medium text-slate-900">
+                {config.valueGroup}/{config.valueName}
+              </span>
+              吗？
+            </div>
+            <div className="rounded-lg border border-red-100 bg-red-50 px-3 py-2 text-sm leading-6 text-red-700">
+              删除后无法恢复。依赖该配置的业务会读取默认值或出现运行异常，请先确认调用方已停止使用。
+            </div>
+          </div>
+        ),
+        onOk: async () => {
+          try {
+            await deleteConfig(config.id);
+            message.success('配置已删除');
+
+            if (configs.length === 1 && pagination.current > 1) {
+              setPagination((current) => ({
+                ...current,
+                current: current.current - 1,
+              }));
+            } else {
+              reload();
+            }
+            void loadGroups();
+          } catch (error) {
+            message.error(errorText(error, '配置删除失败'));
+            throw error;
+          }
         },
-      },
+      });
+    },
+    [
+      configs.length,
+      loadGroups,
+      pagination.current,
+      reload,
+    ],
+  );
+
+  const columns = useMemo<ProColumns<SystemConfig>[]>(
+    () => [
       {
-        title: '配置名称',
+        title: '配置项',
         dataIndex: 'valueName',
+        width: 260,
+        render: (_, row) => (
+          <div className="min-w-0">
+            <div className="flex min-w-0 items-center gap-2">
+              <Typography.Text
+                strong
+                ellipsis={{ tooltip: row.valueName }}
+                className="min-w-0"
+              >
+                {row.valueName || '未命名配置'}
+              </Typography.Text>
+              <Tag className="shrink-0 !mr-0">
+                {row.valueGroup || '未分组'}
+              </Tag>
+            </div>
+            <div className="mt-1 text-xs text-slate-400">
+              ID {row.id}
+            </div>
+          </div>
+        ),
       },
       {
         title: '配置值',
         dataIndex: 'value',
-        search: false,
-        ellipsis: true,
-        copyable: true,
+        width: 300,
+        render: (_, row) => (
+          <Typography.Text
+            code
+            copyable={{ text: row.value ?? '' }}
+            ellipsis={{ tooltip: row.value || '(空字符串)' }}
+            className="max-w-[270px]"
+          >
+            {row.value || '(空字符串)'}
+          </Typography.Text>
+        ),
       },
       {
         title: '备注',
         dataIndex: 'memo',
-        search: false,
+        width: 240,
         ellipsis: true,
-        renderText: (
-          value,
-        ) => value || '-',
+        renderText: (value) => value || '-',
       },
       {
         title: '状态',
         dataIndex: 'status',
-        valueType: 'select',
-        valueEnum: {
-          1: {
-            text: '启用',
-            status: 'Success',
-          },
-          2: {
-            text: '停用',
-            status: 'Default',
-          },
-        },
+        width: 120,
+        align: 'center',
         render: (_, row) => (
           <PermissionGuard
             mode="one"
-            permission={permission(
-              'toggle',
-            )}
+            permission={configPermission('toggle')}
             behavior="disable"
           >
             <Switch
-              checked={
-                row.status ===
-                CONFIG_STATUS_ENABLED
-              }
+              checked={row.status === CONFIG_STATUS_ENABLED}
+              loading={switchingIds.has(row.id)}
               checkedChildren="启用"
               unCheckedChildren="停用"
-              onChange={async (
-                checked,
-              ) => {
-                try {
-                  await toggleConfig(
-                    row.id,
-                    checked
-                      ? CONFIG_STATUS_ENABLED
-                      : CONFIG_STATUS_DISABLED,
-                  );
-
-                  message.success(
-                    '配置状态已更新',
-                  );
-
-                  reload();
-                } catch {
-                  message.error(
-                    '配置状态更新失败',
-                  );
-                }
-              }}
+              onChange={(checked) =>
+                void changeStatus(row, checked)
+              }
             />
           </PermissionGuard>
         ),
       },
       {
-        title: '操作人',
+        title: '最后操作人',
         dataIndex: 'operator',
-        search: false,
-        renderText: (
-          value,
-        ) => value || '-',
-      },
-      {
-        title: '创建时间',
-        dataIndex: 'createTime',
-        valueType: 'dateTime',
-        search: false,
+        width: 140,
+        renderText: (value) => value || '-',
       },
       {
         title: '更新时间',
         dataIndex: 'updateTime',
-        valueType: 'dateTime',
-        search: false,
+        width: 180,
+        renderText: (value) => dateText(value),
       },
       {
         title: '操作',
         valueType: 'option',
         fixed: 'right',
-        width: 140,
+        width: 190,
         render: (_, row) => (
           <Space size={0}>
+            <Button
+              type="link"
+              icon={<EyeOutlined />}
+              onClick={() => showDetail(row)}
+            >
+              详情
+            </Button>
+
             <PermissionGuard
               mode="one"
-              permission={permission(
-                'update',
-              )}
+              permission={configPermission('update')}
             >
               <Button
                 type="link"
-                onClick={() =>
-                  showForm(row)
-                }
+                icon={<EditOutlined />}
+                onClick={() => showEdit(row)}
               >
                 编辑
               </Button>
@@ -374,16 +386,13 @@ export default function ConfigsPage() {
 
             <PermissionGuard
               mode="one"
-              permission={permission(
-                'delete',
-              )}
+              permission={configPermission('delete')}
             >
               <Button
                 type="link"
                 danger
-                onClick={() =>
-                  remove(row)
-                }
+                icon={<DeleteOutlined />}
+                onClick={() => remove(row)}
               >
                 删除
               </Button>
@@ -391,280 +400,64 @@ export default function ConfigsPage() {
           </Space>
         ),
       },
-    ];
-
-  /**
-   * 保存配置。
-   */
-  const handleSave = async (
-    values: ConfigInput,
-  ) => {
-    setSaving(true);
-
-    try {
-      const body: ConfigInput = {
-        valueGroup:
-          values.valueGroup.trim(),
-        valueName:
-          values.valueName.trim(),
-        value: values.value,
-        status:
-          values.status,
-        memo:
-          values.memo?.trim() ??
-          '',
-      };
-
-      if (editing) {
-        await updateConfig(
-          editing.id,
-          body,
-        );
-      } else {
-        await createConfig(body);
-      }
-
-      message.success(
-        editing
-          ? '配置已更新'
-          : '配置已创建',
-      );
-
-      closeForm();
-      reload();
-      await loadGroups();
-    } catch {
-      message.error(
-        editing
-          ? '配置更新失败'
-          : '配置创建失败',
-      );
-    } finally {
-      setSaving(false);
-    }
-  };
+    ],
+    [changeStatus, remove, showDetail, showEdit, switchingIds],
+  );
 
   return (
-    <section className="p-6">
-      <SecurityQueryTable<SystemConfig>
-        actionRef={actionRef}
-        rowKey="id"
-        columns={columns}
-        scroll={{
-          x: 1100,
-        }}
-        request={async (
-          params,
-        ) => {
-          try {
-            const result =
-              await pageConfigs({
-                pageNum:
-                  params.current ??
-                  1,
-                pageSize:
-                  params.pageSize ??
-                  10,
-                valueGroup:
-                  typeof params.valueGroup ===
-                  'string'
-                    ? params.valueGroup
-                    : undefined,
-                valueName:
-                  typeof params.valueName ===
-                  'string'
-                    ? params.valueName
-                    : undefined,
-                status:
-                  normalizeStatus(
-                    params.status,
-                  ),
-              });
+    <section
+      className="box-border flex flex-col bg-slate-50/50 p-6"
+      style={{
+        minHeight: 'calc(100vh - 64px)',
+        overflow: 'hidden',
+      }}
+    >
+      <div className="shrink-0">
+        <h1
+          className="mb-4 font-semibold"
+          style={{ fontSize: 18, color: '#282828' }}
+        >
+          系统配置
+        </h1>
 
-            return {
-              data:
-                Array.isArray(
-                  result.records,
-                )
-                  ? result.records
-                  : [],
-              total: Number(
-                result.total ?? 0,
-              ),
-              success: true,
-            };
-          } catch {
-            return {
-              data: [],
-              total: 0,
-              success: false,
-            };
-          }
-        }}
-        toolBarRender={() => [
-          <PermissionGuard
-            key="create"
-            mode="one"
-            permission={permission(
-              'create',
-            )}
-          >
-            <Button
-              type="primary"
-              onClick={() =>
-                showForm()
-              }
-            >
-              新增配置
-            </Button>
-          </PermissionGuard>,
-        ]}
+        <ConfigFilterBar
+          groups={groups}
+          loading={loading}
+          onSearch={handleSearch}
+          onRefresh={reload}
+          onCreate={() => editorRef.current?.openCreate()}
+        />
+
+        <SecurityQueryTable<SystemConfig>
+          rowKey="id"
+          columns={columns}
+          dataSource={configs}
+          loading={loading}
+          search={false}
+          options={false}
+          pagination={false}
+          bordered
+          scroll={{ x: 'max-content' }}
+        />
+      </div>
+
+      <div className="min-h-6 flex-1" />
+
+      <SecurityPagination
+        current={pagination.current}
+        pageSize={pagination.pageSize}
+        total={pagination.total}
+        disabled={loading}
+        onChange={handlePageChange}
       />
 
-      <Modal
-        open={open}
-        title={
-          editing
-            ? '编辑配置'
-            : '新增配置'
-        }
-        destroyOnClose
-        maskClosable={false}
-        confirmLoading={saving}
-        okText="保存"
-        cancelText="取消"
-        onCancel={closeForm}
-        onOk={() =>
-          form.submit()
-        }
-      >
-        <Form<ConfigInput>
-          form={form}
-          layout="vertical"
-          initialValues={
-            initialValues
-          }
-          preserve={false}
-          onFinish={
-            handleSave
-          }
-        >
-          <Form.Item
-            name="valueGroup"
-            label="配置分组"
-            rules={[
-              {
-                required: true,
-                message:
-                  '请输入配置分组',
-              },
-              {
-                whitespace: true,
-                message:
-                  '配置分组不能为空',
-              },
-            ]}
-          >
-            <AutoComplete
-              options={
-                groupOptions
-              }
-              filterOption={(
-                inputValue,
-                option,
-              ) =>
-                String(
-                  option?.value ??
-                    '',
-                )
-                  .toLowerCase()
-                  .includes(
-                    inputValue.toLowerCase(),
-                  )
-              }
-              placeholder="请选择或输入配置分组"
-            />
-          </Form.Item>
+      <ConfigEditorModal
+        ref={editorRef}
+        groups={groups}
+        onSuccess={reloadAll}
+      />
 
-          <Form.Item
-            name="valueName"
-            label="配置名称"
-            rules={[
-              {
-                required: true,
-                message:
-                  '请输入配置名称',
-              },
-              {
-                whitespace: true,
-                message:
-                  '配置名称不能为空',
-              },
-            ]}
-          >
-            <Input
-              placeholder="请输入配置名称"
-              maxLength={128}
-            />
-          </Form.Item>
-
-          <Form.Item
-            name="value"
-            label="配置值"
-            rules={[
-              {
-                required: true,
-                message:
-                  '请输入配置值',
-              },
-            ]}
-          >
-            <Input.TextArea
-              rows={4}
-              placeholder="请输入配置值"
-            />
-          </Form.Item>
-
-          <Form.Item
-            name="status"
-            label="状态"
-            rules={[
-              {
-                required: true,
-                message:
-                  '请选择配置状态',
-              },
-            ]}
-          >
-            <Select
-              options={[
-                {
-                  value:
-                    CONFIG_STATUS_ENABLED,
-                  label: '启用',
-                },
-                {
-                  value:
-                    CONFIG_STATUS_DISABLED,
-                  label: '停用',
-                },
-              ]}
-            />
-          </Form.Item>
-
-          <Form.Item
-            name="memo"
-            label="备注"
-          >
-            <Input.TextArea
-              rows={3}
-              maxLength={500}
-              showCount
-              placeholder="请输入备注"
-            />
-          </Form.Item>
-        </Form>
-      </Modal>
+      <ConfigDetailDrawer ref={detailRef} />
     </section>
   );
 }

--- a/yak-ops-ui/src/services/security/configs.test.ts
+++ b/yak-ops-ui/src/services/security/configs.test.ts
@@ -1,15 +1,17 @@
-import { sanitizeConfigInput, type ConfigInput } from './configs';
+import { formatConfigValue } from './configs';
 
-const input = (configValue?: string): ConfigInput => ({
-  configKey: 'secret', configName: 'Secret', groupCode: 'security', valueType: 'STRING',
-  status: 'ENABLED', sensitive: true, configValue,
-});
-
-describe('sanitizeConfigInput', () => {
-  it.each([undefined, '', '   ', '******', '••••'])('never resubmits an empty or masked secret (%p)', (value) => {
-    expect(sanitizeConfigInput(input(value), true)).not.toHaveProperty('configValue');
+describe('formatConfigValue', () => {
+  it('pretty prints valid JSON', () => {
+    expect(formatConfigValue('{"enabled":true,"count":2}')).toBe(
+      '{\n  "enabled": true,\n  "count": 2\n}',
+    );
   });
-  it('keeps a newly entered value', () => {
-    expect(sanitizeConfigInput(input('new-secret'), true).configValue).toBe('new-secret');
+
+  it('keeps non-JSON values unchanged', () => {
+    expect(formatConfigValue('plain-text')).toBe('plain-text');
+  });
+
+  it('keeps an empty configuration value empty', () => {
+    expect(formatConfigValue('')).toBe('');
   });
 });

--- a/yak-ops-ui/src/services/security/configs.ts
+++ b/yak-ops-ui/src/services/security/configs.ts
@@ -24,10 +24,12 @@ export interface SystemConfig {
 export interface ConfigPageQuery {
   pageNum: number;
   pageSize: number;
+  id?: number;
   valueGroup?: string;
   valueName?: string;
   status?: ConfigStatus;
   memo?: string;
+  operator?: string;
 }
 
 export interface ConfigInput {
@@ -53,11 +55,11 @@ export interface ConfigPage {
   total: number;
 }
 
-/**
- * 分页查询配置。
- *
- * 后端使用 POST /page，并接收 page、size。
- */
+const clean = (value?: string): string | undefined => {
+  const normalized = value?.trim();
+  return normalized || undefined;
+};
+
 export const pageConfigs = async (
   params: ConfigPageQuery,
 ): Promise<ConfigPage> => {
@@ -66,10 +68,12 @@ export const pageConfigs = async (
   >(`${CONFIG_API}/page`, {
     page: params.pageNum,
     size: params.pageSize,
-    valueGroup: params.valueGroup,
-    valueName: params.valueName,
+    id: params.id,
+    valueGroup: clean(params.valueGroup),
+    valueName: clean(params.valueName),
     status: params.status,
-    memo: params.memo,
+    memo: clean(params.memo),
+    operator: clean(params.operator),
   });
 
   return {
@@ -80,67 +84,70 @@ export const pageConfigs = async (
   };
 };
 
-/**
- * 查询配置分组。
- */
-export const listConfigGroups =
-  async (): Promise<string[]> => {
-    const data = await securityGetData<string[]>(
-      `${CONFIG_API}/group/list`,
-    );
+export const listConfigGroups = async (): Promise<string[]> => {
+  const data = await securityGetData<string[]>(
+    `${CONFIG_API}/group/list`,
+  );
 
-    return Array.isArray(data) ? data : [];
-  };
+  if (!Array.isArray(data)) return [];
 
-/**
- * 新增配置。
- */
+  return [
+    ...new Set(
+      data
+        .filter(
+          (value): value is string =>
+            typeof value === 'string' && value.trim().length > 0,
+        )
+        .map((value) => value.trim()),
+    ),
+  ].sort((left, right) => left.localeCompare(right));
+};
+
+export const getConfig = (id: number): Promise<SystemConfig> =>
+  securityGetData<SystemConfig>(
+    `${CONFIG_API}/${encodeURIComponent(String(id))}`,
+  );
+
 export const createConfig = (
   body: ConfigInput,
 ): Promise<number> =>
-  securityPutData<number>(
-    `${CONFIG_API}/add`,
-    body,
-  );
+  securityPostData<number>(CONFIG_API, body);
 
-/**
- * 编辑配置。
- */
 export const updateConfig = (
   id: number,
   body: ConfigInput,
 ): Promise<void> =>
-  securityPostData<void>(
-    `${CONFIG_API}/edit`,
-    {
-      id,
-      ...body,
-    },
-  );
+  securityPutData<void>(CONFIG_API, {
+    id,
+    ...body,
+  });
 
-/**
- * 切换配置状态。
- */
 export const toggleConfig = (
   id: number,
   status: ConfigStatus,
 ): Promise<void> =>
-  securityPostData<void>(
-    `${CONFIG_API}/switch`,
-    {
-      id,
-      status,
-    },
+  securityPutData<void>(
+    `${CONFIG_API}/${encodeURIComponent(String(id))}/status`,
+    { status },
   );
 
-/**
- * 删除配置。
- */
-export const deleteConfig = (
-  id: number,
-): Promise<void> =>
+export const deleteConfig = (id: number): Promise<void> =>
   securityDeleteData<void>(
-    `${CONFIG_API}/del?id=${encodeURIComponent(
-      String(id),
-    )}`,
+    `${CONFIG_API}/${encodeURIComponent(String(id))}`,
   );
+
+/** Format JSON-like configuration values for detail display. */
+export const formatConfigValue = (value: unknown): string => {
+  if (typeof value !== 'string') {
+    return JSON.stringify(value ?? '', null, 2);
+  }
+
+  const normalized = value.trim();
+  if (!normalized) return '';
+
+  try {
+    return JSON.stringify(JSON.parse(normalized), null, 2);
+  } catch {
+    return value;
+  }
+};


### PR DESCRIPTION
## 变更内容

重构系统配置管理页面，按当前 `yak-security` 配置模型完成分页、详情、新增、编辑、启停和删除联调。

## 页面布局

- 采用与用户管理、操作日志一致的“筛选栏 + 表格 + 独立底部分页”布局
- 状态快捷筛选：全部、已启用、已停用
- 配置分组下拉筛选
- 可切换搜索字段：配置名称、备注、操作人、配置 ID
- 表格展示配置项、分组、配置值、备注、状态、最后操作人和更新时间
- 表格与分页分离，页面剩余空间自适应

## 配置详情

新增结构化详情抽屉：

- 配置 ID、状态、分组、名称
- 创建时间、更新时间、最后操作人
- 配置值支持复制
- JSON 配置值自动格式化
- 普通文本和空字符串保持真实展示
- 备注独立展示

## 新增与编辑

新增独立配置编辑弹窗：

- 配置分组支持选择已有分组或直接输入新分组
- 配置名称与分组作为唯一配置项
- 配置值允许为空字符串，与后端语义保持一致
- 支持手动格式化 JSON
- 编辑时重新读取配置详情，避免使用过期列表数据
- 保存成功后完整清理弹窗状态并刷新列表和分组

## 状态与删除

- 单行状态切换加载状态，防止重复提交
- 删除前明确提示配置调用方风险
- 删除分页最后一条数据后自动返回上一页
- 删除、新增、编辑后同步刷新配置分组

## 接口联调

依赖后端 PR：`weifuwan/yak-framework#59`

接入标准接口：

- `POST /yak-security/api/v1/config/page`
- `GET /yak-security/api/v1/config/group/list`
- `GET /yak-security/api/v1/config/{id}`
- `POST /yak-security/api/v1/config`
- `PUT /yak-security/api/v1/config`
- `PUT /yak-security/api/v1/config/{id}/status`
- `DELETE /yak-security/api/v1/config/{id}`

分页请求支持：

- `id`
- `valueGroup`
- `valueName`
- `status`
- `memo`
- `operator`

## 修复

- 移除 ProTable 默认搜索表单和内置分页，避免页面样式与其他系统管理页面不一致
- 修复配置值被前端强制要求非空、与后端允许空字符串不一致的问题
- 修复编辑弹窗保存成功时因 saving 状态导致无法正常关闭的问题
- 修复关闭状态下 Form 未挂载便调用 `setFieldsValue` 的潜在警告
- 替换仓库中仍测试旧版 `configKey / sensitive / configValue` 模型的失效测试，改为当前真实配置值格式化测试

## 权限控制

保持现有权限编码兼容：

- `security:config:create`
- `security:config:update`
- `security:config:toggle`
- `security:config:delete`

## 验证

- 已静态复核分页响应转换、请求竞态、详情请求、状态重复提交、删除翻页和编辑表单状态清理
- 当前执行环境无法解析 GitHub 域名，未能本地执行前端构建；合并前建议在 `yak-ops-ui` 执行：
  - `npm run tsc`
  - `npm run build`
  - 项目现有测试命令
