### PR TITLE
refactor(ui): promote data development to standalone module

### DIFF
--- a/yak-ops-ui/src/config/navigation.ts
+++ b/yak-ops-ui/src/config/navigation.ts
@@ -1,4 +1,7 @@
-import { type PermissionRequirement, satisfiesPermissionRequirement } from '../utils/security/permission';
+import {
+  type PermissionRequirement,
+  satisfiesPermissionRequirement,
+} from '../utils/security/permission';
 
 export type NavigationIconKey =
   | 'home'
@@ -22,8 +25,9 @@ export type NavigationIconKey =
 /**
  * 主菜单业务区域：
  *
- * task：任务创建、数据同步和流程编排；
- * management：资源、质量及运行管理。
+ * task：任务创建、数据同步、数据开发和流程编排；
+ * management：资源、质量及运行管理；
+ * system：系统与权限管理。
  */
 export type NavigationSectionKey = 'task' | 'management' | 'system';
 
@@ -46,7 +50,8 @@ interface NavigationRouteBase {
  * inherits its parent route's requirement. There is deliberately no implicit
  * default for new root routes, so migrations cannot accidentally expose them.
  */
-export type NavigationRoute = NavigationRouteBase & (PermissionRequirement | { parentId: string; mode?: never });
+export type NavigationRoute = NavigationRouteBase &
+  (PermissionRequirement | { parentId: string; mode?: never });
 
 export interface NavigationGroup {
   id: string;
@@ -60,7 +65,13 @@ export interface NavigationGroupWithRoutes extends NavigationGroup {
   routes: NavigationRoute[];
 }
 
-const sortByOrder = <T extends { order?: number }>(left: T, right: T) => (left.order ?? 0) - (right.order ?? 0);
+const sortByOrder = <T extends { order?: number }>(left: T, right: T) =>
+  (left.order ?? 0) - (right.order ?? 0);
+
+const DATA_DEVELOPMENT_READ_PERMISSIONS = [
+  'task:batch:read',
+  'task:realtime:read',
+] as const;
 
 /**
  * 主菜单顺序：
@@ -68,11 +79,13 @@ const sortByOrder = <T extends { order?: number }>(left: T, right: T) => (left.o
  * 首页
  * ────────────────
  * 数据集成
+ * 数据开发
  * 流程编排
  * ────────────────
  * 资源管理
  * 数据质量
  * 运维中心
+ * 系统管理
  *
  * 尚未包含页面的分组不会展示。
  * 后续只需增加对应路由，菜单分组便会自动出现。
@@ -86,39 +99,46 @@ export const navigationGroups: readonly NavigationGroup[] = [
     order: 10,
   },
   {
+    id: 'development',
+    title: '数据开发',
+    iconKey: 'api',
+    section: 'task',
+    order: 20,
+  },
+  {
     id: 'workflow',
     title: '流程编排',
     iconKey: 'workflow',
     section: 'task',
-    order: 20,
+    order: 30,
   },
   {
     id: 'resources',
     title: '资源管理',
     iconKey: 'database',
     section: 'management',
-    order: 30,
+    order: 40,
   },
   {
     id: 'quality',
     title: '数据质量',
     iconKey: 'quality',
     section: 'management',
-    order: 40,
+    order: 50,
   },
   {
     id: 'operations',
     title: '运维中心',
     iconKey: 'monitor',
     section: 'management',
-    order: 50,
+    order: 60,
   },
   {
     id: 'system',
     title: '系统管理',
     iconKey: 'system',
     section: 'system',
-    order: 60,
+    order: 70,
   },
 ];
 
@@ -153,7 +173,10 @@ export const appRoutes: readonly NavigationRoute[] = [
     iconKey: 'sync',
     menuGroup: 'integration',
     order: 10,
-    quickCreateRequirement: { mode: 'one', permission: 'task:batch:create' },
+    quickCreateRequirement: {
+      mode: 'one',
+      permission: 'task:batch:create',
+    },
     quickCreateLabel: '新建离线同步',
   },
   {
@@ -188,7 +211,6 @@ export const appRoutes: readonly NavigationRoute[] = [
     hidden: true,
     parentId: 'batch-link-up',
   },
-
   {
     id: 'realtime-link-up',
     mode: 'one',
@@ -199,7 +221,10 @@ export const appRoutes: readonly NavigationRoute[] = [
     iconKey: 'realtime',
     menuGroup: 'integration',
     order: 20,
-    quickCreateRequirement: { mode: 'one', permission: 'task:realtime:create' },
+    quickCreateRequirement: {
+      mode: 'one',
+      permission: 'task:realtime:create',
+    },
     quickCreateLabel: '新建实时同步',
   },
   {
@@ -219,16 +244,50 @@ export const appRoutes: readonly NavigationRoute[] = [
     parentId: 'realtime-link-up',
   },
 
+  // ---------------------------------------------------------------------------
+  // 数据开发
+  // ---------------------------------------------------------------------------
+
   {
-    id: 'data-development',
+    id: 'data-development-workbench',
     mode: 'any',
-    permissions: ['task:batch:read', 'task:realtime:read'],
+    permissions: DATA_DEVELOPMENT_READ_PERMISSIONS,
+    path: '/data-development/workbench',
+    title: '工作台',
+    component: './data-development',
+    iconKey: 'insight',
+    menuGroup: 'development',
+    order: 10,
+  },
+  {
+    id: 'data-development-instances',
+    mode: 'any',
+    permissions: DATA_DEVELOPMENT_READ_PERMISSIONS,
+    path: '/data-development/instances',
+    title: '运行实例',
+    component: './data-development/instances',
+    iconKey: 'instance',
+    menuGroup: 'development',
+    order: 20,
+  },
+  {
+    id: 'data-development-udf',
+    mode: 'any',
+    permissions: DATA_DEVELOPMENT_READ_PERMISSIONS,
+    path: '/data-development/udf',
+    title: 'UDF 函数',
+    component: './data-development/udf',
+    iconKey: 'api',
+    menuGroup: 'development',
+    order: 30,
+  },
+  {
+    id: 'data-development-legacy',
     path: '/data-development',
     title: '数据开发',
-    component: './data-development',
-    iconKey: 'api',
-    menuGroup: 'integration',
-    order: 30,
+    component: './data-development/redirect',
+    hidden: true,
+    parentId: 'data-development-workbench',
   },
 
   // ---------------------------------------------------------------------------
@@ -254,7 +313,6 @@ export const appRoutes: readonly NavigationRoute[] = [
     hidden: true,
     parentId: 'workflow-project',
   },
-
   {
     id: 'workflow-management',
     mode: 'one',
@@ -265,7 +323,10 @@ export const appRoutes: readonly NavigationRoute[] = [
     iconKey: 'workflow',
     menuGroup: 'workflow',
     order: 20,
-    quickCreateRequirement: { mode: 'one', permission: 'workflow:definition:create' },
+    quickCreateRequirement: {
+      mode: 'one',
+      permission: 'workflow:definition:create',
+    },
     quickCreateLabel: '新建工作流',
   },
   {
@@ -284,7 +345,6 @@ export const appRoutes: readonly NavigationRoute[] = [
     hidden: true,
     parentId: 'workflow-management',
   },
-
   {
     id: 'workflow-instance',
     mode: 'one',
@@ -349,7 +409,6 @@ export const appRoutes: readonly NavigationRoute[] = [
     hidden: true,
     parentId: 'client',
   },
-
   {
     id: 'connector',
     mode: 'one',
@@ -393,7 +452,6 @@ export const appRoutes: readonly NavigationRoute[] = [
     hidden: true,
     parentId: 'data-quality',
   },
-
   {
     id: 'data-quality-report',
     mode: 'one',
@@ -437,7 +495,6 @@ export const appRoutes: readonly NavigationRoute[] = [
     hidden: true,
     parentId: 'metrics',
   },
-
   {
     id: 'alarm',
     mode: 'one',
@@ -584,31 +641,45 @@ export const canAccessNavigationRoute = (
 
   while (candidate && !visited.has(candidate.id)) {
     visited.add(candidate.id);
-    if (candidate.mode && !satisfiesPermissionRequirement(permissionCodes, candidate as PermissionRequirement)) {
+    if (
+      candidate.mode &&
+      !satisfiesPermissionRequirement(
+        permissionCodes,
+        candidate as PermissionRequirement,
+      )
+    ) {
       return false;
     }
-    candidate = candidate.parentId ? routeMap.get(candidate.parentId) : undefined;
+    candidate = candidate.parentId
+      ? routeMap.get(candidate.parentId)
+      : undefined;
   }
 
   return true;
 };
 
-const normalizePath = (path: string) => path.split(/[?#]/, 1)[0].replace(/\/+$/, '') || '/';
+const normalizePath = (path: string) =>
+  path.split(/[?#]/, 1)[0].replace(/\/+$/, '') || '/';
 
 const matchesRoute = (pattern: string, pathname: string) => {
   const patternParts = normalizePath(pattern).split('/').filter(Boolean);
-
   const pathParts = normalizePath(pathname).split('/').filter(Boolean);
 
   return (
     patternParts.length === pathParts.length &&
-    patternParts.every((part, index) => part.startsWith(':') || part === pathParts[index])
+    patternParts.every(
+      (part, index) => part.startsWith(':') || part === pathParts[index],
+    )
   );
 };
 
-export const getRouteMetadata = (pathname: string) => appRoutes.find((route) => matchesRoute(route.path, pathname));
+export const getRouteMetadata = (pathname: string) =>
+  appRoutes.find((route) => matchesRoute(route.path, pathname));
 
-export const getActiveNavigationId = (pathname: string, permissionCodes?: readonly string[] | null) => {
+export const getActiveNavigationId = (
+  pathname: string,
+  permissionCodes?: readonly string[] | null,
+) => {
   const route = getRouteMetadata(pathname);
 
   if (!route || !canAccessNavigationRoute(route, permissionCodes)) {
@@ -618,7 +689,10 @@ export const getActiveNavigationId = (pathname: string, permissionCodes?: readon
   return route.parentId ?? route.id;
 };
 
-export const getActiveNavigationGroupId = (pathname: string, permissionCodes?: readonly string[] | null) => {
+export const getActiveNavigationGroupId = (
+  pathname: string,
+  permissionCodes?: readonly string[] | null,
+) => {
   const activeId = getActiveNavigationId(pathname, permissionCodes);
 
   return activeId ? routeMap.get(activeId)?.menuGroup : undefined;
@@ -627,22 +701,34 @@ export const getActiveNavigationGroupId = (pathname: string, permissionCodes?: r
 /**
  * 首页等独立一级菜单。
  */
-export const getStandaloneNavigationRoutes = (permissionCodes?: readonly string[] | null) =>
+export const getStandaloneNavigationRoutes = (
+  permissionCodes?: readonly string[] | null,
+) =>
   appRoutes
-    .filter((route) => !route.hidden && !route.menuGroup && canAccessNavigationRoute(route, permissionCodes))
+    .filter(
+      (route) =>
+        !route.hidden &&
+        !route.menuGroup &&
+        canAccessNavigationRoute(route, permissionCodes),
+    )
     .sort(sortByOrder);
 
 /**
  * 分组菜单。
  */
-export const getMainNavigationGroups = (permissionCodes?: readonly string[] | null): NavigationGroupWithRoutes[] =>
+export const getMainNavigationGroups = (
+  permissionCodes?: readonly string[] | null,
+): NavigationGroupWithRoutes[] =>
   [...navigationGroups]
     .sort(sortByOrder)
     .map((group) => ({
       ...group,
       routes: appRoutes
         .filter(
-          (route) => !route.hidden && route.menuGroup === group.id && canAccessNavigationRoute(route, permissionCodes),
+          (route) =>
+            !route.hidden &&
+            route.menuGroup === group.id &&
+            canAccessNavigationRoute(route, permissionCodes),
         )
         .sort(sortByOrder),
     }))
@@ -651,13 +737,18 @@ export const getMainNavigationGroups = (permissionCodes?: readonly string[] | nu
 /**
  * 快速创建下拉菜单。
  */
-export const getQuickCreateRoutes = (permissionCodes?: readonly string[] | null) =>
+export const getQuickCreateRoutes = (
+  permissionCodes?: readonly string[] | null,
+) =>
   appRoutes
     .filter(
       (route) =>
         Boolean(route.quickCreateLabel) &&
         canAccessNavigationRoute(route, permissionCodes) &&
         (!route.quickCreateRequirement ||
-          satisfiesPermissionRequirement(permissionCodes, route.quickCreateRequirement)),
+          satisfiesPermissionRequirement(
+            permissionCodes,
+            route.quickCreateRequirement,
+          )),
     )
     .sort(sortByOrder);

--- a/yak-ops-ui/src/pages/data-development/index.tsx
+++ b/yak-ops-ui/src/pages/data-development/index.tsx
@@ -14,7 +14,6 @@ import {
   Space,
   Table,
   Tag,
-  Tooltip,
   Typography,
   type MenuProps,
   type TableColumnsType,
@@ -72,7 +71,7 @@ const typeOptions = [
   { label: 'Python 脚本', value: 'PYTHON' },
 ];
 
-const DataDevelopmentPage = () => {
+const DataDevelopmentWorkbenchPage = () => {
   const [form] = Form.useForm<CreateTaskValues>();
   const [tasks, setTasks] = useState<DevelopmentTask[]>([]);
   const [createOpen, setCreateOpen] = useState(false);
@@ -116,7 +115,6 @@ const DataDevelopmentPage = () => {
   };
 
   const handleCreate = (values: CreateTaskValues) => {
-    const now = dayjs().format('YYYY-MM-DD HH:mm:ss');
     const task: DevelopmentTask = {
       id: `DEV-${Date.now().toString().slice(-8)}`,
       name: values.name.trim(),
@@ -126,7 +124,7 @@ const DataDevelopmentPage = () => {
       description: values.description?.trim(),
       status: 'DRAFT',
       owner: '当前用户',
-      updatedAt: now,
+      updatedAt: dayjs().format('YYYY-MM-DD HH:mm:ss'),
     };
 
     setTasks((current) => [task, ...current]);
@@ -212,7 +210,11 @@ const DataDevelopmentPage = () => {
           onClick={() => handleAction(task, 'open')}
         >
           <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-[7px] bg-[rgba(254,44,85,0.06)] text-[#fe2c55]">
-            {task.type === 'SQL' ? <Braces size={18} /> : <FileCode2 size={18} />}
+            {task.type === 'SQL' ? (
+              <Braces size={18} />
+            ) : (
+              <FileCode2 size={18} />
+            )}
           </span>
           <span className="flex min-w-0 flex-col gap-0.5">
             <strong className="truncate text-[13px] font-medium text-[#161823]">
@@ -231,7 +233,9 @@ const DataDevelopmentPage = () => {
       key: 'type',
       width: 110,
       render: (value: DevelopmentTaskType) => (
-        <Tag bordered={false}>{value === 'SQL' ? 'SQL 脚本' : 'Python'}</Tag>
+        <Tag bordered={false}>
+          {value === 'SQL' ? 'SQL 脚本' : 'Python'}
+        </Tag>
       ),
     },
     {
@@ -257,8 +261,8 @@ const DataDevelopmentPage = () => {
           bordered={false}
           className={
             value === 'PUBLISHED'
-              ? '!text-[#fe2c55] !bg-[rgba(254,44,85,0.06)]'
-              : '!text-[rgba(22,24,35,0.58)] !bg-[#f2f3f5]'
+              ? '!bg-[rgba(254,44,85,0.06)] !text-[#fe2c55]'
+              : '!bg-[#f2f3f5] !text-[rgba(22,24,35,0.58)]'
           }
         >
           {value === 'PUBLISHED' ? '已发布' : '草稿'}
@@ -309,7 +313,7 @@ const DataDevelopmentPage = () => {
     <ConfigProvider theme={BRAND_THEME}>
       <div className="min-h-[calc(100vh-48px)] bg-white px-5 pb-5 pt-4 text-[#161823]">
         <header className="flex min-h-11 items-center justify-between gap-4">
-          <h1 className="m-0 text-[17px] font-semibold leading-6">数据开发</h1>
+          <h1 className="m-0 text-[17px] font-semibold leading-6">工作台</h1>
           <Button
             type="primary"
             icon={<Plus size={16} />}
@@ -325,7 +329,9 @@ const DataDevelopmentPage = () => {
               <FileText size={19} />
             </span>
             <div>
-              <Text type="secondary" className="!text-[11px]">开发任务</Text>
+              <Text type="secondary" className="!text-[11px]">
+                开发任务
+              </Text>
               <div className="mt-0.5 text-lg font-semibold">{summary.total}</div>
             </div>
           </div>
@@ -334,7 +340,9 @@ const DataDevelopmentPage = () => {
               <Clock3 size={19} />
             </span>
             <div>
-              <Text type="secondary" className="!text-[11px]">草稿</Text>
+              <Text type="secondary" className="!text-[11px]">
+                草稿
+              </Text>
               <div className="mt-0.5 text-lg font-semibold">{summary.draft}</div>
             </div>
           </div>
@@ -343,8 +351,12 @@ const DataDevelopmentPage = () => {
               <CircleCheck size={19} />
             </span>
             <div>
-              <Text type="secondary" className="!text-[11px]">已发布</Text>
-              <div className="mt-0.5 text-lg font-semibold">{summary.published}</div>
+              <Text type="secondary" className="!text-[11px]">
+                已发布
+              </Text>
+              <div className="mt-0.5 text-lg font-semibold">
+                {summary.published}
+              </div>
             </div>
           </div>
           <div className="flex min-h-[70px] items-center gap-3 border border-[#f0f0f0] bg-[#fafbfc] px-4 py-3">
@@ -352,14 +364,16 @@ const DataDevelopmentPage = () => {
               <Braces size={19} />
             </span>
             <div>
-              <Text type="secondary" className="!text-[11px]">支持引擎</Text>
+              <Text type="secondary" className="!text-[11px]">
+                支持引擎
+              </Text>
               <div className="mt-0.5 text-lg font-semibold">4</div>
             </div>
           </div>
         </section>
 
         <section className="mt-3 border border-[#e4e7ec] bg-white">
-          <div className="flex min-h-[54px] items-center justify-between gap-4 border-b border-[#eaecf0] px-3 py-2 max-[900px]:items-stretch max-[900px]:flex-col">
+          <div className="flex min-h-[54px] items-center justify-between gap-4 border-b border-[#eaecf0] px-3 py-2 max-[900px]:flex-col max-[900px]:items-stretch">
             <Segmented
               value={statusFilter}
               options={[
@@ -401,7 +415,13 @@ const DataDevelopmentPage = () => {
             locale={{
               emptyText: (
                 <Empty
-                  image={<YakOpsEmpty width={220} height={174} primaryColor={BRAND_COLOR} />}
+                  image={
+                    <YakOpsEmpty
+                      width={220}
+                      height={174}
+                      primaryColor={BRAND_COLOR}
+                    />
+                  }
                   description={
                     keyword || statusFilter !== 'ALL' || engineFilter
                       ? '没有匹配的数据开发任务'
@@ -491,4 +511,4 @@ const DataDevelopmentPage = () => {
   );
 };
 
-export default DataDevelopmentPage;
+export default DataDevelopmentWorkbenchPage;

--- a/yak-ops-ui/src/pages/data-development/instances/index.tsx
+++ b/yak-ops-ui/src/pages/data-development/instances/index.tsx
@@ -1,0 +1,304 @@
+import YakOpsEmpty from '@/components/YakOpsEmpty';
+import { BRAND_COLOR, BRAND_THEME } from '@/styles/brand';
+import {
+  Button,
+  ConfigProvider,
+  Empty,
+  Input,
+  Segmented,
+  Select,
+  Space,
+  Table,
+  Tag,
+  Typography,
+  type TableColumnsType,
+} from 'antd';
+import {
+  CircleCheck,
+  CircleX,
+  Clock3,
+  History,
+  RefreshCw,
+  Search,
+} from 'lucide-react';
+import { useMemo, useState } from 'react';
+
+const { Text } = Typography;
+
+type InstanceStatus = 'RUNNING' | 'SUCCESS' | 'FAILED' | 'CANCELED';
+type InstanceStatusFilter = 'ALL' | InstanceStatus;
+
+interface DevelopmentInstance {
+  id: string;
+  taskName: string;
+  taskType: string;
+  engine: string;
+  status: InstanceStatus;
+  startTime: string;
+  endTime?: string;
+  duration?: string;
+  operator: string;
+}
+
+const engineOptions = [
+  { label: 'Flink SQL', value: 'Flink SQL' },
+  { label: 'Spark SQL', value: 'Spark SQL' },
+  { label: 'Trino SQL', value: 'Trino SQL' },
+  { label: 'Python', value: 'Python' },
+];
+
+const statusMeta: Record<
+  InstanceStatus,
+  { label: string; className: string }
+> = {
+  RUNNING: {
+    label: '运行中',
+    className: '!bg-[rgba(254,44,85,0.06)] !text-[#fe2c55]',
+  },
+  SUCCESS: {
+    label: '成功',
+    className: '!bg-[#f2f3f5] !text-[#344054]',
+  },
+  FAILED: {
+    label: '失败',
+    className: '!bg-[#fff1f0] !text-[#ff4d4f]',
+  },
+  CANCELED: {
+    label: '已取消',
+    className: '!bg-[#f2f3f5] !text-[rgba(22,24,35,0.58)]',
+  },
+};
+
+const DataDevelopmentInstancesPage = () => {
+  const [instances] = useState<DevelopmentInstance[]>([]);
+  const [keyword, setKeyword] = useState('');
+  const [statusFilter, setStatusFilter] =
+    useState<InstanceStatusFilter>('ALL');
+  const [engineFilter, setEngineFilter] = useState<string>();
+
+  const summary = useMemo(
+    () => ({
+      total: instances.length,
+      running: instances.filter((item) => item.status === 'RUNNING').length,
+      success: instances.filter((item) => item.status === 'SUCCESS').length,
+      failed: instances.filter((item) => item.status === 'FAILED').length,
+    }),
+    [instances],
+  );
+
+  const filteredInstances = useMemo(() => {
+    const normalizedKeyword = keyword.trim().toLowerCase();
+
+    return instances.filter((instance) => {
+      const matchesKeyword =
+        !normalizedKeyword ||
+        instance.id.toLowerCase().includes(normalizedKeyword) ||
+        instance.taskName.toLowerCase().includes(normalizedKeyword);
+      const matchesStatus =
+        statusFilter === 'ALL' || instance.status === statusFilter;
+      const matchesEngine = !engineFilter || instance.engine === engineFilter;
+
+      return matchesKeyword && matchesStatus && matchesEngine;
+    });
+  }, [engineFilter, instances, keyword, statusFilter]);
+
+  const resetFilters = () => {
+    setKeyword('');
+    setStatusFilter('ALL');
+    setEngineFilter(undefined);
+  };
+
+  const columns: TableColumnsType<DevelopmentInstance> = [
+    {
+      title: '实例',
+      dataIndex: 'id',
+      key: 'id',
+      width: 230,
+      render: (value: string, instance) => (
+        <div className="flex min-w-0 items-center gap-3">
+          <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-[7px] bg-[rgba(254,44,85,0.06)] text-[#fe2c55]">
+            <History size={18} />
+          </span>
+          <span className="min-w-0">
+            <strong className="block truncate text-[13px] font-medium text-[#161823]">
+              {value}
+            </strong>
+            <small className="block truncate text-[11px] text-[rgba(22,24,35,0.42)]">
+              {instance.taskName}
+            </small>
+          </span>
+        </div>
+      ),
+    },
+    {
+      title: '任务类型',
+      dataIndex: 'taskType',
+      key: 'taskType',
+      width: 110,
+      render: (value: string) => <Tag bordered={false}>{value}</Tag>,
+    },
+    {
+      title: '计算引擎',
+      dataIndex: 'engine',
+      key: 'engine',
+      width: 130,
+    },
+    {
+      title: '状态',
+      dataIndex: 'status',
+      key: 'status',
+      width: 100,
+      render: (value: InstanceStatus) => (
+        <Tag bordered={false} className={statusMeta[value].className}>
+          {statusMeta[value].label}
+        </Tag>
+      ),
+    },
+    {
+      title: '开始时间',
+      dataIndex: 'startTime',
+      key: 'startTime',
+      width: 170,
+    },
+    {
+      title: '结束时间',
+      dataIndex: 'endTime',
+      key: 'endTime',
+      width: 170,
+      render: (value?: string) => value || '-',
+    },
+    {
+      title: '耗时',
+      dataIndex: 'duration',
+      key: 'duration',
+      width: 100,
+      render: (value?: string) => value || '-',
+    },
+    {
+      title: '执行人',
+      dataIndex: 'operator',
+      key: 'operator',
+      width: 120,
+    },
+  ];
+
+  const hasFilters =
+    Boolean(keyword) || statusFilter !== 'ALL' || Boolean(engineFilter);
+
+  return (
+    <ConfigProvider theme={BRAND_THEME}>
+      <div className="min-h-[calc(100vh-48px)] bg-white px-5 pb-5 pt-4 text-[#161823]">
+        <header className="flex min-h-11 items-center justify-between gap-4">
+          <h1 className="m-0 text-[17px] font-semibold leading-6">运行实例</h1>
+          <Button icon={<RefreshCw size={15} />} onClick={resetFilters}>
+            重置筛选
+          </Button>
+        </header>
+
+        <section className="mt-2 grid grid-cols-4 gap-2 max-[980px]:grid-cols-2">
+          <div className="flex min-h-[70px] items-center gap-3 border border-[#f0f0f0] bg-[#fafbfc] px-4 py-3">
+            <span className="flex h-9 w-9 items-center justify-center rounded-[7px] bg-[#f2f3f5] text-[rgba(22,24,35,0.58)]">
+              <History size={19} />
+            </span>
+            <div>
+              <Text type="secondary" className="!text-[11px]">全部实例</Text>
+              <div className="mt-0.5 text-lg font-semibold">{summary.total}</div>
+            </div>
+          </div>
+          <div className="flex min-h-[70px] items-center gap-3 border border-[#f0f0f0] bg-[#fafbfc] px-4 py-3">
+            <span className="flex h-9 w-9 items-center justify-center rounded-[7px] bg-[rgba(254,44,85,0.06)] text-[#fe2c55]">
+              <Clock3 size={19} />
+            </span>
+            <div>
+              <Text type="secondary" className="!text-[11px]">运行中</Text>
+              <div className="mt-0.5 text-lg font-semibold">{summary.running}</div>
+            </div>
+          </div>
+          <div className="flex min-h-[70px] items-center gap-3 border border-[#f0f0f0] bg-[#fafbfc] px-4 py-3">
+            <span className="flex h-9 w-9 items-center justify-center rounded-[7px] bg-[#f2f3f5] text-[#344054]">
+              <CircleCheck size={19} />
+            </span>
+            <div>
+              <Text type="secondary" className="!text-[11px]">成功</Text>
+              <div className="mt-0.5 text-lg font-semibold">{summary.success}</div>
+            </div>
+          </div>
+          <div className="flex min-h-[70px] items-center gap-3 border border-[#f0f0f0] bg-[#fafbfc] px-4 py-3">
+            <span className="flex h-9 w-9 items-center justify-center rounded-[7px] bg-[#fff1f0] text-[#ff4d4f]">
+              <CircleX size={19} />
+            </span>
+            <div>
+              <Text type="secondary" className="!text-[11px]">失败</Text>
+              <div className="mt-0.5 text-lg font-semibold">{summary.failed}</div>
+            </div>
+          </div>
+        </section>
+
+        <section className="mt-3 border border-[#e4e7ec] bg-white">
+          <div className="flex min-h-[54px] items-center justify-between gap-4 border-b border-[#eaecf0] px-3 py-2 max-[960px]:flex-col max-[960px]:items-stretch">
+            <Segmented
+              value={statusFilter}
+              options={[
+                { label: '全部', value: 'ALL' },
+                { label: '运行中', value: 'RUNNING' },
+                { label: '成功', value: 'SUCCESS' },
+                { label: '失败', value: 'FAILED' },
+                { label: '已取消', value: 'CANCELED' },
+              ]}
+              onChange={(value) =>
+                setStatusFilter(value as InstanceStatusFilter)
+              }
+            />
+
+            <Space size={8} wrap>
+              <Input
+                allowClear
+                variant="filled"
+                prefix={<Search size={15} />}
+                placeholder="搜索实例 ID 或任务名称"
+                className="w-[250px]"
+                value={keyword}
+                onChange={(event) => setKeyword(event.target.value)}
+              />
+              <Select
+                allowClear
+                variant="filled"
+                placeholder="全部引擎"
+                className="w-[140px]"
+                options={engineOptions}
+                value={engineFilter}
+                onChange={setEngineFilter}
+              />
+            </Space>
+          </div>
+
+          <Table<DevelopmentInstance>
+            rowKey="id"
+            columns={columns}
+            dataSource={filteredInstances}
+            pagination={false}
+            scroll={{ x: 1200 }}
+            locale={{
+              emptyText: (
+                <Empty
+                  image={
+                    <YakOpsEmpty
+                      width={220}
+                      height={174}
+                      primaryColor={BRAND_COLOR}
+                    />
+                  }
+                  description={
+                    hasFilters ? '没有匹配的运行实例' : '暂时没有运行实例'
+                  }
+                />
+              ),
+            }}
+          />
+        </section>
+      </div>
+    </ConfigProvider>
+  );
+};
+
+export default DataDevelopmentInstancesPage;

--- a/yak-ops-ui/src/pages/data-development/redirect/index.tsx
+++ b/yak-ops-ui/src/pages/data-development/redirect/index.tsx
@@ -1,0 +1,12 @@
+import { history } from '@umijs/max';
+import { useEffect } from 'react';
+
+const DataDevelopmentRedirectPage = () => {
+  useEffect(() => {
+    history.replace('/data-development/workbench');
+  }, []);
+
+  return null;
+};
+
+export default DataDevelopmentRedirectPage;

--- a/yak-ops-ui/src/pages/data-development/udf/index.tsx
+++ b/yak-ops-ui/src/pages/data-development/udf/index.tsx
@@ -1,0 +1,532 @@
+import YakOpsEmpty from '@/components/YakOpsEmpty';
+import { BRAND_COLOR, BRAND_THEME } from '@/styles/brand';
+import {
+  Button,
+  ConfigProvider,
+  Dropdown,
+  Empty,
+  Form,
+  Input,
+  message,
+  Modal,
+  Segmented,
+  Select,
+  Space,
+  Table,
+  Tag,
+  Typography,
+  type MenuProps,
+  type TableColumnsType,
+} from 'antd';
+import dayjs from 'dayjs';
+import {
+  Braces,
+  CircleCheck,
+  Clock3,
+  Copy,
+  FileCode2,
+  MoreHorizontal,
+  Plus,
+  Search,
+  Trash2,
+} from 'lucide-react';
+import { useMemo, useState } from 'react';
+
+const { Text } = Typography;
+
+type UdfLanguage = 'JAVA' | 'SCALA' | 'PYTHON';
+type UdfType = 'UDF' | 'UDTF' | 'UDAF';
+type UdfStatus = 'DRAFT' | 'PUBLISHED';
+type UdfStatusFilter = 'ALL' | UdfStatus;
+
+interface UdfFunction {
+  id: string;
+  name: string;
+  type: UdfType;
+  language: UdfLanguage;
+  entryClass: string;
+  resourcePath: string;
+  description?: string;
+  status: UdfStatus;
+  owner: string;
+  updatedAt: string;
+}
+
+interface CreateUdfValues {
+  name: string;
+  type: UdfType;
+  language: UdfLanguage;
+  entryClass: string;
+  resourcePath: string;
+  description?: string;
+}
+
+const languageOptions = [
+  { label: 'Java', value: 'JAVA' },
+  { label: 'Scala', value: 'SCALA' },
+  { label: 'Python', value: 'PYTHON' },
+];
+
+const udfTypeOptions = [
+  { label: '标量函数 UDF', value: 'UDF' },
+  { label: '表值函数 UDTF', value: 'UDTF' },
+  { label: '聚合函数 UDAF', value: 'UDAF' },
+];
+
+const DataDevelopmentUdfPage = () => {
+  const [form] = Form.useForm<CreateUdfValues>();
+  const [functions, setFunctions] = useState<UdfFunction[]>([]);
+  const [createOpen, setCreateOpen] = useState(false);
+  const [keyword, setKeyword] = useState('');
+  const [statusFilter, setStatusFilter] =
+    useState<UdfStatusFilter>('ALL');
+  const [languageFilter, setLanguageFilter] = useState<UdfLanguage>();
+
+  const summary = useMemo(
+    () => ({
+      total: functions.length,
+      published: functions.filter((item) => item.status === 'PUBLISHED').length,
+      draft: functions.filter((item) => item.status === 'DRAFT').length,
+    }),
+    [functions],
+  );
+
+  const filteredFunctions = useMemo(() => {
+    const normalizedKeyword = keyword.trim().toLowerCase();
+
+    return functions.filter((item) => {
+      const matchesKeyword =
+        !normalizedKeyword ||
+        item.name.toLowerCase().includes(normalizedKeyword) ||
+        item.id.toLowerCase().includes(normalizedKeyword) ||
+        item.entryClass.toLowerCase().includes(normalizedKeyword);
+      const matchesStatus =
+        statusFilter === 'ALL' || item.status === statusFilter;
+      const matchesLanguage =
+        !languageFilter || item.language === languageFilter;
+
+      return matchesKeyword && matchesStatus && matchesLanguage;
+    });
+  }, [functions, keyword, languageFilter, statusFilter]);
+
+  const openCreateModal = () => {
+    form.setFieldsValue({
+      type: 'UDF',
+      language: 'JAVA',
+    });
+    setCreateOpen(true);
+  };
+
+  const handleCreate = (values: CreateUdfValues) => {
+    const udf: UdfFunction = {
+      id: `UDF-${Date.now().toString().slice(-8)}`,
+      name: values.name.trim(),
+      type: values.type,
+      language: values.language,
+      entryClass: values.entryClass.trim(),
+      resourcePath: values.resourcePath.trim(),
+      description: values.description?.trim(),
+      status: 'DRAFT',
+      owner: '当前用户',
+      updatedAt: dayjs().format('YYYY-MM-DD HH:mm:ss'),
+    };
+
+    setFunctions((current) => [udf, ...current]);
+    setCreateOpen(false);
+    form.resetFields();
+    message.success('UDF 函数已创建');
+  };
+
+  const duplicateFunction = (udf: UdfFunction) => {
+    const copyFunction: UdfFunction = {
+      ...udf,
+      id: `UDF-${Date.now().toString().slice(-8)}`,
+      name: `${udf.name} 副本`,
+      status: 'DRAFT',
+      updatedAt: dayjs().format('YYYY-MM-DD HH:mm:ss'),
+    };
+
+    setFunctions((current) => [copyFunction, ...current]);
+    message.success('UDF 函数已复制');
+  };
+
+  const deleteFunction = (udf: UdfFunction) => {
+    Modal.confirm({
+      centered: true,
+      title: '确认删除 UDF 函数吗？',
+      content: `删除“${udf.name}”后无法恢复。`,
+      okText: '删除',
+      cancelText: '取消',
+      okButtonProps: { danger: true },
+      onOk: () => {
+        setFunctions((current) =>
+          current.filter((item) => item.id !== udf.id),
+        );
+        message.success('UDF 函数已删除');
+      },
+    });
+  };
+
+  const getActionItems = (udf: UdfFunction): MenuProps['items'] => [
+    {
+      key: 'detail',
+      icon: <FileCode2 size={15} />,
+      label: '查看函数',
+    },
+    {
+      key: 'copy',
+      icon: <Copy size={15} />,
+      label: '复制函数',
+    },
+    { type: 'divider' },
+    {
+      key: 'delete',
+      danger: true,
+      icon: <Trash2 size={15} />,
+      label: '删除',
+    },
+  ];
+
+  const handleAction = (udf: UdfFunction, key: string) => {
+    switch (key) {
+      case 'detail':
+        message.info('UDF 详情将在后续版本接入');
+        break;
+      case 'copy':
+        duplicateFunction(udf);
+        break;
+      case 'delete':
+        deleteFunction(udf);
+        break;
+      default:
+        break;
+    }
+  };
+
+  const columns: TableColumnsType<UdfFunction> = [
+    {
+      title: '函数名称',
+      dataIndex: 'name',
+      key: 'name',
+      width: 260,
+      render: (_, udf) => (
+        <button
+          type="button"
+          className="flex min-w-0 items-center gap-3 border-0 bg-transparent p-0 text-left"
+          onClick={() => handleAction(udf, 'detail')}
+        >
+          <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-[7px] bg-[rgba(254,44,85,0.06)] text-[#fe2c55]">
+            <Braces size={18} />
+          </span>
+          <span className="min-w-0">
+            <strong className="block truncate text-[13px] font-medium text-[#161823]">
+              {udf.name}
+            </strong>
+            <small className="block truncate text-[11px] text-[rgba(22,24,35,0.42)]">
+              {udf.id}
+            </small>
+          </span>
+        </button>
+      ),
+    },
+    {
+      title: '函数类型',
+      dataIndex: 'type',
+      key: 'type',
+      width: 110,
+      render: (value: UdfType) => <Tag bordered={false}>{value}</Tag>,
+    },
+    {
+      title: '语言',
+      dataIndex: 'language',
+      key: 'language',
+      width: 100,
+      render: (value: UdfLanguage) =>
+        languageOptions.find((item) => item.value === value)?.label || value,
+    },
+    {
+      title: '入口类 / 函数',
+      dataIndex: 'entryClass',
+      key: 'entryClass',
+      width: 240,
+      ellipsis: true,
+    },
+    {
+      title: '资源文件',
+      dataIndex: 'resourcePath',
+      key: 'resourcePath',
+      width: 220,
+      ellipsis: true,
+    },
+    {
+      title: '状态',
+      dataIndex: 'status',
+      key: 'status',
+      width: 100,
+      render: (value: UdfStatus) => (
+        <Tag
+          bordered={false}
+          className={
+            value === 'PUBLISHED'
+              ? '!bg-[rgba(254,44,85,0.06)] !text-[#fe2c55]'
+              : '!bg-[#f2f3f5] !text-[rgba(22,24,35,0.58)]'
+          }
+        >
+          {value === 'PUBLISHED' ? '已发布' : '草稿'}
+        </Tag>
+      ),
+    },
+    {
+      title: '负责人',
+      dataIndex: 'owner',
+      key: 'owner',
+      width: 120,
+    },
+    {
+      title: '更新时间',
+      dataIndex: 'updatedAt',
+      key: 'updatedAt',
+      width: 170,
+    },
+    {
+      title: '',
+      key: 'actions',
+      fixed: 'right',
+      width: 60,
+      align: 'center',
+      render: (_, udf) => (
+        <Dropdown
+          trigger={['click']}
+          menu={{
+            items: getActionItems(udf),
+            onClick: ({ key, domEvent }) => {
+              domEvent.stopPropagation();
+              handleAction(udf, key);
+            },
+          }}
+        >
+          <Button
+            type="text"
+            size="small"
+            aria-label={`操作 ${udf.name}`}
+            icon={<MoreHorizontal size={17} />}
+          />
+        </Dropdown>
+      ),
+    },
+  ];
+
+  const hasFilters =
+    Boolean(keyword) || statusFilter !== 'ALL' || Boolean(languageFilter);
+
+  return (
+    <ConfigProvider theme={BRAND_THEME}>
+      <div className="min-h-[calc(100vh-48px)] bg-white px-5 pb-5 pt-4 text-[#161823]">
+        <header className="flex min-h-11 items-center justify-between gap-4">
+          <h1 className="m-0 text-[17px] font-semibold leading-6">UDF 函数</h1>
+          <Button
+            type="primary"
+            icon={<Plus size={16} />}
+            onClick={openCreateModal}
+          >
+            新建 UDF
+          </Button>
+        </header>
+
+        <section className="mt-2 grid grid-cols-4 gap-2 max-[980px]:grid-cols-2">
+          <div className="flex min-h-[70px] items-center gap-3 border border-[#f0f0f0] bg-[#fafbfc] px-4 py-3">
+            <span className="flex h-9 w-9 items-center justify-center rounded-[7px] bg-[rgba(254,44,85,0.06)] text-[#fe2c55]">
+              <Braces size={19} />
+            </span>
+            <div>
+              <Text type="secondary" className="!text-[11px]">函数数量</Text>
+              <div className="mt-0.5 text-lg font-semibold">{summary.total}</div>
+            </div>
+          </div>
+          <div className="flex min-h-[70px] items-center gap-3 border border-[#f0f0f0] bg-[#fafbfc] px-4 py-3">
+            <span className="flex h-9 w-9 items-center justify-center rounded-[7px] bg-[rgba(254,44,85,0.06)] text-[#fe2c55]">
+              <CircleCheck size={19} />
+            </span>
+            <div>
+              <Text type="secondary" className="!text-[11px]">已发布</Text>
+              <div className="mt-0.5 text-lg font-semibold">{summary.published}</div>
+            </div>
+          </div>
+          <div className="flex min-h-[70px] items-center gap-3 border border-[#f0f0f0] bg-[#fafbfc] px-4 py-3">
+            <span className="flex h-9 w-9 items-center justify-center rounded-[7px] bg-[#f2f3f5] text-[rgba(22,24,35,0.58)]">
+              <Clock3 size={19} />
+            </span>
+            <div>
+              <Text type="secondary" className="!text-[11px]">草稿</Text>
+              <div className="mt-0.5 text-lg font-semibold">{summary.draft}</div>
+            </div>
+          </div>
+          <div className="flex min-h-[70px] items-center gap-3 border border-[#f0f0f0] bg-[#fafbfc] px-4 py-3">
+            <span className="flex h-9 w-9 items-center justify-center rounded-[7px] bg-[#f2f3f5] text-[rgba(22,24,35,0.58)]">
+              <FileCode2 size={19} />
+            </span>
+            <div>
+              <Text type="secondary" className="!text-[11px]">函数类型</Text>
+              <div className="mt-0.5 text-lg font-semibold">3</div>
+            </div>
+          </div>
+        </section>
+
+        <section className="mt-3 border border-[#e4e7ec] bg-white">
+          <div className="flex min-h-[54px] items-center justify-between gap-4 border-b border-[#eaecf0] px-3 py-2 max-[920px]:flex-col max-[920px]:items-stretch">
+            <Segmented
+              value={statusFilter}
+              options={[
+                { label: '全部函数', value: 'ALL' },
+                { label: '草稿', value: 'DRAFT' },
+                { label: '已发布', value: 'PUBLISHED' },
+              ]}
+              onChange={(value) =>
+                setStatusFilter(value as UdfStatusFilter)
+              }
+            />
+
+            <Space size={8} wrap>
+              <Input
+                allowClear
+                variant="filled"
+                prefix={<Search size={15} />}
+                placeholder="搜索函数名称、ID 或入口类"
+                className="w-[260px]"
+                value={keyword}
+                onChange={(event) => setKeyword(event.target.value)}
+              />
+              <Select<UdfLanguage>
+                allowClear
+                variant="filled"
+                placeholder="全部语言"
+                className="w-[130px]"
+                options={languageOptions}
+                value={languageFilter}
+                onChange={setLanguageFilter}
+              />
+            </Space>
+          </div>
+
+          <Table<UdfFunction>
+            rowKey="id"
+            columns={columns}
+            dataSource={filteredFunctions}
+            pagination={false}
+            scroll={{ x: 1350 }}
+            locale={{
+              emptyText: (
+                <Empty
+                  image={
+                    <YakOpsEmpty
+                      width={220}
+                      height={174}
+                      primaryColor={BRAND_COLOR}
+                    />
+                  }
+                  description={
+                    hasFilters ? '没有匹配的 UDF 函数' : '还没有 UDF 函数'
+                  }
+                >
+                  {!hasFilters && (
+                    <Button
+                      type="primary"
+                      icon={<Plus size={15} />}
+                      onClick={openCreateModal}
+                    >
+                      新建第一个 UDF
+                    </Button>
+                  )}
+                </Empty>
+              ),
+            }}
+          />
+        </section>
+
+        <Modal
+          title="新建 UDF 函数"
+          open={createOpen}
+          centered
+          width={600}
+          okText="创建函数"
+          cancelText="取消"
+          destroyOnHidden
+          onCancel={() => {
+            setCreateOpen(false);
+            form.resetFields();
+          }}
+          onOk={() => form.submit()}
+        >
+          <Form<CreateUdfValues>
+            form={form}
+            layout="vertical"
+            className="pt-2"
+            onFinish={handleCreate}
+          >
+            <Form.Item
+              name="name"
+              label="函数名称"
+              rules={[
+                { required: true, message: '请输入函数名称' },
+                { max: 80, message: '函数名称不能超过 80 个字符' },
+              ]}
+            >
+              <Input variant="filled" placeholder="例如：mask_phone" />
+            </Form.Item>
+
+            <div className="grid grid-cols-2 gap-3">
+              <Form.Item
+                name="type"
+                label="函数类型"
+                rules={[{ required: true, message: '请选择函数类型' }]}
+              >
+                <Select variant="filled" options={udfTypeOptions} />
+              </Form.Item>
+              <Form.Item
+                name="language"
+                label="开发语言"
+                rules={[{ required: true, message: '请选择开发语言' }]}
+              >
+                <Select variant="filled" options={languageOptions} />
+              </Form.Item>
+            </div>
+
+            <Form.Item
+              name="entryClass"
+              label="入口类 / 函数"
+              rules={[{ required: true, message: '请输入入口类或函数名称' }]}
+            >
+              <Input
+                variant="filled"
+                placeholder="例如：io.yak.ops.udf.MaskPhoneFunction"
+              />
+            </Form.Item>
+
+            <Form.Item
+              name="resourcePath"
+              label="资源文件"
+              rules={[{ required: true, message: '请输入资源文件路径' }]}
+            >
+              <Input
+                variant="filled"
+                placeholder="例如：/udf/yak-ops-udf.jar"
+              />
+            </Form.Item>
+
+            <Form.Item name="description" label="函数说明">
+              <Input.TextArea
+                variant="filled"
+                rows={4}
+                maxLength={300}
+                showCount
+                placeholder="补充函数用途、输入参数和返回值说明"
+              />
+            </Form.Item>
+          </Form>
+        </Modal>
+      </div>
+    </ConfigProvider>
+  );
+};
+
+export default DataDevelopmentUdfPage;


### PR DESCRIPTION
## 调整背景

此前将“数据开发”作为“数据集成”下的单个页面，菜单层级不符合实际业务划分。本次将其调整为独立一级业务模块。

## 变更内容

- 新增独立一级菜单“数据开发”，放在“数据集成”和“流程编排”之间。
- “数据开发”下新增三个子页面：
  - 工作台：管理 SQL / Python 开发任务，支持筛选、新建、复制和删除等前端交互。
  - 运行实例：提供实例状态概览、状态筛选、引擎筛选和实例列表空状态。
  - UDF 函数：管理 UDF / UDTF / UDAF，支持 Java、Scala、Python 类型及前端新建、复制和删除交互。
- 将原 `/data-development` 地址保留为兼容入口，并自动跳转到 `/data-development/workbench`。
- 页面继续使用 Yak Ops 品牌主色、Ant Design filled 控件和 `YakOpsEmpty` 空状态。

## 权限说明

当前后端尚未提供数据开发专属权限，三个子页面暂时复用 `task:batch:read` 或 `task:realtime:read` 任一权限；超级管理员仍可正常访问。后续接入数据开发后端模块时，可统一替换为专属权限编码。

## 影响范围

仅调整前端导航和数据开发页面，不修改数据集成、流程编排及后端接口。

## 验证

- 使用 TypeScript `transpileModule` 对导航文件及四个页面文件进行了语法检查，均通过。
- 分支新增运行实例、UDF 函数、旧路由跳转页面，并重构原数据开发页为工作台。
- 当前页面数据仍为前端内存状态，刷新后不持久化，等待后端接口接入。