### PR TITLE
refactor(offline-sync): complete multi-table flat definition

### DIFF
--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/OfflineDefinitionModelAdapter.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/OfflineDefinitionModelAdapter.java
@@ -23,6 +23,27 @@ public final class OfflineDefinitionModelAdapter {
       Set.of("SAME_NAME", "PREFIX", "SUFFIX");
   private static final Set<String> WRITE_MODES =
       Set.of("APPEND", "OVERWRITE", "UPSERT");
+  private static final Set<String> JDBC_DATASOURCE_OWNED_FIELDS = Set.of(
+      "url",
+      "jdbcUrl",
+      "jdbc_url",
+      "driver",
+      "driverClassName",
+      "driver_class_name",
+      "username",
+      "user",
+      "password",
+      "passwd",
+      "schema",
+      "dialect",
+      "compatible_mode",
+      "properties",
+      "connectionParams",
+      "connection_params",
+      "connJson",
+      "connection_check_timeout_sec",
+      "connect_timeout_ms",
+      "socket_timeout_ms");
 
   private static final List<String> SOURCE_FIELDS = List.of(
       "database",
@@ -60,6 +81,58 @@ public final class OfflineDefinitionModelAdapter {
     adaptEndpoint(adapted, "source", mode, objectMapper);
     adaptEndpoint(adapted, "sink", mode, objectMapper);
     return adapted;
+  }
+
+  /**
+   * 清理 JDBC 数据源负责维护的连接字段，防止凭据进入 definition_json。
+   * 非 JDBC Connector 的 options 不做处理。
+   */
+  public static void sanitizeForPersistence(ObjectNode definition) {
+    if (definition == null) {
+      return;
+    }
+    sanitizeEndpoint(definition, "source");
+    sanitizeEndpoint(definition, "sink");
+  }
+
+  private static void sanitizeEndpoint(ObjectNode definition, String field) {
+    JsonNode value = definition.get(field);
+    if (value == null || !value.isObject()) {
+      return;
+    }
+    ObjectNode endpoint = (ObjectNode) value;
+    String connectorId;
+    try {
+      connectorId = ConnectorIdResolver.resolve(
+          text(endpoint, "connectorId", null),
+          text(endpoint, "connectorType", null),
+          text(endpoint, "dbType", null),
+          null);
+    } catch (IllegalArgumentException ignored) {
+      return;
+    }
+    if (!ConnectorIdResolver.isJdbc(connectorId)) {
+      return;
+    }
+
+    removeDatasourceOwnedFields(endpoint);
+    JsonNode options = endpoint.get("options");
+    if (options != null && options.isObject()) {
+      removeDatasourceOwnedFields((ObjectNode) options);
+    }
+    JsonNode config = endpoint.get("config");
+    if (config != null && config.isObject()) {
+      ObjectNode configObject = (ObjectNode) config;
+      removeDatasourceOwnedFields(configObject);
+      JsonNode connectorOptions = configObject.get("connectorOptions");
+      if (connectorOptions != null && connectorOptions.isObject()) {
+        removeDatasourceOwnedFields((ObjectNode) connectorOptions);
+      }
+    }
+  }
+
+  private static void removeDatasourceOwnedFields(ObjectNode node) {
+    JDBC_DATASOURCE_OWNED_FIELDS.forEach(node::remove);
   }
 
   private static void adaptEndpoint(
@@ -104,6 +177,10 @@ public final class OfflineDefinitionModelAdapter {
 
   private static void adaptMultiSource(ObjectNode config, ObjectMapper objectMapper) {
     String database = trim(text(config, "database", null));
+    if (!StringUtils.hasText(database)) {
+      throw new IllegalArgumentException("多表同步必须填写来源数据库");
+    }
+
     JsonNode tables = config.get("tables");
     if (tables != null && tables.isArray()) {
       ArrayNode qualified = objectMapper.createArrayNode();
@@ -128,6 +205,10 @@ public final class OfflineDefinitionModelAdapter {
 
   private static void adaptMultiSink(ObjectNode config) {
     String database = trim(text(config, "database", null));
+    if (!StringUtils.hasText(database)) {
+      throw new IllegalArgumentException("多表同步必须填写目标数据库");
+    }
+
     String rule = text(config, "tableNamingRule", "SAME_NAME")
         .trim()
         .toUpperCase(Locale.ROOT);
@@ -161,9 +242,7 @@ public final class OfflineDefinitionModelAdapter {
     } else if ("SUFFIX".equals(rule)) {
       tableTemplate = tableTemplate + suffix;
     }
-    if (StringUtils.hasText(database)) {
-      tableTemplate = database + "." + tableTemplate;
-    }
+    tableTemplate = database + "." + tableTemplate;
 
     config.put("targetTableName", tableTemplate);
     config.put("tableNamingRule", rule.toLowerCase(Locale.ROOT));
@@ -184,7 +263,7 @@ public final class OfflineDefinitionModelAdapter {
   }
 
   private static String qualify(String database, String table) {
-    if (!StringUtils.hasText(database) || table.contains(".")) {
+    if (table.contains(".")) {
       return table;
     }
     return database + "." + table;

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/OfflineDefinitionModelAdapter.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/OfflineDefinitionModelAdapter.java
@@ -1,0 +1,211 @@
+package io.yak.ops.business.sync.offline.engine;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import org.springframework.util.StringUtils;
+
+/**
+ * 将 Yak Ops 对外任务定义转换为 JobSpec 工厂使用的内部配置结构。
+ *
+ * <p>持久化协议保持 basic + source + sink + channel。该适配仅作用于构建副本，
+ * 不会把 config、workflow 或其他执行期结构写回任务定义。</p>
+ *
+ * @author weifuwan
+ */
+public final class OfflineDefinitionModelAdapter {
+
+  private static final Set<String> TABLE_NAMING_RULES =
+      Set.of("SAME_NAME", "PREFIX", "SUFFIX");
+  private static final Set<String> WRITE_MODES =
+      Set.of("APPEND", "OVERWRITE", "UPSERT");
+
+  private static final List<String> SOURCE_FIELDS = List.of(
+      "database",
+      "readMode",
+      "table",
+      "tables",
+      "tablePattern",
+      "sql",
+      "whereCondition",
+      "fetchSize");
+
+  private static final List<String> SINK_FIELDS = List.of(
+      "database",
+      "targetMode",
+      "table",
+      "targetTableName",
+      "tableNamingRule",
+      "tablePrefix",
+      "tableSuffix",
+      "autoCreateTable",
+      "writeMode",
+      "primaryKey",
+      "batchSize",
+      "sql");
+
+  private OfflineDefinitionModelAdapter() {
+  }
+
+  public static JsonNode forJobSpec(JsonNode definition, ObjectMapper objectMapper) {
+    if (definition == null || !definition.isObject()) {
+      return definition;
+    }
+    ObjectNode adapted = (ObjectNode) definition.deepCopy();
+    String mode = text(adapted.path("basic"), "mode", "GUIDE_SINGLE");
+    adaptEndpoint(adapted, "source", mode, objectMapper);
+    adaptEndpoint(adapted, "sink", mode, objectMapper);
+    return adapted;
+  }
+
+  private static void adaptEndpoint(
+      ObjectNode definition,
+      String field,
+      String mode,
+      ObjectMapper objectMapper) {
+    JsonNode value = definition.get(field);
+    if (value == null || !value.isObject()) {
+      return;
+    }
+
+    ObjectNode endpoint = (ObjectNode) value;
+    ObjectNode config = endpoint.path("config").isObject()
+        ? (ObjectNode) endpoint.path("config").deepCopy()
+        : objectMapper.createObjectNode();
+
+    JsonNode options = endpoint.get("options");
+    if (options != null && options.isObject()) {
+      config.set("connectorOptions", options.deepCopy());
+    } else if (!config.path("connectorOptions").isObject()) {
+      config.set("connectorOptions", objectMapper.createObjectNode());
+    }
+
+    List<String> fields = "source".equals(field) ? SOURCE_FIELDS : SINK_FIELDS;
+    for (String key : fields) {
+      copy(endpoint, config, key);
+    }
+    copyManagedOption(config, "fetchSize", "fetch_size");
+    copyManagedOption(config, "batchSize", "batch_size");
+
+    if ("GUIDE_MULTI".equalsIgnoreCase(mode)) {
+      if ("source".equals(field)) {
+        adaptMultiSource(config, objectMapper);
+      } else {
+        adaptMultiSink(config);
+      }
+    }
+
+    endpoint.set("config", config);
+  }
+
+  private static void adaptMultiSource(ObjectNode config, ObjectMapper objectMapper) {
+    String database = trim(text(config, "database", null));
+    JsonNode tables = config.get("tables");
+    if (tables != null && tables.isArray()) {
+      ArrayNode qualified = objectMapper.createArrayNode();
+      for (JsonNode tableNode : tables) {
+        if (!tableNode.isValueNode()) {
+          qualified.add(tableNode.deepCopy());
+          continue;
+        }
+        String table = trim(tableNode.asText(null));
+        if (StringUtils.hasText(table)) {
+          qualified.add(qualify(database, table));
+        }
+      }
+      config.set("tables", qualified);
+    }
+
+    String pattern = trim(text(config, "tablePattern", null));
+    if (StringUtils.hasText(pattern)) {
+      config.put("tablePattern", qualify(database, pattern));
+    }
+  }
+
+  private static void adaptMultiSink(ObjectNode config) {
+    String database = trim(text(config, "database", null));
+    String rule = text(config, "tableNamingRule", "SAME_NAME")
+        .trim()
+        .toUpperCase(Locale.ROOT);
+    if (!TABLE_NAMING_RULES.contains(rule)) {
+      throw new IllegalArgumentException("不支持的目标表命名规则：" + rule);
+    }
+
+    String prefix = text(config, "tablePrefix", "").trim();
+    String suffix = text(config, "tableSuffix", "").trim();
+    if ("PREFIX".equals(rule) && !StringUtils.hasText(prefix)) {
+      throw new IllegalArgumentException("目标表命名规则为 PREFIX 时必须填写 tablePrefix");
+    }
+    if ("SUFFIX".equals(rule) && !StringUtils.hasText(suffix)) {
+      throw new IllegalArgumentException("目标表命名规则为 SUFFIX 时必须填写 tableSuffix");
+    }
+
+    String writeMode = text(config, "writeMode", "APPEND")
+        .trim()
+        .toUpperCase(Locale.ROOT);
+    if (!WRITE_MODES.contains(writeMode)) {
+      throw new IllegalArgumentException("不支持的多表写入模式：" + writeMode);
+    }
+    if ("UPSERT".equals(writeMode)
+        && !StringUtils.hasText(text(config, "primaryKey", null))) {
+      throw new IllegalArgumentException("UPSERT 写入模式必须配置主键字段");
+    }
+
+    String tableTemplate = "${table_name}";
+    if ("PREFIX".equals(rule)) {
+      tableTemplate = prefix + tableTemplate;
+    } else if ("SUFFIX".equals(rule)) {
+      tableTemplate = tableTemplate + suffix;
+    }
+    if (StringUtils.hasText(database)) {
+      tableTemplate = database + "." + tableTemplate;
+    }
+
+    config.put("targetTableName", tableTemplate);
+    config.put("tableNamingRule", rule.toLowerCase(Locale.ROOT));
+    config.put("writeMode", writeMode.toLowerCase(Locale.ROOT));
+  }
+
+  private static void copyManagedOption(
+      ObjectNode config,
+      String configField,
+      String optionField) {
+    if (config.hasNonNull(configField)) {
+      return;
+    }
+    JsonNode value = config.path("connectorOptions").get(optionField);
+    if (value != null && !value.isNull()) {
+      config.set(configField, value.deepCopy());
+    }
+  }
+
+  private static String qualify(String database, String table) {
+    if (!StringUtils.hasText(database) || table.contains(".")) {
+      return table;
+    }
+    return database + "." + table;
+  }
+
+  private static void copy(ObjectNode source, ObjectNode target, String field) {
+    JsonNode value = source.get(field);
+    if (value != null && !value.isNull()) {
+      target.set(field, value.deepCopy());
+    }
+  }
+
+  private static String text(JsonNode node, String field, String fallback) {
+    JsonNode value = node == null ? null : node.get(field);
+    if (value == null || value.isNull() || !value.isValueNode()) {
+      return fallback;
+    }
+    return value.asText(fallback);
+  }
+
+  private static String trim(String value) {
+    return StringUtils.hasText(value) ? value.trim() : null;
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineDefinitionSupport.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineDefinitionSupport.java
@@ -230,6 +230,7 @@ public class OfflineDefinitionSupport {
     normalizeEndpoint(request, "source");
     normalizeEndpoint(request, "sink");
     normalizeChannel(request);
+    OfflineDefinitionModelAdapter.sanitizeForPersistence(request);
     return request;
   }
 

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineDefinitionSupport.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineDefinitionSupport.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.yak.ops.business.datasource.dao.DataSourceDao;
 import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
 import io.yak.ops.business.sync.offline.engine.LinkUpJobSpecFactory;
+import io.yak.ops.business.sync.offline.engine.OfflineDefinitionModelAdapter;
 import io.yak.ops.business.sync.offline.form.ConnectorFormValidationService;
 import io.yak.ops.business.sync.offline.form.ConnectorFormValidationService.ValidationRequest;
 import io.yak.ops.business.sync.offline.form.ConnectorFormValidationService.ValidationResult;
@@ -62,7 +63,8 @@ public class OfflineDefinitionSupport {
     JsonNode basic = request.path("basic");
     String name = requiredText(basic, "jobName", "任务名称不能为空");
     String mode = mode(basic);
-    LinkUpJobSpecFactory.BuildResult buildResult = jobSpecFactory.build(request);
+    JsonNode buildRequest = OfflineDefinitionModelAdapter.forJobSpec(request, objectMapper);
+    LinkUpJobSpecFactory.BuildResult buildResult = jobSpecFactory.build(buildRequest);
     validateEndpoint(
         buildResult.getSourceConnectorId(),
         "SOURCE",
@@ -114,7 +116,8 @@ public class OfflineDefinitionSupport {
     if (parsed == null || !parsed.isObject()) {
       throw new IllegalStateException("任务定义 JSON 已损坏");
     }
-    LinkUpJobSpecFactory.BuildResult result = jobSpecFactory.build(parsed);
+    JsonNode buildRequest = OfflineDefinitionModelAdapter.forJobSpec(parsed, objectMapper);
+    LinkUpJobSpecFactory.BuildResult result = jobSpecFactory.build(buildRequest);
     validateEndpoint(
         result.getSourceConnectorId(),
         "SOURCE",
@@ -233,12 +236,13 @@ public class OfflineDefinitionSupport {
   private void normalizeEndpoint(ObjectNode request, String field) {
     JsonNode value = request.get(field);
     requireObject(value, field + " 配置不能为空");
-    ObjectNode endpoint = (ObjectNode) value;
-    JsonNode config = endpoint.get("config");
-    if (config == null || config.isNull()) {
-      endpoint.set("config", objectMapper.createObjectNode());
-    } else {
+    JsonNode config = value.get("config");
+    if (config != null && !config.isNull()) {
       requireObject(config, field + ".config 必须是 JSON 对象");
+    }
+    JsonNode options = value.get("options");
+    if (options != null && !options.isNull()) {
+      requireObject(options, field + ".options 必须是 JSON 对象");
     }
   }
 
@@ -254,7 +258,7 @@ public class OfflineDefinitionSupport {
     putDefault(channel, "parallelism", 1);
     putDefault(channel, "speedLimitEnabled", false);
     putDefault(channel, "recordsPerSecond", 10000L);
-    putDefault(channel, "dirtyDataPolicy", "stop");
+    putDefault(channel, "dirtyDataPolicy", "STOP");
     putDefault(channel, "dirtyDataLimit", 0L);
   }
 

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/engine/LinkUpJobSpecFactoryTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/engine/LinkUpJobSpecFactoryTest.java
@@ -93,6 +93,77 @@ class LinkUpJobSpecFactoryTest {
   }
 
   @Test
+  void shouldBuildMultiTableJobSpecFromPublicPayload() throws Exception {
+    DataSourceDao dao = mock(DataSourceDao.class);
+    when(dao.selectById(1001L)).thenReturn(dataSource(1001L, "source", "source-secret"));
+    when(dao.selectById(1002L)).thenReturn(dataSource(1002L, "sink", "sink-secret"));
+
+    JsonNode definition = mapper.readTree("""
+        {
+          "basic": {
+            "jobName": "业务库批量同步",
+            "jobDesc": "",
+            "mode": "GUIDE_MULTI"
+          },
+          "source": {
+            "connectorId": "jdbc",
+            "dbType": "MYSQL",
+            "dataSourceId": "1001",
+            "database": "business",
+            "tables": ["orders", "order_item", "customer"],
+            "tablePattern": "",
+            "options": {"fetch_size": 500}
+          },
+          "sink": {
+            "connectorId": "jdbc",
+            "dbType": "MYSQL",
+            "dataSourceId": "1002",
+            "database": "ods",
+            "tableNamingRule": "SAME_NAME",
+            "tablePrefix": "",
+            "tableSuffix": "",
+            "autoCreateTable": true,
+            "writeMode": "APPEND",
+            "options": {"batch_size": 1000}
+          },
+          "channel": {
+            "parallelism": 3,
+            "speedLimitEnabled": false,
+            "recordsPerSecond": 10000,
+            "dirtyDataPolicy": "STOP",
+            "dirtyDataLimit": 0
+          }
+        }
+        """);
+
+    JsonNode buildDefinition = OfflineDefinitionModelAdapter.forJobSpec(definition, mapper);
+    LinkUpJobSpecFactory.BuildResult result =
+        new LinkUpJobSpecFactory(dao, mapper).build(buildDefinition);
+    JsonNode logical = result.getJobSpec();
+
+    assertThat(logical.path("source").path("options").path("table_list").size())
+        .isEqualTo(3);
+    assertThat(logical.path("source").path("options").path("table_list")
+        .get(0).path("table_path").asText())
+        .isEqualTo("business.orders");
+    assertThat(logical.path("source").path("options").path("fetch_size").asInt())
+        .isEqualTo(500);
+    assertThat(logical.path("sink").path("options").path("table_path").asText())
+        .isEqualTo("ods.${table_name}");
+    assertThat(logical.path("sink").path("options").path("batch_size").asInt())
+        .isEqualTo(1000);
+    assertThat(logical.path("sink").path("options").path("schema_save_mode").asText())
+        .isEqualTo("CREATE_SCHEMA_WHEN_NOT_EXIST");
+    assertThat(logical.path("sink").path("options").path("dirty_data_policy").asText())
+        .isEqualTo("FAIL_FAST");
+    assertThat(logical.path("runtime").path("pipelineParallelism").asInt())
+        .isEqualTo(3);
+    assertThat(logical.path("runtime").has("maxRecordsPerSecond")).isFalse();
+    assertThat(result.getSourceTable()).contains("business.orders", "business.customer");
+    assertThat(result.getSinkTable()).contains("ods.orders", "ods.customer");
+  }
+
+  @Test
   void shouldPassThroughFutureConnectorOptionsWithoutDedicatedBuilder() throws Exception {
     DataSourceDao dao = mock(DataSourceDao.class);
     JsonNode definition = mapper.readTree("""

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/engine/OfflineDefinitionModelAdapterTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/engine/OfflineDefinitionModelAdapterTest.java
@@ -1,0 +1,123 @@
+package io.yak.ops.business.sync.offline.engine;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+class OfflineDefinitionModelAdapterTest {
+
+  private final ObjectMapper mapper = new ObjectMapper();
+
+  @Test
+  void shouldAdaptMultiTableDefinitionWithoutMutatingPersistedContract() throws Exception {
+    JsonNode definition = mapper.readTree("""
+        {
+          "basic": {
+            "jobName": "业务库批量同步",
+            "jobDesc": "",
+            "mode": "GUIDE_MULTI"
+          },
+          "source": {
+            "connectorId": "jdbc",
+            "dbType": "MYSQL",
+            "dataSourceId": "1001",
+            "database": "business",
+            "tables": ["orders", "order_item", "customer"],
+            "tablePattern": "",
+            "options": {"fetch_size": 500}
+          },
+          "sink": {
+            "connectorId": "jdbc",
+            "dbType": "MYSQL",
+            "dataSourceId": "1002",
+            "database": "ods",
+            "tableNamingRule": "PREFIX",
+            "tablePrefix": "dw_",
+            "tableSuffix": "",
+            "autoCreateTable": true,
+            "writeMode": "APPEND",
+            "options": {"batch_size": 1000}
+          },
+          "channel": {
+            "parallelism": 3,
+            "speedLimitEnabled": false,
+            "recordsPerSecond": 10000,
+            "dirtyDataPolicy": "STOP",
+            "dirtyDataLimit": 0
+          }
+        }
+        """);
+
+    JsonNode adapted = OfflineDefinitionModelAdapter.forJobSpec(definition, mapper);
+
+    assertThat(definition.path("source").has("config")).isFalse();
+    assertThat(definition.path("sink").has("config")).isFalse();
+    assertThat(definition.path("source").path("tables").get(0).asText())
+        .isEqualTo("orders");
+
+    assertThat(adapted.path("source").path("config").path("tables").get(0).asText())
+        .isEqualTo("business.orders");
+    assertThat(adapted.path("source").path("config")
+        .path("connectorOptions").path("fetch_size").asInt())
+        .isEqualTo(500);
+    assertThat(adapted.path("source").path("config").path("fetchSize").asInt())
+        .isEqualTo(500);
+    assertThat(adapted.path("sink").path("config").path("targetTableName").asText())
+        .isEqualTo("ods.dw_${table_name}");
+    assertThat(adapted.path("sink").path("config").path("batchSize").asInt())
+        .isEqualTo(1000);
+    assertThat(adapted.path("sink").path("config").path("autoCreateTable").asBoolean())
+        .isTrue();
+    assertThat(adapted.path("sink").path("config").path("writeMode").asText())
+        .isEqualTo("append");
+    assertThat(adapted.path("channel").path("parallelism").asInt()).isEqualTo(3);
+  }
+
+  @Test
+  void shouldRejectIncompleteMultiTableNamingConfiguration() throws Exception {
+    JsonNode definition = mapper.readTree("""
+        {
+          "basic": {"jobName": "invalid", "mode": "GUIDE_MULTI"},
+          "source": {
+            "connectorId": "jdbc",
+            "database": "business",
+            "tables": ["orders"]
+          },
+          "sink": {
+            "connectorId": "jdbc",
+            "database": "ods",
+            "tableNamingRule": "PREFIX",
+            "tablePrefix": "",
+            "writeMode": "APPEND"
+          },
+          "channel": {"parallelism": 1}
+        }
+        """);
+
+    assertThatThrownBy(() -> OfflineDefinitionModelAdapter.forJobSpec(definition, mapper))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("tablePrefix");
+  }
+
+  @Test
+  void shouldKeepLegacyWorkflowDefinitionUntouched() throws Exception {
+    JsonNode definition = mapper.readTree("""
+        {
+          "basic": {"jobName": "legacy", "mode": "GUIDE_SINGLE"},
+          "workflow": {
+            "nodes": [
+              {"data": {"nodeType": "source", "config": {"table": "orders"}}},
+              {"data": {"nodeType": "sink", "config": {"table": "orders"}}}
+            ]
+          }
+        }
+        """);
+
+    JsonNode adapted = OfflineDefinitionModelAdapter.forJobSpec(definition, mapper);
+
+    assertThat(adapted).isEqualTo(definition);
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/engine/OfflineDefinitionModelAdapterTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/engine/OfflineDefinitionModelAdapterTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.junit.jupiter.api.Test;
 
 class OfflineDefinitionModelAdapterTest {
@@ -100,6 +101,71 @@ class OfflineDefinitionModelAdapterTest {
     assertThatThrownBy(() -> OfflineDefinitionModelAdapter.forJobSpec(definition, mapper))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("tablePrefix");
+  }
+
+  @Test
+  void shouldRejectMultiTableDefinitionWithoutDatabase() throws Exception {
+    JsonNode definition = mapper.readTree("""
+        {
+          "basic": {"jobName": "invalid", "mode": "GUIDE_MULTI"},
+          "source": {
+            "connectorId": "jdbc",
+            "database": "",
+            "tables": ["orders"]
+          },
+          "sink": {
+            "connectorId": "jdbc",
+            "database": "ods",
+            "tableNamingRule": "SAME_NAME",
+            "writeMode": "APPEND"
+          }
+        }
+        """);
+
+    assertThatThrownBy(() -> OfflineDefinitionModelAdapter.forJobSpec(definition, mapper))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("来源数据库");
+  }
+
+  @Test
+  void shouldStripJdbcDatasourceFieldsButKeepConnectorOptions() throws Exception {
+    ObjectNode definition = (ObjectNode) mapper.readTree("""
+        {
+          "source": {
+            "connectorId": "jdbc",
+            "dbType": "MYSQL",
+            "options": {
+              "url": "jdbc:mysql://127.0.0.1/demo",
+              "username": "root",
+              "password": "secret",
+              "fetch_size": 500,
+              "partition_column": "id"
+            }
+          },
+          "sink": {
+            "connectorId": "http",
+            "dbType": "HTTP",
+            "options": {
+              "url": "https://example.test/result",
+              "password": "http-token"
+            }
+          }
+        }
+        """);
+
+    OfflineDefinitionModelAdapter.sanitizeForPersistence(definition);
+
+    JsonNode jdbcOptions = definition.path("source").path("options");
+    assertThat(jdbcOptions.has("url")).isFalse();
+    assertThat(jdbcOptions.has("username")).isFalse();
+    assertThat(jdbcOptions.has("password")).isFalse();
+    assertThat(jdbcOptions.path("fetch_size").asInt()).isEqualTo(500);
+    assertThat(jdbcOptions.path("partition_column").asText()).isEqualTo("id");
+
+    JsonNode httpOptions = definition.path("sink").path("options");
+    assertThat(httpOptions.path("url").asText())
+        .isEqualTo("https://example.test/result");
+    assertThat(httpOptions.path("password").asText()).isEqualTo("http-token");
   }
 
   @Test

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/dto/sync/offline/OfflineJobChannelDTO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/dto/sync/offline/OfflineJobChannelDTO.java
@@ -17,6 +17,6 @@ public class OfflineJobChannelDTO {
   private Integer parallelism = 1;
   private Boolean speedLimitEnabled = false;
   private Long recordsPerSecond = 10000L;
-  private String dirtyDataPolicy = "stop";
+  private String dirtyDataPolicy = "STOP";
   private Long dirtyDataLimit = 0L;
 }

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/dto/sync/offline/OfflineJobEndpointDTO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/dto/sync/offline/OfflineJobEndpointDTO.java
@@ -3,10 +3,14 @@ package io.yak.ops.common.bean.dto.sync.offline;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.JsonNode;
+import java.util.List;
 import lombok.Data;
 
 /**
  * 离线同步 Source 或 Sink 端点配置。
+ *
+ * <p>公共连接信息位于端点根节点；单表模式暂时保留 config，
+ * 多表模式使用 database、tables、命名规则和 options 等明确字段。</p>
  *
  * @author weifuwan
  */
@@ -19,5 +23,30 @@ public class OfflineJobEndpointDTO {
   private String pluginName;
   private String dbType;
   private String dataSourceId;
+
+  /** 单表同步以及旧版本兼容配置。 */
   private JsonNode config;
+
+  /** Connector 动态扩展参数，不包含 Yak Ops 管理的标准字段。 */
+  private JsonNode options;
+
+  /** 多表同步来源库或目标库。 */
+  private String database;
+
+  /** 多表同步来源表列表。 */
+  private List<String> tables;
+
+  /** 多表同步来源表过滤规则。 */
+  private String tablePattern;
+
+  /** SAME_NAME、PREFIX 或 SUFFIX。 */
+  private String tableNamingRule;
+
+  private String tablePrefix;
+  private String tableSuffix;
+  private Boolean autoCreateTable;
+  private String writeMode;
+
+  /** UPSERT 模式使用，多个字段使用英文逗号分隔。 */
+  private String primaryKey;
 }

--- a/yak-ops-ui/src/pages/batch-link-up/detail/components/ChannelConfigSection.tsx
+++ b/yak-ops-ui/src/pages/batch-link-up/detail/components/ChannelConfigSection.tsx
@@ -46,7 +46,7 @@ export default function ChannelConfigSection({
 
   return (
     <EditorSection title="运行参数">
-      <div className="grid grid-cols-4 gap-4 max-lg:grid-cols-2 max-sm:grid-cols-1">
+      <div className="grid grid-cols-3 gap-4 max-lg:grid-cols-2 max-sm:grid-cols-1">
         <Field label="Channel 并发数">
           <InputNumber
             min={1}
@@ -107,6 +107,37 @@ export default function ChannelConfigSection({
             onChange={(recordsPerSecond) =>
               updateChannel({
                 recordsPerSecond: Number(recordsPerSecond || 10000),
+              })
+            }
+          />
+        </Field>
+
+        <Field label="脏数据策略">
+          <Select
+            variant="filled"
+            value={editor.channel.dirtyDataPolicy}
+            options={[
+              { label: '遇错停止', value: 'stop' },
+              { label: '跳过并继续', value: 'skip' },
+            ]}
+            className="w-full"
+            onChange={(dirtyDataPolicy) =>
+              updateChannel({ dirtyDataPolicy })
+            }
+          />
+        </Field>
+
+        <Field label="脏数据上限">
+          <InputNumber
+            min={0}
+            max={10000000}
+            variant="filled"
+            disabled={editor.channel.dirtyDataPolicy !== 'skip'}
+            className="!w-full"
+            value={Number(editor.channel.dirtyDataLimit || 0)}
+            onChange={(dirtyDataLimit) =>
+              updateChannel({
+                dirtyDataLimit: Math.max(0, Number(dirtyDataLimit || 0)),
               })
             }
           />

--- a/yak-ops-ui/src/pages/batch-link-up/detail/components/MultiTableConfigSection.tsx
+++ b/yak-ops-ui/src/pages/batch-link-up/detail/components/MultiTableConfigSection.tsx
@@ -99,8 +99,9 @@ export default function MultiTableConfigSection({
   onSourceChange,
   onSinkChange,
 }: MultiTableConfigSectionProps) {
-  const tableNamingRule =
-    sinkConfig.tableNamingRule || 'same_name';
+  const tableNamingRule = String(
+    sinkConfig.tableNamingRule || 'same_name',
+  ).toLowerCase();
 
   const selectedTables = useMemo(
     () =>
@@ -129,8 +130,24 @@ export default function MultiTableConfigSection({
         <EndpointPanel
           icon={<DatabaseOutlined />}
           title="Source 来源配置"
-          description="从来源数据源中批量选择需要同步的数据表。"
+          description="从来源数据库中批量选择需要同步的数据表。"
         >
+          <div>
+            <FieldLabel required>来源数据库</FieldLabel>
+            <Input
+              variant="filled"
+              disabled={!sourceReady}
+              value={sourceConfig.database || ''}
+              placeholder="例如：business"
+              onChange={(event) =>
+                onSourceChange({ database: event.target.value })
+              }
+            />
+            <div className="mt-1.5 text-[11px] leading-5 text-[#98a2b3]">
+              用于补全未携带库名前缀的来源表。
+            </div>
+          </div>
+
           <div>
             <div className="mb-2 flex items-center justify-between gap-3">
               <div className="text-[12px] font-medium text-[#475467]">
@@ -186,14 +203,9 @@ export default function MultiTableConfigSection({
                 </span>
               )}
               className="w-full"
-              onChange={(targetKeys) => {
-                const tables = targetKeys.map(String);
-
-                onSourceChange({
-                  tables,
-                  table: tables[0] || '',
-                });
-              }}
+              onChange={(targetKeys) =>
+                onSourceChange({ tables: targetKeys.map(String) })
+              }
             />
           </div>
 
@@ -203,16 +215,14 @@ export default function MultiTableConfigSection({
               variant="filled"
               disabled={!sourceReady}
               value={sourceConfig.tablePattern || ''}
-              placeholder="可选，例如：ods_*"
+              placeholder="可选，例如：orders_*"
               onChange={(event) =>
-                onSourceChange({
-                  tablePattern: event.target.value,
-                })
+                onSourceChange({ tablePattern: event.target.value })
               }
             />
 
             <div className="mt-1.5 text-[11px] leading-5 text-[#98a2b3]">
-              可选；用于按表名规则批量匹配来源表。
+              用于记录筛选规则；当前仍需在上方确认实际同步表。
             </div>
           </div>
 
@@ -222,13 +232,24 @@ export default function MultiTableConfigSection({
         <EndpointPanel
           icon={<ExportOutlined />}
           title="Sink 目标配置"
-          description="统一配置目标表命名规则、建表方式和写入策略。"
+          description="统一配置目标数据库、表名规则、建表方式和写入策略。"
         >
+          <div>
+            <FieldLabel required>目标数据库</FieldLabel>
+            <Input
+              variant="filled"
+              disabled={!targetReady}
+              value={sinkConfig.database || ''}
+              placeholder="例如：ods"
+              onChange={(event) =>
+                onSinkChange({ database: event.target.value })
+              }
+            />
+          </div>
+
           <div className="flex items-center justify-between rounded-lg bg-[#f5f5f6] px-3.5 py-3">
-            <div>
-              <div className="text-[12px] font-medium text-[#475467]">
-                自动创建目标表
-              </div>
+            <div className="text-[12px] font-medium text-[#475467]">
+              自动创建目标表
             </div>
 
             <Switch
@@ -257,26 +278,31 @@ export default function MultiTableConfigSection({
             />
           </div>
 
-          {tableNamingRule !== 'same_name' ? (
+          {tableNamingRule === 'prefix' ? (
             <div>
-              <FieldLabel required>
-                {tableNamingRule === 'prefix'
-                  ? '目标表名前缀'
-                  : '目标表名后缀'}
-              </FieldLabel>
+              <FieldLabel required>目标表名前缀</FieldLabel>
               <Input
                 variant="filled"
                 disabled={!targetReady}
-                value={sinkConfig.tableNameAffix || ''}
-                placeholder={
-                  tableNamingRule === 'prefix'
-                    ? '例如：dw_'
-                    : '例如：_bak'
-                }
+                value={sinkConfig.tablePrefix || ''}
+                placeholder="例如：dw_"
                 onChange={(event) =>
-                  onSinkChange({
-                    tableNameAffix: event.target.value,
-                  })
+                  onSinkChange({ tablePrefix: event.target.value })
+                }
+              />
+            </div>
+          ) : null}
+
+          {tableNamingRule === 'suffix' ? (
+            <div>
+              <FieldLabel required>目标表名后缀</FieldLabel>
+              <Input
+                variant="filled"
+                disabled={!targetReady}
+                value={sinkConfig.tableSuffix || ''}
+                placeholder="例如：_bak"
+                onChange={(event) =>
+                  onSinkChange({ tableSuffix: event.target.value })
                 }
               />
             </div>
@@ -286,7 +312,7 @@ export default function MultiTableConfigSection({
             <FieldLabel required>写入模式</FieldLabel>
             <Select
               variant="filled"
-              value={sinkConfig.writeMode || 'append'}
+              value={String(sinkConfig.writeMode || 'append').toLowerCase()}
               options={[
                 { label: '追加写入 Append', value: 'append' },
                 { label: '覆盖写入 Overwrite', value: 'overwrite' },
@@ -299,7 +325,7 @@ export default function MultiTableConfigSection({
             />
           </div>
 
-          {sinkConfig.writeMode === 'upsert' ? (
+          {String(sinkConfig.writeMode || '').toLowerCase() === 'upsert' ? (
             <div>
               <FieldLabel required>主键字段</FieldLabel>
               <Input

--- a/yak-ops-ui/src/pages/batch-link-up/detail/components/SyncTaskEditor.tsx
+++ b/yak-ops-ui/src/pages/batch-link-up/detail/components/SyncTaskEditor.tsx
@@ -33,10 +33,9 @@ const SINK_MANAGED_KEYS = [
   'write_mode',
   'primary_keys',
   'batch_size',
+  'dirty_data_policy',
+  'dirty_data_max_count',
 ];
-
-const hasOwn = (value: Record<string, any>, key: string) =>
-  Object.prototype.hasOwnProperty.call(value, key);
 
 export default function SyncTaskEditor({
   editor,
@@ -74,30 +73,7 @@ export default function SyncTaskEditor({
   };
 
   const updateSink = (patch: Record<string, any>) => {
-    let nextEditor = updateEndpointConfig(editor, 'sink', patch);
-    const channelPatch: Partial<SyncEditorState['channel']> = {};
-
-    if (hasOwn(patch, 'dirtyDataPolicy')) {
-      channelPatch.dirtyDataPolicy =
-        patch.dirtyDataPolicy === 'SKIP' ? 'skip' : 'stop';
-    }
-    if (hasOwn(patch, 'dirtyDataMaxCount')) {
-      channelPatch.dirtyDataLimit = Number(
-        patch.dirtyDataMaxCount || 0,
-      );
-    }
-
-    if (Object.keys(channelPatch).length > 0) {
-      nextEditor = {
-        ...nextEditor,
-        channel: {
-          ...nextEditor.channel,
-          ...channelPatch,
-        },
-      };
-    }
-
-    onChange(nextEditor);
+    onChange(updateEndpointConfig(editor, 'sink', patch));
   };
 
   const sourceConnectorId =

--- a/yak-ops-ui/src/pages/batch-link-up/detail/index.tsx
+++ b/yak-ops-ui/src/pages/batch-link-up/detail/index.tsx
@@ -44,15 +44,28 @@ const validateTaskConfig = (
   const sink = editor.sink.config || {};
 
   if (editor.mode === 'GUIDE_MULTI') {
-    if (!source.tables?.length && !source.tablePattern?.trim()) {
-      return '请选择来源表，或填写表名过滤规则';
+    if (!source.database?.trim()) {
+      return '请输入来源数据库';
     }
 
-    if (
-      sink.tableNamingRule !== 'same_name' &&
-      !sink.tableNameAffix?.trim()
-    ) {
-      return '请填写目标表名前缀或后缀';
+    if (!source.tables?.length) {
+      return source.tablePattern?.trim()
+        ? '表名过滤规则暂不能直接执行，请确认并选择实际来源表'
+        : '请选择至少一张来源表';
+    }
+
+    if (!sink.database?.trim()) {
+      return '请输入目标数据库';
+    }
+
+    const tableNamingRule = String(
+      sink.tableNamingRule || 'same_name',
+    ).toLowerCase();
+    if (tableNamingRule === 'prefix' && !sink.tablePrefix?.trim()) {
+      return '请填写目标表名前缀';
+    }
+    if (tableNamingRule === 'suffix' && !sink.tableSuffix?.trim()) {
+      return '请填写目标表名后缀';
     }
   } else if (source.readMode === 'sql') {
     if (!source.sql?.trim()) {
@@ -72,12 +85,22 @@ const validateTaskConfig = (
     }
   }
 
-  if (sink.writeMode === 'upsert' && !sink.primaryKey?.trim()) {
+  if (
+    String(sink.writeMode || '').toLowerCase() === 'upsert' &&
+    !sink.primaryKey?.trim()
+  ) {
     return 'Upsert 写入模式需要配置主键字段';
   }
 
   if (!editor.channel.parallelism || editor.channel.parallelism < 1) {
     return 'Channel 并发数必须大于 0';
+  }
+
+  if (
+    editor.channel.dirtyDataPolicy === 'skip' &&
+    editor.channel.dirtyDataLimit < 0
+  ) {
+    return '脏数据上限不能小于 0';
   }
 
   return null;

--- a/yak-ops-ui/src/pages/batch-link-up/detail/model.ts
+++ b/yak-ops-ui/src/pages/batch-link-up/detail/model.ts
@@ -94,22 +94,73 @@ const endpointFromType = (
   };
 };
 
+const serializeChannel = (channel: SyncChannel) => ({
+  parallelism: Math.max(1, Number(channel.parallelism || 1)),
+  speedLimitEnabled: Boolean(channel.speedLimitEnabled),
+  recordsPerSecond: Math.max(1, Number(channel.recordsPerSecond || 10000)),
+  dirtyDataPolicy: channel.dirtyDataPolicy === 'skip' ? 'SKIP' : 'STOP',
+  dirtyDataLimit: Math.max(0, Number(channel.dirtyDataLimit || 0)),
+});
+
+const multiDraftEndpoint = (
+  endpoint: SyncEndpoint,
+  kind: EndpointKind,
+) =>
+  kind === 'source'
+    ? {
+        connectorId: endpoint.connectorId,
+        dbType: endpoint.dbType,
+        dataSourceId: '',
+        database: '',
+        tables: [] as string[],
+        tablePattern: '',
+        options: {},
+      }
+    : {
+        connectorId: endpoint.connectorId,
+        dbType: endpoint.dbType,
+        dataSourceId: '',
+        database: '',
+        tableNamingRule: 'SAME_NAME',
+        tablePrefix: '',
+        tableSuffix: '',
+        autoCreateTable: true,
+        writeMode: 'APPEND',
+        options: {},
+      };
+
 export const buildCreatePayload = (
   taskId: string,
   values: CreateSyncTaskValues,
   source: CreateSyncEndpoint,
   sink: CreateSyncEndpoint,
-) => ({
-  id: taskId,
-  basic: {
+) => {
+  const sourceEndpoint = endpointFromType(source);
+  const sinkEndpoint = endpointFromType(sink);
+  const basic = {
     jobName: values.jobName.trim(),
     jobDesc: values.jobDesc?.trim() || '',
     mode: values.mode,
-  },
-  source: endpointFromType(source),
-  sink: endpointFromType(sink),
-  channel: DEFAULT_CHANNEL_CONFIG,
-});
+  };
+
+  if (values.mode === 'GUIDE_MULTI') {
+    return {
+      id: taskId,
+      basic,
+      source: multiDraftEndpoint(sourceEndpoint, 'source'),
+      sink: multiDraftEndpoint(sinkEndpoint, 'sink'),
+      channel: serializeChannel(DEFAULT_CHANNEL_CONFIG),
+    };
+  }
+
+  return {
+    id: taskId,
+    basic,
+    source: sourceEndpoint,
+    sink: sinkEndpoint,
+    channel: DEFAULT_CHANNEL_CONFIG,
+  };
+};
 
 const legacyEndpoint = (
   raw: any,
@@ -158,6 +209,79 @@ const legacyEndpoint = (
   };
 };
 
+const directConfig = (
+  value: Record<string, any>,
+  kind: EndpointKind,
+): Record<string, any> => {
+  const config =
+    value?.config && typeof value.config === 'object'
+      ? { ...value.config }
+      : {};
+  const options =
+    value?.options && typeof value.options === 'object'
+      ? value.options
+      : config.connectorOptions || {};
+
+  const keys = kind === 'source'
+    ? [
+        'database',
+        'readMode',
+        'table',
+        'tables',
+        'tablePattern',
+        'sql',
+        'whereCondition',
+        'fetchSize',
+      ]
+    : [
+        'database',
+        'targetMode',
+        'table',
+        'targetTableName',
+        'tableNamingRule',
+        'tablePrefix',
+        'tableSuffix',
+        'autoCreateTable',
+        'writeMode',
+        'primaryKey',
+        'batchSize',
+        'sql',
+      ];
+
+  for (const key of keys) {
+    if (value?.[key] !== undefined) {
+      config[key] = value[key];
+    }
+  }
+
+  if (typeof config.tableNamingRule === 'string') {
+    config.tableNamingRule = config.tableNamingRule.toLowerCase();
+  }
+  if (typeof config.writeMode === 'string') {
+    config.writeMode = config.writeMode.toLowerCase();
+  }
+
+  if (config.tableNameAffix && !config.tablePrefix && !config.tableSuffix) {
+    if (config.tableNamingRule === 'prefix') {
+      config.tablePrefix = config.tableNameAffix;
+    } else if (config.tableNamingRule === 'suffix') {
+      config.tableSuffix = config.tableNameAffix;
+    }
+  }
+
+  if (!config.fetchSize && options.fetch_size) {
+    config.fetchSize = Number(options.fetch_size);
+  }
+  if (!config.batchSize && options.batch_size) {
+    config.batchSize = Number(options.batch_size);
+  }
+
+  return {
+    ...config,
+    connectorOptions: options,
+  };
+};
+
 const normalizeEndpoint = (
   raw: any,
   kind: EndpointKind,
@@ -180,10 +304,7 @@ const normalizeEndpoint = (
     pluginName: String(value?.pluginName || dbType),
     dbType,
     dataSourceId: String(value?.dataSourceId || ''),
-    config:
-      value?.config && typeof value.config === 'object'
-        ? value.config
-        : {},
+    config: directConfig(value as Record<string, any>, kind),
   };
 };
 
@@ -198,6 +319,9 @@ export const normalizeEditDetail = (
   ) as SyncMode;
   const legacyChannel = raw?.workflow?.channelConfig || {};
   const channelRaw = raw?.channel || {};
+  const dirtyDataPolicy = String(
+    channelRaw?.dirtyDataPolicy || legacyChannel?.dirtyDataPolicy || 'STOP',
+  ).toUpperCase();
 
   return {
     id,
@@ -216,10 +340,7 @@ export const normalizeEditDetail = (
       parallelism: Number(
         channelRaw?.parallelism || raw?.env?.parallelism || 1,
       ),
-      dirtyDataPolicy:
-        (channelRaw?.dirtyDataPolicy || legacyChannel?.dirtyDataPolicy) === 'skip'
-          ? 'skip'
-          : 'stop',
+      dirtyDataPolicy: dirtyDataPolicy === 'SKIP' ? 'skip' : 'stop',
     },
     state: raw?.state,
   };
@@ -237,6 +358,7 @@ const resetEndpointConfig = (
   kind === 'source'
     ? {
         ...config,
+        database: '',
         table: '',
         tables: [],
         tablePattern: '',
@@ -244,6 +366,7 @@ const resetEndpointConfig = (
       }
     : {
         ...config,
+        database: '',
         table: '',
         targetTableName: '',
         sql: '',
@@ -300,16 +423,96 @@ export const updateEndpointConfig = (
   },
 });
 
+const stripDatabase = (table: unknown, database: string): string => {
+  const value = String(table || '').trim();
+  const prefix = database ? `${database}.` : '';
+  return prefix && value.startsWith(prefix)
+    ? value.slice(prefix.length)
+    : value;
+};
+
+const multiSourcePayload = (source: SyncEndpoint) => {
+  const config = source.config || {};
+  const database = String(config.database || '').trim();
+  const tables = Array.isArray(config.tables)
+    ? config.tables
+        .map((table: unknown) => stripDatabase(table, database))
+        .filter(Boolean)
+    : [];
+  const options = {
+    ...(config.connectorOptions || {}),
+  };
+
+  if (config.fetchSize) {
+    options.fetch_size = Number(config.fetchSize);
+  }
+
+  return {
+    connectorId: source.connectorId,
+    dbType: source.dbType,
+    dataSourceId: source.dataSourceId,
+    database,
+    tables,
+    tablePattern: String(config.tablePattern || '').trim(),
+    options,
+  };
+};
+
+const multiSinkPayload = (sink: SyncEndpoint) => {
+  const config = sink.config || {};
+  const tableNamingRule = String(
+    config.tableNamingRule || 'same_name',
+  ).toUpperCase();
+  const writeMode = String(config.writeMode || 'append').toUpperCase();
+  const options = {
+    ...(config.connectorOptions || {}),
+  };
+
+  if (config.batchSize) {
+    options.batch_size = Number(config.batchSize);
+  }
+
+  return {
+    connectorId: sink.connectorId,
+    dbType: sink.dbType,
+    dataSourceId: sink.dataSourceId,
+    database: String(config.database || '').trim(),
+    tableNamingRule,
+    tablePrefix: String(config.tablePrefix || ''),
+    tableSuffix: String(config.tableSuffix || ''),
+    autoCreateTable: Boolean(config.autoCreateTable),
+    writeMode,
+    ...(writeMode === 'UPSERT'
+      ? { primaryKey: String(config.primaryKey || '').trim() }
+      : {}),
+    options,
+  };
+};
+
 export const buildSavePayload = (
   editor: SyncEditorState,
-) => ({
-  id: editor.id,
-  basic: {
+) => {
+  const basic = {
     jobName: editor.basic.jobName.trim(),
     jobDesc: editor.basic.jobDesc.trim(),
     mode: editor.mode,
-  },
-  source: editor.source,
-  sink: editor.sink,
-  channel: editor.channel,
-});
+  };
+
+  if (editor.mode === 'GUIDE_MULTI') {
+    return {
+      id: editor.id,
+      basic,
+      source: multiSourcePayload(editor.source),
+      sink: multiSinkPayload(editor.sink),
+      channel: serializeChannel(editor.channel),
+    };
+  }
+
+  return {
+    id: editor.id,
+    basic,
+    source: editor.source,
+    sink: editor.sink,
+    channel: editor.channel,
+  };
+};


### PR DESCRIPTION
## 背景

PR #171 已将离线同步基础模型从通用 `workflow` 收敛为固定的 `basic + source + sink + channel`。本 PR 在最新 `main` 上继续完成多表同步，使创建、编辑、保存、持久化和 JobSpec 构建统一使用明确的多表参数协议。

## 多表同步参数协议

```json
{
  "basic": {
    "jobName": "业务库批量同步",
    "jobDesc": "",
    "mode": "GUIDE_MULTI"
  },
  "source": {
    "connectorId": "jdbc",
    "dbType": "MYSQL",
    "dataSourceId": "1001",
    "database": "business",
    "tables": [
      "orders",
      "order_item",
      "customer"
    ],
    "tablePattern": "",
    "options": {}
  },
  "sink": {
    "connectorId": "jdbc",
    "dbType": "MYSQL",
    "dataSourceId": "1002",
    "database": "ods",
    "tableNamingRule": "SAME_NAME",
    "tablePrefix": "",
    "tableSuffix": "",
    "autoCreateTable": true,
    "writeMode": "APPEND",
    "options": {}
  },
  "channel": {
    "parallelism": 3,
    "speedLimitEnabled": false,
    "recordsPerSecond": 10000,
    "dirtyDataPolicy": "STOP",
    "dirtyDataLimit": 0
  }
}
```

本阶段不传递、不覆盖离线同步调度参数。

## 前端调整

- 多表草稿和正式保存按上述协议生成参数，不再把多表业务字段放进 `source.config` 或 `sink.config`
- 编辑页加载时，将接口根字段转换为内部表单状态；保存时再转换回稳定的接口协议
- 增加来源数据库、目标数据库输入
- 将目标命名拆分为 `tableNamingRule + tablePrefix + tableSuffix`
- 增加自动建表、写入模式和 UPSERT 主键配置
- Connector 动态字段统一输出到 `options`
- `fetchSize` 和 `batchSize` 分别映射到 `options.fetch_size`、`options.batch_size`，避免保存后丢失
- Channel 统一维护并发、限速和脏数据策略，删除 Sink 与 Channel 之间的双份脏数据状态
- 当前 Link-Up 不直接执行通配符表名，因此保存前仍要求确认实际来源表；`tablePattern` 先作为配置字段保留

## 后端调整

- 扩展 `OfflineJobEndpointDTO`，明确承接多表数据库、表列表、命名规则、写入模式、UPSERT 主键和 `options`
- 新增 `OfflineDefinitionModelAdapter`：
  - 持久化定义保持公开的扁平协议
  - 仅在构建 JobSpec 时，对深拷贝生成内部 `config`
  - 来源表补全来源数据库
  - 目标表生成 `${table_name}` 命名模板并补全目标数据库
  - 校验数据库、命名规则、前后缀、写入模式和 UPSERT 主键
  - 将 `options` 映射为 Connector 参数
- 继续兼容历史 `workflow.nodes + env` 版本的执行与回看
- JDBC 端点持久化前清理数据源托管的 URL、用户名、密码、驱动等字段，避免凭据进入 `definition_json`
- 非 JDBC Connector 的自有 `options` 不做误删

## Review 中已修复的问题

1. 多表页面允许仅填写 `tablePattern`，但 Link-Up 当前不能直接执行通配符，前后端行为不一致
2. `fetchSize`、`batchSize` 在扁平模型转换时可能丢失
3. 多表 UPSERT 的 `primaryKey` 未进入公开 DTO 和保存参数
4. 脏数据策略同时存在于 Sink 扩展参数和 Channel，容易出现两份值不一致
5. JobSpec 使用内部 `config` 时可能反向污染持久化任务定义
6. JDBC 请求中的连接字段可能被原样写入任务定义 JSON
7. 多表来源库、目标库、命名规则与写入模式缺少后端兜底校验

## 测试

- 新增多表公开协议到内部 JobSpec 配置的适配测试
- 覆盖三张来源表、来源库补全、目标库和命名模板、批次、并发、自动建表与脏数据策略
- 覆盖 PREFIX 配置缺失、数据库缺失等错误输入
- 覆盖 JDBC 凭据清理以及非 JDBC options 保留
- 保留历史 Workflow 定义兼容测试

当前环境无法实际执行 Maven 和前端构建，需由 CI 或本地环境完成最终编译、类型检查和联调。

## 后续 Review 建议

以下问题不适合混入本次参数重构，建议后续独立处理：

- `nextId()` 使用进程内序列，在多实例部署时应改为数据库、雪花算法或统一 ID 服务
- 任务名称去重需要数据库唯一约束兜底，避免并发创建竞态
- 同一任务并发保存需要乐观锁或版本条件更新，避免产生重复版本号和覆盖 currentVersion
- 单表/多表保存路径应校验请求中的 `basic.mode` 与接口路径一致
