### PR TITLE
fix(datasource): standardize on MySQL Connector/J

### DIFF
--- a/yak-ops-boot/src/main/resources/application.yml
+++ b/yak-ops-boot/src/main/resources/application.yml
@@ -69,10 +69,10 @@ yak:
 
     datasource:
       enabled: true
-      url: ${YAK_SECURITY_DATASOURCE_URL:jdbc:mariadb://127.0.0.1:3306/yak_security?useUnicode=true&allowPublicKeyRetrieval=true&characterEncoding=UTF-8&useSSL=false&serverTimezone=Asia/Shanghai}
+      url: ${YAK_SECURITY_DATASOURCE_URL:jdbc:mysql://127.0.0.1:3306/yak_security?useUnicode=true&allowPublicKeyRetrieval=true&characterEncoding=UTF-8&useSSL=false&serverTimezone=Asia/Shanghai}
       username: ${YAK_SECURITY_DATASOURCE_USERNAME:root}
       password: ${YAK_SECURITY_DATASOURCE_PASSWORD:123456}
-      driver-class-name: org.mariadb.jdbc.Driver
+      driver-class-name: com.mysql.cj.jdbc.Driver
       initial-size: 1
       min-idle: 1
       max-active: 8
@@ -85,10 +85,10 @@ yak:
   datasource:
     enabled: true
     database:
-      url: ${YAK_DATASOURCE_URL:${YAK_SECURITY_DATASOURCE_URL:jdbc:mariadb://127.0.0.1:3306/yak_security?useUnicode=true&allowPublicKeyRetrieval=true&characterEncoding=UTF-8&useSSL=false&serverTimezone=Asia/Shanghai}}
+      url: ${YAK_DATASOURCE_URL:${YAK_SECURITY_DATASOURCE_URL:jdbc:mysql://127.0.0.1:3306/yak_security?useUnicode=true&allowPublicKeyRetrieval=true&characterEncoding=UTF-8&useSSL=false&serverTimezone=Asia/Shanghai}}
       username: ${YAK_DATASOURCE_USERNAME:${YAK_SECURITY_DATASOURCE_USERNAME:root}}
       password: ${YAK_DATASOURCE_PASSWORD:${YAK_SECURITY_DATASOURCE_PASSWORD:123456}}
-      driver-class-name: ${YAK_DATASOURCE_DRIVER:org.mariadb.jdbc.Driver}
+      driver-class-name: ${YAK_DATASOURCE_DRIVER:com.mysql.cj.jdbc.Driver}
       minimum-idle: 1
       maximum-pool-size: 8
     connection-test:
@@ -99,10 +99,10 @@ yak:
     max-file-size: ${YAK_RESOURCE_MAX_FILE_BYTES:104857600}
     editable-max-bytes: ${YAK_RESOURCE_EDITABLE_MAX_BYTES:2097152}
     database:
-      url: ${YAK_RESOURCE_DATASOURCE_URL:${YAK_SECURITY_DATASOURCE_URL:jdbc:mariadb://127.0.0.1:3306/yak_security?useUnicode=true&allowPublicKeyRetrieval=true&characterEncoding=UTF-8&useSSL=false&serverTimezone=Asia/Shanghai}}
+      url: ${YAK_RESOURCE_DATASOURCE_URL:${YAK_SECURITY_DATASOURCE_URL:jdbc:mysql://127.0.0.1:3306/yak_security?useUnicode=true&allowPublicKeyRetrieval=true&characterEncoding=UTF-8&useSSL=false&serverTimezone=Asia/Shanghai}}
       username: ${YAK_RESOURCE_DATASOURCE_USERNAME:${YAK_SECURITY_DATASOURCE_USERNAME:root}}
       password: ${YAK_RESOURCE_DATASOURCE_PASSWORD:${YAK_SECURITY_DATASOURCE_PASSWORD:123456}}
-      driver-class-name: ${YAK_RESOURCE_DATASOURCE_DRIVER:org.mariadb.jdbc.Driver}
+      driver-class-name: ${YAK_RESOURCE_DATASOURCE_DRIVER:com.mysql.cj.jdbc.Driver}
       minimum-idle: 1
       maximum-pool-size: 8
     storage:
@@ -130,10 +130,10 @@ yak:
     offline:
       enabled: ${YAK_OFFLINE_SYNC_ENABLED:true}
       datasource:
-        url: ${YAK_OFFLINE_SYNC_DATASOURCE_URL:${YAK_SECURITY_DATASOURCE_URL:jdbc:mariadb://127.0.0.1:3306/yak_security?useUnicode=true&allowPublicKeyRetrieval=true&characterEncoding=UTF-8&useSSL=false&serverTimezone=Asia/Shanghai}}
+        url: ${YAK_OFFLINE_SYNC_DATASOURCE_URL:${YAK_SECURITY_DATASOURCE_URL:jdbc:mysql://127.0.0.1:3306/yak_security?useUnicode=true&allowPublicKeyRetrieval=true&characterEncoding=UTF-8&useSSL=false&serverTimezone=Asia/Shanghai}}
         username: ${YAK_OFFLINE_SYNC_DATASOURCE_USERNAME:${YAK_SECURITY_DATASOURCE_USERNAME:root}}
         password: ${YAK_OFFLINE_SYNC_DATASOURCE_PASSWORD:${YAK_SECURITY_DATASOURCE_PASSWORD:123456}}
-        driver-class-name: ${YAK_OFFLINE_SYNC_DATASOURCE_DRIVER:org.mariadb.jdbc.Driver}
+        driver-class-name: ${YAK_OFFLINE_SYNC_DATASOURCE_DRIVER:com.mysql.cj.jdbc.Driver}
         minimum-idle: 1
         maximum-pool-size: 8
       engine:
@@ -159,10 +159,10 @@ yak:
   workflow:
     enabled: true
     datasource:
-      url: ${YAK_WORKFLOW_DATASOURCE_URL:${YAK_SECURITY_DATASOURCE_URL:jdbc:mariadb://127.0.0.1:3306/yak_security?useUnicode=true&allowPublicKeyRetrieval=true&characterEncoding=UTF-8&useSSL=false&serverTimezone=Asia/Shanghai}}
+      url: ${YAK_WORKFLOW_DATASOURCE_URL:${YAK_SECURITY_DATASOURCE_URL:jdbc:mysql://127.0.0.1:3306/yak_security?useUnicode=true&allowPublicKeyRetrieval=true&characterEncoding=UTF-8&useSSL=false&serverTimezone=Asia/Shanghai}}
       username: ${YAK_WORKFLOW_DATASOURCE_USERNAME:${YAK_SECURITY_DATASOURCE_USERNAME:root}}
       password: ${YAK_WORKFLOW_DATASOURCE_PASSWORD:${YAK_SECURITY_DATASOURCE_PASSWORD:123456}}
-      driver-class-name: ${YAK_WORKFLOW_DATASOURCE_DRIVER:org.mariadb.jdbc.Driver}
+      driver-class-name: ${YAK_WORKFLOW_DATASOURCE_DRIVER:com.mysql.cj.jdbc.Driver}
       minimum-idle: 1
       maximum-pool-size: 8
     executor:

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/pom.xml
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/pom.xml
@@ -54,8 +54,8 @@
             <artifactId>flyway-mysql</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.mariadb.jdbc</groupId>
-            <artifactId>mariadb-java-client</artifactId>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
             <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/yak-ops-business/yak-ops-business-workflow/pom.xml
+++ b/yak-ops-business/yak-ops-business-workflow/pom.xml
@@ -62,8 +62,8 @@
             <artifactId>flyway-mysql</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.mariadb.jdbc</groupId>
-            <artifactId>mariadb-java-client</artifactId>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
             <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-doris/src/main/java/io/yak/ops/plugin/database/doris/DorisDataSourcePlugin.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-doris/src/main/java/io/yak/ops/plugin/database/doris/DorisDataSourcePlugin.java
@@ -25,7 +25,7 @@ public final class DorisDataSourcePlugin extends AbstractJdbcDataSourcePlugin {
 
   @Override
   protected String defaultDriverClassName() {
-    return "org.mariadb.jdbc.Driver";
+    return "com.mysql.cj.jdbc.Driver";
   }
 
   @Override
@@ -35,7 +35,7 @@ public final class DorisDataSourcePlugin extends AbstractJdbcDataSourcePlugin {
 
   @Override
   protected String buildJdbcUrl(String host, int port, String database, JsonNode connectionJson) {
-    return "jdbc:mariadb://" + host + ":" + port + "/" + database;
+    return "jdbc:mysql://" + host + ":" + port + "/" + database;
   }
 
   @Override
@@ -67,7 +67,6 @@ public final class DorisDataSourcePlugin extends AbstractJdbcDataSourcePlugin {
 
   @Override
   public boolean acceptsUrl(String jdbcUrl) {
-    return jdbcUrl != null
-        && (jdbcUrl.startsWith("jdbc:mysql:") || jdbcUrl.startsWith("jdbc:mariadb:"));
+    return jdbcUrl != null && jdbcUrl.startsWith("jdbc:mysql:");
   }
 }

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-doris/src/test/java/io/yak/ops/plugin/database/doris/DorisDataSourcePluginTest.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-doris/src/test/java/io/yak/ops/plugin/database/doris/DorisDataSourcePluginTest.java
@@ -16,8 +16,8 @@ class DorisDataSourcePluginTest {
                     + "\"database\":\"warehouse\",\"username\":\"root\","
                     + "\"fenodes\":\"doris-fe:8030\"}");
 
-    assertThat(connection.jdbcUrl()).isEqualTo("jdbc:mariadb://doris-fe:9030/warehouse");
-    assertThat(connection.driverClassName()).isEqualTo("org.mariadb.jdbc.Driver");
+    assertThat(connection.jdbcUrl()).isEqualTo("jdbc:mysql://doris-fe:9030/warehouse");
+    assertThat(connection.driverClassName()).isEqualTo("com.mysql.cj.jdbc.Driver");
     assertThat(connection.normalizedJson()).contains("\"fenodes\":\"doris-fe:8030\"");
     assertThat(new DorisDataSourcePlugin().createCatalog(connection, 5))
         .isInstanceOf(DorisJdbcCatalog.class);

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/pom.xml
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/pom.xml
@@ -26,8 +26,8 @@
             <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.mariadb.jdbc</groupId>
-            <artifactId>mariadb-java-client</artifactId>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
             <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/mysql/MySqlDataSourcePlugin.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/mysql/MySqlDataSourcePlugin.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import io.yak.ops.common.enums.datasource.DataSourceDbType;
 import io.yak.ops.plugin.database.jdbc.AbstractJdbcDataSourcePlugin;
 
-/** MySQL/MariaDB JDBC 数据源插件。 */
+/** MySQL JDBC 数据源插件。 */
 public final class MySqlDataSourcePlugin extends AbstractJdbcDataSourcePlugin {
 
   @Override
@@ -19,17 +19,16 @@ public final class MySqlDataSourcePlugin extends AbstractJdbcDataSourcePlugin {
 
   @Override
   protected String defaultDriverClassName() {
-    return "org.mariadb.jdbc.Driver";
+    return "com.mysql.cj.jdbc.Driver";
   }
 
   @Override
   protected String buildJdbcUrl(String host, int port, String database, JsonNode connectionJson) {
-    return "jdbc:mariadb://" + host + ":" + port + "/" + database;
+    return "jdbc:mysql://" + host + ":" + port + "/" + database;
   }
 
   @Override
   public boolean acceptsUrl(String jdbcUrl) {
-    return jdbcUrl != null
-        && (jdbcUrl.startsWith("jdbc:mysql:") || jdbcUrl.startsWith("jdbc:mariadb:"));
+    return jdbcUrl != null && jdbcUrl.startsWith("jdbc:mysql:");
   }
 }

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/test/java/io/yak/ops/plugin/database/jdbc/mysql/MySqlDataSourcePluginTest.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/test/java/io/yak/ops/plugin/database/jdbc/mysql/MySqlDataSourcePluginTest.java
@@ -1,0 +1,24 @@
+package io.yak.ops.plugin.database.jdbc.mysql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.yak.ops.spi.datasource.DataSourceConnection;
+import org.junit.jupiter.api.Test;
+
+class MySqlDataSourcePluginTest {
+
+  @Test
+  void shouldUseMysqlConnectorJDefaults() {
+    DataSourceConnection connection =
+        new MySqlDataSourcePlugin()
+            .parseConnection(
+                "{\"dbType\":\"MYSQL\",\"host\":\"127.0.0.1\","
+                    + "\"database\":\"demo\",\"username\":\"root\"}");
+
+    assertThat(connection.jdbcUrl()).isEqualTo("jdbc:mysql://127.0.0.1:3306/demo");
+    assertThat(connection.driverClassName()).isEqualTo("com.mysql.cj.jdbc.Driver");
+    assertThat(new MySqlDataSourcePlugin().acceptsUrl(connection.jdbcUrl())).isTrue();
+    assertThat(new MySqlDataSourcePlugin().acceptsUrl("jdbc:mariadb://127.0.0.1/demo"))
+        .isFalse();
+  }
+}


### PR DESCRIPTION
## 变更说明

- 将默认数据库驱动从 `org.mariadb.jdbc.Driver` 统一调整为 `com.mysql.cj.jdbc.Driver`
- 将默认 JDBC URL 从 `jdbc:mariadb://` 对齐为 `jdbc:mysql://`
- MySQL 与 Doris 数据源插件统一使用 MySQL Connector/J
- 将离线同步、工作流和 JDBC 数据源插件中的运行时依赖从 `mariadb-java-client` 替换为 `mysql-connector-j`
- 更新 Doris 测试，并补充 MySQL 插件默认驱动测试

## 背景

Link-Up 运行环境已经包含 MySQL Connector/J，但没有 MariaDB JDBC Driver。Yak Ops 继续下发 `org.mariadb.jdbc.Driver` 会导致 `/api/v1/connectors/jdbc/preflight` 报驱动类不存在。此次修改统一控制面配置、数据源插件和运行时依赖，避免驱动类与 JDBC URL 不匹配。

## 验证

- 已检查分支差异，涉及 8 个文件
- 当前执行环境未运行 Maven 全量测试，等待 CI 验证