### PR TITLE
feat(ui): consume role-managed menu authorization

### DIFF
--- a/yak-ops-ui/src/components/security/RouteAccessBoundary/index.tsx
+++ b/yak-ops-ui/src/components/security/RouteAccessBoundary/index.tsx
@@ -11,6 +11,7 @@ import {
   type NavigationRoute,
 } from '@/config/navigation';
 import ForbiddenPage from '@/pages/403';
+import { hasRouteMenuAccess } from '@/utils/security/menu';
 
 export interface RouteAccessBoundaryProps {
   /**
@@ -27,6 +28,11 @@ export interface RouteAccessBoundaryProps {
    * 主要用于独立组件和单元测试。
    */
   permissionCodes?: readonly string[];
+
+  /**
+   * 数据库返回的角色菜单编码，主要用于独立组件和单元测试。
+   */
+  menuCodes?: readonly string[];
 }
 
 const defaultFallback = <ForbiddenPage />;
@@ -43,6 +49,7 @@ export default function RouteAccessBoundary({
   fallback = defaultFallback,
   route,
   permissionCodes,
+  menuCodes,
 }: RouteAccessBoundaryProps) {
   const location = useLocation();
   const { initialState } = useModel('@@initialState');
@@ -53,6 +60,8 @@ export default function RouteAccessBoundary({
   const granted =
     permissionCodes ??
     initialState?.currentUser?.permissionCodes;
+  const grantedMenus =
+    menuCodes ?? initialState?.currentUser?.menuCodes;
 
   /*
    * 当前用户信息加载失败不等于无权限，
@@ -65,9 +74,16 @@ export default function RouteAccessBoundary({
   const allowed =
     identityPending ||
     !metadata ||
-    canAccessNavigationRoute(
-      metadata,
-      granted,
+    (
+      canAccessNavigationRoute(
+        metadata,
+        granted,
+      ) &&
+      hasRouteMenuAccess(
+        grantedMenus,
+        metadata,
+        granted,
+      )
     );
 
   if (!allowed) {

--- a/yak-ops-ui/src/services/ant-design-pro/typings.d.ts
+++ b/yak-ops-ui/src/services/ant-design-pro/typings.d.ts
@@ -25,6 +25,8 @@ declare namespace API {
     roleList?: RoleBrief[] | null;
     /** Optional until AccountController/current explicitly guarantees it. */
     permissionCodes?: string[] | null;
+    /** Menu codes granted through the user's roles. */
+    menuCodes?: string[] | null;
     /** Security projects authorized for this identity, not an admin list. */
     projectList?: ProjectBrief[] | null;
   };
@@ -36,6 +38,7 @@ declare namespace API {
     deptId?: number | null;
     roleList?: RoleBrief[];
     permissionCodes?: string[];
+    menuCodes?: string[];
     projectList?: ProjectBrief[];
     name?: string;
     avatar?: string;

--- a/yak-ops-ui/src/services/security/currentIdentity.test.ts
+++ b/yak-ops-ui/src/services/security/currentIdentity.test.ts
@@ -2,7 +2,9 @@ import { toCurrentUser } from './currentIdentity';
 
 describe('current identity normalization', () => {
   it('fails closed when optional authorization context is absent', () => {
-    expect(toCurrentUser({ id: 7, userName: 'yak' })).toMatchObject({
+    const user = toCurrentUser({ id: 7, userName: 'yak' });
+
+    expect(user).toMatchObject({
       id: 7,
       userName: 'yak',
       name: 'yak',
@@ -10,9 +12,9 @@ describe('current identity normalization', () => {
       deptId: null,
       roleList: [],
       permissionCodes: [],
-      menuCodes: [],
       projectList: [],
     });
+    expect(user.menuCodes).toBeUndefined();
   });
 
   it('uses only values supplied by the current-account response', () => {

--- a/yak-ops-ui/src/services/security/currentIdentity.test.ts
+++ b/yak-ops-ui/src/services/security/currentIdentity.test.ts
@@ -10,6 +10,7 @@ describe('current identity normalization', () => {
       deptId: null,
       roleList: [],
       permissionCodes: [],
+      menuCodes: [],
       projectList: [],
     });
   });
@@ -22,6 +23,7 @@ describe('current identity normalization', () => {
       deptId: 12,
       roleList: [{ id: 2, roleName: 'operator' }],
       permissionCodes: ['task:read'],
+      menuCodes: ['integration', 'batch-link-up'],
       projectList: [{ id: 3, projectCode: 'SEC', projectName: 'Security' }],
     });
 
@@ -29,6 +31,7 @@ describe('current identity normalization', () => {
       name: 'Yak Operator',
       deptId: 12,
       permissionCodes: ['task:read'],
+      menuCodes: ['integration', 'batch-link-up'],
       projectList: [{ id: 3, projectCode: 'SEC' }],
     });
   });

--- a/yak-ops-ui/src/services/security/currentIdentity.ts
+++ b/yak-ops-ui/src/services/security/currentIdentity.ts
@@ -17,7 +17,8 @@ export const toCurrentUser = (user: API.CurrentUserVO): API.CurrentUser => ({
   permissionCodes: Array.isArray(user.permissionCodes)
     ? user.permissionCodes
     : [],
-  menuCodes: Array.isArray(user.menuCodes) ? user.menuCodes : [],
+  // Undefined means an older backend has not exposed menu authorization yet.
+  menuCodes: Array.isArray(user.menuCodes) ? user.menuCodes : undefined,
   projectList: Array.isArray(user.projectList) ? user.projectList : [],
   // A missing/null deptId means “no current department”; it is not inferred.
   deptId: user.deptId ?? null,

--- a/yak-ops-ui/src/services/security/currentIdentity.ts
+++ b/yak-ops-ui/src/services/security/currentIdentity.ts
@@ -17,6 +17,7 @@ export const toCurrentUser = (user: API.CurrentUserVO): API.CurrentUser => ({
   permissionCodes: Array.isArray(user.permissionCodes)
     ? user.permissionCodes
     : [],
+  menuCodes: Array.isArray(user.menuCodes) ? user.menuCodes : [],
   projectList: Array.isArray(user.projectList) ? user.projectList : [],
   // A missing/null deptId means “no current department”; it is not inferred.
   deptId: user.deptId ?? null,

--- a/yak-ops-ui/src/utils/security/menu.test.ts
+++ b/yak-ops-ui/src/utils/security/menu.test.ts
@@ -1,0 +1,43 @@
+import { hasRouteMenuAccess } from './menu';
+
+describe('route menu authorization', () => {
+  const protectedRoute = {
+    id: 'batch-link-up',
+    mode: 'one' as const,
+  };
+
+  it('enforces menu codes when the backend contract is present', () => {
+    expect(
+      hasRouteMenuAccess(['batch-link-up'], protectedRoute, []),
+    ).toBe(true);
+    expect(
+      hasRouteMenuAccess(['client'], protectedRoute, []),
+    ).toBe(false);
+    expect(hasRouteMenuAccess([], protectedRoute, [])).toBe(false);
+  });
+
+  it('inherits the parent grant for hidden detail routes', () => {
+    expect(
+      hasRouteMenuAccess(
+        ['batch-link-up'],
+        {
+          id: 'batch-link-up-detail',
+          parentId: 'batch-link-up',
+        },
+        [],
+      ),
+    ).toBe(true);
+  });
+
+  it('keeps public, root, and staggered deployments compatible', () => {
+    expect(
+      hasRouteMenuAccess([], { id: 'home', mode: 'public' }, []),
+    ).toBe(true);
+    expect(
+      hasRouteMenuAccess([], protectedRoute, ['security:root']),
+    ).toBe(true);
+    expect(
+      hasRouteMenuAccess(undefined, protectedRoute, []),
+    ).toBe(true);
+  });
+});

--- a/yak-ops-ui/src/utils/security/menu.ts
+++ b/yak-ops-ui/src/utils/security/menu.ts
@@ -1,0 +1,36 @@
+type MenuProtectedRoute = {
+  id: string;
+  parentId?: string;
+  mode?: 'public' | 'one' | 'any' | 'all';
+};
+
+const ROOT_PERMISSION = 'security:root';
+
+/**
+ * Checks the database-backed menu grant for one route.
+ *
+ * <p>An undefined menuCodes value means the backend has not exposed the new
+ * contract yet, so deployments can roll out backend and frontend separately.
+ * Once the field is present, an empty array deliberately denies every
+ * protected menu. Hidden detail routes inherit their parent menu grant.
+ */
+export const hasRouteMenuAccess = (
+  menuCodes: readonly string[] | null | undefined,
+  route: MenuProtectedRoute,
+  permissionCodes?: readonly string[] | null,
+): boolean => {
+  if (route.mode === 'public') {
+    return true;
+  }
+
+  if (permissionCodes?.includes(ROOT_PERMISSION)) {
+    return true;
+  }
+
+  if (!Array.isArray(menuCodes)) {
+    return true;
+  }
+
+  const requiredMenuCode = route.parentId ?? route.id;
+  return menuCodes.includes(requiredMenuCode);
+};


### PR DESCRIPTION
## 背景

配合 Yak Security 的角色菜单授权能力，让前端能够识别当前用户的数据库菜单编码，并在直接访问页面路由时同时校验菜单权限。

## 实现

- 当前用户类型新增 `menuCodes`
- 身份初始化时保留后端返回的角色菜单编码
- 路由访问边界增加菜单授权校验
- 隐藏的详情路由继承父级菜单授权
- 公开页面和 `security:root` 超级管理员保持原有访问语义
- 后端尚未启用 `menuCodes` 时暂时沿用旧权限逻辑，支持前后端分批发布
- 后端明确返回空菜单数组时，受保护页面按无菜单权限处理

## 角色管理兼容

现有角色编辑抽屉无需重写。后端会把“菜单权限”作为权限树的独立分组返回；当前 Tree 组件和 `permissionIdList` 保存逻辑能够保留负数菜单节点 ID，并交由 Yak Security 拆分持久化。

## 测试

- 扩展当前身份归一化测试
- 新增页面菜单访问、父路由继承、公开页面、超级管理员及分批发布兼容测试

## 验证状态

仓库当前没有可用的 GitHub Actions 或 commit status，因此本 PR 没有远程 CI 结果。已完成 TypeScript 类型、路由元数据结构、旧后端回退语义及后端菜单编码映射的静态核对；新增测试尚需在完整前端依赖环境中执行。

## 依赖

需配合后端 Draft PR `weifuwan/yak-framework#66`。