### PR TITLE
build: establish yak-ops modular architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,37 +42,40 @@
 
 ---
 
-## Overview
+## Architecture
 
-```
+```text
 yak-ops
-├── 核心业务
-│   ├── yak-ops-domain
-│   └── yak-ops-application
-│
-├── 接口接入
-│   ├── yak-ops-web
-│   └── yak-ops-web-contract
-│
-├── 基础设施
-│   ├── yak-ops-infrastructure
-│   ├── yak-ops-dao
-│   └── yak-ops-common
-│
-├── 插件体系
-│   ├── yak-ops-plugin-spi
-│   ├── yak-ops-datasource-plugins
-│   ├── yak-ops-engine-*
-│   ├── yak-ops-alarm-plugins
-│   └── yak-ops-persistence-plugins
-│
-├── 应用装配
-│   ├── yak-ops-boot
-│   └── yak-ops-dist
-│
-├── 前端
-│   └── yak-ops-ui
-│
-└── 依赖管理
-    └── yak-ops-bom
+├── yak-ops-bom
+├── yak-ops-common
+├── yak-ops-spi
+├── yak-ops-core
+├── yak-ops-business
+│   └── io.yak.ops.business
+│       ├── datasource
+│       ├── job
+│       ├── workflow
+│       ├── quality
+│       └── resource
+├── yak-ops-plugins
+│   └── yak-ops-plugin-database
+├── yak-ops-boot
+├── yak-ops-ui
+└── yak-ops-dist
 ```
+
+### Dependency direction
+
+```text
+business -> core -> spi -> common
+plugin-database -> spi -> common
+boot -> business + plugin-database
+dist -> boot
+```
+
+`yak-framework` is consumed as a second-party dependency through dependency management.
+It provides shared security, scheduling, file storage and cross-project common contracts.
+
+Business capabilities start as vertical packages in `yak-ops-business`. A domain should only be
+promoted to an independent Maven module after it develops an independent model, lifecycle,
+dependency set or release boundary.

--- a/pom.xml
+++ b/pom.xml
@@ -1,36 +1,153 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.3.13</version>
+        <relativePath/>
+    </parent>
+
     <groupId>io.yak.ops</groupId>
     <artifactId>yak-ops</artifactId>
     <version>1.0.0</version>
     <packaging>pom</packaging>
+
     <name>Yak Ops</name>
+    <description>Yak Ops unified parent and reactor build</description>
+
     <properties>
-        <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
-        <maven-assembly-plugin.version>3.3.0</maven-assembly-plugin.version>
-        <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
-        <maven-javadoc-plugin.version>2.10.3</maven-javadoc-plugin.version>
-        <maven-source-plugin.version>2.4</maven-source-plugin.version>
-        <maven-surefire-plugin.version>3.0.0-M6</maven-surefire-plugin.version>
-        <maven-dependency-plugin.version>3.1.1</maven-dependency-plugin.version>
-        <maven-shade-plugin.version>3.2.1</maven-shade-plugin.version>
-        <exec-maven-plugin.version>3.5.0</exec-maven-plugin.version>
-        <spring-boot-maven-plugin.version>2.7.18</spring-boot-maven-plugin.version>
-        <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
-        <java.version>8</java.version>
+        <java.version>21</java.version>
+        <maven.compiler.release>${java.version}</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <file_encoding>UTF-8</file_encoding>
-        <architecture.check.skip>false</architecture.check.skip>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <yak-framework.version>1.0.0-SNAPSHOT</yak-framework.version>
+        <maven-assembly-plugin.version>3.7.1</maven-assembly-plugin.version>
+        <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
+        <maven-enforcer-plugin.version>3.5.0</maven-enforcer-plugin.version>
+        <maven-release-plugin.version>3.1.1</maven-release-plugin.version>
+        <maven-surefire-plugin.version>3.5.3</maven-surefire-plugin.version>
     </properties>
 
     <modules>
-
+        <module>yak-ops-bom</module>
+        <module>yak-ops-common</module>
+        <module>yak-ops-spi</module>
+        <module>yak-ops-core</module>
+        <module>yak-ops-business</module>
+        <module>yak-ops-plugins/yak-ops-plugin-database</module>
+        <module>yak-ops-boot</module>
         <module>yak-ops-ui</module>
         <module>yak-ops-dist</module>
     </modules>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.yak.framework</groupId>
+                <artifactId>yak-framework-parent</artifactId>
+                <version>${yak-framework.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.yak.framework</groupId>
+                <artifactId>yak-common</artifactId>
+                <version>${yak-framework.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.yak.framework</groupId>
+                <artifactId>yak-security-spring-boot-starter</artifactId>
+                <version>${yak-framework.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.yak.framework</groupId>
+                <artifactId>yak-schedule-spring-boot-starter</artifactId>
+                <version>${yak-framework.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.yak.framework</groupId>
+                <artifactId>yak-file</artifactId>
+                <version>${yak-framework.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.yak.ops</groupId>
+                <artifactId>yak-ops-common</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.yak.ops</groupId>
+                <artifactId>yak-ops-spi</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.yak.ops</groupId>
+                <artifactId>yak-ops-core</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.yak.ops</groupId>
+                <artifactId>yak-ops-business</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.yak.ops</groupId>
+                <artifactId>yak-ops-plugin-database</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.yak.ops</groupId>
+                <artifactId>yak-ops-boot</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>${maven-compiler-plugin.version}</version>
+                    <configuration>
+                        <release>${java.version}</release>
+                        <parameters>true</parameters>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>${maven-surefire-plugin.version}</version>
+                    <configuration>
+                        <useModulePath>false</useModulePath>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>${maven-enforcer-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>enforce-build-environment</id>
+                        <goals><goal>enforce</goal></goals>
+                        <configuration>
+                            <rules>
+                                <requireJavaVersion><version>[21,22)</version></requireJavaVersion>
+                                <requireMavenVersion><version>[3.9,)</version></requireMavenVersion>
+                                <dependencyConvergence/>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/yak-ops-bom/pom.xml
+++ b/yak-ops-bom/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.yak.ops</groupId>
+        <artifactId>yak-ops</artifactId>
+        <version>1.0.0</version>
+    </parent>
+    <artifactId>yak-ops-bom</artifactId>
+    <packaging>pom</packaging>
+    <name>Yak Ops BOM</name>
+    <description>Yak Ops and Yak Framework dependency alignment</description>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.yak.framework</groupId>
+                <artifactId>yak-framework-parent</artifactId>
+                <version>${yak-framework.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency><groupId>io.yak.framework</groupId><artifactId>yak-common</artifactId><version>${yak-framework.version}</version></dependency>
+            <dependency><groupId>io.yak.framework</groupId><artifactId>yak-security-spring-boot-starter</artifactId><version>${yak-framework.version}</version></dependency>
+            <dependency><groupId>io.yak.framework</groupId><artifactId>yak-schedule-spring-boot-starter</artifactId><version>${yak-framework.version}</version></dependency>
+            <dependency><groupId>io.yak.framework</groupId><artifactId>yak-file</artifactId><version>${yak-framework.version}</version></dependency>
+            <dependency><groupId>io.yak.ops</groupId><artifactId>yak-ops-common</artifactId><version>${project.version}</version></dependency>
+            <dependency><groupId>io.yak.ops</groupId><artifactId>yak-ops-spi</artifactId><version>${project.version}</version></dependency>
+            <dependency><groupId>io.yak.ops</groupId><artifactId>yak-ops-core</artifactId><version>${project.version}</version></dependency>
+            <dependency><groupId>io.yak.ops</groupId><artifactId>yak-ops-business</artifactId><version>${project.version}</version></dependency>
+            <dependency><groupId>io.yak.ops</groupId><artifactId>yak-ops-plugin-database</artifactId><version>${project.version}</version></dependency>
+            <dependency><groupId>io.yak.ops</groupId><artifactId>yak-ops-boot</artifactId><version>${project.version}</version></dependency>
+        </dependencies>
+    </dependencyManagement>
+</project>

--- a/yak-ops-boot/pom.xml
+++ b/yak-ops-boot/pom.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.yak.ops</groupId>
+        <artifactId>yak-ops</artifactId>
+        <version>1.0.0</version>
+    </parent>
+    <artifactId>yak-ops-boot</artifactId>
+    <name>Yak Ops Boot</name>
+    <description>Yak Ops application assembly and Spring Boot entry module</description>
+    <dependencies>
+        <dependency><groupId>io.yak.ops</groupId><artifactId>yak-ops-business</artifactId></dependency>
+        <dependency><groupId>io.yak.ops</groupId><artifactId>yak-ops-plugin-database</artifactId></dependency>
+        <dependency><groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter</artifactId></dependency>
+    </dependencies>
+</project>

--- a/yak-ops-boot/src/main/java/io/yak/ops/boot/config/package-info.java
+++ b/yak-ops-boot/src/main/java/io/yak/ops/boot/config/package-info.java
@@ -1,0 +1,2 @@
+/** Final Spring Boot assembly and module wiring configuration. */
+package io.yak.ops.boot.config;

--- a/yak-ops-boot/src/main/java/io/yak/ops/boot/health/package-info.java
+++ b/yak-ops-boot/src/main/java/io/yak/ops/boot/health/package-info.java
@@ -1,0 +1,2 @@
+/** Application health and runtime readiness integration points. */
+package io.yak.ops.boot.health;

--- a/yak-ops-boot/src/main/java/io/yak/ops/boot/package-info.java
+++ b/yak-ops-boot/src/main/java/io/yak/ops/boot/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Final application assembly, auto-configuration and runtime entry concerns for Yak Ops.
+ */
+package io.yak.ops.boot;

--- a/yak-ops-business/pom.xml
+++ b/yak-ops-business/pom.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.yak.ops</groupId>
+        <artifactId>yak-ops</artifactId>
+        <version>1.0.0</version>
+    </parent>
+    <artifactId>yak-ops-business</artifactId>
+    <name>Yak Ops Business</name>
+    <description>Vertical business capabilities for datasource, job, workflow, quality and resource management</description>
+    <dependencies>
+        <dependency><groupId>io.yak.ops</groupId><artifactId>yak-ops-core</artifactId></dependency>
+        <dependency><groupId>io.yak.framework</groupId><artifactId>yak-security-spring-boot-starter</artifactId></dependency>
+        <dependency><groupId>io.yak.framework</groupId><artifactId>yak-schedule-spring-boot-starter</artifactId></dependency>
+        <dependency><groupId>io.yak.framework</groupId><artifactId>yak-file</artifactId></dependency>
+    </dependencies>
+</project>

--- a/yak-ops-business/src/main/java/io/yak/ops/business/datasource/package-info.java
+++ b/yak-ops-business/src/main/java/io/yak/ops/business/datasource/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Datasource registration, configuration, metadata and connectivity business capabilities.
+ */
+package io.yak.ops.business.datasource;

--- a/yak-ops-business/src/main/java/io/yak/ops/business/job/package-info.java
+++ b/yak-ops-business/src/main/java/io/yak/ops/business/job/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * SeaTunnel job definition, publication, execution and operation business capabilities.
+ */
+package io.yak.ops.business.job;

--- a/yak-ops-business/src/main/java/io/yak/ops/business/package-info.java
+++ b/yak-ops-business/src/main/java/io/yak/ops/business/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * Yak Ops product business capabilities organized as vertical domains.
+ *
+ * <p>Domains remain packages in this module until their size and lifecycle justify independent
+ * Maven modules.
+ */
+package io.yak.ops.business;

--- a/yak-ops-business/src/main/java/io/yak/ops/business/quality/package-info.java
+++ b/yak-ops-business/src/main/java/io/yak/ops/business/quality/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Data-quality rules, executions, results, scoring and report capabilities.
+ */
+package io.yak.ops.business.quality;

--- a/yak-ops-business/src/main/java/io/yak/ops/business/resource/package-info.java
+++ b/yak-ops-business/src/main/java/io/yak/ops/business/resource/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Business resource catalog, versions, references and lifecycle capabilities.
+ *
+ * <p>Physical file storage is provided by {@code yak-framework}'s file abstraction.
+ */
+package io.yak.ops.business.resource;

--- a/yak-ops-business/src/main/java/io/yak/ops/business/workflow/package-info.java
+++ b/yak-ops-business/src/main/java/io/yak/ops/business/workflow/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Workflow definition, DAG orchestration, instances, retries and node lifecycle capabilities.
+ */
+package io.yak.ops.business.workflow;

--- a/yak-ops-common/pom.xml
+++ b/yak-ops-common/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.yak.ops</groupId>
+        <artifactId>yak-ops</artifactId>
+        <version>1.0.0</version>
+    </parent>
+    <artifactId>yak-ops-common</artifactId>
+    <name>Yak Ops Common</name>
+    <description>Yak Ops product-specific shared contracts and value objects</description>
+    <dependencies>
+        <dependency><groupId>io.yak.framework</groupId><artifactId>yak-common</artifactId></dependency>
+    </dependencies>
+</project>

--- a/yak-ops-common/src/main/java/io/yak/ops/common/constant/package-info.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/constant/package-info.java
@@ -1,0 +1,2 @@
+/** Yak Ops product-specific constants. */
+package io.yak.ops.common.constant;

--- a/yak-ops-common/src/main/java/io/yak/ops/common/enums/package-info.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/enums/package-info.java
@@ -1,0 +1,2 @@
+/** Yak Ops product-specific enumerations. */
+package io.yak.ops.common.enums;

--- a/yak-ops-common/src/main/java/io/yak/ops/common/model/package-info.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/model/package-info.java
@@ -1,0 +1,2 @@
+/** Shared Yak Ops value objects and lightweight product contracts. */
+package io.yak.ops.common.model;

--- a/yak-ops-common/src/main/java/io/yak/ops/common/package-info.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * Product-specific shared contracts, constants and value objects for Yak Ops.
+ *
+ * <p>Cross-project infrastructure contracts belong to {@code yak-framework}; this package only
+ * contains concepts owned by Yak Ops.
+ */
+package io.yak.ops.common;

--- a/yak-ops-common/src/main/java/io/yak/ops/common/util/package-info.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/util/package-info.java
@@ -1,0 +1,2 @@
+/** Small stateless helpers owned by Yak Ops. */
+package io.yak.ops.common.util;

--- a/yak-ops-core/pom.xml
+++ b/yak-ops-core/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.yak.ops</groupId>
+        <artifactId>yak-ops</artifactId>
+        <version>1.0.0</version>
+    </parent>
+    <artifactId>yak-ops-core</artifactId>
+    <name>Yak Ops Core</name>
+    <description>Plugin registry, runtime coordination and execution mechanisms</description>
+    <dependencies>
+        <dependency><groupId>io.yak.ops</groupId><artifactId>yak-ops-spi</artifactId></dependency>
+    </dependencies>
+</project>

--- a/yak-ops-core/src/main/java/io/yak/ops/core/config/package-info.java
+++ b/yak-ops-core/src/main/java/io/yak/ops/core/config/package-info.java
@@ -1,0 +1,2 @@
+/** Core runtime configuration contracts and defaults. */
+package io.yak.ops.core.config;

--- a/yak-ops-core/src/main/java/io/yak/ops/core/datasource/package-info.java
+++ b/yak-ops-core/src/main/java/io/yak/ops/core/datasource/package-info.java
@@ -1,0 +1,2 @@
+/** Datasource runtime access, connection coordination and metadata mechanisms. */
+package io.yak.ops.core.datasource;

--- a/yak-ops-core/src/main/java/io/yak/ops/core/engine/package-info.java
+++ b/yak-ops-core/src/main/java/io/yak/ops/core/engine/package-info.java
@@ -1,0 +1,2 @@
+/** SeaTunnel engine coordination and client runtime mechanisms. */
+package io.yak.ops.core.engine;

--- a/yak-ops-core/src/main/java/io/yak/ops/core/execution/package-info.java
+++ b/yak-ops-core/src/main/java/io/yak/ops/core/execution/package-info.java
@@ -1,0 +1,2 @@
+/** Generic execution context, lifecycle and listener mechanisms. */
+package io.yak.ops.core.execution;

--- a/yak-ops-core/src/main/java/io/yak/ops/core/package-info.java
+++ b/yak-ops-core/src/main/java/io/yak/ops/core/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Stable runtime mechanisms for plugin registration, execution and engine coordination.
+ *
+ * <p>Product-facing CRUD and workflow rules belong to business modules.
+ */
+package io.yak.ops.core;

--- a/yak-ops-core/src/main/java/io/yak/ops/core/plugin/package-info.java
+++ b/yak-ops-core/src/main/java/io/yak/ops/core/plugin/package-info.java
@@ -1,0 +1,2 @@
+/** Plugin discovery, registration and lifecycle runtime mechanisms. */
+package io.yak.ops.core.plugin;

--- a/yak-ops-plugins/yak-ops-plugin-database/pom.xml
+++ b/yak-ops-plugins/yak-ops-plugin-database/pom.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.yak.ops</groupId>
+        <artifactId>yak-ops</artifactId>
+        <version>1.0.0</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+    <artifactId>yak-ops-plugin-database</artifactId>
+    <name>Yak Ops Database Plugin</name>
+    <description>Database plugin implementations behind the Yak Ops SPI</description>
+    <dependencies>
+        <dependency><groupId>io.yak.ops</groupId><artifactId>yak-ops-spi</artifactId></dependency>
+    </dependencies>
+</project>

--- a/yak-ops-plugins/yak-ops-plugin-database/src/main/java/io/yak/ops/plugin/database/jdbc/package-info.java
+++ b/yak-ops-plugins/yak-ops-plugin-database/src/main/java/io/yak/ops/plugin/database/jdbc/package-info.java
@@ -1,0 +1,2 @@
+/** Shared JDBC support used by concrete database plugins. */
+package io.yak.ops.plugin.database.jdbc;

--- a/yak-ops-plugins/yak-ops-plugin-database/src/main/java/io/yak/ops/plugin/database/mysql/package-info.java
+++ b/yak-ops-plugins/yak-ops-plugin-database/src/main/java/io/yak/ops/plugin/database/mysql/package-info.java
@@ -1,0 +1,2 @@
+/** MySQL database plugin implementation boundary. */
+package io.yak.ops.plugin.database.mysql;

--- a/yak-ops-plugins/yak-ops-plugin-database/src/main/java/io/yak/ops/plugin/database/oracle/package-info.java
+++ b/yak-ops-plugins/yak-ops-plugin-database/src/main/java/io/yak/ops/plugin/database/oracle/package-info.java
@@ -1,0 +1,2 @@
+/** Oracle database plugin implementation boundary. */
+package io.yak.ops.plugin.database.oracle;

--- a/yak-ops-plugins/yak-ops-plugin-database/src/main/java/io/yak/ops/plugin/database/package-info.java
+++ b/yak-ops-plugins/yak-ops-plugin-database/src/main/java/io/yak/ops/plugin/database/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Database plugin implementations isolated from Yak Ops business modules.
+ */
+package io.yak.ops.plugin.database;

--- a/yak-ops-plugins/yak-ops-plugin-database/src/main/java/io/yak/ops/plugin/database/postgresql/package-info.java
+++ b/yak-ops-plugins/yak-ops-plugin-database/src/main/java/io/yak/ops/plugin/database/postgresql/package-info.java
@@ -1,0 +1,2 @@
+/** PostgreSQL database plugin implementation boundary. */
+package io.yak.ops.plugin.database.postgresql;

--- a/yak-ops-plugins/yak-ops-plugin-database/src/main/java/io/yak/ops/plugin/database/sqlserver/package-info.java
+++ b/yak-ops-plugins/yak-ops-plugin-database/src/main/java/io/yak/ops/plugin/database/sqlserver/package-info.java
@@ -1,0 +1,2 @@
+/** SQL Server database plugin implementation boundary. */
+package io.yak.ops.plugin.database.sqlserver;

--- a/yak-ops-spi/pom.xml
+++ b/yak-ops-spi/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.yak.ops</groupId>
+        <artifactId>yak-ops</artifactId>
+        <version>1.0.0</version>
+    </parent>
+    <artifactId>yak-ops-spi</artifactId>
+    <name>Yak Ops SPI</name>
+    <description>Stable extension contracts for Yak Ops plugins</description>
+    <dependencies>
+        <dependency><groupId>io.yak.ops</groupId><artifactId>yak-ops-common</artifactId></dependency>
+    </dependencies>
+</project>

--- a/yak-ops-spi/src/main/java/io/yak/ops/spi/database/package-info.java
+++ b/yak-ops-spi/src/main/java/io/yak/ops/spi/database/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Database capability contracts exposed to database plugin implementations.
+ */
+package io.yak.ops.spi.database;

--- a/yak-ops-spi/src/main/java/io/yak/ops/spi/package-info.java
+++ b/yak-ops-spi/src/main/java/io/yak/ops/spi/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Stable extension contracts implemented by Yak Ops plugins.
+ *
+ * <p>SPI packages must not depend on core runtime or business modules.
+ */
+package io.yak.ops.spi;


### PR DESCRIPTION
## What changed

- align the root build with Java 21 and Spring Boot 3.3.13
- add `yak-ops-bom` and manage Yak Framework `1.0.0-SNAPSHOT` dependencies
- add the initial backend module chain:
  - `yak-ops-common`
  - `yak-ops-spi`
  - `yak-ops-core`
  - `yak-ops-business`
  - `yak-ops-plugin-database`
  - `yak-ops-boot`
- keep workflow, data quality and resource management as vertical packages inside `yak-ops-business`
- add package boundaries for common contracts, SPI, core runtime mechanisms, database implementations and boot assembly
- document the module tree and dependency direction in the README

## Why

Yak Ops needs a stable backend skeleton before business implementation starts. This structure keeps the initial module count small while preserving clear boundaries for future workflow, data-quality and resource-management growth.

The dependency direction is intentionally one-way:

```text
business -> core -> spi -> common
plugin-database -> spi -> common
boot -> business + plugin-database
dist -> boot
```

## Impact

- no concrete business classes or runtime behavior are introduced
- future features should be implemented under the prepared vertical business packages
- database implementations remain isolated behind the SPI boundary
- shared security, scheduling, file and common capabilities are expected to come from `yak-framework`

## Validation

- verified the branch is based directly on current `main` and is not behind
- reviewed the complete changed-file list and dependency direction
- parsed all newly generated POM files as valid XML locally
- Maven execution was not available in the current environment because the Maven CLI is not installed

## Integration note

`io.yak.framework:*:1.0.0-SNAPSHOT` must be installed locally or published to the configured internal Maven repository before a full reactor build can resolve the framework dependencies.
