### PR TITLE
refactor(offline-sync): move field mapping to task root

### DIFF
--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/ColumnMappingLinkUpJobSpecFactory.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/ColumnMappingLinkUpJobSpecFactory.java
@@ -17,9 +17,10 @@ import org.springframework.util.StringUtils;
 /**
  * Adds Yak Ops' fixed single-table column mapping contract to Link-Up JobSpec.
  *
- * <p>The existing factory remains responsible for connector and runtime
- * compilation. This primary specialization only normalizes mapping metadata,
- * keeping the mapping independent from connector options.</p>
+ * <p>Field mapping is a job-level configuration and is therefore stored next
+ * to basic/source/sink/channel in the Yak Ops definition. Historical
+ * source.config.mapping definitions are promoted to the top level before the
+ * base JobSpec compiler runs.</p>
  */
 @Primary
 @Component
@@ -37,15 +38,21 @@ public class ColumnMappingLinkUpJobSpecFactory extends LinkUpJobSpecFactory {
 
   @Override
   public BuildResult build(JsonNode definition) {
-    BuildResult base = super.build(definition);
-    ObjectNode mapping = normalizeMapping(definition);
-    if (mapping == null) {
-      return base;
+    ObjectNode normalizedDefinition = normalizeDefinition(definition);
+    ObjectNode mapping = objectMapping(normalizedDefinition.get("mapping"));
+
+    if (mapping != null) {
+      String mode = normalizedDefinition.path("basic")
+          .path("mode")
+          .asText("GUIDE_SINGLE");
+      if (!"GUIDE_SINGLE".equalsIgnoreCase(mode)) {
+        throw new IllegalArgumentException("多表同步暂不支持自定义字段映射");
+      }
     }
 
-    String mode = definition.path("basic").path("mode").asText("GUIDE_SINGLE");
-    if (!"GUIDE_SINGLE".equalsIgnoreCase(mode)) {
-      throw new IllegalArgumentException("多表同步暂不支持自定义字段映射");
+    BuildResult base = super.build(normalizedDefinition);
+    if (mapping == null) {
+      return base;
     }
 
     ObjectNode jobSpec = (ObjectNode) base.getJobSpec().deepCopy();
@@ -60,6 +67,34 @@ public class ColumnMappingLinkUpJobSpecFactory extends LinkUpJobSpecFactory {
         base.getSinkConnectorId(),
         base.getSourceTable(),
         base.getSinkTable());
+  }
+
+  private ObjectNode normalizeDefinition(JsonNode definition) {
+    if (definition == null || !definition.isObject()) {
+      throw new IllegalArgumentException("离线同步任务定义必须是 JSON 对象");
+    }
+
+    ObjectNode normalized = (ObjectNode) definition.deepCopy();
+    ObjectNode mapping = normalizeMapping(definition);
+
+    if (mapping == null) {
+      normalized.remove("mapping");
+    } else {
+      normalized.set("mapping", mapping);
+    }
+
+    JsonNode source = normalized.get("source");
+    if (source != null && source.isObject()) {
+      ObjectNode sourceObject = (ObjectNode) source;
+      sourceObject.remove("mapping");
+
+      JsonNode config = sourceObject.get("config");
+      if (config != null && config.isObject()) {
+        ((ObjectNode) config).remove("mapping");
+      }
+    }
+
+    return normalized;
   }
 
   private ObjectNode normalizeMapping(JsonNode definition) {
@@ -83,6 +118,7 @@ public class ColumnMappingLinkUpJobSpecFactory extends LinkUpJobSpecFactory {
       if (!StringUtils.hasText(source) || !StringUtils.hasText(target)) {
         throw new IllegalArgumentException("字段映射的来源字段和目标字段不能为空");
       }
+
       source = source.trim();
       target = target.trim();
       if (!sources.add(source)) {
@@ -91,6 +127,7 @@ public class ColumnMappingLinkUpJobSpecFactory extends LinkUpJobSpecFactory {
       if (!targets.add(target)) {
         throw new IllegalArgumentException("目标字段不能重复映射：" + target);
       }
+
       normalizedColumns.addObject()
           .put("source", source)
           .put("target", target);
@@ -99,6 +136,12 @@ public class ColumnMappingLinkUpJobSpecFactory extends LinkUpJobSpecFactory {
     ObjectNode normalized = objectMapper.createObjectNode();
     normalized.set("columns", normalizedColumns);
     return normalized;
+  }
+
+  private ObjectNode objectMapping(JsonNode mapping) {
+    return mapping != null && mapping.isObject()
+        ? (ObjectNode) mapping
+        : null;
   }
 
   private String text(JsonNode node, String field, String fallback) {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/engine/ColumnMappingLinkUpJobSpecFactoryTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/engine/ColumnMappingLinkUpJobSpecFactoryTest.java
@@ -16,7 +16,7 @@ class ColumnMappingLinkUpJobSpecFactoryTest {
   private final ObjectMapper mapper = new ObjectMapper();
 
   @Test
-  void shouldPromoteEditorMappingIntoTopLevelJobSpec() throws Exception {
+  void shouldCompileTopLevelEditorMappingIntoJobSpec() throws Exception {
     ColumnMappingLinkUpJobSpecFactory factory = factory();
     JsonNode definition = mapper.readTree("""
         {
@@ -24,15 +24,7 @@ class ColumnMappingLinkUpJobSpecFactoryTest {
           "source": {
             "connectorId": "jdbc",
             "dataSourceId": 1,
-            "config": {
-              "table": "demo.users",
-              "mapping": {
-                "columns": [
-                  {"source": "name", "target": "user_name"},
-                  {"sourceField": "id", "targetField": "user_id"}
-                ]
-              }
-            }
+            "config": {"table": "demo.users"}
           },
           "sink": {
             "connectorId": "jdbc",
@@ -42,7 +34,13 @@ class ColumnMappingLinkUpJobSpecFactoryTest {
               "writeMode": "append"
             }
           },
-          "channel": {"parallelism": 1}
+          "channel": {"parallelism": 1},
+          "mapping": {
+            "columns": [
+              {"source": "name", "target": "user_name"},
+              {"sourceField": "id", "targetField": "user_id"}
+            ]
+          }
         }
         """);
 
@@ -57,7 +55,42 @@ class ColumnMappingLinkUpJobSpecFactoryTest {
   }
 
   @Test
-  void shouldRejectMappingForMultiTableJobs() throws Exception {
+  void shouldPromoteLegacySourceConfigMapping() throws Exception {
+    ColumnMappingLinkUpJobSpecFactory factory = factory();
+    JsonNode definition = mapper.readTree("""
+        {
+          "basic": {"jobName": "legacy-mapped-users", "mode": "GUIDE_SINGLE"},
+          "source": {
+            "connectorId": "jdbc",
+            "dataSourceId": 1,
+            "config": {
+              "table": "demo.users",
+              "mapping": {
+                "columns": [
+                  {"source": "id", "target": "user_id"}
+                ]
+              }
+            }
+          },
+          "sink": {
+            "connectorId": "jdbc",
+            "dataSourceId": 2,
+            "config": {"table": "demo.users_copy"}
+          },
+          "channel": {"parallelism": 1}
+        }
+        """);
+
+    LinkUpJobSpecFactory.BuildResult result = factory.build(definition);
+
+    assertThat(result.getJobSpec().path("mapping").path("columns")).hasSize(1);
+    assertThat(result.getJobSpec().path("mapping").path("columns").get(0).path("target").asText())
+        .isEqualTo("user_id");
+    assertThat(result.getJobSpec().path("source").path("options").has("mapping")).isFalse();
+  }
+
+  @Test
+  void shouldRejectTopLevelMappingForMultiTableJobs() throws Exception {
     ColumnMappingLinkUpJobSpecFactory factory = factory();
     JsonNode definition = mapper.readTree("""
         {
@@ -66,10 +99,7 @@ class ColumnMappingLinkUpJobSpecFactoryTest {
             "connectorId": "jdbc",
             "dataSourceId": 1,
             "database": "demo",
-            "tables": ["users"],
-            "config": {
-              "mapping": {"columns": [{"source": "id", "target": "user_id"}]}
-            }
+            "tables": ["users"]
           },
           "sink": {
             "connectorId": "jdbc",
@@ -79,7 +109,10 @@ class ColumnMappingLinkUpJobSpecFactoryTest {
             "autoCreateTable": true,
             "writeMode": "APPEND"
           },
-          "channel": {"parallelism": 1}
+          "channel": {"parallelism": 1},
+          "mapping": {
+            "columns": [{"source": "id", "target": "user_id"}]
+          }
         }
         """);
 

--- a/yak-ops-ui/src/pages/batch-link-up/detail/components/SyncTaskEditor.tsx
+++ b/yak-ops-ui/src/pages/batch-link-up/detail/components/SyncTaskEditor.tsx
@@ -27,7 +27,6 @@ const SOURCE_MANAGED_KEYS = [
   'table_path',
   'table_list',
   'query',
-  'mapping',
 ];
 
 const SINK_MANAGED_KEYS = [
@@ -71,7 +70,7 @@ export default function SyncTaskEditor({
   const sourceId = editor.source.dataSourceId;
   const targetId = editor.sink.dataSourceId;
   const mappingColumns = normalizeMappings(
-    sourceConfig.mapping?.columns,
+    editor.mapping?.columns,
   );
 
   const sourceCatalog = useDataSourceTables(sourceId);
@@ -112,6 +111,15 @@ export default function SyncTaskEditor({
 
   const updateSink = (patch: Record<string, any>) => {
     onChange(updateEndpointConfig(editor, 'sink', patch));
+  };
+
+  const updateMapping = (columns: FieldMappingValue[]) => {
+    onChange({
+      ...editor,
+      mapping: {
+        columns,
+      },
+    });
   };
 
   const sourceConnectorId =
@@ -200,13 +208,7 @@ export default function SyncTaskEditor({
         <div id="field-mapping" className="scroll-mt-6">
           <FieldMappingSection
             value={mappingColumns}
-            onChange={(columns) =>
-              updateSource({
-                mapping: {
-                  columns,
-                },
-              })
-            }
+            onChange={updateMapping}
             sourceColumns={sourceColumnCatalog.columns}
             targetColumns={mappingTargetColumns}
             sourceLoading={sourceColumnCatalog.loading}

--- a/yak-ops-ui/src/pages/batch-link-up/detail/model.ts
+++ b/yak-ops-ui/src/pages/batch-link-up/detail/model.ts
@@ -28,6 +28,15 @@ export interface SyncChannel {
   dirtyDataLimit: number;
 }
 
+export interface SyncColumnMapping {
+  source: string;
+  target: string;
+}
+
+export interface SyncMapping {
+  columns: SyncColumnMapping[];
+}
+
 export interface SyncEditorState {
   id: string;
   mode: SyncMode;
@@ -35,6 +44,7 @@ export interface SyncEditorState {
   source: SyncEndpoint;
   sink: SyncEndpoint;
   channel: SyncChannel;
+  mapping: SyncMapping;
   state?: Record<string, any>;
 }
 
@@ -58,6 +68,10 @@ export const DEFAULT_CHANNEL_CONFIG: SyncChannel = {
   dirtyDataLimit: 0,
 };
 
+export const DEFAULT_MAPPING_CONFIG: SyncMapping = {
+  columns: [],
+};
+
 export const isApiSuccess = (response: any): boolean =>
   response?.code === API_SUCCESS_CODE;
 
@@ -77,6 +91,59 @@ export const extractSavedId = (response: any, fallback: string): string => {
     ? fallback
     : String(value);
 };
+
+const normalizeMappingColumns = (value: unknown): SyncColumnMapping[] => {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  const usedSources = new Set<string>();
+  const usedTargets = new Set<string>();
+
+  return value.reduce<SyncColumnMapping[]>((result, item: any) => {
+    const source = String(
+      item?.source ?? item?.sourceField ?? '',
+    ).trim();
+    const target = String(
+      item?.target ?? item?.targetField ?? '',
+    ).trim();
+
+    if (
+      !source ||
+      !target ||
+      usedSources.has(source) ||
+      usedTargets.has(target)
+    ) {
+      return result;
+    }
+
+    usedSources.add(source);
+    usedTargets.add(target);
+    result.push({ source, target });
+    return result;
+  }, []);
+};
+
+const normalizeMapping = (raw: any): SyncMapping => {
+  const directMapping =
+    raw?.mapping && typeof raw.mapping === 'object'
+      ? raw.mapping
+      : undefined;
+  const legacyMapping =
+    raw?.source?.config?.mapping &&
+    typeof raw.source.config.mapping === 'object'
+      ? raw.source.config.mapping
+      : undefined;
+  const mapping = directMapping || legacyMapping || {};
+
+  return {
+    columns: normalizeMappingColumns(mapping.columns),
+  };
+};
+
+const serializeMapping = (mapping?: SyncMapping): SyncMapping => ({
+  columns: normalizeMappingColumns(mapping?.columns),
+});
 
 const endpointFromType = (
   endpoint?: Partial<CreateSyncEndpoint> | null,
@@ -150,6 +217,7 @@ export const buildCreatePayload = (
       source: multiDraftEndpoint(sourceEndpoint, 'source'),
       sink: multiDraftEndpoint(sinkEndpoint, 'sink'),
       channel: serializeChannel(DEFAULT_CHANNEL_CONFIG),
+      mapping: { ...DEFAULT_MAPPING_CONFIG },
     };
   }
 
@@ -159,6 +227,7 @@ export const buildCreatePayload = (
     source: sourceEndpoint,
     sink: sinkEndpoint,
     channel: DEFAULT_CHANNEL_CONFIG,
+    mapping: { ...DEFAULT_MAPPING_CONFIG },
   };
 };
 
@@ -221,6 +290,10 @@ const directConfig = (
     value?.options && typeof value.options === 'object'
       ? value.options
       : config.connectorOptions || {};
+
+  // 字段映射是任务级配置。旧任务中的 source.config.mapping
+  // 会由 normalizeMapping 迁移到顶层，端点配置不再保留该字段。
+  delete config.mapping;
 
   const keys = kind === 'source'
     ? [
@@ -342,6 +415,7 @@ export const normalizeEditDetail = (
       ),
       dirtyDataPolicy: dirtyDataPolicy === 'SKIP' ? 'skip' : 'stop',
     },
+    mapping: normalizeMapping(raw),
     state: raw?.state,
   };
 };
@@ -405,6 +479,9 @@ export const applyEndpointSelection = (
         ? resetEndpointConfig(kind, current.config)
         : current.config,
     },
+    mapping: dataSourceChanged
+      ? { ...DEFAULT_MAPPING_CONFIG }
+      : editor.mapping,
   };
 };
 
@@ -489,6 +566,16 @@ const multiSinkPayload = (sink: SyncEndpoint) => {
   };
 };
 
+const endpointSavePayload = (endpointValue: SyncEndpoint): SyncEndpoint => {
+  const config = { ...(endpointValue.config || {}) };
+  delete config.mapping;
+
+  return {
+    ...endpointValue,
+    config,
+  };
+};
+
 export const buildSavePayload = (
   editor: SyncEditorState,
 ) => {
@@ -497,6 +584,9 @@ export const buildSavePayload = (
     jobDesc: editor.basic.jobDesc.trim(),
     mode: editor.mode,
   };
+  const mapping = editor.mode === 'GUIDE_SINGLE'
+    ? serializeMapping(editor.mapping)
+    : { ...DEFAULT_MAPPING_CONFIG };
 
   if (editor.mode === 'GUIDE_MULTI') {
     return {
@@ -505,14 +595,16 @@ export const buildSavePayload = (
       source: multiSourcePayload(editor.source),
       sink: multiSinkPayload(editor.sink),
       channel: serializeChannel(editor.channel),
+      mapping,
     };
   }
 
   return {
     id: editor.id,
     basic,
-    source: editor.source,
-    sink: editor.sink,
+    source: endpointSavePayload(editor.source),
+    sink: endpointSavePayload(editor.sink),
     channel: editor.channel,
+    mapping,
   };
 };


### PR DESCRIPTION
## 变更说明

字段映射属于任务级配置，不应挂在来源端配置下。本 PR 将离线同步任务定义从：

```json
{
  "source": {
    "config": {
      "mapping": {
        "columns": []
      }
    }
  }
}
```

调整为：

```json
{
  "basic": {},
  "source": {},
  "sink": {},
  "channel": {},
  "mapping": {
    "columns": []
  }
}
```

## 前端改造

- 在 `SyncEditorState` 中新增顶层 `mapping` 任务配置。
- 创建任务、编辑回显和保存载荷统一使用顶层 `mapping.columns`。
- `SyncTaskEditor` 直接读写 `editor.mapping.columns`。
- 保存前主动清理端点配置中可能残留的 `config.mapping`。
- 切换来源端或目标端数据源时清空旧字段映射，避免旧 Schema 残留。
- 不修改 `FieldMappingSection` 的 UI、样式和交互结构。

## 后端改造

- `ColumnMappingLinkUpJobSpecFactory` 以顶层 `mapping` 为标准输入。
- 历史任务中的 `source.config.mapping` 会在编译前提升到顶层。
- 编译前从 `source` 和 `source.config` 中移除旧的嵌套字段，避免进入 Connector 配置。
- Link-Up JobSpec 仍然输出顶层 `mapping.columns`。
- 保持单表映射限制以及来源字段、目标字段重复校验。

## 兼容性

- 新任务只保存顶层 `mapping`。
- 旧任务的 `source.config.mapping` 仍可正常回显和运行；下一次保存后会迁移为顶层结构。
- 多表同步保持 `mapping.columns` 为空，不启用自定义字段映射。

## 验证

- TypeScript 文件已做独立语法检查，除当前环境缺少项目模块解析外未发现语法错误。
- 更新后端单元测试，覆盖顶层结构、历史嵌套结构兼容以及多表模式拒绝。
- 分支与 `main` 的差异仅包含 4 个文件，没有修改字段映射 UI 组件。