### PR TITLE
feat(resource): integrate embedded local storage across UI and API

### DIFF
--- a/yak-ops-business/yak-ops-business-resource/src/test/java/io/yak/ops/business/resource/controller/v1/ResourcesControllerContractTest.java
+++ b/yak-ops-business/yak-ops-business-resource/src/test/java/io/yak/ops/business/resource/controller/v1/ResourcesControllerContractTest.java
@@ -6,6 +6,7 @@ import io.yak.framework.security.web.RequiresPermission;
 import io.yak.ops.common.constant.resource.ResourcePermissionCode;
 import java.lang.reflect.Method;
 import org.junit.jupiter.api.Test;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 class ResourcesControllerContractTest {
@@ -17,9 +18,12 @@ class ResourcesControllerContractTest {
     Method download = ResourcesController.class.getMethod(
         "download", Long.class, jakarta.servlet.http.HttpServletResponse.class);
     RequiresPermission downloadPermission = download.getAnnotation(RequiresPermission.class);
+    Method storagePlugins = ResourcesController.class.getMethod("storagePlugins");
+    GetMapping storagePluginsMapping = storagePlugins.getAnnotation(GetMapping.class);
 
     assertThat(mapping.value()).containsExactly("/api/v1/resources");
     assertThat(read.value()).isEqualTo(ResourcePermissionCode.READ);
     assertThat(downloadPermission.value()).isEqualTo(ResourcePermissionCode.DOWNLOAD);
+    assertThat(storagePluginsMapping.value()).containsExactly("/storage-plugins");
   }
 }

--- a/yak-ops-business/yak-ops-business-resource/src/test/java/io/yak/ops/business/resource/storage/StorageOperatorRegistryTest.java
+++ b/yak-ops-business/yak-ops-business-resource/src/test/java/io/yak/ops/business/resource/storage/StorageOperatorRegistryTest.java
@@ -15,16 +15,24 @@ import org.junit.jupiter.api.Test;
 class StorageOperatorRegistryTest {
 
   @Test
-  void resolvesConfiguredDefaultAndListsInstalledPlugins() {
+  void resolvesLocalAsConfiguredDefaultAndListsInstalledPlugins() {
     ResourceProperties properties = new ResourceProperties();
+    StorageOperator local = new StubOperator(ResourceStorageType.LOCAL, "本地存储");
     StorageOperator minio = new StubOperator(ResourceStorageType.MINIO, "MinIO");
-    StorageOperatorRegistry registry = new StorageOperatorRegistry(List.of(minio), properties);
+    StorageOperatorRegistry registry =
+        new StorageOperatorRegistry(List.of(local, minio), properties);
 
-    assertThat(registry.require(null)).isSameAs(minio);
-    assertThat(registry.list()).singleElement().satisfies(plugin -> {
-      assertThat(plugin.getType()).isEqualTo(ResourceStorageType.MINIO);
-      assertThat(plugin.isActive()).isTrue();
-    });
+    assertThat(registry.require(null)).isSameAs(local);
+    assertThat(registry.list())
+        .extracting(
+            plugin -> plugin.getType(),
+            plugin -> plugin.getName(),
+            plugin -> plugin.isActive())
+        .containsExactly(
+            org.assertj.core.groups.Tuple.tuple(
+                ResourceStorageType.LOCAL, "本地存储", true),
+            org.assertj.core.groups.Tuple.tuple(
+                ResourceStorageType.MINIO, "MinIO", false));
   }
 
   @Test

--- a/yak-ops-business/yak-ops-business-resource/src/test/java/io/yak/ops/business/resource/storage/StorageOperatorRegistryTest.java
+++ b/yak-ops-business/yak-ops-business-resource/src/test/java/io/yak/ops/business/resource/storage/StorageOperatorRegistryTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.yak.ops.business.resource.config.ResourceProperties;
 import io.yak.ops.business.resource.exception.ResourceException;
+import io.yak.ops.common.bean.vo.resource.ResourceStoragePluginVO;
 import io.yak.ops.common.enums.resource.ResourceStorageType;
 import io.yak.ops.spi.storage.StorageObjectMetadata;
 import io.yak.ops.spi.storage.StorageOperator;
@@ -23,16 +24,14 @@ class StorageOperatorRegistryTest {
         new StorageOperatorRegistry(List.of(local, minio), properties);
 
     assertThat(registry.require(null)).isSameAs(local);
-    assertThat(registry.list())
-        .extracting(
-            plugin -> plugin.getType(),
-            plugin -> plugin.getName(),
-            plugin -> plugin.isActive())
-        .containsExactly(
-            org.assertj.core.groups.Tuple.tuple(
-                ResourceStorageType.LOCAL, "本地存储", true),
-            org.assertj.core.groups.Tuple.tuple(
-                ResourceStorageType.MINIO, "MinIO", false));
+
+    List<ResourceStoragePluginVO> plugins = registry.list();
+    assertThat(plugins).hasSize(2);
+    assertThat(plugins.get(0).getType()).isEqualTo(ResourceStorageType.LOCAL);
+    assertThat(plugins.get(0).getName()).isEqualTo("本地存储");
+    assertThat(plugins.get(0).isActive()).isTrue();
+    assertThat(plugins.get(1).getType()).isEqualTo(ResourceStorageType.MINIO);
+    assertThat(plugins.get(1).isActive()).isFalse();
   }
 
   @Test

--- a/yak-ops-ui/src/pages/resource-management/components/ResourceDetailDrawer.tsx
+++ b/yak-ops-ui/src/pages/resource-management/components/ResourceDetailDrawer.tsx
@@ -27,6 +27,7 @@ import { API_SUCCESS_CODE } from '@/services/http/response';
 import { fetchResourceContent, updateResourceContent } from '../service';
 import type { ResourceContent, ResourceItem } from '../types';
 import { formatFileSize, isDirectory, isEditableResource } from '../utils';
+import { getResourceStorageLabel } from './StorageTypeLabel';
 
 interface ResourceDetailDrawerProps {
   open: boolean;
@@ -108,7 +109,7 @@ const ResourceDetailDrawer = ({
       {
         key: 'storage',
         label: '存储类型',
-        children: resource?.storageType || '-',
+        children: getResourceStorageLabel(resource?.storageType),
       },
       {
         key: 'size',
@@ -225,7 +226,9 @@ const ResourceDetailDrawer = ({
       <section className="resource-detail-section">
         <div className="resource-detail-section__heading">
           <h3>资源信息</h3>
-          <Tag bordered={false}>{resource?.storageType || 'UNKNOWN'}</Tag>
+          <Tag bordered={false}>
+            {getResourceStorageLabel(resource?.storageType)}
+          </Tag>
         </div>
         <Descriptions
           size="small"

--- a/yak-ops-ui/src/pages/resource-management/components/StorageTypeLabel.tsx
+++ b/yak-ops-ui/src/pages/resource-management/components/StorageTypeLabel.tsx
@@ -1,0 +1,47 @@
+import { Cloud, Database, HardDrive } from 'lucide-react';
+
+import type { ResourceStorageType } from '../types';
+
+interface StorageTypeLabelProps {
+  type?: ResourceStorageType | null;
+  name?: string;
+}
+
+export const getResourceStorageLabel = (
+  type?: ResourceStorageType | null,
+) => {
+  switch (String(type || '').toUpperCase()) {
+    case 'LOCAL':
+      return '本地存储';
+    case 'MINIO':
+      return 'MinIO';
+    case 'HDFS':
+      return 'HDFS';
+    default:
+      return String(type || '-');
+  }
+};
+
+const storageIcon = (type?: ResourceStorageType | null) => {
+  switch (String(type || '').toUpperCase()) {
+    case 'LOCAL':
+      return HardDrive;
+    case 'HDFS':
+      return Database;
+    default:
+      return Cloud;
+  }
+};
+
+const StorageTypeLabel = ({ type, name }: StorageTypeLabelProps) => {
+  const Icon = storageIcon(type);
+
+  return (
+    <span className="resource-storage-cell">
+      <Icon size={14} />
+      {name || getResourceStorageLabel(type)}
+    </span>
+  );
+};
+
+export default StorageTypeLabel;

--- a/yak-ops-ui/src/pages/resource-management/index.tsx
+++ b/yak-ops-ui/src/pages/resource-management/index.tsx
@@ -23,7 +23,6 @@ import {
 } from 'antd';
 import dayjs from 'dayjs';
 import {
-  Cloud,
   Database,
   Download,
   File,
@@ -55,6 +54,7 @@ import CreateTextResourceModal from './components/CreateTextResourceModal';
 import MoveResourceModal from './components/MoveResourceModal';
 import ResourceDetailDrawer from './components/ResourceDetailDrawer';
 import ResourceMetadataModal from './components/ResourceMetadataModal';
+import StorageTypeLabel from './components/StorageTypeLabel';
 import './index.less';
 import {
   createDirectory,
@@ -481,12 +481,7 @@ const ResourceManagementPage = () => {
       dataIndex: 'storageType',
       key: 'storageType',
       width: 120,
-      render: (value) => (
-        <span className="resource-storage-cell">
-          <Cloud size={14} />
-          {String(value || '-')}
-        </span>
-      ),
+      render: (value) => <StorageTypeLabel type={value} />,
     },
     {
       title: '版本',
@@ -563,7 +558,9 @@ const ResourceManagementPage = () => {
         <header className="resource-header">
           <div>
             <h1>资源管理</h1>
-            <p>统一管理任务脚本、配置文件与运行资源，底层支持 MinIO 和 HDFS。</p>
+            <p>
+              默认使用内置 Local 文件存储，也可按部署需要切换 MinIO 或 HDFS。
+            </p>
           </div>
           <Space size={10} wrap>
             {canCreate && (

--- a/yak-ops-ui/src/pages/resource-management/types.ts
+++ b/yak-ops-ui/src/pages/resource-management/types.ts
@@ -1,6 +1,10 @@
 export type ResourceId = number | string;
 export type ResourceNodeType = 'DIRECTORY' | 'FILE';
-export type ResourceStorageType = 'MINIO' | 'HDFS' | string;
+export type ResourceStorageType =
+  | 'LOCAL'
+  | 'MINIO'
+  | 'HDFS'
+  | (string & {});
 
 export interface CommonApiResponse<T> {
   code: number;


### PR DESCRIPTION
## 背景

内置 Local 存储插件已经合并，但资源管理前端仍沿用 MinIO/HDFS 文案和云存储展示，后端已有测试也仍假设 MinIO 是默认存储，导致前后端契约与最新默认配置不一致。

## 主要变更

- 前端资源存储类型显式支持 `LOCAL`、`MINIO`、`HDFS`，同时保留后续扩展类型兼容
- 新增统一的存储类型展示组件
  - Local 使用本地磁盘图标并展示“本地存储”
  - MinIO 使用云存储图标
  - HDFS 使用数据存储图标
- 资源列表和资源详情统一使用友好存储名称，不再直接展示原始 `LOCAL` 枚举值
- 更新资源管理页说明，明确默认使用内置 Local，可按部署需要切换 MinIO/HDFS
- 修复 `StorageOperatorRegistryTest`，按真实默认配置验证 Local 为当前活动存储、MinIO 为可选插件
- 补充 `/api/v1/resources/storage-plugins` 后端接口契约测试

## 默认行为

无需配置时，资源根目录的新建文件夹、上传文件和在线创建文件均使用：

```yaml
yak:
  resource:
    storage:
      type: LOCAL
```

默认本地目录仍为：

```yaml
yak:
  resource:
    storage:
      local:
        base-directory: ./data/resources
```

已有 MinIO/HDFS 资源继续根据数据库中的 `storageType` 使用对应插件读取，不会迁移或覆盖已有文件。

## 联调链路

前端通过：

```text
GET /api/v1/resources/storage-plugins
```

读取后端已安装插件和当前活动插件；资源列表、详情、上传、下载、在线编辑、替换、移动和删除接口保持原有契约不变。

## 验证

- 核对 Local 插件已由 `storage-all` 自动装配
- 核对 `ResourceProperties.Storage` 默认值为 `LOCAL`
- 更新注册表测试覆盖 Local 默认选择和插件活动状态
- 更新 Controller 契约测试覆盖 `storage-plugins` 路由
- 核对前端 API 类型与后端 `ResourceStorageType` 枚举一致

当前执行环境无法直接克隆仓库或安装依赖，因此未本地执行完整 Maven/TypeScript 构建；以仓库检查结果为准。