### PR TITLE
fix(workflow-ui): synchronize collapsed sidebar and canvas

### DIFF
--- a/yak-ops-ui/src/pages/workflow-management/designer/index.less
+++ b/yak-ops-ui/src/pages/workflow-management/designer/index.less
@@ -2,8 +2,8 @@
  * components use Tailwind classes; this file only owns the full-screen editor
  * frame and the third-party canvas DOM. */
 .dify-workflow-designer {
-  --workflow-sidebar-width: 220px;
-  --workflow-header-height: 52px;
+  --workflow-sidebar-width: 248px;
+  --workflow-header-height: 48px;
 
   position: fixed;
   inset: 0;
@@ -11,6 +11,17 @@
   overflow: hidden;
   color: #101828;
   background: #f4f6f8;
+}
+
+/*
+ * The sidebar owns its collapsed state. Derive the canvas offset from the
+ * collapse button that is rendered only in the compact navigation state, so
+ * the sidebar, top toolbar and React Flow canvas move as one layout unit.
+ */
+.dify-workflow-designer:has(
+    > aside button[aria-label='展开侧边栏']
+  ) {
+  --workflow-sidebar-width: 64px;
 }
 
 .dify-workflow-loading {
@@ -21,6 +32,8 @@
   left: var(--workflow-sidebar-width);
   width: auto;
   height: auto;
+  transition: left 200ms ease-in-out;
+  will-change: left;
 }
 
 .dify-workflow-loading > .ant-spin-container,
@@ -127,7 +140,10 @@
 }
 
 @media (max-width: 1023px) {
-  .dify-workflow-designer {
+  .dify-workflow-designer,
+  .dify-workflow-designer:has(
+      > aside button[aria-label='展开侧边栏']
+    ) {
     --workflow-sidebar-width: 0px;
   }
 }


### PR DESCRIPTION
## 问题

工作流设计器左侧菜单收起后，菜单和顶部操作栏会缩小到 `64px`，但 React Flow 画布区域仍然按照旧的固定宽度 `220px` 计算左侧偏移，因此菜单右侧会留下明显空白区域，整体看起来像是两个互不关联的布局。

另外，当前展开菜单已经调整为 `248px`、顶部栏高度为 `48px`，画布框架仍沿用原来的 `220px / 52px`，展开状态下也存在尺寸不一致。

## 调整

- 将工作流画布默认左侧偏移同步为展开菜单宽度 `248px`
- 菜单收起时，将画布左侧偏移同步切换为 `64px`
- 通过侧边栏现有的收起按钮状态派生布局变量，不新增重复的折叠状态
- 为画布容器增加与菜单、顶部栏一致的 `200ms` 过渡动画
- 将画布顶部偏移同步为当前顶部栏高度 `48px`
- 小屏幕下继续保持左侧偏移为 `0px`

## 效果

展开或收起左侧菜单时：

- 左侧菜单宽度变化
- 顶部操作栏位置变化
- React Flow 画布宽度和起始位置变化

三者会同时完成过渡，不再出现菜单收起后残留的大块空白区域。

## 影响范围

仅修改：

```text
yak-ops-ui/src/pages/workflow-management/designer/index.less
```

不修改工作流数据、接口、节点状态或画布业务逻辑。

## 验证重点

1. 展开侧边栏时，画布从 `248px` 后开始显示
2. 收起侧边栏时，画布平滑扩展到 `64px` 后
3. 展开与收起过程中顶部栏、菜单和画布动画保持同步
4. 1024px 以下窗口仍保持画布全宽显示