### PR TITLE
fix(ui): keep sidebar visible during route loading

### DIFF
--- a/yak-ops-ui/src/loading.tsx
+++ b/yak-ops-ui/src/loading.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 const Loading: React.FC = () => {
   return (
-    <div className="fixed inset-0 z-[9999] flex items-center justify-center bg-white">
+    <div className="fixed inset-0 z-[35] flex items-center justify-center bg-white">
       <div className="flex flex-col items-center gap-4">
         <div className="loading-spinner" aria-label="加载中" />
 


### PR DESCRIPTION
## What changed

- Lowered the global route loading mask from `z-[9999]` to `z-[35]`.
- Kept the mask above the fixed header (`z-30`) and below the custom sidebar (`z-40`).

## Why

`src/loading.tsx` is rendered outside the custom layout and used `fixed inset-0` with an extremely high stacking level. During menu navigation it covered the whole application shell, including the sidebar, which made the navigation feel unstable and caused a visible white flash.

## Impact

- Route transitions still block and cover the business content area.
- The sidebar remains visible and interactive while the target route is loading.
- Expanded and collapsed sidebar widths require no special handling because the fix relies on the existing layout stacking order.

## Validation

- Verified the branch contains one focused change to `yak-ops-ui/src/loading.tsx`.
- Verified the loading mask stacking level is between the header and sidebar layers.
- No runtime test was executed because this environment does not provide a local Node dependency checkout.