### PR TITLE
refactor(workflow): replace records with classes

### DIFF
--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dag/CompiledWorkflowDag.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dag/CompiledWorkflowDag.java
@@ -3,14 +3,59 @@ package io.yak.ops.business.workflow.dag;
 import io.yak.ops.business.workflow.model.WorkflowDag;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 /** Immutable, validated execution graph derived from a published DAG snapshot. */
-public record CompiledWorkflowDag(
-    Map<String, WorkflowDag.Node> nodes,
-    Map<String, Set<String>> predecessors,
-    Map<String, Set<String>> successors,
-    List<String> topologicalOrder) {
+public final class CompiledWorkflowDag {
+
+  private final Map<String, WorkflowDag.Node> nodes;
+  private final Map<String, Set<String>> predecessors;
+  private final Map<String, Set<String>> successors;
+  private final List<String> topologicalOrder;
+
+  public CompiledWorkflowDag(
+      Map<String, WorkflowDag.Node> nodes,
+      Map<String, Set<String>> predecessors,
+      Map<String, Set<String>> successors,
+      List<String> topologicalOrder) {
+    this.nodes = Objects.requireNonNull(nodes, "nodes");
+    this.predecessors = Objects.requireNonNull(predecessors, "predecessors");
+    this.successors = Objects.requireNonNull(successors, "successors");
+    this.topologicalOrder = Objects.requireNonNull(topologicalOrder, "topologicalOrder");
+  }
+
+  public Map<String, WorkflowDag.Node> nodes() {
+    return nodes;
+  }
+
+  public Map<String, WorkflowDag.Node> getNodes() {
+    return nodes;
+  }
+
+  public Map<String, Set<String>> predecessors() {
+    return predecessors;
+  }
+
+  public Map<String, Set<String>> getPredecessors() {
+    return predecessors;
+  }
+
+  public Map<String, Set<String>> successors() {
+    return successors;
+  }
+
+  public Map<String, Set<String>> getSuccessors() {
+    return successors;
+  }
+
+  public List<String> topologicalOrder() {
+    return topologicalOrder;
+  }
+
+  public List<String> getTopologicalOrder() {
+    return topologicalOrder;
+  }
 
   public List<String> startNodes() {
     return topologicalOrder.stream()

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/model/WorkflowDag.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/model/WorkflowDag.java
@@ -4,34 +4,344 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /** Serializable workflow DAG snapshot stored in each published version. */
-public record WorkflowDag(List<Node> nodes, List<Edge> edges) {
+public final class WorkflowDag {
 
-  public WorkflowDag {
-    nodes = nodes == null ? List.of() : List.copyOf(nodes);
-    edges = edges == null ? List.of() : List.copyOf(edges);
+  private List<Node> nodes = List.of();
+  private List<Edge> edges = List.of();
+
+  public WorkflowDag() {
   }
 
-  public record Node(
-      String key,
-      String name,
-      String type,
-      Map<String, Object> config,
-      int retryTimes,
-      int retryIntervalSeconds,
-      int timeoutSeconds,
-      boolean enabled,
-      boolean idempotent,
-      boolean retryOnRestart) {
+  public WorkflowDag(List<Node> nodes, List<Edge> edges) {
+    setNodes(nodes);
+    setEdges(edges);
+  }
 
-    public Node {
-      config = config == null || config.isEmpty()
-          ? Map.of()
-          : Collections.unmodifiableMap(new LinkedHashMap<>(config));
+  public List<Node> nodes() {
+    return nodes;
+  }
+
+  public List<Node> getNodes() {
+    return nodes;
+  }
+
+  public void setNodes(List<Node> nodes) {
+    this.nodes = nodes == null ? List.of() : List.copyOf(nodes);
+  }
+
+  public List<Edge> edges() {
+    return edges;
+  }
+
+  public List<Edge> getEdges() {
+    return edges;
+  }
+
+  public void setEdges(List<Edge> edges) {
+    this.edges = edges == null ? List.of() : List.copyOf(edges);
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    }
+    if (!(other instanceof WorkflowDag)) {
+      return false;
+    }
+    WorkflowDag that = (WorkflowDag) other;
+    return Objects.equals(nodes, that.nodes) && Objects.equals(edges, that.edges);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(nodes, edges);
+  }
+
+  @Override
+  public String toString() {
+    return "WorkflowDag{nodes=" + nodes + ", edges=" + edges + '}';
+  }
+
+  public static final class Node {
+
+    private String key;
+    private String name;
+    private String type;
+    private Map<String, Object> config = Map.of();
+    private int retryTimes;
+    private int retryIntervalSeconds;
+    private int timeoutSeconds;
+    private boolean enabled;
+    private boolean idempotent;
+    private boolean retryOnRestart;
+
+    public Node() {
+    }
+
+    public Node(
+        String key,
+        String name,
+        String type,
+        Map<String, Object> config,
+        int retryTimes,
+        int retryIntervalSeconds,
+        int timeoutSeconds,
+        boolean enabled,
+        boolean idempotent,
+        boolean retryOnRestart) {
+      this.key = key;
+      this.name = name;
+      this.type = type;
+      setConfig(config);
+      this.retryTimes = retryTimes;
+      this.retryIntervalSeconds = retryIntervalSeconds;
+      this.timeoutSeconds = timeoutSeconds;
+      this.enabled = enabled;
+      this.idempotent = idempotent;
+      this.retryOnRestart = retryOnRestart;
+    }
+
+    public String key() {
+      return key;
+    }
+
+    public String getKey() {
+      return key;
+    }
+
+    public void setKey(String key) {
+      this.key = key;
+    }
+
+    public String name() {
+      return name;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public void setName(String name) {
+      this.name = name;
+    }
+
+    public String type() {
+      return type;
+    }
+
+    public String getType() {
+      return type;
+    }
+
+    public void setType(String type) {
+      this.type = type;
+    }
+
+    public Map<String, Object> config() {
+      return config;
+    }
+
+    public Map<String, Object> getConfig() {
+      return config;
+    }
+
+    public void setConfig(Map<String, Object> config) {
+      this.config = immutableMap(config);
+    }
+
+    public int retryTimes() {
+      return retryTimes;
+    }
+
+    public int getRetryTimes() {
+      return retryTimes;
+    }
+
+    public void setRetryTimes(int retryTimes) {
+      this.retryTimes = retryTimes;
+    }
+
+    public int retryIntervalSeconds() {
+      return retryIntervalSeconds;
+    }
+
+    public int getRetryIntervalSeconds() {
+      return retryIntervalSeconds;
+    }
+
+    public void setRetryIntervalSeconds(int retryIntervalSeconds) {
+      this.retryIntervalSeconds = retryIntervalSeconds;
+    }
+
+    public int timeoutSeconds() {
+      return timeoutSeconds;
+    }
+
+    public int getTimeoutSeconds() {
+      return timeoutSeconds;
+    }
+
+    public void setTimeoutSeconds(int timeoutSeconds) {
+      this.timeoutSeconds = timeoutSeconds;
+    }
+
+    public boolean enabled() {
+      return enabled;
+    }
+
+    public boolean isEnabled() {
+      return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+      this.enabled = enabled;
+    }
+
+    public boolean idempotent() {
+      return idempotent;
+    }
+
+    public boolean isIdempotent() {
+      return idempotent;
+    }
+
+    public void setIdempotent(boolean idempotent) {
+      this.idempotent = idempotent;
+    }
+
+    public boolean retryOnRestart() {
+      return retryOnRestart;
+    }
+
+    public boolean isRetryOnRestart() {
+      return retryOnRestart;
+    }
+
+    public void setRetryOnRestart(boolean retryOnRestart) {
+      this.retryOnRestart = retryOnRestart;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+      if (this == other) {
+        return true;
+      }
+      if (!(other instanceof Node)) {
+        return false;
+      }
+      Node that = (Node) other;
+      return retryTimes == that.retryTimes
+          && retryIntervalSeconds == that.retryIntervalSeconds
+          && timeoutSeconds == that.timeoutSeconds
+          && enabled == that.enabled
+          && idempotent == that.idempotent
+          && retryOnRestart == that.retryOnRestart
+          && Objects.equals(key, that.key)
+          && Objects.equals(name, that.name)
+          && Objects.equals(type, that.type)
+          && Objects.equals(config, that.config);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(
+          key,
+          name,
+          type,
+          config,
+          retryTimes,
+          retryIntervalSeconds,
+          timeoutSeconds,
+          enabled,
+          idempotent,
+          retryOnRestart);
+    }
+
+    @Override
+    public String toString() {
+      return "Node{"
+          + "key='" + key + '\''
+          + ", name='" + name + '\''
+          + ", type='" + type + '\''
+          + ", config=" + config
+          + ", retryTimes=" + retryTimes
+          + ", retryIntervalSeconds=" + retryIntervalSeconds
+          + ", timeoutSeconds=" + timeoutSeconds
+          + ", enabled=" + enabled
+          + ", idempotent=" + idempotent
+          + ", retryOnRestart=" + retryOnRestart
+          + '}';
     }
   }
 
-  public record Edge(String from, String to) {
+  public static final class Edge {
+
+    private String from;
+    private String to;
+
+    public Edge() {
+    }
+
+    public Edge(String from, String to) {
+      this.from = from;
+      this.to = to;
+    }
+
+    public String from() {
+      return from;
+    }
+
+    public String getFrom() {
+      return from;
+    }
+
+    public void setFrom(String from) {
+      this.from = from;
+    }
+
+    public String to() {
+      return to;
+    }
+
+    public String getTo() {
+      return to;
+    }
+
+    public void setTo(String to) {
+      this.to = to;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+      if (this == other) {
+        return true;
+      }
+      if (!(other instanceof Edge)) {
+        return false;
+      }
+      Edge that = (Edge) other;
+      return Objects.equals(from, that.from) && Objects.equals(to, that.to);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(from, to);
+    }
+
+    @Override
+    public String toString() {
+      return "Edge{from='" + from + "', to='" + to + "'}";
+    }
+  }
+
+  private static Map<String, Object> immutableMap(Map<String, Object> source) {
+    if (source == null || source.isEmpty()) {
+      return Map.of();
+    }
+    return Collections.unmodifiableMap(new LinkedHashMap<>(source));
   }
 }

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/model/WorkflowRecords.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/model/WorkflowRecords.java
@@ -9,96 +9,403 @@ import io.yak.ops.business.workflow.model.WorkflowEnums.TaskState;
 import io.yak.ops.business.workflow.model.WorkflowEnums.TriggerType;
 import io.yak.ops.business.workflow.model.WorkflowEnums.WorkflowState;
 import java.time.Instant;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
-/** Immutable records returned by the workflow repository and REST layer. */
+/** Immutable data models returned by the workflow repository and REST layer. */
 public final class WorkflowRecords {
 
   private WorkflowRecords() {
   }
 
-  public record Definition(
-      long id,
-      String code,
-      String name,
-      String description,
-      DefinitionState state,
-      Integer currentVersion,
-      FailureStrategy failureStrategy,
-      int maxParallelism,
-      WorkflowDag draft,
-      String createdBy,
-      Instant createdAt,
-      Instant updatedAt) {
+  public static final class Definition {
+
+    private final long id;
+    private final String code;
+    private final String name;
+    private final String description;
+    private final DefinitionState state;
+    private final Integer currentVersion;
+    private final FailureStrategy failureStrategy;
+    private final int maxParallelism;
+    private final WorkflowDag draft;
+    private final String createdBy;
+    private final Instant createdAt;
+    private final Instant updatedAt;
+
+    public Definition(
+        long id,
+        String code,
+        String name,
+        String description,
+        DefinitionState state,
+        Integer currentVersion,
+        FailureStrategy failureStrategy,
+        int maxParallelism,
+        WorkflowDag draft,
+        String createdBy,
+        Instant createdAt,
+        Instant updatedAt) {
+      this.id = id;
+      this.code = code;
+      this.name = name;
+      this.description = description;
+      this.state = state;
+      this.currentVersion = currentVersion;
+      this.failureStrategy = failureStrategy;
+      this.maxParallelism = maxParallelism;
+      this.draft = draft;
+      this.createdBy = createdBy;
+      this.createdAt = createdAt;
+      this.updatedAt = updatedAt;
+    }
+
+    public long id() { return id; }
+    public long getId() { return id; }
+    public String code() { return code; }
+    public String getCode() { return code; }
+    public String name() { return name; }
+    public String getName() { return name; }
+    public String description() { return description; }
+    public String getDescription() { return description; }
+    public DefinitionState state() { return state; }
+    public DefinitionState getState() { return state; }
+    public Integer currentVersion() { return currentVersion; }
+    public Integer getCurrentVersion() { return currentVersion; }
+    public FailureStrategy failureStrategy() { return failureStrategy; }
+    public FailureStrategy getFailureStrategy() { return failureStrategy; }
+    public int maxParallelism() { return maxParallelism; }
+    public int getMaxParallelism() { return maxParallelism; }
+    public WorkflowDag draft() { return draft; }
+    public WorkflowDag getDraft() { return draft; }
+    public String createdBy() { return createdBy; }
+    public String getCreatedBy() { return createdBy; }
+    public Instant createdAt() { return createdAt; }
+    public Instant getCreatedAt() { return createdAt; }
+    public Instant updatedAt() { return updatedAt; }
+    public Instant getUpdatedAt() { return updatedAt; }
   }
 
-  public record Version(
-      long id,
-      long workflowId,
-      int version,
-      WorkflowDag dag,
-      String contentHash,
-      String publishedBy,
-      Instant publishedAt) {
+  public static final class Version {
+
+    private final long id;
+    private final long workflowId;
+    private final int version;
+    private final WorkflowDag dag;
+    private final String contentHash;
+    private final String publishedBy;
+    private final Instant publishedAt;
+
+    public Version(
+        long id,
+        long workflowId,
+        int version,
+        WorkflowDag dag,
+        String contentHash,
+        String publishedBy,
+        Instant publishedAt) {
+      this.id = id;
+      this.workflowId = workflowId;
+      this.version = version;
+      this.dag = dag;
+      this.contentHash = contentHash;
+      this.publishedBy = publishedBy;
+      this.publishedAt = publishedAt;
+    }
+
+    public long id() { return id; }
+    public long getId() { return id; }
+    public long workflowId() { return workflowId; }
+    public long getWorkflowId() { return workflowId; }
+    public int version() { return version; }
+    public int getVersion() { return version; }
+    public WorkflowDag dag() { return dag; }
+    public WorkflowDag getDag() { return dag; }
+    public String contentHash() { return contentHash; }
+    public String getContentHash() { return contentHash; }
+    public String publishedBy() { return publishedBy; }
+    public String getPublishedBy() { return publishedBy; }
+    public Instant publishedAt() { return publishedAt; }
+    public Instant getPublishedAt() { return publishedAt; }
   }
 
-  public record Instance(
-      long id,
-      long workflowId,
-      int workflowVersion,
-      TriggerType triggerType,
-      WorkflowState state,
-      Map<String, Object> globalParameters,
-      FailureStrategy failureStrategy,
-      int maxParallelism,
-      boolean stopRequested,
-      Instant startTime,
-      Instant endTime,
-      String createdBy,
-      Instant createdAt) {
+  public static final class Instance {
+
+    private final long id;
+    private final long workflowId;
+    private final int workflowVersion;
+    private final TriggerType triggerType;
+    private final WorkflowState state;
+    private final Map<String, Object> globalParameters;
+    private final FailureStrategy failureStrategy;
+    private final int maxParallelism;
+    private final boolean stopRequested;
+    private final Instant startTime;
+    private final Instant endTime;
+    private final String createdBy;
+    private final Instant createdAt;
+
+    public Instance(
+        long id,
+        long workflowId,
+        int workflowVersion,
+        TriggerType triggerType,
+        WorkflowState state,
+        Map<String, Object> globalParameters,
+        FailureStrategy failureStrategy,
+        int maxParallelism,
+        boolean stopRequested,
+        Instant startTime,
+        Instant endTime,
+        String createdBy,
+        Instant createdAt) {
+      this.id = id;
+      this.workflowId = workflowId;
+      this.workflowVersion = workflowVersion;
+      this.triggerType = triggerType;
+      this.state = state;
+      this.globalParameters = immutableMap(globalParameters);
+      this.failureStrategy = failureStrategy;
+      this.maxParallelism = maxParallelism;
+      this.stopRequested = stopRequested;
+      this.startTime = startTime;
+      this.endTime = endTime;
+      this.createdBy = createdBy;
+      this.createdAt = createdAt;
+    }
+
+    public long id() { return id; }
+    public long getId() { return id; }
+    public long workflowId() { return workflowId; }
+    public long getWorkflowId() { return workflowId; }
+    public int workflowVersion() { return workflowVersion; }
+    public int getWorkflowVersion() { return workflowVersion; }
+    public TriggerType triggerType() { return triggerType; }
+    public TriggerType getTriggerType() { return triggerType; }
+    public WorkflowState state() { return state; }
+    public WorkflowState getState() { return state; }
+    public Map<String, Object> globalParameters() { return globalParameters; }
+    public Map<String, Object> getGlobalParameters() { return globalParameters; }
+    public FailureStrategy failureStrategy() { return failureStrategy; }
+    public FailureStrategy getFailureStrategy() { return failureStrategy; }
+    public int maxParallelism() { return maxParallelism; }
+    public int getMaxParallelism() { return maxParallelism; }
+    public boolean stopRequested() { return stopRequested; }
+    public boolean isStopRequested() { return stopRequested; }
+    public Instant startTime() { return startTime; }
+    public Instant getStartTime() { return startTime; }
+    public Instant endTime() { return endTime; }
+    public Instant getEndTime() { return endTime; }
+    public String createdBy() { return createdBy; }
+    public String getCreatedBy() { return createdBy; }
+    public Instant createdAt() { return createdAt; }
+    public Instant getCreatedAt() { return createdAt; }
   }
 
-  public record TaskInstance(
-      long id,
-      long workflowInstanceId,
-      String nodeKey,
-      String nodeName,
-      String taskType,
-      TaskState state,
-      Map<String, Object> configuration,
-      int maxRetryTimes,
-      int retryCount,
-      int retryIntervalSeconds,
-      int timeoutSeconds,
-      boolean idempotent,
-      boolean retryOnRestart,
-      Instant nextRetryTime,
-      Instant startTime,
-      Instant endTime,
-      Map<String, Object> resultData,
-      String errorMessage) {
+  public static final class TaskInstance {
+
+    private final long id;
+    private final long workflowInstanceId;
+    private final String nodeKey;
+    private final String nodeName;
+    private final String taskType;
+    private final TaskState state;
+    private final Map<String, Object> configuration;
+    private final int maxRetryTimes;
+    private final int retryCount;
+    private final int retryIntervalSeconds;
+    private final int timeoutSeconds;
+    private final boolean idempotent;
+    private final boolean retryOnRestart;
+    private final Instant nextRetryTime;
+    private final Instant startTime;
+    private final Instant endTime;
+    private final Map<String, Object> resultData;
+    private final String errorMessage;
+
+    public TaskInstance(
+        long id,
+        long workflowInstanceId,
+        String nodeKey,
+        String nodeName,
+        String taskType,
+        TaskState state,
+        Map<String, Object> configuration,
+        int maxRetryTimes,
+        int retryCount,
+        int retryIntervalSeconds,
+        int timeoutSeconds,
+        boolean idempotent,
+        boolean retryOnRestart,
+        Instant nextRetryTime,
+        Instant startTime,
+        Instant endTime,
+        Map<String, Object> resultData,
+        String errorMessage) {
+      this.id = id;
+      this.workflowInstanceId = workflowInstanceId;
+      this.nodeKey = nodeKey;
+      this.nodeName = nodeName;
+      this.taskType = taskType;
+      this.state = state;
+      this.configuration = immutableMap(configuration);
+      this.maxRetryTimes = maxRetryTimes;
+      this.retryCount = retryCount;
+      this.retryIntervalSeconds = retryIntervalSeconds;
+      this.timeoutSeconds = timeoutSeconds;
+      this.idempotent = idempotent;
+      this.retryOnRestart = retryOnRestart;
+      this.nextRetryTime = nextRetryTime;
+      this.startTime = startTime;
+      this.endTime = endTime;
+      this.resultData = immutableMap(resultData);
+      this.errorMessage = errorMessage;
+    }
+
+    public long id() { return id; }
+    public long getId() { return id; }
+    public long workflowInstanceId() { return workflowInstanceId; }
+    public long getWorkflowInstanceId() { return workflowInstanceId; }
+    public String nodeKey() { return nodeKey; }
+    public String getNodeKey() { return nodeKey; }
+    public String nodeName() { return nodeName; }
+    public String getNodeName() { return nodeName; }
+    public String taskType() { return taskType; }
+    public String getTaskType() { return taskType; }
+    public TaskState state() { return state; }
+    public TaskState getState() { return state; }
+    public Map<String, Object> configuration() { return configuration; }
+    public Map<String, Object> getConfiguration() { return configuration; }
+    public int maxRetryTimes() { return maxRetryTimes; }
+    public int getMaxRetryTimes() { return maxRetryTimes; }
+    public int retryCount() { return retryCount; }
+    public int getRetryCount() { return retryCount; }
+    public int retryIntervalSeconds() { return retryIntervalSeconds; }
+    public int getRetryIntervalSeconds() { return retryIntervalSeconds; }
+    public int timeoutSeconds() { return timeoutSeconds; }
+    public int getTimeoutSeconds() { return timeoutSeconds; }
+    public boolean idempotent() { return idempotent; }
+    public boolean isIdempotent() { return idempotent; }
+    public boolean retryOnRestart() { return retryOnRestart; }
+    public boolean isRetryOnRestart() { return retryOnRestart; }
+    public Instant nextRetryTime() { return nextRetryTime; }
+    public Instant getNextRetryTime() { return nextRetryTime; }
+    public Instant startTime() { return startTime; }
+    public Instant getStartTime() { return startTime; }
+    public Instant endTime() { return endTime; }
+    public Instant getEndTime() { return endTime; }
+    public Map<String, Object> resultData() { return resultData; }
+    public Map<String, Object> getResultData() { return resultData; }
+    public String errorMessage() { return errorMessage; }
+    public String getErrorMessage() { return errorMessage; }
   }
 
-  public record Attempt(
-      long id,
-      long taskInstanceId,
-      int attemptNo,
-      AttemptState state,
-      String executorType,
-      String externalId,
-      Instant startTime,
-      Instant endTime,
-      String errorMessage) {
+  public static final class Attempt {
+
+    private final long id;
+    private final long taskInstanceId;
+    private final int attemptNo;
+    private final AttemptState state;
+    private final String executorType;
+    private final String externalId;
+    private final Instant startTime;
+    private final Instant endTime;
+    private final String errorMessage;
+
+    public Attempt(
+        long id,
+        long taskInstanceId,
+        int attemptNo,
+        AttemptState state,
+        String executorType,
+        String externalId,
+        Instant startTime,
+        Instant endTime,
+        String errorMessage) {
+      this.id = id;
+      this.taskInstanceId = taskInstanceId;
+      this.attemptNo = attemptNo;
+      this.state = state;
+      this.executorType = executorType;
+      this.externalId = externalId;
+      this.startTime = startTime;
+      this.endTime = endTime;
+      this.errorMessage = errorMessage;
+    }
+
+    public long id() { return id; }
+    public long getId() { return id; }
+    public long taskInstanceId() { return taskInstanceId; }
+    public long getTaskInstanceId() { return taskInstanceId; }
+    public int attemptNo() { return attemptNo; }
+    public int getAttemptNo() { return attemptNo; }
+    public AttemptState state() { return state; }
+    public AttemptState getState() { return state; }
+    public String executorType() { return executorType; }
+    public String getExecutorType() { return executorType; }
+    public String externalId() { return externalId; }
+    public String getExternalId() { return externalId; }
+    public Instant startTime() { return startTime; }
+    public Instant getStartTime() { return startTime; }
+    public Instant endTime() { return endTime; }
+    public Instant getEndTime() { return endTime; }
+    public String errorMessage() { return errorMessage; }
+    public String getErrorMessage() { return errorMessage; }
   }
 
-  public record Schedule(
-      long id,
-      long workflowId,
-      String cronExpression,
-      String timezone,
-      boolean enabled,
-      MisfirePolicy misfirePolicy,
-      ScheduleConcurrencyPolicy concurrencyPolicy,
-      Instant updatedAt) {
+  public static final class Schedule {
+
+    private final long id;
+    private final long workflowId;
+    private final String cronExpression;
+    private final String timezone;
+    private final boolean enabled;
+    private final MisfirePolicy misfirePolicy;
+    private final ScheduleConcurrencyPolicy concurrencyPolicy;
+    private final Instant updatedAt;
+
+    public Schedule(
+        long id,
+        long workflowId,
+        String cronExpression,
+        String timezone,
+        boolean enabled,
+        MisfirePolicy misfirePolicy,
+        ScheduleConcurrencyPolicy concurrencyPolicy,
+        Instant updatedAt) {
+      this.id = id;
+      this.workflowId = workflowId;
+      this.cronExpression = cronExpression;
+      this.timezone = timezone;
+      this.enabled = enabled;
+      this.misfirePolicy = misfirePolicy;
+      this.concurrencyPolicy = concurrencyPolicy;
+      this.updatedAt = updatedAt;
+    }
+
+    public long id() { return id; }
+    public long getId() { return id; }
+    public long workflowId() { return workflowId; }
+    public long getWorkflowId() { return workflowId; }
+    public String cronExpression() { return cronExpression; }
+    public String getCronExpression() { return cronExpression; }
+    public String timezone() { return timezone; }
+    public String getTimezone() { return timezone; }
+    public boolean enabled() { return enabled; }
+    public boolean isEnabled() { return enabled; }
+    public MisfirePolicy misfirePolicy() { return misfirePolicy; }
+    public MisfirePolicy getMisfirePolicy() { return misfirePolicy; }
+    public ScheduleConcurrencyPolicy concurrencyPolicy() { return concurrencyPolicy; }
+    public ScheduleConcurrencyPolicy getConcurrencyPolicy() { return concurrencyPolicy; }
+    public Instant updatedAt() { return updatedAt; }
+    public Instant getUpdatedAt() { return updatedAt; }
+  }
+
+  private static Map<String, Object> immutableMap(Map<String, Object> source) {
+    if (source == null || source.isEmpty()) {
+      return Map.of();
+    }
+    return Collections.unmodifiableMap(new LinkedHashMap<>(source));
   }
 }

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/web/WorkflowController.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/web/WorkflowController.java
@@ -1,17 +1,15 @@
 package io.yak.ops.business.workflow.web;
 
-import io.yak.ops.business.workflow.config.ConditionalOnWorkflowEnabled;
 import io.yak.framework.common.Result;
+import io.yak.ops.business.workflow.config.ConditionalOnWorkflowEnabled;
 import io.yak.ops.business.workflow.model.WorkflowDag;
 import io.yak.ops.business.workflow.model.WorkflowEnums.FailureStrategy;
 import io.yak.ops.business.workflow.model.WorkflowEnums.MisfirePolicy;
 import io.yak.ops.business.workflow.model.WorkflowEnums.ScheduleConcurrencyPolicy;
 import io.yak.ops.business.workflow.model.WorkflowEnums.TriggerType;
-import io.yak.ops.business.workflow.model.WorkflowRecords.Attempt;
 import io.yak.ops.business.workflow.model.WorkflowRecords.Definition;
 import io.yak.ops.business.workflow.model.WorkflowRecords.Instance;
 import io.yak.ops.business.workflow.model.WorkflowRecords.Schedule;
-import io.yak.ops.business.workflow.model.WorkflowRecords.TaskInstance;
 import io.yak.ops.business.workflow.model.WorkflowRecords.Version;
 import io.yak.ops.business.workflow.schedule.WorkflowScheduleService;
 import io.yak.ops.business.workflow.service.WorkflowDefinitionService;
@@ -142,31 +140,171 @@ public class WorkflowController {
     return Result.success(true);
   }
 
-  public record CreateWorkflowRequest(
-      @NotBlank String code,
-      @NotBlank String name,
-      String description,
-      FailureStrategy failureStrategy,
-      @Min(1) @Max(256) int maxParallelism,
-      @Valid WorkflowDag dag) {
+  public static class CreateWorkflowRequest {
+
+    @NotBlank
+    private String code;
+    @NotBlank
+    private String name;
+    private String description;
+    private FailureStrategy failureStrategy;
+    @Min(1)
+    @Max(256)
+    private int maxParallelism;
+    @Valid
+    private WorkflowDag dag;
+
+    public CreateWorkflowRequest() {
+    }
+
+    public CreateWorkflowRequest(
+        String code,
+        String name,
+        String description,
+        FailureStrategy failureStrategy,
+        int maxParallelism,
+        WorkflowDag dag) {
+      this.code = code;
+      this.name = name;
+      this.description = description;
+      this.failureStrategy = failureStrategy;
+      this.maxParallelism = maxParallelism;
+      this.dag = dag;
+    }
+
+    public String code() { return code; }
+    public String getCode() { return code; }
+    public void setCode(String code) { this.code = code; }
+    public String name() { return name; }
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+    public String description() { return description; }
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
+    public FailureStrategy failureStrategy() { return failureStrategy; }
+    public FailureStrategy getFailureStrategy() { return failureStrategy; }
+    public void setFailureStrategy(FailureStrategy failureStrategy) {
+      this.failureStrategy = failureStrategy;
+    }
+    public int maxParallelism() { return maxParallelism; }
+    public int getMaxParallelism() { return maxParallelism; }
+    public void setMaxParallelism(int maxParallelism) { this.maxParallelism = maxParallelism; }
+    public WorkflowDag dag() { return dag; }
+    public WorkflowDag getDag() { return dag; }
+    public void setDag(WorkflowDag dag) { this.dag = dag; }
   }
 
-  public record UpdateWorkflowRequest(
-      @NotBlank String name,
-      String description,
-      FailureStrategy failureStrategy,
-      @Min(1) @Max(256) int maxParallelism,
-      @Valid WorkflowDag dag) {
+  public static class UpdateWorkflowRequest {
+
+    @NotBlank
+    private String name;
+    private String description;
+    private FailureStrategy failureStrategy;
+    @Min(1)
+    @Max(256)
+    private int maxParallelism;
+    @Valid
+    private WorkflowDag dag;
+
+    public UpdateWorkflowRequest() {
+    }
+
+    public UpdateWorkflowRequest(
+        String name,
+        String description,
+        FailureStrategy failureStrategy,
+        int maxParallelism,
+        WorkflowDag dag) {
+      this.name = name;
+      this.description = description;
+      this.failureStrategy = failureStrategy;
+      this.maxParallelism = maxParallelism;
+      this.dag = dag;
+    }
+
+    public String name() { return name; }
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+    public String description() { return description; }
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
+    public FailureStrategy failureStrategy() { return failureStrategy; }
+    public FailureStrategy getFailureStrategy() { return failureStrategy; }
+    public void setFailureStrategy(FailureStrategy failureStrategy) {
+      this.failureStrategy = failureStrategy;
+    }
+    public int maxParallelism() { return maxParallelism; }
+    public int getMaxParallelism() { return maxParallelism; }
+    public void setMaxParallelism(int maxParallelism) { this.maxParallelism = maxParallelism; }
+    public WorkflowDag dag() { return dag; }
+    public WorkflowDag getDag() { return dag; }
+    public void setDag(WorkflowDag dag) { this.dag = dag; }
   }
 
-  public record TriggerWorkflowRequest(Map<String, Object> globalParameters) {
+  public static class TriggerWorkflowRequest {
+
+    private Map<String, Object> globalParameters;
+
+    public TriggerWorkflowRequest() {
+    }
+
+    public TriggerWorkflowRequest(Map<String, Object> globalParameters) {
+      this.globalParameters = globalParameters;
+    }
+
+    public Map<String, Object> globalParameters() { return globalParameters; }
+    public Map<String, Object> getGlobalParameters() { return globalParameters; }
+    public void setGlobalParameters(Map<String, Object> globalParameters) {
+      this.globalParameters = globalParameters;
+    }
   }
 
-  public record ScheduleWorkflowRequest(
-      @NotBlank String cronExpression,
-      @NotBlank String timezone,
-      boolean enabled,
-      MisfirePolicy misfirePolicy,
-      ScheduleConcurrencyPolicy concurrencyPolicy) {
+  public static class ScheduleWorkflowRequest {
+
+    @NotBlank
+    private String cronExpression;
+    @NotBlank
+    private String timezone;
+    private boolean enabled;
+    private MisfirePolicy misfirePolicy;
+    private ScheduleConcurrencyPolicy concurrencyPolicy;
+
+    public ScheduleWorkflowRequest() {
+    }
+
+    public ScheduleWorkflowRequest(
+        String cronExpression,
+        String timezone,
+        boolean enabled,
+        MisfirePolicy misfirePolicy,
+        ScheduleConcurrencyPolicy concurrencyPolicy) {
+      this.cronExpression = cronExpression;
+      this.timezone = timezone;
+      this.enabled = enabled;
+      this.misfirePolicy = misfirePolicy;
+      this.concurrencyPolicy = concurrencyPolicy;
+    }
+
+    public String cronExpression() { return cronExpression; }
+    public String getCronExpression() { return cronExpression; }
+    public void setCronExpression(String cronExpression) {
+      this.cronExpression = cronExpression;
+    }
+    public String timezone() { return timezone; }
+    public String getTimezone() { return timezone; }
+    public void setTimezone(String timezone) { this.timezone = timezone; }
+    public boolean enabled() { return enabled; }
+    public boolean isEnabled() { return enabled; }
+    public void setEnabled(boolean enabled) { this.enabled = enabled; }
+    public MisfirePolicy misfirePolicy() { return misfirePolicy; }
+    public MisfirePolicy getMisfirePolicy() { return misfirePolicy; }
+    public void setMisfirePolicy(MisfirePolicy misfirePolicy) {
+      this.misfirePolicy = misfirePolicy;
+    }
+    public ScheduleConcurrencyPolicy concurrencyPolicy() { return concurrencyPolicy; }
+    public ScheduleConcurrencyPolicy getConcurrencyPolicy() { return concurrencyPolicy; }
+    public void setConcurrencyPolicy(ScheduleConcurrencyPolicy concurrencyPolicy) {
+      this.concurrencyPolicy = concurrencyPolicy;
+    }
   }
 }

--- a/yak-ops-core/src/main/java/io/yak/ops/core/workflow/LocalWorkflowTaskDispatcher.java
+++ b/yak-ops-core/src/main/java/io/yak/ops/core/workflow/LocalWorkflowTaskDispatcher.java
@@ -79,11 +79,30 @@ public final class LocalWorkflowTaskDispatcher implements AutoCloseable {
     executor.shutdownNow();
   }
 
-  public record DispatchHandle<T>(CompletableFuture<T> completion, Future<?> submittedTask) {
+  public static final class DispatchHandle<T> {
 
-    public DispatchHandle {
-      Objects.requireNonNull(completion, "completion");
-      Objects.requireNonNull(submittedTask, "submittedTask");
+    private final CompletableFuture<T> completion;
+    private final Future<?> submittedTask;
+
+    public DispatchHandle(CompletableFuture<T> completion, Future<?> submittedTask) {
+      this.completion = Objects.requireNonNull(completion, "completion");
+      this.submittedTask = Objects.requireNonNull(submittedTask, "submittedTask");
+    }
+
+    public CompletableFuture<T> completion() {
+      return completion;
+    }
+
+    public CompletableFuture<T> getCompletion() {
+      return completion;
+    }
+
+    public Future<?> submittedTask() {
+      return submittedTask;
+    }
+
+    public Future<?> getSubmittedTask() {
+      return submittedTask;
     }
 
     public boolean cancel(boolean mayInterruptIfRunning) {

--- a/yak-ops-core/src/test/java/io/yak/ops/core/workflow/WorkflowTaskExecutorRegistryTest.java
+++ b/yak-ops-core/src/test/java/io/yak/ops/core/workflow/WorkflowTaskExecutorRegistryTest.java
@@ -27,7 +27,18 @@ class WorkflowTaskExecutorRegistryTest {
         .hasMessageContaining("SHELL");
   }
 
-  private record Stub(String type) implements WorkflowTaskExecutor {
+  private static final class Stub implements WorkflowTaskExecutor {
+
+    private final String type;
+
+    private Stub(String type) {
+      this.type = type;
+    }
+
+    @Override
+    public String type() {
+      return type;
+    }
 
     @Override
     public WorkflowTaskResult execute(WorkflowTaskContext context) {

--- a/yak-ops-spi/src/main/java/io/yak/ops/spi/workflow/WorkflowTaskContext.java
+++ b/yak-ops-spi/src/main/java/io/yak/ops/spi/workflow/WorkflowTaskContext.java
@@ -6,25 +6,120 @@ import java.util.Map;
 import java.util.Objects;
 
 /** Immutable runtime data passed to a workflow task plugin. */
-public record WorkflowTaskContext(
-    long workflowInstanceId,
-    long taskInstanceId,
-    long attemptId,
-    int attemptNo,
-    String nodeKey,
-    String taskType,
-    Map<String, Object> configuration,
-    Map<String, Object> globalParameters,
-    WorkflowCancellationToken cancellationToken,
-    WorkflowTaskLogger logger) {
+public final class WorkflowTaskContext {
 
-  public WorkflowTaskContext {
-    Objects.requireNonNull(nodeKey, "nodeKey");
-    Objects.requireNonNull(taskType, "taskType");
-    configuration = immutableCopy(configuration);
-    globalParameters = immutableCopy(globalParameters);
-    Objects.requireNonNull(cancellationToken, "cancellationToken");
-    Objects.requireNonNull(logger, "logger");
+  private final long workflowInstanceId;
+  private final long taskInstanceId;
+  private final long attemptId;
+  private final int attemptNo;
+  private final String nodeKey;
+  private final String taskType;
+  private final Map<String, Object> configuration;
+  private final Map<String, Object> globalParameters;
+  private final WorkflowCancellationToken cancellationToken;
+  private final WorkflowTaskLogger logger;
+
+  public WorkflowTaskContext(
+      long workflowInstanceId,
+      long taskInstanceId,
+      long attemptId,
+      int attemptNo,
+      String nodeKey,
+      String taskType,
+      Map<String, Object> configuration,
+      Map<String, Object> globalParameters,
+      WorkflowCancellationToken cancellationToken,
+      WorkflowTaskLogger logger) {
+    this.workflowInstanceId = workflowInstanceId;
+    this.taskInstanceId = taskInstanceId;
+    this.attemptId = attemptId;
+    this.attemptNo = attemptNo;
+    this.nodeKey = Objects.requireNonNull(nodeKey, "nodeKey");
+    this.taskType = Objects.requireNonNull(taskType, "taskType");
+    this.configuration = immutableCopy(configuration);
+    this.globalParameters = immutableCopy(globalParameters);
+    this.cancellationToken = Objects.requireNonNull(cancellationToken, "cancellationToken");
+    this.logger = Objects.requireNonNull(logger, "logger");
+  }
+
+  public long workflowInstanceId() {
+    return workflowInstanceId;
+  }
+
+  public long getWorkflowInstanceId() {
+    return workflowInstanceId;
+  }
+
+  public long taskInstanceId() {
+    return taskInstanceId;
+  }
+
+  public long getTaskInstanceId() {
+    return taskInstanceId;
+  }
+
+  public long attemptId() {
+    return attemptId;
+  }
+
+  public long getAttemptId() {
+    return attemptId;
+  }
+
+  public int attemptNo() {
+    return attemptNo;
+  }
+
+  public int getAttemptNo() {
+    return attemptNo;
+  }
+
+  public String nodeKey() {
+    return nodeKey;
+  }
+
+  public String getNodeKey() {
+    return nodeKey;
+  }
+
+  public String taskType() {
+    return taskType;
+  }
+
+  public String getTaskType() {
+    return taskType;
+  }
+
+  public Map<String, Object> configuration() {
+    return configuration;
+  }
+
+  public Map<String, Object> getConfiguration() {
+    return configuration;
+  }
+
+  public Map<String, Object> globalParameters() {
+    return globalParameters;
+  }
+
+  public Map<String, Object> getGlobalParameters() {
+    return globalParameters;
+  }
+
+  public WorkflowCancellationToken cancellationToken() {
+    return cancellationToken;
+  }
+
+  public WorkflowCancellationToken getCancellationToken() {
+    return cancellationToken;
+  }
+
+  public WorkflowTaskLogger logger() {
+    return logger;
+  }
+
+  public WorkflowTaskLogger getLogger() {
+    return logger;
   }
 
   private static Map<String, Object> immutableCopy(Map<String, Object> source) {

--- a/yak-ops-spi/src/main/java/io/yak/ops/spi/workflow/WorkflowTaskResult.java
+++ b/yak-ops-spi/src/main/java/io/yak/ops/spi/workflow/WorkflowTaskResult.java
@@ -5,16 +5,56 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 /** Result returned by one physical task attempt. */
-public record WorkflowTaskResult(
-    boolean success,
-    String externalId,
-    Map<String, Object> outputs,
-    String message) {
+public final class WorkflowTaskResult {
 
-  public WorkflowTaskResult {
-    outputs = outputs == null || outputs.isEmpty()
+  private final boolean success;
+  private final String externalId;
+  private final Map<String, Object> outputs;
+  private final String message;
+
+  public WorkflowTaskResult(
+      boolean success,
+      String externalId,
+      Map<String, Object> outputs,
+      String message) {
+    this.success = success;
+    this.externalId = externalId;
+    this.outputs = outputs == null || outputs.isEmpty()
         ? Map.of()
         : Collections.unmodifiableMap(new LinkedHashMap<>(outputs));
+    this.message = message;
+  }
+
+  public boolean success() {
+    return success;
+  }
+
+  public boolean isSuccess() {
+    return success;
+  }
+
+  public String externalId() {
+    return externalId;
+  }
+
+  public String getExternalId() {
+    return externalId;
+  }
+
+  public Map<String, Object> outputs() {
+    return outputs;
+  }
+
+  public Map<String, Object> getOutputs() {
+    return outputs;
+  }
+
+  public String message() {
+    return message;
+  }
+
+  public String getMessage() {
+    return message;
   }
 
   public static WorkflowTaskResult succeeded() {


### PR DESCRIPTION
## What changed

Replaces every Java `record` introduced by the lightweight workflow backend with ordinary classes to keep the model easier to migrate to older JDK baselines later.

- converts DAG, compiled graph, repository response models, REST request DTOs, task SPI context/result, dispatcher handle and test stub
- preserves existing record-style accessors such as `nodes()`, `state()` and `success()` so existing workflow engine call sites do not need broad changes
- adds standard JavaBean getters for serialization and integration compatibility
- adds no-argument constructors and setters to JSON request/DAG models used by Jackson
- preserves immutable collection copies for runtime and persisted response models

## Validation

- Java 21 syntax compilation passed for the converted SPI, DAG, repository models and dispatcher classes
- verified the converted source set contains no Java `record` declarations
- backend only; no frontend files changed

## Context

This is a follow-up to merged PR #85. That PR had already merged before the compatibility adjustment was requested, so this PR applies the change cleanly on top of the latest `main`.