### PR TITLE
fix(workflow-ui): correct NodeIcon import path

### DIFF
--- a/yak-ops-ui/src/pages/workflow-management/designer/components/BlockSelector.tsx
+++ b/yak-ops-ui/src/pages/workflow-management/designer/components/BlockSelector.tsx
@@ -9,7 +9,7 @@ import {
   type WorkflowNodeMeta,
 } from '../constants';
 import { mergeTaskPluginCatalog } from '../taskPluginCatalog';
-import NodeIcon from './NodeIcon';
+import NodeIcon from './node/NodeIcon';
 
 interface BlockSelectorProps {
   open: boolean;


### PR DESCRIPTION
## What changed

- Updated `BlockSelector.tsx` to import `NodeIcon` from its current `components/node` location.

## Root cause

The workflow designer component structure was reorganized, and `NodeIcon.tsx` now lives under `components/node`. The legacy block selector still imported it from the same directory, causing Umi/esbuild to fail during startup with `Could not resolve "./NodeIcon"`.

## Impact

- Restores `yarn start` module resolution for the workflow designer.
- Does not change workflow behavior or UI logic.

## Validation

- Confirmed `components/node/NodeIcon.tsx` exists on the target branch.
- Confirmed the branch is one commit ahead of `main` and only changes `BlockSelector.tsx`.
- Full local build was not run because the execution environment cannot clone the repository from GitHub; the fix is limited to the verified missing-module path.