### PR TITLE
fix(ui): standardize API success code to 200

### DIFF
--- a/yak-ops-ui/src/pages/workflow-management/designer/components/create-guide/index.tsx
+++ b/yak-ops-ui/src/pages/workflow-management/designer/components/create-guide/index.tsx
@@ -1,3 +1,4 @@
+import { API_SUCCESS_CODE } from '@/services/http/response';
 import { history } from '@umijs/max';
 import { Form, Input, InputNumber, message, Select } from 'antd';
 import { ArrowLeft, ArrowRight, Check, Sparkles } from 'lucide-react';
@@ -82,7 +83,10 @@ const WorkflowCreateGuide = () => {
           viewport: selectedTemplate.viewport,
         },
       });
-      if (response.code !== 0 || !response.data?.workflowId) {
+      if (
+        response.code !== API_SUCCESS_CODE ||
+        !response.data?.workflowId
+      ) {
         message.error(response.message || '创建工作流失败');
         return;
       }

--- a/yak-ops-ui/src/pages/workflow-management/designer/index.tsx
+++ b/yak-ops-ui/src/pages/workflow-management/designer/index.tsx
@@ -1,3 +1,4 @@
+import { API_SUCCESS_CODE } from '@/services/http/response';
 import { history, useParams } from '@umijs/max';
 import { message, Modal, Spin } from 'antd';
 import { Plus, Sparkles } from 'lucide-react';
@@ -134,7 +135,7 @@ const WorkflowDesignerContent = () => {
     try {
       setLoading(true);
       const response = await fetchWorkflowDetail(workflowId);
-      if (response.code !== 0 || !response.data) {
+      if (response.code !== API_SUCCESS_CODE || !response.data) {
         message.error(response.message || '加载工作流失败');
         return;
       }
@@ -249,7 +250,7 @@ const WorkflowDesignerContent = () => {
           viewport,
         },
       });
-      if (response.code !== 0) {
+      if (response.code !== API_SUCCESS_CODE) {
         message.error(response.message || '保存工作流失败');
         return;
       }

--- a/yak-ops-ui/src/pages/workflow-management/index.tsx
+++ b/yak-ops-ui/src/pages/workflow-management/index.tsx
@@ -1,3 +1,4 @@
+import { API_SUCCESS_CODE } from '@/services/http/response';
 import { history } from '@umijs/max';
 import {
   Dropdown,
@@ -58,7 +59,7 @@ const WorkflowManagementPage = () => {
     try {
       setLoading(true);
       const response = await fetchWorkflowList();
-      if (response.code !== 0) {
+      if (response.code !== API_SUCCESS_CODE) {
         message.error(response.message || '加载工作流失败');
         return;
       }
@@ -98,7 +99,7 @@ const WorkflowManagementPage = () => {
       centered: true,
       async onOk() {
         const response = await deleteWorkflow(workflow.id);
-        if (response.code !== 0) {
+        if (response.code !== API_SUCCESS_CODE) {
           message.error(response.message || '删除工作流失败');
           return;
         }
@@ -118,7 +119,10 @@ const WorkflowManagementPage = () => {
       maxParallelism: workflow.maxParallelism,
       dag: workflow.draft,
     });
-    if (response.code !== 0 || !response.data?.workflowId) {
+    if (
+      response.code !== API_SUCCESS_CODE ||
+      !response.data?.workflowId
+    ) {
       message.error(response.message || '复制工作流失败');
       return;
     }

--- a/yak-ops-ui/src/pages/workflow-management/service.test.ts
+++ b/yak-ops-ui/src/pages/workflow-management/service.test.ts
@@ -1,7 +1,7 @@
 import { normalizeWorkflowResponse } from './service';
 
 describe('workflow response adapter', () => {
-  it('maps yak-framework success responses to the workflow UI contract', () => {
+  it('preserves the framework success code', () => {
     expect(
       normalizeWorkflowResponse({
         code: 200,
@@ -9,7 +9,7 @@ describe('workflow response adapter', () => {
         message: '成功',
       }),
     ).toEqual({
-      code: 0,
+      code: 200,
       data: [{ id: 1 }],
       message: '成功',
     });

--- a/yak-ops-ui/src/pages/workflow-management/service.ts
+++ b/yak-ops-ui/src/pages/workflow-management/service.ts
@@ -1,4 +1,3 @@
-import { isSuccessfulResponse } from '@/services/http/response';
 import HttpUtils, { type ApiResponse } from '@/utils/HttpUtils';
 import type {
   CommonApiResponse,
@@ -10,11 +9,11 @@ import type {
 
 const WORKFLOW_API_PREFIX = '/api/v1/workflows';
 
-/** Adapt yak-framework's 200 success envelope to the workflow UI's legacy code-0 contract. */
+/** Normalize message fields without rewriting the backend business code. */
 export const normalizeWorkflowResponse = <T>(
   response: ApiResponse<T>,
 ): CommonApiResponse<T> => ({
-  code: isSuccessfulResponse(response, 'yak-framework') ? 0 : response.code,
+  code: response.code,
   data: response.data,
   message: response.message ?? response.msg,
 });

--- a/yak-ops-ui/src/services/http/response.test.ts
+++ b/yak-ops-ui/src/services/http/response.test.ts
@@ -1,4 +1,5 @@
 import {
+  API_SUCCESS_CODE,
   extractErrorMessage,
   isApiResponse,
   isSuccessfulResponse,
@@ -7,31 +8,42 @@ import {
 } from './response';
 
 describe('API response protocols', () => {
-  it('keeps success codes isolated by namespace', () => {
-    expect(isSuccessfulResponse({ code: 0 }, 'yak-ops')).toBe(true);
-    expect(isSuccessfulResponse({ code: 200 }, 'yak-framework')).toBe(true);
+  it('uses the framework success code for every API namespace', () => {
+    expect(API_SUCCESS_CODE).toBe(200);
+    expect(isSuccessfulResponse({ code: 200 }, 'yak-ops')).toBe(true);
     expect(isSuccessfulResponse({ code: 200 }, 'security')).toBe(true);
-    expect(isSuccessfulResponse({ code: 200 }, 'yak-ops')).toBe(false);
-    expect(isSuccessfulResponse({ code: 0 }, 'yak-framework')).toBe(false);
+    expect(isSuccessfulResponse({ code: 0 }, 'yak-ops')).toBe(false);
     expect(isSuccessfulResponse({ code: 0 }, 'security')).toBe(false);
   });
 
   it('extracts errors from both envelope variants', () => {
-    expect(extractErrorMessage({ code: 2, msg: 'ops failed' })).toBe('ops failed');
-    expect(extractErrorMessage({ code: 500, message: 'security failed' })).toBe('security failed');
+    expect(extractErrorMessage({ code: 999, msg: 'ops failed' })).toBe(
+      'ops failed',
+    );
+    expect(extractErrorMessage({ code: 500, message: 'security failed' })).toBe(
+      'security failed',
+    );
   });
 
   it('recognizes business session expiry without treating forbidden as anonymous', () => {
+    expect(isUnauthenticatedResponse({ code: 401 }, 'yak-ops')).toBe(true);
     expect(isUnauthenticatedResponse({ code: 401 }, 'security')).toBe(true);
     expect(isUnauthenticatedResponse({ code: 403 }, 'security')).toBe(false);
-    expect(isUnauthenticatedResponse({ code: 9, message: 'session_expired' }, 'security')).toBe(true);
+    expect(
+      isUnauthenticatedResponse(
+        { code: 999, message: 'session_expired' },
+        'security',
+      ),
+    ).toBe(true);
   });
 
-  it('does not parse arbitrary JSON as an envelope', () => {
+  it('routes only security endpoints to the security protocol', () => {
     expect(isApiResponse({ data: { code: 200 } })).toBe(false);
-    expect(protocolForUrl('/yak-security/api/v1/account/current')).toBe('security');
-    expect(protocolForUrl('/api/v1/workflows')).toBe('yak-framework');
-    expect(protocolForUrl('/api/v1/workflows/1')).toBe('yak-framework');
+    expect(protocolForUrl('/yak-security/api/v1/account/current')).toBe(
+      'security',
+    );
+    expect(protocolForUrl('/api/v1/workflows')).toBe('yak-ops');
+    expect(protocolForUrl('/api/v1/data-sources')).toBe('yak-ops');
     expect(protocolForUrl('/api/v1/jobs')).toBe('yak-ops');
   });
 });

--- a/yak-ops-ui/src/services/http/response.test.ts
+++ b/yak-ops-ui/src/services/http/response.test.ts
@@ -43,7 +43,7 @@ describe('API response protocols', () => {
       'security',
     );
     expect(protocolForUrl('/api/v1/workflows')).toBe('yak-ops');
-    expect(protocolForUrl('/api/v1/data-sources')).toBe('yak-ops');
+    expect(protocolForUrl('/api/v1/data-source/page')).toBe('yak-ops');
     expect(protocolForUrl('/api/v1/jobs')).toBe('yak-ops');
   });
 });

--- a/yak-ops-ui/src/services/http/response.ts
+++ b/yak-ops-ui/src/services/http/response.ts
@@ -1,4 +1,6 @@
-export type ApiProtocol = 'yak-ops' | 'yak-framework' | 'security';
+export type ApiProtocol = 'yak-ops' | 'security';
+
+export const API_SUCCESS_CODE = 200;
 
 export interface ApiResponse<T = unknown> {
   code: number;
@@ -11,10 +13,12 @@ const protocolRules: Record<
   ApiProtocol,
   { success: readonly number[]; unauthenticated: readonly number[] }
 > = {
-  'yak-ops': { success: [0], unauthenticated: [1, 401] },
-  'yak-framework': { success: [200], unauthenticated: [401] },
+  'yak-ops': {
+    success: [API_SUCCESS_CODE],
+    unauthenticated: [401],
+  },
   security: {
-    success: [200],
+    success: [API_SUCCESS_CODE],
     unauthenticated: [401, 2001],
   },
 };
@@ -26,11 +30,8 @@ const unauthenticatedMessages = new Set([
   'SESSION_INVALID',
 ]);
 
-export const protocolForUrl = (url?: string): ApiProtocol => {
-  if (url?.includes('/yak-security/')) return 'security';
-  if (url?.includes('/api/v1/workflows')) return 'yak-framework';
-  return 'yak-ops';
-};
+export const protocolForUrl = (url?: string): ApiProtocol =>
+  url?.includes('/yak-security/') ? 'security' : 'yak-ops';
 
 export const isApiResponse = (value: unknown): value is ApiResponse => {
   if (!value || typeof value !== 'object') return false;


### PR DESCRIPTION
## 背景

Yak Framework 的统一 `Result.success()` 返回业务成功码 `200`，但前端请求层仍将普通 Yak Ops 接口按旧协议处理，只认可 `0`。因此数据源、任务、资源等接口即使后端正常返回，也可能被请求拦截器错误抛成 `BizError`。

此前工作流页面通过单独的 `yak-framework` 协议和 `200 -> 0` 适配规避了问题，但这使前端同时存在两套成功码规则。

## 调整

- 统一定义 `API_SUCCESS_CODE = 200`
- Yak Ops 与 Yak Security 接口全部以 `200` 作为业务成功码
- 删除工作流专用的 `yak-framework` 响应协议
- 删除工作流 Service 中的 `200 -> 0` 转换，保留后端原始业务码
- 将工作流列表、详情、保存、复制、删除和创建等显式判断统一改为共享成功码常量
- 保留 `message` / `msg` 两种响应消息字段兼容
- 更新响应协议和工作流 Service 测试，明确拒绝旧成功码 `0`

## 修复效果

`/api/v1/data-source/page` 等普通业务接口返回：

```json
{
  "code": 200,
  "message": "成功",
  "data": {}
}
```

将被全局请求拦截器正确识别为成功，不再出现：

```text
Unhandled Rejection (BizError): 数据源操作失败，请稍后重试
```

## 影响范围

仅统一前端业务响应成功码及相关判断，不修改后端接口和业务数据结构。