### PR TITLE
feat(resource): add backend resource management and storage plugins

### DIFF
--- a/docs/resource-management-backend.md
+++ b/docs/resource-management-backend.md
@@ -1,0 +1,76 @@
+# 资源管理后端
+
+## 模块边界
+
+```text
+yak-ops-common
+  └─ resource DTO / VO / PO / enum / permission code
+
+yak-ops-spi
+  └─ ResourceFileSyncProvider（Git/DataOps 同步扩展口）
+
+yak-ops-business-resource
+  ├─ Controller / Service / DAO
+  ├─ 独立 Hikari + MyBatis-Plus + Flyway
+  └─ 资源目录树、版本、校验值和存储路径元数据
+
+yak-ops-plugin-storage
+  ├─ storage-api
+  ├─ storage-minio
+  ├─ storage-hdfs
+  └─ storage-all
+```
+
+资源数据库保存目录和文件元数据，MinIO/HDFS 插件只保存物理内容。业务模块只依赖存储 API，不依赖具体实现。
+
+## 接口
+
+基础路径：`/api/v1/resources`
+
+- `POST /directory`：创建目录
+- `POST /`：上传文件
+- `POST /online-create`：在线创建文本文件
+- `GET /{id}`：资源详情
+- `GET /list`：查询目录直属资源
+- `POST /page`：分页查询
+- `GET /tree`：完整资源树
+- `PUT /{id}`：重命名或修改描述
+- `PUT /{id}/file`：替换文件
+- `GET /{id}/content`：在线查看文本内容
+- `PUT /{id}/content`：在线更新文本内容
+- `POST /{id}/move`：移动文件或目录
+- `DELETE /{id}`：递归删除
+- `GET /{id}/download`：下载文件
+- `GET /storage-plugins`：查看已安装存储插件
+
+接口复用现有资源权限：`resource:view`、`resource:upload`、`resource:download`、`resource:update`、`resource:delete`。
+
+## 存储配置
+
+默认启用 MinIO，HDFS 默认关闭。通过 `yak.resource.storage.type` 选择当前根目录使用的存储类型。
+
+```yaml
+yak:
+  resource:
+    enabled: true
+    storage:
+      type: MINIO
+      minio:
+        enabled: true
+        endpoint: http://127.0.0.1:9000
+        access-key: minioadmin
+        secret-key: minioadmin
+        bucket: yak-ops
+        base-prefix: resources
+      hdfs:
+        enabled: false
+        uri: hdfs://127.0.0.1:9000
+        user: hdfs
+        base-directory: /yak-ops/resources
+```
+
+同一目录树内的资源继承父目录存储类型，当前不允许跨 MinIO/HDFS 移动。
+
+## Git/DataOps 扩展口
+
+本次只提供 `ResourceFileSyncProvider`，不包含具体 Git 实现。后续插件注册为 Spring Bean 后，会在资源事务提交后收到 `CREATED`、`UPDATED`、`MOVED`、`DELETED` 事件，无需修改资源业务代码。

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <yak-framework.version>1.0.0-SNAPSHOT</yak-framework.version>
+        <minio.version>8.6.0</minio.version>
+        <hadoop.version>3.5.0</hadoop.version>
         <maven-assembly-plugin.version>3.7.1</maven-assembly-plugin.version>
         <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
         <maven-enforcer-plugin.version>3.5.0</maven-enforcer-plugin.version>
@@ -39,6 +41,7 @@
         <module>yak-ops-core</module>
         <module>yak-ops-business</module>
         <module>yak-ops-plugins/yak-ops-plugin-datasource</module>
+        <module>yak-ops-plugins/yak-ops-plugin-storage</module>
         <module>yak-ops-plugins/yak-ops-plugin-task</module>
         <module>yak-ops-boot</module>
         <module>yak-ops-ui</module>
@@ -142,6 +145,26 @@
             <dependency>
                 <groupId>io.yak.ops</groupId>
                 <artifactId>yak-ops-plugin-datasource-all</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.yak.ops</groupId>
+                <artifactId>yak-ops-plugin-storage-api</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.yak.ops</groupId>
+                <artifactId>yak-ops-plugin-storage-minio</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.yak.ops</groupId>
+                <artifactId>yak-ops-plugin-storage-hdfs</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.yak.ops</groupId>
+                <artifactId>yak-ops-plugin-storage-all</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>

--- a/yak-ops-bom/pom.xml
+++ b/yak-ops-bom/pom.xml
@@ -117,6 +117,26 @@
             </dependency>
             <dependency>
                 <groupId>io.yak.ops</groupId>
+                <artifactId>yak-ops-plugin-storage-api</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.yak.ops</groupId>
+                <artifactId>yak-ops-plugin-storage-minio</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.yak.ops</groupId>
+                <artifactId>yak-ops-plugin-storage-hdfs</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.yak.ops</groupId>
+                <artifactId>yak-ops-plugin-storage-all</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.yak.ops</groupId>
                 <artifactId>yak-ops-plugin-task-api</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/yak-ops-boot/pom.xml
+++ b/yak-ops-boot/pom.xml
@@ -50,6 +50,10 @@
         </dependency>
         <dependency>
             <groupId>io.yak.ops</groupId>
+            <artifactId>yak-ops-plugin-storage-all</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.yak.ops</groupId>
             <artifactId>yak-ops-plugin-task-all</artifactId>
         </dependency>
         <dependency>

--- a/yak-ops-boot/src/main/resources/application.yml
+++ b/yak-ops-boot/src/main/resources/application.yml
@@ -5,7 +5,7 @@ server:
 spring:
   application:
     name: yak-ops
-  # Yak Security、Yak Datasource 和 Yak Workflow 分别维护自己的数据源与事务管理器。
+  # Yak Security、Yak Datasource、Yak Resource 和 Yak Workflow 分别维护自己的数据源与事务管理器。
   autoconfigure:
     exclude:
       - org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
@@ -13,6 +13,10 @@ spring:
   # 各业务模块自行创建并执行 Flyway。
   flyway:
     enabled: false
+  servlet:
+    multipart:
+      max-file-size: ${YAK_RESOURCE_MAX_FILE_SIZE:100MB}
+      max-request-size: ${YAK_RESOURCE_MAX_REQUEST_SIZE:110MB}
   lifecycle:
     timeout-per-shutdown-phase: 20s
   jackson:
@@ -87,6 +91,34 @@ yak:
       maximum-pool-size: 8
     connection-test:
       timeout-seconds: ${YAK_DATASOURCE_CONNECT_TIMEOUT_SECONDS:5}
+
+  resource:
+    enabled: ${YAK_RESOURCE_ENABLED:true}
+    max-file-size: ${YAK_RESOURCE_MAX_FILE_BYTES:104857600}
+    editable-max-bytes: ${YAK_RESOURCE_EDITABLE_MAX_BYTES:2097152}
+    database:
+      url: ${YAK_RESOURCE_DATASOURCE_URL:${YAK_SECURITY_DATASOURCE_URL:jdbc:mariadb://127.0.0.1:3306/yak_security?useUnicode=true&allowPublicKeyRetrieval=true&characterEncoding=UTF-8&useSSL=false&serverTimezone=Asia/Shanghai}}
+      username: ${YAK_RESOURCE_DATASOURCE_USERNAME:${YAK_SECURITY_DATASOURCE_USERNAME:root}}
+      password: ${YAK_RESOURCE_DATASOURCE_PASSWORD:${YAK_SECURITY_DATASOURCE_PASSWORD:123456}}
+      driver-class-name: ${YAK_RESOURCE_DATASOURCE_DRIVER:org.mariadb.jdbc.Driver}
+      minimum-idle: 1
+      maximum-pool-size: 8
+    storage:
+      type: ${YAK_RESOURCE_STORAGE_TYPE:MINIO}
+      minio:
+        enabled: ${YAK_RESOURCE_MINIO_ENABLED:true}
+        endpoint: ${YAK_RESOURCE_MINIO_ENDPOINT:http://127.0.0.1:9000}
+        access-key: ${YAK_RESOURCE_MINIO_ACCESS_KEY:minioadmin}
+        secret-key: ${YAK_RESOURCE_MINIO_SECRET_KEY:minioadmin}
+        bucket: ${YAK_RESOURCE_MINIO_BUCKET:yak-ops}
+        base-prefix: ${YAK_RESOURCE_MINIO_BASE_PREFIX:resources}
+        auto-create-bucket: ${YAK_RESOURCE_MINIO_AUTO_CREATE_BUCKET:true}
+      hdfs:
+        enabled: ${YAK_RESOURCE_HDFS_ENABLED:false}
+        uri: ${YAK_RESOURCE_HDFS_URI:hdfs://127.0.0.1:9000}
+        user: ${YAK_RESOURCE_HDFS_USER:hdfs}
+        base-directory: ${YAK_RESOURCE_HDFS_BASE_DIRECTORY:/yak-ops/resources}
+        replication: ${YAK_RESOURCE_HDFS_REPLICATION:1}
 
   sync:
     offline:

--- a/yak-ops-boot/src/test/resources/application-test.yml
+++ b/yak-ops-boot/src/test/resources/application-test.yml
@@ -22,6 +22,13 @@ yak:
       enabled: false
   datasource:
     enabled: false
+  resource:
+    enabled: false
+    storage:
+      minio:
+        enabled: false
+      hdfs:
+        enabled: false
   sync:
     offline:
       enabled: false

--- a/yak-ops-business/yak-ops-business-resource/pom.xml
+++ b/yak-ops-business/yak-ops-business-resource/pom.xml
@@ -19,11 +19,68 @@
     <dependencies>
         <dependency>
             <groupId>io.yak.ops</groupId>
-            <artifactId>yak-ops-core</artifactId>
+            <artifactId>yak-ops-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.yak.ops</groupId>
+            <artifactId>yak-ops-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.yak.ops</groupId>
+            <artifactId>yak-ops-plugin-storage-api</artifactId>
         </dependency>
         <dependency>
             <groupId>io.yak.framework</groupId>
-            <artifactId>yak-file</artifactId>
+            <artifactId>yak-security-spring-boot-starter</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-jdbc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.baomidou</groupId>
+            <artifactId>mybatis-plus-spring-boot3-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.baomidou</groupId>
+            <artifactId>mybatis-plus-jsqlparser-4.9</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-mysql</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/yak-ops-business/yak-ops-business-resource/src/main/java/io/yak/ops/business/resource/config/ConditionalOnResourceEnabled.java
+++ b/yak-ops-business/yak-ops-business-resource/src/main/java/io/yak/ops/business/resource/config/ConditionalOnResourceEnabled.java
@@ -1,0 +1,18 @@
+package io.yak.ops.business.resource.config;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+
+/** 仅在资源管理模块启用时装配相关 Bean。 */
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@ConditionalOnProperty(
+    prefix = "yak.resource",
+    name = "enabled",
+    havingValue = "true",
+    matchIfMissing = true)
+public @interface ConditionalOnResourceEnabled {
+}

--- a/yak-ops-business/yak-ops-business-resource/src/main/java/io/yak/ops/business/resource/config/ResourceConfiguration.java
+++ b/yak-ops-business/yak-ops-business-resource/src/main/java/io/yak/ops/business/resource/config/ResourceConfiguration.java
@@ -1,0 +1,84 @@
+package io.yak.ops.business.resource.config;
+
+import com.baomidou.mybatisplus.annotation.DbType;
+import com.baomidou.mybatisplus.extension.plugins.MybatisPlusInterceptor;
+import com.baomidou.mybatisplus.extension.plugins.inner.PaginationInnerInterceptor;
+import com.baomidou.mybatisplus.extension.spring.MybatisSqlSessionFactoryBean;
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import io.yak.ops.common.mybatis.MybatisPlusFactorySupport;
+import javax.sql.DataSource;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.flywaydb.core.Flyway;
+import org.flywaydb.core.api.MigrationVersion;
+import org.mybatis.spring.SqlSessionTemplate;
+import org.mybatis.spring.annotation.MapperScan;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.transaction.PlatformTransactionManager;
+
+/** 资源管理模块基础设施配置。 */
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnResourceEnabled
+@EnableConfigurationProperties(ResourceProperties.class)
+@MapperScan(
+    basePackages = "io.yak.ops.business.resource.dao.mapper",
+    sqlSessionFactoryRef = "opsResourceSqlSessionFactory")
+public class ResourceConfiguration {
+
+  @Bean(name = "opsResourceDataSource", destroyMethod = "close")
+  public HikariDataSource opsResourceDataSource(ResourceProperties properties) {
+    ResourceProperties.Database database = properties.getDatabase();
+    HikariConfig config = new HikariConfig();
+    config.setPoolName("YakOpsResourcePool");
+    config.setJdbcUrl(database.getUrl());
+    config.setUsername(database.getUsername());
+    config.setPassword(database.getPassword());
+    config.setDriverClassName(database.getDriverClassName());
+    config.setMinimumIdle(database.getMinimumIdle());
+    config.setMaximumPoolSize(database.getMaximumPoolSize());
+    config.setAutoCommit(true);
+    return new HikariDataSource(config);
+  }
+
+  @Bean(name = "opsResourceTransactionManager")
+  public PlatformTransactionManager opsResourceTransactionManager(
+      @Qualifier("opsResourceDataSource") DataSource dataSource) {
+    return new DataSourceTransactionManager(dataSource);
+  }
+
+  @Bean(name = "opsResourceSqlSessionFactory")
+  public SqlSessionFactory opsResourceSqlSessionFactory(
+      @Qualifier("opsResourceDataSource") DataSource dataSource) throws Exception {
+    MybatisSqlSessionFactoryBean factory = new MybatisSqlSessionFactoryBean();
+    factory.setDataSource(dataSource);
+    factory.setTypeAliasesPackage("io.yak.ops.common.bean.po.resource");
+    factory.setConfiguration(MybatisPlusFactorySupport.createConfiguration());
+    factory.setGlobalConfig(MybatisPlusFactorySupport.createGlobalConfig());
+
+    MybatisPlusInterceptor interceptor = new MybatisPlusInterceptor();
+    interceptor.addInnerInterceptor(new PaginationInnerInterceptor(DbType.MYSQL));
+    factory.setPlugins(interceptor);
+    return factory.getObject();
+  }
+
+  @Bean(name = "opsResourceSqlSessionTemplate")
+  public SqlSessionTemplate opsResourceSqlSessionTemplate(
+      @Qualifier("opsResourceSqlSessionFactory") SqlSessionFactory sqlSessionFactory) {
+    return new SqlSessionTemplate(sqlSessionFactory);
+  }
+
+  @Bean(initMethod = "migrate")
+  public Flyway opsResourceFlyway(@Qualifier("opsResourceDataSource") DataSource dataSource) {
+    return Flyway.configure()
+        .dataSource(dataSource)
+        .locations("classpath:db/migration/yak-resource")
+        .table("yak_resource_schema_history")
+        .baselineVersion(MigrationVersion.fromVersion("0"))
+        .baselineOnMigrate(true)
+        .load();
+  }
+}

--- a/yak-ops-business/yak-ops-business-resource/src/main/java/io/yak/ops/business/resource/config/ResourceProperties.java
+++ b/yak-ops-business/yak-ops-business-resource/src/main/java/io/yak/ops/business/resource/config/ResourceProperties.java
@@ -1,0 +1,137 @@
+package io.yak.ops.business.resource.config;
+
+import io.yak.ops.common.enums.resource.ResourceStorageType;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/** 资源管理模块配置。 */
+@ConfigurationProperties(prefix = "yak.resource")
+public class ResourceProperties {
+
+  private boolean enabled = true;
+  private long maxFileSize = 100L * 1024L * 1024L;
+  private long editableMaxBytes = 2L * 1024L * 1024L;
+  private final Database database = new Database();
+  private final Storage storage = new Storage();
+  private Set<String> editableSuffixes = new LinkedHashSet<>(Arrays.asList(
+      "txt", "log", "sql", "json", "xml", "yaml", "yml", "conf", "properties",
+      "sh", "py", "java", "js", "ts", "tsx", "md", "csv", "hocon"));
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  public long getMaxFileSize() {
+    return maxFileSize;
+  }
+
+  public void setMaxFileSize(long maxFileSize) {
+    this.maxFileSize = maxFileSize;
+  }
+
+  public long getEditableMaxBytes() {
+    return editableMaxBytes;
+  }
+
+  public void setEditableMaxBytes(long editableMaxBytes) {
+    this.editableMaxBytes = editableMaxBytes;
+  }
+
+  public Database getDatabase() {
+    return database;
+  }
+
+  public Storage getStorage() {
+    return storage;
+  }
+
+  public Set<String> getEditableSuffixes() {
+    return editableSuffixes;
+  }
+
+  public void setEditableSuffixes(Set<String> editableSuffixes) {
+    this.editableSuffixes = editableSuffixes;
+  }
+
+  /** 资源元数据数据库配置。 */
+  public static class Database {
+
+    private String url =
+        "jdbc:mariadb://127.0.0.1:3306/yak_security"
+            + "?useUnicode=true&allowPublicKeyRetrieval=true&characterEncoding=UTF-8"
+            + "&useSSL=false&serverTimezone=Asia/Shanghai";
+    private String username = "root";
+    private String password = "123456";
+    private String driverClassName = "org.mariadb.jdbc.Driver";
+    private int minimumIdle = 1;
+    private int maximumPoolSize = 8;
+
+    public String getUrl() {
+      return url;
+    }
+
+    public void setUrl(String url) {
+      this.url = url;
+    }
+
+    public String getUsername() {
+      return username;
+    }
+
+    public void setUsername(String username) {
+      this.username = username;
+    }
+
+    public String getPassword() {
+      return password;
+    }
+
+    public void setPassword(String password) {
+      this.password = password;
+    }
+
+    public String getDriverClassName() {
+      return driverClassName;
+    }
+
+    public void setDriverClassName(String driverClassName) {
+      this.driverClassName = driverClassName;
+    }
+
+    public int getMinimumIdle() {
+      return minimumIdle;
+    }
+
+    public void setMinimumIdle(int minimumIdle) {
+      this.minimumIdle = minimumIdle;
+    }
+
+    public int getMaximumPoolSize() {
+      return maximumPoolSize;
+    }
+
+    public void setMaximumPoolSize(int maximumPoolSize) {
+      this.maximumPoolSize = maximumPoolSize;
+    }
+  }
+
+  /** 当前资源存储选择。 */
+  public static class Storage {
+
+    private ResourceStorageType type = ResourceStorageType.MINIO;
+
+    public ResourceStorageType getType() {
+      return type;
+    }
+
+    public void setType(ResourceStorageType type) {
+      this.type = type;
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-resource/src/main/java/io/yak/ops/business/resource/controller/v1/ResourcesController.java
+++ b/yak-ops-business/yak-ops-business-resource/src/main/java/io/yak/ops/business/resource/controller/v1/ResourcesController.java
@@ -1,0 +1,193 @@
+package io.yak.ops.business.resource.controller.v1;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.yak.framework.common.PagingResult;
+import io.yak.framework.common.Result;
+import io.yak.framework.security.web.RequiresPermission;
+import io.yak.ops.business.resource.config.ConditionalOnResourceEnabled;
+import io.yak.ops.business.resource.model.ResourceDownload;
+import io.yak.ops.business.resource.service.ResourceService;
+import io.yak.ops.common.bean.dto.resource.ResourceContentUpdateDTO;
+import io.yak.ops.common.bean.dto.resource.ResourceCreateContentDTO;
+import io.yak.ops.common.bean.dto.resource.ResourceCreateDirectoryDTO;
+import io.yak.ops.common.bean.dto.resource.ResourceMoveDTO;
+import io.yak.ops.common.bean.dto.resource.ResourceQueryDTO;
+import io.yak.ops.common.bean.dto.resource.ResourceUpdateDTO;
+import io.yak.ops.common.bean.vo.resource.ResourceContentVO;
+import io.yak.ops.common.bean.vo.resource.ResourceStoragePluginVO;
+import io.yak.ops.common.bean.vo.resource.ResourceVO;
+import io.yak.ops.common.constant.resource.ResourcePermissionCode;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.util.StreamUtils;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+/** 资源目录与文件管理接口。 */
+@Tag(name = "资源管理接口")
+@RestController
+@Validated
+@ConditionalOnResourceEnabled
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/resources")
+@RequiresPermission(ResourcePermissionCode.READ)
+public class ResourcesController {
+
+  private final ResourceService resourceService;
+
+  @Operation(summary = "创建资源目录")
+  @PostMapping("/directory")
+  @RequiresPermission(ResourcePermissionCode.CREATE)
+  public Result<ResourceVO> createDirectory(
+      @Valid @RequestBody ResourceCreateDirectoryDTO requestDTO) {
+    return Result.success(resourceService.createDirectory(requestDTO));
+  }
+
+  @Operation(summary = "上传资源文件")
+  @PostMapping
+  @RequiresPermission(ResourcePermissionCode.CREATE)
+  public Result<ResourceVO> upload(
+      @RequestParam(value = "parentId", required = false, defaultValue = "0") Long parentId,
+      @RequestParam(value = "name", required = false) String name,
+      @RequestParam(value = "description", required = false) String description,
+      @RequestParam("file") MultipartFile file) {
+    return Result.success(resourceService.upload(parentId, name, description, file));
+  }
+
+  @Operation(summary = "在线创建文本资源")
+  @PostMapping("/online-create")
+  @RequiresPermission(ResourcePermissionCode.CREATE)
+  public Result<ResourceVO> createContent(
+      @Valid @RequestBody ResourceCreateContentDTO requestDTO) {
+    return Result.success(resourceService.createContent(requestDTO));
+  }
+
+  @Operation(summary = "查询资源详情")
+  @GetMapping("/{id}")
+  public Result<ResourceVO> detail(@PathVariable("id") Long id) {
+    return Result.success(resourceService.get(id));
+  }
+
+  @Operation(summary = "查询目录直属资源")
+  @GetMapping("/list")
+  public Result<List<ResourceVO>> list(
+      @RequestParam(value = "parentId", required = false, defaultValue = "0") Long parentId,
+      @RequestParam(value = "keyword", required = false) String keyword) {
+    return Result.success(resourceService.list(parentId, keyword));
+  }
+
+  @Operation(summary = "分页查询资源")
+  @PostMapping("/page")
+  public PagingResult<ResourceVO> page(
+      @Valid @RequestBody(required = false) ResourceQueryDTO queryDTO) {
+    return PagingResult.success(resourceService.page(queryDTO));
+  }
+
+  @Operation(summary = "查询完整资源树")
+  @GetMapping("/tree")
+  public Result<List<ResourceVO>> tree() {
+    return Result.success(resourceService.tree());
+  }
+
+  @Operation(summary = "重命名资源或修改描述")
+  @PutMapping("/{id}")
+  @RequiresPermission(ResourcePermissionCode.UPDATE)
+  public Result<ResourceVO> update(
+      @PathVariable("id") Long id,
+      @Valid @RequestBody ResourceUpdateDTO requestDTO) {
+    return Result.success(resourceService.update(id, requestDTO));
+  }
+
+  @Operation(summary = "替换资源文件")
+  @PutMapping("/{id}/file")
+  @RequiresPermission(ResourcePermissionCode.UPDATE)
+  public Result<ResourceVO> replaceFile(
+      @PathVariable("id") Long id,
+      @RequestParam("file") MultipartFile file) {
+    return Result.success(resourceService.replaceFile(id, file));
+  }
+
+  @Operation(summary = "更新资源文本内容")
+  @PutMapping("/{id}/content")
+  @RequiresPermission(ResourcePermissionCode.UPDATE)
+  public Result<ResourceContentVO> updateContent(
+      @PathVariable("id") Long id,
+      @Valid @RequestBody ResourceContentUpdateDTO requestDTO) {
+    return Result.success(resourceService.updateContent(id, requestDTO));
+  }
+
+  @Operation(summary = "分页查看资源文本内容")
+  @GetMapping("/{id}/content")
+  public Result<ResourceContentVO> content(
+      @PathVariable("id") Long id,
+      @RequestParam(value = "skipLineNum", defaultValue = "0")
+      @Min(value = 0, message = "跳过行数不能小于 0") int skipLineNum,
+      @RequestParam(value = "limit", defaultValue = "200")
+      @Min(value = 1, message = "读取行数必须大于 0")
+      @Max(value = 2000, message = "单次读取不能超过 2000 行") int limit) {
+    return Result.success(resourceService.getContent(id, skipLineNum, limit));
+  }
+
+  @Operation(summary = "移动资源")
+  @PostMapping("/{id}/move")
+  @RequiresPermission(ResourcePermissionCode.UPDATE)
+  public Result<ResourceVO> move(
+      @PathVariable("id") Long id,
+      @Valid @RequestBody ResourceMoveDTO requestDTO) {
+    return Result.success(resourceService.move(id, requestDTO));
+  }
+
+  @Operation(summary = "递归删除资源")
+  @DeleteMapping("/{id}")
+  @RequiresPermission(ResourcePermissionCode.DELETE)
+  public Result<Boolean> delete(@PathVariable("id") Long id) {
+    return Result.success(resourceService.delete(id));
+  }
+
+  @Operation(summary = "下载资源文件")
+  @GetMapping("/{id}/download")
+  @RequiresPermission(ResourcePermissionCode.DOWNLOAD)
+  public void download(
+      @PathVariable("id") Long id,
+      HttpServletResponse response) throws IOException {
+    ResourceDownload download = resourceService.download(id);
+    response.setContentType(download.getContentType());
+    if (download.getFileSize() >= 0L) {
+      response.setContentLengthLong(download.getFileSize());
+    }
+    String encodedName = URLEncoder.encode(download.getFileName(), StandardCharsets.UTF_8)
+        .replace("+", "%20");
+    response.setHeader(
+        HttpHeaders.CONTENT_DISPOSITION,
+        "attachment; filename*=UTF-8''" + encodedName);
+    try (InputStream inputStream = download.getInputStream()) {
+      StreamUtils.copy(inputStream, response.getOutputStream());
+      response.flushBuffer();
+    }
+  }
+
+  @Operation(summary = "查询已安装存储插件")
+  @GetMapping("/storage-plugins")
+  public Result<List<ResourceStoragePluginVO>> storagePlugins() {
+    return Result.success(resourceService.storagePlugins());
+  }
+}

--- a/yak-ops-business/yak-ops-business-resource/src/main/java/io/yak/ops/business/resource/dao/ResourceDao.java
+++ b/yak-ops-business/yak-ops-business-resource/src/main/java/io/yak/ops/business/resource/dao/ResourceDao.java
@@ -1,0 +1,32 @@
+package io.yak.ops.business.resource.dao;
+
+import com.baomidou.mybatisplus.core.metadata.IPage;
+import io.yak.ops.common.bean.dto.resource.ResourceQueryDTO;
+import io.yak.ops.common.bean.po.resource.ResourcePO;
+import java.util.List;
+
+/** 资源数据访问接口。 */
+public interface ResourceDao {
+
+  int insert(ResourcePO resourcePO);
+
+  boolean update(ResourcePO resourcePO);
+
+  ResourcePO selectById(Long id);
+
+  ResourcePO selectByFullPath(String fullPath);
+
+  boolean existsByParentAndName(Long parentId, String name, Long excludeId);
+
+  List<ResourcePO> selectChildren(Long parentId, String keyword);
+
+  List<ResourcePO> selectAll();
+
+  List<ResourcePO> selectDescendants(String fullPath);
+
+  IPage<ResourcePO> selectPage(ResourceQueryDTO queryDTO);
+
+  boolean updateBatch(List<ResourcePO> resources);
+
+  boolean deleteBatch(List<Long> ids);
+}

--- a/yak-ops-business/yak-ops-business-resource/src/main/java/io/yak/ops/business/resource/dao/impl/ResourceDaoImpl.java
+++ b/yak-ops-business/yak-ops-business-resource/src/main/java/io/yak/ops/business/resource/dao/impl/ResourceDaoImpl.java
@@ -1,0 +1,136 @@
+package io.yak.ops.business.resource.dao.impl;
+
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.baomidou.mybatisplus.core.metadata.IPage;
+import com.baomidou.mybatisplus.core.toolkit.Wrappers;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import io.yak.ops.business.resource.config.ConditionalOnResourceEnabled;
+import io.yak.ops.business.resource.dao.ResourceDao;
+import io.yak.ops.business.resource.dao.mapper.ResourceMapper;
+import io.yak.ops.common.bean.dto.resource.ResourceQueryDTO;
+import io.yak.ops.common.bean.po.resource.ResourcePO;
+import io.yak.ops.common.enums.resource.ResourceNodeType;
+import java.util.Collections;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
+
+/** 资源数据访问实现。 */
+@Repository
+@ConditionalOnResourceEnabled
+@RequiredArgsConstructor
+public class ResourceDaoImpl implements ResourceDao {
+
+  private final ResourceMapper resourceMapper;
+
+  @Override
+  public int insert(ResourcePO resourcePO) {
+    return resourceMapper.insert(resourcePO);
+  }
+
+  @Override
+  public boolean update(ResourcePO resourcePO) {
+    return resourcePO != null && resourceMapper.updateById(resourcePO) > 0;
+  }
+
+  @Override
+  public ResourcePO selectById(Long id) {
+    return id == null ? null : resourceMapper.selectById(id);
+  }
+
+  @Override
+  public ResourcePO selectByFullPath(String fullPath) {
+    if (!StringUtils.hasText(fullPath)) {
+      return null;
+    }
+    return resourceMapper.selectOne(
+        Wrappers.<ResourcePO>lambdaQuery().eq(ResourcePO::getFullPath, fullPath));
+  }
+
+  @Override
+  public boolean existsByParentAndName(Long parentId, String name, Long excludeId) {
+    Long count = resourceMapper.selectCount(
+        Wrappers.<ResourcePO>lambdaQuery()
+            .eq(ResourcePO::getParentId, parentId == null ? 0L : parentId)
+            .eq(ResourcePO::getName, name)
+            .ne(excludeId != null, ResourcePO::getId, excludeId));
+    return count != null && count > 0L;
+  }
+
+  @Override
+  public List<ResourcePO> selectChildren(Long parentId, String keyword) {
+    return resourceMapper.selectList(
+        Wrappers.<ResourcePO>lambdaQuery()
+            .eq(ResourcePO::getParentId, parentId == null ? 0L : parentId)
+            .and(
+                StringUtils.hasText(keyword),
+                nested -> nested
+                    .like(ResourcePO::getName, keyword)
+                    .or()
+                    .like(ResourcePO::getFullPath, keyword))
+            .orderByAsc(ResourcePO::getNodeType)
+            .orderByAsc(ResourcePO::getName)
+            .orderByAsc(ResourcePO::getId));
+  }
+
+  @Override
+  public List<ResourcePO> selectAll() {
+    return resourceMapper.selectList(
+        Wrappers.<ResourcePO>lambdaQuery()
+            .orderByAsc(ResourcePO::getFullPath)
+            .orderByAsc(ResourcePO::getId));
+  }
+
+  @Override
+  public List<ResourcePO> selectDescendants(String fullPath) {
+    if (!StringUtils.hasText(fullPath)) {
+      return Collections.emptyList();
+    }
+    return resourceMapper.selectList(
+        Wrappers.<ResourcePO>lambdaQuery()
+            .likeRight(ResourcePO::getFullPath, fullPath + "/")
+            .orderByAsc(ResourcePO::getFullPath));
+  }
+
+  @Override
+  public IPage<ResourcePO> selectPage(ResourceQueryDTO queryDTO) {
+    Page<ResourcePO> page = Page.of(queryDTO.getPageNo(), queryDTO.getPageSize());
+    LambdaQueryWrapper<ResourcePO> wrapper = Wrappers.lambdaQuery();
+    wrapper
+        .eq(queryDTO.getParentId() != null, ResourcePO::getParentId, queryDTO.getParentId())
+        .and(
+            StringUtils.hasText(queryDTO.getKeyword()),
+            nested -> nested
+                .like(ResourcePO::getName, queryDTO.getKeyword())
+                .or()
+                .like(ResourcePO::getFullPath, queryDTO.getKeyword()));
+    if (StringUtils.hasText(queryDTO.getNodeType())) {
+      wrapper.eq(ResourcePO::getNodeType,
+          ResourceNodeType.valueOf(queryDTO.getNodeType().trim().toUpperCase()));
+    }
+    wrapper
+        .orderByAsc(ResourcePO::getNodeType)
+        .orderByAsc(ResourcePO::getName)
+        .orderByAsc(ResourcePO::getId);
+    return resourceMapper.selectPage(page, wrapper);
+  }
+
+  @Override
+  public boolean updateBatch(List<ResourcePO> resources) {
+    if (resources == null || resources.isEmpty()) {
+      return true;
+    }
+    for (ResourcePO resource : resources) {
+      if (resourceMapper.updateById(resource) <= 0) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  @Override
+  public boolean deleteBatch(List<Long> ids) {
+    return ids != null && !ids.isEmpty() && resourceMapper.deleteByIds(ids) == ids.size();
+  }
+}

--- a/yak-ops-business/yak-ops-business-resource/src/main/java/io/yak/ops/business/resource/dao/mapper/ResourceMapper.java
+++ b/yak-ops-business/yak-ops-business-resource/src/main/java/io/yak/ops/business/resource/dao/mapper/ResourceMapper.java
@@ -1,0 +1,10 @@
+package io.yak.ops.business.resource.dao.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import io.yak.ops.common.bean.po.resource.ResourcePO;
+import org.apache.ibatis.annotations.Mapper;
+
+/** 资源 MyBatis-Plus Mapper。 */
+@Mapper
+public interface ResourceMapper extends BaseMapper<ResourcePO> {
+}

--- a/yak-ops-business/yak-ops-business-resource/src/main/java/io/yak/ops/business/resource/exception/ResourceException.java
+++ b/yak-ops-business/yak-ops-business-resource/src/main/java/io/yak/ops/business/resource/exception/ResourceException.java
@@ -1,0 +1,43 @@
+package io.yak.ops.business.resource.exception;
+
+import io.yak.framework.common.BusinessException;
+import io.yak.framework.common.ErrorCode;
+
+/** 资源管理业务异常。 */
+public class ResourceException extends BusinessException {
+
+  private static final long serialVersionUID = 1L;
+
+  private final ErrorCode actualErrorCode;
+  private final String userMessage;
+
+  public ResourceException(ErrorCode errorCode) {
+    super(errorCode);
+    this.actualErrorCode = errorCode;
+    this.userMessage = errorCode == null ? null : errorCode.getMessage();
+  }
+
+  public ResourceException(ErrorCode errorCode, String detail) {
+    this(errorCode, detail, null);
+  }
+
+  public ResourceException(ErrorCode errorCode, String detail, Throwable cause) {
+    super(buildMessage(errorCode, detail), cause);
+    this.actualErrorCode = errorCode;
+    this.userMessage = buildMessage(errorCode, detail);
+  }
+
+  @Override
+  public ErrorCode getErrorCode() {
+    return actualErrorCode;
+  }
+
+  public String getUserMessage() {
+    return userMessage;
+  }
+
+  private static String buildMessage(ErrorCode errorCode, String detail) {
+    String base = errorCode == null ? "资源操作失败" : errorCode.getMessage();
+    return detail == null || detail.trim().isEmpty() ? base : base + "：" + detail.trim();
+  }
+}

--- a/yak-ops-business/yak-ops-business-resource/src/main/java/io/yak/ops/business/resource/exception/ResourceExceptionHandler.java
+++ b/yak-ops-business/yak-ops-business-resource/src/main/java/io/yak/ops/business/resource/exception/ResourceExceptionHandler.java
@@ -1,0 +1,103 @@
+package io.yak.ops.business.resource.exception;
+
+import io.yak.framework.common.ErrorCode;
+import io.yak.framework.common.Result;
+import io.yak.framework.security.common.enums.ResultCode;
+import io.yak.framework.security.exception.YakSecurityException;
+import io.yak.ops.business.resource.config.ConditionalOnResourceEnabled;
+import io.yak.ops.business.resource.controller.v1.ResourcesController;
+import io.yak.ops.common.enums.resource.ResourceErrorCode;
+import jakarta.validation.ConstraintViolationException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.BindException;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
+
+/** 资源管理接口异常转换。 */
+@Slf4j
+@Order(Ordered.HIGHEST_PRECEDENCE)
+@RestControllerAdvice(basePackageClasses = ResourcesController.class)
+@ConditionalOnResourceEnabled
+public class ResourceExceptionHandler {
+
+  @ExceptionHandler(YakSecurityException.class)
+  public ResponseEntity<Result<Void>> handleSecurityException(
+      YakSecurityException exception) {
+    ErrorCode errorCode = exception.getErrorCode();
+    Result<Void> body = errorCode == null
+        ? Result.fail(exception)
+        : Result.fail(errorCode.getCode(), errorCode.getMessage());
+    HttpStatus status = errorCode == ResultCode.NO_PERMISSION
+        ? HttpStatus.FORBIDDEN
+        : HttpStatus.UNAUTHORIZED;
+    return ResponseEntity.status(status).body(body);
+  }
+
+  @ExceptionHandler(ResourceException.class)
+  public Result<Void> handleResourceException(ResourceException exception) {
+    if (exception.getErrorCode() == null) {
+      return Result.fail(exception.getUserMessage());
+    }
+    return Result.fail(
+        exception.getErrorCode().getCode(),
+        exception.getUserMessage());
+  }
+
+  @ExceptionHandler({
+    MethodArgumentNotValidException.class,
+    BindException.class,
+    HttpMessageNotReadableException.class
+  })
+  public Result<Void> handleInvalidRequest(Exception exception) {
+    return Result.buildParamIllegal(resolveValidationMessage(exception));
+  }
+
+  @ExceptionHandler(ConstraintViolationException.class)
+  public Result<Void> handleConstraintViolation(ConstraintViolationException exception) {
+    return Result.buildParamIllegal(exception.getMessage());
+  }
+
+  @ExceptionHandler(MaxUploadSizeExceededException.class)
+  public Result<Void> handleMaxUploadSize(MaxUploadSizeExceededException exception) {
+    return Result.fail(
+        ResourceErrorCode.FILE_TOO_LARGE.getCode(),
+        ResourceErrorCode.FILE_TOO_LARGE.getMessage());
+  }
+
+  @ExceptionHandler(DataIntegrityViolationException.class)
+  public Result<Void> handleDataIntegrityViolation(
+      DataIntegrityViolationException exception) {
+    log.warn("Resource persistence constraint violation", exception);
+    return Result.fail(
+        ResourceErrorCode.DUPLICATE_NAME.getCode(),
+        ResourceErrorCode.DUPLICATE_NAME.getMessage());
+  }
+
+  @ExceptionHandler(Exception.class)
+  public Result<Void> handleUnexpectedException(Exception exception) {
+    log.error("Unexpected resource management error", exception);
+    return Result.fail("资源操作失败，请稍后重试");
+  }
+
+  private String resolveValidationMessage(Exception exception) {
+    BindingResult bindingResult = null;
+    if (exception instanceof MethodArgumentNotValidException) {
+      bindingResult = ((MethodArgumentNotValidException) exception).getBindingResult();
+    } else if (exception instanceof BindException) {
+      bindingResult = ((BindException) exception).getBindingResult();
+    }
+    if (bindingResult != null && bindingResult.getFieldError() != null) {
+      return bindingResult.getFieldError().getDefaultMessage();
+    }
+    return "请求参数格式不正确";
+  }
+}

--- a/yak-ops-business/yak-ops-business-resource/src/main/java/io/yak/ops/business/resource/model/ResourceDownload.java
+++ b/yak-ops-business/yak-ops-business-resource/src/main/java/io/yak/ops/business/resource/model/ResourceDownload.java
@@ -1,0 +1,14 @@
+package io.yak.ops.business.resource.model;
+
+import java.io.InputStream;
+import lombok.Value;
+
+/** 资源下载流及响应元数据。 */
+@Value
+public class ResourceDownload {
+
+  String fileName;
+  String contentType;
+  long fileSize;
+  InputStream inputStream;
+}

--- a/yak-ops-business/yak-ops-business-resource/src/main/java/io/yak/ops/business/resource/service/ResourceService.java
+++ b/yak-ops-business/yak-ops-business-resource/src/main/java/io/yak/ops/business/resource/service/ResourceService.java
@@ -1,0 +1,49 @@
+package io.yak.ops.business.resource.service;
+
+import io.yak.framework.common.PagingData;
+import io.yak.ops.business.resource.model.ResourceDownload;
+import io.yak.ops.common.bean.dto.resource.ResourceContentUpdateDTO;
+import io.yak.ops.common.bean.dto.resource.ResourceCreateContentDTO;
+import io.yak.ops.common.bean.dto.resource.ResourceCreateDirectoryDTO;
+import io.yak.ops.common.bean.dto.resource.ResourceMoveDTO;
+import io.yak.ops.common.bean.dto.resource.ResourceQueryDTO;
+import io.yak.ops.common.bean.dto.resource.ResourceUpdateDTO;
+import io.yak.ops.common.bean.vo.resource.ResourceContentVO;
+import io.yak.ops.common.bean.vo.resource.ResourceStoragePluginVO;
+import io.yak.ops.common.bean.vo.resource.ResourceVO;
+import java.util.List;
+import org.springframework.web.multipart.MultipartFile;
+
+/** 资源管理服务。 */
+public interface ResourceService {
+
+  ResourceVO createDirectory(ResourceCreateDirectoryDTO requestDTO);
+
+  ResourceVO upload(Long parentId, String name, String description, MultipartFile file);
+
+  ResourceVO createContent(ResourceCreateContentDTO requestDTO);
+
+  ResourceVO get(Long id);
+
+  List<ResourceVO> list(Long parentId, String keyword);
+
+  PagingData<ResourceVO> page(ResourceQueryDTO queryDTO);
+
+  List<ResourceVO> tree();
+
+  ResourceVO update(Long id, ResourceUpdateDTO requestDTO);
+
+  ResourceVO replaceFile(Long id, MultipartFile file);
+
+  ResourceContentVO updateContent(Long id, ResourceContentUpdateDTO requestDTO);
+
+  ResourceContentVO getContent(Long id, int skipLineNum, int limit);
+
+  ResourceVO move(Long id, ResourceMoveDTO requestDTO);
+
+  boolean delete(Long id);
+
+  ResourceDownload download(Long id);
+
+  List<ResourceStoragePluginVO> storagePlugins();
+}

--- a/yak-ops-business/yak-ops-business-resource/src/main/java/io/yak/ops/business/resource/service/impl/ResourceFileOperations.java
+++ b/yak-ops-business/yak-ops-business-resource/src/main/java/io/yak/ops/business/resource/service/impl/ResourceFileOperations.java
@@ -1,0 +1,328 @@
+package io.yak.ops.business.resource.service.impl;
+
+import io.yak.ops.business.resource.config.ConditionalOnResourceEnabled;
+import io.yak.ops.business.resource.config.ResourceProperties;
+import io.yak.ops.business.resource.dao.ResourceDao;
+import io.yak.ops.business.resource.exception.ResourceException;
+import io.yak.ops.business.resource.model.ResourceDownload;
+import io.yak.ops.business.resource.storage.StorageOperatorRegistry;
+import io.yak.ops.business.resource.util.ResourcePathUtils;
+import io.yak.ops.common.bean.dto.resource.ResourceContentUpdateDTO;
+import io.yak.ops.common.bean.dto.resource.ResourceCreateContentDTO;
+import io.yak.ops.common.bean.po.resource.ResourcePO;
+import io.yak.ops.common.bean.vo.resource.ResourceContentVO;
+import io.yak.ops.common.bean.vo.resource.ResourceVO;
+import io.yak.ops.common.enums.resource.ResourceErrorCode;
+import io.yak.ops.common.enums.resource.ResourceNodeType;
+import io.yak.ops.spi.resource.ResourceFileSyncAction;
+import io.yak.ops.spi.storage.StorageOperator;
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.security.DigestInputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+/** 资源文件上传、下载、替换和在线编辑操作。 */
+@Component
+@ConditionalOnResourceEnabled
+@RequiredArgsConstructor
+class ResourceFileOperations {
+
+  private static final String DEFAULT_CONTENT_TYPE = "application/octet-stream";
+  private static final int MAX_CONTENT_LINES = 2000;
+
+  private final ResourceDao resourceDao;
+  private final StorageOperatorRegistry storageRegistry;
+  private final ResourceServiceSupport support;
+  private final ResourceProperties properties;
+
+  ResourceVO upload(Long parentId, String requestedName, String description, MultipartFile file) {
+    if (file == null || file.isEmpty()) {
+      throw new ResourceException(ResourceErrorCode.INVALID_NAME, "上传文件不能为空");
+    }
+    ensureFileSize(file.getSize());
+    ResourceServiceSupport.ParentContext parent = support.parent(parentId);
+    String sourceName = StringUtils.hasText(requestedName)
+        ? requestedName
+        : file.getOriginalFilename();
+    String name = ResourcePathUtils.normalizeName(sourceName);
+    support.ensureNameAvailable(parent.id, name, null);
+    String fullPath = ResourcePathUtils.childPath(parent.fullPath, name);
+    String storagePath = ResourcePathUtils.storagePath(fullPath);
+    String contentType = contentType(file.getContentType());
+    String checksum = checksum(file);
+    StorageOperator operator = storageRegistry.require(parent.storageType);
+
+    try (InputStream inputStream = file.getInputStream()) {
+      support.storageRun(() -> operator.upload(
+          storagePath, inputStream, file.getSize(), contentType, false));
+    } catch (IOException exception) {
+      throw new ResourceException(
+          ResourceErrorCode.STORAGE_OPERATION_FAILED, "读取上传文件失败", exception);
+    }
+
+    try {
+      ResourcePO resource = support.newResource(
+          parent.id,
+          name,
+          fullPath,
+          ResourceNodeType.FILE,
+          parent.storageType,
+          storagePath,
+          contentType,
+          ResourcePathUtils.suffix(name),
+          file.getSize(),
+          checksum,
+          description);
+      support.insert(resource);
+      support.dispatch(resource, ResourceFileSyncAction.CREATED, null);
+      return support.toVO(resource);
+    } catch (RuntimeException exception) {
+      support.cleanupCreatedObject(operator, storagePath, false);
+      throw exception;
+    }
+  }
+
+  ResourceVO createContent(ResourceCreateContentDTO requestDTO) {
+    if (requestDTO == null) {
+      throw new ResourceException(ResourceErrorCode.INVALID_NAME, "在线创建参数不能为空");
+    }
+    byte[] content = requestDTO.getContent().getBytes(StandardCharsets.UTF_8);
+    ensureFileSize(content.length);
+    ResourceServiceSupport.ParentContext parent = support.parent(requestDTO.getParentId());
+    String name = ResourcePathUtils.normalizeName(requestDTO.getName());
+    ensureEditableName(name);
+    support.ensureNameAvailable(parent.id, name, null);
+    String fullPath = ResourcePathUtils.childPath(parent.fullPath, name);
+    String storagePath = ResourcePathUtils.storagePath(fullPath);
+    String contentType = contentType(requestDTO.getContentType());
+    StorageOperator operator = storageRegistry.require(parent.storageType);
+
+    support.storageRun(() -> operator.upload(
+        storagePath,
+        new ByteArrayInputStream(content),
+        content.length,
+        contentType,
+        false));
+    try {
+      ResourcePO resource = support.newResource(
+          parent.id,
+          name,
+          fullPath,
+          ResourceNodeType.FILE,
+          parent.storageType,
+          storagePath,
+          contentType,
+          ResourcePathUtils.suffix(name),
+          (long) content.length,
+          checksum(content),
+          requestDTO.getDescription());
+      support.insert(resource);
+      support.dispatch(resource, ResourceFileSyncAction.CREATED, null);
+      return support.toVO(resource);
+    } catch (RuntimeException exception) {
+      support.cleanupCreatedObject(operator, storagePath, false);
+      throw exception;
+    }
+  }
+
+  ResourceVO replaceFile(Long id, MultipartFile file) {
+    if (file == null || file.isEmpty()) {
+      throw new ResourceException(ResourceErrorCode.INVALID_NAME, "更新文件不能为空");
+    }
+    ensureFileSize(file.getSize());
+    ResourcePO resource = support.requireFile(id);
+    String contentType = contentType(file.getContentType());
+    StorageOperator operator = storageRegistry.require(resource.getStorageType());
+    try (InputStream inputStream = file.getInputStream()) {
+      support.storageRun(() -> operator.upload(
+          resource.getStoragePath(), inputStream, file.getSize(), contentType, true));
+    } catch (IOException exception) {
+      throw new ResourceException(
+          ResourceErrorCode.STORAGE_OPERATION_FAILED, "读取更新文件失败", exception);
+    }
+    resource.setContentType(contentType);
+    resource.setFileSize(file.getSize());
+    resource.setChecksum(checksum(file));
+    resource.setVersion(support.nextVersion(resource));
+    resource.setUpdateTime(LocalDateTime.now());
+    if (!resourceDao.update(resource)) {
+      throw new ResourceException(ResourceErrorCode.UPDATE_FAILED);
+    }
+    support.dispatch(resource, ResourceFileSyncAction.UPDATED, resource.getFullPath());
+    return support.toVO(resource);
+  }
+
+  ResourceContentVO updateContent(Long id, ResourceContentUpdateDTO requestDTO) {
+    if (requestDTO == null || requestDTO.getContent() == null) {
+      throw new ResourceException(ResourceErrorCode.CONTENT_NOT_EDITABLE, "文件内容不能为空");
+    }
+    ResourcePO resource = support.requireFile(id);
+    ensureEditable(resource);
+    byte[] content = requestDTO.getContent().getBytes(StandardCharsets.UTF_8);
+    ensureFileSize(content.length);
+    if (content.length > properties.getEditableMaxBytes()) {
+      throw new ResourceException(
+          ResourceErrorCode.CONTENT_NOT_EDITABLE,
+          "在线编辑内容不能超过 " + properties.getEditableMaxBytes() + " 字节");
+    }
+    StorageOperator operator = storageRegistry.require(resource.getStorageType());
+    support.storageRun(() -> operator.upload(
+        resource.getStoragePath(),
+        new ByteArrayInputStream(content),
+        content.length,
+        contentType(resource.getContentType()),
+        true));
+    resource.setFileSize((long) content.length);
+    resource.setChecksum(checksum(content));
+    resource.setVersion(support.nextVersion(resource));
+    resource.setUpdateTime(LocalDateTime.now());
+    if (!resourceDao.update(resource)) {
+      throw new ResourceException(ResourceErrorCode.UPDATE_FAILED);
+    }
+    support.dispatch(resource, ResourceFileSyncAction.UPDATED, resource.getFullPath());
+    return contentVO(resource, requestDTO.getContent(), 0, lineCount(requestDTO.getContent()), false);
+  }
+
+  ResourceContentVO getContent(Long id, int skipLineNum, int limit) {
+    ResourcePO resource = support.requireFile(id);
+    ensureEditable(resource);
+    if (resource.getFileSize() != null
+        && resource.getFileSize() > properties.getEditableMaxBytes()) {
+      throw new ResourceException(
+          ResourceErrorCode.CONTENT_NOT_EDITABLE, "文件超过在线查看大小限制");
+    }
+    int normalizedSkip = Math.max(0, skipLineNum);
+    int normalizedLimit = Math.max(1, Math.min(limit, MAX_CONTENT_LINES));
+    StorageOperator operator = storageRegistry.require(resource.getStorageType());
+    try (InputStream inputStream =
+            support.storageGet(() -> operator.download(resource.getStoragePath()));
+        BufferedReader reader = new BufferedReader(
+            new InputStreamReader(inputStream, StandardCharsets.UTF_8))) {
+      for (int index = 0; index < normalizedSkip; index++) {
+        if (reader.readLine() == null) {
+          return contentVO(resource, "", normalizedSkip, 0, false);
+        }
+      }
+      List<String> lines = new ArrayList<>();
+      String line;
+      while (lines.size() <= normalizedLimit && (line = reader.readLine()) != null) {
+        lines.add(line);
+      }
+      boolean hasMore = lines.size() > normalizedLimit;
+      if (hasMore) {
+        lines.remove(lines.size() - 1);
+      }
+      return contentVO(
+          resource, String.join("\n", lines), normalizedSkip, lines.size(), hasMore);
+    } catch (IOException exception) {
+      throw new ResourceException(
+          ResourceErrorCode.STORAGE_OPERATION_FAILED, "读取资源内容失败", exception);
+    }
+  }
+
+  ResourceDownload download(Long id) {
+    ResourcePO resource = support.requireFile(id);
+    StorageOperator operator = storageRegistry.require(resource.getStorageType());
+    InputStream inputStream =
+        support.storageGet(() -> operator.download(resource.getStoragePath()));
+    return new ResourceDownload(
+        resource.getName(),
+        contentType(resource.getContentType()),
+        resource.getFileSize() == null ? 0L : resource.getFileSize(),
+        inputStream);
+  }
+
+  private void ensureFileSize(long size) {
+    if (size < 0L || size > properties.getMaxFileSize()) {
+      throw new ResourceException(
+          ResourceErrorCode.FILE_TOO_LARGE,
+          "最大允许 " + properties.getMaxFileSize() + " 字节");
+    }
+  }
+
+  private void ensureEditable(ResourcePO resource) {
+    ensureEditableName(resource.getName());
+  }
+
+  private void ensureEditableName(String name) {
+    String suffix = ResourcePathUtils.suffix(name);
+    if (!StringUtils.hasText(suffix)
+        || properties.getEditableSuffixes() == null
+        || !properties.getEditableSuffixes().contains(suffix.toLowerCase(Locale.ROOT))) {
+      throw new ResourceException(ResourceErrorCode.CONTENT_NOT_EDITABLE, name);
+    }
+  }
+
+  private String checksum(MultipartFile file) {
+    try (InputStream inputStream = file.getInputStream()) {
+      return checksum(inputStream);
+    } catch (IOException exception) {
+      throw new ResourceException(
+          ResourceErrorCode.STORAGE_OPERATION_FAILED, "计算文件校验值失败", exception);
+    }
+  }
+
+  private String checksum(byte[] content) {
+    return checksum(new ByteArrayInputStream(content));
+  }
+
+  private String checksum(InputStream inputStream) {
+    try {
+      MessageDigest digest = MessageDigest.getInstance("SHA-256");
+      try (DigestInputStream digestInputStream = new DigestInputStream(inputStream, digest)) {
+        byte[] buffer = new byte[8192];
+        while (digestInputStream.read(buffer) >= 0) {
+          // 读取完整输入流以更新摘要。
+        }
+      }
+      StringBuilder value = new StringBuilder(64);
+      for (byte item : digest.digest()) {
+        value.append(String.format("%02x", item & 0xff));
+      }
+      return value.toString();
+    } catch (NoSuchAlgorithmException | IOException exception) {
+      throw new ResourceException(
+          ResourceErrorCode.STORAGE_OPERATION_FAILED, "计算文件校验值失败", exception);
+    }
+  }
+
+  private ResourceContentVO contentVO(
+      ResourcePO resource,
+      String content,
+      int skipLineNum,
+      int lineCount,
+      boolean hasMore) {
+    return ResourceContentVO.builder()
+        .resourceId(resource.getId())
+        .fullPath(resource.getFullPath())
+        .content(content)
+        .skipLineNum(skipLineNum)
+        .lineCount(lineCount)
+        .hasMore(hasMore)
+        .build();
+  }
+
+  private String contentType(String value) {
+    return StringUtils.hasText(value) ? value.trim() : DEFAULT_CONTENT_TYPE;
+  }
+
+  private int lineCount(String content) {
+    if (content == null || content.isEmpty()) {
+      return 0;
+    }
+    return (int) content.lines().count();
+  }
+}

--- a/yak-ops-business/yak-ops-business-resource/src/main/java/io/yak/ops/business/resource/service/impl/ResourceServiceImpl.java
+++ b/yak-ops-business/yak-ops-business-resource/src/main/java/io/yak/ops/business/resource/service/impl/ResourceServiceImpl.java
@@ -1,0 +1,241 @@
+package io.yak.ops.business.resource.service.impl;
+
+import com.baomidou.mybatisplus.core.metadata.IPage;
+import io.yak.framework.common.PagingData;
+import io.yak.ops.business.resource.config.ConditionalOnResourceEnabled;
+import io.yak.ops.business.resource.dao.ResourceDao;
+import io.yak.ops.business.resource.exception.ResourceException;
+import io.yak.ops.business.resource.model.ResourceDownload;
+import io.yak.ops.business.resource.service.ResourceService;
+import io.yak.ops.business.resource.storage.StorageOperatorRegistry;
+import io.yak.ops.business.resource.util.ResourcePathUtils;
+import io.yak.ops.common.bean.dto.resource.ResourceContentUpdateDTO;
+import io.yak.ops.common.bean.dto.resource.ResourceCreateContentDTO;
+import io.yak.ops.common.bean.dto.resource.ResourceCreateDirectoryDTO;
+import io.yak.ops.common.bean.dto.resource.ResourceMoveDTO;
+import io.yak.ops.common.bean.dto.resource.ResourceQueryDTO;
+import io.yak.ops.common.bean.dto.resource.ResourceUpdateDTO;
+import io.yak.ops.common.bean.po.resource.ResourcePO;
+import io.yak.ops.common.bean.vo.resource.ResourceContentVO;
+import io.yak.ops.common.bean.vo.resource.ResourceStoragePluginVO;
+import io.yak.ops.common.bean.vo.resource.ResourceVO;
+import io.yak.ops.common.enums.resource.ResourceErrorCode;
+import io.yak.ops.common.enums.resource.ResourceNodeType;
+import io.yak.ops.spi.resource.ResourceFileSyncAction;
+import io.yak.ops.spi.storage.StorageOperator;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+/** 资源管理服务实现。目录元数据由数据库维护，文件内容由存储插件负责。 */
+@Slf4j
+@Service
+@ConditionalOnResourceEnabled
+@RequiredArgsConstructor
+public class ResourceServiceImpl implements ResourceService {
+
+  private final ResourceDao resourceDao;
+  private final StorageOperatorRegistry storageRegistry;
+  private final ResourceServiceSupport support;
+  private final ResourceFileOperations fileOperations;
+
+  @Override
+  @Transactional(transactionManager = "opsResourceTransactionManager", rollbackFor = Exception.class)
+  public ResourceVO createDirectory(ResourceCreateDirectoryDTO requestDTO) {
+    if (requestDTO == null) {
+      throw new ResourceException(ResourceErrorCode.INVALID_NAME, "创建目录参数不能为空");
+    }
+    ResourceServiceSupport.ParentContext parent = support.parent(requestDTO.getParentId());
+    String name = ResourcePathUtils.normalizeName(requestDTO.getName());
+    support.ensureNameAvailable(parent.id, name, null);
+    String fullPath = ResourcePathUtils.childPath(parent.fullPath, name);
+    String storagePath = ResourcePathUtils.storagePath(fullPath);
+    StorageOperator operator = storageRegistry.require(parent.storageType);
+
+    support.storageRun(() -> operator.createDirectory(storagePath));
+    try {
+      ResourcePO resource = support.newResource(
+          parent.id,
+          name,
+          fullPath,
+          ResourceNodeType.DIRECTORY,
+          parent.storageType,
+          storagePath,
+          null,
+          null,
+          0L,
+          null,
+          requestDTO.getDescription());
+      support.insert(resource);
+      support.dispatch(resource, ResourceFileSyncAction.CREATED, null);
+      return support.toVO(resource);
+    } catch (RuntimeException exception) {
+      support.cleanupCreatedObject(operator, storagePath, true);
+      throw exception;
+    }
+  }
+
+  @Override
+  @Transactional(transactionManager = "opsResourceTransactionManager", rollbackFor = Exception.class)
+  public ResourceVO upload(
+      Long parentId,
+      String name,
+      String description,
+      MultipartFile file) {
+    return fileOperations.upload(parentId, name, description, file);
+  }
+
+  @Override
+  @Transactional(transactionManager = "opsResourceTransactionManager", rollbackFor = Exception.class)
+  public ResourceVO createContent(ResourceCreateContentDTO requestDTO) {
+    return fileOperations.createContent(requestDTO);
+  }
+
+  @Override
+  public ResourceVO get(Long id) {
+    return support.toVO(support.require(id));
+  }
+
+  @Override
+  public List<ResourceVO> list(Long parentId, String keyword) {
+    return resourceDao.selectChildren(
+            support.normalizeParentId(parentId), support.trimToNull(keyword)).stream()
+        .map(support::toVO)
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public PagingData<ResourceVO> page(ResourceQueryDTO queryDTO) {
+    ResourceQueryDTO normalized = support.normalizeQuery(queryDTO);
+    IPage<ResourcePO> page = resourceDao.selectPage(normalized);
+    List<ResourceVO> records = page.getRecords().stream()
+        .map(support::toVO)
+        .collect(Collectors.toList());
+    return new PagingData<>(records, page);
+  }
+
+  @Override
+  public List<ResourceVO> tree() {
+    List<ResourcePO> resources = resourceDao.selectAll();
+    Map<Long, ResourceVO> mapped = new HashMap<>();
+    for (ResourcePO resource : resources) {
+      mapped.put(resource.getId(), support.toVO(resource));
+    }
+    List<ResourceVO> roots = new ArrayList<>();
+    for (ResourcePO resource : resources) {
+      ResourceVO current = mapped.get(resource.getId());
+      if (resource.getParentId() == null || resource.getParentId() == 0L) {
+        roots.add(current);
+        continue;
+      }
+      ResourceVO parent = mapped.get(resource.getParentId());
+      if (parent == null) {
+        roots.add(current);
+      } else {
+        parent.getChildren().add(current);
+      }
+    }
+    return roots;
+  }
+
+  @Override
+  @Transactional(transactionManager = "opsResourceTransactionManager", rollbackFor = Exception.class)
+  public ResourceVO update(Long id, ResourceUpdateDTO requestDTO) {
+    if (requestDTO == null) {
+      throw new ResourceException(ResourceErrorCode.INVALID_NAME, "更新资源参数不能为空");
+    }
+    ResourcePO resource = support.require(id);
+    String name = ResourcePathUtils.normalizeName(requestDTO.getName());
+    support.ensureNameAvailable(resource.getParentId(), name, resource.getId());
+    String oldFullPath = resource.getFullPath();
+    if (!name.equals(resource.getName())) {
+      support.relocate(resource, support.parent(resource.getParentId()), name);
+    }
+    resource.setDescription(support.trimToNull(requestDTO.getDescription()));
+    resource.setUpdateTime(LocalDateTime.now());
+    if (!resourceDao.update(resource)) {
+      throw new ResourceException(ResourceErrorCode.UPDATE_FAILED);
+    }
+    support.dispatch(resource, ResourceFileSyncAction.UPDATED, oldFullPath);
+    return support.toVO(resource);
+  }
+
+  @Override
+  @Transactional(transactionManager = "opsResourceTransactionManager", rollbackFor = Exception.class)
+  public ResourceVO replaceFile(Long id, MultipartFile file) {
+    return fileOperations.replaceFile(id, file);
+  }
+
+  @Override
+  @Transactional(transactionManager = "opsResourceTransactionManager", rollbackFor = Exception.class)
+  public ResourceContentVO updateContent(Long id, ResourceContentUpdateDTO requestDTO) {
+    return fileOperations.updateContent(id, requestDTO);
+  }
+
+  @Override
+  public ResourceContentVO getContent(Long id, int skipLineNum, int limit) {
+    return fileOperations.getContent(id, skipLineNum, limit);
+  }
+
+  @Override
+  @Transactional(transactionManager = "opsResourceTransactionManager", rollbackFor = Exception.class)
+  public ResourceVO move(Long id, ResourceMoveDTO requestDTO) {
+    if (requestDTO == null || requestDTO.getTargetParentId() == null) {
+      throw new ResourceException(ResourceErrorCode.INVALID_MOVE_TARGET, "目标目录不能为空");
+    }
+    ResourcePO resource = support.require(id);
+    ResourceServiceSupport.ParentContext targetParent =
+        support.parent(requestDTO.getTargetParentId());
+    support.ensureNameAvailable(targetParent.id, resource.getName(), resource.getId());
+    String oldFullPath = resource.getFullPath();
+    support.relocate(resource, targetParent, resource.getName());
+    support.dispatch(resource, ResourceFileSyncAction.MOVED, oldFullPath);
+    return support.toVO(resource);
+  }
+
+  @Override
+  @Transactional(transactionManager = "opsResourceTransactionManager", rollbackFor = Exception.class)
+  public boolean delete(Long id) {
+    ResourcePO resource = support.require(id);
+    List<ResourcePO> descendants = resourceDao.selectDescendants(resource.getFullPath());
+    List<Long> ids = new ArrayList<>(descendants.size() + 1);
+    ids.add(resource.getId());
+    for (ResourcePO descendant : descendants) {
+      ids.add(descendant.getId());
+    }
+    if (!resourceDao.deleteBatch(ids)) {
+      throw new ResourceException(ResourceErrorCode.DELETE_FAILED);
+    }
+    StorageOperator operator = storageRegistry.require(resource.getStorageType());
+    support.runAfterCommit(() -> {
+      try {
+        operator.delete(
+            resource.getStoragePath(),
+            resource.getNodeType() == ResourceNodeType.DIRECTORY);
+      } catch (RuntimeException exception) {
+        log.error("Failed to remove resource object after metadata deletion: {}",
+            resource.getStoragePath(), exception);
+      }
+    });
+    support.dispatch(resource, ResourceFileSyncAction.DELETED, resource.getFullPath());
+    return true;
+  }
+
+  @Override
+  public ResourceDownload download(Long id) {
+    return fileOperations.download(id);
+  }
+
+  @Override
+  public List<ResourceStoragePluginVO> storagePlugins() {
+    return storageRegistry.list();
+  }
+}

--- a/yak-ops-business/yak-ops-business-resource/src/main/java/io/yak/ops/business/resource/service/impl/ResourceServiceSupport.java
+++ b/yak-ops-business/yak-ops-business-resource/src/main/java/io/yak/ops/business/resource/service/impl/ResourceServiceSupport.java
@@ -1,0 +1,307 @@
+package io.yak.ops.business.resource.service.impl;
+
+import io.yak.ops.business.resource.config.ConditionalOnResourceEnabled;
+import io.yak.ops.business.resource.config.ResourceProperties;
+import io.yak.ops.business.resource.dao.ResourceDao;
+import io.yak.ops.business.resource.exception.ResourceException;
+import io.yak.ops.business.resource.storage.StorageOperatorRegistry;
+import io.yak.ops.business.resource.sync.ResourceFileSyncDispatcher;
+import io.yak.ops.business.resource.util.ResourcePathUtils;
+import io.yak.ops.common.bean.dto.resource.ResourceQueryDTO;
+import io.yak.ops.common.bean.po.resource.ResourcePO;
+import io.yak.ops.common.bean.vo.resource.ResourceVO;
+import io.yak.ops.common.enums.resource.ResourceErrorCode;
+import io.yak.ops.common.enums.resource.ResourceNodeType;
+import io.yak.ops.common.enums.resource.ResourceStorageType;
+import io.yak.ops.spi.resource.ResourceFileSyncAction;
+import io.yak.ops.spi.resource.ResourceFileSyncContext;
+import io.yak.ops.spi.storage.StorageOperator;
+import io.yak.ops.spi.storage.StoragePluginException;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+import org.springframework.util.StringUtils;
+
+/** 资源服务共享的元数据、路径、存储异常与同步事件支持。 */
+@Slf4j
+@Component
+@ConditionalOnResourceEnabled
+@RequiredArgsConstructor
+class ResourceServiceSupport {
+
+  private final ResourceDao resourceDao;
+  private final StorageOperatorRegistry storageRegistry;
+  private final ResourceFileSyncDispatcher syncDispatcher;
+  private final ResourceProperties properties;
+
+  ParentContext parent(Long parentId) {
+    Long normalized = normalizeParentId(parentId);
+    if (normalized == 0L) {
+      ResourceStorageType type = properties.getStorage().getType();
+      storageRegistry.require(type);
+      return new ParentContext(0L, "/", type);
+    }
+    ResourcePO parent = resourceDao.selectById(normalized);
+    if (parent == null) {
+      throw new ResourceException(ResourceErrorCode.PARENT_NOT_FOUND);
+    }
+    if (parent.getNodeType() != ResourceNodeType.DIRECTORY) {
+      throw new ResourceException(ResourceErrorCode.PARENT_NOT_DIRECTORY);
+    }
+    return new ParentContext(parent.getId(), parent.getFullPath(), parent.getStorageType());
+  }
+
+  ResourcePO require(Long id) {
+    if (id == null || id <= 0L) {
+      throw new ResourceException(ResourceErrorCode.NOT_FOUND);
+    }
+    ResourcePO resource = resourceDao.selectById(id);
+    if (resource == null) {
+      throw new ResourceException(ResourceErrorCode.NOT_FOUND, String.valueOf(id));
+    }
+    return resource;
+  }
+
+  ResourcePO requireFile(Long id) {
+    ResourcePO resource = require(id);
+    if (resource.getNodeType() != ResourceNodeType.FILE) {
+      throw new ResourceException(ResourceErrorCode.DIRECTORY_CONTENT_UNSUPPORTED);
+    }
+    return resource;
+  }
+
+  void ensureNameAvailable(Long parentId, String name, Long excludeId) {
+    if (resourceDao.existsByParentAndName(normalizeParentId(parentId), name, excludeId)) {
+      throw new ResourceException(ResourceErrorCode.DUPLICATE_NAME, name);
+    }
+  }
+
+  ResourceQueryDTO normalizeQuery(ResourceQueryDTO queryDTO) {
+    ResourceQueryDTO normalized = queryDTO == null ? new ResourceQueryDTO() : queryDTO;
+    normalized.setKeyword(trimToNull(normalized.getKeyword()));
+    if (StringUtils.hasText(normalized.getNodeType())) {
+      String nodeType = normalized.getNodeType().trim().toUpperCase(Locale.ROOT);
+      try {
+        ResourceNodeType.valueOf(nodeType);
+      } catch (IllegalArgumentException exception) {
+        throw new ResourceException(ResourceErrorCode.INVALID_NODE_TYPE, nodeType);
+      }
+      normalized.setNodeType(nodeType);
+    }
+    return normalized;
+  }
+
+  ResourcePO newResource(
+      Long parentId,
+      String name,
+      String fullPath,
+      ResourceNodeType nodeType,
+      ResourceStorageType storageType,
+      String storagePath,
+      String contentType,
+      String suffix,
+      Long fileSize,
+      String checksum,
+      String description) {
+    LocalDateTime now = LocalDateTime.now();
+    ResourcePO resource = new ResourcePO();
+    resource.setParentId(normalizeParentId(parentId));
+    resource.setName(name);
+    resource.setFullPath(fullPath);
+    resource.setNodeType(nodeType);
+    resource.setStorageType(storageType);
+    resource.setStoragePath(storagePath);
+    resource.setContentType(contentType);
+    resource.setSuffix(suffix);
+    resource.setFileSize(fileSize == null ? 0L : fileSize);
+    resource.setChecksum(checksum);
+    resource.setDescription(trimToNull(description));
+    resource.setVersion(1);
+    resource.setGitSyncStatus("NONE");
+    resource.setCreateTime(now);
+    resource.setUpdateTime(now);
+    return resource;
+  }
+
+  void insert(ResourcePO resource) {
+    if (resourceDao.insert(resource) <= 0) {
+      throw new ResourceException(ResourceErrorCode.CREATE_FAILED);
+    }
+  }
+
+  void relocate(ResourcePO resource, ParentContext targetParent, String targetName) {
+    if (resource.getId().equals(targetParent.id)) {
+      throw new ResourceException(ResourceErrorCode.INVALID_MOVE_TARGET);
+    }
+    if (targetParent.storageType != resource.getStorageType()) {
+      throw new ResourceException(ResourceErrorCode.CROSS_STORAGE_MOVE_UNSUPPORTED);
+    }
+    String oldFullPath = resource.getFullPath();
+    String newFullPath = ResourcePathUtils.childPath(targetParent.fullPath, targetName);
+    if (newFullPath.equals(oldFullPath)) {
+      resource.setName(targetName);
+      resource.setParentId(targetParent.id);
+      return;
+    }
+    if (newFullPath.startsWith(oldFullPath + "/")) {
+      throw new ResourceException(ResourceErrorCode.INVALID_MOVE_TARGET);
+    }
+    String oldStoragePath = resource.getStoragePath();
+    String newStoragePath = ResourcePathUtils.storagePath(newFullPath);
+    StorageOperator operator = storageRegistry.require(resource.getStorageType());
+    storageRun(() -> operator.move(oldStoragePath, newStoragePath, false));
+
+    List<ResourcePO> updates = new ArrayList<>();
+    resource.setParentId(targetParent.id);
+    resource.setName(targetName);
+    resource.setFullPath(newFullPath);
+    resource.setStoragePath(newStoragePath);
+    resource.setVersion(nextVersion(resource));
+    resource.setUpdateTime(LocalDateTime.now());
+    updates.add(resource);
+
+    if (resource.getNodeType() == ResourceNodeType.DIRECTORY) {
+      for (ResourcePO descendant : resourceDao.selectDescendants(oldFullPath)) {
+        String suffix = descendant.getFullPath().substring(oldFullPath.length());
+        descendant.setFullPath(newFullPath + suffix);
+        descendant.setStoragePath(ResourcePathUtils.storagePath(descendant.getFullPath()));
+        descendant.setVersion(nextVersion(descendant));
+        descendant.setUpdateTime(LocalDateTime.now());
+        updates.add(descendant);
+      }
+    }
+
+    if (!resourceDao.updateBatch(updates)) {
+      try {
+        operator.move(newStoragePath, oldStoragePath, false);
+      } catch (RuntimeException rollbackException) {
+        log.error("Failed to rollback storage move: {} -> {}",
+            newStoragePath, oldStoragePath, rollbackException);
+      }
+      throw new ResourceException(ResourceErrorCode.UPDATE_FAILED);
+    }
+  }
+
+  ResourceVO toVO(ResourcePO resource) {
+    return ResourceVO.builder()
+        .id(resource.getId())
+        .parentId(resource.getParentId())
+        .name(resource.getName())
+        .fullPath(resource.getFullPath())
+        .nodeType(resource.getNodeType())
+        .storageType(resource.getStorageType())
+        .contentType(resource.getContentType())
+        .suffix(resource.getSuffix())
+        .fileSize(resource.getFileSize())
+        .checksum(resource.getChecksum())
+        .description(resource.getDescription())
+        .version(resource.getVersion())
+        .gitSyncStatus(resource.getGitSyncStatus())
+        .createTime(resource.getCreateTime())
+        .updateTime(resource.getUpdateTime())
+        .build();
+  }
+
+  void dispatch(ResourcePO resource, ResourceFileSyncAction action, String oldFullPath) {
+    syncDispatcher.dispatchAfterCommit(ResourceFileSyncContext.builder()
+        .resourceId(resource.getId())
+        .action(action)
+        .nodeType(resource.getNodeType())
+        .storageType(resource.getStorageType())
+        .oldFullPath(oldFullPath)
+        .fullPath(resource.getFullPath())
+        .storagePath(resource.getStoragePath())
+        .version(resource.getVersion())
+        .build());
+  }
+
+  void storageRun(Runnable operation) {
+    try {
+      operation.run();
+    } catch (ResourceException exception) {
+      throw exception;
+    } catch (StoragePluginException exception) {
+      throw storageException(exception);
+    } catch (RuntimeException exception) {
+      throw storageException(exception);
+    }
+  }
+
+  <T> T storageGet(StorageSupplier<T> operation) {
+    try {
+      return operation.get();
+    } catch (ResourceException exception) {
+      throw exception;
+    } catch (StoragePluginException exception) {
+      throw storageException(exception);
+    } catch (RuntimeException exception) {
+      throw storageException(exception);
+    }
+  }
+
+  void cleanupCreatedObject(StorageOperator operator, String storagePath, boolean recursive) {
+    try {
+      operator.delete(storagePath, recursive);
+    } catch (RuntimeException cleanupException) {
+      log.warn("Failed to cleanup storage object after persistence failure: {}",
+          storagePath, cleanupException);
+    }
+  }
+
+  void runAfterCommit(Runnable action) {
+    if (!TransactionSynchronizationManager.isSynchronizationActive()) {
+      action.run();
+      return;
+    }
+    TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+      @Override
+      public void afterCommit() {
+        action.run();
+      }
+    });
+  }
+
+  Long normalizeParentId(Long parentId) {
+    return parentId == null || parentId <= 0L ? 0L : parentId;
+  }
+
+  int nextVersion(ResourcePO resource) {
+    return resource.getVersion() == null ? 1 : resource.getVersion() + 1;
+  }
+
+  String trimToNull(String value) {
+    return StringUtils.hasText(value) ? value.trim() : null;
+  }
+
+  private ResourceException storageException(RuntimeException exception) {
+    return new ResourceException(
+        ResourceErrorCode.STORAGE_OPERATION_FAILED,
+        exception.getMessage(),
+        exception);
+  }
+
+  @FunctionalInterface
+  interface StorageSupplier<T> {
+    T get();
+  }
+
+  static final class ParentContext {
+
+    final Long id;
+    final String fullPath;
+    final ResourceStorageType storageType;
+
+    ParentContext(Long id, String fullPath, ResourceStorageType storageType) {
+      this.id = Objects.requireNonNull(id, "parent id");
+      this.fullPath = Objects.requireNonNull(fullPath, "parent full path");
+      this.storageType = Objects.requireNonNull(storageType, "parent storage type");
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-resource/src/main/java/io/yak/ops/business/resource/storage/StorageOperatorRegistry.java
+++ b/yak-ops-business/yak-ops-business-resource/src/main/java/io/yak/ops/business/resource/storage/StorageOperatorRegistry.java
@@ -1,0 +1,63 @@
+package io.yak.ops.business.resource.storage;
+
+import io.yak.ops.business.resource.config.ConditionalOnResourceEnabled;
+import io.yak.ops.business.resource.config.ResourceProperties;
+import io.yak.ops.business.resource.exception.ResourceException;
+import io.yak.ops.common.bean.vo.resource.ResourceStoragePluginVO;
+import io.yak.ops.common.enums.resource.ResourceErrorCode;
+import io.yak.ops.common.enums.resource.ResourceStorageType;
+import io.yak.ops.spi.storage.StorageOperator;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import org.springframework.stereotype.Component;
+
+/** 已安装资源存储插件注册表。 */
+@Component
+@ConditionalOnResourceEnabled
+public class StorageOperatorRegistry {
+
+  private final Map<ResourceStorageType, StorageOperator> operators;
+  private final ResourceProperties properties;
+
+  public StorageOperatorRegistry(
+      List<StorageOperator> storageOperators,
+      ResourceProperties properties) {
+    this.properties = properties;
+    Map<ResourceStorageType, StorageOperator> mapped =
+        new EnumMap<>(ResourceStorageType.class);
+    for (StorageOperator operator : storageOperators) {
+      StorageOperator previous = mapped.put(operator.type(), operator);
+      if (previous != null) {
+        throw new IllegalStateException("重复的资源存储插件：" + operator.type());
+      }
+    }
+    this.operators = Collections.unmodifiableMap(mapped);
+  }
+
+  public StorageOperator require(ResourceStorageType type) {
+    ResourceStorageType effective = type == null ? properties.getStorage().getType() : type;
+    StorageOperator operator = operators.get(effective);
+    if (operator == null) {
+      throw new ResourceException(
+          ResourceErrorCode.STORAGE_PLUGIN_NOT_FOUND,
+          effective == null ? "未配置默认存储类型" : effective.name());
+    }
+    return operator;
+  }
+
+  public List<ResourceStoragePluginVO> list() {
+    List<ResourceStoragePluginVO> plugins = new ArrayList<>();
+    ResourceStorageType activeType = properties.getStorage().getType();
+    for (StorageOperator operator : operators.values()) {
+      plugins.add(ResourceStoragePluginVO.builder()
+          .type(operator.type())
+          .name(operator.name())
+          .active(operator.type() == activeType)
+          .build());
+    }
+    return plugins;
+  }
+}

--- a/yak-ops-business/yak-ops-business-resource/src/main/java/io/yak/ops/business/resource/sync/ResourceFileSyncDispatcher.java
+++ b/yak-ops-business/yak-ops-business-resource/src/main/java/io/yak/ops/business/resource/sync/ResourceFileSyncDispatcher.java
@@ -1,0 +1,53 @@
+package io.yak.ops.business.resource.sync;
+
+import io.yak.ops.business.resource.config.ConditionalOnResourceEnabled;
+import io.yak.ops.spi.resource.ResourceFileSyncContext;
+import io.yak.ops.spi.resource.ResourceFileSyncProvider;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+/** 资源变更事件分发器；当前没有 Git 实现时自动为空操作。 */
+@Slf4j
+@Component
+@ConditionalOnResourceEnabled
+public class ResourceFileSyncDispatcher {
+
+  private final List<ResourceFileSyncProvider> providers;
+
+  public ResourceFileSyncDispatcher(List<ResourceFileSyncProvider> providers) {
+    this.providers = providers;
+  }
+
+  public void dispatchAfterCommit(ResourceFileSyncContext context) {
+    if (context == null || providers.isEmpty()) {
+      return;
+    }
+    if (TransactionSynchronizationManager.isSynchronizationActive()) {
+      TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+        @Override
+        public void afterCommit() {
+          dispatch(context);
+        }
+      });
+      return;
+    }
+    dispatch(context);
+  }
+
+  private void dispatch(ResourceFileSyncContext context) {
+    for (ResourceFileSyncProvider provider : providers) {
+      try {
+        provider.synchronize(context);
+      } catch (RuntimeException exception) {
+        log.warn(
+            "Resource sync provider {} failed for resource {}",
+            provider.type(),
+            context.getResourceId(),
+            exception);
+      }
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-resource/src/main/java/io/yak/ops/business/resource/util/ResourcePathUtils.java
+++ b/yak-ops-business/yak-ops-business-resource/src/main/java/io/yak/ops/business/resource/util/ResourcePathUtils.java
@@ -1,0 +1,52 @@
+package io.yak.ops.business.resource.util;
+
+import io.yak.ops.business.resource.exception.ResourceException;
+import io.yak.ops.common.enums.resource.ResourceErrorCode;
+import org.springframework.util.StringUtils;
+
+/** 资源名称与路径安全处理。 */
+public final class ResourcePathUtils {
+
+  private ResourcePathUtils() {
+  }
+
+  public static String normalizeName(String value) {
+    if (!StringUtils.hasText(value)) {
+      throw new ResourceException(ResourceErrorCode.INVALID_NAME, "名称不能为空");
+    }
+    String name = value.trim();
+    if (name.length() > 255) {
+      throw new ResourceException(ResourceErrorCode.INVALID_NAME, "名称不能超过 255 个字符");
+    }
+    if (".".equals(name)
+        || "..".equals(name)
+        || name.indexOf('/') >= 0
+        || name.indexOf('\\') >= 0
+        || name.indexOf('\0') >= 0) {
+      throw new ResourceException(ResourceErrorCode.INVALID_NAME, name);
+    }
+    return name;
+  }
+
+  public static String childPath(String parentPath, String name) {
+    String normalizedName = normalizeName(name);
+    if (!StringUtils.hasText(parentPath) || "/".equals(parentPath)) {
+      return "/" + normalizedName;
+    }
+    return parentPath + "/" + normalizedName;
+  }
+
+  public static String storagePath(String fullPath) {
+    if (!StringUtils.hasText(fullPath) || "/".equals(fullPath)) {
+      throw new ResourceException(ResourceErrorCode.INVALID_NAME, "资源路径不能为空");
+    }
+    return fullPath.startsWith("/") ? fullPath.substring(1) : fullPath;
+  }
+
+  public static String suffix(String name) {
+    int index = name == null ? -1 : name.lastIndexOf('.');
+    return index <= 0 || index == name.length() - 1
+        ? null
+        : name.substring(index + 1).toLowerCase();
+  }
+}

--- a/yak-ops-business/yak-ops-business-resource/src/main/resources/db/migration/yak-resource/V1__init_resource_management.sql
+++ b/yak-ops-business/yak-ops-business-resource/src/main/resources/db/migration/yak-resource/V1__init_resource_management.sql
@@ -1,0 +1,23 @@
+CREATE TABLE IF NOT EXISTS yak_ops_resource (
+    id BIGINT NOT NULL,
+    parent_id BIGINT NOT NULL DEFAULT 0,
+    name VARCHAR(255) NOT NULL,
+    full_path VARCHAR(1024) NOT NULL,
+    node_type VARCHAR(32) NOT NULL,
+    storage_type VARCHAR(32) NOT NULL,
+    storage_path VARCHAR(1024) NOT NULL,
+    content_type VARCHAR(255) NULL,
+    suffix VARCHAR(64) NULL,
+    file_size BIGINT NOT NULL DEFAULT 0,
+    checksum VARCHAR(128) NULL,
+    description VARCHAR(512) NULL,
+    version INT NOT NULL DEFAULT 1,
+    git_sync_status VARCHAR(32) NOT NULL DEFAULT 'NONE',
+    create_time DATETIME(3) NOT NULL,
+    update_time DATETIME(3) NOT NULL,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_yak_resource_full_path (full_path),
+    UNIQUE KEY uk_yak_resource_parent_name (parent_id, name),
+    KEY idx_yak_resource_parent_type (parent_id, node_type),
+    KEY idx_yak_resource_storage (storage_type, storage_path(255))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/yak-ops-business/yak-ops-business-resource/src/test/java/io/yak/ops/business/resource/controller/v1/ResourcesControllerContractTest.java
+++ b/yak-ops-business/yak-ops-business-resource/src/test/java/io/yak/ops/business/resource/controller/v1/ResourcesControllerContractTest.java
@@ -1,0 +1,25 @@
+package io.yak.ops.business.resource.controller.v1;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.yak.framework.security.web.RequiresPermission;
+import io.yak.ops.common.constant.resource.ResourcePermissionCode;
+import java.lang.reflect.Method;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+class ResourcesControllerContractTest {
+
+  @Test
+  void exposesVersionedResourceApiAndExistingPermissionContract() throws Exception {
+    RequestMapping mapping = ResourcesController.class.getAnnotation(RequestMapping.class);
+    RequiresPermission read = ResourcesController.class.getAnnotation(RequiresPermission.class);
+    Method download = ResourcesController.class.getMethod(
+        "download", Long.class, jakarta.servlet.http.HttpServletResponse.class);
+    RequiresPermission downloadPermission = download.getAnnotation(RequiresPermission.class);
+
+    assertThat(mapping.value()).containsExactly("/api/v1/resources");
+    assertThat(read.value()).isEqualTo(ResourcePermissionCode.READ);
+    assertThat(downloadPermission.value()).isEqualTo(ResourcePermissionCode.DOWNLOAD);
+  }
+}

--- a/yak-ops-business/yak-ops-business-resource/src/test/java/io/yak/ops/business/resource/storage/StorageOperatorRegistryTest.java
+++ b/yak-ops-business/yak-ops-business-resource/src/test/java/io/yak/ops/business/resource/storage/StorageOperatorRegistryTest.java
@@ -1,0 +1,96 @@
+package io.yak.ops.business.resource.storage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.yak.ops.business.resource.config.ResourceProperties;
+import io.yak.ops.business.resource.exception.ResourceException;
+import io.yak.ops.common.enums.resource.ResourceStorageType;
+import io.yak.ops.spi.storage.StorageObjectMetadata;
+import io.yak.ops.spi.storage.StorageOperator;
+import java.io.InputStream;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class StorageOperatorRegistryTest {
+
+  @Test
+  void resolvesConfiguredDefaultAndListsInstalledPlugins() {
+    ResourceProperties properties = new ResourceProperties();
+    StorageOperator minio = new StubOperator(ResourceStorageType.MINIO, "MinIO");
+    StorageOperatorRegistry registry = new StorageOperatorRegistry(List.of(minio), properties);
+
+    assertThat(registry.require(null)).isSameAs(minio);
+    assertThat(registry.list()).singleElement().satisfies(plugin -> {
+      assertThat(plugin.getType()).isEqualTo(ResourceStorageType.MINIO);
+      assertThat(plugin.isActive()).isTrue();
+    });
+  }
+
+  @Test
+  void rejectsMissingConfiguredPlugin() {
+    ResourceProperties properties = new ResourceProperties();
+    properties.getStorage().setType(ResourceStorageType.HDFS);
+    StorageOperatorRegistry registry = new StorageOperatorRegistry(List.of(), properties);
+
+    assertThatThrownBy(() -> registry.require(null))
+        .isInstanceOf(ResourceException.class);
+  }
+
+  private static final class StubOperator implements StorageOperator {
+
+    private final ResourceStorageType type;
+    private final String name;
+
+    private StubOperator(ResourceStorageType type, String name) {
+      this.type = type;
+      this.name = name;
+    }
+
+    @Override
+    public ResourceStorageType type() {
+      return type;
+    }
+
+    @Override
+    public String name() {
+      return name;
+    }
+
+    @Override
+    public void createDirectory(String path) {
+    }
+
+    @Override
+    public boolean exists(String path) {
+      return false;
+    }
+
+    @Override
+    public void upload(
+        String path,
+        InputStream inputStream,
+        long size,
+        String contentType,
+        boolean overwrite) {
+    }
+
+    @Override
+    public InputStream download(String path) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void delete(String path, boolean recursive) {
+    }
+
+    @Override
+    public void move(String sourcePath, String targetPath, boolean overwrite) {
+    }
+
+    @Override
+    public StorageObjectMetadata metadata(String path) {
+      throw new UnsupportedOperationException();
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-resource/src/test/java/io/yak/ops/business/resource/util/ResourcePathUtilsTest.java
+++ b/yak-ops-business/yak-ops-business-resource/src/test/java/io/yak/ops/business/resource/util/ResourcePathUtilsTest.java
@@ -1,0 +1,30 @@
+package io.yak.ops.business.resource.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.yak.ops.business.resource.exception.ResourceException;
+import org.junit.jupiter.api.Test;
+
+class ResourcePathUtilsTest {
+
+  @Test
+  void buildsSafeLogicalAndStoragePaths() {
+    assertThat(ResourcePathUtils.childPath("/", "demo.sql")).isEqualTo("/demo.sql");
+    assertThat(ResourcePathUtils.childPath("/jobs", "demo.sql"))
+        .isEqualTo("/jobs/demo.sql");
+    assertThat(ResourcePathUtils.storagePath("/jobs/demo.sql"))
+        .isEqualTo("jobs/demo.sql");
+    assertThat(ResourcePathUtils.suffix("demo.SQL")).isEqualTo("sql");
+  }
+
+  @Test
+  void rejectsTraversalAndPathSeparatorsInNames() {
+    assertThatThrownBy(() -> ResourcePathUtils.normalizeName(".."))
+        .isInstanceOf(ResourceException.class);
+    assertThatThrownBy(() -> ResourcePathUtils.normalizeName("a/b"))
+        .isInstanceOf(ResourceException.class);
+    assertThatThrownBy(() -> ResourcePathUtils.normalizeName("a\\b"))
+        .isInstanceOf(ResourceException.class);
+  }
+}

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/dto/resource/ResourceContentUpdateDTO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/dto/resource/ResourceContentUpdateDTO.java
@@ -1,0 +1,12 @@
+package io.yak.ops.common.bean.dto.resource;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+/** 更新资源文本内容请求。 */
+@Data
+public class ResourceContentUpdateDTO {
+
+  @NotNull(message = "文件内容不能为空")
+  private String content;
+}

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/dto/resource/ResourceCreateContentDTO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/dto/resource/ResourceCreateContentDTO.java
@@ -1,0 +1,27 @@
+package io.yak.ops.common.bean.dto.resource;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+/** 在线创建文本资源请求。 */
+@Data
+public class ResourceCreateContentDTO {
+
+  /** 父目录 ID，根目录使用 0。 */
+  private Long parentId = 0L;
+
+  @NotBlank(message = "文件名称不能为空")
+  @Size(max = 255, message = "文件名称不能超过 255 个字符")
+  private String name;
+
+  @NotNull(message = "文件内容不能为空")
+  private String content;
+
+  @Size(max = 255, message = "内容类型不能超过 255 个字符")
+  private String contentType = "text/plain;charset=UTF-8";
+
+  @Size(max = 512, message = "文件描述不能超过 512 个字符")
+  private String description;
+}

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/dto/resource/ResourceCreateDirectoryDTO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/dto/resource/ResourceCreateDirectoryDTO.java
@@ -1,0 +1,20 @@
+package io.yak.ops.common.bean.dto.resource;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+/** 创建资源目录请求。 */
+@Data
+public class ResourceCreateDirectoryDTO {
+
+  /** 父目录 ID，根目录使用 0。 */
+  private Long parentId = 0L;
+
+  @NotBlank(message = "目录名称不能为空")
+  @Size(max = 255, message = "目录名称不能超过 255 个字符")
+  private String name;
+
+  @Size(max = 512, message = "目录描述不能超过 512 个字符")
+  private String description;
+}

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/dto/resource/ResourceMoveDTO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/dto/resource/ResourceMoveDTO.java
@@ -1,0 +1,12 @@
+package io.yak.ops.common.bean.dto.resource;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+/** 移动资源请求。 */
+@Data
+public class ResourceMoveDTO {
+
+  @NotNull(message = "目标目录 ID 不能为空")
+  private Long targetParentId;
+}

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/dto/resource/ResourceQueryDTO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/dto/resource/ResourceQueryDTO.java
@@ -1,0 +1,27 @@
+package io.yak.ops.common.bean.dto.resource;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+/** 资源分页查询请求。 */
+@Data
+public class ResourceQueryDTO {
+
+  @Min(value = 1, message = "页码必须大于 0")
+  private int pageNo = 1;
+
+  @Min(value = 1, message = "每页条数必须大于 0")
+  @Max(value = 200, message = "每页条数不能超过 200")
+  private int pageSize = 20;
+
+  /** 父目录 ID；为空时查询全部资源。 */
+  private Long parentId;
+
+  @Size(max = 256, message = "搜索关键词不能超过 256 个字符")
+  private String keyword;
+
+  /** DIRECTORY 或 FILE。 */
+  private String nodeType;
+}

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/dto/resource/ResourceUpdateDTO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/dto/resource/ResourceUpdateDTO.java
@@ -1,0 +1,17 @@
+package io.yak.ops.common.bean.dto.resource;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+/** 更新资源名称与描述请求。 */
+@Data
+public class ResourceUpdateDTO {
+
+  @NotBlank(message = "资源名称不能为空")
+  @Size(max = 255, message = "资源名称不能超过 255 个字符")
+  private String name;
+
+  @Size(max = 512, message = "资源描述不能超过 512 个字符")
+  private String description;
+}

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/resource/ResourcePO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/resource/ResourcePO.java
@@ -1,0 +1,33 @@
+package io.yak.ops.common.bean.po.resource;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import io.yak.ops.common.enums.resource.ResourceNodeType;
+import io.yak.ops.common.enums.resource.ResourceStorageType;
+import java.time.LocalDateTime;
+import lombok.Data;
+
+/** 资源目录与文件持久化对象。 */
+@Data
+@TableName("yak_ops_resource")
+public class ResourcePO {
+
+  @TableId(type = IdType.ASSIGN_ID)
+  private Long id;
+  private Long parentId;
+  private String name;
+  private String fullPath;
+  private ResourceNodeType nodeType;
+  private ResourceStorageType storageType;
+  private String storagePath;
+  private String contentType;
+  private String suffix;
+  private Long fileSize;
+  private String checksum;
+  private String description;
+  private Integer version;
+  private String gitSyncStatus;
+  private LocalDateTime createTime;
+  private LocalDateTime updateTime;
+}

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/vo/resource/ResourceContentVO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/vo/resource/ResourceContentVO.java
@@ -1,0 +1,17 @@
+package io.yak.ops.common.bean.vo.resource;
+
+import lombok.Builder;
+import lombok.Data;
+
+/** 在线查看资源内容响应。 */
+@Data
+@Builder
+public class ResourceContentVO {
+
+  private Long resourceId;
+  private String fullPath;
+  private String content;
+  private int skipLineNum;
+  private int lineCount;
+  private boolean hasMore;
+}

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/vo/resource/ResourceStoragePluginVO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/vo/resource/ResourceStoragePluginVO.java
@@ -1,0 +1,15 @@
+package io.yak.ops.common.bean.vo.resource;
+
+import io.yak.ops.common.enums.resource.ResourceStorageType;
+import lombok.Builder;
+import lombok.Data;
+
+/** 已安装资源存储插件信息。 */
+@Data
+@Builder
+public class ResourceStoragePluginVO {
+
+  private ResourceStorageType type;
+  private String name;
+  private boolean active;
+}

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/vo/resource/ResourceVO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/vo/resource/ResourceVO.java
@@ -1,0 +1,34 @@
+package io.yak.ops.common.bean.vo.resource;
+
+import io.yak.ops.common.enums.resource.ResourceNodeType;
+import io.yak.ops.common.enums.resource.ResourceStorageType;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Builder;
+import lombok.Data;
+
+/** 资源目录或文件视图。 */
+@Data
+@Builder
+public class ResourceVO {
+
+  private Long id;
+  private Long parentId;
+  private String name;
+  private String fullPath;
+  private ResourceNodeType nodeType;
+  private ResourceStorageType storageType;
+  private String contentType;
+  private String suffix;
+  private Long fileSize;
+  private String checksum;
+  private String description;
+  private Integer version;
+  private String gitSyncStatus;
+  private LocalDateTime createTime;
+  private LocalDateTime updateTime;
+
+  @Builder.Default
+  private List<ResourceVO> children = new ArrayList<>();
+}

--- a/yak-ops-common/src/main/java/io/yak/ops/common/constant/resource/ResourcePermissionCode.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/constant/resource/ResourcePermissionCode.java
@@ -1,0 +1,14 @@
+package io.yak.ops.common.constant.resource;
+
+/** 资源管理权限编码，复用 Yak Ops 已有资源兼容权限。 */
+public final class ResourcePermissionCode {
+
+  public static final String READ = "resource:view";
+  public static final String CREATE = "resource:upload";
+  public static final String UPDATE = "resource:update";
+  public static final String DELETE = "resource:delete";
+  public static final String DOWNLOAD = "resource:download";
+
+  private ResourcePermissionCode() {
+  }
+}

--- a/yak-ops-common/src/main/java/io/yak/ops/common/enums/resource/ResourceErrorCode.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/enums/resource/ResourceErrorCode.java
@@ -1,0 +1,33 @@
+package io.yak.ops.common.enums.resource;
+
+import io.yak.framework.common.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/** 资源管理业务错误码。 */
+@Getter
+@RequiredArgsConstructor
+public enum ResourceErrorCode implements ErrorCode {
+
+  NOT_FOUND(43001, "资源不存在"),
+  PARENT_NOT_FOUND(43002, "父目录不存在"),
+  PARENT_NOT_DIRECTORY(43003, "父资源不是目录"),
+  DUPLICATE_NAME(43004, "同级资源名称已存在"),
+  INVALID_NAME(43005, "资源名称不合法"),
+  INVALID_NODE_TYPE(43006, "资源类型不合法"),
+  STORAGE_PLUGIN_NOT_FOUND(43007, "资源存储插件未安装"),
+  STORAGE_OPERATION_FAILED(43008, "资源存储操作失败"),
+  CREATE_FAILED(43009, "创建资源失败"),
+  UPDATE_FAILED(43010, "更新资源失败"),
+  DELETE_FAILED(43011, "删除资源失败"),
+  QUERY_FAILED(43012, "查询资源失败"),
+  FILE_TOO_LARGE(43013, "上传文件超过大小限制"),
+  DIRECTORY_CONTENT_UNSUPPORTED(43014, "目录不支持读取或更新内容"),
+  CROSS_STORAGE_MOVE_UNSUPPORTED(43015, "不支持跨存储类型移动资源"),
+  INVALID_MOVE_TARGET(43016, "资源不能移动到自身或其子目录"),
+  CONTENT_NOT_EDITABLE(43017, "该资源不支持在线编辑"),
+  DOWNLOAD_FAILED(43018, "下载资源失败");
+
+  private final Integer code;
+  private final String message;
+}

--- a/yak-ops-common/src/main/java/io/yak/ops/common/enums/resource/ResourceNodeType.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/enums/resource/ResourceNodeType.java
@@ -1,0 +1,7 @@
+package io.yak.ops.common.enums.resource;
+
+/** 资源节点类型。 */
+public enum ResourceNodeType {
+  DIRECTORY,
+  FILE
+}

--- a/yak-ops-common/src/main/java/io/yak/ops/common/enums/resource/ResourceStorageType.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/enums/resource/ResourceStorageType.java
@@ -1,0 +1,7 @@
+package io.yak.ops.common.enums.resource;
+
+/** 资源文件存储类型。 */
+public enum ResourceStorageType {
+  MINIO,
+  HDFS
+}

--- a/yak-ops-plugins/yak-ops-plugin-storage/pom.xml
+++ b/yak-ops-plugins/yak-ops-plugin-storage/pom.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.yak.ops</groupId>
+        <artifactId>yak-ops</artifactId>
+        <version>1.0.0</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>yak-ops-plugin-storage</artifactId>
+    <packaging>pom</packaging>
+
+    <name>Yak Ops Storage Plugins</name>
+    <description>Yak Ops storage-plugin module aggregation</description>
+
+    <modules>
+        <module>yak-ops-plugin-storage-api</module>
+        <module>yak-ops-plugin-storage-minio</module>
+        <module>yak-ops-plugin-storage-hdfs</module>
+        <module>yak-ops-plugin-storage-all</module>
+    </modules>
+</project>

--- a/yak-ops-plugins/yak-ops-plugin-storage/yak-ops-plugin-storage-all/pom.xml
+++ b/yak-ops-plugins/yak-ops-plugin-storage/yak-ops-plugin-storage-all/pom.xml
@@ -3,23 +3,26 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>io.yak.ops</groupId>
-        <artifactId>yak-ops</artifactId>
+        <artifactId>yak-ops-plugin-storage</artifactId>
         <version>1.0.0</version>
+        <relativePath>../pom.xml</relativePath>
     </parent>
-    <artifactId>yak-ops-spi</artifactId>
-    <name>Yak Ops SPI</name>
-    <description>Stable extension contracts for Yak Ops plugins</description>
+
+    <artifactId>yak-ops-plugin-storage-all</artifactId>
+    <name>Yak Ops All Storage Plugins</name>
+    <description>Aggregates all built-in resource storage plugins</description>
+
     <dependencies>
         <dependency>
             <groupId>io.yak.ops</groupId>
-            <artifactId>yak-ops-common</artifactId>
+            <artifactId>yak-ops-plugin-storage-minio</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <optional>true</optional>
+            <groupId>io.yak.ops</groupId>
+            <artifactId>yak-ops-plugin-storage-hdfs</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/yak-ops-plugins/yak-ops-plugin-storage/yak-ops-plugin-storage-api/pom.xml
+++ b/yak-ops-plugins/yak-ops-plugin-storage/yak-ops-plugin-storage-api/pom.xml
@@ -3,14 +3,17 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>io.yak.ops</groupId>
-        <artifactId>yak-ops</artifactId>
+        <artifactId>yak-ops-plugin-storage</artifactId>
         <version>1.0.0</version>
+        <relativePath>../pom.xml</relativePath>
     </parent>
-    <artifactId>yak-ops-spi</artifactId>
-    <name>Yak Ops SPI</name>
-    <description>Stable extension contracts for Yak Ops plugins</description>
+
+    <artifactId>yak-ops-plugin-storage-api</artifactId>
+    <name>Yak Ops Storage Plugin API</name>
+
     <dependencies>
         <dependency>
             <groupId>io.yak.ops</groupId>

--- a/yak-ops-plugins/yak-ops-plugin-storage/yak-ops-plugin-storage-api/src/main/java/io/yak/ops/spi/storage/StorageObjectMetadata.java
+++ b/yak-ops-plugins/yak-ops-plugin-storage/yak-ops-plugin-storage-api/src/main/java/io/yak/ops/spi/storage/StorageObjectMetadata.java
@@ -1,0 +1,18 @@
+package io.yak.ops.spi.storage;
+
+import java.time.Instant;
+import lombok.Builder;
+import lombok.Value;
+
+/** 存储对象元数据。 */
+@Value
+@Builder
+public class StorageObjectMetadata {
+
+  String path;
+  boolean directory;
+  long size;
+  String contentType;
+  String checksum;
+  Instant lastModified;
+}

--- a/yak-ops-plugins/yak-ops-plugin-storage/yak-ops-plugin-storage-api/src/main/java/io/yak/ops/spi/storage/StorageOperator.java
+++ b/yak-ops-plugins/yak-ops-plugin-storage/yak-ops-plugin-storage-api/src/main/java/io/yak/ops/spi/storage/StorageOperator.java
@@ -1,0 +1,39 @@
+package io.yak.ops.spi.storage;
+
+import io.yak.ops.common.enums.resource.ResourceStorageType;
+import java.io.InputStream;
+
+/**
+ * 资源存储插件稳定接口。
+ *
+ * <p>接口只接受相对逻辑路径，具体 bucket、HDFS 根目录和连接参数由实现插件负责。
+ */
+public interface StorageOperator {
+
+  /** 插件唯一存储类型。 */
+  ResourceStorageType type();
+
+  /** 插件展示名称。 */
+  String name();
+
+  /** 创建目录；对象存储实现可创建目录标记对象。 */
+  void createDirectory(String path);
+
+  /** 判断文件或目录是否存在。 */
+  boolean exists(String path);
+
+  /** 上传文件内容。 */
+  void upload(String path, InputStream inputStream, long size, String contentType, boolean overwrite);
+
+  /** 下载文件内容，调用方负责关闭返回流。 */
+  InputStream download(String path);
+
+  /** 删除文件或目录。 */
+  void delete(String path, boolean recursive);
+
+  /** 移动文件或目录。 */
+  void move(String sourcePath, String targetPath, boolean overwrite);
+
+  /** 获取文件或目录元数据。 */
+  StorageObjectMetadata metadata(String path);
+}

--- a/yak-ops-plugins/yak-ops-plugin-storage/yak-ops-plugin-storage-api/src/main/java/io/yak/ops/spi/storage/StoragePluginException.java
+++ b/yak-ops-plugins/yak-ops-plugin-storage/yak-ops-plugin-storage-api/src/main/java/io/yak/ops/spi/storage/StoragePluginException.java
@@ -1,0 +1,15 @@
+package io.yak.ops.spi.storage;
+
+/** 存储插件统一异常。 */
+public class StoragePluginException extends RuntimeException {
+
+  private static final long serialVersionUID = 1L;
+
+  public StoragePluginException(String message) {
+    super(message);
+  }
+
+  public StoragePluginException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/yak-ops-plugins/yak-ops-plugin-storage/yak-ops-plugin-storage-hdfs/pom.xml
+++ b/yak-ops-plugins/yak-ops-plugin-storage/yak-ops-plugin-storage-hdfs/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.yak.ops</groupId>
+        <artifactId>yak-ops-plugin-storage</artifactId>
+        <version>1.0.0</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>yak-ops-plugin-storage-hdfs</artifactId>
+    <name>Yak Ops HDFS Storage Plugin</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.yak.ops</groupId>
+            <artifactId>yak-ops-plugin-storage-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-client-api</artifactId>
+            <version>${hadoop.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-client-runtime</artifactId>
+            <version>${hadoop.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+    </dependencies>
+</project>

--- a/yak-ops-plugins/yak-ops-plugin-storage/yak-ops-plugin-storage-hdfs/src/main/java/io/yak/ops/plugin/storage/hdfs/HdfsStorageAutoConfiguration.java
+++ b/yak-ops-plugins/yak-ops-plugin-storage/yak-ops-plugin-storage-hdfs/src/main/java/io/yak/ops/plugin/storage/hdfs/HdfsStorageAutoConfiguration.java
@@ -1,0 +1,46 @@
+package io.yak.ops.plugin.storage.hdfs;
+
+import io.yak.ops.spi.storage.StorageOperator;
+import java.io.IOException;
+import java.net.URI;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+
+/** HDFS 存储插件自动装配。 */
+@AutoConfiguration
+@ConditionalOnClass(FileSystem.class)
+@ConditionalOnProperty(
+    prefix = "yak.resource.storage.hdfs",
+    name = "enabled",
+    havingValue = "true")
+@EnableConfigurationProperties(HdfsStorageProperties.class)
+public class HdfsStorageAutoConfiguration {
+
+  @Bean(name = "yakResourceHdfsFileSystem", destroyMethod = "close")
+  @ConditionalOnMissingBean(name = "yakResourceHdfsFileSystem")
+  public FileSystem yakResourceHdfsFileSystem(HdfsStorageProperties properties) throws IOException {
+    Configuration configuration = new Configuration();
+    configuration.set("fs.defaultFS", properties.getUri());
+    try {
+      return FileSystem.get(URI.create(properties.getUri()), configuration, properties.getUser());
+    } catch (InterruptedException exception) {
+      Thread.currentThread().interrupt();
+      throw new IOException("创建 HDFS FileSystem 时线程被中断", exception);
+    }
+  }
+
+  @Bean
+  @ConditionalOnMissingBean(name = "hdfsResourceStorageOperator")
+  public StorageOperator hdfsResourceStorageOperator(
+      @Qualifier("yakResourceHdfsFileSystem") FileSystem yakResourceHdfsFileSystem,
+      HdfsStorageProperties properties) {
+    return new HdfsStorageOperator(yakResourceHdfsFileSystem, properties);
+  }
+}

--- a/yak-ops-plugins/yak-ops-plugin-storage/yak-ops-plugin-storage-hdfs/src/main/java/io/yak/ops/plugin/storage/hdfs/HdfsStorageOperator.java
+++ b/yak-ops-plugins/yak-ops-plugin-storage/yak-ops-plugin-storage-hdfs/src/main/java/io/yak/ops/plugin/storage/hdfs/HdfsStorageOperator.java
@@ -1,0 +1,207 @@
+package io.yak.ops.plugin.storage.hdfs;
+
+import io.yak.ops.common.enums.resource.ResourceStorageType;
+import io.yak.ops.spi.storage.StorageObjectMetadata;
+import io.yak.ops.spi.storage.StorageOperator;
+import io.yak.ops.spi.storage.StoragePluginException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.Instant;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileChecksum;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.IOUtils;
+import org.springframework.util.StringUtils;
+
+/** HDFS 资源存储实现。 */
+public class HdfsStorageOperator implements StorageOperator {
+
+  private final FileSystem fileSystem;
+  private final HdfsStorageProperties properties;
+  private final Path baseDirectory;
+
+  public HdfsStorageOperator(FileSystem fileSystem, HdfsStorageProperties properties) {
+    this.fileSystem = fileSystem;
+    this.properties = properties;
+    this.baseDirectory = new Path(properties.getBaseDirectory());
+  }
+
+  @Override
+  public ResourceStorageType type() {
+    return ResourceStorageType.HDFS;
+  }
+
+  @Override
+  public String name() {
+    return "HDFS";
+  }
+
+  @Override
+  public void createDirectory(String path) {
+    Path target = resolve(path);
+    try {
+      if (fileSystem.exists(target)) {
+        throw new StoragePluginException("HDFS 目录已存在：" + target);
+      }
+      if (!fileSystem.mkdirs(target)) {
+        throw new StoragePluginException("创建 HDFS 目录失败：" + target);
+      }
+    } catch (IOException exception) {
+      throw pluginException("创建 HDFS 目录失败：" + target, exception);
+    }
+  }
+
+  @Override
+  public boolean exists(String path) {
+    Path target = resolve(path);
+    try {
+      return fileSystem.exists(target);
+    } catch (IOException exception) {
+      throw pluginException("检查 HDFS 路径失败：" + target, exception);
+    }
+  }
+
+  @Override
+  public void upload(
+      String path,
+      InputStream inputStream,
+      long size,
+      String contentType,
+      boolean overwrite) {
+    Path target = resolve(path);
+    try {
+      Path parent = target.getParent();
+      if (parent != null && !fileSystem.exists(parent) && !fileSystem.mkdirs(parent)) {
+        throw new StoragePluginException("创建 HDFS 父目录失败：" + parent);
+      }
+      if (!overwrite && fileSystem.exists(target)) {
+        throw new StoragePluginException("HDFS 文件已存在：" + target);
+      }
+      long blockSize = fileSystem.getDefaultBlockSize(target);
+      try (FSDataOutputStream outputStream = fileSystem.create(
+          target,
+          overwrite,
+          fileSystem.getConf().getInt("io.file.buffer.size", 4096),
+          properties.getReplication(),
+          blockSize)) {
+        IOUtils.copyBytes(inputStream, outputStream, 8192, false);
+        outputStream.hflush();
+      }
+    } catch (StoragePluginException exception) {
+      throw exception;
+    } catch (IOException exception) {
+      throw pluginException("上传 HDFS 文件失败：" + target, exception);
+    }
+  }
+
+  @Override
+  public InputStream download(String path) {
+    Path target = resolve(path);
+    try {
+      return fileSystem.open(target);
+    } catch (IOException exception) {
+      throw pluginException("下载 HDFS 文件失败：" + target, exception);
+    }
+  }
+
+  @Override
+  public void delete(String path, boolean recursive) {
+    Path target = resolve(path);
+    try {
+      if (!fileSystem.exists(target)) {
+        return;
+      }
+      if (!fileSystem.delete(target, recursive)) {
+        throw new StoragePluginException("删除 HDFS 路径失败：" + target);
+      }
+    } catch (StoragePluginException exception) {
+      throw exception;
+    } catch (IOException exception) {
+      throw pluginException("删除 HDFS 路径失败：" + target, exception);
+    }
+  }
+
+  @Override
+  public void move(String sourcePath, String targetPath, boolean overwrite) {
+    Path source = resolve(sourcePath);
+    Path target = resolve(targetPath);
+    try {
+      if (!fileSystem.exists(source)) {
+        throw new StoragePluginException("HDFS 源路径不存在：" + source);
+      }
+      if (fileSystem.exists(target)) {
+        if (!overwrite) {
+          throw new StoragePluginException("HDFS 目标路径已存在：" + target);
+        }
+        if (!fileSystem.delete(target, true)) {
+          throw new StoragePluginException("清理 HDFS 目标路径失败：" + target);
+        }
+      }
+      Path parent = target.getParent();
+      if (parent != null && !fileSystem.exists(parent) && !fileSystem.mkdirs(parent)) {
+        throw new StoragePluginException("创建 HDFS 目标父目录失败：" + parent);
+      }
+      if (!fileSystem.rename(source, target)) {
+        throw new StoragePluginException("移动 HDFS 路径失败：" + source + " -> " + target);
+      }
+    } catch (StoragePluginException exception) {
+      throw exception;
+    } catch (IOException exception) {
+      throw pluginException("移动 HDFS 路径失败：" + source + " -> " + target, exception);
+    }
+  }
+
+  @Override
+  public StorageObjectMetadata metadata(String path) {
+    Path target = resolve(path);
+    try {
+      FileStatus status = fileSystem.getFileStatus(target);
+      FileChecksum checksum = status.isFile() ? fileSystem.getFileChecksum(target) : null;
+      return StorageObjectMetadata.builder()
+          .path(path)
+          .directory(status.isDirectory())
+          .size(status.getLen())
+          .contentType(null)
+          .checksum(checksum == null ? null : checksum.toString())
+          .lastModified(Instant.ofEpochMilli(status.getModificationTime()))
+          .build();
+    } catch (IOException exception) {
+      throw pluginException("读取 HDFS 元数据失败：" + target, exception);
+    }
+  }
+
+  private Path resolve(String logicalPath) {
+    String normalized = normalize(logicalPath);
+    Path target = new Path(baseDirectory, normalized);
+    String base = baseDirectory.toUri().normalize().getPath();
+    String resolved = target.toUri().normalize().getPath();
+    String basePrefix = base.endsWith("/") ? base : base + "/";
+    if (!resolved.equals(base) && !resolved.startsWith(basePrefix)) {
+      throw new StoragePluginException("HDFS 路径越界：" + logicalPath);
+    }
+    return target;
+  }
+
+  private String normalize(String path) {
+    if (!StringUtils.hasText(path)) {
+      throw new StoragePluginException("存储路径不能为空");
+    }
+    String normalized = path.replace('\\', '/').trim();
+    while (normalized.startsWith("/")) {
+      normalized = normalized.substring(1);
+    }
+    while (normalized.contains("//")) {
+      normalized = normalized.replace("//", "/");
+    }
+    if (normalized.equals("..") || normalized.startsWith("../") || normalized.contains("/../")) {
+      throw new StoragePluginException("存储路径不能包含上级目录：" + path);
+    }
+    return normalized;
+  }
+
+  private StoragePluginException pluginException(String message, IOException cause) {
+    return new StoragePluginException(message, cause);
+  }
+}

--- a/yak-ops-plugins/yak-ops-plugin-storage/yak-ops-plugin-storage-hdfs/src/main/java/io/yak/ops/plugin/storage/hdfs/HdfsStorageProperties.java
+++ b/yak-ops-plugins/yak-ops-plugin-storage/yak-ops-plugin-storage-hdfs/src/main/java/io/yak/ops/plugin/storage/hdfs/HdfsStorageProperties.java
@@ -1,0 +1,54 @@
+package io.yak.ops.plugin.storage.hdfs;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/** HDFS 资源存储配置。 */
+@ConfigurationProperties(prefix = "yak.resource.storage.hdfs")
+public class HdfsStorageProperties {
+
+  private boolean enabled;
+  private String uri = "hdfs://127.0.0.1:9000";
+  private String user = "hdfs";
+  private String baseDirectory = "/yak-ops/resources";
+  private short replication = 1;
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  public String getUri() {
+    return uri;
+  }
+
+  public void setUri(String uri) {
+    this.uri = uri;
+  }
+
+  public String getUser() {
+    return user;
+  }
+
+  public void setUser(String user) {
+    this.user = user;
+  }
+
+  public String getBaseDirectory() {
+    return baseDirectory;
+  }
+
+  public void setBaseDirectory(String baseDirectory) {
+    this.baseDirectory = baseDirectory;
+  }
+
+  public short getReplication() {
+    return replication;
+  }
+
+  public void setReplication(short replication) {
+    this.replication = replication;
+  }
+}

--- a/yak-ops-plugins/yak-ops-plugin-storage/yak-ops-plugin-storage-hdfs/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/yak-ops-plugins/yak-ops-plugin-storage/yak-ops-plugin-storage-hdfs/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+io.yak.ops.plugin.storage.hdfs.HdfsStorageAutoConfiguration

--- a/yak-ops-plugins/yak-ops-plugin-storage/yak-ops-plugin-storage-minio/pom.xml
+++ b/yak-ops-plugins/yak-ops-plugin-storage/yak-ops-plugin-storage-minio/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.yak.ops</groupId>
+        <artifactId>yak-ops-plugin-storage</artifactId>
+        <version>1.0.0</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>yak-ops-plugin-storage-minio</artifactId>
+    <name>Yak Ops MinIO Storage Plugin</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.yak.ops</groupId>
+            <artifactId>yak-ops-plugin-storage-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.minio</groupId>
+            <artifactId>minio</artifactId>
+            <version>${minio.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+    </dependencies>
+</project>

--- a/yak-ops-plugins/yak-ops-plugin-storage/yak-ops-plugin-storage-minio/src/main/java/io/yak/ops/plugin/storage/minio/MinioStorageAutoConfiguration.java
+++ b/yak-ops-plugins/yak-ops-plugin-storage/yak-ops-plugin-storage-minio/src/main/java/io/yak/ops/plugin/storage/minio/MinioStorageAutoConfiguration.java
@@ -1,0 +1,32 @@
+package io.yak.ops.plugin.storage.minio;
+
+import io.minio.MinioClient;
+import io.yak.ops.spi.storage.StorageOperator;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+
+/** MinIO 存储插件自动装配。 */
+@AutoConfiguration
+@ConditionalOnClass(MinioClient.class)
+@ConditionalOnProperty(
+    prefix = "yak.resource.storage.minio",
+    name = "enabled",
+    havingValue = "true",
+    matchIfMissing = true)
+@EnableConfigurationProperties(MinioStorageProperties.class)
+public class MinioStorageAutoConfiguration {
+
+  @Bean
+  @ConditionalOnMissingBean(name = "minioResourceStorageOperator")
+  public StorageOperator minioResourceStorageOperator(MinioStorageProperties properties) {
+    MinioClient client = MinioClient.builder()
+        .endpoint(properties.getEndpoint())
+        .credentials(properties.getAccessKey(), properties.getSecretKey())
+        .build();
+    return new MinioStorageOperator(client, properties);
+  }
+}

--- a/yak-ops-plugins/yak-ops-plugin-storage/yak-ops-plugin-storage-minio/src/main/java/io/yak/ops/plugin/storage/minio/MinioStorageOperator.java
+++ b/yak-ops-plugins/yak-ops-plugin-storage/yak-ops-plugin-storage-minio/src/main/java/io/yak/ops/plugin/storage/minio/MinioStorageOperator.java
@@ -1,0 +1,357 @@
+package io.yak.ops.plugin.storage.minio;
+
+import io.minio.BucketExistsArgs;
+import io.minio.CopyObjectArgs;
+import io.minio.CopySource;
+import io.minio.GetObjectArgs;
+import io.minio.ListObjectsArgs;
+import io.minio.MakeBucketArgs;
+import io.minio.MinioClient;
+import io.minio.PutObjectArgs;
+import io.minio.RemoveObjectArgs;
+import io.minio.RemoveObjectsArgs;
+import io.minio.StatObjectArgs;
+import io.minio.StatObjectResponse;
+import io.minio.errors.ErrorResponseException;
+import io.minio.messages.DeleteError;
+import io.minio.messages.DeleteObject;
+import io.minio.messages.Item;
+import io.yak.ops.common.enums.resource.ResourceStorageType;
+import io.yak.ops.spi.storage.StorageObjectMetadata;
+import io.yak.ops.spi.storage.StorageOperator;
+import io.yak.ops.spi.storage.StoragePluginException;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.util.StringUtils;
+
+/** MinIO 资源存储实现。 */
+public class MinioStorageOperator implements StorageOperator {
+
+  private static final byte[] EMPTY_CONTENT = new byte[0];
+
+  private final MinioClient client;
+  private final MinioStorageProperties properties;
+  private volatile boolean bucketReady;
+
+  public MinioStorageOperator(MinioClient client, MinioStorageProperties properties) {
+    this.client = client;
+    this.properties = properties;
+  }
+
+  @Override
+  public ResourceStorageType type() {
+    return ResourceStorageType.MINIO;
+  }
+
+  @Override
+  public String name() {
+    return "MinIO";
+  }
+
+  @Override
+  public void createDirectory(String path) {
+    String objectName = directoryObjectName(path);
+    upload(objectName, new ByteArrayInputStream(EMPTY_CONTENT), 0L,
+        "application/x-directory", false);
+  }
+
+  @Override
+  public boolean exists(String path) {
+    ensureBucket();
+    String objectName = objectName(path);
+    try {
+      client.statObject(
+          StatObjectArgs.builder().bucket(properties.getBucket()).object(objectName).build());
+      return true;
+    } catch (ErrorResponseException exception) {
+      if (!isNotFound(exception)) {
+        throw pluginException("检查 MinIO 对象失败", exception);
+      }
+    } catch (Exception exception) {
+      throw pluginException("检查 MinIO 对象失败", exception);
+    }
+
+    String prefix = directoryObjectName(path);
+    try {
+      for (io.minio.Result<Item> result : client.listObjects(
+          ListObjectsArgs.builder()
+              .bucket(properties.getBucket())
+              .prefix(prefix)
+              .recursive(true)
+              .build())) {
+        result.get();
+        return true;
+      }
+      return false;
+    } catch (Exception exception) {
+      throw pluginException("检查 MinIO 目录失败", exception);
+    }
+  }
+
+  @Override
+  public void upload(
+      String path,
+      InputStream inputStream,
+      long size,
+      String contentType,
+      boolean overwrite) {
+    ensureBucket();
+    String objectName = objectName(path);
+    if (!overwrite && exists(objectName)) {
+      throw new StoragePluginException("MinIO 对象已存在：" + objectName);
+    }
+    try {
+      client.putObject(
+          PutObjectArgs.builder()
+              .bucket(properties.getBucket())
+              .object(objectName)
+              .stream(inputStream, size, -1)
+              .contentType(StringUtils.hasText(contentType)
+                  ? contentType
+                  : "application/octet-stream")
+              .build());
+    } catch (Exception exception) {
+      throw pluginException("上传 MinIO 对象失败：" + objectName, exception);
+    }
+  }
+
+  @Override
+  public InputStream download(String path) {
+    ensureBucket();
+    String objectName = objectName(path);
+    try {
+      return client.getObject(
+          GetObjectArgs.builder().bucket(properties.getBucket()).object(objectName).build());
+    } catch (Exception exception) {
+      throw pluginException("下载 MinIO 对象失败：" + objectName, exception);
+    }
+  }
+
+  @Override
+  public void delete(String path, boolean recursive) {
+    ensureBucket();
+    String objectName = objectName(path);
+    if (!recursive) {
+      try {
+        client.removeObject(
+            RemoveObjectArgs.builder().bucket(properties.getBucket()).object(objectName).build());
+        return;
+      } catch (Exception exception) {
+        throw pluginException("删除 MinIO 对象失败：" + objectName, exception);
+      }
+    }
+
+    String prefix = directoryObjectName(path);
+    List<DeleteObject> objects = new ArrayList<>();
+    try {
+      for (io.minio.Result<Item> result : client.listObjects(
+          ListObjectsArgs.builder()
+              .bucket(properties.getBucket())
+              .prefix(prefix)
+              .recursive(true)
+              .build())) {
+        objects.add(new DeleteObject(result.get().objectName()));
+      }
+      if (objects.isEmpty()) {
+        objects.add(new DeleteObject(objectName));
+      }
+      Iterable<io.minio.Result<DeleteError>> errors = client.removeObjects(
+          RemoveObjectsArgs.builder().bucket(properties.getBucket()).objects(objects).build());
+      for (io.minio.Result<DeleteError> error : errors) {
+        DeleteError deleteError = error.get();
+        throw new StoragePluginException(
+            "删除 MinIO 对象失败：" + deleteError.objectName() + "，" + deleteError.message());
+      }
+    } catch (StoragePluginException exception) {
+      throw exception;
+    } catch (Exception exception) {
+      throw pluginException("递归删除 MinIO 目录失败：" + prefix, exception);
+    }
+  }
+
+  @Override
+  public void move(String sourcePath, String targetPath, boolean overwrite) {
+    ensureBucket();
+    String source = objectName(sourcePath);
+    String target = objectName(targetPath);
+    if (!overwrite && exists(target)) {
+      throw new StoragePluginException("目标 MinIO 对象已存在：" + target);
+    }
+
+    String sourceDirectory = directoryObjectName(sourcePath);
+    List<String> sourceObjects = listObjectNames(sourceDirectory);
+    if (sourceObjects.isEmpty()) {
+      copyObject(source, target);
+      removeObject(source);
+      return;
+    }
+
+    String targetDirectory = directoryObjectName(targetPath);
+    List<String> copiedTargets = new ArrayList<>();
+    try {
+      for (String sourceObject : sourceObjects) {
+        String relative = sourceObject.substring(sourceDirectory.length());
+        String targetObject = targetDirectory + relative;
+        if (!overwrite && exists(targetObject)) {
+          throw new StoragePluginException("目标 MinIO 对象已存在：" + targetObject);
+        }
+        copyObject(sourceObject, targetObject);
+        copiedTargets.add(targetObject);
+      }
+      delete(sourceDirectory, true);
+    } catch (RuntimeException exception) {
+      for (String copiedTarget : copiedTargets) {
+        try {
+          removeObject(copiedTarget);
+        } catch (RuntimeException ignored) {
+          // 回滚清理失败不覆盖原始异常。
+        }
+      }
+      throw exception;
+    }
+  }
+
+  @Override
+  public StorageObjectMetadata metadata(String path) {
+    ensureBucket();
+    String objectName = objectName(path);
+    try {
+      StatObjectResponse response = client.statObject(
+          StatObjectArgs.builder().bucket(properties.getBucket()).object(objectName).build());
+      Instant modified = response.lastModified() == null
+          ? null
+          : response.lastModified().toInstant();
+      return StorageObjectMetadata.builder()
+          .path(path)
+          .directory(objectName.endsWith("/"))
+          .size(response.size())
+          .contentType(response.contentType())
+          .checksum(response.etag())
+          .lastModified(modified)
+          .build();
+    } catch (Exception exception) {
+      throw pluginException("读取 MinIO 对象元数据失败：" + objectName, exception);
+    }
+  }
+
+  private List<String> listObjectNames(String prefix) {
+    List<String> names = new ArrayList<>();
+    try {
+      for (io.minio.Result<Item> result : client.listObjects(
+          ListObjectsArgs.builder()
+              .bucket(properties.getBucket())
+              .prefix(prefix)
+              .recursive(true)
+              .build())) {
+        names.add(result.get().objectName());
+      }
+      return names;
+    } catch (Exception exception) {
+      throw pluginException("列举 MinIO 对象失败：" + prefix, exception);
+    }
+  }
+
+  private void copyObject(String source, String target) {
+    try {
+      client.copyObject(
+          CopyObjectArgs.builder()
+              .bucket(properties.getBucket())
+              .object(target)
+              .source(CopySource.builder()
+                  .bucket(properties.getBucket())
+                  .object(source)
+                  .build())
+              .build());
+    } catch (Exception exception) {
+      throw pluginException("复制 MinIO 对象失败：" + source + " -> " + target, exception);
+    }
+  }
+
+  private void removeObject(String objectName) {
+    try {
+      client.removeObject(
+          RemoveObjectArgs.builder().bucket(properties.getBucket()).object(objectName).build());
+    } catch (Exception exception) {
+      throw pluginException("删除 MinIO 对象失败：" + objectName, exception);
+    }
+  }
+
+  private void ensureBucket() {
+    if (bucketReady) {
+      return;
+    }
+    synchronized (this) {
+      if (bucketReady) {
+        return;
+      }
+      try {
+        boolean exists = client.bucketExists(
+            BucketExistsArgs.builder().bucket(properties.getBucket()).build());
+        if (!exists) {
+          if (!properties.isAutoCreateBucket()) {
+            throw new StoragePluginException("MinIO bucket 不存在：" + properties.getBucket());
+          }
+          client.makeBucket(MakeBucketArgs.builder().bucket(properties.getBucket()).build());
+        }
+        bucketReady = true;
+      } catch (StoragePluginException exception) {
+        throw exception;
+      } catch (Exception exception) {
+        throw pluginException("初始化 MinIO bucket 失败：" + properties.getBucket(), exception);
+      }
+    }
+  }
+
+  private String objectName(String path) {
+    String normalized = normalize(path);
+    if (!StringUtils.hasText(properties.getBasePrefix())) {
+      return normalized;
+    }
+    String basePrefix = normalize(properties.getBasePrefix());
+    return normalized.startsWith(basePrefix + "/") || normalized.equals(basePrefix)
+        ? normalized
+        : basePrefix + "/" + normalized;
+  }
+
+  private String directoryObjectName(String path) {
+    String objectName = objectName(path);
+    return objectName.endsWith("/") ? objectName : objectName + "/";
+  }
+
+  private String normalize(String path) {
+    if (!StringUtils.hasText(path)) {
+      throw new StoragePluginException("存储路径不能为空");
+    }
+    String normalized = path.replace('\\', '/').trim();
+    while (normalized.startsWith("/")) {
+      normalized = normalized.substring(1);
+    }
+    while (normalized.contains("//")) {
+      normalized = normalized.replace("//", "/");
+    }
+    if (!StringUtils.hasText(normalized)) {
+      throw new StoragePluginException("存储路径不能为空");
+    }
+    if (normalized.equals("..") || normalized.startsWith("../") || normalized.contains("/../")) {
+      throw new StoragePluginException("存储路径不能包含上级目录：" + path);
+    }
+    return normalized;
+  }
+
+  private boolean isNotFound(ErrorResponseException exception) {
+    if (exception.errorResponse() == null) {
+      return false;
+    }
+    String code = exception.errorResponse().code();
+    return "NoSuchKey".equals(code)
+        || "NoSuchObject".equals(code)
+        || "NoSuchBucket".equals(code);
+  }
+
+  private StoragePluginException pluginException(String message, Exception cause) {
+    return new StoragePluginException(message, cause);
+  }
+}

--- a/yak-ops-plugins/yak-ops-plugin-storage/yak-ops-plugin-storage-minio/src/main/java/io/yak/ops/plugin/storage/minio/MinioStorageProperties.java
+++ b/yak-ops-plugins/yak-ops-plugin-storage/yak-ops-plugin-storage-minio/src/main/java/io/yak/ops/plugin/storage/minio/MinioStorageProperties.java
@@ -1,0 +1,72 @@
+package io.yak.ops.plugin.storage.minio;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/** MinIO 资源存储配置。 */
+@ConfigurationProperties(prefix = "yak.resource.storage.minio")
+public class MinioStorageProperties {
+
+  private boolean enabled = true;
+  private String endpoint = "http://127.0.0.1:9000";
+  private String accessKey = "minioadmin";
+  private String secretKey = "minioadmin";
+  private String bucket = "yak-ops";
+  private String basePrefix = "resources";
+  private boolean autoCreateBucket = true;
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  public String getEndpoint() {
+    return endpoint;
+  }
+
+  public void setEndpoint(String endpoint) {
+    this.endpoint = endpoint;
+  }
+
+  public String getAccessKey() {
+    return accessKey;
+  }
+
+  public void setAccessKey(String accessKey) {
+    this.accessKey = accessKey;
+  }
+
+  public String getSecretKey() {
+    return secretKey;
+  }
+
+  public void setSecretKey(String secretKey) {
+    this.secretKey = secretKey;
+  }
+
+  public String getBucket() {
+    return bucket;
+  }
+
+  public void setBucket(String bucket) {
+    this.bucket = bucket;
+  }
+
+  public String getBasePrefix() {
+    return basePrefix;
+  }
+
+  public void setBasePrefix(String basePrefix) {
+    this.basePrefix = basePrefix;
+  }
+
+  public boolean isAutoCreateBucket() {
+    return autoCreateBucket;
+  }
+
+  public void setAutoCreateBucket(boolean autoCreateBucket) {
+    this.autoCreateBucket = autoCreateBucket;
+  }
+}

--- a/yak-ops-plugins/yak-ops-plugin-storage/yak-ops-plugin-storage-minio/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/yak-ops-plugins/yak-ops-plugin-storage/yak-ops-plugin-storage-minio/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+io.yak.ops.plugin.storage.minio.MinioStorageAutoConfiguration

--- a/yak-ops-spi/src/main/java/io/yak/ops/spi/resource/ResourceFileSyncAction.java
+++ b/yak-ops-spi/src/main/java/io/yak/ops/spi/resource/ResourceFileSyncAction.java
@@ -1,0 +1,9 @@
+package io.yak.ops.spi.resource;
+
+/** 资源文件同步事件类型。 */
+public enum ResourceFileSyncAction {
+  CREATED,
+  UPDATED,
+  MOVED,
+  DELETED
+}

--- a/yak-ops-spi/src/main/java/io/yak/ops/spi/resource/ResourceFileSyncContext.java
+++ b/yak-ops-spi/src/main/java/io/yak/ops/spi/resource/ResourceFileSyncContext.java
@@ -1,0 +1,21 @@
+package io.yak.ops.spi.resource;
+
+import io.yak.ops.common.enums.resource.ResourceNodeType;
+import io.yak.ops.common.enums.resource.ResourceStorageType;
+import lombok.Builder;
+import lombok.Value;
+
+/** 资源文件同步上下文，后续 Git/DataOps 插件可直接消费。 */
+@Value
+@Builder
+public class ResourceFileSyncContext {
+
+  Long resourceId;
+  ResourceFileSyncAction action;
+  ResourceNodeType nodeType;
+  ResourceStorageType storageType;
+  String oldFullPath;
+  String fullPath;
+  String storagePath;
+  Integer version;
+}

--- a/yak-ops-spi/src/main/java/io/yak/ops/spi/resource/ResourceFileSyncProvider.java
+++ b/yak-ops-spi/src/main/java/io/yak/ops/spi/resource/ResourceFileSyncProvider.java
@@ -1,0 +1,15 @@
+package io.yak.ops.spi.resource;
+
+/**
+ * 资源文件外部同步扩展点。
+ *
+ * <p>Git/DataOps 文件集成后续只需实现该接口并注册为 Spring Bean，资源业务无需修改。
+ */
+public interface ResourceFileSyncProvider {
+
+  /** 同步提供方唯一名称，例如 git。 */
+  String type();
+
+  /** 消费一次资源变更事件。 */
+  void synchronize(ResourceFileSyncContext context);
+}


### PR DESCRIPTION
## Summary

- add resource metadata CRUD, directory tree/page/list, upload/download, online text editing, rename, move and recursive delete
- place resource DTO/VO/PO, enums and permission constants in `yak-ops-common`
- add a storage plugin API plus built-in MinIO and HDFS implementations under `yak-ops-plugins`
- add isolated resource datasource, MyBatis-Plus and Flyway configuration, and wire the module into `yak-ops-boot`
- add `ResourceFileSyncProvider` as the future Git/DataOps synchronization extension point; this PR intentionally does not implement Git synchronization

## API

Base path: `/api/v1/resources`

- `POST /directory`
- `POST /`
- `POST /online-create`
- `GET /{id}`
- `GET /list`
- `POST /page`
- `GET /tree`
- `PUT /{id}`
- `PUT /{id}/file`
- `GET /{id}/content`
- `PUT /{id}/content`
- `POST /{id}/move`
- `DELETE /{id}`
- `GET /{id}/download`
- `GET /storage-plugins`

## Design notes

- database metadata is the source of truth for the resource tree; MinIO/HDFS plugins store physical file content
- children inherit the parent storage type, and cross-storage moves are rejected
- path traversal, duplicate sibling names, editable suffixes, online-edit size and upload size are validated in the backend
- resource changes are dispatched to sync providers only after the metadata transaction commits
- existing resource permissions are reused: `resource:view`, `resource:upload`, `resource:download`, `resource:update`, `resource:delete`

## Validation

- XML and YAML parse validation passed
- Java parser-stage syntax validation passed
- tests added for resource path security, storage plugin registry and controller permission/API contract
- a full local Maven build could not be run because Maven is unavailable in the execution environment; GitHub checks are used as the final build signal
