### PR TITLE
feat(data-development): complete editor tab interactions

### DIFF
--- a/yak-ops-ui/src/pages/data-development/workbench/WorkbenchPage.tsx
+++ b/yak-ops-ui/src/pages/data-development/workbench/WorkbenchPage.tsx
@@ -7,8 +7,10 @@ import {
   ChevronRight,
   Circle,
   Cloud,
+  Columns2,
   Maximize2,
   Minimize2,
+  X,
 } from 'lucide-react';
 import { useState } from 'react';
 import CreateResourceModal from './components/CreateResourceModal';
@@ -25,7 +27,15 @@ import { useWorkbenchStore } from './store/workbench.store';
 const WorkbenchPage = () => {
   const explorerVisible = useWorkbenchStore((state) => state.explorerVisible);
   const fullscreen = useWorkbenchStore((state) => state.fullscreen);
+  const splitResourceId = useWorkbenchStore((state) => state.splitResourceId);
+  const resourcesById = useWorkbenchStore((state) => state.resourcesById);
   const setFullscreen = useWorkbenchStore((state) => state.setFullscreen);
+  const setSplitResource = useWorkbenchStore(
+    (state) => state.setSplitResource,
+  );
+  const setActiveResource = useWorkbenchStore(
+    (state) => state.setActiveResource,
+  );
   const [createOpen, setCreateOpen] = useState(false);
   const [createType, setCreateType] = useState<ResourceType>('SQL');
 
@@ -33,6 +43,10 @@ const WorkbenchPage = () => {
     setCreateType(resourceType);
     setCreateOpen(true);
   };
+
+  const splitResource = splitResourceId
+    ? resourcesById[splitResourceId]
+    : undefined;
 
   return (
     <ConfigProvider theme={BRAND_THEME}>
@@ -90,9 +104,40 @@ const WorkbenchPage = () => {
           <main className="flex min-w-0 flex-1 flex-col bg-white">
             <EditorTabs onCreate={openCreateModal} />
             <WorkbenchToolbar />
-            <div className="min-h-0 flex-1">
-              <ResourceView onCreate={() => openCreateModal('SQL')} />
+
+            <div className="flex min-h-0 flex-1 overflow-hidden">
+              <section className="min-w-0 flex-1 overflow-hidden">
+                <ResourceView onCreate={() => openCreateModal('SQL')} />
+              </section>
+
+              {splitResource && !fullscreen && (
+                <section className="flex min-w-[360px] flex-1 flex-col border-l border-[#dfe2e6] bg-white">
+                  <div className="flex h-9 shrink-0 items-center justify-between border-b border-[#e7e9ec] bg-[#fafbfc] px-3">
+                    <button
+                      type="button"
+                      className="flex min-w-0 items-center gap-2 border-0 bg-transparent p-0 text-left text-[12px] text-[rgba(22,24,35,0.72)]"
+                      onClick={() => setActiveResource(splitResource.id)}
+                    >
+                      <Columns2 size={14} />
+                      <span className="truncate">{splitResource.name}</span>
+                    </button>
+                    <Tooltip title="关闭拆分编辑器">
+                      <Button
+                        type="text"
+                        size="small"
+                        className="!h-7 !w-7 !px-0"
+                        icon={<X size={14} />}
+                        onClick={() => setSplitResource(undefined)}
+                      />
+                    </Tooltip>
+                  </div>
+                  <div className="min-h-0 flex-1 overflow-hidden">
+                    <ResourceView resourceId={splitResource.id} />
+                  </div>
+                </section>
+              )}
             </div>
+
             <StatusBar />
           </main>
 

--- a/yak-ops-ui/src/pages/data-development/workbench/components/EditorTabs.tsx
+++ b/yak-ops-ui/src/pages/data-development/workbench/components/EditorTabs.tsx
@@ -1,6 +1,37 @@
 import type React from 'react';
-import { Button, Dropdown, Tooltip, type MenuProps } from 'antd';
-import { Circle, PanelLeftOpen, Plus, X } from 'lucide-react';
+import {
+  Button,
+  Dropdown,
+  Modal,
+  Tooltip,
+  message,
+  type MenuProps,
+} from 'antd';
+import {
+  AlertTriangle,
+  Check,
+  ChevronLeft,
+  ChevronRight,
+  Circle,
+  Columns2,
+  Files,
+  LockKeyhole,
+  PanelLeftOpen,
+  Pin,
+  PinOff,
+  Plus,
+  X,
+} from 'lucide-react';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type DragEvent,
+  type MouseEvent,
+  type WheelEvent,
+} from 'react';
 import { nodePluginRegistry } from '../core/registry';
 import type { ResourceType } from '../core/types';
 import { useWorkbenchStore } from '../store/workbench.store';
@@ -9,6 +40,23 @@ interface EditorTabsProps {
   onCreate: (resourceType: ResourceType) => void;
 }
 
+const MenuLabel = ({
+  children,
+  shortcut,
+}: {
+  children: React.ReactNode;
+  shortcut?: string;
+}) => (
+  <span className="flex min-w-[190px] items-center justify-between gap-8">
+    <span>{children}</span>
+    {shortcut && (
+      <span className="text-[11px] text-[rgba(22,24,35,0.36)]">
+        {shortcut}
+      </span>
+    )}
+  </span>
+);
+
 const EditorTabs = ({ onCreate }: EditorTabsProps) => {
   const resourcesById = useWorkbenchStore((state) => state.resourcesById);
   const documentsByResourceId = useWorkbenchStore(
@@ -16,15 +64,46 @@ const EditorTabs = ({ onCreate }: EditorTabsProps) => {
   );
   const openResourceIds = useWorkbenchStore((state) => state.openResourceIds);
   const activeResourceId = useWorkbenchStore((state) => state.activeResourceId);
+  const previewResourceId = useWorkbenchStore(
+    (state) => state.previewResourceId,
+  );
+  const pinnedResourceIds = useWorkbenchStore(
+    (state) => state.pinnedResourceIds,
+  );
   const explorerVisible = useWorkbenchStore((state) => state.explorerVisible);
   const fullscreen = useWorkbenchStore((state) => state.fullscreen);
+  const previewEnabled = useWorkbenchStore((state) => state.previewEnabled);
+  const tabGroupLocked = useWorkbenchStore((state) => state.tabGroupLocked);
   const setExplorerVisible = useWorkbenchStore(
     (state) => state.setExplorerVisible,
+  );
+  const setPreviewEnabled = useWorkbenchStore(
+    (state) => state.setPreviewEnabled,
+  );
+  const setTabGroupLocked = useWorkbenchStore(
+    (state) => state.setTabGroupLocked,
   );
   const setActiveResource = useWorkbenchStore(
     (state) => state.setActiveResource,
   );
-  const closeResource = useWorkbenchStore((state) => state.closeResource);
+  const closeResources = useWorkbenchStore((state) => state.closeResources);
+  const pinResource = useWorkbenchStore((state) => state.pinResource);
+  const moveResourceTab = useWorkbenchStore(
+    (state) => state.moveResourceTab,
+  );
+  const markDocumentSaved = useWorkbenchStore(
+    (state) => state.markDocumentSaved,
+  );
+  const setSplitResource = useWorkbenchStore(
+    (state) => state.setSplitResource,
+  );
+
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [canScrollLeft, setCanScrollLeft] = useState(false);
+  const [canScrollRight, setCanScrollRight] = useState(false);
+  const [openedEditorsOpen, setOpenedEditorsOpen] = useState(false);
+  const [pendingCloseIds, setPendingCloseIds] = useState<string[]>([]);
+  const [draggedResourceId, setDraggedResourceId] = useState<string>();
 
   const plugins = nodePluginRegistry.list();
   const createItems: MenuProps['items'] = plugins.map((plugin) => {
@@ -36,67 +115,563 @@ const EditorTabs = ({ onCreate }: EditorTabsProps) => {
     };
   });
 
-  return (
-    <div className="flex h-10 shrink-0 items-stretch border-b border-[#e5e7ea] bg-[#fafbfc]">
-      {!explorerVisible && !fullscreen && (
-        <Tooltip title="展开项目目录">
-          <Button
-            type="text"
-            className="!h-10 !rounded-none"
-            icon={<PanelLeftOpen size={15} />}
-            onClick={() => setExplorerVisible(true)}
-          />
-        </Tooltip>
-      )}
+  const pinnedSet = useMemo(
+    () => new Set(pinnedResourceIds),
+    [pinnedResourceIds],
+  );
 
-      <div className="flex min-w-0 flex-1 items-stretch overflow-x-auto">
-        {openResourceIds.map((resourceId) => {
-          const resource = resourcesById[resourceId];
-          const document = documentsByResourceId[resourceId];
-          if (!resource) return null;
+  const updateScrollState = useCallback(() => {
+    const container = scrollRef.current;
+    if (!container) return;
 
-          const plugin = nodePluginRegistry.get(resource.resourceType);
-          if (!plugin) return null;
+    setCanScrollLeft(container.scrollLeft > 2);
+    setCanScrollRight(
+      container.scrollLeft + container.clientWidth < container.scrollWidth - 2,
+    );
+  }, []);
 
-          const Icon = plugin.metadata.icon;
-          const active = resource.id === activeResourceId;
+  useEffect(() => {
+    updateScrollState();
+    const container = scrollRef.current;
+    if (!container) return undefined;
 
-          return (
-            <button
-              key={resource.id}
-              type="button"
-              onClick={() => setActiveResource(resource.id)}
-              className={[
-                'group relative flex h-10 min-w-[150px] max-w-[230px] items-center gap-2 border-0 border-r border-[#e7e9ec] px-3 text-left text-[12px]',
-                active
-                  ? 'bg-white text-[#161823]'
-                  : 'bg-[#f7f8f9] text-[rgba(22,24,35,0.54)] hover:bg-white',
-              ].join(' ')}
-            >
-              {active && (
-                <span className="absolute inset-x-0 top-0 h-0.5 bg-[var(--yak-brand-color)]" />
-              )}
+    const observer = new ResizeObserver(updateScrollState);
+    observer.observe(container);
+    Array.from(container.children).forEach((child) => observer.observe(child));
+
+    return () => observer.disconnect();
+  }, [openResourceIds, updateScrollState]);
+
+  useEffect(() => {
+    const container = scrollRef.current;
+    if (!container || !activeResourceId) return;
+
+    const activeTab = Array.from(
+      container.querySelectorAll<HTMLElement>('[data-tab-resource-id]'),
+    ).find((element) => element.dataset.tabResourceId === activeResourceId);
+
+    activeTab?.scrollIntoView({
+      behavior: 'smooth',
+      block: 'nearest',
+      inline: 'nearest',
+    });
+  }, [activeResourceId]);
+
+  const requestClose = useCallback(
+    (resourceIds: string[]) => {
+      const requestedIds = Array.from(
+        new Set(resourceIds.filter((resourceId) => openResourceIds.includes(resourceId))),
+      );
+      if (requestedIds.length === 0) return;
+
+      if (tabGroupLocked) {
+        message.warning('当前编辑器组已锁定，请先解除锁定');
+        return;
+      }
+
+      const dirtyIds = requestedIds.filter(
+        (resourceId) => documentsByResourceId[resourceId]?.dirty,
+      );
+
+      if (dirtyIds.length === 0) {
+        closeResources(requestedIds);
+        return;
+      }
+
+      setPendingCloseIds(requestedIds);
+    },
+    [
+      closeResources,
+      documentsByResourceId,
+      openResourceIds,
+      tabGroupLocked,
+    ],
+  );
+
+  const bulkClosableIds = useCallback(
+    (ids: string[]) => ids.filter((resourceId) => !pinnedSet.has(resourceId)),
+    [pinnedSet],
+  );
+
+  const closeSaved = useCallback(() => {
+    const ids = bulkClosableIds(
+      openResourceIds.filter(
+        (resourceId) => !documentsByResourceId[resourceId]?.dirty,
+      ),
+    );
+    if (ids.length === 0) {
+      message.info('没有可关闭的已保存标签页');
+      return;
+    }
+    requestClose(ids);
+  }, [
+    bulkClosableIds,
+    documentsByResourceId,
+    openResourceIds,
+    requestClose,
+  ]);
+
+  const closeAll = useCallback(() => {
+    const ids = bulkClosableIds(openResourceIds);
+    if (ids.length === 0) {
+      message.info('固定标签页已保留，没有其它可关闭标签页');
+      return;
+    }
+    requestClose(ids);
+  }, [bulkClosableIds, openResourceIds, requestClose]);
+
+  const revealInExplorer = useCallback(
+    (resourceId: string) => {
+      setExplorerVisible(true);
+      setActiveResource(resourceId);
+      window.requestAnimationFrame(() => {
+        const rows = Array.from(
+          document.querySelectorAll<HTMLElement>('[data-explorer-resource-id]'),
+        );
+        const row = rows.find(
+          (element) => element.dataset.explorerResourceId === resourceId,
+        );
+        row?.scrollIntoView({
+          behavior: 'smooth',
+          block: 'center',
+          inline: 'nearest',
+        });
+      });
+    },
+    [setActiveResource, setExplorerVisible],
+  );
+
+  const buildTabMenu = useCallback(
+    (resourceId: string): MenuProps['items'] => {
+      const index = openResourceIds.indexOf(resourceId);
+      const isPinned = pinnedSet.has(resourceId);
+      const otherIds = bulkClosableIds(
+        openResourceIds.filter((id) => id !== resourceId),
+      );
+      const rightIds = bulkClosableIds(openResourceIds.slice(index + 1));
+
+      return [
+        {
+          key: 'close',
+          label: <MenuLabel shortcut="Alt+W">关闭</MenuLabel>,
+          disabled: tabGroupLocked,
+        },
+        {
+          key: 'close-others',
+          label: '关闭其他',
+          disabled: tabGroupLocked || otherIds.length === 0,
+        },
+        {
+          key: 'close-right',
+          label: '关闭右侧标签页',
+          disabled: tabGroupLocked || rightIds.length === 0,
+        },
+        {
+          key: 'close-saved',
+          label: <MenuLabel shortcut="Ctrl+K U">关闭已保存</MenuLabel>,
+          disabled:
+            tabGroupLocked ||
+            !openResourceIds.some(
+              (id) =>
+                !pinnedSet.has(id) && !documentsByResourceId[id]?.dirty,
+            ),
+        },
+        {
+          key: 'close-all',
+          label: <MenuLabel shortcut="Ctrl+K W">全部关闭</MenuLabel>,
+          disabled: tabGroupLocked || bulkClosableIds(openResourceIds).length === 0,
+        },
+        { type: 'divider' },
+        {
+          key: 'reveal',
+          label: '在资源管理器视图中显示',
+        },
+        { type: 'divider' },
+        {
+          key: 'pin',
+          icon: isPinned ? <PinOff size={14} /> : <Pin size={14} />,
+          label: isPinned ? '取消固定' : '固定',
+        },
+        {
+          key: 'split-right',
+          icon: <Columns2 size={14} />,
+          label: <MenuLabel shortcut="Ctrl+\\">向右拆分</MenuLabel>,
+        },
+      ];
+    },
+    [
+      bulkClosableIds,
+      documentsByResourceId,
+      openResourceIds,
+      pinnedSet,
+      tabGroupLocked,
+    ],
+  );
+
+  const handleTabMenu = useCallback(
+    (resourceId: string, key: string) => {
+      const index = openResourceIds.indexOf(resourceId);
+
+      switch (key) {
+        case 'close':
+          requestClose([resourceId]);
+          break;
+        case 'close-others':
+          requestClose(
+            bulkClosableIds(
+              openResourceIds.filter((id) => id !== resourceId),
+            ),
+          );
+          break;
+        case 'close-right':
+          requestClose(bulkClosableIds(openResourceIds.slice(index + 1)));
+          break;
+        case 'close-saved':
+          closeSaved();
+          break;
+        case 'close-all':
+          closeAll();
+          break;
+        case 'reveal':
+          revealInExplorer(resourceId);
+          break;
+        case 'pin':
+          pinResource(resourceId);
+          break;
+        case 'split-right':
+          setSplitResource(resourceId);
+          break;
+        default:
+          break;
+      }
+    },
+    [
+      bulkClosableIds,
+      closeAll,
+      closeSaved,
+      openResourceIds,
+      pinResource,
+      requestClose,
+      revealInExplorer,
+      setSplitResource,
+    ],
+  );
+
+  const emptyAreaItems: MenuProps['items'] = [
+    {
+      key: 'split-right',
+      icon: <Columns2 size={14} />,
+      label: <MenuLabel shortcut="Ctrl+\\">向右拆分编辑器</MenuLabel>,
+      disabled: !activeResourceId,
+    },
+    {
+      key: 'show-opened',
+      icon: <Files size={14} />,
+      label: '显示打开的编辑器',
+      disabled: openResourceIds.length === 0,
+    },
+    { type: 'divider' },
+    {
+      key: 'close-all',
+      label: <MenuLabel shortcut="Ctrl+K W">全部关闭</MenuLabel>,
+      disabled: tabGroupLocked || bulkClosableIds(openResourceIds).length === 0,
+    },
+    {
+      key: 'close-saved',
+      label: <MenuLabel shortcut="Ctrl+K U">关闭已保存</MenuLabel>,
+      disabled:
+        tabGroupLocked ||
+        !openResourceIds.some(
+          (id) => !pinnedSet.has(id) && !documentsByResourceId[id]?.dirty,
+        ),
+    },
+    { type: 'divider' },
+    {
+      key: 'preview',
+      label: previewEnabled ? '禁用预览编辑器' : '启用预览编辑器',
+    },
+    {
+      key: 'lock',
+      icon: tabGroupLocked ? <LockKeyhole size={14} /> : undefined,
+      label: tabGroupLocked ? '解除锁定组' : '锁定组',
+    },
+  ];
+
+  const openedEditorItems: MenuProps['items'] = openResourceIds.flatMap(
+    (resourceId) => {
+      const resource = resourcesById[resourceId];
+      if (!resource) return [];
+      const plugin = nodePluginRegistry.get(resource.resourceType);
+      if (!plugin) return [];
+      const Icon = plugin.metadata.icon;
+      const dirty = documentsByResourceId[resourceId]?.dirty;
+
+      return [
+        {
+          key: resourceId,
+          icon:
+            activeResourceId === resourceId ? (
+              <Check size={14} />
+            ) : (
               <Icon size={14} className={plugin.metadata.iconClassName} />
-              <span className="min-w-0 flex-1 truncate">{resource.name}</span>
-              {document?.dirty ? (
+            ),
+          label: (
+            <span className="flex min-w-[230px] items-center justify-between gap-4">
+              <span className="max-w-[190px] truncate">{resource.name}</span>
+              {dirty && (
                 <Circle
                   size={7}
                   fill="currentColor"
-                  className="shrink-0 text-[var(--yak-brand-color)]"
-                />
-              ) : (
-                <X
-                  size={13}
-                  className="shrink-0 opacity-0 transition-opacity group-hover:opacity-100"
-                  onClick={(event: React.MouseEvent<SVGSVGElement>) => {
-                    event.stopPropagation();
-                    closeResource(resource.id);
-                  }}
+                  className="text-[var(--yak-brand-color)]"
                 />
               )}
-            </button>
-          );
-        })}
+            </span>
+          ),
+        },
+      ];
+    },
+  );
+
+  const handleWheel = (event: WheelEvent<HTMLDivElement>) => {
+    const container = scrollRef.current;
+    if (!container || container.scrollWidth <= container.clientWidth) return;
+
+    if (Math.abs(event.deltaY) >= Math.abs(event.deltaX)) {
+      event.preventDefault();
+      container.scrollLeft += event.deltaY;
+      updateScrollState();
+    }
+  };
+
+  const scrollTabs = (direction: -1 | 1) => {
+    scrollRef.current?.scrollBy({
+      left: direction * 260,
+      behavior: 'smooth',
+    });
+  };
+
+  const dirtyPendingIds = pendingCloseIds.filter(
+    (resourceId) => documentsByResourceId[resourceId]?.dirty,
+  );
+  const pendingNames = dirtyPendingIds
+    .map((resourceId) => resourcesById[resourceId]?.name)
+    .filter((name): name is string => Boolean(name));
+
+  const confirmSaveAndClose = () => {
+    dirtyPendingIds.forEach(markDocumentSaved);
+    closeResources(pendingCloseIds);
+    setPendingCloseIds([]);
+    message.success(
+      dirtyPendingIds.length > 1
+        ? `已保存并关闭 ${dirtyPendingIds.length} 个文件`
+        : '文件已保存并关闭',
+    );
+  };
+
+  const discardAndClose = () => {
+    closeResources(pendingCloseIds);
+    setPendingCloseIds([]);
+  };
+
+  return (
+    <>
+      <div className="flex h-10 shrink-0 items-stretch border-b border-[#e5e7ea] bg-[#fafbfc]">
+        {!explorerVisible && !fullscreen && (
+          <Tooltip title="展开项目目录">
+            <Button
+              type="text"
+              className="!h-10 !rounded-none"
+              icon={<PanelLeftOpen size={15} />}
+              onClick={() => setExplorerVisible(true)}
+            />
+          </Tooltip>
+        )}
+
+        {canScrollLeft && (
+          <Tooltip title="向左滚动标签页">
+            <Button
+              type="text"
+              className="!h-10 !w-8 !shrink-0 !rounded-none !px-0"
+              icon={<ChevronLeft size={15} />}
+              onClick={() => scrollTabs(-1)}
+            />
+          </Tooltip>
+        )}
+
+        <Dropdown
+          trigger={['contextMenu']}
+          menu={{
+            items: emptyAreaItems,
+            onClick: ({ key }) => {
+              if (key === 'split-right' && activeResourceId) {
+                setSplitResource(activeResourceId);
+              }
+              if (key === 'show-opened') setOpenedEditorsOpen(true);
+              if (key === 'close-all') closeAll();
+              if (key === 'close-saved') closeSaved();
+              if (key === 'preview') setPreviewEnabled(!previewEnabled);
+              if (key === 'lock') setTabGroupLocked(!tabGroupLocked);
+            },
+          }}
+        >
+          <div
+            ref={scrollRef}
+            onScroll={updateScrollState}
+            onWheel={handleWheel}
+            className="flex min-w-0 flex-1 items-stretch overflow-x-auto overflow-y-hidden [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+          >
+            {openResourceIds.map((resourceId) => {
+              const resource = resourcesById[resourceId];
+              const documentState = documentsByResourceId[resourceId];
+              if (!resource) return null;
+
+              const plugin = nodePluginRegistry.get(resource.resourceType);
+              if (!plugin) return null;
+
+              const Icon = plugin.metadata.icon;
+              const active = resource.id === activeResourceId;
+              const pinned = pinnedSet.has(resource.id);
+              const preview = previewResourceId === resource.id;
+
+              return (
+                <Dropdown
+                  key={resource.id}
+                  trigger={['contextMenu']}
+                  menu={{
+                    items: buildTabMenu(resource.id),
+                    onClick: ({ key }) => handleTabMenu(resource.id, key),
+                  }}
+                >
+                  <button
+                    type="button"
+                    data-tab-resource-id={resource.id}
+                    draggable={!tabGroupLocked}
+                    onClick={() => setActiveResource(resource.id)}
+                    onDoubleClick={() => pinResource(resource.id, true)}
+                    onContextMenu={(event: MouseEvent<HTMLButtonElement>) => {
+                      event.stopPropagation();
+                      setActiveResource(resource.id);
+                    }}
+                    onAuxClick={(event: MouseEvent<HTMLButtonElement>) => {
+                      if (event.button === 1) {
+                        event.preventDefault();
+                        requestClose([resource.id]);
+                      }
+                    }}
+                    onDragStart={(event: DragEvent<HTMLButtonElement>) => {
+                      setDraggedResourceId(resource.id);
+                      event.dataTransfer.effectAllowed = 'move';
+                      event.dataTransfer.setData('text/plain', resource.id);
+                    }}
+                    onDragOver={(event: DragEvent<HTMLButtonElement>) => {
+                      if (!tabGroupLocked) event.preventDefault();
+                    }}
+                    onDrop={(event: DragEvent<HTMLButtonElement>) => {
+                      event.preventDefault();
+                      const sourceId =
+                        draggedResourceId || event.dataTransfer.getData('text/plain');
+                      if (sourceId) moveResourceTab(sourceId, resource.id);
+                      setDraggedResourceId(undefined);
+                    }}
+                    className={[
+                      'group relative flex h-10 min-w-[150px] max-w-[230px] shrink-0 items-center gap-2 border-0 border-r border-[#e7e9ec] px-3 text-left text-[12px] transition-colors',
+                      active
+                        ? 'bg-white text-[#161823]'
+                        : 'bg-[#f7f8f9] text-[rgba(22,24,35,0.54)] hover:bg-white',
+                      draggedResourceId === resource.id ? 'opacity-50' : '',
+                    ].join(' ')}
+                  >
+                    {active && (
+                      <span className="absolute inset-x-0 top-0 h-0.5 bg-[var(--yak-brand-color)]" />
+                    )}
+                    <Icon size={14} className={plugin.metadata.iconClassName} />
+                    <span
+                      className={[
+                        'min-w-0 flex-1 truncate',
+                        preview ? 'italic' : '',
+                      ].join(' ')}
+                    >
+                      {resource.name}
+                    </span>
+                    {pinned && (
+                      <Pin
+                        size={11}
+                        className="shrink-0 text-[rgba(22,24,35,0.38)]"
+                      />
+                    )}
+                    <span className="relative flex h-4 w-4 shrink-0 items-center justify-center">
+                      {documentState?.dirty && (
+                        <Circle
+                          size={7}
+                          fill="currentColor"
+                          className="text-[var(--yak-brand-color)] group-hover:hidden"
+                        />
+                      )}
+                      <X
+                        size={13}
+                        className={[
+                          'transition-opacity',
+                          documentState?.dirty
+                            ? 'hidden group-hover:block'
+                            : 'opacity-0 group-hover:opacity-100',
+                        ].join(' ')}
+                        onClick={(event: MouseEvent<SVGSVGElement>) => {
+                          event.stopPropagation();
+                          requestClose([resource.id]);
+                        }}
+                      />
+                    </span>
+                  </button>
+                </Dropdown>
+              );
+            })}
+
+            <div className="min-w-8 flex-1" />
+          </div>
+        </Dropdown>
+
+        {canScrollRight && (
+          <Tooltip title="向右滚动标签页">
+            <Button
+              type="text"
+              className="!h-10 !w-8 !shrink-0 !rounded-none !px-0"
+              icon={<ChevronRight size={15} />}
+              onClick={() => scrollTabs(1)}
+            />
+          </Tooltip>
+        )}
+
+        {tabGroupLocked && (
+          <Tooltip title="编辑器组已锁定，点击解除锁定">
+            <Button
+              type="text"
+              className="!h-10 !w-9 !shrink-0 !rounded-none !px-0 text-[var(--yak-brand-color)]"
+              icon={<LockKeyhole size={14} />}
+              onClick={() => setTabGroupLocked(false)}
+            />
+          </Tooltip>
+        )}
+
+        <Dropdown
+          trigger={['click']}
+          open={openedEditorsOpen}
+          onOpenChange={setOpenedEditorsOpen}
+          menu={{
+            items: openedEditorItems,
+            onClick: ({ key }) => {
+              setActiveResource(key);
+              setOpenedEditorsOpen(false);
+            },
+          }}
+        >
+          <Tooltip title="显示打开的编辑器">
+            <Button
+              type="text"
+              className="!h-10 !w-9 !shrink-0 !rounded-none !px-0"
+              icon={<Files size={15} />}
+            />
+          </Tooltip>
+        </Dropdown>
 
         <Dropdown
           trigger={['click']}
@@ -105,14 +680,60 @@ const EditorTabs = ({ onCreate }: EditorTabsProps) => {
             onClick: ({ key }: { key: string }) => onCreate(key),
           }}
         >
-          <Button
-            type="text"
-            className="!h-10 !w-10 !shrink-0 !rounded-none"
-            icon={<Plus size={15} />}
-          />
+          <Tooltip title="新建开发节点">
+            <Button
+              type="text"
+              className="!h-10 !w-10 !shrink-0 !rounded-none"
+              icon={<Plus size={15} />}
+            />
+          </Tooltip>
         </Dropdown>
       </div>
-    </div>
+
+      <Modal
+        open={pendingCloseIds.length > 0}
+        centered
+        width={520}
+        title={null}
+        closable
+        maskClosable={false}
+        onCancel={() => setPendingCloseIds([])}
+        footer={
+          <div className="flex justify-end gap-2">
+            <Button type="primary" onClick={confirmSaveAndClose}>
+              {dirtyPendingIds.length > 1 ? '全部保存' : '保存'}
+            </Button>
+            <Button onClick={discardAndClose}>不保存</Button>
+            <Button onClick={() => setPendingCloseIds([])}>取消</Button>
+          </div>
+        }
+      >
+        <div className="flex gap-4 px-1 pb-2 pt-3">
+          <div className="flex h-11 w-11 shrink-0 items-center justify-center text-[#faad14]">
+            <AlertTriangle size={38} strokeWidth={1.7} />
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="text-[16px] font-medium leading-7 text-[#161823]">
+              {pendingNames.length === 1
+                ? `是否要保存对 ${pendingNames[0]} 的更改？`
+                : `是否要保存对 ${pendingNames.length} 个文件的更改？`}
+            </div>
+            <div className="mt-2 text-[13px] leading-6 text-[rgba(22,24,35,0.58)]">
+              如果不保存，你的更改将丢失。
+            </div>
+            {pendingNames.length > 1 && (
+              <div className="mt-3 max-h-28 overflow-y-auto rounded-md bg-[#f7f8f9] px-3 py-2 text-[12px] leading-6 text-[rgba(22,24,35,0.62)]">
+                {pendingNames.map((name) => (
+                  <div key={name} className="truncate">
+                    {name}
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      </Modal>
+    </>
   );
 };
 

--- a/yak-ops-ui/src/pages/data-development/workbench/components/ResourceView.tsx
+++ b/yak-ops-ui/src/pages/data-development/workbench/components/ResourceView.tsx
@@ -9,15 +9,25 @@ import {
 } from '../store/workbench.store';
 
 interface ResourceViewProps {
-  onCreate: () => void;
+  onCreate?: () => void;
+  resourceId?: string;
 }
 
-const ResourceView = ({ onCreate }: ResourceViewProps) => {
-  const resource = useWorkbenchStore(selectActiveResource);
-  const document = useWorkbenchStore(selectActiveDocument);
+const ResourceView = ({ onCreate, resourceId }: ResourceViewProps) => {
+  const activeResource = useWorkbenchStore(selectActiveResource);
+  const activeDocument = useWorkbenchStore(selectActiveDocument);
+  const resourcesById = useWorkbenchStore((state) => state.resourcesById);
+  const documentsByResourceId = useWorkbenchStore(
+    (state) => state.documentsByResourceId,
+  );
   const updateDocument = useWorkbenchStore((state) => state.updateDocument);
 
-  if (!resource || !document) {
+  const resource = resourceId ? resourcesById[resourceId] : activeResource;
+  const documentState = resourceId
+    ? documentsByResourceId[resourceId]
+    : activeDocument;
+
+  if (!resource || !documentState) {
     return (
       <div className="flex h-full items-center justify-center bg-[#fbfbfc] p-8">
         <div className="w-full max-w-[620px] text-center">
@@ -30,14 +40,16 @@ const ResourceView = ({ onCreate }: ResourceViewProps) => {
           <p className="m-0 text-[13px] text-[rgba(22,24,35,0.48)]">
             从左侧打开开发节点，或创建 SQL、HTTP、Notebook、数据集成等资源。
           </p>
-          <Button
-            type="primary"
-            className="mt-5"
-            icon={<Plus size={15} />}
-            onClick={onCreate}
-          >
-            新建开发节点
-          </Button>
+          {onCreate && (
+            <Button
+              type="primary"
+              className="mt-5"
+              icon={<Plus size={15} />}
+              onClick={onCreate}
+            >
+              新建开发节点
+            </Button>
+          )}
         </div>
       </div>
     );
@@ -65,7 +77,7 @@ const ResourceView = ({ onCreate }: ResourceViewProps) => {
     <Renderer
       key={resource.id}
       resource={resource}
-      document={document}
+      document={documentState}
       plugin={plugin}
       onChange={(nextDocument: DevelopmentDocument) =>
         updateDocument(resource.id, () => nextDocument)

--- a/yak-ops-ui/src/pages/data-development/workbench/store/workbench.store.ts
+++ b/yak-ops-ui/src/pages/data-development/workbench/store/workbench.store.ts
@@ -15,6 +15,9 @@ interface WorkbenchStoreState {
   resourceIdsByFolder: Record<string, string[]>;
   openResourceIds: string[];
   activeResourceId?: string;
+  previewResourceId?: string;
+  pinnedResourceIds: string[];
+  splitResourceId?: string;
   expandedFolderIds: Record<string, boolean>;
   executionStatusByResourceId: Record<string, ExecutionStatus>;
   scheduleEnabledByResourceId: Record<string, boolean>;
@@ -23,18 +26,26 @@ interface WorkbenchStoreState {
   explorerKeyword: string;
   explorerVisible: boolean;
   fullscreen: boolean;
+  previewEnabled: boolean;
+  tabGroupLocked: boolean;
   rightPanel: RightPanelKey | null;
 
   setExplorerFilter: (filter: ExplorerFilter) => void;
   setExplorerKeyword: (keyword: string) => void;
   setExplorerVisible: (visible: boolean) => void;
   setFullscreen: (fullscreen: boolean) => void;
+  setPreviewEnabled: (enabled: boolean) => void;
+  setTabGroupLocked: (locked: boolean) => void;
   setRightPanel: (panel: RightPanelKey | null) => void;
+  setSplitResource: (resourceId?: string) => void;
   toggleFolder: (folderId: string) => void;
 
-  openResource: (resourceId: string) => void;
+  openResource: (resourceId: string, options?: { pinned?: boolean }) => void;
   closeResource: (resourceId: string) => void;
+  closeResources: (resourceIds: string[]) => void;
   setActiveResource: (resourceId: string) => void;
+  pinResource: (resourceId: string, pinned?: boolean) => void;
+  moveResourceTab: (sourceId: string, targetId: string) => void;
   createResource: (
     resource: DevelopmentResource,
     document: DevelopmentDocument,
@@ -78,12 +89,17 @@ const expandedFolderIds = Object.keys(resourceIdsByFolder).reduce<
   return result;
 }, {});
 
+const uniqueIds = (ids: string[]) => Array.from(new Set(ids));
+
 export const useWorkbenchStore = create<WorkbenchStoreState>((set, get) => ({
   resourcesById,
   documentsByResourceId,
   resourceIdsByFolder,
   openResourceIds: snapshot.openResourceIds,
   activeResourceId: snapshot.activeResourceId,
+  previewResourceId: undefined,
+  pinnedResourceIds: [],
+  splitResourceId: undefined,
   expandedFolderIds,
   executionStatusByResourceId: {},
   scheduleEnabledByResourceId: {},
@@ -92,13 +108,22 @@ export const useWorkbenchStore = create<WorkbenchStoreState>((set, get) => ({
   explorerKeyword: '',
   explorerVisible: true,
   fullscreen: false,
+  previewEnabled: true,
+  tabGroupLocked: false,
   rightPanel: null,
 
   setExplorerFilter: (explorerFilter) => set({ explorerFilter }),
   setExplorerKeyword: (explorerKeyword) => set({ explorerKeyword }),
   setExplorerVisible: (explorerVisible) => set({ explorerVisible }),
   setFullscreen: (fullscreen) => set({ fullscreen }),
+  setPreviewEnabled: (previewEnabled) =>
+    set((state) => ({
+      previewEnabled,
+      previewResourceId: previewEnabled ? state.previewResourceId : undefined,
+    })),
+  setTabGroupLocked: (tabGroupLocked) => set({ tabGroupLocked }),
   setRightPanel: (rightPanel) => set({ rightPanel }),
+  setSplitResource: (splitResourceId) => set({ splitResourceId }),
   toggleFolder: (folderId) =>
     set((state: WorkbenchStoreState) => ({
       expandedFolderIds: {
@@ -107,30 +132,127 @@ export const useWorkbenchStore = create<WorkbenchStoreState>((set, get) => ({
       },
     })),
 
-  openResource: (resourceId) =>
-    set((state: WorkbenchStoreState) => ({
-      openResourceIds: state.openResourceIds.includes(resourceId)
-        ? state.openResourceIds
-        : [...state.openResourceIds, resourceId],
-      activeResourceId: resourceId,
-    })),
+  openResource: (resourceId, options) =>
+    set((state: WorkbenchStoreState) => {
+      if (!state.resourcesById[resourceId]) return state;
 
-  closeResource: (resourceId) => {
-    const { openResourceIds, activeResourceId } = get();
-    const index = openResourceIds.indexOf(resourceId);
-    const nextOpenIds = openResourceIds.filter((id: string) => id !== resourceId);
-    const nextActiveId =
-      activeResourceId === resourceId
-        ? nextOpenIds[Math.max(0, index - 1)] ?? nextOpenIds[0]
-        : activeResourceId;
+      const alreadyOpen = state.openResourceIds.includes(resourceId);
+      const shouldPin = options?.pinned === true;
+      const pinnedResourceIds = shouldPin
+        ? uniqueIds([...state.pinnedResourceIds, resourceId])
+        : state.pinnedResourceIds;
 
-    set({
-      openResourceIds: nextOpenIds,
-      activeResourceId: nextActiveId,
-    });
-  },
+      if (alreadyOpen) {
+        return {
+          activeResourceId: resourceId,
+          pinnedResourceIds,
+          previewResourceId:
+            shouldPin && state.previewResourceId === resourceId
+              ? undefined
+              : state.previewResourceId,
+        };
+      }
+
+      if (!shouldPin && state.previewEnabled && state.previewResourceId) {
+        const previousPreviewId = state.previewResourceId;
+        const previousPreviewDocument =
+          state.documentsByResourceId[previousPreviewId];
+        const canReplacePreview =
+          !state.pinnedResourceIds.includes(previousPreviewId) &&
+          !previousPreviewDocument?.dirty;
+
+        if (canReplacePreview) {
+          const previewIndex = state.openResourceIds.indexOf(previousPreviewId);
+          const nextOpenIds = [...state.openResourceIds];
+          if (previewIndex >= 0) {
+            nextOpenIds.splice(previewIndex, 1, resourceId);
+          } else {
+            nextOpenIds.push(resourceId);
+          }
+
+          return {
+            openResourceIds: uniqueIds(nextOpenIds),
+            activeResourceId: resourceId,
+            previewResourceId: resourceId,
+            pinnedResourceIds,
+          };
+        }
+      }
+
+      return {
+        openResourceIds: [...state.openResourceIds, resourceId],
+        activeResourceId: resourceId,
+        previewResourceId:
+          !shouldPin && state.previewEnabled ? resourceId : undefined,
+        pinnedResourceIds,
+      };
+    }),
+
+  closeResource: (resourceId) => get().closeResources([resourceId]),
+
+  closeResources: (resourceIds) =>
+    set((state: WorkbenchStoreState) => {
+      const closeSet = new Set(resourceIds);
+      if (closeSet.size === 0) return state;
+
+      const nextOpenIds = state.openResourceIds.filter(
+        (resourceId) => !closeSet.has(resourceId),
+      );
+      const activeIndex = state.activeResourceId
+        ? state.openResourceIds.indexOf(state.activeResourceId)
+        : -1;
+      const nextActiveId =
+        state.activeResourceId && closeSet.has(state.activeResourceId)
+          ? nextOpenIds[Math.max(0, activeIndex - 1)] ?? nextOpenIds[0]
+          : state.activeResourceId;
+
+      return {
+        openResourceIds: nextOpenIds,
+        activeResourceId: nextActiveId,
+        previewResourceId:
+          state.previewResourceId && closeSet.has(state.previewResourceId)
+            ? undefined
+            : state.previewResourceId,
+        pinnedResourceIds: state.pinnedResourceIds.filter(
+          (resourceId) => !closeSet.has(resourceId),
+        ),
+        splitResourceId:
+          state.splitResourceId && closeSet.has(state.splitResourceId)
+            ? undefined
+            : state.splitResourceId,
+      };
+    }),
 
   setActiveResource: (activeResourceId) => set({ activeResourceId }),
+
+  pinResource: (resourceId, pinned) =>
+    set((state: WorkbenchStoreState) => {
+      const currentlyPinned = state.pinnedResourceIds.includes(resourceId);
+      const nextPinned = pinned ?? !currentlyPinned;
+
+      return {
+        pinnedResourceIds: nextPinned
+          ? uniqueIds([...state.pinnedResourceIds, resourceId])
+          : state.pinnedResourceIds.filter((id) => id !== resourceId),
+        previewResourceId:
+          nextPinned && state.previewResourceId === resourceId
+            ? undefined
+            : state.previewResourceId,
+      };
+    }),
+
+  moveResourceTab: (sourceId, targetId) =>
+    set((state: WorkbenchStoreState) => {
+      if (sourceId === targetId) return state;
+      const sourceIndex = state.openResourceIds.indexOf(sourceId);
+      const targetIndex = state.openResourceIds.indexOf(targetId);
+      if (sourceIndex < 0 || targetIndex < 0) return state;
+
+      const nextOpenIds = [...state.openResourceIds];
+      nextOpenIds.splice(sourceIndex, 1);
+      nextOpenIds.splice(targetIndex, 0, sourceId);
+      return { openResourceIds: nextOpenIds };
+    }),
 
   createResource: (resource, document) =>
     set((state: WorkbenchStoreState) => ({
@@ -153,8 +275,10 @@ export const useWorkbenchStore = create<WorkbenchStoreState>((set, get) => ({
         ...state.expandedFolderIds,
         [resource.folderId]: true,
       },
-      openResourceIds: [...state.openResourceIds, resource.id],
+      openResourceIds: uniqueIds([...state.openResourceIds, resource.id]),
       activeResourceId: resource.id,
+      previewResourceId: undefined,
+      pinnedResourceIds: uniqueIds([...state.pinnedResourceIds, resource.id]),
     })),
 
   deleteResource: (resourceId) => {
@@ -171,7 +295,7 @@ export const useWorkbenchStore = create<WorkbenchStoreState>((set, get) => ({
     delete nextExecution[resourceId];
     delete nextSchedule[resourceId];
 
-    const nextOpenIds = state.openResourceIds.filter((id: string) => id !== resourceId);
+    const nextOpenIds = state.openResourceIds.filter((id) => id !== resourceId);
 
     set({
       resourcesById: nextResources,
@@ -189,6 +313,17 @@ export const useWorkbenchStore = create<WorkbenchStoreState>((set, get) => ({
         state.activeResourceId === resourceId
           ? nextOpenIds[nextOpenIds.length - 1]
           : state.activeResourceId,
+      previewResourceId:
+        state.previewResourceId === resourceId
+          ? undefined
+          : state.previewResourceId,
+      pinnedResourceIds: state.pinnedResourceIds.filter(
+        (id) => id !== resourceId,
+      ),
+      splitResourceId:
+        state.splitResourceId === resourceId
+          ? undefined
+          : state.splitResourceId,
     });
   },
 
@@ -213,12 +348,17 @@ export const useWorkbenchStore = create<WorkbenchStoreState>((set, get) => ({
     set((state: WorkbenchStoreState) => {
       const document = state.documentsByResourceId[resourceId];
       if (!document) return state;
+      const nextDocument = updater(document);
 
       return {
         documentsByResourceId: {
           ...state.documentsByResourceId,
-          [resourceId]: updater(document),
+          [resourceId]: nextDocument,
         },
+        previewResourceId:
+          nextDocument.dirty && state.previewResourceId === resourceId
+            ? undefined
+            : state.previewResourceId,
       };
     }),
 


### PR DESCRIPTION
## 变更说明

补齐 `/data-development/workbench` 顶部编辑器标签页能力，并处理标签数量较多时原生横向滚动条遮挡内容的问题。

### 标签页交互

- 标签页右键菜单：关闭、关闭其他、关闭右侧、关闭已保存、全部关闭
- 支持在资源管理器中定位当前资源
- 支持固定/取消固定标签页，批量关闭时保留固定标签
- 支持双击固定、鼠标中键关闭
- 支持拖拽调整标签页顺序
- 支持预览编辑器模式：未修改的预览标签可被下一个资源替换，编辑后自动转为普通标签
- 支持编辑器组锁定，避免误关闭和误拖动
- 新增“显示打开的编辑器”下拉列表，快速定位已打开资源

### 未保存关闭确认

- 关闭存在未保存内容的标签时显示确认弹窗
- 支持“保存 / 不保存 / 取消”
- 批量关闭多个未保存标签时展示文件清单并支持全部保存

### 标签滚动优化

- 隐藏会遮挡下一行内容的原生横向滚动条
- 鼠标滚轮可直接横向滚动标签
- 标签溢出后显示左右滚动按钮
- 切换标签时自动将活动标签滚动到可视区域
- 标签右侧的打开列表和新建按钮保持固定，不再被滚动区域挤走

### 拆分编辑器

- 标签和标签栏右键菜单支持“向右拆分”
- 右侧拆分区域可独立展示同一套 Resource Renderer
- 支持关闭拆分区域和从拆分标题切换当前活动资源
- 代码、表单、Notebook、数据集成等 Renderer 均可复用拆分能力

### 状态层调整

扩展 Zustand Workbench Store，新增：

- `previewResourceId`
- `pinnedResourceIds`
- `splitResourceId`
- `previewEnabled`
- `tabGroupLocked`
- 多标签批量关闭和拖拽排序能力

## 验证建议

1. 连续打开多个资源，确认标签栏不再出现遮挡内容的原生滚动条
2. 使用鼠标滚轮和左右按钮滚动标签
3. 右键标签检查关闭、固定、拆分和资源定位菜单
4. 修改内容后关闭，检查保存确认弹窗
5. 执行关闭其他、关闭右侧、关闭已保存和全部关闭
6. 双击固定标签，并确认批量关闭保留固定标签
7. 从标签栏空白区域切换预览模式和锁定编辑器组
8. 对 SQL、HTTP、Notebook、数据集成资源执行向右拆分

## 验证情况

- 已对本次修改的 TS/TSX 文件执行 TypeScript `transpileModule` 语法检查
- 分支基于合并 PR #188 后的最新 `main`
- 当前工具环境无法拉取依赖并执行完整 `npm run tsc` / `npm run build`，因此 PR 保持 Draft 状态
