### PR TITLE
feat(offline-sync): add complex form interactions

### DIFF
--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/FORM_SCHEMA.md
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/FORM_SCHEMA.md
@@ -1,48 +1,88 @@
 # Yak Ops Connector Form Schema
 
-第二阶段在 Link-Up Connector Schema 之上增加产品展示层：
+第三阶段在第二阶段 Form Schema 之上补齐复杂交互、受控 Action 和前端动态渲染：
 
 ```text
-Link-Up Connector Schema
-          ↓ 缓存原始快照
-ConnectorSchemaRegistry
-          ↓ 合并
-ConnectorPresentationRegistry + ConnectorFormSchemaComposer
+Link-Up Connector Rule
+          ↓ 归一化
+Yak Ops Interaction Model
           ↓
-Yak Ops Form Schema
+Frontend Rule Engine + Backend Validation
+
+Presentation Profile OptionSource
+          ↓
+Connector Form Action API
+          ↓
+Datasource Catalog
 ```
+
+## 复杂交互
+
+Form Schema 新增 `interactions`，把 Link-Up Rule 转换为稳定的跨语言效果：
+
+- `VISIBLE`：条件成立时显示字段；
+- `REQUIRED`：条件成立时必填；
+- `DISABLED`：条件成立时只读；
+- `EXCLUSIVE`：多个字段互斥；
+- `BUNDLED`：字段同时填写或同时留空；
+- `VALIDATE`：条件不成立时产生字段或表单错误。
+
+条件支持链式 `AND / OR`，以及等于、不等于、包含、存在、布尔、数值比较、前后缀和正则等操作符。原始 `rules` 仍保留，`interactions` 只作为控制面稳定交互模型。
+
+## 远程选项与级联
+
+字段可声明：
+
+```json
+{
+  "dependsOn": ["table_path"],
+  "clearWhenHidden": true,
+  "optionSource": {
+    "action": "LIST_COLUMNS",
+    "searchable": true,
+    "multiple": true,
+    "cacheTtlMillis": 30000,
+    "requestValueKeys": ["table_path"]
+  }
+}
+```
+
+内置受控 Action：
+
+- `LIST_TABLES`
+- `LIST_COLUMNS`
+- `PREVIEW`
+- `COUNT`
+- `SQL_TEMPLATE`
+- `RESOLVE_SQL`
+
+Action 只通过 Yak Ops 数据源 Catalog 执行，前端不直接连接数据库，也不直接访问 Link-Up Worker。
 
 ## API
 
 ```http
-GET  /api/v1/job/batch-control/connectors/form-schemas?role=SOURCE
 GET  /api/v1/job/batch-control/connectors/{connectorId}/form-schema?role=SOURCE
+POST /api/v1/job/batch-control/connectors/{connectorId}/form-schema/validate?role=SOURCE
+POST /api/v1/job/batch-control/connectors/actions/{action}
 POST /api/v1/job/batch-control/connectors/schemas/refresh
 ```
 
-Form Schema 保留 Link-Up 的类型、默认值、枚举值、必填、敏感、Scope、Semantic Type、规则和能力，同时补充：
+## 前端
 
-- 分组和顺序；
-- PRIMARY / COMMON / ADVANCED / EXPERT / HIDDEN 重要程度；
-- widget、label、help、placeholder；
-- hidden、readOnly、valueSource；
-- Schema/Profile/Form 三层版本与指纹；
-- REMOTE/CACHE 来源、同步时间和 stale 状态。
+离线任务编辑页新增 Schema 驱动的 Connector 扩展配置：
 
-JDBC Source/Sink 已提供第一版专属 Profile。未知 Connector 会通过通用推导得到可用表单，不会因为缺少 Profile 而丢失参数。数据源连接参数默认隐藏并由数据源中心注入。
+- 分组、折叠和 Widget 动态渲染；
+- 条件显示、条件必填、互斥和组合校验；
+- 数据源 → 表 → 字段级联；
+- 搜索防抖、请求竞态保护和短期缓存；
+- 隐藏字段自动清理；
+- 保存前执行后端在线校验；
+- 缓存 Schema 使用状态明确提示。
 
-配置项：
+当前单表主键字段也改为 Catalog 字段选择器；目标表自动创建时读取来源字段，写入已有表时读取目标字段。
 
-```yaml
-yak:
-  sync:
-    offline:
-      schema:
-        enabled: true
-        refresh-enabled: true
-        initial-delay-millis: 5000
-        refresh-delay-millis: 300000
-        max-stale-millis: 86400000
-```
+## 兼容策略
 
-本阶段不包含前端动态渲染器、Connector Action API、JSON JobSpec 或 HOCON 替换。
+动态表单值保存到 `connectorOptions`，同时同步现有 `table`、`sql`、`fetchSize`、`writeMode`、`primaryKey`、`batchSize` 等字段，因此本阶段不改变任务保存结构和 `LinkUpHoconBuilder`。
+
+本阶段仍不包含 JSON JobSpec、HOCON 删除、CDC 或实时同步语义。

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/controller/OfflineConnectorFormController.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/controller/OfflineConnectorFormController.java
@@ -2,27 +2,41 @@ package io.yak.ops.business.sync.offline.controller;
 
 import io.yak.framework.common.Result;
 import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import io.yak.ops.business.sync.offline.form.ConnectorFormActionService;
+import io.yak.ops.business.sync.offline.form.ConnectorFormActionService.ActionRequest;
+import io.yak.ops.business.sync.offline.form.ConnectorFormActionService.ActionResult;
 import io.yak.ops.business.sync.offline.form.ConnectorFormSchema;
 import io.yak.ops.business.sync.offline.form.ConnectorFormSchemaService;
+import io.yak.ops.business.sync.offline.form.ConnectorFormValidationService;
+import io.yak.ops.business.sync.offline.form.ConnectorFormValidationService.ValidationRequest;
+import io.yak.ops.business.sync.offline.form.ConnectorFormValidationService.ValidationResult;
 import java.util.List;
 import java.util.Map;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-/** Yak Ops Connector Form Schema 接口。 */
+/** Yak Ops Connector Form Schema、复杂交互与 Action 接口。 */
 @ConditionalOnOfflineSyncEnabled
 @RestController
 @RequestMapping("/api/v1/job/batch-control/connectors")
 public class OfflineConnectorFormController {
 
   private final ConnectorFormSchemaService service;
+  private final ConnectorFormValidationService validationService;
+  private final ConnectorFormActionService actionService;
 
-  public OfflineConnectorFormController(ConnectorFormSchemaService service) {
+  public OfflineConnectorFormController(
+      ConnectorFormSchemaService service,
+      ConnectorFormValidationService validationService,
+      ConnectorFormActionService actionService) {
     this.service = service;
+    this.validationService = validationService;
+    this.actionService = actionService;
   }
 
   @GetMapping("/form-schemas")
@@ -36,6 +50,21 @@ public class OfflineConnectorFormController {
       @PathVariable String connectorId,
       @RequestParam String role) {
     return Result.success(service.get(connectorId, role));
+  }
+
+  @PostMapping("/{connectorId}/form-schema/validate")
+  public Result<ValidationResult> validate(
+      @PathVariable String connectorId,
+      @RequestParam String role,
+      @RequestBody(required = false) ValidationRequest request) {
+    return Result.success(validationService.validate(connectorId, role, request));
+  }
+
+  @PostMapping("/actions/{action}")
+  public Result<ActionResult> action(
+      @PathVariable String action,
+      @RequestBody ActionRequest request) {
+    return Result.success(actionService.execute(action, request));
   }
 
   @PostMapping("/schemas/refresh")

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/form/ConnectorConditionEvaluator.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/form/ConnectorConditionEvaluator.java
@@ -1,0 +1,130 @@
+package io.yak.ops.business.sync.offline.form;
+
+import java.math.BigDecimal;
+import java.util.Collection;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+/** Yak Ops 后端和前端遵循的条件求值语义。 */
+public final class ConnectorConditionEvaluator {
+
+  public boolean evaluate(ConnectorFormSchema.Condition condition, Map<String, Object> values) {
+    if (condition == null) {
+      return true;
+    }
+    boolean current = evaluateSingle(condition, values);
+    if (condition.getNext() == null) {
+      return current;
+    }
+    boolean next = evaluate(condition.getNext(), values);
+    String logical = normalize(condition.getLogicalOperator());
+    return "OR".equals(logical) ? current || next : current && next;
+  }
+
+  private boolean evaluateSingle(ConnectorFormSchema.Condition condition, Map<String, Object> values) {
+    Object actual = values.get(condition.getOptionKey());
+    Object expected = condition.getCompareOptionKey() == null
+        ? condition.getExpectedValue() : values.get(condition.getCompareOptionKey());
+    String operator = normalize(condition.getOperator());
+    return switch (operator) {
+      case "EQ", "EQUAL", "EQUALS", "IS" -> equalsValue(actual, expected);
+      case "NE", "NOT_EQUAL", "NOT_EQUALS", "IS_NOT" -> !equalsValue(actual, expected);
+      case "IN" -> contains(expected, actual);
+      case "NOT_IN" -> !contains(expected, actual);
+      case "CONTAINS" -> contains(actual, expected);
+      case "NOT_CONTAINS" -> !contains(actual, expected);
+      case "EXISTS", "PRESENT", "NOT_EMPTY" -> !isEmpty(actual);
+      case "NOT_EXISTS", "ABSENT", "EMPTY" -> isEmpty(actual);
+      case "TRUE", "IS_TRUE" -> Boolean.TRUE.equals(booleanValue(actual));
+      case "FALSE", "IS_FALSE" -> Boolean.FALSE.equals(booleanValue(actual));
+      case "GT", "GREATER_THAN" -> compare(actual, expected) > 0;
+      case "GTE", "GREATER_THAN_OR_EQUAL" -> compare(actual, expected) >= 0;
+      case "LT", "LESS_THAN" -> compare(actual, expected) < 0;
+      case "LTE", "LESS_THAN_OR_EQUAL" -> compare(actual, expected) <= 0;
+      case "STARTS_WITH" -> string(actual).startsWith(string(expected));
+      case "ENDS_WITH" -> string(actual).endsWith(string(expected));
+      case "MATCHES", "REGEX" -> matches(actual, expected);
+      case "EXTENSION", "" -> true;
+      default -> true;
+    };
+  }
+
+  public boolean isEmpty(Object value) {
+    if (value == null) { return true; }
+    if (value instanceof CharSequence text) { return text.toString().trim().isEmpty(); }
+    if (value instanceof Collection<?> collection) { return collection.isEmpty(); }
+    if (value instanceof Map<?, ?> map) { return map.isEmpty(); }
+    return false;
+  }
+
+  private boolean equalsValue(Object left, Object right) {
+    if (left instanceof Collection<?> collection) {
+      return collection.stream().anyMatch(item -> equalsValue(item, right));
+    }
+    if (right instanceof Collection<?> collection) {
+      return collection.stream().anyMatch(item -> equalsValue(left, item));
+    }
+    if (left instanceof Number || right instanceof Number) {
+      try {
+        return decimal(left).compareTo(decimal(right)) == 0;
+      } catch (RuntimeException ignored) {
+        return Objects.equals(string(left), string(right));
+      }
+    }
+    return Objects.equals(left, right) || string(left).equalsIgnoreCase(string(right));
+  }
+
+  private boolean contains(Object container, Object value) {
+    if (container instanceof Collection<?> collection) {
+      return collection.stream().anyMatch(item -> equalsValue(item, value));
+    }
+    if (container instanceof Map<?, ?> map) {
+      return map.containsKey(value) || map.containsValue(value);
+    }
+    return string(container).contains(string(value));
+  }
+
+  private int compare(Object left, Object right) {
+    try {
+      return decimal(left).compareTo(decimal(right));
+    } catch (RuntimeException ignored) {
+      return string(left).compareTo(string(right));
+    }
+  }
+
+  private BigDecimal decimal(Object value) {
+    return new BigDecimal(string(value));
+  }
+
+  private Boolean booleanValue(Object value) {
+    if (value instanceof Boolean bool) { return bool; }
+    String text = string(value);
+    if (List.of("true", "1", "yes", "on").contains(text.toLowerCase(Locale.ROOT))) {
+      return true;
+    }
+    if (List.of("false", "0", "no", "off").contains(text.toLowerCase(Locale.ROOT))) {
+      return false;
+    }
+    return null;
+  }
+
+  private boolean matches(Object actual, Object expected) {
+    try {
+      return Pattern.compile(string(expected)).matcher(string(actual)).matches();
+    } catch (PatternSyntaxException ignored) {
+      return true;
+    }
+  }
+
+  private String string(Object value) {
+    return value == null ? "" : String.valueOf(value).trim();
+  }
+
+  private String normalize(String value) {
+    return value == null ? "" : value.trim().toUpperCase(Locale.ROOT).replace('-', '_');
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/form/ConnectorFormActionService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/form/ConnectorFormActionService.java
@@ -1,0 +1,168 @@
+package io.yak.ops.business.sync.offline.form;
+
+import io.yak.ops.business.datasource.service.DataSourceCatalogService;
+import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import io.yak.ops.common.bean.vo.datasource.DataSourceCatalogColumnOptionVO;
+import io.yak.ops.common.bean.vo.datasource.DataSourceCatalogOptionVO;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.stereotype.Service;
+
+/** 为动态表单提供表、字段、预览和 SQL 等受控 Action。 */
+@ConditionalOnOfflineSyncEnabled
+@Service
+public class ConnectorFormActionService {
+
+  private final ObjectProvider<DataSourceCatalogService> catalogServiceProvider;
+
+  public ConnectorFormActionService(
+      ObjectProvider<DataSourceCatalogService> catalogServiceProvider) {
+    this.catalogServiceProvider = catalogServiceProvider;
+  }
+
+  public ActionResult execute(String action, ActionRequest request) {
+    String normalized = action == null ? "" : action.trim().toUpperCase(Locale.ROOT);
+    DataSourceCatalogService catalogService = catalogServiceProvider.getIfAvailable();
+    if (catalogService == null) {
+      throw new IllegalStateException("数据源 Catalog 服务未启用");
+    }
+    Long dataSourceId = requireDataSourceId(request);
+    Map<String, Object> values = request == null || request.getValues() == null
+        ? new LinkedHashMap<>() : new LinkedHashMap<>(request.getValues());
+
+    return switch (normalized) {
+      case "LIST_TABLES" -> filterOptions(
+          tableOptions(catalogService.listTableReference(
+              dataSourceId, request.getMatchMode(), request.getKeyword())),
+          request.getKeyword());
+      case "LIST_COLUMNS" -> filterOptions(
+          columnOptions(catalogService.listColumn(dataSourceId, values)),
+          request.getKeyword());
+      case "PREVIEW" -> ActionResult.data(catalogService.preview(dataSourceId, values));
+      case "COUNT" -> ActionResult.data(catalogService.count(dataSourceId, values));
+      case "SQL_TEMPLATE" -> ActionResult.data(catalogService.buildSqlTemplate(dataSourceId, values));
+      case "RESOLVE_SQL" -> ActionResult.data(catalogService.resolveSql(dataSourceId, values));
+      default -> throw new IllegalArgumentException("不支持的 Connector Form Action：" + action);
+    };
+  }
+
+  private ActionResult filterOptions(ActionResult result, String keyword) {
+    if (keyword == null || keyword.isBlank()) {
+      return result;
+    }
+    String normalized = keyword.trim().toLowerCase(Locale.ROOT);
+    List<Option> filtered = result.getOptions().stream()
+        .filter(option -> String.valueOf(option.getValue()).toLowerCase(Locale.ROOT).contains(normalized)
+            || String.valueOf(option.getLabel()).toLowerCase(Locale.ROOT).contains(normalized)
+            || String.valueOf(option.getDescription()).toLowerCase(Locale.ROOT).contains(normalized))
+        .toList();
+    return ActionResult.options(filtered);
+  }
+
+  private ActionResult tableOptions(List<DataSourceCatalogOptionVO> source) {
+    List<Option> options = new ArrayList<>();
+    for (DataSourceCatalogOptionVO item : source) {
+      Option option = new Option();
+      option.setValue(item.getValue());
+      option.setLabel(item.getLabel() == null || item.getLabel().isBlank()
+          ? String.valueOf(item.getValue()) : item.getLabel());
+      option.setDescription(item.getDescription());
+      options.add(option);
+    }
+    return ActionResult.options(options);
+  }
+
+  private ActionResult columnOptions(List<DataSourceCatalogColumnOptionVO> source) {
+    List<Option> options = new ArrayList<>();
+    for (DataSourceCatalogColumnOptionVO item : source) {
+      Option option = new Option();
+      option.setValue(item.getFieldName());
+      option.setLabel(String.valueOf(item.getFieldName()));
+      String type = item.getFieldType() == null ? "" : String.valueOf(item.getFieldType());
+      String comment = item.getFieldComment() == null ? "" : item.getFieldComment();
+      option.setDescription(comment.isBlank() ? type : type + " · " + comment);
+      Map<String, Object> meta = new LinkedHashMap<>();
+      meta.put("type", item.getFieldType());
+      meta.put("nullable", item.getIsNullable());
+      meta.put("primaryKey", "PRI".equalsIgnoreCase(item.getFieldKey()));
+      meta.put("ordinalPosition", item.getOrdinalPosition());
+      option.setMeta(meta);
+      options.add(option);
+    }
+    return ActionResult.options(options);
+  }
+
+  private Long requireDataSourceId(ActionRequest request) {
+    if (request == null || request.getDataSourceId() == null || request.getDataSourceId() <= 0L) {
+      throw new IllegalArgumentException("dataSourceId 不能为空");
+    }
+    return request.getDataSourceId();
+  }
+
+  public static class ActionRequest {
+    private Long dataSourceId;
+    private String connectorId;
+    private String role;
+    private String fieldKey;
+    private String keyword;
+    private String matchMode;
+    private Map<String, Object> values = new LinkedHashMap<>();
+
+    public Long getDataSourceId() { return dataSourceId; }
+    public void setDataSourceId(Long dataSourceId) { this.dataSourceId = dataSourceId; }
+    public String getConnectorId() { return connectorId; }
+    public void setConnectorId(String connectorId) { this.connectorId = connectorId; }
+    public String getRole() { return role; }
+    public void setRole(String role) { this.role = role; }
+    public String getFieldKey() { return fieldKey; }
+    public void setFieldKey(String fieldKey) { this.fieldKey = fieldKey; }
+    public String getKeyword() { return keyword; }
+    public void setKeyword(String keyword) { this.keyword = keyword; }
+    public String getMatchMode() { return matchMode; }
+    public void setMatchMode(String matchMode) { this.matchMode = matchMode; }
+    public Map<String, Object> getValues() { return values; }
+    public void setValues(Map<String, Object> values) { this.values = values; }
+  }
+
+  public static class ActionResult {
+    private List<Option> options = new ArrayList<>();
+    private Object data;
+
+    public static ActionResult options(List<Option> options) {
+      ActionResult result = new ActionResult();
+      result.setOptions(options);
+      return result;
+    }
+
+    public static ActionResult data(Object data) {
+      ActionResult result = new ActionResult();
+      result.setData(data);
+      return result;
+    }
+
+    public List<Option> getOptions() { return options; }
+    public void setOptions(List<Option> options) { this.options = options; }
+    public Object getData() { return data; }
+    public void setData(Object data) { this.data = data; }
+  }
+
+  public static class Option {
+    private Object value;
+    private String label;
+    private String description;
+    private Map<String, Object> meta = new LinkedHashMap<>();
+
+    public Object getValue() { return value; }
+    public void setValue(Object value) { this.value = value; }
+    public String getLabel() { return label; }
+    public void setLabel(String label) { this.label = label; }
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
+    public Map<String, Object> getMeta() { return meta; }
+    public void setMeta(Map<String, Object> meta) { this.meta = meta; }
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/form/ConnectorFormSchema.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/form/ConnectorFormSchema.java
@@ -19,6 +19,7 @@ public class ConnectorFormSchema {
   private List<String> capabilities = new ArrayList<>();
   private List<Group> groups = new ArrayList<>();
   private List<Field> fields = new ArrayList<>();
+  private List<Interaction> interactions = new ArrayList<>();
   private JsonNode rules;
   private List<String> warnings = new ArrayList<>();
 
@@ -46,6 +47,8 @@ public class ConnectorFormSchema {
   public void setGroups(List<Group> groups) { this.groups = groups; }
   public List<Field> getFields() { return fields; }
   public void setFields(List<Field> fields) { this.fields = fields; }
+  public List<Interaction> getInteractions() { return interactions; }
+  public void setInteractions(List<Interaction> interactions) { this.interactions = interactions; }
   public JsonNode getRules() { return rules; }
   public void setRules(JsonNode rules) { this.rules = rules; }
   public List<String> getWarnings() { return warnings; }
@@ -93,6 +96,9 @@ public class ConnectorFormSchema {
     private boolean hidden;
     private boolean readOnly;
     private String valueSource;
+    private List<String> dependsOn = new ArrayList<>();
+    private boolean clearWhenHidden;
+    private OptionSource optionSource;
 
     public String getKey() { return key; }
     public void setKey(String key) { this.key = key; }
@@ -138,5 +144,77 @@ public class ConnectorFormSchema {
     public void setReadOnly(boolean readOnly) { this.readOnly = readOnly; }
     public String getValueSource() { return valueSource; }
     public void setValueSource(String valueSource) { this.valueSource = valueSource; }
+    public List<String> getDependsOn() { return dependsOn; }
+    public void setDependsOn(List<String> dependsOn) { this.dependsOn = dependsOn; }
+    public boolean isClearWhenHidden() { return clearWhenHidden; }
+    public void setClearWhenHidden(boolean clearWhenHidden) { this.clearWhenHidden = clearWhenHidden; }
+    public OptionSource getOptionSource() { return optionSource; }
+    public void setOptionSource(OptionSource optionSource) { this.optionSource = optionSource; }
+  }
+
+  /** 远程下拉、表和字段选择器的数据来源。 */
+  public static class OptionSource {
+    private String action;
+    private boolean searchable;
+    private boolean multiple;
+    private long cacheTtlMillis = 30_000L;
+    private List<String> requestValueKeys = new ArrayList<>();
+
+    public String getAction() { return action; }
+    public void setAction(String action) { this.action = action; }
+    public boolean isSearchable() { return searchable; }
+    public void setSearchable(boolean searchable) { this.searchable = searchable; }
+    public boolean isMultiple() { return multiple; }
+    public void setMultiple(boolean multiple) { this.multiple = multiple; }
+    public long getCacheTtlMillis() { return cacheTtlMillis; }
+    public void setCacheTtlMillis(long cacheTtlMillis) { this.cacheTtlMillis = cacheTtlMillis; }
+    public List<String> getRequestValueKeys() { return requestValueKeys; }
+    public void setRequestValueKeys(List<String> requestValueKeys) { this.requestValueKeys = requestValueKeys; }
+  }
+
+  /** Link-Up 规则归一化后的前端交互。 */
+  public static class Interaction {
+    private String id;
+    private String effect;
+    private List<String> optionKeys = new ArrayList<>();
+    private Condition condition;
+    private String message;
+
+    public String getId() { return id; }
+    public void setId(String id) { this.id = id; }
+    public String getEffect() { return effect; }
+    public void setEffect(String effect) { this.effect = effect; }
+    public List<String> getOptionKeys() { return optionKeys; }
+    public void setOptionKeys(List<String> optionKeys) { this.optionKeys = optionKeys; }
+    public Condition getCondition() { return condition; }
+    public void setCondition(Condition condition) { this.condition = condition; }
+    public String getMessage() { return message; }
+    public void setMessage(String message) { this.message = message; }
+  }
+
+  /** 跨语言条件表达式，支持链式 AND/OR。 */
+  public static class Condition {
+    private String optionKey;
+    private String operator;
+    private Object expectedValue;
+    private String compareOptionKey;
+    private String extensionDescription;
+    private String logicalOperator;
+    private Condition next;
+
+    public String getOptionKey() { return optionKey; }
+    public void setOptionKey(String optionKey) { this.optionKey = optionKey; }
+    public String getOperator() { return operator; }
+    public void setOperator(String operator) { this.operator = operator; }
+    public Object getExpectedValue() { return expectedValue; }
+    public void setExpectedValue(Object expectedValue) { this.expectedValue = expectedValue; }
+    public String getCompareOptionKey() { return compareOptionKey; }
+    public void setCompareOptionKey(String compareOptionKey) { this.compareOptionKey = compareOptionKey; }
+    public String getExtensionDescription() { return extensionDescription; }
+    public void setExtensionDescription(String extensionDescription) { this.extensionDescription = extensionDescription; }
+    public String getLogicalOperator() { return logicalOperator; }
+    public void setLogicalOperator(String logicalOperator) { this.logicalOperator = logicalOperator; }
+    public Condition getNext() { return next; }
+    public void setNext(Condition next) { this.next = next; }
   }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/form/ConnectorFormSchemaComposer.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/form/ConnectorFormSchemaComposer.java
@@ -10,12 +10,12 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.LinkedHashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Set;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
@@ -27,12 +27,14 @@ public class ConnectorFormSchemaComposer {
 
   private final ConnectorPresentationRegistry presentationRegistry;
   private final ObjectMapper objectMapper;
+  private final ConnectorInteractionNormalizer interactionNormalizer;
 
   public ConnectorFormSchemaComposer(
       ConnectorPresentationRegistry presentationRegistry,
       @Qualifier("offlineSyncJsonMapper") ObjectMapper objectMapper) {
     this.presentationRegistry = presentationRegistry;
     this.objectMapper = objectMapper;
+    this.interactionNormalizer = new ConnectorInteractionNormalizer(objectMapper);
   }
 
   public ConnectorFormSchema compose(ConnectorSchemaSnapshot snapshot) {
@@ -51,6 +53,7 @@ public class ConnectorFormSchemaComposer {
     result.setStale(snapshot.isStale());
     result.setSyncedAt(snapshot.getSyncedAt());
     result.setRules(schema.path("rules").deepCopy());
+    result.setInteractions(interactionNormalizer.normalize(schema.path("rules")));
     copyStrings(schema.path("capabilities"), result.getCapabilities());
 
     Map<String, ConnectorFormSchema.Group> groups = defaultGroups();
@@ -79,7 +82,8 @@ public class ConnectorFormSchemaComposer {
 
     if (profile != null) {
       for (String profileKey : profile.getFields().keySet()) {
-        boolean found = result.getFields().stream().anyMatch(field -> profileKey.equals(field.getKey()));
+        boolean found = result.getFields().stream()
+            .anyMatch(field -> profileKey.equals(field.getKey()));
         if (!found) {
           result.getWarnings().add("Presentation Profile 字段在 Link-Up Schema 中不存在：" + profileKey);
         }
@@ -123,8 +127,10 @@ public class ConnectorFormSchemaComposer {
     field.setPlaceholder(profile == null ? null : profile.getPlaceholder());
     field.setValueType(valueType);
     field.setJavaType(option.path("javaType").asText(null));
-    field.setElementType(option.path("elementType").asText(null));
-    field.setDefaultValue(hasDefault ? objectMapper.convertValue(option.get("defaultValue"), Object.class) : null);
+    field.setElementType(option.path("elementType")
+        .asText(option.path("elementJavaType").asText(null)));
+    field.setDefaultValue(hasDefault
+        ? objectMapper.convertValue(option.get("defaultValue"), Object.class) : null);
     copyObjects(option.path("allowedValues"), field.getAllowedValues());
     copyStrings(option.path("fallbackKeys"), field.getFallbackKeys());
     field.setRequired(required);
@@ -151,7 +157,49 @@ public class ConnectorFormSchemaComposer {
         ? profile.getValueSource() : inferValueSource(scope));
     field.setReadOnly(profile != null && profile.getReadOnly() != null
         ? profile.getReadOnly() : field.isHidden() || !"USER".equals(field.getValueSource()));
+    field.setDependsOn(profile == null ? inferDependsOn(field.getWidget())
+        : new ArrayList<>(profile.getDependsOn()));
+    field.setClearWhenHidden(profile != null && profile.getClearWhenHidden() != null
+        ? profile.getClearWhenHidden() : false);
+    field.setOptionSource(profile != null && profile.getOptionSource() != null
+        ? optionSource(profile.getOptionSource())
+        : inferOptionSource(field.getWidget(), field.getValueType()));
     return field;
+  }
+
+  private ConnectorFormSchema.OptionSource optionSource(
+      ConnectorPresentationProfile.OptionSourceProfile profile) {
+    ConnectorFormSchema.OptionSource result = new ConnectorFormSchema.OptionSource();
+    result.setAction(profile.getAction());
+    result.setSearchable(profile.isSearchable());
+    result.setMultiple(profile.isMultiple());
+    result.setCacheTtlMillis(profile.getCacheTtlMillis());
+    result.setRequestValueKeys(new ArrayList<>(profile.getRequestValueKeys()));
+    return result;
+  }
+
+  private ConnectorFormSchema.OptionSource inferOptionSource(String widget, String valueType) {
+    String normalized = widget == null ? "" : widget.toLowerCase(Locale.ROOT);
+    if (!List.of("table-picker", "multi-table-picker", "field-selector").contains(normalized)) {
+      return null;
+    }
+    ConnectorFormSchema.OptionSource result = new ConnectorFormSchema.OptionSource();
+    result.setAction("field-selector".equals(normalized) ? "LIST_COLUMNS" : "LIST_TABLES");
+    result.setSearchable(true);
+    result.setMultiple("multi-table-picker".equals(normalized)
+        || ("field-selector".equals(normalized) && "LIST".equalsIgnoreCase(valueType)));
+    result.setCacheTtlMillis(30_000L);
+    if ("field-selector".equals(normalized)) {
+      result.setRequestValueKeys(List.of("table_path", "query"));
+    }
+    return result;
+  }
+
+  private List<String> inferDependsOn(String widget) {
+    if ("field-selector".equalsIgnoreCase(widget)) {
+      return new ArrayList<>(List.of("table_path", "query"));
+    }
+    return new ArrayList<>();
   }
 
   private Map<String, ConnectorFormSchema.Group> defaultGroups() {
@@ -188,7 +236,8 @@ public class ConnectorFormSchemaComposer {
   }
 
   private String inferGroup(String importance, String scope) {
-    if ("DATASOURCE".equals(scope) || "SYSTEM".equals(scope) || "HIDDEN".equals(importance)) {
+    if ("DATASOURCE".equals(scope) || "SYSTEM".equals(scope)
+        || "HIDDEN".equals(importance)) {
       return "hidden";
     }
     if ("PRIMARY".equals(importance)) { return "basic"; }
@@ -203,6 +252,9 @@ public class ConnectorFormSchemaComposer {
     if ("SQL".equals(semanticType)) { return "sql-editor"; }
     if ("TABLE_PATH".equals(semanticType)) { return "table-picker"; }
     if ("TABLE_LIST".equals(semanticType)) { return "multi-table-picker"; }
+    if (List.of("COLUMN_NAME", "FIELD_NAME", "COLUMN_LIST", "PRIMARY_KEY").contains(semanticType)) {
+      return "field-selector";
+    }
     if ("FILE_PATH".equals(semanticType)) { return "file-path"; }
     if (hasChoices || "ENUM".equals(valueType)) { return "select"; }
     if ("BOOLEAN".equals(valueType)) { return "switch"; }
@@ -241,7 +293,9 @@ public class ConnectorFormSchemaComposer {
 
   private void copyObjects(JsonNode source, List<Object> target) {
     if (!source.isArray()) { return; }
-    for (JsonNode value : source) { target.add(objectMapper.convertValue(value, Object.class)); }
+    for (JsonNode value : source) {
+      target.add(objectMapper.convertValue(value, Object.class));
+    }
   }
 
   private String fingerprint(ConnectorFormSchema schema) {
@@ -254,8 +308,10 @@ public class ConnectorFormSchemaComposer {
       canonical.set("capabilities", objectMapper.valueToTree(schema.getCapabilities()));
       canonical.set("groups", objectMapper.valueToTree(schema.getGroups()));
       canonical.set("fields", objectMapper.valueToTree(schema.getFields()));
+      canonical.set("interactions", objectMapper.valueToTree(schema.getInteractions()));
       canonical.set("rules", schema.getRules());
-      byte[] payload = objectMapper.writeValueAsString(canonical).getBytes(StandardCharsets.UTF_8);
+      byte[] payload = objectMapper.writeValueAsString(canonical)
+          .getBytes(StandardCharsets.UTF_8);
       byte[] digest = MessageDigest.getInstance("SHA-256").digest(payload);
       StringBuilder result = new StringBuilder("sha256:");
       for (byte value : digest) { result.append(String.format("%02x", value & 0xff)); }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/form/ConnectorFormValidationService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/form/ConnectorFormValidationService.java
@@ -1,0 +1,207 @@
+package io.yak.ops.business.sync.offline.form;
+
+import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import org.springframework.stereotype.Service;
+
+/** 基于 Form Schema 对任务侧 Connector 参数执行在线校验。 */
+@ConditionalOnOfflineSyncEnabled
+@Service
+public class ConnectorFormValidationService {
+
+  private final ConnectorFormSchemaService schemaService;
+  private final ConnectorConditionEvaluator conditionEvaluator = new ConnectorConditionEvaluator();
+
+  public ConnectorFormValidationService(ConnectorFormSchemaService schemaService) {
+    this.schemaService = schemaService;
+  }
+
+  public ValidationResult validate(String connectorId, String role, ValidationRequest request) {
+    ConnectorFormSchema schema = schemaService.get(connectorId, role);
+    Map<String, Object> values = request == null || request.getValues() == null
+        ? new LinkedHashMap<>() : new LinkedHashMap<>(request.getValues());
+    for (ConnectorFormSchema.Field field : schema.getFields()) {
+      if (!values.containsKey(field.getKey()) && field.getDefaultValue() != null) {
+        values.put(field.getKey(), field.getDefaultValue());
+      }
+    }
+    ValidationResult result = new ValidationResult();
+    result.setNormalizedValues(values);
+
+    Map<String, Boolean> visible = new LinkedHashMap<>();
+    Map<String, Boolean> required = new LinkedHashMap<>();
+    for (ConnectorFormSchema.Field field : schema.getFields()) {
+      visible.put(field.getKey(), !field.isHidden());
+      required.put(field.getKey(), field.isRequired());
+    }
+
+    for (ConnectorFormSchema.Interaction interaction : schema.getInteractions()) {
+      boolean active = conditionEvaluator.evaluate(interaction.getCondition(), values);
+      switch (normalize(interaction.getEffect())) {
+        case "VISIBLE" -> interaction.getOptionKeys().forEach(key ->
+            visible.compute(key, (ignored, current) -> Boolean.TRUE.equals(current) && active));
+        case "REQUIRED" -> {
+          if (active) {
+            interaction.getOptionKeys().forEach(key -> required.put(key, true));
+          }
+        }
+        case "EXCLUSIVE" -> {
+          if (active) { validateExclusive(interaction, values, result); }
+        }
+        case "BUNDLED" -> {
+          if (active) { validateBundled(interaction, values, result); }
+        }
+        case "VALIDATE" -> {
+          if (!active) { addInteractionError(interaction, result); }
+        }
+        default -> { }
+      }
+    }
+
+    for (ConnectorFormSchema.Field field : schema.getFields()) {
+      if (!Boolean.TRUE.equals(visible.get(field.getKey()))) {
+        if (field.isClearWhenHidden()) {
+          values.remove(field.getKey());
+        }
+        continue;
+      }
+      Object value = values.get(field.getKey());
+      if (Boolean.TRUE.equals(required.get(field.getKey())) && conditionEvaluator.isEmpty(value)) {
+        result.addFieldError(field.getKey(), field.getLabel() + "不能为空");
+        continue;
+      }
+      if (!conditionEvaluator.isEmpty(value)) {
+        validateType(field, value, result);
+        validateAllowedValues(field, value, result);
+      }
+    }
+
+    result.setValid(result.getFieldErrors().isEmpty() && result.getFormErrors().isEmpty());
+    return result;
+  }
+
+  private void validateExclusive(ConnectorFormSchema.Interaction interaction,
+      Map<String, Object> values, ValidationResult result) {
+    long count = interaction.getOptionKeys().stream()
+        .map(values::get)
+        .filter(value -> !conditionEvaluator.isEmpty(value))
+        .count();
+    if (count > 1) {
+      result.getFormErrors().add(message(interaction, "互斥配置只能填写其中一项"));
+    }
+  }
+
+  private void validateBundled(ConnectorFormSchema.Interaction interaction,
+      Map<String, Object> values, ValidationResult result) {
+    long count = interaction.getOptionKeys().stream()
+        .map(values::get)
+        .filter(value -> !conditionEvaluator.isEmpty(value))
+        .count();
+    if (count > 0 && count < interaction.getOptionKeys().size()) {
+      result.getFormErrors().add(message(interaction, "关联配置必须同时填写或同时留空"));
+    }
+  }
+
+  private void addInteractionError(ConnectorFormSchema.Interaction interaction,
+      ValidationResult result) {
+    if (interaction.getOptionKeys().size() == 1) {
+      result.addFieldError(interaction.getOptionKeys().get(0),
+          message(interaction, "配置不满足 Connector 约束"));
+    } else {
+      result.getFormErrors().add(message(interaction, "配置不满足 Connector 约束"));
+    }
+  }
+
+  private void validateType(ConnectorFormSchema.Field field, Object value,
+      ValidationResult result) {
+    String type = normalize(field.getValueType());
+    try {
+      switch (type) {
+        case "INTEGER", "LONG" -> new BigDecimal(String.valueOf(value)).longValueExact();
+        case "DECIMAL", "FLOAT", "DOUBLE" -> new BigDecimal(String.valueOf(value));
+        case "BOOLEAN" -> {
+          if (!(value instanceof Boolean)
+              && !List.of("true", "false", "1", "0").contains(String.valueOf(value).toLowerCase(Locale.ROOT))) {
+            throw new IllegalArgumentException("not boolean");
+          }
+        }
+        case "LIST" -> {
+          if (!(value instanceof Collection<?>)) { throw new IllegalArgumentException("not list"); }
+        }
+        case "MAP", "OBJECT" -> {
+          if (!(value instanceof Map<?, ?>)) { throw new IllegalArgumentException("not map"); }
+        }
+        default -> { }
+      }
+    } catch (RuntimeException exception) {
+      result.addFieldError(field.getKey(), field.getLabel() + "的值类型应为 " + type);
+    }
+  }
+
+  private void validateAllowedValues(ConnectorFormSchema.Field field, Object value,
+      ValidationResult result) {
+    if (field.getAllowedValues().isEmpty()) {
+      return;
+    }
+    if (value instanceof Collection<?> values) {
+      for (Object item : values) {
+        if (!containsAllowed(field.getAllowedValues(), item)) {
+          result.addFieldError(field.getKey(), field.getLabel() + "包含不支持的选项：" + item);
+        }
+      }
+    } else if (!containsAllowed(field.getAllowedValues(), value)) {
+      result.addFieldError(field.getKey(), field.getLabel() + "不是支持的选项");
+    }
+  }
+
+  private boolean containsAllowed(List<Object> allowedValues, Object value) {
+    return allowedValues.stream().anyMatch(allowed ->
+        String.valueOf(allowed).equalsIgnoreCase(String.valueOf(value)));
+  }
+
+  private String message(ConnectorFormSchema.Interaction interaction, String fallback) {
+    return interaction.getMessage() == null || interaction.getMessage().isBlank()
+        ? fallback : interaction.getMessage();
+  }
+
+  private String normalize(String value) {
+    return value == null ? "" : value.trim().toUpperCase(Locale.ROOT).replace('-', '_');
+  }
+
+  public static class ValidationRequest {
+    private Map<String, Object> values = new LinkedHashMap<>();
+    private Map<String, Object> context = new LinkedHashMap<>();
+
+    public Map<String, Object> getValues() { return values; }
+    public void setValues(Map<String, Object> values) { this.values = values; }
+    public Map<String, Object> getContext() { return context; }
+    public void setContext(Map<String, Object> context) { this.context = context; }
+  }
+
+  public static class ValidationResult {
+    private boolean valid;
+    private Map<String, List<String>> fieldErrors = new LinkedHashMap<>();
+    private List<String> formErrors = new ArrayList<>();
+    private Map<String, Object> normalizedValues = new LinkedHashMap<>();
+
+    public boolean isValid() { return valid; }
+    public void setValid(boolean valid) { this.valid = valid; }
+    public Map<String, List<String>> getFieldErrors() { return fieldErrors; }
+    public void setFieldErrors(Map<String, List<String>> fieldErrors) { this.fieldErrors = fieldErrors; }
+    public List<String> getFormErrors() { return formErrors; }
+    public void setFormErrors(List<String> formErrors) { this.formErrors = formErrors; }
+    public Map<String, Object> getNormalizedValues() { return normalizedValues; }
+    public void setNormalizedValues(Map<String, Object> normalizedValues) {
+      this.normalizedValues = normalizedValues;
+    }
+    public void addFieldError(String key, String message) {
+      fieldErrors.computeIfAbsent(key, ignored -> new ArrayList<>()).add(message);
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/form/ConnectorInteractionNormalizer.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/form/ConnectorInteractionNormalizer.java
@@ -1,0 +1,166 @@
+package io.yak.ops.business.sync.offline.form;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/** 将 Link-Up Rule 协议转换为前端稳定的交互模型。 */
+public final class ConnectorInteractionNormalizer {
+
+  private final ObjectMapper objectMapper;
+
+  public ConnectorInteractionNormalizer(ObjectMapper objectMapper) {
+    this.objectMapper = objectMapper;
+  }
+
+  public List<ConnectorFormSchema.Interaction> normalize(JsonNode rules) {
+    List<ConnectorFormSchema.Interaction> result = new ArrayList<>();
+    AtomicInteger sequence = new AtomicInteger(1);
+    if (rules == null || !rules.isArray()) {
+      return result;
+    }
+    for (JsonNode rule : rules) {
+      appendRule(rule, null, result, sequence);
+    }
+    return result;
+  }
+
+  private void appendRule(JsonNode rule, ConnectorFormSchema.Condition inheritedCondition,
+      List<ConnectorFormSchema.Interaction> target, AtomicInteger sequence) {
+    if (rule == null || !rule.isObject()) {
+      return;
+    }
+    String type = rule.path("type").asText("").trim().toUpperCase(Locale.ROOT);
+    ConnectorFormSchema.Condition ownCondition = condition(rule.path("condition"));
+    ConnectorFormSchema.Condition effectiveCondition = combine(inheritedCondition, ownCondition);
+    List<String> optionKeys = strings(rule.path("optionKeys"));
+
+    switch (type) {
+      case "REQUIRED" -> target.add(interaction(sequence, "REQUIRED", optionKeys,
+          inheritedCondition, message(type, optionKeys, null)));
+      case "REQUIRED_WHEN" -> target.add(interaction(sequence, "REQUIRED", optionKeys,
+          effectiveCondition, message(type, optionKeys, ownCondition)));
+      case "EXCLUSIVE" -> target.add(interaction(sequence, "EXCLUSIVE", optionKeys,
+          inheritedCondition, message(type, optionKeys, null)));
+      case "BUNDLED" -> target.add(interaction(sequence, "BUNDLED", optionKeys,
+          inheritedCondition, message(type, optionKeys, null)));
+      case "RULE_WHEN" -> target.add(interaction(sequence, "VISIBLE", optionKeys,
+          effectiveCondition, message(type, optionKeys, ownCondition)));
+      case "CONSTRAINT" -> target.add(interaction(sequence, "VALIDATE", optionKeys,
+          effectiveCondition, message(type, optionKeys, ownCondition)));
+      default -> {
+        if (!type.isEmpty()) {
+          target.add(interaction(sequence, "VALIDATE", optionKeys,
+              effectiveCondition, "Connector 规则：" + type));
+        }
+      }
+    }
+
+    JsonNode nested = rule.path("nestedRules");
+    if (nested.isArray()) {
+      ConnectorFormSchema.Condition nestedCondition = "RULE_WHEN".equals(type)
+          ? effectiveCondition : inheritedCondition;
+      for (JsonNode nestedRule : nested) {
+        appendRule(nestedRule, nestedCondition, target, sequence);
+      }
+    }
+  }
+
+  private ConnectorFormSchema.Interaction interaction(AtomicInteger sequence, String effect,
+      List<String> optionKeys, ConnectorFormSchema.Condition condition, String message) {
+    ConnectorFormSchema.Interaction result = new ConnectorFormSchema.Interaction();
+    result.setId("rule-" + sequence.getAndIncrement());
+    result.setEffect(effect);
+    result.setOptionKeys(optionKeys);
+    result.setCondition(copy(condition));
+    result.setMessage(message);
+    return result;
+  }
+
+  private ConnectorFormSchema.Condition condition(JsonNode node) {
+    if (node == null || !node.isObject()) {
+      return null;
+    }
+    ConnectorFormSchema.Condition result = new ConnectorFormSchema.Condition();
+    result.setOptionKey(text(node, "optionKey"));
+    result.setOperator(text(node, "operator"));
+    if (node.has("expectedValue") && !node.get("expectedValue").isNull()) {
+      result.setExpectedValue(objectMapper.convertValue(node.get("expectedValue"), Object.class));
+    }
+    result.setCompareOptionKey(text(node, "compareOptionKey"));
+    result.setExtensionDescription(text(node, "extensionDescription"));
+    result.setLogicalOperator(text(node, "logicalOperator"));
+    result.setNext(condition(node.path("next")));
+    return result;
+  }
+
+  private ConnectorFormSchema.Condition combine(ConnectorFormSchema.Condition left,
+      ConnectorFormSchema.Condition right) {
+    if (left == null) {
+      return copy(right);
+    }
+    if (right == null) {
+      return copy(left);
+    }
+    ConnectorFormSchema.Condition result = copy(left);
+    ConnectorFormSchema.Condition tail = result;
+    while (tail.getNext() != null) {
+      tail = tail.getNext();
+    }
+    tail.setLogicalOperator("AND");
+    tail.setNext(copy(right));
+    return result;
+  }
+
+  private ConnectorFormSchema.Condition copy(ConnectorFormSchema.Condition source) {
+    if (source == null) {
+      return null;
+    }
+    ConnectorFormSchema.Condition result = new ConnectorFormSchema.Condition();
+    result.setOptionKey(source.getOptionKey());
+    result.setOperator(source.getOperator());
+    result.setExpectedValue(source.getExpectedValue());
+    result.setCompareOptionKey(source.getCompareOptionKey());
+    result.setExtensionDescription(source.getExtensionDescription());
+    result.setLogicalOperator(source.getLogicalOperator());
+    result.setNext(copy(source.getNext()));
+    return result;
+  }
+
+  private String message(String type, List<String> keys, ConnectorFormSchema.Condition condition) {
+    if (condition != null && condition.getExtensionDescription() != null
+        && !condition.getExtensionDescription().isBlank()) {
+      return condition.getExtensionDescription();
+    }
+    String joined = keys.isEmpty() ? "配置项" : String.join("、", keys);
+    return switch (type) {
+      case "REQUIRED" -> joined + " 为必填项";
+      case "REQUIRED_WHEN" -> "当前条件下需要填写 " + joined;
+      case "EXCLUSIVE" -> joined + " 只能选择其中一项";
+      case "BUNDLED" -> joined + " 必须同时填写或同时留空";
+      case "RULE_WHEN" -> "满足条件时启用 " + joined;
+      case "CONSTRAINT" -> joined + " 不满足 Connector 约束";
+      default -> "Connector 配置不满足规则";
+    };
+  }
+
+  private List<String> strings(JsonNode node) {
+    List<String> result = new ArrayList<>();
+    if (node != null && node.isArray()) {
+      for (JsonNode value : node) {
+        if (value.isTextual() && !value.asText().isBlank()) {
+          result.add(value.asText());
+        }
+      }
+    }
+    return result;
+  }
+
+  private String text(JsonNode node, String key) {
+    JsonNode value = node.get(key);
+    return value == null || value.isNull() || value.asText().isBlank() ? null : value.asText();
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/form/ConnectorPresentationProfile.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/form/ConnectorPresentationProfile.java
@@ -1,6 +1,7 @@
 package io.yak.ops.business.sync.offline.form;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -63,6 +64,9 @@ public final class ConnectorPresentationProfile {
     private final String valueSource;
     private final String help;
     private final String placeholder;
+    private final List<String> dependsOn;
+    private final Boolean clearWhenHidden;
+    private final OptionSourceProfile optionSource;
 
     private FieldProfile(Builder builder) {
       this.label = builder.label;
@@ -75,6 +79,9 @@ public final class ConnectorPresentationProfile {
       this.valueSource = builder.valueSource;
       this.help = builder.help;
       this.placeholder = builder.placeholder;
+      this.dependsOn = Collections.unmodifiableList(new ArrayList<>(builder.dependsOn));
+      this.clearWhenHidden = builder.clearWhenHidden;
+      this.optionSource = builder.optionSource;
     }
 
     public static Builder builder() { return new Builder(); }
@@ -88,6 +95,9 @@ public final class ConnectorPresentationProfile {
     public String getValueSource() { return valueSource; }
     public String getHelp() { return help; }
     public String getPlaceholder() { return placeholder; }
+    public List<String> getDependsOn() { return dependsOn; }
+    public Boolean getClearWhenHidden() { return clearWhenHidden; }
+    public OptionSourceProfile getOptionSource() { return optionSource; }
 
     public static final class Builder {
       private String label;
@@ -100,6 +110,9 @@ public final class ConnectorPresentationProfile {
       private String valueSource;
       private String help;
       private String placeholder;
+      private List<String> dependsOn = new ArrayList<>();
+      private Boolean clearWhenHidden;
+      private OptionSourceProfile optionSource;
 
       public Builder label(String value) { this.label = value; return this; }
       public Builder group(String value) { this.groupId = value; return this; }
@@ -111,7 +124,41 @@ public final class ConnectorPresentationProfile {
       public Builder valueSource(String value) { this.valueSource = value; return this; }
       public Builder help(String value) { this.help = value; return this; }
       public Builder placeholder(String value) { this.placeholder = value; return this; }
+      public Builder dependsOn(String... values) {
+        this.dependsOn = values == null ? new ArrayList<>() : new ArrayList<>(Arrays.asList(values));
+        return this;
+      }
+      public Builder clearWhenHidden(boolean value) { this.clearWhenHidden = value; return this; }
+      public Builder optionSource(String action, boolean searchable, boolean multiple,
+          long cacheTtlMillis, String... requestValueKeys) {
+        this.optionSource = new OptionSourceProfile(action, searchable, multiple, cacheTtlMillis,
+            requestValueKeys == null ? List.of() : Arrays.asList(requestValueKeys));
+        return this;
+      }
       public FieldProfile build() { return new FieldProfile(this); }
     }
+  }
+
+  public static final class OptionSourceProfile {
+    private final String action;
+    private final boolean searchable;
+    private final boolean multiple;
+    private final long cacheTtlMillis;
+    private final List<String> requestValueKeys;
+
+    public OptionSourceProfile(String action, boolean searchable, boolean multiple,
+        long cacheTtlMillis, List<String> requestValueKeys) {
+      this.action = action;
+      this.searchable = searchable;
+      this.multiple = multiple;
+      this.cacheTtlMillis = cacheTtlMillis;
+      this.requestValueKeys = Collections.unmodifiableList(new ArrayList<>(requestValueKeys));
+    }
+
+    public String getAction() { return action; }
+    public boolean isSearchable() { return searchable; }
+    public boolean isMultiple() { return multiple; }
+    public long getCacheTtlMillis() { return cacheTtlMillis; }
+    public List<String> getRequestValueKeys() { return requestValueKeys; }
   }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/form/ConnectorPresentationRegistry.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/form/ConnectorPresentationRegistry.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class ConnectorPresentationRegistry {
 
+  private static final long CATALOG_CACHE_TTL_MILLIS = 30_000L;
   private final Map<String, ConnectorPresentationProfile> profiles;
 
   public ConnectorPresentationRegistry() {
@@ -38,13 +39,22 @@ public class ConnectorPresentationRegistry {
   private ConnectorPresentationProfile jdbcSource() {
     Map<String, ConnectorPresentationProfile.FieldProfile> fields = new LinkedHashMap<>();
     datasourceFields(fields);
-    fields.put("table_path", field("来源表", "read", 10, "PRIMARY", "table-picker"));
-    fields.put("table_list", field("多表配置", "read", 20, "PRIMARY", "multi-table-picker"));
-    fields.put("query", field("查询 SQL", "read", 30, "PRIMARY", "sql-editor"));
+    fields.put("table_path", remoteField("来源表", "read", 10, "PRIMARY", "table-picker",
+        "LIST_TABLES", true, false));
+    fields.put("table_list", remoteField("多表配置", "read", 20, "PRIMARY", "multi-table-picker",
+        "LIST_TABLES", true, true));
+    fields.put("query", ConnectorPresentationProfile.FieldProfile.builder()
+        .label("查询 SQL").group("read").order(30).importance("PRIMARY")
+        .widget("sql-editor").clearWhenHidden(true).build());
     fields.put("where_condition", field("过滤条件", "read", 40, "COMMON", "sql-condition"));
     fields.put("read_consistency", field("读取一致性", "consistency", 10, "COMMON", "select"));
     fields.put("fetch_size", field("每批读取行数", "performance", 10, "ADVANCED", "number"));
-    fields.put("partition_column", field("分片字段", "performance", 20, "ADVANCED", "field-selector"));
+    fields.put("partition_column", ConnectorPresentationProfile.FieldProfile.builder()
+        .label("分片字段").group("performance").order(20).importance("ADVANCED")
+        .widget("field-selector").dependsOn("table_path", "query")
+        .optionSource("LIST_COLUMNS", true, false, CATALOG_CACHE_TTL_MILLIS,
+            "table_path", "query")
+        .clearWhenHidden(true).build());
     fields.put("partition_num", field("分片数量", "performance", 30, "ADVANCED", "number"));
     fields.put("partition_lower_bound", field("分片下界", "performance", 40, "EXPERT", "text"));
     fields.put("partition_upper_bound", field("分片上界", "performance", 50, "EXPERT", "text"));
@@ -55,7 +65,7 @@ public class ConnectorPresentationRegistry {
     fields.put("null_partition_single_split", field("空分片单独处理", "advanced", 40, "EXPERT", "switch"));
     fields.put("multi_table_failure_policy", field("多表失败策略", "advanced", 50, "ADVANCED", "select"));
     fields.put("int_type_narrowing", field("整数类型缩小", "advanced", 60, "EXPERT", "switch"));
-    return new ConnectorPresentationProfile("jdbc", "SOURCE", "1",
+    return new ConnectorPresentationProfile("jdbc", "SOURCE", "2",
         Arrays.asList(
             group("read", "读取配置", 10, false, false),
             group("consistency", "一致性", 20, false, false),
@@ -67,12 +77,19 @@ public class ConnectorPresentationRegistry {
   private ConnectorPresentationProfile jdbcSink() {
     Map<String, ConnectorPresentationProfile.FieldProfile> fields = new LinkedHashMap<>();
     datasourceFields(fields);
-    fields.put("table_path", field("目标表", "write", 10, "PRIMARY", "table-picker"));
+    fields.put("table_path", remoteField("目标表", "write", 10, "PRIMARY", "table-picker",
+        "LIST_TABLES", true, false));
     fields.put("schema_save_mode", field("表结构处理", "write", 20, "PRIMARY", "select"));
     fields.put("data_save_mode", field("已有数据处理", "write", 30, "PRIMARY", "select"));
     fields.put("write_mode", field("写入方式", "write", 40, "PRIMARY", "segmented"));
-    fields.put("primary_keys", field("主键字段", "write", 50, "COMMON", "field-selector"));
-    fields.put("custom_sql", field("自定义写入 SQL", "write", 60, "ADVANCED", "sql-editor"));
+    fields.put("primary_keys", ConnectorPresentationProfile.FieldProfile.builder()
+        .label("主键字段").group("write").order(50).importance("COMMON")
+        .widget("field-selector").dependsOn("table_path")
+        .optionSource("LIST_COLUMNS", true, true, CATALOG_CACHE_TTL_MILLIS, "table_path")
+        .clearWhenHidden(true).build());
+    fields.put("custom_sql", ConnectorPresentationProfile.FieldProfile.builder()
+        .label("自定义写入 SQL").group("write").order(60).importance("ADVANCED")
+        .widget("sql-editor").clearWhenHidden(true).build());
     fields.put("batch_size", field("每批写入行数", "performance", 10, "ADVANCED", "number"));
     fields.put("prepared_statement_cache_size", field("语句缓存数量", "performance", 20, "EXPERT", "number"));
     fields.put("query_timeout_sec", field("写入超时", "performance", 30, "ADVANCED", "number"));
@@ -84,7 +101,7 @@ public class ConnectorPresentationRegistry {
     fields.put("dirty_data_max_count", field("脏数据数量上限", "dirty", 50, "ADVANCED", "number"));
     fields.put("dirty_data_max_percentage", field("脏数据比例上限", "dirty", 60, "ADVANCED", "number"));
     fields.put("create_primary_key", field("自动创建主键", "advanced", 10, "ADVANCED", "switch"));
-    return new ConnectorPresentationProfile("jdbc", "SINK", "1",
+    return new ConnectorPresentationProfile("jdbc", "SINK", "2",
         Arrays.asList(
             group("write", "写入配置", 10, false, false),
             group("performance", "性能配置", 20, true, false),
@@ -112,5 +129,14 @@ public class ConnectorPresentationRegistry {
       String importance, String widget) {
     return ConnectorPresentationProfile.FieldProfile.builder()
         .label(label).group(groupId).order(order).importance(importance).widget(widget).build();
+  }
+
+  private ConnectorPresentationProfile.FieldProfile remoteField(String label, String groupId,
+      int order, String importance, String widget, String action, boolean searchable,
+      boolean multiple) {
+    return ConnectorPresentationProfile.FieldProfile.builder()
+        .label(label).group(groupId).order(order).importance(importance).widget(widget)
+        .optionSource(action, searchable, multiple, CATALOG_CACHE_TTL_MILLIS)
+        .build();
   }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/form/ConnectorFormSchemaComposerTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/form/ConnectorFormSchemaComposerTest.java
@@ -14,40 +14,45 @@ class ConnectorFormSchemaComposerTest {
       new ConnectorFormSchemaComposer(new ConnectorPresentationRegistry(), mapper);
 
   @Test
-  void shouldComposeJdbcSourceProfileAndHideDatasourceSecrets() throws Exception {
+  void shouldComposeJdbcInteractionsAndRemoteCatalogSources() throws Exception {
     JsonNode schema = mapper.readTree("""
         {
-          "connectorId":"jdbc","role":"SOURCE","schemaVersion":"1",
-          "schemaFingerprint":"sha256:source","capabilities":["MULTI_TABLE"],
+          "connectorId":"jdbc","role":"SINK","schemaVersion":"1",
+          "schemaFingerprint":"sha256:sink","capabilities":["TABLE_SCHEMA_DISCOVERY"],
           "options":[
             {"key":"url","valueType":"STRING","required":true,"semanticType":"JDBC_URL","scope":"DATASOURCE"},
-            {"key":"password","valueType":"STRING","required":false,"sensitive":true,"semanticType":"PASSWORD","scope":"DATASOURCE"},
-            {"key":"table_path","valueType":"STRING","required":false,"semanticType":"TABLE_PATH","scope":"TASK"},
-            {"key":"fetch_size","valueType":"INTEGER","defaultValue":1000,"scope":"RUNTIME"}
+            {"key":"table_path","valueType":"STRING","required":true,"semanticType":"TABLE_PATH","scope":"TASK"},
+            {"key":"write_mode","valueType":"ENUM","allowedValues":["INSERT","UPSERT"],"required":true,"scope":"TASK"},
+            {"key":"primary_keys","valueType":"LIST","required":false,"scope":"TASK"}
           ],
-          "rules":[]
+          "rules":[
+            {"type":"RULE_WHEN","optionKeys":["primary_keys"],
+             "condition":{"optionKey":"write_mode","operator":"EQ","expectedValue":"UPSERT"},
+             "nestedRules":[{"type":"REQUIRED","optionKeys":["primary_keys"]}]}
+          ]
         }
         """);
 
     ConnectorFormSchema result = composer.compose(
         new ConnectorSchemaSnapshot(schema, "REMOTE", false, LocalDateTime.now()));
 
-    assertThat(result.getProfileVersion()).isEqualTo("1");
-    assertThat(field(result, "table_path").getWidget()).isEqualTo("table-picker");
-    assertThat(field(result, "table_path").getGroupId()).isEqualTo("read");
-    assertThat(field(result, "password").isHidden()).isTrue();
-    assertThat(field(result, "password").getValueSource()).isEqualTo("DATASOURCE");
-    assertThat(field(result, "fetch_size").getImportance()).isEqualTo("ADVANCED");
+    assertThat(result.getProfileVersion()).isEqualTo("2");
+    assertThat(field(result, "table_path").getOptionSource().getAction()).isEqualTo("LIST_TABLES");
+    assertThat(field(result, "primary_keys").getOptionSource().getAction()).isEqualTo("LIST_COLUMNS");
+    assertThat(field(result, "primary_keys").getDependsOn()).containsExactly("table_path");
+    assertThat(field(result, "url").isHidden()).isTrue();
+    assertThat(result.getInteractions()).extracting(ConnectorFormSchema.Interaction::getEffect)
+        .contains("VISIBLE", "REQUIRED");
     assertThat(result.getFormFingerprint()).startsWith("sha256:");
   }
 
   @Test
-  void shouldGenerateUsableFallbackForUnknownConnector() throws Exception {
+  void shouldInferRemoteTableAndFieldActionsForUnknownConnector() throws Exception {
     JsonNode schema = mapper.readTree("""
-        {"connectorId":"http","role":"SOURCE","schemaVersion":"1","schemaFingerprint":"x",
+        {"connectorId":"warehouse","role":"SOURCE","schemaVersion":"1","schemaFingerprint":"x",
          "options":[
-           {"key":"method","valueType":"ENUM","allowedValues":["GET","POST"],"required":true,"scope":"TASK"},
-           {"key":"headers","valueType":"MAP","required":false,"scope":"TASK"}
+           {"key":"table","valueType":"STRING","semanticType":"TABLE_PATH","scope":"TASK"},
+           {"key":"partition","valueType":"STRING","semanticType":"COLUMN_NAME","scope":"TASK"}
          ],"rules":[],"capabilities":[]}
         """);
 
@@ -55,10 +60,9 @@ class ConnectorFormSchemaComposerTest {
         new ConnectorSchemaSnapshot(schema, "CACHE", true, LocalDateTime.now()));
 
     assertThat(result.getProfileVersion()).isEqualTo("auto");
-    assertThat(field(result, "method").getWidget()).isEqualTo("select");
-    assertThat(field(result, "headers").getWidget()).isEqualTo("key-value");
+    assertThat(field(result, "table").getOptionSource().getAction()).isEqualTo("LIST_TABLES");
+    assertThat(field(result, "partition").getOptionSource().getAction()).isEqualTo("LIST_COLUMNS");
     assertThat(result.getWarnings()).isNotEmpty();
-    assertThat(result.isStale()).isTrue();
   }
 
   private ConnectorFormSchema.Field field(ConnectorFormSchema schema, String key) {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/form/ConnectorFormValidationServiceTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/form/ConnectorFormValidationServiceTest.java
@@ -1,0 +1,61 @@
+package io.yak.ops.business.sync.offline.form;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.sync.offline.form.ConnectorFormValidationService.ValidationRequest;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class ConnectorFormValidationServiceTest {
+
+  @Test
+  void shouldApplyConditionalRequiredAndExclusiveRules() {
+    ConnectorFormSchema schema = new ConnectorFormSchema();
+    schema.setConnectorId("jdbc");
+    schema.setRole("SINK");
+    schema.setFields(List.of(
+        field("write_mode", "写入方式", true),
+        field("primary_keys", "主键字段", false),
+        field("custom_sql", "自定义 SQL", false)));
+
+    ConnectorFormSchema.Condition upsert = new ConnectorFormSchema.Condition();
+    upsert.setOptionKey("write_mode");
+    upsert.setOperator("EQ");
+    upsert.setExpectedValue("UPSERT");
+    schema.setInteractions(List.of(
+        interaction("REQUIRED", List.of("primary_keys"), upsert),
+        interaction("EXCLUSIVE", List.of("primary_keys", "custom_sql"), null)));
+
+    ConnectorFormSchemaService schemaService = mock(ConnectorFormSchemaService.class);
+    when(schemaService.get("jdbc", "SINK")).thenReturn(schema);
+    ConnectorFormValidationService service = new ConnectorFormValidationService(schemaService);
+
+    ValidationRequest request = new ValidationRequest();
+    request.setValues(Map.of("write_mode", "UPSERT", "custom_sql", "INSERT INTO t VALUES (?)"));
+    var result = service.validate("jdbc", "SINK", request);
+
+    assertThat(result.isValid()).isFalse();
+    assertThat(result.getFieldErrors()).containsKey("primary_keys");
+  }
+
+  private ConnectorFormSchema.Field field(String key, String label, boolean required) {
+    ConnectorFormSchema.Field field = new ConnectorFormSchema.Field();
+    field.setKey(key);
+    field.setLabel(label);
+    field.setValueType("STRING");
+    field.setRequired(required);
+    return field;
+  }
+
+  private ConnectorFormSchema.Interaction interaction(String effect, List<String> keys,
+      ConnectorFormSchema.Condition condition) {
+    ConnectorFormSchema.Interaction interaction = new ConnectorFormSchema.Interaction();
+    interaction.setEffect(effect);
+    interaction.setOptionKeys(keys);
+    interaction.setCondition(condition);
+    return interaction;
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/form/ConnectorInteractionNormalizerTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/form/ConnectorInteractionNormalizerTest.java
@@ -1,0 +1,37 @@
+package io.yak.ops.business.sync.offline.form;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class ConnectorInteractionNormalizerTest {
+
+  private final ObjectMapper mapper = new ObjectMapper();
+
+  @Test
+  void shouldNormalizeConditionalVisibilityAndNestedRequiredRule() throws Exception {
+    var rules = mapper.readTree("""
+        [
+          {
+            "type":"RULE_WHEN",
+            "optionKeys":["primary_keys"],
+            "condition":{"optionKey":"write_mode","operator":"EQ","expectedValue":"UPSERT"},
+            "nestedRules":[
+              {"type":"REQUIRED","optionKeys":["primary_keys"],"nestedRules":[]}
+            ]
+          },
+          {"type":"EXCLUSIVE","optionKeys":["table_path","query"],"nestedRules":[]}
+        ]
+        """);
+
+    List<ConnectorFormSchema.Interaction> result =
+        new ConnectorInteractionNormalizer(mapper).normalize(rules);
+
+    assertThat(result).extracting(ConnectorFormSchema.Interaction::getEffect)
+        .containsExactly("VISIBLE", "REQUIRED", "EXCLUSIVE");
+    assertThat(result.get(1).getCondition().getOptionKey()).isEqualTo("write_mode");
+    assertThat(result.get(1).getCondition().getExpectedValue()).isEqualTo("UPSERT");
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/form/ConnectorPresentationRegistryTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/form/ConnectorPresentationRegistryTest.java
@@ -9,14 +9,18 @@ class ConnectorPresentationRegistryTest {
   private final ConnectorPresentationRegistry registry = new ConnectorPresentationRegistry();
 
   @Test
-  void shouldProvideDifferentJdbcSourceAndSinkProfiles() {
+  void shouldProvideJdbcCatalogInteractions() {
     ConnectorPresentationProfile source = registry.find("jdbc", "SOURCE");
     ConnectorPresentationProfile sink = registry.find("JDBC", "sink");
 
     assertThat(source).isNotNull();
     assertThat(sink).isNotNull();
-    assertThat(source.getFields().get("table_path").getLabel()).isEqualTo("来源表");
-    assertThat(sink.getFields().get("table_path").getLabel()).isEqualTo("目标表");
+    assertThat(source.getProfileVersion()).isEqualTo("2");
+    assertThat(source.getFields().get("table_path").getOptionSource().getAction())
+        .isEqualTo("LIST_TABLES");
+    assertThat(source.getFields().get("partition_column").getDependsOn())
+        .containsExactly("table_path", "query");
+    assertThat(sink.getFields().get("primary_keys").getOptionSource().isMultiple()).isTrue();
     assertThat(source.getFields().get("password").getValueSource()).isEqualTo("DATASOURCE");
   }
 

--- a/yak-ops-ui/src/pages/batch-link-up/detail/components/ConnectorSchemaConfigSection.tsx
+++ b/yak-ops-ui/src/pages/batch-link-up/detail/components/ConnectorSchemaConfigSection.tsx
@@ -1,0 +1,169 @@
+import { Alert, Spin, Tabs } from 'antd';
+import { useEffect, useMemo, useState } from 'react';
+
+import type { SyncEditorState } from '../model';
+import ConnectorDynamicForm from '../form-schema/ConnectorDynamicForm';
+import useConnectorFormSchema from '../form-schema/useConnectorFormSchema';
+import {
+  applySchemaValue,
+  connectorIdForDataSourceType,
+  toSchemaValues,
+} from '../form-schema/valueAdapter';
+import EditorSection from './EditorSection';
+
+interface ConnectorSchemaConfigSectionProps {
+  editor: SyncEditorState;
+  sourceConfig: Record<string, any>;
+  sinkConfig: Record<string, any>;
+  onSourceChange: (patch: Record<string, any>) => void;
+  onSinkChange: (patch: Record<string, any>) => void;
+  onChannelChange: (patch: Record<string, any>) => void;
+  onValidationChange?: (errors: string[]) => void;
+}
+
+const SOURCE_MANAGED_KEYS = ['table_path', 'table_list', 'query'];
+const SINK_MANAGED_KEYS = [
+  'table_path',
+  'schema_save_mode',
+  'data_save_mode',
+  'write_mode',
+  'primary_keys',
+  'batch_size',
+];
+
+export default function ConnectorSchemaConfigSection({
+  editor,
+  sourceConfig,
+  sinkConfig,
+  onSourceChange,
+  onSinkChange,
+  onChannelChange,
+  onValidationChange,
+}: ConnectorSchemaConfigSectionProps) {
+  const sourceConnectorId = connectorIdForDataSourceType(editor.basic.sourceType);
+  const sinkConnectorId = connectorIdForDataSourceType(editor.basic.targetType);
+  const source = useConnectorFormSchema(sourceConnectorId, 'SOURCE');
+  const sink = useConnectorFormSchema(sinkConnectorId, 'SINK');
+  const [sourceErrors, setSourceErrors] = useState<string[]>([]);
+  const [sinkErrors, setSinkErrors] = useState<string[]>([]);
+  const channel = editor.workflow.channelConfig || {};
+
+  const sourceValues = useMemo(
+    () => toSchemaValues(sourceConfig, 'SOURCE'),
+    [sourceConfig],
+  );
+  const sinkValues = useMemo(
+    () => ({
+      ...toSchemaValues(sinkConfig, 'SINK'),
+      dirty_data_policy:
+        channel.dirtyDataPolicy === 'skip' ? 'SKIP' : 'FAIL_FAST',
+      dirty_data_max_count: Number(channel.dirtyDataLimit || 0),
+    }),
+    [channel.dirtyDataLimit, channel.dirtyDataPolicy, sinkConfig],
+  );
+
+  useEffect(() => {
+    if (!source.schema) setSourceErrors([]);
+  }, [source.schema, sourceConnectorId]);
+
+  useEffect(() => {
+    if (!sink.schema) setSinkErrors([]);
+  }, [sink.schema, sinkConnectorId]);
+
+  useEffect(() => {
+    onValidationChange?.([...sourceErrors, ...sinkErrors]);
+  }, [onValidationChange, sinkErrors, sourceErrors]);
+
+  const updateSink = (key: string, value: unknown) => {
+    if (key === 'dirty_data_policy') {
+      onChannelChange({
+        dirtyDataPolicy: value === 'SKIP' ? 'skip' : 'stop',
+      });
+      return;
+    }
+    if (key === 'dirty_data_max_count') {
+      onChannelChange({ dirtyDataLimit: Number(value || 0) });
+      return;
+    }
+    onSinkChange(applySchemaValue(sinkConfig, 'SINK', key, value));
+  };
+
+  if (!sourceConnectorId && !sinkConnectorId) return null;
+
+  const loading = source.loading || sink.loading;
+  const errors = [source.error, sink.error].filter(Boolean);
+  const stale = source.schema?.stale || sink.schema?.stale;
+
+  return (
+    <EditorSection title="Connector 扩展配置">
+      {stale ? (
+        <Alert
+          type="warning"
+          showIcon
+          className="mb-4"
+          message="当前使用缓存的 Connector Schema"
+          description="配置仍可编辑；Worker 恢复后会自动刷新 Schema。"
+        />
+      ) : null}
+
+      {loading ? (
+        <div className="flex min-h-36 items-center justify-center">
+          <Spin />
+        </div>
+      ) : null}
+
+      {!loading && errors.length > 0 && !source.schema && !sink.schema ? (
+        <Alert
+          type="warning"
+          showIcon
+          message="Connector Schema 暂不可用"
+          description={errors[0]}
+        />
+      ) : null}
+
+      {!loading && (source.schema || sink.schema) ? (
+        <Tabs
+          size="small"
+          items={[
+            source.schema
+              ? {
+                  key: 'source',
+                  label: 'Source 高级配置',
+                  children: (
+                    <ConnectorDynamicForm
+                      schema={source.schema}
+                      dataSourceId={editor.basic.sourceDataSourceId}
+                      values={sourceValues}
+                      excludeKeys={SOURCE_MANAGED_KEYS}
+                      onChange={(key, value) =>
+                        onSourceChange(
+                          applySchemaValue(sourceConfig, 'SOURCE', key, value),
+                        )
+                      }
+                      onValidationChange={setSourceErrors}
+                    />
+                  ),
+                }
+              : null,
+            sink.schema
+              ? {
+                  key: 'sink',
+                  label: 'Sink 高级配置',
+                  children: (
+                    <ConnectorDynamicForm
+                      schema={sink.schema}
+                      dataSourceId={editor.basic.targetDataSourceId}
+                      values={sinkValues}
+                      excludeKeys={SINK_MANAGED_KEYS}
+                      onChange={updateSink}
+                      onValidationChange={setSinkErrors}
+                    />
+                  ),
+                }
+              : null,
+          ].filter(Boolean) as any}
+        />
+      ) : null}
+    </EditorSection>
+  );
+}

--- a/yak-ops-ui/src/pages/batch-link-up/detail/components/SingleTableConfigSection.tsx
+++ b/yak-ops-ui/src/pages/batch-link-up/detail/components/SingleTableConfigSection.tsx
@@ -9,8 +9,9 @@ import {
   Spin,
   Switch,
 } from 'antd';
-import type { ReactNode } from 'react';
+import type { ChangeEvent, ReactNode } from 'react';
 
+import type { DataSourceColumnOption } from '../hooks/useDataSourceColumns';
 import EditorSection from './EditorSection';
 
 interface SingleTableConfigSectionProps {
@@ -20,6 +21,8 @@ interface SingleTableConfigSectionProps {
   targetTables: string[];
   sourceLoading: boolean;
   targetLoading: boolean;
+  primaryKeyOptions: DataSourceColumnOption[];
+  primaryKeyLoading: boolean;
   sourceReady: boolean;
   targetReady: boolean;
   onSourceChange: (patch: Record<string, any>) => void;
@@ -32,46 +35,34 @@ interface EndpointPanelProps {
   children: ReactNode;
 }
 
-function EndpointPanel({
-  icon,
-  title,
-  children,
-}: EndpointPanelProps) {
+function EndpointPanel({ icon, title, children }: EndpointPanelProps) {
   return (
     <div className="rounded-xl border border-[#ebecef] bg-[#fcfcfd] p-5">
       <div className="flex items-start gap-3">
         <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-[var(--yak-brand-color-soft-hover)] text-[var(--yak-brand-color)]">
           {icon}
         </span>
-
-        <div>
-          <div className="text-[14px] font-semibold text-[#182230]">
-            {title}
-          </div>
-        </div>
+        <div className="text-[14px] font-semibold text-[#182230]">{title}</div>
       </div>
-
       <div className="mt-5 space-y-5">{children}</div>
     </div>
   );
 }
 
-function FieldLabel({
-  children,
-  required = false,
-}: {
-  children: ReactNode;
-  required?: boolean;
-}) {
+function FieldLabel({ children, required = false }: { children: ReactNode; required?: boolean }) {
   return (
     <div className="mb-2 text-[12px] font-medium text-[#475467]">
       {children}
-      {required ? (
-        <span className="ml-1 text-[var(--yak-brand-color)]">*</span>
-      ) : null}
+      {required ? <span className="ml-1 text-[var(--yak-brand-color)]">*</span> : null}
     </div>
   );
 }
+
+const splitPrimaryKeys = (value: unknown): string[] =>
+  String(value || '')
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean);
 
 export default function SingleTableConfigSection({
   sourceConfig,
@@ -80,20 +71,17 @@ export default function SingleTableConfigSection({
   targetTables,
   sourceLoading,
   targetLoading,
+  primaryKeyOptions,
+  primaryKeyLoading,
   sourceReady,
   targetReady,
   onSourceChange,
   onSinkChange,
 }: SingleTableConfigSectionProps) {
   return (
-    <EditorSection
-      title="单表同步配置"
-    >
+    <EditorSection title="单表同步配置">
       <div className="grid grid-cols-2 gap-5 max-lg:grid-cols-1">
-        <EndpointPanel
-          icon={<DatabaseOutlined />}
-          title="Source 来源配置"
-        >
+        <EndpointPanel icon={<DatabaseOutlined />} title="Source 来源配置">
           <div>
             <FieldLabel>读取方式</FieldLabel>
             <Segmented
@@ -103,8 +91,11 @@ export default function SingleTableConfigSection({
                 { label: '选择数据表', value: 'table' },
                 { label: '自定义 SQL', value: 'sql' },
               ]}
-              onChange={(readMode) =>
-                onSourceChange({ readMode })
+              onChange={(readMode: string | number) =>
+                onSourceChange({
+                  readMode,
+                  ...(readMode === 'table' ? { sql: '' } : { table: '' }),
+                })
               }
             />
           </div>
@@ -118,9 +109,7 @@ export default function SingleTableConfigSection({
                 value={sourceConfig.sql || ''}
                 placeholder="SELECT * FROM source_table"
                 className="font-mono"
-                onChange={(event) =>
-                  onSourceChange({ sql: event.target.value })
-                }
+                onChange={(event: ChangeEvent<HTMLTextAreaElement>) => onSourceChange({ sql: event.target.value })}
               />
             </div>
           ) : (
@@ -131,42 +120,30 @@ export default function SingleTableConfigSection({
                 variant="filled"
                 disabled={!sourceReady}
                 value={sourceConfig.table || undefined}
-                options={sourceTables.map((table) => ({
-                  label: table,
-                  value: table,
-                }))}
+                options={sourceTables.map((table) => ({ label: table, value: table }))}
                 loading={sourceLoading}
-                notFoundContent={
-                  sourceLoading ? <Spin size="small" /> : undefined
-                }
-                placeholder={
-                  sourceReady
-                    ? '请选择来源表'
-                    : '请先选择来源数据源'
-                }
+                notFoundContent={sourceLoading ? <Spin size="small" /> : undefined}
+                placeholder={sourceReady ? '请选择来源表' : '请先选择来源数据源'}
                 optionFilterProp="label"
                 className="w-full"
-                onChange={(table) => onSourceChange({ table })}
+                onChange={(table: string) => onSourceChange({ table })}
               />
             </div>
           )}
         </EndpointPanel>
 
-        <EndpointPanel
-          icon={<ExportOutlined />}
-          title="Sink 目标配置"
-        >
+        <EndpointPanel icon={<ExportOutlined />} title="Sink 目标配置">
           <div className="flex items-center justify-between rounded-lg bg-[#f5f5f6] px-3.5 py-3">
-            <div>
-              <div className="text-[12px] font-medium text-[#475467]">
-                自动创建目标表
-              </div>
-            </div>
-
+            <div className="text-[12px] font-medium text-[#475467]">自动创建目标表</div>
             <Switch
               checked={Boolean(sinkConfig.autoCreateTable)}
-              onChange={(autoCreateTable) =>
-                onSinkChange({ autoCreateTable })
+              onChange={(autoCreateTable: boolean) =>
+                onSinkChange({
+                  autoCreateTable,
+                  table: '',
+                  targetTableName: '',
+                  primaryKey: '',
+                })
               }
             />
           </div>
@@ -178,16 +155,8 @@ export default function SingleTableConfigSection({
                 variant="filled"
                 disabled={!targetReady}
                 value={sinkConfig.targetTableName || ''}
-                placeholder={
-                  targetReady
-                    ? '请输入需要创建的目标表名'
-                    : '请先选择目标数据源'
-                }
-                onChange={(event) =>
-                  onSinkChange({
-                    targetTableName: event.target.value,
-                  })
-                }
+                placeholder={targetReady ? '请输入需要创建的目标表名' : '请先选择目标数据源'}
+                onChange={(event: ChangeEvent<HTMLInputElement>) => onSinkChange({ targetTableName: event.target.value })}
               />
             </div>
           ) : (
@@ -198,19 +167,12 @@ export default function SingleTableConfigSection({
                 variant="filled"
                 disabled={!targetReady}
                 value={sinkConfig.table || undefined}
-                options={targetTables.map((table) => ({
-                  label: table,
-                  value: table,
-                }))}
+                options={targetTables.map((table) => ({ label: table, value: table }))}
                 loading={targetLoading}
-                placeholder={
-                  targetReady
-                    ? '请选择目标表'
-                    : '请先选择目标数据源'
-                }
+                placeholder={targetReady ? '请选择目标表' : '请先选择目标数据源'}
                 optionFilterProp="label"
                 className="w-full"
-                onChange={(table) => onSinkChange({ table })}
+                onChange={(table: string) => onSinkChange({ table, primaryKey: '' })}
               />
             </div>
           )}
@@ -226,8 +188,11 @@ export default function SingleTableConfigSection({
                 { label: '主键更新 Upsert', value: 'upsert' },
               ]}
               className="w-full"
-              onChange={(writeMode) =>
-                onSinkChange({ writeMode })
+              onChange={(writeMode: string) =>
+                onSinkChange({
+                  writeMode,
+                  ...(writeMode === 'upsert' ? {} : { primaryKey: '' }),
+                })
               }
             />
           </div>
@@ -235,12 +200,31 @@ export default function SingleTableConfigSection({
           {sinkConfig.writeMode === 'upsert' ? (
             <div>
               <FieldLabel required>主键字段</FieldLabel>
-              <Input
+              <Select
+                mode="tags"
+                allowClear
+                showSearch
                 variant="filled"
-                value={sinkConfig.primaryKey || ''}
-                placeholder="多个字段使用英文逗号分隔"
-                onChange={(event) =>
-                  onSinkChange({ primaryKey: event.target.value })
+                value={splitPrimaryKeys(sinkConfig.primaryKey)}
+                loading={primaryKeyLoading}
+                disabled={!targetReady}
+                options={primaryKeyOptions.map((option) => ({
+                  label: option.description
+                    ? `${option.label} · ${option.description}`
+                    : option.label,
+                  value: option.value,
+                }))}
+                placeholder={
+                  primaryKeyLoading
+                    ? '正在加载字段'
+                    : primaryKeyOptions.length > 0
+                      ? '请选择一个或多个主键字段'
+                      : '请先选择来源或目标表'
+                }
+                optionFilterProp="label"
+                className="w-full"
+                onChange={(primaryKeys: string[]) =>
+                  onSinkChange({ primaryKey: primaryKeys.join(',') })
                 }
               />
             </div>

--- a/yak-ops-ui/src/pages/batch-link-up/detail/components/SyncTaskEditor.tsx
+++ b/yak-ops-ui/src/pages/batch-link-up/detail/components/SyncTaskEditor.tsx
@@ -1,5 +1,6 @@
 import type { DataSourceRecord } from '@/pages/data-source/types';
 
+import useDataSourceColumns from '../hooks/useDataSourceColumns';
 import useDataSourceTables from '../hooks/useDataSourceTables';
 import {
   endpointNode,
@@ -7,6 +8,7 @@ import {
   type SyncEditorState,
 } from '../model';
 import ChannelConfigSection from './ChannelConfigSection';
+import ConnectorSchemaConfigSection from './ConnectorSchemaConfigSection';
 import MultiTableConfigSection from './MultiTableConfigSection';
 import SingleTableConfigSection from './SingleTableConfigSection';
 import TaskBasicSection from './TaskBasicSection';
@@ -16,6 +18,7 @@ interface SyncTaskEditorProps {
   dataSources: DataSourceRecord[];
   dataSourceLoading: boolean;
   onChange: (value: SyncEditorState) => void;
+  onValidationChange?: (errors: string[]) => void;
 }
 
 export default function SyncTaskEditor({
@@ -23,6 +26,7 @@ export default function SyncTaskEditor({
   dataSources,
   dataSourceLoading,
   onChange,
+  onValidationChange,
 }: SyncTaskEditorProps) {
   const sourceNode = endpointNode(editor.workflow, 'source');
   const sinkNode = endpointNode(editor.workflow, 'sink');
@@ -36,12 +40,42 @@ export default function SyncTaskEditor({
   const sourceCatalog = useDataSourceTables(sourceId);
   const targetCatalog = useDataSourceTables(targetId);
 
+  const sourceColumnRequest = sourceConfig.readMode === 'sql'
+    ? sourceConfig.sql?.trim()
+      ? { query: sourceConfig.sql }
+      : undefined
+    : sourceConfig.table
+      ? { table_path: sourceConfig.table }
+      : undefined;
+  const targetColumnRequest = sinkConfig.autoCreateTable
+    ? sourceColumnRequest
+    : sinkConfig.table
+      ? { table_path: sinkConfig.table }
+      : undefined;
+  const primaryKeyCatalog = useDataSourceColumns(
+    sinkConfig.autoCreateTable ? sourceId : targetId,
+    targetColumnRequest,
+  );
+
   const updateSource = (patch: Record<string, any>) => {
     onChange(updateEndpointConfig(editor, 'source', patch));
   };
 
   const updateSink = (patch: Record<string, any>) => {
     onChange(updateEndpointConfig(editor, 'sink', patch));
+  };
+
+  const updateChannel = (patch: Record<string, any>) => {
+    onChange({
+      ...editor,
+      workflow: {
+        ...editor.workflow,
+        channelConfig: {
+          ...(editor.workflow.channelConfig || {}),
+          ...patch,
+        },
+      },
+    });
   };
 
   return (
@@ -72,12 +106,24 @@ export default function SyncTaskEditor({
           targetTables={targetCatalog.tables}
           sourceLoading={sourceCatalog.loading}
           targetLoading={targetCatalog.loading}
+          primaryKeyOptions={primaryKeyCatalog.columns}
+          primaryKeyLoading={primaryKeyCatalog.loading}
           sourceReady={Boolean(sourceId)}
           targetReady={Boolean(targetId)}
           onSourceChange={updateSource}
           onSinkChange={updateSink}
         />
       )}
+
+      <ConnectorSchemaConfigSection
+        editor={editor}
+        sourceConfig={sourceConfig}
+        sinkConfig={sinkConfig}
+        onSourceChange={updateSource}
+        onSinkChange={updateSink}
+        onChannelChange={updateChannel}
+        onValidationChange={onValidationChange}
+      />
 
       <ChannelConfigSection
         editor={editor}

--- a/yak-ops-ui/src/pages/batch-link-up/detail/form-schema/ConnectorDynamicForm.tsx
+++ b/yak-ops-ui/src/pages/batch-link-up/detail/form-schema/ConnectorDynamicForm.tsx
@@ -1,0 +1,367 @@
+import {
+  Collapse,
+  Input,
+  InputNumber,
+  Segmented,
+  Select,
+  Spin,
+  Switch,
+  Tooltip,
+} from 'antd';
+import { CircleHelp } from 'lucide-react';
+import { useEffect, useMemo, type ChangeEvent } from 'react';
+
+import { evaluateConnectorForm, isEmptyValue } from './ruleEngine';
+import type {
+  ConnectorFormField,
+  ConnectorFormSchema,
+  ConnectorFormValues,
+} from './types';
+import useRemoteOptions from './useRemoteOptions';
+
+interface ConnectorDynamicFormProps {
+  schema: ConnectorFormSchema;
+  dataSourceId: string;
+  values: ConnectorFormValues;
+  excludeKeys?: string[];
+  onChange: (key: string, value: unknown) => void;
+  onValidationChange?: (errors: string[]) => void;
+}
+
+interface FieldControlProps {
+  schema: ConnectorFormSchema;
+  field: ConnectorFormField;
+  dataSourceId: string;
+  values: ConnectorFormValues;
+  disabled: boolean;
+  error: boolean;
+  onChange: (value: unknown) => void;
+}
+
+const staticOptions = (field: ConnectorFormField) =>
+  (field.allowedValues || []).map((value) => ({
+    label: String(value),
+    value,
+  }));
+
+function RemoteSelectControl({
+  schema,
+  field,
+  dataSourceId,
+  values,
+  disabled,
+  error,
+  onChange,
+}: FieldControlProps) {
+  const remote = useRemoteOptions(schema, field, dataSourceId, values);
+  const multiple =
+    field.optionSource?.multiple ||
+    field.widget === 'multi-table-picker' ||
+    field.valueType === 'LIST';
+
+  return (
+    <Select
+      showSearch
+      allowClear
+      variant="filled"
+      mode={multiple ? 'multiple' : undefined}
+      value={values[field.key] as any}
+      disabled={disabled || !remote.ready}
+      loading={remote.loading}
+      status={error ? 'error' : undefined}
+      filterOption={field.optionSource?.searchable ? false : undefined}
+      onSearch={remote.onSearch}
+      options={remote.options.map((option) => ({
+        label: option.description
+          ? `${option.label} · ${option.description}`
+          : option.label,
+        value: option.value as any,
+      }))}
+      notFoundContent={remote.loading ? <Spin size="small" /> : undefined}
+      placeholder={
+        !dataSourceId
+          ? '请先选择数据源'
+          : !remote.ready
+            ? '请先完成依赖配置'
+            : field.placeholder || `请选择${field.label}`
+      }
+      className="w-full"
+      onChange={onChange}
+    />
+  );
+}
+
+function JsonControl({
+  field,
+  values,
+  disabled,
+  error,
+  onChange,
+}: FieldControlProps) {
+  const value = values[field.key];
+  const text = typeof value === 'string'
+    ? value
+    : value === undefined
+      ? ''
+      : JSON.stringify(value, null, 2);
+
+  return (
+    <Input.TextArea
+      rows={5}
+      variant="filled"
+      className="font-mono"
+      value={text}
+      disabled={disabled}
+      status={error ? 'error' : undefined}
+      placeholder={field.placeholder || '请输入 JSON'}
+      onChange={(event: ChangeEvent<HTMLTextAreaElement>) => {
+        const next = event.target.value;
+        if (!next.trim()) {
+          onChange(undefined);
+          return;
+        }
+        try {
+          onChange(JSON.parse(next));
+        } catch {
+          onChange(next);
+        }
+      }}
+    />
+  );
+}
+
+function FieldControl(props: FieldControlProps) {
+  const { field, values, disabled, error, onChange } = props;
+  const value = values[field.key];
+
+  if (field.optionSource) return <RemoteSelectControl {...props} />;
+
+  if (field.widget === 'switch' || field.valueType === 'BOOLEAN') {
+    return <Switch checked={Boolean(value)} disabled={disabled} onChange={onChange} />;
+  }
+
+  if (field.widget === 'number' || ['INTEGER', 'LONG', 'FLOAT', 'DOUBLE', 'DECIMAL'].includes(field.valueType)) {
+    return (
+      <InputNumber
+        variant="filled"
+        value={value as number | undefined}
+        disabled={disabled}
+        status={error ? 'error' : undefined}
+        className="!w-full"
+        placeholder={field.placeholder}
+        onChange={onChange}
+      />
+    );
+  }
+
+  if (field.widget === 'segmented') {
+    return (
+      <Segmented
+        block
+        value={value as any}
+        disabled={disabled}
+        options={staticOptions(field) as any}
+        onChange={onChange}
+      />
+    );
+  }
+
+  if (field.widget === 'select' || field.valueType === 'ENUM') {
+    return (
+      <Select
+        allowClear
+        showSearch
+        variant="filled"
+        value={value as any}
+        disabled={disabled}
+        status={error ? 'error' : undefined}
+        options={staticOptions(field) as any}
+        className="w-full"
+        placeholder={field.placeholder || `请选择${field.label}`}
+        onChange={onChange}
+      />
+    );
+  }
+
+  if (['key-value', 'json-editor'].includes(field.widget) || ['MAP', 'OBJECT'].includes(field.valueType)) {
+    return <JsonControl {...props} />;
+  }
+
+  if (field.widget === 'list-editor' || field.valueType === 'LIST') {
+    return (
+      <Select
+        mode="tags"
+        variant="filled"
+        value={Array.isArray(value) ? value : []}
+        disabled={disabled}
+        status={error ? 'error' : undefined}
+        tokenSeparators={[',', '\n']}
+        className="w-full"
+        placeholder={field.placeholder || '输入后按回车添加'}
+        onChange={onChange}
+      />
+    );
+  }
+
+  if (['sql-editor', 'sql-condition'].includes(field.widget)) {
+    return (
+      <Input.TextArea
+        rows={field.widget === 'sql-editor' ? 7 : 3}
+        variant="filled"
+        value={(value as string) || ''}
+        disabled={disabled}
+        status={error ? 'error' : undefined}
+        className="font-mono"
+        placeholder={field.placeholder || `请输入${field.label}`}
+        onChange={(event: ChangeEvent<HTMLTextAreaElement>) => onChange(event.target.value)}
+      />
+    );
+  }
+
+  return (
+    <Input
+      type={field.widget === 'password' ? 'password' : 'text'}
+      variant="filled"
+      value={(value as string) || ''}
+      disabled={disabled}
+      status={error ? 'error' : undefined}
+      placeholder={field.placeholder || `请输入${field.label}`}
+      onChange={(event: ChangeEvent<HTMLInputElement>) => onChange(event.target.value)}
+    />
+  );
+}
+
+export default function ConnectorDynamicForm({
+  schema,
+  dataSourceId,
+  values,
+  excludeKeys = [],
+  onChange,
+  onValidationChange,
+}: ConnectorDynamicFormProps) {
+  const effectiveValues = useMemo(() => {
+    const defaults = Object.fromEntries(
+      schema.fields
+        .filter((field) => field.defaultValue !== undefined && field.defaultValue !== null)
+        .map((field) => [field.key, field.defaultValue]),
+    );
+    return { ...defaults, ...values };
+  }, [schema.fields, values]);
+  const evaluation = useMemo(
+    () => evaluateConnectorForm(schema, effectiveValues),
+    [effectiveValues, schema],
+  );
+  const excluded = useMemo(() => new Set(excludeKeys), [excludeKeys]);
+
+  const validationErrors = useMemo(
+    () => [
+      ...evaluation.formErrors,
+      ...Object.values(evaluation.fieldStates).flatMap((state) => state.errors),
+    ],
+    [evaluation],
+  );
+
+  useEffect(() => {
+    onValidationChange?.(validationErrors);
+  }, [onValidationChange, validationErrors]);
+
+  useEffect(() => {
+    for (const field of schema.fields) {
+      const state = evaluation.fieldStates[field.key];
+      if (
+        field.clearWhenHidden &&
+        state &&
+        !state.visible &&
+        !isEmptyValue(values[field.key])
+      ) {
+        onChange(field.key, undefined);
+        break;
+      }
+    }
+  }, [evaluation.fieldStates, onChange, schema.fields, values]);
+
+  const items = schema.groups
+    .filter((group) => !group.hidden)
+    .map((group) => {
+      const fields = schema.fields.filter((field) => {
+        const state = evaluation.fieldStates[field.key];
+        return (
+          field.groupId === group.id &&
+          !field.hidden &&
+          !excluded.has(field.key) &&
+          state?.visible
+        );
+      });
+      if (fields.length === 0) return null;
+
+      return {
+        key: group.id,
+        label: (
+          <span className="text-[13px] font-semibold text-[#344054]">
+            {group.title}
+          </span>
+        ),
+        children: (
+          <div className="grid grid-cols-2 gap-x-5 gap-y-4 max-md:grid-cols-1">
+            {fields.map((field) => {
+              const state = evaluation.fieldStates[field.key];
+              return (
+                <div
+                  key={field.key}
+                  className={['sql-editor', 'sql-condition', 'json-editor', 'key-value'].includes(field.widget)
+                    ? 'col-span-2 max-md:col-span-1'
+                    : undefined}
+                >
+                  <div className="mb-2 flex items-center gap-1 text-[12px] font-medium text-[#475467]">
+                    <span>{field.label}</span>
+                    {state.required ? (
+                      <span className="text-[var(--yak-brand-color)]">*</span>
+                    ) : null}
+                    {field.help || field.description ? (
+                      <Tooltip title={field.help || field.description}>
+                        <CircleHelp size={13} className="text-[#98a2b3]" />
+                      </Tooltip>
+                    ) : null}
+                  </div>
+
+                  <FieldControl
+                    schema={schema}
+                    field={field}
+                    dataSourceId={dataSourceId}
+                    values={effectiveValues}
+                    disabled={state.disabled}
+                    error={state.errors.length > 0}
+                    onChange={(value) => onChange(field.key, value)}
+                  />
+
+                  {state.errors.length > 0 ? (
+                    <div className="mt-1 text-[12px] text-[#d92d20]">
+                      {state.errors[0]}
+                    </div>
+                  ) : null}
+                </div>
+              );
+            })}
+          </div>
+        ),
+      };
+    })
+    .filter(Boolean) as any[];
+
+  return (
+    <div>
+      {evaluation.formErrors.length > 0 ? (
+        <div className="mb-3 rounded-lg bg-[#fff1f0] px-3 py-2 text-[12px] text-[#d92d20]">
+          {evaluation.formErrors[0]}
+        </div>
+      ) : null}
+      <Collapse
+        bordered={false}
+        ghost
+        defaultActiveKey={schema.groups.filter((group) => !group.collapsed).map((group) => group.id)}
+        items={items}
+        className="[&_.ant-collapse-content-box]:!px-0 [&_.ant-collapse-header]:!px-0"
+      />
+    </div>
+  );
+}

--- a/yak-ops-ui/src/pages/batch-link-up/detail/form-schema/ruleEngine.test.ts
+++ b/yak-ops-ui/src/pages/batch-link-up/detail/form-schema/ruleEngine.test.ts
@@ -1,0 +1,79 @@
+import { evaluateConnectorForm } from './ruleEngine';
+import type { ConnectorFormSchema } from './types';
+
+const schema: ConnectorFormSchema = {
+  connectorId: 'jdbc',
+  role: 'SINK',
+  stale: false,
+  capabilities: [],
+  warnings: [],
+  rules: [],
+  groups: [{ id: 'write', title: '写入', order: 1, collapsed: false, hidden: false }],
+  fields: [
+    {
+      key: 'write_mode',
+      label: '写入方式',
+      valueType: 'ENUM',
+      allowedValues: ['INSERT', 'UPSERT'],
+      fallbackKeys: [],
+      required: true,
+      sensitive: false,
+      groupId: 'write',
+      order: 1,
+      widget: 'select',
+      hidden: false,
+      readOnly: false,
+      dependsOn: [],
+      clearWhenHidden: false,
+    },
+    {
+      key: 'primary_keys',
+      label: '主键字段',
+      valueType: 'LIST',
+      allowedValues: [],
+      fallbackKeys: [],
+      required: false,
+      sensitive: false,
+      groupId: 'write',
+      order: 2,
+      widget: 'field-selector',
+      hidden: false,
+      readOnly: false,
+      dependsOn: ['table_path'],
+      clearWhenHidden: true,
+    },
+  ],
+  interactions: [
+    {
+      id: 'rule-1',
+      effect: 'VISIBLE',
+      optionKeys: ['primary_keys'],
+      condition: {
+        optionKey: 'write_mode',
+        operator: 'EQ',
+        expectedValue: 'UPSERT',
+      },
+    },
+    {
+      id: 'rule-2',
+      effect: 'REQUIRED',
+      optionKeys: ['primary_keys'],
+      condition: {
+        optionKey: 'write_mode',
+        operator: 'EQ',
+        expectedValue: 'UPSERT',
+      },
+    },
+  ],
+};
+
+test('applies conditional visibility and required state', () => {
+  const insert = evaluateConnectorForm(schema, { write_mode: 'INSERT' });
+  expect(insert.fieldStates.primary_keys.visible).toBe(false);
+  expect(insert.valid).toBe(true);
+
+  const upsert = evaluateConnectorForm(schema, { write_mode: 'UPSERT' });
+  expect(upsert.fieldStates.primary_keys.visible).toBe(true);
+  expect(upsert.fieldStates.primary_keys.required).toBe(true);
+  expect(upsert.valid).toBe(false);
+});

--- a/yak-ops-ui/src/pages/batch-link-up/detail/form-schema/ruleEngine.ts
+++ b/yak-ops-ui/src/pages/batch-link-up/detail/form-schema/ruleEngine.ts
@@ -1,0 +1,246 @@
+import type {
+  ConnectorCondition,
+  ConnectorFormEvaluation,
+  ConnectorFormSchema,
+  ConnectorFormValues,
+} from './types';
+
+export const isEmptyValue = (value: unknown): boolean => {
+  if (value === undefined || value === null) return true;
+  if (typeof value === 'string') return value.trim().length === 0;
+  if (Array.isArray(value)) return value.length === 0;
+  if (typeof value === 'object') return Object.keys(value as object).length === 0;
+  return false;
+};
+
+const normalize = (value?: string) =>
+  (value || '').trim().toUpperCase().replaceAll('-', '_');
+
+const asString = (value: unknown) =>
+  value === undefined || value === null ? '' : String(value).trim();
+
+const asNumber = (value: unknown): number | undefined => {
+  const result = Number(value);
+  return Number.isFinite(result) ? result : undefined;
+};
+
+const equalsValue = (left: unknown, right: unknown): boolean => {
+  if (Array.isArray(left)) return left.some((item) => equalsValue(item, right));
+  if (Array.isArray(right)) return right.some((item) => equalsValue(left, item));
+  const leftNumber = asNumber(left);
+  const rightNumber = asNumber(right);
+  if (leftNumber !== undefined && rightNumber !== undefined) {
+    return leftNumber === rightNumber;
+  }
+  return left === right || asString(left).toLowerCase() === asString(right).toLowerCase();
+};
+
+const contains = (container: unknown, value: unknown): boolean => {
+  if (Array.isArray(container)) {
+    return container.some((item) => equalsValue(item, value));
+  }
+  if (container && typeof container === 'object') {
+    return Object.entries(container as Record<string, unknown>).some(
+      ([key, item]) => equalsValue(key, value) || equalsValue(item, value),
+    );
+  }
+  return asString(container).includes(asString(value));
+};
+
+const evaluateSingle = (
+  condition: ConnectorCondition,
+  values: ConnectorFormValues,
+): boolean => {
+  const actual = condition.optionKey ? values[condition.optionKey] : undefined;
+  const expected = condition.compareOptionKey
+    ? values[condition.compareOptionKey]
+    : condition.expectedValue;
+  const operator = normalize(condition.operator);
+
+  switch (operator) {
+    case 'EQ':
+    case 'EQUAL':
+    case 'EQUALS':
+    case 'IS':
+      return equalsValue(actual, expected);
+    case 'NE':
+    case 'NOT_EQUAL':
+    case 'NOT_EQUALS':
+    case 'IS_NOT':
+      return !equalsValue(actual, expected);
+    case 'IN':
+      return contains(expected, actual);
+    case 'NOT_IN':
+      return !contains(expected, actual);
+    case 'CONTAINS':
+      return contains(actual, expected);
+    case 'NOT_CONTAINS':
+      return !contains(actual, expected);
+    case 'EXISTS':
+    case 'PRESENT':
+    case 'NOT_EMPTY':
+      return !isEmptyValue(actual);
+    case 'NOT_EXISTS':
+    case 'ABSENT':
+    case 'EMPTY':
+      return isEmptyValue(actual);
+    case 'TRUE':
+    case 'IS_TRUE':
+      return actual === true || actual === 'true' || actual === 1;
+    case 'FALSE':
+    case 'IS_FALSE':
+      return actual === false || actual === 'false' || actual === 0;
+    case 'GT':
+    case 'GREATER_THAN':
+      return Number(actual) > Number(expected);
+    case 'GTE':
+    case 'GREATER_THAN_OR_EQUAL':
+      return Number(actual) >= Number(expected);
+    case 'LT':
+    case 'LESS_THAN':
+      return Number(actual) < Number(expected);
+    case 'LTE':
+    case 'LESS_THAN_OR_EQUAL':
+      return Number(actual) <= Number(expected);
+    case 'STARTS_WITH':
+      return asString(actual).startsWith(asString(expected));
+    case 'ENDS_WITH':
+      return asString(actual).endsWith(asString(expected));
+    case 'MATCHES':
+    case 'REGEX':
+      try {
+        return new RegExp(asString(expected)).test(asString(actual));
+      } catch {
+        return true;
+      }
+    case 'EXTENSION':
+    case '':
+      return true;
+    default:
+      return true;
+  }
+};
+
+export const evaluateCondition = (
+  condition: ConnectorCondition | undefined,
+  values: ConnectorFormValues,
+): boolean => {
+  if (!condition) return true;
+  const current = evaluateSingle(condition, values);
+  if (!condition.next) return current;
+  const next = evaluateCondition(condition.next, values);
+  return normalize(condition.logicalOperator) === 'OR'
+    ? current || next
+    : current && next;
+};
+
+const message = (value: string | undefined, fallback: string) =>
+  value?.trim() || fallback;
+
+export const evaluateConnectorForm = (
+  schema: ConnectorFormSchema,
+  values: ConnectorFormValues,
+): ConnectorFormEvaluation => {
+  const fieldStates = Object.fromEntries(
+    schema.fields.map((field) => [
+      field.key,
+      {
+        visible: !field.hidden,
+        required: field.required,
+        disabled: field.readOnly,
+        errors: [] as string[],
+      },
+    ]),
+  );
+  const formErrors: string[] = [];
+
+  for (const interaction of schema.interactions || []) {
+    const active = evaluateCondition(interaction.condition, values);
+    const effect = normalize(interaction.effect);
+
+    if (effect === 'VISIBLE') {
+      for (const key of interaction.optionKeys) {
+        if (fieldStates[key]) fieldStates[key].visible &&= active;
+      }
+      continue;
+    }
+
+    if (effect === 'REQUIRED' && active) {
+      for (const key of interaction.optionKeys) {
+        if (fieldStates[key]) fieldStates[key].required = true;
+      }
+      continue;
+    }
+
+    if (effect === 'DISABLED') {
+      for (const key of interaction.optionKeys) {
+        if (fieldStates[key]) fieldStates[key].disabled ||= active;
+      }
+      continue;
+    }
+
+    if (effect === 'EXCLUSIVE' && active) {
+      const selected = interaction.optionKeys.filter(
+        (key) => !isEmptyValue(values[key]),
+      );
+      if (selected.length > 1) {
+        formErrors.push(
+          message(interaction.message, '互斥配置只能填写其中一项'),
+        );
+      }
+      continue;
+    }
+
+    if (effect === 'BUNDLED' && active) {
+      const selected = interaction.optionKeys.filter(
+        (key) => !isEmptyValue(values[key]),
+      );
+      if (selected.length > 0 && selected.length < interaction.optionKeys.length) {
+        formErrors.push(
+          message(interaction.message, '关联配置必须同时填写或同时留空'),
+        );
+      }
+      continue;
+    }
+
+    if (effect === 'VALIDATE' && !active) {
+      const error = message(
+        interaction.message,
+        '配置不满足 Connector 约束',
+      );
+      if (interaction.optionKeys.length === 1 && fieldStates[interaction.optionKeys[0]]) {
+        fieldStates[interaction.optionKeys[0]].errors.push(error);
+      } else {
+        formErrors.push(error);
+      }
+    }
+  }
+
+  for (const field of schema.fields) {
+    const state = fieldStates[field.key];
+    if (!state?.visible) continue;
+    if (state.required && isEmptyValue(values[field.key])) {
+      state.errors.push(`${field.label}不能为空`);
+    }
+    if (
+      !isEmptyValue(values[field.key]) &&
+      field.allowedValues?.length > 0
+    ) {
+      const selected: unknown[] = Array.isArray(values[field.key])
+        ? (values[field.key] as unknown[])
+        : [values[field.key]];
+      const invalid = selected.some(
+        (value) => !field.allowedValues.some((allowed) => equalsValue(allowed, value)),
+      );
+      if (invalid) state.errors.push(`${field.label}包含不支持的选项`);
+    }
+  }
+
+  return {
+    valid:
+      formErrors.length === 0 &&
+      Object.values(fieldStates).every((state) => state.errors.length === 0),
+    fieldStates,
+    formErrors: Array.from(new Set(formErrors)),
+  };
+};

--- a/yak-ops-ui/src/pages/batch-link-up/detail/form-schema/service.ts
+++ b/yak-ops-ui/src/pages/batch-link-up/detail/form-schema/service.ts
@@ -1,0 +1,50 @@
+import type { ApiResponse } from '@/services/http/response';
+import HttpUtils from '@/utils/HttpUtils';
+
+import type {
+  ConnectorActionResult,
+  ConnectorFormSchema,
+  ConnectorFormValues,
+  ConnectorRole,
+  ConnectorValidationResult,
+} from './types';
+
+const PREFIX = '/api/v1/job/batch-control/connectors';
+
+export const connectorFormApi = {
+  schema: (
+    connectorId: string,
+    role: ConnectorRole,
+  ): Promise<ApiResponse<ConnectorFormSchema>> =>
+    HttpUtils.get(
+      `${PREFIX}/${encodeURIComponent(connectorId)}/form-schema?role=${encodeURIComponent(role)}`,
+    ),
+
+  action: (
+    action: string,
+    payload: {
+      dataSourceId: string | number;
+      connectorId: string;
+      role: ConnectorRole;
+      fieldKey?: string;
+      keyword?: string;
+      matchMode?: string;
+      values: ConnectorFormValues;
+    },
+  ): Promise<ApiResponse<ConnectorActionResult>> =>
+    HttpUtils.post(
+      `${PREFIX}/actions/${encodeURIComponent(action)}`,
+      payload,
+    ),
+
+  validate: (
+    connectorId: string,
+    role: ConnectorRole,
+    values: ConnectorFormValues,
+    context: Record<string, unknown> = {},
+  ): Promise<ApiResponse<ConnectorValidationResult>> =>
+    HttpUtils.post(
+      `${PREFIX}/${encodeURIComponent(connectorId)}/form-schema/validate?role=${encodeURIComponent(role)}`,
+      { values, context },
+    ),
+};

--- a/yak-ops-ui/src/pages/batch-link-up/detail/form-schema/types.ts
+++ b/yak-ops-ui/src/pages/batch-link-up/detail/form-schema/types.ts
@@ -1,0 +1,115 @@
+export type ConnectorRole = 'SOURCE' | 'SINK';
+
+export interface ConnectorCondition {
+  optionKey?: string;
+  operator?: string;
+  expectedValue?: unknown;
+  compareOptionKey?: string;
+  extensionDescription?: string;
+  logicalOperator?: 'AND' | 'OR' | string;
+  next?: ConnectorCondition;
+}
+
+export interface ConnectorInteraction {
+  id: string;
+  effect: 'VISIBLE' | 'REQUIRED' | 'DISABLED' | 'EXCLUSIVE' | 'BUNDLED' | 'VALIDATE' | string;
+  optionKeys: string[];
+  condition?: ConnectorCondition;
+  message?: string;
+}
+
+export interface ConnectorOptionSource {
+  action: string;
+  searchable: boolean;
+  multiple: boolean;
+  cacheTtlMillis: number;
+  requestValueKeys: string[];
+}
+
+export interface ConnectorFormField {
+  key: string;
+  label: string;
+  description?: string;
+  help?: string;
+  placeholder?: string;
+  valueType: string;
+  javaType?: string;
+  elementType?: string;
+  defaultValue?: unknown;
+  allowedValues: unknown[];
+  fallbackKeys: string[];
+  required: boolean;
+  sensitive: boolean;
+  semanticType?: string;
+  scope?: string;
+  groupId: string;
+  order: number;
+  importance?: string;
+  widget: string;
+  hidden: boolean;
+  readOnly: boolean;
+  valueSource?: string;
+  dependsOn: string[];
+  clearWhenHidden: boolean;
+  optionSource?: ConnectorOptionSource;
+}
+
+export interface ConnectorFormGroup {
+  id: string;
+  title: string;
+  order: number;
+  collapsed: boolean;
+  hidden: boolean;
+}
+
+export interface ConnectorFormSchema {
+  connectorId: string;
+  role: ConnectorRole;
+  schemaVersion?: string;
+  schemaFingerprint?: string;
+  profileVersion?: string;
+  formFingerprint?: string;
+  source?: 'REMOTE' | 'CACHE' | string;
+  stale: boolean;
+  syncedAt?: string;
+  capabilities: string[];
+  groups: ConnectorFormGroup[];
+  fields: ConnectorFormField[];
+  interactions: ConnectorInteraction[];
+  rules?: unknown;
+  warnings: string[];
+}
+
+export type ConnectorFormValues = Record<string, unknown>;
+
+export interface ConnectorFieldState {
+  visible: boolean;
+  required: boolean;
+  disabled: boolean;
+  errors: string[];
+}
+
+export interface ConnectorFormEvaluation {
+  valid: boolean;
+  fieldStates: Record<string, ConnectorFieldState>;
+  formErrors: string[];
+}
+
+export interface ConnectorActionOption {
+  value: unknown;
+  label: string;
+  description?: string;
+  meta?: Record<string, unknown>;
+}
+
+export interface ConnectorActionResult {
+  options?: ConnectorActionOption[];
+  data?: unknown;
+}
+
+export interface ConnectorValidationResult {
+  valid: boolean;
+  fieldErrors: Record<string, string[]>;
+  formErrors: string[];
+  normalizedValues: ConnectorFormValues;
+}

--- a/yak-ops-ui/src/pages/batch-link-up/detail/form-schema/useConnectorFormSchema.ts
+++ b/yak-ops-ui/src/pages/batch-link-up/detail/form-schema/useConnectorFormSchema.ts
@@ -1,0 +1,53 @@
+import { useEffect, useState } from 'react';
+
+import { isApiSuccess, responseMessage } from '../model';
+import { connectorFormApi } from './service';
+import type { ConnectorFormSchema, ConnectorRole } from './types';
+
+export default function useConnectorFormSchema(
+  connectorId: string,
+  role: ConnectorRole,
+) {
+  const [schema, setSchema] = useState<ConnectorFormSchema>();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (!connectorId) {
+      setSchema(undefined);
+      setLoading(false);
+      setError('');
+      return;
+    }
+
+    let active = true;
+    setLoading(true);
+    setError('');
+
+    connectorFormApi
+      .schema(connectorId, role)
+      .then((response) => {
+        if (!active) return;
+        if (!isApiSuccess(response) || !response.data) {
+          setSchema(undefined);
+          setError(responseMessage(response, '获取 Connector Form Schema 失败'));
+          return;
+        }
+        setSchema(response.data);
+      })
+      .catch((reason: any) => {
+        if (!active) return;
+        setSchema(undefined);
+        setError(reason?.message || '获取 Connector Form Schema 失败');
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [connectorId, role]);
+
+  return { schema, loading, error };
+}

--- a/yak-ops-ui/src/pages/batch-link-up/detail/form-schema/useRemoteOptions.ts
+++ b/yak-ops-ui/src/pages/batch-link-up/detail/form-schema/useRemoteOptions.ts
@@ -1,0 +1,117 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import { isApiSuccess } from '../model';
+import { connectorFormApi } from './service';
+import type {
+  ConnectorActionOption,
+  ConnectorFormField,
+  ConnectorFormSchema,
+  ConnectorFormValues,
+} from './types';
+
+interface CacheEntry {
+  expiresAt: number;
+  options: ConnectorActionOption[];
+}
+
+const optionCache = new Map<string, CacheEntry>();
+
+const hasValue = (value: unknown) =>
+  value !== undefined &&
+  value !== null &&
+  (!Array.isArray(value) || value.length > 0) &&
+  (typeof value !== 'string' || value.trim().length > 0);
+
+export default function useRemoteOptions(
+  schema: ConnectorFormSchema,
+  field: ConnectorFormField,
+  dataSourceId: string,
+  values: ConnectorFormValues,
+) {
+  const [options, setOptions] = useState<ConnectorActionOption[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [keyword, setKeyword] = useState('');
+  const requestIdRef = useRef(0);
+  const source = field.optionSource;
+
+  const requestValues = useMemo(() => {
+    const keys = source?.requestValueKeys || [];
+    if (keys.length === 0) return values;
+    return Object.fromEntries(
+      keys
+        .filter((key) => hasValue(values[key]))
+        .map((key) => [key, values[key]]),
+    );
+  }, [source?.requestValueKeys, values]);
+
+  const ready = useMemo(() => {
+    if (!source || !dataSourceId) return false;
+    if (source.action !== 'LIST_COLUMNS') return true;
+    return Object.values(requestValues).some(hasValue);
+  }, [dataSourceId, requestValues, source]);
+
+  const cacheKey = useMemo(
+    () =>
+      JSON.stringify({
+        action: source?.action,
+        connectorId: schema.connectorId,
+        role: schema.role,
+        fieldKey: field.key,
+        dataSourceId,
+        keyword,
+        values: requestValues,
+      }),
+    [dataSourceId, field.key, keyword, requestValues, schema.connectorId, schema.role, source?.action],
+  );
+
+  const load = useCallback(async () => {
+    if (!source || !ready) {
+      requestIdRef.current += 1;
+      setOptions([]);
+      setLoading(false);
+      return;
+    }
+
+    const cached = optionCache.get(cacheKey);
+    if (cached && cached.expiresAt > Date.now()) {
+      setOptions(cached.options);
+      return;
+    }
+
+    const requestId = ++requestIdRef.current;
+    setLoading(true);
+    try {
+      const response = await connectorFormApi.action(source.action, {
+        dataSourceId,
+        connectorId: schema.connectorId,
+        role: schema.role,
+        fieldKey: field.key,
+        keyword,
+        values: requestValues,
+      });
+      if (requestId !== requestIdRef.current) return;
+      const next = isApiSuccess(response) ? response.data?.options || [] : [];
+      optionCache.set(cacheKey, {
+        options: next,
+        expiresAt: Date.now() + Math.max(1000, source.cacheTtlMillis || 30000),
+      });
+      setOptions(next);
+    } catch {
+      if (requestId === requestIdRef.current) setOptions([]);
+    } finally {
+      if (requestId === requestIdRef.current) setLoading(false);
+    }
+  }, [cacheKey, dataSourceId, field.key, keyword, ready, requestValues, schema.connectorId, schema.role, source]);
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => void load(), keyword ? 250 : 0);
+    return () => window.clearTimeout(timer);
+  }, [keyword, load]);
+
+  return {
+    options,
+    loading,
+    ready,
+    onSearch: source?.searchable ? setKeyword : undefined,
+  };
+}

--- a/yak-ops-ui/src/pages/batch-link-up/detail/form-schema/validateEditorConnectorForms.ts
+++ b/yak-ops-ui/src/pages/batch-link-up/detail/form-schema/validateEditorConnectorForms.ts
@@ -1,0 +1,67 @@
+import {
+  endpointNode,
+  isApiSuccess,
+  type SyncEditorState,
+} from '../model';
+import { connectorFormApi } from './service';
+import {
+  connectorIdForDataSourceType,
+  toSchemaValues,
+} from './valueAdapter';
+
+const resultErrors = (result: any): string[] => {
+  if (!result || result.valid) return [];
+  return [
+    ...(result.formErrors || []),
+    ...Object.values(result.fieldErrors || {}).flatMap((errors) =>
+      Array.isArray(errors) ? errors.map(String) : [],
+    ),
+  ].map(String);
+};
+
+export default async function validateEditorConnectorForms(
+  editor: SyncEditorState,
+): Promise<string[]> {
+  const sourceConfig = endpointNode(editor.workflow, 'source')?.data?.config || {};
+  const sinkConfig = endpointNode(editor.workflow, 'sink')?.data?.config || {};
+  const sourceConnectorId = connectorIdForDataSourceType(editor.basic.sourceType);
+  const sinkConnectorId = connectorIdForDataSourceType(editor.basic.targetType);
+  const channel = editor.workflow.channelConfig || {};
+
+  const requests: Promise<any>[] = [];
+  if (sourceConnectorId) {
+    requests.push(
+      connectorFormApi.validate(
+        sourceConnectorId,
+        'SOURCE',
+        toSchemaValues(sourceConfig, 'SOURCE'),
+        { dataSourceId: editor.basic.sourceDataSourceId },
+      ),
+    );
+  }
+  if (sinkConnectorId) {
+    requests.push(
+      connectorFormApi.validate(
+        sinkConnectorId,
+        'SINK',
+        {
+          ...toSchemaValues(sinkConfig, 'SINK'),
+          dirty_data_policy:
+            channel.dirtyDataPolicy === 'skip' ? 'SKIP' : 'FAIL_FAST',
+          dirty_data_max_count: Number(channel.dirtyDataLimit || 0),
+        },
+        { dataSourceId: editor.basic.targetDataSourceId },
+      ),
+    );
+  }
+
+  try {
+    const responses = await Promise.all(requests);
+    return responses.flatMap((response) =>
+      isApiSuccess(response) ? resultErrors(response.data) : [],
+    );
+  } catch {
+    // Worker 或 Schema 缓存临时不可用时，保留原有前端校验，不阻断任务保存。
+    return [];
+  }
+}

--- a/yak-ops-ui/src/pages/batch-link-up/detail/form-schema/valueAdapter.test.ts
+++ b/yak-ops-ui/src/pages/batch-link-up/detail/form-schema/valueAdapter.test.ts
@@ -1,0 +1,29 @@
+import {
+  applySchemaValue,
+  connectorIdForDataSourceType,
+  toSchemaValues,
+} from './valueAdapter';
+
+test('maps relational datasource types to jdbc schema', () => {
+  expect(connectorIdForDataSourceType('MYSQL')).toBe('jdbc');
+  expect(connectorIdForDataSourceType('DORIS')).toBe('jdbc');
+  expect(connectorIdForDataSourceType('HTTP')).toBe('http');
+});
+
+test('keeps native connector options and legacy fields aligned', () => {
+  const patch = applySchemaValue(
+    { writeMode: 'append', connectorOptions: {} },
+    'SINK',
+    'primary_keys',
+    ['id', 'tenant_id'],
+  );
+  expect(patch.primaryKey).toBe('id,tenant_id');
+  expect(patch.connectorOptions.primary_keys).toEqual(['id', 'tenant_id']);
+
+  const values = toSchemaValues(
+    { table: 'orders', sql: '', fetchSize: 2000 },
+    'SOURCE',
+  );
+  expect(values.table_path).toBe('orders');
+  expect(values.fetch_size).toBe(2000);
+});

--- a/yak-ops-ui/src/pages/batch-link-up/detail/form-schema/valueAdapter.ts
+++ b/yak-ops-ui/src/pages/batch-link-up/detail/form-schema/valueAdapter.ts
@@ -1,0 +1,161 @@
+import type { ConnectorFormValues, ConnectorRole } from './types';
+
+const RELATIONAL_TYPES = new Set([
+  'MYSQL',
+  'MARIADB',
+  'POSTGRESQL',
+  'POSTGRES',
+  'ORACLE',
+  'SQLSERVER',
+  'SQL_SERVER',
+  'DORIS',
+  'STARROCKS',
+  'CLICKHOUSE',
+  'DB2',
+  'HIVE',
+  'JDBC',
+]);
+
+export const connectorIdForDataSourceType = (value?: string): string => {
+  const normalized = (value || '').trim().toUpperCase();
+  if (!normalized) return '';
+  return RELATIONAL_TYPES.has(normalized) ? 'jdbc' : normalized.toLowerCase();
+};
+
+const splitKeys = (value: unknown): string[] => {
+  if (Array.isArray(value)) return value.map(String).filter(Boolean);
+  return String(value || '')
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean);
+};
+
+export const toSchemaValues = (
+  config: Record<string, any>,
+  role: ConnectorRole,
+): ConnectorFormValues => {
+  const values: ConnectorFormValues = {
+    ...(config.connectorOptions || {}),
+  };
+
+  if (role === 'SOURCE') {
+    Object.assign(values, {
+      table_path: config.table || undefined,
+      table_list: config.tables || [],
+      query: config.sql || undefined,
+      where_condition: config.whereCondition || undefined,
+      fetch_size: config.fetchSize,
+      partition_column: config.partitionColumn,
+      partition_num: config.partitionNum,
+      partition_lower_bound: config.partitionLowerBound,
+      partition_upper_bound: config.partitionUpperBound,
+      split_planning_mode: config.splitPlanningMode,
+      statistics_query_timeout: config.statisticsQueryTimeout,
+      sample_size: config.sampleSize,
+      allow_statistics_fallback: config.allowStatisticsFallback,
+      null_partition_single_split: config.nullPartitionSingleSplit,
+      multi_table_failure_policy: config.multiTableFailurePolicy,
+      int_type_narrowing: config.intTypeNarrowing,
+    });
+  } else {
+    const writeMode = String(config.writeMode || 'append').toLowerCase();
+    Object.assign(values, {
+      table_path: config.targetTableName || config.table || undefined,
+      schema_save_mode: config.autoCreateTable
+        ? 'CREATE_SCHEMA_WHEN_NOT_EXIST'
+        : 'ERROR_WHEN_SCHEMA_NOT_EXIST',
+      data_save_mode: writeMode === 'overwrite' ? 'DROP_DATA' : 'APPEND_DATA',
+      write_mode: writeMode === 'upsert' ? 'UPSERT' : 'INSERT',
+      primary_keys: splitKeys(config.primaryKey),
+      custom_sql: config.sql || undefined,
+      batch_size: config.batchSize,
+      prepared_statement_cache_size: config.preparedStatementCacheSize,
+      query_timeout_sec: config.queryTimeoutSec,
+      max_retries: config.maxRetries,
+      dirty_data_policy: config.dirtyDataPolicy,
+      dirty_data_output_type: config.dirtyDataOutputType,
+      dirty_data_output_path: config.dirtyDataOutputPath,
+      dirty_data_max_samples: config.dirtyDataMaxSamples,
+      dirty_data_max_count: config.dirtyDataMaxCount,
+      dirty_data_max_percentage: config.dirtyDataMaxPercentage,
+      create_primary_key: config.createPrimaryKey,
+    });
+  }
+
+  return Object.fromEntries(
+    Object.entries(values).filter(([, value]) => value !== undefined),
+  );
+};
+
+const snakeToCamel = (value: string) =>
+  value.replace(/_([a-z])/g, (_, letter: string) => letter.toUpperCase());
+
+export const applySchemaValue = (
+  config: Record<string, any>,
+  role: ConnectorRole,
+  key: string,
+  value: unknown,
+): Record<string, any> => {
+  const connectorOptions = {
+    ...(config.connectorOptions || {}),
+    [key]: value,
+  };
+  const patch: Record<string, any> = { connectorOptions };
+
+  if (role === 'SOURCE') {
+    const mapping: Record<string, string> = {
+      table_path: 'table',
+      table_list: 'tables',
+      query: 'sql',
+      where_condition: 'whereCondition',
+      fetch_size: 'fetchSize',
+      partition_column: 'partitionColumn',
+      partition_num: 'partitionNum',
+      partition_lower_bound: 'partitionLowerBound',
+      partition_upper_bound: 'partitionUpperBound',
+      split_planning_mode: 'splitPlanningMode',
+      statistics_query_timeout: 'statisticsQueryTimeout',
+      sample_size: 'sampleSize',
+      allow_statistics_fallback: 'allowStatisticsFallback',
+      null_partition_single_split: 'nullPartitionSingleSplit',
+      multi_table_failure_policy: 'multiTableFailurePolicy',
+      int_type_narrowing: 'intTypeNarrowing',
+    };
+    patch[mapping[key] || snakeToCamel(key)] = value;
+    return patch;
+  }
+
+  if (key === 'table_path') {
+    patch[config.autoCreateTable ? 'targetTableName' : 'table'] = value;
+  } else if (key === 'schema_save_mode') {
+    patch.autoCreateTable = value === 'CREATE_SCHEMA_WHEN_NOT_EXIST';
+  } else if (key === 'data_save_mode') {
+    if (value === 'DROP_DATA') patch.writeMode = 'overwrite';
+    if (value === 'APPEND_DATA' && config.writeMode !== 'upsert') patch.writeMode = 'append';
+  } else if (key === 'write_mode') {
+    patch.writeMode = value === 'UPSERT'
+      ? 'upsert'
+      : config.writeMode === 'overwrite'
+        ? 'overwrite'
+        : 'append';
+  } else if (key === 'primary_keys') {
+    patch.primaryKey = Array.isArray(value) ? value.join(',') : value;
+  } else {
+    const mapping: Record<string, string> = {
+      custom_sql: 'sql',
+      batch_size: 'batchSize',
+      prepared_statement_cache_size: 'preparedStatementCacheSize',
+      query_timeout_sec: 'queryTimeoutSec',
+      max_retries: 'maxRetries',
+      dirty_data_policy: 'dirtyDataPolicy',
+      dirty_data_output_type: 'dirtyDataOutputType',
+      dirty_data_output_path: 'dirtyDataOutputPath',
+      dirty_data_max_samples: 'dirtyDataMaxSamples',
+      dirty_data_max_count: 'dirtyDataMaxCount',
+      dirty_data_max_percentage: 'dirtyDataMaxPercentage',
+      create_primary_key: 'createPrimaryKey',
+    };
+    patch[mapping[key] || snakeToCamel(key)] = value;
+  }
+  return patch;
+};

--- a/yak-ops-ui/src/pages/batch-link-up/detail/hooks/useDataSourceColumns.ts
+++ b/yak-ops-ui/src/pages/batch-link-up/detail/hooks/useDataSourceColumns.ts
@@ -1,0 +1,73 @@
+import { useEffect, useMemo, useState } from 'react';
+
+import { dataSourceCatalogApi } from '@/pages/data-source/service';
+
+export interface DataSourceColumnOption {
+  label: string;
+  value: string;
+  description?: string;
+  primaryKey?: boolean;
+}
+
+const normalizeColumns = (data: any): DataSourceColumnOption[] => {
+  const values = Array.isArray(data)
+    ? data
+    : Array.isArray(data?.bizData)
+      ? data.bizData
+      : Array.isArray(data?.records)
+        ? data.records
+        : [];
+
+  return values
+    .map((item: any) => {
+      const value = item?.fieldName || item?.name || item?.value;
+      if (!value) return null;
+      const type = item?.fieldType || item?.typeName || item?.type;
+      const comment = item?.fieldComment || item?.remarks || item?.description;
+      return {
+        value: String(value),
+        label: String(value),
+        description: [type, comment].filter(Boolean).join(' · ') || undefined,
+        primaryKey: String(item?.fieldKey || '').toUpperCase() === 'PRI' || Boolean(item?.primaryKey),
+      };
+    })
+    .filter(Boolean) as DataSourceColumnOption[];
+};
+
+export default function useDataSourceColumns(
+  dataSourceId: string,
+  request: Record<string, unknown> | undefined,
+) {
+  const [columns, setColumns] = useState<DataSourceColumnOption[]>([]);
+  const [loading, setLoading] = useState(false);
+  const requestKey = useMemo(() => JSON.stringify(request || {}), [request]);
+
+  useEffect(() => {
+    if (!dataSourceId || !request || Object.keys(request).length === 0) {
+      setColumns([]);
+      setLoading(false);
+      return;
+    }
+
+    let active = true;
+    setLoading(true);
+
+    dataSourceCatalogApi
+      .listColumn(dataSourceId, request)
+      .then((response) => {
+        if (active) setColumns(normalizeColumns(response?.data));
+      })
+      .catch(() => {
+        if (active) setColumns([]);
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [dataSourceId, requestKey]);
+
+  return { columns, loading };
+}

--- a/yak-ops-ui/src/pages/batch-link-up/detail/index.tsx
+++ b/yak-ops-ui/src/pages/batch-link-up/detail/index.tsx
@@ -1,26 +1,21 @@
-import { history, useLocation, useParams } from "@umijs/max";
-import {
-  Button,
-  ConfigProvider,
-  Empty,
-  message,
-  Spin,
-} from "antd";
+import { history, useLocation, useParams } from '@umijs/max';
+import { Button, ConfigProvider, Empty, message, Spin } from 'antd';
 import {
   useCallback,
   useEffect,
   useMemo,
   useRef,
   useState,
-} from "react";
+} from 'react';
 
-import { fetchDataSourceAll } from "@/pages/data-source/service";
-import type { DataSourceRecord } from "@/pages/data-source/types";
-import { BRAND_THEME } from "@/styles/brand";
+import { fetchDataSourceAll } from '@/pages/data-source/service';
+import type { DataSourceRecord } from '@/pages/data-source/types';
+import { BRAND_THEME } from '@/styles/brand';
 
-import { linkupJobDefinitionApi } from "../api";
-import SyncTaskEditor from "./components/SyncTaskEditor";
-import { useSmoothWheelScroll } from "./hooks/useSmoothWheelScroll";
+import { linkupJobDefinitionApi } from '../api';
+import SyncTaskEditor from './components/SyncTaskEditor';
+import validateEditorConnectorForms from './form-schema/validateEditorConnectorForms';
+import { useSmoothWheelScroll } from './hooks/useSmoothWheelScroll';
 import {
   buildSavePayload,
   endpointNode,
@@ -29,73 +24,61 @@ import {
   normalizeEditDetail,
   responseMessage,
   type SyncEditorState,
-} from "./model";
+} from './model';
 
 const validateTaskConfig = (
   editor: SyncEditorState,
 ): string | null => {
   if (!editor.basic.jobName.trim()) {
-    return "请输入任务名称";
+    return '请输入任务名称';
   }
 
   if (!editor.basic.sourceDataSourceId) {
-    return "请选择来源数据源";
+    return '请选择来源数据源';
   }
 
   if (!editor.basic.targetDataSourceId) {
-    return "请选择目标数据源";
+    return '请选择目标数据源';
   }
 
-  const source =
-    endpointNode(editor.workflow, "source")?.data?.config || {};
+  const source = endpointNode(editor.workflow, 'source')?.data?.config || {};
+  const sink = endpointNode(editor.workflow, 'sink')?.data?.config || {};
 
-  const sink =
-    endpointNode(editor.workflow, "sink")?.data?.config || {};
-
-  if (editor.mode === "GUIDE_MULTI") {
-    if (
-      !source.tables?.length &&
-      !source.tablePattern?.trim()
-    ) {
-      return "请选择来源表，或填写表名过滤规则";
+  if (editor.mode === 'GUIDE_MULTI') {
+    if (!source.tables?.length && !source.tablePattern?.trim()) {
+      return '请选择来源表，或填写表名过滤规则';
     }
 
     if (
-      sink.tableNamingRule !== "same_name" &&
+      sink.tableNamingRule !== 'same_name' &&
       !sink.tableNameAffix?.trim()
     ) {
-      return "请填写目标表名前缀或后缀";
+      return '请填写目标表名前缀或后缀';
     }
-  } else if (source.readMode === "sql") {
+  } else if (source.readMode === 'sql') {
     if (!source.sql?.trim()) {
-      return "请填写来源查询 SQL";
+      return '请填写来源查询 SQL';
     }
   } else if (!source.table) {
-    return "请选择来源表";
+    return '请选择来源表';
   }
 
-  if (editor.mode === "GUIDE_SINGLE") {
+  if (editor.mode === 'GUIDE_SINGLE') {
     if (sink.autoCreateTable) {
       if (!sink.targetTableName?.trim()) {
-        return "请输入目标表名";
+        return '请输入目标表名';
       }
     } else if (!sink.table) {
-      return "请选择目标表";
+      return '请选择目标表';
     }
   }
 
-  if (
-    sink.writeMode === "upsert" &&
-    !sink.primaryKey?.trim()
-  ) {
-    return "Upsert 写入模式需要配置主键字段";
+  if (sink.writeMode === 'upsert' && !sink.primaryKey?.trim()) {
+    return 'Upsert 写入模式需要配置主键字段';
   }
 
-  if (
-    !editor.env.parallelism ||
-    editor.env.parallelism < 1
-  ) {
-    return "Channel 并发数必须大于 0";
+  if (!editor.env.parallelism || editor.env.parallelism < 1) {
+    return 'Channel 并发数必须大于 0';
   }
 
   return null;
@@ -104,53 +87,42 @@ const validateTaskConfig = (
 export default function BatchLinkUpDetailPage() {
   const location = useLocation();
   const routeParams = useParams<{ id?: string }>();
-
   const pageRootRef = useRef<HTMLDivElement>(null);
 
   const taskId = useMemo(
     () =>
       routeParams.id ||
-      new URLSearchParams(location.search).get("id") ||
-      "",
+      new URLSearchParams(location.search).get('id') ||
+      '',
     [location.search, routeParams.id],
   );
 
-  const [editor, setEditor] =
-    useState<SyncEditorState | null>(null);
-
+  const [editor, setEditor] = useState<SyncEditorState | null>(null);
   const [loading, setLoading] = useState(false);
   const [saving, setSaving] = useState(false);
-
-  const [dataSourceLoading, setDataSourceLoading] =
-    useState(false);
-
-  const [dataSources, setDataSources] = useState<
-    DataSourceRecord[]
-  >([]);
+  const [connectorFormErrors, setConnectorFormErrors] = useState<string[]>([]);
+  const [dataSourceLoading, setDataSourceLoading] = useState(false);
+  const [dataSources, setDataSources] = useState<DataSourceRecord[]>([]);
 
   useSmoothWheelScroll(
     pageRootRef,
-    editor?.mode === "GUIDE_SINGLE",
+    editor?.mode === 'GUIDE_SINGLE',
   );
 
   const loadDataSources = useCallback(async () => {
     try {
       setDataSourceLoading(true);
-
       const response = await fetchDataSourceAll();
 
       if (!isApiSuccess(response)) {
-        message.error(
-          responseMessage(response, "获取数据源失败"),
-        );
-
+        message.error(responseMessage(response, '获取数据源失败'));
         setDataSources([]);
         return;
       }
 
       setDataSources(response?.data?.bizData || []);
     } catch (error: any) {
-      message.error(error?.message || "获取数据源失败");
+      message.error(error?.message || '获取数据源失败');
       setDataSources([]);
     } finally {
       setDataSourceLoading(false);
@@ -162,24 +134,18 @@ export default function BatchLinkUpDetailPage() {
 
     try {
       setLoading(true);
-
-      const response =
-        await linkupJobDefinitionApi.selectEditDetail(taskId);
+      const response = await linkupJobDefinitionApi.selectEditDetail(taskId);
 
       if (!isApiSuccess(response) || !response?.data) {
-        message.error(
-          responseMessage(response, "获取同步任务失败"),
-        );
-
+        message.error(responseMessage(response, '获取同步任务失败'));
         setEditor(null);
         return;
       }
 
-      setEditor(
-        normalizeEditDetail(response.data, taskId),
-      );
+      setEditor(normalizeEditDetail(response.data, taskId));
+      setConnectorFormErrors([]);
     } catch (error: any) {
-      message.error(error?.message || "获取同步任务失败");
+      message.error(error?.message || '获取同步任务失败');
       setEditor(null);
     } finally {
       setLoading(false);
@@ -188,11 +154,7 @@ export default function BatchLinkUpDetailPage() {
 
   useEffect(() => {
     if (!taskId) return;
-
-    void Promise.all([
-      loadTask(),
-      loadDataSources(),
-    ]);
+    void Promise.all([loadTask(), loadDataSources()]);
   }, [loadDataSources, loadTask, taskId]);
 
   const persistEditor = async (
@@ -200,44 +162,28 @@ export default function BatchLinkUpDetailPage() {
   ): Promise<SyncEditorState | null> => {
     try {
       setSaving(true);
-
       const payload = buildSavePayload(nextEditor);
-
       const response =
-        nextEditor.mode === "GUIDE_MULTI"
-          ? await linkupJobDefinitionApi.saveOrUpdateGuideMulti(
-              payload,
-            )
-          : await linkupJobDefinitionApi.saveOrUpdateGuideSingle(
-              payload,
-            );
+        nextEditor.mode === 'GUIDE_MULTI'
+          ? await linkupJobDefinitionApi.saveOrUpdateGuideMulti(payload)
+          : await linkupJobDefinitionApi.saveOrUpdateGuideSingle(payload);
 
       if (!isApiSuccess(response)) {
-        message.error(
-          responseMessage(response, "保存同步任务失败"),
-        );
-
+        message.error(responseMessage(response, '保存同步任务失败'));
         return null;
       }
 
       const savedEditor: SyncEditorState = {
         ...nextEditor,
         basic: payload.basic,
-        id: extractSavedId(
-          response,
-          nextEditor.id,
-        ),
+        id: extractSavedId(response, nextEditor.id),
       };
 
       setEditor(savedEditor);
-      message.success("任务配置已保存");
-
+      message.success('任务配置已保存');
       return savedEditor;
     } catch (error: any) {
-      message.error(
-        error?.message || "保存同步任务失败",
-      );
-
+      message.error(error?.message || '保存同步任务失败');
       return null;
     } finally {
       setSaving(false);
@@ -248,9 +194,19 @@ export default function BatchLinkUpDetailPage() {
     if (!editor) return;
 
     const error = validateTaskConfig(editor);
-
     if (error) {
       message.warning(error);
+      return;
+    }
+
+    if (connectorFormErrors.length > 0) {
+      message.warning(connectorFormErrors[0]);
+      return;
+    }
+
+    const remoteErrors = await validateEditorConnectorForms(editor);
+    if (remoteErrors.length > 0) {
+      message.warning(remoteErrors[0]);
       return;
     }
 
@@ -258,11 +214,11 @@ export default function BatchLinkUpDetailPage() {
   };
 
   const handleCancel = () => {
-    history.push("/sync/batch-link-up");
+    history.push('/sync/batch-link-up');
   };
 
   if (!taskId) {
-    history.replace("/sync/batch-link-up");
+    history.replace('/sync/batch-link-up');
     return null;
   }
 
@@ -281,9 +237,7 @@ export default function BatchLinkUpDetailPage() {
           description="未找到同步任务"
           image={Empty.PRESENTED_IMAGE_SIMPLE}
         >
-          <Button onClick={handleCancel}>
-            返回任务列表
-          </Button>
+          <Button onClick={handleCancel}>返回任务列表</Button>
         </Empty>
       </div>
     );
@@ -291,15 +245,8 @@ export default function BatchLinkUpDetailPage() {
 
   return (
     <ConfigProvider theme={BRAND_THEME}>
-      {/*
-        这里必须限制高度并隐藏外层滚动，
-        让 pageRootRef 成为唯一的滚动容器。
-      */}
       <div className="h-[calc(100vh-64px)] overflow-hidden bg-[#f7f8fa] text-[#161823]">
-        <div
-          ref={pageRootRef}
-          className="h-full overflow-y-auto"
-        >
+        <div ref={pageRootRef} className="h-full overflow-y-auto">
           <div className="mx-auto w-full max-w-[1040px] px-6 pt-6">
             <main className="pb-4">
               <SyncTaskEditor
@@ -307,13 +254,10 @@ export default function BatchLinkUpDetailPage() {
                 dataSources={dataSources}
                 dataSourceLoading={dataSourceLoading}
                 onChange={setEditor}
+                onValidationChange={setConnectorFormErrors}
               />
             </main>
 
-            {/*
-              直接使用 sticky 即可。
-              它会相对于上面的 pageRootRef 滚动容器吸附。
-            */}
             <footer className="sticky bottom-0 z-50 overflow-hidden rounded-t-lg border border-b-0 border-[#eaecf0] bg-white shadow-[0_-8px_16px_rgba(0,0,0,0.06)]">
               <div className="flex min-h-[80px] items-center gap-3 px-8 py-4">
                 <Button


### PR DESCRIPTION
## Summary

This implements phase three of the Yak Ops Connector configuration architecture: **complex Form Schema interactions**.

The phase-two Form Schema is now executable as a real task-editor contract. Link-Up rules are normalized into a stable interaction model, Yak Ops exposes controlled datasource actions and backend validation, and the existing offline task editor renders Connector advanced configuration dynamically.

- normalize Link-Up rules into frontend-ready interactions
- support conditional visibility, conditional required fields, disabled state, exclusive fields, bundled fields and constraints
- support chained `AND` / `OR` conditions and common comparison operators
- expose controlled table, column, preview, count and SQL actions through Yak Ops
- keep database credentials server-side and route all metadata calls through datasource IDs
- add datasource → table → field cascading selections
- add remote search debounce, request race protection and short-lived option caching
- add schema-driven frontend groups, widgets, help text and validation
- add backend online validation before task persistence
- replace the single-table Upsert primary-key text input with a catalog-backed multi-field selector while retaining manual tags as fallback
- keep the existing task JSON and HOCON builder compatible through a schema-value adapter

## Architecture

```text
Link-Up Connector Rules
          ↓
ConnectorInteractionNormalizer
          ↓
Yak Ops Interaction Model
   ├─ frontend rule engine
   └─ backend validation

Presentation Profile OptionSource
          ↓
ConnectorFormActionService
          ↓
Datasource Catalog
          ↓
remote table / column / preview options
```

## Interaction model

The composed Form Schema now exposes `interactions` with these effects:

- `VISIBLE`
- `REQUIRED`
- `DISABLED`
- `EXCLUSIVE`
- `BUNDLED`
- `VALIDATE`

Supported conditions include equality, inequality, membership, contains, presence/empty checks, boolean checks, numeric comparisons, prefixes, suffixes, regular expressions and chained `AND` / `OR` evaluation.

The original Link-Up `rules` remain unchanged in the response. The normalized interactions are the stable Yak Ops control-plane view.

## Remote option sources

Fields may now define:

```json
{
  "dependsOn": ["table_path"],
  "clearWhenHidden": true,
  "optionSource": {
    "action": "LIST_COLUMNS",
    "searchable": true,
    "multiple": true,
    "cacheTtlMillis": 30000,
    "requestValueKeys": ["table_path"]
  }
}
```

JDBC profiles are upgraded to version `2`:

- Source `table_path` and `table_list` use `LIST_TABLES`
- Source `partition_column` uses `LIST_COLUMNS` and depends on table/query
- Sink `table_path` uses `LIST_TABLES`
- Sink `primary_keys` uses multi-select `LIST_COLUMNS`

Unknown future Connectors still receive inferred table/field actions based on semantic types and widgets.

## API

```http
GET  /api/v1/job/batch-control/connectors/{connectorId}/form-schema?role=SOURCE
POST /api/v1/job/batch-control/connectors/{connectorId}/form-schema/validate?role=SOURCE
POST /api/v1/job/batch-control/connectors/actions/{action}
POST /api/v1/job/batch-control/connectors/schemas/refresh
```

Controlled actions currently include:

- `LIST_TABLES`
- `LIST_COLUMNS`
- `PREVIEW`
- `COUNT`
- `SQL_TEMPLATE`
- `RESOLVE_SQL`

All actions execute through Yak Ops datasource plugins. The browser never receives connection credentials and never connects directly to databases or the Link-Up Worker.

## Frontend integration

The current offline task editor now includes a `Connector 扩展配置` section:

- Source/Sink tabs
- schema groups and collapsible advanced settings
- dynamic Ant Design widgets
- conditional show/hide and required state
- exclusive/bundled/constraint errors
- stale cached-schema warning
- remote option search with debounce and cache
- hidden-value cleanup
- server validation before save

The existing primary task fields remain in their current focused panels. The dynamic section excludes those duplicated keys but evaluates the complete Connector value model.

## Compatibility

Schema-native values are stored in `connectorOptions` and synchronized to the current legacy fields such as:

- `table`
- `tables`
- `sql`
- `whereCondition`
- `fetchSize`
- `writeMode`
- `primaryKey`
- `batchSize`

This means the existing task definition payload and `LinkUpHoconBuilder` remain unchanged in this phase.

If the Form Schema service is temporarily unavailable, existing page validation remains active and the editor does not fail closed solely because the Worker/schema refresh is unavailable.

## Validation

- based on latest `main` commit `1f7a0d74df162f32ed30c484963a81613683c7ca`
- Java 21 static compilation passed for all new and modified backend production sources using dependency stubs
- strict TypeScript checking passed for the dynamic form, rule engine, remote options, value adapter and editor integration using realistic module stubs
- runtime assertions passed for the TypeScript rule engine and legacy/schema value adapter
- added backend tests for rule normalization, conditional validation, JDBC remote sources and generic action inference
- added frontend tests for conditional visibility/required state and value-model compatibility
- branch is exactly one commit ahead of `main`

A full Maven reactor build was not available because Maven is not installed in the execution environment. A full repository npm build was also not available without the project dependency installation. Repository CI should run the complete Java, frontend, Flyway and test suites for this draft.

## Non-goals

This PR intentionally does not include:

- JSON JobSpec submission
- replacement or removal of HOCON
- direct Link-Up Action APIs
- arbitrary frontend-defined database calls
- CDC, realtime synchronization, checkpoints or savepoints
