### PR TITLE
feat(offline-sync): add task schedule configuration

### DIFF
--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineScheduleRepository.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineScheduleRepository.java
@@ -34,11 +34,16 @@ public class OfflineScheduleRepository {
   }
 
   public ScheduleRecord saveSchedule(Long definitionId, JsonNode schedule) {
-    String cronExpression = text(schedule, "cronExpression");
-    String runType = text(schedule, "scheduleRunType");
-    boolean enabled = StringUtils.hasText(cronExpression)
-        && !"pause".equalsIgnoreCase(runType)
-        && !"paused".equalsIgnoreCase(runType);
+    String cronExpression = firstText(schedule, "cron", "cronExpression");
+    boolean requestedEnabled = enabled(schedule, cronExpression);
+    if (requestedEnabled && !StringUtils.hasText(cronExpression)) {
+      throw new IllegalArgumentException("启用调度时必须填写 Cron 表达式");
+    }
+    if (StringUtils.hasText(cronExpression)) {
+      validateCron(cronExpression);
+    }
+
+    boolean enabled = requestedEnabled && StringUtils.hasText(cronExpression);
     int maxAttempts = maxAttempts(schedule);
     int backoffSeconds = backoffSeconds(schedule);
     LocalDateTime nextFireTime = enabled ? next(cronExpression, LocalDateTime.now()) : null;
@@ -98,10 +103,39 @@ public class OfflineScheduleRepository {
         definitionId);
   }
 
+  public void deleteSchedule(Long definitionId) {
+    jdbc.update(
+        "DELETE FROM yak_offline_schedule WHERE job_definition_id = ?",
+        definitionId);
+  }
+
+  private boolean enabled(JsonNode schedule, String cronExpression) {
+    if (schedule == null || schedule.isNull()) {
+      return false;
+    }
+    JsonNode configured = schedule.get("enabled");
+    if (configured != null && !configured.isNull()) {
+      return configured.asBoolean(false);
+    }
+
+    String runType = text(schedule, "scheduleRunType");
+    if (StringUtils.hasText(runType)) {
+      return !"pause".equalsIgnoreCase(runType)
+          && !"paused".equalsIgnoreCase(runType);
+    }
+    return StringUtils.hasText(cronExpression);
+  }
+
   private int maxAttempts(JsonNode schedule) {
     if (schedule == null || schedule.isNull()) {
       return 1;
     }
+
+    JsonNode retryOnFailure = schedule.get("retryOnFailure");
+    if (retryOnFailure != null && !retryOnFailure.isNull()) {
+      return retryOnFailure.asBoolean(false) ? 2 : 1;
+    }
+
     if (!schedule.path("autoRetry").asBoolean(true)) {
       return 1;
     }
@@ -115,7 +149,7 @@ public class OfflineScheduleRepository {
 
   private int backoffSeconds(JsonNode schedule) {
     if (schedule == null || schedule.isNull()) {
-      return 30;
+      return 60;
     }
     JsonNode configured = schedule.path("retryPolicy").path("backoffSeconds");
     if (configured.canConvertToInt() && configured.asInt() > 0) {
@@ -125,7 +159,7 @@ public class OfflineScheduleRepository {
     if (seconds.canConvertToInt() && seconds.asInt() > 0) {
       return seconds.asInt();
     }
-    // The existing editor exposes retryInterval in minutes.
+    // The historical editor exposed retryInterval in minutes.
     int minutes = intValue(schedule, "retryInterval", 1);
     return Math.max(1, minutes) * 60;
   }
@@ -156,6 +190,11 @@ public class OfflineScheduleRepository {
     }
   }
 
+  private String firstText(JsonNode node, String first, String second) {
+    String value = text(node, first);
+    return StringUtils.hasText(value) ? value : text(node, second);
+  }
+
   private String text(JsonNode node, String field) {
     if (node == null || node.isNull() || !node.hasNonNull(field)) {
       return null;
@@ -170,15 +209,16 @@ public class OfflineScheduleRepository {
         : node.path(field).asInt(fallback);
   }
 
-  private LocalDateTime next(String cron, LocalDateTime after) {
-    if (!StringUtils.hasText(cron)) {
-      return null;
-    }
+  private void validateCron(String cron) {
     try {
-      return CronExpression.parse(cron).next(after);
+      CronExpression.parse(cron);
     } catch (IllegalArgumentException exception) {
       throw new IllegalArgumentException("调度 Cron 表达式不合法：" + cron, exception);
     }
+  }
+
+  private LocalDateTime next(String cron, LocalDateTime after) {
+    return CronExpression.parse(cron).next(after);
   }
 
   private Timestamp timestamp(LocalDateTime value) {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineJobDefinitionService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineJobDefinitionService.java
@@ -80,6 +80,7 @@ public class OfflineJobDefinitionService {
       throw new IllegalArgumentException("离线同步任务名称已存在：" + draft.getJobName());
     }
 
+    JsonNode schedule = draft.getRequest().get("schedule");
     LocalDateTime now = LocalDateTime.now();
     OfflineJobDefinitionPO definition = existing == null
         ? new OfflineJobDefinitionPO()
@@ -98,7 +99,7 @@ public class OfflineJobDefinitionService {
     definition.setSinkDatasourceId(null);
     definition.setSourceTable(null);
     definition.setSinkTable(null);
-    definition.setScheduleJson(existing == null ? null : existing.getScheduleJson());
+    definition.setScheduleJson(support.writeNullable(schedule));
     definition.setEnvJson(null);
     ensureDefaultWorkerPolicy(definition);
     definition.setCapabilityRequirementsJson(null);
@@ -112,6 +113,7 @@ public class OfflineJobDefinitionService {
     } else {
       definitionDao.updateById(definition);
     }
+    scheduleRepository.saveSchedule(id, schedule);
     return id;
   }
 
@@ -133,6 +135,7 @@ public class OfflineJobDefinitionService {
       throw new IllegalArgumentException("离线同步任务名称已存在：" + prepared.getJobName());
     }
 
+    JsonNode schedule = prepared.getRequest().get("schedule");
     int currentVersion = existing == null || existing.getVersion() == null
         ? 0
         : Math.max(0, existing.getVersion());
@@ -154,7 +157,7 @@ public class OfflineJobDefinitionService {
     definition.setSinkDatasourceId(id(prepared.getSink()));
     definition.setSourceTable(prepared.getSourceTable());
     definition.setSinkTable(prepared.getSinkTable());
-    definition.setScheduleJson(existing == null ? null : existing.getScheduleJson());
+    definition.setScheduleJson(support.writeNullable(schedule));
     definition.setEnvJson(null);
     ensureDefaultWorkerPolicy(definition);
     definition.setCapabilityRequirementsJson(capabilityRequirementsJson);
@@ -177,6 +180,7 @@ public class OfflineJobDefinitionService {
         capabilityRequirementsJson);
     definition.setCurrentVersionId(versionId);
     definitionDao.updateById(definition);
+    scheduleRepository.saveSchedule(id, schedule);
     return id;
   }
 
@@ -251,6 +255,7 @@ public class OfflineJobDefinitionService {
     if (executionRepository.hasActiveExecution(id)) {
       throw new IllegalStateException("运行中的任务不能删除");
     }
+    scheduleRepository.deleteSchedule(id);
     return definitionDao.deleteById(id);
   }
 

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/service/OfflineJobDefinitionServiceTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/service/OfflineJobDefinitionServiceTest.java
@@ -20,9 +20,11 @@ import io.yak.ops.business.sync.offline.repository.OfflineDefinitionCatalogRepos
 import io.yak.ops.business.sync.offline.repository.OfflineExecutionControlRepository;
 import io.yak.ops.business.sync.offline.repository.OfflineScheduleRepository;
 import io.yak.ops.business.sync.offline.service.OfflineDefinitionSupport.DraftDefinition;
+import io.yak.ops.business.sync.offline.service.OfflineDefinitionSupport.PreparedDefinition;
 import io.yak.ops.business.sync.offline.worker.OfflineCapabilityRequirementResolver;
 import io.yak.ops.business.sync.offline.worker.OfflineWorkerScheduler;
 import io.yak.ops.common.bean.dto.sync.offline.OfflineJobDefinitionDTO;
+import io.yak.ops.common.bean.po.datasource.DataSourcePO;
 import io.yak.ops.common.bean.po.sync.offline.OfflineJobDefinitionPO;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -32,7 +34,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 /**
- * 离线同步基础定义持久化测试。
+ * 离线同步基础定义和调度持久化测试。
  *
  * @author weifuwan
  */
@@ -41,6 +43,8 @@ class OfflineJobDefinitionServiceTest {
 
   private static final long TASK_ID = 1001L;
   private static final String JOB_NAME = "MYSQL → MYSQL 离线同步";
+  private static final String SCHEDULE_JSON =
+      "{\"cron\":\"0 0 2 * * ?\",\"enabled\":true,\"retryOnFailure\":true}";
 
   @Mock
   private OfflineJobDefinitionDao definitionDao;
@@ -72,21 +76,24 @@ class OfflineJobDefinitionServiceTest {
   }
 
   @Test
-  void saveDraftPersistsOnlyBaseDefinitionAndDefaultWorkerPolicy() {
+  void saveDraftPersistsBaseDefinitionAndSchedule() {
     OfflineJobDefinitionDTO request = request();
     ObjectNode requestJson = JsonNodeFactory.instance.objectNode();
+    ObjectNode schedule = schedule(requestJson);
     DraftDefinition draft = new DraftDefinition(
         requestJson,
         JOB_NAME,
         null,
         "GUIDE_SINGLE",
-        "{\"id\":1001,\"basic\":{},\"source\":{},\"sink\":{},\"channel\":{}}",
+        "{\"id\":1001,\"basic\":{},\"source\":{},\"sink\":{},"
+            + "\"channel\":{},\"schedule\":" + SCHEDULE_JSON + "}",
         "MYSQL",
         "MYSQL");
 
     when(definitionDao.selectById(TASK_ID)).thenReturn(null);
     when(support.prepareDraft(request)).thenReturn(draft);
     when(definitionDao.existsByName(JOB_NAME, TASK_ID)).thenReturn(false);
+    when(support.writeNullable(schedule)).thenReturn(SCHEDULE_JSON);
 
     assertEquals(TASK_ID, service.saveDraft(request));
 
@@ -102,11 +109,11 @@ class OfflineJobDefinitionServiceTest {
     assertEquals("MYSQL", saved.getSinkType());
     assertEquals("AUTO", saved.getWorkerSelectMode());
     assertEquals("{}", saved.getWorkerRequiredLabelsJson());
+    assertEquals(SCHEDULE_JSON, saved.getScheduleJson());
     assertEquals(0, saved.getVersion());
     assertNull(saved.getCurrentVersionId());
-    assertNull(saved.getScheduleJson());
     assertNull(saved.getEnvJson());
-    verifyNoInteractions(scheduleRepository);
+    verify(scheduleRepository).saveSchedule(TASK_ID, schedule);
     verify(catalogRepository, never()).saveVersion(
         anyLong(),
         anyInt(),
@@ -114,6 +121,57 @@ class OfflineJobDefinitionServiceTest {
         anyString(),
         anyString(),
         anyString());
+  }
+
+  @Test
+  void saveGuidePersistsExecutableVersionAndSchedule() {
+    OfflineJobDefinitionDTO request = request();
+    ObjectNode requestJson = JsonNodeFactory.instance.objectNode();
+    ObjectNode schedule = schedule(requestJson);
+    DataSourcePO source = dataSource(1L);
+    DataSourcePO sink = dataSource(2L);
+    PreparedDefinition prepared = new PreparedDefinition(
+        requestJson,
+        JOB_NAME,
+        null,
+        "GUIDE_SINGLE",
+        "{\"id\":1001,\"schedule\":" + SCHEDULE_JSON + "}",
+        "{\"apiVersion\":\"link-up/v1\",\"kind\":\"BatchSyncJob\"}",
+        source,
+        sink,
+        "jdbc",
+        "jdbc",
+        "source_table",
+        "sink_table",
+        "digest");
+
+    when(definitionDao.selectById(TASK_ID)).thenReturn(null);
+    when(support.prepare(request)).thenReturn(prepared);
+    when(capabilityResolver.resolve(prepared.getJobSpecJson())).thenReturn("{}");
+    when(definitionDao.existsByName(JOB_NAME, TASK_ID)).thenReturn(false);
+    when(support.writeNullable(schedule)).thenReturn(SCHEDULE_JSON);
+    when(catalogRepository.saveVersion(
+        TASK_ID,
+        1,
+        prepared.getDefinitionJson(),
+        prepared.getJobSpecJson(),
+        prepared.getDigest(),
+        "{}"))
+        .thenReturn(2001L);
+
+    assertEquals(TASK_ID, service.saveGuide(request));
+
+    ArgumentCaptor<OfflineJobDefinitionPO> captor =
+        ArgumentCaptor.forClass(OfflineJobDefinitionPO.class);
+    verify(definitionDao).insert(captor.capture());
+    OfflineJobDefinitionPO saved = captor.getValue();
+    assertEquals(TASK_ID, saved.getId());
+    assertEquals(SCHEDULE_JSON, saved.getScheduleJson());
+    assertEquals(1, saved.getVersion());
+    assertEquals(2001L, saved.getCurrentVersionId());
+    assertEquals(1L, saved.getSourceDatasourceId());
+    assertEquals(2L, saved.getSinkDatasourceId());
+    verify(scheduleRepository).saveSchedule(TASK_ID, schedule);
   }
 
   @Test
@@ -132,6 +190,20 @@ class OfflineJobDefinitionServiceTest {
     verify(support, never()).prepareDraft(any());
     verify(definitionDao, never()).insert(any());
     verifyNoInteractions(scheduleRepository);
+  }
+
+  private ObjectNode schedule(ObjectNode requestJson) {
+    ObjectNode schedule = requestJson.putObject("schedule");
+    schedule.put("cron", "0 0 2 * * ?");
+    schedule.put("enabled", true);
+    schedule.put("retryOnFailure", true);
+    return schedule;
+  }
+
+  private DataSourcePO dataSource(Long id) {
+    DataSourcePO value = new DataSourcePO();
+    value.setId(id);
+    return value;
   }
 
   private OfflineJobDefinitionDTO request() {

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/dto/sync/offline/OfflineJobDefinitionDTO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/dto/sync/offline/OfflineJobDefinitionDTO.java
@@ -7,8 +7,8 @@ import lombok.Data;
 /**
  * 离线同步任务定义入参。
  *
- * <p>离线同步是固定的 Source -> Channel -> Sink 链路。字段映射作为任务级配置
- * 与 basic、source、sink、channel 同级保存，不再挂载到任一端点配置中。</p>
+ * <p>离线同步是固定的 Source -> Channel -> Sink 链路。字段映射和调度配置作为
+ * 任务级配置，与 basic、source、sink、channel 同级保存。</p>
  *
  * @author weifuwan
  */
@@ -25,4 +25,7 @@ public class OfflineJobDefinitionDTO {
 
   /** 单表同步任务级字段映射。 */
   private OfflineJobMappingDTO mapping;
+
+  /** 任务级 Cron、启停和失败重跑配置。 */
+  private OfflineJobScheduleDTO schedule = new OfflineJobScheduleDTO();
 }

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/dto/sync/offline/OfflineJobScheduleDTO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/dto/sync/offline/OfflineJobScheduleDTO.java
@@ -1,0 +1,26 @@
+package io.yak.ops.common.bean.dto.sync.offline;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Data;
+
+/**
+ * 离线同步任务级调度配置。
+ *
+ * <p>调度配置与 basic、source、sink、channel、mapping 同级保存。Quartz 只负责
+ * 时间触发，业务失败重跑仍由离线同步执行状态机负责。</p>
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Data
+public class OfflineJobScheduleDTO {
+
+  /** Quartz Cron 表达式，例如 0 0 2 * * ?。 */
+  private String cron = "";
+
+  /** 是否启用定时调度。 */
+  private Boolean enabled = false;
+
+  /** 业务执行失败后是否自动重跑一次。 */
+  private Boolean retryOnFailure = false;
+}

--- a/yak-ops-common/src/test/java/io/yak/ops/common/bean/dto/sync/offline/OfflineJobDefinitionDTOTest.java
+++ b/yak-ops-common/src/test/java/io/yak/ops/common/bean/dto/sync/offline/OfflineJobDefinitionDTOTest.java
@@ -11,7 +11,7 @@ class OfflineJobDefinitionDTOTest {
   private final ObjectMapper mapper = new ObjectMapper();
 
   @Test
-  void shouldPreserveTopLevelMappingDuringRequestBindingAndSerialization() throws Exception {
+  void shouldPreserveTopLevelTaskConfigurationDuringRequestBinding() throws Exception {
     OfflineJobDefinitionDTO definition = mapper.readValue("""
         {
           "id": 1785737278040000,
@@ -38,6 +38,11 @@ class OfflineJobDefinitionDTOTest {
               {"source": "username", "target": "username"},
               {"sourceField": "id", "targetField": "age"}
             ]
+          },
+          "schedule": {
+            "cron": "0 0 2 * * ?",
+            "enabled": true,
+            "retryOnFailure": true
           }
         }
         """, OfflineJobDefinitionDTO.class);
@@ -51,6 +56,11 @@ class OfflineJobDefinitionDTOTest {
     assertThat(definition.getMapping().getColumns().get(1).getTarget())
         .isEqualTo("age");
 
+    assertThat(definition.getSchedule()).isNotNull();
+    assertThat(definition.getSchedule().getCron()).isEqualTo("0 0 2 * * ?");
+    assertThat(definition.getSchedule().getEnabled()).isTrue();
+    assertThat(definition.getSchedule().getRetryOnFailure()).isTrue();
+
     JsonNode persisted = mapper.valueToTree(definition);
     assertThat(persisted.path("mapping").path("columns")).hasSize(2);
     assertThat(persisted.path("mapping").path("columns").get(1).path("source").asText())
@@ -59,5 +69,9 @@ class OfflineJobDefinitionDTOTest {
         .isEqualTo("age");
     assertThat(persisted.path("mapping").path("columns").get(1).has("sourceField"))
         .isFalse();
+    assertThat(persisted.path("schedule").path("cron").asText())
+        .isEqualTo("0 0 2 * * ?");
+    assertThat(persisted.path("schedule").path("enabled").asBoolean()).isTrue();
+    assertThat(persisted.path("schedule").path("retryOnFailure").asBoolean()).isTrue();
   }
 }

--- a/yak-ops-ui/src/pages/batch-link-up/detail/components/ScheduleConfigSection.tsx
+++ b/yak-ops-ui/src/pages/batch-link-up/detail/components/ScheduleConfigSection.tsx
@@ -1,0 +1,103 @@
+import { Input, Switch } from 'antd';
+import type { ReactNode } from 'react';
+
+import type { SyncEditorState } from '../model';
+import EditorSection from './EditorSection';
+
+interface ScheduleConfigSectionProps {
+  editor: SyncEditorState;
+  onChange: (value: SyncEditorState) => void;
+}
+
+function Field({
+  label,
+  hint,
+  children,
+}: {
+  label: string;
+  hint?: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className="min-w-0">
+      <div className="mb-2 text-[12px] font-medium text-[#475467]">
+        {label}
+      </div>
+      {children}
+      {hint ? (
+        <div className="mt-1.5 text-[11px] leading-5 text-[#98a2b3]">
+          {hint}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export default function ScheduleConfigSection({
+  editor,
+  onChange,
+}: ScheduleConfigSectionProps) {
+  const updateSchedule = (
+    patch: Partial<SyncEditorState['schedule']>,
+  ) => {
+    onChange({
+      ...editor,
+      schedule: {
+        ...editor.schedule,
+        ...patch,
+      },
+    });
+  };
+
+  return (
+    <EditorSection title="调度配置">
+      <div className="grid grid-cols-[minmax(0,1.8fr)_minmax(180px,.6fr)_minmax(180px,.6fr)] gap-4 max-lg:grid-cols-2 max-sm:grid-cols-1">
+        <Field
+          label="Cron 表达式"
+          hint="采用 Quartz Cron，例如每天凌晨 2 点：0 0 2 * * ?"
+        >
+          <Input
+            allowClear
+            variant="filled"
+            value={editor.schedule.cron}
+            placeholder="0 0 2 * * ?"
+            status={
+              editor.schedule.enabled && !editor.schedule.cron.trim()
+                ? 'error'
+                : undefined
+            }
+            onChange={(event) =>
+              updateSchedule({ cron: event.target.value })
+            }
+          />
+        </Field>
+
+        <Field
+          label="启用调度"
+          hint="关闭后保留 Cron，但不会触发任务"
+        >
+          <div className="flex h-8 items-center">
+            <Switch
+              checked={editor.schedule.enabled}
+              onChange={(enabled) => updateSchedule({ enabled })}
+            />
+          </div>
+        </Field>
+
+        <Field
+          label="失败重跑"
+          hint="失败后由业务状态机自动重跑一次"
+        >
+          <div className="flex h-8 items-center">
+            <Switch
+              checked={editor.schedule.retryOnFailure}
+              onChange={(retryOnFailure) =>
+                updateSchedule({ retryOnFailure })
+              }
+            />
+          </div>
+        </Field>
+      </div>
+    </EditorSection>
+  );
+}

--- a/yak-ops-ui/src/pages/batch-link-up/detail/components/SyncTaskEditor.tsx
+++ b/yak-ops-ui/src/pages/batch-link-up/detail/components/SyncTaskEditor.tsx
@@ -13,6 +13,7 @@ import FieldMappingSection, {
   type FieldMappingValue,
 } from './FieldMappingSection';
 import MultiTableConfigSection from './MultiTableConfigSection';
+import ScheduleConfigSection from './ScheduleConfigSection';
 import SingleTableConfigSection from './SingleTableConfigSection';
 import TaskBasicSection from './TaskBasicSection';
 
@@ -222,6 +223,13 @@ export default function SyncTaskEditor({
           />
         </div>
       ) : null}
+
+      <div id="schedule-config" className="scroll-mt-6">
+        <ScheduleConfigSection
+          editor={editor}
+          onChange={onChange}
+        />
+      </div>
     </div>
   );
 }

--- a/yak-ops-ui/src/pages/batch-link-up/detail/model.ts
+++ b/yak-ops-ui/src/pages/batch-link-up/detail/model.ts
@@ -37,6 +37,12 @@ export interface SyncMapping {
   columns: SyncColumnMapping[];
 }
 
+export interface SyncSchedule {
+  cron: string;
+  enabled: boolean;
+  retryOnFailure: boolean;
+}
+
 export interface SyncEditorState {
   id: string;
   mode: SyncMode;
@@ -45,6 +51,7 @@ export interface SyncEditorState {
   sink: SyncEndpoint;
   channel: SyncChannel;
   mapping: SyncMapping;
+  schedule: SyncSchedule;
   state?: Record<string, any>;
 }
 
@@ -70,6 +77,12 @@ export const DEFAULT_CHANNEL_CONFIG: SyncChannel = {
 
 export const DEFAULT_MAPPING_CONFIG: SyncMapping = {
   columns: [],
+};
+
+export const DEFAULT_SCHEDULE_CONFIG: SyncSchedule = {
+  cron: '',
+  enabled: false,
+  retryOnFailure: false,
 };
 
 export const isApiSuccess = (response: any): boolean =>
@@ -145,6 +158,43 @@ const serializeMapping = (mapping?: SyncMapping): SyncMapping => ({
   columns: normalizeMappingColumns(mapping?.columns),
 });
 
+const normalizeSchedule = (raw: any): SyncSchedule => {
+  const schedule =
+    raw?.schedule && typeof raw.schedule === 'object'
+      ? raw.schedule
+      : {};
+  const cron = String(
+    schedule.cron ?? schedule.cronExpression ?? '',
+  ).trim();
+  const legacyRunType = String(
+    schedule.scheduleRunType || '',
+  ).toLowerCase();
+  const enabled = schedule.enabled !== undefined
+    ? Boolean(schedule.enabled)
+    : Boolean(
+        cron &&
+          legacyRunType !== 'pause' &&
+          legacyRunType !== 'paused',
+      );
+  const retryOnFailure = schedule.retryOnFailure !== undefined
+    ? Boolean(schedule.retryOnFailure)
+    : Boolean(schedule.autoRetry);
+
+  return {
+    cron,
+    enabled,
+    retryOnFailure,
+  };
+};
+
+const serializeSchedule = (
+  schedule?: SyncSchedule,
+): SyncSchedule => ({
+  cron: String(schedule?.cron || '').trim(),
+  enabled: Boolean(schedule?.enabled),
+  retryOnFailure: Boolean(schedule?.retryOnFailure),
+});
+
 const endpointFromType = (
   endpoint?: Partial<CreateSyncEndpoint> | null,
 ): SyncEndpoint => {
@@ -218,6 +268,7 @@ export const buildCreatePayload = (
       sink: multiDraftEndpoint(sinkEndpoint, 'sink'),
       channel: serializeChannel(DEFAULT_CHANNEL_CONFIG),
       mapping: { ...DEFAULT_MAPPING_CONFIG },
+      schedule: { ...DEFAULT_SCHEDULE_CONFIG },
     };
   }
 
@@ -228,6 +279,7 @@ export const buildCreatePayload = (
     sink: sinkEndpoint,
     channel: DEFAULT_CHANNEL_CONFIG,
     mapping: { ...DEFAULT_MAPPING_CONFIG },
+    schedule: { ...DEFAULT_SCHEDULE_CONFIG },
   };
 };
 
@@ -416,6 +468,7 @@ export const normalizeEditDetail = (
       dirtyDataPolicy: dirtyDataPolicy === 'SKIP' ? 'skip' : 'stop',
     },
     mapping: normalizeMapping(raw),
+    schedule: normalizeSchedule(raw),
     state: raw?.state,
   };
 };
@@ -587,6 +640,7 @@ export const buildSavePayload = (
   const mapping = editor.mode === 'GUIDE_SINGLE'
     ? serializeMapping(editor.mapping)
     : { ...DEFAULT_MAPPING_CONFIG };
+  const schedule = serializeSchedule(editor.schedule);
 
   if (editor.mode === 'GUIDE_MULTI') {
     return {
@@ -596,6 +650,7 @@ export const buildSavePayload = (
       sink: multiSinkPayload(editor.sink),
       channel: serializeChannel(editor.channel),
       mapping,
+      schedule,
     };
   }
 
@@ -606,5 +661,6 @@ export const buildSavePayload = (
     sink: endpointSavePayload(editor.sink),
     channel: editor.channel,
     mapping,
+    schedule,
   };
 };


### PR DESCRIPTION
## 背景

离线同步任务目前只保存 `basic/source/sink/channel/mapping`。虽然 Yak Ops 已经有 `OfflineSyncScheduleRegistrar`、`OfflineSyncScheduleHandler` 和 Yak Schedule 的 Quartz 集成，但编辑器保存链路不再写入调度配置，导致 `yak_offline_schedule` 没有可注册的计划。

## 顶层协议

任务定义新增与其他配置同级的 `schedule`：

```json
{
  "basic": {},
  "source": {},
  "sink": {},
  "channel": {},
  "mapping": {},
  "schedule": {
    "cron": "0 0 2 * * ?",
    "enabled": true,
    "retryOnFailure": true
  }
}
```

## 前端

- 在任务编辑器底部新增“调度配置”区块。
- 核心字段：
  - Quartz Cron 表达式；
  - 是否启用调度；
  - 执行失败后是否自动重跑一次。
- 创建草稿、编辑回显和保存 payload 均保留顶层 `schedule`。
- 兼容历史字段 `cronExpression`、`scheduleRunType` 和 `autoRetry`。
- 不修改现有数据源、运行参数和字段映射 UI。

## 后端

- 新增 `OfflineJobScheduleDTO` 并绑定到 `OfflineJobDefinitionDTO`。
- 草稿和正式任务版本都会保存顶层调度配置。
- 同步更新 `yak_offline_schedule`，供现有 `OfflineSyncScheduleRegistrar` 对账到 Framework `ScheduleManager`。
- 启用调度但 Cron 为空时拒绝保存。
- 使用 Spring CronExpression 校验 Quartz Cron。
- `retryOnFailure=true` 映射为总尝试 2 次：首次执行 + 失败后业务重跑一次。
- 删除任务时同步删除业务调度投影，注册器下一轮对账会删除 Quartz 计划。

## 架构边界

Quartz 只负责按时间触发 `OfflineSyncScheduleHandler`。Worker 选择、任务状态机、失败判断和失败重跑仍由 offline-sync 模块负责，避免 Quartz 与业务层重复重试。

## 测试

- 覆盖顶层 `schedule` 的 Jackson 请求绑定和序列化。
- 覆盖草稿任务的调度持久化。
- 覆盖正式版本和调度配置同时保存。
- 覆盖任务校验失败时不写入调度数据。

## 依赖 PR

- Framework Quartz MySQL JDBC JobStore 建表资源：weifuwan/yak-framework#79

当前内存 JobStore 不依赖 Framework PR；生产环境切换 Quartz JDBC JobStore 时应先合并并执行 Framework PR 中的建表脚本。