### PR TITLE
feat(offline-worker): add multi-worker scheduling

### DIFF
--- a/docs/offline-worker-management.md
+++ b/docs/offline-worker-management.md
@@ -101,6 +101,7 @@ GET /api/v1/node
 - `MANUAL`：严格使用指定 `nodeId`；节点不可用时直接失败，不自动切换。
 - 标签采用精确匹配，手动和自动模式都会校验。
 - 已经创建的执行实例不会因为任务策略或 Worker 地址后来发生变化而漂移。
+- 手动任务通过数据库外键引用 Worker，仍被任务定义引用的节点不能删除。
 
 ## 自动调度算法
 
@@ -118,6 +119,18 @@ GET /api/v1/node
 
 `DRAINING` 节点不会接收新任务，但原有执行仍继续在该节点对账和取消。
 
+### 有效负载
+
+Worker 心跳存在刷新间隔。为了避免多个任务并发提交时同时读取旧负载，执行领取事务会：
+
+1. 锁定当前任务定义，防止同一任务重复运行。
+2. 按 `nodeId` 固定顺序对全部 Worker 行执行 `SELECT ... FOR UPDATE`。
+3. 聚合 Yak Ops 数据库中 `CREATED / SUBMITTED / QUEUED / RUNNING` 的执行数。
+4. 将控制面活跃执行数与 Worker 上报的运行、排队数量取保守值。
+5. 选择 Worker 并在同一事务内插入执行实例，然后释放锁。
+
+因此，不同任务即使并发提交，也不会全部基于同一份旧心跳选择同一个 Worker。
+
 ### 评分
 
 通过硬过滤后计算：
@@ -130,14 +143,14 @@ score = runningHeadroom × 55
 
 其中：
 
-- `runningHeadroom`：即时运行并发余量比例
-- `totalCapacityHeadroom`：运行并发与等待队列的综合余量比例
+- `runningHeadroom`：有效运行并发余量比例
+- `totalCapacityHeadroom`：有效运行并发与等待队列的综合余量比例
 - `normalizedWeight`：管理权重归一化结果，权重范围为 `1..1000`
 
 同分时依次比较：
 
-1. 排队任务更少
-2. 运行任务更少
+1. 有效排队任务更少
+2. 有效运行任务更少
 3. 权重更高
 4. `nodeId` 字典序
 
@@ -146,6 +159,9 @@ score = runningHeadroom × 55
 - 分配模式
 - 最终得分
 - 选择原因
+- Worker 上报负载
+- 控制面活跃执行数
+- 计算后的有效负载
 - 所有候选节点及淘汰原因
 
 ## 执行路由与可靠性
@@ -180,6 +196,7 @@ Flyway V7 为任务定义增加：
 - `worker_select_mode`
 - `worker_node_id`
 - `worker_required_labels_json`
+- `worker_node_id -> yak_offline_engine_node.node_id` 外键
 
 为执行实例增加：
 
@@ -198,7 +215,7 @@ Flyway V7 为任务定义增加：
 - CDC 或流式任务调度
 - 跨 Worker 迁移正在运行的任务
 - 提交不确定时的自动故障转移
-- 资源预占或分布式容量锁
+- Worker 侧资源预占或分布式容量租约
 - 基于 Connector 能力清单的调度约束
 
-后续可以在现有调度器上增加 Connector 能力、租户配额、资源预占和更细粒度的调度审计。
+后续可以在现有调度器上增加 Connector 能力、租户配额、Worker 侧资源租约和更细粒度的调度审计。

--- a/docs/offline-worker-management.md
+++ b/docs/offline-worker-management.md
@@ -1,10 +1,10 @@
-# Link-Up 离线 Worker 管理
+# Link-Up 离线 Worker 管理与调度
 
 ## 定位
 
 Yak Ops 是离线同步控制面，Link-Up Server 是可独立部署的离线执行 Worker。
 
-第一阶段只完成 Worker 管理闭环：
+Worker 管理负责：
 
 - 手工注册 Link-Up Worker
 - 自动登记 `application.yml` 中的默认 Worker
@@ -12,20 +12,13 @@ Yak Ops 是离线同步控制面，Link-Up Server 是可独立部署的离线执
 - 定时心跳与手工刷新
 - 版本、进程实例、并发、队列和负载展示
 - 启用、排空、禁用和删除管理
-- 为后续手动选择和自动分配保留权重、标签和 options 接口
 
-本阶段不启用多 Worker 自动调度。离线任务仍使用：
+多 Worker 调度负责：
 
-```yaml
-yak:
-  sync:
-    offline:
-      engine:
-        node-id: link-up-node-1
-        base-url: http://127.0.0.1:18080
-```
-
-指定的默认 Worker。
+- 为任务配置 `AUTO` 或 `MANUAL` Worker 策略
+- 根据标签、健康状态、心跳、容量、负载和权重选择 Worker
+- 将 Worker 地址、进程实例和分配依据固化到执行实例
+- 后续提交、取消、指标查询和状态对账始终访问该执行实例的 Worker
 
 ## Worker 状态
 
@@ -42,7 +35,7 @@ yak:
 
 默认配置 Worker 的登记来源是 `CONFIG`，不能在页面删除或修改地址；手工节点来源是 `MANUAL`。
 
-## API
+## Worker 管理 API
 
 基础路径：
 
@@ -64,7 +57,7 @@ PUT    /{nodeId}/scheduling-status
 DELETE /{nodeId}
 ```
 
-新增和编辑会先请求目标 Link-Up：
+新增和编辑地址会请求目标 Link-Up：
 
 ```http
 GET /api/v1/node
@@ -72,28 +65,140 @@ GET /api/v1/node
 
 只有返回稳定 `nodeId` 且 `offlineOnly=true` 的节点才能登记。
 
+## 任务调度策略
+
+任务定义中保存：
+
+```json
+{
+  "worker": {
+    "mode": "AUTO",
+    "requiredLabels": {
+      "region": "south-china",
+      "storage": "ssd"
+    }
+  }
+}
+```
+
+手动指定节点：
+
+```json
+{
+  "worker": {
+    "mode": "MANUAL",
+    "nodeId": "link-up-south-01",
+    "requiredLabels": {
+      "region": "south-china"
+    }
+  }
+}
+```
+
+规则：
+
+- `AUTO`：每次新执行或重试重新评估当前 Worker 集合。
+- `MANUAL`：严格使用指定 `nodeId`；节点不可用时直接失败，不自动切换。
+- 标签采用精确匹配，手动和自动模式都会校验。
+- 已经创建的执行实例不会因为任务策略或 Worker 地址后来发生变化而漂移。
+
+## 自动调度算法
+
+### 硬过滤
+
+候选节点必须同时满足：
+
+1. `enabled=true`
+2. `scheduling_status=ENABLED`
+3. `status=UP`
+4. `offline_only=true`
+5. 心跳未过期
+6. 满足任务要求的全部标签
+7. 运行并发和等待队列没有同时满载
+
+`DRAINING` 节点不会接收新任务，但原有执行仍继续在该节点对账和取消。
+
+### 评分
+
+通过硬过滤后计算：
+
+```text
+score = runningHeadroom × 55
+      + totalCapacityHeadroom × 35
+      + normalizedWeight × 10
+```
+
+其中：
+
+- `runningHeadroom`：即时运行并发余量比例
+- `totalCapacityHeadroom`：运行并发与等待队列的综合余量比例
+- `normalizedWeight`：管理权重归一化结果，权重范围为 `1..1000`
+
+同分时依次比较：
+
+1. 排队任务更少
+2. 运行任务更少
+3. 权重更高
+4. `nodeId` 字典序
+
+调度结果会记录：
+
+- 分配模式
+- 最终得分
+- 选择原因
+- 所有候选节点及淘汰原因
+
+## 执行路由与可靠性
+
+执行实例固化：
+
+- `engine_node_id`
+- `engine_node_base_url`
+- `worker_instance_id`
+- `assignment_mode`
+- `assignment_score`
+- `assignment_reason`
+- `assignment_candidates_json`
+
+所有远程操作均使用执行实例固化的 `engine_node_base_url`：
+
+- 提交 JobSpec
+- 根据 `jobId` 或 `externalExecutionId` 对账
+- 取消任务
+- 查询 pipeline、task 和 metrics
+
+当提交发生不确定网络错误时，Yak Ops 不会立即切换到其他 Worker，因为原 Worker 可能已经接收幂等请求；控制面会继续在原 Worker 上按 `externalExecutionId` 对账。
+
+Worker 进程实例发生变化且原执行仍未结束时，控制面将该执行标记为 `LOST`。后续重试会创建新的执行实例并重新执行 Worker 调度。
+
 ## 数据模型
 
-Worker 继续复用 `yak_offline_engine_node`，Flyway V6 增加：
+Worker 管理继续复用 `yak_offline_engine_node`。
 
-- `registration_mode`
-- `enabled`
-- `scheduling_status`
-- `weight`
-- `labels_json`
-- `started_at_millis`
-- `offline_only`
-- `last_success_time`
-- `consecutive_failures`
+Flyway V7 为任务定义增加：
 
-运行状态和容量由心跳更新；节点名称、权重、标签和调度状态由 Yak Ops 管理。
+- `worker_select_mode`
+- `worker_node_id`
+- `worker_required_labels_json`
 
-## 下一阶段
+为执行实例增加：
 
-第二阶段再实现：
+- `engine_node_base_url`
+- `assignment_mode`
+- `assignment_score`
+- `assignment_reason`
+- `assignment_candidates_json`
 
-- 任务定义的 `AUTO` / `MANUAL` Worker 选择
-- Link-Up 客户端按执行节点地址路由
-- 自动过滤不可用、排空、队列已满和能力不匹配的 Worker
-- 按负载、权重和标签自动分配
-- 执行实例固化 Worker 地址和分配原因
+历史任务默认迁移为 `AUTO`。历史执行没有 `engine_node_base_url` 时，继续兼容原默认 Worker 配置。
+
+## 当前边界
+
+本阶段完成离线任务的多 Worker 调度，不引入：
+
+- CDC 或流式任务调度
+- 跨 Worker 迁移正在运行的任务
+- 提交不确定时的自动故障转移
+- 资源预占或分布式容量锁
+- 基于 Connector 能力清单的调度约束
+
+后续可以在现有调度器上增加 Connector 能力、租户配额、资源预占和更细粒度的调度审计。

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/LinkUpClient.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/LinkUpClient.java
@@ -21,7 +21,10 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
 /**
- * Link-Up 单节点离线 Worker 强类型客户端。
+ * Link-Up 离线 Worker 强类型客户端。
+ *
+ * <p>无 baseUrl 参数的方法保留默认 Worker 兼容行为；多 Worker 调度使用显式 baseUrl
+ * 方法，确保提交、取消、查询和对账始终访问执行实例固化的节点。
  *
  * @author weifuwan
  */
@@ -43,7 +46,11 @@ public class LinkUpClient {
   }
 
   public LinkUpNodeResponse node() {
-    return get("/api/v1/node", LinkUpNodeResponse.class);
+    return node(configuredBaseUrl());
+  }
+
+  public LinkUpNodeResponse node(String baseUrl) {
+    return get(baseUrl, "/api/v1/node", LinkUpNodeResponse.class);
   }
 
   public LinkUpNodeResponse health() {
@@ -51,6 +58,20 @@ public class LinkUpClient {
   }
 
   public LinkUpJobResponse submit(
+      String externalExecutionId,
+      String idempotencyKey,
+      int definitionVersion,
+      JsonNode jobSpec) {
+    return submit(
+        configuredBaseUrl(),
+        externalExecutionId,
+        idempotencyKey,
+        definitionVersion,
+        jobSpec);
+  }
+
+  public LinkUpJobResponse submit(
+      String baseUrl,
       String externalExecutionId,
       String idempotencyKey,
       int definitionVersion,
@@ -67,58 +88,89 @@ public class LinkUpClient {
     body.setIdempotencyKey(idempotencyKey.trim());
     body.setDefinitionVersion(definitionVersion);
     body.setJobSpec(jobSpec);
-    HttpRequest request = HttpRequest.newBuilder(uri("/api/v1/jobs"))
+    String normalized = normalizeBaseUrl(baseUrl);
+    HttpRequest request = HttpRequest.newBuilder(uri(normalized, "/api/v1/jobs"))
         .timeout(properties.getEngine().getRequestTimeout())
         .header("Content-Type", "application/json;charset=UTF-8")
         .header("Accept", "application/json")
         .POST(HttpRequest.BodyPublishers.ofString(write(body), StandardCharsets.UTF_8))
         .build();
-    return send(request, LinkUpJobResponse.class);
+    return send(request, LinkUpJobResponse.class, normalized);
   }
 
   public LinkUpJobResponse getJob(String engineJobId) {
-    return get("/api/v1/jobs/" + encode(engineJobId), LinkUpJobResponse.class);
+    return getJob(configuredBaseUrl(), engineJobId);
+  }
+
+  public LinkUpJobResponse getJob(String baseUrl, String engineJobId) {
+    return get(baseUrl, "/api/v1/jobs/" + encode(engineJobId), LinkUpJobResponse.class);
   }
 
   public LinkUpJobResponse findByExternalExecutionId(String externalExecutionId) {
+    return findByExternalExecutionId(configuredBaseUrl(), externalExecutionId);
+  }
+
+  public LinkUpJobResponse findByExternalExecutionId(
+      String baseUrl,
+      String externalExecutionId) {
     return get(
+        baseUrl,
         "/api/v1/jobs/external/" + encode(externalExecutionId),
         LinkUpJobResponse.class);
   }
 
   public LinkUpJobResponse cancel(String engineJobId) {
+    return cancel(configuredBaseUrl(), engineJobId);
+  }
+
+  public LinkUpJobResponse cancel(String baseUrl, String engineJobId) {
     requireEnabled();
-    HttpRequest request = HttpRequest.newBuilder(uri("/api/v1/jobs/" + encode(engineJobId)))
+    String normalized = normalizeBaseUrl(baseUrl);
+    HttpRequest request = HttpRequest.newBuilder(
+            uri(normalized, "/api/v1/jobs/" + encode(engineJobId)))
         .timeout(properties.getEngine().getRequestTimeout())
         .header("Accept", "application/json")
         .DELETE()
         .build();
-    return send(request, LinkUpJobResponse.class);
+    return send(request, LinkUpJobResponse.class, normalized);
   }
 
   public JsonNode pipelines(String engineJobId) {
-    return get("/api/v1/jobs/" + encode(engineJobId) + "/pipelines", JsonNode.class);
+    return pipelines(configuredBaseUrl(), engineJobId);
+  }
+
+  public JsonNode pipelines(String baseUrl, String engineJobId) {
+    return get(baseUrl, "/api/v1/jobs/" + encode(engineJobId) + "/pipelines", JsonNode.class);
   }
 
   public JsonNode tasks(String engineJobId) {
-    return get("/api/v1/jobs/" + encode(engineJobId) + "/tasks", JsonNode.class);
+    return tasks(configuredBaseUrl(), engineJobId);
+  }
+
+  public JsonNode tasks(String baseUrl, String engineJobId) {
+    return get(baseUrl, "/api/v1/jobs/" + encode(engineJobId) + "/tasks", JsonNode.class);
   }
 
   public JsonNode metrics(String engineJobId) {
-    return get("/api/v1/jobs/" + encode(engineJobId) + "/metrics", JsonNode.class);
+    return metrics(configuredBaseUrl(), engineJobId);
   }
 
-  private <T> T get(String path, Class<T> type) {
+  public JsonNode metrics(String baseUrl, String engineJobId) {
+    return get(baseUrl, "/api/v1/jobs/" + encode(engineJobId) + "/metrics", JsonNode.class);
+  }
+
+  private <T> T get(String baseUrl, String path, Class<T> type) {
     requireEnabled();
-    HttpRequest request = HttpRequest.newBuilder(uri(path))
+    String normalized = normalizeBaseUrl(baseUrl);
+    HttpRequest request = HttpRequest.newBuilder(uri(normalized, path))
         .timeout(properties.getEngine().getRequestTimeout())
         .header("Accept", "application/json")
         .GET()
         .build();
-    return send(request, type);
+    return send(request, type, normalized);
   }
 
-  private <T> T send(HttpRequest request, Class<T> type) {
+  private <T> T send(HttpRequest request, Class<T> type, String baseUrl) {
     try {
       HttpResponse<String> response =
           httpClient.send(request, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
@@ -136,7 +188,7 @@ public class LinkUpClient {
     } catch (IOException exception) {
       // JDK HttpClient cannot always tell whether bytes reached the Worker. Reconcile by external ID.
       throw new LinkUpTransportException(
-          "无法确认 Link-Up Worker 是否已接收请求：" + properties.getEngine().getBaseUrl(),
+          "无法确认 Link-Up Worker 是否已接收请求：" + baseUrl,
           exception,
           true);
     }
@@ -183,19 +235,30 @@ public class LinkUpClient {
     return StringUtils.hasText(message) ? message : fallback;
   }
 
-  private URI uri(String path) {
-    String baseUrl = properties.getEngine().getBaseUrl();
-    if (!StringUtils.hasText(baseUrl)) {
-      throw new LinkUpProtocolException("yak.sync.offline.engine.base-url 不能为空");
-    }
-    String normalized = baseUrl.endsWith("/")
-        ? baseUrl.substring(0, baseUrl.length() - 1)
-        : baseUrl;
+  private String configuredBaseUrl() {
+    return normalizeBaseUrl(properties.getEngine().getBaseUrl());
+  }
+
+  private URI uri(String baseUrl, String path) {
     try {
-      return URI.create(normalized + path);
+      return URI.create(normalizeBaseUrl(baseUrl) + path);
     } catch (IllegalArgumentException exception) {
-      throw new LinkUpProtocolException("Link-Up Worker 地址不合法：" + normalized, exception);
+      throw new LinkUpProtocolException("Link-Up Worker 地址不合法：" + baseUrl, exception);
     }
+  }
+
+  private String normalizeBaseUrl(String baseUrl) {
+    if (!StringUtils.hasText(baseUrl)) {
+      throw new LinkUpProtocolException("Link-Up Worker 地址不能为空");
+    }
+    String normalized = baseUrl.trim();
+    while (normalized.endsWith("/")) {
+      normalized = normalized.substring(0, normalized.length() - 1);
+    }
+    if (!normalized.startsWith("http://") && !normalized.startsWith("https://")) {
+      throw new LinkUpProtocolException("Link-Up Worker 地址必须使用 HTTP 或 HTTPS：" + baseUrl);
+    }
+    return normalized;
   }
 
   private String encode(String value) {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineExecutionControlRepository.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineExecutionControlRepository.java
@@ -60,9 +60,11 @@ public class OfflineExecutionControlRepository {
             + "WHERE engine_node_id IS NOT NULL "
             + "AND status IN ('CREATED','SUBMITTED','QUEUED','RUNNING') "
             + "GROUP BY engine_node_id",
-        resultSet -> result.put(
-            resultSet.getString("engine_node_id"),
-            resultSet.getInt("active_count")));
+        resultSet -> {
+          result.put(
+              resultSet.getString("engine_node_id"),
+              resultSet.getInt("active_count"));
+        });
     return result;
   }
 

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineExecutionControlRepository.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineExecutionControlRepository.java
@@ -5,6 +5,7 @@ import io.yak.ops.common.bean.po.sync.offline.OfflineJobExecutionPO;
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import javax.sql.DataSource;
@@ -46,6 +47,23 @@ public class OfflineExecutionControlRepository {
         Integer.class,
         definitionId);
     return count != null && count > 0;
+  }
+
+  /**
+   * 返回 Yak Ops 已创建但尚未结束的执行数，用于弥补 Worker 心跳负载的时间差。
+   */
+  public Map<String, Integer> countActiveExecutionsByNode() {
+    Map<String, Integer> result = new LinkedHashMap<>();
+    jdbc.query(
+        "SELECT engine_node_id, COUNT(1) AS active_count "
+            + "FROM yak_offline_job_execution "
+            + "WHERE engine_node_id IS NOT NULL "
+            + "AND status IN ('CREATED','SUBMITTED','QUEUED','RUNNING') "
+            + "GROUP BY engine_node_id",
+        resultSet -> result.put(
+            resultSet.getString("engine_node_id"),
+            resultSet.getInt("active_count")));
+    return result;
   }
 
   public List<OfflineJobExecutionPO> findActiveExecutions(int limit) {
@@ -136,10 +154,15 @@ public class OfflineExecutionControlRepository {
     execution.setDefinitionVersionId(nullableLong(resultSet, "definition_version_id"));
     execution.setDefinitionVersion(resultSet.getInt("definition_version"));
     execution.setEngineNodeId(resultSet.getString("engine_node_id"));
+    execution.setEngineNodeBaseUrl(resultSet.getString("engine_node_base_url"));
     execution.setEngineJobId(resultSet.getString("engine_job_id"));
     execution.setExternalExecutionId(resultSet.getString("external_execution_id"));
     execution.setIdempotencyKey(resultSet.getString("idempotency_key"));
     execution.setWorkerInstanceId(resultSet.getString("worker_instance_id"));
+    execution.setAssignmentMode(resultSet.getString("assignment_mode"));
+    execution.setAssignmentScore(nullableDouble(resultSet, "assignment_score"));
+    execution.setAssignmentReason(resultSet.getString("assignment_reason"));
+    execution.setAssignmentCandidatesJson(resultSet.getString("assignment_candidates_json"));
     execution.setStatus(resultSet.getString("status"));
     execution.setStateVersion(resultSet.getLong("state_version"));
     execution.setAttemptNo(resultSet.getInt("attempt_no"));
@@ -169,6 +192,12 @@ public class OfflineExecutionControlRepository {
   private Long nullableLong(java.sql.ResultSet resultSet, String column)
       throws java.sql.SQLException {
     long value = resultSet.getLong(column);
+    return resultSet.wasNull() ? null : value;
+  }
+
+  private Double nullableDouble(java.sql.ResultSet resultSet, String column)
+      throws java.sql.SQLException {
+    double value = resultSet.getDouble(column);
     return resultSet.wasNull() ? null : value;
   }
 

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineExecutionControlRepository.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineExecutionControlRepository.java
@@ -51,19 +51,20 @@ public class OfflineExecutionControlRepository {
 
   /**
    * 返回 Yak Ops 已创建但尚未结束的执行数，用于弥补 Worker 心跳负载的时间差。
+   *
+   * <p>该查询使用 FOR UPDATE 当前读，避免 MySQL REPEATABLE READ 继续读取领取事务
+   * 建立时的旧快照。调用方必须先按固定顺序锁定 Worker 行。
    */
   public Map<String, Integer> countActiveExecutionsByNode() {
     Map<String, Integer> result = new LinkedHashMap<>();
     jdbc.query(
-        "SELECT engine_node_id, COUNT(1) AS active_count "
-            + "FROM yak_offline_job_execution "
+        "SELECT engine_node_id FROM yak_offline_job_execution "
             + "WHERE engine_node_id IS NOT NULL "
             + "AND status IN ('CREATED','SUBMITTED','QUEUED','RUNNING') "
-            + "GROUP BY engine_node_id",
+            + "ORDER BY id ASC FOR UPDATE",
         resultSet -> {
-          result.put(
-              resultSet.getString("engine_node_id"),
-              resultSet.getInt("active_count"));
+          String nodeId = resultSet.getString("engine_node_id");
+          result.merge(nodeId, 1, Integer::sum);
         });
     return result;
   }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineNodeRepository.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineNodeRepository.java
@@ -152,6 +152,16 @@ public class OfflineNodeRepository {
         rowMapper);
   }
 
+  /**
+   * 调度事务内按稳定顺序锁定全部 Worker 行，防止多个任务并发使用相同负载快照。
+   */
+  public List<NodeRecord> listAllForScheduling() {
+    return jdbc.query(
+        "SELECT " + SELECT_COLUMNS + " FROM yak_offline_engine_node "
+            + "ORDER BY node_id ASC FOR UPDATE",
+        rowMapper);
+  }
+
   public List<NodeRecord> listHeartbeatTargets() {
     return jdbc.query(
         "SELECT " + SELECT_COLUMNS + " FROM yak_offline_engine_node "

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineExecutionClaimService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineExecutionClaimService.java
@@ -6,6 +6,8 @@ import io.yak.ops.business.sync.offline.domain.OfflineExecutionStatus;
 import io.yak.ops.business.sync.offline.repository.OfflineDefinitionCatalogRepository.DefinitionVersion;
 import io.yak.ops.business.sync.offline.repository.OfflineExecutionControlRepository;
 import io.yak.ops.business.sync.offline.repository.OfflineNodeRepository.NodeRecord;
+import io.yak.ops.business.sync.offline.worker.OfflineWorkerScheduler;
+import io.yak.ops.business.sync.offline.worker.OfflineWorkerScheduler.Assignment;
 import io.yak.ops.common.bean.po.sync.offline.OfflineJobDefinitionPO;
 import io.yak.ops.common.bean.po.sync.offline.OfflineJobExecutionPO;
 import java.time.LocalDateTime;
@@ -16,7 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 /**
  * 离线同步执行实例原子领取服务。
  *
- * Atomically claims a definition and creates one durable execution attempt.
+ * Atomically claims a definition, selects one Worker and creates one durable execution attempt.
  *
  * @author weifuwan
  */
@@ -27,14 +29,17 @@ public class OfflineExecutionClaimService {
   private final OfflineJobDefinitionService definitionService;
   private final OfflineJobExecutionDao executionDao;
   private final OfflineExecutionControlRepository executionRepository;
+  private final OfflineWorkerScheduler workerScheduler;
 
   public OfflineExecutionClaimService(
       OfflineJobDefinitionService definitionService,
       OfflineJobExecutionDao executionDao,
-      OfflineExecutionControlRepository executionRepository) {
+      OfflineExecutionControlRepository executionRepository,
+      OfflineWorkerScheduler workerScheduler) {
     this.definitionService = definitionService;
     this.executionDao = executionDao;
     this.executionRepository = executionRepository;
+    this.workerScheduler = workerScheduler;
   }
 
   @Transactional(transactionManager = "offlineSyncTransactionManager", rollbackFor = Exception.class)
@@ -42,11 +47,7 @@ public class OfflineExecutionClaimService {
       Long definitionId,
       String triggerType,
       Long retryFromExecutionId,
-      int attemptNo,
-      NodeRecord node) {
-    if (node == null) {
-      throw new IllegalArgumentException("Link-Up Worker 节点不能为空");
-    }
+      int attemptNo) {
     executionRepository.lockDefinition(definitionId);
     OfflineJobDefinitionPO definition = definitionService.require(definitionId);
     if (!"ONLINE".equalsIgnoreCase(definition.getReleaseState())) {
@@ -57,6 +58,8 @@ public class OfflineExecutionClaimService {
     }
 
     DefinitionVersion version = definitionService.requireCurrentVersion(definition);
+    Assignment assignment = workerScheduler.select(definition);
+    NodeRecord node = assignment.getNode();
     String logicalJobSpecJson = definitionService.resolveLogicalJobSpec(version);
     LocalDateTime now = LocalDateTime.now();
     OfflineJobExecutionPO execution = new OfflineJobExecutionPO();
@@ -64,7 +67,12 @@ public class OfflineExecutionClaimService {
     execution.setDefinitionVersionId(version.getId());
     execution.setDefinitionVersion(version.getVersionNo());
     execution.setEngineNodeId(node.getNodeId());
+    execution.setEngineNodeBaseUrl(node.getBaseUrl());
     execution.setWorkerInstanceId(node.getWorkerInstanceId());
+    execution.setAssignmentMode(assignment.getMode());
+    execution.setAssignmentScore(assignment.getScore());
+    execution.setAssignmentReason(assignment.getReason());
+    execution.setAssignmentCandidatesJson(assignment.getCandidatesJson());
     execution.setStatus(OfflineExecutionStatus.CREATED.name());
     execution.setStateVersion(1L);
     execution.setAttemptNo(Math.max(1, attemptNo));
@@ -92,7 +100,7 @@ public class OfflineExecutionClaimService {
     if (!executionDao.updateById(execution)) {
       throw new IllegalStateException("初始化离线同步执行标识失败");
     }
-    return new ClaimResult(definition, version, logicalJobSpecJson, execution);
+    return new ClaimResult(definition, version, logicalJobSpecJson, execution, assignment);
   }
 
   public static final class ClaimResult {
@@ -100,21 +108,25 @@ public class OfflineExecutionClaimService {
     private final DefinitionVersion version;
     private final String logicalJobSpecJson;
     private final OfflineJobExecutionPO execution;
+    private final Assignment assignment;
 
     public ClaimResult(
         OfflineJobDefinitionPO definition,
         DefinitionVersion version,
         String logicalJobSpecJson,
-        OfflineJobExecutionPO execution) {
+        OfflineJobExecutionPO execution,
+        Assignment assignment) {
       this.definition = definition;
       this.version = version;
       this.logicalJobSpecJson = logicalJobSpecJson;
       this.execution = execution;
+      this.assignment = assignment;
     }
 
     public OfflineJobDefinitionPO getDefinition() { return definition; }
     public DefinitionVersion getVersion() { return version; }
     public String getLogicalJobSpecJson() { return logicalJobSpecJson; }
     public OfflineJobExecutionPO getExecution() { return execution; }
+    public Assignment getAssignment() { return assignment; }
   }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineExecutionOrchestrator.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineExecutionOrchestrator.java
@@ -13,7 +13,6 @@ import io.yak.ops.business.sync.offline.engine.LinkUpClient.LinkUpJobResponse;
 import io.yak.ops.business.sync.offline.engine.LinkUpClient.LinkUpRequestException;
 import io.yak.ops.business.sync.offline.engine.LinkUpClient.LinkUpTransportException;
 import io.yak.ops.business.sync.offline.repository.OfflineExecutionControlRepository;
-import io.yak.ops.business.sync.offline.repository.OfflineNodeRepository.NodeRecord;
 import io.yak.ops.business.sync.offline.repository.OfflineScheduleRepository;
 import io.yak.ops.business.sync.offline.repository.OfflineScheduleRepository.ScheduleRecord;
 import io.yak.ops.business.sync.offline.service.OfflineExecutionClaimService.ClaimResult;
@@ -41,7 +40,6 @@ public class OfflineExecutionOrchestrator {
   private final OfflineJobExecutionDao executionDao;
   private final OfflineExecutionControlRepository executionRepository;
   private final OfflineScheduleRepository scheduleRepository;
-  private final OfflineWorkerRegistry workerRegistry;
   private final OfflineAlertPublisher alertPublisher;
   private final LinkUpClient linkUpClient;
   private final OfflineSyncProperties properties;
@@ -54,7 +52,6 @@ public class OfflineExecutionOrchestrator {
       OfflineJobExecutionDao executionDao,
       OfflineExecutionControlRepository executionRepository,
       OfflineScheduleRepository scheduleRepository,
-      OfflineWorkerRegistry workerRegistry,
       OfflineAlertPublisher alertPublisher,
       LinkUpClient linkUpClient,
       OfflineSyncProperties properties,
@@ -65,7 +62,6 @@ public class OfflineExecutionOrchestrator {
     this.executionDao = executionDao;
     this.executionRepository = executionRepository;
     this.scheduleRepository = scheduleRepository;
-    this.workerRegistry = workerRegistry;
     this.alertPublisher = alertPublisher;
     this.linkUpClient = linkUpClient;
     this.properties = properties;
@@ -77,15 +73,19 @@ public class OfflineExecutionOrchestrator {
       String triggerType,
       Long retryFromExecutionId,
       int attemptNo) {
-    NodeRecord node = workerRegistry.selectNode();
     ClaimResult claim = claimService.claim(
         definitionId,
         triggerType,
         retryFromExecutionId,
-        attemptNo,
-        node);
+        attemptNo);
     OfflineJobExecutionPO execution = claim.getExecution();
-    record(execution, null, execution.getStatus(), "CREATED", "Yak Ops 已创建执行实例", null);
+    record(
+        execution,
+        null,
+        execution.getStatus(),
+        "WORKER_ASSIGNED",
+        execution.getAssignmentReason(),
+        execution.getAssignmentCandidatesJson());
 
     try {
       String resolvedJobSpecJson = definitionService.resolveExecutionJobSpec(claim.getVersion());
@@ -94,9 +94,10 @@ public class OfflineExecutionOrchestrator {
           execution,
           OfflineExecutionStatus.SUBMITTED,
           "SUBMITTING",
-          "正在提交 Link-Up JobSpec",
+          "正在向 " + execution.getEngineNodeId() + " 提交 Link-Up JobSpec",
           null);
       LinkUpJobResponse response = linkUpClient.submit(
+          baseUrl(execution),
           execution.getExternalExecutionId(),
           execution.getIdempotencyKey(),
           claim.getVersion().getVersionNo(),
@@ -114,7 +115,7 @@ public class OfflineExecutionOrchestrator {
       throw exception;
     } catch (LinkUpTransportException exception) {
       if (exception.isUncertain()) {
-        // The Worker may have accepted the idempotent request. Reconcile by externalExecutionId.
+        // The assigned Worker may have accepted the idempotent request. Never fail over here.
         execution.setErrorMessage(exception.getMessage());
         execution.setLastSyncTime(LocalDateTime.now());
         execution.setUpdateTime(LocalDateTime.now());
@@ -175,7 +176,7 @@ public class OfflineExecutionOrchestrator {
     if (StringUtils.hasText(execution.getEngineJobId())) {
       applySnapshot(
           execution,
-          linkUpClient.cancel(execution.getEngineJobId()),
+          linkUpClient.cancel(baseUrl(execution), execution.getEngineJobId()),
           "CANCEL_ACCEPTED");
     }
     return execution;
@@ -187,6 +188,13 @@ public class OfflineExecutionOrchestrator {
       String eventType) {
     if (execution == null || response == null) {
       return;
+    }
+    if (StringUtils.hasText(response.getWorkerNodeId())
+        && StringUtils.hasText(execution.getEngineNodeId())
+        && !execution.getEngineNodeId().equals(response.getWorkerNodeId())) {
+      throw new IllegalStateException(
+          "Link-Up 返回的 workerNodeId 与执行分配不一致，分配="
+              + execution.getEngineNodeId() + "，实际=" + response.getWorkerNodeId());
     }
     String previousStatus = execution.getStatus();
     OfflineExecutionStatus nextStatus = StringUtils.hasText(response.getStatus())
@@ -393,6 +401,12 @@ public class OfflineExecutionOrchestrator {
         && properties.getControl().isAlertOnLost()) {
       alertPublisher.publish(execution, "LOST", text(execution.getErrorMessage()));
     }
+  }
+
+  private String baseUrl(OfflineJobExecutionPO execution) {
+    return StringUtils.hasText(execution.getEngineNodeBaseUrl())
+        ? execution.getEngineNodeBaseUrl()
+        : properties.getEngine().getBaseUrl();
   }
 
   private String write(Object value) {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineExecutionReadService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineExecutionReadService.java
@@ -4,6 +4,7 @@ import com.baomidou.mybatisplus.core.metadata.IPage;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.yak.framework.common.PagingData;
 import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import io.yak.ops.business.sync.offline.config.OfflineSyncProperties;
 import io.yak.ops.business.sync.offline.dao.OfflineJobExecutionDao;
 import io.yak.ops.business.sync.offline.engine.LinkUpClient;
 import io.yak.ops.business.sync.offline.repository.OfflineExecutionControlRepository;
@@ -36,6 +37,7 @@ public class OfflineExecutionReadService {
   private final OfflineJobExecutionDao executionDao;
   private final OfflineExecutionControlRepository repository;
   private final LinkUpClient linkUpClient;
+  private final OfflineSyncProperties properties;
 
   public OfflineJobExecutionPO require(Long id) {
     if (id == null || id <= 0L) {
@@ -80,7 +82,7 @@ public class OfflineExecutionReadService {
     if (!StringUtils.hasText(execution.getEngineJobId())) {
       throw new IllegalStateException("当前执行实例尚未获得 Link-Up jobId，暂时无法查询表级指标");
     }
-    return linkUpClient.pipelines(execution.getEngineJobId());
+    return linkUpClient.pipelines(baseUrl(execution), execution.getEngineJobId());
   }
 
   public String logs(Long id) {
@@ -92,7 +94,11 @@ public class OfflineExecutionReadService {
         .append("definitionVersion: ").append(value(execution.getDefinitionVersion())).append('\n')
         .append("externalExecutionId: ").append(text(execution.getExternalExecutionId())).append('\n')
         .append("engineNodeId: ").append(text(execution.getEngineNodeId())).append('\n')
+        .append("engineNodeBaseUrl: ").append(text(execution.getEngineNodeBaseUrl())).append('\n')
         .append("workerInstanceId: ").append(text(execution.getWorkerInstanceId())).append('\n')
+        .append("assignmentMode: ").append(text(execution.getAssignmentMode())).append('\n')
+        .append("assignmentScore: ").append(decimal(execution.getAssignmentScore())).append('\n')
+        .append("assignmentReason: ").append(text(execution.getAssignmentReason())).append('\n')
         .append("engineJobId: ").append(text(execution.getEngineJobId())).append('\n')
         .append("status: ").append(text(execution.getStatus())).append('\n')
         .append("attemptNo: ").append(value(execution.getAttemptNo())).append('\n')
@@ -123,9 +129,13 @@ public class OfflineExecutionReadService {
         .definitionVersionId(execution.getDefinitionVersionId())
         .definitionVersion(execution.getDefinitionVersion())
         .engineNodeId(execution.getEngineNodeId())
+        .engineNodeBaseUrl(execution.getEngineNodeBaseUrl())
         .engineJobId(execution.getEngineJobId())
         .externalExecutionId(execution.getExternalExecutionId())
         .workerInstanceId(execution.getWorkerInstanceId())
+        .assignmentMode(execution.getAssignmentMode())
+        .assignmentScore(execution.getAssignmentScore())
+        .assignmentReason(execution.getAssignmentReason())
         .stateVersion(value(execution.getStateVersion()))
         .attemptNo(value(execution.getAttemptNo()))
         .triggerType(execution.getTriggerType())
@@ -148,12 +158,22 @@ public class OfflineExecutionReadService {
         .build();
   }
 
+  private String baseUrl(OfflineJobExecutionPO execution) {
+    return StringUtils.hasText(execution.getEngineNodeBaseUrl())
+        ? execution.getEngineNodeBaseUrl()
+        : properties.getEngine().getBaseUrl();
+  }
+
   private String format(LocalDateTime value) {
     return value == null ? null : value.format(FORMAT);
   }
 
   private String text(String value) {
     return StringUtils.hasText(value) ? value : "-";
+  }
+
+  private String decimal(Double value) {
+    return value == null ? "-" : String.format(java.util.Locale.ROOT, "%.3f", value);
   }
 
   private long value(Long value) {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineExecutionReconciler.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineExecutionReconciler.java
@@ -55,7 +55,8 @@ public class OfflineExecutionReconciler {
       NodeRecord node = StringUtils.hasText(execution.getEngineNodeId())
           ? nodeRepository.find(execution.getEngineNodeId())
           : null;
-      if (node != null && "UP".equalsIgnoreCase(node.getStatus())
+      if (node != null && sameRoute(execution, node)
+          && "UP".equalsIgnoreCase(node.getStatus())
           && StringUtils.hasText(execution.getWorkerInstanceId())
           && StringUtils.hasText(node.getWorkerInstanceId())
           && !execution.getWorkerInstanceId().equals(node.getWorkerInstanceId())) {
@@ -102,6 +103,14 @@ public class OfflineExecutionReconciler {
     }
   }
 
+  private boolean sameRoute(OfflineJobExecutionPO execution, NodeRecord node) {
+    if (!StringUtils.hasText(execution.getEngineNodeBaseUrl())) {
+      // 历史执行没有地址快照，沿用原 nodeId/instanceId 判定。
+      return true;
+    }
+    return normalize(execution.getEngineNodeBaseUrl()).equals(normalize(node.getBaseUrl()));
+  }
+
   private String baseUrl(OfflineJobExecutionPO execution, NodeRecord node) {
     if (StringUtils.hasText(execution.getEngineNodeBaseUrl())) {
       return execution.getEngineNodeBaseUrl();
@@ -110,6 +119,17 @@ public class OfflineExecutionReconciler {
       return node.getBaseUrl();
     }
     return properties.getEngine().getBaseUrl();
+  }
+
+  private String normalize(String value) {
+    if (!StringUtils.hasText(value)) {
+      return "";
+    }
+    String normalized = value.trim();
+    while (normalized.endsWith("/")) {
+      normalized = normalized.substring(0, normalized.length() - 1);
+    }
+    return normalized;
   }
 
   private boolean isPastLostDeadline(OfflineJobExecutionPO execution) {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineExecutionReconciler.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineExecutionReconciler.java
@@ -5,6 +5,7 @@ import io.yak.ops.business.sync.offline.config.OfflineSyncProperties;
 import io.yak.ops.business.sync.offline.engine.LinkUpClient;
 import io.yak.ops.business.sync.offline.engine.LinkUpClient.LinkUpJobResponse;
 import io.yak.ops.business.sync.offline.repository.OfflineExecutionControlRepository;
+import io.yak.ops.business.sync.offline.repository.OfflineNodeRepository;
 import io.yak.ops.business.sync.offline.repository.OfflineNodeRepository.NodeRecord;
 import io.yak.ops.common.bean.po.sync.offline.OfflineJobExecutionPO;
 import java.time.Duration;
@@ -18,7 +19,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
 /**
- * 后台持续对账 Link-Up 实际状态，页面查询不再触发远程刷新。
+ * 后台持续对账每个执行实例固化的 Link-Up Worker，页面查询不再触发远程刷新。
  *
  * @author weifuwan
  */
@@ -30,7 +31,7 @@ public class OfflineExecutionReconciler {
   private static final Logger LOG = LoggerFactory.getLogger(OfflineExecutionReconciler.class);
 
   private final OfflineExecutionControlRepository repository;
-  private final OfflineWorkerRegistry workerRegistry;
+  private final OfflineNodeRepository nodeRepository;
   private final OfflineJobExecutionService executionService;
   private final LinkUpClient linkUpClient;
   private final OfflineSyncProperties properties;
@@ -40,31 +41,35 @@ public class OfflineExecutionReconciler {
       fixedDelayString = "${yak.sync.offline.control.reconcile-delay-millis:5000}")
   public void reconcile() {
     int limit = Math.max(1, properties.getControl().getScanBatchSize());
-    NodeRecord node = workerRegistry.currentNode();
     List<OfflineJobExecutionPO> executions = repository.findActiveExecutions(limit);
     for (OfflineJobExecutionPO execution : executions) {
-      reconcileExecution(execution, node);
+      reconcileExecution(execution);
     }
     for (OfflineJobExecutionPO execution : repository.findRetryCandidates(LocalDateTime.now(), limit)) {
       retry(execution);
     }
   }
 
-  private void reconcileExecution(OfflineJobExecutionPO execution, NodeRecord node) {
+  private void reconcileExecution(OfflineJobExecutionPO execution) {
     try {
+      NodeRecord node = StringUtils.hasText(execution.getEngineNodeId())
+          ? nodeRepository.find(execution.getEngineNodeId())
+          : null;
       if (node != null && "UP".equalsIgnoreCase(node.getStatus())
           && StringUtils.hasText(execution.getWorkerInstanceId())
           && StringUtils.hasText(node.getWorkerInstanceId())
           && !execution.getWorkerInstanceId().equals(node.getWorkerInstanceId())) {
         executionService.markLost(
             execution,
-            "Link-Up Worker instanceId 已变化，原执行结果无法继续确认");
+            "Link-Up Worker " + execution.getEngineNodeId()
+                + " 的 instanceId 已变化，原执行结果无法继续确认");
         return;
       }
 
+      String baseUrl = baseUrl(execution, node);
       LinkUpJobResponse response = StringUtils.hasText(execution.getEngineJobId())
-          ? linkUpClient.getJob(execution.getEngineJobId())
-          : linkUpClient.findByExternalExecutionId(execution.getExternalExecutionId());
+          ? linkUpClient.getJob(baseUrl, execution.getEngineJobId())
+          : linkUpClient.findByExternalExecutionId(baseUrl, execution.getExternalExecutionId());
       executionService.applySnapshot(execution, response, "RECONCILED");
 
       if (Boolean.TRUE.equals(execution.getCancellationRequested())
@@ -73,12 +78,15 @@ public class OfflineExecutionReconciler {
           && isActive(response.getStatus())) {
         executionService.applySnapshot(
             execution,
-            linkUpClient.cancel(execution.getEngineJobId()),
+            linkUpClient.cancel(baseUrl, execution.getEngineJobId()),
             "CANCEL_RECONCILED");
       }
     } catch (RuntimeException exception) {
       if (isPastLostDeadline(execution)) {
-        executionService.markLost(execution, "Link-Up 状态对账超时：" + exception.getMessage());
+        executionService.markLost(
+            execution,
+            "Link-Up Worker " + execution.getEngineNodeId()
+                + " 状态对账超时：" + exception.getMessage());
       } else {
         LOG.debug("Offline execution reconcile failed, executionId={}", execution.getId(), exception);
       }
@@ -92,6 +100,16 @@ public class OfflineExecutionReconciler {
     } catch (RuntimeException exception) {
       LOG.warn("Offline execution retry failed, executionId={}", execution.getId(), exception);
     }
+  }
+
+  private String baseUrl(OfflineJobExecutionPO execution, NodeRecord node) {
+    if (StringUtils.hasText(execution.getEngineNodeBaseUrl())) {
+      return execution.getEngineNodeBaseUrl();
+    }
+    if (node != null && StringUtils.hasText(node.getBaseUrl())) {
+      return node.getBaseUrl();
+    }
+    return properties.getEngine().getBaseUrl();
   }
 
   private boolean isPastLostDeadline(OfflineJobExecutionPO execution) {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineJobDefinitionService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineJobDefinitionService.java
@@ -13,6 +13,8 @@ import io.yak.ops.business.sync.offline.repository.OfflineScheduleRepository;
 import io.yak.ops.business.sync.offline.repository.OfflineScheduleRepository.ScheduleRecord;
 import io.yak.ops.business.sync.offline.service.OfflineDefinitionSupport.DraftDefinition;
 import io.yak.ops.business.sync.offline.service.OfflineDefinitionSupport.PreparedDefinition;
+import io.yak.ops.business.sync.offline.worker.OfflineWorkerScheduler;
+import io.yak.ops.business.sync.offline.worker.OfflineWorkerScheduler.PolicyProjection;
 import io.yak.ops.common.bean.dto.sync.offline.OfflineJobDefinitionDTO;
 import io.yak.ops.common.bean.dto.sync.offline.OfflineJobDefinitionQueryDTO;
 import io.yak.ops.common.bean.po.sync.offline.OfflineJobDefinitionPO;
@@ -50,6 +52,7 @@ public class OfflineJobDefinitionService {
   private final OfflineScheduleRepository scheduleRepository;
   private final OfflineExecutionControlRepository executionRepository;
   private final OfflineDefinitionSupport support;
+  private final OfflineWorkerScheduler workerScheduler;
   private final AtomicLong idSequence = new AtomicLong(System.currentTimeMillis() * 1000L);
 
   public Long nextId() {
@@ -76,6 +79,7 @@ public class OfflineJobDefinitionService {
     }
 
     DraftDefinition draft = support.prepareDraft(requestDTO);
+    PolicyProjection policy = workerScheduler.normalize(draft.getRequest().get("worker"));
     if (definitionDao.existsByName(draft.getJobName(), id)) {
       throw new IllegalArgumentException("离线同步任务名称已存在：" + draft.getJobName());
     }
@@ -100,6 +104,7 @@ public class OfflineJobDefinitionService {
     definition.setSinkTable(null);
     definition.setScheduleJson(support.writeNullable(draft.getRequest().get("schedule")));
     definition.setEnvJson(support.writeNullable(draft.getRequest().get("env")));
+    applyWorkerPolicy(definition, policy);
     definition.setVersion(0);
     definition.setCurrentVersionId(null);
     definition.setCreateTime(existing == null ? now : existing.getCreateTime());
@@ -132,6 +137,7 @@ public class OfflineJobDefinitionService {
       }
       throw exception;
     }
+    PolicyProjection policy = workerScheduler.normalize(prepared.getRequest().get("worker"));
     if (definitionDao.existsByName(prepared.getJobName(), id)) {
       throw new IllegalArgumentException("离线同步任务名称已存在：" + prepared.getJobName());
     }
@@ -159,6 +165,7 @@ public class OfflineJobDefinitionService {
     definition.setSinkTable(prepared.getSinkTable());
     definition.setScheduleJson(support.writeNullable(prepared.getRequest().get("schedule")));
     definition.setEnvJson(support.writeNullable(prepared.getRequest().get("env")));
+    applyWorkerPolicy(definition, policy);
     definition.setVersion(version);
     definition.setReleaseState(existing == null ? "OFFLINE" : existing.getReleaseState());
     definition.setCreateTime(existing == null ? now : existing.getCreateTime());
@@ -226,6 +233,7 @@ public class OfflineJobDefinitionService {
   public boolean online(Long id) {
     OfflineJobDefinitionPO definition = require(id);
     requireCurrentVersion(definition);
+    workerScheduler.validateDefinition(definition);
     definition.setReleaseState("ONLINE");
     definition.setUpdateTime(LocalDateTime.now());
     return definitionDao.updateById(definition);
@@ -296,12 +304,28 @@ public class OfflineJobDefinitionService {
 
   private OfflineJobDefinitionVO toVO(OfflineJobDefinitionPO definition) {
     ScheduleRecord schedule = scheduleRepository.findSchedule(definition.getId());
-    return support.toVO(
+    OfflineJobDefinitionVO view = support.toVO(
         definition,
         schedule == null ? null : schedule.getCronExpression(),
         schedule != null && schedule.isEnabled(),
         schedule == null ? null : schedule.getLastFireTime(),
         schedule == null ? null : schedule.getNextFireTime());
+    view.setWorkerSelectMode(
+        StringUtils.hasText(definition.getWorkerSelectMode())
+            ? definition.getWorkerSelectMode() : "AUTO");
+    view.setWorkerNodeId(definition.getWorkerNodeId());
+    view.setWorkerNodeName(workerScheduler.nodeName(definition.getWorkerNodeId()));
+    view.setWorkerRequiredLabels(
+        workerScheduler.labels(definition.getWorkerRequiredLabelsJson()));
+    return view;
+  }
+
+  private void applyWorkerPolicy(
+      OfflineJobDefinitionPO definition,
+      PolicyProjection policy) {
+    definition.setWorkerSelectMode(policy.getMode());
+    definition.setWorkerNodeId(policy.getNodeId());
+    definition.setWorkerRequiredLabelsJson(policy.getRequiredLabelsJson());
   }
 
   private void ensureEditable(OfflineJobDefinitionPO existing) {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/worker/OfflineWorkerScheduler.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/worker/OfflineWorkerScheduler.java
@@ -1,0 +1,427 @@
+package io.yak.ops.business.sync.offline.worker;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import io.yak.ops.business.sync.offline.config.OfflineSyncProperties;
+import io.yak.ops.business.sync.offline.repository.OfflineNodeRepository;
+import io.yak.ops.business.sync.offline.repository.OfflineNodeRepository.NodeRecord;
+import io.yak.ops.business.sync.offline.service.OfflineWorkerRegistry;
+import io.yak.ops.common.bean.po.sync.offline.OfflineJobDefinitionPO;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+/**
+ * 离线任务 Worker 选择器。
+ *
+ * <p>先执行健康、调度状态、心跳新鲜度、标签和容量硬过滤，再按即时并发余量、
+ * 总容量余量和管理权重计算可解释得分。选择过程只读取控制面快照，不在数据库事务中
+ * 发起远程请求。
+ *
+ * @author weifuwan
+ */
+@ConditionalOnOfflineSyncEnabled
+@Component
+public class OfflineWorkerScheduler {
+
+  private static final TypeReference<Map<String, String>> LABELS_TYPE =
+      new TypeReference<Map<String, String>>() { };
+
+  private final OfflineNodeRepository repository;
+  private final OfflineWorkerRegistry registry;
+  private final OfflineSyncProperties properties;
+  private final ObjectMapper objectMapper;
+
+  public OfflineWorkerScheduler(
+      OfflineNodeRepository repository,
+      OfflineWorkerRegistry registry,
+      OfflineSyncProperties properties,
+      @Qualifier("offlineSyncJsonMapper") ObjectMapper objectMapper) {
+    this.repository = repository;
+    this.registry = registry;
+    this.properties = properties;
+    this.objectMapper = objectMapper;
+  }
+
+  public PolicyProjection normalize(JsonNode worker) {
+    String mode = normalizeMode(text(worker, "mode", "AUTO"));
+    String nodeId = trim(text(worker, "nodeId", null));
+    Map<String, String> labels = readLabels(worker == null ? null : worker.get("requiredLabels"));
+    if ("MANUAL".equals(mode) && !StringUtils.hasText(nodeId)) {
+      throw new IllegalArgumentException("手动 Worker 模式必须选择执行节点");
+    }
+    return new PolicyProjection(mode, nodeId, writeLabels(labels), labels);
+  }
+
+  public PolicyProjection projection(OfflineJobDefinitionPO definition) {
+    if (definition == null) {
+      throw new IllegalArgumentException("任务定义不能为空");
+    }
+    String mode = normalizeMode(definition.getWorkerSelectMode());
+    String nodeId = trim(definition.getWorkerNodeId());
+    Map<String, String> labels = readLabels(definition.getWorkerRequiredLabelsJson());
+    if ("MANUAL".equals(mode) && !StringUtils.hasText(nodeId)) {
+      throw new IllegalStateException("任务配置为手动 Worker，但未指定 nodeId");
+    }
+    return new PolicyProjection(mode, nodeId, writeLabels(labels), labels);
+  }
+
+  /** 保存和上线前验证稳定引用；节点当前离线不阻止维护任务定义。 */
+  public void validateDefinition(OfflineJobDefinitionPO definition) {
+    PolicyProjection policy = projection(definition);
+    if ("MANUAL".equals(policy.getMode())
+        && repository.find(policy.getNodeId()) == null) {
+      throw new IllegalStateException("指定的 Link-Up Worker 不存在：" + policy.getNodeId());
+    }
+  }
+
+  public String nodeName(String nodeId) {
+    if (!StringUtils.hasText(nodeId)) {
+      return null;
+    }
+    NodeRecord node = repository.find(nodeId);
+    return node == null ? null : node.getNodeName();
+  }
+
+  public Map<String, String> labels(String labelsJson) {
+    return readLabels(labelsJson);
+  }
+
+  public Assignment select(OfflineJobDefinitionPO definition) {
+    registry.ensureConfiguredWorker();
+    PolicyProjection policy = projection(definition);
+    List<NodeRecord> nodes = repository.listAll();
+    if ("MANUAL".equals(policy.getMode())) {
+      return selectManual(policy, nodes);
+    }
+    return selectAuto(policy, nodes);
+  }
+
+  private Assignment selectManual(PolicyProjection policy, List<NodeRecord> nodes) {
+    NodeRecord selected = nodes.stream()
+        .filter(node -> Objects.equals(policy.getNodeId(), node.getNodeId()))
+        .findFirst()
+        .orElseThrow(() -> new IllegalStateException(
+            "指定的 Link-Up Worker 不存在：" + policy.getNodeId()));
+    Candidate candidate = evaluate(selected, policy.getRequiredLabels());
+    if (!candidate.isEligible()) {
+      throw new IllegalStateException(
+          "指定的 Link-Up Worker 当前不可调度：" + candidate.getRejectionReason());
+    }
+    List<Candidate> snapshot = nodes.stream()
+        .map(node -> evaluate(node, policy.getRequiredLabels()))
+        .collect(Collectors.toList());
+    candidate.setSelected(true);
+    return assignment(
+        candidate,
+        "MANUAL",
+        "手动指定 Worker " + selected.getNodeName() + "（" + selected.getNodeId() + "）",
+        snapshot);
+  }
+
+  private Assignment selectAuto(PolicyProjection policy, List<NodeRecord> nodes) {
+    List<Candidate> candidates = nodes.stream()
+        .map(node -> evaluate(node, policy.getRequiredLabels()))
+        .collect(Collectors.toList());
+    List<Candidate> eligible = candidates.stream()
+        .filter(Candidate::isEligible)
+        .sorted(candidateComparator())
+        .collect(Collectors.toList());
+    if (eligible.isEmpty()) {
+      String rejected = candidates.stream()
+          .limit(5)
+          .map(candidate -> candidate.getNode().getNodeId() + "=" + candidate.getRejectionReason())
+          .collect(Collectors.joining("；"));
+      throw new IllegalStateException(
+          "没有可调度的 Link-Up Worker" + (StringUtils.hasText(rejected) ? "：" + rejected : ""));
+    }
+    Candidate selected = eligible.get(0);
+    selected.setSelected(true);
+    String reason = String.format(
+        Locale.ROOT,
+        "AUTO 评分 %.3f：即时并发余量 %.1f%%，总容量余量 %.1f%%，权重 %d；候选 %d/%d",
+        selected.getScore(),
+        selected.getRunningHeadroom() * 100D,
+        selected.getTotalHeadroom() * 100D,
+        value(selected.getNode().getWeight(), 100),
+        eligible.size(),
+        candidates.size());
+    return assignment(selected, "AUTO", reason, candidates);
+  }
+
+  private Assignment assignment(
+      Candidate selected,
+      String mode,
+      String reason,
+      List<Candidate> candidates) {
+    return new Assignment(
+        selected.getNode(),
+        mode,
+        selected.getScore(),
+        reason,
+        writeCandidates(candidates));
+  }
+
+  private Candidate evaluate(NodeRecord node, Map<String, String> requiredLabels) {
+    Candidate candidate = new Candidate(node);
+    if (!Boolean.TRUE.equals(node.getEnabled())) {
+      return candidate.reject("节点已禁用");
+    }
+    if (!"ENABLED".equalsIgnoreCase(node.getSchedulingStatus())) {
+      return candidate.reject("节点处于" + node.getSchedulingStatus() + "状态");
+    }
+    if (!"UP".equalsIgnoreCase(node.getStatus())) {
+      return candidate.reject("节点健康状态为" + node.getStatus());
+    }
+    if (!Boolean.TRUE.equals(node.getOfflineOnly())) {
+      return candidate.reject("节点不是离线专用 Worker");
+    }
+    if (heartbeatStale(node.getLastHeartbeatTime())) {
+      return candidate.reject("节点心跳已过期");
+    }
+    Map<String, String> nodeLabels = readLabels(node.getLabelsJson());
+    for (Map.Entry<String, String> required : requiredLabels.entrySet()) {
+      if (!Objects.equals(required.getValue(), nodeLabels.get(required.getKey()))) {
+        return candidate.reject(
+            "缺少标签 " + required.getKey() + "=" + required.getValue());
+      }
+    }
+
+    int maxRunning = Math.max(1, value(node.getMaxConcurrentJobs(), 1));
+    int maxQueued = Math.max(0, value(node.getMaxQueuedJobs(), 0));
+    int running = Math.max(0, value(node.getRunningJobs(), 0));
+    int queued = Math.max(0, value(node.getQueuedJobs(), 0));
+    if (running >= maxRunning && queued >= maxQueued) {
+      return candidate.reject("并发和等待队列均已满");
+    }
+
+    int totalCapacity = Math.max(1, maxRunning + maxQueued);
+    int active = Math.max(0, running + queued);
+    double runningHeadroom = clamp((double) (maxRunning - running) / maxRunning);
+    double totalHeadroom = clamp((double) (totalCapacity - active) / totalCapacity);
+    double weightScore = clamp((double) value(node.getWeight(), 100) / 1000D);
+    double score = runningHeadroom * 55D + totalHeadroom * 35D + weightScore * 10D;
+    candidate.accept(score, runningHeadroom, totalHeadroom, nodeLabels);
+    return candidate;
+  }
+
+  private Comparator<Candidate> candidateComparator() {
+    return Comparator.comparingDouble(Candidate::getScore).reversed()
+        .thenComparingInt(candidate -> value(candidate.getNode().getQueuedJobs(), 0))
+        .thenComparingInt(candidate -> value(candidate.getNode().getRunningJobs(), 0))
+        .thenComparing(
+            candidate -> value(candidate.getNode().getWeight(), 100),
+            Comparator.reverseOrder())
+        .thenComparing(candidate -> candidate.getNode().getNodeId());
+  }
+
+  private boolean heartbeatStale(LocalDateTime heartbeat) {
+    if (heartbeat == null) {
+      return true;
+    }
+    long staleAfter = Math.max(
+        30_000L,
+        Math.max(
+            properties.getControl().getHeartbeatDelayMillis() * 3L,
+            properties.getControl().getLostAfterMillis()));
+    return heartbeat.isBefore(LocalDateTime.now().minusNanos(staleAfter * 1_000_000L));
+  }
+
+  private String writeCandidates(List<Candidate> candidates) {
+    List<Map<String, Object>> snapshot = new ArrayList<>();
+    for (Candidate candidate : candidates) {
+      NodeRecord node = candidate.getNode();
+      Map<String, Object> item = new LinkedHashMap<>();
+      item.put("nodeId", node.getNodeId());
+      item.put("nodeName", node.getNodeName());
+      item.put("baseUrl", node.getBaseUrl());
+      item.put("eligible", candidate.isEligible());
+      item.put("selected", candidate.isSelected());
+      item.put("score", candidate.getScore());
+      item.put("reason", candidate.getRejectionReason());
+      item.put("weight", value(node.getWeight(), 100));
+      item.put("runningJobs", value(node.getRunningJobs(), 0));
+      item.put("maxConcurrentJobs", value(node.getMaxConcurrentJobs(), 1));
+      item.put("queuedJobs", value(node.getQueuedJobs(), 0));
+      item.put("maxQueuedJobs", value(node.getMaxQueuedJobs(), 0));
+      item.put("labels", candidate.getNodeLabels());
+      snapshot.add(item);
+    }
+    try {
+      return objectMapper.writeValueAsString(snapshot);
+    } catch (JsonProcessingException exception) {
+      throw new IllegalStateException("序列化 Worker 候选快照失败", exception);
+    }
+  }
+
+  private Map<String, String> readLabels(JsonNode labels) {
+    if (labels == null || labels.isNull() || labels.isMissingNode()) {
+      return Collections.emptyMap();
+    }
+    if (!labels.isObject()) {
+      throw new IllegalArgumentException("Worker 标签条件必须是 JSON 对象");
+    }
+    Map<String, String> result = new LinkedHashMap<>();
+    labels.fields().forEachRemaining(entry -> {
+      if (StringUtils.hasText(entry.getKey())) {
+        result.put(entry.getKey().trim(), entry.getValue().asText("").trim());
+      }
+    });
+    return result;
+  }
+
+  private Map<String, String> readLabels(String labelsJson) {
+    if (!StringUtils.hasText(labelsJson)) {
+      return Collections.emptyMap();
+    }
+    try {
+      return objectMapper.readValue(labelsJson, LABELS_TYPE);
+    } catch (JsonProcessingException exception) {
+      throw new IllegalStateException("Worker 标签 JSON 已损坏", exception);
+    }
+  }
+
+  private String writeLabels(Map<String, String> labels) {
+    try {
+      return objectMapper.writeValueAsString(labels == null ? Collections.emptyMap() : labels);
+    } catch (JsonProcessingException exception) {
+      throw new IllegalStateException("序列化 Worker 标签条件失败", exception);
+    }
+  }
+
+  private String normalizeMode(String mode) {
+    String normalized = StringUtils.hasText(mode)
+        ? mode.trim().toUpperCase(Locale.ROOT)
+        : "AUTO";
+    if (!"AUTO".equals(normalized) && !"MANUAL".equals(normalized)) {
+      throw new IllegalArgumentException("不支持的 Worker 选择模式：" + mode);
+    }
+    return normalized;
+  }
+
+  private String text(JsonNode node, String field, String fallback) {
+    if (node == null || node.isNull() || node.isMissingNode()) {
+      return fallback;
+    }
+    JsonNode value = node.get(field);
+    return value == null || value.isNull() ? fallback : value.asText(fallback);
+  }
+
+  private String trim(String value) {
+    return StringUtils.hasText(value) ? value.trim() : null;
+  }
+
+  private int value(Integer value, int fallback) {
+    return value == null ? fallback : value;
+  }
+
+  private double clamp(double value) {
+    return Math.max(0D, Math.min(1D, value));
+  }
+
+  public static final class PolicyProjection {
+    private final String mode;
+    private final String nodeId;
+    private final String requiredLabelsJson;
+    private final Map<String, String> requiredLabels;
+
+    public PolicyProjection(
+        String mode,
+        String nodeId,
+        String requiredLabelsJson,
+        Map<String, String> requiredLabels) {
+      this.mode = mode;
+      this.nodeId = nodeId;
+      this.requiredLabelsJson = requiredLabelsJson;
+      this.requiredLabels = requiredLabels;
+    }
+
+    public String getMode() { return mode; }
+    public String getNodeId() { return nodeId; }
+    public String getRequiredLabelsJson() { return requiredLabelsJson; }
+    public Map<String, String> getRequiredLabels() { return requiredLabels; }
+  }
+
+  public static final class Assignment {
+    private final NodeRecord node;
+    private final String mode;
+    private final double score;
+    private final String reason;
+    private final String candidatesJson;
+
+    public Assignment(
+        NodeRecord node,
+        String mode,
+        double score,
+        String reason,
+        String candidatesJson) {
+      this.node = node;
+      this.mode = mode;
+      this.score = score;
+      this.reason = reason;
+      this.candidatesJson = candidatesJson;
+    }
+
+    public NodeRecord getNode() { return node; }
+    public String getMode() { return mode; }
+    public double getScore() { return score; }
+    public String getReason() { return reason; }
+    public String getCandidatesJson() { return candidatesJson; }
+  }
+
+  private static final class Candidate {
+    private final NodeRecord node;
+    private boolean eligible;
+    private boolean selected;
+    private double score;
+    private double runningHeadroom;
+    private double totalHeadroom;
+    private String rejectionReason;
+    private Map<String, String> nodeLabels = Collections.emptyMap();
+
+    private Candidate(NodeRecord node) {
+      this.node = node;
+    }
+
+    private Candidate reject(String reason) {
+      this.eligible = false;
+      this.rejectionReason = reason;
+      return this;
+    }
+
+    private void accept(
+        double score,
+        double runningHeadroom,
+        double totalHeadroom,
+        Map<String, String> nodeLabels) {
+      this.eligible = true;
+      this.score = score;
+      this.runningHeadroom = runningHeadroom;
+      this.totalHeadroom = totalHeadroom;
+      this.nodeLabels = nodeLabels;
+    }
+
+    private NodeRecord getNode() { return node; }
+    private boolean isEligible() { return eligible; }
+    private boolean isSelected() { return selected; }
+    private void setSelected(boolean selected) { this.selected = selected; }
+    private double getScore() { return score; }
+    private double getRunningHeadroom() { return runningHeadroom; }
+    private double getTotalHeadroom() { return totalHeadroom; }
+    private String getRejectionReason() { return rejectionReason; }
+    private Map<String, String> getNodeLabels() { return nodeLabels; }
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/worker/OfflineWorkerScheduler.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/worker/OfflineWorkerScheduler.java
@@ -111,25 +111,27 @@ public class OfflineWorkerScheduler {
   }
 
   private Assignment selectManual(PolicyProjection policy, List<NodeRecord> nodes) {
-    NodeRecord selected = nodes.stream()
-        .filter(node -> Objects.equals(policy.getNodeId(), node.getNodeId()))
+    List<Candidate> candidates = nodes.stream()
+        .map(node -> evaluate(node, policy.getRequiredLabels()))
+        .collect(Collectors.toList());
+    Candidate selected = candidates.stream()
+        .filter(candidate -> Objects.equals(
+            policy.getNodeId(),
+            candidate.getNode().getNodeId()))
         .findFirst()
         .orElseThrow(() -> new IllegalStateException(
             "指定的 Link-Up Worker 不存在：" + policy.getNodeId()));
-    Candidate candidate = evaluate(selected, policy.getRequiredLabels());
-    if (!candidate.isEligible()) {
+    if (!selected.isEligible()) {
       throw new IllegalStateException(
-          "指定的 Link-Up Worker 当前不可调度：" + candidate.getRejectionReason());
+          "指定的 Link-Up Worker 当前不可调度：" + selected.getRejectionReason());
     }
-    List<Candidate> snapshot = nodes.stream()
-        .map(node -> evaluate(node, policy.getRequiredLabels()))
-        .collect(Collectors.toList());
-    candidate.setSelected(true);
+    selected.setSelected(true);
     return assignment(
-        candidate,
+        selected,
         "MANUAL",
-        "手动指定 Worker " + selected.getNodeName() + "（" + selected.getNodeId() + "）",
-        snapshot);
+        "手动指定 Worker " + selected.getNode().getNodeName()
+            + "（" + selected.getNode().getNodeId() + "）",
+        candidates);
   }
 
   private Assignment selectAuto(PolicyProjection policy, List<NodeRecord> nodes) {
@@ -146,7 +148,8 @@ public class OfflineWorkerScheduler {
           .map(candidate -> candidate.getNode().getNodeId() + "=" + candidate.getRejectionReason())
           .collect(Collectors.joining("；"));
       throw new IllegalStateException(
-          "没有可调度的 Link-Up Worker" + (StringUtils.hasText(rejected) ? "：" + rejected : ""));
+          "没有可调度的 Link-Up Worker"
+              + (StringUtils.hasText(rejected) ? "：" + rejected : ""));
     }
     Candidate selected = eligible.get(0);
     selected.setSelected(true);
@@ -223,8 +226,9 @@ public class OfflineWorkerScheduler {
         .thenComparingInt(candidate -> value(candidate.getNode().getQueuedJobs(), 0))
         .thenComparingInt(candidate -> value(candidate.getNode().getRunningJobs(), 0))
         .thenComparing(
-            candidate -> value(candidate.getNode().getWeight(), 100),
-            Comparator.reverseOrder())
+            Comparator.comparingInt(
+                (Candidate candidate) -> value(candidate.getNode().getWeight(), 100))
+                .reversed())
         .thenComparing(candidate -> candidate.getNode().getNodeId());
   }
 
@@ -237,7 +241,8 @@ public class OfflineWorkerScheduler {
         Math.max(
             properties.getControl().getHeartbeatDelayMillis() * 3L,
             properties.getControl().getLostAfterMillis()));
-    return heartbeat.isBefore(LocalDateTime.now().minusNanos(staleAfter * 1_000_000L));
+    return heartbeat.isBefore(
+        LocalDateTime.now().minusNanos(staleAfter * 1_000_000L));
   }
 
   private String writeCandidates(List<Candidate> candidates) {
@@ -296,7 +301,8 @@ public class OfflineWorkerScheduler {
 
   private String writeLabels(Map<String, String> labels) {
     try {
-      return objectMapper.writeValueAsString(labels == null ? Collections.emptyMap() : labels);
+      return objectMapper.writeValueAsString(
+          labels == null ? Collections.emptyMap() : labels);
     } catch (JsonProcessingException exception) {
       throw new IllegalStateException("序列化 Worker 标签条件失败", exception);
     }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/worker/OfflineWorkerScheduler.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/worker/OfflineWorkerScheduler.java
@@ -20,6 +20,8 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
@@ -37,6 +39,7 @@ import org.springframework.util.StringUtils;
 @Component
 public class OfflineWorkerScheduler {
 
+  private static final Logger LOG = LoggerFactory.getLogger(OfflineWorkerScheduler.class);
   private static final TypeReference<Map<String, String>> LABELS_TYPE =
       new TypeReference<Map<String, String>>() { };
 
@@ -101,7 +104,12 @@ public class OfflineWorkerScheduler {
   }
 
   public Assignment select(OfflineJobDefinitionPO definition) {
-    registry.ensureConfiguredWorker();
+    try {
+      registry.ensureConfiguredWorker();
+    } catch (RuntimeException exception) {
+      // 默认配置错误不能阻断已登记手工 Worker 的调度。
+      LOG.warn("初始化默认 Link-Up Worker 失败，继续评估已登记节点：{}", exception.getMessage());
+    }
     PolicyProjection policy = projection(definition);
     List<NodeRecord> nodes = repository.listAll();
     if ("MANUAL".equals(policy.getMode())) {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/worker/OfflineWorkerScheduler.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/worker/OfflineWorkerScheduler.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
 import io.yak.ops.business.sync.offline.config.OfflineSyncProperties;
+import io.yak.ops.business.sync.offline.repository.OfflineExecutionControlRepository;
 import io.yak.ops.business.sync.offline.repository.OfflineNodeRepository;
 import io.yak.ops.business.sync.offline.repository.OfflineNodeRepository.NodeRecord;
 import io.yak.ops.business.sync.offline.service.OfflineWorkerRegistry;
@@ -30,8 +31,8 @@ import org.springframework.util.StringUtils;
  * 离线任务 Worker 选择器。
  *
  * <p>先执行健康、调度状态、心跳新鲜度、标签和容量硬过滤，再按即时并发余量、
- * 总容量余量和管理权重计算可解释得分。选择过程只读取控制面快照，不在数据库事务中
- * 发起远程请求。
+ * 总容量余量和管理权重计算可解释得分。调度事务会锁定 Worker 行，并将 Yak Ops
+ * 已创建的活跃执行叠加到 Worker 心跳负载中，避免并发提交使用同一份旧快照。
  *
  * @author weifuwan
  */
@@ -44,16 +45,19 @@ public class OfflineWorkerScheduler {
       new TypeReference<Map<String, String>>() { };
 
   private final OfflineNodeRepository repository;
+  private final OfflineExecutionControlRepository executionRepository;
   private final OfflineWorkerRegistry registry;
   private final OfflineSyncProperties properties;
   private final ObjectMapper objectMapper;
 
   public OfflineWorkerScheduler(
       OfflineNodeRepository repository,
+      OfflineExecutionControlRepository executionRepository,
       OfflineWorkerRegistry registry,
       OfflineSyncProperties properties,
       @Qualifier("offlineSyncJsonMapper") ObjectMapper objectMapper) {
     this.repository = repository;
+    this.executionRepository = executionRepository;
     this.registry = registry;
     this.properties = properties;
     this.objectMapper = objectMapper;
@@ -103,6 +107,7 @@ public class OfflineWorkerScheduler {
     return readLabels(labelsJson);
   }
 
+  /** 必须在 offline-sync 事务内调用。 */
   public Assignment select(OfflineJobDefinitionPO definition) {
     try {
       registry.ensureConfiguredWorker();
@@ -111,16 +116,23 @@ public class OfflineWorkerScheduler {
       LOG.warn("初始化默认 Link-Up Worker 失败，继续评估已登记节点：{}", exception.getMessage());
     }
     PolicyProjection policy = projection(definition);
-    List<NodeRecord> nodes = repository.listAll();
+    List<NodeRecord> nodes = repository.listAllForScheduling();
+    Map<String, Integer> activeExecutions = executionRepository.countActiveExecutionsByNode();
     if ("MANUAL".equals(policy.getMode())) {
-      return selectManual(policy, nodes);
+      return selectManual(policy, nodes, activeExecutions);
     }
-    return selectAuto(policy, nodes);
+    return selectAuto(policy, nodes, activeExecutions);
   }
 
-  private Assignment selectManual(PolicyProjection policy, List<NodeRecord> nodes) {
+  private Assignment selectManual(
+      PolicyProjection policy,
+      List<NodeRecord> nodes,
+      Map<String, Integer> activeExecutions) {
     List<Candidate> candidates = nodes.stream()
-        .map(node -> evaluate(node, policy.getRequiredLabels()))
+        .map(node -> evaluate(
+            node,
+            policy.getRequiredLabels(),
+            activeExecutions.getOrDefault(node.getNodeId(), 0)))
         .collect(Collectors.toList());
     Candidate selected = candidates.stream()
         .filter(candidate -> Objects.equals(
@@ -142,9 +154,15 @@ public class OfflineWorkerScheduler {
         candidates);
   }
 
-  private Assignment selectAuto(PolicyProjection policy, List<NodeRecord> nodes) {
+  private Assignment selectAuto(
+      PolicyProjection policy,
+      List<NodeRecord> nodes,
+      Map<String, Integer> activeExecutions) {
     List<Candidate> candidates = nodes.stream()
-        .map(node -> evaluate(node, policy.getRequiredLabels()))
+        .map(node -> evaluate(
+            node,
+            policy.getRequiredLabels(),
+            activeExecutions.getOrDefault(node.getNodeId(), 0)))
         .collect(Collectors.toList());
     List<Candidate> eligible = candidates.stream()
         .filter(Candidate::isEligible)
@@ -163,11 +181,12 @@ public class OfflineWorkerScheduler {
     selected.setSelected(true);
     String reason = String.format(
         Locale.ROOT,
-        "AUTO 评分 %.3f：即时并发余量 %.1f%%，总容量余量 %.1f%%，权重 %d；候选 %d/%d",
+        "AUTO 评分 %.3f：即时并发余量 %.1f%%，总容量余量 %.1f%%，权重 %d，控制面活跃 %d；候选 %d/%d",
         selected.getScore(),
         selected.getRunningHeadroom() * 100D,
         selected.getTotalHeadroom() * 100D,
         value(selected.getNode().getWeight(), 100),
+        selected.getControlPlaneActive(),
         eligible.size(),
         candidates.size());
     return assignment(selected, "AUTO", reason, candidates);
@@ -186,8 +205,12 @@ public class OfflineWorkerScheduler {
         writeCandidates(candidates));
   }
 
-  private Candidate evaluate(NodeRecord node, Map<String, String> requiredLabels) {
+  private Candidate evaluate(
+      NodeRecord node,
+      Map<String, String> requiredLabels,
+      int controlPlaneActive) {
     Candidate candidate = new Candidate(node);
+    candidate.setControlPlaneActive(Math.max(0, controlPlaneActive));
     if (!Boolean.TRUE.equals(node.getEnabled())) {
       return candidate.reject("节点已禁用");
     }
@@ -213,15 +236,23 @@ public class OfflineWorkerScheduler {
 
     int maxRunning = Math.max(1, value(node.getMaxConcurrentJobs(), 1));
     int maxQueued = Math.max(0, value(node.getMaxQueuedJobs(), 0));
-    int running = Math.max(0, value(node.getRunningJobs(), 0));
-    int queued = Math.max(0, value(node.getQueuedJobs(), 0));
-    if (running >= maxRunning && queued >= maxQueued) {
+    int reportedRunning = Math.max(0, value(node.getRunningJobs(), 0));
+    int reportedQueued = Math.max(0, value(node.getQueuedJobs(), 0));
+    int effectiveRunning = Math.max(
+        reportedRunning,
+        Math.min(controlPlaneActive, maxRunning));
+    int effectiveQueued = Math.max(
+        reportedQueued,
+        Math.max(0, controlPlaneActive - maxRunning));
+    candidate.setEffectiveRunning(effectiveRunning);
+    candidate.setEffectiveQueued(effectiveQueued);
+    if (effectiveRunning >= maxRunning && effectiveQueued >= maxQueued) {
       return candidate.reject("并发和等待队列均已满");
     }
 
     int totalCapacity = Math.max(1, maxRunning + maxQueued);
-    int active = Math.max(0, running + queued);
-    double runningHeadroom = clamp((double) (maxRunning - running) / maxRunning);
+    int active = Math.max(0, effectiveRunning + effectiveQueued);
+    double runningHeadroom = clamp((double) (maxRunning - effectiveRunning) / maxRunning);
     double totalHeadroom = clamp((double) (totalCapacity - active) / totalCapacity);
     double weightScore = clamp((double) value(node.getWeight(), 100) / 1000D);
     double score = runningHeadroom * 55D + totalHeadroom * 35D + weightScore * 10D;
@@ -231,8 +262,8 @@ public class OfflineWorkerScheduler {
 
   private Comparator<Candidate> candidateComparator() {
     return Comparator.comparingDouble(Candidate::getScore).reversed()
-        .thenComparingInt(candidate -> value(candidate.getNode().getQueuedJobs(), 0))
-        .thenComparingInt(candidate -> value(candidate.getNode().getRunningJobs(), 0))
+        .thenComparingInt(Candidate::getEffectiveQueued)
+        .thenComparingInt(Candidate::getEffectiveRunning)
         .thenComparing(
             Comparator.comparingInt(
                 (Candidate candidate) -> value(candidate.getNode().getWeight(), 100))
@@ -266,9 +297,12 @@ public class OfflineWorkerScheduler {
       item.put("score", candidate.getScore());
       item.put("reason", candidate.getRejectionReason());
       item.put("weight", value(node.getWeight(), 100));
-      item.put("runningJobs", value(node.getRunningJobs(), 0));
+      item.put("reportedRunningJobs", value(node.getRunningJobs(), 0));
+      item.put("reportedQueuedJobs", value(node.getQueuedJobs(), 0));
+      item.put("controlPlaneActive", candidate.getControlPlaneActive());
+      item.put("effectiveRunningJobs", candidate.getEffectiveRunning());
+      item.put("effectiveQueuedJobs", candidate.getEffectiveQueued());
       item.put("maxConcurrentJobs", value(node.getMaxConcurrentJobs(), 1));
-      item.put("queuedJobs", value(node.getQueuedJobs(), 0));
       item.put("maxQueuedJobs", value(node.getMaxQueuedJobs(), 0));
       item.put("labels", candidate.getNodeLabels());
       snapshot.add(item);
@@ -405,6 +439,9 @@ public class OfflineWorkerScheduler {
     private double totalHeadroom;
     private String rejectionReason;
     private Map<String, String> nodeLabels = Collections.emptyMap();
+    private int controlPlaneActive;
+    private int effectiveRunning;
+    private int effectiveQueued;
 
     private Candidate(NodeRecord node) {
       this.node = node;
@@ -437,5 +474,11 @@ public class OfflineWorkerScheduler {
     private double getTotalHeadroom() { return totalHeadroom; }
     private String getRejectionReason() { return rejectionReason; }
     private Map<String, String> getNodeLabels() { return nodeLabels; }
+    private int getControlPlaneActive() { return controlPlaneActive; }
+    private void setControlPlaneActive(int value) { this.controlPlaneActive = value; }
+    private int getEffectiveRunning() { return effectiveRunning; }
+    private void setEffectiveRunning(int value) { this.effectiveRunning = value; }
+    private int getEffectiveQueued() { return effectiveQueued; }
+    private void setEffectiveQueued(int value) { this.effectiveQueued = value; }
   }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/resources/db/migration/yak-offline-sync/V7__add_multi_worker_scheduling.sql
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/resources/db/migration/yak-offline-sync/V7__add_multi_worker_scheduling.sql
@@ -7,7 +7,10 @@ ALTER TABLE yak_offline_job_definition
         COMMENT 'MANUAL 模式指定的稳定 Worker nodeId' AFTER worker_select_mode,
     ADD COLUMN worker_required_labels_json TEXT NULL
         COMMENT 'AUTO/MANUAL 模式要求的 Worker 标签 JSON' AFTER worker_node_id,
-    ADD INDEX idx_yak_offline_definition_worker (worker_select_mode, worker_node_id);
+    ADD INDEX idx_yak_offline_definition_worker (worker_select_mode, worker_node_id),
+    ADD CONSTRAINT fk_yak_offline_definition_worker
+        FOREIGN KEY (worker_node_id) REFERENCES yak_offline_engine_node (node_id)
+        ON UPDATE CASCADE ON DELETE RESTRICT;
 
 UPDATE yak_offline_job_definition
 SET worker_select_mode = 'AUTO'

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/resources/db/migration/yak-offline-sync/V7__add_multi_worker_scheduling.sql
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/resources/db/migration/yak-offline-sync/V7__add_multi_worker_scheduling.sql
@@ -1,0 +1,28 @@
+-- Persist task-level Worker policies and execution-level assignment snapshots.
+
+ALTER TABLE yak_offline_job_definition
+    ADD COLUMN worker_select_mode VARCHAR(16) NOT NULL DEFAULT 'AUTO'
+        COMMENT 'Worker 选择模式：AUTO/MANUAL' AFTER env_json,
+    ADD COLUMN worker_node_id VARCHAR(128) NULL
+        COMMENT 'MANUAL 模式指定的稳定 Worker nodeId' AFTER worker_select_mode,
+    ADD COLUMN worker_required_labels_json TEXT NULL
+        COMMENT 'AUTO/MANUAL 模式要求的 Worker 标签 JSON' AFTER worker_node_id,
+    ADD INDEX idx_yak_offline_definition_worker (worker_select_mode, worker_node_id);
+
+UPDATE yak_offline_job_definition
+SET worker_select_mode = 'AUTO'
+WHERE worker_select_mode IS NULL OR worker_select_mode = '';
+
+ALTER TABLE yak_offline_job_execution
+    ADD COLUMN engine_node_base_url VARCHAR(500) NULL
+        COMMENT '本次执行固化的 Worker 地址' AFTER engine_node_id,
+    ADD COLUMN assignment_mode VARCHAR(16) NULL
+        COMMENT '本次分配模式：AUTO/MANUAL' AFTER worker_instance_id,
+    ADD COLUMN assignment_score DECIMAL(12, 6) NULL
+        COMMENT '自动调度得分' AFTER assignment_mode,
+    ADD COLUMN assignment_reason VARCHAR(1000) NULL
+        COMMENT 'Worker 分配原因' AFTER assignment_score,
+    ADD COLUMN assignment_candidates_json LONGTEXT NULL
+        COMMENT '分配时的候选 Worker 快照' AFTER assignment_reason,
+    ADD INDEX idx_yak_offline_execution_worker_route
+        (engine_node_id, status, last_sync_time);

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/worker/OfflineWorkerSchedulerTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/worker/OfflineWorkerSchedulerTest.java
@@ -7,13 +7,16 @@ import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.yak.ops.business.sync.offline.config.OfflineSyncProperties;
+import io.yak.ops.business.sync.offline.repository.OfflineExecutionControlRepository;
 import io.yak.ops.business.sync.offline.repository.OfflineNodeRepository;
 import io.yak.ops.business.sync.offline.repository.OfflineNodeRepository.NodeRecord;
 import io.yak.ops.business.sync.offline.service.OfflineWorkerRegistry;
 import io.yak.ops.business.sync.offline.worker.OfflineWorkerScheduler.Assignment;
 import io.yak.ops.common.bean.po.sync.offline.OfflineJobDefinitionPO;
 import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 class OfflineWorkerSchedulerTest {
@@ -21,8 +24,9 @@ class OfflineWorkerSchedulerTest {
   @Test
   void autoModeFiltersLabelsAndChoosesWorkerWithMoreHeadroom() {
     OfflineNodeRepository repository = mock(OfflineNodeRepository.class);
+    OfflineExecutionControlRepository executionRepository = executionRepository();
     OfflineWorkerRegistry registry = mock(OfflineWorkerRegistry.class);
-    OfflineWorkerScheduler scheduler = scheduler(repository, registry);
+    OfflineWorkerScheduler scheduler = scheduler(repository, executionRepository, registry);
 
     NodeRecord busy = worker(
         "worker-busy", "{\"region\":\"south\"}", 8, 10, 2, 10, 900);
@@ -30,7 +34,7 @@ class OfflineWorkerSchedulerTest {
         "worker-idle", "{\"region\":\"south\"}", 1, 10, 0, 10, 100);
     NodeRecord otherRegion = worker(
         "worker-north", "{\"region\":\"north\"}", 0, 10, 0, 10, 1000);
-    when(repository.listAll()).thenReturn(List.of(busy, idle, otherRegion));
+    when(repository.listAllForScheduling()).thenReturn(List.of(busy, idle, otherRegion));
 
     OfflineJobDefinitionPO definition = definition("AUTO", null, "{\"region\":\"south\"}");
     Assignment assignment = scheduler.select(definition);
@@ -46,16 +50,39 @@ class OfflineWorkerSchedulerTest {
   }
 
   @Test
+  void controlPlaneOccupancyPreventsHeartbeatLagOverbooking() {
+    OfflineNodeRepository repository = mock(OfflineNodeRepository.class);
+    OfflineExecutionControlRepository executionRepository =
+        mock(OfflineExecutionControlRepository.class);
+    OfflineWorkerRegistry registry = mock(OfflineWorkerRegistry.class);
+    OfflineWorkerScheduler scheduler = scheduler(repository, executionRepository, registry);
+
+    NodeRecord first = worker("worker-a", "{}", 0, 4, 0, 4, 100);
+    NodeRecord second = worker("worker-b", "{}", 0, 4, 0, 4, 100);
+    when(repository.listAllForScheduling()).thenReturn(List.of(first, second));
+    when(executionRepository.countActiveExecutionsByNode())
+        .thenReturn(Map.of("worker-a", 4));
+
+    Assignment assignment = scheduler.select(definition("AUTO", null, "{}"));
+
+    assertThat(assignment.getNode().getNodeId()).isEqualTo("worker-b");
+    assertThat(assignment.getCandidatesJson())
+        .contains("\"controlPlaneActive\":4")
+        .contains("\"nodeId\":\"worker-a\"");
+  }
+
+  @Test
   void manualModeNeverFallsBackToAnotherWorker() {
     OfflineNodeRepository repository = mock(OfflineNodeRepository.class);
+    OfflineExecutionControlRepository executionRepository = executionRepository();
     OfflineWorkerRegistry registry = mock(OfflineWorkerRegistry.class);
-    OfflineWorkerScheduler scheduler = scheduler(repository, registry);
+    OfflineWorkerScheduler scheduler = scheduler(repository, executionRepository, registry);
 
     NodeRecord selected = worker(
         "worker-manual", "{}", 2, 2, 2, 2, 100);
     NodeRecord spare = worker(
         "worker-spare", "{}", 0, 10, 0, 10, 100);
-    when(repository.listAll()).thenReturn(List.of(selected, spare));
+    when(repository.listAllForScheduling()).thenReturn(List.of(selected, spare));
 
     OfflineJobDefinitionPO definition = definition("MANUAL", "worker-manual", "{}");
 
@@ -68,14 +95,15 @@ class OfflineWorkerSchedulerTest {
   @Test
   void manualModeMarksSelectedWorkerInAuditSnapshot() {
     OfflineNodeRepository repository = mock(OfflineNodeRepository.class);
+    OfflineExecutionControlRepository executionRepository = executionRepository();
     OfflineWorkerRegistry registry = mock(OfflineWorkerRegistry.class);
-    OfflineWorkerScheduler scheduler = scheduler(repository, registry);
+    OfflineWorkerScheduler scheduler = scheduler(repository, executionRepository, registry);
 
     NodeRecord selected = worker(
         "worker-manual", "{}", 0, 4, 0, 4, 100);
     NodeRecord spare = worker(
         "worker-spare", "{}", 0, 8, 0, 8, 1000);
-    when(repository.listAll()).thenReturn(List.of(selected, spare));
+    when(repository.listAllForScheduling()).thenReturn(List.of(selected, spare));
 
     Assignment assignment = scheduler.select(
         definition("MANUAL", "worker-manual", "{}"));
@@ -89,12 +117,13 @@ class OfflineWorkerSchedulerTest {
   @Test
   void rejectsStaleWorkerEvenWhenItReportsUp() {
     OfflineNodeRepository repository = mock(OfflineNodeRepository.class);
+    OfflineExecutionControlRepository executionRepository = executionRepository();
     OfflineWorkerRegistry registry = mock(OfflineWorkerRegistry.class);
-    OfflineWorkerScheduler scheduler = scheduler(repository, registry);
+    OfflineWorkerScheduler scheduler = scheduler(repository, executionRepository, registry);
 
     NodeRecord stale = worker("worker-stale", "{}", 0, 4, 0, 4, 100);
     stale.setLastHeartbeatTime(LocalDateTime.now().minusMinutes(10));
-    when(repository.listAll()).thenReturn(List.of(stale));
+    when(repository.listAllForScheduling()).thenReturn(List.of(stale));
 
     assertThatThrownBy(() -> scheduler.select(definition("AUTO", null, "{}")))
         .isInstanceOf(IllegalStateException.class)
@@ -104,27 +133,37 @@ class OfflineWorkerSchedulerTest {
   @Test
   void invalidDefaultConfigurationDoesNotBlockManualWorkers() {
     OfflineNodeRepository repository = mock(OfflineNodeRepository.class);
+    OfflineExecutionControlRepository executionRepository = executionRepository();
     OfflineWorkerRegistry registry = mock(OfflineWorkerRegistry.class);
-    OfflineWorkerScheduler scheduler = scheduler(repository, registry);
+    OfflineWorkerScheduler scheduler = scheduler(repository, executionRepository, registry);
 
     NodeRecord manual = worker("worker-manual", "{}", 0, 4, 0, 4, 100);
     when(registry.ensureConfiguredWorker())
         .thenThrow(new IllegalArgumentException("bad default worker url"));
-    when(repository.listAll()).thenReturn(List.of(manual));
+    when(repository.listAllForScheduling()).thenReturn(List.of(manual));
 
     Assignment assignment = scheduler.select(definition("AUTO", null, "{}"));
 
     assertThat(assignment.getNode().getNodeId()).isEqualTo("worker-manual");
   }
 
+  private OfflineExecutionControlRepository executionRepository() {
+    OfflineExecutionControlRepository repository =
+        mock(OfflineExecutionControlRepository.class);
+    when(repository.countActiveExecutionsByNode()).thenReturn(Collections.emptyMap());
+    return repository;
+  }
+
   private OfflineWorkerScheduler scheduler(
       OfflineNodeRepository repository,
+      OfflineExecutionControlRepository executionRepository,
       OfflineWorkerRegistry registry) {
     OfflineSyncProperties properties = new OfflineSyncProperties();
     properties.getControl().setHeartbeatDelayMillis(10_000L);
     properties.getControl().setLostAfterMillis(120_000L);
     return new OfflineWorkerScheduler(
         repository,
+        executionRepository,
         registry,
         properties,
         new ObjectMapper().findAndRegisterModules());

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/worker/OfflineWorkerSchedulerTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/worker/OfflineWorkerSchedulerTest.java
@@ -41,7 +41,8 @@ class OfflineWorkerSchedulerTest {
     assertThat(assignment.getCandidatesJson())
         .contains("worker-idle")
         .contains("worker-busy")
-        .contains("缺少标签 region=south");
+        .contains("缺少标签 region=south")
+        .contains("\"selected\":true");
   }
 
   @Test
@@ -65,6 +66,27 @@ class OfflineWorkerSchedulerTest {
   }
 
   @Test
+  void manualModeMarksSelectedWorkerInAuditSnapshot() {
+    OfflineNodeRepository repository = mock(OfflineNodeRepository.class);
+    OfflineWorkerRegistry registry = mock(OfflineWorkerRegistry.class);
+    OfflineWorkerScheduler scheduler = scheduler(repository, registry);
+
+    NodeRecord selected = worker(
+        "worker-manual", "{}", 0, 4, 0, 4, 100);
+    NodeRecord spare = worker(
+        "worker-spare", "{}", 0, 8, 0, 8, 1000);
+    when(repository.listAll()).thenReturn(List.of(selected, spare));
+
+    Assignment assignment = scheduler.select(
+        definition("MANUAL", "worker-manual", "{}"));
+
+    assertThat(assignment.getNode().getNodeId()).isEqualTo("worker-manual");
+    assertThat(assignment.getCandidatesJson())
+        .contains("\"nodeId\":\"worker-manual\"")
+        .contains("\"selected\":true");
+  }
+
+  @Test
   void rejectsStaleWorkerEvenWhenItReportsUp() {
     OfflineNodeRepository repository = mock(OfflineNodeRepository.class);
     OfflineWorkerRegistry registry = mock(OfflineWorkerRegistry.class);
@@ -77,6 +99,22 @@ class OfflineWorkerSchedulerTest {
     assertThatThrownBy(() -> scheduler.select(definition("AUTO", null, "{}")))
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("节点心跳已过期");
+  }
+
+  @Test
+  void invalidDefaultConfigurationDoesNotBlockManualWorkers() {
+    OfflineNodeRepository repository = mock(OfflineNodeRepository.class);
+    OfflineWorkerRegistry registry = mock(OfflineWorkerRegistry.class);
+    OfflineWorkerScheduler scheduler = scheduler(repository, registry);
+
+    NodeRecord manual = worker("worker-manual", "{}", 0, 4, 0, 4, 100);
+    when(registry.ensureConfiguredWorker())
+        .thenThrow(new IllegalArgumentException("bad default worker url"));
+    when(repository.listAll()).thenReturn(List.of(manual));
+
+    Assignment assignment = scheduler.select(definition("AUTO", null, "{}"));
+
+    assertThat(assignment.getNode().getNodeId()).isEqualTo("worker-manual");
   }
 
   private OfflineWorkerScheduler scheduler(

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/worker/OfflineWorkerSchedulerTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/worker/OfflineWorkerSchedulerTest.java
@@ -1,0 +1,133 @@
+package io.yak.ops.business.sync.offline.worker;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.sync.offline.config.OfflineSyncProperties;
+import io.yak.ops.business.sync.offline.repository.OfflineNodeRepository;
+import io.yak.ops.business.sync.offline.repository.OfflineNodeRepository.NodeRecord;
+import io.yak.ops.business.sync.offline.service.OfflineWorkerRegistry;
+import io.yak.ops.business.sync.offline.worker.OfflineWorkerScheduler.Assignment;
+import io.yak.ops.common.bean.po.sync.offline.OfflineJobDefinitionPO;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class OfflineWorkerSchedulerTest {
+
+  @Test
+  void autoModeFiltersLabelsAndChoosesWorkerWithMoreHeadroom() {
+    OfflineNodeRepository repository = mock(OfflineNodeRepository.class);
+    OfflineWorkerRegistry registry = mock(OfflineWorkerRegistry.class);
+    OfflineWorkerScheduler scheduler = scheduler(repository, registry);
+
+    NodeRecord busy = worker(
+        "worker-busy", "{\"region\":\"south\"}", 8, 10, 2, 10, 900);
+    NodeRecord idle = worker(
+        "worker-idle", "{\"region\":\"south\"}", 1, 10, 0, 10, 100);
+    NodeRecord otherRegion = worker(
+        "worker-north", "{\"region\":\"north\"}", 0, 10, 0, 10, 1000);
+    when(repository.listAll()).thenReturn(List.of(busy, idle, otherRegion));
+
+    OfflineJobDefinitionPO definition = definition("AUTO", null, "{\"region\":\"south\"}");
+    Assignment assignment = scheduler.select(definition);
+
+    assertThat(assignment.getNode().getNodeId()).isEqualTo("worker-idle");
+    assertThat(assignment.getMode()).isEqualTo("AUTO");
+    assertThat(assignment.getReason()).contains("即时并发余量");
+    assertThat(assignment.getCandidatesJson())
+        .contains("worker-idle")
+        .contains("worker-busy")
+        .contains("缺少标签 region=south");
+  }
+
+  @Test
+  void manualModeNeverFallsBackToAnotherWorker() {
+    OfflineNodeRepository repository = mock(OfflineNodeRepository.class);
+    OfflineWorkerRegistry registry = mock(OfflineWorkerRegistry.class);
+    OfflineWorkerScheduler scheduler = scheduler(repository, registry);
+
+    NodeRecord selected = worker(
+        "worker-manual", "{}", 2, 2, 2, 2, 100);
+    NodeRecord spare = worker(
+        "worker-spare", "{}", 0, 10, 0, 10, 100);
+    when(repository.listAll()).thenReturn(List.of(selected, spare));
+
+    OfflineJobDefinitionPO definition = definition("MANUAL", "worker-manual", "{}");
+
+    assertThatThrownBy(() -> scheduler.select(definition))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("指定的 Link-Up Worker 当前不可调度")
+        .hasMessageContaining("并发和等待队列均已满");
+  }
+
+  @Test
+  void rejectsStaleWorkerEvenWhenItReportsUp() {
+    OfflineNodeRepository repository = mock(OfflineNodeRepository.class);
+    OfflineWorkerRegistry registry = mock(OfflineWorkerRegistry.class);
+    OfflineWorkerScheduler scheduler = scheduler(repository, registry);
+
+    NodeRecord stale = worker("worker-stale", "{}", 0, 4, 0, 4, 100);
+    stale.setLastHeartbeatTime(LocalDateTime.now().minusMinutes(10));
+    when(repository.listAll()).thenReturn(List.of(stale));
+
+    assertThatThrownBy(() -> scheduler.select(definition("AUTO", null, "{}")))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("节点心跳已过期");
+  }
+
+  private OfflineWorkerScheduler scheduler(
+      OfflineNodeRepository repository,
+      OfflineWorkerRegistry registry) {
+    OfflineSyncProperties properties = new OfflineSyncProperties();
+    properties.getControl().setHeartbeatDelayMillis(10_000L);
+    properties.getControl().setLostAfterMillis(120_000L);
+    return new OfflineWorkerScheduler(
+        repository,
+        registry,
+        properties,
+        new ObjectMapper().findAndRegisterModules());
+  }
+
+  private OfflineJobDefinitionPO definition(
+      String mode,
+      String nodeId,
+      String labelsJson) {
+    OfflineJobDefinitionPO definition = new OfflineJobDefinitionPO();
+    definition.setWorkerSelectMode(mode);
+    definition.setWorkerNodeId(nodeId);
+    definition.setWorkerRequiredLabelsJson(labelsJson);
+    return definition;
+  }
+
+  private NodeRecord worker(
+      String nodeId,
+      String labelsJson,
+      int running,
+      int maxRunning,
+      int queued,
+      int maxQueued,
+      int weight) {
+    return NodeRecord.builder()
+        .nodeId(nodeId)
+        .nodeName(nodeId)
+        .baseUrl("http://" + nodeId + ":18080")
+        .registrationMode("MANUAL")
+        .enabled(true)
+        .schedulingStatus("ENABLED")
+        .weight(weight)
+        .labelsJson(labelsJson)
+        .workerInstanceId(nodeId + "-instance")
+        .offlineOnly(true)
+        .status("UP")
+        .maxConcurrentJobs(maxRunning)
+        .maxQueuedJobs(maxQueued)
+        .runningJobs(running)
+        .queuedJobs(queued)
+        .lastHeartbeatTime(LocalDateTime.now())
+        .build();
+  }
+}

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/dto/sync/offline/OfflineJobDefinitionDTO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/dto/sync/offline/OfflineJobDefinitionDTO.java
@@ -26,6 +26,10 @@ public class OfflineJobDefinitionDTO {
   private JsonNode mapping;
   private JsonNode schedule;
   private JsonNode env;
+
+  /** Worker 选择策略：mode、nodeId 和 requiredLabels。 */
+  private JsonNode worker;
+
   private String hoconConfig;
   private String jobDefinitionInfo;
   private String script;

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/sync/offline/OfflineJobDefinitionPO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/sync/offline/OfflineJobDefinitionPO.java
@@ -62,6 +62,13 @@ public class OfflineJobDefinitionPO {
   @TableField(updateStrategy = FieldStrategy.ALWAYS)
   private String envJson;
 
+  private String workerSelectMode;
+  @TableField(updateStrategy = FieldStrategy.ALWAYS)
+  private String workerNodeId;
+  @ToString.Exclude
+  @TableField(updateStrategy = FieldStrategy.ALWAYS)
+  private String workerRequiredLabelsJson;
+
   private Integer version;
   private Long currentVersionId;
   private Long lastExecutionId;

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/sync/offline/OfflineJobExecutionPO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/sync/offline/OfflineJobExecutionPO.java
@@ -22,10 +22,18 @@ public class OfflineJobExecutionPO {
   private Long definitionVersionId;
   private Integer definitionVersion;
   private String engineNodeId;
+  private String engineNodeBaseUrl;
   private String engineJobId;
   private String externalExecutionId;
   private String idempotencyKey;
   private String workerInstanceId;
+  private String assignmentMode;
+  private Double assignmentScore;
+  private String assignmentReason;
+
+  @ToString.Exclude
+  private String assignmentCandidatesJson;
+
   private String status;
   private Long stateVersion;
   private Integer attemptNo;

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/vo/sync/offline/OfflineJobDefinitionVO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/vo/sync/offline/OfflineJobDefinitionVO.java
@@ -1,5 +1,6 @@
 package io.yak.ops.common.bean.vo.sync.offline;
 
+import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -30,6 +31,10 @@ public class OfflineJobDefinitionVO {
   private String sinkDatasourceName;
   private String sourceTable;
   private String sinkTable;
+  private String workerSelectMode;
+  private String workerNodeId;
+  private String workerNodeName;
+  private Map<String, String> workerRequiredLabels;
   private String lastJobStatus;
   private String lastErrorMessage;
   private Long instanceId;

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/vo/sync/offline/OfflineJobExecutionVO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/vo/sync/offline/OfflineJobExecutionVO.java
@@ -21,9 +21,13 @@ public class OfflineJobExecutionVO {
   private Long definitionVersionId;
   private Integer definitionVersion;
   private String engineNodeId;
+  private String engineNodeBaseUrl;
   private String engineJobId;
   private String externalExecutionId;
   private String workerInstanceId;
+  private String assignmentMode;
+  private Double assignmentScore;
+  private String assignmentReason;
   private String status;
   private Long stateVersion;
   private Integer attemptNo;

--- a/yak-ops-ui/src/pages/batch-link-up/api.ts
+++ b/yak-ops-ui/src/pages/batch-link-up/api.ts
@@ -42,6 +42,10 @@ export interface OfflineJobDefinitionVO extends LinkupJobDefinition {
   sinkDatasourceName?: string;
   sourceTable?: string;
   sinkTable?: string;
+  workerSelectMode?: 'AUTO' | 'MANUAL';
+  workerNodeId?: string;
+  workerNodeName?: string;
+  workerRequiredLabels?: Record<string, string>;
   lastJobStatus?: string;
   lastErrorMessage?: string;
   instanceId?: string | number;
@@ -60,7 +64,14 @@ export interface OfflineJobDefinitionVO extends LinkupJobDefinition {
 export interface OfflineJobExecutionVO {
   id: string | number;
   jobDefinitionId: string | number;
+  engineNodeId?: string;
+  engineNodeBaseUrl?: string;
   engineJobId?: string;
+  externalExecutionId?: string;
+  workerInstanceId?: string;
+  assignmentMode?: 'AUTO' | 'MANUAL';
+  assignmentScore?: number;
+  assignmentReason?: string;
   status?: string;
   errorMessage?: string;
   sourceRecordCount: number;

--- a/yak-ops-ui/src/pages/batch-link-up/detail/components/SyncTaskEditor.tsx
+++ b/yak-ops-ui/src/pages/batch-link-up/detail/components/SyncTaskEditor.tsx
@@ -15,6 +15,7 @@ import ConnectorExtraParams from './ConnectorExtraParams';
 import MultiTableConfigSection from './MultiTableConfigSection';
 import SingleTableConfigSection from './SingleTableConfigSection';
 import TaskBasicSection from './TaskBasicSection';
+import WorkerSchedulingSection from './WorkerSchedulingSection';
 
 interface SyncTaskEditorProps {
   editor: SyncEditorState;
@@ -144,6 +145,11 @@ export default function SyncTaskEditor({
         editor={editor}
         dataSources={dataSources}
         dataSourceLoading={dataSourceLoading}
+        onChange={onChange}
+      />
+
+      <WorkerSchedulingSection
+        editor={editor}
         onChange={onChange}
       />
 

--- a/yak-ops-ui/src/pages/batch-link-up/detail/components/WorkerSchedulingSection.tsx
+++ b/yak-ops-ui/src/pages/batch-link-up/detail/components/WorkerSchedulingSection.tsx
@@ -73,6 +73,7 @@ export default function WorkerSchedulingSection({
   const selectOptions = useMemo(
     () => workers.map((worker) => ({
       value: worker.value,
+      title: worker.label,
       label: (
         <div className="flex min-w-0 items-center justify-between gap-3">
           <span className="truncate">{worker.label}</span>
@@ -168,7 +169,7 @@ export default function WorkerSchedulingSection({
               value={editor.worker.nodeId}
               loading={loading}
               options={selectOptions}
-              optionFilterProp="label"
+              optionFilterProp="title"
               placeholder="请选择 Link-Up Worker"
               className="w-full"
               onDropdownVisibleChange={(open) => {
@@ -207,7 +208,7 @@ export default function WorkerSchedulingSection({
         <EditorField label="Worker 标签约束">
           <div className="space-y-2">
             {editor.worker.requiredLabels.map((label, index) => (
-              <Space.Compact key={`${index}-${label.key}`} block>
+              <Space.Compact key={index} block>
                 <Input
                   variant="filled"
                   value={label.key}

--- a/yak-ops-ui/src/pages/batch-link-up/detail/components/WorkerSchedulingSection.tsx
+++ b/yak-ops-ui/src/pages/batch-link-up/detail/components/WorkerSchedulingSection.tsx
@@ -1,0 +1,264 @@
+import {
+  ApartmentOutlined,
+  DeleteOutlined,
+  PlusOutlined,
+} from '@ant-design/icons';
+import {
+  Alert,
+  Button,
+  Input,
+  Segmented,
+  Select,
+  Space,
+  Tag,
+} from 'antd';
+import { useEffect, useMemo, useState } from 'react';
+
+import {
+  linkupClientApi,
+  type LinkupClientOption,
+} from '@/pages/client/api';
+import { API_SUCCESS_CODE } from '@/services/http/response';
+
+import type {
+  SyncEditorState,
+  WorkerLabelRequirement,
+  WorkerSelectMode,
+} from '../model';
+import EditorSection, { EditorField } from './EditorSection';
+
+interface WorkerSchedulingSectionProps {
+  editor: SyncEditorState;
+  onChange: (value: SyncEditorState) => void;
+}
+
+const statusText = (worker: LinkupClientOption) => {
+  if (worker.schedulingStatus === 'DRAINING') return '排空中';
+  if (worker.schedulingStatus === 'DISABLED') return '已禁用';
+  if (worker.status !== 'UP') return '离线';
+  return worker.available ? '可调度' : '容量已满';
+};
+
+export default function WorkerSchedulingSection({
+  editor,
+  onChange,
+}: WorkerSchedulingSectionProps) {
+  const [workers, setWorkers] = useState<LinkupClientOption[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [loadError, setLoadError] = useState('');
+
+  const loadWorkers = async () => {
+    try {
+      setLoading(true);
+      setLoadError('');
+      const response = await linkupClientApi.option();
+      if (response?.code !== API_SUCCESS_CODE) {
+        setWorkers([]);
+        setLoadError(response?.message || response?.msg || '获取 Worker 列表失败');
+        return;
+      }
+      setWorkers(response?.data || []);
+    } catch (error: any) {
+      setWorkers([]);
+      setLoadError(error?.message || '获取 Worker 列表失败');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    void loadWorkers();
+  }, []);
+
+  const selectOptions = useMemo(
+    () => workers.map((worker) => ({
+      value: worker.value,
+      label: (
+        <div className="flex min-w-0 items-center justify-between gap-3">
+          <span className="truncate">{worker.label}</span>
+          <span className="shrink-0 text-[11px] text-[#98a2b3]">
+            {worker.runningJobs || 0}/{worker.maxConcurrentJobs || 0} 运行 ·{' '}
+            {worker.queuedJobs || 0}/{worker.maxQueuedJobs || 0} 排队 ·{' '}
+            {statusText(worker)}
+          </span>
+        </div>
+      ),
+    })),
+    [workers],
+  );
+
+  const selectedWorker = workers.find(
+    (worker) => worker.value === editor.worker.nodeId,
+  );
+
+  const updateWorker = (
+    patch: Partial<SyncEditorState['worker']>,
+  ) => {
+    onChange({
+      ...editor,
+      worker: {
+        ...editor.worker,
+        ...patch,
+      },
+    });
+  };
+
+  const updateMode = (mode: WorkerSelectMode) => {
+    updateWorker({
+      mode,
+      nodeId: mode === 'MANUAL' ? editor.worker.nodeId : undefined,
+    });
+  };
+
+  const updateLabel = (
+    index: number,
+    patch: Partial<WorkerLabelRequirement>,
+  ) => {
+    updateWorker({
+      requiredLabels: editor.worker.requiredLabels.map((label, current) =>
+        current === index ? { ...label, ...patch } : label,
+      ),
+    });
+  };
+
+  const removeLabel = (index: number) => {
+    updateWorker({
+      requiredLabels: editor.worker.requiredLabels.filter(
+        (_, current) => current !== index,
+      ),
+    });
+  };
+
+  const addLabel = () => {
+    updateWorker({
+      requiredLabels: [
+        ...editor.worker.requiredLabels,
+        { key: '', value: '' },
+      ],
+    });
+  };
+
+  return (
+    <EditorSection title="执行节点调度">
+      <div className="space-y-5">
+        <EditorField label="选择方式" required>
+          <Segmented
+            block
+            value={editor.worker.mode}
+            options={[
+              {
+                value: 'AUTO',
+                label: '自动分配',
+              },
+              {
+                value: 'MANUAL',
+                label: '指定节点',
+              },
+            ]}
+            onChange={(value) => updateMode(value as WorkerSelectMode)}
+          />
+        </EditorField>
+
+        {editor.worker.mode === 'MANUAL' ? (
+          <EditorField label="执行 Worker" required>
+            <Select
+              showSearch
+              allowClear
+              variant="filled"
+              value={editor.worker.nodeId}
+              loading={loading}
+              options={selectOptions}
+              optionFilterProp="label"
+              placeholder="请选择 Link-Up Worker"
+              className="w-full"
+              onDropdownVisibleChange={(open) => {
+                if (open && workers.length === 0) void loadWorkers();
+              }}
+              onChange={(nodeId) => updateWorker({ nodeId })}
+            />
+
+            {selectedWorker ? (
+              <div className="mt-2 flex flex-wrap items-center gap-2 text-[12px] text-[#667085]">
+                <Tag className="!m-0">{selectedWorker.status || 'UNKNOWN'}</Tag>
+                <Tag className="!m-0">
+                  {selectedWorker.schedulingStatus || 'UNKNOWN'}
+                </Tag>
+                <span>
+                  运行 {selectedWorker.runningJobs || 0}/
+                  {selectedWorker.maxConcurrentJobs || 0}
+                </span>
+                <span>
+                  排队 {selectedWorker.queuedJobs || 0}/
+                  {selectedWorker.maxQueuedJobs || 0}
+                </span>
+              </div>
+            ) : null}
+          </EditorField>
+        ) : (
+          <Alert
+            type="info"
+            showIcon
+            icon={<ApartmentOutlined />}
+            message="自动调度会先做硬过滤，再按负载与权重评分"
+            description="只选择在线、心跳有效、允许调度、标签匹配且容量未满的 Worker；即时并发余量占 55%，总容量余量占 35%，管理权重占 10%。"
+          />
+        )}
+
+        <EditorField label="Worker 标签约束">
+          <div className="space-y-2">
+            {editor.worker.requiredLabels.map((label, index) => (
+              <Space.Compact key={`${index}-${label.key}`} block>
+                <Input
+                  variant="filled"
+                  value={label.key}
+                  placeholder="标签名，例如 region"
+                  onChange={(event) =>
+                    updateLabel(index, { key: event.target.value })
+                  }
+                />
+                <Input
+                  variant="filled"
+                  value={label.value}
+                  placeholder="标签值，例如 south-china"
+                  onChange={(event) =>
+                    updateLabel(index, { value: event.target.value })
+                  }
+                />
+                <Button
+                  danger
+                  icon={<DeleteOutlined />}
+                  onClick={() => removeLabel(index)}
+                />
+              </Space.Compact>
+            ))}
+
+            <Button
+              type="dashed"
+              block
+              icon={<PlusOutlined />}
+              onClick={addLabel}
+            >
+              添加标签约束
+            </Button>
+          </div>
+          <div className="mt-2 text-[12px] leading-5 text-[#98a2b3]">
+            标签采用精确匹配。自动模式用于筛选候选节点；指定节点模式也会校验所选 Worker 是否满足标签。
+          </div>
+        </EditorField>
+
+        {loadError ? (
+          <Alert
+            type="warning"
+            showIcon
+            message={loadError}
+            action={
+              <Button size="small" onClick={() => void loadWorkers()}>
+                重试
+              </Button>
+            }
+          />
+        ) : null}
+      </div>
+    </EditorSection>
+  );
+}

--- a/yak-ops-ui/src/pages/batch-link-up/detail/index.tsx
+++ b/yak-ops-ui/src/pages/batch-link-up/detail/index.tsx
@@ -33,6 +33,22 @@ const validateTaskConfig = (
     return '请输入任务名称';
   }
 
+  if (editor.worker.mode === 'MANUAL' && !editor.worker.nodeId) {
+    return '指定节点模式需要选择执行 Worker';
+  }
+
+  const workerLabelKeys = new Set<string>();
+  for (const label of editor.worker.requiredLabels) {
+    const key = label.key.trim();
+    if (!key) {
+      return 'Worker 标签约束的标签名不能为空';
+    }
+    if (workerLabelKeys.has(key)) {
+      return `Worker 标签约束存在重复标签：${key}`;
+    }
+    workerLabelKeys.add(key);
+  }
+
   if (!editor.basic.sourceDataSourceId) {
     return '请选择来源数据源';
   }

--- a/yak-ops-ui/src/pages/batch-link-up/detail/model.ts
+++ b/yak-ops-ui/src/pages/batch-link-up/detail/model.ts
@@ -3,6 +3,18 @@ import { API_SUCCESS_CODE } from '@/services/http/response';
 
 export type SyncMode = 'GUIDE_SINGLE' | 'GUIDE_MULTI';
 export type EndpointKind = 'source' | 'sink';
+export type WorkerSelectMode = 'AUTO' | 'MANUAL';
+
+export interface WorkerLabelRequirement {
+  key: string;
+  value: string;
+}
+
+export interface WorkerSelectionConfig {
+  mode: WorkerSelectMode;
+  nodeId?: string;
+  requiredLabels: WorkerLabelRequirement[];
+}
 
 export interface ScheduleParam {
   name: string;
@@ -76,6 +88,7 @@ export interface SyncEditorState {
   workflow: SyncWorkflow;
   schedule: ScheduleConfig;
   env: EnvConfig;
+  worker: WorkerSelectionConfig;
   state?: Record<string, any>;
 }
 
@@ -121,6 +134,12 @@ export const DEFAULT_SCHEDULE_CONFIG: ScheduleConfig = {
 export const DEFAULT_ENV_CONFIG: EnvConfig = {
   jobMode: 'BATCH',
   parallelism: 1,
+};
+
+export const DEFAULT_WORKER_SELECTION: WorkerSelectionConfig = {
+  mode: 'AUTO',
+  nodeId: undefined,
+  requiredLabels: [],
 };
 
 export const isApiSuccess = (response: any): boolean =>
@@ -260,6 +279,7 @@ export const buildCreatePayload = (
     workflow: buildDirectWorkflow(taskId),
     schedule: DEFAULT_SCHEDULE_CONFIG,
     env: DEFAULT_ENV_CONFIG,
+    worker: DEFAULT_WORKER_SELECTION,
   };
 };
 
@@ -285,6 +305,22 @@ const mergeSchedule = (
     ...(schedule?.weeklyValue || {}),
   },
 });
+
+const normalizeRequiredLabels = (
+  value?: Record<string, unknown> | WorkerLabelRequirement[],
+): WorkerLabelRequirement[] => {
+  if (Array.isArray(value)) {
+    return value.map((item) => ({
+      key: String(item?.key || ''),
+      value: String(item?.value || ''),
+    }));
+  }
+
+  return Object.entries(value || {}).map(([key, labelValue]) => ({
+    key,
+    value: String(labelValue ?? ''),
+  }));
+};
 
 export const normalizeEditDetail = (
   raw: any,
@@ -317,6 +353,9 @@ export const normalizeEditDetail = (
           },
         }
       : buildDirectWorkflow(id);
+
+  const workerRaw = raw?.worker || {};
+  const workerMode = String(workerRaw?.mode || 'AUTO').toUpperCase() as WorkerSelectMode;
 
   return {
     id,
@@ -355,6 +394,11 @@ export const normalizeEditDetail = (
       ...DEFAULT_ENV_CONFIG,
       ...(raw?.env || {}),
       jobMode: 'BATCH',
+    },
+    worker: {
+      mode: workerMode === 'MANUAL' ? 'MANUAL' : 'AUTO',
+      nodeId: workerRaw?.nodeId ? String(workerRaw.nodeId) : undefined,
+      requiredLabels: normalizeRequiredLabels(workerRaw?.requiredLabels),
     },
     state: raw?.state,
   };
@@ -506,6 +550,15 @@ export const updateEndpointConfig = (
   };
 };
 
+const requiredLabelsRecord = (
+  labels: WorkerLabelRequirement[],
+): Record<string, string> =>
+  labels.reduce<Record<string, string>>((result, item) => {
+    const key = item.key.trim();
+    if (key) result[key] = item.value.trim();
+    return result;
+  }, {});
+
 export const buildSavePayload = (
   editor: SyncEditorState,
 ) => ({
@@ -518,4 +571,11 @@ export const buildSavePayload = (
   workflow: editor.workflow,
   schedule: editor.schedule,
   env: editor.env,
+  worker: {
+    mode: editor.worker.mode,
+    nodeId: editor.worker.mode === 'MANUAL'
+      ? editor.worker.nodeId
+      : undefined,
+    requiredLabels: requiredLabelsRecord(editor.worker.requiredLabels),
+  },
 });

--- a/yak-ops-ui/src/pages/batch-link-up/detail/workerScheduling.test.ts
+++ b/yak-ops-ui/src/pages/batch-link-up/detail/workerScheduling.test.ts
@@ -1,0 +1,102 @@
+import {
+  buildSavePayload,
+  normalizeEditDetail,
+} from './model';
+
+test('defaults historical task definitions to automatic scheduling', () => {
+  const editor = normalizeEditDetail(
+    {
+      id: '1001',
+      basic: {
+        jobName: '历史任务',
+        jobDesc: '',
+        mode: 'GUIDE_SINGLE',
+      },
+      workflow: {
+        nodes: [],
+        edges: [],
+      },
+    },
+    '1001',
+  );
+
+  expect(editor.worker).toEqual({
+    mode: 'AUTO',
+    nodeId: undefined,
+    requiredLabels: [],
+  });
+});
+
+test('keeps manual worker and label requirements in save payload', () => {
+  const editor = normalizeEditDetail(
+    {
+      id: '1002',
+      basic: {
+        jobName: '手动节点任务',
+        jobDesc: '固定到华南节点',
+        mode: 'GUIDE_SINGLE',
+      },
+      workflow: {
+        nodes: [],
+        edges: [],
+      },
+      worker: {
+        mode: 'MANUAL',
+        nodeId: 'worker-south-01',
+        requiredLabels: {
+          region: 'south-china',
+          storage: 'ssd',
+        },
+      },
+    },
+    '1002',
+  );
+
+  const payload = buildSavePayload(editor);
+
+  expect(editor.worker.requiredLabels).toEqual([
+    { key: 'region', value: 'south-china' },
+    { key: 'storage', value: 'ssd' },
+  ]);
+  expect(payload.worker).toEqual({
+    mode: 'MANUAL',
+    nodeId: 'worker-south-01',
+    requiredLabels: {
+      region: 'south-china',
+      storage: 'ssd',
+    },
+  });
+});
+
+test('automatic scheduling omits stale manual node id', () => {
+  const editor = normalizeEditDetail(
+    {
+      id: '1003',
+      basic: {
+        jobName: '自动节点任务',
+        jobDesc: '',
+        mode: 'GUIDE_MULTI',
+      },
+      workflow: {
+        nodes: [],
+        edges: [],
+      },
+      worker: {
+        mode: 'AUTO',
+        nodeId: 'legacy-manual-node',
+        requiredLabels: {
+          region: 'east-china',
+        },
+      },
+    },
+    '1003',
+  );
+
+  expect(buildSavePayload(editor).worker).toEqual({
+    mode: 'AUTO',
+    nodeId: undefined,
+    requiredLabels: {
+      region: 'east-china',
+    },
+  });
+});


### PR DESCRIPTION
## 背景

第一阶段已经完成 Link-Up Worker 的注册、验证、心跳、容量观测以及启用、排空和禁用管理。本 PR 在最新 `main` 的 Worker 管理闭环之上完成第二阶段：**离线任务多 Worker 调度**。

Yak Ops 现在可以为每个离线任务配置自动分配或指定节点，并确保提交、取消、指标查询和后台对账始终访问该执行实例实际分配的 Worker。

## 任务策略

任务定义新增：

```json
{
  "worker": {
    "mode": "AUTO",
    "requiredLabels": {
      "region": "south-china",
      "storage": "ssd"
    }
  }
}
```

手动指定：

```json
{
  "worker": {
    "mode": "MANUAL",
    "nodeId": "link-up-south-01",
    "requiredLabels": {
      "region": "south-china"
    }
  }
}
```

- `AUTO`：每个新执行和重试都重新评估当前 Worker 集合。
- `MANUAL`：严格使用指定 `nodeId`；不可用时直接失败，不擅自切换节点。
- 标签采用精确匹配，自动和手动模式都会在运行时校验。
- 历史任务默认迁移为 `AUTO`。

## 自动调度

### 硬过滤

候选 Worker 必须同时满足：

- `enabled=true`
- `schedulingStatus=ENABLED`
- `status=UP`
- `offlineOnly=true`
- 心跳未过期
- 满足全部任务标签
- 运行并发与等待队列没有同时满载

`DRAINING` 节点不接收新任务，但已有执行仍继续在原节点对账和取消。

### 评分

```text
score = runningHeadroom × 55
      + totalCapacityHeadroom × 35
      + normalizedWeight × 10
```

同分时依次选择：

1. 有效排队任务更少
2. 有效运行任务更少
3. 权重更高
4. `nodeId` 字典序更小

分配结果会持久化最终得分、选择原因以及全部候选节点和淘汰原因。

### 并发安全

仅依赖 Worker 心跳会存在负载刷新窗口，因此执行领取事务还会：

- 锁定当前任务定义，防止同一任务重复提交
- 按稳定顺序对 Worker 行执行 `SELECT ... FOR UPDATE`
- 聚合 Yak Ops 中 `CREATED / SUBMITTED / QUEUED / RUNNING` 的控制面活跃执行数
- 将控制面活跃数与 Worker 上报负载合并为保守的有效负载
- 在同一事务中完成 Worker 选择与执行实例创建

这避免了不同任务并发提交时全部基于同一份旧心跳选择同一个 Worker。

## 执行路由与可靠性

执行实例新增并固化：

- `engineNodeId`
- `engineNodeBaseUrl`
- `workerInstanceId`
- `assignmentMode`
- `assignmentScore`
- `assignmentReason`
- `assignmentCandidatesJson`

以下操作全部按执行实例固化的 Worker 地址路由：

- JobSpec 提交
- `jobId` / `externalExecutionId` 对账
- 取消任务
- pipeline、task 和 metrics 查询

可靠性约束：

- 提交出现不确定网络错误时不会立即切换节点，因为原 Worker 可能已经接收幂等请求。
- 同一次执行绝不会跨 Worker 漂移。
- Worker 进程实例变化时将原执行标记为 `LOST`。
- 重试创建新执行实例并重新执行调度。
- Worker 管理地址变更后，历史执行仍按自己的地址快照对账；只有地址一致时才比较当前 `instanceId`。
- 历史执行没有地址快照时继续兼容默认 Worker 配置。

## 数据库

Flyway V7 为任务定义增加：

- `worker_select_mode`
- `worker_node_id`
- `worker_required_labels_json`
- `worker_node_id -> yak_offline_engine_node.node_id` 外键

为执行实例增加：

- `engine_node_base_url`
- `assignment_mode`
- `assignment_score`
- `assignment_reason`
- `assignment_candidates_json`

仍被手动任务引用的 Worker 不能删除，防止产生悬空节点引用。

## 前端

离线任务编辑器新增“执行节点调度”区域：

- 自动分配 / 指定节点切换
- Worker 下拉选择
- 在线状态、调度状态、运行容量和队列容量展示
- Worker 标签约束编辑
- 手动节点必选、标签名非空和重复标签校验
- 历史任务自动兼容为 `AUTO`

## 测试

新增测试覆盖：

- 标签硬过滤与负载评分
- 控制面活跃执行对心跳延迟的容量补偿
- 手动模式不自动故障转移
- 手动候选审计快照的 selected 标记
- 心跳过期过滤
- 默认 Worker 配置异常不阻断手工 Worker
- 前端历史任务 AUTO 兼容
- MANUAL 节点和标签策略序列化往返

## 当前边界

本阶段不包含：

- CDC 或流式任务调度
- 正在运行任务的跨 Worker 迁移
- 提交不确定时的自动故障转移
- Worker 侧资源租约或分布式容量预占
- Connector 能力清单调度

## 验证说明

- 分支基于最新 `main` 合并提交 `55ac6c7d7ee0fcd380565ac7b691d57e4be92990`
- PR 创建前分支落后 `main` 为 0
- 已完成源码级依赖、路由、Flyway 顺序、手写 JDBC 映射和前后端契约审查
- 当前执行环境没有 Maven，也无法通过本地 Git 网络克隆完整仓库；前端完整依赖树同样不在本地，因此新增测试尚未在完整仓库环境执行
- 仓库 CI 应执行 Maven、Flyway、Jest、TypeScript 和生产构建验证，完成后再将本 PR 转为 Ready