### PR TITLE
fix(offline-sync): preserve field mappings through persistence

### DIFF
--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/engine/ColumnMappingLinkUpJobSpecFactoryTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/engine/ColumnMappingLinkUpJobSpecFactoryTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.when;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.yak.ops.business.datasource.dao.DataSourceDao;
+import io.yak.ops.common.bean.dto.sync.offline.OfflineJobDefinitionDTO;
 import io.yak.ops.common.bean.po.datasource.DataSourcePO;
 import org.junit.jupiter.api.Test;
 
@@ -16,9 +17,9 @@ class ColumnMappingLinkUpJobSpecFactoryTest {
   private final ObjectMapper mapper = new ObjectMapper();
 
   @Test
-  void shouldCompileTopLevelEditorMappingIntoJobSpec() throws Exception {
+  void shouldPreserveRequestMappingAndCompileItIntoJobSpec() throws Exception {
     ColumnMappingLinkUpJobSpecFactory factory = factory();
-    JsonNode definition = mapper.readTree("""
+    OfflineJobDefinitionDTO request = mapper.readValue("""
         {
           "basic": {"jobName": "mapped-users", "mode": "GUIDE_SINGLE"},
           "source": {
@@ -42,7 +43,10 @@ class ColumnMappingLinkUpJobSpecFactoryTest {
             ]
           }
         }
-        """);
+        """, OfflineJobDefinitionDTO.class);
+    JsonNode definition = mapper.valueToTree(request);
+
+    assertThat(definition.path("mapping").path("columns")).hasSize(2);
 
     LinkUpJobSpecFactory.BuildResult result = factory.build(definition);
 

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/dto/sync/offline/OfflineJobColumnMappingDTO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/dto/sync/offline/OfflineJobColumnMappingDTO.java
@@ -1,0 +1,23 @@
+package io.yak.ops.common.bean.dto.sync.offline;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Data;
+
+/**
+ * 离线同步单个字段映射。
+ *
+ * @author weifuwan
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Data
+public class OfflineJobColumnMappingDTO {
+
+  @JsonAlias("sourceField")
+  private String source;
+
+  @JsonAlias("targetField")
+  private String target;
+}

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/dto/sync/offline/OfflineJobDefinitionDTO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/dto/sync/offline/OfflineJobDefinitionDTO.java
@@ -7,8 +7,8 @@ import lombok.Data;
 /**
  * 离线同步任务定义入参。
  *
- * <p>离线同步是固定的 Source -> Channel -> Sink 链路，不再保存前端 workflow
- * 节点、边和画布位置等交互状态。</p>
+ * <p>离线同步是固定的 Source -> Channel -> Sink 链路。字段映射作为任务级配置
+ * 与 basic、source、sink、channel 同级保存，不再挂载到任一端点配置中。</p>
  *
  * @author weifuwan
  */
@@ -22,4 +22,7 @@ public class OfflineJobDefinitionDTO {
   private OfflineJobEndpointDTO source;
   private OfflineJobEndpointDTO sink;
   private OfflineJobChannelDTO channel;
+
+  /** 单表同步任务级字段映射。 */
+  private OfflineJobMappingDTO mapping;
 }

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/dto/sync/offline/OfflineJobMappingDTO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/dto/sync/offline/OfflineJobMappingDTO.java
@@ -1,0 +1,19 @@
+package io.yak.ops.common.bean.dto.sync.offline;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.util.List;
+import lombok.Data;
+
+/**
+ * 离线同步任务级字段映射配置。
+ *
+ * @author weifuwan
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Data
+public class OfflineJobMappingDTO {
+
+  private List<OfflineJobColumnMappingDTO> columns;
+}

--- a/yak-ops-common/src/test/java/io/yak/ops/common/bean/dto/sync/offline/OfflineJobDefinitionDTOTest.java
+++ b/yak-ops-common/src/test/java/io/yak/ops/common/bean/dto/sync/offline/OfflineJobDefinitionDTOTest.java
@@ -1,0 +1,63 @@
+package io.yak.ops.common.bean.dto.sync.offline;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+class OfflineJobDefinitionDTOTest {
+
+  private final ObjectMapper mapper = new ObjectMapper();
+
+  @Test
+  void shouldPreserveTopLevelMappingDuringRequestBindingAndSerialization() throws Exception {
+    OfflineJobDefinitionDTO definition = mapper.readValue("""
+        {
+          "id": 1785737278040000,
+          "basic": {
+            "jobName": "MYSQL → MYSQL 离线同步",
+            "mode": "GUIDE_SINGLE"
+          },
+          "source": {
+            "connectorId": "jdbc",
+            "dataSourceId": "2",
+            "config": {"table": "sink_user_info"}
+          },
+          "sink": {
+            "connectorId": "jdbc",
+            "dataSourceId": "2",
+            "config": {
+              "targetTableName": "test1234",
+              "autoCreateTable": true
+            }
+          },
+          "channel": {"parallelism": 1},
+          "mapping": {
+            "columns": [
+              {"source": "username", "target": "username"},
+              {"sourceField": "id", "targetField": "age"}
+            ]
+          }
+        }
+        """, OfflineJobDefinitionDTO.class);
+
+    assertThat(definition.getMapping()).isNotNull();
+    assertThat(definition.getMapping().getColumns()).hasSize(2);
+    assertThat(definition.getMapping().getColumns().get(0).getSource())
+        .isEqualTo("username");
+    assertThat(definition.getMapping().getColumns().get(1).getSource())
+        .isEqualTo("id");
+    assertThat(definition.getMapping().getColumns().get(1).getTarget())
+        .isEqualTo("age");
+
+    JsonNode persisted = mapper.valueToTree(definition);
+    assertThat(persisted.path("mapping").path("columns")).hasSize(2);
+    assertThat(persisted.path("mapping").path("columns").get(1).path("source").asText())
+        .isEqualTo("id");
+    assertThat(persisted.path("mapping").path("columns").get(1).path("target").asText())
+        .isEqualTo("age");
+    assertThat(persisted.path("mapping").path("columns").get(1).has("sourceField"))
+        .isFalse();
+  }
+}


### PR DESCRIPTION
## 问题原因

前端已经将字段映射保存为任务顶层的 `mapping.columns`，但后端 `OfflineJobDefinitionDTO` 未声明 `mapping` 字段，并且启用了 `@JsonIgnoreProperties(ignoreUnknown = true)`。因此请求反序列化时字段映射被静默丢弃，导致：

1. `definition_json` 中没有映射，重新进入编辑页后前端只能重新生成默认同名映射；
2. `job_spec_json` 中没有映射，执行时提交给 Link-Up 的 `jobSpec` 也缺少 `mapping`。

## 修复内容

- 在 `OfflineJobDefinitionDTO` 中增加任务级 `mapping` 字段。
- 新增 `OfflineJobMappingDTO` 和 `OfflineJobColumnMappingDTO` 强类型协议。
- 字段映射继续与 `basic/source/sink/channel` 同级保存。
- 兼容历史字段名 `sourceField/targetField`，序列化后统一输出 `source/target`。
- 不修改前端字段映射 UI、样式或交互结构。

## 修复后的链路

```text
前端 mapping.columns
  -> OfflineJobDefinitionDTO.mapping
  -> OfflineDefinitionSupport valueToTree
  -> definition_json（编辑回显）
  -> ColumnMappingLinkUpJobSpecFactory
  -> job_spec_json
  -> Link-Up /api/v1/jobs jobSpec.mapping.columns
```

## 测试

- 新增公共 DTO Jackson 回归测试，覆盖 HTTP JSON 反序列化及重新序列化。
- 更新 JobSpec 工厂测试，通过 `OfflineJobDefinitionDTO` 绑定请求，再验证映射进入 Link-Up JobSpec。
- 保留旧 `source.config.mapping` 的兼容测试及多表映射拒绝测试。

## 部署后验证

历史版本的 `job_spec_json` 不会自动变化。部署本修复后，需要重新打开任务并保存一次，生成新版本，再执行任务。新的 Link-Up 请求应包含 `jobSpec.mapping.columns`。