### PR TITLE
feat(ui): unify workflow management with brand colors

### DIFF
--- a/yak-ops-ui/src/pages/workflow-management/designer/components/create-guide/index.tsx
+++ b/yak-ops-ui/src/pages/workflow-management/designer/components/create-guide/index.tsx
@@ -144,11 +144,11 @@ const WorkflowCreateGuide = () => {
                 type="button"
                 className={[
                   'relative h-[122px] w-[218px] rounded-xl border border-[#c7d2fe] bg-white p-3 text-left',
-                  'shadow-[0_4px_12px_rgba(79,70,229,0.08)] outline outline-2 outline-[#6366f1]',
+                  'shadow-[0_4px_12px_var(--yak-brand-color-soft-hover)] outline outline-2 outline-[var(--yak-brand-color)]',
                   'max-sm:w-full',
                 ].join(' ')}
               >
-                <span className="flex h-7 w-7 items-center justify-center rounded-md bg-[#4f46e5] text-white">
+                <span className="flex h-7 w-7 items-center justify-center rounded-md bg-[var(--yak-brand-color)] text-white">
                   <WorkflowIcon size={16} />
                 </span>
 
@@ -237,7 +237,7 @@ const WorkflowCreateGuide = () => {
                     className={[
                       'h-10 rounded-lg border border-transparent bg-[#f2f4f7] px-3 text-[13px]',
                       'shadow-none hover:border-[#d0d5dd] hover:bg-white',
-                      'focus:border-[#6366f1] focus:bg-white focus:shadow-[0_0_0_3px_rgba(99,102,241,0.08)]',
+                      'focus:border-[var(--yak-brand-color)] focus:bg-white focus:shadow-[0_0_0_3px_rgba(99,102,241,0.08)]',
                     ].join(' ')}
                   />
                 </Form.Item>
@@ -245,7 +245,7 @@ const WorkflowCreateGuide = () => {
                 <button
                   type="button"
                   title="应用图标"
-                  className="mb-4 flex h-14 w-14 shrink-0 items-center justify-center rounded-2xl border border-[#dbe4ff] bg-[#eef2ff] text-[#4f46e5]"
+                  className="mb-4 flex h-14 w-14 shrink-0 items-center justify-center rounded-2xl border border-[var(--yak-brand-color-border)] bg-[var(--yak-brand-color-soft)] text-[var(--yak-brand-color)]"
                 >
                   <WorkflowIcon size={25} />
                 </button>
@@ -269,7 +269,7 @@ const WorkflowCreateGuide = () => {
                   className={[
                     'min-h-[86px] resize-none rounded-lg border border-transparent bg-[#f2f4f7]',
                     'px-3 py-2 text-[13px] shadow-none hover:border-[#d0d5dd] hover:bg-white',
-                    'focus:border-[#6366f1] focus:bg-white focus:shadow-[0_0_0_3px_rgba(99,102,241,0.08)]',
+                    'focus:border-[var(--yak-brand-color)] focus:bg-white focus:shadow-[0_0_0_3px_rgba(99,102,241,0.08)]',
                   ].join(' ')}
                 />
               </Form.Item>
@@ -291,7 +291,7 @@ const WorkflowCreateGuide = () => {
                     'text-[13px] font-medium text-white transition-colors',
                     createDisabled
                       ? 'cursor-not-allowed bg-[#d6d9ff] shadow-none'
-                      : 'bg-[#4f46e5] shadow-[0_5px_12px_rgba(79,70,229,0.22)] hover:bg-[#4338ca]',
+                      : 'bg-[var(--yak-brand-color)] shadow-[0_5px_12px_var(--yak-brand-color-outline)] hover:bg-[var(--yak-brand-color-hover)]',
                   ].join(' ')}
                 >
                   {saving ? '创建中...' : '创建'}
@@ -328,7 +328,7 @@ const WorkflowCreateGuide = () => {
               <div className="relative h-[448px] w-full overflow-hidden border border-[#dfe5ec] bg-white shadow-[0_12px_28px_rgba(16,24,40,0.10)]">
                 <div className="flex h-11 items-center justify-between border-b border-[#edf0f3] px-4">
                   <div className="flex items-center gap-2">
-                    <span className="flex h-6 w-6 items-center justify-center rounded-md bg-[#4f46e5] text-white">
+                    <span className="flex h-6 w-6 items-center justify-center rounded-md bg-[var(--yak-brand-color)] text-white">
                       <WorkflowIcon size={13} />
                     </span>
 
@@ -346,7 +346,7 @@ const WorkflowCreateGuide = () => {
                       预览
                     </span>
 
-                    <span className="rounded-md bg-[#4f46e5] px-2 py-1 text-[9px] text-white">
+                    <span className="rounded-md bg-[var(--yak-brand-color)] px-2 py-1 text-[9px] text-white">
                       发布
                     </span>
                   </div>
@@ -364,7 +364,7 @@ const WorkflowCreateGuide = () => {
                     <div className="absolute left-[8%] top-[44%] flex items-center gap-8">
                       <div className="w-[128px] rounded-lg border border-[#c7d2fe] bg-white p-3 shadow-[0_7px_18px_rgba(16,24,40,0.08)]">
                         <div className="flex items-center gap-2">
-                          <span className="flex h-5 w-5 items-center justify-center rounded bg-[#4f46e5] text-white">
+                          <span className="flex h-5 w-5 items-center justify-center rounded bg-[var(--yak-brand-color)] text-white">
                             <CirclePlay size={11} />
                           </span>
 
@@ -379,7 +379,7 @@ const WorkflowCreateGuide = () => {
 
                       <ArrowRight size={20} className="text-[#98a2b3]" />
 
-                      <div className="w-[138px] rounded-lg border border-[#dbe4ff] bg-white p-3 shadow-[0_7px_18px_rgba(16,24,40,0.08)]">
+                      <div className="w-[138px] rounded-lg border border-[var(--yak-brand-color-border)] bg-white p-3 shadow-[0_7px_18px_rgba(16,24,40,0.08)]">
                         <div className="flex items-center gap-2">
                           <span className="flex h-5 w-5 items-center justify-center rounded bg-[#7c3aed] text-white">
                             <Bot size={11} />

--- a/yak-ops-ui/src/pages/workflow-management/designer/components/header/index.tsx
+++ b/yak-ops-ui/src/pages/workflow-management/designer/components/header/index.tsx
@@ -80,9 +80,9 @@ const SideNavItem = ({
           : 'gap-2',
         active
           ? [
-              'bg-[#eaf0ff]',
-              'font-semibold text-[#155eef]',
-              'shadow-[inset_0_0_0_1px_rgba(178,204,255,0.45)]',
+              'bg-[var(--yak-brand-color-soft)]',
+              'font-semibold text-[var(--yak-brand-color)]',
+              'shadow-[inset_0_0_0_1px_var(--yak-brand-color-outline)]',
             ].join(' ')
           : [
               'bg-transparent',
@@ -513,7 +513,7 @@ const WorkflowHeader = ({
                   className={[
                     'flex h-7 w-7 shrink-0',
                     'items-center justify-center',
-                    'rounded-full bg-[#155eef]',
+                    'rounded-full bg-[var(--yak-brand-color)]',
                     'text-[12px] font-semibold',
                     'text-white',
                   ].join(' ')}
@@ -543,7 +543,7 @@ const WorkflowHeader = ({
                     'shadow-[0_1px_2px_rgba(16,24,40,0.05)]',
                     'transition-colors',
                     'hover:bg-[#f9fafb]',
-                    'hover:text-[#155eef]',
+                    'hover:text-[var(--yak-brand-color)]',
                   ].join(' ')}
                 >
                   <CircleHelp size={15} />
@@ -631,9 +631,9 @@ const WorkflowHeader = ({
               'transition-colors',
               activePanel === 'run'
                 ? [
-                    'border-[#b2ccff]',
-                    'bg-[#eff4ff]',
-                    'text-[#155eef]',
+                    'border-[var(--yak-brand-color-border)]',
+                    'bg-[var(--yak-brand-color-soft)]',
+                    'text-[var(--yak-brand-color)]',
                   ].join(' ')
                 : [
                     'border-[#e4e7ec]',
@@ -655,10 +655,10 @@ const WorkflowHeader = ({
             className={[
               'inline-flex h-8 items-center gap-1.5',
               'rounded-[10px] border-0',
-              'bg-[#155eef] px-3.5',
+              'bg-[var(--yak-brand-color)] px-3.5',
               'text-[12px] font-semibold text-white',
               'transition-colors',
-              'hover:bg-[#004eeb]',
+              'hover:bg-[var(--yak-brand-color-hover)]',
               'disabled:cursor-not-allowed',
               'disabled:opacity-50',
             ].join(' ')}

--- a/yak-ops-ui/src/pages/workflow-management/designer/components/node/BaseNode.tsx
+++ b/yak-ops-ui/src/pages/workflow-management/designer/components/node/BaseNode.tsx
@@ -57,7 +57,7 @@ const BaseNode = ({ id, data, meta, selected, children }: BaseNodeProps) => {
     <div
       className={[
         'group relative flex rounded-2xl border p-[1px] transition-[filter,opacity] duration-150',
-        selected ? 'border-[#155eef]' : 'border-transparent',
+        selected ? 'border-[var(--yak-brand-color)]' : 'border-transparent',
         data.enabled ? '' : 'opacity-60 grayscale-[0.25]',
       ]
         .filter(Boolean)

--- a/yak-ops-ui/src/pages/workflow-management/designer/components/node/node.helpers.ts
+++ b/yak-ops-ui/src/pages/workflow-management/designer/components/node/node.helpers.ts
@@ -4,14 +4,14 @@ export type WorkflowNodeStatus = NonNullable<WorkflowNodeData['runningStatus']>;
 
 export const nodeStatusBorderClass: Record<WorkflowNodeStatus, string> = {
   idle: 'border-transparent',
-  running: 'border-[#155eef]',
+  running: 'border-[var(--yak-brand-color)]',
   success: 'border-[#17b26a]',
   failed: 'border-[#f04438]',
 };
 
 export const nodeStatusTextClass: Record<WorkflowNodeStatus, string> = {
   idle: 'text-[#98a2b3]',
-  running: 'text-[#155eef]',
+  running: 'text-[var(--yak-brand-color)]',
   success: 'text-[#079455]',
   failed: 'text-[#d92d20]',
 };

--- a/yak-ops-ui/src/pages/workflow-management/designer/components/node/nodes/http/index.tsx
+++ b/yak-ops-ui/src/pages/workflow-management/designer/components/node/nodes/http/index.tsx
@@ -4,7 +4,7 @@ import { getText } from '../../node.helpers';
 const HttpNodeContent = ({ data }: { data: WorkflowNodeData }) => (
   <div className="px-3 pb-2">
     <div className="flex min-h-8 items-center gap-2 rounded-lg bg-[#f5f7fa] px-2.5 py-2 text-[10px] text-[#475467]">
-      <span className="shrink-0 rounded-md bg-white px-1.5 py-0.5 text-[9px] font-semibold text-[#155eef] shadow-[0_0_0_1px_#d1e0ff]">
+      <span className="shrink-0 rounded-md bg-white px-1.5 py-0.5 text-[9px] font-semibold text-[var(--yak-brand-color)] shadow-[0_0_0_1px_var(--yak-brand-color-border)]">
         {getText(data.config.method, 'GET').toUpperCase()}
       </span>
       <span

--- a/yak-ops-ui/src/pages/workflow-management/designer/components/operator/CanvasOperator.tsx
+++ b/yak-ops-ui/src/pages/workflow-management/designer/components/operator/CanvasOperator.tsx
@@ -81,7 +81,7 @@ const iconButtonClass = [
   "text-[#667085] outline-none",
   "transition-[background-color,color,box-shadow,transform] duration-150",
   "hover:bg-[#f2f4f7] hover:text-[#344054]",
-  "focus-visible:ring-2 focus-visible:ring-[#84adff]",
+  "focus-visible:ring-2 focus-visible:ring-[var(--yak-brand-color-border)]",
   "focus-visible:ring-offset-1",
   "active:scale-[0.96]",
   "disabled:cursor-not-allowed disabled:opacity-[0.35]",
@@ -89,9 +89,9 @@ const iconButtonClass = [
 ].join(" ");
 
 const activeIconButtonClass = [
-  "bg-[#eef4ff] text-[#155eef]",
-  "shadow-[inset_0_0_0_1px_rgba(21,94,239,0.06)]",
-  "hover:bg-[#e6efff] hover:text-[#155eef]",
+  "bg-[var(--yak-brand-color-soft)] text-[var(--yak-brand-color)]",
+  "shadow-[inset_0_0_0_1px_var(--yak-brand-color-soft)]",
+  "hover:bg-[var(--yak-brand-color-soft-hover)] hover:text-[var(--yak-brand-color)]",
 ].join(" ");
 
 const getIconButtonClass = (active?: boolean) =>
@@ -102,7 +102,7 @@ const ActiveIndicator = () => (
     className={[
       "pointer-events-none absolute -left-[5px] top-1/2",
       "h-4 w-0.5 -translate-y-1/2 rounded-r-full",
-      "bg-[#155eef]",
+      "bg-[var(--yak-brand-color)]",
     ].join(" ")}
   />
 );
@@ -249,7 +249,7 @@ const CanvasOperator = ({
                 "rounded-full text-white",
                 "transition-colors duration-150",
                 nodePanelOpen
-                  ? "bg-[#155eef]"
+                  ? "bg-[var(--yak-brand-color)]"
                   : "bg-[#475467] group-hover:bg-[#344054]",
               ].join(" ")}
             >
@@ -329,14 +329,14 @@ const CanvasOperator = ({
               <div
                 className={[
                   "relative flex h-[42px] items-center",
-                  "text-[14px] font-semibold text-[#155eef]",
+                  "text-[14px] font-semibold text-[var(--yak-brand-color)]",
                 ].join(" ")}
               >
                 节点
                 <span
                   className={[
                     "absolute inset-x-0 bottom-0",
-                    "h-0.5 rounded-full bg-[#155eef]",
+                    "h-0.5 rounded-full bg-[var(--yak-brand-color)]",
                   ].join(" ")}
                 />
               </div>
@@ -359,8 +359,8 @@ const CanvasOperator = ({
                   "bg-[#fcfcfd]",
                   "shadow-[0_1px_2px_rgba(16,24,40,0.02)]",
                   "hover:border-[#b8c0cc]",
-                  "focus-within:border-[#84adff]",
-                  "focus-within:shadow-[0_0_0_3px_rgba(21,94,239,0.08)]",
+                  "focus-within:border-[var(--yak-brand-color-border)]",
+                  "focus-within:shadow-[0_0_0_3px_var(--yak-brand-color-soft-hover)]",
                   "[&_.ant-input]:bg-transparent",
                   "[&_.ant-input]:text-[13px]",
                   "[&_.ant-input::placeholder]:text-[#98a2b3]",
@@ -414,8 +414,8 @@ const CanvasOperator = ({
                               "duration-150",
                               "hover:border-[#eaecf0]",
                               "hover:bg-[#f5f7fa]",
-                              "focus-visible:border-[#b2ccff]",
-                              "focus-visible:bg-[#eef4ff]",
+                              "focus-visible:border-[var(--yak-brand-color-border)]",
+                              "focus-visible:bg-[var(--yak-brand-color-soft)]",
                               "active:scale-[0.995]",
                             ].join(" ")}
                             onClick={() => onSelectLibraryItem(item)}
@@ -448,7 +448,7 @@ const CanvasOperator = ({
                                 "transition-[opacity,transform,color]",
                                 "duration-150",
                                 "group-hover:translate-x-0",
-                                "group-hover:text-[#155eef]",
+                                "group-hover:text-[var(--yak-brand-color)]",
                                 "group-hover:opacity-100",
                               ].join(" ")}
                             />

--- a/yak-ops-ui/src/pages/workflow-management/designer/components/operator/VariableInspectPanel.tsx
+++ b/yak-ops-ui/src/pages/workflow-management/designer/components/operator/VariableInspectPanel.tsx
@@ -92,7 +92,7 @@ const VariableInspectPanel = ({
             title="点击复制变量引用"
             className="grid min-w-[190px] grid-cols-[45px_minmax(0,1fr)] gap-x-2 gap-y-0.5 rounded-md border border-[#eaecf0] bg-white p-2 text-left hover:bg-[#fcfcfd]"
           >
-            <span className="row-span-2 self-center rounded bg-[#f1f0ff] px-1.5 py-1 text-center text-[7px] text-[#5d5fef]">
+            <span className="row-span-2 self-center rounded bg-[var(--yak-brand-color-soft)] px-1.5 py-1 text-center text-[7px] text-[var(--yak-brand-color)]">
               {row.source}
             </span>
             <strong className="text-[9px] text-[#475467]">{row.name}</strong>

--- a/yak-ops-ui/src/pages/workflow-management/designer/components/panel/HistoryPanel.tsx
+++ b/yak-ops-ui/src/pages/workflow-management/designer/components/panel/HistoryPanel.tsx
@@ -31,7 +31,7 @@ const HistoryPanel = ({ snapshots, onRestore, onClose }: HistoryPanelProps) => (
               key={snapshot.id}
               className="relative grid grid-cols-[30px_minmax(0,1fr)_auto] items-center gap-2 rounded-lg border border-[#e4e7ec] bg-white p-2.5"
             >
-              <span className="flex h-[29px] w-[29px] items-center justify-center rounded-lg bg-[#f1f0ff] text-[#5d5fef]">
+              <span className="flex h-[29px] w-[29px] items-center justify-center rounded-lg bg-[var(--yak-brand-color-soft)] text-[var(--yak-brand-color)]">
                 <History size={16} />
               </span>
               <div>

--- a/yak-ops-ui/src/pages/workflow-management/designer/components/panel/RunPanel.tsx
+++ b/yak-ops-ui/src/pages/workflow-management/designer/components/panel/RunPanel.tsx
@@ -132,7 +132,7 @@ const RunPanel = ({ nodes, onStatusChange, onClose }: RunPanelProps) => {
 
   const statusClass = (status: WorkflowRunLog['status']) => {
     if (status === 'running')
-      return 'border-[#c7d7fe] bg-[#f5f8ff] text-[#4f46e5]';
+      return 'border-[#c7d7fe] bg-[var(--yak-brand-color-soft)] text-[var(--yak-brand-color)]';
     if (status === 'success')
       return 'border-[#abefc6] bg-[#f6fef9] text-[#039855]';
     if (status === 'failed')
@@ -173,7 +173,7 @@ const RunPanel = ({ nodes, onStatusChange, onClose }: RunPanelProps) => {
             ) : (
               <button
                 type="button"
-                className="inline-flex h-[30px] items-center gap-1.5 rounded-md border-0 bg-[#5d5fef] px-2.5 text-[9px] text-white"
+                className="inline-flex h-[30px] items-center gap-1.5 rounded-md border-0 bg-[var(--yak-brand-color)] px-2.5 text-[9px] text-white"
                 onClick={() => void run()}
               >
                 <Play size={14} /> 开始运行

--- a/yak-ops-ui/src/pages/workflow-management/designer/components/panel/node/shared.tsx
+++ b/yak-ops-ui/src/pages/workflow-management/designer/components/panel/node/shared.tsx
@@ -131,7 +131,7 @@ export const AddButton = ({
           'text-[#667085]',
           'transition-colors duration-150',
           'hover:bg-[#f2f4f7]',
-          'hover:text-[#155eef]',
+          'hover:text-[var(--yak-brand-color)]',
         ].join(' ')}
       >
         <Plus size={15} strokeWidth={2} />
@@ -148,8 +148,8 @@ export const AddButton = ({
       className={[
         '!h-7 !rounded-md !px-2',
         '!text-[12px] !font-medium',
-        '!text-[#155eef]',
-        'hover:!bg-[#eef4ff]',
+        '!text-[var(--yak-brand-color)]',
+        'hover:!bg-[var(--yak-brand-color-soft)]',
       ].join(' ')}
     >
       {children}
@@ -296,8 +296,8 @@ export const KeyValueEditor = ({
           'bg-[#fcfcfd]',
           'text-[12px] text-[#667085]',
           'transition-colors duration-150',
-          'hover:bg-[#f8faff]',
-          'hover:text-[#155eef]',
+          'hover:bg-[var(--yak-brand-color-soft)]',
+          'hover:text-[var(--yak-brand-color)]',
         ].join(' ')}
       >
         <Plus size={14} strokeWidth={2} />

--- a/yak-ops-ui/src/pages/workflow-management/designer/components/panel/node/start/index.tsx
+++ b/yak-ops-ui/src/pages/workflow-management/designer/components/panel/node/start/index.tsx
@@ -125,7 +125,7 @@ const StartPanel = ({
               <span
                 className={[
                   'flex h-6 w-6 shrink-0 items-center justify-center',
-                  'rounded-md bg-[#eef4ff] text-[#155eef]',
+                  'rounded-md bg-[var(--yak-brand-color-soft)] text-[var(--yak-brand-color)]',
                 ].join(' ')}
               >
                 <Braces size={13} strokeWidth={2} />
@@ -223,9 +223,9 @@ const StartPanel = ({
               'rounded-lg border border-dashed border-[#d0d5dd]',
               'bg-[#fcfcfd] text-[#98a2b3]',
               'transition-colors duration-150',
-              'hover:border-[#84adff]',
-              'hover:bg-[#f8faff]',
-              'hover:text-[#155eef]',
+              'hover:border-[var(--yak-brand-color-border)]',
+              'hover:bg-[var(--yak-brand-color-soft)]',
+              'hover:text-[var(--yak-brand-color)]',
             ].join(' ')}
           >
             <Braces size={17} strokeWidth={1.8} />

--- a/yak-ops-ui/src/pages/workflow-management/designer/components/quick-add/NextStepSection.tsx
+++ b/yak-ops-ui/src/pages/workflow-management/designer/components/quick-add/NextStepSection.tsx
@@ -34,7 +34,7 @@ const NextStepSection = ({
               'rounded-lg border border-[#e4e7ec] bg-white px-2.5 text-left',
               'shadow-[0_1px_2px_rgba(16,24,40,0.04)]',
               'transition-colors duration-150',
-              'hover:border-[#b2ccff] hover:bg-[#f8faff]',
+              'hover:border-[var(--yak-brand-color-border)] hover:bg-[var(--yak-brand-color-soft)]',
             ].join(' ')}
             style={{ '--node-color': meta.color } as CSSProperties}
             onClick={() => onOpenNode(node.id)}
@@ -47,7 +47,7 @@ const NextStepSection = ({
             </span>
             <ChevronRight
               size={14}
-              className="shrink-0 text-[#98a2b3] group-hover:text-[#155eef]"
+              className="shrink-0 text-[#98a2b3] group-hover:text-[var(--yak-brand-color)]"
             />
           </button>
         );

--- a/yak-ops-ui/src/pages/workflow-management/designer/components/quick-add/NodePicker.tsx
+++ b/yak-ops-ui/src/pages/workflow-management/designer/components/quick-add/NodePicker.tsx
@@ -67,7 +67,7 @@ const NodePicker = ({ onSelect, allowedTypes }: NodePickerProps) => {
                       'group flex min-h-[52px] w-full items-center gap-2.5',
                       'rounded-lg border border-transparent px-2 py-2 text-left',
                       'transition-colors duration-150',
-                      'hover:border-[#d1e0ff] hover:bg-[#f5f8ff]',
+                      'hover:border-[var(--yak-brand-color-border)] hover:bg-[var(--yak-brand-color-soft)]',
                     ].join(' ')}
                     style={{ '--node-color': item.color } as CSSProperties}
                     onClick={() => onSelect(item.type)}
@@ -85,7 +85,7 @@ const NodePicker = ({ onSelect, allowedTypes }: NodePickerProps) => {
                       </span>
                     </span>
 
-                    <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-[#98a2b3] transition-colors group-hover:bg-white group-hover:text-[#155eef]">
+                    <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-[#98a2b3] transition-colors group-hover:bg-white group-hover:text-[var(--yak-brand-color)]">
                       <Plus size={15} />
                     </span>
                   </button>

--- a/yak-ops-ui/src/pages/workflow-management/designer/components/quick-add/QuickAddButton.tsx
+++ b/yak-ops-ui/src/pages/workflow-management/designer/components/quick-add/QuickAddButton.tsx
@@ -32,7 +32,7 @@ const QuickAddButton = ({
           'rounded-lg border border-dashed border-[#d0d5dd] bg-[#f9fafb]',
           'px-3 text-[12px] font-medium text-[#667085]',
           'transition-colors duration-150',
-          'hover:border-[#84adff] hover:bg-[#f5f8ff] hover:text-[#155eef]',
+          'hover:border-[var(--yak-brand-color-border)] hover:bg-[var(--yak-brand-color-soft)] hover:text-[var(--yak-brand-color)]',
           className,
         ].join(' ')}
         onMouseDown={(event) => event.stopPropagation()}
@@ -63,14 +63,14 @@ const QuickAddButton = ({
       <span
         className={[
           'flex items-center justify-center rounded-full border bg-white',
-          'text-[#155eef] shadow-[0_4px_12px_rgba(16,24,40,0.14)]',
+          'text-[var(--yak-brand-color)] shadow-[0_4px_12px_rgba(16,24,40,0.14)]',
           'transition-[border-color,background-color,box-shadow,transform] duration-150',
-          'group-hover/quick-add:border-[#84adff]',
-          'group-hover/quick-add:bg-[#f5f8ff]',
-          'group-hover/quick-add:shadow-[0_5px_16px_rgba(21,94,239,0.18)]',
+          'group-hover/quick-add:border-[var(--yak-brand-color-border)]',
+          'group-hover/quick-add:bg-[var(--yak-brand-color-soft)]',
+          'group-hover/quick-add:shadow-[0_5px_16px_var(--yak-brand-color-outline)]',
           'group-active/quick-add:scale-95',
           variant === 'edge'
-            ? 'h-7 w-7 border-[#b2ccff]'
+            ? 'h-7 w-7 border-[var(--yak-brand-color-border)]'
             : 'h-7 w-7 border-[#d0d5dd]',
         ].join(' ')}
       >

--- a/yak-ops-ui/src/pages/workflow-management/designer/components/quick-add/WorkflowQuickAddLayer.tsx
+++ b/yak-ops-ui/src/pages/workflow-management/designer/components/quick-add/WorkflowQuickAddLayer.tsx
@@ -238,7 +238,7 @@ const WorkflowQuickAddLayer = () => {
             orient="auto"
             markerUnits="strokeWidth"
           >
-            <path d="M 0 0 L 8 4 L 0 8 z" fill="#155eef" />
+            <path d="M 0 0 L 8 4 L 0 8 z" fill="var(--yak-brand-color)" />
           </marker>
         </defs>
 
@@ -249,7 +249,7 @@ const WorkflowQuickAddLayer = () => {
               key={edge.id}
               d={path}
               fill="none"
-              stroke={active ? '#155eef' : '#a6afbd'}
+              stroke={active ? 'var(--yak-brand-color)' : '#a6afbd'}
               strokeWidth={active ? 2 : 1.6}
               strokeLinecap="round"
               markerEnd={

--- a/yak-ops-ui/src/pages/workflow-management/designer/index.less
+++ b/yak-ops-ui/src/pages/workflow-management/designer/index.less
@@ -90,8 +90,8 @@
 }
 
 .dify-workflow-canvas .react-flow__selection {
-  border: 1px solid rgba(21, 94, 239, 0.65);
-  background: rgba(21, 94, 239, 0.08);
+  border: 1px solid var(--yak-brand-color-border);
+  background: var(--yak-brand-color-soft-hover);
 }
 
 .dify-workflow-canvas .react-flow__background {
@@ -108,7 +108,7 @@
   padding: 28px 38px;
   border: 1px dashed #cfd4dc;
   border-radius: 12px;
-  color: #155eef;
+  color: var(--yak-brand-color);
   background: rgba(255, 255, 255, 0.82);
   box-shadow: 0 10px 30px rgba(16, 24, 40, 0.06);
   transform: translate(-50%, -50%);

--- a/yak-ops-ui/src/pages/workflow-management/designer/index.tsx
+++ b/yak-ops-ui/src/pages/workflow-management/designer/index.tsx
@@ -1,6 +1,7 @@
 import { API_SUCCESS_CODE } from '@/services/http/response';
+import { BRAND_CSS_VARIABLES, BRAND_THEME } from '@/styles/brand';
 import { history, useParams } from '@umijs/max';
-import { message, Modal, Spin } from 'antd';
+import { ConfigProvider, message, Modal, Spin } from 'antd';
 import { Sparkles } from 'lucide-react';
 import {
   addEdge,
@@ -1115,8 +1116,8 @@ const WorkflowDesignerContent = () => {
             <div
               className={[
                 'pointer-events-none absolute z-30 w-[224px] -translate-x-1/2 -translate-y-1/2',
-                'overflow-hidden rounded-xl border border-[#84adff] bg-white/95',
-                'shadow-[0_0_0_3px_rgba(21,94,239,0.10),0_14px_34px_rgba(16,24,40,0.16)]',
+                'overflow-hidden rounded-xl border border-[var(--yak-brand-color-border)] bg-white/95',
+                'shadow-[0_0_0_3px_var(--yak-brand-color-outline),0_14px_34px_rgba(16,24,40,0.16)]',
                 'backdrop-blur-[8px]',
               ].join(' ')}
               style={
@@ -1341,9 +1342,13 @@ const WorkflowDesignerContent = () => {
 };
 
 const WorkflowDesignerPage = () => (
-  <ReactFlowProvider>
-    <WorkflowDesignerContent />
-  </ReactFlowProvider>
+  <ConfigProvider theme={BRAND_THEME}>
+    <div style={BRAND_CSS_VARIABLES}>
+      <ReactFlowProvider>
+        <WorkflowDesignerContent />
+      </ReactFlowProvider>
+    </div>
+  </ConfigProvider>
 );
 
 export default WorkflowDesignerPage;

--- a/yak-ops-ui/src/pages/workflow-management/index.tsx
+++ b/yak-ops-ui/src/pages/workflow-management/index.tsx
@@ -1,5 +1,7 @@
+import { BRAND_CSS_VARIABLES, BRAND_THEME } from '@/styles/brand';
 import { history } from '@umijs/max';
 import {
+  ConfigProvider,
   Dropdown,
   Empty,
   Input,
@@ -235,20 +237,22 @@ const WorkflowManagementPage = () => {
       'relative inline-flex h-[46px] items-center border-0 bg-transparent px-0 text-[14px] transition-colors',
       'after:absolute after:inset-x-0 after:bottom-[-1px] after:h-[2px] after:rounded-full after:content-[""]',
       active
-        ? 'font-semibold text-[#101828] after:bg-[#ff3b6b]'
+        ? 'font-semibold text-[#101828] after:bg-[var(--yak-brand-color)]'
         : 'font-normal text-[#667085] after:bg-transparent hover:text-[#344054]',
     ].join(' ');
 
   return (
-    <div
-      className={[
-        'min-h-full bg-white px-7 pb-9 pt-6 text-[#101828]',
-        'max-lg:px-5',
-      ].join(' ')}
-    >
+    <ConfigProvider theme={BRAND_THEME}>
+      <div
+        style={BRAND_CSS_VARIABLES}
+        className={[
+          'min-h-full bg-white px-7 pb-9 pt-6 text-[#101828]',
+          'max-lg:px-5',
+        ].join(' ')}
+      >
       <header className="mb-6 flex items-start justify-between gap-5">
         <div>
-          <span className="text-[11px] font-bold tracking-[0.12em] text-[#7f56d9]">
+          <span className="text-[11px] font-bold tracking-[0.12em] text-[var(--yak-brand-color)]">
             WORKFLOW
           </span>
 
@@ -446,7 +450,7 @@ const WorkflowManagementPage = () => {
                     )
                   }
                 >
-                  <span className="mb-3.5 flex h-11 w-11 items-center justify-center rounded-xl bg-[#eeefff] text-[#5d5fef]">
+                  <span className="mb-3.5 flex h-11 w-11 items-center justify-center rounded-xl bg-[var(--yak-brand-color-soft)] text-[var(--yak-brand-color)]">
                     <Plus size={22} />
                   </span>
 
@@ -592,7 +596,8 @@ const WorkflowManagementPage = () => {
           </div>
         )}
       </Spin>
-    </div>
+      </div>
+    </ConfigProvider>
   );
 };
 

--- a/yak-ops-ui/src/styles/brand.ts
+++ b/yak-ops-ui/src/styles/brand.ts
@@ -1,4 +1,5 @@
 import type { ThemeConfig } from 'antd';
+import type { CSSProperties } from 'react';
 
 /** Yak Ops 全局品牌主色。 */
 export const BRAND_COLOR = 'rgba(254,44,85,1)';
@@ -10,6 +11,16 @@ export const BRAND_COLOR_SOFT = 'rgba(254,44,85,0.06)';
 export const BRAND_COLOR_SOFT_HOVER = 'rgba(254,44,85,0.1)';
 export const BRAND_COLOR_BORDER = 'rgba(254,44,85,0.35)';
 export const BRAND_COLOR_OUTLINE = 'rgba(254,44,85,0.16)';
+
+/** 供 Tailwind 任意值、Less 及 SVG 复用的品牌色 CSS 变量。 */
+export const BRAND_CSS_VARIABLES = {
+  '--yak-brand-color': BRAND_COLOR,
+  '--yak-brand-color-hover': BRAND_COLOR_HOVER,
+  '--yak-brand-color-soft': BRAND_COLOR_SOFT,
+  '--yak-brand-color-soft-hover': BRAND_COLOR_SOFT_HOVER,
+  '--yak-brand-color-border': BRAND_COLOR_BORDER,
+  '--yak-brand-color-outline': BRAND_COLOR_OUTLINE,
+} as CSSProperties;
 
 /**
  * Ant Design 品牌主题。


### PR DESCRIPTION
### Motivation

- Unify the workflow-management UI color scheme to the Yak Ops brand tokens so list, designer and quick-add visuals share the same primary/interaction colors.
- Provide reusable CSS variables for brand colors so Tailwind/Less/SVG and inline styles can consistently reference the same tokens.

### Description

- Export a CSS variables object `BRAND_CSS_VARIABLES` from `src/styles/brand.ts` and keep the existing `BRAND_THEME` `ThemeConfig` for Ant Design usage so both CSS and Ant components share brand tokens.
- Wrap the workflow pages with Ant Design `ConfigProvider theme={BRAND_THEME}` and apply `style={BRAND_CSS_VARIABLES}` in `src/pages/workflow-management/index.tsx` and `src/pages/workflow-management/designer/index.tsx` to scope the theme/vars to those screens.
- Replace many hard-coded blues/purples/soft backgrounds/outlines (selection borders, focus rings, active states, soft backgrounds, buttons, node highlights) with the new CSS variables across workflow files including `CanvasOperator.tsx`, `WorkflowQuickAddLayer.tsx`, `QuickAddButton.tsx`, `NodePicker.tsx`, `Header`, `CreateGuide`, node helpers and panels, and `designer/index.less` (SVG arrow markers and edge stroke colors now use `var(--yak-brand-color)`).
- Keep Ant Design tokens (`BRAND_THEME`) for control theming while exposing `BRAND_CSS_VARIABLES` so Tailwind utility classes, inline style attributes and SVG elements can reference the same palette.

### Testing

- Ran `git diff --check` and staged changes; pre-commit checks passed for the applied diffs in this environment.
- Ran `npx @biomejs/biome check` which applied automatic fixes to multiple files and reported remaining formatting/lint diagnostics (unused variable and an SVG title a11y warning) that were not broadly refactored in this change. 
- Ran `npm run tsc` which failed in this environment due to a missing ambient type (`TS2688: Cannot find type definition file for 'minimatch'`).
- Attempted `npm run jest` for workflow tests but the Umi-generated-file preparation step ran in this environment (no full test output produced); CI/test runs should be executed in the project CI (with dev deps installed) to verify runtime/visual results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6e0507eb3c83268da6397c44e3f001)