### PR TITLE
fix(offline-sync): support staged editor persistence

### DIFF
--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineExecutionSynchronizer.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineExecutionSynchronizer.java
@@ -29,7 +29,10 @@ public class OfflineExecutionSynchronizer {
       "PENDING",
       "SCHEDULED",
       "RUNNING",
-      "CANCELING");
+      "FAILING",
+      "DOING_SAVEPOINT",
+      "CANCELING",
+      "CANCELLING");
 
   private final LinkUpClient linkUpClient;
   private final OfflineJobDefinitionDao definitionDao;
@@ -138,10 +141,7 @@ public class OfflineExecutionSynchronizer {
     if ("SUCCEEDED".equals(normalized)) {
       return "FINISHED";
     }
-    if ("SUBMITTED".equals(normalized) || "CANCELLING".equals(normalized)) {
-      return "RUNNING";
-    }
-    return normalized;
+    return ACTIVE_STATUSES.contains(normalized) ? "RUNNING" : normalized;
   }
 
   private long number(JsonNode node, String field, long fallback) {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineJobDefinitionService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineJobDefinitionService.java
@@ -76,11 +76,13 @@ public class OfflineJobDefinitionService {
     String jobName = requiredText(basic, "jobName", "任务名称不能为空");
     String jobDesc = text(basic, "jobDesc", null);
     String mode = text(basic, "mode", text(request, "mode", "GUIDE_SINGLE"));
+    ensureGuideMode(mode);
     ensureNameUnique(jobName, id);
 
     OfflineJobDefinitionPO existing = definitionDao.selectById(id);
     ensureEditable(existing);
-    LinkUpHoconBuilder.BuildResult result = hoconBuilder.build(request);
+    LinkUpHoconBuilder.BuildResult result =
+        isGuideReady(request, mode) ? hoconBuilder.build(request) : null;
     LocalDateTime now = LocalDateTime.now();
     OfflineJobDefinitionPO definition = existing == null ? new OfflineJobDefinitionPO() : existing;
     definition.setId(id);
@@ -88,13 +90,7 @@ public class OfflineJobDefinitionService {
     definition.setJobDesc(trimToNull(jobDesc));
     definition.setMode(mode);
     definition.setDefinitionJson(write(request));
-    definition.setHoconConfig(result.getHocon());
-    definition.setSourceType(enumName(result.getSourceDataSource()));
-    definition.setSinkType(enumName(result.getSinkDataSource()));
-    definition.setSourceDatasourceId(result.getSourceDataSource().getId());
-    definition.setSinkDatasourceId(result.getSinkDataSource().getId());
-    definition.setSourceTable(result.getSourceTable());
-    definition.setSinkTable(result.getSinkTable());
+    applyGuideBuildResult(definition, result);
     definition.setScheduleJson(writeNullable(request.get("schedule")));
     definition.setEnvJson(writeNullable(request.get("env")));
     definition.setVersion(existing == null || existing.getVersion() == null ? 1 : existing.getVersion() + 1);
@@ -209,7 +205,7 @@ public class OfflineJobDefinitionService {
     } else {
       JsonNode detail = read(definition.getDefinitionJson());
       LinkUpHoconBuilder.BuildResult result = hoconBuilder.build(detail);
-      definition.setHoconConfig(result.getHocon());
+      applyGuideBuildResult(definition, result);
     }
     definition.setReleaseState("ONLINE");
     definition.setUpdateTime(LocalDateTime.now());
@@ -312,6 +308,113 @@ public class OfflineJobDefinitionService {
     if (definitionDao.existsByName(normalized, excludedId)) {
       throw new IllegalArgumentException("离线同步任务名称已存在：" + normalized);
     }
+  }
+
+  private void ensureGuideMode(String mode) {
+    if (!"GUIDE_SINGLE".equals(mode) && !"GUIDE_MULTI".equals(mode)) {
+      throw new IllegalArgumentException("仅支持 GUIDE_SINGLE 和 GUIDE_MULTI 向导模式");
+    }
+  }
+
+  private boolean isGuideReady(JsonNode request, String mode) {
+    JsonNode workflow = request.path("workflow");
+    JsonNode basic = request.path("basic");
+    if (!workflow.isObject()) {
+      return false;
+    }
+    JsonNode source = endpointConfig(workflow, "source");
+    JsonNode sink = endpointConfig(workflow, "sink");
+    if (source == null || sink == null) {
+      return false;
+    }
+    if (resolveDataSourceId(source, basic, workflow, true) <= 0L
+        || resolveDataSourceId(sink, basic, workflow, false) <= 0L) {
+      return false;
+    }
+    if ("GUIDE_MULTI".equals(mode)) {
+      return hasConfiguredTables(source.path("tables"))
+          || StringUtils.hasText(text(source, "tablePattern", null));
+    }
+    boolean sourceReady = "sql".equalsIgnoreCase(text(source, "readMode", "table"))
+        ? StringUtils.hasText(text(source, "sql", null))
+        : StringUtils.hasText(text(source, "table", null));
+    boolean sinkReady = StringUtils.hasText(
+        text(sink, "targetTableName", text(sink, "table", null)));
+    return sourceReady && sinkReady;
+  }
+
+  private JsonNode endpointConfig(JsonNode workflow, String kind) {
+    JsonNode nodes = workflow.path("nodes");
+    if (!nodes.isArray()) {
+      return null;
+    }
+    for (JsonNode node : nodes) {
+      String nodeType = text(node.path("data"), "nodeType", text(node, "type", null));
+      if (kind.equalsIgnoreCase(nodeType)) {
+        JsonNode config = node.path("data").path("config");
+        return config.isObject() ? config : null;
+      }
+    }
+    return null;
+  }
+
+  private long resolveDataSourceId(
+      JsonNode config, JsonNode basic, JsonNode workflow, boolean source) {
+    long id = config.path("dataSourceId").asLong(0L);
+    if (id <= 0L) {
+      id = basic.path(source ? "sourceDataSourceId" : "targetDataSourceId").asLong(0L);
+    }
+    if (id <= 0L) {
+      id = workflow.path(source ? "sourceDataSourceId" : "targetDataSourceId").asLong(0L);
+    }
+    return id;
+  }
+
+  private boolean hasConfiguredTables(JsonNode tables) {
+    if (tables == null || tables.isNull() || tables.isMissingNode()) {
+      return false;
+    }
+    if (tables.isTextual()) {
+      return StringUtils.hasText(tables.asText());
+    }
+    if (tables.isArray()) {
+      for (JsonNode table : tables) {
+        if (hasConfiguredTables(table)) {
+          return true;
+        }
+      }
+      return false;
+    }
+    if (tables.isObject()) {
+      var values = tables.elements();
+      while (values.hasNext()) {
+        if (hasConfiguredTables(values.next())) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  private void applyGuideBuildResult(
+      OfflineJobDefinitionPO definition, LinkUpHoconBuilder.BuildResult result) {
+    if (result == null) {
+      definition.setHoconConfig("");
+      definition.setSourceType(null);
+      definition.setSinkType(null);
+      definition.setSourceDatasourceId(null);
+      definition.setSinkDatasourceId(null);
+      definition.setSourceTable(null);
+      definition.setSinkTable(null);
+      return;
+    }
+    definition.setHoconConfig(result.getHocon());
+    definition.setSourceType(enumName(result.getSourceDataSource()));
+    definition.setSinkType(enumName(result.getSinkDataSource()));
+    definition.setSourceDatasourceId(result.getSourceDataSource().getId());
+    definition.setSinkDatasourceId(result.getSinkDataSource().getId());
+    definition.setSourceTable(result.getSourceTable());
+    definition.setSinkTable(result.getSinkTable());
   }
 
   private String enumName(DataSourcePO dataSource) {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/service/OfflineExecutionSynchronizerTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/service/OfflineExecutionSynchronizerTest.java
@@ -1,0 +1,39 @@
+package io.yak.ops.business.sync.offline.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.sync.offline.dao.OfflineJobDefinitionDao;
+import io.yak.ops.business.sync.offline.dao.OfflineJobExecutionDao;
+import io.yak.ops.business.sync.offline.engine.LinkUpClient;
+import io.yak.ops.common.bean.po.sync.offline.OfflineJobDefinitionPO;
+import io.yak.ops.common.bean.po.sync.offline.OfflineJobExecutionPO;
+import org.junit.jupiter.api.Test;
+
+class OfflineExecutionSynchronizerTest {
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+  private final OfflineExecutionSynchronizer synchronizer =
+      new OfflineExecutionSynchronizer(
+          mock(LinkUpClient.class),
+          mock(OfflineJobDefinitionDao.class),
+          mock(OfflineJobExecutionDao.class),
+          objectMapper);
+
+  @Test
+  void normalizesEngineActiveStatusesForFrontendActions() throws Exception {
+    OfflineJobDefinitionPO definition = new OfflineJobDefinitionPO();
+    OfflineJobExecutionPO execution = new OfflineJobExecutionPO();
+
+    synchronizer.apply(
+        definition,
+        execution,
+        objectMapper.readTree("{\"status\":\"INITIALIZING\",\"metrics\":{}}"));
+
+    assertThat(definition.getLastJobStatus()).isEqualTo("RUNNING");
+    assertThat(execution.getStatus()).isEqualTo("RUNNING");
+    assertThat(synchronizer.isActive("DOING_SAVEPOINT")).isTrue();
+    assertThat(synchronizer.isActive("FINISHED")).isFalse();
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/service/OfflineJobDefinitionServiceTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/service/OfflineJobDefinitionServiceTest.java
@@ -1,0 +1,176 @@
+package io.yak.ops.business.sync.offline.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.datasource.dao.DataSourceDao;
+import io.yak.ops.business.sync.offline.dao.OfflineJobDefinitionDao;
+import io.yak.ops.business.sync.offline.engine.LinkUpHoconBuilder;
+import io.yak.ops.common.bean.dto.sync.offline.OfflineJobDefinitionDTO;
+import io.yak.ops.common.bean.po.datasource.DataSourcePO;
+import io.yak.ops.common.bean.po.sync.offline.OfflineJobDefinitionPO;
+import io.yak.ops.common.enums.datasource.DataSourceDbType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class OfflineJobDefinitionServiceTest {
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+  private OfflineJobDefinitionDao definitionDao;
+  private DataSourceDao dataSourceDao;
+  private LinkUpHoconBuilder hoconBuilder;
+  private OfflineExecutionSynchronizer synchronizer;
+  private OfflineJobDefinitionService service;
+
+  @BeforeEach
+  void setUp() {
+    definitionDao = mock(OfflineJobDefinitionDao.class);
+    dataSourceDao = mock(DataSourceDao.class);
+    hoconBuilder = new LinkUpHoconBuilder(dataSourceDao, objectMapper);
+    synchronizer = mock(OfflineExecutionSynchronizer.class);
+    service = new OfflineJobDefinitionService(
+        definitionDao, dataSourceDao, hoconBuilder, synchronizer, objectMapper);
+  }
+
+  @Test
+  void savesEditorDraftBeforeConnectionsAndTablesAreConfigured() throws Exception {
+    OfflineJobDefinitionDTO request = definition(
+        """
+        {
+          "id": 1001,
+          "basic": {
+            "jobName": "orders-draft",
+            "jobDesc": "draft task",
+            "mode": "GUIDE_SINGLE",
+            "sourceDataSourceId": "",
+            "targetDataSourceId": ""
+          },
+          "workflow": {
+            "nodes": [
+              {
+                "type": "source",
+                "data": {
+                  "nodeType": "source",
+                  "config": {
+                    "dataSourceId": "",
+                    "readMode": "table",
+                    "table": "",
+                    "tables": []
+                  }
+                }
+              },
+              {
+                "type": "sink",
+                "data": {
+                  "nodeType": "sink",
+                  "config": {
+                    "dataSourceId": "",
+                    "table": "",
+                    "targetTableName": ""
+                  }
+                }
+              }
+            ]
+          },
+          "schedule": {},
+          "env": {"parallelism": 1}
+        }
+        """);
+
+    service.saveGuide(request);
+
+    ArgumentCaptor<OfflineJobDefinitionPO> captor =
+        ArgumentCaptor.forClass(OfflineJobDefinitionPO.class);
+    verify(definitionDao).insert(captor.capture());
+    OfflineJobDefinitionPO saved = captor.getValue();
+    assertThat(saved.getId()).isEqualTo(1001L);
+    assertThat(saved.getHoconConfig()).isEmpty();
+    assertThat(saved.getSourceDatasourceId()).isNull();
+    assertThat(saved.getSinkDatasourceId()).isNull();
+    assertThat(saved.getDefinitionJson()).contains("\"workflow\"");
+    verify(dataSourceDao, never()).selectById(any());
+  }
+
+  @Test
+  void buildsHoconWhenGuideConfigurationIsComplete() throws Exception {
+    when(dataSourceDao.selectById(1L)).thenReturn(dataSource(1L, "source"));
+    when(dataSourceDao.selectById(2L)).thenReturn(dataSource(2L, "sink"));
+    OfflineJobDefinitionDTO request = definition(
+        """
+        {
+          "id": 1002,
+          "basic": {
+            "jobName": "orders-sync",
+            "mode": "GUIDE_SINGLE",
+            "sourceDataSourceId": "1",
+            "targetDataSourceId": "2"
+          },
+          "workflow": {
+            "nodes": [
+              {
+                "type": "source",
+                "data": {
+                  "nodeType": "source",
+                  "config": {
+                    "dataSourceId": "1",
+                    "readMode": "table",
+                    "table": "source_db.orders"
+                  }
+                }
+              },
+              {
+                "type": "sink",
+                "data": {
+                  "nodeType": "sink",
+                  "config": {
+                    "dataSourceId": "2",
+                    "table": "target_db.orders",
+                    "writeMode": "append"
+                  }
+                }
+              }
+            ]
+          },
+          "schedule": {},
+          "env": {"parallelism": 1}
+        }
+        """);
+
+    service.saveGuide(request);
+
+    ArgumentCaptor<OfflineJobDefinitionPO> captor =
+        ArgumentCaptor.forClass(OfflineJobDefinitionPO.class);
+    verify(definitionDao).insert(captor.capture());
+    OfflineJobDefinitionPO saved = captor.getValue();
+    assertThat(saved.getHoconConfig())
+        .contains("job.name = \"orders-sync\"")
+        .contains("table_path = \"source_db.orders\"")
+        .contains("table_path = \"target_db.orders\"");
+    assertThat(saved.getSourceDatasourceId()).isEqualTo(1L);
+    assertThat(saved.getSinkDatasourceId()).isEqualTo(2L);
+  }
+
+  private OfflineJobDefinitionDTO definition(String json) throws Exception {
+    return objectMapper.treeToValue(
+        objectMapper.readTree(json), OfflineJobDefinitionDTO.class);
+  }
+
+  private DataSourcePO dataSource(Long id, String name) {
+    DataSourcePO dataSource = new DataSourcePO();
+    dataSource.setId(id);
+    dataSource.setName(name);
+    dataSource.setDbType(DataSourceDbType.MYSQL);
+    dataSource.setJdbcUrl("jdbc:mysql://127.0.0.1:3306/test");
+    dataSource.setConnectionParams(
+        "{\"url\":\"jdbc:mysql://127.0.0.1:3306/test\"," 
+            + "\"driver\":\"com.mysql.cj.jdbc.Driver\"," 
+            + "\"username\":\"root\",\"password\":\"secret\"}");
+    return dataSource;
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/service/OfflineJobDefinitionServiceTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/service/OfflineJobDefinitionServiceTest.java
@@ -94,7 +94,7 @@ class OfflineJobDefinitionServiceTest {
     assertThat(saved.getSourceDatasourceId()).isNull();
     assertThat(saved.getSinkDatasourceId()).isNull();
     assertThat(saved.getDefinitionJson()).contains("\"workflow\"");
-    verify(dataSourceDao, never()).selectById(any());
+    verify(dataSourceDao, never()).selectById(any(Long.class));
   }
 
   @Test
@@ -168,8 +168,8 @@ class OfflineJobDefinitionServiceTest {
     dataSource.setDbType(DataSourceDbType.MYSQL);
     dataSource.setJdbcUrl("jdbc:mysql://127.0.0.1:3306/test");
     dataSource.setConnectionParams(
-        "{\"url\":\"jdbc:mysql://127.0.0.1:3306/test\"," 
-            + "\"driver\":\"com.mysql.cj.jdbc.Driver\"," 
+        "{\"url\":\"jdbc:mysql://127.0.0.1:3306/test\","
+            + "\"driver\":\"com.mysql.cj.jdbc.Driver\","
             + "\"username\":\"root\",\"password\":\"secret\"}");
     return dataSource;
   }

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/sync/offline/OfflineJobDefinitionPO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/sync/offline/OfflineJobDefinitionPO.java
@@ -1,6 +1,8 @@
 package io.yak.ops.common.bean.po.sync.offline;
 
+import com.baomidou.mybatisplus.annotation.FieldStrategy;
 import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableField;
 import com.baomidou.mybatisplus.annotation.TableId;
 import com.baomidou.mybatisplus.annotation.TableName;
 import java.time.LocalDateTime;
@@ -15,7 +17,10 @@ public class OfflineJobDefinitionPO {
   @TableId(type = IdType.INPUT)
   private Long id;
   private String jobName;
+
+  @TableField(updateStrategy = FieldStrategy.ALWAYS)
   private String jobDesc;
+
   private String mode;
 
   @ToString.Exclude
@@ -25,24 +30,41 @@ public class OfflineJobDefinitionPO {
   private String hoconConfig;
 
   private String releaseState;
+
+  @TableField(updateStrategy = FieldStrategy.ALWAYS)
   private String sourceType;
+
+  @TableField(updateStrategy = FieldStrategy.ALWAYS)
   private String sinkType;
+
+  @TableField(updateStrategy = FieldStrategy.ALWAYS)
   private Long sourceDatasourceId;
+
+  @TableField(updateStrategy = FieldStrategy.ALWAYS)
   private Long sinkDatasourceId;
+
+  @TableField(updateStrategy = FieldStrategy.ALWAYS)
   private String sourceTable;
+
+  @TableField(updateStrategy = FieldStrategy.ALWAYS)
   private String sinkTable;
 
   @ToString.Exclude
+  @TableField(updateStrategy = FieldStrategy.ALWAYS)
   private String scheduleJson;
 
   @ToString.Exclude
+  @TableField(updateStrategy = FieldStrategy.ALWAYS)
   private String envJson;
 
   private Integer version;
   private Long lastExecutionId;
   private String lastEngineJobId;
   private String lastJobStatus;
+
+  @TableField(updateStrategy = FieldStrategy.ALWAYS)
   private String lastErrorMessage;
+
   private Long lastDurationMillis;
   private Long lastReadRowCount;
   private Double lastQps;

--- a/yak-ops-ui/src/pages/batch-link-up/detail/model.ts
+++ b/yak-ops-ui/src/pages/batch-link-up/detail/model.ts
@@ -307,6 +307,26 @@ export const endpointNode = (
     (node) => node?.data?.nodeType === kind || node?.type === kind,
   );
 
+const resetConnectionDependentConfig = (
+  kind: EndpointKind,
+  config: Record<string, any>,
+): Record<string, any> =>
+  kind === 'source'
+    ? {
+        ...config,
+        table: '',
+        tables: [],
+        tablePattern: '',
+        sql: '',
+      }
+    : {
+        ...config,
+        table: '',
+        targetTableName: '',
+        sql: '',
+        primaryKey: '',
+      };
+
 const replaceEndpointNode = (
   workflow: SyncWorkflow,
   kind: EndpointKind,
@@ -316,13 +336,19 @@ const replaceEndpointNode = (
   const meta = connectorMeta(record)!;
   const existing = endpointNode(workflow, kind);
   const nextNode = existing || createEndpointNode('draft', kind, record);
+  const previousConfig = nextNode.data?.config || {};
+  const dataSourceChanged =
+    String(previousConfig.dataSourceId || '') !== recordId;
+  const nextConfig = dataSourceChanged
+    ? resetConnectionDependentConfig(kind, previousConfig)
+    : previousConfig;
   const nextData = {
     ...(nextNode.data || {}),
     dbType: meta.dbType,
     connectorType: meta.connectorType,
     pluginName: meta.pluginName,
     config: {
-      ...(nextNode.data?.config || {}),
+      ...nextConfig,
       dataSourceId: recordId,
       dbType: meta.dbType,
       connectorType: meta.connectorType,


### PR DESCRIPTION
## 问题背景

离线同步前端采用分阶段编辑流程：

1. 新建任务时只保存任务名称和模式；
2. 连接测试完成后保存来源端/目标端数据源；
3. 最后再配置来源表、目标表和写入策略。

后端此前在每次 `saveOrUpdate` 时都会立即构建完整 Link-Up HOCON，因此前两个阶段都会因为缺少数据源或表配置而失败，导致新建和“下一步：任务配置”无法正常联调。

另外还存在两个明显的状态/数据残留问题：

- 前端更换数据源时会保留旧数据源的表名、SQL 和主键配置；
- Link-Up 的 `INITIALIZING/PENDING/SCHEDULED/CANCELING` 等活动状态会原样返回，但前端只把 `RUNNING` 视为运行中，可能短暂开放重复运行、编辑或删除操作。

## 修复内容

- 向导任务支持草稿态保存：配置未完整时保存可编辑 JSON，不提前构建 HOCON；
- 配置完整时仍立即生成并保存 HOCON；
- 任务上线时强制重新构建 HOCON，继续执行完整的数据源、表、SQL、主键等校验；
- 切换来源端或目标端数据源时，清理依赖旧连接的表名、表集合、过滤规则、SQL、目标表和主键配置；
- 为可清空字段增加 MyBatis-Plus `FieldStrategy.ALWAYS`，避免旧数据源元数据、描述和错误信息残留；
- 将 Link-Up 活动状态统一归一为 `RUNNING`，与前端任务操作判断保持一致；
- 新增单元测试，覆盖草稿保存、完整配置生成 HOCON 和活动状态归一。

## 联调影响

修复后以下流程可以正常衔接：

- 新建离线同步任务；
- 完成连接测试并进入任务配置；
- 保存完整 Source/Sink/Channel 配置；
- 上线前进行最终完整校验；
- 更换数据源后不会误用旧表配置；
- 引擎处于初始化、等待、调度或取消中时，页面不会开放冲突操作。

## 验证

- 已核对前端创建、连接测试、编辑保存、上线、执行和停止调用链；
- 已核对分支与 `main` 的 diff，变更均限定在离线同步模块；
- 已新增后端单元测试；
- 当前执行环境无法解析 `github.com`，未能在本地拉取仓库执行 Maven/前端构建；仓库当前也没有为该提交返回 GitHub Actions 或状态检查。