### PR TITLE
fix(ui): use current data source detail API

### DIFF
--- a/yak-ops-ui/src/pages/batch-link-up/components/SyncTaskList/components/DataSourceSyncPlan.tsx
+++ b/yak-ops-ui/src/pages/batch-link-up/components/SyncTaskList/components/DataSourceSyncPlan.tsx
@@ -1,4 +1,4 @@
-import { selectDataSourceById } from "@/pages/data-source/service";
+import { fetchDataSourceDetail } from "@/pages/data-source/service";
 import { DoubleRightOutlined } from "@ant-design/icons";
 import { Empty, Popover } from "antd";
 import { CSSProperties, useState } from "react";
@@ -402,11 +402,11 @@ const DataSourceSyncPlan: React.FC<DataSourceSyncPlanProps> = ({ record }) => {
                   href="#"
                   onClick={(e) => {
                     e.preventDefault();
-                    selectDataSourceById(record?.sourceDatasourceId).then(
+                    fetchDataSourceDetail(record?.sourceDatasourceId).then(
                       (data) => {
                         if (data?.code === 0) {
                           setJsonData(
-                            safeParse(data?.data?.connectionParams || {})
+                            safeParse(data?.data?.originalJson || {})
                           );
                           setSourcePopoverVisible(true);
                         }
@@ -493,11 +493,11 @@ const DataSourceSyncPlan: React.FC<DataSourceSyncPlanProps> = ({ record }) => {
                   href="#"
                   onClick={(e) => {
                     e.preventDefault();
-                    selectDataSourceById(record?.sinkDatasourceId).then(
+                    fetchDataSourceDetail(record?.sinkDatasourceId).then(
                       (data) => {
                         if (data?.code === 0) {
                           setJsonData(
-                            safeParse(data?.data?.connectionParams || {})
+                            safeParse(data?.data?.originalJson || {})
                           );
                           setSinkPopoverVisible(true);
                         }


### PR DESCRIPTION
### Motivation
- Fix a build-time import error caused by the removed `selectDataSourceById` API and use the up-to-date data returned by the data source detail endpoint.

### Description
- Replace the removed import `selectDataSourceById` with `fetchDataSourceDetail` in `DataSourceSyncPlan.tsx`.
- Change both source and sink popover handlers to call `fetchDataSourceDetail(...)` and read connection data from the `originalJson` field returned by the detail API.
- Keep the JSON parsing helper (`safeParse`) and popover rendering unchanged, only adjust the data source and response field used.

### Testing
- Ran `yarn build` and the Umi/Webpack build completed successfully (compiled and produced `dist` bundles). 
- Ran `git diff --check` and there were no whitespace/diff issues.
- Ran `yarn tsc` which failed in this environment due to a missing `minimatch` type definition, but the change was validated by the successful `yarn build`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6aa2af8bb48326bbb82682a2ef93f1)