### PR TITLE
fix(security): declare built-in permissions before bootstrap

### DIFF
--- a/yak-ops-boot/src/main/java/io/yak/ops/boot/config/YakOpsPermissionConfiguration.java
+++ b/yak-ops-boot/src/main/java/io/yak/ops/boot/config/YakOpsPermissionConfiguration.java
@@ -1,0 +1,88 @@
+package io.yak.ops.boot.config;
+
+import io.yak.framework.security.permission.PermissionDefinition;
+import io.yak.framework.security.permission.PermissionDefinitionProvider;
+import java.util.List;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Declares the built-in Yak Ops permission tree consumed by Yak Security.
+ *
+ * <p>The declarations are synchronized before the bootstrap administrator is created. This gives
+ * the initial administrator role a complete, deterministic permission set without coupling every
+ * business module directly to the security starter.</p>
+ */
+@Configuration(proxyBeanMethods = false)
+public class YakOpsPermissionConfiguration {
+
+  @Bean
+  public PermissionDefinitionProvider yakOpsPermissionDefinitionProvider() {
+    return () -> List.of(
+        datasourcePermissions(),
+        jobPermissions(),
+        workflowPermissions(),
+        qualityPermissions(),
+        resourcePermissions());
+  }
+
+  private static PermissionDefinition datasourcePermissions() {
+    return PermissionDefinition.of(
+        "datasource",
+        "数据源管理",
+        item("datasource:view", "查看数据源"),
+        item("datasource:create", "新增数据源"),
+        item("datasource:update", "编辑数据源"),
+        item("datasource:delete", "删除数据源"),
+        item("datasource:test", "测试数据源连接"));
+  }
+
+  private static PermissionDefinition jobPermissions() {
+    return PermissionDefinition.of(
+        "job",
+        "任务管理",
+        item("job:view", "查看任务"),
+        item("job:create", "新增任务"),
+        item("job:update", "编辑任务"),
+        item("job:delete", "删除任务"),
+        item("job:execute", "执行任务"),
+        item("job:stop", "停止任务"));
+  }
+
+  private static PermissionDefinition workflowPermissions() {
+    return PermissionDefinition.of(
+        "workflow",
+        "工作流管理",
+        item("workflow:view", "查看工作流"),
+        item("workflow:create", "新增工作流"),
+        item("workflow:update", "编辑工作流"),
+        item("workflow:delete", "删除工作流"),
+        item("workflow:execute", "执行工作流"));
+  }
+
+  private static PermissionDefinition qualityPermissions() {
+    return PermissionDefinition.of(
+        "quality",
+        "数据质量管理",
+        item("quality:view", "查看质量规则"),
+        item("quality:create", "新增质量规则"),
+        item("quality:update", "编辑质量规则"),
+        item("quality:delete", "删除质量规则"),
+        item("quality:execute", "执行质量检查"));
+  }
+
+  private static PermissionDefinition resourcePermissions() {
+    return PermissionDefinition.of(
+        "resource",
+        "资源管理",
+        item("resource:view", "查看资源"),
+        item("resource:upload", "上传资源"),
+        item("resource:download", "下载资源"),
+        item("resource:update", "编辑资源"),
+        item("resource:delete", "删除资源"));
+  }
+
+  private static PermissionDefinition.Item item(String code, String name) {
+    return PermissionDefinition.Item.of(code, name);
+  }
+}

--- a/yak-ops-boot/src/test/java/io/yak/ops/boot/YakOpsApplicationTests.java
+++ b/yak-ops-boot/src/test/java/io/yak/ops/boot/YakOpsApplicationTests.java
@@ -1,9 +1,11 @@
 package io.yak.ops.boot;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import io.yak.framework.security.permission.PermissionDefinitionProvider;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -19,6 +21,9 @@ class YakOpsApplicationTests {
   @Autowired
   private MockMvc mockMvc;
 
+  @Autowired
+  private PermissionDefinitionProvider permissionDefinitionProvider;
+
   @Test
   void testControllerShouldReturnFrameworkResult() throws Exception {
     mockMvc.perform(get("/api/test/ping"))
@@ -33,5 +38,12 @@ class YakOpsApplicationTests {
     mockMvc.perform(get("/v3/api-docs/yak-ops"))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.paths['/api/test/ping']").exists());
+  }
+
+  @Test
+  void shouldDeclarePermissionsBeforeSecurityBootstrap() {
+    assertThat(permissionDefinitionProvider.getPermissionDefinitions())
+        .extracting("code")
+        .containsExactly("datasource", "job", "workflow", "quality", "resource");
   }
 }


### PR DESCRIPTION
## What changed

- add `YakOpsPermissionConfiguration` in the Boot assembly
- declare five built-in permission groups for datasource, job, workflow, quality and resource management
- register the declarations through Yak Security's `PermissionDefinitionProvider`
- add an application-context test that verifies the permission provider exposes all five groups

## Why

Yak Security bootstrap only creates the first administrator after at least one built-in permission has been synchronized. Yak Ops enabled permission registration and administrator bootstrap, but did not declare any `PermissionDefinitionProvider` or `@YakPermission` values.

The database and Flyway migrations completed successfully, then bootstrap failed with:

```text
Cannot bootstrap Yak Security: no built-in permissions exist
```

The new declarations are discovered by `PermissionRegistrationInitializer`, synchronized into `yak_security_permission`, and then assigned to the initial administrator role by `YakSecurityBootstrapInitializer`.

## Declared groups

```text
datasource
job
workflow
quality
resource
```

Each group contains practical view/create/update/delete and domain-specific actions such as connection testing, execution, stopping, upload and download.

## Existing database

The failed startup did not create a user, so the database does not need to be deleted. After merging, restart the application against the same `yak_security` schema. Permission synchronization will insert the declarations before bootstrap creates the administrator.

## Local verification

```bat
mvn -pl yak-ops-boot -am test
mvn clean package -DskipTests
java -jar yak-ops-boot\target\yak-ops-boot-1.0.0.jar
```

Expected startup behavior:

1. Flyway validates/migrates the schema
2. declared permissions are synchronized
3. the administrator role is created and receives all declared permissions
4. the configured bootstrap user is created
5. the application remains running

## Validation

- branch is based on current `main` and is not behind
- fix is limited to the Boot assembly and its integration test
- follows Yak Security's intended `PermissionDefinitionProvider` extension point
- no database cleanup or manual permission inserts are required

## Merge note

Prefer **Squash and merge**.