### PR TITLE
refactor(workflow-ui): simplify designer to four node types

### DIFF
--- a/yak-ops-ui/src/pages/workflow-management/designer/components/block-selector/index.tsx
+++ b/yak-ops-ui/src/pages/workflow-management/designer/components/block-selector/index.tsx
@@ -1,11 +1,11 @@
 import { Input } from 'antd';
 import { ChevronLeft, Plus, Search, X } from 'lucide-react';
-import { useMemo, useState } from 'react';
+import { useMemo, useState, type MouseEvent } from 'react';
 import type { WorkflowNodeType } from '../../../types';
 import {
   CATEGORY_LABELS,
   WORKFLOW_NODE_CATALOG,
-  type WorkflowNodeMeta,
+  type WorkflowNodeCategory,
 } from '../../constants';
 import NodeIcon from '../node/NodeIcon';
 
@@ -16,40 +16,33 @@ interface BlockSelectorProps {
   compact?: boolean;
 }
 
-const categoryOrder: WorkflowNodeMeta['category'][] = [
-  'trigger',
-  'ai',
-  'integration',
-  'transform',
-  'logic',
-  'annotation',
-];
+const categoryOrder: WorkflowNodeCategory[] = ['control', 'action'];
 
 const BlockSelector = ({ open, onClose, onSelect }: BlockSelectorProps) => {
   const [keyword, setKeyword] = useState('');
-  const [category, setCategory] =
-    useState<WorkflowNodeMeta['category'] | 'all'>('all');
 
   const filtered = useMemo(() => {
     const normalized = keyword.trim().toLowerCase();
-    return WORKFLOW_NODE_CATALOG.filter((item) => {
-      if (category !== 'all' && item.category !== category) return false;
-      if (!normalized) return true;
-      return `${item.title} ${item.description} ${item.type}`
+
+    if (!normalized) return WORKFLOW_NODE_CATALOG;
+
+    return WORKFLOW_NODE_CATALOG.filter((item) =>
+      `${item.title} ${item.description} ${item.type}`
         .toLowerCase()
-        .includes(normalized);
-    });
-  }, [category, keyword]);
+        .includes(normalized),
+    );
+  }, [keyword]);
 
   if (!open) return null;
 
   return (
     <aside
       className={[
-        'absolute left-4 top-[58px] z-40 flex max-h-[calc(100vh-132px)] w-[370px]',
+        'absolute left-4 top-[58px] z-40 flex max-h-[calc(100vh-132px)] w-[340px]',
         'flex-col overflow-hidden rounded-xl border border-[#d0d5dd] bg-white',
         'shadow-[0_18px_50px_rgba(16,24,40,0.16)] max-sm:w-[calc(100vw-32px)]',
       ].join(' ')}
+      onMouseDown={(event: MouseEvent<HTMLElement>) => event.stopPropagation()}
     >
       <header className="flex h-12 shrink-0 items-center justify-between border-b border-[#eaecf0] px-2.5">
         <div className="flex items-center gap-1.5">
@@ -61,7 +54,12 @@ const BlockSelector = ({ open, onClose, onSelect }: BlockSelectorProps) => {
           >
             <ChevronLeft size={17} />
           </button>
-          <strong className="text-[13px] text-[#344054]">添加节点</strong>
+          <div>
+            <strong className="block text-[13px] text-[#344054]">添加节点</strong>
+            <span className="block text-[9px] text-[#98a2b3]">
+              当前工作流仅支持 4 类节点
+            </span>
+          </div>
         </div>
         <button
           type="button"
@@ -73,89 +71,63 @@ const BlockSelector = ({ open, onClose, onSelect }: BlockSelectorProps) => {
         </button>
       </header>
 
-      <div className="mx-2.5 mb-2 mt-2.5 flex h-[37px] shrink-0 items-center gap-1.5 rounded-lg border border-[#d0d5dd] bg-white px-2.5 text-[#98a2b3] focus-within:border-[#84adff] focus-within:shadow-[0_0_0_3px_rgba(21,94,239,0.08)]">
+      <div className="mx-2.5 mb-1.5 mt-2.5 flex h-[37px] shrink-0 items-center gap-1.5 rounded-lg border border-[#d0d5dd] bg-white px-2.5 text-[#98a2b3] focus-within:border-[#84adff] focus-within:shadow-[0_0_0_3px_rgba(21,94,239,0.08)]">
         <Search size={15} />
         <Input
           bordered={false}
           autoFocus
           value={keyword}
-          placeholder="搜索节点"
+          placeholder="搜索开始、结束、HTTP、Shell"
           onChange={(event) => setKeyword(event.target.value)}
           allowClear
           className="bg-transparent text-xs"
         />
       </div>
 
-      <div className="flex shrink-0 gap-1 overflow-x-auto px-2.5 pb-2 [scrollbar-width:none]">
-        <button
-          type="button"
-          className={[
-            'h-[27px] shrink-0 rounded-md border-0 px-2.5 text-[10px]',
-            category === 'all'
-              ? 'bg-[#eff4ff] font-semibold text-[#155eef]'
-              : 'bg-[#f2f4f7] text-[#667085]',
-          ].join(' ')}
-          onClick={() => setCategory('all')}
-        >
-          全部
-        </button>
-        {categoryOrder.map((value) => (
-          <button
-            key={value}
-            type="button"
-            className={[
-              'h-[27px] shrink-0 rounded-md border-0 px-2.5 text-[10px]',
-              category === value
-                ? 'bg-[#eff4ff] font-semibold text-[#155eef]'
-                : 'bg-[#f2f4f7] text-[#667085]',
-            ].join(' ')}
-            onClick={() => setCategory(value)}
-          >
-            {CATEGORY_LABELS[value]}
-          </button>
-        ))}
-      </div>
-
-      <div className="min-h-0 flex-1 overflow-y-auto px-2 pb-2.5">
+      <div className="min-h-0 flex-1 overflow-y-auto px-2 pb-3">
         {categoryOrder.map((group) => {
           const items = filtered.filter((item) => item.category === group);
           if (!items.length) return null;
+
           return (
             <section key={group}>
               <h3 className="mx-1.5 mb-1.5 mt-2.5 text-[9px] font-bold uppercase tracking-[0.08em] text-[#98a2b3]">
                 {CATEGORY_LABELS[group]}
               </h3>
-              <div className="grid grid-cols-2 gap-1.5">
+              <div className="space-y-1">
                 {items.map((item) => (
                   <button
                     key={item.type}
                     type="button"
                     className={[
-                      'grid min-h-[58px] grid-cols-[30px_minmax(0,1fr)_16px] items-center gap-2',
-                      'rounded-lg border border-transparent bg-transparent px-2 py-2 text-left text-[#344054]',
-                      'hover:border-[#b2ccff] hover:bg-[#f5f8ff]',
+                      'group grid min-h-[62px] w-full grid-cols-[34px_minmax(0,1fr)_22px]',
+                      'items-center gap-2 rounded-lg border border-transparent px-2.5 py-2 text-left',
+                      'text-[#344054] transition-colors hover:border-[#b2ccff] hover:bg-[#f5f8ff]',
                     ].join(' ')}
                     onClick={() => {
                       onSelect(item.type);
                       onClose();
                     }}
                   >
-                    <span className="flex h-[29px] w-[29px] items-center justify-center rounded-lg bg-[color-mix(in_srgb,var(--node-color)_10%,white)]">
+                    <span className="flex h-[32px] w-[32px] items-center justify-center rounded-lg bg-[color-mix(in_srgb,var(--node-color)_10%,white)]">
                       <NodeIcon type={item.type} size={18} />
                     </span>
                     <span className="min-w-0">
                       <strong className="block text-[11px]">{item.title}</strong>
-                      <small className="mt-0.5 block overflow-hidden text-ellipsis whitespace-nowrap text-[9px] text-[#98a2b3]">
+                      <small className="mt-0.5 block text-[9px] leading-[14px] text-[#98a2b3]">
                         {item.description}
                       </small>
                     </span>
-                    <Plus size={15} className="text-[#98a2b3]" />
+                    <span className="flex h-6 w-6 items-center justify-center rounded-md text-[#98a2b3] group-hover:bg-white group-hover:text-[#155eef]">
+                      <Plus size={14} />
+                    </span>
                   </button>
                 ))}
               </div>
             </section>
           );
         })}
+
         {!filtered.length && (
           <div className="py-11 text-center text-[11px] text-[#98a2b3]">
             没有匹配的节点

--- a/yak-ops-ui/src/pages/workflow-management/designer/components/node/NodeIcon.tsx
+++ b/yak-ops-ui/src/pages/workflow-management/designer/components/node/NodeIcon.tsx
@@ -1,19 +1,9 @@
 import {
-  Bot,
-  Braces,
+  CircleHelp,
   CircleStop,
-  Code2,
-  FileText,
-  GitBranch,
   Globe2,
-  Layers3,
-  ListTree,
-  MessageSquareText,
   Play,
-  Search,
-  StickyNote,
   TerminalSquare,
-  Variable,
 } from 'lucide-react';
 import type { CSSProperties } from 'react';
 import type { WorkflowNodeType } from '../../../types';
@@ -22,18 +12,8 @@ import { getNodeMeta } from '../../constants';
 const iconMap = {
   START: Play,
   END: CircleStop,
-  LLM: Bot,
   HTTP: Globe2,
   SHELL: TerminalSquare,
-  CODE: Code2,
-  CONDITION: GitBranch,
-  TEMPLATE: FileText,
-  VARIABLE: Variable,
-  ITERATION: Layers3,
-  KNOWLEDGE: Search,
-  QUESTION_CLASSIFIER: ListTree,
-  NOTE: StickyNote,
-  NOOP: Braces,
 };
 
 interface NodeIconProps {
@@ -45,7 +25,7 @@ interface NodeIconProps {
 
 const NodeIcon = ({ type, size = 17, className, style }: NodeIconProps) => {
   const meta = getNodeMeta(type);
-  const Icon = iconMap[meta.type] || MessageSquareText;
+  const Icon = iconMap[type as keyof typeof iconMap] || CircleHelp;
 
   return (
     <span

--- a/yak-ops-ui/src/pages/workflow-management/designer/components/node/WorkflowNode.tsx
+++ b/yak-ops-ui/src/pages/workflow-management/designer/components/node/WorkflowNode.tsx
@@ -3,11 +3,8 @@ import type { WorkflowNodeData } from '../../../types';
 import { getNodeMeta } from '../../constants';
 import BaseNode from './BaseNode';
 import NodeContent from './components/NodeContent';
-import NoteNode from './components/NoteNode';
 
 const WorkflowNode = ({ id, data, selected }: NodeProps<WorkflowNodeData>) => {
-  if (data.nodeType === 'NOTE') return <NoteNode data={data} selected={selected} />;
-
   const meta = getNodeMeta(data.nodeType);
 
   return (

--- a/yak-ops-ui/src/pages/workflow-management/designer/components/node/components/NodeContent.tsx
+++ b/yak-ops-ui/src/pages/workflow-management/designer/components/node/components/NodeContent.tsx
@@ -1,162 +1,25 @@
 import type { WorkflowNodeData } from '../../../../types';
-import { getArrayLength, getConditionBranches, getText } from '../node.helpers';
-
-const detailShellClass = [
-  'flex min-h-8 items-center gap-2 rounded-lg',
-  'bg-[#f5f7fa] px-2.5 py-2 text-[10px] text-[#475467]',
-].join(' ');
-
-const mutedTextClass =
-  'min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-[#667085]';
-
-const CountDetail = ({ label, count }: { label: string; count: number }) => (
-  <div className={detailShellClass}>
-    <span className="font-medium text-[#344054]">{label}</span>
-    <span className="ml-auto rounded-md bg-white px-1.5 py-0.5 text-[9px] text-[#667085] shadow-[0_0_0_1px_#e4e7ec]">
-      {count}
-    </span>
-  </div>
-);
+import EndNodeContent from '../nodes/end';
+import HttpNodeContent from '../nodes/http';
+import ShellNodeContent from '../nodes/shell';
+import StartNodeContent from '../nodes/start';
 
 const NodeContent = ({ data }: { data: WorkflowNodeData }) => {
   switch (data.nodeType) {
     case 'START':
-      return (
-        <div className="px-3 pb-2">
-          <CountDetail
-            label="输入变量"
-            count={getArrayLength(data.config.inputVariables)}
-          />
-        </div>
-      );
+      return <StartNodeContent data={data} />;
     case 'END':
-      return (
-        <div className="px-3 pb-2">
-          <CountDetail label="输出变量" count={getArrayLength(data.config.outputs)} />
-        </div>
-      );
-    case 'LLM':
-      return (
-        <div className="px-3 pb-2">
-          <div className={detailShellClass}>
-            <span className="shrink-0 rounded-md bg-white px-1.5 py-0.5 text-[9px] font-medium text-[#6941c6] shadow-[0_0_0_1px_#e4e7ec]">
-              {getText(data.config.provider, 'OpenAI')}
-            </span>
-            <span className={mutedTextClass}>
-              {getText(data.config.model, '模型未选择')}
-            </span>
-          </div>
-        </div>
-      );
+      return <EndNodeContent data={data} />;
     case 'HTTP':
-      return (
-        <div className="px-3 pb-2">
-          <div className={detailShellClass}>
-            <span className="shrink-0 rounded-md bg-white px-1.5 py-0.5 text-[9px] font-semibold text-[#155eef] shadow-[0_0_0_1px_#d1e0ff]">
-              {getText(data.config.method, 'GET').toUpperCase()}
-            </span>
-            <span className={mutedTextClass} title={getText(data.config.url)}>
-              {getText(data.config.url, '未配置 URL')}
-            </span>
-          </div>
-        </div>
-      );
+      return <HttpNodeContent data={data} />;
     case 'SHELL':
-      return (
-        <div className="px-3 pb-2">
-          <div className={`${detailShellClass} font-mono`}>
-            <span className={mutedTextClass} title={getText(data.config.command)}>
-              {getText(data.config.command, '未配置执行命令')}
-            </span>
-          </div>
-        </div>
-      );
-    case 'CODE':
-      return (
-        <div className="px-3 pb-2">
-          <div className={detailShellClass}>
-            <span className="shrink-0 rounded-md bg-white px-1.5 py-0.5 text-[9px] font-medium text-[#b54708] shadow-[0_0_0_1px_#fedf89]">
-              {getText(data.config.language, 'JavaScript')}
-            </span>
-            <span className={mutedTextClass}>main(inputs)</span>
-          </div>
-        </div>
-      );
-    case 'CONDITION':
-      return (
-        <div className="px-3 pb-2">
-          <div className="flex gap-1.5">
-            {getConditionBranches(data).map((branch, index) => (
-              <span
-                key={`${branch}-${index}`}
-                className="min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap rounded-md border border-[#e4e7ec] bg-[#fcfcfd] px-2 py-1.5 text-center text-[9px] font-medium text-[#667085]"
-                title={branch}
-              >
-                {branch}
-              </span>
-            ))}
-          </div>
-        </div>
-      );
-    case 'TEMPLATE':
-      return (
-        <div className="px-3 pb-2">
-          <div className={detailShellClass}>
-            <span className={mutedTextClass} title={getText(data.config.template)}>
-              {getText(data.config.template, '未配置模板内容')}
-            </span>
-          </div>
-        </div>
-      );
-    case 'VARIABLE':
-      return (
-        <div className="px-3 pb-2">
-          <CountDetail
-            label="变量赋值"
-            count={getArrayLength(data.config.assignments)}
-          />
-        </div>
-      );
-    case 'ITERATION':
-      return (
-        <div className="px-3 pb-2">
-          <div className={detailShellClass}>
-            <span className={mutedTextClass} title={getText(data.config.source)}>
-              {getText(data.config.source, '未配置迭代数组')}
-            </span>
-            <span className="shrink-0 text-[9px] text-[#98a2b3]">
-              并行 {Number(data.config.parallel || 1)}
-            </span>
-          </div>
-        </div>
-      );
-    case 'KNOWLEDGE':
-      return (
-        <div className="px-3 pb-2">
-          <div className={detailShellClass}>
-            <span className={mutedTextClass} title={getText(data.config.dataset)}>
-              {getText(data.config.dataset, '未选择知识库')}
-            </span>
-            <span className="shrink-0 text-[9px] text-[#98a2b3]">
-              Top {Number(data.config.topK || 3)}
-            </span>
-          </div>
-        </div>
-      );
-    case 'QUESTION_CLASSIFIER':
-      return (
-        <div className="px-3 pb-2">
-          <CountDetail label="分类" count={getArrayLength(data.config.classes)} />
-        </div>
-      );
+      return <ShellNodeContent data={data} />;
     default:
       return (
         <div className="px-3 pb-2">
-          <div className={detailShellClass}>
-            <span className="shrink-0 font-medium text-[#344054]">
-              {data.taskType}
-            </span>
-            <span className={mutedTextClass}>自定义任务节点</span>
+          <div className="rounded-lg border border-dashed border-[#d0d5dd] bg-[#f9fafb] px-2.5 py-2 text-[10px] text-[#667085]">
+            旧节点类型：{data.nodeType}。当前设计器仅支持 Start、End、HTTP 和
+            Shell。
           </div>
         </div>
       );

--- a/yak-ops-ui/src/pages/workflow-management/designer/components/node/nodes/end/index.tsx
+++ b/yak-ops-ui/src/pages/workflow-management/designer/components/node/nodes/end/index.tsx
@@ -1,0 +1,15 @@
+import type { WorkflowNodeData } from '../../../../../types';
+import { getArrayLength } from '../../node.helpers';
+
+const EndNodeContent = ({ data }: { data: WorkflowNodeData }) => (
+  <div className="px-3 pb-2">
+    <div className="flex min-h-8 items-center rounded-lg bg-[#f5f7fa] px-2.5 py-2 text-[10px] text-[#475467]">
+      <span className="font-medium text-[#344054]">输出变量</span>
+      <span className="ml-auto rounded-md bg-white px-1.5 py-0.5 text-[9px] text-[#667085] shadow-[0_0_0_1px_#e4e7ec]">
+        {getArrayLength(data.config.outputs)}
+      </span>
+    </div>
+  </div>
+);
+
+export default EndNodeContent;

--- a/yak-ops-ui/src/pages/workflow-management/designer/components/node/nodes/http/index.tsx
+++ b/yak-ops-ui/src/pages/workflow-management/designer/components/node/nodes/http/index.tsx
@@ -1,0 +1,20 @@
+import type { WorkflowNodeData } from '../../../../../types';
+import { getText } from '../../node.helpers';
+
+const HttpNodeContent = ({ data }: { data: WorkflowNodeData }) => (
+  <div className="px-3 pb-2">
+    <div className="flex min-h-8 items-center gap-2 rounded-lg bg-[#f5f7fa] px-2.5 py-2 text-[10px] text-[#475467]">
+      <span className="shrink-0 rounded-md bg-white px-1.5 py-0.5 text-[9px] font-semibold text-[#155eef] shadow-[0_0_0_1px_#d1e0ff]">
+        {getText(data.config.method, 'GET').toUpperCase()}
+      </span>
+      <span
+        className="min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-[#667085]"
+        title={getText(data.config.url)}
+      >
+        {getText(data.config.url, '未配置 URL')}
+      </span>
+    </div>
+  </div>
+);
+
+export default HttpNodeContent;

--- a/yak-ops-ui/src/pages/workflow-management/designer/components/node/nodes/shell/index.tsx
+++ b/yak-ops-ui/src/pages/workflow-management/designer/components/node/nodes/shell/index.tsx
@@ -1,0 +1,17 @@
+import type { WorkflowNodeData } from '../../../../../types';
+import { getText } from '../../node.helpers';
+
+const ShellNodeContent = ({ data }: { data: WorkflowNodeData }) => (
+  <div className="px-3 pb-2">
+    <div className="flex min-h-8 items-center gap-2 rounded-lg bg-[#101828] px-2.5 py-2 font-mono text-[10px] text-[#d0d5dd]">
+      <span
+        className="min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap"
+        title={getText(data.config.command)}
+      >
+        {getText(data.config.command, '未配置执行命令')}
+      </span>
+    </div>
+  </div>
+);
+
+export default ShellNodeContent;

--- a/yak-ops-ui/src/pages/workflow-management/designer/components/node/nodes/start/index.tsx
+++ b/yak-ops-ui/src/pages/workflow-management/designer/components/node/nodes/start/index.tsx
@@ -1,0 +1,15 @@
+import type { WorkflowNodeData } from '../../../../../types';
+import { getArrayLength } from '../../node.helpers';
+
+const StartNodeContent = ({ data }: { data: WorkflowNodeData }) => (
+  <div className="px-3 pb-2">
+    <div className="flex min-h-8 items-center rounded-lg bg-[#f5f7fa] px-2.5 py-2 text-[10px] text-[#475467]">
+      <span className="font-medium text-[#344054]">输入变量</span>
+      <span className="ml-auto rounded-md bg-white px-1.5 py-0.5 text-[9px] text-[#667085] shadow-[0_0_0_1px_#e4e7ec]">
+        {getArrayLength(data.config.inputVariables)}
+      </span>
+    </div>
+  </div>
+);
+
+export default StartNodeContent;

--- a/yak-ops-ui/src/pages/workflow-management/designer/components/operator/CanvasOperator.tsx
+++ b/yak-ops-ui/src/pages/workflow-management/designer/components/operator/CanvasOperator.tsx
@@ -1,46 +1,23 @@
-import { Dropdown, Input, Tooltip, type MenuProps } from 'antd';
+import { Dropdown, Tooltip, type MenuProps } from 'antd';
 import {
-  AlignHorizontalSpaceAround,
-  Bot,
-  BookOpen,
   Braces,
-  BrainCircuit,
   ChevronDown,
-  Code2,
   Download,
   Eye,
   EyeOff,
-  FileInput,
-  FileOutput,
-  GitBranch,
   Hand,
-  Infinity as InfinityIcon,
-  ListFilter,
   Maximize2,
-  MessageSquareText,
   Minus,
   MoreHorizontal,
   MousePointer2,
   Plus,
   Redo2,
-  RefreshCw,
   ScanLine,
-  Search,
   Upload,
-  UserRound,
-  Variable,
   Undo2,
 } from 'lucide-react';
-import {
-  useMemo,
-  useState,
-  type ReactNode,
-} from 'react';
-import {
-  MiniMap,
-  useReactFlow,
-  useViewport,
-} from 'reactflow';
+import type { ReactNode } from 'react';
+import { MiniMap, useReactFlow, useViewport } from 'reactflow';
 
 export type CanvasInteractionMode = 'select' | 'pan';
 
@@ -63,10 +40,8 @@ interface CanvasOperatorProps {
   canUndo: boolean;
   canRedo: boolean;
   showMiniMap: boolean;
-
   nodePanelOpen: boolean;
   interactionMode: CanvasInteractionMode;
-
   onUndo: () => void;
   onRedo: () => void;
   onToggleMiniMap: () => void;
@@ -77,23 +52,19 @@ interface CanvasOperatorProps {
   onToggleNodePanel: () => void;
   onInteractionModeChange: (mode: CanvasInteractionMode) => void;
   onSelectLibraryItem?: (item: CanvasLibraryItem) => void;
-
   variableInspectOpen: boolean;
   nodeGroups?: CanvasLibraryGroup[];
   toolGroups?: CanvasLibraryGroup[];
 }
 
 const operatorGroupClass = [
-  'pointer-events-auto flex items-center gap-px',
-  'rounded-lg border border-[#e4e7ec]',
-  'bg-white p-[3px]',
-  'shadow-[0_4px_12px_rgba(16,24,40,0.08)]',
+  'pointer-events-auto flex items-center gap-px rounded-lg border border-[#e4e7ec]',
+  'bg-white p-[3px] shadow-[0_4px_12px_rgba(16,24,40,0.08)]',
 ].join(' ');
 
 const iconButtonClass = [
-  'relative flex h-8 w-8 shrink-0 items-center justify-center',
-  'rounded-md border-0 bg-transparent p-0',
-  'text-[#667085] transition-all duration-150',
+  'relative flex h-8 w-8 shrink-0 items-center justify-center rounded-md border-0',
+  'bg-transparent p-0 text-[#667085] transition-all duration-150',
   'hover:bg-[#f2f4f7] hover:text-[#344054]',
   'disabled:cursor-not-allowed disabled:opacity-[0.35]',
 ].join(' ');
@@ -101,166 +72,20 @@ const iconButtonClass = [
 const activeIconButtonClass =
   'bg-[#eef2ff] text-[#155eef] hover:bg-[#e7edff] hover:text-[#155eef]';
 
-const panelIconClass = [
-  'flex h-5 w-5 shrink-0 items-center justify-center',
-  'rounded-[6px] text-white',
-].join(' ');
-
-const DEFAULT_NODE_GROUPS: CanvasLibraryGroup[] = [
-  {
-    key: 'basic',
-    items: [
-      {
-        key: 'llm',
-        label: 'LLM',
-        description: '调用大语言模型处理输入内容',
-        keywords: ['大模型', '语言模型', 'AI'],
-        icon: <BrainCircuit size={13} strokeWidth={2.2} />,
-        iconClassName: 'bg-[#6366f1]',
-      },
-      {
-        key: 'knowledge-retrieval',
-        label: '知识检索',
-        description: '从知识库中检索相关内容',
-        keywords: ['知识库', '检索', 'RAG'],
-        icon: <BookOpen size={13} strokeWidth={2.2} />,
-        iconClassName: 'bg-[#12b76a]',
-      },
-      {
-        key: 'direct-answer',
-        label: '直接回复',
-        description: '向用户直接输出指定内容',
-        keywords: ['回答', '回复', '输出'],
-        icon: <MessageSquareText size={13} strokeWidth={2.2} />,
-        iconClassName: 'bg-[#f79009]',
-      },
-      {
-        key: 'agent',
-        label: 'Agent',
-        description: '通过智能体自主选择工具完成任务',
-        keywords: ['智能体', 'Agent', '工具调用'],
-        icon: <Bot size={13} strokeWidth={2.2} />,
-        iconClassName: 'bg-[#7f56d9]',
-      },
-    ],
-  },
-  {
-    key: 'problem-understanding',
-    title: '问题理解',
-    items: [
-      {
-        key: 'question-classifier',
-        label: '问题分类器',
-        description: '根据问题内容选择不同的执行分支',
-        keywords: ['分类', '判断', '意图'],
-        icon: <ListFilter size={13} strokeWidth={2.2} />,
-        iconClassName: 'bg-[#12b76a]',
-      },
-    ],
-  },
-  {
-    key: 'logic',
-    title: '逻辑',
-    items: [
-      {
-        key: 'condition',
-        label: '条件分支',
-        description: '根据条件判断进入不同分支',
-        keywords: ['判断', '条件', '分支'],
-        icon: <GitBranch size={13} strokeWidth={2.2} />,
-        iconClassName: 'bg-[#06aed4]',
-      },
-      {
-        key: 'human-intervention',
-        label: '人工介入',
-        description: '暂停流程并等待人工处理',
-        keywords: ['人工', '审核', '暂停'],
-        icon: <UserRound size={13} strokeWidth={2.2} />,
-        iconClassName: 'bg-[#06aed4]',
-      },
-      {
-        key: 'iteration',
-        label: '迭代',
-        description: '遍历数组并逐项执行流程',
-        keywords: ['遍历', '数组', '迭代'],
-        icon: <RefreshCw size={13} strokeWidth={2.2} />,
-        iconClassName: 'bg-[#06aed4]',
-      },
-      {
-        key: 'loop',
-        label: '循环',
-        description: '根据条件重复执行流程',
-        keywords: ['循环', '重复'],
-        icon: <InfinityIcon size={14} strokeWidth={2.2} />,
-        iconClassName: 'bg-[#06aed4]',
-      },
-    ],
-  },
-  {
-    key: 'transform',
-    title: '转换',
-    items: [
-      {
-        key: 'code',
-        label: '代码执行',
-        description: '执行自定义代码处理数据',
-        keywords: ['代码', 'JavaScript', 'Python'],
-        icon: <Code2 size={13} strokeWidth={2.2} />,
-        iconClassName: 'bg-[#2e90fa]',
-      },
-      {
-        key: 'template',
-        label: '模板转换',
-        description: '使用模板重新组织输入内容',
-        keywords: ['模板', '格式化'],
-        icon: <FileOutput size={13} strokeWidth={2.2} />,
-        iconClassName: 'bg-[#2e90fa]',
-      },
-      {
-        key: 'variable-aggregator',
-        label: '变量聚合器',
-        description: '将多个分支变量合并为一个变量',
-        keywords: ['变量', '合并', '聚合'],
-        icon: <Variable size={13} strokeWidth={2.2} />,
-        iconClassName: 'bg-[#2e90fa]',
-      },
-    ],
-  },
-];
-
-const DEFAULT_TOOL_GROUPS: CanvasLibraryGroup[] = [
-  {
-    key: 'workflow-tools',
-    items: [
-      {
-        key: 'variable-tool',
-        label: '变量工具',
-        description: '读取或处理工作流中的变量',
-        keywords: ['变量', '参数'],
-        icon: <Braces size={13} strokeWidth={2.2} />,
-        iconClassName: 'bg-[#6172f3]',
-      },
-      {
-        key: 'input-tool',
-        label: '输入转换',
-        description: '对输入数据进行格式转换',
-        keywords: ['输入', '转换'],
-        icon: <FileInput size={13} strokeWidth={2.2} />,
-        iconClassName: 'bg-[#2e90fa]',
-      },
-    ],
-  },
-];
+const openNodeSelector = () => {
+  window.dispatchEvent(
+    new CustomEvent('yak-workflow-quick-add', {
+      detail: { nodeId: undefined },
+    }),
+  );
+};
 
 const CanvasOperator = ({
   canUndo,
   canRedo,
   showMiniMap,
-  nodePanelOpen,
   interactionMode,
   variableInspectOpen,
-  nodeGroups = DEFAULT_NODE_GROUPS,
-  toolGroups = DEFAULT_TOOL_GROUPS,
   onUndo,
   onRedo,
   onToggleMiniMap,
@@ -268,38 +93,22 @@ const CanvasOperator = ({
   onExport,
   onImport,
   onToggleVariableInspect,
-  onToggleNodePanel,
   onInteractionModeChange,
-  onSelectLibraryItem,
 }: CanvasOperatorProps) => {
   const reactFlow = useReactFlow();
   const { zoom } = useViewport();
-
-  const [libraryTab, setLibraryTab] = useState<'node' | 'tool'>('node');
-  const [keyword, setKeyword] = useState('');
 
   const zoomItems: MenuProps['items'] = [
     ...[2, 1, 0.75, 0.5, 0.25].map((value) => ({
       key: String(value),
       label: `${Math.round(value * 100)}%`,
-      onClick: () => {
-        reactFlow.zoomTo(value, {
-          duration: 180,
-        });
-      },
+      onClick: () => reactFlow.zoomTo(value, { duration: 180 }),
     })),
-    {
-      type: 'divider' as const,
-    },
+    { type: 'divider' as const },
     {
       key: 'fit',
       label: '适应画布',
-      onClick: () => {
-        reactFlow.fitView({
-          padding: 0.24,
-          duration: 220,
-        });
-      },
+      onClick: () => reactFlow.fitView({ padding: 0.24, duration: 220 }),
     },
   ];
 
@@ -318,57 +127,16 @@ const CanvasOperator = ({
     },
   ];
 
-  const visibleGroups = useMemo(() => {
-    const groups = libraryTab === 'node' ? nodeGroups : toolGroups;
-    const normalizedKeyword = keyword.trim().toLowerCase();
-
-    if (!normalizedKeyword) {
-      return groups;
-    }
-
-    return groups
-      .map((group) => ({
-        ...group,
-        items: group.items.filter((item) => {
-          const searchableContent = [
-            item.label,
-            item.description,
-            ...(item.keywords ?? []),
-          ]
-            .join(' ')
-            .toLowerCase();
-
-          return searchableContent.includes(normalizedKeyword);
-        }),
-      }))
-      .filter((group) => group.items.length > 0);
-  }, [
-    keyword,
-    libraryTab,
-    nodeGroups,
-    toolGroups,
-  ]);
-
   return (
     <div className="pointer-events-none absolute inset-0 z-20">
-      {/* 左侧主工具栏 */}
       <div className="absolute left-3 top-1/2 flex -translate-y-1/2 items-start gap-1.5">
-        <div
-          className={[
-            operatorGroupClass,
-            'w-[38px] flex-col gap-1 py-1',
-          ].join(' ')}
-        >
+        <div className={`${operatorGroupClass} w-[38px] flex-col gap-1 py-1`}>
           <Tooltip title="添加节点" placement="right">
             <button
               type="button"
-              className={[
-                iconButtonClass,
-                nodePanelOpen
-                  ? 'bg-[#f2f4f7] text-[#344054]'
-                  : '',
-              ].join(' ')}
-              onClick={onToggleNodePanel}
+              className={iconButtonClass}
+              onClick={openNodeSelector}
+              aria-label="添加节点"
             >
               <span className="flex h-[18px] w-[18px] items-center justify-center rounded-full bg-[#475467] text-white">
                 <Plus size={12} strokeWidth={2.8} />
@@ -391,9 +159,7 @@ const CanvasOperator = ({
               type="button"
               className={[
                 iconButtonClass,
-                interactionMode === 'select'
-                  ? activeIconButtonClass
-                  : '',
+                interactionMode === 'select' ? activeIconButtonClass : '',
               ].join(' ')}
               onClick={() => onInteractionModeChange('select')}
             >
@@ -406,9 +172,7 @@ const CanvasOperator = ({
               type="button"
               className={[
                 iconButtonClass,
-                interactionMode === 'pan'
-                  ? activeIconButtonClass
-                  : '',
+                interactionMode === 'pan' ? activeIconButtonClass : '',
               ].join(' ')}
               onClick={() => onInteractionModeChange('pan')}
             >
@@ -421,9 +185,7 @@ const CanvasOperator = ({
               type="button"
               className={[
                 iconButtonClass,
-                variableInspectOpen
-                  ? activeIconButtonClass
-                  : '',
+                variableInspectOpen ? activeIconButtonClass : '',
               ].join(' ')}
               onClick={onToggleVariableInspect}
             >
@@ -445,165 +207,9 @@ const CanvasOperator = ({
             </button>
           </Dropdown>
         </div>
-
-        {/* 节点选择面板 */}
-        {nodePanelOpen && (
-          <div
-            className={[
-              'pointer-events-auto flex',
-              'h-[min(570px,calc(100vh-140px))] w-[400px]',
-              'flex-col overflow-hidden rounded-xl',
-              'border border-[#e4e7ec] bg-white',
-              'shadow-[0_12px_32px_rgba(16,24,40,0.12)]',
-            ].join(' ')}
-            onMouseDown={(event) => event.stopPropagation()}
-            onClick={(event) => event.stopPropagation()}
-          >
-            <div className="flex h-10 shrink-0 items-end border-b border-[#e4e7ec] px-2">
-              <button
-                type="button"
-                className={[
-                  'relative flex h-10 items-center px-2.5 text-[14px]',
-                  'transition-colors',
-                  libraryTab === 'node'
-                    ? 'font-medium text-[#155eef]'
-                    : 'text-[#667085] hover:text-[#344054]',
-                ].join(' ')}
-                onClick={() => setLibraryTab('node')}
-              >
-                节点
-
-                {libraryTab === 'node' && (
-                  <span className="absolute inset-x-1 bottom-0 h-0.5 rounded-full bg-[#155eef]" />
-                )}
-              </button>
-
-              <button
-                type="button"
-                className={[
-                  'relative flex h-10 items-center px-2.5 text-[14px]',
-                  'transition-colors',
-                  libraryTab === 'tool'
-                    ? 'font-medium text-[#155eef]'
-                    : 'text-[#667085] hover:text-[#344054]',
-                ].join(' ')}
-                onClick={() => setLibraryTab('tool')}
-              >
-                工具
-
-                {libraryTab === 'tool' && (
-                  <span className="absolute inset-x-1 bottom-0 h-0.5 rounded-full bg-[#155eef]" />
-                )}
-              </button>
-            </div>
-
-            <div className="shrink-0 px-2 py-2">
-              <Input
-                allowClear
-                value={keyword}
-                prefix={
-                  <Search
-                    size={15}
-                    className="text-[#98a2b3]"
-                  />
-                }
-                placeholder={
-                  libraryTab === 'node'
-                    ? '搜索节点、Agent、人工、知识库'
-                    : '搜索工具'
-                }
-                className={[
-                  'h-8 rounded-lg border-[#d0d5dd]',
-                  'bg-[#fcfcfd]',
-                  '[&_.ant-input]:text-[13px]',
-                  '[&_.ant-input::placeholder]:text-[#98a2b3]',
-                ].join(' ')}
-                onChange={(event) => setKeyword(event.target.value)}
-              />
-            </div>
-
-            <div
-              className={[
-                'min-h-0 flex-1 overflow-y-auto px-3 pb-3',
-                '[&::-webkit-scrollbar]:w-1.5',
-                '[&::-webkit-scrollbar-thumb]:rounded-full',
-                '[&::-webkit-scrollbar-thumb]:bg-[#98a2b3]',
-                '[&::-webkit-scrollbar-track]:bg-transparent',
-              ].join(' ')}
-            >
-              {visibleGroups.length > 0 ? (
-                visibleGroups.map((group) => (
-                  <div
-                    key={group.key}
-                    className="mb-2 last:mb-0"
-                  >
-                    {group.title && (
-                      <div className="mb-1 px-1 text-[12px] leading-5 text-[#667085]">
-                        {group.title}
-                      </div>
-                    )}
-
-                    <div className="space-y-0.5">
-                      {group.items.map((item) => (
-                        <button
-                          key={item.key}
-                          type="button"
-                          className={[
-                            'group flex h-8 w-full items-center gap-2',
-                            'rounded-md px-1.5 text-left',
-                            'text-[14px] text-[#344054]',
-                            'transition-colors',
-                            'hover:bg-[#f2f4f7]',
-                          ].join(' ')}
-                          onClick={() => onSelectLibraryItem?.(item)}
-                        >
-                          <span
-                            className={[
-                              panelIconClass,
-                              item.iconClassName,
-                            ].join(' ')}
-                          >
-                            {item.icon}
-                          </span>
-
-                          <span className="min-w-0 flex-1 truncate">
-                            {item.label}
-                          </span>
-
-                          <Plus
-                            size={14}
-                            className={[
-                              'shrink-0 text-[#98a2b3]',
-                              'opacity-0 transition-opacity',
-                              'group-hover:opacity-100',
-                            ].join(' ')}
-                          />
-                        </button>
-                      ))}
-                    </div>
-                  </div>
-                ))
-              ) : (
-                <div className="flex h-32 flex-col items-center justify-center text-[#98a2b3]">
-                  <Search size={22} strokeWidth={1.5} />
-
-                  <span className="mt-2 text-[13px]">
-                    没有找到相关内容
-                  </span>
-                </div>
-              )}
-            </div>
-          </div>
-        )}
       </div>
 
-      {/* 左下角撤销、重做 */}
-      <div
-        className={[
-          operatorGroupClass,
-          'absolute bottom-3 left-3',
-        ].join(' ')}
-      >
+      <div className={`${operatorGroupClass} absolute bottom-3 left-3`}>
         <Tooltip title="撤销 Ctrl/⌘ + Z">
           <button
             type="button"
@@ -614,7 +220,6 @@ const CanvasOperator = ({
             <Undo2 size={15} />
           </button>
         </Tooltip>
-
         <Tooltip title="重做 Ctrl/⌘ + Shift + Z">
           <button
             type="button"
@@ -627,17 +232,14 @@ const CanvasOperator = ({
         </Tooltip>
       </div>
 
-      {/* 右下角缩放、小地图 */}
       <div className="pointer-events-auto absolute bottom-3 right-3 flex items-end gap-2">
         {showMiniMap && (
           <MiniMap
             pannable
             zoomable
             className={[
-              '!absolute !bottom-[43px] !right-0 !m-0',
-              '!h-[88px] !w-32 !overflow-hidden',
-              '!rounded-lg !border !border-[#d0d5dd]',
-              '!bg-white/95',
+              '!absolute !bottom-[43px] !right-0 !m-0 !h-[88px] !w-32 !overflow-hidden',
+              '!rounded-lg !border !border-[#d0d5dd] !bg-white/95',
               '!shadow-[0_8px_22px_rgba(16,24,40,0.12)]',
             ].join(' ')}
             nodeStrokeWidth={2}
@@ -645,40 +247,24 @@ const CanvasOperator = ({
           />
         )}
 
-        <div
-          className={[
-            operatorGroupClass,
-            'min-w-[146px]',
-          ].join(' ')}
-        >
+        <div className={`${operatorGroupClass} min-w-[146px]`}>
           <Tooltip title="缩小">
             <button
               type="button"
               className={iconButtonClass}
               disabled={zoom <= 0.25}
-              onClick={() => {
-                reactFlow.zoomOut({
-                  duration: 150,
-                });
-              }}
+              onClick={() => reactFlow.zoomOut({ duration: 150 })}
             >
               <Minus size={15} />
             </button>
           </Tooltip>
 
-          <Dropdown
-            menu={{ items: zoomItems }}
-            placement="topRight"
-          >
+          <Dropdown menu={{ items: zoomItems }} placement="topRight">
             <button
               type="button"
-              className={[
-                iconButtonClass,
-                'min-w-[48px] gap-1 text-[#475467]',
-              ].join(' ')}
+              className={`${iconButtonClass} min-w-[48px] gap-1 text-[#475467]`}
             >
               {Math.round(zoom * 100)}%
-
               <ChevronDown size={12} />
             </button>
           </Dropdown>
@@ -688,11 +274,7 @@ const CanvasOperator = ({
               type="button"
               className={iconButtonClass}
               disabled={zoom >= 2}
-              onClick={() => {
-                reactFlow.zoomIn({
-                  duration: 150,
-                });
-              }}
+              onClick={() => reactFlow.zoomIn({ duration: 150 })}
             >
               <Plus size={15} />
             </button>
@@ -702,30 +284,21 @@ const CanvasOperator = ({
             <button
               type="button"
               className={iconButtonClass}
-              onClick={() => {
-                reactFlow.fitView({
-                  padding: 0.24,
-                  duration: 220,
-                });
-              }}
+              onClick={() =>
+                reactFlow.fitView({ padding: 0.24, duration: 220 })
+              }
             >
               <Maximize2 size={15} />
             </button>
           </Tooltip>
 
-          <Tooltip
-            title={showMiniMap ? '隐藏小地图' : '显示小地图'}
-          >
+          <Tooltip title={showMiniMap ? '隐藏小地图' : '显示小地图'}>
             <button
               type="button"
               className={iconButtonClass}
               onClick={onToggleMiniMap}
             >
-              {showMiniMap ? (
-                <Eye size={15} />
-              ) : (
-                <EyeOff size={15} />
-              )}
+              {showMiniMap ? <Eye size={15} /> : <EyeOff size={15} />}
             </button>
           </Tooltip>
         </div>

--- a/yak-ops-ui/src/pages/workflow-management/designer/components/panel/NodePanel.tsx
+++ b/yak-ops-ui/src/pages/workflow-management/designer/components/panel/NodePanel.tsx
@@ -1,24 +1,20 @@
-import {
-  Input,
-  InputNumber,
-  Select,
-  Slider,
-  Switch,
-  Tabs,
-  Tag,
-} from 'antd';
+import { Input, InputNumber, Switch } from 'antd';
 import {
   ChevronDown,
   Copy,
-  Info,
   MoreHorizontal,
   Trash2,
   X,
 } from 'lucide-react';
-import { useMemo, useState, type ReactNode } from 'react';
+import { useMemo, useState, type ChangeEvent } from 'react';
 import type { WorkflowFlowNode, WorkflowNodeData } from '../../../types';
 import { getNodeMeta } from '../../constants';
 import NodeIcon from '../node/NodeIcon';
+import EndPanel from './node/end';
+import HttpPanel from './node/http';
+import ShellPanel from './node/shell';
+import StartPanel from './node/start';
+import { PanelField, PanelSection } from './node/shared';
 import {
   panelContentClass,
   panelFooterClass,
@@ -34,61 +30,6 @@ interface NodePanelProps {
   onDuplicate: () => void;
   onClose: () => void;
 }
-
-interface FieldProps {
-  label: string;
-  hint?: string;
-  children: ReactNode;
-}
-
-const sectionClass = 'border-b border-[#f0f1f4] p-[15px]';
-const titleClass = 'mb-3 text-[11px] font-semibold text-[#344054]';
-const hintClass = '-mt-1.5 mb-3 text-[9px] leading-[15px] text-[#98a2b3]';
-
-const Field = ({ label, hint, children }: FieldProps) => (
-  <label
-    className={[
-      'mb-3 block',
-      '[&_.ant-input]:w-full [&_.ant-input]:text-[11px]',
-      '[&_.ant-input-number]:w-full [&_.ant-input-number]:text-[11px]',
-      '[&_.ant-select]:w-full [&_.ant-select]:text-[11px]',
-      '[&_.ant-input-affix-wrapper]:w-full [&_.ant-input-affix-wrapper]:text-[11px]',
-    ].join(' ')}
-  >
-    <span className="mb-1.5 flex items-center gap-1 text-[9px] font-semibold text-[#667085]">
-      {label}
-      {hint && (
-        <small title={hint} className="inline-flex text-[#98a2b3]">
-          <Info size={12} />
-        </small>
-      )}
-    </span>
-    {children}
-  </label>
-);
-
-const JsonEditor = ({
-  value,
-  onChange,
-  rows = 8,
-}: {
-  value: unknown;
-  onChange: (value: unknown) => void;
-  rows?: number;
-}) => (
-  <Input.TextArea
-    rows={rows}
-    value={JSON.stringify(value, null, 2)}
-    className="font-mono text-[10px] leading-[17px]"
-    onChange={(event) => {
-      try {
-        onChange(JSON.parse(event.target.value));
-      } catch {
-        // Keep the last valid value while users are editing JSON.
-      }
-    }}
-  />
-);
 
 const SwitchRow = ({
   title,
@@ -122,6 +63,12 @@ const NodePanel = ({
   const [advancedOpen, setAdvancedOpen] = useState(false);
   const data = node.data;
   const meta = getNodeMeta(data.nodeType);
+  const isControlNode = data.nodeType === 'START' || data.nodeType === 'END';
+  const isSupported =
+    data.nodeType === 'START' ||
+    data.nodeType === 'END' ||
+    data.nodeType === 'HTTP' ||
+    data.nodeType === 'SHELL';
 
   const patch = (values: Partial<WorkflowNodeData>) => {
     onChange({ ...data, ...values });
@@ -145,408 +92,28 @@ const NodePanel = ({
     [data.config],
   );
 
-  const renderMainConfiguration = () => {
+  const renderNodePanel = () => {
     switch (data.nodeType) {
       case 'START':
-        return (
-          <section className={sectionClass}>
-            <h3 className={titleClass}>输入字段</h3>
-            <p className={hintClass}>定义运行工作流时需要填写的变量。</p>
-            <Field label="变量定义（JSON）">
-              <JsonEditor
-                value={data.config.inputVariables || []}
-                onChange={(value) => patchConfig('inputVariables', value)}
-              />
-            </Field>
-          </section>
-        );
+        return <StartPanel data={data} onConfigChange={patchConfig} />;
       case 'END':
-        return (
-          <section className={sectionClass}>
-            <h3 className={titleClass}>输出变量</h3>
-            <Field label="输出定义（JSON）">
-              <JsonEditor
-                value={data.config.outputs || []}
-                onChange={(value) => patchConfig('outputs', value)}
-              />
-            </Field>
-          </section>
-        );
-      case 'LLM':
-        return (
-          <>
-            <section className={sectionClass}>
-              <h3 className={titleClass}>模型</h3>
-              <div className="mb-3 grid grid-cols-[34px_minmax(0,1fr)_18px] items-center gap-2 rounded-lg border border-[#e4e7ec] bg-[#fcfcfd] p-2">
-                <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-[#f1f0ff]">
-                  <NodeIcon type="LLM" size={19} />
-                </span>
-                <div>
-                  <strong className="block text-[10px] text-[#344054]">
-                    {String(data.config.model || 'gpt-4o-mini')}
-                  </strong>
-                  <span className="block text-[9px] text-[#98a2b3]">
-                    {String(data.config.provider || 'OpenAI')}
-                  </span>
-                </div>
-                <ChevronDown size={15} className="text-[#98a2b3]" />
-              </div>
-              <div className="grid grid-cols-2 gap-2.5">
-                <Field label="供应商">
-                  <Select
-                    value={String(data.config.provider || 'OpenAI')}
-                    onChange={(value) => patchConfig('provider', value)}
-                    options={[
-                      'OpenAI',
-                      'Azure OpenAI',
-                      'Anthropic',
-                      'DeepSeek',
-                      'Ollama',
-                    ].map((value) => ({ label: value, value }))}
-                  />
-                </Field>
-                <Field label="模型">
-                  <Select
-                    value={String(data.config.model || 'gpt-4o-mini')}
-                    onChange={(value) => patchConfig('model', value)}
-                    options={[
-                      'gpt-4o-mini',
-                      'gpt-4o',
-                      'claude-3-5-sonnet',
-                      'deepseek-chat',
-                    ].map((value) => ({ label: value, value }))}
-                  />
-                </Field>
-              </div>
-            </section>
-            <section className={sectionClass}>
-              <h3 className={titleClass}>提示词</h3>
-              <Field label="系统提示词">
-                <Input.TextArea
-                  rows={5}
-                  value={String(data.config.systemPrompt || '')}
-                  onChange={(event) =>
-                    patchConfig('systemPrompt', event.target.value)
-                  }
-                />
-              </Field>
-              <Field label="用户提示词">
-                <Input.TextArea
-                  rows={7}
-                  value={String(data.config.prompt || '')}
-                  onChange={(event) => patchConfig('prompt', event.target.value)}
-                />
-              </Field>
-              <Field
-                label={`温度 ${Number(data.config.temperature ?? 0.7).toFixed(1)}`}
-              >
-                <Slider
-                  min={0}
-                  max={2}
-                  step={0.1}
-                  value={Number(data.config.temperature ?? 0.7)}
-                  onChange={(value) => patchConfig('temperature', value)}
-                />
-              </Field>
-            </section>
-          </>
-        );
+        return <EndPanel data={data} onConfigChange={patchConfig} />;
       case 'HTTP':
-        return (
-          <section className={sectionClass}>
-            <h3 className={titleClass}>HTTP 请求</h3>
-            <div className="mb-3 grid grid-cols-[92px_minmax(0,1fr)] gap-2">
-              <Select
-                value={String(data.config.method || 'GET')}
-                onChange={(value) => patchConfig('method', value)}
-                options={['GET', 'POST', 'PUT', 'PATCH', 'DELETE'].map(
-                  (value) => ({ label: value, value }),
-                )}
-              />
-              <Input
-                value={String(data.config.url || '')}
-                placeholder="https://api.example.com"
-                onChange={(event) => patchConfig('url', event.target.value)}
-              />
-            </div>
-            <Tabs
-              size="small"
-              items={[
-                {
-                  key: 'body',
-                  label: 'Body',
-                  children: (
-                    <Input.TextArea
-                      rows={7}
-                      value={String(data.config.body || '')}
-                      placeholder='{"query":"{{start.query}}"}'
-                      onChange={(event) =>
-                        patchConfig('body', event.target.value)
-                      }
-                    />
-                  ),
-                },
-                {
-                  key: 'headers',
-                  label: 'Headers',
-                  children: (
-                    <JsonEditor
-                      rows={7}
-                      value={data.config.headers || {}}
-                      onChange={(value) => patchConfig('headers', value)}
-                    />
-                  ),
-                },
-              ]}
-            />
-            <Field label="请求超时（秒）">
-              <InputNumber
-                min={1}
-                max={3600}
-                value={Number(data.config.requestTimeoutSeconds || 60)}
-                onChange={(value) =>
-                  patchConfig('requestTimeoutSeconds', value || 60)
-                }
-              />
-            </Field>
-          </section>
-        );
+        return <HttpPanel data={data} onConfigChange={patchConfig} />;
       case 'SHELL':
-        return (
-          <section className={sectionClass}>
-            <h3 className={titleClass}>Shell 配置</h3>
-            <Field label="执行命令">
-              <Input.TextArea
-                rows={9}
-                className="font-mono text-[10px] leading-[17px] !bg-[#101828] !text-[#e4e7ec]"
-                value={String(data.config.command || '')}
-                placeholder="echo 'hello yak ops'"
-                onChange={(event) => patchConfig('command', event.target.value)}
-              />
-            </Field>
-            <Field label="工作目录">
-              <Input
-                value={String(data.config.workDirectory || '')}
-                placeholder="/opt/yak/jobs"
-                onChange={(event) =>
-                  patchConfig('workDirectory', event.target.value)
-                }
-              />
-            </Field>
-          </section>
-        );
-      case 'CODE':
-        return (
-          <section className={sectionClass}>
-            <h3 className={titleClass}>代码</h3>
-            <Field label="语言">
-              <Select
-                value={String(data.config.language || 'javascript')}
-                onChange={(value) => patchConfig('language', value)}
-                options={[
-                  { label: 'JavaScript', value: 'javascript' },
-                  { label: 'Python', value: 'python' },
-                ]}
-              />
-            </Field>
-            <Field label="代码内容">
-              <Input.TextArea
-                rows={14}
-                className="font-mono text-[10px] leading-[17px] !bg-[#101828] !text-[#e4e7ec]"
-                value={String(data.config.code || '')}
-                onChange={(event) => patchConfig('code', event.target.value)}
-              />
-            </Field>
-          </section>
-        );
-      case 'CONDITION':
-        return (
-          <section className={sectionClass}>
-            <h3 className={titleClass}>条件</h3>
-            <div className="mb-2.5 flex items-center gap-1.5 text-[10px] text-[#667085]">
-              <Tag color="blue">IF</Tag>
-              满足以下表达式
-            </div>
-            <Field label="表达式">
-              <Input.TextArea
-                rows={4}
-                value={String(data.config.expression || '')}
-                placeholder="{{http.statusCode}} == 200"
-                onChange={(event) =>
-                  patchConfig('expression', event.target.value)
-                }
-              />
-            </Field>
-            <Field label="分支名称（每行一个）">
-              <Input.TextArea
-                rows={4}
-                value={
-                  Array.isArray(data.config.cases)
-                    ? data.config.cases.join('\n')
-                    : ''
-                }
-                onChange={(event) =>
-                  patchConfig(
-                    'cases',
-                    event.target.value.split('\n').filter(Boolean),
-                  )
-                }
-              />
-            </Field>
-          </section>
-        );
-      case 'TEMPLATE':
-        return (
-          <section className={sectionClass}>
-            <h3 className={titleClass}>模板</h3>
-            <Field label="Jinja2 风格模板">
-              <Input.TextArea
-                rows={14}
-                className="font-mono text-[10px] leading-[17px]"
-                value={String(data.config.template || '')}
-                onChange={(event) =>
-                  patchConfig('template', event.target.value)
-                }
-              />
-            </Field>
-          </section>
-        );
-      case 'VARIABLE':
-        return (
-          <section className={sectionClass}>
-            <h3 className={titleClass}>变量赋值</h3>
-            <Field label="赋值配置（JSON）">
-              <JsonEditor
-                rows={12}
-                value={data.config.assignments || []}
-                onChange={(value) => patchConfig('assignments', value)}
-              />
-            </Field>
-          </section>
-        );
-      case 'ITERATION':
-        return (
-          <section className={sectionClass}>
-            <h3 className={titleClass}>迭代设置</h3>
-            <Field label="迭代数组">
-              <Input
-                value={String(data.config.source || '')}
-                placeholder="{{start.items}}"
-                onChange={(event) => patchConfig('source', event.target.value)}
-              />
-            </Field>
-            <Field label="并行数">
-              <InputNumber
-                min={1}
-                max={20}
-                value={Number(data.config.parallel || 1)}
-                onChange={(value) => patchConfig('parallel', value || 1)}
-              />
-            </Field>
-            <Field label="输出变量">
-              <Input
-                value={String(data.config.output || 'results')}
-                onChange={(event) => patchConfig('output', event.target.value)}
-              />
-            </Field>
-          </section>
-        );
-      case 'KNOWLEDGE':
-        return (
-          <section className={sectionClass}>
-            <h3 className={titleClass}>知识检索</h3>
-            <Field label="知识库">
-              <Select
-                value={String(data.config.dataset || '') || undefined}
-                placeholder="选择知识库"
-                onChange={(value) => patchConfig('dataset', value)}
-                options={[
-                  { label: '产品知识库', value: 'product' },
-                  { label: '技术文档库', value: 'technical' },
-                  { label: '客户案例库', value: 'cases' },
-                ]}
-              />
-            </Field>
-            <Field label="查询变量">
-              <Input
-                value={String(data.config.query || '')}
-                onChange={(event) => patchConfig('query', event.target.value)}
-              />
-            </Field>
-            <div className="grid grid-cols-2 gap-2.5">
-              <Field label="Top K">
-                <InputNumber
-                  min={1}
-                  max={20}
-                  value={Number(data.config.topK || 3)}
-                  onChange={(value) => patchConfig('topK', value || 3)}
-                />
-              </Field>
-              <Field label="分数阈值">
-                <InputNumber
-                  min={0}
-                  max={1}
-                  step={0.05}
-                  value={Number(data.config.scoreThreshold || 0.5)}
-                  onChange={(value) =>
-                    patchConfig('scoreThreshold', value || 0)
-                  }
-                />
-              </Field>
-            </div>
-          </section>
-        );
-      case 'QUESTION_CLASSIFIER':
-        return (
-          <section className={sectionClass}>
-            <h3 className={titleClass}>问题分类</h3>
-            <Field label="输入变量">
-              <Input
-                value={String(data.config.input || '')}
-                onChange={(event) => patchConfig('input', event.target.value)}
-              />
-            </Field>
-            <Field label="分类（每行一个）">
-              <Input.TextArea
-                rows={8}
-                value={
-                  Array.isArray(data.config.classes)
-                    ? data.config.classes.join('\n')
-                    : ''
-                }
-                onChange={(event) =>
-                  patchConfig(
-                    'classes',
-                    event.target.value.split('\n').filter(Boolean),
-                  )
-                }
-              />
-            </Field>
-          </section>
-        );
-      case 'NOTE':
-        return (
-          <section className={sectionClass}>
-            <h3 className={titleClass}>注释</h3>
-            <Field label="内容">
-              <Input.TextArea
-                rows={12}
-                value={String(data.config.content || '')}
-                onChange={(event) =>
-                  patchConfig('content', event.target.value)
-                }
-              />
-            </Field>
-          </section>
-        );
+        return <ShellPanel data={data} onConfigChange={patchConfig} />;
       default:
         return (
-          <section className={sectionClass}>
-            <h3 className={titleClass}>节点配置</h3>
-            <p className={hintClass}>
-              当前节点没有专属表单，可在高级配置中编辑 JSON。
-            </p>
-          </section>
+          <PanelSection
+            title="不支持的节点"
+            description="该节点来自旧版工作流。当前设计器仅允许新建 Start、End、HTTP 和 Shell 节点。"
+          >
+            <div className="rounded-lg border border-dashed border-[#d0d5dd] bg-[#f9fafb] p-3 text-[10px] leading-[16px] text-[#667085]">
+              节点类型：{data.nodeType}
+              <br />
+              后端任务类型：{data.taskType}
+            </div>
+          </PanelSection>
         );
     }
   };
@@ -555,14 +122,16 @@ const NodePanel = ({
     <aside className={panelShellClass}>
       <header className={panelHeaderClass}>
         <div className="flex min-w-0 flex-1 items-center gap-2.5">
-          <span className="flex h-[31px] w-[31px] shrink-0 items-center justify-center rounded-lg bg-[color-mix(in_srgb,var(--node-color)_10%,white)]">
+          <span className="flex h-[32px] w-[32px] shrink-0 items-center justify-center rounded-lg bg-[color-mix(in_srgb,var(--node-color)_10%,white)]">
             <NodeIcon type={data.nodeType} size={19} />
           </span>
           <div className="min-w-0 flex-1">
             <input
               value={data.title}
               maxLength={255}
-              onChange={(event) => patch({ title: event.target.value })}
+              onChange={(event: ChangeEvent<HTMLInputElement>) =>
+                patch({ title: event.target.value })
+              }
               className="w-full border-0 bg-transparent p-0 text-[13px] font-semibold text-[#344054] outline-none"
             />
             <span className="block text-[9px] text-[#98a2b3]">
@@ -570,15 +139,18 @@ const NodePanel = ({
             </span>
           </div>
         </div>
+
         <div className="flex items-center gap-px">
-          <button
-            type="button"
-            className={panelIconButtonClass}
-            aria-label="复制节点"
-            onClick={onDuplicate}
-          >
-            <Copy size={16} />
-          </button>
+          {!isControlNode && isSupported && (
+            <button
+              type="button"
+              className={panelIconButtonClass}
+              aria-label="复制节点"
+              onClick={onDuplicate}
+            >
+              <Copy size={16} />
+            </button>
+          )}
           <button
             type="button"
             className={panelIconButtonClass}
@@ -598,112 +170,124 @@ const NodePanel = ({
       </header>
 
       <div className={panelContentClass}>
-        <section className="border-b border-[#f0f1f4] px-[15px] py-2.5">
+        <section className="border-b border-[#f0f1f4] px-4 py-3">
           <Input.TextArea
             value={data.description}
             rows={2}
             maxLength={500}
-            placeholder="添加描述..."
+            placeholder="添加节点说明..."
             className="resize-none !border-0 !bg-[#f8f9fb] !shadow-none"
             onChange={(event) => patch({ description: event.target.value })}
           />
         </section>
 
-        {renderMainConfiguration()}
+        {renderNodePanel()}
 
-        <section className={sectionClass}>
-          <button
-            type="button"
-            className="flex w-full items-center justify-between border-0 bg-transparent p-0 text-[11px] font-semibold text-[#475467]"
-            onClick={() => setAdvancedOpen((value) => !value)}
-          >
-            <span>错误处理与高级设置</span>
-            <ChevronDown
-              size={15}
-              className={[
-                'transition-transform duration-200',
-                advancedOpen ? 'rotate-180' : '',
-              ].join(' ')}
-            />
-          </button>
-          {advancedOpen && (
-            <div className="mt-3.5">
-              <div className="grid grid-cols-2 gap-2.5">
-                <Field label="重试次数">
-                  <InputNumber
-                    min={0}
-                    max={20}
-                    value={data.retryTimes}
-                    onChange={(value) => patch({ retryTimes: value || 0 })}
-                  />
-                </Field>
-                <Field label="重试间隔（秒）">
+        {!isControlNode && isSupported && (
+          <section className="border-t border-[#f0f1f4] px-4 py-4">
+            <button
+              type="button"
+              className="flex w-full items-center justify-between border-0 bg-transparent p-0 text-[11px] font-semibold text-[#475467]"
+              onClick={() => setAdvancedOpen((value) => !value)}
+            >
+              <span>错误处理与高级设置</span>
+              <ChevronDown
+                size={15}
+                className={[
+                  'transition-transform duration-200',
+                  advancedOpen ? 'rotate-180' : '',
+                ].join(' ')}
+              />
+            </button>
+
+            {advancedOpen && (
+              <div className="mt-3.5">
+                <div className="grid grid-cols-2 gap-2.5">
+                  <PanelField label="重试次数">
+                    <InputNumber
+                      min={0}
+                      max={20}
+                      value={data.retryTimes}
+                      onChange={(value) => patch({ retryTimes: value || 0 })}
+                    />
+                  </PanelField>
+                  <PanelField label="重试间隔（秒）">
+                    <InputNumber
+                      min={0}
+                      max={86400}
+                      value={data.retryIntervalSeconds}
+                      onChange={(value) =>
+                        patch({ retryIntervalSeconds: value || 0 })
+                      }
+                    />
+                  </PanelField>
+                </div>
+                <PanelField label="节点超时（秒）">
                   <InputNumber
                     min={0}
                     max={86400}
-                    value={data.retryIntervalSeconds}
+                    value={data.timeoutSeconds}
                     onChange={(value) =>
-                      patch({ retryIntervalSeconds: value || 0 })
+                      patch({ timeoutSeconds: value || 0 })
                     }
                   />
-                </Field>
+                </PanelField>
+                <SwitchRow
+                  title="启用节点"
+                  description="停用后保留配置但不参与流程"
+                  checked={data.enabled}
+                  onChange={(value) => patch({ enabled: value })}
+                />
+                <SwitchRow
+                  title="幂等任务"
+                  description="允许执行器安全重复提交"
+                  checked={data.idempotent}
+                  onChange={(value) => patch({ idempotent: value })}
+                />
+                <SwitchRow
+                  title="重启后重试"
+                  description="服务恢复后继续未完成任务"
+                  checked={data.retryOnRestart}
+                  onChange={(value) => patch({ retryOnRestart: value })}
+                />
+                <PanelField label="原始配置 JSON">
+                  <Input.TextArea
+                    rows={10}
+                    className="font-mono text-[10px] leading-[17px] !bg-[#101828] !text-[#e4e7ec]"
+                    value={jsonConfig}
+                    onChange={(event) => {
+                      try {
+                        const next = JSON.parse(event.target.value);
+                        patch({
+                          config: { ...next, __uiType: data.nodeType },
+                        });
+                      } catch {
+                        // Keep the last valid state while editing.
+                      }
+                    }}
+                  />
+                </PanelField>
               </div>
-              <Field label="节点超时（秒）">
-                <InputNumber
-                  min={0}
-                  max={86400}
-                  value={data.timeoutSeconds}
-                  onChange={(value) => patch({ timeoutSeconds: value || 0 })}
-                />
-              </Field>
-              <SwitchRow
-                title="启用节点"
-                description="停用后保留配置但不参与流程"
-                checked={data.enabled}
-                onChange={(value) => patch({ enabled: value })}
-              />
-              <SwitchRow
-                title="幂等任务"
-                description="允许安全重复提交"
-                checked={data.idempotent}
-                onChange={(value) => patch({ idempotent: value })}
-              />
-              <SwitchRow
-                title="重启后重试"
-                description="服务恢复后继续尝试"
-                checked={data.retryOnRestart}
-                onChange={(value) => patch({ retryOnRestart: value })}
-              />
-              <Field label="原始配置 JSON">
-                <Input.TextArea
-                  rows={10}
-                  className="font-mono text-[10px] leading-[17px] !bg-[#101828] !text-[#e4e7ec]"
-                  value={jsonConfig}
-                  onChange={(event) => {
-                    try {
-                      const next = JSON.parse(event.target.value);
-                      patch({
-                        config: { ...next, __uiType: data.nodeType },
-                      });
-                    } catch {
-                      // Keep the last valid state while editing.
-                    }
-                  }}
-                />
-              </Field>
-            </div>
-          )}
-        </section>
+            )}
+          </section>
+        )}
       </div>
 
       <footer className={panelFooterClass}>
-        <button
-          type="button"
-          className="inline-flex h-[29px] items-center gap-1.5 rounded-md border border-[#fecdca] bg-[#fff5f4] px-2.5 text-[9px] text-[#b42318]"
-          onClick={onDelete}
-        >
-          <Trash2 size={16} /> 删除节点
-        </button>
+        {!isControlNode && isSupported ? (
+          <button
+            type="button"
+            className="inline-flex h-[29px] items-center gap-1.5 rounded-md border border-[#fecdca] bg-[#fff5f4] px-2.5 text-[9px] text-[#b42318]"
+            onClick={onDelete}
+          >
+            <Trash2 size={15} />
+            删除节点
+          </button>
+        ) : (
+          <span className="text-[9px] text-[#667085]">
+            {isControlNode ? '流程控制节点不可复制或删除' : '旧节点仅支持查看'}
+          </span>
+        )}
         <span className="text-[8px] text-[#98a2b3]">节点 ID：{node.id}</span>
       </footer>
     </aside>

--- a/yak-ops-ui/src/pages/workflow-management/designer/components/panel/node/end/index.tsx
+++ b/yak-ops-ui/src/pages/workflow-management/designer/components/panel/node/end/index.tsx
@@ -1,0 +1,115 @@
+import { Input } from 'antd';
+import type { WorkflowNodeData } from '../../../../../types';
+import {
+  AddButton,
+  PanelField,
+  PanelSection,
+  RowDeleteButton,
+} from '../shared';
+
+interface OutputVariable {
+  name: string;
+  value: string;
+}
+
+interface EndPanelProps {
+  data: WorkflowNodeData;
+  onConfigChange: (key: string, value: unknown) => void;
+}
+
+const EndPanel = ({ data, onConfigChange }: EndPanelProps) => {
+  const outputs = normalizeOutputs(data.config.outputs);
+
+  const update = (index: number, values: Partial<OutputVariable>) => {
+    onConfigChange(
+      'outputs',
+      outputs.map((item, current) =>
+        current === index ? { ...item, ...values } : item,
+      ),
+    );
+  };
+
+  return (
+    <PanelSection
+      title="输出变量"
+      description="将上游节点结果映射为工作流最终输出。"
+      operation={
+        <AddButton
+          onClick={() =>
+            onConfigChange('outputs', [
+              ...outputs,
+              {
+                name: `output_${outputs.length + 1}`,
+                value: '',
+              },
+            ])
+          }
+        >
+          添加输出
+        </AddButton>
+      }
+    >
+      <div className="space-y-2">
+        {outputs.map((output, index) => (
+          <div
+            key={`${output.name}-${index}`}
+            className="grid grid-cols-[124px_minmax(0,1fr)_32px] gap-2 rounded-lg border border-[#e4e7ec] bg-[#fcfcfd] p-2.5"
+          >
+            <PanelField label="输出名" required>
+              <Input
+                value={output.name}
+                placeholder="result"
+                onChange={(event) =>
+                  update(index, { name: event.target.value })
+                }
+              />
+            </PanelField>
+            <PanelField label="变量或表达式" required>
+              <Input
+                value={output.value}
+                placeholder="{{http.body}}"
+                onChange={(event) =>
+                  update(index, { value: event.target.value })
+                }
+              />
+            </PanelField>
+            <div className="pt-[21px]">
+              <RowDeleteButton
+                onClick={() =>
+                  onConfigChange(
+                    'outputs',
+                    outputs.filter((_, current) => current !== index),
+                  )
+                }
+              />
+            </div>
+          </div>
+        ))}
+
+        {!outputs.length && (
+          <div className="rounded-lg border border-dashed border-[#d0d5dd] py-8 text-center text-[10px] text-[#98a2b3]">
+            至少添加一个输出变量
+          </div>
+        )}
+      </div>
+    </PanelSection>
+  );
+};
+
+const normalizeOutputs = (value: unknown): OutputVariable[] => {
+  if (!Array.isArray(value)) return [];
+
+  return value.map((item, index) => {
+    const record =
+      item && typeof item === 'object'
+        ? (item as Record<string, unknown>)
+        : {};
+
+    return {
+      name: String(record.name || `output_${index + 1}`),
+      value: String(record.value || ''),
+    };
+  });
+};
+
+export default EndPanel;

--- a/yak-ops-ui/src/pages/workflow-management/designer/components/panel/node/http/index.tsx
+++ b/yak-ops-ui/src/pages/workflow-management/designer/components/panel/node/http/index.tsx
@@ -1,0 +1,104 @@
+import { Input, InputNumber, Select, Tabs } from 'antd';
+import type { WorkflowNodeData } from '../../../../../types';
+import {
+  KeyValueEditor,
+  OutputVariables,
+  PanelField,
+  PanelSection,
+} from '../shared';
+
+interface HttpPanelProps {
+  data: WorkflowNodeData;
+  onConfigChange: (key: string, value: unknown) => void;
+}
+
+const HttpPanel = ({ data, onConfigChange }: HttpPanelProps) => (
+  <>
+    <PanelSection
+      title="API"
+      description="配置请求方法和地址，变量可直接写入 URL、Header 或 Body。"
+    >
+      <div className="grid grid-cols-[96px_minmax(0,1fr)] gap-2">
+        <PanelField label="方法">
+          <Select
+            value={String(data.config.method || 'GET')}
+            options={['GET', 'POST', 'PUT', 'PATCH', 'DELETE'].map((value) => ({
+              label: value,
+              value,
+            }))}
+            onChange={(value) => onConfigChange('method', value)}
+          />
+        </PanelField>
+        <PanelField label="请求地址" required>
+          <Input
+            value={String(data.config.url || '')}
+            placeholder="https://api.example.com/orders/{{start.input}}"
+            onChange={(event) => onConfigChange('url', event.target.value)}
+          />
+        </PanelField>
+      </div>
+    </PanelSection>
+
+    <PanelSection title="请求数据">
+      <Tabs
+        size="small"
+        items={[
+          {
+            key: 'headers',
+            label: 'Headers',
+            children: (
+              <KeyValueEditor
+                value={data.config.headers}
+                onChange={(value) => onConfigChange('headers', value)}
+                keyPlaceholder="Header"
+              />
+            ),
+          },
+          {
+            key: 'body',
+            label: 'Body',
+            children: (
+              <Input.TextArea
+                rows={10}
+                className="font-mono text-[10px] leading-[17px]"
+                value={String(data.config.body || '')}
+                placeholder='{"id":"{{start.input}}"}'
+                onChange={(event) =>
+                  onConfigChange('body', event.target.value)
+                }
+              />
+            ),
+          },
+        ]}
+      />
+    </PanelSection>
+
+    <PanelSection title="超时设置">
+      <PanelField label="请求超时（秒）">
+        <InputNumber
+          min={1}
+          max={3600}
+          value={Number(data.config.requestTimeoutSeconds || 60)}
+          onChange={(value) =>
+            onConfigChange('requestTimeoutSeconds', value || 60)
+          }
+        />
+      </PanelField>
+    </PanelSection>
+
+    <PanelSection
+      title="输出变量"
+      description="HTTP 节点完成后可供下游节点引用。"
+    >
+      <OutputVariables
+        items={[
+          { name: 'body', type: 'String', description: '响应正文' },
+          { name: 'statusCode', type: 'Number', description: 'HTTP 状态码' },
+          { name: 'headers', type: 'Object', description: '响应头' },
+        ]}
+      />
+    </PanelSection>
+  </>
+);
+
+export default HttpPanel;

--- a/yak-ops-ui/src/pages/workflow-management/designer/components/panel/node/shared.tsx
+++ b/yak-ops-ui/src/pages/workflow-management/designer/components/panel/node/shared.tsx
@@ -1,0 +1,199 @@
+import { Button, Input } from 'antd';
+import { Plus, Trash2 } from 'lucide-react';
+import type { ReactNode } from 'react';
+
+interface PanelSectionProps {
+  title: string;
+  description?: string;
+  operation?: ReactNode;
+  children: ReactNode;
+}
+
+export const PanelSection = ({
+  title,
+  description,
+  operation,
+  children,
+}: PanelSectionProps) => (
+  <section className="border-b border-[#f0f1f4] px-4 py-4 last:border-b-0">
+    <div className="mb-3 flex items-start justify-between gap-3">
+      <div>
+        <h3 className="m-0 text-[11px] font-semibold text-[#344054]">
+          {title}
+        </h3>
+        {description && (
+          <p className="mb-0 mt-1 text-[9px] leading-[15px] text-[#98a2b3]">
+            {description}
+          </p>
+        )}
+      </div>
+      {operation}
+    </div>
+    {children}
+  </section>
+);
+
+interface PanelFieldProps {
+  label: string;
+  hint?: string;
+  required?: boolean;
+  children: ReactNode;
+}
+
+export const PanelField = ({
+  label,
+  hint,
+  required,
+  children,
+}: PanelFieldProps) => (
+  <label
+    className={[
+      'mb-3 block last:mb-0',
+      '[&_.ant-input]:w-full [&_.ant-input]:text-[11px]',
+      '[&_.ant-input-number]:w-full [&_.ant-input-number]:text-[11px]',
+      '[&_.ant-select]:w-full [&_.ant-select]:text-[11px]',
+      '[&_.ant-input-affix-wrapper]:w-full [&_.ant-input-affix-wrapper]:text-[11px]',
+    ].join(' ')}
+  >
+    <span className="mb-1.5 flex items-center gap-1 text-[9px] font-semibold text-[#667085]">
+      {label}
+      {required && <span className="text-[#d92d20]">*</span>}
+      {hint && <small className="font-normal text-[#98a2b3]">{hint}</small>}
+    </span>
+    {children}
+  </label>
+);
+
+export const AddButton = ({
+  children,
+  onClick,
+}: {
+  children: ReactNode;
+  onClick: () => void;
+}) => (
+  <Button
+    type="text"
+    size="small"
+    icon={<Plus size={13} />}
+    onClick={onClick}
+    className="!h-7 !px-2 !text-[10px] !text-[#155eef]"
+  >
+    {children}
+  </Button>
+);
+
+export const RowDeleteButton = ({ onClick }: { onClick: () => void }) => (
+  <button
+    type="button"
+    aria-label="删除"
+    onClick={onClick}
+    className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md border-0 bg-transparent text-[#98a2b3] hover:bg-[#fff1f0] hover:text-[#d92d20]"
+  >
+    <Trash2 size={14} />
+  </button>
+);
+
+export const KeyValueEditor = ({
+  value,
+  onChange,
+  keyPlaceholder = 'Key',
+  valuePlaceholder = 'Value',
+}: {
+  value: unknown;
+  onChange: (value: Record<string, string>) => void;
+  keyPlaceholder?: string;
+  valuePlaceholder?: string;
+}) => {
+  const entries = toEntries(value);
+
+  const updateEntry = (
+    index: number,
+    field: 'key' | 'value',
+    nextValue: string,
+  ) => {
+    const next = entries.map((entry) => ({ ...entry }));
+    next[index][field] = nextValue;
+    onChange(toRecord(next));
+  };
+
+  const removeEntry = (index: number) => {
+    onChange(toRecord(entries.filter((_, current) => current !== index)));
+  };
+
+  return (
+    <div className="overflow-hidden rounded-lg border border-[#e4e7ec]">
+      {entries.map((entry, index) => (
+        <div
+          key={`${entry.key}-${index}`}
+          className="grid grid-cols-[minmax(0,0.8fr)_minmax(0,1.2fr)_30px] gap-1 border-b border-[#f2f4f7] p-1.5 last:border-b-0"
+        >
+          <Input
+            bordered={false}
+            value={entry.key}
+            placeholder={keyPlaceholder}
+            onChange={(event) => updateEntry(index, 'key', event.target.value)}
+          />
+          <Input
+            bordered={false}
+            value={entry.value}
+            placeholder={valuePlaceholder}
+            onChange={(event) =>
+              updateEntry(index, 'value', event.target.value)
+            }
+          />
+          <RowDeleteButton onClick={() => removeEntry(index)} />
+        </div>
+      ))}
+      <button
+        type="button"
+        onClick={() =>
+          onChange(
+            toRecord([
+              ...entries,
+              { key: `key_${entries.length + 1}`, value: '' },
+            ]),
+          )
+        }
+        className="flex h-8 w-full items-center justify-center gap-1 border-0 bg-[#fcfcfd] text-[10px] text-[#667085] hover:bg-[#f5f8ff] hover:text-[#155eef]"
+      >
+        <Plus size={13} />
+        添加一项
+      </button>
+    </div>
+  );
+};
+
+export const OutputVariables = ({
+  items,
+}: {
+  items: Array<{ name: string; type: string; description: string }>;
+}) => (
+  <div className="overflow-hidden rounded-lg border border-[#e4e7ec] bg-[#fcfcfd]">
+    {items.map((item) => (
+      <div
+        key={item.name}
+        className="grid grid-cols-[90px_72px_minmax(0,1fr)] gap-2 border-b border-[#f2f4f7] px-2.5 py-2 text-[9px] last:border-b-0"
+      >
+        <code className="font-semibold text-[#344054]">{item.name}</code>
+        <span className="text-[#667085]">{item.type}</span>
+        <span className="text-[#98a2b3]">{item.description}</span>
+      </div>
+    ))}
+  </div>
+);
+
+const toEntries = (value: unknown) => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return [];
+  return Object.entries(value).map(([key, item]) => ({
+    key,
+    value: String(item ?? ''),
+  }));
+};
+
+const toRecord = (entries: Array<{ key: string; value: string }>) =>
+  Object.fromEntries(
+    entries
+      .map((entry) => ({ key: entry.key.trim(), value: entry.value }))
+      .filter((entry) => entry.key)
+      .map((entry) => [entry.key, entry.value] as const),
+  );

--- a/yak-ops-ui/src/pages/workflow-management/designer/components/panel/node/shell/index.tsx
+++ b/yak-ops-ui/src/pages/workflow-management/designer/components/panel/node/shell/index.tsx
@@ -1,0 +1,67 @@
+import { Input } from 'antd';
+import type { WorkflowNodeData } from '../../../../../types';
+import {
+  KeyValueEditor,
+  OutputVariables,
+  PanelField,
+  PanelSection,
+} from '../shared';
+
+interface ShellPanelProps {
+  data: WorkflowNodeData;
+  onConfigChange: (key: string, value: unknown) => void;
+}
+
+const ShellPanel = ({ data, onConfigChange }: ShellPanelProps) => (
+  <>
+    <PanelSection
+      title="执行命令"
+      description="命令由工作流执行节点运行，请避免在脚本中直接写入敏感信息。"
+    >
+      <PanelField label="命令或脚本" required>
+        <Input.TextArea
+          rows={12}
+          className="font-mono text-[10px] leading-[18px] !bg-[#101828] !text-[#e4e7ec]"
+          value={String(data.config.command || '')}
+          placeholder={'#!/usr/bin/env bash\necho "hello yak ops"'}
+          onChange={(event) => onConfigChange('command', event.target.value)}
+        />
+      </PanelField>
+      <PanelField label="工作目录">
+        <Input
+          value={String(data.config.workDirectory || '')}
+          placeholder="/opt/yak/jobs"
+          onChange={(event) =>
+            onConfigChange('workDirectory', event.target.value)
+          }
+        />
+      </PanelField>
+    </PanelSection>
+
+    <PanelSection
+      title="环境变量"
+      description="节点级环境变量会在执行命令时注入。"
+    >
+      <KeyValueEditor
+        value={data.config.environment}
+        onChange={(value) => onConfigChange('environment', value)}
+        keyPlaceholder="变量名"
+      />
+    </PanelSection>
+
+    <PanelSection
+      title="输出变量"
+      description="Shell 节点完成后可供下游节点引用。"
+    >
+      <OutputVariables
+        items={[
+          { name: 'exitCode', type: 'Number', description: '进程退出码' },
+          { name: 'stdout', type: 'String', description: '标准输出' },
+          { name: 'stderr', type: 'String', description: '错误输出' },
+        ]}
+      />
+    </PanelSection>
+  </>
+);
+
+export default ShellPanel;

--- a/yak-ops-ui/src/pages/workflow-management/designer/components/panel/node/start/index.tsx
+++ b/yak-ops-ui/src/pages/workflow-management/designer/components/panel/node/start/index.tsx
@@ -1,0 +1,143 @@
+import { Input, Select, Switch } from 'antd';
+import type { WorkflowNodeData } from '../../../../../types';
+import {
+  AddButton,
+  PanelField,
+  PanelSection,
+  RowDeleteButton,
+} from '../shared';
+
+interface InputVariable {
+  name: string;
+  type: string;
+  required: boolean;
+  description?: string;
+}
+
+interface StartPanelProps {
+  data: WorkflowNodeData;
+  onConfigChange: (key: string, value: unknown) => void;
+}
+
+const StartPanel = ({ data, onConfigChange }: StartPanelProps) => {
+  const variables = normalizeVariables(data.config.inputVariables);
+
+  const update = (index: number, values: Partial<InputVariable>) => {
+    onConfigChange(
+      'inputVariables',
+      variables.map((item, current) =>
+        current === index ? { ...item, ...values } : item,
+      ),
+    );
+  };
+
+  return (
+    <PanelSection
+      title="输入字段"
+      description="定义启动工作流时需要填写的参数，可在后续节点中引用。"
+      operation={
+        <AddButton
+          onClick={() =>
+            onConfigChange('inputVariables', [
+              ...variables,
+              {
+                name: `input_${variables.length + 1}`,
+                type: 'string',
+                required: false,
+                description: '',
+              },
+            ])
+          }
+        >
+          添加变量
+        </AddButton>
+      }
+    >
+      <div className="space-y-2">
+        {variables.map((variable, index) => (
+          <div
+            key={`${variable.name}-${index}`}
+            className="rounded-lg border border-[#e4e7ec] bg-[#fcfcfd] p-2.5"
+          >
+            <div className="grid grid-cols-[minmax(0,1fr)_104px_32px] gap-2">
+              <PanelField label="变量名" required>
+                <Input
+                  value={variable.name}
+                  placeholder="例如：orderId"
+                  onChange={(event) =>
+                    update(index, { name: event.target.value })
+                  }
+                />
+              </PanelField>
+              <PanelField label="类型">
+                <Select
+                  value={variable.type}
+                  options={[
+                    { label: 'String', value: 'string' },
+                    { label: 'Number', value: 'number' },
+                    { label: 'Boolean', value: 'boolean' },
+                    { label: 'JSON', value: 'json' },
+                  ]}
+                  onChange={(value) => update(index, { type: value })}
+                />
+              </PanelField>
+              <div className="pt-[21px]">
+                <RowDeleteButton
+                  onClick={() =>
+                    onConfigChange(
+                      'inputVariables',
+                      variables.filter((_, current) => current !== index),
+                    )
+                  }
+                />
+              </div>
+            </div>
+            <PanelField label="说明">
+              <Input
+                value={variable.description}
+                placeholder="说明这个变量的用途"
+                onChange={(event) =>
+                  update(index, { description: event.target.value })
+                }
+              />
+            </PanelField>
+            <div className="flex items-center justify-between text-[9px] text-[#667085]">
+              <span>必填参数</span>
+              <Switch
+                size="small"
+                checked={variable.required}
+                onChange={(checked) => update(index, { required: checked })}
+              />
+            </div>
+          </div>
+        ))}
+
+        {!variables.length && (
+          <div className="rounded-lg border border-dashed border-[#d0d5dd] py-8 text-center text-[10px] text-[#98a2b3]">
+            暂无输入变量
+          </div>
+        )}
+      </div>
+    </PanelSection>
+  );
+};
+
+const normalizeVariables = (value: unknown): InputVariable[] => {
+  if (!Array.isArray(value)) return [];
+
+  return value.map((item, index) => {
+    const record =
+      item && typeof item === 'object'
+        ? (item as Record<string, unknown>)
+        : {};
+
+    return {
+      name: String(record.name || `input_${index + 1}`),
+      type: String(record.type || 'string'),
+      required: Boolean(record.required),
+      description: String(record.description || ''),
+    };
+  });
+};
+
+export default StartPanel;

--- a/yak-ops-ui/src/pages/workflow-management/designer/components/panel/shared.tsx
+++ b/yak-ops-ui/src/pages/workflow-management/designer/components/panel/shared.tsx
@@ -1,18 +1,18 @@
 import type { ReactNode } from 'react';
 
 export const panelShellClass = [
-  'absolute bottom-0 right-0 top-0 z-40 flex w-[380px] flex-col overflow-hidden',
+  'absolute bottom-0 right-0 top-0 z-40 flex w-[420px] flex-col overflow-hidden',
   'border-l border-[#e4e7ec] bg-white shadow-[-10px_0_30px_rgba(16,24,40,0.06)]',
-  'max-lg:w-[min(380px,100vw)]',
+  'max-lg:w-[min(420px,100vw)]',
 ].join(' ');
 
 export const panelHeaderClass =
-  'flex min-h-[62px] shrink-0 items-center justify-between border-b border-[#eaecf0] pl-4 pr-3';
+  'flex min-h-[64px] shrink-0 items-center justify-between border-b border-[#eaecf0] pl-4 pr-3';
 
 export const panelContentClass = 'min-h-0 flex-1 overflow-y-auto bg-white';
 
 export const panelFooterClass =
-  'flex min-h-[46px] shrink-0 items-center justify-between border-t border-[#eaecf0] bg-[#fcfcfd] px-3.5';
+  'flex min-h-[48px] shrink-0 items-center justify-between border-t border-[#eaecf0] bg-[#fcfcfd] px-3.5';
 
 export const panelIconButtonClass =
   'flex h-8 w-8 items-center justify-center rounded-lg border-0 bg-transparent text-[#667085] hover:bg-[#f2f4f7] hover:text-[#344054]';

--- a/yak-ops-ui/src/pages/workflow-management/designer/constants.ts
+++ b/yak-ops-ui/src/pages/workflow-management/designer/constants.ts
@@ -6,11 +6,13 @@ import type {
   WorkflowTemplateDefinition,
 } from '../types';
 
+export type WorkflowNodeCategory = 'control' | 'action';
+
 export interface WorkflowNodeMeta {
   type: WorkflowNodeType;
   title: string;
   description: string;
-  category: 'trigger' | 'logic' | 'transform' | 'integration' | 'ai' | 'annotation';
+  category: WorkflowNodeCategory;
   color: string;
   backendType: WorkflowBackendTaskType;
   defaults: Record<string, unknown>;
@@ -20,164 +22,106 @@ export const WORKFLOW_NODE_CATALOG: WorkflowNodeMeta[] = [
   {
     type: 'START',
     title: '开始',
-    description: '定义工作流输入变量',
-    category: 'trigger',
-    color: '#7c3aed',
-    backendType: 'NOOP',
-    defaults: { inputVariables: [{ name: 'query', type: 'string', required: true }] },
-  },
-  {
-    type: 'LLM',
-    title: 'LLM',
-    description: '调用大语言模型生成内容',
-    category: 'ai',
+    description: '定义工作流运行时的输入变量',
+    category: 'control',
     color: '#7c3aed',
     backendType: 'NOOP',
     defaults: {
-      provider: 'OpenAI',
-      model: 'gpt-4o-mini',
-      systemPrompt: '你是一个专业、可靠的助手。',
-      prompt: '{{start.query}}',
-      temperature: 0.7,
+      inputVariables: [
+        {
+          name: 'input',
+          type: 'string',
+          required: true,
+          description: '',
+        },
+      ],
     },
-  },
-  {
-    type: 'KNOWLEDGE',
-    title: '知识检索',
-    description: '从知识库中检索相关内容',
-    category: 'ai',
-    color: '#2563eb',
-    backendType: 'NOOP',
-    defaults: { dataset: '', query: '{{start.query}}', topK: 3, scoreThreshold: 0.5 },
-  },
-  {
-    type: 'QUESTION_CLASSIFIER',
-    title: '问题分类器',
-    description: '通过模型将输入路由到不同分支',
-    category: 'ai',
-    color: '#2563eb',
-    backendType: 'NOOP',
-    defaults: { input: '{{start.query}}', classes: ['类型一', '类型二'] },
-  },
-  {
-    type: 'HTTP',
-    title: 'HTTP 请求',
-    description: '调用外部 REST API',
-    category: 'integration',
-    color: '#0ea5e9',
-    backendType: 'HTTP',
-    defaults: { method: 'GET', url: '', headers: {}, body: '', requestTimeoutSeconds: 60 },
-  },
-  {
-    type: 'SHELL',
-    title: 'Shell',
-    description: '运行本地命令或脚本',
-    category: 'integration',
-    color: '#475569',
-    backendType: 'SHELL',
-    defaults: { command: '', workDirectory: '', environment: {} },
-  },
-  {
-    type: 'CODE',
-    title: '代码执行',
-    description: '使用代码转换输入数据',
-    category: 'transform',
-    color: '#f59e0b',
-    backendType: 'NOOP',
-    defaults: {
-      language: 'javascript',
-      code: 'function main(inputs) {\n  return { result: inputs };\n}',
-    },
-  },
-  {
-    type: 'TEMPLATE',
-    title: '模板转换',
-    description: '使用模板拼装文本内容',
-    category: 'transform',
-    color: '#f97316',
-    backendType: 'NOOP',
-    defaults: { template: '处理结果：{{llm.text}}' },
-  },
-  {
-    type: 'VARIABLE',
-    title: '变量赋值',
-    description: '设置或聚合工作流变量',
-    category: 'transform',
-    color: '#14b8a6',
-    backendType: 'NOOP',
-    defaults: { assignments: [{ name: 'result', value: '{{llm.text}}' }] },
-  },
-  {
-    type: 'CONDITION',
-    title: '条件分支',
-    description: '根据表达式进入不同流程分支',
-    category: 'logic',
-    color: '#f59e0b',
-    backendType: 'NOOP',
-    defaults: { expression: '{{http.statusCode}} == 200', cases: ['TRUE', 'FALSE'] },
-  },
-  {
-    type: 'ITERATION',
-    title: '迭代',
-    description: '遍历数组并执行内部步骤',
-    category: 'logic',
-    color: '#06b6d4',
-    backendType: 'NOOP',
-    defaults: { source: '{{start.items}}', parallel: 1, output: 'results' },
   },
   {
     type: 'END',
     title: '结束',
-    description: '定义工作流输出结果',
-    category: 'logic',
-    color: '#10b981',
+    description: '定义工作流最终输出结果',
+    category: 'control',
+    color: '#12b76a',
     backendType: 'NOOP',
-    defaults: { outputs: [{ name: 'result', value: '{{llm.text}}' }] },
+    defaults: {
+      outputs: [
+        {
+          name: 'result',
+          value: '',
+        },
+      ],
+    },
   },
   {
-    type: 'NOOP',
-    title: '基础节点',
-    description: '通用占位或人工步骤',
-    category: 'logic',
-    color: '#64748b',
-    backendType: 'NOOP',
-    defaults: {},
+    type: 'HTTP',
+    title: 'HTTP 请求',
+    description: '调用外部 HTTP 或 REST API',
+    category: 'action',
+    color: '#2e90fa',
+    backendType: 'HTTP',
+    defaults: {
+      method: 'GET',
+      url: '',
+      headers: {},
+      body: '',
+      requestTimeoutSeconds: 60,
+    },
   },
   {
-    type: 'NOTE',
-    title: '注释',
-    description: '在画布上补充说明',
-    category: 'annotation',
-    color: '#eab308',
-    backendType: 'NOOP',
-    defaults: { content: '双击或在右侧面板编辑注释内容。' },
+    type: 'SHELL',
+    title: 'Shell',
+    description: '在执行节点上运行命令或脚本',
+    category: 'action',
+    color: '#475467',
+    backendType: 'SHELL',
+    defaults: {
+      command: '',
+      workDirectory: '',
+      environment: {},
+    },
   },
 ];
 
-export const CATEGORY_LABELS: Record<WorkflowNodeMeta['category'], string> = {
-  trigger: '触发器',
-  ai: 'AI',
-  integration: '集成',
-  transform: '数据转换',
-  logic: '逻辑',
-  annotation: '辅助',
+export const CATEGORY_LABELS: Record<WorkflowNodeCategory, string> = {
+  control: '流程节点',
+  action: '执行节点',
 };
+
+const FALLBACK_NODE_META: WorkflowNodeMeta = {
+  type: 'SHELL',
+  title: '不支持的节点',
+  description: '该节点不在当前四节点工作流范围内',
+  category: 'action',
+  color: '#98a2b3',
+  backendType: 'NOOP',
+  defaults: {},
+};
+
+export const isSupportedWorkflowNodeType = (
+  type: string,
+): type is 'START' | 'END' | 'HTTP' | 'SHELL' =>
+  WORKFLOW_NODE_CATALOG.some((item) => item.type === type);
 
 export const getNodeMeta = (type: WorkflowNodeType | string) =>
   WORKFLOW_NODE_CATALOG.find((item) => item.type === type) ||
-  WORKFLOW_NODE_CATALOG.find((item) => item.type === 'NOOP')!;
+  FALLBACK_NODE_META;
 
 export const createNodeData = (
   type: WorkflowNodeType,
   index: number,
 ): WorkflowNodeData => {
   const meta = getNodeMeta(type);
+  const nodeType = isSupportedWorkflowNodeType(String(type))
+    ? type
+    : meta.type;
+
   return {
-    title: `${meta.title}${['START', 'END', 'NOTE'].includes(type) ? '' : ` ${index}`}`,
+    title: `${meta.title}${['START', 'END'].includes(String(nodeType)) ? '' : ` ${index}`}`,
     description: meta.description,
-    nodeType: type,
+    nodeType,
     taskType: meta.backendType,
-    config: { ...meta.defaults, __uiType: type },
+    config: { ...meta.defaults, __uiType: nodeType },
     retryTimes: 0,
     retryIntervalSeconds: 0,
     timeoutSeconds: 0,
@@ -196,6 +140,7 @@ const nodeRecord = (
   title?: string,
 ): WorkflowNodeRecord => {
   const data = createNodeData(type, 1);
+
   return {
     key,
     name: title || data.title,
@@ -217,67 +162,12 @@ export const WORKFLOW_TEMPLATES: WorkflowTemplateDefinition[] = [
   {
     id: 'blank',
     name: '空白工作流',
-    description: '从开始节点构建新的工作流。',
+    description: '从开始节点构建 HTTP 与 Shell 自动化流程。',
     category: '基础',
     icon: 'START',
     nodes: [nodeRecord('start', 'START', 80, 220, '开始')],
     edges: [],
     viewport: { x: 120, y: 60, zoom: 0.9 },
-  },
-  {
-    id: 'ai-answer',
-    name: 'AI 问答',
-    description: '输入问题，调用模型并返回生成结果。',
-    category: 'AI',
-    icon: 'LLM',
-    nodes: [
-      nodeRecord('start', 'START', 40, 220, '开始'),
-      nodeRecord('llm', 'LLM', 360, 220, '生成回答'),
-      nodeRecord('end', 'END', 680, 220, '结束'),
-    ],
-    edges: [
-      { from: 'start', to: 'llm' },
-      { from: 'llm', to: 'end' },
-    ],
-    viewport: { x: 80, y: 100, zoom: 0.9 },
-  },
-  {
-    id: 'knowledge-answer',
-    name: '知识库问答',
-    description: '检索知识库，将召回内容交给模型生成答案。',
-    category: 'AI',
-    icon: 'KNOWLEDGE',
-    nodes: [
-      nodeRecord('start', 'START', 20, 220, '开始'),
-      nodeRecord('knowledge', 'KNOWLEDGE', 300, 120, '知识检索'),
-      nodeRecord('llm', 'LLM', 580, 220, '生成答案'),
-      nodeRecord('end', 'END', 860, 220, '结束'),
-    ],
-    edges: [
-      { from: 'start', to: 'knowledge' },
-      { from: 'knowledge', to: 'llm' },
-      { from: 'llm', to: 'end' },
-    ],
-    viewport: { x: 30, y: 110, zoom: 0.82 },
-  },
-  {
-    id: 'api-orchestration',
-    name: 'API 编排',
-    description: '请求外部接口，根据结果执行条件分支。',
-    category: '集成',
-    icon: 'HTTP',
-    nodes: [
-      nodeRecord('start', 'START', 20, 220, '开始'),
-      nodeRecord('http', 'HTTP', 300, 220, '请求接口'),
-      nodeRecord('condition', 'CONDITION', 580, 220, '判断结果'),
-      nodeRecord('end', 'END', 860, 220, '结束'),
-    ],
-    edges: [
-      { from: 'start', to: 'http' },
-      { from: 'http', to: 'condition' },
-      { from: 'condition', to: 'end' },
-    ],
-    viewport: { x: 30, y: 100, zoom: 0.82 },
   },
 ];
 
@@ -286,9 +176,12 @@ export const resolveVisualNodeType = (
   config: Record<string, unknown> | undefined,
 ): WorkflowNodeType => {
   const uiType = config?.__uiType;
-  if (typeof uiType === 'string' && WORKFLOW_NODE_CATALOG.some((item) => item.type === uiType))
-    return uiType as WorkflowNodeType;
-  if (backendType === 'HTTP' || backendType === 'SHELL' || backendType === 'NOOP')
-    return backendType;
-  return 'NOOP';
+
+  if (typeof uiType === 'string' && isSupportedWorkflowNodeType(uiType))
+    return uiType;
+  if (backendType === 'HTTP' || backendType === 'SHELL') return backendType;
+
+  // Keep legacy node types readable without exposing them in the node selector.
+  if (typeof uiType === 'string') return uiType as WorkflowNodeType;
+  return backendType as WorkflowNodeType;
 };

--- a/yak-ops-ui/src/pages/workflow-management/designer/taskPluginCatalog.test.ts
+++ b/yak-ops-ui/src/pages/workflow-management/designer/taskPluginCatalog.test.ts
@@ -2,18 +2,51 @@ import { getNodeMeta, WORKFLOW_NODE_CATALOG } from './constants';
 import { mergeTaskPluginCatalog } from './taskPluginCatalog';
 
 describe('task plugin catalog', () => {
-  const originalLength = WORKFLOW_NODE_CATALOG.length;
+  const originalCatalog = WORKFLOW_NODE_CATALOG.map((item) => ({
+    ...item,
+    defaults: { ...item.defaults },
+  }));
 
   afterEach(() => {
-    WORKFLOW_NODE_CATALOG.splice(originalLength);
+    WORKFLOW_NODE_CATALOG.splice(
+      0,
+      WORKFLOW_NODE_CATALOG.length,
+      ...originalCatalog.map((item) => ({
+        ...item,
+        defaults: { ...item.defaults },
+      })),
+    );
   });
 
-  it('adds an unknown backend plugin as a generic integration node', () => {
+  it('only merges defaults for the supported HTTP and Shell plugins', () => {
     mergeTaskPluginCatalog([
+      {
+        type: 'HTTP',
+        name: 'HTTP',
+        description: 'HTTP task',
+        category: 'GENERAL',
+        version: '1.0.0',
+        cancellable: true,
+        outputCapable: true,
+        configurationSchema: {
+          fields: {
+            requestTimeoutSeconds: {
+              type: 'number',
+              required: false,
+              defaultValue: 30,
+            },
+            followRedirects: {
+              type: 'boolean',
+              required: false,
+              defaultValue: true,
+            },
+          },
+        },
+      },
       {
         type: 'PYTHON',
         name: 'Python',
-        description: '运行 Python 脚本',
+        description: 'Python task',
         category: 'SYSTEM',
         version: '1.0.0',
         cancellable: true,
@@ -30,12 +63,16 @@ describe('task plugin catalog', () => {
       },
     ]);
 
-    expect(getNodeMeta('PYTHON')).toMatchObject({
-      type: 'PYTHON',
-      backendType: 'PYTHON',
-      title: 'Python',
-      category: 'integration',
-      defaults: { script: 'print("hello")' },
+    expect(WORKFLOW_NODE_CATALOG.map((item) => item.type)).toEqual([
+      'START',
+      'END',
+      'HTTP',
+      'SHELL',
+    ]);
+    expect(getNodeMeta('HTTP').defaults).toMatchObject({
+      requestTimeoutSeconds: 60,
+      followRedirects: true,
     });
+    expect(getNodeMeta('PYTHON').title).toBe('不支持的节点');
   });
 });

--- a/yak-ops-ui/src/pages/workflow-management/designer/taskPluginCatalog.ts
+++ b/yak-ops-ui/src/pages/workflow-management/designer/taskPluginCatalog.ts
@@ -1,45 +1,37 @@
-import type { WorkflowNodeType, WorkflowTaskPluginRecord } from '../types';
-import {
-  WORKFLOW_NODE_CATALOG,
-  type WorkflowNodeMeta,
-} from './constants';
+import type { WorkflowTaskPluginRecord } from '../types';
+import { WORKFLOW_NODE_CATALOG } from './constants';
 
-const categoryColor: Record<string, string> = {
-  GENERAL: '#0ea5e9',
-  SYSTEM: '#475569',
-  DATA: '#14b8a6',
-  AI: '#7c3aed',
-};
+const SUPPORTED_TASK_TYPES = new Set(['HTTP', 'SHELL']);
 
 export const mergeTaskPluginCatalog = (plugins: WorkflowTaskPluginRecord[]) => {
   for (const plugin of plugins) {
-    const defaults = extractDefaults(plugin.configurationSchema);
-    const existing = WORKFLOW_NODE_CATALOG.find((item) => item.type === plugin.type);
-    if (existing) {
-      existing.defaults = { ...defaults, ...existing.defaults };
-      continue;
-    }
+    if (!SUPPORTED_TASK_TYPES.has(plugin.type)) continue;
 
-    const meta: WorkflowNodeMeta = {
-      type: plugin.type as WorkflowNodeType,
-      title: plugin.name || plugin.type,
-      description: plugin.description || `${plugin.type} 任务插件`,
-      category: 'integration',
-      color: categoryColor[plugin.category] || '#64748b',
-      backendType: plugin.type,
-      defaults,
+    const existing = WORKFLOW_NODE_CATALOG.find(
+      (item) => item.backendType === plugin.type,
+    );
+    if (!existing) continue;
+
+    existing.defaults = {
+      ...extractDefaults(plugin.configurationSchema),
+      ...existing.defaults,
     };
-    WORKFLOW_NODE_CATALOG.push(meta);
   }
 };
 
 const extractDefaults = (schema: Record<string, unknown>) => {
   const fields = isObject(schema.fields) ? schema.fields : {};
   const defaults: Record<string, unknown> = {};
+
   Object.entries(fields).forEach(([key, value]) => {
-    if (!isObject(value) || !Object.prototype.hasOwnProperty.call(value, 'defaultValue')) return;
+    if (
+      !isObject(value) ||
+      !Object.prototype.hasOwnProperty.call(value, 'defaultValue')
+    )
+      return;
     defaults[key] = value.defaultValue;
   });
+
   return defaults;
 };
 


### PR DESCRIPTION
## 变更说明

参考 Dify workflow 的节点/面板拆分方式，收口 Yak Ops 工作流设计器，仅保留以下四类节点：

- Start：输入变量配置
- End：输出变量映射
- HTTP：请求方法、URL、Headers、Body、超时及输出变量
- Shell：命令、工作目录、环境变量及输出变量

## 主要调整

- 将原先集中在 `NodePanel.tsx` 中的大型 switch 表单拆成独立节点面板目录
- 将节点卡片内容拆分到 `components/node/nodes/{start,end,http,shell}`
- 节点目录、图标、模板和动态插件注册统一限制为四类节点
- 合并重复的节点选择入口，左侧工具栏统一打开轻量节点选择器
- 保留旧工作流节点的只读兜底展示，避免历史数据加载时直接崩溃
- 保留 React Flow、撤销/重做、自动布局、变量检查、导入导出和小地图能力

## 校验

- TypeScript/TSX 语法检查通过
- 带依赖桩的严格 TypeScript 检查通过
- 四节点目录及插件限制逻辑测试通过

> 当前环境无法下载仓库依赖，因此未执行完整 `npm run build`；PR CI 可继续验证真实项目依赖下的构建结果。