### PR TITLE
feat(workflow): complete task plugin lifecycle integration

### DIFF
--- a/docs/workflow-task-plugin-integration.md
+++ b/docs/workflow-task-plugin-integration.md
@@ -1,0 +1,68 @@
+# Workflow 与 Task Plugin 集成设计
+
+## 设计目标
+
+Yak Ops 借鉴 DolphinScheduler 的任务插件职责拆分，但保持当前单进程工作流引擎的轻量定位，不引入 Master、Worker 或注册中心。
+
+对应关系：
+
+| DolphinScheduler | Yak Ops | 职责 |
+| --- | --- | --- |
+| `TaskChannelFactory` | `WorkflowTaskPluginFactory` | 插件身份、元数据、配置校验和执行器创建 |
+| `TaskChannel` | `WorkflowTaskExecutorRegistry` | 插件发现、类型唯一性和运行时路由 |
+| `AbstractTask` | `WorkflowTaskExecutor` | 一次物理 Attempt 的执行与取消 |
+| `AbstractParameters` | 插件 `configurationSchema` 与 `validate` | 参数结构描述和发布期校验 |
+| `TaskExecutionContext` | `WorkflowTaskContext` | 工作流实例、任务实例、Attempt、参数、日志和取消信号 |
+
+## 生命周期
+
+```text
+应用启动
+  -> ServiceLoader 发现 WorkflowTaskPluginFactory
+  -> WorkflowTaskExecutorRegistry 建立插件目录
+
+设计器打开
+  -> GET /api/v1/workflows/task-plugins
+  -> 节点选择器合并后端插件目录
+  -> 未提供专属表单的插件使用通用 JSON 配置
+
+保存草稿
+  -> 保存 taskType + config
+
+发布工作流
+  -> WorkflowDagCompiler 校验 DAG
+  -> WorkflowTaskExecutorRegistry.validate(taskType, config)
+  -> 插件执行静态参数校验
+
+运行工作流
+  -> 每个物理 Attempt 调用 factory.create()
+  -> 创建独立 WorkflowTaskExecutor
+  -> 注入 WorkflowTaskContext
+  -> 执行、日志、取消、超时、重试和结果落库
+```
+
+## 参数命名空间
+
+任务插件统一从 `WorkflowTaskContext.parameters()` 读取参数：
+
+```text
+${name}                       兼容原有全局参数
+${global.name}                显式全局参数
+${system.workflowInstanceId}  工作流实例 ID
+${system.taskInstanceId}      任务实例 ID
+${system.attemptId}           物理尝试 ID
+${system.attemptNo}           当前尝试次数
+${system.nodeKey}             节点编码
+${system.taskType}            插件类型
+```
+
+## 插件扩展步骤
+
+1. 新建独立 Maven 模块，例如 `yak-ops-plugin-task-python`。
+2. 实现 `WorkflowTaskExecutor`，负责单次 Attempt 的执行和取消。
+3. 实现 `WorkflowTaskPluginFactory`，提供描述信息、配置 Schema 和执行器创建。
+4. 在 `META-INF/services/io.yak.ops.spi.workflow.WorkflowTaskPluginFactory` 声明 Factory。
+5. 将模块加入 `yak-ops-plugin-task-all`。
+6. 增加参数校验、执行、取消和 ServiceLoader 发现测试。
+
+工作流业务模块不得直接依赖具体任务插件。Boot 通过 `task-all` 完成最终装配。

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/controller/v1/WorkflowController.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/controller/v1/WorkflowController.java
@@ -12,13 +12,17 @@ import io.yak.ops.common.bean.dto.workflow.WorkflowUpdateDTO;
 import io.yak.ops.common.bean.vo.workflow.WorkflowDefinitionVO;
 import io.yak.ops.common.bean.vo.workflow.WorkflowInstanceVO;
 import io.yak.ops.common.bean.vo.workflow.WorkflowScheduleVO;
+import io.yak.ops.common.bean.vo.workflow.WorkflowTaskPluginVO;
 import io.yak.ops.common.bean.vo.workflow.WorkflowVersionVO;
 import io.yak.ops.common.constant.workflow.WorkflowConstant;
 import io.yak.ops.common.enums.workflow.TriggerType;
+import io.yak.ops.core.workflow.WorkflowTaskExecutorRegistry;
+import io.yak.ops.spi.workflow.WorkflowTaskPluginDescriptor;
 import jakarta.validation.Valid;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -41,6 +45,7 @@ public class WorkflowController {
   private final WorkflowDefinitionService definitionService;
   private final WorkflowExecutionService executionService;
   private final WorkflowScheduleService scheduleService;
+  private final WorkflowTaskExecutorRegistry taskPluginRegistry;
 
   @PostMapping
   public Result<Map<String, Long>> addWorkflow(
@@ -78,6 +83,14 @@ public class WorkflowController {
   @GetMapping
   public Result<List<WorkflowDefinitionVO>> getWorkflowList() {
     return Result.success(definitionService.getWorkflowList());
+  }
+
+  @GetMapping("/task-plugins")
+  public Result<List<WorkflowTaskPluginVO>> getTaskPluginList() {
+    List<WorkflowTaskPluginVO> plugins = taskPluginRegistry.descriptors().stream()
+        .map(WorkflowController::toTaskPluginVO)
+        .collect(Collectors.toList());
+    return Result.success(plugins);
   }
 
   @GetMapping("/{workflowId}")
@@ -126,5 +139,17 @@ public class WorkflowController {
   public Result<Boolean> deleteSchedule(@PathVariable Long workflowId) {
     scheduleService.delete(workflowId);
     return Result.success(true);
+  }
+
+  private static WorkflowTaskPluginVO toTaskPluginVO(WorkflowTaskPluginDescriptor descriptor) {
+    return new WorkflowTaskPluginVO(
+        descriptor.getType(),
+        descriptor.getName(),
+        descriptor.getDescription(),
+        descriptor.getCategory(),
+        descriptor.getVersion(),
+        descriptor.isCancellable(),
+        descriptor.isOutputCapable(),
+        descriptor.getConfigurationSchema());
   }
 }

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dag/WorkflowDagCompiler.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dag/WorkflowDagCompiler.java
@@ -112,7 +112,7 @@ public class WorkflowDagCompiler {
       throw new IllegalArgumentException("重试和超时时间不能为负数：" + node.getKey());
     }
     if (node.isEnabled()) {
-      executorRegistry.require(node.getType()).validate(node.getConfig());
+      executorRegistry.validate(node.getType(), node.getConfig());
     }
   }
 

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/vo/workflow/WorkflowTaskPluginVO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/vo/workflow/WorkflowTaskPluginVO.java
@@ -1,0 +1,71 @@
+package io.yak.ops.common.bean.vo.workflow;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/** 工作流任务插件目录信息。 */
+public final class WorkflowTaskPluginVO {
+
+  private final String type;
+  private final String name;
+  private final String description;
+  private final String category;
+  private final String version;
+  private final boolean cancellable;
+  private final boolean outputCapable;
+  private final Map<String, Object> configurationSchema;
+
+  public WorkflowTaskPluginVO(
+      String type,
+      String name,
+      String description,
+      String category,
+      String version,
+      boolean cancellable,
+      boolean outputCapable,
+      Map<String, Object> configurationSchema) {
+    this.type = type;
+    this.name = name;
+    this.description = description;
+    this.category = category;
+    this.version = version;
+    this.cancellable = cancellable;
+    this.outputCapable = outputCapable;
+    this.configurationSchema = configurationSchema == null || configurationSchema.isEmpty()
+        ? Map.of()
+        : Collections.unmodifiableMap(new LinkedHashMap<>(configurationSchema));
+  }
+
+  public String getType() {
+    return type;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public String getCategory() {
+    return category;
+  }
+
+  public String getVersion() {
+    return version;
+  }
+
+  public boolean isCancellable() {
+    return cancellable;
+  }
+
+  public boolean isOutputCapable() {
+    return outputCapable;
+  }
+
+  public Map<String, Object> getConfigurationSchema() {
+    return configurationSchema;
+  }
+}

--- a/yak-ops-core/src/main/java/io/yak/ops/core/workflow/WorkflowTaskExecutorRegistry.java
+++ b/yak-ops-core/src/main/java/io/yak/ops/core/workflow/WorkflowTaskExecutorRegistry.java
@@ -1,71 +1,118 @@
 package io.yak.ops.core.workflow;
 
 import io.yak.ops.spi.workflow.WorkflowTaskExecutor;
+import io.yak.ops.spi.workflow.WorkflowTaskPluginDescriptor;
+import io.yak.ops.spi.workflow.WorkflowTaskPluginFactory;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.ServiceLoader;
 import java.util.Set;
 
-/** Immutable task executor registry used by the workflow compiler and runtime. */
+/** Immutable task-plugin registry used by the workflow compiler and runtime. */
 public final class WorkflowTaskExecutorRegistry {
 
-  private final Map<String, WorkflowTaskExecutor> executors;
+  private final Map<String, WorkflowTaskPluginFactory> factories;
 
   public WorkflowTaskExecutorRegistry(Collection<WorkflowTaskExecutor> builtInExecutors) {
-    Map<String, WorkflowTaskExecutor> registered = new LinkedHashMap<>();
-    registerAll(registered, builtInExecutors);
+    Map<String, WorkflowTaskPluginFactory> registered = new LinkedHashMap<>();
+    registerLegacyExecutors(registered, builtInExecutors);
 
     ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
     ClassLoader pluginClassLoader = contextClassLoader == null
-        ? WorkflowTaskExecutor.class.getClassLoader()
+        ? WorkflowTaskPluginFactory.class.getClassLoader()
         : contextClassLoader;
-    ServiceLoader.load(WorkflowTaskExecutor.class, pluginClassLoader)
-        .forEach(executor -> register(registered, executor));
 
-    this.executors = Collections.unmodifiableMap(registered);
+    ServiceLoader.load(WorkflowTaskPluginFactory.class, pluginClassLoader)
+        .forEach(factory -> registerFactory(registered, factory));
+
+    // Keep compatibility with task plugins published before the factory contract was introduced.
+    ServiceLoader.load(WorkflowTaskExecutor.class, pluginClassLoader)
+        .forEach(executor -> registerLegacyExecutor(registered, executor));
+
+    this.factories = Collections.unmodifiableMap(registered);
   }
 
+  /** Creates one executor instance for a physical task attempt. */
   public WorkflowTaskExecutor require(String taskType) {
     String type = normalize(taskType);
-    WorkflowTaskExecutor executor = executors.get(type);
+    WorkflowTaskExecutor executor = requireFactory(type).create();
     if (executor == null) {
-      throw new IllegalArgumentException(
-          "No workflow task executor registered for type: " + type);
+      throw new IllegalStateException("Workflow task plugin returned a null executor: " + type);
+    }
+    String executorType = normalize(executor.type());
+    if (!type.equals(executorType)) {
+      throw new IllegalStateException(
+          "Workflow task plugin type mismatch: factory=" + type + ", executor=" + executorType);
     }
     return executor;
   }
 
+  public WorkflowTaskPluginFactory requireFactory(String taskType) {
+    String type = normalize(taskType);
+    WorkflowTaskPluginFactory factory = factories.get(type);
+    if (factory == null) {
+      throw new IllegalArgumentException(
+          "No workflow task plugin registered for type: " + type);
+    }
+    return factory;
+  }
+
+  public void validate(String taskType, Map<String, Object> configuration) {
+    requireFactory(taskType).validate(configuration);
+  }
+
+  public WorkflowTaskPluginDescriptor descriptor(String taskType) {
+    return requireFactory(taskType).descriptor();
+  }
+
+  public List<WorkflowTaskPluginDescriptor> descriptors() {
+    List<WorkflowTaskPluginDescriptor> result = new ArrayList<>(factories.size());
+    factories.values().forEach(factory -> result.add(factory.descriptor()));
+    return Collections.unmodifiableList(result);
+  }
+
   public boolean contains(String taskType) {
-    return executors.containsKey(normalize(taskType));
+    return factories.containsKey(normalize(taskType));
   }
 
   public Set<String> types() {
-    return executors.keySet();
+    return factories.keySet();
   }
 
-  private static void registerAll(
-      Map<String, WorkflowTaskExecutor> registered,
+  private static void registerLegacyExecutors(
+      Map<String, WorkflowTaskPluginFactory> registered,
       Collection<WorkflowTaskExecutor> executors) {
     if (executors == null) {
       return;
     }
     for (WorkflowTaskExecutor executor : executors) {
-      register(registered, executor);
+      registerLegacyExecutor(registered, executor);
     }
   }
 
-  private static void register(
-      Map<String, WorkflowTaskExecutor> registered,
+  private static void registerLegacyExecutor(
+      Map<String, WorkflowTaskPluginFactory> registered,
       WorkflowTaskExecutor executor) {
     Objects.requireNonNull(executor, "taskExecutor");
     String type = normalize(executor.type());
-    WorkflowTaskExecutor previous = registered.putIfAbsent(type, executor);
+    registerFactory(registered, new LegacyWorkflowTaskPluginFactory(type, executor));
+  }
+
+  private static void registerFactory(
+      Map<String, WorkflowTaskPluginFactory> registered,
+      WorkflowTaskPluginFactory factory) {
+    Objects.requireNonNull(factory, "taskPluginFactory");
+    Objects.requireNonNull(factory.descriptor(), "taskPluginDescriptor");
+    String type = normalize(factory.type());
+    WorkflowTaskPluginFactory previous = registered.putIfAbsent(type, factory);
     if (previous != null) {
-      throw new IllegalStateException("Duplicate workflow task executor type: " + type);
+      throw new IllegalStateException("Duplicate workflow task plugin type: " + type);
     }
   }
 
@@ -74,5 +121,40 @@ public final class WorkflowTaskExecutorRegistry {
       throw new IllegalArgumentException("Workflow task type must not be blank");
     }
     return taskType.trim().toUpperCase(Locale.ROOT);
+  }
+
+  private static final class LegacyWorkflowTaskPluginFactory
+      implements WorkflowTaskPluginFactory {
+
+    private final WorkflowTaskPluginDescriptor descriptor;
+    private final WorkflowTaskExecutor executor;
+
+    private LegacyWorkflowTaskPluginFactory(String type, WorkflowTaskExecutor executor) {
+      this.descriptor = new WorkflowTaskPluginDescriptor(
+          type,
+          type,
+          "Legacy or built-in workflow task executor",
+          "LEGACY",
+          "1.0.0",
+          false,
+          true,
+          Map.of());
+      this.executor = executor;
+    }
+
+    @Override
+    public WorkflowTaskPluginDescriptor descriptor() {
+      return descriptor;
+    }
+
+    @Override
+    public void validate(Map<String, Object> configuration) {
+      executor.validate(configuration);
+    }
+
+    @Override
+    public WorkflowTaskExecutor create() {
+      return executor;
+    }
   }
 }

--- a/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-all/src/test/java/io/yak/ops/plugin/task/all/TaskPluginAssemblyTest.java
+++ b/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-all/src/test/java/io/yak/ops/plugin/task/all/TaskPluginAssemblyTest.java
@@ -13,5 +13,15 @@ class TaskPluginAssemblyTest {
     WorkflowTaskExecutorRegistry registry = new WorkflowTaskExecutorRegistry(List.of());
 
     assertThat(registry.types()).contains("HTTP", "SHELL");
+    assertThat(registry.descriptor("HTTP").getName()).isEqualTo("HTTP 请求");
+    assertThat(registry.descriptor("SHELL").getConfigurationSchema()).containsKey("fields");
+  }
+
+  @Test
+  void shouldCreateAttemptScopedExecutors() {
+    WorkflowTaskExecutorRegistry registry = new WorkflowTaskExecutorRegistry(List.of());
+
+    assertThat(registry.require("HTTP")).isNotSameAs(registry.require("HTTP"));
+    assertThat(registry.require("SHELL")).isNotSameAs(registry.require("SHELL"));
   }
 }

--- a/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-http/src/main/java/io/yak/ops/plugin/task/http/HttpWorkflowTaskExecutor.java
+++ b/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-http/src/main/java/io/yak/ops/plugin/task/http/HttpWorkflowTaskExecutor.java
@@ -85,7 +85,7 @@ public final class HttpWorkflowTaskExecutor implements WorkflowTaskExecutor {
   public WorkflowTaskResult execute(WorkflowTaskContext context) throws Exception {
     Map<String, Object> configuration = TaskParameterResolver.resolveConfiguration(
         context.configuration(),
-        context.globalParameters());
+        context.parameters());
     validate(configuration);
 
     HttpRequest request = buildRequest(configuration);

--- a/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-http/src/main/java/io/yak/ops/plugin/task/http/HttpWorkflowTaskPluginFactory.java
+++ b/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-http/src/main/java/io/yak/ops/plugin/task/http/HttpWorkflowTaskPluginFactory.java
@@ -1,0 +1,80 @@
+package io.yak.ops.plugin.task.http;
+
+import io.yak.ops.plugin.task.api.TaskPluginType;
+import io.yak.ops.spi.workflow.WorkflowTaskExecutor;
+import io.yak.ops.spi.workflow.WorkflowTaskPluginDescriptor;
+import io.yak.ops.spi.workflow.WorkflowTaskPluginFactory;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/** Factory and discoverable metadata for the HTTP workflow task plugin. */
+public final class HttpWorkflowTaskPluginFactory implements WorkflowTaskPluginFactory {
+
+  private static final WorkflowTaskPluginDescriptor DESCRIPTOR =
+      new WorkflowTaskPluginDescriptor(
+          TaskPluginType.HTTP,
+          "HTTP 请求",
+          "调用 HTTP 接口，并将状态码、响应头和响应体写入任务输出。",
+          "GENERAL",
+          "1.0.0",
+          true,
+          true,
+          configurationSchema());
+
+  @Override
+  public WorkflowTaskPluginDescriptor descriptor() {
+    return DESCRIPTOR;
+  }
+
+  @Override
+  public WorkflowTaskExecutor create() {
+    return new HttpWorkflowTaskExecutor();
+  }
+
+  private static Map<String, Object> configurationSchema() {
+    Map<String, Object> fields = new LinkedHashMap<>();
+    fields.put("url", field("string", true, "请求地址，支持 ${parameter} 参数。", null));
+    fields.put("method", field(
+        "string",
+        false,
+        "HTTP 请求方法。",
+        "GET",
+        List.of("GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS")));
+    fields.put("headers", field("map", false, "请求头。", Map.of()));
+    fields.put("body", field("string", false, "请求体。", ""));
+    fields.put("requestTimeoutSeconds", field("integer", false, "请求超时秒数。", 60));
+    fields.put("successCodes", field("integer-list", false, "成功状态码，默认 200-299。", List.of()));
+    fields.put(
+        "maxResponseBodyCharacters",
+        field("integer", false, "最多保存的响应体字符数。", 1_000_000));
+    return Map.of("fields", fields);
+  }
+
+  private static Map<String, Object> field(
+      String type,
+      boolean required,
+      String description,
+      Object defaultValue) {
+    return field(type, required, description, defaultValue, List.of());
+  }
+
+  private static Map<String, Object> field(
+      String type,
+      boolean required,
+      String description,
+      Object defaultValue,
+      List<?> options) {
+    Map<String, Object> field = new LinkedHashMap<>();
+    field.put("type", type);
+    field.put("required", required);
+    field.put("description", description);
+    if (defaultValue != null) {
+      field.put("defaultValue", defaultValue);
+    }
+    if (options != null && !options.isEmpty()) {
+      field.put("options", options);
+    }
+    return field;
+  }
+}

--- a/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-http/src/main/resources/META-INF/services/io.yak.ops.spi.workflow.WorkflowTaskExecutor
+++ b/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-http/src/main/resources/META-INF/services/io.yak.ops.spi.workflow.WorkflowTaskExecutor
@@ -1,1 +1,0 @@
-io.yak.ops.plugin.task.http.HttpWorkflowTaskExecutor

--- a/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-http/src/main/resources/META-INF/services/io.yak.ops.spi.workflow.WorkflowTaskPluginFactory
+++ b/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-http/src/main/resources/META-INF/services/io.yak.ops.spi.workflow.WorkflowTaskPluginFactory
@@ -1,0 +1,1 @@
+io.yak.ops.plugin.task.http.HttpWorkflowTaskPluginFactory

--- a/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-http/src/test/java/io/yak/ops/plugin/task/http/HttpWorkflowTaskExecutorTest.java
+++ b/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-http/src/test/java/io/yak/ops/plugin/task/http/HttpWorkflowTaskExecutorTest.java
@@ -45,14 +45,14 @@ class HttpWorkflowTaskExecutorTest {
         1L,
         2L,
         3L,
-        1,
+        4,
         "http-node",
         "HTTP",
         Map.of(
-            "url", "http://127.0.0.1:${port}/echo",
+            "url", "http://127.0.0.1:${global.port}/echo",
             "method", "POST",
-            "headers", Map.of("X-Token", "${token}"),
-            "body", "{\"name\":\"${name}\"}"),
+            "headers", Map.of("X-Token", "${global.token}"),
+            "body", "{\"name\":\"${name}\",\"attempt\":${system.attemptNo}}"),
         Map.of(
             "port", server.getAddress().getPort(),
             "token", "task-secret",
@@ -68,7 +68,7 @@ class HttpWorkflowTaskExecutorTest {
         .containsEntry("body", "ok")
         .containsEntry("bodyTruncated", false);
     assertThat(requestToken.get()).isEqualTo("task-secret");
-    assertThat(requestBody.get()).isEqualTo("{\"name\":\"yak-ops\"}");
+    assertThat(requestBody.get()).isEqualTo("{\"name\":\"yak-ops\",\"attempt\":4}");
     assertThat(logs).anyMatch(line -> line.contains("HTTP status: 200"));
   }
 }

--- a/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-shell/src/main/java/io/yak/ops/plugin/task/shell/ShellWorkflowTaskExecutor.java
+++ b/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-shell/src/main/java/io/yak/ops/plugin/task/shell/ShellWorkflowTaskExecutor.java
@@ -44,7 +44,7 @@ public final class ShellWorkflowTaskExecutor implements WorkflowTaskExecutor {
   public WorkflowTaskResult execute(WorkflowTaskContext context) throws Exception {
     Map<String, Object> configuration = TaskParameterResolver.resolveConfiguration(
         context.configuration(),
-        context.globalParameters());
+        context.parameters());
     validate(configuration);
 
     List<String> command = resolveCommand(configuration);

--- a/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-shell/src/main/java/io/yak/ops/plugin/task/shell/ShellWorkflowTaskPluginFactory.java
+++ b/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-shell/src/main/java/io/yak/ops/plugin/task/shell/ShellWorkflowTaskPluginFactory.java
@@ -1,0 +1,55 @@
+package io.yak.ops.plugin.task.shell;
+
+import io.yak.ops.plugin.task.api.TaskPluginType;
+import io.yak.ops.spi.workflow.WorkflowTaskExecutor;
+import io.yak.ops.spi.workflow.WorkflowTaskPluginDescriptor;
+import io.yak.ops.spi.workflow.WorkflowTaskPluginFactory;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/** Factory and discoverable metadata for the Shell workflow task plugin. */
+public final class ShellWorkflowTaskPluginFactory implements WorkflowTaskPluginFactory {
+
+  private static final WorkflowTaskPluginDescriptor DESCRIPTOR =
+      new WorkflowTaskPluginDescriptor(
+          TaskPluginType.SHELL,
+          "Shell 命令",
+          "在 Yak Ops 运行主机执行受信任的 Shell 命令，并实时采集进程日志。",
+          "SYSTEM",
+          "1.0.0",
+          true,
+          true,
+          configurationSchema());
+
+  @Override
+  public WorkflowTaskPluginDescriptor descriptor() {
+    return DESCRIPTOR;
+  }
+
+  @Override
+  public WorkflowTaskExecutor create() {
+    return new ShellWorkflowTaskExecutor();
+  }
+
+  private static Map<String, Object> configurationSchema() {
+    Map<String, Object> fields = new LinkedHashMap<>();
+    fields.put("command", field("string", false, "Shell 命令，支持 ${parameter} 参数。", ""));
+    fields.put("args", field("string-list", false, "完整进程参数数组，配置后优先于 command。", java.util.List.of()));
+    fields.put("workDirectory", field("string", false, "进程工作目录。", ""));
+    fields.put("environment", field("map", false, "进程环境变量。", Map.of()));
+    return Map.of("fields", fields);
+  }
+
+  private static Map<String, Object> field(
+      String type,
+      boolean required,
+      String description,
+      Object defaultValue) {
+    Map<String, Object> field = new LinkedHashMap<>();
+    field.put("type", type);
+    field.put("required", required);
+    field.put("description", description);
+    field.put("defaultValue", defaultValue);
+    return field;
+  }
+}

--- a/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-shell/src/main/resources/META-INF/services/io.yak.ops.spi.workflow.WorkflowTaskExecutor
+++ b/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-shell/src/main/resources/META-INF/services/io.yak.ops.spi.workflow.WorkflowTaskExecutor
@@ -1,1 +1,0 @@
-io.yak.ops.plugin.task.shell.ShellWorkflowTaskExecutor

--- a/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-shell/src/main/resources/META-INF/services/io.yak.ops.spi.workflow.WorkflowTaskPluginFactory
+++ b/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-shell/src/main/resources/META-INF/services/io.yak.ops.spi.workflow.WorkflowTaskPluginFactory
@@ -1,0 +1,1 @@
+io.yak.ops.plugin.task.shell.ShellWorkflowTaskPluginFactory

--- a/yak-ops-spi/src/main/java/io/yak/ops/spi/workflow/WorkflowTaskContext.java
+++ b/yak-ops-spi/src/main/java/io/yak/ops/spi/workflow/WorkflowTaskContext.java
@@ -16,6 +16,7 @@ public final class WorkflowTaskContext {
   private final String taskType;
   private final Map<String, Object> configuration;
   private final Map<String, Object> globalParameters;
+  private final Map<String, Object> parameters;
   private final WorkflowCancellationToken cancellationToken;
   private final WorkflowTaskLogger logger;
 
@@ -38,6 +39,7 @@ public final class WorkflowTaskContext {
     this.taskType = Objects.requireNonNull(taskType, "taskType");
     this.configuration = immutableCopy(configuration);
     this.globalParameters = immutableCopy(globalParameters);
+    this.parameters = buildParameters();
     this.cancellationToken = Objects.requireNonNull(cancellationToken, "cancellationToken");
     this.logger = Objects.requireNonNull(logger, "logger");
   }
@@ -106,6 +108,20 @@ public final class WorkflowTaskContext {
     return globalParameters;
   }
 
+  /**
+   * Returns the unified parameter namespace used by task plugins.
+   *
+   * <p>Global parameters remain available at the top level for backward compatibility. They are
+   * also exposed under {@code global.*}. Runtime identifiers are exposed under {@code system.*}.
+   */
+  public Map<String, Object> parameters() {
+    return parameters;
+  }
+
+  public Map<String, Object> getParameters() {
+    return parameters;
+  }
+
   public WorkflowCancellationToken cancellationToken() {
     return cancellationToken;
   }
@@ -120,6 +136,21 @@ public final class WorkflowTaskContext {
 
   public WorkflowTaskLogger getLogger() {
     return logger;
+  }
+
+  private Map<String, Object> buildParameters() {
+    Map<String, Object> values = new LinkedHashMap<>(globalParameters);
+    values.put("global", globalParameters);
+
+    Map<String, Object> system = new LinkedHashMap<>();
+    system.put("workflowInstanceId", workflowInstanceId);
+    system.put("taskInstanceId", taskInstanceId);
+    system.put("attemptId", attemptId);
+    system.put("attemptNo", attemptNo);
+    system.put("nodeKey", nodeKey);
+    system.put("taskType", taskType);
+    values.put("system", Collections.unmodifiableMap(system));
+    return Collections.unmodifiableMap(values);
   }
 
   private static Map<String, Object> immutableCopy(Map<String, Object> source) {

--- a/yak-ops-spi/src/main/java/io/yak/ops/spi/workflow/WorkflowTaskPluginDescriptor.java
+++ b/yak-ops-spi/src/main/java/io/yak/ops/spi/workflow/WorkflowTaskPluginDescriptor.java
@@ -1,0 +1,86 @@
+package io.yak.ops.spi.workflow;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/** Immutable metadata exposed by one workflow task plugin. */
+public final class WorkflowTaskPluginDescriptor {
+
+  private final String type;
+  private final String name;
+  private final String description;
+  private final String category;
+  private final String version;
+  private final boolean cancellable;
+  private final boolean outputCapable;
+  private final Map<String, Object> configurationSchema;
+
+  public WorkflowTaskPluginDescriptor(
+      String type,
+      String name,
+      String description,
+      String category,
+      String version,
+      boolean cancellable,
+      boolean outputCapable,
+      Map<String, Object> configurationSchema) {
+    this.type = requireText(type, "type");
+    this.name = requireText(name, "name");
+    this.description = description == null ? "" : description;
+    this.category = requireText(category, "category");
+    this.version = requireText(version, "version");
+    this.cancellable = cancellable;
+    this.outputCapable = outputCapable;
+    this.configurationSchema = immutableCopy(configurationSchema);
+  }
+
+  public String getType() {
+    return type;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public String getCategory() {
+    return category;
+  }
+
+  public String getVersion() {
+    return version;
+  }
+
+  public boolean isCancellable() {
+    return cancellable;
+  }
+
+  public boolean isOutputCapable() {
+    return outputCapable;
+  }
+
+  public Map<String, Object> getConfigurationSchema() {
+    return configurationSchema;
+  }
+
+  private static String requireText(String value, String field) {
+    if (value == null || value.isBlank()) {
+      throw new IllegalArgumentException("Workflow task plugin " + field + " must not be blank");
+    }
+    return value.trim();
+  }
+
+  private static Map<String, Object> immutableCopy(Map<String, Object> source) {
+    if (source == null || source.isEmpty()) {
+      return Map.of();
+    }
+    Map<String, Object> copy = new LinkedHashMap<>();
+    source.forEach((key, value) -> copy.put(Objects.requireNonNull(key, "schema key"), value));
+    return Collections.unmodifiableMap(copy);
+  }
+}

--- a/yak-ops-spi/src/main/java/io/yak/ops/spi/workflow/WorkflowTaskPluginFactory.java
+++ b/yak-ops-spi/src/main/java/io/yak/ops/spi/workflow/WorkflowTaskPluginFactory.java
@@ -1,0 +1,25 @@
+package io.yak.ops.spi.workflow;
+
+import java.util.Map;
+
+/**
+ * Factory boundary for one workflow task plugin.
+ *
+ * <p>The factory owns plugin identity, static validation and creation of an attempt-scoped executor.
+ */
+public interface WorkflowTaskPluginFactory {
+
+  WorkflowTaskPluginDescriptor descriptor();
+
+  default String type() {
+    return descriptor().getType();
+  }
+
+  /** Validates configuration while compiling or publishing a workflow definition. */
+  default void validate(Map<String, Object> configuration) {
+    create().validate(configuration);
+  }
+
+  /** Creates a new executor for one physical task attempt. */
+  WorkflowTaskExecutor create();
+}

--- a/yak-ops-ui/src/pages/workflow-management/designer/components/BlockSelector.tsx
+++ b/yak-ops-ui/src/pages/workflow-management/designer/components/BlockSelector.tsx
@@ -1,12 +1,14 @@
 import { Input } from 'antd';
 import { ChevronLeft, Plus, Search, X } from 'lucide-react';
-import { useMemo, useState } from 'react';
-import type { WorkflowNodeType } from '../../types';
+import { useEffect, useMemo, useState } from 'react';
+import { fetchTaskPluginList } from '../../service';
+import type { WorkflowNodeType, WorkflowTaskPluginRecord } from '../../types';
 import {
   CATEGORY_LABELS,
   WORKFLOW_NODE_CATALOG,
   type WorkflowNodeMeta,
 } from '../constants';
+import { mergeTaskPluginCatalog } from '../taskPluginCatalog';
 import NodeIcon from './NodeIcon';
 
 interface BlockSelectorProps {
@@ -28,15 +30,41 @@ const categoryOrder: WorkflowNodeMeta['category'][] = [
 const BlockSelector = ({ open, onClose, onSelect, compact = false }: BlockSelectorProps) => {
   const [keyword, setKeyword] = useState('');
   const [category, setCategory] = useState<WorkflowNodeMeta['category'] | 'all'>('all');
+  const [plugins, setPlugins] = useState<WorkflowTaskPluginRecord[]>([]);
+  const [catalogLoaded, setCatalogLoaded] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    const loadPlugins = async () => {
+      try {
+        const response = await fetchTaskPluginList();
+        if (!active || response.code !== 0 || !Array.isArray(response.data)) return;
+        mergeTaskPluginCatalog(response.data);
+        setPlugins(response.data);
+      } finally {
+        if (active) setCatalogLoaded(true);
+      }
+    };
+    void loadPlugins();
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const pluginsByType = useMemo(
+    () => new Map(plugins.map((plugin) => [plugin.type, plugin])),
+    [plugins],
+  );
 
   const filtered = useMemo(() => {
     const normalized = keyword.trim().toLowerCase();
     return WORKFLOW_NODE_CATALOG.filter((item) => {
+      if (catalogLoaded && !pluginsByType.has(item.backendType)) return false;
       if (category !== 'all' && item.category !== category) return false;
       if (!normalized) return true;
       return `${item.title} ${item.description} ${item.type}`.toLowerCase().includes(normalized);
     });
-  }, [category, keyword]);
+  }, [catalogLoaded, category, keyword, pluginsByType]);
 
   if (!open) return null;
 
@@ -94,23 +122,29 @@ const BlockSelector = ({ open, onClose, onSelect, compact = false }: BlockSelect
             <section key={group}>
               <h3>{CATEGORY_LABELS[group]}</h3>
               <div>
-                {items.map((item) => (
-                  <button
-                    key={item.type}
-                    type="button"
-                    onClick={() => {
-                      onSelect(item.type);
-                      onClose();
-                    }}
-                  >
-                    <NodeIcon type={item.type} size={18} />
-                    <span>
-                      <strong>{item.title}</strong>
-                      <small>{item.description}</small>
-                    </span>
-                    <Plus size={15} />
-                  </button>
-                ))}
+                {items.map((item) => {
+                  const plugin = pluginsByType.get(item.backendType);
+                  return (
+                    <button
+                      key={item.type}
+                      type="button"
+                      onClick={() => {
+                        onSelect(item.type);
+                        onClose();
+                      }}
+                    >
+                      <NodeIcon type={item.type} size={18} />
+                      <span>
+                        <strong>{item.title}</strong>
+                        <small>
+                          {item.description}
+                          {plugin?.version ? ` · v${plugin.version}` : ''}
+                        </small>
+                      </span>
+                      <Plus size={15} />
+                    </button>
+                  );
+                })}
               </div>
             </section>
           );

--- a/yak-ops-ui/src/pages/workflow-management/designer/components/BlockSelector.tsx
+++ b/yak-ops-ui/src/pages/workflow-management/designer/components/BlockSelector.tsx
@@ -41,8 +41,9 @@ const BlockSelector = ({ open, onClose, onSelect, compact = false }: BlockSelect
         if (!active || response.code !== 0 || !Array.isArray(response.data)) return;
         mergeTaskPluginCatalog(response.data);
         setPlugins(response.data);
-      } finally {
-        if (active) setCatalogLoaded(true);
+        setCatalogLoaded(true);
+      } catch {
+        // Keep the built-in visual catalog available when the backend catalog cannot be loaded.
       }
     };
     void loadPlugins();

--- a/yak-ops-ui/src/pages/workflow-management/designer/taskPluginCatalog.test.ts
+++ b/yak-ops-ui/src/pages/workflow-management/designer/taskPluginCatalog.test.ts
@@ -1,0 +1,41 @@
+import { getNodeMeta, WORKFLOW_NODE_CATALOG } from './constants';
+import { mergeTaskPluginCatalog } from './taskPluginCatalog';
+
+describe('task plugin catalog', () => {
+  const originalLength = WORKFLOW_NODE_CATALOG.length;
+
+  afterEach(() => {
+    WORKFLOW_NODE_CATALOG.splice(originalLength);
+  });
+
+  it('adds an unknown backend plugin as a generic integration node', () => {
+    mergeTaskPluginCatalog([
+      {
+        type: 'PYTHON',
+        name: 'Python',
+        description: '运行 Python 脚本',
+        category: 'SYSTEM',
+        version: '1.0.0',
+        cancellable: true,
+        outputCapable: true,
+        configurationSchema: {
+          fields: {
+            script: {
+              type: 'string',
+              required: true,
+              defaultValue: 'print("hello")',
+            },
+          },
+        },
+      },
+    ]);
+
+    expect(getNodeMeta('PYTHON')).toMatchObject({
+      type: 'PYTHON',
+      backendType: 'PYTHON',
+      title: 'Python',
+      category: 'integration',
+      defaults: { script: 'print("hello")' },
+    });
+  });
+});

--- a/yak-ops-ui/src/pages/workflow-management/designer/taskPluginCatalog.ts
+++ b/yak-ops-ui/src/pages/workflow-management/designer/taskPluginCatalog.ts
@@ -47,5 +47,5 @@ const extractDefaults = (schema: Record<string, unknown>) => {
   return defaults;
 };
 
-const isObject = (value: unknown): value is Record<string, any> =>
+const isObject = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value);

--- a/yak-ops-ui/src/pages/workflow-management/designer/taskPluginCatalog.ts
+++ b/yak-ops-ui/src/pages/workflow-management/designer/taskPluginCatalog.ts
@@ -1,0 +1,51 @@
+import type { WorkflowNodeType, WorkflowTaskPluginRecord } from '../types';
+import {
+  WORKFLOW_NODE_CATALOG,
+  type WorkflowNodeMeta,
+} from './constants';
+
+const categoryColor: Record<string, string> = {
+  GENERAL: '#0ea5e9',
+  SYSTEM: '#475569',
+  DATA: '#14b8a6',
+  AI: '#7c3aed',
+};
+
+export const mergeTaskPluginCatalog = (plugins: WorkflowTaskPluginRecord[]) => {
+  for (const plugin of plugins) {
+    const defaults = extractDefaults(plugin.configurationSchema);
+    const existing = WORKFLOW_NODE_CATALOG.find(
+      (item) => item.backendType === plugin.type || item.type === plugin.type,
+    );
+    if (existing) {
+      existing.title = plugin.name || existing.title;
+      existing.description = plugin.description || existing.description;
+      existing.defaults = { ...defaults, ...existing.defaults };
+      continue;
+    }
+
+    const meta: WorkflowNodeMeta = {
+      type: plugin.type as WorkflowNodeType,
+      title: plugin.name || plugin.type,
+      description: plugin.description || `${plugin.type} 任务插件`,
+      category: 'integration',
+      color: categoryColor[plugin.category] || '#64748b',
+      backendType: plugin.type,
+      defaults,
+    };
+    WORKFLOW_NODE_CATALOG.push(meta);
+  }
+};
+
+const extractDefaults = (schema: Record<string, unknown>) => {
+  const fields = isObject(schema.fields) ? schema.fields : {};
+  const defaults: Record<string, unknown> = {};
+  Object.entries(fields).forEach(([key, value]) => {
+    if (!isObject(value) || !Object.prototype.hasOwnProperty.call(value, 'defaultValue')) return;
+    defaults[key] = value.defaultValue;
+  });
+  return defaults;
+};
+
+const isObject = (value: unknown): value is Record<string, any> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);

--- a/yak-ops-ui/src/pages/workflow-management/designer/taskPluginCatalog.ts
+++ b/yak-ops-ui/src/pages/workflow-management/designer/taskPluginCatalog.ts
@@ -14,9 +14,7 @@ const categoryColor: Record<string, string> = {
 export const mergeTaskPluginCatalog = (plugins: WorkflowTaskPluginRecord[]) => {
   for (const plugin of plugins) {
     const defaults = extractDefaults(plugin.configurationSchema);
-    const existing = WORKFLOW_NODE_CATALOG.find(
-      (item) => item.backendType === plugin.type || item.type === plugin.type,
-    );
+    const existing = WORKFLOW_NODE_CATALOG.find((item) => item.type === plugin.type);
     if (existing) {
       existing.title = plugin.name || existing.title;
       existing.description = plugin.description || existing.description;

--- a/yak-ops-ui/src/pages/workflow-management/designer/taskPluginCatalog.ts
+++ b/yak-ops-ui/src/pages/workflow-management/designer/taskPluginCatalog.ts
@@ -16,8 +16,6 @@ export const mergeTaskPluginCatalog = (plugins: WorkflowTaskPluginRecord[]) => {
     const defaults = extractDefaults(plugin.configurationSchema);
     const existing = WORKFLOW_NODE_CATALOG.find((item) => item.type === plugin.type);
     if (existing) {
-      existing.title = plugin.name || existing.title;
-      existing.description = plugin.description || existing.description;
       existing.defaults = { ...defaults, ...existing.defaults };
       continue;
     }

--- a/yak-ops-ui/src/pages/workflow-management/service.ts
+++ b/yak-ops-ui/src/pages/workflow-management/service.ts
@@ -3,6 +3,7 @@ import type {
   CommonApiResponse,
   WorkflowCreatePayload,
   WorkflowDefinitionRecord,
+  WorkflowTaskPluginRecord,
   WorkflowUpdatePayload,
 } from './types';
 
@@ -18,6 +19,12 @@ export async function fetchWorkflowDetail(
   workflowId: string | number,
 ): Promise<CommonApiResponse<WorkflowDefinitionRecord>> {
   return HttpUtils.get(`${WORKFLOW_API_PREFIX}/${workflowId}`);
+}
+
+export async function fetchTaskPluginList(): Promise<
+  CommonApiResponse<WorkflowTaskPluginRecord[]>
+> {
+  return HttpUtils.get(`${WORKFLOW_API_PREFIX}/task-plugins`);
 }
 
 export async function createWorkflow(

--- a/yak-ops-ui/src/pages/workflow-management/types.ts
+++ b/yak-ops-ui/src/pages/workflow-management/types.ts
@@ -3,13 +3,8 @@ import type { Edge, Node, Viewport } from 'reactflow';
 export type WorkflowDefinitionState = 'DRAFT' | 'PUBLISHED' | 'OFFLINE';
 export type WorkflowFailureStrategy = 'FAIL_FAST' | 'CONTINUE';
 
-/**
- * Front-end workflow block types. Only HTTP and SHELL currently map to concrete
- * backend executors. The remaining visual blocks are persisted as NOOP nodes
- * with their visual type stored in config.__uiType, so the draft remains
- * compatible with the current backend while execution is intentionally out of scope.
- */
-export type WorkflowNodeType =
+/** Visual node types with support for dynamically discovered task-plugin types. */
+export type KnownWorkflowNodeType =
   | 'START'
   | 'END'
   | 'LLM'
@@ -25,6 +20,7 @@ export type WorkflowNodeType =
   | 'NOTE'
   | 'NOOP';
 
+export type WorkflowNodeType = KnownWorkflowNodeType | (string & {});
 export type WorkflowBackendTaskType = 'NOOP' | 'HTTP' | 'SHELL' | string;
 export type WorkflowPanelType =
   | 'node'
@@ -39,6 +35,17 @@ export interface CommonApiResponse<T> {
   code: number;
   data: T;
   message?: string;
+}
+
+export interface WorkflowTaskPluginRecord {
+  type: string;
+  name: string;
+  description: string;
+  category: string;
+  version: string;
+  cancellable: boolean;
+  outputCapable: boolean;
+  configurationSchema: Record<string, unknown>;
 }
 
 export interface WorkflowVariable {


### PR DESCRIPTION
## 背景

PR #98 已经完成 HTTP / Shell 的独立 Maven 模块和 ServiceLoader 发现，但工作流与 task-plugin 之间仍有三个缺口：

1. 注册表直接管理执行器实例，插件缺少 Factory、元数据和清晰的 Attempt 生命周期；
2. 工作流设计器仍主要依赖前端硬编码节点目录，无法从后端确认真实可用插件；
3. 插件只读取扁平全局参数，缺少明确的运行期系统参数命名空间。

本 PR 继续参考 DolphinScheduler 的 `TaskChannelFactory -> TaskChannel -> AbstractTask -> TaskExecutionContext` 设计理念，在不引入 Master / Worker / 注册中心的前提下，完善 Yak Ops 的轻量工作流闭环。

## DolphinScheduler 与 Yak Ops 的职责映射

| DolphinScheduler | Yak Ops | 职责 |
| --- | --- | --- |
| `TaskChannelFactory` | `WorkflowTaskPluginFactory` | 插件身份、元数据、配置校验和执行器创建 |
| `TaskChannel` | `WorkflowTaskExecutorRegistry` | 插件发现、类型唯一性和运行时路由 |
| `AbstractTask` | `WorkflowTaskExecutor` | 一次物理 Attempt 的执行和取消 |
| `AbstractParameters` | `configurationSchema + validate` | 参数描述和发布期校验 |
| `TaskExecutionContext` | `WorkflowTaskContext` | 实例、Attempt、参数、日志和取消信号 |

## 后端改动

### 1. 插件 Factory 与 Descriptor

新增：

- `WorkflowTaskPluginFactory`
- `WorkflowTaskPluginDescriptor`

Factory 负责：

- 声明插件类型；
- 返回展示名称、分类、版本、取消能力和输出能力；
- 暴露配置 Schema；
- 发布期配置校验；
- 为每个物理 Attempt 创建独立执行器。

HTTP / Shell 的 ServiceLoader 注册从：

```text
WorkflowTaskExecutor
```

切换为：

```text
WorkflowTaskPluginFactory
```

注册表继续兼容旧版直接通过 ServiceLoader 提供 `WorkflowTaskExecutor` 的插件。

### 2. Attempt 级执行器生命周期

`WorkflowTaskExecutorRegistry.require(taskType)` 现在通过 Factory 创建执行器。

因此 HTTP / Shell 每次物理尝试都会获得独立执行器，取消状态、HTTP Future 和 Shell Process 不再共享同一个插件单例。内置 NOOP 和旧版插件通过 Legacy Factory 适配器保持兼容。

### 3. 发布期插件校验

`WorkflowDagCompiler` 不再直接创建执行器进行校验，而是调用：

```java
executorRegistry.validate(taskType, configuration)
```

工作流发布链路变为：

```text
DAG 校验
  -> 插件存在性校验
  -> 插件配置校验
  -> 生成不可变发布版本
```

### 4. 插件目录 API

新增：

```http
GET /api/v1/workflows/task-plugins
```

返回：

- type
- name
- description
- category
- version
- cancellable
- outputCapable
- configurationSchema

工作流业务模块只读取注册表目录，不依赖 HTTP / Shell 具体模块。

### 5. 统一参数命名空间

`WorkflowTaskContext.parameters()` 同时提供：

```text
${name}                       兼容原有全局参数
${global.name}                显式全局参数
${system.workflowInstanceId}  工作流实例 ID
${system.taskInstanceId}      任务实例 ID
${system.attemptId}           Attempt ID
${system.attemptNo}           当前尝试次数
${system.nodeKey}             节点编码
${system.taskType}            插件类型
```

HTTP / Shell 已切换为统一参数入口。

## 前端打通

工作流节点选择器现在调用后端插件目录接口：

- 后端未安装的任务插件不会继续作为可执行节点展示；
- HTTP / Shell 展示实际插件版本；
- 后续新增插件会自动加入“集成”分类；
- 插件配置 Schema 中的默认值会进入节点初始配置；
- 未开发专属表单的插件仍可使用现有高级 JSON 配置编辑。

接口不可用时保留原有静态节点目录，避免设计器被网络问题完全阻断。

## 文档

新增：

```text
docs/workflow-task-plugin-integration.md
```

记录职责映射、启动/设计/发布/运行生命周期、参数命名空间和新增插件步骤。

## 测试与验证

新增或扩展：

- Factory ServiceLoader 发现测试；
- HTTP / Shell Attempt 级执行器实例测试；
- 插件 Descriptor 和 Schema 测试；
- `${global.*}` 和 `${system.*}` 参数解析测试；
- 前端动态插件节点和默认配置测试。

当前环境无法解析 GitHub / Maven / npm 外部依赖域名，未能运行完整 Reactor 和前端测试。已使用 JDK 21 对新增 SPI、注册表和 Factory 代码进行独立语法编译，结果通过。

合并前建议执行：

```bash
mvn -pl yak-ops-plugins/yak-ops-plugin-task -am test
mvn -pl yak-ops-boot -am test

cd yak-ops-ui
npm test -- taskPluginCatalog.test.ts
npm run tsc
npm run build
```

## 数据库

本次不新增表。现有 `yak_wf_*` 表已经保存 task type、config、Attempt、日志、结果、重试和超时状态，插件目录属于运行时装配信息，不应重复持久化。