### PR TITLE
feat(datasource): implement datasource CRUD backend

### DIFF
--- a/yak-ops-boot/src/main/resources/application.yml
+++ b/yak-ops-boot/src/main/resources/application.yml
@@ -5,12 +5,12 @@ server:
 spring:
   application:
     name: yak-ops
-  # Yak Security and Yak Workflow own dedicated DataSources and transaction managers.
+  # Yak Security、Yak Datasource 和 Yak Workflow 分别维护自己的数据源与事务管理器。
   autoconfigure:
     exclude:
       - org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
       - org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration
-  # Domain modules create and run their own Flyway instances.
+  # 各业务模块自行创建并执行 Flyway。
   flyway:
     enabled: false
   lifecycle:
@@ -75,6 +75,18 @@ yak:
       test-while-idle: true
       test-on-borrow: false
       test-on-return: false
+
+  datasource:
+    enabled: true
+    database:
+      url: ${YAK_DATASOURCE_URL:${YAK_SECURITY_DATASOURCE_URL:jdbc:mariadb://127.0.0.1:3306/yak_security?useUnicode=true&allowPublicKeyRetrieval=true&characterEncoding=UTF-8&useSSL=false&serverTimezone=Asia/Shanghai}}
+      username: ${YAK_DATASOURCE_USERNAME:${YAK_SECURITY_DATASOURCE_USERNAME:root}}
+      password: ${YAK_DATASOURCE_PASSWORD:${YAK_SECURITY_DATASOURCE_PASSWORD:123456}}
+      driver-class-name: ${YAK_DATASOURCE_DRIVER:org.mariadb.jdbc.Driver}
+      minimum-idle: 1
+      maximum-pool-size: 8
+    connection-test:
+      timeout-seconds: ${YAK_DATASOURCE_CONNECT_TIMEOUT_SECONDS:5}
 
   schedule:
     enabled: true

--- a/yak-ops-boot/src/test/resources/application-test.yml
+++ b/yak-ops-boot/src/test/resources/application-test.yml
@@ -20,6 +20,8 @@ yak:
       enabled: false
     bootstrap:
       enabled: false
+  datasource:
+    enabled: false
   schedule:
     enabled: false
     web-enabled: false

--- a/yak-ops-business/yak-ops-business-datasource/pom.xml
+++ b/yak-ops-business/yak-ops-business-datasource/pom.xml
@@ -21,5 +21,62 @@
             <groupId>io.yak.ops</groupId>
             <artifactId>yak-ops-core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.yak.framework</groupId>
+            <artifactId>yak-common</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-jdbc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-mysql</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.mariadb.jdbc</groupId>
+            <artifactId>mariadb-java-client</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/common/constant/DataSourceConstants.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/common/constant/DataSourceConstants.java
@@ -1,0 +1,13 @@
+package io.yak.ops.business.datasource.common.constant;
+
+/** 数据源管理常量。 */
+public final class DataSourceConstants {
+
+  public static final String API_PREFIX = "/api/v1/data-source";
+  public static final int DEFAULT_PAGE_NO = 1;
+  public static final int DEFAULT_PAGE_SIZE = 10;
+  public static final int MAX_PAGE_SIZE = 200;
+
+  private DataSourceConstants() {
+  }
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/common/dto/DataSourceConnectTestDTO.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/common/dto/DataSourceConnectTestDTO.java
@@ -1,0 +1,13 @@
+package io.yak.ops.business.datasource.common.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+/** 未保存数据源连接测试参数。 */
+@Data
+public class DataSourceConnectTestDTO {
+
+  /** 动态表单连接参数 JSON。 */
+  @NotBlank(message = "connJson 不能为空")
+  private String connJson;
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/common/dto/DataSourceDTO.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/common/dto/DataSourceDTO.java
@@ -1,0 +1,30 @@
+package io.yak.ops.business.datasource.common.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+/** 数据源新增和编辑数据传输对象。 */
+@Data
+public class DataSourceDTO {
+
+  /** 数据源名称。 */
+  @NotBlank(message = "数据源名称不能为空")
+  @Size(max = 128, message = "数据源名称不能超过 128 个字符")
+  private String name;
+
+  /** 数据库类型。 */
+  @NotBlank(message = "数据源类型不能为空")
+  private String dbType;
+
+  /** 运行环境。 */
+  private String environment;
+
+  /** 备注。 */
+  @Size(max = 500, message = "数据源备注不能超过 500 个字符")
+  private String remark;
+
+  /** 前端动态表单提交的连接参数 JSON。 */
+  @NotBlank(message = "数据源连接参数不能为空")
+  private String connectionParams;
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/common/dto/DataSourceQueryDTO.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/common/dto/DataSourceQueryDTO.java
@@ -1,0 +1,29 @@
+package io.yak.ops.business.datasource.common.dto;
+
+import io.yak.ops.business.datasource.common.constant.DataSourceConstants;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import lombok.Data;
+
+/** 数据源分页查询数据传输对象。 */
+@Data
+public class DataSourceQueryDTO {
+
+  /** 当前页码。 */
+  @Min(value = 1, message = "页码必须大于 0")
+  private int pageNo = DataSourceConstants.DEFAULT_PAGE_NO;
+
+  /** 每页条数。 */
+  @Min(value = 1, message = "每页条数必须大于 0")
+  @Max(value = DataSourceConstants.MAX_PAGE_SIZE, message = "每页条数不能超过 200")
+  private int pageSize = DataSourceConstants.DEFAULT_PAGE_SIZE;
+
+  /** 数据源名称。 */
+  private String name;
+
+  /** 数据库类型。 */
+  private String dbType;
+
+  /** 运行环境。 */
+  private String environment;
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/common/enums/DataSourceConnStatus.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/common/enums/DataSourceConnStatus.java
@@ -1,0 +1,16 @@
+package io.yak.ops.business.datasource.common.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/** 数据源连通状态。 */
+@Getter
+@RequiredArgsConstructor
+public enum DataSourceConnStatus {
+
+  UNKNOWN("未测试"),
+  CONNECTED("连接可用"),
+  DISCONNECTED("连接不可用");
+
+  private final String displayName;
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/common/enums/DataSourceDbType.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/common/enums/DataSourceDbType.java
@@ -1,0 +1,45 @@
+package io.yak.ops.business.datasource.common.enums;
+
+import io.yak.ops.business.datasource.exception.DataSourceException;
+import java.util.Locale;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.util.StringUtils;
+
+/** Yak Ops 当前支持的数据源类型。 */
+@Getter
+@RequiredArgsConstructor
+public enum DataSourceDbType {
+
+  MYSQL("MySQL", "org.mariadb.jdbc.Driver", 3306, "jdbc:mariadb"),
+  ORACLE("Oracle", "oracle.jdbc.OracleDriver", 1521, "jdbc:oracle:thin:@"),
+  POSTGRE_SQL("PostgreSQL", "org.postgresql.Driver", 5432, "jdbc:postgresql"),
+  DORIS("Doris", "org.mariadb.jdbc.Driver", 9030, "jdbc:mariadb"),
+  KINGBASE("KingbaseES", "com.kingbase8.Driver", 54321, "jdbc:kingbase8"),
+  DAMENG("达梦", "dm.jdbc.driver.DmDriver", 5236, "jdbc:dm");
+
+  private final String displayName;
+  private final String defaultDriverClassName;
+  private final int defaultPort;
+  private final String jdbcPrefix;
+
+  public static DataSourceDbType parse(String value) {
+    if (!StringUtils.hasText(value)) {
+      throw new DataSourceException(DataSourceErrorCode.INVALID_DB_TYPE);
+    }
+
+    String normalized = value.trim().toUpperCase(Locale.ROOT).replace('-', '_');
+    if ("POSTGRESQL".equals(normalized) || "POSTGRES".equals(normalized)) {
+      normalized = "POSTGRE_SQL";
+    }
+
+    try {
+      return valueOf(normalized);
+    } catch (IllegalArgumentException exception) {
+      throw new DataSourceException(
+          DataSourceErrorCode.INVALID_DB_TYPE,
+          "不支持的数据源类型：" + value,
+          exception);
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/common/enums/DataSourceEnvironment.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/common/enums/DataSourceEnvironment.java
@@ -1,0 +1,42 @@
+package io.yak.ops.business.datasource.common.enums;
+
+import io.yak.ops.business.datasource.exception.DataSourceException;
+import java.util.Locale;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.util.StringUtils;
+
+/** 数据源所属环境。 */
+@Getter
+@RequiredArgsConstructor
+public enum DataSourceEnvironment {
+
+  DEVELOP("开发"),
+  TEST("测试"),
+  PROD("生产");
+
+  private final String displayName;
+
+  public static DataSourceEnvironment parse(String value) {
+    if (!StringUtils.hasText(value)) {
+      return DEVELOP;
+    }
+
+    String normalized = value.trim().toUpperCase(Locale.ROOT);
+    if ("DEV".equals(normalized) || "DEVELOPMENT".equals(normalized)) {
+      normalized = "DEVELOP";
+    }
+    if ("PRODUCTION".equals(normalized)) {
+      normalized = "PROD";
+    }
+
+    try {
+      return valueOf(normalized);
+    } catch (IllegalArgumentException exception) {
+      throw new DataSourceException(
+          DataSourceErrorCode.INVALID_ENVIRONMENT,
+          "不支持的运行环境：" + value,
+          exception);
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/common/enums/DataSourceErrorCode.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/common/enums/DataSourceErrorCode.java
@@ -1,0 +1,25 @@
+package io.yak.ops.business.datasource.common.enums;
+
+import io.yak.framework.common.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/** 数据源管理业务错误码。 */
+@Getter
+@RequiredArgsConstructor
+public enum DataSourceErrorCode implements ErrorCode {
+
+  NOT_FOUND(41001, "数据源不存在"),
+  DUPLICATE_NAME(41002, "数据源名称已存在"),
+  INVALID_DB_TYPE(41003, "数据源类型不合法"),
+  INVALID_ENVIRONMENT(41004, "数据源环境不合法"),
+  INVALID_CONNECTION_PARAMS(41005, "数据源连接参数不合法"),
+  CONNECT_FAILED(41006, "数据源连接测试失败"),
+  CREATE_FAILED(41007, "创建数据源失败"),
+  UPDATE_FAILED(41008, "更新数据源失败"),
+  DELETE_FAILED(41009, "删除数据源失败"),
+  QUERY_FAILED(41010, "查询数据源失败");
+
+  private final Integer code;
+  private final String message;
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/common/po/DataSourcePO.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/common/po/DataSourcePO.java
@@ -1,0 +1,48 @@
+package io.yak.ops.business.datasource.common.po;
+
+import io.yak.ops.business.datasource.common.enums.DataSourceConnStatus;
+import io.yak.ops.business.datasource.common.enums.DataSourceDbType;
+import io.yak.ops.business.datasource.common.enums.DataSourceEnvironment;
+import java.time.LocalDateTime;
+import lombok.Data;
+import lombok.ToString;
+
+/** 数据源持久化对象。 */
+@Data
+public class DataSourcePO {
+
+  /** 主键。 */
+  private Long id;
+
+  /** 数据源名称。 */
+  private String name;
+
+  /** 数据库类型。 */
+  private DataSourceDbType dbType;
+
+  /** 展示和连接使用的 JDBC 地址。 */
+  private String jdbcUrl;
+
+  /** 运行环境。 */
+  private DataSourceEnvironment environment;
+
+  /** 连通状态。 */
+  private DataSourceConnStatus connStatus;
+
+  /** 备注。 */
+  private String remark;
+
+  /** 规范化后的连接参数。 */
+  @ToString.Exclude
+  private String connectionParams;
+
+  /** 前端原始连接参数，用于编辑回显。 */
+  @ToString.Exclude
+  private String originalJson;
+
+  /** 创建时间。 */
+  private LocalDateTime createTime;
+
+  /** 更新时间。 */
+  private LocalDateTime updateTime;
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/common/vo/DataSourceOptionVO.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/common/vo/DataSourceOptionVO.java
@@ -1,0 +1,16 @@
+package io.yak.ops.business.datasource.common.vo;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/** 数据源下拉选项。 */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class DataSourceOptionVO {
+
+  private String label;
+  private String value;
+  private String dbType;
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/common/vo/DataSourcePluginConfigVO.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/common/vo/DataSourcePluginConfigVO.java
@@ -1,0 +1,71 @@
+package io.yak.ops.business.datasource.common.vo;
+
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/** 数据源动态表单配置。 */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DataSourcePluginConfigVO {
+
+  private String pluginType;
+
+  @Builder.Default
+  private List<FormFieldVO> formFields = new ArrayList<>();
+
+  @Builder.Default
+  private Boolean installRequired = false;
+
+  private String installHint;
+
+  /** 动态表单字段。 */
+  @Data
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class FormFieldVO {
+
+    private String key;
+    private String label;
+    private String type;
+    private String placeholder;
+    private Object defaultValue;
+
+    @Builder.Default
+    private List<OptionVO> options = new ArrayList<>();
+
+    @Builder.Default
+    private List<RuleVO> rules = new ArrayList<>();
+  }
+
+  /** 下拉选项。 */
+  @Data
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class OptionVO {
+
+    private String label;
+    private Object value;
+  }
+
+  /** 前端表单校验规则。 */
+  @Data
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class RuleVO {
+
+    private Boolean required;
+    private String pattern;
+    private Integer min;
+    private Integer max;
+    private String message;
+  }
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/common/vo/DataSourceVO.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/common/vo/DataSourceVO.java
@@ -1,0 +1,21 @@
+package io.yak.ops.business.datasource.common.vo;
+
+import java.time.LocalDateTime;
+import lombok.Data;
+
+/** 数据源展示对象。 */
+@Data
+public class DataSourceVO {
+
+  private Long id;
+  private String name;
+  private String dbType;
+  private String jdbcUrl;
+  private String environment;
+  private String environmentName;
+  private String connStatus;
+  private String remark;
+  private String originalJson;
+  private LocalDateTime createTime;
+  private LocalDateTime updateTime;
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/config/ConditionalOnDataSourceEnabled.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/config/ConditionalOnDataSourceEnabled.java
@@ -1,0 +1,18 @@
+package io.yak.ops.business.datasource.config;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+
+/** 仅在数据源管理模块启用时装配相关 Bean。 */
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@ConditionalOnProperty(
+    prefix = "yak.datasource",
+    name = "enabled",
+    havingValue = "true",
+    matchIfMissing = true)
+public @interface ConditionalOnDataSourceEnabled {
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/config/DataSourceConfiguration.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/config/DataSourceConfiguration.java
@@ -1,0 +1,57 @@
+package io.yak.ops.business.datasource.config;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import javax.sql.DataSource;
+import org.flywaydb.core.Flyway;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.transaction.PlatformTransactionManager;
+
+/** 数据源管理模块基础设施配置。 */
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnDataSourceEnabled
+@EnableConfigurationProperties(DataSourceProperties.class)
+public class DataSourceConfiguration {
+
+  @Bean(name = "opsDataSource", destroyMethod = "close")
+  public HikariDataSource opsDataSource(DataSourceProperties properties) {
+    DataSourceProperties.Database database = properties.getDatabase();
+    HikariConfig config = new HikariConfig();
+    config.setPoolName("YakOpsDatasourcePool");
+    config.setJdbcUrl(database.getUrl());
+    config.setUsername(database.getUsername());
+    config.setPassword(database.getPassword());
+    config.setDriverClassName(database.getDriverClassName());
+    config.setMinimumIdle(database.getMinimumIdle());
+    config.setMaximumPoolSize(database.getMaximumPoolSize());
+    config.setAutoCommit(true);
+    return new HikariDataSource(config);
+  }
+
+  @Bean(name = "opsDataSourceTransactionManager")
+  public PlatformTransactionManager opsDataSourceTransactionManager(
+      @Qualifier("opsDataSource") DataSource dataSource) {
+    return new DataSourceTransactionManager(dataSource);
+  }
+
+  @Bean(initMethod = "migrate")
+  public Flyway opsDataSourceFlyway(@Qualifier("opsDataSource") DataSource dataSource) {
+    return Flyway.configure()
+        .dataSource(dataSource)
+        .locations("classpath:db/migration/yak-datasource")
+        .table("yak_ds_schema_history")
+        .baselineOnMigrate(true)
+        .load();
+  }
+
+  @Bean(name = "opsDataSourceJdbcTemplate")
+  public NamedParameterJdbcTemplate opsDataSourceJdbcTemplate(
+      @Qualifier("opsDataSource") DataSource dataSource) {
+    return new NamedParameterJdbcTemplate(dataSource);
+  }
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/config/DataSourceProperties.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/config/DataSourceProperties.java
@@ -1,0 +1,104 @@
+package io.yak.ops.business.datasource.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/** 数据源管理模块配置。 */
+@ConfigurationProperties(prefix = "yak.datasource")
+public class DataSourceProperties {
+
+  private boolean enabled = true;
+  private final Database database = new Database();
+  private final ConnectionTest connectionTest = new ConnectionTest();
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  public Database getDatabase() {
+    return database;
+  }
+
+  public ConnectionTest getConnectionTest() {
+    return connectionTest;
+  }
+
+  /** 数据源管理元数据数据库配置。 */
+  public static class Database {
+
+    private String url =
+        "jdbc:mariadb://127.0.0.1:3306/yak_security"
+            + "?useUnicode=true&allowPublicKeyRetrieval=true&characterEncoding=UTF-8"
+            + "&useSSL=false&serverTimezone=Asia/Shanghai";
+    private String username = "root";
+    private String password = "123456";
+    private String driverClassName = "org.mariadb.jdbc.Driver";
+    private int minimumIdle = 1;
+    private int maximumPoolSize = 8;
+
+    public String getUrl() {
+      return url;
+    }
+
+    public void setUrl(String url) {
+      this.url = url;
+    }
+
+    public String getUsername() {
+      return username;
+    }
+
+    public void setUsername(String username) {
+      this.username = username;
+    }
+
+    public String getPassword() {
+      return password;
+    }
+
+    public void setPassword(String password) {
+      this.password = password;
+    }
+
+    public String getDriverClassName() {
+      return driverClassName;
+    }
+
+    public void setDriverClassName(String driverClassName) {
+      this.driverClassName = driverClassName;
+    }
+
+    public int getMinimumIdle() {
+      return minimumIdle;
+    }
+
+    public void setMinimumIdle(int minimumIdle) {
+      this.minimumIdle = minimumIdle;
+    }
+
+    public int getMaximumPoolSize() {
+      return maximumPoolSize;
+    }
+
+    public void setMaximumPoolSize(int maximumPoolSize) {
+      this.maximumPoolSize = maximumPoolSize;
+    }
+  }
+
+  /** 用户配置的数据源连接测试参数。 */
+  public static class ConnectionTest {
+
+    private int timeoutSeconds = 5;
+
+    public int getTimeoutSeconds() {
+      return timeoutSeconds;
+    }
+
+    public void setTimeoutSeconds(int timeoutSeconds) {
+      this.timeoutSeconds = timeoutSeconds;
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/controller/DataSourceController.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/controller/DataSourceController.java
@@ -1,0 +1,98 @@
+package io.yak.ops.business.datasource.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.yak.framework.common.PagingData;
+import io.yak.framework.common.PagingResult;
+import io.yak.framework.common.Result;
+import io.yak.ops.business.datasource.common.constant.DataSourceConstants;
+import io.yak.ops.business.datasource.common.dto.DataSourceConnectTestDTO;
+import io.yak.ops.business.datasource.common.dto.DataSourceDTO;
+import io.yak.ops.business.datasource.common.dto.DataSourceQueryDTO;
+import io.yak.ops.business.datasource.common.vo.DataSourceOptionVO;
+import io.yak.ops.business.datasource.common.vo.DataSourceVO;
+import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
+import io.yak.ops.business.datasource.service.DataSourceService;
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/** 数据源管理接口。 */
+@Tag(name = "数据源管理接口")
+@RestController
+@ConditionalOnDataSourceEnabled
+@RequiredArgsConstructor
+@RequestMapping(DataSourceConstants.API_PREFIX)
+public class DataSourceController {
+
+  private final DataSourceService dataSourceService;
+
+  @Operation(summary = "新增数据源")
+  @PostMapping
+  public Result<Boolean> create(@Valid @RequestBody DataSourceDTO dataSourceDTO) {
+    return Result.success(dataSourceService.createDataSource(dataSourceDTO));
+  }
+
+  @Operation(summary = "编辑数据源")
+  @PutMapping("/{id}")
+  public Result<Boolean> update(
+      @PathVariable("id") Long id,
+      @Valid @RequestBody DataSourceDTO dataSourceDTO) {
+    return Result.success(dataSourceService.updateDataSource(id, dataSourceDTO));
+  }
+
+  @Operation(summary = "查询数据源详情")
+  @GetMapping("/{id}")
+  public Result<DataSourceVO> detail(@PathVariable("id") Long id) {
+    return Result.success(dataSourceService.getDataSource(id));
+  }
+
+  @Operation(summary = "删除数据源")
+  @DeleteMapping("/{id}")
+  public Result<Boolean> delete(@PathVariable("id") Long id) {
+    return Result.success(dataSourceService.deleteDataSource(id));
+  }
+
+  @Operation(summary = "分页查询数据源")
+  @PostMapping("/page")
+  public PagingResult<DataSourceVO> page(
+      @Valid @RequestBody DataSourceQueryDTO queryDTO) {
+    return PagingResult.success(dataSourceService.getDataSourcePage(queryDTO));
+  }
+
+  @Operation(summary = "查询全部数据源")
+  @RequestMapping(value = "/all", method = {RequestMethod.GET, RequestMethod.POST})
+  public Result<PagingData<DataSourceVO>> all() {
+    return Result.success(dataSourceService.getAllDataSources());
+  }
+
+  @Operation(summary = "查询数据源下拉选项")
+  @GetMapping("/option")
+  public Result<List<DataSourceOptionVO>> option(
+      @RequestParam(value = "dbType", required = false) String dbType) {
+    return Result.success(dataSourceService.getOptions(dbType));
+  }
+
+  @Operation(summary = "测试已保存数据源连接")
+  @GetMapping("/{id}/connect-test")
+  public Result<Boolean> testConnection(@PathVariable("id") Long id) {
+    return Result.success(dataSourceService.testConnection(id));
+  }
+
+  @Operation(summary = "使用连接参数测试数据源连接")
+  @PostMapping("/connect-test-with-param")
+  public Result<Boolean> testConnection(
+      @Valid @RequestBody DataSourceConnectTestDTO connectTestDTO) {
+    return Result.success(dataSourceService.testConnection(connectTestDTO));
+  }
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/controller/DataSourcePluginConfigController.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/controller/DataSourcePluginConfigController.java
@@ -1,0 +1,40 @@
+package io.yak.ops.business.datasource.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.yak.framework.common.Result;
+import io.yak.ops.business.datasource.common.constant.DataSourceConstants;
+import io.yak.ops.business.datasource.common.vo.DataSourcePluginConfigVO;
+import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
+import io.yak.ops.business.datasource.service.DataSourcePluginConfigService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/** 数据源动态表单配置接口。 */
+@Tag(name = "数据源表单配置接口")
+@RestController
+@ConditionalOnDataSourceEnabled
+@RequiredArgsConstructor
+@RequestMapping(DataSourceConstants.API_PREFIX + "/plugin/config")
+public class DataSourcePluginConfigController {
+
+  private final DataSourcePluginConfigService pluginConfigService;
+
+  @Operation(summary = "查询数据源动态表单配置")
+  @GetMapping
+  public Result<DataSourcePluginConfigVO> getPluginConfig(
+      @RequestParam("pluginType") String pluginType) {
+    return Result.success(pluginConfigService.getPluginConfig(pluginType));
+  }
+
+  @Operation(summary = "安装数据源配置")
+  @PostMapping("/install")
+  public Result<Boolean> installPlugin(
+      @RequestParam("pluginType") String pluginType) {
+    return Result.success(pluginConfigService.installPlugin(pluginType));
+  }
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/dao/DataSourceDao.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/dao/DataSourceDao.java
@@ -1,0 +1,27 @@
+package io.yak.ops.business.datasource.dao;
+
+import io.yak.ops.business.datasource.common.dto.DataSourceQueryDTO;
+import io.yak.ops.business.datasource.common.po.DataSourcePO;
+import java.util.List;
+
+/** 数据源数据访问接口。 */
+public interface DataSourceDao {
+
+  int addDataSource(DataSourcePO dataSourcePO);
+
+  int editDataSource(DataSourcePO dataSourcePO);
+
+  DataSourcePO selectById(Long id);
+
+  long count(DataSourceQueryDTO queryDTO);
+
+  List<DataSourcePO> selectPage(DataSourceQueryDTO queryDTO);
+
+  List<DataSourcePO> selectAll(String dbType);
+
+  boolean existsByName(String name, Long excludeId);
+
+  boolean deleteById(Long id);
+
+  boolean updateConnectionStatus(Long id, String connStatus);
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/dao/impl/JdbcDataSourceDao.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/dao/impl/JdbcDataSourceDao.java
@@ -1,0 +1,230 @@
+package io.yak.ops.business.datasource.dao.impl;
+
+import io.yak.ops.business.datasource.common.dto.DataSourceQueryDTO;
+import io.yak.ops.business.datasource.common.enums.DataSourceConnStatus;
+import io.yak.ops.business.datasource.common.enums.DataSourceDbType;
+import io.yak.ops.business.datasource.common.enums.DataSourceEnvironment;
+import io.yak.ops.business.datasource.common.po.DataSourcePO;
+import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
+import io.yak.ops.business.datasource.dao.DataSourceDao;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.support.GeneratedKeyHolder;
+import org.springframework.jdbc.support.KeyHolder;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
+
+/** 基于 Spring JDBC 的数据源数据访问实现。 */
+@Repository
+@ConditionalOnDataSourceEnabled
+public class JdbcDataSourceDao implements DataSourceDao {
+
+  private static final String BASE_COLUMNS =
+      "id,name,db_type,jdbc_url,environment,conn_status,remark,"
+          + "connection_params,original_json,create_time,update_time";
+
+  private final NamedParameterJdbcTemplate jdbcTemplate;
+  private final RowMapper<DataSourcePO> rowMapper = this::mapRow;
+
+  public JdbcDataSourceDao(
+      @Qualifier("opsDataSourceJdbcTemplate")
+      NamedParameterJdbcTemplate jdbcTemplate) {
+    this.jdbcTemplate = jdbcTemplate;
+  }
+
+  @Override
+  public int addDataSource(DataSourcePO dataSourcePO) {
+    String sql =
+        "INSERT INTO yak_ops_data_source "
+            + "(name,db_type,jdbc_url,environment,conn_status,remark,"
+            + "connection_params,original_json,create_time,update_time) "
+            + "VALUES (:name,:dbType,:jdbcUrl,:environment,:connStatus,:remark,"
+            + ":connectionParams,:originalJson,CURRENT_TIMESTAMP(3),CURRENT_TIMESTAMP(3))";
+
+    MapSqlParameterSource parameters = toParameters(dataSourcePO);
+    KeyHolder keyHolder = new GeneratedKeyHolder();
+    int rows = jdbcTemplate.update(sql, parameters, keyHolder, new String[] {"id"});
+    Number key = keyHolder.getKey();
+    if (key != null) {
+      dataSourcePO.setId(key.longValue());
+    }
+    return rows;
+  }
+
+  @Override
+  public int editDataSource(DataSourcePO dataSourcePO) {
+    String sql =
+        "UPDATE yak_ops_data_source SET "
+            + "name=:name,db_type=:dbType,jdbc_url=:jdbcUrl,environment=:environment,"
+            + "conn_status=:connStatus,remark=:remark,connection_params=:connectionParams,"
+            + "original_json=:originalJson,update_time=CURRENT_TIMESTAMP(3) "
+            + "WHERE id=:id";
+
+    return jdbcTemplate.update(sql, toParameters(dataSourcePO));
+  }
+
+  @Override
+  public DataSourcePO selectById(Long id) {
+    if (id == null) {
+      return null;
+    }
+
+    List<DataSourcePO> rows =
+        jdbcTemplate.query(
+            "SELECT " + BASE_COLUMNS + " FROM yak_ops_data_source WHERE id=:id",
+            new MapSqlParameterSource("id", id),
+            rowMapper);
+    return rows.isEmpty() ? null : rows.get(0);
+  }
+
+  @Override
+  public long count(DataSourceQueryDTO queryDTO) {
+    QueryParts parts = buildQueryParts(queryDTO);
+    Long total =
+        jdbcTemplate.queryForObject(
+            "SELECT COUNT(1) FROM yak_ops_data_source" + parts.whereClause,
+            parts.parameters,
+            Long.class);
+    return total == null ? 0L : total;
+  }
+
+  @Override
+  public List<DataSourcePO> selectPage(DataSourceQueryDTO queryDTO) {
+    QueryParts parts = buildQueryParts(queryDTO);
+    parts.parameters.addValue("limit", queryDTO.getPageSize());
+    parts.parameters.addValue(
+        "offset",
+        (long) (queryDTO.getPageNo() - 1) * queryDTO.getPageSize());
+
+    return jdbcTemplate.query(
+        "SELECT "
+            + BASE_COLUMNS
+            + " FROM yak_ops_data_source"
+            + parts.whereClause
+            + " ORDER BY update_time DESC,id DESC LIMIT :limit OFFSET :offset",
+        parts.parameters,
+        rowMapper);
+  }
+
+  @Override
+  public List<DataSourcePO> selectAll(String dbType) {
+    MapSqlParameterSource parameters = new MapSqlParameterSource();
+    String where = "";
+    if (StringUtils.hasText(dbType)) {
+      where = " WHERE db_type=:dbType";
+      parameters.addValue("dbType", dbType);
+    }
+
+    return jdbcTemplate.query(
+        "SELECT "
+            + BASE_COLUMNS
+            + " FROM yak_ops_data_source"
+            + where
+            + " ORDER BY name ASC,id ASC",
+        parameters,
+        rowMapper);
+  }
+
+  @Override
+  public boolean existsByName(String name, Long excludeId) {
+    StringBuilder sql =
+        new StringBuilder("SELECT COUNT(1) FROM yak_ops_data_source WHERE name=:name");
+    MapSqlParameterSource parameters = new MapSqlParameterSource("name", name);
+    if (excludeId != null) {
+      sql.append(" AND id<>:excludeId");
+      parameters.addValue("excludeId", excludeId);
+    }
+
+    Long count = jdbcTemplate.queryForObject(sql.toString(), parameters, Long.class);
+    return count != null && count > 0;
+  }
+
+  @Override
+  public boolean deleteById(Long id) {
+    return id != null
+        && jdbcTemplate.update(
+                "DELETE FROM yak_ops_data_source WHERE id=:id",
+                new MapSqlParameterSource("id", id))
+            > 0;
+  }
+
+  @Override
+  public boolean updateConnectionStatus(Long id, String connStatus) {
+    return id != null
+        && jdbcTemplate.update(
+                "UPDATE yak_ops_data_source SET conn_status=:connStatus,"
+                    + "update_time=CURRENT_TIMESTAMP(3) WHERE id=:id",
+                new MapSqlParameterSource()
+                    .addValue("id", id)
+                    .addValue("connStatus", connStatus))
+            > 0;
+  }
+
+  private QueryParts buildQueryParts(DataSourceQueryDTO queryDTO) {
+    StringBuilder where = new StringBuilder(" WHERE 1=1");
+    MapSqlParameterSource parameters = new MapSqlParameterSource();
+
+    if (StringUtils.hasText(queryDTO.getName())) {
+      where.append(" AND name LIKE :name");
+      parameters.addValue("name", "%" + queryDTO.getName().trim() + "%");
+    }
+    if (StringUtils.hasText(queryDTO.getDbType())) {
+      where.append(" AND db_type=:dbType");
+      parameters.addValue("dbType", queryDTO.getDbType());
+    }
+    if (StringUtils.hasText(queryDTO.getEnvironment())) {
+      where.append(" AND environment=:environment");
+      parameters.addValue("environment", queryDTO.getEnvironment());
+    }
+    return new QueryParts(where.toString(), parameters);
+  }
+
+  private MapSqlParameterSource toParameters(DataSourcePO dataSourcePO) {
+    return new MapSqlParameterSource()
+        .addValue("id", dataSourcePO.getId())
+        .addValue("name", dataSourcePO.getName())
+        .addValue("dbType", dataSourcePO.getDbType().name())
+        .addValue("jdbcUrl", dataSourcePO.getJdbcUrl())
+        .addValue("environment", dataSourcePO.getEnvironment().name())
+        .addValue("connStatus", dataSourcePO.getConnStatus().name())
+        .addValue("remark", dataSourcePO.getRemark())
+        .addValue("connectionParams", dataSourcePO.getConnectionParams())
+        .addValue("originalJson", dataSourcePO.getOriginalJson());
+  }
+
+  private DataSourcePO mapRow(ResultSet resultSet, int rowNum) throws SQLException {
+    DataSourcePO dataSourcePO = new DataSourcePO();
+    dataSourcePO.setId(resultSet.getLong("id"));
+    dataSourcePO.setName(resultSet.getString("name"));
+    dataSourcePO.setDbType(DataSourceDbType.valueOf(resultSet.getString("db_type")));
+    dataSourcePO.setJdbcUrl(resultSet.getString("jdbc_url"));
+    dataSourcePO.setEnvironment(
+        DataSourceEnvironment.valueOf(resultSet.getString("environment")));
+    dataSourcePO.setConnStatus(
+        DataSourceConnStatus.valueOf(resultSet.getString("conn_status")));
+    dataSourcePO.setRemark(resultSet.getString("remark"));
+    dataSourcePO.setConnectionParams(resultSet.getString("connection_params"));
+    dataSourcePO.setOriginalJson(resultSet.getString("original_json"));
+    dataSourcePO.setCreateTime(
+        resultSet.getTimestamp("create_time").toLocalDateTime());
+    dataSourcePO.setUpdateTime(
+        resultSet.getTimestamp("update_time").toLocalDateTime());
+    return dataSourcePO;
+  }
+
+  private static final class QueryParts {
+
+    private final String whereClause;
+    private final MapSqlParameterSource parameters;
+
+    private QueryParts(String whereClause, MapSqlParameterSource parameters) {
+      this.whereClause = whereClause;
+      this.parameters = parameters;
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/exception/DataSourceException.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/exception/DataSourceException.java
@@ -1,0 +1,43 @@
+package io.yak.ops.business.datasource.exception;
+
+import io.yak.framework.common.BusinessException;
+import io.yak.framework.common.ErrorCode;
+
+/** 数据源管理业务异常。 */
+public class DataSourceException extends BusinessException {
+
+  private static final long serialVersionUID = 1L;
+
+  private final ErrorCode actualErrorCode;
+  private final String userMessage;
+
+  public DataSourceException(ErrorCode errorCode) {
+    super(errorCode);
+    this.actualErrorCode = errorCode;
+    this.userMessage = errorCode == null ? null : errorCode.getMessage();
+  }
+
+  public DataSourceException(ErrorCode errorCode, String detail) {
+    this(errorCode, detail, null);
+  }
+
+  public DataSourceException(ErrorCode errorCode, String detail, Throwable cause) {
+    super(buildMessage(errorCode, detail), cause);
+    this.actualErrorCode = errorCode;
+    this.userMessage = buildMessage(errorCode, detail);
+  }
+
+  @Override
+  public ErrorCode getErrorCode() {
+    return actualErrorCode;
+  }
+
+  public String getUserMessage() {
+    return userMessage;
+  }
+
+  private static String buildMessage(ErrorCode errorCode, String detail) {
+    String base = errorCode == null ? "数据源操作失败" : errorCode.getMessage();
+    return detail == null || detail.trim().isEmpty() ? base : base + "：" + detail.trim();
+  }
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/exception/DataSourceExceptionHandler.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/exception/DataSourceExceptionHandler.java
@@ -1,0 +1,66 @@
+package io.yak.ops.business.datasource.exception;
+
+import io.yak.framework.common.Result;
+import io.yak.ops.business.datasource.common.enums.DataSourceErrorCode;
+import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
+import io.yak.ops.business.datasource.controller.DataSourceController;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.BindException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+/** 数据源管理接口异常转换。 */
+@Slf4j
+@Order(Ordered.HIGHEST_PRECEDENCE)
+@RestControllerAdvice(basePackageClasses = DataSourceController.class)
+@ConditionalOnDataSourceEnabled
+public class DataSourceExceptionHandler {
+
+  @ExceptionHandler(DataSourceException.class)
+  public Result<Void> handleDataSourceException(DataSourceException exception) {
+    if (exception.getErrorCode() == null) {
+      return Result.fail(exception.getUserMessage());
+    }
+    return Result.fail(exception.getErrorCode().getCode(), exception.getUserMessage());
+  }
+
+  @ExceptionHandler({
+      MethodArgumentNotValidException.class,
+      BindException.class,
+      HttpMessageNotReadableException.class
+  })
+  public Result<Void> handleInvalidRequest(Exception exception) {
+    return Result.buildParamIllegal(resolveValidationMessage(exception));
+  }
+
+  @ExceptionHandler(DataIntegrityViolationException.class)
+  public Result<Void> handleDataIntegrityViolation(DataIntegrityViolationException exception) {
+    log.warn("Datasource persistence constraint violation", exception);
+    return Result.fail(
+        DataSourceErrorCode.DUPLICATE_NAME.getCode(),
+        DataSourceErrorCode.DUPLICATE_NAME.getMessage());
+  }
+
+  @ExceptionHandler(Exception.class)
+  public Result<Void> handleUnexpectedException(Exception exception) {
+    log.error("Unexpected datasource management error", exception);
+    return Result.fail("数据源操作失败，请稍后重试");
+  }
+
+  private String resolveValidationMessage(Exception exception) {
+    if (exception instanceof MethodArgumentNotValidException validationException
+        && validationException.getBindingResult().getFieldError() != null) {
+      return validationException.getBindingResult().getFieldError().getDefaultMessage();
+    }
+    if (exception instanceof BindException bindException
+        && bindException.getBindingResult().getFieldError() != null) {
+      return bindException.getBindingResult().getFieldError().getDefaultMessage();
+    }
+    return "请求参数格式不正确";
+  }
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/package-info.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/package-info.java
@@ -1,4 +1,4 @@
 /**
- * Datasource registration, configuration, metadata and connectivity business capabilities.
+ * 数据源注册、连接配置、分页查询与连通性管理能力。
  */
 package io.yak.ops.business.datasource;

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/service/DataSourcePluginConfigService.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/service/DataSourcePluginConfigService.java
@@ -1,0 +1,11 @@
+package io.yak.ops.business.datasource.service;
+
+import io.yak.ops.business.datasource.common.vo.DataSourcePluginConfigVO;
+
+/** 数据源动态表单配置服务。 */
+public interface DataSourcePluginConfigService {
+
+  DataSourcePluginConfigVO getPluginConfig(String pluginType);
+
+  boolean installPlugin(String pluginType);
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/service/DataSourceService.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/service/DataSourceService.java
@@ -1,0 +1,31 @@
+package io.yak.ops.business.datasource.service;
+
+import io.yak.framework.common.PagingData;
+import io.yak.ops.business.datasource.common.dto.DataSourceConnectTestDTO;
+import io.yak.ops.business.datasource.common.dto.DataSourceDTO;
+import io.yak.ops.business.datasource.common.dto.DataSourceQueryDTO;
+import io.yak.ops.business.datasource.common.vo.DataSourceOptionVO;
+import io.yak.ops.business.datasource.common.vo.DataSourceVO;
+import java.util.List;
+
+/** 数据源管理服务。 */
+public interface DataSourceService {
+
+  boolean createDataSource(DataSourceDTO dataSourceDTO);
+
+  boolean updateDataSource(Long id, DataSourceDTO dataSourceDTO);
+
+  DataSourceVO getDataSource(Long id);
+
+  PagingData<DataSourceVO> getDataSourcePage(DataSourceQueryDTO queryDTO);
+
+  PagingData<DataSourceVO> getAllDataSources();
+
+  boolean deleteDataSource(Long id);
+
+  boolean testConnection(Long id);
+
+  boolean testConnection(DataSourceConnectTestDTO connectTestDTO);
+
+  List<DataSourceOptionVO> getOptions(String dbType);
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/service/JdbcConnectionTester.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/service/JdbcConnectionTester.java
@@ -1,0 +1,221 @@
+package io.yak.ops.business.datasource.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.datasource.common.enums.DataSourceDbType;
+import io.yak.ops.business.datasource.common.enums.DataSourceErrorCode;
+import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
+import io.yak.ops.business.datasource.config.DataSourceProperties;
+import io.yak.ops.business.datasource.exception.DataSourceException;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Properties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+/** JDBC 连接地址解析和连通性测试组件。 */
+@Component
+@ConditionalOnDataSourceEnabled
+@RequiredArgsConstructor
+public class JdbcConnectionTester {
+
+  private final ObjectMapper objectMapper;
+  private final DataSourceProperties properties;
+
+  public JsonNode parseConnectionParams(String json) {
+    if (!StringUtils.hasText(json)) {
+      throw new DataSourceException(DataSourceErrorCode.INVALID_CONNECTION_PARAMS);
+    }
+
+    try {
+      JsonNode node = objectMapper.readTree(json);
+      if (node == null || !node.isObject()) {
+        throw new DataSourceException(
+            DataSourceErrorCode.INVALID_CONNECTION_PARAMS,
+            "连接参数必须是 JSON 对象");
+      }
+      return node;
+    } catch (DataSourceException exception) {
+      throw exception;
+    } catch (Exception exception) {
+      throw new DataSourceException(
+          DataSourceErrorCode.INVALID_CONNECTION_PARAMS,
+          "连接参数不是合法 JSON",
+          exception);
+    }
+  }
+
+  public String normalize(JsonNode node) {
+    try {
+      return objectMapper.writeValueAsString(node);
+    } catch (Exception exception) {
+      throw new DataSourceException(
+          DataSourceErrorCode.INVALID_CONNECTION_PARAMS,
+          "连接参数序列化失败",
+          exception);
+    }
+  }
+
+  public DataSourceDbType resolveDbType(JsonNode node, String fallback) {
+    String value = firstText(node, "dbType", "type", "pluginType");
+    return DataSourceDbType.parse(StringUtils.hasText(value) ? value : fallback);
+  }
+
+  public String resolveJdbcUrl(DataSourceDbType dbType, JsonNode node) {
+    String explicitUrl = firstText(node, "jdbcUrl", "url");
+    if (StringUtils.hasText(explicitUrl)) {
+      return explicitUrl.trim();
+    }
+
+    String host = firstText(node, "host", "hostname");
+    String database = firstText(node, "database", "databaseName", "serviceName");
+    int port = intValue(node, dbType.getDefaultPort(), "port");
+
+    if (!StringUtils.hasText(host)) {
+      throw new DataSourceException(
+          DataSourceErrorCode.INVALID_CONNECTION_PARAMS,
+          "host 不能为空");
+    }
+    if (!StringUtils.hasText(database)) {
+      throw new DataSourceException(
+          DataSourceErrorCode.INVALID_CONNECTION_PARAMS,
+          "database 不能为空");
+    }
+
+    if (dbType == DataSourceDbType.ORACLE) {
+      return dbType.getJdbcPrefix()
+          + "//"
+          + host.trim()
+          + ":"
+          + port
+          + "/"
+          + database.trim();
+    }
+
+    return dbType.getJdbcPrefix()
+        + "://"
+        + host.trim()
+        + ":"
+        + port
+        + "/"
+        + database.trim();
+  }
+
+  public boolean test(DataSourceDbType dbType, JsonNode node) {
+    String jdbcUrl = resolveJdbcUrl(dbType, node);
+    String driverClassName =
+        defaultIfBlank(
+            firstText(node, "driverClassName", "driver"),
+            dbType.getDefaultDriverClassName());
+
+    try {
+      Class.forName(driverClassName);
+    } catch (ClassNotFoundException exception) {
+      throw new DataSourceException(
+          DataSourceErrorCode.CONNECT_FAILED,
+          "数据库驱动未安装：" + driverClassName,
+          exception);
+    }
+
+    Properties connectionProperties = new Properties();
+    String username = firstText(node, "username", "user");
+    String password = firstText(node, "password");
+
+    if (StringUtils.hasText(username)) {
+      connectionProperties.setProperty("user", username);
+    }
+    if (password != null) {
+      connectionProperties.setProperty("password", password);
+    }
+    appendCustomProperties(node.get("properties"), connectionProperties);
+
+    int timeoutSeconds = Math.max(1, properties.getConnectionTest().getTimeoutSeconds());
+    try {
+      DriverManager.setLoginTimeout(timeoutSeconds);
+      try (Connection connection =
+          DriverManager.getConnection(jdbcUrl, connectionProperties)) {
+        if (connection == null || connection.isClosed()) {
+          throw new DataSourceException(
+              DataSourceErrorCode.CONNECT_FAILED,
+              "数据库连接未建立");
+        }
+        return true;
+      }
+    } catch (DataSourceException exception) {
+      throw exception;
+    } catch (Exception exception) {
+      throw new DataSourceException(
+          DataSourceErrorCode.CONNECT_FAILED,
+          safeMessage(exception),
+          exception);
+    }
+  }
+
+  private void appendCustomProperties(JsonNode node, Properties target) {
+    if (node == null || node.isNull()) {
+      return;
+    }
+
+    JsonNode propertiesNode = node;
+    if (node.isTextual() && StringUtils.hasText(node.asText())) {
+      propertiesNode = parseConnectionParams(node.asText());
+    }
+    if (!propertiesNode.isObject()) {
+      return;
+    }
+
+    Iterator<Map.Entry<String, JsonNode>> fields = propertiesNode.fields();
+    while (fields.hasNext()) {
+      Map.Entry<String, JsonNode> field = fields.next();
+      if (field.getValue() != null && !field.getValue().isNull()) {
+        target.setProperty(field.getKey(), field.getValue().asText());
+      }
+    }
+  }
+
+  private String firstText(JsonNode node, String... keys) {
+    if (node == null) {
+      return null;
+    }
+    for (String key : keys) {
+      JsonNode value = node.get(key);
+      if (value != null && !value.isNull()) {
+        return value.asText();
+      }
+    }
+    return null;
+  }
+
+  private int intValue(JsonNode node, int defaultValue, String key) {
+    JsonNode value = node == null ? null : node.get(key);
+    if (value == null || value.isNull() || value.asText().trim().isEmpty()) {
+      return defaultValue;
+    }
+    int port = value.asInt(-1);
+    if (port < 1 || port > 65535) {
+      throw new DataSourceException(
+          DataSourceErrorCode.INVALID_CONNECTION_PARAMS,
+          "port 必须在 1 到 65535 之间");
+    }
+    return port;
+  }
+
+  private String defaultIfBlank(String value, String defaultValue) {
+    return StringUtils.hasText(value) ? value.trim() : defaultValue;
+  }
+
+  private String safeMessage(Exception exception) {
+    String message = exception.getMessage();
+    if (!StringUtils.hasText(message)) {
+      return exception.getClass().getSimpleName();
+    }
+    String sanitized =
+        message.replaceAll(
+            "(?i)(password|pwd)=([^;&\\s]+)",
+            "$1=******");
+    return sanitized.length() > 300 ? sanitized.substring(0, 300) : sanitized;
+  }
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/service/impl/DataSourcePluginConfigServiceImpl.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/service/impl/DataSourcePluginConfigServiceImpl.java
@@ -1,0 +1,138 @@
+package io.yak.ops.business.datasource.service.impl;
+
+import io.yak.ops.business.datasource.common.enums.DataSourceDbType;
+import io.yak.ops.business.datasource.common.vo.DataSourcePluginConfigVO;
+import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
+import io.yak.ops.business.datasource.common.vo.DataSourcePluginConfigVO.FormFieldVO;
+import io.yak.ops.business.datasource.common.vo.DataSourcePluginConfigVO.RuleVO;
+import io.yak.ops.business.datasource.service.DataSourcePluginConfigService;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+/** 内置 JDBC 数据源动态表单配置服务。 */
+@Service
+@ConditionalOnDataSourceEnabled
+public class DataSourcePluginConfigServiceImpl implements DataSourcePluginConfigService {
+
+  @Override
+  public DataSourcePluginConfigVO getPluginConfig(String pluginType) {
+    DataSourceDbType dbType = DataSourceDbType.parse(pluginType);
+    return DataSourcePluginConfigVO.builder()
+        .pluginType(dbType.name())
+        .formFields(buildFields(dbType))
+        .installRequired(false)
+        .build();
+  }
+
+  @Override
+  public boolean installPlugin(String pluginType) {
+    DataSourceDbType.parse(pluginType);
+    return true;
+  }
+
+  private List<FormFieldVO> buildFields(DataSourceDbType dbType) {
+    List<FormFieldVO> fields = new ArrayList<>();
+    fields.add(
+        field(
+            "host",
+            "主机地址",
+            "INPUT",
+            "请输入数据库主机地址",
+            "127.0.0.1",
+            required("请输入主机地址")));
+    fields.add(
+        field(
+            "port",
+            "端口",
+            "NUMBER",
+            "请输入数据库端口",
+            dbType.getDefaultPort(),
+            rangeRule(1, 65535, "端口必须在 1 到 65535 之间")));
+    fields.add(
+        field(
+            "database",
+            dbType == DataSourceDbType.ORACLE ? "服务名 / 数据库" : "数据库",
+            "INPUT",
+            "请输入数据库名称",
+            null,
+            required("请输入数据库名称")));
+    fields.add(
+        field(
+            "username",
+            "用户名",
+            "INPUT",
+            "请输入数据库用户名",
+            null,
+            required("请输入数据库用户名")));
+    fields.add(
+        field(
+            "password",
+            "密码",
+            "PASSWORD",
+            "请输入数据库密码",
+            null,
+            Collections.emptyList()));
+    fields.add(
+        field(
+            "jdbcUrl",
+            "JDBC 地址",
+            "INPUT",
+            "可选；留空时根据主机、端口和数据库自动生成",
+            null,
+            Collections.emptyList()));
+    fields.add(
+        field(
+            "driverClassName",
+            "驱动类",
+            "INPUT",
+            "请输入 JDBC Driver Class",
+            dbType.getDefaultDriverClassName(),
+            required("请输入 JDBC 驱动类")));
+    fields.add(
+        field(
+            "properties",
+            "扩展属性",
+            "TEXTAREA",
+            "可选；请输入 JSON 对象，例如 {\"useSSL\":\"false\"}",
+            null,
+            Collections.emptyList()));
+    return fields;
+  }
+
+  private FormFieldVO field(
+      String key,
+      String label,
+      String type,
+      String placeholder,
+      Object defaultValue,
+      List<RuleVO> rules) {
+    return FormFieldVO.builder()
+        .key(key)
+        .label(label)
+        .type(type)
+        .placeholder(placeholder)
+        .defaultValue(defaultValue)
+        .rules(rules)
+        .build();
+  }
+
+  private List<RuleVO> required(String message) {
+    return Collections.singletonList(
+        RuleVO.builder()
+            .required(true)
+            .message(message)
+            .build());
+  }
+
+  private List<RuleVO> rangeRule(int min, int max, String message) {
+    return Collections.singletonList(
+        RuleVO.builder()
+            .required(true)
+            .min(min)
+            .max(max)
+            .message(message)
+            .build());
+  }
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/service/impl/DataSourceServiceImpl.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/service/impl/DataSourceServiceImpl.java
@@ -1,0 +1,244 @@
+package io.yak.ops.business.datasource.service.impl;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.yak.framework.common.PagingData;
+import io.yak.ops.business.datasource.common.dto.DataSourceConnectTestDTO;
+import io.yak.ops.business.datasource.common.dto.DataSourceDTO;
+import io.yak.ops.business.datasource.common.dto.DataSourceQueryDTO;
+import io.yak.ops.business.datasource.common.enums.DataSourceConnStatus;
+import io.yak.ops.business.datasource.common.enums.DataSourceDbType;
+import io.yak.ops.business.datasource.common.enums.DataSourceEnvironment;
+import io.yak.ops.business.datasource.common.enums.DataSourceErrorCode;
+import io.yak.ops.business.datasource.common.po.DataSourcePO;
+import io.yak.ops.business.datasource.common.vo.DataSourceOptionVO;
+import io.yak.ops.business.datasource.common.vo.DataSourceVO;
+import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
+import io.yak.ops.business.datasource.dao.DataSourceDao;
+import io.yak.ops.business.datasource.exception.DataSourceException;
+import io.yak.ops.business.datasource.service.DataSourceService;
+import io.yak.ops.business.datasource.service.JdbcConnectionTester;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+/** 数据源管理服务实现。 */
+@Service
+@ConditionalOnDataSourceEnabled
+@RequiredArgsConstructor
+public class DataSourceServiceImpl implements DataSourceService {
+
+  private final DataSourceDao dataSourceDao;
+  private final JdbcConnectionTester connectionTester;
+
+  @Override
+  @Transactional(
+      transactionManager = "opsDataSourceTransactionManager",
+      rollbackFor = Exception.class)
+  public boolean createDataSource(DataSourceDTO dataSourceDTO) {
+    String name = normalizeName(dataSourceDTO.getName());
+    ensureNameAvailable(name, null);
+
+    DataSourcePO dataSourcePO = buildDataSource(dataSourceDTO);
+    dataSourcePO.setName(name);
+    dataSourcePO.setConnStatus(DataSourceConnStatus.UNKNOWN);
+
+    if (dataSourceDao.addDataSource(dataSourcePO) <= 0) {
+      throw new DataSourceException(DataSourceErrorCode.CREATE_FAILED);
+    }
+    return true;
+  }
+
+  @Override
+  @Transactional(
+      transactionManager = "opsDataSourceTransactionManager",
+      rollbackFor = Exception.class)
+  public boolean updateDataSource(Long id, DataSourceDTO dataSourceDTO) {
+    DataSourcePO existing = getDataSourceOrThrow(id);
+    String name = normalizeName(dataSourceDTO.getName());
+    ensureNameAvailable(name, id);
+
+    DataSourcePO dataSourcePO = buildDataSource(dataSourceDTO);
+    dataSourcePO.setId(id);
+    dataSourcePO.setName(name);
+    dataSourcePO.setConnStatus(DataSourceConnStatus.UNKNOWN);
+    dataSourcePO.setCreateTime(existing.getCreateTime());
+
+    if (dataSourceDao.editDataSource(dataSourcePO) <= 0) {
+      throw new DataSourceException(DataSourceErrorCode.UPDATE_FAILED);
+    }
+    return true;
+  }
+
+  @Override
+  public DataSourceVO getDataSource(Long id) {
+    return toVO(getDataSourceOrThrow(id), true);
+  }
+
+  @Override
+  public PagingData<DataSourceVO> getDataSourcePage(DataSourceQueryDTO queryDTO) {
+    normalizeQuery(queryDTO);
+    long total = dataSourceDao.count(queryDTO);
+    List<DataSourceVO> records =
+        dataSourceDao.selectPage(queryDTO).stream()
+            .map(dataSourcePO -> toVO(dataSourcePO, true))
+            .collect(Collectors.toList());
+    return pagingData(records, total, queryDTO.getPageNo(), queryDTO.getPageSize());
+  }
+
+  @Override
+  public PagingData<DataSourceVO> getAllDataSources() {
+    List<DataSourceVO> records =
+        dataSourceDao.selectAll(null).stream()
+            .map(dataSourcePO -> toVO(dataSourcePO, false))
+            .collect(Collectors.toList());
+    return pagingData(records, records.size(), 1, Math.max(1, records.size()));
+  }
+
+  @Override
+  @Transactional(
+      transactionManager = "opsDataSourceTransactionManager",
+      rollbackFor = Exception.class)
+  public boolean deleteDataSource(Long id) {
+    getDataSourceOrThrow(id);
+    if (!dataSourceDao.deleteById(id)) {
+      throw new DataSourceException(DataSourceErrorCode.DELETE_FAILED);
+    }
+    return true;
+  }
+
+  @Override
+  public boolean testConnection(Long id) {
+    DataSourcePO dataSourcePO = getDataSourceOrThrow(id);
+    JsonNode params = connectionTester.parseConnectionParams(dataSourcePO.getConnectionParams());
+
+    try {
+      boolean connected = connectionTester.test(dataSourcePO.getDbType(), params);
+      dataSourceDao.updateConnectionStatus(id, DataSourceConnStatus.CONNECTED.name());
+      return connected;
+    } catch (RuntimeException exception) {
+      dataSourceDao.updateConnectionStatus(id, DataSourceConnStatus.DISCONNECTED.name());
+      throw exception;
+    }
+  }
+
+  @Override
+  public boolean testConnection(DataSourceConnectTestDTO connectTestDTO) {
+    JsonNode params = connectionTester.parseConnectionParams(connectTestDTO.getConnJson());
+    DataSourceDbType dbType = connectionTester.resolveDbType(params, null);
+    return connectionTester.test(dbType, params);
+  }
+
+  @Override
+  public List<DataSourceOptionVO> getOptions(String dbType) {
+    String normalizedType =
+        StringUtils.hasText(dbType) ? DataSourceDbType.parse(dbType).name() : null;
+    return dataSourceDao.selectAll(normalizedType).stream()
+        .map(
+            dataSourcePO ->
+                new DataSourceOptionVO(
+                    dataSourcePO.getName(),
+                    String.valueOf(dataSourcePO.getId()),
+                    dataSourcePO.getDbType().name()))
+        .collect(Collectors.toList());
+  }
+
+  private DataSourcePO buildDataSource(DataSourceDTO dataSourceDTO) {
+    DataSourceDbType dbType = DataSourceDbType.parse(dataSourceDTO.getDbType());
+    DataSourceEnvironment environment =
+        DataSourceEnvironment.parse(dataSourceDTO.getEnvironment());
+    JsonNode params =
+        connectionTester.parseConnectionParams(dataSourceDTO.getConnectionParams());
+    String normalizedJson = connectionTester.normalize(params);
+
+    DataSourcePO dataSourcePO = new DataSourcePO();
+    dataSourcePO.setDbType(dbType);
+    dataSourcePO.setJdbcUrl(connectionTester.resolveJdbcUrl(dbType, params));
+    dataSourcePO.setEnvironment(environment);
+    dataSourcePO.setRemark(normalizeNullable(dataSourceDTO.getRemark()));
+    dataSourcePO.setConnectionParams(normalizedJson);
+    dataSourcePO.setOriginalJson(normalizedJson);
+    return dataSourcePO;
+  }
+
+  private DataSourcePO getDataSourceOrThrow(Long id) {
+    if (id == null || id <= 0) {
+      throw new DataSourceException(DataSourceErrorCode.NOT_FOUND);
+    }
+    DataSourcePO dataSourcePO = dataSourceDao.selectById(id);
+    if (dataSourcePO == null) {
+      throw new DataSourceException(DataSourceErrorCode.NOT_FOUND);
+    }
+    return dataSourcePO;
+  }
+
+  private void ensureNameAvailable(String name, Long excludeId) {
+    if (dataSourceDao.existsByName(name, excludeId)) {
+      throw new DataSourceException(DataSourceErrorCode.DUPLICATE_NAME);
+    }
+  }
+
+  private String normalizeName(String name) {
+    if (!StringUtils.hasText(name)) {
+      throw new DataSourceException(
+          DataSourceErrorCode.INVALID_CONNECTION_PARAMS,
+          "数据源名称不能为空");
+    }
+    return name.trim();
+  }
+
+  private String normalizeNullable(String value) {
+    return StringUtils.hasText(value) ? value.trim() : null;
+  }
+
+  private void normalizeQuery(DataSourceQueryDTO queryDTO) {
+    if (StringUtils.hasText(queryDTO.getName())) {
+      queryDTO.setName(queryDTO.getName().trim());
+    }
+    if (StringUtils.hasText(queryDTO.getDbType())) {
+      queryDTO.setDbType(DataSourceDbType.parse(queryDTO.getDbType()).name());
+    }
+    if (StringUtils.hasText(queryDTO.getEnvironment())) {
+      queryDTO.setEnvironment(
+          DataSourceEnvironment.parse(queryDTO.getEnvironment()).name());
+    }
+  }
+
+  private DataSourceVO toVO(DataSourcePO dataSourcePO, boolean includeOriginalJson) {
+    DataSourceVO dataSourceVO = new DataSourceVO();
+    dataSourceVO.setId(dataSourcePO.getId());
+    dataSourceVO.setName(dataSourcePO.getName());
+    dataSourceVO.setDbType(dataSourcePO.getDbType().name());
+    dataSourceVO.setJdbcUrl(dataSourcePO.getJdbcUrl());
+    dataSourceVO.setEnvironment(dataSourcePO.getEnvironment().name());
+    dataSourceVO.setEnvironmentName(dataSourcePO.getEnvironment().getDisplayName());
+    dataSourceVO.setConnStatus(dataSourcePO.getConnStatus().name());
+    dataSourceVO.setRemark(dataSourcePO.getRemark());
+    dataSourceVO.setCreateTime(dataSourcePO.getCreateTime());
+    dataSourceVO.setUpdateTime(dataSourcePO.getUpdateTime());
+    if (includeOriginalJson) {
+      dataSourceVO.setOriginalJson(dataSourcePO.getOriginalJson());
+    }
+    return dataSourceVO;
+  }
+
+  private PagingData<DataSourceVO> pagingData(
+      List<DataSourceVO> records,
+      long total,
+      int pageNo,
+      int pageSize) {
+    long pages = pageSize <= 0 ? 0 : (total + pageSize - 1) / pageSize;
+    PagingData<DataSourceVO> pagingData = new PagingData<>();
+    pagingData.setBizData(records);
+    pagingData.setPagination(
+        PagingData.Pagination.builder()
+            .total(total)
+            .pages(pages)
+            .pageNo(pageNo)
+            .pageSize(pageSize)
+            .build());
+    return pagingData;
+  }
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/resources/db/migration/yak-datasource/V1__create_data_source_table.sql
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/resources/db/migration/yak-datasource/V1__create_data_source_table.sql
@@ -1,0 +1,24 @@
+-- Yak Ops 数据源管理表。
+CREATE TABLE IF NOT EXISTS yak_ops_data_source (
+    id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT COMMENT '主键',
+    name VARCHAR(128) NOT NULL COMMENT '数据源名称',
+    db_type VARCHAR(32) NOT NULL COMMENT '数据库类型',
+    jdbc_url VARCHAR(1024) NOT NULL COMMENT 'JDBC 地址',
+    environment VARCHAR(32) NOT NULL DEFAULT 'DEVELOP' COMMENT '运行环境',
+    conn_status VARCHAR(32) NOT NULL DEFAULT 'UNKNOWN' COMMENT '连通状态',
+    remark VARCHAR(500) DEFAULT NULL COMMENT '备注',
+    connection_params LONGTEXT NOT NULL COMMENT '规范化连接参数 JSON',
+    original_json LONGTEXT NOT NULL COMMENT '前端编辑回显参数 JSON',
+    create_time DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) COMMENT '创建时间',
+    update_time DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3)
+        ON UPDATE CURRENT_TIMESTAMP(3) COMMENT '更新时间',
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_yak_ops_data_source_name (name),
+    KEY idx_yak_ops_data_source_type (db_type),
+    KEY idx_yak_ops_data_source_environment (environment),
+    KEY idx_yak_ops_data_source_status (conn_status),
+    KEY idx_yak_ops_data_source_update_time (update_time)
+) ENGINE=InnoDB
+  DEFAULT CHARSET=utf8mb4
+  COLLATE=utf8mb4_unicode_ci
+  COMMENT='Yak Ops 数据源管理';

--- a/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/common/enums/DataSourceDbTypeTest.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/common/enums/DataSourceDbTypeTest.java
@@ -1,0 +1,24 @@
+package io.yak.ops.business.datasource.common.enums;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class DataSourceDbTypeTest {
+
+  @Test
+  void shouldSupportPostgresAliases() {
+    assertThat(DataSourceDbType.parse("postgresql"))
+        .isEqualTo(DataSourceDbType.POSTGRE_SQL);
+    assertThat(DataSourceDbType.parse("POSTGRES"))
+        .isEqualTo(DataSourceDbType.POSTGRE_SQL);
+  }
+
+  @Test
+  void shouldExposeDefaultDriverAndPort() {
+    assertThat(DataSourceDbType.MYSQL.getDefaultDriverClassName())
+        .isEqualTo("org.mariadb.jdbc.Driver");
+    assertThat(DataSourceDbType.DORIS.getDefaultPort())
+        .isEqualTo(9030);
+  }
+}


### PR DESCRIPTION
## 背景

`yak-ops-ui` 的数据源管理页面已经具备新增、编辑、删除、分页查询和连接测试交互，但 `yak-ops-business-datasource` 仍为空模块。本 PR 按现有前端接口契约补齐后端闭环，并参考 `baize-flow-backend` 的数据源业务逻辑和 `yak-framework-security` 的 DTO / VO / PO / enum / DAO 分层规范。

## 本次实现

### 后端接口

- `POST /api/v1/data-source`：新增数据源
- `PUT /api/v1/data-source/{id}`：编辑数据源
- `GET /api/v1/data-source/{id}`：查询详情
- `DELETE /api/v1/data-source/{id}`：删除数据源
- `POST /api/v1/data-source/page`：分页查询
- `GET|POST /api/v1/data-source/all`：查询全部数据源，兼容当前前端调用
- `GET /api/v1/data-source/option`：查询下拉选项
- `GET /api/v1/data-source/{id}/connect-test`：测试已保存数据源
- `POST /api/v1/data-source/connect-test-with-param`：使用未保存参数测试连接
- `GET /api/v1/data-source/plugin/config`：返回前端动态表单配置
- `POST /api/v1/data-source/plugin/config/install`：保留现有前端兼容入口

### 分层与规范

- `common/dto`：新增、分页、连接测试请求对象
- `common/vo`：列表、详情、选项和动态表单响应对象
- `common/po`：数据源持久化对象
- `common/enums`：数据库类型、环境、连接状态和业务错误码
- `dao + dao/impl`：显式 DAO 接口和 Spring JDBC 实现
- `service + service/impl`：名称唯一校验、参数规范化、分页转换和状态维护
- `controller`：统一使用 `Result`、`PagingResult`、`PagingData`
- `exception`：数据源模块业务异常和接口异常转换

### 数据库与启动配置

- 新增独立 Hikari 数据源、事务管理器和 Flyway 实例
- 配置前缀：`yak.datasource`
- 新增建表迁移：
  `yak-ops-business/yak-ops-business-datasource/src/main/resources/db/migration/yak-datasource/V1__create_data_source_table.sql`
- 默认复用 Yak Security 的数据库连接变量，也可通过以下变量单独指定：
  - `YAK_DATASOURCE_URL`
  - `YAK_DATASOURCE_USERNAME`
  - `YAK_DATASOURCE_PASSWORD`
  - `YAK_DATASOURCE_DRIVER`
  - `YAK_DATASOURCE_CONNECT_TIMEOUT_SECONDS`

### 前后端联调

后端返回结构和字段已对齐当前 `yak-ops-ui/src/pages/data-source`：

- 分页数据：`data.bizData + data.pagination`
- 字段：`id/name/dbType/jdbcUrl/environment/environmentName/connStatus/remark/originalJson/createTime/updateTime`
- 新增和编辑参数：`dbType/name/environment/remark/connectionParams`
- 连接状态使用 `CONNECTED / DISCONNECTED / UNKNOWN`，现有前端状态判断可直接识别

因此本次不需要修改前端请求代码。

## 驱动说明

- MariaDB / MySQL 和 PostgreSQL 驱动已作为运行时依赖加入
- Oracle、KingbaseES、达梦仍需在部署环境提供对应 JDBC 驱动；缺失时连接测试会返回明确错误，不影响配置的增删改查

## 验证情况

- 已完成 Java 源文件语法层面的本地检查
- 已确认分支仅领先 `main` 1 个提交，未夹带其他改动
- 当前执行环境没有 Maven，无法运行完整 `mvn test/package`
- 仓库当前未对该提交触发 GitHub Actions 或其他状态检查

建议合并前在本地执行：

```bash
mvn -pl yak-ops-business/yak-ops-business-datasource -am test
mvn -pl yak-ops-boot -am package -DskipTests
```
