### PR TITLE
feat(offline-worker): complete capability and reachability scheduling

### DIFF
--- a/docs/offline-worker-management.md
+++ b/docs/offline-worker-management.md
@@ -1,24 +1,14 @@
-# Link-Up 离线 Worker 管理与调度
+# Link-Up 离线 Worker 管理与能力调度
 
 ## 定位
 
-Yak Ops 是离线同步控制面，Link-Up Server 是可独立部署的离线执行 Worker。
+Yak Ops 是离线同步控制面，Link-Up Server 是可独立部署、可横向扩容的离线执行 Worker。
 
-Worker 管理负责：
+当前已经形成三层闭环：
 
-- 手工注册 Link-Up Worker
-- 自动登记 `application.yml` 中的默认 Worker
-- 连接验证与节点身份校验
-- 定时心跳与手工刷新
-- 版本、进程实例、并发、队列和负载展示
-- 启用、排空、禁用和删除管理
-
-多 Worker 调度负责：
-
-- 为任务配置 `AUTO` 或 `MANUAL` Worker 策略
-- 根据标签、健康状态、心跳、容量、负载和权重选择 Worker
-- 将 Worker 地址、进程实例和分配依据固化到执行实例
-- 后续提交、取消、指标查询和状态对账始终访问该执行实例的 Worker
+1. Worker 管理：注册、验证、心跳、容量、启停和排空。
+2. 多 Worker 调度：`AUTO / MANUAL`、标签、容量、权重和执行路由固化。
+3. 能力调度：逐 Worker Connector 能力快照、任务能力要求、Schema 指纹匹配和执行审计。
 
 ## Worker 状态
 
@@ -33,7 +23,13 @@ Worker 管理负责：
 - `DRAINING`：不接收新任务，保留正在运行的任务
 - `DISABLED`：不接收新任务，也不再执行定时心跳
 
-默认配置 Worker 的登记来源是 `CONFIG`，不能在页面删除或修改地址；手工节点来源是 `MANUAL`。
+能力状态：
+
+- `UNKNOWN`：尚未获取 Connector 能力
+- `READY`：已经保存可用于调度的能力快照
+- `ERROR`：最近一次同步失败；保留最后一次成功快照用于诊断，但不会参与严格能力调度
+
+只有健康、调度、容量和能力条件均满足的 Worker 才会在页面和任务节点下拉中标记为可用。
 
 ## Worker 管理 API
 
@@ -43,8 +39,6 @@ Worker 管理负责：
 /api/v1/offline/workers
 ```
 
-接口：
-
 ```http
 POST   /verify
 POST   /
@@ -53,21 +47,17 @@ GET    /{nodeId}
 POST   /page
 GET    /options
 POST   /{nodeId}/refresh
+GET    /{nodeId}/capabilities
+POST   /{nodeId}/capabilities/refresh
 PUT    /{nodeId}/scheduling-status
 DELETE /{nodeId}
 ```
 
-新增和编辑地址会请求目标 Link-Up：
-
-```http
-GET /api/v1/node
-```
-
-只有返回稳定 `nodeId` 且 `offlineOnly=true` 的节点才能登记。
+`POST /{nodeId}/refresh` 会同时刷新节点心跳和 Connector 能力；能力接口可单独查询或强制刷新能力快照。
 
 ## 任务调度策略
 
-任务定义中保存：
+自动模式：
 
 ```json
 {
@@ -81,7 +71,7 @@ GET /api/v1/node
 }
 ```
 
-手动指定节点：
+手动模式：
 
 ```json
 {
@@ -98,16 +88,99 @@ GET /api/v1/node
 规则：
 
 - `AUTO`：每次新执行或重试重新评估当前 Worker 集合。
-- `MANUAL`：严格使用指定 `nodeId`；节点不可用时直接失败，不自动切换。
+- `MANUAL`：严格使用指定 `nodeId`；节点不满足能力或运行条件时直接失败。
 - 标签采用精确匹配，手动和自动模式都会校验。
-- 已经创建的执行实例不会因为任务策略或 Worker 地址后来发生变化而漂移。
-- 手动任务通过数据库外键引用 Worker，仍被任务定义引用的节点不能删除。
+- 已创建的执行实例不会因为任务策略、Worker 地址或能力后来发生变化而漂移。
+
+## Connector 能力事实层
+
+Yak Ops 使用 Link-Up 已有协议：
+
+```http
+GET /api/v1/connectors
+GET /api/v1/connectors/{connectorId}/schema?role=SOURCE|SINK
+```
+
+每个 Worker 独立保存精简能力摘要：
+
+```json
+{
+  "nodeId": "link-up-south-01",
+  "workerInstanceId": "instance-xxx",
+  "engineVersion": "1.0.0",
+  "connectors": [
+    {
+      "connectorId": "jdbc",
+      "role": "SOURCE",
+      "schemaVersion": "1",
+      "schemaFingerprint": "sha256:...",
+      "implementationVersion": "1.0.0",
+      "capabilities": [
+        "CUSTOM_SQL",
+        "MULTI_TABLE",
+        "PARTITION_SPLIT"
+      ]
+    }
+  ]
+}
+```
+
+快照会进行规范化排序并生成 SHA-256 摘要。远程能力请求只发生在后台刷新、手工刷新或执行领取之前的预热阶段，不会发生在 Worker 行锁和任务领取事务内。
+
+默认配置：
+
+```yaml
+yak:
+  sync:
+    offline:
+      capability:
+        enabled: true
+        strict-schema-fingerprint: true
+        max-stale-millis: 900000
+        initial-delay-millis: 10000
+        refresh-delay-millis: 60000
+        worker-refresh-millis: 300000
+```
+
+## 任务能力要求
+
+Yak Ops 从不可变 JobSpec 自动派生能力要求，无需用户重复配置。
+
+固定要求：
+
+- Source Connector 与 `SOURCE` 角色
+- Sink Connector 与 `SINK` 角色
+- 保存任务版本时使用的 Schema 版本和指纹
+
+根据任务配置自动派生：
+
+| JobSpec 配置 | 所需能力 |
+|---|---|
+| Source 自定义 SQL | `CUSTOM_SQL` |
+| 多表同步 | `MULTI_TABLE` |
+| 分片字段或分片数量 | `PARTITION_SPLIT` |
+| Sink UPSERT | `UPSERT` |
+| 自动建表 | `AUTO_CREATE_TABLE` |
+| Sink 自定义 SQL | `CUSTOM_SQL` |
+| 跳过脏数据或脏数据阈值 | `DIRTY_DATA_HANDLING` |
+
+新任务版本在保存时固化能力要求。历史版本没有能力字段时，会在首次执行前从该版本的不可变 JobSpec 派生并回填，不修改 JobSpec、配置摘要或版本号。
+
+## 能力匹配
+
+调度器对每个候选 Worker 依次校验：
+
+1. 存在所需 `connectorId + role`
+2. 能力快照状态为 `READY`
+3. 快照未超过 `max-stale-millis`
+4. 严格模式下 Schema 指纹与任务版本一致
+5. Worker 声明的能力集合包含任务要求的全部能力
+
+能力不匹配属于硬过滤，不通过加权评分弥补。`MANUAL` 模式同样执行完整能力校验，不会偷偷切换到其他 Worker。
 
 ## 自动调度算法
 
-### 硬过滤
-
-候选节点必须同时满足：
+候选节点还必须满足：
 
 1. `enabled=true`
 2. `scheduling_status=ENABLED`
@@ -115,23 +188,8 @@ GET /api/v1/node
 4. `offline_only=true`
 5. 心跳未过期
 6. 满足任务要求的全部标签
-7. 运行并发和等待队列没有同时满载
-
-`DRAINING` 节点不会接收新任务，但原有执行仍继续在该节点对账和取消。
-
-### 有效负载
-
-Worker 心跳存在刷新间隔。为了避免多个任务并发提交时同时读取旧负载，执行领取事务会：
-
-1. 锁定当前任务定义，防止同一任务重复运行。
-2. 按 `nodeId` 固定顺序对全部 Worker 行执行 `SELECT ... FOR UPDATE`。
-3. 聚合 Yak Ops 数据库中 `CREATED / SUBMITTED / QUEUED / RUNNING` 的执行数。
-4. 将控制面活跃执行数与 Worker 上报的运行、排队数量取保守值。
-5. 选择 Worker 并在同一事务内插入执行实例，然后释放锁。
-
-因此，不同任务即使并发提交，也不会全部基于同一份旧心跳选择同一个 Worker。
-
-### 评分
+7. Connector 能力完全匹配
+8. 运行并发和等待队列没有同时满载
 
 通过硬过滤后计算：
 
@@ -141,30 +199,9 @@ score = runningHeadroom × 55
       + normalizedWeight × 10
 ```
 
-其中：
+执行领取事务按 `nodeId` 固定顺序锁定 Worker 行，并将数据库中的活跃执行数叠加到 Worker 心跳负载，避免并发提交基于同一份旧快照产生容量超卖。
 
-- `runningHeadroom`：有效运行并发余量比例
-- `totalCapacityHeadroom`：有效运行并发与等待队列的综合余量比例
-- `normalizedWeight`：管理权重归一化结果，权重范围为 `1..1000`
-
-同分时依次比较：
-
-1. 有效排队任务更少
-2. 有效运行任务更少
-3. 权重更高
-4. `nodeId` 字典序
-
-调度结果会记录：
-
-- 分配模式
-- 最终得分
-- 选择原因
-- Worker 上报负载
-- 控制面活跃执行数
-- 计算后的有效负载
-- 所有候选节点及淘汰原因
-
-## 执行路由与可靠性
+## 执行路由与审计
 
 执行实例固化：
 
@@ -175,47 +212,50 @@ score = runningHeadroom × 55
 - `assignment_score`
 - `assignment_reason`
 - `assignment_candidates_json`
+- `required_capabilities_json`
+- `assigned_capabilities_json`
 
-所有远程操作均使用执行实例固化的 `engine_node_base_url`：
+所有提交、取消、指标查询和后台对账都访问执行实例固化的 Worker 地址。
 
-- 提交 JobSpec
-- 根据 `jobId` 或 `externalExecutionId` 对账
-- 取消任务
-- 查询 pipeline、task 和 metrics
+实例详情可以查看：
 
-当提交发生不确定网络错误时，Yak Ops 不会立即切换到其他 Worker，因为原 Worker 可能已经接收幂等请求；控制面会继续在原 Worker 上按 `externalExecutionId` 对账。
+- 任务版本要求的 Connector、角色、Schema 指纹和执行能力
+- 最终 Worker 实际匹配的能力摘要
+- 所有候选 Worker 的能力状态、摘要、匹配结果和淘汰原因
 
-Worker 进程实例发生变化且原执行仍未结束时，控制面将该执行标记为 `LOST`。后续重试会创建新的执行实例并重新执行 Worker 调度。
+当提交发生不确定网络错误时，不会自动切换 Worker，而是在原 Worker 上继续通过幂等标识对账。
 
-## 数据模型
+## Flyway
 
-Worker 管理继续复用 `yak_offline_engine_node`。
+V7 增加多 Worker 策略和执行分配字段。
 
-Flyway V7 为任务定义增加：
+V8 增加：
 
-- `worker_select_mode`
-- `worker_node_id`
-- `worker_required_labels_json`
-- `worker_node_id -> yak_offline_engine_node.node_id` 外键
+Worker：
 
-为执行实例增加：
+- `capability_status`
+- `capability_digest`
+- `connector_schemas_json`
+- `capability_synced_at`
+- `capability_error_message`
 
-- `engine_node_base_url`
-- `assignment_mode`
-- `assignment_score`
-- `assignment_reason`
-- `assignment_candidates_json`
+任务定义与版本：
 
-历史任务默认迁移为 `AUTO`。历史执行没有 `engine_node_base_url` 时，继续兼容原默认 Worker 配置。
+- `capability_requirements_json`
+
+执行实例：
+
+- `required_capabilities_json`
+- `assigned_capabilities_json`
 
 ## 当前边界
 
-本阶段完成离线任务的多 Worker 调度，不引入：
+本阶段完成基于 Link-Up Connector Schema 的能力调度，不包含：
 
 - CDC 或流式任务调度
-- 跨 Worker 迁移正在运行的任务
-- 提交不确定时的自动故障转移
-- Worker 侧资源预占或分布式容量租约
-- 基于 Connector 能力清单的调度约束
+- 运行中任务跨 Worker 迁移
+- 提交结果不确定时自动故障转移
+- Worker 侧分布式资源租约
+- Worker 侧真实数据源网络探测
 
-后续可以在现有调度器上增加 Connector 能力、租户配额、Worker 侧资源租约和更细粒度的调度审计。
+数据中心、网络区域和专线隔离继续通过 Worker 标签约束。真正的 Worker 侧数据源可达性探测需要 Link-Up 提供安全的预检协议，不能使用 Yak Ops 自身网络连通结果代替 Worker 视角。

--- a/docs/offline-worker-reachability.md
+++ b/docs/offline-worker-reachability.md
@@ -1,0 +1,113 @@
+# Link-Up Worker 数据源可达性调度
+
+## 目标
+
+能力调度只能证明 Worker 安装了正确 Connector，并不能证明该 Worker 所在网络能够连接具体 Source 和 Sink。
+
+Yak Ops 因此在任务领取事务之前调用 Link-Up Connector 安全预检，从实际候选 Worker 视角验证外部系统可达性。
+
+配套 Link-Up PR 提供：
+
+```http
+POST /api/v1/connectors/{connectorId}/preflight?role=SOURCE|SINK
+```
+
+## 运行流程
+
+```text
+执行命令
+  ↓
+刷新到期 Worker Connector 能力
+  ↓
+解析当前任务版本 JobSpec 和最新数据源凭据
+  ↓
+从候选 Worker 依次执行 Source/Sink 只读 preflight
+  ↓
+仅持久化 options SHA-256、状态、耗时和脱敏错误
+  ↓
+进入数据库事务并锁定 Worker 行
+  ↓
+按能力、可达性、标签、健康、容量和权重选择 Worker
+  ↓
+创建执行实例并固化全部调度证据
+```
+
+远程调用不会发生在任务定义锁或 Worker 行锁内部。
+
+## 缓存键
+
+```text
+nodeId + connectorId + role + optionsDigest
+```
+
+`optionsDigest` 是 Connector 实际运行 options 的规范化 SHA-256，包含连接参数变化的影响，但数据库不保存 options 或凭据明文。
+
+因此：
+
+- 数据源地址、用户名、密码或额外连接参数变化后，不会复用旧预检。
+- 同一任务短时间批量触发时，可以复用相同结果，避免数据库探测风暴。
+- 不同 Worker 的结果完全隔离。
+
+## 状态
+
+- `REACHABLE`：Worker 预检成功
+- `UNREACHABLE`：连接失败、超时或配置错误
+- `UNSUPPORTED`：Worker 版本或 Connector 尚未实现安全 preflight
+- `MISSING`：尚无缓存记录，仅在审计响应中使用
+
+默认严格模式下，只有 Source 和 Sink 均为新鲜 `REACHABLE` 的 Worker 才能参与调度。
+
+## 配置
+
+```yaml
+yak:
+  sync:
+    offline:
+      capability:
+        reachability-enabled: true
+        reachability-required: true
+        reachability-max-stale-millis: 60000
+        reachability-max-workers: 50
+        reachability-retention-millis: 86400000
+```
+
+升级 Link-Up Worker 期间可以临时使用：
+
+```yaml
+yak:
+  sync:
+    offline:
+      capability:
+        reachability-required: false
+```
+
+此时不可达或不支持结果不会成为硬过滤条件，但仍会写入候选审计。生产环境完成 Worker 升级后应恢复严格模式。
+
+## 执行审计
+
+执行实例新增：
+
+- `reachability_requirements_json`
+- `assigned_reachability_json`
+
+查询：
+
+```http
+GET /api/v1/offline/executions/{executionId}/scheduling-evidence
+```
+
+响应包含：
+
+- 任务能力要求
+- Worker 实际能力匹配
+- Source/Sink options 摘要
+- Worker 视角预检状态、耗时和检查时间
+- 所有候选 Worker 的能力、可达性和淘汰原因
+
+## 安全边界
+
+- Yak Ops 不持久化预检请求中的密码、Token 或完整 options。
+- Link-Up 统一错误协议会对常见密码字段进行脱敏。
+- JDBC preflight 只建立连接并调用 `Connection.isValid`，不执行 SQL。
+- 运行中任务不会因为后续预检状态变化而迁移到其他 Worker。
+- 提交结果不确定时仍只在原 Worker 上通过幂等标识对账。

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/config/OfflineCapabilityProperties.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/config/OfflineCapabilityProperties.java
@@ -1,0 +1,77 @@
+package io.yak.ops.business.sync.offline.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+/** Link-Up Worker Connector 能力采集与调度配置。 */
+@ConditionalOnOfflineSyncEnabled
+@Component
+@ConfigurationProperties(prefix = "yak.sync.offline.capability")
+public class OfflineCapabilityProperties {
+
+  /** 是否启用能力采集和能力调度。 */
+  private boolean enabled = true;
+
+  /** Schema 指纹不一致时是否拒绝调度。 */
+  private boolean strictSchemaFingerprint = true;
+
+  /** 能力快照超过该时间后视为过期。 */
+  private long maxStaleMillis = 900_000L;
+
+  /** 后台能力刷新初始延迟。 */
+  private long initialDelayMillis = 10_000L;
+
+  /** 后台扫描能力快照的间隔。 */
+  private long refreshDelayMillis = 60_000L;
+
+  /** 单个 Worker 能力快照的目标刷新周期。 */
+  private long workerRefreshMillis = 300_000L;
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  public boolean isStrictSchemaFingerprint() {
+    return strictSchemaFingerprint;
+  }
+
+  public void setStrictSchemaFingerprint(boolean strictSchemaFingerprint) {
+    this.strictSchemaFingerprint = strictSchemaFingerprint;
+  }
+
+  public long getMaxStaleMillis() {
+    return maxStaleMillis;
+  }
+
+  public void setMaxStaleMillis(long maxStaleMillis) {
+    this.maxStaleMillis = maxStaleMillis;
+  }
+
+  public long getInitialDelayMillis() {
+    return initialDelayMillis;
+  }
+
+  public void setInitialDelayMillis(long initialDelayMillis) {
+    this.initialDelayMillis = initialDelayMillis;
+  }
+
+  public long getRefreshDelayMillis() {
+    return refreshDelayMillis;
+  }
+
+  public void setRefreshDelayMillis(long refreshDelayMillis) {
+    this.refreshDelayMillis = refreshDelayMillis;
+  }
+
+  public long getWorkerRefreshMillis() {
+    return workerRefreshMillis;
+  }
+
+  public void setWorkerRefreshMillis(long workerRefreshMillis) {
+    this.workerRefreshMillis = workerRefreshMillis;
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/config/OfflineCapabilityProperties.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/config/OfflineCapabilityProperties.java
@@ -3,7 +3,7 @@ package io.yak.ops.business.sync.offline.config;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
-/** Link-Up Worker Connector 能力采集与调度配置。 */
+/** Link-Up Worker Connector 能力采集、可达性预检与调度配置。 */
 @ConditionalOnOfflineSyncEnabled
 @Component
 @ConfigurationProperties(prefix = "yak.sync.offline.capability")
@@ -26,6 +26,21 @@ public class OfflineCapabilityProperties {
 
   /** 单个 Worker 能力快照的目标刷新周期。 */
   private long workerRefreshMillis = 300_000L;
+
+  /** 是否启用 Worker 视角的数据源连通性预检。 */
+  private boolean reachabilityEnabled = true;
+
+  /** 预检未通过或 Worker 不支持 preflight 时是否拒绝调度。 */
+  private boolean reachabilityRequired = true;
+
+  /** 成功预检结果的最大复用时间。 */
+  private long reachabilityMaxStaleMillis = 60_000L;
+
+  /** 单次运行最多探测的 Worker 数量，避免错误配置造成请求风暴。 */
+  private int reachabilityMaxWorkers = 50;
+
+  /** 预检历史缓存保留时间。 */
+  private long reachabilityRetentionMillis = 86_400_000L;
 
   public boolean isEnabled() {
     return enabled;
@@ -73,5 +88,45 @@ public class OfflineCapabilityProperties {
 
   public void setWorkerRefreshMillis(long workerRefreshMillis) {
     this.workerRefreshMillis = workerRefreshMillis;
+  }
+
+  public boolean isReachabilityEnabled() {
+    return reachabilityEnabled;
+  }
+
+  public void setReachabilityEnabled(boolean reachabilityEnabled) {
+    this.reachabilityEnabled = reachabilityEnabled;
+  }
+
+  public boolean isReachabilityRequired() {
+    return reachabilityRequired;
+  }
+
+  public void setReachabilityRequired(boolean reachabilityRequired) {
+    this.reachabilityRequired = reachabilityRequired;
+  }
+
+  public long getReachabilityMaxStaleMillis() {
+    return reachabilityMaxStaleMillis;
+  }
+
+  public void setReachabilityMaxStaleMillis(long reachabilityMaxStaleMillis) {
+    this.reachabilityMaxStaleMillis = reachabilityMaxStaleMillis;
+  }
+
+  public int getReachabilityMaxWorkers() {
+    return reachabilityMaxWorkers;
+  }
+
+  public void setReachabilityMaxWorkers(int reachabilityMaxWorkers) {
+    this.reachabilityMaxWorkers = reachabilityMaxWorkers;
+  }
+
+  public long getReachabilityRetentionMillis() {
+    return reachabilityRetentionMillis;
+  }
+
+  public void setReachabilityRetentionMillis(long reachabilityRetentionMillis) {
+    this.reachabilityRetentionMillis = reachabilityRetentionMillis;
   }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/controller/OfflineExecutionSchedulingEvidenceController.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/controller/OfflineExecutionSchedulingEvidenceController.java
@@ -1,0 +1,72 @@
+package io.yak.ops.business.sync.offline.controller;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.framework.common.Result;
+import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import io.yak.ops.business.sync.offline.dao.OfflineJobExecutionDao;
+import io.yak.ops.common.bean.po.sync.offline.OfflineJobExecutionPO;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** 多 Worker 能力、可达性和评分的完整审计接口。 */
+@ConditionalOnOfflineSyncEnabled
+@RestController
+@RequestMapping("/api/v1/offline/executions")
+public class OfflineExecutionSchedulingEvidenceController {
+
+  private final OfflineJobExecutionDao executionDao;
+  private final ObjectMapper objectMapper;
+
+  public OfflineExecutionSchedulingEvidenceController(
+      OfflineJobExecutionDao executionDao,
+      @Qualifier("offlineSyncJsonMapper") ObjectMapper objectMapper) {
+    this.executionDao = executionDao;
+    this.objectMapper = objectMapper;
+  }
+
+  @GetMapping("/{executionId}/scheduling-evidence")
+  public Result<Map<String, Object>> evidence(@PathVariable Long executionId) {
+    if (executionId == null || executionId <= 0L) {
+      throw new IllegalArgumentException("任务实例 ID 不合法");
+    }
+    OfflineJobExecutionPO execution = executionDao.selectById(executionId);
+    if (execution == null) {
+      throw new IllegalArgumentException("离线同步任务实例不存在：" + executionId);
+    }
+
+    Map<String, Object> result = new LinkedHashMap<>();
+    result.put("executionId", execution.getId());
+    result.put("jobDefinitionId", execution.getJobDefinitionId());
+    result.put("definitionVersion", execution.getDefinitionVersion());
+    result.put("engineNodeId", execution.getEngineNodeId());
+    result.put("engineNodeBaseUrl", execution.getEngineNodeBaseUrl());
+    result.put("workerInstanceId", execution.getWorkerInstanceId());
+    result.put("assignmentMode", execution.getAssignmentMode());
+    result.put("assignmentScore", execution.getAssignmentScore());
+    result.put("assignmentReason", execution.getAssignmentReason());
+    result.put("requiredCapabilities", parse(execution.getRequiredCapabilitiesJson()));
+    result.put("assignedCapabilities", parse(execution.getAssignedCapabilitiesJson()));
+    result.put("reachabilityRequirements", parse(execution.getReachabilityRequirementsJson()));
+    result.put("assignedReachability", parse(execution.getAssignedReachabilityJson()));
+    result.put("candidates", parse(execution.getAssignmentCandidatesJson()));
+    return Result.success(result);
+  }
+
+  private JsonNode parse(String value) {
+    if (value == null || value.trim().isEmpty()) {
+      return null;
+    }
+    try {
+      return objectMapper.readTree(value);
+    } catch (JsonProcessingException exception) {
+      throw new IllegalStateException("执行调度审计 JSON 已损坏", exception);
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/controller/OfflineWorkerController.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/controller/OfflineWorkerController.java
@@ -2,6 +2,8 @@ package io.yak.ops.business.sync.offline.controller;
 
 import io.yak.framework.common.Result;
 import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import io.yak.ops.business.sync.offline.worker.OfflineWorkerCapabilityService;
+import io.yak.ops.business.sync.offline.worker.OfflineWorkerModels.CapabilityView;
 import io.yak.ops.business.sync.offline.worker.OfflineWorkerModels.CreateRequest;
 import io.yak.ops.business.sync.offline.worker.OfflineWorkerModels.OptionView;
 import io.yak.ops.business.sync.offline.worker.OfflineWorkerModels.PageView;
@@ -35,6 +37,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class OfflineWorkerController {
 
   private final OfflineWorkerService service;
+  private final OfflineWorkerCapabilityService capabilityService;
 
   @PostMapping("/verify")
   public Result<WorkerView> verify(@Valid @RequestBody VerifyRequest request) {
@@ -43,42 +46,67 @@ public class OfflineWorkerController {
 
   @PostMapping
   public Result<WorkerView> create(@Valid @RequestBody CreateRequest request) {
-    return Result.success(service.create(request));
+    WorkerView worker = service.create(request);
+    capabilityService.refreshQuietly(worker.getNodeId());
+    return Result.success(capabilityService.enrich(service.get(worker.getNodeId())));
   }
 
   @PutMapping("/{nodeId}")
   public Result<WorkerView> update(
       @PathVariable String nodeId,
       @Valid @RequestBody UpdateRequest request) {
-    return Result.success(service.update(nodeId, request));
+    service.update(nodeId, request);
+    capabilityService.refreshQuietly(nodeId);
+    return Result.success(capabilityService.enrich(service.get(nodeId)));
   }
 
   @GetMapping("/{nodeId}")
   public Result<WorkerView> detail(@PathVariable String nodeId) {
-    return Result.success(service.get(nodeId));
+    return Result.success(capabilityService.enrich(service.get(nodeId)));
   }
 
   @PostMapping("/page")
   public Result<PageView> page(@Valid @RequestBody(required = false) QueryRequest request) {
-    return Result.success(service.page(request));
+    PageView page = service.page(request);
+    if (page.getRecords() != null) {
+      page.getRecords().forEach(capabilityService::enrich);
+    }
+    return Result.success(page);
   }
 
   @GetMapping("/options")
   public Result<List<OptionView>> options() {
-    return Result.success(service.options());
+    List<OptionView> options = service.options();
+    options.forEach(capabilityService::enrich);
+    return Result.success(options);
   }
 
   @PostMapping("/{nodeId}/refresh")
   public Result<WorkerView> refresh(@PathVariable String nodeId) {
-    return Result.success(service.refresh(nodeId));
+    service.refresh(nodeId);
+    capabilityService.refresh(nodeId, true);
+    return Result.success(capabilityService.enrich(service.get(nodeId)));
+  }
+
+  @GetMapping("/{nodeId}/capabilities")
+  public Result<CapabilityView> capabilities(@PathVariable String nodeId) {
+    return Result.success(capabilityService.get(nodeId));
+  }
+
+  @PostMapping("/{nodeId}/capabilities/refresh")
+  public Result<CapabilityView> refreshCapabilities(@PathVariable String nodeId) {
+    return Result.success(capabilityService.refreshView(nodeId));
   }
 
   @PutMapping("/{nodeId}/scheduling-status")
   public Result<WorkerView> schedulingStatus(
       @PathVariable String nodeId,
       @Valid @RequestBody SchedulingRequest request) {
-    return Result.success(
-        service.changeSchedulingStatus(nodeId, request.getSchedulingStatus()));
+    WorkerView worker = service.changeSchedulingStatus(nodeId, request.getSchedulingStatus());
+    if (Boolean.TRUE.equals(worker.getEnabled())) {
+      capabilityService.refreshQuietly(nodeId);
+    }
+    return Result.success(capabilityService.enrich(service.get(nodeId)));
   }
 
   @DeleteMapping("/{nodeId}")

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/LinkUpConnectorPreflightClient.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/LinkUpConnectorPreflightClient.java
@@ -1,0 +1,154 @@
+package io.yak.ops.business.sync.offline.engine;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import io.yak.ops.business.sync.offline.config.OfflineSyncProperties;
+import io.yak.ops.business.sync.offline.engine.LinkUpClient.LinkUpRequestException;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.Locale;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+/** Worker 视角的 Connector 只读可达性预检客户端。 */
+@ConditionalOnOfflineSyncEnabled
+@Component
+public class LinkUpConnectorPreflightClient {
+
+  private final HttpClient httpClient;
+  private final ObjectMapper objectMapper;
+  private final OfflineSyncProperties properties;
+
+  public LinkUpConnectorPreflightClient(
+      @Qualifier("offlineSyncHttpClient") HttpClient httpClient,
+      @Qualifier("offlineSyncJsonMapper") ObjectMapper objectMapper,
+      OfflineSyncProperties properties) {
+    this.httpClient = httpClient;
+    this.objectMapper = objectMapper;
+    this.properties = properties;
+  }
+
+  public JsonNode preflight(
+      String baseUrl,
+      String connectorId,
+      String role,
+      JsonNode options) {
+    requireEnabled();
+    String normalizedBaseUrl = normalizeBaseUrl(baseUrl);
+    String normalizedConnectorId = required(connectorId, "connectorId").toLowerCase(Locale.ROOT);
+    String normalizedRole = required(role, "role").toUpperCase(Locale.ROOT);
+    if (!"SOURCE".equals(normalizedRole) && !"SINK".equals(normalizedRole)) {
+      throw new IllegalArgumentException("role 只支持 SOURCE 或 SINK");
+    }
+
+    ObjectNode requestBody = objectMapper.createObjectNode();
+    requestBody.set(
+        "options",
+        options == null || !options.isObject()
+            ? objectMapper.createObjectNode()
+            : options.deepCopy());
+    URI uri = URI.create(
+        normalizedBaseUrl
+            + "/api/v1/connectors/"
+            + encode(normalizedConnectorId)
+            + "/preflight?role="
+            + encode(normalizedRole));
+    HttpRequest request = HttpRequest.newBuilder(uri)
+        .timeout(properties.getEngine().getRequestTimeout())
+        .header("Content-Type", "application/json;charset=UTF-8")
+        .header("Accept", "application/json")
+        .POST(HttpRequest.BodyPublishers.ofString(write(requestBody), StandardCharsets.UTF_8))
+        .build();
+    try {
+      HttpResponse<String> response = httpClient.send(
+          request,
+          HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+      JsonNode body = read(response.body());
+      if (response.statusCode() >= 200 && response.statusCode() < 300) {
+        return body;
+      }
+      throw new LinkUpRequestException(
+          response.statusCode(),
+          body.path("code").asText("LINK-UP-HTTP-" + response.statusCode()),
+          errorMessage(body, response.body()));
+    } catch (InterruptedException exception) {
+      Thread.currentThread().interrupt();
+      throw new IllegalStateException("Link-Up Connector 预检被中断", exception);
+    } catch (IOException exception) {
+      throw new IllegalStateException(
+          "无法从 Worker 执行 Connector 预检：" + normalizedBaseUrl,
+          exception);
+    }
+  }
+
+  private JsonNode read(String body) {
+    if (!StringUtils.hasText(body)) {
+      return objectMapper.createObjectNode();
+    }
+    try {
+      return objectMapper.readTree(body);
+    } catch (JsonProcessingException exception) {
+      throw new IllegalStateException("Link-Up 返回了无法解析的预检结果", exception);
+    }
+  }
+
+  private String write(JsonNode body) {
+    try {
+      return objectMapper.writeValueAsString(body);
+    } catch (JsonProcessingException exception) {
+      throw new IllegalStateException("序列化 Connector 预检请求失败", exception);
+    }
+  }
+
+  private String errorMessage(JsonNode body, String fallback) {
+    String message = body.path("message").asText(null);
+    if (!StringUtils.hasText(message)) {
+      message = body.path("error").asText(null);
+    }
+    return StringUtils.hasText(message) ? message : fallback;
+  }
+
+  private String normalizeBaseUrl(String value) {
+    String normalized = required(value, "Worker 地址");
+    while (normalized.endsWith("/")) {
+      normalized = normalized.substring(0, normalized.length() - 1);
+    }
+    URI uri;
+    try {
+      uri = URI.create(normalized);
+    } catch (IllegalArgumentException exception) {
+      throw new IllegalArgumentException("Worker 地址不合法：" + value, exception);
+    }
+    if (!("http".equalsIgnoreCase(uri.getScheme()) || "https".equalsIgnoreCase(uri.getScheme()))
+        || !StringUtils.hasText(uri.getHost())) {
+      throw new IllegalArgumentException("Worker 地址必须是有效的 HTTP/HTTPS 地址");
+    }
+    return normalized;
+  }
+
+  private String required(String value, String name) {
+    if (!StringUtils.hasText(value)) {
+      throw new IllegalArgumentException(name + "不能为空");
+    }
+    return value.trim();
+  }
+
+  private String encode(String value) {
+    return URLEncoder.encode(value, StandardCharsets.UTF_8).replace("+", "%20");
+  }
+
+  private void requireEnabled() {
+    if (!properties.getEngine().isEnabled()) {
+      throw new IllegalStateException("Link-Up 引擎对接已关闭");
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/LinkUpConnectorSchemaClient.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/LinkUpConnectorSchemaClient.java
@@ -19,6 +19,8 @@ import org.springframework.util.StringUtils;
 /**
  * Link-Up Connector Schema 只读客户端。
  *
+ * <p>既支持默认 Worker，也支持按已登记 Worker 地址查询，用于多 Worker 能力快照。
+ *
  * @author weifuwan
  */
 @ConditionalOnOfflineSyncEnabled
@@ -39,23 +41,38 @@ public class LinkUpConnectorSchemaClient {
   }
 
   public JsonNode list() {
-    return get("/api/v1/connectors");
+    return list(properties.getEngine().getBaseUrl());
   }
 
-  public JsonNode list(String role) {
-    return get("/api/v1/connectors?role=" + encodeRole(role));
+  public JsonNode list(String baseUrl) {
+    return get(baseUrl, "/api/v1/connectors");
+  }
+
+  public JsonNode listByRole(String role) {
+    return listByRole(properties.getEngine().getBaseUrl(), role);
+  }
+
+  public JsonNode listByRole(String baseUrl, String role) {
+    return get(baseUrl, "/api/v1/connectors?role=" + encodeRole(role));
   }
 
   public JsonNode get(String connectorId, String role) {
+    return get(properties.getEngine().getBaseUrl(), connectorId, role);
+  }
+
+  public JsonNode get(String baseUrl, String connectorId, String role) {
     if (!StringUtils.hasText(connectorId)) {
       throw new IllegalArgumentException("connectorId 不能为空");
     }
-    return get("/api/v1/connectors/" + encode(connectorId) + "/schema?role=" + encodeRole(role));
+    return get(
+        baseUrl,
+        "/api/v1/connectors/" + encode(connectorId) + "/schema?role=" + encodeRole(role));
   }
 
-  private JsonNode get(String path) {
+  private JsonNode get(String baseUrl, String path) {
     requireEnabled();
-    HttpRequest request = HttpRequest.newBuilder(uri(path))
+    String normalized = normalizeBaseUrl(baseUrl);
+    HttpRequest request = HttpRequest.newBuilder(URI.create(normalized + path))
         .timeout(properties.getEngine().getRequestTimeout())
         .header("Accept", "application/json")
         .GET()
@@ -75,8 +92,7 @@ public class LinkUpConnectorSchemaClient {
       Thread.currentThread().interrupt();
       throw new IllegalStateException("Link-Up Connector Schema 请求被中断", exception);
     } catch (IOException exception) {
-      throw new IllegalStateException(
-          "无法连接 Link-Up Worker：" + properties.getEngine().getBaseUrl(), exception);
+      throw new IllegalStateException("无法连接 Link-Up Worker：" + normalized, exception);
     }
   }
 
@@ -99,15 +115,25 @@ public class LinkUpConnectorSchemaClient {
     return StringUtils.hasText(message) ? message : fallback;
   }
 
-  private URI uri(String path) {
-    String baseUrl = properties.getEngine().getBaseUrl();
-    if (!StringUtils.hasText(baseUrl)) {
-      throw new IllegalStateException("yak.sync.offline.engine.base-url 不能为空");
+  private String normalizeBaseUrl(String value) {
+    if (!StringUtils.hasText(value)) {
+      throw new IllegalStateException("Link-Up Worker 地址不能为空");
     }
-    String normalized = baseUrl.endsWith("/")
-        ? baseUrl.substring(0, baseUrl.length() - 1)
-        : baseUrl;
-    return URI.create(normalized + path);
+    String normalized = value.trim();
+    while (normalized.endsWith("/")) {
+      normalized = normalized.substring(0, normalized.length() - 1);
+    }
+    URI uri;
+    try {
+      uri = URI.create(normalized);
+    } catch (IllegalArgumentException exception) {
+      throw new IllegalArgumentException("Link-Up Worker 地址不合法：" + value, exception);
+    }
+    if (!("http".equalsIgnoreCase(uri.getScheme()) || "https".equalsIgnoreCase(uri.getScheme()))
+        || !StringUtils.hasText(uri.getHost())) {
+      throw new IllegalArgumentException("Link-Up Worker 地址必须是有效的 HTTP/HTTPS 地址");
+    }
+    return normalized;
   }
 
   private String encode(String value) {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineDefinitionCatalogRepository.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineDefinitionCatalogRepository.java
@@ -154,6 +154,28 @@ public class OfflineDefinitionCatalogRepository {
     private final String capabilityRequirementsJson;
     private final LocalDateTime createTime;
 
+    /** 兼容第三阶段之前的直接构造调用。 */
+    public DefinitionVersion(
+        Long id,
+        Long jobDefinitionId,
+        int versionNo,
+        String definitionJson,
+        String jobSpecJson,
+        String legacyHoconConfig,
+        String configDigest,
+        LocalDateTime createTime) {
+      this(
+          id,
+          jobDefinitionId,
+          versionNo,
+          definitionJson,
+          jobSpecJson,
+          legacyHoconConfig,
+          configDigest,
+          null,
+          createTime);
+    }
+
     public DefinitionVersion(
         Long id,
         Long jobDefinitionId,

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineDefinitionCatalogRepository.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineDefinitionCatalogRepository.java
@@ -30,6 +30,22 @@ public class OfflineDefinitionCatalogRepository {
     this.jdbc = new JdbcTemplate(dataSource);
   }
 
+  /** 兼容现有保存链路；能力要求可在保存后或首次执行时回填。 */
+  public Long saveVersion(
+      Long definitionId,
+      int version,
+      String definitionJson,
+      String jobSpecJson,
+      String configDigest) {
+    return saveVersion(
+        definitionId,
+        version,
+        definitionJson,
+        jobSpecJson,
+        configDigest,
+        null);
+  }
+
   public Long saveVersion(
       Long definitionId,
       int version,
@@ -61,6 +77,27 @@ public class OfflineDefinitionCatalogRepository {
       throw new IllegalStateException("保存离线任务版本后未返回版本 ID");
     }
     return key.longValue();
+  }
+
+  /** 只回填派生元数据，不修改 JobSpec、配置摘要或版本号。 */
+  public void backfillCapabilityRequirements(
+      Long definitionId,
+      Long versionId,
+      String capabilityRequirementsJson) {
+    if (definitionId == null || versionId == null || capabilityRequirementsJson == null) {
+      return;
+    }
+    jdbc.update(
+        "UPDATE yak_offline_job_version SET capability_requirements_json = ? "
+            + "WHERE id = ? AND capability_requirements_json IS NULL",
+        capabilityRequirementsJson,
+        versionId);
+    jdbc.update(
+        "UPDATE yak_offline_job_definition SET capability_requirements_json = ?, update_time = ? "
+            + "WHERE id = ?",
+        capabilityRequirementsJson,
+        Timestamp.valueOf(LocalDateTime.now()),
+        definitionId);
   }
 
   public DefinitionVersion findCurrentVersion(Long definitionId, Long currentVersionId) {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineDefinitionCatalogRepository.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineDefinitionCatalogRepository.java
@@ -35,22 +35,24 @@ public class OfflineDefinitionCatalogRepository {
       int version,
       String definitionJson,
       String jobSpecJson,
-      String configDigest) {
+      String configDigest,
+      String capabilityRequirementsJson) {
     KeyHolder keyHolder = new GeneratedKeyHolder();
     jdbc.update(
         connection -> {
           PreparedStatement statement = connection.prepareStatement(
               "INSERT INTO yak_offline_job_version "
                   + "(job_definition_id, version_no, definition_json, job_spec_json, "
-                  + "hocon_config, config_digest, create_time) "
-                  + "VALUES (?, ?, ?, ?, NULL, ?, ?)",
+                  + "hocon_config, config_digest, capability_requirements_json, create_time) "
+                  + "VALUES (?, ?, ?, ?, NULL, ?, ?, ?)",
               Statement.RETURN_GENERATED_KEYS);
           statement.setLong(1, definitionId);
           statement.setInt(2, version);
           statement.setString(3, definitionJson);
           statement.setString(4, jobSpecJson);
           statement.setString(5, configDigest);
-          statement.setTimestamp(6, Timestamp.valueOf(LocalDateTime.now()));
+          statement.setString(6, capabilityRequirementsJson);
+          statement.setTimestamp(7, Timestamp.valueOf(LocalDateTime.now()));
           return statement;
         },
         keyHolder);
@@ -87,7 +89,8 @@ public class OfflineDefinitionCatalogRepository {
 
   private String selectSql() {
     return "SELECT id, job_definition_id, version_no, definition_json, job_spec_json, "
-        + "hocon_config, config_digest, create_time FROM yak_offline_job_version";
+        + "hocon_config, config_digest, capability_requirements_json, create_time "
+        + "FROM yak_offline_job_version";
   }
 
   private DefinitionVersion map(java.sql.ResultSet resultSet) throws java.sql.SQLException {
@@ -99,6 +102,7 @@ public class OfflineDefinitionCatalogRepository {
         resultSet.getString("job_spec_json"),
         resultSet.getString("hocon_config"),
         resultSet.getString("config_digest"),
+        resultSet.getString("capability_requirements_json"),
         resultSet.getTimestamp("create_time").toLocalDateTime());
   }
 
@@ -110,6 +114,7 @@ public class OfflineDefinitionCatalogRepository {
     private final String jobSpecJson;
     private final String legacyHoconConfig;
     private final String configDigest;
+    private final String capabilityRequirementsJson;
     private final LocalDateTime createTime;
 
     public DefinitionVersion(
@@ -120,6 +125,7 @@ public class OfflineDefinitionCatalogRepository {
         String jobSpecJson,
         String legacyHoconConfig,
         String configDigest,
+        String capabilityRequirementsJson,
         LocalDateTime createTime) {
       this.id = id;
       this.jobDefinitionId = jobDefinitionId;
@@ -128,6 +134,7 @@ public class OfflineDefinitionCatalogRepository {
       this.jobSpecJson = jobSpecJson;
       this.legacyHoconConfig = legacyHoconConfig;
       this.configDigest = configDigest;
+      this.capabilityRequirementsJson = capabilityRequirementsJson;
       this.createTime = createTime;
     }
 
@@ -138,6 +145,7 @@ public class OfflineDefinitionCatalogRepository {
     public String getJobSpecJson() { return jobSpecJson; }
     public String getLegacyHoconConfig() { return legacyHoconConfig; }
     public String getConfigDigest() { return configDigest; }
+    public String getCapabilityRequirementsJson() { return capabilityRequirementsJson; }
     public LocalDateTime getCreateTime() { return createTime; }
   }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineExecutionControlRepository.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineExecutionControlRepository.java
@@ -166,6 +166,8 @@ public class OfflineExecutionControlRepository {
     execution.setAssignmentScore(nullableDouble(resultSet, "assignment_score"));
     execution.setAssignmentReason(resultSet.getString("assignment_reason"));
     execution.setAssignmentCandidatesJson(resultSet.getString("assignment_candidates_json"));
+    execution.setRequiredCapabilitiesJson(resultSet.getString("required_capabilities_json"));
+    execution.setAssignedCapabilitiesJson(resultSet.getString("assigned_capabilities_json"));
     execution.setStatus(resultSet.getString("status"));
     execution.setStateVersion(resultSet.getLong("state_version"));
     execution.setAttemptNo(resultSet.getInt("attempt_no"));

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineNodeRepository.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineNodeRepository.java
@@ -18,7 +18,7 @@ import org.springframework.jdbc.core.RowMapper;
 import org.springframework.stereotype.Repository;
 
 /**
- * Link-Up Worker 注册信息、调度状态和心跳持久化。
+ * Link-Up Worker 注册信息、调度状态、心跳和能力快照持久化。
  *
  * @author weifuwan
  */
@@ -31,7 +31,8 @@ public class OfflineNodeRepository {
           + "weight, labels_json, worker_instance_id, engine_version, started_at_millis, "
           + "offline_only, status, max_concurrent_jobs, max_queued_jobs, running_jobs, "
           + "queued_jobs, last_heartbeat_time, last_success_time, consecutive_failures, "
-          + "last_error_message, create_time, update_time";
+          + "last_error_message, capability_status, capability_digest, connector_schemas_json, "
+          + "capability_synced_at, capability_error_message, create_time, update_time";
 
   private final JdbcTemplate jdbc;
   private final RowMapper<NodeRecord> rowMapper = this::map;
@@ -40,7 +41,7 @@ public class OfflineNodeRepository {
     this.jdbc = new JdbcTemplate(dataSource);
   }
 
-  /** 创建或覆盖配置来源的默认 Worker。 */
+  /** 创建或覆盖配置来源的默认 Worker；已有能力快照不会被心跳登记覆盖。 */
   public void upsert(NodeRecord node) {
     LocalDateTime now = LocalDateTime.now();
     jdbc.update(
@@ -49,8 +50,9 @@ public class OfflineNodeRepository {
             + "weight, labels_json, worker_instance_id, engine_version, started_at_millis, "
             + "offline_only, status, max_concurrent_jobs, max_queued_jobs, running_jobs, "
             + "queued_jobs, last_heartbeat_time, last_success_time, consecutive_failures, "
-            + "last_error_message, create_time, update_time) "
-            + "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "
+            + "last_error_message, capability_status, capability_digest, connector_schemas_json, "
+            + "capability_synced_at, capability_error_message, create_time, update_time) "
+            + "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "
             + "ON DUPLICATE KEY UPDATE "
             + "node_name = VALUES(node_name), base_url = VALUES(base_url), "
             + "registration_mode = VALUES(registration_mode), enabled = VALUES(enabled), "
@@ -70,7 +72,10 @@ public class OfflineNodeRepository {
         bool(node.getOfflineOnly()), node.getStatus(), node.getMaxConcurrentJobs(),
         node.getMaxQueuedJobs(), node.getRunningJobs(), node.getQueuedJobs(),
         timestamp(node.getLastHeartbeatTime()), timestamp(node.getLastSuccessTime()),
-        node.getConsecutiveFailures(), node.getLastErrorMessage(), timestamp(now), timestamp(now));
+        node.getConsecutiveFailures(), node.getLastErrorMessage(),
+        text(node.getCapabilityStatus(), "UNKNOWN"), node.getCapabilityDigest(),
+        node.getConnectorSchemasJson(), timestamp(node.getCapabilitySyncedAt()),
+        node.getCapabilityErrorMessage(), timestamp(now), timestamp(now));
   }
 
   /** 更新用户可编辑的 Worker 定义，并同步本次验证得到的运行信息。 */
@@ -116,6 +121,36 @@ public class OfflineNodeRepository {
         timestamp(LocalDateTime.now()), message, timestamp(LocalDateTime.now()), nodeId);
   }
 
+  public void updateCapabilitySuccess(
+      String nodeId,
+      String digest,
+      String connectorSchemasJson,
+      LocalDateTime syncedAt) {
+    LocalDateTime now = syncedAt == null ? LocalDateTime.now() : syncedAt;
+    jdbc.update(
+        "UPDATE yak_offline_engine_node SET capability_status = 'READY', capability_digest = ?, "
+            + "connector_schemas_json = ?, capability_synced_at = ?, "
+            + "capability_error_message = NULL, update_time = ? WHERE node_id = ?",
+        digest, connectorSchemasJson, timestamp(now), timestamp(LocalDateTime.now()), nodeId);
+  }
+
+  /** 保留最后一次成功快照，只更新错误状态，便于诊断和短时容错。 */
+  public void updateCapabilityFailure(String nodeId, String message) {
+    jdbc.update(
+        "UPDATE yak_offline_engine_node SET capability_status = 'ERROR', "
+            + "capability_error_message = ?, update_time = ? WHERE node_id = ?",
+        message, timestamp(LocalDateTime.now()), nodeId);
+  }
+
+  public void resetCapabilities(String nodeId) {
+    jdbc.update(
+        "UPDATE yak_offline_engine_node SET capability_status = 'UNKNOWN', "
+            + "capability_digest = NULL, connector_schemas_json = NULL, "
+            + "capability_synced_at = NULL, capability_error_message = NULL, update_time = ? "
+            + "WHERE node_id = ?",
+        timestamp(LocalDateTime.now()), nodeId);
+  }
+
   public boolean updateSchedulingStatus(String nodeId, String status, boolean enabled) {
     return jdbc.update(
         "UPDATE yak_offline_engine_node SET scheduling_status = ?, enabled = ?, update_time = ? "
@@ -152,9 +187,7 @@ public class OfflineNodeRepository {
         rowMapper);
   }
 
-  /**
-   * 调度事务内按稳定顺序锁定全部 Worker 行，防止多个任务并发使用相同负载快照。
-   */
+  /** 调度事务内按稳定顺序锁定全部 Worker 行。 */
   public List<NodeRecord> listAllForScheduling() {
     return jdbc.query(
         "SELECT " + SELECT_COLUMNS + " FROM yak_offline_engine_node "
@@ -166,6 +199,14 @@ public class OfflineNodeRepository {
     return jdbc.query(
         "SELECT " + SELECT_COLUMNS + " FROM yak_offline_engine_node "
             + "WHERE enabled = 1 AND scheduling_status <> 'DISABLED' "
+            + "ORDER BY node_id ASC",
+        rowMapper);
+  }
+
+  public List<NodeRecord> listCapabilityRefreshTargets() {
+    return jdbc.query(
+        "SELECT " + SELECT_COLUMNS + " FROM yak_offline_engine_node "
+            + "WHERE enabled = 1 AND status = 'UP' AND scheduling_status <> 'DISABLED' "
             + "ORDER BY node_id ASC",
         rowMapper);
   }
@@ -197,9 +238,18 @@ public class OfflineNodeRepository {
         .lastSuccessTime(localDateTime(rs.getTimestamp("last_success_time")))
         .consecutiveFailures(rs.getInt("consecutive_failures"))
         .lastErrorMessage(rs.getString("last_error_message"))
+        .capabilityStatus(rs.getString("capability_status"))
+        .capabilityDigest(rs.getString("capability_digest"))
+        .connectorSchemasJson(rs.getString("connector_schemas_json"))
+        .capabilitySyncedAt(localDateTime(rs.getTimestamp("capability_synced_at")))
+        .capabilityErrorMessage(rs.getString("capability_error_message"))
         .createTime(localDateTime(rs.getTimestamp("create_time")))
         .updateTime(localDateTime(rs.getTimestamp("update_time")))
         .build();
+  }
+
+  private String text(String value, String fallback) {
+    return value == null || value.isBlank() ? fallback : value;
   }
 
   private int bool(Boolean value) {
@@ -241,6 +291,11 @@ public class OfflineNodeRepository {
     private LocalDateTime lastSuccessTime;
     private Integer consecutiveFailures;
     private String lastErrorMessage;
+    private String capabilityStatus;
+    private String capabilityDigest;
+    private String connectorSchemasJson;
+    private LocalDateTime capabilitySyncedAt;
+    private String capabilityErrorMessage;
     private LocalDateTime createTime;
     private LocalDateTime updateTime;
   }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineWorkerPreflightRepository.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineWorkerPreflightRepository.java
@@ -1,0 +1,128 @@
+package io.yak.ops.business.sync.offline.repository;
+
+import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import javax.sql.DataSource;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+/** Worker 视角 Connector 可达性预检的多实例共享短缓存。 */
+@ConditionalOnOfflineSyncEnabled
+@Repository
+public class OfflineWorkerPreflightRepository {
+
+  private final JdbcTemplate jdbc;
+
+  public OfflineWorkerPreflightRepository(
+      @Qualifier("offlineSyncDataSource") DataSource dataSource) {
+    this.jdbc = new JdbcTemplate(dataSource);
+  }
+
+  public PreflightRecord find(
+      String nodeId,
+      String connectorId,
+      String role,
+      String optionsDigest) {
+    try {
+      return jdbc.queryForObject(
+          "SELECT node_id, connector_id, connector_role, options_digest, status, "
+              + "duration_millis, error_code, error_message, checked_at, create_time, update_time "
+              + "FROM yak_offline_worker_preflight WHERE node_id = ? AND connector_id = ? "
+              + "AND connector_role = ? AND options_digest = ?",
+          this::map,
+          nodeId,
+          connectorId,
+          role,
+          optionsDigest);
+    } catch (EmptyResultDataAccessException exception) {
+      return null;
+    }
+  }
+
+  public void save(PreflightRecord record) {
+    LocalDateTime now = LocalDateTime.now();
+    LocalDateTime checkedAt = record.getCheckedAt() == null ? now : record.getCheckedAt();
+    jdbc.update(
+        "INSERT INTO yak_offline_worker_preflight "
+            + "(node_id, connector_id, connector_role, options_digest, status, duration_millis, "
+            + "error_code, error_message, checked_at, create_time, update_time) "
+            + "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "
+            + "ON DUPLICATE KEY UPDATE status = VALUES(status), "
+            + "duration_millis = VALUES(duration_millis), error_code = VALUES(error_code), "
+            + "error_message = VALUES(error_message), checked_at = VALUES(checked_at), "
+            + "update_time = VALUES(update_time)",
+        record.getNodeId(),
+        record.getConnectorId(),
+        record.getRole(),
+        record.getOptionsDigest(),
+        record.getStatus(),
+        record.getDurationMillis(),
+        record.getErrorCode(),
+        record.getErrorMessage(),
+        timestamp(checkedAt),
+        timestamp(now),
+        timestamp(now));
+  }
+
+  public int deleteExpired(LocalDateTime cutoff) {
+    return jdbc.update(
+        "DELETE FROM yak_offline_worker_preflight WHERE checked_at < ?",
+        timestamp(cutoff));
+  }
+
+  private PreflightRecord map(ResultSet rs, int rowNum) throws SQLException {
+    return PreflightRecord.builder()
+        .nodeId(rs.getString("node_id"))
+        .connectorId(rs.getString("connector_id"))
+        .role(rs.getString("connector_role"))
+        .optionsDigest(rs.getString("options_digest"))
+        .status(rs.getString("status"))
+        .durationMillis(nullableLong(rs, "duration_millis"))
+        .errorCode(rs.getString("error_code"))
+        .errorMessage(rs.getString("error_message"))
+        .checkedAt(localDateTime(rs.getTimestamp("checked_at")))
+        .createTime(localDateTime(rs.getTimestamp("create_time")))
+        .updateTime(localDateTime(rs.getTimestamp("update_time")))
+        .build();
+  }
+
+  private Long nullableLong(ResultSet rs, String column) throws SQLException {
+    long value = rs.getLong(column);
+    return rs.wasNull() ? null : value;
+  }
+
+  private Timestamp timestamp(LocalDateTime value) {
+    return value == null ? null : Timestamp.valueOf(value);
+  }
+
+  private LocalDateTime localDateTime(Timestamp value) {
+    return value == null ? null : value.toLocalDateTime();
+  }
+
+  @Data
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class PreflightRecord {
+    private String nodeId;
+    private String connectorId;
+    private String role;
+    private String optionsDigest;
+    private String status;
+    private Long durationMillis;
+    private String errorCode;
+    private String errorMessage;
+    private LocalDateTime checkedAt;
+    private LocalDateTime createTime;
+    private LocalDateTime updateTime;
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/CapabilityAwareOfflineExecutionClaimService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/CapabilityAwareOfflineExecutionClaimService.java
@@ -1,0 +1,68 @@
+package io.yak.ops.business.sync.offline.service;
+
+import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import io.yak.ops.business.sync.offline.dao.OfflineJobExecutionDao;
+import io.yak.ops.business.sync.offline.repository.OfflineDefinitionCatalogRepository;
+import io.yak.ops.business.sync.offline.repository.OfflineDefinitionCatalogRepository.DefinitionVersion;
+import io.yak.ops.business.sync.offline.repository.OfflineExecutionControlRepository;
+import io.yak.ops.business.sync.offline.worker.OfflineCapabilityRequirementResolver;
+import io.yak.ops.business.sync.offline.worker.OfflineWorkerReachabilityService;
+import io.yak.ops.business.sync.offline.worker.OfflineWorkerScheduler;
+import io.yak.ops.common.bean.po.sync.offline.OfflineJobDefinitionPO;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 第三阶段能力调度使用的主领取服务。
+ *
+ * <p>Worker 远程预检由执行门面在事务外完成；这里仅根据不可变 JobSpec 本地重算摘要，
+ * 再进入原有原子领取流程读取共享预检缓存。
+ *
+ * @author weifuwan
+ */
+@Primary
+@ConditionalOnOfflineSyncEnabled
+@Service
+public class CapabilityAwareOfflineExecutionClaimService extends OfflineExecutionClaimService {
+
+  private final OfflineJobDefinitionService definitionService;
+  private final OfflineWorkerReachabilityService reachabilityService;
+
+  public CapabilityAwareOfflineExecutionClaimService(
+      OfflineJobDefinitionService definitionService,
+      OfflineJobExecutionDao executionDao,
+      OfflineExecutionControlRepository executionRepository,
+      OfflineDefinitionCatalogRepository catalogRepository,
+      OfflineCapabilityRequirementResolver capabilityResolver,
+      OfflineWorkerScheduler workerScheduler,
+      OfflineWorkerReachabilityService reachabilityService) {
+    super(
+        definitionService,
+        executionDao,
+        executionRepository,
+        catalogRepository,
+        capabilityResolver,
+        workerScheduler);
+    this.definitionService = definitionService;
+    this.reachabilityService = reachabilityService;
+  }
+
+  @Override
+  @Transactional(transactionManager = "offlineSyncTransactionManager", rollbackFor = Exception.class)
+  public ClaimResult claim(
+      Long definitionId,
+      String triggerType,
+      Long retryFromExecutionId,
+      int attemptNo) {
+    OfflineJobDefinitionPO definition = definitionService.require(definitionId);
+    DefinitionVersion version = definitionService.requireCurrentVersion(definition);
+    String reachabilityRequirements = reachabilityService.requirements(definition, version);
+    return super.claim(
+        definitionId,
+        triggerType,
+        retryFromExecutionId,
+        attemptNo,
+        reachabilityRequirements);
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineExecutionClaimService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineExecutionClaimService.java
@@ -21,8 +21,8 @@ import org.springframework.util.StringUtils;
 /**
  * 离线同步执行实例原子领取服务。
  *
- * Atomically claims a definition, selects one capability-compatible Worker and creates one
- * durable execution attempt.
+ * Atomically claims a definition, selects one capability-compatible and reachable Worker and
+ * creates one durable execution attempt.
  *
  * @author weifuwan
  */
@@ -52,12 +52,21 @@ public class OfflineExecutionClaimService {
     this.workerScheduler = workerScheduler;
   }
 
-  @Transactional(transactionManager = "offlineSyncTransactionManager", rollbackFor = Exception.class)
   public ClaimResult claim(
       Long definitionId,
       String triggerType,
       Long retryFromExecutionId,
       int attemptNo) {
+    return claim(definitionId, triggerType, retryFromExecutionId, attemptNo, null);
+  }
+
+  @Transactional(transactionManager = "offlineSyncTransactionManager", rollbackFor = Exception.class)
+  public ClaimResult claim(
+      Long definitionId,
+      String triggerType,
+      Long retryFromExecutionId,
+      int attemptNo,
+      String reachabilityRequirementsJson) {
     executionRepository.lockDefinition(definitionId);
     OfflineJobDefinitionPO definition = definitionService.require(definitionId);
     if (!"ONLINE".equalsIgnoreCase(definition.getReleaseState())) {
@@ -80,7 +89,10 @@ public class OfflineExecutionClaimService {
       definition.setCapabilityRequirementsJson(capabilityRequirementsJson);
     }
 
-    Assignment assignment = workerScheduler.select(definition, capabilityRequirementsJson);
+    Assignment assignment = workerScheduler.select(
+        definition,
+        capabilityRequirementsJson,
+        reachabilityRequirementsJson);
     NodeRecord node = assignment.getNode();
     LocalDateTime now = LocalDateTime.now();
     OfflineJobExecutionPO execution = new OfflineJobExecutionPO();
@@ -96,6 +108,8 @@ public class OfflineExecutionClaimService {
     execution.setAssignmentCandidatesJson(assignment.getCandidatesJson());
     execution.setRequiredCapabilitiesJson(capabilityRequirementsJson);
     execution.setAssignedCapabilitiesJson(assignment.getAssignedCapabilitiesJson());
+    execution.setReachabilityRequirementsJson(reachabilityRequirementsJson);
+    execution.setAssignedReachabilityJson(assignment.getAssignedReachabilityJson());
     execution.setStatus(OfflineExecutionStatus.CREATED.name());
     execution.setStateVersion(1L);
     execution.setAttemptNo(Math.max(1, attemptNo));

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineExecutionClaimService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineExecutionClaimService.java
@@ -3,9 +3,11 @@ package io.yak.ops.business.sync.offline.service;
 import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
 import io.yak.ops.business.sync.offline.dao.OfflineJobExecutionDao;
 import io.yak.ops.business.sync.offline.domain.OfflineExecutionStatus;
+import io.yak.ops.business.sync.offline.repository.OfflineDefinitionCatalogRepository;
 import io.yak.ops.business.sync.offline.repository.OfflineDefinitionCatalogRepository.DefinitionVersion;
 import io.yak.ops.business.sync.offline.repository.OfflineExecutionControlRepository;
 import io.yak.ops.business.sync.offline.repository.OfflineNodeRepository.NodeRecord;
+import io.yak.ops.business.sync.offline.worker.OfflineCapabilityRequirementResolver;
 import io.yak.ops.business.sync.offline.worker.OfflineWorkerScheduler;
 import io.yak.ops.business.sync.offline.worker.OfflineWorkerScheduler.Assignment;
 import io.yak.ops.common.bean.po.sync.offline.OfflineJobDefinitionPO;
@@ -14,11 +16,13 @@ import java.time.LocalDateTime;
 import java.util.UUID;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 /**
  * 离线同步执行实例原子领取服务。
  *
- * Atomically claims a definition, selects one Worker and creates one durable execution attempt.
+ * Atomically claims a definition, selects one capability-compatible Worker and creates one
+ * durable execution attempt.
  *
  * @author weifuwan
  */
@@ -29,16 +33,22 @@ public class OfflineExecutionClaimService {
   private final OfflineJobDefinitionService definitionService;
   private final OfflineJobExecutionDao executionDao;
   private final OfflineExecutionControlRepository executionRepository;
+  private final OfflineDefinitionCatalogRepository catalogRepository;
+  private final OfflineCapabilityRequirementResolver capabilityResolver;
   private final OfflineWorkerScheduler workerScheduler;
 
   public OfflineExecutionClaimService(
       OfflineJobDefinitionService definitionService,
       OfflineJobExecutionDao executionDao,
       OfflineExecutionControlRepository executionRepository,
+      OfflineDefinitionCatalogRepository catalogRepository,
+      OfflineCapabilityRequirementResolver capabilityResolver,
       OfflineWorkerScheduler workerScheduler) {
     this.definitionService = definitionService;
     this.executionDao = executionDao;
     this.executionRepository = executionRepository;
+    this.catalogRepository = catalogRepository;
+    this.capabilityResolver = capabilityResolver;
     this.workerScheduler = workerScheduler;
   }
 
@@ -58,9 +68,20 @@ public class OfflineExecutionClaimService {
     }
 
     DefinitionVersion version = definitionService.requireCurrentVersion(definition);
-    Assignment assignment = workerScheduler.select(definition);
-    NodeRecord node = assignment.getNode();
     String logicalJobSpecJson = definitionService.resolveLogicalJobSpec(version);
+    String capabilityRequirementsJson = StringUtils.hasText(version.getCapabilityRequirementsJson())
+        ? version.getCapabilityRequirementsJson()
+        : StringUtils.hasText(definition.getCapabilityRequirementsJson())
+            ? definition.getCapabilityRequirementsJson()
+            : capabilityResolver.resolve(logicalJobSpecJson);
+    if (!StringUtils.hasText(version.getCapabilityRequirementsJson())) {
+      catalogRepository.backfillCapabilityRequirements(
+          definition.getId(), version.getId(), capabilityRequirementsJson);
+      definition.setCapabilityRequirementsJson(capabilityRequirementsJson);
+    }
+
+    Assignment assignment = workerScheduler.select(definition, capabilityRequirementsJson);
+    NodeRecord node = assignment.getNode();
     LocalDateTime now = LocalDateTime.now();
     OfflineJobExecutionPO execution = new OfflineJobExecutionPO();
     execution.setJobDefinitionId(definitionId);
@@ -73,6 +94,8 @@ public class OfflineExecutionClaimService {
     execution.setAssignmentScore(assignment.getScore());
     execution.setAssignmentReason(assignment.getReason());
     execution.setAssignmentCandidatesJson(assignment.getCandidatesJson());
+    execution.setRequiredCapabilitiesJson(capabilityRequirementsJson);
+    execution.setAssignedCapabilitiesJson(assignment.getAssignedCapabilitiesJson());
     execution.setStatus(OfflineExecutionStatus.CREATED.name());
     execution.setStateVersion(1L);
     execution.setAttemptNo(Math.max(1, attemptNo));

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineExecutionReadService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineExecutionReadService.java
@@ -2,6 +2,7 @@ package io.yak.ops.business.sync.offline.service;
 
 import com.baomidou.mybatisplus.core.metadata.IPage;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.yak.framework.common.PagingData;
 import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
 import io.yak.ops.business.sync.offline.config.OfflineSyncProperties;
@@ -62,11 +63,14 @@ public class OfflineExecutionReadService {
   public OfflineJobExecutionDetailVO detail(Long id) {
     OfflineJobExecutionPO execution = require(id);
     OfflineJobExecutionDetailVO detail = OfflineJobExecutionDetailVO.builder()
-        .execution(toVO(execution)).build();
+        .execution(toVO(execution))
+        .requiredCapabilities(parse(execution.getRequiredCapabilitiesJson()))
+        .assignedCapabilities(parse(execution.getAssignedCapabilitiesJson()))
+        .assignmentCandidates(parse(execution.getAssignmentCandidatesJson()))
+        .build();
     if (StringUtils.hasText(execution.getEngineSnapshotJson())) {
       try {
-        JsonNode snapshot = new com.fasterxml.jackson.databind.ObjectMapper()
-            .readTree(execution.getEngineSnapshotJson());
+        JsonNode snapshot = new ObjectMapper().readTree(execution.getEngineSnapshotJson());
         detail.setJob(snapshot);
         detail.setPipelines(snapshot.path("pipelines"));
         detail.setMetrics(snapshot.path("metrics"));
@@ -99,6 +103,10 @@ public class OfflineExecutionReadService {
         .append("assignmentMode: ").append(text(execution.getAssignmentMode())).append('\n')
         .append("assignmentScore: ").append(decimal(execution.getAssignmentScore())).append('\n')
         .append("assignmentReason: ").append(text(execution.getAssignmentReason())).append('\n')
+        .append("requiredCapabilities: ")
+        .append(text(execution.getRequiredCapabilitiesJson())).append('\n')
+        .append("assignedCapabilities: ")
+        .append(text(execution.getAssignedCapabilitiesJson())).append('\n')
         .append("engineJobId: ").append(text(execution.getEngineJobId())).append('\n')
         .append("status: ").append(text(execution.getStatus())).append('\n')
         .append("attemptNo: ").append(value(execution.getAttemptNo())).append('\n')
@@ -136,6 +144,8 @@ public class OfflineExecutionReadService {
         .assignmentMode(execution.getAssignmentMode())
         .assignmentScore(execution.getAssignmentScore())
         .assignmentReason(execution.getAssignmentReason())
+        .requiredCapabilitiesJson(execution.getRequiredCapabilitiesJson())
+        .assignedCapabilitiesJson(execution.getAssignedCapabilitiesJson())
         .stateVersion(value(execution.getStateVersion()))
         .attemptNo(value(execution.getAttemptNo()))
         .triggerType(execution.getTriggerType())
@@ -156,6 +166,17 @@ public class OfflineExecutionReadService {
         .lastSyncTime(format(execution.getLastSyncTime()))
         .updateTime(format(execution.getUpdateTime()))
         .build();
+  }
+
+  private JsonNode parse(String value) {
+    if (!StringUtils.hasText(value)) {
+      return null;
+    }
+    try {
+      return new ObjectMapper().readTree(value);
+    } catch (Exception ignored) {
+      return null;
+    }
   }
 
   private String baseUrl(OfflineJobExecutionPO execution) {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineJobDefinitionService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineJobDefinitionService.java
@@ -13,6 +13,7 @@ import io.yak.ops.business.sync.offline.repository.OfflineScheduleRepository;
 import io.yak.ops.business.sync.offline.repository.OfflineScheduleRepository.ScheduleRecord;
 import io.yak.ops.business.sync.offline.service.OfflineDefinitionSupport.DraftDefinition;
 import io.yak.ops.business.sync.offline.service.OfflineDefinitionSupport.PreparedDefinition;
+import io.yak.ops.business.sync.offline.worker.OfflineCapabilityRequirementResolver;
 import io.yak.ops.business.sync.offline.worker.OfflineWorkerScheduler;
 import io.yak.ops.business.sync.offline.worker.OfflineWorkerScheduler.PolicyProjection;
 import io.yak.ops.common.bean.dto.sync.offline.OfflineJobDefinitionDTO;
@@ -53,6 +54,7 @@ public class OfflineJobDefinitionService {
   private final OfflineExecutionControlRepository executionRepository;
   private final OfflineDefinitionSupport support;
   private final OfflineWorkerScheduler workerScheduler;
+  private final OfflineCapabilityRequirementResolver capabilityResolver;
   private final AtomicLong idSequence = new AtomicLong(System.currentTimeMillis() * 1000L);
 
   public Long nextId() {
@@ -105,6 +107,7 @@ public class OfflineJobDefinitionService {
     definition.setScheduleJson(support.writeNullable(draft.getRequest().get("schedule")));
     definition.setEnvJson(support.writeNullable(draft.getRequest().get("env")));
     applyWorkerPolicy(definition, policy);
+    definition.setCapabilityRequirementsJson(null);
     definition.setVersion(0);
     definition.setCurrentVersionId(null);
     definition.setCreateTime(existing == null ? now : existing.getCreateTime());
@@ -138,6 +141,7 @@ public class OfflineJobDefinitionService {
       throw exception;
     }
     PolicyProjection policy = workerScheduler.normalize(prepared.getRequest().get("worker"));
+    String capabilityRequirementsJson = capabilityResolver.resolve(prepared.getJobSpecJson());
     if (definitionDao.existsByName(prepared.getJobName(), id)) {
       throw new IllegalArgumentException("离线同步任务名称已存在：" + prepared.getJobName());
     }
@@ -166,6 +170,7 @@ public class OfflineJobDefinitionService {
     definition.setScheduleJson(support.writeNullable(prepared.getRequest().get("schedule")));
     definition.setEnvJson(support.writeNullable(prepared.getRequest().get("env")));
     applyWorkerPolicy(definition, policy);
+    definition.setCapabilityRequirementsJson(capabilityRequirementsJson);
     definition.setVersion(version);
     definition.setReleaseState(existing == null ? "OFFLINE" : existing.getReleaseState());
     definition.setCreateTime(existing == null ? now : existing.getCreateTime());
@@ -181,7 +186,8 @@ public class OfflineJobDefinitionService {
         version,
         prepared.getDefinitionJson(),
         prepared.getJobSpecJson(),
-        prepared.getDigest());
+        prepared.getDigest(),
+        capabilityRequirementsJson);
     definition.setCurrentVersionId(versionId);
     definitionDao.updateById(definition);
     scheduleRepository.saveSchedule(id, prepared.getRequest().get("schedule"));
@@ -296,6 +302,7 @@ public class OfflineJobDefinitionService {
           "format",
           StringUtils.hasText(version.getJobSpecJson()) ? "JOB_SPEC" : "LEGACY_DERIVED");
       item.put("configDigest", version.getConfigDigest());
+      item.put("capabilityRequirements", version.getCapabilityRequirementsJson());
       item.put("createTime", version.getCreateTime());
       result.add(item);
     }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineJobExecutionService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineJobExecutionService.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import io.yak.framework.common.PagingData;
 import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
 import io.yak.ops.business.sync.offline.engine.LinkUpClient.LinkUpJobResponse;
+import io.yak.ops.business.sync.offline.worker.OfflineWorkerCapabilityService;
 import io.yak.ops.common.bean.dto.sync.offline.OfflineBatchOperationDTO;
 import io.yak.ops.common.bean.dto.sync.offline.OfflineJobExecutionQueryDTO;
 import io.yak.ops.common.bean.po.sync.offline.OfflineJobDefinitionPO;
@@ -30,20 +31,25 @@ public class OfflineJobExecutionService {
   private final OfflineExecutionOrchestrator orchestrator;
   private final OfflineExecutionReadService readService;
   private final OfflineJobDefinitionService definitionService;
+  private final OfflineWorkerCapabilityService capabilityService;
 
   public OfflineJobExecutionVO execute(Long definitionId) {
+    preheatCapabilities();
     return readService.toVO(orchestrator.execute(definitionId, "MANUAL", null, 1));
   }
 
   public OfflineJobExecutionVO executeScheduled(Long definitionId) {
+    preheatCapabilities();
     return readService.toVO(orchestrator.execute(definitionId, "SCHEDULE", null, 1));
   }
 
   public OfflineJobExecutionVO retry(Long executionId) {
+    preheatCapabilities();
     return readService.toVO(orchestrator.retryFrom(readService.require(executionId)));
   }
 
   public OfflineJobExecutionVO retryFrom(OfflineJobExecutionPO previous) {
+    preheatCapabilities();
     return readService.toVO(orchestrator.retryFrom(previous));
   }
 
@@ -90,6 +96,11 @@ public class OfflineJobExecutionService {
 
   public void markLost(OfflineJobExecutionPO execution, String message) {
     orchestrator.markLost(execution, message);
+  }
+
+  private void preheatCapabilities() {
+    // 该调用发生在执行领取事务之前；内部仅刷新到期或未知快照。
+    capabilityService.scheduledRefresh();
   }
 
   private OfflineBatchOperationVO batch(OfflineBatchOperationDTO requestDTO, boolean execute) {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineWorkerRegistry.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineWorkerRegistry.java
@@ -18,8 +18,7 @@ import org.springframework.util.StringUtils;
 /**
  * Link-Up Worker 注册表、定时心跳和默认节点选择器。
  *
- * <p>本阶段只扩展节点管理闭环。任务执行仍优先使用
- * {@code yak.sync.offline.engine.node-id} 指定的默认 Worker。
+ * <p>任务执行由多 Worker 调度器选择节点；本组件继续负责默认配置节点的登记和全部节点心跳。
  *
  * @author weifuwan
  */
@@ -110,6 +109,9 @@ public class OfflineWorkerRegistry {
       return existing;
     }
 
+    boolean addressChanged = existing != null
+        && StringUtils.hasText(existing.getBaseUrl())
+        && !baseUrl.equals(existing.getBaseUrl());
     LocalDateTime now = LocalDateTime.now();
     NodeRecord configured = existing == null ? NodeRecord.builder().build() : existing;
     configured.setNodeId(nodeId);
@@ -136,6 +138,10 @@ public class OfflineWorkerRegistry {
         ? now : configured.getCreateTime());
     configured.setUpdateTime(now);
     repository.upsert(configured);
+    if (addressChanged) {
+      // 新地址必须重新证明 Connector 能力，不能沿用原地址的 READY 快照。
+      repository.resetCapabilities(nodeId);
+    }
     return repository.find(nodeId);
   }
 

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineWorkerRegistry.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineWorkerRegistry.java
@@ -149,6 +149,7 @@ public class OfflineWorkerRegistry {
     try {
       LinkUpNodeResponse response = probeClient.node(node.getBaseUrl());
       validate(node, response);
+      boolean runtimeChanged = runtimeChanged(node, response);
       NodeRecord heartbeat = NodeRecord.builder()
           .nodeId(node.getNodeId())
           .nodeName(StringUtils.hasText(node.getNodeName())
@@ -164,6 +165,10 @@ public class OfflineWorkerRegistry {
           .lastHeartbeatTime(LocalDateTime.now())
           .build();
       repository.updateHeartbeatSuccess(heartbeat);
+      if (runtimeChanged) {
+        // 同一 nodeId 的新进程或新版本必须重新证明 Connector 能力。
+        repository.resetCapabilities(node.getNodeId());
+      }
       return repository.find(node.getNodeId());
     } catch (RuntimeException exception) {
       repository.updateHeartbeatFailure(node.getNodeId(), message(exception));
@@ -172,6 +177,16 @@ public class OfflineWorkerRegistry {
       }
       return repository.find(node.getNodeId());
     }
+  }
+
+  private boolean runtimeChanged(NodeRecord previous, LinkUpNodeResponse current) {
+    boolean instanceChanged = StringUtils.hasText(previous.getWorkerInstanceId())
+        && StringUtils.hasText(current.getInstanceId())
+        && !Objects.equals(previous.getWorkerInstanceId(), current.getInstanceId());
+    boolean versionChanged = StringUtils.hasText(previous.getEngineVersion())
+        && StringUtils.hasText(current.getVersion())
+        && !Objects.equals(previous.getEngineVersion(), current.getVersion());
+    return instanceChanged || versionChanged;
   }
 
   private void validate(NodeRecord expected, LinkUpNodeResponse response) {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/ReachabilityAwareOfflineJobExecutionService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/ReachabilityAwareOfflineJobExecutionService.java
@@ -1,0 +1,61 @@
+package io.yak.ops.business.sync.offline.service;
+
+import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import io.yak.ops.business.sync.offline.worker.OfflineWorkerCapabilityService;
+import io.yak.ops.business.sync.offline.worker.OfflineWorkerReachabilityService;
+import io.yak.ops.common.bean.po.sync.offline.OfflineJobExecutionPO;
+import io.yak.ops.common.bean.vo.sync.offline.OfflineJobExecutionVO;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Service;
+
+/**
+ * 执行命令主实现：在原子领取事务之前预热 Worker Connector 能力和数据源可达性。
+ *
+ * @author weifuwan
+ */
+@Primary
+@ConditionalOnOfflineSyncEnabled
+@Service
+public class ReachabilityAwareOfflineJobExecutionService extends OfflineJobExecutionService {
+
+  private final OfflineExecutionReadService readService;
+  private final OfflineWorkerReachabilityService reachabilityService;
+
+  public ReachabilityAwareOfflineJobExecutionService(
+      OfflineExecutionOrchestrator orchestrator,
+      OfflineExecutionReadService readService,
+      OfflineJobDefinitionService definitionService,
+      OfflineWorkerCapabilityService capabilityService,
+      OfflineWorkerReachabilityService reachabilityService) {
+    super(orchestrator, readService, definitionService, capabilityService);
+    this.readService = readService;
+    this.reachabilityService = reachabilityService;
+  }
+
+  @Override
+  public OfflineJobExecutionVO execute(Long definitionId) {
+    reachabilityService.preheat(definitionId);
+    return super.execute(definitionId);
+  }
+
+  @Override
+  public OfflineJobExecutionVO executeScheduled(Long definitionId) {
+    reachabilityService.preheat(definitionId);
+    return super.executeScheduled(definitionId);
+  }
+
+  @Override
+  public OfflineJobExecutionVO retry(Long executionId) {
+    OfflineJobExecutionPO previous = readService.require(executionId);
+    reachabilityService.preheat(previous.getJobDefinitionId());
+    return super.retry(executionId);
+  }
+
+  @Override
+  public OfflineJobExecutionVO retryFrom(OfflineJobExecutionPO previous) {
+    if (previous != null) {
+      reachabilityService.preheat(previous.getJobDefinitionId());
+    }
+    return super.retryFrom(previous);
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/worker/CapabilityRefreshingOfflineWorkerReachabilityService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/worker/CapabilityRefreshingOfflineWorkerReachabilityService.java
@@ -1,0 +1,63 @@
+package io.yak.ops.business.sync.offline.worker;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import io.yak.ops.business.sync.offline.config.OfflineCapabilityProperties;
+import io.yak.ops.business.sync.offline.engine.LinkUpConnectorPreflightClient;
+import io.yak.ops.business.sync.offline.repository.OfflineDefinitionCatalogRepository.DefinitionVersion;
+import io.yak.ops.business.sync.offline.repository.OfflineNodeRepository;
+import io.yak.ops.business.sync.offline.repository.OfflineWorkerPreflightRepository;
+import io.yak.ops.business.sync.offline.service.OfflineJobDefinitionService;
+import io.yak.ops.common.bean.po.sync.offline.OfflineJobDefinitionPO;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Service;
+
+/**
+ * 能力调度使用的主预热服务：先刷新 Worker Connector 能力，再执行 Worker 视角预检。
+ *
+ * @author weifuwan
+ */
+@Primary
+@ConditionalOnOfflineSyncEnabled
+@Service
+public class CapabilityRefreshingOfflineWorkerReachabilityService
+    extends OfflineWorkerReachabilityService {
+
+  private final OfflineWorkerCapabilityService capabilityService;
+
+  public CapabilityRefreshingOfflineWorkerReachabilityService(
+      OfflineJobDefinitionService definitionService,
+      OfflineNodeRepository nodeRepository,
+      OfflineWorkerPreflightRepository preflightRepository,
+      OfflineCapabilityMatcher capabilityMatcher,
+      OfflineCapabilityRequirementResolver capabilityResolver,
+      LinkUpConnectorPreflightClient preflightClient,
+      OfflineCapabilityProperties properties,
+      @Qualifier("offlineSyncJsonMapper") ObjectMapper objectMapper,
+      OfflineWorkerCapabilityService capabilityService) {
+    super(
+        definitionService,
+        nodeRepository,
+        preflightRepository,
+        capabilityMatcher,
+        capabilityResolver,
+        preflightClient,
+        properties,
+        objectMapper);
+    this.capabilityService = capabilityService;
+  }
+
+  @Override
+  public String preheat(Long definitionId) {
+    capabilityService.scheduledRefresh();
+    return super.preheat(definitionId);
+  }
+
+  @Override
+  public String requirements(
+      OfflineJobDefinitionPO definition,
+      DefinitionVersion version) {
+    return super.requirements(definition, version);
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/worker/OfflineCapabilityMatcher.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/worker/OfflineCapabilityMatcher.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeSet;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
@@ -60,6 +61,19 @@ public class OfflineCapabilityMatcher {
     }
 
     JsonNode snapshot = read(node.getConnectorSchemasJson(), "Worker Connector 能力快照");
+    String snapshotInstanceId = snapshot.path("workerInstanceId").asText(null);
+    if (StringUtils.hasText(snapshotInstanceId)
+        && StringUtils.hasText(node.getWorkerInstanceId())
+        && !snapshotInstanceId.equals(node.getWorkerInstanceId())) {
+      return MatchResult.reject("Connector 能力快照属于旧 Worker 进程");
+    }
+    String snapshotEngineVersion = snapshot.path("engineVersion").asText(null);
+    if (StringUtils.hasText(snapshotEngineVersion)
+        && StringUtils.hasText(node.getEngineVersion())
+        && !snapshotEngineVersion.equals(node.getEngineVersion())) {
+      return MatchResult.reject("Connector 能力快照属于旧引擎版本");
+    }
+
     Map<String, JsonNode> available = index(snapshot.path("connectors"));
     ArrayNode matched = objectMapper.createArrayNode();
     List<String> descriptions = new ArrayList<>();
@@ -86,7 +100,7 @@ public class OfflineCapabilityMatcher {
 
       Set<String> actualCapabilities = values(connector.path("capabilities"));
       Set<String> requiredCapabilities = values(requirement.path("capabilities"));
-      Set<String> missing = new HashSet<>(requiredCapabilities);
+      Set<String> missing = new TreeSet<>(requiredCapabilities);
       missing.removeAll(actualCapabilities);
       if (!missing.isEmpty()) {
         return MatchResult.reject(
@@ -105,6 +119,8 @@ public class OfflineCapabilityMatcher {
     }
 
     ObjectNode assigned = objectMapper.createObjectNode();
+    assigned.put("workerInstanceId", node.getWorkerInstanceId());
+    assigned.put("engineVersion", node.getEngineVersion());
     assigned.put("capabilityDigest", node.getCapabilityDigest());
     assigned.put("capabilitySyncedAt", node.getCapabilitySyncedAt().toString());
     assigned.set("connectors", matched);

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/worker/OfflineCapabilityMatcher.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/worker/OfflineCapabilityMatcher.java
@@ -1,0 +1,202 @@
+package io.yak.ops.business.sync.offline.worker;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import io.yak.ops.business.sync.offline.config.OfflineCapabilityProperties;
+import io.yak.ops.business.sync.offline.repository.OfflineNodeRepository.NodeRecord;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+/** 任务能力要求与 Worker Connector 能力快照匹配器。 */
+@ConditionalOnOfflineSyncEnabled
+@Component
+public class OfflineCapabilityMatcher {
+
+  private final OfflineCapabilityProperties properties;
+  private final ObjectMapper objectMapper;
+
+  public OfflineCapabilityMatcher(
+      OfflineCapabilityProperties properties,
+      @Qualifier("offlineSyncJsonMapper") ObjectMapper objectMapper) {
+    this.properties = properties;
+    this.objectMapper = objectMapper;
+  }
+
+  public MatchResult match(NodeRecord node, String requirementsJson) {
+    if (!properties.isEnabled()) {
+      return MatchResult.accept("能力调度已关闭", "{}");
+    }
+    JsonNode requirements = read(requirementsJson, "任务能力要求");
+    JsonNode endpoints = requirements.path("endpoints");
+    if (!endpoints.isArray() || endpoints.isEmpty()) {
+      return MatchResult.accept("任务没有显式能力要求", "{}");
+    }
+    if (node == null) {
+      return MatchResult.reject("Worker 不存在");
+    }
+    if (!"READY".equalsIgnoreCase(node.getCapabilityStatus())) {
+      return MatchResult.reject("Connector 能力状态为 " + text(node.getCapabilityStatus(), "UNKNOWN"));
+    }
+    if (!StringUtils.hasText(node.getConnectorSchemasJson()) || node.getCapabilitySyncedAt() == null) {
+      return MatchResult.reject("Worker 缺少 Connector 能力快照");
+    }
+    long age = Duration.between(node.getCapabilitySyncedAt(), LocalDateTime.now()).toMillis();
+    if (age > Math.max(1_000L, properties.getMaxStaleMillis())) {
+      return MatchResult.reject("Worker Connector 能力快照已过期");
+    }
+
+    JsonNode snapshot = read(node.getConnectorSchemasJson(), "Worker Connector 能力快照");
+    Map<String, JsonNode> available = index(snapshot.path("connectors"));
+    ArrayNode matched = objectMapper.createArrayNode();
+    List<String> descriptions = new ArrayList<>();
+
+    for (JsonNode requirement : endpoints) {
+      String connectorId = requirement.path("connectorId").asText("")
+          .trim().toLowerCase(Locale.ROOT);
+      String role = requirement.path("role").asText("")
+          .trim().toUpperCase(Locale.ROOT);
+      JsonNode connector = available.get(key(connectorId, role));
+      if (connector == null) {
+        return MatchResult.reject("缺少 Connector " + connectorId + "/" + role);
+      }
+
+      String requiredFingerprint = requirement.path("schemaFingerprint").asText("");
+      String actualFingerprint = connector.path("schemaFingerprint").asText("");
+      if (properties.isStrictSchemaFingerprint()
+          && StringUtils.hasText(requiredFingerprint)
+          && !requiredFingerprint.equals(actualFingerprint)) {
+        return MatchResult.reject(
+            connectorId + "/" + role + " Schema 指纹不一致，任务="
+                + requiredFingerprint + "，Worker=" + actualFingerprint);
+      }
+
+      Set<String> actualCapabilities = values(connector.path("capabilities"));
+      Set<String> requiredCapabilities = values(requirement.path("capabilities"));
+      Set<String> missing = new HashSet<>(requiredCapabilities);
+      missing.removeAll(actualCapabilities);
+      if (!missing.isEmpty()) {
+        return MatchResult.reject(
+            connectorId + "/" + role + " 缺少能力 " + String.join(",", missing));
+      }
+
+      ObjectNode item = objectMapper.createObjectNode();
+      item.put("connectorId", connectorId);
+      item.put("role", role);
+      item.put("schemaVersion", connector.path("schemaVersion").asText(""));
+      item.put("schemaFingerprint", actualFingerprint);
+      item.set("requiredCapabilities", requirement.path("capabilities").deepCopy());
+      item.set("workerCapabilities", connector.path("capabilities").deepCopy());
+      matched.add(item);
+      descriptions.add(connectorId + "/" + role);
+    }
+
+    ObjectNode assigned = objectMapper.createObjectNode();
+    assigned.put("capabilityDigest", node.getCapabilityDigest());
+    assigned.put("capabilitySyncedAt", node.getCapabilitySyncedAt().toString());
+    assigned.set("connectors", matched);
+    return MatchResult.accept(
+        "能力匹配：" + String.join("、", descriptions), write(assigned));
+  }
+
+  private Map<String, JsonNode> index(JsonNode connectors) {
+    Map<String, JsonNode> result = new HashMap<>();
+    if (!connectors.isArray()) {
+      return result;
+    }
+    for (JsonNode connector : connectors) {
+      String connectorId = connector.path("connectorId").asText("")
+          .trim().toLowerCase(Locale.ROOT);
+      String role = connector.path("role").asText("")
+          .trim().toUpperCase(Locale.ROOT);
+      if (StringUtils.hasText(connectorId) && StringUtils.hasText(role)) {
+        result.put(key(connectorId, role), connector);
+      }
+    }
+    return result;
+  }
+
+  private Set<String> values(JsonNode values) {
+    Set<String> result = new HashSet<>();
+    if (values != null && values.isArray()) {
+      for (JsonNode value : values) {
+        if (StringUtils.hasText(value.asText())) {
+          result.add(value.asText().trim().toUpperCase(Locale.ROOT));
+        }
+      }
+    }
+    return result;
+  }
+
+  private JsonNode read(String value, String name) {
+    if (!StringUtils.hasText(value)) {
+      return objectMapper.createObjectNode();
+    }
+    try {
+      return objectMapper.readTree(value);
+    } catch (JsonProcessingException exception) {
+      throw new IllegalStateException(name + "已损坏", exception);
+    }
+  }
+
+  private String write(JsonNode value) {
+    try {
+      return objectMapper.writeValueAsString(value);
+    } catch (JsonProcessingException exception) {
+      throw new IllegalStateException("序列化能力匹配结果失败", exception);
+    }
+  }
+
+  private String key(String connectorId, String role) {
+    return connectorId + ":" + role;
+  }
+
+  private String text(String value, String fallback) {
+    return StringUtils.hasText(value) ? value : fallback;
+  }
+
+  public static final class MatchResult {
+    private final boolean matched;
+    private final String reason;
+    private final String assignedCapabilitiesJson;
+
+    private MatchResult(boolean matched, String reason, String assignedCapabilitiesJson) {
+      this.matched = matched;
+      this.reason = reason;
+      this.assignedCapabilitiesJson = assignedCapabilitiesJson;
+    }
+
+    public static MatchResult accept(String reason, String assignedCapabilitiesJson) {
+      return new MatchResult(true, reason, assignedCapabilitiesJson);
+    }
+
+    public static MatchResult reject(String reason) {
+      return new MatchResult(false, reason, null);
+    }
+
+    public boolean isMatched() {
+      return matched;
+    }
+
+    public String getReason() {
+      return reason;
+    }
+
+    public String getAssignedCapabilitiesJson() {
+      return assignedCapabilitiesJson;
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/worker/OfflineCapabilityRequirementResolver.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/worker/OfflineCapabilityRequirementResolver.java
@@ -8,8 +8,6 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
 import io.yak.ops.business.sync.offline.form.ConnectorSchemaRegistry;
 import io.yak.ops.business.sync.offline.form.ConnectorSchemaSnapshot;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 import java.util.TreeSet;
@@ -53,9 +51,8 @@ public class OfflineCapabilityRequirementResolver {
     if (jobSpec == null || !jobSpec.isObject()) {
       throw new IllegalArgumentException("JobSpec 必须是 JSON 对象");
     }
-    ObjectNode result = objectMapper.createObjectNode();
-    result.put("version", "1");
-    ArrayNode endpoints = result.putArray("endpoints");
+    ObjectNode result = emptyRequirements();
+    ArrayNode endpoints = (ArrayNode) result.path("endpoints");
     endpoints.add(endpoint(jobSpec.path("source"), "SOURCE"));
     endpoints.add(endpoint(jobSpec.path("sink"), "SINK"));
     return write(result);
@@ -63,7 +60,7 @@ public class OfflineCapabilityRequirementResolver {
 
   public JsonNode read(String value) {
     if (!StringUtils.hasText(value)) {
-      return objectMapper.createObjectNode().put("version", "1").putArray("endpoints");
+      return emptyRequirements();
     }
     try {
       JsonNode parsed = objectMapper.readTree(value);
@@ -74,6 +71,13 @@ public class OfflineCapabilityRequirementResolver {
     } catch (JsonProcessingException exception) {
       throw new IllegalStateException("能力要求 JSON 已损坏", exception);
     }
+  }
+
+  private ObjectNode emptyRequirements() {
+    ObjectNode result = objectMapper.createObjectNode();
+    result.put("version", "1");
+    result.putArray("endpoints");
+    return result;
   }
 
   private ObjectNode endpoint(JsonNode endpoint, String role) {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/worker/OfflineCapabilityRequirementResolver.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/worker/OfflineCapabilityRequirementResolver.java
@@ -1,0 +1,163 @@
+package io.yak.ops.business.sync.offline.worker;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import io.yak.ops.business.sync.offline.form.ConnectorSchemaRegistry;
+import io.yak.ops.business.sync.offline.form.ConnectorSchemaSnapshot;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.TreeSet;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+/**
+ * 从不可变 JobSpec 派生 Worker Connector 能力要求。
+ *
+ * <p>要求包含 Connector、角色、保存时使用的 Schema 指纹以及任务实际启用的执行特性。
+ *
+ * @author weifuwan
+ */
+@ConditionalOnOfflineSyncEnabled
+@Component
+public class OfflineCapabilityRequirementResolver {
+
+  private final ConnectorSchemaRegistry schemaRegistry;
+  private final ObjectMapper objectMapper;
+
+  public OfflineCapabilityRequirementResolver(
+      ConnectorSchemaRegistry schemaRegistry,
+      @Qualifier("offlineSyncJsonMapper") ObjectMapper objectMapper) {
+    this.schemaRegistry = schemaRegistry;
+    this.objectMapper = objectMapper;
+  }
+
+  public String resolve(String jobSpecJson) {
+    if (!StringUtils.hasText(jobSpecJson)) {
+      throw new IllegalArgumentException("JobSpec 不能为空");
+    }
+    try {
+      return resolve(objectMapper.readTree(jobSpecJson));
+    } catch (JsonProcessingException exception) {
+      throw new IllegalStateException("JobSpec JSON 已损坏", exception);
+    }
+  }
+
+  public String resolve(JsonNode jobSpec) {
+    if (jobSpec == null || !jobSpec.isObject()) {
+      throw new IllegalArgumentException("JobSpec 必须是 JSON 对象");
+    }
+    ObjectNode result = objectMapper.createObjectNode();
+    result.put("version", "1");
+    ArrayNode endpoints = result.putArray("endpoints");
+    endpoints.add(endpoint(jobSpec.path("source"), "SOURCE"));
+    endpoints.add(endpoint(jobSpec.path("sink"), "SINK"));
+    return write(result);
+  }
+
+  public JsonNode read(String value) {
+    if (!StringUtils.hasText(value)) {
+      return objectMapper.createObjectNode().put("version", "1").putArray("endpoints");
+    }
+    try {
+      JsonNode parsed = objectMapper.readTree(value);
+      if (parsed == null || !parsed.isObject() || !parsed.path("endpoints").isArray()) {
+        throw new IllegalStateException("能力要求 JSON 格式不正确");
+      }
+      return parsed;
+    } catch (JsonProcessingException exception) {
+      throw new IllegalStateException("能力要求 JSON 已损坏", exception);
+    }
+  }
+
+  private ObjectNode endpoint(JsonNode endpoint, String role) {
+    if (endpoint == null || !endpoint.isObject()) {
+      throw new IllegalArgumentException(role + " JobSpec 不完整");
+    }
+    String connectorId = endpoint.path("connectorId").asText("").trim().toLowerCase(Locale.ROOT);
+    if (!StringUtils.hasText(connectorId)) {
+      throw new IllegalArgumentException(role + " JobSpec 缺少 connectorId");
+    }
+
+    ObjectNode requirement = objectMapper.createObjectNode();
+    requirement.put("connectorId", connectorId);
+    requirement.put("role", role);
+    JsonNode schema = schema(connectorId, role);
+    requirement.put("schemaVersion", schema.path("schemaVersion").asText(""));
+    requirement.put("schemaFingerprint", schema.path("schemaFingerprint").asText(""));
+
+    ArrayNode capabilities = requirement.putArray("capabilities");
+    requiredCapabilities(endpoint.path("options"), role).forEach(capabilities::add);
+    return requirement;
+  }
+
+  private JsonNode schema(String connectorId, String role) {
+    try {
+      ConnectorSchemaSnapshot snapshot = schemaRegistry.get(connectorId, role);
+      return snapshot == null || snapshot.getSchema() == null
+          ? objectMapper.createObjectNode()
+          : snapshot.getSchema();
+    } catch (RuntimeException ignored) {
+      // Worker 暂时离线时仍允许保存任务；调度至少会校验 Connector 和实际特性能力。
+      return objectMapper.createObjectNode();
+    }
+  }
+
+  private Set<String> requiredCapabilities(JsonNode options, String role) {
+    Set<String> required = new TreeSet<>();
+    JsonNode value = options == null || !options.isObject()
+        ? objectMapper.createObjectNode() : options;
+    if ("SOURCE".equals(role)) {
+      if (text(value, "query") || text(value, "sql")) {
+        required.add("CUSTOM_SQL");
+      }
+      if (value.path("table_list").isArray() && !value.path("table_list").isEmpty()) {
+        required.add("MULTI_TABLE");
+      }
+      if (text(value, "partition_column")
+          || number(value, "partition_num")
+          || number(value, "partition_size")) {
+        required.add("PARTITION_SPLIT");
+      }
+    } else {
+      if ("UPSERT".equalsIgnoreCase(value.path("write_mode").asText())) {
+        required.add("UPSERT");
+      }
+      if ("CREATE_SCHEMA_WHEN_NOT_EXIST".equalsIgnoreCase(
+          value.path("schema_save_mode").asText())) {
+        required.add("AUTO_CREATE_TABLE");
+      }
+      if (text(value, "custom_sql")) {
+        required.add("CUSTOM_SQL");
+      }
+      String dirtyPolicy = value.path("dirty_data_policy").asText("");
+      if ("SKIP".equalsIgnoreCase(dirtyPolicy) || value.has("dirty_data_max_count")) {
+        required.add("DIRTY_DATA_HANDLING");
+      }
+    }
+    return required;
+  }
+
+  private boolean text(JsonNode node, String field) {
+    return StringUtils.hasText(node.path(field).asText(null));
+  }
+
+  private boolean number(JsonNode node, String field) {
+    JsonNode value = node.get(field);
+    return value != null && value.isNumber() && value.asLong() > 0L;
+  }
+
+  private String write(JsonNode value) {
+    try {
+      return objectMapper.writeValueAsString(value);
+    } catch (JsonProcessingException exception) {
+      throw new IllegalStateException("序列化能力要求失败", exception);
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/worker/OfflineCapabilityRequirementResolver.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/worker/OfflineCapabilityRequirementResolver.java
@@ -6,8 +6,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
-import io.yak.ops.business.sync.offline.form.ConnectorSchemaRegistry;
-import io.yak.ops.business.sync.offline.form.ConnectorSchemaSnapshot;
+import io.yak.ops.business.sync.offline.repository.OfflineConnectorSchemaRepository;
+import io.yak.ops.business.sync.offline.repository.OfflineConnectorSchemaRepository.SchemaRecord;
 import java.util.Locale;
 import java.util.Set;
 import java.util.TreeSet;
@@ -19,6 +19,7 @@ import org.springframework.util.StringUtils;
  * 从不可变 JobSpec 派生 Worker Connector 能力要求。
  *
  * <p>要求包含 Connector、角色、保存时使用的 Schema 指纹以及任务实际启用的执行特性。
+ * Schema 只读取 Yak Ops 已持久化的本地快照，不在任务保存或执行领取事务中回源 Worker。
  *
  * @author weifuwan
  */
@@ -26,13 +27,13 @@ import org.springframework.util.StringUtils;
 @Component
 public class OfflineCapabilityRequirementResolver {
 
-  private final ConnectorSchemaRegistry schemaRegistry;
+  private final OfflineConnectorSchemaRepository schemaRepository;
   private final ObjectMapper objectMapper;
 
   public OfflineCapabilityRequirementResolver(
-      ConnectorSchemaRegistry schemaRegistry,
+      OfflineConnectorSchemaRepository schemaRepository,
       @Qualifier("offlineSyncJsonMapper") ObjectMapper objectMapper) {
-    this.schemaRegistry = schemaRegistry;
+    this.schemaRepository = schemaRepository;
     this.objectMapper = objectMapper;
   }
 
@@ -92,7 +93,7 @@ public class OfflineCapabilityRequirementResolver {
     ObjectNode requirement = objectMapper.createObjectNode();
     requirement.put("connectorId", connectorId);
     requirement.put("role", role);
-    JsonNode schema = schema(connectorId, role);
+    JsonNode schema = localSchema(connectorId, role);
     requirement.put("schemaVersion", schema.path("schemaVersion").asText(""));
     requirement.put("schemaFingerprint", schema.path("schemaFingerprint").asText(""));
 
@@ -101,15 +102,20 @@ public class OfflineCapabilityRequirementResolver {
     return requirement;
   }
 
-  private JsonNode schema(String connectorId, String role) {
-    try {
-      ConnectorSchemaSnapshot snapshot = schemaRegistry.get(connectorId, role);
-      return snapshot == null || snapshot.getSchema() == null
-          ? objectMapper.createObjectNode()
-          : snapshot.getSchema();
-    } catch (RuntimeException ignored) {
-      // Worker 暂时离线时仍允许保存任务；调度至少会校验 Connector 和实际特性能力。
+  private JsonNode localSchema(String connectorId, String role) {
+    SchemaRecord record = schemaRepository.find(connectorId, role);
+    if (record == null || !StringUtils.hasText(record.getSchemaJson())) {
       return objectMapper.createObjectNode();
+    }
+    try {
+      JsonNode schema = objectMapper.readTree(record.getSchemaJson());
+      return schema == null || !schema.isObject()
+          ? objectMapper.createObjectNode()
+          : schema;
+    } catch (JsonProcessingException exception) {
+      throw new IllegalStateException(
+          "本地 Connector Schema 已损坏：" + connectorId + "/" + role,
+          exception);
     }
   }
 

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/worker/OfflineReachabilityMatcher.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/worker/OfflineReachabilityMatcher.java
@@ -1,0 +1,162 @@
+package io.yak.ops.business.sync.offline.worker;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import io.yak.ops.business.sync.offline.config.OfflineCapabilityProperties;
+import io.yak.ops.business.sync.offline.repository.OfflineWorkerPreflightRepository;
+import io.yak.ops.business.sync.offline.repository.OfflineWorkerPreflightRepository.PreflightRecord;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+/** 调度事务内只读 Worker 预检短缓存，不发起远程请求。 */
+@ConditionalOnOfflineSyncEnabled
+@Component
+public class OfflineReachabilityMatcher {
+
+  private final OfflineWorkerPreflightRepository repository;
+  private final OfflineCapabilityProperties properties;
+  private final ObjectMapper objectMapper;
+
+  public OfflineReachabilityMatcher(
+      OfflineWorkerPreflightRepository repository,
+      OfflineCapabilityProperties properties,
+      @Qualifier("offlineSyncJsonMapper") ObjectMapper objectMapper) {
+    this.repository = repository;
+    this.properties = properties;
+    this.objectMapper = objectMapper;
+  }
+
+  public MatchResult match(String nodeId, String requirementsJson) {
+    if (!properties.isReachabilityEnabled()) {
+      return MatchResult.accept("Worker 可达性预检已关闭", "{}");
+    }
+    JsonNode requirements = read(requirementsJson);
+    JsonNode endpoints = requirements.path("endpoints");
+    if (!endpoints.isArray() || endpoints.isEmpty()) {
+      return MatchResult.accept("任务没有可达性预检要求", "{}");
+    }
+
+    boolean required = properties.isReachabilityRequired();
+    ArrayNode assigned = objectMapper.createArrayNode();
+    List<String> messages = new ArrayList<>();
+    for (JsonNode endpoint : endpoints) {
+      String connectorId = endpoint.path("connectorId").asText("")
+          .trim().toLowerCase(Locale.ROOT);
+      String role = endpoint.path("role").asText("")
+          .trim().toUpperCase(Locale.ROOT);
+      String optionsDigest = endpoint.path("optionsDigest").asText("").trim();
+      PreflightRecord record = repository.find(nodeId, connectorId, role, optionsDigest);
+      String failure = failure(record);
+      if (failure != null && required) {
+        return MatchResult.reject(connectorId + "/" + role + " " + failure);
+      }
+
+      ObjectNode evidence = objectMapper.createObjectNode();
+      evidence.put("connectorId", connectorId);
+      evidence.put("role", role);
+      evidence.put("optionsDigest", optionsDigest);
+      evidence.put("status", record == null ? "MISSING" : record.getStatus());
+      if (record != null) {
+        evidence.put("durationMillis", record.getDurationMillis());
+        evidence.put(
+            "checkedAt",
+            record.getCheckedAt() == null ? null : record.getCheckedAt().toString());
+        evidence.put("errorCode", record.getErrorCode());
+        evidence.put("errorMessage", record.getErrorMessage());
+      }
+      assigned.add(evidence);
+      messages.add(
+          connectorId + "/" + role + "="
+              + (failure == null ? "REACHABLE" : "BEST_EFFORT(" + failure + ")"));
+    }
+
+    ObjectNode result = objectMapper.createObjectNode();
+    result.put("nodeId", nodeId);
+    result.put("required", required);
+    result.set("endpoints", assigned);
+    return MatchResult.accept(
+        "可达性预检：" + String.join("、", messages),
+        write(result));
+  }
+
+  private String failure(PreflightRecord record) {
+    if (record == null) {
+      return "缺少预检结果";
+    }
+    if (record.getCheckedAt() == null) {
+      return "预检结果缺少时间";
+    }
+    long age = Duration.between(record.getCheckedAt(), LocalDateTime.now()).toMillis();
+    if (age > Math.max(1_000L, properties.getReachabilityMaxStaleMillis())) {
+      return "预检结果已过期";
+    }
+    if (!"REACHABLE".equalsIgnoreCase(record.getStatus())) {
+      return "预检状态为 " + record.getStatus()
+          + (StringUtils.hasText(record.getErrorMessage())
+              ? "：" + record.getErrorMessage() : "");
+    }
+    return null;
+  }
+
+  private JsonNode read(String value) {
+    if (!StringUtils.hasText(value)) {
+      return objectMapper.createObjectNode();
+    }
+    try {
+      JsonNode parsed = objectMapper.readTree(value);
+      return parsed == null ? objectMapper.createObjectNode() : parsed;
+    } catch (JsonProcessingException exception) {
+      throw new IllegalStateException("Worker 可达性要求 JSON 已损坏", exception);
+    }
+  }
+
+  private String write(JsonNode value) {
+    try {
+      return objectMapper.writeValueAsString(value);
+    } catch (JsonProcessingException exception) {
+      throw new IllegalStateException("序列化 Worker 可达性证据失败", exception);
+    }
+  }
+
+  public static final class MatchResult {
+    private final boolean matched;
+    private final String reason;
+    private final String assignedReachabilityJson;
+
+    private MatchResult(boolean matched, String reason, String assignedReachabilityJson) {
+      this.matched = matched;
+      this.reason = reason;
+      this.assignedReachabilityJson = assignedReachabilityJson;
+    }
+
+    public static MatchResult accept(String reason, String assignedReachabilityJson) {
+      return new MatchResult(true, reason, assignedReachabilityJson);
+    }
+
+    public static MatchResult reject(String reason) {
+      return new MatchResult(false, reason, null);
+    }
+
+    public boolean isMatched() {
+      return matched;
+    }
+
+    public String getReason() {
+      return reason;
+    }
+
+    public String getAssignedReachabilityJson() {
+      return assignedReachabilityJson;
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/worker/OfflineWorkerCapabilityService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/worker/OfflineWorkerCapabilityService.java
@@ -1,0 +1,210 @@
+package io.yak.ops.business.sync.offline.worker;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import io.yak.ops.business.sync.offline.config.OfflineCapabilityProperties;
+import io.yak.ops.business.sync.offline.engine.LinkUpConnectorSchemaClient;
+import io.yak.ops.business.sync.offline.repository.OfflineNodeRepository;
+import io.yak.ops.business.sync.offline.repository.OfflineNodeRepository.NodeRecord;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Locale;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+/**
+ * 按 Worker 拉取并持久化 Connector Schema 能力摘要。
+ *
+ * <p>远程调用在后台刷新或管理操作中完成，调度事务只读取数据库快照。
+ *
+ * @author weifuwan
+ */
+@ConditionalOnOfflineSyncEnabled
+@Service
+public class OfflineWorkerCapabilityService {
+
+  private static final Logger LOG = LoggerFactory.getLogger(OfflineWorkerCapabilityService.class);
+
+  private final OfflineNodeRepository repository;
+  private final LinkUpConnectorSchemaClient schemaClient;
+  private final OfflineCapabilityProperties properties;
+  private final ObjectMapper objectMapper;
+
+  public OfflineWorkerCapabilityService(
+      OfflineNodeRepository repository,
+      LinkUpConnectorSchemaClient schemaClient,
+      OfflineCapabilityProperties properties,
+      @Qualifier("offlineSyncJsonMapper") ObjectMapper objectMapper) {
+    this.repository = repository;
+    this.schemaClient = schemaClient;
+    this.properties = properties;
+    this.objectMapper = objectMapper;
+  }
+
+  @Scheduled(
+      initialDelayString = "${yak.sync.offline.capability.initial-delay-millis:10000}",
+      fixedDelayString = "${yak.sync.offline.capability.refresh-delay-millis:60000}")
+  public void scheduledRefresh() {
+    if (!properties.isEnabled()) {
+      return;
+    }
+    for (NodeRecord node : repository.listCapabilityRefreshTargets()) {
+      try {
+        refresh(node, false);
+      } catch (RuntimeException exception) {
+        LOG.debug("Refresh Worker capability failed, nodeId={}", node.getNodeId(), exception);
+      }
+    }
+  }
+
+  public NodeRecord refresh(String nodeId, boolean force) {
+    NodeRecord node = repository.find(nodeId);
+    if (node == null) {
+      throw new IllegalArgumentException("Link-Up Worker 不存在：" + nodeId);
+    }
+    refresh(node, force);
+    return repository.find(nodeId);
+  }
+
+  public void refreshQuietly(String nodeId) {
+    try {
+      refresh(nodeId, true);
+    } catch (RuntimeException exception) {
+      LOG.warn("刷新 Worker Connector 能力失败，nodeId={}：{}", nodeId, exception.getMessage());
+    }
+  }
+
+  public boolean isFresh(NodeRecord node) {
+    if (node == null
+        || !"READY".equalsIgnoreCase(node.getCapabilityStatus())
+        || node.getCapabilitySyncedAt() == null
+        || !StringUtils.hasText(node.getConnectorSchemasJson())) {
+      return false;
+    }
+    long age = Duration.between(node.getCapabilitySyncedAt(), LocalDateTime.now()).toMillis();
+    return age <= Math.max(1_000L, properties.getMaxStaleMillis());
+  }
+
+  private void refresh(NodeRecord node, boolean force) {
+    if (!properties.isEnabled()) {
+      return;
+    }
+    if (!force && !due(node)) {
+      return;
+    }
+    try {
+      JsonNode response = schemaClient.list(node.getBaseUrl());
+      ObjectNode snapshot = snapshot(node, response);
+      String json = write(snapshot);
+      repository.updateCapabilitySuccess(
+          node.getNodeId(), digest(json), json, LocalDateTime.now());
+    } catch (RuntimeException exception) {
+      repository.updateCapabilityFailure(node.getNodeId(), concise(exception));
+      throw exception;
+    }
+  }
+
+  private boolean due(NodeRecord node) {
+    if (node.getCapabilitySyncedAt() == null
+        || !"READY".equalsIgnoreCase(node.getCapabilityStatus())) {
+      return true;
+    }
+    long age = Duration.between(node.getCapabilitySyncedAt(), LocalDateTime.now()).toMillis();
+    return age >= Math.max(1_000L, properties.getWorkerRefreshMillis());
+  }
+
+  private ObjectNode snapshot(NodeRecord node, JsonNode response) {
+    JsonNode schemas = response != null && response.isArray()
+        ? response
+        : response == null ? null : response.path("items");
+    if (schemas == null || !schemas.isArray()) {
+      throw new IllegalStateException("Link-Up Connector Schema 列表协议不正确");
+    }
+
+    List<ObjectNode> connectors = new ArrayList<>();
+    for (JsonNode schema : schemas) {
+      String connectorId = text(schema, "connectorId").toLowerCase(Locale.ROOT);
+      String role = text(schema, "role").toUpperCase(Locale.ROOT);
+      if (!"SOURCE".equals(role) && !"SINK".equals(role)) {
+        throw new IllegalStateException("Connector Schema role 不合法：" + role);
+      }
+      ObjectNode summary = objectMapper.createObjectNode();
+      summary.put("connectorId", connectorId);
+      summary.put("role", role);
+      summary.put("schemaVersion", schema.path("schemaVersion").asText(""));
+      summary.put("schemaFingerprint", schema.path("schemaFingerprint").asText(""));
+      summary.put("implementationVersion", schema.path("implementationVersion").asText(""));
+      ArrayNode capabilities = summary.putArray("capabilities");
+      List<String> values = new ArrayList<>();
+      JsonNode capabilityValues = schema.path("capabilities");
+      if (capabilityValues.isArray()) {
+        for (JsonNode value : capabilityValues) {
+          if (StringUtils.hasText(value.asText())) {
+            values.add(value.asText().trim().toUpperCase(Locale.ROOT));
+          }
+        }
+      }
+      values.stream().distinct().sorted().forEach(capabilities::add);
+      connectors.add(summary);
+    }
+    connectors.sort(Comparator
+        .comparing((ObjectNode value) -> value.path("connectorId").asText())
+        .thenComparing(value -> value.path("role").asText()));
+
+    ObjectNode result = objectMapper.createObjectNode();
+    result.put("nodeId", node.getNodeId());
+    result.put("workerInstanceId", node.getWorkerInstanceId());
+    result.put("engineVersion", node.getEngineVersion());
+    ArrayNode items = result.putArray("connectors");
+    connectors.forEach(items::add);
+    return result;
+  }
+
+  private String text(JsonNode node, String field) {
+    String value = node == null ? null : node.path(field).asText(null);
+    if (!StringUtils.hasText(value)) {
+      throw new IllegalStateException("Connector Schema 缺少 " + field);
+    }
+    return value.trim();
+  }
+
+  private String write(JsonNode value) {
+    try {
+      return objectMapper.writeValueAsString(value);
+    } catch (JsonProcessingException exception) {
+      throw new IllegalStateException("序列化 Worker Connector 能力失败", exception);
+    }
+  }
+
+  private String digest(String value) {
+    try {
+      byte[] bytes = MessageDigest.getInstance("SHA-256")
+          .digest(value.getBytes(StandardCharsets.UTF_8));
+      return "sha256:" + HexFormat.of().formatHex(bytes);
+    } catch (Exception exception) {
+      throw new IllegalStateException("生成 Worker 能力摘要失败", exception);
+    }
+  }
+
+  private String concise(Throwable throwable) {
+    String message = throwable == null ? null : throwable.getMessage();
+    if (!StringUtils.hasText(message)) {
+      message = throwable == null ? "未知错误" : throwable.getClass().getSimpleName();
+    }
+    return message.length() <= 2000 ? message : message.substring(0, 2000);
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/worker/OfflineWorkerCapabilityService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/worker/OfflineWorkerCapabilityService.java
@@ -10,6 +10,10 @@ import io.yak.ops.business.sync.offline.config.OfflineCapabilityProperties;
 import io.yak.ops.business.sync.offline.engine.LinkUpConnectorSchemaClient;
 import io.yak.ops.business.sync.offline.repository.OfflineNodeRepository;
 import io.yak.ops.business.sync.offline.repository.OfflineNodeRepository.NodeRecord;
+import io.yak.ops.business.sync.offline.worker.OfflineWorkerModels.CapabilityView;
+import io.yak.ops.business.sync.offline.worker.OfflineWorkerModels.ConnectorCapabilityView;
+import io.yak.ops.business.sync.offline.worker.OfflineWorkerModels.OptionView;
+import io.yak.ops.business.sync.offline.worker.OfflineWorkerModels.WorkerView;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.time.Duration;
@@ -78,6 +82,52 @@ public class OfflineWorkerCapabilityService {
     }
     refresh(node, force);
     return repository.find(nodeId);
+  }
+
+  public CapabilityView refreshView(String nodeId) {
+    return view(refresh(nodeId, true));
+  }
+
+  public CapabilityView get(String nodeId) {
+    NodeRecord node = repository.find(nodeId);
+    if (node == null) {
+      throw new IllegalArgumentException("Link-Up Worker 不存在：" + nodeId);
+    }
+    return view(node);
+  }
+
+  public WorkerView enrich(WorkerView worker) {
+    if (worker == null || !StringUtils.hasText(worker.getNodeId())) {
+      return worker;
+    }
+    NodeRecord node = repository.find(worker.getNodeId());
+    if (node == null) {
+      return worker;
+    }
+    CapabilityView capability = view(node);
+    worker.setCapabilityStatus(capability.getStatus());
+    worker.setCapabilityDigest(capability.getDigest());
+    worker.setCapabilitySyncedAt(capability.getSyncedAt());
+    worker.setCapabilityErrorMessage(capability.getErrorMessage());
+    worker.setConnectors(capability.getConnectors());
+    worker.setConnectorCount(capability.getConnectors().size());
+    worker.setAvailable(Boolean.TRUE.equals(worker.getAvailable()) && Boolean.TRUE.equals(capability.getFresh()));
+    return worker;
+  }
+
+  public OptionView enrich(OptionView option) {
+    if (option == null || !StringUtils.hasText(option.getValue())) {
+      return option;
+    }
+    NodeRecord node = repository.find(option.getValue());
+    if (node == null) {
+      return option;
+    }
+    CapabilityView capability = view(node);
+    option.setCapabilityStatus(capability.getStatus());
+    option.setConnectorCount(capability.getConnectors().size());
+    option.setAvailable(Boolean.TRUE.equals(option.getAvailable()) && Boolean.TRUE.equals(capability.getFresh()));
+    return option;
   }
 
   public void refreshQuietly(String nodeId) {
@@ -172,6 +222,44 @@ public class OfflineWorkerCapabilityService {
     ArrayNode items = result.putArray("connectors");
     connectors.forEach(items::add);
     return result;
+  }
+
+  private CapabilityView view(NodeRecord node) {
+    List<ConnectorCapabilityView> connectors = new ArrayList<>();
+    if (node != null && StringUtils.hasText(node.getConnectorSchemasJson())) {
+      try {
+        JsonNode values = objectMapper.readTree(node.getConnectorSchemasJson()).path("connectors");
+        if (values.isArray()) {
+          for (JsonNode value : values) {
+            List<String> capabilities = new ArrayList<>();
+            if (value.path("capabilities").isArray()) {
+              for (JsonNode item : value.path("capabilities")) {
+                capabilities.add(item.asText());
+              }
+            }
+            connectors.add(ConnectorCapabilityView.builder()
+                .connectorId(value.path("connectorId").asText(null))
+                .role(value.path("role").asText(null))
+                .schemaVersion(value.path("schemaVersion").asText(null))
+                .schemaFingerprint(value.path("schemaFingerprint").asText(null))
+                .implementationVersion(value.path("implementationVersion").asText(null))
+                .capabilities(capabilities)
+                .build());
+          }
+        }
+      } catch (JsonProcessingException exception) {
+        LOG.warn("Worker capability snapshot is invalid, nodeId={}", node.getNodeId(), exception);
+      }
+    }
+    return CapabilityView.builder()
+        .nodeId(node == null ? null : node.getNodeId())
+        .status(node == null ? "UNKNOWN" : node.getCapabilityStatus())
+        .digest(node == null ? null : node.getCapabilityDigest())
+        .syncedAt(node == null ? null : node.getCapabilitySyncedAt())
+        .errorMessage(node == null ? null : node.getCapabilityErrorMessage())
+        .fresh(isFresh(node))
+        .connectors(connectors)
+        .build();
   }
 
   private String text(JsonNode node, String field) {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/worker/OfflineWorkerCapabilityService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/worker/OfflineWorkerCapabilityService.java
@@ -111,7 +111,9 @@ public class OfflineWorkerCapabilityService {
     worker.setCapabilityErrorMessage(capability.getErrorMessage());
     worker.setConnectors(capability.getConnectors());
     worker.setConnectorCount(capability.getConnectors().size());
-    worker.setAvailable(Boolean.TRUE.equals(worker.getAvailable()) && Boolean.TRUE.equals(capability.getFresh()));
+    worker.setAvailable(
+        Boolean.TRUE.equals(worker.getAvailable())
+            && Boolean.TRUE.equals(capability.getFresh()));
     return worker;
   }
 
@@ -126,7 +128,9 @@ public class OfflineWorkerCapabilityService {
     CapabilityView capability = view(node);
     option.setCapabilityStatus(capability.getStatus());
     option.setConnectorCount(capability.getConnectors().size());
-    option.setAvailable(Boolean.TRUE.equals(option.getAvailable()) && Boolean.TRUE.equals(capability.getFresh()));
+    option.setAvailable(
+        Boolean.TRUE.equals(option.getAvailable())
+            && Boolean.TRUE.equals(capability.getFresh()));
     return option;
   }
 
@@ -139,6 +143,9 @@ public class OfflineWorkerCapabilityService {
   }
 
   public boolean isFresh(NodeRecord node) {
+    if (!properties.isEnabled()) {
+      return true;
+    }
     if (node == null
         || !"READY".equalsIgnoreCase(node.getCapabilityStatus())
         || node.getCapabilitySyncedAt() == null
@@ -160,8 +167,10 @@ public class OfflineWorkerCapabilityService {
       JsonNode response = schemaClient.list(node.getBaseUrl());
       ObjectNode snapshot = snapshot(node, response);
       String json = write(snapshot);
+      // 能力摘要只反映规范化 Connector 能力，不受进程 instanceId 重启噪声影响。
+      String capabilityDigest = digest(write(snapshot.path("connectors")));
       repository.updateCapabilitySuccess(
-          node.getNodeId(), digest(json), json, LocalDateTime.now());
+          node.getNodeId(), capabilityDigest, json, LocalDateTime.now());
     } catch (RuntimeException exception) {
       repository.updateCapabilityFailure(node.getNodeId(), concise(exception));
       throw exception;
@@ -253,7 +262,9 @@ public class OfflineWorkerCapabilityService {
     }
     return CapabilityView.builder()
         .nodeId(node == null ? null : node.getNodeId())
-        .status(node == null ? "UNKNOWN" : node.getCapabilityStatus())
+        .status(!properties.isEnabled()
+            ? "DISABLED"
+            : node == null ? "UNKNOWN" : node.getCapabilityStatus())
         .digest(node == null ? null : node.getCapabilityDigest())
         .syncedAt(node == null ? null : node.getCapabilitySyncedAt())
         .errorMessage(node == null ? null : node.getCapabilityErrorMessage())

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/worker/OfflineWorkerModels.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/worker/OfflineWorkerModels.java
@@ -121,6 +121,12 @@ public final class OfflineWorkerModels {
     private LocalDateTime lastSuccessTime;
     private Integer consecutiveFailures;
     private String lastErrorMessage;
+    private String capabilityStatus;
+    private String capabilityDigest;
+    private Integer connectorCount;
+    private LocalDateTime capabilitySyncedAt;
+    private String capabilityErrorMessage;
+    private List<ConnectorCapabilityView> connectors;
     private LocalDateTime createTime;
     private LocalDateTime updateTime;
   }
@@ -152,5 +158,36 @@ public final class OfflineWorkerModels {
     private Integer queuedJobs;
     private Integer maxQueuedJobs;
     private Boolean available;
+    private String capabilityStatus;
+    private Integer connectorCount;
+  }
+
+  @Data
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class CapabilityView {
+
+    private String nodeId;
+    private String status;
+    private String digest;
+    private LocalDateTime syncedAt;
+    private String errorMessage;
+    private Boolean fresh;
+    private List<ConnectorCapabilityView> connectors;
+  }
+
+  @Data
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class ConnectorCapabilityView {
+
+    private String connectorId;
+    private String role;
+    private String schemaVersion;
+    private String schemaFingerprint;
+    private String implementationVersion;
+    private List<String> capabilities;
   }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/worker/OfflineWorkerReachabilityService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/worker/OfflineWorkerReachabilityService.java
@@ -35,7 +35,7 @@ import org.springframework.util.StringUtils;
  * 运行前从候选 Link-Up Worker 视角预检任务 Source/Sink 外部系统可达性。
  *
  * <p>实际 Connector options 只在内存和 HTTPS/HTTP 请求中使用；数据库仅保存 SHA-256 摘要、
- * 状态、耗时和脱敏错误。该服务必须在执行领取事务之前调用。
+ * 状态、耗时和脱敏错误。远程预热必须发生在执行领取事务之前；领取事务只重算摘要并读取缓存。
  *
  * @author weifuwan
  */
@@ -71,6 +71,11 @@ public class OfflineWorkerReachabilityService {
     this.objectMapper = objectMapper;
   }
 
+  /**
+   * 远程预热候选 Worker。该方法由执行门面在进入领取事务前调用。
+   *
+   * @return 不包含凭据明文的预检摘要要求
+   */
   public String preheat(Long definitionId) {
     if (!properties.isReachabilityEnabled()) {
       return emptyPlan("DISABLED");
@@ -78,18 +83,8 @@ public class OfflineWorkerReachabilityService {
 
     OfflineJobDefinitionPO definition = definitionService.require(definitionId);
     DefinitionVersion version = definitionService.requireCurrentVersion(definition);
-    String resolvedJobSpecJson = definitionService.resolveExecutionJobSpec(version);
-    JsonNode jobSpec = read(resolvedJobSpecJson, "执行 JobSpec");
-    String capabilityRequirements = StringUtils.hasText(version.getCapabilityRequirementsJson())
-        ? version.getCapabilityRequirementsJson()
-        : StringUtils.hasText(definition.getCapabilityRequirementsJson())
-            ? definition.getCapabilityRequirementsJson()
-            : capabilityResolver.resolve(definitionService.resolveLogicalJobSpec(version));
-
-    List<EndpointPlan> endpoints = List.of(
-        endpoint(jobSpec.path("source"), "SOURCE"),
-        endpoint(jobSpec.path("sink"), "SINK"));
-    String planJson = plan(endpoints, "REQUIRED");
+    PreflightPlan plan = buildPlan(definition, version);
+    String capabilityRequirements = capabilityRequirements(definition, version);
 
     List<NodeRecord> candidates = candidateNodes(definition, capabilityRequirements);
     int limit = Math.max(1, properties.getReachabilityMaxWorkers());
@@ -98,7 +93,7 @@ public class OfflineWorkerReachabilityService {
       if (processed++ >= limit) {
         break;
       }
-      for (EndpointPlan endpoint : endpoints) {
+      for (EndpointPlan endpoint : plan.endpoints) {
         refreshIfNeeded(node, endpoint);
       }
     }
@@ -106,7 +101,43 @@ public class OfflineWorkerReachabilityService {
     preflightRepository.deleteExpired(
         LocalDateTime.now().minusNanos(
             Math.max(60_000L, properties.getReachabilityRetentionMillis()) * 1_000_000L));
-    return planJson;
+    return plan.requirementsJson;
+  }
+
+  /**
+   * 只从数据库和不可变 JobSpec 计算预检摘要，不发起远程请求，可在领取事务内调用。
+   */
+  public String requirements(
+      OfflineJobDefinitionPO definition,
+      DefinitionVersion version) {
+    if (!properties.isReachabilityEnabled()) {
+      return emptyPlan("DISABLED");
+    }
+    return buildPlan(definition, version).requirementsJson;
+  }
+
+  private PreflightPlan buildPlan(
+      OfflineJobDefinitionPO definition,
+      DefinitionVersion version) {
+    if (definition == null || version == null) {
+      throw new IllegalArgumentException("任务定义和版本不能为空");
+    }
+    String resolvedJobSpecJson = definitionService.resolveExecutionJobSpec(version);
+    JsonNode jobSpec = read(resolvedJobSpecJson, "执行 JobSpec");
+    List<EndpointPlan> endpoints = List.of(
+        endpoint(jobSpec.path("source"), "SOURCE"),
+        endpoint(jobSpec.path("sink"), "SINK"));
+    return new PreflightPlan(endpoints, plan(endpoints, "REQUIRED"));
+  }
+
+  private String capabilityRequirements(
+      OfflineJobDefinitionPO definition,
+      DefinitionVersion version) {
+    return StringUtils.hasText(version.getCapabilityRequirementsJson())
+        ? version.getCapabilityRequirementsJson()
+        : StringUtils.hasText(definition.getCapabilityRequirementsJson())
+            ? definition.getCapabilityRequirementsJson()
+            : capabilityResolver.resolve(definitionService.resolveLogicalJobSpec(version));
   }
 
   private List<NodeRecord> candidateNodes(
@@ -263,6 +294,9 @@ public class OfflineWorkerReachabilityService {
   }
 
   private JsonNode read(String value, String name) {
+    if (!StringUtils.hasText(value)) {
+      throw new IllegalStateException(name + "为空");
+    }
     try {
       JsonNode parsed = objectMapper.readTree(value);
       if (parsed == null || !parsed.isObject()) {
@@ -300,6 +334,16 @@ public class OfflineWorkerReachabilityService {
         "(?i)(password|passwd|pwd)\\s*[=:]\\s*[^,;\\s]+",
         "$1=***");
     return sanitized.length() <= 2000 ? sanitized : sanitized.substring(0, 2000);
+  }
+
+  private static final class PreflightPlan {
+    private final List<EndpointPlan> endpoints;
+    private final String requirementsJson;
+
+    private PreflightPlan(List<EndpointPlan> endpoints, String requirementsJson) {
+      this.endpoints = endpoints;
+      this.requirementsJson = requirementsJson;
+    }
   }
 
   private static final class EndpointPlan {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/worker/OfflineWorkerReachabilityService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/worker/OfflineWorkerReachabilityService.java
@@ -1,0 +1,322 @@
+package io.yak.ops.business.sync.offline.worker;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import io.yak.ops.business.sync.offline.config.OfflineCapabilityProperties;
+import io.yak.ops.business.sync.offline.engine.LinkUpClient.LinkUpRequestException;
+import io.yak.ops.business.sync.offline.engine.LinkUpConnectorPreflightClient;
+import io.yak.ops.business.sync.offline.repository.OfflineDefinitionCatalogRepository.DefinitionVersion;
+import io.yak.ops.business.sync.offline.repository.OfflineNodeRepository;
+import io.yak.ops.business.sync.offline.repository.OfflineNodeRepository.NodeRecord;
+import io.yak.ops.business.sync.offline.repository.OfflineWorkerPreflightRepository;
+import io.yak.ops.business.sync.offline.repository.OfflineWorkerPreflightRepository.PreflightRecord;
+import io.yak.ops.business.sync.offline.service.OfflineJobDefinitionService;
+import io.yak.ops.common.bean.po.sync.offline.OfflineJobDefinitionPO;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.TreeMap;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+/**
+ * 运行前从候选 Link-Up Worker 视角预检任务 Source/Sink 外部系统可达性。
+ *
+ * <p>实际 Connector options 只在内存和 HTTPS/HTTP 请求中使用；数据库仅保存 SHA-256 摘要、
+ * 状态、耗时和脱敏错误。该服务必须在执行领取事务之前调用。
+ *
+ * @author weifuwan
+ */
+@ConditionalOnOfflineSyncEnabled
+@Service
+public class OfflineWorkerReachabilityService {
+
+  private final OfflineJobDefinitionService definitionService;
+  private final OfflineNodeRepository nodeRepository;
+  private final OfflineWorkerPreflightRepository preflightRepository;
+  private final OfflineCapabilityMatcher capabilityMatcher;
+  private final OfflineCapabilityRequirementResolver capabilityResolver;
+  private final LinkUpConnectorPreflightClient preflightClient;
+  private final OfflineCapabilityProperties properties;
+  private final ObjectMapper objectMapper;
+
+  public OfflineWorkerReachabilityService(
+      OfflineJobDefinitionService definitionService,
+      OfflineNodeRepository nodeRepository,
+      OfflineWorkerPreflightRepository preflightRepository,
+      OfflineCapabilityMatcher capabilityMatcher,
+      OfflineCapabilityRequirementResolver capabilityResolver,
+      LinkUpConnectorPreflightClient preflightClient,
+      OfflineCapabilityProperties properties,
+      @Qualifier("offlineSyncJsonMapper") ObjectMapper objectMapper) {
+    this.definitionService = definitionService;
+    this.nodeRepository = nodeRepository;
+    this.preflightRepository = preflightRepository;
+    this.capabilityMatcher = capabilityMatcher;
+    this.capabilityResolver = capabilityResolver;
+    this.preflightClient = preflightClient;
+    this.properties = properties;
+    this.objectMapper = objectMapper;
+  }
+
+  public String preheat(Long definitionId) {
+    if (!properties.isReachabilityEnabled()) {
+      return emptyPlan("DISABLED");
+    }
+
+    OfflineJobDefinitionPO definition = definitionService.require(definitionId);
+    DefinitionVersion version = definitionService.requireCurrentVersion(definition);
+    String resolvedJobSpecJson = definitionService.resolveExecutionJobSpec(version);
+    JsonNode jobSpec = read(resolvedJobSpecJson, "执行 JobSpec");
+    String capabilityRequirements = StringUtils.hasText(version.getCapabilityRequirementsJson())
+        ? version.getCapabilityRequirementsJson()
+        : StringUtils.hasText(definition.getCapabilityRequirementsJson())
+            ? definition.getCapabilityRequirementsJson()
+            : capabilityResolver.resolve(definitionService.resolveLogicalJobSpec(version));
+
+    List<EndpointPlan> endpoints = List.of(
+        endpoint(jobSpec.path("source"), "SOURCE"),
+        endpoint(jobSpec.path("sink"), "SINK"));
+    String planJson = plan(endpoints, "REQUIRED");
+
+    List<NodeRecord> candidates = candidateNodes(definition, capabilityRequirements);
+    int limit = Math.max(1, properties.getReachabilityMaxWorkers());
+    int processed = 0;
+    for (NodeRecord node : candidates) {
+      if (processed++ >= limit) {
+        break;
+      }
+      for (EndpointPlan endpoint : endpoints) {
+        refreshIfNeeded(node, endpoint);
+      }
+    }
+
+    preflightRepository.deleteExpired(
+        LocalDateTime.now().minusNanos(
+            Math.max(60_000L, properties.getReachabilityRetentionMillis()) * 1_000_000L));
+    return planJson;
+  }
+
+  private List<NodeRecord> candidateNodes(
+      OfflineJobDefinitionPO definition,
+      String capabilityRequirements) {
+    List<NodeRecord> result = new ArrayList<>();
+    boolean manual = "MANUAL".equalsIgnoreCase(definition.getWorkerSelectMode());
+    for (NodeRecord node : nodeRepository.listAll()) {
+      if (manual && !node.getNodeId().equals(definition.getWorkerNodeId())) {
+        continue;
+      }
+      if (!Boolean.TRUE.equals(node.getEnabled())
+          || !"ENABLED".equalsIgnoreCase(node.getSchedulingStatus())
+          || !"UP".equalsIgnoreCase(node.getStatus())
+          || !Boolean.TRUE.equals(node.getOfflineOnly())) {
+        continue;
+      }
+      if (!capabilityMatcher.match(node, capabilityRequirements).isMatched()) {
+        continue;
+      }
+      result.add(node);
+    }
+    result.sort(Comparator.comparing(NodeRecord::getNodeId));
+    return result;
+  }
+
+  private void refreshIfNeeded(NodeRecord node, EndpointPlan endpoint) {
+    PreflightRecord existing = preflightRepository.find(
+        node.getNodeId(),
+        endpoint.connectorId,
+        endpoint.role,
+        endpoint.optionsDigest);
+    if (fresh(existing)) {
+      return;
+    }
+
+    LocalDateTime checkedAt = LocalDateTime.now();
+    try {
+      JsonNode response = preflightClient.preflight(
+          node.getBaseUrl(),
+          endpoint.connectorId,
+          endpoint.role,
+          endpoint.options);
+      preflightRepository.save(PreflightRecord.builder()
+          .nodeId(node.getNodeId())
+          .connectorId(endpoint.connectorId)
+          .role(endpoint.role)
+          .optionsDigest(endpoint.optionsDigest)
+          .status("REACHABLE")
+          .durationMillis(response.path("durationMillis").isNumber()
+              ? response.path("durationMillis").asLong() : null)
+          .checkedAt(checkedAt)
+          .build());
+    } catch (LinkUpRequestException exception) {
+      preflightRepository.save(PreflightRecord.builder()
+          .nodeId(node.getNodeId())
+          .connectorId(endpoint.connectorId)
+          .role(endpoint.role)
+          .optionsDigest(endpoint.optionsDigest)
+          .status(unsupported(exception) ? "UNSUPPORTED" : "UNREACHABLE")
+          .errorCode(exception.getCode())
+          .errorMessage(concise(exception.getMessage()))
+          .checkedAt(checkedAt)
+          .build());
+    } catch (RuntimeException exception) {
+      preflightRepository.save(PreflightRecord.builder()
+          .nodeId(node.getNodeId())
+          .connectorId(endpoint.connectorId)
+          .role(endpoint.role)
+          .optionsDigest(endpoint.optionsDigest)
+          .status("UNREACHABLE")
+          .errorCode(exception.getClass().getSimpleName())
+          .errorMessage(concise(exception.getMessage()))
+          .checkedAt(checkedAt)
+          .build());
+    }
+  }
+
+  private boolean fresh(PreflightRecord record) {
+    if (record == null || record.getCheckedAt() == null) {
+      return false;
+    }
+    long age = Duration.between(record.getCheckedAt(), LocalDateTime.now()).toMillis();
+    return age <= Math.max(1_000L, properties.getReachabilityMaxStaleMillis());
+  }
+
+  private boolean unsupported(LinkUpRequestException exception) {
+    String code = exception.getCode() == null ? "" : exception.getCode().toUpperCase(Locale.ROOT);
+    return exception.getStatusCode() == 404
+        || exception.getStatusCode() == 422
+        || exception.getStatusCode() == 501
+        || code.contains("UNSUPPORTED")
+        || code.contains("DISABLED");
+  }
+
+  private EndpointPlan endpoint(JsonNode endpoint, String role) {
+    if (endpoint == null || !endpoint.isObject()) {
+      throw new IllegalStateException(role + " JobSpec 不完整");
+    }
+    String connectorId = endpoint.path("connectorId").asText("")
+        .trim().toLowerCase(Locale.ROOT);
+    if (!StringUtils.hasText(connectorId)) {
+      throw new IllegalStateException(role + " JobSpec 缺少 connectorId");
+    }
+    JsonNode options = endpoint.path("options");
+    JsonNode safeOptions = options.isObject() ? options.deepCopy() : objectMapper.createObjectNode();
+    String canonical = write(canonical(safeOptions));
+    String optionsDigest = digest(connectorId + "|" + role + "|" + canonical);
+    return new EndpointPlan(connectorId, role, safeOptions, optionsDigest);
+  }
+
+  private String plan(List<EndpointPlan> endpoints, String status) {
+    ObjectNode plan = objectMapper.createObjectNode();
+    plan.put("version", "1");
+    plan.put("status", status);
+    ArrayNode values = plan.putArray("endpoints");
+    for (EndpointPlan endpoint : endpoints) {
+      ObjectNode value = objectMapper.createObjectNode();
+      value.put("connectorId", endpoint.connectorId);
+      value.put("role", endpoint.role);
+      value.put("optionsDigest", endpoint.optionsDigest);
+      values.add(value);
+    }
+    return write(plan);
+  }
+
+  private String emptyPlan(String status) {
+    ObjectNode plan = objectMapper.createObjectNode();
+    plan.put("version", "1");
+    plan.put("status", status);
+    plan.putArray("endpoints");
+    return write(plan);
+  }
+
+  private JsonNode canonical(JsonNode value) {
+    if (value == null || value.isNull()) {
+      return objectMapper.nullNode();
+    }
+    if (value.isArray()) {
+      ArrayNode result = objectMapper.createArrayNode();
+      for (JsonNode item : value) {
+        result.add(canonical(item));
+      }
+      return result;
+    }
+    if (value.isObject()) {
+      ObjectNode result = objectMapper.createObjectNode();
+      Map<String, JsonNode> sorted = new TreeMap<>();
+      value.fields().forEachRemaining(entry -> sorted.put(entry.getKey(), entry.getValue()));
+      sorted.forEach((key, item) -> result.set(key, canonical(item)));
+      return result;
+    }
+    return value.deepCopy();
+  }
+
+  private JsonNode read(String value, String name) {
+    try {
+      JsonNode parsed = objectMapper.readTree(value);
+      if (parsed == null || !parsed.isObject()) {
+        throw new IllegalStateException(name + "不是 JSON 对象");
+      }
+      return parsed;
+    } catch (JsonProcessingException exception) {
+      throw new IllegalStateException(name + "已损坏", exception);
+    }
+  }
+
+  private String write(JsonNode value) {
+    try {
+      return objectMapper.writeValueAsString(value);
+    } catch (JsonProcessingException exception) {
+      throw new IllegalStateException("序列化 Worker 预检计划失败", exception);
+    }
+  }
+
+  private String digest(String value) {
+    try {
+      byte[] bytes = MessageDigest.getInstance("SHA-256")
+          .digest(value.getBytes(StandardCharsets.UTF_8));
+      return "sha256:" + HexFormat.of().formatHex(bytes);
+    } catch (Exception exception) {
+      throw new IllegalStateException("生成 Worker 预检摘要失败", exception);
+    }
+  }
+
+  private String concise(String value) {
+    if (!StringUtils.hasText(value)) {
+      return "Connector 预检失败";
+    }
+    String sanitized = value.replaceAll(
+        "(?i)(password|passwd|pwd)\\s*[=:]\\s*[^,;\\s]+",
+        "$1=***");
+    return sanitized.length() <= 2000 ? sanitized : sanitized.substring(0, 2000);
+  }
+
+  private static final class EndpointPlan {
+    private final String connectorId;
+    private final String role;
+    private final JsonNode options;
+    private final String optionsDigest;
+
+    private EndpointPlan(
+        String connectorId,
+        String role,
+        JsonNode options,
+        String optionsDigest) {
+      this.connectorId = connectorId;
+      this.role = role;
+      this.options = options;
+      this.optionsDigest = optionsDigest;
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/worker/OfflineWorkerScheduler.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/worker/OfflineWorkerScheduler.java
@@ -31,9 +31,9 @@ import org.springframework.util.StringUtils;
 /**
  * 离线任务 Worker 选择器。
  *
- * <p>先执行健康、调度状态、心跳、标签、Connector 能力和容量硬过滤，再按即时并发余量、
- * 总容量余量和管理权重计算可解释得分。调度事务会锁定 Worker 行，并将 Yak Ops
- * 已创建的活跃执行叠加到 Worker 心跳负载中，避免并发提交使用同一份旧快照。
+ * <p>先执行健康、调度状态、心跳、标签、Connector 能力、Worker 视角可达性和容量硬过滤，
+ * 再按即时并发余量、总容量余量和管理权重计算可解释得分。调度事务会锁定 Worker 行，
+ * 并将 Yak Ops 已创建的活跃执行叠加到 Worker 心跳负载中，避免并发提交使用同一份旧快照。
  *
  * @author weifuwan
  */
@@ -49,6 +49,7 @@ public class OfflineWorkerScheduler {
   private final OfflineExecutionControlRepository executionRepository;
   private final OfflineWorkerRegistry registry;
   private final OfflineCapabilityMatcher capabilityMatcher;
+  private final OfflineReachabilityMatcher reachabilityMatcher;
   private final OfflineSyncProperties properties;
   private final ObjectMapper objectMapper;
 
@@ -57,12 +58,14 @@ public class OfflineWorkerScheduler {
       OfflineExecutionControlRepository executionRepository,
       OfflineWorkerRegistry registry,
       OfflineCapabilityMatcher capabilityMatcher,
+      OfflineReachabilityMatcher reachabilityMatcher,
       OfflineSyncProperties properties,
       @Qualifier("offlineSyncJsonMapper") ObjectMapper objectMapper) {
     this.repository = repository;
     this.executionRepository = executionRepository;
     this.registry = registry;
     this.capabilityMatcher = capabilityMatcher;
+    this.reachabilityMatcher = reachabilityMatcher;
     this.properties = properties;
     this.objectMapper = objectMapper;
   }
@@ -113,13 +116,23 @@ public class OfflineWorkerScheduler {
 
   /** 兼容旧调用，优先使用定义中已回填的能力要求。 */
   public Assignment select(OfflineJobDefinitionPO definition) {
-    return select(definition, definition == null ? null : definition.getCapabilityRequirementsJson());
+    return select(
+        definition,
+        definition == null ? null : definition.getCapabilityRequirementsJson(),
+        null);
   }
 
-  /** 必须在 offline-sync 事务内调用。 */
   public Assignment select(
       OfflineJobDefinitionPO definition,
       String capabilityRequirementsJson) {
+    return select(definition, capabilityRequirementsJson, null);
+  }
+
+  /** 必须在 offline-sync 事务内调用；远程预检必须在进入该方法前完成。 */
+  public Assignment select(
+      OfflineJobDefinitionPO definition,
+      String capabilityRequirementsJson,
+      String reachabilityRequirementsJson) {
     try {
       registry.ensureConfiguredWorker();
     } catch (RuntimeException exception) {
@@ -129,22 +142,34 @@ public class OfflineWorkerScheduler {
     List<NodeRecord> nodes = repository.listAllForScheduling();
     Map<String, Integer> activeExecutions = executionRepository.countActiveExecutionsByNode();
     if ("MANUAL".equals(policy.getMode())) {
-      return selectManual(policy, nodes, activeExecutions, capabilityRequirementsJson);
+      return selectManual(
+          policy,
+          nodes,
+          activeExecutions,
+          capabilityRequirementsJson,
+          reachabilityRequirementsJson);
     }
-    return selectAuto(policy, nodes, activeExecutions, capabilityRequirementsJson);
+    return selectAuto(
+        policy,
+        nodes,
+        activeExecutions,
+        capabilityRequirementsJson,
+        reachabilityRequirementsJson);
   }
 
   private Assignment selectManual(
       PolicyProjection policy,
       List<NodeRecord> nodes,
       Map<String, Integer> activeExecutions,
-      String capabilityRequirementsJson) {
+      String capabilityRequirementsJson,
+      String reachabilityRequirementsJson) {
     List<Candidate> candidates = nodes.stream()
         .map(node -> evaluate(
             node,
             policy.getRequiredLabels(),
             activeExecutions.getOrDefault(node.getNodeId(), 0),
-            capabilityRequirementsJson))
+            capabilityRequirementsJson,
+            reachabilityRequirementsJson))
         .collect(Collectors.toList());
     Candidate selected = candidates.stream()
         .filter(candidate -> Objects.equals(
@@ -162,7 +187,8 @@ public class OfflineWorkerScheduler {
         selected,
         "MANUAL",
         "手动指定 Worker " + selected.getNode().getNodeName()
-            + "（" + selected.getNode().getNodeId() + "）；" + selected.getCapabilityReason(),
+            + "（" + selected.getNode().getNodeId() + "）；"
+            + selected.getCapabilityReason() + "；" + selected.getReachabilityReason(),
         candidates);
   }
 
@@ -170,13 +196,15 @@ public class OfflineWorkerScheduler {
       PolicyProjection policy,
       List<NodeRecord> nodes,
       Map<String, Integer> activeExecutions,
-      String capabilityRequirementsJson) {
+      String capabilityRequirementsJson,
+      String reachabilityRequirementsJson) {
     List<Candidate> candidates = nodes.stream()
         .map(node -> evaluate(
             node,
             policy.getRequiredLabels(),
             activeExecutions.getOrDefault(node.getNodeId(), 0),
-            capabilityRequirementsJson))
+            capabilityRequirementsJson,
+            reachabilityRequirementsJson))
         .collect(Collectors.toList());
     List<Candidate> eligible = candidates.stream()
         .filter(Candidate::isEligible)
@@ -188,20 +216,21 @@ public class OfflineWorkerScheduler {
           .map(candidate -> candidate.getNode().getNodeId() + "=" + candidate.getRejectionReason())
           .collect(Collectors.joining("；"));
       throw new IllegalStateException(
-          "没有能力兼容且可调度的 Link-Up Worker"
+          "没有能力兼容、数据源可达且可调度的 Link-Up Worker"
               + (StringUtils.hasText(rejected) ? "：" + rejected : ""));
     }
     Candidate selected = eligible.get(0);
     selected.setSelected(true);
     String reason = String.format(
         Locale.ROOT,
-        "AUTO 评分 %.3f：即时并发余量 %.1f%%，总容量余量 %.1f%%，权重 %d，控制面活跃 %d；%s；候选 %d/%d",
+        "AUTO 评分 %.3f：即时并发余量 %.1f%%，总容量余量 %.1f%%，权重 %d，控制面活跃 %d；%s；%s；候选 %d/%d",
         selected.getScore(),
         selected.getRunningHeadroom() * 100D,
         selected.getTotalHeadroom() * 100D,
         value(selected.getNode().getWeight(), 100),
         selected.getControlPlaneActive(),
         selected.getCapabilityReason(),
+        selected.getReachabilityReason(),
         eligible.size(),
         candidates.size());
     return assignment(selected, "AUTO", reason, candidates);
@@ -218,14 +247,16 @@ public class OfflineWorkerScheduler {
         selected.getScore(),
         reason,
         writeCandidates(candidates),
-        selected.getAssignedCapabilitiesJson());
+        selected.getAssignedCapabilitiesJson(),
+        selected.getAssignedReachabilityJson());
   }
 
   private Candidate evaluate(
       NodeRecord node,
       Map<String, String> requiredLabels,
       int controlPlaneActive,
-      String capabilityRequirementsJson) {
+      String capabilityRequirementsJson,
+      String reachabilityRequirementsJson) {
     Candidate candidate = new Candidate(node);
     candidate.setControlPlaneActive(Math.max(0, controlPlaneActive));
     if (!Boolean.TRUE.equals(node.getEnabled())) {
@@ -256,6 +287,14 @@ public class OfflineWorkerScheduler {
     candidate.setAssignedCapabilitiesJson(capability.getAssignedCapabilitiesJson());
     if (!capability.isMatched()) {
       return candidate.reject("能力不匹配：" + capability.getReason());
+    }
+
+    OfflineReachabilityMatcher.MatchResult reachability =
+        reachabilityMatcher.match(node.getNodeId(), reachabilityRequirementsJson);
+    candidate.setReachabilityReason(reachability.getReason());
+    candidate.setAssignedReachabilityJson(reachability.getAssignedReachabilityJson());
+    if (!reachability.isMatched()) {
+      return candidate.reject("数据源不可达：" + reachability.getReason());
     }
 
     int maxRunning = Math.max(1, value(node.getMaxConcurrentJobs(), 1));
@@ -333,6 +372,7 @@ public class OfflineWorkerScheduler {
       item.put("capabilityDigest", node.getCapabilityDigest());
       item.put("capabilitySyncedAt", node.getCapabilitySyncedAt());
       item.put("capabilityMatch", candidate.getCapabilityReason());
+      item.put("reachabilityMatch", candidate.getReachabilityReason());
       snapshot.add(item);
     }
     try {
@@ -438,6 +478,7 @@ public class OfflineWorkerScheduler {
     private final String reason;
     private final String candidatesJson;
     private final String assignedCapabilitiesJson;
+    private final String assignedReachabilityJson;
 
     public Assignment(
         NodeRecord node,
@@ -445,13 +486,15 @@ public class OfflineWorkerScheduler {
         double score,
         String reason,
         String candidatesJson,
-        String assignedCapabilitiesJson) {
+        String assignedCapabilitiesJson,
+        String assignedReachabilityJson) {
       this.node = node;
       this.mode = mode;
       this.score = score;
       this.reason = reason;
       this.candidatesJson = candidatesJson;
       this.assignedCapabilitiesJson = assignedCapabilitiesJson;
+      this.assignedReachabilityJson = assignedReachabilityJson;
     }
 
     public NodeRecord getNode() { return node; }
@@ -460,6 +503,7 @@ public class OfflineWorkerScheduler {
     public String getReason() { return reason; }
     public String getCandidatesJson() { return candidatesJson; }
     public String getAssignedCapabilitiesJson() { return assignedCapabilitiesJson; }
+    public String getAssignedReachabilityJson() { return assignedReachabilityJson; }
   }
 
   private static final class Candidate {
@@ -476,6 +520,8 @@ public class OfflineWorkerScheduler {
     private int effectiveQueued;
     private String capabilityReason;
     private String assignedCapabilitiesJson;
+    private String reachabilityReason;
+    private String assignedReachabilityJson;
 
     private Candidate(NodeRecord node) {
       this.node = node;
@@ -518,5 +564,9 @@ public class OfflineWorkerScheduler {
     private void setCapabilityReason(String value) { this.capabilityReason = value; }
     private String getAssignedCapabilitiesJson() { return assignedCapabilitiesJson; }
     private void setAssignedCapabilitiesJson(String value) { this.assignedCapabilitiesJson = value; }
+    private String getReachabilityReason() { return reachabilityReason; }
+    private void setReachabilityReason(String value) { this.reachabilityReason = value; }
+    private String getAssignedReachabilityJson() { return assignedReachabilityJson; }
+    private void setAssignedReachabilityJson(String value) { this.assignedReachabilityJson = value; }
   }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/worker/OfflineWorkerScheduler.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/worker/OfflineWorkerScheduler.java
@@ -10,6 +10,7 @@ import io.yak.ops.business.sync.offline.repository.OfflineExecutionControlReposi
 import io.yak.ops.business.sync.offline.repository.OfflineNodeRepository;
 import io.yak.ops.business.sync.offline.repository.OfflineNodeRepository.NodeRecord;
 import io.yak.ops.business.sync.offline.service.OfflineWorkerRegistry;
+import io.yak.ops.business.sync.offline.worker.OfflineCapabilityMatcher.MatchResult;
 import io.yak.ops.common.bean.po.sync.offline.OfflineJobDefinitionPO;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -30,7 +31,7 @@ import org.springframework.util.StringUtils;
 /**
  * 离线任务 Worker 选择器。
  *
- * <p>先执行健康、调度状态、心跳新鲜度、标签和容量硬过滤，再按即时并发余量、
+ * <p>先执行健康、调度状态、心跳、标签、Connector 能力和容量硬过滤，再按即时并发余量、
  * 总容量余量和管理权重计算可解释得分。调度事务会锁定 Worker 行，并将 Yak Ops
  * 已创建的活跃执行叠加到 Worker 心跳负载中，避免并发提交使用同一份旧快照。
  *
@@ -47,6 +48,7 @@ public class OfflineWorkerScheduler {
   private final OfflineNodeRepository repository;
   private final OfflineExecutionControlRepository executionRepository;
   private final OfflineWorkerRegistry registry;
+  private final OfflineCapabilityMatcher capabilityMatcher;
   private final OfflineSyncProperties properties;
   private final ObjectMapper objectMapper;
 
@@ -54,11 +56,13 @@ public class OfflineWorkerScheduler {
       OfflineNodeRepository repository,
       OfflineExecutionControlRepository executionRepository,
       OfflineWorkerRegistry registry,
+      OfflineCapabilityMatcher capabilityMatcher,
       OfflineSyncProperties properties,
       @Qualifier("offlineSyncJsonMapper") ObjectMapper objectMapper) {
     this.repository = repository;
     this.executionRepository = executionRepository;
     this.registry = registry;
+    this.capabilityMatcher = capabilityMatcher;
     this.properties = properties;
     this.objectMapper = objectMapper;
   }
@@ -107,32 +111,40 @@ public class OfflineWorkerScheduler {
     return readLabels(labelsJson);
   }
 
-  /** 必须在 offline-sync 事务内调用。 */
+  /** 兼容旧调用，优先使用定义中已回填的能力要求。 */
   public Assignment select(OfflineJobDefinitionPO definition) {
+    return select(definition, definition == null ? null : definition.getCapabilityRequirementsJson());
+  }
+
+  /** 必须在 offline-sync 事务内调用。 */
+  public Assignment select(
+      OfflineJobDefinitionPO definition,
+      String capabilityRequirementsJson) {
     try {
       registry.ensureConfiguredWorker();
     } catch (RuntimeException exception) {
-      // 默认配置错误不能阻断已登记手工 Worker 的调度。
       LOG.warn("初始化默认 Link-Up Worker 失败，继续评估已登记节点：{}", exception.getMessage());
     }
     PolicyProjection policy = projection(definition);
     List<NodeRecord> nodes = repository.listAllForScheduling();
     Map<String, Integer> activeExecutions = executionRepository.countActiveExecutionsByNode();
     if ("MANUAL".equals(policy.getMode())) {
-      return selectManual(policy, nodes, activeExecutions);
+      return selectManual(policy, nodes, activeExecutions, capabilityRequirementsJson);
     }
-    return selectAuto(policy, nodes, activeExecutions);
+    return selectAuto(policy, nodes, activeExecutions, capabilityRequirementsJson);
   }
 
   private Assignment selectManual(
       PolicyProjection policy,
       List<NodeRecord> nodes,
-      Map<String, Integer> activeExecutions) {
+      Map<String, Integer> activeExecutions,
+      String capabilityRequirementsJson) {
     List<Candidate> candidates = nodes.stream()
         .map(node -> evaluate(
             node,
             policy.getRequiredLabels(),
-            activeExecutions.getOrDefault(node.getNodeId(), 0)))
+            activeExecutions.getOrDefault(node.getNodeId(), 0),
+            capabilityRequirementsJson))
         .collect(Collectors.toList());
     Candidate selected = candidates.stream()
         .filter(candidate -> Objects.equals(
@@ -150,19 +162,21 @@ public class OfflineWorkerScheduler {
         selected,
         "MANUAL",
         "手动指定 Worker " + selected.getNode().getNodeName()
-            + "（" + selected.getNode().getNodeId() + "）",
+            + "（" + selected.getNode().getNodeId() + "）；" + selected.getCapabilityReason(),
         candidates);
   }
 
   private Assignment selectAuto(
       PolicyProjection policy,
       List<NodeRecord> nodes,
-      Map<String, Integer> activeExecutions) {
+      Map<String, Integer> activeExecutions,
+      String capabilityRequirementsJson) {
     List<Candidate> candidates = nodes.stream()
         .map(node -> evaluate(
             node,
             policy.getRequiredLabels(),
-            activeExecutions.getOrDefault(node.getNodeId(), 0)))
+            activeExecutions.getOrDefault(node.getNodeId(), 0),
+            capabilityRequirementsJson))
         .collect(Collectors.toList());
     List<Candidate> eligible = candidates.stream()
         .filter(Candidate::isEligible)
@@ -174,19 +188,20 @@ public class OfflineWorkerScheduler {
           .map(candidate -> candidate.getNode().getNodeId() + "=" + candidate.getRejectionReason())
           .collect(Collectors.joining("；"));
       throw new IllegalStateException(
-          "没有可调度的 Link-Up Worker"
+          "没有能力兼容且可调度的 Link-Up Worker"
               + (StringUtils.hasText(rejected) ? "：" + rejected : ""));
     }
     Candidate selected = eligible.get(0);
     selected.setSelected(true);
     String reason = String.format(
         Locale.ROOT,
-        "AUTO 评分 %.3f：即时并发余量 %.1f%%，总容量余量 %.1f%%，权重 %d，控制面活跃 %d；候选 %d/%d",
+        "AUTO 评分 %.3f：即时并发余量 %.1f%%，总容量余量 %.1f%%，权重 %d，控制面活跃 %d；%s；候选 %d/%d",
         selected.getScore(),
         selected.getRunningHeadroom() * 100D,
         selected.getTotalHeadroom() * 100D,
         value(selected.getNode().getWeight(), 100),
         selected.getControlPlaneActive(),
+        selected.getCapabilityReason(),
         eligible.size(),
         candidates.size());
     return assignment(selected, "AUTO", reason, candidates);
@@ -202,13 +217,15 @@ public class OfflineWorkerScheduler {
         mode,
         selected.getScore(),
         reason,
-        writeCandidates(candidates));
+        writeCandidates(candidates),
+        selected.getAssignedCapabilitiesJson());
   }
 
   private Candidate evaluate(
       NodeRecord node,
       Map<String, String> requiredLabels,
-      int controlPlaneActive) {
+      int controlPlaneActive,
+      String capabilityRequirementsJson) {
     Candidate candidate = new Candidate(node);
     candidate.setControlPlaneActive(Math.max(0, controlPlaneActive));
     if (!Boolean.TRUE.equals(node.getEnabled())) {
@@ -232,6 +249,13 @@ public class OfflineWorkerScheduler {
         return candidate.reject(
             "缺少标签 " + required.getKey() + "=" + required.getValue());
       }
+    }
+
+    MatchResult capability = capabilityMatcher.match(node, capabilityRequirementsJson);
+    candidate.setCapabilityReason(capability.getReason());
+    candidate.setAssignedCapabilitiesJson(capability.getAssignedCapabilitiesJson());
+    if (!capability.isMatched()) {
+      return candidate.reject("能力不匹配：" + capability.getReason());
     }
 
     int maxRunning = Math.max(1, value(node.getMaxConcurrentJobs(), 1));
@@ -305,6 +329,10 @@ public class OfflineWorkerScheduler {
       item.put("maxConcurrentJobs", value(node.getMaxConcurrentJobs(), 1));
       item.put("maxQueuedJobs", value(node.getMaxQueuedJobs(), 0));
       item.put("labels", candidate.getNodeLabels());
+      item.put("capabilityStatus", node.getCapabilityStatus());
+      item.put("capabilityDigest", node.getCapabilityDigest());
+      item.put("capabilitySyncedAt", node.getCapabilitySyncedAt());
+      item.put("capabilityMatch", candidate.getCapabilityReason());
       snapshot.add(item);
     }
     try {
@@ -409,18 +437,21 @@ public class OfflineWorkerScheduler {
     private final double score;
     private final String reason;
     private final String candidatesJson;
+    private final String assignedCapabilitiesJson;
 
     public Assignment(
         NodeRecord node,
         String mode,
         double score,
         String reason,
-        String candidatesJson) {
+        String candidatesJson,
+        String assignedCapabilitiesJson) {
       this.node = node;
       this.mode = mode;
       this.score = score;
       this.reason = reason;
       this.candidatesJson = candidatesJson;
+      this.assignedCapabilitiesJson = assignedCapabilitiesJson;
     }
 
     public NodeRecord getNode() { return node; }
@@ -428,6 +459,7 @@ public class OfflineWorkerScheduler {
     public double getScore() { return score; }
     public String getReason() { return reason; }
     public String getCandidatesJson() { return candidatesJson; }
+    public String getAssignedCapabilitiesJson() { return assignedCapabilitiesJson; }
   }
 
   private static final class Candidate {
@@ -442,6 +474,8 @@ public class OfflineWorkerScheduler {
     private int controlPlaneActive;
     private int effectiveRunning;
     private int effectiveQueued;
+    private String capabilityReason;
+    private String assignedCapabilitiesJson;
 
     private Candidate(NodeRecord node) {
       this.node = node;
@@ -480,5 +514,9 @@ public class OfflineWorkerScheduler {
     private void setEffectiveRunning(int value) { this.effectiveRunning = value; }
     private int getEffectiveQueued() { return effectiveQueued; }
     private void setEffectiveQueued(int value) { this.effectiveQueued = value; }
+    private String getCapabilityReason() { return capabilityReason; }
+    private void setCapabilityReason(String value) { this.capabilityReason = value; }
+    private String getAssignedCapabilitiesJson() { return assignedCapabilitiesJson; }
+    private void setAssignedCapabilitiesJson(String value) { this.assignedCapabilitiesJson = value; }
   }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/resources/db/migration/yak-offline-sync/V8__add_worker_capability_scheduling.sql
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/resources/db/migration/yak-offline-sync/V8__add_worker_capability_scheduling.sql
@@ -16,4 +16,30 @@ ALTER TABLE yak_offline_job_version
 
 ALTER TABLE yak_offline_job_execution
     ADD COLUMN required_capabilities_json LONGTEXT NULL AFTER assignment_candidates_json,
-    ADD COLUMN assigned_capabilities_json LONGTEXT NULL AFTER required_capabilities_json;
+    ADD COLUMN assigned_capabilities_json LONGTEXT NULL AFTER required_capabilities_json,
+    ADD COLUMN reachability_requirements_json LONGTEXT NULL AFTER assigned_capabilities_json,
+    ADD COLUMN assigned_reachability_json LONGTEXT NULL AFTER reachability_requirements_json;
+
+CREATE TABLE yak_offline_worker_preflight (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    node_id VARCHAR(128) NOT NULL,
+    connector_id VARCHAR(128) NOT NULL,
+    connector_role VARCHAR(16) NOT NULL,
+    options_digest VARCHAR(128) NOT NULL,
+    status VARCHAR(32) NOT NULL,
+    duration_millis BIGINT NULL,
+    error_code VARCHAR(128) NULL,
+    error_message VARCHAR(2000) NULL,
+    checked_at DATETIME NOT NULL,
+    create_time DATETIME NOT NULL,
+    update_time DATETIME NOT NULL,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_offline_worker_preflight
+        (node_id, connector_id, connector_role, options_digest),
+    KEY idx_offline_worker_preflight_status
+        (status, checked_at),
+    CONSTRAINT fk_offline_worker_preflight_node
+        FOREIGN KEY (node_id)
+        REFERENCES yak_offline_engine_node (node_id)
+        ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/resources/db/migration/yak-offline-sync/V8__add_worker_capability_scheduling.sql
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/resources/db/migration/yak-offline-sync/V8__add_worker_capability_scheduling.sql
@@ -1,0 +1,19 @@
+ALTER TABLE yak_offline_engine_node
+    ADD COLUMN capability_status VARCHAR(32) NOT NULL DEFAULT 'UNKNOWN' AFTER last_error_message,
+    ADD COLUMN capability_digest VARCHAR(128) NULL AFTER capability_status,
+    ADD COLUMN connector_schemas_json LONGTEXT NULL AFTER capability_digest,
+    ADD COLUMN capability_synced_at DATETIME NULL AFTER connector_schemas_json,
+    ADD COLUMN capability_error_message VARCHAR(2000) NULL AFTER capability_synced_at;
+
+CREATE INDEX idx_offline_node_capability_status
+    ON yak_offline_engine_node (capability_status, capability_synced_at);
+
+ALTER TABLE yak_offline_job_definition
+    ADD COLUMN capability_requirements_json LONGTEXT NULL AFTER worker_required_labels_json;
+
+ALTER TABLE yak_offline_job_version
+    ADD COLUMN capability_requirements_json LONGTEXT NULL AFTER config_digest;
+
+ALTER TABLE yak_offline_job_execution
+    ADD COLUMN required_capabilities_json LONGTEXT NULL AFTER assignment_candidates_json,
+    ADD COLUMN assigned_capabilities_json LONGTEXT NULL AFTER required_capabilities_json;

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/controller/OfflineWorkerControllerContractTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/controller/OfflineWorkerControllerContractTest.java
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 class OfflineWorkerControllerContractTest {
 
   @Test
-  void exposesWorkerManagementClosure() throws Exception {
+  void exposesWorkerManagementAndCapabilityClosure() throws Exception {
     RequestMapping root = OfflineWorkerController.class.getAnnotation(RequestMapping.class);
     assertThat(root.value()).containsExactly("/api/v1/offline/workers");
 
@@ -29,6 +29,14 @@ class OfflineWorkerControllerContractTest {
     assertPost("page", new Class<?>[] {QueryRequest.class}, "/page");
     assertGet("options", new Class<?>[0], "/options");
     assertPost("refresh", new Class<?>[] {String.class}, "/{nodeId}/refresh");
+    assertGet(
+        "capabilities",
+        new Class<?>[] {String.class},
+        "/{nodeId}/capabilities");
+    assertPost(
+        "refreshCapabilities",
+        new Class<?>[] {String.class},
+        "/{nodeId}/capabilities/refresh");
     assertPut(
         "schedulingStatus",
         new Class<?>[] {String.class, SchedulingRequest.class},

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/service/OfflineWorkerRegistryTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/service/OfflineWorkerRegistryTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.yak.ops.business.sync.offline.config.OfflineSyncProperties;
+import io.yak.ops.business.sync.offline.engine.LinkUpClient.LinkUpNodeResponse;
 import io.yak.ops.business.sync.offline.engine.LinkUpWorkerProbeClient;
 import io.yak.ops.business.sync.offline.repository.OfflineNodeRepository;
 import io.yak.ops.business.sync.offline.repository.OfflineNodeRepository.NodeRecord;
@@ -71,6 +72,79 @@ class OfflineWorkerRegistryTest {
 
     assertThat(registry.ensureConfiguredWorker()).isSameAs(existing);
     verify(repository, never()).upsert(existing);
+  }
+
+  @Test
+  void resetsCapabilitiesWhenConfiguredWorkerAddressChanges() {
+    LinkUpWorkerProbeClient probeClient = mock(LinkUpWorkerProbeClient.class);
+    OfflineNodeRepository repository = mock(OfflineNodeRepository.class);
+    OfflineSyncProperties properties = properties();
+    properties.getEngine().setBaseUrl("http://127.0.0.1:28080");
+    NodeRecord existing = NodeRecord.builder()
+        .nodeId("link-up-node-1")
+        .nodeName("Link-Up Offline Worker")
+        .baseUrl("http://127.0.0.1:18080")
+        .registrationMode("CONFIG")
+        .enabled(true)
+        .schedulingStatus("ENABLED")
+        .capabilityStatus("READY")
+        .build();
+    NodeRecord persisted = NodeRecord.builder()
+        .nodeId("link-up-node-1")
+        .baseUrl("http://127.0.0.1:28080")
+        .capabilityStatus("UNKNOWN")
+        .build();
+
+    when(probeClient.normalizeBaseUrl("http://127.0.0.1:28080"))
+        .thenReturn("http://127.0.0.1:28080");
+    when(repository.find("link-up-node-1")).thenReturn(existing, persisted);
+
+    OfflineWorkerRegistry registry =
+        new OfflineWorkerRegistry(probeClient, repository, properties);
+    NodeRecord result = registry.ensureConfiguredWorker();
+
+    verify(repository).resetCapabilities("link-up-node-1");
+    assertThat(result).isSameAs(persisted);
+  }
+
+  @Test
+  void resetsCapabilitiesWhenWorkerProcessChanges() {
+    LinkUpWorkerProbeClient probeClient = mock(LinkUpWorkerProbeClient.class);
+    OfflineNodeRepository repository = mock(OfflineNodeRepository.class);
+    OfflineSyncProperties properties = properties();
+    NodeRecord existing = NodeRecord.builder()
+        .nodeId("link-up-node-1")
+        .nodeName("Link-Up Offline Worker")
+        .baseUrl("http://127.0.0.1:18080")
+        .workerInstanceId("instance-old")
+        .engineVersion("1.0.0")
+        .build();
+    NodeRecord refreshed = NodeRecord.builder()
+        .nodeId("link-up-node-1")
+        .workerInstanceId("instance-new")
+        .engineVersion("1.0.0")
+        .capabilityStatus("UNKNOWN")
+        .build();
+    LinkUpNodeResponse response = new LinkUpNodeResponse();
+    response.setNodeId("link-up-node-1");
+    response.setNodeName("Link-Up Offline Worker");
+    response.setInstanceId("instance-new");
+    response.setVersion("1.0.0");
+    response.setOfflineOnly(true);
+    response.setMaxConcurrentJobs(4);
+    response.setMaxQueuedJobs(4);
+    response.setRunningJobs(0);
+    response.setQueuedJobs(0);
+
+    when(repository.find("link-up-node-1")).thenReturn(existing, refreshed);
+    when(probeClient.node(existing.getBaseUrl())).thenReturn(response);
+
+    OfflineWorkerRegistry registry =
+        new OfflineWorkerRegistry(probeClient, repository, properties);
+    NodeRecord result = registry.refresh("link-up-node-1", true);
+
+    verify(repository).resetCapabilities("link-up-node-1");
+    assertThat(result).isSameAs(refreshed);
   }
 
   @Test

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/worker/OfflineCapabilityMatcherTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/worker/OfflineCapabilityMatcherTest.java
@@ -24,7 +24,9 @@ class OfflineCapabilityMatcherTest {
 
     assertThat(result.isMatched()).isTrue();
     assertThat(result.getReason()).contains("jdbc/SOURCE").contains("jdbc/SINK");
-    assertThat(result.getAssignedCapabilitiesJson()).contains("capabilityDigest");
+    assertThat(result.getAssignedCapabilitiesJson())
+        .contains("capabilityDigest")
+        .contains("instance-current");
   }
 
   @Test
@@ -70,6 +72,37 @@ class OfflineCapabilityMatcherTest {
     assertThat(result.getReason()).contains("能力快照已过期");
   }
 
+  @Test
+  void rejectsSnapshotFromPreviousWorkerProcess() {
+    OfflineCapabilityProperties properties = new OfflineCapabilityProperties();
+    OfflineCapabilityMatcher matcher = new OfflineCapabilityMatcher(properties, objectMapper);
+    NodeRecord worker = worker("sha256:source", "sha256:sink", "UPSERT");
+    worker.setConnectorSchemasJson(
+        worker.getConnectorSchemasJson().replace("instance-current", "instance-old"));
+
+    MatchResult result = matcher.match(
+        worker,
+        requirements("sha256:source", "sha256:sink", "UPSERT"));
+
+    assertThat(result.isMatched()).isFalse();
+    assertThat(result.getReason()).contains("旧 Worker 进程");
+  }
+
+  @Test
+  void disabledCapabilitySchedulingKeepsWorkerEligible() {
+    OfflineCapabilityProperties properties = new OfflineCapabilityProperties();
+    properties.setEnabled(false);
+    OfflineCapabilityMatcher matcher = new OfflineCapabilityMatcher(properties, objectMapper);
+    NodeRecord worker = NodeRecord.builder().nodeId("worker-1").build();
+
+    MatchResult result = matcher.match(
+        worker,
+        requirements("sha256:source", "sha256:sink", "UPSERT"));
+
+    assertThat(result.isMatched()).isTrue();
+    assertThat(result.getReason()).contains("已关闭");
+  }
+
   private NodeRecord worker(
       String sourceFingerprint,
       String sinkFingerprint,
@@ -81,7 +114,8 @@ class OfflineCapabilityMatcherTest {
       }
       capabilities.append('"').append(sinkCapabilities[index]).append('"');
     }
-    String snapshot = "{\"connectors\":["
+    String snapshot = "{\"workerInstanceId\":\"instance-current\","
+        + "\"engineVersion\":\"1.0.0\",\"connectors\":["
         + "{\"connectorId\":\"jdbc\",\"role\":\"SOURCE\","
         + "\"schemaVersion\":\"1\",\"schemaFingerprint\":\""
         + sourceFingerprint + "\",\"capabilities\":[\"MULTI_TABLE\",\"CUSTOM_SQL\"]},"
@@ -90,6 +124,8 @@ class OfflineCapabilityMatcherTest {
         + sinkFingerprint + "\",\"capabilities\":[" + capabilities + "]}]}";
     return NodeRecord.builder()
         .nodeId("worker-1")
+        .workerInstanceId("instance-current")
+        .engineVersion("1.0.0")
         .capabilityStatus("READY")
         .capabilityDigest("sha256:worker")
         .connectorSchemasJson(snapshot)

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/worker/OfflineCapabilityMatcherTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/worker/OfflineCapabilityMatcherTest.java
@@ -1,0 +1,112 @@
+package io.yak.ops.business.sync.offline.worker;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.sync.offline.config.OfflineCapabilityProperties;
+import io.yak.ops.business.sync.offline.repository.OfflineNodeRepository.NodeRecord;
+import io.yak.ops.business.sync.offline.worker.OfflineCapabilityMatcher.MatchResult;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+
+class OfflineCapabilityMatcherTest {
+
+  private final ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();
+
+  @Test
+  void acceptsMatchingConnectorRoleFingerprintAndFeatures() {
+    OfflineCapabilityProperties properties = new OfflineCapabilityProperties();
+    OfflineCapabilityMatcher matcher = new OfflineCapabilityMatcher(properties, objectMapper);
+
+    MatchResult result = matcher.match(
+        worker("sha256:source", "sha256:sink", "UPSERT", "AUTO_CREATE_TABLE"),
+        requirements("sha256:source", "sha256:sink", "UPSERT"));
+
+    assertThat(result.isMatched()).isTrue();
+    assertThat(result.getReason()).contains("jdbc/SOURCE").contains("jdbc/SINK");
+    assertThat(result.getAssignedCapabilitiesJson()).contains("capabilityDigest");
+  }
+
+  @Test
+  void rejectsMissingExecutionCapability() {
+    OfflineCapabilityProperties properties = new OfflineCapabilityProperties();
+    OfflineCapabilityMatcher matcher = new OfflineCapabilityMatcher(properties, objectMapper);
+
+    MatchResult result = matcher.match(
+        worker("sha256:source", "sha256:sink", "AUTO_CREATE_TABLE"),
+        requirements("sha256:source", "sha256:sink", "UPSERT"));
+
+    assertThat(result.isMatched()).isFalse();
+    assertThat(result.getReason()).contains("缺少能力 UPSERT");
+  }
+
+  @Test
+  void rejectsSchemaFingerprintMismatchInStrictMode() {
+    OfflineCapabilityProperties properties = new OfflineCapabilityProperties();
+    properties.setStrictSchemaFingerprint(true);
+    OfflineCapabilityMatcher matcher = new OfflineCapabilityMatcher(properties, objectMapper);
+
+    MatchResult result = matcher.match(
+        worker("sha256:other", "sha256:sink", "UPSERT"),
+        requirements("sha256:source", "sha256:sink", "UPSERT"));
+
+    assertThat(result.isMatched()).isFalse();
+    assertThat(result.getReason()).contains("Schema 指纹不一致");
+  }
+
+  @Test
+  void rejectsStaleCapabilitySnapshot() {
+    OfflineCapabilityProperties properties = new OfflineCapabilityProperties();
+    properties.setMaxStaleMillis(1_000L);
+    OfflineCapabilityMatcher matcher = new OfflineCapabilityMatcher(properties, objectMapper);
+    NodeRecord worker = worker("sha256:source", "sha256:sink", "UPSERT");
+    worker.setCapabilitySyncedAt(LocalDateTime.now().minusMinutes(1));
+
+    MatchResult result = matcher.match(
+        worker,
+        requirements("sha256:source", "sha256:sink", "UPSERT"));
+
+    assertThat(result.isMatched()).isFalse();
+    assertThat(result.getReason()).contains("能力快照已过期");
+  }
+
+  private NodeRecord worker(
+      String sourceFingerprint,
+      String sinkFingerprint,
+      String... sinkCapabilities) {
+    StringBuilder capabilities = new StringBuilder();
+    for (int index = 0; index < sinkCapabilities.length; index++) {
+      if (index > 0) {
+        capabilities.append(',');
+      }
+      capabilities.append('"').append(sinkCapabilities[index]).append('"');
+    }
+    String snapshot = "{\"connectors\":["
+        + "{\"connectorId\":\"jdbc\",\"role\":\"SOURCE\","
+        + "\"schemaVersion\":\"1\",\"schemaFingerprint\":\""
+        + sourceFingerprint + "\",\"capabilities\":[\"MULTI_TABLE\",\"CUSTOM_SQL\"]},"
+        + "{\"connectorId\":\"jdbc\",\"role\":\"SINK\","
+        + "\"schemaVersion\":\"1\",\"schemaFingerprint\":\""
+        + sinkFingerprint + "\",\"capabilities\":[" + capabilities + "]}]}";
+    return NodeRecord.builder()
+        .nodeId("worker-1")
+        .capabilityStatus("READY")
+        .capabilityDigest("sha256:worker")
+        .connectorSchemasJson(snapshot)
+        .capabilitySyncedAt(LocalDateTime.now())
+        .build();
+  }
+
+  private String requirements(
+      String sourceFingerprint,
+      String sinkFingerprint,
+      String sinkCapability) {
+    return "{\"version\":\"1\",\"endpoints\":["
+        + "{\"connectorId\":\"jdbc\",\"role\":\"SOURCE\","
+        + "\"schemaFingerprint\":\"" + sourceFingerprint + "\","
+        + "\"capabilities\":[\"MULTI_TABLE\"]},"
+        + "{\"connectorId\":\"jdbc\",\"role\":\"SINK\","
+        + "\"schemaFingerprint\":\"" + sinkFingerprint + "\","
+        + "\"capabilities\":[\"" + sinkCapability + "\"]}]}";
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/worker/OfflineCapabilityRequirementResolverTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/worker/OfflineCapabilityRequirementResolverTest.java
@@ -6,8 +6,8 @@ import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.yak.ops.business.sync.offline.form.ConnectorSchemaRegistry;
-import io.yak.ops.business.sync.offline.form.ConnectorSchemaSnapshot;
+import io.yak.ops.business.sync.offline.repository.OfflineConnectorSchemaRepository;
+import io.yak.ops.business.sync.offline.repository.OfflineConnectorSchemaRepository.SchemaRecord;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.Test;
 
@@ -16,13 +16,13 @@ class OfflineCapabilityRequirementResolverTest {
   @Test
   void derivesConnectorFingerprintsAndExecutionFeatures() throws Exception {
     ObjectMapper mapper = new ObjectMapper().findAndRegisterModules();
-    ConnectorSchemaRegistry registry = mock(ConnectorSchemaRegistry.class);
-    when(registry.get("jdbc", "SOURCE"))
-        .thenReturn(snapshot(mapper, "SOURCE", "sha256:source"));
-    when(registry.get("jdbc", "SINK"))
-        .thenReturn(snapshot(mapper, "SINK", "sha256:sink"));
+    OfflineConnectorSchemaRepository repository = mock(OfflineConnectorSchemaRepository.class);
+    when(repository.find("jdbc", "SOURCE"))
+        .thenReturn(schemaRecord(mapper, "SOURCE", "sha256:source"));
+    when(repository.find("jdbc", "SINK"))
+        .thenReturn(schemaRecord(mapper, "SINK", "sha256:sink"));
     OfflineCapabilityRequirementResolver resolver =
-        new OfflineCapabilityRequirementResolver(registry, mapper);
+        new OfflineCapabilityRequirementResolver(repository, mapper);
 
     String jobSpec = "{"
         + "\"source\":{\"connectorId\":\"jdbc\",\"options\":{"
@@ -48,7 +48,24 @@ class OfflineCapabilityRequirementResolverTest {
         .contains("DIRTY_DATA_HANDLING");
   }
 
-  private ConnectorSchemaSnapshot snapshot(
+  @Test
+  void doesNotCallWorkerWhenLocalSchemaIsMissing() throws Exception {
+    ObjectMapper mapper = new ObjectMapper().findAndRegisterModules();
+    OfflineConnectorSchemaRepository repository = mock(OfflineConnectorSchemaRepository.class);
+    OfflineCapabilityRequirementResolver resolver =
+        new OfflineCapabilityRequirementResolver(repository, mapper);
+
+    JsonNode requirements = mapper.readTree(resolver.resolve("{"
+        + "\"source\":{\"connectorId\":\"jdbc\",\"options\":{}},"
+        + "\"sink\":{\"connectorId\":\"jdbc\",\"options\":{}}}"));
+
+    assertThat(requirements.path("endpoints").get(0).path("schemaFingerprint").asText())
+        .isEmpty();
+    assertThat(requirements.path("endpoints").get(1).path("schemaFingerprint").asText())
+        .isEmpty();
+  }
+
+  private SchemaRecord schemaRecord(
       ObjectMapper mapper,
       String role,
       String fingerprint) throws Exception {
@@ -58,6 +75,14 @@ class OfflineCapabilityRequirementResolverTest {
         + "\"schemaVersion\":\"1\","
         + "\"schemaFingerprint\":\"" + fingerprint + "\","
         + "\"options\":[]}");
-    return new ConnectorSchemaSnapshot(schema, "CACHE", false, LocalDateTime.now());
+    return new SchemaRecord(
+        "jdbc",
+        role,
+        "1",
+        fingerprint,
+        "worker-1",
+        "instance-1",
+        mapper.writeValueAsString(schema),
+        LocalDateTime.now());
   }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/worker/OfflineCapabilityRequirementResolverTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/worker/OfflineCapabilityRequirementResolverTest.java
@@ -1,0 +1,63 @@
+package io.yak.ops.business.sync.offline.worker;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.sync.offline.form.ConnectorSchemaRegistry;
+import io.yak.ops.business.sync.offline.form.ConnectorSchemaSnapshot;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+
+class OfflineCapabilityRequirementResolverTest {
+
+  @Test
+  void derivesConnectorFingerprintsAndExecutionFeatures() throws Exception {
+    ObjectMapper mapper = new ObjectMapper().findAndRegisterModules();
+    ConnectorSchemaRegistry registry = mock(ConnectorSchemaRegistry.class);
+    when(registry.get("jdbc", "SOURCE"))
+        .thenReturn(snapshot(mapper, "SOURCE", "sha256:source"));
+    when(registry.get("jdbc", "SINK"))
+        .thenReturn(snapshot(mapper, "SINK", "sha256:sink"));
+    OfflineCapabilityRequirementResolver resolver =
+        new OfflineCapabilityRequirementResolver(registry, mapper);
+
+    String jobSpec = "{"
+        + "\"source\":{\"connectorId\":\"jdbc\",\"options\":{"
+        + "\"table_list\":[{\"table_path\":\"orders\"}],"
+        + "\"partition_column\":\"id\"}},"
+        + "\"sink\":{\"connectorId\":\"jdbc\",\"options\":{"
+        + "\"write_mode\":\"UPSERT\","
+        + "\"schema_save_mode\":\"CREATE_SCHEMA_WHEN_NOT_EXIST\","
+        + "\"dirty_data_policy\":\"SKIP\"}}}";
+
+    JsonNode requirements = mapper.readTree(resolver.resolve(jobSpec));
+
+    assertThat(requirements.path("endpoints").get(0).path("schemaFingerprint").asText())
+        .isEqualTo("sha256:source");
+    assertThat(requirements.path("endpoints").get(0).path("capabilities").toString())
+        .contains("MULTI_TABLE")
+        .contains("PARTITION_SPLIT");
+    assertThat(requirements.path("endpoints").get(1).path("schemaFingerprint").asText())
+        .isEqualTo("sha256:sink");
+    assertThat(requirements.path("endpoints").get(1).path("capabilities").toString())
+        .contains("UPSERT")
+        .contains("AUTO_CREATE_TABLE")
+        .contains("DIRTY_DATA_HANDLING");
+  }
+
+  private ConnectorSchemaSnapshot snapshot(
+      ObjectMapper mapper,
+      String role,
+      String fingerprint) throws Exception {
+    JsonNode schema = mapper.readTree("{"
+        + "\"connectorId\":\"jdbc\","
+        + "\"role\":\"" + role + "\","
+        + "\"schemaVersion\":\"1\","
+        + "\"schemaFingerprint\":\"" + fingerprint + "\","
+        + "\"options\":[]}");
+    return new ConnectorSchemaSnapshot(schema, "CACHE", false, LocalDateTime.now());
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/worker/OfflineReachabilityMatcherTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/worker/OfflineReachabilityMatcherTest.java
@@ -1,0 +1,126 @@
+package io.yak.ops.business.sync.offline.worker;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.sync.offline.config.OfflineCapabilityProperties;
+import io.yak.ops.business.sync.offline.repository.OfflineWorkerPreflightRepository;
+import io.yak.ops.business.sync.offline.repository.OfflineWorkerPreflightRepository.PreflightRecord;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+
+class OfflineReachabilityMatcherTest {
+
+  @Test
+  void acceptsFreshSourceAndSinkPreflightEvidence() {
+    OfflineWorkerPreflightRepository repository = mock(OfflineWorkerPreflightRepository.class);
+    OfflineCapabilityProperties properties = new OfflineCapabilityProperties();
+    OfflineReachabilityMatcher matcher = new OfflineReachabilityMatcher(
+        repository,
+        properties,
+        new ObjectMapper().findAndRegisterModules());
+    when(repository.find("worker-1", "jdbc", "SOURCE", "sha256:source"))
+        .thenReturn(record("SOURCE", "sha256:source", "REACHABLE"));
+    when(repository.find("worker-1", "jdbc", "SINK", "sha256:sink"))
+        .thenReturn(record("SINK", "sha256:sink", "REACHABLE"));
+
+    OfflineReachabilityMatcher.MatchResult result = matcher.match(
+        "worker-1",
+        requirements());
+
+    assertThat(result.isMatched()).isTrue();
+    assertThat(result.getReason()).contains("jdbc/SOURCE=REACHABLE");
+    assertThat(result.getAssignedReachabilityJson())
+        .contains("sha256:source")
+        .contains("sha256:sink");
+  }
+
+  @Test
+  void rejectsUnreachableSinkInStrictMode() {
+    OfflineWorkerPreflightRepository repository = mock(OfflineWorkerPreflightRepository.class);
+    OfflineCapabilityProperties properties = new OfflineCapabilityProperties();
+    OfflineReachabilityMatcher matcher = new OfflineReachabilityMatcher(
+        repository,
+        properties,
+        new ObjectMapper().findAndRegisterModules());
+    when(repository.find("worker-1", "jdbc", "SOURCE", "sha256:source"))
+        .thenReturn(record("SOURCE", "sha256:source", "REACHABLE"));
+    PreflightRecord sink = record("SINK", "sha256:sink", "UNREACHABLE");
+    sink.setErrorMessage("connection refused");
+    when(repository.find("worker-1", "jdbc", "SINK", "sha256:sink"))
+        .thenReturn(sink);
+
+    OfflineReachabilityMatcher.MatchResult result = matcher.match(
+        "worker-1",
+        requirements());
+
+    assertThat(result.isMatched()).isFalse();
+    assertThat(result.getReason())
+        .contains("jdbc/SINK")
+        .contains("UNREACHABLE")
+        .contains("connection refused");
+  }
+
+  @Test
+  void acceptsMissingEvidenceInBestEffortModeButKeepsAudit() {
+    OfflineWorkerPreflightRepository repository = mock(OfflineWorkerPreflightRepository.class);
+    OfflineCapabilityProperties properties = new OfflineCapabilityProperties();
+    properties.setReachabilityRequired(false);
+    OfflineReachabilityMatcher matcher = new OfflineReachabilityMatcher(
+        repository,
+        properties,
+        new ObjectMapper().findAndRegisterModules());
+
+    OfflineReachabilityMatcher.MatchResult result = matcher.match(
+        "worker-1",
+        requirements());
+
+    assertThat(result.isMatched()).isTrue();
+    assertThat(result.getReason()).contains("BEST_EFFORT");
+    assertThat(result.getAssignedReachabilityJson()).contains("MISSING");
+  }
+
+  @Test
+  void rejectsExpiredEvidence() {
+    OfflineWorkerPreflightRepository repository = mock(OfflineWorkerPreflightRepository.class);
+    OfflineCapabilityProperties properties = new OfflineCapabilityProperties();
+    properties.setReachabilityMaxStaleMillis(1_000L);
+    OfflineReachabilityMatcher matcher = new OfflineReachabilityMatcher(
+        repository,
+        properties,
+        new ObjectMapper().findAndRegisterModules());
+    PreflightRecord source = record("SOURCE", "sha256:source", "REACHABLE");
+    source.setCheckedAt(LocalDateTime.now().minusMinutes(1));
+    when(repository.find("worker-1", "jdbc", "SOURCE", "sha256:source"))
+        .thenReturn(source);
+
+    OfflineReachabilityMatcher.MatchResult result = matcher.match(
+        "worker-1",
+        requirements());
+
+    assertThat(result.isMatched()).isFalse();
+    assertThat(result.getReason()).contains("已过期");
+  }
+
+  private PreflightRecord record(String role, String digest, String status) {
+    return PreflightRecord.builder()
+        .nodeId("worker-1")
+        .connectorId("jdbc")
+        .role(role)
+        .optionsDigest(digest)
+        .status(status)
+        .durationMillis(12L)
+        .checkedAt(LocalDateTime.now())
+        .build();
+  }
+
+  private String requirements() {
+    return "{\"version\":\"1\",\"status\":\"REQUIRED\",\"endpoints\":["
+        + "{\"connectorId\":\"jdbc\",\"role\":\"SOURCE\","
+        + "\"optionsDigest\":\"sha256:source\"},"
+        + "{\"connectorId\":\"jdbc\",\"role\":\"SINK\","
+        + "\"optionsDigest\":\"sha256:sink\"}]}";
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/worker/OfflineWorkerSchedulerTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/worker/OfflineWorkerSchedulerTest.java
@@ -3,7 +3,6 @@ package io.yak.ops.business.sync.offline.worker;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/worker/OfflineWorkerSchedulerTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/worker/OfflineWorkerSchedulerTest.java
@@ -2,6 +2,8 @@ package io.yak.ops.business.sync.offline.worker;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -11,6 +13,7 @@ import io.yak.ops.business.sync.offline.repository.OfflineExecutionControlReposi
 import io.yak.ops.business.sync.offline.repository.OfflineNodeRepository;
 import io.yak.ops.business.sync.offline.repository.OfflineNodeRepository.NodeRecord;
 import io.yak.ops.business.sync.offline.service.OfflineWorkerRegistry;
+import io.yak.ops.business.sync.offline.worker.OfflineCapabilityMatcher.MatchResult;
 import io.yak.ops.business.sync.offline.worker.OfflineWorkerScheduler.Assignment;
 import io.yak.ops.common.bean.po.sync.offline.OfflineJobDefinitionPO;
 import java.time.LocalDateTime;
@@ -161,10 +164,14 @@ class OfflineWorkerSchedulerTest {
     OfflineSyncProperties properties = new OfflineSyncProperties();
     properties.getControl().setHeartbeatDelayMillis(10_000L);
     properties.getControl().setLostAfterMillis(120_000L);
+    OfflineCapabilityMatcher matcher = mock(OfflineCapabilityMatcher.class);
+    when(matcher.match(any(NodeRecord.class), any()))
+        .thenReturn(MatchResult.accept("能力匹配", "{}"));
     return new OfflineWorkerScheduler(
         repository,
         executionRepository,
         registry,
+        matcher,
         properties,
         new ObjectMapper().findAndRegisterModules());
   }

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/sync/offline/OfflineJobDefinitionPO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/sync/offline/OfflineJobDefinitionPO.java
@@ -69,6 +69,11 @@ public class OfflineJobDefinitionPO {
   @TableField(updateStrategy = FieldStrategy.ALWAYS)
   private String workerRequiredLabelsJson;
 
+  /** 根据不可变 JobSpec 派生的 Connector、Schema 和执行特性能力要求。 */
+  @ToString.Exclude
+  @TableField(updateStrategy = FieldStrategy.ALWAYS)
+  private String capabilityRequirementsJson;
+
   private Integer version;
   private Long currentVersionId;
   private Long lastExecutionId;

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/sync/offline/OfflineJobExecutionPO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/sync/offline/OfflineJobExecutionPO.java
@@ -34,6 +34,14 @@ public class OfflineJobExecutionPO {
   @ToString.Exclude
   private String assignmentCandidatesJson;
 
+  /** 本次执行所依据的任务 Connector 能力要求。 */
+  @ToString.Exclude
+  private String requiredCapabilitiesJson;
+
+  /** 分配时 Worker 实际匹配的 Connector 能力快照。 */
+  @ToString.Exclude
+  private String assignedCapabilitiesJson;
+
   private String status;
   private Long stateVersion;
   private Integer attemptNo;

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/sync/offline/OfflineJobExecutionPO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/sync/offline/OfflineJobExecutionPO.java
@@ -42,6 +42,14 @@ public class OfflineJobExecutionPO {
   @ToString.Exclude
   private String assignedCapabilitiesJson;
 
+  /** Worker 预热时生成的 Source/Sink options 摘要要求，不包含凭据明文。 */
+  @ToString.Exclude
+  private String reachabilityRequirementsJson;
+
+  /** 分配时命中的 Worker 视角可达性预检证据。 */
+  @ToString.Exclude
+  private String assignedReachabilityJson;
+
   private String status;
   private Long stateVersion;
   private Integer attemptNo;

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/vo/sync/offline/OfflineJobExecutionDetailVO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/vo/sync/offline/OfflineJobExecutionDetailVO.java
@@ -22,4 +22,7 @@ public class OfflineJobExecutionDetailVO {
   private JsonNode pipelines;
   private JsonNode tasks;
   private JsonNode metrics;
+  private JsonNode requiredCapabilities;
+  private JsonNode assignedCapabilities;
+  private JsonNode assignmentCandidates;
 }

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/vo/sync/offline/OfflineJobExecutionVO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/vo/sync/offline/OfflineJobExecutionVO.java
@@ -28,6 +28,8 @@ public class OfflineJobExecutionVO {
   private String assignmentMode;
   private Double assignmentScore;
   private String assignmentReason;
+  private String requiredCapabilitiesJson;
+  private String assignedCapabilitiesJson;
   private String status;
   private Long stateVersion;
   private Integer attemptNo;

--- a/yak-ops-ui/src/pages/client/api.ts
+++ b/yak-ops-ui/src/pages/client/api.ts
@@ -7,6 +7,26 @@ export type WorkerId = string | number;
 export type WorkerHealthStatus = 'UP' | 'DOWN' | string;
 export type WorkerSchedulingStatus = 'ENABLED' | 'DRAINING' | 'DISABLED';
 export type WorkerRegistrationMode = 'CONFIG' | 'MANUAL';
+export type WorkerCapabilityStatus = 'UNKNOWN' | 'READY' | 'ERROR' | string;
+
+export interface ConnectorCapability {
+  connectorId: string;
+  role: 'SOURCE' | 'SINK' | string;
+  schemaVersion?: string;
+  schemaFingerprint?: string;
+  implementationVersion?: string;
+  capabilities: string[];
+}
+
+export interface WorkerCapability {
+  nodeId: string;
+  status: WorkerCapabilityStatus;
+  digest?: string;
+  syncedAt?: string;
+  errorMessage?: string;
+  fresh: boolean;
+  connectors: ConnectorCapability[];
+}
 
 export interface LinkupClient {
   /** 兼容旧调用方，值与 nodeId 相同。 */
@@ -39,6 +59,12 @@ export interface LinkupClient {
   lastSuccessTime?: string;
   consecutiveFailures: number;
   lastErrorMessage?: string;
+  capabilityStatus?: WorkerCapabilityStatus;
+  capabilityDigest?: string;
+  connectorCount?: number;
+  capabilitySyncedAt?: string;
+  capabilityErrorMessage?: string;
+  connectors?: ConnectorCapability[];
   createTime?: string;
   updateTime?: string;
 
@@ -97,6 +123,8 @@ export interface LinkupClientOption {
   queuedJobs?: number;
   maxQueuedJobs?: number;
   available?: boolean;
+  capabilityStatus?: WorkerCapabilityStatus;
+  connectorCount?: number;
 }
 
 const workerPath = (nodeId: WorkerId) => encodeURIComponent(String(nodeId));
@@ -183,6 +211,19 @@ export const linkupClientApi = {
 
   refresh: (nodeId: WorkerId): Promise<ApiResponse<LinkupClient>> => {
     return HttpUtils.post(`${apiPrefix}/${workerPath(nodeId)}/refresh`, {});
+  },
+
+  capabilities: (nodeId: WorkerId): Promise<ApiResponse<WorkerCapability>> => {
+    return HttpUtils.get(`${apiPrefix}/${workerPath(nodeId)}/capabilities`);
+  },
+
+  refreshCapabilities: (
+    nodeId: WorkerId,
+  ): Promise<ApiResponse<WorkerCapability>> => {
+    return HttpUtils.post(
+      `${apiPrefix}/${workerPath(nodeId)}/capabilities/refresh`,
+      {},
+    );
   },
 
   updateSchedulingStatus: (

--- a/yak-ops-ui/src/pages/client/detail/index.tsx
+++ b/yak-ops-ui/src/pages/client/detail/index.tsx
@@ -1,3 +1,295 @@
-const DataQualityPage = () => <div>good</div>;
+import {
+  ArrowLeftOutlined,
+  ReloadOutlined,
+} from '@ant-design/icons';
+import { history, useParams } from '@umijs/max';
+import {
+  Alert,
+  Button,
+  ConfigProvider,
+  Descriptions,
+  Empty,
+  message,
+  Spin,
+  Table,
+  Tag,
+} from 'antd';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
-export default DataQualityPage;
+import { API_SUCCESS_CODE } from '@/services/http/response';
+import { BRAND_THEME } from '@/styles/brand';
+
+import {
+  linkupClientApi,
+  type ConnectorCapability,
+  type LinkupClient,
+  type WorkerCapability,
+} from '../api';
+
+const capabilityStatusMeta = (status?: string, fresh?: boolean) => {
+  if (status === 'READY' && fresh) {
+    return { label: '能力就绪', color: 'success' as const };
+  }
+  if (status === 'ERROR') {
+    return { label: '同步异常', color: 'error' as const };
+  }
+  if (status === 'READY') {
+    return { label: '快照过期', color: 'warning' as const };
+  }
+  return { label: '等待同步', color: 'default' as const };
+};
+
+const formatTime = (value?: string) => value || '--';
+
+export default function WorkerDetailPage() {
+  const params = useParams<{ id?: string }>();
+  const nodeId = params.id ? decodeURIComponent(params.id) : '';
+  const [loading, setLoading] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
+  const [worker, setWorker] = useState<LinkupClient | null>(null);
+  const [capability, setCapability] = useState<WorkerCapability | null>(null);
+
+  const load = useCallback(async () => {
+    if (!nodeId) return;
+    setLoading(true);
+    try {
+      const [workerResponse, capabilityResponse] = await Promise.all([
+        linkupClientApi.selectById(nodeId),
+        linkupClientApi.capabilities(nodeId),
+      ]);
+      if (workerResponse?.code !== API_SUCCESS_CODE || !workerResponse.data) {
+        throw new Error(workerResponse?.message || '获取 Worker 详情失败');
+      }
+      setWorker(workerResponse.data);
+      setCapability(
+        capabilityResponse?.code === API_SUCCESS_CODE
+          ? capabilityResponse.data || null
+          : null,
+      );
+    } catch (error: any) {
+      message.error(error?.message || '获取 Worker 详情失败');
+      setWorker(null);
+      setCapability(null);
+    } finally {
+      setLoading(false);
+    }
+  }, [nodeId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const refresh = async () => {
+    if (!nodeId) return;
+    setRefreshing(true);
+    try {
+      const response = await linkupClientApi.refresh(nodeId);
+      if (response?.code !== API_SUCCESS_CODE) {
+        throw new Error(response?.message || '刷新 Worker 失败');
+      }
+      message.success('Worker 心跳与 Connector 能力已刷新');
+      await load();
+    } catch (error: any) {
+      message.error(error?.message || '刷新 Worker 失败');
+    } finally {
+      setRefreshing(false);
+    }
+  };
+
+  const columns = useMemo(
+    () => [
+      {
+        title: 'Connector',
+        dataIndex: 'connectorId',
+        width: 160,
+        render: (value: string, record: ConnectorCapability) => (
+          <div>
+            <div className="font-medium text-[#161823]">{value}</div>
+            <div className="mt-0.5 text-xs text-[#8a8f99]">
+              {record.implementationVersion || '--'}
+            </div>
+          </div>
+        ),
+      },
+      {
+        title: '角色',
+        dataIndex: 'role',
+        width: 100,
+        render: (value: string) => (
+          <Tag className="!m-0">{value}</Tag>
+        ),
+      },
+      {
+        title: 'Schema',
+        width: 260,
+        render: (_: unknown, record: ConnectorCapability) => (
+          <div>
+            <div className="text-sm text-[#344054]">
+              v{record.schemaVersion || '--'}
+            </div>
+            <div className="mt-0.5 max-w-[240px] truncate font-mono text-xs text-[#98a2b3]">
+              {record.schemaFingerprint || '--'}
+            </div>
+          </div>
+        ),
+      },
+      {
+        title: '执行能力',
+        dataIndex: 'capabilities',
+        render: (values: string[] = []) =>
+          values.length > 0 ? (
+            <div className="flex flex-wrap gap-1.5">
+              {values.map((value) => (
+                <Tag key={value} className="!m-0">
+                  {value}
+                </Tag>
+              ))}
+            </div>
+          ) : (
+            <span className="text-[#98a2b3]">无额外能力声明</span>
+          ),
+      },
+    ],
+    [],
+  );
+
+  if (loading) {
+    return (
+      <div className="flex min-h-[calc(100vh-64px)] items-center justify-center bg-[#f7f7f8]">
+        <Spin size="large" />
+      </div>
+    );
+  }
+
+  if (!worker) {
+    return (
+      <div className="flex min-h-[calc(100vh-64px)] items-center justify-center bg-[#f7f7f8]">
+        <Empty description="未找到执行节点">
+          <Button onClick={() => history.push('/client')}>返回节点列表</Button>
+        </Empty>
+      </div>
+    );
+  }
+
+  const status = capabilityStatusMeta(capability?.status, capability?.fresh);
+
+  return (
+    <ConfigProvider theme={BRAND_THEME}>
+      <div className="min-h-[calc(100vh-64px)] bg-[#f7f7f8] px-6 py-6">
+        <div className="mx-auto max-w-[1280px]">
+          <div className="mb-5 flex flex-wrap items-center justify-between gap-3">
+            <div className="flex min-w-0 items-center gap-3">
+              <Button
+                type="text"
+                icon={<ArrowLeftOutlined />}
+                onClick={() => history.push('/client')}
+              />
+              <div className="min-w-0">
+                <div className="flex flex-wrap items-center gap-2">
+                  <h1 className="m-0 truncate text-[22px] font-semibold text-[#161823]">
+                    {worker.nodeName}
+                  </h1>
+                  <Tag color={worker.status === 'UP' ? 'success' : 'error'}>
+                    {worker.status === 'UP' ? '在线' : '离线'}
+                  </Tag>
+                  <Tag color={status.color}>{status.label}</Tag>
+                </div>
+                <div className="mt-1 font-mono text-xs text-[#8a8f99]">
+                  {worker.nodeId}
+                </div>
+              </div>
+            </div>
+
+            <Button
+              icon={<ReloadOutlined />}
+              loading={refreshing}
+              onClick={() => void refresh()}
+            >
+              刷新心跳与能力
+            </Button>
+          </div>
+
+          <section className="rounded-xl border border-[#eceef1] bg-white p-5">
+            <Descriptions
+              title="节点概览"
+              column={{ xs: 1, sm: 2, lg: 3 }}
+              items={[
+                { key: 'url', label: 'Worker 地址', children: worker.baseUrl },
+                { key: 'version', label: '引擎版本', children: worker.engineVersion || '--' },
+                { key: 'instance', label: '进程实例', children: worker.workerInstanceId || '--' },
+                {
+                  key: 'schedule',
+                  label: '调度状态',
+                  children: worker.schedulingStatus,
+                },
+                {
+                  key: 'capacity',
+                  label: '运行容量',
+                  children: `${worker.runningJobs}/${worker.maxConcurrentJobs}`,
+                },
+                {
+                  key: 'queue',
+                  label: '队列容量',
+                  children: `${worker.queuedJobs}/${worker.maxQueuedJobs}`,
+                },
+                {
+                  key: 'heartbeat',
+                  label: '最近心跳',
+                  children: formatTime(worker.lastHeartbeatTime),
+                },
+                {
+                  key: 'capabilityTime',
+                  label: '能力同步',
+                  children: formatTime(capability?.syncedAt),
+                },
+                {
+                  key: 'digest',
+                  label: '能力摘要',
+                  children: (
+                    <span className="font-mono text-xs">
+                      {capability?.digest || '--'}
+                    </span>
+                  ),
+                },
+              ]}
+            />
+          </section>
+
+          {capability?.errorMessage ? (
+            <Alert
+              className="mt-4"
+              type="warning"
+              showIcon
+              message="Connector 能力同步异常"
+              description={capability.errorMessage}
+            />
+          ) : null}
+
+          <section className="mt-4 rounded-xl border border-[#eceef1] bg-white p-5">
+            <div className="mb-4 flex items-center justify-between gap-3">
+              <div>
+                <h2 className="m-0 text-base font-semibold text-[#161823]">
+                  Connector 能力
+                </h2>
+                <div className="mt-1 text-xs text-[#8a8f99]">
+                  调度器会按 Connector、角色、Schema 指纹和任务特性能力进行硬过滤。
+                </div>
+              </div>
+              <span className="text-sm text-[#667085]">
+                {capability?.connectors?.length || 0} 个能力项
+              </span>
+            </div>
+
+            <Table<ConnectorCapability>
+              rowKey={(record) => `${record.connectorId}-${record.role}`}
+              columns={columns}
+              dataSource={capability?.connectors || []}
+              pagination={false}
+              locale={{ emptyText: '当前 Worker 尚未同步 Connector 能力' }}
+            />
+          </section>
+        </div>
+      </div>
+    </ConfigProvider>
+  );
+}

--- a/yak-ops-ui/src/pages/client/index.tsx
+++ b/yak-ops-ui/src/pages/client/index.tsx
@@ -5,6 +5,7 @@ import {
   DeleteOutlined,
   EditOutlined,
   ExclamationCircleOutlined,
+  EyeOutlined,
   LinkOutlined,
   MoreOutlined,
   PauseCircleOutlined,
@@ -13,6 +14,7 @@ import {
   SearchOutlined,
   StopOutlined,
 } from '@ant-design/icons';
+import { history } from '@umijs/max';
 import {
   Alert,
   Button,
@@ -52,6 +54,25 @@ const filters: Array<{ key: WorkerFilter; label: string }> = [
 
 const normalize = (value?: string) => value?.trim().toLowerCase() || '';
 
+const capabilityMeta = (worker: LinkupClient) => {
+  if (worker.capabilityStatus === 'READY') {
+    return {
+      label: `能力就绪${worker.connectorCount ? ` · ${worker.connectorCount}` : ''}`,
+      className: '!border-[#b2ddff] !bg-[#eff8ff] !text-[#175cd3]',
+    };
+  }
+  if (worker.capabilityStatus === 'ERROR') {
+    return {
+      label: '能力异常',
+      className: '!border-[#fedf89] !bg-[#fffaeb] !text-[#b54708]',
+    };
+  }
+  return {
+    label: '能力待同步',
+    className: '!border-[#e4e7ec] !bg-[#f8f9fb] !text-[#667085]',
+  };
+};
+
 const healthMeta = (worker: LinkupClient) => {
   if (worker.schedulingStatus === 'DISABLED') {
     return {
@@ -70,9 +91,12 @@ const healthMeta = (worker: LinkupClient) => {
     };
   }
   if (worker.status === 'UP') {
+    const unavailableReason = worker.capabilityStatus !== 'READY'
+      ? '能力未就绪'
+      : '暂不可调度';
     return {
       filter: 'online' as const,
-      label: worker.available ? '在线可用' : '队列已满',
+      label: worker.available ? '在线可用' : unavailableReason,
       dot: worker.available ? 'bg-[#12b76a]' : 'bg-[#f79009]',
       tag: worker.available
         ? '!border-[#abefc6] !bg-[#ecfdf3] !text-[#067647]'
@@ -134,6 +158,7 @@ const WorkerRow = ({
   onDelete: () => void;
 }) => {
   const meta = healthMeta(worker);
+  const capability = capabilityMeta(worker);
   const loadPercent = Math.round(Math.max(0, Math.min(1, worker.loadRatio || 0)) * 100);
   const configManaged = worker.registrationMode === 'CONFIG';
 
@@ -183,6 +208,9 @@ const WorkerRow = ({
                     {meta.label}
                   </span>
                 </Tag>
+                <Tag className={`!m-0 !rounded-md !px-2 ${capability.className}`}>
+                  {capability.label}
+                </Tag>
                 <Tag className="!m-0 !rounded-md !border-[#e4e7ec] !bg-[#f8f9fb] !text-[#667085]">
                   {configManaged ? '配置托管' : '手工注册'}
                 </Tag>
@@ -196,6 +224,7 @@ const WorkerRow = ({
               <div className="mt-1 flex flex-wrap gap-x-4 gap-y-1 text-[12px] leading-6 text-[#98a2b3]">
                 <span>nodeId：{worker.nodeId}</span>
                 <span>最近心跳：{formatTime(worker.lastHeartbeatTime)}</span>
+                <span>能力同步：{formatTime(worker.capabilitySyncedAt)}</span>
                 <span>连续失败：{worker.consecutiveFailures || 0}</span>
               </div>
 
@@ -213,7 +242,16 @@ const WorkerRow = ({
             </div>
 
             <Space size={4} wrap>
-              <Tooltip title="立即读取 /api/v1/node">
+              <Button
+                type="text"
+                icon={<EyeOutlined />}
+                onClick={() =>
+                  history.push(`/client/${encodeURIComponent(worker.nodeId)}/detail`)
+                }
+              >
+                详情
+              </Button>
+              <Tooltip title="刷新节点心跳与 Connector 能力">
                 <Button
                   type="text"
                   icon={<ReloadOutlined spin={refreshing} />}
@@ -264,6 +302,16 @@ const WorkerRow = ({
             />
           ) : null}
 
+          {worker.capabilityErrorMessage ? (
+            <Alert
+              className="mt-3"
+              type="warning"
+              showIcon
+              message="Connector 能力同步异常"
+              description={worker.capabilityErrorMessage}
+            />
+          ) : null}
+
           <div className="mt-4 flex flex-col gap-4 border-t border-[#f0f1f3] pt-4 lg:flex-row lg:items-center">
             <div className="min-w-[220px] flex-1">
               <div className="mb-1 flex items-center justify-between text-[12px] text-[#667085]">
@@ -281,6 +329,7 @@ const WorkerRow = ({
                 label="排队任务"
                 value={`${worker.queuedJobs || 0} / ${worker.maxQueuedJobs || 0}`}
               />
+              <WorkerMetric label="Connector" value={worker.connectorCount || 0} />
               <WorkerMetric label="调度权重" value={worker.weight || 100} />
               <WorkerMetric label="进程运行" value={formatUptime(worker.startedAtMillis)} />
             </div>
@@ -335,10 +384,17 @@ const ClientPage = () => {
         result.activeJobs += Number(worker.activeJobs || 0);
         result.runningCapacity += Number(worker.maxConcurrentJobs || 0);
         result.queueCapacity += Number(worker.maxQueuedJobs || 0);
+        result.connectors += Number(worker.connectorCount || 0);
         if (worker.available) result.available += 1;
         return result;
       },
-      { activeJobs: 0, runningCapacity: 0, queueCapacity: 0, available: 0 },
+      {
+        activeJobs: 0,
+        runningCapacity: 0,
+        queueCapacity: 0,
+        connectors: 0,
+        available: 0,
+      },
     );
   }, [clients]);
 
@@ -352,6 +408,7 @@ const ClientPage = () => {
         worker.nodeName,
         worker.baseUrl,
         worker.engineVersion,
+        worker.capabilityStatus,
         JSON.stringify(worker.labels || {}),
       ].some((item) => normalize(item).includes(value));
     });
@@ -367,7 +424,7 @@ const ClientPage = () => {
                 执行节点
               </h1>
               <p className="m-0 mt-1 text-[13px] leading-6 text-[#8a8f99]">
-                管理 Link-Up 离线 Worker 的注册、心跳、容量和调度状态。
+                管理 Link-Up Worker 的注册、心跳、容量、Connector 能力和调度状态。
               </p>
             </div>
             <Space size={8} wrap>
@@ -387,11 +444,11 @@ const ClientPage = () => {
           <section className="mt-4 grid grid-cols-2 gap-3 xl:grid-cols-4">
             {[
               { label: '登记节点', value: total, icon: <CloudServerOutlined /> },
-              { label: '在线可用', value: summary.available, icon: <CheckCircleOutlined /> },
+              { label: '能力可用', value: summary.available, icon: <CheckCircleOutlined /> },
               { label: '活跃任务', value: summary.activeJobs, icon: <ClockCircleOutlined /> },
               {
-                label: '总容量',
-                value: `${summary.runningCapacity} + ${summary.queueCapacity}`,
+                label: 'Connector 能力',
+                value: summary.connectors,
                 icon: <ExclamationCircleOutlined />,
               },
             ].map((item) => (
@@ -430,7 +487,7 @@ const ClientPage = () => {
                 allowClear
                 variant="filled"
                 prefix={<SearchOutlined className="text-[#98a2b3]" />}
-                placeholder="搜索名称、nodeId、地址或标签"
+                placeholder="搜索名称、nodeId、地址、能力状态或标签"
                 value={keyword}
                 className="w-full lg:w-[320px]"
                 onChange={(event) => setKeyword(event.target.value)}


### PR DESCRIPTION
## 背景

第一阶段完成 Link-Up Worker 管理闭环，第二阶段完成 `AUTO / MANUAL` 多 Worker 调度。本 PR 完成第三阶段 **能力调度**：

1. 确认候选 Worker 实际安装了任务需要的 Connector、角色、Schema 契约和执行特性。
2. 从实际 Link-Up Worker 所在网络对 Source 和 Sink 进行只读可达性预检。
3. 在执行实例中固化能力、可达性、负载评分和全部候选淘汰证据。

本 PR 基于第二阶段合并后的最新 `main`（`5e36f77`）。

配套 Link-Up Draft PR 使用分支：`agent/connector-preflight`，提供安全 preflight REST 协议与 JDBC 实现。

## 一、Worker Connector 能力事实层

Yak Ops 逐 Worker 调用：

```http
GET /api/v1/connectors
```

并保存规范化能力摘要：

- `connectorId`
- `role`
- `schemaVersion`
- `schemaFingerprint`
- `implementationVersion`
- `capabilities`
- SHA-256 能力摘要

能力状态：

- `UNKNOWN`：尚未同步
- `READY`：能力快照可用于调度
- `ERROR`：最近同步失败

能力快照支持后台周期刷新、运行前预热、注册/编辑后刷新和手工强制刷新。

当 Worker 地址、`instanceId` 或引擎版本发生变化时，会立即清空旧能力快照；匹配器也会防御性拒绝属于旧进程或旧版本的快照。

## 二、任务能力要求

从不可变 JobSpec 自动派生：

- Source/Sink `connectorId + role`
- 保存版本时使用的 Schema 版本和指纹
- 自定义 SQL → `CUSTOM_SQL`
- 多表同步 → `MULTI_TABLE`
- 分片读取 → `PARTITION_SPLIT`
- UPSERT → `UPSERT`
- 自动建表 → `AUTO_CREATE_TABLE`
- 脏数据跳过/阈值 → `DIRTY_DATA_HANDLING`

新任务版本在保存时固化能力要求。历史版本没有该字段时，会在首次执行前根据该版本 JobSpec 自动派生并回填，不修改 JobSpec、版本号或配置摘要。

能力要求只读取 Yak Ops 已持久化的 Connector Schema，不会在任务保存或领取事务中回源 Worker。

## 三、Worker 视角 Source/Sink 可达性

配套 Link-Up PR 新增：

```http
POST /api/v1/connectors/{connectorId}/preflight?role=SOURCE|SINK
```

执行流程：

```text
运行命令
  → 刷新到期 Worker Connector 能力
  → 解析当前任务版本与最新数据源凭据
  → 从候选 Worker 执行 Source/Sink 只读 preflight
  → 只保存 options SHA-256、状态、耗时和脱敏错误
  → 进入数据库领取事务
  → 按能力、可达性、标签、健康、容量和权重选择 Worker
```

缓存键：

```text
nodeId + connectorId + role + optionsDigest
```

数据库不保存预检请求中的密码、Token 或完整 options。连接参数变化后摘要变化，不会误用旧预检结果。

预检状态：

- `REACHABLE`
- `UNREACHABLE`
- `UNSUPPORTED`
- `MISSING`（审计展示）

默认严格模式下 Source 和 Sink 均必须为新鲜 `REACHABLE`。

## 四、调度硬过滤与评分

候选 Worker 必须满足：

1. 节点启用、在线、允许调度且心跳新鲜
2. 标签精确匹配
3. Connector 与角色存在
4. 能力快照 `READY` 且未过期
5. 严格模式下 Schema 指纹一致
6. Worker 包含任务要求的全部执行能力
7. Source 和 Sink 从该 Worker 视角可达
8. 运行并发与等待队列未同时满载

硬过滤通过后继续使用第二阶段评分：

```text
score = runningHeadroom × 55
      + totalCapacityHeadroom × 35
      + normalizedWeight × 10
```

`MANUAL` 模式同样执行完整能力和可达性检查，不匹配时直接失败，绝不切换其他 Worker。

## 五、事务与并发安全

- 所有远程能力刷新和可达性预检均发生在领取事务之前。
- 调度事务只读取数据库快照与共享预检缓存。
- Worker 行按 `nodeId` 固定顺序加锁。
- Yak Ops 活跃执行数叠加到 Worker 心跳负载，降低并发提交超卖。
- 同一次执行从提交、取消到后台对账始终绑定固化 Worker。

## 六、执行审计

执行实例固化：

- `required_capabilities_json`
- `assigned_capabilities_json`
- `reachability_requirements_json`
- `assigned_reachability_json`
- `assignment_candidates_json`
- Worker 地址、实例 ID、模式、得分和选择原因

新增接口：

```http
GET /api/v1/offline/executions/{executionId}/scheduling-evidence
```

可查看任务要求、Worker 实际能力、Source/Sink 预检证据和全部候选淘汰原因。

## 七、Worker 管理 API 与前端

新增：

```http
GET  /api/v1/offline/workers/{nodeId}/capabilities
POST /api/v1/offline/workers/{nodeId}/capabilities/refresh
```

原节点刷新接口现在同时刷新心跳与能力。

前端完成：

- 节点列表区分能力待同步、异常和就绪
- 展示 Connector 数量和能力同步时间
- 增加节点详情入口
- 节点详情展示角色、Schema 版本/指纹、实现版本和能力集合
- 修复能力未就绪被误显示成“队列已满”

## 八、Flyway V8

Worker 增加能力快照字段。

任务定义和版本增加：

- `capability_requirements_json`

执行实例增加：

- `required_capabilities_json`
- `assigned_capabilities_json`
- `reachability_requirements_json`
- `assigned_reachability_json`

新增共享短缓存表：

- `yak_offline_worker_preflight`

## 九、配置

```yaml
yak:
  sync:
    offline:
      capability:
        enabled: true
        strict-schema-fingerprint: true
        max-stale-millis: 900000
        initial-delay-millis: 10000
        refresh-delay-millis: 60000
        worker-refresh-millis: 300000
        reachability-enabled: true
        reachability-required: true
        reachability-max-stale-millis: 60000
        reachability-max-workers: 50
        reachability-retention-millis: 86400000
```

Link-Up Worker 滚动升级期间可以临时设置：

```yaml
yak:
  sync:
    offline:
      capability:
        reachability-required: false
```

全部 Worker 支持 preflight 后恢复 `true`。

## 十、测试与审查

测试覆盖：

- Connector、角色、Schema 指纹和能力集合匹配
- 缺失能力、指纹不一致、快照过期和旧进程快照拒绝
- JobSpec 能力要求派生
- AUTO/MANUAL 原调度行为继续成立
- Source/Sink 新鲜预检证据匹配
- 不可达、过期和兼容模式行为
- Worker 改址、重启后的能力失效
- 能力 API 路由契约

生产源码已进行离线同步模块定向编译；完整双仓库联动测试仍保留 Draft 状态，待配套 Link-Up PR 合并/发布后执行集成验证。

## 当前边界

- 不迁移运行中任务
- 提交结果不确定时不自动故障转移
- 不实现 Worker 侧分布式资源租约
- 非 JDBC Connector 需要按安全语义逐步实现 `ConnectorPreflightSupport`，未实现时明确返回 `UNSUPPORTED`
