### PR TITLE
Rename internal HTTP helper to fix duplicate get(String,String)

### DIFF
--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/LinkUpConnectorSchemaClient.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/LinkUpConnectorSchemaClient.java
@@ -45,7 +45,7 @@ public class LinkUpConnectorSchemaClient {
   }
 
   public JsonNode list(String baseUrl) {
-    return get(baseUrl, "/api/v1/connectors");
+    return request(baseUrl, "/api/v1/connectors");
   }
 
   public JsonNode listByRole(String role) {
@@ -53,7 +53,7 @@ public class LinkUpConnectorSchemaClient {
   }
 
   public JsonNode listByRole(String baseUrl, String role) {
-    return get(baseUrl, "/api/v1/connectors?role=" + encodeRole(role));
+    return request(baseUrl, "/api/v1/connectors?role=" + encodeRole(role));
   }
 
   public JsonNode get(String connectorId, String role) {
@@ -64,12 +64,12 @@ public class LinkUpConnectorSchemaClient {
     if (!StringUtils.hasText(connectorId)) {
       throw new IllegalArgumentException("connectorId 不能为空");
     }
-    return get(
+    return request(
         baseUrl,
         "/api/v1/connectors/" + encode(connectorId) + "/schema?role=" + encodeRole(role));
   }
 
-  private JsonNode get(String baseUrl, String path) {
+  private JsonNode request(String baseUrl, String path) {
     requireEnabled();
     String normalized = normalizeBaseUrl(baseUrl);
     HttpRequest request = HttpRequest.newBuilder(URI.create(normalized + path))


### PR DESCRIPTION
### Motivation

- Fix a compile error caused by two methods sharing the same signature `get(String, String)` by removing the conflicting private helper and keeping the public API intact.

### Description

- Rename the internal HTTP helper from `get(String baseUrl, String path)` to `request(String baseUrl, String path)` and update `list`, `listByRole` and the schema lookup to call the renamed helper while preserving the public `get(String connectorId, String role)` API.

### Testing

- Ran `git diff --check` which succeeded, and attempted to compile with `./mvnw -pl yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline -am -DskipTests compile` and `mvn -pl yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline -am -DskipTests compile`, both of which could not complete due to network/Maven Central access returning HTTP 403, preventing a full compile verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6ff4e9f174832682e50f080d83b3a2)