### PR TITLE
fix(ui): migrate multi config route off workflow model

### DIFF
--- a/yak-ops-ui/src/pages/batch-link-up/config/multi/components/MultiTableSyncTaskEditor.tsx
+++ b/yak-ops-ui/src/pages/batch-link-up/config/multi/components/MultiTableSyncTaskEditor.tsx
@@ -1,14 +1,7 @@
 import type { DataSourceRecord } from '@/pages/data-source/types';
 
-import ChannelConfigSection from '../../../detail/components/ChannelConfigSection';
-import MultiTableConfigSection from '../../../detail/components/MultiTableConfigSection';
-import TaskBasicSection from '../../../detail/components/TaskBasicSection';
-import useDataSourceTables from '../../../detail/hooks/useDataSourceTables';
-import {
-  endpointNode,
-  updateEndpointConfig,
-  type SyncEditorState,
-} from '../../../detail/model';
+import SyncTaskEditor from '../../../detail/components/SyncTaskEditor';
+import type { SyncEditorState } from '../../../detail/model';
 
 interface MultiTableSyncTaskEditorProps {
   editor: SyncEditorState;
@@ -17,57 +10,14 @@ interface MultiTableSyncTaskEditorProps {
   onChange: (value: SyncEditorState) => void;
 }
 
-export default function MultiTableSyncTaskEditor({
-  editor,
-  dataSources,
-  dataSourceLoading,
-  onChange,
-}: MultiTableSyncTaskEditorProps) {
-  const sourceNode = endpointNode(editor.workflow, 'source');
-  const sinkNode = endpointNode(editor.workflow, 'sink');
-
-  const sourceConfig = sourceNode?.data?.config || {};
-  const sinkConfig = sinkNode?.data?.config || {};
-
-  const sourceId = editor.basic.sourceDataSourceId;
-  const targetId = editor.basic.targetDataSourceId;
-
-  const sourceCatalog = useDataSourceTables(sourceId);
-
-  const updateSource = (patch: Record<string, any>) => {
-    onChange(updateEndpointConfig(editor, 'source', patch));
-  };
-
-  const updateSink = (patch: Record<string, any>) => {
-    onChange(updateEndpointConfig(editor, 'sink', patch));
-  };
-
-  return (
-    <div className="space-y-5">
-      <TaskBasicSection
-        editor={editor}
-        dataSources={dataSources}
-        dataSourceLoading={dataSourceLoading}
-        onChange={onChange}
-      />
-
-      <MultiTableConfigSection
-        sourceConfig={sourceConfig}
-        sinkConfig={sinkConfig}
-        sourceTables={sourceCatalog.tables}
-        sourceLoading={sourceCatalog.loading}
-        sourceReady={Boolean(sourceId)}
-        targetReady={Boolean(targetId)}
-        onSourceChange={updateSource}
-        onSinkChange={updateSink}
-      />
-
-      <ChannelConfigSection
-        editor={editor}
-        sinkConfig={sinkConfig}
-        onChange={onChange}
-        onSinkChange={updateSink}
-      />
-    </div>
-  );
+/**
+ * 多表路由入口复用统一离线同步编辑器。
+ *
+ * 任务模式已经由路由页校验为 GUIDE_MULTI，具体渲染由 SyncTaskEditor
+ * 基于 editor.mode 选择 MultiTableConfigSection，避免维护第二套旧 Workflow 状态。
+ */
+export default function MultiTableSyncTaskEditor(
+  props: MultiTableSyncTaskEditorProps,
+) {
+  return <SyncTaskEditor {...props} />;
 }

--- a/yak-ops-ui/src/pages/batch-link-up/config/multi/index.tsx
+++ b/yak-ops-ui/src/pages/batch-link-up/config/multi/index.tsx
@@ -19,10 +19,10 @@ import type { DataSourceRecord } from '@/pages/data-source/types';
 import { BRAND_THEME } from '@/styles/brand';
 
 import { linkupJobDefinitionApi } from '../../api';
+import validateEditorConnectorForms from '../../detail/form-schema/validateEditorConnectorForms';
 import { useSmoothWheelScroll } from '../../detail/hooks/useSmoothWheelScroll';
 import {
   buildSavePayload,
-  endpointNode,
   extractSavedId,
   isApiSuccess,
   normalizeEditDetail,
@@ -38,37 +38,59 @@ const validateTaskConfig = (
     return '请输入任务名称';
   }
 
-  if (!editor.basic.sourceDataSourceId) {
+  if (!editor.source.dataSourceId) {
     return '请选择来源数据源';
   }
 
-  if (!editor.basic.targetDataSourceId) {
+  if (!editor.sink.dataSourceId) {
     return '请选择目标数据源';
   }
 
-  const source =
-    endpointNode(editor.workflow, 'source')?.data?.config || {};
+  const source = editor.source.config || {};
+  const sink = editor.sink.config || {};
 
-  const sink =
-    endpointNode(editor.workflow, 'sink')?.data?.config || {};
+  if (!source.database?.trim()) {
+    return '请输入来源数据库';
+  }
 
-  if (!source.tables?.length && !source.tablePattern?.trim()) {
-    return '请选择来源表，或填写表名过滤规则';
+  if (!source.tables?.length) {
+    return source.tablePattern?.trim()
+      ? '表名过滤规则暂不能直接执行，请确认并选择实际来源表'
+      : '请选择至少一张来源表';
+  }
+
+  if (!sink.database?.trim()) {
+    return '请输入目标数据库';
+  }
+
+  const tableNamingRule = String(
+    sink.tableNamingRule || 'same_name',
+  ).toLowerCase();
+
+  if (tableNamingRule === 'prefix' && !sink.tablePrefix?.trim()) {
+    return '请填写目标表名前缀';
+  }
+
+  if (tableNamingRule === 'suffix' && !sink.tableSuffix?.trim()) {
+    return '请填写目标表名后缀';
   }
 
   if (
-    sink.tableNamingRule !== 'same_name' &&
-    !sink.tableNameAffix?.trim()
+    String(sink.writeMode || '').toLowerCase() === 'upsert' &&
+    !sink.primaryKey?.trim()
   ) {
-    return '请填写目标表名前缀或后缀';
-  }
-
-  if (sink.writeMode === 'upsert' && !sink.primaryKey?.trim()) {
     return 'Upsert 写入模式需要配置主键字段';
   }
 
-  if (!editor.env.parallelism || editor.env.parallelism < 1) {
+  if (!editor.channel.parallelism || editor.channel.parallelism < 1) {
     return 'Channel 并发数必须大于 0';
+  }
+
+  if (
+    editor.channel.dirtyDataPolicy === 'skip' &&
+    editor.channel.dirtyDataLimit < 0
+  ) {
+    return '脏数据上限不能小于 0';
   }
 
   return null;
@@ -77,7 +99,6 @@ const validateTaskConfig = (
 export default function MultiBatchLinkUpDetailPage() {
   const location = useLocation();
   const routeParams = useParams<{ id?: string }>();
-
   const pageRootRef = useRef<HTMLDivElement>(null);
 
   const taskId = useMemo(
@@ -90,13 +111,10 @@ export default function MultiBatchLinkUpDetailPage() {
 
   const [editor, setEditor] =
     useState<SyncEditorState | null>(null);
-
   const [loading, setLoading] = useState(false);
   const [saving, setSaving] = useState(false);
-
   const [dataSourceLoading, setDataSourceLoading] =
     useState(false);
-
   const [dataSources, setDataSources] = useState<
     DataSourceRecord[]
   >([]);
@@ -106,14 +124,12 @@ export default function MultiBatchLinkUpDetailPage() {
   const loadDataSources = useCallback(async () => {
     try {
       setDataSourceLoading(true);
-
       const response = await fetchDataSourceAll();
 
       if (!isApiSuccess(response)) {
         message.error(
           responseMessage(response, '获取数据源失败'),
         );
-
         setDataSources([]);
         return;
       }
@@ -132,7 +148,6 @@ export default function MultiBatchLinkUpDetailPage() {
 
     try {
       setLoading(true);
-
       const response =
         await linkupJobDefinitionApi.selectEditDetail(taskId);
 
@@ -140,7 +155,6 @@ export default function MultiBatchLinkUpDetailPage() {
         message.error(
           responseMessage(response, '获取同步任务失败'),
         );
-
         setEditor(null);
         return;
       }
@@ -167,7 +181,6 @@ export default function MultiBatchLinkUpDetailPage() {
 
   useEffect(() => {
     if (!taskId) return;
-
     void Promise.all([loadTask(), loadDataSources()]);
   }, [loadDataSources, loadTask, taskId]);
 
@@ -176,9 +189,7 @@ export default function MultiBatchLinkUpDetailPage() {
   ): Promise<SyncEditorState | null> => {
     try {
       setSaving(true);
-
       const payload = buildSavePayload(nextEditor);
-
       const response =
         await linkupJobDefinitionApi.saveOrUpdateGuideMulti(payload);
 
@@ -186,7 +197,6 @@ export default function MultiBatchLinkUpDetailPage() {
         message.error(
           responseMessage(response, '保存同步任务失败'),
         );
-
         return null;
       }
 
@@ -198,11 +208,9 @@ export default function MultiBatchLinkUpDetailPage() {
 
       setEditor(savedEditor);
       message.success('任务配置已保存');
-
       return savedEditor;
     } catch (error: any) {
       message.error(error?.message || '保存同步任务失败');
-
       return null;
     } finally {
       setSaving(false);
@@ -213,9 +221,14 @@ export default function MultiBatchLinkUpDetailPage() {
     if (!editor) return;
 
     const error = validateTaskConfig(editor);
-
     if (error) {
       message.warning(error);
+      return;
+    }
+
+    const remoteErrors = await validateEditorConnectorForms(editor);
+    if (remoteErrors.length > 0) {
+      message.warning(remoteErrors[0]);
       return;
     }
 


### PR DESCRIPTION
## 问题

离线同步模型已经重构为 `basic + source + sink + channel`，但多表独立路由仍保留旧 Workflow 访问方式：

- 导入已删除的 `endpointNode`
- 访问不存在的 `editor.workflow`
- 访问旧字段 `basic.sourceDataSourceId / targetDataSourceId`
- 访问旧字段 `editor.env.parallelism`

因此前端启动时 esbuild 报错：

```text
No matching export in detail/model.ts for import endpointNode
```

## 修复

- `MultiTableSyncTaskEditor` 直接复用统一的 `SyncTaskEditor`
- 删除多表路由中的 `endpointNode` 和 Workflow 节点访问
- 数据源 ID 改为 `editor.source.dataSourceId / editor.sink.dataSourceId`
- Source、Sink 配置改为 `editor.source.config / editor.sink.config`
- 并发与脏数据校验改为 `editor.channel`
- 多表校验同步到新的数据库、表列表、前后缀和 UPSERT 参数模型
- 保存前补回统一的 Connector Schema 远程校验

## 影响范围

仅修改多表同步独立配置路由的两个前端文件，不调整后端协议和通用编辑器。

## 验证

已通过代码级检查确认两个报错文件不再引用 `endpointNode`、`editor.workflow` 或 `editor.env`。当前环境无法执行本地前端构建，请在本地拉取分支后运行现有启动或构建命令完成最终验证。