### PR TITLE
refactor(client): rebuild client management page

### DIFF
--- a/yak-ops-ui/src/pages/client/hooks/useClientPageState.ts
+++ b/yak-ops-ui/src/pages/client/hooks/useClientPageState.ts
@@ -1,91 +1,129 @@
-import {Form, message} from "antd";
-import {useCallback, useEffect, useMemo, useState} from "react";
-import {linkupClientApi} from "../api";
+import { Form, message } from 'antd';
+import { useCallback, useEffect, useState } from 'react';
 
+import type { LinkupClient, LinkupClientMetrics } from '../api';
+import { linkupClientApi } from '../api';
+
+const normalizePageRecords = (response: any): LinkupClient[] => {
+  const data = response?.data || response;
+
+  if (Array.isArray(data)) return data;
+  if (Array.isArray(data?.records)) return data.records;
+  if (Array.isArray(data?.data?.records)) return data.data.records;
+
+  return [];
+};
+
+const normalizeMetrics = (response: any): LinkupClientMetrics | undefined => {
+  const data = response?.data || response;
+
+  if (!data || typeof data !== 'object' || Array.isArray(data)) {
+    return undefined;
+  }
+
+  return data as LinkupClientMetrics;
+};
+
+const normalizePort = (value?: string | number) => {
+  if (value === undefined || value === null || value === '') return undefined;
+
+  const numberValue = Number(value);
+  return Number.isNaN(numberValue) ? undefined : numberValue;
+};
 
 export const useClientPageState = () => {
   const [form] = Form.useForm();
 
-  const [clients, setClients] = useState<any[]>([]);
-  const [selectedClientId, setSelectedClientId] = useState<number>();
+  const [clients, setClients] = useState<LinkupClient[]>([]);
+  const [loading, setLoading] = useState(false);
   const [openAddModal, setOpenAddModal] = useState(false);
-  const [editingClient, setEditingClient] = useState<any>();
+  const [editingClient, setEditingClient] = useState<LinkupClient>();
   const [confirmLoading, setConfirmLoading] = useState(false);
-  const [metricsLoading, setMetricsLoading] = useState(false);
   const [deleteLoadingId, setDeleteLoadingId] = useState<number>();
-  const [metrics, setMetrics] = useState<any>();
+  const [metricsByClientId, setMetricsByClientId] = useState<Record<number, LinkupClientMetrics | undefined>>({});
+  const [metricsLoadingIds, setMetricsLoadingIds] = useState<Set<number>>(new Set());
 
-  const selectedClient = useMemo(() => {
-    return clients.find((item) => item.id === selectedClientId);
-  }, [clients, selectedClientId]);
+  const loadClientMetrics = useCallback(async (id: number) => {
+    if (!id) return;
 
-  const normalizePageRecords = (res: any) => {
-    const data = res?.data || res;
+    setMetricsLoadingIds((previous) => {
+      const next = new Set(previous);
+      next.add(id);
+      return next;
+    });
 
-    if (Array.isArray(data)) {
-      return data;
-    }
+    try {
+      const response = await linkupClientApi.metrics(id);
+      const metrics = normalizeMetrics(response);
 
-    if (Array.isArray(data?.records)) {
-      return data.records;
-    }
-
-    if (Array.isArray(data?.data?.records)) {
-      return data.data.records;
-    }
-
-    return [];
-  };
-
-  const loadClients = useCallback(
-    async (nextSelectedId?: number) => {
-      const res = await linkupClientApi.page({
-        pageNo: 1,
-        pageSize: 999,
+      setMetricsByClientId((previous) => ({
+        ...previous,
+        [id]: metrics,
+      }));
+    } catch (error) {
+      setMetricsByClientId((previous) => ({
+        ...previous,
+        [id]: undefined,
+      }));
+      console.error('加载客户端指标失败', error);
+    } finally {
+      setMetricsLoadingIds((previous) => {
+        const next = new Set(previous);
+        next.delete(id);
+        return next;
       });
+    }
+  }, []);
 
-      const records = normalizePageRecords(res);
-      setClients(records);
+  const loadClientMetricsBatch = useCallback(async (records: LinkupClient[]) => {
+    const ids = records
+      .map((item) => Number(item.id))
+      .filter((id) => Number.isFinite(id) && id > 0);
 
-      if (!records.length) {
-        setSelectedClientId(undefined);
-        setMetrics(undefined);
-        return records;
-      }
-
-      const targetId =
-        nextSelectedId && records.some((item: any) => item.id === nextSelectedId)
-          ? nextSelectedId
-          : selectedClientId &&
-          records.some((item: any) => item.id === selectedClientId)
-          ? selectedClientId
-          : records[0].id;
-
-      setSelectedClientId(targetId);
-      return records;
-    },
-    [selectedClientId]
-  );
-
-  const loadClientMetrics = useCallback(async (id?: number) => {
-    const targetId = id;
-    if (!targetId) {
-      setMetrics(undefined);
+    if (!ids.length) {
+      setMetricsByClientId({});
       return;
     }
 
-    setMetricsLoading(true);
-    try {
-      const res = await linkupClientApi.metrics(targetId);
-      setMetrics(res?.data || res);
-    } catch (e) {
-      // 产生异常都认为client存在问题
-      setMetrics(-1);
-      console.error(e);
-    } finally {
-      setMetricsLoading(false);
-    }
+    setMetricsLoadingIds(new Set(ids));
+
+    const entries = await Promise.all(
+      ids.map(async (id) => {
+        try {
+          const response = await linkupClientApi.metrics(id);
+          return [id, normalizeMetrics(response)] as const;
+        } catch (error) {
+          console.error(`加载客户端 ${id} 指标失败`, error);
+          return [id, undefined] as const;
+        }
+      }),
+    );
+
+    setMetricsByClientId(Object.fromEntries(entries));
+    setMetricsLoadingIds(new Set());
   }, []);
+
+  const loadClients = useCallback(async () => {
+    setLoading(true);
+
+    try {
+      const response = await linkupClientApi.page({
+        pageNo: 1,
+        pageSize: 999,
+      });
+      const records = normalizePageRecords(response);
+
+      setClients(records);
+      void loadClientMetricsBatch(records);
+      return records;
+    } catch (error) {
+      console.error('加载客户端列表失败', error);
+      message.error('客户端列表加载失败');
+      return [];
+    } finally {
+      setLoading(false);
+    }
+  }, [loadClientMetricsBatch]);
 
   const handleOpenCreate = useCallback(() => {
     setEditingClient(undefined);
@@ -94,12 +132,12 @@ export const useClientPageState = () => {
   }, [form]);
 
   const handleOpenEdit = useCallback(
-    (client: any) => {
+    (client: LinkupClient) => {
       setEditingClient(client);
       form.resetFields();
       setOpenAddModal(true);
     },
-    [form]
+    [form],
   );
 
   const handleCancelModal = useCallback(() => {
@@ -114,76 +152,67 @@ export const useClientPageState = () => {
     const payload = {
       ...values,
       id: editingClient?.id,
-      clientPort: Number(values.clientPort),
+      clientPort: normalizePort(values.clientPort),
+      masterEndpoints: values.masterEndpoints?.map((endpoint, index) => ({
+        ...endpoint,
+        port: normalizePort(endpoint.port),
+        role: 'MASTER',
+        priority: endpoint.priority || index + 1,
+      })),
     };
 
     setConfirmLoading(true);
+
     try {
-      await linkupClientApi.saveOrUpdate(payload);
-
-      message.success(editingClient ? "Client 修改成功" : "Client 创建成功");
-
+      await linkupClientApi.saveOrUpdate(payload as any);
+      message.success(editingClient ? '客户端修改成功' : '客户端创建成功');
       setOpenAddModal(false);
       setEditingClient(undefined);
       form.resetFields();
-
-      await loadClients(editingClient?.id);
+      await loadClients();
+    } catch (error) {
+      console.error('保存客户端失败', error);
+      message.error(editingClient ? '客户端修改失败' : '客户端创建失败');
     } finally {
       setConfirmLoading(false);
     }
   }, [editingClient, form, loadClients]);
 
   const handleDeleteClient = useCallback(
-    async (client: any) => {
-      if (!client?.id) return;
+    async (client: LinkupClient) => {
+      const clientId = Number(client.id);
+      if (!clientId) return;
 
-      setDeleteLoadingId(client.id);
+      setDeleteLoadingId(clientId);
+
       try {
-        await linkupClientApi.delete(client.id);
-        message.success("Client 删除成功");
-
-        const nextClients = await loadClients();
-
-        if (selectedClientId === client.id) {
-          const nextSelected = nextClients.find((item: any) => item.id !== client.id);
-          setSelectedClientId(nextSelected?.id);
-        }
+        await linkupClientApi.delete(clientId);
+        message.success('客户端删除成功');
+        await loadClients();
+      } catch (error) {
+        console.error('删除客户端失败', error);
+        message.error('客户端删除失败');
       } finally {
         setDeleteLoadingId(undefined);
       }
     },
-    [loadClients, selectedClientId]
+    [loadClients],
   );
 
   useEffect(() => {
-    loadClients();
-  }, []);
-
-  useEffect(() => {
-    if (selectedClientId) {
-      loadClientMetrics(selectedClientId);
-    } else {
-      setMetrics(undefined);
-    }
-  }, [selectedClientId, loadClientMetrics]);
+    void loadClients();
+  }, [loadClients]);
 
   return {
     clients,
-    selectedClientId,
-    setSelectedClientId,
-    selectedClient,
-
+    loading,
     openAddModal,
-    setOpenAddModal,
     editingClient,
-
     confirmLoading,
-    metricsLoading,
     deleteLoadingId,
-
-    metrics,
+    metricsByClientId,
+    metricsLoadingIds,
     form,
-
     handleOpenCreate,
     handleOpenEdit,
     handleDeleteClient,

--- a/yak-ops-ui/src/pages/client/index.tsx
+++ b/yak-ops-ui/src/pages/client/index.tsx
@@ -1,113 +1,459 @@
-import React from "react";
-import ClickSpark from "@/components/ClickSpark";
-import AddClientModal from "./components/AddClientModal";
-import ClientPageHeader from "./components/ClientPageHeader";
-import ClientListPanel from "./components/ClientListPanel";
-import ClientDetailPanel from "./components/ClientDetailPanel";
-import {BORDER_COLOR, CARD_BG, PAGE_BG} from "./constants";
-import {useClientPageState} from "./hooks/useClientPageState";
+import {
+  CloudServerOutlined,
+  DeleteOutlined,
+  EditOutlined,
+  EyeOutlined,
+  LinkOutlined,
+  PlusOutlined,
+  ReloadOutlined,
+  SearchOutlined,
+} from '@ant-design/icons';
+import { history } from '@umijs/max';
+import {
+  Button,
+  ConfigProvider,
+  Empty,
+  Input,
+  Popconfirm,
+  Skeleton,
+  Tag,
+  Tooltip,
+} from 'antd';
+import { useMemo, useState } from 'react';
 
-const ClientPageTailwind: React.FC = () => {
+import {
+  BRAND_COLOR,
+  BRAND_THEME,
+} from '@/styles/brand';
+
+import type { LinkupClient, LinkupClientMetrics } from './api';
+import AddClientModal from './components/AddClientModal';
+import { useClientPageState } from './hooks/useClientPageState';
+
+type ClientStatusFilter = 'all' | 'online' | 'warning' | 'offline';
+
+interface StatusTab {
+  key: ClientStatusFilter;
+  label: string;
+}
+
+const statusTabs: StatusTab[] = [
+  { key: 'all', label: '全部客户端' },
+  { key: 'online', label: '在线' },
+  { key: 'warning', label: '异常' },
+  { key: 'offline', label: '离线' },
+];
+
+const getHealthMeta = (healthStatus?: number) => {
+  if (healthStatus === 1) {
+    return {
+      filter: 'online' as const,
+      label: '在线',
+      dotClass: 'bg-emerald-500',
+      tagClass: '!border-emerald-200 !bg-emerald-50 !text-emerald-700',
+      iconClass: 'border-emerald-100 bg-emerald-50 text-emerald-600',
+    };
+  }
+
+  if (healthStatus === 2) {
+    return {
+      filter: 'warning' as const,
+      label: '异常',
+      dotClass: 'bg-amber-500',
+      tagClass: '!border-amber-200 !bg-amber-50 !text-amber-700',
+      iconClass: 'border-amber-100 bg-amber-50 text-amber-600',
+    };
+  }
+
+  return {
+    filter: 'offline' as const,
+    label: '离线',
+    dotClass: 'bg-rose-500',
+    tagClass: '!border-rose-200 !bg-rose-50 !text-rose-700',
+    iconClass: 'border-rose-100 bg-rose-50 text-rose-600',
+  };
+};
+
+const normalizeKeyword = (value?: string) => value?.trim().toLowerCase() || '';
+
+const formatPercent = (value?: number) => {
+  if (value === undefined || value === null || Number.isNaN(Number(value))) {
+    return '--';
+  }
+
+  return `${Math.round(Number(value) * 10) / 10}%`;
+};
+
+const formatNumber = (value?: number) => {
+  if (value === undefined || value === null || Number.isNaN(Number(value))) {
+    return '--';
+  }
+
+  return Number(value).toLocaleString();
+};
+
+const formatTime = (value?: string) => value || '--';
+
+const getClientAddress = (client: LinkupClient) => {
+  if (client.baseUrl) return client.baseUrl;
+
+  if (client.clientAddress) {
+    const port = (client as LinkupClient & { clientPort?: number | string })
+      .clientPort;
+    return port ? `${client.clientAddress}:${port}` : client.clientAddress;
+  }
+
+  return '--';
+};
+
+interface ClientMetricItemProps {
+  label: string;
+  value: string;
+  loading?: boolean;
+}
+
+const ClientMetricItem = ({ label, value, loading }: ClientMetricItemProps) => (
+  <div className="min-w-[112px] px-4 first:pl-0">
+    <div className="text-[12px] leading-5 text-[#98a2b3]">{label}</div>
+    <div className="mt-1 min-h-6 text-[14px] font-semibold leading-6 text-[#101828]">
+      {loading ? <Skeleton.Input active size="small" className="!h-5 !w-12" /> : value}
+    </div>
+  </div>
+);
+
+interface ClientRowProps {
+  client: LinkupClient;
+  metrics?: LinkupClientMetrics;
+  metricsLoading: boolean;
+  deleting: boolean;
+  onRefreshMetrics: (id: number) => void;
+  onEdit: (client: LinkupClient) => void;
+  onDelete: (client: LinkupClient) => void;
+}
+
+const ClientRow = ({
+  client,
+  metrics,
+  metricsLoading,
+  deleting,
+  onRefreshMetrics,
+  onEdit,
+  onDelete,
+}: ClientRowProps) => {
+  const healthMeta = getHealthMeta(client.healthStatus);
+  const clientId = Number(client.id);
+
+  return (
+    <article className="group overflow-hidden rounded-[10px] border border-[#eceef2] bg-white transition-all duration-200 hover:border-[#dfe3e8] hover:shadow-[0_8px_28px_rgba(16,24,40,0.04)]">
+      <div className="flex min-w-0 flex-col gap-5 p-4 lg:flex-row lg:items-stretch lg:p-5">
+        <div
+          className={[
+            'relative flex h-[108px] w-full shrink-0 items-center justify-center overflow-hidden rounded-lg border',
+            'lg:h-[116px] lg:w-[116px]',
+            healthMeta.iconClass,
+          ].join(' ')}
+        >
+          <CloudServerOutlined className="text-[38px]" />
+          <span className={`absolute right-3 top-3 h-2.5 w-2.5 rounded-full ${healthMeta.dotClass}`} />
+          <span className="absolute bottom-2.5 left-3 text-[11px] font-semibold uppercase tracking-[0.08em] opacity-70">
+            {client.engineType || 'CLIENT'}
+          </span>
+        </div>
+
+        <div className="flex min-w-0 flex-1 flex-col">
+          <div className="flex min-w-0 flex-col gap-4 xl:flex-row xl:items-start xl:justify-between">
+            <div className="min-w-0 flex-1">
+              <div className="flex min-w-0 flex-wrap items-center gap-2.5">
+                <h2 className="m-0 max-w-full truncate text-[16px] font-semibold leading-7 text-[#101828]">
+                  {client.clientName || '未命名客户端'}
+                </h2>
+
+                <Tag className={`!m-0 !rounded-md !px-2 !text-[12px] ${healthMeta.tagClass}`}>
+                  <span className="inline-flex items-center gap-1.5">
+                    <span className={`h-1.5 w-1.5 rounded-full ${healthMeta.dotClass}`} />
+                    {healthMeta.label}
+                  </span>
+                </Tag>
+
+                {client.clientVersion ? (
+                  <Tag className="!m-0 !rounded-md !border-[#e4e7ec] !bg-[#f8f9fb] !px-2 !text-[12px] !text-[#667085]">
+                    v{client.clientVersion}
+                  </Tag>
+                ) : null}
+              </div>
+
+              <div className="mt-1 flex flex-wrap items-center gap-x-4 gap-y-1 text-[12px] leading-6 text-[#98a2b3]">
+                <span>客户端 ID：{client.id ?? '--'}</span>
+                <span>最近心跳：{formatTime(client.heartbeatTime)}</span>
+              </div>
+
+              <div className="mt-2 flex min-w-0 flex-wrap items-center gap-2 text-[13px] text-[#667085]">
+                <span className="inline-flex min-w-0 max-w-full items-center gap-1.5 rounded-md bg-[#f7f7f8] px-2.5 py-1.5">
+                  <LinkOutlined className="shrink-0 text-[#98a2b3]" />
+                  <span className="truncate">{getClientAddress(client)}</span>
+                </span>
+                {client.remark ? <span className="truncate">{client.remark}</span> : null}
+              </div>
+            </div>
+
+            <div className="flex shrink-0 flex-wrap items-center gap-0.5 xl:justify-end">
+              <Button
+                type="text"
+                size="small"
+                icon={<EyeOutlined />}
+                className="!h-8 !px-2.5 !text-[#667085] hover:!bg-[#f5f5f6] hover:!text-[#101828]"
+                onClick={() => history.push(`/client/${client.id}/detail`)}
+              >
+                详情
+              </Button>
+
+              <Tooltip title="重新获取该客户端的运行指标">
+                <Button
+                  type="text"
+                  size="small"
+                  icon={<ReloadOutlined spin={metricsLoading} />}
+                  className="!h-8 !px-2.5 !text-[#667085] hover:!bg-[#f5f5f6] hover:!text-[#101828]"
+                  disabled={!clientId}
+                  onClick={() => onRefreshMetrics(clientId)}
+                >
+                  刷新
+                </Button>
+              </Tooltip>
+
+              <Button
+                type="text"
+                size="small"
+                icon={<EditOutlined />}
+                className="!h-8 !px-2.5 !text-[#667085] hover:!bg-[#f5f5f6] hover:!text-[#101828]"
+                onClick={() => onEdit(client)}
+              >
+                编辑
+              </Button>
+
+              <Popconfirm
+                title="删除客户端"
+                description="删除后不可恢复，确定继续吗？"
+                okText="删除"
+                cancelText="取消"
+                okButtonProps={{ danger: true, loading: deleting }}
+                onConfirm={() => onDelete(client)}
+              >
+                <Button
+                  danger
+                  type="text"
+                  size="small"
+                  icon={<DeleteOutlined />}
+                  loading={deleting}
+                  className="!h-8 !px-2.5"
+                >
+                  删除
+                </Button>
+              </Popconfirm>
+            </div>
+          </div>
+
+          <div className="mt-auto flex min-w-0 flex-wrap divide-x divide-[#eceef2] border-t border-[#f0f1f3] pt-3">
+            <ClientMetricItem label="CPU 使用率" value={formatPercent(metrics?.cpuUsage)} loading={metricsLoading} />
+            <ClientMetricItem label="内存使用率" value={formatPercent(metrics?.memoryUsage)} loading={metricsLoading} />
+            <ClientMetricItem label="活跃线程" value={formatNumber(metrics?.threadCount)} loading={metricsLoading} />
+            <ClientMetricItem label="运行中任务" value={formatNumber(metrics?.runningOps)} loading={metricsLoading} />
+            <ClientMetricItem label="引擎类型" value={client.engineType || '--'} />
+          </div>
+        </div>
+      </div>
+    </article>
+  );
+};
+
+const ClientPage = () => {
   const {
     clients,
-    selectedClientId,
-    setSelectedClientId,
-    selectedClient,
+    loading,
     confirmLoading,
-    metricsLoading,
     openAddModal,
-    setOpenAddModal,
     editingClient,
     deleteLoadingId,
-    metrics,
+    metricsByClientId,
+    metricsLoadingIds,
     form,
     handleOpenCreate,
     handleOpenEdit,
     handleDeleteClient,
     handleSaveClient,
     handleCancelModal,
+    loadClients,
     loadClientMetrics,
   } = useClientPageState();
 
+  const [statusFilter, setStatusFilter] = useState<ClientStatusFilter>('all');
+  const [keyword, setKeyword] = useState('');
+
+  const statusCounts = useMemo(() => {
+    return clients.reduce(
+      (result, client) => {
+        const filter = getHealthMeta(client.healthStatus).filter;
+        result.all += 1;
+        result[filter] += 1;
+        return result;
+      },
+      { all: 0, online: 0, warning: 0, offline: 0 },
+    );
+  }, [clients]);
+
+  const filteredClients = useMemo(() => {
+    const normalizedKeyword = normalizeKeyword(keyword);
+
+    return clients.filter((client) => {
+      const healthFilter = getHealthMeta(client.healthStatus).filter;
+      const matchesStatus = statusFilter === 'all' || healthFilter === statusFilter;
+
+      if (!matchesStatus) return false;
+      if (!normalizedKeyword) return true;
+
+      return [
+        client.clientName,
+        client.engineType,
+        client.baseUrl,
+        client.clientAddress,
+        client.clientVersion,
+        client.remark,
+        String(client.id ?? ''),
+      ].some((item) => normalizeKeyword(item).includes(normalizedKeyword));
+    });
+  }, [clients, keyword, statusFilter]);
+
   return (
-    <ClickSpark
-      sparkColor="hsl(231 48% 48%)"
-      sparkSize={10}
-      sparkRadius={15}
-      sparkCount={8}
-      duration={400}
-      easing="ease-out"
-      extraScale={1}
-    >
-      <div
-        className="h-[calc(100vh-48px)]"
-        style={{background: PAGE_BG}}
-      >
-        <div className="box-border px-6 py-6">
-          <ClientPageHeader onAdd={handleOpenCreate}/>
-
-          <div
-            style={{
-              background: CARD_BG,
-              border: `1px solid ${BORDER_COLOR}`,
-              borderRadius: 24,
-              overflow: "hidden",
-            }}
-          >
-            <div
-              style={{
-                display: "grid",
-                gridTemplateColumns: "300px 1fr",
-                minHeight: "calc(100vh - 80px)",
-              }}
-            >
-              <ClientListPanel
-                clients={clients}
-                selectedClientId={selectedClientId}
-                onSelect={setSelectedClientId}
-                onEdit={handleOpenEdit}
-                onDelete={handleDeleteClient}
-                deleteLoadingId={deleteLoadingId}
-              />
-
-              <div className="min-w-0 p-6">
-                {!selectedClient ? (
-                  <div className="flex h-full min-h-[520px] items-center justify-center">
-                    <div className="max-w-[420px] text-center">
-                      <div className="text-[28px] font-bold tracking-[-0.03em] text-[#172033]">
-                        选择一个 Client
-                      </div>
-                      <div className="mt-3 text-[14px] leading-8 text-[#667085]">
-                        左侧选择节点后，可查看基础信息、健康状态与核心运行指标。
-                      </div>
-                    </div>
-                  </div>
-                ) : (
-                  <ClientDetailPanel
-                    selectedClient={selectedClient}
-                    selectedClientId={selectedClientId}
-                    metrics={metrics}
-                    metricsLoading={metricsLoading}
-                    onRefresh={loadClientMetrics}
-                  />
-                )}
+    <ConfigProvider theme={BRAND_THEME}>
+      <div className="min-h-[calc(100vh-48px)] bg-[#f7f7f8] px-5 py-5 lg:px-6">
+        <div className="mx-auto w-full max-w-[1680px]">
+          <div className="flex flex-col gap-4 border-b border-[#e8e9ec] pb-3 lg:flex-row lg:items-end lg:justify-between">
+            <div>
+              <h1 className="m-0 text-[22px] font-semibold leading-8 text-[#161823]">客户端管理</h1>
+              <div className="mt-1 text-[13px] leading-6 text-[#8a8f99]">
+                管理 Link-Up 客户端连接、健康状态与运行指标。
               </div>
             </div>
+
+            <div className="flex flex-wrap items-center gap-2">
+              <Input
+                allowClear
+                variant="filled"
+                value={keyword}
+                prefix={<SearchOutlined className="text-[#98a2b3]" />}
+                placeholder="搜索客户端"
+                className="!h-9 !w-[240px]"
+                onChange={(event) => setKeyword(event.target.value)}
+              />
+
+              <Tooltip title="刷新客户端列表">
+                <Button
+                  icon={<ReloadOutlined spin={loading} />}
+                  className="!h-9 !w-9 !px-0"
+                  onClick={() => loadClients()}
+                />
+              </Tooltip>
+
+              <Button
+                type="primary"
+                icon={<PlusOutlined />}
+                className="!h-9 !px-4"
+                onClick={handleOpenCreate}
+              >
+                新增客户端
+              </Button>
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-3 border-b border-[#e8e9ec] lg:flex-row lg:items-center lg:justify-between">
+            <div className="flex min-w-0 items-center gap-6 overflow-x-auto">
+              {statusTabs.map((tab) => {
+                const active = tab.key === statusFilter;
+
+                return (
+                  <button
+                    key={tab.key}
+                    type="button"
+                    className={[
+                      'relative h-12 shrink-0 border-0 bg-transparent px-0 text-[13px] transition-colors',
+                      active ? 'font-semibold text-[#161823]' : 'font-normal text-[#667085] hover:text-[#161823]',
+                    ].join(' ')}
+                    onClick={() => setStatusFilter(tab.key)}
+                  >
+                    <span>{tab.label}</span>
+                    <span className="ml-1.5 text-[12px] text-[#98a2b3]">{statusCounts[tab.key]}</span>
+                    {active ? (
+                      <span
+                        className="absolute inset-x-0 bottom-0 h-0.5"
+                        style={{ background: BRAND_COLOR }}
+                      />
+                    ) : null}
+                  </button>
+                );
+              })}
+            </div>
+
+            <div className="pb-3 text-[12px] text-[#8a8f99] lg:pb-0">
+              共 <span className="font-semibold text-[#344054]">{filteredClients.length}</span> 个客户端
+            </div>
+          </div>
+
+          <div className="py-4">
+            {loading && !clients.length ? (
+              <div className="space-y-3">
+                {[0, 1, 2].map((item) => (
+                  <div key={item} className="rounded-[10px] border border-[#eceef2] bg-white p-5">
+                    <Skeleton active avatar paragraph={{ rows: 3 }} />
+                  </div>
+                ))}
+              </div>
+            ) : filteredClients.length ? (
+              <div className="space-y-3">
+                {filteredClients.map((client) => {
+                  const id = Number(client.id);
+
+                  return (
+                    <ClientRow
+                      key={client.id ?? client.clientName}
+                      client={client}
+                      metrics={id ? metricsByClientId[id] : undefined}
+                      metricsLoading={id ? metricsLoadingIds.has(id) : false}
+                      deleting={deleteLoadingId === client.id}
+                      onRefreshMetrics={loadClientMetrics}
+                      onEdit={handleOpenEdit}
+                      onDelete={handleDeleteClient}
+                    />
+                  );
+                })}
+              </div>
+            ) : (
+              <div className="flex min-h-[420px] items-center justify-center rounded-[10px] border border-dashed border-[#dfe2e7] bg-white">
+                <Empty
+                  image={Empty.PRESENTED_IMAGE_SIMPLE}
+                  description={keyword || statusFilter !== 'all' ? '没有匹配的客户端' : '还没有客户端'}
+                >
+                  {!keyword && statusFilter === 'all' ? (
+                    <Button type="primary" icon={<PlusOutlined />} onClick={handleOpenCreate}>
+                      新增客户端
+                    </Button>
+                  ) : null}
+                </Empty>
+              </div>
+            )}
           </div>
         </div>
 
         <AddClientModal
           open={openAddModal}
           form={form}
-          mode={editingClient ? "edit" : "create"}
+          mode={editingClient ? 'edit' : 'create'}
           initialValues={editingClient}
           confirmLoading={confirmLoading}
           onCancel={handleCancelModal}
           onSubmit={handleSaveClient}
         />
       </div>
-    </ClickSpark>
+    </ConfigProvider>
   );
 };
 
-export default ClientPageTailwind;
+export default ClientPage;


### PR DESCRIPTION
## 改动内容

- 按参考视频重构客户端管理页，移除原有左右分栏详情布局，改为更轻量的横向客户端列表
- 增加全部、在线、异常、离线状态页签及数量统计
- 增加客户端名称、地址、引擎、版本、备注和 ID 的前端即时搜索
- 每个客户端集中展示连接地址、最近心跳、健康状态、版本和运行指标
- 将详情、指标刷新、编辑、删除操作收敛到列表行右上角
- 保留现有新增、编辑、删除及详情页面跳转能力
- 调整客户端状态 Hook，支持列表加载状态、批量指标加载、单客户端指标刷新及失败兜底

## 设计说明

页面结构参考上传视频中的管理列表风格：标题与操作区、状态页签、右侧搜索、列表数量、横向信息卡片和底部指标区。配色继续复用 Yak Ops 全局品牌色，并为后续对接 Link-Up Server 的心跳、版本和运行指标预留展示位置。

## 校验

- 使用 TypeScript 5.8 `transpileModule` 对修改的 TS/TSX 文件进行了语法检查
- 对比 `main` 确认仅修改客户端管理页与其状态 Hook
- 当前环境无法拉取完整仓库依赖，因此未执行项目级 `npm run tsc` / `npm run build`
