### PR TITLE
feat(realtime-sync): add Flink CDC task configuration UI

### DIFF
--- a/yak-ops-ui/src/pages/realtime-link-up/components/CommonConfigPanels.tsx
+++ b/yak-ops-ui/src/pages/realtime-link-up/components/CommonConfigPanels.tsx
@@ -1,0 +1,386 @@
+import { Database, Gauge, Settings2 } from 'lucide-react';
+import { Input, InputNumber, Select, Switch } from 'antd';
+import type { ReactNode } from 'react';
+import { sinkDataSourceOptions, sourceDataSourceOptions } from '../data';
+import type { PipelineConfig, SinkConfig, SourceConfig } from '../types';
+
+const { TextArea } = Input;
+
+const Card = ({
+  title,
+  description,
+  icon,
+  children,
+}: {
+  title: string;
+  description: string;
+  icon: ReactNode;
+  children: ReactNode;
+}) => (
+  <section className="overflow-hidden rounded-[10px] border border-black/[0.07] bg-white">
+    <div className="flex items-start gap-3 border-b border-black/[0.055] px-5 py-4">
+      <span className="mt-0.5 flex h-8 w-8 items-center justify-center rounded-[8px] bg-[#f1f3f6] text-[#424754]">
+        {icon}
+      </span>
+      <div>
+        <div className="text-[13px] font-semibold text-[#161823]">{title}</div>
+        <div className="mt-1 text-[11px] text-[rgba(22,24,35,0.46)]">{description}</div>
+      </div>
+    </div>
+    <div className="p-5">{children}</div>
+  </section>
+);
+
+const Field = ({
+  label,
+  required,
+  help,
+  children,
+}: {
+  label: string;
+  required?: boolean;
+  help?: string;
+  children: ReactNode;
+}) => (
+  <label className="block">
+    <span className="mb-2 flex items-center gap-1 text-[11px] font-semibold text-[#343741]">
+      {label}
+      {required && <span className="text-[#d92d20]">*</span>}
+    </span>
+    {children}
+    {help && <span className="mt-1.5 block text-[10px] leading-4 text-[rgba(22,24,35,0.42)]">{help}</span>}
+  </label>
+);
+
+interface PipelineBasicPanelProps {
+  value: PipelineConfig;
+  onChange: (value: PipelineConfig) => void;
+}
+
+export const PipelineBasicPanel = ({ value, onChange }: PipelineBasicPanelProps) => (
+  <Card
+    title="任务基本信息"
+    description="定义实时同步任务名称、描述以及运行时版本。"
+    icon={<Settings2 size={17} strokeWidth={1.8} />}
+  >
+    <div className="grid grid-cols-2 gap-5 max-lg:grid-cols-1">
+      <Field label="任务名称" required>
+        <Input
+          value={value.name}
+          onChange={(event) => onChange({ ...value, name: event.target.value })}
+          placeholder="请输入任务名称"
+          className="!h-10 !rounded-[7px] !border-black/[0.075] !text-[12px]"
+        />
+      </Field>
+      <div className="grid grid-cols-2 gap-3">
+        <Field label="Flink 版本" required>
+          <Select
+            value={value.flinkVersion}
+            options={[
+              { label: 'Flink 2.2.1（推荐）', value: '2.2.1' },
+              { label: 'Flink 2.2.0', value: '2.2.0' },
+              { label: 'Flink 1.20.2', value: '1.20.2' },
+            ]}
+            onChange={(flinkVersion) => onChange({ ...value, flinkVersion })}
+            className="w-full [&_.ant-select-selector]:!h-10 [&_.ant-select-selector]:!rounded-[7px] [&_.ant-select-selector]:!border-black/[0.075] [&_.ant-select-selection-item]:!text-[11px] [&_.ant-select-selection-item]:!leading-[38px]"
+          />
+        </Field>
+        <Field label="Flink CDC 版本" required>
+          <Select
+            value={value.cdcVersion}
+            options={[
+              { label: 'CDC 3.6.0（推荐）', value: '3.6.0' },
+              { label: 'CDC 3.5.0', value: '3.5.0' },
+            ]}
+            onChange={(cdcVersion) => onChange({ ...value, cdcVersion })}
+            className="w-full [&_.ant-select-selector]:!h-10 [&_.ant-select-selector]:!rounded-[7px] [&_.ant-select-selector]:!border-black/[0.075] [&_.ant-select-selection-item]:!text-[11px] [&_.ant-select-selection-item]:!leading-[38px]"
+          />
+        </Field>
+      </div>
+      <div className="col-span-2 max-lg:col-span-1">
+        <Field label="任务描述">
+          <TextArea
+            value={value.description}
+            onChange={(event) => onChange({ ...value, description: event.target.value })}
+            placeholder="说明同步范围、业务用途与维护信息"
+            autoSize={{ minRows: 3, maxRows: 5 }}
+            className="!rounded-[7px] !border-black/[0.075] !text-[12px]"
+          />
+        </Field>
+      </div>
+    </div>
+  </Card>
+);
+
+interface SourceSinkPanelProps {
+  source: SourceConfig;
+  sink: SinkConfig;
+  multi?: boolean;
+  onSourceChange: (value: SourceConfig) => void;
+  onSinkChange: (value: SinkConfig) => void;
+}
+
+export const SourceSinkPanel = ({
+  source,
+  sink,
+  multi,
+  onSourceChange,
+  onSinkChange,
+}: SourceSinkPanelProps) => (
+  <div className="grid grid-cols-2 gap-5 max-xl:grid-cols-1">
+    <Card
+      title="来源端"
+      description="选择已维护的数据源，并配置 Flink CDC Source 的采集范围。"
+      icon={<Database size={17} strokeWidth={1.8} />}
+    >
+      <div className="space-y-4">
+        <Field label="来源数据源" required>
+          <Select
+            showSearch
+            value={source.dataSourceId}
+            options={sourceDataSourceOptions}
+            onChange={(dataSourceId, option: any) =>
+              onSourceChange({ ...source, dataSourceId, type: option.type })
+            }
+            className="w-full [&_.ant-select-selector]:!h-10 [&_.ant-select-selector]:!rounded-[7px] [&_.ant-select-selector]:!border-black/[0.075] [&_.ant-select-selection-item]:!text-[11px] [&_.ant-select-selection-item]:!leading-[38px]"
+          />
+        </Field>
+
+        <div className="grid grid-cols-2 gap-3">
+          <Field label="数据库" required>
+            <Input
+              value={source.database}
+              onChange={(event) => onSourceChange({ ...source, database: event.target.value })}
+              placeholder="trade_db"
+              className="!h-9 !rounded-[7px] !border-black/[0.075] !font-mono !text-[11px]"
+            />
+          </Field>
+          <Field label="Schema" help="MySQL 可留空">
+            <Input
+              value={source.schema}
+              onChange={(event) => onSourceChange({ ...source, schema: event.target.value })}
+              placeholder="public"
+              className="!h-9 !rounded-[7px] !border-black/[0.075] !font-mono !text-[11px]"
+            />
+          </Field>
+        </div>
+
+        {multi ? (
+          <Field
+            label="表匹配规则"
+            required
+            help="支持 Flink CDC source-table 正则，例如 trade_db.order_.*"
+          >
+            <Input
+              value={source.tablePattern}
+              onChange={(event) => onSourceChange({ ...source, tablePattern: event.target.value })}
+              placeholder="trade_db.order_.*"
+              className="!h-9 !rounded-[7px] !border-black/[0.075] !font-mono !text-[11px]"
+            />
+          </Field>
+        ) : (
+          <Field label="来源表" required>
+            <Input
+              value={source.table}
+              onChange={(event) => onSourceChange({ ...source, table: event.target.value })}
+              placeholder="order_main"
+              className="!h-9 !rounded-[7px] !border-black/[0.075] !font-mono !text-[11px]"
+            />
+          </Field>
+        )}
+
+        <div className="grid grid-cols-2 gap-3">
+          <Field label="启动模式" required>
+            <Select
+              value={source.startupMode}
+              options={[
+                { label: '全量 + 增量（initial）', value: 'initial' },
+                { label: '仅最新增量', value: 'latest-offset' },
+                { label: '指定 Offset', value: 'specific-offset' },
+                { label: '指定时间戳', value: 'timestamp' },
+              ]}
+              onChange={(startupMode) => onSourceChange({ ...source, startupMode })}
+              className="w-full [&_.ant-select-selector]:!h-9 [&_.ant-select-selector]:!rounded-[7px] [&_.ant-select-selector]:!border-black/[0.075] [&_.ant-select-selection-item]:!text-[10px] [&_.ant-select-selection-item]:!leading-[34px]"
+            />
+          </Field>
+          <Field label="Server ID" required={source.type === 'mysql'}>
+            <Input
+              value={source.serverId}
+              disabled={source.type !== 'mysql'}
+              onChange={(event) => onSourceChange({ ...source, serverId: event.target.value })}
+              placeholder="5400-5404"
+              className="!h-9 !rounded-[7px] !border-black/[0.075] !font-mono !text-[11px]"
+            />
+          </Field>
+        </div>
+      </div>
+    </Card>
+
+    <Card
+      title="目标端"
+      description="选择下游存储并配置目标库表与 Schema Evolution 策略。"
+      icon={<Database size={17} strokeWidth={1.8} />}
+    >
+      <div className="space-y-4">
+        <Field label="目标数据源" required>
+          <Select
+            showSearch
+            value={sink.dataSourceId}
+            options={sinkDataSourceOptions}
+            onChange={(dataSourceId, option: any) =>
+              onSinkChange({ ...sink, dataSourceId, type: option.type })
+            }
+            className="w-full [&_.ant-select-selector]:!h-10 [&_.ant-select-selector]:!rounded-[7px] [&_.ant-select-selector]:!border-black/[0.075] [&_.ant-select-selection-item]:!text-[11px] [&_.ant-select-selection-item]:!leading-[38px]"
+          />
+        </Field>
+
+        <div className="grid grid-cols-2 gap-3">
+          <Field label="目标数据库" required>
+            <Input
+              value={sink.database}
+              onChange={(event) => onSinkChange({ ...sink, database: event.target.value })}
+              placeholder="ods_db"
+              className="!h-9 !rounded-[7px] !border-black/[0.075] !font-mono !text-[11px]"
+            />
+          </Field>
+          <Field label="目标 Schema">
+            <Input
+              value={sink.schema}
+              onChange={(event) => onSinkChange({ ...sink, schema: event.target.value })}
+              placeholder="ods"
+              className="!h-9 !rounded-[7px] !border-black/[0.075] !font-mono !text-[11px]"
+            />
+          </Field>
+        </div>
+
+        {multi ? (
+          <div className="grid grid-cols-2 gap-3">
+            <Field label="目标表前缀">
+              <Input
+                value={sink.tablePrefix}
+                onChange={(event) => onSinkChange({ ...sink, tablePrefix: event.target.value })}
+                placeholder="ods_"
+                className="!h-9 !rounded-[7px] !border-black/[0.075] !font-mono !text-[11px]"
+              />
+            </Field>
+            <Field label="目标表后缀">
+              <Input
+                value={sink.tableSuffix}
+                onChange={(event) => onSinkChange({ ...sink, tableSuffix: event.target.value })}
+                placeholder="_rt"
+                className="!h-9 !rounded-[7px] !border-black/[0.075] !font-mono !text-[11px]"
+              />
+            </Field>
+          </div>
+        ) : (
+          <Field label="目标表" required>
+            <Input
+              value={sink.table}
+              onChange={(event) => onSinkChange({ ...sink, table: event.target.value })}
+              placeholder="ods_order_main"
+              className="!h-9 !rounded-[7px] !border-black/[0.075] !font-mono !text-[11px]"
+            />
+          </Field>
+        )}
+
+        <Field label="Schema 变更策略" required>
+          <Select
+            value={sink.schemaChangeBehavior}
+            options={[
+              { label: 'evolve - 自动应用结构变更', value: 'evolve' },
+              { label: 'try_evolve - 尝试应用', value: 'try_evolve' },
+              { label: 'lenient - 宽松模式', value: 'lenient' },
+              { label: 'ignore - 忽略变更', value: 'ignore' },
+              { label: 'exception - 发生变更即失败', value: 'exception' },
+            ]}
+            onChange={(schemaChangeBehavior) =>
+              onSinkChange({ ...sink, schemaChangeBehavior })
+            }
+            className="w-full [&_.ant-select-selector]:!h-9 [&_.ant-select-selector]:!rounded-[7px] [&_.ant-select-selector]:!border-black/[0.075] [&_.ant-select-selection-item]:!text-[10px] [&_.ant-select-selection-item]:!leading-[34px]"
+          />
+        </Field>
+
+        <div className="flex items-center justify-between rounded-[8px] border border-black/[0.06] bg-[#fafafa] px-4 py-3">
+          <div>
+            <div className="text-[11px] font-semibold text-[#343741]">自动创建下游表</div>
+            <div className="mt-0.5 text-[10px] text-[rgba(22,24,35,0.42)]">
+              目标表不存在时，根据上游 Schema 自动建表。
+            </div>
+          </div>
+          <Switch
+            size="small"
+            checked={sink.createTable}
+            onChange={(createTable) => onSinkChange({ ...sink, createTable })}
+          />
+        </div>
+      </div>
+    </Card>
+  </div>
+);
+
+interface PipelineRuntimePanelProps {
+  value: PipelineConfig;
+  onChange: (value: PipelineConfig) => void;
+}
+
+export const PipelineRuntimePanel = ({ value, onChange }: PipelineRuntimePanelProps) => (
+  <Card
+    title="运行参数"
+    description="配置并行度、Checkpoint、本地时区和故障重启策略。"
+    icon={<Gauge size={17} strokeWidth={1.8} />}
+  >
+    <div className="grid grid-cols-3 gap-5 max-xl:grid-cols-2 max-lg:grid-cols-1">
+      <Field label="并行度" required>
+        <InputNumber
+          min={1}
+          max={512}
+          value={value.parallelism}
+          onChange={(parallelism) => onChange({ ...value, parallelism: Number(parallelism || 1) })}
+          className="!h-10 !w-full !rounded-[7px] !border-black/[0.075] [&_.ant-input-number-input]:!h-9 [&_.ant-input-number-input]:!text-[11px]"
+        />
+      </Field>
+      <Field label="Checkpoint 间隔（秒）" required>
+        <InputNumber
+          min={10}
+          value={value.checkpointInterval}
+          onChange={(checkpointInterval) =>
+            onChange({ ...value, checkpointInterval: Number(checkpointInterval || 60) })
+          }
+          className="!h-10 !w-full !rounded-[7px] !border-black/[0.075] [&_.ant-input-number-input]:!h-9 [&_.ant-input-number-input]:!text-[11px]"
+        />
+      </Field>
+      <Field label="故障重启策略" required>
+        <Select
+          value={value.restartStrategy}
+          options={[
+            { label: '固定延迟重启', value: 'fixed-delay' },
+            { label: '失败率重启', value: 'failure-rate' },
+            { label: '不自动重启', value: 'none' },
+          ]}
+          onChange={(restartStrategy) => onChange({ ...value, restartStrategy })}
+          className="w-full [&_.ant-select-selector]:!h-10 [&_.ant-select-selector]:!rounded-[7px] [&_.ant-select-selector]:!border-black/[0.075] [&_.ant-select-selection-item]:!text-[11px] [&_.ant-select-selection-item]:!leading-[38px]"
+        />
+      </Field>
+      <Field label="本地时区" required>
+        <Select
+          showSearch
+          value={value.localTimezone}
+          options={[
+            { label: 'Asia/Shanghai', value: 'Asia/Shanghai' },
+            { label: 'Asia/Tokyo', value: 'Asia/Tokyo' },
+            { label: 'UTC', value: 'UTC' },
+          ]}
+          onChange={(localTimezone) => onChange({ ...value, localTimezone })}
+          className="w-full [&_.ant-select-selector]:!h-10 [&_.ant-select-selector]:!rounded-[7px] [&_.ant-select-selector]:!border-black/[0.075] [&_.ant-select-selection-item]:!text-[11px] [&_.ant-select-selection-item]:!leading-[38px]"
+        />
+      </Field>
+      <Field label="Schema Operator UID" required>
+        <Input
+          value={value.schemaOperatorUid}
+          onChange={(event) => onChange({ ...value, schemaOperatorUid: event.target.value })}
+          className="!h-10 !rounded-[7px] !border-black/[0.075] !font-mono !text-[11px]"
+        />
+      </Field>
+    </div>
+  </Card>
+);

--- a/yak-ops-ui/src/pages/realtime-link-up/components/ConfigShell.tsx
+++ b/yak-ops-ui/src/pages/realtime-link-up/components/ConfigShell.tsx
@@ -1,0 +1,176 @@
+import { ArrowLeft, CheckCircle2, Code2, Save } from 'lucide-react';
+import { history } from '@umijs/max';
+import { Button, Drawer, Tag } from 'antd';
+import { useState, type ReactNode } from 'react';
+import { modeMeta } from '../data';
+import type { RealtimeTaskMode } from '../types';
+
+export interface ConfigStep {
+  key: string;
+  title: string;
+  description: string;
+  complete?: boolean;
+}
+
+interface ConfigShellProps {
+  taskId: string;
+  mode: RealtimeTaskMode;
+  title: string;
+  description?: string;
+  steps: ConfigStep[];
+  activeStep: string;
+  onStepChange: (key: string) => void;
+  yaml: string;
+  saving?: boolean;
+  onSave: () => void;
+  children: ReactNode;
+  footer?: ReactNode;
+}
+
+const ConfigShell = ({
+  taskId,
+  mode,
+  title,
+  description,
+  steps,
+  activeStep,
+  onStepChange,
+  yaml,
+  saving,
+  onSave,
+  children,
+  footer,
+}: ConfigShellProps) => {
+  const [previewOpen, setPreviewOpen] = useState(false);
+  const meta = modeMeta[mode];
+  const completeCount = steps.filter((step) => step.complete).length;
+
+  return (
+    <div className="min-h-[calc(100vh-48px)] bg-[#f7f8fa]">
+      <header className="sticky top-0 z-20 border-b border-black/[0.07] bg-white/95 backdrop-blur">
+        <div className="flex h-[66px] items-center justify-between gap-4 px-5">
+          <div className="flex min-w-0 items-center gap-3">
+            <button
+              type="button"
+              aria-label="返回实时同步任务列表"
+              onClick={() => history.push('/sync/realtime-link-up')}
+              className="flex h-9 w-9 shrink-0 items-center justify-center rounded-[8px] border border-black/[0.07] bg-white text-[rgba(22,24,35,0.62)] transition hover:border-black/[0.14] hover:text-[#161823]"
+            >
+              <ArrowLeft size={17} strokeWidth={1.9} />
+            </button>
+
+            <div className="min-w-0">
+              <div className="flex items-center gap-2">
+                <h1 className="truncate text-[17px] font-semibold text-[#161823]">
+                  {title}
+                </h1>
+                <Tag
+                  className={`!m-0 !rounded-full !px-2.5 !py-0.5 !text-[11px] ${meta.className}`}
+                >
+                  {meta.label}
+                </Tag>
+                <span className="text-[11px] text-[rgba(22,24,35,0.38)]">
+                  ID: {taskId}
+                </span>
+              </div>
+              <div className="mt-0.5 truncate text-[11px] text-[rgba(22,24,35,0.45)]">
+                {description || meta.description}
+              </div>
+            </div>
+          </div>
+
+          <div className="flex shrink-0 items-center gap-2">
+            <Button
+              icon={<Code2 size={15} strokeWidth={1.8} />}
+              onClick={() => setPreviewOpen(true)}
+              className="!h-9 !rounded-[8px] !border-black/[0.08] !text-[12px]"
+            >
+              YAML 预览
+            </Button>
+            <Button
+              type="primary"
+              icon={<Save size={15} strokeWidth={1.9} />}
+              loading={saving}
+              onClick={onSave}
+              className="!h-9 !rounded-[8px] !border-[#161823] !bg-[#161823] !px-4 !text-[12px] hover:!border-[#2b2d38] hover:!bg-[#2b2d38]"
+            >
+              保存草稿
+            </Button>
+          </div>
+        </div>
+      </header>
+
+      <div className="flex min-h-[calc(100vh-114px)]">
+        <aside className="sticky top-[66px] h-[calc(100vh-66px)] w-[246px] shrink-0 border-r border-black/[0.065] bg-white px-4 py-5">
+          <div className="mb-4 flex items-center justify-between px-2">
+            <span className="text-[12px] font-semibold text-[#161823]">配置步骤</span>
+            <span className="text-[10px] text-[rgba(22,24,35,0.42)]">
+              {completeCount}/{steps.length}
+            </span>
+          </div>
+
+          <div className="space-y-1.5">
+            {steps.map((step, index) => {
+              const active = step.key === activeStep;
+              return (
+                <button
+                  key={step.key}
+                  type="button"
+                  onClick={() => onStepChange(step.key)}
+                  className={[
+                    'group flex w-full items-start gap-3 rounded-[8px] border-0 px-3 py-3 text-left transition',
+                    active
+                      ? 'bg-[#f1f3f6] text-[#161823]'
+                      : 'bg-transparent text-[rgba(22,24,35,0.58)] hover:bg-[#f8f8f9] hover:text-[#161823]',
+                  ].join(' ')}
+                >
+                  <span
+                    className={[
+                      'mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full border text-[10px] font-semibold',
+                      step.complete
+                        ? 'border-[#b7e4cf] bg-[#edf9f3] text-[#16845b]'
+                        : active
+                          ? 'border-[#161823] bg-[#161823] text-white'
+                          : 'border-black/[0.10] bg-white text-[rgba(22,24,35,0.42)]',
+                    ].join(' ')}
+                  >
+                    {step.complete ? <CheckCircle2 size={14} strokeWidth={2} /> : index + 1}
+                  </span>
+                  <span className="min-w-0 flex-1">
+                    <span className="block text-[12px] font-semibold">{step.title}</span>
+                    <span className="mt-0.5 block text-[10px] leading-4 text-[rgba(22,24,35,0.42)]">
+                      {step.description}
+                    </span>
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+        </aside>
+
+        <main className="min-w-0 flex-1 px-6 py-6">
+          <div className="mx-auto max-w-[1380px]">{children}</div>
+        </main>
+      </div>
+
+      {footer}
+
+      <Drawer
+        title="Flink CDC Pipeline YAML"
+        width={620}
+        open={previewOpen}
+        onClose={() => setPreviewOpen(false)}
+        styles={{ body: { padding: 0 } }}
+      >
+        <div className="border-b border-black/[0.06] bg-[#fafafa] px-5 py-3 text-[11px] text-[rgba(22,24,35,0.50)]">
+          当前内容由页面配置实时生成，保存草稿时会与结构化配置一并保存。
+        </div>
+        <pre className="m-0 min-h-[calc(100vh-112px)] overflow-auto bg-[#101318] p-5 font-mono text-[12px] leading-6 text-[#d7dce2]">
+          {yaml}
+        </pre>
+      </Drawer>
+    </div>
+  );
+};
+
+export default ConfigShell;

--- a/yak-ops-ui/src/pages/realtime-link-up/components/TransformEditor.tsx
+++ b/yak-ops-ui/src/pages/realtime-link-up/components/TransformEditor.tsx
@@ -1,0 +1,492 @@
+import { Braces, KeyRound, Plus, Sigma, TableProperties, Trash2 } from 'lucide-react';
+import { Button, Checkbox, Collapse, Empty, Input, Select, Tag } from 'antd';
+import { useMemo, type ReactNode } from 'react';
+import { createDefaultUdf, transformFunctionGroups } from '../data';
+import type {
+  ColumnMapping,
+  TableOptionEntry,
+  TransformRule,
+  UdfDefinition,
+  UdfOptionEntry,
+} from '../types';
+
+const { TextArea } = Input;
+const createId = (prefix: string) =>
+  `${prefix}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+
+const Section = ({
+  icon,
+  title,
+  description,
+  extra,
+  children,
+}: {
+  icon: ReactNode;
+  title: string;
+  description: string;
+  extra?: ReactNode;
+  children: ReactNode;
+}) => (
+  <section className="overflow-hidden rounded-[10px] border border-black/[0.07] bg-white">
+    <div className="flex items-start justify-between gap-4 border-b border-black/[0.055] px-5 py-4">
+      <div className="flex items-start gap-3">
+        <span className="mt-0.5 flex h-8 w-8 items-center justify-center rounded-[8px] bg-[#f1f3f6] text-[#424754]">
+          {icon}
+        </span>
+        <div>
+          <div className="text-[13px] font-semibold text-[#161823]">{title}</div>
+          <div className="mt-1 text-[11px] leading-5 text-[rgba(22,24,35,0.46)]">
+            {description}
+          </div>
+        </div>
+      </div>
+      {extra}
+    </div>
+    {children}
+  </section>
+);
+
+const functionOptions = transformFunctionGroups.map((group) => ({
+  label: group.label,
+  options: group.options,
+}));
+
+const FunctionSelect = ({
+  field,
+  onSelect,
+}: {
+  field: string;
+  onSelect: (expression: string) => void;
+}) => (
+  <Select
+    value={undefined}
+    placeholder="插入函数"
+    options={functionOptions}
+    onChange={(value) =>
+      onSelect(String(value).replaceAll('${field}', field || 'field_name'))
+    }
+    popupMatchSelectWidth={320}
+    className="w-[118px] [&_.ant-select-selector]:!h-8 [&_.ant-select-selector]:!rounded-[7px] [&_.ant-select-selection-placeholder]:!text-[10px] [&_.ant-select-selection-placeholder]:!leading-[30px]"
+  />
+);
+
+export const TransformRuleEditor = ({
+  value,
+  onChange,
+}: {
+  value: TransformRule;
+  onChange: (value: TransformRule) => void;
+  compact?: boolean;
+}) => {
+  const outputFields = useMemo(
+    () =>
+      value.columns
+        .filter((column) => column.selected && column.targetName.trim())
+        .map((column) => column.targetName.trim()),
+    [value.columns],
+  );
+
+  const updateColumn = (id: string, values: Partial<ColumnMapping>) =>
+    onChange({
+      ...value,
+      columns: value.columns.map((column) =>
+        column.id === id ? { ...column, ...values } : column,
+      ),
+    });
+
+  const removeColumn = (id: string) =>
+    onChange({ ...value, columns: value.columns.filter((column) => column.id !== id) });
+
+  const addComputedColumn = () =>
+    onChange({
+      ...value,
+      columns: [
+        ...value.columns,
+        {
+          id: createId('computed'),
+          sourceName: '',
+          sourceType: 'COMPUTED',
+          selected: true,
+          targetName: `computed_field_${value.columns.length + 1}`,
+          expression: "CASE WHEN status = 'PAID' THEN 1 ELSE 0 END",
+          computed: true,
+        },
+      ],
+    });
+
+  const updateTableOption = (id: string, values: Partial<TableOptionEntry>) =>
+    onChange({
+      ...value,
+      tableOptions: value.tableOptions.map((option) =>
+        option.id === id ? { ...option, ...values } : option,
+      ),
+    });
+
+  return (
+    <div className="space-y-4">
+      <Section
+        icon={<TableProperties size={17} strokeWidth={1.8} />}
+        title="字段投影"
+        description="选择保留字段、删除字段、重命名目标字段，并使用表达式添加计算字段。"
+        extra={
+          <Button
+            icon={<Plus size={14} />}
+            onClick={addComputedColumn}
+            className="!h-8 !rounded-[7px] !border-black/[0.08] !text-[11px]"
+          >
+            计算字段
+          </Button>
+        }
+      >
+        <div className="overflow-x-auto">
+          <table className="w-full min-w-[900px] border-collapse">
+            <thead>
+              <tr className="border-b border-black/[0.055] bg-[#fafafa] text-left text-[10px] font-semibold text-[rgba(22,24,35,0.52)]">
+                <th className="w-[58px] px-4 py-3">保留</th>
+                <th className="w-[155px] px-3 py-3">来源字段</th>
+                <th className="w-[118px] px-3 py-3">类型</th>
+                <th className="w-[180px] px-3 py-3">目标字段名</th>
+                <th className="min-w-[320px] px-3 py-3">表达式</th>
+                <th className="w-[55px] px-3 py-3">操作</th>
+              </tr>
+            </thead>
+            <tbody>
+              {value.columns.map((column) => (
+                <tr key={column.id} className="border-b border-black/[0.045] last:border-b-0">
+                  <td className="px-4 py-2.5">
+                    <Checkbox
+                      checked={column.selected}
+                      onChange={(event) =>
+                        updateColumn(column.id, { selected: event.target.checked })
+                      }
+                    />
+                  </td>
+                  <td className="px-3 py-2.5 font-mono text-[11px] text-[#252832]">
+                    <div className="flex items-center gap-2">
+                      {column.sourceName || '—'}
+                      {column.computed && (
+                        <Tag className="!m-0 !rounded-full !border-[#d9d6fe] !bg-[#f4f3ff] !px-2 !text-[9px] !text-[#6938ef]">
+                          计算
+                        </Tag>
+                      )}
+                    </div>
+                  </td>
+                  <td className="px-3 py-2.5 font-mono text-[10px] text-[rgba(22,24,35,0.42)]">
+                    {column.sourceType}
+                  </td>
+                  <td className="px-3 py-2.5">
+                    <Input
+                      value={column.targetName}
+                      onChange={(event) =>
+                        updateColumn(column.id, { targetName: event.target.value })
+                      }
+                      className="!h-8 !rounded-[6px] !border-black/[0.075] !font-mono !text-[10px]"
+                    />
+                  </td>
+                  <td className="px-3 py-2.5">
+                    <div className="flex gap-2">
+                      <Input
+                        value={column.expression}
+                        onChange={(event) =>
+                          updateColumn(column.id, { expression: event.target.value })
+                        }
+                        className="!h-8 min-w-0 flex-1 !rounded-[6px] !border-black/[0.075] !font-mono !text-[10px]"
+                      />
+                      <FunctionSelect
+                        field={column.sourceName || outputFields[0] || 'field_name'}
+                        onSelect={(expression) => updateColumn(column.id, { expression })}
+                      />
+                    </div>
+                  </td>
+                  <td className="px-3 py-2.5">
+                    <button
+                      type="button"
+                      onClick={() => removeColumn(column.id)}
+                      className="flex h-7 w-7 items-center justify-center rounded-[6px] border-0 bg-transparent text-[rgba(22,24,35,0.35)] hover:bg-[#fff1f2] hover:text-[#d92d20]"
+                    >
+                      <Trash2 size={14} />
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </Section>
+
+      <Section
+        icon={<Braces size={17} strokeWidth={1.8} />}
+        title="行过滤"
+        description="使用类似 SQL WHERE 的表达式过滤变更事件，支持内置函数和 UDF。"
+        extra={
+          <FunctionSelect
+            field={outputFields[0] || 'field_name'}
+            onSelect={(expression) =>
+              onChange({
+                ...value,
+                filter: value.filter ? `${value.filter} AND ${expression}` : expression,
+              })
+            }
+          />
+        }
+      >
+        <div className="p-5">
+          <TextArea
+            value={value.filter}
+            onChange={(event) => onChange({ ...value, filter: event.target.value })}
+            placeholder="status = 'PAID' AND amount > 0"
+            autoSize={{ minRows: 4, maxRows: 8 }}
+            className="!rounded-[8px] !border-black/[0.075] !font-mono !text-[11px] !leading-6"
+          />
+        </div>
+      </Section>
+
+      <Section
+        icon={<KeyRound size={17} strokeWidth={1.8} />}
+        title="主键与分区键"
+        description="重新指定下游表的主键和分区键，字段来自最终投影结果。"
+      >
+        <div className="grid grid-cols-2 gap-5 p-5 max-lg:grid-cols-1">
+          <label>
+            <span className="mb-2 block text-[11px] font-semibold text-[#343741]">目标表主键</span>
+            <Select
+              mode="multiple"
+              value={value.primaryKeys}
+              options={outputFields.map((field) => ({ label: field, value: field }))}
+              onChange={(primaryKeys) => onChange({ ...value, primaryKeys })}
+              className="w-full [&_.ant-select-selector]:!min-h-10 [&_.ant-select-selector]:!rounded-[7px] [&_.ant-select-selector]:!border-black/[0.075]"
+            />
+          </label>
+          <label>
+            <span className="mb-2 block text-[11px] font-semibold text-[#343741]">目标表分区键</span>
+            <Select
+              mode="multiple"
+              allowClear
+              value={value.partitionKeys}
+              options={outputFields.map((field) => ({ label: field, value: field }))}
+              onChange={(partitionKeys) => onChange({ ...value, partitionKeys })}
+              className="w-full [&_.ant-select-selector]:!min-h-10 [&_.ant-select-selector]:!rounded-[7px] [&_.ant-select-selector]:!border-black/[0.075]"
+            />
+          </label>
+        </div>
+      </Section>
+
+      <Section
+        icon={<Sigma size={17} strokeWidth={1.8} />}
+        title="下游建表参数"
+        description="配置自动创建目标表时透传的 table-options。"
+        extra={
+          <Button
+            icon={<Plus size={14} />}
+            onClick={() =>
+              onChange({
+                ...value,
+                tableOptions: [
+                  ...value.tableOptions,
+                  { id: createId('table-option'), key: '', value: '' },
+                ],
+              })
+            }
+            className="!h-8 !rounded-[7px] !border-black/[0.08] !text-[11px]"
+          >
+            新增参数
+          </Button>
+        }
+      >
+        <div className="p-5">
+          <div className="mb-4 flex items-center gap-3">
+            <span className="text-[11px] font-semibold text-[#343741]">参数分隔符</span>
+            <Input
+              maxLength={1}
+              value={value.tableOptionsDelimiter}
+              onChange={(event) =>
+                onChange({ ...value, tableOptionsDelimiter: event.target.value || ',' })
+              }
+              className="!h-8 !w-20 !rounded-[6px] !border-black/[0.075] !text-center !font-mono !text-[11px]"
+            />
+          </div>
+          {value.tableOptions.length ? (
+            <div className="space-y-2">
+              {value.tableOptions.map((option) => (
+                <div key={option.id} className="flex items-center gap-2">
+                  <Input
+                    value={option.key}
+                    onChange={(event) =>
+                      updateTableOption(option.id, { key: event.target.value })
+                    }
+                    placeholder="参数名"
+                    className="!h-9 !w-[280px] !rounded-[7px] !border-black/[0.075] !font-mono !text-[10px]"
+                  />
+                  <Input
+                    value={option.value}
+                    onChange={(event) =>
+                      updateTableOption(option.id, { value: event.target.value })
+                    }
+                    placeholder="参数值"
+                    className="!h-9 min-w-0 flex-1 !rounded-[7px] !border-black/[0.075] !font-mono !text-[10px]"
+                  />
+                  <button
+                    type="button"
+                    onClick={() =>
+                      onChange({
+                        ...value,
+                        tableOptions: value.tableOptions.filter(
+                          (item) => item.id !== option.id,
+                        ),
+                      })
+                    }
+                    className="flex h-8 w-8 items-center justify-center border-0 bg-transparent text-[rgba(22,24,35,0.35)] hover:text-[#d92d20]"
+                  >
+                    <Trash2 size={14} />
+                  </button>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="暂未配置建表参数" />
+          )}
+        </div>
+      </Section>
+    </div>
+  );
+};
+
+export const UdfEditor = ({
+  value,
+  onChange,
+}: {
+  value: UdfDefinition[];
+  onChange: (value: UdfDefinition[]) => void;
+}) => {
+  const updateUdf = (id: string, values: Partial<UdfDefinition>) =>
+    onChange(value.map((udf) => (udf.id === id ? { ...udf, ...values } : udf)));
+
+  const updateOption = (
+    udfId: string,
+    optionId: string,
+    values: Partial<UdfOptionEntry>,
+  ) =>
+    onChange(
+      value.map((udf) =>
+        udf.id === udfId
+          ? {
+              ...udf,
+              options: udf.options.map((option) =>
+                option.id === optionId ? { ...option, ...values } : option,
+              ),
+            }
+          : udf,
+      ),
+    );
+
+  return (
+    <Section
+      icon={<Sigma size={17} strokeWidth={1.8} />}
+      title="用户自定义函数（UDF）"
+      description="注册函数名称、实现类及初始化参数。对应 JAR 由后端提交任务时加载。"
+      extra={
+        <Button
+          icon={<Plus size={14} />}
+          onClick={() => onChange([...value, createDefaultUdf()])}
+          className="!h-8 !rounded-[7px] !border-black/[0.08] !text-[11px]"
+        >
+          新增 UDF
+        </Button>
+      }
+    >
+      <div className="p-5">
+        {value.length ? (
+          <Collapse
+            bordered={false}
+            className="!bg-transparent [&_.ant-collapse-item]:!mb-3 [&_.ant-collapse-item]:!rounded-[8px] [&_.ant-collapse-item]:!border [&_.ant-collapse-item]:!border-black/[0.07] [&_.ant-collapse-header]:!bg-[#fafafa]"
+            items={value.map((udf, index) => ({
+              key: udf.id,
+              label: udf.name || `未命名 UDF ${index + 1}`,
+              extra: (
+                <button
+                  type="button"
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    onChange(value.filter((item) => item.id !== udf.id));
+                  }}
+                  className="flex h-7 w-7 items-center justify-center border-0 bg-transparent text-[rgba(22,24,35,0.35)] hover:text-[#d92d20]"
+                >
+                  <Trash2 size={14} />
+                </button>
+              ),
+              children: (
+                <div className="space-y-4 pt-1">
+                  <div className="grid grid-cols-2 gap-4 max-lg:grid-cols-1">
+                    <Input
+                      value={udf.name}
+                      onChange={(event) => updateUdf(udf.id, { name: event.target.value })}
+                      placeholder="函数名，例如 format_order"
+                      className="!h-9 !rounded-[7px] !border-black/[0.075] !font-mono !text-[10px]"
+                    />
+                    <Input
+                      value={udf.classpath}
+                      onChange={(event) =>
+                        updateUdf(udf.id, { classpath: event.target.value })
+                      }
+                      placeholder="com.example.cdc.FormatOrderFunction"
+                      className="!h-9 !rounded-[7px] !border-black/[0.075] !font-mono !text-[10px]"
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    {udf.options.map((option) => (
+                      <div key={option.id} className="flex items-center gap-2">
+                        <Input
+                          value={option.key}
+                          onChange={(event) =>
+                            updateOption(udf.id, option.id, { key: event.target.value })
+                          }
+                          placeholder="参数名"
+                          className="!h-8 !w-[240px] !rounded-[6px] !border-black/[0.075] !font-mono !text-[10px]"
+                        />
+                        <Input
+                          value={option.value}
+                          onChange={(event) =>
+                            updateOption(udf.id, option.id, { value: event.target.value })
+                          }
+                          placeholder="参数值"
+                          className="!h-8 min-w-0 flex-1 !rounded-[6px] !border-black/[0.075] !font-mono !text-[10px]"
+                        />
+                        <button
+                          type="button"
+                          onClick={() =>
+                            updateUdf(udf.id, {
+                              options: udf.options.filter((item) => item.id !== option.id),
+                            })
+                          }
+                          className="flex h-7 w-7 items-center justify-center border-0 bg-transparent text-[rgba(22,24,35,0.35)] hover:text-[#d92d20]"
+                        >
+                          <Trash2 size={13} />
+                        </button>
+                      </div>
+                    ))}
+                    <button
+                      type="button"
+                      onClick={() =>
+                        updateUdf(udf.id, {
+                          options: [
+                            ...udf.options,
+                            { id: createId('udf-option'), key: '', value: '' },
+                          ],
+                        })
+                      }
+                      className="border-0 bg-transparent text-[10px] font-semibold text-[#315efb]"
+                    >
+                      + 添加初始化参数
+                    </button>
+                  </div>
+                </div>
+              ),
+            }))}
+          />
+        ) : (
+          <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="当前任务未注册 UDF" />
+        )}
+      </div>
+    </Section>
+  );
+};

--- a/yak-ops-ui/src/pages/realtime-link-up/config/MultiConfigPage.tsx
+++ b/yak-ops-ui/src/pages/realtime-link-up/config/MultiConfigPage.tsx
@@ -1,0 +1,472 @@
+import { Plus, Trash2 } from 'lucide-react';
+import { useParams } from '@umijs/max';
+import { Alert, Button, Collapse, Empty, Input, message, Select, Tag } from 'antd';
+import { useMemo, useState } from 'react';
+import ConfigShell from '../components/ConfigShell';
+import {
+  PipelineBasicPanel,
+  PipelineRuntimePanel,
+  SourceSinkPanel,
+} from '../components/CommonConfigPanels';
+import { TransformRuleEditor, UdfEditor } from '../components/TransformEditor';
+import {
+  createDefaultMultiDraft,
+  createDefaultTransform,
+  formatUpdatedAt,
+  loadRealtimeDraft,
+  sampleTables,
+  saveRealtimeDraft,
+  saveRealtimeTask,
+} from '../data';
+import type { MultiTableDraft, TransformRule } from '../types';
+import { buildMultiTableYaml } from '../yaml';
+
+const createId = (prefix: string) =>
+  `${prefix}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+
+const MultiConfigPage = () => {
+  const { id = `rt-${Date.now()}` } = useParams<{ id: string }>();
+  const [draft, setDraft] = useState<MultiTableDraft>(() =>
+    loadRealtimeDraft<MultiTableDraft>(id) || createDefaultMultiDraft(id),
+  );
+  const [activeStep, setActiveStep] = useState('basic');
+  const [saving, setSaving] = useState(false);
+
+  const yaml = useMemo(() => buildMultiTableYaml(draft), [draft]);
+
+  const steps = [
+    {
+      key: 'basic',
+      title: '基本信息',
+      description: '任务名称与运行版本',
+      complete: Boolean(draft.pipeline.name.trim()),
+    },
+    {
+      key: 'scope',
+      title: '同步范围',
+      description: '来源规则、目标端和表清单',
+      complete: Boolean(
+        draft.source.dataSourceId &&
+          draft.source.database &&
+          (draft.source.tablePattern.trim() || draft.source.tables.length) &&
+          draft.sink.dataSourceId &&
+          draft.sink.database,
+      ),
+    },
+    {
+      key: 'route',
+      title: '表路由',
+      description: '来源表映射到目标表',
+      complete: Boolean(
+        draft.routes.length &&
+          draft.routes.every((route) => route.sourceTable.trim() && route.sinkTable.trim()),
+      ),
+    },
+    {
+      key: 'transform',
+      title: '转换规则',
+      description: '每张表独立配置 Transform',
+      complete: Boolean(
+        draft.transforms.length &&
+          draft.transforms.every(
+            (rule) =>
+              rule.sourceTable.trim() &&
+              rule.columns.some(
+                (column) => column.selected && column.targetName.trim() && column.expression.trim(),
+              ),
+          ),
+      ),
+    },
+    {
+      key: 'udf',
+      title: 'UDF',
+      description: '注册自定义转换函数',
+      complete: draft.udfs.every((udf) => udf.name.trim() && udf.classpath.trim()),
+    },
+    {
+      key: 'runtime',
+      title: '运行参数',
+      description: '并行度与 Checkpoint',
+      complete: draft.pipeline.parallelism > 0 && draft.pipeline.checkpointInterval >= 10,
+    },
+  ];
+
+  const updateSelectedTables = (tables: string[]) => {
+    setDraft((current) => {
+      const transformMap = new Map(current.transforms.map((rule) => [rule.sourceTable, rule]));
+      const routeMap = new Map(current.routes.map((route) => [route.sourceTable, route]));
+      const transforms = tables.map(
+        (table) => transformMap.get(table) || createDefaultTransform(table),
+      );
+      const routes = tables.map((table) => {
+        const existing = routeMap.get(table);
+        if (existing) return existing;
+        const tableName = table.split('.').pop() || table;
+        return {
+          id: createId('route'),
+          sourceTable: table,
+          sinkTable: `${current.sink.database}.${current.sink.tablePrefix}${tableName}${current.sink.tableSuffix}`,
+          description: '',
+        };
+      });
+      return {
+        ...current,
+        source: { ...current.source, tables },
+        transforms,
+        routes,
+      };
+    });
+  };
+
+  const updateTransform = (id: string, transform: TransformRule) => {
+    setDraft((current) => ({
+      ...current,
+      transforms: current.transforms.map((item) => (item.id === id ? transform : item)),
+    }));
+  };
+
+  const save = async () => {
+    const firstIncomplete = steps.find((step) => !step.complete);
+    if (firstIncomplete) {
+      setActiveStep(firstIncomplete.key);
+      message.warning(`请先完成“${firstIncomplete.title}”配置`);
+      return;
+    }
+
+    setSaving(true);
+    try {
+      saveRealtimeDraft(id, draft);
+      saveRealtimeTask({
+        id,
+        name: draft.pipeline.name,
+        description: draft.pipeline.description,
+        mode: 'MULTI_TABLE',
+        status: 'DRAFT',
+        sourceType: `${draft.source.type.toUpperCase()} CDC`,
+        sourceSummary: `${draft.source.tablePattern || draft.source.database}（${draft.source.tables.length} 张表）`,
+        sinkType: draft.sink.type.toUpperCase(),
+        sinkSummary: `${draft.sink.database}.${draft.sink.tablePrefix || ''}*${draft.sink.tableSuffix || ''}`,
+        flinkVersion: draft.pipeline.flinkVersion,
+        cdcVersion: draft.pipeline.cdcVersion,
+        updatedAt: formatUpdatedAt(),
+        yaml,
+      });
+      message.success('多表实时同步草稿已保存');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <ConfigShell
+      taskId={id}
+      mode="MULTI_TABLE"
+      title={draft.pipeline.name || '未命名多表同步任务'}
+      description={draft.pipeline.description}
+      steps={steps}
+      activeStep={activeStep}
+      onStepChange={setActiveStep}
+      yaml={yaml}
+      saving={saving}
+      onSave={() => void save()}
+    >
+      {activeStep === 'basic' && (
+        <PipelineBasicPanel
+          value={draft.pipeline}
+          onChange={(pipeline) => setDraft((current) => ({ ...current, pipeline }))}
+        />
+      )}
+
+      {activeStep === 'scope' && (
+        <div className="space-y-4">
+          <Alert
+            type="info"
+            showIcon
+            message="多表模式支持表名正则与明确表清单"
+            description="当前页面不执行连接测试。表清单暂使用前端示例元数据，后续接入后端后由数据源元数据接口加载。"
+            className="!rounded-[9px] !border-[#c7d7fe] !bg-[#f5f8ff] [&_.ant-alert-message]:!text-[12px] [&_.ant-alert-description]:!text-[11px]"
+          />
+          <SourceSinkPanel
+            multi
+            source={draft.source}
+            sink={draft.sink}
+            onSourceChange={(source) => setDraft((current) => ({ ...current, source }))}
+            onSinkChange={(sink) => setDraft((current) => ({ ...current, sink }))}
+          />
+
+          <section className="overflow-hidden rounded-[10px] border border-black/[0.07] bg-white">
+            <div className="border-b border-black/[0.055] px-5 py-4">
+              <div className="text-[13px] font-semibold text-[#161823]">已选择同步表</div>
+              <div className="mt-1 text-[11px] text-[rgba(22,24,35,0.46)]">
+                选择后会自动生成对应的 Transform 和 Route 草稿，可在后续步骤逐条调整。
+              </div>
+            </div>
+            <div className="p-5">
+              <Select
+                mode="multiple"
+                allowClear
+                value={draft.source.tables}
+                options={sampleTables.map((table) => ({ label: table, value: table }))}
+                onChange={updateSelectedTables}
+                placeholder="选择需要同步的表"
+                className="w-full [&_.ant-select-selector]:!min-h-11 [&_.ant-select-selector]:!rounded-[8px] [&_.ant-select-selector]:!border-black/[0.075]"
+              />
+              <div className="mt-3 flex flex-wrap gap-2">
+                {draft.source.tables.map((table) => (
+                  <Tag
+                    key={table}
+                    className="!m-0 !rounded-full !border-black/[0.07] !bg-[#f7f8fa] !px-2.5 !py-1 !font-mono !text-[10px] !text-[#343741]"
+                  >
+                    {table}
+                  </Tag>
+                ))}
+              </div>
+            </div>
+          </section>
+        </div>
+      )}
+
+      {activeStep === 'route' && (
+        <section className="overflow-hidden rounded-[10px] border border-black/[0.07] bg-white">
+          <div className="flex items-start justify-between gap-4 border-b border-black/[0.055] px-5 py-4">
+            <div>
+              <div className="text-[13px] font-semibold text-[#161823]">Route 表路由</div>
+              <div className="mt-1 text-[11px] text-[rgba(22,24,35,0.46)]">
+                定义来源表到目标表的映射。规则顺序会保持在最终 Pipeline YAML 中。
+              </div>
+            </div>
+            <Button
+              icon={<Plus size={14} />}
+              onClick={() =>
+                setDraft((current) => ({
+                  ...current,
+                  routes: [
+                    ...current.routes,
+                    { id: createId('route'), sourceTable: '', sinkTable: '', description: '' },
+                  ],
+                }))
+              }
+              className="!h-8 !rounded-[7px] !border-black/[0.08] !text-[11px]"
+            >
+              新增路由
+            </Button>
+          </div>
+
+          {draft.routes.length ? (
+            <div className="overflow-x-auto">
+              <table className="w-full min-w-[920px] border-collapse">
+                <thead>
+                  <tr className="border-b border-black/[0.055] bg-[#fafafa] text-left text-[10px] font-semibold text-[rgba(22,24,35,0.52)]">
+                    <th className="w-[36%] px-5 py-3">来源表规则</th>
+                    <th className="w-[36%] px-3 py-3">目标表</th>
+                    <th className="px-3 py-3">说明</th>
+                    <th className="w-[60px] px-3 py-3">操作</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {draft.routes.map((route) => (
+                    <tr key={route.id} className="border-b border-black/[0.045] last:border-b-0">
+                      <td className="px-5 py-3">
+                        <Input
+                          value={route.sourceTable}
+                          onChange={(event) =>
+                            setDraft((current) => ({
+                              ...current,
+                              routes: current.routes.map((item) =>
+                                item.id === route.id
+                                  ? { ...item, sourceTable: event.target.value }
+                                  : item,
+                              ),
+                            }))
+                          }
+                          className="!h-9 !rounded-[7px] !border-black/[0.075] !font-mono !text-[11px]"
+                        />
+                      </td>
+                      <td className="px-3 py-3">
+                        <Input
+                          value={route.sinkTable}
+                          onChange={(event) =>
+                            setDraft((current) => ({
+                              ...current,
+                              routes: current.routes.map((item) =>
+                                item.id === route.id
+                                  ? { ...item, sinkTable: event.target.value }
+                                  : item,
+                              ),
+                            }))
+                          }
+                          className="!h-9 !rounded-[7px] !border-black/[0.075] !font-mono !text-[11px]"
+                        />
+                      </td>
+                      <td className="px-3 py-3">
+                        <Input
+                          value={route.description}
+                          onChange={(event) =>
+                            setDraft((current) => ({
+                              ...current,
+                              routes: current.routes.map((item) =>
+                                item.id === route.id
+                                  ? { ...item, description: event.target.value }
+                                  : item,
+                              ),
+                            }))
+                          }
+                          placeholder="可选"
+                          className="!h-9 !rounded-[7px] !border-black/[0.075] !text-[11px]"
+                        />
+                      </td>
+                      <td className="px-3 py-3">
+                        <button
+                          type="button"
+                          onClick={() =>
+                            setDraft((current) => ({
+                              ...current,
+                              routes: current.routes.filter((item) => item.id !== route.id),
+                            }))
+                          }
+                          className="flex h-8 w-8 items-center justify-center rounded-[6px] border-0 bg-transparent text-[rgba(22,24,35,0.35)] hover:bg-[#fff1f2] hover:text-[#d92d20]"
+                        >
+                          <Trash2 size={14} />
+                        </button>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          ) : (
+            <Empty
+              image={Empty.PRESENTED_IMAGE_SIMPLE}
+              description={<span className="text-[11px] text-[rgba(22,24,35,0.42)]">暂未配置路由规则</span>}
+            />
+          )}
+        </section>
+      )}
+
+      {activeStep === 'transform' && (
+        <div className="space-y-4">
+          <div className="flex items-center justify-between rounded-[10px] border border-black/[0.07] bg-white px-5 py-4">
+            <div>
+              <div className="text-[13px] font-semibold text-[#161823]">Transform 规则</div>
+              <div className="mt-1 text-[11px] text-[rgba(22,24,35,0.46)]">
+                多条规则按顺序匹配，同一张表只应用第一条命中的 Transform。
+              </div>
+            </div>
+            <Button
+              icon={<Plus size={14} />}
+              onClick={() =>
+                setDraft((current) => ({
+                  ...current,
+                  transforms: [...current.transforms, createDefaultTransform('')],
+                }))
+              }
+              className="!h-8 !rounded-[7px] !border-black/[0.08] !text-[11px]"
+            >
+              新增 Transform
+            </Button>
+          </div>
+
+          <Collapse
+            defaultActiveKey={draft.transforms[0]?.id ? [draft.transforms[0].id] : []}
+            className="!border-0 !bg-transparent [&_.ant-collapse-item]:!mb-4 [&_.ant-collapse-item]:!overflow-hidden [&_.ant-collapse-item]:!rounded-[10px] [&_.ant-collapse-item]:!border [&_.ant-collapse-item]:!border-black/[0.07] [&_.ant-collapse-header]:!items-center [&_.ant-collapse-header]:!bg-white [&_.ant-collapse-header]:!px-5 [&_.ant-collapse-header]:!py-4 [&_.ant-collapse-content-box]:!bg-[#f7f8fa] [&_.ant-collapse-content-box]:!p-4"
+            items={draft.transforms.map((rule, index) => ({
+              key: rule.id,
+              label: (
+                <div className="flex items-center gap-3">
+                  <span className="flex h-7 w-7 items-center justify-center rounded-full bg-[#f1f3f6] text-[10px] font-semibold text-[#343741]">
+                    {index + 1}
+                  </span>
+                  <div>
+                    <div className="font-mono text-[12px] font-semibold text-[#252832]">
+                      {rule.sourceTable || '未配置来源表规则'}
+                    </div>
+                    <div className="mt-0.5 text-[10px] text-[rgba(22,24,35,0.42)]">
+                      {rule.columns.filter((column) => column.selected).length} 个输出字段
+                      {rule.filter ? ' · 已配置行过滤' : ''}
+                    </div>
+                  </div>
+                </div>
+              ),
+              extra: (
+                <button
+                  type="button"
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    setDraft((current) => ({
+                      ...current,
+                      transforms: current.transforms.filter((item) => item.id !== rule.id),
+                    }));
+                  }}
+                  className="flex h-8 w-8 items-center justify-center rounded-[6px] border-0 bg-transparent text-[rgba(22,24,35,0.35)] hover:bg-[#fff1f2] hover:text-[#d92d20]"
+                >
+                  <Trash2 size={14} />
+                </button>
+              ),
+              children: (
+                <div className="space-y-4">
+                  <section className="rounded-[9px] border border-black/[0.07] bg-white p-4">
+                    <div className="grid grid-cols-2 gap-4 max-lg:grid-cols-1">
+                      <label>
+                        <span className="mb-2 block text-[11px] font-semibold text-[#343741]">
+                          来源表规则 <span className="text-[#d92d20]">*</span>
+                        </span>
+                        <Input
+                          value={rule.sourceTable}
+                          onChange={(event) =>
+                            updateTransform(rule.id, {
+                              ...rule,
+                              sourceTable: event.target.value,
+                            })
+                          }
+                          placeholder="trade_db.order_main 或正则"
+                          className="!h-9 !rounded-[7px] !border-black/[0.075] !font-mono !text-[11px]"
+                        />
+                      </label>
+                      <label>
+                        <span className="mb-2 block text-[11px] font-semibold text-[#343741]">
+                          规则说明
+                        </span>
+                        <Input
+                          value={rule.description}
+                          onChange={(event) =>
+                            updateTransform(rule.id, {
+                              ...rule,
+                              description: event.target.value,
+                            })
+                          }
+                          placeholder="可选"
+                          className="!h-9 !rounded-[7px] !border-black/[0.075] !text-[11px]"
+                        />
+                      </label>
+                    </div>
+                  </section>
+                  <TransformRuleEditor
+                    compact
+                    value={rule}
+                    onChange={(next) => updateTransform(rule.id, next)}
+                  />
+                </div>
+              ),
+            }))}
+          />
+        </div>
+      )}
+
+      {activeStep === 'udf' && (
+        <UdfEditor
+          value={draft.udfs}
+          onChange={(udfs) => setDraft((current) => ({ ...current, udfs }))}
+        />
+      )}
+
+      {activeStep === 'runtime' && (
+        <PipelineRuntimePanel
+          value={draft.pipeline}
+          onChange={(pipeline) => setDraft((current) => ({ ...current, pipeline }))}
+        />
+      )}
+    </ConfigShell>
+  );
+};
+
+export default MultiConfigPage;

--- a/yak-ops-ui/src/pages/realtime-link-up/config/SingleConfigPage.tsx
+++ b/yak-ops-ui/src/pages/realtime-link-up/config/SingleConfigPage.tsx
@@ -1,0 +1,175 @@
+import { useParams } from '@umijs/max';
+import { Alert, message } from 'antd';
+import { useMemo, useState } from 'react';
+import ConfigShell from '../components/ConfigShell';
+import {
+  PipelineBasicPanel,
+  PipelineRuntimePanel,
+  SourceSinkPanel,
+} from '../components/CommonConfigPanels';
+import { TransformRuleEditor, UdfEditor } from '../components/TransformEditor';
+import {
+  createDefaultSingleDraft,
+  formatUpdatedAt,
+  loadRealtimeDraft,
+  saveRealtimeDraft,
+  saveRealtimeTask,
+} from '../data';
+import type { SingleTableDraft } from '../types';
+import { buildSingleTableYaml } from '../yaml';
+
+const SingleConfigPage = () => {
+  const { id = `rt-${Date.now()}` } = useParams<{ id: string }>();
+  const [draft, setDraft] = useState<SingleTableDraft>(() =>
+    loadRealtimeDraft<SingleTableDraft>(id) || createDefaultSingleDraft(id),
+  );
+  const [activeStep, setActiveStep] = useState('basic');
+  const [saving, setSaving] = useState(false);
+
+  const yaml = useMemo(() => buildSingleTableYaml(draft), [draft]);
+  const selectedColumns = draft.transform.columns.filter((column) => column.selected);
+
+  const steps = [
+    {
+      key: 'basic',
+      title: '基本信息',
+      description: '任务名称与运行版本',
+      complete: Boolean(draft.pipeline.name.trim()),
+    },
+    {
+      key: 'endpoint',
+      title: '来源与目标',
+      description: '单表采集与写入位置',
+      complete: Boolean(
+        draft.source.dataSourceId &&
+          draft.source.database &&
+          draft.source.table &&
+          draft.sink.dataSourceId &&
+          draft.sink.database &&
+          draft.sink.table,
+      ),
+    },
+    {
+      key: 'transform',
+      title: '字段与转换',
+      description: '投影、过滤、键和 UDF',
+      complete: Boolean(
+        selectedColumns.length &&
+          selectedColumns.every((column) => column.targetName.trim() && column.expression.trim()),
+      ),
+    },
+    {
+      key: 'runtime',
+      title: '运行参数',
+      description: '并行度与 Checkpoint',
+      complete: draft.pipeline.parallelism > 0 && draft.pipeline.checkpointInterval >= 10,
+    },
+  ];
+
+  const save = async () => {
+    const firstIncomplete = steps.find((step) => !step.complete);
+    if (firstIncomplete) {
+      setActiveStep(firstIncomplete.key);
+      message.warning(`请先完成“${firstIncomplete.title}”配置`);
+      return;
+    }
+
+    setSaving(true);
+    try {
+      saveRealtimeDraft(id, draft);
+      saveRealtimeTask({
+        id,
+        name: draft.pipeline.name,
+        description: draft.pipeline.description,
+        mode: 'SINGLE_TABLE',
+        status: 'DRAFT',
+        sourceType: `${draft.source.type.toUpperCase()} CDC`,
+        sourceSummary: [draft.source.database, draft.source.schema, draft.source.table]
+          .filter(Boolean)
+          .join('.'),
+        sinkType: draft.sink.type.toUpperCase(),
+        sinkSummary: [draft.sink.database, draft.sink.schema, draft.sink.table]
+          .filter(Boolean)
+          .join('.'),
+        flinkVersion: draft.pipeline.flinkVersion,
+        cdcVersion: draft.pipeline.cdcVersion,
+        updatedAt: formatUpdatedAt(),
+        yaml,
+      });
+      message.success('单表实时同步草稿已保存');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <ConfigShell
+      taskId={id}
+      mode="SINGLE_TABLE"
+      title={draft.pipeline.name || '未命名单表同步任务'}
+      description={draft.pipeline.description}
+      steps={steps}
+      activeStep={activeStep}
+      onStepChange={setActiveStep}
+      yaml={yaml}
+      saving={saving}
+      onSave={() => void save()}
+    >
+      {activeStep === 'basic' && (
+        <PipelineBasicPanel
+          value={draft.pipeline}
+          onChange={(pipeline) => setDraft((current) => ({ ...current, pipeline }))}
+        />
+      )}
+
+      {activeStep === 'endpoint' && (
+        <div className="space-y-4">
+          <Alert
+            type="info"
+            showIcon
+            message="当前版本不要求在配置过程中执行连接测试"
+            description="这里只选择资源管理中已维护的数据源。连接检查与 Connector 参数校验将在后端提交任务时统一处理。"
+            className="!rounded-[9px] !border-[#c7d7fe] !bg-[#f5f8ff] [&_.ant-alert-message]:!text-[12px] [&_.ant-alert-description]:!text-[11px]"
+          />
+          <SourceSinkPanel
+            source={draft.source}
+            sink={draft.sink}
+            onSourceChange={(source) => {
+              const sourceTable = [source.database, source.schema, source.table]
+                .filter(Boolean)
+                .join('.');
+              setDraft((current) => ({
+                ...current,
+                source,
+                transform: { ...current.transform, sourceTable },
+              }));
+            }}
+            onSinkChange={(sink) => setDraft((current) => ({ ...current, sink }))}
+          />
+        </div>
+      )}
+
+      {activeStep === 'transform' && (
+        <div className="space-y-4">
+          <TransformRuleEditor
+            value={draft.transform}
+            onChange={(transform) => setDraft((current) => ({ ...current, transform }))}
+          />
+          <UdfEditor
+            value={draft.udfs}
+            onChange={(udfs) => setDraft((current) => ({ ...current, udfs }))}
+          />
+        </div>
+      )}
+
+      {activeStep === 'runtime' && (
+        <PipelineRuntimePanel
+          value={draft.pipeline}
+          onChange={(pipeline) => setDraft((current) => ({ ...current, pipeline }))}
+        />
+      )}
+    </ConfigShell>
+  );
+};
+
+export default SingleConfigPage;

--- a/yak-ops-ui/src/pages/realtime-link-up/config/YamlConfigPage.tsx
+++ b/yak-ops-ui/src/pages/realtime-link-up/config/YamlConfigPage.tsx
@@ -1,0 +1,353 @@
+import { FileCode2, FileUp, ShieldCheck } from 'lucide-react';
+import { useParams } from '@umijs/max';
+import { Alert, Input, message, Select, Tag, Upload } from 'antd';
+import { useMemo, useState } from 'react';
+import ConfigShell from '../components/ConfigShell';
+import {
+  formatUpdatedAt,
+  loadRealtimeDraft,
+  saveRealtimeDraft,
+  saveRealtimeTask,
+} from '../data';
+import type { CustomYamlDraft } from '../types';
+import { validateCustomYaml } from '../yaml';
+
+const { TextArea } = Input;
+const { Dragger } = Upload;
+
+const DEFAULT_YAML = `source:
+  type: mysql
+  hostname: localhost
+  port: 3306
+  username: root
+  password: ""
+  tables: trade_db.order_main
+  server-id: 5400-5404
+  server-time-zone: Asia/Shanghai
+
+sink:
+  type: doris
+  fenodes: 127.0.0.1:8030
+  username: root
+  password: ""
+
+transform:
+  - source-table: trade_db.order_main
+    projection: "id, order_no, UPPER(product_name) AS product_name, amount"
+    filter: "status = 'PAID' AND amount > 0"
+    primary-keys: id
+    partition-keys: created_at
+    table-options: "comment=order realtime table"
+
+route:
+  - source-table: trade_db.order_main
+    sink-table: ods_db.ods_order_main
+
+pipeline:
+  name: Order Realtime Pipeline
+  parallelism: 2
+  schema.change.behavior: evolve
+  local-time-zone: Asia/Shanghai
+  user-defined-function:
+    - name: format_order
+      classpath: com.example.cdc.FormatOrderFunction
+      options:
+        prefix: "ORDER-"
+`;
+
+const createDefaultDraft = (taskId: string): CustomYamlDraft => ({
+  taskId,
+  mode: 'CUSTOM_YAML',
+  name: '自定义 Flink CDC Pipeline',
+  description: '',
+  flinkVersion: '2.2.1',
+  cdcVersion: '3.6.0',
+  yaml: DEFAULT_YAML,
+});
+
+const YamlConfigPage = () => {
+  const { id = `rt-${Date.now()}` } = useParams<{ id: string }>();
+  const [draft, setDraft] = useState<CustomYamlDraft>(() =>
+    loadRealtimeDraft<CustomYamlDraft>(id) || createDefaultDraft(id),
+  );
+  const [activeStep, setActiveStep] = useState('metadata');
+  const [saving, setSaving] = useState(false);
+  const validation = useMemo(() => validateCustomYaml(draft.yaml), [draft.yaml]);
+
+  const steps = [
+    {
+      key: 'metadata',
+      title: '任务信息',
+      description: '名称与运行版本',
+      complete: Boolean(draft.name.trim()),
+    },
+    {
+      key: 'yaml',
+      title: 'Pipeline YAML',
+      description: '编辑或导入 YAML 文件',
+      complete: validation.valid,
+    },
+    {
+      key: 'review',
+      title: '配置检查',
+      description: '检查必要区块与版本',
+      complete: Boolean(draft.name.trim() && validation.valid),
+    },
+  ];
+
+  const importFile = async (file: File) => {
+    const fileName = file.name.toLowerCase();
+    if (!fileName.endsWith('.yaml') && !fileName.endsWith('.yml')) {
+      message.error('请选择 .yaml 或 .yml 文件');
+      return Upload.LIST_IGNORE;
+    }
+    try {
+      const yaml = await file.text();
+      setDraft((current) => ({ ...current, yaml }));
+      setActiveStep('yaml');
+      message.success('YAML 文件已导入');
+    } catch {
+      message.error('读取 YAML 文件失败');
+    }
+    return false;
+  };
+
+  const save = async () => {
+    if (!draft.name.trim()) {
+      setActiveStep('metadata');
+      message.warning('请输入任务名称');
+      return;
+    }
+    if (!validation.valid) {
+      setActiveStep('yaml');
+      message.warning(`YAML 缺少必要区块：${validation.missing.join('、')}`);
+      return;
+    }
+
+    setSaving(true);
+    try {
+      saveRealtimeDraft(id, draft);
+      saveRealtimeTask({
+        id,
+        name: draft.name,
+        description: draft.description,
+        mode: 'CUSTOM_YAML',
+        status: 'DRAFT',
+        sourceType: 'YAML Pipeline',
+        sourceSummary: '由 YAML source 区块定义',
+        sinkType: 'YAML Pipeline',
+        sinkSummary: '由 YAML sink 区块定义',
+        flinkVersion: draft.flinkVersion,
+        cdcVersion: draft.cdcVersion,
+        updatedAt: formatUpdatedAt(),
+        yaml: draft.yaml,
+      });
+      message.success('自定义 YAML 草稿已保存');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <ConfigShell
+      taskId={id}
+      mode="CUSTOM_YAML"
+      title={draft.name || '未命名 YAML Pipeline'}
+      description={draft.description}
+      steps={steps}
+      activeStep={activeStep}
+      onStepChange={setActiveStep}
+      yaml={draft.yaml}
+      saving={saving}
+      onSave={() => void save()}
+    >
+      {activeStep === 'metadata' && (
+        <section className="overflow-hidden rounded-[10px] border border-black/[0.07] bg-white">
+          <div className="flex items-start gap-3 border-b border-black/[0.055] px-5 py-4">
+            <span className="mt-0.5 flex h-8 w-8 items-center justify-center rounded-[8px] bg-[#fff5e7] text-[#b54708]">
+              <FileCode2 size={17} strokeWidth={1.8} />
+            </span>
+            <div>
+              <div className="text-[13px] font-semibold text-[#161823]">自定义 Pipeline 信息</div>
+              <div className="mt-1 text-[11px] text-[rgba(22,24,35,0.46)]">
+                YAML 模式完全保留用户输入，前端只维护任务元数据和基础结构检查。
+              </div>
+            </div>
+          </div>
+          <div className="grid grid-cols-2 gap-5 p-5 max-lg:grid-cols-1">
+            <label className="block">
+              <span className="mb-2 block text-[11px] font-semibold text-[#343741]">
+                任务名称 <span className="text-[#d92d20]">*</span>
+              </span>
+              <Input
+                value={draft.name}
+                onChange={(event) => setDraft((current) => ({ ...current, name: event.target.value }))}
+                className="!h-10 !rounded-[7px] !border-black/[0.075] !text-[12px]"
+              />
+            </label>
+            <div className="grid grid-cols-2 gap-3">
+              <label>
+                <span className="mb-2 block text-[11px] font-semibold text-[#343741]">Flink 版本</span>
+                <Select
+                  value={draft.flinkVersion}
+                  options={[
+                    { label: 'Flink 2.2.1', value: '2.2.1' },
+                    { label: 'Flink 2.2.0', value: '2.2.0' },
+                    { label: 'Flink 1.20.2', value: '1.20.2' },
+                  ]}
+                  onChange={(flinkVersion) =>
+                    setDraft((current) => ({ ...current, flinkVersion }))
+                  }
+                  className="w-full [&_.ant-select-selector]:!h-10 [&_.ant-select-selector]:!rounded-[7px] [&_.ant-select-selector]:!border-black/[0.075] [&_.ant-select-selection-item]:!text-[11px] [&_.ant-select-selection-item]:!leading-[38px]"
+                />
+              </label>
+              <label>
+                <span className="mb-2 block text-[11px] font-semibold text-[#343741]">CDC 版本</span>
+                <Select
+                  value={draft.cdcVersion}
+                  options={[
+                    { label: 'CDC 3.6.0', value: '3.6.0' },
+                    { label: 'CDC 3.5.0', value: '3.5.0' },
+                  ]}
+                  onChange={(cdcVersion) =>
+                    setDraft((current) => ({ ...current, cdcVersion }))
+                  }
+                  className="w-full [&_.ant-select-selector]:!h-10 [&_.ant-select-selector]:!rounded-[7px] [&_.ant-select-selector]:!border-black/[0.075] [&_.ant-select-selection-item]:!text-[11px] [&_.ant-select-selection-item]:!leading-[38px]"
+                />
+              </label>
+            </div>
+            <div className="col-span-2 max-lg:col-span-1">
+              <span className="mb-2 block text-[11px] font-semibold text-[#343741]">任务描述</span>
+              <TextArea
+                value={draft.description}
+                onChange={(event) =>
+                  setDraft((current) => ({ ...current, description: event.target.value }))
+                }
+                autoSize={{ minRows: 3, maxRows: 5 }}
+                placeholder="说明 YAML Pipeline 的用途和维护信息"
+                className="!rounded-[7px] !border-black/[0.075] !text-[12px]"
+              />
+            </div>
+          </div>
+        </section>
+      )}
+
+      {activeStep === 'yaml' && (
+        <div className="space-y-4">
+          <Dragger
+            accept=".yaml,.yml,text/yaml,application/x-yaml"
+            maxCount={1}
+            showUploadList={false}
+            beforeUpload={importFile}
+            className="!rounded-[10px] !border-black/[0.08] !bg-white [&_.ant-upload]:!py-5"
+          >
+            <div className="flex items-center justify-center gap-3">
+              <span className="flex h-9 w-9 items-center justify-center rounded-[8px] bg-[#fff5e7] text-[#b54708]">
+                <FileUp size={18} strokeWidth={1.8} />
+              </span>
+              <div className="text-left">
+                <div className="text-[12px] font-semibold text-[#343741]">导入 YAML 文件</div>
+                <div className="mt-0.5 text-[10px] text-[rgba(22,24,35,0.42)]">
+                  点击或拖入 .yaml / .yml 文件，导入后仍可继续编辑。
+                </div>
+              </div>
+            </div>
+          </Dragger>
+
+          <section className="overflow-hidden rounded-[10px] border border-black/[0.07] bg-white">
+            <div className="flex items-center justify-between border-b border-black/[0.055] px-5 py-3.5">
+              <div>
+                <div className="text-[13px] font-semibold text-[#161823]">Pipeline YAML</div>
+                <div className="mt-1 text-[10px] text-[rgba(22,24,35,0.42)]">
+                  必须包含 source、sink 和 pipeline 区块；transform 与 route 为可选区块。
+                </div>
+              </div>
+              <div className="flex items-center gap-2">
+                {['source', 'sink', 'transform', 'route', 'pipeline'].map((section) => {
+                  const exists = new RegExp(`^${section}:`, 'm').test(draft.yaml);
+                  return (
+                    <Tag
+                      key={section}
+                      className={[
+                        '!m-0 !rounded-full !px-2 !font-mono !text-[9px]',
+                        exists
+                          ? '!border-[#b7e4cf] !bg-[#edf9f3] !text-[#16845b]'
+                          : '!border-black/[0.08] !bg-[#f7f8fa] !text-[rgba(22,24,35,0.40)]',
+                      ].join(' ')}
+                    >
+                      {section}
+                    </Tag>
+                  );
+                })}
+              </div>
+            </div>
+            <TextArea
+              value={draft.yaml}
+              spellCheck={false}
+              onChange={(event) =>
+                setDraft((current) => ({ ...current, yaml: event.target.value }))
+              }
+              className="!min-h-[620px] !resize-y !rounded-none !border-0 !bg-[#101318] !p-5 !font-mono !text-[12px] !leading-6 !text-[#d7dce2] !shadow-none focus:!shadow-none"
+            />
+          </section>
+        </div>
+      )}
+
+      {activeStep === 'review' && (
+        <div className="space-y-4">
+          <Alert
+            type={validation.valid ? 'success' : 'error'}
+            showIcon
+            message={validation.valid ? 'YAML 必要区块检查通过' : 'YAML 配置不完整'}
+            description={
+              validation.valid
+                ? '已检测到 source、sink 和 pipeline。更完整的 Connector 参数、表达式和 UDF 校验将在后端接入后执行。'
+                : `当前缺少：${validation.missing.join('、')}`
+            }
+            className="!rounded-[9px] [&_.ant-alert-message]:!text-[12px] [&_.ant-alert-description]:!text-[11px]"
+          />
+
+          <section className="overflow-hidden rounded-[10px] border border-black/[0.07] bg-white">
+            <div className="flex items-start gap-3 border-b border-black/[0.055] px-5 py-4">
+              <span className="mt-0.5 flex h-8 w-8 items-center justify-center rounded-[8px] bg-[#edf9f3] text-[#16845b]">
+                <ShieldCheck size={17} strokeWidth={1.8} />
+              </span>
+              <div>
+                <div className="text-[13px] font-semibold text-[#161823]">保存内容摘要</div>
+                <div className="mt-1 text-[11px] text-[rgba(22,24,35,0.46)]">
+                  保存后会在实时同步列表中生成草稿记录。
+                </div>
+              </div>
+            </div>
+            <div className="grid grid-cols-2 gap-x-8 gap-y-5 p-5 text-[11px] max-lg:grid-cols-1">
+              <div>
+                <div className="text-[rgba(22,24,35,0.42)]">任务名称</div>
+                <div className="mt-1 font-semibold text-[#343741]">{draft.name || '未填写'}</div>
+              </div>
+              <div>
+                <div className="text-[rgba(22,24,35,0.42)]">运行版本</div>
+                <div className="mt-1 font-semibold text-[#343741]">
+                  Flink {draft.flinkVersion} / CDC {draft.cdcVersion}
+                </div>
+              </div>
+              <div>
+                <div className="text-[rgba(22,24,35,0.42)]">YAML 行数</div>
+                <div className="mt-1 font-semibold text-[#343741]">
+                  {draft.yaml.split('\n').length} 行
+                </div>
+              </div>
+              <div>
+                <div className="text-[rgba(22,24,35,0.42)]">必要区块</div>
+                <div className="mt-1 font-semibold text-[#343741]">
+                  {validation.valid ? '完整' : `缺少 ${validation.missing.length} 项`}
+                </div>
+              </div>
+            </div>
+          </section>
+        </div>
+      )}
+    </ConfigShell>
+  );
+};
+
+export default YamlConfigPage;

--- a/yak-ops-ui/src/pages/realtime-link-up/config/index.tsx
+++ b/yak-ops-ui/src/pages/realtime-link-up/config/index.tsx
@@ -1,3 +1,29 @@
-const DataQualityPage = () => <div>good</div>;
+import { history, useLocation } from '@umijs/max';
+import { Empty, Button } from 'antd';
+import MultiConfigPage from './MultiConfigPage';
+import SingleConfigPage from './SingleConfigPage';
+import YamlConfigPage from './YamlConfigPage';
 
-export default DataQualityPage;
+const RealtimeConfigPage = () => {
+  const location = useLocation();
+  const mode = new URLSearchParams(location.search).get('mode');
+
+  if (mode === 'single') return <SingleConfigPage />;
+  if (mode === 'multi') return <MultiConfigPage />;
+  if (mode === 'yaml') return <YamlConfigPage />;
+
+  return (
+    <div className="flex min-h-[calc(100vh-48px)] items-center justify-center bg-[#f7f8fa]">
+      <Empty
+        image={Empty.PRESENTED_IMAGE_SIMPLE}
+        description="未识别实时同步配置模式"
+      >
+        <Button type="primary" onClick={() => history.push('/sync/realtime-link-up')}>
+          返回任务列表
+        </Button>
+      </Empty>
+    </div>
+  );
+};
+
+export default RealtimeConfigPage;

--- a/yak-ops-ui/src/pages/realtime-link-up/data.ts
+++ b/yak-ops-ui/src/pages/realtime-link-up/data.ts
@@ -1,0 +1,292 @@
+import type {
+  ColumnMapping,
+  MultiTableDraft,
+  PipelineConfig,
+  RealtimeTaskMode,
+  RealtimeTaskRecord,
+  SingleTableDraft,
+  SourceConfig,
+  SinkConfig,
+  TransformRule,
+  UdfDefinition,
+} from './types';
+
+export const REALTIME_TASK_STORAGE_KEY = 'yak-ops-realtime-task-records';
+export const REALTIME_DRAFT_STORAGE_PREFIX = 'yak-ops-realtime-draft-';
+
+export const modeMeta: Record<
+  RealtimeTaskMode,
+  { label: string; description: string; className: string }
+> = {
+  SINGLE_TABLE: {
+    label: '单表同步',
+    description: '一个来源表同步到一个目标表，支持完整 Transform 配置。',
+    className: 'border-[#c7d7fe] bg-[#eff4ff] text-[#315efb]',
+  },
+  MULTI_TABLE: {
+    label: '多表同步',
+    description: '整库或多表同步，支持多条 Transform 与 Route 规则。',
+    className: 'border-[#d9d6fe] bg-[#f4f3ff] text-[#6938ef]',
+  },
+  CUSTOM_YAML: {
+    label: '自定义 YAML',
+    description: '直接编辑或导入 Flink CDC Pipeline YAML。',
+    className: 'border-[#fedf89] bg-[#fffaeb] text-[#b54708]',
+  },
+};
+
+export const sourceDataSourceOptions = [
+  { label: '生产环境 / MySQL 订单库', value: 'mysql-prod-order', type: 'mysql' },
+  { label: '测试环境 / MySQL 业务库', value: 'mysql-test-app', type: 'mysql' },
+  { label: '生产环境 / PostgreSQL 用户库', value: 'pg-prod-user', type: 'postgres' },
+  { label: '生产环境 / Oracle HIS', value: 'oracle-prod-his', type: 'oracle' },
+];
+
+export const sinkDataSourceOptions = [
+  { label: '生产环境 / Doris 数仓', value: 'doris-prod-warehouse', type: 'doris' },
+  { label: '生产环境 / Paimon Lakehouse', value: 'paimon-prod-lake', type: 'paimon' },
+  { label: '生产环境 / StarRocks', value: 'starrocks-prod', type: 'starrocks' },
+  { label: '生产环境 / Iceberg Catalog', value: 'iceberg-prod', type: 'iceberg' },
+];
+
+export const sampleTables = [
+  'trade_db.order_main',
+  'trade_db.order_item',
+  'trade_db.order_payment',
+  'trade_db.order_refund',
+  'trade_db.order_address',
+];
+
+export const sampleColumns: ColumnMapping[] = [
+  { id: 'id', sourceName: 'id', sourceType: 'BIGINT', selected: true, targetName: 'id', expression: 'id', computed: false, comment: '主键' },
+  { id: 'order_no', sourceName: 'order_no', sourceType: 'STRING', selected: true, targetName: 'order_no', expression: 'order_no', computed: false },
+  { id: 'user_id', sourceName: 'user_id', sourceType: 'BIGINT', selected: true, targetName: 'user_id', expression: 'user_id', computed: false },
+  { id: 'product_name', sourceName: 'product_name', sourceType: 'STRING', selected: true, targetName: 'product_name', expression: 'product_name', computed: false },
+  { id: 'amount', sourceName: 'amount', sourceType: 'DECIMAL(18,2)', selected: true, targetName: 'amount', expression: 'amount', computed: false },
+  { id: 'status', sourceName: 'status', sourceType: 'STRING', selected: true, targetName: 'status', expression: 'status', computed: false },
+  { id: 'created_at', sourceName: 'created_at', sourceType: 'TIMESTAMP', selected: true, targetName: 'created_at', expression: 'created_at', computed: false },
+  { id: 'updated_at', sourceName: 'updated_at', sourceType: 'TIMESTAMP', selected: true, targetName: 'updated_at', expression: 'updated_at', computed: false },
+];
+
+export const transformFunctionGroups = [
+  {
+    label: '字符串函数',
+    options: [
+      { label: 'UPPER(value)', value: 'UPPER(${field})' },
+      { label: 'LOWER(value)', value: 'LOWER(${field})' },
+      { label: 'TRIM(value)', value: 'TRIM(${field})' },
+      { label: 'CONCAT(a, b)', value: "CONCAT(${field}, '')" },
+      { label: 'SUBSTRING(value, 1, 10)', value: 'SUBSTRING(${field}, 1, 10)' },
+      { label: 'REGEXP_REPLACE(value, pattern, replacement)', value: "REGEXP_REPLACE(${field}, '', '')" },
+    ],
+  },
+  {
+    label: '时间函数',
+    options: [
+      { label: 'CURRENT_TIMESTAMP', value: 'CURRENT_TIMESTAMP' },
+      { label: 'LOCALTIME', value: 'LOCALTIME' },
+      { label: 'LOCALTIMESTAMP', value: 'LOCALTIMESTAMP' },
+      { label: 'DATE_FORMAT(time, format)', value: "DATE_FORMAT(${field}, 'yyyy-MM-dd HH:mm:ss')" },
+      { label: 'TIMESTAMPDIFF(unit, start, end)', value: 'TIMESTAMPDIFF(DAY, ${field}, CURRENT_TIMESTAMP)' },
+    ],
+  },
+  {
+    label: '算术函数',
+    options: [
+      { label: 'ABS(value)', value: 'ABS(${field})' },
+      { label: 'ROUND(value, 2)', value: 'ROUND(${field}, 2)' },
+      { label: 'CEIL(value)', value: 'CEIL(${field})' },
+      { label: 'FLOOR(value)', value: 'FLOOR(${field})' },
+      { label: 'value * 100', value: '${field} * 100' },
+    ],
+  },
+  {
+    label: '条件函数',
+    options: [
+      { label: 'CASE WHEN', value: "CASE WHEN ${field} IS NULL THEN '' ELSE ${field} END" },
+      { label: 'COALESCE(value, default)', value: "COALESCE(${field}, '')" },
+      { label: 'NULLIF(a, b)', value: "NULLIF(${field}, '')" },
+    ],
+  },
+];
+
+const now = () => new Date().toLocaleString('zh-CN', { hour12: false });
+const uid = (prefix: string) => `${prefix}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+
+export const createTaskId = () => `rt-${Date.now()}`;
+
+export const createDefaultPipeline = (name = '未命名实时同步任务'): PipelineConfig => ({
+  name,
+  description: '',
+  parallelism: 2,
+  timezone: 'Asia/Shanghai',
+  schemaOperatorUid: 'schema-operator',
+  localTimezone: 'Asia/Shanghai',
+  checkpointInterval: 60,
+  restartStrategy: 'fixed-delay',
+  flinkVersion: '2.2.1',
+  cdcVersion: '3.6.0',
+});
+
+export const createDefaultSource = (): SourceConfig => ({
+  dataSourceId: 'mysql-prod-order',
+  type: 'mysql',
+  database: 'trade_db',
+  schema: '',
+  table: 'order_main',
+  tables: ['trade_db.order_main', 'trade_db.order_item'],
+  tablePattern: 'trade_db.order_.*',
+  startupMode: 'initial',
+  serverId: '5400-5404',
+  timezone: 'Asia/Shanghai',
+  advanced: [],
+});
+
+export const createDefaultSink = (): SinkConfig => ({
+  dataSourceId: 'doris-prod-warehouse',
+  type: 'doris',
+  database: 'ods_db',
+  schema: '',
+  table: 'ods_order_main',
+  tablePrefix: 'ods_',
+  tableSuffix: '',
+  createTable: true,
+  schemaChangeBehavior: 'evolve',
+  advanced: [],
+});
+
+export const createDefaultTransform = (sourceTable = 'trade_db.order_main'): TransformRule => ({
+  id: uid('transform'),
+  sourceTable,
+  description: '',
+  columns: sampleColumns.map((column) => ({ ...column })),
+  filter: '',
+  primaryKeys: ['id'],
+  partitionKeys: [],
+  tableOptions: [],
+  tableOptionsDelimiter: ',',
+});
+
+export const createDefaultUdf = (): UdfDefinition => ({
+  id: uid('udf'),
+  name: '',
+  classpath: '',
+  options: [],
+});
+
+export const createDefaultSingleDraft = (taskId: string): SingleTableDraft => ({
+  taskId,
+  mode: 'SINGLE_TABLE',
+  pipeline: createDefaultPipeline('订单单表实时同步'),
+  source: createDefaultSource(),
+  sink: createDefaultSink(),
+  transform: createDefaultTransform(),
+  udfs: [],
+});
+
+export const createDefaultMultiDraft = (taskId: string): MultiTableDraft => ({
+  taskId,
+  mode: 'MULTI_TABLE',
+  pipeline: createDefaultPipeline('订单库多表实时同步'),
+  source: createDefaultSource(),
+  sink: createDefaultSink(),
+  transforms: [
+    createDefaultTransform('trade_db.order_main'),
+    createDefaultTransform('trade_db.order_item'),
+  ],
+  routes: [
+    { id: uid('route'), sourceTable: 'trade_db.order_main', sinkTable: 'ods_db.ods_order_main', description: '' },
+    { id: uid('route'), sourceTable: 'trade_db.order_item', sinkTable: 'ods_db.ods_order_item', description: '' },
+  ],
+  udfs: [],
+});
+
+const builtinTasks: RealtimeTaskRecord[] = [
+  {
+    id: 'rt-demo-001',
+    name: '订单主表实时同步',
+    description: 'MySQL 订单主表实时写入 Doris ODS 层',
+    mode: 'SINGLE_TABLE',
+    status: 'RUNNING',
+    sourceType: 'MySQL CDC',
+    sourceSummary: 'trade_db.order_main',
+    sinkType: 'Doris',
+    sinkSummary: 'ods_db.ods_order_main',
+    flinkVersion: '2.2.1',
+    cdcVersion: '3.6.0',
+    updatedAt: now(),
+  },
+  {
+    id: 'rt-demo-002',
+    name: '订单库多表实时入仓',
+    description: 'order_* 多表同步与路由',
+    mode: 'MULTI_TABLE',
+    status: 'DRAFT',
+    sourceType: 'MySQL CDC',
+    sourceSummary: 'trade_db.order_*（5 张表）',
+    sinkType: 'Doris',
+    sinkSummary: 'ods_db.ods_*',
+    flinkVersion: '2.2.1',
+    cdcVersion: '3.6.0',
+    updatedAt: now(),
+  },
+  {
+    id: 'rt-demo-003',
+    name: '自定义会员同步 Pipeline',
+    description: '通过 YAML 管理复杂 Pipeline 配置',
+    mode: 'CUSTOM_YAML',
+    status: 'STOPPED',
+    sourceType: 'PostgreSQL CDC',
+    sourceSummary: 'member.public.*',
+    sinkType: 'Paimon',
+    sinkSummary: 'ods_member.*',
+    flinkVersion: '2.2.1',
+    cdcVersion: '3.6.0',
+    updatedAt: now(),
+  },
+];
+
+export const loadRealtimeTasks = (): RealtimeTaskRecord[] => {
+  if (typeof window === 'undefined') return builtinTasks;
+  try {
+    const raw = window.localStorage.getItem(REALTIME_TASK_STORAGE_KEY);
+    if (!raw) return builtinTasks;
+    const saved = JSON.parse(raw) as RealtimeTaskRecord[];
+    const demoIds = new Set(saved.map((item) => item.id));
+    return [...saved, ...builtinTasks.filter((item) => !demoIds.has(item.id))];
+  } catch {
+    return builtinTasks;
+  }
+};
+
+export const saveRealtimeTask = (task: RealtimeTaskRecord) => {
+  if (typeof window === 'undefined') return;
+  const tasks = loadRealtimeTasks().filter((item) => !item.id.startsWith('rt-demo-'));
+  const next = [task, ...tasks.filter((item) => item.id !== task.id)];
+  window.localStorage.setItem(REALTIME_TASK_STORAGE_KEY, JSON.stringify(next));
+};
+
+export const removeRealtimeTask = (taskId: string) => {
+  if (typeof window === 'undefined') return;
+  const tasks = loadRealtimeTasks().filter(
+    (item) => item.id !== taskId && !item.id.startsWith('rt-demo-'),
+  );
+  window.localStorage.setItem(REALTIME_TASK_STORAGE_KEY, JSON.stringify(tasks));
+};
+
+export const saveRealtimeDraft = (taskId: string, draft: unknown) => {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem(`${REALTIME_DRAFT_STORAGE_PREFIX}${taskId}`, JSON.stringify(draft));
+};
+
+export const loadRealtimeDraft = <T,>(taskId: string): T | null => {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = window.localStorage.getItem(`${REALTIME_DRAFT_STORAGE_PREFIX}${taskId}`);
+    return raw ? (JSON.parse(raw) as T) : null;
+  } catch {
+    return null;
+  }
+};
+
+export const formatUpdatedAt = () => now();

--- a/yak-ops-ui/src/pages/realtime-link-up/detail/index.tsx
+++ b/yak-ops-ui/src/pages/realtime-link-up/detail/index.tsx
@@ -1,3 +1,136 @@
-const DataQualityPage = () => <div>good</div>;
+import { ArrowLeft, ArrowRight, DatabaseZap, FileCode2, Table2 } from 'lucide-react';
+import { history, useParams } from '@umijs/max';
+import { Tag } from 'antd';
+import { modeMeta } from '../data';
 
-export default DataQualityPage;
+const modes = [
+  {
+    key: 'single',
+    mode: 'SINGLE_TABLE' as const,
+    title: '单表同步',
+    subtitle: '一个来源表 → 一个目标表',
+    description:
+      '适合订单主表、用户表等明确的一对一实时同步。配置字段投影、重命名、计算字段、行过滤、主键、分区键、建表参数和 UDF。',
+    icon: <Table2 size={22} strokeWidth={1.7} />,
+    iconClassName: 'bg-[#eff4ff] text-[#315efb]',
+    features: ['来源表与目标表配置', '可视化字段投影与过滤', '主键 / 分区键重设', '自动生成 Pipeline YAML'],
+  },
+  {
+    key: 'multi',
+    mode: 'MULTI_TABLE' as const,
+    title: '多表同步',
+    subtitle: '整库、多表或表名规则同步',
+    description:
+      '适合整库同步、分库分表合并与多表路由。每张表可以配置独立 Transform，并通过 Route 映射到不同目标表。',
+    icon: <DatabaseZap size={22} strokeWidth={1.7} />,
+    iconClassName: 'bg-[#f4f3ff] text-[#6938ef]',
+    features: ['表名正则与表清单', '多条 Transform 规则', 'Route 表路由映射', '统一 UDF 与运行参数'],
+  },
+  {
+    key: 'yaml',
+    mode: 'CUSTOM_YAML' as const,
+    title: '自定义 YAML',
+    subtitle: '直接编辑 Flink CDC Pipeline',
+    description:
+      '适合熟悉 Flink CDC 的高级用户，以及需要使用暂未在可视化页面开放的 Connector 参数和 Pipeline 能力。',
+    icon: <FileCode2 size={22} strokeWidth={1.7} />,
+    iconClassName: 'bg-[#fff5e7] text-[#b54708]',
+    features: ['导入 .yaml / .yml 文件', '保留完整原始配置', '必要区块实时检查', '支持 Transform、Route 与 UDF'],
+  },
+];
+
+const RealtimeTaskTypePage = () => {
+  const { id = `rt-${Date.now()}` } = useParams<{ id: string }>();
+
+  const selectMode = (mode: string) => {
+    history.push(`/sync/realtime-link-up/${id}/config?mode=${mode}&scene=create`);
+  };
+
+  return (
+    <div className="min-h-[calc(100vh-48px)] bg-[#f7f8fa]">
+      <header className="border-b border-black/[0.07] bg-white">
+        <div className="flex h-[66px] items-center px-5">
+          <button
+            type="button"
+            onClick={() => history.push('/sync/realtime-link-up')}
+            className="flex h-9 w-9 items-center justify-center rounded-[8px] border border-black/[0.07] bg-white text-[rgba(22,24,35,0.58)] transition hover:border-black/[0.14] hover:text-[#161823]"
+          >
+            <ArrowLeft size={17} strokeWidth={1.9} />
+          </button>
+          <div className="ml-3">
+            <div className="text-[16px] font-semibold text-[#161823]">新建实时同步任务</div>
+            <div className="mt-0.5 text-[10px] text-[rgba(22,24,35,0.42)]">选择创建模式后进入对应配置页面</div>
+          </div>
+        </div>
+      </header>
+
+      <main className="mx-auto max-w-[1320px] px-6 py-10">
+        <div className="text-center">
+          <Tag className="!m-0 !rounded-full !border-black/[0.07] !bg-white !px-3 !py-1 !text-[10px] !font-medium !text-[rgba(22,24,35,0.52)]">
+            Flink CDC Pipeline
+          </Tag>
+          <h1 className="mt-4 text-[26px] font-semibold tracking-[-0.02em] text-[#161823]">
+            选择实时同步任务类型
+          </h1>
+          <p className="mx-auto mt-3 max-w-[720px] text-[12px] leading-6 text-[rgba(22,24,35,0.50)]">
+            第一版不引入 Debezium Server、Kafka 或 Kafka Connect。三种模式最终都保存为 Flink CDC Pipeline 配置，后续由后端负责校验与提交。
+          </p>
+        </div>
+
+        <div className="mt-9 grid grid-cols-3 gap-5 max-xl:grid-cols-1">
+          {modes.map((item) => {
+            const meta = modeMeta[item.mode];
+            return (
+              <button
+                key={item.key}
+                type="button"
+                onClick={() => selectMode(item.key)}
+                className="group flex min-h-[420px] flex-col rounded-[12px] border border-black/[0.08] bg-white p-6 text-left shadow-[0_1px_2px_rgba(16,24,40,0.03)] transition duration-200 hover:-translate-y-0.5 hover:border-black/[0.16] hover:shadow-[0_12px_32px_rgba(16,24,40,0.08)]"
+              >
+                <div className="flex items-start justify-between gap-4">
+                  <span className={`flex h-12 w-12 items-center justify-center rounded-[10px] ${item.iconClassName}`}>
+                    {item.icon}
+                  </span>
+                  <Tag className={`!m-0 !rounded-full !px-2.5 !text-[10px] ${meta.className}`}>
+                    {item.key === 'single' ? '推荐入门' : item.key === 'multi' ? '批量同步' : '高级模式'}
+                  </Tag>
+                </div>
+
+                <div className="mt-6 text-[19px] font-semibold text-[#161823]">{item.title}</div>
+                <div className="mt-1 text-[11px] font-medium text-[#315efb]">{item.subtitle}</div>
+                <p className="mt-4 min-h-[72px] text-[11px] leading-6 text-[rgba(22,24,35,0.52)]">
+                  {item.description}
+                </p>
+
+                <div className="mt-5 space-y-3 border-t border-black/[0.055] pt-5">
+                  {item.features.map((feature) => (
+                    <div key={feature} className="flex items-center gap-2 text-[11px] text-[#343741]">
+                      <span className="h-1.5 w-1.5 rounded-full bg-[#9aa1ad]" />
+                      {feature}
+                    </div>
+                  ))}
+                </div>
+
+                <div className="mt-auto flex items-center justify-between border-t border-black/[0.055] pt-5 text-[11px] font-semibold text-[#161823]">
+                  <span>使用此模式</span>
+                  <ArrowRight
+                    size={16}
+                    strokeWidth={1.9}
+                    className="transition-transform group-hover:translate-x-1"
+                  />
+                </div>
+              </button>
+            );
+          })}
+        </div>
+
+        <div className="mt-6 rounded-[10px] border border-black/[0.07] bg-white px-5 py-4 text-[11px] leading-5 text-[rgba(22,24,35,0.50)]">
+          <span className="font-semibold text-[#343741]">配置说明：</span>
+          中间不设置连接测试步骤。单表和多表页面使用结构化表单生成 YAML；自定义 YAML 页面直接保存用户内容。三种模式都只完成任务定义，不涉及运行执行。
+        </div>
+      </main>
+    </div>
+  );
+};
+
+export default RealtimeTaskTypePage;

--- a/yak-ops-ui/src/pages/realtime-link-up/index.tsx
+++ b/yak-ops-ui/src/pages/realtime-link-up/index.tsx
@@ -1,3 +1,431 @@
-const DataQualityPage = () => <div>good</div>;
+import {
+  Activity,
+  Copy,
+  DatabaseZap,
+  FileCode2,
+  MoreHorizontal,
+  Plus,
+  RefreshCw,
+  Search,
+  Table2,
+  Trash2,
+} from 'lucide-react';
+import { history } from '@umijs/max';
+import {
+  Button,
+  Dropdown,
+  Empty,
+  Input,
+  message,
+  Modal,
+  Select,
+  Table,
+  Tag,
+  type MenuProps,
+  type TableColumnsType,
+} from 'antd';
+import { useEffect, useMemo, useState, type ReactNode } from 'react';
+import {
+  createTaskId,
+  loadRealtimeTasks,
+  modeMeta,
+  removeRealtimeTask,
+} from './data';
+import type {
+  RealtimeTaskMode,
+  RealtimeTaskRecord,
+  RealtimeTaskStatus,
+} from './types';
 
-export default DataQualityPage;
+const statusMeta: Record<
+  RealtimeTaskStatus,
+  { label: string; className: string; dotClassName: string }
+> = {
+  DRAFT: {
+    label: '草稿',
+    className: '!border-[#fedf89] !bg-[#fffaeb] !text-[#b54708]',
+    dotClassName: 'bg-[#f79009]',
+  },
+  RUNNING: {
+    label: '运行中',
+    className: '!border-[#b7e4cf] !bg-[#edf9f3] !text-[#16845b]',
+    dotClassName: 'bg-[#12b76a]',
+  },
+  STOPPED: {
+    label: '已停止',
+    className: '!border-black/[0.08] !bg-[#f7f8fa] !text-[rgba(22,24,35,0.55)]',
+    dotClassName: 'bg-[#98a2b3]',
+  },
+  FAILED: {
+    label: '异常',
+    className: '!border-[#fecdca] !bg-[#fef3f2] !text-[#b42318]',
+    dotClassName: 'bg-[#f04438]',
+  },
+};
+
+const modeIcon: Record<RealtimeTaskMode, ReactNode> = {
+  SINGLE_TABLE: <Table2 size={15} strokeWidth={1.8} />,
+  MULTI_TABLE: <DatabaseZap size={15} strokeWidth={1.8} />,
+  CUSTOM_YAML: <FileCode2 size={15} strokeWidth={1.8} />,
+};
+
+const modeQuery: Record<RealtimeTaskMode, string> = {
+  SINGLE_TABLE: 'single',
+  MULTI_TABLE: 'multi',
+  CUSTOM_YAML: 'yaml',
+};
+
+const RealtimeLinkUpPage = () => {
+  const [tasks, setTasks] = useState<RealtimeTaskRecord[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [keyword, setKeyword] = useState('');
+  const [mode, setMode] = useState<RealtimeTaskMode | undefined>();
+  const [status, setStatus] = useState<RealtimeTaskStatus | undefined>();
+
+  const refresh = () => {
+    setLoading(true);
+    window.setTimeout(() => {
+      setTasks(loadRealtimeTasks());
+      setLoading(false);
+    }, 180);
+  };
+
+  useEffect(() => {
+    refresh();
+  }, []);
+
+  const filteredTasks = useMemo(() => {
+    const normalized = keyword.trim().toLowerCase();
+    return tasks.filter((task) => {
+      if (mode && task.mode !== mode) return false;
+      if (status && task.status !== status) return false;
+      if (!normalized) return true;
+      return [
+        task.id,
+        task.name,
+        task.description,
+        task.sourceSummary,
+        task.sinkSummary,
+      ]
+        .filter(Boolean)
+        .some((value) => String(value).toLowerCase().includes(normalized));
+    });
+  }, [keyword, mode, status, tasks]);
+
+  const stats = useMemo(
+    () => ({
+      total: tasks.length,
+      running: tasks.filter((task) => task.status === 'RUNNING').length,
+      draft: tasks.filter((task) => task.status === 'DRAFT').length,
+      yaml: tasks.filter((task) => task.mode === 'CUSTOM_YAML').length,
+    }),
+    [tasks],
+  );
+
+  const goEdit = (task: RealtimeTaskRecord) => {
+    history.push(
+      `/sync/realtime-link-up/${task.id}/config?mode=${modeQuery[task.mode]}&scene=edit`,
+    );
+  };
+
+  const copyId = async (taskId: string) => {
+    try {
+      await navigator.clipboard.writeText(taskId);
+      message.success('任务 ID 已复制');
+    } catch {
+      message.error('复制失败，请手动复制');
+    }
+  };
+
+  const remove = (task: RealtimeTaskRecord) => {
+    if (task.id.startsWith('rt-demo-')) {
+      message.info('示例任务用于页面预览，不能删除');
+      return;
+    }
+    Modal.confirm({
+      title: '删除实时同步任务？',
+      content: `确定删除“${task.name}”吗？此操作只删除当前浏览器中的前端草稿。`,
+      okText: '删除',
+      okButtonProps: { danger: true },
+      cancelText: '取消',
+      onOk: () => {
+        removeRealtimeTask(task.id);
+        refresh();
+        message.success('任务已删除');
+      },
+    });
+  };
+
+  const columns: TableColumnsType<RealtimeTaskRecord> = [
+    {
+      title: '任务名称',
+      dataIndex: 'name',
+      width: 290,
+      fixed: 'left',
+      render: (_, task) => (
+        <button
+          type="button"
+          onClick={() => goEdit(task)}
+          className="group flex min-w-0 items-center gap-3 border-0 bg-transparent p-0 text-left"
+        >
+          <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-[8px] bg-[#f1f3f6] text-[#424754] transition group-hover:bg-[#e9edf2]">
+            {modeIcon[task.mode]}
+          </span>
+          <span className="min-w-0">
+            <span className="block truncate text-[12px] font-semibold text-[#252832] group-hover:text-[#315efb]">
+              {task.name}
+            </span>
+            <span className="mt-1 block truncate text-[10px] text-[rgba(22,24,35,0.42)]">
+              {task.description || task.id}
+            </span>
+          </span>
+        </button>
+      ),
+    },
+    {
+      title: '任务类型',
+      dataIndex: 'mode',
+      width: 130,
+      render: (value: RealtimeTaskMode) => {
+        const meta = modeMeta[value];
+        return (
+          <Tag className={`!m-0 !rounded-full !px-2.5 !text-[10px] ${meta.className}`}>
+            {meta.label}
+          </Tag>
+        );
+      },
+    },
+    {
+      title: '同步链路',
+      key: 'pipeline',
+      width: 360,
+      render: (_, task) => (
+        <div className="flex min-w-0 items-center gap-2 text-[10px]">
+          <div className="min-w-0 flex-1 rounded-[6px] border border-black/[0.055] bg-[#fafafa] px-2.5 py-2">
+            <div className="font-semibold text-[#343741]">{task.sourceType}</div>
+            <div className="mt-0.5 truncate font-mono text-[9px] text-[rgba(22,24,35,0.42)]">
+              {task.sourceSummary}
+            </div>
+          </div>
+          <span className="text-[rgba(22,24,35,0.30)]">→</span>
+          <div className="min-w-0 flex-1 rounded-[6px] border border-black/[0.055] bg-[#fafafa] px-2.5 py-2">
+            <div className="font-semibold text-[#343741]">{task.sinkType}</div>
+            <div className="mt-0.5 truncate font-mono text-[9px] text-[rgba(22,24,35,0.42)]">
+              {task.sinkSummary}
+            </div>
+          </div>
+        </div>
+      ),
+    },
+    {
+      title: '运行版本',
+      key: 'version',
+      width: 160,
+      render: (_, task) => (
+        <div className="text-[10px] leading-5 text-[#343741]">
+          <div>Flink {task.flinkVersion}</div>
+          <div className="text-[rgba(22,24,35,0.42)]">CDC {task.cdcVersion}</div>
+        </div>
+      ),
+    },
+    {
+      title: '状态',
+      dataIndex: 'status',
+      width: 105,
+      render: (value: RealtimeTaskStatus) => {
+        const meta = statusMeta[value];
+        return (
+          <Tag className={`!m-0 !inline-flex !items-center !gap-1.5 !rounded-full !px-2.5 !text-[10px] ${meta.className}`}>
+            <span className={`h-1.5 w-1.5 rounded-full ${meta.dotClassName}`} />
+            {meta.label}
+          </Tag>
+        );
+      },
+    },
+    {
+      title: '更新时间',
+      dataIndex: 'updatedAt',
+      width: 170,
+      render: (value: string) => (
+        <span className="text-[10px] text-[rgba(22,24,35,0.48)]">{value}</span>
+      ),
+    },
+    {
+      title: '操作',
+      key: 'action',
+      fixed: 'right',
+      width: 100,
+      align: 'center',
+      render: (_, task) => {
+        const items: MenuProps['items'] = [
+          {
+            key: 'copy',
+            icon: <Copy size={14} />,
+            label: '复制任务 ID',
+            onClick: () => void copyId(task.id),
+          },
+          { type: 'divider' },
+          {
+            key: 'delete',
+            danger: true,
+            icon: <Trash2 size={14} />,
+            label: '删除任务',
+            onClick: () => remove(task),
+          },
+        ];
+        return (
+          <div className="flex items-center justify-center gap-1">
+            <Button
+              type="link"
+              size="small"
+              onClick={() => goEdit(task)}
+              className="!px-1 !text-[10px] !font-semibold !text-[#315efb]"
+            >
+              编辑
+            </Button>
+            <Dropdown menu={{ items }} trigger={['click']} placement="bottomRight">
+              <button
+                type="button"
+                className="flex h-7 w-7 items-center justify-center rounded-[6px] border-0 bg-transparent text-[rgba(22,24,35,0.40)] hover:bg-[#f1f3f6] hover:text-[#161823]"
+              >
+                <MoreHorizontal size={15} />
+              </button>
+            </Dropdown>
+          </div>
+        );
+      },
+    },
+  ];
+
+  const createTask = () => {
+    const taskId = createTaskId();
+    history.push(`/sync/realtime-link-up/${taskId}/detail?scene=create`);
+  };
+
+  return (
+    <div className="min-h-[calc(100vh-48px)] bg-[#f7f8fa] px-5 py-5">
+      <div className="mx-auto max-w-[1560px]">
+        <div className="flex items-start justify-between gap-5">
+          <div>
+            <div className="flex items-center gap-2">
+              <span className="flex h-9 w-9 items-center justify-center rounded-[9px] bg-[#161823] text-white">
+                <Activity size={18} strokeWidth={1.8} />
+              </span>
+              <div>
+                <h1 className="text-[20px] font-semibold tracking-[-0.01em] text-[#161823]">实时同步</h1>
+                <p className="mt-0.5 text-[11px] text-[rgba(22,24,35,0.46)]">
+                  基于 Flink CDC Pipeline 管理单表、多表和自定义 YAML 实时任务定义
+                </p>
+              </div>
+            </div>
+          </div>
+          <Button
+            type="primary"
+            icon={<Plus size={15} strokeWidth={2} />}
+            onClick={createTask}
+            className="!h-9 !rounded-[8px] !border-[#161823] !bg-[#161823] !px-4 !text-[11px] !font-semibold hover:!border-[#2b2d38] hover:!bg-[#2b2d38]"
+          >
+            新建实时同步
+          </Button>
+        </div>
+
+        <div className="mt-5 grid grid-cols-4 gap-3 max-xl:grid-cols-2 max-md:grid-cols-1">
+          {[
+            { label: '任务总数', value: stats.total, help: '当前全部任务定义' },
+            { label: '运行中', value: stats.running, help: '后续由执行接口更新' },
+            { label: '草稿任务', value: stats.draft, help: '尚未发布的配置' },
+            { label: '自定义 YAML', value: stats.yaml, help: '高级 Pipeline 模式' },
+          ].map((item) => (
+            <div key={item.label} className="rounded-[10px] border border-black/[0.065] bg-white px-4 py-4">
+              <div className="text-[10px] font-medium text-[rgba(22,24,35,0.44)]">{item.label}</div>
+              <div className="mt-2 text-[23px] font-semibold tracking-[-0.02em] text-[#161823]">{item.value}</div>
+              <div className="mt-1 text-[9px] text-[rgba(22,24,35,0.36)]">{item.help}</div>
+            </div>
+          ))}
+        </div>
+
+        <section className="mt-4 overflow-hidden rounded-[10px] border border-black/[0.065] bg-white">
+          <div className="flex flex-wrap items-center justify-between gap-3 border-b border-black/[0.055] px-4 py-3.5">
+            <div className="flex flex-1 flex-wrap items-center gap-2">
+              <Input
+                allowClear
+                value={keyword}
+                onChange={(event) => setKeyword(event.target.value)}
+                prefix={<Search size={14} className="text-[rgba(22,24,35,0.30)]" />}
+                placeholder="搜索任务名称、ID、来源表或目标表"
+                className="!h-9 !w-[320px] !rounded-[7px] !border-black/[0.075] !text-[11px] max-md:!w-full"
+              />
+              <Select
+                allowClear
+                value={mode}
+                onChange={setMode}
+                placeholder="全部类型"
+                options={Object.entries(modeMeta).map(([value, meta]) => ({
+                  label: meta.label,
+                  value,
+                }))}
+                className="w-[150px] [&_.ant-select-selector]:!h-9 [&_.ant-select-selector]:!rounded-[7px] [&_.ant-select-selector]:!border-black/[0.075] [&_.ant-select-selection-item]:!text-[10px] [&_.ant-select-selection-item]:!leading-[34px] [&_.ant-select-selection-placeholder]:!text-[10px] [&_.ant-select-selection-placeholder]:!leading-[34px]"
+              />
+              <Select
+                allowClear
+                value={status}
+                onChange={setStatus}
+                placeholder="全部状态"
+                options={Object.entries(statusMeta).map(([value, meta]) => ({
+                  label: meta.label,
+                  value,
+                }))}
+                className="w-[140px] [&_.ant-select-selector]:!h-9 [&_.ant-select-selector]:!rounded-[7px] [&_.ant-select-selector]:!border-black/[0.075] [&_.ant-select-selection-item]:!text-[10px] [&_.ant-select-selection-item]:!leading-[34px] [&_.ant-select-selection-placeholder]:!text-[10px] [&_.ant-select-selection-placeholder]:!leading-[34px]"
+              />
+            </div>
+            <button
+              type="button"
+              onClick={refresh}
+              className="flex h-8 w-8 items-center justify-center rounded-[7px] border border-black/[0.07] bg-white text-[rgba(22,24,35,0.42)] transition hover:border-black/[0.14] hover:text-[#161823]"
+            >
+              <RefreshCw size={14} className={loading ? 'animate-spin' : ''} />
+            </button>
+          </div>
+
+          <Table<RealtimeTaskRecord>
+            rowKey="id"
+            columns={columns}
+            dataSource={filteredTasks}
+            loading={loading}
+            pagination={{
+              pageSize: 10,
+              showSizeChanger: true,
+              showTotal: (total) => `共 ${total} 条`,
+              className: '!mx-4 !my-3 !text-[10px]',
+            }}
+            scroll={{ x: 1320 }}
+            className={[
+              '[&_.ant-table]:!rounded-none',
+              '[&_.ant-table-container]:!border-0',
+              '[&_.ant-table-thead>tr>th]:!h-11',
+              '[&_.ant-table-thead>tr>th]:!border-b',
+              '[&_.ant-table-thead>tr>th]:!border-black/[0.055]',
+              '[&_.ant-table-thead>tr>th]:!bg-[#fafafa]',
+              '[&_.ant-table-thead>tr>th]:!text-[10px]',
+              '[&_.ant-table-thead>tr>th]:!font-semibold',
+              '[&_.ant-table-thead>tr>th]:!text-[rgba(22,24,35,0.55)]',
+              '[&_.ant-table-tbody>tr>td]:!border-black/[0.045]',
+              '[&_.ant-table-tbody>tr>td]:!py-3',
+              '[&_.ant-table-tbody>tr:hover>td]:!bg-[#fcfcfd]',
+            ].join(' ')}
+            locale={{
+              emptyText: (
+                <Empty
+                  image={Empty.PRESENTED_IMAGE_SIMPLE}
+                  description={<span className="text-[11px] text-[rgba(22,24,35,0.42)]">暂无符合条件的实时同步任务</span>}
+                />
+              ),
+            }}
+          />
+        </section>
+      </div>
+    </div>
+  );
+};
+
+export default RealtimeLinkUpPage;

--- a/yak-ops-ui/src/pages/realtime-link-up/types.ts
+++ b/yak-ops-ui/src/pages/realtime-link-up/types.ts
@@ -1,0 +1,137 @@
+export type RealtimeTaskMode = 'SINGLE_TABLE' | 'MULTI_TABLE' | 'CUSTOM_YAML';
+
+export type RealtimeTaskStatus = 'DRAFT' | 'RUNNING' | 'STOPPED' | 'FAILED';
+
+export interface RealtimeTaskRecord {
+  id: string;
+  name: string;
+  description?: string;
+  mode: RealtimeTaskMode;
+  status: RealtimeTaskStatus;
+  sourceType: string;
+  sourceSummary: string;
+  sinkType: string;
+  sinkSummary: string;
+  flinkVersion: string;
+  cdcVersion: string;
+  updatedAt: string;
+  yaml?: string;
+}
+
+export interface ColumnMapping {
+  id: string;
+  sourceName: string;
+  sourceType: string;
+  selected: boolean;
+  targetName: string;
+  expression: string;
+  computed: boolean;
+  comment?: string;
+}
+
+export interface TableOptionEntry {
+  id: string;
+  key: string;
+  value: string;
+}
+
+export interface UdfOptionEntry {
+  id: string;
+  key: string;
+  value: string;
+}
+
+export interface UdfDefinition {
+  id: string;
+  name: string;
+  classpath: string;
+  options: UdfOptionEntry[];
+}
+
+export interface TransformRule {
+  id: string;
+  sourceTable: string;
+  description: string;
+  columns: ColumnMapping[];
+  filter: string;
+  primaryKeys: string[];
+  partitionKeys: string[];
+  tableOptions: TableOptionEntry[];
+  tableOptionsDelimiter: string;
+}
+
+export interface SourceConfig {
+  dataSourceId: string;
+  type: 'mysql' | 'postgres' | 'oracle';
+  database: string;
+  schema: string;
+  table: string;
+  tables: string[];
+  tablePattern: string;
+  startupMode: 'initial' | 'latest-offset' | 'specific-offset' | 'timestamp';
+  serverId: string;
+  timezone: string;
+  advanced: TableOptionEntry[];
+}
+
+export interface SinkConfig {
+  dataSourceId: string;
+  type: 'doris' | 'paimon' | 'starrocks' | 'iceberg';
+  database: string;
+  schema: string;
+  table: string;
+  tablePrefix: string;
+  tableSuffix: string;
+  createTable: boolean;
+  schemaChangeBehavior: 'evolve' | 'try_evolve' | 'lenient' | 'ignore' | 'exception';
+  advanced: TableOptionEntry[];
+}
+
+export interface PipelineConfig {
+  name: string;
+  description: string;
+  parallelism: number;
+  timezone: string;
+  schemaOperatorUid: string;
+  localTimezone: string;
+  checkpointInterval: number;
+  restartStrategy: 'fixed-delay' | 'failure-rate' | 'none';
+  flinkVersion: string;
+  cdcVersion: string;
+}
+
+export interface SingleTableDraft {
+  taskId: string;
+  mode: 'SINGLE_TABLE';
+  pipeline: PipelineConfig;
+  source: SourceConfig;
+  sink: SinkConfig;
+  transform: TransformRule;
+  udfs: UdfDefinition[];
+}
+
+export interface MultiTableDraft {
+  taskId: string;
+  mode: 'MULTI_TABLE';
+  pipeline: PipelineConfig;
+  source: SourceConfig;
+  sink: SinkConfig;
+  transforms: TransformRule[];
+  routes: Array<{
+    id: string;
+    sourceTable: string;
+    sinkTable: string;
+    description: string;
+  }>;
+  udfs: UdfDefinition[];
+}
+
+export interface CustomYamlDraft {
+  taskId: string;
+  mode: 'CUSTOM_YAML';
+  name: string;
+  description: string;
+  flinkVersion: string;
+  cdcVersion: string;
+  yaml: string;
+}

--- a/yak-ops-ui/src/pages/realtime-link-up/yaml.ts
+++ b/yak-ops-ui/src/pages/realtime-link-up/yaml.ts
@@ -1,0 +1,188 @@
+import type {
+  MultiTableDraft,
+  SingleTableDraft,
+  TableOptionEntry,
+  TransformRule,
+  UdfDefinition,
+} from './types';
+
+const quote = (value: string) => {
+  if (!value) return '""';
+  if (/^[a-zA-Z0-9_./:*\\-]+$/.test(value)) return value;
+  return JSON.stringify(value);
+};
+
+const indent = (level: number) => '  '.repeat(level);
+
+const appendOptions = (
+  lines: string[],
+  options: TableOptionEntry[],
+  level: number,
+) => {
+  options
+    .filter((option) => option.key.trim())
+    .forEach((option) => {
+      lines.push(`${indent(level)}${option.key.trim()}: ${quote(option.value)}`);
+    });
+};
+
+const projectionOf = (rule: TransformRule) => {
+  const expressions = rule.columns
+    .filter((column) => column.selected)
+    .map((column) => {
+      const expression = column.expression.trim() || column.sourceName;
+      const targetName = column.targetName.trim() || column.sourceName;
+      const isDirect = expression === column.sourceName && targetName === column.sourceName;
+      return isDirect ? column.sourceName : `${expression} AS ${targetName}`;
+    });
+  return expressions.length ? expressions.join(', ') : '\\*';
+};
+
+const appendTransform = (lines: string[], rule: TransformRule) => {
+  lines.push(`  - source-table: ${quote(rule.sourceTable)}`);
+  lines.push(`    projection: ${quote(projectionOf(rule))}`);
+  if (rule.filter.trim()) lines.push(`    filter: ${quote(rule.filter.trim())}`);
+  if (rule.primaryKeys.length) {
+    lines.push(`    primary-keys: ${quote(rule.primaryKeys.join(', '))}`);
+  }
+  if (rule.partitionKeys.length) {
+    lines.push(`    partition-keys: ${quote(rule.partitionKeys.join(', '))}`);
+  }
+  const tableOptions = rule.tableOptions
+    .filter((option) => option.key.trim())
+    .map((option) => `${option.key.trim()}=${option.value}`)
+    .join(rule.tableOptionsDelimiter || ',');
+  if (tableOptions) {
+    lines.push(`    table-options: ${quote(tableOptions)}`);
+    if ((rule.tableOptionsDelimiter || ',') !== ',') {
+      lines.push(`    table-options.delimiter: ${quote(rule.tableOptionsDelimiter)}`);
+    }
+  }
+  if (rule.description.trim()) {
+    lines.push(`    description: ${quote(rule.description.trim())}`);
+  }
+};
+
+const appendUdfs = (lines: string[], udfs: UdfDefinition[]) => {
+  const validUdfs = udfs.filter((udf) => udf.name.trim() && udf.classpath.trim());
+  if (!validUdfs.length) return;
+  lines.push('  user-defined-function:');
+  validUdfs.forEach((udf) => {
+    lines.push(`    - name: ${quote(udf.name.trim())}`);
+    lines.push(`      classpath: ${quote(udf.classpath.trim())}`);
+    const options = udf.options.filter((option) => option.key.trim());
+    if (options.length) {
+      lines.push('      options:');
+      options.forEach((option) => {
+        lines.push(`        ${option.key.trim()}: ${quote(option.value)}`);
+      });
+    }
+  });
+};
+
+const appendPipeline = (
+  lines: string[],
+  draft: SingleTableDraft | MultiTableDraft,
+) => {
+  lines.push('pipeline:');
+  lines.push(`  name: ${quote(draft.pipeline.name)}`);
+  lines.push(`  parallelism: ${draft.pipeline.parallelism}`);
+  lines.push(`  schema.change.behavior: ${draft.sink.schemaChangeBehavior}`);
+  lines.push(`  local-time-zone: ${quote(draft.pipeline.localTimezone)}`);
+  lines.push(`  schema-operator.uid: ${quote(draft.pipeline.schemaOperatorUid)}`);
+  appendUdfs(lines, draft.udfs);
+};
+
+const appendSource = (
+  lines: string[],
+  draft: SingleTableDraft | MultiTableDraft,
+) => {
+  lines.push('source:');
+  lines.push(`  type: ${draft.source.type}`);
+  lines.push(`  datasource-id: ${quote(draft.source.dataSourceId)}`);
+  if (draft.source.database) lines.push(`  database: ${quote(draft.source.database)}`);
+  if (draft.source.schema) lines.push(`  schema: ${quote(draft.source.schema)}`);
+  const tables =
+    draft.mode === 'SINGLE_TABLE'
+      ? [draft.source.database, draft.source.schema, draft.source.table]
+          .filter(Boolean)
+          .join('.')
+      : draft.source.tablePattern || draft.source.tables.join('|');
+  lines.push(`  tables: ${quote(tables)}`);
+  lines.push(`  scan.startup.mode: ${draft.source.startupMode}`);
+  if (draft.source.type === 'mysql' && draft.source.serverId) {
+    lines.push(`  server-id: ${quote(draft.source.serverId)}`);
+  }
+  if (draft.source.timezone) {
+    lines.push(`  server-time-zone: ${quote(draft.source.timezone)}`);
+  }
+  appendOptions(lines, draft.source.advanced, 1);
+};
+
+const appendSink = (
+  lines: string[],
+  draft: SingleTableDraft | MultiTableDraft,
+) => {
+  lines.push('sink:');
+  lines.push(`  type: ${draft.sink.type}`);
+  lines.push(`  datasource-id: ${quote(draft.sink.dataSourceId)}`);
+  if (draft.sink.database) lines.push(`  database: ${quote(draft.sink.database)}`);
+  if (draft.sink.schema) lines.push(`  schema: ${quote(draft.sink.schema)}`);
+  if (draft.mode === 'SINGLE_TABLE' && draft.sink.table) {
+    lines.push(`  table: ${quote(draft.sink.table)}`);
+  }
+  if (draft.mode === 'MULTI_TABLE') {
+    if (draft.sink.tablePrefix) lines.push(`  table-prefix: ${quote(draft.sink.tablePrefix)}`);
+    if (draft.sink.tableSuffix) lines.push(`  table-suffix: ${quote(draft.sink.tableSuffix)}`);
+  }
+  appendOptions(lines, draft.sink.advanced, 1);
+};
+
+export const buildSingleTableYaml = (draft: SingleTableDraft) => {
+  const lines: string[] = [];
+  appendSource(lines, draft);
+  lines.push('');
+  appendSink(lines, draft);
+  lines.push('');
+  lines.push('transform:');
+  appendTransform(lines, draft.transform);
+  lines.push('');
+  appendPipeline(lines, draft);
+  return lines.join('\n');
+};
+
+export const buildMultiTableYaml = (draft: MultiTableDraft) => {
+  const lines: string[] = [];
+  appendSource(lines, draft);
+  lines.push('');
+  appendSink(lines, draft);
+  if (draft.transforms.length) {
+    lines.push('');
+    lines.push('transform:');
+    draft.transforms.forEach((rule) => appendTransform(lines, rule));
+  }
+  if (draft.routes.length) {
+    lines.push('');
+    lines.push('route:');
+    draft.routes.forEach((route) => {
+      lines.push(`  - source-table: ${quote(route.sourceTable)}`);
+      lines.push(`    sink-table: ${quote(route.sinkTable)}`);
+      if (route.description.trim()) {
+        lines.push(`    description: ${quote(route.description.trim())}`);
+      }
+    });
+  }
+  lines.push('');
+  appendPipeline(lines, draft);
+  return lines.join('\n');
+};
+
+export const validateCustomYaml = (yaml: string) => {
+  const missing = ['source:', 'sink:', 'pipeline:'].filter(
+    (section) => !new RegExp(`^${section}`, 'm').test(yaml),
+  );
+  return {
+    valid: missing.length === 0,
+    missing,
+  };
+};


### PR DESCRIPTION
## 变更内容

实现 Yak Ops 实时同步第一版前端页面，统一基于 Flink CDC Pipeline，不引入 Debezium Server、Kafka 或 Kafka Connect。

### 页面

- 实时同步任务列表页
  - 任务统计、搜索、类型与状态过滤
  - 单表、多表、自定义 YAML 模式展示
  - 新建、编辑、复制任务 ID 和删除前端草稿
- 新建任务类型选择页
  - 单表同步
  - 多表同步
  - 自定义 YAML
- 单表配置页
  - 基本信息、Source/Sink、Transform、UDF、运行参数
- 多表配置页
  - 同步范围、表清单、Route、多条 Transform、UDF、运行参数
- 自定义 YAML 配置页
  - YAML 文件导入、在线编辑、必要区块检查与摘要

### Transform 能力

- 字段选择与删除
- 字段重命名
- 计算字段
- 字符串、时间、算术和条件函数模板
- 行过滤
- 主键与分区键重设
- 下游建表参数
- UDF 注册与初始化参数
- 实时生成 Pipeline YAML 预览

## 当前边界

- 本 PR 仅实现前端任务定义与交互，不涉及任务执行。
- 配置过程中不设置连接测试步骤。
- 数据源、表和字段元数据暂使用前端示例数据。
- 草稿暂存于 localStorage，后续接入后端任务定义接口后替换。
- 自定义 YAML 当前只检查 source、sink、pipeline 必要区块；完整 Connector 与表达式校验留给后端。

## 验证

- 对新增页面执行了本地 TypeScript 语法检查：通过。
- 变更范围已通过分支对比确认，仅包含 `yak-ops-ui/src/pages/realtime-link-up`。