### PR TITLE
feat(security): enable database-backed security and Swagger APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,8 @@ http://localhost:8080/swagger-ui.html
 
 Use the API group selector to switch between:
 
-- `Yak Ops`: `/v3/api-docs/yak-ops`
-- `Yak Security`: `/v3/api-docs/yak-security`
+- `yak-ops`: `/v3/api-docs/yak-ops`
+- `yak-security`: `/v3/api-docs/yak-security`
 
 The login endpoint is public:
 
@@ -117,8 +117,8 @@ POST /yak-security/api/v1/account/login
 Content-Type: application/json
 
 {
-  "username": "root",
-  "password": "Root@123456"
+  "userName": "root",
+  "pw": "Root@123456"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -44,22 +44,86 @@
 
 ## Quick start
 
-Install `yak-framework:1.0.0-SNAPSHOT` into the same Maven local repository first, then run:
+Install `yak-framework:1.0.0-SNAPSHOT` into the same Maven local repository first.
+
+Create the Yak Security database before starting the application:
+
+```sql
+CREATE DATABASE yak_security
+  DEFAULT CHARACTER SET utf8mb4
+  COLLATE utf8mb4_unicode_ci;
+```
+
+The same statement is available in `scripts/database/create-yak-security-database.sql`.
+
+The default local connection is:
+
+```text
+URL:      jdbc:mariadb://127.0.0.1:3306/yak_security
+Username: root
+Password: 123456
+```
+
+Override any value with environment variables when needed:
+
+```text
+YAK_SECURITY_DATASOURCE_URL
+YAK_SECURITY_DATASOURCE_USERNAME
+YAK_SECURITY_DATASOURCE_PASSWORD
+YAK_SECURITY_APPLICATION_NAME
+YAK_SECURITY_BOOTSTRAP_USERNAME
+YAK_SECURITY_BOOTSTRAP_PASSWORD
+YAK_SECURITY_BOOTSTRAP_REAL_NAME
+```
+
+Build and start:
 
 ```bash
 mvn clean package -DskipTests
 java -jar yak-ops-boot/target/yak-ops-boot-1.0.0.jar
 ```
 
-The runnable baseline does not require an external database. Verify the application and the
-Yak Framework unified response contract with:
+Yak Security runs its own Flyway migration against the dedicated security DataSource. On an empty
+database it also creates the initial administrator configured in `application.yml`:
+
+```text
+Username: root
+Password: Root@123456
+```
+
+Change the bootstrap password through `YAK_SECURITY_BOOTSTRAP_PASSWORD` outside local development.
+
+Verify the application:
 
 ```bash
 curl http://localhost:8080/api/test/ping
 ```
 
-The endpoint returns a successful `io.yak.framework.common.Result` response. Database-backed
-security and scheduling are disabled in `application.yml` until their infrastructure is configured.
+Swagger UI is available at:
+
+```text
+http://localhost:8080/swagger-ui.html
+```
+
+Use the API group selector to switch between:
+
+- `Yak Ops`: `/v3/api-docs/yak-ops`
+- `Yak Security`: `/v3/api-docs/yak-security`
+
+The login endpoint is public:
+
+```http
+POST /yak-security/api/v1/account/login
+Content-Type: application/json
+
+{
+  "username": "root",
+  "password": "Root@123456"
+}
+```
+
+After login, the same-origin Swagger UI keeps the HTTP session cookie and can invoke protected
+Security APIs directly.
 
 ## Architecture
 

--- a/scripts/database/create-yak-security-database.sql
+++ b/scripts/database/create-yak-security-database.sql
@@ -1,0 +1,3 @@
+CREATE DATABASE IF NOT EXISTS yak_security
+  DEFAULT CHARACTER SET utf8mb4
+  COLLATE utf8mb4_unicode_ci;

--- a/yak-ops-boot/src/main/java/io/yak/ops/boot/config/OpenApiConfiguration.java
+++ b/yak-ops-boot/src/main/java/io/yak/ops/boot/config/OpenApiConfiguration.java
@@ -25,7 +25,6 @@ public class OpenApiConfiguration {
   public GroupedOpenApi yakOpsApiGroup() {
     return GroupedOpenApi.builder()
         .group("yak-ops")
-        .displayName("Yak Ops")
         .pathsToMatch("/api/**")
         .build();
   }
@@ -34,7 +33,6 @@ public class OpenApiConfiguration {
   public GroupedOpenApi yakSecurityApiGroup() {
     return GroupedOpenApi.builder()
         .group("yak-security")
-        .displayName("Yak Security")
         .pathsToMatch("/yak-security/api/**")
         .build();
   }

--- a/yak-ops-boot/src/main/java/io/yak/ops/boot/config/OpenApiConfiguration.java
+++ b/yak-ops-boot/src/main/java/io/yak/ops/boot/config/OpenApiConfiguration.java
@@ -1,0 +1,41 @@
+package io.yak.ops.boot.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springdoc.core.models.GroupedOpenApi;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * OpenAPI grouping for Yak Ops and the APIs contributed by Yak Framework.
+ */
+@Configuration(proxyBeanMethods = false)
+public class OpenApiConfiguration {
+
+  @Bean
+  public OpenAPI yakOpsOpenApi() {
+    return new OpenAPI()
+        .info(new Info()
+            .title("Yak Ops API")
+            .description("Yak Ops APIs and integrated Yak Framework capabilities")
+            .version("1.0.0"));
+  }
+
+  @Bean
+  public GroupedOpenApi yakOpsApiGroup() {
+    return GroupedOpenApi.builder()
+        .group("yak-ops")
+        .displayName("Yak Ops")
+        .pathsToMatch("/api/**")
+        .build();
+  }
+
+  @Bean
+  public GroupedOpenApi yakSecurityApiGroup() {
+    return GroupedOpenApi.builder()
+        .group("yak-security")
+        .displayName("Yak Security")
+        .pathsToMatch("/yak-security/api/**")
+        .build();
+  }
+}

--- a/yak-ops-boot/src/main/resources/application.yml
+++ b/yak-ops-boot/src/main/resources/application.yml
@@ -5,11 +5,14 @@ server:
 spring:
   application:
     name: yak-ops
+  # Yak Security owns its dedicated DataSource and transaction manager.
   autoconfigure:
     exclude:
       - org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
       - org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration
-      - org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration
+  # Yak Security creates and runs its own Flyway instance against its dedicated DataSource.
+  flyway:
+    enabled: false
   lifecycle:
     timeout-per-shutdown-phase: 20s
   jackson:
@@ -18,19 +21,60 @@ spring:
   quartz:
     auto-startup: false
 
-# Runnable baseline: load Yak Framework while keeping external infrastructure optional.
+springdoc:
+  api-docs:
+    enabled: true
+    path: /v3/api-docs
+  swagger-ui:
+    enabled: true
+    path: /swagger-ui.html
+    display-request-duration: true
+    groups-order: ASC
+    operations-sorter: alpha
+    tags-sorter: alpha
+
 yak:
   security:
     enabled: true
-    application-name: ${spring.application.name}
-    database-enabled: false
-    web-enabled: false
-    authentication-enabled: false
-    audit-enabled: false
+    database-enabled: true
+    web-enabled: true
+    authentication-enabled: true
+    audit-enabled: true
+    application-name: ${YAK_SECURITY_APPLICATION_NAME:${spring.application.name}}
+
+    # Keep startup verification and API documentation public. Other endpoints require login.
+    public-paths:
+      - /api/test/ping
+      - /yak-security/api/v1/account/login
+      - /yak-security/api/v1/common/heart
+      - /v3/api-docs/**
+      - /swagger-ui/**
+      - /swagger-ui.html
+
     permission-registration:
-      enabled: false
+      enabled: true
+
     bootstrap:
-      enabled: false
+      enabled: true
+      username: ${YAK_SECURITY_BOOTSTRAP_USERNAME:root}
+      password: ${YAK_SECURITY_BOOTSTRAP_PASSWORD:Root@123456}
+      real-name: ${YAK_SECURITY_BOOTSTRAP_REAL_NAME:系统管理员}
+
+    datasource:
+      enabled: true
+      url: ${YAK_SECURITY_DATASOURCE_URL:jdbc:mariadb://127.0.0.1:3306/yak_security?useUnicode=true&allowPublicKeyRetrieval=true&characterEncoding=UTF-8&useSSL=false&serverTimezone=Asia/Shanghai}
+      username: ${YAK_SECURITY_DATASOURCE_USERNAME:root}
+      password: ${YAK_SECURITY_DATASOURCE_PASSWORD:123456}
+      driver-class-name: org.mariadb.jdbc.Driver
+      initial-size: 1
+      min-idle: 1
+      max-active: 8
+      max-wait: 60000
+      validation-query: SELECT 1
+      test-while-idle: true
+      test-on-borrow: false
+      test-on-return: false
+
   schedule:
     enabled: false
     web-enabled: false
@@ -38,4 +82,6 @@ yak:
 logging:
   level:
     root: INFO
-    io.yak: INFO
+    io.yak.ops: INFO
+    io.yak.framework.security: DEBUG
+    org.flywaydb: INFO

--- a/yak-ops-boot/src/test/java/io/yak/ops/boot/YakOpsApplicationTests.java
+++ b/yak-ops-boot/src/test/java/io/yak/ops/boot/YakOpsApplicationTests.java
@@ -8,10 +8,12 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 @SpringBootTest(classes = YakOpsApplication.class)
 @AutoConfigureMockMvc
+@ActiveProfiles("test")
 class YakOpsApplicationTests {
 
   @Autowired
@@ -24,5 +26,12 @@ class YakOpsApplicationTests {
         .andExpect(jsonPath("$.data.application").value("yak-ops"))
         .andExpect(jsonPath("$.data.status").value("UP"))
         .andExpect(jsonPath("$.data.framework").value("yak-framework"));
+  }
+
+  @Test
+  void yakOpsOpenApiGroupShouldContainTestEndpoint() throws Exception {
+    mockMvc.perform(get("/v3/api-docs/yak-ops"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.paths['/api/test/ping']").exists());
   }
 }

--- a/yak-ops-boot/src/test/resources/application-test.yml
+++ b/yak-ops-boot/src/test/resources/application-test.yml
@@ -1,0 +1,23 @@
+spring:
+  autoconfigure:
+    exclude:
+      - org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
+      - org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration
+      - org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration
+  flyway:
+    enabled: false
+
+yak:
+  security:
+    enabled: true
+    database-enabled: false
+    web-enabled: false
+    authentication-enabled: false
+    audit-enabled: false
+    permission-registration:
+      enabled: false
+    bootstrap:
+      enabled: false
+  schedule:
+    enabled: false
+    web-enabled: false


### PR DESCRIPTION
## What changed

- enable Yak Security database, Web API, authentication, audit, permission registration and administrator bootstrap in `application.yml`
- configure the dedicated MariaDB DataSource through environment-overridable properties
- keep Spring Boot Flyway disabled because Yak Security creates and runs its own Flyway instance
- keep the host application's generic DataSource auto-configuration disabled so the Security starter owns its isolated DataSource and transaction manager
- explicitly keep the ping endpoint, login endpoint, health endpoint and Swagger resources public
- add `OpenApiConfiguration` with separate `yak-ops` and `yak-security` groups
- add a test profile that disables external database requirements during automated tests
- extend the Boot integration test to verify the `yak-ops` OpenAPI group
- add a database creation SQL script and document startup, bootstrap credentials, login payload and Swagger URLs

## Why

Yak Ops can already start with Yak Framework on the classpath, but the previous baseline deliberately disabled the Security database and Web interfaces. This change enables the complete Yak Security runtime against a real MariaDB database and makes its controllers visible and testable through Swagger UI.

The Security starter already supplies MariaDB JDBC, Druid, MyBatis-Plus, Flyway and Springdoc dependencies, so no duplicate dependency declarations are required in Yak Ops.

## Database

Create the database before startup:

```sql
CREATE DATABASE yak_security
  DEFAULT CHARACTER SET utf8mb4
  COLLATE utf8mb4_unicode_ci;
```

Default local connection:

```text
jdbc:mariadb://127.0.0.1:3306/yak_security
username: root
password: 123456
```

Yak Security runs migrations from its module-specific Flyway location and creates the initial administrator when the user table is empty.

Default local administrator:

```text
username: root
password: Root@123456
```

All credentials can be overridden through environment variables documented in the README.

## Swagger

Swagger UI:

```text
http://localhost:8080/swagger-ui.html
```

OpenAPI groups:

```text
/v3/api-docs/yak-ops
/v3/api-docs/yak-security
```

The `yak-security` group matches `/yak-security/api/**`, which includes the account, user, role, permission, resource, project, configuration, message and audit interfaces imported by the Yak Security starter.

Login request:

```json
{
  "userName": "root",
  "pw": "Root@123456"
}
```

## Testing

The `test` profile keeps database-backed Security disabled so regular Maven tests do not require a local MariaDB instance:

```bat
mvn -pl yak-ops-boot -am test
```

The integration test verifies both the framework-backed ping response and the `yak-ops` OpenAPI group.

## Validation

- branch is based on the current `main` commit and is not behind
- verified the Security starter includes MariaDB JDBC, Druid, MyBatis-Plus, Flyway and Springdoc
- verified Yak Security creates its own DataSource, transaction manager and Flyway migration instance
- verified Security Web auto-configuration imports the Security controllers when database and Web support are enabled
- verified login request fields against `AccountLoginDTO` (`userName`, `pw`)
- reviewed all YAML property names against the current Yak Security configuration model
- a full database startup could not be executed in the connector environment because no MariaDB service or Maven runtime is available

## Merge note

The connector creates fine-grained commits. Prefer **Squash and merge**.