### PR TITLE
fix(offline-sync): allow editing draft tasks

### DIFF
--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/domain/OfflineExecutionStatus.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/domain/OfflineExecutionStatus.java
@@ -46,6 +46,9 @@ public enum OfflineExecutionStatus {
   }
 
   public static boolean isActive(String value) {
+    if (value == null || value.trim().isEmpty()) {
+      return false;
+    }
     try {
       return parse(value).isActive();
     } catch (IllegalArgumentException exception) {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/domain/OfflineExecutionStatusTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/domain/OfflineExecutionStatusTest.java
@@ -19,6 +19,13 @@ class OfflineExecutionStatusTest {
   }
 
   @Test
+  void shouldTreatMissingPersistedStatusAsInactive() {
+    assertThat(OfflineExecutionStatus.isActive(null)).isFalse();
+    assertThat(OfflineExecutionStatus.isActive("")).isFalse();
+    assertThat(OfflineExecutionStatus.isActive("   ")).isFalse();
+  }
+
+  @Test
   void shouldNormalizeLegacyStatusesWithoutAddingRealtimeStates() {
     assertThat(OfflineExecutionStatus.parse("FINISHED"))
         .isEqualTo(OfflineExecutionStatus.SUCCEEDED);


### PR DESCRIPTION
## 问题

创建离线同步草稿后，任务尚未产生任何执行记录，`lastJobStatus` 为 `null`。保存配置时，`ensureEditable` 会调用 `OfflineExecutionStatus.isActive(lastJobStatus)`；原实现进一步通过 `parse(null)` 将空状态转换为 `CREATED`，而 `CREATED` 属于活动执行状态，最终错误抛出“运行中的任务不能修改”。

## 修复

- 在字符串状态判断入口中，将 `null`、空字符串和纯空白字符串视为“尚未运行”，允许草稿继续编辑；
- 保留显式 `CREATED`、`SUBMITTED`、`QUEUED`、`RUNNING` 为活动状态；
- 保留 `parse(null) -> CREATED` 的既有兼容语义，避免影响其他调用方；
- 增加单元测试，覆盖草稿缺失持久化状态的场景。

## 验证

- 使用 Java 21 对修改后的状态枚举进行编译；
- 通过轻量断言验证：空状态均为非活动状态，显式 `CREATED`/`RUNNING` 仍为活动状态，终态和未知状态仍为非活动状态；
- 当前执行环境未安装 Maven，因此未运行完整模块测试，建议在本地或 CI 中执行离线同步模块测试后再合并。