### PR TITLE
feat(ui): present menu and action permission hierarchy

### DIFF
--- a/yak-ops-boot/src/main/resources/yak-security/db/migration/V1300__link_yak_ops_permissions_to_menus.sql
+++ b/yak-ops-boot/src/main/resources/yak-security/db/migration/V1300__link_yak_ops_permissions_to_menus.sql
@@ -1,0 +1,105 @@
+-- Yak Ops 业务按钮权限与稳定菜单编码绑定。
+-- 菜单只控制页面访问；按钮权限会自动包含所属菜单和父级目录。
+
+UPDATE yak_security_permission
+SET menu_code='batch-link-up'
+WHERE app_name='${appName}' AND is_delete=0
+  AND permission_code LIKE 'task:batch:%';
+
+UPDATE yak_security_permission
+SET menu_code='realtime-link-up'
+WHERE app_name='${appName}' AND is_delete=0
+  AND permission_code LIKE 'task:realtime:%';
+
+UPDATE yak_security_permission
+SET menu_code='workflow-project'
+WHERE app_name='${appName}' AND is_delete=0
+  AND permission_code LIKE 'workflow:project:%';
+
+UPDATE yak_security_permission
+SET menu_code='workflow-management'
+WHERE app_name='${appName}' AND is_delete=0
+  AND (permission_code LIKE 'workflow:definition:%'
+       OR permission_code='workflow:schedule:manage');
+
+UPDATE yak_security_permission
+SET menu_code='workflow-instance'
+WHERE app_name='${appName}' AND is_delete=0
+  AND permission_code LIKE 'workflow:instance:%';
+
+UPDATE yak_security_permission
+SET menu_code='data-source'
+WHERE app_name='${appName}' AND is_delete=0
+  AND (permission_code LIKE 'resource:data-source:%'
+       OR permission_code LIKE 'datasource:%');
+
+UPDATE yak_security_permission
+SET menu_code='client'
+WHERE app_name='${appName}' AND is_delete=0
+  AND permission_code LIKE 'resource:client:%';
+
+UPDATE yak_security_permission
+SET menu_code='connector'
+WHERE app_name='${appName}' AND is_delete=0
+  AND permission_code LIKE 'resource:connector:%';
+
+UPDATE yak_security_permission
+SET menu_code='data-quality'
+WHERE app_name='${appName}' AND is_delete=0
+  AND (permission_code LIKE 'quality:rule:%'
+       OR permission_code IN ('quality:view','quality:create','quality:update','quality:delete','quality:execute'));
+
+UPDATE yak_security_permission
+SET menu_code='data-quality-report'
+WHERE app_name='${appName}' AND is_delete=0
+  AND permission_code LIKE 'quality:report:%';
+
+UPDATE yak_security_permission
+SET menu_code='metrics'
+WHERE app_name='${appName}' AND is_delete=0
+  AND permission_code LIKE 'operations:metrics:%';
+
+UPDATE yak_security_permission
+SET menu_code='alarm'
+WHERE app_name='${appName}' AND is_delete=0
+  AND permission_code LIKE 'operations:alarm:%';
+
+UPDATE yak_security_permission
+SET menu_code='knowledge-management'
+WHERE app_name='${appName}' AND is_delete=0
+  AND permission_code LIKE 'knowledge:%';
+
+-- 已有角色的按钮权限自动回填所属菜单。
+INSERT IGNORE INTO yak_security_role_menu(role_id,menu_id,app_name)
+SELECT DISTINCT role_permission.role_id,menu_row.id,role_permission.app_name
+FROM yak_security_role_permission role_permission
+JOIN yak_security_permission permission_row
+  ON permission_row.id=role_permission.permission_id
+ AND permission_row.app_name=role_permission.app_name
+ AND permission_row.is_delete=0
+ AND permission_row.active=1
+ AND permission_row.menu_code IS NOT NULL
+JOIN yak_security_menu menu_row
+  ON menu_row.menu_code=permission_row.menu_code
+ AND menu_row.app_name=role_permission.app_name
+ AND menu_row.is_delete=0
+ AND menu_row.active=1
+WHERE role_permission.app_name='${appName}'
+  AND role_permission.is_delete=0;
+
+-- 回填一级父目录。
+INSERT IGNORE INTO yak_security_role_menu(role_id,menu_id,app_name)
+SELECT DISTINCT role_menu.role_id,parent_menu.id,role_menu.app_name
+FROM yak_security_role_menu role_menu
+JOIN yak_security_menu child_menu
+  ON child_menu.id=role_menu.menu_id
+ AND child_menu.app_name=role_menu.app_name
+ AND child_menu.is_delete=0
+JOIN yak_security_menu parent_menu
+  ON parent_menu.menu_code=child_menu.parent_code
+ AND parent_menu.app_name=role_menu.app_name
+ AND parent_menu.is_delete=0
+ AND parent_menu.active=1
+WHERE role_menu.app_name='${appName}'
+  AND role_menu.is_delete=0
+  AND child_menu.parent_code IS NOT NULL;

--- a/yak-ops-boot/src/main/resources/yak-security/db/migration/V1300__link_yak_ops_permissions_to_menus.sql
+++ b/yak-ops-boot/src/main/resources/yak-security/db/migration/V1300__link_yak_ops_permissions_to_menus.sql
@@ -20,7 +20,8 @@ UPDATE yak_security_permission
 SET menu_code='workflow-management'
 WHERE app_name='${appName}' AND is_delete=0
   AND (permission_code LIKE 'workflow:definition:%'
-       OR permission_code='workflow:schedule:manage');
+       OR permission_code='workflow:schedule:manage'
+       OR permission_code IN ('workflow:view','workflow:create','workflow:update','workflow:delete','workflow:execute'));
 
 UPDATE yak_security_permission
 SET menu_code='workflow-instance'

--- a/yak-ops-boot/src/test/java/io/yak/ops/boot/config/YakOpsPermissionMenuMigrationTest.java
+++ b/yak-ops-boot/src/test/java/io/yak/ops/boot/config/YakOpsPermissionMenuMigrationTest.java
@@ -1,0 +1,29 @@
+package io.yak.ops.boot.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.io.ClassPathResource;
+
+class YakOpsPermissionMenuMigrationTest {
+
+  @Test
+  void migrationLinksBusinessActionsToBusinessMenus() throws Exception {
+    ClassPathResource resource = new ClassPathResource(
+        "yak-security/db/migration/V1300__link_yak_ops_permissions_to_menus.sql");
+    String sql = resource.getContentAsString(StandardCharsets.UTF_8);
+
+    assertThat(sql)
+        .contains("SET menu_code='batch-link-up'")
+        .contains("SET menu_code='workflow-management'")
+        .contains("'workflow:create'")
+        .contains("SET menu_code='data-source'")
+        .contains("SET menu_code='data-quality'")
+        .contains("SET menu_code='metrics'")
+        .contains("INSERT IGNORE INTO yak_security_role_menu")
+        .contains("permission_row.menu_code")
+        .doesNotContain("SET menu_code='system-users'")
+        .doesNotContain("security:user:create");
+  }
+}

--- a/yak-ops-ui/src/pages/system/roles/components/RoleCapabilityTree.test.tsx
+++ b/yak-ops-ui/src/pages/system/roles/components/RoleCapabilityTree.test.tsx
@@ -1,0 +1,52 @@
+import type { PermissionTreeNode } from '@/services/security/roles';
+
+import { collectCapabilityCheckedKeys } from './RoleCapabilityTree';
+
+const tree = (
+  menuHas: boolean,
+  actionHas: boolean,
+): PermissionTreeNode => ({
+  id: 0,
+  nodeType: 'ROOT',
+  childList: [
+    {
+      id: -1,
+      permissionName: '菜单与操作权限',
+      nodeType: 'MENU_GROUP',
+      childList: [
+        {
+          id: -11,
+          permissionName: '用户管理',
+          nodeType: 'MENU',
+          has: menuHas,
+          active: true,
+          childList: [
+            {
+              id: 101,
+              permissionName: '新增用户',
+              permissionCode: 'security:user:create',
+              nodeType: 'ACTION',
+              menuCode: 'system-users',
+              has: actionHas,
+              active: true,
+            },
+          ],
+        },
+      ],
+    },
+  ],
+});
+
+describe('RoleCapabilityTree', () => {
+  it('adds the containing menu when an action is selected', () => {
+    expect(collectCapabilityCheckedKeys(tree(false, true)))
+      .toEqual(expect.arrayContaining([-11, 101]));
+  });
+
+  it('does not grant actions when only the menu is selected', () => {
+    const keys = collectCapabilityCheckedKeys(tree(true, false));
+
+    expect(keys).toContain(-11);
+    expect(keys).not.toContain(101);
+  });
+});

--- a/yak-ops-ui/src/pages/system/roles/components/RoleCapabilityTree.tsx
+++ b/yak-ops-ui/src/pages/system/roles/components/RoleCapabilityTree.tsx
@@ -118,6 +118,26 @@ const buildTreeData = (
   };
 };
 
+const buildTreeForest = (
+  tree?: PermissionTreeNode,
+): CapabilityDataNode[] => {
+  if (!tree) return [];
+
+  const virtualRoot =
+    tree.nodeType === 'ROOT' ||
+    (Number(tree.id) === 0 &&
+      !tree.permissionName &&
+      !tree.permissionCode);
+
+  if (virtualRoot) {
+    return (tree.childList ?? []).map((child, index) =>
+      buildTreeData(child, [index]),
+    );
+  }
+
+  return [buildTreeData(tree, [0])];
+};
+
 const buildIndex = (tree?: PermissionTreeNode): CapabilityIndex => {
   const nodes = new Map<number, PermissionTreeNode>();
   const parents = new Map<number, number>();
@@ -190,10 +210,7 @@ export default function RoleCapabilityTree({
   onChange,
 }: RoleCapabilityTreeProps) {
   const index = useMemo(() => buildIndex(tree), [tree]);
-  const treeData = useMemo(
-    () => (tree ? [buildTreeData(tree, [0])] : []),
-    [tree],
-  );
+  const treeData = useMemo(() => buildTreeForest(tree), [tree]);
   const normalizedCheckedKeys = useMemo(
     () => normalizeKeys(checkedKeys, index),
     [checkedKeys, index],

--- a/yak-ops-ui/src/pages/system/roles/components/RoleCapabilityTree.tsx
+++ b/yak-ops-ui/src/pages/system/roles/components/RoleCapabilityTree.tsx
@@ -1,0 +1,269 @@
+import { Alert, Empty, Tree } from 'antd';
+import type { DataNode } from 'antd/es/tree';
+import type { Key, ReactNode } from 'react';
+import { useMemo } from 'react';
+
+import type {
+  PermissionNodeType,
+  PermissionTreeNode,
+} from '@/services/security/roles';
+
+interface CapabilityDataNode extends DataNode {
+  key: Key;
+  nodeType?: PermissionNodeType;
+  active?: boolean;
+  children?: CapabilityDataNode[];
+}
+
+interface CapabilityIndex {
+  nodes: Map<number, PermissionTreeNode>;
+  parents: Map<number, number>;
+  descendants: Map<number, number[]>;
+  selectableKeys: Set<number>;
+}
+
+interface RoleCapabilityTreeProps {
+  tree?: PermissionTreeNode;
+  checkedKeys: Key[];
+  loading?: boolean;
+  readOnly?: boolean;
+  onChange?: (keys: Key[]) => void;
+}
+
+const nodeKey = (
+  node: PermissionTreeNode,
+  path: number[],
+): number => {
+  const id = Number(node.id);
+  if (Number.isFinite(id)) return id;
+
+  return Number(`9${path.map((item) => item + 1).join('')}`);
+};
+
+const nodeTypeLabel: Record<PermissionNodeType, string> = {
+  ROOT: '根节点',
+  MENU_GROUP: '菜单目录',
+  MENU: '菜单',
+  PERMISSION_GROUP: '权限分组',
+  ACTION: '按钮',
+};
+
+const nodeTypeClass: Record<PermissionNodeType, string> = {
+  ROOT: 'border-slate-200 bg-slate-50 text-slate-500',
+  MENU_GROUP: 'border-slate-200 bg-slate-50 text-slate-500',
+  MENU: 'border-blue-100 bg-blue-50 text-blue-600',
+  PERMISSION_GROUP: 'border-slate-200 bg-slate-50 text-slate-500',
+  ACTION: 'border-violet-100 bg-violet-50 text-violet-600',
+};
+
+const titleOf = (node: PermissionTreeNode): ReactNode => {
+  const type = node.nodeType ?? 'ACTION';
+  const name =
+    node.permissionName || node.permissionCode || '未命名权限';
+
+  return (
+    <div
+      className={[
+        'flex min-w-0 items-center gap-2 py-0.5',
+        node.active === false ? 'text-slate-400' : 'text-slate-700',
+      ].join(' ')}
+      title={node.description}
+    >
+      <span className="truncate">{name}</span>
+      <span
+        className={[
+          'shrink-0 rounded border px-1.5 py-0.5 text-[10px] leading-4',
+          nodeTypeClass[type],
+        ].join(' ')}
+      >
+        {nodeTypeLabel[type]}
+      </span>
+      {node.permissionCode && type === 'ACTION' && (
+        <span className="truncate font-mono text-xs text-slate-400">
+          {node.permissionCode}
+        </span>
+      )}
+    </div>
+  );
+};
+
+const isSelectable = (node?: PermissionTreeNode): boolean =>
+  Boolean(
+    node &&
+      node.active !== false &&
+      (node.nodeType === 'MENU' || node.nodeType === 'ACTION'),
+  );
+
+const buildTreeData = (
+  node: PermissionTreeNode,
+  path: number[],
+): CapabilityDataNode => {
+  const key = nodeKey(node, path);
+  const selectable = isSelectable(node);
+  const children = Array.isArray(node.childList)
+    ? node.childList.map((child, index) =>
+        buildTreeData(child, [...path, index]),
+      )
+    : [];
+
+  return {
+    key,
+    title: titleOf(node),
+    nodeType: node.nodeType,
+    active: node.active,
+    disabled: node.active === false,
+    disableCheckbox: !selectable,
+    selectable: false,
+    ...(children.length ? { children } : {}),
+  };
+};
+
+const buildIndex = (tree?: PermissionTreeNode): CapabilityIndex => {
+  const nodes = new Map<number, PermissionTreeNode>();
+  const parents = new Map<number, number>();
+  const descendants = new Map<number, number[]>();
+  const selectableKeys = new Set<number>();
+
+  const visit = (
+    node: PermissionTreeNode,
+    path: number[],
+    parentKey?: number,
+  ): number[] => {
+    const key = nodeKey(node, path);
+    nodes.set(key, node);
+    if (parentKey !== undefined) parents.set(key, parentKey);
+    if (isSelectable(node)) selectableKeys.add(key);
+
+    const childKeys = (node.childList ?? []).flatMap((child, index) =>
+      visit(child, [...path, index], key),
+    );
+    descendants.set(key, childKeys);
+    return [key, ...childKeys];
+  };
+
+  if (tree) visit(tree, [0]);
+  return { nodes, parents, descendants, selectableKeys };
+};
+
+const normalizeKeys = (
+  keys: Iterable<Key>,
+  index: CapabilityIndex,
+): Key[] => {
+  const result = new Set<number>();
+
+  for (const value of keys) {
+    const key = Number(value);
+    if (!Number.isFinite(key) || !index.selectableKeys.has(key)) {
+      continue;
+    }
+    result.add(key);
+
+    let parent = index.parents.get(key);
+    while (parent !== undefined) {
+      const parentNode = index.nodes.get(parent);
+      if (parentNode?.nodeType === 'MENU') result.add(parent);
+      parent = index.parents.get(parent);
+    }
+  }
+
+  return Array.from(result);
+};
+
+export const collectCapabilityCheckedKeys = (
+  tree?: PermissionTreeNode,
+): Key[] => {
+  const index = buildIndex(tree);
+  const keys: Key[] = [];
+
+  index.nodes.forEach((node, key) => {
+    if (node.has && index.selectableKeys.has(key)) keys.push(key);
+  });
+
+  return normalizeKeys(keys, index);
+};
+
+export default function RoleCapabilityTree({
+  tree,
+  checkedKeys,
+  loading = false,
+  readOnly = false,
+  onChange,
+}: RoleCapabilityTreeProps) {
+  const index = useMemo(() => buildIndex(tree), [tree]);
+  const treeData = useMemo(
+    () => (tree ? [buildTreeData(tree, [0])] : []),
+    [tree],
+  );
+  const normalizedCheckedKeys = useMemo(
+    () => normalizeKeys(checkedKeys, index),
+    [checkedKeys, index],
+  );
+
+  if (!loading && treeData.length === 0) {
+    return (
+      <Empty
+        image={Empty.PRESENTED_IMAGE_SIMPLE}
+        description="暂无可配置权限"
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {!readOnly && (
+        <Alert
+          type="info"
+          showIcon
+          message="菜单权限与按钮权限独立"
+          description="菜单只控制页面访问；勾选按钮会自动勾选所属菜单和父级目录。取消菜单时，会同时清除该菜单下的按钮权限。"
+        />
+      )}
+
+      <div className="min-h-48 rounded-lg border border-slate-200 bg-slate-50/40 p-3">
+        <Tree<CapabilityDataNode>
+          checkable
+          checkStrictly
+          selectable={false}
+          defaultExpandAll
+          disabled={readOnly}
+          checkedKeys={normalizedCheckedKeys}
+          treeData={treeData}
+          onCheck={(_, info) => {
+            if (readOnly || !onChange) return;
+
+            const key = Number(info.node.key);
+            if (!Number.isFinite(key)) return;
+
+            const next = new Set<number>(
+              normalizedCheckedKeys.map((value) => Number(value)),
+            );
+            const node = index.nodes.get(key);
+
+            if (info.checked) {
+              if (index.selectableKeys.has(key)) next.add(key);
+
+              let parent = index.parents.get(key);
+              while (parent !== undefined) {
+                if (index.nodes.get(parent)?.nodeType === 'MENU') {
+                  next.add(parent);
+                }
+                parent = index.parents.get(parent);
+              }
+            } else {
+              next.delete(key);
+
+              if (node?.nodeType === 'MENU') {
+                for (const descendant of
+                  index.descendants.get(key) ?? []) {
+                  next.delete(descendant);
+                }
+              }
+            }
+
+            onChange(normalizeKeys(next, index));
+          }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/yak-ops-ui/src/pages/system/roles/index.tsx
+++ b/yak-ops-ui/src/pages/system/roles/index.tsx
@@ -26,32 +26,27 @@ import {
   Spin,
   Tag,
   Tooltip,
-  Tree,
   Typography,
   message,
   type MenuProps,
 } from 'antd';
 import dayjs from 'dayjs';
 import {
-  type Key,
-  type ReactNode,
   useCallback,
   useEffect,
   useMemo,
   useRef,
   useState,
+  type Key,
 } from 'react';
 
 import {
-  PermissionGuard,
   SecurityPagination,
   SecurityQueryTable,
 } from '@/components/security';
+import { SECURITY_PERMISSIONS } from '@/constants/securityPermissions';
+import { usePermissionAccess } from '@/hooks/usePermissionAccess';
 import {
-  type PermissionTreeNode,
-  type RoleAssignmentInfo,
-  type RoleInput,
-  type SystemRole,
   assignUsersToRole,
   checkRoleBeforeDelete,
   createRole,
@@ -61,7 +56,15 @@ import {
   getRoleUserAssignments,
   pageRoles,
   updateRole,
+  type PermissionTreeNode,
+  type RoleAssignmentInfo,
+  type RoleInput,
+  type SystemRole,
 } from '@/services/security/roles';
+
+import RoleCapabilityTree, {
+  collectCapabilityCheckedKeys,
+} from './components/RoleCapabilityTree';
 
 interface RolePaginationState {
   current: number;
@@ -81,14 +84,6 @@ type RoleSearchField =
   | 'roleCode'
   | 'description'
   | 'id';
-
-interface PermissionTreeDataNode {
-  key: Key;
-  title: ReactNode;
-  children?: PermissionTreeDataNode[];
-  disabled?: boolean;
-  disableCheckbox?: boolean;
-}
 
 const DEFAULT_PAGINATION: RolePaginationState = {
   current: 1,
@@ -123,103 +118,11 @@ const errorText = (error: unknown, fallback: string): string =>
 
 const formatDateTime = (value?: string): string => {
   if (!value) return '-';
-
   const date = dayjs(value);
   return date.isValid()
     ? date.format('YYYY-MM-DD HH:mm:ss')
     : value;
 };
-
-const rolePermission = (action: string): string =>
-  `security:role:${action}`;
-
-const permissionNodeKey = (
-  node: PermissionTreeNode,
-  path: number[],
-): Key => {
-  const id = Number(node.id);
-  return Number.isFinite(id)
-    ? id
-    : `permission-${path.join('-')}`;
-};
-
-const toPermissionTreeNode = (
-  node: PermissionTreeNode,
-  path: number[],
-): PermissionTreeDataNode => {
-  const children = Array.isArray(node.childList)
-    ? node.childList.map((child, index) =>
-        toPermissionTreeNode(child, [...path, index]),
-      )
-    : [];
-
-  return {
-    key: permissionNodeKey(node, path),
-    disabled: node.active === false,
-    disableCheckbox: node.active === false,
-    title: (
-      <span
-        className={
-          node.active === false
-            ? 'text-slate-400'
-            : 'text-slate-700'
-        }
-        title={node.description}
-      >
-        {node.permissionName || node.permissionCode || '未命名权限'}
-        {node.permissionCode &&
-          node.permissionCode !== node.permissionName && (
-            <span className="ml-2 text-xs text-slate-400">
-              {node.permissionCode}
-            </span>
-          )}
-      </span>
-    ),
-    ...(children.length ? { children } : {}),
-  };
-};
-
-const toPermissionTreeData = (
-  tree?: PermissionTreeNode,
-): PermissionTreeDataNode[] => {
-  if (!tree) return [];
-
-  const hasRoot =
-    Number.isFinite(Number(tree.id)) ||
-    Boolean(tree.permissionName) ||
-    Boolean(tree.permissionCode);
-
-  if (!hasRoot) {
-    return tree.childList?.map((node, index) =>
-      toPermissionTreeNode(node, [index]),
-    ) ?? [];
-  }
-
-  return [toPermissionTreeNode(tree, [0])];
-};
-
-const collectCheckedKeys = (
-  tree?: PermissionTreeNode,
-): Key[] => {
-  const keys: Key[] = [];
-
-  const visit = (node?: PermissionTreeNode) => {
-    if (!node) return;
-
-    const id = Number(node.id);
-    if (node.has && Number.isFinite(id)) keys.push(id);
-    node.childList?.forEach(visit);
-  };
-
-  visit(tree);
-  return keys;
-};
-
-const unwrapCheckedKeys = (
-  value:
-    | Key[]
-    | { checked: Key[]; halfChecked: Key[] },
-): Key[] => (Array.isArray(value) ? value : value.checked);
 
 const checkedKeysToIds = (keys: Key[]): number[] =>
   Array.from(
@@ -243,6 +146,7 @@ function RoleFilterBar({
   onRefresh,
   onCreate,
 }: RoleFilterBarProps) {
+  const { can } = usePermissionAccess();
   const [field, setField] =
     useState<RoleSearchField>('roleName');
   const [keyword, setKeyword] = useState('');
@@ -253,19 +157,17 @@ function RoleFilterBar({
   ): RoleFilterValues => {
     const value = cleanText(nextKeyword);
     if (!value) return {};
-
     if (nextField === 'id') {
       const id = Number(value);
       return Number.isInteger(id) && id > 0 ? { id } : {};
     }
-
     return { [nextField]: value } as RoleFilterValues;
   };
 
   return (
     <div className="mb-4 flex min-w-0 flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
-      <div className="flex min-w-0 items-center gap-2 overflow-x-auto pb-1 lg:pb-0">
-        <div className="cursor-default rounded bg-[#f2f2f4] px-3 py-1 text-sm font-medium leading-5 text-[#FE2C55]">
+      <div className="flex min-w-0 items-center gap-2">
+        <div className="rounded bg-[#f2f2f4] px-3 py-1 text-sm font-medium leading-5 text-[#FE2C55]">
           全部角色
           <span className="ml-1 text-xs text-slate-400">
             {total}
@@ -296,7 +198,7 @@ function RoleFilterBar({
             placeholder={SEARCH_PLACEHOLDERS[field]}
             suffix={
               <SearchOutlined
-                className="cursor-pointer text-slate-400 transition-colors hover:text-slate-700"
+                className="cursor-pointer text-slate-400 hover:text-slate-700"
                 onClick={() => onSearch(buildFilters())}
               />
             }
@@ -314,18 +216,15 @@ function RoleFilterBar({
           <Button icon={<ReloadOutlined />} onClick={onRefresh} />
         </Tooltip>
 
-        <PermissionGuard
-          mode="one"
-          permission={rolePermission('create')}
-        >
+        {can(SECURITY_PERMISSIONS.role.create) && (
           <Button
             type="primary"
-            danger
+            icon={<PlusOutlined />}
             onClick={onCreate}
           >
             新增角色
           </Button>
-        </PermissionGuard>
+        )}
       </div>
     </div>
   );
@@ -351,8 +250,7 @@ function RoleEditorDrawer({
 }: RoleEditorDrawerProps) {
   const [form] = Form.useForm<RoleFormValues>();
   const [detail, setDetail] = useState<SystemRole>();
-  const [permissionTree, setPermissionTree] =
-    useState<PermissionTreeNode>();
+  const [tree, setTree] = useState<PermissionTreeNode>();
   const [checkedKeys, setCheckedKeys] = useState<Key[]>([]);
   const [loading, setLoading] = useState(false);
   const [saving, setSaving] = useState(false);
@@ -362,7 +260,7 @@ function RoleEditorDrawer({
 
     let active = true;
     setDetail(undefined);
-    setPermissionTree(undefined);
+    setTree(undefined);
     setCheckedKeys([]);
     form.resetFields();
     form.setFieldsValue({ roleName: '', description: '' });
@@ -370,22 +268,23 @@ function RoleEditorDrawer({
 
     const load = async () => {
       try {
-        if (role) {
-          const value = await getRoleDetail(role.id);
-          if (!active) return;
+        const value = role
+          ? await getRoleDetail(role.id)
+          : undefined;
+        const permissionTree = value?.permissionTreeVO
+          ?? await getPermissionTree();
+        if (!active) return;
 
-          setDetail(value);
-          setPermissionTree(value.permissionTreeVO);
-          setCheckedKeys(
-            collectCheckedKeys(value.permissionTreeVO),
-          );
+        setDetail(value);
+        setTree(permissionTree);
+        setCheckedKeys(
+          collectCapabilityCheckedKeys(permissionTree),
+        );
+        if (value) {
           form.setFieldsValue({
             roleName: value.roleName,
             description: value.description ?? '',
           });
-        } else {
-          const tree = await getPermissionTree();
-          if (active) setPermissionTree(tree);
         }
       } catch (error) {
         if (active) {
@@ -442,16 +341,11 @@ function RoleEditorDrawer({
     }
   };
 
-  const treeData = useMemo(
-    () => toPermissionTreeData(permissionTree),
-    [permissionTree],
-  );
-
   return (
     <Drawer
       open={open}
       title={role ? '编辑角色' : '新增角色'}
-      width={620}
+      width={720}
       forceRender
       maskClosable={false}
       keyboard={!saving}
@@ -507,28 +401,15 @@ function RoleEditorDrawer({
           />
         </Form.Item>
 
-        <Form.Item label="权限配置">
-          <div className="min-h-48 rounded-lg border border-slate-200 bg-slate-50/40 p-3">
-            <Spin spinning={loading}>
-              {!loading && treeData.length === 0 ? (
-                <Empty
-                  image={Empty.PRESENTED_IMAGE_SIMPLE}
-                  description="暂无可配置权限"
-                />
-              ) : (
-                <Tree
-                  checkable
-                  selectable={false}
-                  defaultExpandAll
-                  checkedKeys={checkedKeys}
-                  treeData={treeData}
-                  onCheck={(value) =>
-                    setCheckedKeys(unwrapCheckedKeys(value))
-                  }
-                />
-              )}
-            </Spin>
-          </div>
+        <Form.Item label="菜单与按钮权限">
+          <Spin spinning={loading}>
+            <RoleCapabilityTree
+              tree={tree}
+              checkedKeys={checkedKeys}
+              loading={loading}
+              onChange={setCheckedKeys}
+            />
+          </Spin>
         </Form.Item>
       </Form>
     </Drawer>
@@ -551,7 +432,6 @@ function RoleDetailDrawer({
 
   useEffect(() => {
     if (!open || !role) return;
-
     let active = true;
     setDetail(role);
     setLoading(true);
@@ -574,14 +454,6 @@ function RoleDetailDrawer({
     };
   }, [open, role]);
 
-  const treeData = useMemo(
-    () => toPermissionTreeData(detail?.permissionTreeVO),
-    [detail?.permissionTreeVO],
-  );
-  const checkedKeys = useMemo(
-    () => collectCheckedKeys(detail?.permissionTreeVO),
-    [detail?.permissionTreeVO],
-  );
   const users = Array.isArray(detail?.authedUsers)
     ? detail.authedUsers
     : [];
@@ -590,7 +462,7 @@ function RoleDetailDrawer({
     <Drawer
       open={open}
       title="角色详情"
-      width={620}
+      width={720}
       onClose={onClose}
     >
       <Spin spinning={loading}>
@@ -626,11 +498,6 @@ function RoleDetailDrawer({
                   children: detail.description || '暂无描述',
                 },
                 {
-                  key: 'lastReviser',
-                  label: '最后修改人',
-                  children: detail.lastReviser || '-',
-                },
-                {
                   key: 'createTime',
                   label: '创建时间',
                   children: formatDateTime(detail.createTime),
@@ -645,10 +512,7 @@ function RoleDetailDrawer({
 
             <div>
               <div className="mb-2 font-medium text-slate-800">
-                已授权用户
-                <span className="ml-2 text-xs font-normal text-slate-400">
-                  {detail.authedUserCnt ?? users.length} 人
-                </span>
+                授权用户
               </div>
               <div className="rounded-lg border border-slate-200 bg-white p-3">
                 {users.length === 0 ? (
@@ -667,25 +531,15 @@ function RoleDetailDrawer({
 
             <div>
               <div className="mb-2 font-medium text-slate-800">
-                权限明细
+                菜单与按钮权限
               </div>
-              <div className="min-h-40 rounded-lg border border-slate-200 bg-slate-50/40 p-3">
-                {treeData.length === 0 ? (
-                  <Empty
-                    image={Empty.PRESENTED_IMAGE_SIMPLE}
-                    description="暂无权限"
-                  />
-                ) : (
-                  <Tree
-                    checkable
-                    selectable={false}
-                    defaultExpandAll
-                    disabled
-                    checkedKeys={checkedKeys}
-                    treeData={treeData}
-                  />
+              <RoleCapabilityTree
+                tree={detail.permissionTreeVO}
+                checkedKeys={collectCapabilityCheckedKeys(
+                  detail.permissionTreeVO,
                 )}
-              </div>
+                readOnly
+              />
             </div>
           </div>
         )}
@@ -717,7 +571,6 @@ function RoleUserAssignmentDrawer({
 
   useEffect(() => {
     if (!open || !role) return;
-
     let active = true;
     setAssignments([]);
     setSelectedIds([]);
@@ -727,7 +580,6 @@ function RoleUserAssignmentDrawer({
     void getRoleUserAssignments(role.id)
       .then((values) => {
         if (!active) return;
-
         const data = Array.isArray(values) ? values : [];
         setAssignments(data);
         setSelectedIds(
@@ -756,7 +608,6 @@ function RoleUserAssignmentDrawer({
   const visibleAssignments = useMemo(() => {
     const value = keyword.trim().toLowerCase();
     if (!value) return assignments;
-
     return assignments.filter((item) =>
       item.name.toLowerCase().includes(value),
     );
@@ -765,7 +616,6 @@ function RoleUserAssignmentDrawer({
   const save = async () => {
     if (!role || loading || saving) return;
     setSaving(true);
-
     try {
       await assignUsersToRole(role.id, selectedIds);
       message.success('角色用户已更新');
@@ -783,10 +633,7 @@ function RoleUserAssignmentDrawer({
       open={open}
       title="分配用户"
       width={560}
-      forceRender
       maskClosable={false}
-      keyboard={!saving}
-      closable={!saving}
       onClose={onClose}
       extra={
         <Space>
@@ -804,18 +651,6 @@ function RoleUserAssignmentDrawer({
         </Space>
       }
     >
-      {role && (
-        <div className="mb-4 rounded-lg border border-slate-200 bg-slate-50 px-4 py-3">
-          <div className="text-xs text-slate-500">当前角色</div>
-          <div className="mt-1 font-medium text-slate-900">
-            {role.roleName}
-          </div>
-          <div className="mt-0.5 text-xs text-slate-400">
-            {role.roleCode || `ID ${role.id}`}
-          </div>
-        </div>
-      )}
-
       <Input
         allowClear
         value={keyword}
@@ -829,30 +664,19 @@ function RoleUserAssignmentDrawer({
         {!loading && visibleAssignments.length === 0 ? (
           <Empty
             image={Empty.PRESENTED_IMAGE_SIMPLE}
-            description={
-              assignments.length === 0
-                ? '暂无可分配用户'
-                : '没有匹配的用户'
-            }
+            description="暂无可分配用户"
           />
         ) : (
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
             {visibleAssignments.map((item) => {
               const userId = Number(item.id);
               const checked = selectedIds.includes(userId);
-
               return (
                 <Checkbox
                   key={item.id}
                   checked={checked}
                   disabled={saving}
-                  className={[
-                    'm-0 flex min-h-12 items-center rounded-lg border px-4 py-3',
-                    'transition-colors duration-200',
-                    checked
-                      ? 'border-primary bg-primary/5'
-                      : 'border-slate-200 bg-white hover:border-slate-300',
-                  ].join(' ')}
+                  className="m-0 flex min-h-12 items-center rounded-lg border border-slate-200 bg-white px-4 py-3"
                   onChange={(event) => {
                     setSelectedIds((current) =>
                       event.target.checked
@@ -887,19 +711,36 @@ function RoleRowActions({
   onAssignUsers,
   onDelete,
 }: RoleRowActionsProps) {
+  const { can, canAny } = usePermissionAccess();
+  const canUpdate = can(SECURITY_PERMISSIONS.role.update);
+  const canAssign = can(SECURITY_PERMISSIONS.role.assign);
+  const canDelete = can(SECURITY_PERMISSIONS.role.delete);
+  const hasMore = canAny([
+    SECURITY_PERMISSIONS.role.assign,
+    SECURITY_PERMISSIONS.role.delete,
+  ]);
+
   const items: MenuProps['items'] = [
-    {
-      key: 'assignUsers',
-      icon: <TeamOutlined />,
-      label: '分配用户',
-    },
-    { type: 'divider' },
-    {
-      key: 'delete',
-      icon: <DeleteOutlined />,
-      label: '删除角色',
-      danger: true,
-    },
+    ...(canAssign
+      ? [
+          {
+            key: 'assignUsers',
+            icon: <TeamOutlined />,
+            label: '分配用户',
+          },
+        ]
+      : []),
+    ...(canAssign && canDelete ? [{ type: 'divider' as const }] : []),
+    ...(canDelete
+      ? [
+          {
+            key: 'delete',
+            icon: <DeleteOutlined />,
+            label: '删除角色',
+            danger: true,
+          },
+        ]
+      : []),
   ];
 
   return (
@@ -913,35 +754,41 @@ function RoleRowActions({
       >
         详情
       </Button>
-      <Button
-        type="link"
-        size="small"
-        icon={<EditOutlined />}
-        className="!px-1.5 !text-slate-600 hover:!text-slate-900"
-        onClick={() => onEdit(role)}
-      >
-        编辑
-      </Button>
-      <Dropdown
-        trigger={['click']}
-        placement="bottomRight"
-        menu={{
-          items,
-          onClick: ({ key }) => {
-            if (key === 'assignUsers') onAssignUsers(role);
-            if (key === 'delete') onDelete(role);
-          },
-        }}
-      >
+
+      {canUpdate && (
         <Button
           type="link"
           size="small"
+          icon={<EditOutlined />}
           className="!px-1.5 !text-slate-600 hover:!text-slate-900"
+          onClick={() => onEdit(role)}
         >
-          更多
-          <DownOutlined className="ml-1 text-[10px]" />
+          编辑
         </Button>
-      </Dropdown>
+      )}
+
+      {hasMore && (
+        <Dropdown
+          trigger={['click']}
+          placement="bottomRight"
+          menu={{
+            items,
+            onClick: ({ key }) => {
+              if (key === 'assignUsers') onAssignUsers(role);
+              if (key === 'delete') onDelete(role);
+            },
+          }}
+        >
+          <Button
+            type="link"
+            size="small"
+            className="!px-1.5 !text-slate-600 hover:!text-slate-900"
+          >
+            更多
+            <DownOutlined className="ml-1 text-[10px]" />
+          </Button>
+        </Dropdown>
+      )}
     </Space>
   );
 }
@@ -966,16 +813,13 @@ export default function RolesPage() {
   const loadRoles = useCallback(async () => {
     const sequence = ++requestSequenceRef.current;
     setLoading(true);
-
     try {
       const result = await pageRoles({
         pageNum: pagination.current,
         pageSize: pagination.pageSize,
         ...filters,
       });
-
       if (sequence !== requestSequenceRef.current) return;
-
       setRoles(result.records ?? []);
       setPagination((current) => ({
         ...current,
@@ -999,23 +843,6 @@ export default function RolesPage() {
   const reload = useCallback(() => {
     void loadRoles();
   }, [loadRoles]);
-
-  const handleSearch = useCallback((values: RoleFilterValues) => {
-    setFilters(values);
-    setPagination((current) => ({ ...current, current: 1 }));
-  }, []);
-
-  const handlePageChange = useCallback(
-    (current: number, pageSize: number) => {
-      setPagination((previous) => ({
-        ...previous,
-        current:
-          previous.pageSize === pageSize ? current : 1,
-        pageSize,
-      }));
-    },
-    [],
-  );
 
   const confirmDelete = useCallback(
     async (role: SystemRole) => {
@@ -1043,28 +870,15 @@ export default function RolesPage() {
               </div>
               {users.length > 0 && (
                 <div className="rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800">
-                  当前角色已关联 {users.length} 个用户，删除后会同步解除关联：
-                  <div className="mt-2 flex flex-wrap gap-1">
-                    {users.slice(0, 8).map((userName) => (
-                      <Tag key={userName}>{userName}</Tag>
-                    ))}
-                    {users.length > 8 && (
-                      <Tag>+{users.length - 8}</Tag>
-                    )}
-                  </div>
+                  当前角色已关联 {users.length} 个用户，删除后会同步解除关联。
                 </div>
               )}
             </div>
           ),
           onOk: async () => {
-            try {
-              await deleteRole(role.id);
-              message.success('角色已删除');
-              reload();
-            } catch (error) {
-              message.error(errorText(error, '角色删除失败'));
-              throw error;
-            }
+            await deleteRole(role.id);
+            message.success('角色已删除');
+            reload();
           },
         });
       } catch (error) {
@@ -1097,9 +911,7 @@ export default function RolesPage() {
                 {role.roleName}
               </Typography.Text>
               <div className="mt-1 truncate text-xs text-slate-500">
-                {role.roleCode || '暂无编码'}
-                <span className="mx-1 text-slate-300">·</span>
-                ID {role.id}
+                {role.roleCode || '暂无编码'} · ID {role.id}
               </div>
             </div>
           </div>
@@ -1122,45 +934,17 @@ export default function RolesPage() {
       {
         title: '授权用户',
         key: 'authedUsers',
-        width: 260,
-        render: (_, role) => {
-          const users = Array.isArray(role.authedUsers)
-            ? role.authedUsers
-            : [];
-          const visible = users.slice(0, 2);
-          const remaining = users.length - visible.length;
-
-          return (
-            <div>
-              <div className="text-sm font-medium text-slate-700">
-                {role.authedUserCnt ?? users.length} 人
-              </div>
-              <div className="mt-1 min-h-5">
-                {visible.length === 0 ? (
-                  <span className="text-xs text-slate-400">
-                    暂无授权用户
-                  </span>
-                ) : (
-                  <Space size={[4, 4]} wrap>
-                    {visible.map((userName) => (
-                      <Tag
-                        key={userName}
-                        className="!m-0 !border-slate-200 !bg-slate-50 !text-slate-600"
-                      >
-                        {userName}
-                      </Tag>
-                    ))}
-                    {remaining > 0 && (
-                      <Tag className="!m-0 !border-slate-200 !bg-slate-50 !text-slate-600">
-                        +{remaining}
-                      </Tag>
-                    )}
-                  </Space>
-                )}
-              </div>
+        width: 240,
+        render: (_, role) => (
+          <div>
+            <div className="text-sm font-medium text-slate-700">
+              {role.authedUserCnt ?? role.authedUsers?.length ?? 0} 人
             </div>
-          );
-        },
+            <div className="mt-1 text-xs text-slate-400">
+              {role.authedUsers?.slice(0, 2).join('、') || '暂无授权用户'}
+            </div>
+          </div>
+        ),
       },
       {
         title: '最近更新',
@@ -1183,7 +967,7 @@ export default function RolesPage() {
         title: '操作',
         key: 'action',
         fixed: 'right',
-        width: 180,
+        width: 190,
         align: 'center',
         render: (_, role) => (
           <RoleRowActions
@@ -1226,7 +1010,13 @@ export default function RolesPage() {
 
         <RoleFilterBar
           total={pagination.total}
-          onSearch={handleSearch}
+          onSearch={(values) => {
+            setFilters(values);
+            setPagination((current) => ({
+              ...current,
+              current: 1,
+            }));
+          }}
           onRefresh={reload}
           onCreate={() => {
             setEditingRole(undefined);
@@ -1252,7 +1042,13 @@ export default function RolesPage() {
         pageSize={pagination.pageSize}
         total={pagination.total}
         disabled={loading}
-        onChange={handlePageChange}
+        onChange={(current, pageSize) => {
+          setPagination((previous) => ({
+            ...previous,
+            current: previous.pageSize === pageSize ? current : 1,
+            pageSize,
+          }));
+        }}
       />
 
       <RoleEditorDrawer
@@ -1264,6 +1060,7 @@ export default function RolesPage() {
         }}
         onSuccess={reload}
       />
+
       <RoleDetailDrawer
         open={detailOpen}
         role={detailRole}
@@ -1272,6 +1069,7 @@ export default function RolesPage() {
           setDetailRole(undefined);
         }}
       />
+
       <RoleUserAssignmentDrawer
         open={assignmentOpen}
         role={assignmentRole}

--- a/yak-ops-ui/src/services/security/roles.ts
+++ b/yak-ops-ui/src/services/security/roles.ts
@@ -8,6 +8,13 @@ import {
 const ROLE_API = '/api/v1/role';
 const PERMISSION_API = '/api/v1/permission';
 
+export type PermissionNodeType =
+  | 'ROOT'
+  | 'MENU_GROUP'
+  | 'MENU'
+  | 'PERMISSION_GROUP'
+  | 'ACTION';
+
 export interface PermissionTreeNode {
   id?: number;
   has?: boolean;
@@ -18,6 +25,8 @@ export interface PermissionTreeNode {
   description?: string;
   active?: boolean;
   declared?: boolean;
+  menuCode?: string;
+  nodeType?: PermissionNodeType;
   childList?: PermissionTreeNode[];
 }
 


### PR DESCRIPTION
## 背景

角色管理当前把菜单权限和普通权限作为两个平级分组展示，无法直观看出某个按钮属于哪个菜单，也没有在交互上体现“按钮权限包含菜单权限”的规则。

本 PR 配合 `weifuwan/yak-framework#72`，将前端角色授权改成统一能力树，并补齐 Yak Ops 业务权限与菜单的映射。

## 权限模型

采用单向包含关系：

- 菜单权限只控制页面访问；
- 按钮权限控制新增、编辑、删除、执行等页面内操作；
- 勾选按钮会自动勾选所属菜单和父级目录；
- 勾选菜单不会自动获得任何按钮；
- 取消菜单会同步清除该菜单下的按钮权限；
- 后端仍会重新推导并校正菜单关系，前端不是安全边界。

## 前端展示

新增 `RoleCapabilityTree`，将后端能力树显示为：

```text
系统管理
  用户管理        [菜单]
    新增用户      [按钮]
    编辑用户      [按钮]
    重置密码      [按钮]
    删除用户      [按钮]
```

主要交互：

- 菜单和按钮使用不同标签；
- 虚拟根节点不展示；
- 使用 Ant Design Tree 的 `checkStrictly`，避免默认父子全选破坏权限语义；
- 按钮选中时前端立即补齐菜单；
- 菜单单独选中时不会选中按钮；
- 菜单取消时清除全部子按钮；
- 角色详情也使用相同树展示，只读状态下可以清楚查看菜单和按钮范围。

## 角色页面按钮权限

角色管理页面同时统一接入已有的 `usePermissionAccess` 和 `SECURITY_PERMISSIONS`：

- 新增角色：`security:role:create`；
- 编辑角色：`security:role:update`；
- 分配用户：`security:role:assign`；
- 删除角色：`security:role:delete`。

无对应权限时，不展示相关按钮或空的“更多”菜单。

## Yak Ops 业务映射

新增：

```text
V1300__link_yak_ops_permissions_to_menus.sql
```

负责将业务按钮绑定到稳定菜单编码，包括：

- 离线同步、实时同步；
- 工作流项目、定义、实例、调度和旧版兼容权限；
- 数据源、客户端、连接器；
- 质量规则和质量报告；
- 运行监控、告警管理；
- 知识管理。

迁移还会根据已有按钮权限回填角色菜单和父级目录，历史角色不需要手工重新授权。

## 接口模型

`PermissionTreeNode` 新增：

- `menuCode`；
- `nodeType`：ROOT、MENU_GROUP、MENU、PERMISSION_GROUP、ACTION。

角色保存接口保持不变，仍提交同一个 `permissionIdList`。

## 测试

新增测试覆盖：

- 按钮选中时自动包含菜单；
- 只选菜单时不会包含按钮；
- Yak Ops 业务权限迁移包含主要菜单映射；
- 业务迁移不包含 Yak Security 的系统菜单映射。

## 后端依赖

依赖 Draft PR：`weifuwan/yak-framework#72`

后端 PR 提供：

- `menu_code` 数据模型；
- 按钮反推菜单的保存约束；
- 登录态运行时兜底；
- “菜单 → 按钮”能力树结构；
- 声明式 `menuCode` 扩展。

建议先合并并发布框架 PR，再合并本 PR，或者确保二者作为同一版本组合交付。

## 验证说明

当前运行环境无法解析 GitHub 域名，无法本地克隆并执行前端或 Maven 构建。已完成 GitHub 文件级静态复核并补充测试，请以 PR CI 或本地执行结果为准：

```bash
cd yak-ops-ui
npm test -- RoleCapabilityTree

mvn -pl yak-ops-boot -am test
```