### PR TITLE
fix(offline-sync): repair end-to-end task flow

### DIFF
--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/README.md
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/README.md
@@ -6,11 +6,12 @@
 
 Yak Ops 负责：
 
-- 保存前端可编辑任务定义和不可变 JobSpec 版本；
-- 根据 Connector Form Schema 收集 Connector options；
-- 解析数据源引用并在服务端注入连接参数和敏感信息；
+- 先创建轻量草稿，再在配置完成后生成不可变 JobSpec 版本；
+- 根据 Connector Form Schema 收集并强制校验 Connector options；
+- 持久化不含数据库凭据的逻辑 JobSpec；
+- 在每次执行前根据 `dataSourceRef.id` 解析最新连接参数；
 - 保存 Cron 调度与重试策略；
-- 创建并持久化执行历史；
+- 原子领取任务并创建执行历史，避免手动和调度重复提交；
 - 选择并记录 Link-Up Worker；
 - 生成 `externalExecutionId` 和 `idempotencyKey`；
 - 后台持续对账 Link-Up 作业状态；
@@ -25,12 +26,32 @@ Link-Up 负责：
 - 排队、运行、取消并返回最终结果；
 - 暴露 Worker 身份、状态、指标、Pipeline 和 Task 信息。
 
+## 创建和保存流程
+
+```text
+创建任务抽屉
+  ↓
+草稿记录（version=0、currentVersionId=NULL）
+  ↓
+选择数据源、表和运行参数
+  ↓
+前端即时校验 + 后端 Form Schema 强制校验
+  ↓
+逻辑 JobSpec（dataSourceRef，不含密码）
+  ↓
+不可变任务版本
+```
+
+草稿不能上线或运行。第一次完整保存生成版本 `1`，以后每次离线编辑保存都会增加版本号。
+
 ## 核心组件
 
 ```text
-LinkUpJobSpecFactory              编辑模型与数据源引用 -> 结构化 JobSpec
-OfflineDefinitionSupport         定义序列化、JobSpec 生成和展示映射
+ConnectorIdResolver              数据源类型/旧标签 -> Link-Up Connector ID
+LinkUpJobSpecFactory             编辑模型 -> 逻辑 JobSpec；执行前解析数据源引用
+OfflineDefinitionSupport         草稿、定义序列化、Schema 校验和展示映射
 OfflineJobDefinitionService      当前定义、上线下线和不可变版本目录
+OfflineExecutionClaimService     行锁保护下原子创建一次执行尝试
 OfflineExecutionOrchestrator     JobSpec 提交、幂等命令和状态持久化
 OfflineExecutionReadService      执行历史、指标和日志读模型
 OfflineJobExecutionService       Controller 使用的执行门面
@@ -40,7 +61,40 @@ OfflineScheduleDispatcher        持久化 Cron 调度派发
 OfflineAlertPublisher            告警持久化和应用事件发布
 ```
 
-`LinkUpHoconBuilder` 已移除。新增 Connector 时只需让 Form Schema 产生对应 `connectorOptions`；公共 JobSpec 协议不需要增加 Doris、HTTP、文件等专用序列化分支。JDBC 当前仍由 `LinkUpJobSpecFactory` 负责将 Yak Ops 数据源 ID 解析为运行时连接 options。
+`LinkUpHoconBuilder` 已移除。新增 Connector 时只需让 Form Schema 产生对应 `connectorOptions`；公共 JobSpec 协议不需要增加 Doris、HTTP、文件等专用序列化分支。
+
+## 逻辑与执行 JobSpec
+
+数据库中的逻辑 JobSpec：
+
+```json
+{
+  "source": {
+    "connectorId": "jdbc",
+    "dataSourceRef": {"id": 10001},
+    "options": {"table_path": "sales.orders"}
+  }
+}
+```
+
+提交 Link-Up 前临时解析成：
+
+```json
+{
+  "source": {
+    "connectorId": "jdbc",
+    "options": {
+      "url": "jdbc:mysql://source:3306/demo",
+      "driver": "com.mysql.cj.jdbc.Driver",
+      "username": "runtime-user",
+      "password": "runtime-secret",
+      "table_path": "sales.orders"
+    }
+  }
+}
+```
+
+解析后的敏感 JobSpec 只存在于本次 HTTP 请求内，不写入当前定义、不可变版本或执行快照。数据源密码轮换后，下次执行自动使用最新凭据。
 
 ## Link-Up 提交协议
 
@@ -59,13 +113,41 @@ Content-Type: application/json
     "kind": "BatchSyncJob",
     "name": "orders-sync",
     "source": {"connectorId": "jdbc", "options": {}},
-    "sink": {"connectorId": "doris", "options": {}},
+    "sink": {"connectorId": "jdbc", "options": {}},
     "runtime": {"batchSize": 1000, "sourceParallelism": 2}
   }
 }
 ```
 
 Yak Ops 不再生成或提交 HOCON。`hocon_config` 数据库列只保留为历史兼容字段，新任务版本写入 `job_spec_json`。
+
+## 状态和命令接口
+
+稳定执行状态：
+
+```text
+CREATED -> SUBMITTED -> QUEUED -> RUNNING
+                                      |-> SUCCEEDED
+                                      |-> FAILED
+                                      |-> CANCELED
+                                      `-> LOST
+```
+
+执行和取消只能通过 POST 命令接口：
+
+```http
+POST /api/v1/job/batch-execution/{definitionId}/execute
+POST /api/v1/job/batch-execution/{executionId}/cancel
+```
+
+本地配置、序列化和协议错误立即进入 `FAILED`。只有无法判断 Worker 是否已经接收请求的传输异常才保留 `SUBMITTED`，并通过 `externalExecutionId` 后台对账。
+
+## 调度和重试
+
+- `retryPolicy.maxAttempts` 表示总尝试次数；
+- 兼容字段 `retryTimes` 表示首次失败后的额外重试次数，因此总尝试次数为 `retryTimes + 1`；
+- `retryPolicy.backoffSeconds` 和 `retryIntervalSeconds` 使用秒；
+- 兼容字段 `retryInterval` 使用分钟。
 
 ## 历史任务兼容
 
@@ -75,4 +157,11 @@ Flyway V4：
 - 将旧 `hocon_config` 改为可空并标记为停用；
 - 将执行快照语义改为 JobSpec JSON。
 
-历史版本没有 `job_spec_json` 时，执行器会从该版本的 `definition_json` 重新构建 JobSpec，不解析旧 HOCON，也不要求一次性迁移历史数据。
+Flyway V5：
+
+- 将历史 `MYSQL`、`ORACLE`、`POSTGRE_SQL`、`DORIS` 等关系型标签统一为 `jdbc`；
+- 为关系型 JobSpec 增加 `dataSourceRef.id`；
+- 删除当前定义、不可变版本和执行快照中的 URL、用户名和密码等连接参数；
+- 根据迁移后的逻辑 JobSpec 重新计算版本摘要。
+
+历史版本没有 `job_spec_json` 时，执行器会从该版本的 `definition_json` 重新构建逻辑 JobSpec，不解析旧 HOCON。

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/controller/OfflineJobDefinitionController.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/controller/OfflineJobDefinitionController.java
@@ -31,7 +31,14 @@ public class OfflineJobDefinitionController {
   }
 
   @GetMapping("/get-unique-id")
-  public Result<Long> nextId() { return Result.success(service.nextId()); }
+  public Result<Long> nextId() {
+    return Result.success(service.nextId());
+  }
+
+  @PostMapping("/draft")
+  public Result<Long> saveDraft(@RequestBody OfflineJobDefinitionDTO requestDTO) {
+    return Result.success(service.saveDraft(requestDTO));
+  }
 
   @PostMapping({"/guide-single/saveOrUpdate", "/guide-multi/saveOrUpdate"})
   public Result<Long> saveGuide(@RequestBody OfflineJobDefinitionDTO requestDTO) {
@@ -41,8 +48,7 @@ public class OfflineJobDefinitionController {
   @PostMapping({
       "/guide-single/build-config",
       "/guide-multi/build-config",
-      "/build-job-spec",
-      "/buildHoconConfig"
+      "/build-job-spec"
   })
   public Result<String> buildGuideConfig(@RequestBody OfflineJobDefinitionDTO requestDTO) {
     return Result.success(service.buildGuideConfig(requestDTO));
@@ -65,11 +71,17 @@ public class OfflineJobDefinitionController {
   }
 
   @PutMapping("/{id}/online")
-  public Result<Boolean> online(@PathVariable Long id) { return Result.success(service.online(id)); }
+  public Result<Boolean> online(@PathVariable Long id) {
+    return Result.success(service.online(id));
+  }
 
   @PutMapping("/{id}/offline")
-  public Result<Boolean> offline(@PathVariable Long id) { return Result.success(service.offline(id)); }
+  public Result<Boolean> offline(@PathVariable Long id) {
+    return Result.success(service.offline(id));
+  }
 
   @DeleteMapping("/{id}")
-  public Result<Boolean> delete(@PathVariable Long id) { return Result.success(service.delete(id)); }
+  public Result<Boolean> delete(@PathVariable Long id) {
+    return Result.success(service.delete(id));
+  }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/controller/OfflineJobExecutionController.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/controller/OfflineJobExecutionController.java
@@ -40,23 +40,13 @@ public class OfflineJobExecutionController {
     return Result.success(linkUpClient.node());
   }
 
-  @GetMapping({"/api/v1/job/batch-execution/execute", "/api/v1/executor/execute"})
-  public Result<OfflineJobExecutionVO> execute(@RequestParam Long jobDefineId) {
-    return Result.success(service.execute(jobDefineId));
-  }
-
   @PostMapping("/api/v1/job/batch-execution/{jobDefineId}/execute")
-  public Result<OfflineJobExecutionVO> executeByPath(@PathVariable Long jobDefineId) {
+  public Result<OfflineJobExecutionVO> execute(@PathVariable Long jobDefineId) {
     return Result.success(service.execute(jobDefineId));
-  }
-
-  @GetMapping({"/api/v1/job/batch-execution/pause", "/api/v1/executor/pause"})
-  public Result<OfflineJobExecutionVO> pause(@RequestParam Long jobInstanceId) {
-    return Result.success(service.cancel(jobInstanceId));
   }
 
   @PostMapping("/api/v1/job/batch-execution/{jobInstanceId}/cancel")
-  public Result<OfflineJobExecutionVO> cancelByPath(@PathVariable Long jobInstanceId) {
+  public Result<OfflineJobExecutionVO> cancel(@PathVariable Long jobInstanceId) {
     return Result.success(service.cancel(jobInstanceId));
   }
 

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/dao/impl/OfflineJobDefinitionDaoImpl.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/dao/impl/OfflineJobDefinitionDaoImpl.java
@@ -93,8 +93,8 @@ public class OfflineJobDefinitionDaoImpl implements OfflineJobDefinitionDao {
 
   private String normalizeStatus(String status) {
     String normalized = status.trim().toUpperCase(Locale.ROOT);
-    return "COMPLETED".equals(normalized) || "SUCCEEDED".equals(normalized)
-        ? "FINISHED"
+    return "COMPLETED".equals(normalized) || "FINISHED".equals(normalized)
+        ? "SUCCEEDED"
         : normalized;
   }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/dao/impl/OfflineJobDefinitionDaoImpl.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/dao/impl/OfflineJobDefinitionDaoImpl.java
@@ -8,6 +8,7 @@ import io.yak.ops.business.sync.offline.dao.OfflineJobDefinitionDao;
 import io.yak.ops.business.sync.offline.dao.mapper.OfflineJobDefinitionMapper;
 import io.yak.ops.common.bean.dto.sync.offline.OfflineJobDefinitionQueryDTO;
 import io.yak.ops.common.bean.po.sync.offline.OfflineJobDefinitionPO;
+import java.util.List;
 import java.util.Locale;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -18,6 +19,9 @@ import org.springframework.util.StringUtils;
 @Repository
 @RequiredArgsConstructor
 public class OfflineJobDefinitionDaoImpl implements OfflineJobDefinitionDao {
+
+  private static final List<String> ACTIVE_STATUSES =
+      List.of("CREATED", "SUBMITTED", "QUEUED", "RUNNING");
 
   private final OfflineJobDefinitionMapper mapper;
 
@@ -64,7 +68,12 @@ public class OfflineJobDefinitionDaoImpl implements OfflineJobDefinitionDao {
       query.eq(OfflineJobDefinitionPO::getId, condition.getId());
     }
     if (StringUtils.hasText(condition.getStatus())) {
-      query.eq(OfflineJobDefinitionPO::getLastJobStatus, normalizeStatus(condition.getStatus()));
+      String status = normalizeStatus(condition.getStatus());
+      if ("RUNNING".equals(status)) {
+        query.in(OfflineJobDefinitionPO::getLastJobStatus, ACTIVE_STATUSES);
+      } else {
+        query.eq(OfflineJobDefinitionPO::getLastJobStatus, status);
+      }
     }
     addLike(query, OfflineJobDefinitionPO::getSourceType, condition.getSourceType());
     addLike(query, OfflineJobDefinitionPO::getSinkType, condition.getSinkType());

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/ConnectorIdResolver.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/ConnectorIdResolver.java
@@ -1,0 +1,57 @@
+package io.yak.ops.business.sync.offline.engine;
+
+import java.util.Locale;
+import java.util.Set;
+import org.springframework.util.StringUtils;
+
+/** Normalizes product datasource types and legacy connector labels to Link-Up connector IDs. */
+public final class ConnectorIdResolver {
+
+  private static final Set<String> JDBC_TYPES = Set.of(
+      "JDBC",
+      "MYSQL",
+      "MARIADB",
+      "POSTGRE_SQL",
+      "POSTGRESQL",
+      "POSTGRES",
+      "ORACLE",
+      "SQLSERVER",
+      "SQL_SERVER",
+      "DORIS",
+      "STARROCKS",
+      "CLICKHOUSE",
+      "DB2",
+      "HIVE",
+      "KINGBASE",
+      "DAMENG",
+      "DM");
+
+  private ConnectorIdResolver() {
+  }
+
+  public static String resolve(String connectorId, String connectorType, String dbType,
+      String fallback) {
+    String value = firstText(connectorId, connectorType, dbType, fallback);
+    if (!StringUtils.hasText(value)) {
+      throw new IllegalArgumentException("Connector 类型不能为空");
+    }
+    String normalized = value.trim().toUpperCase(Locale.ROOT).replace('-', '_');
+    if (JDBC_TYPES.contains(normalized)) {
+      return "jdbc";
+    }
+    return normalized.toLowerCase(Locale.ROOT);
+  }
+
+  public static boolean isJdbc(String connectorId) {
+    return "jdbc".equalsIgnoreCase(connectorId);
+  }
+
+  private static String firstText(String... values) {
+    for (String value : values) {
+      if (StringUtils.hasText(value)) {
+        return value;
+      }
+    }
+    return null;
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/LinkUpClient.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/LinkUpClient.java
@@ -38,8 +38,13 @@ public class LinkUpClient {
     this.properties = properties;
   }
 
-  public LinkUpNodeResponse node() { return get("/api/v1/node", LinkUpNodeResponse.class); }
-  public LinkUpNodeResponse health() { return node(); }
+  public LinkUpNodeResponse node() {
+    return get("/api/v1/node", LinkUpNodeResponse.class);
+  }
+
+  public LinkUpNodeResponse health() {
+    return node();
+  }
 
   public LinkUpJobResponse submit(
       String externalExecutionId,
@@ -51,7 +56,7 @@ public class LinkUpClient {
         || !StringUtils.hasText(idempotencyKey)
         || jobSpec == null
         || !jobSpec.isObject()) {
-      throw new IllegalArgumentException("Link-Up JobSpec 提交参数不完整");
+      throw new LinkUpProtocolException("Link-Up JobSpec 提交参数不完整");
     }
     LinkUpSubmitRequest body = new LinkUpSubmitRequest();
     body.setExternalExecutionId(externalExecutionId.trim());
@@ -72,7 +77,9 @@ public class LinkUpClient {
   }
 
   public LinkUpJobResponse findByExternalExecutionId(String externalExecutionId) {
-    return get("/api/v1/jobs/external/" + encode(externalExecutionId), LinkUpJobResponse.class);
+    return get(
+        "/api/v1/jobs/external/" + encode(externalExecutionId),
+        LinkUpJobResponse.class);
   }
 
   public LinkUpJobResponse cancel(String engineJobId) {
@@ -80,7 +87,8 @@ public class LinkUpClient {
     HttpRequest request = HttpRequest.newBuilder(uri("/api/v1/jobs/" + encode(engineJobId)))
         .timeout(properties.getEngine().getRequestTimeout())
         .header("Accept", "application/json")
-        .DELETE().build();
+        .DELETE()
+        .build();
     return send(request, LinkUpJobResponse.class);
   }
 
@@ -101,7 +109,8 @@ public class LinkUpClient {
     HttpRequest request = HttpRequest.newBuilder(uri(path))
         .timeout(properties.getEngine().getRequestTimeout())
         .header("Accept", "application/json")
-        .GET().build();
+        .GET()
+        .build();
     return send(request, type);
   }
 
@@ -112,58 +121,90 @@ public class LinkUpClient {
       if (response.statusCode() >= 200 && response.statusCode() < 300) {
         return read(response.body(), type);
       }
-      JsonNode error = read(response.body(), JsonNode.class);
+      JsonNode error = readError(response.body());
       throw new LinkUpRequestException(
           response.statusCode(),
           error.path("code").asText("LINK-UP-HTTP-" + response.statusCode()),
           errorMessage(error, response.body()));
     } catch (InterruptedException exception) {
       Thread.currentThread().interrupt();
-      throw new IllegalStateException("Link-Up 请求被中断", exception);
+      throw new LinkUpTransportException("Link-Up 请求被中断", exception, false);
     } catch (IOException exception) {
-      throw new IllegalStateException("无法连接 Link-Up Worker：" + properties.getEngine().getBaseUrl(), exception);
+      // JDK HttpClient cannot always tell whether bytes reached the Worker. Reconcile by external ID.
+      throw new LinkUpTransportException(
+          "无法确认 Link-Up Worker 是否已接收请求：" + properties.getEngine().getBaseUrl(),
+          exception,
+          true);
+    }
+  }
+
+  private JsonNode readError(String body) {
+    if (!StringUtils.hasText(body)) {
+      return objectMapper.createObjectNode();
+    }
+    try {
+      return objectMapper.readTree(body);
+    } catch (JsonProcessingException exception) {
+      return objectMapper.createObjectNode().put("message", body);
     }
   }
 
   private <T> T read(String body, Class<T> type) {
     try {
       if (!StringUtils.hasText(body)) {
-        if (JsonNode.class.equals(type)) return type.cast(objectMapper.createObjectNode());
+        if (JsonNode.class.equals(type)) {
+          return type.cast(objectMapper.createObjectNode());
+        }
         return type.getDeclaredConstructor().newInstance();
       }
       return objectMapper.readValue(body, type);
     } catch (ReflectiveOperationException | JsonProcessingException exception) {
-      throw new IllegalStateException("Link-Up 返回了无法解析的协议数据", exception);
+      throw new LinkUpProtocolException("Link-Up 返回了无法解析的协议数据", exception);
     }
   }
 
   private String write(Object value) {
-    try { return objectMapper.writeValueAsString(value); }
-    catch (JsonProcessingException exception) {
-      throw new IllegalStateException("序列化 Link-Up JobSpec 提交协议失败", exception);
+    try {
+      return objectMapper.writeValueAsString(value);
+    } catch (JsonProcessingException exception) {
+      throw new LinkUpProtocolException("序列化 Link-Up JobSpec 提交协议失败", exception);
     }
   }
 
   private String errorMessage(JsonNode body, String fallback) {
     String message = body.path("message").asText(null);
-    if (!StringUtils.hasText(message)) message = body.path("error").asText(null);
+    if (!StringUtils.hasText(message)) {
+      message = body.path("error").asText(null);
+    }
     return StringUtils.hasText(message) ? message : fallback;
   }
 
   private URI uri(String path) {
     String baseUrl = properties.getEngine().getBaseUrl();
-    if (!StringUtils.hasText(baseUrl)) throw new IllegalStateException("yak.sync.offline.engine.base-url 不能为空");
-    String normalized = baseUrl.endsWith("/") ? baseUrl.substring(0, baseUrl.length() - 1) : baseUrl;
-    return URI.create(normalized + path);
+    if (!StringUtils.hasText(baseUrl)) {
+      throw new LinkUpProtocolException("yak.sync.offline.engine.base-url 不能为空");
+    }
+    String normalized = baseUrl.endsWith("/")
+        ? baseUrl.substring(0, baseUrl.length() - 1)
+        : baseUrl;
+    try {
+      return URI.create(normalized + path);
+    } catch (IllegalArgumentException exception) {
+      throw new LinkUpProtocolException("Link-Up Worker 地址不合法：" + normalized, exception);
+    }
   }
 
   private String encode(String value) {
-    if (!StringUtils.hasText(value)) throw new IllegalArgumentException("Link-Up 标识不能为空");
+    if (!StringUtils.hasText(value)) {
+      throw new LinkUpProtocolException("Link-Up 标识不能为空");
+    }
     return URLEncoder.encode(value.trim(), StandardCharsets.UTF_8).replace("+", "%20");
   }
 
   private void requireEnabled() {
-    if (!properties.getEngine().isEnabled()) throw new IllegalStateException("Link-Up 引擎对接已关闭");
+    if (!properties.getEngine().isEnabled()) {
+      throw new LinkUpProtocolException("Link-Up 引擎对接已关闭");
+    }
   }
 
   @Data
@@ -226,10 +267,38 @@ public class LinkUpClient {
   public static final class LinkUpRequestException extends RuntimeException {
     private final int statusCode;
     private final String code;
+
     public LinkUpRequestException(int statusCode, String code, String message) {
-      super(message); this.statusCode = statusCode; this.code = code;
+      super(message);
+      this.statusCode = statusCode;
+      this.code = code;
     }
+
     public int getStatusCode() { return statusCode; }
     public String getCode() { return code; }
+  }
+
+  public static final class LinkUpTransportException extends RuntimeException {
+    private final boolean uncertain;
+
+    public LinkUpTransportException(
+        String message,
+        Throwable cause,
+        boolean uncertain) {
+      super(message, cause);
+      this.uncertain = uncertain;
+    }
+
+    public boolean isUncertain() { return uncertain; }
+  }
+
+  public static final class LinkUpProtocolException extends RuntimeException {
+    public LinkUpProtocolException(String message) {
+      super(message);
+    }
+
+    public LinkUpProtocolException(String message, Throwable cause) {
+      super(message, cause);
+    }
   }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/LinkUpJobSpecFactory.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/LinkUpJobSpecFactory.java
@@ -28,6 +28,18 @@ public class LinkUpJobSpecFactory {
 
   private static final String API_VERSION = "link-up/v1";
   private static final String KIND = "BatchSyncJob";
+  private static final Set<String> DATASOURCE_OWNED_OPTIONS = Set.of(
+      "url",
+      "driver",
+      "username",
+      "password",
+      "schema",
+      "dialect",
+      "compatible_mode",
+      "properties",
+      "connection_check_timeout_sec",
+      "connect_timeout_ms",
+      "socket_timeout_ms");
 
   private final DataSourceDao dataSourceDao;
   private final ObjectMapper objectMapper;
@@ -39,6 +51,7 @@ public class LinkUpJobSpecFactory {
     this.objectMapper = objectMapper;
   }
 
+  /** Builds a logical, durable JobSpec. JDBC credentials are intentionally not included. */
   public BuildResult build(JsonNode definition) {
     requireObject(definition, "任务定义不能为空");
     JsonNode basic = definition.path("basic");
@@ -56,14 +69,24 @@ public class LinkUpJobSpecFactory {
     Endpoint sink = endpoint(workflow, "sink");
     String sourceConnectorId = connectorId(source.config, "jdbc");
     String sinkConnectorId = connectorId(sink.config, "jdbc");
+    boolean jdbcSource = ConnectorIdResolver.isJdbc(sourceConnectorId);
+    boolean jdbcSink = ConnectorIdResolver.isJdbc(sinkConnectorId);
+
     Long sourceDataSourceId = resolveDataSourceId(
-        source.config, basic, workflow, true, "jdbc".equalsIgnoreCase(sourceConnectorId));
+        source.config, basic, workflow, true, jdbcSource);
     Long sinkDataSourceId = resolveDataSourceId(
-        sink.config, basic, workflow, false, "jdbc".equalsIgnoreCase(sinkConnectorId));
+        sink.config, basic, workflow, false, jdbcSink);
     DataSourcePO sourceDataSource = dataSource(sourceDataSourceId, "来源端");
     DataSourcePO sinkDataSource = dataSource(sinkDataSourceId, "目标端");
+
     ObjectNode sourceOptions = connectorOptions(source.config);
     ObjectNode sinkOptions = connectorOptions(sink.config);
+    if (jdbcSource) {
+      removeDatasourceOwnedOptions(sourceOptions);
+    }
+    if (jdbcSink) {
+      removeDatasourceOwnedOptions(sinkOptions);
+    }
 
     String sourceTableView = text(sourceOptions, "table_path", null);
     String sinkTableView = text(sinkOptions, "table_path", null);
@@ -72,57 +95,86 @@ public class LinkUpJobSpecFactory {
     int batchSize = Math.max(1, sink.config.path("batchSize").asInt(1000));
     int fetchSize = Math.max(1, source.config.path("fetchSize").asInt(batchSize));
 
-    if ("jdbc".equalsIgnoreCase(sourceConnectorId)) {
-      appendConnection(sourceOptions, connection(sourceDataSource));
-      List<String> sourceTables = sourceTables(source.config, mode, jobName);
+    List<String> sourceTables = new ArrayList<>();
+    if (jdbcSource) {
+      sourceTables = sourceTables(source.config, mode, jobName);
       String sourceQuery = sourceQuery(source.config);
       sourceOptions.put("fetch_size", fetchSize);
       if ("GUIDE_MULTI".equals(mode)) {
         ArrayNode tableList = objectMapper.createArrayNode();
-        for (String table : sourceTables) tableList.addObject().put("table_path", table);
+        for (String table : sourceTables) {
+          tableList.addObject().put("table_path", table);
+        }
         sourceOptions.set("table_list", tableList);
+        sourceOptions.remove("table_path");
       } else {
         sourceOptions.put("table_path", sourceTables.get(0));
-        if (StringUtils.hasText(sourceQuery)) sourceOptions.put("query", sourceQuery);
+        sourceOptions.remove("table_list");
+        if (StringUtils.hasText(sourceQuery)) {
+          sourceOptions.put("query", sourceQuery);
+        } else {
+          sourceOptions.remove("query");
+        }
       }
       String whereCondition = text(source.config, "whereCondition", null);
-      if (StringUtils.hasText(whereCondition)) sourceOptions.put("where_condition", whereCondition.trim());
+      if (StringUtils.hasText(whereCondition)) {
+        sourceOptions.put("where_condition", whereCondition.trim());
+      }
       sourceTableView = tableView(sourceTables, mode);
-
-      if ("jdbc".equalsIgnoreCase(sinkConnectorId)) {
-        appendConnection(sinkOptions, connection(sinkDataSource));
-        String sinkTableTemplate = sinkTable(sink.config, mode, sourceTables);
-        sinkOptions.put("table_path", sinkTableTemplate);
-        sinkTableView = sinkTableView(sinkTableTemplate, sourceTables, mode);
-      }
-    } else if ("jdbc".equalsIgnoreCase(sinkConnectorId)) {
-      appendConnection(sinkOptions, connection(sinkDataSource));
-      String targetTable = text(sink.config, "targetTableName", text(sink.config, "table", null));
-      if (StringUtils.hasText(targetTable)) {
-        sinkOptions.put("table_path", targetTable.trim());
-        sinkTableView = targetTable.trim();
-      }
     }
 
-    if ("jdbc".equalsIgnoreCase(sinkConnectorId)) {
-      sinkOptions.put("schema_save_mode", sink.config.path("autoCreateTable").asBoolean(false)
-          ? "CREATE_SCHEMA_WHEN_NOT_EXIST" : "ERROR_WHEN_SCHEMA_NOT_EXIST");
+    if (jdbcSink) {
+      String sinkTableTemplate;
+      if (jdbcSource) {
+        sinkTableTemplate = sinkTable(sink.config, mode, sourceTables);
+        sinkTableView = sinkTableView(sinkTableTemplate, sourceTables, mode);
+      } else {
+        sinkTableTemplate = text(
+            sink.config,
+            "targetTableName",
+            text(sink.config, "table", text(sinkOptions, "table_path", null)));
+        if (!StringUtils.hasText(sinkTableTemplate)) {
+          throw new IllegalArgumentException("请选择或填写目标表");
+        }
+        sinkTableTemplate = sinkTableTemplate.trim();
+        sinkTableView = sinkTableTemplate;
+      }
+      sinkOptions.put("table_path", sinkTableTemplate);
+      sinkOptions.put(
+          "schema_save_mode",
+          sink.config.path("autoCreateTable").asBoolean(false)
+              ? "CREATE_SCHEMA_WHEN_NOT_EXIST"
+              : "ERROR_WHEN_SCHEMA_NOT_EXIST");
       String writeMode = text(sink.config, "writeMode", "append").toLowerCase(Locale.ROOT);
-      sinkOptions.put("data_save_mode", "overwrite".equals(writeMode) ? "DROP_DATA" : "APPEND_DATA");
+      sinkOptions.put(
+          "data_save_mode",
+          "overwrite".equals(writeMode) ? "DROP_DATA" : "APPEND_DATA");
       sinkOptions.put("write_mode", "upsert".equals(writeMode) ? "UPSERT" : "INSERT");
       if ("upsert".equals(writeMode)) {
         List<String> primaryKeys = splitValues(text(sink.config, "primaryKey", null));
-        if (primaryKeys.isEmpty()) throw new IllegalArgumentException("UPSERT 写入模式必须配置主键字段");
+        if (primaryKeys.isEmpty()) {
+          throw new IllegalArgumentException("UPSERT 写入模式必须配置主键字段");
+        }
         sinkOptions.set("primary_keys", objectMapper.valueToTree(primaryKeys));
+      } else {
+        sinkOptions.remove("primary_keys");
       }
       String customSql = text(sink.config, "sql", null);
-      if (StringUtils.hasText(customSql)) sinkOptions.put("custom_sql", customSql.trim());
+      if (StringUtils.hasText(customSql)) {
+        sinkOptions.put("custom_sql", customSql.trim());
+      }
       sinkOptions.put("batch_size", batchSize);
       JsonNode channelConfig = workflow.path("channelConfig");
       String dirtyPolicy = text(channelConfig, "dirtyDataPolicy", "stop");
-      sinkOptions.put("dirty_data_policy", "skip".equalsIgnoreCase(dirtyPolicy) ? "SKIP" : "FAIL_FAST");
+      sinkOptions.put(
+          "dirty_data_policy",
+          "skip".equalsIgnoreCase(dirtyPolicy) ? "SKIP" : "FAIL_FAST");
       if ("skip".equalsIgnoreCase(dirtyPolicy)) {
-        sinkOptions.put("dirty_data_max_count", Math.max(0, channelConfig.path("dirtyDataLimit").asInt(0)));
+        sinkOptions.put(
+            "dirty_data_max_count",
+            Math.max(0, channelConfig.path("dirtyDataLimit").asInt(0)));
+      } else {
+        sinkOptions.remove("dirty_data_max_count");
       }
     }
 
@@ -138,31 +190,98 @@ public class LinkUpJobSpecFactory {
     jobSpec.put("apiVersion", API_VERSION);
     jobSpec.put("kind", KIND);
     jobSpec.put("name", jobName.trim());
-    jobSpec.set("source", connector(sourceConnectorId, sourceOptions));
-    jobSpec.set("sink", connector(sinkConnectorId, sinkOptions));
+    jobSpec.set(
+        "source",
+        connector(sourceConnectorId, sourceOptions, sourceDataSourceId));
+    jobSpec.set(
+        "sink",
+        connector(sinkConnectorId, sinkOptions, sinkDataSourceId));
     jobSpec.set("runtime", runtime);
 
     JsonNode canonical = canonical(jobSpec);
-    return new BuildResult(canonical, write(canonical), sourceDataSource, sinkDataSource,
-        sourceConnectorId, sinkConnectorId, sourceTableView, sinkTableView);
+    return new BuildResult(
+        canonical,
+        write(canonical),
+        sourceDataSource,
+        sinkDataSource,
+        sourceConnectorId,
+        sinkConnectorId,
+        sourceTableView,
+        sinkTableView);
   }
 
-  private ObjectNode connector(String connectorId, ObjectNode options) {
+  /** Resolves datasource references immediately before a Worker submission. */
+  public JsonNode resolveForExecution(JsonNode logicalJobSpec) {
+    requireObject(logicalJobSpec, "JobSpec 不能为空");
+    ObjectNode resolved = (ObjectNode) logicalJobSpec.deepCopy();
+    resolveEndpointForExecution(resolved, "source", "来源端");
+    resolveEndpointForExecution(resolved, "sink", "目标端");
+    return canonical(resolved);
+  }
+
+  public String resolveForExecution(String logicalJobSpecJson) {
+    if (!StringUtils.hasText(logicalJobSpecJson)) {
+      throw new IllegalArgumentException("JobSpec 不能为空");
+    }
+    try {
+      return write(resolveForExecution(objectMapper.readTree(logicalJobSpecJson)));
+    } catch (JsonProcessingException exception) {
+      throw new IllegalStateException("JobSpec JSON 已损坏", exception);
+    }
+  }
+
+  private void resolveEndpointForExecution(
+      ObjectNode root,
+      String endpointName,
+      String endpointLabel) {
+    JsonNode value = root.get(endpointName);
+    requireObject(value, endpointLabel + " JobSpec 不完整");
+    ObjectNode endpoint = (ObjectNode) value;
+    String connectorId = ConnectorIdResolver.resolve(
+        text(endpoint, "connectorId", null), null, null, null);
+    endpoint.put("connectorId", connectorId);
+    if (ConnectorIdResolver.isJdbc(connectorId)) {
+      long dataSourceId = endpoint.path("dataSourceRef").path("id").asLong(0L);
+      if (dataSourceId <= 0L) {
+        throw new IllegalStateException(endpointLabel + " JDBC JobSpec 缺少 dataSourceRef.id");
+      }
+      ObjectNode options = endpoint.with("options");
+      removeDatasourceOwnedOptions(options);
+      appendConnection(options, connection(dataSource(dataSourceId, endpointLabel)));
+    }
+    endpoint.remove("dataSourceRef");
+  }
+
+  private ObjectNode connector(
+      String connectorId,
+      ObjectNode options,
+      Long dataSourceId) {
     ObjectNode connector = objectMapper.createObjectNode();
     connector.put("connectorId", connectorId);
+    if (dataSourceId != null) {
+      connector.putObject("dataSourceRef").put("id", dataSourceId);
+    }
     connector.set("options", options);
     return connector;
   }
 
   private String connectorId(JsonNode config, String fallback) {
-    return requiredValue(text(config, "connectorId", text(config, "connectorType", fallback)),
-        "Connector 类型不能为空");
+    return ConnectorIdResolver.resolve(
+        text(config, "connectorId", null),
+        text(config, "connectorType", null),
+        text(config, "dbType", null),
+        fallback);
   }
 
   private ObjectNode connectorOptions(JsonNode config) {
     JsonNode value = config == null ? null : config.get("connectorOptions");
     return value != null && value.isObject()
-        ? (ObjectNode) value.deepCopy() : objectMapper.createObjectNode();
+        ? (ObjectNode) value.deepCopy()
+        : objectMapper.createObjectNode();
+  }
+
+  private void removeDatasourceOwnedOptions(ObjectNode options) {
+    DATASOURCE_OWNED_OPTIONS.forEach(options::remove);
   }
 
   private void copyRuntime(JsonNode env, ObjectNode runtime) {
@@ -174,29 +293,51 @@ public class LinkUpJobSpecFactory {
     copyText(env, runtime, "splitAssignmentMode", "splitAssignmentMode");
   }
 
-  private void copyPositiveLong(JsonNode source, ObjectNode target, String sourceKey, String targetKey) {
+  private void copyPositiveLong(
+      JsonNode source,
+      ObjectNode target,
+      String sourceKey,
+      String targetKey) {
     JsonNode value = source == null ? null : source.get(sourceKey);
-    if (value != null && value.isNumber() && value.asLong() > 0L) target.put(targetKey, value.asLong());
+    if (value != null && value.isNumber() && value.asLong() > 0L) {
+      target.put(targetKey, value.asLong());
+    }
   }
 
-  private void copyText(JsonNode source, ObjectNode target, String sourceKey, String targetKey) {
+  private void copyText(
+      JsonNode source,
+      ObjectNode target,
+      String sourceKey,
+      String targetKey) {
     String value = text(source, sourceKey, null);
-    if (StringUtils.hasText(value)) target.put(targetKey, value.trim());
+    if (StringUtils.hasText(value)) {
+      target.put(targetKey, value.trim());
+    }
   }
 
   private void appendConnection(ObjectNode options, ConnectionDetails connection) {
     options.put("url", connection.url);
     options.put("driver", connection.driver);
-    if (connection.username != null) options.put("username", connection.username);
-    if (connection.password != null) options.put("password", connection.password);
-    if (StringUtils.hasText(connection.schema)) options.put("schema", connection.schema);
+    if (connection.username != null) {
+      options.put("username", connection.username);
+    }
+    if (connection.password != null) {
+      options.put("password", connection.password);
+    }
+    if (StringUtils.hasText(connection.schema)) {
+      options.put("schema", connection.schema);
+    }
   }
 
   private JsonNode canonical(JsonNode node) {
-    if (node == null || node.isNull() || node.isValueNode()) return node;
+    if (node == null || node.isNull() || node.isValueNode()) {
+      return node;
+    }
     if (node.isArray()) {
       ArrayNode result = objectMapper.createArrayNode();
-      for (JsonNode item : node) result.add(canonical(item));
+      for (JsonNode item : node) {
+        result.add(canonical(item));
+      }
       return result;
     }
     ObjectNode result = objectMapper.createObjectNode();
@@ -212,7 +353,9 @@ public class LinkUpJobSpecFactory {
 
   private Endpoint endpoint(JsonNode workflow, String kind) {
     JsonNode nodes = workflow.path("nodes");
-    if (!nodes.isArray()) throw new IllegalArgumentException("workflow.nodes 不能为空");
+    if (!nodes.isArray()) {
+      throw new IllegalArgumentException("workflow.nodes 不能为空");
+    }
     for (JsonNode node : nodes) {
       String nodeType = text(node.path("data"), "nodeType", text(node, "type", null));
       if (kind.equalsIgnoreCase(nodeType)) {
@@ -224,43 +367,77 @@ public class LinkUpJobSpecFactory {
     throw new IllegalArgumentException("任务缺少 " + kind + " 节点");
   }
 
-  private Long resolveDataSourceId(JsonNode config, JsonNode basic, JsonNode workflow,
-      boolean source, boolean required) {
+  private Long resolveDataSourceId(
+      JsonNode config,
+      JsonNode basic,
+      JsonNode workflow,
+      boolean source,
+      boolean required) {
     long id = config.path("dataSourceId").asLong(0L);
-    if (id <= 0L) id = basic.path(source ? "sourceDataSourceId" : "targetDataSourceId").asLong(0L);
-    if (id <= 0L) id = workflow.path(source ? "sourceDataSourceId" : "targetDataSourceId").asLong(0L);
-    if (id <= 0L && required) throw new IllegalArgumentException(source ? "请选择来源数据源" : "请选择目标数据源");
+    if (id <= 0L) {
+      id = basic.path(source ? "sourceDataSourceId" : "targetDataSourceId").asLong(0L);
+    }
+    if (id <= 0L) {
+      id = workflow.path(source ? "sourceDataSourceId" : "targetDataSourceId").asLong(0L);
+    }
+    if (id <= 0L && required) {
+      throw new IllegalArgumentException(source ? "请选择来源数据源" : "请选择目标数据源");
+    }
     return id <= 0L ? null : id;
   }
 
   private DataSourcePO dataSource(Long id, String endpointName) {
-    if (id == null) return null;
+    if (id == null) {
+      return null;
+    }
     DataSourcePO dataSource = dataSourceDao.selectById(id);
-    if (dataSource == null) throw new IllegalArgumentException(endpointName + "数据源不存在：" + id);
+    if (dataSource == null) {
+      throw new IllegalArgumentException(endpointName + "数据源不存在：" + id);
+    }
     return dataSource;
   }
 
   private ConnectionDetails connection(DataSourcePO dataSource) {
-    if (dataSource == null) throw new IllegalArgumentException("JDBC Connector 必须选择数据源");
+    if (dataSource == null) {
+      throw new IllegalArgumentException("JDBC Connector 必须选择数据源");
+    }
     JsonNode parameters = parseJson(dataSource.getConnectionParams());
     String url = firstText(parameters, "url", "jdbcUrl", "jdbc_url", "jdbc-url");
-    if (!StringUtils.hasText(url)) url = dataSource.getJdbcUrl();
-    if (!StringUtils.hasText(url)) throw new IllegalArgumentException("数据源 " + dataSource.getName() + " 缺少 JDBC URL");
-    String driver = firstText(parameters, "driver", "driverClassName", "driver_class_name", "driver-class-name");
-    if (!StringUtils.hasText(driver)) {
-      driver = defaultDriver(url, dataSource.getDbType() == null ? null : dataSource.getDbType().name());
+    if (!StringUtils.hasText(url)) {
+      url = dataSource.getJdbcUrl();
     }
-    if (!StringUtils.hasText(driver)) throw new IllegalArgumentException("数据源 " + dataSource.getName() + " 缺少 JDBC Driver");
-    return new ConnectionDetails(url.trim(), driver.trim(),
+    if (!StringUtils.hasText(url)) {
+      throw new IllegalArgumentException("数据源 " + dataSource.getName() + " 缺少 JDBC URL");
+    }
+    String driver = firstText(
+        parameters,
+        "driver",
+        "driverClassName",
+        "driver_class_name",
+        "driver-class-name");
+    if (!StringUtils.hasText(driver)) {
+      driver = defaultDriver(
+          url,
+          dataSource.getDbType() == null ? null : dataSource.getDbType().name());
+    }
+    if (!StringUtils.hasText(driver)) {
+      throw new IllegalArgumentException("数据源 " + dataSource.getName() + " 缺少 JDBC Driver");
+    }
+    return new ConnectionDetails(
+        url.trim(),
+        driver.trim(),
         firstTextAllowEmpty(parameters, "username", "user"),
         firstTextAllowEmpty(parameters, "password", "passwd"),
         firstText(parameters, "schema", "schemaName", "schema_name"));
   }
 
   private JsonNode parseJson(String value) {
-    if (!StringUtils.hasText(value)) return objectMapper.createObjectNode();
-    try { return objectMapper.readTree(value); }
-    catch (JsonProcessingException exception) {
+    if (!StringUtils.hasText(value)) {
+      return objectMapper.createObjectNode();
+    }
+    try {
+      return objectMapper.readTree(value);
+    } catch (JsonProcessingException exception) {
       throw new IllegalArgumentException("数据源连接参数不是有效 JSON", exception);
     }
   }
@@ -270,42 +447,70 @@ public class LinkUpJobSpecFactory {
       List<String> tables = flattenTables(config.path("tables"));
       if (tables.isEmpty()) {
         String pattern = text(config, "tablePattern", null);
-        if (StringUtils.hasText(pattern) && !containsWildcard(pattern)) tables.add(pattern.trim());
+        if (StringUtils.hasText(pattern) && !containsWildcard(pattern)) {
+          tables.add(pattern.trim());
+        }
       }
-      if (tables.isEmpty()) throw new IllegalArgumentException("多表同步必须选择至少一张来源表，Link-Up 暂不直接执行通配符表名");
+      if (tables.isEmpty()) {
+        throw new IllegalArgumentException(
+            "多表同步必须选择至少一张来源表，Link-Up 暂不直接执行通配符表名");
+      }
       return tables;
     }
     String table = text(config, "table", null);
     String query = sourceQuery(config);
-    if (!StringUtils.hasText(table) && StringUtils.hasText(query)) table = "yak_query." + safeIdentifier(jobName);
-    if (!StringUtils.hasText(table)) throw new IllegalArgumentException("请选择来源表");
+    if (!StringUtils.hasText(table) && StringUtils.hasText(query)) {
+      table = "yak_query." + safeIdentifier(jobName);
+    }
+    if (!StringUtils.hasText(table)) {
+      throw new IllegalArgumentException("请选择来源表");
+    }
     return new ArrayList<>(List.of(table.trim()));
   }
 
   private String sourceQuery(JsonNode config) {
-    if (!"sql".equalsIgnoreCase(text(config, "readMode", "table"))) return null;
+    if (!"sql".equalsIgnoreCase(text(config, "readMode", "table"))) {
+      return null;
+    }
     String query = text(config, "sql", null);
-    if (!StringUtils.hasText(query)) throw new IllegalArgumentException("SQL 读取模式必须填写来源查询 SQL");
+    if (!StringUtils.hasText(query)) {
+      throw new IllegalArgumentException("SQL 读取模式必须填写来源查询 SQL");
+    }
     return query.trim();
   }
 
   private String sinkTable(JsonNode config, String mode, List<String> sourceTables) {
     String explicit = text(config, "targetTableName", text(config, "table", null));
     if ("GUIDE_SINGLE".equals(mode)) {
-      if (!StringUtils.hasText(explicit)) throw new IllegalArgumentException("请选择或填写目标表");
+      if (!StringUtils.hasText(explicit)) {
+        throw new IllegalArgumentException("请选择或填写目标表");
+      }
       return explicit.trim();
     }
-    if (StringUtils.hasText(explicit)) return explicit.trim();
+    if (StringUtils.hasText(explicit)) {
+      return explicit.trim();
+    }
     String rule = text(config, "tableNamingRule", "same_name");
     String affix = text(config, "tableNameAffix", "");
-    if ("prefix".equalsIgnoreCase(rule)) return affix + "${table_name}";
-    if ("suffix".equalsIgnoreCase(rule)) return "${table_name}" + affix;
-    if (!"same_name".equalsIgnoreCase(rule) && StringUtils.hasText(affix)) return affix + "${table_name}";
+    if ("prefix".equalsIgnoreCase(rule)) {
+      return affix + "${table_name}";
+    }
+    if ("suffix".equalsIgnoreCase(rule)) {
+      return "${table_name}" + affix;
+    }
+    if (!"same_name".equalsIgnoreCase(rule) && StringUtils.hasText(affix)) {
+      return affix + "${table_name}";
+    }
     return "${table_name}";
   }
 
-  private String sinkTableView(String template, List<String> sourceTables, String mode) {
-    if ("GUIDE_SINGLE".equals(mode)) return template;
+  private String sinkTableView(
+      String template,
+      List<String> sourceTables,
+      String mode) {
+    if ("GUIDE_SINGLE".equals(mode)) {
+      return template;
+    }
     List<String> targetTables = new ArrayList<>();
     for (String sourceTable : sourceTables) {
       String schemaName = "";
@@ -315,23 +520,32 @@ public class LinkUpJobSpecFactory {
         schemaName = sourceTable.substring(0, separator);
         tableName = sourceTable.substring(separator + 1);
       }
-      targetTables.add(template.replace("${schema_name}", schemaName).replace("${table_name}", tableName));
+      targetTables.add(
+          template
+              .replace("${schema_name}", schemaName)
+              .replace("${table_name}", tableName));
     }
-    return writeValue(targetTables);
+    return writeJson(targetTables);
   }
 
   private String tableView(List<String> tables, String mode) {
-    return "GUIDE_MULTI".equals(mode) ? writeValue(tables) : tables.get(0);
+    return "GUIDE_MULTI".equals(mode) ? writeJson(tables) : tables.get(0);
   }
 
-  private String writeValue(Object value) {
-    try { return objectMapper.writeValueAsString(value); }
-    catch (JsonProcessingException exception) { throw new IllegalStateException("序列化表信息失败", exception); }
+  private String writeJson(Object value) {
+    try {
+      return objectMapper.writeValueAsString(value);
+    } catch (JsonProcessingException exception) {
+      throw new IllegalStateException("序列化表信息失败", exception);
+    }
   }
 
   private String write(JsonNode value) {
-    try { return objectMapper.writeValueAsString(value); }
-    catch (JsonProcessingException exception) { throw new IllegalStateException("序列化 Link-Up JobSpec 失败", exception); }
+    try {
+      return objectMapper.writeValueAsString(value);
+    } catch (JsonProcessingException exception) {
+      throw new IllegalStateException("序列化 JobSpec 失败", exception);
+    }
   }
 
   private List<String> flattenTables(JsonNode value) {
@@ -341,17 +555,29 @@ public class LinkUpJobSpecFactory {
   }
 
   private void flattenTables(JsonNode value, String schema, Set<String> result) {
-    if (value == null || value.isNull() || value.isMissingNode()) return;
+    if (value == null || value.isNull() || value.isMissingNode()) {
+      return;
+    }
     if (value.isTextual()) {
       String table = value.asText().trim();
-      if (StringUtils.hasText(table)) result.add(StringUtils.hasText(schema) && !table.contains(".") ? schema + "." + table : table);
+      if (StringUtils.hasText(table)) {
+        result.add(
+            StringUtils.hasText(schema) && !table.contains(".")
+                ? schema + "." + table
+                : table);
+      }
       return;
     }
     if (value.isArray()) {
-      for (JsonNode item : value) flattenTables(item, schema, result);
+      for (JsonNode item : value) {
+        flattenTables(item, schema, result);
+      }
       return;
     }
-    if (value.isObject()) value.fields().forEachRemaining(entry -> flattenTables(entry.getValue(), entry.getKey(), result));
+    if (value.isObject()) {
+      value.fields().forEachRemaining(
+          entry -> flattenTables(entry.getValue(), entry.getKey(), result));
+    }
   }
 
   private String firstText(JsonNode node, String... keys) {
@@ -366,23 +592,31 @@ public class LinkUpJobSpecFactory {
   }
 
   private String findText(JsonNode node, Set<String> normalizedKeys) {
-    if (node == null || node.isNull() || node.isMissingNode()) return null;
+    if (node == null || node.isNull() || node.isMissingNode()) {
+      return null;
+    }
     if (node.isObject()) {
       Iterator<Map.Entry<String, JsonNode>> fields = node.fields();
       while (fields.hasNext()) {
         Map.Entry<String, JsonNode> entry = fields.next();
         JsonNode value = entry.getValue();
-        if (normalizedKeys.contains(normalizeKey(entry.getKey())) && value.isValueNode()) return value.isNull() ? null : value.asText();
+        if (normalizedKeys.contains(normalizeKey(entry.getKey())) && value.isValueNode()) {
+          return value.isNull() ? null : value.asText();
+        }
       }
       fields = node.fields();
       while (fields.hasNext()) {
         String value = findText(fields.next().getValue(), normalizedKeys);
-        if (value != null) return value;
+        if (value != null) {
+          return value;
+        }
       }
     } else if (node.isArray()) {
       for (JsonNode item : node) {
         String value = findText(item, normalizedKeys);
-        if (value != null) return value;
+        if (value != null) {
+          return value;
+        }
       }
     }
     return null;
@@ -390,18 +624,36 @@ public class LinkUpJobSpecFactory {
 
   private String defaultDriver(String url, String dbType) {
     String normalized = (url + " " + (dbType == null ? "" : dbType)).toLowerCase(Locale.ROOT);
-    if (normalized.contains("mariadb")) return "org.mariadb.jdbc.Driver";
-    if (normalized.contains("mysql") || normalized.contains("doris")) return "com.mysql.cj.jdbc.Driver";
-    if (normalized.contains("postgres")) return "org.postgresql.Driver";
-    if (normalized.contains("oracle")) return "oracle.jdbc.OracleDriver";
-    if (normalized.contains("kingbase")) return "com.kingbase8.Driver";
-    if (normalized.contains("dm:") || normalized.contains("dameng")) return "dm.jdbc.driver.DmDriver";
+    if (normalized.contains("mariadb")) {
+      return "org.mariadb.jdbc.Driver";
+    }
+    if (normalized.contains("mysql") || normalized.contains("doris")) {
+      return "com.mysql.cj.jdbc.Driver";
+    }
+    if (normalized.contains("postgres")) {
+      return "org.postgresql.Driver";
+    }
+    if (normalized.contains("oracle")) {
+      return "oracle.jdbc.OracleDriver";
+    }
+    if (normalized.contains("kingbase")) {
+      return "com.kingbase8.Driver";
+    }
+    if (normalized.contains("dm:") || normalized.contains("dameng")) {
+      return "dm.jdbc.driver.DmDriver";
+    }
     return null;
   }
 
   private List<String> splitValues(String value) {
-    if (!StringUtils.hasText(value)) return new ArrayList<>();
-    return Arrays.stream(value.split(",")).map(String::trim).filter(StringUtils::hasText).distinct().toList();
+    if (!StringUtils.hasText(value)) {
+      return new ArrayList<>();
+    }
+    return Arrays.stream(value.split(","))
+        .map(String::trim)
+        .filter(StringUtils::hasText)
+        .distinct()
+        .toList();
   }
 
   private boolean containsWildcard(String value) {
@@ -414,22 +666,25 @@ public class LinkUpJobSpecFactory {
   }
 
   private String requiredText(JsonNode node, String field, String message) {
-    return requiredValue(text(node, field, null), message);
-  }
-
-  private String requiredValue(String value, String message) {
-    if (!StringUtils.hasText(value)) throw new IllegalArgumentException(message);
+    String value = text(node, field, null);
+    if (!StringUtils.hasText(value)) {
+      throw new IllegalArgumentException(message);
+    }
     return value.trim();
   }
 
   private String text(JsonNode node, String field, String fallback) {
     JsonNode value = node == null ? null : node.get(field);
-    if (value == null || value.isNull() || !value.isValueNode()) return fallback;
+    if (value == null || value.isNull() || !value.isValueNode()) {
+      return fallback;
+    }
     return value.asText(fallback);
   }
 
   private void requireObject(JsonNode node, String message) {
-    if (node == null || !node.isObject()) throw new IllegalArgumentException(message);
+    if (node == null || !node.isObject()) {
+      throw new IllegalArgumentException(message);
+    }
   }
 
   private String normalizeKey(String value) {
@@ -438,7 +693,10 @@ public class LinkUpJobSpecFactory {
 
   private static final class Endpoint {
     private final JsonNode config;
-    private Endpoint(JsonNode config) { this.config = config; }
+
+    private Endpoint(JsonNode config) {
+      this.config = config;
+    }
   }
 
   private static final class ConnectionDetails {
@@ -447,8 +705,18 @@ public class LinkUpJobSpecFactory {
     private final String username;
     private final String password;
     private final String schema;
-    private ConnectionDetails(String url, String driver, String username, String password, String schema) {
-      this.url = url; this.driver = driver; this.username = username; this.password = password; this.schema = schema;
+
+    private ConnectionDetails(
+        String url,
+        String driver,
+        String username,
+        String password,
+        String schema) {
+      this.url = url;
+      this.driver = driver;
+      this.username = username;
+      this.password = password;
+      this.schema = schema;
     }
   }
 
@@ -462,9 +730,15 @@ public class LinkUpJobSpecFactory {
     private final String sourceTable;
     private final String sinkTable;
 
-    BuildResult(JsonNode jobSpec, String jobSpecJson, DataSourcePO sourceDataSource,
-        DataSourcePO sinkDataSource, String sourceConnectorId, String sinkConnectorId,
-        String sourceTable, String sinkTable) {
+    BuildResult(
+        JsonNode jobSpec,
+        String jobSpecJson,
+        DataSourcePO sourceDataSource,
+        DataSourcePO sinkDataSource,
+        String sourceConnectorId,
+        String sinkConnectorId,
+        String sourceTable,
+        String sinkTable) {
       this.jobSpec = jobSpec;
       this.jobSpecJson = jobSpecJson;
       this.sourceDataSource = sourceDataSource;
@@ -475,13 +749,36 @@ public class LinkUpJobSpecFactory {
       this.sinkTable = sinkTable;
     }
 
-    public JsonNode getJobSpec() { return jobSpec; }
-    public String getJobSpecJson() { return jobSpecJson; }
-    public DataSourcePO getSourceDataSource() { return sourceDataSource; }
-    public DataSourcePO getSinkDataSource() { return sinkDataSource; }
-    public String getSourceConnectorId() { return sourceConnectorId; }
-    public String getSinkConnectorId() { return sinkConnectorId; }
-    public String getSourceTable() { return sourceTable; }
-    public String getSinkTable() { return sinkTable; }
+    public JsonNode getJobSpec() {
+      return jobSpec;
+    }
+
+    public String getJobSpecJson() {
+      return jobSpecJson;
+    }
+
+    public DataSourcePO getSourceDataSource() {
+      return sourceDataSource;
+    }
+
+    public DataSourcePO getSinkDataSource() {
+      return sinkDataSource;
+    }
+
+    public String getSourceConnectorId() {
+      return sourceConnectorId;
+    }
+
+    public String getSinkConnectorId() {
+      return sinkConnectorId;
+    }
+
+    public String getSourceTable() {
+      return sourceTable;
+    }
+
+    public String getSinkTable() {
+      return sinkTable;
+    }
   }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/form/ConnectorFormActionService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/form/ConnectorFormActionService.java
@@ -9,30 +9,41 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 
-/** 为动态表单提供表、字段、预览和 SQL 等受控 Action。 */
+/** 为动态表单提供 Schema 声明过的只读表和字段发现 Action。 */
 @ConditionalOnOfflineSyncEnabled
 @Service
 public class ConnectorFormActionService {
 
+  private static final Set<String> SAFE_ACTIONS = Set.of("LIST_TABLES", "LIST_COLUMNS");
+
   private final ObjectProvider<DataSourceCatalogService> catalogServiceProvider;
+  private final ConnectorFormSchemaService schemaService;
 
   public ConnectorFormActionService(
-      ObjectProvider<DataSourceCatalogService> catalogServiceProvider) {
+      ObjectProvider<DataSourceCatalogService> catalogServiceProvider,
+      ConnectorFormSchemaService schemaService) {
     this.catalogServiceProvider = catalogServiceProvider;
+    this.schemaService = schemaService;
   }
 
   public ActionResult execute(String action, ActionRequest request) {
-    String normalized = action == null ? "" : action.trim().toUpperCase(Locale.ROOT);
+    String normalized = normalize(action);
+    if (!SAFE_ACTIONS.contains(normalized)) {
+      throw new IllegalArgumentException("动态表单仅允许只读元数据 Action：" + action);
+    }
+    validateSchemaContract(normalized, request);
+
     DataSourceCatalogService catalogService = catalogServiceProvider.getIfAvailable();
     if (catalogService == null) {
       throw new IllegalStateException("数据源 Catalog 服务未启用");
     }
     Long dataSourceId = requireDataSourceId(request);
-    Map<String, Object> values = request == null || request.getValues() == null
-        ? new LinkedHashMap<>() : new LinkedHashMap<>(request.getValues());
+    Map<String, Object> values = allowedRequestValues(request);
 
     return switch (normalized) {
       case "LIST_TABLES" -> filterOptions(
@@ -42,16 +53,60 @@ public class ConnectorFormActionService {
       case "LIST_COLUMNS" -> filterOptions(
           columnOptions(catalogService.listColumn(dataSourceId, values)),
           request.getKeyword());
-      case "PREVIEW" -> ActionResult.data(catalogService.preview(dataSourceId, values));
-      case "COUNT" -> ActionResult.data(catalogService.count(dataSourceId, values));
-      case "SQL_TEMPLATE" -> ActionResult.data(catalogService.buildSqlTemplate(dataSourceId, values));
-      case "RESOLVE_SQL" -> ActionResult.data(catalogService.resolveSql(dataSourceId, values));
       default -> throw new IllegalArgumentException("不支持的 Connector Form Action：" + action);
     };
   }
 
+  private void validateSchemaContract(String action, ActionRequest request) {
+    if (request == null
+        || !StringUtils.hasText(request.getConnectorId())
+        || !StringUtils.hasText(request.getRole())
+        || !StringUtils.hasText(request.getFieldKey())) {
+      throw new IllegalArgumentException("connectorId、role 和 fieldKey 不能为空");
+    }
+    ConnectorFormSchema schema = schemaService.get(
+        request.getConnectorId().trim(),
+        request.getRole().trim());
+    ConnectorFormSchema.Field field = schema.getFields().stream()
+        .filter(item -> request.getFieldKey().trim().equals(item.getKey()))
+        .findFirst()
+        .orElseThrow(() -> new IllegalArgumentException(
+            "Form Schema 中不存在字段：" + request.getFieldKey()));
+    ConnectorFormSchema.OptionSource optionSource = field.getOptionSource();
+    if (optionSource == null || !action.equals(normalize(optionSource.getAction()))) {
+      throw new IllegalArgumentException(
+          "字段 " + field.getKey() + " 未声明 Action " + action);
+    }
+  }
+
+  private Map<String, Object> allowedRequestValues(ActionRequest request) {
+    ConnectorFormSchema schema = schemaService.get(
+        request.getConnectorId().trim(),
+        request.getRole().trim());
+    ConnectorFormSchema.Field field = schema.getFields().stream()
+        .filter(item -> request.getFieldKey().trim().equals(item.getKey()))
+        .findFirst()
+        .orElseThrow();
+    List<String> allowed = field.getOptionSource() == null
+        ? List.of()
+        : field.getOptionSource().getRequestValueKeys();
+    Map<String, Object> source = request.getValues() == null
+        ? Map.of()
+        : request.getValues();
+    if (allowed == null || allowed.isEmpty()) {
+      return new LinkedHashMap<>(source);
+    }
+    Map<String, Object> result = new LinkedHashMap<>();
+    for (String key : allowed) {
+      if (source.containsKey(key)) {
+        result.put(key, source.get(key));
+      }
+    }
+    return result;
+  }
+
   private ActionResult filterOptions(ActionResult result, String keyword) {
-    if (keyword == null || keyword.isBlank()) {
+    if (!StringUtils.hasText(keyword)) {
       return result;
     }
     String normalized = keyword.trim().toLowerCase(Locale.ROOT);
@@ -101,6 +156,10 @@ public class ConnectorFormActionService {
       throw new IllegalArgumentException("dataSourceId 不能为空");
     }
     return request.getDataSourceId();
+  }
+
+  private String normalize(String value) {
+    return value == null ? "" : value.trim().toUpperCase(Locale.ROOT).replace('-', '_');
   }
 
   public static class ActionRequest {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineExecutionControlRepository.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineExecutionControlRepository.java
@@ -12,7 +12,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
 
-/** 持久化执行扫描、状态事件和告警记录。 */
+/** 持久化执行扫描、并发领取、状态事件和告警记录。 */
 @ConditionalOnOfflineSyncEnabled
 @Repository
 public class OfflineExecutionControlRepository {
@@ -22,6 +22,17 @@ public class OfflineExecutionControlRepository {
   public OfflineExecutionControlRepository(
       @Qualifier("offlineSyncDataSource") DataSource dataSource) {
     this.jdbc = new JdbcTemplate(dataSource);
+  }
+
+  /** Must be called inside the offline-sync transaction before checking active executions. */
+  public void lockDefinition(Long definitionId) {
+    Long locked = jdbc.queryForObject(
+        "SELECT id FROM yak_offline_job_definition WHERE id = ? FOR UPDATE",
+        Long.class,
+        definitionId);
+    if (locked == null) {
+      throw new IllegalArgumentException("离线同步任务不存在：" + definitionId);
+    }
   }
 
   public boolean hasActiveExecution(Long definitionId) {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineScheduleRepository.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineScheduleRepository.java
@@ -35,10 +35,8 @@ public class OfflineScheduleRepository {
     boolean enabled = StringUtils.hasText(cronExpression)
         && !"pause".equalsIgnoreCase(runType)
         && !"paused".equalsIgnoreCase(runType);
-    int maxAttempts = nestedInt(schedule, "retryPolicy", "maxAttempts",
-        intValue(schedule, "retryTimes", 1));
-    int backoffSeconds = nestedInt(schedule, "retryPolicy", "backoffSeconds",
-        intValue(schedule, "retryIntervalSeconds", 30));
+    int maxAttempts = maxAttempts(schedule);
+    int backoffSeconds = backoffSeconds(schedule);
     LocalDateTime nextFireTime = enabled ? next(cronExpression, LocalDateTime.now()) : null;
     String scheduleJson = schedule == null || schedule.isNull() ? null : write(schedule);
 
@@ -114,6 +112,38 @@ public class OfflineScheduleRepository {
         timestamp(schedule.getNextFireTime())) > 0;
   }
 
+  private int maxAttempts(JsonNode schedule) {
+    if (schedule == null || schedule.isNull()) {
+      return 1;
+    }
+    if (!schedule.path("autoRetry").asBoolean(true)) {
+      return 1;
+    }
+    JsonNode configured = schedule.path("retryPolicy").path("maxAttempts");
+    if (configured.canConvertToInt() && configured.asInt() > 0) {
+      return configured.asInt();
+    }
+    // retryTimes is the number of retries after the first attempt.
+    return Math.max(1, intValue(schedule, "retryTimes", 0) + 1);
+  }
+
+  private int backoffSeconds(JsonNode schedule) {
+    if (schedule == null || schedule.isNull()) {
+      return 30;
+    }
+    JsonNode configured = schedule.path("retryPolicy").path("backoffSeconds");
+    if (configured.canConvertToInt() && configured.asInt() > 0) {
+      return configured.asInt();
+    }
+    JsonNode seconds = schedule.path("retryIntervalSeconds");
+    if (seconds.canConvertToInt() && seconds.asInt() > 0) {
+      return seconds.asInt();
+    }
+    // The existing editor exposes retryInterval in minutes.
+    int minutes = intValue(schedule, "retryInterval", 1);
+    return Math.max(1, minutes) * 60;
+  }
+
   private String selectSql() {
     return "SELECT job_definition_id, cron_expression, enabled, retry_max_attempts, "
         + "retry_backoff_seconds, next_fire_time, last_fire_time, schedule_json "
@@ -150,11 +180,8 @@ public class OfflineScheduleRepository {
 
   private int intValue(JsonNode node, String field, int fallback) {
     return node == null || !node.path(field).canConvertToInt()
-        ? fallback : node.path(field).asInt(fallback);
-  }
-
-  private int nestedInt(JsonNode node, String objectField, String field, int fallback) {
-    return node == null ? fallback : intValue(node.path(objectField), field, fallback);
+        ? fallback
+        : node.path(field).asInt(fallback);
   }
 
   private LocalDateTime next(String cron, LocalDateTime after) {
@@ -186,9 +213,15 @@ public class OfflineScheduleRepository {
     private final LocalDateTime lastFireTime;
     private final String scheduleJson;
 
-    public ScheduleRecord(Long jobDefinitionId, String cronExpression, boolean enabled,
-        int retryMaxAttempts, int retryBackoffSeconds, LocalDateTime nextFireTime,
-        LocalDateTime lastFireTime, String scheduleJson) {
+    public ScheduleRecord(
+        Long jobDefinitionId,
+        String cronExpression,
+        boolean enabled,
+        int retryMaxAttempts,
+        int retryBackoffSeconds,
+        LocalDateTime nextFireTime,
+        LocalDateTime lastFireTime,
+        String scheduleJson) {
       this.jobDefinitionId = jobDefinitionId;
       this.cronExpression = cronExpression;
       this.enabled = enabled;

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineDefinitionSupport.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineDefinitionSupport.java
@@ -1,12 +1,16 @@
 package io.yak.ops.business.sync.offline.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.yak.ops.business.datasource.dao.DataSourceDao;
 import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
 import io.yak.ops.business.sync.offline.engine.LinkUpJobSpecFactory;
+import io.yak.ops.business.sync.offline.form.ConnectorFormValidationService;
+import io.yak.ops.business.sync.offline.form.ConnectorFormValidationService.ValidationRequest;
+import io.yak.ops.business.sync.offline.form.ConnectorFormValidationService.ValidationResult;
 import io.yak.ops.common.bean.dto.sync.offline.OfflineJobDefinitionDTO;
 import io.yak.ops.common.bean.po.datasource.DataSourcePO;
 import io.yak.ops.common.bean.po.sync.offline.OfflineJobDefinitionPO;
@@ -15,8 +19,11 @@ import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.HexFormat;
+import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
@@ -30,27 +37,36 @@ public class OfflineDefinitionSupport {
       DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
 
   private final LinkUpJobSpecFactory jobSpecFactory;
+  private final ConnectorFormValidationService validationService;
   private final DataSourceDao dataSourceDao;
   private final ObjectMapper objectMapper;
 
   public OfflineDefinitionSupport(
       LinkUpJobSpecFactory jobSpecFactory,
+      ConnectorFormValidationService validationService,
       DataSourceDao dataSourceDao,
       @Qualifier("offlineSyncJsonMapper") ObjectMapper objectMapper) {
     this.jobSpecFactory = jobSpecFactory;
+    this.validationService = validationService;
     this.dataSourceDao = dataSourceDao;
     this.objectMapper = objectMapper;
   }
 
+  /** Builds and validates an executable logical JobSpec. */
   public PreparedDefinition prepare(OfflineJobDefinitionDTO requestDTO) {
     ObjectNode request = object(requestDTO);
     JsonNode basic = request.path("basic");
     String name = requiredText(basic, "jobName", "任务名称不能为空");
-    String mode = text(basic, "mode", text(request, "mode", "GUIDE_SINGLE"));
-    if (!"GUIDE_SINGLE".equals(mode) && !"GUIDE_MULTI".equals(mode)) {
-      throw new IllegalArgumentException("离线同步仅支持 GUIDE_SINGLE 和 GUIDE_MULTI 模式");
-    }
+    String mode = mode(request, basic);
     LinkUpJobSpecFactory.BuildResult buildResult = jobSpecFactory.build(request);
+    validateEndpoint(
+        buildResult.getSourceConnectorId(),
+        "SOURCE",
+        buildResult.getJobSpec().path("source").path("options"));
+    validateEndpoint(
+        buildResult.getSinkConnectorId(),
+        "SINK",
+        buildResult.getJobSpec().path("sink").path("options"));
     String definitionJson = write(request);
     return new PreparedDefinition(
         request,
@@ -68,22 +84,54 @@ public class OfflineDefinitionSupport {
         digest(buildResult.getJobSpecJson()));
   }
 
+  /** Prepares the lightweight record created before datasource and table configuration. */
+  public DraftDefinition prepareDraft(OfflineJobDefinitionDTO requestDTO) {
+    ObjectNode request = object(requestDTO);
+    JsonNode basic = request.path("basic");
+    String name = requiredText(basic, "jobName", "任务名称不能为空");
+    String mode = mode(request, basic);
+    return new DraftDefinition(
+        request,
+        name.trim(),
+        trim(text(basic, "jobDesc", null)),
+        mode,
+        write(request),
+        draftType(request, basic, true),
+        draftType(request, basic, false));
+  }
+
   public String buildJobSpec(OfflineJobDefinitionDTO requestDTO) {
     return prepare(requestDTO).getJobSpecJson();
   }
 
+  /** Rebuilds a logical JobSpec from a historical editable definition. */
   public String buildJobSpec(String definitionJson) {
     JsonNode parsed = read(definitionJson);
     if (parsed == null || !parsed.isObject()) {
       throw new IllegalStateException("任务定义 JSON 已损坏");
     }
-    return jobSpecFactory.build(parsed).getJobSpecJson();
+    LinkUpJobSpecFactory.BuildResult result = jobSpecFactory.build(parsed);
+    validateEndpoint(
+        result.getSourceConnectorId(),
+        "SOURCE",
+        result.getJobSpec().path("source").path("options"));
+    validateEndpoint(
+        result.getSinkConnectorId(),
+        "SINK",
+        result.getJobSpec().path("sink").path("options"));
+    return result.getJobSpecJson();
+  }
+
+  /** Resolves the current datasource credentials only for the outbound Worker request. */
+  public String resolveExecutionJobSpec(String logicalJobSpecJson) {
+    return jobSpecFactory.resolveForExecution(logicalJobSpecJson);
   }
 
   public JsonNode editDetail(OfflineJobDefinitionPO definition) {
     JsonNode parsed = read(definition.getDefinitionJson());
     ObjectNode detail = parsed != null && parsed.isObject()
-        ? (ObjectNode) parsed.deepCopy() : objectMapper.createObjectNode();
+        ? (ObjectNode) parsed.deepCopy()
+        : objectMapper.createObjectNode();
     detail.put("id", definition.getId());
     detail.put("mode", definition.getMode());
     ObjectNode state = detail.with("state");
@@ -93,6 +141,7 @@ public class OfflineDefinitionSupport {
     state.set("lastExecutionId", objectMapper.valueToTree(definition.getLastExecutionId()));
     state.put("lastEngineJobId", definition.getLastEngineJobId());
     state.set("currentVersionId", objectMapper.valueToTree(definition.getCurrentVersionId()));
+    state.put("draft", definition.getCurrentVersionId() == null);
     return detail;
   }
 
@@ -130,7 +179,8 @@ public class OfflineDefinitionSupport {
         .syncSize(formatBytes(definition.getLastSyncBytes()))
         .cronExpression(cronExpression)
         .scheduleStatus(scheduled ? "NORMAL" : "PAUSED")
-        .lastScheduleTime(format(lastFireTime == null ? definition.getLastStartTime() : lastFireTime))
+        .lastScheduleTime(
+            format(lastFireTime == null ? definition.getLastStartTime() : lastFireTime))
         .nextScheduleTime(format(nextFireTime))
         .createTime(format(definition.getCreateTime()))
         .updateTime(format(definition.getUpdateTime()))
@@ -141,24 +191,68 @@ public class OfflineDefinitionSupport {
     return value == null || value.isMissingNode() || value.isNull() ? null : write(value);
   }
 
+  private void validateEndpoint(String connectorId, String role, JsonNode options) {
+    ValidationRequest request = new ValidationRequest();
+    Map<String, Object> values = options == null || !options.isObject()
+        ? Map.of()
+        : objectMapper.convertValue(options, new TypeReference<Map<String, Object>>() { });
+    request.setValues(values);
+    ValidationResult result = validationService.validate(connectorId, role, request);
+    if (result.isValid()) {
+      return;
+    }
+    List<String> errors = new ArrayList<>(result.getFormErrors());
+    result.getFieldErrors().values().forEach(errors::addAll);
+    String message = errors.isEmpty() ? "Connector 配置校验失败" : errors.get(0);
+    throw new IllegalArgumentException(role + " Connector 配置不合法：" + message);
+  }
+
   private ObjectNode object(OfflineJobDefinitionDTO requestDTO) {
-    if (requestDTO == null) throw new IllegalArgumentException("任务定义不能为空");
+    if (requestDTO == null) {
+      throw new IllegalArgumentException("任务定义不能为空");
+    }
     JsonNode value = objectMapper.valueToTree(requestDTO);
-    if (!value.isObject()) throw new IllegalArgumentException("任务定义格式不正确");
+    if (!value.isObject()) {
+      throw new IllegalArgumentException("任务定义格式不正确");
+    }
     return (ObjectNode) value;
   }
 
+  private String mode(JsonNode request, JsonNode basic) {
+    String mode = text(basic, "mode", text(request, "mode", "GUIDE_SINGLE"));
+    if (!"GUIDE_SINGLE".equals(mode) && !"GUIDE_MULTI".equals(mode)) {
+      throw new IllegalArgumentException("离线同步仅支持 GUIDE_SINGLE 和 GUIDE_MULTI 模式");
+    }
+    return mode;
+  }
+
+  private String draftType(JsonNode request, JsonNode basic, boolean source) {
+    String basicField = source ? "sourceType" : "targetType";
+    String workflowField = source ? "sourceType" : "targetType";
+    String value = text(basic, basicField, null);
+    if (StringUtils.hasText(value)) {
+      return value.trim();
+    }
+    JsonNode workflowValue = request.path("workflow").path(workflowField);
+    value = text(workflowValue, "dbType", null);
+    return StringUtils.hasText(value) ? value.trim() : null;
+  }
+
   private JsonNode read(String value) {
-    if (!StringUtils.hasText(value)) return objectMapper.createObjectNode();
-    try { return objectMapper.readTree(value); }
-    catch (JsonProcessingException exception) {
+    if (!StringUtils.hasText(value)) {
+      return objectMapper.createObjectNode();
+    }
+    try {
+      return objectMapper.readTree(value);
+    } catch (JsonProcessingException exception) {
       throw new IllegalStateException("任务定义 JSON 已损坏", exception);
     }
   }
 
   private String write(JsonNode value) {
-    try { return objectMapper.writeValueAsString(value); }
-    catch (JsonProcessingException exception) {
+    try {
+      return objectMapper.writeValueAsString(value);
+    } catch (JsonProcessingException exception) {
       throw new IllegalStateException("序列化任务定义失败", exception);
     }
   }
@@ -175,31 +269,93 @@ public class OfflineDefinitionSupport {
 
   private String requiredText(JsonNode node, String field, String message) {
     String value = text(node, field, null);
-    if (!StringUtils.hasText(value)) throw new IllegalArgumentException(message);
+    if (!StringUtils.hasText(value)) {
+      throw new IllegalArgumentException(message);
+    }
     return value;
   }
 
   private String text(JsonNode node, String field, String fallback) {
-    if (node == null || node.isMissingNode() || node.isNull()) return fallback;
+    if (node == null || node.isMissingNode() || node.isNull()) {
+      return fallback;
+    }
     JsonNode value = node.get(field);
     return value == null || value.isNull() || !value.isValueNode()
-        ? fallback : value.asText(fallback);
+        ? fallback
+        : value.asText(fallback);
   }
 
-  private String trim(String value) { return StringUtils.hasText(value) ? value.trim() : null; }
-  private DataSourcePO dataSource(Long id) { return id == null ? null : dataSourceDao.selectById(id); }
-  private String format(LocalDateTime value) { return value == null ? null : value.format(FORMAT); }
-  private long seconds(Long millis) { return millis == null ? 0L : Math.max(0L, millis / 1000L); }
-  private long value(Long number) { return number == null ? 0L : number; }
-  private double value(Double number) { return number == null ? 0D : number; }
+  private String trim(String value) {
+    return StringUtils.hasText(value) ? value.trim() : null;
+  }
+
+  private DataSourcePO dataSource(Long id) {
+    return id == null ? null : dataSourceDao.selectById(id);
+  }
+
+  private String format(LocalDateTime value) {
+    return value == null ? null : value.format(FORMAT);
+  }
+
+  private long seconds(Long millis) {
+    return millis == null ? 0L : Math.max(0L, millis / 1000L);
+  }
+
+  private long value(Long number) {
+    return number == null ? 0L : number;
+  }
+
+  private double value(Double number) {
+    return number == null ? 0D : number;
+  }
 
   private String formatBytes(Long bytes) {
-    if (bytes == null || bytes <= 0L) return "-";
+    if (bytes == null || bytes <= 0L) {
+      return "-";
+    }
     double size = bytes;
     String[] units = {"B", "KB", "MB", "GB", "TB"};
     int unit = 0;
-    while (size >= 1024D && unit < units.length - 1) { size /= 1024D; unit++; }
+    while (size >= 1024D && unit < units.length - 1) {
+      size /= 1024D;
+      unit++;
+    }
     return String.format(Locale.ROOT, "%.2f %s", size, units[unit]);
+  }
+
+  public static final class DraftDefinition {
+    private final ObjectNode request;
+    private final String jobName;
+    private final String jobDesc;
+    private final String mode;
+    private final String definitionJson;
+    private final String sourceType;
+    private final String sinkType;
+
+    public DraftDefinition(
+        ObjectNode request,
+        String jobName,
+        String jobDesc,
+        String mode,
+        String definitionJson,
+        String sourceType,
+        String sinkType) {
+      this.request = request;
+      this.jobName = jobName;
+      this.jobDesc = jobDesc;
+      this.mode = mode;
+      this.definitionJson = definitionJson;
+      this.sourceType = sourceType;
+      this.sinkType = sinkType;
+    }
+
+    public ObjectNode getRequest() { return request; }
+    public String getJobName() { return jobName; }
+    public String getJobDesc() { return jobDesc; }
+    public String getMode() { return mode; }
+    public String getDefinitionJson() { return definitionJson; }
+    public String getSourceType() { return sourceType; }
+    public String getSinkType() { return sinkType; }
   }
 
   public static final class PreparedDefinition {
@@ -217,16 +373,35 @@ public class OfflineDefinitionSupport {
     private final String sinkTable;
     private final String digest;
 
-    public PreparedDefinition(ObjectNode request, String jobName, String jobDesc, String mode,
-        String definitionJson, String jobSpecJson, DataSourcePO source, DataSourcePO sink,
-        String sourceConnectorId, String sinkConnectorId,
-        String sourceTable, String sinkTable, String digest) {
-      this.request = request; this.jobName = jobName; this.jobDesc = jobDesc; this.mode = mode;
-      this.definitionJson = definitionJson; this.jobSpecJson = jobSpecJson; this.source = source;
-      this.sink = sink; this.sourceConnectorId = sourceConnectorId;
-      this.sinkConnectorId = sinkConnectorId; this.sourceTable = sourceTable; this.sinkTable = sinkTable;
+    public PreparedDefinition(
+        ObjectNode request,
+        String jobName,
+        String jobDesc,
+        String mode,
+        String definitionJson,
+        String jobSpecJson,
+        DataSourcePO source,
+        DataSourcePO sink,
+        String sourceConnectorId,
+        String sinkConnectorId,
+        String sourceTable,
+        String sinkTable,
+        String digest) {
+      this.request = request;
+      this.jobName = jobName;
+      this.jobDesc = jobDesc;
+      this.mode = mode;
+      this.definitionJson = definitionJson;
+      this.jobSpecJson = jobSpecJson;
+      this.source = source;
+      this.sink = sink;
+      this.sourceConnectorId = sourceConnectorId;
+      this.sinkConnectorId = sinkConnectorId;
+      this.sourceTable = sourceTable;
+      this.sinkTable = sinkTable;
       this.digest = digest;
     }
+
     public ObjectNode getRequest() { return request; }
     public String getJobName() { return jobName; }
     public String getJobDesc() { return jobDesc; }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineExecutionClaimService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineExecutionClaimService.java
@@ -1,0 +1,114 @@
+package io.yak.ops.business.sync.offline.service;
+
+import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import io.yak.ops.business.sync.offline.dao.OfflineJobExecutionDao;
+import io.yak.ops.business.sync.offline.domain.OfflineExecutionStatus;
+import io.yak.ops.business.sync.offline.repository.OfflineDefinitionCatalogRepository.DefinitionVersion;
+import io.yak.ops.business.sync.offline.repository.OfflineExecutionControlRepository;
+import io.yak.ops.business.sync.offline.repository.OfflineNodeRepository.NodeRecord;
+import io.yak.ops.common.bean.po.sync.offline.OfflineJobDefinitionPO;
+import io.yak.ops.common.bean.po.sync.offline.OfflineJobExecutionPO;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/** Atomically claims a definition and creates one durable execution attempt. */
+@ConditionalOnOfflineSyncEnabled
+@Service
+public class OfflineExecutionClaimService {
+
+  private final OfflineJobDefinitionService definitionService;
+  private final OfflineJobExecutionDao executionDao;
+  private final OfflineExecutionControlRepository executionRepository;
+
+  public OfflineExecutionClaimService(
+      OfflineJobDefinitionService definitionService,
+      OfflineJobExecutionDao executionDao,
+      OfflineExecutionControlRepository executionRepository) {
+    this.definitionService = definitionService;
+    this.executionDao = executionDao;
+    this.executionRepository = executionRepository;
+  }
+
+  @Transactional(transactionManager = "offlineSyncTransactionManager", rollbackFor = Exception.class)
+  public ClaimResult claim(
+      Long definitionId,
+      String triggerType,
+      Long retryFromExecutionId,
+      int attemptNo,
+      NodeRecord node) {
+    if (node == null) {
+      throw new IllegalArgumentException("Link-Up Worker 节点不能为空");
+    }
+    executionRepository.lockDefinition(definitionId);
+    OfflineJobDefinitionPO definition = definitionService.require(definitionId);
+    if (!"ONLINE".equalsIgnoreCase(definition.getReleaseState())) {
+      throw new IllegalStateException("请先上线任务，再执行运行操作");
+    }
+    if (executionRepository.hasActiveExecution(definitionId)) {
+      throw new IllegalStateException("任务已有运行中的执行实例，不能重复提交");
+    }
+
+    DefinitionVersion version = definitionService.requireCurrentVersion(definition);
+    String logicalJobSpecJson = definitionService.resolveLogicalJobSpec(version);
+    LocalDateTime now = LocalDateTime.now();
+    OfflineJobExecutionPO execution = new OfflineJobExecutionPO();
+    execution.setJobDefinitionId(definitionId);
+    execution.setDefinitionVersionId(version.getId());
+    execution.setDefinitionVersion(version.getVersionNo());
+    execution.setEngineNodeId(node.getNodeId());
+    execution.setWorkerInstanceId(node.getWorkerInstanceId());
+    execution.setStatus(OfflineExecutionStatus.CREATED.name());
+    execution.setStateVersion(1L);
+    execution.setAttemptNo(Math.max(1, attemptNo));
+    execution.setTriggerType(triggerType);
+    execution.setRetryFromExecutionId(retryFromExecutionId);
+    execution.setCancellationRequested(false);
+    execution.setRetryCreated(false);
+    execution.setConfigDigest(version.getConfigDigest());
+    execution.setSubmittedConfig(logicalJobSpecJson);
+    execution.setSourceRecordCount(0L);
+    execution.setSinkSuccessRecordCount(0L);
+    execution.setSourceReadBytes(0L);
+    execution.setSinkWrittenBytes(0L);
+    execution.setQps(0D);
+    execution.setDurationMillis(0L);
+    execution.setCreateTime(now);
+    execution.setUpdateTime(now);
+    if (!executionDao.insert(execution) || execution.getId() == null) {
+      throw new IllegalStateException("创建离线同步执行实例失败");
+    }
+
+    execution.setExternalExecutionId("yak-offline-execution-" + execution.getId());
+    execution.setIdempotencyKey(UUID.randomUUID().toString());
+    execution.setUpdateTime(LocalDateTime.now());
+    if (!executionDao.updateById(execution)) {
+      throw new IllegalStateException("初始化离线同步执行标识失败");
+    }
+    return new ClaimResult(definition, version, logicalJobSpecJson, execution);
+  }
+
+  public static final class ClaimResult {
+    private final OfflineJobDefinitionPO definition;
+    private final DefinitionVersion version;
+    private final String logicalJobSpecJson;
+    private final OfflineJobExecutionPO execution;
+
+    public ClaimResult(
+        OfflineJobDefinitionPO definition,
+        DefinitionVersion version,
+        String logicalJobSpecJson,
+        OfflineJobExecutionPO execution) {
+      this.definition = definition;
+      this.version = version;
+      this.logicalJobSpecJson = logicalJobSpecJson;
+      this.execution = execution;
+    }
+
+    public OfflineJobDefinitionPO getDefinition() { return definition; }
+    public DefinitionVersion getVersion() { return version; }
+    public String getLogicalJobSpecJson() { return logicalJobSpecJson; }
+    public OfflineJobExecutionPO getExecution() { return execution; }
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineExecutionOrchestrator.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineExecutionOrchestrator.java
@@ -11,17 +11,17 @@ import io.yak.ops.business.sync.offline.domain.OfflineExecutionStatus;
 import io.yak.ops.business.sync.offline.engine.LinkUpClient;
 import io.yak.ops.business.sync.offline.engine.LinkUpClient.LinkUpJobResponse;
 import io.yak.ops.business.sync.offline.engine.LinkUpClient.LinkUpRequestException;
-import io.yak.ops.business.sync.offline.repository.OfflineDefinitionCatalogRepository.DefinitionVersion;
+import io.yak.ops.business.sync.offline.engine.LinkUpClient.LinkUpTransportException;
 import io.yak.ops.business.sync.offline.repository.OfflineExecutionControlRepository;
 import io.yak.ops.business.sync.offline.repository.OfflineNodeRepository.NodeRecord;
 import io.yak.ops.business.sync.offline.repository.OfflineScheduleRepository;
 import io.yak.ops.business.sync.offline.repository.OfflineScheduleRepository.ScheduleRecord;
+import io.yak.ops.business.sync.offline.service.OfflineExecutionClaimService.ClaimResult;
 import io.yak.ops.common.bean.po.sync.offline.OfflineJobDefinitionPO;
 import io.yak.ops.common.bean.po.sync.offline.OfflineJobExecutionPO;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
-import java.util.UUID;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
@@ -32,6 +32,7 @@ import org.springframework.util.StringUtils;
 public class OfflineExecutionOrchestrator {
 
   private final OfflineJobDefinitionService definitionService;
+  private final OfflineExecutionClaimService claimService;
   private final OfflineJobDefinitionDao definitionDao;
   private final OfflineJobExecutionDao executionDao;
   private final OfflineExecutionControlRepository executionRepository;
@@ -44,6 +45,7 @@ public class OfflineExecutionOrchestrator {
 
   public OfflineExecutionOrchestrator(
       OfflineJobDefinitionService definitionService,
+      OfflineExecutionClaimService claimService,
       OfflineJobDefinitionDao definitionDao,
       OfflineJobExecutionDao executionDao,
       OfflineExecutionControlRepository executionRepository,
@@ -54,6 +56,7 @@ public class OfflineExecutionOrchestrator {
       OfflineSyncProperties properties,
       @Qualifier("offlineSyncJsonMapper") ObjectMapper objectMapper) {
     this.definitionService = definitionService;
+    this.claimService = claimService;
     this.definitionDao = definitionDao;
     this.executionDao = executionDao;
     this.executionRepository = executionRepository;
@@ -66,70 +69,76 @@ public class OfflineExecutionOrchestrator {
   }
 
   public OfflineJobExecutionPO execute(
-      Long definitionId, String triggerType, Long retryFromExecutionId, int attemptNo) {
-    OfflineJobDefinitionPO definition = definitionService.require(definitionId);
-    if (!"ONLINE".equalsIgnoreCase(definition.getReleaseState())) {
-      throw new IllegalStateException("请先上线任务，再执行运行操作");
-    }
-    if (executionRepository.hasActiveExecution(definitionId)) {
-      throw new IllegalStateException("任务已有运行中的执行实例，不能重复提交");
-    }
-    DefinitionVersion version = definitionService.requireCurrentVersion(definition);
-    String jobSpecJson = definitionService.resolveJobSpec(version);
-    JsonNode jobSpec = readJobSpec(jobSpecJson);
+      Long definitionId,
+      String triggerType,
+      Long retryFromExecutionId,
+      int attemptNo) {
     NodeRecord node = workerRegistry.selectNode();
-
-    LocalDateTime now = LocalDateTime.now();
-    OfflineJobExecutionPO execution = new OfflineJobExecutionPO();
-    execution.setJobDefinitionId(definitionId);
-    execution.setDefinitionVersionId(version.getId());
-    execution.setDefinitionVersion(version.getVersionNo());
-    execution.setEngineNodeId(node.getNodeId());
-    execution.setWorkerInstanceId(node.getWorkerInstanceId());
-    execution.setStatus(OfflineExecutionStatus.CREATED.name());
-    execution.setStateVersion(1L);
-    execution.setAttemptNo(Math.max(1, attemptNo));
-    execution.setTriggerType(triggerType);
-    execution.setRetryFromExecutionId(retryFromExecutionId);
-    execution.setCancellationRequested(false);
-    execution.setRetryCreated(false);
-    execution.setConfigDigest(version.getConfigDigest());
-    execution.setSubmittedConfig(jobSpecJson);
-    execution.setSourceRecordCount(0L);
-    execution.setSinkSuccessRecordCount(0L);
-    execution.setSourceReadBytes(0L);
-    execution.setSinkWrittenBytes(0L);
-    execution.setQps(0D);
-    execution.setDurationMillis(0L);
-    execution.setCreateTime(now);
-    execution.setUpdateTime(now);
-    executionDao.insert(execution);
-
-    execution.setExternalExecutionId("yak-offline-execution-" + execution.getId());
-    execution.setIdempotencyKey(UUID.randomUUID().toString());
-    executionDao.updateById(execution);
+    ClaimResult claim = claimService.claim(
+        definitionId,
+        triggerType,
+        retryFromExecutionId,
+        attemptNo,
+        node);
+    OfflineJobExecutionPO execution = claim.getExecution();
     record(execution, null, execution.getStatus(), "CREATED", "Yak Ops 已创建执行实例", null);
 
     try {
-      transition(execution, OfflineExecutionStatus.SUBMITTED, "SUBMITTING", "正在提交 Link-Up JobSpec", null);
+      String resolvedJobSpecJson = definitionService.resolveExecutionJobSpec(claim.getVersion());
+      JsonNode resolvedJobSpec = readJobSpec(resolvedJobSpecJson);
+      transition(
+          execution,
+          OfflineExecutionStatus.SUBMITTED,
+          "SUBMITTING",
+          "正在提交 Link-Up JobSpec",
+          null);
       LinkUpJobResponse response = linkUpClient.submit(
-          execution.getExternalExecutionId(), execution.getIdempotencyKey(),
-          version.getVersionNo(), jobSpec);
+          execution.getExternalExecutionId(),
+          execution.getIdempotencyKey(),
+          claim.getVersion().getVersionNo(),
+          resolvedJobSpec);
       applySnapshot(execution, response, "SUBMITTED");
       return execution;
     } catch (LinkUpRequestException exception) {
       boolean retryable = exception.getStatusCode() == 429 || exception.getStatusCode() >= 500;
-      markTerminal(execution, OfflineExecutionStatus.FAILED,
-          exception.getCode() + "：" + exception.getMessage(), null, retryable);
+      markTerminal(
+          execution,
+          OfflineExecutionStatus.FAILED,
+          exception.getCode() + "：" + exception.getMessage(),
+          null,
+          retryable);
+      throw exception;
+    } catch (LinkUpTransportException exception) {
+      if (exception.isUncertain()) {
+        // The Worker may have accepted the idempotent request. Reconcile by externalExecutionId.
+        execution.setErrorMessage(exception.getMessage());
+        execution.setLastSyncTime(LocalDateTime.now());
+        execution.setUpdateTime(LocalDateTime.now());
+        executionDao.updateById(execution);
+        record(
+            execution,
+            execution.getStatus(),
+            execution.getStatus(),
+            "SUBMIT_UNCERTAIN",
+            exception.getMessage(),
+            null);
+        return execution;
+      }
+      markTerminal(
+          execution,
+          OfflineExecutionStatus.FAILED,
+          exception.getMessage(),
+          null,
+          true);
       throw exception;
     } catch (RuntimeException exception) {
-      execution.setErrorMessage(exception.getMessage());
-      execution.setLastSyncTime(LocalDateTime.now());
-      execution.setUpdateTime(LocalDateTime.now());
-      executionDao.updateById(execution);
-      record(execution, execution.getStatus(), execution.getStatus(),
-          "SUBMIT_UNCERTAIN", exception.getMessage(), null);
-      return execution;
+      markTerminal(
+          execution,
+          OfflineExecutionStatus.FAILED,
+          exception.getMessage(),
+          null,
+          false);
+      throw exception;
     }
   }
 
@@ -137,7 +146,10 @@ public class OfflineExecutionOrchestrator {
     if (previous == null || previous.getId() == null) {
       throw new IllegalArgumentException("重试来源实例不能为空");
     }
-    return execute(previous.getJobDefinitionId(), "RETRY", previous.getId(),
+    return execute(
+        previous.getJobDefinitionId(),
+        "RETRY",
+        previous.getId(),
         value(previous.getAttemptNo(), 1) + 1);
   }
 
@@ -149,28 +161,43 @@ public class OfflineExecutionOrchestrator {
     execution.setCancellationRequested(true);
     execution.setUpdateTime(LocalDateTime.now());
     executionDao.updateById(execution);
-    record(execution, execution.getStatus(), execution.getStatus(),
-        "CANCEL_REQUESTED", "Yak Ops 已记录取消意图", null);
+    record(
+        execution,
+        execution.getStatus(),
+        execution.getStatus(),
+        "CANCEL_REQUESTED",
+        "Yak Ops 已记录取消意图",
+        null);
     if (StringUtils.hasText(execution.getEngineJobId())) {
-      applySnapshot(execution, linkUpClient.cancel(execution.getEngineJobId()), "CANCEL_ACCEPTED");
+      applySnapshot(
+          execution,
+          linkUpClient.cancel(execution.getEngineJobId()),
+          "CANCEL_ACCEPTED");
     }
     return execution;
   }
 
   public void applySnapshot(
-      OfflineJobExecutionPO execution, LinkUpJobResponse response, String eventType) {
-    if (execution == null || response == null) return;
+      OfflineJobExecutionPO execution,
+      LinkUpJobResponse response,
+      String eventType) {
+    if (execution == null || response == null) {
+      return;
+    }
     String previousStatus = execution.getStatus();
     OfflineExecutionStatus nextStatus = StringUtils.hasText(response.getStatus())
         ? OfflineExecutionStatus.parse(response.getStatus())
         : OfflineExecutionStatus.parse(execution.getStatus());
     execution.setEngineJobId(first(response.getJobId(), execution.getEngineJobId()));
-    execution.setWorkerInstanceId(first(response.getWorkerInstanceId(), execution.getWorkerInstanceId()));
+    execution.setWorkerInstanceId(
+        first(response.getWorkerInstanceId(), execution.getWorkerInstanceId()));
     execution.setStatus(nextStatus.name());
-    execution.setStateVersion(Math.max(value(execution.getStateVersion(), 0L),
+    execution.setStateVersion(Math.max(
+        value(execution.getStateVersion(), 0L),
         value(response.getStateVersion(), 0L)));
-    execution.setCancellationRequested(Boolean.TRUE.equals(response.getCancellationRequested())
-        || Boolean.TRUE.equals(execution.getCancellationRequested()));
+    execution.setCancellationRequested(
+        Boolean.TRUE.equals(response.getCancellationRequested())
+            || Boolean.TRUE.equals(execution.getCancellationRequested()));
     execution.setEngineSnapshotJson(write(response));
     execution.setErrorMessage(response.getErrorMessage());
     JsonNode metrics = response.getMetrics();
@@ -178,7 +205,10 @@ public class OfflineExecutionOrchestrator {
     execution.setSinkSuccessRecordCount(number(metrics, "sinkSuccessRecordCount", 0L));
     execution.setSourceReadBytes(number(metrics, "sourceReadBytes", 0L));
     execution.setSinkWrittenBytes(number(metrics, "sinkWrittenBytes", 0L));
-    execution.setQps(decimal(metrics, "sourceAverageQps", decimal(metrics, "sinkAverageQps", 0D)));
+    execution.setQps(decimal(
+        metrics,
+        "sourceAverageQps",
+        decimal(metrics, "sinkAverageQps", 0D)));
     execution.setDurationMillis(value(response.getDurationMillis(), 0L));
     execution.setStartTime(time(response.getStartTimeMillis()));
     execution.setEndTime(time(response.getEndTimeMillis()));
@@ -188,8 +218,13 @@ public class OfflineExecutionOrchestrator {
     executionDao.updateById(execution);
     updateDefinition(execution, nextStatus);
     if (!nextStatus.name().equals(previousStatus)) {
-      record(execution, previousStatus, nextStatus.name(), eventType,
-          response.getErrorMessage(), execution.getEngineSnapshotJson());
+      record(
+          execution,
+          previousStatus,
+          nextStatus.name(),
+          eventType,
+          response.getErrorMessage(),
+          execution.getEngineSnapshotJson());
     }
     publishAlert(execution, nextStatus);
   }
@@ -205,12 +240,18 @@ public class OfflineExecutionOrchestrator {
       throw new IllegalArgumentException("任务实例 ID 不合法");
     }
     OfflineJobExecutionPO execution = executionDao.selectById(executionId);
-    if (execution == null) throw new IllegalArgumentException("离线同步任务实例不存在：" + executionId);
+    if (execution == null) {
+      throw new IllegalArgumentException("离线同步任务实例不存在：" + executionId);
+    }
     return execution;
   }
 
-  private void markTerminal(OfflineJobExecutionPO execution, OfflineExecutionStatus status,
-      String message, String payload, boolean retryable) {
+  private void markTerminal(
+      OfflineJobExecutionPO execution,
+      OfflineExecutionStatus status,
+      String message,
+      String payload,
+      boolean retryable) {
     String previousStatus = execution.getStatus();
     execution.setStatus(status.name());
     execution.setStateVersion(value(execution.getStateVersion(), 0L) + 1L);
@@ -225,9 +266,13 @@ public class OfflineExecutionOrchestrator {
     publishAlert(execution, status);
   }
 
-  private void updateDefinition(OfflineJobExecutionPO execution, OfflineExecutionStatus status) {
+  private void updateDefinition(
+      OfflineJobExecutionPO execution,
+      OfflineExecutionStatus status) {
     OfflineJobDefinitionPO definition = definitionDao.selectById(execution.getJobDefinitionId());
-    if (definition == null) return;
+    if (definition == null) {
+      return;
+    }
     definition.setLastExecutionId(execution.getId());
     definition.setLastEngineJobId(execution.getEngineJobId());
     definition.setLastJobStatus(status.name());
@@ -235,7 +280,8 @@ public class OfflineExecutionOrchestrator {
     definition.setLastDurationMillis(execution.getDurationMillis());
     definition.setLastReadRowCount(execution.getSourceRecordCount());
     definition.setLastQps(execution.getQps());
-    definition.setLastSyncBytes(Math.max(value(execution.getSourceReadBytes(), 0L),
+    definition.setLastSyncBytes(Math.max(
+        value(execution.getSourceReadBytes(), 0L),
         value(execution.getSinkWrittenBytes(), 0L)));
     definition.setLastStartTime(execution.getStartTime());
     definition.setLastEndTime(execution.getEndTime());
@@ -243,8 +289,12 @@ public class OfflineExecutionOrchestrator {
     definitionDao.updateById(definition);
   }
 
-  private void transition(OfflineJobExecutionPO execution, OfflineExecutionStatus target,
-      String eventType, String message, String payload) {
+  private void transition(
+      OfflineJobExecutionPO execution,
+      OfflineExecutionStatus target,
+      String eventType,
+      String message,
+      String payload) {
     String previous = execution.getStatus();
     execution.setStatus(target.name());
     execution.setStateVersion(value(execution.getStateVersion(), 0L) + 1L);
@@ -254,32 +304,52 @@ public class OfflineExecutionOrchestrator {
   }
 
   private void configureRetry(
-      OfflineJobExecutionPO execution, OfflineExecutionStatus status, boolean retryable) {
+      OfflineJobExecutionPO execution,
+      OfflineExecutionStatus status,
+      boolean retryable) {
     execution.setNextRetryTime(null);
-    if (!retryable || (status != OfflineExecutionStatus.FAILED && status != OfflineExecutionStatus.LOST)) return;
+    if (!retryable
+        || (status != OfflineExecutionStatus.FAILED
+            && status != OfflineExecutionStatus.LOST)) {
+      return;
+    }
     ScheduleRecord schedule = scheduleRepository.findSchedule(execution.getJobDefinitionId());
     int maxAttempts = schedule == null
-        ? properties.getControl().getDefaultMaxAttempts() : schedule.getRetryMaxAttempts();
+        ? properties.getControl().getDefaultMaxAttempts()
+        : schedule.getRetryMaxAttempts();
     int backoff = schedule == null
-        ? properties.getControl().getDefaultRetryBackoffSeconds() : schedule.getRetryBackoffSeconds();
+        ? properties.getControl().getDefaultRetryBackoffSeconds()
+        : schedule.getRetryBackoffSeconds();
     if (value(execution.getAttemptNo(), 1) < Math.max(1, maxAttempts)) {
       execution.setNextRetryTime(LocalDateTime.now().plusSeconds(Math.max(1, backoff)));
     }
   }
 
-  private boolean retryable(LinkUpJobResponse response, OfflineExecutionStatus status) {
-    if (status == OfflineExecutionStatus.LOST) return true;
-    if (status != OfflineExecutionStatus.FAILED) return false;
+  private boolean retryable(
+      LinkUpJobResponse response,
+      OfflineExecutionStatus status) {
+    if (status == OfflineExecutionStatus.LOST) {
+      return true;
+    }
+    if (status != OfflineExecutionStatus.FAILED) {
+      return false;
+    }
     String code = response == null ? null : response.getErrorCode();
-    if (!StringUtils.hasText(code)) return true;
+    if (!StringUtils.hasText(code)) {
+      return true;
+    }
     String normalized = code.toUpperCase(java.util.Locale.ROOT);
-    return !(normalized.contains("CONFIG") || normalized.contains("VALIDATION")
-        || normalized.contains("IDEMPOTENCY") || normalized.contains("BAD_REQUEST")
+    return !(normalized.contains("CONFIG")
+        || normalized.contains("VALIDATION")
+        || normalized.contains("IDEMPOTENCY")
+        || normalized.contains("BAD_REQUEST")
         || normalized.contains("UNSUPPORTED"));
   }
 
   private JsonNode readJobSpec(String value) {
-    if (!StringUtils.hasText(value)) throw new IllegalStateException("任务版本缺少 Link-Up JobSpec");
+    if (!StringUtils.hasText(value)) {
+      throw new IllegalStateException("任务版本缺少 Link-Up JobSpec");
+    }
     try {
       JsonNode jobSpec = objectMapper.readTree(value);
       if (jobSpec == null || !jobSpec.isObject()) {
@@ -291,24 +361,40 @@ public class OfflineExecutionOrchestrator {
     }
   }
 
-  private void record(OfflineJobExecutionPO execution, String from, String to,
-      String type, String message, String payload) {
+  private void record(
+      OfflineJobExecutionPO execution,
+      String from,
+      String to,
+      String type,
+      String message,
+      String payload) {
     executionRepository.recordExecutionEvent(
-        execution.getId(), value(execution.getStateVersion(), 0L), from, to, type, message, payload);
+        execution.getId(),
+        value(execution.getStateVersion(), 0L),
+        from,
+        to,
+        type,
+        message,
+        payload);
   }
 
-  private void publishAlert(OfflineJobExecutionPO execution, OfflineExecutionStatus status) {
-    if (status == OfflineExecutionStatus.FAILED && properties.getControl().isAlertOnFailed()) {
+  private void publishAlert(
+      OfflineJobExecutionPO execution,
+      OfflineExecutionStatus status) {
+    if (status == OfflineExecutionStatus.FAILED
+        && properties.getControl().isAlertOnFailed()) {
       alertPublisher.publish(execution, "FAILED", text(execution.getErrorMessage()));
     }
-    if (status == OfflineExecutionStatus.LOST && properties.getControl().isAlertOnLost()) {
+    if (status == OfflineExecutionStatus.LOST
+        && properties.getControl().isAlertOnLost()) {
       alertPublisher.publish(execution, "LOST", text(execution.getErrorMessage()));
     }
   }
 
   private String write(Object value) {
-    try { return objectMapper.writeValueAsString(value); }
-    catch (JsonProcessingException exception) {
+    try {
+      return objectMapper.writeValueAsString(value);
+    } catch (JsonProcessingException exception) {
       throw new IllegalStateException("序列化 Link-Up 执行快照失败", exception);
     }
   }
@@ -324,12 +410,24 @@ public class OfflineExecutionOrchestrator {
   }
 
   private LocalDateTime time(Long millis) {
-    return millis == null || millis <= 0L ? null
+    return millis == null || millis <= 0L
+        ? null
         : LocalDateTime.ofInstant(Instant.ofEpochMilli(millis), ZoneId.systemDefault());
   }
 
-  private String first(String value, String fallback) { return StringUtils.hasText(value) ? value : fallback; }
-  private String text(String value) { return StringUtils.hasText(value) ? value : "离线任务执行失败"; }
-  private int value(Integer value, int fallback) { return value == null ? fallback : value; }
-  private long value(Long value, long fallback) { return value == null ? fallback : value; }
+  private String first(String value, String fallback) {
+    return StringUtils.hasText(value) ? value : fallback;
+  }
+
+  private String text(String value) {
+    return StringUtils.hasText(value) ? value : "离线任务执行失败";
+  }
+
+  private int value(Integer value, int fallback) {
+    return value == null ? fallback : value;
+  }
+
+  private long value(Long value, long fallback) {
+    return value == null ? fallback : value;
+  }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineExecutionReadService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineExecutionReadService.java
@@ -2,7 +2,6 @@ package io.yak.ops.business.sync.offline.service;
 
 import com.baomidou.mybatisplus.core.metadata.IPage;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import io.yak.framework.common.PagingData;
 import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
 import io.yak.ops.business.sync.offline.dao.OfflineJobExecutionDao;
@@ -82,13 +81,9 @@ public class OfflineExecutionReadService {
   public JsonNode tableMetrics(Long id) {
     OfflineJobExecutionPO execution = require(id);
     if (!StringUtils.hasText(execution.getEngineJobId())) {
-      return JsonNodeFactory.instance.arrayNode();
+      throw new IllegalStateException("当前执行实例尚未获得 Link-Up jobId，暂时无法查询表级指标");
     }
-    try {
-      return linkUpClient.pipelines(execution.getEngineJobId());
-    } catch (RuntimeException exception) {
-      return JsonNodeFactory.instance.arrayNode();
-    }
+    return linkUpClient.pipelines(execution.getEngineJobId());
   }
 
   public String logs(Long id) {
@@ -156,8 +151,19 @@ public class OfflineExecutionReadService {
         .build();
   }
 
-  private String format(LocalDateTime value) { return value == null ? null : value.format(FORMAT); }
-  private String text(String value) { return StringUtils.hasText(value) ? value : "-"; }
-  private long value(Long value) { return value == null ? 0L : value; }
-  private int value(Integer value) { return value == null ? 0 : value; }
+  private String format(LocalDateTime value) {
+    return value == null ? null : value.format(FORMAT);
+  }
+
+  private String text(String value) {
+    return StringUtils.hasText(value) ? value : "-";
+  }
+
+  private long value(Long value) {
+    return value == null ? 0L : value;
+  }
+
+  private int value(Integer value) {
+    return value == null ? 0 : value;
+  }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineJobDefinitionService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineJobDefinitionService.java
@@ -11,6 +11,7 @@ import io.yak.ops.business.sync.offline.repository.OfflineDefinitionCatalogRepos
 import io.yak.ops.business.sync.offline.repository.OfflineExecutionControlRepository;
 import io.yak.ops.business.sync.offline.repository.OfflineScheduleRepository;
 import io.yak.ops.business.sync.offline.repository.OfflineScheduleRepository.ScheduleRecord;
+import io.yak.ops.business.sync.offline.service.OfflineDefinitionSupport.DraftDefinition;
 import io.yak.ops.business.sync.offline.service.OfflineDefinitionSupport.PreparedDefinition;
 import io.yak.ops.common.bean.dto.sync.offline.OfflineJobDefinitionDTO;
 import io.yak.ops.common.bean.dto.sync.offline.OfflineJobDefinitionQueryDTO;
@@ -26,7 +27,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
-/** Offline job definition catalog with immutable structured JobSpec versions. */
+/** Offline job definition catalog with draft records and immutable structured JobSpec versions. */
 @ConditionalOnOfflineSyncEnabled
 @Service
 public class OfflineJobDefinitionService {
@@ -54,8 +55,63 @@ public class OfflineJobDefinitionService {
   public Long nextId() {
     long floor = System.currentTimeMillis() * 1000L;
     long candidate = idSequence.updateAndGet(current -> Math.max(current + 1L, floor));
-    while (definitionDao.selectById(candidate) != null) candidate = idSequence.incrementAndGet();
+    while (definitionDao.selectById(candidate) != null) {
+      candidate = idSequence.incrementAndGet();
+    }
     return candidate;
+  }
+
+  /** Creates the lightweight task shell used before datasource and table configuration. */
+  @Transactional(transactionManager = "offlineSyncTransactionManager", rollbackFor = Exception.class)
+  public Long saveDraft(OfflineJobDefinitionDTO requestDTO) {
+    Long id = requestDTO == null ? null : requestDTO.getId();
+    if (id == null || id <= 0L) {
+      id = nextId();
+      requestDTO.setId(id);
+    }
+    OfflineJobDefinitionPO existing = definitionDao.selectById(id);
+    ensureEditable(existing);
+    if (existing != null && existing.getCurrentVersionId() != null) {
+      throw new IllegalStateException("已生成可执行版本的任务不能退回草稿");
+    }
+
+    DraftDefinition draft = support.prepareDraft(requestDTO);
+    if (definitionDao.existsByName(draft.getJobName(), id)) {
+      throw new IllegalArgumentException("离线同步任务名称已存在：" + draft.getJobName());
+    }
+
+    LocalDateTime now = LocalDateTime.now();
+    OfflineJobDefinitionPO definition = existing == null
+        ? new OfflineJobDefinitionPO()
+        : existing;
+    definition.setId(id);
+    definition.setJobName(draft.getJobName());
+    definition.setJobDesc(draft.getJobDesc());
+    definition.setMode(draft.getMode());
+    definition.setDefinitionJson(draft.getDefinitionJson());
+    definition.setJobSpecJson(null);
+    definition.setHoconConfig(null);
+    definition.setReleaseState("OFFLINE");
+    definition.setSourceType(draft.getSourceType());
+    definition.setSinkType(draft.getSinkType());
+    definition.setSourceDatasourceId(null);
+    definition.setSinkDatasourceId(null);
+    definition.setSourceTable(null);
+    definition.setSinkTable(null);
+    definition.setScheduleJson(support.writeNullable(draft.getRequest().get("schedule")));
+    definition.setEnvJson(support.writeNullable(draft.getRequest().get("env")));
+    definition.setVersion(0);
+    definition.setCurrentVersionId(null);
+    definition.setCreateTime(existing == null ? now : existing.getCreateTime());
+    definition.setUpdateTime(now);
+
+    if (existing == null) {
+      definitionDao.insert(definition);
+    } else {
+      definitionDao.updateById(definition);
+    }
+    scheduleRepository.saveSchedule(id, draft.getRequest().get("schedule"));
+    return id;
   }
 
   @Transactional(transactionManager = "offlineSyncTransactionManager", rollbackFor = Exception.class)
@@ -72,9 +128,14 @@ public class OfflineJobDefinitionService {
       throw new IllegalArgumentException("离线同步任务名称已存在：" + prepared.getJobName());
     }
 
-    int version = existing == null || existing.getVersion() == null ? 1 : existing.getVersion() + 1;
+    int currentVersion = existing == null || existing.getVersion() == null
+        ? 0
+        : Math.max(0, existing.getVersion());
+    int version = currentVersion + 1;
     LocalDateTime now = LocalDateTime.now();
-    OfflineJobDefinitionPO definition = existing == null ? new OfflineJobDefinitionPO() : existing;
+    OfflineJobDefinitionPO definition = existing == null
+        ? new OfflineJobDefinitionPO()
+        : existing;
     definition.setId(id);
     definition.setJobName(prepared.getJobName());
     definition.setJobDesc(prepared.getJobDesc());
@@ -94,35 +155,62 @@ public class OfflineJobDefinitionService {
     definition.setReleaseState(existing == null ? "OFFLINE" : existing.getReleaseState());
     definition.setCreateTime(existing == null ? now : existing.getCreateTime());
     definition.setUpdateTime(now);
-    if (existing == null) definitionDao.insert(definition); else definitionDao.updateById(definition);
+    if (existing == null) {
+      definitionDao.insert(definition);
+    } else {
+      definitionDao.updateById(definition);
+    }
 
     Long versionId = catalogRepository.saveVersion(
-        id, version, prepared.getDefinitionJson(), prepared.getJobSpecJson(), prepared.getDigest());
+        id,
+        version,
+        prepared.getDefinitionJson(),
+        prepared.getJobSpecJson(),
+        prepared.getDigest());
     definition.setCurrentVersionId(versionId);
     definitionDao.updateById(definition);
     scheduleRepository.saveSchedule(id, prepared.getRequest().get("schedule"));
     return id;
   }
 
-  /** Existing preview endpoint now returns structured JSON JobSpec instead of HOCON text. */
+  /** Existing preview endpoint now returns a logical structured JobSpec. */
   public String buildGuideConfig(OfflineJobDefinitionDTO requestDTO) {
     return support.buildJobSpec(requestDTO);
   }
 
-  public String resolveJobSpec(DefinitionVersion version) {
-    if (version == null) throw new IllegalArgumentException("任务版本不能为空");
+  public String resolveLogicalJobSpec(DefinitionVersion version) {
+    if (version == null) {
+      throw new IllegalArgumentException("任务版本不能为空");
+    }
     return StringUtils.hasText(version.getJobSpecJson())
         ? version.getJobSpecJson()
         : support.buildJobSpec(version.getDefinitionJson());
   }
 
-  public OfflineJobDefinitionVO get(Long id) { return toVO(require(id)); }
-  public JsonNode getEditDetail(Long id) { return support.editDetail(require(id)); }
+  /** Resolves the latest datasource credentials only for the outbound Worker request. */
+  public String resolveExecutionJobSpec(DefinitionVersion version) {
+    return support.resolveExecutionJobSpec(resolveLogicalJobSpec(version));
+  }
+
+  /** Compatibility alias for callers that need the durable logical JobSpec. */
+  public String resolveJobSpec(DefinitionVersion version) {
+    return resolveLogicalJobSpec(version);
+  }
+
+  public OfflineJobDefinitionVO get(Long id) {
+    return toVO(require(id));
+  }
+
+  public JsonNode getEditDetail(Long id) {
+    return support.editDetail(require(id));
+  }
 
   public PagingData<OfflineJobDefinitionVO> page(OfflineJobDefinitionQueryDTO queryDTO) {
     IPage<OfflineJobDefinitionPO> page = definitionDao.selectPage(queryDTO);
     List<OfflineJobDefinitionVO> records = new ArrayList<>(page.getRecords().size());
-    for (OfflineJobDefinitionPO definition : page.getRecords()) records.add(toVO(definition));
+    for (OfflineJobDefinitionPO definition : page.getRecords()) {
+      records.add(toVO(definition));
+    }
     return new PagingData<>(records, page);
   }
 
@@ -152,21 +240,32 @@ public class OfflineJobDefinitionService {
     if ("ONLINE".equalsIgnoreCase(definition.getReleaseState())) {
       throw new IllegalStateException("已上线任务不能删除，请先下线");
     }
-    if (executionRepository.hasActiveExecution(id)) throw new IllegalStateException("运行中的任务不能删除");
+    if (executionRepository.hasActiveExecution(id)) {
+      throw new IllegalStateException("运行中的任务不能删除");
+    }
     return definitionDao.deleteById(id);
   }
 
   public OfflineJobDefinitionPO require(Long id) {
-    if (id == null || id <= 0L) throw new IllegalArgumentException("任务定义 ID 不合法");
+    if (id == null || id <= 0L) {
+      throw new IllegalArgumentException("任务定义 ID 不合法");
+    }
     OfflineJobDefinitionPO definition = definitionDao.selectById(id);
-    if (definition == null) throw new IllegalArgumentException("离线同步任务不存在：" + id);
+    if (definition == null) {
+      throw new IllegalArgumentException("离线同步任务不存在：" + id);
+    }
     return definition;
   }
 
   public DefinitionVersion requireCurrentVersion(OfflineJobDefinitionPO definition) {
+    if (definition == null || definition.getCurrentVersionId() == null) {
+      throw new IllegalStateException("任务仍是草稿，请完成配置并保存后再上线或运行");
+    }
     DefinitionVersion version = catalogRepository.findCurrentVersion(
         definition.getId(), definition.getCurrentVersionId());
-    if (version == null) throw new IllegalStateException("任务没有可执行的定义版本");
+    if (version == null) {
+      throw new IllegalStateException("任务没有可执行的定义版本");
+    }
     return version;
   }
 
@@ -177,7 +276,9 @@ public class OfflineJobDefinitionService {
       Map<String, Object> item = new LinkedHashMap<>();
       item.put("id", version.getId());
       item.put("version", version.getVersionNo());
-      item.put("format", StringUtils.hasText(version.getJobSpecJson()) ? "JOB_SPEC" : "LEGACY_DERIVED");
+      item.put(
+          "format",
+          StringUtils.hasText(version.getJobSpecJson()) ? "JOB_SPEC" : "LEGACY_DERIVED");
       item.put("configDigest", version.getConfigDigest());
       item.put("createTime", version.getCreateTime());
       result.add(item);
@@ -187,7 +288,8 @@ public class OfflineJobDefinitionService {
 
   private OfflineJobDefinitionVO toVO(OfflineJobDefinitionPO definition) {
     ScheduleRecord schedule = scheduleRepository.findSchedule(definition.getId());
-    return support.toVO(definition,
+    return support.toVO(
+        definition,
         schedule == null ? null : schedule.getCronExpression(),
         schedule != null && schedule.isEnabled(),
         schedule == null ? null : schedule.getLastFireTime(),
@@ -195,7 +297,9 @@ public class OfflineJobDefinitionService {
   }
 
   private void ensureEditable(OfflineJobDefinitionPO existing) {
-    if (existing == null) return;
+    if (existing == null) {
+      return;
+    }
     if ("ONLINE".equalsIgnoreCase(existing.getReleaseState())) {
       throw new IllegalStateException("已上线任务不能修改，请先下线");
     }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/resources/db/migration/yak-offline-sync/V5__redact_job_spec_credentials.sql
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/resources/db/migration/yak-offline-sync/V5__redact_job_spec_credentials.sql
@@ -1,5 +1,7 @@
 -- Convert previously persisted resolved JobSpecs back to logical control-plane JobSpecs.
 -- Credentials are resolved from datasource references only for the outbound Link-Up request.
+-- Phase-four payloads may have used datasource types (MYSQL/ORACLE/...) as connector IDs,
+-- so this migration also normalizes all relational variants to the Link-Up connector ID "jdbc".
 
 UPDATE yak_offline_job_definition
 SET job_spec_json = JSON_SET(
@@ -11,12 +13,17 @@ SET job_spec_json = JSON_SET(
             '$.source.options.password',
             '$.source.options.schema',
             '$.source.options.properties'),
+        '$.source.connectorId',
+        'jdbc',
         '$.source.dataSourceRef.id',
         source_datasource_id)
 WHERE job_spec_json IS NOT NULL
   AND JSON_VALID(job_spec_json)
   AND source_datasource_id IS NOT NULL
-  AND LOWER(JSON_UNQUOTE(JSON_EXTRACT(job_spec_json, '$.source.connectorId'))) = 'jdbc';
+  AND UPPER(REPLACE(JSON_UNQUOTE(JSON_EXTRACT(job_spec_json, '$.source.connectorId')), '-', '_'))
+      IN ('JDBC','MYSQL','MARIADB','POSTGRE_SQL','POSTGRESQL','POSTGRES','ORACLE',
+          'SQLSERVER','SQL_SERVER','DORIS','STARROCKS','CLICKHOUSE','DB2','HIVE',
+          'KINGBASE','DAMENG','DM');
 
 UPDATE yak_offline_job_definition
 SET job_spec_json = JSON_SET(
@@ -28,12 +35,17 @@ SET job_spec_json = JSON_SET(
             '$.sink.options.password',
             '$.sink.options.schema',
             '$.sink.options.properties'),
+        '$.sink.connectorId',
+        'jdbc',
         '$.sink.dataSourceRef.id',
         sink_datasource_id)
 WHERE job_spec_json IS NOT NULL
   AND JSON_VALID(job_spec_json)
   AND sink_datasource_id IS NOT NULL
-  AND LOWER(JSON_UNQUOTE(JSON_EXTRACT(job_spec_json, '$.sink.connectorId'))) = 'jdbc';
+  AND UPPER(REPLACE(JSON_UNQUOTE(JSON_EXTRACT(job_spec_json, '$.sink.connectorId')), '-', '_'))
+      IN ('JDBC','MYSQL','MARIADB','POSTGRE_SQL','POSTGRESQL','POSTGRES','ORACLE',
+          'SQLSERVER','SQL_SERVER','DORIS','STARROCKS','CLICKHOUSE','DB2','HIVE',
+          'KINGBASE','DAMENG','DM');
 
 UPDATE yak_offline_job_version version_record
 JOIN yak_offline_job_definition definition
@@ -47,12 +59,17 @@ SET version_record.job_spec_json = JSON_SET(
             '$.source.options.password',
             '$.source.options.schema',
             '$.source.options.properties'),
+        '$.source.connectorId',
+        'jdbc',
         '$.source.dataSourceRef.id',
         definition.source_datasource_id)
 WHERE version_record.job_spec_json IS NOT NULL
   AND JSON_VALID(version_record.job_spec_json)
   AND definition.source_datasource_id IS NOT NULL
-  AND LOWER(JSON_UNQUOTE(JSON_EXTRACT(version_record.job_spec_json, '$.source.connectorId'))) = 'jdbc';
+  AND UPPER(REPLACE(JSON_UNQUOTE(JSON_EXTRACT(version_record.job_spec_json, '$.source.connectorId')), '-', '_'))
+      IN ('JDBC','MYSQL','MARIADB','POSTGRE_SQL','POSTGRESQL','POSTGRES','ORACLE',
+          'SQLSERVER','SQL_SERVER','DORIS','STARROCKS','CLICKHOUSE','DB2','HIVE',
+          'KINGBASE','DAMENG','DM');
 
 UPDATE yak_offline_job_version version_record
 JOIN yak_offline_job_definition definition
@@ -66,12 +83,17 @@ SET version_record.job_spec_json = JSON_SET(
             '$.sink.options.password',
             '$.sink.options.schema',
             '$.sink.options.properties'),
+        '$.sink.connectorId',
+        'jdbc',
         '$.sink.dataSourceRef.id',
         definition.sink_datasource_id)
 WHERE version_record.job_spec_json IS NOT NULL
   AND JSON_VALID(version_record.job_spec_json)
   AND definition.sink_datasource_id IS NOT NULL
-  AND LOWER(JSON_UNQUOTE(JSON_EXTRACT(version_record.job_spec_json, '$.sink.connectorId'))) = 'jdbc';
+  AND UPPER(REPLACE(JSON_UNQUOTE(JSON_EXTRACT(version_record.job_spec_json, '$.sink.connectorId')), '-', '_'))
+      IN ('JDBC','MYSQL','MARIADB','POSTGRE_SQL','POSTGRESQL','POSTGRES','ORACLE',
+          'SQLSERVER','SQL_SERVER','DORIS','STARROCKS','CLICKHOUSE','DB2','HIVE',
+          'KINGBASE','DAMENG','DM');
 
 UPDATE yak_offline_job_version
 SET config_digest = SHA2(job_spec_json, 256)

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/resources/db/migration/yak-offline-sync/V5__redact_job_spec_credentials.sql
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/resources/db/migration/yak-offline-sync/V5__redact_job_spec_credentials.sql
@@ -1,0 +1,92 @@
+-- Convert previously persisted resolved JobSpecs back to logical control-plane JobSpecs.
+-- Credentials are resolved from datasource references only for the outbound Link-Up request.
+
+UPDATE yak_offline_job_definition
+SET job_spec_json = JSON_SET(
+        JSON_REMOVE(
+            job_spec_json,
+            '$.source.options.url',
+            '$.source.options.driver',
+            '$.source.options.username',
+            '$.source.options.password',
+            '$.source.options.schema',
+            '$.source.options.properties'),
+        '$.source.dataSourceRef.id',
+        source_datasource_id)
+WHERE job_spec_json IS NOT NULL
+  AND JSON_VALID(job_spec_json)
+  AND source_datasource_id IS NOT NULL
+  AND LOWER(JSON_UNQUOTE(JSON_EXTRACT(job_spec_json, '$.source.connectorId'))) = 'jdbc';
+
+UPDATE yak_offline_job_definition
+SET job_spec_json = JSON_SET(
+        JSON_REMOVE(
+            job_spec_json,
+            '$.sink.options.url',
+            '$.sink.options.driver',
+            '$.sink.options.username',
+            '$.sink.options.password',
+            '$.sink.options.schema',
+            '$.sink.options.properties'),
+        '$.sink.dataSourceRef.id',
+        sink_datasource_id)
+WHERE job_spec_json IS NOT NULL
+  AND JSON_VALID(job_spec_json)
+  AND sink_datasource_id IS NOT NULL
+  AND LOWER(JSON_UNQUOTE(JSON_EXTRACT(job_spec_json, '$.sink.connectorId'))) = 'jdbc';
+
+UPDATE yak_offline_job_version version_record
+JOIN yak_offline_job_definition definition
+  ON definition.id = version_record.job_definition_id
+SET version_record.job_spec_json = JSON_SET(
+        JSON_REMOVE(
+            version_record.job_spec_json,
+            '$.source.options.url',
+            '$.source.options.driver',
+            '$.source.options.username',
+            '$.source.options.password',
+            '$.source.options.schema',
+            '$.source.options.properties'),
+        '$.source.dataSourceRef.id',
+        definition.source_datasource_id)
+WHERE version_record.job_spec_json IS NOT NULL
+  AND JSON_VALID(version_record.job_spec_json)
+  AND definition.source_datasource_id IS NOT NULL
+  AND LOWER(JSON_UNQUOTE(JSON_EXTRACT(version_record.job_spec_json, '$.source.connectorId'))) = 'jdbc';
+
+UPDATE yak_offline_job_version version_record
+JOIN yak_offline_job_definition definition
+  ON definition.id = version_record.job_definition_id
+SET version_record.job_spec_json = JSON_SET(
+        JSON_REMOVE(
+            version_record.job_spec_json,
+            '$.sink.options.url',
+            '$.sink.options.driver',
+            '$.sink.options.username',
+            '$.sink.options.password',
+            '$.sink.options.schema',
+            '$.sink.options.properties'),
+        '$.sink.dataSourceRef.id',
+        definition.sink_datasource_id)
+WHERE version_record.job_spec_json IS NOT NULL
+  AND JSON_VALID(version_record.job_spec_json)
+  AND definition.sink_datasource_id IS NOT NULL
+  AND LOWER(JSON_UNQUOTE(JSON_EXTRACT(version_record.job_spec_json, '$.sink.connectorId'))) = 'jdbc';
+
+UPDATE yak_offline_job_execution
+SET submitted_config = JSON_REMOVE(
+        submitted_config,
+        '$.source.options.url',
+        '$.source.options.driver',
+        '$.source.options.username',
+        '$.source.options.password',
+        '$.source.options.schema',
+        '$.source.options.properties',
+        '$.sink.options.url',
+        '$.sink.options.driver',
+        '$.sink.options.username',
+        '$.sink.options.password',
+        '$.sink.options.schema',
+        '$.sink.options.properties')
+WHERE submitted_config IS NOT NULL
+  AND JSON_VALID(submitted_config);

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/resources/db/migration/yak-offline-sync/V5__redact_job_spec_credentials.sql
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/resources/db/migration/yak-offline-sync/V5__redact_job_spec_credentials.sql
@@ -73,6 +73,11 @@ WHERE version_record.job_spec_json IS NOT NULL
   AND definition.sink_datasource_id IS NOT NULL
   AND LOWER(JSON_UNQUOTE(JSON_EXTRACT(version_record.job_spec_json, '$.sink.connectorId'))) = 'jdbc';
 
+UPDATE yak_offline_job_version
+SET config_digest = SHA2(job_spec_json, 256)
+WHERE job_spec_json IS NOT NULL
+  AND JSON_VALID(job_spec_json);
+
 UPDATE yak_offline_job_execution
 SET submitted_config = JSON_REMOVE(
         submitted_config,

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/engine/ConnectorIdResolverTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/engine/ConnectorIdResolverTest.java
@@ -1,0 +1,22 @@
+package io.yak.ops.business.sync.offline.engine;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class ConnectorIdResolverTest {
+
+  @Test
+  void shouldNormalizeDatasourceTypesToJdbc() {
+    assertThat(ConnectorIdResolver.resolve(null, "MYSQL", null, null)).isEqualTo("jdbc");
+    assertThat(ConnectorIdResolver.resolve(null, null, "POSTGRE_SQL", null)).isEqualTo("jdbc");
+    assertThat(ConnectorIdResolver.resolve("Doris", null, null, null)).isEqualTo("jdbc");
+    assertThat(ConnectorIdResolver.resolve(null, "Jdbc", null, null)).isEqualTo("jdbc");
+  }
+
+  @Test
+  void shouldKeepFutureConnectorIdsFrameworkNeutral() {
+    assertThat(ConnectorIdResolver.resolve("HTTP", null, null, null)).isEqualTo("http");
+    assertThat(ConnectorIdResolver.resolve(null, "file", null, null)).isEqualTo("file");
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/engine/LinkUpJobSpecFactoryTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/engine/LinkUpJobSpecFactoryTest.java
@@ -15,10 +15,10 @@ class LinkUpJobSpecFactoryTest {
   private final ObjectMapper mapper = new ObjectMapper();
 
   @Test
-  void shouldBuildJdbcJobSpecWithoutHocon() throws Exception {
+  void shouldPersistLogicalJdbcJobSpecAndResolveCredentialsAtExecution() throws Exception {
     DataSourceDao dao = mock(DataSourceDao.class);
-    when(dao.selectById(1L)).thenReturn(dataSource(1L, "source"));
-    when(dao.selectById(2L)).thenReturn(dataSource(2L, "sink"));
+    when(dao.selectById(1L)).thenReturn(dataSource(1L, "source", "source-secret"));
+    when(dao.selectById(2L)).thenReturn(dataSource(2L, "sink", "sink-secret"));
 
     JsonNode definition = mapper.readTree("""
         {
@@ -32,12 +32,17 @@ class LinkUpJobSpecFactoryTest {
           "workflow": {
             "nodes": [
               {"data": {"nodeType": "source", "config": {
+                "connectorType": "MYSQL",
                 "dataSourceId": 1,
                 "table": "sales.orders",
                 "fetchSize": 500,
-                "connectorOptions": {"partition_column": "id"}
+                "connectorOptions": {
+                  "password": "must-not-persist",
+                  "partition_column": "id"
+                }
               }}},
               {"data": {"nodeType": "sink", "config": {
+                "connectorType": "Jdbc",
                 "dataSourceId": 2,
                 "targetTableName": "warehouse.orders",
                 "writeMode": "upsert",
@@ -50,19 +55,30 @@ class LinkUpJobSpecFactoryTest {
         }
         """);
 
-    LinkUpJobSpecFactory.BuildResult result =
-        new LinkUpJobSpecFactory(dao, mapper).build(definition);
+    LinkUpJobSpecFactory factory = new LinkUpJobSpecFactory(dao, mapper);
+    LinkUpJobSpecFactory.BuildResult result = factory.build(definition);
+    JsonNode logical = result.getJobSpec();
 
-    JsonNode spec = result.getJobSpec();
-    assertThat(spec.path("apiVersion").asText()).isEqualTo("link-up/v1");
-    assertThat(spec.path("source").path("connectorId").asText()).isEqualTo("jdbc");
-    assertThat(spec.path("source").path("options").path("table_path").asText())
+    assertThat(logical.path("source").path("connectorId").asText()).isEqualTo("jdbc");
+    assertThat(logical.path("source").path("dataSourceRef").path("id").asLong()).isEqualTo(1L);
+    assertThat(logical.path("sink").path("dataSourceRef").path("id").asLong()).isEqualTo(2L);
+    assertThat(logical.path("source").path("options").path("table_path").asText())
         .isEqualTo("sales.orders");
-    assertThat(spec.path("source").path("options").path("partition_column").asText())
+    assertThat(logical.path("source").path("options").path("partition_column").asText())
         .isEqualTo("id");
-    assertThat(spec.path("sink").path("options").path("primary_keys").size()).isEqualTo(2);
-    assertThat(spec.path("runtime").path("sourceParallelism").asInt()).isEqualTo(2);
-    assertThat(result.getJobSpecJson()).doesNotContain("job.name", "source {");
+    assertThat(logical.path("sink").path("options").path("primary_keys").size()).isEqualTo(2);
+    assertThat(logical.path("runtime").path("sourceParallelism").asInt()).isEqualTo(2);
+    assertThat(result.getJobSpecJson()).doesNotContain(
+        "source-secret", "sink-secret", "must-not-persist", "jdbc:mysql");
+
+    JsonNode resolved = factory.resolveForExecution(logical);
+    assertThat(resolved.path("source").has("dataSourceRef")).isFalse();
+    assertThat(resolved.path("source").path("options").path("password").asText())
+        .isEqualTo("source-secret");
+    assertThat(resolved.path("sink").path("options").path("password").asText())
+        .isEqualTo("sink-secret");
+    assertThat(resolved.path("source").path("options").path("url").asText())
+        .startsWith("jdbc:mysql:");
   }
 
   @Test
@@ -86,22 +102,23 @@ class LinkUpJobSpecFactoryTest {
         }
         """);
 
-    JsonNode spec = new LinkUpJobSpecFactory(dao, mapper).build(definition).getJobSpec();
+    LinkUpJobSpecFactory factory = new LinkUpJobSpecFactory(dao, mapper);
+    JsonNode logical = factory.build(definition).getJobSpec();
+    JsonNode resolved = factory.resolveForExecution(logical);
 
-    assertThat(spec.path("source").path("connectorId").asText()).isEqualTo("http");
-    assertThat(spec.path("source").path("options").path("method").asText()).isEqualTo("GET");
-    assertThat(spec.path("sink").path("connectorId").asText()).isEqualTo("file");
-    assertThat(spec.path("sink").path("options").path("path").asText())
-        .isEqualTo("/data/result.json");
+    assertThat(logical.path("source").path("connectorId").asText()).isEqualTo("http");
+    assertThat(logical.path("source").path("options").path("method").asText()).isEqualTo("GET");
+    assertThat(logical.path("sink").path("connectorId").asText()).isEqualTo("file");
+    assertThat(resolved).isEqualTo(logical);
   }
 
-  private DataSourcePO dataSource(Long id, String name) {
+  private DataSourcePO dataSource(Long id, String name, String password) {
     DataSourcePO value = new DataSourcePO();
     value.setId(id);
     value.setName(name);
     value.setJdbcUrl("jdbc:mysql://127.0.0.1:3306/demo");
     value.setConnectionParams("{\"driver\":\"com.mysql.cj.jdbc.Driver\","
-        + "\"username\":\"root\",\"password\":\"secret\"}");
+        + "\"username\":\"root\",\"password\":\"" + password + "\"}");
     return value;
   }
 }

--- a/yak-ops-ui/src/pages/batch-link-up/api.ts
+++ b/yak-ops-ui/src/pages/batch-link-up/api.ts
@@ -89,21 +89,19 @@ export interface OfflineBatchOperationResult {
 export const apiPrefix = '/api/v1/job/batch-definition';
 
 export const linkupJobDefinitionApi = {
-  /** SCRIPT 模式保存/更新。 */
-  saveOrUpdateScript: (
+  /** 创建尚未配置数据源和表的草稿任务。 */
+  createDraft: (
     data: Record<string, unknown>,
   ): Promise<ApiResponse<string | number>> => {
-    return HttpUtils.post(`${apiPrefix}/script/saveOrUpdate`, data);
+    return HttpUtils.post(`${apiPrefix}/draft`, data);
   },
 
-  /** GUIDE_SINGLE 模式保存/更新。 */
   saveOrUpdateGuideSingle: (
     data: Record<string, unknown>,
   ): Promise<ApiResponse<string | number>> => {
     return HttpUtils.post(`${apiPrefix}/guide-single/saveOrUpdate`, data);
   },
 
-  /** GUIDE_MULTI 模式保存/更新。 */
   saveOrUpdateGuideMulti: (
     data: Record<string, unknown>,
   ): Promise<ApiResponse<string | number>> => {
@@ -116,7 +114,6 @@ export const linkupJobDefinitionApi = {
     return HttpUtils.get(`${apiPrefix}/${id}`);
   },
 
-  /** 编辑页详情查询。 */
   selectEditDetail: (
     id: string | number,
   ): Promise<ApiResponse<Record<string, unknown>>> => {
@@ -131,14 +128,12 @@ export const linkupJobDefinitionApi = {
     return HttpUtils.delete(`${apiPrefix}/${id}`);
   },
 
-  /** 任务上线。 */
   online: (
     id: string | number,
   ): Promise<ApiResponse<boolean>> => {
     return HttpUtils.put(`${apiPrefix}/${id}/online`);
   },
 
-  /** 任务下线。 */
   offline: (
     id: string | number,
   ): Promise<ApiResponse<boolean>> => {
@@ -151,31 +146,22 @@ export const linkupJobDefinitionApi = {
     return HttpUtils.post(`${apiPrefix}/page`, data);
   },
 
-  /** GUIDE_SINGLE 模式预览 HOCON。 */
   buildGuideSingleConfig: (
     data: Record<string, unknown>,
   ): Promise<ApiResponse<string>> => {
     return HttpUtils.post(`${apiPrefix}/guide-single/build-config`, data);
   },
 
-  /** GUIDE_MULTI 模式预览 HOCON。 */
   buildGuideMultiConfig: (
     data: Record<string, unknown>,
   ): Promise<ApiResponse<string>> => {
     return HttpUtils.post(`${apiPrefix}/guide-multi/build-config`, data);
   },
 
-  /** SCRIPT 模式预览 HOCON。 */
-  buildScriptConfig: (
+  buildJobSpec: (
     data: Record<string, unknown>,
   ): Promise<ApiResponse<string>> => {
-    return HttpUtils.post(`${apiPrefix}/script/build-config`, data);
-  },
-
-  hocon: (
-    data: Record<string, unknown>,
-  ): Promise<ApiResponse<string>> => {
-    return HttpUtils.post(`${apiPrefix}/buildHoconConfig`, data);
+    return HttpUtils.post(`${apiPrefix}/build-job-spec`, data);
   },
 };
 
@@ -190,17 +176,13 @@ export const linkupJobExecuteApi = {
   execute: (
     jobDefineId: string | number,
   ): Promise<ApiResponse<OfflineJobExecutionVO>> => {
-    return HttpUtils.get(
-      `${executeApiPrefix}/execute?jobDefineId=${encodeURIComponent(jobDefineId)}`,
-    );
+    return HttpUtils.post(`${executeApiPrefix}/${encodeURIComponent(jobDefineId)}/execute`, {});
   },
 
   pause: (
     jobInstanceId: string | number,
   ): Promise<ApiResponse<OfflineJobExecutionVO>> => {
-    return HttpUtils.get(
-      `${executeApiPrefix}/pause?jobInstanceId=${encodeURIComponent(jobInstanceId)}`,
-    );
+    return HttpUtils.post(`${executeApiPrefix}/${encodeURIComponent(jobInstanceId)}/cancel`, {});
   },
 };
 

--- a/yak-ops-ui/src/pages/batch-link-up/components/CreateSyncTaskModal.tsx
+++ b/yak-ops-ui/src/pages/batch-link-up/components/CreateSyncTaskModal.tsx
@@ -41,11 +41,12 @@ import {
   type CreateSyncTaskValues,
   type SyncMode,
 } from "../detail/model";
+import { connectorIdForDataSourceType } from "../detail/form-schema/valueAdapter";
 
 interface CreateSyncTaskDrawerProps {
   open: boolean;
   onCancel: () => void;
-  onCreated: (taskId: string) => void;
+  onCreated: (taskId: string, mode: SyncMode) => void;
 }
 
 interface CreateSyncTaskFormValues extends CreateSyncTaskValues {
@@ -62,6 +63,7 @@ interface ConnectorOption {
 
 interface CreateSyncEndpoint {
   dbType: string;
+  connectorId: string;
   connectorType: string;
   pluginName: string;
 }
@@ -103,10 +105,12 @@ const resolveEndpoint = (
   options: ConnectorOption[]
 ): CreateSyncEndpoint => {
   const option = options.find((item) => item.value === dbType);
+  const connectorId = connectorIdForDataSourceType(dbType);
 
   return {
     dbType,
-    connectorType: option?.connectorType || dbType,
+    connectorId,
+    connectorType: connectorId,
     pluginName: option?.pluginName || dbType,
   };
 };
@@ -130,11 +134,13 @@ const applyConnectorSelection = (
       data: {
         ...(node?.data || {}),
         dbType: endpoint.dbType,
+        connectorId: endpoint.connectorId,
         connectorType: endpoint.connectorType,
         pluginName: endpoint.pluginName,
         config: {
           ...(node?.data?.config || {}),
           dbType: endpoint.dbType,
+          connectorId: endpoint.connectorId,
           connectorType: endpoint.connectorType,
           pluginName: endpoint.pluginName,
         },
@@ -239,7 +245,6 @@ export default function CreateSyncTaskDrawer({
       };
 
       const source = resolveEndpoint(values.sourceDbType, connectorOptions);
-
       const target = resolveEndpoint(values.targetDbType, connectorOptions);
 
       setSubmitting(true);
@@ -264,10 +269,7 @@ export default function CreateSyncTaskDrawer({
         target
       );
 
-      const saveResponse =
-        normalizedValues.mode === "GUIDE_MULTI"
-          ? await linkupJobDefinitionApi.saveOrUpdateGuideMulti(payload)
-          : await linkupJobDefinitionApi.saveOrUpdateGuideSingle(payload);
+      const saveResponse = await linkupJobDefinitionApi.createDraft(payload);
 
       if (!isApiSuccess(saveResponse)) {
         message.error(responseMessage(saveResponse, "创建同步任务失败"));
@@ -278,8 +280,8 @@ export default function CreateSyncTaskDrawer({
 
       form.resetFields();
       autoJobNameRef.current = "";
-      message.success("同步任务已创建");
-      onCreated(createdId);
+      message.success("任务草稿已创建，请继续配置数据源和同步表");
+      onCreated(createdId, normalizedValues.mode);
     } catch (error: any) {
       if (error?.errorFields) return;
 
@@ -325,7 +327,7 @@ export default function CreateSyncTaskDrawer({
               onClick={handleSubmit}
               className="!h-9 !rounded-lg !px-5 !font-medium !text-white"
             >
-              创建
+              创建并配置
             </Button>
           </div>
         }
@@ -345,21 +347,12 @@ export default function CreateSyncTaskDrawer({
           requiredMark="optional"
         >
           <div className="mb-6">
-            {/* <div className="mb-2 text-[13px] font-medium text-[#344054]">
-              同步链路
-            </div> */}
-
             <div className="grid grid-cols-[minmax(0,1fr)_32px_minmax(0,1fr)] items-end gap-3">
               <Form.Item
                 name="sourceDbType"
                 label="来源类型"
                 className="!mb-0"
-                rules={[
-                  {
-                    required: true,
-                    message: "请选择来源类型",
-                  },
-                ]}
+                rules={[{ required: true, message: "请选择来源类型" }]}
               >
                 <Select
                   showSearch
@@ -384,12 +377,7 @@ export default function CreateSyncTaskDrawer({
                 name="targetDbType"
                 label="目标类型"
                 className="!mb-0"
-                rules={[
-                  {
-                    required: true,
-                    message: "请选择目标类型",
-                  },
-                ]}
+                rules={[{ required: true, message: "请选择目标类型" }]}
               >
                 <Select
                   showSearch
@@ -412,14 +400,8 @@ export default function CreateSyncTaskDrawer({
             name="jobName"
             label="任务名称"
             rules={[
-              {
-                required: true,
-                message: "请输入任务名称",
-              },
-              {
-                max: 64,
-                message: "任务名称不能超过 64 个字符",
-              },
+              { required: true, message: "请输入任务名称" },
+              { max: 64, message: "任务名称不能超过 64 个字符" },
             ]}
           >
             <Input
@@ -434,12 +416,7 @@ export default function CreateSyncTaskDrawer({
           <Form.Item
             name="jobDesc"
             label="任务描述"
-            rules={[
-              {
-                max: 200,
-                message: "任务描述不能超过 200 个字符",
-              },
-            ]}
+            rules={[{ max: 200, message: "任务描述不能超过 200 个字符" }]}
           >
             <Input.TextArea
               rows={5}
@@ -453,12 +430,7 @@ export default function CreateSyncTaskDrawer({
           <Form.Item
             name="mode"
             label="同步类型"
-            rules={[
-              {
-                required: true,
-                message: "请选择同步类型",
-              },
-            ]}
+            rules={[{ required: true, message: "请选择同步类型" }]}
           >
             <Radio.Group className="grid w-full grid-cols-2 gap-3">
               {modeOptions.map((option) => (

--- a/yak-ops-ui/src/pages/batch-link-up/components/CreateSyncTaskModal.tsx
+++ b/yak-ops-ui/src/pages/batch-link-up/components/CreateSyncTaskModal.tsx
@@ -3,6 +3,7 @@ import {
   DatabaseOutlined,
   TableOutlined,
 } from "@ant-design/icons";
+import { history } from "@umijs/max";
 import {
   Button,
   ConfigProvider,
@@ -277,11 +278,16 @@ export default function CreateSyncTaskDrawer({
       }
 
       const createdId = extractSavedId(saveResponse, taskId);
+      const path =
+        normalizedValues.mode === "GUIDE_MULTI"
+          ? `/sync/batch-link-up/${createdId}/config/multi?scene=edit`
+          : `/sync/batch-link-up/${createdId}/config/single?scene=edit`;
 
       form.resetFields();
       autoJobNameRef.current = "";
       message.success("任务草稿已创建，请继续配置数据源和同步表");
       onCreated(createdId, normalizedValues.mode);
+      history.push(path);
     } catch (error: any) {
       if (error?.errorFields) return;
 

--- a/yak-ops-ui/src/pages/batch-link-up/components/SyncTaskList/components/ActionColumn.tsx
+++ b/yak-ops-ui/src/pages/batch-link-up/components/SyncTaskList/components/ActionColumn.tsx
@@ -36,79 +36,55 @@ interface ActionColumnProps {
 }
 
 const { confirm } = Modal;
+const ACTIVE_STATUSES = new Set(['CREATED', 'SUBMITTED', 'QUEUED', 'RUNNING']);
+
+const normalizeStatus = (value?: string) =>
+  String(value || '').trim().toUpperCase();
 
 const isReleaseOnline = (releaseState?: string | number) =>
   releaseState === 'ONLINE' || releaseState === 1;
 
-const ActionColumn: React.FC<ActionColumnProps> = ({
-  record,
-  cbk,
-  goDetail,
-}) => {
+const errorText = (response: any, fallback: string) =>
+  response?.msg || response?.message || fallback;
+
+const ActionColumn: React.FC<ActionColumnProps> = ({ record, cbk, goDetail }) => {
   const intl = useIntl();
   const taskViewRef = useRef<any>(null);
-
   const [runOpen, setRunOpen] = useState(false);
   const [runLoading, setRunLoading] = useState(false);
   const [logOpen, setLogOpen] = useState(false);
 
   const isOnline = isReleaseOnline(record?.releaseState);
-  const isRunning = record?.lastJobStatus === 'RUNNING';
+  const isActive = ACTIVE_STATUSES.has(normalizeStatus(record?.lastJobStatus));
+  const canRun = isOnline && !isActive;
+  const canEdit = !isOnline && !isActive;
+  const canDelete = !isOnline && !isActive;
 
-  const canRun = isOnline && !isRunning;
-  const canEdit = !isOnline && !isRunning;
-  const canDelete = !isOnline && !isRunning;
-
-  const stopPropagation = (
-    event: React.MouseEvent<HTMLElement>,
-  ) => {
+  const stopPropagation = (event: React.MouseEvent<HTMLElement>) => {
     event.stopPropagation();
   };
 
-  const yesText = intl.formatMessage({
-    id: 'pages.common.yes',
-    defaultMessage: '确认',
-  });
-
-  const noText = intl.formatMessage({
-    id: 'pages.common.no',
-    defaultMessage: '取消',
-  });
-
   const handleRun = async () => {
     if (!canRun) {
-      message.warning('请先上线任务，再执行运行操作');
+      message.warning(isOnline ? '任务正在执行中' : '请先上线任务，再执行运行操作');
       return;
     }
-
     if (record?.id === undefined || record?.id === null) {
       message.error('任务定义 ID 不存在');
       return;
     }
-
     try {
       setRunLoading(true);
-
       const response = await linkupJobExecuteApi.execute(record.id);
-
-      if (response?.code === API_SUCCESS_CODE) {
-        message.success(
-          intl.formatMessage({
-            id: 'pages.common.success',
-            defaultMessage: '运行成功',
-          }),
-        );
-
-        setRunOpen(false);
-        cbk();
+      if (response?.code !== API_SUCCESS_CODE) {
+        message.error(errorText(response, '运行失败'));
         return;
       }
-
-      message.error(
-        response?.msg ||
-          response?.message ||
-          '运行失败',
-      );
+      message.success('任务已提交运行');
+      setRunOpen(false);
+      cbk();
+    } catch (error: any) {
+      message.error(error?.message || '运行失败');
     } finally {
       setRunLoading(false);
     }
@@ -116,26 +92,21 @@ const ActionColumn: React.FC<ActionColumnProps> = ({
 
   const handleStop = async () => {
     const instanceId = record?.instanceId;
-
     if (instanceId === undefined || instanceId === null) {
       message.error('任务实例 ID 不存在');
       return;
     }
-
-    const response =
-      await linkupJobExecuteApi.pause(instanceId);
-
-    if (response?.code === API_SUCCESS_CODE) {
-      message.success('停止成功');
+    try {
+      const response = await linkupJobExecuteApi.pause(instanceId);
+      if (response?.code !== API_SUCCESS_CODE) {
+        message.error(errorText(response, '停止失败'));
+        return;
+      }
+      message.success('停止请求已提交');
       cbk();
-      return;
+    } catch (error: any) {
+      message.error(error?.message || '停止失败');
     }
-
-    message.error(
-      response?.msg ||
-        response?.message ||
-        '停止失败',
-    );
   };
 
   const handleOnline = async () => {
@@ -143,61 +114,46 @@ const ActionColumn: React.FC<ActionColumnProps> = ({
       message.error('任务定义 ID 不存在');
       return;
     }
-
-    const response =
-      await linkupJobDefinitionApi.online(record.id);
-
-    if (response?.code === API_SUCCESS_CODE) {
+    try {
+      const response = await linkupJobDefinitionApi.online(record.id);
+      if (response?.code !== API_SUCCESS_CODE) {
+        message.error(errorText(response, '上线失败'));
+        return;
+      }
       message.success('上线成功');
       cbk();
-      return;
+    } catch (error: any) {
+      message.error(error?.message || '上线失败');
     }
-
-    message.error(
-      response?.msg ||
-        response?.message ||
-        '上线失败',
-    );
   };
 
   const handleOffline = async () => {
-    if (isRunning) {
-      message.warning('任务正在运行中，请先停止任务后再下线');
+    if (isActive) {
+      message.warning('任务正在执行中，请先停止任务后再下线');
       return;
     }
-
     if (record?.id === undefined || record?.id === null) {
       message.error('任务定义 ID 不存在');
       return;
     }
-
-    const response =
-      await linkupJobDefinitionApi.offline(record.id);
-
-    if (response?.code === API_SUCCESS_CODE) {
+    try {
+      const response = await linkupJobDefinitionApi.offline(record.id);
+      if (response?.code !== API_SUCCESS_CODE) {
+        message.error(errorText(response, '下线失败'));
+        return;
+      }
       message.success('下线成功');
       cbk();
-      return;
+    } catch (error: any) {
+      message.error(error?.message || '下线失败');
     }
-
-    message.error(
-      response?.msg ||
-        response?.message ||
-        '下线失败',
-    );
   };
 
   const showOnlineConfirm = () => {
     confirm({
       title: '任务上线',
       centered: true,
-      content: (
-        <div className="text-sm leading-6 text-[#667085]">
-          上线后任务将恢复可运行状态，并同步恢复调度。
-          <br />
-          确认上线该任务吗？
-        </div>
-      ),
+      content: '上线后任务可以被手动运行或调度触发，确认上线吗？',
       okText: '确认',
       cancelText: '取消',
       onOk: handleOnline,
@@ -205,168 +161,68 @@ const ActionColumn: React.FC<ActionColumnProps> = ({
   };
 
   const showOfflineConfirm = () => {
-    if (isRunning) {
-      message.warning('任务正在运行中，请先停止任务后再下线');
+    if (isActive) {
+      message.warning('任务正在执行中，请先停止任务后再下线');
       return;
     }
-
     confirm({
       title: '任务下线',
       centered: true,
-      content: (
-        <div className="text-sm leading-6 text-[#667085]">
-          下线后任务将不会再被调度触发。
-          <br />
-          确认下线该任务吗？
-        </div>
-      ),
+      content: '下线后任务将不会再被调度触发，确认下线吗？',
       okText: '确认',
       cancelText: '取消',
       onOk: handleOffline,
     });
   };
 
-  const handleEdit = async () => {
+  const handleEdit = () => {
     if (!canEdit) {
-      if (isOnline) {
-        message.warning('任务已上线，请先下线后再编辑');
-        return;
-      }
-
-      if (isRunning) {
-        message.warning('任务正在运行中，请先停止后再编辑');
-        return;
-      }
+      message.warning(isOnline ? '任务已上线，请先下线后再编辑' : '任务正在执行中');
+      return;
     }
-
     if (record?.id === undefined || record?.id === null) {
       message.error('任务定义 ID 不存在');
       return;
     }
-
-    const response =
-      await linkupJobDefinitionApi.selectEditDetail(
-        record.id,
-      );
-
-    if (response?.code === API_SUCCESS_CODE) {
-      goDetail(record.id, record);
-      return;
-    }
-
-    message.error(
-      response?.msg ||
-        response?.message ||
-        '获取任务详情失败',
-    );
-  };
-
-  const doDeleteTask = async (
-    id: string | number,
-  ) => {
-    const response =
-      await linkupJobDefinitionApi.delete(id);
-
-    if (response?.code === API_SUCCESS_CODE) {
-      message.success(
-        response?.msg || '删除成功',
-      );
-      cbk();
-      return;
-    }
-
-    message.error(
-      response?.msg ||
-        response?.message ||
-        '删除失败',
-    );
+    goDetail(record.id, record);
   };
 
   const handleDeleteTask = () => {
     if (!canDelete) {
-      if (isOnline) {
-        message.warning('任务已上线，请先下线后再删除');
-        return;
-      }
-
-      if (isRunning) {
-        message.warning('任务正在运行中，请先停止后再删除');
-        return;
-      }
+      message.warning(isOnline ? '任务已上线，请先下线后再删除' : '任务正在执行中');
+      return;
     }
-
     confirm({
-      title: intl.formatMessage({
-        id: 'pages.job.action.delete.confirmTitle',
-        defaultMessage: '删除任务',
-      }),
+      title: '删除任务',
       centered: true,
-      content: (
-        <div className="text-sm leading-6 text-[#667085]">
-          确认删除任务
-          <span className="mx-1 font-medium text-[#344054]">
-            {record?.jobName || '-'}
-          </span>
-          吗？
-          <br />
-          删除后将无法恢复。
-        </div>
-      ),
-      okText: intl.formatMessage({
-        id: 'pages.job.action.delete.okText',
-        defaultMessage: '删除',
-      }),
+      content: `确认删除任务 ${record?.jobName || '-'} 吗？删除后无法恢复。`,
+      okText: '删除',
       cancelText: '取消',
-      okButtonProps: {
-        danger: true,
-      },
-      maskClosable: true,
-      onOk: () => {
-        if (
-          record?.id === undefined ||
-          record?.id === null
-        ) {
-          message.error('任务定义 ID 不存在');
+      okButtonProps: { danger: true },
+      onOk: async () => {
+        const response = await linkupJobDefinitionApi.delete(record.id);
+        if (response?.code !== API_SUCCESS_CODE) {
+          message.error(errorText(response, '删除失败'));
           return;
         }
-
-        return doDeleteTask(record.id);
+        message.success('删除成功');
+        cbk();
       },
     });
   };
 
   const menuItems: MenuProps['items'] = [
-    {
-      key: 'view',
-      icon: <EyeOutlined />,
-      label: '查看详情',
-    },
-    {
-      key: 'edit',
-      icon: <EditOutlined />,
-      label: '编辑配置',
-      disabled: !canEdit,
-    },
-    {
-      key: 'log',
-      icon: <FileSearchOutlined />,
-      label: '查看日志',
-    },
-    {
-      type: 'divider',
-    },
+    { key: 'view', icon: <EyeOutlined />, label: '查看详情' },
+    { key: 'edit', icon: <EditOutlined />, label: '编辑配置', disabled: !canEdit },
+    { key: 'log', icon: <FileSearchOutlined />, label: '查看日志' },
+    { type: 'divider' },
     {
       key: isOnline ? 'offline' : 'online',
-      icon: isOnline ? (
-        <CloudDownloadOutlined />
-      ) : (
-        <CloudUploadOutlined />
-      ),
+      icon: isOnline ? <CloudDownloadOutlined /> : <CloudUploadOutlined />,
       label: isOnline ? '下线任务' : '上线任务',
+      disabled: isActive,
     },
-    {
-      type: 'divider',
-    },
+    { type: 'divider' },
     {
       key: 'delete',
       icon: <DeleteOutlined />,
@@ -376,58 +232,25 @@ const ActionColumn: React.FC<ActionColumnProps> = ({
     },
   ];
 
-  const handleMenuClick: MenuProps['onClick'] = ({
-    key,
-    domEvent,
-  }) => {
+  const handleMenuClick: MenuProps['onClick'] = ({ key, domEvent }) => {
     domEvent.stopPropagation();
-
-    switch (key) {
-      case 'view':
-        taskViewRef.current?.onOpen(
-          true,
-          record,
-          cbk,
-        );
-        break;
-
-      case 'edit':
-        handleEdit();
-        break;
-
-      case 'log':
-        setLogOpen(true);
-        break;
-
-      case 'online':
-        showOnlineConfirm();
-        break;
-
-      case 'offline':
-        showOfflineConfirm();
-        break;
-
-      case 'delete':
-        handleDeleteTask();
-        break;
-
-      default:
-        break;
-    }
+    if (key === 'view') taskViewRef.current?.onOpen(true, record, cbk);
+    if (key === 'edit') handleEdit();
+    if (key === 'log') setLogOpen(true);
+    if (key === 'online') showOnlineConfirm();
+    if (key === 'offline') showOfflineConfirm();
+    if (key === 'delete') handleDeleteTask();
   };
 
   return (
     <>
       <div className="flex items-center gap-1 whitespace-nowrap">
-        {isRunning ? (
+        {isActive ? (
           <Popconfirm
-            title={intl.formatMessage({
-              id: 'pages.job.action.stop.title',
-              defaultMessage: '停止任务',
-            })}
+            title="停止任务"
             description="确认停止当前任务吗？"
-            okText={yesText}
-            cancelText={noText}
+            okText={intl.formatMessage({ id: 'pages.common.yes', defaultMessage: '确认' })}
+            cancelText={intl.formatMessage({ id: 'pages.common.no', defaultMessage: '取消' })}
             onConfirm={handleStop}
           >
             <Button
@@ -442,56 +265,33 @@ const ActionColumn: React.FC<ActionColumnProps> = ({
             </Button>
           </Popconfirm>
         ) : (
-          <Tooltip
-            title={
-              canRun
-                ? undefined
-                : '请先上线任务'
-            }
-          >
+          <Tooltip title={canRun ? undefined : '请先上线任务'}>
             <Popconfirm
-              title={intl.formatMessage({
-                id: 'pages.job.action.run.title',
-                defaultMessage: '运行任务',
-              })}
+              title="运行任务"
               description="确认运行当前任务吗？"
               open={canRun && runOpen}
-              okText={yesText}
-              cancelText={noText}
-              okButtonProps={{
-                loading: runLoading,
-              }}
+              okText="确认"
+              cancelText="取消"
+              okButtonProps={{ loading: runLoading }}
               onConfirm={handleRun}
               onOpenChange={(open) => {
                 if (!canRun) {
-                  if (open) {
-                    message.warning(
-                      '请先上线任务，再执行运行操作',
-                    );
-                  }
-
+                  if (open) message.warning('请先上线任务，再执行运行操作');
                   return;
                 }
-
-                if (!runLoading) {
-                  setRunOpen(open);
-                }
+                if (!runLoading) setRunOpen(open);
               }}
             >
               <Button
                 size="small"
-                color={
-                  canRun ? 'primary' : 'default'
-                }
+                color={canRun ? 'primary' : 'default'}
                 variant="filled"
                 loading={runLoading}
                 aria-disabled={!canRun}
                 icon={<PlayCircleOutlined />}
                 className={[
                   '!h-7 !rounded-md !px-2.5 !text-xs',
-                  !canRun
-                    ? '!cursor-not-allowed !text-[#98a2b3]'
-                    : '',
+                  !canRun ? '!cursor-not-allowed !text-[#98a2b3]' : '',
                 ].join(' ')}
                 onClick={stopPropagation}
               >
@@ -504,10 +304,7 @@ const ActionColumn: React.FC<ActionColumnProps> = ({
         <Dropdown
           trigger={['click']}
           placement="bottomRight"
-          menu={{
-            items: menuItems,
-            onClick: handleMenuClick,
-          }}
+          menu={{ items: menuItems, onClick: handleMenuClick }}
         >
           <Button
             size="small"
@@ -523,18 +320,13 @@ const ActionColumn: React.FC<ActionColumnProps> = ({
       </div>
 
       <TaskViewModal ref={taskViewRef} />
-
       <RunLogDrawer
         open={logOpen}
         jobMode="BATCH"
         instanceId={record?.instanceId}
         onClose={() => setLogOpen(false)}
         title="运行日志"
-        subtitle={
-          record?.jobName
-            ? `任务：${record.jobName}`
-            : '查看任务运行输出'
-        }
+        subtitle={record?.jobName ? `任务：${record.jobName}` : '查看任务运行输出'}
       />
     </>
   );

--- a/yak-ops-ui/src/pages/batch-link-up/components/SyncTaskList/components/TaskStatus.tsx
+++ b/yak-ops-ui/src/pages/batch-link-up/components/SyncTaskList/components/TaskStatus.tsx
@@ -1,541 +1,140 @@
-import { message, Popover } from "antd";
-import React, { useEffect, useRef, useState } from "react";
+import {
+  CheckCircleFilled,
+  ClockCircleFilled,
+  CloseCircleFilled,
+  ExclamationCircleFilled,
+  LoadingOutlined,
+  MinusCircleFilled,
+  QuestionCircleFilled,
+} from '@ant-design/icons';
+import { Button, Popover, Tag, message } from 'antd';
+import React, { useMemo } from 'react';
 
 interface TaskStatusProps {
   status?: string;
   errorMessage?: string;
 }
 
-type PixelIconProps = {
-  className?: string;
-};
+interface StatusMeta {
+  label: string;
+  color: string;
+  icon: React.ReactNode;
+  active?: boolean;
+}
 
-const PixelStatusStyle: React.FC = () => (
-  <style>
-    {`
-      @keyframes pixelTrackMove {
-        0% {
-          transform: translateX(-16px);
-        }
-        100% {
-          transform: translateX(16px);
-        }
-      }
-
-      @keyframes pixelRunnerBob {
-        0%, 100% {
-          transform: translateY(0);
-        }
-        50% {
-          transform: translateY(-1px);
-        }
-      }
-
-      @keyframes pixelRunnerFrameA {
-        0%, 49% {
-          opacity: 1;
-        }
-        50%, 100% {
-          opacity: 0;
-        }
-      }
-
-      @keyframes pixelRunnerFrameB {
-        0%, 49% {
-          opacity: 0;
-        }
-        50%, 100% {
-          opacity: 1;
-        }
-      }
-
-      @keyframes pixelPulse {
-        0%, 100% {
-          opacity: 0.45;
-        }
-        50% {
-          opacity: 1;
-        }
-      }
-
-      @keyframes pixelBlink {
-        0%, 45% {
-          opacity: 1;
-        }
-        46%, 100% {
-          opacity: 0.25;
-        }
-      }
-
-      @keyframes copySuccessPop {
-        0% {
-          transform: scale(0.92);
-          opacity: 0.75;
-        }
-        60% {
-          transform: scale(1.06);
-          opacity: 1;
-        }
-        100% {
-          transform: scale(1);
-          opacity: 1;
-        }
-      }
-    `}
-  </style>
-);
-
-const PixelRunningIcon: React.FC<PixelIconProps> = ({ className }) => {
-  return (
-    <span
-      className={[
-        "relative inline-flex h-[18px] w-[46px] items-center overflow-hidden",
-        className,
-      ]
-        .filter(Boolean)
-        .join(" ")}
-      aria-hidden="true"
-    >
-      {/* moving pixel road */}
-      <span className="absolute left-0 top-[12px] h-[2px] w-full overflow-hidden opacity-60">
-        <span
-          className="absolute left-0 top-0 h-[2px] w-[78px]"
-          style={{
-            background:
-              "repeating-linear-gradient(to right, currentColor 0 6px, transparent 6px 10px)",
-            animation: "pixelTrackMove 0.42s linear infinite",
-          }}
-        />
-      </span>
-
-      {/* center runner */}
-      <svg
-        width="46"
-        height="18"
-        viewBox="0 0 46 18"
-        fill="currentColor"
-        shapeRendering="crispEdges"
-        className="relative z-10"
-      >
-        <g style={{ animation: "pixelRunnerBob 0.24s steps(2, end) infinite" }}>
-          {/* head */}
-          <rect x="22" y="1" width="4" height="4" />
-          <rect x="21" y="2" width="1" height="2" />
-          <rect x="26" y="2" width="1" height="2" />
-
-          {/* body */}
-          <rect x="21" y="6" width="6" height="5" />
-          <rect x="23" y="5" width="2" height="1" />
-
-          {/* frame A */}
-          <g style={{ animation: "pixelRunnerFrameA 0.32s steps(1, end) infinite" }}>
-            <rect x="17" y="6" width="4" height="2" />
-            <rect x="27" y="7" width="5" height="2" />
-            <rect x="19" y="11" width="3" height="2" />
-            <rect x="17" y="13" width="3" height="2" />
-            <rect x="26" y="11" width="2" height="4" />
-            <rect x="28" y="15" width="4" height="2" />
-          </g>
-
-          {/* frame B */}
-          <g style={{ animation: "pixelRunnerFrameB 0.32s steps(1, end) infinite" }}>
-            <rect x="18" y="7" width="5" height="2" />
-            <rect x="27" y="6" width="4" height="2" />
-            <rect x="21" y="11" width="2" height="4" />
-            <rect x="18" y="15" width="4" height="2" />
-            <rect x="26" y="11" width="3" height="2" />
-            <rect x="29" y="13" width="3" height="2" />
-          </g>
-        </g>
-
-        {/* speed pixels */}
-        <rect x="7" y="5" width="6" height="2" opacity="0.45" />
-        <rect x="3" y="9" width="8" height="2" opacity="0.28" />
-        <rect x="11" y="13" width="5" height="2" opacity="0.38" />
-      </svg>
-    </span>
-  );
-};
-
-const PixelFinishedIcon: React.FC<PixelIconProps> = ({ className }) => (
-  <svg
-    width="28"
-    height="20"
-    viewBox="0 0 28 20"
-    fill="currentColor"
-    shapeRendering="crispEdges"
-    className={className}
-    aria-hidden="true"
-  >
-    {/* flag pole */}
-    <rect x="4" y="2" width="2" height="16" />
-    <rect x="2" y="17" width="8" height="2" />
-
-    {/* pixel flag */}
-    <rect x="6" y="2" width="14" height="3" />
-    <rect x="6" y="5" width="12" height="3" />
-    <rect x="6" y="8" width="14" height="3" />
-
-    {/* check */}
-    <rect x="12" y="8" width="3" height="3" fill="white" />
-    <rect x="15" y="11" width="3" height="3" fill="white" />
-    <rect x="18" y="5" width="3" height="3" fill="white" />
-    <rect x="18" y="8" width="3" height="3" fill="white" />
-    <rect x="21" y="2" width="3" height="3" fill="white" />
-  </svg>
-);
-
-const PixelFailedIcon: React.FC<PixelIconProps> = ({ className }) => (
-  <svg
-    width="26"
-    height="20"
-    viewBox="0 0 26 20"
-    fill="none"
-    shapeRendering="crispEdges"
-    className={className}
-    aria-hidden="true"
-  >
-    {/* outer pixel badge */}
-    <rect x="7" y="1" width="12" height="2" fill="currentColor" />
-    <rect x="5" y="3" width="16" height="2" fill="currentColor" />
-    <rect x="3" y="5" width="20" height="10" fill="currentColor" />
-    <rect x="5" y="15" width="16" height="2" fill="currentColor" />
-    <rect x="7" y="17" width="12" height="2" fill="currentColor" />
-
-    {/* center X */}
-    <rect x="8" y="6" width="3" height="3" fill="white" />
-    <rect x="11" y="9" width="3" height="2" fill="white" />
-    <rect x="8" y="11" width="3" height="3" fill="white" />
-
-    <rect x="15" y="6" width="3" height="3" fill="white" />
-    <rect x="12" y="9" width="3" height="2" fill="white" />
-    <rect x="15" y="11" width="3" height="3" fill="white" />
-
-    {/* glitch pixels */}
-    <rect
-      x="1"
-      y="4"
-      width="2"
-      height="2"
-      fill="currentColor"
-      style={{ animation: "pixelBlink 0.8s steps(1, end) infinite" }}
-    />
-    <rect
-      x="22"
-      y="2"
-      width="2"
-      height="2"
-      fill="currentColor"
-      style={{ animation: "pixelBlink 1s steps(1, end) infinite" }}
-    />
-    <rect
-      x="23"
-      y="15"
-      width="2"
-      height="2"
-      fill="currentColor"
-      style={{ animation: "pixelBlink 0.9s steps(1, end) infinite" }}
-    />
-  </svg>
-);
-
-const PixelCanceledIcon: React.FC<PixelIconProps> = ({ className }) => (
-  <svg
-    width="24"
-    height="20"
-    viewBox="0 0 24 20"
-    fill="currentColor"
-    shapeRendering="crispEdges"
-    className={className}
-    aria-hidden="true"
-  >
-    {/* stop block */}
-    <rect x="7" y="1" width="10" height="2" />
-    <rect x="5" y="3" width="14" height="2" />
-    <rect x="3" y="5" width="18" height="10" />
-    <rect x="5" y="15" width="14" height="2" />
-    <rect x="7" y="17" width="10" height="2" />
-
-    {/* minus */}
-    <rect x="7" y="9" width="10" height="2" fill="white" />
-  </svg>
-);
-
-const PixelPausedIcon: React.FC<PixelIconProps> = ({ className }) => (
-  <svg
-    width="24"
-    height="20"
-    viewBox="0 0 24 20"
-    fill="currentColor"
-    shapeRendering="crispEdges"
-    className={className}
-    aria-hidden="true"
-  >
-    {/* cartridge-like pause icon */}
-    <rect x="4" y="2" width="16" height="2" />
-    <rect x="2" y="4" width="20" height="12" />
-    <rect x="4" y="16" width="16" height="2" />
-
-    <rect x="8" y="6" width="3" height="8" fill="white" />
-    <rect x="13" y="6" width="3" height="8" fill="white" />
-
-    <rect
-      x="21"
-      y="7"
-      width="2"
-      height="2"
-      style={{ animation: "pixelPulse 1s steps(2, end) infinite" }}
-    />
-  </svg>
-);
-
-const PixelNotStartedIcon: React.FC<PixelIconProps> = ({ className }) => (
-  <svg
-    width="24"
-    height="20"
-    viewBox="0 0 24 20"
-    fill="currentColor"
-    shapeRendering="crispEdges"
-    className={className}
-    aria-hidden="true"
-  >
-    {/* idle terminal */}
-    <rect x="3" y="3" width="18" height="2" />
-    <rect x="1" y="5" width="2" height="10" />
-    <rect x="21" y="5" width="2" height="10" />
-    <rect x="3" y="15" width="18" height="2" />
-
-    <rect x="6" y="7" width="2" height="2" />
-    <rect x="8" y="9" width="2" height="2" />
-    <rect x="6" y="11" width="2" height="2" />
-
-    <rect
-      x="13"
-      y="11"
-      width="5"
-      height="2"
-      style={{ animation: "pixelBlink 1s steps(1, end) infinite" }}
-    />
-  </svg>
-);
-
-const PixelCopyIcon: React.FC<PixelIconProps> = ({ className }) => (
-  <svg
-    width="14"
-    height="14"
-    viewBox="0 0 14 14"
-    fill="currentColor"
-    shapeRendering="crispEdges"
-    className={className}
-    aria-hidden="true"
-  >
-    <rect x="5" y="1" width="7" height="2" />
-    <rect x="5" y="3" width="2" height="8" />
-    <rect x="10" y="3" width="2" height="8" />
-    <rect x="5" y="10" width="7" height="2" />
-
-    <rect x="2" y="4" width="2" height="8" opacity="0.55" />
-    <rect x="2" y="12" width="7" height="1" opacity="0.55" />
-  </svg>
-);
-
-const PixelCopiedIcon: React.FC<PixelIconProps> = ({ className }) => (
-  <svg
-    width="14"
-    height="14"
-    viewBox="0 0 14 14"
-    fill="currentColor"
-    shapeRendering="crispEdges"
-    className={className}
-    aria-hidden="true"
-  >
-    <rect x="2" y="7" width="2" height="2" />
-    <rect x="4" y="9" width="2" height="2" />
-    <rect x="6" y="7" width="2" height="2" />
-    <rect x="8" y="5" width="2" height="2" />
-    <rect x="10" y="3" width="2" height="2" />
-  </svg>
-);
-
-const statusConfig: Record<
-  string,
-  {
-    color: string;
-    bgColor: string;
-    icon: React.ReactNode;
-    label: string;
-  }
-> = {
-  FINISHED: {
-    color: "#16a34a",
-    bgColor: "rgba(22, 163, 74, 0.10)",
-    icon: <PixelFinishedIcon />,
-    label: "FINISHED",
+const STATUS_META: Record<string, StatusMeta> = {
+  CREATED: {
+    label: '已创建',
+    color: 'default',
+    icon: <ClockCircleFilled />,
+    active: true,
+  },
+  SUBMITTED: {
+    label: '提交中',
+    color: 'processing',
+    icon: <LoadingOutlined spin />,
+    active: true,
+  },
+  QUEUED: {
+    label: '排队中',
+    color: 'processing',
+    icon: <LoadingOutlined spin />,
+    active: true,
   },
   RUNNING: {
-    color: "#1677ff",
-    bgColor: "rgba(22, 119, 255, 0.10)",
-    icon: <PixelRunningIcon />,
-    label: "RUNNING",
+    label: '运行中',
+    color: 'processing',
+    icon: <LoadingOutlined spin />,
+    active: true,
+  },
+  SUCCEEDED: {
+    label: '已完成',
+    color: 'success',
+    icon: <CheckCircleFilled />,
   },
   FAILED: {
-    color: "#ef4444",
-    bgColor: "rgba(239, 68, 68, 0.12)",
-    icon: <PixelFailedIcon />,
-    label: "FAILED",
+    label: '失败',
+    color: 'error',
+    icon: <CloseCircleFilled />,
   },
   CANCELED: {
-    color: "#64748b",
-    bgColor: "rgba(100, 116, 139, 0.12)",
-    icon: <PixelCanceledIcon />,
-    label: "CANCELED",
+    label: '已取消',
+    color: 'default',
+    icon: <MinusCircleFilled />,
   },
-  PAUSED: {
-    color: "#f59e0b",
-    bgColor: "rgba(245, 158, 11, 0.13)",
-    icon: <PixelPausedIcon />,
-    label: "PAUSED",
+  LOST: {
+    label: '状态丢失',
+    color: 'warning',
+    icon: <ExclamationCircleFilled />,
   },
+};
+
+const LEGACY_ALIASES: Record<string, string> = {
+  FINISHED: 'SUCCEEDED',
+  COMPLETED: 'SUCCEEDED',
+  CANCELLED: 'CANCELED',
+  PENDING: 'QUEUED',
+};
+
+const normalizeStatus = (value?: string) => {
+  const normalized = String(value || '').trim().toUpperCase();
+  return LEGACY_ALIASES[normalized] || normalized;
 };
 
 const TaskStatus: React.FC<TaskStatusProps> = ({ status, errorMessage }) => {
-  const config = status ? statusConfig[status] : undefined;
-  const [copied, setCopied] = useState(false);
-  const timerRef = useRef<number | null>(null);
-  console.log(status);
-  console.log(errorMessage)
-  useEffect(() => {
-    return () => {
-      if (timerRef.current) {
-        window.clearTimeout(timerRef.current);
-      }
-    };
-  }, []);
+  const normalized = normalizeStatus(status);
+  const meta = useMemo<StatusMeta>(
+    () =>
+      STATUS_META[normalized] || {
+        label: normalized || '未运行',
+        color: 'default',
+        icon: normalized ? <QuestionCircleFilled /> : <ClockCircleFilled />,
+      },
+    [normalized],
+  );
 
-  const handleCopy = async (e?: React.MouseEvent) => {
-    e?.stopPropagation();
+  const tag = (
+    <Tag
+      color={meta.color}
+      icon={meta.icon}
+      className="!m-0 inline-flex min-w-[76px] items-center justify-center !rounded-md !px-2 !py-0.5 text-xs"
+    >
+      {meta.label}
+    </Tag>
+  );
 
-    if (!errorMessage) return;
+  if (!errorMessage || (normalized !== 'FAILED' && normalized !== 'LOST')) {
+    return tag;
+  }
 
+  const copyError = async () => {
     try {
       await navigator.clipboard.writeText(errorMessage);
-      setCopied(true);
-
-      if (timerRef.current) {
-        window.clearTimeout(timerRef.current);
-      }
-
-      timerRef.current = window.setTimeout(() => {
-        setCopied(false);
-      }, 1800);
-    } catch (err) {
-      console.log(err)
-      message.error(err);
+      message.success('错误信息已复制');
+    } catch {
+      message.error('复制失败，请手动复制');
     }
   };
 
-  if (!config) {
-    return (
-      <>
-        <PixelStatusStyle />
-
-        <span
-          className="inline-flex h-6 min-w-[46px] items-center justify-center"
-          style={{ color: "#999" }}
-          title="NOT STARTED"
-          aria-label="NOT STARTED"
-        >
-          <PixelNotStartedIcon />
-        </span>
-      </>
-    );
-  }
-
-const content = (
-  <span
-    className="inline-flex h-7 min-w-[58px] items-center justify-center rounded-md px-2"
-    style={{
-      color: config.color,
-      backgroundColor: config.bgColor,
-    }}
-    title={config.label}
-    aria-label={config.label}
-  >
-    {config.icon}
-  </span>
-);
-
-  if (status === "FAILED" && errorMessage) {
-    const lines = errorMessage.split("\n");
-
-    return (
-      <>
-        <PixelStatusStyle />
-
-        <Popover
-          placement="right"
-          trigger="hover"
-          title={null}
-          overlayInnerStyle={{
-            padding: 0,
-            borderRadius: 14,
-            overflow: "hidden",
-            boxShadow: "0 18px 45px rgba(15, 23, 42, 0.18)",
-          }}
-          content={
-            <div className="w-[520px] overflow-hidden rounded-[14px] border border-white/10 bg-[#0f172a] font-mono text-[13px] leading-[1.6]">
-              <div className="flex h-10 items-center justify-between border-b border-white/10 bg-white/[0.03] px-3">
-                <div className="flex items-center gap-1.5">
-                  <span className="h-2.5 w-2.5 rounded-full bg-[#ff5f57]" />
-                  <span className="h-2.5 w-2.5 rounded-full bg-[#ffbd2e]" />
-                  <span className="h-2.5 w-2.5 rounded-full bg-[#28c840]" />
-                </div>
-
-                <button
-                  type="button"
-                  onClick={handleCopy}
-                  className={[
-                    "inline-flex items-center justify-center gap-1.5 rounded-full border px-2.5 py-1 text-xs transition-all duration-200",
-                    copied
-                      ? "border-[#86efac]/80 bg-[#f0fdf4] text-[#16a34a]"
-                      : "border-white/10 bg-white/5 text-slate-300 hover:bg-white/10 hover:text-white",
-                  ].join(" ")}
-                  style={{
-                    animation: copied ? "copySuccessPop 0.28s ease" : "none",
-                  }}
-                >
-                  {copied ? <PixelCopiedIcon /> : <PixelCopyIcon />}
-                  <span>{copied ? "COPIED" : "COPY"}</span>
-                </button>
-              </div>
-
-              <div className="max-h-[240px] min-h-[120px] overflow-auto px-3 py-3">
-                {lines.map((line, index) => (
-                  <div key={index} className="flex items-start">
-                    <span className="w-9 shrink-0 select-none pr-3 text-right text-[#64748b]">
-                      {index + 1}
-                    </span>
-
-                    <span className="flex-1 whitespace-pre-wrap break-words text-[rgb(0,255,136)]">
-                      {line || " "}
-                    </span>
-                  </div>
-                ))}
-              </div>
-            </div>
-          }
-        >
-          <span className="inline-flex cursor-pointer">{content}</span>
-        </Popover>
-      </>
-    );
-  }
-
   return (
-    <>
-      <PixelStatusStyle />
-      {content}
-    </>
+    <Popover
+      placement="right"
+      trigger="hover"
+      content={
+        <div className="w-[440px]">
+          <div className="max-h-[240px] overflow-auto whitespace-pre-wrap break-words rounded-md bg-[#101828] p-3 font-mono text-xs leading-5 text-[#fda29b]">
+            {errorMessage}
+          </div>
+          <div className="mt-2 flex justify-end">
+            <Button size="small" onClick={copyError}>
+              复制错误
+            </Button>
+          </div>
+        </div>
+      }
+    >
+      <span className="inline-flex cursor-help">{tag}</span>
+    </Popover>
   );
 };
 

--- a/yak-ops-ui/src/pages/batch-link-up/detail/form-schema/validateEditorConnectorForms.ts
+++ b/yak-ops-ui/src/pages/batch-link-up/detail/form-schema/validateEditorConnectorForms.ts
@@ -1,6 +1,7 @@
 import {
   endpointNode,
   isApiSuccess,
+  responseMessage,
   type SyncEditorState,
 } from '../model';
 import { connectorFormApi } from './service';
@@ -24,8 +25,12 @@ export default async function validateEditorConnectorForms(
 ): Promise<string[]> {
   const sourceConfig = endpointNode(editor.workflow, 'source')?.data?.config || {};
   const sinkConfig = endpointNode(editor.workflow, 'sink')?.data?.config || {};
-  const sourceConnectorId = connectorIdForDataSourceType(editor.basic.sourceType);
-  const sinkConnectorId = connectorIdForDataSourceType(editor.basic.targetType);
+  const sourceConnectorId = connectorIdForDataSourceType(
+    sourceConfig.connectorId || editor.basic.sourceType,
+  );
+  const sinkConnectorId = connectorIdForDataSourceType(
+    sinkConfig.connectorId || editor.basic.targetType,
+  );
   const channel = editor.workflow.channelConfig || {};
 
   const requests: Promise<any>[] = [];
@@ -58,10 +63,14 @@ export default async function validateEditorConnectorForms(
   try {
     const responses = await Promise.all(requests);
     return responses.flatMap((response) =>
-      isApiSuccess(response) ? resultErrors(response.data) : [],
+      isApiSuccess(response)
+        ? resultErrors(response.data)
+        : [responseMessage(response, 'Connector 配置校验失败')],
     );
-  } catch {
-    // Worker 或 Schema 缓存临时不可用时，保留原有前端校验，不阻断任务保存。
-    return [];
+  } catch (error: any) {
+    return [
+      error?.message ||
+        'Connector 配置校验服务不可用，请检查 Link-Up Worker 和 Schema 缓存后重试',
+    ];
   }
 }

--- a/yak-ops-ui/src/pages/batch-link-up/detail/form-schema/valueAdapter.test.ts
+++ b/yak-ops-ui/src/pages/batch-link-up/detail/form-schema/valueAdapter.test.ts
@@ -7,6 +7,9 @@ import {
 test('maps relational datasource types to jdbc schema', () => {
   expect(connectorIdForDataSourceType('MYSQL')).toBe('jdbc');
   expect(connectorIdForDataSourceType('DORIS')).toBe('jdbc');
+  expect(connectorIdForDataSourceType('POSTGRE_SQL')).toBe('jdbc');
+  expect(connectorIdForDataSourceType('KINGBASE')).toBe('jdbc');
+  expect(connectorIdForDataSourceType('DAMENG')).toBe('jdbc');
   expect(connectorIdForDataSourceType('HTTP')).toBe('http');
 });
 

--- a/yak-ops-ui/src/pages/batch-link-up/detail/form-schema/valueAdapter.ts
+++ b/yak-ops-ui/src/pages/batch-link-up/detail/form-schema/valueAdapter.ts
@@ -3,6 +3,7 @@ import type { ConnectorFormValues, ConnectorRole } from './types';
 const RELATIONAL_TYPES = new Set([
   'MYSQL',
   'MARIADB',
+  'POSTGRE_SQL',
   'POSTGRESQL',
   'POSTGRES',
   'ORACLE',
@@ -13,11 +14,14 @@ const RELATIONAL_TYPES = new Set([
   'CLICKHOUSE',
   'DB2',
   'HIVE',
+  'KINGBASE',
+  'DAMENG',
+  'DM',
   'JDBC',
 ]);
 
 export const connectorIdForDataSourceType = (value?: string): string => {
-  const normalized = (value || '').trim().toUpperCase();
+  const normalized = (value || '').trim().toUpperCase().replace(/-/g, '_');
   if (!normalized) return '';
   return RELATIONAL_TYPES.has(normalized) ? 'jdbc' : normalized.toLowerCase();
 };


### PR DESCRIPTION
## Summary

This repairs the reviewed Yak Ops offline-sync frontend/backend flow after the structured JobSpec migration.

### Task creation and definitions

- add a real draft lifecycle for newly created tasks
- create the lightweight task shell without requiring datasource/table configuration
- prevent drafts from being online or executed until the first immutable version exists
- create version `1` only after the editor completes and saves the executable configuration
- normalize datasource labels such as `MYSQL`, `POSTGRE_SQL`, `ORACLE`, `DORIS`, `KINGBASE`, and `DAMENG` to the Link-Up connector ID `jdbc`
- remove the misleading HOCON preview alias and retain only JobSpec preview routes

### Validation and form actions

- make frontend remote Connector validation fail closed
- enforce Connector Form Schema validation again in the formal backend save path
- restrict dynamic Form Actions to Schema-declared `LIST_TABLES` and `LIST_COLUMNS`
- reject arbitrary preview/count/SQL actions through the dynamic-form action endpoint
- restrict Action request values to the keys declared by the field's `optionSource`

### JobSpec and credential safety

- persist a logical JobSpec containing `dataSourceRef.id`, not JDBC credentials
- resolve the latest URL, driver, username, password, and schema immediately before each Link-Up submission
- keep the resolved sensitive payload in the outbound HTTP request only
- store the logical/redacted JobSpec in immutable versions and execution snapshots
- add Flyway V5 to normalize historical relational Connector IDs, add datasource references, remove persisted connection values, and recalculate version digests
- allow datasource password rotation without editing every task version

### Execution reliability

- add a short transactional execution-claim service using `SELECT ... FOR UPDATE`
- atomically check active executions and create one execution attempt
- prevent manual, schedule, and retry triggers from submitting the same task concurrently
- distinguish Link-Up protocol/local failures from uncertain transport failures
- mark local configuration and serialization failures as `FAILED` immediately
- retain `SUBMITTED` only when the Worker may have accepted the idempotent request
- remove GET mutation endpoints; execute and cancel now use POST

### Scheduling and status

- align `retryInterval` with the editor's minute-based meaning
- support explicit `retryIntervalSeconds` and `retryPolicy.backoffSeconds`
- interpret `retryTimes` as retries after the first attempt, so total attempts are `retryTimes + 1`
- normalize `COMPLETED` and `FINISHED` filters to `SUCCEEDED`
- make the running filter include `CREATED`, `SUBMITTED`, `QUEUED`, and `RUNNING`
- update task status rendering for the complete offline Worker lifecycle
- prevent edit/delete/offline actions for every active execution state

### Observability

- stop converting Link-Up table-metric failures into an indistinguishable empty array
- return a clear error when the execution has no Worker job ID or the Worker request fails
- remove leftover frontend SCRIPT/HOCON API methods

## Main flow after this PR

```text
Create drawer
  -> draft definition
  -> datasource/table configuration
  -> frontend validation
  -> backend Form Schema validation
  -> logical immutable JobSpec
  -> online
  -> atomic execution claim
  -> runtime datasource credential resolution
  -> Link-Up structured JobSpec submission
  -> reconciliation / retry / terminal status
```

## Validation

- added Connector ID normalization tests
- extended JobSpec tests to verify logical persistence, credential redaction, datasource references, runtime credential resolution, primary keys, and future Connector pass-through
- extended frontend value-adapter coverage for `POSTGRE_SQL`, Kingbase, and Dameng
- performed source-level cross-checks of Spring dependency direction, REST paths, DTO fields, MyBatis persistence fields, and Flyway V4 -> V5 ordering
- verified the branch is based on and not behind latest `main` commit `8764d839c4d58c76d29774d2ee99081d09dafaec`

The repository has no GitHub Actions workflow and the execution environment does not contain Maven or the complete frontend dependency tree, so a full reactor build, Spring context boot, Flyway integration run, and production UI build still need to be executed in a local checkout before marking the PR ready.

## Notes

- Link-Up remains an offline-only Worker; this does not add CDC, checkpoint, savepoint, pause/resume, or streaming deployment semantics.
- temporary helper branches created during connector-backed validation are not used by this PR; the PR head is `agent/offline-sync-flow-fixes`.