### PR TITLE
feat(offline-sync): split multi-table sync detail page

### DIFF
--- a/yak-ops-ui/src/pages/batch-link-up/config/multi/components/MultiTableSyncTaskEditor.tsx
+++ b/yak-ops-ui/src/pages/batch-link-up/config/multi/components/MultiTableSyncTaskEditor.tsx
@@ -1,0 +1,73 @@
+import type { DataSourceRecord } from '@/pages/data-source/types';
+
+import ChannelConfigSection from '../../../detail/components/ChannelConfigSection';
+import MultiTableConfigSection from '../../../detail/components/MultiTableConfigSection';
+import TaskBasicSection from '../../../detail/components/TaskBasicSection';
+import useDataSourceTables from '../../../detail/hooks/useDataSourceTables';
+import {
+  endpointNode,
+  updateEndpointConfig,
+  type SyncEditorState,
+} from '../../../detail/model';
+
+interface MultiTableSyncTaskEditorProps {
+  editor: SyncEditorState;
+  dataSources: DataSourceRecord[];
+  dataSourceLoading: boolean;
+  onChange: (value: SyncEditorState) => void;
+}
+
+export default function MultiTableSyncTaskEditor({
+  editor,
+  dataSources,
+  dataSourceLoading,
+  onChange,
+}: MultiTableSyncTaskEditorProps) {
+  const sourceNode = endpointNode(editor.workflow, 'source');
+  const sinkNode = endpointNode(editor.workflow, 'sink');
+
+  const sourceConfig = sourceNode?.data?.config || {};
+  const sinkConfig = sinkNode?.data?.config || {};
+
+  const sourceId = editor.basic.sourceDataSourceId;
+  const targetId = editor.basic.targetDataSourceId;
+
+  const sourceCatalog = useDataSourceTables(sourceId);
+
+  const updateSource = (patch: Record<string, any>) => {
+    onChange(updateEndpointConfig(editor, 'source', patch));
+  };
+
+  const updateSink = (patch: Record<string, any>) => {
+    onChange(updateEndpointConfig(editor, 'sink', patch));
+  };
+
+  return (
+    <div className="space-y-5">
+      <TaskBasicSection
+        editor={editor}
+        dataSources={dataSources}
+        dataSourceLoading={dataSourceLoading}
+        onChange={onChange}
+      />
+
+      <MultiTableConfigSection
+        sourceConfig={sourceConfig}
+        sinkConfig={sinkConfig}
+        sourceTables={sourceCatalog.tables}
+        sourceLoading={sourceCatalog.loading}
+        sourceReady={Boolean(sourceId)}
+        targetReady={Boolean(targetId)}
+        onSourceChange={updateSource}
+        onSinkChange={updateSink}
+      />
+
+      <ChannelConfigSection
+        editor={editor}
+        sinkConfig={sinkConfig}
+        onChange={onChange}
+        onSinkChange={updateSink}
+      />
+    </div>
+  );
+}

--- a/yak-ops-ui/src/pages/batch-link-up/config/multi/index.tsx
+++ b/yak-ops-ui/src/pages/batch-link-up/config/multi/index.tsx
@@ -1,1 +1,297 @@
-export { default } from '../../detail';
+import { history, useLocation, useParams } from '@umijs/max';
+import {
+  Button,
+  ConfigProvider,
+  Empty,
+  message,
+  Spin,
+} from 'antd';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+
+import { fetchDataSourceAll } from '@/pages/data-source/service';
+import type { DataSourceRecord } from '@/pages/data-source/types';
+import { BRAND_THEME } from '@/styles/brand';
+
+import { linkupJobDefinitionApi } from '../../api';
+import { useSmoothWheelScroll } from '../../detail/hooks/useSmoothWheelScroll';
+import {
+  buildSavePayload,
+  endpointNode,
+  extractSavedId,
+  isApiSuccess,
+  normalizeEditDetail,
+  responseMessage,
+  type SyncEditorState,
+} from '../../detail/model';
+import MultiTableSyncTaskEditor from './components/MultiTableSyncTaskEditor';
+
+const validateTaskConfig = (
+  editor: SyncEditorState,
+): string | null => {
+  if (!editor.basic.jobName.trim()) {
+    return '请输入任务名称';
+  }
+
+  if (!editor.basic.sourceDataSourceId) {
+    return '请选择来源数据源';
+  }
+
+  if (!editor.basic.targetDataSourceId) {
+    return '请选择目标数据源';
+  }
+
+  const source =
+    endpointNode(editor.workflow, 'source')?.data?.config || {};
+
+  const sink =
+    endpointNode(editor.workflow, 'sink')?.data?.config || {};
+
+  if (!source.tables?.length && !source.tablePattern?.trim()) {
+    return '请选择来源表，或填写表名过滤规则';
+  }
+
+  if (
+    sink.tableNamingRule !== 'same_name' &&
+    !sink.tableNameAffix?.trim()
+  ) {
+    return '请填写目标表名前缀或后缀';
+  }
+
+  if (sink.writeMode === 'upsert' && !sink.primaryKey?.trim()) {
+    return 'Upsert 写入模式需要配置主键字段';
+  }
+
+  if (!editor.env.parallelism || editor.env.parallelism < 1) {
+    return 'Channel 并发数必须大于 0';
+  }
+
+  return null;
+};
+
+export default function MultiBatchLinkUpDetailPage() {
+  const location = useLocation();
+  const routeParams = useParams<{ id?: string }>();
+
+  const pageRootRef = useRef<HTMLDivElement>(null);
+
+  const taskId = useMemo(
+    () =>
+      routeParams.id ||
+      new URLSearchParams(location.search).get('id') ||
+      '',
+    [location.search, routeParams.id],
+  );
+
+  const [editor, setEditor] =
+    useState<SyncEditorState | null>(null);
+
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  const [dataSourceLoading, setDataSourceLoading] =
+    useState(false);
+
+  const [dataSources, setDataSources] = useState<
+    DataSourceRecord[]
+  >([]);
+
+  useSmoothWheelScroll(pageRootRef, true);
+
+  const loadDataSources = useCallback(async () => {
+    try {
+      setDataSourceLoading(true);
+
+      const response = await fetchDataSourceAll();
+
+      if (!isApiSuccess(response)) {
+        message.error(
+          responseMessage(response, '获取数据源失败'),
+        );
+
+        setDataSources([]);
+        return;
+      }
+
+      setDataSources(response?.data?.bizData || []);
+    } catch (error: any) {
+      message.error(error?.message || '获取数据源失败');
+      setDataSources([]);
+    } finally {
+      setDataSourceLoading(false);
+    }
+  }, []);
+
+  const loadTask = useCallback(async () => {
+    if (!taskId) return;
+
+    try {
+      setLoading(true);
+
+      const response =
+        await linkupJobDefinitionApi.selectEditDetail(taskId);
+
+      if (!isApiSuccess(response) || !response?.data) {
+        message.error(
+          responseMessage(response, '获取同步任务失败'),
+        );
+
+        setEditor(null);
+        return;
+      }
+
+      const nextEditor = normalizeEditDetail(response.data, taskId);
+
+      if (nextEditor.mode !== 'GUIDE_MULTI') {
+        history.replace(
+          `/sync/batch-link-up/${encodeURIComponent(
+            taskId,
+          )}/config/single?scene=edit`,
+        );
+        return;
+      }
+
+      setEditor(nextEditor);
+    } catch (error: any) {
+      message.error(error?.message || '获取同步任务失败');
+      setEditor(null);
+    } finally {
+      setLoading(false);
+    }
+  }, [taskId]);
+
+  useEffect(() => {
+    if (!taskId) return;
+
+    void Promise.all([loadTask(), loadDataSources()]);
+  }, [loadDataSources, loadTask, taskId]);
+
+  const persistEditor = async (
+    nextEditor: SyncEditorState,
+  ): Promise<SyncEditorState | null> => {
+    try {
+      setSaving(true);
+
+      const payload = buildSavePayload(nextEditor);
+
+      const response =
+        await linkupJobDefinitionApi.saveOrUpdateGuideMulti(payload);
+
+      if (!isApiSuccess(response)) {
+        message.error(
+          responseMessage(response, '保存同步任务失败'),
+        );
+
+        return null;
+      }
+
+      const savedEditor: SyncEditorState = {
+        ...nextEditor,
+        basic: payload.basic,
+        id: extractSavedId(response, nextEditor.id),
+      };
+
+      setEditor(savedEditor);
+      message.success('任务配置已保存');
+
+      return savedEditor;
+    } catch (error: any) {
+      message.error(error?.message || '保存同步任务失败');
+
+      return null;
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleSave = async () => {
+    if (!editor) return;
+
+    const error = validateTaskConfig(editor);
+
+    if (error) {
+      message.warning(error);
+      return;
+    }
+
+    await persistEditor(editor);
+  };
+
+  const handleCancel = () => {
+    history.push('/sync/batch-link-up');
+  };
+
+  if (!taskId) {
+    history.replace('/sync/batch-link-up');
+    return null;
+  }
+
+  if (loading) {
+    return (
+      <div className="flex min-h-[calc(100vh-64px)] items-center justify-center bg-[#f7f8fa]">
+        <Spin size="large" />
+      </div>
+    );
+  }
+
+  if (!editor) {
+    return (
+      <div className="flex min-h-[calc(100vh-64px)] items-center justify-center bg-[#f7f8fa]">
+        <Empty
+          description="未找到多表同步任务"
+          image={Empty.PRESENTED_IMAGE_SIMPLE}
+        >
+          <Button onClick={handleCancel}>返回任务列表</Button>
+        </Empty>
+      </div>
+    );
+  }
+
+  return (
+    <ConfigProvider theme={BRAND_THEME}>
+      <div className="h-[calc(100vh-64px)] overflow-hidden bg-[#f7f8fa] text-[#161823]">
+        <div
+          ref={pageRootRef}
+          className="h-full overflow-y-auto"
+        >
+          <div className="mx-auto w-full max-w-[1040px] px-6 pt-6">
+            <main className="pb-4">
+              <MultiTableSyncTaskEditor
+                editor={editor}
+                dataSources={dataSources}
+                dataSourceLoading={dataSourceLoading}
+                onChange={setEditor}
+              />
+            </main>
+
+            <footer className="sticky bottom-0 z-50 overflow-hidden rounded-t-lg border border-b-0 border-[#eaecf0] bg-white shadow-[0_-8px_16px_rgba(0,0,0,0.06)]">
+              <div className="flex min-h-[80px] items-center gap-3 px-8 py-4">
+                <Button
+                  type="primary"
+                  loading={saving}
+                  className="!h-9 !min-w-[120px] !rounded-lg !px-6 !font-medium !text-white"
+                  onClick={handleSave}
+                >
+                  保存配置
+                </Button>
+
+                <Button
+                  disabled={saving}
+                  className="!h-9 !min-w-[120px] !rounded-lg !border-0 !bg-[#f2f3f5] !px-5 !font-medium !text-[#344054] hover:!bg-[#e9eaec]"
+                  onClick={handleCancel}
+                >
+                  取消
+                </Button>
+              </div>
+            </footer>
+          </div>
+        </div>
+      </div>
+    </ConfigProvider>
+  );
+}

--- a/yak-ops-ui/src/pages/batch-link-up/detail/components/MultiTableConfigSection.tsx
+++ b/yak-ops-ui/src/pages/batch-link-up/detail/components/MultiTableConfigSection.tsx
@@ -2,8 +2,15 @@ import {
   DatabaseOutlined,
   ExportOutlined,
 } from '@ant-design/icons';
-import { Input, Select, Switch } from 'antd';
-import type { ReactNode } from 'react';
+import {
+  Empty,
+  Input,
+  Select,
+  Spin,
+  Switch,
+  Transfer,
+} from 'antd';
+import { useMemo, type ReactNode } from 'react';
 
 import EditorSection from './EditorSection';
 
@@ -21,8 +28,13 @@ interface MultiTableConfigSectionProps {
 interface EndpointPanelProps {
   icon: ReactNode;
   title: string;
-  description: string;
+  description?: string;
   children: ReactNode;
+}
+
+interface TableTransferItem {
+  key: string;
+  title: string;
 }
 
 function EndpointPanel({
@@ -38,13 +50,16 @@ function EndpointPanel({
           {icon}
         </span>
 
-        <div>
+        <div className="min-w-0">
           <div className="text-[14px] font-semibold text-[#182230]">
             {title}
           </div>
-          <div className="mt-0.5 text-[11px] leading-5 text-[#667085]">
-            {description}
-          </div>
+
+          {description ? (
+            <div className="mt-0.5 text-[11px] leading-5 text-[#667085]">
+              {description}
+            </div>
+          ) : null}
         </div>
       </div>
 
@@ -83,42 +98,96 @@ export default function MultiTableConfigSection({
   const tableNamingRule =
     sinkConfig.tableNamingRule || 'same_name';
 
+  const selectedTables = useMemo(
+    () =>
+      Array.isArray(sourceConfig.tables)
+        ? sourceConfig.tables.filter(Boolean).map(String)
+        : [],
+    [sourceConfig.tables],
+  );
+
+  const transferDataSource = useMemo<TableTransferItem[]>(
+    () =>
+      Array.from(new Set([...sourceTables, ...selectedTables])).map(
+        (table) => ({
+          key: table,
+          title: table,
+        }),
+      ),
+    [selectedTables, sourceTables],
+  );
+
   return (
-    <EditorSection
-      title="多表同步配置"
-    >
+    <EditorSection title="多表同步配置">
       <div className="grid grid-cols-2 gap-5 max-lg:grid-cols-1">
         <EndpointPanel
           icon={<DatabaseOutlined />}
           title="Source 来源配置"
-          description="选择一张或多张来源表，也可以通过表名规则批量匹配。"
+          description="从来源数据源中批量选择需要同步的数据表。"
         >
           <div>
-            <FieldLabel required>来源表</FieldLabel>
-            <Select
-              mode="tags"
+            <div className="mb-2 flex items-center justify-between gap-3">
+              <div className="text-[12px] font-medium text-[#475467]">
+                来源表
+                <span className="ml-1 text-[var(--yak-brand-color)]">
+                  *
+                </span>
+              </div>
+
+              <span className="text-[11px] text-[#98a2b3]">
+                已选择 {selectedTables.length} 张表
+              </span>
+            </div>
+
+            <Transfer<TableTransferItem>
+              dataSource={transferDataSource}
+              targetKeys={selectedTables}
+              disabled={!sourceReady || sourceLoading}
               showSearch
-              variant="filled"
-              disabled={!sourceReady}
-              value={sourceConfig.tables || []}
-              options={sourceTables.map((table) => ({
-                label: table,
-                value: table,
-              }))}
-              loading={sourceLoading}
-              placeholder={
-                sourceReady
-                  ? '请选择一张或多张来源表'
-                  : '请先选择来源数据源'
+              showSelectAll
+              operations={['添加', '移除']}
+              titles={[
+                `可选表 (${sourceTables.length})`,
+                `已选表 (${selectedTables.length})`,
+              ]}
+              listStyle={{
+                width: 'calc(50% - 28px)',
+                height: 320,
+              }}
+              locale={{
+                itemUnit: '项',
+                itemsUnit: '项',
+                searchPlaceholder: '搜索表名',
+                notFoundContent: sourceLoading ? (
+                  <Spin size="small" />
+                ) : sourceReady ? (
+                  <Empty
+                    image={Empty.PRESENTED_IMAGE_SIMPLE}
+                    description="暂无数据表"
+                  />
+                ) : (
+                  '请先选择来源数据源'
+                ),
+              }}
+              filterOption={(inputValue, item) =>
+                item.title
+                  .toLowerCase()
+                  .includes(inputValue.trim().toLowerCase())
               }
-              optionFilterProp="label"
+              render={(item) => (
+                <span className="block truncate" title={item.title}>
+                  {item.title}
+                </span>
+              )}
               className="w-full"
-              onChange={(tables) =>
+              onChange={(targetKeys) => {
+                const tables = targetKeys.map(String);
+
                 onSourceChange({
                   tables,
-                  table: tables?.[0] || '',
-                })
-              }
+                  table: tables[0] || '',
+                });
+              }}
             />
           </div>
 
@@ -135,6 +204,10 @@ export default function MultiTableConfigSection({
                 })
               }
             />
+
+            <div className="mt-1.5 text-[11px] leading-5 text-[#98a2b3]">
+              可与已选表同时使用，运行时会合并匹配结果并自动去重。
+            </div>
           </div>
         </EndpointPanel>
 

--- a/yak-ops-ui/src/pages/batch-link-up/detail/components/MultiTableConfigSection.tsx
+++ b/yak-ops-ui/src/pages/batch-link-up/detail/components/MultiTableConfigSection.tsx
@@ -101,7 +101,9 @@ export default function MultiTableConfigSection({
   const selectedTables = useMemo(
     () =>
       Array.isArray(sourceConfig.tables)
-        ? sourceConfig.tables.filter(Boolean).map(String)
+        ? Array.from(
+            new Set(sourceConfig.tables.filter(Boolean).map(String)),
+          )
         : [],
     [sourceConfig.tables],
   );
@@ -206,7 +208,7 @@ export default function MultiTableConfigSection({
             />
 
             <div className="mt-1.5 text-[11px] leading-5 text-[#98a2b3]">
-              可与已选表同时使用，运行时会合并匹配结果并自动去重。
+              可选；用于按表名规则批量匹配来源表。
             </div>
           </div>
         </EndpointPanel>


### PR DESCRIPTION
## 变更内容

- 将 `/sync/batch-link-up/:id/config/multi` 从复用单表详情页改为独立的多表同步详情页
- 新增多表同步专用编辑器，复用现有任务基础信息、运行参数和底部操作栏，保持与单表同步一致的布局与视觉风格
- 使用 Ant Design `Transfer` 实现来源表批量选择，支持搜索、批量添加、移除和已选数量展示
- 保留表名过滤规则、目标表命名规则、写入模式、主键配置等原有多表能力
- 当多表路由打开了单表任务时，自动跳转到单表配置页面，避免任务模式与页面不一致

## 影响范围

仅调整离线同步的多表配置页面，不修改后端接口和保存数据结构。多表保存继续调用 `saveOrUpdateGuideMulti`。

## 校验

- 使用 TypeScript `transpileModule` 对本次新增和修改的 TSX 文件进行了语法解析检查
- 对比 `main` 分支确认仅包含 3 个文件变更：1 个新增文件、2 个修改文件

## 待确认

- 在真实数据源下确认 `Transfer` 的表列表加载、搜索、批量选择和回显效果
- 确认较窄窗口下左右穿梭框的展示宽度是否符合产品预期