### PR TITLE
完成资源授权页面与后端联调

### DIFF
--- a/yak-ops-ui/src/pages/system/resource-permissions/components/AuthorizationChecklist.tsx
+++ b/yak-ops-ui/src/pages/system/resource-permissions/components/AuthorizationChecklist.tsx
@@ -1,0 +1,209 @@
+import {
+  ArrowRightOutlined,
+  SearchOutlined,
+} from '@ant-design/icons';
+import {
+  Button,
+  Checkbox,
+  Empty,
+  Input,
+  Space,
+  Spin,
+  Tag,
+} from 'antd';
+import { useMemo, useState } from 'react';
+
+import type { ResourceOwnershipLevel } from '@/services/security/resourcePermissions';
+
+export interface AuthorizationChecklistItem {
+  id: number;
+  label: string;
+  description?: string;
+  hasLevel: ResourceOwnershipLevel;
+}
+
+interface AuthorizationChecklistProps {
+  items: AuthorizationChecklistItem[];
+  selectedIds: number[];
+  partialIds: number[];
+  loading?: boolean;
+  disabled?: boolean;
+  emptyText?: string;
+  searchPlaceholder?: string;
+  drillLabel?: string;
+  onChange: (selectedIds: number[], partialIds: number[]) => void;
+  onDrill?: (item: AuthorizationChecklistItem) => void;
+}
+
+const unique = (ids: number[]): number[] =>
+  Array.from(new Set(ids.filter(Number.isFinite)));
+
+export default function AuthorizationChecklist({
+  items,
+  selectedIds,
+  partialIds,
+  loading = false,
+  disabled = false,
+  emptyText = '暂无可授权数据',
+  searchPlaceholder = '搜索名称',
+  drillLabel = '进入下一级',
+  onChange,
+  onDrill,
+}: AuthorizationChecklistProps) {
+  const [keyword, setKeyword] = useState('');
+
+  const selected = useMemo(
+    () => new Set(selectedIds),
+    [selectedIds],
+  );
+  const partial = useMemo(
+    () => new Set(partialIds),
+    [partialIds],
+  );
+
+  const visible = useMemo(() => {
+    const query = keyword.trim().toLocaleLowerCase();
+    if (!query) return items;
+
+    return items.filter((item) =>
+      `${item.label} ${item.description ?? ''}`
+        .toLocaleLowerCase()
+        .includes(query),
+    );
+  }, [items, keyword]);
+
+  const visibleIds = visible.map((item) => item.id);
+  const allVisibleChecked =
+    visibleIds.length > 0 &&
+    visibleIds.every((id) => selected.has(id));
+  const someVisibleChecked =
+    visibleIds.some((id) => selected.has(id) || partial.has(id)) &&
+    !allVisibleChecked;
+
+  const toggle = (id: number, checked: boolean) => {
+    const nextSelected = new Set(selected);
+    const nextPartial = new Set(partial);
+
+    if (checked) {
+      nextSelected.add(id);
+      nextPartial.delete(id);
+    } else {
+      nextSelected.delete(id);
+      nextPartial.delete(id);
+    }
+
+    onChange(
+      unique(Array.from(nextSelected)),
+      unique(Array.from(nextPartial)),
+    );
+  };
+
+  const toggleVisible = (checked: boolean) => {
+    const nextSelected = new Set(selected);
+    const nextPartial = new Set(partial);
+
+    visibleIds.forEach((id) => {
+      if (checked) nextSelected.add(id);
+      else nextSelected.delete(id);
+      nextPartial.delete(id);
+    });
+
+    onChange(
+      unique(Array.from(nextSelected)),
+      unique(Array.from(nextPartial)),
+    );
+  };
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="mb-3 flex shrink-0 flex-wrap items-center gap-2">
+        <Input
+          allowClear
+          value={keyword}
+          prefix={<SearchOutlined className="text-slate-400" />}
+          placeholder={searchPlaceholder}
+          className="min-w-[220px] flex-1"
+          onChange={(event) => setKeyword(event.target.value)}
+        />
+
+        <Checkbox
+          checked={allVisibleChecked}
+          indeterminate={someVisibleChecked}
+          disabled={disabled || visibleIds.length === 0}
+          onChange={(event) => toggleVisible(event.target.checked)}
+        >
+          全选当前结果
+        </Checkbox>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto rounded-lg border border-slate-200 bg-white">
+        <Spin spinning={loading}>
+          {!loading && visible.length === 0 ? (
+            <Empty
+              className="my-16"
+              image={Empty.PRESENTED_IMAGE_SIMPLE}
+              description={emptyText}
+            />
+          ) : (
+            <div className="divide-y divide-slate-100">
+              {visible.map((item) => {
+                const checked = selected.has(item.id);
+                const indeterminate = partial.has(item.id);
+
+                return (
+                  <div
+                    key={item.id}
+                    className="flex items-center gap-3 px-4 py-3 transition-colors hover:bg-slate-50/70"
+                  >
+                    <Checkbox
+                      checked={checked}
+                      indeterminate={indeterminate}
+                      disabled={disabled}
+                      onChange={(event) =>
+                        toggle(item.id, event.target.checked)
+                      }
+                    />
+
+                    <div className="min-w-0 flex-1">
+                      <div className="flex min-w-0 flex-wrap items-center gap-2">
+                        <span className="truncate text-sm font-medium text-slate-700">
+                          {item.label}
+                        </span>
+                        {checked && <Tag color="processing">全部授权</Tag>}
+                        {indeterminate && <Tag color="warning">部分授权</Tag>}
+                        {!checked && !indeterminate && <Tag>未授权</Tag>}
+                      </div>
+                      {item.description && (
+                        <div className="mt-1 truncate text-xs text-slate-400">
+                          {item.description}
+                        </div>
+                      )}
+                    </div>
+
+                    {onDrill && (
+                      <Button
+                        type="link"
+                        size="small"
+                        icon={<ArrowRightOutlined />}
+                        iconPosition="end"
+                        onClick={() => onDrill(item)}
+                      >
+                        {drillLabel}
+                      </Button>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </Spin>
+      </div>
+
+      <Space className="mt-3 shrink-0 text-xs text-slate-400" wrap>
+        <span>全部授权：{selectedIds.length}</span>
+        <span>部分授权：{partialIds.length}</span>
+        <span>当前显示：{visible.length}</span>
+      </Space>
+    </div>
+  );
+}

--- a/yak-ops-ui/src/pages/system/resource-permissions/components/ByResourceAuthorization.tsx
+++ b/yak-ops-ui/src/pages/system/resource-permissions/components/ByResourceAuthorization.tsx
@@ -1,0 +1,567 @@
+import {
+  ArrowLeftOutlined,
+  ArrowRightOutlined,
+  DatabaseOutlined,
+  ReloadOutlined,
+  SearchOutlined,
+  TeamOutlined,
+} from '@ant-design/icons';
+import {
+  Avatar,
+  Button,
+  Empty,
+  Input,
+  Pagination,
+  Segmented,
+  Space,
+  Spin,
+  Tag,
+  Typography,
+  message,
+} from 'antd';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+
+import { PermissionGuard } from '@/components/security';
+import {
+  type ResourceControlLevel,
+  type ResourcePermissionResourceSummary,
+  type ResourcePermissionUserOption,
+  type ResourceShowLevel,
+  assignUsersToResource,
+  listUsersForResource,
+  pageResourcePermissionResources,
+} from '@/services/security/resourcePermissions';
+
+import AuthorizationChecklist, {
+  type AuthorizationChecklistItem,
+} from './AuthorizationChecklist';
+
+interface ByResourceAuthorizationProps {
+  viewControlEnabled: boolean;
+  onAuthorizationChanged?: () => void;
+}
+
+interface PaginationState {
+  current: number;
+  pageSize: number;
+  total: number;
+}
+
+const DEFAULT_PAGINATION: PaginationState = {
+  current: 1,
+  pageSize: 10,
+  total: 0,
+};
+
+const errorText = (error: unknown, fallback: string): string =>
+  error instanceof Error && error.message ? error.message : fallback;
+
+const permission = (action: string): string =>
+  `security:resource-permission:${action}`;
+
+const rowId = (
+  row: ResourcePermissionResourceSummary,
+  level: ResourceShowLevel,
+): number => {
+  if (level === 1) return row.projectId;
+  if (level === 2) return Number(row.resourceTypeId);
+  return Number(row.resourceId);
+};
+
+const rowName = (
+  row: ResourcePermissionResourceSummary,
+  level: ResourceShowLevel,
+): string => {
+  if (level === 1) return row.projectName || `项目 ${row.projectId}`;
+  if (level === 2) {
+    return row.resourceTypeName || `资源类型 ${row.resourceTypeId}`;
+  }
+  return row.resourceName || `资源 ${row.resourceId}`;
+};
+
+export default function ByResourceAuthorization({
+  viewControlEnabled,
+  onAuthorizationChanged,
+}: ByResourceAuthorizationProps) {
+  const pageRequestRef = useRef(0);
+  const userRequestRef = useRef(0);
+
+  const [showLevel, setShowLevel] = useState<ResourceShowLevel>(1);
+  const [project, setProject] = useState<{ id: number; name: string }>();
+  const [resourceType, setResourceType] =
+    useState<{ id: number; name: string }>();
+  const [rows, setRows] =
+    useState<ResourcePermissionResourceSummary[]>([]);
+  const [selectedId, setSelectedId] = useState<number>();
+  const [pagination, setPagination] =
+    useState<PaginationState>(DEFAULT_PAGINATION);
+  const [keyword, setKeyword] = useState('');
+  const [submittedKeyword, setSubmittedKeyword] = useState('');
+  const [pageLoading, setPageLoading] = useState(false);
+
+  const [controlLevel, setControlLevel] =
+    useState<ResourceControlLevel>(2);
+  const [users, setUsers] =
+    useState<ResourcePermissionUserOption[]>([]);
+  const [selectedUserIds, setSelectedUserIds] = useState<number[]>([]);
+  const [partialUserIds, setPartialUserIds] = useState<number[]>([]);
+  const [usersLoading, setUsersLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (!viewControlEnabled && controlLevel === 1) {
+      setControlLevel(2);
+    }
+  }, [controlLevel, viewControlEnabled]);
+
+  const selectedRow = useMemo(
+    () => rows.find((row) => rowId(row, showLevel) === selectedId),
+    [rows, selectedId, showLevel],
+  );
+
+  const loadPage = useCallback(async () => {
+    const sequence = ++pageRequestRef.current;
+    setPageLoading(true);
+
+    try {
+      const result = await pageResourcePermissionResources({
+        pageNum: pagination.current,
+        pageSize: pagination.pageSize,
+        showLevel,
+        projectId: project?.id,
+        resourceTypeId: resourceType?.id,
+        name: submittedKeyword || undefined,
+      });
+      if (sequence !== pageRequestRef.current) return;
+
+      setRows(result.records ?? []);
+      setPagination((current) => ({
+        ...current,
+        total: result.total ?? 0,
+      }));
+    } catch (error) {
+      if (sequence !== pageRequestRef.current) return;
+      setRows([]);
+      setPagination((current) => ({ ...current, total: 0 }));
+      message.error(errorText(error, '资源授权列表加载失败'));
+    } finally {
+      if (sequence === pageRequestRef.current) {
+        setPageLoading(false);
+      }
+    }
+  }, [
+    pagination.current,
+    pagination.pageSize,
+    project?.id,
+    resourceType?.id,
+    showLevel,
+    submittedKeyword,
+  ]);
+
+  useEffect(() => {
+    void loadPage();
+  }, [loadPage]);
+
+  useEffect(() => {
+    if (rows.length === 0) {
+      setSelectedId(undefined);
+      return;
+    }
+
+    if (!rows.some((row) => rowId(row, showLevel) === selectedId)) {
+      setSelectedId(rowId(rows[0], showLevel));
+    }
+  }, [rows, selectedId, showLevel]);
+
+  const loadUsers = useCallback(async () => {
+    if (!selectedRow) {
+      setUsers([]);
+      setSelectedUserIds([]);
+      setPartialUserIds([]);
+      return;
+    }
+
+    const sequence = ++userRequestRef.current;
+    setUsersLoading(true);
+
+    try {
+      const result = await listUsersForResource({
+        projectId: selectedRow.projectId,
+        resourceTypeId:
+          showLevel >= 2
+            ? Number(selectedRow.resourceTypeId)
+            : undefined,
+        resourceId:
+          showLevel === 3
+            ? Number(selectedRow.resourceId)
+            : undefined,
+        controlLevel,
+        batch: false,
+      });
+      if (sequence !== userRequestRef.current) return;
+
+      setUsers(result);
+      setSelectedUserIds(
+        result
+          .filter((user) => user.hasLevel === 2)
+          .map((user) => user.userId),
+      );
+      setPartialUserIds(
+        result
+          .filter((user) => user.hasLevel === 1)
+          .map((user) => user.userId),
+      );
+    } catch (error) {
+      if (sequence !== userRequestRef.current) return;
+      setUsers([]);
+      setSelectedUserIds([]);
+      setPartialUserIds([]);
+      message.error(errorText(error, '资源用户授权数据加载失败'));
+    } finally {
+      if (sequence === userRequestRef.current) {
+        setUsersLoading(false);
+      }
+    }
+  }, [controlLevel, selectedRow, showLevel]);
+
+  useEffect(() => {
+    void loadUsers();
+  }, [loadUsers]);
+
+  const userItems = useMemo<AuthorizationChecklistItem[]>(
+    () =>
+      users.map((user) => ({
+        id: user.userId,
+        label: user.realName || user.userName || `用户 ${user.userId}`,
+        description:
+          user.realName && user.userName
+            ? `用户名：${user.userName}`
+            : `用户 ID：${user.userId}`,
+        hasLevel: user.hasLevel,
+      })),
+    [users],
+  );
+
+  const enterNextLevel = (row: ResourcePermissionResourceSummary) => {
+    if (showLevel === 1) {
+      setProject({ id: row.projectId, name: rowName(row, 1) });
+      setResourceType(undefined);
+      setShowLevel(2);
+    } else if (showLevel === 2 && row.resourceTypeId != null) {
+      setResourceType({
+        id: Number(row.resourceTypeId),
+        name: rowName(row, 2),
+      });
+      setShowLevel(3);
+    }
+
+    setKeyword('');
+    setSubmittedKeyword('');
+    setPagination((current) => ({ ...current, current: 1 }));
+    setSelectedId(undefined);
+  };
+
+  const goBack = () => {
+    if (showLevel === 3) {
+      setResourceType(undefined);
+      setShowLevel(2);
+    } else if (showLevel === 2) {
+      setProject(undefined);
+      setShowLevel(1);
+    }
+
+    setKeyword('');
+    setSubmittedKeyword('');
+    setPagination((current) => ({ ...current, current: 1 }));
+    setSelectedId(undefined);
+  };
+
+  const save = async () => {
+    if (!selectedRow || saving) return;
+    setSaving(true);
+
+    try {
+      await assignUsersToResource({
+        projectId: selectedRow.projectId,
+        resourceTypeId:
+          showLevel >= 2
+            ? Number(selectedRow.resourceTypeId)
+            : undefined,
+        resourceId:
+          showLevel === 3
+            ? Number(selectedRow.resourceId)
+            : undefined,
+        userIdList: selectedUserIds,
+        excludeUserIdList: partialUserIds,
+        controlLevel,
+      });
+      message.success(
+        controlLevel === 2 ? '管理用户已保存' : '查看用户已保存',
+      );
+      await Promise.all([loadUsers(), loadPage()]);
+      onAuthorizationChanged?.();
+    } catch (error) {
+      message.error(errorText(error, '用户授权保存失败'));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const levelTitle =
+    showLevel === 1
+      ? '项目列表'
+      : showLevel === 2
+        ? `${project?.name ?? '-'} / 资源类型`
+        : `${project?.name ?? '-'} / ${resourceType?.name ?? '-'} / 资源`;
+
+  return (
+    <div className="grid min-h-0 flex-1 overflow-hidden rounded-lg border border-slate-200 bg-white lg:grid-cols-[430px_minmax(0,1fr)]">
+      <aside className="flex min-h-0 flex-col border-b border-slate-200 lg:border-b-0 lg:border-r">
+        <div className="shrink-0 border-b border-slate-100 p-4">
+          <div className="mb-3 flex items-center justify-between gap-2">
+            <div className="min-w-0">
+              <div className="truncate font-medium text-slate-800">
+                {levelTitle}
+              </div>
+              <div className="mt-0.5 text-xs text-slate-400">
+                共 {pagination.total} 项
+              </div>
+            </div>
+            <Space size={4}>
+              {showLevel > 1 && (
+                <Button
+                  type="text"
+                  icon={<ArrowLeftOutlined />}
+                  onClick={goBack}
+                />
+              )}
+              <Button
+                type="text"
+                icon={<ReloadOutlined />}
+                loading={pageLoading}
+                onClick={() => void loadPage()}
+              />
+            </Space>
+          </div>
+
+          <Input
+            allowClear
+            value={keyword}
+            prefix={<SearchOutlined className="text-slate-400" />}
+            placeholder={
+              showLevel === 1
+                ? '搜索项目'
+                : showLevel === 2
+                  ? '搜索资源类型'
+                  : '搜索资源名称'
+            }
+            onChange={(event) => {
+              setKeyword(event.target.value);
+              if (!event.target.value) {
+                setSubmittedKeyword('');
+                setPagination((current) => ({
+                  ...current,
+                  current: 1,
+                }));
+              }
+            }}
+            onPressEnter={() => {
+              setSubmittedKeyword(keyword.trim());
+              setPagination((current) => ({
+                ...current,
+                current: 1,
+              }));
+            }}
+          />
+        </div>
+
+        <div className="min-h-0 flex-1 overflow-y-auto">
+          <Spin spinning={pageLoading}>
+            {!pageLoading && rows.length === 0 ? (
+              <Empty
+                className="my-16"
+                image={Empty.PRESENTED_IMAGE_SIMPLE}
+                description="当前层级暂无资源"
+              />
+            ) : (
+              <div className="divide-y divide-slate-100">
+                {rows.map((row) => {
+                  const id = rowId(row, showLevel);
+                  const active = selectedId === id;
+                  const adminCount = row.adminUserCnt ?? 0;
+                  const viewCount = row.viewUserCnt ?? 0;
+
+                  return (
+                    <div
+                      key={`${showLevel}-${id}`}
+                      className={[
+                        'flex items-center gap-3 px-4 py-3 transition-colors',
+                        active
+                          ? 'bg-rose-50/70'
+                          : 'hover:bg-slate-50',
+                      ].join(' ')}
+                    >
+                      <button
+                        type="button"
+                        className="flex min-w-0 flex-1 items-center gap-3 text-left"
+                        onClick={() => setSelectedId(id)}
+                      >
+                        <Avatar
+                          icon={<DatabaseOutlined />}
+                          className={
+                            active ? '!bg-[#FE2C55]' : '!bg-slate-500'
+                          }
+                        />
+                        <div className="min-w-0 flex-1">
+                          <div className="truncate text-sm font-medium text-slate-700">
+                            {rowName(row, showLevel)}
+                          </div>
+                          <div className="mt-0.5 truncate text-xs text-slate-400">
+                            {showLevel === 1 &&
+                              (row.projectCode || `项目 ID ${row.projectId}`)}
+                            {showLevel === 2 &&
+                              `资源类型 ID ${row.resourceTypeId}`}
+                            {showLevel === 3 &&
+                              `资源 ID ${row.resourceId}`}
+                          </div>
+                          <Space size={4} className="mt-1" wrap>
+                            <Tag className="!mr-0">管理 {adminCount}</Tag>
+                            {viewControlEnabled && (
+                              <Tag className="!mr-0">查看 {viewCount}</Tag>
+                            )}
+                          </Space>
+                        </div>
+                      </button>
+
+                      {showLevel < 3 && (
+                        <Button
+                          type="text"
+                          size="small"
+                          icon={<ArrowRightOutlined />}
+                          onClick={() => enterNextLevel(row)}
+                        />
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </Spin>
+        </div>
+
+        <div className="shrink-0 border-t border-slate-100 px-3 py-3">
+          <Pagination
+            size="small"
+            current={pagination.current}
+            pageSize={pagination.pageSize}
+            total={pagination.total}
+            showSizeChanger
+            pageSizeOptions={[10, 20, 50]}
+            onChange={(current, pageSize) =>
+              setPagination((previous) => ({
+                ...previous,
+                current:
+                  pageSize !== previous.pageSize ? 1 : current,
+                pageSize,
+              }))
+            }
+          />
+        </div>
+      </aside>
+
+      <main className="flex min-h-0 flex-col overflow-hidden">
+        {selectedRow ? (
+          <>
+            <div className="flex shrink-0 flex-col gap-4 border-b border-slate-100 px-6 py-4 xl:flex-row xl:items-center xl:justify-between">
+              <div className="flex min-w-0 items-center gap-3">
+                <Avatar
+                  size={44}
+                  icon={<TeamOutlined />}
+                  className="!bg-slate-600"
+                />
+                <div className="min-w-0">
+                  <Typography.Title level={5} className="!mb-0">
+                    为 {rowName(selectedRow, showLevel)} 分配用户
+                  </Typography.Title>
+                  <div className="mt-1 text-xs text-slate-400">
+                    {showLevel === 1 && '项目范围内的全部资源'}
+                    {showLevel === 2 &&
+                      `${project?.name ?? '-'} / 当前资源类型全部资源`}
+                    {showLevel === 3 &&
+                      `${project?.name ?? '-'} / ${resourceType?.name ?? '-'}`}
+                  </div>
+                </div>
+              </div>
+
+              <Space wrap>
+                <Segmented<ResourceControlLevel>
+                  value={controlLevel}
+                  options={[
+                    { label: '管理权限', value: 2 },
+                    ...(viewControlEnabled
+                      ? [{ label: '查看权限', value: 1 as const }]
+                      : []),
+                  ]}
+                  onChange={setControlLevel}
+                />
+                <PermissionGuard
+                  mode="one"
+                  permission={permission('assign')}
+                >
+                  <Button
+                    type="primary"
+                    loading={saving}
+                    disabled={usersLoading}
+                    onClick={() => void save()}
+                  >
+                    保存授权
+                  </Button>
+                </PermissionGuard>
+              </Space>
+            </div>
+
+            <div className="flex min-h-0 flex-1 flex-col p-6">
+              <div className="mb-4 flex shrink-0 flex-wrap items-center gap-2">
+                <Tag color={controlLevel === 2 ? 'magenta' : 'blue'}>
+                  {controlLevel === 2 ? '管理权限' : '查看权限'}
+                </Tag>
+                {partialUserIds.length > 0 && (
+                  <span className="text-xs text-amber-600">
+                    部分授权用户会保留其现有下级授权
+                  </span>
+                )}
+              </div>
+
+              <AuthorizationChecklist
+                items={userItems}
+                selectedIds={selectedUserIds}
+                partialIds={partialUserIds}
+                loading={usersLoading}
+                disabled={saving}
+                searchPlaceholder="搜索用户名或真实姓名"
+                emptyText="暂无可授权用户"
+                onChange={(nextSelected, nextPartial) => {
+                  setSelectedUserIds(nextSelected);
+                  setPartialUserIds(nextPartial);
+                }}
+              />
+            </div>
+          </>
+        ) : (
+          <div className="flex min-h-full items-center justify-center p-8">
+            <Empty
+              image={Empty.PRESENTED_IMAGE_SIMPLE}
+              description="请从左侧选择项目、资源类型或资源"
+            />
+          </div>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/yak-ops-ui/src/pages/system/resource-permissions/components/ByUserAuthorization.tsx
+++ b/yak-ops-ui/src/pages/system/resource-permissions/components/ByUserAuthorization.tsx
@@ -1,0 +1,550 @@
+import {
+  ArrowLeftOutlined,
+  ReloadOutlined,
+  SafetyCertificateOutlined,
+  SearchOutlined,
+  UserOutlined,
+} from '@ant-design/icons';
+import {
+  Avatar,
+  Button,
+  Empty,
+  Input,
+  Pagination,
+  Segmented,
+  Select,
+  Space,
+  Spin,
+  Tag,
+  Typography,
+  message,
+} from 'antd';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+
+import { PermissionGuard } from '@/components/security';
+import {
+  type ResourceControlLevel,
+  type ResourcePermissionNode,
+  type ResourcePermissionUserSummary,
+  type ResourceShowLevel,
+  assignResourcesToUser,
+  listResourcesForUser,
+  pageResourcePermissionUsers,
+} from '@/services/security/resourcePermissions';
+
+import AuthorizationChecklist, {
+  type AuthorizationChecklistItem,
+} from './AuthorizationChecklist';
+
+interface ByUserAuthorizationProps {
+  viewControlEnabled: boolean;
+  onAuthorizationChanged?: () => void;
+}
+
+interface PaginationState {
+  current: number;
+  pageSize: number;
+  total: number;
+}
+
+type UserSearchField = 'userName' | 'realName' | 'deptName';
+
+const DEFAULT_PAGINATION: PaginationState = {
+  current: 1,
+  pageSize: 10,
+  total: 0,
+};
+
+const errorText = (error: unknown, fallback: string): string =>
+  error instanceof Error && error.message ? error.message : fallback;
+
+const displayName = (user?: ResourcePermissionUserSummary): string =>
+  user?.realName || user?.userName || '未命名用户';
+
+const permission = (action: string): string =>
+  `security:resource-permission:${action}`;
+
+export default function ByUserAuthorization({
+  viewControlEnabled,
+  onAuthorizationChanged,
+}: ByUserAuthorizationProps) {
+  const userRequestRef = useRef(0);
+  const dataRequestRef = useRef(0);
+
+  const [users, setUsers] = useState<ResourcePermissionUserSummary[]>([]);
+  const [selectedUserId, setSelectedUserId] = useState<number>();
+  const [pagination, setPagination] =
+    useState<PaginationState>(DEFAULT_PAGINATION);
+  const [searchField, setSearchField] =
+    useState<UserSearchField>('userName');
+  const [keyword, setKeyword] = useState('');
+  const [submittedKeyword, setSubmittedKeyword] = useState('');
+  const [usersLoading, setUsersLoading] = useState(false);
+
+  const [controlLevel, setControlLevel] =
+    useState<ResourceControlLevel>(2);
+  const [showLevel, setShowLevel] = useState<ResourceShowLevel>(1);
+  const [project, setProject] = useState<{ id: number; name: string }>();
+  const [resourceType, setResourceType] =
+    useState<{ id: number; name: string }>();
+  const [nodes, setNodes] = useState<ResourcePermissionNode[]>([]);
+  const [selectedIds, setSelectedIds] = useState<number[]>([]);
+  const [partialIds, setPartialIds] = useState<number[]>([]);
+  const [dataLoading, setDataLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  const selectedUser = useMemo(
+    () => users.find((user) => user.userId === selectedUserId),
+    [selectedUserId, users],
+  );
+
+  useEffect(() => {
+    if (!viewControlEnabled && controlLevel === 1) {
+      setControlLevel(2);
+    }
+  }, [controlLevel, viewControlEnabled]);
+
+  const loadUsers = useCallback(async () => {
+    const sequence = ++userRequestRef.current;
+    setUsersLoading(true);
+
+    const search: Record<string, string | undefined> = {};
+    if (submittedKeyword) search[searchField] = submittedKeyword;
+
+    try {
+      const result = await pageResourcePermissionUsers({
+        pageNum: pagination.current,
+        pageSize: pagination.pageSize,
+        userName: search.userName,
+        realName: search.realName,
+        deptName: search.deptName,
+      });
+      if (sequence !== userRequestRef.current) return;
+
+      setUsers(result.records ?? []);
+      setPagination((current) => ({
+        ...current,
+        total: result.total ?? 0,
+      }));
+    } catch (error) {
+      if (sequence !== userRequestRef.current) return;
+      setUsers([]);
+      setPagination((current) => ({ ...current, total: 0 }));
+      message.error(errorText(error, '用户授权列表加载失败'));
+    } finally {
+      if (sequence === userRequestRef.current) {
+        setUsersLoading(false);
+      }
+    }
+  }, [
+    pagination.current,
+    pagination.pageSize,
+    searchField,
+    submittedKeyword,
+  ]);
+
+  useEffect(() => {
+    void loadUsers();
+  }, [loadUsers]);
+
+  useEffect(() => {
+    if (users.length === 0) {
+      setSelectedUserId(undefined);
+      return;
+    }
+
+    if (!users.some((user) => user.userId === selectedUserId)) {
+      setSelectedUserId(users[0].userId);
+    }
+  }, [selectedUserId, users]);
+
+  const loadPermissionData = useCallback(async () => {
+    if (selectedUserId === undefined) {
+      setNodes([]);
+      setSelectedIds([]);
+      setPartialIds([]);
+      return;
+    }
+
+    const sequence = ++dataRequestRef.current;
+    setDataLoading(true);
+
+    try {
+      const result = await listResourcesForUser({
+        userId: selectedUserId,
+        projectId: project?.id,
+        resourceTypeId: resourceType?.id,
+        showLevel,
+        controlLevel,
+        batch: false,
+      });
+      if (sequence !== dataRequestRef.current) return;
+
+      setNodes(result);
+      setSelectedIds(
+        result
+          .filter((node) => node.hasLevel === 2)
+          .map((node) => node.id),
+      );
+      setPartialIds(
+        result
+          .filter((node) => node.hasLevel === 1)
+          .map((node) => node.id),
+      );
+    } catch (error) {
+      if (sequence !== dataRequestRef.current) return;
+      setNodes([]);
+      setSelectedIds([]);
+      setPartialIds([]);
+      message.error(errorText(error, '资源授权数据加载失败'));
+    } finally {
+      if (sequence === dataRequestRef.current) {
+        setDataLoading(false);
+      }
+    }
+  }, [
+    controlLevel,
+    project?.id,
+    resourceType?.id,
+    selectedUserId,
+    showLevel,
+  ]);
+
+  useEffect(() => {
+    void loadPermissionData();
+  }, [loadPermissionData]);
+
+  const resetHierarchy = useCallback(() => {
+    setShowLevel(1);
+    setProject(undefined);
+    setResourceType(undefined);
+  }, []);
+
+  useEffect(() => {
+    resetHierarchy();
+  }, [resetHierarchy, selectedUserId]);
+
+  const checklistItems = useMemo<AuthorizationChecklistItem[]>(
+    () =>
+      nodes.map((node) => ({
+        id: node.id,
+        label: node.name || `ID ${node.id}`,
+        description:
+          showLevel === 1
+            ? '项目范围'
+            : showLevel === 2
+              ? `所属项目：${project?.name ?? '-'}`
+              : `所属资源类型：${resourceType?.name ?? '-'}`,
+        hasLevel: node.hasLevel,
+      })),
+    [nodes, project?.name, resourceType?.name, showLevel],
+  );
+
+  const drill = (item: AuthorizationChecklistItem) => {
+    if (showLevel === 1) {
+      setProject({ id: item.id, name: item.label });
+      setResourceType(undefined);
+      setShowLevel(2);
+      return;
+    }
+
+    if (showLevel === 2) {
+      setResourceType({ id: item.id, name: item.label });
+      setShowLevel(3);
+    }
+  };
+
+  const goBack = () => {
+    if (showLevel === 3) {
+      setResourceType(undefined);
+      setShowLevel(2);
+      return;
+    }
+
+    if (showLevel === 2) {
+      setProject(undefined);
+      setShowLevel(1);
+    }
+  };
+
+  const save = async () => {
+    if (selectedUserId === undefined || saving) return;
+    setSaving(true);
+
+    try {
+      await assignResourcesToUser({
+        userId: selectedUserId,
+        projectId: project?.id,
+        resourceTypeId: resourceType?.id,
+        idList: selectedIds,
+        excludeIdList: partialIds,
+        controlLevel,
+      });
+      message.success(
+        controlLevel === 2 ? '管理权限已保存' : '查看权限已保存',
+      );
+      await Promise.all([loadPermissionData(), loadUsers()]);
+      onAuthorizationChanged?.();
+    } catch (error) {
+      message.error(errorText(error, '资源授权保存失败'));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const submitSearch = () => {
+    setSubmittedKeyword(keyword.trim());
+    setPagination((current) => ({ ...current, current: 1 }));
+  };
+
+  return (
+    <div className="grid min-h-0 flex-1 overflow-hidden rounded-lg border border-slate-200 bg-white lg:grid-cols-[390px_minmax(0,1fr)]">
+      <aside className="flex min-h-0 flex-col border-b border-slate-200 lg:border-b-0 lg:border-r">
+        <div className="shrink-0 border-b border-slate-100 p-4">
+          <div className="mb-3 flex items-center justify-between">
+            <div>
+              <div className="font-medium text-slate-800">选择用户</div>
+              <div className="mt-0.5 text-xs text-slate-400">
+                共 {pagination.total} 个用户
+              </div>
+            </div>
+            <Button
+              type="text"
+              icon={<ReloadOutlined />}
+              loading={usersLoading}
+              onClick={() => void loadUsers()}
+            />
+          </div>
+
+          <div className="flex h-8 overflow-hidden rounded-md bg-slate-100">
+            <Select<UserSearchField>
+              value={searchField}
+              variant="borderless"
+              className="h-8 w-[105px] shrink-0"
+              options={[
+                { label: '用户名', value: 'userName' },
+                { label: '真实姓名', value: 'realName' },
+                { label: '部门名称', value: 'deptName' },
+              ]}
+              onChange={(value) => {
+                setSearchField(value);
+                setKeyword('');
+                setSubmittedKeyword('');
+              }}
+            />
+            <div className="my-2 w-px bg-slate-200" />
+            <Input
+              allowClear
+              value={keyword}
+              variant="borderless"
+              prefix={<SearchOutlined className="text-slate-400" />}
+              placeholder="搜索用户"
+              className="min-w-0 flex-1 !bg-transparent"
+              onChange={(event) => {
+                setKeyword(event.target.value);
+                if (!event.target.value) {
+                  setSubmittedKeyword('');
+                  setPagination((current) => ({
+                    ...current,
+                    current: 1,
+                  }));
+                }
+              }}
+              onPressEnter={submitSearch}
+            />
+          </div>
+        </div>
+
+        <div className="min-h-0 flex-1 overflow-y-auto">
+          <Spin spinning={usersLoading}>
+            {!usersLoading && users.length === 0 ? (
+              <Empty
+                className="my-16"
+                image={Empty.PRESENTED_IMAGE_SIMPLE}
+                description="暂无用户"
+              />
+            ) : (
+              <div className="divide-y divide-slate-100">
+                {users.map((user) => {
+                  const active = user.userId === selectedUserId;
+                  const deptPath = (user.deptList ?? [])
+                    .map((dept) => dept.deptName)
+                    .filter(Boolean)
+                    .join(' / ');
+
+                  return (
+                    <button
+                      key={user.userId}
+                      type="button"
+                      className={[
+                        'flex w-full items-center gap-3 px-4 py-3 text-left transition-colors',
+                        active
+                          ? 'bg-rose-50/70'
+                          : 'hover:bg-slate-50',
+                      ].join(' ')}
+                      onClick={() => setSelectedUserId(user.userId)}
+                    >
+                      <Avatar
+                        icon={<UserOutlined />}
+                        className={
+                          active ? '!bg-[#FE2C55]' : '!bg-slate-500'
+                        }
+                      />
+                      <div className="min-w-0 flex-1">
+                        <div className="truncate text-sm font-medium text-slate-700">
+                          {displayName(user)}
+                        </div>
+                        <div className="mt-0.5 truncate text-xs text-slate-400">
+                          {user.userName}
+                          {deptPath ? ` · ${deptPath}` : ''}
+                        </div>
+                        <Space size={4} className="mt-1" wrap>
+                          <Tag className="!mr-0">
+                            管理 {user.adminResourceCnt ?? 0}
+                          </Tag>
+                          {viewControlEnabled && (
+                            <Tag className="!mr-0">
+                              查看 {user.viewResourceCnt ?? 0}
+                            </Tag>
+                          )}
+                        </Space>
+                      </div>
+                    </button>
+                  );
+                })}
+              </div>
+            )}
+          </Spin>
+        </div>
+
+        <div className="shrink-0 border-t border-slate-100 px-3 py-3">
+          <Pagination
+            size="small"
+            current={pagination.current}
+            pageSize={pagination.pageSize}
+            total={pagination.total}
+            showSizeChanger
+            pageSizeOptions={[10, 20, 50]}
+            onChange={(current, pageSize) =>
+              setPagination((previous) => ({
+                ...previous,
+                current:
+                  pageSize !== previous.pageSize ? 1 : current,
+                pageSize,
+              }))
+            }
+          />
+        </div>
+      </aside>
+
+      <main className="flex min-h-0 flex-col overflow-hidden">
+        {selectedUser ? (
+          <>
+            <div className="flex shrink-0 flex-col gap-4 border-b border-slate-100 px-6 py-4 xl:flex-row xl:items-center xl:justify-between">
+              <div className="flex min-w-0 items-center gap-3">
+                <Avatar
+                  size={44}
+                  icon={<SafetyCertificateOutlined />}
+                  className="!bg-slate-600"
+                />
+                <div className="min-w-0">
+                  <Typography.Title level={5} className="!mb-0">
+                    为 {displayName(selectedUser)} 分配资源权限
+                  </Typography.Title>
+                  <div className="mt-1 text-xs text-slate-400">
+                    {showLevel === 1 && '项目级授权'}
+                    {showLevel === 2 && `${project?.name} / 资源类型授权`}
+                    {showLevel === 3 &&
+                      `${project?.name} / ${resourceType?.name} / 资源授权`}
+                  </div>
+                </div>
+              </div>
+
+              <Space wrap>
+                <Segmented<ResourceControlLevel>
+                  value={controlLevel}
+                  options={[
+                    { label: '管理权限', value: 2 },
+                    ...(viewControlEnabled
+                      ? [{ label: '查看权限', value: 1 as const }]
+                      : []),
+                  ]}
+                  onChange={setControlLevel}
+                />
+                <PermissionGuard
+                  mode="one"
+                  permission={permission('assign')}
+                >
+                  <Button
+                    type="primary"
+                    loading={saving}
+                    disabled={dataLoading}
+                    onClick={() => void save()}
+                  >
+                    保存授权
+                  </Button>
+                </PermissionGuard>
+              </Space>
+            </div>
+
+            <div className="flex min-h-0 flex-1 flex-col p-6">
+              <div className="mb-4 flex shrink-0 items-center gap-2">
+                {showLevel > 1 && (
+                  <Button
+                    type="text"
+                    icon={<ArrowLeftOutlined />}
+                    onClick={goBack}
+                  >
+                    返回上一级
+                  </Button>
+                )}
+                <Tag color={controlLevel === 2 ? 'magenta' : 'blue'}>
+                  {controlLevel === 2 ? '管理权限' : '查看权限'}
+                </Tag>
+                {partialIds.length > 0 && (
+                  <span className="text-xs text-amber-600">
+                    部分授权节点会保留其现有下级授权
+                  </span>
+                )}
+              </div>
+
+              <AuthorizationChecklist
+                items={checklistItems}
+                selectedIds={selectedIds}
+                partialIds={partialIds}
+                loading={dataLoading}
+                disabled={saving}
+                searchPlaceholder={
+                  showLevel === 1
+                    ? '搜索项目'
+                    : showLevel === 2
+                      ? '搜索资源类型'
+                      : '搜索资源'
+                }
+                emptyText="当前层级暂无可授权数据"
+                onChange={(nextSelected, nextPartial) => {
+                  setSelectedIds(nextSelected);
+                  setPartialIds(nextPartial);
+                }}
+                onDrill={showLevel < 3 ? drill : undefined}
+              />
+            </div>
+          </>
+        ) : (
+          <div className="flex min-h-full items-center justify-center p-8">
+            <Empty
+              image={Empty.PRESENTED_IMAGE_SIMPLE}
+              description="请从左侧选择用户"
+            />
+          </div>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/yak-ops-ui/src/pages/system/resource-permissions/index.tsx
+++ b/yak-ops-ui/src/pages/system/resource-permissions/index.tsx
@@ -1,5 +1,181 @@
-import SystemPageShell from '../SystemPageShell';
+import {
+  SafetyCertificateOutlined,
+  TeamOutlined,
+} from '@ant-design/icons';
+import {
+  Alert,
+  Segmented,
+  Space,
+  Switch,
+  Tag,
+  Tooltip,
+  message,
+} from 'antd';
+import { useCallback, useEffect, useState } from 'react';
 
-export default function SystemPage() {
-  return <SystemPageShell title='资源授权' description='为用户和角色分配资源权限。' />;
+import { PermissionGuard } from '@/components/security';
+import {
+  getResourceViewControlStatus,
+  setResourceViewControlStatus,
+} from '@/services/security/resourcePermissions';
+
+import ByResourceAuthorization from './components/ByResourceAuthorization';
+import ByUserAuthorization from './components/ByUserAuthorization';
+
+type AuthorizationMode = 'user' | 'resource';
+
+const errorText = (error: unknown, fallback: string): string =>
+  error instanceof Error && error.message ? error.message : fallback;
+
+const permission = (action: string): string =>
+  `security:resource-permission:${action}`;
+
+export default function ResourcePermissionsPage() {
+  const [mode, setMode] = useState<AuthorizationMode>('user');
+  const [viewControlEnabled, setViewControlEnabled] = useState(false);
+  const [statusLoading, setStatusLoading] = useState(false);
+  const [statusSaving, setStatusSaving] = useState(false);
+
+  const loadViewControlStatus = useCallback(async () => {
+    setStatusLoading(true);
+    try {
+      setViewControlEnabled(await getResourceViewControlStatus());
+    } catch (error) {
+      setViewControlEnabled(false);
+      message.error(errorText(error, '查看权限控制状态加载失败'));
+    } finally {
+      setStatusLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadViewControlStatus();
+  }, [loadViewControlStatus]);
+
+  const changeViewControlStatus = async (enabled: boolean) => {
+    if (statusSaving) return;
+    setStatusSaving(true);
+
+    try {
+      await setResourceViewControlStatus(enabled);
+      setViewControlEnabled(enabled);
+      message.success(
+        enabled
+          ? '查看权限控制已开启，可为用户单独分配查看权限'
+          : '查看权限控制已关闭，未授予管理权限的用户默认可查看资源',
+      );
+    } catch (error) {
+      message.error(errorText(error, '查看权限控制状态更新失败'));
+    } finally {
+      setStatusSaving(false);
+    }
+  };
+
+  return (
+    <section
+      className="box-border flex min-h-[680px] flex-col overflow-hidden bg-slate-50/50 p-6"
+      style={{ height: 'calc(100vh - 64px)' }}
+      aria-labelledby="resource-permission-title"
+    >
+      <div className="mb-4 flex shrink-0 flex-col gap-4 xl:flex-row xl:items-start xl:justify-between">
+        <div>
+          <h1
+            id="resource-permission-title"
+            className="font-semibold"
+            style={{ fontSize: 18, color: '#282828' }}
+          >
+            资源授权
+          </h1>
+          <div className="mt-1 text-sm text-slate-500">
+            按用户或按资源维护项目、资源类型和具体资源三级权限。
+          </div>
+        </div>
+
+        <Space size={16} wrap>
+          <Segmented<AuthorizationMode>
+            value={mode}
+            options={[
+              {
+                label: (
+                  <Space size={6}>
+                    <TeamOutlined />
+                    按用户授权
+                  </Space>
+                ),
+                value: 'user',
+              },
+              {
+                label: (
+                  <Space size={6}>
+                    <SafetyCertificateOutlined />
+                    按资源授权
+                  </Space>
+                ),
+                value: 'resource',
+              },
+            ]}
+            onChange={setMode}
+          />
+
+          <div className="flex items-center gap-2 rounded-lg border border-slate-200 bg-white px-3 py-1.5">
+            <div>
+              <div className="text-sm font-medium text-slate-700">
+                查看权限控制
+              </div>
+              <div className="text-xs text-slate-400">
+                {viewControlEnabled
+                  ? '未授权用户不可查看资源'
+                  : '关闭时默认拥有查看权限'}
+              </div>
+            </div>
+
+            <PermissionGuard
+              mode="one"
+              permission={permission('toggle')}
+              behavior="disable"
+            >
+              <Tooltip
+                title={
+                  viewControlEnabled
+                    ? '关闭后，未授予管理权限的用户默认可查看资源'
+                    : '开启时会清理历史查看授权，并从空授权开始配置'
+                }
+              >
+                <Switch
+                  checked={viewControlEnabled}
+                  loading={statusLoading || statusSaving}
+                  onChange={(checked) =>
+                    void changeViewControlStatus(checked)
+                  }
+                />
+              </Tooltip>
+            </PermissionGuard>
+          </div>
+        </Space>
+      </div>
+
+      {!viewControlEnabled && (
+        <Alert
+          showIcon
+          type="info"
+          className="mb-4 shrink-0"
+          message="查看权限控制当前处于关闭状态"
+          description="页面仍可维护管理权限；查看权限将在开启控制后才需要单独分配。"
+          action={<Tag>默认可查看</Tag>}
+        />
+      )}
+
+      <div className="min-h-0 flex-1">
+        {mode === 'user' ? (
+          <ByUserAuthorization
+            viewControlEnabled={viewControlEnabled}
+          />
+        ) : (
+          <ByResourceAuthorization
+            viewControlEnabled={viewControlEnabled}
+          />
+        )}
+      </div>
+    </section>
+  );
 }

--- a/yak-ops-ui/src/services/security/resourcePermissions.ts
+++ b/yak-ops-ui/src/services/security/resourcePermissions.ts
@@ -1,0 +1,214 @@
+import {
+  securityGetData,
+  securityPostData,
+  securityPutData,
+} from './client';
+
+const RESOURCE_API = '/api/v1/resource';
+
+export type ResourceControlLevel = 1 | 2;
+export type ResourceShowLevel = 1 | 2 | 3;
+export type ResourceOwnershipLevel = 0 | 1 | 2;
+
+export interface ResourceTypeOption {
+  id: number;
+  typeName: string;
+  description?: string | null;
+}
+
+export interface ResourceDepartmentBrief {
+  id: number;
+  deptName?: string | null;
+}
+
+export interface ResourcePermissionUserSummary {
+  userId: number;
+  userName: string;
+  realName?: string | null;
+  deptList?: ResourceDepartmentBrief[];
+  adminResourceCnt?: number;
+  viewResourceCnt?: number;
+}
+
+export interface ResourcePermissionResourceSummary {
+  projectId: number;
+  projectCode?: string | null;
+  projectName?: string | null;
+  resourceTypeId?: number | null;
+  resourceTypeName?: string | null;
+  resourceId?: number | null;
+  resourceName?: string | null;
+  adminUserCnt?: number;
+  viewUserCnt?: number;
+}
+
+export interface ResourcePermissionNode {
+  id: number;
+  name: string;
+  hasLevel: ResourceOwnershipLevel;
+}
+
+export interface ResourcePermissionUserOption {
+  userId: number;
+  userName: string;
+  realName?: string | null;
+  hasLevel: ResourceOwnershipLevel;
+}
+
+export interface ResourcePermissionPage<T> {
+  records: T[];
+  total: number;
+}
+
+export interface ByUserPageQuery {
+  pageNum: number;
+  pageSize: number;
+  deptId?: number;
+  deptName?: string;
+  userName?: string;
+  realName?: string;
+}
+
+export interface ByResourcePageQuery {
+  pageNum: number;
+  pageSize: number;
+  showLevel: ResourceShowLevel;
+  projectId?: number;
+  resourceTypeId?: number;
+  name?: string;
+}
+
+export interface UserPermissionDataQuery {
+  userId: number;
+  projectId?: number;
+  resourceTypeId?: number;
+  showLevel: ResourceShowLevel;
+  controlLevel: ResourceControlLevel;
+  batch?: boolean;
+}
+
+export interface ResourcePermissionDataQuery {
+  projectId: number;
+  resourceTypeId?: number;
+  resourceId?: number;
+  controlLevel: ResourceControlLevel;
+  batch?: boolean;
+}
+
+export interface AssignResourcesToUserInput {
+  userId: number;
+  projectId?: number;
+  resourceTypeId?: number;
+  idList: number[];
+  excludeIdList: number[];
+  controlLevel: ResourceControlLevel;
+}
+
+export interface AssignUsersToResourceInput {
+  projectId: number;
+  resourceTypeId?: number;
+  resourceId?: number;
+  userIdList: number[];
+  excludeUserIdList: number[];
+  controlLevel: ResourceControlLevel;
+}
+
+interface BackendPagingData<T> {
+  bizData?: T[];
+  pagination?: {
+    total?: number;
+    pages?: number;
+    pageNo?: number;
+    pageSize?: number;
+  };
+}
+
+const toPage = <T>(data?: BackendPagingData<T>): ResourcePermissionPage<T> => ({
+  records: Array.isArray(data?.bizData) ? data.bizData : [],
+  total: Number(data?.pagination?.total ?? 0),
+});
+
+export const getResourceViewControlStatus = (): Promise<boolean> =>
+  securityGetData<boolean>(`${RESOURCE_API}/view-control/status`);
+
+export const setResourceViewControlStatus = (
+  enabled: boolean,
+): Promise<void> =>
+  securityPutData<void>(`${RESOURCE_API}/view-control/status`, {
+    enabled,
+  });
+
+export const listResourceTypes = async (): Promise<ResourceTypeOption[]> => {
+  const data = await securityGetData<ResourceTypeOption[]>(
+    `${RESOURCE_API}/type/list`,
+  );
+  return Array.isArray(data) ? data : [];
+};
+
+export const pageResourcePermissionUsers = async (
+  query: ByUserPageQuery,
+): Promise<ResourcePermissionPage<ResourcePermissionUserSummary>> =>
+  toPage(
+    await securityPostData<
+      BackendPagingData<ResourcePermissionUserSummary>
+    >(`${RESOURCE_API}/by-user/page`, {
+      page: query.pageNum,
+      size: query.pageSize,
+      deptId: query.deptId,
+      deptName: query.deptName,
+      userName: query.userName,
+      realName: query.realName,
+    }),
+  );
+
+export const pageResourcePermissionResources = async (
+  query: ByResourcePageQuery,
+): Promise<ResourcePermissionPage<ResourcePermissionResourceSummary>> =>
+  toPage(
+    await securityPostData<
+      BackendPagingData<ResourcePermissionResourceSummary>
+    >(`${RESOURCE_API}/by-resource/page`, {
+      page: query.pageNum,
+      size: query.pageSize,
+      showLevel: query.showLevel,
+      projectId: query.projectId,
+      resourceTypeId: query.resourceTypeId,
+      name: query.name,
+    }),
+  );
+
+export const listResourcesForUser = async (
+  query: UserPermissionDataQuery,
+): Promise<ResourcePermissionNode[]> => {
+  const data = await securityPostData<ResourcePermissionNode[]>(
+    `${RESOURCE_API}/by-user/data`,
+    {
+      ...query,
+      batch: query.batch ?? false,
+    },
+  );
+  return Array.isArray(data) ? data : [];
+};
+
+export const listUsersForResource = async (
+  query: ResourcePermissionDataQuery,
+): Promise<ResourcePermissionUserOption[]> => {
+  const data = await securityPostData<ResourcePermissionUserOption[]>(
+    `${RESOURCE_API}/by-resource/data`,
+    {
+      ...query,
+      batch: query.batch ?? false,
+    },
+  );
+  return Array.isArray(data) ? data : [];
+};
+
+export const assignResourcesToUser = (
+  input: AssignResourcesToUserInput,
+): Promise<void> =>
+  securityPutData<void>(`${RESOURCE_API}/by-user/assign`, input);
+
+export const assignUsersToResource = (
+  input: AssignUsersToResourceInput,
+): Promise<void> =>
+  securityPutData<void>(`${RESOURCE_API}/by-resource/assign`, input);


### PR DESCRIPTION
## 变更内容

将系统管理中的“资源授权”占位页实现为可实际使用的授权管理页面，并接入 `yak-security` 资源权限接口。

## 页面结构

页面采用固定高度的左右分栏，并提供两种管理模式：

### 按用户授权

- 左侧分页展示用户
- 支持按用户名、真实姓名和部门名称搜索
- 展示每个用户的管理资源数量和查看资源数量
- 右侧为当前用户分配资源权限
- 支持项目 → 资源类型 → 具体资源三级下钻
- 支持管理权限和查看权限切换

### 按资源授权

- 左侧分页展示项目、资源类型和具体资源
- 支持逐级进入和返回上一级
- 支持搜索当前层级数据
- 展示每个范围已授权的管理用户和查看用户数量
- 右侧为当前项目、资源类型或资源选择授权用户

## 授权状态

根据后端 `hasLevel` 展示：

- `0`：未授权
- `1`：部分授权
- `2`：全部授权

部分授权节点使用半选状态显示。保存父级授权时会通过：

- `excludeIdList`
- `excludeUserIdList`

保留已有的下级授权，不会错误覆盖部分授权关系。

## 查看权限控制

- 页面顶部展示查看权限控制开关
- 使用显式状态接口，不再调用“反转当前状态”接口
- 关闭时页面只维护管理权限，并提示未授权用户默认可查看资源
- 开启时可独立维护查看权限
- 开关操作包含加载状态和错误回滚提示

## 接口联调

依赖后端 PR：`weifuwan/yak-framework#61`

接入接口：

- `GET /yak-security/api/v1/resource/view-control/status`
- `PUT /yak-security/api/v1/resource/view-control/status`
- `POST /yak-security/api/v1/resource/by-user/page`
- `POST /yak-security/api/v1/resource/by-user/data`
- `PUT /yak-security/api/v1/resource/by-user/assign`
- `POST /yak-security/api/v1/resource/by-resource/page`
- `POST /yak-security/api/v1/resource/by-resource/data`
- `PUT /yak-security/api/v1/resource/by-resource/assign`

分页响应已按后端真实的 `bizData` 和 `pagination.total` 转换。

## 交互与稳定性

- 用户列表和资源列表均支持独立分页
- 左右区域独立滚动
- 列表与授权详情请求均增加请求序号保护，避免旧请求覆盖新状态
- 支持搜索结果全选
- 保存按钮具有提交状态，防止重复提交
- 用户、项目、资源类型和资源切换时自动重新加载授权回显
- 关闭查看权限控制后，自动从查看权限切换回管理权限
- 最终分支重新基于最新 `main` 创建，没有携带空状态组件等无关改动

## 权限控制

- 页面访问：`security:resource-permission:read`
- 保存授权：`security:resource-permission:assign`
- 切换查看权限控制：`security:resource-permission:toggle`

## 数据模型说明

当前后端只支持用户资源授权，没有角色资源关联模型。因此页面提供“按用户”和“按资源选择用户”两种视角，没有展示无法实际生效的角色授权入口。

## 验证

- 已静态复核 TypeScript 数据模型、分页转换、三级下钻、部分授权回显、请求竞态和保存参数
- 当前执行环境无法本地检出并运行完整前端项目，合并前建议在 `yak-ops-ui` 执行：
  - `npm run tsc`
  - `npm run build`
  - `npm test -- --runInBand`
