### PR TITLE
revert(build): remove ineffective framework revision workaround

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,1 +1,0 @@
--Drevision=1.0.0-SNAPSHOT


### PR DESCRIPTION
## What changed

- remove `.mvn/maven.config`
- stop injecting `-Drevision=1.0.0-SNAPSHOT` into Yak Ops Maven builds

## Why

The setting does not repair external `yak-framework` POMs that were already installed with an unresolved parent version (`${revision}`). Maven still fails while reading the dependency descriptor before Yak Ops modules can compile.

The correct fix is in Yak Framework: publish flattened consumer POMs during `install` and `deploy` so external projects receive concrete versions.

Related fix: `weifuwan/yak-framework#65`.

## Impact

- removes a misleading consumer-side workaround
- keeps Yak Ops build configuration clean
- no module dependency, Java code, BOM, or runtime behavior changes

## Validation

- branch is based on current `main` and is not behind
- diff removes only one Maven configuration line

## Merge order

Merge the Yak Framework flattening fix first, reinstall Yak Framework locally, then merge this cleanup PR.