### PR TITLE
fix(sync): select realtime JSON mapper by default

### DIFF
--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/config/RealtimeSyncConfiguration.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/config/RealtimeSyncConfiguration.java
@@ -19,6 +19,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 import org.springframework.transaction.PlatformTransactionManager;
 
@@ -85,6 +86,7 @@ public class RealtimeSyncConfiguration {
   }
 
   @Bean(name = "realtimeSyncJsonMapper")
+  @Primary
   public ObjectMapper realtimeSyncJsonMapper() {
     return new ObjectMapper().findAndRegisterModules();
   }


### PR DESCRIPTION
### Motivation
- Fix Spring startup failure caused by two `ObjectMapper` beans (`realtimeSyncJsonMapper` and `realtimeSyncYamlMapper`) being candidates for injection so that unqualified `ObjectMapper` dependencies receive the JSON mapper by default.

### Description
- Mark the JSON mapper bean `realtimeSyncJsonMapper` with `@Primary` and add the necessary `import org.springframework.context.annotation.Primary;` so the JSON `ObjectMapper` is selected when no `@Qualifier` is present.

### Testing
- Attempted to run module tests with `mvn -pl yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime -am test -DskipTests=false`, but the build failed due to inability to download parent POM from Maven Central (HTTP 403), so unit tests could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6aaf4862d08326b2492338d51cc16a)