### PR TITLE
fix(ui): correct numeric datasource field validation

### DIFF
--- a/yak-ops-ui/src/pages/data-source/components/DynamicDataSourceForm/index.tsx
+++ b/yak-ops-ui/src/pages/data-source/components/DynamicDataSourceForm/index.tsx
@@ -401,7 +401,7 @@ const DynamicDataSourceForm = ({
                   label={field.label}
                   name={field.key}
                   valuePropName={field.type === 'SWITCH' ? 'checked' : 'value'}
-                  rules={transformRules(field.rules)}
+                  rules={transformRules(field.rules, field.type)}
                   validateTrigger={['onChange', 'onBlur']}
                   className="!mb-[18px]"
                 >

--- a/yak-ops-ui/src/pages/data-source/components/DynamicDataSourceForm/utils/formUtils.test.ts
+++ b/yak-ops-ui/src/pages/data-source/components/DynamicDataSourceForm/utils/formUtils.test.ts
@@ -1,0 +1,46 @@
+import { getConfigInitialValues, transformRules } from './formUtils';
+
+describe('dynamic data source form utils', () => {
+  it('marks number field rules as numeric validation rules', () => {
+    expect(
+      transformRules(
+        [
+          {
+            required: true,
+            min: 1,
+            max: 65535,
+            message: '端口必须在 1 到 65535 之间',
+          },
+        ],
+        'NUMBER',
+      ),
+    ).toEqual([
+      {
+        type: 'number',
+        required: true,
+        min: 1,
+        max: 65535,
+        message: '端口必须在 1 到 65535 之间',
+      },
+    ]);
+  });
+
+  it('keeps text field length rules as non-numeric rules', () => {
+    expect(
+      transformRules([{ max: 10, message: '最多输入 10 个字符' }], 'INPUT'),
+    ).toEqual([{ max: 10, message: '最多输入 10 个字符' }]);
+  });
+
+  it('parses number defaults into numbers', () => {
+    expect(
+      getConfigInitialValues([
+        {
+          key: 'port',
+          label: '端口',
+          type: 'NUMBER',
+          defaultValue: '3306',
+        },
+      ]),
+    ).toEqual({ port: 3306 });
+  });
+});

--- a/yak-ops-ui/src/pages/data-source/components/DynamicDataSourceForm/utils/formUtils.ts
+++ b/yak-ops-ui/src/pages/data-source/components/DynamicDataSourceForm/utils/formUtils.ts
@@ -4,11 +4,15 @@ import type { DynamicFormField, DynamicFormFieldRule } from '../../../types';
 
 export const transformRules = (
   rules: DynamicFormFieldRule[] | undefined,
+  fieldType?: DynamicFormField['type'],
 ): Rule[] => {
   if (!rules) return [];
 
   return rules.map((rule) => {
-    const formRule: Rule = { message: rule.message };
+    const formRule: Rule = {
+      message: rule.message,
+      ...(fieldType === 'NUMBER' ? { type: 'number' as const } : {}),
+    };
     if (rule.required === true) formRule.required = true;
     if (typeof rule.min === 'number') formRule.min = rule.min;
     if (typeof rule.max === 'number') formRule.max = rule.max;


### PR DESCRIPTION
### Motivation
- Numeric validation rules (e.g. port min/max) were applied without declaring the field type as numeric, so values like `"3306"` were validated as strings and range checks failed.
- The dynamic datasource form needs to treat `NUMBER` fields as numeric so Ant Design compares numeric ranges correctly.

### Description
- Pass the dynamic field type into the rule transformer by calling `transformRules(field.rules, field.type)` in `DynamicDataSourceForm` (`src/pages/data-source/components/DynamicDataSourceForm/index.tsx`).
- Update `transformRules` to emit `type: 'number'` for `NUMBER` fields so Ant Design performs numeric validation (`src/pages/data-source/components/DynamicDataSourceForm/utils/formUtils.ts`).
- Add unit tests covering numeric range rules, text length rules, and numeric default parsing (`src/pages/data-source/components/DynamicDataSourceForm/utils/formUtils.test.ts`).

### Testing
- Ran the new unit tests with `npm test -- --runInBand src/pages/data-source/components/DynamicDataSourceForm/utils/formUtils.test.ts`, all tests passed (3/3).
- Ran `git diff --check` with no diff-check issues reported.
- Running `npm run tsc` in this environment failed due to a pre-existing missing type definition (`TS2688: Cannot find type definition file for 'minimatch'`), which is unrelated to these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6ab7ab6590832687afd3231d700986)