### PR TITLE
fix(resource): preserve directory ids in JSON

### DIFF
--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/vo/resource/ResourceContentVO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/vo/resource/ResourceContentVO.java
@@ -1,5 +1,7 @@
 package io.yak.ops.common.bean.vo.resource;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 import lombok.Builder;
 import lombok.Data;
 
@@ -8,6 +10,7 @@ import lombok.Data;
 @Builder
 public class ResourceContentVO {
 
+  @JsonSerialize(using = ToStringSerializer.class)
   private Long resourceId;
   private String fullPath;
   private String content;

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/vo/resource/ResourceVO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/vo/resource/ResourceVO.java
@@ -1,5 +1,7 @@
 package io.yak.ops.common.bean.vo.resource;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 import io.yak.ops.common.enums.resource.ResourceNodeType;
 import io.yak.ops.common.enums.resource.ResourceStorageType;
 import java.time.LocalDateTime;
@@ -13,7 +15,9 @@ import lombok.Data;
 @Builder
 public class ResourceVO {
 
+  @JsonSerialize(using = ToStringSerializer.class)
   private Long id;
+  @JsonSerialize(using = ToStringSerializer.class)
   private Long parentId;
   private String name;
   private String fullPath;

--- a/yak-ops-common/src/test/java/io/yak/ops/common/bean/vo/resource/ResourceVOJsonTest.java
+++ b/yak-ops-common/src/test/java/io/yak/ops/common/bean/vo/resource/ResourceVOJsonTest.java
@@ -1,0 +1,42 @@
+package io.yak.ops.common.bean.vo.resource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+class ResourceVOJsonTest {
+
+  private static final long SNOWFLAKE_ID = 1_919_789_105_691_844_609L;
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  @Test
+  void serializesResourceIdentifiersAsStringsWithoutLosingPrecision() throws Exception {
+    ResourceVO resource = ResourceVO.builder()
+        .id(SNOWFLAKE_ID)
+        .parentId(SNOWFLAKE_ID - 1)
+        .fileSize(1024L)
+        .build();
+
+    JsonNode json = objectMapper.valueToTree(resource);
+
+    assertThat(json.get("id").isTextual()).isTrue();
+    assertThat(json.get("id").textValue()).isEqualTo("1919789105691844609");
+    assertThat(json.get("parentId").textValue()).isEqualTo("1919789105691844608");
+    assertThat(json.get("fileSize").isIntegralNumber()).isTrue();
+  }
+
+  @Test
+  void serializesContentResourceIdentifierAsString() {
+    ResourceContentVO content = ResourceContentVO.builder()
+        .resourceId(SNOWFLAKE_ID)
+        .build();
+
+    JsonNode json = objectMapper.valueToTree(content);
+
+    assertThat(json.get("resourceId").isTextual()).isTrue();
+    assertThat(json.get("resourceId").textValue()).isEqualTo("1919789105691844609");
+  }
+}


### PR DESCRIPTION
### Motivation

- 子目录上传和创建时出现“父目录不存在”错误是因为资源使用 Snowflake `Long` ID，JSON 以数字导出时超出 JavaScript 安全整数范围导致精度丢失从而无法匹配父目录 ID。 
- 需要统一资源接口对标识符的精度安全约定以避免前端将目录 ID 四舍五入导致逻辑错误。

### Description

- 将 `ResourceVO` 中的 `id` 与 `parentId` 添加 `@JsonSerialize(using = ToStringSerializer.class)`，确保以字符串形式序列化保留精度（修改文件 `yak-ops-common/src/main/java/io/yak/ops/common/bean/vo/resource/ResourceVO.java`）。
- 将 `ResourceContentVO` 中的 `resourceId` 添加 `@JsonSerialize(using = ToStringSerializer.class)`，使资源内容响应保持相同的精度策略（修改文件 `yak-ops-common/src/main/java/io/yak/ops/common/bean/vo/resource/ResourceContentVO.java`）。
- 新增回归测试 `ResourceVOJsonTest` 来验证超过 JavaScript 安全整数范围的 Snowflake ID 被序列化为字符串且文件大小仍为数值（新增文件 `yak-ops-common/src/test/java/io/yak/ops/common/bean/vo/resource/ResourceVOJsonTest.java`）。

### Testing

- 执行 `git diff --cached --check` 并通过了静态检查。 
- 尝试运行 `./mvnw -pl yak-ops-common -am test` 时因环境无法下载 Maven Wrapper JAR 导致失败。 
- 使用系统 `mvn -pl yak-ops-common -am test` 运行单元测试时因访问 Maven Central 返回 HTTP 403 而无法解析父 POM，导致测试无法在当前环境中执行。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6ffd0dc210832687a17807f104c8d7)