### PR TITLE
feat(workflow-ui): 增加曲线连线与节点快速插入

### DIFF
--- a/yak-ops-ui/src/pages/workflow-management/designer/components/WorkflowHeaderWithValidation.tsx
+++ b/yak-ops-ui/src/pages/workflow-management/designer/components/WorkflowHeaderWithValidation.tsx
@@ -6,6 +6,7 @@ import { useEdges, useNodes, useReactFlow } from 'reactflow';
 import type { WorkflowNodeData } from '../../types';
 import { validateWorkflow } from '../validation';
 import WorkflowHeader from './header';
+import WorkflowQuickAddLayer from './quick-add/WorkflowQuickAddLayer';
 
 type WorkflowHeaderWithValidationProps = ComponentProps<typeof WorkflowHeader>;
 
@@ -53,6 +54,7 @@ const WorkflowHeaderWithValidation = (
   return (
     <>
       <WorkflowHeader {...props} onSave={handleSave} />
+      <WorkflowQuickAddLayer />
 
       <div className="absolute right-3 top-[56px] z-50 flex flex-col items-end gap-2">
         <button

--- a/yak-ops-ui/src/pages/workflow-management/designer/components/node/BaseNode.tsx
+++ b/yak-ops-ui/src/pages/workflow-management/designer/components/node/BaseNode.tsx
@@ -2,13 +2,14 @@ import {
   CheckCircle2,
   CircleAlert,
   MoreHorizontal,
-  Plus,
   RotateCw,
 } from 'lucide-react';
 import type { CSSProperties, MouseEvent, ReactNode } from 'react';
 import { Handle, Position } from 'reactflow';
 import type { WorkflowNodeData } from '../../../types';
 import type { WorkflowNodeMeta } from '../../constants';
+import QuickAddButton from '../quick-add/QuickAddButton';
+import { openWorkflowQuickAdd } from '../quick-add/events';
 import NodeIcon from './NodeIcon';
 import {
   nodeStatusBorderClass,
@@ -25,8 +26,8 @@ interface BaseNodeProps {
 }
 
 const handleClass = [
-  '!top-4 !h-4 !w-4 !translate-y-0 !rounded-none !border-0 !bg-transparent',
-  '!outline-none transition-transform hover:scale-125',
+  '!top-[3px] !h-7 !w-7 !translate-y-0 !rounded-full',
+  '!border-0 !bg-transparent !outline-none',
 ].join(' ');
 
 const StatusIcon = ({
@@ -46,11 +47,10 @@ const BaseNode = ({ id, data, meta, selected, children }: BaseNodeProps) => {
     !data.enabled || data.retryTimes > 0 || data.timeoutSeconds > 0 || status !== 'idle';
 
   const openQuickAdd = () => {
-    window.dispatchEvent(
-      new CustomEvent('yak-workflow-quick-add', {
-        detail: { nodeId: id },
-      }),
-    );
+    openWorkflowQuickAdd({
+      mode: 'append',
+      sourceNodeId: id,
+    });
   };
 
   return (
@@ -103,9 +103,9 @@ const BaseNode = ({ id, data, meta, selected, children }: BaseNodeProps) => {
             id="target"
             type="target"
             position={Position.Left}
-            className={`${handleClass} !-left-[9px]`}
+            className={`${handleClass} !-left-[15px]`}
           >
-            <span className="absolute left-[7px] top-1 h-2 w-0.5 rounded-full bg-[#98a2b3]" />
+            <span className="absolute left-[13px] top-[9px] h-2.5 w-0.5 rounded-full bg-[#98a2b3] transition-colors group-hover:bg-[#667085]" />
           </Handle>
         )}
 
@@ -115,31 +115,20 @@ const BaseNode = ({ id, data, meta, selected, children }: BaseNodeProps) => {
               id="source"
               type="source"
               position={Position.Right}
-              className={`${handleClass} !-right-[9px]`}
+              className={`${handleClass} !-right-[15px]`}
             >
-              <span className="absolute right-[7px] top-1 h-2 w-0.5 rounded-full bg-[#98a2b3]" />
+              <span className="absolute right-[13px] top-[9px] h-2.5 w-0.5 rounded-full bg-[#98a2b3] transition-opacity group-hover:opacity-0" />
             </Handle>
-            <button
-              type="button"
+
+            <QuickAddButton
+              label="添加后续节点"
               className={[
-                'nodrag nopan absolute right-[-28px] top-[5px] z-10 flex h-[22px] w-[22px]',
-                'items-center justify-center rounded-full border border-[#d0d5dd] bg-white text-[#667085]',
-                'opacity-0 shadow-[0_3px_8px_rgba(16,24,40,0.10)] transition-all duration-150',
-                'hover:border-[#84adff] hover:bg-[#f5f8ff] hover:text-[#155eef]',
+                'absolute -right-[35px] top-[1px] z-20',
                 'group-hover:opacity-100',
-                selected ? 'opacity-100' : '',
-              ]
-                .filter(Boolean)
-                .join(' ')}
-              aria-label="添加后续节点"
-              onMouseDown={(event: MouseEvent<HTMLButtonElement>) => event.stopPropagation()}
-              onClick={(event: MouseEvent<HTMLButtonElement>) => {
-                event.stopPropagation();
-                openQuickAdd();
-              }}
-            >
-              <Plus size={12} strokeWidth={2.2} />
-            </button>
+              ].join(' ')}
+              alwaysVisible={selected}
+              onClick={openQuickAdd}
+            />
           </>
         )}
 

--- a/yak-ops-ui/src/pages/workflow-management/designer/components/panel/NodePanel.tsx
+++ b/yak-ops-ui/src/pages/workflow-management/designer/components/panel/NodePanel.tsx
@@ -7,9 +7,12 @@ import {
   X,
 } from 'lucide-react';
 import { useMemo, useState, type ChangeEvent } from 'react';
+import { useEdges, useNodes, useReactFlow } from 'reactflow';
 import type { WorkflowFlowNode, WorkflowNodeData } from '../../../types';
 import { getNodeMeta } from '../../constants';
 import NodeIcon from '../node/NodeIcon';
+import NextStepSection from '../quick-add/NextStepSection';
+import { openWorkflowQuickAdd } from '../quick-add/events';
 import EndPanel from './node/end';
 import HttpPanel from './node/http';
 import ShellPanel from './node/shell';
@@ -61,6 +64,9 @@ const NodePanel = ({
   onClose,
 }: NodePanelProps) => {
   const [advancedOpen, setAdvancedOpen] = useState(false);
+  const nodes = useNodes<WorkflowNodeData>();
+  const edges = useEdges();
+  const reactFlow = useReactFlow<WorkflowNodeData>();
   const data = node.data;
   const meta = getNodeMeta(data.nodeType);
   const isControlNode = data.nodeType === 'START' || data.nodeType === 'END';
@@ -69,6 +75,13 @@ const NodePanel = ({
     data.nodeType === 'END' ||
     data.nodeType === 'HTTP' ||
     data.nodeType === 'SHELL';
+
+  const nextNodes = useMemo(() => {
+    const targetIds = new Set(
+      edges.filter((edge) => edge.source === node.id).map((edge) => edge.target),
+    );
+    return nodes.filter((item) => targetIds.has(item.id));
+  }, [edges, node.id, nodes]);
 
   const patch = (values: Partial<WorkflowNodeData>) => {
     onChange({ ...data, ...values });
@@ -91,6 +104,27 @@ const NodePanel = ({
       ),
     [data.config],
   );
+
+  const openNextNode = (nodeId: string) => {
+    const target = reactFlow.getNode(nodeId);
+    if (!target) return;
+
+    const position = target.positionAbsolute || target.position;
+    void reactFlow.setCenter(
+      position.x + (target.width || 240) / 2,
+      position.y + (target.height || 112) / 2,
+      {
+        zoom: Math.max(reactFlow.getZoom(), 0.85),
+        duration: 220,
+      },
+    );
+
+    requestAnimationFrame(() => {
+      document
+        .querySelector<HTMLElement>(`.react-flow__node[data-id="${nodeId}"]`)
+        ?.click();
+    });
+  };
 
   const renderNodePanel = () => {
     switch (data.nodeType) {
@@ -182,6 +216,19 @@ const NodePanel = ({
         </section>
 
         {renderNodePanel()}
+
+        {isSupported && data.nodeType !== 'END' && (
+          <NextStepSection
+            nodes={nextNodes}
+            onOpenNode={openNextNode}
+            onAdd={() =>
+              openWorkflowQuickAdd({
+                mode: 'append',
+                sourceNodeId: node.id,
+              })
+            }
+          />
+        )}
 
         {!isControlNode && isSupported && (
           <section className="border-t border-[#f0f1f4] px-4 py-4">

--- a/yak-ops-ui/src/pages/workflow-management/designer/components/quick-add/NextStepSection.tsx
+++ b/yak-ops-ui/src/pages/workflow-management/designer/components/quick-add/NextStepSection.tsx
@@ -1,6 +1,8 @@
 import { ChevronRight } from 'lucide-react';
+import type { CSSProperties } from 'react';
 
 import type { WorkflowFlowNode } from '../../../types';
+import { getNodeMeta } from '../../constants';
 import NodeIcon from '../node/NodeIcon';
 import { PanelSection } from '../panel/node/shared';
 import QuickAddButton from './QuickAddButton';
@@ -21,31 +23,35 @@ const NextStepSection = ({
     description="添加此工作流中的下一个节点"
   >
     <div className="space-y-2">
-      {nodes.map((node) => (
-        <button
-          key={node.id}
-          type="button"
-          className={[
-            'group flex min-h-[38px] w-full items-center gap-2',
-            'rounded-lg border border-[#e4e7ec] bg-white px-2.5 text-left',
-            'shadow-[0_1px_2px_rgba(16,24,40,0.04)]',
-            'transition-colors duration-150',
-            'hover:border-[#b2ccff] hover:bg-[#f8faff]',
-          ].join(' ')}
-          onClick={() => onOpenNode(node.id)}
-        >
-          <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md bg-[color-mix(in_srgb,var(--node-color)_10%,white)]">
-            <NodeIcon type={node.data.nodeType} size={15} />
-          </span>
-          <span className="min-w-0 flex-1 truncate text-[12px] font-medium text-[#344054]">
-            {node.data.title}
-          </span>
-          <ChevronRight
-            size={14}
-            className="shrink-0 text-[#98a2b3] group-hover:text-[#155eef]"
-          />
-        </button>
-      ))}
+      {nodes.map((node) => {
+        const meta = getNodeMeta(node.data.nodeType);
+        return (
+          <button
+            key={node.id}
+            type="button"
+            className={[
+              'group flex min-h-[38px] w-full items-center gap-2',
+              'rounded-lg border border-[#e4e7ec] bg-white px-2.5 text-left',
+              'shadow-[0_1px_2px_rgba(16,24,40,0.04)]',
+              'transition-colors duration-150',
+              'hover:border-[#b2ccff] hover:bg-[#f8faff]',
+            ].join(' ')}
+            style={{ '--node-color': meta.color } as CSSProperties}
+            onClick={() => onOpenNode(node.id)}
+          >
+            <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md bg-[color-mix(in_srgb,var(--node-color)_10%,white)]">
+              <NodeIcon type={node.data.nodeType} size={15} />
+            </span>
+            <span className="min-w-0 flex-1 truncate text-[12px] font-medium text-[#344054]">
+              {node.data.title}
+            </span>
+            <ChevronRight
+              size={14}
+              className="shrink-0 text-[#98a2b3] group-hover:text-[#155eef]"
+            />
+          </button>
+        );
+      })}
 
       <QuickAddButton
         label={nodes.length ? '添加并行节点' : '添加后续节点'}

--- a/yak-ops-ui/src/pages/workflow-management/designer/components/quick-add/NextStepSection.tsx
+++ b/yak-ops-ui/src/pages/workflow-management/designer/components/quick-add/NextStepSection.tsx
@@ -1,0 +1,59 @@
+import { ChevronRight } from 'lucide-react';
+
+import type { WorkflowFlowNode } from '../../../types';
+import NodeIcon from '../node/NodeIcon';
+import { PanelSection } from '../panel/node/shared';
+import QuickAddButton from './QuickAddButton';
+
+interface NextStepSectionProps {
+  nodes: WorkflowFlowNode[];
+  onAdd: () => void;
+  onOpenNode: (nodeId: string) => void;
+}
+
+const NextStepSection = ({
+  nodes,
+  onAdd,
+  onOpenNode,
+}: NextStepSectionProps) => (
+  <PanelSection
+    title="下一步"
+    description="添加此工作流中的下一个节点"
+  >
+    <div className="space-y-2">
+      {nodes.map((node) => (
+        <button
+          key={node.id}
+          type="button"
+          className={[
+            'group flex min-h-[38px] w-full items-center gap-2',
+            'rounded-lg border border-[#e4e7ec] bg-white px-2.5 text-left',
+            'shadow-[0_1px_2px_rgba(16,24,40,0.04)]',
+            'transition-colors duration-150',
+            'hover:border-[#b2ccff] hover:bg-[#f8faff]',
+          ].join(' ')}
+          onClick={() => onOpenNode(node.id)}
+        >
+          <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md bg-[color-mix(in_srgb,var(--node-color)_10%,white)]">
+            <NodeIcon type={node.data.nodeType} size={15} />
+          </span>
+          <span className="min-w-0 flex-1 truncate text-[12px] font-medium text-[#344054]">
+            {node.data.title}
+          </span>
+          <ChevronRight
+            size={14}
+            className="shrink-0 text-[#98a2b3] group-hover:text-[#155eef]"
+          />
+        </button>
+      ))}
+
+      <QuickAddButton
+        label={nodes.length ? '添加并行节点' : '添加后续节点'}
+        variant="panel"
+        onClick={onAdd}
+      />
+    </div>
+  </PanelSection>
+);
+
+export default NextStepSection;

--- a/yak-ops-ui/src/pages/workflow-management/designer/components/quick-add/NodePicker.tsx
+++ b/yak-ops-ui/src/pages/workflow-management/designer/components/quick-add/NodePicker.tsx
@@ -1,6 +1,6 @@
 import { Input } from 'antd';
 import { Plus, Search } from 'lucide-react';
-import { useMemo, useState } from 'react';
+import { useMemo, useState, type CSSProperties } from 'react';
 
 import type { WorkflowNodeType } from '../../../types';
 import {
@@ -69,6 +69,7 @@ const NodePicker = ({ onSelect, allowedTypes }: NodePickerProps) => {
                       'transition-colors duration-150',
                       'hover:border-[#d1e0ff] hover:bg-[#f5f8ff]',
                     ].join(' ')}
+                    style={{ '--node-color': item.color } as CSSProperties}
                     onClick={() => onSelect(item.type)}
                   >
                     <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-[color-mix(in_srgb,var(--node-color)_10%,white)]">

--- a/yak-ops-ui/src/pages/workflow-management/designer/components/quick-add/NodePicker.tsx
+++ b/yak-ops-ui/src/pages/workflow-management/designer/components/quick-add/NodePicker.tsx
@@ -1,0 +1,108 @@
+import { Input } from 'antd';
+import { Plus, Search } from 'lucide-react';
+import { useMemo, useState } from 'react';
+
+import type { WorkflowNodeType } from '../../../types';
+import {
+  CATEGORY_LABELS,
+  WORKFLOW_NODE_CATALOG,
+  type WorkflowNodeCategory,
+} from '../../constants';
+import NodeIcon from '../node/NodeIcon';
+
+interface NodePickerProps {
+  onSelect: (type: WorkflowNodeType) => void;
+  allowedTypes?: WorkflowNodeType[];
+}
+
+const categoryOrder: WorkflowNodeCategory[] = ['control', 'action'];
+
+const NodePicker = ({ onSelect, allowedTypes }: NodePickerProps) => {
+  const [keyword, setKeyword] = useState('');
+
+  const visibleItems = useMemo(() => {
+    const normalized = keyword.trim().toLowerCase();
+    const allowed = allowedTypes?.length ? new Set(allowedTypes) : undefined;
+
+    return WORKFLOW_NODE_CATALOG.filter((item) => {
+      if (allowed && !allowed.has(item.type)) return false;
+      if (!normalized) return true;
+      return `${item.title} ${item.description} ${item.type}`
+        .toLowerCase()
+        .includes(normalized);
+    });
+  }, [allowedTypes, keyword]);
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="shrink-0 px-3 py-3">
+        <Input
+          allowClear
+          autoFocus
+          value={keyword}
+          prefix={<Search size={15} className="text-[#98a2b3]" />}
+          placeholder="搜索开始、结束、HTTP、Shell"
+          className="h-9 rounded-lg border-[#d0d5dd] bg-[#fcfcfd]"
+          onChange={(event) => setKeyword(event.target.value)}
+        />
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto px-3 pb-4">
+        {categoryOrder.map((category) => {
+          const items = visibleItems.filter((item) => item.category === category);
+          if (!items.length) return null;
+
+          return (
+            <section key={category} className="mb-4 last:mb-0">
+              <h3 className="mb-1.5 px-1 text-[12px] font-medium text-[#667085]">
+                {CATEGORY_LABELS[category]}
+              </h3>
+
+              <div className="space-y-1">
+                {items.map((item) => (
+                  <button
+                    key={item.type}
+                    type="button"
+                    className={[
+                      'group flex min-h-[52px] w-full items-center gap-2.5',
+                      'rounded-lg border border-transparent px-2 py-2 text-left',
+                      'transition-colors duration-150',
+                      'hover:border-[#d1e0ff] hover:bg-[#f5f8ff]',
+                    ].join(' ')}
+                    onClick={() => onSelect(item.type)}
+                  >
+                    <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-[color-mix(in_srgb,var(--node-color)_10%,white)]">
+                      <NodeIcon type={item.type} size={18} />
+                    </span>
+
+                    <span className="min-w-0 flex-1">
+                      <strong className="block truncate text-[13px] font-medium text-[#344054]">
+                        {item.title}
+                      </strong>
+                      <span className="mt-0.5 block truncate text-[11px] text-[#98a2b3]">
+                        {item.description}
+                      </span>
+                    </span>
+
+                    <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-[#98a2b3] transition-colors group-hover:bg-white group-hover:text-[#155eef]">
+                      <Plus size={15} />
+                    </span>
+                  </button>
+                ))}
+              </div>
+            </section>
+          );
+        })}
+
+        {!visibleItems.length && (
+          <div className="flex h-40 flex-col items-center justify-center text-[#98a2b3]">
+            <Search size={20} />
+            <span className="mt-2 text-[12px]">没有匹配的节点</span>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default NodePicker;

--- a/yak-ops-ui/src/pages/workflow-management/designer/components/quick-add/QuickAddButton.tsx
+++ b/yak-ops-ui/src/pages/workflow-management/designer/components/quick-add/QuickAddButton.tsx
@@ -1,0 +1,83 @@
+import { Plus } from 'lucide-react';
+import type { MouseEvent } from 'react';
+
+interface QuickAddButtonProps {
+  label: string;
+  onClick: () => void;
+  variant?: 'node' | 'edge' | 'panel';
+  className?: string;
+  alwaysVisible?: boolean;
+}
+
+const QuickAddButton = ({
+  label,
+  onClick,
+  variant = 'node',
+  className = '',
+  alwaysVisible = false,
+}: QuickAddButtonProps) => {
+  const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+    onClick();
+  };
+
+  if (variant === 'panel') {
+    return (
+      <button
+        type="button"
+        aria-label={label}
+        className={[
+          'group flex min-h-[38px] w-full items-center justify-center gap-1.5',
+          'rounded-lg border border-dashed border-[#d0d5dd] bg-[#f9fafb]',
+          'px-3 text-[12px] font-medium text-[#667085]',
+          'transition-colors duration-150',
+          'hover:border-[#84adff] hover:bg-[#f5f8ff] hover:text-[#155eef]',
+          className,
+        ].join(' ')}
+        onMouseDown={(event) => event.stopPropagation()}
+        onClick={handleClick}
+      >
+        <Plus size={14} strokeWidth={2.2} />
+        {label}
+      </button>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      title={label}
+      className={[
+        'nodrag nopan nowheel group/quick-add flex items-center justify-center',
+        'border-0 bg-transparent p-0 outline-none',
+        'transition-[opacity,transform] duration-150',
+        variant === 'edge' ? 'h-11 w-11' : 'h-8 w-8',
+        alwaysVisible ? 'opacity-100' : 'opacity-0 hover:opacity-100 focus-visible:opacity-100',
+        className,
+      ].join(' ')}
+      onMouseDown={(event) => event.stopPropagation()}
+      onClick={handleClick}
+    >
+      <span
+        className={[
+          'flex items-center justify-center rounded-full border bg-white',
+          'text-[#155eef] shadow-[0_4px_12px_rgba(16,24,40,0.14)]',
+          'transition-[border-color,background-color,box-shadow,transform] duration-150',
+          'group-hover/quick-add:border-[#84adff]',
+          'group-hover/quick-add:bg-[#f5f8ff]',
+          'group-hover/quick-add:shadow-[0_5px_16px_rgba(21,94,239,0.18)]',
+          'group-active/quick-add:scale-95',
+          variant === 'edge'
+            ? 'h-7 w-7 border-[#b2ccff]'
+            : 'h-7 w-7 border-[#d0d5dd]',
+        ].join(' ')}
+      >
+        <Plus size={15} strokeWidth={2.5} />
+      </span>
+    </button>
+  );
+};
+
+export default QuickAddButton;

--- a/yak-ops-ui/src/pages/workflow-management/designer/components/quick-add/WorkflowQuickAddLayer.tsx
+++ b/yak-ops-ui/src/pages/workflow-management/designer/components/quick-add/WorkflowQuickAddLayer.tsx
@@ -1,0 +1,327 @@
+import { X } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+import { createPortal } from 'react-dom';
+import {
+  MarkerType,
+  useEdges,
+  useNodes,
+  useReactFlow,
+  useViewport,
+} from 'reactflow';
+
+import type {
+  WorkflowFlowEdge,
+  WorkflowFlowNode,
+  WorkflowNodeData,
+  WorkflowNodeType,
+} from '../../../types';
+import { createNodeData } from '../../constants';
+import NodePicker from './NodePicker';
+import QuickAddButton from './QuickAddButton';
+import {
+  WORKFLOW_QUICK_ADD_EVENT,
+  type WorkflowQuickAddContext,
+} from './events';
+
+interface EdgeCurve {
+  edge: WorkflowFlowEdge;
+  path: string;
+  middleX: number;
+  middleY: number;
+  flowMiddleX: number;
+  flowMiddleY: number;
+}
+
+const NODE_WIDTH = 240;
+const NODE_HEIGHT = 112;
+const HANDLE_OFFSET_Y = 17;
+
+const uniqueNodeId = (type: WorkflowNodeType) =>
+  `${String(type).toLowerCase()}_${Date.now().toString(36)}_${Math.random()
+    .toString(36)
+    .slice(2, 6)}`;
+
+const cubicPoint = (
+  start: number,
+  control1: number,
+  control2: number,
+  end: number,
+) => (start + 3 * control1 + 3 * control2 + end) / 8;
+
+const buildCurve = (
+  edge: WorkflowFlowEdge,
+  source: WorkflowFlowNode,
+  target: WorkflowFlowNode,
+  viewport: { x: number; y: number; zoom: number },
+): EdgeCurve => {
+  const sourcePosition = source.positionAbsolute || source.position;
+  const targetPosition = target.positionAbsolute || target.position;
+  const sourceX = sourcePosition.x + (source.width || NODE_WIDTH);
+  const sourceY = sourcePosition.y + HANDLE_OFFSET_Y;
+  const targetX = targetPosition.x;
+  const targetY = targetPosition.y + HANDLE_OFFSET_Y;
+  const controlOffset = Math.max(72, Math.abs(targetX - sourceX) * 0.45);
+  const control1X = sourceX + controlOffset;
+  const control2X = targetX - controlOffset;
+  const flowMiddleX = cubicPoint(sourceX, control1X, control2X, targetX);
+  const flowMiddleY = cubicPoint(sourceY, sourceY, targetY, targetY);
+
+  const screen = (value: number, offset: number) =>
+    value * viewport.zoom + offset;
+
+  return {
+    edge,
+    path: [
+      `M ${screen(sourceX, viewport.x)} ${screen(sourceY, viewport.y)}`,
+      `C ${screen(control1X, viewport.x)} ${screen(sourceY, viewport.y)}`,
+      `${screen(control2X, viewport.x)} ${screen(targetY, viewport.y)}`,
+      `${screen(targetX, viewport.x)} ${screen(targetY, viewport.y)}`,
+    ].join(' '),
+    middleX: screen(flowMiddleX, viewport.x),
+    middleY: screen(flowMiddleY, viewport.y),
+    flowMiddleX,
+    flowMiddleY,
+  };
+};
+
+const WorkflowQuickAddLayer = () => {
+  const nodes = useNodes<WorkflowNodeData>();
+  const edges = useEdges();
+  const reactFlow = useReactFlow<WorkflowNodeData>();
+  const viewport = useViewport();
+  const [canvas, setCanvas] = useState<HTMLElement | null>(null);
+  const [context, setContext] = useState<WorkflowQuickAddContext>();
+
+  useEffect(() => {
+    setCanvas(document.querySelector<HTMLElement>('.dify-workflow-canvas'));
+  }, []);
+
+  useEffect(() => {
+    const open = (event: Event) => {
+      const customEvent = event as CustomEvent<WorkflowQuickAddContext>;
+      setContext(customEvent.detail);
+    };
+
+    window.addEventListener(WORKFLOW_QUICK_ADD_EVENT, open);
+    return () => window.removeEventListener(WORKFLOW_QUICK_ADD_EVENT, open);
+  }, []);
+
+  useEffect(() => {
+    if (!context) return;
+    const close = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setContext(undefined);
+    };
+    window.addEventListener('keydown', close);
+    return () => window.removeEventListener('keydown', close);
+  }, [context]);
+
+  const nodeMap = useMemo(
+    () => new Map(nodes.map((node) => [node.id, node])),
+    [nodes],
+  );
+
+  const curves = useMemo(
+    () =>
+      edges.flatMap((edge) => {
+        const source = nodeMap.get(edge.source);
+        const target = nodeMap.get(edge.target);
+        return source && target
+          ? [buildCurve(edge, source, target, viewport)]
+          : [];
+      }),
+    [edges, nodeMap, viewport],
+  );
+
+  const allowedTypes: WorkflowNodeType[] = context?.mode === 'insert'
+    ? ['HTTP', 'SHELL']
+    : ['HTTP', 'SHELL', 'END'];
+
+  const openNodePanel = (nodeId: string) => {
+    requestAnimationFrame(() => {
+      const nodeElement = canvas?.querySelector<HTMLElement>(
+        `.react-flow__node[data-id="${nodeId}"]`,
+      );
+      nodeElement?.click();
+    });
+  };
+
+  const addNode = (type: WorkflowNodeType) => {
+    if (!context) return;
+    const source = nodeMap.get(context.sourceNodeId);
+    if (!source) return;
+
+    const id = uniqueNodeId(type);
+    const sourcePosition = source.positionAbsolute || source.position;
+    const position = context.mode === 'insert' && context.position
+      ? {
+          x: context.position.x - NODE_WIDTH / 2,
+          y: context.position.y - NODE_HEIGHT / 2,
+        }
+      : {
+          x: sourcePosition.x + NODE_WIDTH + 110,
+          y: sourcePosition.y,
+        };
+    const node: WorkflowFlowNode = {
+      id,
+      type: 'workflowNode',
+      position,
+      data: createNodeData(type, nodes.length + 1),
+    };
+
+    reactFlow.setNodes((current) => [...current, node]);
+    reactFlow.setEdges((current) => {
+      const next = context.edgeId
+        ? current.filter((edge) => edge.id !== context.edgeId)
+        : current;
+      const markerEnd = { type: MarkerType.ArrowClosed };
+      const sourceEdge: WorkflowFlowEdge = {
+        id: `edge_${context.sourceNodeId}_${id}_${Date.now()}`,
+        source: context.sourceNodeId,
+        target: id,
+        type: 'smoothstep',
+        markerEnd,
+      };
+
+      if (context.mode !== 'insert' || !context.targetNodeId) {
+        return [...next, sourceEdge];
+      }
+
+      return [
+        ...next,
+        sourceEdge,
+        {
+          id: `edge_${id}_${context.targetNodeId}_${Date.now() + 1}`,
+          source: id,
+          target: context.targetNodeId,
+          type: 'smoothstep',
+          markerEnd,
+        },
+      ];
+    });
+
+    setContext(undefined);
+    void reactFlow.setCenter(
+      position.x + NODE_WIDTH / 2,
+      position.y + NODE_HEIGHT / 2,
+      {
+        zoom: Math.max(reactFlow.getZoom(), 0.85),
+        duration: 240,
+      },
+    );
+    openNodePanel(id);
+  };
+
+  if (!canvas) return null;
+
+  return createPortal(
+    <div className="pointer-events-none absolute inset-0 z-[12]">
+      <svg className="absolute inset-0 h-full w-full overflow-visible">
+        <defs>
+          <marker
+            id="yak-workflow-edge-arrow"
+            markerWidth="8"
+            markerHeight="8"
+            refX="7"
+            refY="4"
+            orient="auto"
+            markerUnits="strokeWidth"
+          >
+            <path d="M 0 0 L 8 4 L 0 8 z" fill="#a6afbd" />
+          </marker>
+          <marker
+            id="yak-workflow-edge-arrow-active"
+            markerWidth="8"
+            markerHeight="8"
+            refX="7"
+            refY="4"
+            orient="auto"
+            markerUnits="strokeWidth"
+          >
+            <path d="M 0 0 L 8 4 L 0 8 z" fill="#155eef" />
+          </marker>
+        </defs>
+
+        {curves.map(({ edge, path }) => (
+          <path
+            key={edge.id}
+            d={path}
+            fill="none"
+            stroke={edge.selected ? '#155eef' : '#a6afbd'}
+            strokeWidth={edge.selected ? 2 : 1.6}
+            strokeLinecap="round"
+            markerEnd={
+              edge.selected
+                ? 'url(#yak-workflow-edge-arrow-active)'
+                : 'url(#yak-workflow-edge-arrow)'
+            }
+          />
+        ))}
+      </svg>
+
+      {curves.map((curve) => (
+        <div
+          key={`${curve.edge.id}-quick-add`}
+          className="pointer-events-auto absolute -translate-x-1/2 -translate-y-1/2"
+          style={{ left: curve.middleX, top: curve.middleY }}
+        >
+          <QuickAddButton
+            label="在连线中插入节点"
+            variant="edge"
+            alwaysVisible={Boolean(curve.edge.selected)}
+            onClick={() =>
+              setContext({
+                mode: 'insert',
+                edgeId: curve.edge.id,
+                sourceNodeId: curve.edge.source,
+                targetNodeId: curve.edge.target,
+                position: {
+                  x: curve.flowMiddleX,
+                  y: curve.flowMiddleY,
+                },
+              })
+            }
+          />
+        </div>
+      ))}
+
+      {context && (
+        <aside
+          className={[
+            'pointer-events-auto absolute bottom-0 right-0 top-0 z-50',
+            'flex w-[400px] max-w-full flex-col overflow-hidden',
+            'border-l border-[#e4e7ec] bg-white',
+            'shadow-[-12px_0_32px_rgba(16,24,40,0.10)]',
+          ].join(' ')}
+          onMouseDown={(event) => event.stopPropagation()}
+          onClick={(event) => event.stopPropagation()}
+        >
+          <header className="flex min-h-[64px] shrink-0 items-center justify-between border-b border-[#eaecf0] px-4">
+            <div>
+              <h3 className="m-0 text-[15px] font-semibold text-[#101828]">
+                {context.mode === 'insert' ? '在连线中添加节点' : '添加下一个节点'}
+              </h3>
+              <p className="mb-0 mt-1 text-[11px] text-[#98a2b3]">
+                {context.mode === 'insert'
+                  ? '选择后会自动拆分当前连线，并把节点放在中间。'
+                  : '选择后会自动连接到当前节点。'}
+              </p>
+            </div>
+            <button
+              type="button"
+              aria-label="关闭节点列表"
+              className="flex h-8 w-8 items-center justify-center rounded-lg border-0 bg-transparent text-[#667085] hover:bg-[#f2f4f7]"
+              onClick={() => setContext(undefined)}
+            >
+              <X size={17} />
+            </button>
+          </header>
+
+          <NodePicker allowedTypes={allowedTypes} onSelect={addNode} />
+        </aside>
+      )}
+    </div>,
+    canvas,
+  );
+};
+
+export default WorkflowQuickAddLayer;

--- a/yak-ops-ui/src/pages/workflow-management/designer/components/quick-add/WorkflowQuickAddLayer.tsx
+++ b/yak-ops-ui/src/pages/workflow-management/designer/components/quick-add/WorkflowQuickAddLayer.tsx
@@ -91,6 +91,7 @@ const WorkflowQuickAddLayer = () => {
   const viewport = useViewport();
   const [canvas, setCanvas] = useState<HTMLElement | null>(null);
   const [context, setContext] = useState<WorkflowQuickAddContext>();
+  const [hoveredEdgeId, setHoveredEdgeId] = useState<string>();
 
   useEffect(() => {
     setCanvas(document.querySelector<HTMLElement>('.dify-workflow-canvas'));
@@ -241,21 +242,24 @@ const WorkflowQuickAddLayer = () => {
           </marker>
         </defs>
 
-        {curves.map(({ edge, path }) => (
-          <path
-            key={edge.id}
-            d={path}
-            fill="none"
-            stroke={edge.selected ? '#155eef' : '#a6afbd'}
-            strokeWidth={edge.selected ? 2 : 1.6}
-            strokeLinecap="round"
-            markerEnd={
-              edge.selected
-                ? 'url(#yak-workflow-edge-arrow-active)'
-                : 'url(#yak-workflow-edge-arrow)'
-            }
-          />
-        ))}
+        {curves.map(({ edge, path }) => {
+          const active = edge.selected || hoveredEdgeId === edge.id;
+          return (
+            <path
+              key={edge.id}
+              d={path}
+              fill="none"
+              stroke={active ? '#155eef' : '#a6afbd'}
+              strokeWidth={active ? 2 : 1.6}
+              strokeLinecap="round"
+              markerEnd={
+                active
+                  ? 'url(#yak-workflow-edge-arrow-active)'
+                  : 'url(#yak-workflow-edge-arrow)'
+              }
+            />
+          );
+        })}
       </svg>
 
       {curves.map((curve) => (
@@ -263,6 +267,8 @@ const WorkflowQuickAddLayer = () => {
           key={`${curve.edge.id}-quick-add`}
           className="pointer-events-auto absolute -translate-x-1/2 -translate-y-1/2"
           style={{ left: curve.middleX, top: curve.middleY }}
+          onMouseEnter={() => setHoveredEdgeId(curve.edge.id)}
+          onMouseLeave={() => setHoveredEdgeId(undefined)}
         >
           <QuickAddButton
             label="在连线中插入节点"

--- a/yak-ops-ui/src/pages/workflow-management/designer/components/quick-add/WorkflowQuickAddLayer.tsx
+++ b/yak-ops-ui/src/pages/workflow-management/designer/components/quick-add/WorkflowQuickAddLayer.tsx
@@ -137,12 +137,12 @@ const WorkflowQuickAddLayer = () => {
     : ['HTTP', 'SHELL', 'END'];
 
   const openNodePanel = (nodeId: string) => {
-    requestAnimationFrame(() => {
+    window.setTimeout(() => {
       const nodeElement = canvas?.querySelector<HTMLElement>(
         `.react-flow__node[data-id="${nodeId}"]`,
       );
       nodeElement?.click();
-    });
+    }, 0);
   };
 
   const addNode = (type: WorkflowNodeType) => {
@@ -213,7 +213,7 @@ const WorkflowQuickAddLayer = () => {
 
   if (!canvas) return null;
 
-  return createPortal(
+  const edgeLayer = (
     <div className="pointer-events-none absolute inset-0 z-[12]">
       <svg className="absolute inset-0 h-full w-full overflow-visible">
         <defs>
@@ -283,44 +283,50 @@ const WorkflowQuickAddLayer = () => {
           />
         </div>
       ))}
+    </div>
+  );
 
-      {context && (
-        <aside
-          className={[
-            'pointer-events-auto absolute bottom-0 right-0 top-0 z-50',
-            'flex w-[400px] max-w-full flex-col overflow-hidden',
-            'border-l border-[#e4e7ec] bg-white',
-            'shadow-[-12px_0_32px_rgba(16,24,40,0.10)]',
-          ].join(' ')}
-          onMouseDown={(event) => event.stopPropagation()}
-          onClick={(event) => event.stopPropagation()}
+  const pickerPanel = context ? (
+    <aside
+      className={[
+        'pointer-events-auto absolute bottom-0 right-0 top-0 z-[70]',
+        'flex w-[400px] max-w-full flex-col overflow-hidden',
+        'border-l border-[#e4e7ec] bg-white',
+        'shadow-[-12px_0_32px_rgba(16,24,40,0.10)]',
+      ].join(' ')}
+      onMouseDown={(event) => event.stopPropagation()}
+      onClick={(event) => event.stopPropagation()}
+    >
+      <header className="flex min-h-[64px] shrink-0 items-center justify-between border-b border-[#eaecf0] px-4">
+        <div>
+          <h3 className="m-0 text-[15px] font-semibold text-[#101828]">
+            {context.mode === 'insert' ? '在连线中添加节点' : '添加下一个节点'}
+          </h3>
+          <p className="mb-0 mt-1 text-[11px] text-[#98a2b3]">
+            {context.mode === 'insert'
+              ? '选择后会自动拆分当前连线，并把节点放在中间。'
+              : '选择后会自动连接到当前节点。'}
+          </p>
+        </div>
+        <button
+          type="button"
+          aria-label="关闭节点列表"
+          className="flex h-8 w-8 items-center justify-center rounded-lg border-0 bg-transparent text-[#667085] hover:bg-[#f2f4f7]"
+          onClick={() => setContext(undefined)}
         >
-          <header className="flex min-h-[64px] shrink-0 items-center justify-between border-b border-[#eaecf0] px-4">
-            <div>
-              <h3 className="m-0 text-[15px] font-semibold text-[#101828]">
-                {context.mode === 'insert' ? '在连线中添加节点' : '添加下一个节点'}
-              </h3>
-              <p className="mb-0 mt-1 text-[11px] text-[#98a2b3]">
-                {context.mode === 'insert'
-                  ? '选择后会自动拆分当前连线，并把节点放在中间。'
-                  : '选择后会自动连接到当前节点。'}
-              </p>
-            </div>
-            <button
-              type="button"
-              aria-label="关闭节点列表"
-              className="flex h-8 w-8 items-center justify-center rounded-lg border-0 bg-transparent text-[#667085] hover:bg-[#f2f4f7]"
-              onClick={() => setContext(undefined)}
-            >
-              <X size={17} />
-            </button>
-          </header>
+          <X size={17} />
+        </button>
+      </header>
 
-          <NodePicker allowedTypes={allowedTypes} onSelect={addNode} />
-        </aside>
-      )}
-    </div>,
-    canvas,
+      <NodePicker allowedTypes={allowedTypes} onSelect={addNode} />
+    </aside>
+  ) : null;
+
+  return (
+    <>
+      {createPortal(edgeLayer, canvas)}
+      {pickerPanel && createPortal(pickerPanel, canvas)}
+    </>
   );
 };
 

--- a/yak-ops-ui/src/pages/workflow-management/designer/components/quick-add/events.test.ts
+++ b/yak-ops-ui/src/pages/workflow-management/designer/components/quick-add/events.test.ts
@@ -1,0 +1,41 @@
+import {
+  WORKFLOW_QUICK_ADD_EVENT,
+  openWorkflowQuickAdd,
+  type WorkflowQuickAddContext,
+} from './events';
+
+describe('workflow quick-add events', () => {
+  it('dispatches append context for shared add triggers', () => {
+    const listener = jest.fn();
+    window.addEventListener(WORKFLOW_QUICK_ADD_EVENT, listener);
+
+    const context: WorkflowQuickAddContext = {
+      mode: 'append',
+      sourceNodeId: 'http_1',
+    };
+    openWorkflowQuickAdd(context);
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect((listener.mock.calls[0][0] as CustomEvent).detail).toEqual(context);
+
+    window.removeEventListener(WORKFLOW_QUICK_ADD_EVENT, listener);
+  });
+
+  it('keeps edge insertion metadata intact', () => {
+    const listener = jest.fn();
+    window.addEventListener(WORKFLOW_QUICK_ADD_EVENT, listener);
+
+    const context: WorkflowQuickAddContext = {
+      mode: 'insert',
+      sourceNodeId: 'http_1',
+      targetNodeId: 'shell_1',
+      edgeId: 'edge_http_shell',
+      position: { x: 320, y: 180 },
+    };
+    openWorkflowQuickAdd(context);
+
+    expect((listener.mock.calls[0][0] as CustomEvent).detail).toEqual(context);
+
+    window.removeEventListener(WORKFLOW_QUICK_ADD_EVENT, listener);
+  });
+});

--- a/yak-ops-ui/src/pages/workflow-management/designer/components/quick-add/events.ts
+++ b/yak-ops-ui/src/pages/workflow-management/designer/components/quick-add/events.ts
@@ -1,0 +1,24 @@
+export type WorkflowQuickAddMode = 'append' | 'insert';
+
+export interface WorkflowQuickAddPoint {
+  x: number;
+  y: number;
+}
+
+export interface WorkflowQuickAddContext {
+  mode: WorkflowQuickAddMode;
+  sourceNodeId: string;
+  targetNodeId?: string;
+  edgeId?: string;
+  position?: WorkflowQuickAddPoint;
+}
+
+export const WORKFLOW_QUICK_ADD_EVENT = 'yak-workflow-open-quick-add';
+
+export const openWorkflowQuickAdd = (context: WorkflowQuickAddContext) => {
+  window.dispatchEvent(
+    new CustomEvent<WorkflowQuickAddContext>(WORKFLOW_QUICK_ADD_EVENT, {
+      detail: context,
+    }),
+  );
+};

--- a/yak-ops-ui/src/pages/workflow-management/designer/index.less
+++ b/yak-ops-ui/src/pages/workflow-management/designer/index.less
@@ -76,15 +76,17 @@
   cursor: crosshair;
 }
 
-.dify-workflow-canvas .react-flow__edge-path {
-  stroke: #a6afbd;
-  stroke-width: 1.5;
-}
-
+/* The visible edge is rendered by WorkflowQuickAddLayer. Keep React Flow's
+ * interaction path so selection and context menus still work. */
+.dify-workflow-canvas .react-flow__edge-path,
 .dify-workflow-canvas .react-flow__edge.selected .react-flow__edge-path,
 .dify-workflow-canvas .react-flow__edge:hover .react-flow__edge-path {
-  stroke: #155eef;
-  stroke-width: 2;
+  stroke: transparent !important;
+  marker-end: none !important;
+}
+
+.dify-workflow-canvas .react-flow__edge-interaction {
+  stroke-width: 24;
 }
 
 .dify-workflow-canvas .react-flow__selection {


### PR DESCRIPTION
## 改动说明

- 将工作流连线视觉调整为 Dify 风格三次贝塞尔曲线，并保留 React Flow 原有边选择、右键菜单和交互命中区域。
- 鼠标移动到连线中点时显示 `+`，点击后从右侧打开节点列表；选择节点后自动拆分原连线并把新节点插入中间。
- 放大节点输入/输出连接热区，输出端改为悬停显示的圆形 `+`，点击后从右侧选择并自动连接下一个节点。
- 每个非结束节点的配置 Panel 新增“下一步”区域：
  - 展示当前后续节点；
  - 点击后续节点可定位并切换到对应节点 Panel；
  - 支持添加后续节点或并行节点。
- 抽取公共快速添加能力：
  - `QuickAddButton`：节点、连线、Panel 共用的添加触发器；
  - `NodePicker`：统一节点搜索与选择列表；
  - `WorkflowQuickAddLayer`：统一处理曲线绘制、右侧选择面板、追加节点与连线中插入节点；
  - `events.ts`：统一快速添加事件契约。
- 增加快速添加事件单元测试，覆盖节点追加与连线插入上下文。

## 交互结果

1. 节点右侧悬停出现较大的 `+`，点击后右侧显示节点列表。
2. 连线中点悬停出现 `+`，选择 HTTP/Shell 后原连线自动变为：`源节点 -> 新节点 -> 目标节点`。
3. Panel 的“下一步”可以直接查看和进入后续节点，也可以继续添加节点。
4. 新增节点后画布自动聚焦，并尝试直接打开新节点的配置 Panel。

## 验证建议

```bash
cd yak-ops-ui
npm run tsc
npm test -- --runInBand
```

> 当前连接环境无法拉取仓库依赖并在本地执行命令，因此本 PR 提交了针对性的测试代码，但没有宣称本地构建已经通过。