### PR TITLE
feat(ui): complete Security project integration

### DIFF
--- a/yak-ops-ui/src/components/security/AssignmentDrawer/index.tsx
+++ b/yak-ops-ui/src/components/security/AssignmentDrawer/index.tsx
@@ -1,5 +1,18 @@
-import { Button, Checkbox, Drawer, Empty, Input, Radio, Space, Spin } from 'antd';
-import { useMemo, useState } from 'react';
+import {
+  Button,
+  Checkbox,
+  Drawer,
+  Empty,
+  Input,
+  Radio,
+  Space,
+  Spin,
+} from 'antd';
+import {
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
 
 export interface AssignmentOption {
   id: number;
@@ -14,43 +27,101 @@ export interface AssignmentDrawerProps {
   options: AssignmentOption[];
   value: number[];
   loading?: boolean;
+  allowEmpty?: boolean;
   onClose: () => void;
   onSubmit: (value: number[]) => Promise<void> | void;
 }
 
-export default function AssignmentDrawer(props: AssignmentDrawerProps) {
-  const { open, title, mode, options, value, loading, onClose, onSubmit } = props;
+export default function AssignmentDrawer(
+  props: AssignmentDrawerProps,
+) {
+  const {
+    open,
+    title,
+    mode,
+    options,
+    value,
+    loading,
+    allowEmpty = false,
+    onClose,
+    onSubmit,
+  } = props;
   const [keyword, setKeyword] = useState('');
-  const [selected, setSelected] = useState<number[]>(value);
+  const [selected, setSelected] =
+    useState<number[]>(value);
+  const [submitting, setSubmitting] =
+    useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+
+    setKeyword('');
+    setSelected([...new Set(value)]);
+  }, [open, value]);
+
   const visible = useMemo(
     () =>
       options.filter((option) =>
-        `${option.label} ${option.description ?? ''}`.toLowerCase().includes(keyword.toLowerCase()),
+        `${option.label} ${option.description ?? ''}`
+          .toLowerCase()
+          .includes(keyword.trim().toLowerCase()),
       ),
     [keyword, options],
   );
 
+  const submit = async () => {
+    if (submitting) return;
+
+    setSubmitting(true);
+    try {
+      await onSubmit(selected);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
   const body = visible.length ? (
     visible.map((option) => (
-      <div key={option.id} className="rounded-lg px-2 py-2 hover:bg-gray-50">
+      <div
+        key={option.id}
+        className="rounded-lg px-2 py-2 hover:bg-gray-50"
+      >
         {mode === 'single' ? (
-          <Radio checked={selected[0] === option.id} onChange={() => setSelected([option.id])}>
-            {option.label} <span className="text-gray-400">{option.description}</span>
+          <Radio
+            checked={selected[0] === option.id}
+            onChange={() => setSelected([option.id])}
+          >
+            {option.label}{' '}
+            <span className="text-gray-400">
+              {option.description}
+            </span>
           </Radio>
         ) : (
           <Checkbox
             checked={selected.includes(option.id)}
             onChange={(event) =>
-              setSelected(event.target.checked ? [...selected, option.id] : selected.filter((id) => id !== option.id))
+              setSelected(
+                event.target.checked
+                  ? [...new Set([...selected, option.id])]
+                  : selected.filter(
+                      (id) => id !== option.id,
+                    ),
+              )
             }
           >
-            {option.label} <span className="text-gray-400">{option.description}</span>
+            {option.label}{' '}
+            <span className="text-gray-400">
+              {option.description}
+            </span>
           </Checkbox>
         )}
       </div>
     ))
   ) : (
-    <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="无匹配用户" />
+    <Empty
+      image={Empty.PRESENTED_IMAGE_SIMPLE}
+      description="无匹配用户"
+    />
   );
 
   return (
@@ -59,10 +130,25 @@ export default function AssignmentDrawer(props: AssignmentDrawerProps) {
       title={title}
       onClose={onClose}
       width={420}
+      maskClosable={!submitting}
+      closable={!submitting}
       extra={
         <Space>
-          <Button onClick={onClose}>取消</Button>
-          <Button type="primary" disabled={!selected.length} onClick={() => onSubmit(selected)}>
+          <Button
+            disabled={submitting}
+            onClick={onClose}
+          >
+            取消
+          </Button>
+          <Button
+            type="primary"
+            loading={submitting}
+            disabled={
+              Boolean(loading) ||
+              (!allowEmpty && !selected.length)
+            }
+            onClick={() => void submit()}
+          >
             确定
           </Button>
         </Space>
@@ -70,11 +156,16 @@ export default function AssignmentDrawer(props: AssignmentDrawerProps) {
     >
       <Input.Search
         allowClear
+        value={keyword}
         placeholder="搜索用户名或姓名"
         className="mb-3"
-        onChange={(event) => setKeyword(event.target.value)}
+        onChange={(event) =>
+          setKeyword(event.target.value)
+        }
       />
-      <Spin spinning={Boolean(loading)}>{body}</Spin>
+      <Spin spinning={Boolean(loading)}>
+        {body}
+      </Spin>
     </Drawer>
   );
 }

--- a/yak-ops-ui/src/components/security/AssignmentDrawer/index.tsx
+++ b/yak-ops-ui/src/components/security/AssignmentDrawer/index.tsx
@@ -154,15 +154,25 @@ export default function AssignmentDrawer(
         </Space>
       }
     >
-      <Input.Search
-        allowClear
-        value={keyword}
-        placeholder="搜索用户名或姓名"
-        className="mb-3"
-        onChange={(event) =>
-          setKeyword(event.target.value)
-        }
-      />
+      <div className="mb-3 flex items-center gap-2">
+        <Input.Search
+          allowClear
+          value={keyword}
+          placeholder="搜索用户名或姓名"
+          onChange={(event) =>
+            setKeyword(event.target.value)
+          }
+        />
+        {allowEmpty && selected.length > 0 && (
+          <Button
+            type="text"
+            size="small"
+            onClick={() => setSelected([])}
+          >
+            清空
+          </Button>
+        )}
+      </div>
       <Spin spinning={Boolean(loading)}>
         {body}
       </Spin>

--- a/yak-ops-ui/src/pages/system/security-projects/index.tsx
+++ b/yak-ops-ui/src/pages/system/security-projects/index.tsx
@@ -1,7 +1,28 @@
-import type { ActionType, ProColumns } from '@ant-design/pro-components';
-import { Button, Descriptions, Drawer, Form, Input, Modal, message, Space, Switch, Tag, Typography } from 'antd';
+import type {
+  ActionType,
+  ProColumns,
+} from '@ant-design/pro-components';
+import {
+  Alert,
+  Button,
+  Descriptions,
+  Drawer,
+  Form,
+  Input,
+  Modal,
+  Space,
+  Switch,
+  Tag,
+  Typography,
+  message,
+} from 'antd';
 import { useRef, useState } from 'react';
-import { AssignmentDrawer, PermissionGuard, SecurityQueryTable } from '@/components/security';
+
+import {
+  AssignmentDrawer,
+  PermissionGuard,
+  SecurityQueryTable,
+} from '@/components/security';
 import { useSecurityProject } from '@/contexts/SecurityProjectContext';
 import {
   assignSecurityProjectMembers,
@@ -21,114 +42,343 @@ import {
   updateSecurityProjectStatus,
 } from '@/services/security/projects';
 
-const permission = (action: string) => `system:project:${action}`;
+const permission = (action: string) =>
+  `system:project:${action}`;
+
+const errorText = (
+  error: unknown,
+  fallback: string,
+): string =>
+  error instanceof Error && error.message
+    ? error.message
+    : fallback;
+
+const userDisplayName = (
+  user?: SecurityProjectUser,
+): string =>
+  user?.realName || user?.nickName || user?.userName || '-';
+
+interface AssignmentState {
+  project: SecurityProjectSummary;
+  mode: 'single' | 'multiple';
+  value: number[];
+}
 
 export default function SecurityProjectsPage() {
   const actionRef = useRef<ActionType>();
   const [form] = Form.useForm<SecurityProjectInput>();
-  const { currentProject, refreshProjects } = useSecurityProject();
-  const [editing, setEditing] = useState<SecurityProjectSummary>();
+  const { currentProject, refreshProjects } =
+    useSecurityProject();
+  const [editing, setEditing] =
+    useState<SecurityProjectSummary>();
   const [formOpen, setFormOpen] = useState(false);
-  const [detail, setDetail] = useState<SecurityProjectDetail>();
-  const [assigning, setAssigning] = useState<{ project: SecurityProjectSummary; mode: 'single' | 'multiple' }>();
-  const [candidates, setCandidates] = useState<SecurityProjectUser[]>([]);
+  const [saving, setSaving] = useState(false);
+  const [detail, setDetail] =
+    useState<SecurityProjectDetail>();
+  const [detailLoading, setDetailLoading] =
+    useState(false);
+  const [assigning, setAssigning] =
+    useState<AssignmentState>();
+  const [candidates, setCandidates] =
+    useState<SecurityProjectUser[]>([]);
+  const [candidateLoading, setCandidateLoading] =
+    useState(false);
 
   const reload = () => actionRef.current?.reload();
+
+  const resetForm = () => {
+    setFormOpen(false);
+    setEditing(undefined);
+    form.resetFields();
+  };
+
+  const closeForm = () => {
+    if (!saving) resetForm();
+  };
+
   const openForm = (project?: SecurityProjectSummary) => {
     setEditing(project);
     setFormOpen(true);
-    form.setFieldsValue(project ?? { projectCode: '', projectName: '' });
-  };
-  const openAssignment = async (project: SecurityProjectSummary, mode: 'single' | 'multiple') => {
-    setAssigning({ project, mode });
-    try {
-      setCandidates(await getSecurityProjectMemberCandidates(project.id));
-    } catch {
-      setCandidates([]);
-    }
-  };
-  const showDetail = async (project: SecurityProjectSummary) => setDetail(await getSecurityProject(project.id));
-  const changeStatus = (project: SecurityProjectSummary, checked: boolean) => {
-    const status: SecurityProjectStatus = checked ? 'ENABLED' : 'DISABLED';
-    Modal.confirm({
-      title: `确认${checked ? '启用' : '停用'}项目“${project.projectName}”？`,
-      content: !checked ? '停用后该项目将不可再从项目切换器选择。' : undefined,
-      onOk: async () => {
-        await updateSecurityProjectStatus(project.id, status);
-        if (!checked && currentProject?.id === project.id) await refreshProjects();
-        message.success('状态已更新');
-        reload();
-      },
+    form.setFieldsValue({
+      projectName: project?.projectName ?? '',
+      description: project?.description ?? '',
+      deptId: project?.deptId ?? undefined,
     });
   };
-  const remove = async (project: SecurityProjectSummary) => {
-    const check = await checkSecurityProjectDeletion(project.id);
+
+  const showDetail = async (
+    project: SecurityProjectSummary,
+  ) => {
+    setDetailLoading(true);
+    try {
+      setDetail(await getSecurityProject(project.id));
+    } catch (error) {
+      message.error(
+        errorText(error, '项目详情加载失败'),
+      );
+    } finally {
+      setDetailLoading(false);
+    }
+  };
+
+  const openAssignment = async (
+    project: SecurityProjectSummary,
+    mode: 'single' | 'multiple',
+  ) => {
+    setCandidateLoading(true);
+    try {
+      const [projectDetail, userCandidates] =
+        await Promise.all([
+          getSecurityProject(project.id),
+          getSecurityProjectMemberCandidates(project.id),
+        ]);
+
+      setCandidates(userCandidates);
+      setAssigning({
+        project,
+        mode,
+        value:
+          mode === 'single'
+            ? projectDetail.owners
+                .slice(0, 1)
+                .map((user) => user.id)
+            : projectDetail.members.map(
+                (user) => user.id,
+              ),
+      });
+    } catch (error) {
+      setCandidates([]);
+      message.error(
+        errorText(error, '用户候选列表加载失败'),
+      );
+    } finally {
+      setCandidateLoading(false);
+    }
+  };
+
+  const changeStatus = (
+    project: SecurityProjectSummary,
+    checked: boolean,
+  ) => {
+    const status: SecurityProjectStatus = checked
+      ? 'ENABLED'
+      : 'DISABLED';
+
     Modal.confirm({
-      title: `删除项目“${project.projectName}”？`,
-      okButtonProps: { danger: true, disabled: !check.deletable },
-      content: (
-        <>
-          <p>
-            {check.deletable ? '检查通过。删除后无法恢复。' : (check.reason ?? '项目仍有资源或授权引用，无法删除。')}
-          </p>
-          <pre>{JSON.stringify(check.references ?? {}, null, 2)}</pre>
-        </>
-      ),
+      title: `确认${checked ? '启用' : '停用'}项目“${project.projectName}”？`,
+      content: !checked
+        ? '停用后该项目将不可再从项目切换器选择。'
+        : undefined,
       onOk: async () => {
-        await deleteSecurityProject(project.id);
-        if (currentProject?.id === project.id) await refreshProjects();
-        message.success('项目已删除');
-        reload();
+        try {
+          await updateSecurityProjectStatus(
+            project.id,
+            status,
+          );
+
+          if (currentProject?.id === project.id) {
+            await refreshProjects();
+          }
+
+          message.success('状态已更新');
+          reload();
+        } catch (error) {
+          message.error(
+            errorText(error, '项目状态更新失败'),
+          );
+          throw error;
+        }
       },
     });
   };
 
+  const remove = async (
+    project: SecurityProjectSummary,
+  ) => {
+    try {
+      const check =
+        await checkSecurityProjectDeletion(project.id);
+
+      Modal.confirm({
+        title: `删除项目“${project.projectName}”？`,
+        okButtonProps: {
+          danger: true,
+          disabled: !check.deletable,
+        },
+        content: check.deletable ? (
+          <Alert
+            showIcon
+            type="warning"
+            message="检查通过，删除后无法恢复。"
+          />
+        ) : (
+          <div className="space-y-3">
+            <Alert
+              showIcon
+              type="error"
+              message={
+                check.reason ??
+                '项目仍有关联资源，无法删除。'
+              }
+            />
+            <Space size={[4, 6]} wrap>
+              {check.resourceNameList.map((name) => (
+                <Tag key={name}>{name}</Tag>
+              ))}
+            </Space>
+          </div>
+        ),
+        onOk: async () => {
+          try {
+            await deleteSecurityProject(project.id);
+
+            if (currentProject?.id === project.id) {
+              await refreshProjects();
+            }
+
+            message.success('项目已删除');
+            reload();
+          } catch (error) {
+            message.error(
+              errorText(error, '项目删除失败'),
+            );
+            throw error;
+          }
+        },
+      });
+    } catch (error) {
+      message.error(
+        errorText(error, '项目删除检查失败'),
+      );
+    }
+  };
+
   const columns: ProColumns<SecurityProjectSummary>[] = [
-    { title: '项目编码', dataIndex: 'projectCode' },
-    { title: '项目名称', dataIndex: 'projectName' },
-    { title: '负责人', dataIndex: ['owner', 'userName'], fieldProps: { placeholder: '负责人' } },
-    { title: '成员数', dataIndex: 'memberCount', search: false },
+    {
+      title: '项目编码',
+      dataIndex: 'projectCode',
+    },
+    {
+      title: '项目名称',
+      dataIndex: 'projectName',
+    },
+    {
+      title: '负责人',
+      dataIndex: 'ownerName',
+      fieldProps: { placeholder: '用户名或姓名' },
+      render: (_, row) =>
+        row.owners.length > 0 ? (
+          <Space size={[4, 4]} wrap>
+            {row.owners.map((owner) => (
+              <Tag key={owner.id}>
+                {userDisplayName(owner)}
+              </Tag>
+            ))}
+          </Space>
+        ) : (
+          '-'
+        ),
+    },
+    {
+      title: '成员数',
+      dataIndex: 'memberCount',
+      search: false,
+    },
     {
       title: '状态',
       dataIndex: 'status',
       valueType: 'select',
-      valueEnum: { ENABLED: { text: '运行中', status: 'Success' }, DISABLED: { text: '已停用', status: 'Default' } },
+      valueEnum: {
+        ENABLED: {
+          text: '运行中',
+          status: 'Success',
+        },
+        DISABLED: {
+          text: '已停用',
+          status: 'Default',
+        },
+      },
       render: (_, row) => (
-        <PermissionGuard mode="one" permission={permission('status')} behavior="disable">
+        <PermissionGuard
+          mode="one"
+          permission={permission('status')}
+          behavior="disable"
+        >
           <Switch
             checked={row.status === 'ENABLED'}
             checkedChildren="运行"
             unCheckedChildren="停用"
-            onChange={(checked) => changeStatus(row, checked)}
+            onChange={(checked) =>
+              changeStatus(row, checked)
+            }
           />
         </PermissionGuard>
       ),
     },
-    { title: '创建时间', dataIndex: 'createTime', valueType: 'dateTime', search: false },
-    { title: '更新时间', dataIndex: 'updateTime', valueType: 'dateTime', search: false },
+    {
+      title: '创建时间',
+      dataIndex: 'createTime',
+      valueType: 'dateTime',
+      search: false,
+    },
+    {
+      title: '更新时间',
+      dataIndex: 'updateTime',
+      valueType: 'dateTime',
+      search: false,
+    },
     {
       title: '操作',
       valueType: 'option',
       render: (_, row) => (
         <Space wrap>
-          <Button type="link" onClick={() => showDetail(row)}>
+          <Button
+            type="link"
+            onClick={() => void showDetail(row)}
+          >
             详情
           </Button>
-          <PermissionGuard mode="one" permission={permission('update')}>
-            <Button type="link" onClick={() => openForm(row)}>
+          <PermissionGuard
+            mode="one"
+            permission={permission('update')}
+          >
+            <Button
+              type="link"
+              onClick={() => openForm(row)}
+            >
               编辑
             </Button>
           </PermissionGuard>
-          <PermissionGuard mode="one" permission={permission('assign')}>
-            <Button type="link" onClick={() => openAssignment(row, 'single')}>
+          <PermissionGuard
+            mode="one"
+            permission={permission('assign')}
+          >
+            <Button
+              type="link"
+              onClick={() =>
+                void openAssignment(row, 'single')
+              }
+            >
               负责人
             </Button>
-            <Button type="link" onClick={() => openAssignment(row, 'multiple')}>
+            <Button
+              type="link"
+              onClick={() =>
+                void openAssignment(row, 'multiple')
+              }
+            >
               成员
             </Button>
           </PermissionGuard>
-          <PermissionGuard mode="one" permission={permission('delete')}>
-            <Button danger type="link" onClick={() => remove(row)}>
+          <PermissionGuard
+            mode="one"
+            permission={permission('delete')}
+          >
+            <Button
+              danger
+              type="link"
+              onClick={() => void remove(row)}
+            >
               删除
             </Button>
           </PermissionGuard>
@@ -139,109 +389,289 @@ export default function SecurityProjectsPage() {
 
   return (
     <section className="m-4 rounded-xl bg-white p-6">
-      <Typography.Title level={4}>Security 授权项目</Typography.Title>
+      <Typography.Title level={4}>
+        Security 授权项目
+      </Typography.Title>
+
       <SecurityQueryTable<SecurityProjectSummary>
         actionRef={actionRef}
         columns={columns}
         request={async (params) => {
-          const result = await pageSecurityProjects({
-            pageNum: params.current ?? 1,
-            pageSize: params.pageSize ?? 10,
-            projectCode: params.projectCode as string,
-            projectName: params.projectName as string,
-            ownerName: (params.owner as string) ?? (params.ownerName as string),
-            status: params.status as SecurityProjectStatus,
-          });
-          return { data: result.records, total: result.total, success: true };
+          try {
+            const result = await pageSecurityProjects({
+              pageNum: params.current ?? 1,
+              pageSize: params.pageSize ?? 10,
+              projectCode:
+                params.projectCode as string,
+              projectName:
+                params.projectName as string,
+              ownerName: params.ownerName as string,
+              status:
+                params.status as SecurityProjectStatus,
+            });
+
+            return {
+              data: result.records,
+              total: result.total,
+              success: true,
+            };
+          } catch (error) {
+            message.error(
+              errorText(error, '项目列表加载失败'),
+            );
+
+            return {
+              data: [],
+              total: 0,
+              success: false,
+            };
+          }
         }}
         toolBarRender={() => [
-          <PermissionGuard key="create" mode="one" permission={permission('create')}>
-            <Button type="primary" onClick={() => openForm()}>
+          <PermissionGuard
+            key="create"
+            mode="one"
+            permission={permission('create')}
+          >
+            <Button
+              type="primary"
+              onClick={() => openForm()}
+            >
               新增项目
             </Button>
           </PermissionGuard>,
         ]}
       />
+
       <Modal
         open={formOpen}
-        title={editing ? '编辑 Security 授权项目' : '新增 Security 授权项目'}
-        onCancel={() => setFormOpen(false)}
-        onOk={() => form.submit()}
+        title={
+          editing
+            ? '编辑 Security 授权项目'
+            : '新增 Security 授权项目'
+        }
+        confirmLoading={saving}
+        maskClosable={!saving}
+        closable={!saving}
         destroyOnClose
+        onCancel={closeForm}
+        onOk={() => form.submit()}
       >
-        <Form
+        <Form<SecurityProjectInput>
           form={form}
           layout="vertical"
+          preserve={false}
+          disabled={saving}
           onFinish={async (values) => {
-            editing ? await updateSecurityProject(editing.id, values) : await createSecurityProject(values);
-            message.success('保存成功');
-            setFormOpen(false);
-            reload();
+            setSaving(true);
+            try {
+              if (editing) {
+                await updateSecurityProject(
+                  editing.id,
+                  values,
+                );
+              } else {
+                await createSecurityProject(values);
+              }
+
+              message.success('保存成功');
+              resetForm();
+              reload();
+            } catch (error) {
+              message.error(
+                errorText(error, '项目保存失败'),
+              );
+            } finally {
+              setSaving(false);
+            }
           }}
         >
-          <Form.Item
-            name="projectCode"
-            label="项目编码"
-            rules={[{ required: true }, { pattern: /^[A-Za-z0-9_-]+$/, message: '仅支持字母、数字、下划线和连字符' }]}
-          >
-            <Input disabled={Boolean(editing)} maxLength={64} />
+          <Form.Item label="项目编码">
+            <Input
+              disabled
+              value={
+                editing?.projectCode ||
+                '保存后由后端自动生成'
+              }
+            />
           </Form.Item>
-          <Form.Item name="projectName" label="项目名称" rules={[{ required: true }]}>
-            <Input maxLength={128} />
+          <Form.Item
+            name="projectName"
+            label="项目名称"
+            rules={[
+              {
+                required: true,
+                whitespace: true,
+                message: '请输入项目名称',
+              },
+            ]}
+          >
+            <Input
+              maxLength={128}
+              showCount
+              placeholder="请输入项目名称"
+            />
+          </Form.Item>
+          <Form.Item
+            name="description"
+            label="项目描述"
+          >
+            <Input.TextArea
+              maxLength={500}
+              showCount
+              autoSize={{ minRows: 3, maxRows: 6 }}
+              placeholder="请输入项目用途或授权范围"
+            />
           </Form.Item>
         </Form>
       </Modal>
+
       <AssignmentDrawer
         open={Boolean(assigning)}
-        title={assigning?.mode === 'single' ? '分配负责人' : '分配成员'}
+        title={
+          assigning?.mode === 'single'
+            ? '分配负责人'
+            : '分配成员'
+        }
         mode={assigning?.mode ?? 'single'}
         options={candidates.map((user) => ({
           id: user.id,
-          label: user.nickName || user.userName,
-          description: user.userName,
+          label: userDisplayName(user),
+          description:
+            user.realName &&
+            user.realName !== user.userName
+              ? user.userName
+              : undefined,
         }))}
-        value={
-          assigning?.mode === 'single'
-            ? candidates.filter((user) => user.id === assigning.project.owner?.id).map((user) => user.id)
-            : []
-        }
-        onClose={() => setAssigning(undefined)}
+        value={assigning?.value ?? []}
+        loading={candidateLoading}
+        allowEmpty
+        onClose={() => {
+          setAssigning(undefined);
+          setCandidates([]);
+        }}
         onSubmit={async (ids) => {
           if (!assigning) return;
-          assigning.mode === 'single'
-            ? await assignSecurityProjectOwner(assigning.project.id, ids[0])
-            : await assignSecurityProjectMembers(assigning.project.id, ids);
-          message.success('分配成功');
-          setAssigning(undefined);
-          reload();
+
+          try {
+            if (assigning.mode === 'single') {
+              await assignSecurityProjectOwner(
+                assigning.project.id,
+                ids.slice(0, 1),
+              );
+            } else {
+              await assignSecurityProjectMembers(
+                assigning.project.id,
+                ids,
+              );
+            }
+
+            await refreshProjects();
+            message.success('分配成功');
+            setAssigning(undefined);
+            setCandidates([]);
+            reload();
+          } catch (error) {
+            message.error(
+              errorText(error, '项目用户分配失败'),
+            );
+            throw error;
+          }
         }}
       />
-      <Drawer open={Boolean(detail)} title="Security 授权项目详情" width={560} onClose={() => setDetail(undefined)}>
+
+      <Drawer
+        open={Boolean(detail) || detailLoading}
+        title="Security 授权项目详情"
+        width={600}
+        loading={detailLoading}
+        onClose={() => setDetail(undefined)}
+      >
         {detail && (
-          <>
+          <div className="space-y-6">
             <Descriptions
               column={1}
               bordered
               items={[
-                { key: 'code', label: '编码', children: detail.projectCode },
-                { key: 'name', label: '名称', children: detail.projectName },
-                { key: 'owner', label: '负责人', children: detail.owner?.userName ?? '-' },
+                {
+                  key: 'code',
+                  label: '编码',
+                  children: detail.projectCode || '-',
+                },
+                {
+                  key: 'name',
+                  label: '名称',
+                  children: detail.projectName,
+                },
+                {
+                  key: 'dept',
+                  label: '所属部门',
+                  children:
+                    detail.deptPath?.join(' / ') || '-',
+                },
+                {
+                  key: 'description',
+                  label: '描述',
+                  children: detail.description || '-',
+                },
                 {
                   key: 'status',
                   label: '状态',
-                  children: <Tag color={detail.status === 'ENABLED' ? 'green' : 'default'}>{detail.status}</Tag>,
+                  children: (
+                    <Tag
+                      color={
+                        detail.status === 'ENABLED'
+                          ? 'success'
+                          : 'default'
+                      }
+                    >
+                      {detail.status === 'ENABLED'
+                        ? '运行中'
+                        : '已停用'}
+                    </Tag>
+                  ),
                 },
               ]}
             />
-            <Typography.Title level={5}>成员</Typography.Title>
-            <Space wrap>
-              {detail.members.map((member) => (
-                <Tag key={member.id}>{member.nickName || member.userName}</Tag>
-              ))}
-            </Space>
-            <Typography.Title level={5}>资源统计</Typography.Title>
-            <pre>{JSON.stringify(detail.resourceStatistics ?? {}, null, 2)}</pre>
-          </>
+
+            <div>
+              <Typography.Title level={5}>
+                负责人
+              </Typography.Title>
+              <Space wrap>
+                {detail.owners.length > 0 ? (
+                  detail.owners.map((owner) => (
+                    <Tag key={owner.id}>
+                      {userDisplayName(owner)}
+                    </Tag>
+                  ))
+                ) : (
+                  <Typography.Text type="secondary">
+                    暂未分配负责人
+                  </Typography.Text>
+                )}
+              </Space>
+            </div>
+
+            <div>
+              <Typography.Title level={5}>
+                成员
+              </Typography.Title>
+              <Space wrap>
+                {detail.members.length > 0 ? (
+                  detail.members.map((member) => (
+                    <Tag key={member.id}>
+                      {userDisplayName(member)}
+                    </Tag>
+                  ))
+                ) : (
+                  <Typography.Text type="secondary">
+                    暂未分配成员
+                  </Typography.Text>
+                )}
+              </Space>
+            </div>
+          </div>
         )}
       </Drawer>
     </section>

--- a/yak-ops-ui/src/services/security/projects.ts
+++ b/yak-ops-ui/src/services/security/projects.ts
@@ -1,4 +1,9 @@
-import { securityDeleteData, securityGetData, securityPostData, securityPutData } from './client';
+import {
+  securityDeleteData,
+  securityGetData,
+  securityPostData,
+  securityPutData,
+} from './client';
 
 const PROJECT_API = '/api/v1/project';
 
@@ -6,8 +11,9 @@ export type SecurityProjectStatus = 'ENABLED' | 'DISABLED';
 export type SecurityProjectId = number;
 
 export interface SecurityProjectUser {
-  id: SecurityProjectId;
+  id: number;
   userName: string;
+  realName?: string | null;
   nickName?: string | null;
 }
 
@@ -15,17 +21,19 @@ export interface SecurityProjectSummary {
   id: SecurityProjectId;
   projectCode: string;
   projectName: string;
+  description?: string | null;
   owner?: SecurityProjectUser | null;
+  owners: SecurityProjectUser[];
+  members: SecurityProjectUser[];
   memberCount: number;
   status: SecurityProjectStatus;
+  deptId?: number | null;
+  deptPath?: string[];
   createTime?: string;
   updateTime?: string;
 }
 
-export interface SecurityProjectDetail extends SecurityProjectSummary {
-  members: SecurityProjectUser[];
-  resourceStatistics?: Record<string, number>;
-}
+export type SecurityProjectDetail = SecurityProjectSummary;
 
 export interface SecurityProjectPageQuery {
   pageNum: number;
@@ -42,48 +50,252 @@ export interface SecurityProjectPage {
 }
 
 export interface SecurityProjectInput {
-  projectCode: string;
   projectName: string;
+  description?: string;
+  deptId?: number;
 }
 
 export interface SecurityProjectDeleteCheck {
   deletable: boolean;
   reason?: string;
+  resourceNameList: string[];
   references?: Record<string, number>;
 }
 
-const query = (values: object) => {
-  const params = new URLSearchParams();
-  Object.entries(values as Record<string, unknown>).forEach(([key, value]) => {
-    if (value !== undefined && value !== null && value !== '') params.set(key, String(value));
-  });
-  return params.toString();
+interface BackendUserBrief {
+  id: number;
+  userName: string;
+  realName?: string | null;
+}
+
+interface BackendDeptBrief {
+  id: number;
+  deptName?: string | null;
+}
+
+interface BackendProjectVO {
+  id: number;
+  projectCode?: string | null;
+  projectName?: string | null;
+  userList?: BackendUserBrief[];
+  ownerList?: BackendUserBrief[];
+  description?: string | null;
+  running?: boolean | null;
+  deptList?: BackendDeptBrief[];
+  deptId?: number | null;
+  createTime?: string;
+  updateTime?: string;
+}
+
+interface BackendPagingData<T> {
+  bizData?: T[];
+  pagination?: {
+    total?: number;
+    pages?: number;
+    pageNo?: number;
+    pageSize?: number;
+  };
+}
+
+interface BackendDeleteCheck {
+  projectId: number;
+  deletable?: boolean;
+  resourceNameList?: string[];
+}
+
+const idPath = (id: SecurityProjectId) =>
+  `${PROJECT_API}/${encodeURIComponent(String(id))}`;
+
+const toUser = (user: BackendUserBrief): SecurityProjectUser => ({
+  id: Number(user.id),
+  userName: user.userName,
+  realName: user.realName,
+  nickName: user.realName,
+});
+
+const toUsers = (users?: BackendUserBrief[]): SecurityProjectUser[] =>
+  Array.isArray(users) ? users.map(toUser) : [];
+
+const toProject = (
+  project: BackendProjectVO,
+): SecurityProjectSummary => {
+  const owners = toUsers(project.ownerList);
+  const members = toUsers(project.userList);
+
+  return {
+    id: Number(project.id),
+    projectCode: project.projectCode ?? '',
+    projectName: project.projectName ?? '',
+    description: project.description,
+    owner: owners[0] ?? null,
+    owners,
+    members,
+    memberCount: members.length,
+    status:
+      project.running === false
+        ? 'DISABLED'
+        : 'ENABLED',
+    deptId: project.deptId,
+    deptPath: Array.isArray(project.deptList)
+      ? project.deptList
+          .map((dept) => dept.deptName?.trim())
+          .filter((name): name is string => Boolean(name))
+      : [],
+    createTime: project.createTime,
+    updateTime: project.updateTime,
+  };
 };
-const idPath = (id: SecurityProjectId) => `${PROJECT_API}/${encodeURIComponent(String(id))}`;
+
+const uniqueUsers = (
+  users: SecurityProjectUser[],
+): SecurityProjectUser[] => {
+  const result = new Map<number, SecurityProjectUser>();
+  users.forEach((user) => result.set(user.id, user));
+  return Array.from(result.values());
+};
 
 /** Project management endpoints are deliberately project-header free. */
-export const pageSecurityProjects = (params: SecurityProjectPageQuery) =>
-  securityGetData<SecurityProjectPage>(`${PROJECT_API}/page?${query(params)}`);
-export const getSecurityProject = (id: SecurityProjectId) =>
-  securityGetData<SecurityProjectDetail>(idPath(id));
-export const createSecurityProject = (body: SecurityProjectInput) =>
-  securityPostData<SecurityProjectSummary>(PROJECT_API, body);
-export const updateSecurityProject = (id: SecurityProjectId, body: SecurityProjectInput) =>
-  securityPutData<SecurityProjectSummary>(idPath(id), body);
-export const assignSecurityProjectOwner = (id: SecurityProjectId, ownerId: SecurityProjectId) =>
-  securityPutData<void>(`${idPath(id)}/owner`, { ownerId });
-export const assignSecurityProjectMembers = (id: SecurityProjectId, memberIds: SecurityProjectId[]) =>
-  securityPutData<void>(`${idPath(id)}/members`, { memberIds });
-export const getSecurityProjectMemberCandidates = (id: SecurityProjectId) =>
-  securityGetData<SecurityProjectUser[]>(`${idPath(id)}/member-candidates`);
-export const updateSecurityProjectStatus = (id: SecurityProjectId, status: SecurityProjectStatus) =>
-  securityPutData<void>(`${idPath(id)}/status`, { status });
-export const checkSecurityProjectDeletion = (id: SecurityProjectId) =>
-  securityGetData<SecurityProjectDeleteCheck>(`${idPath(id)}/delete-check`);
-export const deleteSecurityProject = (id: SecurityProjectId) =>
+export const pageSecurityProjects = async (
+  params: SecurityProjectPageQuery,
+): Promise<SecurityProjectPage> => {
+  const data =
+    await securityPostData<
+      BackendPagingData<BackendProjectVO>
+    >(`${PROJECT_API}/page`, {
+      page: params.pageNum,
+      size: params.pageSize,
+      projectCode: params.projectCode,
+      projectName: params.projectName,
+      chargeUsername: params.ownerName,
+      running:
+        params.status === undefined
+          ? undefined
+          : params.status === 'ENABLED',
+    });
+
+  return {
+    records: Array.isArray(data?.bizData)
+      ? data.bizData.map(toProject)
+      : [],
+    total: Number(
+      data?.pagination?.total ?? 0,
+    ),
+  };
+};
+
+export const getSecurityProject = async (
+  id: SecurityProjectId,
+): Promise<SecurityProjectDetail> =>
+  toProject(
+    await securityGetData<BackendProjectVO>(
+      idPath(id),
+    ),
+  );
+
+export const createSecurityProject = async (
+  body: SecurityProjectInput,
+): Promise<SecurityProjectSummary> =>
+  toProject(
+    await securityPostData<BackendProjectVO>(
+      PROJECT_API,
+      {
+        ...body,
+        running: true,
+      },
+    ),
+  );
+
+export const updateSecurityProject = (
+  id: SecurityProjectId,
+  body: SecurityProjectInput,
+): Promise<void> =>
+  securityPutData<void>(PROJECT_API, {
+    id,
+    ...body,
+  });
+
+export const assignSecurityProjectOwner = (
+  id: SecurityProjectId,
+  ownerIds: SecurityProjectId[],
+): Promise<void> =>
+  securityPutData<void>(`${idPath(id)}/owners`, {
+    userIdList: ownerIds,
+  });
+
+export const assignSecurityProjectMembers = (
+  id: SecurityProjectId,
+  memberIds: SecurityProjectId[],
+): Promise<void> =>
+  securityPutData<void>(`${idPath(id)}/users`, {
+    userIdList: memberIds,
+  });
+
+export const getSecurityProjectMemberCandidates = async (
+  id: SecurityProjectId,
+): Promise<SecurityProjectUser[]> => {
+  const [detail, unassigned] = await Promise.all([
+    getSecurityProject(id),
+    securityGetData<BackendUserBrief[]>(
+      `${PROJECT_API}/unassigned?id=${encodeURIComponent(
+        String(id),
+      )}`,
+    ),
+  ]);
+
+  return uniqueUsers([
+    ...detail.owners,
+    ...detail.members,
+    ...toUsers(unassigned),
+  ]);
+};
+
+export const updateSecurityProjectStatus = (
+  id: SecurityProjectId,
+  status: SecurityProjectStatus,
+): Promise<void> =>
+  securityPutData<void>(`${idPath(id)}/status`, {
+    running: status === 'ENABLED',
+  });
+
+export const checkSecurityProjectDeletion = async (
+  id: SecurityProjectId,
+): Promise<SecurityProjectDeleteCheck> => {
+  const result =
+    await securityGetData<BackendDeleteCheck>(
+      `${PROJECT_API}/delete/check/${encodeURIComponent(
+        String(id),
+      )}`,
+    );
+
+  const resourceNameList = Array.isArray(
+    result?.resourceNameList,
+  )
+    ? result.resourceNameList
+    : [];
+  const deletable =
+    result?.deletable ??
+    resourceNameList.length === 0;
+
+  return {
+    deletable,
+    resourceNameList,
+    reason: deletable
+      ? undefined
+      : `项目仍关联 ${resourceNameList.length} 个资源，不能删除。`,
+    references: {
+      resources: resourceNameList.length,
+    },
+  };
+};
+
+export const deleteSecurityProject = (
+  id: SecurityProjectId,
+): Promise<void> =>
   securityDeleteData<void>(idPath(id));
 
-export const toSecurityProjectBrief = (project: SecurityProjectSummary): API.ProjectBrief => ({
+export const toSecurityProjectBrief = (
+  project: SecurityProjectSummary,
+): API.ProjectBrief => ({
   id: project.id,
   projectCode: project.projectCode,
   projectName: project.projectName,


### PR DESCRIPTION
## What changed

- align project pagination with the backend `POST /project/page` contract and `PagingData` response
- map backend `running`, `ownerList`, `userList`, department path, and generated project code into UI models
- integrate create, update, target-status, owner assignment, member assignment, deletion check, and delete flows
- load current assignments and unassigned candidates before opening the assignment drawer
- fix assignment selection state so it refreshes for each project and supports clearing assignments
- improve details, errors, confirmation prompts, loading states, and project-context refresh behavior

## Why

The Security authorization-project page used paths and payloads that did not match the Yak Security backend. The table expected query-string pagination, project codes were submitted even though the backend generates them, and assignment/status/delete APIs used incompatible shapes.

## Impact

The page now follows the backend contract end to end and can manage the complete Security authorization-project lifecycle without maintaining a second incompatible API model.

## Validation

- verified the branch only changes the three intended frontend files
- ran TypeScript parser checks for all changed TS/TSX files; no syntax or delimiter errors were reported
- unresolved-module diagnostics are expected because the execution environment cannot clone/install the repository dependencies
- repository commit status currently reports no configured checks

## Companion backend PR

- weifuwan/yak-framework#60