### PR TITLE
feat(workflow): add lightweight backend engine

### DIFF
--- a/yak-ops-boot/src/main/java/io/yak/ops/boot/config/YakOpsPermissionConfiguration.java
+++ b/yak-ops-boot/src/main/java/io/yak/ops/boot/config/YakOpsPermissionConfiguration.java
@@ -1,10 +1,10 @@
 package io.yak.ops.boot.config;
 
+import io.yak.framework.security.dao.PermissionDao;
 import io.yak.framework.security.permission.PermissionDefinition;
 import io.yak.framework.security.permission.PermissionDefinitionProvider;
 import io.yak.framework.security.service.RolePermissionService;
 import io.yak.framework.security.service.RoleService;
-import io.yak.framework.security.dao.PermissionDao;
 import java.util.List;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
@@ -108,7 +108,12 @@ public class YakOpsPermissionConfiguration {
         item("workflow:project:read", "查看工作流项目"),
         item("workflow:definition:read", "查看工作流定义"),
         item("workflow:definition:create", "新建工作流定义"),
+        item("workflow:definition:update", "编辑工作流定义"),
+        item("workflow:definition:publish", "发布工作流定义"),
         item("workflow:instance:read", "查看工作流实例"),
+        item("workflow:instance:execute", "执行工作流实例"),
+        item("workflow:instance:stop", "停止工作流实例"),
+        item("workflow:schedule:manage", "管理工作流调度"),
         item("workflow:view", "查看工作流（兼容）"),
         item("workflow:create", "新增工作流（兼容）"),
         item("workflow:update", "编辑工作流（兼容）"),

--- a/yak-ops-boot/src/main/resources/application.yml
+++ b/yak-ops-boot/src/main/resources/application.yml
@@ -5,12 +5,12 @@ server:
 spring:
   application:
     name: yak-ops
-  # Yak Security owns its dedicated DataSource and transaction manager.
+  # Yak Security and Yak Workflow own dedicated DataSources and transaction managers.
   autoconfigure:
     exclude:
       - org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
       - org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration
-  # Yak Security creates and runs its own Flyway instance against its dedicated DataSource.
+  # Domain modules create and run their own Flyway instances.
   flyway:
     enabled: false
   lifecycle:
@@ -19,7 +19,8 @@ spring:
     default-property-inclusion: non_null
     time-zone: Asia/Shanghai
   quartz:
-    auto-startup: false
+    auto-startup: true
+    job-store-type: memory
 
 springdoc:
   api-docs:
@@ -76,8 +77,28 @@ yak:
       test-on-return: false
 
   schedule:
-    enabled: false
+    enabled: true
     web-enabled: false
+
+  workflow:
+    enabled: true
+    datasource:
+      url: ${YAK_WORKFLOW_DATASOURCE_URL:${YAK_SECURITY_DATASOURCE_URL:jdbc:mariadb://127.0.0.1:3306/yak_security?useUnicode=true&allowPublicKeyRetrieval=true&characterEncoding=UTF-8&useSSL=false&serverTimezone=Asia/Shanghai}}
+      username: ${YAK_WORKFLOW_DATASOURCE_USERNAME:${YAK_SECURITY_DATASOURCE_USERNAME:root}}
+      password: ${YAK_WORKFLOW_DATASOURCE_PASSWORD:${YAK_SECURITY_DATASOURCE_PASSWORD:123456}}
+      driver-class-name: ${YAK_WORKFLOW_DATASOURCE_DRIVER:org.mariadb.jdbc.Driver}
+      minimum-idle: 1
+      maximum-pool-size: 8
+    executor:
+      core-pool-size: ${YAK_WORKFLOW_CORE_POOL_SIZE:8}
+      maximum-pool-size: ${YAK_WORKFLOW_MAX_POOL_SIZE:32}
+      queue-capacity: ${YAK_WORKFLOW_QUEUE_CAPACITY:500}
+      default-workflow-parallelism: 4
+      thread-name-prefix: yak-workflow-
+    recovery:
+      enabled: true
+      initial-delay-millis: 5000
+      fixed-delay-millis: 10000
 
 logging:
   level:

--- a/yak-ops-boot/src/test/resources/application-test.yml
+++ b/yak-ops-boot/src/test/resources/application-test.yml
@@ -6,6 +6,8 @@ spring:
       - org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration
   flyway:
     enabled: false
+  quartz:
+    auto-startup: false
 
 yak:
   security:
@@ -21,3 +23,5 @@ yak:
   schedule:
     enabled: false
     web-enabled: false
+  workflow:
+    enabled: false

--- a/yak-ops-business/yak-ops-business-workflow/pom.xml
+++ b/yak-ops-business/yak-ops-business-workflow/pom.xml
@@ -25,5 +25,44 @@
             <groupId>io.yak.framework</groupId>
             <artifactId>yak-schedule-spring-boot-starter</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-jdbc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-quartz</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-mysql</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.mariadb.jdbc</groupId>
+            <artifactId>mariadb-java-client</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/config/ConditionalOnWorkflowEnabled.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/config/ConditionalOnWorkflowEnabled.java
@@ -1,0 +1,18 @@
+package io.yak.ops.business.workflow.config;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+
+/** Enables workflow beans only when the lightweight engine is configured on. */
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@ConditionalOnProperty(
+    prefix = "yak.workflow",
+    name = "enabled",
+    havingValue = "true",
+    matchIfMissing = true)
+public @interface ConditionalOnWorkflowEnabled {
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/config/WorkflowConfiguration.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/config/WorkflowConfiguration.java
@@ -1,0 +1,94 @@
+package io.yak.ops.business.workflow.config;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import io.yak.ops.business.workflow.dag.WorkflowDagCompiler;
+import io.yak.ops.business.workflow.schedule.WorkflowQuartzJob;
+import io.yak.ops.core.workflow.LocalWorkflowTaskDispatcher;
+import io.yak.ops.core.workflow.WorkflowTaskExecutorRegistry;
+import io.yak.ops.spi.workflow.WorkflowTaskExecutor;
+import java.util.List;
+import javax.sql.DataSource;
+import org.flywaydb.core.Flyway;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.quartz.SchedulerFactoryBeanCustomizer;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.transaction.PlatformTransactionManager;
+
+/** Infrastructure wiring for the single-process workflow runtime. */
+@ConditionalOnWorkflowEnabled
+@Configuration(proxyBeanMethods = false)
+@EnableScheduling
+@EnableConfigurationProperties(WorkflowProperties.class)
+public class WorkflowConfiguration {
+
+  @Bean(name = "workflowDataSource", destroyMethod = "close")
+  public HikariDataSource workflowDataSource(WorkflowProperties properties) {
+    WorkflowProperties.Datasource datasource = properties.getDatasource();
+    HikariConfig config = new HikariConfig();
+    config.setPoolName("YakWorkflowPool");
+    config.setJdbcUrl(datasource.getUrl());
+    config.setUsername(datasource.getUsername());
+    config.setPassword(datasource.getPassword());
+    config.setDriverClassName(datasource.getDriverClassName());
+    config.setMaximumPoolSize(datasource.getMaximumPoolSize());
+    config.setMinimumIdle(datasource.getMinimumIdle());
+    config.setAutoCommit(true);
+    return new HikariDataSource(config);
+  }
+
+  @Bean(name = "workflowTransactionManager")
+  public PlatformTransactionManager workflowTransactionManager(
+      @Qualifier("workflowDataSource") DataSource dataSource) {
+    return new DataSourceTransactionManager(dataSource);
+  }
+
+  @Bean(initMethod = "migrate")
+  public Flyway workflowFlyway(@Qualifier("workflowDataSource") DataSource dataSource) {
+    return Flyway.configure()
+        .dataSource(dataSource)
+        .locations("classpath:db/migration/yak-workflow")
+        .table("yak_wf_schema_history")
+        .baselineOnMigrate(true)
+        .load();
+  }
+
+  @Bean
+  public NamedParameterJdbcTemplate workflowJdbcTemplate(
+      @Qualifier("workflowDataSource") DataSource dataSource) {
+    return new NamedParameterJdbcTemplate(dataSource);
+  }
+
+  @Bean
+  public WorkflowTaskExecutorRegistry workflowTaskExecutorRegistry(
+      List<WorkflowTaskExecutor> executors) {
+    return new WorkflowTaskExecutorRegistry(executors);
+  }
+
+  @Bean
+  public WorkflowDagCompiler workflowDagCompiler(WorkflowTaskExecutorRegistry registry) {
+    return new WorkflowDagCompiler(registry);
+  }
+
+  @Bean
+  public SchedulerFactoryBeanCustomizer workflowSchedulerContextCustomizer() {
+    return factory -> {
+      factory.setApplicationContextSchedulerContextKey(WorkflowQuartzJob.APPLICATION_CONTEXT_KEY);
+    };
+  }
+
+  @Bean(destroyMethod = "close")
+  public LocalWorkflowTaskDispatcher workflowTaskDispatcher(WorkflowProperties properties) {
+    WorkflowProperties.Executor executor = properties.getExecutor();
+    return new LocalWorkflowTaskDispatcher(
+        executor.getCorePoolSize(),
+        executor.getMaximumPoolSize(),
+        executor.getQueueCapacity(),
+        executor.getThreadNamePrefix());
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/config/WorkflowProperties.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/config/WorkflowProperties.java
@@ -1,0 +1,171 @@
+package io.yak.ops.business.workflow.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/** Runtime and persistence settings for the lightweight workflow engine. */
+@ConfigurationProperties(prefix = "yak.workflow")
+public class WorkflowProperties {
+
+  private boolean enabled = true;
+  private final Datasource datasource = new Datasource();
+  private final Executor executor = new Executor();
+  private final Recovery recovery = new Recovery();
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  public Datasource getDatasource() {
+    return datasource;
+  }
+
+  public Executor getExecutor() {
+    return executor;
+  }
+
+  public Recovery getRecovery() {
+    return recovery;
+  }
+
+  public static class Datasource {
+
+    private String url = "jdbc:mariadb://127.0.0.1:3306/yak_security?useUnicode=true&characterEncoding=UTF-8&useSSL=false&serverTimezone=Asia/Shanghai";
+    private String username = "root";
+    private String password = "123456";
+    private String driverClassName = "org.mariadb.jdbc.Driver";
+    private int maximumPoolSize = 8;
+    private int minimumIdle = 1;
+
+    public String getUrl() {
+      return url;
+    }
+
+    public void setUrl(String url) {
+      this.url = url;
+    }
+
+    public String getUsername() {
+      return username;
+    }
+
+    public void setUsername(String username) {
+      this.username = username;
+    }
+
+    public String getPassword() {
+      return password;
+    }
+
+    public void setPassword(String password) {
+      this.password = password;
+    }
+
+    public String getDriverClassName() {
+      return driverClassName;
+    }
+
+    public void setDriverClassName(String driverClassName) {
+      this.driverClassName = driverClassName;
+    }
+
+    public int getMaximumPoolSize() {
+      return maximumPoolSize;
+    }
+
+    public void setMaximumPoolSize(int maximumPoolSize) {
+      this.maximumPoolSize = maximumPoolSize;
+    }
+
+    public int getMinimumIdle() {
+      return minimumIdle;
+    }
+
+    public void setMinimumIdle(int minimumIdle) {
+      this.minimumIdle = minimumIdle;
+    }
+  }
+
+  public static class Executor {
+
+    private int corePoolSize = Math.max(2, Runtime.getRuntime().availableProcessors());
+    private int maximumPoolSize = Math.max(4, Runtime.getRuntime().availableProcessors() * 2);
+    private int queueCapacity = 500;
+    private int defaultWorkflowParallelism = 4;
+    private String threadNamePrefix = "yak-workflow-";
+
+    public int getCorePoolSize() {
+      return corePoolSize;
+    }
+
+    public void setCorePoolSize(int corePoolSize) {
+      this.corePoolSize = corePoolSize;
+    }
+
+    public int getMaximumPoolSize() {
+      return maximumPoolSize;
+    }
+
+    public void setMaximumPoolSize(int maximumPoolSize) {
+      this.maximumPoolSize = maximumPoolSize;
+    }
+
+    public int getQueueCapacity() {
+      return queueCapacity;
+    }
+
+    public void setQueueCapacity(int queueCapacity) {
+      this.queueCapacity = queueCapacity;
+    }
+
+    public int getDefaultWorkflowParallelism() {
+      return defaultWorkflowParallelism;
+    }
+
+    public void setDefaultWorkflowParallelism(int defaultWorkflowParallelism) {
+      this.defaultWorkflowParallelism = defaultWorkflowParallelism;
+    }
+
+    public String getThreadNamePrefix() {
+      return threadNamePrefix;
+    }
+
+    public void setThreadNamePrefix(String threadNamePrefix) {
+      this.threadNamePrefix = threadNamePrefix;
+    }
+  }
+
+  public static class Recovery {
+
+    private boolean enabled = true;
+    private long initialDelayMillis = 5_000L;
+    private long fixedDelayMillis = 10_000L;
+
+    public boolean isEnabled() {
+      return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+      this.enabled = enabled;
+    }
+
+    public long getInitialDelayMillis() {
+      return initialDelayMillis;
+    }
+
+    public void setInitialDelayMillis(long initialDelayMillis) {
+      this.initialDelayMillis = initialDelayMillis;
+    }
+
+    public long getFixedDelayMillis() {
+      return fixedDelayMillis;
+    }
+
+    public void setFixedDelayMillis(long fixedDelayMillis) {
+      this.fixedDelayMillis = fixedDelayMillis;
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dag/CompiledWorkflowDag.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dag/CompiledWorkflowDag.java
@@ -1,0 +1,20 @@
+package io.yak.ops.business.workflow.dag;
+
+import io.yak.ops.business.workflow.model.WorkflowDag;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/** Immutable, validated execution graph derived from a published DAG snapshot. */
+public record CompiledWorkflowDag(
+    Map<String, WorkflowDag.Node> nodes,
+    Map<String, Set<String>> predecessors,
+    Map<String, Set<String>> successors,
+    List<String> topologicalOrder) {
+
+  public List<String> startNodes() {
+    return topologicalOrder.stream()
+        .filter(nodeKey -> predecessors.getOrDefault(nodeKey, Set.of()).isEmpty())
+        .toList();
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dag/WorkflowDagCompiler.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dag/WorkflowDagCompiler.java
@@ -1,0 +1,153 @@
+package io.yak.ops.business.workflow.dag;
+
+import io.yak.ops.business.workflow.model.WorkflowDag;
+import io.yak.ops.core.workflow.WorkflowTaskExecutorRegistry;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+/** Validates a workflow snapshot and compiles it into adjacency maps and topological order. */
+public final class WorkflowDagCompiler {
+
+  private static final Pattern NODE_KEY = Pattern.compile("[A-Za-z][A-Za-z0-9_-]{0,63}");
+
+  private final WorkflowTaskExecutorRegistry executorRegistry;
+
+  public WorkflowDagCompiler(WorkflowTaskExecutorRegistry executorRegistry) {
+    this.executorRegistry = executorRegistry;
+  }
+
+  public CompiledWorkflowDag compile(WorkflowDag dag) {
+    if (dag == null || dag.nodes().isEmpty()) {
+      throw new IllegalArgumentException("Workflow DAG must contain at least one node");
+    }
+
+    Map<String, WorkflowDag.Node> nodes = new LinkedHashMap<>();
+    Map<String, Set<String>> predecessors = new LinkedHashMap<>();
+    Map<String, Set<String>> successors = new LinkedHashMap<>();
+
+    for (WorkflowDag.Node source : dag.nodes()) {
+      WorkflowDag.Node node = normalize(source);
+      validateNode(node);
+      if (nodes.putIfAbsent(node.key(), node) != null) {
+        throw new IllegalArgumentException("Duplicate workflow node key: " + node.key());
+      }
+      predecessors.put(node.key(), new LinkedHashSet<>());
+      successors.put(node.key(), new LinkedHashSet<>());
+    }
+
+    Set<String> uniqueEdges = new LinkedHashSet<>();
+    for (WorkflowDag.Edge edge : dag.edges()) {
+      if (edge == null || edge.from() == null || edge.to() == null) {
+        throw new IllegalArgumentException("Workflow edge endpoints must not be null");
+      }
+      String from = edge.from().trim();
+      String to = edge.to().trim();
+      if (!nodes.containsKey(from) || !nodes.containsKey(to)) {
+        throw new IllegalArgumentException("Workflow edge references an unknown node: " + from + " -> " + to);
+      }
+      if (from.equals(to)) {
+        throw new IllegalArgumentException("Workflow node cannot depend on itself: " + from);
+      }
+      String edgeKey = from + "\u0000" + to;
+      if (uniqueEdges.add(edgeKey)) {
+        successors.get(from).add(to);
+        predecessors.get(to).add(from);
+      }
+    }
+
+    List<String> order = topologicalSort(predecessors, successors);
+    return new CompiledWorkflowDag(
+        Collections.unmodifiableMap(nodes),
+        immutableSetMap(predecessors),
+        immutableSetMap(successors),
+        List.copyOf(order));
+  }
+
+  private WorkflowDag.Node normalize(WorkflowDag.Node source) {
+    if (source == null) {
+      throw new IllegalArgumentException("Workflow node must not be null");
+    }
+    String key = source.key() == null ? null : source.key().trim();
+    String name = source.name() == null ? null : source.name().trim();
+    String type = source.type() == null ? null : source.type().trim().toUpperCase(Locale.ROOT);
+    return new WorkflowDag.Node(
+        key,
+        name,
+        type,
+        source.config(),
+        source.retryTimes(),
+        source.retryIntervalSeconds(),
+        source.timeoutSeconds(),
+        source.enabled(),
+        source.idempotent(),
+        source.retryOnRestart());
+  }
+
+  private void validateNode(WorkflowDag.Node node) {
+    if (node.key() == null || !NODE_KEY.matcher(node.key()).matches()) {
+      throw new IllegalArgumentException(
+          "Workflow node key must match " + NODE_KEY.pattern() + ": " + node.key());
+    }
+    if (node.name() == null || node.name().isBlank()) {
+      throw new IllegalArgumentException("Workflow node name must not be blank: " + node.key());
+    }
+    if (node.type() == null || node.type().isBlank()) {
+      throw new IllegalArgumentException("Workflow task type must not be blank: " + node.key());
+    }
+    if (node.retryTimes() < 0 || node.retryIntervalSeconds() < 0 || node.timeoutSeconds() < 0) {
+      throw new IllegalArgumentException("Retry and timeout values must not be negative: " + node.key());
+    }
+    if (!node.enabled()) {
+      return;
+    }
+    executorRegistry.require(node.type()).validate(node.config());
+  }
+
+  private static List<String> topologicalSort(
+      Map<String, Set<String>> predecessors,
+      Map<String, Set<String>> successors) {
+    Map<String, Integer> indegrees = new LinkedHashMap<>();
+    predecessors.forEach((node, values) -> indegrees.put(node, values.size()));
+    Deque<String> ready = new ArrayDeque<>();
+    indegrees.forEach((node, degree) -> {
+      if (degree == 0) {
+        ready.addLast(node);
+      }
+    });
+
+    List<String> result = new ArrayList<>(indegrees.size());
+    while (!ready.isEmpty()) {
+      String node = ready.removeFirst();
+      result.add(node);
+      for (String successor : successors.getOrDefault(node, Set.of())) {
+        int remaining = indegrees.computeIfPresent(successor, (ignored, degree) -> degree - 1);
+        if (remaining == 0) {
+          ready.addLast(successor);
+        }
+      }
+    }
+    if (result.size() != indegrees.size()) {
+      List<String> cyclicNodes = indegrees.entrySet().stream()
+          .filter(entry -> entry.getValue() > 0)
+          .map(Map.Entry::getKey)
+          .toList();
+      throw new IllegalArgumentException("Workflow DAG contains a cycle: " + cyclicNodes);
+    }
+    return result;
+  }
+
+  private static Map<String, Set<String>> immutableSetMap(Map<String, Set<String>> source) {
+    Map<String, Set<String>> copy = new LinkedHashMap<>();
+    source.forEach((key, value) -> copy.put(key, Collections.unmodifiableSet(new LinkedHashSet<>(value))));
+    return Collections.unmodifiableMap(copy);
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/executor/HttpWorkflowTaskExecutor.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/executor/HttpWorkflowTaskExecutor.java
@@ -1,0 +1,120 @@
+package io.yak.ops.business.workflow.executor;
+
+import io.yak.ops.business.workflow.config.ConditionalOnWorkflowEnabled;
+import io.yak.ops.spi.workflow.WorkflowTaskContext;
+import io.yak.ops.spi.workflow.WorkflowTaskExecutor;
+import io.yak.ops.spi.workflow.WorkflowTaskResult;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import org.springframework.stereotype.Component;
+
+/** Executes an HTTP request using the JDK client. */
+@ConditionalOnWorkflowEnabled
+@Component
+public final class HttpWorkflowTaskExecutor implements WorkflowTaskExecutor {
+
+  private final HttpClient client = HttpClient.newBuilder()
+      .followRedirects(HttpClient.Redirect.NORMAL)
+      .connectTimeout(Duration.ofSeconds(15))
+      .build();
+  private final Map<Long, CompletableFuture<?>> runningRequests = new ConcurrentHashMap<>();
+
+  @Override
+  public String type() {
+    return "HTTP";
+  }
+
+  @Override
+  public void validate(Map<String, Object> configuration) {
+    Object url = configuration == null ? null : configuration.get("url");
+    if (url == null || String.valueOf(url).isBlank()) {
+      throw new IllegalArgumentException("HTTP task requires a non-blank url");
+    }
+    URI.create(String.valueOf(url));
+  }
+
+  @Override
+  public WorkflowTaskResult execute(WorkflowTaskContext context) throws Exception {
+    HttpRequest request = buildRequest(context.configuration());
+    context.logger().log(request.method() + " " + request.uri());
+    CompletableFuture<HttpResponse<String>> future = client.sendAsync(
+        request,
+        HttpResponse.BodyHandlers.ofString());
+    runningRequests.put(context.attemptId(), future);
+    try {
+      while (!future.isDone()) {
+        if (context.cancellationToken().isCancellationRequested()) {
+          future.cancel(true);
+          context.cancellationToken().throwIfCancellationRequested();
+        }
+        TimeUnit.MILLISECONDS.sleep(100L);
+      }
+      HttpResponse<String> response = future.join();
+      int statusCode = response.statusCode();
+      context.logger().log("HTTP status: " + statusCode);
+      if (!successCodes(context.configuration()).contains(statusCode)) {
+        return WorkflowTaskResult.failure(
+            "HTTP request returned status " + statusCode + ": " + abbreviate(response.body()));
+      }
+      Map<String, Object> outputs = new LinkedHashMap<>();
+      outputs.put("statusCode", statusCode);
+      outputs.put("body", response.body());
+      return WorkflowTaskResult.succeeded(null, outputs, "HTTP request completed");
+    } finally {
+      runningRequests.remove(context.attemptId());
+    }
+  }
+
+  @Override
+  public void cancel(WorkflowTaskContext context) {
+    CompletableFuture<?> future = runningRequests.get(context.attemptId());
+    if (future != null) {
+      future.cancel(true);
+    }
+  }
+
+  private static HttpRequest buildRequest(Map<String, Object> configuration) {
+    String method = String.valueOf(configuration.getOrDefault("method", "GET")).toUpperCase();
+    String body = String.valueOf(configuration.getOrDefault("body", ""));
+    int requestTimeoutSeconds = integer(configuration.get("requestTimeoutSeconds"), 60);
+    HttpRequest.Builder builder = HttpRequest.newBuilder(URI.create(String.valueOf(configuration.get("url"))))
+        .timeout(Duration.ofSeconds(Math.max(1, requestTimeoutSeconds)));
+    Object headers = configuration.get("headers");
+    if (headers instanceof Map<?, ?> values) {
+      values.forEach((key, value) -> builder.header(String.valueOf(key), String.valueOf(value)));
+    }
+    HttpRequest.BodyPublisher publisher = body.isEmpty()
+        ? HttpRequest.BodyPublishers.noBody()
+        : HttpRequest.BodyPublishers.ofString(body);
+    return builder.method(method, publisher).build();
+  }
+
+  private static Set<Integer> successCodes(Map<String, Object> configuration) {
+    Object configured = configuration.get("successCodes");
+    if (configured instanceof List<?> values && !values.isEmpty()) {
+      return values.stream().map(value -> Integer.parseInt(String.valueOf(value))).collect(java.util.stream.Collectors.toSet());
+    }
+    return java.util.stream.IntStream.rangeClosed(200, 299).boxed().collect(java.util.stream.Collectors.toSet());
+  }
+
+  private static int integer(Object value, int fallback) {
+    return value == null ? fallback : Integer.parseInt(String.valueOf(value));
+  }
+
+  private static String abbreviate(String value) {
+    if (value == null || value.length() <= 500) {
+      return value;
+    }
+    return value.substring(0, 500) + "...";
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/executor/NoopWorkflowTaskExecutor.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/executor/NoopWorkflowTaskExecutor.java
@@ -1,0 +1,25 @@
+package io.yak.ops.business.workflow.executor;
+
+import io.yak.ops.business.workflow.config.ConditionalOnWorkflowEnabled;
+import io.yak.ops.spi.workflow.WorkflowTaskContext;
+import io.yak.ops.spi.workflow.WorkflowTaskExecutor;
+import io.yak.ops.spi.workflow.WorkflowTaskResult;
+import org.springframework.stereotype.Component;
+
+/** Lightweight task useful for DAG validation, smoke tests and explicit synchronization points. */
+@ConditionalOnWorkflowEnabled
+@Component
+public final class NoopWorkflowTaskExecutor implements WorkflowTaskExecutor {
+
+  @Override
+  public String type() {
+    return "NOOP";
+  }
+
+  @Override
+  public WorkflowTaskResult execute(WorkflowTaskContext context) {
+    context.cancellationToken().throwIfCancellationRequested();
+    context.logger().log("NOOP task completed");
+    return WorkflowTaskResult.succeeded();
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/executor/ShellWorkflowTaskExecutor.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/executor/ShellWorkflowTaskExecutor.java
@@ -1,0 +1,120 @@
+package io.yak.ops.business.workflow.executor;
+
+import io.yak.ops.business.workflow.config.ConditionalOnWorkflowEnabled;
+import io.yak.ops.spi.workflow.WorkflowTaskContext;
+import io.yak.ops.spi.workflow.WorkflowTaskExecutor;
+import io.yak.ops.spi.workflow.WorkflowTaskResult;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import org.springframework.stereotype.Component;
+
+/** Executes an administrator-provided local shell command in the Yak Ops process host. */
+@ConditionalOnWorkflowEnabled
+@Component
+public final class ShellWorkflowTaskExecutor implements WorkflowTaskExecutor {
+
+  private final Map<Long, Process> runningProcesses = new ConcurrentHashMap<>();
+
+  @Override
+  public String type() {
+    return "SHELL";
+  }
+
+  @Override
+  public void validate(Map<String, Object> configuration) {
+    Object command = configuration == null ? null : configuration.get("command");
+    Object args = configuration == null ? null : configuration.get("args");
+    if ((command == null || String.valueOf(command).isBlank()) && !(args instanceof List<?> list && !list.isEmpty())) {
+      throw new IllegalArgumentException("SHELL task requires a non-blank command or args list");
+    }
+  }
+
+  @Override
+  public WorkflowTaskResult execute(WorkflowTaskContext context) throws Exception {
+    List<String> command = resolveCommand(context.configuration());
+    ProcessBuilder builder = new ProcessBuilder(command).redirectErrorStream(true);
+    Object workDirectory = context.configuration().get("workDirectory");
+    if (workDirectory != null && !String.valueOf(workDirectory).isBlank()) {
+      builder.directory(new File(String.valueOf(workDirectory)));
+    }
+    Object environment = context.configuration().get("environment");
+    if (environment instanceof Map<?, ?> values) {
+      values.forEach((key, value) -> builder.environment().put(String.valueOf(key), String.valueOf(value)));
+    }
+
+    context.logger().log("Starting command: " + String.join(" ", command));
+    Process process = builder.start();
+    runningProcesses.put(context.attemptId(), process);
+    Thread outputReader = Thread.ofVirtual().name("yak-workflow-shell-log-" + context.attemptId()).start(() -> {
+      try (BufferedReader reader = new BufferedReader(
+          new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
+        String line;
+        while ((line = reader.readLine()) != null) {
+          context.logger().log(line);
+        }
+      } catch (Exception error) {
+        context.logger().log("Failed to read process output: " + error.getMessage());
+      }
+    });
+
+    try {
+      while (!process.waitFor(200, TimeUnit.MILLISECONDS)) {
+        if (context.cancellationToken().isCancellationRequested()) {
+          terminate(process);
+          context.cancellationToken().throwIfCancellationRequested();
+        }
+      }
+      outputReader.join(2_000L);
+      int exitCode = process.exitValue();
+      context.logger().log("Command exited with code " + exitCode);
+      if (exitCode != 0) {
+        return WorkflowTaskResult.failure("Shell command exited with code " + exitCode);
+      }
+      return WorkflowTaskResult.succeeded(
+          Long.toString(process.pid()),
+          Map.of("exitCode", exitCode),
+          "Shell command completed");
+    } finally {
+      runningProcesses.remove(context.attemptId());
+    }
+  }
+
+  @Override
+  public void cancel(WorkflowTaskContext context) {
+    Process process = runningProcesses.get(context.attemptId());
+    if (process != null) {
+      terminate(process);
+    }
+  }
+
+  private static List<String> resolveCommand(Map<String, Object> configuration) {
+    Object args = configuration.get("args");
+    if (args instanceof List<?> values && !values.isEmpty()) {
+      List<String> command = new ArrayList<>(values.size());
+      values.forEach(value -> command.add(String.valueOf(value)));
+      return command;
+    }
+    String command = String.valueOf(configuration.get("command"));
+    boolean windows = System.getProperty("os.name", "").toLowerCase().contains("win");
+    return windows ? List.of("cmd.exe", "/c", command) : List.of("/bin/sh", "-c", command);
+  }
+
+  private static void terminate(Process process) {
+    process.destroy();
+    try {
+      if (!process.waitFor(2, TimeUnit.SECONDS)) {
+        process.destroyForcibly();
+      }
+    } catch (InterruptedException interrupted) {
+      Thread.currentThread().interrupt();
+      process.destroyForcibly();
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/model/WorkflowDag.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/model/WorkflowDag.java
@@ -1,0 +1,37 @@
+package io.yak.ops.business.workflow.model;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/** Serializable workflow DAG snapshot stored in each published version. */
+public record WorkflowDag(List<Node> nodes, List<Edge> edges) {
+
+  public WorkflowDag {
+    nodes = nodes == null ? List.of() : List.copyOf(nodes);
+    edges = edges == null ? List.of() : List.copyOf(edges);
+  }
+
+  public record Node(
+      String key,
+      String name,
+      String type,
+      Map<String, Object> config,
+      int retryTimes,
+      int retryIntervalSeconds,
+      int timeoutSeconds,
+      boolean enabled,
+      boolean idempotent,
+      boolean retryOnRestart) {
+
+    public Node {
+      config = config == null || config.isEmpty()
+          ? Map.of()
+          : Collections.unmodifiableMap(new LinkedHashMap<>(config));
+    }
+  }
+
+  public record Edge(String from, String to) {
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/model/WorkflowEnums.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/model/WorkflowEnums.java
@@ -1,0 +1,75 @@
+package io.yak.ops.business.workflow.model;
+
+/** Shared workflow state and policy enums. */
+public final class WorkflowEnums {
+
+  private WorkflowEnums() {
+  }
+
+  public enum DefinitionState {
+    DRAFT,
+    PUBLISHED,
+    OFFLINE
+  }
+
+  public enum FailureStrategy {
+    FAIL_FAST,
+    CONTINUE
+  }
+
+  public enum TriggerType {
+    MANUAL,
+    SCHEDULE,
+    RECOVERY
+  }
+
+  public enum WorkflowState {
+    PENDING,
+    RUNNING,
+    STOPPING,
+    SUCCESS,
+    FAILED,
+    STOPPED;
+
+    public boolean isTerminal() {
+      return this == SUCCESS || this == FAILED || this == STOPPED;
+    }
+  }
+
+  public enum TaskState {
+    WAITING,
+    READY,
+    RUNNING,
+    RETRY_WAITING,
+    SUCCESS,
+    FAILED,
+    SKIPPED,
+    STOPPED;
+
+    public boolean isTerminal() {
+      return this == SUCCESS || this == FAILED || this == SKIPPED || this == STOPPED;
+    }
+
+    public boolean satisfiesDependency() {
+      return this == SUCCESS || this == SKIPPED;
+    }
+  }
+
+  public enum AttemptState {
+    RUNNING,
+    SUCCESS,
+    FAILED,
+    STOPPED,
+    INTERRUPTED
+  }
+
+  public enum MisfirePolicy {
+    FIRE_NOW,
+    DO_NOTHING
+  }
+
+  public enum ScheduleConcurrencyPolicy {
+    PARALLEL,
+    SKIP_IF_RUNNING
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/model/WorkflowRecords.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/model/WorkflowRecords.java
@@ -1,0 +1,104 @@
+package io.yak.ops.business.workflow.model;
+
+import io.yak.ops.business.workflow.model.WorkflowEnums.AttemptState;
+import io.yak.ops.business.workflow.model.WorkflowEnums.DefinitionState;
+import io.yak.ops.business.workflow.model.WorkflowEnums.FailureStrategy;
+import io.yak.ops.business.workflow.model.WorkflowEnums.MisfirePolicy;
+import io.yak.ops.business.workflow.model.WorkflowEnums.ScheduleConcurrencyPolicy;
+import io.yak.ops.business.workflow.model.WorkflowEnums.TaskState;
+import io.yak.ops.business.workflow.model.WorkflowEnums.TriggerType;
+import io.yak.ops.business.workflow.model.WorkflowEnums.WorkflowState;
+import java.time.Instant;
+import java.util.Map;
+
+/** Immutable records returned by the workflow repository and REST layer. */
+public final class WorkflowRecords {
+
+  private WorkflowRecords() {
+  }
+
+  public record Definition(
+      long id,
+      String code,
+      String name,
+      String description,
+      DefinitionState state,
+      Integer currentVersion,
+      FailureStrategy failureStrategy,
+      int maxParallelism,
+      WorkflowDag draft,
+      String createdBy,
+      Instant createdAt,
+      Instant updatedAt) {
+  }
+
+  public record Version(
+      long id,
+      long workflowId,
+      int version,
+      WorkflowDag dag,
+      String contentHash,
+      String publishedBy,
+      Instant publishedAt) {
+  }
+
+  public record Instance(
+      long id,
+      long workflowId,
+      int workflowVersion,
+      TriggerType triggerType,
+      WorkflowState state,
+      Map<String, Object> globalParameters,
+      FailureStrategy failureStrategy,
+      int maxParallelism,
+      boolean stopRequested,
+      Instant startTime,
+      Instant endTime,
+      String createdBy,
+      Instant createdAt) {
+  }
+
+  public record TaskInstance(
+      long id,
+      long workflowInstanceId,
+      String nodeKey,
+      String nodeName,
+      String taskType,
+      TaskState state,
+      Map<String, Object> configuration,
+      int maxRetryTimes,
+      int retryCount,
+      int retryIntervalSeconds,
+      int timeoutSeconds,
+      boolean idempotent,
+      boolean retryOnRestart,
+      Instant nextRetryTime,
+      Instant startTime,
+      Instant endTime,
+      Map<String, Object> resultData,
+      String errorMessage) {
+  }
+
+  public record Attempt(
+      long id,
+      long taskInstanceId,
+      int attemptNo,
+      AttemptState state,
+      String executorType,
+      String externalId,
+      Instant startTime,
+      Instant endTime,
+      String errorMessage) {
+  }
+
+  public record Schedule(
+      long id,
+      long workflowId,
+      String cronExpression,
+      String timezone,
+      boolean enabled,
+      MisfirePolicy misfirePolicy,
+      ScheduleConcurrencyPolicy concurrencyPolicy,
+      Instant updatedAt) {
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/repository/JdbcWorkflowRepository.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/repository/JdbcWorkflowRepository.java
@@ -1,0 +1,782 @@
+package io.yak.ops.business.workflow.repository;
+
+import io.yak.ops.business.workflow.config.ConditionalOnWorkflowEnabled;
+import io.yak.ops.business.workflow.model.WorkflowDag;
+import io.yak.ops.business.workflow.model.WorkflowEnums.AttemptState;
+import io.yak.ops.business.workflow.model.WorkflowEnums.DefinitionState;
+import io.yak.ops.business.workflow.model.WorkflowEnums.FailureStrategy;
+import io.yak.ops.business.workflow.model.WorkflowEnums.MisfirePolicy;
+import io.yak.ops.business.workflow.model.WorkflowEnums.ScheduleConcurrencyPolicy;
+import io.yak.ops.business.workflow.model.WorkflowEnums.TaskState;
+import io.yak.ops.business.workflow.model.WorkflowEnums.TriggerType;
+import io.yak.ops.business.workflow.model.WorkflowEnums.WorkflowState;
+import io.yak.ops.business.workflow.model.WorkflowRecords.Attempt;
+import io.yak.ops.business.workflow.model.WorkflowRecords.Definition;
+import io.yak.ops.business.workflow.model.WorkflowRecords.Instance;
+import io.yak.ops.business.workflow.model.WorkflowRecords.Schedule;
+import io.yak.ops.business.workflow.model.WorkflowRecords.TaskInstance;
+import io.yak.ops.business.workflow.model.WorkflowRecords.Version;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.support.GeneratedKeyHolder;
+import org.springframework.jdbc.support.KeyHolder;
+import org.springframework.stereotype.Repository;
+
+/** JDBC persistence boundary for workflow definitions, immutable versions and runtime instances. */
+@ConditionalOnWorkflowEnabled
+@Repository
+public final class JdbcWorkflowRepository {
+
+  private static final Set<WorkflowState> RECOVERABLE_STATES =
+      Set.of(WorkflowState.PENDING, WorkflowState.RUNNING, WorkflowState.STOPPING);
+
+  private final NamedParameterJdbcTemplate jdbc;
+  private final WorkflowJsonCodec codec;
+  private final AtomicLong logSequence = new AtomicLong();
+
+  public JdbcWorkflowRepository(
+      @Qualifier("workflowJdbcTemplate") NamedParameterJdbcTemplate workflowJdbcTemplate,
+      WorkflowJsonCodec codec) {
+    this.jdbc = workflowJdbcTemplate;
+    this.codec = codec;
+  }
+
+  public long createDefinition(
+      String code,
+      String name,
+      String description,
+      FailureStrategy failureStrategy,
+      int maxParallelism,
+      WorkflowDag draft,
+      String operator) {
+    Instant now = Instant.now();
+    MapSqlParameterSource params = new MapSqlParameterSource()
+        .addValue("code", code)
+        .addValue("name", name)
+        .addValue("description", description)
+        .addValue("state", DefinitionState.DRAFT.name())
+        .addValue("failureStrategy", failureStrategy.name())
+        .addValue("maxParallelism", maxParallelism)
+        .addValue("draftJson", codec.write(draft))
+        .addValue("createdBy", operator)
+        .addValue("createdAt", timestamp(now))
+        .addValue("updatedAt", timestamp(now));
+    KeyHolder keys = new GeneratedKeyHolder();
+    jdbc.update("""
+        INSERT INTO yak_wf_definition
+          (code, name, description, state, current_version, failure_strategy,
+           max_parallelism, draft_json, created_by, created_at, updated_at)
+        VALUES
+          (:code, :name, :description, :state, NULL, :failureStrategy,
+           :maxParallelism, :draftJson, :createdBy, :createdAt, :updatedAt)
+        """, params, keys, new String[] {"id"});
+    return requiredKey(keys);
+  }
+
+  public void updateDraft(
+      long workflowId,
+      String name,
+      String description,
+      FailureStrategy failureStrategy,
+      int maxParallelism,
+      WorkflowDag draft) {
+    int updated = jdbc.update("""
+        UPDATE yak_wf_definition
+        SET name = :name,
+            description = :description,
+            failure_strategy = :failureStrategy,
+            max_parallelism = :maxParallelism,
+            draft_json = :draftJson,
+            updated_at = :updatedAt
+        WHERE id = :id
+        """, new MapSqlParameterSource()
+        .addValue("id", workflowId)
+        .addValue("name", name)
+        .addValue("description", description)
+        .addValue("failureStrategy", failureStrategy.name())
+        .addValue("maxParallelism", maxParallelism)
+        .addValue("draftJson", codec.write(draft))
+        .addValue("updatedAt", timestamp(Instant.now())));
+    requireUpdated(updated, "Workflow definition does not exist: " + workflowId);
+  }
+
+  public Optional<Definition> findDefinition(long workflowId) {
+    return queryOptional("""
+        SELECT id, code, name, description, state, current_version, failure_strategy,
+               max_parallelism, draft_json, created_by, created_at, updated_at
+        FROM yak_wf_definition
+        WHERE id = :id
+        """, Map.of("id", workflowId), this::mapDefinition);
+  }
+
+  public List<Definition> listDefinitions() {
+    return jdbc.query("""
+        SELECT id, code, name, description, state, current_version, failure_strategy,
+               max_parallelism, draft_json, created_by, created_at, updated_at
+        FROM yak_wf_definition
+        ORDER BY updated_at DESC, id DESC
+        """, Map.of(), this::mapDefinition);
+  }
+
+  public Version publishVersion(long workflowId, WorkflowDag dag, String operator) {
+    Definition definition = findDefinition(workflowId)
+        .orElseThrow(() -> new IllegalArgumentException("Workflow definition does not exist: " + workflowId));
+    int version = definition.currentVersion() == null ? 1 : definition.currentVersion() + 1;
+    Instant now = Instant.now();
+    String contentHash = codec.sha256(dag);
+    MapSqlParameterSource params = new MapSqlParameterSource()
+        .addValue("workflowId", workflowId)
+        .addValue("version", version)
+        .addValue("dagJson", codec.write(dag))
+        .addValue("contentHash", contentHash)
+        .addValue("publishedBy", operator)
+        .addValue("publishedAt", timestamp(now));
+    KeyHolder keys = new GeneratedKeyHolder();
+    jdbc.update("""
+        INSERT INTO yak_wf_version
+          (workflow_id, version, dag_json, content_hash, published_by, published_at)
+        VALUES
+          (:workflowId, :version, :dagJson, :contentHash, :publishedBy, :publishedAt)
+        """, params, keys, new String[] {"id"});
+    jdbc.update("""
+        UPDATE yak_wf_definition
+        SET state = :state, current_version = :version, updated_at = :updatedAt
+        WHERE id = :workflowId
+        """, new MapSqlParameterSource()
+        .addValue("state", DefinitionState.PUBLISHED.name())
+        .addValue("version", version)
+        .addValue("updatedAt", timestamp(now))
+        .addValue("workflowId", workflowId));
+    return new Version(requiredKey(keys), workflowId, version, dag, contentHash, operator, now);
+  }
+
+  public Optional<Version> findVersion(long workflowId, int version) {
+    return queryOptional("""
+        SELECT id, workflow_id, version, dag_json, content_hash, published_by, published_at
+        FROM yak_wf_version
+        WHERE workflow_id = :workflowId AND version = :version
+        """, Map.of("workflowId", workflowId, "version", version), this::mapVersion);
+  }
+
+  public long createInstance(
+      Definition definition,
+      Version version,
+      TriggerType triggerType,
+      Map<String, Object> globalParameters,
+      String operator) {
+    Instant now = Instant.now();
+    MapSqlParameterSource params = new MapSqlParameterSource()
+        .addValue("workflowId", definition.id())
+        .addValue("workflowVersion", version.version())
+        .addValue("triggerType", triggerType.name())
+        .addValue("state", WorkflowState.PENDING.name())
+        .addValue("globalParams", codec.write(globalParameters))
+        .addValue("failureStrategy", definition.failureStrategy().name())
+        .addValue("maxParallelism", definition.maxParallelism())
+        .addValue("createdBy", operator)
+        .addValue("createdAt", timestamp(now));
+    KeyHolder keys = new GeneratedKeyHolder();
+    jdbc.update("""
+        INSERT INTO yak_wf_instance
+          (workflow_id, workflow_version, trigger_type, state, global_params_json,
+           failure_strategy, max_parallelism, stop_requested, created_by, created_at)
+        VALUES
+          (:workflowId, :workflowVersion, :triggerType, :state, :globalParams,
+           :failureStrategy, :maxParallelism, 0, :createdBy, :createdAt)
+        """, params, keys, new String[] {"id"});
+    long instanceId = requiredKey(keys);
+    for (WorkflowDag.Node node : version.dag().nodes()) {
+      TaskState initialState = node.enabled() ? TaskState.WAITING : TaskState.SKIPPED;
+      jdbc.update("""
+          INSERT INTO yak_wf_task_instance
+            (workflow_instance_id, node_key, node_name, task_type, state, config_json,
+             max_retry_times, retry_count, retry_interval_seconds, timeout_seconds,
+             idempotent, retry_on_restart, next_retry_time, start_time, end_time,
+             result_json, error_message, lock_version)
+          VALUES
+            (:instanceId, :nodeKey, :nodeName, :taskType, :state, :configJson,
+             :maxRetryTimes, 0, :retryIntervalSeconds, :timeoutSeconds,
+             :idempotent, :retryOnRestart, NULL, NULL, :endTime,
+             NULL, NULL, 0)
+          """, new MapSqlParameterSource()
+          .addValue("instanceId", instanceId)
+          .addValue("nodeKey", node.key())
+          .addValue("nodeName", node.name())
+          .addValue("taskType", node.type())
+          .addValue("state", initialState.name())
+          .addValue("configJson", codec.write(node.config()))
+          .addValue("maxRetryTimes", node.retryTimes())
+          .addValue("retryIntervalSeconds", node.retryIntervalSeconds())
+          .addValue("timeoutSeconds", node.timeoutSeconds())
+          .addValue("idempotent", node.idempotent())
+          .addValue("retryOnRestart", node.retryOnRestart())
+          .addValue("endTime", initialState == TaskState.SKIPPED ? timestamp(now) : null));
+    }
+    return instanceId;
+  }
+
+  public Optional<Instance> findInstance(long instanceId) {
+    return queryOptional("""
+        SELECT id, workflow_id, workflow_version, trigger_type, state, global_params_json,
+               failure_strategy, max_parallelism, stop_requested, start_time, end_time,
+               created_by, created_at
+        FROM yak_wf_instance
+        WHERE id = :id
+        """, Map.of("id", instanceId), this::mapInstance);
+  }
+
+  public List<Instance> listInstances(long workflowId, int limit) {
+    return jdbc.query("""
+        SELECT id, workflow_id, workflow_version, trigger_type, state, global_params_json,
+               failure_strategy, max_parallelism, stop_requested, start_time, end_time,
+               created_by, created_at
+        FROM yak_wf_instance
+        WHERE workflow_id = :workflowId
+        ORDER BY id DESC
+        LIMIT :limit
+        """, Map.of("workflowId", workflowId, "limit", Math.max(1, Math.min(limit, 200))), this::mapInstance);
+  }
+
+  public List<Long> findRecoverableInstanceIds(int limit) {
+    return jdbc.queryForList("""
+        SELECT id
+        FROM yak_wf_instance
+        WHERE state IN (:states)
+        ORDER BY id
+        LIMIT :limit
+        """, Map.of(
+        "states", RECOVERABLE_STATES.stream().map(Enum::name).toList(),
+        "limit", Math.max(1, limit)), Long.class);
+  }
+
+  public boolean hasRunningInstance(long workflowId) {
+    Integer count = jdbc.queryForObject("""
+        SELECT COUNT(1)
+        FROM yak_wf_instance
+        WHERE workflow_id = :workflowId
+          AND state IN (:states)
+        """, Map.of(
+        "workflowId", workflowId,
+        "states", RECOVERABLE_STATES.stream().map(Enum::name).toList()), Integer.class);
+    return count != null && count > 0;
+  }
+
+  public void markInstanceRunning(long instanceId) {
+    jdbc.update("""
+        UPDATE yak_wf_instance
+        SET state = :running,
+            start_time = COALESCE(start_time, :startTime),
+            lock_version = lock_version + 1
+        WHERE id = :id AND state = :pending
+        """, Map.of(
+        "running", WorkflowState.RUNNING.name(),
+        "startTime", timestamp(Instant.now()),
+        "id", instanceId,
+        "pending", WorkflowState.PENDING.name()));
+  }
+
+  public void requestStop(long instanceId) {
+    int updated = jdbc.update("""
+        UPDATE yak_wf_instance
+        SET stop_requested = 1,
+            state = CASE WHEN state IN (:activeStates) THEN :stopping ELSE state END,
+            lock_version = lock_version + 1
+        WHERE id = :id AND state NOT IN (:terminalStates)
+        """, Map.of(
+        "activeStates", List.of(WorkflowState.PENDING.name(), WorkflowState.RUNNING.name()),
+        "stopping", WorkflowState.STOPPING.name(),
+        "id", instanceId,
+        "terminalStates", List.of(
+            WorkflowState.SUCCESS.name(), WorkflowState.FAILED.name(), WorkflowState.STOPPED.name())));
+    requireUpdated(updated, "Workflow instance cannot be stopped: " + instanceId);
+  }
+
+  public void finishInstance(long instanceId, WorkflowState state) {
+    if (!state.isTerminal()) {
+      throw new IllegalArgumentException("Workflow final state required: " + state);
+    }
+    jdbc.update("""
+        UPDATE yak_wf_instance
+        SET state = :state, end_time = :endTime, lock_version = lock_version + 1
+        WHERE id = :id AND state NOT IN (:terminalStates)
+        """, Map.of(
+        "state", state.name(),
+        "endTime", timestamp(Instant.now()),
+        "id", instanceId,
+        "terminalStates", List.of(
+            WorkflowState.SUCCESS.name(), WorkflowState.FAILED.name(), WorkflowState.STOPPED.name())));
+  }
+
+  public List<TaskInstance> findTasks(long workflowInstanceId) {
+    return jdbc.query("""
+        SELECT id, workflow_instance_id, node_key, node_name, task_type, state, config_json,
+               max_retry_times, retry_count, retry_interval_seconds, timeout_seconds,
+               idempotent, retry_on_restart, next_retry_time, start_time, end_time,
+               result_json, error_message
+        FROM yak_wf_task_instance
+        WHERE workflow_instance_id = :instanceId
+        ORDER BY id
+        """, Map.of("instanceId", workflowInstanceId), this::mapTaskInstance);
+  }
+
+  public Optional<TaskInstance> findTask(long taskInstanceId) {
+    return queryOptional("""
+        SELECT id, workflow_instance_id, node_key, node_name, task_type, state, config_json,
+               max_retry_times, retry_count, retry_interval_seconds, timeout_seconds,
+               idempotent, retry_on_restart, next_retry_time, start_time, end_time,
+               result_json, error_message
+        FROM yak_wf_task_instance
+        WHERE id = :id
+        """, Map.of("id", taskInstanceId), this::mapTaskInstance);
+  }
+
+  public boolean claimTask(long taskInstanceId) {
+    return jdbc.update("""
+        UPDATE yak_wf_task_instance
+        SET state = :running,
+            start_time = COALESCE(start_time, :startTime),
+            next_retry_time = NULL,
+            lock_version = lock_version + 1
+        WHERE id = :id
+          AND state IN (:claimable)
+          AND (next_retry_time IS NULL OR next_retry_time <= :now)
+        """, Map.of(
+        "running", TaskState.RUNNING.name(),
+        "startTime", timestamp(Instant.now()),
+        "id", taskInstanceId,
+        "claimable", List.of(TaskState.WAITING.name(), TaskState.READY.name(), TaskState.RETRY_WAITING.name()),
+        "now", timestamp(Instant.now()))) == 1;
+  }
+
+  public long createAttempt(TaskInstance task) {
+    int attemptNo = task.retryCount() + 1;
+    MapSqlParameterSource params = new MapSqlParameterSource()
+        .addValue("taskInstanceId", task.id())
+        .addValue("attemptNo", attemptNo)
+        .addValue("state", AttemptState.RUNNING.name())
+        .addValue("executorType", task.taskType())
+        .addValue("startTime", timestamp(Instant.now()));
+    KeyHolder keys = new GeneratedKeyHolder();
+    jdbc.update("""
+        INSERT INTO yak_wf_task_attempt
+          (task_instance_id, attempt_no, state, executor_type, start_time)
+        VALUES
+          (:taskInstanceId, :attemptNo, :state, :executorType, :startTime)
+        """, params, keys, new String[] {"id"});
+    return requiredKey(keys);
+  }
+
+  public void finishAttempt(
+      long attemptId,
+      AttemptState state,
+      String externalId,
+      String errorMessage) {
+    jdbc.update("""
+        UPDATE yak_wf_task_attempt
+        SET state = :state,
+            external_id = :externalId,
+            error_message = :errorMessage,
+            end_time = :endTime
+        WHERE id = :id AND state = :running
+        """, new MapSqlParameterSource()
+        .addValue("state", state.name())
+        .addValue("externalId", externalId)
+        .addValue("errorMessage", errorMessage)
+        .addValue("endTime", timestamp(Instant.now()))
+        .addValue("id", attemptId)
+        .addValue("running", AttemptState.RUNNING.name()));
+  }
+
+  public void appendLog(long attemptId, String content) {
+    if (content == null) {
+      return;
+    }
+    long lineNo = Math.max(Instant.now().toEpochMilli() * 1_000L, logSequence.incrementAndGet());
+    jdbc.update("""
+        INSERT INTO yak_wf_task_log (task_attempt_id, line_no, content, created_at)
+        VALUES (:attemptId, :lineNo, :content, :createdAt)
+        """, Map.of(
+        "attemptId", attemptId,
+        "lineNo", lineNo,
+        "content", content,
+        "createdAt", timestamp(Instant.now())));
+  }
+
+  public List<String> findLogs(long taskInstanceId, int limit) {
+    return jdbc.queryForList("""
+        SELECT log.content
+        FROM yak_wf_task_log log
+        JOIN yak_wf_task_attempt attempt ON attempt.id = log.task_attempt_id
+        WHERE attempt.task_instance_id = :taskInstanceId
+        ORDER BY log.id
+        LIMIT :limit
+        """, Map.of(
+        "taskInstanceId", taskInstanceId,
+        "limit", Math.max(1, Math.min(limit, 10_000))), String.class);
+  }
+
+  public List<Attempt> findAttempts(long taskInstanceId) {
+    return jdbc.query("""
+        SELECT id, task_instance_id, attempt_no, state, executor_type, external_id,
+               start_time, end_time, error_message
+        FROM yak_wf_task_attempt
+        WHERE task_instance_id = :taskInstanceId
+        ORDER BY attempt_no
+        """, Map.of("taskInstanceId", taskInstanceId), this::mapAttempt);
+  }
+
+  public void markTaskSuccess(long taskInstanceId, Map<String, Object> resultData) {
+    jdbc.update("""
+        UPDATE yak_wf_task_instance
+        SET state = :state,
+            result_json = :resultJson,
+            error_message = NULL,
+            end_time = :endTime,
+            lock_version = lock_version + 1
+        WHERE id = :id AND state = :running
+        """, new MapSqlParameterSource()
+        .addValue("state", TaskState.SUCCESS.name())
+        .addValue("resultJson", codec.write(resultData))
+        .addValue("endTime", timestamp(Instant.now()))
+        .addValue("id", taskInstanceId)
+        .addValue("running", TaskState.RUNNING.name()));
+  }
+
+  public void markTaskRetryWaiting(long taskInstanceId, int retryCount, Instant nextRetryTime, String errorMessage) {
+    jdbc.update("""
+        UPDATE yak_wf_task_instance
+        SET state = :state,
+            retry_count = :retryCount,
+            next_retry_time = :nextRetryTime,
+            error_message = :errorMessage,
+            lock_version = lock_version + 1
+        WHERE id = :id AND state = :running
+        """, new MapSqlParameterSource()
+        .addValue("state", TaskState.RETRY_WAITING.name())
+        .addValue("retryCount", retryCount)
+        .addValue("nextRetryTime", timestamp(nextRetryTime))
+        .addValue("errorMessage", errorMessage)
+        .addValue("id", taskInstanceId)
+        .addValue("running", TaskState.RUNNING.name()));
+  }
+
+  public void markTaskFailed(long taskInstanceId, int retryCount, String errorMessage) {
+    jdbc.update("""
+        UPDATE yak_wf_task_instance
+        SET state = :state,
+            retry_count = :retryCount,
+            error_message = :errorMessage,
+            end_time = :endTime,
+            lock_version = lock_version + 1
+        WHERE id = :id AND state IN (:activeStates)
+        """, new MapSqlParameterSource()
+        .addValue("state", TaskState.FAILED.name())
+        .addValue("retryCount", retryCount)
+        .addValue("errorMessage", errorMessage)
+        .addValue("endTime", timestamp(Instant.now()))
+        .addValue("id", taskInstanceId)
+        .addValue("activeStates", List.of(TaskState.RUNNING.name(), TaskState.RETRY_WAITING.name())));
+  }
+
+  public void markTaskStopped(long taskInstanceId, String message) {
+    jdbc.update("""
+        UPDATE yak_wf_task_instance
+        SET state = :state,
+            error_message = :message,
+            end_time = :endTime,
+            lock_version = lock_version + 1
+        WHERE id = :id AND state NOT IN (:terminalStates)
+        """, new MapSqlParameterSource()
+        .addValue("state", TaskState.STOPPED.name())
+        .addValue("message", message)
+        .addValue("endTime", timestamp(Instant.now()))
+        .addValue("id", taskInstanceId)
+        .addValue("terminalStates", terminalTaskStates()));
+  }
+
+  public int markTasksSkipped(long workflowInstanceId, Collection<String> nodeKeys, String reason) {
+    if (nodeKeys == null || nodeKeys.isEmpty()) {
+      return 0;
+    }
+    return jdbc.update("""
+        UPDATE yak_wf_task_instance
+        SET state = :state,
+            error_message = :reason,
+            end_time = :endTime,
+            lock_version = lock_version + 1
+        WHERE workflow_instance_id = :instanceId
+          AND node_key IN (:nodeKeys)
+          AND state NOT IN (:terminalStates)
+        """, new MapSqlParameterSource()
+        .addValue("state", TaskState.SKIPPED.name())
+        .addValue("reason", reason)
+        .addValue("endTime", timestamp(Instant.now()))
+        .addValue("instanceId", workflowInstanceId)
+        .addValue("nodeKeys", nodeKeys)
+        .addValue("terminalStates", terminalTaskStates()));
+  }
+
+  public int markAllPendingTasksSkipped(long workflowInstanceId, String reason) {
+    return jdbc.update("""
+        UPDATE yak_wf_task_instance
+        SET state = :state,
+            error_message = :reason,
+            end_time = :endTime,
+            lock_version = lock_version + 1
+        WHERE workflow_instance_id = :instanceId
+          AND state IN (:states)
+        """, new MapSqlParameterSource()
+        .addValue("state", TaskState.SKIPPED.name())
+        .addValue("reason", reason)
+        .addValue("endTime", timestamp(Instant.now()))
+        .addValue("instanceId", workflowInstanceId)
+        .addValue("states", List.of(
+            TaskState.WAITING.name(), TaskState.READY.name(), TaskState.RETRY_WAITING.name())));
+  }
+
+  public void interruptRunningTask(TaskInstance task) {
+    jdbc.update("""
+        UPDATE yak_wf_task_attempt
+        SET state = :interrupted, end_time = :endTime,
+            error_message = COALESCE(error_message, :message)
+        WHERE task_instance_id = :taskId AND state = :running
+        """, Map.of(
+        "interrupted", AttemptState.INTERRUPTED.name(),
+        "endTime", timestamp(Instant.now()),
+        "message", "Yak Ops restarted while the task was running",
+        "taskId", task.id(),
+        "running", AttemptState.RUNNING.name()));
+
+    boolean canRetry = task.retryOnRestart()
+        && task.idempotent()
+        && task.retryCount() < task.maxRetryTimes();
+    if (canRetry) {
+      jdbc.update("""
+          UPDATE yak_wf_task_instance
+          SET state = :retryWaiting,
+              retry_count = retry_count + 1,
+              next_retry_time = :nextRetryTime,
+              error_message = :message,
+              lock_version = lock_version + 1
+          WHERE id = :id AND state = :running
+          """, Map.of(
+          "retryWaiting", TaskState.RETRY_WAITING.name(),
+          "nextRetryTime", timestamp(Instant.now()),
+          "message", "Recovered after Yak Ops restart",
+          "id", task.id(),
+          "running", TaskState.RUNNING.name()));
+    } else {
+      markTaskFailed(
+          task.id(),
+          task.retryCount(),
+          "Task was interrupted by Yak Ops restart and is not configured for safe restart retry");
+    }
+  }
+
+  public Schedule upsertSchedule(
+      long workflowId,
+      String cronExpression,
+      String timezone,
+      boolean enabled,
+      MisfirePolicy misfirePolicy,
+      ScheduleConcurrencyPolicy concurrencyPolicy) {
+    Instant now = Instant.now();
+    jdbc.update("""
+        INSERT INTO yak_wf_schedule
+          (workflow_id, cron_expression, timezone, enabled, misfire_policy,
+           concurrency_policy, updated_at)
+        VALUES
+          (:workflowId, :cronExpression, :timezone, :enabled, :misfirePolicy,
+           :concurrencyPolicy, :updatedAt)
+        ON DUPLICATE KEY UPDATE
+          cron_expression = VALUES(cron_expression),
+          timezone = VALUES(timezone),
+          enabled = VALUES(enabled),
+          misfire_policy = VALUES(misfire_policy),
+          concurrency_policy = VALUES(concurrency_policy),
+          updated_at = VALUES(updated_at)
+        """, new MapSqlParameterSource()
+        .addValue("workflowId", workflowId)
+        .addValue("cronExpression", cronExpression)
+        .addValue("timezone", timezone)
+        .addValue("enabled", enabled)
+        .addValue("misfirePolicy", misfirePolicy.name())
+        .addValue("concurrencyPolicy", concurrencyPolicy.name())
+        .addValue("updatedAt", timestamp(now)));
+    return findSchedule(workflowId)
+        .orElseThrow(() -> new IllegalStateException("Workflow schedule was not persisted"));
+  }
+
+  public Optional<Schedule> findSchedule(long workflowId) {
+    return queryOptional("""
+        SELECT id, workflow_id, cron_expression, timezone, enabled,
+               misfire_policy, concurrency_policy, updated_at
+        FROM yak_wf_schedule
+        WHERE workflow_id = :workflowId
+        """, Map.of("workflowId", workflowId), this::mapSchedule);
+  }
+
+  public List<Schedule> findEnabledSchedules() {
+    return jdbc.query("""
+        SELECT id, workflow_id, cron_expression, timezone, enabled,
+               misfire_policy, concurrency_policy, updated_at
+        FROM yak_wf_schedule
+        WHERE enabled = 1
+        ORDER BY id
+        """, Map.of(), this::mapSchedule);
+  }
+
+  public void deleteSchedule(long workflowId) {
+    jdbc.update("DELETE FROM yak_wf_schedule WHERE workflow_id = :workflowId",
+        Map.of("workflowId", workflowId));
+  }
+
+  private Definition mapDefinition(ResultSet rs, int rowNum) throws SQLException {
+    Integer currentVersion = (Integer) rs.getObject("current_version");
+    return new Definition(
+        rs.getLong("id"),
+        rs.getString("code"),
+        rs.getString("name"),
+        rs.getString("description"),
+        DefinitionState.valueOf(rs.getString("state")),
+        currentVersion,
+        FailureStrategy.valueOf(rs.getString("failure_strategy")),
+        rs.getInt("max_parallelism"),
+        codec.readDag(rs.getString("draft_json")),
+        rs.getString("created_by"),
+        instant(rs.getTimestamp("created_at")),
+        instant(rs.getTimestamp("updated_at")));
+  }
+
+  private Version mapVersion(ResultSet rs, int rowNum) throws SQLException {
+    return new Version(
+        rs.getLong("id"),
+        rs.getLong("workflow_id"),
+        rs.getInt("version"),
+        codec.readDag(rs.getString("dag_json")),
+        rs.getString("content_hash"),
+        rs.getString("published_by"),
+        instant(rs.getTimestamp("published_at")));
+  }
+
+  private Instance mapInstance(ResultSet rs, int rowNum) throws SQLException {
+    return new Instance(
+        rs.getLong("id"),
+        rs.getLong("workflow_id"),
+        rs.getInt("workflow_version"),
+        TriggerType.valueOf(rs.getString("trigger_type")),
+        WorkflowState.valueOf(rs.getString("state")),
+        codec.readMap(rs.getString("global_params_json")),
+        FailureStrategy.valueOf(rs.getString("failure_strategy")),
+        rs.getInt("max_parallelism"),
+        rs.getBoolean("stop_requested"),
+        instant(rs.getTimestamp("start_time")),
+        instant(rs.getTimestamp("end_time")),
+        rs.getString("created_by"),
+        instant(rs.getTimestamp("created_at")));
+  }
+
+  private TaskInstance mapTaskInstance(ResultSet rs, int rowNum) throws SQLException {
+    return new TaskInstance(
+        rs.getLong("id"),
+        rs.getLong("workflow_instance_id"),
+        rs.getString("node_key"),
+        rs.getString("node_name"),
+        rs.getString("task_type"),
+        TaskState.valueOf(rs.getString("state")),
+        codec.readMap(rs.getString("config_json")),
+        rs.getInt("max_retry_times"),
+        rs.getInt("retry_count"),
+        rs.getInt("retry_interval_seconds"),
+        rs.getInt("timeout_seconds"),
+        rs.getBoolean("idempotent"),
+        rs.getBoolean("retry_on_restart"),
+        instant(rs.getTimestamp("next_retry_time")),
+        instant(rs.getTimestamp("start_time")),
+        instant(rs.getTimestamp("end_time")),
+        codec.readMap(rs.getString("result_json")),
+        rs.getString("error_message"));
+  }
+
+  private Attempt mapAttempt(ResultSet rs, int rowNum) throws SQLException {
+    return new Attempt(
+        rs.getLong("id"),
+        rs.getLong("task_instance_id"),
+        rs.getInt("attempt_no"),
+        AttemptState.valueOf(rs.getString("state")),
+        rs.getString("executor_type"),
+        rs.getString("external_id"),
+        instant(rs.getTimestamp("start_time")),
+        instant(rs.getTimestamp("end_time")),
+        rs.getString("error_message"));
+  }
+
+  private Schedule mapSchedule(ResultSet rs, int rowNum) throws SQLException {
+    return new Schedule(
+        rs.getLong("id"),
+        rs.getLong("workflow_id"),
+        rs.getString("cron_expression"),
+        rs.getString("timezone"),
+        rs.getBoolean("enabled"),
+        MisfirePolicy.valueOf(rs.getString("misfire_policy")),
+        ScheduleConcurrencyPolicy.valueOf(rs.getString("concurrency_policy")),
+        instant(rs.getTimestamp("updated_at")));
+  }
+
+  private <T> Optional<T> queryOptional(
+      String sql,
+      Map<String, ?> params,
+      RowMapper<T> mapper) {
+    try {
+      return Optional.ofNullable(jdbc.queryForObject(sql, params, mapper));
+    } catch (EmptyResultDataAccessException ignored) {
+      return Optional.empty();
+    }
+  }
+
+  private static List<String> terminalTaskStates() {
+    return List.of(
+        TaskState.SUCCESS.name(),
+        TaskState.FAILED.name(),
+        TaskState.SKIPPED.name(),
+        TaskState.STOPPED.name());
+  }
+
+  private static Timestamp timestamp(Instant value) {
+    return value == null ? null : Timestamp.from(value);
+  }
+
+  private static Instant instant(Timestamp value) {
+    return value == null ? null : value.toInstant();
+  }
+
+  private static long requiredKey(KeyHolder keys) {
+    Number key = keys.getKey();
+    if (key == null) {
+      throw new IllegalStateException("Database did not return a generated key");
+    }
+    return key.longValue();
+  }
+
+  private static void requireUpdated(int updated, String message) {
+    if (updated != 1) {
+      throw new IllegalArgumentException(message);
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/repository/WorkflowJsonCodec.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/repository/WorkflowJsonCodec.java
@@ -1,0 +1,64 @@
+package io.yak.ops.business.workflow.repository;
+
+import io.yak.ops.business.workflow.config.ConditionalOnWorkflowEnabled;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.workflow.model.WorkflowDag;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+import java.util.Map;
+import org.springframework.stereotype.Component;
+
+/** Central JSON serialization and content hashing for immutable workflow snapshots. */
+@ConditionalOnWorkflowEnabled
+@Component
+public final class WorkflowJsonCodec {
+
+  private static final TypeReference<Map<String, Object>> MAP_TYPE = new TypeReference<>() { };
+
+  private final ObjectMapper objectMapper;
+
+  public WorkflowJsonCodec(ObjectMapper objectMapper) {
+    this.objectMapper = objectMapper;
+  }
+
+  public String write(Object value) {
+    try {
+      return objectMapper.writeValueAsString(value == null ? Map.of() : value);
+    } catch (JsonProcessingException error) {
+      throw new IllegalArgumentException("Cannot serialize workflow JSON", error);
+    }
+  }
+
+  public WorkflowDag readDag(String json) {
+    try {
+      return objectMapper.readValue(json, WorkflowDag.class);
+    } catch (JsonProcessingException error) {
+      throw new IllegalStateException("Cannot deserialize workflow DAG", error);
+    }
+  }
+
+  public Map<String, Object> readMap(String json) {
+    if (json == null || json.isBlank()) {
+      return Map.of();
+    }
+    try {
+      return objectMapper.readValue(json, MAP_TYPE);
+    } catch (JsonProcessingException error) {
+      throw new IllegalStateException("Cannot deserialize workflow map", error);
+    }
+  }
+
+  public String sha256(Object value) {
+    try {
+      byte[] digest = MessageDigest.getInstance("SHA-256")
+          .digest(write(value).getBytes(StandardCharsets.UTF_8));
+      return HexFormat.of().formatHex(digest);
+    } catch (NoSuchAlgorithmException error) {
+      throw new IllegalStateException("SHA-256 is unavailable", error);
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/schedule/WorkflowQuartzJob.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/schedule/WorkflowQuartzJob.java
@@ -1,0 +1,40 @@
+package io.yak.ops.business.workflow.schedule;
+
+import io.yak.ops.business.workflow.model.WorkflowEnums.ScheduleConcurrencyPolicy;
+import io.yak.ops.business.workflow.model.WorkflowEnums.TriggerType;
+import io.yak.ops.business.workflow.model.WorkflowRecords.Schedule;
+import io.yak.ops.business.workflow.repository.JdbcWorkflowRepository;
+import io.yak.ops.business.workflow.service.WorkflowExecutionService;
+import org.quartz.Job;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.springframework.context.ApplicationContext;
+
+/** Quartz bridge that creates a durable workflow instance and immediately returns. */
+public final class WorkflowQuartzJob implements Job {
+
+  public static final String APPLICATION_CONTEXT_KEY = "yakWorkflowApplicationContext";
+  public static final String WORKFLOW_ID_KEY = "workflowId";
+
+  @Override
+  public void execute(JobExecutionContext context) throws JobExecutionException {
+    try {
+      ApplicationContext applicationContext =
+          (ApplicationContext) context.getScheduler().getContext().get(APPLICATION_CONTEXT_KEY);
+      long workflowId = context.getMergedJobDataMap().getLong(WORKFLOW_ID_KEY);
+      JdbcWorkflowRepository repository = applicationContext.getBean(JdbcWorkflowRepository.class);
+      Schedule schedule = repository.findSchedule(workflowId).orElse(null);
+      if (schedule == null || !schedule.enabled()) {
+        return;
+      }
+      if (schedule.concurrencyPolicy() == ScheduleConcurrencyPolicy.SKIP_IF_RUNNING
+          && repository.hasRunningInstance(workflowId)) {
+        return;
+      }
+      applicationContext.getBean(WorkflowExecutionService.class)
+          .trigger(workflowId, TriggerType.SCHEDULE, java.util.Map.of(), "QUARTZ");
+    } catch (Exception error) {
+      throw new JobExecutionException("Cannot trigger Yak Ops workflow", error, false);
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/schedule/WorkflowScheduleService.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/schedule/WorkflowScheduleService.java
@@ -1,0 +1,131 @@
+package io.yak.ops.business.workflow.schedule;
+
+import io.yak.ops.business.workflow.config.ConditionalOnWorkflowEnabled;
+import io.yak.ops.business.workflow.model.WorkflowEnums.MisfirePolicy;
+import io.yak.ops.business.workflow.model.WorkflowEnums.ScheduleConcurrencyPolicy;
+import io.yak.ops.business.workflow.model.WorkflowRecords.Schedule;
+import io.yak.ops.business.workflow.repository.JdbcWorkflowRepository;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.TimeZone;
+import org.quartz.CronExpression;
+import org.quartz.CronScheduleBuilder;
+import org.quartz.CronTrigger;
+import org.quartz.JobBuilder;
+import org.quartz.JobDetail;
+import org.quartz.JobKey;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+import org.quartz.TriggerBuilder;
+import org.quartz.TriggerKey;
+import org.springframework.context.event.EventListener;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/** Persists workflow schedules and mirrors them into the local Quartz scheduler. */
+@ConditionalOnWorkflowEnabled
+@Service
+public final class WorkflowScheduleService {
+
+  private static final String GROUP = "yak-workflow";
+
+  private final JdbcWorkflowRepository repository;
+  private final Scheduler scheduler;
+
+  public WorkflowScheduleService(JdbcWorkflowRepository repository, Scheduler scheduler) {
+    this.repository = repository;
+    this.scheduler = scheduler;
+  }
+
+  @Transactional(transactionManager = "workflowTransactionManager")
+  public Schedule upsert(
+      long workflowId,
+      String cronExpression,
+      String timezone,
+      boolean enabled,
+      MisfirePolicy misfirePolicy,
+      ScheduleConcurrencyPolicy concurrencyPolicy) {
+    repository.findDefinition(workflowId)
+        .orElseThrow(() -> new IllegalArgumentException(
+            "Workflow definition does not exist: " + workflowId));
+    validate(cronExpression, timezone);
+    Schedule schedule = repository.upsertSchedule(
+        workflowId,
+        cronExpression,
+        timezone,
+        enabled,
+        misfirePolicy == null ? MisfirePolicy.DO_NOTHING : misfirePolicy,
+        concurrencyPolicy == null ? ScheduleConcurrencyPolicy.SKIP_IF_RUNNING : concurrencyPolicy);
+    synchronize(schedule);
+    return schedule;
+  }
+
+  @Transactional(transactionManager = "workflowTransactionManager")
+  public void delete(long workflowId) {
+    repository.deleteSchedule(workflowId);
+    try {
+      scheduler.deleteJob(jobKey(workflowId));
+    } catch (SchedulerException error) {
+      throw new IllegalStateException("Cannot delete workflow Quartz job", error);
+    }
+  }
+
+  public Schedule get(long workflowId) {
+    return repository.findSchedule(workflowId)
+        .orElseThrow(() -> new IllegalArgumentException(
+            "Workflow schedule does not exist: " + workflowId));
+  }
+
+  @EventListener(ApplicationReadyEvent.class)
+  public void synchronizeEnabledSchedules() {
+    List<Schedule> schedules = repository.findEnabledSchedules();
+    for (Schedule schedule : schedules) {
+      synchronize(schedule);
+    }
+  }
+
+  private void synchronize(Schedule schedule) {
+    try {
+      JobKey jobKey = jobKey(schedule.workflowId());
+      if (!schedule.enabled()) {
+        scheduler.deleteJob(jobKey);
+        return;
+      }
+      JobDetail job = JobBuilder.newJob(WorkflowQuartzJob.class)
+          .withIdentity(jobKey)
+          .usingJobData(WorkflowQuartzJob.WORKFLOW_ID_KEY, schedule.workflowId())
+          .storeDurably(false)
+          .build();
+      CronScheduleBuilder cron = CronScheduleBuilder
+          .cronSchedule(schedule.cronExpression())
+          .inTimeZone(TimeZone.getTimeZone(ZoneId.of(schedule.timezone())));
+      cron = schedule.misfirePolicy() == MisfirePolicy.FIRE_NOW
+          ? cron.withMisfireHandlingInstructionFireAndProceed()
+          : cron.withMisfireHandlingInstructionDoNothing();
+      CronTrigger trigger = TriggerBuilder.newTrigger()
+          .withIdentity(triggerKey(schedule.workflowId()))
+          .forJob(job)
+          .withSchedule(cron)
+          .build();
+      scheduler.scheduleJob(job, java.util.Set.of(trigger), true);
+    } catch (SchedulerException error) {
+      throw new IllegalStateException("Cannot synchronize workflow schedule", error);
+    }
+  }
+
+  private static void validate(String cronExpression, String timezone) {
+    if (cronExpression == null || !CronExpression.isValidExpression(cronExpression)) {
+      throw new IllegalArgumentException("Invalid Quartz cron expression: " + cronExpression);
+    }
+    ZoneId.of(timezone == null || timezone.isBlank() ? "Asia/Shanghai" : timezone);
+  }
+
+  private static JobKey jobKey(long workflowId) {
+    return JobKey.jobKey("workflow-" + workflowId, GROUP);
+  }
+
+  private static TriggerKey triggerKey(long workflowId) {
+    return TriggerKey.triggerKey("workflow-" + workflowId, GROUP);
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowDefinitionService.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowDefinitionService.java
@@ -1,0 +1,98 @@
+package io.yak.ops.business.workflow.service;
+
+import io.yak.ops.business.workflow.config.ConditionalOnWorkflowEnabled;
+import io.yak.ops.business.workflow.dag.WorkflowDagCompiler;
+import io.yak.ops.business.workflow.model.WorkflowDag;
+import io.yak.ops.business.workflow.model.WorkflowEnums.FailureStrategy;
+import io.yak.ops.business.workflow.model.WorkflowRecords.Definition;
+import io.yak.ops.business.workflow.model.WorkflowRecords.Version;
+import io.yak.ops.business.workflow.repository.JdbcWorkflowRepository;
+import java.util.List;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/** Definition, draft and immutable publication use cases. */
+@ConditionalOnWorkflowEnabled
+@Service
+public class WorkflowDefinitionService {
+
+  private final JdbcWorkflowRepository repository;
+  private final WorkflowDagCompiler compiler;
+
+  public WorkflowDefinitionService(
+      JdbcWorkflowRepository repository,
+      WorkflowDagCompiler compiler) {
+    this.repository = repository;
+    this.compiler = compiler;
+  }
+
+  @Transactional(transactionManager = "workflowTransactionManager")
+  public long create(
+      String code,
+      String name,
+      String description,
+      FailureStrategy failureStrategy,
+      int maxParallelism,
+      WorkflowDag draft,
+      String operator) {
+    requireText(code, "code");
+    requireText(name, "name");
+    validateParallelism(maxParallelism);
+    return repository.createDefinition(
+        code.trim(),
+        name.trim(),
+        description,
+        failureStrategy == null ? FailureStrategy.FAIL_FAST : failureStrategy,
+        maxParallelism,
+        draft == null ? new WorkflowDag(List.of(), List.of()) : draft,
+        operator);
+  }
+
+  @Transactional(transactionManager = "workflowTransactionManager")
+  public void updateDraft(
+      long workflowId,
+      String name,
+      String description,
+      FailureStrategy failureStrategy,
+      int maxParallelism,
+      WorkflowDag draft) {
+    requireText(name, "name");
+    validateParallelism(maxParallelism);
+    repository.updateDraft(
+        workflowId,
+        name.trim(),
+        description,
+        failureStrategy == null ? FailureStrategy.FAIL_FAST : failureStrategy,
+        maxParallelism,
+        draft == null ? new WorkflowDag(List.of(), List.of()) : draft);
+  }
+
+  @Transactional(transactionManager = "workflowTransactionManager")
+  public Version publish(long workflowId, String operator) {
+    Definition definition = get(workflowId);
+    compiler.compile(definition.draft());
+    return repository.publishVersion(workflowId, definition.draft(), operator);
+  }
+
+  public Definition get(long workflowId) {
+    return repository.findDefinition(workflowId)
+        .orElseThrow(() -> new IllegalArgumentException(
+            "Workflow definition does not exist: " + workflowId));
+  }
+
+  public List<Definition> list() {
+    return repository.listDefinitions();
+  }
+
+  private static void validateParallelism(int maxParallelism) {
+    if (maxParallelism < 1 || maxParallelism > 256) {
+      throw new IllegalArgumentException("maxParallelism must be between 1 and 256");
+    }
+  }
+
+  private static void requireText(String value, String field) {
+    if (value == null || value.isBlank()) {
+      throw new IllegalArgumentException(field + " must not be blank");
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowEngine.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowEngine.java
@@ -1,0 +1,486 @@
+package io.yak.ops.business.workflow.service;
+
+import io.yak.ops.business.workflow.config.ConditionalOnWorkflowEnabled;
+import io.yak.ops.business.workflow.dag.CompiledWorkflowDag;
+import io.yak.ops.business.workflow.dag.WorkflowDagCompiler;
+import io.yak.ops.business.workflow.model.WorkflowEnums.AttemptState;
+import io.yak.ops.business.workflow.model.WorkflowEnums.FailureStrategy;
+import io.yak.ops.business.workflow.model.WorkflowEnums.TaskState;
+import io.yak.ops.business.workflow.model.WorkflowEnums.WorkflowState;
+import io.yak.ops.business.workflow.model.WorkflowRecords.Instance;
+import io.yak.ops.business.workflow.model.WorkflowRecords.TaskInstance;
+import io.yak.ops.business.workflow.model.WorkflowRecords.Version;
+import io.yak.ops.business.workflow.repository.JdbcWorkflowRepository;
+import io.yak.ops.core.workflow.LocalWorkflowTaskDispatcher;
+import io.yak.ops.core.workflow.LocalWorkflowTaskDispatcher.DispatchHandle;
+import io.yak.ops.core.workflow.WorkflowTaskExecutorRegistry;
+import io.yak.ops.spi.workflow.WorkflowTaskContext;
+import io.yak.ops.spi.workflow.WorkflowTaskExecutor;
+import io.yak.ops.spi.workflow.WorkflowTaskResult;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+/** Single-process DAG runtime. Database state remains authoritative; memory only coordinates active work. */
+@ConditionalOnWorkflowEnabled
+@Service
+public final class WorkflowEngine {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(WorkflowEngine.class);
+
+  private final JdbcWorkflowRepository repository;
+  private final WorkflowDagCompiler compiler;
+  private final WorkflowTaskExecutorRegistry executorRegistry;
+  private final LocalWorkflowTaskDispatcher dispatcher;
+  private final ConcurrentMap<Long, RuntimeState> runtimes = new ConcurrentHashMap<>();
+
+  public WorkflowEngine(
+      JdbcWorkflowRepository repository,
+      WorkflowDagCompiler compiler,
+      WorkflowTaskExecutorRegistry executorRegistry,
+      LocalWorkflowTaskDispatcher dispatcher) {
+    this.repository = repository;
+    this.compiler = compiler;
+    this.executorRegistry = executorRegistry;
+    this.dispatcher = dispatcher;
+  }
+
+  public void start(long workflowInstanceId) {
+    RuntimeState runtime = runtimes.computeIfAbsent(workflowInstanceId, this::loadRuntime);
+    dispatch(runtime);
+  }
+
+  public void stop(long workflowInstanceId) {
+    RuntimeState runtime = runtimes.get(workflowInstanceId);
+    if (runtime == null) {
+      start(workflowInstanceId);
+      runtime = runtimes.get(workflowInstanceId);
+    }
+    if (runtime == null) {
+      return;
+    }
+    synchronized (runtime.monitor) {
+      cancelRunning(runtime, "Workflow stop requested");
+    }
+    dispatch(runtime);
+  }
+
+  public void recover() {
+    for (Long instanceId : repository.findRecoverableInstanceIds(100)) {
+      try {
+        start(instanceId);
+      } catch (Exception error) {
+        LOGGER.error("Failed to recover workflow instance {}", instanceId, error);
+      }
+    }
+  }
+
+  public boolean isActive(long workflowInstanceId) {
+    return runtimes.containsKey(workflowInstanceId);
+  }
+
+  private RuntimeState loadRuntime(long instanceId) {
+    Instance instance = requireInstance(instanceId);
+    Version version = repository.findVersion(instance.workflowId(), instance.workflowVersion())
+        .orElseThrow(() -> new IllegalStateException(
+            "Workflow version does not exist: " + instance.workflowId() + "/" + instance.workflowVersion()));
+    CompiledWorkflowDag graph = compiler.compile(version.dag());
+
+    if (instance.state() == WorkflowState.RUNNING || instance.state() == WorkflowState.STOPPING) {
+      for (TaskInstance task : repository.findTasks(instanceId)) {
+        if (task.state() == TaskState.RUNNING) {
+          repository.interruptRunningTask(task);
+        }
+      }
+    }
+    repository.markInstanceRunning(instanceId);
+    return new RuntimeState(instanceId, graph);
+  }
+
+  private void dispatch(RuntimeState runtime) {
+    synchronized (runtime.monitor) {
+      try {
+        Instance instance = requireInstance(runtime.instanceId);
+        if (instance.state().isTerminal()) {
+          runtimes.remove(runtime.instanceId, runtime);
+          return;
+        }
+
+        List<TaskInstance> tasks = repository.findTasks(runtime.instanceId);
+        Map<String, TaskInstance> byNode = indexByNode(tasks);
+
+        if (instance.stopRequested() || instance.state() == WorkflowState.STOPPING) {
+          cancelRunning(runtime, "Workflow stop requested");
+          for (TaskInstance task : tasks) {
+            if (!task.state().isTerminal() && task.state() != TaskState.RUNNING) {
+              repository.markTaskStopped(task.id(), "Workflow stop requested");
+            }
+          }
+          finalizeIfComplete(runtime, requireInstance(runtime.instanceId), repository.findTasks(runtime.instanceId));
+          return;
+        }
+
+        applyFailurePropagation(runtime, instance, byNode);
+        tasks = repository.findTasks(runtime.instanceId);
+        byNode = indexByNode(tasks);
+
+        int available = Math.max(0, instance.maxParallelism() - runtime.running.size());
+        if (available > 0 && !hasFinalFailure(instance, tasks)) {
+          for (String nodeKey : runtime.graph.topologicalOrder()) {
+            if (available == 0) {
+              break;
+            }
+            TaskInstance task = byNode.get(nodeKey);
+            if (task == null || !isClaimCandidate(task)) {
+              continue;
+            }
+            if (hasBlockingPredecessor(runtime.graph, task.nodeKey(), byNode)) {
+              repository.markTasksSkipped(
+                  runtime.instanceId,
+                  Set.of(task.nodeKey()),
+                  "A predecessor did not complete successfully");
+              continue;
+            }
+            if (!allPredecessorsSatisfied(runtime.graph, task.nodeKey(), byNode)) {
+              continue;
+            }
+            if (submit(runtime, instance, task)) {
+              available--;
+            }
+          }
+        }
+
+        finalizeIfComplete(runtime, requireInstance(runtime.instanceId), repository.findTasks(runtime.instanceId));
+      } catch (Exception error) {
+        LOGGER.error("Workflow dispatch failed for instance {}", runtime.instanceId, error);
+        repository.markAllPendingTasksSkipped(runtime.instanceId, "Workflow engine dispatch failed");
+        repository.finishInstance(runtime.instanceId, WorkflowState.FAILED);
+        cancelRunning(runtime, "Workflow engine dispatch failed");
+        runtimes.remove(runtime.instanceId, runtime);
+      }
+    }
+  }
+
+  private boolean submit(RuntimeState runtime, Instance instance, TaskInstance candidate) {
+    if (!repository.claimTask(candidate.id())) {
+      return false;
+    }
+    TaskInstance task = repository.findTask(candidate.id())
+        .orElseThrow(() -> new IllegalStateException("Claimed task disappeared: " + candidate.id()));
+    long attemptId = repository.createAttempt(task);
+    int attemptNo = task.retryCount() + 1;
+    WorkflowTaskExecutor executor = executorRegistry.require(task.taskType());
+    AtomicBoolean cancelled = new AtomicBoolean(false);
+    WorkflowTaskContext context = new WorkflowTaskContext(
+        instance.id(),
+        task.id(),
+        attemptId,
+        attemptNo,
+        task.nodeKey(),
+        task.taskType(),
+        task.configuration(),
+        instance.globalParameters(),
+        cancelled::get,
+        line -> appendLogSafely(attemptId, line));
+
+    DispatchHandle<WorkflowTaskResult> handle = dispatcher.submit(() -> executor.execute(context));
+    RunningTask running = new RunningTask(task, attemptId, executor, context, cancelled, handle);
+    runtime.running.put(task.id(), running);
+
+    if (task.timeoutSeconds() > 0) {
+      running.timeoutFuture = dispatcher.schedule(
+          () -> timeout(runtime, running),
+          Duration.ofSeconds(task.timeoutSeconds()));
+    }
+    handle.completion().whenComplete((result, error) -> complete(runtime, running, result, error));
+    return true;
+  }
+
+  private void timeout(RuntimeState runtime, RunningTask running) {
+    if (!runtime.running.containsKey(running.task.id())) {
+      return;
+    }
+    running.timedOut.set(true);
+    running.cancelled.set(true);
+    cancelPlugin(running);
+    running.handle.cancel(true);
+  }
+
+  private void complete(
+      RuntimeState runtime,
+      RunningTask running,
+      WorkflowTaskResult result,
+      Throwable error) {
+    runtime.running.remove(running.task.id(), running);
+    if (running.timeoutFuture != null) {
+      running.timeoutFuture.cancel(false);
+    }
+
+    try {
+      Instance instance = requireInstance(runtime.instanceId);
+      Throwable failure = unwrap(error);
+      if (instance.stopRequested() || instance.state() == WorkflowState.STOPPING) {
+        repository.finishAttempt(
+            running.attemptId,
+            AttemptState.STOPPED,
+            result == null ? null : result.externalId(),
+            "Workflow stop requested");
+        repository.markTaskStopped(running.task.id(), "Workflow stop requested");
+      } else if (running.timedOut.get()) {
+        String message = "Task timed out after " + running.task.timeoutSeconds() + " seconds";
+        repository.finishAttempt(running.attemptId, AttemptState.FAILED, null, message);
+        retryOrFail(running.task, message);
+      } else if (failure != null) {
+        String message = failureMessage(failure);
+        AttemptState attemptState = failure instanceof CancellationException
+            ? AttemptState.STOPPED
+            : AttemptState.FAILED;
+        repository.finishAttempt(running.attemptId, attemptState, null, message);
+        if (attemptState == AttemptState.STOPPED) {
+          repository.markTaskStopped(running.task.id(), message);
+        } else {
+          retryOrFail(running.task, message);
+        }
+      } else if (result == null || !result.success()) {
+        String message = result == null ? "Task executor returned no result" : result.message();
+        repository.finishAttempt(
+            running.attemptId,
+            AttemptState.FAILED,
+            result == null ? null : result.externalId(),
+            message);
+        retryOrFail(running.task, message);
+      } else {
+        repository.finishAttempt(
+            running.attemptId,
+            AttemptState.SUCCESS,
+            result.externalId(),
+            null);
+        repository.markTaskSuccess(running.task.id(), result.outputs());
+      }
+    } catch (Exception completionError) {
+      LOGGER.error(
+          "Failed to persist task completion for workflow instance {}, task {}",
+          runtime.instanceId,
+          running.task.id(),
+          completionError);
+      repository.markTaskFailed(
+          running.task.id(),
+          running.task.retryCount(),
+          failureMessage(completionError));
+    }
+    dispatch(runtime);
+  }
+
+  private void retryOrFail(TaskInstance task, String message) {
+    if (task.retryCount() < task.maxRetryTimes()) {
+      int retryCount = task.retryCount() + 1;
+      Instant nextRetryTime = Instant.now().plusSeconds(task.retryIntervalSeconds());
+      repository.markTaskRetryWaiting(task.id(), retryCount, nextRetryTime, message);
+      dispatcher.schedule(
+          () -> runtimes.values().stream()
+              .filter(runtime -> runtime.instanceId == task.workflowInstanceId())
+              .findFirst()
+              .ifPresent(this::dispatch),
+          Duration.ofSeconds(task.retryIntervalSeconds()));
+    } else {
+      repository.markTaskFailed(task.id(), task.retryCount(), message);
+    }
+  }
+
+  private void applyFailurePropagation(
+      RuntimeState runtime,
+      Instance instance,
+      Map<String, TaskInstance> byNode) {
+    List<TaskInstance> failed = byNode.values().stream()
+        .filter(task -> task.state() == TaskState.FAILED)
+        .toList();
+    if (failed.isEmpty()) {
+      return;
+    }
+    if (instance.failureStrategy() == FailureStrategy.FAIL_FAST) {
+      repository.markAllPendingTasksSkipped(runtime.instanceId, "Skipped after workflow failure");
+      return;
+    }
+    Set<String> descendants = new LinkedHashSet<>();
+    for (TaskInstance task : failed) {
+      descendants.addAll(descendants(runtime.graph, task.nodeKey()));
+    }
+    repository.markTasksSkipped(
+        runtime.instanceId,
+        descendants,
+        "Skipped because an upstream task failed");
+  }
+
+  private void finalizeIfComplete(
+      RuntimeState runtime,
+      Instance instance,
+      List<TaskInstance> tasks) {
+    if (!runtime.running.isEmpty() || tasks.stream().anyMatch(task -> !task.state().isTerminal())) {
+      return;
+    }
+    WorkflowState finalState;
+    if (instance.stopRequested() || tasks.stream().anyMatch(task -> task.state() == TaskState.STOPPED)) {
+      finalState = WorkflowState.STOPPED;
+    } else if (tasks.stream().anyMatch(task -> task.state() == TaskState.FAILED)) {
+      finalState = WorkflowState.FAILED;
+    } else {
+      finalState = WorkflowState.SUCCESS;
+    }
+    repository.finishInstance(runtime.instanceId, finalState);
+    runtimes.remove(runtime.instanceId, runtime);
+  }
+
+  private void cancelRunning(RuntimeState runtime, String reason) {
+    for (RunningTask running : new ArrayList<>(runtime.running.values())) {
+      running.cancelled.set(true);
+      appendLogSafely(running.attemptId, reason);
+      cancelPlugin(running);
+      running.handle.cancel(true);
+    }
+  }
+
+  private void cancelPlugin(RunningTask running) {
+    try {
+      running.executor.cancel(running.context);
+    } catch (Exception error) {
+      LOGGER.warn("Task plugin cancellation failed for task {}", running.task.id(), error);
+    }
+  }
+
+  private void appendLogSafely(long attemptId, String line) {
+    try {
+      repository.appendLog(attemptId, line);
+    } catch (Exception error) {
+      LOGGER.warn("Cannot persist workflow task log for attempt {}", attemptId, error);
+    }
+  }
+
+  private Instance requireInstance(long instanceId) {
+    return repository.findInstance(instanceId)
+        .orElseThrow(() -> new IllegalArgumentException(
+            "Workflow instance does not exist: " + instanceId));
+  }
+
+  private static boolean isClaimCandidate(TaskInstance task) {
+    if (task.state() == TaskState.WAITING || task.state() == TaskState.READY) {
+      return true;
+    }
+    return task.state() == TaskState.RETRY_WAITING
+        && (task.nextRetryTime() == null || !task.nextRetryTime().isAfter(Instant.now()));
+  }
+
+  private static boolean hasFinalFailure(Instance instance, List<TaskInstance> tasks) {
+    return instance.failureStrategy() == FailureStrategy.FAIL_FAST
+        && tasks.stream().anyMatch(task -> task.state() == TaskState.FAILED);
+  }
+
+  private static Map<String, TaskInstance> indexByNode(List<TaskInstance> tasks) {
+    Map<String, TaskInstance> result = new HashMap<>();
+    tasks.forEach(task -> result.put(task.nodeKey(), task));
+    return result;
+  }
+
+  private static boolean allPredecessorsSatisfied(
+      CompiledWorkflowDag graph,
+      String nodeKey,
+      Map<String, TaskInstance> byNode) {
+    return graph.predecessors().getOrDefault(nodeKey, Set.of()).stream()
+        .map(byNode::get)
+        .allMatch(task -> task != null && task.state().satisfiesDependency());
+  }
+
+  private static boolean hasBlockingPredecessor(
+      CompiledWorkflowDag graph,
+      String nodeKey,
+      Map<String, TaskInstance> byNode) {
+    return graph.predecessors().getOrDefault(nodeKey, Set.of()).stream()
+        .map(byNode::get)
+        .anyMatch(task -> task != null
+            && (task.state() == TaskState.FAILED || task.state() == TaskState.STOPPED));
+  }
+
+  private static Set<String> descendants(CompiledWorkflowDag graph, String nodeKey) {
+    Set<String> result = new HashSet<>();
+    ArrayDeque<String> queue = new ArrayDeque<>(graph.successors().getOrDefault(nodeKey, Set.of()));
+    while (!queue.isEmpty()) {
+      String current = queue.removeFirst();
+      if (result.add(current)) {
+        queue.addAll(graph.successors().getOrDefault(current, Set.of()));
+      }
+    }
+    return result;
+  }
+
+  private static Throwable unwrap(Throwable error) {
+    Throwable current = error;
+    while (current instanceof CompletionException && current.getCause() != null) {
+      current = current.getCause();
+    }
+    return current;
+  }
+
+  private static String failureMessage(Throwable error) {
+    if (error == null) {
+      return "Unknown workflow task failure";
+    }
+    return error.getMessage() == null || error.getMessage().isBlank()
+        ? error.getClass().getSimpleName()
+        : error.getMessage();
+  }
+
+  private static final class RuntimeState {
+
+    private final long instanceId;
+    private final CompiledWorkflowDag graph;
+    private final Object monitor = new Object();
+    private final ConcurrentMap<Long, RunningTask> running = new ConcurrentHashMap<>();
+
+    private RuntimeState(long instanceId, CompiledWorkflowDag graph) {
+      this.instanceId = instanceId;
+      this.graph = graph;
+    }
+  }
+
+  private static final class RunningTask {
+
+    private final TaskInstance task;
+    private final long attemptId;
+    private final WorkflowTaskExecutor executor;
+    private final WorkflowTaskContext context;
+    private final AtomicBoolean cancelled;
+    private final AtomicBoolean timedOut = new AtomicBoolean(false);
+    private final DispatchHandle<WorkflowTaskResult> handle;
+    private volatile Future<?> timeoutFuture;
+
+    private RunningTask(
+        TaskInstance task,
+        long attemptId,
+        WorkflowTaskExecutor executor,
+        WorkflowTaskContext context,
+        AtomicBoolean cancelled,
+        DispatchHandle<WorkflowTaskResult> handle) {
+      this.task = task;
+      this.attemptId = attemptId;
+      this.executor = executor;
+      this.context = context;
+      this.cancelled = cancelled;
+      this.handle = handle;
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowExecutionService.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowExecutionService.java
@@ -1,0 +1,99 @@
+package io.yak.ops.business.workflow.service;
+
+import io.yak.ops.business.workflow.config.ConditionalOnWorkflowEnabled;
+import io.yak.ops.business.workflow.model.WorkflowEnums.DefinitionState;
+import io.yak.ops.business.workflow.model.WorkflowEnums.TriggerType;
+import io.yak.ops.business.workflow.model.WorkflowRecords.Attempt;
+import io.yak.ops.business.workflow.model.WorkflowRecords.Definition;
+import io.yak.ops.business.workflow.model.WorkflowRecords.Instance;
+import io.yak.ops.business.workflow.model.WorkflowRecords.TaskInstance;
+import io.yak.ops.business.workflow.model.WorkflowRecords.Version;
+import io.yak.ops.business.workflow.repository.JdbcWorkflowRepository;
+import java.util.List;
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+/** Workflow instance creation, control and query facade. */
+@ConditionalOnWorkflowEnabled
+@Service
+public class WorkflowExecutionService {
+
+  private final JdbcWorkflowRepository repository;
+  private final WorkflowEngine engine;
+  private final TransactionTemplate transactions;
+
+  public WorkflowExecutionService(
+      JdbcWorkflowRepository repository,
+      WorkflowEngine engine,
+      @Qualifier("workflowTransactionManager") PlatformTransactionManager transactionManager) {
+    this.repository = repository;
+    this.engine = engine;
+    this.transactions = new TransactionTemplate(transactionManager);
+  }
+
+  public long trigger(
+      long workflowId,
+      TriggerType triggerType,
+      Map<String, Object> globalParameters,
+      String operator) {
+    long instanceId = transactions.execute(status -> {
+      Definition definition = repository.findDefinition(workflowId)
+          .orElseThrow(() -> new IllegalArgumentException(
+              "Workflow definition does not exist: " + workflowId));
+      if (definition.state() != DefinitionState.PUBLISHED || definition.currentVersion() == null) {
+        throw new IllegalStateException("Workflow must be published before execution: " + workflowId);
+      }
+      Version version = repository.findVersion(workflowId, definition.currentVersion())
+          .orElseThrow(() -> new IllegalStateException(
+              "Published workflow version does not exist: " + workflowId + "/" + definition.currentVersion()));
+      return repository.createInstance(
+          definition,
+          version,
+          triggerType == null ? TriggerType.MANUAL : triggerType,
+          globalParameters == null ? Map.of() : globalParameters,
+          operator);
+    });
+    if (instanceId == 0L) {
+      throw new IllegalStateException("Workflow transaction returned no instance id");
+    }
+    engine.start(instanceId);
+    return instanceId;
+  }
+
+  public void stop(long workflowInstanceId) {
+    transactions.executeWithoutResult(status -> repository.requestStop(workflowInstanceId));
+    engine.stop(workflowInstanceId);
+  }
+
+  public Instance get(long workflowInstanceId) {
+    return repository.findInstance(workflowInstanceId)
+        .orElseThrow(() -> new IllegalArgumentException(
+            "Workflow instance does not exist: " + workflowInstanceId));
+  }
+
+  public List<TaskInstance> tasks(long workflowInstanceId) {
+    get(workflowInstanceId);
+    return repository.findTasks(workflowInstanceId);
+  }
+
+  public List<Attempt> attempts(long taskInstanceId) {
+    repository.findTask(taskInstanceId)
+        .orElseThrow(() -> new IllegalArgumentException(
+            "Workflow task instance does not exist: " + taskInstanceId));
+    return repository.findAttempts(taskInstanceId);
+  }
+
+  public List<String> logs(long taskInstanceId, int limit) {
+    repository.findTask(taskInstanceId)
+        .orElseThrow(() -> new IllegalArgumentException(
+            "Workflow task instance does not exist: " + taskInstanceId));
+    return repository.findLogs(taskInstanceId, limit);
+  }
+
+  public List<Instance> list(long workflowId, int limit) {
+    return repository.listInstances(workflowId, limit);
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowRecoveryScanner.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowRecoveryScanner.java
@@ -1,0 +1,24 @@
+package io.yak.ops.business.workflow.service;
+
+import io.yak.ops.business.workflow.config.ConditionalOnWorkflowEnabled;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/** Periodically restores persisted non-terminal instances after process restarts or missed callbacks. */
+@ConditionalOnWorkflowEnabled
+@Component
+public final class WorkflowRecoveryScanner {
+
+  private final WorkflowEngine engine;
+
+  public WorkflowRecoveryScanner(WorkflowEngine engine) {
+    this.engine = engine;
+  }
+
+  @Scheduled(
+      initialDelayString = "${yak.workflow.recovery.initial-delay-millis:5000}",
+      fixedDelayString = "${yak.workflow.recovery.fixed-delay-millis:10000}")
+  public void recover() {
+    engine.recover();
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/web/WorkflowController.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/web/WorkflowController.java
@@ -1,0 +1,172 @@
+package io.yak.ops.business.workflow.web;
+
+import io.yak.ops.business.workflow.config.ConditionalOnWorkflowEnabled;
+import io.yak.framework.common.Result;
+import io.yak.ops.business.workflow.model.WorkflowDag;
+import io.yak.ops.business.workflow.model.WorkflowEnums.FailureStrategy;
+import io.yak.ops.business.workflow.model.WorkflowEnums.MisfirePolicy;
+import io.yak.ops.business.workflow.model.WorkflowEnums.ScheduleConcurrencyPolicy;
+import io.yak.ops.business.workflow.model.WorkflowEnums.TriggerType;
+import io.yak.ops.business.workflow.model.WorkflowRecords.Attempt;
+import io.yak.ops.business.workflow.model.WorkflowRecords.Definition;
+import io.yak.ops.business.workflow.model.WorkflowRecords.Instance;
+import io.yak.ops.business.workflow.model.WorkflowRecords.Schedule;
+import io.yak.ops.business.workflow.model.WorkflowRecords.TaskInstance;
+import io.yak.ops.business.workflow.model.WorkflowRecords.Version;
+import io.yak.ops.business.workflow.schedule.WorkflowScheduleService;
+import io.yak.ops.business.workflow.service.WorkflowDefinitionService;
+import io.yak.ops.business.workflow.service.WorkflowExecutionService;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import java.util.List;
+import java.util.Map;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Backend API for workflow definitions, published versions, instances and schedules. */
+@ConditionalOnWorkflowEnabled
+@RestController
+@RequestMapping("/api/v1/workflows")
+public class WorkflowController {
+
+  private final WorkflowDefinitionService definitions;
+  private final WorkflowExecutionService executions;
+  private final WorkflowScheduleService schedules;
+
+  public WorkflowController(
+      WorkflowDefinitionService definitions,
+      WorkflowExecutionService executions,
+      WorkflowScheduleService schedules) {
+    this.definitions = definitions;
+    this.executions = executions;
+    this.schedules = schedules;
+  }
+
+  @PostMapping
+  public Result<Map<String, Long>> create(
+      @Valid @RequestBody CreateWorkflowRequest request,
+      @RequestHeader(name = "X-Operator", defaultValue = "SYSTEM") String operator) {
+    long workflowId = definitions.create(
+        request.code(),
+        request.name(),
+        request.description(),
+        request.failureStrategy(),
+        request.maxParallelism(),
+        request.dag(),
+        operator);
+    return Result.success(Map.of("workflowId", workflowId));
+  }
+
+  @PutMapping("/{workflowId}/draft")
+  public Result<Boolean> updateDraft(
+      @PathVariable long workflowId,
+      @Valid @RequestBody UpdateWorkflowRequest request) {
+    definitions.updateDraft(
+        workflowId,
+        request.name(),
+        request.description(),
+        request.failureStrategy(),
+        request.maxParallelism(),
+        request.dag());
+    return Result.success(true);
+  }
+
+  @PostMapping("/{workflowId}/publish")
+  public Result<Version> publish(
+      @PathVariable long workflowId,
+      @RequestHeader(name = "X-Operator", defaultValue = "SYSTEM") String operator) {
+    return Result.success(definitions.publish(workflowId, operator));
+  }
+
+  @GetMapping
+  public Result<List<Definition>> listDefinitions() {
+    return Result.success(definitions.list());
+  }
+
+  @GetMapping("/{workflowId}")
+  public Result<Definition> getDefinition(@PathVariable long workflowId) {
+    return Result.success(definitions.get(workflowId));
+  }
+
+  @PostMapping("/{workflowId}/run")
+  public Result<Map<String, Long>> run(
+      @PathVariable long workflowId,
+      @RequestBody(required = false) TriggerWorkflowRequest request,
+      @RequestHeader(name = "X-Operator", defaultValue = "SYSTEM") String operator) {
+    long instanceId = executions.trigger(
+        workflowId,
+        TriggerType.MANUAL,
+        request == null || request.globalParameters() == null ? Map.of() : request.globalParameters(),
+        operator);
+    return Result.success(Map.of("workflowInstanceId", instanceId));
+  }
+
+  @GetMapping("/{workflowId}/instances")
+  public Result<List<Instance>> listInstances(
+      @PathVariable long workflowId,
+      @RequestParam(defaultValue = "50") int limit) {
+    return Result.success(executions.list(workflowId, limit));
+  }
+
+  @PutMapping("/{workflowId}/schedule")
+  public Result<Schedule> upsertSchedule(
+      @PathVariable long workflowId,
+      @Valid @RequestBody ScheduleWorkflowRequest request) {
+    return Result.success(schedules.upsert(
+        workflowId,
+        request.cronExpression(),
+        request.timezone(),
+        request.enabled(),
+        request.misfirePolicy(),
+        request.concurrencyPolicy()));
+  }
+
+  @GetMapping("/{workflowId}/schedule")
+  public Result<Schedule> getSchedule(@PathVariable long workflowId) {
+    return Result.success(schedules.get(workflowId));
+  }
+
+  @DeleteMapping("/{workflowId}/schedule")
+  public Result<Boolean> deleteSchedule(@PathVariable long workflowId) {
+    schedules.delete(workflowId);
+    return Result.success(true);
+  }
+
+  public record CreateWorkflowRequest(
+      @NotBlank String code,
+      @NotBlank String name,
+      String description,
+      FailureStrategy failureStrategy,
+      @Min(1) @Max(256) int maxParallelism,
+      @Valid WorkflowDag dag) {
+  }
+
+  public record UpdateWorkflowRequest(
+      @NotBlank String name,
+      String description,
+      FailureStrategy failureStrategy,
+      @Min(1) @Max(256) int maxParallelism,
+      @Valid WorkflowDag dag) {
+  }
+
+  public record TriggerWorkflowRequest(Map<String, Object> globalParameters) {
+  }
+
+  public record ScheduleWorkflowRequest(
+      @NotBlank String cronExpression,
+      @NotBlank String timezone,
+      boolean enabled,
+      MisfirePolicy misfirePolicy,
+      ScheduleConcurrencyPolicy concurrencyPolicy) {
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/web/WorkflowInstanceController.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/web/WorkflowInstanceController.java
@@ -1,0 +1,56 @@
+package io.yak.ops.business.workflow.web;
+
+import io.yak.ops.business.workflow.config.ConditionalOnWorkflowEnabled;
+import io.yak.framework.common.Result;
+import io.yak.ops.business.workflow.model.WorkflowRecords.Attempt;
+import io.yak.ops.business.workflow.model.WorkflowRecords.Instance;
+import io.yak.ops.business.workflow.model.WorkflowRecords.TaskInstance;
+import io.yak.ops.business.workflow.service.WorkflowExecutionService;
+import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Runtime control and inspection endpoints separated from definition CRUD. */
+@ConditionalOnWorkflowEnabled
+@RestController
+@RequestMapping("/api/v1/workflow-instances")
+public class WorkflowInstanceController {
+
+  private final WorkflowExecutionService executions;
+
+  public WorkflowInstanceController(WorkflowExecutionService executions) {
+    this.executions = executions;
+  }
+
+  @GetMapping("/{instanceId}")
+  public Result<Instance> get(@PathVariable long instanceId) {
+    return Result.success(executions.get(instanceId));
+  }
+
+  @GetMapping("/{instanceId}/tasks")
+  public Result<List<TaskInstance>> tasks(@PathVariable long instanceId) {
+    return Result.success(executions.tasks(instanceId));
+  }
+
+  @PostMapping("/{instanceId}/stop")
+  public Result<Boolean> stop(@PathVariable long instanceId) {
+    executions.stop(instanceId);
+    return Result.success(true);
+  }
+
+  @GetMapping("/tasks/{taskInstanceId}/attempts")
+  public Result<List<Attempt>> attempts(@PathVariable long taskInstanceId) {
+    return Result.success(executions.attempts(taskInstanceId));
+  }
+
+  @GetMapping("/tasks/{taskInstanceId}/logs")
+  public Result<List<String>> logs(
+      @PathVariable long taskInstanceId,
+      @RequestParam(defaultValue = "2000") int limit) {
+    return Result.success(executions.logs(taskInstanceId, limit));
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/main/resources/db/migration/yak-workflow/V1__create_lightweight_workflow_tables.sql
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/resources/db/migration/yak-workflow/V1__create_lightweight_workflow_tables.sql
@@ -1,0 +1,113 @@
+CREATE TABLE IF NOT EXISTS yak_wf_definition (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  code VARCHAR(128) NOT NULL,
+  name VARCHAR(255) NOT NULL,
+  description VARCHAR(1000) NULL,
+  state VARCHAR(32) NOT NULL,
+  current_version INT NULL,
+  failure_strategy VARCHAR(32) NOT NULL,
+  max_parallelism INT NOT NULL,
+  draft_json LONGTEXT NOT NULL,
+  created_by VARCHAR(128) NULL,
+  created_at DATETIME(6) NOT NULL,
+  updated_at DATETIME(6) NOT NULL,
+  PRIMARY KEY (id),
+  UNIQUE KEY uk_yak_wf_definition_code (code)
+);
+
+CREATE TABLE IF NOT EXISTS yak_wf_version (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  workflow_id BIGINT NOT NULL,
+  version INT NOT NULL,
+  dag_json LONGTEXT NOT NULL,
+  content_hash VARCHAR(64) NOT NULL,
+  published_by VARCHAR(128) NULL,
+  published_at DATETIME(6) NOT NULL,
+  PRIMARY KEY (id),
+  UNIQUE KEY uk_yak_wf_version (workflow_id, version),
+  KEY idx_yak_wf_version_workflow (workflow_id)
+);
+
+CREATE TABLE IF NOT EXISTS yak_wf_schedule (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  workflow_id BIGINT NOT NULL,
+  cron_expression VARCHAR(255) NOT NULL,
+  timezone VARCHAR(64) NOT NULL,
+  enabled TINYINT(1) NOT NULL,
+  misfire_policy VARCHAR(32) NOT NULL,
+  concurrency_policy VARCHAR(32) NOT NULL,
+  updated_at DATETIME(6) NOT NULL,
+  PRIMARY KEY (id),
+  UNIQUE KEY uk_yak_wf_schedule_workflow (workflow_id)
+);
+
+CREATE TABLE IF NOT EXISTS yak_wf_instance (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  workflow_id BIGINT NOT NULL,
+  workflow_version INT NOT NULL,
+  trigger_type VARCHAR(32) NOT NULL,
+  state VARCHAR(32) NOT NULL,
+  global_params_json LONGTEXT NOT NULL,
+  failure_strategy VARCHAR(32) NOT NULL,
+  max_parallelism INT NOT NULL,
+  stop_requested TINYINT(1) NOT NULL DEFAULT 0,
+  start_time DATETIME(6) NULL,
+  end_time DATETIME(6) NULL,
+  created_by VARCHAR(128) NULL,
+  created_at DATETIME(6) NOT NULL,
+  lock_version INT NOT NULL DEFAULT 0,
+  PRIMARY KEY (id),
+  KEY idx_yak_wf_instance_workflow_state (workflow_id, state),
+  KEY idx_yak_wf_instance_state (state)
+);
+
+CREATE TABLE IF NOT EXISTS yak_wf_task_instance (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  workflow_instance_id BIGINT NOT NULL,
+  node_key VARCHAR(64) NOT NULL,
+  node_name VARCHAR(255) NOT NULL,
+  task_type VARCHAR(64) NOT NULL,
+  state VARCHAR(32) NOT NULL,
+  config_json LONGTEXT NOT NULL,
+  max_retry_times INT NOT NULL,
+  retry_count INT NOT NULL DEFAULT 0,
+  retry_interval_seconds INT NOT NULL DEFAULT 0,
+  timeout_seconds INT NOT NULL DEFAULT 0,
+  idempotent TINYINT(1) NOT NULL DEFAULT 0,
+  retry_on_restart TINYINT(1) NOT NULL DEFAULT 0,
+  next_retry_time DATETIME(6) NULL,
+  start_time DATETIME(6) NULL,
+  end_time DATETIME(6) NULL,
+  result_json LONGTEXT NULL,
+  error_message LONGTEXT NULL,
+  lock_version INT NOT NULL DEFAULT 0,
+  PRIMARY KEY (id),
+  UNIQUE KEY uk_yak_wf_task_instance_node (workflow_instance_id, node_key),
+  KEY idx_yak_wf_task_instance_state (workflow_instance_id, state)
+);
+
+CREATE TABLE IF NOT EXISTS yak_wf_task_attempt (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  task_instance_id BIGINT NOT NULL,
+  attempt_no INT NOT NULL,
+  state VARCHAR(32) NOT NULL,
+  executor_type VARCHAR(64) NOT NULL,
+  external_id VARCHAR(255) NULL,
+  start_time DATETIME(6) NOT NULL,
+  end_time DATETIME(6) NULL,
+  error_message LONGTEXT NULL,
+  PRIMARY KEY (id),
+  UNIQUE KEY uk_yak_wf_task_attempt (task_instance_id, attempt_no),
+  KEY idx_yak_wf_task_attempt_task (task_instance_id)
+);
+
+CREATE TABLE IF NOT EXISTS yak_wf_task_log (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  task_attempt_id BIGINT NOT NULL,
+  line_no BIGINT NOT NULL,
+  content LONGTEXT NOT NULL,
+  created_at DATETIME(6) NOT NULL,
+  PRIMARY KEY (id),
+  UNIQUE KEY uk_yak_wf_task_log_line (task_attempt_id, line_no),
+  KEY idx_yak_wf_task_log_attempt (task_attempt_id)
+);

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/dag/WorkflowDagCompilerTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/dag/WorkflowDagCompilerTest.java
@@ -1,0 +1,78 @@
+package io.yak.ops.business.workflow.dag;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.yak.ops.business.workflow.model.WorkflowDag;
+import io.yak.ops.core.workflow.WorkflowTaskExecutorRegistry;
+import io.yak.ops.spi.workflow.WorkflowTaskContext;
+import io.yak.ops.spi.workflow.WorkflowTaskExecutor;
+import io.yak.ops.spi.workflow.WorkflowTaskResult;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class WorkflowDagCompilerTest {
+
+  private final WorkflowDagCompiler compiler = new WorkflowDagCompiler(
+      new WorkflowTaskExecutorRegistry(List.of(new TestExecutor())));
+
+  @Test
+  void shouldCompileParallelDagInTopologicalOrder() {
+    WorkflowDag dag = new WorkflowDag(
+        List.of(node("extract"), node("transform"), node("quality"), node("publish")),
+        List.of(
+            new WorkflowDag.Edge("extract", "transform"),
+            new WorkflowDag.Edge("extract", "quality"),
+            new WorkflowDag.Edge("transform", "publish"),
+            new WorkflowDag.Edge("quality", "publish")));
+
+    CompiledWorkflowDag compiled = compiler.compile(dag);
+
+    assertThat(compiled.startNodes()).containsExactly("extract");
+    assertThat(compiled.predecessors().get("publish"))
+        .containsExactlyInAnyOrder("transform", "quality");
+    assertThat(compiled.topologicalOrder().indexOf("extract"))
+        .isLessThan(compiled.topologicalOrder().indexOf("publish"));
+  }
+
+  @Test
+  void shouldRejectCyclesBeforePublication() {
+    WorkflowDag dag = new WorkflowDag(
+        List.of(node("first"), node("second")),
+        List.of(
+            new WorkflowDag.Edge("first", "second"),
+            new WorkflowDag.Edge("second", "first")));
+
+    assertThatThrownBy(() -> compiler.compile(dag))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("cycle");
+  }
+
+  @Test
+  void shouldRejectUnknownTaskExecutor() {
+    WorkflowDag.Node node = new WorkflowDag.Node(
+        "missing", "Missing", "UNKNOWN", Map.of(), 0, 0, 0, true, true, true);
+
+    assertThatThrownBy(() -> compiler.compile(new WorkflowDag(List.of(node), List.of())))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("UNKNOWN");
+  }
+
+  private static WorkflowDag.Node node(String key) {
+    return new WorkflowDag.Node(key, key, "TEST", Map.of(), 0, 0, 0, true, true, true);
+  }
+
+  private static final class TestExecutor implements WorkflowTaskExecutor {
+
+    @Override
+    public String type() {
+      return "TEST";
+    }
+
+    @Override
+    public WorkflowTaskResult execute(WorkflowTaskContext context) {
+      return WorkflowTaskResult.succeeded();
+    }
+  }
+}

--- a/yak-ops-core/pom.xml
+++ b/yak-ops-core/pom.xml
@@ -12,6 +12,14 @@
     <name>Yak Ops Core</name>
     <description>Plugin registry, runtime coordination and execution mechanisms</description>
     <dependencies>
-        <dependency><groupId>io.yak.ops</groupId><artifactId>yak-ops-spi</artifactId></dependency>
+        <dependency>
+            <groupId>io.yak.ops</groupId>
+            <artifactId>yak-ops-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/yak-ops-core/src/main/java/io/yak/ops/core/workflow/LocalWorkflowTaskDispatcher.java
+++ b/yak-ops-core/src/main/java/io/yak/ops/core/workflow/LocalWorkflowTaskDispatcher.java
@@ -1,0 +1,104 @@
+package io.yak.ops.core.workflow;
+
+import java.time.Duration;
+import java.util.Objects;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionHandler;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/** Bounded, process-local dispatcher used by the lightweight workflow runtime. */
+public final class LocalWorkflowTaskDispatcher implements AutoCloseable {
+
+  private final ThreadPoolExecutor executor;
+  private final ScheduledExecutorService scheduler;
+
+  public LocalWorkflowTaskDispatcher(
+      int corePoolSize,
+      int maximumPoolSize,
+      int queueCapacity,
+      String threadNamePrefix) {
+    if (corePoolSize < 1 || maximumPoolSize < corePoolSize || queueCapacity < 1) {
+      throw new IllegalArgumentException("Invalid workflow dispatcher pool configuration");
+    }
+    String prefix = threadNamePrefix == null || threadNamePrefix.isBlank()
+        ? "yak-workflow-"
+        : threadNamePrefix;
+    RejectedExecutionHandler rejection = new ThreadPoolExecutor.AbortPolicy();
+    this.executor = new ThreadPoolExecutor(
+        corePoolSize,
+        maximumPoolSize,
+        60L,
+        TimeUnit.SECONDS,
+        new ArrayBlockingQueue<>(queueCapacity),
+        namedThreadFactory(prefix + "task-"),
+        rejection);
+    this.executor.allowCoreThreadTimeOut(false);
+    this.scheduler = new ScheduledThreadPoolExecutor(
+        Math.max(1, Math.min(2, corePoolSize)),
+        namedThreadFactory(prefix + "timer-"));
+  }
+
+  public <T> DispatchHandle<T> submit(Callable<T> task) {
+    Objects.requireNonNull(task, "task");
+    CompletableFuture<T> completion = new CompletableFuture<>();
+    Future<?> submitted = executor.submit(() -> {
+      try {
+        completion.complete(task.call());
+      } catch (Throwable error) {
+        completion.completeExceptionally(error);
+      }
+    });
+    return new DispatchHandle<>(completion, submitted);
+  }
+
+  public Future<?> schedule(Runnable task, Duration delay) {
+    Objects.requireNonNull(task, "task");
+    long delayMillis = Math.max(0L, delay == null ? 0L : delay.toMillis());
+    return scheduler.schedule(task, delayMillis, TimeUnit.MILLISECONDS);
+  }
+
+  public int activeCount() {
+    return executor.getActiveCount();
+  }
+
+  public int queuedCount() {
+    return executor.getQueue().size();
+  }
+
+  @Override
+  public void close() {
+    scheduler.shutdownNow();
+    executor.shutdownNow();
+  }
+
+  public record DispatchHandle<T>(CompletableFuture<T> completion, Future<?> submittedTask) {
+
+    public DispatchHandle {
+      Objects.requireNonNull(completion, "completion");
+      Objects.requireNonNull(submittedTask, "submittedTask");
+    }
+
+    public boolean cancel(boolean mayInterruptIfRunning) {
+      boolean cancelled = submittedTask.cancel(mayInterruptIfRunning);
+      completion.cancel(mayInterruptIfRunning);
+      return cancelled;
+    }
+  }
+
+  private static ThreadFactory namedThreadFactory(String prefix) {
+    AtomicInteger sequence = new AtomicInteger();
+    return runnable -> {
+      Thread thread = new Thread(runnable, prefix + sequence.incrementAndGet());
+      thread.setDaemon(true);
+      return thread;
+    };
+  }
+}

--- a/yak-ops-core/src/main/java/io/yak/ops/core/workflow/WorkflowTaskExecutorRegistry.java
+++ b/yak-ops-core/src/main/java/io/yak/ops/core/workflow/WorkflowTaskExecutorRegistry.java
@@ -1,0 +1,56 @@
+package io.yak.ops.core.workflow;
+
+import io.yak.ops.spi.workflow.WorkflowTaskExecutor;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/** Immutable task executor registry used by the workflow compiler and runtime. */
+public final class WorkflowTaskExecutorRegistry {
+
+  private final Map<String, WorkflowTaskExecutor> executors;
+
+  public WorkflowTaskExecutorRegistry(Collection<WorkflowTaskExecutor> taskExecutors) {
+    Map<String, WorkflowTaskExecutor> registered = new LinkedHashMap<>();
+    if (taskExecutors != null) {
+      for (WorkflowTaskExecutor executor : taskExecutors) {
+        Objects.requireNonNull(executor, "taskExecutor");
+        String type = normalize(executor.type());
+        WorkflowTaskExecutor previous = registered.putIfAbsent(type, executor);
+        if (previous != null) {
+          throw new IllegalStateException("Duplicate workflow task executor type: " + type);
+        }
+      }
+    }
+    this.executors = Collections.unmodifiableMap(registered);
+  }
+
+  public WorkflowTaskExecutor require(String taskType) {
+    String type = normalize(taskType);
+    WorkflowTaskExecutor executor = executors.get(type);
+    if (executor == null) {
+      throw new IllegalArgumentException(
+          "No workflow task executor registered for type: " + type);
+    }
+    return executor;
+  }
+
+  public boolean contains(String taskType) {
+    return executors.containsKey(normalize(taskType));
+  }
+
+  public Set<String> types() {
+    return executors.keySet();
+  }
+
+  private static String normalize(String taskType) {
+    if (taskType == null || taskType.isBlank()) {
+      throw new IllegalArgumentException("Workflow task type must not be blank");
+    }
+    return taskType.trim().toUpperCase(Locale.ROOT);
+  }
+}

--- a/yak-ops-core/src/test/java/io/yak/ops/core/workflow/WorkflowTaskExecutorRegistryTest.java
+++ b/yak-ops-core/src/test/java/io/yak/ops/core/workflow/WorkflowTaskExecutorRegistryTest.java
@@ -1,0 +1,37 @@
+package io.yak.ops.core.workflow;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.yak.ops.spi.workflow.WorkflowTaskContext;
+import io.yak.ops.spi.workflow.WorkflowTaskExecutor;
+import io.yak.ops.spi.workflow.WorkflowTaskResult;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class WorkflowTaskExecutorRegistryTest {
+
+  @Test
+  void shouldNormalizeExecutorTypes() {
+    WorkflowTaskExecutorRegistry registry = new WorkflowTaskExecutorRegistry(List.of(new Stub("http")));
+
+    assertThat(registry.require(" HTTP ").type()).isEqualTo("http");
+    assertThat(registry.types()).containsExactly("HTTP");
+  }
+
+  @Test
+  void shouldRejectDuplicateTypes() {
+    assertThatThrownBy(() -> new WorkflowTaskExecutorRegistry(
+        List.of(new Stub("shell"), new Stub("SHELL"))))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("SHELL");
+  }
+
+  private record Stub(String type) implements WorkflowTaskExecutor {
+
+    @Override
+    public WorkflowTaskResult execute(WorkflowTaskContext context) {
+      return WorkflowTaskResult.succeeded();
+    }
+  }
+}

--- a/yak-ops-spi/src/main/java/io/yak/ops/spi/workflow/WorkflowCancellationToken.java
+++ b/yak-ops-spi/src/main/java/io/yak/ops/spi/workflow/WorkflowCancellationToken.java
@@ -1,0 +1,16 @@
+package io.yak.ops.spi.workflow;
+
+import java.util.concurrent.CancellationException;
+
+/** Cooperative cancellation signal shared between the workflow engine and task plugins. */
+@FunctionalInterface
+public interface WorkflowCancellationToken {
+
+  boolean isCancellationRequested();
+
+  default void throwIfCancellationRequested() {
+    if (isCancellationRequested()) {
+      throw new CancellationException("Workflow task execution was cancelled");
+    }
+  }
+}

--- a/yak-ops-spi/src/main/java/io/yak/ops/spi/workflow/WorkflowTaskContext.java
+++ b/yak-ops-spi/src/main/java/io/yak/ops/spi/workflow/WorkflowTaskContext.java
@@ -1,0 +1,36 @@
+package io.yak.ops.spi.workflow;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/** Immutable runtime data passed to a workflow task plugin. */
+public record WorkflowTaskContext(
+    long workflowInstanceId,
+    long taskInstanceId,
+    long attemptId,
+    int attemptNo,
+    String nodeKey,
+    String taskType,
+    Map<String, Object> configuration,
+    Map<String, Object> globalParameters,
+    WorkflowCancellationToken cancellationToken,
+    WorkflowTaskLogger logger) {
+
+  public WorkflowTaskContext {
+    Objects.requireNonNull(nodeKey, "nodeKey");
+    Objects.requireNonNull(taskType, "taskType");
+    configuration = immutableCopy(configuration);
+    globalParameters = immutableCopy(globalParameters);
+    Objects.requireNonNull(cancellationToken, "cancellationToken");
+    Objects.requireNonNull(logger, "logger");
+  }
+
+  private static Map<String, Object> immutableCopy(Map<String, Object> source) {
+    if (source == null || source.isEmpty()) {
+      return Map.of();
+    }
+    return Collections.unmodifiableMap(new LinkedHashMap<>(source));
+  }
+}

--- a/yak-ops-spi/src/main/java/io/yak/ops/spi/workflow/WorkflowTaskExecutor.java
+++ b/yak-ops-spi/src/main/java/io/yak/ops/spi/workflow/WorkflowTaskExecutor.java
@@ -1,0 +1,21 @@
+package io.yak.ops.spi.workflow;
+
+import java.util.Map;
+
+/** Stable extension contract implemented by workflow task plugins. */
+public interface WorkflowTaskExecutor {
+
+  /** Stable uppercase task type, for example {@code SHELL}, {@code HTTP} or {@code SEATUNNEL_JOB}. */
+  String type();
+
+  /** Validates task configuration when a workflow version is published. */
+  default void validate(Map<String, Object> configuration) {
+  }
+
+  /** Executes one physical attempt. Implementations should honor the cancellation token. */
+  WorkflowTaskResult execute(WorkflowTaskContext context) throws Exception;
+
+  /** Best-effort external cancellation hook. */
+  default void cancel(WorkflowTaskContext context) throws Exception {
+  }
+}

--- a/yak-ops-spi/src/main/java/io/yak/ops/spi/workflow/WorkflowTaskLogger.java
+++ b/yak-ops-spi/src/main/java/io/yak/ops/spi/workflow/WorkflowTaskLogger.java
@@ -1,0 +1,8 @@
+package io.yak.ops.spi.workflow;
+
+/** Appends one line to the durable workflow task log. */
+@FunctionalInterface
+public interface WorkflowTaskLogger {
+
+  void log(String line);
+}

--- a/yak-ops-spi/src/main/java/io/yak/ops/spi/workflow/WorkflowTaskResult.java
+++ b/yak-ops-spi/src/main/java/io/yak/ops/spi/workflow/WorkflowTaskResult.java
@@ -1,0 +1,34 @@
+package io.yak.ops.spi.workflow;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/** Result returned by one physical task attempt. */
+public record WorkflowTaskResult(
+    boolean success,
+    String externalId,
+    Map<String, Object> outputs,
+    String message) {
+
+  public WorkflowTaskResult {
+    outputs = outputs == null || outputs.isEmpty()
+        ? Map.of()
+        : Collections.unmodifiableMap(new LinkedHashMap<>(outputs));
+  }
+
+  public static WorkflowTaskResult succeeded() {
+    return new WorkflowTaskResult(true, null, Map.of(), null);
+  }
+
+  public static WorkflowTaskResult succeeded(
+      String externalId,
+      Map<String, Object> outputs,
+      String message) {
+    return new WorkflowTaskResult(true, externalId, outputs, message);
+  }
+
+  public static WorkflowTaskResult failure(String message) {
+    return new WorkflowTaskResult(false, null, Map.of(), message);
+  }
+}


### PR DESCRIPTION
## What changed

Adds the first backend-only implementation of the Yak Ops lightweight workflow engine without introducing DolphinScheduler-style Master/Worker services or a registry center.

### Workflow model and persistence

- separates workflow drafts, immutable published versions, workflow instances, task instances and physical task attempts
- adds Flyway-managed `yak_wf_*` tables for definitions, versions, schedules, instances, attempts and durable task logs
- binds each workflow run to an immutable published DAG snapshot

### DAG runtime

- validates node keys, task types, edges and cycles before publication
- executes ready nodes from predecessor state and supports serial/parallel DAGs
- enforces per-workflow maximum parallelism on a bounded local thread pool
- supports task retry intervals, timeouts, stop requests and `FAIL_FAST` / `CONTINUE` failure policies
- restores persisted non-terminal instances after application restart
- only retries interrupted tasks after restart when both `idempotent` and `retryOnRestart` are enabled

### Task extension model

- introduces stable workflow task SPI contracts in `yak-ops-spi`
- adds executor registration and local dispatch infrastructure in `yak-ops-core`
- provides built-in `NOOP`, `HTTP` and `SHELL` task executors
- leaves SeaTunnel job execution behind the same `WorkflowTaskExecutor` SPI so the job module can add `SEATUNNEL_JOB` without coupling the workflow domain back to job internals

### Scheduling and API

- integrates Quartz as a trigger only; Quartz jobs create a durable workflow instance and return
- supports `PARALLEL` and `SKIP_IF_RUNNING` schedule concurrency policies
- adds backend REST endpoints for draft CRUD, publication, manual execution, schedules, instance inspection, task attempts/logs and stop requests
- extends the workflow permission declaration with update, publish, execute, stop and schedule-management permissions

## Validation

- Java 21 compilation passed for the new SPI, core and workflow main sources against generated API stubs
- workflow and core unit test sources were added for DAG topology/cycle validation and executor registry behavior
- Maven POM XML and application YAML files were parsed successfully
- every GitHub blob SHA was checked against the local `git hash-object` result before building the commit tree

## Environment limitation

A full Maven build could not be executed in the current runner because Maven dependencies and GitHub CLI were unavailable and outbound package access was blocked. Repository CI is therefore the authoritative full dependency/build check for this draft PR.

## Scope

Backend only. No files under `yak-ops-ui` are changed.