### PR TITLE
feat(workflow): add CRUD designer with React Flow

### DIFF
--- a/yak-ops-boot/src/main/resources/yak-security/db/migration/V1000__init_yak_ops_security_catalog.sql
+++ b/yak-ops-boot/src/main/resources/yak-security/db/migration/V1000__init_yak_ops_security_catalog.sql
@@ -59,6 +59,7 @@ JOIN (
     UNION ALL SELECT 'workflow','workflow:definition:read','查看工作流定义','查看工作流定义页面及接口'
     UNION ALL SELECT 'workflow','workflow:definition:create','新建工作流定义','创建工作流定义'
     UNION ALL SELECT 'workflow','workflow:definition:update','编辑工作流定义','编辑工作流定义'
+    UNION ALL SELECT 'workflow','workflow:definition:delete','删除工作流定义','删除尚未产生运行实例的工作流定义'
     UNION ALL SELECT 'workflow','workflow:definition:publish','发布工作流定义','发布工作流定义'
     UNION ALL SELECT 'workflow','workflow:instance:read','查看工作流实例','查看工作流实例页面及接口'
     UNION ALL SELECT 'workflow','workflow:instance:execute','执行工作流实例','执行工作流实例'

--- a/yak-ops-boot/src/test/java/io/yak/ops/boot/config/YakOpsSecurityCatalogMigrationTest.java
+++ b/yak-ops-boot/src/test/java/io/yak/ops/boot/config/YakOpsSecurityCatalogMigrationTest.java
@@ -21,6 +21,7 @@ class YakOpsSecurityCatalogMigrationTest {
         .contains("INSERT INTO yak_security_menu")
         .contains("'task:batch:read'")
         .contains("'workflow:definition:update'")
+        .contains("'workflow:definition:delete'")
         .contains("'workflow:definition:publish'")
         .contains("'workflow:instance:execute'")
         .contains("'workflow:instance:stop'")

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/controller/v1/WorkflowController.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/controller/v1/WorkflowController.java
@@ -1,20 +1,20 @@
 package io.yak.ops.business.workflow.controller.v1;
 
 import io.yak.framework.common.Result;
-import io.yak.ops.common.constant.workflow.WorkflowConstant;
-import io.yak.ops.common.bean.dto.workflow.WorkflowDTO;
-import io.yak.ops.common.bean.dto.workflow.WorkflowScheduleDTO;
-import io.yak.ops.common.bean.dto.workflow.WorkflowTriggerDTO;
-import io.yak.ops.common.bean.dto.workflow.WorkflowUpdateDTO;
-import io.yak.ops.common.enums.workflow.TriggerType;
-import io.yak.ops.common.bean.vo.workflow.WorkflowDefinitionVO;
-import io.yak.ops.common.bean.vo.workflow.WorkflowInstanceVO;
-import io.yak.ops.common.bean.vo.workflow.WorkflowScheduleVO;
-import io.yak.ops.common.bean.vo.workflow.WorkflowVersionVO;
 import io.yak.ops.business.workflow.config.ConditionalOnWorkflowEnabled;
 import io.yak.ops.business.workflow.service.WorkflowDefinitionService;
 import io.yak.ops.business.workflow.service.WorkflowExecutionService;
 import io.yak.ops.business.workflow.service.WorkflowScheduleService;
+import io.yak.ops.common.bean.dto.workflow.WorkflowDTO;
+import io.yak.ops.common.bean.dto.workflow.WorkflowScheduleDTO;
+import io.yak.ops.common.bean.dto.workflow.WorkflowTriggerDTO;
+import io.yak.ops.common.bean.dto.workflow.WorkflowUpdateDTO;
+import io.yak.ops.common.bean.vo.workflow.WorkflowDefinitionVO;
+import io.yak.ops.common.bean.vo.workflow.WorkflowInstanceVO;
+import io.yak.ops.common.bean.vo.workflow.WorkflowScheduleVO;
+import io.yak.ops.common.bean.vo.workflow.WorkflowVersionVO;
+import io.yak.ops.common.constant.workflow.WorkflowConstant;
+import io.yak.ops.common.enums.workflow.TriggerType;
 import jakarta.validation.Valid;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -52,11 +52,17 @@ public class WorkflowController {
     return Result.success(Map.of("workflowId", workflowId));
   }
 
-  @PutMapping("/{workflowId}/draft")
+  @PutMapping({"/{workflowId}", "/{workflowId}/draft"})
   public Result<Boolean> editWorkflow(
       @PathVariable Long workflowId,
       @Valid @RequestBody WorkflowUpdateDTO workflowDTO) {
     definitionService.editWorkflow(workflowId, workflowDTO);
+    return Result.success(true);
+  }
+
+  @DeleteMapping("/{workflowId}")
+  public Result<Boolean> deleteWorkflow(@PathVariable Long workflowId) {
+    definitionService.deleteWorkflow(workflowId);
     return Result.success(true);
   }
 

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/WorkflowDefinitionDao.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/WorkflowDefinitionDao.java
@@ -13,6 +13,10 @@ public interface WorkflowDefinitionDao {
 
   int editDefinition(WorkflowDefinitionPO definitionPO);
 
+  int deleteDefinition(Long workflowId);
+
+  boolean existsDefinitionByCode(String code);
+
   WorkflowDefinition selectDefinitionById(Long workflowId);
 
   List<WorkflowDefinition> selectAllDefinition();

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/impl/WorkflowDefinitionDaoImpl.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/impl/WorkflowDefinitionDaoImpl.java
@@ -2,15 +2,17 @@ package io.yak.ops.business.workflow.dao.impl;
 
 import com.baomidou.mybatisplus.core.toolkit.Wrappers;
 import io.yak.ops.business.workflow.config.ConditionalOnWorkflowEnabled;
-import io.yak.ops.common.bean.entity.workflow.WorkflowDefinition;
-import io.yak.ops.common.bean.entity.workflow.WorkflowVersion;
-import io.yak.ops.common.bean.po.workflow.WorkflowDefinitionPO;
-import io.yak.ops.common.bean.po.workflow.WorkflowVersionPO;
 import io.yak.ops.business.workflow.dao.WorkflowDefinitionDao;
 import io.yak.ops.business.workflow.dao.mapper.WorkflowDefinitionMapper;
+import io.yak.ops.business.workflow.dao.mapper.WorkflowScheduleMapper;
 import io.yak.ops.business.workflow.dao.mapper.WorkflowVersionMapper;
 import io.yak.ops.business.workflow.util.WorkflowConvertUtils;
 import io.yak.ops.business.workflow.util.WorkflowJsonCodec;
+import io.yak.ops.common.bean.entity.workflow.WorkflowDefinition;
+import io.yak.ops.common.bean.entity.workflow.WorkflowVersion;
+import io.yak.ops.common.bean.po.workflow.WorkflowDefinitionPO;
+import io.yak.ops.common.bean.po.workflow.WorkflowSchedulePO;
+import io.yak.ops.common.bean.po.workflow.WorkflowVersionPO;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -24,6 +26,7 @@ public class WorkflowDefinitionDaoImpl implements WorkflowDefinitionDao {
 
   private final WorkflowDefinitionMapper definitionMapper;
   private final WorkflowVersionMapper versionMapper;
+  private final WorkflowScheduleMapper scheduleMapper;
   private final WorkflowJsonCodec jsonCodec;
 
   @Override
@@ -34,6 +37,24 @@ public class WorkflowDefinitionDaoImpl implements WorkflowDefinitionDao {
   @Override
   public int editDefinition(WorkflowDefinitionPO definitionPO) {
     return definitionMapper.updateById(definitionPO);
+  }
+
+  @Override
+  public int deleteDefinition(Long workflowId) {
+    scheduleMapper.delete(
+        Wrappers.<WorkflowSchedulePO>lambdaQuery()
+            .eq(WorkflowSchedulePO::getWorkflowId, workflowId));
+    versionMapper.delete(
+        Wrappers.<WorkflowVersionPO>lambdaQuery()
+            .eq(WorkflowVersionPO::getWorkflowId, workflowId));
+    return definitionMapper.deleteById(workflowId);
+  }
+
+  @Override
+  public boolean existsDefinitionByCode(String code) {
+    return definitionMapper.selectCount(
+        Wrappers.<WorkflowDefinitionPO>lambdaQuery()
+            .eq(WorkflowDefinitionPO::getCode, code)) > 0;
   }
 
   @Override

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/impl/WorkflowDefinitionDaoImpl.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/impl/WorkflowDefinitionDaoImpl.java
@@ -4,14 +4,12 @@ import com.baomidou.mybatisplus.core.toolkit.Wrappers;
 import io.yak.ops.business.workflow.config.ConditionalOnWorkflowEnabled;
 import io.yak.ops.business.workflow.dao.WorkflowDefinitionDao;
 import io.yak.ops.business.workflow.dao.mapper.WorkflowDefinitionMapper;
-import io.yak.ops.business.workflow.dao.mapper.WorkflowScheduleMapper;
 import io.yak.ops.business.workflow.dao.mapper.WorkflowVersionMapper;
 import io.yak.ops.business.workflow.util.WorkflowConvertUtils;
 import io.yak.ops.business.workflow.util.WorkflowJsonCodec;
 import io.yak.ops.common.bean.entity.workflow.WorkflowDefinition;
 import io.yak.ops.common.bean.entity.workflow.WorkflowVersion;
 import io.yak.ops.common.bean.po.workflow.WorkflowDefinitionPO;
-import io.yak.ops.common.bean.po.workflow.WorkflowSchedulePO;
 import io.yak.ops.common.bean.po.workflow.WorkflowVersionPO;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -26,7 +24,6 @@ public class WorkflowDefinitionDaoImpl implements WorkflowDefinitionDao {
 
   private final WorkflowDefinitionMapper definitionMapper;
   private final WorkflowVersionMapper versionMapper;
-  private final WorkflowScheduleMapper scheduleMapper;
   private final WorkflowJsonCodec jsonCodec;
 
   @Override
@@ -41,9 +38,6 @@ public class WorkflowDefinitionDaoImpl implements WorkflowDefinitionDao {
 
   @Override
   public int deleteDefinition(Long workflowId) {
-    scheduleMapper.delete(
-        Wrappers.<WorkflowSchedulePO>lambdaQuery()
-            .eq(WorkflowSchedulePO::getWorkflowId, workflowId));
     versionMapper.delete(
         Wrappers.<WorkflowVersionPO>lambdaQuery()
             .eq(WorkflowVersionPO::getWorkflowId, workflowId));

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowDefinitionService.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowDefinitionService.java
@@ -13,6 +13,8 @@ public interface WorkflowDefinitionService {
 
   void editWorkflow(Long workflowId, WorkflowUpdateDTO workflowDTO);
 
+  void deleteWorkflow(Long workflowId);
+
   WorkflowVersionVO publishWorkflow(Long workflowId, String operator);
 
   WorkflowDefinitionVO getWorkflow(Long workflowId);

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/impl/WorkflowDefinitionServiceImpl.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/impl/WorkflowDefinitionServiceImpl.java
@@ -5,6 +5,7 @@ import io.yak.ops.business.workflow.dag.WorkflowDagCompiler;
 import io.yak.ops.business.workflow.dao.WorkflowDefinitionDao;
 import io.yak.ops.business.workflow.dao.WorkflowExecutionDao;
 import io.yak.ops.business.workflow.service.WorkflowDefinitionService;
+import io.yak.ops.business.workflow.service.WorkflowScheduleService;
 import io.yak.ops.business.workflow.util.WorkflowConvertUtils;
 import io.yak.ops.business.workflow.util.WorkflowJsonCodec;
 import io.yak.ops.common.bean.dto.workflow.WorkflowDTO;
@@ -33,6 +34,7 @@ public class WorkflowDefinitionServiceImpl implements WorkflowDefinitionService 
 
   private final WorkflowDefinitionDao definitionDao;
   private final WorkflowExecutionDao executionDao;
+  private final WorkflowScheduleService scheduleService;
   private final WorkflowDagCompiler dagCompiler;
   private final WorkflowJsonCodec jsonCodec;
 
@@ -86,6 +88,7 @@ public class WorkflowDefinitionServiceImpl implements WorkflowDefinitionService 
     if (!executionDao.selectInstanceListByWorkflowId(workflowId, 1).isEmpty()) {
       throw new IllegalStateException("工作流已经产生运行实例，暂不允许删除：" + workflowId);
     }
+    scheduleService.delete(workflowId);
     if (definitionDao.deleteDefinition(workflowId) != 1) {
       throw new IllegalArgumentException("工作流定义不存在：" + workflowId);
     }

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/impl/WorkflowDefinitionServiceImpl.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/impl/WorkflowDefinitionServiceImpl.java
@@ -1,22 +1,23 @@
 package io.yak.ops.business.workflow.service.impl;
 
-import io.yak.ops.common.constant.workflow.WorkflowConstant;
+import io.yak.ops.business.workflow.config.ConditionalOnWorkflowEnabled;
+import io.yak.ops.business.workflow.dag.WorkflowDagCompiler;
+import io.yak.ops.business.workflow.dao.WorkflowDefinitionDao;
+import io.yak.ops.business.workflow.dao.WorkflowExecutionDao;
+import io.yak.ops.business.workflow.service.WorkflowDefinitionService;
+import io.yak.ops.business.workflow.util.WorkflowConvertUtils;
+import io.yak.ops.business.workflow.util.WorkflowJsonCodec;
 import io.yak.ops.common.bean.dto.workflow.WorkflowDTO;
 import io.yak.ops.common.bean.dto.workflow.WorkflowUpdateDTO;
 import io.yak.ops.common.bean.entity.workflow.WorkflowDefinition;
 import io.yak.ops.common.bean.entity.workflow.WorkflowVersion;
-import io.yak.ops.common.enums.workflow.DefinitionState;
-import io.yak.ops.common.enums.workflow.FailureStrategy;
 import io.yak.ops.common.bean.po.workflow.WorkflowDefinitionPO;
 import io.yak.ops.common.bean.po.workflow.WorkflowVersionPO;
 import io.yak.ops.common.bean.vo.workflow.WorkflowDefinitionVO;
 import io.yak.ops.common.bean.vo.workflow.WorkflowVersionVO;
-import io.yak.ops.business.workflow.config.ConditionalOnWorkflowEnabled;
-import io.yak.ops.business.workflow.dag.WorkflowDagCompiler;
-import io.yak.ops.business.workflow.dao.WorkflowDefinitionDao;
-import io.yak.ops.business.workflow.service.WorkflowDefinitionService;
-import io.yak.ops.business.workflow.util.WorkflowConvertUtils;
-import io.yak.ops.business.workflow.util.WorkflowJsonCodec;
+import io.yak.ops.common.constant.workflow.WorkflowConstant;
+import io.yak.ops.common.enums.workflow.DefinitionState;
+import io.yak.ops.common.enums.workflow.FailureStrategy;
 import java.util.Date;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -31,6 +32,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class WorkflowDefinitionServiceImpl implements WorkflowDefinitionService {
 
   private final WorkflowDefinitionDao definitionDao;
+  private final WorkflowExecutionDao executionDao;
   private final WorkflowDagCompiler dagCompiler;
   private final WorkflowJsonCodec jsonCodec;
 
@@ -38,9 +40,14 @@ public class WorkflowDefinitionServiceImpl implements WorkflowDefinitionService 
   @Transactional(transactionManager = "workflowTransactionManager")
   public Long addWorkflow(WorkflowDTO workflowDTO, String operator) {
     validate(workflowDTO);
+    String code = workflowDTO.getCode().trim();
+    if (definitionDao.existsDefinitionByCode(code)) {
+      throw new IllegalArgumentException("工作流编码已存在：" + code);
+    }
+
     Date now = new Date();
     WorkflowDefinitionPO definitionPO = new WorkflowDefinitionPO();
-    definitionPO.setCode(workflowDTO.getCode().trim());
+    definitionPO.setCode(code);
     definitionPO.setName(workflowDTO.getName().trim());
     definitionPO.setDescription(workflowDTO.getDescription());
     definitionPO.setState(DefinitionState.DRAFT.name());
@@ -68,6 +75,18 @@ public class WorkflowDefinitionServiceImpl implements WorkflowDefinitionService 
     definitionPO.setDraftJson(jsonCodec.write(workflowDTO.getDag()));
     definitionPO.setUpdatedAt(new Date());
     if (definitionDao.editDefinition(definitionPO) != 1) {
+      throw new IllegalArgumentException("工作流定义不存在：" + workflowId);
+    }
+  }
+
+  @Override
+  @Transactional(transactionManager = "workflowTransactionManager")
+  public void deleteWorkflow(Long workflowId) {
+    requireWorkflow(workflowId);
+    if (!executionDao.selectInstanceListByWorkflowId(workflowId, 1).isEmpty()) {
+      throw new IllegalStateException("工作流已经产生运行实例，暂不允许删除：" + workflowId);
+    }
+    if (definitionDao.deleteDefinition(workflowId) != 1) {
       throw new IllegalArgumentException("工作流定义不存在：" + workflowId);
     }
   }

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/util/WorkflowJsonCodecTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/util/WorkflowJsonCodecTest.java
@@ -1,0 +1,47 @@
+package io.yak.ops.business.workflow.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.common.bean.entity.workflow.WorkflowDag;
+import io.yak.ops.common.bean.entity.workflow.WorkflowNode;
+import io.yak.ops.common.bean.entity.workflow.WorkflowViewport;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class WorkflowJsonCodecTest {
+
+  private final WorkflowJsonCodec codec = new WorkflowJsonCodec(new ObjectMapper());
+
+  @Test
+  void shouldRoundTripDesignerMetadata() {
+    WorkflowNode node = new WorkflowNode(
+        "start",
+        "开始",
+        "NOOP",
+        Map.of(),
+        0,
+        0,
+        0,
+        true,
+        true,
+        true);
+    node.setDescription("工作流入口节点");
+    node.setPositionX(120D);
+    node.setPositionY(240D);
+
+    WorkflowDag dag = new WorkflowDag(List.of(node), List.of());
+    dag.setViewport(new WorkflowViewport(20D, 40D, 0.8D));
+
+    WorkflowDag restored = codec.readDag(codec.write(dag));
+
+    assertThat(restored.getNodes()).hasSize(1);
+    assertThat(restored.getNodes().get(0).getDescription()).isEqualTo("工作流入口节点");
+    assertThat(restored.getNodes().get(0).getPositionX()).isEqualTo(120D);
+    assertThat(restored.getNodes().get(0).getPositionY()).isEqualTo(240D);
+    assertThat(restored.getViewport().getX()).isEqualTo(20D);
+    assertThat(restored.getViewport().getY()).isEqualTo(40D);
+    assertThat(restored.getViewport().getZoom()).isEqualTo(0.8D);
+  }
+}

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/entity/workflow/WorkflowDag.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/entity/workflow/WorkflowDag.java
@@ -12,6 +12,7 @@ public class WorkflowDag {
 
   private List<WorkflowNode> nodes = new ArrayList<>();
   private List<WorkflowEdge> edges = new ArrayList<>();
+  private WorkflowViewport viewport = new WorkflowViewport(0D, 0D, 1D);
 
   public WorkflowDag(List<WorkflowNode> nodes, List<WorkflowEdge> edges) {
     setNodes(nodes);
@@ -24,5 +25,9 @@ public class WorkflowDag {
 
   public void setEdges(List<WorkflowEdge> edges) {
     this.edges = edges == null ? new ArrayList<>() : new ArrayList<>(edges);
+  }
+
+  public void setViewport(WorkflowViewport viewport) {
+    this.viewport = viewport == null ? new WorkflowViewport(0D, 0D, 1D) : viewport;
   }
 }

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/entity/workflow/WorkflowNode.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/entity/workflow/WorkflowNode.java
@@ -2,19 +2,20 @@ package io.yak.ops.common.bean.entity.workflow;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
-import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 /** 工作流 DAG 节点。 */
 @Data
 @NoArgsConstructor
-@AllArgsConstructor
 public class WorkflowNode {
 
   private String key;
   private String name;
   private String type;
+  private String description;
+  private Double positionX;
+  private Double positionY;
   private Map<String, Object> config = new LinkedHashMap<>();
   private int retryTimes;
   private int retryIntervalSeconds;
@@ -22,6 +23,30 @@ public class WorkflowNode {
   private boolean enabled = true;
   private boolean idempotent;
   private boolean retryOnRestart;
+
+  /** 保留原有构造方式，兼容已有测试与调用代码。 */
+  public WorkflowNode(
+      String key,
+      String name,
+      String type,
+      Map<String, Object> config,
+      int retryTimes,
+      int retryIntervalSeconds,
+      int timeoutSeconds,
+      boolean enabled,
+      boolean idempotent,
+      boolean retryOnRestart) {
+    this.key = key;
+    this.name = name;
+    this.type = type;
+    setConfig(config);
+    this.retryTimes = retryTimes;
+    this.retryIntervalSeconds = retryIntervalSeconds;
+    this.timeoutSeconds = timeoutSeconds;
+    this.enabled = enabled;
+    this.idempotent = idempotent;
+    this.retryOnRestart = retryOnRestart;
+  }
 
   public void setConfig(Map<String, Object> config) {
     this.config = config == null ? new LinkedHashMap<>() : new LinkedHashMap<>(config);

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/entity/workflow/WorkflowViewport.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/entity/workflow/WorkflowViewport.java
@@ -1,0 +1,16 @@
+package io.yak.ops.common.bean.entity.workflow;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/** 工作流设计器视口信息。 */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class WorkflowViewport {
+
+  private double x;
+  private double y;
+  private double zoom = 1D;
+}

--- a/yak-ops-ui/src/pages/workflow-management/components/CreateWorkflowModal.tsx
+++ b/yak-ops-ui/src/pages/workflow-management/components/CreateWorkflowModal.tsx
@@ -1,0 +1,164 @@
+import { Form, Input, InputNumber, message, Modal, Select } from 'antd';
+import { useEffect, useState } from 'react';
+import { createWorkflow } from '../service';
+import type {
+  WorkflowCreatePayload,
+  WorkflowFailureStrategy,
+} from '../types';
+
+interface CreateWorkflowModalProps {
+  open: boolean;
+  onCancel: () => void;
+  onCreated: (workflowId: number) => void;
+}
+
+interface CreateWorkflowFormValues {
+  code: string;
+  name: string;
+  description?: string;
+  failureStrategy: WorkflowFailureStrategy;
+  maxParallelism: number;
+}
+
+const CreateWorkflowModal = ({
+  open,
+  onCancel,
+  onCreated,
+}: CreateWorkflowModalProps) => {
+  const [form] = Form.useForm<CreateWorkflowFormValues>();
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (open) {
+      form.setFieldsValue({
+        failureStrategy: 'FAIL_FAST',
+        maxParallelism: 4,
+      });
+    }
+  }, [form, open]);
+
+  const handleSubmit = async () => {
+    const values = await form.validateFields();
+    const payload: WorkflowCreatePayload = {
+      ...values,
+      code: values.code.trim(),
+      name: values.name.trim(),
+      dag: {
+        nodes: [
+          {
+            key: 'start',
+            name: '开始',
+            type: 'NOOP',
+            description: '工作流入口节点',
+            positionX: 120,
+            positionY: 180,
+            config: {},
+            retryTimes: 0,
+            retryIntervalSeconds: 0,
+            timeoutSeconds: 0,
+            enabled: true,
+            idempotent: true,
+            retryOnRestart: true,
+          },
+        ],
+        edges: [],
+        viewport: {
+          x: 0,
+          y: 0,
+          zoom: 1,
+        },
+      },
+    };
+
+    try {
+      setSaving(true);
+      const response = await createWorkflow(payload);
+      if (response.code !== 0 || !response.data?.workflowId) {
+        message.error(response.message || '创建工作流失败');
+        return;
+      }
+      message.success('工作流已创建');
+      form.resetFields();
+      onCreated(response.data.workflowId);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Modal
+      title="新建工作流"
+      open={open}
+      okText="创建并设计"
+      cancelText="取消"
+      confirmLoading={saving}
+      onCancel={onCancel}
+      onOk={handleSubmit}
+      destroyOnClose
+      centered
+    >
+      <Form form={form} layout="vertical" requiredMark={false}>
+        <Form.Item
+          label="工作流名称"
+          name="name"
+          rules={[
+            { required: true, message: '请输入工作流名称' },
+            { max: 255, message: '名称不能超过 255 个字符' },
+          ]}
+        >
+          <Input placeholder="例如：每日数据同步流程" maxLength={255} />
+        </Form.Item>
+
+        <Form.Item
+          label="工作流编码"
+          name="code"
+          extra="创建后不可修改，建议使用小写字母、数字和短横线。"
+          rules={[
+            { required: true, message: '请输入工作流编码' },
+            {
+              pattern: /^[a-zA-Z][a-zA-Z0-9_-]{1,127}$/,
+              message: '编码需以字母开头，只能包含字母、数字、下划线和短横线',
+            },
+          ]}
+        >
+          <Input placeholder="daily-data-sync" maxLength={128} />
+        </Form.Item>
+
+        <Form.Item label="描述" name="description">
+          <Input.TextArea
+            placeholder="描述这个工作流负责解决什么问题"
+            rows={3}
+            maxLength={1000}
+            showCount
+          />
+        </Form.Item>
+
+        <div className="workflow-create-modal__row">
+          <Form.Item
+            label="失败策略"
+            name="failureStrategy"
+            className="workflow-create-modal__field"
+          >
+            <Select
+              options={[
+                { label: '失败即停止', value: 'FAIL_FAST' },
+                { label: '继续后续分支', value: 'CONTINUE' },
+              ]}
+            />
+          </Form.Item>
+
+          <Form.Item
+            label="最大并行度"
+            name="maxParallelism"
+            className="workflow-create-modal__field"
+            rules={[{ required: true, message: '请输入最大并行度' }]}
+          >
+            <InputNumber min={1} max={256} className="w-full" />
+          </Form.Item>
+        </div>
+      </Form>
+    </Modal>
+  );
+};
+
+export default CreateWorkflowModal;

--- a/yak-ops-ui/src/pages/workflow-management/components/CreateWorkflowModal.tsx
+++ b/yak-ops-ui/src/pages/workflow-management/components/CreateWorkflowModal.tsx
@@ -30,6 +30,7 @@ const CreateWorkflowModal = ({
 
   useEffect(() => {
     if (open) {
+      form.resetFields();
       form.setFieldsValue({
         failureStrategy: 'FAIL_FAST',
         maxParallelism: 4,

--- a/yak-ops-ui/src/pages/workflow-management/designer/components/NodePanel.tsx
+++ b/yak-ops-ui/src/pages/workflow-management/designer/components/NodePanel.tsx
@@ -1,0 +1,228 @@
+import {
+  Input,
+  InputNumber,
+  Select,
+  Switch,
+} from 'antd';
+import { Trash2, X } from 'lucide-react';
+import type { WorkflowFlowNode, WorkflowNodeData } from '../../types';
+
+interface NodePanelProps {
+  node: WorkflowFlowNode;
+  onChange: (data: WorkflowNodeData) => void;
+  onDelete: () => void;
+  onClose: () => void;
+}
+
+const taskTypeLabelMap: Record<string, string> = {
+  NOOP: '基础节点',
+  HTTP: 'HTTP 请求',
+  SHELL: 'Shell 脚本',
+};
+
+const NodePanel = ({
+  node,
+  onChange,
+  onDelete,
+  onClose,
+}: NodePanelProps) => {
+  const data = node.data;
+
+  const patch = (values: Partial<WorkflowNodeData>) => {
+    onChange({ ...data, ...values });
+  };
+
+  const patchConfig = (key: string, value: unknown) => {
+    patch({
+      config: {
+        ...data.config,
+        [key]: value,
+      },
+    });
+  };
+
+  return (
+    <aside className="workflow-node-panel">
+      <header className="workflow-node-panel__header">
+        <div>
+          <span>NODE PANEL</span>
+          <strong>{data.name || '未命名节点'}</strong>
+        </div>
+        <button type="button" onClick={onClose} aria-label="关闭节点面板">
+          <X size={17} />
+        </button>
+      </header>
+
+      <div className="workflow-node-panel__content">
+        <section className="workflow-node-panel__section">
+          <h3>基础信息</h3>
+          <label>
+            <span>节点名称</span>
+            <Input
+              value={data.name}
+              maxLength={255}
+              onChange={(event) => patch({ name: event.target.value })}
+            />
+          </label>
+          <label>
+            <span>节点类型</span>
+            <Input value={taskTypeLabelMap[data.taskType] || data.taskType} disabled />
+          </label>
+          <label>
+            <span>节点描述</span>
+            <Input.TextArea
+              value={data.description}
+              rows={3}
+              maxLength={500}
+              placeholder="说明这个节点在流程中的职责"
+              onChange={(event) => patch({ description: event.target.value })}
+            />
+          </label>
+        </section>
+
+        {data.taskType === 'HTTP' && (
+          <section className="workflow-node-panel__section">
+            <h3>HTTP 配置</h3>
+            <label>
+              <span>请求方法</span>
+              <Select
+                value={String(data.config.method || 'GET')}
+                onChange={(value) => patchConfig('method', value)}
+                options={['GET', 'POST', 'PUT', 'PATCH', 'DELETE'].map(
+                  (value) => ({ label: value, value }),
+                )}
+              />
+            </label>
+            <label>
+              <span>请求地址</span>
+              <Input
+                value={String(data.config.url || '')}
+                placeholder="https://api.example.com/tasks"
+                onChange={(event) => patchConfig('url', event.target.value)}
+              />
+            </label>
+            <label>
+              <span>请求体</span>
+              <Input.TextArea
+                value={String(data.config.body || '')}
+                rows={5}
+                placeholder='{"name":"yak"}'
+                onChange={(event) => patchConfig('body', event.target.value)}
+              />
+            </label>
+            <label>
+              <span>请求超时（秒）</span>
+              <InputNumber
+                min={1}
+                max={3600}
+                value={Number(data.config.requestTimeoutSeconds || 60)}
+                onChange={(value) =>
+                  patchConfig('requestTimeoutSeconds', value || 60)
+                }
+              />
+            </label>
+          </section>
+        )}
+
+        {data.taskType === 'SHELL' && (
+          <section className="workflow-node-panel__section">
+            <h3>Shell 配置</h3>
+            <label>
+              <span>执行命令</span>
+              <Input.TextArea
+                value={String(data.config.command || '')}
+                rows={5}
+                placeholder="echo 'hello yak ops'"
+                onChange={(event) => patchConfig('command', event.target.value)}
+              />
+            </label>
+            <label>
+              <span>工作目录</span>
+              <Input
+                value={String(data.config.workDirectory || '')}
+                placeholder="可选，例如 /opt/yak/jobs"
+                onChange={(event) =>
+                  patchConfig('workDirectory', event.target.value)
+                }
+              />
+            </label>
+          </section>
+        )}
+
+        <section className="workflow-node-panel__section">
+          <h3>容错设置</h3>
+          <div className="workflow-node-panel__grid">
+            <label>
+              <span>重试次数</span>
+              <InputNumber
+                min={0}
+                max={20}
+                value={data.retryTimes}
+                onChange={(value) => patch({ retryTimes: value || 0 })}
+              />
+            </label>
+            <label>
+              <span>重试间隔（秒）</span>
+              <InputNumber
+                min={0}
+                max={86400}
+                value={data.retryIntervalSeconds}
+                onChange={(value) =>
+                  patch({ retryIntervalSeconds: value || 0 })
+                }
+              />
+            </label>
+          </div>
+          <label>
+            <span>节点超时（秒）</span>
+            <InputNumber
+              min={0}
+              max={86400}
+              value={data.timeoutSeconds}
+              onChange={(value) => patch({ timeoutSeconds: value || 0 })}
+            />
+          </label>
+          <div className="workflow-node-panel__switch-row">
+            <div>
+              <strong>启用节点</strong>
+              <span>停用后仍保留节点配置</span>
+            </div>
+            <Switch
+              checked={data.enabled}
+              onChange={(checked) => patch({ enabled: checked })}
+            />
+          </div>
+          <div className="workflow-node-panel__switch-row">
+            <div>
+              <strong>幂等任务</strong>
+              <span>允许安全重复提交</span>
+            </div>
+            <Switch
+              checked={data.idempotent}
+              onChange={(checked) => patch({ idempotent: checked })}
+            />
+          </div>
+          <div className="workflow-node-panel__switch-row">
+            <div>
+              <strong>重启后重试</strong>
+              <span>服务重启后继续尝试该节点</span>
+            </div>
+            <Switch
+              checked={data.retryOnRestart}
+              onChange={(checked) => patch({ retryOnRestart: checked })}
+            />
+          </div>
+        </section>
+      </div>
+
+      <footer className="workflow-node-panel__footer">
+        <button type="button" onClick={onDelete}>
+          <Trash2 size={16} />
+          删除节点
+        </button>
+      </footer>
+    </aside>
+  );
+};
+
+export default NodePanel;

--- a/yak-ops-ui/src/pages/workflow-management/designer/components/NodeSelector.tsx
+++ b/yak-ops-ui/src/pages/workflow-management/designer/components/NodeSelector.tsx
@@ -1,0 +1,64 @@
+import { Globe2, Play, Plus, TerminalSquare } from 'lucide-react';
+import type { WorkflowNodeType } from '../../types';
+
+interface NodeSelectorProps {
+  onAdd: (type: WorkflowNodeType) => void;
+}
+
+const nodeOptions = [
+  {
+    type: 'NOOP' as const,
+    title: '基础节点',
+    description: '用于开始、结束或占位步骤',
+    icon: Play,
+  },
+  {
+    type: 'HTTP' as const,
+    title: 'HTTP 请求',
+    description: '调用外部 REST API',
+    icon: Globe2,
+  },
+  {
+    type: 'SHELL' as const,
+    title: 'Shell 脚本',
+    description: '配置命令或脚本任务',
+    icon: TerminalSquare,
+  },
+];
+
+const NodeSelector = ({ onAdd }: NodeSelectorProps) => (
+  <aside className="workflow-node-selector">
+    <div className="workflow-node-selector__header">
+      <div>
+        <strong>节点</strong>
+        <span>选择后添加到画布</span>
+      </div>
+      <Plus size={16} />
+    </div>
+
+    <div className="workflow-node-selector__list">
+      {nodeOptions.map((option) => {
+        const Icon = option.icon;
+        return (
+          <button
+            key={option.type}
+            type="button"
+            className="workflow-node-selector__item"
+            onClick={() => onAdd(option.type)}
+          >
+            <span className={`is-${option.type.toLowerCase()}`}>
+              <Icon size={17} />
+            </span>
+            <div>
+              <strong>{option.title}</strong>
+              <small>{option.description}</small>
+            </div>
+            <Plus size={15} />
+          </button>
+        );
+      })}
+    </div>
+  </aside>
+);
+
+export default NodeSelector;

--- a/yak-ops-ui/src/pages/workflow-management/designer/components/WorkflowNode.tsx
+++ b/yak-ops-ui/src/pages/workflow-management/designer/components/WorkflowNode.tsx
@@ -1,0 +1,62 @@
+import { Globe2, Play, TerminalSquare } from 'lucide-react';
+import { Handle, Position, type NodeProps } from 'reactflow';
+import type { WorkflowNodeData } from '../../types';
+
+const iconMap = {
+  NOOP: Play,
+  HTTP: Globe2,
+  SHELL: TerminalSquare,
+};
+
+const typeLabelMap: Record<string, string> = {
+  NOOP: '基础节点',
+  HTTP: 'HTTP 请求',
+  SHELL: 'Shell 脚本',
+};
+
+const WorkflowNode = ({ data, selected }: NodeProps<WorkflowNodeData>) => {
+  const Icon = iconMap[data.taskType as keyof typeof iconMap] || Play;
+
+  return (
+    <div
+      className={[
+        'workflow-canvas-node',
+        selected ? 'is-selected' : '',
+        data.enabled ? '' : 'is-disabled',
+      ]
+        .filter(Boolean)
+        .join(' ')}
+    >
+      <Handle
+        type="target"
+        position={Position.Left}
+        className="workflow-canvas-node__handle"
+      />
+
+      <div className="workflow-canvas-node__header">
+        <span className={`workflow-canvas-node__icon is-${data.taskType.toLowerCase()}`}>
+          <Icon size={17} />
+        </span>
+        <div>
+          <strong>{data.name || '未命名节点'}</strong>
+          <span>{typeLabelMap[data.taskType] || data.taskType}</span>
+        </div>
+      </div>
+
+      <p>{data.description || '点击节点，在右侧配置面板中完善节点信息。'}</p>
+
+      <div className="workflow-canvas-node__footer">
+        <span>{data.enabled ? '已启用' : '已停用'}</span>
+        {data.timeoutSeconds > 0 && <span>{data.timeoutSeconds}s 超时</span>}
+      </div>
+
+      <Handle
+        type="source"
+        position={Position.Right}
+        className="workflow-canvas-node__handle"
+      />
+    </div>
+  );
+};
+
+export default WorkflowNode;

--- a/yak-ops-ui/src/pages/workflow-management/designer/index.less
+++ b/yak-ops-ui/src/pages/workflow-management/designer/index.less
@@ -1,0 +1,607 @@
+.workflow-designer-page {
+  display: flex;
+  height: calc(100vh - 1px);
+  min-height: 680px;
+  flex-direction: column;
+  overflow: hidden;
+  background: #f5f7fa;
+  color: #172033;
+}
+
+.workflow-designer-header {
+  z-index: 20;
+  display: flex;
+  min-height: 66px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 0 18px;
+  border-bottom: 1px solid #e4e7ec;
+  background: rgb(255 255 255 / 96%);
+  box-shadow: 0 1px 3px rgb(16 24 40 / 4%);
+  backdrop-filter: blur(12px);
+}
+
+.workflow-designer-header__left,
+.workflow-designer-header__actions,
+.workflow-designer-header__title-row {
+  display: flex;
+  align-items: center;
+}
+
+.workflow-designer-header__left {
+  gap: 12px;
+  min-width: 0;
+}
+
+.workflow-designer-header__left > div:last-child {
+  min-width: 0;
+}
+
+.workflow-designer-header__title-row {
+  gap: 10px;
+}
+
+.workflow-designer-header h1 {
+  max-width: 440px;
+  margin: 0;
+  overflow: hidden;
+  color: #101828;
+  font-size: 16px;
+  font-weight: 700;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.workflow-designer-header__left > div > span:last-child {
+  display: block;
+  margin-top: 3px;
+  color: #98a2b3;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 11px;
+}
+
+.workflow-designer-icon-button,
+.workflow-designer-secondary-button,
+.workflow-designer-save-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  border: 0;
+  cursor: pointer;
+  transition: all 0.18s ease;
+}
+
+.workflow-designer-icon-button {
+  width: 36px;
+  height: 36px;
+  border: 1px solid #e4e7ec;
+  border-radius: 10px;
+  background: #fff;
+  color: #475467;
+}
+
+.workflow-designer-icon-button:hover {
+  border-color: #bfdbfe;
+  color: #2563eb;
+}
+
+.workflow-designer-header__actions {
+  gap: 9px;
+}
+
+.workflow-designer-secondary-button,
+.workflow-designer-save-button {
+  min-height: 36px;
+  padding: 0 13px;
+  border-radius: 9px;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.workflow-designer-secondary-button {
+  border: 1px solid #e4e7ec;
+  background: #fff;
+  color: #475467;
+}
+
+.workflow-designer-secondary-button:hover {
+  border-color: #bfdbfe;
+  background: #f8fbff;
+  color: #1d4ed8;
+}
+
+.workflow-designer-save-button {
+  background: #2563eb;
+  color: #fff;
+  box-shadow: 0 6px 16px rgb(37 99 235 / 18%);
+}
+
+.workflow-designer-save-button:hover {
+  background: #1d4ed8;
+}
+
+.workflow-designer-save-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.workflow-designer-save-button.is-compact {
+  min-height: 32px;
+  padding: 0 14px;
+}
+
+.workflow-designer-save-state {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 7px;
+  border-radius: 999px;
+  background: #ecfdf3;
+  color: #027a48;
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.workflow-designer-save-state.is-dirty {
+  background: #fff7ed;
+  color: #c2410c;
+}
+
+.workflow-designer-main,
+.workflow-designer-spin,
+.workflow-designer-spin > .ant-spin-container {
+  min-height: 0;
+  flex: 1;
+  height: 100%;
+}
+
+.workflow-designer-main {
+  position: relative;
+  overflow: hidden;
+}
+
+.workflow-designer-canvas {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  background:
+    radial-gradient(circle at 50% 0%, rgb(219 234 254 / 35%), transparent 34%),
+    #f8fafc;
+}
+
+.workflow-designer-canvas .react-flow__pane {
+  cursor: grab;
+}
+
+.workflow-designer-canvas .react-flow__pane:active {
+  cursor: grabbing;
+}
+
+.workflow-designer-canvas .react-flow__edge-path {
+  stroke: #94a3b8;
+  stroke-width: 1.6;
+}
+
+.workflow-designer-canvas .react-flow__edge.selected .react-flow__edge-path {
+  stroke: #2563eb;
+  stroke-width: 2;
+}
+
+.workflow-designer-canvas .react-flow__controls {
+  overflow: hidden;
+  margin: 0 0 18px 18px;
+  border: 1px solid #e4e7ec;
+  border-radius: 10px;
+  background: #fff;
+  box-shadow: 0 8px 24px rgb(15 23 42 / 8%);
+}
+
+.workflow-designer-canvas .react-flow__controls-button {
+  border-bottom-color: #f2f4f7;
+}
+
+.workflow-designer-canvas .react-flow__minimap {
+  overflow: hidden;
+  margin: 0 18px 18px 0;
+  border: 1px solid #e4e7ec;
+  border-radius: 10px;
+  background: rgb(255 255 255 / 90%);
+  box-shadow: 0 8px 24px rgb(15 23 42 / 8%);
+}
+
+.workflow-node-selector {
+  position: absolute;
+  top: 18px;
+  left: 18px;
+  z-index: 10;
+  width: 260px;
+  overflow: hidden;
+  border: 1px solid #e4e7ec;
+  border-radius: 14px;
+  background: rgb(255 255 255 / 96%);
+  box-shadow: 0 14px 36px rgb(15 23 42 / 10%);
+  backdrop-filter: blur(14px);
+}
+
+.workflow-node-selector__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 15px;
+  border-bottom: 1px solid #f0f2f5;
+  color: #475467;
+}
+
+.workflow-node-selector__header strong,
+.workflow-node-selector__header span {
+  display: block;
+}
+
+.workflow-node-selector__header strong {
+  color: #101828;
+  font-size: 14px;
+}
+
+.workflow-node-selector__header span {
+  margin-top: 2px;
+  color: #98a2b3;
+  font-size: 11px;
+}
+
+.workflow-node-selector__list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 9px;
+}
+
+.workflow-node-selector__item {
+  display: grid;
+  grid-template-columns: 36px minmax(0, 1fr) 18px;
+  align-items: center;
+  gap: 10px;
+  padding: 10px;
+  border: 1px solid transparent;
+  border-radius: 10px;
+  background: transparent;
+  color: #98a2b3;
+  cursor: pointer;
+  text-align: left;
+  transition: all 0.18s ease;
+}
+
+.workflow-node-selector__item:hover {
+  border-color: #dbeafe;
+  background: #f8fbff;
+  color: #2563eb;
+}
+
+.workflow-node-selector__item > span {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 10px;
+  background: #eff6ff;
+  color: #2563eb;
+}
+
+.workflow-node-selector__item > span.is-http {
+  background: #ecfeff;
+  color: #0891b2;
+}
+
+.workflow-node-selector__item > span.is-shell {
+  background: #f5f3ff;
+  color: #7c3aed;
+}
+
+.workflow-node-selector__item strong,
+.workflow-node-selector__item small {
+  display: block;
+}
+
+.workflow-node-selector__item strong {
+  color: #344054;
+  font-size: 13px;
+}
+
+.workflow-node-selector__item small {
+  margin-top: 2px;
+  color: #98a2b3;
+  font-size: 11px;
+  line-height: 1.45;
+}
+
+.workflow-canvas-node {
+  position: relative;
+  width: 248px;
+  overflow: hidden;
+  border: 1px solid #dfe3ea;
+  border-radius: 14px;
+  background: #fff;
+  box-shadow: 0 8px 22px rgb(15 23 42 / 8%);
+  transition: border-color 0.18s ease, box-shadow 0.18s ease, opacity 0.18s ease;
+}
+
+.workflow-canvas-node:hover {
+  border-color: #bfdbfe;
+  box-shadow: 0 13px 28px rgb(15 23 42 / 12%);
+}
+
+.workflow-canvas-node.is-selected {
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 3px rgb(59 130 246 / 12%), 0 16px 32px rgb(15 23 42 / 13%);
+}
+
+.workflow-canvas-node.is-disabled {
+  opacity: 0.58;
+}
+
+.workflow-canvas-node__header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 14px 14px 10px;
+}
+
+.workflow-canvas-node__header > div {
+  min-width: 0;
+}
+
+.workflow-canvas-node__header strong,
+.workflow-canvas-node__header span {
+  display: block;
+}
+
+.workflow-canvas-node__header strong {
+  overflow: hidden;
+  color: #101828;
+  font-size: 13px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.workflow-canvas-node__header span:not(.workflow-canvas-node__icon) {
+  margin-top: 2px;
+  color: #98a2b3;
+  font-size: 10px;
+  text-transform: uppercase;
+}
+
+.workflow-canvas-node__icon {
+  display: inline-flex !important;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  margin: 0 !important;
+  border-radius: 9px;
+  background: #eff6ff;
+  color: #2563eb !important;
+}
+
+.workflow-canvas-node__icon.is-http {
+  background: #ecfeff;
+  color: #0891b2 !important;
+}
+
+.workflow-canvas-node__icon.is-shell {
+  background: #f5f3ff;
+  color: #7c3aed !important;
+}
+
+.workflow-canvas-node p {
+  min-height: 38px;
+  margin: 0;
+  padding: 0 14px 12px;
+  overflow: hidden;
+  color: #667085;
+  font-size: 11px;
+  line-height: 1.55;
+  text-overflow: ellipsis;
+}
+
+.workflow-canvas-node__footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  min-height: 34px;
+  padding: 0 14px;
+  border-top: 1px solid #f2f4f7;
+  background: #fcfcfd;
+  color: #98a2b3;
+  font-size: 10px;
+}
+
+.workflow-canvas-node__handle {
+  width: 10px !important;
+  height: 10px !important;
+  border: 2px solid #fff !important;
+  background: #64748b !important;
+  box-shadow: 0 0 0 1px #cbd5e1;
+}
+
+.workflow-canvas-node.is-selected .workflow-canvas-node__handle {
+  background: #2563eb !important;
+  box-shadow: 0 0 0 1px #60a5fa;
+}
+
+.workflow-node-panel {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  bottom: 12px;
+  z-index: 12;
+  display: flex;
+  width: 380px;
+  flex-direction: column;
+  overflow: hidden;
+  border: 1px solid #e4e7ec;
+  border-radius: 14px;
+  background: rgb(255 255 255 / 98%);
+  box-shadow: 0 18px 44px rgb(15 23 42 / 14%);
+  backdrop-filter: blur(14px);
+}
+
+.workflow-node-panel__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 14px;
+  padding: 15px 16px;
+  border-bottom: 1px solid #e4e7ec;
+}
+
+.workflow-node-panel__header span,
+.workflow-node-panel__header strong {
+  display: block;
+}
+
+.workflow-node-panel__header span {
+  color: #98a2b3;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+}
+
+.workflow-node-panel__header strong {
+  max-width: 280px;
+  margin-top: 4px;
+  overflow: hidden;
+  color: #101828;
+  font-size: 15px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.workflow-node-panel__header button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  color: #667085;
+  cursor: pointer;
+}
+
+.workflow-node-panel__header button:hover {
+  background: #f2f4f7;
+}
+
+.workflow-node-panel__content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0 16px 18px;
+}
+
+.workflow-node-panel__section {
+  padding: 17px 0;
+  border-bottom: 1px solid #f0f2f5;
+}
+
+.workflow-node-panel__section:last-child {
+  border-bottom: 0;
+}
+
+.workflow-node-panel__section h3 {
+  margin: 0 0 13px;
+  color: #344054;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.workflow-node-panel__section label {
+  display: block;
+  margin-bottom: 13px;
+}
+
+.workflow-node-panel__section label:last-child {
+  margin-bottom: 0;
+}
+
+.workflow-node-panel__section label > span:first-child {
+  display: block;
+  margin-bottom: 6px;
+  color: #667085;
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.workflow-node-panel__section .ant-input-number,
+.workflow-node-panel__section .ant-select {
+  width: 100%;
+}
+
+.workflow-node-panel__grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+}
+
+.workflow-node-panel__switch-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 10px 0;
+}
+
+.workflow-node-panel__switch-row strong,
+.workflow-node-panel__switch-row span {
+  display: block;
+}
+
+.workflow-node-panel__switch-row strong {
+  color: #344054;
+  font-size: 12px;
+}
+
+.workflow-node-panel__switch-row span {
+  margin-top: 2px;
+  color: #98a2b3;
+  font-size: 10px;
+}
+
+.workflow-node-panel__footer {
+  padding: 12px 16px;
+  border-top: 1px solid #e4e7ec;
+  background: #fcfcfd;
+}
+
+.workflow-node-panel__footer button {
+  display: inline-flex;
+  width: 100%;
+  min-height: 36px;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  border: 1px solid #fecdca;
+  border-radius: 9px;
+  background: #fff;
+  color: #d92d20;
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.workflow-node-panel__footer button:hover {
+  background: #fef3f2;
+}
+
+@media (max-width: 980px) {
+  .workflow-node-panel {
+    width: 340px;
+  }
+
+  .workflow-node-selector {
+    width: 230px;
+  }
+}

--- a/yak-ops-ui/src/pages/workflow-management/designer/index.tsx
+++ b/yak-ops-ui/src/pages/workflow-management/designer/index.tsx
@@ -1,3 +1,522 @@
-const WorkflowManagementPage = () => <div>good</div>;
+import { history, useParams } from '@umijs/max';
+import {
+  Drawer,
+  Form,
+  Input,
+  InputNumber,
+  message,
+  Select,
+  Spin,
+} from 'antd';
+import {
+  ArrowLeft,
+  Check,
+  CircleDot,
+  Save,
+  Settings2,
+} from 'lucide-react';
+import {
+  addEdge,
+  Background,
+  BackgroundVariant,
+  Controls,
+  MarkerType,
+  MiniMap,
+  ReactFlow,
+  ReactFlowProvider,
+  useEdgesState,
+  useNodesState,
+  useReactFlow,
+  type Connection,
+  type EdgeChange,
+  type NodeChange,
+} from 'reactflow';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import 'reactflow/dist/style.css';
+import NodePanel from './components/NodePanel';
+import NodeSelector from './components/NodeSelector';
+import WorkflowNode from './components/WorkflowNode';
+import './index.less';
+import { fetchWorkflowDetail, updateWorkflow } from '../service';
+import type {
+  WorkflowDefinitionRecord,
+  WorkflowFailureStrategy,
+  WorkflowFlowEdge,
+  WorkflowFlowNode,
+  WorkflowNodeData,
+  WorkflowNodeType,
+} from '../types';
 
-export default WorkflowManagementPage;
+const nodeTypes = {
+  workflowNode: WorkflowNode,
+};
+
+const defaultNodeData = (
+  type: WorkflowNodeType,
+  index: number,
+): WorkflowNodeData => {
+  const defaults = {
+    NOOP: {
+      name: `基础节点 ${index}`,
+      description: '用于开始、结束或流程占位。',
+      config: {},
+    },
+    HTTP: {
+      name: `HTTP 请求 ${index}`,
+      description: '调用外部 REST API。',
+      config: {
+        method: 'GET',
+        url: '',
+        body: '',
+        requestTimeoutSeconds: 60,
+      },
+    },
+    SHELL: {
+      name: `Shell 脚本 ${index}`,
+      description: '在工作流执行主机上运行命令。',
+      config: {
+        command: '',
+        workDirectory: '',
+      },
+    },
+  }[type];
+
+  return {
+    ...defaults,
+    taskType: type,
+    retryTimes: 0,
+    retryIntervalSeconds: 0,
+    timeoutSeconds: 0,
+    enabled: true,
+    idempotent: type === 'NOOP',
+    retryOnRestart: type === 'NOOP',
+  };
+};
+
+interface WorkflowSettingsValues {
+  name: string;
+  description?: string;
+  failureStrategy: WorkflowFailureStrategy;
+  maxParallelism: number;
+}
+
+const WorkflowDesignerContent = () => {
+  const params = useParams<{ id: string }>();
+  const workflowId = params.id;
+  const reactFlow = useReactFlow();
+  const [settingsForm] = Form.useForm<WorkflowSettingsValues>();
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [dirty, setDirty] = useState(false);
+  const [settingsOpen, setSettingsOpen] = useState(false);
+  const [workflow, setWorkflow] = useState<WorkflowDefinitionRecord>();
+  const [selectedNodeId, setSelectedNodeId] = useState<string>();
+  const [nodes, setNodes, onNodesChangeBase] =
+    useNodesState<WorkflowNodeData>([]);
+  const [edges, setEdges, onEdgesChangeBase] = useEdgesState([]);
+
+  const selectedNode = useMemo(
+    () => nodes.find((node) => node.id === selectedNodeId),
+    [nodes, selectedNodeId],
+  );
+
+  const loadWorkflow = useCallback(async () => {
+    if (!workflowId) {
+      return;
+    }
+    try {
+      setLoading(true);
+      const response = await fetchWorkflowDetail(workflowId);
+      if (response.code !== 0 || !response.data) {
+        message.error(response.message || '加载工作流失败');
+        return;
+      }
+
+      const detail = response.data;
+      const flowNodes: WorkflowFlowNode[] = (detail.draft?.nodes || []).map(
+        (node, index) => ({
+          id: node.key,
+          type: 'workflowNode',
+          position: {
+            x: node.positionX ?? 120 + index * 280,
+            y: node.positionY ?? 180,
+          },
+          data: {
+            name: node.name,
+            description: node.description,
+            taskType: node.type,
+            config: node.config || {},
+            retryTimes: node.retryTimes || 0,
+            retryIntervalSeconds: node.retryIntervalSeconds || 0,
+            timeoutSeconds: node.timeoutSeconds || 0,
+            enabled: node.enabled !== false,
+            idempotent: Boolean(node.idempotent),
+            retryOnRestart: Boolean(node.retryOnRestart),
+          },
+        }),
+      );
+      const flowEdges: WorkflowFlowEdge[] = (detail.draft?.edges || []).map(
+        (edge, index) => ({
+          id: `edge_${edge.from}_${edge.to}_${index}`,
+          source: edge.from,
+          target: edge.to,
+          type: 'smoothstep',
+          markerEnd: { type: MarkerType.ArrowClosed },
+        }),
+      );
+
+      setWorkflow(detail);
+      setNodes(flowNodes);
+      setEdges(flowEdges);
+      setSelectedNodeId(undefined);
+      setDirty(false);
+
+      const viewport = detail.draft?.viewport;
+      requestAnimationFrame(() => {
+        if (viewport) {
+          reactFlow.setViewport(viewport, { duration: 0 });
+        } else if (flowNodes.length) {
+          reactFlow.fitView({ padding: 0.25, duration: 0 });
+        }
+      });
+    } finally {
+      setLoading(false);
+    }
+  }, [reactFlow, setEdges, setNodes, workflowId]);
+
+  useEffect(() => {
+    loadWorkflow();
+  }, [loadWorkflow]);
+
+  useEffect(() => {
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      if (!dirty) {
+        return;
+      }
+      event.preventDefault();
+      event.returnValue = '';
+    };
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    return () => window.removeEventListener('beforeunload', handleBeforeUnload);
+  }, [dirty]);
+
+  const onNodesChange = (changes: NodeChange[]) => {
+    onNodesChangeBase(changes);
+    if (changes.some((change) => change.type !== 'select')) {
+      setDirty(true);
+    }
+  };
+
+  const onEdgesChange = (changes: EdgeChange[]) => {
+    onEdgesChangeBase(changes);
+    setDirty(true);
+  };
+
+  const onConnect = (connection: Connection) => {
+    if (!connection.source || !connection.target) {
+      return;
+    }
+    if (connection.source === connection.target) {
+      message.warning('节点不能连接到自身');
+      return;
+    }
+    setEdges((currentEdges) =>
+      addEdge(
+        {
+          ...connection,
+          type: 'smoothstep',
+          markerEnd: { type: MarkerType.ArrowClosed },
+        },
+        currentEdges,
+      ),
+    );
+    setDirty(true);
+  };
+
+  const addNode = (type: WorkflowNodeType) => {
+    const id = `node_${Date.now().toString(36)}`;
+    const position = reactFlow.screenToFlowPosition({
+      x: window.innerWidth / 2,
+      y: window.innerHeight / 2,
+    });
+    const node: WorkflowFlowNode = {
+      id,
+      type: 'workflowNode',
+      position,
+      data: defaultNodeData(type, nodes.length + 1),
+    };
+    setNodes((currentNodes) => [...currentNodes, node]);
+    setSelectedNodeId(id);
+    setDirty(true);
+  };
+
+  const updateSelectedNode = (data: WorkflowNodeData) => {
+    if (!selectedNodeId) {
+      return;
+    }
+    setNodes((currentNodes) =>
+      currentNodes.map((node) =>
+        node.id === selectedNodeId ? { ...node, data } : node,
+      ),
+    );
+    setDirty(true);
+  };
+
+  const deleteSelectedNode = () => {
+    if (!selectedNodeId) {
+      return;
+    }
+    setNodes((currentNodes) =>
+      currentNodes.filter((node) => node.id !== selectedNodeId),
+    );
+    setEdges((currentEdges) =>
+      currentEdges.filter(
+        (edge) =>
+          edge.source !== selectedNodeId && edge.target !== selectedNodeId,
+      ),
+    );
+    setSelectedNodeId(undefined);
+    setDirty(true);
+  };
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const target = event.target as HTMLElement | null;
+      const editing =
+        target?.tagName === 'INPUT' ||
+        target?.tagName === 'TEXTAREA' ||
+        target?.isContentEditable;
+      if (!editing && selectedNodeId && ['Delete', 'Backspace'].includes(event.key)) {
+        event.preventDefault();
+        deleteSelectedNode();
+      }
+      if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === 's') {
+        event.preventDefault();
+        void saveWorkflow();
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  });
+
+  const saveWorkflow = async () => {
+    if (!workflow || !workflowId) {
+      return;
+    }
+    const unnamedNode = nodes.find((node) => !node.data.name.trim());
+    if (unnamedNode) {
+      setSelectedNodeId(unnamedNode.id);
+      message.warning('节点名称不能为空');
+      return;
+    }
+
+    try {
+      setSaving(true);
+      const viewport = reactFlow.getViewport();
+      const response = await updateWorkflow(workflowId, {
+        name: workflow.name,
+        description: workflow.description,
+        failureStrategy: workflow.failureStrategy,
+        maxParallelism: workflow.maxParallelism,
+        dag: {
+          nodes: nodes.map((node) => ({
+            key: node.id,
+            name: node.data.name.trim(),
+            type: node.data.taskType,
+            description: node.data.description,
+            positionX: node.position.x,
+            positionY: node.position.y,
+            config: node.data.config || {},
+            retryTimes: node.data.retryTimes,
+            retryIntervalSeconds: node.data.retryIntervalSeconds,
+            timeoutSeconds: node.data.timeoutSeconds,
+            enabled: node.data.enabled,
+            idempotent: node.data.idempotent,
+            retryOnRestart: node.data.retryOnRestart,
+          })),
+          edges: edges.map((edge) => ({
+            from: edge.source,
+            to: edge.target,
+          })),
+          viewport,
+        },
+      });
+      if (response.code !== 0) {
+        message.error(response.message || '保存工作流失败');
+        return;
+      }
+      setDirty(false);
+      message.success('工作流草稿已保存');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const openSettings = () => {
+    if (!workflow) {
+      return;
+    }
+    settingsForm.setFieldsValue({
+      name: workflow.name,
+      description: workflow.description,
+      failureStrategy: workflow.failureStrategy,
+      maxParallelism: workflow.maxParallelism,
+    });
+    setSettingsOpen(true);
+  };
+
+  const applySettings = async () => {
+    if (!workflow) {
+      return;
+    }
+    const values = await settingsForm.validateFields();
+    setWorkflow({ ...workflow, ...values });
+    setSettingsOpen(false);
+    setDirty(true);
+  };
+
+  return (
+    <div className="workflow-designer-page">
+      <header className="workflow-designer-header">
+        <div className="workflow-designer-header__left">
+          <button
+            type="button"
+            className="workflow-designer-icon-button"
+            onClick={() => history.push('/workflow-management')}
+          >
+            <ArrowLeft size={18} />
+          </button>
+          <div>
+            <div className="workflow-designer-header__title-row">
+              <h1>{workflow?.name || '工作流设计器'}</h1>
+              <span className={`workflow-designer-save-state ${dirty ? 'is-dirty' : ''}`}>
+                {dirty ? <CircleDot size={13} /> : <Check size={13} />}
+                {dirty ? '有未保存修改' : '已保存'}
+              </span>
+            </div>
+            <span>{workflow?.code || '-'}</span>
+          </div>
+        </div>
+
+        <div className="workflow-designer-header__actions">
+          <button
+            type="button"
+            className="workflow-designer-secondary-button"
+            onClick={openSettings}
+          >
+            <Settings2 size={16} />
+            工作流设置
+          </button>
+          <button
+            type="button"
+            className="workflow-designer-save-button"
+            onClick={() => void saveWorkflow()}
+            disabled={saving || loading}
+          >
+            <Save size={16} />
+            {saving ? '保存中...' : '保存草稿'}
+          </button>
+        </div>
+      </header>
+
+      <main className="workflow-designer-main">
+        <Spin spinning={loading} wrapperClassName="workflow-designer-spin">
+          <div className="workflow-designer-canvas">
+            <ReactFlow
+              nodes={nodes}
+              edges={edges}
+              nodeTypes={nodeTypes}
+              onNodesChange={onNodesChange}
+              onEdgesChange={onEdgesChange}
+              onConnect={onConnect}
+              onNodeClick={(_, node) => setSelectedNodeId(node.id)}
+              onPaneClick={() => setSelectedNodeId(undefined)}
+              minZoom={0.25}
+              maxZoom={2}
+              fitView
+              defaultEdgeOptions={{
+                type: 'smoothstep',
+                markerEnd: { type: MarkerType.ArrowClosed },
+              }}
+              proOptions={{ hideAttribution: true }}
+            >
+              <Background
+                variant={BackgroundVariant.Dots}
+                gap={18}
+                size={1.2}
+              />
+              <Controls position="bottom-left" showInteractive={false} />
+              <MiniMap
+                position="bottom-right"
+                pannable
+                zoomable
+                nodeStrokeWidth={2}
+              />
+            </ReactFlow>
+            <NodeSelector onAdd={addNode} />
+            {selectedNode && (
+              <NodePanel
+                node={selectedNode}
+                onChange={updateSelectedNode}
+                onDelete={deleteSelectedNode}
+                onClose={() => setSelectedNodeId(undefined)}
+              />
+            )}
+          </div>
+        </Spin>
+      </main>
+
+      <Drawer
+        title="工作流设置"
+        open={settingsOpen}
+        width={420}
+        onClose={() => setSettingsOpen(false)}
+        extra={
+          <button
+            type="button"
+            className="workflow-designer-save-button is-compact"
+            onClick={() => void applySettings()}
+          >
+            应用
+          </button>
+        }
+      >
+        <Form form={settingsForm} layout="vertical" requiredMark={false}>
+          <Form.Item
+            label="工作流名称"
+            name="name"
+            rules={[{ required: true, message: '请输入工作流名称' }]}
+          >
+            <Input maxLength={255} />
+          </Form.Item>
+          <Form.Item label="描述" name="description">
+            <Input.TextArea rows={4} maxLength={1000} showCount />
+          </Form.Item>
+          <Form.Item label="失败策略" name="failureStrategy">
+            <Select
+              options={[
+                { label: '失败即停止', value: 'FAIL_FAST' },
+                { label: '继续后续分支', value: 'CONTINUE' },
+              ]}
+            />
+          </Form.Item>
+          <Form.Item
+            label="最大并行度"
+            name="maxParallelism"
+            rules={[{ required: true, message: '请输入最大并行度' }]}
+          >
+            <InputNumber min={1} max={256} className="w-full" />
+          </Form.Item>
+        </Form>
+      </Drawer>
+    </div>
+  );
+};
+
+const WorkflowDesignerPage = () => (
+  <ReactFlowProvider>
+    <WorkflowDesignerContent />
+  </ReactFlowProvider>
+);
+
+export default WorkflowDesignerPage;

--- a/yak-ops-ui/src/pages/workflow-management/detail/index.tsx
+++ b/yak-ops-ui/src/pages/workflow-management/detail/index.tsx
@@ -1,3 +1,1 @@
-const WorkflowManagementPage = () => <div>good</div>;
-
-export default WorkflowManagementPage;
+export { default } from '../designer';

--- a/yak-ops-ui/src/pages/workflow-management/index.less
+++ b/yak-ops-ui/src/pages/workflow-management/index.less
@@ -1,0 +1,378 @@
+.workflow-management-page {
+  min-height: 100%;
+  padding: 28px;
+  background: #f6f7f9;
+  color: #172033;
+}
+
+.workflow-management-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 24px;
+  margin-bottom: 24px;
+}
+
+.workflow-management-header__eyebrow {
+  display: block;
+  margin-bottom: 8px;
+  color: #667085;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+}
+
+.workflow-management-header h1 {
+  margin: 0;
+  color: #101828;
+  font-size: 30px;
+  line-height: 1.25;
+}
+
+.workflow-management-header p {
+  max-width: 720px;
+  margin: 10px 0 0;
+  color: #667085;
+  font-size: 14px;
+  line-height: 1.7;
+}
+
+.workflow-primary-button,
+.workflow-secondary-button,
+.workflow-card-edit-action,
+.workflow-card-danger-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  border: 0;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.workflow-primary-button {
+  min-height: 40px;
+  padding: 0 16px;
+  border-radius: 10px;
+  background: #2563eb;
+  color: #fff;
+  font-weight: 600;
+  box-shadow: 0 7px 18px rgb(37 99 235 / 20%);
+}
+
+.workflow-primary-button:hover {
+  background: #1d4ed8;
+  transform: translateY(-1px);
+}
+
+.workflow-secondary-button {
+  min-height: 36px;
+  padding: 0 12px;
+  border: 1px solid #e4e7ec;
+  border-radius: 9px;
+  background: #fff;
+  color: #475467;
+}
+
+.workflow-secondary-button:hover {
+  border-color: #cbd5e1;
+  color: #1d4ed8;
+}
+
+.workflow-overview-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 14px;
+  margin-bottom: 18px;
+}
+
+.workflow-overview-card {
+  display: flex;
+  align-items: center;
+  gap: 13px;
+  min-height: 92px;
+  padding: 18px;
+  border: 1px solid #eaecf0;
+  border-radius: 14px;
+  background: #fff;
+  box-shadow: 0 1px 2px rgb(16 24 40 / 3%);
+}
+
+.workflow-overview-card__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 42px;
+  height: 42px;
+  border-radius: 11px;
+  background: #eff6ff;
+  color: #2563eb;
+}
+
+.workflow-overview-card__icon.is-draft {
+  background: #f5f3ff;
+  color: #7c3aed;
+}
+
+.workflow-overview-card__icon.is-published {
+  background: #ecfdf3;
+  color: #039855;
+}
+
+.workflow-overview-card__icon.is-node {
+  background: #fff7ed;
+  color: #ea580c;
+}
+
+.workflow-overview-card span {
+  color: #667085;
+  font-size: 13px;
+}
+
+.workflow-overview-card strong {
+  display: block;
+  margin-top: 4px;
+  color: #101828;
+  font-size: 23px;
+}
+
+.workflow-list-panel {
+  min-height: 360px;
+  padding: 18px;
+  border: 1px solid #e4e7ec;
+  border-radius: 16px;
+  background: #fff;
+}
+
+.workflow-list-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 18px;
+}
+
+.workflow-search-box {
+  display: flex;
+  align-items: center;
+  width: min(420px, 100%);
+  min-height: 38px;
+  padding: 0 12px;
+  border: 1px solid #e4e7ec;
+  border-radius: 10px;
+  background: #f9fafb;
+  color: #98a2b3;
+}
+
+.workflow-search-box:focus-within {
+  border-color: #93c5fd;
+  background: #fff;
+  box-shadow: 0 0 0 3px rgb(37 99 235 / 8%);
+}
+
+.workflow-card-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.workflow-definition-card {
+  display: flex;
+  min-height: 268px;
+  flex-direction: column;
+  padding: 18px;
+  border: 1px solid #e4e7ec;
+  border-radius: 14px;
+  background: #fff;
+  transition: all 0.2s ease;
+}
+
+.workflow-definition-card:hover {
+  border-color: #bfdbfe;
+  box-shadow: 0 12px 28px rgb(15 23 42 / 8%);
+  transform: translateY(-2px);
+}
+
+.workflow-definition-card__top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.workflow-definition-card__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 11px;
+  background: linear-gradient(135deg, #dbeafe, #eff6ff);
+  color: #2563eb;
+}
+
+.workflow-state-tag {
+  padding: 4px 9px;
+  border-radius: 999px;
+  background: #f2f4f7;
+  color: #475467;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.workflow-state-tag.is-published {
+  background: #ecfdf3;
+  color: #027a48;
+}
+
+.workflow-state-tag.is-offline {
+  background: #fff4ed;
+  color: #c4320a;
+}
+
+.workflow-definition-card__title {
+  margin: 18px 0 4px;
+  padding: 0;
+  overflow: hidden;
+  border: 0;
+  background: transparent;
+  color: #101828;
+  cursor: pointer;
+  font-size: 17px;
+  font-weight: 700;
+  text-align: left;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.workflow-definition-card__title:hover {
+  color: #1d4ed8;
+}
+
+.workflow-definition-card code {
+  color: #667085;
+  font-size: 12px;
+}
+
+.workflow-definition-card p {
+  display: -webkit-box;
+  min-height: 44px;
+  margin: 14px 0;
+  overflow: hidden;
+  color: #667085;
+  font-size: 13px;
+  line-height: 1.65;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.workflow-definition-card__meta {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  margin-top: auto;
+  padding: 13px 0;
+  border-top: 1px solid #f2f4f7;
+  color: #667085;
+  font-size: 12px;
+}
+
+.workflow-definition-card__meta span {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+}
+
+.workflow-definition-card__footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-top: 2px;
+}
+
+.workflow-card-edit-action,
+.workflow-card-danger-action {
+  padding: 7px 8px;
+  border-radius: 8px;
+  background: transparent;
+  font-size: 13px;
+}
+
+.workflow-card-edit-action {
+  color: #2563eb;
+  font-weight: 600;
+}
+
+.workflow-card-edit-action:hover {
+  background: #eff6ff;
+}
+
+.workflow-card-danger-action {
+  color: #667085;
+}
+
+.workflow-card-danger-action:hover {
+  background: #fef3f2;
+  color: #d92d20;
+}
+
+.workflow-empty-state {
+  display: flex;
+  min-height: 300px;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 18px;
+}
+
+.workflow-create-modal__row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 14px;
+}
+
+.workflow-create-modal__field {
+  margin-bottom: 0;
+}
+
+.is-spinning {
+  animation: workflow-spin 0.9s linear infinite;
+}
+
+@keyframes workflow-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (max-width: 1180px) {
+  .workflow-card-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 900px) {
+  .workflow-overview-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .workflow-management-header {
+    flex-direction: column;
+  }
+}
+
+@media (max-width: 680px) {
+  .workflow-management-page {
+    padding: 18px;
+  }
+
+  .workflow-card-grid,
+  .workflow-overview-grid,
+  .workflow-create-modal__row {
+    grid-template-columns: 1fr;
+  }
+
+  .workflow-list-toolbar {
+    align-items: stretch;
+    flex-direction: column;
+  }
+}

--- a/yak-ops-ui/src/pages/workflow-management/index.tsx
+++ b/yak-ops-ui/src/pages/workflow-management/index.tsx
@@ -1,3 +1,278 @@
-const WorkflowManagementPage = () => <div>good</div>;
+import { history } from '@umijs/max';
+import { Empty, Input, message, Modal, Spin } from 'antd';
+import dayjs from 'dayjs';
+import {
+  Boxes,
+  ChevronRight,
+  Clock3,
+  GitBranch,
+  MoreHorizontal,
+  PencilLine,
+  Plus,
+  RefreshCw,
+  Search,
+  Trash2,
+} from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+import CreateWorkflowModal from './components/CreateWorkflowModal';
+import './index.less';
+import { deleteWorkflow, fetchWorkflowList } from './service';
+import type { WorkflowDefinitionRecord } from './types';
+
+const stateLabelMap: Record<string, string> = {
+  DRAFT: '草稿',
+  PUBLISHED: '已发布',
+  OFFLINE: '已下线',
+};
+
+const WorkflowManagementPage = () => {
+  const [loading, setLoading] = useState(false);
+  const [creating, setCreating] = useState(false);
+  const [keyword, setKeyword] = useState('');
+  const [workflowList, setWorkflowList] = useState<WorkflowDefinitionRecord[]>([]);
+
+  const loadWorkflows = async () => {
+    try {
+      setLoading(true);
+      const response = await fetchWorkflowList();
+      if (response.code !== 0) {
+        message.error(response.message || '加载工作流失败');
+        return;
+      }
+      setWorkflowList(response.data || []);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadWorkflows();
+  }, []);
+
+  const filteredList = useMemo(() => {
+    const normalized = keyword.trim().toLowerCase();
+    if (!normalized) {
+      return workflowList;
+    }
+    return workflowList.filter((workflow) =>
+      [workflow.name, workflow.code, workflow.description]
+        .filter(Boolean)
+        .some((value) => String(value).toLowerCase().includes(normalized)),
+    );
+  }, [keyword, workflowList]);
+
+  const statistics = useMemo(() => {
+    const draft = workflowList.filter((item) => item.state === 'DRAFT').length;
+    const published = workflowList.filter(
+      (item) => item.state === 'PUBLISHED',
+    ).length;
+    return {
+      total: workflowList.length,
+      draft,
+      published,
+      nodes: workflowList.reduce(
+        (count, item) => count + (item.draft?.nodes?.length || 0),
+        0,
+      ),
+    };
+  }, [workflowList]);
+
+  const openDesigner = (workflowId: number) => {
+    history.push(`/workflow-management/${workflowId}/designer`);
+  };
+
+  const handleDelete = (workflow: WorkflowDefinitionRecord) => {
+    Modal.confirm({
+      title: '删除工作流',
+      content: `确定删除“${workflow.name}”吗？草稿和历史版本将一并删除。`,
+      okText: '删除',
+      cancelText: '取消',
+      okButtonProps: { danger: true },
+      centered: true,
+      async onOk() {
+        const response = await deleteWorkflow(workflow.id);
+        if (response.code !== 0) {
+          message.error(response.message || '删除工作流失败');
+          return;
+        }
+        message.success('工作流已删除');
+        await loadWorkflows();
+      },
+    });
+  };
+
+  return (
+    <div className="workflow-management-page">
+      <header className="workflow-management-header">
+        <div>
+          <span className="workflow-management-header__eyebrow">
+            WORKFLOW STUDIO
+          </span>
+          <h1>工作流管理</h1>
+          <p>创建、维护和组织可视化工作流定义，当前阶段专注于设计与草稿管理。</p>
+        </div>
+        <button
+          type="button"
+          className="workflow-primary-button"
+          onClick={() => setCreating(true)}
+        >
+          <Plus size={17} />
+          新建工作流
+        </button>
+      </header>
+
+      <section className="workflow-overview-grid">
+        <div className="workflow-overview-card">
+          <span className="workflow-overview-card__icon">
+            <Boxes size={19} />
+          </span>
+          <div>
+            <span>全部工作流</span>
+            <strong>{statistics.total}</strong>
+          </div>
+        </div>
+        <div className="workflow-overview-card">
+          <span className="workflow-overview-card__icon is-draft">
+            <PencilLine size={19} />
+          </span>
+          <div>
+            <span>草稿</span>
+            <strong>{statistics.draft}</strong>
+          </div>
+        </div>
+        <div className="workflow-overview-card">
+          <span className="workflow-overview-card__icon is-published">
+            <GitBranch size={19} />
+          </span>
+          <div>
+            <span>已发布</span>
+            <strong>{statistics.published}</strong>
+          </div>
+        </div>
+        <div className="workflow-overview-card">
+          <span className="workflow-overview-card__icon is-node">
+            <MoreHorizontal size={19} />
+          </span>
+          <div>
+            <span>节点总数</span>
+            <strong>{statistics.nodes}</strong>
+          </div>
+        </div>
+      </section>
+
+      <section className="workflow-list-panel">
+        <div className="workflow-list-toolbar">
+          <div className="workflow-search-box">
+            <Search size={16} />
+            <Input
+              bordered={false}
+              value={keyword}
+              placeholder="搜索名称、编码或描述"
+              onChange={(event) => setKeyword(event.target.value)}
+              allowClear
+            />
+          </div>
+          <button
+            type="button"
+            className="workflow-secondary-button"
+            onClick={loadWorkflows}
+            disabled={loading}
+          >
+            <RefreshCw size={15} className={loading ? 'is-spinning' : ''} />
+            刷新
+          </button>
+        </div>
+
+        <Spin spinning={loading}>
+          {filteredList.length ? (
+            <div className="workflow-card-grid">
+              {filteredList.map((workflow) => (
+                <article key={workflow.id} className="workflow-definition-card">
+                  <div className="workflow-definition-card__top">
+                    <div className="workflow-definition-card__icon">
+                      <GitBranch size={20} />
+                    </div>
+                    <span
+                      className={`workflow-state-tag is-${workflow.state.toLowerCase()}`}
+                    >
+                      {stateLabelMap[workflow.state] || workflow.state}
+                    </span>
+                  </div>
+
+                  <button
+                    type="button"
+                    className="workflow-definition-card__title"
+                    onClick={() => openDesigner(workflow.id)}
+                  >
+                    {workflow.name}
+                  </button>
+                  <code>{workflow.code}</code>
+                  <p>{workflow.description || '暂未填写工作流描述。'}</p>
+
+                  <div className="workflow-definition-card__meta">
+                    <span>
+                      <GitBranch size={14} />
+                      {workflow.draft?.nodes?.length || 0} 个节点
+                    </span>
+                    <span>
+                      <Clock3 size={14} />
+                      {workflow.updatedAt
+                        ? dayjs(workflow.updatedAt).format('YYYY-MM-DD HH:mm')
+                        : '-'}
+                    </span>
+                  </div>
+
+                  <div className="workflow-definition-card__footer">
+                    <button
+                      type="button"
+                      className="workflow-card-danger-action"
+                      onClick={() => handleDelete(workflow)}
+                    >
+                      <Trash2 size={15} />
+                      删除
+                    </button>
+                    <button
+                      type="button"
+                      className="workflow-card-edit-action"
+                      onClick={() => openDesigner(workflow.id)}
+                    >
+                      进入设计器
+                      <ChevronRight size={15} />
+                    </button>
+                  </div>
+                </article>
+              ))}
+            </div>
+          ) : (
+            <div className="workflow-empty-state">
+              <Empty
+                description={keyword ? '没有匹配的工作流' : '还没有工作流'}
+              />
+              {!keyword && (
+                <button
+                  type="button"
+                  className="workflow-primary-button"
+                  onClick={() => setCreating(true)}
+                >
+                  <Plus size={17} />
+                  创建第一个工作流
+                </button>
+              )}
+            </div>
+          )}
+        </Spin>
+      </section>
+
+      <CreateWorkflowModal
+        open={creating}
+        onCancel={() => setCreating(false)}
+        onCreated={(workflowId) => {
+          setCreating(false);
+          openDesigner(workflowId);
+        }}
+      />
+    </div>
+  );
+};
 
 export default WorkflowManagementPage;

--- a/yak-ops-ui/src/pages/workflow-management/service.ts
+++ b/yak-ops-ui/src/pages/workflow-management/service.ts
@@ -1,0 +1,40 @@
+import HttpUtils from '@/utils/HttpUtils';
+import type {
+  CommonApiResponse,
+  WorkflowCreatePayload,
+  WorkflowDefinitionRecord,
+  WorkflowUpdatePayload,
+} from './types';
+
+const WORKFLOW_API_PREFIX = '/api/v1/workflows';
+
+export async function fetchWorkflowList(): Promise<
+  CommonApiResponse<WorkflowDefinitionRecord[]>
+> {
+  return HttpUtils.get(WORKFLOW_API_PREFIX);
+}
+
+export async function fetchWorkflowDetail(
+  workflowId: string | number,
+): Promise<CommonApiResponse<WorkflowDefinitionRecord>> {
+  return HttpUtils.get(`${WORKFLOW_API_PREFIX}/${workflowId}`);
+}
+
+export async function createWorkflow(
+  payload: WorkflowCreatePayload,
+): Promise<CommonApiResponse<{ workflowId: number }>> {
+  return HttpUtils.post(WORKFLOW_API_PREFIX, payload);
+}
+
+export async function updateWorkflow(
+  workflowId: string | number,
+  payload: WorkflowUpdatePayload,
+): Promise<CommonApiResponse<boolean>> {
+  return HttpUtils.put(`${WORKFLOW_API_PREFIX}/${workflowId}`, payload);
+}
+
+export async function deleteWorkflow(
+  workflowId: string | number,
+): Promise<CommonApiResponse<boolean>> {
+  return HttpUtils.delete(`${WORKFLOW_API_PREFIX}/${workflowId}`);
+}

--- a/yak-ops-ui/src/pages/workflow-management/types.ts
+++ b/yak-ops-ui/src/pages/workflow-management/types.ts
@@ -1,0 +1,98 @@
+import type { Edge, Node, Viewport } from 'reactflow';
+
+export type WorkflowDefinitionState = 'DRAFT' | 'PUBLISHED' | 'OFFLINE';
+export type WorkflowFailureStrategy = 'FAIL_FAST' | 'CONTINUE';
+export type WorkflowNodeType = 'NOOP' | 'HTTP' | 'SHELL';
+
+export interface CommonApiResponse<T> {
+  code: number;
+  data: T;
+  message?: string;
+}
+
+export interface WorkflowNodeRecord {
+  key: string;
+  name: string;
+  type: WorkflowNodeType | string;
+  description?: string;
+  positionX?: number;
+  positionY?: number;
+  config: Record<string, unknown>;
+  retryTimes: number;
+  retryIntervalSeconds: number;
+  timeoutSeconds: number;
+  enabled: boolean;
+  idempotent: boolean;
+  retryOnRestart: boolean;
+}
+
+export interface WorkflowEdgeRecord {
+  from: string;
+  to: string;
+}
+
+export interface WorkflowViewportRecord {
+  x: number;
+  y: number;
+  zoom: number;
+}
+
+export interface WorkflowDagRecord {
+  nodes: WorkflowNodeRecord[];
+  edges: WorkflowEdgeRecord[];
+  viewport?: WorkflowViewportRecord;
+}
+
+export interface WorkflowDefinitionRecord {
+  id: number;
+  code: string;
+  name: string;
+  description?: string;
+  state: WorkflowDefinitionState;
+  currentVersion?: number;
+  failureStrategy: WorkflowFailureStrategy;
+  maxParallelism: number;
+  draft: WorkflowDagRecord;
+  createdBy?: string;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export interface WorkflowCreatePayload {
+  code: string;
+  name: string;
+  description?: string;
+  failureStrategy: WorkflowFailureStrategy;
+  maxParallelism: number;
+  dag: WorkflowDagRecord;
+}
+
+export interface WorkflowUpdatePayload {
+  name: string;
+  description?: string;
+  failureStrategy: WorkflowFailureStrategy;
+  maxParallelism: number;
+  dag: WorkflowDagRecord;
+}
+
+export interface WorkflowNodeData {
+  name: string;
+  description?: string;
+  taskType: WorkflowNodeType | string;
+  config: Record<string, unknown>;
+  retryTimes: number;
+  retryIntervalSeconds: number;
+  timeoutSeconds: number;
+  enabled: boolean;
+  idempotent: boolean;
+  retryOnRestart: boolean;
+}
+
+export type WorkflowFlowNode = Node<WorkflowNodeData>;
+export type WorkflowFlowEdge = Edge;
+
+export interface WorkflowDesignerState {
+  nodes: WorkflowFlowNode[];
+  edges: WorkflowFlowEdge[];
+  viewport: Viewport;
+}


### PR DESCRIPTION
## 背景

参考 `weifuwan/dify` 工作流编辑器的组件职责，先实现 Yak Ops 工作流定义的 CRUD 与可视化草稿设计闭环。本 PR **不新增工作流执行入口**，发布、实例和调度页面也不在本次前端范围内。

## 后端

- 补齐标准工作流定义 CRUD：
  - `POST /api/v1/workflows`
  - `GET /api/v1/workflows`
  - `GET /api/v1/workflows/{workflowId}`
  - `PUT /api/v1/workflows/{workflowId}`
  - `DELETE /api/v1/workflows/{workflowId}`
- 保留原 `PUT /api/v1/workflows/{workflowId}/draft` 兼容路径
- 创建时校验工作流编码唯一性
- 删除时同步清理调度配置、Quartz Job 和发布版本
- 已存在运行实例的工作流禁止删除，避免历史数据失联
- 新增 `workflow:definition:delete` 权限

## 设计器数据模型

工作流草稿仍保存在现有 `yak_wf_definition.draft_json` 中，不新增数据库表：

- DAG 节点增加 `description`、`positionX`、`positionY`
- DAG 增加 `viewport`，保存 React Flow 的平移和缩放状态
- 保留原执行配置、重试、超时、幂等和重启重试字段
- 旧草稿缺少画布字段时使用默认坐标和默认 viewport，保持向后兼容

## 前端

### 工作流管理

- 工作流列表、搜索和统计卡片
- 新建工作流弹窗
- 删除确认
- 进入工作流设计器
- 所有数据均对接真实后端接口

### React Flow 设计器

组件职责参考 Dify 的 canvas / node / panel 分层：

- `NodeSelector`：左侧节点选择面板
- `WorkflowNode`：统一节点卡片和连接点
- `NodePanel`：右侧选中节点配置面板
- `WorkflowDesignerPage`：画布状态、节点连线、草稿转换和保存编排

当前支持：

- NOOP、HTTP、SHELL 三类节点
- 添加、移动、选择和删除节点
- 节点连线和删除连线
- HTTP 与 Shell 基础配置
- 重试、间隔、超时、启用、幂等和重启重试配置
- 工作流名称、描述、失败策略和最大并行度设置
- 保存节点位置、边和 viewport
- `Ctrl/Cmd + S` 保存
- 未保存状态提示和浏览器离开提醒
- MiniMap、缩放控制和画布背景

## 非目标

- 不提供前端运行、停止、发布和调度交互
- 不实现 Dify 的调试、变量系统、容器节点、协作和版本历史
- 暂不细化视觉主题，当前样式只采用类似 Dify 的轻量面板和节点卡片结构

## 验证

- 新增 `WorkflowJsonCodecTest`，验证节点描述、坐标和 viewport 的 JSON 往返
- 更新安全目录测试，覆盖定义删除权限
- 核对 React Flow 11.11.4 使用的节点、边、viewport 和坐标 API
- 核对接口 DTO 与前端 payload 字段一一对应
- 与最新 `main` 的新增数据源改动没有文件重叠

## 环境说明

当前执行环境无法进行完整 Maven 与前端依赖安装构建；GitHub CI 和项目本地环境仍是最终的依赖、类型与集成验证依据。