### PR TITLE
feat(offline-worker): add signed dynamic registration leases

### DIFF
--- a/docs/dynamic-worker-registration.md
+++ b/docs/dynamic-worker-registration.md
@@ -149,7 +149,7 @@ V9 为 Worker 增加：
 并新增：
 
 - `yak_offline_worker_registration_nonce`：nonce 防重放
-- `yak_offline_worker_registration_event`：注册、续租、接管、注销和撤销审计
+- `yak_offline_worker_registration_event`：注册、重试、接管、注销和撤销等低频生命周期审计；普通心跳只更新节点表，不写事件表
 
 ## 发布顺序
 

--- a/docs/dynamic-worker-registration.md
+++ b/docs/dynamic-worker-registration.md
@@ -1,0 +1,162 @@
+# Link-Up Worker 动态注册
+
+## 定位
+
+第四阶段将 Worker 管理从“Yak Ops 预先知道每一个 Worker 地址”扩展为“Worker 启动后主动登记并续租”。
+
+动态注册只负责 Worker 运行事实：
+
+- Worker 地址、nodeId 与进程 instanceId
+- 引擎版本、启动时间
+- 运行并发、等待队列和当前负载
+- Connector、角色、Schema 指纹与执行能力
+- 租约到期时间和心跳序列
+
+Yak Ops 始终拥有管理字段：
+
+- 节点显示名称
+- 标签
+- 调度权重
+- 启用、排空和禁用状态
+
+Worker 心跳不会覆盖这些管理设置。
+
+## 注册模式
+
+| 模式 | 来源 | 健康与能力更新方式 |
+|---|---|---|
+| `CONFIG` | Yak Ops `application.yml` | Yak Ops 主动探测 |
+| `MANUAL` | 管理页面手工登记 | Yak Ops 主动探测 |
+| `DYNAMIC` | Link-Up Worker 主动注册 | Worker 签名心跳续租 |
+
+相同 `nodeId` 不能在不同模式之间自动抢占。需要先删除或调整原节点，再切换注册模式。
+
+## 安全协议
+
+公开路径：
+
+```http
+POST /api/v1/offline/worker-registration/register
+POST /api/v1/offline/worker-registration/heartbeat
+POST /api/v1/offline/worker-registration/deregister
+```
+
+每个请求必须携带：
+
+```text
+X-Yak-Registration-Timestamp
+X-Yak-Registration-Nonce
+X-Yak-Registration-Signature
+```
+
+签名原文：
+
+```text
+HTTP_METHOD\n
+REQUEST_URI\n
+TIMESTAMP_MILLIS\n
+NONCE\n
+SHA256(RAW_JSON_BODY)
+```
+
+签名算法为 `HMAC-SHA256`。Yak Ops 还会校验时间偏差并将 nonce 摘要写入一次性防重放表。签名校验成功后才会消耗 nonce。
+
+生产环境应同时使用 HTTPS；HMAC 用于请求身份和完整性，TLS 用于保护请求中的 Worker 元数据。
+
+## Yak Ops 配置
+
+动态注册默认关闭：
+
+```yaml
+yak:
+  sync:
+    offline:
+      registration:
+        enabled: true
+        secret: ${YAK_OFFLINE_REGISTRATION_SECRET}
+        auto-enable: true
+        heartbeat-interval-millis: 20000
+        lease-duration-millis: 90000
+        clock-skew-millis: 300000
+        nonce-retention-millis: 600000
+```
+
+环境变量示例：
+
+```bash
+export YAK_OFFLINE_REGISTRATION_ENABLED=true
+export YAK_OFFLINE_REGISTRATION_SECRET='replace-with-at-least-16-random-characters'
+```
+
+建议使用不少于 32 字节的随机密钥，并通过 Secret 管理系统注入，不要提交到仓库。
+
+## 租约语义
+
+首次注册：
+
+1. 校验签名、时间戳和 nonce。
+2. 校验协议版本、nodeId、instanceId 和 Worker 地址。
+3. 创建 `DYNAMIC` 节点和租约。
+4. 根据 `auto-enable` 设置初始调度状态。
+5. 保存 Worker 推送的 Connector 能力快照。
+
+续租：
+
+- `leaseId + nodeId + instanceId` 必须完全匹配。
+- `sequence` 必须严格递增。
+- 每次成功心跳延长租约。
+- 管理名称、标签、权重和调度状态不被覆盖。
+
+实例接管：
+
+- 旧租约有效时，不同 `instanceId` 会收到 `409 Conflict`。
+- 旧租约过期后，新实例可使用相同 nodeId 注册并获得新 leaseId。
+- 同一实例的不确定网络重试会复用原 leaseId。
+
+租约过期：
+
+- 节点被标记为 `DOWN`，但不会自动删除。
+- 调度器在能力过滤阶段再次直接检查租约时间，不依赖后台清理间隔。
+- 管理员可在节点列表或详情页撤销租约。
+
+## 管理接口
+
+```http
+POST /api/v1/offline/workers/{nodeId}/lease/revoke
+```
+
+请求示例：
+
+```json
+{
+  "reason": "节点下线维护"
+}
+```
+
+有效租约存在时不能直接删除动态节点，必须先撤销租约，避免把仍在运行的 Worker 误认为未登记节点。
+
+## Flyway V9
+
+V9 为 Worker 增加：
+
+- `registration_lease_id`
+- `registration_instance_id`
+- `registration_protocol_version`
+- `lease_expires_at`
+- `last_registration_time`
+- `heartbeat_sequence`
+
+并新增：
+
+- `yak_offline_worker_registration_nonce`：nonce 防重放
+- `yak_offline_worker_registration_event`：注册、续租、接管、注销和撤销审计
+
+## 发布顺序
+
+1. 先部署支持动态注册接口的 Yak Ops。
+2. 配置共享密钥并启用 Yak Ops 动态注册。
+3. 再滚动升级 Link-Up Worker，并配置相同共享密钥。
+4. 确认节点显示为“动态注册 / 租约有效 / 能力就绪”。
+5. 逐步删除不再需要的手工登记节点。
+
+旧版 Worker 不受影响，仍可继续以 `CONFIG` 或 `MANUAL` 模式运行。

--- a/yak-ops-boot/src/main/resources/application.yml
+++ b/yak-ops-boot/src/main/resources/application.yml
@@ -47,9 +47,11 @@ yak:
     audit-enabled: true
     application-name: ${YAK_SECURITY_APPLICATION_NAME:${spring.application.name}}
 
-    # Keep startup verification and API documentation public. Other endpoints require login.
+    # Keep startup verification, signed Worker registration and API documentation public.
+    # Dynamic registration performs its own HMAC authentication and replay protection.
     public-paths:
       - /api/test/ping
+      - /api/v1/offline/worker-registration/**
       - /yak-security/api/v1/account/login
       - /yak-security/api/v1/common/heart
       - /v3/api-docs/**
@@ -139,6 +141,16 @@ yak:
         base-url: ${YAK_LINK_UP_BASE_URL:http://127.0.0.1:18080}
         connect-timeout: ${YAK_LINK_UP_CONNECT_TIMEOUT:10s}
         request-timeout: ${YAK_LINK_UP_REQUEST_TIMEOUT:30s}
+      registration:
+        enabled: ${YAK_OFFLINE_REGISTRATION_ENABLED:false}
+        secret: ${YAK_OFFLINE_REGISTRATION_SECRET:}
+        auto-enable: ${YAK_OFFLINE_REGISTRATION_AUTO_ENABLE:true}
+        heartbeat-interval-millis: ${YAK_OFFLINE_REGISTRATION_HEARTBEAT_MILLIS:20000}
+        lease-duration-millis: ${YAK_OFFLINE_REGISTRATION_LEASE_MILLIS:90000}
+        clock-skew-millis: ${YAK_OFFLINE_REGISTRATION_CLOCK_SKEW_MILLIS:300000}
+        nonce-retention-millis: ${YAK_OFFLINE_REGISTRATION_NONCE_RETENTION_MILLIS:600000}
+        cleanup-initial-delay-millis: ${YAK_OFFLINE_REGISTRATION_CLEANUP_INITIAL_DELAY_MILLIS:10000}
+        cleanup-delay-millis: ${YAK_OFFLINE_REGISTRATION_CLEANUP_DELAY_MILLIS:10000}
 
   schedule:
     enabled: true

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/config/OfflineWorkerRegistrationProperties.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/config/OfflineWorkerRegistrationProperties.java
@@ -1,0 +1,67 @@
+package io.yak.ops.business.sync.offline.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+/** Link-Up Worker 主动注册、心跳续租和防重放配置。 */
+@ConditionalOnOfflineSyncEnabled
+@Component
+@ConfigurationProperties(prefix = "yak.sync.offline.registration")
+public class OfflineWorkerRegistrationProperties {
+
+  /** 是否开放动态注册接口。默认关闭，配置共享密钥后再显式开启。 */
+  private boolean enabled = false;
+
+  /** HMAC-SHA256 共享密钥，不会持久化到数据库。 */
+  private String secret;
+
+  /** 新动态 Worker 首次登记后是否自动允许调度。 */
+  private boolean autoEnable = true;
+
+  /** 控制面建议的心跳间隔。 */
+  private long heartbeatIntervalMillis = 20_000L;
+
+  /** 每次注册或心跳续期后的租约时长。 */
+  private long leaseDurationMillis = 90_000L;
+
+  /** 请求时间戳允许的最大偏差。 */
+  private long clockSkewMillis = 300_000L;
+
+  /** nonce 保留时间，保留期内相同 nonce 只能使用一次。 */
+  private long nonceRetentionMillis = 600_000L;
+
+  /** 租约过期扫描的初始延迟。 */
+  private long cleanupInitialDelayMillis = 10_000L;
+
+  /** 租约过期和 nonce 清理间隔。 */
+  private long cleanupDelayMillis = 10_000L;
+
+  public boolean isEnabled() { return enabled; }
+  public void setEnabled(boolean enabled) { this.enabled = enabled; }
+  public String getSecret() { return secret; }
+  public void setSecret(String secret) { this.secret = secret; }
+  public boolean isAutoEnable() { return autoEnable; }
+  public void setAutoEnable(boolean autoEnable) { this.autoEnable = autoEnable; }
+  public long getHeartbeatIntervalMillis() { return heartbeatIntervalMillis; }
+  public void setHeartbeatIntervalMillis(long heartbeatIntervalMillis) {
+    this.heartbeatIntervalMillis = heartbeatIntervalMillis;
+  }
+  public long getLeaseDurationMillis() { return leaseDurationMillis; }
+  public void setLeaseDurationMillis(long leaseDurationMillis) {
+    this.leaseDurationMillis = leaseDurationMillis;
+  }
+  public long getClockSkewMillis() { return clockSkewMillis; }
+  public void setClockSkewMillis(long clockSkewMillis) { this.clockSkewMillis = clockSkewMillis; }
+  public long getNonceRetentionMillis() { return nonceRetentionMillis; }
+  public void setNonceRetentionMillis(long nonceRetentionMillis) {
+    this.nonceRetentionMillis = nonceRetentionMillis;
+  }
+  public long getCleanupInitialDelayMillis() { return cleanupInitialDelayMillis; }
+  public void setCleanupInitialDelayMillis(long cleanupInitialDelayMillis) {
+    this.cleanupInitialDelayMillis = cleanupInitialDelayMillis;
+  }
+  public long getCleanupDelayMillis() { return cleanupDelayMillis; }
+  public void setCleanupDelayMillis(long cleanupDelayMillis) {
+    this.cleanupDelayMillis = cleanupDelayMillis;
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/controller/OfflineWorkerController.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/controller/OfflineWorkerController.java
@@ -5,6 +5,7 @@ import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
 import io.yak.ops.business.sync.offline.worker.OfflineWorkerCapabilityService;
 import io.yak.ops.business.sync.offline.worker.OfflineWorkerModels.CapabilityView;
 import io.yak.ops.business.sync.offline.worker.OfflineWorkerModels.CreateRequest;
+import io.yak.ops.business.sync.offline.worker.OfflineWorkerModels.LeaseRevokeRequest;
 import io.yak.ops.business.sync.offline.worker.OfflineWorkerModels.OptionView;
 import io.yak.ops.business.sync.offline.worker.OfflineWorkerModels.PageView;
 import io.yak.ops.business.sync.offline.worker.OfflineWorkerModels.QueryRequest;
@@ -12,6 +13,7 @@ import io.yak.ops.business.sync.offline.worker.OfflineWorkerModels.SchedulingReq
 import io.yak.ops.business.sync.offline.worker.OfflineWorkerModels.UpdateRequest;
 import io.yak.ops.business.sync.offline.worker.OfflineWorkerModels.VerifyRequest;
 import io.yak.ops.business.sync.offline.worker.OfflineWorkerModels.WorkerView;
+import io.yak.ops.business.sync.offline.worker.OfflineWorkerRegistrationService;
 import io.yak.ops.business.sync.offline.worker.OfflineWorkerService;
 import jakarta.validation.Valid;
 import java.util.List;
@@ -38,6 +40,7 @@ public class OfflineWorkerController {
 
   private final OfflineWorkerService service;
   private final OfflineWorkerCapabilityService capabilityService;
+  private final OfflineWorkerRegistrationService registrationService;
 
   @PostMapping("/verify")
   public Result<WorkerView> verify(@Valid @RequestBody VerifyRequest request) {
@@ -96,6 +99,14 @@ public class OfflineWorkerController {
   @PostMapping("/{nodeId}/capabilities/refresh")
   public Result<CapabilityView> refreshCapabilities(@PathVariable String nodeId) {
     return Result.success(capabilityService.refreshView(nodeId));
+  }
+
+  @PostMapping("/{nodeId}/lease/revoke")
+  public Result<WorkerView> revokeLease(
+      @PathVariable String nodeId,
+      @RequestBody(required = false) LeaseRevokeRequest request) {
+    registrationService.revoke(nodeId, request == null ? null : request.getReason());
+    return Result.success(capabilityService.enrich(service.get(nodeId)));
   }
 
   @PutMapping("/{nodeId}/scheduling-status")

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/controller/OfflineWorkerRegistrationController.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/controller/OfflineWorkerRegistrationController.java
@@ -1,0 +1,88 @@
+package io.yak.ops.business.sync.offline.controller;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.framework.common.Result;
+import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import io.yak.ops.business.sync.offline.worker.OfflineWorkerRegistrationAuthenticator;
+import io.yak.ops.business.sync.offline.worker.OfflineWorkerRegistrationModels.DeregisterRequest;
+import io.yak.ops.business.sync.offline.worker.OfflineWorkerRegistrationModels.HeartbeatRequest;
+import io.yak.ops.business.sync.offline.worker.OfflineWorkerRegistrationModels.LeaseResponse;
+import io.yak.ops.business.sync.offline.worker.OfflineWorkerRegistrationModels.RegisterRequest;
+import io.yak.ops.business.sync.offline.worker.OfflineWorkerRegistrationService;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.MediaType;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+/** Link-Up Worker 主动注册、心跳续租与优雅注销接口。 */
+@ConditionalOnOfflineSyncEnabled
+@RestController
+@RequestMapping("/api/v1/offline/worker-registration")
+public class OfflineWorkerRegistrationController {
+
+  private final OfflineWorkerRegistrationAuthenticator authenticator;
+  private final OfflineWorkerRegistrationService service;
+  private final ObjectMapper objectMapper;
+
+  public OfflineWorkerRegistrationController(
+      OfflineWorkerRegistrationAuthenticator authenticator,
+      OfflineWorkerRegistrationService service,
+      @Qualifier("offlineSyncJsonMapper") ObjectMapper objectMapper) {
+    this.authenticator = authenticator;
+    this.service = service;
+    this.objectMapper = objectMapper;
+  }
+
+  @PostMapping(value = "/register", consumes = MediaType.APPLICATION_JSON_VALUE)
+  public Result<LeaseResponse> register(
+      HttpServletRequest servletRequest,
+      @RequestBody String body) {
+    authenticator.authenticate(servletRequest, body);
+    RegisterRequest request = read(body, RegisterRequest.class);
+    return Result.success(service.register(request, remoteAddress(servletRequest)));
+  }
+
+  @PostMapping(value = "/heartbeat", consumes = MediaType.APPLICATION_JSON_VALUE)
+  public Result<LeaseResponse> heartbeat(
+      HttpServletRequest servletRequest,
+      @RequestBody String body) {
+    authenticator.authenticate(servletRequest, body);
+    HeartbeatRequest request = read(body, HeartbeatRequest.class);
+    return Result.success(service.heartbeat(request, remoteAddress(servletRequest)));
+  }
+
+  @PostMapping(value = "/deregister", consumes = MediaType.APPLICATION_JSON_VALUE)
+  public Result<Boolean> deregister(
+      HttpServletRequest servletRequest,
+      @RequestBody String body) {
+    authenticator.authenticate(servletRequest, body);
+    DeregisterRequest request = read(body, DeregisterRequest.class);
+    return Result.success(service.deregister(request, remoteAddress(servletRequest)));
+  }
+
+  private <T> T read(String body, Class<T> type) {
+    try {
+      return objectMapper.readValue(body, type);
+    } catch (JsonProcessingException exception) {
+      throw new ResponseStatusException(
+          HttpStatus.BAD_REQUEST,
+          "动态 Worker 注册 JSON 格式不正确",
+          exception);
+    }
+  }
+
+  private String remoteAddress(HttpServletRequest request) {
+    String forwarded = request.getHeader("X-Forwarded-For");
+    if (forwarded != null && !forwarded.trim().isEmpty()) {
+      int comma = forwarded.indexOf(',');
+      return (comma >= 0 ? forwarded.substring(0, comma) : forwarded).trim();
+    }
+    return request.getRemoteAddr();
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineNodeRepository.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineNodeRepository.java
@@ -5,6 +5,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.List;
 import javax.sql.DataSource;
 import lombok.AllArgsConstructor;
@@ -17,11 +18,7 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.stereotype.Repository;
 
-/**
- * Link-Up Worker 注册信息、调度状态、心跳、租约和能力快照持久化。
- *
- * @author weifuwan
- */
+/** Link-Up Worker 管理状态、动态租约、心跳和能力快照仓储。 */
 @ConditionalOnOfflineSyncEnabled
 @Repository
 public class OfflineNodeRepository {
@@ -36,6 +33,8 @@ public class OfflineNodeRepository {
           + "last_error_message, capability_status, capability_digest, connector_schemas_json, "
           + "capability_synced_at, capability_error_message, create_time, update_time";
 
+  private static final int UPSERT_COLUMN_COUNT = 34;
+
   private final JdbcTemplate jdbc;
   private final RowMapper<NodeRecord> rowMapper = this::map;
 
@@ -43,10 +42,9 @@ public class OfflineNodeRepository {
     this.jdbc = new JdbcTemplate(dataSource);
   }
 
-  /** 创建或覆盖配置来源 Worker；能力快照和租约字段按传入值更新。 */
   public void upsert(NodeRecord node) {
     LocalDateTime now = LocalDateTime.now();
-    jdbc.update(
+    String sql =
         "INSERT INTO yak_offline_engine_node ("
             + "node_id, node_name, base_url, registration_mode, registration_lease_id, "
             + "registration_instance_id, registration_protocol_version, lease_expires_at, "
@@ -55,10 +53,9 @@ public class OfflineNodeRepository {
             + "offline_only, status, max_concurrent_jobs, max_queued_jobs, running_jobs, "
             + "queued_jobs, last_heartbeat_time, last_success_time, consecutive_failures, "
             + "last_error_message, capability_status, capability_digest, connector_schemas_json, "
-            + "capability_synced_at, capability_error_message, create_time, update_time) "
-            + "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, "
-            + "?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "
-            + "ON DUPLICATE KEY UPDATE "
+            + "capability_synced_at, capability_error_message, create_time, update_time) VALUES ("
+            + String.join(", ", Collections.nCopies(UPSERT_COLUMN_COUNT, "?"))
+            + ") ON DUPLICATE KEY UPDATE "
             + "node_name = VALUES(node_name), base_url = VALUES(base_url), "
             + "registration_mode = VALUES(registration_mode), "
             + "registration_lease_id = VALUES(registration_lease_id), "
@@ -82,11 +79,13 @@ public class OfflineNodeRepository {
             + "connector_schemas_json = VALUES(connector_schemas_json), "
             + "capability_synced_at = VALUES(capability_synced_at), "
             + "capability_error_message = VALUES(capability_error_message), "
-            + "update_time = VALUES(update_time)",
+            + "update_time = VALUES(update_time)";
+    jdbc.update(
+        sql,
         node.getNodeId(), node.getNodeName(), node.getBaseUrl(), node.getRegistrationMode(),
         node.getRegistrationLeaseId(), node.getRegistrationInstanceId(),
         node.getRegistrationProtocolVersion(), timestamp(node.getLeaseExpiresAt()),
-        timestamp(node.getLastRegistrationTime()), value(node.getHeartbeatSequence(), 0L),
+        timestamp(node.getLastRegistrationTime()), number(node.getHeartbeatSequence(), 0L),
         bool(node.getEnabled()), node.getSchedulingStatus(), node.getWeight(), node.getLabelsJson(),
         node.getWorkerInstanceId(), node.getEngineVersion(), node.getStartedAtMillis(),
         bool(node.getOfflineOnly()), node.getStatus(), node.getMaxConcurrentJobs(),
@@ -95,13 +94,12 @@ public class OfflineNodeRepository {
         node.getConsecutiveFailures(), node.getLastErrorMessage(),
         text(node.getCapabilityStatus(), "UNKNOWN"), node.getCapabilityDigest(),
         node.getConnectorSchemasJson(), timestamp(node.getCapabilitySyncedAt()),
-        node.getCapabilityErrorMessage(), timestamp(
-            node.getCreateTime() == null ? now : node.getCreateTime()), timestamp(now));
+        node.getCapabilityErrorMessage(),
+        timestamp(node.getCreateTime() == null ? now : node.getCreateTime()), timestamp(now));
   }
 
-  /** 更新用户可编辑的 Worker 定义，并同步本次验证得到的运行信息。 */
   public boolean update(NodeRecord node) {
-    int updated = jdbc.update(
+    return jdbc.update(
         "UPDATE yak_offline_engine_node SET node_name = ?, base_url = ?, enabled = ?, "
             + "scheduling_status = ?, weight = ?, labels_json = ?, worker_instance_id = ?, "
             + "engine_version = ?, started_at_millis = ?, offline_only = ?, status = ?, "
@@ -115,8 +113,7 @@ public class OfflineNodeRepository {
         node.getMaxQueuedJobs(), node.getRunningJobs(), node.getQueuedJobs(),
         timestamp(node.getLastHeartbeatTime()), timestamp(node.getLastSuccessTime()),
         node.getConsecutiveFailures(), node.getLastErrorMessage(),
-        timestamp(LocalDateTime.now()), node.getNodeId());
-    return updated > 0;
+        timestamp(LocalDateTime.now()), node.getNodeId()) > 0;
   }
 
   public void updateHeartbeatSuccess(NodeRecord node) {
@@ -130,8 +127,8 @@ public class OfflineNodeRepository {
             + "last_error_message = NULL, update_time = ? WHERE node_id = ?",
         node.getNodeName(), node.getWorkerInstanceId(), node.getEngineVersion(),
         node.getStartedAtMillis(), bool(node.getOfflineOnly()), node.getMaxConcurrentJobs(),
-        node.getMaxQueuedJobs(), node.getRunningJobs(), node.getQueuedJobs(), timestamp(now),
-        timestamp(now), timestamp(LocalDateTime.now()), node.getNodeId());
+        node.getMaxQueuedJobs(), node.getRunningJobs(), node.getQueuedJobs(),
+        timestamp(now), timestamp(now), timestamp(LocalDateTime.now()), node.getNodeId());
   }
 
   public void updateHeartbeatFailure(String nodeId, String message) {
@@ -143,10 +140,7 @@ public class OfflineNodeRepository {
   }
 
   public void updateCapabilitySuccess(
-      String nodeId,
-      String digest,
-      String connectorSchemasJson,
-      LocalDateTime syncedAt) {
+      String nodeId, String digest, String connectorSchemasJson, LocalDateTime syncedAt) {
     LocalDateTime now = syncedAt == null ? LocalDateTime.now() : syncedAt;
     jdbc.update(
         "UPDATE yak_offline_engine_node SET capability_status = 'READY', capability_digest = ?, "
@@ -155,7 +149,6 @@ public class OfflineNodeRepository {
         digest, connectorSchemasJson, timestamp(now), timestamp(LocalDateTime.now()), nodeId);
   }
 
-  /** 保留最后一次成功快照，只更新错误状态，便于诊断和短时容错。 */
   public void updateCapabilityFailure(String nodeId, String message) {
     jdbc.update(
         "UPDATE yak_offline_engine_node SET capability_status = 'ERROR', "
@@ -183,8 +176,7 @@ public class OfflineNodeRepository {
     try {
       return jdbc.queryForObject(
           "SELECT " + SELECT_COLUMNS + " FROM yak_offline_engine_node WHERE node_id = ?",
-          rowMapper,
-          nodeId);
+          rowMapper, nodeId);
     } catch (EmptyResultDataAccessException exception) {
       return null;
     }
@@ -196,8 +188,7 @@ public class OfflineNodeRepository {
       return jdbc.queryForObject(
           "SELECT " + SELECT_COLUMNS
               + " FROM yak_offline_engine_node WHERE node_id = ? FOR UPDATE",
-          rowMapper,
-          nodeId);
+          rowMapper, nodeId);
     } catch (EmptyResultDataAccessException exception) {
       return null;
     }
@@ -207,8 +198,7 @@ public class OfflineNodeRepository {
     try {
       return jdbc.queryForObject(
           "SELECT " + SELECT_COLUMNS + " FROM yak_offline_engine_node WHERE base_url = ? LIMIT 1",
-          rowMapper,
-          baseUrl);
+          rowMapper, baseUrl);
     } catch (EmptyResultDataAccessException exception) {
       return null;
     }
@@ -216,16 +206,15 @@ public class OfflineNodeRepository {
 
   public List<NodeRecord> listAll() {
     return jdbc.query(
-        "SELECT " + SELECT_COLUMNS + " FROM yak_offline_engine_node "
-            + "ORDER BY update_time DESC, node_name ASC",
+        "SELECT " + SELECT_COLUMNS
+            + " FROM yak_offline_engine_node ORDER BY update_time DESC, node_name ASC",
         rowMapper);
   }
 
-  /** 调度事务内按稳定顺序锁定全部 Worker 行。 */
   public List<NodeRecord> listAllForScheduling() {
     return jdbc.query(
-        "SELECT " + SELECT_COLUMNS + " FROM yak_offline_engine_node "
-            + "ORDER BY node_id ASC FOR UPDATE",
+        "SELECT " + SELECT_COLUMNS
+            + " FROM yak_offline_engine_node ORDER BY node_id ASC FOR UPDATE",
         rowMapper);
   }
 
@@ -297,7 +286,7 @@ public class OfflineNodeRepository {
     return Boolean.TRUE.equals(value) ? 1 : 0;
   }
 
-  private long value(Long value, long fallback) {
+  private long number(Long value, long fallback) {
     return value == null ? fallback : value;
   }
 
@@ -314,7 +303,6 @@ public class OfflineNodeRepository {
   @NoArgsConstructor
   @AllArgsConstructor
   public static class NodeRecord {
-
     private String nodeId;
     private String nodeName;
     private String baseUrl;

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineNodeRepository.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineNodeRepository.java
@@ -18,7 +18,7 @@ import org.springframework.jdbc.core.RowMapper;
 import org.springframework.stereotype.Repository;
 
 /**
- * Link-Up Worker 注册信息、调度状态、心跳和能力快照持久化。
+ * Link-Up Worker 注册信息、调度状态、心跳、租约和能力快照持久化。
  *
  * @author weifuwan
  */
@@ -27,7 +27,9 @@ import org.springframework.stereotype.Repository;
 public class OfflineNodeRepository {
 
   private static final String SELECT_COLUMNS =
-      "node_id, node_name, base_url, registration_mode, enabled, scheduling_status, "
+      "node_id, node_name, base_url, registration_mode, registration_lease_id, "
+          + "registration_instance_id, registration_protocol_version, lease_expires_at, "
+          + "last_registration_time, heartbeat_sequence, enabled, scheduling_status, "
           + "weight, labels_json, worker_instance_id, engine_version, started_at_millis, "
           + "offline_only, status, max_concurrent_jobs, max_queued_jobs, running_jobs, "
           + "queued_jobs, last_heartbeat_time, last_success_time, consecutive_failures, "
@@ -41,21 +43,30 @@ public class OfflineNodeRepository {
     this.jdbc = new JdbcTemplate(dataSource);
   }
 
-  /** 创建或覆盖配置来源的默认 Worker；已有能力快照不会被心跳登记覆盖。 */
+  /** 创建或覆盖配置来源 Worker；能力快照和租约字段按传入值更新。 */
   public void upsert(NodeRecord node) {
     LocalDateTime now = LocalDateTime.now();
     jdbc.update(
         "INSERT INTO yak_offline_engine_node ("
-            + "node_id, node_name, base_url, registration_mode, enabled, scheduling_status, "
+            + "node_id, node_name, base_url, registration_mode, registration_lease_id, "
+            + "registration_instance_id, registration_protocol_version, lease_expires_at, "
+            + "last_registration_time, heartbeat_sequence, enabled, scheduling_status, "
             + "weight, labels_json, worker_instance_id, engine_version, started_at_millis, "
             + "offline_only, status, max_concurrent_jobs, max_queued_jobs, running_jobs, "
             + "queued_jobs, last_heartbeat_time, last_success_time, consecutive_failures, "
             + "last_error_message, capability_status, capability_digest, connector_schemas_json, "
             + "capability_synced_at, capability_error_message, create_time, update_time) "
-            + "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "
+            + "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, "
+            + "?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "
             + "ON DUPLICATE KEY UPDATE "
             + "node_name = VALUES(node_name), base_url = VALUES(base_url), "
-            + "registration_mode = VALUES(registration_mode), enabled = VALUES(enabled), "
+            + "registration_mode = VALUES(registration_mode), "
+            + "registration_lease_id = VALUES(registration_lease_id), "
+            + "registration_instance_id = VALUES(registration_instance_id), "
+            + "registration_protocol_version = VALUES(registration_protocol_version), "
+            + "lease_expires_at = VALUES(lease_expires_at), "
+            + "last_registration_time = VALUES(last_registration_time), "
+            + "heartbeat_sequence = VALUES(heartbeat_sequence), enabled = VALUES(enabled), "
             + "scheduling_status = VALUES(scheduling_status), weight = VALUES(weight), "
             + "labels_json = VALUES(labels_json), worker_instance_id = VALUES(worker_instance_id), "
             + "engine_version = VALUES(engine_version), started_at_millis = VALUES(started_at_millis), "
@@ -65,8 +76,17 @@ public class OfflineNodeRepository {
             + "queued_jobs = VALUES(queued_jobs), last_heartbeat_time = VALUES(last_heartbeat_time), "
             + "last_success_time = VALUES(last_success_time), "
             + "consecutive_failures = VALUES(consecutive_failures), "
-            + "last_error_message = VALUES(last_error_message), update_time = VALUES(update_time)",
+            + "last_error_message = VALUES(last_error_message), "
+            + "capability_status = VALUES(capability_status), "
+            + "capability_digest = VALUES(capability_digest), "
+            + "connector_schemas_json = VALUES(connector_schemas_json), "
+            + "capability_synced_at = VALUES(capability_synced_at), "
+            + "capability_error_message = VALUES(capability_error_message), "
+            + "update_time = VALUES(update_time)",
         node.getNodeId(), node.getNodeName(), node.getBaseUrl(), node.getRegistrationMode(),
+        node.getRegistrationLeaseId(), node.getRegistrationInstanceId(),
+        node.getRegistrationProtocolVersion(), timestamp(node.getLeaseExpiresAt()),
+        timestamp(node.getLastRegistrationTime()), value(node.getHeartbeatSequence(), 0L),
         bool(node.getEnabled()), node.getSchedulingStatus(), node.getWeight(), node.getLabelsJson(),
         node.getWorkerInstanceId(), node.getEngineVersion(), node.getStartedAtMillis(),
         bool(node.getOfflineOnly()), node.getStatus(), node.getMaxConcurrentJobs(),
@@ -75,7 +95,8 @@ public class OfflineNodeRepository {
         node.getConsecutiveFailures(), node.getLastErrorMessage(),
         text(node.getCapabilityStatus(), "UNKNOWN"), node.getCapabilityDigest(),
         node.getConnectorSchemasJson(), timestamp(node.getCapabilitySyncedAt()),
-        node.getCapabilityErrorMessage(), timestamp(now), timestamp(now));
+        node.getCapabilityErrorMessage(), timestamp(
+            node.getCreateTime() == null ? now : node.getCreateTime()), timestamp(now));
   }
 
   /** 更新用户可编辑的 Worker 定义，并同步本次验证得到的运行信息。 */
@@ -169,6 +190,19 @@ public class OfflineNodeRepository {
     }
   }
 
+  /** 必须在 offline-sync 事务内调用。 */
+  public NodeRecord findForUpdate(String nodeId) {
+    try {
+      return jdbc.queryForObject(
+          "SELECT " + SELECT_COLUMNS
+              + " FROM yak_offline_engine_node WHERE node_id = ? FOR UPDATE",
+          rowMapper,
+          nodeId);
+    } catch (EmptyResultDataAccessException exception) {
+      return null;
+    }
+  }
+
   public NodeRecord findByBaseUrl(String baseUrl) {
     try {
       return jdbc.queryForObject(
@@ -195,11 +229,12 @@ public class OfflineNodeRepository {
         rowMapper);
   }
 
+  /** CONFIG/MANUAL 使用 Yak Ops 主动探测；DYNAMIC 由 Worker 主动续租。 */
   public List<NodeRecord> listHeartbeatTargets() {
     return jdbc.query(
         "SELECT " + SELECT_COLUMNS + " FROM yak_offline_engine_node "
             + "WHERE enabled = 1 AND scheduling_status <> 'DISABLED' "
-            + "ORDER BY node_id ASC",
+            + "AND registration_mode <> 'DYNAMIC' ORDER BY node_id ASC",
         rowMapper);
   }
 
@@ -221,6 +256,12 @@ public class OfflineNodeRepository {
         .nodeName(rs.getString("node_name"))
         .baseUrl(rs.getString("base_url"))
         .registrationMode(rs.getString("registration_mode"))
+        .registrationLeaseId(rs.getString("registration_lease_id"))
+        .registrationInstanceId(rs.getString("registration_instance_id"))
+        .registrationProtocolVersion(rs.getString("registration_protocol_version"))
+        .leaseExpiresAt(localDateTime(rs.getTimestamp("lease_expires_at")))
+        .lastRegistrationTime(localDateTime(rs.getTimestamp("last_registration_time")))
+        .heartbeatSequence(rs.getLong("heartbeat_sequence"))
         .enabled(rs.getBoolean("enabled"))
         .schedulingStatus(rs.getString("scheduling_status"))
         .weight(rs.getInt("weight"))
@@ -256,6 +297,10 @@ public class OfflineNodeRepository {
     return Boolean.TRUE.equals(value) ? 1 : 0;
   }
 
+  private long value(Long value, long fallback) {
+    return value == null ? fallback : value;
+  }
+
   private Timestamp timestamp(LocalDateTime value) {
     return value == null ? null : Timestamp.valueOf(value);
   }
@@ -274,6 +319,12 @@ public class OfflineNodeRepository {
     private String nodeName;
     private String baseUrl;
     private String registrationMode;
+    private String registrationLeaseId;
+    private String registrationInstanceId;
+    private String registrationProtocolVersion;
+    private LocalDateTime leaseExpiresAt;
+    private LocalDateTime lastRegistrationTime;
+    private Long heartbeatSequence;
     private Boolean enabled;
     private String schedulingStatus;
     private Integer weight;

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineWorkerRegistrationRepository.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineWorkerRegistrationRepository.java
@@ -9,7 +9,7 @@ import org.springframework.dao.DuplicateKeyException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
 
-/** 动态 Worker 注册 nonce、租约过期和事件审计仓储。 */
+/** 动态 Worker 注册 nonce、租约过期和生命周期事件审计仓储。 */
 @ConditionalOnOfflineSyncEnabled
 @Repository
 public class OfflineWorkerRegistrationRepository {
@@ -62,6 +62,10 @@ public class OfflineWorkerRegistrationRepository {
         nodeId) > 0;
   }
 
+  /**
+   * 只记录低频生命周期事件。普通 HEARTBEAT 已由节点表的时间和序列承载，
+   * 不写事件表，避免长时间运行产生高容量无价值审计数据。
+   */
   public void recordEvent(
       String nodeId,
       String instanceId,
@@ -69,6 +73,9 @@ public class OfflineWorkerRegistrationRepository {
       String eventType,
       String remoteAddress,
       String message) {
+    if ("HEARTBEAT".equalsIgnoreCase(eventType)) {
+      return;
+    }
     jdbc.update(
         "INSERT INTO yak_offline_worker_registration_event "
             + "(node_id, instance_id, lease_id, event_type, remote_address, message, event_time) "

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineWorkerRegistrationRepository.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineWorkerRegistrationRepository.java
@@ -1,0 +1,95 @@
+package io.yak.ops.business.sync.offline.repository;
+
+import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import javax.sql.DataSource;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+/** 动态 Worker 注册 nonce、租约过期和事件审计仓储。 */
+@ConditionalOnOfflineSyncEnabled
+@Repository
+public class OfflineWorkerRegistrationRepository {
+
+  private final JdbcTemplate jdbc;
+
+  public OfflineWorkerRegistrationRepository(
+      @Qualifier("offlineSyncDataSource") DataSource dataSource) {
+    this.jdbc = new JdbcTemplate(dataSource);
+  }
+
+  /** nonce 在有效期内只能成功写入一次。 */
+  public boolean consumeNonce(String nonceHash, LocalDateTime expiresAt) {
+    try {
+      jdbc.update(
+          "INSERT INTO yak_offline_worker_registration_nonce "
+              + "(nonce_hash, expires_at, create_time) VALUES (?, ?, ?)",
+          nonceHash,
+          timestamp(expiresAt),
+          timestamp(LocalDateTime.now()));
+      return true;
+    } catch (DuplicateKeyException exception) {
+      return false;
+    }
+  }
+
+  public int cleanupNonces(LocalDateTime now) {
+    return jdbc.update(
+        "DELETE FROM yak_offline_worker_registration_nonce WHERE expires_at < ?",
+        timestamp(now));
+  }
+
+  public int expireLeases(LocalDateTime now) {
+    return jdbc.update(
+        "UPDATE yak_offline_engine_node SET status = 'DOWN', "
+            + "last_error_message = '动态注册租约已过期', update_time = ? "
+            + "WHERE registration_mode = 'DYNAMIC' AND lease_expires_at < ? AND status <> 'DOWN'",
+        timestamp(now),
+        timestamp(now));
+  }
+
+  public boolean revokeLease(String nodeId, LocalDateTime now, String reason) {
+    return jdbc.update(
+        "UPDATE yak_offline_engine_node SET lease_expires_at = ?, status = 'DOWN', "
+            + "last_error_message = ?, update_time = ? "
+            + "WHERE node_id = ? AND registration_mode = 'DYNAMIC'",
+        timestamp(now),
+        reason,
+        timestamp(now),
+        nodeId) > 0;
+  }
+
+  public void recordEvent(
+      String nodeId,
+      String instanceId,
+      String leaseId,
+      String eventType,
+      String remoteAddress,
+      String message) {
+    jdbc.update(
+        "INSERT INTO yak_offline_worker_registration_event "
+            + "(node_id, instance_id, lease_id, event_type, remote_address, message, event_time) "
+            + "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        nodeId,
+        instanceId,
+        leaseId,
+        eventType,
+        remoteAddress,
+        concise(message),
+        timestamp(LocalDateTime.now()));
+  }
+
+  private String concise(String value) {
+    if (value == null) {
+      return null;
+    }
+    return value.length() <= 1000 ? value : value.substring(0, 1000);
+  }
+
+  private Timestamp timestamp(LocalDateTime value) {
+    return value == null ? null : Timestamp.valueOf(value);
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineWorkerRegistry.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineWorkerRegistry.java
@@ -18,7 +18,7 @@ import org.springframework.util.StringUtils;
 /**
  * Link-Up Worker 注册表、定时心跳和默认节点选择器。
  *
- * <p>任务执行由多 Worker 调度器选择节点；本组件继续负责默认配置节点的登记和全部节点心跳。
+ * <p>CONFIG/MANUAL 节点由 Yak Ops 主动探测；DYNAMIC 节点由 Worker 主动续租。
  *
  * @author weifuwan
  */
@@ -56,6 +56,9 @@ public class OfflineWorkerRegistry {
     NodeRecord node = repository.find(nodeId);
     if (node == null) {
       throw new IllegalArgumentException("Link-Up Worker 不存在：" + nodeId);
+    }
+    if ("DYNAMIC".equalsIgnoreCase(node.getRegistrationMode())) {
+      return node;
     }
     return refresh(node, failFast);
   }
@@ -101,11 +104,13 @@ public class OfflineWorkerRegistry {
         ? engine.getNodeName().trim() : nodeId;
     String baseUrl = probeClient.normalizeBaseUrl(engine.getBaseUrl());
     NodeRecord existing = repository.find(nodeId);
+    if (existing != null && !"CONFIG".equalsIgnoreCase(existing.getRegistrationMode())) {
+      throw new IllegalStateException(
+          "默认 Worker nodeId 已由 " + existing.getRegistrationMode() + " 模式管理：" + nodeId);
+    }
     String nodeName = existing != null && StringUtils.hasText(existing.getNodeName())
         ? existing.getNodeName() : configuredNodeName;
-    if (existing != null
-        && "CONFIG".equalsIgnoreCase(existing.getRegistrationMode())
-        && baseUrl.equals(existing.getBaseUrl())) {
+    if (existing != null && baseUrl.equals(existing.getBaseUrl())) {
       return existing;
     }
 
@@ -118,6 +123,12 @@ public class OfflineWorkerRegistry {
     configured.setNodeName(nodeName);
     configured.setBaseUrl(baseUrl);
     configured.setRegistrationMode("CONFIG");
+    configured.setRegistrationLeaseId(null);
+    configured.setRegistrationInstanceId(null);
+    configured.setRegistrationProtocolVersion(null);
+    configured.setLeaseExpiresAt(null);
+    configured.setLastRegistrationTime(null);
+    configured.setHeartbeatSequence(0L);
     // 页面设置的排空/禁用状态必须跨定时心跳保留。
     configured.setEnabled(existing == null
         ? true : !Boolean.FALSE.equals(existing.getEnabled()));

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/worker/OfflineCapabilityMatcher.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/worker/OfflineCapabilityMatcher.java
@@ -38,6 +38,14 @@ public class OfflineCapabilityMatcher {
   }
 
   public MatchResult match(NodeRecord node, String requirementsJson) {
+    if (node == null) {
+      return MatchResult.reject("Worker 不存在");
+    }
+    if ("DYNAMIC".equalsIgnoreCase(node.getRegistrationMode())
+        && (node.getLeaseExpiresAt() == null
+            || !node.getLeaseExpiresAt().isAfter(LocalDateTime.now()))) {
+      return MatchResult.reject("动态注册租约已过期");
+    }
     if (!properties.isEnabled()) {
       return MatchResult.accept("能力调度已关闭", "{}");
     }
@@ -45,9 +53,6 @@ public class OfflineCapabilityMatcher {
     JsonNode endpoints = requirements.path("endpoints");
     if (!endpoints.isArray() || endpoints.isEmpty()) {
       return MatchResult.accept("任务没有显式能力要求", "{}");
-    }
-    if (node == null) {
-      return MatchResult.reject("Worker 不存在");
     }
     if (!"READY".equalsIgnoreCase(node.getCapabilityStatus())) {
       return MatchResult.reject("Connector 能力状态为 " + text(node.getCapabilityStatus(), "UNKNOWN"));
@@ -203,16 +208,8 @@ public class OfflineCapabilityMatcher {
       return new MatchResult(false, reason, null);
     }
 
-    public boolean isMatched() {
-      return matched;
-    }
-
-    public String getReason() {
-      return reason;
-    }
-
-    public String getAssignedCapabilitiesJson() {
-      return assignedCapabilitiesJson;
-    }
+    public boolean isMatched() { return matched; }
+    public String getReason() { return reason; }
+    public String getAssignedCapabilitiesJson() { return assignedCapabilitiesJson; }
   }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/worker/OfflineWorkerCapabilityService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/worker/OfflineWorkerCapabilityService.java
@@ -31,11 +31,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
 /**
- * 按 Worker 拉取并持久化 Connector Schema 能力摘要。
+ * Worker Connector 能力摘要服务。
  *
- * <p>远程调用在后台刷新或管理操作中完成，调度事务只读取数据库快照。
- *
- * @author weifuwan
+ * <p>CONFIG/MANUAL 节点由 Yak Ops 拉取；DYNAMIC 节点由签名注册心跳推送。
+ * 调度事务始终只读取数据库快照。
  */
 @ConditionalOnOfflineSyncEnabled
 @Service
@@ -157,7 +156,8 @@ public class OfflineWorkerCapabilityService {
   }
 
   private void refresh(NodeRecord node, boolean force) {
-    if (!properties.isEnabled()) {
+    if (!properties.isEnabled()
+        || "DYNAMIC".equalsIgnoreCase(node.getRegistrationMode())) {
       return;
     }
     if (!force && !due(node)) {
@@ -167,7 +167,6 @@ public class OfflineWorkerCapabilityService {
       JsonNode response = schemaClient.list(node.getBaseUrl());
       ObjectNode snapshot = snapshot(node, response);
       String json = write(snapshot);
-      // 能力摘要只反映规范化 Connector 能力，不受进程 instanceId 重启噪声影响。
       String capabilityDigest = digest(write(snapshot.path("connectors")));
       repository.updateCapabilitySuccess(
           node.getNodeId(), capabilityDigest, json, LocalDateTime.now());

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/worker/OfflineWorkerModels.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/worker/OfflineWorkerModels.java
@@ -76,6 +76,7 @@ public final class OfflineWorkerModels {
     private String keyword;
     private String status;
     private String schedulingStatus;
+    private String registrationMode;
     private Boolean enabled;
   }
 
@@ -92,6 +93,12 @@ public final class OfflineWorkerModels {
   }
 
   @Data
+  @NoArgsConstructor
+  public static class LeaseRevokeRequest {
+    private String reason;
+  }
+
+  @Data
   @Builder
   @NoArgsConstructor
   @AllArgsConstructor
@@ -101,6 +108,11 @@ public final class OfflineWorkerModels {
     private String nodeName;
     private String baseUrl;
     private String registrationMode;
+    private String leaseStatus;
+    private LocalDateTime leaseExpiresAt;
+    private LocalDateTime lastRegistrationTime;
+    private Long heartbeatSequence;
+    private String registrationProtocolVersion;
     private Boolean enabled;
     private String schedulingStatus;
     private Integer weight;
@@ -153,6 +165,8 @@ public final class OfflineWorkerModels {
     private String label;
     private String status;
     private String schedulingStatus;
+    private String registrationMode;
+    private String leaseStatus;
     private Integer runningJobs;
     private Integer maxConcurrentJobs;
     private Integer queuedJobs;

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/worker/OfflineWorkerRegistrationAuthenticator.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/worker/OfflineWorkerRegistrationAuthenticator.java
@@ -1,0 +1,127 @@
+package io.yak.ops.business.sync.offline.worker;
+
+import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import io.yak.ops.business.sync.offline.config.OfflineWorkerRegistrationProperties;
+import io.yak.ops.business.sync.offline.repository.OfflineWorkerRegistrationRepository;
+import jakarta.servlet.http.HttpServletRequest;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.HexFormat;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ResponseStatusException;
+
+/** 使用 HMAC、时间戳和一次性 nonce 校验 Worker 主动注册请求。 */
+@ConditionalOnOfflineSyncEnabled
+@Component
+public class OfflineWorkerRegistrationAuthenticator {
+
+  public static final String HEADER_TIMESTAMP = "X-Yak-Registration-Timestamp";
+  public static final String HEADER_NONCE = "X-Yak-Registration-Nonce";
+  public static final String HEADER_SIGNATURE = "X-Yak-Registration-Signature";
+
+  private final OfflineWorkerRegistrationProperties properties;
+  private final OfflineWorkerRegistrationRepository repository;
+
+  public OfflineWorkerRegistrationAuthenticator(
+      OfflineWorkerRegistrationProperties properties,
+      OfflineWorkerRegistrationRepository repository) {
+    this.properties = properties;
+    this.repository = repository;
+  }
+
+  public void authenticate(HttpServletRequest request, String body) {
+    if (!properties.isEnabled()) {
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND, "动态 Worker 注册未启用");
+    }
+    String secret = properties.getSecret();
+    if (!StringUtils.hasText(secret) || secret.trim().length() < 16) {
+      throw new ResponseStatusException(
+          HttpStatus.SERVICE_UNAVAILABLE,
+          "动态 Worker 注册密钥未正确配置");
+    }
+
+    String timestampValue = header(request, HEADER_TIMESTAMP);
+    String nonce = header(request, HEADER_NONCE);
+    String signature = header(request, HEADER_SIGNATURE);
+    if (!nonce.matches("[A-Za-z0-9_-]{16,128}")) {
+      unauthorized("注册 nonce 格式不正确");
+    }
+    if (!signature.matches("(?i)[0-9a-f]{64}")) {
+      unauthorized("注册签名格式不正确");
+    }
+
+    long timestamp;
+    try {
+      timestamp = Long.parseLong(timestampValue);
+    } catch (NumberFormatException exception) {
+      unauthorized("注册时间戳格式不正确");
+      return;
+    }
+    long now = System.currentTimeMillis();
+    long skew = Math.abs(now - timestamp);
+    if (skew > Math.max(1_000L, properties.getClockSkewMillis())) {
+      unauthorized("注册请求时间戳已过期");
+    }
+
+    String payload = body == null ? "" : body;
+    String canonical = request.getMethod().toUpperCase()
+        + "\n" + request.getRequestURI()
+        + "\n" + timestampValue
+        + "\n" + nonce
+        + "\n" + sha256(payload);
+    String expected = hmac(secret.trim(), canonical);
+    if (!MessageDigest.isEqual(
+        expected.getBytes(StandardCharsets.US_ASCII),
+        signature.toLowerCase().getBytes(StandardCharsets.US_ASCII))) {
+      unauthorized("动态注册签名校验失败");
+    }
+
+    LocalDateTime expiresAt = LocalDateTime.ofInstant(
+        Instant.ofEpochMilli(now + Math.max(
+            properties.getClockSkewMillis(),
+            properties.getNonceRetentionMillis())),
+        ZoneId.systemDefault());
+    if (!repository.consumeNonce(sha256(nonce), expiresAt)) {
+      unauthorized("动态注册请求 nonce 已使用");
+    }
+  }
+
+  private String header(HttpServletRequest request, String name) {
+    String value = request.getHeader(name);
+    if (!StringUtils.hasText(value)) {
+      unauthorized("缺少请求头 " + name);
+    }
+    return value.trim();
+  }
+
+  private String hmac(String secret, String value) {
+    try {
+      Mac mac = Mac.getInstance("HmacSHA256");
+      mac.init(new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HmacSHA256"));
+      return HexFormat.of().formatHex(mac.doFinal(value.getBytes(StandardCharsets.UTF_8)));
+    } catch (Exception exception) {
+      throw new IllegalStateException("生成动态注册签名失败", exception);
+    }
+  }
+
+  private String sha256(String value) {
+    try {
+      return HexFormat.of().formatHex(
+          MessageDigest.getInstance("SHA-256")
+              .digest(value.getBytes(StandardCharsets.UTF_8)));
+    } catch (Exception exception) {
+      throw new IllegalStateException("生成动态注册摘要失败", exception);
+    }
+  }
+
+  private void unauthorized(String message) {
+    throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, message);
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/worker/OfflineWorkerRegistrationModels.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/worker/OfflineWorkerRegistrationModels.java
@@ -1,0 +1,107 @@
+package io.yak.ops.business.sync.offline.worker;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/** Link-Up Worker 主动注册协议模型。 */
+public final class OfflineWorkerRegistrationModels {
+
+  public static final String PROTOCOL_VERSION = "link-up-registration/v1";
+
+  private OfflineWorkerRegistrationModels() {
+  }
+
+  @Data
+  @NoArgsConstructor
+  public static class RegisterRequest {
+    private String protocolVersion;
+    private String nodeId;
+    private String nodeName;
+    private String instanceId;
+    private String baseUrl;
+    private String engineVersion;
+    private Long startedAtMillis;
+    private Boolean offlineOnly;
+    private Integer maxConcurrentJobs;
+    private Integer maxQueuedJobs;
+    private Integer runningJobs;
+    private Integer queuedJobs;
+    private Map<String, String> labels;
+    private List<ConnectorCapabilityPayload> connectors;
+  }
+
+  @Data
+  @NoArgsConstructor
+  public static class HeartbeatRequest {
+    private String protocolVersion;
+    private String leaseId;
+    private String nodeId;
+    private String instanceId;
+    private Long sequence;
+    private String baseUrl;
+    private String engineVersion;
+    private Long startedAtMillis;
+    private Boolean offlineOnly;
+    private Integer maxConcurrentJobs;
+    private Integer maxQueuedJobs;
+    private Integer runningJobs;
+    private Integer queuedJobs;
+    private List<ConnectorCapabilityPayload> connectors;
+  }
+
+  @Data
+  @NoArgsConstructor
+  public static class DeregisterRequest {
+    private String protocolVersion;
+    private String leaseId;
+    private String nodeId;
+    private String instanceId;
+    private Long sequence;
+  }
+
+  @Data
+  @NoArgsConstructor
+  public static class ConnectorCapabilityPayload {
+    private String connectorId;
+    private String role;
+    private String schemaVersion;
+    private String schemaFingerprint;
+    private String implementationVersion;
+    private List<String> capabilities;
+  }
+
+  @Data
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class LeaseResponse {
+    private String protocolVersion;
+    private String nodeId;
+    private String instanceId;
+    private String leaseId;
+    private LocalDateTime leaseExpiresAt;
+    private Long heartbeatIntervalMillis;
+    private Long serverTimeMillis;
+    private Boolean enabled;
+    private String schedulingStatus;
+  }
+
+  @Data
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class LeaseAdminView {
+    private String nodeId;
+    private String registrationMode;
+    private String leaseStatus;
+    private LocalDateTime leaseExpiresAt;
+    private LocalDateTime lastRegistrationTime;
+    private Long heartbeatSequence;
+    private String protocolVersion;
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/worker/OfflineWorkerRegistrationModels.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/worker/OfflineWorkerRegistrationModels.java
@@ -86,6 +86,7 @@ public final class OfflineWorkerRegistrationModels {
     private String leaseId;
     private LocalDateTime leaseExpiresAt;
     private Long heartbeatIntervalMillis;
+    private Long heartbeatSequence;
     private Long serverTimeMillis;
     private Boolean enabled;
     private String schedulingStatus;

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/worker/OfflineWorkerRegistrationService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/worker/OfflineWorkerRegistrationService.java
@@ -1,0 +1,512 @@
+package io.yak.ops.business.sync.offline.worker;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import io.yak.ops.business.sync.offline.config.OfflineWorkerRegistrationProperties;
+import io.yak.ops.business.sync.offline.engine.LinkUpWorkerProbeClient;
+import io.yak.ops.business.sync.offline.repository.OfflineNodeRepository;
+import io.yak.ops.business.sync.offline.repository.OfflineNodeRepository.NodeRecord;
+import io.yak.ops.business.sync.offline.repository.OfflineWorkerRegistrationRepository;
+import io.yak.ops.business.sync.offline.worker.OfflineWorkerRegistrationModels.ConnectorCapabilityPayload;
+import io.yak.ops.business.sync.offline.worker.OfflineWorkerRegistrationModels.DeregisterRequest;
+import io.yak.ops.business.sync.offline.worker.OfflineWorkerRegistrationModels.HeartbeatRequest;
+import io.yak.ops.business.sync.offline.worker.OfflineWorkerRegistrationModels.LeaseResponse;
+import io.yak.ops.business.sync.offline.worker.OfflineWorkerRegistrationModels.RegisterRequest;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.UUID;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpStatus;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ResponseStatusException;
+
+/** 动态 Link-Up Worker 注册、续租、实例接管和租约清理服务。 */
+@ConditionalOnOfflineSyncEnabled
+@Service
+public class OfflineWorkerRegistrationService {
+
+  private final OfflineNodeRepository nodeRepository;
+  private final OfflineWorkerRegistrationRepository registrationRepository;
+  private final LinkUpWorkerProbeClient probeClient;
+  private final OfflineWorkerRegistrationProperties properties;
+  private final ObjectMapper objectMapper;
+
+  public OfflineWorkerRegistrationService(
+      OfflineNodeRepository nodeRepository,
+      OfflineWorkerRegistrationRepository registrationRepository,
+      LinkUpWorkerProbeClient probeClient,
+      OfflineWorkerRegistrationProperties properties,
+      @Qualifier("offlineSyncJsonMapper") ObjectMapper objectMapper) {
+    this.nodeRepository = nodeRepository;
+    this.registrationRepository = registrationRepository;
+    this.probeClient = probeClient;
+    this.properties = properties;
+    this.objectMapper = objectMapper;
+  }
+
+  @Transactional(transactionManager = "offlineSyncTransactionManager", rollbackFor = Exception.class)
+  public LeaseResponse register(RegisterRequest request, String remoteAddress) {
+    validateRegister(request);
+    LocalDateTime now = LocalDateTime.now();
+    String nodeId = request.getNodeId().trim();
+    String instanceId = request.getInstanceId().trim();
+    String baseUrl = probeClient.normalizeBaseUrl(request.getBaseUrl());
+
+    NodeRecord sameAddress = nodeRepository.findByBaseUrl(baseUrl);
+    if (sameAddress != null && !nodeId.equals(sameAddress.getNodeId())) {
+      conflict("Worker 地址已被其他节点使用：" + baseUrl);
+    }
+
+    NodeRecord existing = nodeRepository.findForUpdate(nodeId);
+    boolean takeover = false;
+    boolean idempotent = false;
+    String leaseId;
+    long sequence;
+    if (existing == null) {
+      leaseId = UUID.randomUUID().toString();
+      sequence = 0L;
+    } else {
+      if (!"DYNAMIC".equalsIgnoreCase(existing.getRegistrationMode())) {
+        conflict("nodeId 已由 " + existing.getRegistrationMode() + " 模式管理：" + nodeId);
+      }
+      boolean active = active(existing, now);
+      if (active && !instanceId.equals(existing.getRegistrationInstanceId())) {
+        conflict("同一 nodeId 的旧 Worker 实例租约仍有效：" + nodeId);
+      }
+      idempotent = active && instanceId.equals(existing.getRegistrationInstanceId());
+      takeover = !active && !instanceId.equals(existing.getRegistrationInstanceId());
+      leaseId = idempotent && StringUtils.hasText(existing.getRegistrationLeaseId())
+          ? existing.getRegistrationLeaseId()
+          : UUID.randomUUID().toString();
+      sequence = idempotent ? value(existing.getHeartbeatSequence(), 0L) : 0L;
+    }
+
+    LocalDateTime expiresAt = now.plusNanos(leaseDurationMillis() * 1_000_000L);
+    NodeRecord record = existing == null ? NodeRecord.builder().build() : copy(existing);
+    record.setNodeId(nodeId);
+    if (existing == null || !StringUtils.hasText(existing.getNodeName())) {
+      record.setNodeName(first(request.getNodeName(), nodeId));
+    }
+    record.setBaseUrl(baseUrl);
+    record.setRegistrationMode("DYNAMIC");
+    record.setRegistrationLeaseId(leaseId);
+    record.setRegistrationInstanceId(instanceId);
+    record.setRegistrationProtocolVersion(request.getProtocolVersion().trim());
+    record.setLeaseExpiresAt(expiresAt);
+    record.setLastRegistrationTime(now);
+    record.setHeartbeatSequence(sequence);
+    if (existing == null) {
+      boolean enabled = properties.isAutoEnable();
+      record.setEnabled(enabled);
+      record.setSchedulingStatus(enabled ? "ENABLED" : "DISABLED");
+      record.setWeight(100);
+      record.setLabelsJson(writeLabels(request.getLabels()));
+      record.setCreateTime(now);
+    }
+    applyRuntime(record, request.getEngineVersion(), request.getStartedAtMillis(),
+        request.getOfflineOnly(), request.getMaxConcurrentJobs(), request.getMaxQueuedJobs(),
+        request.getRunningJobs(), request.getQueuedJobs(), instanceId, request.getConnectors(), now);
+    record.setUpdateTime(now);
+    nodeRepository.upsert(record);
+
+    registrationRepository.recordEvent(
+        nodeId,
+        instanceId,
+        leaseId,
+        takeover ? "LEASE_TAKEOVER" : idempotent ? "REGISTER_RETRY" : "REGISTERED",
+        remoteAddress,
+        takeover ? "旧租约已过期，新实例接管" : "Worker 动态注册成功");
+    return response(nodeRepository.find(nodeId));
+  }
+
+  @Transactional(transactionManager = "offlineSyncTransactionManager", rollbackFor = Exception.class)
+  public LeaseResponse heartbeat(HeartbeatRequest request, String remoteAddress) {
+    validateHeartbeat(request);
+    LocalDateTime now = LocalDateTime.now();
+    NodeRecord existing = nodeRepository.findForUpdate(request.getNodeId().trim());
+    validateLease(existing, request.getLeaseId(), request.getInstanceId(), now);
+    long sequence = request.getSequence();
+    if (sequence <= value(existing.getHeartbeatSequence(), 0L)) {
+      conflict("心跳序列必须严格递增，当前=" + existing.getHeartbeatSequence()
+          + "，请求=" + sequence);
+    }
+
+    NodeRecord record = copy(existing);
+    record.setBaseUrl(probeClient.normalizeBaseUrl(request.getBaseUrl()));
+    record.setLeaseExpiresAt(now.plusNanos(leaseDurationMillis() * 1_000_000L));
+    record.setHeartbeatSequence(sequence);
+    applyRuntime(record, request.getEngineVersion(), request.getStartedAtMillis(),
+        request.getOfflineOnly(), request.getMaxConcurrentJobs(), request.getMaxQueuedJobs(),
+        request.getRunningJobs(), request.getQueuedJobs(), request.getInstanceId(),
+        request.getConnectors(), now);
+    record.setUpdateTime(now);
+    nodeRepository.upsert(record);
+    registrationRepository.recordEvent(
+        record.getNodeId(),
+        record.getRegistrationInstanceId(),
+        record.getRegistrationLeaseId(),
+        "HEARTBEAT",
+        remoteAddress,
+        "sequence=" + sequence);
+    return response(nodeRepository.find(record.getNodeId()));
+  }
+
+  @Transactional(transactionManager = "offlineSyncTransactionManager", rollbackFor = Exception.class)
+  public boolean deregister(DeregisterRequest request, String remoteAddress) {
+    validateDeregister(request);
+    LocalDateTime now = LocalDateTime.now();
+    NodeRecord existing = nodeRepository.findForUpdate(request.getNodeId().trim());
+    validateLease(existing, request.getLeaseId(), request.getInstanceId(), now);
+    if (request.getSequence() != null
+        && request.getSequence() <= value(existing.getHeartbeatSequence(), 0L)) {
+      conflict("注销序列不能小于或等于最后心跳序列");
+    }
+    registrationRepository.revokeLease(existing.getNodeId(), now, "Worker 已主动注销动态租约");
+    registrationRepository.recordEvent(
+        existing.getNodeId(),
+        existing.getRegistrationInstanceId(),
+        existing.getRegistrationLeaseId(),
+        "DEREGISTERED",
+        remoteAddress,
+        "Worker 主动注销");
+    return true;
+  }
+
+  @Transactional(transactionManager = "offlineSyncTransactionManager", rollbackFor = Exception.class)
+  public boolean revoke(String nodeId, String reason) {
+    NodeRecord existing = nodeRepository.findForUpdate(nodeId);
+    if (existing == null) {
+      throw new IllegalArgumentException("Link-Up Worker 不存在：" + nodeId);
+    }
+    if (!"DYNAMIC".equalsIgnoreCase(existing.getRegistrationMode())) {
+      throw new IllegalStateException("只有动态注册 Worker 才有可撤销租约");
+    }
+    LocalDateTime now = LocalDateTime.now();
+    boolean updated = registrationRepository.revokeLease(
+        nodeId,
+        now,
+        StringUtils.hasText(reason) ? reason : "管理员已撤销动态注册租约");
+    registrationRepository.recordEvent(
+        existing.getNodeId(),
+        existing.getRegistrationInstanceId(),
+        existing.getRegistrationLeaseId(),
+        "LEASE_REVOKED",
+        null,
+        reason);
+    return updated;
+  }
+
+  @Scheduled(
+      initialDelayString = "${yak.sync.offline.registration.cleanup-initial-delay-millis:10000}",
+      fixedDelayString = "${yak.sync.offline.registration.cleanup-delay-millis:10000}")
+  public void cleanup() {
+    LocalDateTime now = LocalDateTime.now();
+    registrationRepository.expireLeases(now);
+    registrationRepository.cleanupNonces(now);
+  }
+
+  private void applyRuntime(
+      NodeRecord record,
+      String engineVersion,
+      Long startedAtMillis,
+      Boolean offlineOnly,
+      Integer maxConcurrentJobs,
+      Integer maxQueuedJobs,
+      Integer runningJobs,
+      Integer queuedJobs,
+      String instanceId,
+      List<ConnectorCapabilityPayload> connectors,
+      LocalDateTime now) {
+    record.setWorkerInstanceId(instanceId);
+    record.setEngineVersion(engineVersion);
+    record.setStartedAtMillis(startedAtMillis);
+    record.setOfflineOnly(offlineOnly);
+    record.setStatus("UP");
+    record.setMaxConcurrentJobs(positive(maxConcurrentJobs, 1));
+    record.setMaxQueuedJobs(nonNegative(maxQueuedJobs, 0));
+    record.setRunningJobs(nonNegative(runningJobs, 0));
+    record.setQueuedJobs(nonNegative(queuedJobs, 0));
+    record.setLastHeartbeatTime(now);
+    record.setLastSuccessTime(now);
+    record.setConsecutiveFailures(0);
+    record.setLastErrorMessage(null);
+
+    String snapshot = capabilitySnapshot(
+        record.getNodeId(), instanceId, engineVersion, connectors);
+    if (snapshot == null) {
+      record.setCapabilityStatus("UNKNOWN");
+      record.setCapabilityDigest(null);
+      record.setConnectorSchemasJson(null);
+      record.setCapabilitySyncedAt(null);
+      record.setCapabilityErrorMessage(null);
+    } else {
+      record.setCapabilityStatus("READY");
+      record.setCapabilityDigest("sha256:" + sha256(snapshot));
+      record.setConnectorSchemasJson(snapshot);
+      record.setCapabilitySyncedAt(now);
+      record.setCapabilityErrorMessage(null);
+    }
+  }
+
+  private String capabilitySnapshot(
+      String nodeId,
+      String instanceId,
+      String engineVersion,
+      List<ConnectorCapabilityPayload> values) {
+    if (values == null || values.isEmpty()) {
+      return null;
+    }
+    List<ConnectorCapabilityPayload> connectors = new ArrayList<>(values);
+    connectors.sort(Comparator
+        .comparing((ConnectorCapabilityPayload value) -> normalizeId(value.getConnectorId()))
+        .thenComparing(value -> normalizeRole(value.getRole())));
+    ObjectNode root = objectMapper.createObjectNode();
+    root.put("nodeId", nodeId);
+    root.put("workerInstanceId", instanceId);
+    root.put("engineVersion", engineVersion);
+    ArrayNode items = root.putArray("connectors");
+    for (ConnectorCapabilityPayload connector : connectors) {
+      ObjectNode item = objectMapper.createObjectNode();
+      item.put("connectorId", normalizeId(connector.getConnectorId()));
+      item.put("role", normalizeRole(connector.getRole()));
+      item.put("schemaVersion", text(connector.getSchemaVersion()));
+      item.put("schemaFingerprint", text(connector.getSchemaFingerprint()));
+      item.put("implementationVersion", text(connector.getImplementationVersion()));
+      ArrayNode capabilities = item.putArray("capabilities");
+      List<String> capabilityValues = connector.getCapabilities() == null
+          ? Collections.emptyList() : new ArrayList<>(connector.getCapabilities());
+      capabilityValues.stream()
+          .filter(StringUtils::hasText)
+          .map(value -> value.trim().toUpperCase(Locale.ROOT))
+          .distinct()
+          .sorted()
+          .forEach(capabilities::add);
+      items.add(item);
+    }
+    try {
+      return objectMapper.writeValueAsString(root);
+    } catch (JsonProcessingException exception) {
+      throw new IllegalStateException("序列化动态 Worker 能力快照失败", exception);
+    }
+  }
+
+  private LeaseResponse response(NodeRecord node) {
+    return LeaseResponse.builder()
+        .protocolVersion(OfflineWorkerRegistrationModels.PROTOCOL_VERSION)
+        .nodeId(node.getNodeId())
+        .instanceId(node.getRegistrationInstanceId())
+        .leaseId(node.getRegistrationLeaseId())
+        .leaseExpiresAt(node.getLeaseExpiresAt())
+        .heartbeatIntervalMillis(heartbeatIntervalMillis())
+        .serverTimeMillis(System.currentTimeMillis())
+        .enabled(node.getEnabled())
+        .schedulingStatus(node.getSchedulingStatus())
+        .build();
+  }
+
+  private void validateRegister(RegisterRequest request) {
+    if (request == null) {
+      badRequest("注册参数不能为空");
+    }
+    validateProtocol(request.getProtocolVersion());
+    required(request.getNodeId(), "nodeId");
+    required(request.getInstanceId(), "instanceId");
+    required(request.getBaseUrl(), "baseUrl");
+    if (!Boolean.TRUE.equals(request.getOfflineOnly())) {
+      badRequest("动态注册节点必须是 offlineOnly Worker");
+    }
+  }
+
+  private void validateHeartbeat(HeartbeatRequest request) {
+    if (request == null) {
+      badRequest("心跳参数不能为空");
+    }
+    validateProtocol(request.getProtocolVersion());
+    required(request.getLeaseId(), "leaseId");
+    required(request.getNodeId(), "nodeId");
+    required(request.getInstanceId(), "instanceId");
+    required(request.getBaseUrl(), "baseUrl");
+    if (request.getSequence() == null || request.getSequence() <= 0L) {
+      badRequest("heartbeat sequence 必须大于 0");
+    }
+    if (!Boolean.TRUE.equals(request.getOfflineOnly())) {
+      badRequest("动态注册节点必须是 offlineOnly Worker");
+    }
+  }
+
+  private void validateDeregister(DeregisterRequest request) {
+    if (request == null) {
+      badRequest("注销参数不能为空");
+    }
+    validateProtocol(request.getProtocolVersion());
+    required(request.getLeaseId(), "leaseId");
+    required(request.getNodeId(), "nodeId");
+    required(request.getInstanceId(), "instanceId");
+  }
+
+  private void validateProtocol(String version) {
+    if (!OfflineWorkerRegistrationModels.PROTOCOL_VERSION.equals(version)) {
+      badRequest("不支持的动态注册协议版本：" + version);
+    }
+  }
+
+  private void validateLease(
+      NodeRecord node,
+      String leaseId,
+      String instanceId,
+      LocalDateTime now) {
+    if (node == null || !"DYNAMIC".equalsIgnoreCase(node.getRegistrationMode())) {
+      conflict("动态注册 Worker 不存在");
+    }
+    if (!leaseId.equals(node.getRegistrationLeaseId())
+        || !instanceId.equals(node.getRegistrationInstanceId())) {
+      conflict("动态注册租约或 Worker 实例不匹配");
+    }
+    if (!active(node, now)) {
+      conflict("动态注册租约已过期，请重新注册");
+    }
+  }
+
+  private boolean active(NodeRecord node, LocalDateTime now) {
+    return node != null
+        && StringUtils.hasText(node.getRegistrationLeaseId())
+        && node.getLeaseExpiresAt() != null
+        && node.getLeaseExpiresAt().isAfter(now);
+  }
+
+  private NodeRecord copy(NodeRecord source) {
+    return NodeRecord.builder()
+        .nodeId(source.getNodeId())
+        .nodeName(source.getNodeName())
+        .baseUrl(source.getBaseUrl())
+        .registrationMode(source.getRegistrationMode())
+        .registrationLeaseId(source.getRegistrationLeaseId())
+        .registrationInstanceId(source.getRegistrationInstanceId())
+        .registrationProtocolVersion(source.getRegistrationProtocolVersion())
+        .leaseExpiresAt(source.getLeaseExpiresAt())
+        .lastRegistrationTime(source.getLastRegistrationTime())
+        .heartbeatSequence(source.getHeartbeatSequence())
+        .enabled(source.getEnabled())
+        .schedulingStatus(source.getSchedulingStatus())
+        .weight(source.getWeight())
+        .labelsJson(source.getLabelsJson())
+        .workerInstanceId(source.getWorkerInstanceId())
+        .engineVersion(source.getEngineVersion())
+        .startedAtMillis(source.getStartedAtMillis())
+        .offlineOnly(source.getOfflineOnly())
+        .status(source.getStatus())
+        .maxConcurrentJobs(source.getMaxConcurrentJobs())
+        .maxQueuedJobs(source.getMaxQueuedJobs())
+        .runningJobs(source.getRunningJobs())
+        .queuedJobs(source.getQueuedJobs())
+        .lastHeartbeatTime(source.getLastHeartbeatTime())
+        .lastSuccessTime(source.getLastSuccessTime())
+        .consecutiveFailures(source.getConsecutiveFailures())
+        .lastErrorMessage(source.getLastErrorMessage())
+        .capabilityStatus(source.getCapabilityStatus())
+        .capabilityDigest(source.getCapabilityDigest())
+        .connectorSchemasJson(source.getConnectorSchemasJson())
+        .capabilitySyncedAt(source.getCapabilitySyncedAt())
+        .capabilityErrorMessage(source.getCapabilityErrorMessage())
+        .createTime(source.getCreateTime())
+        .updateTime(source.getUpdateTime())
+        .build();
+  }
+
+  private String writeLabels(Map<String, String> labels) {
+    Map<String, String> normalized = new TreeMap<>();
+    if (labels != null) {
+      labels.forEach((key, value) -> {
+        if (StringUtils.hasText(key)) {
+          normalized.put(key.trim(), value == null ? "" : value.trim());
+        }
+      });
+    }
+    try {
+      return objectMapper.writeValueAsString(normalized);
+    } catch (JsonProcessingException exception) {
+      throw new IllegalArgumentException("Worker 注册标签无法序列化", exception);
+    }
+  }
+
+  private String normalizeId(String value) {
+    required(value, "connectorId");
+    return value.trim().toLowerCase(Locale.ROOT);
+  }
+
+  private String normalizeRole(String value) {
+    required(value, "connector role");
+    String normalized = value.trim().toUpperCase(Locale.ROOT);
+    if (!"SOURCE".equals(normalized) && !"SINK".equals(normalized)) {
+      badRequest("Connector role 仅支持 SOURCE 或 SINK");
+    }
+    return normalized;
+  }
+
+  private long heartbeatIntervalMillis() {
+    return Math.max(5_000L, Math.min(60_000L, properties.getHeartbeatIntervalMillis()));
+  }
+
+  private long leaseDurationMillis() {
+    return Math.max(heartbeatIntervalMillis() * 3L, properties.getLeaseDurationMillis());
+  }
+
+  private int positive(Integer value, int fallback) {
+    return value == null || value <= 0 ? fallback : value;
+  }
+
+  private int nonNegative(Integer value, int fallback) {
+    return value == null || value < 0 ? fallback : value;
+  }
+
+  private long value(Long value, long fallback) {
+    return value == null ? fallback : value;
+  }
+
+  private String first(String value, String fallback) {
+    return StringUtils.hasText(value) ? value.trim() : fallback;
+  }
+
+  private String text(String value) {
+    return value == null ? "" : value.trim();
+  }
+
+  private void required(String value, String field) {
+    if (!StringUtils.hasText(value)) {
+      badRequest(field + " 不能为空");
+    }
+  }
+
+  private String sha256(String value) {
+    try {
+      return HexFormat.of().formatHex(
+          MessageDigest.getInstance("SHA-256")
+              .digest(value.getBytes(StandardCharsets.UTF_8)));
+    } catch (Exception exception) {
+      throw new IllegalStateException("生成 Worker 能力摘要失败", exception);
+    }
+  }
+
+  private void badRequest(String message) {
+    throw new ResponseStatusException(HttpStatus.BAD_REQUEST, message);
+  }
+
+  private void conflict(String message) {
+    throw new ResponseStatusException(HttpStatus.CONFLICT, message);
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/worker/OfflineWorkerRegistrationService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/worker/OfflineWorkerRegistrationService.java
@@ -66,11 +66,7 @@ public class OfflineWorkerRegistrationService {
     String nodeId = request.getNodeId().trim();
     String instanceId = request.getInstanceId().trim();
     String baseUrl = probeClient.normalizeBaseUrl(request.getBaseUrl());
-
-    NodeRecord sameAddress = nodeRepository.findByBaseUrl(baseUrl);
-    if (sameAddress != null && !nodeId.equals(sameAddress.getNodeId())) {
-      conflict("Worker 地址已被其他节点使用：" + baseUrl);
-    }
+    requireAddressOwnership(nodeId, baseUrl);
 
     NodeRecord existing = nodeRepository.findForUpdate(nodeId);
     boolean takeover = false;
@@ -96,7 +92,6 @@ public class OfflineWorkerRegistrationService {
       sequence = idempotent ? value(existing.getHeartbeatSequence(), 0L) : 0L;
     }
 
-    LocalDateTime expiresAt = now.plusNanos(leaseDurationMillis() * 1_000_000L);
     NodeRecord record = existing == null ? NodeRecord.builder().build() : copy(existing);
     record.setNodeId(nodeId);
     if (existing == null || !StringUtils.hasText(existing.getNodeName())) {
@@ -107,7 +102,7 @@ public class OfflineWorkerRegistrationService {
     record.setRegistrationLeaseId(leaseId);
     record.setRegistrationInstanceId(instanceId);
     record.setRegistrationProtocolVersion(request.getProtocolVersion().trim());
-    record.setLeaseExpiresAt(expiresAt);
+    record.setLeaseExpiresAt(now.plusNanos(leaseDurationMillis() * 1_000_000L));
     record.setLastRegistrationTime(now);
     record.setHeartbeatSequence(sequence);
     if (existing == null) {
@@ -118,9 +113,18 @@ public class OfflineWorkerRegistrationService {
       record.setLabelsJson(writeLabels(request.getLabels()));
       record.setCreateTime(now);
     }
-    applyRuntime(record, request.getEngineVersion(), request.getStartedAtMillis(),
-        request.getOfflineOnly(), request.getMaxConcurrentJobs(), request.getMaxQueuedJobs(),
-        request.getRunningJobs(), request.getQueuedJobs(), instanceId, request.getConnectors(), now);
+    applyRuntime(
+        record,
+        request.getEngineVersion(),
+        request.getStartedAtMillis(),
+        request.getOfflineOnly(),
+        request.getMaxConcurrentJobs(),
+        request.getMaxQueuedJobs(),
+        request.getRunningJobs(),
+        request.getQueuedJobs(),
+        instanceId,
+        request.getConnectors(),
+        now);
     record.setUpdateTime(now);
     nodeRepository.upsert(record);
 
@@ -131,14 +135,15 @@ public class OfflineWorkerRegistrationService {
         takeover ? "LEASE_TAKEOVER" : idempotent ? "REGISTER_RETRY" : "REGISTERED",
         remoteAddress,
         takeover ? "旧租约已过期，新实例接管" : "Worker 动态注册成功");
-    return response(nodeRepository.find(nodeId));
+    return response(requireStored(nodeId));
   }
 
   @Transactional(transactionManager = "offlineSyncTransactionManager", rollbackFor = Exception.class)
   public LeaseResponse heartbeat(HeartbeatRequest request, String remoteAddress) {
     validateHeartbeat(request);
     LocalDateTime now = LocalDateTime.now();
-    NodeRecord existing = nodeRepository.findForUpdate(request.getNodeId().trim());
+    String nodeId = request.getNodeId().trim();
+    NodeRecord existing = nodeRepository.findForUpdate(nodeId);
     validateLease(existing, request.getLeaseId(), request.getInstanceId(), now);
     long sequence = request.getSequence();
     if (sequence <= value(existing.getHeartbeatSequence(), 0L)) {
@@ -146,14 +151,24 @@ public class OfflineWorkerRegistrationService {
           + "，请求=" + sequence);
     }
 
+    String baseUrl = probeClient.normalizeBaseUrl(request.getBaseUrl());
+    requireAddressOwnership(nodeId, baseUrl);
     NodeRecord record = copy(existing);
-    record.setBaseUrl(probeClient.normalizeBaseUrl(request.getBaseUrl()));
+    record.setBaseUrl(baseUrl);
     record.setLeaseExpiresAt(now.plusNanos(leaseDurationMillis() * 1_000_000L));
     record.setHeartbeatSequence(sequence);
-    applyRuntime(record, request.getEngineVersion(), request.getStartedAtMillis(),
-        request.getOfflineOnly(), request.getMaxConcurrentJobs(), request.getMaxQueuedJobs(),
-        request.getRunningJobs(), request.getQueuedJobs(), request.getInstanceId(),
-        request.getConnectors(), now);
+    applyRuntime(
+        record,
+        request.getEngineVersion(),
+        request.getStartedAtMillis(),
+        request.getOfflineOnly(),
+        request.getMaxConcurrentJobs(),
+        request.getMaxQueuedJobs(),
+        request.getRunningJobs(),
+        request.getQueuedJobs(),
+        request.getInstanceId(),
+        request.getConnectors(),
+        now);
     record.setUpdateTime(now);
     nodeRepository.upsert(record);
     registrationRepository.recordEvent(
@@ -163,7 +178,7 @@ public class OfflineWorkerRegistrationService {
         "HEARTBEAT",
         remoteAddress,
         "sequence=" + sequence);
-    return response(nodeRepository.find(record.getNodeId()));
+    return response(requireStored(nodeId));
   }
 
   @Transactional(transactionManager = "offlineSyncTransactionManager", rollbackFor = Exception.class)
@@ -215,9 +230,27 @@ public class OfflineWorkerRegistrationService {
       initialDelayString = "${yak.sync.offline.registration.cleanup-initial-delay-millis:10000}",
       fixedDelayString = "${yak.sync.offline.registration.cleanup-delay-millis:10000}")
   public void cleanup() {
+    if (!properties.isEnabled()) {
+      return;
+    }
     LocalDateTime now = LocalDateTime.now();
     registrationRepository.expireLeases(now);
     registrationRepository.cleanupNonces(now);
+  }
+
+  private void requireAddressOwnership(String nodeId, String baseUrl) {
+    NodeRecord sameAddress = nodeRepository.findByBaseUrl(baseUrl);
+    if (sameAddress != null && !nodeId.equals(sameAddress.getNodeId())) {
+      conflict("Worker 地址已被其他节点使用：" + baseUrl);
+    }
+  }
+
+  private NodeRecord requireStored(String nodeId) {
+    NodeRecord stored = nodeRepository.find(nodeId);
+    if (stored == null) {
+      throw new IllegalStateException("动态 Worker 租约保存后无法读取：" + nodeId);
+    }
+    return stored;
   }
 
   private void applyRuntime(
@@ -246,7 +279,7 @@ public class OfflineWorkerRegistrationService {
     record.setConsecutiveFailures(0);
     record.setLastErrorMessage(null);
 
-    String snapshot = capabilitySnapshot(
+    CapabilitySnapshot snapshot = capabilitySnapshot(
         record.getNodeId(), instanceId, engineVersion, connectors);
     if (snapshot == null) {
       record.setCapabilityStatus("UNKNOWN");
@@ -256,14 +289,14 @@ public class OfflineWorkerRegistrationService {
       record.setCapabilityErrorMessage(null);
     } else {
       record.setCapabilityStatus("READY");
-      record.setCapabilityDigest("sha256:" + sha256(snapshot));
-      record.setConnectorSchemasJson(snapshot);
+      record.setCapabilityDigest(snapshot.digest);
+      record.setConnectorSchemasJson(snapshot.json);
       record.setCapabilitySyncedAt(now);
       record.setCapabilityErrorMessage(null);
     }
   }
 
-  private String capabilitySnapshot(
+  private CapabilitySnapshot capabilitySnapshot(
       String nodeId,
       String instanceId,
       String engineVersion,
@@ -275,6 +308,7 @@ public class OfflineWorkerRegistrationService {
     connectors.sort(Comparator
         .comparing((ConnectorCapabilityPayload value) -> normalizeId(value.getConnectorId()))
         .thenComparing(value -> normalizeRole(value.getRole())));
+
     ObjectNode root = objectMapper.createObjectNode();
     root.put("nodeId", nodeId);
     root.put("workerInstanceId", instanceId);
@@ -289,7 +323,8 @@ public class OfflineWorkerRegistrationService {
       item.put("implementationVersion", text(connector.getImplementationVersion()));
       ArrayNode capabilities = item.putArray("capabilities");
       List<String> capabilityValues = connector.getCapabilities() == null
-          ? Collections.emptyList() : new ArrayList<>(connector.getCapabilities());
+          ? Collections.emptyList()
+          : new ArrayList<>(connector.getCapabilities());
       capabilityValues.stream()
           .filter(StringUtils::hasText)
           .map(value -> value.trim().toUpperCase(Locale.ROOT))
@@ -298,11 +333,9 @@ public class OfflineWorkerRegistrationService {
           .forEach(capabilities::add);
       items.add(item);
     }
-    try {
-      return objectMapper.writeValueAsString(root);
-    } catch (JsonProcessingException exception) {
-      throw new IllegalStateException("序列化动态 Worker 能力快照失败", exception);
-    }
+    String json = write(root, "序列化动态 Worker 能力快照失败");
+    String canonicalConnectors = write(items, "序列化动态 Worker 能力摘要失败");
+    return new CapabilitySnapshot(json, "sha256:" + sha256(canonicalConnectors));
   }
 
   private LeaseResponse response(NodeRecord node) {
@@ -313,6 +346,7 @@ public class OfflineWorkerRegistrationService {
         .leaseId(node.getRegistrationLeaseId())
         .leaseExpiresAt(node.getLeaseExpiresAt())
         .heartbeatIntervalMillis(heartbeatIntervalMillis())
+        .heartbeatSequence(value(node.getHeartbeatSequence(), 0L))
         .serverTimeMillis(System.currentTimeMillis())
         .enabled(node.getEnabled())
         .schedulingStatus(node.getSchedulingStatus())
@@ -444,6 +478,22 @@ public class OfflineWorkerRegistrationService {
     }
   }
 
+  private String write(ObjectNode value, String message) {
+    try {
+      return objectMapper.writeValueAsString(value);
+    } catch (JsonProcessingException exception) {
+      throw new IllegalStateException(message, exception);
+    }
+  }
+
+  private String write(ArrayNode value, String message) {
+    try {
+      return objectMapper.writeValueAsString(value);
+    } catch (JsonProcessingException exception) {
+      throw new IllegalStateException(message, exception);
+    }
+  }
+
   private String normalizeId(String value) {
     required(value, "connectorId");
     return value.trim().toLowerCase(Locale.ROOT);
@@ -508,5 +558,15 @@ public class OfflineWorkerRegistrationService {
 
   private void conflict(String message) {
     throw new ResponseStatusException(HttpStatus.CONFLICT, message);
+  }
+
+  private static final class CapabilitySnapshot {
+    private final String json;
+    private final String digest;
+
+    private CapabilitySnapshot(String json, String digest) {
+      this.json = json;
+      this.digest = digest;
+    }
   }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/worker/OfflineWorkerService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/worker/OfflineWorkerService.java
@@ -142,6 +142,9 @@ public class OfflineWorkerService {
     if ("CONFIG".equalsIgnoreCase(existing.getRegistrationMode()) && addressChanged) {
       throw new IllegalStateException("默认 Worker 地址由 application.yml 管理，不能在页面修改");
     }
+    if ("DYNAMIC".equalsIgnoreCase(existing.getRegistrationMode()) && addressChanged) {
+      throw new IllegalStateException("动态 Worker 地址由 Worker 注册心跳维护，不能在页面修改");
+    }
 
     NodeRecord updated;
     if (addressChanged) {
@@ -181,7 +184,10 @@ public class OfflineWorkerService {
   }
 
   public WorkerView refresh(String nodeId) {
-    registry.refresh(nodeId, true);
+    NodeRecord node = require(nodeId);
+    if (!"DYNAMIC".equalsIgnoreCase(node.getRegistrationMode())) {
+      registry.refresh(nodeId, true);
+    }
     return get(nodeId);
   }
 
@@ -192,7 +198,7 @@ public class OfflineWorkerService {
     if (!repository.updateSchedulingStatus(node.getNodeId(), status, enabled)) {
       throw new IllegalStateException("Worker 调度状态更新失败：" + nodeId);
     }
-    if (enabled) {
+    if (enabled && !"DYNAMIC".equalsIgnoreCase(node.getRegistrationMode())) {
       registry.refresh(nodeId, false);
     }
     return get(nodeId);
@@ -203,6 +209,10 @@ public class OfflineWorkerService {
     if ("CONFIG".equalsIgnoreCase(node.getRegistrationMode())
         || nodeId.equals(properties.getEngine().getNodeId())) {
       throw new IllegalStateException("默认 Worker 不能删除，可将其设置为排空或禁用");
+    }
+    if ("DYNAMIC".equalsIgnoreCase(node.getRegistrationMode())
+        && "ACTIVE".equals(leaseStatus(node))) {
+      throw new IllegalStateException("动态 Worker 租约仍有效，请先撤销租约再删除");
     }
     return repository.delete(nodeId);
   }
@@ -217,6 +227,8 @@ public class OfflineWorkerService {
           .label(worker.getNodeName())
           .status(worker.getStatus())
           .schedulingStatus(worker.getSchedulingStatus())
+          .registrationMode(worker.getRegistrationMode())
+          .leaseStatus(worker.getLeaseStatus())
           .runningJobs(worker.getRunningJobs())
           .maxConcurrentJobs(worker.getMaxConcurrentJobs())
           .queuedJobs(worker.getQueuedJobs())
@@ -241,6 +253,12 @@ public class OfflineWorkerService {
             ? requestedName : first(response.getNodeName(), response.getNodeId()))
         .baseUrl(baseUrl)
         .registrationMode(registrationMode)
+        .registrationLeaseId(null)
+        .registrationInstanceId(null)
+        .registrationProtocolVersion(null)
+        .leaseExpiresAt(null)
+        .lastRegistrationTime(null)
+        .heartbeatSequence(0L)
         .enabled(true)
         .schedulingStatus("ENABLED")
         .weight(weight)
@@ -258,6 +276,7 @@ public class OfflineWorkerService {
         .lastSuccessTime(now)
         .consecutiveFailures(0)
         .lastErrorMessage(null)
+        .capabilityStatus("UNKNOWN")
         .createTime(now)
         .updateTime(now)
         .build();
@@ -269,6 +288,12 @@ public class OfflineWorkerService {
         .nodeName(source.getNodeName())
         .baseUrl(source.getBaseUrl())
         .registrationMode(source.getRegistrationMode())
+        .registrationLeaseId(source.getRegistrationLeaseId())
+        .registrationInstanceId(source.getRegistrationInstanceId())
+        .registrationProtocolVersion(source.getRegistrationProtocolVersion())
+        .leaseExpiresAt(source.getLeaseExpiresAt())
+        .lastRegistrationTime(source.getLastRegistrationTime())
+        .heartbeatSequence(source.getHeartbeatSequence())
         .enabled(source.getEnabled())
         .schedulingStatus(source.getSchedulingStatus())
         .weight(source.getWeight())
@@ -286,6 +311,11 @@ public class OfflineWorkerService {
         .lastSuccessTime(source.getLastSuccessTime())
         .consecutiveFailures(source.getConsecutiveFailures())
         .lastErrorMessage(source.getLastErrorMessage())
+        .capabilityStatus(source.getCapabilityStatus())
+        .capabilityDigest(source.getCapabilityDigest())
+        .connectorSchemasJson(source.getConnectorSchemasJson())
+        .capabilitySyncedAt(source.getCapabilitySyncedAt())
+        .capabilityErrorMessage(source.getCapabilityErrorMessage())
         .createTime(source.getCreateTime())
         .updateTime(source.getUpdateTime())
         .build();
@@ -300,15 +330,24 @@ public class OfflineWorkerService {
     int maxRunning = Math.max(1, value(node.getMaxConcurrentJobs(), 1));
     int maxQueued = Math.max(0, value(node.getMaxQueuedJobs(), 0));
     int capacity = Math.max(1, maxRunning + maxQueued);
+    String leaseStatus = leaseStatus(node);
+    boolean leaseReady = !"DYNAMIC".equalsIgnoreCase(node.getRegistrationMode())
+        || "ACTIVE".equals(leaseStatus);
     boolean available = Boolean.TRUE.equals(node.getEnabled())
         && "ENABLED".equalsIgnoreCase(node.getSchedulingStatus())
         && "UP".equalsIgnoreCase(node.getStatus())
+        && leaseReady
         && !(running >= maxRunning && queued >= maxQueued);
     return WorkerView.builder()
         .nodeId(node.getNodeId())
         .nodeName(node.getNodeName())
         .baseUrl(node.getBaseUrl())
         .registrationMode(node.getRegistrationMode())
+        .leaseStatus(leaseStatus)
+        .leaseExpiresAt(node.getLeaseExpiresAt())
+        .lastRegistrationTime(node.getLastRegistrationTime())
+        .heartbeatSequence(node.getHeartbeatSequence())
+        .registrationProtocolVersion(node.getRegistrationProtocolVersion())
         .enabled(node.getEnabled())
         .schedulingStatus(node.getSchedulingStatus())
         .weight(node.getWeight())
@@ -334,6 +373,16 @@ public class OfflineWorkerService {
         .build();
   }
 
+  private String leaseStatus(NodeRecord node) {
+    if (!"DYNAMIC".equalsIgnoreCase(node.getRegistrationMode())) {
+      return "NOT_APPLICABLE";
+    }
+    if (!StringUtils.hasText(node.getRegistrationLeaseId()) || node.getLeaseExpiresAt() == null) {
+      return "UNKNOWN";
+    }
+    return node.getLeaseExpiresAt().isAfter(LocalDateTime.now()) ? "ACTIVE" : "EXPIRED";
+  }
+
   private boolean matches(NodeRecord node, QueryRequest query) {
     if (query.getEnabled() != null
         && query.getEnabled() != Boolean.TRUE.equals(node.getEnabled())) {
@@ -347,6 +396,10 @@ public class OfflineWorkerService {
         && !query.getSchedulingStatus().trim().equalsIgnoreCase(node.getSchedulingStatus())) {
       return false;
     }
+    if (StringUtils.hasText(query.getRegistrationMode())
+        && !query.getRegistrationMode().trim().equalsIgnoreCase(node.getRegistrationMode())) {
+      return false;
+    }
     if (!StringUtils.hasText(query.getKeyword())) {
       return true;
     }
@@ -355,6 +408,7 @@ public class OfflineWorkerService {
         || contains(node.getNodeName(), keyword)
         || contains(node.getBaseUrl(), keyword)
         || contains(node.getEngineVersion(), keyword)
+        || contains(node.getRegistrationInstanceId(), keyword)
         || contains(node.getLabelsJson(), keyword);
   }
 

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/resources/db/migration/yak-offline-sync/V9__add_dynamic_worker_registration.sql
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/resources/db/migration/yak-offline-sync/V9__add_dynamic_worker_registration.sql
@@ -1,0 +1,35 @@
+ALTER TABLE yak_offline_engine_node
+    ADD COLUMN registration_lease_id VARCHAR(64) NULL AFTER registration_mode,
+    ADD COLUMN registration_instance_id VARCHAR(128) NULL AFTER registration_lease_id,
+    ADD COLUMN registration_protocol_version VARCHAR(64) NULL AFTER registration_instance_id,
+    ADD COLUMN lease_expires_at DATETIME NULL AFTER registration_protocol_version,
+    ADD COLUMN last_registration_time DATETIME NULL AFTER lease_expires_at,
+    ADD COLUMN heartbeat_sequence BIGINT NOT NULL DEFAULT 0 AFTER last_registration_time;
+
+CREATE UNIQUE INDEX uk_offline_node_registration_lease
+    ON yak_offline_engine_node (registration_lease_id);
+
+CREATE INDEX idx_offline_node_dynamic_lease
+    ON yak_offline_engine_node (registration_mode, lease_expires_at, status);
+
+CREATE TABLE yak_offline_worker_registration_nonce (
+    nonce_hash CHAR(64) NOT NULL,
+    expires_at DATETIME NOT NULL,
+    create_time DATETIME NOT NULL,
+    PRIMARY KEY (nonce_hash),
+    KEY idx_offline_registration_nonce_expire (expires_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE yak_offline_worker_registration_event (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    node_id VARCHAR(128) NULL,
+    instance_id VARCHAR(128) NULL,
+    lease_id VARCHAR(64) NULL,
+    event_type VARCHAR(64) NOT NULL,
+    remote_address VARCHAR(128) NULL,
+    message VARCHAR(1000) NULL,
+    event_time DATETIME NOT NULL,
+    PRIMARY KEY (id),
+    KEY idx_offline_registration_event_node (node_id, event_time),
+    KEY idx_offline_registration_event_lease (lease_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/controller/OfflineWorkerControllerContractTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/controller/OfflineWorkerControllerContractTest.java
@@ -3,6 +3,7 @@ package io.yak.ops.business.sync.offline.controller;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.yak.ops.business.sync.offline.worker.OfflineWorkerModels.CreateRequest;
+import io.yak.ops.business.sync.offline.worker.OfflineWorkerModels.LeaseRevokeRequest;
 import io.yak.ops.business.sync.offline.worker.OfflineWorkerModels.QueryRequest;
 import io.yak.ops.business.sync.offline.worker.OfflineWorkerModels.SchedulingRequest;
 import io.yak.ops.business.sync.offline.worker.OfflineWorkerModels.UpdateRequest;
@@ -18,7 +19,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 class OfflineWorkerControllerContractTest {
 
   @Test
-  void exposesWorkerManagementAndCapabilityClosure() throws Exception {
+  void exposesWorkerManagementCapabilityAndLeaseClosure() throws Exception {
     RequestMapping root = OfflineWorkerController.class.getAnnotation(RequestMapping.class);
     assertThat(root.value()).containsExactly("/api/v1/offline/workers");
 
@@ -29,14 +30,15 @@ class OfflineWorkerControllerContractTest {
     assertPost("page", new Class<?>[] {QueryRequest.class}, "/page");
     assertGet("options", new Class<?>[0], "/options");
     assertPost("refresh", new Class<?>[] {String.class}, "/{nodeId}/refresh");
-    assertGet(
-        "capabilities",
-        new Class<?>[] {String.class},
-        "/{nodeId}/capabilities");
+    assertGet("capabilities", new Class<?>[] {String.class}, "/{nodeId}/capabilities");
     assertPost(
         "refreshCapabilities",
         new Class<?>[] {String.class},
         "/{nodeId}/capabilities/refresh");
+    assertPost(
+        "revokeLease",
+        new Class<?>[] {String.class, LeaseRevokeRequest.class},
+        "/{nodeId}/lease/revoke");
     assertPut(
         "schedulingStatus",
         new Class<?>[] {String.class, SchedulingRequest.class},

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/controller/OfflineWorkerRegistrationControllerContractTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/controller/OfflineWorkerRegistrationControllerContractTest.java
@@ -1,0 +1,31 @@
+package io.yak.ops.business.sync.offline.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.lang.reflect.Method;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+class OfflineWorkerRegistrationControllerContractTest {
+
+  @Test
+  void exposesRegisterHeartbeatAndDeregisterRoutes() throws Exception {
+    RequestMapping root = OfflineWorkerRegistrationController.class
+        .getAnnotation(RequestMapping.class);
+    assertThat(root.value()).containsExactly("/api/v1/offline/worker-registration");
+
+    assertPost("register", "/register");
+    assertPost("heartbeat", "/heartbeat");
+    assertPost("deregister", "/deregister");
+  }
+
+  private void assertPost(String methodName, String path) throws Exception {
+    Method method = OfflineWorkerRegistrationController.class.getMethod(
+        methodName,
+        HttpServletRequest.class,
+        String.class);
+    assertThat(method.getAnnotation(PostMapping.class).value()).containsExactly(path);
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/worker/OfflineCapabilityMatcherTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/worker/OfflineCapabilityMatcherTest.java
@@ -30,6 +30,37 @@ class OfflineCapabilityMatcherTest {
   }
 
   @Test
+  void rejectsExpiredDynamicRegistrationLease() {
+    OfflineCapabilityProperties properties = new OfflineCapabilityProperties();
+    OfflineCapabilityMatcher matcher = new OfflineCapabilityMatcher(properties, objectMapper);
+    NodeRecord worker = worker("sha256:source", "sha256:sink", "UPSERT");
+    worker.setRegistrationMode("DYNAMIC");
+    worker.setLeaseExpiresAt(LocalDateTime.now().minusSeconds(1));
+
+    MatchResult result = matcher.match(
+        worker,
+        requirements("sha256:source", "sha256:sink", "UPSERT"));
+
+    assertThat(result.isMatched()).isFalse();
+    assertThat(result.getReason()).contains("租约已过期");
+  }
+
+  @Test
+  void acceptsActiveDynamicRegistrationLease() {
+    OfflineCapabilityProperties properties = new OfflineCapabilityProperties();
+    OfflineCapabilityMatcher matcher = new OfflineCapabilityMatcher(properties, objectMapper);
+    NodeRecord worker = worker("sha256:source", "sha256:sink", "UPSERT");
+    worker.setRegistrationMode("DYNAMIC");
+    worker.setLeaseExpiresAt(LocalDateTime.now().plusMinutes(1));
+
+    MatchResult result = matcher.match(
+        worker,
+        requirements("sha256:source", "sha256:sink", "UPSERT"));
+
+    assertThat(result.isMatched()).isTrue();
+  }
+
+  @Test
   void rejectsMissingExecutionCapability() {
     OfflineCapabilityProperties properties = new OfflineCapabilityProperties();
     OfflineCapabilityMatcher matcher = new OfflineCapabilityMatcher(properties, objectMapper);
@@ -89,7 +120,7 @@ class OfflineCapabilityMatcherTest {
   }
 
   @Test
-  void disabledCapabilitySchedulingKeepsWorkerEligible() {
+  void disabledCapabilitySchedulingKeepsNonDynamicWorkerEligible() {
     OfflineCapabilityProperties properties = new OfflineCapabilityProperties();
     properties.setEnabled(false);
     OfflineCapabilityMatcher matcher = new OfflineCapabilityMatcher(properties, objectMapper);

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/worker/OfflineWorkerRegistrationAuthenticatorTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/worker/OfflineWorkerRegistrationAuthenticatorTest.java
@@ -1,0 +1,138 @@
+package io.yak.ops.business.sync.offline.worker;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.sync.offline.config.OfflineWorkerRegistrationProperties;
+import io.yak.ops.business.sync.offline.repository.OfflineWorkerRegistrationRepository;
+import jakarta.servlet.http.HttpServletRequest;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.time.LocalDateTime;
+import java.util.HexFormat;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
+import org.springframework.web.server.ResponseStatusException;
+
+class OfflineWorkerRegistrationAuthenticatorTest {
+
+  @Test
+  void acceptsValidSignatureAndConsumesNonce() throws Exception {
+    OfflineWorkerRegistrationProperties properties = properties();
+    OfflineWorkerRegistrationRepository repository =
+        mock(OfflineWorkerRegistrationRepository.class);
+    when(repository.consumeNonce(
+        ArgumentMatchers.anyString(),
+        ArgumentMatchers.any(LocalDateTime.class))).thenReturn(true);
+    OfflineWorkerRegistrationAuthenticator authenticator =
+        new OfflineWorkerRegistrationAuthenticator(properties, repository);
+
+    String body = "{\"nodeId\":\"worker-a\"}";
+    String timestamp = String.valueOf(System.currentTimeMillis());
+    String nonce = "1234567890abcdef1234567890abcdef";
+    HttpServletRequest request = request(
+        timestamp,
+        nonce,
+        sign("POST", "/api/v1/offline/worker-registration/register",
+            timestamp, nonce, body, properties.getSecret()));
+
+    authenticator.authenticate(request, body);
+
+    verify(repository).consumeNonce(
+        ArgumentMatchers.anyString(),
+        ArgumentMatchers.any(LocalDateTime.class));
+  }
+
+  @Test
+  void rejectsReplayedNonce() throws Exception {
+    OfflineWorkerRegistrationProperties properties = properties();
+    OfflineWorkerRegistrationRepository repository =
+        mock(OfflineWorkerRegistrationRepository.class);
+    when(repository.consumeNonce(
+        ArgumentMatchers.anyString(),
+        ArgumentMatchers.any(LocalDateTime.class))).thenReturn(false);
+    OfflineWorkerRegistrationAuthenticator authenticator =
+        new OfflineWorkerRegistrationAuthenticator(properties, repository);
+
+    String body = "{}";
+    String timestamp = String.valueOf(System.currentTimeMillis());
+    String nonce = "1234567890abcdef1234567890abcdef";
+    HttpServletRequest request = request(
+        timestamp,
+        nonce,
+        sign("POST", "/api/v1/offline/worker-registration/register",
+            timestamp, nonce, body, properties.getSecret()));
+
+    assertThatThrownBy(() -> authenticator.authenticate(request, body))
+        .isInstanceOf(ResponseStatusException.class)
+        .hasMessageContaining("nonce 已使用");
+  }
+
+  @Test
+  void rejectsBodyTamperingBeforeNonceIsConsumed() throws Exception {
+    OfflineWorkerRegistrationProperties properties = properties();
+    OfflineWorkerRegistrationRepository repository =
+        mock(OfflineWorkerRegistrationRepository.class);
+    OfflineWorkerRegistrationAuthenticator authenticator =
+        new OfflineWorkerRegistrationAuthenticator(properties, repository);
+
+    String timestamp = String.valueOf(System.currentTimeMillis());
+    String nonce = "1234567890abcdef1234567890abcdef";
+    HttpServletRequest request = request(
+        timestamp,
+        nonce,
+        sign("POST", "/api/v1/offline/worker-registration/register",
+            timestamp, nonce, "{\"value\":1}", properties.getSecret()));
+
+    assertThatThrownBy(() -> authenticator.authenticate(request, "{\"value\":2}"))
+        .isInstanceOf(ResponseStatusException.class)
+        .hasMessageContaining("签名校验失败");
+  }
+
+  private OfflineWorkerRegistrationProperties properties() {
+    OfflineWorkerRegistrationProperties properties =
+        new OfflineWorkerRegistrationProperties();
+    properties.setEnabled(true);
+    properties.setSecret("0123456789abcdef/");
+    return properties;
+  }
+
+  private HttpServletRequest request(
+      String timestamp,
+      String nonce,
+      String signature) {
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    when(request.getMethod()).thenReturn("POST");
+    when(request.getRequestURI())
+        .thenReturn("/api/v1/offline/worker-registration/register");
+    when(request.getHeader(OfflineWorkerRegistrationAuthenticator.HEADER_TIMESTAMP))
+        .thenReturn(timestamp);
+    when(request.getHeader(OfflineWorkerRegistrationAuthenticator.HEADER_NONCE))
+        .thenReturn(nonce);
+    when(request.getHeader(OfflineWorkerRegistrationAuthenticator.HEADER_SIGNATURE))
+        .thenReturn(signature);
+    return request;
+  }
+
+  private String sign(
+      String method,
+      String path,
+      String timestamp,
+      String nonce,
+      String body,
+      String secret) throws Exception {
+    String bodyHash = HexFormat.of().formatHex(
+        MessageDigest.getInstance("SHA-256")
+            .digest(body.getBytes(StandardCharsets.UTF_8)));
+    String canonical = method + "\n" + path + "\n" + timestamp + "\n" + nonce
+        + "\n" + bodyHash;
+    Mac mac = Mac.getInstance("HmacSHA256");
+    mac.init(new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HmacSHA256"));
+    return HexFormat.of().formatHex(
+        mac.doFinal(canonical.getBytes(StandardCharsets.UTF_8)));
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/worker/OfflineWorkerRegistrationServiceTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/worker/OfflineWorkerRegistrationServiceTest.java
@@ -1,0 +1,154 @@
+package io.yak.ops.business.sync.offline.worker;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.sync.offline.config.OfflineWorkerRegistrationProperties;
+import io.yak.ops.business.sync.offline.engine.LinkUpWorkerProbeClient;
+import io.yak.ops.business.sync.offline.repository.OfflineNodeRepository;
+import io.yak.ops.business.sync.offline.repository.OfflineNodeRepository.NodeRecord;
+import io.yak.ops.business.sync.offline.repository.OfflineWorkerRegistrationRepository;
+import io.yak.ops.business.sync.offline.worker.OfflineWorkerRegistrationModels.HeartbeatRequest;
+import io.yak.ops.business.sync.offline.worker.OfflineWorkerRegistrationModels.LeaseResponse;
+import io.yak.ops.business.sync.offline.worker.OfflineWorkerRegistrationModels.RegisterRequest;
+import java.time.LocalDateTime;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+class OfflineWorkerRegistrationServiceTest {
+
+  @Test
+  void createsDynamicLeaseAndKeepsWorkerRuntimeFacts() {
+    OfflineNodeRepository nodes = mock(OfflineNodeRepository.class);
+    OfflineWorkerRegistrationRepository registrations =
+        mock(OfflineWorkerRegistrationRepository.class);
+    LinkUpWorkerProbeClient probe = mock(LinkUpWorkerProbeClient.class);
+    when(probe.normalizeBaseUrl("http://worker-a:18080"))
+        .thenReturn("http://worker-a:18080");
+
+    AtomicReference<NodeRecord> stored = new AtomicReference<>();
+    doAnswer(invocation -> {
+      stored.set(invocation.getArgument(0));
+      return null;
+    }).when(nodes).upsert(any(NodeRecord.class));
+    when(nodes.find("worker-a")).thenAnswer(invocation -> stored.get());
+
+    OfflineWorkerRegistrationService service = service(nodes, registrations, probe);
+    LeaseResponse response = service.register(registerRequest("instance-a"), "10.0.0.1");
+
+    assertThat(stored.get().getRegistrationMode()).isEqualTo("DYNAMIC");
+    assertThat(stored.get().getRegistrationInstanceId()).isEqualTo("instance-a");
+    assertThat(stored.get().getStatus()).isEqualTo("UP");
+    assertThat(stored.get().getLeaseExpiresAt()).isAfter(LocalDateTime.now());
+    assertThat(response.getLeaseId()).isNotBlank();
+    assertThat(response.getSchedulingStatus()).isEqualTo("ENABLED");
+  }
+
+  @Test
+  void rejectsDifferentInstanceWhileLeaseIsActive() {
+    OfflineNodeRepository nodes = mock(OfflineNodeRepository.class);
+    OfflineWorkerRegistrationRepository registrations =
+        mock(OfflineWorkerRegistrationRepository.class);
+    LinkUpWorkerProbeClient probe = mock(LinkUpWorkerProbeClient.class);
+    when(probe.normalizeBaseUrl("http://worker-a:18080"))
+        .thenReturn("http://worker-a:18080");
+    when(nodes.findForUpdate("worker-a")).thenReturn(activeNode("instance-old", 3L));
+
+    OfflineWorkerRegistrationService service = service(nodes, registrations, probe);
+
+    assertThatThrownBy(() -> service.register(registerRequest("instance-new"), "10.0.0.2"))
+        .isInstanceOfSatisfying(ResponseStatusException.class, exception ->
+            assertThat(exception.getStatusCode()).isEqualTo(HttpStatus.CONFLICT))
+        .hasMessageContaining("旧 Worker 实例租约仍有效");
+  }
+
+  @Test
+  void rejectsHeartbeatSequenceThatDoesNotIncrease() {
+    OfflineNodeRepository nodes = mock(OfflineNodeRepository.class);
+    OfflineWorkerRegistrationRepository registrations =
+        mock(OfflineWorkerRegistrationRepository.class);
+    LinkUpWorkerProbeClient probe = mock(LinkUpWorkerProbeClient.class);
+    when(nodes.findForUpdate("worker-a")).thenReturn(activeNode("instance-a", 5L));
+
+    OfflineWorkerRegistrationService service = service(nodes, registrations, probe);
+    HeartbeatRequest request = new HeartbeatRequest();
+    request.setProtocolVersion(OfflineWorkerRegistrationModels.PROTOCOL_VERSION);
+    request.setLeaseId("lease-a");
+    request.setNodeId("worker-a");
+    request.setInstanceId("instance-a");
+    request.setSequence(5L);
+    request.setBaseUrl("http://worker-a:18080");
+    request.setOfflineOnly(true);
+
+    assertThatThrownBy(() -> service.heartbeat(request, "10.0.0.1"))
+        .isInstanceOf(ResponseStatusException.class)
+        .hasMessageContaining("严格递增");
+  }
+
+  private OfflineWorkerRegistrationService service(
+      OfflineNodeRepository nodes,
+      OfflineWorkerRegistrationRepository registrations,
+      LinkUpWorkerProbeClient probe) {
+    OfflineWorkerRegistrationProperties properties =
+        new OfflineWorkerRegistrationProperties();
+    properties.setEnabled(true);
+    properties.setAutoEnable(true);
+    return new OfflineWorkerRegistrationService(
+        nodes,
+        registrations,
+        probe,
+        properties,
+        new ObjectMapper().findAndRegisterModules());
+  }
+
+  private RegisterRequest registerRequest(String instanceId) {
+    RegisterRequest request = new RegisterRequest();
+    request.setProtocolVersion(OfflineWorkerRegistrationModels.PROTOCOL_VERSION);
+    request.setNodeId("worker-a");
+    request.setNodeName("Worker A");
+    request.setInstanceId(instanceId);
+    request.setBaseUrl("http://worker-a:18080");
+    request.setEngineVersion("1.0.0");
+    request.setStartedAtMillis(System.currentTimeMillis());
+    request.setOfflineOnly(true);
+    request.setMaxConcurrentJobs(4);
+    request.setMaxQueuedJobs(8);
+    request.setRunningJobs(1);
+    request.setQueuedJobs(0);
+    return request;
+  }
+
+  private NodeRecord activeNode(String instanceId, long sequence) {
+    return NodeRecord.builder()
+        .nodeId("worker-a")
+        .nodeName("Worker A")
+        .baseUrl("http://worker-a:18080")
+        .registrationMode("DYNAMIC")
+        .registrationLeaseId("lease-a")
+        .registrationInstanceId(instanceId)
+        .registrationProtocolVersion(OfflineWorkerRegistrationModels.PROTOCOL_VERSION)
+        .leaseExpiresAt(LocalDateTime.now().plusMinutes(1))
+        .heartbeatSequence(sequence)
+        .enabled(true)
+        .schedulingStatus("ENABLED")
+        .weight(100)
+        .labelsJson("{}")
+        .workerInstanceId(instanceId)
+        .offlineOnly(true)
+        .status("UP")
+        .maxConcurrentJobs(4)
+        .maxQueuedJobs(8)
+        .runningJobs(0)
+        .queuedJobs(0)
+        .createTime(LocalDateTime.now())
+        .updateTime(LocalDateTime.now())
+        .build();
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/worker/OfflineWorkerRegistrationServiceTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/worker/OfflineWorkerRegistrationServiceTest.java
@@ -48,6 +48,7 @@ class OfflineWorkerRegistrationServiceTest {
     assertThat(stored.get().getStatus()).isEqualTo("UP");
     assertThat(stored.get().getLeaseExpiresAt()).isAfter(LocalDateTime.now());
     assertThat(response.getLeaseId()).isNotBlank();
+    assertThat(response.getHeartbeatSequence()).isZero();
     assertThat(response.getSchedulingStatus()).isEqualTo("ENABLED");
   }
 

--- a/yak-ops-ui/src/pages/client/api.ts
+++ b/yak-ops-ui/src/pages/client/api.ts
@@ -6,7 +6,13 @@ export const apiPrefix = '/api/v1/offline/workers';
 export type WorkerId = string | number;
 export type WorkerHealthStatus = 'UP' | 'DOWN' | string;
 export type WorkerSchedulingStatus = 'ENABLED' | 'DRAINING' | 'DISABLED';
-export type WorkerRegistrationMode = 'CONFIG' | 'MANUAL';
+export type WorkerRegistrationMode = 'CONFIG' | 'MANUAL' | 'DYNAMIC';
+export type WorkerLeaseStatus =
+  | 'ACTIVE'
+  | 'EXPIRED'
+  | 'UNKNOWN'
+  | 'NOT_APPLICABLE'
+  | string;
 export type WorkerCapabilityStatus = 'UNKNOWN' | 'READY' | 'ERROR' | string;
 
 export interface ConnectorCapability {
@@ -36,6 +42,11 @@ export interface LinkupClient {
   clientName?: string;
   baseUrl: string;
   registrationMode: WorkerRegistrationMode;
+  leaseStatus?: WorkerLeaseStatus;
+  leaseExpiresAt?: string;
+  lastRegistrationTime?: string;
+  heartbeatSequence?: number;
+  registrationProtocolVersion?: string;
   enabled: boolean;
   schedulingStatus: WorkerSchedulingStatus;
   weight: number;
@@ -96,6 +107,7 @@ export interface LinkupClientPageRequest {
   keywords?: string;
   status?: string;
   schedulingStatus?: WorkerSchedulingStatus;
+  registrationMode?: WorkerRegistrationMode;
   enabled?: boolean;
 }
 
@@ -118,6 +130,8 @@ export interface LinkupClientOption {
   label: string;
   status?: string;
   schedulingStatus?: string;
+  registrationMode?: WorkerRegistrationMode;
+  leaseStatus?: WorkerLeaseStatus;
   runningJobs?: number;
   maxConcurrentJobs?: number;
   queuedJobs?: number;
@@ -223,6 +237,16 @@ export const linkupClientApi = {
     return HttpUtils.post(
       `${apiPrefix}/${workerPath(nodeId)}/capabilities/refresh`,
       {},
+    );
+  },
+
+  revokeLease: (
+    nodeId: WorkerId,
+    reason?: string,
+  ): Promise<ApiResponse<LinkupClient>> => {
+    return HttpUtils.post(
+      `${apiPrefix}/${workerPath(nodeId)}/lease/revoke`,
+      { reason },
     );
   },
 

--- a/yak-ops-ui/src/pages/client/components/AddClientModal.tsx
+++ b/yak-ops-ui/src/pages/client/components/AddClientModal.tsx
@@ -62,6 +62,8 @@ const AddClientDrawer = ({
   const [verifiedWorker, setVerifiedWorker] = useState<LinkupClient>();
   const isEdit = mode === 'edit';
   const configManaged = initialValues?.registrationMode === 'CONFIG';
+  const dynamicManaged = initialValues?.registrationMode === 'DYNAMIC';
+  const addressManaged = configManaged || dynamicManaged;
 
   useEffect(() => {
     if (!open) return;
@@ -132,7 +134,7 @@ const AddClientDrawer = ({
         type="info"
         showIcon
         message="Yak Ops 会读取 /api/v1/node 获取 nodeId、进程实例、版本和执行容量。"
-        description="节点保存后由后台定时心跳维护状态。禁用节点不会继续自动探测，排空节点不接收新任务但保留运行任务。"
+        description="手工和配置节点由 Yak Ops 主动探测；动态节点由 Worker 使用签名心跳续租。禁用节点不接收新任务，排空节点保留运行任务。"
       />
 
       {configManaged ? (
@@ -141,7 +143,17 @@ const AddClientDrawer = ({
           type="warning"
           showIcon
           message="该节点来自 application.yml"
-          description="Worker 地址和稳定 nodeId 由配置文件托管；页面可调整权重、标签和调度状态。"
+          description="Worker 地址和稳定 nodeId 由配置文件托管；页面可调整名称、权重、标签和调度状态。"
+        />
+      ) : null}
+
+      {dynamicManaged ? (
+        <Alert
+          className="mb-5"
+          type="warning"
+          showIcon
+          message="该节点由 Worker 动态注册"
+          description="Worker 地址、进程实例、容量和 Connector 能力由签名心跳维护；页面仅管理名称、权重、标签和调度状态。"
         />
       ) : null}
 
@@ -184,7 +196,13 @@ const AddClientDrawer = ({
         <Form.Item
           name="baseUrl"
           label="Worker 地址"
-          extra={configManaged ? '配置来源节点的地址请在 application.yml 中修改' : undefined}
+          extra={
+            configManaged
+              ? '配置来源节点的地址请在 application.yml 中修改'
+              : dynamicManaged
+                ? '动态节点地址由 Worker 的 advertised base URL 维护'
+                : undefined
+          }
           rules={[
             { required: true, whitespace: true, message: '请输入 Worker 地址' },
             {
@@ -195,7 +213,7 @@ const AddClientDrawer = ({
         >
           <Input
             variant="filled"
-            disabled={configManaged}
+            disabled={addressManaged}
             placeholder="http://127.0.0.1:18080"
           />
         </Form.Item>
@@ -203,7 +221,7 @@ const AddClientDrawer = ({
         <Form.Item
           name="weight"
           label="调度权重"
-          extra="第一阶段只保存权重，自动分配将在下一阶段启用。"
+          extra="自动调度会在能力、可达性、租约和容量硬过滤后使用该权重评分。"
           rules={[{ required: true, message: '请输入调度权重' }]}
         >
           <InputNumber

--- a/yak-ops-ui/src/pages/client/detail/index.tsx
+++ b/yak-ops-ui/src/pages/client/detail/index.tsx
@@ -1,5 +1,6 @@
 import {
   ArrowLeftOutlined,
+  DisconnectOutlined,
   ReloadOutlined,
 } from '@ant-design/icons';
 import { history, useParams } from '@umijs/max';
@@ -10,6 +11,7 @@ import {
   Descriptions,
   Empty,
   message,
+  Popconfirm,
   Spin,
   Table,
   Tag,
@@ -39,6 +41,12 @@ const capabilityStatusMeta = (status?: string, fresh?: boolean) => {
   return { label: '等待同步', color: 'default' as const };
 };
 
+const registrationLabel = (worker: LinkupClient) => {
+  if (worker.registrationMode === 'CONFIG') return '配置托管';
+  if (worker.registrationMode === 'DYNAMIC') return '动态注册';
+  return '手工注册';
+};
+
 const formatTime = (value?: string) => value || '--';
 
 export default function WorkerDetailPage() {
@@ -46,6 +54,7 @@ export default function WorkerDetailPage() {
   const nodeId = params.id ? decodeURIComponent(params.id) : '';
   const [loading, setLoading] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
+  const [revoking, setRevoking] = useState(false);
   const [worker, setWorker] = useState<LinkupClient | null>(null);
   const [capability, setCapability] = useState<WorkerCapability | null>(null);
 
@@ -87,12 +96,36 @@ export default function WorkerDetailPage() {
       if (response?.code !== API_SUCCESS_CODE) {
         throw new Error(response?.message || '刷新 Worker 失败');
       }
-      message.success('Worker 心跳与 Connector 能力已刷新');
+      message.success(
+        worker?.registrationMode === 'DYNAMIC'
+          ? '动态注册状态与 Connector 能力已刷新'
+          : 'Worker 心跳与 Connector 能力已刷新',
+      );
       await load();
     } catch (error: any) {
       message.error(error?.message || '刷新 Worker 失败');
     } finally {
       setRefreshing(false);
+    }
+  };
+
+  const revokeLease = async () => {
+    if (!nodeId) return;
+    setRevoking(true);
+    try {
+      const response = await linkupClientApi.revokeLease(
+        nodeId,
+        '管理员从执行节点详情页撤销租约',
+      );
+      if (response?.code !== API_SUCCESS_CODE) {
+        throw new Error(response?.message || '撤销动态注册租约失败');
+      }
+      message.success('动态注册租约已撤销');
+      await load();
+    } catch (error: any) {
+      message.error(error?.message || '撤销动态注册租约失败');
+    } finally {
+      setRevoking(false);
     }
   };
 
@@ -115,9 +148,7 @@ export default function WorkerDetailPage() {
         title: '角色',
         dataIndex: 'role',
         width: 100,
-        render: (value: string) => (
-          <Tag className="!m-0">{value}</Tag>
-        ),
+        render: (value: string) => <Tag className="!m-0">{value}</Tag>,
       },
       {
         title: 'Schema',
@@ -172,6 +203,8 @@ export default function WorkerDetailPage() {
   }
 
   const status = capabilityStatusMeta(capability?.status, capability?.fresh);
+  const dynamic = worker.registrationMode === 'DYNAMIC';
+  const activeLease = dynamic && worker.leaseStatus === 'ACTIVE';
 
   return (
     <ConfigProvider theme={BRAND_THEME}>
@@ -193,6 +226,12 @@ export default function WorkerDetailPage() {
                     {worker.status === 'UP' ? '在线' : '离线'}
                   </Tag>
                   <Tag color={status.color}>{status.label}</Tag>
+                  <Tag>{registrationLabel(worker)}</Tag>
+                  {dynamic ? (
+                    <Tag color={activeLease ? 'success' : 'error'}>
+                      {activeLease ? '租约有效' : '租约已失效'}
+                    </Tag>
+                  ) : null}
                 </div>
                 <div className="mt-1 font-mono text-xs text-[#8a8f99]">
                   {worker.nodeId}
@@ -200,14 +239,44 @@ export default function WorkerDetailPage() {
               </div>
             </div>
 
-            <Button
-              icon={<ReloadOutlined />}
-              loading={refreshing}
-              onClick={() => void refresh()}
-            >
-              刷新心跳与能力
-            </Button>
+            <div className="flex flex-wrap gap-2">
+              {activeLease ? (
+                <Popconfirm
+                  title="撤销动态注册租约"
+                  description="撤销后节点立即离线；Worker 如仍启用动态注册，会重新发起登记。"
+                  okText="撤销租约"
+                  cancelText="取消"
+                  okButtonProps={{ danger: true, loading: revoking }}
+                  onConfirm={() => void revokeLease()}
+                >
+                  <Button danger icon={<DisconnectOutlined />} loading={revoking}>
+                    撤销租约
+                  </Button>
+                </Popconfirm>
+              ) : null}
+              <Button
+                icon={<ReloadOutlined />}
+                loading={refreshing}
+                onClick={() => void refresh()}
+              >
+                刷新状态与能力
+              </Button>
+            </div>
           </div>
+
+          {dynamic ? (
+            <Alert
+              className="mb-4"
+              type={activeLease ? 'info' : 'warning'}
+              showIcon
+              message="该节点由 Link-Up Worker 主动注册"
+              description={
+                activeLease
+                  ? '地址、实例、容量和能力由签名心跳维护；名称、标签、权重和调度状态由 Yak Ops 管理。'
+                  : '当前租约无效，节点不会参与调度；请检查 Worker 注册配置、共享密钥和控制面网络。'
+              }
+            />
+          ) : null}
 
           <section className="rounded-xl border border-[#eceef1] bg-white p-5">
             <Descriptions
@@ -215,13 +284,10 @@ export default function WorkerDetailPage() {
               column={{ xs: 1, sm: 2, lg: 3 }}
               items={[
                 { key: 'url', label: 'Worker 地址', children: worker.baseUrl },
+                { key: 'mode', label: '注册模式', children: registrationLabel(worker) },
                 { key: 'version', label: '引擎版本', children: worker.engineVersion || '--' },
                 { key: 'instance', label: '进程实例', children: worker.workerInstanceId || '--' },
-                {
-                  key: 'schedule',
-                  label: '调度状态',
-                  children: worker.schedulingStatus,
-                },
+                { key: 'schedule', label: '调度状态', children: worker.schedulingStatus },
                 {
                   key: 'capacity',
                   label: '运行容量',
@@ -237,6 +303,35 @@ export default function WorkerDetailPage() {
                   label: '最近心跳',
                   children: formatTime(worker.lastHeartbeatTime),
                 },
+                ...(dynamic
+                  ? [
+                      {
+                        key: 'lease',
+                        label: '租约状态',
+                        children: worker.leaseStatus || '--',
+                      },
+                      {
+                        key: 'leaseExpires',
+                        label: '租约到期',
+                        children: formatTime(worker.leaseExpiresAt),
+                      },
+                      {
+                        key: 'registerTime',
+                        label: '最近注册',
+                        children: formatTime(worker.lastRegistrationTime),
+                      },
+                      {
+                        key: 'sequence',
+                        label: '心跳序列',
+                        children: String(worker.heartbeatSequence ?? '--'),
+                      },
+                      {
+                        key: 'protocol',
+                        label: '注册协议',
+                        children: worker.registrationProtocolVersion || '--',
+                      },
+                    ]
+                  : []),
                 {
                   key: 'capabilityTime',
                   label: '能力同步',
@@ -272,7 +367,7 @@ export default function WorkerDetailPage() {
                   Connector 能力
                 </h2>
                 <div className="mt-1 text-xs text-[#8a8f99]">
-                  调度器会按 Connector、角色、Schema 指纹和任务特性能力进行硬过滤。
+                  调度器会按租约、Connector、角色、Schema 指纹和任务特性能力进行硬过滤。
                 </div>
               </div>
               <span className="text-sm text-[#667085]">

--- a/yak-ops-ui/src/pages/client/hooks/useClientPageState.ts
+++ b/yak-ops-ui/src/pages/client/hooks/useClientPageState.ts
@@ -37,6 +37,9 @@ export const useClientPageState = () => {
   const [statusLoadingIds, setStatusLoadingIds] = useState<Set<string>>(
     new Set(),
   );
+  const [leaseLoadingIds, setLeaseLoadingIds] = useState<Set<string>>(
+    new Set(),
+  );
 
   const loadClients = useCallback(async () => {
     setLoading(true);
@@ -205,6 +208,33 @@ export const useClientPageState = () => {
     [],
   );
 
+  const handleRevokeLease = useCallback(async (nodeId: string) => {
+    setLeaseLoadingIds((previous) => new Set(previous).add(nodeId));
+    try {
+      const response = await linkupClientApi.revokeLease(
+        nodeId,
+        '管理员从执行节点页面撤销租约',
+      );
+      if (response.code !== API_SUCCESS_CODE || !response.data) return;
+      setClients((previous) =>
+        previous.map((item) =>
+          item.nodeId === nodeId ? response.data : item,
+        ),
+      );
+      message.success('动态注册租约已撤销');
+    } catch (error) {
+      console.error('撤销动态注册租约失败', error);
+      message.error('动态注册租约撤销失败');
+      await loadClients();
+    } finally {
+      setLeaseLoadingIds((previous) => {
+        const next = new Set(previous);
+        next.delete(nodeId);
+        return next;
+      });
+    }
+  }, [loadClients]);
+
   useEffect(() => {
     void loadClients();
   }, [loadClients]);
@@ -220,6 +250,7 @@ export const useClientPageState = () => {
     deleteLoadingId,
     refreshLoadingIds,
     statusLoadingIds,
+    leaseLoadingIds,
     form,
     handleOpenCreate,
     handleOpenEdit,
@@ -229,6 +260,7 @@ export const useClientPageState = () => {
     handleVerifyWorker,
     handleRefreshWorker,
     handleChangeSchedulingStatus,
+    handleRevokeLease,
     loadClients,
   };
 };

--- a/yak-ops-ui/src/pages/client/index.tsx
+++ b/yak-ops-ui/src/pages/client/index.tsx
@@ -3,6 +3,7 @@ import {
   ClockCircleOutlined,
   CloudServerOutlined,
   DeleteOutlined,
+  DisconnectOutlined,
   EditOutlined,
   ExclamationCircleOutlined,
   EyeOutlined,
@@ -54,6 +55,32 @@ const filters: Array<{ key: WorkerFilter; label: string }> = [
 
 const normalize = (value?: string) => value?.trim().toLowerCase() || '';
 
+const registrationLabel = (worker: LinkupClient) => {
+  if (worker.registrationMode === 'CONFIG') return '配置托管';
+  if (worker.registrationMode === 'DYNAMIC') return '动态注册';
+  return '手工注册';
+};
+
+const leaseMeta = (worker: LinkupClient) => {
+  if (worker.registrationMode !== 'DYNAMIC') return null;
+  if (worker.leaseStatus === 'ACTIVE') {
+    return {
+      label: '租约有效',
+      className: '!border-[#abefc6] !bg-[#ecfdf3] !text-[#067647]',
+    };
+  }
+  if (worker.leaseStatus === 'EXPIRED') {
+    return {
+      label: '租约已过期',
+      className: '!border-[#fecdca] !bg-[#fef3f2] !text-[#b42318]',
+    };
+  }
+  return {
+    label: '租约未知',
+    className: '!border-[#fedf89] !bg-[#fffaeb] !text-[#b54708]',
+  };
+};
+
 const capabilityMeta = (worker: LinkupClient) => {
   if (worker.capabilityStatus === 'READY') {
     return {
@@ -80,6 +107,17 @@ const healthMeta = (worker: LinkupClient) => {
       label: '已禁用',
       dot: 'bg-[#98a2b3]',
       tag: '!border-[#e4e7ec] !bg-[#f2f4f7] !text-[#667085]',
+    };
+  }
+  if (
+    worker.registrationMode === 'DYNAMIC' &&
+    worker.leaseStatus !== 'ACTIVE'
+  ) {
+    return {
+      filter: 'offline' as const,
+      label: worker.leaseStatus === 'EXPIRED' ? '租约已过期' : '租约未就绪',
+      dot: 'bg-[#f04438]',
+      tag: '!border-[#fecdca] !bg-[#fef3f2] !text-[#b42318]',
     };
   }
   if (worker.status === 'UP' && worker.schedulingStatus === 'DRAINING') {
@@ -142,25 +180,32 @@ const WorkerRow = ({
   worker,
   refreshing,
   statusLoading,
+  leaseLoading,
   deleting,
   onRefresh,
   onEdit,
   onStatus,
+  onRevokeLease,
   onDelete,
 }: {
   worker: LinkupClient;
   refreshing: boolean;
   statusLoading: boolean;
+  leaseLoading: boolean;
   deleting: boolean;
   onRefresh: () => void;
   onEdit: () => void;
   onStatus: (status: WorkerSchedulingStatus) => void;
+  onRevokeLease: () => void;
   onDelete: () => void;
 }) => {
   const meta = healthMeta(worker);
   const capability = capabilityMeta(worker);
+  const lease = leaseMeta(worker);
   const loadPercent = Math.round(Math.max(0, Math.min(1, worker.loadRatio || 0)) * 100);
   const configManaged = worker.registrationMode === 'CONFIG';
+  const dynamicManaged = worker.registrationMode === 'DYNAMIC';
+  const activeDynamicLease = dynamicManaged && worker.leaseStatus === 'ACTIVE';
 
   const statusItems: MenuProps['items'] = [
     {
@@ -211,8 +256,13 @@ const WorkerRow = ({
                 <Tag className={`!m-0 !rounded-md !px-2 ${capability.className}`}>
                   {capability.label}
                 </Tag>
+                {lease ? (
+                  <Tag className={`!m-0 !rounded-md !px-2 ${lease.className}`}>
+                    {lease.label}
+                  </Tag>
+                ) : null}
                 <Tag className="!m-0 !rounded-md !border-[#e4e7ec] !bg-[#f8f9fb] !text-[#667085]">
-                  {configManaged ? '配置托管' : '手工注册'}
+                  {registrationLabel(worker)}
                 </Tag>
                 {worker.engineVersion ? (
                   <Tag className="!m-0 !rounded-md !border-[#e4e7ec] !bg-white !text-[#667085]">
@@ -224,6 +274,9 @@ const WorkerRow = ({
               <div className="mt-1 flex flex-wrap gap-x-4 gap-y-1 text-[12px] leading-6 text-[#98a2b3]">
                 <span>nodeId：{worker.nodeId}</span>
                 <span>最近心跳：{formatTime(worker.lastHeartbeatTime)}</span>
+                {dynamicManaged ? (
+                  <span>租约到期：{formatTime(worker.leaseExpiresAt)}</span>
+                ) : null}
                 <span>能力同步：{formatTime(worker.capabilitySyncedAt)}</span>
                 <span>连续失败：{worker.consecutiveFailures || 0}</span>
               </div>
@@ -251,7 +304,9 @@ const WorkerRow = ({
               >
                 详情
               </Button>
-              <Tooltip title="刷新节点心跳与 Connector 能力">
+              <Tooltip
+                title={dynamicManaged ? '读取当前动态注册状态与能力快照' : '刷新节点心跳与 Connector 能力'}
+              >
                 <Button
                   type="text"
                   icon={<ReloadOutlined spin={refreshing} />}
@@ -275,7 +330,21 @@ const WorkerRow = ({
                   状态
                 </Button>
               </Dropdown>
-              {!configManaged ? (
+              {activeDynamicLease ? (
+                <Popconfirm
+                  title="撤销动态注册租约"
+                  description="撤销后节点立即离线；Worker 会重新发起注册，除非同步关闭 Worker 侧动态注册。"
+                  okText="撤销租约"
+                  cancelText="取消"
+                  okButtonProps={{ danger: true, loading: leaseLoading }}
+                  onConfirm={onRevokeLease}
+                >
+                  <Button danger type="text" loading={leaseLoading} icon={<DisconnectOutlined />}>
+                    撤销租约
+                  </Button>
+                </Popconfirm>
+              ) : null}
+              {!configManaged && !activeDynamicLease ? (
                 <Popconfirm
                   title="删除执行节点"
                   description="只删除 Yak Ops 中的登记信息，不会停止 Link-Up 进程。"
@@ -297,7 +366,7 @@ const WorkerRow = ({
               className="mt-3"
               type="error"
               showIcon
-              message="最近一次心跳失败"
+              message={dynamicManaged ? '动态注册状态异常' : '最近一次心跳失败'}
               description={worker.lastErrorMessage}
             />
           ) : null}
@@ -352,6 +421,7 @@ const ClientPage = () => {
     deleteLoadingId,
     refreshLoadingIds,
     statusLoadingIds,
+    leaseLoadingIds,
     form,
     handleOpenCreate,
     handleOpenEdit,
@@ -361,6 +431,7 @@ const ClientPage = () => {
     handleVerifyWorker,
     handleRefreshWorker,
     handleChangeSchedulingStatus,
+    handleRevokeLease,
     loadClients,
   } = useClientPageState();
 
@@ -386,6 +457,9 @@ const ClientPage = () => {
         result.queueCapacity += Number(worker.maxQueuedJobs || 0);
         result.connectors += Number(worker.connectorCount || 0);
         if (worker.available) result.available += 1;
+        if (worker.registrationMode === 'DYNAMIC' && worker.leaseStatus === 'ACTIVE') {
+          result.dynamic += 1;
+        }
         return result;
       },
       {
@@ -394,6 +468,7 @@ const ClientPage = () => {
         queueCapacity: 0,
         connectors: 0,
         available: 0,
+        dynamic: 0,
       },
     );
   }, [clients]);
@@ -409,6 +484,8 @@ const ClientPage = () => {
         worker.baseUrl,
         worker.engineVersion,
         worker.capabilityStatus,
+        worker.registrationMode,
+        worker.leaseStatus,
         JSON.stringify(worker.labels || {}),
       ].some((item) => normalize(item).includes(value));
     });
@@ -424,7 +501,7 @@ const ClientPage = () => {
                 执行节点
               </h1>
               <p className="m-0 mt-1 text-[13px] leading-6 text-[#8a8f99]">
-                管理 Link-Up Worker 的注册、心跳、容量、Connector 能力和调度状态。
+                管理 Link-Up Worker 的手工、配置与动态注册、租约、能力和调度状态。
               </p>
             </div>
             <Space size={8} wrap>
@@ -445,7 +522,7 @@ const ClientPage = () => {
             {[
               { label: '登记节点', value: total, icon: <CloudServerOutlined /> },
               { label: '能力可用', value: summary.available, icon: <CheckCircleOutlined /> },
-              { label: '活跃任务', value: summary.activeJobs, icon: <ClockCircleOutlined /> },
+              { label: '动态租约', value: summary.dynamic, icon: <ClockCircleOutlined /> },
               {
                 label: 'Connector 能力',
                 value: summary.connectors,
@@ -487,9 +564,9 @@ const ClientPage = () => {
                 allowClear
                 variant="filled"
                 prefix={<SearchOutlined className="text-[#98a2b3]" />}
-                placeholder="搜索名称、nodeId、地址、能力状态或标签"
+                placeholder="搜索名称、nodeId、地址、注册模式、租约或标签"
                 value={keyword}
-                className="w-full lg:w-[320px]"
+                className="w-full lg:w-[340px]"
                 onChange={(event) => setKeyword(event.target.value)}
               />
             </div>
@@ -509,12 +586,14 @@ const ClientPage = () => {
                   worker={worker}
                   refreshing={refreshLoadingIds.has(worker.nodeId)}
                   statusLoading={statusLoadingIds.has(worker.nodeId)}
+                  leaseLoading={leaseLoadingIds.has(worker.nodeId)}
                   deleting={deleteLoadingId === worker.nodeId}
                   onRefresh={() => void handleRefreshWorker(worker.nodeId)}
                   onEdit={() => handleOpenEdit(worker)}
                   onStatus={(status) =>
                     void handleChangeSchedulingStatus(worker.nodeId, status)
                   }
+                  onRevokeLease={() => void handleRevokeLease(worker.nodeId)}
                   onDelete={() => void handleDeleteClient(worker)}
                 />
               ))


### PR DESCRIPTION
## 背景

前三阶段已经完成 Worker 管理、多 Worker 调度、Connector 能力调度和 Worker 视角数据源预检。本 PR 完成第四阶段 **动态注册控制面**：Link-Up Worker 启动后可以主动登记、续租、推送运行容量和 Connector 能力，不再要求 Yak Ops 预先配置所有 Worker 地址。

配套 Worker PR：weifuwan/yak-link-up#53。

## 注册模式边界

- `CONFIG`：由 Yak Ops application.yml 管理，Yak Ops 主动探测
- `MANUAL`：由管理页面登记，Yak Ops 主动探测
- `DYNAMIC`：由 Link-Up Worker 签名注册和心跳续租

动态心跳只更新 Worker 拥有的运行事实：地址、instanceId、版本、容量、负载、能力和租约。

Yak Ops 始终拥有：显示名称、标签、调度权重、启用、排空和禁用状态。心跳不会覆盖这些管理员配置。

## 安全协议

新增公开但独立 HMAC 鉴权的接口：

```http
POST /api/v1/offline/worker-registration/register
POST /api/v1/offline/worker-registration/heartbeat
POST /api/v1/offline/worker-registration/deregister
```

请求头：

```text
X-Yak-Registration-Timestamp
X-Yak-Registration-Nonce
X-Yak-Registration-Signature
```

签名原文：

```text
HTTP_METHOD\nREQUEST_URI\nTIMESTAMP_MILLIS\nNONCE\nSHA256(RAW_JSON_BODY)
```

控制面使用 HMAC-SHA256、时间偏差检查和 nonce 一次性消费防止伪造与重放。只有签名正确后才消耗 nonce。

## 租约与实例接管

- 首次注册创建 `DYNAMIC` 节点和 leaseId
- 相同 instanceId 的不确定注册重试复用原租约
- 旧租约有效时，不同 instanceId 使用同一 nodeId 会收到 409
- 旧租约过期后允许新实例接管并创建新 leaseId
- 心跳 sequence 必须严格递增，控制面响应返回当前 sequence 供 Worker 恢复
- 注册和心跳改址都会校验 Worker 地址未被其他 nodeId 占用
- 租约过期或管理员撤销后节点立即不再参与调度
- 过期节点保留在管理页面，不自动删除，便于排障和重新接管
- 有效动态租约不能直接删除，必须先撤销

## 能力与调度

- 动态 Worker 在注册和心跳中推送 Connector 能力快照
- 动态节点能力使用 Push-only 模式，不再被后台 Pull 覆盖
- CONFIG/MANUAL 继续使用原能力拉取机制
- 调度能力匹配阶段直接校验 `lease_expires_at`
- 即使后台过期扫描尚未执行，过期租约也无法进入调度
- 能力摘要只覆盖规范化 Connector 列表，不受进程实例噪声影响

## Flyway V9

Worker 新增：

- `registration_lease_id`
- `registration_instance_id`
- `registration_protocol_version`
- `lease_expires_at`
- `last_registration_time`
- `heartbeat_sequence`

新增表：

- `yak_offline_worker_registration_nonce`：nonce 防重放
- `yak_offline_worker_registration_event`：注册、重试、接管、注销和撤销等低频生命周期审计；普通心跳只更新节点表

## 管理 API

```http
POST /api/v1/offline/workers/{nodeId}/lease/revoke
```

## 前端

- 区分配置托管、手工注册和动态注册
- 展示租约有效、过期和未知状态
- 展示租约到期时间、最近注册时间、心跳序列和协议版本
- 动态节点地址只读，避免页面覆盖 Worker advertised URL
- 列表和详情页支持撤销租约
- 有效租约撤销前隐藏删除操作
- 动态租约失效时明确显示为不可调度

## 配置

动态注册默认关闭：

```yaml
yak:
  sync:
    offline:
      registration:
        enabled: true
        secret: ${YAK_OFFLINE_REGISTRATION_SECRET}
        auto-enable: true
        heartbeat-interval-millis: 20000
        lease-duration-millis: 90000
        clock-skew-millis: 300000
        nonce-retention-millis: 600000
```

生产环境建议使用至少 32 字节随机密钥并启用 HTTPS。

## 测试与审查

新增测试覆盖：

- 注册、心跳和注销路由契约
- 管理侧撤销租约路由
- 固定 HMAC 签名与 body 篡改拒绝
- nonce 重放拒绝
- 新节点动态租约创建与 sequence 恢复元数据
- 活跃旧实例阻止新实例抢占
- 心跳序列必须严格递增
- 过期动态租约拒绝能力调度
- 有效动态租约继续参与能力匹配

同时完成：

- Node upsert 按 34 个字段动态生成占位符，避免 SQL 参数漂移
- CONFIG / MANUAL / DYNAMIC 健康所有权隔离
- 动态能力 Push 与传统 Pull 机制隔离
- 管理设置跨心跳保留
- 动态注册关闭时跳过租约与 nonce 清理扫描

## 发布顺序

1. 先合并并部署本 Yak Ops PR。
2. 配置共享密钥并启用动态注册。
3. 再合并和滚动部署 Link-Up PR #53。
4. 确认动态节点显示“租约有效 / 能力就绪”。
5. 逐步移除不再需要的手工登记节点。

旧 Worker 不受影响，可以继续使用 CONFIG 或 MANUAL 模式。

## 当前验证边界

当前执行环境无法解析 `github.com`，因此未能克隆仓库执行完整 Maven、TypeScript 和生产构建。已完成 Flyway、SQL 参数、Spring 路由、HMAC 原文、事务锁、实例接管、前后端字段和 Java 21 API 的源码级审查；PR 保持 Draft，待 CI 与多 Worker 联调通过后转 Ready。