### PR TITLE
feat(offline-sync): add field mapping and section navigation

### DIFF
--- a/yak-ops-ui/src/pages/batch-link-up/config/single/index.tsx
+++ b/yak-ops-ui/src/pages/batch-link-up/config/single/index.tsx
@@ -25,6 +25,75 @@ import {
   type SyncEditorState,
 } from '../../detail/model';
 
+const SECTION_ITEMS = [
+  { key: 'task-basic', label: '任务基础信息' },
+  { key: 'sync-config', label: '单表同步配置' },
+  { key: 'runtime-params', label: '运行参数' },
+  { key: 'field-mapping', label: '字段映射' },
+] as const;
+
+type SectionKey = (typeof SECTION_ITEMS)[number]['key'];
+
+interface SectionNavigatorProps {
+  activeKey: SectionKey;
+  onSelect: (key: SectionKey) => void;
+}
+
+function SectionNavigator({
+  activeKey,
+  onSelect,
+}: SectionNavigatorProps) {
+  return (
+    <nav
+      aria-label="配置区块定位"
+      className="rounded-xl bg-white px-4 py-4"
+    >
+      <div className="mb-3 text-[12px] font-semibold text-[#344054]">
+        快速定位
+      </div>
+
+      <div className="relative">
+        <span className="absolute bottom-3 left-[5px] top-3 w-px bg-[#e4e7ec]" />
+
+        <div className="space-y-1">
+          {SECTION_ITEMS.map((item) => {
+            const active = activeKey === item.key;
+
+            return (
+              <button
+                key={item.key}
+                type="button"
+                aria-current={active ? 'location' : undefined}
+                className="relative flex w-full cursor-pointer items-center gap-3 border-0 bg-transparent px-0 py-2 text-left"
+                onClick={() => onSelect(item.key)}
+              >
+                <span
+                  className={[
+                    'relative z-10 h-[11px] w-[11px] shrink-0 rounded-full border-2 border-white transition-colors',
+                    active
+                      ? 'bg-[var(--yak-brand-color)] shadow-[0_0_0_1px_var(--yak-brand-color)]'
+                      : 'bg-[#98a2b3] shadow-[0_0_0_1px_#d0d5dd]',
+                  ].join(' ')}
+                />
+                <span
+                  className={[
+                    'text-[12px] leading-5 transition-colors',
+                    active
+                      ? 'font-medium text-[var(--yak-brand-color)]'
+                      : 'text-[#667085] hover:text-[#344054]',
+                  ].join(' ')}
+                >
+                  {item.label}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    </nav>
+  );
+}
+
 const validateTaskConfig = (
   editor: SyncEditorState,
 ): string | null => {
@@ -98,8 +167,59 @@ export default function SingleBatchLinkUpConfigPage() {
   const [saving, setSaving] = useState(false);
   const [dataSourceLoading, setDataSourceLoading] = useState(false);
   const [dataSources, setDataSources] = useState<DataSourceRecord[]>([]);
+  const [activeSection, setActiveSection] = useState<SectionKey>('task-basic');
 
   useSmoothWheelScroll(pageRootRef, true);
+
+  const updateActiveSection = useCallback(() => {
+    const container = pageRootRef.current;
+    if (!container) return;
+
+    const threshold = container.getBoundingClientRect().top + 140;
+    let nextActive: SectionKey = SECTION_ITEMS[0].key;
+
+    SECTION_ITEMS.forEach((item) => {
+      const element = document.getElementById(item.key);
+      if (element && element.getBoundingClientRect().top <= threshold) {
+        nextActive = item.key;
+      }
+    });
+
+    setActiveSection((current) =>
+      current === nextActive ? current : nextActive,
+    );
+  }, []);
+
+  useEffect(() => {
+    const container = pageRootRef.current;
+    if (!container || !editor) return;
+
+    const handleViewportChange = () => {
+      window.requestAnimationFrame(updateActiveSection);
+    };
+
+    container.addEventListener('scroll', handleViewportChange, {
+      passive: true,
+    });
+    window.addEventListener('resize', handleViewportChange);
+    updateActiveSection();
+
+    return () => {
+      container.removeEventListener('scroll', handleViewportChange);
+      window.removeEventListener('resize', handleViewportChange);
+    };
+  }, [editor, updateActiveSection]);
+
+  const handleSectionLocate = (key: SectionKey) => {
+    const element = document.getElementById(key);
+    if (!element) return;
+
+    setActiveSection(key);
+    element.scrollIntoView({
+      behavior: 'smooth',
+      block: 'start',
+    });
+  };
 
   const loadDataSources = useCallback(async () => {
     try {
@@ -252,36 +372,47 @@ export default function SingleBatchLinkUpConfigPage() {
     <ConfigProvider theme={BRAND_THEME}>
       <div className="h-[calc(100vh-64px)] overflow-hidden bg-[#f7f8fa] text-[#161823]">
         <div ref={pageRootRef} className="h-full overflow-y-auto">
-          <div className="mx-auto w-full max-w-[1040px] px-6 pt-6">
-            <main className="pb-4">
-              <SyncTaskEditor
-                editor={editor}
-                dataSources={dataSources}
-                dataSourceLoading={dataSourceLoading}
-                onChange={setEditor}
-              />
-            </main>
+          <div className="mx-auto grid w-full max-w-[1280px] grid-cols-1 gap-6 px-6 pt-6 max-xl:max-w-[1040px] xl:grid-cols-[minmax(0,1fr)_160px]">
+            <div className="min-w-0">
+              <main className="pb-4">
+                <SyncTaskEditor
+                  editor={editor}
+                  dataSources={dataSources}
+                  dataSourceLoading={dataSourceLoading}
+                  onChange={setEditor}
+                />
+              </main>
 
-            <footer className="sticky bottom-0 z-50 overflow-hidden rounded-t-lg border border-b-0 border-[#eaecf0] bg-white shadow-[0_-8px_16px_rgba(0,0,0,0.06)]">
-              <div className="flex min-h-[80px] items-center gap-3 px-8 py-4">
-                <Button
-                  type="primary"
-                  loading={saving}
-                  className="!h-9 !min-w-[120px] !rounded-lg !px-6 !font-medium !text-white"
-                  onClick={handleSave}
-                >
-                  保存配置
-                </Button>
+              <footer className="sticky bottom-0 z-50 overflow-hidden rounded-t-lg border border-b-0 border-[#eaecf0] bg-white shadow-[0_-8px_16px_rgba(0,0,0,0.06)]">
+                <div className="flex min-h-[80px] items-center gap-3 px-8 py-4">
+                  <Button
+                    type="primary"
+                    loading={saving}
+                    className="!h-9 !min-w-[120px] !rounded-lg !px-6 !font-medium !text-white"
+                    onClick={handleSave}
+                  >
+                    保存配置
+                  </Button>
 
-                <Button
-                  disabled={saving}
-                  className="!h-9 !min-w-[120px] !rounded-lg !border-0 !bg-[#f2f3f5] !px-5 !font-medium !text-[#344054] hover:!bg-[#e9eaec]"
-                  onClick={handleCancel}
-                >
-                  取消
-                </Button>
+                  <Button
+                    disabled={saving}
+                    className="!h-9 !min-w-[120px] !rounded-lg !border-0 !bg-[#f2f3f5] !px-5 !font-medium !text-[#344054] hover:!bg-[#e9eaec]"
+                    onClick={handleCancel}
+                  >
+                    取消
+                  </Button>
+                </div>
+              </footer>
+            </div>
+
+            <aside className="hidden xl:block">
+              <div className="sticky top-6">
+                <SectionNavigator
+                  activeKey={activeSection}
+                  onSelect={handleSectionLocate}
+                />
               </div>
-            </footer>
+            </aside>
           </div>
         </div>
       </div>

--- a/yak-ops-ui/src/pages/batch-link-up/detail/components/FieldMappingSection.tsx
+++ b/yak-ops-ui/src/pages/batch-link-up/detail/components/FieldMappingSection.tsx
@@ -1,0 +1,363 @@
+import {
+  DeleteOutlined,
+  PlusOutlined,
+  SwapOutlined,
+} from '@ant-design/icons';
+import { Button, Empty, Input, Select, Tag } from 'antd';
+import { useEffect, useMemo, useRef, useState } from 'react';
+
+import type { DataSourceColumnOption } from '../hooks/useDataSourceColumns';
+import EditorSection from './EditorSection';
+
+interface FieldMappingSectionProps {
+  sourceColumns: DataSourceColumnOption[];
+  targetColumns: DataSourceColumnOption[];
+  sourceLoading: boolean;
+  targetLoading: boolean;
+  sourceReady: boolean;
+  targetReady: boolean;
+  targetDerived?: boolean;
+}
+
+interface FieldMappingRow {
+  key: string;
+  sourceField?: string;
+  targetField?: string;
+}
+
+const normalizeFieldName = (value: string) => value.trim().toLowerCase();
+
+let mappingRowSeed = 0;
+
+const createMappingKey = (index: number) => {
+  mappingRowSeed += 1;
+  return `mapping-${mappingRowSeed}-${index}`;
+};
+
+const buildSameNameMappings = (
+  sourceColumns: DataSourceColumnOption[],
+  targetColumns: DataSourceColumnOption[],
+): FieldMappingRow[] => {
+  const targetMap = new Map(
+    targetColumns.map((column) => [normalizeFieldName(column.value), column.value]),
+  );
+
+  return sourceColumns
+    .map((column, index) => {
+      const targetField = targetMap.get(normalizeFieldName(column.value));
+      if (!targetField) return null;
+      return {
+        key: createMappingKey(index),
+        sourceField: column.value,
+        targetField,
+      };
+    })
+    .filter(Boolean) as FieldMappingRow[];
+};
+
+const buildPositionMappings = (
+  sourceColumns: DataSourceColumnOption[],
+  targetColumns: DataSourceColumnOption[],
+): FieldMappingRow[] => {
+  const size = Math.min(sourceColumns.length, targetColumns.length);
+
+  return Array.from({ length: size }, (_, index) => ({
+    key: createMappingKey(index),
+    sourceField: sourceColumns[index]?.value,
+    targetField: targetColumns[index]?.value,
+  }));
+};
+
+const fieldType = (column?: DataSourceColumnOption) =>
+  column?.description?.split(' · ')[0] || '-';
+
+const filterColumns = (
+  columns: DataSourceColumnOption[],
+  keyword: string,
+) => {
+  const normalized = keyword.trim().toLowerCase();
+  if (!normalized) return columns;
+
+  return columns.filter((column) =>
+    [column.label, column.value, column.description]
+      .filter(Boolean)
+      .some((value) => String(value).toLowerCase().includes(normalized)),
+  );
+};
+
+export default function FieldMappingSection({
+  sourceColumns,
+  targetColumns,
+  sourceLoading,
+  targetLoading,
+  sourceReady,
+  targetReady,
+  targetDerived = false,
+}: FieldMappingSectionProps) {
+  const [rows, setRows] = useState<FieldMappingRow[]>([]);
+  const [sourceKeyword, setSourceKeyword] = useState('');
+  const [targetKeyword, setTargetKeyword] = useState('');
+  const initializedKeyRef = useRef('');
+
+  const sourceMap = useMemo(
+    () => new Map(sourceColumns.map((column) => [column.value, column])),
+    [sourceColumns],
+  );
+  const targetMap = useMemo(
+    () => new Map(targetColumns.map((column) => [column.value, column])),
+    [targetColumns],
+  );
+
+  const filteredSourceColumns = useMemo(
+    () => filterColumns(sourceColumns, sourceKeyword),
+    [sourceColumns, sourceKeyword],
+  );
+  const filteredTargetColumns = useMemo(
+    () => filterColumns(targetColumns, targetKeyword),
+    [targetColumns, targetKeyword],
+  );
+
+  const sourceOptions = useMemo(
+    () =>
+      filteredSourceColumns.map((column) => ({
+        label: column.description
+          ? `${column.label} · ${column.description}`
+          : column.label,
+        value: column.value,
+      })),
+    [filteredSourceColumns],
+  );
+  const targetOptions = useMemo(
+    () =>
+      filteredTargetColumns.map((column) => ({
+        label: column.description
+          ? `${column.label} · ${column.description}`
+          : column.label,
+        value: column.value,
+      })),
+    [filteredTargetColumns],
+  );
+
+  useEffect(() => {
+    const initializeKey = [
+      sourceColumns.map((column) => column.value).join(','),
+      targetColumns.map((column) => column.value).join(','),
+    ].join('::');
+
+    if (!initializeKey || initializedKeyRef.current === initializeKey) return;
+
+    initializedKeyRef.current = initializeKey;
+    setRows(buildSameNameMappings(sourceColumns, targetColumns));
+  }, [sourceColumns, targetColumns]);
+
+  const updateRow = (
+    key: string,
+    patch: Partial<FieldMappingRow>,
+  ) => {
+    setRows((current) =>
+      current.map((row) => (row.key === key ? { ...row, ...patch } : row)),
+    );
+  };
+
+  const addRow = () => {
+    setRows((current) => [
+      ...current,
+      { key: createMappingKey(current.length) },
+    ]);
+  };
+
+  const removeRow = (key: string) => {
+    setRows((current) => current.filter((row) => row.key !== key));
+  };
+
+  const mappingReady = sourceColumns.length > 0 && targetColumns.length > 0;
+  const loading = sourceLoading || targetLoading;
+
+  return (
+    <EditorSection title="字段映射">
+      <div className="space-y-4">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="flex min-w-0 items-center gap-2 text-[12px] text-[#667085]">
+            <span>配置来源字段与目标字段的对应关系</span>
+            <Tag bordered={false} className="!m-0 !bg-[#f2f3f5] !text-[#667085]">
+              已映射 {rows.filter((row) => row.sourceField && row.targetField).length} 项
+            </Tag>
+            {targetDerived ? (
+              <Tag bordered={false} className="!m-0 !bg-[#fff4f6] !text-[var(--yak-brand-color)]">
+                目标字段按来源预览
+              </Tag>
+            ) : null}
+          </div>
+
+          <div className="flex flex-wrap items-center gap-2">
+            <Button
+              size="small"
+              type="primary"
+              disabled={!mappingReady}
+              onClick={() =>
+                setRows(buildSameNameMappings(sourceColumns, targetColumns))
+              }
+            >
+              同名映射
+            </Button>
+            <Button
+              size="small"
+              disabled={!mappingReady}
+              onClick={() =>
+                setRows(buildPositionMappings(sourceColumns, targetColumns))
+              }
+            >
+              同序映射
+            </Button>
+            <Button size="small" disabled={rows.length === 0} onClick={() => setRows([])}>
+              清空映射
+            </Button>
+          </div>
+        </div>
+
+        <div className="overflow-hidden rounded-xl border border-[#e8eaee] bg-white">
+          <div className="grid grid-cols-[minmax(0,1fr)_96px_minmax(0,1fr)_44px] items-center gap-3 border-b border-[#e8eaee] bg-[#f7f8fa] px-4 py-3 max-md:grid-cols-[minmax(0,1fr)_52px_minmax(0,1fr)_36px]">
+            <div>
+              <div className="text-[12px] font-semibold text-[#344054]">来源字段</div>
+              <Input
+                allowClear
+                variant="filled"
+                size="small"
+                value={sourceKeyword}
+                placeholder="搜索来源字段"
+                className="!mt-2"
+                onChange={(event) => setSourceKeyword(event.target.value)}
+              />
+            </div>
+            <div className="text-center text-[11px] text-[#98a2b3]">映射关系</div>
+            <div>
+              <div className="text-[12px] font-semibold text-[#344054]">目标字段</div>
+              <Input
+                allowClear
+                variant="filled"
+                size="small"
+                value={targetKeyword}
+                placeholder="搜索目标字段"
+                className="!mt-2"
+                onChange={(event) => setTargetKeyword(event.target.value)}
+              />
+            </div>
+            <div />
+          </div>
+
+          {!sourceReady || !targetReady ? (
+            <div className="flex min-h-[220px] items-center justify-center px-5">
+              <Empty
+                image={Empty.PRESENTED_IMAGE_SIMPLE}
+                description="请先完成来源端和目标端配置"
+              />
+            </div>
+          ) : loading ? (
+            <div className="flex min-h-[220px] items-center justify-center text-[12px] text-[#98a2b3]">
+              正在加载字段信息...
+            </div>
+          ) : !mappingReady ? (
+            <div className="flex min-h-[220px] items-center justify-center px-5">
+              <Empty
+                image={Empty.PRESENTED_IMAGE_SIMPLE}
+                description="当前表暂未获取到可映射字段"
+              />
+            </div>
+          ) : (
+            <div>
+              {rows.length > 0 ? (
+                rows.map((row) => {
+                  const sourceColumn = row.sourceField
+                    ? sourceMap.get(row.sourceField)
+                    : undefined;
+                  const targetColumn = row.targetField
+                    ? targetMap.get(row.targetField)
+                    : undefined;
+
+                  return (
+                    <div
+                      key={row.key}
+                      className="grid min-h-[64px] grid-cols-[minmax(0,1fr)_96px_minmax(0,1fr)_44px] items-center gap-3 border-b border-[#f0f1f3] px-4 py-2.5 last:border-b-0 max-md:grid-cols-[minmax(0,1fr)_52px_minmax(0,1fr)_36px]"
+                    >
+                      <div className="min-w-0">
+                        <Select
+                          allowClear
+                          showSearch
+                          variant="filled"
+                          value={row.sourceField}
+                          options={sourceOptions}
+                          optionFilterProp="label"
+                          placeholder="选择来源字段"
+                          className="w-full"
+                          onChange={(sourceField) =>
+                            updateRow(row.key, { sourceField })
+                          }
+                        />
+                        <div className="mt-1 truncate text-[11px] text-[#98a2b3]">
+                          类型：{fieldType(sourceColumn)}
+                        </div>
+                      </div>
+
+                      <div className="relative flex h-8 items-center justify-center">
+                        <div className="absolute left-0 right-0 top-1/2 h-px -translate-y-1/2 bg-[#cfd4dc]" />
+                        <span className="relative z-10 flex h-7 w-7 items-center justify-center rounded-full border border-[#dfe3e8] bg-white text-[12px] text-[#98a2b3]">
+                          <SwapOutlined />
+                        </span>
+                      </div>
+
+                      <div className="min-w-0">
+                        <Select
+                          allowClear
+                          showSearch
+                          variant="filled"
+                          value={row.targetField}
+                          options={targetOptions}
+                          optionFilterProp="label"
+                          placeholder="选择目标字段"
+                          className="w-full"
+                          onChange={(targetField) =>
+                            updateRow(row.key, { targetField })
+                          }
+                        />
+                        <div className="mt-1 truncate text-[11px] text-[#98a2b3]">
+                          类型：{fieldType(targetColumn)}
+                        </div>
+                      </div>
+
+                      <Button
+                        type="text"
+                        danger
+                        icon={<DeleteOutlined />}
+                        className="!h-8 !w-8 !min-w-0 !p-0"
+                        onClick={() => removeRow(row.key)}
+                      />
+                    </div>
+                  );
+                })
+              ) : (
+                <div className="flex min-h-[160px] items-center justify-center px-5 text-[12px] text-[#98a2b3]">
+                  暂无映射关系，可通过上方规则生成或手动添加。
+                </div>
+              )}
+
+              <div className="border-t border-[#f0f1f3] px-4 py-3">
+                <Button
+                  type="dashed"
+                  block
+                  icon={<PlusOutlined />}
+                  onClick={addRow}
+                >
+                  添加字段映射
+                </Button>
+              </div>
+            </div>
+          )}
+        </div>
+
+        <div className="text-[11px] leading-5 text-[#98a2b3]">
+          当前字段映射仅保存在页面状态中，本次改动暂不写入任务定义。
+        </div>
+      </div>
+    </EditorSection>
+  );
+}

--- a/yak-ops-ui/src/pages/batch-link-up/detail/components/SyncTaskEditor.tsx
+++ b/yak-ops-ui/src/pages/batch-link-up/detail/components/SyncTaskEditor.tsx
@@ -9,6 +9,7 @@ import {
 } from '../model';
 import ChannelConfigSection from './ChannelConfigSection';
 import ConnectorExtraParams from './ConnectorExtraParams';
+import FieldMappingSection from './FieldMappingSection';
 import MultiTableConfigSection from './MultiTableConfigSection';
 import SingleTableConfigSection from './SingleTableConfigSection';
 import TaskBasicSection from './TaskBasicSection';
@@ -58,15 +59,27 @@ export default function SyncTaskEditor({
     : sourceConfig.table
       ? { table_path: sourceConfig.table }
       : undefined;
-  const targetColumnRequest = sinkConfig.autoCreateTable
-    ? sourceColumnRequest
-    : sinkConfig.table
-      ? { table_path: sinkConfig.table }
-      : undefined;
-  const primaryKeyCatalog = useDataSourceColumns(
-    sinkConfig.autoCreateTable ? sourceId : targetId,
+  const targetColumnRequest = !sinkConfig.autoCreateTable && sinkConfig.table
+    ? { table_path: sinkConfig.table }
+    : undefined;
+
+  const sourceColumnCatalog = useDataSourceColumns(
+    sourceId,
+    sourceColumnRequest,
+  );
+  const targetColumnCatalog = useDataSourceColumns(
+    targetId,
     targetColumnRequest,
   );
+  const primaryKeyCatalog = sinkConfig.autoCreateTable
+    ? sourceColumnCatalog
+    : targetColumnCatalog;
+  const mappingTargetColumns = sinkConfig.autoCreateTable
+    ? sourceColumnCatalog.columns
+    : targetColumnCatalog.columns;
+  const mappingTargetLoading = sinkConfig.autoCreateTable
+    ? sourceColumnCatalog.loading
+    : targetColumnCatalog.loading;
 
   const updateSource = (patch: Record<string, any>) => {
     onChange(updateEndpointConfig(editor, 'source', patch));
@@ -106,51 +119,74 @@ export default function SyncTaskEditor({
 
   return (
     <div className="space-y-5">
-      <TaskBasicSection
-        editor={editor}
-        dataSources={dataSources}
-        dataSourceLoading={dataSourceLoading}
-        onChange={onChange}
-      />
+      <div id="task-basic" className="scroll-mt-6">
+        <TaskBasicSection
+          editor={editor}
+          dataSources={dataSources}
+          dataSourceLoading={dataSourceLoading}
+          onChange={onChange}
+        />
+      </div>
 
-      {editor.mode === 'GUIDE_MULTI' ? (
-        <MultiTableConfigSection
-          sourceConfig={sourceConfig}
+      <div id="sync-config" className="scroll-mt-6">
+        {editor.mode === 'GUIDE_MULTI' ? (
+          <MultiTableConfigSection
+            sourceConfig={sourceConfig}
+            sinkConfig={sinkConfig}
+            sourceTables={sourceCatalog.tables}
+            sourceLoading={sourceCatalog.loading}
+            sourceReady={Boolean(sourceId)}
+            targetReady={Boolean(targetId)}
+            sourceExtraParameters={sourceExtraParameters}
+            sinkExtraParameters={sinkExtraParameters}
+            onSourceChange={updateSource}
+            onSinkChange={updateSink}
+          />
+        ) : (
+          <SingleTableConfigSection
+            sourceConfig={sourceConfig}
+            sinkConfig={sinkConfig}
+            sourceTables={sourceCatalog.tables}
+            targetTables={targetCatalog.tables}
+            sourceLoading={sourceCatalog.loading}
+            targetLoading={targetCatalog.loading}
+            primaryKeyOptions={primaryKeyCatalog.columns}
+            primaryKeyLoading={primaryKeyCatalog.loading}
+            sourceReady={Boolean(sourceId)}
+            targetReady={Boolean(targetId)}
+            sourceExtraParameters={sourceExtraParameters}
+            sinkExtraParameters={sinkExtraParameters}
+            onSourceChange={updateSource}
+            onSinkChange={updateSink}
+          />
+        )}
+      </div>
+
+      <div id="runtime-params" className="scroll-mt-6">
+        <ChannelConfigSection
+          editor={editor}
           sinkConfig={sinkConfig}
-          sourceTables={sourceCatalog.tables}
-          sourceLoading={sourceCatalog.loading}
-          sourceReady={Boolean(sourceId)}
-          targetReady={Boolean(targetId)}
-          sourceExtraParameters={sourceExtraParameters}
-          sinkExtraParameters={sinkExtraParameters}
-          onSourceChange={updateSource}
+          onChange={onChange}
           onSinkChange={updateSink}
         />
-      ) : (
-        <SingleTableConfigSection
-          sourceConfig={sourceConfig}
-          sinkConfig={sinkConfig}
-          sourceTables={sourceCatalog.tables}
-          targetTables={targetCatalog.tables}
-          sourceLoading={sourceCatalog.loading}
-          targetLoading={targetCatalog.loading}
-          primaryKeyOptions={primaryKeyCatalog.columns}
-          primaryKeyLoading={primaryKeyCatalog.loading}
-          sourceReady={Boolean(sourceId)}
-          targetReady={Boolean(targetId)}
-          sourceExtraParameters={sourceExtraParameters}
-          sinkExtraParameters={sinkExtraParameters}
-          onSourceChange={updateSource}
-          onSinkChange={updateSink}
-        />
-      )}
+      </div>
 
-      <ChannelConfigSection
-        editor={editor}
-        sinkConfig={sinkConfig}
-        onChange={onChange}
-        onSinkChange={updateSink}
-      />
+      {editor.mode === 'GUIDE_SINGLE' ? (
+        <div id="field-mapping" className="scroll-mt-6">
+          <FieldMappingSection
+            sourceColumns={sourceColumnCatalog.columns}
+            targetColumns={mappingTargetColumns}
+            sourceLoading={sourceColumnCatalog.loading}
+            targetLoading={mappingTargetLoading}
+            sourceReady={Boolean(sourceId && sourceColumnRequest)}
+            targetReady={Boolean(
+              targetId &&
+                (sinkConfig.autoCreateTable || targetColumnRequest),
+            )}
+            targetDerived={Boolean(sinkConfig.autoCreateTable)}
+          />
+        </div>
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
## 变更说明

- 在单表离线同步配置页的「运行参数」下方新增「字段映射」区域。
- 复用现有字段元数据接口加载来源字段与目标字段。
- 支持同名映射、同序映射、清空映射、手动新增/删除及字段搜索。
- 自动建表场景下，目标字段先按来源字段生成前端预览。
- 页面右侧新增粘性快速定位导航，支持基础信息、单表配置、运行参数和字段映射之间平滑定位，并随滚动更新当前区块。

## 当前边界

- 字段映射仅保存在当前页面状态中。
- 未修改保存接口、任务定义结构或后端逻辑，保存任务时不会提交字段映射。

## 验证

- 已检查分支与 `main` 的差异，变更仅涉及离线同步单表配置页及新增字段映射组件。
- 当前环境无法拉取完整仓库依赖，因此未执行本地 `npm run lint` / `npm run build`，等待 PR CI 进一步验证。