### PR TITLE
fix(offline-sync): recover after Link-Up worker restart

### DIFF
--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/controller/OfflineWorkerRegistrationController.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/controller/OfflineWorkerRegistrationController.java
@@ -9,11 +9,11 @@ import io.yak.ops.business.sync.offline.worker.OfflineWorkerRegistrationModels.D
 import io.yak.ops.business.sync.offline.worker.OfflineWorkerRegistrationModels.HeartbeatRequest;
 import io.yak.ops.business.sync.offline.worker.OfflineWorkerRegistrationModels.LeaseResponse;
 import io.yak.ops.business.sync.offline.worker.OfflineWorkerRegistrationModels.RegisterRequest;
-import io.yak.ops.business.sync.offline.worker.OfflineWorkerRegistrationService;
+import io.yak.ops.business.sync.offline.worker.RestartAwareOfflineWorkerRegistrationFacade;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.http.MediaType;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -27,12 +27,12 @@ import org.springframework.web.server.ResponseStatusException;
 public class OfflineWorkerRegistrationController {
 
   private final OfflineWorkerRegistrationAuthenticator authenticator;
-  private final OfflineWorkerRegistrationService service;
+  private final RestartAwareOfflineWorkerRegistrationFacade service;
   private final ObjectMapper objectMapper;
 
   public OfflineWorkerRegistrationController(
       OfflineWorkerRegistrationAuthenticator authenticator,
-      OfflineWorkerRegistrationService service,
+      RestartAwareOfflineWorkerRegistrationFacade service,
       @Qualifier("offlineSyncJsonMapper") ObjectMapper objectMapper) {
     this.authenticator = authenticator;
     this.service = service;

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineWorkerRestartTakeoverRepository.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineWorkerRestartTakeoverRepository.java
@@ -1,0 +1,68 @@
+package io.yak.ops.business.sync.offline.repository;
+
+import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.List;
+import javax.sql.DataSource;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+/**
+ * Link-Up Worker 重启接管所需的条件租约作废和旧执行查询。
+ *
+ * <p>租约作废使用旧 leaseId、instanceId、baseUrl 和启动时间作为 fencing 条件，避免并发注册时
+ * 较旧请求覆盖已经完成的新实例接管。
+ */
+@ConditionalOnOfflineSyncEnabled
+@Repository
+public class OfflineWorkerRestartTakeoverRepository {
+
+  private final JdbcTemplate jdbc;
+
+  public OfflineWorkerRestartTakeoverRepository(
+      @Qualifier("offlineSyncDataSource") DataSource dataSource) {
+    this.jdbc = new JdbcTemplate(dataSource);
+  }
+
+  public boolean fenceActiveLease(
+      String nodeId,
+      String expectedLeaseId,
+      String expectedInstanceId,
+      String expectedBaseUrl,
+      long replacementStartedAtMillis,
+      LocalDateTime now,
+      String reason) {
+    return jdbc.update(
+        "UPDATE yak_offline_engine_node SET lease_expires_at = ?, status = 'DOWN', "
+            + "last_error_message = ?, update_time = ? "
+            + "WHERE node_id = ? AND registration_mode = 'DYNAMIC' "
+            + "AND registration_lease_id = ? AND registration_instance_id = ? "
+            + "AND base_url = ? AND lease_expires_at > ? "
+            + "AND started_at_millis IS NOT NULL AND started_at_millis < ?",
+        timestamp(now),
+        reason,
+        timestamp(now),
+        nodeId,
+        expectedLeaseId,
+        expectedInstanceId,
+        expectedBaseUrl,
+        timestamp(now),
+        replacementStartedAtMillis) > 0;
+  }
+
+  public List<Long> findActiveExecutionIds(String nodeId, String workerInstanceId) {
+    return jdbc.queryForList(
+        "SELECT id FROM yak_offline_job_execution "
+            + "WHERE engine_node_id = ? AND worker_instance_id = ? "
+            + "AND status IN ('CREATED','SUBMITTED','QUEUED','RUNNING') ORDER BY id ASC",
+        Long.class,
+        nodeId,
+        workerInstanceId);
+  }
+
+  private Timestamp timestamp(LocalDateTime value) {
+    return value == null ? null : Timestamp.valueOf(value);
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/worker/OfflineWorkerRestartRecoveryService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/worker/OfflineWorkerRestartRecoveryService.java
@@ -1,0 +1,57 @@
+package io.yak.ops.business.sync.offline.worker;
+
+import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import io.yak.ops.business.sync.offline.dao.OfflineJobExecutionDao;
+import io.yak.ops.business.sync.offline.domain.OfflineExecutionStatus;
+import io.yak.ops.business.sync.offline.repository.OfflineWorkerRestartTakeoverRepository;
+import io.yak.ops.business.sync.offline.service.OfflineJobExecutionService;
+import io.yak.ops.common.bean.po.sync.offline.OfflineJobExecutionPO;
+import java.util.List;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+/** 将被新 Link-Up 进程替代的旧实例执行立即转为 LOST。 */
+@ConditionalOnOfflineSyncEnabled
+@Service
+public class OfflineWorkerRestartRecoveryService {
+
+  private final OfflineWorkerRestartTakeoverRepository repository;
+  private final OfflineJobExecutionDao executionDao;
+  private final OfflineJobExecutionService executionService;
+
+  public OfflineWorkerRestartRecoveryService(
+      OfflineWorkerRestartTakeoverRepository repository,
+      OfflineJobExecutionDao executionDao,
+      OfflineJobExecutionService executionService) {
+    this.repository = repository;
+    this.executionDao = executionDao;
+    this.executionService = executionService;
+  }
+
+  public int recover(String nodeId, String previousInstanceId, String currentInstanceId) {
+    if (!StringUtils.hasText(nodeId)
+        || !StringUtils.hasText(previousInstanceId)
+        || !StringUtils.hasText(currentInstanceId)
+        || previousInstanceId.equals(currentInstanceId)) {
+      return 0;
+    }
+
+    int recovered = 0;
+    List<Long> executionIds = repository.findActiveExecutionIds(nodeId, previousInstanceId);
+    for (Long executionId : executionIds) {
+      OfflineJobExecutionPO execution = executionDao.selectById(executionId);
+      if (execution == null
+          || !OfflineExecutionStatus.isActive(execution.getStatus())
+          || !nodeId.equals(execution.getEngineNodeId())
+          || !previousInstanceId.equals(execution.getWorkerInstanceId())) {
+        continue;
+      }
+      executionService.markLost(
+          execution,
+          "Link-Up Worker " + nodeId + " 已由新实例 " + currentInstanceId
+              + " 接管；旧实例 " + previousInstanceId + " 的执行无法继续确认");
+      recovered++;
+    }
+    return recovered;
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/worker/RestartAwareOfflineWorkerRegistrationFacade.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/worker/RestartAwareOfflineWorkerRegistrationFacade.java
@@ -1,0 +1,159 @@
+package io.yak.ops.business.sync.offline.worker;
+
+import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import io.yak.ops.business.sync.offline.engine.LinkUpWorkerProbeClient;
+import io.yak.ops.business.sync.offline.repository.OfflineNodeRepository;
+import io.yak.ops.business.sync.offline.repository.OfflineNodeRepository.NodeRecord;
+import io.yak.ops.business.sync.offline.repository.OfflineWorkerRegistrationRepository;
+import io.yak.ops.business.sync.offline.repository.OfflineWorkerRestartTakeoverRepository;
+import io.yak.ops.business.sync.offline.worker.OfflineWorkerRegistrationModels.DeregisterRequest;
+import io.yak.ops.business.sync.offline.worker.OfflineWorkerRegistrationModels.HeartbeatRequest;
+import io.yak.ops.business.sync.offline.worker.OfflineWorkerRegistrationModels.LeaseResponse;
+import io.yak.ops.business.sync.offline.worker.OfflineWorkerRegistrationModels.RegisterRequest;
+import java.time.LocalDateTime;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * 为动态注册增加受控重启接管。
+ *
+ * <p>普通注册仍由 {@link OfflineWorkerRegistrationService} 完成。只有旧租约仍有效、nodeId 和
+ * advertised base URL 相同、且新进程启动时间严格更新时，才会条件作废旧租约并重新注册。
+ */
+@ConditionalOnOfflineSyncEnabled
+@Service
+public class RestartAwareOfflineWorkerRegistrationFacade {
+
+  private final OfflineWorkerRegistrationService registrationService;
+  private final OfflineNodeRepository nodeRepository;
+  private final OfflineWorkerRegistrationRepository registrationRepository;
+  private final OfflineWorkerRestartTakeoverRepository takeoverRepository;
+  private final OfflineWorkerRestartRecoveryService recoveryService;
+  private final LinkUpWorkerProbeClient probeClient;
+
+  public RestartAwareOfflineWorkerRegistrationFacade(
+      OfflineWorkerRegistrationService registrationService,
+      OfflineNodeRepository nodeRepository,
+      OfflineWorkerRegistrationRepository registrationRepository,
+      OfflineWorkerRestartTakeoverRepository takeoverRepository,
+      OfflineWorkerRestartRecoveryService recoveryService,
+      LinkUpWorkerProbeClient probeClient) {
+    this.registrationService = registrationService;
+    this.nodeRepository = nodeRepository;
+    this.registrationRepository = registrationRepository;
+    this.takeoverRepository = takeoverRepository;
+    this.recoveryService = recoveryService;
+    this.probeClient = probeClient;
+  }
+
+  public LeaseResponse register(RegisterRequest request, String remoteAddress) {
+    try {
+      return registrationService.register(request, remoteAddress);
+    } catch (ResponseStatusException exception) {
+      if (exception.getStatusCode() != HttpStatus.CONFLICT) {
+        throw exception;
+      }
+
+      RestartCandidate candidate = restartCandidate(request);
+      if (candidate == null) {
+        throw exception;
+      }
+
+      LocalDateTime now = LocalDateTime.now();
+      String reason = "检测到同节点同地址的较新 Link-Up 进程，旧实例已被重启接管："
+          + candidate.previousInstanceId + " -> " + request.getInstanceId().trim();
+      boolean fenced = takeoverRepository.fenceActiveLease(
+          candidate.nodeId,
+          candidate.previousLeaseId,
+          candidate.previousInstanceId,
+          candidate.baseUrl,
+          request.getStartedAtMillis(),
+          now,
+          reason);
+
+      if (!fenced) {
+        // 注册状态已被其他并发请求改变，交回基础注册逻辑重新判定。
+        return registrationService.register(request, remoteAddress);
+      }
+
+      registrationRepository.recordEvent(
+          candidate.nodeId,
+          candidate.previousInstanceId,
+          candidate.previousLeaseId,
+          "RESTART_FENCED",
+          remoteAddress,
+          reason);
+
+      LeaseResponse response = registrationService.register(request, remoteAddress);
+      recoveryService.recover(
+          candidate.nodeId,
+          candidate.previousInstanceId,
+          request.getInstanceId().trim());
+      return response;
+    }
+  }
+
+  public LeaseResponse heartbeat(HeartbeatRequest request, String remoteAddress) {
+    return registrationService.heartbeat(request, remoteAddress);
+  }
+
+  public boolean deregister(DeregisterRequest request, String remoteAddress) {
+    return registrationService.deregister(request, remoteAddress);
+  }
+
+  private RestartCandidate restartCandidate(RegisterRequest request) {
+    if (request == null
+        || !StringUtils.hasText(request.getNodeId())
+        || !StringUtils.hasText(request.getInstanceId())
+        || !StringUtils.hasText(request.getBaseUrl())
+        || request.getStartedAtMillis() == null
+        || request.getStartedAtMillis() <= 0L) {
+      return null;
+    }
+
+    String nodeId = request.getNodeId().trim();
+    String instanceId = request.getInstanceId().trim();
+    String baseUrl = probeClient.normalizeBaseUrl(request.getBaseUrl());
+    NodeRecord existing = nodeRepository.find(nodeId);
+    LocalDateTime now = LocalDateTime.now();
+
+    if (existing == null
+        || !"DYNAMIC".equalsIgnoreCase(existing.getRegistrationMode())
+        || !StringUtils.hasText(existing.getRegistrationLeaseId())
+        || !StringUtils.hasText(existing.getRegistrationInstanceId())
+        || existing.getLeaseExpiresAt() == null
+        || !existing.getLeaseExpiresAt().isAfter(now)
+        || instanceId.equals(existing.getRegistrationInstanceId())
+        || !baseUrl.equals(existing.getBaseUrl())
+        || existing.getStartedAtMillis() == null
+        || request.getStartedAtMillis() <= existing.getStartedAtMillis()) {
+      return null;
+    }
+
+    return new RestartCandidate(
+        nodeId,
+        baseUrl,
+        existing.getRegistrationLeaseId(),
+        existing.getRegistrationInstanceId());
+  }
+
+  private static final class RestartCandidate {
+    private final String nodeId;
+    private final String baseUrl;
+    private final String previousLeaseId;
+    private final String previousInstanceId;
+
+    private RestartCandidate(
+        String nodeId,
+        String baseUrl,
+        String previousLeaseId,
+        String previousInstanceId) {
+      this.nodeId = nodeId;
+      this.baseUrl = baseUrl;
+      this.previousLeaseId = previousLeaseId;
+      this.previousInstanceId = previousInstanceId;
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/worker/OfflineWorkerRestartRecoveryServiceTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/worker/OfflineWorkerRestartRecoveryServiceTest.java
@@ -1,0 +1,42 @@
+package io.yak.ops.business.sync.offline.worker;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.sync.offline.dao.OfflineJobExecutionDao;
+import io.yak.ops.business.sync.offline.repository.OfflineWorkerRestartTakeoverRepository;
+import io.yak.ops.business.sync.offline.service.OfflineJobExecutionService;
+import io.yak.ops.common.bean.po.sync.offline.OfflineJobExecutionPO;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+
+class OfflineWorkerRestartRecoveryServiceTest {
+
+  @Test
+  void marksOldInstanceExecutionLostImmediately() {
+    OfflineWorkerRestartTakeoverRepository repository =
+        mock(OfflineWorkerRestartTakeoverRepository.class);
+    OfflineJobExecutionDao executionDao = mock(OfflineJobExecutionDao.class);
+    OfflineJobExecutionService executionService = mock(OfflineJobExecutionService.class);
+
+    OfflineJobExecutionPO execution = new OfflineJobExecutionPO();
+    execution.setId(10L);
+    execution.setEngineNodeId("worker-a");
+    execution.setWorkerInstanceId("instance-old");
+    execution.setStatus("RUNNING");
+    when(repository.findActiveExecutionIds("worker-a", "instance-old"))
+        .thenReturn(Collections.singletonList(10L));
+    when(executionDao.selectById(10L)).thenReturn(execution);
+
+    OfflineWorkerRestartRecoveryService recovery = new OfflineWorkerRestartRecoveryService(
+        repository, executionDao, executionService);
+
+    assertThat(recovery.recover("worker-a", "instance-old", "instance-new")).isEqualTo(1);
+    verify(executionService).markLost(
+        execution,
+        contains("instance-new"));
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/worker/RestartAwareOfflineWorkerRegistrationFacadeTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/worker/RestartAwareOfflineWorkerRegistrationFacadeTest.java
@@ -1,0 +1,132 @@
+package io.yak.ops.business.sync.offline.worker;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.sync.offline.engine.LinkUpWorkerProbeClient;
+import io.yak.ops.business.sync.offline.repository.OfflineNodeRepository;
+import io.yak.ops.business.sync.offline.repository.OfflineNodeRepository.NodeRecord;
+import io.yak.ops.business.sync.offline.repository.OfflineWorkerRegistrationRepository;
+import io.yak.ops.business.sync.offline.repository.OfflineWorkerRestartTakeoverRepository;
+import io.yak.ops.business.sync.offline.worker.OfflineWorkerRegistrationModels.LeaseResponse;
+import io.yak.ops.business.sync.offline.worker.OfflineWorkerRegistrationModels.RegisterRequest;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+class RestartAwareOfflineWorkerRegistrationFacadeTest {
+
+  @Test
+  void replacesActiveLeaseForNewerInstanceOnSameNodeAndAddress() {
+    OfflineWorkerRegistrationService registration = mock(OfflineWorkerRegistrationService.class);
+    OfflineNodeRepository nodes = mock(OfflineNodeRepository.class);
+    OfflineWorkerRegistrationRepository events = mock(OfflineWorkerRegistrationRepository.class);
+    OfflineWorkerRestartTakeoverRepository takeover =
+        mock(OfflineWorkerRestartTakeoverRepository.class);
+    OfflineWorkerRestartRecoveryService recovery = mock(OfflineWorkerRestartRecoveryService.class);
+    LinkUpWorkerProbeClient probe = mock(LinkUpWorkerProbeClient.class);
+
+    RegisterRequest request = request("instance-new", "http://worker-a:18080", 2_000L);
+    LeaseResponse expected = LeaseResponse.builder()
+        .nodeId("worker-a")
+        .instanceId("instance-new")
+        .leaseId("lease-new")
+        .build();
+    when(registration.register(request, "10.0.0.2"))
+        .thenThrow(new ResponseStatusException(HttpStatus.CONFLICT, "旧租约仍有效"))
+        .thenReturn(expected);
+    when(probe.normalizeBaseUrl("http://worker-a:18080"))
+        .thenReturn("http://worker-a:18080");
+    when(nodes.find("worker-a")).thenReturn(activeNode("instance-old", 1_000L));
+    when(takeover.fenceActiveLease(
+        eq("worker-a"),
+        eq("lease-old"),
+        eq("instance-old"),
+        eq("http://worker-a:18080"),
+        eq(2_000L),
+        any(LocalDateTime.class),
+        anyString()))
+        .thenReturn(true);
+
+    RestartAwareOfflineWorkerRegistrationFacade facade = new RestartAwareOfflineWorkerRegistrationFacade(
+        registration, nodes, events, takeover, recovery, probe);
+
+    LeaseResponse actual = facade.register(request, "10.0.0.2");
+
+    assertThat(actual).isSameAs(expected);
+    verify(registration, times(2)).register(request, "10.0.0.2");
+    verify(events).recordEvent(
+        eq("worker-a"),
+        eq("instance-old"),
+        eq("lease-old"),
+        eq("RESTART_FENCED"),
+        eq("10.0.0.2"),
+        anyString());
+    verify(recovery).recover("worker-a", "instance-old", "instance-new");
+  }
+
+  @Test
+  void keepsConflictWhenAddressChanges() {
+    OfflineWorkerRegistrationService registration = mock(OfflineWorkerRegistrationService.class);
+    OfflineNodeRepository nodes = mock(OfflineNodeRepository.class);
+    OfflineWorkerRegistrationRepository events = mock(OfflineWorkerRegistrationRepository.class);
+    OfflineWorkerRestartTakeoverRepository takeover =
+        mock(OfflineWorkerRestartTakeoverRepository.class);
+    OfflineWorkerRestartRecoveryService recovery = mock(OfflineWorkerRestartRecoveryService.class);
+    LinkUpWorkerProbeClient probe = mock(LinkUpWorkerProbeClient.class);
+
+    RegisterRequest request = request("instance-new", "http://worker-b:18080", 2_000L);
+    ResponseStatusException conflict =
+        new ResponseStatusException(HttpStatus.CONFLICT, "旧租约仍有效");
+    when(registration.register(request, "10.0.0.2")).thenThrow(conflict);
+    when(probe.normalizeBaseUrl("http://worker-b:18080"))
+        .thenReturn("http://worker-b:18080");
+    when(nodes.find("worker-a")).thenReturn(activeNode("instance-old", 1_000L));
+
+    RestartAwareOfflineWorkerRegistrationFacade facade = new RestartAwareOfflineWorkerRegistrationFacade(
+        registration, nodes, events, takeover, recovery, probe);
+
+    assertThatThrownBy(() -> facade.register(request, "10.0.0.2"))
+        .isSameAs(conflict);
+    verify(takeover, never()).fenceActiveLease(
+        anyString(), anyString(), anyString(), anyString(), anyLong(), any(), anyString());
+    verify(recovery, never()).recover(anyString(), anyString(), anyString());
+  }
+
+  private RegisterRequest request(String instanceId, String baseUrl, long startedAtMillis) {
+    RegisterRequest request = new RegisterRequest();
+    request.setProtocolVersion(OfflineWorkerRegistrationModels.PROTOCOL_VERSION);
+    request.setNodeId("worker-a");
+    request.setNodeName("Worker A");
+    request.setInstanceId(instanceId);
+    request.setBaseUrl(baseUrl);
+    request.setEngineVersion("1.0.0");
+    request.setStartedAtMillis(startedAtMillis);
+    request.setOfflineOnly(true);
+    return request;
+  }
+
+  private NodeRecord activeNode(String instanceId, long startedAtMillis) {
+    return NodeRecord.builder()
+        .nodeId("worker-a")
+        .nodeName("Worker A")
+        .baseUrl("http://worker-a:18080")
+        .registrationMode("DYNAMIC")
+        .registrationLeaseId("lease-old")
+        .registrationInstanceId(instanceId)
+        .leaseExpiresAt(LocalDateTime.now().plusMinutes(1))
+        .workerInstanceId(instanceId)
+        .startedAtMillis(startedAtMillis)
+        .build();
+  }
+}


### PR DESCRIPTION
## 背景

Link-Up Worker 每次启动都会生成新的 `instanceId`。当旧实例未优雅注销、租约仍有效时，Yak Ops 会拒绝同一 `nodeId` 的新实例注册，导致 Link-Up 重启后节点长时间不可调度；旧实例上的活跃执行还会继续阻塞任务再次运行。

## 修改内容

- 在动态注册入口增加受控重启接管：
  - `nodeId` 必须相同；
  - advertised base URL 必须相同；
  - 新实例 `startedAtMillis` 必须严格大于旧实例；
  - 使用旧 `leaseId + instanceId + baseUrl + startedAtMillis` 条件更新作废旧租约，防止并发注册误覆盖。
- 新实例注册成功后，立即将旧实例上的 `CREATED / SUBMITTED / QUEUED / RUNNING` 执行标记为 `LOST`，沿用现有重试策略释放任务再次运行。
- 保持不同地址、不同节点或较旧实例的注册冲突保护，避免脑裂和错误接管。
- 新增重启接管与旧执行恢复单元测试。

## 用户影响

停止并重新启动同一个 Link-Up Worker 后，Yak Ops 会把它识别为同一逻辑节点的新运行实例，立即更新调度事实。任务不再因为旧 `instanceId` 或旧租约持续报错，可重新执行或按既有策略自动重试。

## 验证

- `RestartAwareOfflineWorkerRegistrationFacadeTest`：覆盖同节点同地址的新实例接管，以及地址变化仍然拒绝。
- `OfflineWorkerRestartRecoveryServiceTest`：覆盖旧实例活跃执行立即转为 `LOST`。
- 当前仓库没有为该提交返回 GitHub Actions 检查，合并前建议在本地运行 offline-sync 模块测试。

## 关联改动

- weifuwan/yak-link-up#55