### PR TITLE
fix(security): align backend permissions with frontend navigation

### DIFF
--- a/yak-ops-boot/src/main/java/io/yak/ops/boot/config/YakOpsAdministratorPermissionInitializer.java
+++ b/yak-ops-boot/src/main/java/io/yak/ops/boot/config/YakOpsAdministratorPermissionInitializer.java
@@ -1,0 +1,77 @@
+package io.yak.ops.boot.config;
+
+import io.yak.framework.security.common.entity.Permission;
+import io.yak.framework.security.common.vo.role.RoleBriefVO;
+import io.yak.framework.security.dao.PermissionDao;
+import io.yak.framework.security.service.RolePermissionService;
+import io.yak.framework.security.service.RoleService;
+import java.util.ArrayList;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.core.Ordered;
+
+/**
+ * Ensures the built-in administrator role owns the root permission.
+ *
+ * <p>This initializer is intentionally idempotent. It covers existing databases where the
+ * administrator was created before {@code security:root} became part of the Yak Ops permission
+ * contract. New installations already receive the permission through Yak Security bootstrap.</p>
+ */
+public final class YakOpsAdministratorPermissionInitializer
+    implements ApplicationRunner, Ordered {
+
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(YakOpsAdministratorPermissionInitializer.class);
+  private static final String ADMINISTRATOR_ROLE = "系统管理员";
+  private static final String ROOT_PERMISSION = "security:root";
+
+  private final RoleService roleService;
+  private final RolePermissionService rolePermissionService;
+  private final PermissionDao permissionDao;
+
+  public YakOpsAdministratorPermissionInitializer(
+      RoleService roleService,
+      RolePermissionService rolePermissionService,
+      PermissionDao permissionDao) {
+    this.roleService = roleService;
+    this.rolePermissionService = rolePermissionService;
+    this.permissionDao = permissionDao;
+  }
+
+  @Override
+  public int getOrder() {
+    return Ordered.LOWEST_PRECEDENCE;
+  }
+
+  @Override
+  public void run(ApplicationArguments args) {
+    RoleBriefVO administratorRole = roleService
+        .getRoleBriefListByRoleName(ADMINISTRATOR_ROLE)
+        .stream()
+        .findFirst()
+        .orElse(null);
+    if (administratorRole == null || administratorRole.getId() == null) {
+      return;
+    }
+
+    Permission rootPermission = permissionDao.selectAllAndAscOrderByLevel()
+        .stream()
+        .filter(permission -> ROOT_PERMISSION.equals(permission.getPermissionCode()))
+        .findFirst()
+        .orElseThrow(() -> new IllegalStateException(
+            "Cannot grant Yak Ops administrator permission: security:root is not declared"));
+
+    List<Long> permissionIds = new ArrayList<>(
+        rolePermissionService.getPermissionIdListByRoleId(administratorRole.getId()));
+    if (permissionIds.contains(rootPermission.getId())) {
+      return;
+    }
+
+    permissionIds.add(rootPermission.getId());
+    rolePermissionService.updateRolePermission(administratorRole.getId(), permissionIds);
+    LOGGER.info("Granted '{}' to Yak Security role '{}'", ROOT_PERMISSION, ADMINISTRATOR_ROLE);
+  }
+}

--- a/yak-ops-boot/src/main/java/io/yak/ops/boot/config/YakOpsPermissionConfiguration.java
+++ b/yak-ops-boot/src/main/java/io/yak/ops/boot/config/YakOpsPermissionConfiguration.java
@@ -2,16 +2,19 @@ package io.yak.ops.boot.config;
 
 import io.yak.framework.security.permission.PermissionDefinition;
 import io.yak.framework.security.permission.PermissionDefinitionProvider;
+import io.yak.framework.security.service.RolePermissionService;
+import io.yak.framework.security.service.RoleService;
+import io.yak.framework.security.dao.PermissionDao;
 import java.util.List;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 /**
  * Declares the built-in Yak Ops permission tree consumed by Yak Security.
  *
- * <p>The declarations are synchronized before the bootstrap administrator is created. This gives
- * the initial administrator role a complete, deterministic permission set without coupling every
- * business module directly to the security starter.</p>
+ * <p>The permission codes are shared with the frontend navigation contract. Legacy permission codes
+ * remain declared during the migration period so existing roles are not invalidated abruptly.</p>
  */
 @Configuration(proxyBeanMethods = false)
 public class YakOpsPermissionConfiguration {
@@ -19,17 +22,65 @@ public class YakOpsPermissionConfiguration {
   @Bean
   public PermissionDefinitionProvider yakOpsPermissionDefinitionProvider() {
     return () -> List.of(
+        securityPermissions(),
+        taskPermissions(),
         datasourcePermissions(),
         jobPermissions(),
         workflowPermissions(),
+        resourcePermissions(),
         qualityPermissions(),
-        resourcePermissions());
+        operationsPermissions(),
+        knowledgePermissions());
   }
 
+  /**
+   * Backfills the root permission for an administrator role created before the permission contract
+   * was aligned with the frontend.
+   */
+  @Bean
+  @ConditionalOnProperty(
+      prefix = "yak.security",
+      name = "database-enabled",
+      havingValue = "true",
+      matchIfMissing = true)
+  public YakOpsAdministratorPermissionInitializer yakOpsAdministratorPermissionInitializer(
+      RoleService roleService,
+      RolePermissionService rolePermissionService,
+      PermissionDao permissionDao) {
+    return new YakOpsAdministratorPermissionInitializer(
+        roleService, rolePermissionService, permissionDao);
+  }
+
+  private static PermissionDefinition securityPermissions() {
+    return PermissionDefinition.of(
+        "security",
+        "系统管理",
+        item("security:root", "超级管理员"),
+        item("security:user:read", "查看用户管理"),
+        item("security:role:read", "查看角色管理"),
+        item("security:permission:read", "查看权限管理"),
+        item("security:department:read", "查看部门管理"),
+        item("security:project:read", "查看授权项目"),
+        item("security:resource-permission:read", "查看资源授权"),
+        item("security:config:read", "查看系统配置"),
+        item("security:operation-log:read", "查看操作日志"));
+  }
+
+  private static PermissionDefinition taskPermissions() {
+    return PermissionDefinition.of(
+        "task",
+        "数据集成",
+        item("task:batch:read", "查看离线同步"),
+        item("task:batch:create", "新建离线同步"),
+        item("task:realtime:read", "查看实时同步"),
+        item("task:realtime:create", "新建实时同步"));
+  }
+
+  /** Legacy datasource permissions retained for existing roles and API checks. */
   private static PermissionDefinition datasourcePermissions() {
     return PermissionDefinition.of(
         "datasource",
-        "数据源管理",
+        "数据源管理兼容权限",
         item("datasource:view", "查看数据源"),
         item("datasource:create", "新增数据源"),
         item("datasource:update", "编辑数据源"),
@@ -37,10 +88,11 @@ public class YakOpsPermissionConfiguration {
         item("datasource:test", "测试数据源连接"));
   }
 
+  /** Legacy job permissions retained for existing roles and API checks. */
   private static PermissionDefinition jobPermissions() {
     return PermissionDefinition.of(
         "job",
-        "任务管理",
+        "任务管理兼容权限",
         item("job:view", "查看任务"),
         item("job:create", "新增任务"),
         item("job:update", "编辑任务"),
@@ -52,34 +104,58 @@ public class YakOpsPermissionConfiguration {
   private static PermissionDefinition workflowPermissions() {
     return PermissionDefinition.of(
         "workflow",
-        "工作流管理",
-        item("workflow:view", "查看工作流"),
-        item("workflow:create", "新增工作流"),
-        item("workflow:update", "编辑工作流"),
-        item("workflow:delete", "删除工作流"),
-        item("workflow:execute", "执行工作流"));
-  }
-
-  private static PermissionDefinition qualityPermissions() {
-    return PermissionDefinition.of(
-        "quality",
-        "数据质量管理",
-        item("quality:view", "查看质量规则"),
-        item("quality:create", "新增质量规则"),
-        item("quality:update", "编辑质量规则"),
-        item("quality:delete", "删除质量规则"),
-        item("quality:execute", "执行质量检查"));
+        "流程编排",
+        item("workflow:project:read", "查看工作流项目"),
+        item("workflow:definition:read", "查看工作流定义"),
+        item("workflow:definition:create", "新建工作流定义"),
+        item("workflow:instance:read", "查看工作流实例"),
+        item("workflow:view", "查看工作流（兼容）"),
+        item("workflow:create", "新增工作流（兼容）"),
+        item("workflow:update", "编辑工作流（兼容）"),
+        item("workflow:delete", "删除工作流（兼容）"),
+        item("workflow:execute", "执行工作流（兼容）"));
   }
 
   private static PermissionDefinition resourcePermissions() {
     return PermissionDefinition.of(
         "resource",
         "资源管理",
-        item("resource:view", "查看资源"),
-        item("resource:upload", "上传资源"),
-        item("resource:download", "下载资源"),
-        item("resource:update", "编辑资源"),
-        item("resource:delete", "删除资源"));
+        item("resource:data-source:read", "查看数据源管理"),
+        item("resource:client:read", "查看客户端管理"),
+        item("resource:connector:read", "查看连接器管理"),
+        item("resource:view", "查看资源（兼容）"),
+        item("resource:upload", "上传资源（兼容）"),
+        item("resource:download", "下载资源（兼容）"),
+        item("resource:update", "编辑资源（兼容）"),
+        item("resource:delete", "删除资源（兼容）"));
+  }
+
+  private static PermissionDefinition qualityPermissions() {
+    return PermissionDefinition.of(
+        "quality",
+        "数据质量",
+        item("quality:rule:read", "查看质量规则"),
+        item("quality:report:read", "查看质量报告"),
+        item("quality:view", "查看质量规则（兼容）"),
+        item("quality:create", "新增质量规则（兼容）"),
+        item("quality:update", "编辑质量规则（兼容）"),
+        item("quality:delete", "删除质量规则（兼容）"),
+        item("quality:execute", "执行质量检查（兼容）"));
+  }
+
+  private static PermissionDefinition operationsPermissions() {
+    return PermissionDefinition.of(
+        "operations",
+        "运维中心",
+        item("operations:metrics:read", "查看运行监控"),
+        item("operations:alarm:read", "查看告警管理"));
+  }
+
+  private static PermissionDefinition knowledgePermissions() {
+    return PermissionDefinition.of(
+        "knowledge",
+        "知识管理",
+        item("knowledge:read", "查看知识管理"));
   }
 
   private static PermissionDefinition.Item item(String code, String name) {

--- a/yak-ops-boot/src/test/java/io/yak/ops/boot/YakOpsApplicationTests.java
+++ b/yak-ops-boot/src/test/java/io/yak/ops/boot/YakOpsApplicationTests.java
@@ -5,7 +5,9 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import io.yak.framework.security.permission.PermissionDefinition;
 import io.yak.framework.security.permission.PermissionDefinitionProvider;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -41,9 +43,53 @@ class YakOpsApplicationTests {
   }
 
   @Test
-  void shouldDeclarePermissionsBeforeSecurityBootstrap() {
-    assertThat(permissionDefinitionProvider.getPermissionDefinitions())
-        .extracting("code")
-        .containsExactly("datasource", "job", "workflow", "quality", "resource");
+  void shouldDeclareFrontendNavigationPermissionContract() {
+    List<PermissionDefinition> definitions =
+        permissionDefinitionProvider.getPermissionDefinitions();
+
+    assertThat(definitions)
+        .extracting(PermissionDefinition::getCode)
+        .containsExactly(
+            "security",
+            "task",
+            "datasource",
+            "job",
+            "workflow",
+            "resource",
+            "quality",
+            "operations",
+            "knowledge");
+
+    List<String> permissionCodes = definitions.stream()
+        .flatMap(definition -> definition.getPermissions().stream())
+        .map(PermissionDefinition.Item::getCode)
+        .toList();
+
+    assertThat(permissionCodes).contains(
+        "security:root",
+        "task:batch:read",
+        "task:batch:create",
+        "task:realtime:read",
+        "task:realtime:create",
+        "workflow:project:read",
+        "workflow:definition:read",
+        "workflow:definition:create",
+        "workflow:instance:read",
+        "resource:data-source:read",
+        "resource:client:read",
+        "resource:connector:read",
+        "quality:rule:read",
+        "quality:report:read",
+        "operations:metrics:read",
+        "operations:alarm:read",
+        "knowledge:read",
+        "security:user:read",
+        "security:role:read",
+        "security:permission:read",
+        "security:department:read",
+        "security:project:read",
+        "security:resource-permission:read",
+        "security:config:read",
+        "security:operation-log:read");
   }
 }

--- a/yak-ops-ui/src/utils/security/permission.test.ts
+++ b/yak-ops-ui/src/utils/security/permission.test.ts
@@ -18,6 +18,14 @@ describe('permission helpers', () => {
     expect(satisfiesPermissionRequirement(granted, { mode: 'all', permissions: ['task:read', 'task:create'] })).toBe(true);
   });
 
+  it('grants every permission requirement to the security root identity', () => {
+    const root = ['security:root'];
+
+    expect(hasPermission(root, 'task:batch:read')).toBe(true);
+    expect(hasAnyPermission(root, ['quality:rule:read', 'operations:metrics:read'])).toBe(true);
+    expect(hasAllPermissions(root, ['security:user:read', 'security:role:read'])).toBe(true);
+  });
+
   it('uses fail-closed empty-set semantics while public remains public', () => {
     expect(hasAnyPermission(granted, [])).toBe(false);
     expect(hasAllPermissions(granted, [])).toBe(true);


### PR DESCRIPTION
## What changed

- align Yak Ops backend permission declarations with the exact permission codes used by `yak-ops-ui/src/config/navigation.ts`
- add the shared `security:root` super-administrator permission supported by both frontend and backend authorization helpers
- retain the previous coarse-grained permission codes as compatibility declarations for existing roles and future migration work
- add `YakOpsAdministratorPermissionInitializer` to idempotently grant `security:root` to an existing `系统管理员` role
- keep new installations compatible with the existing Yak Security bootstrap flow
- add backend contract coverage for every permission currently used by navigation and quick-create entries
- add a frontend regression test proving `security:root` satisfies arbitrary menu permission checks

## Root cause

The current-user endpoint correctly returned `permissionCodes`, and the frontend correctly stored and consumed them. The menu disappeared because the two sides used different permission contracts.

Examples:

```text
frontend: resource:data-source:read
backend:  datasource:view

frontend: task:batch:read
backend:  job:view

frontend: workflow:definition:read
backend:  workflow:view
```

Frontend permission checks intentionally use exact string matching, so only the public home route remained visible.

## Existing administrator migration

The bootstrap administrator already exists in current development databases. Adding a new declaration alone would not re-run bootstrap or update that role.

The new initializer runs after application runners, locates the built-in `系统管理员` role, and adds `security:root` only when missing. It preserves all existing role permissions and is safe to run repeatedly.

After merging, no database deletion or manual SQL is required. Restarting the application will:

1. synchronize the aligned permission declarations
2. backfill `security:root` to the existing administrator role
3. invalidate the affected role permission cache through `RolePermissionService`
4. return `security:root` from `/yak-security/api/v1/account/current`
5. allow the frontend to render every authorized menu

## Permission groups

```text
security
  security:root
  security:user:read
  security:role:read
  security:permission:read
  security:department:read
  security:project:read
  security:resource-permission:read
  security:config:read
  security:operation-log:read

task
  task:batch:read
  task:batch:create
  task:realtime:read
  task:realtime:create

workflow
  workflow:project:read
  workflow:definition:read
  workflow:definition:create
  workflow:instance:read

resource
  resource:data-source:read
  resource:client:read
  resource:connector:read

quality
  quality:rule:read
  quality:report:read

operations
  operations:metrics:read
  operations:alarm:read

knowledge
  knowledge:read
```

## Local verification

```bat
mvn -pl yak-ops-boot -am test
mvn clean package -DskipTests
java -jar yak-ops-boot\target\yak-ops-boot-1.0.0.jar
```

Verify the current user response contains:

```json
{
  "permissionCodes": [
    "security:root"
  ]
}
```

Then refresh or sign in again at the frontend. All root-authorized menus should be visible.

Frontend permission test:

```bat
cd yak-ops-ui
npm test -- permission.test.ts
```

## Validation

- branch is based on current `main` and is not behind
- backend declarations were compared against every protected route and quick-create permission in `navigation.ts`
- existing legacy declarations remain available during migration
- administrator backfill uses the framework's public role, permission and cache-aware role-permission services
- changes are limited to four files

## Merge note

Prefer **Squash and merge**.