### PR TITLE
feat(boot): add runnable Yak Ops application baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Install `yak-framework:1.0.0-SNAPSHOT` into the same Maven local repository firs
 
 ```bash
 mvn clean package -DskipTests
-mvn -pl yak-ops-boot -am spring-boot:run
+java -jar yak-ops-boot/target/yak-ops-boot-1.0.0.jar
 ```
 
 The runnable baseline does not require an external database. Verify the application and the

--- a/README.md
+++ b/README.md
@@ -42,6 +42,25 @@
 
 ---
 
+## Quick start
+
+Install `yak-framework:1.0.0-SNAPSHOT` into the same Maven local repository first, then run:
+
+```bash
+mvn clean package -DskipTests
+mvn -pl yak-ops-boot -am spring-boot:run
+```
+
+The runnable baseline does not require an external database. Verify the application and the
+Yak Framework unified response contract with:
+
+```bash
+curl http://localhost:8080/api/test/ping
+```
+
+The endpoint returns a successful `io.yak.framework.common.Result` response. Database-backed
+security and scheduling are disabled in `application.yml` until their infrastructure is configured.
+
 ## Architecture
 
 ```text

--- a/yak-ops-boot/pom.xml
+++ b/yak-ops-boot/pom.xml
@@ -67,13 +67,6 @@
                 <configuration>
                     <mainClass>io.yak.ops.boot.YakOpsApplication</mainClass>
                 </configuration>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>repackage</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/yak-ops-boot/pom.xml
+++ b/yak-ops-boot/pom.xml
@@ -50,7 +50,26 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter</artifactId>
+            <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <mainClass>io.yak.ops.boot.YakOpsApplication</mainClass>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/yak-ops-boot/pom.xml
+++ b/yak-ops-boot/pom.xml
@@ -52,6 +52,11 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/yak-ops-boot/src/main/java/io/yak/ops/boot/YakOpsApplication.java
+++ b/yak-ops-boot/src/main/java/io/yak/ops/boot/YakOpsApplication.java
@@ -1,0 +1,28 @@
+package io.yak.ops.boot;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration;
+
+/**
+ * Yak Ops application entry point.
+ *
+ * <p>The first runnable baseline starts without an external database. Yak Framework remains on the
+ * classpath and its non-database extension beans are loaded, while database-backed security features
+ * are enabled later through configuration.</p>
+ */
+@SpringBootApplication(
+        scanBasePackages = "io.yak.ops",
+        exclude = {
+            DataSourceAutoConfiguration.class,
+            DataSourceTransactionManagerAutoConfiguration.class,
+            FlywayAutoConfiguration.class
+        })
+public class YakOpsApplication {
+
+  public static void main(String[] args) {
+    SpringApplication.run(YakOpsApplication.class, args);
+  }
+}

--- a/yak-ops-boot/src/main/java/io/yak/ops/boot/YakOpsApplication.java
+++ b/yak-ops-boot/src/main/java/io/yak/ops/boot/YakOpsApplication.java
@@ -2,24 +2,14 @@ package io.yak.ops.boot;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration;
-import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
-import org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration;
 
 /**
  * Yak Ops application entry point.
  *
- * <p>The first runnable baseline starts without an external database. Yak Framework remains on the
- * classpath and its non-database extension beans are loaded, while database-backed security features
- * are enabled later through configuration.</p>
+ * <p>Yak Ops modules are scanned from their shared root package. Yak Framework integrations are
+ * loaded through their Spring Boot auto-configuration metadata.</p>
  */
-@SpringBootApplication(
-        scanBasePackages = "io.yak.ops",
-        exclude = {
-            DataSourceAutoConfiguration.class,
-            DataSourceTransactionManagerAutoConfiguration.class,
-            FlywayAutoConfiguration.class
-        })
+@SpringBootApplication(scanBasePackages = "io.yak.ops")
 public class YakOpsApplication {
 
   public static void main(String[] args) {

--- a/yak-ops-boot/src/main/java/io/yak/ops/boot/controller/TestController.java
+++ b/yak-ops-boot/src/main/java/io/yak/ops/boot/controller/TestController.java
@@ -1,0 +1,32 @@
+package io.yak.ops.boot.controller;
+
+import io.yak.framework.common.Result;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Simple endpoint used to verify the Yak Ops and Yak Framework integration. */
+@RestController
+@RequestMapping("/api/test")
+public class TestController {
+
+  private final String applicationName;
+
+  public TestController(@Value("${spring.application.name:yak-ops}") String applicationName) {
+    this.applicationName = applicationName;
+  }
+
+  @GetMapping("/ping")
+  public Result<Map<String, Object>> ping() {
+    Map<String, Object> data = new LinkedHashMap<>();
+    data.put("application", applicationName);
+    data.put("status", "UP");
+    data.put("framework", "yak-framework");
+    data.put("timestamp", Instant.now().toString());
+    return Result.success(data);
+  }
+}

--- a/yak-ops-boot/src/main/resources/application.yml
+++ b/yak-ops-boot/src/main/resources/application.yml
@@ -5,6 +5,11 @@ server:
 spring:
   application:
     name: yak-ops
+  autoconfigure:
+    exclude:
+      - org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
+      - org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration
+      - org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration
   lifecycle:
     timeout-per-shutdown-phase: 20s
   jackson:

--- a/yak-ops-boot/src/main/resources/application.yml
+++ b/yak-ops-boot/src/main/resources/application.yml
@@ -1,0 +1,36 @@
+server:
+  port: ${SERVER_PORT:8080}
+  shutdown: graceful
+
+spring:
+  application:
+    name: yak-ops
+  lifecycle:
+    timeout-per-shutdown-phase: 20s
+  jackson:
+    default-property-inclusion: non_null
+    time-zone: Asia/Shanghai
+  quartz:
+    auto-startup: false
+
+# Runnable baseline: load Yak Framework while keeping external infrastructure optional.
+yak:
+  security:
+    enabled: true
+    application-name: ${spring.application.name}
+    database-enabled: false
+    web-enabled: false
+    authentication-enabled: false
+    audit-enabled: false
+    permission-registration:
+      enabled: false
+    bootstrap:
+      enabled: false
+  schedule:
+    enabled: false
+    web-enabled: false
+
+logging:
+  level:
+    root: INFO
+    io.yak: INFO

--- a/yak-ops-boot/src/test/java/io/yak/ops/boot/YakOpsApplicationTests.java
+++ b/yak-ops-boot/src/test/java/io/yak/ops/boot/YakOpsApplicationTests.java
@@ -1,0 +1,28 @@
+package io.yak.ops.boot;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest(classes = YakOpsApplication.class)
+@AutoConfigureMockMvc
+class YakOpsApplicationTests {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Test
+  void testControllerShouldReturnFrameworkResult() throws Exception {
+    mockMvc.perform(get("/api/test/ping"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data.application").value("yak-ops"))
+        .andExpect(jsonPath("$.data.status").value("UP"))
+        .andExpect(jsonPath("$.data.framework").value("yak-framework"));
+  }
+}


### PR DESCRIPTION
## What changed

- add `io.yak.ops.boot.YakOpsApplication` as the Spring Boot entry point
- scan the shared `io.yak.ops` root package so controllers and future business components across modules are discovered
- add `application.yml` with a no-database runnable baseline
- keep Yak Security Starter enabled while disabling its database-backed endpoints, authentication and audit features
- disable Yak Schedule startup until scheduling infrastructure is configured
- add `TestController` at `GET /api/test/ping`
- return the test response through `io.yak.framework.common.Result`
- configure `yak-ops-boot` as an executable Spring Boot Jar
- add a MockMvc integration test that loads the application context and verifies the test endpoint
- document package, startup and curl verification commands in the README

## Why

The modular structure now needs a concrete runtime assembly that proves Yak Ops can start with Yak Framework on the classpath before database and scheduling infrastructure are introduced.

The initial configuration intentionally starts without an external database. Generic Spring Boot datasource, transaction-manager and Flyway auto-configuration are excluded through `application.yml`, while Yak Framework remains integrated through its Spring Boot auto-configuration metadata.

## Endpoint

```http
GET /api/test/ping
```

Expected response shape:

```json
{
  "code": 200,
  "message": "成功",
  "data": {
    "application": "yak-ops",
    "status": "UP",
    "framework": "yak-framework",
    "timestamp": "..."
  }
}
```

The exact success code and message come from Yak Framework's `Result.success(...)` contract.

## Run locally

Install `yak-framework:1.0.0-SNAPSHOT` into the same Maven local repository first, then run:

```bat
mvn clean package -DskipTests
java -jar yak-ops-boot\target\yak-ops-boot-1.0.0.jar
```

Verify:

```bat
curl http://localhost:8080/api/test/ping
```

Run the integration test with:

```bat
mvn -pl yak-ops-boot -am test
```

## Validation

- branch is based on the current `main` and is not behind
- verified Yak Security and Yak Schedule are loaded through their `AutoConfiguration.imports` metadata
- verified the disabled security properties match the current Yak Framework configuration model
- reviewed Boot dependency, plugin, controller and configuration alignment
- the execution environment has Java 21, but Maven is unavailable and outbound repository access is blocked, so a full Maven build could not be executed here

## Merge note

The connector creates fine-grained commits. Prefer **Squash and merge**.