### PR TITLE
refactor(theme): centralize global brand colors

### DIFF
--- a/yak-ops-ui/src/pages/batch-link-up/components/CreateSyncTaskModal.tsx
+++ b/yak-ops-ui/src/pages/batch-link-up/components/CreateSyncTaskModal.tsx
@@ -11,7 +11,20 @@ import {
   Radio,
   message,
 } from 'antd';
-import { useEffect, useState, type ReactNode } from 'react';
+import {
+  useEffect,
+  useState,
+  type CSSProperties,
+  type ReactNode,
+} from 'react';
+
+import {
+  BRAND_COLOR,
+  BRAND_COLOR_BORDER,
+  BRAND_COLOR_SOFT,
+  BRAND_COLOR_SOFT_HOVER,
+  BRAND_THEME,
+} from '@/styles/brand';
 
 import { linkupJobDefinitionApi } from '../api';
 import {
@@ -29,14 +42,6 @@ interface CreateSyncTaskDrawerProps {
   onCancel: () => void;
   onCreated: (taskId: string) => void;
 }
-
-const BRAND_COLOR = 'rgba(254,44,85,1)';
-const BRAND_COLOR_HOVER = 'rgba(254,44,85,0.88)';
-const BRAND_COLOR_ACTIVE = 'rgba(226,25,70,1)';
-const BRAND_COLOR_SOFT = 'rgba(254,44,85,0.06)';
-const BRAND_COLOR_SOFT_HOVER = 'rgba(254,44,85,0.1)';
-const BRAND_COLOR_BORDER = 'rgba(254,44,85,0.35)';
-const BRAND_COLOR_OUTLINE = 'rgba(254,44,85,0.16)';
 
 const modeOptions: Array<{
   value: SyncMode;
@@ -57,6 +62,13 @@ const modeOptions: Array<{
     icon: <DatabaseOutlined />,
   },
 ];
+
+const brandCssVariables = {
+  '--yak-brand-color': BRAND_COLOR,
+  '--yak-brand-color-border': BRAND_COLOR_BORDER,
+  '--yak-brand-color-soft': BRAND_COLOR_SOFT,
+  '--yak-brand-color-soft-hover': BRAND_COLOR_SOFT_HOVER,
+} as CSSProperties;
 
 export default function CreateSyncTaskDrawer({
   open,
@@ -130,19 +142,7 @@ export default function CreateSyncTaskDrawer({
   };
 
   return (
-    <ConfigProvider
-      theme={{
-        token: {
-          colorPrimary: BRAND_COLOR,
-          colorPrimaryHover: BRAND_COLOR_HOVER,
-          colorPrimaryActive: BRAND_COLOR_ACTIVE,
-          colorPrimaryBg: BRAND_COLOR_SOFT,
-          colorPrimaryBgHover: BRAND_COLOR_SOFT_HOVER,
-          colorPrimaryBorder: BRAND_COLOR_BORDER,
-          controlOutline: BRAND_COLOR_OUTLINE,
-        },
-      }}
-    >
+    <ConfigProvider theme={BRAND_THEME}>
       <Drawer
         open={open}
         width={620}
@@ -150,6 +150,7 @@ export default function CreateSyncTaskDrawer({
         destroyOnClose
         maskClosable={false}
         keyboard={!submitting}
+        rootStyle={brandCssVariables}
         onClose={handleCancel}
         title={
           <div>
@@ -188,7 +189,7 @@ export default function CreateSyncTaskDrawer({
               type="primary"
               loading={submitting}
               onClick={handleSubmit}
-              className="!border-[rgba(254,44,85,1)] !bg-[rgba(254,44,85,1)] !text-white hover:!border-[rgba(254,44,85,0.88)] hover:!bg-[rgba(254,44,85,0.88)] active:!border-[rgba(226,25,70,1)] active:!bg-[rgba(226,25,70,1)]"
+              className="!text-white"
             >
               创建
             </Button>
@@ -269,15 +270,22 @@ export default function CreateSyncTaskDrawer({
                     '!px-4',
                     '!py-4',
                     '!shadow-none',
-                    'hover:!border-[rgba(254,44,85,0.35)]',
-                    '[&.ant-radio-button-wrapper-checked]:!border-[rgba(254,44,85,1)]',
-                    '[&.ant-radio-button-wrapper-checked]:!bg-[rgba(254,44,85,0.06)]',
+                    'hover:!border-[var(--yak-brand-color-border)]',
+                    'hover:!bg-[var(--yak-brand-color-soft-hover)]',
+                    '[&.ant-radio-button-wrapper-checked]:!border-[var(--yak-brand-color)]',
+                    '[&.ant-radio-button-wrapper-checked]:!bg-[var(--yak-brand-color-soft)]',
                     '[&.ant-radio-button-wrapper-checked]:!text-inherit',
                     'before:!hidden',
                   ].join(' ')}
                 >
                   <div className="flex items-start gap-3 whitespace-normal">
-                    <div className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-[rgba(254,44,85,0.08)] text-[17px] text-[rgba(254,44,85,1)]">
+                    <div
+                      className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-lg text-[17px]"
+                      style={{
+                        color: BRAND_COLOR,
+                        backgroundColor: BRAND_COLOR_SOFT_HOVER,
+                      }}
+                    >
                       {option.icon}
                     </div>
 

--- a/yak-ops-ui/src/styles/brand.ts
+++ b/yak-ops-ui/src/styles/brand.ts
@@ -1,0 +1,30 @@
+import type { ThemeConfig } from 'antd';
+
+/** Yak Ops 全局品牌主色。 */
+export const BRAND_COLOR = 'rgba(254,44,85,1)';
+
+/** 品牌色交互及弱化状态。 */
+export const BRAND_COLOR_HOVER = 'rgba(254,44,85,0.88)';
+export const BRAND_COLOR_ACTIVE = BRAND_COLOR;
+export const BRAND_COLOR_SOFT = 'rgba(254,44,85,0.06)';
+export const BRAND_COLOR_SOFT_HOVER = 'rgba(254,44,85,0.1)';
+export const BRAND_COLOR_BORDER = 'rgba(254,44,85,0.35)';
+export const BRAND_COLOR_OUTLINE = 'rgba(254,44,85,0.16)';
+
+/**
+ * Ant Design 品牌主题。
+ *
+ * 页面或组件需要品牌交互色时，可通过 ConfigProvider 局部引入；
+ * 后续若升级为应用级主题，也可以直接复用该配置。
+ */
+export const BRAND_THEME: ThemeConfig = {
+  token: {
+    colorPrimary: BRAND_COLOR,
+    colorPrimaryHover: BRAND_COLOR_HOVER,
+    colorPrimaryActive: BRAND_COLOR_ACTIVE,
+    colorPrimaryBg: BRAND_COLOR_SOFT,
+    colorPrimaryBgHover: BRAND_COLOR_SOFT_HOVER,
+    colorPrimaryBorder: BRAND_COLOR_BORDER,
+    controlOutline: BRAND_COLOR_OUTLINE,
+  },
+};

--- a/yak-ops-ui/src/styles/brand.ts.tmp
+++ b/yak-ops-ui/src/styles/brand.ts.tmp
@@ -1,0 +1,1 @@
+temporary

--- a/yak-ops-ui/src/styles/brand.ts.tmp
+++ b/yak-ops-ui/src/styles/brand.ts.tmp
@@ -1,1 +1,0 @@
-temporary


### PR DESCRIPTION
## 背景

品牌色目前直接声明在 `CreateSyncTaskDrawer` 内，后续其他页面或目录需要使用同一套颜色时会产生重复定义，也不方便统一调整。

## 修改内容

- 使用现有的 `yak-ops-ui/src/styles/brand.ts` 作为全局品牌色入口；
- 导出主色 `rgba(254,44,85,1)` 以及 hover、浅背景、描边和 focus outline 等透明度变体；
- 导出可复用的 `BRAND_THEME`，供 Ant Design `ConfigProvider` 在页面级或组件级使用；
- `CreateSyncTaskDrawer` 删除本地品牌色常量，统一从 `@/styles/brand` 引入；
- 创建按钮、输入框、单选卡片、图标等交互样式继续使用同一品牌色体系；
- 通过 CSS 变量连接 Tailwind 选中态样式，组件中不再直接写品牌色数值。

## 后续使用

其他目录需要品牌色时可直接引入：

```ts
import {
  BRAND_COLOR,
  BRAND_COLOR_SOFT,
  BRAND_THEME,
} from '@/styles/brand';
```

Ant Design 组件可以使用：

```tsx
<ConfigProvider theme={BRAND_THEME}>...</ConfigProvider>
```

## 验证

- 已核对 `main...agent/brand-create-sync-task-drawer`，实际文件差异仅包含 `styles/brand.ts` 和 `CreateSyncTaskDrawer`；
- 已确认 Drawer 内不再声明 `BRAND_COLOR` 等本地常量；
- 已确认品牌色的基础值和衍生值均集中在全局文件中；
- 当前环境无法执行本地前端构建，需由仓库 CI 或本地开发环境继续验证。