### PR TITLE
feat(resource-ui): add resource management workbench

### DIFF
--- a/yak-ops-business/yak-ops-business-resource/src/main/resources/db/migration/yak-resource/V1__init_resource_management.sql
+++ b/yak-ops-business/yak-ops-business-resource/src/main/resources/db/migration/yak-resource/V1__init_resource_management.sql
@@ -16,8 +16,8 @@ CREATE TABLE IF NOT EXISTS yak_ops_resource (
     create_time DATETIME(3) NOT NULL,
     update_time DATETIME(3) NOT NULL,
     PRIMARY KEY (id),
-    UNIQUE KEY uk_yak_resource_full_path (full_path),
     UNIQUE KEY uk_yak_resource_parent_name (parent_id, name),
+    KEY idx_yak_resource_full_path (full_path(255)),
     KEY idx_yak_resource_parent_type (parent_id, node_type),
     KEY idx_yak_resource_storage (storage_type, storage_path(255))
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/yak-ops-ui/src/config/navigation.ts
+++ b/yak-ops-ui/src/config/navigation.ts
@@ -307,7 +307,17 @@ export const appRoutes: readonly NavigationRoute[] = [
     iconKey: 'database',
     order: 10,
   },
-
+  {
+    id: 'resource-management',
+    mode: 'one',
+    permission: 'resource:view',
+    path: '/resource-management',
+    title: '文件资源',
+    component: './resource-management',
+    iconKey: 'database',
+    menuGroup: 'resources',
+    order: 10,
+  },
   {
     id: 'client',
     mode: 'one',

--- a/yak-ops-ui/src/constants/yakOpsPermissions.ts
+++ b/yak-ops-ui/src/constants/yakOpsPermissions.ts
@@ -7,7 +7,15 @@ export const YAK_OPS_PERMISSIONS = {
     delete: 'datasource:delete',
     test: 'datasource:test',
   },
+  resource: {
+    read: 'resource:view',
+    create: 'resource:upload',
+    update: 'resource:update',
+    delete: 'resource:delete',
+    download: 'resource:download',
+  },
 } as const;
 
 export type YakOpsPermissionCode =
-  (typeof YAK_OPS_PERMISSIONS.dataSource)[keyof typeof YAK_OPS_PERMISSIONS.dataSource];
+  | (typeof YAK_OPS_PERMISSIONS.dataSource)[keyof typeof YAK_OPS_PERMISSIONS.dataSource]
+  | (typeof YAK_OPS_PERMISSIONS.resource)[keyof typeof YAK_OPS_PERMISSIONS.resource];

--- a/yak-ops-ui/src/pages/resource-management/components/CreateDirectoryModal.tsx
+++ b/yak-ops-ui/src/pages/resource-management/components/CreateDirectoryModal.tsx
@@ -1,0 +1,75 @@
+import { Form, Input, Modal } from 'antd';
+import { useEffect } from 'react';
+
+import type { DirectoryFormValues } from '../types';
+
+interface CreateDirectoryModalProps {
+  open: boolean;
+  parentName: string;
+  saving: boolean;
+  onCancel: () => void;
+  onSubmit: (values: DirectoryFormValues) => Promise<void>;
+}
+
+const CreateDirectoryModal = ({
+  open,
+  parentName,
+  saving,
+  onCancel,
+  onSubmit,
+}: CreateDirectoryModalProps) => {
+  const [form] = Form.useForm<DirectoryFormValues>();
+
+  useEffect(() => {
+    if (open) form.resetFields();
+  }, [form, open]);
+
+  return (
+    <Modal
+      title="新建文件夹"
+      open={open}
+      centered
+      okText="创建"
+      cancelText="取消"
+      confirmLoading={saving}
+      destroyOnClose
+      onCancel={onCancel}
+      onOk={() => void form.submit()}
+    >
+      <div className="resource-form-context">
+        创建位置：<strong>{parentName}</strong>
+      </div>
+      <Form
+        form={form}
+        layout="vertical"
+        requiredMark={false}
+        onFinish={(values) => void onSubmit(values)}
+      >
+        <Form.Item
+          label="文件夹名称"
+          name="name"
+          rules={[
+            { required: true, message: '请输入文件夹名称' },
+            { max: 255, message: '文件夹名称不能超过 255 个字符' },
+          ]}
+        >
+          <Input autoFocus placeholder="例如：同步脚本" />
+        </Form.Item>
+        <Form.Item
+          label="描述"
+          name="description"
+          rules={[{ max: 512, message: '描述不能超过 512 个字符' }]}
+        >
+          <Input.TextArea
+            rows={3}
+            showCount
+            maxLength={512}
+            placeholder="选填，用于说明该目录保存的内容"
+          />
+        </Form.Item>
+      </Form>
+    </Modal>
+  );
+};
+
+export default CreateDirectoryModal;

--- a/yak-ops-ui/src/pages/resource-management/components/CreateTextResourceModal.tsx
+++ b/yak-ops-ui/src/pages/resource-management/components/CreateTextResourceModal.tsx
@@ -1,0 +1,102 @@
+import { Form, Input, Modal, Select } from 'antd';
+import { useEffect } from 'react';
+
+import type { TextResourceFormValues } from '../types';
+
+interface CreateTextResourceModalProps {
+  open: boolean;
+  parentName: string;
+  saving: boolean;
+  onCancel: () => void;
+  onSubmit: (values: TextResourceFormValues) => Promise<void>;
+}
+
+const CONTENT_TYPES = [
+  { label: '普通文本', value: 'text/plain;charset=UTF-8' },
+  { label: 'JSON', value: 'application/json;charset=UTF-8' },
+  { label: 'YAML', value: 'application/yaml;charset=UTF-8' },
+  { label: 'SQL', value: 'application/sql;charset=UTF-8' },
+  { label: 'Shell', value: 'text/x-shellscript;charset=UTF-8' },
+];
+
+const CreateTextResourceModal = ({
+  open,
+  parentName,
+  saving,
+  onCancel,
+  onSubmit,
+}: CreateTextResourceModalProps) => {
+  const [form] = Form.useForm<TextResourceFormValues>();
+
+  useEffect(() => {
+    if (!open) return;
+    form.resetFields();
+    form.setFieldValue('contentType', CONTENT_TYPES[0].value);
+  }, [form, open]);
+
+  return (
+    <Modal
+      title="在线创建文件"
+      open={open}
+      width={760}
+      centered
+      okText="创建文件"
+      cancelText="取消"
+      confirmLoading={saving}
+      destroyOnClose
+      onCancel={onCancel}
+      onOk={() => void form.submit()}
+    >
+      <div className="resource-form-context">
+        创建位置：<strong>{parentName}</strong>
+      </div>
+      <Form
+        form={form}
+        layout="vertical"
+        requiredMark={false}
+        onFinish={(values) => void onSubmit(values)}
+      >
+        <div className="resource-form-grid">
+          <Form.Item
+            label="文件名称"
+            name="name"
+            rules={[
+              { required: true, message: '请输入文件名称' },
+              { max: 255, message: '文件名称不能超过 255 个字符' },
+            ]}
+          >
+            <Input autoFocus placeholder="例如：job-config.yaml" />
+          </Form.Item>
+          <Form.Item label="内容类型" name="contentType">
+            <Select options={CONTENT_TYPES} />
+          </Form.Item>
+        </div>
+        <Form.Item
+          label="文件内容"
+          name="content"
+          rules={[{ required: true, message: '请输入文件内容' }]}
+        >
+          <Input.TextArea
+            className="resource-code-textarea"
+            rows={14}
+            placeholder="在这里输入文本内容"
+          />
+        </Form.Item>
+        <Form.Item
+          label="描述"
+          name="description"
+          rules={[{ max: 512, message: '描述不能超过 512 个字符' }]}
+        >
+          <Input.TextArea
+            rows={2}
+            showCount
+            maxLength={512}
+            placeholder="选填"
+          />
+        </Form.Item>
+      </Form>
+    </Modal>
+  );
+};
+
+export default CreateTextResourceModal;

--- a/yak-ops-ui/src/pages/resource-management/components/MoveResourceModal.tsx
+++ b/yak-ops-ui/src/pages/resource-management/components/MoveResourceModal.tsx
@@ -1,0 +1,75 @@
+import { Form, Modal, TreeSelect } from 'antd';
+import { useEffect } from 'react';
+
+import type {
+  DirectoryTreeNode,
+} from '../utils';
+import type {
+  MoveResourceFormValues,
+  ResourceItem,
+} from '../types';
+
+interface MoveResourceModalProps {
+  open: boolean;
+  resource?: ResourceItem;
+  directories: DirectoryTreeNode[];
+  saving: boolean;
+  onCancel: () => void;
+  onSubmit: (values: MoveResourceFormValues) => Promise<void>;
+}
+
+const MoveResourceModal = ({
+  open,
+  resource,
+  directories,
+  saving,
+  onCancel,
+  onSubmit,
+}: MoveResourceModalProps) => {
+  const [form] = Form.useForm<MoveResourceFormValues>();
+
+  useEffect(() => {
+    if (!open || !resource) return;
+    form.setFieldsValue({ targetParentId: resource.parentId });
+  }, [form, open, resource]);
+
+  return (
+    <Modal
+      title="移动资源"
+      open={open}
+      centered
+      okText="移动"
+      cancelText="取消"
+      confirmLoading={saving}
+      destroyOnClose
+      onCancel={onCancel}
+      onOk={() => void form.submit()}
+    >
+      <div className="resource-form-context">
+        正在移动：<strong>{resource?.name}</strong>
+      </div>
+      <Form
+        form={form}
+        layout="vertical"
+        requiredMark={false}
+        onFinish={(values) => void onSubmit(values)}
+      >
+        <Form.Item
+          label="目标文件夹"
+          name="targetParentId"
+          rules={[{ required: true, message: '请选择目标文件夹' }]}
+        >
+          <TreeSelect
+            treeData={directories}
+            treeDefaultExpandAll
+            showSearch
+            treeNodeFilterProp="title"
+            placeholder="选择目标文件夹"
+          />
+        </Form.Item>
+      </Form>
+    </Modal>
+  );
+};
+
+export default MoveResourceModal;

--- a/yak-ops-ui/src/pages/resource-management/components/ResourceDetailDrawer.tsx
+++ b/yak-ops-ui/src/pages/resource-management/components/ResourceDetailDrawer.tsx
@@ -1,0 +1,300 @@
+import {
+  Alert,
+  Button,
+  Descriptions,
+  Drawer,
+  Empty,
+  Input,
+  message,
+  Space,
+  Spin,
+  Tag,
+} from 'antd';
+import dayjs from 'dayjs';
+import {
+  Download,
+  FileCode2,
+  Folder,
+  RefreshCw,
+  Save,
+  Upload,
+} from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+
+import { API_SUCCESS_CODE } from '@/services/http/response';
+
+import {
+  fetchResourceContent,
+  updateResourceContent,
+} from '../service';
+import type { ResourceContent, ResourceItem } from '../types';
+import { formatFileSize, isDirectory, isEditableResource } from '../utils';
+
+interface ResourceDetailDrawerProps {
+  open: boolean;
+  resource?: ResourceItem;
+  canUpdate: boolean;
+  canDownload: boolean;
+  onClose: () => void;
+  onDownload: (resource: ResourceItem) => Promise<void>;
+  onReplace: (resource: ResourceItem) => void;
+  onSaved: () => void;
+}
+
+const EMPTY_CONTENT: ResourceContent = {
+  resourceId: 0,
+  fullPath: '',
+  content: '',
+  skipLineNum: 0,
+  lineCount: 0,
+  hasMore: false,
+};
+
+const ResourceDetailDrawer = ({
+  open,
+  resource,
+  canUpdate,
+  canDownload,
+  onClose,
+  onDownload,
+  onReplace,
+  onSaved,
+}: ResourceDetailDrawerProps) => {
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [downloading, setDownloading] = useState(false);
+  const [contentResult, setContentResult] =
+    useState<ResourceContent>(EMPTY_CONTENT);
+  const [content, setContent] = useState('');
+  const [initialContent, setInitialContent] = useState('');
+
+  const editable = isEditableResource(resource);
+  const dirty = content !== initialContent;
+
+  const loadContent = async () => {
+    if (!resource || !editable) return;
+    try {
+      setLoading(true);
+      const response = await fetchResourceContent(resource.id);
+      if (response.code !== API_SUCCESS_CODE || !response.data) return;
+      setContentResult(response.data);
+      setContent(response.data.content || '');
+      setInitialContent(response.data.content || '');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (!open || !resource) return;
+    setContentResult(EMPTY_CONTENT);
+    setContent('');
+    setInitialContent('');
+    void loadContent();
+  }, [open, resource?.id]);
+
+  const descriptionItems = useMemo(
+    () => [
+      {
+        key: 'path',
+        label: '完整路径',
+        children: resource?.fullPath || '-',
+        span: 2,
+      },
+      {
+        key: 'type',
+        label: '资源类型',
+        children: isDirectory(resource) ? '文件夹' : '文件',
+      },
+      {
+        key: 'storage',
+        label: '存储类型',
+        children: resource?.storageType || '-',
+      },
+      {
+        key: 'size',
+        label: '文件大小',
+        children: isDirectory(resource)
+          ? '-'
+          : formatFileSize(resource?.fileSize),
+      },
+      {
+        key: 'version',
+        label: '版本',
+        children: resource?.version ? `v${resource.version}` : '-',
+      },
+      {
+        key: 'updated',
+        label: '更新时间',
+        children: resource?.updateTime
+          ? dayjs(resource.updateTime).format('YYYY-MM-DD HH:mm:ss')
+          : '-',
+      },
+      {
+        key: 'checksum',
+        label: '校验值',
+        children: resource?.checksum || '-',
+        span: 2,
+      },
+      {
+        key: 'description',
+        label: '描述',
+        children: resource?.description || '暂无描述',
+        span: 2,
+      },
+    ],
+    [resource],
+  );
+
+  const handleSave = async () => {
+    if (!resource || !dirty || !canUpdate) return;
+    try {
+      setSaving(true);
+      const response = await updateResourceContent(resource.id, content);
+      if (response.code !== API_SUCCESS_CODE) return;
+      setInitialContent(content);
+      message.success(response.message || '文件内容已保存');
+      onSaved();
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDownload = async () => {
+    if (!resource || !canDownload) return;
+    try {
+      setDownloading(true);
+      await onDownload(resource);
+    } finally {
+      setDownloading(false);
+    }
+  };
+
+  return (
+    <Drawer
+      title={
+        <div className="resource-drawer-title">
+          <span className="resource-drawer-title__icon">
+            {isDirectory(resource) ? <Folder size={18} /> : <FileCode2 size={18} />}
+          </span>
+          <div>
+            <strong>{resource?.name || '资源详情'}</strong>
+            <span>{resource?.fullPath || '/'}</span>
+          </div>
+        </div>
+      }
+      open={open}
+      width={760}
+      destroyOnClose
+      onClose={onClose}
+      extra={
+        resource?.nodeType === 'FILE' ? (
+          <Space size={8}>
+            {canUpdate && (
+              <Button
+                size="small"
+                icon={<Upload size={14} />}
+                onClick={() => onReplace(resource)}
+              >
+                替换文件
+              </Button>
+            )}
+            {canDownload && (
+              <Button
+                size="small"
+                loading={downloading}
+                icon={<Download size={14} />}
+                onClick={() => void handleDownload()}
+              >
+                下载
+              </Button>
+            )}
+          </Space>
+        ) : null
+      }
+    >
+      <section className="resource-detail-section">
+        <div className="resource-detail-section__heading">
+          <h3>资源信息</h3>
+          <Tag bordered={false}>{resource?.storageType || 'UNKNOWN'}</Tag>
+        </div>
+        <Descriptions
+          size="small"
+          bordered
+          column={2}
+          items={descriptionItems}
+        />
+      </section>
+
+      {!isDirectory(resource) && (
+        <section className="resource-detail-section resource-detail-section--content">
+          <div className="resource-detail-section__heading">
+            <div>
+              <h3>文件内容</h3>
+              <p>
+                {editable
+                  ? `支持在线预览与编辑 .${resource?.suffix || 'txt'} 文件`
+                  : '当前文件类型不支持在线预览'}
+              </p>
+            </div>
+            {editable && (
+              <Space size={8}>
+                <Button
+                  size="small"
+                  icon={<RefreshCw size={14} />}
+                  disabled={loading || saving}
+                  onClick={() => void loadContent()}
+                >
+                  重新加载
+                </Button>
+                {canUpdate && (
+                  <Button
+                    type="primary"
+                    size="small"
+                    icon={<Save size={14} />}
+                    disabled={!dirty}
+                    loading={saving}
+                    onClick={() => void handleSave()}
+                  >
+                    保存内容
+                  </Button>
+                )}
+              </Space>
+            )}
+          </div>
+
+          {editable ? (
+            <Spin spinning={loading}>
+              {contentResult.hasMore && (
+                <Alert
+                  className="resource-content-alert"
+                  type="warning"
+                  showIcon
+                  message="文件内容超过 2000 行，当前仅展示前 2000 行；保存会覆盖整个文件，请谨慎修改。"
+                />
+              )}
+              <Input.TextArea
+                className="resource-content-editor"
+                value={content}
+                readOnly={!canUpdate}
+                spellCheck={false}
+                onChange={(event) => setContent(event.target.value)}
+              />
+              <div className="resource-content-footer">
+                <span>{contentResult.lineCount || content.split('\n').length} 行</span>
+                <span>{new Blob([content]).size} 字节</span>
+              </div>
+            </Spin>
+          ) : (
+            <Empty
+              image={Empty.PRESENTED_IMAGE_SIMPLE}
+              description="可下载文件后在本地查看"
+            />
+          )}
+        </section>
+      )}
+    </Drawer>
+  );
+};
+
+export default ResourceDetailDrawer;

--- a/yak-ops-ui/src/pages/resource-management/components/ResourceMetadataModal.tsx
+++ b/yak-ops-ui/src/pages/resource-management/components/ResourceMetadataModal.tsx
@@ -1,0 +1,71 @@
+import { Form, Input, Modal } from 'antd';
+import { useEffect } from 'react';
+
+import type { ResourceItem, ResourceMetadataFormValues } from '../types';
+
+interface ResourceMetadataModalProps {
+  open: boolean;
+  resource?: ResourceItem;
+  saving: boolean;
+  onCancel: () => void;
+  onSubmit: (values: ResourceMetadataFormValues) => Promise<void>;
+}
+
+const ResourceMetadataModal = ({
+  open,
+  resource,
+  saving,
+  onCancel,
+  onSubmit,
+}: ResourceMetadataModalProps) => {
+  const [form] = Form.useForm<ResourceMetadataFormValues>();
+
+  useEffect(() => {
+    if (!open || !resource) return;
+    form.setFieldsValue({
+      name: resource.name,
+      description: resource.description,
+    });
+  }, [form, open, resource]);
+
+  return (
+    <Modal
+      title="编辑资源信息"
+      open={open}
+      centered
+      okText="保存"
+      cancelText="取消"
+      confirmLoading={saving}
+      destroyOnClose
+      onCancel={onCancel}
+      onOk={() => void form.submit()}
+    >
+      <Form
+        form={form}
+        layout="vertical"
+        requiredMark={false}
+        onFinish={(values) => void onSubmit(values)}
+      >
+        <Form.Item
+          label="资源名称"
+          name="name"
+          rules={[
+            { required: true, message: '请输入资源名称' },
+            { max: 255, message: '资源名称不能超过 255 个字符' },
+          ]}
+        >
+          <Input autoFocus />
+        </Form.Item>
+        <Form.Item
+          label="描述"
+          name="description"
+          rules={[{ max: 512, message: '描述不能超过 512 个字符' }]}
+        >
+          <Input.TextArea rows={4} showCount maxLength={512} />
+        </Form.Item>
+      </Form>
+    </Modal>
+  );
+};
+
+export default ResourceMetadataModal;

--- a/yak-ops-ui/src/pages/resource-management/index.less
+++ b/yak-ops-ui/src/pages/resource-management/index.less
@@ -1,0 +1,502 @@
+.resource-page {
+  min-height: calc(100vh - 64px);
+  padding: 24px;
+  color: #101828;
+  background: #f5f7fa;
+}
+
+.resource-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 24px;
+  margin-bottom: 18px;
+
+  h1 {
+    margin: 0;
+    font-size: 24px;
+    font-weight: 650;
+    letter-spacing: -0.02em;
+  }
+
+  p {
+    margin: 7px 0 0;
+    color: #667085;
+    font-size: 13px;
+  }
+}
+
+.resource-overview {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(150px, 0.8fr)) minmax(280px, 1.4fr);
+  gap: 12px;
+  margin-bottom: 14px;
+}
+
+.resource-overview-card {
+  display: flex;
+  min-height: 82px;
+  align-items: center;
+  gap: 12px;
+  padding: 16px 18px;
+  border: 1px solid #e4e7ec;
+  background: #fff;
+  box-shadow: 0 1px 2px rgb(16 24 40 / 3%);
+
+  > span {
+    display: inline-flex;
+    width: 38px;
+    height: 38px;
+    flex: 0 0 38px;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid #d9e6ff;
+    border-radius: 10px;
+    color: #155eef;
+    background: #f3f7ff;
+  }
+
+  > div {
+    min-width: 0;
+  }
+
+  small {
+    display: block;
+    margin-bottom: 4px;
+    color: #667085;
+    font-size: 12px;
+  }
+
+  strong {
+    color: #101828;
+    font-size: 20px;
+    font-weight: 650;
+  }
+}
+
+.resource-overview-card--plugins {
+  align-items: flex-start;
+}
+
+.resource-plugin-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+
+  .ant-tag {
+    margin: 0;
+    color: #475467;
+    background: #f2f4f7;
+  }
+
+  .ant-tag.is-active {
+    color: #175cd3;
+    background: #eff4ff;
+  }
+}
+
+.resource-workbench {
+  display: grid;
+  min-height: 610px;
+  grid-template-columns: 268px minmax(0, 1fr);
+  overflow: hidden;
+  border: 1px solid #dfe3e8;
+  background: #fff;
+  box-shadow: 0 4px 18px rgb(16 24 40 / 5%);
+}
+
+.resource-tree-panel {
+  min-width: 0;
+  border-right: 1px solid #e4e7ec;
+  background: #fbfcfe;
+}
+
+.resource-tree-panel__header {
+  display: flex;
+  height: 54px;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 12px 0 16px;
+  border-bottom: 1px solid #e4e7ec;
+  background: #fff;
+
+  > div {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  strong {
+    font-size: 14px;
+    font-weight: 600;
+  }
+}
+
+.resource-directory-tree {
+  min-height: 520px;
+  padding: 10px 8px;
+  background: transparent;
+
+  .ant-tree-node-content-wrapper {
+    min-height: 32px;
+    padding: 3px 7px;
+    border-radius: 6px;
+    line-height: 26px;
+  }
+
+  .ant-tree-node-selected {
+    color: #175cd3 !important;
+    background: #eff4ff !important;
+  }
+
+  .ant-tree-title {
+    font-size: 13px;
+  }
+}
+
+.resource-list-panel {
+  min-width: 0;
+  background: #fff;
+}
+
+.resource-list-toolbar {
+  display: flex;
+  min-height: 54px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 8px 14px 8px 18px;
+  border-bottom: 1px solid #e4e7ec;
+
+  > div:first-child {
+    display: flex;
+    min-width: 0;
+    align-items: center;
+    gap: 10px;
+  }
+
+  .ant-breadcrumb {
+    min-width: 0;
+  }
+}
+
+.resource-list-toolbar__count {
+  flex: none;
+  padding-left: 10px;
+  border-left: 1px solid #e4e7ec;
+  color: #98a2b3;
+  font-size: 12px;
+}
+
+.resource-breadcrumb-button {
+  max-width: 180px;
+  overflow: hidden;
+  padding: 0;
+  border: 0;
+  color: #475467;
+  background: transparent;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  cursor: pointer;
+
+  &:hover {
+    color: #155eef;
+  }
+}
+
+.resource-search {
+  width: 230px;
+}
+
+.resource-table {
+  .ant-table {
+    border-radius: 0;
+  }
+
+  .ant-table-thead > tr > th {
+    height: 44px;
+    padding-top: 9px;
+    padding-bottom: 9px;
+    color: #667085;
+    font-size: 12px;
+    font-weight: 550;
+    background: #fafbfc;
+  }
+
+  .ant-table-tbody > tr > td {
+    height: 66px;
+    padding-top: 10px;
+    padding-bottom: 10px;
+  }
+
+  .ant-table-tbody > tr {
+    cursor: default;
+  }
+
+  .ant-table-tbody > tr:hover > td {
+    background: #f8faff !important;
+  }
+
+  .ant-empty {
+    margin-block: 70px;
+  }
+}
+
+.resource-name-cell {
+  display: flex;
+  width: 100%;
+  min-width: 0;
+  align-items: center;
+  gap: 11px;
+  padding: 0;
+  border: 0;
+  color: inherit;
+  text-align: left;
+  background: transparent;
+  cursor: pointer;
+}
+
+.resource-name-cell__icon {
+  display: inline-flex;
+  width: 36px;
+  height: 36px;
+  flex: 0 0 36px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 9px;
+
+  &.is-directory {
+    color: #155eef;
+    background: #eff4ff;
+  }
+
+  &.is-file {
+    color: #475467;
+    background: #f2f4f7;
+  }
+}
+
+.resource-name-cell__text {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 3px;
+
+  strong,
+  small {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  strong {
+    color: #101828;
+    font-size: 13px;
+    font-weight: 600;
+  }
+
+  small {
+    color: #98a2b3;
+    font-size: 11px;
+  }
+}
+
+.resource-storage-cell {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  color: #475467;
+}
+
+.resource-form-context {
+  margin-bottom: 18px;
+  padding: 10px 12px;
+  border: 1px solid #e4e7ec;
+  border-radius: 7px;
+  color: #667085;
+  background: #f9fafb;
+  font-size: 12px;
+
+  strong {
+    color: #344054;
+  }
+}
+
+.resource-form-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 220px;
+  gap: 12px;
+}
+
+.resource-code-textarea,
+.resource-content-editor {
+  font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', monospace;
+  font-size: 12px;
+  line-height: 1.7;
+}
+
+.resource-drawer-title {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+
+  > div {
+    display: flex;
+    min-width: 0;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  strong,
+  span {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  strong {
+    max-width: 310px;
+    color: #101828;
+    font-size: 14px;
+  }
+
+  span {
+    max-width: 420px;
+    color: #98a2b3;
+    font-size: 11px;
+  }
+}
+
+.resource-drawer-title__icon {
+  display: inline-flex;
+  width: 34px;
+  height: 34px;
+  flex: 0 0 34px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 8px;
+  color: #155eef;
+  background: #eff4ff;
+}
+
+.resource-detail-section {
+  margin-bottom: 24px;
+}
+
+.resource-detail-section__heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 12px;
+
+  h3 {
+    margin: 0;
+    color: #101828;
+    font-size: 14px;
+    font-weight: 600;
+  }
+
+  p {
+    margin: 4px 0 0;
+    color: #98a2b3;
+    font-size: 12px;
+  }
+}
+
+.resource-detail-section--content {
+  padding-top: 20px;
+  border-top: 1px solid #e4e7ec;
+}
+
+.resource-content-alert {
+  margin-bottom: 10px;
+}
+
+.resource-content-editor {
+  min-height: 390px !important;
+  resize: vertical;
+  color: #d0d5dd;
+  border-color: #344054;
+  background: #101828;
+  caret-color: #fff;
+
+  &:focus,
+  &:hover {
+    border-color: #528bff;
+    background: #101828;
+  }
+
+  &[readonly] {
+    color: #d0d5dd;
+    background: #101828;
+  }
+}
+
+.resource-content-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+  margin-top: 7px;
+  color: #98a2b3;
+  font-size: 11px;
+}
+
+.is-spinning {
+  animation: resource-spin 0.9s linear infinite;
+}
+
+@keyframes resource-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (max-width: 1180px) {
+  .resource-overview {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .resource-workbench {
+    grid-template-columns: 230px minmax(0, 1fr);
+  }
+}
+
+@media (max-width: 860px) {
+  .resource-page {
+    padding: 16px;
+  }
+
+  .resource-header,
+  .resource-list-toolbar {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .resource-overview {
+    grid-template-columns: 1fr;
+  }
+
+  .resource-workbench {
+    grid-template-columns: 1fr;
+  }
+
+  .resource-tree-panel {
+    border-right: 0;
+    border-bottom: 1px solid #e4e7ec;
+  }
+
+  .resource-directory-tree {
+    min-height: 180px;
+    max-height: 260px;
+    overflow: auto;
+  }
+
+  .resource-search {
+    width: 100%;
+  }
+
+  .resource-form-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/yak-ops-ui/src/pages/resource-management/index.tsx
+++ b/yak-ops-ui/src/pages/resource-management/index.tsx
@@ -1,0 +1,797 @@
+import { YAK_OPS_PERMISSIONS } from '@/constants/yakOpsPermissions';
+import usePermissionAccess from '@/hooks/usePermissionAccess';
+import { API_SUCCESS_CODE } from '@/services/http/response';
+import {
+  Breadcrumb,
+  Button,
+  Dropdown,
+  Empty,
+  Input,
+  message,
+  Modal,
+  Space,
+  Spin,
+  Table,
+  Tag,
+  Tooltip,
+  Tree,
+  type MenuProps,
+  type TableColumnsType,
+} from 'antd';
+import dayjs from 'dayjs';
+import {
+  Cloud,
+  Database,
+  Download,
+  File,
+  FileCode2,
+  FilePlus2,
+  Files,
+  Folder,
+  FolderPlus,
+  FolderTree,
+  HardDrive,
+  MoreHorizontal,
+  MoveRight,
+  Pencil,
+  RefreshCw,
+  Search,
+  Trash2,
+  Upload,
+} from 'lucide-react';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+
+import CreateDirectoryModal from './components/CreateDirectoryModal';
+import CreateTextResourceModal from './components/CreateTextResourceModal';
+import MoveResourceModal from './components/MoveResourceModal';
+import ResourceDetailDrawer from './components/ResourceDetailDrawer';
+import ResourceMetadataModal from './components/ResourceMetadataModal';
+import './index.less';
+import {
+  createDirectory,
+  createTextResource,
+  deleteResource,
+  downloadResource,
+  fetchResourceList,
+  fetchResourceTree,
+  fetchStoragePlugins,
+  moveResource,
+  replaceResourceFile,
+  updateResource,
+  uploadResource,
+} from './service';
+import type {
+  DirectoryFormValues,
+  MoveResourceFormValues,
+  ResourceId,
+  ResourceItem,
+  ResourceMetadataFormValues,
+  ResourceStoragePlugin,
+  TextResourceFormValues,
+} from './types';
+import {
+  buildDirectoryTree,
+  findResource,
+  formatFileSize,
+  getResourceBreadcrumbs,
+  getResourceSummary,
+  isDirectory,
+  resourceKey,
+  ROOT_RESOURCE_ID,
+} from './utils';
+
+const { confirm } = Modal;
+
+const ResourceManagementPage = () => {
+  const { can } = usePermissionAccess();
+  const canCreate = can(YAK_OPS_PERMISSIONS.resource.create);
+  const canUpdate = can(YAK_OPS_PERMISSIONS.resource.update);
+  const canDelete = can(YAK_OPS_PERMISSIONS.resource.delete);
+  const canDownload = can(YAK_OPS_PERMISSIONS.resource.download);
+
+  const uploadInputRef = useRef<HTMLInputElement>(null);
+  const replaceInputRef = useRef<HTMLInputElement>(null);
+  const replacingResourceRef = useRef<ResourceItem>();
+  const listRequestSeqRef = useRef(0);
+
+  const [treeLoading, setTreeLoading] = useState(false);
+  const [listLoading, setListLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [uploading, setUploading] = useState(false);
+  const [resourceTree, setResourceTree] = useState<ResourceItem[]>([]);
+  const [resourceList, setResourceList] = useState<ResourceItem[]>([]);
+  const [storagePlugins, setStoragePlugins] = useState<
+    ResourceStoragePlugin[]
+  >([]);
+  const [selectedDirectoryId, setSelectedDirectoryId] =
+    useState<ResourceId>(ROOT_RESOURCE_ID);
+  const [keyword, setKeyword] = useState('');
+  const [debouncedKeyword, setDebouncedKeyword] = useState('');
+  const [refreshVersion, setRefreshVersion] = useState(0);
+  const [directoryModalOpen, setDirectoryModalOpen] = useState(false);
+  const [textModalOpen, setTextModalOpen] = useState(false);
+  const [metadataResource, setMetadataResource] = useState<ResourceItem>();
+  const [movingResource, setMovingResource] = useState<ResourceItem>();
+  const [detailResource, setDetailResource] = useState<ResourceItem>();
+
+  const loadTree = useCallback(async () => {
+    try {
+      setTreeLoading(true);
+      const response = await fetchResourceTree();
+      if (response.code !== API_SUCCESS_CODE) return;
+      setResourceTree(response.data || []);
+    } finally {
+      setTreeLoading(false);
+    }
+  }, []);
+
+  const loadPlugins = useCallback(async () => {
+    const response = await fetchStoragePlugins();
+    if (response.code !== API_SUCCESS_CODE) return;
+    setStoragePlugins(response.data || []);
+  }, []);
+
+  const loadList = useCallback(async () => {
+    const requestSeq = listRequestSeqRef.current + 1;
+    listRequestSeqRef.current = requestSeq;
+    try {
+      setListLoading(true);
+      const response = await fetchResourceList(
+        selectedDirectoryId,
+        debouncedKeyword || undefined,
+      );
+      if (
+        requestSeq !== listRequestSeqRef.current ||
+        response.code !== API_SUCCESS_CODE
+      ) {
+        return;
+      }
+      setResourceList(response.data || []);
+    } finally {
+      if (requestSeq === listRequestSeqRef.current) setListLoading(false);
+    }
+  }, [debouncedKeyword, selectedDirectoryId]);
+
+  useEffect(() => {
+    const timer = window.setTimeout(
+      () => setDebouncedKeyword(keyword.trim()),
+      keyword.trim() ? 250 : 0,
+    );
+    return () => window.clearTimeout(timer);
+  }, [keyword]);
+
+  useEffect(() => {
+    void loadPlugins();
+  }, [loadPlugins]);
+
+  useEffect(() => {
+    void loadTree();
+  }, [loadTree, refreshVersion]);
+
+  useEffect(() => {
+    void loadList();
+  }, [loadList, refreshVersion]);
+
+  const refresh = useCallback(() => {
+    setRefreshVersion((value) => value + 1);
+  }, []);
+
+  const selectedDirectory = useMemo(
+    () => findResource(resourceTree, selectedDirectoryId),
+    [resourceTree, selectedDirectoryId],
+  );
+  const selectedDirectoryName = selectedDirectory?.name || '全部资源';
+  const breadcrumbs = useMemo(
+    () => getResourceBreadcrumbs(resourceTree, selectedDirectoryId),
+    [resourceTree, selectedDirectoryId],
+  );
+  const summary = useMemo(
+    () => getResourceSummary(resourceTree),
+    [resourceTree],
+  );
+  const directoryTree = useMemo(
+    () => buildDirectoryTree(resourceTree),
+    [resourceTree],
+  );
+  const moveDirectoryTree = useMemo(
+    () => buildDirectoryTree(resourceTree, { movingResource }),
+    [movingResource, resourceTree],
+  );
+
+  const navigateToDirectory = (id: ResourceId) => {
+    setSelectedDirectoryId(id);
+    setKeyword('');
+  };
+
+  const openResource = (resource: ResourceItem) => {
+    if (isDirectory(resource)) {
+      navigateToDirectory(resource.id);
+      return;
+    }
+    setDetailResource(resource);
+  };
+
+  const handleCreateDirectory = async (values: DirectoryFormValues) => {
+    try {
+      setSaving(true);
+      const response = await createDirectory({
+        parentId: selectedDirectoryId,
+        ...values,
+      });
+      if (response.code !== API_SUCCESS_CODE) return;
+      message.success(response.message || '文件夹创建成功');
+      setDirectoryModalOpen(false);
+      refresh();
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleCreateTextResource = async (
+    values: TextResourceFormValues,
+  ) => {
+    try {
+      setSaving(true);
+      const response = await createTextResource({
+        parentId: selectedDirectoryId,
+        ...values,
+      });
+      if (response.code !== API_SUCCESS_CODE) return;
+      message.success(response.message || '文件创建成功');
+      setTextModalOpen(false);
+      refresh();
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleUpdateMetadata = async (
+    values: ResourceMetadataFormValues,
+  ) => {
+    if (!metadataResource) return;
+    try {
+      setSaving(true);
+      const response = await updateResource(metadataResource.id, values);
+      if (response.code !== API_SUCCESS_CODE) return;
+      message.success(response.message || '资源信息已更新');
+      setMetadataResource(undefined);
+      if (detailResource?.id === metadataResource.id) {
+        setDetailResource(response.data);
+      }
+      refresh();
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleMoveResource = async (values: MoveResourceFormValues) => {
+    if (!movingResource) return;
+    try {
+      setSaving(true);
+      const response = await moveResource(movingResource.id, values);
+      if (response.code !== API_SUCCESS_CODE) return;
+      message.success(response.message || '资源移动成功');
+      setMovingResource(undefined);
+      if (detailResource?.id === movingResource.id) {
+        setDetailResource(response.data);
+      }
+      refresh();
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDelete = (resource: ResourceItem) => {
+    if (!canDelete) return;
+    confirm({
+      title: `确认删除${isDirectory(resource) ? '文件夹' : '文件'}吗？`,
+      centered: true,
+      content: isDirectory(resource)
+        ? `文件夹“${resource.name}”及其全部子资源都会被递归删除，删除后无法恢复。`
+        : `文件“${resource.name}”删除后无法恢复。`,
+      okText: '删除',
+      cancelText: '取消',
+      okButtonProps: { danger: true },
+      async onOk() {
+        const response = await deleteResource(resource.id);
+        if (response.code !== API_SUCCESS_CODE) return;
+        message.success(response.message || '删除成功');
+        if (detailResource?.id === resource.id) setDetailResource(undefined);
+        refresh();
+      },
+    });
+  };
+
+  const handleDownload = async (resource: ResourceItem) => {
+    try {
+      await downloadResource(resource.id, resource.name);
+      message.success('下载任务已开始');
+    } catch (error) {
+      message.error(error instanceof Error ? error.message : '下载失败');
+    }
+  };
+
+  const handleUpload = async (file?: File) => {
+    if (!file) return;
+    try {
+      setUploading(true);
+      const response = await uploadResource(selectedDirectoryId, file);
+      if (response.code !== API_SUCCESS_CODE) return;
+      message.success(response.message || '文件上传成功');
+      refresh();
+    } finally {
+      setUploading(false);
+      if (uploadInputRef.current) uploadInputRef.current.value = '';
+    }
+  };
+
+  const requestReplaceFile = (resource: ResourceItem) => {
+    replacingResourceRef.current = resource;
+    replaceInputRef.current?.click();
+  };
+
+  const handleReplaceFile = async (file?: File) => {
+    const resource = replacingResourceRef.current;
+    if (!resource || !file) return;
+    try {
+      setUploading(true);
+      const response = await replaceResourceFile(resource.id, file);
+      if (response.code !== API_SUCCESS_CODE) return;
+      message.success(response.message || '文件替换成功');
+      if (detailResource?.id === resource.id) setDetailResource(response.data);
+      refresh();
+    } finally {
+      setUploading(false);
+      replacingResourceRef.current = undefined;
+      if (replaceInputRef.current) replaceInputRef.current.value = '';
+    }
+  };
+
+  const getActionItems = (resource: ResourceItem): MenuProps['items'] =>
+    [
+      {
+        key: 'open',
+        icon: isDirectory(resource) ? <Folder size={15} /> : <FileCode2 size={15} />,
+        label: isDirectory(resource) ? '打开文件夹' : '查看详情',
+      },
+      !isDirectory(resource) && canDownload
+        ? {
+            key: 'download',
+            icon: <Download size={15} />,
+            label: '下载文件',
+          }
+        : null,
+      canUpdate
+        ? {
+            key: 'edit',
+            icon: <Pencil size={15} />,
+            label: '编辑信息',
+          }
+        : null,
+      canUpdate && !isDirectory(resource)
+        ? {
+            key: 'replace',
+            icon: <Upload size={15} />,
+            label: '替换文件',
+          }
+        : null,
+      canUpdate
+        ? {
+            key: 'move',
+            icon: <MoveRight size={15} />,
+            label: '移动到',
+          }
+        : null,
+      canDelete ? { type: 'divider' as const } : null,
+      canDelete
+        ? {
+            key: 'delete',
+            danger: true,
+            icon: <Trash2 size={15} />,
+            label: '删除',
+          }
+        : null,
+    ].filter(Boolean) as MenuProps['items'];
+
+  const handleAction = (resource: ResourceItem, key: string) => {
+    switch (key) {
+      case 'open':
+        openResource(resource);
+        break;
+      case 'download':
+        void handleDownload(resource);
+        break;
+      case 'edit':
+        setMetadataResource(resource);
+        break;
+      case 'replace':
+        requestReplaceFile(resource);
+        break;
+      case 'move':
+        setMovingResource(resource);
+        break;
+      case 'delete':
+        handleDelete(resource);
+        break;
+      default:
+        break;
+    }
+  };
+
+  const columns: TableColumnsType<ResourceItem> = [
+    {
+      title: '名称',
+      dataIndex: 'name',
+      key: 'name',
+      width: 320,
+      render: (_, resource) => (
+        <button
+          type="button"
+          className="resource-name-cell"
+          onClick={() => openResource(resource)}
+        >
+          <span
+            className={[
+              'resource-name-cell__icon',
+              isDirectory(resource) ? 'is-directory' : 'is-file',
+            ].join(' ')}
+          >
+            {isDirectory(resource) ? <Folder size={19} /> : <File size={19} />}
+          </span>
+          <span className="resource-name-cell__text">
+            <strong title={resource.name}>{resource.name}</strong>
+            <small title={resource.description || resource.fullPath}>
+              {resource.description || resource.fullPath}
+            </small>
+          </span>
+        </button>
+      ),
+    },
+    {
+      title: '类型',
+      dataIndex: 'nodeType',
+      key: 'nodeType',
+      width: 110,
+      render: (_, resource) =>
+        isDirectory(resource) ? (
+          <Tag bordered={false}>文件夹</Tag>
+        ) : (
+          <Tag bordered={false}>{resource.suffix?.toUpperCase() || 'FILE'}</Tag>
+        ),
+    },
+    {
+      title: '大小',
+      dataIndex: 'fileSize',
+      key: 'fileSize',
+      width: 120,
+      render: (_, resource) =>
+        isDirectory(resource) ? '-' : formatFileSize(resource.fileSize),
+    },
+    {
+      title: '存储',
+      dataIndex: 'storageType',
+      key: 'storageType',
+      width: 120,
+      render: (value) => (
+        <span className="resource-storage-cell">
+          <Cloud size={14} />
+          {String(value || '-')}
+        </span>
+      ),
+    },
+    {
+      title: '版本',
+      dataIndex: 'version',
+      key: 'version',
+      width: 90,
+      render: (value, resource) => (isDirectory(resource) ? '-' : `v${value || 1}`),
+    },
+    {
+      title: '更新时间',
+      dataIndex: 'updateTime',
+      key: 'updateTime',
+      width: 180,
+      render: (value) =>
+        value ? dayjs(String(value)).format('YYYY-MM-DD HH:mm:ss') : '-',
+    },
+    {
+      title: '',
+      key: 'actions',
+      fixed: 'right',
+      width: 60,
+      align: 'center',
+      render: (_, resource) => (
+        <Dropdown
+          trigger={['click']}
+          menu={{
+            items: getActionItems(resource),
+            onClick: ({ key, domEvent }) => {
+              domEvent.stopPropagation();
+              handleAction(resource, key);
+            },
+          }}
+        >
+          <Button
+            type="text"
+            size="small"
+            aria-label={`操作 ${resource.name}`}
+            icon={<MoreHorizontal size={17} />}
+            onClick={(event) => event.stopPropagation()}
+          />
+        </Dropdown>
+      ),
+    },
+  ];
+
+  const breadcrumbItems = [
+    {
+      title: (
+        <button
+          type="button"
+          className="resource-breadcrumb-button"
+          onClick={() => navigateToDirectory(ROOT_RESOURCE_ID)}
+        >
+          全部资源
+        </button>
+      ),
+    },
+    ...breadcrumbs.map((resource) => ({
+      title: (
+        <button
+          type="button"
+          className="resource-breadcrumb-button"
+          onClick={() => navigateToDirectory(resource.id)}
+        >
+          {resource.name}
+        </button>
+      ),
+    })),
+  ];
+
+  return (
+    <div className="resource-page">
+      <header className="resource-header">
+        <div>
+          <h1>资源管理</h1>
+          <p>统一管理任务脚本、配置文件与运行资源，底层支持 MinIO 和 HDFS。</p>
+        </div>
+        <Space size={10} wrap>
+          {canCreate && (
+            <Button
+              icon={<FolderPlus size={16} />}
+              onClick={() => setDirectoryModalOpen(true)}
+            >
+              新建文件夹
+            </Button>
+          )}
+          {canCreate && (
+            <Button
+              icon={<FilePlus2 size={16} />}
+              onClick={() => setTextModalOpen(true)}
+            >
+              在线创建
+            </Button>
+          )}
+          {canCreate && (
+            <Button
+              type="primary"
+              loading={uploading}
+              icon={<Upload size={16} />}
+              onClick={() => uploadInputRef.current?.click()}
+            >
+              上传文件
+            </Button>
+          )}
+        </Space>
+      </header>
+
+      <section className="resource-overview">
+        <div className="resource-overview-card">
+          <span><Files size={20} /></span>
+          <div><small>文件数量</small><strong>{summary.files}</strong></div>
+        </div>
+        <div className="resource-overview-card">
+          <span><FolderTree size={20} /></span>
+          <div><small>文件夹</small><strong>{summary.directories}</strong></div>
+        </div>
+        <div className="resource-overview-card">
+          <span><HardDrive size={20} /></span>
+          <div><small>资源容量</small><strong>{formatFileSize(summary.totalBytes)}</strong></div>
+        </div>
+        <div className="resource-overview-card resource-overview-card--plugins">
+          <span><Database size={20} /></span>
+          <div>
+            <small>存储插件</small>
+            <div className="resource-plugin-list">
+              {storagePlugins.length ? (
+                storagePlugins.map((plugin) => (
+                  <Tag
+                    key={plugin.type}
+                    bordered={false}
+                    className={plugin.active ? 'is-active' : ''}
+                  >
+                    {plugin.name || plugin.type}
+                    {plugin.active ? ' · 当前' : ''}
+                  </Tag>
+                ))
+              ) : (
+                <strong>-</strong>
+              )}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="resource-workbench">
+        <aside className="resource-tree-panel">
+          <div className="resource-tree-panel__header">
+            <div>
+              <FolderTree size={17} />
+              <strong>目录</strong>
+            </div>
+            <Tooltip title="刷新目录">
+              <Button
+                type="text"
+                size="small"
+                disabled={treeLoading}
+                icon={
+                  <RefreshCw
+                    size={15}
+                    className={treeLoading ? 'is-spinning' : ''}
+                  />
+                }
+                onClick={refresh}
+              />
+            </Tooltip>
+          </div>
+          <Spin spinning={treeLoading}>
+            <Tree
+              className="resource-directory-tree"
+              treeData={directoryTree}
+              selectedKeys={[resourceKey(selectedDirectoryId)]}
+              defaultExpandAll
+              blockNode
+              showLine={{ showLeafIcon: false }}
+              onSelect={(keys) => {
+                const selectedKey = keys[0];
+                if (selectedKey === undefined) return;
+                const resource = findResource(resourceTree, String(selectedKey));
+                navigateToDirectory(resource?.id ?? ROOT_RESOURCE_ID);
+              }}
+            />
+          </Spin>
+        </aside>
+
+        <main className="resource-list-panel">
+          <div className="resource-list-toolbar">
+            <div>
+              <Breadcrumb items={breadcrumbItems} />
+              <span className="resource-list-toolbar__count">
+                {resourceList.length} 项
+              </span>
+            </div>
+            <Space size={8}>
+              <Input
+                className="resource-search"
+                allowClear
+                prefix={<Search size={15} />}
+                value={keyword}
+                placeholder="搜索当前目录"
+                onChange={(event) => setKeyword(event.target.value)}
+              />
+              <Tooltip title="刷新列表">
+                <Button
+                  icon={
+                    <RefreshCw
+                      size={15}
+                      className={listLoading ? 'is-spinning' : ''}
+                    />
+                  }
+                  disabled={listLoading}
+                  onClick={refresh}
+                />
+              </Tooltip>
+            </Space>
+          </div>
+
+          <Spin spinning={listLoading}>
+            <Table<ResourceItem>
+              className="resource-table"
+              rowKey={(record) => resourceKey(record.id)}
+              columns={columns}
+              dataSource={resourceList}
+              pagination={false}
+              scroll={{ x: 1080 }}
+              locale={{
+                emptyText: (
+                  <Empty
+                    image={Empty.PRESENTED_IMAGE_SIMPLE}
+                    description={
+                      debouncedKeyword
+                        ? '当前目录没有匹配的资源'
+                        : '当前文件夹为空'
+                    }
+                  >
+                    {canCreate && !debouncedKeyword && (
+                      <Button
+                        type="primary"
+                        icon={<Upload size={15} />}
+                        onClick={() => uploadInputRef.current?.click()}
+                      >
+                        上传第一个文件
+                      </Button>
+                    )}
+                  </Empty>
+                ),
+              }}
+              onRow={(resource) => ({
+                onDoubleClick: () => openResource(resource),
+              })}
+            />
+          </Spin>
+        </main>
+      </section>
+
+      <input
+        ref={uploadInputRef}
+        hidden
+        type="file"
+        onChange={(event) => void handleUpload(event.target.files?.[0])}
+      />
+      <input
+        ref={replaceInputRef}
+        hidden
+        type="file"
+        onChange={(event) => void handleReplaceFile(event.target.files?.[0])}
+      />
+
+      <CreateDirectoryModal
+        open={directoryModalOpen}
+        parentName={selectedDirectoryName}
+        saving={saving}
+        onCancel={() => setDirectoryModalOpen(false)}
+        onSubmit={handleCreateDirectory}
+      />
+      <CreateTextResourceModal
+        open={textModalOpen}
+        parentName={selectedDirectoryName}
+        saving={saving}
+        onCancel={() => setTextModalOpen(false)}
+        onSubmit={handleCreateTextResource}
+      />
+      <ResourceMetadataModal
+        open={Boolean(metadataResource)}
+        resource={metadataResource}
+        saving={saving}
+        onCancel={() => setMetadataResource(undefined)}
+        onSubmit={handleUpdateMetadata}
+      />
+      <MoveResourceModal
+        open={Boolean(movingResource)}
+        resource={movingResource}
+        directories={moveDirectoryTree}
+        saving={saving}
+        onCancel={() => setMovingResource(undefined)}
+        onSubmit={handleMoveResource}
+      />
+      <ResourceDetailDrawer
+        open={Boolean(detailResource)}
+        resource={detailResource}
+        canUpdate={canUpdate}
+        canDownload={canDownload}
+        onClose={() => setDetailResource(undefined)}
+        onDownload={handleDownload}
+        onReplace={requestReplaceFile}
+        onSaved={refresh}
+      />
+    </div>
+  );
+};
+
+export default ResourceManagementPage;

--- a/yak-ops-ui/src/pages/resource-management/service.ts
+++ b/yak-ops-ui/src/pages/resource-management/service.ts
@@ -1,0 +1,191 @@
+import HttpUtils, { type ApiResponse } from '@/utils/HttpUtils';
+import request from '@/utils/request';
+
+import type {
+  CreateDirectoryPayload,
+  CreateTextResourcePayload,
+  MoveResourcePayload,
+  ResourceContent,
+  ResourceId,
+  ResourceItem,
+  ResourcePageResult,
+  ResourceQueryParams,
+  ResourceStoragePlugin,
+  UpdateResourcePayload,
+} from './types';
+
+const RESOURCE_API_PREFIX = '/api/v1/resources';
+
+const queryString = (params: Record<string, unknown>) => {
+  const search = new URLSearchParams();
+  Object.entries(params).forEach(([key, value]) => {
+    if (value !== undefined && value !== null && String(value).length > 0) {
+      search.set(key, String(value));
+    }
+  });
+  const result = search.toString();
+  return result ? `?${result}` : '';
+};
+
+export async function fetchResourceTree(): Promise<ApiResponse<ResourceItem[]>> {
+  return HttpUtils.get<ResourceItem[]>(`${RESOURCE_API_PREFIX}/tree`);
+}
+
+export async function fetchResourceList(
+  parentId: ResourceId = 0,
+  keyword?: string,
+): Promise<ApiResponse<ResourceItem[]>> {
+  return HttpUtils.get<ResourceItem[]>(
+    `${RESOURCE_API_PREFIX}/list${queryString({ parentId, keyword })}`,
+  );
+}
+
+export async function fetchResourcePage(
+  params: ResourceQueryParams,
+): Promise<ApiResponse<ResourcePageResult>> {
+  return HttpUtils.post<ResourcePageResult>(
+    `${RESOURCE_API_PREFIX}/page`,
+    params,
+  );
+}
+
+export async function fetchResourceDetail(
+  id: ResourceId,
+): Promise<ApiResponse<ResourceItem>> {
+  return HttpUtils.get<ResourceItem>(`${RESOURCE_API_PREFIX}/${id}`);
+}
+
+export async function fetchResourceContent(
+  id: ResourceId,
+  skipLineNum = 0,
+  limit = 2000,
+): Promise<ApiResponse<ResourceContent>> {
+  return HttpUtils.get<ResourceContent>(
+    `${RESOURCE_API_PREFIX}/${id}/content${queryString({
+      skipLineNum,
+      limit,
+    })}`,
+  );
+}
+
+export async function fetchStoragePlugins(): Promise<
+  ApiResponse<ResourceStoragePlugin[]>
+> {
+  return HttpUtils.get<ResourceStoragePlugin[]>(
+    `${RESOURCE_API_PREFIX}/storage-plugins`,
+  );
+}
+
+export async function createDirectory(
+  payload: CreateDirectoryPayload,
+): Promise<ApiResponse<ResourceItem>> {
+  return HttpUtils.post<ResourceItem>(
+    `${RESOURCE_API_PREFIX}/directory`,
+    payload,
+  );
+}
+
+export async function createTextResource(
+  payload: CreateTextResourcePayload,
+): Promise<ApiResponse<ResourceItem>> {
+  return HttpUtils.post<ResourceItem>(
+    `${RESOURCE_API_PREFIX}/online-create`,
+    payload,
+  );
+}
+
+export async function uploadResource(
+  parentId: ResourceId,
+  file: File,
+  options?: { name?: string; description?: string },
+): Promise<ApiResponse<ResourceItem>> {
+  const formData = new FormData();
+  formData.append('parentId', String(parentId));
+  formData.append('file', file);
+  if (options?.name) formData.append('name', options.name);
+  if (options?.description) {
+    formData.append('description', options.description);
+  }
+  return HttpUtils.postForm<ResourceItem>(RESOURCE_API_PREFIX, formData);
+}
+
+export async function updateResource(
+  id: ResourceId,
+  payload: UpdateResourcePayload,
+): Promise<ApiResponse<ResourceItem>> {
+  return HttpUtils.put<ResourceItem>(`${RESOURCE_API_PREFIX}/${id}`, payload);
+}
+
+export async function replaceResourceFile(
+  id: ResourceId,
+  file: File,
+): Promise<ApiResponse<ResourceItem>> {
+  const formData = new FormData();
+  formData.append('file', file);
+  return request<ApiResponse<ResourceItem>>(
+    `${RESOURCE_API_PREFIX}/${id}/file`,
+    {
+      method: 'PUT',
+      data: formData,
+      businessErrorMode: 'resolve',
+    },
+  );
+}
+
+export async function updateResourceContent(
+  id: ResourceId,
+  content: string,
+): Promise<ApiResponse<ResourceContent>> {
+  return HttpUtils.put<ResourceContent>(
+    `${RESOURCE_API_PREFIX}/${id}/content`,
+    { content },
+  );
+}
+
+export async function moveResource(
+  id: ResourceId,
+  payload: MoveResourcePayload,
+): Promise<ApiResponse<ResourceItem>> {
+  return HttpUtils.post<ResourceItem>(
+    `${RESOURCE_API_PREFIX}/${id}/move`,
+    payload,
+  );
+}
+
+export async function deleteResource(
+  id: ResourceId,
+): Promise<ApiResponse<boolean>> {
+  return HttpUtils.delete<boolean>(`${RESOURCE_API_PREFIX}/${id}`);
+}
+
+const readDownloadName = (value?: string | null) => {
+  if (!value) return undefined;
+  const utf8Match = value.match(/filename\*=UTF-8''([^;]+)/i);
+  if (utf8Match?.[1]) return decodeURIComponent(utf8Match[1]);
+  const basicMatch = value.match(/filename="?([^";]+)"?/i);
+  return basicMatch?.[1];
+};
+
+export async function downloadResource(
+  id: ResourceId,
+  fallbackName: string,
+): Promise<void> {
+  const result = await HttpUtils.download(
+    `${RESOURCE_API_PREFIX}/${id}/download`,
+  );
+  const blob = result?.data instanceof Blob ? result.data : result;
+  if (!(blob instanceof Blob)) {
+    throw new Error('下载响应不是有效文件');
+  }
+
+  const disposition = result?.response?.headers?.get?.('content-disposition');
+  const fileName = readDownloadName(disposition) || fallbackName;
+  const objectUrl = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = objectUrl;
+  link.download = fileName;
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(objectUrl);
+}

--- a/yak-ops-ui/src/pages/resource-management/types.ts
+++ b/yak-ops-ui/src/pages/resource-management/types.ts
@@ -1,0 +1,108 @@
+export type ResourceId = number | string;
+export type ResourceNodeType = 'DIRECTORY' | 'FILE';
+export type ResourceStorageType = 'MINIO' | 'HDFS' | string;
+
+export interface CommonApiResponse<T> {
+  code: number;
+  data: T;
+  msg?: string;
+  message?: string;
+}
+
+export interface PaginationInfo {
+  pageNo: number;
+  pageSize: number;
+  total: number;
+  pages?: number;
+}
+
+export interface ResourceItem {
+  id: ResourceId;
+  parentId: ResourceId;
+  name: string;
+  fullPath: string;
+  nodeType: ResourceNodeType;
+  storageType: ResourceStorageType;
+  contentType?: string;
+  suffix?: string;
+  fileSize?: number;
+  checksum?: string;
+  description?: string;
+  version?: number;
+  gitSyncStatus?: string;
+  createTime?: string;
+  updateTime?: string;
+  children?: ResourceItem[];
+}
+
+export interface ResourceContent {
+  resourceId: ResourceId;
+  fullPath: string;
+  content: string;
+  skipLineNum: number;
+  lineCount: number;
+  hasMore: boolean;
+}
+
+export interface ResourceStoragePlugin {
+  type: ResourceStorageType;
+  name: string;
+  active: boolean;
+}
+
+export interface ResourcePageResult {
+  bizData: ResourceItem[];
+  pagination: PaginationInfo;
+}
+
+export interface ResourceQueryParams {
+  pageNo?: number;
+  pageSize?: number;
+  parentId?: ResourceId;
+  keyword?: string;
+  nodeType?: ResourceNodeType;
+}
+
+export interface CreateDirectoryPayload {
+  parentId: ResourceId;
+  name: string;
+  description?: string;
+}
+
+export interface CreateTextResourcePayload {
+  parentId: ResourceId;
+  name: string;
+  content: string;
+  contentType?: string;
+  description?: string;
+}
+
+export interface UpdateResourcePayload {
+  name: string;
+  description?: string;
+}
+
+export interface MoveResourcePayload {
+  targetParentId: ResourceId;
+}
+
+export interface DirectoryFormValues {
+  name: string;
+  description?: string;
+}
+
+export interface TextResourceFormValues {
+  name: string;
+  content: string;
+  contentType?: string;
+  description?: string;
+}
+
+export interface ResourceMetadataFormValues {
+  name: string;
+  description?: string;
+}
+
+export interface MoveResourceFormValues {
+  targetParentId: ResourceId;
+}

--- a/yak-ops-ui/src/pages/resource-management/utils.test.ts
+++ b/yak-ops-ui/src/pages/resource-management/utils.test.ts
@@ -1,0 +1,83 @@
+import type { ResourceItem } from './types';
+import {
+  buildDirectoryTree,
+  formatFileSize,
+  getResourceBreadcrumbs,
+  getResourceSummary,
+  isEditableResource,
+} from './utils';
+
+const tree: ResourceItem[] = [
+  {
+    id: 1,
+    parentId: 0,
+    name: 'scripts',
+    fullPath: '/scripts',
+    nodeType: 'DIRECTORY',
+    storageType: 'MINIO',
+    children: [
+      {
+        id: 2,
+        parentId: 1,
+        name: 'daily',
+        fullPath: '/scripts/daily',
+        nodeType: 'DIRECTORY',
+        storageType: 'MINIO',
+        children: [
+          {
+            id: 3,
+            parentId: 2,
+            name: 'sync.sql',
+            fullPath: '/scripts/daily/sync.sql',
+            nodeType: 'FILE',
+            storageType: 'MINIO',
+            suffix: 'sql',
+            fileSize: 2048,
+          },
+        ],
+      },
+    ],
+  },
+];
+
+describe('resource management utils', () => {
+  it('formats resource file sizes', () => {
+    expect(formatFileSize(0)).toBe('0 B');
+    expect(formatFileSize(1024)).toBe('1.00 KB');
+    expect(formatFileSize(10 * 1024)).toBe('10.0 KB');
+  });
+
+  it('builds directory breadcrumbs', () => {
+    expect(getResourceBreadcrumbs(tree, 2).map((item) => item.name)).toEqual([
+      'scripts',
+      'daily',
+    ]);
+  });
+
+  it('matches the backend editable suffix allowlist', () => {
+    expect(isEditableResource(tree[0].children?.[0].children?.[0])).toBe(true);
+    expect(
+      isEditableResource({
+        ...tree[0].children?.[0].children?.[0],
+        id: 4,
+        name: 'archive.zip',
+        suffix: 'zip',
+      } as ResourceItem),
+    ).toBe(false);
+  });
+
+  it('summarizes directories, files and capacity', () => {
+    expect(getResourceSummary(tree)).toEqual({
+      directories: 2,
+      files: 1,
+      totalBytes: 2048,
+    });
+  });
+
+  it('disables a moving directory and its descendants', () => {
+    const directories = buildDirectoryTree(tree, { movingResource: tree[0] });
+    expect(directories[0].disabled).toBeFalsy();
+    expect(directories[0].children?.[0].disabled).toBe(true);
+    expect(directories[0].children?.[0].children?.[0].disabled).toBe(true);
+  });
+});

--- a/yak-ops-ui/src/pages/resource-management/utils.ts
+++ b/yak-ops-ui/src/pages/resource-management/utils.ts
@@ -1,0 +1,148 @@
+import type { ResourceId, ResourceItem } from './types';
+
+export const ROOT_RESOURCE_ID = 0;
+
+export const EDITABLE_SUFFIXES = new Set([
+  'txt',
+  'log',
+  'sql',
+  'json',
+  'xml',
+  'yaml',
+  'yml',
+  'conf',
+  'properties',
+  'sh',
+  'py',
+  'java',
+  'js',
+  'ts',
+  'tsx',
+  'md',
+  'csv',
+  'hocon',
+]);
+
+export const resourceKey = (id?: ResourceId) => String(id ?? '');
+
+export const isDirectory = (resource?: ResourceItem | null) =>
+  resource?.nodeType === 'DIRECTORY';
+
+export const isEditableResource = (resource?: ResourceItem | null) => {
+  if (!resource || resource.nodeType !== 'FILE') return false;
+  return EDITABLE_SUFFIXES.has(String(resource.suffix || '').toLowerCase());
+};
+
+export const formatFileSize = (bytes?: number) => {
+  const value = Number(bytes || 0);
+  if (value <= 0) return '0 B';
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  const unitIndex = Math.min(
+    Math.floor(Math.log(value) / Math.log(1024)),
+    units.length - 1,
+  );
+  const normalized = value / 1024 ** unitIndex;
+  const precision = normalized >= 100 || unitIndex === 0 ? 0 : normalized >= 10 ? 1 : 2;
+  return `${normalized.toFixed(precision)} ${units[unitIndex]}`;
+};
+
+export const flattenResources = (resources: ResourceItem[]) => {
+  const result: ResourceItem[] = [];
+  const visit = (items: ResourceItem[]) => {
+    items.forEach((item) => {
+      result.push(item);
+      if (item.children?.length) visit(item.children);
+    });
+  };
+  visit(resources);
+  return result;
+};
+
+export const findResource = (
+  resources: ResourceItem[],
+  id: ResourceId,
+): ResourceItem | undefined =>
+  flattenResources(resources).find((item) => resourceKey(item.id) === resourceKey(id));
+
+export const getResourceBreadcrumbs = (
+  resources: ResourceItem[],
+  id: ResourceId,
+): ResourceItem[] => {
+  if (resourceKey(id) === resourceKey(ROOT_RESOURCE_ID)) return [];
+  const flattened = flattenResources(resources);
+  const byId = new Map(flattened.map((item) => [resourceKey(item.id), item]));
+  const breadcrumbs: ResourceItem[] = [];
+  const visited = new Set<string>();
+  let current = byId.get(resourceKey(id));
+
+  while (current && !visited.has(resourceKey(current.id))) {
+    visited.add(resourceKey(current.id));
+    breadcrumbs.unshift(current);
+    if (resourceKey(current.parentId) === resourceKey(ROOT_RESOURCE_ID)) break;
+    current = byId.get(resourceKey(current.parentId));
+  }
+
+  return breadcrumbs;
+};
+
+export interface DirectoryTreeNode {
+  key: string;
+  title: string;
+  value: ResourceId;
+  resource?: ResourceItem;
+  children?: DirectoryTreeNode[];
+  disabled?: boolean;
+  selectable?: boolean;
+}
+
+const hasResourceInSubtree = (resource: ResourceItem, targetId: ResourceId) => {
+  if (resourceKey(resource.id) === resourceKey(targetId)) return true;
+  return Boolean(
+    resource.children?.some((child) => hasResourceInSubtree(child, targetId)),
+  );
+};
+
+export const buildDirectoryTree = (
+  resources: ResourceItem[],
+  options?: { movingResource?: ResourceItem },
+): DirectoryTreeNode[] => {
+  const movingResource = options?.movingResource;
+  const build = (items: ResourceItem[]): DirectoryTreeNode[] =>
+    items
+      .filter(isDirectory)
+      .map((item) => ({
+        key: resourceKey(item.id),
+        title: item.name,
+        value: item.id,
+        resource: item,
+        disabled: movingResource
+          ? hasResourceInSubtree(movingResource, item.id)
+          : false,
+        children: build(item.children || []),
+      }));
+
+  return [
+    {
+      key: resourceKey(ROOT_RESOURCE_ID),
+      title: '全部资源',
+      value: ROOT_RESOURCE_ID,
+      children: build(resources),
+    },
+  ];
+};
+
+export const getResourceSummary = (resources: ResourceItem[]) => {
+  const flattened = flattenResources(resources);
+  return flattened.reduce(
+    (summary, item) => {
+      if (isDirectory(item)) {
+        summary.directories += 1;
+      } else {
+        summary.files += 1;
+        summary.totalBytes += Number(item.fileSize || 0);
+      }
+      return summary;
+    },
+    { directories: 0, files: 0, totalBytes: 0 },
+  );
+};


### PR DESCRIPTION
## Summary

- 新增资源管理前端工作台：左侧目录树、右侧文件列表、面包屑导航与存储概览
- 对接资源后端全部核心接口：目录创建、文件上传、在线创建、详情、搜索、移动、重命名、替换、内容预览/编辑、下载和递归删除
- 按 `resource:view`、`resource:upload`、`resource:update`、`resource:delete`、`resource:download` 控制页面入口与按钮操作
- 增加文件大小、面包屑、目录树、可编辑后缀与容量统计工具测试
- 修复已合并 V1 迁移中的 `full_path VARCHAR(1024)` 超长唯一索引，避免 utf8mb4 下超过 InnoDB 3072 字节索引限制

## UI and interactions

- 资源总览：文件数量、文件夹数量、资源容量、已安装存储插件
- 目录浏览：完整目录树、当前目录搜索、面包屑跳转、双击进入文件夹
- 文件管理：上传、新建文本文件、编辑元信息、移动、替换、下载、删除
- 内容管理：支持后端允许的文本后缀在线预览与编辑；超过 2000 行时显示覆盖风险提示
- 响应式布局：窄屏下目录树与资源列表纵向排列

## API integration

Base path: `/api/v1/resources`

- `GET /tree`
- `GET /list`
- `GET /storage-plugins`
- `POST /directory`
- `POST /online-create`
- `POST /` multipart upload
- `PUT /{id}`
- `PUT /{id}/file` multipart replace
- `GET /{id}/content`
- `PUT /{id}/content`
- `POST /{id}/move`
- `DELETE /{id}`
- `GET /{id}/download`

## Validation

- TypeScript/TSX parser validation passed for all new source files
- Isolated `tsc --noEmit` validation with dependency stubs passed
- Resource utility runtime assertions passed
- Navigation, permissions and migration files passed syntax/format checks

A full `npm build` was not run in this execution environment because the repository checkout and installed frontend dependencies were unavailable; the PR remains Draft for local integration verification.