### PR TITLE
style(offline-sync): apply brand color to create drawer

### DIFF
--- a/yak-ops-ui/src/pages/batch-link-up/components/CreateSyncTaskModal.tsx
+++ b/yak-ops-ui/src/pages/batch-link-up/components/CreateSyncTaskModal.tsx
@@ -4,6 +4,7 @@ import {
 } from '@ant-design/icons';
 import {
   Button,
+  ConfigProvider,
   Drawer,
   Form,
   Input,
@@ -28,6 +29,14 @@ interface CreateSyncTaskDrawerProps {
   onCancel: () => void;
   onCreated: (taskId: string) => void;
 }
+
+const BRAND_COLOR = 'rgba(254,44,85,1)';
+const BRAND_COLOR_HOVER = 'rgba(254,44,85,0.88)';
+const BRAND_COLOR_ACTIVE = 'rgba(226,25,70,1)';
+const BRAND_COLOR_SOFT = 'rgba(254,44,85,0.06)';
+const BRAND_COLOR_SOFT_HOVER = 'rgba(254,44,85,0.1)';
+const BRAND_COLOR_BORDER = 'rgba(254,44,85,0.35)';
+const BRAND_COLOR_OUTLINE = 'rgba(254,44,85,0.16)';
 
 const modeOptions: Array<{
   value: SyncMode;
@@ -121,159 +130,173 @@ export default function CreateSyncTaskDrawer({
   };
 
   return (
-    <Drawer
-      open={open}
-      width={620}
-      placement="right"
-      destroyOnClose
-      maskClosable={false}
-      keyboard={!submitting}
-      onClose={handleCancel}
-      title={
-        <div>
-          <div className="text-[18px] font-semibold text-[#101828]">
-            新建离线同步任务
-          </div>
-
-          <div className="mt-1 text-[13px] font-normal text-[#667085]">
-            填写任务基础信息，创建后可在任务列表中继续配置。
-          </div>
-        </div>
-      }
-      styles={{
-        header: {
-          padding: '20px 24px',
-          borderBottom: '1px solid #eaecf0',
-        },
-        body: {
-          padding: '24px',
-        },
-        footer: {
-          padding: '16px 24px',
-          borderTop: '1px solid #eaecf0',
+    <ConfigProvider
+      theme={{
+        token: {
+          colorPrimary: BRAND_COLOR,
+          colorPrimaryHover: BRAND_COLOR_HOVER,
+          colorPrimaryActive: BRAND_COLOR_ACTIVE,
+          colorPrimaryBg: BRAND_COLOR_SOFT,
+          colorPrimaryBgHover: BRAND_COLOR_SOFT_HOVER,
+          colorPrimaryBorder: BRAND_COLOR_BORDER,
+          controlOutline: BRAND_COLOR_OUTLINE,
         },
       }}
-      footer={
-        <div className="flex items-center justify-end gap-3">
-          <Button
-            disabled={submitting}
-            onClick={handleCancel}
-          >
-            取消
-          </Button>
-
-          <Button
-            type="primary"
-            danger
-            loading={submitting}
-            onClick={handleSubmit}
-            className="!border-[#ef4444] !bg-[#ef4444] !text-white hover:!border-[#dc2626] hover:!bg-[#dc2626]"
-          >
-            创建
-          </Button>
-        </div>
-      }
     >
-      <Form<CreateSyncTaskValues>
-        form={form}
-        layout="vertical"
-        requiredMark="optional"
+      <Drawer
+        open={open}
+        width={620}
+        placement="right"
+        destroyOnClose
+        maskClosable={false}
+        keyboard={!submitting}
+        onClose={handleCancel}
+        title={
+          <div>
+            <div className="text-[18px] font-semibold text-[#101828]">
+              新建离线同步任务
+            </div>
+
+            <div className="mt-1 text-[13px] font-normal text-[#667085]">
+              填写任务基础信息，创建后可在任务列表中继续配置。
+            </div>
+          </div>
+        }
+        styles={{
+          header: {
+            padding: '20px 24px',
+            borderBottom: '1px solid #eaecf0',
+          },
+          body: {
+            padding: '24px',
+          },
+          footer: {
+            padding: '16px 24px',
+            borderTop: '1px solid #eaecf0',
+          },
+        }}
+        footer={
+          <div className="flex items-center justify-end gap-3">
+            <Button
+              disabled={submitting}
+              onClick={handleCancel}
+            >
+              取消
+            </Button>
+
+            <Button
+              type="primary"
+              loading={submitting}
+              onClick={handleSubmit}
+              className="!border-[rgba(254,44,85,1)] !bg-[rgba(254,44,85,1)] !text-white hover:!border-[rgba(254,44,85,0.88)] hover:!bg-[rgba(254,44,85,0.88)] active:!border-[rgba(226,25,70,1)] active:!bg-[rgba(226,25,70,1)]"
+            >
+              创建
+            </Button>
+          </div>
+        }
       >
-        <Form.Item
-          name="jobName"
-          label="任务名称"
-          rules={[
-            {
-              required: true,
-              message: '请输入任务名称',
-            },
-            {
-              max: 64,
-              message: '任务名称不能超过 64 个字符',
-            },
-            {
-              validator: (_, value) =>
-                value?.trim()
-                  ? Promise.resolve()
-                  : Promise.reject(new Error('任务名称不能为空')),
-            },
-          ]}
+        <Form<CreateSyncTaskValues>
+          form={form}
+          layout="vertical"
+          requiredMark="optional"
         >
-          <Input
-            autoFocus
-            maxLength={64}
-            showCount
-            placeholder="例如：订单数据每日同步"
-          />
-        </Form.Item>
+          <Form.Item
+            name="jobName"
+            label="任务名称"
+            rules={[
+              {
+                required: true,
+                message: '请输入任务名称',
+              },
+              {
+                max: 64,
+                message: '任务名称不能超过 64 个字符',
+              },
+              {
+                validator: (_, value) =>
+                  value?.trim()
+                    ? Promise.resolve()
+                    : Promise.reject(new Error('任务名称不能为空')),
+              },
+            ]}
+          >
+            <Input
+              autoFocus
+              maxLength={64}
+              showCount
+              placeholder="例如：订单数据每日同步"
+            />
+          </Form.Item>
 
-        <Form.Item
-          name="jobDesc"
-          label="任务描述"
-          rules={[
-            {
-              max: 200,
-              message: '任务描述不能超过 200 个字符',
-            },
-          ]}
-        >
-          <Input.TextArea
-            rows={4}
-            maxLength={200}
-            showCount
-            placeholder="说明数据范围、用途或维护责任人"
-          />
-        </Form.Item>
+          <Form.Item
+            name="jobDesc"
+            label="任务描述"
+            rules={[
+              {
+                max: 200,
+                message: '任务描述不能超过 200 个字符',
+              },
+            ]}
+          >
+            <Input.TextArea
+              rows={4}
+              maxLength={200}
+              showCount
+              placeholder="说明数据范围、用途或维护责任人"
+            />
+          </Form.Item>
 
-        <Form.Item
-          name="mode"
-          label="同步类型"
-          rules={[
-            {
-              required: true,
-              message: '请选择同步类型',
-            },
-          ]}
-        >
-          <Radio.Group className="grid w-full grid-cols-2 gap-3">
-            {modeOptions.map((option) => (
-              <Radio.Button
-                key={option.value}
-                value={option.value}
-                className={[
-                  '!h-auto',
-                  '!rounded-lg',
-                  '!border',
-                  '!border-[#e4e7ec]',
-                  '!px-4',
-                  '!py-4',
-                  '!shadow-none',
-                  '[&.ant-radio-button-wrapper-checked]:!border-[#315efb]',
-                  '[&.ant-radio-button-wrapper-checked]:!bg-[#f5f7ff]',
-                  '[&.ant-radio-button-wrapper-checked]:!text-inherit',
-                  'before:!hidden',
-                ].join(' ')}
-              >
-                <div className="flex items-start gap-3 whitespace-normal">
-                  <div className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-[#eef2ff] text-[17px] text-[#315efb]">
-                    {option.icon}
-                  </div>
-
-                  <div className="min-w-0 text-left">
-                    <div className="font-medium text-[#182230]">
-                      {option.title}
+          <Form.Item
+            name="mode"
+            label="同步类型"
+            rules={[
+              {
+                required: true,
+                message: '请选择同步类型',
+              },
+            ]}
+          >
+            <Radio.Group className="grid w-full grid-cols-2 gap-3">
+              {modeOptions.map((option) => (
+                <Radio.Button
+                  key={option.value}
+                  value={option.value}
+                  className={[
+                    '!h-auto',
+                    '!rounded-lg',
+                    '!border',
+                    '!border-[#e4e7ec]',
+                    '!px-4',
+                    '!py-4',
+                    '!shadow-none',
+                    'hover:!border-[rgba(254,44,85,0.35)]',
+                    '[&.ant-radio-button-wrapper-checked]:!border-[rgba(254,44,85,1)]',
+                    '[&.ant-radio-button-wrapper-checked]:!bg-[rgba(254,44,85,0.06)]',
+                    '[&.ant-radio-button-wrapper-checked]:!text-inherit',
+                    'before:!hidden',
+                  ].join(' ')}
+                >
+                  <div className="flex items-start gap-3 whitespace-normal">
+                    <div className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-[rgba(254,44,85,0.08)] text-[17px] text-[rgba(254,44,85,1)]">
+                      {option.icon}
                     </div>
 
-                    <div className="mt-1 text-xs leading-5 text-[#667085]">
-                      {option.description}
+                    <div className="min-w-0 text-left">
+                      <div className="font-medium text-[#182230]">
+                        {option.title}
+                      </div>
+
+                      <div className="mt-1 text-xs leading-5 text-[#667085]">
+                        {option.description}
+                      </div>
                     </div>
                   </div>
-                </div>
-              </Radio.Button>
-            ))}
-          </Radio.Group>
-        </Form.Item>
-      </Form>
-    </Drawer>
+                </Radio.Button>
+              ))}
+            </Radio.Group>
+          </Form.Item>
+        </Form>
+      </Drawer>
+    </ConfigProvider>
   );
 }


### PR DESCRIPTION
## 背景

离线同步创建抽屉仍混用了 Ant Design 默认蓝色和旧红色，和新的产品主色 `rgba(254,44,85,1)` 不一致。

## 修改内容

- 在 `CreateSyncTaskDrawer` 内增加局部 `ConfigProvider` 主题；
- 将 Ant Design 的主色、hover、active、浅色背景、描边和 focus outline 统一为品牌色及其透明度变体；
- 创建按钮改用品牌色，移除 `danger` 语义和旧的 `#ef4444/#dc2626`；
- 单表/多表卡片的 hover、选中边框和选中背景统一为品牌色；
- 同步类型图标的文字色和浅色背景统一为品牌色；
- 输入框、文本域、Radio 等 Ant Design 组件的交互色通过局部主题统一生效。

## 颜色规范

- 主色：`rgba(254,44,85,1)`
- Hover：`rgba(254,44,85,0.88)`
- Active：`rgba(226,25,70,1)`
- 浅背景：`rgba(254,44,85,0.06)` / `rgba(254,44,85,0.1)`
- 描边：`rgba(254,44,85,0.35)`
- Focus outline：`rgba(254,44,85,0.16)`

## 验证

- 已核对分支与 `main` 的 diff，仅修改离线同步创建抽屉组件；
- 已确认组件内不再使用 `#315efb`、`#f5f7ff`、`#eef2ff`、`#ef4444` 或 `#dc2626`；
- 已确认创建按钮、单选卡片、图标和 Ant Design 交互 token 全部使用品牌色体系；
- 当前环境无法解析 `github.com` 进行本地克隆，因此未执行本地前端构建。