### PR TITLE
feat(data-development): run current SQL statement from editor

### DIFF
--- a/yak-ops-ui/src/pages/data-development/workbench/core/commands.ts
+++ b/yak-ops-ui/src/pages/data-development/workbench/core/commands.ts
@@ -45,6 +45,10 @@ export const BUILTIN_COMMANDS: WorkbenchCommandDefinition[] = [
     execute: (context) => runResource(context, '正在运行'),
   },
   {
+    id: 'sql.run-statement',
+    execute: (context) => runResource(context, '正在运行当前 SQL'),
+  },
+  {
     id: 'http.test',
     execute: (context) => runResource(context, '正在发送测试请求'),
   },

--- a/yak-ops-ui/src/pages/data-development/workbench/renderers/CodeResourceRenderer.tsx
+++ b/yak-ops-ui/src/pages/data-development/workbench/renderers/CodeResourceRenderer.tsx
@@ -31,29 +31,73 @@ import {
   type ViewUpdate,
 } from '@codemirror/view';
 import { useEffect, useRef } from 'react';
+import { commandRegistry } from '../core/registry';
 import type { ResourceRendererProps } from '../core/types';
+import { useWorkbenchStore } from '../store/workbench.store';
+import {
+  createSqlStatementExtensions,
+  type SqlStatementRange,
+} from './sql/sqlStatementExtension';
 
 const CodeResourceRenderer = ({
+  resource,
   document,
+  plugin,
   onChange,
 }: ResourceRendererProps) => {
   const hostRef = useRef<HTMLDivElement | null>(null);
   const viewRef = useRef<EditorView | undefined>(undefined);
   const onChangeRef = useRef(onChange);
   const documentRef = useRef(document);
+  const resourceRef = useRef(resource);
+  const pluginRef = useRef(plugin);
 
   const content = document.content.kind === 'text' ? document.content : undefined;
 
   useEffect(() => {
     onChangeRef.current = onChange;
     documentRef.current = document;
-  }, [document, onChange]);
+    resourceRef.current = resource;
+    pluginRef.current = plugin;
+  }, [document, onChange, plugin, resource]);
 
   useEffect(() => {
     if (!hostRef.current || !content) return undefined;
 
     const languageExtensions: Extension[] =
       content.language === 'sql' ? [sql()] : [];
+
+    const runSqlStatement = (statement: SqlStatementRange) => {
+      const currentDocument = documentRef.current;
+      const currentResource = resourceRef.current;
+      const currentPlugin = pluginRef.current;
+
+      if (currentDocument.content.kind !== 'text') return;
+
+      const statementDocument = {
+        ...currentDocument,
+        content: {
+          ...currentDocument.content,
+          value: statement.sql,
+        },
+      };
+      const executionStatus =
+        useWorkbenchStore.getState().executionStatusByResourceId[
+          currentResource.id
+        ] ?? 'IDLE';
+
+      void commandRegistry.execute('sql.run-statement', {
+        resource: currentResource,
+        document: statementDocument,
+        plugin: currentPlugin,
+        executionStatus,
+      });
+    };
+
+    const sqlStatementExtensions: Extension[] =
+      content.language === 'sql'
+        ? createSqlStatementExtensions(runSqlStatement)
+        : [];
 
     const state = EditorState.create({
       doc: content.value,
@@ -80,6 +124,7 @@ const CodeResourceRenderer = ({
           indentWithTab,
         ]),
         ...languageExtensions,
+        ...sqlStatementExtensions,
         highlightActiveLine(),
         EditorView.contentAttributes.of({ 'aria-label': '代码编辑器' }),
         EditorView.updateListener.of((update: ViewUpdate) => {

--- a/yak-ops-ui/src/pages/data-development/workbench/renderers/sql/sqlStatementExtension.ts
+++ b/yak-ops-ui/src/pages/data-development/workbench/renderers/sql/sqlStatementExtension.ts
@@ -1,0 +1,415 @@
+import { type EditorState, type Extension } from '@codemirror/state';
+import {
+  Decoration,
+  type DecorationSet,
+  EditorView,
+  GutterMarker,
+  gutter,
+  keymap,
+  ViewPlugin,
+  type ViewUpdate,
+} from '@codemirror/view';
+
+export interface SqlStatementRange {
+  from: number;
+  to: number;
+  fromLine: number;
+  toLine: number;
+  sql: string;
+  source: 'selection' | 'statement';
+}
+
+export type SqlStatementRunHandler = (range: SqlStatementRange) => void;
+
+interface ParsedSqlStatement {
+  rawFrom: number;
+  rawTo: number;
+  from: number;
+  to: number;
+}
+
+const isWhitespace = (value: string) => /\s/.test(value);
+
+const skipLineComment = (source: string, position: number, limit: number) => {
+  let cursor = position + 2;
+  while (cursor < limit && source[cursor] !== '\n') cursor += 1;
+  return cursor;
+};
+
+const skipBlockComment = (source: string, position: number, limit: number) => {
+  let cursor = position + 2;
+  while (cursor < limit - 1) {
+    if (source[cursor] === '*' && source[cursor + 1] === '/') {
+      return cursor + 2;
+    }
+    cursor += 1;
+  }
+  return limit;
+};
+
+const skipLeadingTrivia = (source: string, from: number, to: number) => {
+  let cursor = from;
+
+  while (cursor < to) {
+    if (isWhitespace(source[cursor])) {
+      cursor += 1;
+      continue;
+    }
+
+    if (source[cursor] === '-' && source[cursor + 1] === '-') {
+      cursor = skipLineComment(source, cursor, to);
+      continue;
+    }
+
+    if (source[cursor] === '/' && source[cursor + 1] === '*') {
+      cursor = skipBlockComment(source, cursor, to);
+      continue;
+    }
+
+    break;
+  }
+
+  return cursor;
+};
+
+const trimTrailingWhitespace = (source: string, from: number, to: number) => {
+  let cursor = to;
+  while (cursor > from && isWhitespace(source[cursor - 1])) cursor -= 1;
+  return cursor;
+};
+
+const normalizeStatement = (
+  source: string,
+  rawFrom: number,
+  rawTo: number,
+): ParsedSqlStatement | undefined => {
+  const from = skipLeadingTrivia(source, rawFrom, rawTo);
+  const to = trimTrailingWhitespace(source, from, rawTo);
+
+  if (from >= to) return undefined;
+
+  const executable = source
+    .slice(from, to)
+    .replace(/;/g, '')
+    .trim();
+
+  if (!executable) return undefined;
+
+  return { rawFrom, rawTo, from, to };
+};
+
+/**
+ * Split SQL on semicolons while preserving semicolons inside quoted values and
+ * comments. This is intentionally dialect-neutral—the SQL language service can
+ * still provide syntax parsing separately.
+ */
+export const parseSqlStatements = (source: string): ParsedSqlStatement[] => {
+  const statements: ParsedSqlStatement[] = [];
+  let statementStart = 0;
+  let quote: "'" | '"' | '`' | undefined;
+  let lineComment = false;
+  let blockComment = false;
+
+  const appendStatement = (rawTo: number) => {
+    const statement = normalizeStatement(source, statementStart, rawTo);
+    if (statement) statements.push(statement);
+    statementStart = rawTo;
+  };
+
+  for (let index = 0; index < source.length; index += 1) {
+    const current = source[index];
+    const next = source[index + 1];
+
+    if (lineComment) {
+      if (current === '\n') lineComment = false;
+      continue;
+    }
+
+    if (blockComment) {
+      if (current === '*' && next === '/') {
+        blockComment = false;
+        index += 1;
+      }
+      continue;
+    }
+
+    if (quote) {
+      if (current === '\\') {
+        index += 1;
+        continue;
+      }
+
+      if (current === quote) {
+        if (next === quote) {
+          index += 1;
+        } else {
+          quote = undefined;
+        }
+      }
+      continue;
+    }
+
+    if (current === '-' && next === '-') {
+      lineComment = true;
+      index += 1;
+      continue;
+    }
+
+    if (current === '/' && next === '*') {
+      blockComment = true;
+      index += 1;
+      continue;
+    }
+
+    if (current === "'" || current === '"' || current === '`') {
+      quote = current;
+      continue;
+    }
+
+    if (current === ';') appendStatement(index + 1);
+  }
+
+  if (statementStart < source.length) appendStatement(source.length);
+  return statements;
+};
+
+const createRange = (
+  state: EditorState,
+  from: number,
+  to: number,
+  source: SqlStatementRange['source'],
+): SqlStatementRange | undefined => {
+  const text = state.doc.sliceString(from, to);
+  let leading = 0;
+  let trailing = text.length;
+
+  while (leading < trailing && isWhitespace(text[leading])) leading += 1;
+  while (trailing > leading && isWhitespace(text[trailing - 1])) trailing -= 1;
+
+  const normalizedFrom = from + leading;
+  const normalizedTo = from + trailing;
+  if (normalizedFrom >= normalizedTo) return undefined;
+
+  const lastCharacter = Math.max(normalizedFrom, normalizedTo - 1);
+
+  return {
+    from: normalizedFrom,
+    to: normalizedTo,
+    fromLine: state.doc.lineAt(normalizedFrom).number,
+    toLine: state.doc.lineAt(lastCharacter).number,
+    sql: state.doc.sliceString(normalizedFrom, normalizedTo),
+    source,
+  };
+};
+
+export const resolveSqlStatementRange = (
+  state: EditorState,
+): SqlStatementRange | undefined => {
+  const selection = state.selection.main;
+
+  if (!selection.empty) {
+    return createRange(state, selection.from, selection.to, 'selection');
+  }
+
+  const source = state.doc.toString();
+  const cursor = selection.head;
+  const statements = parseSqlStatements(source);
+
+  const current =
+    statements.find(
+      (statement) => cursor >= statement.rawFrom && cursor <= statement.rawTo,
+    ) ??
+    statements.find((statement) => cursor < statement.rawFrom) ??
+    statements.at(-1);
+
+  if (!current) return undefined;
+  return createRange(state, current.from, current.to, 'statement');
+};
+
+const buildStatementDecorations = (
+  view: EditorView,
+  statement?: SqlStatementRange,
+): DecorationSet => {
+  if (!statement) return Decoration.none;
+
+  const decorations = [];
+  let line = view.state.doc.lineAt(statement.from);
+  const lastLine = view.state.doc.lineAt(
+    Math.max(statement.from, statement.to - 1),
+  );
+
+  while (line.number <= lastLine.number) {
+    const classes = ['cm-sql-statement-line'];
+    if (line.number === statement.fromLine) {
+      classes.push('cm-sql-statement-line-first');
+    }
+    if (line.number === statement.toLine) {
+      classes.push('cm-sql-statement-line-last');
+    }
+
+    decorations.push(
+      Decoration.line({
+        attributes: { class: classes.join(' ') },
+      }).range(line.from),
+    );
+
+    if (line.number === lastLine.number) break;
+    line = view.state.doc.line(line.number + 1);
+  }
+
+  return Decoration.set(decorations, true);
+};
+
+class SqlRunMarker extends GutterMarker {
+  constructor(
+    readonly statement: SqlStatementRange,
+    readonly onRun: SqlStatementRunHandler,
+  ) {
+    super();
+  }
+
+  toDOM() {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'cm-sql-run-button';
+    button.title = '运行当前 SQL（Ctrl+Enter）';
+    button.setAttribute('aria-label', `运行第 ${this.statement.fromLine} 至 ${this.statement.toLine} 行 SQL`);
+
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    svg.setAttribute('viewBox', '0 0 24 24');
+    svg.setAttribute('width', '14');
+    svg.setAttribute('height', '14');
+    svg.setAttribute('aria-hidden', 'true');
+
+    const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+    path.setAttribute('d', 'M7 4.8 18.5 12 7 19.2Z');
+    path.setAttribute('fill', 'none');
+    path.setAttribute('stroke', 'currentColor');
+    path.setAttribute('stroke-width', '1.8');
+    path.setAttribute('stroke-linejoin', 'round');
+    svg.appendChild(path);
+    button.appendChild(svg);
+
+    button.addEventListener('mousedown', (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+    });
+    button.addEventListener('click', (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      this.onRun(this.statement);
+    });
+
+    return button;
+  }
+}
+
+const sqlRunSpacer = new (class extends GutterMarker {
+  toDOM() {
+    const spacer = document.createElement('span');
+    spacer.className = 'cm-sql-run-spacer';
+    return spacer;
+  }
+})();
+
+export const createSqlStatementExtensions = (
+  onRun: SqlStatementRunHandler,
+): Extension[] => {
+  const statementPlugin = ViewPlugin.fromClass(
+    class {
+      statement?: SqlStatementRange;
+      decorations: DecorationSet;
+
+      constructor(view: EditorView) {
+        this.statement = resolveSqlStatementRange(view.state);
+        this.decorations = buildStatementDecorations(view, this.statement);
+      }
+
+      update(update: ViewUpdate) {
+        if (!update.docChanged && !update.selectionSet) return;
+        this.statement = resolveSqlStatementRange(update.state);
+        this.decorations = buildStatementDecorations(
+          update.view,
+          this.statement,
+        );
+      }
+    },
+    {
+      decorations: (plugin) => plugin.decorations,
+    },
+  );
+
+  return [
+    statementPlugin,
+    gutter({
+      class: 'cm-sql-run-gutter',
+      initialSpacer: () => sqlRunSpacer,
+      lineMarker: (view, line) => {
+        const statement = view.plugin(statementPlugin)?.statement;
+        if (!statement) return null;
+
+        const firstLine = view.state.doc.lineAt(statement.from);
+        return line.from === firstLine.from
+          ? new SqlRunMarker(statement, onRun)
+          : null;
+      },
+      lineMarkerChange: (update) => update.docChanged || update.selectionSet,
+    }),
+    keymap.of([
+      {
+        key: 'Ctrl-Enter',
+        mac: 'Cmd-Enter',
+        run: (view) => {
+          const statement = resolveSqlStatementRange(view.state);
+          if (!statement) return false;
+          onRun(statement);
+          return true;
+        },
+      },
+    ]),
+    EditorView.baseTheme({
+      '.cm-sql-run-gutter': {
+        minWidth: '26px',
+      },
+      '.cm-sql-run-gutter .cm-gutterElement': {
+        boxSizing: 'border-box',
+        minWidth: '26px',
+        padding: '0 3px',
+      },
+      '.cm-sql-run-spacer': {
+        display: 'block',
+        width: '20px',
+        height: '20px',
+      },
+      '.cm-sql-run-button': {
+        display: 'inline-flex',
+        width: '20px',
+        height: '20px',
+        alignItems: 'center',
+        justifyContent: 'center',
+        margin: '0',
+        padding: '0',
+        border: '0',
+        borderRadius: '4px',
+        background: 'transparent',
+        color: 'rgba(22,24,35,0.58)',
+        cursor: 'pointer',
+      },
+      '.cm-sql-run-button:hover': {
+        backgroundColor: 'var(--yak-brand-color-soft)',
+        color: 'var(--yak-brand-color)',
+      },
+      '.cm-sql-run-button:focus-visible': {
+        outline: '2px solid var(--yak-brand-color-border)',
+        outlineOffset: '1px',
+      },
+      '.cm-sql-statement-line': {
+        boxShadow: 'inset 2px 0 0 var(--yak-brand-color)',
+        backgroundColor: 'var(--yak-brand-color-soft)',
+      },
+      '.cm-sql-statement-line.cm-activeLine': {
+        backgroundColor: 'var(--yak-brand-color-soft-hover)',
+      },
+    }),
+  ];
+};


### PR DESCRIPTION
## 变更说明

为 `/data-development/workbench` 的 SQL / Flink SQL 编辑器增加语句级运行能力。其它类型的代码编辑器与 Renderer 不受影响。

### 当前 SQL 范围

- 根据分号拆分 SQL 语句
- 光标位于某条 SQL 内时，自动识别并标记整条语句
- 存在文本选区时，以选区作为待运行 SQL
- 忽略单引号、双引号、反引号字符串中的分号
- 忽略 `--` 行注释和 `/* ... */` 块注释中的分号
- 跳过语句前方的空行与头部注释，使范围标记从真正的 SQL 开始

### 编辑器视觉与交互

- 当前 SQL 的全部行增加品牌色左侧范围线
- 当前 SQL 使用轻量品牌色背景区分
- 在当前 SQL 第一行的 gutter 中显示运行按钮
- 运行按钮提供 `运行当前 SQL（Ctrl+Enter）` 提示
- 支持键盘 `Ctrl+Enter`，macOS 下支持 `Cmd+Enter`
- 光标移动、选区变化和文档修改后实时重新计算范围

### 运行命令

- 新增 `sql.run-statement` Workbench Command
- 传递给命令的 `DevelopmentDocument` 只包含当前语句或当前选区，而不是整个 SQL 文件
- 继续复用现有资源级运行状态和运行消息机制，方便后续对接真正的 SQL 执行接口

### 实现范围

仅涉及：

- `renderers/sql/sqlStatementExtension.ts`
- `renderers/CodeResourceRenderer.tsx`
- `core/commands.ts`

## 验证建议

1. 打开 SQL 或 Flink SQL 节点
2. 在不同分号语句之间移动光标，确认范围线和背景随之变化
3. 点击左侧三角运行按钮
4. 使用 `Ctrl+Enter` 运行当前语句
5. 选择部分 SQL 后运行，确认以选区为准
6. 验证字符串中的分号不会错误拆分，例如 `SELECT 'a;b';`
7. 验证注释中的分号不会错误拆分
8. 打开 Shell 或 Python 节点，确认没有出现 SQL 范围线与运行 gutter

## 验证情况

- 分支基于合并 PR #190 后的最新 `main`
- 实现使用 CodeMirror 6 官方 gutter、GutterMarker、ViewPlugin 与 Decoration 扩展机制
- 当前连接环境无法安装仓库依赖并执行完整 `npm run tsc` / `npm run build`，因此 PR 保持 Draft 状态
