### PR TITLE
feat(offline-sync): add connector form schema layer

### DIFF
--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/FORM_SCHEMA.md
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/FORM_SCHEMA.md
@@ -1,0 +1,48 @@
+# Yak Ops Connector Form Schema
+
+第二阶段在 Link-Up Connector Schema 之上增加产品展示层：
+
+```text
+Link-Up Connector Schema
+          ↓ 缓存原始快照
+ConnectorSchemaRegistry
+          ↓ 合并
+ConnectorPresentationRegistry + ConnectorFormSchemaComposer
+          ↓
+Yak Ops Form Schema
+```
+
+## API
+
+```http
+GET  /api/v1/job/batch-control/connectors/form-schemas?role=SOURCE
+GET  /api/v1/job/batch-control/connectors/{connectorId}/form-schema?role=SOURCE
+POST /api/v1/job/batch-control/connectors/schemas/refresh
+```
+
+Form Schema 保留 Link-Up 的类型、默认值、枚举值、必填、敏感、Scope、Semantic Type、规则和能力，同时补充：
+
+- 分组和顺序；
+- PRIMARY / COMMON / ADVANCED / EXPERT / HIDDEN 重要程度；
+- widget、label、help、placeholder；
+- hidden、readOnly、valueSource；
+- Schema/Profile/Form 三层版本与指纹；
+- REMOTE/CACHE 来源、同步时间和 stale 状态。
+
+JDBC Source/Sink 已提供第一版专属 Profile。未知 Connector 会通过通用推导得到可用表单，不会因为缺少 Profile 而丢失参数。数据源连接参数默认隐藏并由数据源中心注入。
+
+配置项：
+
+```yaml
+yak:
+  sync:
+    offline:
+      schema:
+        enabled: true
+        refresh-enabled: true
+        initial-delay-millis: 5000
+        refresh-delay-millis: 300000
+        max-stale-millis: 86400000
+```
+
+本阶段不包含前端动态渲染器、Connector Action API、JSON JobSpec 或 HOCON 替换。

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/config/ConnectorSchemaProperties.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/config/ConnectorSchemaProperties.java
@@ -1,0 +1,28 @@
+package io.yak.ops.business.sync.offline.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+/** Link-Up Connector Schema 同步与缓存配置。 */
+@ConditionalOnOfflineSyncEnabled
+@Component
+@ConfigurationProperties(prefix = "yak.sync.offline.schema")
+public class ConnectorSchemaProperties {
+
+  private boolean enabled = true;
+  private boolean refreshEnabled = true;
+  private long initialDelayMillis = 5_000L;
+  private long refreshDelayMillis = 300_000L;
+  private long maxStaleMillis = 86_400_000L;
+
+  public boolean isEnabled() { return enabled; }
+  public void setEnabled(boolean enabled) { this.enabled = enabled; }
+  public boolean isRefreshEnabled() { return refreshEnabled; }
+  public void setRefreshEnabled(boolean refreshEnabled) { this.refreshEnabled = refreshEnabled; }
+  public long getInitialDelayMillis() { return initialDelayMillis; }
+  public void setInitialDelayMillis(long initialDelayMillis) { this.initialDelayMillis = initialDelayMillis; }
+  public long getRefreshDelayMillis() { return refreshDelayMillis; }
+  public void setRefreshDelayMillis(long refreshDelayMillis) { this.refreshDelayMillis = refreshDelayMillis; }
+  public long getMaxStaleMillis() { return maxStaleMillis; }
+  public void setMaxStaleMillis(long maxStaleMillis) { this.maxStaleMillis = maxStaleMillis; }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/controller/OfflineConnectorFormController.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/controller/OfflineConnectorFormController.java
@@ -1,0 +1,46 @@
+package io.yak.ops.business.sync.offline.controller;
+
+import io.yak.framework.common.Result;
+import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import io.yak.ops.business.sync.offline.form.ConnectorFormSchema;
+import io.yak.ops.business.sync.offline.form.ConnectorFormSchemaService;
+import java.util.List;
+import java.util.Map;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Yak Ops Connector Form Schema 接口。 */
+@ConditionalOnOfflineSyncEnabled
+@RestController
+@RequestMapping("/api/v1/job/batch-control/connectors")
+public class OfflineConnectorFormController {
+
+  private final ConnectorFormSchemaService service;
+
+  public OfflineConnectorFormController(ConnectorFormSchemaService service) {
+    this.service = service;
+  }
+
+  @GetMapping("/form-schemas")
+  public Result<List<ConnectorFormSchema>> list(
+      @RequestParam(required = false) String role) {
+    return Result.success(service.list(role));
+  }
+
+  @GetMapping("/{connectorId}/form-schema")
+  public Result<ConnectorFormSchema> get(
+      @PathVariable String connectorId,
+      @RequestParam String role) {
+    return Result.success(service.get(connectorId, role));
+  }
+
+  @PostMapping("/schemas/refresh")
+  public Result<Map<String, Object>> refresh() {
+    int count = service.refresh();
+    return Result.success(Map.of("refreshed", count));
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/LinkUpConnectorSchemaClient.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/LinkUpConnectorSchemaClient.java
@@ -1,0 +1,129 @@
+package io.yak.ops.business.sync.offline.engine;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import io.yak.ops.business.sync.offline.config.OfflineSyncProperties;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+/** Link-Up Connector Schema 只读客户端。 */
+@ConditionalOnOfflineSyncEnabled
+@Component
+public class LinkUpConnectorSchemaClient {
+
+  private final HttpClient httpClient;
+  private final ObjectMapper objectMapper;
+  private final OfflineSyncProperties properties;
+
+  public LinkUpConnectorSchemaClient(
+      @Qualifier("offlineSyncHttpClient") HttpClient httpClient,
+      @Qualifier("offlineSyncJsonMapper") ObjectMapper objectMapper,
+      OfflineSyncProperties properties) {
+    this.httpClient = httpClient;
+    this.objectMapper = objectMapper;
+    this.properties = properties;
+  }
+
+  public JsonNode list() {
+    return get("/api/v1/connectors");
+  }
+
+  public JsonNode list(String role) {
+    return get("/api/v1/connectors?role=" + encodeRole(role));
+  }
+
+  public JsonNode get(String connectorId, String role) {
+    if (!StringUtils.hasText(connectorId)) {
+      throw new IllegalArgumentException("connectorId 不能为空");
+    }
+    return get("/api/v1/connectors/" + encode(connectorId) + "/schema?role=" + encodeRole(role));
+  }
+
+  private JsonNode get(String path) {
+    requireEnabled();
+    HttpRequest request = HttpRequest.newBuilder(uri(path))
+        .timeout(properties.getEngine().getRequestTimeout())
+        .header("Accept", "application/json")
+        .GET()
+        .build();
+    try {
+      HttpResponse<String> response = httpClient.send(
+          request, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+      JsonNode body = read(response.body());
+      if (response.statusCode() >= 200 && response.statusCode() < 300) {
+        return body;
+      }
+      throw new LinkUpClient.LinkUpRequestException(
+          response.statusCode(),
+          body.path("code").asText("LINK-UP-HTTP-" + response.statusCode()),
+          errorMessage(body, response.body()));
+    } catch (InterruptedException exception) {
+      Thread.currentThread().interrupt();
+      throw new IllegalStateException("Link-Up Connector Schema 请求被中断", exception);
+    } catch (IOException exception) {
+      throw new IllegalStateException(
+          "无法连接 Link-Up Worker：" + properties.getEngine().getBaseUrl(), exception);
+    }
+  }
+
+  private JsonNode read(String body) {
+    if (!StringUtils.hasText(body)) {
+      return objectMapper.createArrayNode();
+    }
+    try {
+      return objectMapper.readTree(body);
+    } catch (JsonProcessingException exception) {
+      throw new IllegalStateException("Link-Up 返回了无法解析的 Connector Schema", exception);
+    }
+  }
+
+  private String errorMessage(JsonNode body, String fallback) {
+    String message = body.path("message").asText(null);
+    if (!StringUtils.hasText(message)) {
+      message = body.path("error").asText(null);
+    }
+    return StringUtils.hasText(message) ? message : fallback;
+  }
+
+  private URI uri(String path) {
+    String baseUrl = properties.getEngine().getBaseUrl();
+    if (!StringUtils.hasText(baseUrl)) {
+      throw new IllegalStateException("yak.sync.offline.engine.base-url 不能为空");
+    }
+    String normalized = baseUrl.endsWith("/")
+        ? baseUrl.substring(0, baseUrl.length() - 1)
+        : baseUrl;
+    return URI.create(normalized + path);
+  }
+
+  private String encode(String value) {
+    return URLEncoder.encode(value.trim(), StandardCharsets.UTF_8).replace("+", "%20");
+  }
+
+  private String encodeRole(String role) {
+    if (!StringUtils.hasText(role)) {
+      throw new IllegalArgumentException("role 不能为空");
+    }
+    String normalized = role.trim().toUpperCase(java.util.Locale.ROOT);
+    if (!"SOURCE".equals(normalized) && !"SINK".equals(normalized)) {
+      throw new IllegalArgumentException("role 只支持 SOURCE 或 SINK");
+    }
+    return encode(normalized);
+  }
+
+  private void requireEnabled() {
+    if (!properties.getEngine().isEnabled()) {
+      throw new IllegalStateException("Link-Up 引擎对接已关闭");
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/form/ConnectorFormSchema.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/form/ConnectorFormSchema.java
@@ -1,0 +1,142 @@
+package io.yak.ops.business.sync.offline.form;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+/** Yak Ops 前端可直接消费的 Connector Form Schema。 */
+public class ConnectorFormSchema {
+  private String connectorId;
+  private String role;
+  private String schemaVersion;
+  private String schemaFingerprint;
+  private String profileVersion;
+  private String formFingerprint;
+  private String source;
+  private boolean stale;
+  private LocalDateTime syncedAt;
+  private List<String> capabilities = new ArrayList<>();
+  private List<Group> groups = new ArrayList<>();
+  private List<Field> fields = new ArrayList<>();
+  private JsonNode rules;
+  private List<String> warnings = new ArrayList<>();
+
+  public String getConnectorId() { return connectorId; }
+  public void setConnectorId(String connectorId) { this.connectorId = connectorId; }
+  public String getRole() { return role; }
+  public void setRole(String role) { this.role = role; }
+  public String getSchemaVersion() { return schemaVersion; }
+  public void setSchemaVersion(String schemaVersion) { this.schemaVersion = schemaVersion; }
+  public String getSchemaFingerprint() { return schemaFingerprint; }
+  public void setSchemaFingerprint(String schemaFingerprint) { this.schemaFingerprint = schemaFingerprint; }
+  public String getProfileVersion() { return profileVersion; }
+  public void setProfileVersion(String profileVersion) { this.profileVersion = profileVersion; }
+  public String getFormFingerprint() { return formFingerprint; }
+  public void setFormFingerprint(String formFingerprint) { this.formFingerprint = formFingerprint; }
+  public String getSource() { return source; }
+  public void setSource(String source) { this.source = source; }
+  public boolean isStale() { return stale; }
+  public void setStale(boolean stale) { this.stale = stale; }
+  public LocalDateTime getSyncedAt() { return syncedAt; }
+  public void setSyncedAt(LocalDateTime syncedAt) { this.syncedAt = syncedAt; }
+  public List<String> getCapabilities() { return capabilities; }
+  public void setCapabilities(List<String> capabilities) { this.capabilities = capabilities; }
+  public List<Group> getGroups() { return groups; }
+  public void setGroups(List<Group> groups) { this.groups = groups; }
+  public List<Field> getFields() { return fields; }
+  public void setFields(List<Field> fields) { this.fields = fields; }
+  public JsonNode getRules() { return rules; }
+  public void setRules(JsonNode rules) { this.rules = rules; }
+  public List<String> getWarnings() { return warnings; }
+  public void setWarnings(List<String> warnings) { this.warnings = warnings; }
+
+  public static class Group {
+    private String id;
+    private String title;
+    private int order;
+    private boolean collapsed;
+    private boolean hidden;
+
+    public String getId() { return id; }
+    public void setId(String id) { this.id = id; }
+    public String getTitle() { return title; }
+    public void setTitle(String title) { this.title = title; }
+    public int getOrder() { return order; }
+    public void setOrder(int order) { this.order = order; }
+    public boolean isCollapsed() { return collapsed; }
+    public void setCollapsed(boolean collapsed) { this.collapsed = collapsed; }
+    public boolean isHidden() { return hidden; }
+    public void setHidden(boolean hidden) { this.hidden = hidden; }
+  }
+
+  public static class Field {
+    private String key;
+    private String label;
+    private String description;
+    private String help;
+    private String placeholder;
+    private String valueType;
+    private String javaType;
+    private String elementType;
+    private Object defaultValue;
+    private List<Object> allowedValues = new ArrayList<>();
+    private List<String> fallbackKeys = new ArrayList<>();
+    private boolean required;
+    private boolean sensitive;
+    private String semanticType;
+    private String scope;
+    private String groupId;
+    private int order;
+    private String importance;
+    private String widget;
+    private boolean hidden;
+    private boolean readOnly;
+    private String valueSource;
+
+    public String getKey() { return key; }
+    public void setKey(String key) { this.key = key; }
+    public String getLabel() { return label; }
+    public void setLabel(String label) { this.label = label; }
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
+    public String getHelp() { return help; }
+    public void setHelp(String help) { this.help = help; }
+    public String getPlaceholder() { return placeholder; }
+    public void setPlaceholder(String placeholder) { this.placeholder = placeholder; }
+    public String getValueType() { return valueType; }
+    public void setValueType(String valueType) { this.valueType = valueType; }
+    public String getJavaType() { return javaType; }
+    public void setJavaType(String javaType) { this.javaType = javaType; }
+    public String getElementType() { return elementType; }
+    public void setElementType(String elementType) { this.elementType = elementType; }
+    public Object getDefaultValue() { return defaultValue; }
+    public void setDefaultValue(Object defaultValue) { this.defaultValue = defaultValue; }
+    public List<Object> getAllowedValues() { return allowedValues; }
+    public void setAllowedValues(List<Object> allowedValues) { this.allowedValues = allowedValues; }
+    public List<String> getFallbackKeys() { return fallbackKeys; }
+    public void setFallbackKeys(List<String> fallbackKeys) { this.fallbackKeys = fallbackKeys; }
+    public boolean isRequired() { return required; }
+    public void setRequired(boolean required) { this.required = required; }
+    public boolean isSensitive() { return sensitive; }
+    public void setSensitive(boolean sensitive) { this.sensitive = sensitive; }
+    public String getSemanticType() { return semanticType; }
+    public void setSemanticType(String semanticType) { this.semanticType = semanticType; }
+    public String getScope() { return scope; }
+    public void setScope(String scope) { this.scope = scope; }
+    public String getGroupId() { return groupId; }
+    public void setGroupId(String groupId) { this.groupId = groupId; }
+    public int getOrder() { return order; }
+    public void setOrder(int order) { this.order = order; }
+    public String getImportance() { return importance; }
+    public void setImportance(String importance) { this.importance = importance; }
+    public String getWidget() { return widget; }
+    public void setWidget(String widget) { this.widget = widget; }
+    public boolean isHidden() { return hidden; }
+    public void setHidden(boolean hidden) { this.hidden = hidden; }
+    public boolean isReadOnly() { return readOnly; }
+    public void setReadOnly(boolean readOnly) { this.readOnly = readOnly; }
+    public String getValueSource() { return valueSource; }
+    public void setValueSource(String valueSource) { this.valueSource = valueSource; }
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/form/ConnectorFormSchemaComposer.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/form/ConnectorFormSchemaComposer.java
@@ -1,0 +1,267 @@
+package io.yak.ops.business.sync.offline.form;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.Locale;
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+/** 将 Link-Up Connector Schema 与 Yak Ops Presentation Profile 合成为 Form Schema。 */
+@ConditionalOnOfflineSyncEnabled
+@Component
+public class ConnectorFormSchemaComposer {
+
+  private final ConnectorPresentationRegistry presentationRegistry;
+  private final ObjectMapper objectMapper;
+
+  public ConnectorFormSchemaComposer(
+      ConnectorPresentationRegistry presentationRegistry,
+      @Qualifier("offlineSyncJsonMapper") ObjectMapper objectMapper) {
+    this.presentationRegistry = presentationRegistry;
+    this.objectMapper = objectMapper;
+  }
+
+  public ConnectorFormSchema compose(ConnectorSchemaSnapshot snapshot) {
+    JsonNode schema = snapshot.getSchema();
+    String connectorId = schema.path("connectorId").asText();
+    String role = schema.path("role").asText();
+    ConnectorPresentationProfile profile = presentationRegistry.find(connectorId, role);
+
+    ConnectorFormSchema result = new ConnectorFormSchema();
+    result.setConnectorId(connectorId);
+    result.setRole(role);
+    result.setSchemaVersion(schema.path("schemaVersion").asText(null));
+    result.setSchemaFingerprint(schema.path("schemaFingerprint").asText(null));
+    result.setProfileVersion(profile == null ? "auto" : profile.getProfileVersion());
+    result.setSource(snapshot.getSource());
+    result.setStale(snapshot.isStale());
+    result.setSyncedAt(snapshot.getSyncedAt());
+    result.setRules(schema.path("rules").deepCopy());
+    copyStrings(schema.path("capabilities"), result.getCapabilities());
+
+    Map<String, ConnectorFormSchema.Group> groups = defaultGroups();
+    if (profile != null) {
+      for (ConnectorPresentationProfile.GroupProfile source : profile.getGroups()) {
+        ConnectorFormSchema.Group group = new ConnectorFormSchema.Group();
+        group.setId(source.getId());
+        group.setTitle(source.getTitle());
+        group.setOrder(source.getOrder());
+        group.setCollapsed(source.isCollapsed());
+        group.setHidden(source.isHidden());
+        groups.put(group.getId(), group);
+      }
+    } else {
+      result.getWarnings().add("当前 Connector 没有专属 Presentation Profile，已使用通用表单推导");
+    }
+
+    int fallbackOrder = 1000;
+    for (JsonNode option : schema.path("options")) {
+      ConnectorFormSchema.Field field = composeField(option,
+          profile == null ? null : profile.getFields().get(option.path("key").asText()),
+          fallbackOrder++);
+      result.getFields().add(field);
+      groups.computeIfAbsent(field.getGroupId(), this::fallbackGroup);
+    }
+
+    if (profile != null) {
+      for (String profileKey : profile.getFields().keySet()) {
+        boolean found = result.getFields().stream().anyMatch(field -> profileKey.equals(field.getKey()));
+        if (!found) {
+          result.getWarnings().add("Presentation Profile 字段在 Link-Up Schema 中不存在：" + profileKey);
+        }
+      }
+    }
+
+    result.getFields().sort(Comparator
+        .comparingInt((ConnectorFormSchema.Field field) -> groups.get(field.getGroupId()).getOrder())
+        .thenComparingInt(ConnectorFormSchema.Field::getOrder)
+        .thenComparing(ConnectorFormSchema.Field::getKey));
+    Set<String> usedGroups = new HashSet<>();
+    for (ConnectorFormSchema.Field field : result.getFields()) {
+      usedGroups.add(field.getGroupId());
+    }
+    for (ConnectorFormSchema.Group group : groups.values()) {
+      if (usedGroups.contains(group.getId())) {
+        result.getGroups().add(group);
+      }
+    }
+    result.getGroups().sort(Comparator.comparingInt(ConnectorFormSchema.Group::getOrder));
+    result.setFormFingerprint(fingerprint(result));
+    return result;
+  }
+
+  private ConnectorFormSchema.Field composeField(JsonNode option,
+      ConnectorPresentationProfile.FieldProfile profile, int fallbackOrder) {
+    ConnectorFormSchema.Field field = new ConnectorFormSchema.Field();
+    String key = option.path("key").asText();
+    String valueType = option.path("valueType").asText("OBJECT").toUpperCase(Locale.ROOT);
+    String semanticType = option.path("semanticType").asText("").toUpperCase(Locale.ROOT);
+    String scope = option.path("scope").asText("TASK").toUpperCase(Locale.ROOT);
+    boolean required = option.path("required").asBoolean(false);
+    boolean sensitive = option.path("sensitive").asBoolean(false);
+    boolean hasDefault = option.has("defaultValue") && !option.get("defaultValue").isNull();
+
+    field.setKey(key);
+    field.setLabel(profile != null && StringUtils.hasText(profile.getLabel())
+        ? profile.getLabel() : humanize(key));
+    field.setDescription(option.path("description").asText(null));
+    field.setHelp(profile == null ? null : profile.getHelp());
+    field.setPlaceholder(profile == null ? null : profile.getPlaceholder());
+    field.setValueType(valueType);
+    field.setJavaType(option.path("javaType").asText(null));
+    field.setElementType(option.path("elementType").asText(null));
+    field.setDefaultValue(hasDefault ? objectMapper.convertValue(option.get("defaultValue"), Object.class) : null);
+    copyObjects(option.path("allowedValues"), field.getAllowedValues());
+    copyStrings(option.path("fallbackKeys"), field.getFallbackKeys());
+    field.setRequired(required);
+    field.setSensitive(sensitive);
+    field.setSemanticType(semanticType);
+    field.setScope(scope);
+
+    String inferredImportance = inferImportance(scope, required, hasDefault);
+    field.setImportance(profile != null && StringUtils.hasText(profile.getImportance())
+        ? profile.getImportance() : inferredImportance);
+    field.setWidget(profile != null && StringUtils.hasText(profile.getWidget())
+        ? profile.getWidget() : inferWidget(valueType, semanticType, sensitive,
+            !field.getAllowedValues().isEmpty()));
+    field.setGroupId(profile != null && StringUtils.hasText(profile.getGroupId())
+        ? profile.getGroupId() : inferGroup(field.getImportance(), scope));
+    field.setOrder(profile != null && profile.getOrder() != null
+        ? profile.getOrder() : fallbackOrder);
+
+    boolean inferredHidden = "DATASOURCE".equals(scope) || "SYSTEM".equals(scope)
+        || "HIDDEN".equals(field.getImportance());
+    field.setHidden(profile != null && profile.getHidden() != null
+        ? profile.getHidden() : inferredHidden);
+    field.setValueSource(profile != null && StringUtils.hasText(profile.getValueSource())
+        ? profile.getValueSource() : inferValueSource(scope));
+    field.setReadOnly(profile != null && profile.getReadOnly() != null
+        ? profile.getReadOnly() : field.isHidden() || !"USER".equals(field.getValueSource()));
+    return field;
+  }
+
+  private Map<String, ConnectorFormSchema.Group> defaultGroups() {
+    Map<String, ConnectorFormSchema.Group> groups = new LinkedHashMap<>();
+    groups.put("basic", group("basic", "基础配置", 10, false, false));
+    groups.put("common", group("common", "常用配置", 20, false, false));
+    groups.put("advanced", group("advanced", "高级配置", 70, true, false));
+    groups.put("expert", group("expert", "专家配置", 80, true, false));
+    groups.put("hidden", group("hidden", "系统注入", 100, true, true));
+    return groups;
+  }
+
+  private ConnectorFormSchema.Group fallbackGroup(String id) {
+    return group(id, humanize(id), 60, true, false);
+  }
+
+  private ConnectorFormSchema.Group group(String id, String title, int order,
+      boolean collapsed, boolean hidden) {
+    ConnectorFormSchema.Group group = new ConnectorFormSchema.Group();
+    group.setId(id);
+    group.setTitle(title);
+    group.setOrder(order);
+    group.setCollapsed(collapsed);
+    group.setHidden(hidden);
+    return group;
+  }
+
+  private String inferImportance(String scope, boolean required, boolean hasDefault) {
+    if ("DATASOURCE".equals(scope) || "SYSTEM".equals(scope)) { return "HIDDEN"; }
+    if (required && !hasDefault) { return "PRIMARY"; }
+    if ("RUNTIME".equals(scope)) { return "ADVANCED"; }
+    if (required) { return "COMMON"; }
+    return hasDefault ? "ADVANCED" : "COMMON";
+  }
+
+  private String inferGroup(String importance, String scope) {
+    if ("DATASOURCE".equals(scope) || "SYSTEM".equals(scope) || "HIDDEN".equals(importance)) {
+      return "hidden";
+    }
+    if ("PRIMARY".equals(importance)) { return "basic"; }
+    if ("COMMON".equals(importance)) { return "common"; }
+    if ("EXPERT".equals(importance)) { return "expert"; }
+    return "advanced";
+  }
+
+  private String inferWidget(String valueType, String semanticType, boolean sensitive,
+      boolean hasChoices) {
+    if (sensitive || "PASSWORD".equals(semanticType)) { return "password"; }
+    if ("SQL".equals(semanticType)) { return "sql-editor"; }
+    if ("TABLE_PATH".equals(semanticType)) { return "table-picker"; }
+    if ("TABLE_LIST".equals(semanticType)) { return "multi-table-picker"; }
+    if ("FILE_PATH".equals(semanticType)) { return "file-path"; }
+    if (hasChoices || "ENUM".equals(valueType)) { return "select"; }
+    if ("BOOLEAN".equals(valueType)) { return "switch"; }
+    if ("INTEGER".equals(valueType) || "LONG".equals(valueType)
+        || "DECIMAL".equals(valueType) || "FLOAT".equals(valueType)
+        || "DOUBLE".equals(valueType)) { return "number"; }
+    if ("MAP".equals(valueType)) { return "key-value"; }
+    if ("LIST".equals(valueType)) { return "list-editor"; }
+    if ("OBJECT".equals(valueType)) { return "json-editor"; }
+    return "text";
+  }
+
+  private String inferValueSource(String scope) {
+    if ("DATASOURCE".equals(scope)) { return "DATASOURCE"; }
+    if ("SYSTEM".equals(scope)) { return "SYSTEM"; }
+    if ("RUNTIME".equals(scope)) { return "RUNTIME"; }
+    return "USER";
+  }
+
+  private String humanize(String value) {
+    if (!StringUtils.hasText(value)) { return "配置项"; }
+    String[] words = value.trim().split("[_-]");
+    StringBuilder result = new StringBuilder();
+    for (String word : words) {
+      if (word.isEmpty()) { continue; }
+      if (result.length() > 0) { result.append(' '); }
+      result.append(Character.toUpperCase(word.charAt(0))).append(word.substring(1));
+    }
+    return result.toString();
+  }
+
+  private void copyStrings(JsonNode source, List<String> target) {
+    if (!source.isArray()) { return; }
+    for (JsonNode value : source) { target.add(value.asText()); }
+  }
+
+  private void copyObjects(JsonNode source, List<Object> target) {
+    if (!source.isArray()) { return; }
+    for (JsonNode value : source) { target.add(objectMapper.convertValue(value, Object.class)); }
+  }
+
+  private String fingerprint(ConnectorFormSchema schema) {
+    try {
+      ObjectNode canonical = objectMapper.createObjectNode();
+      canonical.put("connectorId", schema.getConnectorId());
+      canonical.put("role", schema.getRole());
+      canonical.put("schemaFingerprint", schema.getSchemaFingerprint());
+      canonical.put("profileVersion", schema.getProfileVersion());
+      canonical.set("capabilities", objectMapper.valueToTree(schema.getCapabilities()));
+      canonical.set("groups", objectMapper.valueToTree(schema.getGroups()));
+      canonical.set("fields", objectMapper.valueToTree(schema.getFields()));
+      canonical.set("rules", schema.getRules());
+      byte[] payload = objectMapper.writeValueAsString(canonical).getBytes(StandardCharsets.UTF_8);
+      byte[] digest = MessageDigest.getInstance("SHA-256").digest(payload);
+      StringBuilder result = new StringBuilder("sha256:");
+      for (byte value : digest) { result.append(String.format("%02x", value & 0xff)); }
+      return result.toString();
+    } catch (JsonProcessingException | NoSuchAlgorithmException exception) {
+      throw new IllegalStateException("生成 Form Schema 指纹失败", exception);
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/form/ConnectorFormSchemaService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/form/ConnectorFormSchemaService.java
@@ -1,0 +1,38 @@
+package io.yak.ops.business.sync.offline.form;
+
+import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+/** Connector Form Schema 查询与刷新门面。 */
+@ConditionalOnOfflineSyncEnabled
+@Service
+public class ConnectorFormSchemaService {
+
+  private final ConnectorSchemaRegistry schemaRegistry;
+  private final ConnectorFormSchemaComposer composer;
+
+  public ConnectorFormSchemaService(
+      ConnectorSchemaRegistry schemaRegistry,
+      ConnectorFormSchemaComposer composer) {
+    this.schemaRegistry = schemaRegistry;
+    this.composer = composer;
+  }
+
+  public ConnectorFormSchema get(String connectorId, String role) {
+    return composer.compose(schemaRegistry.get(connectorId, role));
+  }
+
+  public List<ConnectorFormSchema> list(String role) {
+    List<ConnectorFormSchema> result = new ArrayList<>();
+    for (ConnectorSchemaSnapshot snapshot : schemaRegistry.list(role)) {
+      result.add(composer.compose(snapshot));
+    }
+    return result;
+  }
+
+  public int refresh() {
+    return schemaRegistry.refresh();
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/form/ConnectorPresentationProfile.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/form/ConnectorPresentationProfile.java
@@ -1,0 +1,117 @@
+package io.yak.ops.business.sync.offline.form;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/** Yak Ops 对 Connector Schema 的产品展示覆盖，不参与执行合法性判断。 */
+public final class ConnectorPresentationProfile {
+
+  private final String connectorId;
+  private final String role;
+  private final String profileVersion;
+  private final List<GroupProfile> groups;
+  private final Map<String, FieldProfile> fields;
+
+  public ConnectorPresentationProfile(String connectorId, String role, String profileVersion,
+      List<GroupProfile> groups, Map<String, FieldProfile> fields) {
+    this.connectorId = connectorId;
+    this.role = role;
+    this.profileVersion = profileVersion;
+    this.groups = Collections.unmodifiableList(new ArrayList<>(groups));
+    this.fields = Collections.unmodifiableMap(new LinkedHashMap<>(fields));
+  }
+
+  public String getConnectorId() { return connectorId; }
+  public String getRole() { return role; }
+  public String getProfileVersion() { return profileVersion; }
+  public List<GroupProfile> getGroups() { return groups; }
+  public Map<String, FieldProfile> getFields() { return fields; }
+
+  public static final class GroupProfile {
+    private final String id;
+    private final String title;
+    private final int order;
+    private final boolean collapsed;
+    private final boolean hidden;
+
+    public GroupProfile(String id, String title, int order, boolean collapsed, boolean hidden) {
+      this.id = id;
+      this.title = title;
+      this.order = order;
+      this.collapsed = collapsed;
+      this.hidden = hidden;
+    }
+
+    public String getId() { return id; }
+    public String getTitle() { return title; }
+    public int getOrder() { return order; }
+    public boolean isCollapsed() { return collapsed; }
+    public boolean isHidden() { return hidden; }
+  }
+
+  public static final class FieldProfile {
+    private final String label;
+    private final String groupId;
+    private final Integer order;
+    private final String importance;
+    private final String widget;
+    private final Boolean hidden;
+    private final Boolean readOnly;
+    private final String valueSource;
+    private final String help;
+    private final String placeholder;
+
+    private FieldProfile(Builder builder) {
+      this.label = builder.label;
+      this.groupId = builder.groupId;
+      this.order = builder.order;
+      this.importance = builder.importance;
+      this.widget = builder.widget;
+      this.hidden = builder.hidden;
+      this.readOnly = builder.readOnly;
+      this.valueSource = builder.valueSource;
+      this.help = builder.help;
+      this.placeholder = builder.placeholder;
+    }
+
+    public static Builder builder() { return new Builder(); }
+    public String getLabel() { return label; }
+    public String getGroupId() { return groupId; }
+    public Integer getOrder() { return order; }
+    public String getImportance() { return importance; }
+    public String getWidget() { return widget; }
+    public Boolean getHidden() { return hidden; }
+    public Boolean getReadOnly() { return readOnly; }
+    public String getValueSource() { return valueSource; }
+    public String getHelp() { return help; }
+    public String getPlaceholder() { return placeholder; }
+
+    public static final class Builder {
+      private String label;
+      private String groupId;
+      private Integer order;
+      private String importance;
+      private String widget;
+      private Boolean hidden;
+      private Boolean readOnly;
+      private String valueSource;
+      private String help;
+      private String placeholder;
+
+      public Builder label(String value) { this.label = value; return this; }
+      public Builder group(String value) { this.groupId = value; return this; }
+      public Builder order(int value) { this.order = value; return this; }
+      public Builder importance(String value) { this.importance = value; return this; }
+      public Builder widget(String value) { this.widget = value; return this; }
+      public Builder hidden(boolean value) { this.hidden = value; return this; }
+      public Builder readOnly(boolean value) { this.readOnly = value; return this; }
+      public Builder valueSource(String value) { this.valueSource = value; return this; }
+      public Builder help(String value) { this.help = value; return this; }
+      public Builder placeholder(String value) { this.placeholder = value; return this; }
+      public FieldProfile build() { return new FieldProfile(this); }
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/form/ConnectorPresentationRegistry.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/form/ConnectorPresentationRegistry.java
@@ -1,0 +1,116 @@
+package io.yak.ops.business.sync.offline.form;
+
+import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import org.springframework.stereotype.Component;
+
+/** 内置 Presentation Profile；未知 Connector 自动回退到通用推导。 */
+@ConditionalOnOfflineSyncEnabled
+@Component
+public class ConnectorPresentationRegistry {
+
+  private final Map<String, ConnectorPresentationProfile> profiles;
+
+  public ConnectorPresentationRegistry() {
+    Map<String, ConnectorPresentationProfile> values = new LinkedHashMap<>();
+    register(values, jdbcSource());
+    register(values, jdbcSink());
+    this.profiles = Collections.unmodifiableMap(values);
+  }
+
+  public ConnectorPresentationProfile find(String connectorId, String role) {
+    return profiles.get(key(connectorId, role));
+  }
+
+  private void register(Map<String, ConnectorPresentationProfile> values,
+      ConnectorPresentationProfile profile) {
+    values.put(key(profile.getConnectorId(), profile.getRole()), profile);
+  }
+
+  private String key(String connectorId, String role) {
+    return connectorId.trim().toLowerCase(Locale.ROOT) + ":" + role.trim().toUpperCase(Locale.ROOT);
+  }
+
+  private ConnectorPresentationProfile jdbcSource() {
+    Map<String, ConnectorPresentationProfile.FieldProfile> fields = new LinkedHashMap<>();
+    datasourceFields(fields);
+    fields.put("table_path", field("来源表", "read", 10, "PRIMARY", "table-picker"));
+    fields.put("table_list", field("多表配置", "read", 20, "PRIMARY", "multi-table-picker"));
+    fields.put("query", field("查询 SQL", "read", 30, "PRIMARY", "sql-editor"));
+    fields.put("where_condition", field("过滤条件", "read", 40, "COMMON", "sql-condition"));
+    fields.put("read_consistency", field("读取一致性", "consistency", 10, "COMMON", "select"));
+    fields.put("fetch_size", field("每批读取行数", "performance", 10, "ADVANCED", "number"));
+    fields.put("partition_column", field("分片字段", "performance", 20, "ADVANCED", "field-selector"));
+    fields.put("partition_num", field("分片数量", "performance", 30, "ADVANCED", "number"));
+    fields.put("partition_lower_bound", field("分片下界", "performance", 40, "EXPERT", "text"));
+    fields.put("partition_upper_bound", field("分片上界", "performance", 50, "EXPERT", "text"));
+    fields.put("split_planning_mode", field("分片规划方式", "performance", 60, "ADVANCED", "select"));
+    fields.put("statistics_query_timeout", field("统计查询超时", "advanced", 10, "EXPERT", "number"));
+    fields.put("sample_size", field("统计采样数量", "advanced", 20, "EXPERT", "number"));
+    fields.put("allow_statistics_fallback", field("允许统计降级", "advanced", 30, "EXPERT", "switch"));
+    fields.put("null_partition_single_split", field("空分片单独处理", "advanced", 40, "EXPERT", "switch"));
+    fields.put("multi_table_failure_policy", field("多表失败策略", "advanced", 50, "ADVANCED", "select"));
+    fields.put("int_type_narrowing", field("整数类型缩小", "advanced", 60, "EXPERT", "switch"));
+    return new ConnectorPresentationProfile("jdbc", "SOURCE", "1",
+        Arrays.asList(
+            group("read", "读取配置", 10, false, false),
+            group("consistency", "一致性", 20, false, false),
+            group("performance", "性能配置", 30, true, false),
+            group("advanced", "高级配置", 40, true, false),
+            group("datasource", "数据源注入", 90, true, true)), fields);
+  }
+
+  private ConnectorPresentationProfile jdbcSink() {
+    Map<String, ConnectorPresentationProfile.FieldProfile> fields = new LinkedHashMap<>();
+    datasourceFields(fields);
+    fields.put("table_path", field("目标表", "write", 10, "PRIMARY", "table-picker"));
+    fields.put("schema_save_mode", field("表结构处理", "write", 20, "PRIMARY", "select"));
+    fields.put("data_save_mode", field("已有数据处理", "write", 30, "PRIMARY", "select"));
+    fields.put("write_mode", field("写入方式", "write", 40, "PRIMARY", "segmented"));
+    fields.put("primary_keys", field("主键字段", "write", 50, "COMMON", "field-selector"));
+    fields.put("custom_sql", field("自定义写入 SQL", "write", 60, "ADVANCED", "sql-editor"));
+    fields.put("batch_size", field("每批写入行数", "performance", 10, "ADVANCED", "number"));
+    fields.put("prepared_statement_cache_size", field("语句缓存数量", "performance", 20, "EXPERT", "number"));
+    fields.put("query_timeout_sec", field("写入超时", "performance", 30, "ADVANCED", "number"));
+    fields.put("max_retries", field("批次重试次数", "performance", 40, "ADVANCED", "number"));
+    fields.put("dirty_data_policy", field("脏数据策略", "dirty", 10, "COMMON", "select"));
+    fields.put("dirty_data_output_type", field("脏数据输出", "dirty", 20, "ADVANCED", "select"));
+    fields.put("dirty_data_output_path", field("脏数据文件路径", "dirty", 30, "ADVANCED", "file-path"));
+    fields.put("dirty_data_max_samples", field("样例保留上限", "dirty", 40, "EXPERT", "number"));
+    fields.put("dirty_data_max_count", field("脏数据数量上限", "dirty", 50, "ADVANCED", "number"));
+    fields.put("dirty_data_max_percentage", field("脏数据比例上限", "dirty", 60, "ADVANCED", "number"));
+    fields.put("create_primary_key", field("自动创建主键", "advanced", 10, "ADVANCED", "switch"));
+    return new ConnectorPresentationProfile("jdbc", "SINK", "1",
+        Arrays.asList(
+            group("write", "写入配置", 10, false, false),
+            group("performance", "性能配置", 20, true, false),
+            group("dirty", "脏数据处理", 30, true, false),
+            group("advanced", "高级配置", 40, true, false),
+            group("datasource", "数据源注入", 90, true, true)), fields);
+  }
+
+  private void datasourceFields(Map<String, ConnectorPresentationProfile.FieldProfile> fields) {
+    for (String key : Arrays.asList("url", "driver", "username", "password", "dialect",
+        "compatible_mode", "schema", "properties", "connection_check_timeout_sec",
+        "connect_timeout_ms", "socket_timeout_ms")) {
+      fields.put(key, ConnectorPresentationProfile.FieldProfile.builder()
+          .group("datasource").importance("HIDDEN").widget("hidden")
+          .hidden(true).readOnly(true).valueSource("DATASOURCE").build());
+    }
+  }
+
+  private ConnectorPresentationProfile.GroupProfile group(String id, String title, int order,
+      boolean collapsed, boolean hidden) {
+    return new ConnectorPresentationProfile.GroupProfile(id, title, order, collapsed, hidden);
+  }
+
+  private ConnectorPresentationProfile.FieldProfile field(String label, String groupId, int order,
+      String importance, String widget) {
+    return ConnectorPresentationProfile.FieldProfile.builder()
+        .label(label).group(groupId).order(order).importance(importance).widget(widget).build();
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/form/ConnectorSchemaRegistry.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/form/ConnectorSchemaRegistry.java
@@ -1,0 +1,219 @@
+package io.yak.ops.business.sync.offline.form;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import io.yak.ops.business.sync.offline.config.ConnectorSchemaProperties;
+import io.yak.ops.business.sync.offline.engine.LinkUpClient;
+import io.yak.ops.business.sync.offline.engine.LinkUpConnectorSchemaClient;
+import io.yak.ops.business.sync.offline.repository.OfflineConnectorSchemaRepository;
+import io.yak.ops.business.sync.offline.repository.OfflineConnectorSchemaRepository.SchemaRecord;
+import jakarta.annotation.PostConstruct;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+/** 拉取、持久化并缓存 Link-Up Connector Schema。 */
+@ConditionalOnOfflineSyncEnabled
+@Component
+@DependsOn("offlineSyncFlyway")
+public class ConnectorSchemaRegistry {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ConnectorSchemaRegistry.class);
+
+  private final LinkUpConnectorSchemaClient schemaClient;
+  private final LinkUpClient linkUpClient;
+  private final OfflineConnectorSchemaRepository repository;
+  private final ObjectMapper objectMapper;
+  private final ConnectorSchemaProperties properties;
+  private final Map<String, ConnectorSchemaSnapshot> memory = new ConcurrentHashMap<>();
+
+  public ConnectorSchemaRegistry(
+      LinkUpConnectorSchemaClient schemaClient,
+      LinkUpClient linkUpClient,
+      OfflineConnectorSchemaRepository repository,
+      @Qualifier("offlineSyncJsonMapper") ObjectMapper objectMapper,
+      ConnectorSchemaProperties properties) {
+    this.schemaClient = schemaClient;
+    this.linkUpClient = linkUpClient;
+    this.repository = repository;
+    this.objectMapper = objectMapper;
+    this.properties = properties;
+  }
+
+  @PostConstruct
+  public void initialize() {
+    loadPersistentCache();
+  }
+
+  @Scheduled(
+      initialDelayString = "${yak.sync.offline.schema.initial-delay-millis:5000}",
+      fixedDelayString = "${yak.sync.offline.schema.refresh-delay-millis:300000}")
+  public void scheduledRefresh() {
+    if (!properties.isEnabled() || !properties.isRefreshEnabled()) {
+      return;
+    }
+    try {
+      refresh();
+    } catch (RuntimeException exception) {
+      LOG.warn("刷新 Link-Up Connector Schema 失败，将继续使用本地快照：{}", exception.getMessage());
+    }
+  }
+
+  public synchronized int refresh() {
+    if (!properties.isEnabled()) {
+      return 0;
+    }
+    JsonNode result = schemaClient.list();
+    JsonNode schemas = result.isArray() ? result : result.path("items");
+    if (!schemas.isArray()) {
+      throw new IllegalStateException("Link-Up Connector Schema 列表协议不正确");
+    }
+    LinkUpClient.LinkUpNodeResponse node = linkUpClient.node();
+    LocalDateTime syncedAt = LocalDateTime.now();
+    int count = 0;
+    for (JsonNode schema : schemas) {
+      validate(schema);
+      persist(schema, node, syncedAt);
+      memory.put(key(id(schema), role(schema)),
+          new ConnectorSchemaSnapshot(schema.deepCopy(), "REMOTE", false, syncedAt));
+      count++;
+    }
+    return count;
+  }
+
+  public ConnectorSchemaSnapshot get(String connectorId, String role) {
+    String normalizedRole = normalizeRole(role);
+    String cacheKey = key(connectorId, normalizedRole);
+    ConnectorSchemaSnapshot snapshot = memory.get(cacheKey);
+    if (snapshot != null) {
+      return withCurrentStale(snapshot);
+    }
+    SchemaRecord record = repository.find(normalizeId(connectorId), normalizedRole);
+    if (record != null) {
+      ConnectorSchemaSnapshot loaded = fromRecord(record);
+      memory.put(cacheKey, loaded);
+      return withCurrentStale(loaded);
+    }
+    try {
+      JsonNode schema = schemaClient.get(connectorId, normalizedRole);
+      validate(schema);
+      LinkUpClient.LinkUpNodeResponse node = linkUpClient.node();
+      LocalDateTime syncedAt = LocalDateTime.now();
+      persist(schema, node, syncedAt);
+      ConnectorSchemaSnapshot remote =
+          new ConnectorSchemaSnapshot(schema.deepCopy(), "REMOTE", false, syncedAt);
+      memory.put(cacheKey, remote);
+      return remote;
+    } catch (RuntimeException exception) {
+      throw new IllegalStateException(
+          "没有可用的 Connector Schema：" + connectorId + "/" + normalizedRole, exception);
+    }
+  }
+
+  public List<ConnectorSchemaSnapshot> list(String role) {
+    String normalizedRole = role == null ? null : normalizeRole(role);
+    if (memory.isEmpty()) {
+      loadPersistentCache();
+    }
+    if (memory.isEmpty()) {
+      try {
+        refresh();
+      } catch (RuntimeException ignored) {
+        // 没有远程 Worker 且没有持久化快照时返回空列表。
+      }
+    }
+    List<ConnectorSchemaSnapshot> result = new ArrayList<>();
+    for (ConnectorSchemaSnapshot snapshot : memory.values()) {
+      if (normalizedRole == null
+          || normalizedRole.equals(role(snapshot.getSchema()))) {
+        result.add(withCurrentStale(snapshot));
+      }
+    }
+    result.sort((left, right) -> {
+      int idCompare = id(left.getSchema()).compareTo(id(right.getSchema()));
+      return idCompare != 0 ? idCompare : role(left.getSchema()).compareTo(role(right.getSchema()));
+    });
+    return result;
+  }
+
+  private void loadPersistentCache() {
+    for (SchemaRecord record : repository.list(null)) {
+      memory.put(key(record.getConnectorId(), record.getRole()), fromRecord(record));
+    }
+  }
+
+  private void persist(JsonNode schema, LinkUpClient.LinkUpNodeResponse node,
+      LocalDateTime syncedAt) {
+    try {
+      repository.upsert(new SchemaRecord(
+          id(schema), role(schema), schema.path("schemaVersion").asText(null),
+          schema.path("schemaFingerprint").asText(null),
+          node == null ? null : node.getNodeId(), node == null ? null : node.getInstanceId(),
+          objectMapper.writeValueAsString(schema), syncedAt));
+    } catch (JsonProcessingException exception) {
+      throw new IllegalStateException("保存 Connector Schema 快照失败", exception);
+    }
+  }
+
+  private ConnectorSchemaSnapshot fromRecord(SchemaRecord record) {
+    try {
+      return new ConnectorSchemaSnapshot(
+          objectMapper.readTree(record.getSchemaJson()), "CACHE", isStale(record.getSyncedAt()),
+          record.getSyncedAt());
+    } catch (JsonProcessingException exception) {
+      throw new IllegalStateException("数据库中的 Connector Schema 无法解析", exception);
+    }
+  }
+
+  private ConnectorSchemaSnapshot withCurrentStale(ConnectorSchemaSnapshot snapshot) {
+    return new ConnectorSchemaSnapshot(snapshot.getSchema(), snapshot.getSource(),
+        isStale(snapshot.getSyncedAt()), snapshot.getSyncedAt());
+  }
+
+  private boolean isStale(LocalDateTime syncedAt) {
+    if (syncedAt == null) {
+      return true;
+    }
+    return Duration.between(syncedAt, LocalDateTime.now()).toMillis()
+        > Math.max(0L, properties.getMaxStaleMillis());
+  }
+
+  private void validate(JsonNode schema) {
+    if (schema == null || !schema.isObject()
+        || !StringUtils.hasText(id(schema)) || !StringUtils.hasText(role(schema))
+        || !schema.path("options").isArray()) {
+      throw new IllegalStateException("Link-Up Connector Schema 缺少必要字段");
+    }
+  }
+
+  private String id(JsonNode schema) { return normalizeId(schema.path("connectorId").asText()); }
+  private String role(JsonNode schema) { return normalizeRole(schema.path("role").asText()); }
+  private String normalizeId(String value) {
+    if (!StringUtils.hasText(value)) { throw new IllegalArgumentException("connectorId 不能为空"); }
+    return value.trim().toLowerCase(Locale.ROOT);
+  }
+  private String normalizeRole(String value) {
+    if (!StringUtils.hasText(value)) { throw new IllegalArgumentException("role 不能为空"); }
+    String normalized = value.trim().toUpperCase(Locale.ROOT);
+    if (!"SOURCE".equals(normalized) && !"SINK".equals(normalized)) {
+      throw new IllegalArgumentException("role 只支持 SOURCE 或 SINK");
+    }
+    return normalized;
+  }
+  private String key(String connectorId, String role) {
+    return normalizeId(connectorId) + ":" + normalizeRole(role);
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/form/ConnectorSchemaSnapshot.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/form/ConnectorSchemaSnapshot.java
@@ -1,0 +1,25 @@
+package io.yak.ops.business.sync.offline.form;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.time.LocalDateTime;
+
+/** Connector Schema 快照及其来源状态。 */
+public final class ConnectorSchemaSnapshot {
+  private final JsonNode schema;
+  private final String source;
+  private final boolean stale;
+  private final LocalDateTime syncedAt;
+
+  public ConnectorSchemaSnapshot(JsonNode schema, String source, boolean stale,
+      LocalDateTime syncedAt) {
+    this.schema = schema;
+    this.source = source;
+    this.stale = stale;
+    this.syncedAt = syncedAt;
+  }
+
+  public JsonNode getSchema() { return schema; }
+  public String getSource() { return source; }
+  public boolean isStale() { return stale; }
+  public LocalDateTime getSyncedAt() { return syncedAt; }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineConnectorSchemaRepository.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineConnectorSchemaRepository.java
@@ -1,0 +1,112 @@
+package io.yak.ops.business.sync.offline.repository;
+
+import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.List;
+import javax.sql.DataSource;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+/** 持久化 Link-Up Connector Schema 快照，Worker 暂时离线时仍可编辑任务。 */
+@ConditionalOnOfflineSyncEnabled
+@Repository
+public class OfflineConnectorSchemaRepository {
+
+  private final JdbcTemplate jdbc;
+
+  public OfflineConnectorSchemaRepository(
+      @Qualifier("offlineSyncDataSource") DataSource dataSource) {
+    this.jdbc = new JdbcTemplate(dataSource);
+  }
+
+  public void upsert(SchemaRecord record) {
+    LocalDateTime now = LocalDateTime.now();
+    jdbc.update(
+        "INSERT INTO yak_offline_connector_schema "
+            + "(connector_id, connector_role, schema_version, schema_fingerprint, "
+            + "worker_node_id, worker_instance_id, schema_json, synced_at, create_time, update_time) "
+            + "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "
+            + "ON DUPLICATE KEY UPDATE schema_version = VALUES(schema_version), "
+            + "schema_fingerprint = VALUES(schema_fingerprint), worker_node_id = VALUES(worker_node_id), "
+            + "worker_instance_id = VALUES(worker_instance_id), schema_json = VALUES(schema_json), "
+            + "synced_at = VALUES(synced_at), update_time = VALUES(update_time)",
+        record.getConnectorId(), record.getRole(), record.getSchemaVersion(),
+        record.getSchemaFingerprint(), record.getWorkerNodeId(), record.getWorkerInstanceId(),
+        record.getSchemaJson(), timestamp(record.getSyncedAt()), Timestamp.valueOf(now),
+        Timestamp.valueOf(now));
+  }
+
+  public SchemaRecord find(String connectorId, String role) {
+    try {
+      return jdbc.queryForObject(
+          selectSql() + " WHERE connector_id = ? AND connector_role = ?",
+          (resultSet, rowNum) -> map(resultSet), connectorId, role);
+    } catch (EmptyResultDataAccessException exception) {
+      return null;
+    }
+  }
+
+  public List<SchemaRecord> list(String role) {
+    if (role == null) {
+      return jdbc.query(selectSql() + " ORDER BY connector_id, connector_role",
+          (resultSet, rowNum) -> map(resultSet));
+    }
+    return jdbc.query(selectSql() + " WHERE connector_role = ? ORDER BY connector_id",
+        (resultSet, rowNum) -> map(resultSet), role);
+  }
+
+  private String selectSql() {
+    return "SELECT connector_id, connector_role, schema_version, schema_fingerprint, "
+        + "worker_node_id, worker_instance_id, schema_json, synced_at "
+        + "FROM yak_offline_connector_schema";
+  }
+
+  private SchemaRecord map(java.sql.ResultSet resultSet) throws java.sql.SQLException {
+    Timestamp syncedAt = resultSet.getTimestamp("synced_at");
+    return new SchemaRecord(
+        resultSet.getString("connector_id"), resultSet.getString("connector_role"),
+        resultSet.getString("schema_version"), resultSet.getString("schema_fingerprint"),
+        resultSet.getString("worker_node_id"), resultSet.getString("worker_instance_id"),
+        resultSet.getString("schema_json"), syncedAt == null ? null : syncedAt.toLocalDateTime());
+  }
+
+  private Timestamp timestamp(LocalDateTime value) {
+    return value == null ? null : Timestamp.valueOf(value);
+  }
+
+  public static final class SchemaRecord {
+    private final String connectorId;
+    private final String role;
+    private final String schemaVersion;
+    private final String schemaFingerprint;
+    private final String workerNodeId;
+    private final String workerInstanceId;
+    private final String schemaJson;
+    private final LocalDateTime syncedAt;
+
+    public SchemaRecord(String connectorId, String role, String schemaVersion,
+        String schemaFingerprint, String workerNodeId, String workerInstanceId,
+        String schemaJson, LocalDateTime syncedAt) {
+      this.connectorId = connectorId;
+      this.role = role;
+      this.schemaVersion = schemaVersion;
+      this.schemaFingerprint = schemaFingerprint;
+      this.workerNodeId = workerNodeId;
+      this.workerInstanceId = workerInstanceId;
+      this.schemaJson = schemaJson;
+      this.syncedAt = syncedAt;
+    }
+
+    public String getConnectorId() { return connectorId; }
+    public String getRole() { return role; }
+    public String getSchemaVersion() { return schemaVersion; }
+    public String getSchemaFingerprint() { return schemaFingerprint; }
+    public String getWorkerNodeId() { return workerNodeId; }
+    public String getWorkerInstanceId() { return workerInstanceId; }
+    public String getSchemaJson() { return schemaJson; }
+    public LocalDateTime getSyncedAt() { return syncedAt; }
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/resources/db/migration/yak-offline-sync/V3__add_connector_schema_cache.sql
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/resources/db/migration/yak-offline-sync/V3__add_connector_schema_cache.sql
@@ -1,0 +1,17 @@
+CREATE TABLE IF NOT EXISTS yak_offline_connector_schema (
+    id BIGINT NOT NULL AUTO_INCREMENT COMMENT '主键',
+    connector_id VARCHAR(128) NOT NULL COMMENT 'Connector 标识',
+    connector_role VARCHAR(16) NOT NULL COMMENT 'SOURCE 或 SINK',
+    schema_version VARCHAR(64) NULL COMMENT 'Link-Up Schema 版本',
+    schema_fingerprint VARCHAR(128) NULL COMMENT 'Link-Up Schema 指纹',
+    worker_node_id VARCHAR(128) NULL COMMENT '同步来源 Worker 节点',
+    worker_instance_id VARCHAR(128) NULL COMMENT '同步来源 Worker 实例',
+    schema_json LONGTEXT NOT NULL COMMENT '原始 Connector Schema JSON',
+    synced_at DATETIME(3) NOT NULL COMMENT '最近成功同步时间',
+    create_time DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    update_time DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_offline_connector_schema (connector_id, connector_role),
+    KEY idx_offline_connector_schema_synced (synced_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+  COMMENT='Link-Up Connector Schema 本地快照';

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/form/ConnectorFormSchemaComposerTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/form/ConnectorFormSchemaComposerTest.java
@@ -1,0 +1,69 @@
+package io.yak.ops.business.sync.offline.form;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+
+class ConnectorFormSchemaComposerTest {
+
+  private final ObjectMapper mapper = new ObjectMapper();
+  private final ConnectorFormSchemaComposer composer =
+      new ConnectorFormSchemaComposer(new ConnectorPresentationRegistry(), mapper);
+
+  @Test
+  void shouldComposeJdbcSourceProfileAndHideDatasourceSecrets() throws Exception {
+    JsonNode schema = mapper.readTree("""
+        {
+          "connectorId":"jdbc","role":"SOURCE","schemaVersion":"1",
+          "schemaFingerprint":"sha256:source","capabilities":["MULTI_TABLE"],
+          "options":[
+            {"key":"url","valueType":"STRING","required":true,"semanticType":"JDBC_URL","scope":"DATASOURCE"},
+            {"key":"password","valueType":"STRING","required":false,"sensitive":true,"semanticType":"PASSWORD","scope":"DATASOURCE"},
+            {"key":"table_path","valueType":"STRING","required":false,"semanticType":"TABLE_PATH","scope":"TASK"},
+            {"key":"fetch_size","valueType":"INTEGER","defaultValue":1000,"scope":"RUNTIME"}
+          ],
+          "rules":[]
+        }
+        """);
+
+    ConnectorFormSchema result = composer.compose(
+        new ConnectorSchemaSnapshot(schema, "REMOTE", false, LocalDateTime.now()));
+
+    assertThat(result.getProfileVersion()).isEqualTo("1");
+    assertThat(field(result, "table_path").getWidget()).isEqualTo("table-picker");
+    assertThat(field(result, "table_path").getGroupId()).isEqualTo("read");
+    assertThat(field(result, "password").isHidden()).isTrue();
+    assertThat(field(result, "password").getValueSource()).isEqualTo("DATASOURCE");
+    assertThat(field(result, "fetch_size").getImportance()).isEqualTo("ADVANCED");
+    assertThat(result.getFormFingerprint()).startsWith("sha256:");
+  }
+
+  @Test
+  void shouldGenerateUsableFallbackForUnknownConnector() throws Exception {
+    JsonNode schema = mapper.readTree("""
+        {"connectorId":"http","role":"SOURCE","schemaVersion":"1","schemaFingerprint":"x",
+         "options":[
+           {"key":"method","valueType":"ENUM","allowedValues":["GET","POST"],"required":true,"scope":"TASK"},
+           {"key":"headers","valueType":"MAP","required":false,"scope":"TASK"}
+         ],"rules":[],"capabilities":[]}
+        """);
+
+    ConnectorFormSchema result = composer.compose(
+        new ConnectorSchemaSnapshot(schema, "CACHE", true, LocalDateTime.now()));
+
+    assertThat(result.getProfileVersion()).isEqualTo("auto");
+    assertThat(field(result, "method").getWidget()).isEqualTo("select");
+    assertThat(field(result, "headers").getWidget()).isEqualTo("key-value");
+    assertThat(result.getWarnings()).isNotEmpty();
+    assertThat(result.isStale()).isTrue();
+  }
+
+  private ConnectorFormSchema.Field field(ConnectorFormSchema schema, String key) {
+    return schema.getFields().stream()
+        .filter(field -> key.equals(field.getKey()))
+        .findFirst().orElseThrow();
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/form/ConnectorPresentationRegistryTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/form/ConnectorPresentationRegistryTest.java
@@ -1,0 +1,27 @@
+package io.yak.ops.business.sync.offline.form;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class ConnectorPresentationRegistryTest {
+
+  private final ConnectorPresentationRegistry registry = new ConnectorPresentationRegistry();
+
+  @Test
+  void shouldProvideDifferentJdbcSourceAndSinkProfiles() {
+    ConnectorPresentationProfile source = registry.find("jdbc", "SOURCE");
+    ConnectorPresentationProfile sink = registry.find("JDBC", "sink");
+
+    assertThat(source).isNotNull();
+    assertThat(sink).isNotNull();
+    assertThat(source.getFields().get("table_path").getLabel()).isEqualTo("来源表");
+    assertThat(sink.getFields().get("table_path").getLabel()).isEqualTo("目标表");
+    assertThat(source.getFields().get("password").getValueSource()).isEqualTo("DATASOURCE");
+  }
+
+  @Test
+  void shouldReturnNullForUnknownConnector() {
+    assertThat(registry.find("http", "SOURCE")).isNull();
+  }
+}


### PR DESCRIPTION
## Summary

This implements phase two of the Connector configuration architecture: **Yak Ops Form Schema**.

Link-Up remains the source of truth for executable Connector options and validation rules. Yak Ops now caches those raw schemas, applies product-oriented Presentation Profiles, and exposes a frontend-ready Form Schema without duplicating execution validation.

- fetch Connector Schemas from Link-Up's read-only schema API
- persist raw schema snapshots so task editing remains available during temporary Worker outages
- report snapshot source (`REMOTE` or `CACHE`), synchronization time and stale state explicitly
- add JDBC Source and Sink Presentation Profiles
- merge Link-Up option metadata with labels, groups, order, importance, widgets and value sources
- automatically infer a usable Form Schema for unknown future Connectors
- hide datasource-owned credentials and connection details while retaining them in the schema contract
- preserve Link-Up rules and capabilities unchanged for frontend validation and feature decisions
- generate a deterministic Yak Ops Form Schema fingerprint
- expose Form Schema list, detail and manual refresh endpoints

## Architecture

```text
Link-Up Connector Schema
          ↓
LinkUpConnectorSchemaClient
          ↓
ConnectorSchemaRegistry
  ├─ in-memory snapshot
  └─ yak_offline_connector_schema
          ↓
ConnectorPresentationRegistry
          ↓
ConnectorFormSchemaComposer
          ↓
Yak Ops Form Schema REST API
```

### Responsibility boundary

- **Link-Up** owns option types, defaults, required/exclusive/conditional rules, semantic types, scopes and Connector capabilities.
- **Yak Ops Presentation Profile** owns labels, groups, order, importance, widgets, hidden/read-only behavior and value source.
- **Yak Ops frontend** can render the returned Form Schema without knowing JDBC implementation details.

## API

```http
GET  /api/v1/job/batch-control/connectors/form-schemas
GET  /api/v1/job/batch-control/connectors/form-schemas?role=SOURCE
GET  /api/v1/job/batch-control/connectors/{connectorId}/form-schema?role=SOURCE
POST /api/v1/job/batch-control/connectors/schemas/refresh
```

## Form Schema output

The composed response includes:

- Connector ID and Source/Sink role
- Link-Up schema version and fingerprint
- Yak Ops profile version and composed form fingerprint
- capabilities and original validation rules
- groups with ordering, collapsed and hidden state
- fields with original option metadata plus:
  - `label`
  - `groupId`
  - `order`
  - `importance`
  - `widget`
  - `hidden`
  - `readOnly`
  - `valueSource`
  - `help`
  - `placeholder`
- cache source, sync time and stale state
- profile compatibility warnings

## Default inference

A Connector without a dedicated Yak Ops profile is still usable:

- required fields without defaults become `PRIMARY`
- runtime tuning becomes `ADVANCED`
- datasource/system fields become hidden and read-only
- enums become selects
- booleans become switches
- numbers become number inputs
- maps become key-value editors
- lists become list editors
- SQL, table and file semantic types select specialized widgets

Unknown fields are never dropped.

## JDBC profiles

JDBC Source highlights table/multi-table/query selection, filters and consistency, while moving partition and statistics tuning into advanced groups.

JDBC Sink highlights target table, schema/data save modes, write mode and primary keys, with separate performance and dirty-data groups.

Connection URL, driver, username, password, dialect and connection properties are retained but hidden with `valueSource=DATASOURCE` so the data source center can inject them.

## Persistence

Flyway V3 adds:

```text
yak_offline_connector_schema
```

The unique key is `(connector_id, connector_role)`. Each row stores the original JSON, Link-Up version/fingerprint, Worker node/instance and last successful synchronization time.

## Validation

- based on the latest `main` commit `8ff17e53f1d752878e32759768b3a3729984940a`
- Java 21 static compilation completed for the new Form Schema, profile, registry, REST and repository sources using dependency stubs
- fixed a regex escaping issue found by static compilation
- verified Flyway initialization precedes cache loading
- added tests for JDBC profile composition, datasource secret hiding and unknown-Connector fallback
- verified the branch contains only offline Form Schema backend changes

Full Maven reactor execution was not available because Maven is not installed in the execution environment. Repository CI should run the full compile, Flyway and test suite for this draft.

## Dependency

This phase consumes the Connector Schema endpoints introduced by `weifuwan/yak-link-up#49`. Deploy or merge that Link-Up change before enabling remote schema refresh.

## Non-goals

This PR intentionally does not include:

- the Yak Ops frontend dynamic renderer
- Connector database/table/field Action APIs
- JSON JobSpec submission
- replacement of `LinkUpHoconBuilder`
- HOCON removal
- CDC or realtime synchronization semantics
