### PR TITLE
fix(security): link legacy permissions to menus

### DIFF
--- a/yak-ops-boot/src/main/resources/yak-security/db/migration/V1310__link_legacy_permissions_to_menus.sql
+++ b/yak-ops-boot/src/main/resources/yak-security/db/migration/V1310__link_legacy_permissions_to_menus.sql
@@ -1,0 +1,44 @@
+-- PermissionMenuRelationService builds a permission-to-menu map with Collectors.toMap,
+-- which does not accept null values.  The legacy permissions below were introduced by
+-- V1000 without a menu_code and therefore made GET /api/v1/permission/tree fail.
+
+UPDATE yak_security_permission
+SET menu_code='batch-link-up'
+WHERE app_name='${appName}' AND is_delete=0
+  AND permission_code LIKE 'job:%';
+
+UPDATE yak_security_permission
+SET menu_code='data-source'
+WHERE app_name='${appName}' AND is_delete=0
+  AND permission_code IN (
+    'resource:view',
+    'resource:upload',
+    'resource:download',
+    'resource:update',
+    'resource:delete'
+  );
+
+-- Keep existing roles consistent with the newly completed relations.
+INSERT IGNORE INTO yak_security_role_menu(role_id,menu_id,app_name)
+SELECT DISTINCT role_permission.role_id,menu_row.id,role_permission.app_name
+FROM yak_security_role_permission role_permission
+JOIN yak_security_permission permission_row
+  ON permission_row.id=role_permission.permission_id
+ AND permission_row.app_name=role_permission.app_name
+ AND permission_row.is_delete=0
+ AND permission_row.active=1
+JOIN yak_security_menu menu_row
+  ON menu_row.menu_code=permission_row.menu_code
+ AND menu_row.app_name=role_permission.app_name
+ AND menu_row.is_delete=0
+ AND menu_row.active=1
+WHERE role_permission.app_name='${appName}'
+  AND role_permission.is_delete=0
+  AND (permission_row.permission_code LIKE 'job:%'
+       OR permission_row.permission_code IN (
+         'resource:view',
+         'resource:upload',
+         'resource:download',
+         'resource:update',
+         'resource:delete'
+       ));

--- a/yak-ops-boot/src/test/java/io/yak/ops/boot/config/YakOpsLegacyPermissionMenuMigrationTest.java
+++ b/yak-ops-boot/src/test/java/io/yak/ops/boot/config/YakOpsLegacyPermissionMenuMigrationTest.java
@@ -1,0 +1,28 @@
+package io.yak.ops.boot.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.io.ClassPathResource;
+
+class YakOpsLegacyPermissionMenuMigrationTest {
+
+  @Test
+  void migrationCompletesMenuCodesForLegacyLeafPermissions() throws Exception {
+    ClassPathResource resource = new ClassPathResource(
+        "yak-security/db/migration/V1310__link_legacy_permissions_to_menus.sql");
+    String sql = resource.getContentAsString(StandardCharsets.UTF_8);
+
+    assertThat(sql)
+        .contains("permission_code LIKE 'job:%'")
+        .contains("SET menu_code='batch-link-up'")
+        .contains("'resource:view'")
+        .contains("'resource:upload'")
+        .contains("'resource:download'")
+        .contains("'resource:update'")
+        .contains("'resource:delete'")
+        .contains("SET menu_code='data-source'")
+        .contains("INSERT IGNORE INTO yak_security_role_menu");
+  }
+}


### PR DESCRIPTION
### Motivation
- A NPE in `PermissionMenuRelationService` occurred because legacy leaf permissions (e.g. `job:*` and generic `resource:*`) had `menu_code = NULL`, and `Collectors.toMap` cannot accept null values when building the permission→menu mapping. This made `GET /api/v1/permission/tree` fail with a 500.
- Provide a forward-only database migration to populate missing `menu_code` values and keep existing role→menu relations consistent so the permission tree endpoint recovers on upgrades.

### Description
- Add Flyway migration `yak-ops-boot/src/main/resources/yak-security/db/migration/V1310__link_legacy_permissions_to_menus.sql` that sets `menu_code='batch-link-up'` for `permission_code LIKE 'job:%'` and `menu_code='data-source'` for legacy `resource:*` leaf permissions, and inserts role→menu links to backfill affected roles.
- Add a contract unit test `yak-ops-boot/src/test/java/io/yak/ops/boot/config/YakOpsLegacyPermissionMenuMigrationTest.java` that asserts the migration file contains each repaired permission mapping and the `INSERT IGNORE INTO yak_security_role_menu` backfill.
- The change is limited to a forward migration and a test; no runtime Java changes were required to tolerate nulls.

### Testing
- `git diff --check` on the two new files passed locally. 
- Attempted to run the new migration test with the Maven wrapper via `./mvnw -pl yak-ops-boot -am -Dtest=YakOpsLegacyPermissionMenuMigrationTest test` but the wrapper failed to download due to an environment proxy/permission issue (HTTP 403). 
- Attempted to run the test with the system `mvn` via `mvn -pl yak-ops-boot -am -Dtest=YakOpsLegacyPermissionMenuMigrationTest test` but the build failed to resolve parent POMs from Maven Central due to HTTP 403 in the environment, so automated test execution was blocked by network access rather than test logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6abcab6a788326bd9a1f0f12a620ee)