### PR TITLE
fix: ensure Flyway creates datasource and workflow tables

### DIFF
--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/config/DataSourceConfiguration.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/config/DataSourceConfiguration.java
@@ -11,6 +11,7 @@ import javax.sql.DataSource;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.type.JdbcType;
 import org.flywaydb.core.Flyway;
+import org.flywaydb.core.api.MigrationVersion;
 import org.mybatis.spring.SqlSessionTemplate;
 import org.mybatis.spring.annotation.MapperScan;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -85,6 +86,7 @@ public class DataSourceConfiguration {
         .dataSource(dataSource)
         .locations("classpath:db/migration/yak-datasource")
         .table("yak_ds_schema_history")
+        .baselineVersion(MigrationVersion.fromVersion("0"))
         .baselineOnMigrate(true)
         .load();
   }

--- a/yak-ops-business/yak-ops-business-datasource/src/main/resources/db/migration/yak-datasource/V2__repair_skipped_data_source_table.sql
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/resources/db/migration/yak-datasource/V2__repair_skipped_data_source_table.sql
@@ -1,0 +1,25 @@
+-- 修复旧版本在非空 schema 中以版本 1 建立基线，导致 V1 建表迁移被跳过的问题。
+-- CREATE TABLE IF NOT EXISTS 可同时兼容已经正常完成 V1 的数据库。
+CREATE TABLE IF NOT EXISTS yak_ops_data_source (
+    id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT COMMENT '主键',
+    name VARCHAR(128) NOT NULL COMMENT '数据源名称',
+    db_type VARCHAR(32) NOT NULL COMMENT '数据库类型',
+    jdbc_url VARCHAR(1024) NOT NULL COMMENT 'JDBC 地址',
+    environment VARCHAR(32) NOT NULL DEFAULT 'DEVELOP' COMMENT '运行环境',
+    conn_status VARCHAR(32) NOT NULL DEFAULT 'UNKNOWN' COMMENT '连通状态',
+    remark VARCHAR(500) DEFAULT NULL COMMENT '备注',
+    connection_params LONGTEXT NOT NULL COMMENT '规范化连接参数 JSON',
+    original_json LONGTEXT NOT NULL COMMENT '前端编辑回显参数 JSON',
+    create_time DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) COMMENT '创建时间',
+    update_time DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3)
+        ON UPDATE CURRENT_TIMESTAMP(3) COMMENT '更新时间',
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_yak_ops_data_source_name (name),
+    KEY idx_yak_ops_data_source_type (db_type),
+    KEY idx_yak_ops_data_source_environment (environment),
+    KEY idx_yak_ops_data_source_status (conn_status),
+    KEY idx_yak_ops_data_source_update_time (update_time)
+) ENGINE=InnoDB
+  DEFAULT CHARSET=utf8mb4
+  COLLATE=utf8mb4_unicode_ci
+  COMMENT='Yak Ops 数据源管理';

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/config/WorkflowConfiguration.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/config/WorkflowConfiguration.java
@@ -14,6 +14,7 @@ import javax.sql.DataSource;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.type.JdbcType;
 import org.flywaydb.core.Flyway;
+import org.flywaydb.core.api.MigrationVersion;
 import org.mybatis.spring.SqlSessionTemplate;
 import org.mybatis.spring.annotation.MapperScan;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -86,6 +87,7 @@ public class WorkflowConfiguration {
         .dataSource(dataSource)
         .locations("classpath:db/migration/yak-workflow")
         .table("yak_wf_schema_history")
+        .baselineVersion(MigrationVersion.fromVersion("0"))
         .baselineOnMigrate(true)
         .load();
   }

--- a/yak-ops-business/yak-ops-business-workflow/src/main/resources/db/migration/yak-workflow/V2__repair_skipped_workflow_tables.sql
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/resources/db/migration/yak-workflow/V2__repair_skipped_workflow_tables.sql
@@ -1,0 +1,115 @@
+-- 修复旧版本在非空 schema 中以版本 1 建立基线，导致 V1 建表迁移被跳过的问题。
+-- 所有语句均使用 IF NOT EXISTS，可兼容已经正常完成 V1 的数据库。
+CREATE TABLE IF NOT EXISTS yak_wf_definition (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  code VARCHAR(128) NOT NULL,
+  name VARCHAR(255) NOT NULL,
+  description VARCHAR(1000) NULL,
+  state VARCHAR(32) NOT NULL,
+  current_version INT NULL,
+  failure_strategy VARCHAR(32) NOT NULL,
+  max_parallelism INT NOT NULL,
+  draft_json LONGTEXT NOT NULL,
+  created_by VARCHAR(128) NULL,
+  created_at DATETIME(6) NOT NULL,
+  updated_at DATETIME(6) NOT NULL,
+  PRIMARY KEY (id),
+  UNIQUE KEY uk_yak_wf_definition_code (code)
+);
+
+CREATE TABLE IF NOT EXISTS yak_wf_version (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  workflow_id BIGINT NOT NULL,
+  version INT NOT NULL,
+  dag_json LONGTEXT NOT NULL,
+  content_hash VARCHAR(64) NOT NULL,
+  published_by VARCHAR(128) NULL,
+  published_at DATETIME(6) NOT NULL,
+  PRIMARY KEY (id),
+  UNIQUE KEY uk_yak_wf_version (workflow_id, version),
+  KEY idx_yak_wf_version_workflow (workflow_id)
+);
+
+CREATE TABLE IF NOT EXISTS yak_wf_schedule (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  workflow_id BIGINT NOT NULL,
+  cron_expression VARCHAR(255) NOT NULL,
+  timezone VARCHAR(64) NOT NULL,
+  enabled TINYINT(1) NOT NULL,
+  misfire_policy VARCHAR(32) NOT NULL,
+  concurrency_policy VARCHAR(32) NOT NULL,
+  updated_at DATETIME(6) NOT NULL,
+  PRIMARY KEY (id),
+  UNIQUE KEY uk_yak_wf_schedule_workflow (workflow_id)
+);
+
+CREATE TABLE IF NOT EXISTS yak_wf_instance (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  workflow_id BIGINT NOT NULL,
+  workflow_version INT NOT NULL,
+  trigger_type VARCHAR(32) NOT NULL,
+  state VARCHAR(32) NOT NULL,
+  global_params_json LONGTEXT NOT NULL,
+  failure_strategy VARCHAR(32) NOT NULL,
+  max_parallelism INT NOT NULL,
+  stop_requested TINYINT(1) NOT NULL DEFAULT 0,
+  start_time DATETIME(6) NULL,
+  end_time DATETIME(6) NULL,
+  created_by VARCHAR(128) NULL,
+  created_at DATETIME(6) NOT NULL,
+  lock_version INT NOT NULL DEFAULT 0,
+  PRIMARY KEY (id),
+  KEY idx_yak_wf_instance_workflow_state (workflow_id, state),
+  KEY idx_yak_wf_instance_state (state)
+);
+
+CREATE TABLE IF NOT EXISTS yak_wf_task_instance (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  workflow_instance_id BIGINT NOT NULL,
+  node_key VARCHAR(64) NOT NULL,
+  node_name VARCHAR(255) NOT NULL,
+  task_type VARCHAR(64) NOT NULL,
+  state VARCHAR(32) NOT NULL,
+  config_json LONGTEXT NOT NULL,
+  max_retry_times INT NOT NULL,
+  retry_count INT NOT NULL DEFAULT 0,
+  retry_interval_seconds INT NOT NULL DEFAULT 0,
+  timeout_seconds INT NOT NULL DEFAULT 0,
+  idempotent TINYINT(1) NOT NULL DEFAULT 0,
+  retry_on_restart TINYINT(1) NOT NULL DEFAULT 0,
+  next_retry_time DATETIME(6) NULL,
+  start_time DATETIME(6) NULL,
+  end_time DATETIME(6) NULL,
+  result_json LONGTEXT NULL,
+  error_message LONGTEXT NULL,
+  lock_version INT NOT NULL DEFAULT 0,
+  PRIMARY KEY (id),
+  UNIQUE KEY uk_yak_wf_task_instance_node (workflow_instance_id, node_key),
+  KEY idx_yak_wf_task_instance_state (workflow_instance_id, state)
+);
+
+CREATE TABLE IF NOT EXISTS yak_wf_task_attempt (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  task_instance_id BIGINT NOT NULL,
+  attempt_no INT NOT NULL,
+  state VARCHAR(32) NOT NULL,
+  executor_type VARCHAR(64) NOT NULL,
+  external_id VARCHAR(255) NULL,
+  start_time DATETIME(6) NOT NULL,
+  end_time DATETIME(6) NULL,
+  error_message LONGTEXT NULL,
+  PRIMARY KEY (id),
+  UNIQUE KEY uk_yak_wf_task_attempt (task_instance_id, attempt_no),
+  KEY idx_yak_wf_task_attempt_task (task_instance_id)
+);
+
+CREATE TABLE IF NOT EXISTS yak_wf_task_log (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  task_attempt_id BIGINT NOT NULL,
+  line_no BIGINT NOT NULL,
+  content LONGTEXT NOT NULL,
+  created_at DATETIME(6) NOT NULL,
+  PRIMARY KEY (id),
+  UNIQUE KEY uk_yak_wf_task_log_line (task_attempt_id, line_no),
+  KEY idx_yak_wf_task_log_attempt (task_attempt_id)
+);


### PR DESCRIPTION
## 问题

直接启动 Yak Ops 后，访问数据源管理接口报错：

```text
Table 'yak_security.yak_ops_data_source' doesn't exist
```

## 根因

数据源和工作流模块都使用独立的 Flyway 历史表，但它们运行在已经包含安全模块表的非空 schema 中。此前配置启用了 `baselineOnMigrate(true)`，同时沿用默认基线版本 `1`，Flyway 首次初始化历史表时会直接记录版本 1，导致同为 V1 的业务建表迁移被跳过。

## 修改

- 将数据源模块 Flyway 的基线版本调整为 `0`，保证新环境会执行 V1。
- 将工作流模块 Flyway 的基线版本调整为 `0`，修复相同隐患。
- 新增数据源 V2 幂等恢复迁移，为已被错误标记为版本 1 的数据库补建 `yak_ops_data_source`。
- 新增工作流 V2 幂等恢复迁移，为同类历史环境补建工作流表。
- 恢复迁移均使用 `CREATE TABLE IF NOT EXISTS`，已正常建表的环境可安全升级。

## 验证说明

已核对分支相对 `main` 仅包含 4 个预期文件。当前执行环境没有可用的 Maven/GitHub CLI 和数据库运行环境，因此未在本地实际启动应用；合并前建议在 MariaDB 测试库执行一次启动验证，确认两个 Flyway 历史表升级到版本 2，且业务表自动创建。