### PR TITLE
feat(data-development): enhance explorer interactions

### DIFF
--- a/yak-ops-ui/src/pages/data-development/workbench/WorkbenchPage.tsx
+++ b/yak-ops-ui/src/pages/data-development/workbench/WorkbenchPage.tsx
@@ -20,15 +20,22 @@ import ResourceView from './components/ResourceView';
 import RightPanel from './components/RightPanel';
 import RightRail from './components/RightRail';
 import StatusBar from './components/StatusBar';
+import WorkbenchResizeHandle from './components/WorkbenchResizeHandle';
 import WorkbenchToolbar from './components/WorkbenchToolbar';
 import type { ResourceType } from './core/types';
 import { useWorkbenchStore } from './store/workbench.store';
 
+const EXPLORER_MIN_WIDTH = 300;
+const EXPLORER_MAX_WIDTH = 720;
+const EXPLORER_DEFAULT_WIDTH = 460;
+
 const WorkbenchPage = () => {
   const explorerVisible = useWorkbenchStore((state) => state.explorerVisible);
+  const explorerWidth = useWorkbenchStore((state) => state.explorerWidth);
   const fullscreen = useWorkbenchStore((state) => state.fullscreen);
   const splitResourceId = useWorkbenchStore((state) => state.splitResourceId);
   const resourcesById = useWorkbenchStore((state) => state.resourcesById);
+  const setExplorerWidth = useWorkbenchStore((state) => state.setExplorerWidth);
   const setFullscreen = useWorkbenchStore((state) => state.setFullscreen);
   const setSplitResource = useWorkbenchStore(
     (state) => state.setSplitResource,
@@ -98,7 +105,22 @@ const WorkbenchPage = () => {
 
         <div className="flex min-h-0 flex-1">
           {explorerVisible && !fullscreen && (
-            <ExplorerPanel onCreate={openCreateModal} />
+            <>
+              <div
+                style={{ width: explorerWidth }}
+                className="h-full min-w-0 shrink-0 overflow-hidden"
+              >
+                <ExplorerPanel onCreate={openCreateModal} />
+              </div>
+              <WorkbenchResizeHandle
+                value={explorerWidth}
+                min={EXPLORER_MIN_WIDTH}
+                max={EXPLORER_MAX_WIDTH}
+                defaultValue={EXPLORER_DEFAULT_WIDTH}
+                ariaLabel="调整项目目录宽度"
+                onChange={setExplorerWidth}
+              />
+            </>
           )}
 
           <main className="flex min-w-0 flex-1 flex-col bg-white">

--- a/yak-ops-ui/src/pages/data-development/workbench/components/ExplorerPanel.tsx
+++ b/yak-ops-ui/src/pages/data-development/workbench/components/ExplorerPanel.tsx
@@ -18,10 +18,13 @@ import type {
   WorkbenchFolderDefinition,
 } from '../core/types';
 import { useWorkbenchStore } from '../store/workbench.store';
+import ResourceContextMenu from './ResourceContextMenu';
 
 interface ExplorerPanelProps {
   onCreate: (resourceType: ResourceType) => void;
 }
+
+const PROJECT_LABEL = '用户数据平台';
 
 const ExplorerPanel = ({ onCreate }: ExplorerPanelProps) => {
   const resourcesById = useWorkbenchStore((state) => state.resourcesById);
@@ -37,6 +40,7 @@ const ExplorerPanel = ({ onCreate }: ExplorerPanelProps) => {
   );
   const explorerFilter = useWorkbenchStore((state) => state.explorerFilter);
   const explorerKeyword = useWorkbenchStore((state) => state.explorerKeyword);
+  const explorerWidth = useWorkbenchStore((state) => state.explorerWidth);
   const openResource = useWorkbenchStore((state) => state.openResource);
   const toggleFolder = useWorkbenchStore((state) => state.toggleFolder);
   const setExplorerFilter = useWorkbenchStore(
@@ -60,7 +64,9 @@ const ExplorerPanel = ({ onCreate }: ExplorerPanelProps) => {
         order: plugin.metadata.folderOrder,
       });
     });
-    return Array.from(folderMap.values()).sort((left, right) => left.order - right.order);
+    return Array.from(folderMap.values()).sort(
+      (left, right) => left.order - right.order,
+    );
   }, [plugins]);
 
   const createMenuItems: MenuProps['items'] = plugins
@@ -84,7 +90,9 @@ const ExplorerPanel = ({ onCreate }: ExplorerPanelProps) => {
     .filter((resource) => {
       const matchesKeyword =
         !normalizedKeyword ||
-        resource.name.toLowerCase().includes(normalizedKeyword);
+        resource.name.toLowerCase().includes(normalizedKeyword) ||
+        resource.id.toLowerCase().includes(normalizedKeyword) ||
+        resource.updatedBy.toLowerCase().includes(normalizedKeyword);
       const matchesFilter =
         explorerFilter === 'all' ||
         (explorerFilter === 'owned' && resource.owner === 'me') ||
@@ -93,6 +101,14 @@ const ExplorerPanel = ({ onCreate }: ExplorerPanelProps) => {
     })
     .map((resource) => resource.id);
   const visibleResourceIdSet = new Set(visibleResourceIds);
+
+  const showUpdatedBy = explorerWidth >= 360;
+  const showUpdatedAt = explorerWidth >= 450;
+  const gridClassName = showUpdatedAt
+    ? 'grid-cols-[minmax(110px,1fr)_104px_122px]'
+    : showUpdatedBy
+      ? 'grid-cols-[minmax(110px,1fr)_112px]'
+      : 'grid-cols-[minmax(0,1fr)]';
 
   const renderResourceRow = (resourceId: string) => {
     const resource = resourcesById[resourceId];
@@ -106,42 +122,71 @@ const ExplorerPanel = ({ onCreate }: ExplorerPanelProps) => {
     const document = documentsByResourceId[resource.id];
 
     return (
-      <button
+      <ResourceContextMenu
         key={resource.id}
-        type="button"
-        onClick={() => openResource(resource.id)}
-        className={[
-          'group flex h-7 w-full items-center gap-2 rounded-[5px] border-0 px-2.5 text-left text-[12px] transition-colors',
-          selected
-            ? 'bg-[var(--yak-brand-color-soft)] text-[var(--yak-brand-color)]'
-            : 'bg-transparent text-[rgba(22,24,35,0.72)] hover:bg-[#f5f6f7]',
-        ].join(' ')}
+        resource={resource}
+        folders={folders}
+        projectLabel={PROJECT_LABEL}
       >
-        <Icon
-          size={14}
-          className={selected ? undefined : plugin.metadata.iconClassName}
-        />
-        <span className="min-w-0 flex-1 truncate">{resource.name}</span>
-        {resource.favorite && (
-          <Circle
-            size={6}
-            fill="currentColor"
-            className="shrink-0 text-[rgba(22,24,35,0.24)]"
-          />
-        )}
-        {document?.dirty && (
-          <Circle
-            size={6}
-            fill="currentColor"
-            className="shrink-0 text-[var(--yak-brand-color)]"
-          />
-        )}
-      </button>
+        <button
+          type="button"
+          onClick={() => openResource(resource.id)}
+          onDoubleClick={() => openResource(resource.id, { pinned: true })}
+          className={[
+            `group grid h-8 w-full items-center gap-x-2 rounded-[5px] border-0 px-2 text-left text-[12px] transition-colors ${gridClassName}`,
+            selected
+              ? 'bg-[var(--yak-brand-color-soft)] text-[var(--yak-brand-color)]'
+              : 'bg-transparent text-[rgba(22,24,35,0.72)] hover:bg-[#f5f6f7]',
+          ].join(' ')}
+        >
+          <span className="flex min-w-0 items-center gap-2">
+            <Icon
+              size={14}
+              className={selected ? undefined : plugin.metadata.iconClassName}
+            />
+            <span className="min-w-0 flex-1 truncate" title={resource.name}>
+              {resource.name}
+            </span>
+            {resource.favorite && (
+              <Circle
+                size={6}
+                fill="currentColor"
+                className="shrink-0 text-[rgba(22,24,35,0.24)]"
+              />
+            )}
+            {document?.dirty && (
+              <Circle
+                size={6}
+                fill="currentColor"
+                className="shrink-0 text-[var(--yak-brand-color)]"
+              />
+            )}
+          </span>
+
+          {showUpdatedBy && (
+            <span
+              className="truncate text-[11px] text-[rgba(22,24,35,0.42)]"
+              title={`${resource.updatedBy} 修改`}
+            >
+              {resource.updatedBy} 修改
+            </span>
+          )}
+
+          {showUpdatedAt && (
+            <span
+              className="truncate text-right text-[11px] tabular-nums text-[rgba(22,24,35,0.36)]"
+              title={resource.updatedAt}
+            >
+              {resource.updatedAt}
+            </span>
+          )}
+        </button>
+      </ResourceContextMenu>
     );
   };
 
   return (
-    <aside className="flex w-[292px] shrink-0 flex-col border-r border-[#e5e7ea] bg-[#fbfbfc]">
+    <aside className="flex h-full w-full min-w-0 flex-col bg-[#fbfbfc]">
       <div className="border-b border-[#e7e9ec] p-3">
         <div className="flex items-center justify-between gap-2">
           <Select
@@ -149,7 +194,7 @@ const ExplorerPanel = ({ onCreate }: ExplorerPanelProps) => {
             className="min-w-0 flex-1 [&_.ant-select-selector]:!px-0"
             defaultValue="user-data-platform"
             options={[
-              { label: '用户数据平台', value: 'user-data-platform' },
+              { label: PROJECT_LABEL, value: 'user-data-platform' },
               { label: '实时数仓项目', value: 'realtime-warehouse' },
             ]}
           />
@@ -167,7 +212,7 @@ const ExplorerPanel = ({ onCreate }: ExplorerPanelProps) => {
           allowClear
           variant="filled"
           prefix={<Search size={14} />}
-          placeholder="搜索文件 / 目录"
+          placeholder="搜索名称 / 节点 ID / 修改人"
           value={explorerKeyword}
           onChange={(event: ChangeEvent<HTMLInputElement>) =>
             setExplorerKeyword(event.target.value)
@@ -214,14 +259,22 @@ const ExplorerPanel = ({ onCreate }: ExplorerPanelProps) => {
         </div>
       </div>
 
-      <div className="min-h-0 flex-1 overflow-y-auto px-2 py-2">
-        <div className="px-2 pb-1 text-[11px] font-semibold text-[rgba(22,24,35,0.48)]">
-          数据开发项目
+      <div className="min-h-0 flex-1 overflow-y-auto overflow-x-hidden px-2 pb-2">
+        <div
+          className={`sticky top-0 z-10 grid h-8 items-center gap-x-2 border-b border-[#eceef0] bg-[#fbfbfc] px-2 text-[10px] font-medium text-[rgba(22,24,35,0.38)] ${gridClassName}`}
+        >
+          <span>名称</span>
+          {showUpdatedBy && <span>修改人</span>}
+          {showUpdatedAt && <span className="text-right">修改时间</span>}
+        </div>
+
+        <div className="px-2 pb-1 pt-2 text-[11px] font-semibold text-[rgba(22,24,35,0.48)]">
+          项目目录
         </div>
 
         {folders.map((folder) => {
-          const resourceIds = (resourceIdsByFolder[folder.id] ?? []).filter((id) =>
-            visibleResourceIdSet.has(id),
+          const resourceIds = (resourceIdsByFolder[folder.id] ?? []).filter(
+            (id) => visibleResourceIdSet.has(id),
           );
           const expanded = expandedFolderIds[folder.id] ?? true;
 
@@ -232,9 +285,13 @@ const ExplorerPanel = ({ onCreate }: ExplorerPanelProps) => {
               <button
                 type="button"
                 onClick={() => toggleFolder(folder.id)}
-                className="flex h-7 w-full items-center gap-1.5 rounded-[5px] border-0 bg-transparent px-1.5 text-left text-[12px] font-medium text-[rgba(22,24,35,0.76)] hover:bg-[#f2f3f4]"
+                className="flex h-8 w-full items-center gap-1.5 rounded-[5px] border-0 bg-transparent px-1.5 text-left text-[12px] font-medium text-[rgba(22,24,35,0.76)] hover:bg-[#f2f3f4]"
               >
-                {expanded ? <ChevronDown size={13} /> : <ChevronRight size={13} />}
+                {expanded ? (
+                  <ChevronDown size={13} />
+                ) : (
+                  <ChevronRight size={13} />
+                )}
                 {expanded ? (
                   <FolderOpen size={15} className="text-[#f2a800]" />
                 ) : (
@@ -247,7 +304,7 @@ const ExplorerPanel = ({ onCreate }: ExplorerPanelProps) => {
               </button>
 
               {expanded && (
-                <div className="ml-[22px] border-l border-[#e6e8eb] pl-1.5">
+                <div className="ml-[20px] border-l border-[#e6e8eb] pl-1.5">
                   {resourceIds.length > 0 ? (
                     resourceIds.map(renderResourceRow)
                   ) : (

--- a/yak-ops-ui/src/pages/data-development/workbench/components/ResourceContextMenu.tsx
+++ b/yak-ops-ui/src/pages/data-development/workbench/components/ResourceContextMenu.tsx
@@ -1,0 +1,306 @@
+import { history } from '@umijs/max';
+import {
+  Dropdown,
+  Input,
+  Modal,
+  Select,
+  message,
+  type MenuProps,
+} from 'antd';
+import {
+  Activity,
+  Columns2,
+  Copy,
+  Files,
+  Folder,
+  History,
+  Pencil,
+  Star,
+  Trash2,
+} from 'lucide-react';
+import { useMemo, useState, type ReactElement } from 'react';
+import type {
+  DevelopmentResource,
+  WorkbenchFolderDefinition,
+} from '../core/types';
+import { useWorkbenchStore } from '../store/workbench.store';
+
+interface ResourceContextMenuProps {
+  resource: DevelopmentResource;
+  folders: WorkbenchFolderDefinition[];
+  projectLabel: string;
+  children: ReactElement;
+}
+
+const MenuLabel = ({
+  children,
+  shortcut,
+}: {
+  children: string;
+  shortcut?: string;
+}) => (
+  <span className="flex min-w-[210px] items-center justify-between gap-8">
+    <span>{children}</span>
+    {shortcut && (
+      <span className="text-[11px] text-[rgba(22,24,35,0.36)]">
+        {shortcut}
+      </span>
+    )}
+  </span>
+);
+
+const copyText = async (value: string) => {
+  if (navigator.clipboard?.writeText) {
+    await navigator.clipboard.writeText(value);
+    return;
+  }
+
+  const textarea = document.createElement('textarea');
+  textarea.value = value;
+  textarea.style.position = 'fixed';
+  textarea.style.opacity = '0';
+  document.body.appendChild(textarea);
+  textarea.select();
+  document.execCommand('copy');
+  textarea.remove();
+};
+
+const ResourceContextMenu = ({
+  resource,
+  folders,
+  projectLabel,
+  children,
+}: ResourceContextMenuProps) => {
+  const cloneResource = useWorkbenchStore((state) => state.cloneResource);
+  const deleteResource = useWorkbenchStore((state) => state.deleteResource);
+  const moveResource = useWorkbenchStore((state) => state.moveResource);
+  const updateResource = useWorkbenchStore((state) => state.updateResource);
+  const openResource = useWorkbenchStore((state) => state.openResource);
+  const setActiveResource = useWorkbenchStore(
+    (state) => state.setActiveResource,
+  );
+  const setRightPanel = useWorkbenchStore((state) => state.setRightPanel);
+  const setSplitResource = useWorkbenchStore(
+    (state) => state.setSplitResource,
+  );
+  const document = useWorkbenchStore(
+    (state) => state.documentsByResourceId[resource.id],
+  );
+
+  const [renameOpen, setRenameOpen] = useState(false);
+  const [renameValue, setRenameValue] = useState(resource.name);
+  const [moveOpen, setMoveOpen] = useState(false);
+  const [moveFolderId, setMoveFolderId] = useState(resource.folderId);
+
+  const folderLabel =
+    folders.find((folder) => folder.id === resource.folderId)?.label ??
+    resource.folderId;
+  const resourcePath = `/${projectLabel}/${folderLabel}/${resource.name}`;
+
+  const menuItems = useMemo<MenuProps['items']>(
+    () => [
+      {
+        key: 'clone',
+        icon: <Files size={14} />,
+        label: <MenuLabel>克隆</MenuLabel>,
+      },
+      {
+        key: 'copy-name',
+        icon: <Copy size={14} />,
+        label: <MenuLabel>复制名称</MenuLabel>,
+      },
+      {
+        key: 'copy-path',
+        icon: <Copy size={14} />,
+        label: <MenuLabel>复制路径</MenuLabel>,
+      },
+      { type: 'divider' },
+      {
+        key: 'publish-history',
+        icon: <History size={14} />,
+        label: <MenuLabel>发布历史</MenuLabel>,
+      },
+      {
+        key: 'operations',
+        icon: <Activity size={14} />,
+        label: <MenuLabel>在运维中心查看</MenuLabel>,
+      },
+      { type: 'divider' },
+      {
+        key: 'open-side',
+        icon: <Columns2 size={14} />,
+        label: <MenuLabel shortcut="Ctrl+Enter">在侧边打开</MenuLabel>,
+      },
+      {
+        key: 'favorite',
+        icon: (
+          <Star
+            size={14}
+            fill={resource.favorite ? 'currentColor' : 'none'}
+          />
+        ),
+        label: (
+          <MenuLabel>{resource.favorite ? '取消收藏' : '收藏'}</MenuLabel>
+        ),
+      },
+      { type: 'divider' },
+      {
+        key: 'move',
+        icon: <Folder size={14} />,
+        label: <MenuLabel>移动...</MenuLabel>,
+      },
+      {
+        key: 'rename',
+        icon: <Pencil size={14} />,
+        label: <MenuLabel shortcut="Enter">重命名...</MenuLabel>,
+      },
+      {
+        key: 'delete',
+        danger: true,
+        icon: <Trash2 size={14} />,
+        label: <MenuLabel shortcut="Delete">删除</MenuLabel>,
+      },
+    ],
+    [resource.favorite],
+  );
+
+  const handleMenuClick: MenuProps['onClick'] = async ({ key, domEvent }) => {
+    domEvent.stopPropagation();
+
+    switch (key) {
+      case 'clone': {
+        const clonedId = cloneResource(resource.id);
+        if (clonedId) message.success('节点已克隆并打开');
+        break;
+      }
+      case 'copy-name':
+        await copyText(resource.name);
+        message.success('名称已复制');
+        break;
+      case 'copy-path':
+        await copyText(resourcePath);
+        message.success('路径已复制');
+        break;
+      case 'publish-history':
+        openResource(resource.id, { pinned: true });
+        setActiveResource(resource.id);
+        setRightPanel('version');
+        break;
+      case 'operations':
+        history.push(
+          `/data-development/instances?resourceId=${encodeURIComponent(resource.id)}`,
+        );
+        break;
+      case 'open-side':
+        openResource(resource.id, { pinned: true });
+        setSplitResource(resource.id);
+        break;
+      case 'favorite':
+        updateResource(resource.id, { favorite: !resource.favorite });
+        message.success(resource.favorite ? '已取消收藏' : '已收藏');
+        break;
+      case 'move':
+        setMoveFolderId(resource.folderId);
+        setMoveOpen(true);
+        break;
+      case 'rename':
+        setRenameValue(resource.name);
+        setRenameOpen(true);
+        break;
+      case 'delete':
+        Modal.confirm({
+          centered: true,
+          title: '删除开发节点',
+          content: document?.dirty
+            ? `“${resource.name}”存在未保存的更改，删除后无法恢复。`
+            : `确认删除“${resource.name}”吗？删除后无法恢复。`,
+          okText: '删除',
+          cancelText: '取消',
+          okButtonProps: { danger: true },
+          onOk: () => {
+            deleteResource(resource.id);
+            message.success('节点已删除');
+          },
+        });
+        break;
+      default:
+        break;
+    }
+  };
+
+  const submitRename = () => {
+    const nextName = renameValue.trim();
+    if (!nextName) {
+      message.warning('请输入节点名称');
+      return;
+    }
+
+    updateResource(resource.id, { name: nextName });
+    setRenameOpen(false);
+    message.success('节点已重命名');
+  };
+
+  const submitMove = () => {
+    if (!moveFolderId) return;
+    moveResource(resource.id, moveFolderId);
+    setMoveOpen(false);
+    message.success('节点已移动');
+  };
+
+  return (
+    <>
+      <Dropdown
+        trigger={['contextMenu']}
+        menu={{ items: menuItems, onClick: handleMenuClick }}
+      >
+        {children}
+      </Dropdown>
+
+      <Modal
+        title="重命名节点"
+        open={renameOpen}
+        centered
+        width={440}
+        okText="确定"
+        cancelText="取消"
+        destroyOnHidden
+        onOk={submitRename}
+        onCancel={() => setRenameOpen(false)}
+      >
+        <Input
+          autoFocus
+          variant="filled"
+          value={renameValue}
+          maxLength={120}
+          onChange={(event) => setRenameValue(event.target.value)}
+          onPressEnter={submitRename}
+        />
+      </Modal>
+
+      <Modal
+        title="移动节点"
+        open={moveOpen}
+        centered
+        width={440}
+        okText="移动"
+        cancelText="取消"
+        destroyOnHidden
+        onOk={submitMove}
+        onCancel={() => setMoveOpen(false)}
+      >
+        <Select
+          variant="filled"
+          className="w-full"
+          value={moveFolderId}
+          options={folders.map((folder) => ({
+            value: folder.id,
+            label: folder.label,
+          }))}
+          onChange={setMoveFolderId}
+        />
+      </Modal>
+    </>
+  );
+};
+
+export default ResourceContextMenu;

--- a/yak-ops-ui/src/pages/data-development/workbench/components/WorkbenchResizeHandle.tsx
+++ b/yak-ops-ui/src/pages/data-development/workbench/components/WorkbenchResizeHandle.tsx
@@ -1,0 +1,108 @@
+import { useEffect, useRef, type KeyboardEvent, type PointerEvent } from 'react';
+
+interface WorkbenchResizeHandleProps {
+  value: number;
+  min: number;
+  max: number;
+  defaultValue: number;
+  ariaLabel: string;
+  onChange: (value: number) => void;
+}
+
+const clamp = (value: number, min: number, max: number) =>
+  Math.min(max, Math.max(min, value));
+
+const WorkbenchResizeHandle = ({
+  value,
+  min,
+  max,
+  defaultValue,
+  ariaLabel,
+  onChange,
+}: WorkbenchResizeHandleProps) => {
+  const cleanupRef = useRef<(() => void) | null>(null);
+
+  useEffect(
+    () => () => {
+      cleanupRef.current?.();
+    },
+    [],
+  );
+
+  const handlePointerDown = (event: PointerEvent<HTMLDivElement>) => {
+    if (event.button !== 0) return;
+
+    event.preventDefault();
+    const startX = event.clientX;
+    const startValue = value;
+    const previousCursor = document.body.style.cursor;
+    const previousUserSelect = document.body.style.userSelect;
+
+    document.body.style.cursor = 'col-resize';
+    document.body.style.userSelect = 'none';
+
+    const handlePointerMove = (moveEvent: globalThis.PointerEvent) => {
+      onChange(clamp(startValue + moveEvent.clientX - startX, min, max));
+    };
+
+    const cleanup = () => {
+      window.removeEventListener('pointermove', handlePointerMove);
+      window.removeEventListener('pointerup', cleanup);
+      window.removeEventListener('pointercancel', cleanup);
+      document.body.style.cursor = previousCursor;
+      document.body.style.userSelect = previousUserSelect;
+      cleanupRef.current = null;
+    };
+
+    cleanupRef.current?.();
+    cleanupRef.current = cleanup;
+    window.addEventListener('pointermove', handlePointerMove);
+    window.addEventListener('pointerup', cleanup);
+    window.addEventListener('pointercancel', cleanup);
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    const step = event.shiftKey ? 40 : 12;
+
+    if (event.key === 'ArrowLeft') {
+      event.preventDefault();
+      onChange(clamp(value - step, min, max));
+    }
+
+    if (event.key === 'ArrowRight') {
+      event.preventDefault();
+      onChange(clamp(value + step, min, max));
+    }
+
+    if (event.key === 'Home') {
+      event.preventDefault();
+      onChange(min);
+    }
+
+    if (event.key === 'End') {
+      event.preventDefault();
+      onChange(max);
+    }
+  };
+
+  return (
+    <div
+      role="separator"
+      aria-label={ariaLabel}
+      aria-orientation="vertical"
+      aria-valuemin={min}
+      aria-valuemax={max}
+      aria-valuenow={Math.round(value)}
+      tabIndex={0}
+      onPointerDown={handlePointerDown}
+      onDoubleClick={() => onChange(defaultValue)}
+      onKeyDown={handleKeyDown}
+      className="group relative z-20 h-full w-[5px] shrink-0 cursor-col-resize touch-none bg-transparent outline-none"
+    >
+      <span className="absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-[#e5e7ea] transition-[width,background-color] group-hover:w-[3px] group-hover:bg-[var(--yak-brand-color)] group-focus-visible:w-[3px] group-focus-visible:bg-[var(--yak-brand-color)]" />
+      <span className="pointer-events-none absolute left-1/2 top-1/2 h-10 w-[3px] -translate-x-1/2 -translate-y-1/2 rounded-full bg-transparent transition-colors group-hover:bg-[var(--yak-brand-color-soft-hover)] group-focus-visible:bg-[var(--yak-brand-color-soft-hover)]" />
+    </div>
+  );
+};
+
+export default WorkbenchResizeHandle;

--- a/yak-ops-ui/src/pages/data-development/workbench/core/types.ts
+++ b/yak-ops-ui/src/pages/data-development/workbench/core/types.ts
@@ -86,6 +86,7 @@ export interface DevelopmentResource {
   name: string;
   description?: string;
   owner: ResourceOwner;
+  updatedBy: string;
   favorite?: boolean;
   engine: string;
   status: ResourceStatus;

--- a/yak-ops-ui/src/pages/data-development/workbench/mock/workspace.ts
+++ b/yak-ops-ui/src/pages/data-development/workbench/mock/workspace.ts
@@ -14,6 +14,7 @@ const pluginByType = new Map<string, NodePluginDefinition>(
 );
 
 const now = '2026-08-04 10:20';
+const currentUserName = 'aliyun0124584470';
 
 const createResource = (
   id: string,
@@ -34,6 +35,7 @@ const createResource = (
     name,
     description: plugin.metadata.description,
     owner: 'me',
+    updatedBy: currentUserName,
     favorite: false,
     engine: plugin.metadata.defaultEngine,
     status: 'DRAFT',
@@ -83,19 +85,25 @@ export const createMockWorkspaceSnapshot = (): WorkspaceSnapshot => {
     }),
     createResource('user-behavior-agg', 'user_behavior_agg.sql', 'SQL', {
       engine: 'Spark SQL',
+      updatedBy: 'data_admin',
       updatedAt: '2026-08-04 08:46',
     }),
     createResource('dim-user-profile', 'dim_user_profile.sql', 'SQL', {
       engine: 'Hive',
       owner: 'other',
+      updatedBy: 'zhangsan',
       favorite: true,
     }),
-    createResource('ods-to-dwd-flink', 'ods_to_dwd_flink.sql', 'FLINK_SQL'),
+    createResource('ods-to-dwd-flink', 'ods_to_dwd_flink.sql', 'FLINK_SQL', {
+      updatedBy: 'realtime_owner',
+      updatedAt: '2026-08-04 08:35',
+    }),
     createResource('udf-string-masking', 'udf_string_masking.py', 'PYTHON', {
       favorite: true,
       updatedAt: '2026-08-03 16:21',
     }),
     createResource('shell-clean-log', 'shell_clean_log.sh', 'SHELL', {
+      updatedBy: 'ops_admin',
       updatedAt: '2026-08-03 17:20',
     }),
     createResource(
@@ -104,6 +112,7 @@ export const createMockWorkspaceSnapshot = (): WorkspaceSnapshot => {
       'NOTEBOOK',
       {
         favorite: true,
+        updatedBy: 'analyst_01',
         updatedAt: '2026-08-03 18:45',
       },
     ),
@@ -111,10 +120,19 @@ export const createMockWorkspaceSnapshot = (): WorkspaceSnapshot => {
       'sync-odps-odps',
       'sync_odps_to_odps_20260803',
       'DATA_INTEGRATION',
-      { favorite: true },
+      {
+        favorite: true,
+        updatedAt: '2026-08-04 08:54',
+      },
     ),
-    createResource('http-user-profile', 'fetch_user_profile_api', 'HTTP'),
-    createResource('dev-env', 'dev.env', 'RESOURCE'),
+    createResource('http-user-profile', 'fetch_user_profile_api', 'HTTP', {
+      updatedBy: 'api_owner',
+      updatedAt: '2026-08-04 08:28',
+    }),
+    createResource('dev-env', 'dev.env', 'RESOURCE', {
+      updatedBy: 'platform_admin',
+      updatedAt: '2026-08-02 14:10',
+    }),
   ];
 
   const documents = resources.map((resource) => {
@@ -222,23 +240,30 @@ export const createNewResource = (
   const rawName = name.trim();
   const extension = plugin.metadata.extension ?? '';
   const normalizedName =
-    extension && !rawName.endsWith(extension) ? `${rawName}${extension}` : rawName;
+    extension && !rawName.endsWith(extension)
+      ? `${rawName}${extension}`
+      : rawName;
   const id = `${plugin.type.toLowerCase()}-${timestamp}`;
   const updatedAt = dayjs().format('YYYY-MM-DD HH:mm');
 
   const resource = createResource(id, normalizedName, plugin.type, {
     folderId: plugin.metadata.folderId,
     engine: plugin.metadata.defaultEngine,
+    updatedBy: currentUserName,
     updatedAt,
     createdAt: updatedAt,
     latestRevision: 0,
   });
 
-  const document = createDocument(resource, plugin.authoring.createDefaultContent(normalizedName), {
-    revision: 0,
-    dirty: true,
-    updatedAt,
-  });
+  const document = createDocument(
+    resource,
+    plugin.authoring.createDefaultContent(normalizedName),
+    {
+      revision: 0,
+      dirty: true,
+      updatedAt,
+    },
+  );
 
   return { resource, document };
 };

--- a/yak-ops-ui/src/pages/data-development/workbench/store/workbench.store.ts
+++ b/yak-ops-ui/src/pages/data-development/workbench/store/workbench.store.ts
@@ -25,6 +25,7 @@ interface WorkbenchStoreState {
   explorerFilter: ExplorerFilter;
   explorerKeyword: string;
   explorerVisible: boolean;
+  explorerWidth: number;
   fullscreen: boolean;
   previewEnabled: boolean;
   tabGroupLocked: boolean;
@@ -33,6 +34,7 @@ interface WorkbenchStoreState {
   setExplorerFilter: (filter: ExplorerFilter) => void;
   setExplorerKeyword: (keyword: string) => void;
   setExplorerVisible: (visible: boolean) => void;
+  setExplorerWidth: (width: number) => void;
   setFullscreen: (fullscreen: boolean) => void;
   setPreviewEnabled: (enabled: boolean) => void;
   setTabGroupLocked: (locked: boolean) => void;
@@ -50,6 +52,8 @@ interface WorkbenchStoreState {
     resource: DevelopmentResource,
     document: DevelopmentDocument,
   ) => void;
+  cloneResource: (resourceId: string) => string | undefined;
+  moveResource: (resourceId: string, folderId: string) => void;
   deleteResource: (resourceId: string) => void;
   updateResource: (
     resourceId: string,
@@ -67,6 +71,7 @@ interface WorkbenchStoreState {
   setScheduleEnabled: (resourceId: string, enabled: boolean) => void;
 }
 
+const CURRENT_USER_NAME = 'aliyun0124584470';
 const snapshot = createMockWorkspaceSnapshot();
 
 const resourcesById = Object.fromEntries(
@@ -77,7 +82,10 @@ const documentsByResourceId = Object.fromEntries(
 );
 const resourceIdsByFolder = snapshot.resources.reduce<Record<string, string[]>>(
   (groups, resource) => {
-    groups[resource.folderId] = [...(groups[resource.folderId] ?? []), resource.id];
+    groups[resource.folderId] = [
+      ...(groups[resource.folderId] ?? []),
+      resource.id,
+    ];
     return groups;
   },
   {},
@@ -90,6 +98,21 @@ const expandedFolderIds = Object.keys(resourceIdsByFolder).reduce<
 }, {});
 
 const uniqueIds = (ids: string[]) => Array.from(new Set(ids));
+
+const createCloneName = (sourceName: string, existingNames: Set<string>) => {
+  const dotIndex = sourceName.lastIndexOf('.');
+  const hasExtension = dotIndex > 0;
+  const basename = hasExtension ? sourceName.slice(0, dotIndex) : sourceName;
+  const extension = hasExtension ? sourceName.slice(dotIndex) : '';
+
+  let index = 1;
+  let candidate = `${basename}_copy${extension}`;
+  while (existingNames.has(candidate)) {
+    index += 1;
+    candidate = `${basename}_copy_${index}${extension}`;
+  }
+  return candidate;
+};
 
 export const useWorkbenchStore = create<WorkbenchStoreState>((set, get) => ({
   resourcesById,
@@ -107,6 +130,7 @@ export const useWorkbenchStore = create<WorkbenchStoreState>((set, get) => ({
   explorerFilter: 'all',
   explorerKeyword: '',
   explorerVisible: true,
+  explorerWidth: 460,
   fullscreen: false,
   previewEnabled: true,
   tabGroupLocked: false,
@@ -115,6 +139,10 @@ export const useWorkbenchStore = create<WorkbenchStoreState>((set, get) => ({
   setExplorerFilter: (explorerFilter) => set({ explorerFilter }),
   setExplorerKeyword: (explorerKeyword) => set({ explorerKeyword }),
   setExplorerVisible: (explorerVisible) => set({ explorerVisible }),
+  setExplorerWidth: (explorerWidth) =>
+    set({
+      explorerWidth: Math.min(720, Math.max(300, Math.round(explorerWidth))),
+    }),
   setFullscreen: (fullscreen) => set({ fullscreen }),
   setPreviewEnabled: (previewEnabled) =>
     set((state) => ({
@@ -281,6 +309,109 @@ export const useWorkbenchStore = create<WorkbenchStoreState>((set, get) => ({
       pinnedResourceIds: uniqueIds([...state.pinnedResourceIds, resource.id]),
     })),
 
+  cloneResource: (resourceId) => {
+    const state = get();
+    const resource = state.resourcesById[resourceId];
+    const document = state.documentsByResourceId[resourceId];
+    if (!resource || !document) return undefined;
+
+    const timestamp = Date.now();
+    const clonedId = `${resource.resourceType.toLowerCase()}-${timestamp}`;
+    const updatedAt = dayjs().format('YYYY-MM-DD HH:mm');
+    const existingNames = new Set(
+      (state.resourceIdsByFolder[resource.folderId] ?? [])
+        .map((id) => state.resourcesById[id]?.name)
+        .filter((name): name is string => Boolean(name)),
+    );
+    const clonedName = createCloneName(resource.name, existingNames);
+
+    const clonedResource: DevelopmentResource = {
+      ...resource,
+      id: clonedId,
+      name: clonedName,
+      owner: 'me',
+      updatedBy: CURRENT_USER_NAME,
+      favorite: false,
+      status: 'DRAFT',
+      latestRevision: 0,
+      publishedVersion: undefined,
+      createdAt: updatedAt,
+      updatedAt,
+    };
+    const clonedDocument: DevelopmentDocument = {
+      ...document,
+      resourceId: clonedId,
+      revision: 0,
+      content: structuredClone(document.content),
+      config: structuredClone(document.config),
+      runtime: structuredClone(document.runtime),
+      dirty: true,
+      saveStatus: 'IDLE',
+      updatedAt,
+    };
+
+    set({
+      resourcesById: {
+        ...state.resourcesById,
+        [clonedId]: clonedResource,
+      },
+      documentsByResourceId: {
+        ...state.documentsByResourceId,
+        [clonedId]: clonedDocument,
+      },
+      resourceIdsByFolder: {
+        ...state.resourceIdsByFolder,
+        [resource.folderId]: [
+          ...(state.resourceIdsByFolder[resource.folderId] ?? []),
+          clonedId,
+        ],
+      },
+      expandedFolderIds: {
+        ...state.expandedFolderIds,
+        [resource.folderId]: true,
+      },
+      openResourceIds: uniqueIds([...state.openResourceIds, clonedId]),
+      activeResourceId: clonedId,
+      previewResourceId: undefined,
+      pinnedResourceIds: uniqueIds([...state.pinnedResourceIds, clonedId]),
+    });
+
+    return clonedId;
+  },
+
+  moveResource: (resourceId, folderId) =>
+    set((state: WorkbenchStoreState) => {
+      const resource = state.resourcesById[resourceId];
+      if (!resource || resource.folderId === folderId) return state;
+
+      const updatedAt = dayjs().format('YYYY-MM-DD HH:mm');
+      return {
+        resourcesById: {
+          ...state.resourcesById,
+          [resourceId]: {
+            ...resource,
+            folderId,
+            updatedBy: CURRENT_USER_NAME,
+            updatedAt,
+          },
+        },
+        resourceIdsByFolder: {
+          ...state.resourceIdsByFolder,
+          [resource.folderId]: (
+            state.resourceIdsByFolder[resource.folderId] ?? []
+          ).filter((id) => id !== resourceId),
+          [folderId]: uniqueIds([
+            ...(state.resourceIdsByFolder[folderId] ?? []),
+            resourceId,
+          ]),
+        },
+        expandedFolderIds: {
+          ...state.expandedFolderIds,
+          [folderId]: true,
+        },
+      };
+    }),
+
   deleteResource: (resourceId) => {
     const state = get();
     const resource = state.resourcesById[resourceId];
@@ -338,6 +469,7 @@ export const useWorkbenchStore = create<WorkbenchStoreState>((set, get) => ({
           [resourceId]: {
             ...resource,
             ...patch,
+            updatedBy: patch.updatedBy ?? CURRENT_USER_NAME,
             updatedAt: dayjs().format('YYYY-MM-DD HH:mm'),
           },
         },
@@ -387,6 +519,7 @@ export const useWorkbenchStore = create<WorkbenchStoreState>((set, get) => ({
           [resourceId]: {
             ...resource,
             latestRevision: nextRevision,
+            updatedBy: CURRENT_USER_NAME,
             updatedAt,
           },
         },


### PR DESCRIPTION
## 变更说明

继续完善 `/data-development/workbench` 左侧项目目录体验，补齐资源元数据、右键操作以及目录与编辑区之间的可调整布局。

### 目录字段

- 资源行增加“名称 / 修改人 / 修改时间”字段
- 搜索支持节点名称、节点 ID 和修改人
- 目录宽度不足时自适应隐藏次要字段：
  - 较窄：仅显示名称
  - 中等：显示名称和修改人
  - 较宽：完整显示名称、修改人和修改时间
- 字段标题保持吸顶，长名称、修改人和时间均支持省略与悬浮查看
- 单击以预览方式打开，双击以固定标签方式打开

### 资源右键菜单

参考 DataWorks 目录交互，为开发资源增加：

- 克隆
- 复制名称
- 复制路径
- 发布历史
- 在运维中心查看
- 在侧边打开
- 收藏 / 取消收藏
- 移动
- 重命名
- 删除

其中克隆、移动、重命名、收藏和删除均接入当前 Zustand Store；发布历史会打开版本面板，在侧边打开复用已有拆分编辑器能力。

### 可拖拽分隔线

- 左侧目录与编辑区之间新增拖拽分隔线
- 目录宽度限制在 300px 至 720px
- 双击分隔线恢复默认 460px
- 支持键盘左右方向键微调，按住 Shift 可大步调整
- 支持 Home / End 快速调整到最小或最大宽度
- 分隔线包含可访问性属性和清晰的 Hover / Focus 状态

### 数据模型与状态

- `DevelopmentResource` 增加 `updatedBy`
- Store 增加 `explorerWidth`、`setExplorerWidth`
- Store 增加 `cloneResource`、`moveResource`
- 保存、重命名、移动和克隆时同步更新修改人及修改时间
- Mock 数据补充不同修改人与更新时间，用于验证多列目录展示

## 验证建议

1. 打开 `/data-development/workbench`
2. 拖动左侧与编辑区之间的分隔线，检查目录宽度与字段自适应
3. 双击分隔线，检查是否恢复默认宽度
4. 搜索名称、节点 ID 和修改人
5. 右键任意资源，验证克隆、复制、收藏、移动、重命名和删除
6. 验证“发布历史”“在运维中心查看”和“在侧边打开”
7. 保存节点后检查修改人与修改时间是否更新

## 验证情况

- 已对本次涉及的 7 个 TS/TSX 文件执行 TypeScript `transpileModule` 语法检查
- 分支基于合并 PR #189 后的最新 `main`
- 当前工具环境未执行完整依赖安装和 `npm run build`，因此 PR 保持 Draft 状态
