### PR TITLE
fix(workflow-ui): preserve create form values across steps

### DIFF
--- a/yak-ops-ui/src/pages/workflow-management/designer/components/create-guide/index.test.ts
+++ b/yak-ops-ui/src/pages/workflow-management/designer/components/create-guide/index.test.ts
@@ -1,0 +1,26 @@
+import { normalizeCreateValues } from './index';
+
+describe('workflow create guide values', () => {
+  it('normalizes the first-step values before the form is unmounted', () => {
+    expect(
+      normalizeCreateValues({
+        name: '  实时同步工作流  ',
+        code: '  realtime-sync  ',
+        description: '  MySQL CDC  ',
+        failureStrategy: 'CONTINUE',
+        maxParallelism: 8,
+      }),
+    ).toEqual({
+      name: '实时同步工作流',
+      code: 'realtime-sync',
+      description: 'MySQL CDC',
+      failureStrategy: 'CONTINUE',
+      maxParallelism: 8,
+    });
+  });
+
+  it('does not build submission values when required form fields are missing', () => {
+    expect(normalizeCreateValues({ code: 'realtime-sync' })).toBeUndefined();
+    expect(normalizeCreateValues({ name: '实时同步工作流' })).toBeUndefined();
+  });
+});

--- a/yak-ops-ui/src/pages/workflow-management/designer/components/create-guide/index.tsx
+++ b/yak-ops-ui/src/pages/workflow-management/designer/components/create-guide/index.tsx
@@ -7,7 +7,7 @@ import type { WorkflowFailureStrategy } from '../../../types';
 import { WORKFLOW_TEMPLATES } from '../../constants';
 import NodeIcon from '../node/NodeIcon';
 
-interface CreateValues {
+export interface CreateValues {
   name: string;
   code: string;
   description?: string;
@@ -15,11 +15,38 @@ interface CreateValues {
   maxParallelism: number;
 }
 
+const DEFAULT_CREATE_VALUES: Partial<CreateValues> = {
+  failureStrategy: 'FAIL_FAST',
+  maxParallelism: 4,
+};
+
+/**
+ * Normalize values while the Ant Design Form is still mounted.
+ * The first-step Form is removed when the template step is displayed, so its
+ * field store must not be read again during final submission.
+ */
+export const normalizeCreateValues = (
+  values: Partial<CreateValues>,
+): CreateValues | undefined => {
+  const name = values.name?.trim();
+  const code = values.code?.trim();
+  if (!name || !code) return undefined;
+
+  return {
+    name,
+    code,
+    description: values.description?.trim() || undefined,
+    failureStrategy: values.failureStrategy || 'FAIL_FAST',
+    maxParallelism: values.maxParallelism || 4,
+  };
+};
+
 const WorkflowCreateGuide = () => {
   const [form] = Form.useForm<CreateValues>();
   const [step, setStep] = useState(0);
   const [templateId, setTemplateId] = useState('blank');
   const [saving, setSaving] = useState(false);
+  const [basicValues, setBasicValues] = useState<CreateValues>();
   const selectedTemplate = useMemo(
     () =>
       WORKFLOW_TEMPLATES.find((item) => item.id === templateId) ||
@@ -28,18 +55,27 @@ const WorkflowCreateGuide = () => {
   );
 
   const goNext = async () => {
-    await form.validateFields(['name', 'code', 'description']);
+    const validatedValues = await form.validateFields();
+    const normalizedValues = normalizeCreateValues(validatedValues);
+    if (!normalizedValues) {
+      message.warning('请先完整填写工作流名称和编码');
+      return;
+    }
+    setBasicValues(normalizedValues);
     setStep(1);
   };
 
   const create = async () => {
-    const values = await form.validateFields();
+    if (!basicValues) {
+      message.warning('基本信息已失效，请返回上一步重新确认');
+      setStep(0);
+      return;
+    }
+
     try {
       setSaving(true);
       const response = await createWorkflow({
-        ...values,
-        name: values.name.trim(),
-        code: values.code.trim(),
+        ...basicValues,
         dag: {
           nodes: selectedTemplate.nodes,
           edges: selectedTemplate.edges,
@@ -127,10 +163,7 @@ const WorkflowCreateGuide = () => {
               form={form}
               layout="vertical"
               requiredMark={false}
-              initialValues={{
-                failureStrategy: 'FAIL_FAST',
-                maxParallelism: 4,
-              }}
+              initialValues={basicValues || DEFAULT_CREATE_VALUES}
               className={[
                 'mx-auto w-full max-w-[620px]',
                 '[&_.ant-form-item-label_label]:text-[11px]',


### PR DESCRIPTION
## 问题

访问 `/workflow-management/create/designer` 创建工作流时，第一步填写基本信息后进入模板选择页，第一步的 Ant Design `<Form>` 会被条件渲染卸载。

最终点击“创建并进入编辑器”时，代码再次调用 `form.validateFields()`，此时字段存储已经不可用，导致：

```text
Cannot read properties of undefined (reading 'trim')
```

## 修复

- 在第一步表单仍处于挂载状态时完成完整校验
- 对名称、编码和描述进行归一化
- 将基本信息显式缓存到组件状态
- 最终创建时直接使用缓存值，不再读取已卸载的 Form
- 返回上一步时使用缓存值恢复表单
- 对缓存缺失场景增加保护，不再产生未捕获异常
- 添加基本信息归一化与必填字段保护测试

## 验证重点

1. 打开 `/workflow-management/create/designer`
2. 填写名称和编码并进入第二步
3. 选择任意模板后创建
4. 不再出现 `values.name.trim()` 异常
5. 返回上一步时已填写内容仍然保留
