### PR TITLE
style(offline-sync): move create drawer actions to header

### DIFF
--- a/yak-ops-ui/src/pages/batch-link-up/components/CreateSyncTaskModal.tsx
+++ b/yak-ops-ui/src/pages/batch-link-up/components/CreateSyncTaskModal.tsx
@@ -147,40 +147,29 @@ export default function CreateSyncTaskDrawer({
         open={open}
         width={620}
         placement="right"
+        closable={false}
         destroyOnClose
         maskClosable={false}
         keyboard={!submitting}
         rootStyle={brandCssVariables}
         onClose={handleCancel}
         title={
-          <div>
-            <div className="text-[18px] font-semibold text-[#101828]">
+          <div className="min-w-0">
+            <div className="text-[18px] font-semibold leading-7 text-[#101828]">
               新建离线同步任务
             </div>
 
-            <div className="mt-1 text-[13px] font-normal text-[#667085]">
+            <div className="mt-0.5 text-[13px] font-normal leading-5 text-[#667085]">
               填写任务基础信息，创建后可在任务列表中继续配置。
             </div>
           </div>
         }
-        styles={{
-          header: {
-            padding: '20px 24px',
-            borderBottom: '1px solid #eaecf0',
-          },
-          body: {
-            padding: '24px',
-          },
-          footer: {
-            padding: '16px 24px',
-            borderTop: '1px solid #eaecf0',
-          },
-        }}
-        footer={
-          <div className="flex items-center justify-end gap-3">
+        extra={
+          <div className="flex shrink-0 items-center gap-2">
             <Button
               disabled={submitting}
               onClick={handleCancel}
+              className="!h-9 !rounded-lg !px-4 !font-medium"
             >
               取消
             </Button>
@@ -189,12 +178,21 @@ export default function CreateSyncTaskDrawer({
               type="primary"
               loading={submitting}
               onClick={handleSubmit}
-              className="!text-white"
+              className="!h-9 !rounded-lg !px-5 !font-medium !text-white"
             >
               创建
             </Button>
           </div>
         }
+        styles={{
+          header: {
+            padding: '18px 24px',
+            borderBottom: '1px solid #eaecf0',
+          },
+          body: {
+            padding: '24px',
+          },
+        }}
       >
         <Form<CreateSyncTaskValues>
           form={form}


### PR DESCRIPTION
## 修改内容

- 移除创建任务 Drawer 左上角默认关闭图标；
- 删除底部 footer 操作栏；
- 将“取消 / 创建”移动到标题栏右上角；
- 取消按钮承担关闭抽屉的职责；
- 保留提交中的禁用与 loading 状态，避免重复操作；
- 微调标题行高、说明文字间距和顶部按钮尺寸，使头部布局更紧凑。

## 交互结果

新的头部结构为：左侧展示标题与说明，右侧集中展示“取消 / 创建”。抽屉底部不再固定显示操作栏，内容区域更简洁。

## 验证

- 分支基于最新 `main` 创建；
- diff 仅修改 `CreateSyncTaskDrawer`；
- 已确认 `closable={false}`，默认关闭图标不再显示；
- 已确认 Drawer 不再传入 `footer`；
- 已确认取消和创建按钮均位于 `extra` 右上角操作区；
- 当前环境无法执行本地前端构建，需由仓库 CI 或本地开发环境继续验证。