### PR TITLE
fix(offline-sync): align preflight node collation

### DIFF
--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/resources/db/migration/yak-offline-sync/V8__add_worker_capability_scheduling.sql
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/resources/db/migration/yak-offline-sync/V8__add_worker_capability_scheduling.sql
@@ -42,4 +42,4 @@ CREATE TABLE yak_offline_worker_preflight (
         FOREIGN KEY (node_id)
         REFERENCES yak_offline_engine_node (node_id)
         ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;


### PR DESCRIPTION
### Motivation

- Prevent MariaDB/MySQL error 3780 when creating a foreign key from `yak_offline_worker_preflight.node_id` to `yak_offline_engine_node.node_id` by ensuring the new table uses the same collation as the referenced table.

### Description

- Update `V8__add_worker_capability_scheduling.sql` to create `yak_offline_worker_preflight` with `ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci` so `node_id` collation matches `yak_offline_engine_node`.

### Testing

- `git diff --check` completed without issues.
- Running `mvn -pl yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline -am test -DskipTests=false` was attempted but failed to run due to inability to resolve the Spring Boot parent POM from Maven Central (HTTP 403), so the module tests could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6ff9f40b508326a1306cb82108908e)