### PR TITLE
feat(storage): add embedded local storage plugin

### DIFF
--- a/docs/resource-management-backend.md
+++ b/docs/resource-management-backend.md
@@ -48,7 +48,9 @@ yak-ops-plugin-storage
 
 ## 存储配置
 
-默认启用内置 Local 存储，不再要求部署 MinIO 或 HDFS。通过 `yak.resource.storage.type` 选择当前根目录使用的存储类型。
+默认活动存储改为内置 Local，因此启动和使用资源管理不再要求部署 MinIO 或 HDFS。MinIO 插件继续保持启用，以兼容数据库中已有的 `MINIO` 类型资源；只有实际访问 MinIO 资源时才需要对应服务可用。
+
+通过 `yak.resource.storage.type` 选择当前根目录使用的存储类型。
 
 ```yaml
 yak:
@@ -61,7 +63,7 @@ yak:
         base-directory: ./data/resources
         checksum-enabled: true
       minio:
-        enabled: false
+        enabled: true
         endpoint: http://127.0.0.1:9000
         access-key: minioadmin
         secret-key: minioadmin

--- a/docs/resource-management-backend.md
+++ b/docs/resource-management-backend.md
@@ -16,12 +16,13 @@ yak-ops-business-resource
 
 yak-ops-plugin-storage
   ├─ storage-api
+  ├─ storage-local
   ├─ storage-minio
   ├─ storage-hdfs
   └─ storage-all
 ```
 
-资源数据库保存目录和文件元数据，MinIO/HDFS 插件只保存物理内容。业务模块只依赖存储 API，不依赖具体实现。
+资源数据库保存目录和文件元数据，Local、MinIO、HDFS 插件只保存物理内容。业务模块只依赖存储 API，不依赖具体实现。
 
 ## 接口
 
@@ -47,16 +48,20 @@ yak-ops-plugin-storage
 
 ## 存储配置
 
-默认启用 MinIO，HDFS 默认关闭。通过 `yak.resource.storage.type` 选择当前根目录使用的存储类型。
+默认启用内置 Local 存储，不再要求部署 MinIO 或 HDFS。通过 `yak.resource.storage.type` 选择当前根目录使用的存储类型。
 
 ```yaml
 yak:
   resource:
     enabled: true
     storage:
-      type: MINIO
-      minio:
+      type: LOCAL
+      local:
         enabled: true
+        base-directory: ./data/resources
+        checksum-enabled: true
+      minio:
+        enabled: false
         endpoint: http://127.0.0.1:9000
         access-key: minioadmin
         secret-key: minioadmin
@@ -69,8 +74,33 @@ yak:
         base-directory: /yak-ops/resources
 ```
 
-同一目录树内的资源继承父目录存储类型，当前不允许跨 MinIO/HDFS 移动。
+Local 插件启动时自动创建根目录，上传内容先写入内部暂存目录，校验大小后再原子移动到目标路径。逻辑路径只能位于配置根目录内，并拒绝上级目录、符号链接和内部保留目录。
+
+同一目录树内的资源继承父目录存储类型，当前不允许跨 Local、MinIO、HDFS 移动。
+
+### 部署约束
+
+Local 存储适合单节点部署。多节点部署时，应让所有 Yak Ops 节点挂载同一个共享目录，或者继续使用 MinIO/HDFS 等共享存储。
+
+Docker 部署必须把本地资源目录挂载到持久化卷，例如：
+
+```yaml
+services:
+  yak-ops:
+    volumes:
+      - ./data/resources:/app/data/resources
+    environment:
+      YAK_RESOURCE_STORAGE_TYPE: LOCAL
+      YAK_RESOURCE_LOCAL_BASE_DIRECTORY: /app/data/resources
+```
+
+切回 MinIO 时可配置：
+
+```bash
+YAK_RESOURCE_STORAGE_TYPE=MINIO
+YAK_RESOURCE_MINIO_ENABLED=true
+```
 
 ## Git/DataOps 扩展口
 
-本次只提供 `ResourceFileSyncProvider`，不包含具体 Git 实现。后续插件注册为 Spring Bean 后，会在资源事务提交后收到 `CREATED`、`UPDATED`、`MOVED`、`DELETED` 事件，无需修改资源业务代码。
+当前只提供 `ResourceFileSyncProvider`，不包含具体 Git 实现。后续插件注册为 Spring Bean 后，会在资源事务提交后收到 `CREATED`、`UPDATED`、`MOVED`、`DELETED` 事件，无需修改资源业务代码。

--- a/pom.xml
+++ b/pom.xml
@@ -154,6 +154,11 @@
             </dependency>
             <dependency>
                 <groupId>io.yak.ops</groupId>
+                <artifactId>yak-ops-plugin-storage-local</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.yak.ops</groupId>
                 <artifactId>yak-ops-plugin-storage-minio</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/yak-ops-bom/pom.xml
+++ b/yak-ops-bom/pom.xml
@@ -122,6 +122,11 @@
             </dependency>
             <dependency>
                 <groupId>io.yak.ops</groupId>
+                <artifactId>yak-ops-plugin-storage-local</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.yak.ops</groupId>
                 <artifactId>yak-ops-plugin-storage-minio</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/yak-ops-boot/src/main/resources/application.yml
+++ b/yak-ops-boot/src/main/resources/application.yml
@@ -104,9 +104,13 @@ yak:
       minimum-idle: 1
       maximum-pool-size: 8
     storage:
-      type: ${YAK_RESOURCE_STORAGE_TYPE:MINIO}
+      type: ${YAK_RESOURCE_STORAGE_TYPE:LOCAL}
+      local:
+        enabled: ${YAK_RESOURCE_LOCAL_ENABLED:true}
+        base-directory: ${YAK_RESOURCE_LOCAL_BASE_DIRECTORY:./data/resources}
+        checksum-enabled: ${YAK_RESOURCE_LOCAL_CHECKSUM_ENABLED:true}
       minio:
-        enabled: ${YAK_RESOURCE_MINIO_ENABLED:true}
+        enabled: ${YAK_RESOURCE_MINIO_ENABLED:false}
         endpoint: ${YAK_RESOURCE_MINIO_ENDPOINT:http://127.0.0.1:9000}
         access-key: ${YAK_RESOURCE_MINIO_ACCESS_KEY:minioadmin}
         secret-key: ${YAK_RESOURCE_MINIO_SECRET_KEY:minioadmin}

--- a/yak-ops-boot/src/main/resources/application.yml
+++ b/yak-ops-boot/src/main/resources/application.yml
@@ -110,7 +110,7 @@ yak:
         base-directory: ${YAK_RESOURCE_LOCAL_BASE_DIRECTORY:./data/resources}
         checksum-enabled: ${YAK_RESOURCE_LOCAL_CHECKSUM_ENABLED:true}
       minio:
-        enabled: ${YAK_RESOURCE_MINIO_ENABLED:false}
+        enabled: ${YAK_RESOURCE_MINIO_ENABLED:true}
         endpoint: ${YAK_RESOURCE_MINIO_ENDPOINT:http://127.0.0.1:9000}
         access-key: ${YAK_RESOURCE_MINIO_ACCESS_KEY:minioadmin}
         secret-key: ${YAK_RESOURCE_MINIO_SECRET_KEY:minioadmin}

--- a/yak-ops-boot/src/test/resources/application-test.yml
+++ b/yak-ops-boot/src/test/resources/application-test.yml
@@ -25,6 +25,8 @@ yak:
   resource:
     enabled: false
     storage:
+      local:
+        enabled: false
       minio:
         enabled: false
       hdfs:

--- a/yak-ops-business/yak-ops-business-resource/src/main/java/io/yak/ops/business/resource/config/ResourceProperties.java
+++ b/yak-ops-business/yak-ops-business-resource/src/main/java/io/yak/ops/business/resource/config/ResourceProperties.java
@@ -124,7 +124,7 @@ public class ResourceProperties {
   /** 当前资源存储选择。 */
   public static class Storage {
 
-    private ResourceStorageType type = ResourceStorageType.MINIO;
+    private ResourceStorageType type = ResourceStorageType.LOCAL;
 
     public ResourceStorageType getType() {
       return type;

--- a/yak-ops-common/src/main/java/io/yak/ops/common/enums/resource/ResourceStorageType.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/enums/resource/ResourceStorageType.java
@@ -2,6 +2,7 @@ package io.yak.ops.common.enums.resource;
 
 /** 资源文件存储类型。 */
 public enum ResourceStorageType {
+  LOCAL,
   MINIO,
   HDFS
 }

--- a/yak-ops-plugins/yak-ops-plugin-storage/pom.xml
+++ b/yak-ops-plugins/yak-ops-plugin-storage/pom.xml
@@ -19,6 +19,7 @@
 
     <modules>
         <module>yak-ops-plugin-storage-api</module>
+        <module>yak-ops-plugin-storage-local</module>
         <module>yak-ops-plugin-storage-minio</module>
         <module>yak-ops-plugin-storage-hdfs</module>
         <module>yak-ops-plugin-storage-all</module>

--- a/yak-ops-plugins/yak-ops-plugin-storage/yak-ops-plugin-storage-all/pom.xml
+++ b/yak-ops-plugins/yak-ops-plugin-storage/yak-ops-plugin-storage-all/pom.xml
@@ -18,6 +18,11 @@
     <dependencies>
         <dependency>
             <groupId>io.yak.ops</groupId>
+            <artifactId>yak-ops-plugin-storage-local</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.yak.ops</groupId>
             <artifactId>yak-ops-plugin-storage-minio</artifactId>
         </dependency>
         <dependency>

--- a/yak-ops-plugins/yak-ops-plugin-storage/yak-ops-plugin-storage-all/pom.xml
+++ b/yak-ops-plugins/yak-ops-plugin-storage/yak-ops-plugin-storage-all/pom.xml
@@ -19,7 +19,6 @@
         <dependency>
             <groupId>io.yak.ops</groupId>
             <artifactId>yak-ops-plugin-storage-local</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>io.yak.ops</groupId>

--- a/yak-ops-plugins/yak-ops-plugin-storage/yak-ops-plugin-storage-local/pom.xml
+++ b/yak-ops-plugins/yak-ops-plugin-storage/yak-ops-plugin-storage-local/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.yak.ops</groupId>
+        <artifactId>yak-ops-plugin-storage</artifactId>
+        <version>1.0.0</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>yak-ops-plugin-storage-local</artifactId>
+    <name>Yak Ops Local Storage Plugin</name>
+    <description>Embedded local file-system storage plugin for Yak Ops resources</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.yak.ops</groupId>
+            <artifactId>yak-ops-plugin-storage-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/yak-ops-plugins/yak-ops-plugin-storage/yak-ops-plugin-storage-local/src/main/java/io/yak/ops/plugin/storage/local/LocalStorageAutoConfiguration.java
+++ b/yak-ops-plugins/yak-ops-plugin-storage/yak-ops-plugin-storage-local/src/main/java/io/yak/ops/plugin/storage/local/LocalStorageAutoConfiguration.java
@@ -1,0 +1,27 @@
+package io.yak.ops.plugin.storage.local;
+
+import io.yak.ops.spi.storage.StorageOperator;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+
+/** 本地存储插件自动装配。 */
+@AutoConfiguration
+@ConditionalOnClass(StorageOperator.class)
+@ConditionalOnProperty(
+    prefix = "yak.resource.storage.local",
+    name = "enabled",
+    havingValue = "true",
+    matchIfMissing = true)
+@EnableConfigurationProperties(LocalStorageProperties.class)
+public class LocalStorageAutoConfiguration {
+
+  @Bean
+  @ConditionalOnMissingBean(name = "localResourceStorageOperator")
+  public StorageOperator localResourceStorageOperator(LocalStorageProperties properties) {
+    return new LocalStorageOperator(properties);
+  }
+}

--- a/yak-ops-plugins/yak-ops-plugin-storage/yak-ops-plugin-storage-local/src/main/java/io/yak/ops/plugin/storage/local/LocalStorageOperator.java
+++ b/yak-ops-plugins/yak-ops-plugin-storage/yak-ops-plugin-storage-local/src/main/java/io/yak/ops/plugin/storage/local/LocalStorageOperator.java
@@ -1,0 +1,405 @@
+package io.yak.ops.plugin.storage.local;
+
+import io.yak.ops.common.enums.resource.ResourceStorageType;
+import io.yak.ops.spi.storage.StorageObjectMetadata;
+import io.yak.ops.spi.storage.StorageOperator;
+import io.yak.ops.spi.storage.StoragePluginException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.DirectoryNotEmptyException;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
+import java.nio.file.LinkOption;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.security.DigestInputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Instant;
+import java.util.Objects;
+
+/** 基于应用节点磁盘的内置资源存储实现。 */
+public class LocalStorageOperator implements StorageOperator {
+
+  private static final int BUFFER_SIZE = 8192;
+  private static final String STAGING_DIRECTORY = ".staging";
+
+  private final LocalStorageProperties properties;
+  private final Path baseDirectory;
+  private final Path stagingDirectory;
+
+  public LocalStorageOperator(LocalStorageProperties properties) {
+    this.properties = Objects.requireNonNull(properties, "本地存储配置不能为空");
+    this.baseDirectory = initializeBaseDirectory(properties.getBaseDirectory());
+    this.stagingDirectory = initializeStagingDirectory();
+  }
+
+  @Override
+  public ResourceStorageType type() {
+    return ResourceStorageType.LOCAL;
+  }
+
+  @Override
+  public String name() {
+    return "本地存储";
+  }
+
+  @Override
+  public void createDirectory(String path) {
+    Path target = resolve(path);
+    try {
+      if (Files.exists(target, LinkOption.NOFOLLOW_LINKS)) {
+        throw new StoragePluginException("本地目录已存在：" + path);
+      }
+      Files.createDirectories(target);
+      ensureNoSymbolicLink(target);
+    } catch (StoragePluginException exception) {
+      throw exception;
+    } catch (IOException exception) {
+      throw pluginException("创建本地目录失败：" + path, exception);
+    }
+  }
+
+  @Override
+  public boolean exists(String path) {
+    Path target = resolve(path);
+    return Files.exists(target, LinkOption.NOFOLLOW_LINKS);
+  }
+
+  @Override
+  public void upload(
+      String path,
+      InputStream inputStream,
+      long size,
+      String contentType,
+      boolean overwrite) {
+    Objects.requireNonNull(inputStream, "上传文件流不能为空");
+    if (size < 0L) {
+      throw new StoragePluginException("上传文件大小不能为负数：" + size);
+    }
+
+    Path target = resolve(path);
+    Path temporary = null;
+    try {
+      Path parent = target.getParent();
+      if (parent == null) {
+        throw new StoragePluginException("本地文件缺少父目录：" + path);
+      }
+      Files.createDirectories(parent);
+      ensureNoSymbolicLink(parent);
+
+      if (Files.exists(target, LinkOption.NOFOLLOW_LINKS)) {
+        ensureNoSymbolicLink(target);
+        if (Files.isDirectory(target, LinkOption.NOFOLLOW_LINKS)) {
+          throw new StoragePluginException("本地目标路径是目录：" + path);
+        }
+        if (!overwrite) {
+          throw new StoragePluginException("本地文件已存在：" + path);
+        }
+      }
+
+      temporary = Files.createTempFile(stagingDirectory, "upload-", ".tmp");
+      long copied = Files.copy(inputStream, temporary, StandardCopyOption.REPLACE_EXISTING);
+      if (copied != size) {
+        throw new StoragePluginException(
+            "上传文件大小不一致，声明 " + size + " 字节，实际 " + copied + " 字节");
+      }
+      moveTemporaryFile(temporary, target, overwrite);
+      temporary = null;
+    } catch (StoragePluginException exception) {
+      throw exception;
+    } catch (IOException exception) {
+      throw pluginException("上传本地文件失败：" + path, exception);
+    } finally {
+      deleteTemporaryQuietly(temporary);
+    }
+  }
+
+  @Override
+  public InputStream download(String path) {
+    Path target = requireExisting(path);
+    if (!Files.isRegularFile(target, LinkOption.NOFOLLOW_LINKS)) {
+      throw new StoragePluginException("本地路径不是文件：" + path);
+    }
+    try {
+      return Files.newInputStream(target, StandardOpenOption.READ);
+    } catch (IOException exception) {
+      throw pluginException("下载本地文件失败：" + path, exception);
+    }
+  }
+
+  @Override
+  public void delete(String path, boolean recursive) {
+    Path target = resolve(path);
+    if (!Files.exists(target, LinkOption.NOFOLLOW_LINKS)) {
+      return;
+    }
+    try {
+      if (!recursive) {
+        Files.delete(target);
+        return;
+      }
+      deleteRecursively(target);
+    } catch (DirectoryNotEmptyException exception) {
+      throw pluginException("本地目录非空，请使用递归删除：" + path, exception);
+    } catch (IOException exception) {
+      throw pluginException("删除本地路径失败：" + path, exception);
+    }
+  }
+
+  @Override
+  public void move(String sourcePath, String targetPath, boolean overwrite) {
+    Path source = requireExisting(sourcePath);
+    Path target = resolve(targetPath);
+    if (source.equals(target)) {
+      throw new StoragePluginException("本地源路径和目标路径不能相同：" + sourcePath);
+    }
+    if (Files.isDirectory(source, LinkOption.NOFOLLOW_LINKS) && target.startsWith(source)) {
+      throw new StoragePluginException("本地目录不能移动到自身子目录：" + targetPath);
+    }
+
+    try {
+      if (Files.exists(target, LinkOption.NOFOLLOW_LINKS)) {
+        ensureNoSymbolicLink(target);
+        if (!overwrite) {
+          throw new StoragePluginException("本地目标路径已存在：" + targetPath);
+        }
+        deleteRecursively(target);
+      }
+      Path parent = target.getParent();
+      if (parent == null) {
+        throw new StoragePluginException("本地目标路径缺少父目录：" + targetPath);
+      }
+      Files.createDirectories(parent);
+      ensureNoSymbolicLink(parent);
+      movePath(source, target);
+    } catch (StoragePluginException exception) {
+      throw exception;
+    } catch (IOException exception) {
+      throw pluginException(
+          "移动本地路径失败：" + sourcePath + " -> " + targetPath, exception);
+    }
+  }
+
+  @Override
+  public StorageObjectMetadata metadata(String path) {
+    Path target = requireExisting(path);
+    try {
+      BasicFileAttributes attributes = Files.readAttributes(
+          target,
+          BasicFileAttributes.class,
+          LinkOption.NOFOLLOW_LINKS);
+      boolean directory = attributes.isDirectory();
+      return StorageObjectMetadata.builder()
+          .path(path)
+          .directory(directory)
+          .size(directory ? 0L : attributes.size())
+          .contentType(directory ? null : Files.probeContentType(target))
+          .checksum(directory || !properties.isChecksumEnabled() ? null : checksum(target))
+          .lastModified(Instant.ofEpochMilli(attributes.lastModifiedTime().toMillis()))
+          .build();
+    } catch (IOException exception) {
+      throw pluginException("读取本地文件元数据失败：" + path, exception);
+    }
+  }
+
+  Path baseDirectory() {
+    return baseDirectory;
+  }
+
+  private Path initializeBaseDirectory(String configuredPath) {
+    if (configuredPath == null || configuredPath.trim().isEmpty()) {
+      throw new StoragePluginException("本地存储根目录不能为空");
+    }
+    try {
+      Path configured = Paths.get(configuredPath).toAbsolutePath().normalize();
+      Files.createDirectories(configured);
+      if (!Files.isDirectory(configured, LinkOption.NOFOLLOW_LINKS)) {
+        throw new StoragePluginException("本地存储根路径不是目录：" + configured);
+      }
+      if (Files.isSymbolicLink(configured)) {
+        throw new StoragePluginException("本地存储根目录不能是符号链接：" + configured);
+      }
+      return configured.toRealPath();
+    } catch (InvalidPathException | IOException exception) {
+      throw pluginException("初始化本地存储根目录失败：" + configuredPath, exception);
+    }
+  }
+
+  private Path initializeStagingDirectory() {
+    Path directory = baseDirectory.resolve(STAGING_DIRECTORY).normalize();
+    try {
+      Files.createDirectories(directory);
+      ensureNoSymbolicLink(directory);
+      return directory;
+    } catch (IOException exception) {
+      throw pluginException("初始化本地存储临时目录失败：" + directory, exception);
+    }
+  }
+
+  private Path requireExisting(String path) {
+    Path target = resolve(path);
+    if (!Files.exists(target, LinkOption.NOFOLLOW_LINKS)) {
+      throw new StoragePluginException("本地路径不存在：" + path);
+    }
+    return target;
+  }
+
+  private Path resolve(String logicalPath) {
+    String normalized = normalize(logicalPath);
+    try {
+      Path relative = Paths.get(normalized).normalize();
+      if (relative.isAbsolute() || relative.getNameCount() == 0) {
+        throw new StoragePluginException("本地存储路径必须是相对路径：" + logicalPath);
+      }
+      Path target = baseDirectory.resolve(relative).normalize();
+      if (!target.startsWith(baseDirectory)) {
+        throw new StoragePluginException("本地存储路径越界：" + logicalPath);
+      }
+      ensureNoSymbolicLink(target);
+      return target;
+    } catch (InvalidPathException exception) {
+      throw pluginException("本地存储路径无效：" + logicalPath, exception);
+    }
+  }
+
+  private String normalize(String path) {
+    if (path == null || path.trim().isEmpty()) {
+      throw new StoragePluginException("存储路径不能为空");
+    }
+    String normalized = path.replace('\\', '/').trim();
+    while (normalized.startsWith("/")) {
+      normalized = normalized.substring(1);
+    }
+    while (normalized.contains("//")) {
+      normalized = normalized.replace("//", "/");
+    }
+    if (normalized.isEmpty()) {
+      throw new StoragePluginException("存储路径不能为空");
+    }
+    if (normalized.indexOf('\0') >= 0) {
+      throw new StoragePluginException("存储路径不能包含空字符");
+    }
+    for (String segment : normalized.split("/")) {
+      if (segment.isEmpty() || ".".equals(segment) || "..".equals(segment)) {
+        throw new StoragePluginException("存储路径不能包含当前或上级目录：" + path);
+      }
+    }
+    return normalized;
+  }
+
+  private void ensureNoSymbolicLink(Path path) {
+    Path normalized = path.toAbsolutePath().normalize();
+    if (!normalized.startsWith(baseDirectory)) {
+      throw new StoragePluginException("本地存储路径越界：" + path);
+    }
+    Path current = baseDirectory;
+    Path relative = baseDirectory.relativize(normalized);
+    for (Path segment : relative) {
+      current = current.resolve(segment);
+      if (Files.exists(current, LinkOption.NOFOLLOW_LINKS) && Files.isSymbolicLink(current)) {
+        throw new StoragePluginException("本地存储路径不能包含符号链接：" + current);
+      }
+    }
+  }
+
+  private void moveTemporaryFile(Path source, Path target, boolean overwrite) throws IOException {
+    try {
+      if (overwrite) {
+        Files.move(
+            source,
+            target,
+            StandardCopyOption.ATOMIC_MOVE,
+            StandardCopyOption.REPLACE_EXISTING);
+      } else {
+        Files.move(source, target, StandardCopyOption.ATOMIC_MOVE);
+      }
+    } catch (AtomicMoveNotSupportedException exception) {
+      if (overwrite) {
+        Files.move(source, target, StandardCopyOption.REPLACE_EXISTING);
+      } else {
+        Files.move(source, target);
+      }
+    } catch (FileAlreadyExistsException exception) {
+      if (overwrite) {
+        Files.move(source, target, StandardCopyOption.REPLACE_EXISTING);
+        return;
+      }
+      throw new StoragePluginException("本地文件已存在：" + target, exception);
+    }
+  }
+
+  private void movePath(Path source, Path target) throws IOException {
+    try {
+      Files.move(source, target, StandardCopyOption.ATOMIC_MOVE);
+    } catch (AtomicMoveNotSupportedException exception) {
+      Files.move(source, target);
+    }
+  }
+
+  private void deleteRecursively(Path target) throws IOException {
+    Files.walkFileTree(target, new SimpleFileVisitor<>() {
+      @Override
+      public FileVisitResult visitFile(Path file, BasicFileAttributes attributes) throws IOException {
+        Files.deleteIfExists(file);
+        return FileVisitResult.CONTINUE;
+      }
+
+      @Override
+      public FileVisitResult postVisitDirectory(Path directory, IOException exception)
+          throws IOException {
+        if (exception != null) {
+          throw exception;
+        }
+        Files.deleteIfExists(directory);
+        return FileVisitResult.CONTINUE;
+      }
+    });
+  }
+
+  private String checksum(Path path) throws IOException {
+    try {
+      MessageDigest digest = MessageDigest.getInstance("SHA-256");
+      try (InputStream inputStream = Files.newInputStream(path);
+          DigestInputStream digestInputStream = new DigestInputStream(inputStream, digest)) {
+        byte[] buffer = new byte[BUFFER_SIZE];
+        while (digestInputStream.read(buffer) >= 0) {
+          // 读取完整文件以更新摘要。
+        }
+      }
+      StringBuilder value = new StringBuilder(64);
+      for (byte item : digest.digest()) {
+        value.append(String.format("%02x", item & 0xff));
+      }
+      return value.toString();
+    } catch (NoSuchAlgorithmException exception) {
+      throw new StoragePluginException("当前运行环境不支持 SHA-256", exception);
+    }
+  }
+
+  private void deleteTemporaryQuietly(Path temporary) {
+    if (temporary == null) {
+      return;
+    }
+    try {
+      Files.deleteIfExists(temporary);
+    } catch (IOException ignored) {
+      // 临时文件由后续清理任务兜底，不能覆盖原始异常。
+    }
+  }
+
+  private StoragePluginException pluginException(String message, Exception cause) {
+    if (cause instanceof NoSuchFileException) {
+      return new StoragePluginException(message + "，路径不存在", cause);
+    }
+    return new StoragePluginException(message, cause);
+  }
+}

--- a/yak-ops-plugins/yak-ops-plugin-storage/yak-ops-plugin-storage-local/src/main/java/io/yak/ops/plugin/storage/local/LocalStorageOperator.java
+++ b/yak-ops-plugins/yak-ops-plugin-storage/yak-ops-plugin-storage-local/src/main/java/io/yak/ops/plugin/storage/local/LocalStorageOperator.java
@@ -30,7 +30,8 @@ import java.util.Objects;
 public class LocalStorageOperator implements StorageOperator {
 
   private static final int BUFFER_SIZE = 8192;
-  private static final String STAGING_DIRECTORY = ".staging";
+  private static final String INTERNAL_DIRECTORY = ".yak-storage";
+  private static final String STAGING_DIRECTORY = "staging";
 
   private final LocalStorageProperties properties;
   private final Path baseDirectory;
@@ -70,8 +71,7 @@ public class LocalStorageOperator implements StorageOperator {
 
   @Override
   public boolean exists(String path) {
-    Path target = resolve(path);
-    return Files.exists(target, LinkOption.NOFOLLOW_LINKS);
+    return Files.exists(resolve(path), LinkOption.NOFOLLOW_LINKS);
   }
 
   @Override
@@ -235,7 +235,7 @@ public class LocalStorageOperator implements StorageOperator {
   }
 
   private Path initializeStagingDirectory() {
-    Path directory = baseDirectory.resolve(STAGING_DIRECTORY).normalize();
+    Path directory = baseDirectory.resolve(INTERNAL_DIRECTORY).resolve(STAGING_DIRECTORY).normalize();
     try {
       Files.createDirectories(directory);
       ensureNoSymbolicLink(directory);
@@ -288,7 +288,12 @@ public class LocalStorageOperator implements StorageOperator {
     if (normalized.indexOf('\0') >= 0) {
       throw new StoragePluginException("存储路径不能包含空字符");
     }
-    for (String segment : normalized.split("/")) {
+
+    String[] segments = normalized.split("/");
+    if (segments.length > 0 && INTERNAL_DIRECTORY.equals(segments[0])) {
+      throw new StoragePluginException("存储路径不能使用内部保留目录：" + INTERNAL_DIRECTORY);
+    }
+    for (String segment : segments) {
       if (segment.isEmpty() || ".".equals(segment) || "..".equals(segment)) {
         throw new StoragePluginException("存储路径不能包含当前或上级目录：" + path);
       }

--- a/yak-ops-plugins/yak-ops-plugin-storage/yak-ops-plugin-storage-local/src/main/java/io/yak/ops/plugin/storage/local/LocalStorageProperties.java
+++ b/yak-ops-plugins/yak-ops-plugin-storage/yak-ops-plugin-storage-local/src/main/java/io/yak/ops/plugin/storage/local/LocalStorageProperties.java
@@ -1,0 +1,36 @@
+package io.yak.ops.plugin.storage.local;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/** 本地资源存储配置。 */
+@ConfigurationProperties(prefix = "yak.resource.storage.local")
+public class LocalStorageProperties {
+
+  private boolean enabled = true;
+  private String baseDirectory = "./data/resources";
+  private boolean checksumEnabled = true;
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  public String getBaseDirectory() {
+    return baseDirectory;
+  }
+
+  public void setBaseDirectory(String baseDirectory) {
+    this.baseDirectory = baseDirectory;
+  }
+
+  public boolean isChecksumEnabled() {
+    return checksumEnabled;
+  }
+
+  public void setChecksumEnabled(boolean checksumEnabled) {
+    this.checksumEnabled = checksumEnabled;
+  }
+}

--- a/yak-ops-plugins/yak-ops-plugin-storage/yak-ops-plugin-storage-local/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/yak-ops-plugins/yak-ops-plugin-storage/yak-ops-plugin-storage-local/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+io.yak.ops.plugin.storage.local.LocalStorageAutoConfiguration

--- a/yak-ops-plugins/yak-ops-plugin-storage/yak-ops-plugin-storage-local/src/test/java/io/yak/ops/plugin/storage/local/LocalStorageAutoConfigurationTest.java
+++ b/yak-ops-plugins/yak-ops-plugin-storage/yak-ops-plugin-storage-local/src/test/java/io/yak/ops/plugin/storage/local/LocalStorageAutoConfigurationTest.java
@@ -1,0 +1,38 @@
+package io.yak.ops.plugin.storage.local;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.yak.ops.common.enums.resource.ResourceStorageType;
+import io.yak.ops.spi.storage.StorageOperator;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+class LocalStorageAutoConfigurationTest {
+
+  @TempDir
+  Path temporaryDirectory;
+
+  @Test
+  void shouldRegisterLocalStorageOperatorByDefault() {
+    new ApplicationContextRunner()
+        .withConfiguration(AutoConfigurations.of(LocalStorageAutoConfiguration.class))
+        .withPropertyValues(
+            "yak.resource.storage.local.base-directory=" + temporaryDirectory.resolve("resources"))
+        .run(context -> {
+          assertThat(context).hasSingleBean(StorageOperator.class);
+          assertThat(context.getBean(StorageOperator.class).type())
+              .isEqualTo(ResourceStorageType.LOCAL);
+        });
+  }
+
+  @Test
+  void shouldAllowLocalStorageToBeDisabled() {
+    new ApplicationContextRunner()
+        .withConfiguration(AutoConfigurations.of(LocalStorageAutoConfiguration.class))
+        .withPropertyValues("yak.resource.storage.local.enabled=false")
+        .run(context -> assertThat(context).doesNotHaveBean(StorageOperator.class));
+  }
+}

--- a/yak-ops-plugins/yak-ops-plugin-storage/yak-ops-plugin-storage-local/src/test/java/io/yak/ops/plugin/storage/local/LocalStorageOperatorTest.java
+++ b/yak-ops-plugins/yak-ops-plugin-storage/yak-ops-plugin-storage-local/src/test/java/io/yak/ops/plugin/storage/local/LocalStorageOperatorTest.java
@@ -109,13 +109,16 @@ class LocalStorageOperatorTest {
   }
 
   @Test
-  void shouldRejectUnsafePaths() {
+  void shouldRejectUnsafeAndReservedPaths() {
     assertThatThrownBy(() -> operator.exists("../outside.txt"))
         .isInstanceOf(StoragePluginException.class)
         .hasMessageContaining("上级目录");
     assertThatThrownBy(() -> operator.exists("folder/./file.txt"))
         .isInstanceOf(StoragePluginException.class)
         .hasMessageContaining("当前或上级目录");
+    assertThatThrownBy(() -> operator.exists(".yak-storage/staging/file.tmp"))
+        .isInstanceOf(StoragePluginException.class)
+        .hasMessageContaining("内部保留目录");
     assertThatThrownBy(() -> operator.move("missing", "target", false))
         .isInstanceOf(StoragePluginException.class)
         .hasMessageContaining("不存在");

--- a/yak-ops-plugins/yak-ops-plugin-storage/yak-ops-plugin-storage-local/src/test/java/io/yak/ops/plugin/storage/local/LocalStorageOperatorTest.java
+++ b/yak-ops-plugins/yak-ops-plugin-storage/yak-ops-plugin-storage-local/src/test/java/io/yak/ops/plugin/storage/local/LocalStorageOperatorTest.java
@@ -1,0 +1,123 @@
+package io.yak.ops.plugin.storage.local;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.yak.ops.spi.storage.StorageObjectMetadata;
+import io.yak.ops.spi.storage.StoragePluginException;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class LocalStorageOperatorTest {
+
+  @TempDir
+  Path temporaryDirectory;
+
+  private LocalStorageOperator operator;
+
+  @BeforeEach
+  void setUp() {
+    LocalStorageProperties properties = new LocalStorageProperties();
+    properties.setBaseDirectory(temporaryDirectory.resolve("resources").toString());
+    operator = new LocalStorageOperator(properties);
+  }
+
+  @Test
+  void shouldUploadDownloadAndReadMetadata() throws Exception {
+    byte[] content = "hello yak ops".getBytes(StandardCharsets.UTF_8);
+
+    operator.createDirectory("documents");
+    operator.upload(
+        "documents/readme.txt",
+        new ByteArrayInputStream(content),
+        content.length,
+        "text/plain",
+        false);
+
+    assertThat(operator.exists("documents/readme.txt")).isTrue();
+    try (InputStream inputStream = operator.download("documents/readme.txt")) {
+      assertThat(inputStream.readAllBytes()).isEqualTo(content);
+    }
+
+    StorageObjectMetadata metadata = operator.metadata("documents/readme.txt");
+    assertThat(metadata.isDirectory()).isFalse();
+    assertThat(metadata.getSize()).isEqualTo(content.length);
+    assertThat(metadata.getChecksum())
+        .isEqualTo("2c4e1d1a1e3dc0b29f7736182a3489a7bc8c6cb77032afaed2736b28c0e9eb64");
+    assertThat(metadata.getLastModified()).isNotNull();
+  }
+
+  @Test
+  void shouldMoveDirectoryAndDeleteRecursively() {
+    byte[] content = "content".getBytes(StandardCharsets.UTF_8);
+    operator.createDirectory("source/nested");
+    operator.upload(
+        "source/nested/data.txt",
+        new ByteArrayInputStream(content),
+        content.length,
+        "text/plain",
+        false);
+
+    operator.move("source", "archive", false);
+
+    assertThat(operator.exists("source")).isFalse();
+    assertThat(operator.exists("archive/nested/data.txt")).isTrue();
+
+    operator.delete("archive", true);
+    assertThat(operator.exists("archive")).isFalse();
+  }
+
+  @Test
+  void shouldHonorOverwriteAndDeclaredSize() throws Exception {
+    byte[] first = "first".getBytes(StandardCharsets.UTF_8);
+    byte[] second = "second".getBytes(StandardCharsets.UTF_8);
+    operator.upload("file.txt", new ByteArrayInputStream(first), first.length, "text/plain", false);
+
+    assertThatThrownBy(() -> operator.upload(
+        "file.txt",
+        new ByteArrayInputStream(second),
+        second.length,
+        "text/plain",
+        false))
+        .isInstanceOf(StoragePluginException.class)
+        .hasMessageContaining("已存在");
+
+    operator.upload(
+        "file.txt",
+        new ByteArrayInputStream(second),
+        second.length,
+        "text/plain",
+        true);
+    try (InputStream inputStream = operator.download("file.txt")) {
+      assertThat(inputStream.readAllBytes()).isEqualTo(second);
+    }
+
+    assertThatThrownBy(() -> operator.upload(
+        "invalid.txt",
+        new ByteArrayInputStream(second),
+        1L,
+        "text/plain",
+        false))
+        .isInstanceOf(StoragePluginException.class)
+        .hasMessageContaining("大小不一致");
+    assertThat(operator.exists("invalid.txt")).isFalse();
+  }
+
+  @Test
+  void shouldRejectUnsafePaths() {
+    assertThatThrownBy(() -> operator.exists("../outside.txt"))
+        .isInstanceOf(StoragePluginException.class)
+        .hasMessageContaining("上级目录");
+    assertThatThrownBy(() -> operator.exists("folder/./file.txt"))
+        .isInstanceOf(StoragePluginException.class)
+        .hasMessageContaining("当前或上级目录");
+    assertThatThrownBy(() -> operator.move("missing", "target", false))
+        .isInstanceOf(StoragePluginException.class)
+        .hasMessageContaining("不存在");
+  }
+}


### PR DESCRIPTION
## 背景

Yak Ops 资源管理当前依赖 MinIO 或 HDFS 保存物理文件。对于单节点和轻量部署，这会额外引入外部存储组件和运维成本。

本 PR 新增内置 Local 存储插件，让 Yak Ops 默认可以直接使用应用节点磁盘，同时保留 MinIO、HDFS 作为可选存储后端。

## 主要变更

- 新增 `yak-ops-plugin-storage-local` 模块，并接入现有 `StorageOperator` SPI
- 将 Local 插件纳入父工程依赖管理、BOM 和 `storage-all` 聚合模块
- 支持目录创建、存在性检查、上传、下载、删除、移动和元数据读取
- 上传先写入内部暂存目录，校验声明大小后再原子移动到目标路径
- 文件元数据支持 SHA-256 校验值和最后修改时间
- 拒绝路径穿越、当前/上级目录、符号链接和内部保留目录
- 将资源默认活动存储类型调整为 `LOCAL`
- 保留 MinIO 插件原有默认启用行为，兼容已有 `MINIO` 类型资源；HDFS 仍保持默认关闭
- 补充 Local 操作测试和 Spring Boot 自动装配测试
- 更新资源管理后端文档、Docker 持久化和切换 MinIO 的配置说明

## 设计说明

实现参考了 DolphinScheduler 将本地存储作为独立存储实现、启动时初始化根目录以及统一文件/目录操作语义的思路，但代码基于 Yak Ops 当前 `StorageOperator` 接口独立实现，并额外加入路径隔离、符号链接防护、暂存写入和大小校验。

## 默认配置

```yaml
yak:
  resource:
    storage:
      type: LOCAL
      local:
        enabled: true
        base-directory: ./data/resources
        checksum-enabled: true
      minio:
        enabled: true
```

切回 MinIO：

```bash
YAK_RESOURCE_STORAGE_TYPE=MINIO
YAK_RESOURCE_MINIO_ENABLED=true
```

## 部署约束

- Local 存储适合单节点部署
- 多节点部署需要让所有节点挂载同一个共享目录，或者使用 MinIO/HDFS
- Docker 部署必须将 `base-directory` 挂载到持久化卷

## 验证

- 使用 Java 21 对 Local 核心实现进行了隔离编译验证
- 冒烟验证覆盖上传、下载、元数据、SHA-256、目录移动、递归删除、覆盖写入、声明大小校验和路径穿越拦截
- 新增 `LocalStorageOperatorTest`
- 新增 `LocalStorageAutoConfigurationTest`
- 当前执行环境无法解析 GitHub 域名，且没有可用 Maven 安装，因此未在本地执行完整 Maven Reactor；提交后以仓库 CI 结果为准
