### PR TITLE
fix(ui): show business failures with shared notification

### DIFF
--- a/yak-ops-ui/src/pages/data-source/components/AddOrEditDataSourceModal.tsx
+++ b/yak-ops-ui/src/pages/data-source/components/AddOrEditDataSourceModal.tsx
@@ -141,20 +141,14 @@ const AddOrEditDataSourceModal = forwardRef<DataSourceModalRef>((_, ref) => {
         }),
       });
 
-      if (response.code === 0) {
-        if (response.data === true) {
-          message.success(
-            intl.formatMessage({
-              id: "pages.datasource.modal.message.success",
-              defaultMessage: "Success",
-            })
-          );
-          return;
-        }
-
-        return;
+      if (response.code === 200 && response.data === true) {
+        message.success(
+          intl.formatMessage({
+            id: "pages.datasource.modal.message.success",
+            defaultMessage: "Success",
+          })
+        );
       }
-
     } catch (error: any) {
       if (error?.errorFields) return;
     }
@@ -175,14 +169,12 @@ const AddOrEditDataSourceModal = forwardRef<DataSourceModalRef>((_, ref) => {
         const response = await createDataSource(payload);
 
         if (response.code !== 200) {
-          // message.error(response.message || response.msg || "创建数据源失败");
           return;
         }
       }
 
       if (isEditMode) {
         if (!currentRecord?.id) {
-
           return;
         }
 

--- a/yak-ops-ui/src/pages/data-source/index.tsx
+++ b/yak-ops-ui/src/pages/data-source/index.tsx
@@ -92,6 +92,8 @@ const DataSourcePage: React.FC = () => {
 
       setDataSourceList(response.data?.bizData || []);
       setPagination(response.data?.pagination || PAGE_DEFAULT_PAGINATION);
+    } catch {
+      // 请求层已经统一展示业务、HTTP 与网络错误。
     } finally {
       setLoading(false);
     }
@@ -215,14 +217,18 @@ const DataSourcePage: React.FC = () => {
           return;
         }
 
-        const response = await deleteDataSource(record.id);
+        try {
+          const response = await deleteDataSource(record.id);
 
-        if (response.code !== 200) {
-          return;
+          if (response.code !== 200) {
+            return;
+          }
+
+          message.success(response.message || "删除成功");
+          handleRefresh();
+        } catch {
+          // 请求层已经统一展示错误。
         }
-
-        message.success(response.message || "删除成功");
-        handleRefresh();
       },
     });
   };
@@ -239,7 +245,11 @@ const DataSourcePage: React.FC = () => {
     }
 
     try {
-      await testDataSourceConnection(record.id);
+      const response = await testDataSourceConnection(record.id);
+
+      if (response.code !== 200) {
+        return;
+      }
 
       message.success(
         intl.formatMessage({
@@ -250,7 +260,7 @@ const DataSourcePage: React.FC = () => {
 
       handleRefresh();
     } catch {
-      message.error("连接测试失败，请检查数据源配置");
+      // 请求层已经统一展示错误，页面不再重复弹出 message。
     }
   };
 

--- a/yak-ops-ui/src/utils/HttpUtils.tsx
+++ b/yak-ops-ui/src/utils/HttpUtils.tsx
@@ -1,4 +1,28 @@
-import request, { type ApiResponse } from "@/utils/request";
+import request, {
+  type ApiProtocol,
+  type ApiResponse,
+  type BusinessErrorMode,
+} from "@/utils/request";
+
+export type HttpRequestOptions = RequestInit & {
+  businessErrorMode?: BusinessErrorMode;
+  protocol?: ApiProtocol;
+  skipErrorHandler?: boolean;
+};
+
+const withEnvelopeBusinessErrors = (
+  options?: HttpRequestOptions
+): HttpRequestOptions => ({
+  ...options,
+  businessErrorMode: options?.businessErrorMode ?? "resolve",
+});
+
+const withRejectedBusinessErrors = (
+  options?: HttpRequestOptions
+): HttpRequestOptions => ({
+  ...options,
+  businessErrorMode: "reject",
+});
 
 class HttpUtils {
   /** Preserve the response envelope for existing pages during migration. */
@@ -14,7 +38,7 @@ class HttpUtils {
   public static async post<T>(
     url: string,
     body?: Record<string, any>,
-    options?: RequestInit
+    options?: HttpRequestOptions
   ): Promise<ApiResponse<T>> {
     return request<ApiResponse<T>>(url, {
       method: "POST",
@@ -22,19 +46,19 @@ class HttpUtils {
       headers: {
         "Content-Type": "application/json",
       },
-      ...options,
+      ...withEnvelopeBusinessErrors(options),
     });
   }
 
   public static async postForm<T>(
     url: string,
     formData: FormData,
-    options?: RequestInit
+    options?: HttpRequestOptions
   ): Promise<ApiResponse<T>> {
     return request<ApiResponse<T>>(url, {
       method: "POST",
       data: formData,
-      ...options,
+      ...withEnvelopeBusinessErrors(options),
     });
   }
 
@@ -49,57 +73,78 @@ class HttpUtils {
       headers: {
         "Content-Type": "application/json",
       },
+      businessErrorMode: "resolve",
     });
   }
 
   public static async get<T>(
     url: string,
-    options?: RequestInit
+    options?: HttpRequestOptions
   ): Promise<ApiResponse<T>> {
     return request<ApiResponse<T>>(url, {
       method: "GET",
       headers: {
         "Content-Type": "application/json",
       },
-      ...options,
+      ...withEnvelopeBusinessErrors(options),
     });
   }
 
   public static async getData<T>(
     url: string,
-    options?: RequestInit
+    options?: HttpRequestOptions
   ): Promise<T> {
-    return HttpUtils.unwrap(await HttpUtils.get<T>(url, options));
+    return HttpUtils.unwrap(
+      await HttpUtils.get<T>(url, withRejectedBusinessErrors(options))
+    );
   }
 
   public static async postData<T>(
     url: string,
     body?: Record<string, any>,
-    options?: RequestInit
+    options?: HttpRequestOptions
   ): Promise<T> {
-    return HttpUtils.unwrap(await HttpUtils.post<T>(url, body, options));
+    return HttpUtils.unwrap(
+      await HttpUtils.post<T>(
+        url,
+        body,
+        withRejectedBusinessErrors(options)
+      )
+    );
   }
 
   public static async putData<T>(
     url: string,
     body?: Record<string, any>,
-    options?: RequestInit
+    options?: HttpRequestOptions
   ): Promise<T> {
-    return HttpUtils.unwrap(await HttpUtils.put<T>(url, body, options));
+    return HttpUtils.unwrap(
+      await HttpUtils.put<T>(
+        url,
+        body,
+        withRejectedBusinessErrors(options)
+      )
+    );
   }
 
   public static async deleteData<T>(
     url: string,
     data?: Record<string, any>,
-    options?: RequestInit
+    options?: HttpRequestOptions
   ): Promise<T> {
-    return HttpUtils.unwrap(await HttpUtils.delete<T>(url, data, options));
+    return HttpUtils.unwrap(
+      await HttpUtils.delete<T>(
+        url,
+        data,
+        withRejectedBusinessErrors(options)
+      )
+    );
   }
 
   public static async put<T>(
     url: string,
     body?: Record<string, any>,
-    options?: RequestInit
+    options?: HttpRequestOptions
   ): Promise<ApiResponse<T>> {
     return request<ApiResponse<T>>(url, {
       method: "PUT",
@@ -107,14 +152,14 @@ class HttpUtils {
       headers: {
         "Content-Type": "application/json",
       },
-      ...options,
+      ...withEnvelopeBusinessErrors(options),
     });
   }
 
   public static async delete<T>(
     url: string,
     data?: Record<string, any>,
-    options?: RequestInit
+    options?: HttpRequestOptions
   ): Promise<ApiResponse<T>> {
     return request<ApiResponse<T>>(url, {
       method: "DELETE",
@@ -122,7 +167,7 @@ class HttpUtils {
       headers: {
         "Content-Type": "application/json",
       },
-      ...options,
+      ...withEnvelopeBusinessErrors(options),
     });
   }
 

--- a/yak-ops-ui/src/utils/__tests__/request-business-error-mode.md
+++ b/yak-ops-ui/src/utils/__tests__/request-business-error-mode.md
@@ -1,0 +1,8 @@
+# Business error handling verification
+
+This document records the expected behavior covered by the request wrapper implementation:
+
+- Envelope APIs (`HttpUtils.get/post/put/delete`) resolve a non-success business response after the shared `notifyOnce` notification is displayed.
+- Data APIs (`getData/postData/putData/deleteData`) keep rejecting non-success business responses so callers never unwrap failed payloads.
+- Authentication failures always reject and continue through the shared session-expiry flow.
+- Data source page actions do not display a second local error message after the shared request notification.

--- a/yak-ops-ui/src/utils/__tests__/request-business-error-mode.md
+++ b/yak-ops-ui/src/utils/__tests__/request-business-error-mode.md
@@ -1,8 +1,0 @@
-# Business error handling verification
-
-This document records the expected behavior covered by the request wrapper implementation:
-
-- Envelope APIs (`HttpUtils.get/post/put/delete`) resolve a non-success business response after the shared `notifyOnce` notification is displayed.
-- Data APIs (`getData/postData/putData/deleteData`) keep rejecting non-success business responses so callers never unwrap failed payloads.
-- Authentication failures always reject and continue through the shared session-expiry flow.
-- Data source page actions do not display a second local error message after the shared request notification.

--- a/yak-ops-ui/src/utils/request.tsx
+++ b/yak-ops-ui/src/utils/request.tsx
@@ -14,6 +14,8 @@ import {
 
 export type { ApiProtocol, ApiResponse } from "@/services/http/response";
 
+export type BusinessErrorMode = "reject" | "resolve";
+
 const codeMessage: Record<number, string> = {
   10000: "系统未知错误，请反馈给管理员",
   200: "服务器成功返回请求的数据。",
@@ -97,7 +99,23 @@ export const handleAuthenticationFailure = () => {
     meta: "即将跳转登录页",
   });
   goLogin();
+};
 
+/** 业务异常的唯一展示出口。 */
+const handleBusinessError = (error: BizError) => {
+  if (isUnauthenticatedResponse(error.response, error.protocol)) {
+    handleAuthenticationFailure();
+    return;
+  }
+
+  if (error.skipErrorHandler) return;
+
+  notifyOnce(`business:${error.protocol}:${error.code}:${error.message}`, {
+    type: "error",
+    title: "操作失败",
+    description: error.message || "未知错误",
+    meta: "请稍后重试",
+  });
 };
 
 /** 唯一错误出口 */
@@ -106,17 +124,7 @@ const errorHandler = (error: any): Response | undefined => {
 
   // 业务异常
   if (error instanceof BizError) {
-    if (isUnauthenticatedResponse(error.response, error.protocol)) {
-      handleAuthenticationFailure();
-    } else if (!error.skipErrorHandler) {
-      notifyOnce(`business:${error.protocol}:${error.code}:${error.message}`, {
-        type: "error",
-        title: "操作失败",
-        description: error.message || "未知错误",
-        meta: "请稍后重试",
-      });
-    }
-
+    handleBusinessError(error);
     throw error;
   }
 
@@ -192,7 +200,7 @@ request.interceptors.request.use((url: string, options: any) => {
   };
 });
 
-/** 这里只识别业务异常，不做提示 */
+/** 识别统一响应中的业务状态，并按调用方需要选择返回响应或拒绝 Promise。 */
 request.interceptors.response.use(async (response: Response, options: any) => {
   if (response.status === 204 || options?.responseType === "blob") return response;
   const contentType = response.headers.get("content-type") || "";
@@ -208,7 +216,6 @@ request.interceptors.response.use(async (response: Response, options: any) => {
   const protocol: ApiProtocol = options?.protocol || protocolForUrl(response.url);
 
   if (isUnauthenticatedResponse(res, protocol)) {
-    handleAuthenticationFailure();
     throw new BizError(
       extractErrorMessage(res, "登录状态失效"),
       res.code,
@@ -222,13 +229,20 @@ request.interceptors.response.use(async (response: Response, options: any) => {
     typeof res?.code !== "undefined" &&
     !isSuccessfulResponse(res, protocol)
   ) {
-    throw new BizError(
+    const businessError = new BizError(
       extractErrorMessage(res),
       res.code,
       res,
       options?.skipErrorHandler,
       protocol
     );
+
+    if (options?.businessErrorMode === "resolve") {
+      handleBusinessError(businessError);
+      return response;
+    }
+
+    throw businessError;
   }
 
   return response;


### PR DESCRIPTION
## 问题

当后端返回 HTTP 200、但统一响应中的业务 `code` 不是 200 时，响应拦截器会抛出 `BizError`。数据源列表初始化请求没有捕获该 Promise，导致 Umi 开发环境显示整页 `Unhandled Rejection (BizError)` 遮罩，而不是只展示统一错误通知。

## 修改

- 抽取业务异常统一处理方法，继续使用 `notifyOnce` + `openPrettyNotification` 展示错误。
- 为请求增加 `businessErrorMode`：
  - `resolve`：通知后保留并返回完整业务响应，不触发未处理 Promise。
  - `reject`：仍抛出 `BizError`，供直接解包数据的调用使用。
- `HttpUtils.get/post/put/delete` 这类返回完整响应包的方法默认使用 `resolve`。
- `getData/postData/putData/deleteData` 保持 `reject`，避免把失败响应里的 `data` 当成成功结果。
- 数据源列表、删除、连接测试移除重复错误提示，仅保留请求层统一通知。
- 修正新增数据源弹窗连接测试仍判断旧成功码 `0` 的问题，统一使用 `200`。

## 预期效果

后端返回类似：

```json
{
  "code": 41010,
  "message": "数据源操作失败，请稍后重试"
}
```

页面只显示一次统一错误通知，不再出现 Umi 的 `Unhandled Rejection` 全屏错误页；同时页面不会继续执行成功逻辑。

## 验证

- 已检查分支相对 `main` 的净变更，仅涉及 4 个前端文件。
- 当前工具环境无法拉取仓库依赖并运行前端构建，建议合并前本地执行 `npm run typecheck`（如项目已配置）或现有前端轻量检查，并在 `/data-source` 模拟业务非 200 响应验证通知效果。