### PR TITLE
fix(workflow-ui): stabilize and refine workflow designer

### DIFF
--- a/yak-ops-ui/src/pages/workflow-management/designer/components/block-selector/index.tsx
+++ b/yak-ops-ui/src/pages/workflow-management/designer/components/block-selector/index.tsx
@@ -46,10 +46,9 @@ const BlockSelector = ({ open, onClose, onSelect }: BlockSelectorProps) => {
   return (
     <aside
       className={[
-        'absolute left-4 top-[116px] z-40 flex w-[390px] max-h-[calc(100vh-145px)]',
-        'flex-col overflow-hidden rounded-[14px] border border-[#d0d5dd]/90 bg-white/[0.97]',
-        'shadow-[0_18px_50px_rgba(16,24,40,0.17)] backdrop-blur-[14px]',
-        'max-sm:w-[calc(100vw-32px)]',
+        'absolute left-4 top-[58px] z-40 flex max-h-[calc(100vh-132px)] w-[370px]',
+        'flex-col overflow-hidden rounded-xl border border-[#d0d5dd] bg-white',
+        'shadow-[0_18px_50px_rgba(16,24,40,0.16)] max-sm:w-[calc(100vw-32px)]',
       ].join(' ')}
     >
       <header className="flex h-12 shrink-0 items-center justify-between border-b border-[#eaecf0] px-2.5">
@@ -74,7 +73,7 @@ const BlockSelector = ({ open, onClose, onSelect }: BlockSelectorProps) => {
         </button>
       </header>
 
-      <div className="mx-2.5 mb-2 mt-2.5 flex h-[37px] shrink-0 items-center gap-1.5 rounded-lg border border-[#d0d5dd] bg-white px-2.5 text-[#98a2b3]">
+      <div className="mx-2.5 mb-2 mt-2.5 flex h-[37px] shrink-0 items-center gap-1.5 rounded-lg border border-[#d0d5dd] bg-white px-2.5 text-[#98a2b3] focus-within:border-[#84adff] focus-within:shadow-[0_0_0_3px_rgba(21,94,239,0.08)]">
         <Search size={15} />
         <Input
           bordered={false}
@@ -93,7 +92,7 @@ const BlockSelector = ({ open, onClose, onSelect }: BlockSelectorProps) => {
           className={[
             'h-[27px] shrink-0 rounded-md border-0 px-2.5 text-[10px]',
             category === 'all'
-              ? 'bg-[#eeefff] font-semibold text-[#4f46e5]'
+              ? 'bg-[#eff4ff] font-semibold text-[#155eef]'
               : 'bg-[#f2f4f7] text-[#667085]',
           ].join(' ')}
           onClick={() => setCategory('all')}
@@ -107,7 +106,7 @@ const BlockSelector = ({ open, onClose, onSelect }: BlockSelectorProps) => {
             className={[
               'h-[27px] shrink-0 rounded-md border-0 px-2.5 text-[10px]',
               category === value
-                ? 'bg-[#eeefff] font-semibold text-[#4f46e5]'
+                ? 'bg-[#eff4ff] font-semibold text-[#155eef]'
                 : 'bg-[#f2f4f7] text-[#667085]',
             ].join(' ')}
             onClick={() => setCategory(value)}
@@ -134,7 +133,7 @@ const BlockSelector = ({ open, onClose, onSelect }: BlockSelectorProps) => {
                     className={[
                       'grid min-h-[58px] grid-cols-[30px_minmax(0,1fr)_16px] items-center gap-2',
                       'rounded-lg border border-transparent bg-transparent px-2 py-2 text-left text-[#344054]',
-                      'hover:border-[#dddafe] hover:bg-[#f8f7ff]',
+                      'hover:border-[#b2ccff] hover:bg-[#f5f8ff]',
                     ].join(' ')}
                     onClick={() => {
                       onSelect(item.type);

--- a/yak-ops-ui/src/pages/workflow-management/designer/components/header/index.tsx
+++ b/yak-ops-ui/src/pages/workflow-management/designer/components/header/index.tsx
@@ -1,15 +1,19 @@
 import { Input, Tooltip } from 'antd';
 import {
-  ArrowLeft,
+  Activity,
+  Braces,
   Check,
+  ChevronLeft,
   CircleDot,
+  CircleHelp,
   Clock3,
   History,
+  Home,
   Play,
   Save,
   Settings2,
   SlidersHorizontal,
-  Variable,
+  Workflow as WorkflowIcon,
 } from 'lucide-react';
 import { useEffect, useState, type ReactNode } from 'react';
 import type {
@@ -50,7 +54,7 @@ const WorkflowHeader = ({
     setEditing(false);
   };
 
-  const panelButton = (
+  const topIconButton = (
     panel: Exclude<WorkflowPanelType, 'node' | null>,
     label: string,
     icon: ReactNode,
@@ -59,78 +63,160 @@ const WorkflowHeader = ({
       <button
         type="button"
         className={[
-          'pointer-events-auto inline-flex h-[30px] items-center gap-1.5 rounded-md border-0 px-2.5',
-          'text-[11px] transition-colors',
+          'inline-flex h-8 min-w-8 items-center justify-center gap-1.5 rounded-lg border px-2.5',
+          'text-[12px] font-medium transition-colors',
           activePanel === panel
-            ? 'bg-[#f1f0ff] text-[#4f46e5]'
-            : 'bg-transparent text-[#667085] hover:bg-[#f1f0ff] hover:text-[#4f46e5]',
+            ? 'border-[#b2ccff] bg-[#eff4ff] text-[#155eef]'
+            : 'border-[#e4e7ec] bg-white text-[#475467] hover:bg-[#f9fafb] hover:text-[#344054]',
         ].join(' ')}
         onClick={() => onOpenPanel(panel)}
       >
         {icon}
-        <span>{label}</span>
+        <span className="max-xl:hidden">{label}</span>
       </button>
     </Tooltip>
   );
 
-  return (
-    <header
-      className={[
-        'pointer-events-none absolute left-3.5 right-3.5 top-3.5 z-30 grid items-center',
-        'grid-cols-[minmax(260px,1fr)_auto_minmax(260px,1fr)] max-lg:grid-cols-[1fr_auto]',
-      ].join(' ')}
-    >
-      <div className="justify-self-start flex min-w-0 items-center gap-2.5">
-        <Tooltip title="返回工作流列表">
-          <button
-            type="button"
-            className={[
-              'pointer-events-auto flex h-[38px] w-[38px] items-center justify-center rounded-[10px]',
-              'border border-[#d0d5dd]/80 bg-white/90 text-[#475467]',
-              'shadow-[0_7px_20px_rgba(16,24,40,0.07)] backdrop-blur-[10px]',
-              'hover:bg-white',
-            ].join(' ')}
-            onClick={onBack}
-          >
-            <ArrowLeft size={18} />
-          </button>
-        </Tooltip>
+  const sideNavButton = (
+    panel: Exclude<WorkflowPanelType, 'node' | null> | 'canvas',
+    label: string,
+    icon: ReactNode,
+  ) => {
+    const active =
+      panel === 'canvas'
+        ? activePanel === null || activePanel === 'node'
+        : activePanel === panel;
 
-        <div
-          className={[
-            'pointer-events-auto flex h-[42px] min-w-0 items-center gap-2.5 rounded-[10px]',
-            'border border-[#d0d5dd]/80 bg-white/90 px-2.5',
-            'shadow-[0_7px_20px_rgba(16,24,40,0.07)] backdrop-blur-[10px]',
-          ].join(' ')}
-        >
-          {editing ? (
-            <Input
-              autoFocus
-              value={name}
-              maxLength={255}
-              onChange={(event) => setName(event.target.value)}
-              onPressEnter={applyName}
-              onBlur={applyName}
-              className="h-[30px] w-[210px] px-1.5 text-xs"
-            />
-          ) : (
+    return (
+      <button
+        type="button"
+        className={[
+          'flex h-10 w-full items-center gap-3 rounded-lg border-0 px-3 text-left text-[13px]',
+          'font-medium transition-colors',
+          active
+            ? 'bg-[#eaf0ff] text-[#155eef]'
+            : 'bg-transparent text-[#475467] hover:bg-[#f2f4f7] hover:text-[#344054]',
+        ].join(' ')}
+        onClick={() => {
+          if (panel === 'canvas') {
+            if (activePanel && activePanel !== 'node') onOpenPanel(activePanel);
+            return;
+          }
+          onOpenPanel(panel);
+        }}
+      >
+        {icon}
+        <span>{label}</span>
+      </button>
+    );
+  };
+
+  return (
+    <>
+      <aside className="absolute inset-y-0 left-0 z-50 hidden w-[220px] flex-col border-r border-[#e4e7ec] bg-white lg:flex">
+        <div className="flex h-[52px] shrink-0 items-center gap-2 border-b border-[#eaecf0] px-3">
+          <Tooltip title="返回工作流列表">
             <button
               type="button"
-              onDoubleClick={() => setEditing(true)}
-              className="min-w-0 border-0 bg-transparent p-0 text-left"
+              className="flex h-8 w-8 items-center justify-center rounded-lg border-0 bg-transparent text-[#667085] hover:bg-[#f2f4f7] hover:text-[#344054]"
+              onClick={onBack}
             >
-              <strong className="block max-w-[230px] overflow-hidden text-ellipsis whitespace-nowrap text-xs leading-4 text-[#1d2939]">
-                {workflow?.name || '工作流设计器'}
-              </strong>
-              <span className="block font-mono text-[9px] leading-[13px] text-[#98a2b3]">
-                {workflow?.code || '-'}
-              </span>
+              <ChevronLeft size={17} />
             </button>
+          </Tooltip>
+          <Home size={15} className="text-[#98a2b3]" />
+          <span className="text-[#d0d5dd]">/</span>
+          <strong className="text-[13px] font-semibold text-[#344054]">工作流</strong>
+        </div>
+
+        <div className="px-3 pb-3 pt-4">
+          <div className="flex items-start gap-3">
+            <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border border-[#dbe4ff] bg-[#eef3ff] text-[#155eef]">
+              <WorkflowIcon size={20} />
+            </span>
+            <div className="min-w-0 flex-1">
+              {editing ? (
+                <Input
+                  autoFocus
+                  value={name}
+                  maxLength={255}
+                  onChange={(event) => setName(event.target.value)}
+                  onPressEnter={applyName}
+                  onBlur={applyName}
+                  className="h-8 px-2 text-[13px]"
+                />
+              ) : (
+                <button
+                  type="button"
+                  className="block w-full border-0 bg-transparent p-0 text-left"
+                  onDoubleClick={() => setEditing(true)}
+                >
+                  <strong
+                    className="block overflow-hidden text-ellipsis whitespace-nowrap text-[14px] font-semibold text-[#101828]"
+                    title={workflow?.name}
+                  >
+                    {workflow?.name || '工作流设计器'}
+                  </strong>
+                  <span className="mt-0.5 block overflow-hidden text-ellipsis whitespace-nowrap text-[10px] uppercase tracking-[0.04em] text-[#98a2b3]">
+                    {workflow?.code || 'WORKFLOW'}
+                  </span>
+                </button>
+              )}
+            </div>
+            <Tooltip title="工作流设置">
+              <button
+                type="button"
+                className="flex h-7 w-7 items-center justify-center rounded-md border-0 bg-transparent text-[#98a2b3] hover:bg-[#f2f4f7] hover:text-[#475467]"
+                onClick={() => onOpenPanel('workflow-settings')}
+              >
+                <Settings2 size={15} />
+              </button>
+            </Tooltip>
+          </div>
+        </div>
+
+        <nav className="flex flex-col gap-1 px-3">
+          {sideNavButton('canvas', '编排', <WorkflowIcon size={17} />)}
+          {sideNavButton('variables', '变量', <Braces size={17} />)}
+          {sideNavButton(
+            'environment',
+            '环境变量',
+            <SlidersHorizontal size={17} />,
           )}
+          {sideNavButton('history', '历史版本', <History size={17} />)}
+          {sideNavButton('run', '调试运行', <Activity size={17} />)}
+        </nav>
+
+        <div className="mt-auto flex h-14 items-center justify-between border-t border-[#eaecf0] px-4">
+          <div className="flex items-center gap-2">
+            <span className="flex h-7 w-7 items-center justify-center rounded-full bg-[#155eef] text-[11px] font-semibold text-white">
+              Y
+            </span>
+            <span className="text-[12px] font-medium text-[#475467]">Yak Ops</span>
+          </div>
+          <CircleHelp size={17} className="text-[#98a2b3]" />
+        </div>
+      </aside>
+
+      <header className="absolute left-[220px] right-0 top-0 z-50 flex h-[52px] items-center justify-between border-b border-[#e4e7ec] bg-white px-3 max-lg:left-0">
+        <div className="flex min-w-0 items-center gap-2.5">
+          <div className="hidden items-center gap-2 max-lg:flex">
+            <button
+              type="button"
+              className="flex h-8 w-8 items-center justify-center rounded-lg border-0 bg-transparent text-[#667085] hover:bg-[#f2f4f7]"
+              onClick={onBack}
+            >
+              <ChevronLeft size={17} />
+            </button>
+            <strong className="max-w-[180px] truncate text-[13px] text-[#344054]">
+              {workflow?.name || '工作流'}
+            </strong>
+          </div>
+
+          <span className="hidden text-[12px] text-[#667085] lg:inline">草稿状态</span>
           <i
             className={[
-              'inline-flex items-center gap-1 whitespace-nowrap rounded-[10px] px-1.5 py-[3px]',
-              'text-[9px] not-italic',
+              'hidden items-center gap-1 rounded-full px-2 py-1 text-[11px] not-italic lg:inline-flex',
               dirty
                 ? 'bg-[#fffaeb] text-[#b54708]'
                 : 'bg-[#ecfdf3] text-[#027a48]',
@@ -140,49 +226,45 @@ const WorkflowHeader = ({
             {dirty ? '有未保存修改' : '草稿已保存'}
           </i>
         </div>
-      </div>
 
-      <div
-        className={[
-          'justify-self-center flex h-[38px] items-center gap-0.5 rounded-[10px] p-[3px]',
-          'border border-[#d0d5dd]/80 bg-white/90 shadow-[0_8px_24px_rgba(16,24,40,0.08)]',
-          'backdrop-blur-[12px] max-lg:hidden',
-        ].join(' ')}
-      >
-        {panelButton('variables', '变量', <Variable size={15} />)}
-        {panelButton('environment', '环境变量', <SlidersHorizontal size={15} />)}
-        {panelButton('history', '历史', <History size={15} />)}
-        {panelButton('workflow-settings', '设置', <Settings2 size={15} />)}
-      </div>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            className={[
+              'inline-flex h-8 items-center gap-1.5 rounded-lg border px-3 text-[12px] font-medium',
+              activePanel === 'run'
+                ? 'border-[#b2ccff] bg-[#eff4ff] text-[#155eef]'
+                : 'border-[#e4e7ec] bg-white text-[#475467] hover:bg-[#f9fafb]',
+            ].join(' ')}
+            onClick={() => onOpenPanel('run')}
+          >
+            <Play size={15} />
+            预览
+          </button>
 
-      <div className="justify-self-end flex items-center gap-2">
-        <button
-          type="button"
-          className={[
-            'pointer-events-auto inline-flex h-9 items-center gap-1.5 rounded-lg px-3.5',
-            'border border-[#d0d5dd] bg-white/95 text-xs font-semibold text-[#344054]',
-            'shadow-[0_4px_12px_rgba(16,24,40,0.06)] max-sm:hidden',
-          ].join(' ')}
-          onClick={() => onOpenPanel('run')}
-        >
-          <Play size={15} />
-          运行
-        </button>
-        <button
-          type="button"
-          className={[
-            'pointer-events-auto inline-flex h-9 items-center gap-1.5 rounded-lg px-3.5',
-            'border-0 bg-[#5d5fef] text-xs font-semibold text-white',
-            'shadow-[0_7px_16px_rgba(93,95,239,0.24)] disabled:cursor-not-allowed disabled:opacity-[0.55]',
-          ].join(' ')}
-          disabled={saving}
-          onClick={onSave}
-        >
-          {saving ? <Clock3 size={15} /> : <Save size={15} />}
-          {saving ? '保存中...' : '保存'}
-        </button>
-      </div>
-    </header>
+          <div className="hidden items-center gap-2 md:flex">
+            {topIconButton('variables', '变量', <Braces size={15} />)}
+            {topIconButton(
+              'environment',
+              '环境',
+              <SlidersHorizontal size={15} />,
+            )}
+            {topIconButton('history', '历史', <History size={15} />)}
+            {topIconButton('workflow-settings', '设置', <Settings2 size={15} />)}
+          </div>
+
+          <button
+            type="button"
+            className="inline-flex h-8 items-center gap-1.5 rounded-lg border-0 bg-[#155eef] px-3.5 text-[12px] font-semibold text-white shadow-[0_4px_10px_rgba(21,94,239,0.22)] hover:bg-[#004eeb] disabled:cursor-not-allowed disabled:opacity-[0.55]"
+            disabled={saving}
+            onClick={onSave}
+          >
+            {saving ? <Clock3 size={15} className="animate-spin" /> : <Save size={15} />}
+            {saving ? '保存中...' : '保存'}
+          </button>
+        </div>
+      </header>
+    </>
   );
 };
 

--- a/yak-ops-ui/src/pages/workflow-management/designer/components/node/WorkflowNode.tsx
+++ b/yak-ops-ui/src/pages/workflow-management/designer/components/node/WorkflowNode.tsx
@@ -27,10 +27,10 @@ const footerStatusClass = {
 };
 
 const handleClass = [
-  '!h-[9px] !w-[9px] !border-2 !border-white !bg-[#98a2b3]',
+  '!h-2 !w-2 !border-2 !border-white !bg-[#98a2b3]',
   '!shadow-[0_0_0_1px_#98a2b3]',
-  'hover:!h-[11px] hover:!w-[11px] hover:!bg-[#5d5fef]',
-  'hover:!shadow-[0_0_0_1px_#5d5fef]',
+  'hover:!h-[10px] hover:!w-[10px] hover:!bg-[#155eef]',
+  'hover:!shadow-[0_0_0_1px_#155eef]',
 ].join(' ');
 
 const WorkflowNode = ({ id, data, selected }: NodeProps<WorkflowNodeData>) => {
@@ -41,7 +41,7 @@ const WorkflowNode = ({ id, data, selected }: NodeProps<WorkflowNodeData>) => {
     return (
       <div
         className={[
-          'w-[230px] min-h-[120px] rounded-lg border border-[#f4d35e]',
+          'min-h-[110px] w-[220px] rounded-xl border border-[#f4d35e]',
           'bg-[#fff9c9] px-3.5 py-3 text-[#713f12]',
           'shadow-[0_4px_12px_rgba(113,63,18,0.10)]',
           selected
@@ -53,7 +53,7 @@ const WorkflowNode = ({ id, data, selected }: NodeProps<WorkflowNodeData>) => {
       >
         <div className="flex items-center gap-1.5">
           <NodeIcon type="NOTE" size={16} />
-          <strong className="text-[11px]">{data.title || '注释'}</strong>
+          <strong className="text-[12px]">{data.title || '注释'}</strong>
         </div>
         <p className="mt-2.5 whitespace-pre-wrap text-[11px] leading-[18px] text-[#854d0e]">
           {String(data.config.content || data.description || '注释内容')}
@@ -65,7 +65,7 @@ const WorkflowNode = ({ id, data, selected }: NodeProps<WorkflowNodeData>) => {
   return (
     <div
       className={[
-        'group relative w-[250px] rounded-[17px] transition-[filter,opacity] duration-150',
+        'group relative w-[224px] rounded-xl transition-[filter,opacity] duration-150',
         data.enabled ? '' : 'opacity-55 grayscale-[0.3]',
       ]
         .filter(Boolean)
@@ -78,60 +78,62 @@ const WorkflowNode = ({ id, data, selected }: NodeProps<WorkflowNodeData>) => {
 
       <div
         className={[
-          'overflow-hidden rounded-[15px] border bg-white/95',
-          'shadow-[0_0_0_1px_rgba(208,213,221,0.8),0_4px_12px_rgba(16,24,40,0.08),0_1px_2px_rgba(16,24,40,0.04)]',
+          'overflow-hidden rounded-xl border bg-white',
+          'shadow-[0_1px_2px_rgba(16,24,40,0.05),0_4px_12px_rgba(16,24,40,0.06)]',
           'transition-[box-shadow,border-color] duration-150',
-          'group-hover:shadow-[0_0_0_1px_rgba(152,162,179,0.9),0_10px_24px_rgba(16,24,40,0.11)]',
+          'group-hover:border-[#b9c2cf] group-hover:shadow-[0_8px_20px_rgba(16,24,40,0.10)]',
           selected
-            ? 'border-[#7467f5] shadow-[0_0_0_2px_rgba(109,94,252,0.2),0_10px_26px_rgba(79,70,229,0.14)]'
-            : 'border-transparent',
+            ? 'border-[#155eef] shadow-[0_0_0_2px_rgba(21,94,239,0.16),0_8px_22px_rgba(21,94,239,0.10)]'
+            : 'border-[#dfe4ea]',
           shellStatusClass[status],
         ]
           .filter(Boolean)
           .join(' ')}
       >
-        <header className="flex h-[47px] items-center justify-between border-b border-[#f0f1f4] pl-3 pr-2.5">
+        <header className="flex h-[43px] items-center justify-between px-3">
           <div className="flex min-w-0 items-center gap-2">
-            <span className="flex h-[27px] w-[27px] shrink-0 items-center justify-center rounded-lg bg-[color-mix(in_srgb,var(--node-color)_10%,white)]">
+            <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-[color-mix(in_srgb,var(--node-color)_10%,white)]">
               <NodeIcon type={data.nodeType} size={17} />
             </span>
-            <strong
-              className="max-w-[165px] overflow-hidden text-ellipsis whitespace-nowrap text-xs font-semibold text-[#344054]"
-              title={data.title}
-            >
-              {data.title || meta.title}
-            </strong>
+            <div className="min-w-0">
+              <strong
+                className="block max-w-[150px] overflow-hidden text-ellipsis whitespace-nowrap text-[12px] font-semibold text-[#344054]"
+                title={data.title}
+              >
+                {data.title || meta.title}
+              </strong>
+              <span className="block text-[9px] uppercase tracking-[0.04em] text-[#98a2b3]">
+                {meta.title}
+              </span>
+            </div>
           </div>
           <button
             type="button"
             aria-label="节点操作"
-            className="flex h-[26px] w-[26px] items-center justify-center rounded-md border-0 bg-transparent text-[#98a2b3] opacity-0 hover:bg-[#f2f4f7] hover:text-[#475467] group-hover:opacity-100"
+            className="flex h-7 w-7 items-center justify-center rounded-md border-0 bg-transparent text-[#98a2b3] opacity-0 hover:bg-[#f2f4f7] hover:text-[#475467] group-hover:opacity-100"
           >
             <MoreHorizontal size={15} />
           </button>
         </header>
 
-        <div className="min-h-[76px] px-3 pb-[9px] pt-2.5">
-          <span className="text-[9px] font-bold uppercase tracking-[0.05em] text-[var(--node-color)]">
-            {meta.title}
-          </span>
-          <p className="mt-1 line-clamp-2 text-[11px] leading-[17px] text-[#667085]">
+        <div className="min-h-[56px] border-t border-[#f0f1f4] px-3 py-2.5">
+          <p className="line-clamp-2 text-[10px] leading-[16px] text-[#667085]">
             {data.description || meta.description}
           </p>
           {data.nodeType === 'LLM' && (
-            <div className="mt-[9px] overflow-hidden text-ellipsis whitespace-nowrap rounded-md bg-[#f8f9fb] px-2 py-1.5 text-[10px] text-[#475467]">
+            <div className="mt-2 overflow-hidden text-ellipsis whitespace-nowrap rounded-md bg-[#f5f7fa] px-2 py-1 text-[9px] text-[#475467]">
               {String(data.config.provider || 'OpenAI')} ·{' '}
               {String(data.config.model || '模型未选择')}
             </div>
           )}
           {data.nodeType === 'HTTP' && (
-            <div className="mt-[9px] overflow-hidden text-ellipsis whitespace-nowrap rounded-md bg-[#f8f9fb] px-2 py-1.5 text-[10px] text-[#475467]">
+            <div className="mt-2 overflow-hidden text-ellipsis whitespace-nowrap rounded-md bg-[#f5f7fa] px-2 py-1 text-[9px] text-[#475467]">
               {String(data.config.method || 'GET')} ·{' '}
               {String(data.config.url || '未配置 URL')}
             </div>
           )}
           {data.nodeType === 'CONDITION' && (
-            <div className="mt-[9px] flex gap-1.5">
+            <div className="mt-2 flex gap-1.5">
               {['IF', 'ELSE'].map((branch) => (
                 <span
                   key={branch}
@@ -144,9 +146,14 @@ const WorkflowNode = ({ id, data, selected }: NodeProps<WorkflowNodeData>) => {
           )}
         </div>
 
-        <footer className="flex h-[34px] items-center justify-between border-t border-[#f0f1f4] bg-[#fcfcfd] px-3 text-[9px] text-[#98a2b3]">
-          <span className={['inline-flex items-center gap-1', footerStatusClass[status]].join(' ')}>
-            {status === 'running' && <RotateCw size={12} className="animate-spin" />}
+        <footer className="flex h-[29px] items-center justify-between border-t border-[#f0f1f4] bg-[#fcfcfd] px-3 text-[9px] text-[#98a2b3]">
+          <span
+            className={[
+              'inline-flex items-center gap-1',
+              footerStatusClass[status],
+            ].join(' ')}
+          >
+            {status === 'running' && <RotateCw size={11} className="animate-spin" />}
             {statusLabelMap[status] || (data.enabled ? '已配置' : '已停用')}
           </span>
           {(data.retryTimes > 0 || data.timeoutSeconds > 0) && (
@@ -165,10 +172,10 @@ const WorkflowNode = ({ id, data, selected }: NodeProps<WorkflowNodeData>) => {
           <button
             type="button"
             className={[
-              'nodrag absolute right-[-34px] top-1/2 flex h-[22px] w-[22px] -translate-y-1/2',
+              'nodrag absolute right-[-31px] top-1/2 flex h-[21px] w-[21px] -translate-y-1/2',
               'items-center justify-center rounded-full border border-[#d0d5dd] bg-white text-[#667085]',
               'opacity-0 shadow-[0_3px_8px_rgba(16,24,40,0.09)] transition-all duration-150',
-              'hover:border-[#8b83fa] hover:text-[#5d5fef] group-hover:opacity-100',
+              'hover:border-[#84adff] hover:text-[#155eef] group-hover:opacity-100',
               selected ? 'opacity-100' : '',
             ]
               .filter(Boolean)

--- a/yak-ops-ui/src/pages/workflow-management/designer/components/operator/CanvasOperator.tsx
+++ b/yak-ops-ui/src/pages/workflow-management/designer/components/operator/CanvasOperator.tsx
@@ -30,14 +30,13 @@ interface CanvasOperatorProps {
 }
 
 const operatorGroupClass = [
-  'pointer-events-auto flex h-[35px] items-center gap-px rounded-lg p-[3px]',
-  'border border-[#d0d5dd]/85 bg-white/90',
-  'shadow-[0_7px_20px_rgba(16,24,40,0.09)] backdrop-blur-[10px]',
+  'pointer-events-auto flex items-center gap-px rounded-lg border border-[#d0d5dd]/90',
+  'bg-white/95 p-[3px] shadow-[0_5px_16px_rgba(16,24,40,0.09)] backdrop-blur-[10px]',
 ].join(' ');
 
 const iconButtonClass = [
-  'flex h-[27px] min-w-[27px] items-center justify-center rounded-md border-0 bg-transparent px-2',
-  'text-[9px] text-[#667085] hover:bg-[#f2f4f7] hover:text-[#344054]',
+  'flex h-7 min-w-7 items-center justify-center rounded-md border-0 bg-transparent px-2',
+  'text-[10px] text-[#667085] hover:bg-[#f2f4f7] hover:text-[#344054]',
   'disabled:cursor-not-allowed disabled:opacity-[0.35]',
 ].join(' ');
 
@@ -72,56 +71,51 @@ const CanvasOperator = ({
   ];
 
   return (
-    <div className="pointer-events-none absolute bottom-3 left-3 right-3 z-20 grid grid-cols-[1fr_auto_1fr] items-end">
-      <div className="flex items-end gap-2">
-        <div className={operatorGroupClass}>
-          <Tooltip title="撤销 Ctrl/⌘ + Z">
-            <button type="button" className={iconButtonClass} disabled={!canUndo} onClick={onUndo}>
-              <Undo2 size={15} />
-            </button>
-          </Tooltip>
-          <Tooltip title="重做 Ctrl/⌘ + Shift + Z">
-            <button type="button" className={iconButtonClass} disabled={!canRedo} onClick={onRedo}>
-              <Redo2 size={15} />
-            </button>
-          </Tooltip>
-        </div>
-        <div className={operatorGroupClass}>
-          <Tooltip title="自动布局">
-            <button type="button" className={iconButtonClass} onClick={onAutoLayout}>
-              <AlignHorizontalSpaceAround size={15} />
-            </button>
-          </Tooltip>
-          <Tooltip title="导入 JSON">
-            <button type="button" className={iconButtonClass} onClick={onImport}>
-              <Upload size={15} />
-            </button>
-          </Tooltip>
-          <Tooltip title="导出 JSON">
-            <button type="button" className={iconButtonClass} onClick={onExport}>
-              <Download size={15} />
-            </button>
-          </Tooltip>
-        </div>
+    <div className="pointer-events-none absolute inset-0 z-20">
+      <div className={[operatorGroupClass, 'absolute left-3 top-1/2 -translate-y-1/2 flex-col'].join(' ')}>
+        <Tooltip title="自动布局" placement="right">
+          <button type="button" className={iconButtonClass} onClick={onAutoLayout}>
+            <AlignHorizontalSpaceAround size={15} />
+          </button>
+        </Tooltip>
+        <Tooltip title="导入 JSON" placement="right">
+          <button type="button" className={iconButtonClass} onClick={onImport}>
+            <Upload size={15} />
+          </button>
+        </Tooltip>
+        <Tooltip title="导出 JSON" placement="right">
+          <button type="button" className={iconButtonClass} onClick={onExport}>
+            <Download size={15} />
+          </button>
+        </Tooltip>
+        <Tooltip title="变量检查" placement="right">
+          <button
+            type="button"
+            className={[
+              iconButtonClass,
+              variableInspectOpen ? 'bg-[#eff4ff] text-[#155eef]' : '',
+            ].join(' ')}
+            onClick={onToggleVariableInspect}
+          >
+            <Braces size={15} />
+          </button>
+        </Tooltip>
       </div>
 
-      <button
-        type="button"
-        className={[
-          'pointer-events-auto justify-self-center inline-flex h-[34px] items-center gap-1.5 rounded-lg px-2.5',
-          'border border-[#d0d5dd]/85 bg-white/90 text-[9px]',
-          'shadow-[0_7px_20px_rgba(16,24,40,0.09)] backdrop-blur-[10px]',
-          variableInspectOpen
-            ? 'border-[#c7c4fc] bg-[#f4f3ff] text-[#4f46e5]'
-            : 'text-[#667085]',
-        ].join(' ')}
-        onClick={onToggleVariableInspect}
-      >
-        <Braces size={15} />
-        变量检查
-      </button>
+      <div className={[operatorGroupClass, 'absolute bottom-3 left-3'].join(' ')}>
+        <Tooltip title="撤销 Ctrl/⌘ + Z">
+          <button type="button" className={iconButtonClass} disabled={!canUndo} onClick={onUndo}>
+            <Undo2 size={15} />
+          </button>
+        </Tooltip>
+        <Tooltip title="重做 Ctrl/⌘ + Shift + Z">
+          <button type="button" className={iconButtonClass} disabled={!canRedo} onClick={onRedo}>
+            <Redo2 size={15} />
+          </button>
+        </Tooltip>
+      </div>
 
-      <div className="relative justify-self-end flex items-end gap-2">
+      <div className="pointer-events-auto absolute bottom-3 right-3 flex items-end gap-2">
         {showMiniMap && (
           <MiniMap
             pannable
@@ -142,8 +136,11 @@ const CanvasOperator = ({
               <Minus size={15} />
             </button>
           </Tooltip>
-          <Dropdown menu={{ items: zoomItems }} placement="top">
-            <button type="button" className={[iconButtonClass, 'min-w-[47px] gap-1 text-[#475467]'].join(' ')}>
+          <Dropdown menu={{ items: zoomItems }} placement="topRight">
+            <button
+              type="button"
+              className={[iconButtonClass, 'min-w-[48px] gap-1 text-[#475467]'].join(' ')}
+            >
               {Math.round(zoom * 100)}% <ChevronDown size={12} />
             </button>
           </Dropdown>

--- a/yak-ops-ui/src/pages/workflow-management/designer/components/panel/shared.tsx
+++ b/yak-ops-ui/src/pages/workflow-management/designer/components/panel/shared.tsx
@@ -1,22 +1,21 @@
 import type { ReactNode } from 'react';
 
 export const panelShellClass = [
-  'absolute bottom-2.5 right-2.5 top-[65px] z-40 flex w-[410px] flex-col overflow-hidden',
-  'rounded-[14px] border border-[#d0d5dd]/90 bg-white/[0.98]',
-  'shadow-[0_18px_50px_rgba(16,24,40,0.16)] backdrop-blur-[14px]',
-  'max-lg:w-[min(390px,calc(100vw-20px))]',
+  'absolute bottom-0 right-0 top-0 z-40 flex w-[380px] flex-col overflow-hidden',
+  'border-l border-[#e4e7ec] bg-white shadow-[-10px_0_30px_rgba(16,24,40,0.06)]',
+  'max-lg:w-[min(380px,100vw)]',
 ].join(' ');
 
 export const panelHeaderClass =
-  'flex min-h-14 shrink-0 items-center justify-between border-b border-[#eaecf0] pl-[15px] pr-3';
+  'flex min-h-[62px] shrink-0 items-center justify-between border-b border-[#eaecf0] pl-4 pr-3';
 
-export const panelContentClass = 'min-h-0 flex-1 overflow-y-auto';
+export const panelContentClass = 'min-h-0 flex-1 overflow-y-auto bg-white';
 
 export const panelFooterClass =
-  'flex min-h-[43px] shrink-0 items-center justify-between border-t border-[#eaecf0] bg-[#fcfcfd] px-3';
+  'flex min-h-[46px] shrink-0 items-center justify-between border-t border-[#eaecf0] bg-[#fcfcfd] px-3.5';
 
 export const panelIconButtonClass =
-  'flex h-7 w-7 items-center justify-center rounded-md border-0 bg-transparent text-[#667085] hover:bg-[#f2f4f7] hover:text-[#344054]';
+  'flex h-8 w-8 items-center justify-center rounded-lg border-0 bg-transparent text-[#667085] hover:bg-[#f2f4f7] hover:text-[#344054]';
 
 interface PanelTitleProps {
   title: string;
@@ -28,8 +27,10 @@ export const PanelTitle = ({ title, description, icon }: PanelTitleProps) => (
   <div className="flex min-w-0 items-center gap-2.5">
     {icon}
     <div className="min-w-0">
-      <strong className="block text-[13px] text-[#344054]">{title}</strong>
-      <span className="mt-0.5 block text-[9px] text-[#98a2b3]">
+      <strong className="block text-[14px] font-semibold text-[#344054]">
+        {title}
+      </strong>
+      <span className="mt-0.5 block text-[10px] text-[#98a2b3]">
         {description}
       </span>
     </div>

--- a/yak-ops-ui/src/pages/workflow-management/designer/hooks/useWorkflowHistory.ts
+++ b/yak-ops-ui/src/pages/workflow-management/designer/hooks/useWorkflowHistory.ts
@@ -60,15 +60,25 @@ export const useWorkflowHistory = () => {
     refresh();
   }, []);
 
-  const canUndo = pastRef.current.length > 0;
-  const canRedo = futureRef.current.length > 0;
-
-  return useMemo(() => ({
-    record,
-    undo,
-    redo,
-    reset,
-    canUndo,
-    canRedo,
-  }), [canRedo, canUndo, record, redo, reset, undo]);
+  /*
+   * Keep the history API identity stable. The designer's initial-load callback
+   * depends on this object, so returning a new object whenever canUndo/canRedo
+   * changes causes the workflow to be fetched again after a drag or edit. The
+   * getters still expose the latest stack state on every render.
+   */
+  return useMemo(
+    () => ({
+      record,
+      undo,
+      redo,
+      reset,
+      get canUndo() {
+        return pastRef.current.length > 0;
+      },
+      get canRedo() {
+        return futureRef.current.length > 0;
+      },
+    }),
+    [record, redo, reset, undo],
+  );
 };

--- a/yak-ops-ui/src/pages/workflow-management/designer/index.less
+++ b/yak-ops-ui/src/pages/workflow-management/designer/index.less
@@ -1,16 +1,28 @@
-/* React Flow renders internal DOM outside our component boundaries. All product
- * component styling lives in Tailwind classes; this file only adapts the
- * third-party canvas shell and preserves the existing stable entry markup. */
+/* React Flow renders internal DOM outside our component boundaries. Product
+ * components use Tailwind classes; this file only owns the full-screen editor
+ * frame and the third-party canvas DOM. */
 .dify-workflow-designer {
+  --workflow-sidebar-width: 220px;
+  --workflow-header-height: 52px;
+
   position: fixed;
   inset: 0;
   z-index: 120;
   overflow: hidden;
   color: #101828;
-  background: #f7f8fa;
+  background: #f4f6f8;
 }
 
-.dify-workflow-loading,
+.dify-workflow-loading {
+  position: absolute;
+  top: var(--workflow-header-height);
+  right: 0;
+  bottom: 0;
+  left: var(--workflow-sidebar-width);
+  width: auto;
+  height: auto;
+}
+
 .dify-workflow-loading > .ant-spin-container,
 .dify-workflow-canvas {
   width: 100%;
@@ -23,34 +35,50 @@
 
 .dify-workflow-canvas {
   position: relative;
-  background:
-    radial-gradient(circle at 50% 0, rgba(109, 94, 252, 0.035), transparent 35%),
-    #f8f9fb;
+  overflow: hidden;
+  background: #f7f8fa;
 }
 
-.dify-workflow-canvas .react-flow__pane { cursor: grab; }
-.dify-workflow-canvas .react-flow__pane:active { cursor: grabbing; }
+.dify-workflow-canvas .react-flow__renderer,
+.dify-workflow-canvas .react-flow__pane {
+  background: transparent;
+}
+
+.dify-workflow-canvas .react-flow__pane {
+  cursor: grab;
+}
+
+.dify-workflow-canvas .react-flow__pane:active {
+  cursor: grabbing;
+}
+
 .dify-workflow-canvas .react-flow__edge-path {
-  stroke: #98a2b3;
+  stroke: #a6afbd;
   stroke-width: 1.5;
 }
+
 .dify-workflow-canvas .react-flow__edge.selected .react-flow__edge-path,
 .dify-workflow-canvas .react-flow__edge:hover .react-flow__edge-path {
-  stroke: #6d5efc;
+  stroke: #155eef;
   stroke-width: 2;
 }
+
 .dify-workflow-canvas .react-flow__selection {
-  border: 1px solid rgba(93, 95, 239, 0.7);
-  background: rgba(93, 95, 239, 0.08);
+  border: 1px solid rgba(21, 94, 239, 0.65);
+  background: rgba(21, 94, 239, 0.08);
+}
+
+.dify-workflow-canvas .react-flow__background {
+  opacity: 0.72;
 }
 
 .dify-add-block-trigger {
   position: absolute;
-  top: 76px;
+  top: 16px;
   left: 16px;
   z-index: 20;
   display: inline-flex;
-  height: 35px;
+  height: 34px;
   align-items: center;
   gap: 6px;
   padding: 0 11px;
@@ -59,13 +87,15 @@
   color: #475467;
   font-size: 11px;
   font-weight: 600;
-  background: rgba(255, 255, 255, 0.94);
-  box-shadow: 0 7px 20px rgba(16, 24, 40, 0.08);
+  background: rgba(255, 255, 255, 0.96);
+  box-shadow: 0 5px 14px rgba(16, 24, 40, 0.08);
   backdrop-filter: blur(10px);
 }
+
 .dify-add-block-trigger:hover {
-  color: #4f46e5;
-  border-color: #a9a4fb;
+  color: #155eef;
+  border-color: #84adff;
+  background: #fff;
 }
 
 .dify-empty-canvas {
@@ -77,18 +107,27 @@
   align-items: center;
   padding: 28px 38px;
   border: 1px dashed #cfd4dc;
-  border-radius: 13px;
-  color: #7c6ff4;
-  background: rgba(255, 255, 255, 0.72);
+  border-radius: 12px;
+  color: #155eef;
+  background: rgba(255, 255, 255, 0.82);
+  box-shadow: 0 10px 30px rgba(16, 24, 40, 0.06);
   transform: translate(-50%, -50%);
 }
+
 .dify-empty-canvas strong {
   margin-top: 10px;
-  color: #475467;
-  font-size: 12px;
+  color: #344054;
+  font-size: 13px;
 }
+
 .dify-empty-canvas span {
   margin-top: 4px;
   color: #98a2b3;
-  font-size: 9px;
+  font-size: 10px;
+}
+
+@media (max-width: 1023px) {
+  .dify-workflow-designer {
+    --workflow-sidebar-width: 0px;
+  }
 }


### PR DESCRIPTION
## 背景

当前工作流设计器存在两个明显的交互问题：

1. 点击节点后，右侧配置面板会短暂出现，随后立即消失；
2. 拖动节点或产生历史记录时，页面会反复进入加载状态，影响画布操作。

同时，现有设计器仍偏向浮动工具条式布局，与参考的 Dify 工作流工作台在信息层级、画布空间利用和配置面板稳定性上存在差距。

## 问题根因

`useWorkflowHistory()` 原先会在 `canUndo / canRedo` 状态变化时返回新的对象引用。

设计器的 `loadWorkflow` 回调依赖该对象，因此拖动节点、记录历史或修改节点后会重新创建 `loadWorkflow`，进而再次触发初始化 Effect：

- 重新请求工作流详情；
- 将 `loading` 设置为 `true`；
- 重置 `selectedNodeId` 与 `activePanel`。

这同时导致了“拖动时 Loading 转圈”和“节点 Panel 闪一下消失”。

## 本次调整

### 1. 修复设计器重复加载

- 保持工作流历史 API 的对象引用稳定；
- 使用 getter 暴露最新的 `canUndo / canRedo` 状态；
- 历史栈变化不再触发工作流详情重新加载；
- 点击节点后右侧面板保持打开；
- 拖动节点时不再出现整页 Loading。

### 2. 优化设计器整体布局

参考 Dify 工作流编辑器的布局职责，调整为：

- 左侧固定工作流导航栏；
- 顶部状态与操作栏；
- 中间独立画布区域；
- 右侧贴边节点配置面板；
- 小屏幕下自动隐藏左侧栏，保留顶部返回入口。

### 3. 优化画布与节点样式

- 节点卡片改为更紧凑的白底卡片结构；
- 选中节点使用清晰的蓝色描边和轻量投影；
- 调整节点连接点、快速添加按钮与状态区；
- 统一画布连线、框选和背景视觉；
- 节点选择器使用更清晰的蓝色交互状态。

### 4. 调整画布操作区

- 自动布局、导入、导出和变量检查移动至左侧竖向工具栏；
- 撤销、重做放置在左下角；
- 缩放、小地图与适应画布统一放置在右下角；
- 减少画布顶部的浮层占用。

### 5. 优化右侧配置面板

- 面板改为贴右侧的固定栏布局；
- 去掉悬浮大圆角容器效果；
- 使用左侧分割线和轻量阴影区分画布；
- 节点、变量、历史和设置等现有面板继续复用统一壳层。

## 影响范围

仅修改前端工作流设计器：

```text
yak-ops-ui/src/pages/workflow-management/designer
```

不修改后端接口、工作流数据结构、数据库或执行引擎。

## 验证

已使用 TypeScript `transpileModule` 对本次修改的 6 个 TypeScript / TSX 文件及历史 Hook 进行语法检查，全部通过。

建议合并前在完整依赖环境执行：

```bash
cd yak-ops-ui
npm run tsc
npm run build
```

手工验证重点：

1. 点击任意节点，右侧配置面板稳定显示；
2. 连续拖动节点，页面不再出现 Loading；
3. 拖动后撤销、重做状态正常更新；
4. 节点新增、连线、保存、预览和各功能面板仍可正常使用；
5. 1024px 以下窗口可正常使用顶部返回与操作区。