### PR TITLE
feat(workflow): 对接 HTTP/Shell 参数并增加实时必填检查

### DIFF
--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dag/WorkflowDagCompiler.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dag/WorkflowDagCompiler.java
@@ -48,7 +48,8 @@ public class WorkflowDagCompiler {
     }
 
     Set<String> uniqueEdges = new LinkedHashSet<>();
-    for (WorkflowEdge edge : dag.getEdges()) {
+    List<WorkflowEdge> edges = dag.getEdges() == null ? List.of() : dag.getEdges();
+    for (WorkflowEdge edge : edges) {
       if (edge == null || edge.getFrom() == null || edge.getTo() == null) {
         throw new IllegalArgumentException("工作流边的起止节点不能为空");
       }
@@ -75,6 +76,22 @@ public class WorkflowDagCompiler {
         order);
   }
 
+  /**
+   * Validates a draft and returns the canonical representation persisted by definition APIs.
+   */
+  public WorkflowDag normalizeAndValidate(WorkflowDag dag) {
+    CompiledWorkflowDag compiled = compile(dag);
+    WorkflowDag normalized = new WorkflowDag();
+    normalized.setNodes(new ArrayList<>(compiled.getNodes().values()));
+
+    List<WorkflowEdge> edges = new ArrayList<>();
+    compiled.getSuccessors().forEach((from, targets) ->
+        targets.forEach(to -> edges.add(new WorkflowEdge(from, to))));
+    normalized.setEdges(edges);
+    normalized.setViewport(dag.getViewport());
+    return normalized;
+  }
+
   private WorkflowNode normalize(WorkflowNode source) {
     if (source == null) {
       throw new IllegalArgumentException("工作流节点不能为空");
@@ -85,6 +102,9 @@ public class WorkflowDagCompiler {
     target.setType(source.getType() == null
         ? null
         : source.getType().trim().toUpperCase(Locale.ROOT));
+    target.setDescription(source.getDescription());
+    target.setPositionX(source.getPositionX());
+    target.setPositionY(source.getPositionY());
     target.setConfig(source.getConfig());
     target.setRetryTimes(source.getRetryTimes());
     target.setRetryIntervalSeconds(source.getRetryIntervalSeconds());
@@ -112,7 +132,7 @@ public class WorkflowDagCompiler {
       throw new IllegalArgumentException("重试和超时时间不能为负数：" + node.getKey());
     }
     if (node.isEnabled()) {
-      executorRegistry.validate(node.getType(), node.getConfig());
+      node.setConfig(executorRegistry.normalizeConfiguration(node.getType(), node.getConfig()));
     }
   }
 

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/impl/WorkflowDefinitionServiceImpl.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/impl/WorkflowDefinitionServiceImpl.java
@@ -10,6 +10,7 @@ import io.yak.ops.business.workflow.util.WorkflowConvertUtils;
 import io.yak.ops.business.workflow.util.WorkflowJsonCodec;
 import io.yak.ops.common.bean.dto.workflow.WorkflowDTO;
 import io.yak.ops.common.bean.dto.workflow.WorkflowUpdateDTO;
+import io.yak.ops.common.bean.entity.workflow.WorkflowDag;
 import io.yak.ops.common.bean.entity.workflow.WorkflowDefinition;
 import io.yak.ops.common.bean.entity.workflow.WorkflowVersion;
 import io.yak.ops.common.bean.po.workflow.WorkflowDefinitionPO;
@@ -42,7 +43,7 @@ public class WorkflowDefinitionServiceImpl implements WorkflowDefinitionService 
   @Transactional(transactionManager = "workflowTransactionManager")
   public Long addWorkflow(WorkflowDTO workflowDTO, String operator) {
     validate(workflowDTO);
-    dagCompiler.compile(workflowDTO.getDag());
+    WorkflowDag normalizedDag = dagCompiler.normalizeAndValidate(workflowDTO.getDag());
     String code = workflowDTO.getCode().trim();
     if (definitionDao.existsDefinitionByCode(code)) {
       throw new IllegalArgumentException("工作流编码已存在：" + code);
@@ -56,7 +57,7 @@ public class WorkflowDefinitionServiceImpl implements WorkflowDefinitionService 
     definitionPO.setState(DefinitionState.DRAFT.name());
     definitionPO.setFailureStrategy(strategy(workflowDTO.getFailureStrategy()).name());
     definitionPO.setMaxParallelism(workflowDTO.getMaxParallelism());
-    definitionPO.setDraftJson(jsonCodec.write(workflowDTO.getDag()));
+    definitionPO.setDraftJson(jsonCodec.write(normalizedDag));
     definitionPO.setCreatedBy(operator);
     definitionPO.setCreatedAt(now);
     definitionPO.setUpdatedAt(now);
@@ -68,7 +69,7 @@ public class WorkflowDefinitionServiceImpl implements WorkflowDefinitionService 
   @Transactional(transactionManager = "workflowTransactionManager")
   public void editWorkflow(Long workflowId, WorkflowUpdateDTO workflowDTO) {
     validate(workflowDTO);
-    dagCompiler.compile(workflowDTO.getDag());
+    WorkflowDag normalizedDag = dagCompiler.normalizeAndValidate(workflowDTO.getDag());
     requireWorkflow(workflowId);
     WorkflowDefinitionPO definitionPO = new WorkflowDefinitionPO();
     definitionPO.setId(workflowId);
@@ -76,7 +77,7 @@ public class WorkflowDefinitionServiceImpl implements WorkflowDefinitionService 
     definitionPO.setDescription(workflowDTO.getDescription());
     definitionPO.setFailureStrategy(strategy(workflowDTO.getFailureStrategy()).name());
     definitionPO.setMaxParallelism(workflowDTO.getMaxParallelism());
-    definitionPO.setDraftJson(jsonCodec.write(workflowDTO.getDag()));
+    definitionPO.setDraftJson(jsonCodec.write(normalizedDag));
     definitionPO.setUpdatedAt(new Date());
     if (definitionDao.editDefinition(definitionPO) != 1) {
       throw new IllegalArgumentException("工作流定义不存在：" + workflowId);

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/impl/WorkflowDefinitionServiceImpl.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/impl/WorkflowDefinitionServiceImpl.java
@@ -42,6 +42,7 @@ public class WorkflowDefinitionServiceImpl implements WorkflowDefinitionService 
   @Transactional(transactionManager = "workflowTransactionManager")
   public Long addWorkflow(WorkflowDTO workflowDTO, String operator) {
     validate(workflowDTO);
+    dagCompiler.compile(workflowDTO.getDag());
     String code = workflowDTO.getCode().trim();
     if (definitionDao.existsDefinitionByCode(code)) {
       throw new IllegalArgumentException("工作流编码已存在：" + code);
@@ -67,6 +68,7 @@ public class WorkflowDefinitionServiceImpl implements WorkflowDefinitionService 
   @Transactional(transactionManager = "workflowTransactionManager")
   public void editWorkflow(Long workflowId, WorkflowUpdateDTO workflowDTO) {
     validate(workflowDTO);
+    dagCompiler.compile(workflowDTO.getDag());
     requireWorkflow(workflowId);
     WorkflowDefinitionPO definitionPO = new WorkflowDefinitionPO();
     definitionPO.setId(workflowId);

--- a/yak-ops-core/src/main/java/io/yak/ops/core/workflow/WorkflowTaskExecutorRegistry.java
+++ b/yak-ops-core/src/main/java/io/yak/ops/core/workflow/WorkflowTaskExecutorRegistry.java
@@ -64,7 +64,14 @@ public final class WorkflowTaskExecutorRegistry {
   }
 
   public void validate(String taskType, Map<String, Object> configuration) {
-    requireFactory(taskType).validate(configuration);
+    normalizeConfiguration(taskType, configuration);
+  }
+
+  /** Binds and normalizes one plugin's JSON task parameters. */
+  public Map<String, Object> normalizeConfiguration(
+      String taskType,
+      Map<String, Object> configuration) {
+    return requireFactory(taskType).normalize(configuration);
   }
 
   public WorkflowTaskPluginDescriptor descriptor(String taskType) {

--- a/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-api/src/main/java/io/yak/ops/plugin/task/api/AbstractTaskParameters.java
+++ b/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-api/src/main/java/io/yak/ops/plugin/task/api/AbstractTaskParameters.java
@@ -1,0 +1,65 @@
+package io.yak.ops.plugin.task.api;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Base parameter object shared by task plugins.
+ *
+ * <p>It follows the same separation as DolphinScheduler's AbstractParameters: common local
+ * parameters live here, while each task plugin owns its typed fields and validation rules.
+ */
+public abstract class AbstractTaskParameters {
+
+  private final List<TaskLocalParameter> localParams;
+
+  protected AbstractTaskParameters(Map<String, Object> configuration) {
+    this.localParams = readLocalParams(configuration);
+  }
+
+  public List<TaskLocalParameter> getLocalParams() {
+    return Collections.unmodifiableList(localParams);
+  }
+
+  protected void validateCommonParameters() {
+    localParams.forEach(TaskLocalParameter::validate);
+  }
+
+  protected Map<String, Object> newConfiguration() {
+    Map<String, Object> configuration = new LinkedHashMap<>();
+    if (!localParams.isEmpty()) {
+      configuration.put(
+          "localParams",
+          localParams.stream().map(TaskLocalParameter::toMap).toList());
+    }
+    return configuration;
+  }
+
+  public abstract void validate();
+
+  public abstract Map<String, Object> toConfiguration();
+
+  private static List<TaskLocalParameter> readLocalParams(
+      Map<String, Object> configuration) {
+    Object value = configuration == null ? null : configuration.get("localParams");
+    if (value == null) {
+      return new ArrayList<>();
+    }
+    if (!(value instanceof Collection<?> values)) {
+      throw new IllegalArgumentException("任务配置必须为数组：localParams");
+    }
+
+    List<TaskLocalParameter> result = new ArrayList<>(values.size());
+    for (Object item : values) {
+      if (!(item instanceof Map<?, ?> map)) {
+        throw new IllegalArgumentException("任务局部参数必须为对象");
+      }
+      result.add(TaskLocalParameter.fromMap(map));
+    }
+    return result;
+  }
+}

--- a/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-api/src/main/java/io/yak/ops/plugin/task/api/TaskConfiguration.java
+++ b/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-api/src/main/java/io/yak/ops/plugin/task/api/TaskConfiguration.java
@@ -1,6 +1,13 @@
 package io.yak.ops.plugin.task.api;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /** 任务插件配置读取工具，统一处理必填、类型转换和边界校验。 */
 public final class TaskConfiguration {
@@ -42,34 +49,32 @@ public final class TaskConfiguration {
   }
 
   public static Map<String, String> stringMap(
-          Map<String, Object> configuration,
-          String key) {
+      Map<String, Object> configuration,
+      String key) {
     Object value = value(configuration, key);
     if (value == null) {
       return Collections.emptyMap();
     }
-    if (!(value instanceof Map<?, ?>)) {
+    if (!(value instanceof Map<?, ?> source)) {
       throw new IllegalArgumentException("任务配置必须为对象：" + key);
     }
-    Map<?, ?> source = (Map<?, ?>) value;
     Map<String, String> result = new LinkedHashMap<>();
     source.forEach((entryKey, entryValue) -> result.put(
-            String.valueOf(entryKey),
-            entryValue == null ? "" : String.valueOf(entryValue)));
+        String.valueOf(entryKey),
+        entryValue == null ? "" : String.valueOf(entryValue)));
     return result;
   }
 
   public static List<String> stringList(
-          Map<String, Object> configuration,
-          String key) {
+      Map<String, Object> configuration,
+      String key) {
     Object value = value(configuration, key);
     if (value == null) {
       return Collections.emptyList();
     }
-    if (!(value instanceof Collection<?>)) {
+    if (!(value instanceof Collection<?> source)) {
       throw new IllegalArgumentException("任务配置必须为数组：" + key);
     }
-    Collection<?> source = (Collection<?>) value;
     List<String> result = new ArrayList<>(source.size());
     for (Object item : source) {
       result.add(String.valueOf(item));
@@ -77,22 +82,17 @@ public final class TaskConfiguration {
     return result;
   }
 
-  public static Set<Integer> integerSet(
-          Map<String, Object> configuration,
-          String key,
-          Set<Integer> fallback) {
+  public static List<Integer> integerList(
+      Map<String, Object> configuration,
+      String key) {
     Object value = value(configuration, key);
     if (value == null) {
-      return fallback;
+      return Collections.emptyList();
     }
-    if (!(value instanceof Collection<?>)) {
-      throw new IllegalArgumentException("任务配置必须为非空整数数组：" + key);
+    if (!(value instanceof Collection<?> source)) {
+      throw new IllegalArgumentException("任务配置必须为整数数组：" + key);
     }
-    Collection<?> source = (Collection<?>) value;
-    if (source.isEmpty()) {
-      throw new IllegalArgumentException("任务配置必须为非空整数数组：" + key);
-    }
-    Set<Integer> result = new LinkedHashSet<>();
+    List<Integer> result = new ArrayList<>(source.size());
     try {
       for (Object item : source) {
         result.add(Integer.parseInt(String.valueOf(item)));
@@ -101,6 +101,14 @@ public final class TaskConfiguration {
       throw new IllegalArgumentException("任务配置必须为整数数组：" + key, error);
     }
     return result;
+  }
+
+  public static Set<Integer> integerSet(
+      Map<String, Object> configuration,
+      String key,
+      Set<Integer> fallback) {
+    List<Integer> values = integerList(configuration, key);
+    return values.isEmpty() ? fallback : new LinkedHashSet<>(values);
   }
 
   public static boolean hasText(String value) {

--- a/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-api/src/main/java/io/yak/ops/plugin/task/api/TaskLocalParameter.java
+++ b/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-api/src/main/java/io/yak/ops/plugin/task/api/TaskLocalParameter.java
@@ -1,0 +1,66 @@
+package io.yak.ops.plugin.task.api;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/** Common local input/output parameter shared by all task parameter objects. */
+public final class TaskLocalParameter {
+
+  private final String prop;
+  private final String direct;
+  private final String type;
+  private final String value;
+
+  public TaskLocalParameter(String prop, String direct, String type, String value) {
+    this.prop = prop == null ? "" : prop.trim();
+    this.direct = direct == null ? "IN" : direct.trim().toUpperCase();
+    this.type = type == null ? "VARCHAR" : type.trim().toUpperCase();
+    this.value = value == null ? "" : value;
+  }
+
+  public static TaskLocalParameter fromMap(Map<?, ?> source) {
+    return new TaskLocalParameter(
+        text(source.get("prop")),
+        text(source.get("direct")),
+        text(source.get("type")),
+        text(source.get("value")));
+  }
+
+  public void validate() {
+    if (!TaskConfiguration.hasText(prop)) {
+      throw new IllegalArgumentException("任务局部参数名称不能为空");
+    }
+    if (!"IN".equals(direct) && !"OUT".equals(direct)) {
+      throw new IllegalArgumentException("任务局部参数方向只能为 IN 或 OUT：" + prop);
+    }
+  }
+
+  public Map<String, Object> toMap() {
+    Map<String, Object> result = new LinkedHashMap<>();
+    result.put("prop", prop);
+    result.put("direct", direct);
+    result.put("type", type);
+    result.put("value", value);
+    return result;
+  }
+
+  public String getProp() {
+    return prop;
+  }
+
+  public String getDirect() {
+    return direct;
+  }
+
+  public String getType() {
+    return type;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+  private static String text(Object value) {
+    return value == null ? null : String.valueOf(value);
+  }
+}

--- a/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-http/src/main/java/io/yak/ops/plugin/task/http/HttpTaskParameters.java
+++ b/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-http/src/main/java/io/yak/ops/plugin/task/http/HttpTaskParameters.java
@@ -1,0 +1,108 @@
+package io.yak.ops.plugin.task.http;
+
+import io.yak.ops.plugin.task.api.AbstractTaskParameters;
+import io.yak.ops.plugin.task.api.TaskConfiguration;
+import java.net.URI;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+/** Typed parameters persisted for an HTTP workflow task. */
+public final class HttpTaskParameters extends AbstractTaskParameters {
+
+  public static final int DEFAULT_REQUEST_TIMEOUT_SECONDS = 60;
+  public static final int DEFAULT_MAX_RESPONSE_BODY_CHARACTERS = 1_000_000;
+  private static final Set<String> METHODS = Set.of(
+      "GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS");
+
+  private final String url;
+  private final String method;
+  private final Map<String, String> headers;
+  private final String body;
+  private final int requestTimeoutSeconds;
+  private final List<Integer> successCodes;
+  private final int maxResponseBodyCharacters;
+
+  private HttpTaskParameters(Map<String, Object> configuration) {
+    super(configuration);
+    this.url = TaskConfiguration.string(configuration, "url", "");
+    this.method = TaskConfiguration.string(configuration, "method", "GET")
+        .trim()
+        .toUpperCase(Locale.ROOT);
+    this.headers = new LinkedHashMap<>(TaskConfiguration.stringMap(configuration, "headers"));
+    this.body = TaskConfiguration.string(configuration, "body", "");
+    this.requestTimeoutSeconds = TaskConfiguration.positiveInteger(
+        configuration,
+        "requestTimeoutSeconds",
+        DEFAULT_REQUEST_TIMEOUT_SECONDS);
+    this.successCodes = List.copyOf(TaskConfiguration.integerList(configuration, "successCodes"));
+    this.maxResponseBodyCharacters = TaskConfiguration.positiveInteger(
+        configuration,
+        "maxResponseBodyCharacters",
+        DEFAULT_MAX_RESPONSE_BODY_CHARACTERS);
+  }
+
+  public static HttpTaskParameters from(Map<String, Object> configuration) {
+    return new HttpTaskParameters(configuration);
+  }
+
+  @Override
+  public void validate() {
+    validateCommonParameters();
+    if (!TaskConfiguration.hasText(url)) {
+      throw new IllegalArgumentException("HTTP 任务请求地址不能为空");
+    }
+    URI.create(url.replaceAll("\\$\\{[^}]+}", "placeholder"));
+    if (!METHODS.contains(method)) {
+      throw new IllegalArgumentException("不支持的 HTTP 请求方法：" + method);
+    }
+    for (Integer successCode : successCodes) {
+      if (successCode == null || successCode < 100 || successCode > 599) {
+        throw new IllegalArgumentException("HTTP 成功状态码必须在 100 到 599 之间");
+      }
+    }
+  }
+
+  @Override
+  public Map<String, Object> toConfiguration() {
+    Map<String, Object> configuration = newConfiguration();
+    configuration.put("url", url.trim());
+    configuration.put("method", method);
+    configuration.put("headers", new LinkedHashMap<>(headers));
+    configuration.put("body", body);
+    configuration.put("requestTimeoutSeconds", requestTimeoutSeconds);
+    configuration.put("successCodes", successCodes);
+    configuration.put("maxResponseBodyCharacters", maxResponseBodyCharacters);
+    return configuration;
+  }
+
+  public String getUrl() {
+    return url;
+  }
+
+  public String getMethod() {
+    return method;
+  }
+
+  public Map<String, String> getHeaders() {
+    return Map.copyOf(headers);
+  }
+
+  public String getBody() {
+    return body;
+  }
+
+  public int getRequestTimeoutSeconds() {
+    return requestTimeoutSeconds;
+  }
+
+  public List<Integer> getSuccessCodes() {
+    return successCodes;
+  }
+
+  public int getMaxResponseBodyCharacters() {
+    return maxResponseBodyCharacters;
+  }
+}

--- a/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-http/src/main/java/io/yak/ops/plugin/task/http/HttpWorkflowTaskExecutor.java
+++ b/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-http/src/main/java/io/yak/ops/plugin/task/http/HttpWorkflowTaskExecutor.java
@@ -25,8 +25,6 @@ import java.util.stream.IntStream;
 /** 使用 JDK HttpClient 执行 HTTP 工作流任务。 */
 public final class HttpWorkflowTaskExecutor implements WorkflowTaskExecutor {
 
-  private static final Set<String> METHODS = Set.of(
-      "GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS");
   private static final Set<Integer> DEFAULT_SUCCESS_CODES = IntStream
       .rangeClosed(200, 299)
       .boxed()
@@ -56,29 +54,8 @@ public final class HttpWorkflowTaskExecutor implements WorkflowTaskExecutor {
 
   @Override
   public void validate(Map<String, Object> configuration) {
-    String url = TaskConfiguration.requiredString(configuration, "url");
-    URI.create(url.replaceAll("\\$\\{[^}]+}", "placeholder"));
-
-    String method = TaskConfiguration.string(configuration, "method", "GET")
-        .trim()
-        .toUpperCase(Locale.ROOT);
-    if (!METHODS.contains(method)) {
-      throw new IllegalArgumentException("不支持的 HTTP 请求方法：" + method);
-    }
-
-    TaskConfiguration.stringMap(configuration, "headers");
-    TaskConfiguration.positiveInteger(
-        configuration,
-        "requestTimeoutSeconds",
-        DEFAULT_REQUEST_TIMEOUT_SECONDS);
-    TaskConfiguration.positiveInteger(
-        configuration,
-        "maxResponseBodyCharacters",
-        DEFAULT_MAX_RESPONSE_BODY_CHARACTERS);
-    TaskConfiguration.integerSet(
-        configuration,
-        "successCodes",
-        DEFAULT_SUCCESS_CODES);
+    HttpTaskParameters parameters = HttpTaskParameters.from(configuration);
+    parameters.validate();
   }
 
   @Override

--- a/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-http/src/main/java/io/yak/ops/plugin/task/http/HttpWorkflowTaskPluginFactory.java
+++ b/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-http/src/main/java/io/yak/ops/plugin/task/http/HttpWorkflowTaskPluginFactory.java
@@ -28,12 +28,26 @@ public final class HttpWorkflowTaskPluginFactory implements WorkflowTaskPluginFa
   }
 
   @Override
+  public void validate(Map<String, Object> configuration) {
+    HttpTaskParameters parameters = HttpTaskParameters.from(configuration);
+    parameters.validate();
+  }
+
+  @Override
+  public Map<String, Object> normalize(Map<String, Object> configuration) {
+    HttpTaskParameters parameters = HttpTaskParameters.from(configuration);
+    parameters.validate();
+    return parameters.toConfiguration();
+  }
+
+  @Override
   public WorkflowTaskExecutor create() {
     return new HttpWorkflowTaskExecutor();
   }
 
   private static Map<String, Object> configurationSchema() {
     Map<String, Object> fields = new LinkedHashMap<>();
+    fields.put("localParams", field("parameter-list", false, "节点局部输入输出参数。", List.of()));
     fields.put("url", field("string", true, "请求地址，支持 ${parameter} 参数。", null));
     fields.put("method", field(
         "string",

--- a/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-http/src/test/java/io/yak/ops/plugin/task/http/HttpWorkflowTaskExecutorTest.java
+++ b/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-http/src/test/java/io/yak/ops/plugin/task/http/HttpWorkflowTaskExecutorTest.java
@@ -1,6 +1,7 @@
 package io.yak.ops.plugin.task.http;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.sun.net.httpserver.HttpServer;
 import io.yak.ops.spi.workflow.WorkflowTaskContext;
@@ -23,6 +24,37 @@ class HttpWorkflowTaskExecutorTest {
     if (server != null) {
       server.stop(0);
     }
+  }
+
+  @Test
+  void shouldNormalizeTypedTaskParameters() {
+    Map<String, Object> normalized = new HttpWorkflowTaskPluginFactory().normalize(Map.of(
+        "url", "https://example.com/orders/${orderId}",
+        "method", "post",
+        "successCodes", List.of(),
+        "localParams", List.of(Map.of(
+            "prop", "orderId",
+            "direct", "IN",
+            "type", "VARCHAR",
+            "value", ""))));
+
+    assertThat(normalized)
+        .containsEntry("method", "POST")
+        .containsEntry("requestTimeoutSeconds", 60)
+        .containsEntry("maxResponseBodyCharacters", 1_000_000);
+    assertThat(normalized.get("successCodes")).isEqualTo(List.of());
+    assertThat(normalized.get("localParams")).isEqualTo(List.of(Map.of(
+        "prop", "orderId",
+        "direct", "IN",
+        "type", "VARCHAR",
+        "value", "")));
+  }
+
+  @Test
+  void shouldRejectMissingUrlWhenNormalizingParameters() {
+    assertThatThrownBy(() -> new HttpWorkflowTaskPluginFactory().normalize(Map.of()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("请求地址不能为空");
   }
 
   @Test

--- a/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-shell/src/main/java/io/yak/ops/plugin/task/shell/ShellTaskParameters.java
+++ b/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-shell/src/main/java/io/yak/ops/plugin/task/shell/ShellTaskParameters.java
@@ -1,0 +1,67 @@
+package io.yak.ops.plugin.task.shell;
+
+import io.yak.ops.plugin.task.api.AbstractTaskParameters;
+import io.yak.ops.plugin.task.api.TaskConfiguration;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/** Typed parameters persisted for a Shell workflow task. */
+public final class ShellTaskParameters extends AbstractTaskParameters {
+
+  private final String command;
+  private final List<String> args;
+  private final String workDirectory;
+  private final Map<String, String> environment;
+
+  private ShellTaskParameters(Map<String, Object> configuration) {
+    super(configuration);
+    this.command = TaskConfiguration.string(configuration, "command", "");
+    this.args = List.copyOf(TaskConfiguration.stringList(configuration, "args"));
+    this.workDirectory = TaskConfiguration.string(configuration, "workDirectory", "");
+    this.environment = new LinkedHashMap<>(
+        TaskConfiguration.stringMap(configuration, "environment"));
+  }
+
+  public static ShellTaskParameters from(Map<String, Object> configuration) {
+    return new ShellTaskParameters(configuration);
+  }
+
+  @Override
+  public void validate() {
+    validateCommonParameters();
+    if (!TaskConfiguration.hasText(command) && args.isEmpty()) {
+      throw new IllegalArgumentException("SHELL 任务必须配置 command 或非空 args");
+    }
+    if (args.stream().anyMatch(value -> !TaskConfiguration.hasText(value))) {
+      throw new IllegalArgumentException("SHELL 任务 args 不能包含空参数");
+    }
+  }
+
+  @Override
+  public Map<String, Object> toConfiguration() {
+    Map<String, Object> configuration = newConfiguration();
+    configuration.put("command", command);
+    configuration.put("args", new ArrayList<>(args));
+    configuration.put("workDirectory", workDirectory);
+    configuration.put("environment", new LinkedHashMap<>(environment));
+    return configuration;
+  }
+
+  public String getCommand() {
+    return command;
+  }
+
+  public List<String> getArgs() {
+    return args;
+  }
+
+  public String getWorkDirectory() {
+    return workDirectory;
+  }
+
+  public Map<String, String> getEnvironment() {
+    return Map.copyOf(environment);
+  }
+}

--- a/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-shell/src/main/java/io/yak/ops/plugin/task/shell/ShellWorkflowTaskExecutor.java
+++ b/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-shell/src/main/java/io/yak/ops/plugin/task/shell/ShellWorkflowTaskExecutor.java
@@ -29,15 +29,8 @@ public final class ShellWorkflowTaskExecutor implements WorkflowTaskExecutor {
 
   @Override
   public void validate(Map<String, Object> configuration) {
-    String command = TaskConfiguration.string(configuration, "command", null);
-    List<String> args = TaskConfiguration.stringList(configuration, "args");
-    if (!TaskConfiguration.hasText(command) && args.isEmpty()) {
-      throw new IllegalArgumentException("SHELL 任务必须配置 command 或非空 args");
-    }
-    if (!args.isEmpty() && args.stream().anyMatch(value -> !TaskConfiguration.hasText(value))) {
-      throw new IllegalArgumentException("SHELL 任务 args 不能包含空参数");
-    }
-    TaskConfiguration.stringMap(configuration, "environment");
+    ShellTaskParameters parameters = ShellTaskParameters.from(configuration);
+    parameters.validate();
   }
 
   @Override

--- a/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-shell/src/main/java/io/yak/ops/plugin/task/shell/ShellWorkflowTaskPluginFactory.java
+++ b/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-shell/src/main/java/io/yak/ops/plugin/task/shell/ShellWorkflowTaskPluginFactory.java
@@ -5,6 +5,7 @@ import io.yak.ops.spi.workflow.WorkflowTaskExecutor;
 import io.yak.ops.spi.workflow.WorkflowTaskPluginDescriptor;
 import io.yak.ops.spi.workflow.WorkflowTaskPluginFactory;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 /** Factory and discoverable metadata for the Shell workflow task plugin. */
@@ -27,14 +28,28 @@ public final class ShellWorkflowTaskPluginFactory implements WorkflowTaskPluginF
   }
 
   @Override
+  public void validate(Map<String, Object> configuration) {
+    ShellTaskParameters parameters = ShellTaskParameters.from(configuration);
+    parameters.validate();
+  }
+
+  @Override
+  public Map<String, Object> normalize(Map<String, Object> configuration) {
+    ShellTaskParameters parameters = ShellTaskParameters.from(configuration);
+    parameters.validate();
+    return parameters.toConfiguration();
+  }
+
+  @Override
   public WorkflowTaskExecutor create() {
     return new ShellWorkflowTaskExecutor();
   }
 
   private static Map<String, Object> configurationSchema() {
     Map<String, Object> fields = new LinkedHashMap<>();
+    fields.put("localParams", field("parameter-list", false, "节点局部输入输出参数。", List.of()));
     fields.put("command", field("string", false, "Shell 命令，支持 ${parameter} 参数。", ""));
-    fields.put("args", field("string-list", false, "完整进程参数数组，配置后优先于 command。", java.util.List.of()));
+    fields.put("args", field("string-list", false, "完整进程参数数组，配置后优先于 command。", List.of()));
     fields.put("workDirectory", field("string", false, "进程工作目录。", ""));
     fields.put("environment", field("map", false, "进程环境变量。", Map.of()));
     return Map.of("fields", fields);

--- a/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-shell/src/test/java/io/yak/ops/plugin/task/shell/ShellWorkflowTaskExecutorTest.java
+++ b/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-shell/src/test/java/io/yak/ops/plugin/task/shell/ShellWorkflowTaskExecutorTest.java
@@ -1,6 +1,7 @@
 package io.yak.ops.plugin.task.shell;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.yak.ops.spi.workflow.WorkflowTaskContext;
 import io.yak.ops.spi.workflow.WorkflowTaskResult;
@@ -10,6 +11,31 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import org.junit.jupiter.api.Test;
 
 class ShellWorkflowTaskExecutorTest {
+
+  @Test
+  void shouldNormalizeTypedTaskParameters() {
+    Map<String, Object> normalized = new ShellWorkflowTaskPluginFactory().normalize(Map.of(
+        "args", List.of("/bin/sh", "-c", "echo ${message}"),
+        "environment", Map.of("LANG", "C.UTF-8"),
+        "localParams", List.of(Map.of(
+            "prop", "message",
+            "direct", "IN",
+            "type", "VARCHAR",
+            "value", ""))));
+
+    assertThat(normalized.get("args"))
+        .isEqualTo(List.of("/bin/sh", "-c", "echo ${message}"));
+    assertThat(normalized.get("environment"))
+        .isEqualTo(Map.of("LANG", "C.UTF-8"));
+    assertThat(normalized).containsEntry("command", "");
+  }
+
+  @Test
+  void shouldRejectEmptyCommandAndArgs() {
+    assertThatThrownBy(() -> new ShellWorkflowTaskPluginFactory().normalize(Map.of()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("command 或非空 args");
+  }
 
   @Test
   void shouldResolveParametersAndStreamProcessOutput() throws Exception {

--- a/yak-ops-spi/src/main/java/io/yak/ops/spi/workflow/WorkflowTaskPluginFactory.java
+++ b/yak-ops-spi/src/main/java/io/yak/ops/spi/workflow/WorkflowTaskPluginFactory.java
@@ -1,5 +1,6 @@
 package io.yak.ops.spi.workflow;
 
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -15,9 +16,22 @@ public interface WorkflowTaskPluginFactory {
     return descriptor().getType();
   }
 
-  /** Validates configuration while compiling or publishing a workflow definition. */
+  /** Validates configuration while compiling or saving a workflow definition. */
   default void validate(Map<String, Object> configuration) {
     create().validate(configuration);
+  }
+
+  /**
+   * Converts the JSON task parameters into the canonical plugin representation.
+   *
+   * <p>Concrete plugins may bind the map to a typed parameter object before returning a normalized
+   * map. The default implementation keeps legacy plugins source-compatible.
+   */
+  default Map<String, Object> normalize(Map<String, Object> configuration) {
+    validate(configuration);
+    return configuration == null
+        ? new LinkedHashMap<>()
+        : new LinkedHashMap<>(configuration);
   }
 
   /** Creates a new executor for one physical task attempt. */

--- a/yak-ops-ui/src/pages/workflow-management/designer/components/WorkflowHeader.ts
+++ b/yak-ops-ui/src/pages/workflow-management/designer/components/WorkflowHeader.ts
@@ -1,1 +1,1 @@
-export { default } from './header';
+export { default } from './WorkflowHeaderWithValidation';

--- a/yak-ops-ui/src/pages/workflow-management/designer/components/WorkflowHeaderWithValidation.tsx
+++ b/yak-ops-ui/src/pages/workflow-management/designer/components/WorkflowHeaderWithValidation.tsx
@@ -1,0 +1,145 @@
+import { message } from 'antd';
+import { AlertCircle, CheckCircle2, ChevronRight, ListChecks, X } from 'lucide-react';
+import { useMemo, useState, type ComponentProps } from 'react';
+import { useEdges, useNodes, useReactFlow } from 'reactflow';
+
+import type { WorkflowNodeData } from '../../types';
+import { validateWorkflow } from '../validation';
+import WorkflowHeader from './header';
+
+type WorkflowHeaderWithValidationProps = ComponentProps<typeof WorkflowHeader>;
+
+const WorkflowHeaderWithValidation = (
+  props: WorkflowHeaderWithValidationProps,
+) => {
+  const nodes = useNodes<WorkflowNodeData>();
+  const edges = useEdges();
+  const reactFlow = useReactFlow<WorkflowNodeData>();
+  const [open, setOpen] = useState(false);
+
+  const issues = useMemo(
+    () => validateWorkflow(nodes, edges),
+    [edges, nodes],
+  );
+  const errorCount = issues.filter((issue) => issue.severity === 'error').length;
+
+  const handleSave = () => {
+    if (errorCount > 0) {
+      setOpen(true);
+      message.warning(`还有 ${errorCount} 个必填项需要完善`);
+      return;
+    }
+    props.onSave();
+  };
+
+  const focusNode = (nodeId?: string) => {
+    if (!nodeId) return;
+    const node = reactFlow.getNode(nodeId);
+    if (!node) return;
+
+    reactFlow.setNodes((current) =>
+      current.map((item) => ({
+        ...item,
+        selected: item.id === nodeId,
+      })),
+    );
+    void reactFlow.setCenter(
+      node.position.x + (node.width || 224) / 2,
+      node.position.y + (node.height || 120) / 2,
+      { zoom: Math.max(reactFlow.getZoom(), 0.85), duration: 220 },
+    );
+  };
+
+  return (
+    <>
+      <WorkflowHeader {...props} onSave={handleSave} />
+
+      <div className="absolute right-3 top-[56px] z-50 flex flex-col items-end gap-2">
+        <button
+          type="button"
+          className={[
+            'inline-flex h-9 items-center gap-2 rounded-[10px] border px-3',
+            'bg-white text-[12px] font-semibold shadow-[0_4px_14px_rgba(16,24,40,0.10)]',
+            issues.length
+              ? 'border-[#fedf89] text-[#b54708] hover:bg-[#fffaeb]'
+              : 'border-[#abefc6] text-[#067647] hover:bg-[#ecfdf3]',
+          ].join(' ')}
+          onClick={() => setOpen((value) => !value)}
+        >
+          {issues.length ? <ListChecks size={15} /> : <CheckCircle2 size={15} />}
+          检查清单
+          <span className="min-w-5 rounded-full bg-[#f2f4f7] px-1.5 py-0.5 text-center text-[10px] text-[#475467]">
+            {issues.length}
+          </span>
+        </button>
+
+        {open && (
+          <aside className="flex max-h-[calc(100vh-112px)] w-[390px] flex-col overflow-hidden rounded-xl border border-[#e4e7ec] bg-white shadow-[0_18px_48px_rgba(16,24,40,0.16)]">
+            <header className="flex shrink-0 items-start justify-between px-4 pb-3 pt-4">
+              <div>
+                <h3 className="m-0 text-[16px] font-semibold text-[#101828]">
+                  检查清单({issues.length})
+                </h3>
+                <p className="mb-0 mt-1 text-[12px] text-[#98a2b3]">
+                  保存前请先完善节点必填配置
+                </p>
+              </div>
+              <button
+                type="button"
+                aria-label="关闭检查清单"
+                className="flex h-7 w-7 items-center justify-center rounded-md border-0 bg-transparent text-[#667085] hover:bg-[#f2f4f7]"
+                onClick={() => setOpen(false)}
+              >
+                <X size={16} />
+              </button>
+            </header>
+
+            <div className="min-h-0 flex-1 overflow-y-auto px-3 pb-3">
+              {!issues.length && (
+                <div className="flex items-center gap-2 rounded-lg bg-[#ecfdf3] px-3 py-3 text-[12px] text-[#067647]">
+                  <CheckCircle2 size={16} />
+                  所有必填项均已完成，可以保存工作流。
+                </div>
+              )}
+
+              {issues.map((issue) => (
+                <button
+                  key={issue.id}
+                  type="button"
+                  className="group mb-2 block w-full rounded-lg border-0 bg-[#fcfcfd] px-3 py-2.5 text-left hover:bg-[#f8f9fc]"
+                  onClick={() => focusNode(issue.nodeId)}
+                >
+                  <div className="flex items-center gap-2">
+                    <AlertCircle
+                      size={15}
+                      className={
+                        issue.severity === 'error'
+                          ? 'text-[#f79009]'
+                          : 'text-[#667085]'
+                      }
+                    />
+                    <strong className="min-w-0 flex-1 truncate text-[13px] font-medium text-[#344054]">
+                      {issue.nodeTitle}
+                    </strong>
+                    {issue.nodeId && (
+                      <ChevronRight
+                        size={14}
+                        className="text-[#98a2b3] group-hover:text-[#475467]"
+                      />
+                    )}
+                  </div>
+                  <div className="mt-1.5 flex items-center gap-2 pl-[23px] text-[12px] text-[#f04438]">
+                    <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-[#f79009]" />
+                    {issue.message}
+                  </div>
+                </button>
+              ))}
+            </div>
+          </aside>
+        )}
+      </div>
+    </>
+  );
+};
+
+export default WorkflowHeaderWithValidation;

--- a/yak-ops-ui/src/pages/workflow-management/designer/components/panel/node/http/index.tsx
+++ b/yak-ops-ui/src/pages/workflow-management/designer/components/panel/node/http/index.tsx
@@ -12,27 +12,35 @@ interface HttpPanelProps {
   onConfigChange: (key: string, value: unknown) => void;
 }
 
+const normalizeSuccessCodes = (value: unknown): string[] =>
+  Array.isArray(value) ? value.map(String) : [];
+
 const HttpPanel = ({ data, onConfigChange }: HttpPanelProps) => (
   <>
     <PanelSection
       title="API"
-      description="配置请求方法和地址，变量可直接写入 URL、Header 或 Body。"
+      description="配置请求方法和地址，运行参数统一使用 ${parameter} 语法。"
     >
       <div className="grid grid-cols-[96px_minmax(0,1fr)] gap-2">
         <PanelField label="方法">
           <Select
             value={String(data.config.method || 'GET')}
-            options={['GET', 'POST', 'PUT', 'PATCH', 'DELETE'].map((value) => ({
-              label: value,
-              value,
-            }))}
+            options={[
+              'GET',
+              'POST',
+              'PUT',
+              'PATCH',
+              'DELETE',
+              'HEAD',
+              'OPTIONS',
+            ].map((value) => ({ label: value, value }))}
             onChange={(value) => onConfigChange('method', value)}
           />
         </PanelField>
         <PanelField label="请求地址" required>
           <Input
             value={String(data.config.url || '')}
-            placeholder="https://api.example.com/orders/{{start.input}}"
+            placeholder="https://api.example.com/orders/${orderId}"
             onChange={(event) => onConfigChange('url', event.target.value)}
           />
         </PanelField>
@@ -62,7 +70,7 @@ const HttpPanel = ({ data, onConfigChange }: HttpPanelProps) => (
                 rows={10}
                 className="font-mono text-[10px] leading-[17px]"
                 value={String(data.config.body || '')}
-                placeholder='{"id":"{{start.input}}"}'
+                placeholder={'{"id":"${orderId}"}'}
                 onChange={(event) =>
                   onConfigChange('body', event.target.value)
                 }
@@ -73,17 +81,53 @@ const HttpPanel = ({ data, onConfigChange }: HttpPanelProps) => (
       />
     </PanelSection>
 
-    <PanelSection title="超时设置">
-      <PanelField label="请求超时（秒）">
-        <InputNumber
-          min={1}
-          max={3600}
-          value={Number(data.config.requestTimeoutSeconds || 60)}
-          onChange={(value) =>
-            onConfigChange('requestTimeoutSeconds', value || 60)
+    <PanelSection
+      title="响应与超时"
+      description="不填写成功状态码时，默认将 200-299 判定为成功。"
+    >
+      <PanelField label="成功状态码">
+        <Select
+          mode="tags"
+          value={normalizeSuccessCodes(data.config.successCodes)}
+          placeholder="例如 200、201、204"
+          tokenSeparators={[',', '，', ' ']}
+          options={['200', '201', '202', '204'].map((value) => ({
+            label: value,
+            value,
+          }))}
+          onChange={(values) =>
+            onConfigChange(
+              'successCodes',
+              values
+                .map((value) => Number(value))
+                .filter((value) => Number.isInteger(value)),
+            )
           }
         />
       </PanelField>
+
+      <div className="grid grid-cols-2 gap-2.5">
+        <PanelField label="请求超时（秒）">
+          <InputNumber
+            min={1}
+            max={3600}
+            value={Number(data.config.requestTimeoutSeconds || 60)}
+            onChange={(value) =>
+              onConfigChange('requestTimeoutSeconds', value || 60)
+            }
+          />
+        </PanelField>
+        <PanelField label="响应体最大字符数">
+          <InputNumber
+            min={1}
+            max={10_000_000}
+            value={Number(data.config.maxResponseBodyCharacters || 1_000_000)}
+            onChange={(value) =>
+              onConfigChange('maxResponseBodyCharacters', value || 1_000_000)
+            }
+          />
+        </PanelField>
+      </div>
     </PanelSection>
 
     <PanelSection
@@ -95,6 +139,11 @@ const HttpPanel = ({ data, onConfigChange }: HttpPanelProps) => (
           { name: 'body', type: 'String', description: '响应正文' },
           { name: 'statusCode', type: 'Number', description: 'HTTP 状态码' },
           { name: 'headers', type: 'Object', description: '响应头' },
+          {
+            name: 'bodyTruncated',
+            type: 'Boolean',
+            description: '响应正文是否被截断',
+          },
         ]}
       />
     </PanelSection>

--- a/yak-ops-ui/src/pages/workflow-management/designer/components/panel/node/shell/index.tsx
+++ b/yak-ops-ui/src/pages/workflow-management/designer/components/panel/node/shell/index.tsx
@@ -1,4 +1,4 @@
-import { Input } from 'antd';
+import { Input, Select } from 'antd';
 import type { WorkflowNodeData } from '../../../../../types';
 import {
   KeyValueEditor,
@@ -12,21 +12,39 @@ interface ShellPanelProps {
   onConfigChange: (key: string, value: unknown) => void;
 }
 
+const normalizeArgs = (value: unknown): string[] =>
+  Array.isArray(value) ? value.map(String) : [];
+
 const ShellPanel = ({ data, onConfigChange }: ShellPanelProps) => (
   <>
     <PanelSection
       title="执行命令"
-      description="命令由工作流执行节点运行，请避免在脚本中直接写入敏感信息。"
+      description="command 与 args 至少填写一项；配置 args 后会优先按完整进程参数执行。"
     >
       <PanelField label="命令或脚本" required>
         <Input.TextArea
           rows={12}
           className="font-mono text-[10px] leading-[18px] !bg-[#101828] !text-[#e4e7ec]"
           value={String(data.config.command || '')}
-          placeholder={'#!/usr/bin/env bash\necho "hello yak ops"'}
+          placeholder={'#!/usr/bin/env bash\necho "${message}"'}
           onChange={(event) => onConfigChange('command', event.target.value)}
         />
       </PanelField>
+
+      <PanelField
+        label="进程参数"
+        hint="按 Enter 添加；配置后优先于命令或脚本"
+      >
+        <Select
+          mode="tags"
+          value={normalizeArgs(data.config.args)}
+          placeholder="例如 /bin/sh、-c、echo ${message}"
+          tokenSeparators={['\n']}
+          onChange={(value) => onConfigChange('args', value)}
+          options={[]}
+        />
+      </PanelField>
+
       <PanelField label="工作目录">
         <Input
           value={String(data.config.workDirectory || '')}
@@ -51,13 +69,12 @@ const ShellPanel = ({ data, onConfigChange }: ShellPanelProps) => (
 
     <PanelSection
       title="输出变量"
-      description="Shell 节点完成后可供下游节点引用。"
+      description="Shell 节点完成后可供下游节点引用。进程输出会写入任务日志。"
     >
       <OutputVariables
         items={[
+          { name: 'processId', type: 'Number', description: '操作系统进程 ID' },
           { name: 'exitCode', type: 'Number', description: '进程退出码' },
-          { name: 'stdout', type: 'String', description: '标准输出' },
-          { name: 'stderr', type: 'String', description: '错误输出' },
         ]}
       />
     </PanelSection>

--- a/yak-ops-ui/src/pages/workflow-management/designer/constants.ts
+++ b/yak-ops-ui/src/pages/workflow-management/designer/constants.ts
@@ -66,6 +66,9 @@ export const WORKFLOW_NODE_CATALOG: WorkflowNodeMeta[] = [
       headers: {},
       body: '',
       requestTimeoutSeconds: 60,
+      successCodes: [],
+      maxResponseBodyCharacters: 1_000_000,
+      localParams: [],
     },
   },
   {
@@ -77,8 +80,10 @@ export const WORKFLOW_NODE_CATALOG: WorkflowNodeMeta[] = [
     backendType: 'SHELL',
     defaults: {
       command: '',
+      args: [],
       workDirectory: '',
       environment: {},
+      localParams: [],
     },
   },
 ];

--- a/yak-ops-ui/src/pages/workflow-management/designer/validation.test.ts
+++ b/yak-ops-ui/src/pages/workflow-management/designer/validation.test.ts
@@ -1,0 +1,77 @@
+import type { WorkflowFlowEdge, WorkflowFlowNode } from '../types';
+import { validateWorkflow } from './validation';
+
+const node = (
+  id: string,
+  nodeType: string,
+  config: Record<string, unknown>,
+): WorkflowFlowNode =>
+  ({
+    id,
+    type: 'workflowNode',
+    position: { x: 0, y: 0 },
+    data: {
+      title: id,
+      nodeType,
+      taskType: nodeType === 'START' || nodeType === 'END' ? 'NOOP' : nodeType,
+      config,
+      retryTimes: 0,
+      retryIntervalSeconds: 0,
+      timeoutSeconds: 0,
+      enabled: true,
+      idempotent: false,
+      retryOnRestart: false,
+    },
+  }) as WorkflowFlowNode;
+
+describe('workflow validation', () => {
+  it('reports HTTP, Shell and End required fields in realtime', () => {
+    const nodes = [
+      node('开始', 'START', {
+        inputVariables: [{ name: 'input', type: 'string' }],
+      }),
+      node('HTTP 请求', 'HTTP', { method: 'GET', url: '' }),
+      node('Shell', 'SHELL', { command: '', args: [] }),
+      node('结束', 'END', { outputs: [{ name: 'result', value: '' }] }),
+    ];
+    const edges: WorkflowFlowEdge[] = [
+      { id: '1', source: '开始', target: 'HTTP 请求' },
+      { id: '2', source: 'HTTP 请求', target: 'Shell' },
+      { id: '3', source: 'Shell', target: '结束' },
+    ];
+
+    expect(validateWorkflow(nodes, edges).map((issue) => issue.message)).toEqual(
+      expect.arrayContaining([
+        'API 不能为空',
+        '命令或进程参数不能为空',
+        '输出变量值不能为空',
+      ]),
+    );
+  });
+
+  it('accepts aligned HTTP and Shell parameters', () => {
+    const nodes = [
+      node('开始', 'START', {
+        inputVariables: [{ name: 'input', type: 'string' }],
+      }),
+      node('HTTP 请求', 'HTTP', {
+        method: 'POST',
+        url: 'https://example.com/${input}',
+      }),
+      node('Shell', 'SHELL', {
+        command: '',
+        args: ['/bin/sh', '-c', 'echo ${input}'],
+      }),
+      node('结束', 'END', {
+        outputs: [{ name: 'result', value: '${Shell.exitCode}' }],
+      }),
+    ];
+    const edges: WorkflowFlowEdge[] = [
+      { id: '1', source: '开始', target: 'HTTP 请求' },
+      { id: '2', source: 'HTTP 请求', target: 'Shell' },
+      { id: '3', source: 'Shell', target: '结束' },
+    ];
+
+    expect(validateWorkflow(nodes, edges)).toEqual([]);
+  });
+});

--- a/yak-ops-ui/src/pages/workflow-management/designer/validation.ts
+++ b/yak-ops-ui/src/pages/workflow-management/designer/validation.ts
@@ -1,0 +1,101 @@
+import type { WorkflowFlowEdge, WorkflowFlowNode } from '../types';
+
+export type WorkflowValidationSeverity = 'error' | 'warning';
+
+export interface WorkflowValidationIssue {
+  id: string;
+  nodeId?: string;
+  nodeTitle: string;
+  severity: WorkflowValidationSeverity;
+  message: string;
+}
+
+const text = (value: unknown) => String(value ?? '').trim();
+
+const list = (value: unknown): unknown[] =>
+  Array.isArray(value) ? value : [];
+
+export const validateWorkflow = (
+  nodes: WorkflowFlowNode[],
+  edges: WorkflowFlowEdge[],
+): WorkflowValidationIssue[] => {
+  const issues: WorkflowValidationIssue[] = [];
+  const incoming = new Set(edges.map((edge) => edge.target));
+  const outgoing = new Set(edges.map((edge) => edge.source));
+
+  if (!nodes.some((node) => node.data.nodeType === 'START')) {
+    issues.push({
+      id: 'workflow-start-required',
+      nodeTitle: '工作流',
+      severity: 'error',
+      message: '至少需要一个开始节点',
+    });
+  }
+
+  if (!nodes.some((node) => node.data.nodeType === 'END')) {
+    issues.push({
+      id: 'workflow-end-required',
+      nodeTitle: '工作流',
+      severity: 'error',
+      message: '至少需要一个结束节点',
+    });
+  }
+
+  nodes.forEach((node) => {
+    const title = text(node.data.title) || node.id;
+    const add = (
+      key: string,
+      message: string,
+      severity: WorkflowValidationSeverity = 'error',
+    ) => {
+      issues.push({
+        id: `${node.id}-${key}`,
+        nodeId: node.id,
+        nodeTitle: title,
+        severity,
+        message,
+      });
+    };
+
+    if (!text(node.data.title)) add('title', '节点名称不能为空');
+
+    if (!node.data.enabled) return;
+
+    if (node.data.nodeType === 'HTTP') {
+      if (!text(node.data.config.url)) add('url', 'API 不能为空');
+      if (!text(node.data.config.method)) add('method', '请求方法不能为空');
+    }
+
+    if (node.data.nodeType === 'SHELL') {
+      const args = list(node.data.config.args).filter((item) => text(item));
+      if (!text(node.data.config.command) && args.length === 0) {
+        add('command', '命令或进程参数不能为空');
+      }
+    }
+
+    if (node.data.nodeType === 'START') {
+      list(node.data.config.inputVariables).forEach((item, index) => {
+        const variable = item as Record<string, unknown>;
+        if (!text(variable.name)) add(`input-${index}-name`, '输入变量名称不能为空');
+        if (!text(variable.type)) add(`input-${index}-type`, '输入变量类型不能为空');
+      });
+    }
+
+    if (node.data.nodeType === 'END') {
+      const outputs = list(node.data.config.outputs);
+      if (outputs.length === 0) add('outputs', '输出变量不能为空');
+      outputs.forEach((item, index) => {
+        const output = item as Record<string, unknown>;
+        if (!text(output.name)) add(`output-${index}-name`, '输出变量名称不能为空');
+        if (!text(output.value)) add(`output-${index}-value`, '输出变量值不能为空');
+      });
+    }
+
+    const connected = incoming.has(node.id) || outgoing.has(node.id);
+    if (!connected && nodes.length > 1) {
+      add('connection', '此节点尚未连接到其他节点', 'warning');
+    }
+  });
+
+  return issues;
+};

--- a/yak-ops-ui/src/pages/workflow-management/designer/validation.ts
+++ b/yak-ops-ui/src/pages/workflow-management/designer/validation.ts
@@ -27,8 +27,8 @@ export const validateWorkflow = (
     issues.push({
       id: 'workflow-start-required',
       nodeTitle: '工作流',
-      severity: 'error',
-      message: '至少需要一个开始节点',
+      severity: 'warning',
+      message: '建议添加一个开始节点',
     });
   }
 
@@ -36,8 +36,8 @@ export const validateWorkflow = (
     issues.push({
       id: 'workflow-end-required',
       nodeTitle: '工作流',
-      severity: 'error',
-      message: '至少需要一个结束节点',
+      severity: 'warning',
+      message: '建议添加一个结束节点',
     });
   }
 

--- a/yak-ops-ui/src/pages/workflow-management/types.ts
+++ b/yak-ops-ui/src/pages/workflow-management/types.ts
@@ -56,6 +56,37 @@ export interface WorkflowVariable {
   secret?: boolean;
 }
 
+/** Common local input/output parameter shared by typed task parameter objects. */
+export interface WorkflowLocalTaskParameter {
+  prop: string;
+  direct: 'IN' | 'OUT';
+  type: string;
+  value: string;
+}
+
+export type HttpWorkflowTaskParameters = Record<string, unknown> & {
+  localParams?: WorkflowLocalTaskParameter[];
+  url: string;
+  method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'HEAD' | 'OPTIONS';
+  headers: Record<string, string>;
+  body: string;
+  requestTimeoutSeconds: number;
+  successCodes: number[];
+  maxResponseBodyCharacters: number;
+};
+
+export type ShellWorkflowTaskParameters = Record<string, unknown> & {
+  localParams?: WorkflowLocalTaskParameter[];
+  command: string;
+  args: string[];
+  workDirectory: string;
+  environment: Record<string, string>;
+};
+
+export type KnownWorkflowTaskParameters =
+  | HttpWorkflowTaskParameters
+  | ShellWorkflowTaskParameters;
+
 export interface WorkflowNodeRecord {
   key: string;
   name: string;


### PR DESCRIPTION
## 改动说明

- 参考 DolphinScheduler `AbstractParameters` 设计，引入任务参数基类 `AbstractTaskParameters` 与公共 `localParams`。
- 新增 `HttpTaskParameters`、`ShellTaskParameters`，将前端 JSON 配置绑定为后端强类型对象，并由插件工厂统一校验与标准化。
- 工作流新增、编辑草稿时执行 DAG 与任务参数校验，并将标准化后的参数 JSON 持久化，避免无效 HTTP/Shell 配置写入草稿。
- HTTP 节点补齐成功状态码、响应体最大字符数、HEAD/OPTIONS 等参数，并统一 `${parameter}` 变量语法。
- Shell 节点补齐 `args` 参数，明确其优先级，并对齐实际输出变量 `processId`、`exitCode`。
- 前端补充 HTTP/Shell 强类型参数契约，字段与后端参数对象保持一致。
- 增加 Dify 风格实时检查清单：实时监听节点必填项与连接状态；必填配置未完成时阻止保存，拓扑建议仅提示、不阻断草稿保存。
- 增加 HTTP/Shell 参数标准化测试与前端实时校验测试。

## 参数结构

任务专属参数仍保存在节点 `config` JSON 中，后端通过对应插件的参数对象承接：

- 公共参数：`localParams`
- HTTP：`url`、`method`、`headers`、`body`、`requestTimeoutSeconds`、`successCodes`、`maxResponseBodyCharacters`
- Shell：`command`、`args`、`workDirectory`、`environment`

节点级公共执行参数继续保留在 `WorkflowNode`：重试次数、重试间隔、超时、启用、幂等、重启重试。

## 验证范围

- HTTP 参数默认值、局部参数、缺失 URL 校验
- Shell args 模式、command/args 二选一校验
- 保存草稿时的参数绑定、标准化与 DAG 校验
- HTTP/Shell/结束节点必填项实时检查
- 完整合法链路无检查错误

> 当前仓库未对该提交触发 GitHub Actions/状态检查；本 PR 已补充对应单元测试代码，合并前建议在本地执行后端模块测试及前端 `npm run tsc && npm test`。