### PR TITLE
fix(build): provide yak-framework revision during Maven builds

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,1 @@
+-Drevision=1.0.0-SNAPSHOT


### PR DESCRIPTION
## What changed

- add `.mvn/maven.config`
- provide `-Drevision=1.0.0-SNAPSHOT` automatically for every Maven invocation in this repository

## Why

The locally installed `yak-framework` child POMs currently retain this parent version:

```xml
<version>${revision}</version>
```

When Yak Ops resolves `io.yak.framework:yak-common:1.0.0-SNAPSHOT`, Maven also needs the `revision` user property while building the external artifact model. Without it, Maven tries to resolve the literal coordinate:

```text
io.yak.framework:yak-framework-parent:pom:${revision}
```

and the reactor stops at `yak-ops-common`.

## Impact

After this change, normal project commands automatically receive the required property:

```bash
mvn clean package
mvn clean install
```

This does not change Yak Ops module dependencies, BOM entries, package names, or business code.

## Validation

- branch is based on the current `main` commit and is not behind
- diff contains one new project-level Maven configuration file
- effective Maven argument is equivalent to running `mvn ... -Drevision=1.0.0-SNAPSHOT`

## Follow-up

This is a consumer-side compatibility fix. Once `yak-framework` publishes flattened consumer POMs with resolved versions, this Maven property can be removed from Yak Ops.