### PR TITLE
feat(ui): add button-level permission access

### DIFF
--- a/yak-ops-ui/src/constants/securityPermissions.ts
+++ b/yak-ops-ui/src/constants/securityPermissions.ts
@@ -1,0 +1,31 @@
+/**
+ * 与 Yak Security 内置接口保持一致的稳定权限编码。
+ *
+ * 页面、按钮和下拉操作统一引用这里，避免各组件自行拼接字符串后发生漂移。
+ */
+export const SECURITY_PERMISSIONS = {
+  user: {
+    read: 'security:user:read',
+    create: 'security:user:create',
+    update: 'security:user:update',
+    resetPassword: 'security:user:reset-password',
+    delete: 'security:user:delete',
+  },
+  role: {
+    read: 'security:role:read',
+    create: 'security:role:create',
+    update: 'security:role:update',
+    assign: 'security:role:assign',
+    delete: 'security:role:delete',
+  },
+  permission: {
+    read: 'security:permission:read',
+    import: 'security:permission:import',
+    delete: 'security:permission:delete',
+  },
+} as const;
+
+export type SecurityPermissionCode =
+  | (typeof SECURITY_PERMISSIONS.user)[keyof typeof SECURITY_PERMISSIONS.user]
+  | (typeof SECURITY_PERMISSIONS.role)[keyof typeof SECURITY_PERMISSIONS.role]
+  | (typeof SECURITY_PERMISSIONS.permission)[keyof typeof SECURITY_PERMISSIONS.permission];

--- a/yak-ops-ui/src/hooks/usePermissionAccess.ts
+++ b/yak-ops-ui/src/hooks/usePermissionAccess.ts
@@ -1,0 +1,51 @@
+import { useModel } from '@umijs/max';
+import { useCallback, useMemo } from 'react';
+
+import {
+  hasAllPermissions,
+  hasAnyPermission,
+  hasPermission,
+  type PermissionCode,
+} from '@/utils/security/permission';
+
+/**
+ * 当前登录用户的按钮级权限访问器。
+ *
+ * 与 KnowStreaming 的全局 hasPermission 思路一致，但保留 Umi 初始状态作为
+ * 唯一权限来源，并复用可单测的纯函数，避免页面自行读取和解释权限数组。
+ */
+export const usePermissionAccess = () => {
+  const { initialState } = useModel('@@initialState');
+
+  const permissionCodes = useMemo<readonly PermissionCode[]>(
+    () => initialState?.currentUser?.permissionCodes ?? [],
+    [initialState?.currentUser?.permissionCodes],
+  );
+
+  const can = useCallback(
+    (permission: PermissionCode) =>
+      hasPermission(permissionCodes, permission),
+    [permissionCodes],
+  );
+
+  const canAny = useCallback(
+    (permissions: readonly PermissionCode[]) =>
+      hasAnyPermission(permissionCodes, permissions),
+    [permissionCodes],
+  );
+
+  const canAll = useCallback(
+    (permissions: readonly PermissionCode[]) =>
+      hasAllPermissions(permissionCodes, permissions),
+    [permissionCodes],
+  );
+
+  return {
+    permissionCodes,
+    can,
+    canAny,
+    canAll,
+  };
+};
+
+export default usePermissionAccess;

--- a/yak-ops-ui/src/pages/system/users/components/UserFilterBar.tsx
+++ b/yak-ops-ui/src/pages/system/users/components/UserFilterBar.tsx
@@ -7,6 +7,7 @@ import { Button, Input, Select, Tooltip } from "antd";
 import { useState } from "react";
 
 import { PermissionGuard } from "@/components/security";
+import { SECURITY_PERMISSIONS } from "@/constants/securityPermissions";
 
 import type { RoleOption } from "../shared";
 
@@ -49,9 +50,6 @@ const SEARCH_PLACEHOLDERS: Record<UserSearchField, string> = {
   realName: "请输入真实姓名",
   id: "请输入用户 ID",
 };
-
-const userPermission = (action: string): string =>
-  `security:user:${action}`;
 
 const clean = (value?: string): string | undefined => {
   const normalized = value?.trim();
@@ -226,7 +224,7 @@ export default function UserFilterBar({
 
         <PermissionGuard
           mode="one"
-          permission={userPermission("create")}
+          permission={SECURITY_PERMISSIONS.user.create}
         >
           <Button
             type="primary"

--- a/yak-ops-ui/src/pages/system/users/components/UserRowActions.test.tsx
+++ b/yak-ops-ui/src/pages/system/users/components/UserRowActions.test.tsx
@@ -1,15 +1,16 @@
 import { render, screen } from '@testing-library/react';
+import { useModel } from '@umijs/max';
 
 import { SECURITY_PERMISSIONS } from '@/constants/securityPermissions';
 import type { SystemUser } from '@/services/security/users';
 
 import UserRowActions from './UserRowActions';
 
-const mockUseModel = jest.fn();
-
 jest.mock('@umijs/max', () => ({
-  useModel: (...args: unknown[]) => mockUseModel(...args),
+  useModel: jest.fn(),
 }));
+
+const mockedUseModel = useModel as unknown as jest.Mock;
 
 const user: SystemUser = {
   id: 2,
@@ -32,11 +33,11 @@ const renderActions = () =>
 
 describe('UserRowActions permissions', () => {
   beforeEach(() => {
-    mockUseModel.mockReset();
+    mockedUseModel.mockReset();
   });
 
   it('keeps read-only users from seeing write actions', () => {
-    mockUseModel.mockReturnValue({
+    mockedUseModel.mockReturnValue({
       initialState: {
         currentUser: {
           permissionCodes: [SECURITY_PERMISSIONS.user.read],
@@ -46,13 +47,13 @@ describe('UserRowActions permissions', () => {
 
     renderActions();
 
-    expect(screen.getByText('详情')).toBeInTheDocument();
-    expect(screen.queryByText('编辑')).not.toBeInTheDocument();
-    expect(screen.queryByText('更多')).not.toBeInTheDocument();
+    expect(screen.getByText('详情')).toBeTruthy();
+    expect(screen.queryByText('编辑')).toBeNull();
+    expect(screen.queryByText('更多')).toBeNull();
   });
 
   it('shows only actions granted to the current user', () => {
-    mockUseModel.mockReturnValue({
+    mockedUseModel.mockReturnValue({
       initialState: {
         currentUser: {
           permissionCodes: [
@@ -66,12 +67,12 @@ describe('UserRowActions permissions', () => {
 
     renderActions();
 
-    expect(screen.getByText('编辑')).toBeInTheDocument();
-    expect(screen.getByText('更多')).toBeInTheDocument();
+    expect(screen.getByText('编辑')).toBeTruthy();
+    expect(screen.getByText('更多')).toBeTruthy();
   });
 
   it('lets the security root identity see every action entry', () => {
-    mockUseModel.mockReturnValue({
+    mockedUseModel.mockReturnValue({
       initialState: {
         currentUser: {
           permissionCodes: ['security:root'],
@@ -81,7 +82,7 @@ describe('UserRowActions permissions', () => {
 
     renderActions();
 
-    expect(screen.getByText('编辑')).toBeInTheDocument();
-    expect(screen.getByText('更多')).toBeInTheDocument();
+    expect(screen.getByText('编辑')).toBeTruthy();
+    expect(screen.getByText('更多')).toBeTruthy();
   });
 });

--- a/yak-ops-ui/src/pages/system/users/components/UserRowActions.test.tsx
+++ b/yak-ops-ui/src/pages/system/users/components/UserRowActions.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen } from '@testing-library/react';
+
+import { SECURITY_PERMISSIONS } from '@/constants/securityPermissions';
+import type { SystemUser } from '@/services/security/users';
+
+import UserRowActions from './UserRowActions';
+
+const mockUseModel = jest.fn();
+
+jest.mock('@umijs/max', () => ({
+  useModel: (...args: unknown[]) => mockUseModel(...args),
+}));
+
+const user: SystemUser = {
+  id: 2,
+  userName: 'tester',
+  realName: '测试用户',
+};
+
+const renderActions = () =>
+  render(
+    <UserRowActions
+      user={user}
+      currentUserName="admin"
+      onDetail={jest.fn()}
+      onEdit={jest.fn()}
+      onAssignRole={jest.fn()}
+      onResetPassword={jest.fn()}
+      onDeleted={jest.fn()}
+    />,
+  );
+
+describe('UserRowActions permissions', () => {
+  beforeEach(() => {
+    mockUseModel.mockReset();
+  });
+
+  it('keeps read-only users from seeing write actions', () => {
+    mockUseModel.mockReturnValue({
+      initialState: {
+        currentUser: {
+          permissionCodes: [SECURITY_PERMISSIONS.user.read],
+        },
+      },
+    });
+
+    renderActions();
+
+    expect(screen.getByText('详情')).toBeInTheDocument();
+    expect(screen.queryByText('编辑')).not.toBeInTheDocument();
+    expect(screen.queryByText('更多')).not.toBeInTheDocument();
+  });
+
+  it('shows only actions granted to the current user', () => {
+    mockUseModel.mockReturnValue({
+      initialState: {
+        currentUser: {
+          permissionCodes: [
+            SECURITY_PERMISSIONS.user.read,
+            SECURITY_PERMISSIONS.user.update,
+            SECURITY_PERMISSIONS.user.resetPassword,
+          ],
+        },
+      },
+    });
+
+    renderActions();
+
+    expect(screen.getByText('编辑')).toBeInTheDocument();
+    expect(screen.getByText('更多')).toBeInTheDocument();
+  });
+
+  it('lets the security root identity see every action entry', () => {
+    mockUseModel.mockReturnValue({
+      initialState: {
+        currentUser: {
+          permissionCodes: ['security:root'],
+        },
+      },
+    });
+
+    renderActions();
+
+    expect(screen.getByText('编辑')).toBeInTheDocument();
+    expect(screen.getByText('更多')).toBeInTheDocument();
+  });
+});

--- a/yak-ops-ui/src/pages/system/users/components/UserRowActions.tsx
+++ b/yak-ops-ui/src/pages/system/users/components/UserRowActions.tsx
@@ -15,6 +15,8 @@ import {
   type MenuProps,
 } from 'antd';
 
+import { SECURITY_PERMISSIONS } from '@/constants/securityPermissions';
+import { usePermissionAccess } from '@/hooks/usePermissionAccess';
 import {
   deleteUser as deleteSystemUser,
   type SystemUser,
@@ -43,9 +45,19 @@ export default function UserRowActions({
   onResetPassword,
   onDeleted,
 }: UserRowActionsProps) {
+  const { can } = usePermissionAccess();
   const isCurrentUser = user.userName === currentUserName;
 
+  const canEdit = can(SECURITY_PERMISSIONS.user.update);
+  const canAssignRole = can(SECURITY_PERMISSIONS.role.assign);
+  const canResetPassword = can(
+    SECURITY_PERMISSIONS.user.resetPassword,
+  );
+  const canDelete = can(SECURITY_PERMISSIONS.user.delete);
+
   const remove = async () => {
+    if (!canDelete) return;
+
     try {
       await deleteSystemUser(user.id);
       message.success('用户已删除');
@@ -57,6 +69,8 @@ export default function UserRowActions({
   };
 
   const confirmDelete = () => {
+    if (!canDelete || isCurrentUser) return;
+
     Modal.confirm({
       title: '删除用户',
       content: (
@@ -78,36 +92,45 @@ export default function UserRowActions({
     });
   };
 
-  const menuItems: MenuProps['items'] = [
-    {
+  const menuItems: NonNullable<MenuProps['items']> = [];
+
+  if (canAssignRole) {
+    menuItems.push({
       key: 'assignRole',
       icon: <SafetyCertificateOutlined />,
       label: '分配角色',
-    },
-    {
+    });
+  }
+
+  if (canResetPassword) {
+    menuItems.push({
       key: 'resetPassword',
       icon: <KeyOutlined />,
       label: '重置密码',
-    },
-    {
-      type: 'divider',
-    },
-    {
+    });
+  }
+
+  if (canDelete) {
+    if (menuItems.length > 0) {
+      menuItems.push({ type: 'divider' });
+    }
+
+    menuItems.push({
       key: 'delete',
       icon: <DeleteOutlined />,
       label: '删除用户',
       danger: true,
       disabled: isCurrentUser,
-    },
-  ];
+    });
+  }
 
   const handleMenuClick: MenuProps['onClick'] = ({ key }) => {
     switch (key as ActionKey) {
       case 'assignRole':
-        onAssignRole(user);
+        if (canAssignRole) onAssignRole(user);
         break;
       case 'resetPassword':
-        onResetPassword(user);
+        if (canResetPassword) onResetPassword(user);
         break;
       case 'delete':
         confirmDelete();
@@ -129,33 +152,37 @@ export default function UserRowActions({
         详情
       </Button>
 
-      <Button
-        type="link"
-        size="small"
-        icon={<EditOutlined />}
-        className="!px-1.5 !text-slate-600 hover:!text-slate-900"
-        onClick={() => onEdit(user)}
-      >
-        编辑
-      </Button>
-
-      <Dropdown
-        trigger={['click']}
-        placement="bottomRight"
-        menu={{
-          items: menuItems,
-          onClick: handleMenuClick,
-        }}
-      >
+      {canEdit && (
         <Button
           type="link"
           size="small"
+          icon={<EditOutlined />}
           className="!px-1.5 !text-slate-600 hover:!text-slate-900"
+          onClick={() => onEdit(user)}
         >
-          更多
-          <DownOutlined className="ml-1 text-[10px]" />
+          编辑
         </Button>
-      </Dropdown>
+      )}
+
+      {menuItems.length > 0 && (
+        <Dropdown
+          trigger={['click']}
+          placement="bottomRight"
+          menu={{
+            items: menuItems,
+            onClick: handleMenuClick,
+          }}
+        >
+          <Button
+            type="link"
+            size="small"
+            className="!px-1.5 !text-slate-600 hover:!text-slate-900"
+          >
+            更多
+            <DownOutlined className="ml-1 text-[10px]" />
+          </Button>
+        </Dropdown>
+      )}
     </Space>
   );
 }


### PR DESCRIPTION
## 背景

参考 KnowStreaming 的权限设计：登录后提供统一的 `hasPermission` 能力，并在快捷入口、侧边菜单、路由守卫和页面操作中复用同一权限判断。

Yak Ops 当前其实已经具备：

- `/account/current` 返回 `permissionCodes`；
- `hasPermission / hasAnyPermission / hasAllPermissions` 纯函数；
- `PermissionGuard`；
- 菜单与直接路由授权。

主要缺口是按钮和下拉操作接入不完整、权限字符串分散在页面中。本 PR 先完成统一访问层，并在用户管理操作列落地。

## 实现内容

- 新增 `SECURITY_PERMISSIONS`，集中维护前后端一致的权限编码。
- 新增 `usePermissionAccess`：
  - `can(permission)`
  - `canAny(permissions)`
  - `canAll(permissions)`
- 继续复用已有 `security:root` 超级管理员放行逻辑。
- 用户管理：
  - 新增用户：`security:user:create`
  - 编辑用户：`security:user:update`
  - 分配角色：`security:role:assign`
  - 重置密码：`security:user:reset-password`
  - 删除用户：`security:user:delete`
- 无权限的编辑按钮和“更多”菜单项不渲染；菜单中没有可用操作时，不展示空的“更多”入口。
- 删除当前登录用户的原有业务限制继续保留。
- 新增组件测试，覆盖只读用户、细粒度授权用户和 `security:root` 用户。

## 与 KnowStreaming 的差异

KnowStreaming 主要通过全局 `hasPermission` 直接判断。本实现保留相同使用体验，但将权限来源固定为 Umi `initialState.currentUser.permissionCodes`，底层复用纯函数，权限编码集中定义，减少页面自行拼接字符串造成的漂移。

## 后端依赖

依赖后端 Draft PR：weifuwan/yak-framework#69

前端隐藏按钮不是安全边界；后端 PR 使用 `@RequiresPermission` 对对应接口返回 403，二者应配套合并和发布。

## 验证

- 新增 `UserRowActions.test.tsx`，覆盖按钮显示逻辑。
- 已完成代码级静态复核。
- 当前执行环境没有仓库本地检出与 `gh` CLI，因此未在本地运行前端测试；请以 PR CI 结果为准。

## 对比后仍未完成的范围

- 角色管理目前只有“新增角色”已使用守卫；编辑、分配用户、删除等行操作仍应迁移到 `usePermissionAccess` 和统一常量。
- 权限管理的导入、删除已有守卫，但仍使用页面内字符串拼接，应迁移到统一常量。
- 部门、项目、资源授权、系统配置以及工作流等业务页面，需要逐页建立“按钮 → 权限编码 → 后端接口”的映射。
- 建议后续增加统一的权限矩阵文档和页面接入检查清单。

之所以保持 Draft，是为了先确认权限编码命名和操作粒度，再批量接入剩余页面，避免后续数据库授权重复迁移。
