### PR TITLE
refactor(mybatis): 优化多数据源会话工厂初始化

### DIFF
--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/config/DataSourceConfiguration.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/config/DataSourceConfiguration.java
@@ -1,15 +1,14 @@
 package io.yak.ops.business.datasource.config;
 
 import com.baomidou.mybatisplus.annotation.DbType;
-import com.baomidou.mybatisplus.core.MybatisConfiguration;
 import com.baomidou.mybatisplus.extension.plugins.MybatisPlusInterceptor;
 import com.baomidou.mybatisplus.extension.plugins.inner.PaginationInnerInterceptor;
 import com.baomidou.mybatisplus.extension.spring.MybatisSqlSessionFactoryBean;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
+import io.yak.ops.common.mybatis.MybatisPlusFactorySupport;
 import javax.sql.DataSource;
 import org.apache.ibatis.session.SqlSessionFactory;
-import org.apache.ibatis.type.JdbcType;
 import org.flywaydb.core.Flyway;
 import org.flywaydb.core.api.MigrationVersion;
 import org.mybatis.spring.SqlSessionTemplate;
@@ -18,6 +17,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.Resource;
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 import org.springframework.transaction.PlatformTransactionManager;
@@ -58,15 +58,15 @@ public class DataSourceConfiguration {
     MybatisSqlSessionFactoryBean factory = new MybatisSqlSessionFactoryBean();
     factory.setDataSource(dataSource);
     factory.setTypeAliasesPackage("io.yak.ops.common.bean.po.datasource");
-    factory.setMapperLocations(
-        new PathMatchingResourcePatternResolver()
-            .getResources("classpath*:mapper/datasource/*.xml"));
 
-    MybatisConfiguration configuration = new MybatisConfiguration();
-    configuration.setMapUnderscoreToCamelCase(true);
-    configuration.setJdbcTypeForNull(JdbcType.NULL);
-    configuration.setCacheEnabled(false);
-    factory.setConfiguration(configuration);
+    Resource[] mapperLocations = new PathMatchingResourcePatternResolver()
+        .getResources("classpath*:mapper/datasource/*.xml");
+    if (mapperLocations.length > 0) {
+      factory.setMapperLocations(mapperLocations);
+    }
+
+    factory.setConfiguration(MybatisPlusFactorySupport.createConfiguration());
+    factory.setGlobalConfig(MybatisPlusFactorySupport.createGlobalConfig());
 
     MybatisPlusInterceptor interceptor = new MybatisPlusInterceptor();
     interceptor.addInnerInterceptor(new PaginationInnerInterceptor(DbType.MYSQL));

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/config/OfflineSyncConfiguration.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/config/OfflineSyncConfiguration.java
@@ -1,17 +1,16 @@
 package io.yak.ops.business.sync.offline.config;
 
 import com.baomidou.mybatisplus.annotation.DbType;
-import com.baomidou.mybatisplus.core.MybatisConfiguration;
 import com.baomidou.mybatisplus.extension.plugins.MybatisPlusInterceptor;
 import com.baomidou.mybatisplus.extension.plugins.inner.PaginationInnerInterceptor;
 import com.baomidou.mybatisplus.extension.spring.MybatisSqlSessionFactoryBean;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
+import io.yak.ops.common.mybatis.MybatisPlusFactorySupport;
 import java.net.http.HttpClient;
 import javax.sql.DataSource;
 import org.apache.ibatis.session.SqlSessionFactory;
-import org.apache.ibatis.type.JdbcType;
 import org.flywaydb.core.Flyway;
 import org.flywaydb.core.api.MigrationVersion;
 import org.mybatis.spring.SqlSessionTemplate;
@@ -59,11 +58,9 @@ public class OfflineSyncConfiguration {
     MybatisSqlSessionFactoryBean factory = new MybatisSqlSessionFactoryBean();
     factory.setDataSource(dataSource);
     factory.setTypeAliasesPackage("io.yak.ops.common.bean.po.sync.offline");
-    MybatisConfiguration configuration = new MybatisConfiguration();
-    configuration.setMapUnderscoreToCamelCase(true);
-    configuration.setJdbcTypeForNull(JdbcType.NULL);
-    configuration.setCacheEnabled(false);
-    factory.setConfiguration(configuration);
+    factory.setConfiguration(MybatisPlusFactorySupport.createConfiguration());
+    factory.setGlobalConfig(MybatisPlusFactorySupport.createGlobalConfig());
+
     MybatisPlusInterceptor interceptor = new MybatisPlusInterceptor();
     interceptor.addInnerInterceptor(new PaginationInnerInterceptor(DbType.MYSQL));
     factory.setPlugins(interceptor);

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/config/RealtimeSyncConfiguration.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/config/RealtimeSyncConfiguration.java
@@ -1,16 +1,15 @@
 package io.yak.ops.business.sync.realtime.config;
 
-import com.baomidou.mybatisplus.core.MybatisConfiguration;
 import com.baomidou.mybatisplus.extension.spring.MybatisSqlSessionFactoryBean;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
+import io.yak.ops.common.mybatis.MybatisPlusFactorySupport;
 import java.net.http.HttpClient;
 import java.time.Duration;
 import javax.sql.DataSource;
 import org.apache.ibatis.session.SqlSessionFactory;
-import org.apache.ibatis.type.JdbcType;
 import org.flywaydb.core.Flyway;
 import org.flywaydb.core.api.MigrationVersion;
 import org.mybatis.spring.SqlSessionTemplate;
@@ -59,11 +58,8 @@ public class RealtimeSyncConfiguration {
     MybatisSqlSessionFactoryBean factory = new MybatisSqlSessionFactoryBean();
     factory.setDataSource(dataSource);
     factory.setTypeAliasesPackage("io.yak.ops.business.sync.realtime.model.po");
-    MybatisConfiguration configuration = new MybatisConfiguration();
-    configuration.setMapUnderscoreToCamelCase(true);
-    configuration.setJdbcTypeForNull(JdbcType.NULL);
-    configuration.setCacheEnabled(false);
-    factory.setConfiguration(configuration);
+    factory.setConfiguration(MybatisPlusFactorySupport.createConfiguration());
+    factory.setGlobalConfig(MybatisPlusFactorySupport.createGlobalConfig());
     return factory.getObject();
   }
 

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/config/WorkflowConfiguration.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/config/WorkflowConfiguration.java
@@ -1,18 +1,17 @@
 package io.yak.ops.business.workflow.config;
 
-import com.baomidou.mybatisplus.core.MybatisConfiguration;
 import com.baomidou.mybatisplus.extension.spring.MybatisSqlSessionFactoryBean;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
-import io.yak.ops.common.constant.workflow.WorkflowConstant;
 import io.yak.ops.business.workflow.dag.WorkflowDagCompiler;
+import io.yak.ops.common.constant.workflow.WorkflowConstant;
+import io.yak.ops.common.mybatis.MybatisPlusFactorySupport;
 import io.yak.ops.core.workflow.LocalWorkflowTaskDispatcher;
 import io.yak.ops.core.workflow.WorkflowTaskExecutorRegistry;
 import io.yak.ops.spi.workflow.WorkflowTaskExecutor;
 import java.util.List;
 import javax.sql.DataSource;
 import org.apache.ibatis.session.SqlSessionFactory;
-import org.apache.ibatis.type.JdbcType;
 import org.flywaydb.core.Flyway;
 import org.flywaydb.core.api.MigrationVersion;
 import org.mybatis.spring.SqlSessionTemplate;
@@ -22,6 +21,7 @@ import org.springframework.boot.autoconfigure.quartz.SchedulerFactoryBeanCustomi
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.Resource;
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 import org.springframework.scheduling.annotation.EnableScheduling;
@@ -64,14 +64,15 @@ public class WorkflowConfiguration {
     MybatisSqlSessionFactoryBean factory = new MybatisSqlSessionFactoryBean();
     factory.setDataSource(dataSource);
     factory.setTypeAliasesPackage("io.yak.ops.common.bean.po.workflow");
-    factory.setMapperLocations(new PathMatchingResourcePatternResolver()
-        .getResources("classpath*:mapper/workflow/*.xml"));
 
-    MybatisConfiguration configuration = new MybatisConfiguration();
-    configuration.setMapUnderscoreToCamelCase(true);
-    configuration.setJdbcTypeForNull(JdbcType.NULL);
-    configuration.setCacheEnabled(false);
-    factory.setConfiguration(configuration);
+    Resource[] mapperLocations = new PathMatchingResourcePatternResolver()
+        .getResources("classpath*:mapper/workflow/*.xml");
+    if (mapperLocations.length > 0) {
+      factory.setMapperLocations(mapperLocations);
+    }
+
+    factory.setConfiguration(MybatisPlusFactorySupport.createConfiguration());
+    factory.setGlobalConfig(MybatisPlusFactorySupport.createGlobalConfig());
     return factory.getObject();
   }
 

--- a/yak-ops-common/src/main/java/io/yak/ops/common/mybatis/MybatisPlusFactorySupport.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/mybatis/MybatisPlusFactorySupport.java
@@ -1,0 +1,28 @@
+package io.yak.ops.common.mybatis;
+
+import com.baomidou.mybatisplus.core.MybatisConfiguration;
+import com.baomidou.mybatisplus.core.config.GlobalConfig;
+import org.apache.ibatis.type.JdbcType;
+
+/** Yak Ops 各业务数据源共享的 MyBatis-Plus 会话工厂配置。 */
+public final class MybatisPlusFactorySupport {
+
+  private MybatisPlusFactorySupport() {
+  }
+
+  /** 创建统一的 MyBatis 配置，避免各业务模块出现配置漂移。 */
+  public static MybatisConfiguration createConfiguration() {
+    MybatisConfiguration configuration = new MybatisConfiguration();
+    configuration.setMapUnderscoreToCamelCase(true);
+    configuration.setJdbcTypeForNull(JdbcType.NULL);
+    configuration.setCacheEnabled(false);
+    return configuration;
+  }
+
+  /** 创建关闭启动横幅的全局配置。每个 SqlSessionFactory 使用独立实例。 */
+  public static GlobalConfig createGlobalConfig() {
+    GlobalConfig globalConfig = new GlobalConfig();
+    globalConfig.setBanner(false);
+    return globalConfig;
+  }
+}

--- a/yak-ops-common/src/test/java/io/yak/ops/common/mybatis/MybatisPlusFactorySupportTest.java
+++ b/yak-ops-common/src/test/java/io/yak/ops/common/mybatis/MybatisPlusFactorySupportTest.java
@@ -1,0 +1,30 @@
+package io.yak.ops.common.mybatis;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.baomidou.mybatisplus.core.MybatisConfiguration;
+import com.baomidou.mybatisplus.core.config.GlobalConfig;
+import org.apache.ibatis.type.JdbcType;
+import org.junit.jupiter.api.Test;
+
+class MybatisPlusFactorySupportTest {
+
+  @Test
+  void shouldCreateConsistentMybatisConfiguration() {
+    MybatisConfiguration configuration = MybatisPlusFactorySupport.createConfiguration();
+
+    assertThat(configuration.isMapUnderscoreToCamelCase()).isTrue();
+    assertThat(configuration.getJdbcTypeForNull()).isEqualTo(JdbcType.NULL);
+    assertThat(configuration.isCacheEnabled()).isFalse();
+  }
+
+  @Test
+  void shouldDisableBannerForEveryFactory() {
+    GlobalConfig first = MybatisPlusFactorySupport.createGlobalConfig();
+    GlobalConfig second = MybatisPlusFactorySupport.createGlobalConfig();
+
+    assertThat(first.isBanner()).isFalse();
+    assertThat(second.isBanner()).isFalse();
+    assertThat(first).isNotSameAs(second);
+  }
+}


### PR DESCRIPTION
## 背景

Yak Ops 当前为数据源管理、工作流、离线同步、实时同步分别创建 `DataSource`、`SqlSessionFactory`、事务管理器和 Flyway。它们默认可以连接同一个数据库，但也支持通过独立环境变量拆分数据库，因此本次不强制合并这些基础设施边界。

启动时每个 `MybatisSqlSessionFactoryBean` 都使用默认全局配置，导致 MyBatis-Plus 3.5.16 Banner 重复打印；当 XML Mapper 匹配结果为空时，还会出现 `mapperLocations` 无匹配资源的警告。

## 改动

- 新增 `MybatisPlusFactorySupport`，统一四个业务模块的 MyBatis 配置：
  - 下划线转驼峰
  - `JdbcType.NULL`
  - 关闭一级之外的本地配置缓存开关
  - 为每个会话工厂创建独立 `GlobalConfig` 并关闭 Banner
- 数据源管理和工作流模块仅在实际找到 XML Mapper 时调用 `setMapperLocations`
- 离线同步、实时同步接入相同的公共配置
- 增加公共配置单元测试，校验配置一致性、Banner 关闭以及 `GlobalConfig` 实例隔离

## 保持不变

- 不修改各模块的数据源 URL、连接池参数和独立部署能力
- 不修改 Mapper 扫描包
- 不修改事务管理器
- 不修改 Flyway migration location 和 schema history 表
- 不修改业务 SQL

## 预期效果

- Yak Ops 启动时不再重复输出 MyBatis-Plus 3.5.16 Banner
- XML Mapper 目录没有资源时不再打印误导性的 `mapperLocations` 警告
- 四套会话工厂的基础 MyBatis 行为保持一致

## 验证

- 已完成分支差异和依赖范围检查
- 已增加 `MybatisPlusFactorySupportTest`
- 当前执行环境无法拉取仓库并运行本地 Maven，需由 CI 或本地执行：

```bash
mvn -pl yak-ops-common,yak-ops-business/yak-ops-business-datasource,yak-ops-business/yak-ops-business-workflow,yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline,yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime -am test
```
