### PR TITLE
feat(offline-sync): improve create task experience

### DIFF
--- a/yak-ops-ui/src/pages/batch-link-up/components/CreateSyncTaskModal.tsx
+++ b/yak-ops-ui/src/pages/batch-link-up/components/CreateSyncTaskModal.tsx
@@ -1,4 +1,5 @@
 import {
+  ArrowRightOutlined,
   DatabaseOutlined,
   TableOutlined,
 } from '@ant-design/icons';
@@ -37,10 +38,24 @@ import {
   type SyncMode,
 } from '../detail/model';
 
+export interface CreateSyncEndpoint {
+  name?: string;
+  dbType?: string;
+  connectorType?: string;
+  pluginName?: string;
+}
+
 interface CreateSyncTaskDrawerProps {
   open: boolean;
+  source: CreateSyncEndpoint;
+  target: CreateSyncEndpoint;
   onCancel: () => void;
   onCreated: (taskId: string) => void;
+}
+
+interface EndpointSummaryProps {
+  role: '来源端' | '目标端';
+  endpoint: CreateSyncEndpoint;
 }
 
 const modeOptions: Array<{
@@ -70,23 +85,100 @@ const brandCssVariables = {
   '--yak-brand-color-soft-hover': BRAND_COLOR_SOFT_HOVER,
 } as CSSProperties;
 
+const endpointName = (endpoint: CreateSyncEndpoint) =>
+  endpoint.name?.trim() || endpoint.dbType?.trim() || '未指定';
+
+const endpointMeta = (endpoint: CreateSyncEndpoint) =>
+  [endpoint.connectorType, endpoint.pluginName]
+    .map((value) => value?.trim())
+    .filter(Boolean)
+    .join(' · ');
+
+const buildDefaultJobName = (
+  sourceName: string,
+  targetName: string,
+) => `${sourceName} → ${targetName} 离线同步`.slice(0, 64);
+
+const buildDefaultJobDescription = (
+  sourceName: string,
+  targetName: string,
+) =>
+  [
+    '业务场景：请填写所属业务或使用场景；',
+    `同步范围：从 ${sourceName} 的【来源表】同步至 ${targetName} 的【目标表】；`,
+    '同步目的：请填写数据分析、数据服务、数据归档等使用目的。',
+  ]
+    .join('\n')
+    .slice(0, 200);
+
+function EndpointSummary({
+  role,
+  endpoint,
+}: EndpointSummaryProps) {
+  const name = endpointName(endpoint);
+  const meta = endpointMeta(endpoint);
+
+  return (
+    <div className="min-w-0 rounded-xl border border-[#e4e7ec] bg-white px-4 py-3 shadow-[0_1px_2px_rgba(16,24,40,0.03)]">
+      <div className="flex items-center gap-3">
+        <div
+          className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg text-[16px]"
+          style={{
+            color: BRAND_COLOR,
+            backgroundColor: BRAND_COLOR_SOFT_HOVER,
+          }}
+        >
+          <DatabaseOutlined />
+        </div>
+
+        <div className="min-w-0">
+          <div className="text-[11px] font-medium text-[#98a2b3]">
+            {role}
+          </div>
+
+          <div
+            className="mt-0.5 truncate text-[14px] font-semibold text-[#182230]"
+            title={name}
+          >
+            {name}
+          </div>
+
+          {meta ? (
+            <div
+              className="mt-0.5 truncate text-[11px] text-[#667085]"
+              title={meta}
+            >
+              {meta}
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export default function CreateSyncTaskDrawer({
   open,
+  source,
+  target,
   onCancel,
   onCreated,
 }: CreateSyncTaskDrawerProps) {
   const [form] = Form.useForm<CreateSyncTaskValues>();
   const [submitting, setSubmitting] = useState(false);
 
+  const sourceName = endpointName(source);
+  const targetName = endpointName(target);
+
   useEffect(() => {
     if (!open) return;
 
     form.setFieldsValue({
-      jobName: '',
-      jobDesc: '',
+      jobName: buildDefaultJobName(sourceName, targetName),
+      jobDesc: buildDefaultJobDescription(sourceName, targetName),
       mode: 'GUIDE_SINGLE',
     });
-  }, [form, open]);
+  }, [form, open, sourceName, targetName]);
 
   const handleCancel = () => {
     if (submitting) return;
@@ -98,6 +190,11 @@ export default function CreateSyncTaskDrawer({
   const handleSubmit = async () => {
     try {
       const values = await form.validateFields();
+      const normalizedValues: CreateSyncTaskValues = {
+        ...values,
+        jobName: values.jobName.trim(),
+        jobDesc: values.jobDesc?.trim(),
+      };
 
       setSubmitting(true);
 
@@ -115,10 +212,10 @@ export default function CreateSyncTaskDrawer({
         return;
       }
 
-      const payload = buildCreatePayload(taskId, values);
+      const payload = buildCreatePayload(taskId, normalizedValues);
 
       const saveResponse =
-        values.mode === 'GUIDE_MULTI'
+        normalizedValues.mode === 'GUIDE_MULTI'
           ? await linkupJobDefinitionApi.saveOrUpdateGuideMulti(payload)
           : await linkupJobDefinitionApi.saveOrUpdateGuideSingle(payload);
 
@@ -159,6 +256,9 @@ export default function CreateSyncTaskDrawer({
               新建离线同步任务
             </div>
 
+            <div className="mt-0.5 text-[12px] font-normal text-[#667085]">
+              已根据同步方向生成基础信息，可直接调整后创建。
+            </div>
           </div>
         }
         extra={
@@ -191,6 +291,34 @@ export default function CreateSyncTaskDrawer({
           },
         }}
       >
+        <div className="mb-6">
+          <div className="mb-2 text-[13px] font-medium text-[#344054]">
+            同步链路
+          </div>
+
+          <div className="grid grid-cols-[minmax(0,1fr)_40px_minmax(0,1fr)] items-center gap-2 rounded-xl bg-[#f8fafc] p-3">
+            <EndpointSummary
+              role="来源端"
+              endpoint={source}
+            />
+
+            <div className="flex items-center justify-center text-[#98a2b3]">
+              <span className="flex h-8 w-8 items-center justify-center rounded-full border border-[#e4e7ec] bg-white">
+                <ArrowRightOutlined />
+              </span>
+            </div>
+
+            <EndpointSummary
+              role="目标端"
+              endpoint={target}
+            />
+          </div>
+
+          <div className="mt-2 text-[11px] leading-5 text-[#98a2b3]">
+            同步方向已在任务列表页确定，创建后可继续配置具体数据源和数据表。
+          </div>
+        </div>
+
         <Form<CreateSyncTaskValues>
           form={form}
           layout="vertical"
@@ -199,6 +327,7 @@ export default function CreateSyncTaskDrawer({
           <Form.Item
             name="jobName"
             label="任务名称"
+            extra="已根据同步链路自动生成，可按业务命名习惯修改。"
             rules={[
               {
                 required: true,
@@ -221,6 +350,7 @@ export default function CreateSyncTaskDrawer({
           <Form.Item
             name="jobDesc"
             label="任务描述"
+            extra="已生成填写模板，请补充业务、来源表、目标表和使用目的。"
             rules={[
               {
                 max: 200,
@@ -229,10 +359,10 @@ export default function CreateSyncTaskDrawer({
             ]}
           >
             <Input.TextArea
-              rows={4}
+              rows={5}
               maxLength={200}
               showCount
-              placeholder="说明数据范围、用途或维护责任人"
+              placeholder="请说明业务场景、同步范围和使用目的"
             />
           </Form.Item>
 

--- a/yak-ops-ui/src/pages/batch-link-up/index.tsx
+++ b/yak-ops-ui/src/pages/batch-link-up/index.tsx
@@ -29,7 +29,7 @@ import React, {
   useState,
 } from "react";
 import { linkupJobDefinitionApi } from "./api";
-import CreateSyncTaskModal from "./components/CreateSyncTaskModal";
+import CreateSyncTaskDrawer from "./components/CreateSyncTaskModal";
 import ActionColumn from "./components/SyncTaskList/components/ActionColumn";
 import DataSourceSyncPlan from "./components/SyncTaskList/components/DataSourceSyncPlan";
 import ExecutionStatus from "./components/SyncTaskList/components/ExecutionStatus";
@@ -1691,8 +1691,10 @@ const BatchLinkUpPage: React.FC = () => {
         </section>
       </div>
 
-      <CreateSyncTaskModal
+      <CreateSyncTaskDrawer
         open={createOpen}
+        source={sourceType}
+        target={targetType}
         onCancel={() => setCreateOpen(false)}
         onCreated={handleCreated}
       />


### PR DESCRIPTION
## 背景

创建离线同步任务时，用户虽然已经在列表页选定来源和目标连接器，但进入 Drawer 后看不到当前同步方向；任务名称和描述也需要从空白开始填写，创建成本偏高。

## 修改内容

### 1. 增加只读同步链路

- 在任务名称上方增加“同步链路”区域；
- 展示当前来源端和目标端，以及连接器类型、插件信息；
- 中间使用箭头表达 `source → sink`；
- 链路仅用于确认，不提供重复选择入口；
- 列表页将当前选择的 `sourceType` 和 `targetType` 直接传入 Drawer。

### 2. 自动生成任务名称

打开 Drawer 时，按当前同步方向自动生成名称：

```text
MYSQL → DORIS 离线同步
```

名称仍然可以编辑，并继续保留 64 字符限制。

### 3. 预填任务描述模板

根据来源和目标自动生成可编辑模板：

```text
业务场景：请填写所属业务或使用场景；
同步范围：从 MYSQL 的【来源表】同步至 DORIS 的【目标表】；
同步目的：请填写数据分析、数据服务、数据归档等使用目的。
```

帮助用户按“什么业务、什么数据、同步到哪里、目的是什么”的结构补充信息。

### 4. 交互细节

- 标题下增加“已根据同步方向生成基础信息”的提示；
- 名称和描述增加辅助说明；
- 提交前自动清理名称和描述首尾空格；
- `CreateSyncEndpoint` 支持可选 `name` 字段，后续接入真实数据源实例名称时无需重构 Drawer；
- 保留现有品牌色、右上角取消/创建操作以及单表/多表选择逻辑。

## 变更范围

- `CreateSyncTaskModal.tsx`：增加链路展示、默认名称、描述模板和 endpoint 模型；
- `index.tsx`：将当前来源/目标连接器传入创建 Drawer。

## 验证

- 已核对 `main...agent/improve-create-sync-task-experience`；
- 列表页仅新增 4 行、删除 2 行，未影响任务列表、分页、查询和批量执行逻辑；
- 创建与保存仍复用原有 `getUniqueId`、`buildCreatePayload` 和单表/多表保存接口；
- 当前环境无法联网克隆仓库，因此未执行本地前端构建，需由仓库 CI 或本地开发环境继续验证。