### PR TITLE
fix(offline-sync): align create flow with canonical routes

### DIFF
--- a/yak-ops-ui/src/pages/batch-link-up/api.ts
+++ b/yak-ops-ui/src/pages/batch-link-up/api.ts
@@ -19,6 +19,9 @@ export interface LinkupJobDefinition {
 
 export const apiPrefix = '/api/v1/job/batch-definition';
 
+const normalizeLegacySuccessCode = <T extends { code: number }>(response: T): T =>
+  response?.code === 200 ? ({ ...response, code: 0 } as T) : response;
+
 export const linkupJobDefinitionApi = {
   /**
    * SCRIPT 模式保存/更新
@@ -56,8 +59,19 @@ export const linkupJobDefinitionApi = {
     return HttpUtils.get(`${apiPrefix}/${id}/edit-detail`);
   },
 
-  getUniqueId: (): Promise<{ code: number; data: LinkupJobDefinition; message?: string }> => {
-    return HttpUtils.get(`${apiPrefix}/get-unique-id`);
+  /**
+   * 列表页仍按历史约定以 code=0 判断成功。
+   * 这里兼容统一响应协议的 code=200，避免新建入口被误判为失败。
+   */
+  getUniqueId: async (): Promise<{
+    code: number;
+    data: LinkupJobDefinition;
+    message?: string;
+  }> => {
+    const response = await HttpUtils.get<LinkupJobDefinition>(
+      `${apiPrefix}/get-unique-id`,
+    );
+    return normalizeLegacySuccessCode(response);
   },
 
   delete: (id: string) => {

--- a/yak-ops-ui/src/pages/batch-link-up/detail/index.tsx
+++ b/yak-ops-ui/src/pages/batch-link-up/detail/index.tsx
@@ -4,7 +4,7 @@ import {
   CheckCircleFilled,
   SaveOutlined,
 } from '@ant-design/icons';
-import { history, useLocation } from '@umijs/max';
+import { history, useLocation, useParams } from '@umijs/max';
 import {
   Button,
   Drawer,
@@ -108,8 +108,16 @@ const validateTaskConfig = (editor: SyncEditorState): string | null => {
 
 export default function BatchLinkUpDetailPage() {
   const location = useLocation();
+  const routeParams = useParams<{ id?: string }>();
   const taskId = useMemo(
-    () => new URLSearchParams(location.search).get('id') || '',
+    () =>
+      routeParams.id ||
+      new URLSearchParams(location.search).get('id') ||
+      '',
+    [location.search, routeParams.id],
+  );
+  const editScene = useMemo(
+    () => new URLSearchParams(location.search).get('scene') === 'edit',
     [location.search],
   );
 
@@ -126,6 +134,7 @@ export default function BatchLinkUpDetailPage() {
   const [targetState, setTargetState] =
     useState<ConnectionTestState>('idle');
   const [scheduleOpen, setScheduleOpen] = useState(false);
+  const [createOpen, setCreateOpen] = useState(false);
 
   const loadDataSources = useCallback(async () => {
     try {
@@ -174,8 +183,18 @@ export default function BatchLinkUpDetailPage() {
 
   useEffect(() => {
     if (!taskId) return;
+
+    const cacheKey = `batch-link-up-detail-${taskId}`;
+    const hasCreateCache = Boolean(sessionStorage.getItem(cacheKey));
+    if (hasCreateCache && !editScene) {
+      setCreateOpen(true);
+      void loadDataSources();
+      return;
+    }
+
+    setCreateOpen(false);
     void Promise.all([loadTask(), loadDataSources()]);
-  }, [loadDataSources, loadTask, taskId]);
+  }, [editScene, loadDataSources, loadTask, taskId]);
 
   const persistEditor = async (
     nextEditor: SyncEditorState,
@@ -209,7 +228,9 @@ export default function BatchLinkUpDetailPage() {
     }
   };
 
-  const testConnection = async (endpoint: 'source' | 'target') => {
+  const testConnection = async (
+    endpoint: 'source' | 'target',
+  ) => {
     const id = endpoint === 'source' ? sourceId : targetId;
     const setState = endpoint === 'source' ? setSourceState : setTargetState;
     if (!id) {
@@ -267,17 +288,31 @@ export default function BatchLinkUpDetailPage() {
   };
 
   if (!taskId) {
+    history.replace('/sync/batch-link-up');
+    return null;
+  }
+
+  if (createOpen) {
+    const cacheKey = `batch-link-up-detail-${taskId}`;
     return (
       <div className="relative min-h-screen bg-[#f8fafc]">
         <BatchLinkUpPage />
         <CreateSyncTaskModal
           open
-          onCancel={() => history.push('/batch-link-up')}
-          onCreated={(id) =>
-            history.replace(
-              `/batch-link-up/detail?id=${encodeURIComponent(id)}`,
-            )
-          }
+          reservedTaskId={taskId}
+          onCancel={() => {
+            sessionStorage.removeItem(cacheKey);
+            history.push('/sync/batch-link-up');
+          }}
+          onCreated={(id) => {
+            sessionStorage.removeItem(cacheKey);
+            setCreateOpen(false);
+            const nextPath = `/sync/batch-link-up/${encodeURIComponent(id)}/detail?scene=edit`;
+            history.replace(nextPath);
+            if (String(id) === String(taskId)) {
+              void loadTask();
+            }
+          }}
         />
       </div>
     );
@@ -298,7 +333,7 @@ export default function BatchLinkUpDetailPage() {
           description="未找到同步任务"
           image={Empty.PRESENTED_IMAGE_SIMPLE}
         >
-          <Button onClick={() => history.push('/batch-link-up')}>
+          <Button onClick={() => history.push('/sync/batch-link-up')}>
             返回任务列表
           </Button>
         </Empty>
@@ -316,7 +351,7 @@ export default function BatchLinkUpDetailPage() {
             <Button
               type="text"
               icon={<ArrowLeftOutlined />}
-              onClick={() => history.push('/batch-link-up')}
+              onClick={() => history.push('/sync/batch-link-up')}
             />
             <div className="min-w-0">
               <div className="flex items-center gap-2">
@@ -331,16 +366,18 @@ export default function BatchLinkUpDetailPage() {
             </div>
           </div>
 
-          {activeStep === 1 && (
-            <Button
-              type="primary"
-              icon={<SaveOutlined />}
-              loading={saving}
-              onClick={handleSave}
-            >
-              保存配置
-            </Button>
-          )}
+          <div className="flex items-center gap-2">
+            {activeStep === 1 && (
+              <Button
+                type="primary"
+                icon={<SaveOutlined />}
+                loading={saving}
+                onClick={handleSave}
+              >
+                保存配置
+              </Button>
+            )}
+          </div>
         </div>
       </div>
 
@@ -390,7 +427,7 @@ export default function BatchLinkUpDetailPage() {
             当前阶段仅保存任务定义，不会触发任务执行。
           </div>
           <div className="flex items-center gap-2">
-            <Button onClick={() => history.push('/batch-link-up')}>取消</Button>
+            <Button onClick={() => history.push('/sync/batch-link-up')}>取消</Button>
             {activeStep === 0 ? (
               <Button
                 type="primary"


### PR DESCRIPTION
## 关联

- Follow-up to #116（主体功能已合并）

## 修复内容

- 详情页改为读取仓库现有动态路由 `/sync/batch-link-up/:id/detail`
- 识别列表页预申请的草稿任务 ID，并在详情路由上弹出新建任务 Modal
- 新建成功后清理 sessionStorage 草稿缓存，并切换为编辑场景
- 旧单表/多表入口继续统一进入新的两步编辑页面
- 兼容 `getUniqueId` 接口统一响应 `code=200` 与旧列表页 `code=0` 判断，避免新建入口误报失败

## 验证

- 9 个相关 TypeScript/TSX 文件通过 `transpileModule` 语法检查
- 数据模型行为校验通过：创建 payload、编辑详情归一化、Source/Sink 连接选择
- 分支基于最新 `main`，仅修改 2 个文件，无落后提交

## 说明

该 PR 只补齐 #116 合并时尚未包含的路由与响应兼容修复，不改变已合并的页面设计和任务配置结构。