### PR TITLE
fix(workflow-ui): handle yak-framework success responses

### DIFF
--- a/yak-ops-ui/src/pages/workflow-management/service.test.ts
+++ b/yak-ops-ui/src/pages/workflow-management/service.test.ts
@@ -1,0 +1,31 @@
+import { normalizeWorkflowResponse } from './service';
+
+describe('workflow response adapter', () => {
+  it('maps yak-framework success responses to the workflow UI contract', () => {
+    expect(
+      normalizeWorkflowResponse({
+        code: 200,
+        data: [{ id: 1 }],
+        message: '成功',
+      }),
+    ).toEqual({
+      code: 0,
+      data: [{ id: 1 }],
+      message: '成功',
+    });
+  });
+
+  it('preserves failures and supports the msg envelope field', () => {
+    expect(
+      normalizeWorkflowResponse({
+        code: 999,
+        data: null,
+        msg: '加载失败',
+      }),
+    ).toEqual({
+      code: 999,
+      data: null,
+      message: '加载失败',
+    });
+  });
+});

--- a/yak-ops-ui/src/pages/workflow-management/service.ts
+++ b/yak-ops-ui/src/pages/workflow-management/service.ts
@@ -1,4 +1,5 @@
-import HttpUtils from '@/utils/HttpUtils';
+import { isSuccessfulResponse } from '@/services/http/response';
+import HttpUtils, { type ApiResponse } from '@/utils/HttpUtils';
 import type {
   CommonApiResponse,
   WorkflowCreatePayload,
@@ -9,39 +10,67 @@ import type {
 
 const WORKFLOW_API_PREFIX = '/api/v1/workflows';
 
+/** Adapt yak-framework's 200 success envelope to the workflow UI's legacy code-0 contract. */
+export const normalizeWorkflowResponse = <T>(
+  response: ApiResponse<T>,
+): CommonApiResponse<T> => ({
+  code: isSuccessfulResponse(response, 'yak-framework') ? 0 : response.code,
+  data: response.data,
+  message: response.message ?? response.msg,
+});
+
 export async function fetchWorkflowList(): Promise<
   CommonApiResponse<WorkflowDefinitionRecord[]>
 > {
-  return HttpUtils.get(WORKFLOW_API_PREFIX);
+  return normalizeWorkflowResponse(
+    await HttpUtils.get<WorkflowDefinitionRecord[]>(WORKFLOW_API_PREFIX),
+  );
 }
 
 export async function fetchWorkflowDetail(
   workflowId: string | number,
 ): Promise<CommonApiResponse<WorkflowDefinitionRecord>> {
-  return HttpUtils.get(`${WORKFLOW_API_PREFIX}/${workflowId}`);
+  return normalizeWorkflowResponse(
+    await HttpUtils.get<WorkflowDefinitionRecord>(
+      `${WORKFLOW_API_PREFIX}/${workflowId}`,
+    ),
+  );
 }
 
 export async function fetchTaskPluginList(): Promise<
   CommonApiResponse<WorkflowTaskPluginRecord[]>
 > {
-  return HttpUtils.get(`${WORKFLOW_API_PREFIX}/task-plugins`);
+  return normalizeWorkflowResponse(
+    await HttpUtils.get<WorkflowTaskPluginRecord[]>(
+      `${WORKFLOW_API_PREFIX}/task-plugins`,
+    ),
+  );
 }
 
 export async function createWorkflow(
   payload: WorkflowCreatePayload,
 ): Promise<CommonApiResponse<{ workflowId: number }>> {
-  return HttpUtils.post(WORKFLOW_API_PREFIX, payload);
+  return normalizeWorkflowResponse(
+    await HttpUtils.post<{ workflowId: number }>(WORKFLOW_API_PREFIX, payload),
+  );
 }
 
 export async function updateWorkflow(
   workflowId: string | number,
   payload: WorkflowUpdatePayload,
 ): Promise<CommonApiResponse<boolean>> {
-  return HttpUtils.put(`${WORKFLOW_API_PREFIX}/${workflowId}`, payload);
+  return normalizeWorkflowResponse(
+    await HttpUtils.put<boolean>(
+      `${WORKFLOW_API_PREFIX}/${workflowId}`,
+      payload,
+    ),
+  );
 }
 
 export async function deleteWorkflow(
   workflowId: string | number,
 ): Promise<CommonApiResponse<boolean>> {
-  return HttpUtils.delete(`${WORKFLOW_API_PREFIX}/${workflowId}`);
+  return normalizeWorkflowResponse(
+    await HttpUtils.delete<boolean>(`${WORKFLOW_API_PREFIX}/${workflowId}`),
+  );
 }

--- a/yak-ops-ui/src/services/http/response.test.ts
+++ b/yak-ops-ui/src/services/http/response.test.ts
@@ -9,8 +9,10 @@ import {
 describe('API response protocols', () => {
   it('keeps success codes isolated by namespace', () => {
     expect(isSuccessfulResponse({ code: 0 }, 'yak-ops')).toBe(true);
+    expect(isSuccessfulResponse({ code: 200 }, 'yak-framework')).toBe(true);
     expect(isSuccessfulResponse({ code: 200 }, 'security')).toBe(true);
     expect(isSuccessfulResponse({ code: 200 }, 'yak-ops')).toBe(false);
+    expect(isSuccessfulResponse({ code: 0 }, 'yak-framework')).toBe(false);
     expect(isSuccessfulResponse({ code: 0 }, 'security')).toBe(false);
   });
 
@@ -28,7 +30,8 @@ describe('API response protocols', () => {
   it('does not parse arbitrary JSON as an envelope', () => {
     expect(isApiResponse({ data: { code: 200 } })).toBe(false);
     expect(protocolForUrl('/yak-security/api/v1/account/current')).toBe('security');
+    expect(protocolForUrl('/api/v1/workflows')).toBe('yak-framework');
+    expect(protocolForUrl('/api/v1/workflows/1')).toBe('yak-framework');
     expect(protocolForUrl('/api/v1/jobs')).toBe('yak-ops');
   });
 });
-

--- a/yak-ops-ui/src/services/http/response.ts
+++ b/yak-ops-ui/src/services/http/response.ts
@@ -1,4 +1,4 @@
-export type ApiProtocol = 'yak-ops' | 'security';
+export type ApiProtocol = 'yak-ops' | 'yak-framework' | 'security';
 
 export interface ApiResponse<T = unknown> {
   code: number;
@@ -7,8 +7,12 @@ export interface ApiResponse<T = unknown> {
   message?: string;
 }
 
-const protocolRules: Record<ApiProtocol, { success: readonly number[]; unauthenticated: readonly number[] }> = {
+const protocolRules: Record<
+  ApiProtocol,
+  { success: readonly number[]; unauthenticated: readonly number[] }
+> = {
   'yak-ops': { success: [0], unauthenticated: [1, 401] },
+  'yak-framework': { success: [200], unauthenticated: [401] },
   security: {
     success: [200],
     unauthenticated: [401, 2001],
@@ -22,8 +26,11 @@ const unauthenticatedMessages = new Set([
   'SESSION_INVALID',
 ]);
 
-export const protocolForUrl = (url?: string): ApiProtocol =>
-  url?.includes('/yak-security/') ? 'security' : 'yak-ops';
+export const protocolForUrl = (url?: string): ApiProtocol => {
+  if (url?.includes('/yak-security/')) return 'security';
+  if (url?.includes('/api/v1/workflows')) return 'yak-framework';
+  return 'yak-ops';
+};
 
 export const isApiResponse = (value: unknown): value is ApiResponse => {
   if (!value || typeof value !== 'object') return false;
@@ -54,4 +61,3 @@ export const isUnauthenticatedResponse = (
       unauthenticatedMessages.has(message.trim().toUpperCase()))
   );
 };
-


### PR DESCRIPTION
## 问题

访问 `/workflow-management` 时，`GET /api/v1/workflows` 实际返回 yak-framework 统一响应：

```json
{
  "code": 200,
  "message": "成功",
  "data": []
}
```

前端请求拦截器将该 URL 按旧 Yak Ops 协议处理，只认可成功码 `0`，导致成功响应被抛成 `BizError: 成功`。

## 修复

- 新增 `yak-framework` 响应协议，成功码为 `200`
- 将 `/api/v1/workflows` 及其子路径识别为 `yak-framework`
- 在工作流 service 边界将成功码 `200` 归一为页面既有的成功码 `0`
- 同时兼容后端 `message` 与 `msg` 两种消息字段
- 添加协议识别和工作流响应归一化测试

## 影响范围

仅调整前端响应协议识别及工作流 service，不修改后端接口、页面结构或工作流业务逻辑。

## 验证重点

- 打开 `/workflow-management` 不再出现 `Unhandled Rejection (BizError): 成功`
- 工作流列表能正常加载
- 创建、详情加载、保存和删除仍按现有页面逻辑工作
