### PR TITLE
fix(offline-sync): align instance page request contract

### DIFF
--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/dto/sync/offline/OfflineJobExecutionQueryDTO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/dto/sync/offline/OfflineJobExecutionQueryDTO.java
@@ -13,7 +13,7 @@ import lombok.Data;
 @Data
 public class OfflineJobExecutionQueryDTO {
 
-  @JsonAlias("pageNo")
+  @JsonAlias({"pageNo", "pageNum"})
   @Min(value = 1, message = "页码必须大于 0")
   private int current = 1;
 

--- a/yak-ops-ui/src/pages/batch-link-up/api.ts
+++ b/yak-ops-ui/src/pages/batch-link-up/api.ts
@@ -97,6 +97,58 @@ export interface OfflineBatchOperationResult {
   errors: OfflineBatchOperationError[];
 }
 
+const toPositiveSafeInteger = (value: unknown, fieldName: string) => {
+  const normalizedValue =
+    typeof value === 'string' ? value.trim() : value;
+  const numericValue = Number(normalizedValue);
+
+  if (!Number.isSafeInteger(numericValue) || numericValue < 1) {
+    throw new Error(`${fieldName} 必须是安全的正整数`);
+  }
+
+  return numericValue;
+};
+
+/**
+ * 实例分页接口后端使用 current，并将任务定义 ID 声明为 Long。
+ * 这里统一兼容历史调用中的 pageNo/pageNum，并避免路由参数字符串触发反序列化错误。
+ */
+const normalizeOfflineInstancePageRequest = (
+  data: Record<string, unknown>,
+): Record<string, unknown> => {
+  const {
+    pageNo,
+    pageNum,
+    jobDefinitionId,
+    ...rest
+  } = data;
+  const current = toPositiveSafeInteger(
+    data.current ?? pageNo ?? pageNum ?? 1,
+    '页码',
+  );
+  const pageSize = toPositiveSafeInteger(data.pageSize ?? 10, '每页条数');
+
+  if (pageSize > 200) {
+    throw new Error('每页条数不能超过 200');
+  }
+
+  return {
+    ...rest,
+    current,
+    pageSize,
+    ...(jobDefinitionId === undefined ||
+    jobDefinitionId === null ||
+    jobDefinitionId === ''
+      ? {}
+      : {
+          jobDefinitionId: toPositiveSafeInteger(
+            jobDefinitionId,
+            '任务定义 ID',
+          ),
+        }),
+  };
+};
+
 export const apiPrefix = '/api/v1/job/batch-definition';
 
 export const linkupJobDefinitionApi = {
@@ -187,13 +239,19 @@ export const linkupJobExecuteApi = {
   execute: (
     jobDefineId: string | number,
   ): Promise<ApiResponse<OfflineJobExecutionVO>> => {
-    return HttpUtils.post(`${executeApiPrefix}/${encodeURIComponent(jobDefineId)}/execute`, {});
+    return HttpUtils.post(
+      `${executeApiPrefix}/${encodeURIComponent(jobDefineId)}/execute`,
+      {},
+    );
   },
 
   pause: (
     jobInstanceId: string | number,
   ): Promise<ApiResponse<OfflineJobExecutionVO>> => {
-    return HttpUtils.post(`${executeApiPrefix}/${encodeURIComponent(jobInstanceId)}/cancel`, {});
+    return HttpUtils.post(
+      `${executeApiPrefix}/${encodeURIComponent(jobInstanceId)}/cancel`,
+      {},
+    );
   },
 };
 
@@ -203,7 +261,10 @@ export const linkupJobInstanceApi = {
   page: (
     data: Record<string, unknown>,
   ): Promise<ApiResponse<PagingData<OfflineJobExecutionVO>>> => {
-    return HttpUtils.post(`${instanceApiPrefix}/page`, data);
+    return HttpUtils.post(
+      `${instanceApiPrefix}/page`,
+      normalizeOfflineInstancePageRequest(data),
+    );
   },
 
   selectById: (
@@ -253,7 +314,10 @@ export const batchJobInstanceApi = {
   page: (
     data: Record<string, unknown>,
   ): Promise<ApiResponse<PagingData<OfflineJobExecutionVO>>> => {
-    return HttpUtils.post('/api/v1/job/batch-instance/page', data);
+    return HttpUtils.post(
+      '/api/v1/job/batch-instance/page',
+      normalizeOfflineInstancePageRequest(data),
+    );
   },
 
   detail: (


### PR DESCRIPTION
## 问题原因

离线同步详情页查询执行实例时发送了：

```json
{
  "pageNum": 1,
  "pageSize": 100,
  "jobDefinitionId": "1785737278040000"
}
```

但后端 `OfflineJobExecutionQueryDTO` 的分页字段是 `current`，仅兼容了 `pageNo`；同时 `jobDefinitionId` 是 `Long`。在严格请求体反序列化下，`pageNum` 和字符串 ID 会触发 400 参数格式错误。

## 修复内容

- 前端实例分页 API 统一将 `pageNum` / `pageNo` 转换为标准字段 `current`
- 路由中取得的字符串任务定义 ID 在确认属于 JavaScript 安全整数后转成 number
- 统一校验页码、每页条数和任务定义 ID，避免再次发送无效请求
- `linkupJobInstanceApi.page` 与 `batchJobInstanceApi.page` 共用同一套请求规范化逻辑
- 后端 DTO 同时兼容 `pageNo` 和历史字段 `pageNum`，避免旧页面或旧客户端继续报 400

## 实际请求体

修复后发送：

```json
{
  "current": 1,
  "pageSize": 100,
  "jobDefinitionId": 1785737278040000
}
```

## 验证

- [x] 对照后端 DTO 确认字段契约：`current`、`pageSize`、`Long jobDefinitionId`
- [x] 分支基于最新 `main`，无落后提交
- [x] 检查 TypeScript/Java 修改语法
- [ ] 本地启动前后端后进行接口联调
