### PR TITLE
refactor(realtime-sync): align UI with offline sync

### DIFF
--- a/yak-ops-ui/src/pages/realtime-link-up/components/ConfigShell.tsx
+++ b/yak-ops-ui/src/pages/realtime-link-up/components/ConfigShell.tsx
@@ -1,7 +1,10 @@
-import { ArrowLeft, CheckCircle2, Code2, Save } from 'lucide-react';
+import { ArrowLeft, Check, Code2 } from 'lucide-react';
 import { history } from '@umijs/max';
-import { Button, Drawer, Tag } from 'antd';
+import { Button, ConfigProvider, Drawer, Tag } from 'antd';
 import { useState, type ReactNode } from 'react';
+
+import { BRAND_THEME } from '@/styles/brand';
+
 import { modeMeta } from '../data';
 import type { RealtimeTaskMode } from '../types';
 
@@ -45,131 +48,155 @@ const ConfigShell = ({
   const meta = modeMeta[mode];
   const completeCount = steps.filter((step) => step.complete).length;
 
-  return (
-    <div className="min-h-[calc(100vh-48px)] bg-[#f7f8fa]">
-      <header className="sticky top-0 z-20 border-b border-black/[0.07] bg-white/95 backdrop-blur">
-        <div className="flex h-[66px] items-center justify-between gap-4 px-5">
-          <div className="flex min-w-0 items-center gap-3">
-            <button
-              type="button"
-              aria-label="返回实时同步任务列表"
-              onClick={() => history.push('/sync/realtime-link-up')}
-              className="flex h-9 w-9 shrink-0 items-center justify-center rounded-[8px] border border-black/[0.07] bg-white text-[rgba(22,24,35,0.62)] transition hover:border-black/[0.14] hover:text-[#161823]"
-            >
-              <ArrowLeft size={17} strokeWidth={1.9} />
-            </button>
+  const handleCancel = () => {
+    history.push('/sync/realtime-link-up');
+  };
 
-            <div className="min-w-0">
-              <div className="flex items-center gap-2">
-                <h1 className="truncate text-[17px] font-semibold text-[#161823]">
-                  {title}
-                </h1>
-                <Tag
-                  className={`!m-0 !rounded-full !px-2.5 !py-0.5 !text-[11px] ${meta.className}`}
+  return (
+    <ConfigProvider theme={BRAND_THEME}>
+      <div className="h-[calc(100vh-64px)] overflow-hidden bg-[#f7f8fa] text-[#161823]">
+        <div className="h-full overflow-y-auto">
+          <div className="mx-auto flex min-h-full w-full max-w-[1040px] flex-col px-6 pt-5">
+            <header className="mb-5 bg-white">
+              <div className="flex min-h-[72px] items-center justify-between gap-5 border-b border-[#f0f0f0] py-3">
+                <div className="flex min-w-0 items-center gap-3">
+                  <Button
+                    type="text"
+                    icon={<ArrowLeft size={17} strokeWidth={1.9} />}
+                    aria-label="返回实时同步任务列表"
+                    className="!flex !h-9 !w-9 !min-w-0 !items-center !justify-center !rounded-lg !p-0 !text-[#667085] hover:!bg-[#f2f4f7] hover:!text-[#344054]"
+                    onClick={handleCancel}
+                  />
+
+                  <div className="min-w-0">
+                    <div className="flex min-w-0 items-center gap-2">
+                      <h1 className="truncate text-[17px] font-semibold text-[#101828]">
+                        {title}
+                      </h1>
+                      <Tag
+                        className={`!m-0 !rounded-full !px-2.5 !text-[11px] ${meta.className}`}
+                      >
+                        {meta.label}
+                      </Tag>
+                    </div>
+                    <div className="mt-1 flex min-w-0 items-center gap-2 text-[11px] text-[#98a2b3]">
+                      <span className="truncate">
+                        {description || meta.description}
+                      </span>
+                      <span className="shrink-0">ID：{taskId}</span>
+                    </div>
+                  </div>
+                </div>
+
+                <Button
+                  icon={<Code2 size={15} strokeWidth={1.8} />}
+                  className="!h-9 !rounded-lg !border-[#eaecf0] !px-4 !text-[12px] !text-[#475467]"
+                  onClick={() => setPreviewOpen(true)}
                 >
-                  {meta.label}
-                </Tag>
-                <span className="text-[11px] text-[rgba(22,24,35,0.38)]">
-                  ID: {taskId}
+                  YAML 预览
+                </Button>
+              </div>
+
+              <div className="flex min-h-[64px] items-center justify-between gap-4 overflow-x-auto py-3">
+                <div className="flex min-w-max items-center gap-1 rounded-lg bg-[#f5f5f6] p-1">
+                  {steps.map((step, index) => {
+                    const active = activeStep === step.key;
+
+                    return (
+                      <button
+                        key={step.key}
+                        type="button"
+                        onClick={() => onStepChange(step.key)}
+                        className={[
+                          'flex h-10 items-center gap-2 rounded-md px-3 text-left transition-all',
+                          active
+                            ? 'bg-white text-[#ff4d4f] shadow-[0_1px_4px_rgba(16,24,40,0.08)]'
+                            : 'text-[#667085] hover:bg-white/70 hover:text-[#344054]',
+                        ].join(' ')}
+                      >
+                        <span
+                          className={[
+                            'flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-[10px] font-semibold',
+                            step.complete
+                              ? 'bg-[#fff1f0] text-[#ff4d4f]'
+                              : active
+                                ? 'bg-[#ff4d4f] text-white'
+                                : 'bg-[#eaecf0] text-[#667085]',
+                          ].join(' ')}
+                        >
+                          {step.complete ? (
+                            <Check size={12} strokeWidth={2.4} />
+                          ) : (
+                            index + 1
+                          )}
+                        </span>
+                        <span>
+                          <span className="block whitespace-nowrap text-[12px] font-medium">
+                            {step.title}
+                          </span>
+                          <span className="mt-0.5 block whitespace-nowrap text-[10px] text-[#98a2b3]">
+                            {step.description}
+                          </span>
+                        </span>
+                      </button>
+                    );
+                  })}
+                </div>
+
+                <span className="shrink-0 text-[11px] text-[#98a2b3]">
+                  已完成 {completeCount}/{steps.length}
                 </span>
               </div>
-              <div className="mt-0.5 truncate text-[11px] text-[rgba(22,24,35,0.45)]">
-                {description || meta.description}
-              </div>
-            </div>
-          </div>
+            </header>
 
-          <div className="flex shrink-0 items-center gap-2">
-            <Button
-              icon={<Code2 size={15} strokeWidth={1.8} />}
-              onClick={() => setPreviewOpen(true)}
-              className="!h-9 !rounded-[8px] !border-black/[0.08] !text-[12px]"
-            >
-              YAML 预览
-            </Button>
-            <Button
-              type="primary"
-              icon={<Save size={15} strokeWidth={1.9} />}
-              loading={saving}
-              onClick={onSave}
-              className="!h-9 !rounded-[8px] !border-[#161823] !bg-[#161823] !px-4 !text-[12px] hover:!border-[#2b2d38] hover:!bg-[#2b2d38]"
-            >
-              保存草稿
-            </Button>
-          </div>
-        </div>
-      </header>
+            <main className="flex-1 pb-5">{children}</main>
 
-      <div className="flex min-h-[calc(100vh-114px)]">
-        <aside className="sticky top-[66px] h-[calc(100vh-66px)] w-[246px] shrink-0 border-r border-black/[0.065] bg-white px-4 py-5">
-          <div className="mb-4 flex items-center justify-between px-2">
-            <span className="text-[12px] font-semibold text-[#161823]">配置步骤</span>
-            <span className="text-[10px] text-[rgba(22,24,35,0.42)]">
-              {completeCount}/{steps.length}
-            </span>
-          </div>
+            {footer}
 
-          <div className="space-y-1.5">
-            {steps.map((step, index) => {
-              const active = step.key === activeStep;
-              return (
-                <button
-                  key={step.key}
-                  type="button"
-                  onClick={() => onStepChange(step.key)}
-                  className={[
-                    'group flex w-full items-start gap-3 rounded-[8px] border-0 px-3 py-3 text-left transition',
-                    active
-                      ? 'bg-[#f1f3f6] text-[#161823]'
-                      : 'bg-transparent text-[rgba(22,24,35,0.58)] hover:bg-[#f8f8f9] hover:text-[#161823]',
-                  ].join(' ')}
+            <footer className="sticky bottom-0 z-50 mt-auto overflow-hidden rounded-t-lg border border-b-0 border-[#eaecf0] bg-white shadow-[0_-8px_16px_rgba(16,24,40,0.06)]">
+              <div className="flex min-h-[80px] items-center gap-3 px-8 py-4">
+                <Button
+                  danger
+                  type="primary"
+                  loading={saving}
+                  className="!h-9 !min-w-[120px] !rounded-lg !px-6 !font-medium"
+                  onClick={onSave}
                 >
-                  <span
-                    className={[
-                      'mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full border text-[10px] font-semibold',
-                      step.complete
-                        ? 'border-[#b7e4cf] bg-[#edf9f3] text-[#16845b]'
-                        : active
-                          ? 'border-[#161823] bg-[#161823] text-white'
-                          : 'border-black/[0.10] bg-white text-[rgba(22,24,35,0.42)]',
-                    ].join(' ')}
-                  >
-                    {step.complete ? <CheckCircle2 size={14} strokeWidth={2} /> : index + 1}
-                  </span>
-                  <span className="min-w-0 flex-1">
-                    <span className="block text-[12px] font-semibold">{step.title}</span>
-                    <span className="mt-0.5 block text-[10px] leading-4 text-[rgba(22,24,35,0.42)]">
-                      {step.description}
-                    </span>
-                  </span>
-                </button>
-              );
-            })}
+                  保存配置
+                </Button>
+
+                <Button
+                  disabled={saving}
+                  className="!h-9 !min-w-[120px] !rounded-lg !border-0 !bg-[#f2f3f5] !px-5 !font-medium !text-[#344054] hover:!bg-[#e9eaec]"
+                  onClick={handleCancel}
+                >
+                  取消
+                </Button>
+
+                <span className="ml-auto text-[11px] text-[#98a2b3]">
+                  实时任务不配置调度，保存后由运行中心统一启动和停止
+                </span>
+              </div>
+            </footer>
           </div>
-        </aside>
-
-        <main className="min-w-0 flex-1 px-6 py-6">
-          <div className="mx-auto max-w-[1380px]">{children}</div>
-        </main>
-      </div>
-
-      {footer}
-
-      <Drawer
-        title="Flink CDC Pipeline YAML"
-        width={620}
-        open={previewOpen}
-        onClose={() => setPreviewOpen(false)}
-        styles={{ body: { padding: 0 } }}
-      >
-        <div className="border-b border-black/[0.06] bg-[#fafafa] px-5 py-3 text-[11px] text-[rgba(22,24,35,0.50)]">
-          当前内容由页面配置实时生成，保存草稿时会与结构化配置一并保存。
         </div>
-        <pre className="m-0 min-h-[calc(100vh-112px)] overflow-auto bg-[#101318] p-5 font-mono text-[12px] leading-6 text-[#d7dce2]">
-          {yaml}
-        </pre>
-      </Drawer>
-    </div>
+
+        <Drawer
+          title="Flink CDC Pipeline YAML"
+          width={620}
+          open={previewOpen}
+          onClose={() => setPreviewOpen(false)}
+          styles={{ body: { padding: 0 } }}
+        >
+          <div className="border-b border-[#f0f0f0] bg-[#fafafa] px-5 py-3 text-[12px] text-[#667085]">
+            当前内容由页面配置实时生成，保存时会与结构化配置一并写入草稿。
+          </div>
+          <pre className="m-0 min-h-[calc(100vh-112px)] overflow-auto bg-[#101318] p-5 font-mono text-[12px] leading-6 text-[#d7dce2]">
+            {yaml}
+          </pre>
+        </Drawer>
+      </div>
+    </ConfigProvider>
   );
 };
 

--- a/yak-ops-ui/src/pages/realtime-link-up/components/CreateRealtimeTaskDrawer.tsx
+++ b/yak-ops-ui/src/pages/realtime-link-up/components/CreateRealtimeTaskDrawer.tsx
@@ -1,0 +1,308 @@
+import {
+  DatabaseOutlined,
+  FileTextOutlined,
+  TableOutlined,
+} from '@ant-design/icons';
+import { Button, Drawer, Form, Input, Radio, message } from 'antd';
+import { useEffect, useState, type ReactNode } from 'react';
+
+import {
+  createDefaultMultiDraft,
+  createDefaultSingleDraft,
+  createTaskId,
+  formatUpdatedAt,
+  saveRealtimeDraft,
+  saveRealtimeTask,
+} from '../data';
+import type {
+  CustomYamlDraft,
+  RealtimeTaskMode,
+} from '../types';
+
+interface CreateRealtimeTaskDrawerProps {
+  open: boolean;
+  onCancel: () => void;
+  onCreated: (taskId: string, mode: RealtimeTaskMode) => void;
+}
+
+interface CreateRealtimeTaskValues {
+  name: string;
+  description?: string;
+  mode: RealtimeTaskMode;
+}
+
+const modeOptions: Array<{
+  value: RealtimeTaskMode;
+  title: string;
+  description: string;
+  icon: ReactNode;
+}> = [
+  {
+    value: 'SINGLE_TABLE',
+    title: '单表同步',
+    description: '配置一个来源表到一个目标表的实时同步链路',
+    icon: <TableOutlined />,
+  },
+  {
+    value: 'MULTI_TABLE',
+    title: '多表同步',
+    description: '配置整库、多表匹配、路由和转换规则',
+    icon: <DatabaseOutlined />,
+  },
+  {
+    value: 'CUSTOM_YAML',
+    title: '自定义 YAML',
+    description: '直接维护 Flink CDC Pipeline YAML 配置',
+    icon: <FileTextOutlined />,
+  },
+];
+
+const DEFAULT_YAML = `source:
+  type: mysql
+  hostname: localhost
+  port: 3306
+  username: root
+  password: ""
+  tables: trade_db.order_main
+  server-id: 5400-5404
+  server-time-zone: Asia/Shanghai
+
+sink:
+  type: doris
+  fenodes: 127.0.0.1:8030
+  username: root
+  password: ""
+
+pipeline:
+  name: Realtime Pipeline
+  parallelism: 2
+  schema.change.behavior: evolve
+  local-time-zone: Asia/Shanghai
+`;
+
+const CreateRealtimeTaskDrawer = ({
+  open,
+  onCancel,
+  onCreated,
+}: CreateRealtimeTaskDrawerProps) => {
+  const [form] = Form.useForm<CreateRealtimeTaskValues>();
+  const [submitting, setSubmitting] = useState(false);
+  const selectedMode = Form.useWatch('mode', form);
+
+  useEffect(() => {
+    if (!open) return;
+
+    form.setFieldsValue({
+      name: '',
+      description: '',
+      mode: 'SINGLE_TABLE',
+    });
+  }, [form, open]);
+
+  const handleSubmit = async (values: CreateRealtimeTaskValues) => {
+    setSubmitting(true);
+
+    try {
+      const taskId = createTaskId();
+      const name = values.name.trim();
+      const description = values.description?.trim() || '';
+
+      if (values.mode === 'SINGLE_TABLE') {
+        const draft = createDefaultSingleDraft(taskId);
+        draft.pipeline.name = name;
+        draft.pipeline.description = description;
+        saveRealtimeDraft(taskId, draft);
+        saveRealtimeTask({
+          id: taskId,
+          name,
+          description,
+          mode: values.mode,
+          status: 'DRAFT',
+          sourceType: 'MySQL CDC',
+          sourceSummary: [
+            draft.source.database,
+            draft.source.schema,
+            draft.source.table,
+          ]
+            .filter(Boolean)
+            .join('.'),
+          sinkType: draft.sink.type.toUpperCase(),
+          sinkSummary: [
+            draft.sink.database,
+            draft.sink.schema,
+            draft.sink.table,
+          ]
+            .filter(Boolean)
+            .join('.'),
+          flinkVersion: draft.pipeline.flinkVersion,
+          cdcVersion: draft.pipeline.cdcVersion,
+          updatedAt: formatUpdatedAt(),
+        });
+      }
+
+      if (values.mode === 'MULTI_TABLE') {
+        const draft = createDefaultMultiDraft(taskId);
+        draft.pipeline.name = name;
+        draft.pipeline.description = description;
+        saveRealtimeDraft(taskId, draft);
+        saveRealtimeTask({
+          id: taskId,
+          name,
+          description,
+          mode: values.mode,
+          status: 'DRAFT',
+          sourceType: 'MySQL CDC',
+          sourceSummary: `${draft.source.database}.${draft.source.tablePattern || '*'}（${draft.source.tables.length} 张表）`,
+          sinkType: draft.sink.type.toUpperCase(),
+          sinkSummary: `${draft.sink.database}.${draft.sink.tablePrefix || ''}*${draft.sink.tableSuffix || ''}`,
+          flinkVersion: draft.pipeline.flinkVersion,
+          cdcVersion: draft.pipeline.cdcVersion,
+          updatedAt: formatUpdatedAt(),
+        });
+      }
+
+      if (values.mode === 'CUSTOM_YAML') {
+        const draft: CustomYamlDraft = {
+          taskId,
+          mode: 'CUSTOM_YAML',
+          name,
+          description,
+          flinkVersion: '2.2.1',
+          cdcVersion: '3.6.0',
+          yaml: DEFAULT_YAML,
+        };
+
+        saveRealtimeDraft(taskId, draft);
+        saveRealtimeTask({
+          id: taskId,
+          name,
+          description,
+          mode: values.mode,
+          status: 'DRAFT',
+          sourceType: 'YAML Pipeline',
+          sourceSummary: '由 YAML source 区块定义',
+          sinkType: 'YAML Pipeline',
+          sinkSummary: '由 YAML sink 区块定义',
+          flinkVersion: draft.flinkVersion,
+          cdcVersion: draft.cdcVersion,
+          updatedAt: formatUpdatedAt(),
+          yaml: draft.yaml,
+        });
+      }
+
+      message.success('实时同步任务已创建');
+      onCreated(taskId, values.mode);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Drawer
+      title="新建实时同步任务"
+      width={520}
+      open={open}
+      onClose={onCancel}
+      destroyOnClose
+      styles={{
+        body: { padding: '20px 24px 96px' },
+        footer: { padding: '14px 24px' },
+      }}
+      footer={
+        <div className="flex items-center justify-end gap-2">
+          <Button disabled={submitting} onClick={onCancel}>
+            取消
+          </Button>
+          <Button
+            danger
+            type="primary"
+            loading={submitting}
+            onClick={() => form.submit()}
+          >
+            创建并配置
+          </Button>
+        </div>
+      }
+    >
+      <Form<CreateRealtimeTaskValues>
+        form={form}
+        layout="vertical"
+        requiredMark={false}
+        onFinish={(values) => void handleSubmit(values)}
+      >
+        <Form.Item
+          label="任务名称"
+          name="name"
+          rules={[
+            { required: true, message: '请输入任务名称' },
+            { max: 80, message: '任务名称不能超过 80 个字符' },
+          ]}
+        >
+          <Input
+            variant="filled"
+            placeholder="请输入实时同步任务名称"
+            maxLength={80}
+          />
+        </Form.Item>
+
+        <Form.Item
+          label="同步模式"
+          name="mode"
+          rules={[{ required: true, message: '请选择同步模式' }]}
+        >
+          <Radio.Group className="w-full">
+            <div className="space-y-3">
+              {modeOptions.map((option) => {
+                const active = selectedMode === option.value;
+
+                return (
+                  <label
+                    key={option.value}
+                    className={[
+                      'flex cursor-pointer items-start gap-3 rounded-lg border px-4 py-3.5 transition',
+                      active
+                        ? 'border-[#ff4d4f] bg-[#fff7f7]'
+                        : 'border-[#eaecf0] bg-white hover:border-[#d0d5dd] hover:bg-[#fafafa]',
+                    ].join(' ')}
+                  >
+                    <Radio value={option.value} className="mt-0.5" />
+                    <span
+                      className={[
+                        'flex h-9 w-9 shrink-0 items-center justify-center rounded-lg text-[16px]',
+                        active
+                          ? 'bg-[#ff4d4f] text-white'
+                          : 'bg-[#f2f4f7] text-[#667085]',
+                      ].join(' ')}
+                    >
+                      {option.icon}
+                    </span>
+                    <span className="min-w-0 flex-1">
+                      <span className="block text-[14px] font-medium text-[#344054]">
+                        {option.title}
+                      </span>
+                      <span className="mt-1 block text-[12px] leading-5 text-[#98a2b3]">
+                        {option.description}
+                      </span>
+                    </span>
+                  </label>
+                );
+              })}
+            </div>
+          </Radio.Group>
+        </Form.Item>
+
+        <Form.Item label="任务描述" name="description">
+          <Input.TextArea
+            variant="filled"
+            placeholder="可选，说明任务用途或同步范围"
+            autoSize={{ minRows: 3, maxRows: 5 }}
+            maxLength={200}
+            showCount
+          />
+        </Form.Item>
+      </Form>
+    </Drawer>
+  );
+};
+
+export default CreateRealtimeTaskDrawer;

--- a/yak-ops-ui/src/pages/realtime-link-up/index.tsx
+++ b/yak-ops-ui/src/pages/realtime-link-up/index.tsx
@@ -1,32 +1,31 @@
 import {
-  Activity,
-  Copy,
-  DatabaseZap,
-  FileCode2,
-  MoreHorizontal,
-  Plus,
-  RefreshCw,
-  Search,
-  Table2,
-  Trash2,
-} from 'lucide-react';
+  CopyOutlined,
+  FilterOutlined,
+  ReloadOutlined,
+  SearchOutlined,
+} from '@ant-design/icons';
 import { history } from '@umijs/max';
 import {
   Button,
-  Dropdown,
+  ConfigProvider,
   Empty,
   Input,
   message,
   Modal,
+  Pagination,
+  Popover,
   Select,
   Table,
   Tag,
-  type MenuProps,
-  type TableColumnsType,
+  Tooltip,
 } from 'antd';
-import { useEffect, useMemo, useState, type ReactNode } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+
+import { BRAND_THEME } from '@/styles/brand';
+
+import CreateRealtimeTaskDrawer from './components/CreateRealtimeTaskDrawer';
 import {
-  createTaskId,
+  REALTIME_DRAFT_STORAGE_PREFIX,
   loadRealtimeTasks,
   modeMeta,
   removeRealtimeTask,
@@ -37,37 +36,19 @@ import type {
   RealtimeTaskStatus,
 } from './types';
 
-const statusMeta: Record<
-  RealtimeTaskStatus,
-  { label: string; className: string; dotClassName: string }
-> = {
-  DRAFT: {
-    label: '草稿',
-    className: '!border-[#fedf89] !bg-[#fffaeb] !text-[#b54708]',
-    dotClassName: 'bg-[#f79009]',
-  },
-  RUNNING: {
-    label: '运行中',
-    className: '!border-[#b7e4cf] !bg-[#edf9f3] !text-[#16845b]',
-    dotClassName: 'bg-[#12b76a]',
-  },
-  STOPPED: {
-    label: '已停止',
-    className: '!border-black/[0.08] !bg-[#f7f8fa] !text-[rgba(22,24,35,0.55)]',
-    dotClassName: 'bg-[#98a2b3]',
-  },
-  FAILED: {
-    label: '异常',
-    className: '!border-[#fecdca] !bg-[#fef3f2] !text-[#b42318]',
-    dotClassName: 'bg-[#f04438]',
-  },
-};
+interface SearchState {
+  keyword?: string;
+  id?: string;
+  mode?: RealtimeTaskMode;
+  status?: RealtimeTaskStatus;
+  source?: string;
+  sink?: string;
+}
 
-const modeIcon: Record<RealtimeTaskMode, ReactNode> = {
-  SINGLE_TABLE: <Table2 size={15} strokeWidth={1.8} />,
-  MULTI_TABLE: <DatabaseZap size={15} strokeWidth={1.8} />,
-  CUSTOM_YAML: <FileCode2 size={15} strokeWidth={1.8} />,
-};
+interface PaginationState {
+  current: number;
+  pageSize: number;
+}
 
 const modeQuery: Record<RealtimeTaskMode, string> = {
   SINGLE_TABLE: 'single',
@@ -75,19 +56,57 @@ const modeQuery: Record<RealtimeTaskMode, string> = {
   CUSTOM_YAML: 'yaml',
 };
 
+const statusMeta: Record<
+  RealtimeTaskStatus,
+  { label: string; className: string }
+> = {
+  DRAFT: {
+    label: '草稿',
+    className: '!border-[#fedf89] !bg-[#fffaeb] !text-[#b54708]',
+  },
+  RUNNING: {
+    label: '运行中',
+    className: '!border-[#b7e4cf] !bg-[#edf9f3] !text-[#16845b]',
+  },
+  STOPPED: {
+    label: '已停止',
+    className: '!border-[#eaecf0] !bg-[#f9fafb] !text-[#667085]',
+  },
+  FAILED: {
+    label: '异常',
+    className: '!border-[#fecdca] !bg-[#fef3f2] !text-[#b42318]',
+  },
+};
+
+const statusTabs: Array<{
+  label: string;
+  value: 'ALL' | RealtimeTaskStatus;
+}> = [
+  { label: '全部任务', value: 'ALL' },
+  { label: '运行中', value: 'RUNNING' },
+  { label: '草稿', value: 'DRAFT' },
+  { label: '已停止', value: 'STOPPED' },
+  { label: '异常', value: 'FAILED' },
+];
+
 const RealtimeLinkUpPage = () => {
   const [tasks, setTasks] = useState<RealtimeTaskRecord[]>([]);
   const [loading, setLoading] = useState(false);
-  const [keyword, setKeyword] = useState('');
-  const [mode, setMode] = useState<RealtimeTaskMode | undefined>();
-  const [status, setStatus] = useState<RealtimeTaskStatus | undefined>();
+  const [createOpen, setCreateOpen] = useState(false);
+  const [advancedOpen, setAdvancedOpen] = useState(false);
+  const [searchParams, setSearchParams] = useState<SearchState>({});
+  const [filterDraft, setFilterDraft] = useState<SearchState>({});
+  const [pagination, setPagination] = useState<PaginationState>({
+    current: 1,
+    pageSize: 10,
+  });
 
   const refresh = () => {
     setLoading(true);
     window.setTimeout(() => {
       setTasks(loadRealtimeTasks());
       setLoading(false);
-    }, 180);
+    }, 120);
   };
 
   useEffect(() => {
@@ -95,336 +114,555 @@ const RealtimeLinkUpPage = () => {
   }, []);
 
   const filteredTasks = useMemo(() => {
-    const normalized = keyword.trim().toLowerCase();
+    const keyword = searchParams.keyword?.trim().toLowerCase();
+    const id = searchParams.id?.trim().toLowerCase();
+    const source = searchParams.source?.trim().toLowerCase();
+    const sink = searchParams.sink?.trim().toLowerCase();
+
     return tasks.filter((task) => {
-      if (mode && task.mode !== mode) return false;
-      if (status && task.status !== status) return false;
-      if (!normalized) return true;
+      if (searchParams.mode && task.mode !== searchParams.mode) return false;
+      if (searchParams.status && task.status !== searchParams.status) return false;
+      if (id && !task.id.toLowerCase().includes(id)) return false;
+      if (source && !task.sourceSummary.toLowerCase().includes(source)) return false;
+      if (sink && !task.sinkSummary.toLowerCase().includes(sink)) return false;
+      if (!keyword) return true;
+
       return [
         task.id,
         task.name,
         task.description,
+        task.sourceType,
         task.sourceSummary,
+        task.sinkType,
         task.sinkSummary,
       ]
         .filter(Boolean)
-        .some((value) => String(value).toLowerCase().includes(normalized));
+        .some((value) => String(value).toLowerCase().includes(keyword));
     });
-  }, [keyword, mode, status, tasks]);
+  }, [searchParams, tasks]);
 
-  const stats = useMemo(
-    () => ({
-      total: tasks.length,
-      running: tasks.filter((task) => task.status === 'RUNNING').length,
-      draft: tasks.filter((task) => task.status === 'DRAFT').length,
-      yaml: tasks.filter((task) => task.mode === 'CUSTOM_YAML').length,
-    }),
-    [tasks],
-  );
+  const pagedTasks = useMemo(() => {
+    const start = (pagination.current - 1) * pagination.pageSize;
+    return filteredTasks.slice(start, start + pagination.pageSize);
+  }, [filteredTasks, pagination]);
+
+  useEffect(() => {
+    const maxPage = Math.max(
+      1,
+      Math.ceil(filteredTasks.length / pagination.pageSize),
+    );
+
+    if (pagination.current > maxPage) {
+      setPagination((current) => ({ ...current, current: maxPage }));
+    }
+  }, [filteredTasks.length, pagination.current, pagination.pageSize]);
+
+  const updateFilterDraft = (field: keyof SearchState, value: unknown) => {
+    setFilterDraft((current) => ({ ...current, [field]: value || undefined }));
+  };
+
+  const applyFilter = (nextFilter = filterDraft) => {
+    setFilterDraft(nextFilter);
+    setSearchParams(nextFilter);
+    setPagination((current) => ({ ...current, current: 1 }));
+  };
+
+  const handleReset = () => {
+    setFilterDraft({});
+    setSearchParams({});
+    setPagination((current) => ({ ...current, current: 1 }));
+  };
+
+  const handleStatusChange = (value: 'ALL' | RealtimeTaskStatus) => {
+    const nextFilter = {
+      ...filterDraft,
+      status: value === 'ALL' ? undefined : value,
+    };
+    applyFilter(nextFilter);
+  };
 
   const goEdit = (task: RealtimeTaskRecord) => {
     history.push(
-      `/sync/realtime-link-up/${task.id}/config?mode=${modeQuery[task.mode]}&scene=edit`,
+      `/sync/realtime-link-up/${encodeURIComponent(task.id)}/config?mode=${modeQuery[task.mode]}&scene=edit`,
     );
   };
 
-  const copyId = async (taskId: string) => {
+  const copyTaskId = async (taskId: string) => {
     try {
-      await navigator.clipboard.writeText(taskId);
+      if (navigator.clipboard && window.isSecureContext) {
+        await navigator.clipboard.writeText(taskId);
+      } else {
+        const textarea = document.createElement('textarea');
+        textarea.value = taskId;
+        textarea.style.position = 'fixed';
+        textarea.style.opacity = '0';
+        document.body.appendChild(textarea);
+        textarea.focus();
+        textarea.select();
+        document.execCommand('copy');
+        document.body.removeChild(textarea);
+      }
       message.success('任务 ID 已复制');
     } catch {
       message.error('复制失败，请手动复制');
     }
   };
 
-  const remove = (task: RealtimeTaskRecord) => {
+  const removeTask = (task: RealtimeTaskRecord) => {
     if (task.id.startsWith('rt-demo-')) {
-      message.info('示例任务用于页面预览，不能删除');
+      message.info('示例任务用于页面预览，暂不支持删除');
       return;
     }
+
     Modal.confirm({
       title: '删除实时同步任务？',
-      content: `确定删除“${task.name}”吗？此操作只删除当前浏览器中的前端草稿。`,
+      content: `确定删除“${task.name}”吗？任务草稿和页面配置会一并删除。`,
       okText: '删除',
       okButtonProps: { danger: true },
       cancelText: '取消',
       onOk: () => {
         removeRealtimeTask(task.id);
+        window.localStorage.removeItem(
+          `${REALTIME_DRAFT_STORAGE_PREFIX}${task.id}`,
+        );
         refresh();
-        message.success('任务已删除');
+        message.success('实时同步任务已删除');
       },
     });
   };
 
-  const columns: TableColumnsType<RealtimeTaskRecord> = [
+  const advancedFilterCount = [
+    filterDraft.id,
+    filterDraft.source,
+    filterDraft.sink,
+  ].filter(Boolean).length;
+
+  const currentTab = filterDraft.status || searchParams.status || 'ALL';
+
+  const columns = [
     {
-      title: '任务名称',
+      title: '名称 / ID',
       dataIndex: 'name',
-      width: 290,
-      fixed: 'left',
-      render: (_, task) => (
-        <button
-          type="button"
-          onClick={() => goEdit(task)}
-          className="group flex min-w-0 items-center gap-3 border-0 bg-transparent p-0 text-left"
-        >
-          <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-[8px] bg-[#f1f3f6] text-[#424754] transition group-hover:bg-[#e9edf2]">
-            {modeIcon[task.mode]}
-          </span>
-          <span className="min-w-0">
-            <span className="block truncate text-[12px] font-semibold text-[#252832] group-hover:text-[#315efb]">
-              {task.name}
+      width: 260,
+      render: (_: unknown, task: RealtimeTaskRecord) => (
+        <div className="min-w-0 py-0.5">
+          <button
+            type="button"
+            className="block max-w-full border-0 bg-transparent p-0 text-left"
+            onClick={() => goEdit(task)}
+          >
+            <span
+              className="block truncate text-[13px] font-medium leading-5 text-[#344054] hover:text-[#ff4d4f]"
+              title={task.name}
+            >
+              {task.name || '-'}
             </span>
-            <span className="mt-1 block truncate text-[10px] text-[rgba(22,24,35,0.42)]">
-              {task.description || task.id}
-            </span>
-          </span>
-        </button>
+          </button>
+          <div className="mt-0.5 flex h-5 items-center gap-1 text-[11px] leading-5 text-[#98a2b3]">
+            <span className="truncate">ID：{task.id}</span>
+            <Tooltip title="复制任务 ID">
+              <Button
+                type="text"
+                size="small"
+                icon={<CopyOutlined className="text-[11px]" />}
+                className="!flex !h-5 !w-5 !min-w-0 !items-center !justify-center !p-0 !text-[#98a2b3] hover:!bg-[#f2f4f7] hover:!text-[#475467]"
+                onClick={() => void copyTaskId(task.id)}
+              />
+            </Tooltip>
+          </div>
+        </div>
       ),
     },
     {
-      title: '任务类型',
+      title: '实时同步方案',
+      dataIndex: 'pipeline',
+      width: 340,
+      render: (_: unknown, task: RealtimeTaskRecord) => (
+        <div className="grid min-w-[300px] grid-cols-[minmax(0,1fr)_24px_minmax(0,1fr)] items-center gap-1 text-[12px]">
+          <div className="min-w-0">
+            <div className="truncate font-medium text-[#475467]">
+              {task.sourceType || '-'}
+            </div>
+            <div className="mt-0.5 truncate text-[11px] text-[#98a2b3]">
+              {task.sourceSummary || '-'}
+            </div>
+          </div>
+          <span className="text-center text-[#d0d5dd]">→</span>
+          <div className="min-w-0">
+            <div className="truncate font-medium text-[#475467]">
+              {task.sinkType || '-'}
+            </div>
+            <div className="mt-0.5 truncate text-[11px] text-[#98a2b3]">
+              {task.sinkSummary || '-'}
+            </div>
+          </div>
+        </div>
+      ),
+    },
+    {
+      title: '同步模式',
       dataIndex: 'mode',
-      width: 130,
+      width: 120,
+      align: 'center' as const,
       render: (value: RealtimeTaskMode) => {
         const meta = modeMeta[value];
         return (
-          <Tag className={`!m-0 !rounded-full !px-2.5 !text-[10px] ${meta.className}`}>
+          <Tag className={`!m-0 !rounded-full !px-2.5 !text-[11px] ${meta.className}`}>
             {meta.label}
           </Tag>
         );
       },
-    },
-    {
-      title: '同步链路',
-      key: 'pipeline',
-      width: 360,
-      render: (_, task) => (
-        <div className="flex min-w-0 items-center gap-2 text-[10px]">
-          <div className="min-w-0 flex-1 rounded-[6px] border border-black/[0.055] bg-[#fafafa] px-2.5 py-2">
-            <div className="font-semibold text-[#343741]">{task.sourceType}</div>
-            <div className="mt-0.5 truncate font-mono text-[9px] text-[rgba(22,24,35,0.42)]">
-              {task.sourceSummary}
-            </div>
-          </div>
-          <span className="text-[rgba(22,24,35,0.30)]">→</span>
-          <div className="min-w-0 flex-1 rounded-[6px] border border-black/[0.055] bg-[#fafafa] px-2.5 py-2">
-            <div className="font-semibold text-[#343741]">{task.sinkType}</div>
-            <div className="mt-0.5 truncate font-mono text-[9px] text-[rgba(22,24,35,0.42)]">
-              {task.sinkSummary}
-            </div>
-          </div>
-        </div>
-      ),
-    },
-    {
-      title: '运行版本',
-      key: 'version',
-      width: 160,
-      render: (_, task) => (
-        <div className="text-[10px] leading-5 text-[#343741]">
-          <div>Flink {task.flinkVersion}</div>
-          <div className="text-[rgba(22,24,35,0.42)]">CDC {task.cdcVersion}</div>
-        </div>
-      ),
     },
     {
       title: '状态',
       dataIndex: 'status',
-      width: 105,
+      width: 100,
+      align: 'center' as const,
       render: (value: RealtimeTaskStatus) => {
         const meta = statusMeta[value];
         return (
-          <Tag className={`!m-0 !inline-flex !items-center !gap-1.5 !rounded-full !px-2.5 !text-[10px] ${meta.className}`}>
-            <span className={`h-1.5 w-1.5 rounded-full ${meta.dotClassName}`} />
+          <Tag className={`!m-0 !rounded-full !px-2.5 !text-[11px] ${meta.className}`}>
             {meta.label}
           </Tag>
         );
       },
     },
     {
+      title: '运行版本',
+      dataIndex: 'version',
+      width: 150,
+      render: (_: unknown, task: RealtimeTaskRecord) => (
+        <div className="text-[12px] leading-5 text-[#667085]">
+          <div>Flink {task.flinkVersion || '-'}</div>
+          <div className="text-[11px] text-[#98a2b3]">
+            CDC {task.cdcVersion || '-'}
+          </div>
+        </div>
+      ),
+    },
+    {
       title: '更新时间',
       dataIndex: 'updatedAt',
-      width: 170,
+      width: 175,
       render: (value: string) => (
-        <span className="text-[10px] text-[rgba(22,24,35,0.48)]">{value}</span>
+        <span className="whitespace-nowrap text-[12px] text-[#98a2b3]">
+          {value || '-'}
+        </span>
       ),
     },
     {
       title: '操作',
-      key: 'action',
-      fixed: 'right',
-      width: 100,
-      align: 'center',
-      render: (_, task) => {
-        const items: MenuProps['items'] = [
-          {
-            key: 'copy',
-            icon: <Copy size={14} />,
-            label: '复制任务 ID',
-            onClick: () => void copyId(task.id),
-          },
-          { type: 'divider' },
-          {
-            key: 'delete',
-            danger: true,
-            icon: <Trash2 size={14} />,
-            label: '删除任务',
-            onClick: () => remove(task),
-          },
-        ];
-        return (
-          <div className="flex items-center justify-center gap-1">
-            <Button
-              type="link"
-              size="small"
-              onClick={() => goEdit(task)}
-              className="!px-1 !text-[10px] !font-semibold !text-[#315efb]"
-            >
-              编辑
-            </Button>
-            <Dropdown menu={{ items }} trigger={['click']} placement="bottomRight">
-              <button
-                type="button"
-                className="flex h-7 w-7 items-center justify-center rounded-[6px] border-0 bg-transparent text-[rgba(22,24,35,0.40)] hover:bg-[#f1f3f6] hover:text-[#161823]"
-              >
-                <MoreHorizontal size={15} />
-              </button>
-            </Dropdown>
-          </div>
-        );
-      },
+      dataIndex: 'operate',
+      width: 130,
+      fixed: 'right' as const,
+      render: (_: unknown, task: RealtimeTaskRecord) => (
+        <div className="flex items-center gap-1">
+          <Button
+            type="link"
+            size="small"
+            className="!h-7 !px-2 !text-[12px] !text-[#475467] hover:!text-[#ff4d4f]"
+            onClick={() => goEdit(task)}
+          >
+            编辑
+          </Button>
+          <Button
+            type="link"
+            danger
+            size="small"
+            className="!h-7 !px-2 !text-[12px]"
+            onClick={() => removeTask(task)}
+          >
+            删除
+          </Button>
+        </div>
+      ),
     },
   ];
 
-  const createTask = () => {
-    const taskId = createTaskId();
-    history.push(`/sync/realtime-link-up/${taskId}/detail?scene=create`);
-  };
-
   return (
-    <div className="min-h-[calc(100vh-48px)] bg-[#f7f8fa] px-5 py-5">
-      <div className="mx-auto max-w-[1560px]">
-        <div className="flex items-start justify-between gap-5">
-          <div>
-            <div className="flex items-center gap-2">
-              <span className="flex h-9 w-9 items-center justify-center rounded-[9px] bg-[#161823] text-white">
-                <Activity size={18} strokeWidth={1.8} />
-              </span>
-              <div>
-                <h1 className="text-[20px] font-semibold tracking-[-0.01em] text-[#161823]">实时同步</h1>
-                <p className="mt-0.5 text-[11px] text-[rgba(22,24,35,0.46)]">
-                  基于 Flink CDC Pipeline 管理单表、多表和自定义 YAML 实时任务定义
-                </p>
+    <ConfigProvider theme={BRAND_THEME}>
+      <div className="flex min-h-[calc(100vh-64px)] flex-col bg-white px-5 pt-4">
+        <h1 className="text-[17px] font-semibold text-[#101828]">实时同步</h1>
+
+        <div className="mx-auto flex w-full max-w-full flex-1 flex-col">
+          <div className="mb-3 border-b border-[#f0f0f0]">
+            <div className="flex min-h-[54px] items-center justify-between gap-4 py-2">
+              <div className="flex shrink-0 items-center gap-1 rounded-lg bg-[#f5f5f6] p-1">
+                {statusTabs.map((item) => {
+                  const active = currentTab === item.value;
+
+                  return (
+                    <button
+                      key={item.value}
+                      type="button"
+                      onClick={() => handleStatusChange(item.value)}
+                      className={[
+                        'h-8 rounded-md px-3.5 text-[13px] font-medium transition-all',
+                        active
+                          ? 'bg-white text-[#ff4d4f] shadow-[0_1px_4px_rgba(16,24,40,0.08)]'
+                          : 'text-[#667085] hover:bg-white/70 hover:text-[#344054]',
+                      ].join(' ')}
+                    >
+                      {item.label}
+                    </button>
+                  );
+                })}
+              </div>
+
+              <div className="flex min-w-0 flex-1 items-center justify-end gap-2 overflow-x-auto">
+                <Input
+                  allowClear
+                  variant="filled"
+                  value={filterDraft.keyword}
+                  prefix={<SearchOutlined className="text-[#98a2b3]" />}
+                  placeholder="搜索任务名称或同步链路"
+                  className="!h-9 !w-[240px] !min-w-[200px]"
+                  onChange={(event) =>
+                    updateFilterDraft('keyword', event.target.value)
+                  }
+                  onPressEnter={() => applyFilter()}
+                />
+
+                <Select
+                  allowClear
+                  variant="filled"
+                  value={filterDraft.mode}
+                  placeholder="同步模式"
+                  className="!h-9 !w-[150px] !min-w-[140px]"
+                  options={Object.entries(modeMeta).map(([value, meta]) => ({
+                    label: meta.label,
+                    value,
+                  }))}
+                  onChange={(value) => {
+                    const nextFilter = { ...filterDraft, mode: value };
+                    applyFilter(nextFilter);
+                  }}
+                />
+
+                <Button className="!h-9 !px-4" onClick={() => applyFilter()}>
+                  查询
+                </Button>
+
+                <Popover
+                  trigger="click"
+                  placement="bottomRight"
+                  open={advancedOpen}
+                  onOpenChange={setAdvancedOpen}
+                  content={
+                    <div className="w-[420px]">
+                      <div className="mb-4">
+                        <div className="text-[14px] font-semibold text-[#101828]">
+                          高级搜索
+                        </div>
+                        <div className="mt-1 text-[12px] text-[#98a2b3]">
+                          按任务标识、来源和目标信息进一步筛选
+                        </div>
+                      </div>
+
+                      <div className="grid grid-cols-2 gap-3">
+                        <div className="col-span-2">
+                          <div className="mb-1.5 text-[12px] text-[#667085]">
+                            任务 ID
+                          </div>
+                          <Input
+                            allowClear
+                            variant="filled"
+                            value={filterDraft.id}
+                            placeholder="请输入任务 ID"
+                            onChange={(event) =>
+                              updateFilterDraft('id', event.target.value)
+                            }
+                          />
+                        </div>
+                        <div>
+                          <div className="mb-1.5 text-[12px] text-[#667085]">
+                            来源信息
+                          </div>
+                          <Input
+                            allowClear
+                            variant="filled"
+                            value={filterDraft.source}
+                            placeholder="来源库或表"
+                            onChange={(event) =>
+                              updateFilterDraft('source', event.target.value)
+                            }
+                          />
+                        </div>
+                        <div>
+                          <div className="mb-1.5 text-[12px] text-[#667085]">
+                            目标信息
+                          </div>
+                          <Input
+                            allowClear
+                            variant="filled"
+                            value={filterDraft.sink}
+                            placeholder="目标库或表"
+                            onChange={(event) =>
+                              updateFilterDraft('sink', event.target.value)
+                            }
+                          />
+                        </div>
+                      </div>
+
+                      <div className="mt-5 flex items-center justify-end gap-2 border-t border-[#f0f0f0] pt-4">
+                        <Button
+                          size="small"
+                          className="!h-8"
+                          onClick={() => {
+                            const nextFilter = {
+                              ...filterDraft,
+                              id: undefined,
+                              source: undefined,
+                              sink: undefined,
+                            };
+                            applyFilter(nextFilter);
+                          }}
+                        >
+                          重置
+                        </Button>
+                        <Button
+                          danger
+                          type="primary"
+                          size="small"
+                          className="!h-8"
+                          onClick={() => {
+                            applyFilter();
+                            setAdvancedOpen(false);
+                          }}
+                        >
+                          应用筛选
+                        </Button>
+                      </div>
+                    </div>
+                  }
+                >
+                  <Button
+                    icon={<FilterOutlined />}
+                    className={[
+                      '!h-9 !px-3',
+                      advancedFilterCount > 0
+                        ? '!border-[#ffccc7] !bg-[#fff1f0] !text-[#ff4d4f]'
+                        : '',
+                    ].join(' ')}
+                  >
+                    高级搜索
+                    {advancedFilterCount > 0 && (
+                      <span className="ml-1.5 inline-flex h-[18px] min-w-[18px] items-center justify-center rounded-full bg-[#ff4d4f] px-1 text-[10px] text-white">
+                        {advancedFilterCount}
+                      </span>
+                    )}
+                  </Button>
+                </Popover>
               </div>
             </div>
           </div>
-          <Button
-            type="primary"
-            icon={<Plus size={15} strokeWidth={2} />}
-            onClick={createTask}
-            className="!h-9 !rounded-[8px] !border-[#161823] !bg-[#161823] !px-4 !text-[11px] !font-semibold hover:!border-[#2b2d38] hover:!bg-[#2b2d38]"
-          >
-            新建实时同步
-          </Button>
-        </div>
 
-        <div className="mt-5 grid grid-cols-4 gap-3 max-xl:grid-cols-2 max-md:grid-cols-1">
-          {[
-            { label: '任务总数', value: stats.total, help: '当前全部任务定义' },
-            { label: '运行中', value: stats.running, help: '后续由执行接口更新' },
-            { label: '草稿任务', value: stats.draft, help: '尚未发布的配置' },
-            { label: '自定义 YAML', value: stats.yaml, help: '高级 Pipeline 模式' },
-          ].map((item) => (
-            <div key={item.label} className="rounded-[10px] border border-black/[0.065] bg-white px-4 py-4">
-              <div className="text-[10px] font-medium text-[rgba(22,24,35,0.44)]">{item.label}</div>
-              <div className="mt-2 text-[23px] font-semibold tracking-[-0.02em] text-[#161823]">{item.value}</div>
-              <div className="mt-1 text-[9px] text-[rgba(22,24,35,0.36)]">{item.help}</div>
+          <div className="flex min-h-[48px] items-center justify-between">
+            <div className="flex items-center gap-2">
+              <Button
+                type="text"
+                icon={<ReloadOutlined spin={loading} />}
+                className="!h-8 !px-2 !text-[#667085]"
+                onClick={refresh}
+              >
+                刷新
+              </Button>
+              {(searchParams.keyword ||
+                searchParams.mode ||
+                searchParams.id ||
+                searchParams.source ||
+                searchParams.sink) && (
+                <Button type="link" size="small" onClick={handleReset}>
+                  清空筛选
+                </Button>
+              )}
             </div>
-          ))}
-        </div>
 
-        <section className="mt-4 overflow-hidden rounded-[10px] border border-black/[0.065] bg-white">
-          <div className="flex flex-wrap items-center justify-between gap-3 border-b border-black/[0.055] px-4 py-3.5">
-            <div className="flex flex-1 flex-wrap items-center gap-2">
-              <Input
-                allowClear
-                value={keyword}
-                onChange={(event) => setKeyword(event.target.value)}
-                prefix={<Search size={14} className="text-[rgba(22,24,35,0.30)]" />}
-                placeholder="搜索任务名称、ID、来源表或目标表"
-                className="!h-9 !w-[320px] !rounded-[7px] !border-black/[0.075] !text-[11px] max-md:!w-full"
-              />
-              <Select
-                allowClear
-                value={mode}
-                onChange={setMode}
-                placeholder="全部类型"
-                options={Object.entries(modeMeta).map(([value, meta]) => ({
-                  label: meta.label,
-                  value,
-                }))}
-                className="w-[150px] [&_.ant-select-selector]:!h-9 [&_.ant-select-selector]:!rounded-[7px] [&_.ant-select-selector]:!border-black/[0.075] [&_.ant-select-selection-item]:!text-[10px] [&_.ant-select-selection-item]:!leading-[34px] [&_.ant-select-selection-placeholder]:!text-[10px] [&_.ant-select-selection-placeholder]:!leading-[34px]"
-              />
-              <Select
-                allowClear
-                value={status}
-                onChange={setStatus}
-                placeholder="全部状态"
-                options={Object.entries(statusMeta).map(([value, meta]) => ({
-                  label: meta.label,
-                  value,
-                }))}
-                className="w-[140px] [&_.ant-select-selector]:!h-9 [&_.ant-select-selector]:!rounded-[7px] [&_.ant-select-selector]:!border-black/[0.075] [&_.ant-select-selection-item]:!text-[10px] [&_.ant-select-selection-item]:!leading-[34px] [&_.ant-select-selection-placeholder]:!text-[10px] [&_.ant-select-selection-placeholder]:!leading-[34px]"
-              />
-            </div>
-            <button
-              type="button"
-              onClick={refresh}
-              className="flex h-8 w-8 items-center justify-center rounded-[7px] border border-black/[0.07] bg-white text-[rgba(22,24,35,0.42)] transition hover:border-black/[0.14] hover:text-[#161823]"
+            <Button
+              danger
+              type="primary"
+              size="small"
+              className="!h-8"
+              onClick={() => setCreateOpen(true)}
             >
-              <RefreshCw size={14} className={loading ? 'animate-spin' : ''} />
-            </button>
+              新建实时同步任务
+            </Button>
           </div>
 
-          <Table<RealtimeTaskRecord>
-            rowKey="id"
-            columns={columns}
-            dataSource={filteredTasks}
-            loading={loading}
-            pagination={{
-              pageSize: 10,
-              showSizeChanger: true,
-              showTotal: (total) => `共 ${total} 条`,
-              className: '!mx-4 !my-3 !text-[10px]',
-            }}
-            scroll={{ x: 1320 }}
-            className={[
-              '[&_.ant-table]:!rounded-none',
-              '[&_.ant-table-container]:!border-0',
-              '[&_.ant-table-thead>tr>th]:!h-11',
-              '[&_.ant-table-thead>tr>th]:!border-b',
-              '[&_.ant-table-thead>tr>th]:!border-black/[0.055]',
-              '[&_.ant-table-thead>tr>th]:!bg-[#fafafa]',
-              '[&_.ant-table-thead>tr>th]:!text-[10px]',
-              '[&_.ant-table-thead>tr>th]:!font-semibold',
-              '[&_.ant-table-thead>tr>th]:!text-[rgba(22,24,35,0.55)]',
-              '[&_.ant-table-tbody>tr>td]:!border-black/[0.045]',
-              '[&_.ant-table-tbody>tr>td]:!py-3',
-              '[&_.ant-table-tbody>tr:hover>td]:!bg-[#fcfcfd]',
-            ].join(' ')}
-            locale={{
-              emptyText: (
-                <Empty
-                  image={Empty.PRESENTED_IMAGE_SIMPLE}
-                  description={<span className="text-[11px] text-[rgba(22,24,35,0.42)]">暂无符合条件的实时同步任务</span>}
-                />
-              ),
-            }}
-          />
-        </section>
+          <div className="flex-1">
+            <Table
+              columns={columns}
+              dataSource={pagedTasks}
+              rowKey="id"
+              bordered
+              size="small"
+              pagination={false}
+              loading={loading}
+              scroll={{ x: 'max-content' }}
+              className={[
+                'compact-realtime-task-table',
+                '[&_.ant-table]:!text-[13px]',
+                '[&_.ant-table-container]:!border-[#eaecf0]',
+                '[&_.ant-table-cell]:!align-middle',
+                '[&_.ant-table-thead>tr>th]:!h-10',
+                '[&_.ant-table-thead>tr>th]:!bg-[#f8f9fb]',
+                '[&_.ant-table-thead>tr>th]:!px-4',
+                '[&_.ant-table-thead>tr>th]:!py-2',
+                '[&_.ant-table-thead>tr>th]:!text-[12px]',
+                '[&_.ant-table-thead>tr>th]:!font-medium',
+                '[&_.ant-table-thead>tr>th]:!text-[#667085]',
+                '[&_.ant-table-thead>tr>th]:!border-[#eaecf0]',
+                '[&_.ant-table-tbody>tr>td]:!px-4',
+                '[&_.ant-table-tbody>tr>td]:!py-2.5',
+                '[&_.ant-table-tbody>tr>td]:!border-[#f0f2f5]',
+                '[&_.ant-table-tbody>tr>td]:!text-[#667085]',
+                '[&_.ant-table-tbody>tr:hover>td]:!bg-[#fafbfc]',
+                '[&_.ant-table-cell-fix-right]:!bg-white',
+                '[&_.ant-table-tbody>tr:hover_.ant-table-cell-fix-right]:!bg-[#fafbfc]',
+                '[&_.ant-table-placeholder>td]:!h-[260px]',
+              ].join(' ')}
+              locale={{
+                emptyText: (
+                  <Empty
+                    image={Empty.PRESENTED_IMAGE_SIMPLE}
+                    description={
+                      <span className="text-[12px] text-[#98a2b3]">
+                        暂无实时同步任务
+                      </span>
+                    }
+                  />
+                ),
+              }}
+            />
+          </div>
+
+          <div className="sticky bottom-0 z-20 mt-auto flex min-h-[56px] items-center justify-end border border-t-0 border-[#e5e7eb] bg-white px-5 py-3 shadow-[0_-4px_12px_rgba(16,24,40,0.04)]">
+            <Pagination
+              showSizeChanger
+              showQuickJumper
+              showTotal={(total) => `共 ${total} 条`}
+              total={filteredTasks.length}
+              current={pagination.current}
+              pageSize={pagination.pageSize}
+              onChange={(current, pageSize) =>
+                setPagination({ current, pageSize })
+              }
+            />
+          </div>
+        </div>
+
+        <CreateRealtimeTaskDrawer
+          open={createOpen}
+          onCancel={() => setCreateOpen(false)}
+          onCreated={(taskId, mode) => {
+            setCreateOpen(false);
+            history.push(
+              `/sync/realtime-link-up/${encodeURIComponent(taskId)}/config?mode=${modeQuery[mode]}&scene=create`,
+            );
+          }}
+        />
       </div>
-    </div>
+    </ConfigProvider>
   );
 };
 


### PR DESCRIPTION
## 改动说明

- 重构实时同步任务列表，使筛选栏、表格、底部分页和操作区与离线同步保持一致
- 新增实时同步任务创建抽屉，支持单表同步、多表同步和自定义 YAML 三种模式
- 保留现有 Flink CDC 配置模型与 YAML 生成逻辑，仅重构公共页面外壳
- 统一单表、多表和 YAML 配置页的标题区、步骤导航、内容宽度和底部保存栏
- 实时同步不展示调度信息，也不提供调度配置入口
- 基于 localStorage 打通前端创建、查询、编辑保存和删除草稿的基础交互

## 页面交互

- 状态快捷筛选：全部、运行中、草稿、已停止、异常
- 常用筛选：任务名称/链路、同步模式
- 高级筛选：任务 ID、来源信息、目标信息
- 新建任务后直接进入对应模式配置页
- 删除用户创建任务时同步清理任务记录和配置草稿
- 配置页支持 YAML 预览、步骤切换、保存和取消返回

## 校验

- 已检查分支相对 `main` 的变更范围，仅涉及实时同步前端 3 个文件
- 已核对 Ant Design 版本支持 `variant="filled"`、Drawer/Form/Pagination 等本次使用能力
- 当前执行环境没有 `gh` 和仓库依赖，未能在本地运行 `npm run tsc`；请以 PR CI 结果作为最终类型与构建校验
