### PR TITLE
feat(data-development): add resizable execution result panel

### DIFF
--- a/docs/data-development/execution-bottom-panel.md
+++ b/docs/data-development/execution-bottom-panel.md
@@ -1,0 +1,152 @@
+# Yak Ops 数据开发运行结果面板
+
+本文档描述 `/data-development/workbench` 底部运行结果面板的前端架构。该面板参考 DataWorks Data Studio 的上下分区交互，但保持 Yak Ops Workbench Kernel 的插件化设计。
+
+## 1. 交互目标
+
+- 点击节点工具栏中的“运行”“测试请求”或“运行全部”后，底部面板自动展开。
+- 面板作为编辑区的下半部分参与布局，不使用浮层覆盖代码编辑器。
+- 用户可以拖动顶部横向分隔条调整面板高度，也可以展开、缩小、恢复默认高度或关闭面板。
+- 切换工作台标签时，底部面板显示当前资源自己的运行历史和最近一次运行结果。
+- 运行中默认进入“输出”页，运行完成后自动切换到“结果”页。
+
+## 2. 公共区域与节点差异
+
+所有节点共享以下能力：
+
+- 问题
+- 输出日志
+- 数据血缘占位
+- 运行结果
+- 发布状态
+- 深度检查
+- 质量测试占位
+- 执行 ID、开始时间、结束时间、耗时和运行状态
+- 当前节点运行历史
+
+“结果”页由节点类型决定渲染方式：
+
+| 节点类型 | Result Renderer |
+| --- | --- |
+| SQL / Flink SQL | 表格结果 |
+| HTTP | JSON 响应、状态码和响应头 |
+| Shell / Python | Terminal 输出和退出码 |
+| Notebook | Cell 执行结果 |
+| 数据集成 | 吞吐、行数和阶段状态 |
+| 资源文件及未知类型 | 文本兜底 |
+
+## 3. 目录结构
+
+```text
+workbench/
+├── execution/
+│   ├── bootstrap.ts
+│   ├── definitions.ts
+│   ├── mock-results.ts
+│   ├── registry.ts
+│   ├── types.ts
+│   ├── components/
+│   │   ├── ExecutionBottomPanel.tsx
+│   │   └── ExecutionPanelResizeHandle.tsx
+│   ├── renderers/
+│   │   ├── TableExecutionResultRenderer.tsx
+│   │   ├── JsonExecutionResultRenderer.tsx
+│   │   ├── TerminalExecutionResultRenderer.tsx
+│   │   ├── NotebookExecutionResultRenderer.tsx
+│   │   ├── PipelineExecutionResultRenderer.tsx
+│   │   └── TextExecutionResultRenderer.tsx
+│   └── store/
+│       └── execution-panel.store.ts
+```
+
+执行面板状态和工作台资源状态分开保存。编辑一个字符不会导致运行日志、历史结果和面板尺寸跟随文档 Store 高频更新。
+
+## 4. 执行会话模型
+
+```ts
+interface ExecutionSession {
+  id: string;
+  resourceId: string;
+  resourceType: string;
+  resourceName: string;
+  engine: string;
+  status: ExecutionStatus;
+  submittedAt: string;
+  startedAt: string;
+  finishedAt?: string;
+  durationMs?: number;
+  logs: ExecutionLogEntry[];
+  result?: ExecutionResultPayload;
+  errorMessage?: string;
+}
+```
+
+一次运行对应一个不可变的执行会话。后续接入后端时，前端应使用后端返回的 `executionId`，并通过 SSE 或 WebSocket 增量写入日志、状态和结果事件。
+
+## 5. Result Registry
+
+节点类型不直接出现在 `ExecutionBottomPanel` 的条件分支里，而是先解析结果定义：
+
+```ts
+executionResultDefinitionRegistry.register('HTTP', {
+  resourceType: 'HTTP',
+  rendererKey: 'json-result',
+});
+```
+
+再由 Renderer Registry 获取组件：
+
+```ts
+executionResultRendererRegistry.register(
+  'json-result',
+  JsonExecutionResultRenderer,
+);
+```
+
+新增节点结果类型时，只需要注册新的 definition 和 renderer，不需要修改底部面板外壳。
+
+## 6. 后端接入建议
+
+推荐运行接口：
+
+```http
+POST /api/data-development/resources/{resourceId}/executions
+```
+
+返回：
+
+```json
+{
+  "executionId": "RUN-20260804-0001",
+  "status": "QUEUED"
+}
+```
+
+事件流：
+
+```text
+execution.queued
+execution.running
+execution.log
+execution.progress
+execution.result
+execution.completed
+execution.failed
+```
+
+不同节点的 `execution.result` 可以拥有不同 payload，但必须包含：
+
+```json
+{
+  "schemaVersion": 1,
+  "resourceType": "HTTP",
+  "resultKind": "json",
+  "payload": {}
+}
+```
+
+前端根据 `resourceType` 和 Result Registry 选择 Renderer。后端保存原始执行快照，避免资源内容修改后无法还原当次运行现场。
+
+## 7. 当前范围
+
+本次先落地布局、拖拽、会话状态、公共标签页和各类 Mock Result Renderer。真实日志流、分页结果集、超大 JSON 虚拟滚动、结果导出、血缘图、发布流程和质量测试将在后续接口阶段继续完善。

--- a/docs/data-development/execution-bottom-panel.md
+++ b/docs/data-development/execution-bottom-panel.md
@@ -47,7 +47,11 @@ workbench/
 │   ├── types.ts
 │   ├── components/
 │   │   ├── ExecutionBottomPanel.tsx
-│   │   └── ExecutionPanelResizeHandle.tsx
+│   │   ├── ExecutionCommonPanels.tsx
+│   │   ├── ExecutionPanelHeader.tsx
+│   │   ├── ExecutionPanelResizeHandle.tsx
+│   │   ├── ExecutionPanelShared.tsx
+│   │   └── ExecutionSessionList.tsx
 │   ├── renderers/
 │   │   ├── TableExecutionResultRenderer.tsx
 │   │   ├── JsonExecutionResultRenderer.tsx
@@ -58,6 +62,8 @@ workbench/
 │   └── store/
 │       └── execution-panel.store.ts
 ```
+
+`ExecutionBottomPanel` 只负责组合布局和根据当前 Tab 分发内容。标签栏、运行历史、公共面板、状态摘要和拖拽分隔条分别维护，避免重新形成新的大型单文件组件。
 
 执行面板状态和工作台资源状态分开保存。编辑一个字符不会导致运行日志、历史结果和面板尺寸跟随文档 Store 高频更新。
 

--- a/yak-ops-ui/src/pages/data-development/workbench/WorkbenchPage.tsx
+++ b/yak-ops-ui/src/pages/data-development/workbench/WorkbenchPage.tsx
@@ -23,6 +23,7 @@ import StatusBar from './components/StatusBar';
 import WorkbenchResizeHandle from './components/WorkbenchResizeHandle';
 import WorkbenchToolbar from './components/WorkbenchToolbar';
 import type { ResourceType } from './core/types';
+import ExecutionBottomPanel from './execution/components/ExecutionBottomPanel';
 import { useWorkbenchStore } from './store/workbench.store';
 
 const EXPLORER_MIN_WIDTH = 300;
@@ -127,37 +128,41 @@ const WorkbenchPage = () => {
             <EditorTabs onCreate={openCreateModal} />
             <WorkbenchToolbar />
 
-            <div className="flex min-h-0 flex-1 overflow-hidden">
-              <section className="min-w-0 flex-1 overflow-hidden">
-                <ResourceView onCreate={() => openCreateModal('SQL')} />
-              </section>
-
-              {splitResource && !fullscreen && (
-                <section className="flex min-w-[360px] flex-1 flex-col border-l border-[#dfe2e6] bg-white">
-                  <div className="flex h-9 shrink-0 items-center justify-between border-b border-[#e7e9ec] bg-[#fafbfc] px-3">
-                    <button
-                      type="button"
-                      className="flex min-w-0 items-center gap-2 border-0 bg-transparent p-0 text-left text-[12px] text-[rgba(22,24,35,0.72)]"
-                      onClick={() => setActiveResource(splitResource.id)}
-                    >
-                      <Columns2 size={14} />
-                      <span className="truncate">{splitResource.name}</span>
-                    </button>
-                    <Tooltip title="关闭拆分编辑器">
-                      <Button
-                        type="text"
-                        size="small"
-                        className="!h-7 !w-7 !px-0"
-                        icon={<X size={14} />}
-                        onClick={() => setSplitResource(undefined)}
-                      />
-                    </Tooltip>
-                  </div>
-                  <div className="min-h-0 flex-1 overflow-hidden">
-                    <ResourceView resourceId={splitResource.id} />
-                  </div>
+            <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+              <div className="flex min-h-0 flex-1 overflow-hidden">
+                <section className="min-w-0 flex-1 overflow-hidden">
+                  <ResourceView onCreate={() => openCreateModal('SQL')} />
                 </section>
-              )}
+
+                {splitResource && !fullscreen && (
+                  <section className="flex min-w-[360px] flex-1 flex-col border-l border-[#dfe2e6] bg-white">
+                    <div className="flex h-9 shrink-0 items-center justify-between border-b border-[#e7e9ec] bg-[#fafbfc] px-3">
+                      <button
+                        type="button"
+                        className="flex min-w-0 items-center gap-2 border-0 bg-transparent p-0 text-left text-[12px] text-[rgba(22,24,35,0.72)]"
+                        onClick={() => setActiveResource(splitResource.id)}
+                      >
+                        <Columns2 size={14} />
+                        <span className="truncate">{splitResource.name}</span>
+                      </button>
+                      <Tooltip title="关闭拆分编辑器">
+                        <Button
+                          type="text"
+                          size="small"
+                          className="!h-7 !w-7 !px-0"
+                          icon={<X size={14} />}
+                          onClick={() => setSplitResource(undefined)}
+                        />
+                      </Tooltip>
+                    </div>
+                    <div className="min-h-0 flex-1 overflow-hidden">
+                      <ResourceView resourceId={splitResource.id} />
+                    </div>
+                  </section>
+                )}
+              </div>
+
+              <ExecutionBottomPanel />
             </div>
 
             <StatusBar />

--- a/yak-ops-ui/src/pages/data-development/workbench/core/bootstrap.ts
+++ b/yak-ops-ui/src/pages/data-development/workbench/core/bootstrap.ts
@@ -1,3 +1,9 @@
+import { registerExecutionPanelExtensions } from '../execution/bootstrap';
+import { BUILTIN_NODE_PLUGINS } from '../plugins';
+import CodeResourceRenderer from '../renderers/CodeResourceRenderer';
+import IntegrationRenderer from '../renderers/IntegrationRenderer';
+import NotebookRenderer from '../renderers/NotebookRenderer';
+import SchemaFormRenderer from '../renderers/SchemaFormRenderer';
 import { BUILTIN_ACTIONS } from './actions';
 import { BUILTIN_COMMANDS } from './commands';
 import {
@@ -6,11 +12,6 @@ import {
   nodePluginRegistry,
   rendererRegistry,
 } from './registry';
-import { BUILTIN_NODE_PLUGINS } from '../plugins';
-import CodeResourceRenderer from '../renderers/CodeResourceRenderer';
-import IntegrationRenderer from '../renderers/IntegrationRenderer';
-import NotebookRenderer from '../renderers/NotebookRenderer';
-import SchemaFormRenderer from '../renderers/SchemaFormRenderer';
 
 let registered = false;
 
@@ -34,4 +35,6 @@ export const registerWorkbenchExtensions = () => {
   BUILTIN_COMMANDS.forEach((command) =>
     commandRegistry.register(command.id, command),
   );
+
+  registerExecutionPanelExtensions();
 };

--- a/yak-ops-ui/src/pages/data-development/workbench/core/commands.ts
+++ b/yak-ops-ui/src/pages/data-development/workbench/core/commands.ts
@@ -1,4 +1,5 @@
 import { message } from 'antd';
+import { useExecutionPanelStore } from '../execution/store/execution-panel.store';
 import { useWorkbenchStore } from '../store/workbench.store';
 import type {
   DevelopmentDocument,
@@ -21,19 +22,31 @@ const runResource = (
   context: WorkbenchActionContext,
   successText: string,
 ) => {
-  const store = useWorkbenchStore.getState();
+  const workbenchStore = useWorkbenchStore.getState();
+  const executionPanelStore = useExecutionPanelStore.getState();
   const resourceId = context.resource.id;
+  const executionId = executionPanelStore.startExecution(
+    context.resource,
+    context.plugin,
+  );
 
-  store.setExecutionStatus(resourceId, 'RUNNING');
+  workbenchStore.setExecutionStatus(resourceId, 'RUNNING');
   message.loading({
     content: `${successText}：${context.resource.name}`,
     key: `run-${resourceId}`,
   });
 
   window.setTimeout(() => {
+    const currentSession =
+      useExecutionPanelStore.getState().sessionsById[executionId];
+    if (!currentSession || currentSession.status !== 'RUNNING') return;
+
     useWorkbenchStore.getState().setExecutionStatus(resourceId, 'SUCCESS');
+    useExecutionPanelStore
+      .getState()
+      .completeExecution(executionId, context.resource);
     message.success({
-      content: '运行请求已提交，结果将进入底部运行面板',
+      content: '运行完成，结果已进入底部运行面板',
       key: `run-${resourceId}`,
     });
   }, 1100);
@@ -60,6 +73,7 @@ export const BUILTIN_COMMANDS: WorkbenchCommandDefinition[] = [
     id: 'execution.stop',
     execute: ({ resource }) => {
       useWorkbenchStore.getState().setExecutionStatus(resource.id, 'STOPPED');
+      useExecutionPanelStore.getState().stopExecution(resource.id);
       message.success('停止请求已提交');
     },
   },
@@ -114,7 +128,10 @@ export const BUILTIN_COMMANDS: WorkbenchCommandDefinition[] = [
   },
   {
     id: 'document.validate',
-    execute: ({ plugin }) => {
+    execute: ({ resource, plugin }) => {
+      useExecutionPanelStore
+        .getState()
+        .openForResource(resource.id, 'validation');
       message.success(`${plugin.metadata.label} 语法、依赖与运行参数检查通过`);
     },
   },
@@ -126,6 +143,7 @@ export const BUILTIN_COMMANDS: WorkbenchCommandDefinition[] = [
         status: 'PUBLISHED',
         publishedVersion: (resource.publishedVersion ?? 0) + 1,
       });
+      useExecutionPanelStore.getState().openForResource(resource.id, 'publish');
       message.success('已创建不可变发布版本');
     },
   },
@@ -183,8 +201,9 @@ export const BUILTIN_COMMANDS: WorkbenchCommandDefinition[] = [
   },
   {
     id: 'http.show-response',
-    execute: () => {
-      message.info('最近一次响应：200 OK · 1.2 KB · 286 ms');
+    execute: ({ resource }) => {
+      useExecutionPanelStore.getState().openForResource(resource.id, 'result');
+      message.info('已打开最近一次 HTTP 响应');
     },
   },
 ];

--- a/yak-ops-ui/src/pages/data-development/workbench/execution/bootstrap.ts
+++ b/yak-ops-ui/src/pages/data-development/workbench/execution/bootstrap.ts
@@ -1,0 +1,50 @@
+import { BUILTIN_EXECUTION_RESULT_DEFINITIONS } from './definitions';
+import {
+  executionResultDefinitionRegistry,
+  executionResultRendererRegistry,
+} from './registry';
+import JsonExecutionResultRenderer from './renderers/JsonExecutionResultRenderer';
+import NotebookExecutionResultRenderer from './renderers/NotebookExecutionResultRenderer';
+import PipelineExecutionResultRenderer from './renderers/PipelineExecutionResultRenderer';
+import TableExecutionResultRenderer from './renderers/TableExecutionResultRenderer';
+import TerminalExecutionResultRenderer from './renderers/TerminalExecutionResultRenderer';
+import TextExecutionResultRenderer from './renderers/TextExecutionResultRenderer';
+
+let registered = false;
+
+export const registerExecutionPanelExtensions = () => {
+  if (registered) return;
+  registered = true;
+
+  BUILTIN_EXECUTION_RESULT_DEFINITIONS.forEach((definition) =>
+    executionResultDefinitionRegistry.register(
+      definition.resourceType,
+      definition,
+    ),
+  );
+
+  executionResultRendererRegistry.register(
+    'table-result',
+    TableExecutionResultRenderer,
+  );
+  executionResultRendererRegistry.register(
+    'json-result',
+    JsonExecutionResultRenderer,
+  );
+  executionResultRendererRegistry.register(
+    'terminal-result',
+    TerminalExecutionResultRenderer,
+  );
+  executionResultRendererRegistry.register(
+    'notebook-result',
+    NotebookExecutionResultRenderer,
+  );
+  executionResultRendererRegistry.register(
+    'pipeline-result',
+    PipelineExecutionResultRenderer,
+  );
+  executionResultRendererRegistry.register(
+    'text-result',
+    TextExecutionResultRenderer,
+  );
+};

--- a/yak-ops-ui/src/pages/data-development/workbench/execution/components/ExecutionBottomPanel.tsx
+++ b/yak-ops-ui/src/pages/data-development/workbench/execution/components/ExecutionBottomPanel.tsx
@@ -1,0 +1,542 @@
+import { Button, Empty, Tag, Tooltip } from 'antd';
+import {
+  AlertCircle,
+  CheckCircle2,
+  ChevronDown,
+  ChevronUp,
+  CircleDot,
+  GitBranch,
+  History,
+  ListChecks,
+  LoaderCircle,
+  Maximize2,
+  Minimize2,
+  PackageCheck,
+  PanelBottomClose,
+  ScrollText,
+  ShieldCheck,
+  Sparkles,
+  X,
+} from 'lucide-react';
+import { useMemo } from 'react';
+import { nodePluginRegistry } from '../../core/registry';
+import {
+  selectActiveResource,
+  useWorkbenchStore,
+} from '../../store/workbench.store';
+import {
+  executionResultDefinitionRegistry,
+  executionResultRendererRegistry,
+} from '../registry';
+import {
+  EXECUTION_PANEL_DEFAULT_HEIGHT,
+  EXECUTION_PANEL_MAX_HEIGHT,
+  EXECUTION_PANEL_MIN_HEIGHT,
+  useExecutionPanelStore,
+} from '../store/execution-panel.store';
+import type {
+  ExecutionPanelTabKey,
+  ExecutionSession,
+} from '../types';
+import ExecutionPanelResizeHandle from './ExecutionPanelResizeHandle';
+
+const PANEL_TABS: Array<{
+  key: ExecutionPanelTabKey;
+  label: string;
+  icon: typeof AlertCircle;
+}> = [
+  { key: 'problems', label: '问题', icon: AlertCircle },
+  { key: 'output', label: '输出', icon: ScrollText },
+  { key: 'lineage', label: '血缘', icon: GitBranch },
+  { key: 'result', label: '结果', icon: ListChecks },
+  { key: 'publish', label: '发布', icon: PackageCheck },
+  { key: 'validation', label: '深度检查', icon: ShieldCheck },
+  { key: 'quality', label: '质量测试', icon: Sparkles },
+];
+
+const formatDateTime = (value?: string) => {
+  if (!value) return '-';
+  return new Intl.DateTimeFormat('zh-CN', {
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  }).format(new Date(value));
+};
+
+const formatDuration = (durationMs?: number) => {
+  if (durationMs === undefined) return '-';
+  if (durationMs < 1000) return `${durationMs} ms`;
+  return `${(durationMs / 1000).toFixed(2)} s`;
+};
+
+const ExecutionStatusTag = ({ session }: { session: ExecutionSession }) => {
+  const running = session.status === 'RUNNING';
+  const success = session.status === 'SUCCESS';
+  const stopped = session.status === 'STOPPED';
+
+  return (
+    <Tag
+      bordered={false}
+      icon={
+        running ? (
+          <LoaderCircle size={12} className="animate-spin" />
+        ) : success ? (
+          <CheckCircle2 size={12} />
+        ) : stopped ? (
+          <PanelBottomClose size={12} />
+        ) : (
+          <AlertCircle size={12} />
+        )
+      }
+      color={
+        running ? 'processing' : success ? 'success' : stopped ? 'default' : 'error'
+      }
+      className="!m-0"
+    >
+      {running
+        ? '运行中'
+        : success
+          ? '运行成功'
+          : stopped
+            ? '已停止'
+            : '运行失败'}
+    </Tag>
+  );
+};
+
+const SessionSummary = ({ session }: { session: ExecutionSession }) => (
+  <div className="grid shrink-0 grid-cols-[auto_repeat(4,minmax(120px,1fr))] items-center gap-4 border-b border-[#eceef0] bg-[#fafbfc] px-3 py-2 text-[11px]">
+    <ExecutionStatusTag session={session} />
+    <div>
+      <div className="text-[rgba(22,24,35,0.38)]">执行 ID</div>
+      <div className="mt-0.5 truncate font-mono text-[rgba(22,24,35,0.7)]">
+        {session.id}
+      </div>
+    </div>
+    <div>
+      <div className="text-[rgba(22,24,35,0.38)]">开始时间</div>
+      <div className="mt-0.5 text-[rgba(22,24,35,0.7)]">
+        {formatDateTime(session.startedAt)}
+      </div>
+    </div>
+    <div>
+      <div className="text-[rgba(22,24,35,0.38)]">结束时间</div>
+      <div className="mt-0.5 text-[rgba(22,24,35,0.7)]">
+        {formatDateTime(session.finishedAt)}
+      </div>
+    </div>
+    <div>
+      <div className="text-[rgba(22,24,35,0.38)]">运行耗时</div>
+      <div className="mt-0.5 text-[rgba(22,24,35,0.7)]">
+        {formatDuration(session.durationMs)}
+      </div>
+    </div>
+  </div>
+);
+
+const EmptyPanel = ({ description }: { description: string }) => (
+  <div className="flex h-full items-center justify-center bg-white">
+    <Empty
+      image={Empty.PRESENTED_IMAGE_SIMPLE}
+      description={
+        <span className="text-[12px] text-[rgba(22,24,35,0.42)]">
+          {description}
+        </span>
+      }
+    />
+  </div>
+);
+
+const OutputPanel = ({ session }: { session?: ExecutionSession }) => {
+  if (!session) return <EmptyPanel description="运行节点后可查看实时输出" />;
+
+  return (
+    <div className="h-full min-h-0 overflow-auto bg-[#111418] p-3 font-mono text-[12px] leading-6 text-[#d7dce2]">
+      {session.logs.map((log) => (
+        <div key={log.id} className="grid grid-cols-[72px_52px_1fr] gap-2">
+          <span className="text-white/35">{log.timestamp}</span>
+          <span
+            className={
+              log.level === 'ERROR'
+                ? 'text-[#ff8c8c]'
+                : log.level === 'WARN'
+                  ? 'text-[#f0b45a]'
+                  : 'text-[#7db4ff]'
+            }
+          >
+            {log.level}
+          </span>
+          <span className="whitespace-pre-wrap">{log.message}</span>
+        </div>
+      ))}
+      {session.status === 'RUNNING' && (
+        <div className="mt-1 flex items-center gap-2 text-white/55">
+          <LoaderCircle size={12} className="animate-spin" />
+          waiting for execution events...
+        </div>
+      )}
+    </div>
+  );
+};
+
+const ProblemsPanel = ({ session }: { session?: ExecutionSession }) => {
+  if (!session || session.status !== 'FAILED') {
+    return <EmptyPanel description="当前节点没有发现问题" />;
+  }
+
+  return (
+    <div className="p-3">
+      <div className="flex items-start gap-3 border border-[#f5c2c0] bg-[#fff7f6] p-3">
+        <AlertCircle size={16} className="mt-0.5 text-[#d92d20]" />
+        <div>
+          <div className="text-[12px] font-medium text-[#b42318]">运行失败</div>
+          <div className="mt-1 text-[11px] leading-5 text-[#7a271a]">
+            {session.errorMessage ?? '请查看输出日志定位失败原因。'}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const LineagePanel = ({ resourceName }: { resourceName: string }) => (
+  <div className="flex h-full items-center justify-center bg-[#fafbfc] p-6">
+    <div className="flex items-center gap-6">
+      {['上游数据源', resourceName, '下游数据表'].map((label, index) => (
+        <div key={label} className="flex items-center gap-6">
+          <div className="min-w-[150px] border border-[#dfe2e6] bg-white px-4 py-3 text-center shadow-sm">
+            <CircleDot
+              size={15}
+              className="mx-auto text-[var(--yak-brand-color)]"
+            />
+            <div className="mt-2 truncate text-[12px] font-medium text-[#161823]">
+              {label}
+            </div>
+          </div>
+          {index < 2 && (
+            <span className="h-px w-16 bg-[#cfd3d8] after:float-right after:-mt-[3px] after:block after:h-2 after:w-2 after:rotate-45 after:border-r after:border-t after:border-[#cfd3d8]" />
+          )}
+        </div>
+      ))}
+    </div>
+  </div>
+);
+
+const PublishPanel = ({ published }: { published: boolean }) => (
+  <div className="h-full overflow-auto p-4">
+    <div className="mx-auto max-w-[920px]">
+      <div className="flex items-center justify-between border-b border-[#eceef0] pb-3">
+        <div>
+          <h3 className="m-0 text-[14px] font-semibold text-[#161823]">
+            上线发布内容
+          </h3>
+          <p className="mb-0 mt-1 text-[11px] text-[rgba(22,24,35,0.44)]">
+            运行结果确认后，可创建不可变发布版本并进入生产检查流程。
+          </p>
+        </div>
+        <Tag bordered={false} color={published ? 'success' : 'default'}>
+          {published ? '已有发布版本' : '未发布'}
+        </Tag>
+      </div>
+      <div className="mt-4 grid grid-cols-3 gap-4">
+        {['发布包构建', '生产检查器', '发布到生产环境'].map((label, index) => (
+          <div key={label} className="border border-[#e5e7ea] bg-[#fafbfc] p-3">
+            <span className="flex h-5 w-5 items-center justify-center rounded-full border border-[#d6d9dd] text-[10px] text-[rgba(22,24,35,0.52)]">
+              {index + 1}
+            </span>
+            <div className="mt-2 text-[12px] font-medium text-[#161823]">
+              {label}
+            </div>
+            <div className="mt-1 text-[11px] text-[rgba(22,24,35,0.4)]">
+              {published ? '等待下一次发布' : '未开始'}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  </div>
+);
+
+const ValidationPanel = ({ session }: { session?: ExecutionSession }) => (
+  <div className="h-full overflow-auto p-4">
+    <div className="space-y-2">
+      {[
+        ['语法检查', '通过'],
+        ['依赖资源检查', '通过'],
+        ['运行参数检查', '通过'],
+        ['数据源连通性', session ? '通过' : '等待运行'],
+      ].map(([label, value]) => (
+        <div
+          key={label}
+          className="flex items-center justify-between border-b border-[#eceef0] px-2 py-2.5"
+        >
+          <span className="text-[12px] text-[rgba(22,24,35,0.7)]">
+            {label}
+          </span>
+          <span className="flex items-center gap-1.5 text-[11px] text-[#14945f]">
+            <CheckCircle2 size={13} /> {value}
+          </span>
+        </div>
+      ))}
+    </div>
+  </div>
+);
+
+const QualityPanel = () => (
+  <EmptyPanel description="质量测试框架已预留，后续可接入规则模板和测试报告" />
+);
+
+const ExecutionBottomPanel = () => {
+  const resource = useWorkbenchStore(selectActiveResource);
+  const resourcesById = useWorkbenchStore((state) => state.resourcesById);
+  const visible = useExecutionPanelStore((state) => state.visible);
+  const height = useExecutionPanelStore((state) => state.height);
+  const maximized = useExecutionPanelStore((state) => state.maximized);
+  const activeTab = useExecutionPanelStore((state) => state.activeTab);
+  const sessionsById = useExecutionPanelStore((state) => state.sessionsById);
+  const sessionIdsByResourceId = useExecutionPanelStore(
+    (state) => state.sessionIdsByResourceId,
+  );
+  const activeSessionIdByResourceId = useExecutionPanelStore(
+    (state) => state.activeSessionIdByResourceId,
+  );
+  const setVisible = useExecutionPanelStore((state) => state.setVisible);
+  const setHeight = useExecutionPanelStore((state) => state.setHeight);
+  const setMaximized = useExecutionPanelStore((state) => state.setMaximized);
+  const setActiveTab = useExecutionPanelStore((state) => state.setActiveTab);
+  const selectSession = useExecutionPanelStore((state) => state.selectSession);
+
+  const sessionIds = resource
+    ? sessionIdsByResourceId[resource.id] ?? []
+    : [];
+  const activeSessionId = resource
+    ? activeSessionIdByResourceId[resource.id]
+    : undefined;
+  const activeSession = activeSessionId
+    ? sessionsById[activeSessionId]
+    : undefined;
+  const plugin = resource
+    ? nodePluginRegistry.get(resource.resourceType)
+    : undefined;
+
+  const ResultRenderer = useMemo(() => {
+    if (!resource) return undefined;
+    const definition =
+      executionResultDefinitionRegistry.get(resource.resourceType) ??
+      executionResultDefinitionRegistry.get('RESOURCE');
+    return definition
+      ? executionResultRendererRegistry.get(definition.rendererKey)
+      : undefined;
+  }, [resource]);
+
+  if (!visible) return null;
+
+  const renderPanelContent = () => {
+    if (!resource) return <EmptyPanel description="请先打开一个开发节点" />;
+
+    if (activeTab === 'problems') {
+      return <ProblemsPanel session={activeSession} />;
+    }
+    if (activeTab === 'output') {
+      return <OutputPanel session={activeSession} />;
+    }
+    if (activeTab === 'lineage') {
+      return <LineagePanel resourceName={resource.name} />;
+    }
+    if (activeTab === 'publish') {
+      return <PublishPanel published={resource.status === 'PUBLISHED'} />;
+    }
+    if (activeTab === 'validation') {
+      return <ValidationPanel session={activeSession} />;
+    }
+    if (activeTab === 'quality') {
+      return <QualityPanel />;
+    }
+
+    if (!activeSession) {
+      return <EmptyPanel description="点击运行后将在这里展示节点运行结果" />;
+    }
+    if (activeSession.status === 'RUNNING') {
+      return <OutputPanel session={activeSession} />;
+    }
+    if (!activeSession.result || !ResultRenderer || !plugin) {
+      return <EmptyPanel description="当前执行暂无可展示结果" />;
+    }
+
+    return (
+      <ResultRenderer
+        resource={resource}
+        plugin={plugin}
+        session={activeSession}
+        payload={activeSession.result}
+      />
+    );
+  };
+
+  return (
+    <section
+      style={{ height }}
+      className="relative flex min-h-0 shrink-0 flex-col border-t border-[#dfe2e6] bg-white shadow-[0_-8px_24px_rgba(16,24,40,0.03)]"
+    >
+      <ExecutionPanelResizeHandle
+        value={height}
+        min={EXECUTION_PANEL_MIN_HEIGHT}
+        max={EXECUTION_PANEL_MAX_HEIGHT}
+        defaultValue={EXECUTION_PANEL_DEFAULT_HEIGHT}
+        onChange={setHeight}
+      />
+
+      <header className="flex h-10 shrink-0 items-center justify-between border-b border-[#eceef0] px-2">
+        <div className="flex min-w-0 items-center gap-0.5 overflow-x-auto">
+          {PANEL_TABS.map((tab) => {
+            const Icon = tab.icon;
+            const active = activeTab === tab.key;
+            const badge =
+              tab.key === 'problems' && activeSession?.status === 'FAILED'
+                ? 1
+                : undefined;
+
+            return (
+              <button
+                key={tab.key}
+                type="button"
+                onClick={() => setActiveTab(tab.key)}
+                className={[
+                  'relative flex h-10 shrink-0 items-center gap-1.5 border-0 bg-transparent px-3 text-[11px] transition-colors',
+                  active
+                    ? 'font-medium text-[#161823]'
+                    : 'text-[rgba(22,24,35,0.5)] hover:text-[#161823]',
+                ].join(' ')}
+              >
+                <Icon size={13} />
+                {tab.label}
+                {badge && (
+                  <span className="flex h-4 min-w-4 items-center justify-center rounded-full bg-[var(--yak-brand-color)] px-1 text-[9px] text-white">
+                    {badge}
+                  </span>
+                )}
+                {active && (
+                  <span className="absolute inset-x-2 bottom-0 h-0.5 bg-[var(--yak-brand-color)]" />
+                )}
+              </button>
+            );
+          })}
+        </div>
+
+        <div className="flex shrink-0 items-center gap-0.5 border-l border-[#eceef0] pl-2">
+          <Tooltip title={maximized ? '还原面板' : '展开面板'}>
+            <Button
+              type="text"
+              size="small"
+              className="!h-7 !w-7 !px-0"
+              icon={
+                maximized ? <Minimize2 size={14} /> : <Maximize2 size={14} />
+              }
+              onClick={() => setMaximized(!maximized)}
+            />
+          </Tooltip>
+          <Tooltip title="缩小面板">
+            <Button
+              type="text"
+              size="small"
+              className="!h-7 !w-7 !px-0"
+              icon={<ChevronDown size={14} />}
+              onClick={() => setHeight(EXECUTION_PANEL_MIN_HEIGHT)}
+            />
+          </Tooltip>
+          <Tooltip title="恢复默认高度">
+            <Button
+              type="text"
+              size="small"
+              className="!h-7 !w-7 !px-0"
+              icon={<ChevronUp size={14} />}
+              onClick={() => setHeight(EXECUTION_PANEL_DEFAULT_HEIGHT)}
+            />
+          </Tooltip>
+          <Tooltip title="关闭运行面板">
+            <Button
+              type="text"
+              size="small"
+              className="!h-7 !w-7 !px-0"
+              icon={<X size={14} />}
+              onClick={() => setVisible(false)}
+            />
+          </Tooltip>
+        </div>
+      </header>
+
+      <div className="flex min-h-0 flex-1 overflow-hidden">
+        <aside className="w-[220px] shrink-0 overflow-y-auto border-r border-[#eceef0] bg-[#fafbfc]">
+          <div className="flex h-9 items-center gap-2 border-b border-[#eceef0] px-3 text-[11px] font-medium text-[rgba(22,24,35,0.62)]">
+            <History size={13} />
+            运行记录
+          </div>
+
+          {sessionIds.length === 0 ? (
+            <div className="px-3 py-5 text-center text-[11px] leading-5 text-[rgba(22,24,35,0.36)]">
+              当前节点暂无运行记录
+            </div>
+          ) : (
+            <div className="py-1">
+              {sessionIds.map((sessionId, index) => {
+                const session = sessionsById[sessionId];
+                if (!session) return null;
+                const active = sessionId === activeSessionId;
+
+                return (
+                  <button
+                    key={sessionId}
+                    type="button"
+                    onClick={() =>
+                      resource && selectSession(resource.id, sessionId)
+                    }
+                    className={[
+                      'flex w-full items-start gap-2 border-0 px-3 py-2 text-left transition-colors',
+                      active
+                        ? 'bg-[var(--yak-brand-color-soft)]'
+                        : 'bg-transparent hover:bg-[#f1f2f4]',
+                    ].join(' ')}
+                  >
+                    <span className="mt-0.5">
+                      {session.status === 'RUNNING' ? (
+                        <LoaderCircle
+                          size={13}
+                          className="animate-spin text-[#1677ff]"
+                        />
+                      ) : session.status === 'SUCCESS' ? (
+                        <CheckCircle2 size={13} className="text-[#14945f]" />
+                      ) : (
+                        <AlertCircle size={13} className="text-[#d92d20]" />
+                      )}
+                    </span>
+                    <span className="min-w-0 flex-1">
+                      <span className="block truncate text-[11px] font-medium text-[rgba(22,24,35,0.72)]">
+                        {resource?.name ?? resourcesById[session.resourceId]?.name}
+                        {index === 0 ? ' · 最新' : ''}
+                      </span>
+                      <span className="mt-0.5 block text-[10px] text-[rgba(22,24,35,0.36)]">
+                        {formatDateTime(session.startedAt)} · {session.engine}
+                      </span>
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+          )}
+        </aside>
+
+        <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
+          {activeSession && <SessionSummary session={activeSession} />}
+          <div className="min-h-0 flex-1 overflow-hidden">
+            {renderPanelContent()}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default ExecutionBottomPanel;

--- a/yak-ops-ui/src/pages/data-development/workbench/execution/components/ExecutionBottomPanel.tsx
+++ b/yak-ops-ui/src/pages/data-development/workbench/execution/components/ExecutionBottomPanel.tsx
@@ -1,23 +1,3 @@
-import { Button, Empty, Tag, Tooltip } from 'antd';
-import {
-  AlertCircle,
-  CheckCircle2,
-  ChevronDown,
-  ChevronUp,
-  CircleDot,
-  GitBranch,
-  History,
-  ListChecks,
-  LoaderCircle,
-  Maximize2,
-  Minimize2,
-  PackageCheck,
-  PanelBottomClose,
-  ScrollText,
-  ShieldCheck,
-  Sparkles,
-  X,
-} from 'lucide-react';
 import { useMemo } from 'react';
 import { nodePluginRegistry } from '../../core/registry';
 import {
@@ -34,260 +14,21 @@ import {
   EXECUTION_PANEL_MIN_HEIGHT,
   useExecutionPanelStore,
 } from '../store/execution-panel.store';
-import type {
-  ExecutionPanelTabKey,
-  ExecutionSession,
-} from '../types';
+import {
+  ExecutionLineagePanel,
+  ExecutionOutputPanel,
+  ExecutionProblemsPanel,
+  ExecutionPublishPanel,
+  ExecutionQualityPanel,
+  ExecutionValidationPanel,
+} from './ExecutionCommonPanels';
+import ExecutionPanelHeader from './ExecutionPanelHeader';
 import ExecutionPanelResizeHandle from './ExecutionPanelResizeHandle';
-
-const PANEL_TABS: Array<{
-  key: ExecutionPanelTabKey;
-  label: string;
-  icon: typeof AlertCircle;
-}> = [
-  { key: 'problems', label: '问题', icon: AlertCircle },
-  { key: 'output', label: '输出', icon: ScrollText },
-  { key: 'lineage', label: '血缘', icon: GitBranch },
-  { key: 'result', label: '结果', icon: ListChecks },
-  { key: 'publish', label: '发布', icon: PackageCheck },
-  { key: 'validation', label: '深度检查', icon: ShieldCheck },
-  { key: 'quality', label: '质量测试', icon: Sparkles },
-];
-
-const formatDateTime = (value?: string) => {
-  if (!value) return '-';
-  return new Intl.DateTimeFormat('zh-CN', {
-    month: '2-digit',
-    day: '2-digit',
-    hour: '2-digit',
-    minute: '2-digit',
-    second: '2-digit',
-    hour12: false,
-  }).format(new Date(value));
-};
-
-const formatDuration = (durationMs?: number) => {
-  if (durationMs === undefined) return '-';
-  if (durationMs < 1000) return `${durationMs} ms`;
-  return `${(durationMs / 1000).toFixed(2)} s`;
-};
-
-const ExecutionStatusTag = ({ session }: { session: ExecutionSession }) => {
-  const running = session.status === 'RUNNING';
-  const success = session.status === 'SUCCESS';
-  const stopped = session.status === 'STOPPED';
-
-  return (
-    <Tag
-      bordered={false}
-      icon={
-        running ? (
-          <LoaderCircle size={12} className="animate-spin" />
-        ) : success ? (
-          <CheckCircle2 size={12} />
-        ) : stopped ? (
-          <PanelBottomClose size={12} />
-        ) : (
-          <AlertCircle size={12} />
-        )
-      }
-      color={
-        running ? 'processing' : success ? 'success' : stopped ? 'default' : 'error'
-      }
-      className="!m-0"
-    >
-      {running
-        ? '运行中'
-        : success
-          ? '运行成功'
-          : stopped
-            ? '已停止'
-            : '运行失败'}
-    </Tag>
-  );
-};
-
-const SessionSummary = ({ session }: { session: ExecutionSession }) => (
-  <div className="grid shrink-0 grid-cols-[auto_repeat(4,minmax(120px,1fr))] items-center gap-4 border-b border-[#eceef0] bg-[#fafbfc] px-3 py-2 text-[11px]">
-    <ExecutionStatusTag session={session} />
-    <div>
-      <div className="text-[rgba(22,24,35,0.38)]">执行 ID</div>
-      <div className="mt-0.5 truncate font-mono text-[rgba(22,24,35,0.7)]">
-        {session.id}
-      </div>
-    </div>
-    <div>
-      <div className="text-[rgba(22,24,35,0.38)]">开始时间</div>
-      <div className="mt-0.5 text-[rgba(22,24,35,0.7)]">
-        {formatDateTime(session.startedAt)}
-      </div>
-    </div>
-    <div>
-      <div className="text-[rgba(22,24,35,0.38)]">结束时间</div>
-      <div className="mt-0.5 text-[rgba(22,24,35,0.7)]">
-        {formatDateTime(session.finishedAt)}
-      </div>
-    </div>
-    <div>
-      <div className="text-[rgba(22,24,35,0.38)]">运行耗时</div>
-      <div className="mt-0.5 text-[rgba(22,24,35,0.7)]">
-        {formatDuration(session.durationMs)}
-      </div>
-    </div>
-  </div>
-);
-
-const EmptyPanel = ({ description }: { description: string }) => (
-  <div className="flex h-full items-center justify-center bg-white">
-    <Empty
-      image={Empty.PRESENTED_IMAGE_SIMPLE}
-      description={
-        <span className="text-[12px] text-[rgba(22,24,35,0.42)]">
-          {description}
-        </span>
-      }
-    />
-  </div>
-);
-
-const OutputPanel = ({ session }: { session?: ExecutionSession }) => {
-  if (!session) return <EmptyPanel description="运行节点后可查看实时输出" />;
-
-  return (
-    <div className="h-full min-h-0 overflow-auto bg-[#111418] p-3 font-mono text-[12px] leading-6 text-[#d7dce2]">
-      {session.logs.map((log) => (
-        <div key={log.id} className="grid grid-cols-[72px_52px_1fr] gap-2">
-          <span className="text-white/35">{log.timestamp}</span>
-          <span
-            className={
-              log.level === 'ERROR'
-                ? 'text-[#ff8c8c]'
-                : log.level === 'WARN'
-                  ? 'text-[#f0b45a]'
-                  : 'text-[#7db4ff]'
-            }
-          >
-            {log.level}
-          </span>
-          <span className="whitespace-pre-wrap">{log.message}</span>
-        </div>
-      ))}
-      {session.status === 'RUNNING' && (
-        <div className="mt-1 flex items-center gap-2 text-white/55">
-          <LoaderCircle size={12} className="animate-spin" />
-          waiting for execution events...
-        </div>
-      )}
-    </div>
-  );
-};
-
-const ProblemsPanel = ({ session }: { session?: ExecutionSession }) => {
-  if (!session || session.status !== 'FAILED') {
-    return <EmptyPanel description="当前节点没有发现问题" />;
-  }
-
-  return (
-    <div className="p-3">
-      <div className="flex items-start gap-3 border border-[#f5c2c0] bg-[#fff7f6] p-3">
-        <AlertCircle size={16} className="mt-0.5 text-[#d92d20]" />
-        <div>
-          <div className="text-[12px] font-medium text-[#b42318]">运行失败</div>
-          <div className="mt-1 text-[11px] leading-5 text-[#7a271a]">
-            {session.errorMessage ?? '请查看输出日志定位失败原因。'}
-          </div>
-        </div>
-      </div>
-    </div>
-  );
-};
-
-const LineagePanel = ({ resourceName }: { resourceName: string }) => (
-  <div className="flex h-full items-center justify-center bg-[#fafbfc] p-6">
-    <div className="flex items-center gap-6">
-      {['上游数据源', resourceName, '下游数据表'].map((label, index) => (
-        <div key={label} className="flex items-center gap-6">
-          <div className="min-w-[150px] border border-[#dfe2e6] bg-white px-4 py-3 text-center shadow-sm">
-            <CircleDot
-              size={15}
-              className="mx-auto text-[var(--yak-brand-color)]"
-            />
-            <div className="mt-2 truncate text-[12px] font-medium text-[#161823]">
-              {label}
-            </div>
-          </div>
-          {index < 2 && (
-            <span className="h-px w-16 bg-[#cfd3d8] after:float-right after:-mt-[3px] after:block after:h-2 after:w-2 after:rotate-45 after:border-r after:border-t after:border-[#cfd3d8]" />
-          )}
-        </div>
-      ))}
-    </div>
-  </div>
-);
-
-const PublishPanel = ({ published }: { published: boolean }) => (
-  <div className="h-full overflow-auto p-4">
-    <div className="mx-auto max-w-[920px]">
-      <div className="flex items-center justify-between border-b border-[#eceef0] pb-3">
-        <div>
-          <h3 className="m-0 text-[14px] font-semibold text-[#161823]">
-            上线发布内容
-          </h3>
-          <p className="mb-0 mt-1 text-[11px] text-[rgba(22,24,35,0.44)]">
-            运行结果确认后，可创建不可变发布版本并进入生产检查流程。
-          </p>
-        </div>
-        <Tag bordered={false} color={published ? 'success' : 'default'}>
-          {published ? '已有发布版本' : '未发布'}
-        </Tag>
-      </div>
-      <div className="mt-4 grid grid-cols-3 gap-4">
-        {['发布包构建', '生产检查器', '发布到生产环境'].map((label, index) => (
-          <div key={label} className="border border-[#e5e7ea] bg-[#fafbfc] p-3">
-            <span className="flex h-5 w-5 items-center justify-center rounded-full border border-[#d6d9dd] text-[10px] text-[rgba(22,24,35,0.52)]">
-              {index + 1}
-            </span>
-            <div className="mt-2 text-[12px] font-medium text-[#161823]">
-              {label}
-            </div>
-            <div className="mt-1 text-[11px] text-[rgba(22,24,35,0.4)]">
-              {published ? '等待下一次发布' : '未开始'}
-            </div>
-          </div>
-        ))}
-      </div>
-    </div>
-  </div>
-);
-
-const ValidationPanel = ({ session }: { session?: ExecutionSession }) => (
-  <div className="h-full overflow-auto p-4">
-    <div className="space-y-2">
-      {[
-        ['语法检查', '通过'],
-        ['依赖资源检查', '通过'],
-        ['运行参数检查', '通过'],
-        ['数据源连通性', session ? '通过' : '等待运行'],
-      ].map(([label, value]) => (
-        <div
-          key={label}
-          className="flex items-center justify-between border-b border-[#eceef0] px-2 py-2.5"
-        >
-          <span className="text-[12px] text-[rgba(22,24,35,0.7)]">
-            {label}
-          </span>
-          <span className="flex items-center gap-1.5 text-[11px] text-[#14945f]">
-            <CheckCircle2 size={13} /> {value}
-          </span>
-        </div>
-      ))}
-    </div>
-  </div>
-);
-
-const QualityPanel = () => (
-  <EmptyPanel description="质量测试框架已预留，后续可接入规则模板和测试报告" />
-);
+import {
+  ExecutionEmptyPanel,
+  ExecutionSessionSummary,
+} from './ExecutionPanelShared';
+import ExecutionSessionList from './ExecutionSessionList';
 
 const ExecutionBottomPanel = () => {
   const resource = useWorkbenchStore(selectActiveResource);
@@ -335,35 +76,41 @@ const ExecutionBottomPanel = () => {
   if (!visible) return null;
 
   const renderPanelContent = () => {
-    if (!resource) return <EmptyPanel description="请先打开一个开发节点" />;
+    if (!resource) {
+      return <ExecutionEmptyPanel description="请先打开一个开发节点" />;
+    }
 
     if (activeTab === 'problems') {
-      return <ProblemsPanel session={activeSession} />;
+      return <ExecutionProblemsPanel session={activeSession} />;
     }
     if (activeTab === 'output') {
-      return <OutputPanel session={activeSession} />;
+      return <ExecutionOutputPanel session={activeSession} />;
     }
     if (activeTab === 'lineage') {
-      return <LineagePanel resourceName={resource.name} />;
+      return <ExecutionLineagePanel resourceName={resource.name} />;
     }
     if (activeTab === 'publish') {
-      return <PublishPanel published={resource.status === 'PUBLISHED'} />;
+      return (
+        <ExecutionPublishPanel published={resource.status === 'PUBLISHED'} />
+      );
     }
     if (activeTab === 'validation') {
-      return <ValidationPanel session={activeSession} />;
+      return <ExecutionValidationPanel session={activeSession} />;
     }
     if (activeTab === 'quality') {
-      return <QualityPanel />;
+      return <ExecutionQualityPanel />;
     }
 
     if (!activeSession) {
-      return <EmptyPanel description="点击运行后将在这里展示节点运行结果" />;
+      return (
+        <ExecutionEmptyPanel description="点击运行后将在这里展示节点运行结果" />
+      );
     }
     if (activeSession.status === 'RUNNING') {
-      return <OutputPanel session={activeSession} />;
+      return <ExecutionOutputPanel session={activeSession} />;
     }
     if (!activeSession.result || !ResultRenderer || !plugin) {
-      return <EmptyPanel description="当前执行暂无可展示结果" />;
+      return <ExecutionEmptyPanel description="当前执行暂无可展示结果" />;
     }
 
     return (
@@ -378,7 +125,7 @@ const ExecutionBottomPanel = () => {
 
   return (
     <section
-      style={{ height }}
+      style={{ height, maxHeight: 'calc(100% - 120px)' }}
       className="relative flex min-h-0 shrink-0 flex-col border-t border-[#dfe2e6] bg-white shadow-[0_-8px_24px_rgba(16,24,40,0.03)]"
     >
       <ExecutionPanelResizeHandle
@@ -389,147 +136,33 @@ const ExecutionBottomPanel = () => {
         onChange={setHeight}
       />
 
-      <header className="flex h-10 shrink-0 items-center justify-between border-b border-[#eceef0] px-2">
-        <div className="flex min-w-0 items-center gap-0.5 overflow-x-auto">
-          {PANEL_TABS.map((tab) => {
-            const Icon = tab.icon;
-            const active = activeTab === tab.key;
-            const badge =
-              tab.key === 'problems' && activeSession?.status === 'FAILED'
-                ? 1
-                : undefined;
-
-            return (
-              <button
-                key={tab.key}
-                type="button"
-                onClick={() => setActiveTab(tab.key)}
-                className={[
-                  'relative flex h-10 shrink-0 items-center gap-1.5 border-0 bg-transparent px-3 text-[11px] transition-colors',
-                  active
-                    ? 'font-medium text-[#161823]'
-                    : 'text-[rgba(22,24,35,0.5)] hover:text-[#161823]',
-                ].join(' ')}
-              >
-                <Icon size={13} />
-                {tab.label}
-                {badge && (
-                  <span className="flex h-4 min-w-4 items-center justify-center rounded-full bg-[var(--yak-brand-color)] px-1 text-[9px] text-white">
-                    {badge}
-                  </span>
-                )}
-                {active && (
-                  <span className="absolute inset-x-2 bottom-0 h-0.5 bg-[var(--yak-brand-color)]" />
-                )}
-              </button>
-            );
-          })}
-        </div>
-
-        <div className="flex shrink-0 items-center gap-0.5 border-l border-[#eceef0] pl-2">
-          <Tooltip title={maximized ? '还原面板' : '展开面板'}>
-            <Button
-              type="text"
-              size="small"
-              className="!h-7 !w-7 !px-0"
-              icon={
-                maximized ? <Minimize2 size={14} /> : <Maximize2 size={14} />
-              }
-              onClick={() => setMaximized(!maximized)}
-            />
-          </Tooltip>
-          <Tooltip title="缩小面板">
-            <Button
-              type="text"
-              size="small"
-              className="!h-7 !w-7 !px-0"
-              icon={<ChevronDown size={14} />}
-              onClick={() => setHeight(EXECUTION_PANEL_MIN_HEIGHT)}
-            />
-          </Tooltip>
-          <Tooltip title="恢复默认高度">
-            <Button
-              type="text"
-              size="small"
-              className="!h-7 !w-7 !px-0"
-              icon={<ChevronUp size={14} />}
-              onClick={() => setHeight(EXECUTION_PANEL_DEFAULT_HEIGHT)}
-            />
-          </Tooltip>
-          <Tooltip title="关闭运行面板">
-            <Button
-              type="text"
-              size="small"
-              className="!h-7 !w-7 !px-0"
-              icon={<X size={14} />}
-              onClick={() => setVisible(false)}
-            />
-          </Tooltip>
-        </div>
-      </header>
+      <ExecutionPanelHeader
+        activeTab={activeTab}
+        activeSession={activeSession}
+        maximized={maximized}
+        onTabChange={setActiveTab}
+        onToggleMaximized={() => setMaximized(!maximized)}
+        onMinimize={() => setHeight(EXECUTION_PANEL_MIN_HEIGHT)}
+        onRestore={() => setHeight(EXECUTION_PANEL_DEFAULT_HEIGHT)}
+        onClose={() => setVisible(false)}
+      />
 
       <div className="flex min-h-0 flex-1 overflow-hidden">
-        <aside className="w-[220px] shrink-0 overflow-y-auto border-r border-[#eceef0] bg-[#fafbfc]">
-          <div className="flex h-9 items-center gap-2 border-b border-[#eceef0] px-3 text-[11px] font-medium text-[rgba(22,24,35,0.62)]">
-            <History size={13} />
-            运行记录
-          </div>
-
-          {sessionIds.length === 0 ? (
-            <div className="px-3 py-5 text-center text-[11px] leading-5 text-[rgba(22,24,35,0.36)]">
-              当前节点暂无运行记录
-            </div>
-          ) : (
-            <div className="py-1">
-              {sessionIds.map((sessionId, index) => {
-                const session = sessionsById[sessionId];
-                if (!session) return null;
-                const active = sessionId === activeSessionId;
-
-                return (
-                  <button
-                    key={sessionId}
-                    type="button"
-                    onClick={() =>
-                      resource && selectSession(resource.id, sessionId)
-                    }
-                    className={[
-                      'flex w-full items-start gap-2 border-0 px-3 py-2 text-left transition-colors',
-                      active
-                        ? 'bg-[var(--yak-brand-color-soft)]'
-                        : 'bg-transparent hover:bg-[#f1f2f4]',
-                    ].join(' ')}
-                  >
-                    <span className="mt-0.5">
-                      {session.status === 'RUNNING' ? (
-                        <LoaderCircle
-                          size={13}
-                          className="animate-spin text-[#1677ff]"
-                        />
-                      ) : session.status === 'SUCCESS' ? (
-                        <CheckCircle2 size={13} className="text-[#14945f]" />
-                      ) : (
-                        <AlertCircle size={13} className="text-[#d92d20]" />
-                      )}
-                    </span>
-                    <span className="min-w-0 flex-1">
-                      <span className="block truncate text-[11px] font-medium text-[rgba(22,24,35,0.72)]">
-                        {resource?.name ?? resourcesById[session.resourceId]?.name}
-                        {index === 0 ? ' · 最新' : ''}
-                      </span>
-                      <span className="mt-0.5 block text-[10px] text-[rgba(22,24,35,0.36)]">
-                        {formatDateTime(session.startedAt)} · {session.engine}
-                      </span>
-                    </span>
-                  </button>
-                );
-              })}
-            </div>
-          )}
-        </aside>
+        <ExecutionSessionList
+          resource={resource}
+          resourcesById={resourcesById}
+          sessionIds={sessionIds}
+          sessionsById={sessionsById}
+          activeSessionId={activeSessionId}
+          onSelect={(sessionId) =>
+            resource && selectSession(resource.id, sessionId)
+          }
+        />
 
         <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
-          {activeSession && <SessionSummary session={activeSession} />}
+          {activeSession && (
+            <ExecutionSessionSummary session={activeSession} />
+          )}
           <div className="min-h-0 flex-1 overflow-hidden">
             {renderPanelContent()}
           </div>

--- a/yak-ops-ui/src/pages/data-development/workbench/execution/components/ExecutionCommonPanels.tsx
+++ b/yak-ops-ui/src/pages/data-development/workbench/execution/components/ExecutionCommonPanels.tsx
@@ -1,0 +1,170 @@
+import { Tag } from 'antd';
+import {
+  AlertCircle,
+  CheckCircle2,
+  CircleDot,
+  LoaderCircle,
+} from 'lucide-react';
+import type { ExecutionSession } from '../types';
+import { ExecutionEmptyPanel } from './ExecutionPanelShared';
+
+export const ExecutionOutputPanel = ({
+  session,
+}: {
+  session?: ExecutionSession;
+}) => {
+  if (!session) {
+    return <ExecutionEmptyPanel description="运行节点后可查看实时输出" />;
+  }
+
+  return (
+    <div className="h-full min-h-0 overflow-auto bg-[#111418] p-3 font-mono text-[12px] leading-6 text-[#d7dce2]">
+      {session.logs.map((log) => (
+        <div key={log.id} className="grid grid-cols-[72px_52px_1fr] gap-2">
+          <span className="text-white/35">{log.timestamp}</span>
+          <span
+            className={
+              log.level === 'ERROR'
+                ? 'text-[#ff8c8c]'
+                : log.level === 'WARN'
+                  ? 'text-[#f0b45a]'
+                  : 'text-[#7db4ff]'
+            }
+          >
+            {log.level}
+          </span>
+          <span className="whitespace-pre-wrap">{log.message}</span>
+        </div>
+      ))}
+      {session.status === 'RUNNING' && (
+        <div className="mt-1 flex items-center gap-2 text-white/55">
+          <LoaderCircle size={12} className="animate-spin" />
+          waiting for execution events...
+        </div>
+      )}
+    </div>
+  );
+};
+
+export const ExecutionProblemsPanel = ({
+  session,
+}: {
+  session?: ExecutionSession;
+}) => {
+  if (!session || session.status !== 'FAILED') {
+    return <ExecutionEmptyPanel description="当前节点没有发现问题" />;
+  }
+
+  return (
+    <div className="p-3">
+      <div className="flex items-start gap-3 border border-[#f5c2c0] bg-[#fff7f6] p-3">
+        <AlertCircle size={16} className="mt-0.5 text-[#d92d20]" />
+        <div>
+          <div className="text-[12px] font-medium text-[#b42318]">运行失败</div>
+          <div className="mt-1 text-[11px] leading-5 text-[#7a271a]">
+            {session.errorMessage ?? '请查看输出日志定位失败原因。'}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export const ExecutionLineagePanel = ({
+  resourceName,
+}: {
+  resourceName: string;
+}) => (
+  <div className="flex h-full items-center justify-center bg-[#fafbfc] p-6">
+    <div className="flex items-center gap-6">
+      {['上游数据源', resourceName, '下游数据表'].map((label, index) => (
+        <div key={label} className="flex items-center gap-6">
+          <div className="min-w-[150px] border border-[#dfe2e6] bg-white px-4 py-3 text-center shadow-sm">
+            <CircleDot
+              size={15}
+              className="mx-auto text-[var(--yak-brand-color)]"
+            />
+            <div className="mt-2 truncate text-[12px] font-medium text-[#161823]">
+              {label}
+            </div>
+          </div>
+          {index < 2 && (
+            <span className="h-px w-16 bg-[#cfd3d8] after:float-right after:-mt-[3px] after:block after:h-2 after:w-2 after:rotate-45 after:border-r after:border-t after:border-[#cfd3d8]" />
+          )}
+        </div>
+      ))}
+    </div>
+  </div>
+);
+
+export const ExecutionPublishPanel = ({
+  published,
+}: {
+  published: boolean;
+}) => (
+  <div className="h-full overflow-auto p-4">
+    <div className="mx-auto max-w-[920px]">
+      <div className="flex items-center justify-between border-b border-[#eceef0] pb-3">
+        <div>
+          <h3 className="m-0 text-[14px] font-semibold text-[#161823]">
+            上线发布内容
+          </h3>
+          <p className="mb-0 mt-1 text-[11px] text-[rgba(22,24,35,0.44)]">
+            运行结果确认后，可创建不可变发布版本并进入生产检查流程。
+          </p>
+        </div>
+        <Tag bordered={false} color={published ? 'success' : 'default'}>
+          {published ? '已有发布版本' : '未发布'}
+        </Tag>
+      </div>
+      <div className="mt-4 grid grid-cols-3 gap-4">
+        {['发布包构建', '生产检查器', '发布到生产环境'].map((label, index) => (
+          <div key={label} className="border border-[#e5e7ea] bg-[#fafbfc] p-3">
+            <span className="flex h-5 w-5 items-center justify-center rounded-full border border-[#d6d9dd] text-[10px] text-[rgba(22,24,35,0.52)]">
+              {index + 1}
+            </span>
+            <div className="mt-2 text-[12px] font-medium text-[#161823]">
+              {label}
+            </div>
+            <div className="mt-1 text-[11px] text-[rgba(22,24,35,0.4)]">
+              {published ? '等待下一次发布' : '未开始'}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  </div>
+);
+
+export const ExecutionValidationPanel = ({
+  session,
+}: {
+  session?: ExecutionSession;
+}) => (
+  <div className="h-full overflow-auto p-4">
+    <div className="space-y-2">
+      {[
+        ['语法检查', '通过'],
+        ['依赖资源检查', '通过'],
+        ['运行参数检查', '通过'],
+        ['数据源连通性', session ? '通过' : '等待运行'],
+      ].map(([label, value]) => (
+        <div
+          key={label}
+          className="flex items-center justify-between border-b border-[#eceef0] px-2 py-2.5"
+        >
+          <span className="text-[12px] text-[rgba(22,24,35,0.7)]">
+            {label}
+          </span>
+          <span className="flex items-center gap-1.5 text-[11px] text-[#14945f]">
+            <CheckCircle2 size={13} /> {value}
+          </span>
+        </div>
+      ))}
+    </div>
+  </div>
+);
+
+export const ExecutionQualityPanel = () => (
+  <ExecutionEmptyPanel description="质量测试框架已预留，后续可接入规则模板和测试报告" />
+);

--- a/yak-ops-ui/src/pages/data-development/workbench/execution/components/ExecutionPanelHeader.tsx
+++ b/yak-ops-ui/src/pages/data-development/workbench/execution/components/ExecutionPanelHeader.tsx
@@ -1,0 +1,134 @@
+import { Button, Tooltip } from 'antd';
+import {
+  AlertCircle,
+  ChevronDown,
+  ChevronUp,
+  GitBranch,
+  ListChecks,
+  Maximize2,
+  Minimize2,
+  PackageCheck,
+  ScrollText,
+  ShieldCheck,
+  Sparkles,
+  X,
+} from 'lucide-react';
+import type {
+  ExecutionPanelTabKey,
+  ExecutionSession,
+} from '../types';
+
+const PANEL_TABS: Array<{
+  key: ExecutionPanelTabKey;
+  label: string;
+  icon: typeof AlertCircle;
+}> = [
+  { key: 'problems', label: '问题', icon: AlertCircle },
+  { key: 'output', label: '输出', icon: ScrollText },
+  { key: 'lineage', label: '血缘', icon: GitBranch },
+  { key: 'result', label: '结果', icon: ListChecks },
+  { key: 'publish', label: '发布', icon: PackageCheck },
+  { key: 'validation', label: '深度检查', icon: ShieldCheck },
+  { key: 'quality', label: '质量测试', icon: Sparkles },
+];
+
+interface ExecutionPanelHeaderProps {
+  activeTab: ExecutionPanelTabKey;
+  activeSession?: ExecutionSession;
+  maximized: boolean;
+  onTabChange: (tab: ExecutionPanelTabKey) => void;
+  onToggleMaximized: () => void;
+  onMinimize: () => void;
+  onRestore: () => void;
+  onClose: () => void;
+}
+
+const ExecutionPanelHeader = ({
+  activeTab,
+  activeSession,
+  maximized,
+  onTabChange,
+  onToggleMaximized,
+  onMinimize,
+  onRestore,
+  onClose,
+}: ExecutionPanelHeaderProps) => (
+  <header className="flex h-10 shrink-0 items-center justify-between border-b border-[#eceef0] px-2">
+    <div className="flex min-w-0 items-center gap-0.5 overflow-x-auto">
+      {PANEL_TABS.map((tab) => {
+        const Icon = tab.icon;
+        const active = activeTab === tab.key;
+        const badge =
+          tab.key === 'problems' && activeSession?.status === 'FAILED'
+            ? 1
+            : undefined;
+
+        return (
+          <button
+            key={tab.key}
+            type="button"
+            onClick={() => onTabChange(tab.key)}
+            className={[
+              'relative flex h-10 shrink-0 items-center gap-1.5 border-0 bg-transparent px-3 text-[11px] transition-colors',
+              active
+                ? 'font-medium text-[#161823]'
+                : 'text-[rgba(22,24,35,0.5)] hover:text-[#161823]',
+            ].join(' ')}
+          >
+            <Icon size={13} />
+            {tab.label}
+            {badge && (
+              <span className="flex h-4 min-w-4 items-center justify-center rounded-full bg-[var(--yak-brand-color)] px-1 text-[9px] text-white">
+                {badge}
+              </span>
+            )}
+            {active && (
+              <span className="absolute inset-x-2 bottom-0 h-0.5 bg-[var(--yak-brand-color)]" />
+            )}
+          </button>
+        );
+      })}
+    </div>
+
+    <div className="flex shrink-0 items-center gap-0.5 border-l border-[#eceef0] pl-2">
+      <Tooltip title={maximized ? '还原面板' : '展开面板'}>
+        <Button
+          type="text"
+          size="small"
+          className="!h-7 !w-7 !px-0"
+          icon={maximized ? <Minimize2 size={14} /> : <Maximize2 size={14} />}
+          onClick={onToggleMaximized}
+        />
+      </Tooltip>
+      <Tooltip title="缩小面板">
+        <Button
+          type="text"
+          size="small"
+          className="!h-7 !w-7 !px-0"
+          icon={<ChevronDown size={14} />}
+          onClick={onMinimize}
+        />
+      </Tooltip>
+      <Tooltip title="恢复默认高度">
+        <Button
+          type="text"
+          size="small"
+          className="!h-7 !w-7 !px-0"
+          icon={<ChevronUp size={14} />}
+          onClick={onRestore}
+        />
+      </Tooltip>
+      <Tooltip title="关闭运行面板">
+        <Button
+          type="text"
+          size="small"
+          className="!h-7 !w-7 !px-0"
+          icon={<X size={14} />}
+          onClick={onClose}
+        />
+      </Tooltip>
+    </div>
+  </header>
+);
+
+export default ExecutionPanelHeader;

--- a/yak-ops-ui/src/pages/data-development/workbench/execution/components/ExecutionPanelResizeHandle.tsx
+++ b/yak-ops-ui/src/pages/data-development/workbench/execution/components/ExecutionPanelResizeHandle.tsx
@@ -1,0 +1,110 @@
+import {
+  useEffect,
+  useRef,
+  type KeyboardEvent,
+  type PointerEvent,
+} from 'react';
+
+interface ExecutionPanelResizeHandleProps {
+  value: number;
+  min: number;
+  max: number;
+  defaultValue: number;
+  onChange: (value: number) => void;
+}
+
+const clamp = (value: number, min: number, max: number) =>
+  Math.min(max, Math.max(min, value));
+
+const ExecutionPanelResizeHandle = ({
+  value,
+  min,
+  max,
+  defaultValue,
+  onChange,
+}: ExecutionPanelResizeHandleProps) => {
+  const cleanupRef = useRef<(() => void) | null>(null);
+
+  useEffect(
+    () => () => {
+      cleanupRef.current?.();
+    },
+    [],
+  );
+
+  const handlePointerDown = (event: PointerEvent<HTMLDivElement>) => {
+    if (event.button !== 0) return;
+
+    event.preventDefault();
+    const startY = event.clientY;
+    const startValue = value;
+    const previousCursor = document.body.style.cursor;
+    const previousUserSelect = document.body.style.userSelect;
+
+    document.body.style.cursor = 'row-resize';
+    document.body.style.userSelect = 'none';
+
+    const handlePointerMove = (moveEvent: globalThis.PointerEvent) => {
+      onChange(clamp(startValue + startY - moveEvent.clientY, min, max));
+    };
+
+    const cleanup = () => {
+      window.removeEventListener('pointermove', handlePointerMove);
+      window.removeEventListener('pointerup', cleanup);
+      window.removeEventListener('pointercancel', cleanup);
+      document.body.style.cursor = previousCursor;
+      document.body.style.userSelect = previousUserSelect;
+      cleanupRef.current = null;
+    };
+
+    cleanupRef.current?.();
+    cleanupRef.current = cleanup;
+    window.addEventListener('pointermove', handlePointerMove);
+    window.addEventListener('pointerup', cleanup);
+    window.addEventListener('pointercancel', cleanup);
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    const step = event.shiftKey ? 40 : 12;
+
+    if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      onChange(clamp(value + step, min, max));
+    }
+
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      onChange(clamp(value - step, min, max));
+    }
+
+    if (event.key === 'Home') {
+      event.preventDefault();
+      onChange(min);
+    }
+
+    if (event.key === 'End') {
+      event.preventDefault();
+      onChange(max);
+    }
+  };
+
+  return (
+    <div
+      role="separator"
+      aria-label="调整运行结果面板高度"
+      aria-orientation="horizontal"
+      aria-valuemin={min}
+      aria-valuemax={max}
+      aria-valuenow={Math.round(value)}
+      tabIndex={0}
+      onPointerDown={handlePointerDown}
+      onDoubleClick={() => onChange(defaultValue)}
+      onKeyDown={handleKeyDown}
+      className="group absolute inset-x-0 top-0 z-30 h-[6px] -translate-y-1/2 cursor-row-resize touch-none bg-transparent outline-none"
+    >
+      <span className="absolute inset-x-0 top-1/2 h-px -translate-y-1/2 bg-[#dfe2e6] transition-[height,background-color] group-hover:h-[3px] group-hover:bg-[var(--yak-brand-color)] group-focus-visible:h-[3px] group-focus-visible:bg-[var(--yak-brand-color)]" />
+    </div>
+  );
+};
+
+export default ExecutionPanelResizeHandle;

--- a/yak-ops-ui/src/pages/data-development/workbench/execution/components/ExecutionPanelShared.tsx
+++ b/yak-ops-ui/src/pages/data-development/workbench/execution/components/ExecutionPanelShared.tsx
@@ -1,0 +1,122 @@
+import { Empty, Tag } from 'antd';
+import {
+  AlertCircle,
+  CheckCircle2,
+  LoaderCircle,
+  Square,
+} from 'lucide-react';
+import type { ExecutionSession } from '../types';
+
+export const formatExecutionDateTime = (value?: string) => {
+  if (!value) return '-';
+  return new Intl.DateTimeFormat('zh-CN', {
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  }).format(new Date(value));
+};
+
+const formatDuration = (durationMs?: number) => {
+  if (durationMs === undefined) return '-';
+  if (durationMs < 1000) return `${durationMs} ms`;
+  return `${(durationMs / 1000).toFixed(2)} s`;
+};
+
+export const ExecutionStatusTag = ({
+  session,
+}: {
+  session: ExecutionSession;
+}) => {
+  const running = session.status === 'RUNNING';
+  const success = session.status === 'SUCCESS';
+  const stopped = session.status === 'STOPPED';
+
+  return (
+    <Tag
+      bordered={false}
+      icon={
+        running ? (
+          <LoaderCircle size={12} className="animate-spin" />
+        ) : success ? (
+          <CheckCircle2 size={12} />
+        ) : stopped ? (
+          <Square size={12} />
+        ) : (
+          <AlertCircle size={12} />
+        )
+      }
+      color={
+        running
+          ? 'processing'
+          : success
+            ? 'success'
+            : stopped
+              ? 'default'
+              : 'error'
+      }
+      className="!m-0"
+    >
+      {running
+        ? '运行中'
+        : success
+          ? '运行成功'
+          : stopped
+            ? '已停止'
+            : '运行失败'}
+    </Tag>
+  );
+};
+
+export const ExecutionSessionSummary = ({
+  session,
+}: {
+  session: ExecutionSession;
+}) => (
+  <div className="grid shrink-0 grid-cols-[auto_repeat(4,minmax(120px,1fr))] items-center gap-4 border-b border-[#eceef0] bg-[#fafbfc] px-3 py-2 text-[11px]">
+    <ExecutionStatusTag session={session} />
+    <div>
+      <div className="text-[rgba(22,24,35,0.38)]">执行 ID</div>
+      <div className="mt-0.5 truncate font-mono text-[rgba(22,24,35,0.7)]">
+        {session.id}
+      </div>
+    </div>
+    <div>
+      <div className="text-[rgba(22,24,35,0.38)]">开始时间</div>
+      <div className="mt-0.5 text-[rgba(22,24,35,0.7)]">
+        {formatExecutionDateTime(session.startedAt)}
+      </div>
+    </div>
+    <div>
+      <div className="text-[rgba(22,24,35,0.38)]">结束时间</div>
+      <div className="mt-0.5 text-[rgba(22,24,35,0.7)]">
+        {formatExecutionDateTime(session.finishedAt)}
+      </div>
+    </div>
+    <div>
+      <div className="text-[rgba(22,24,35,0.38)]">运行耗时</div>
+      <div className="mt-0.5 text-[rgba(22,24,35,0.7)]">
+        {formatDuration(session.durationMs)}
+      </div>
+    </div>
+  </div>
+);
+
+export const ExecutionEmptyPanel = ({
+  description,
+}: {
+  description: string;
+}) => (
+  <div className="flex h-full items-center justify-center bg-white">
+    <Empty
+      image={Empty.PRESENTED_IMAGE_SIMPLE}
+      description={
+        <span className="text-[12px] text-[rgba(22,24,35,0.42)]">
+          {description}
+        </span>
+      }
+    />
+  </div>
+);

--- a/yak-ops-ui/src/pages/data-development/workbench/execution/components/ExecutionSessionList.tsx
+++ b/yak-ops-ui/src/pages/data-development/workbench/execution/components/ExecutionSessionList.tsx
@@ -1,0 +1,86 @@
+import {
+  AlertCircle,
+  CheckCircle2,
+  History,
+  LoaderCircle,
+} from 'lucide-react';
+import type { DevelopmentResource } from '../../core/types';
+import type { ExecutionSession } from '../types';
+import { formatExecutionDateTime } from './ExecutionPanelShared';
+
+interface ExecutionSessionListProps {
+  resource?: DevelopmentResource;
+  resourcesById: Record<string, DevelopmentResource>;
+  sessionIds: string[];
+  sessionsById: Record<string, ExecutionSession>;
+  activeSessionId?: string;
+  onSelect: (sessionId: string) => void;
+}
+
+const ExecutionSessionList = ({
+  resource,
+  resourcesById,
+  sessionIds,
+  sessionsById,
+  activeSessionId,
+  onSelect,
+}: ExecutionSessionListProps) => (
+  <aside className="w-[220px] shrink-0 overflow-y-auto border-r border-[#eceef0] bg-[#fafbfc]">
+    <div className="flex h-9 items-center gap-2 border-b border-[#eceef0] px-3 text-[11px] font-medium text-[rgba(22,24,35,0.62)]">
+      <History size={13} />
+      运行记录
+    </div>
+
+    {sessionIds.length === 0 ? (
+      <div className="px-3 py-5 text-center text-[11px] leading-5 text-[rgba(22,24,35,0.36)]">
+        当前节点暂无运行记录
+      </div>
+    ) : (
+      <div className="py-1">
+        {sessionIds.map((sessionId, index) => {
+          const session = sessionsById[sessionId];
+          if (!session) return null;
+          const active = sessionId === activeSessionId;
+
+          return (
+            <button
+              key={sessionId}
+              type="button"
+              onClick={() => onSelect(sessionId)}
+              className={[
+                'flex w-full items-start gap-2 border-0 px-3 py-2 text-left transition-colors',
+                active
+                  ? 'bg-[var(--yak-brand-color-soft)]'
+                  : 'bg-transparent hover:bg-[#f1f2f4]',
+              ].join(' ')}
+            >
+              <span className="mt-0.5">
+                {session.status === 'RUNNING' ? (
+                  <LoaderCircle
+                    size={13}
+                    className="animate-spin text-[#1677ff]"
+                  />
+                ) : session.status === 'SUCCESS' ? (
+                  <CheckCircle2 size={13} className="text-[#14945f]" />
+                ) : (
+                  <AlertCircle size={13} className="text-[#d92d20]" />
+                )}
+              </span>
+              <span className="min-w-0 flex-1">
+                <span className="block truncate text-[11px] font-medium text-[rgba(22,24,35,0.72)]">
+                  {resource?.name ?? resourcesById[session.resourceId]?.name}
+                  {index === 0 ? ' · 最新' : ''}
+                </span>
+                <span className="mt-0.5 block text-[10px] text-[rgba(22,24,35,0.36)]">
+                  {formatExecutionDateTime(session.startedAt)} · {session.engine}
+                </span>
+              </span>
+            </button>
+          );
+        })}
+      </div>
+    )}
+  </aside>
+);
+
+export default ExecutionSessionList;

--- a/yak-ops-ui/src/pages/data-development/workbench/execution/definitions.ts
+++ b/yak-ops-ui/src/pages/data-development/workbench/execution/definitions.ts
@@ -1,0 +1,12 @@
+import type { ExecutionResultDefinition } from './types';
+
+export const BUILTIN_EXECUTION_RESULT_DEFINITIONS: ExecutionResultDefinition[] = [
+  { resourceType: 'SQL', rendererKey: 'table-result' },
+  { resourceType: 'FLINK_SQL', rendererKey: 'table-result' },
+  { resourceType: 'HTTP', rendererKey: 'json-result' },
+  { resourceType: 'SHELL', rendererKey: 'terminal-result' },
+  { resourceType: 'PYTHON', rendererKey: 'terminal-result' },
+  { resourceType: 'NOTEBOOK', rendererKey: 'notebook-result' },
+  { resourceType: 'DATA_INTEGRATION', rendererKey: 'pipeline-result' },
+  { resourceType: 'RESOURCE', rendererKey: 'text-result' },
+];

--- a/yak-ops-ui/src/pages/data-development/workbench/execution/mock-results.ts
+++ b/yak-ops-ui/src/pages/data-development/workbench/execution/mock-results.ts
@@ -1,0 +1,221 @@
+import type {
+  DevelopmentResource,
+  NodePluginDefinition,
+} from '../core/types';
+import type {
+  ExecutionLogEntry,
+  ExecutionResultPayload,
+  ExecutionSession,
+} from './types';
+
+const createTimestamp = () =>
+  new Intl.DateTimeFormat('zh-CN', {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  }).format(new Date());
+
+const createLog = (
+  id: string,
+  message: string,
+  level: ExecutionLogEntry['level'] = 'INFO',
+): ExecutionLogEntry => ({
+  id,
+  level,
+  timestamp: createTimestamp(),
+  message,
+});
+
+export const createRunningExecutionSession = (
+  resource: DevelopmentResource,
+  plugin: NodePluginDefinition,
+): ExecutionSession => {
+  const now = new Date().toISOString();
+  const id = `RUN-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+
+  return {
+    id,
+    resourceId: resource.id,
+    resourceType: resource.resourceType,
+    resourceName: resource.name,
+    engine: resource.engine,
+    status: 'RUNNING',
+    submittedAt: now,
+    startedAt: now,
+    logs: [
+      createLog(`${id}-1`, `提交 ${plugin.metadata.label} 运行请求`),
+      createLog(`${id}-2`, `运行环境：开发环境 · 引擎：${resource.engine}`),
+      createLog(`${id}-3`, '正在申请执行资源并初始化运行上下文'),
+    ],
+  };
+};
+
+const createTableResult = (): ExecutionResultPayload => ({
+  kind: 'table',
+  columns: [
+    { key: 'user_id', title: 'user_id', dataType: 'BIGINT' },
+    { key: 'event_type', title: 'event_type', dataType: 'STRING' },
+    { key: 'event_time', title: 'event_time', dataType: 'TIMESTAMP' },
+    { key: 'dt', title: 'dt', dataType: 'STRING' },
+  ],
+  rows: [
+    {
+      user_id: 10001,
+      event_type: 'LOGIN',
+      event_time: '2026-08-04 14:42:56',
+      dt: '20260804',
+    },
+    {
+      user_id: 10002,
+      event_type: 'VIEW_PRODUCT',
+      event_time: '2026-08-04 14:43:02',
+      dt: '20260804',
+    },
+    {
+      user_id: 10003,
+      event_type: 'SUBMIT_ORDER',
+      event_time: '2026-08-04 14:43:05',
+      dt: '20260804',
+    },
+  ],
+  affectedRows: 3,
+});
+
+const createJsonResult = (): ExecutionResultPayload => ({
+  kind: 'json',
+  statusCode: 200,
+  statusText: 'OK',
+  elapsedMs: 286,
+  headers: {
+    'content-type': 'application/json; charset=utf-8',
+    'x-request-id': `yak-${Date.now()}`,
+    server: 'yak-ops-gateway',
+  },
+  body: {
+    code: 0,
+    message: 'success',
+    data: {
+      userId: 10001,
+      userName: '张三',
+      userLevel: 'VIP',
+      tags: ['高活跃', '高价值'],
+    },
+  },
+});
+
+const createTerminalResult = (
+  resource: DevelopmentResource,
+): ExecutionResultPayload => ({
+  kind: 'terminal',
+  exitCode: 0,
+  stdout: [
+    `$ ${resource.name}`,
+    'initializing runtime context...',
+    'loading environment variables...',
+    'processing task...',
+    'task completed successfully',
+  ],
+  stderr: [],
+});
+
+const createNotebookResult = (): ExecutionResultPayload => ({
+  kind: 'notebook',
+  cells: [
+    {
+      id: 'cell-1',
+      label: 'Cell 1',
+      status: 'SUCCESS',
+      durationMs: 184,
+      output: 'SparkSession available as spark',
+    },
+    {
+      id: 'cell-2',
+      label: 'Cell 2',
+      status: 'SUCCESS',
+      durationMs: 712,
+      output: 'DataFrame[user_level: string, count: bigint]\nVIP  1284\nNORMAL  6382',
+    },
+  ],
+});
+
+const createPipelineResult = (): ExecutionResultPayload => ({
+  kind: 'pipeline',
+  processedRows: 128430,
+  writtenRows: 128426,
+  rejectedRows: 4,
+  throughput: 12680,
+  stages: [
+    {
+      id: 'source',
+      label: '读取 MySQL',
+      status: 'SUCCESS',
+      rows: 128430,
+      durationMs: 2410,
+    },
+    {
+      id: 'transform',
+      label: '字段清洗与映射',
+      status: 'SUCCESS',
+      rows: 128426,
+      durationMs: 1160,
+    },
+    {
+      id: 'sink',
+      label: '写入 ODPS',
+      status: 'SUCCESS',
+      rows: 128426,
+      durationMs: 3260,
+    },
+  ],
+});
+
+export const createMockExecutionResult = (
+  resource: DevelopmentResource,
+): ExecutionResultPayload => {
+  switch (resource.resourceType) {
+    case 'SQL':
+    case 'FLINK_SQL':
+      return createTableResult();
+    case 'HTTP':
+      return createJsonResult();
+    case 'SHELL':
+    case 'PYTHON':
+      return createTerminalResult(resource);
+    case 'NOTEBOOK':
+      return createNotebookResult();
+    case 'DATA_INTEGRATION':
+      return createPipelineResult();
+    default:
+      return {
+        kind: 'text',
+        title: '运行结果',
+        value: `${resource.name} 已完成处理，当前节点未声明专属结果渲染器。`,
+      };
+  }
+};
+
+export const completeMockExecutionSession = (
+  session: ExecutionSession,
+  resource: DevelopmentResource,
+): ExecutionSession => {
+  const finishedAt = new Date().toISOString();
+  const durationMs = Math.max(
+    1,
+    new Date(finishedAt).getTime() - new Date(session.startedAt).getTime(),
+  );
+
+  return {
+    ...session,
+    status: 'SUCCESS',
+    finishedAt,
+    durationMs,
+    logs: [
+      ...session.logs,
+      createLog(`${session.id}-4`, '执行资源准备完成'),
+      createLog(`${session.id}-5`, '节点执行成功，正在整理结果'),
+      createLog(`${session.id}-6`, `运行完成，总耗时 ${durationMs} ms`),
+    ],
+    result: createMockExecutionResult(resource),
+  };
+};

--- a/yak-ops-ui/src/pages/data-development/workbench/execution/registry.ts
+++ b/yak-ops-ui/src/pages/data-development/workbench/execution/registry.ts
@@ -1,0 +1,30 @@
+import type {
+  ExecutionResultDefinition,
+  ExecutionResultRendererComponent,
+} from './types';
+
+class KeyedRegistry<T> {
+  private readonly values = new Map<string, T>();
+
+  register(key: string, value: T) {
+    this.values.set(key, value);
+  }
+
+  get(key: string): T | undefined {
+    return this.values.get(key);
+  }
+
+  require(key: string): T {
+    const value = this.values.get(key);
+    if (!value) {
+      throw new Error(`Execution panel registry item not found: ${key}`);
+    }
+    return value;
+  }
+}
+
+export const executionResultDefinitionRegistry =
+  new KeyedRegistry<ExecutionResultDefinition>();
+
+export const executionResultRendererRegistry =
+  new KeyedRegistry<ExecutionResultRendererComponent>();

--- a/yak-ops-ui/src/pages/data-development/workbench/execution/renderers/JsonExecutionResultRenderer.tsx
+++ b/yak-ops-ui/src/pages/data-development/workbench/execution/renderers/JsonExecutionResultRenderer.tsx
@@ -1,0 +1,60 @@
+import { Button, Descriptions, Tag, message } from 'antd';
+import { Copy } from 'lucide-react';
+import type { ExecutionResultRendererProps } from '../types';
+
+const JsonExecutionResultRenderer = ({
+  payload,
+}: ExecutionResultRendererProps) => {
+  if (payload.kind !== 'json') return null;
+
+  const jsonText = JSON.stringify(payload.body, null, 2);
+
+  return (
+    <div className="flex h-full min-h-0 flex-col overflow-hidden">
+      <div className="shrink-0 border-b border-[#eceef0] bg-[#fafbfc] px-3 py-2">
+        <Descriptions size="small" column={4} colon={false}>
+          <Descriptions.Item label="状态">
+            <Tag bordered={false} color="success">
+              {payload.statusCode} {payload.statusText}
+            </Tag>
+          </Descriptions.Item>
+          <Descriptions.Item label="耗时">
+            {payload.elapsedMs} ms
+          </Descriptions.Item>
+          <Descriptions.Item label="响应类型">
+            {payload.headers['content-type'] ?? '-'}
+          </Descriptions.Item>
+          <Descriptions.Item label="请求 ID">
+            <span className="font-mono text-[11px]">
+              {payload.headers['x-request-id'] ?? '-'}
+            </span>
+          </Descriptions.Item>
+        </Descriptions>
+      </div>
+
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+        <div className="flex h-9 shrink-0 items-center justify-between border-b border-[#eceef0] px-3">
+          <strong className="text-[12px] font-medium text-[#161823]">
+            Response Body
+          </strong>
+          <Button
+            type="text"
+            size="small"
+            icon={<Copy size={13} />}
+            onClick={() => {
+              void navigator.clipboard?.writeText(jsonText);
+              message.success('响应 JSON 已复制');
+            }}
+          >
+            复制
+          </Button>
+        </div>
+        <pre className="m-0 min-h-0 flex-1 overflow-auto bg-[#fbfbfc] p-4 font-mono text-[12px] leading-6 text-[#2f3337]">
+          {jsonText}
+        </pre>
+      </div>
+    </div>
+  );
+};
+
+export default JsonExecutionResultRenderer;

--- a/yak-ops-ui/src/pages/data-development/workbench/execution/renderers/NotebookExecutionResultRenderer.tsx
+++ b/yak-ops-ui/src/pages/data-development/workbench/execution/renderers/NotebookExecutionResultRenderer.tsx
@@ -1,0 +1,43 @@
+import { CheckCircle2, XCircle } from 'lucide-react';
+import type { ExecutionResultRendererProps } from '../types';
+
+const NotebookExecutionResultRenderer = ({
+  payload,
+}: ExecutionResultRendererProps) => {
+  if (payload.kind !== 'notebook') return null;
+
+  return (
+    <div className="h-full min-h-0 overflow-auto bg-[#fafbfc] p-3">
+      <div className="space-y-2">
+        {payload.cells.map((cell) => {
+          const success = cell.status === 'SUCCESS';
+          return (
+            <article
+              key={cell.id}
+              className="overflow-hidden rounded-lg border border-[#e5e7ea] bg-white"
+            >
+              <header className="flex h-9 items-center justify-between border-b border-[#eceef0] px-3">
+                <span className="flex items-center gap-2 text-[12px] font-medium text-[#161823]">
+                  {success ? (
+                    <CheckCircle2 size={14} className="text-[#14945f]" />
+                  ) : (
+                    <XCircle size={14} className="text-[#d92d20]" />
+                  )}
+                  {cell.label}
+                </span>
+                <span className="text-[10px] text-[rgba(22,24,35,0.4)]">
+                  {cell.durationMs} ms
+                </span>
+              </header>
+              <pre className="m-0 whitespace-pre-wrap p-3 font-mono text-[12px] leading-6 text-[rgba(22,24,35,0.72)]">
+                {cell.output}
+              </pre>
+            </article>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default NotebookExecutionResultRenderer;

--- a/yak-ops-ui/src/pages/data-development/workbench/execution/renderers/PipelineExecutionResultRenderer.tsx
+++ b/yak-ops-ui/src/pages/data-development/workbench/execution/renderers/PipelineExecutionResultRenderer.tsx
@@ -1,0 +1,78 @@
+import { CheckCircle2, LoaderCircle, XCircle } from 'lucide-react';
+import type { ExecutionResultRendererProps } from '../types';
+
+const PipelineExecutionResultRenderer = ({
+  payload,
+}: ExecutionResultRendererProps) => {
+  if (payload.kind !== 'pipeline') return null;
+
+  const metrics = [
+    ['读取行数', payload.processedRows.toLocaleString()],
+    ['写入行数', payload.writtenRows.toLocaleString()],
+    ['脏数据', payload.rejectedRows.toLocaleString()],
+    ['吞吐', `${payload.throughput.toLocaleString()} rows/s`],
+  ];
+
+  return (
+    <div className="h-full min-h-0 overflow-auto bg-[#fafbfc] p-3">
+      <div className="grid grid-cols-4 gap-2">
+        {metrics.map(([label, value]) => (
+          <div
+            key={label}
+            className="border border-[#e5e7ea] bg-white px-3 py-2.5"
+          >
+            <div className="text-[10px] text-[rgba(22,24,35,0.42)]">
+              {label}
+            </div>
+            <div className="mt-1 text-[17px] font-semibold text-[#161823]">
+              {value}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div className="mt-3 overflow-hidden border border-[#e5e7ea] bg-white">
+        {payload.stages.map((stage, index) => {
+          const Icon =
+            stage.status === 'SUCCESS'
+              ? CheckCircle2
+              : stage.status === 'FAILED'
+                ? XCircle
+                : LoaderCircle;
+
+          return (
+            <div
+              key={stage.id}
+              className="grid grid-cols-[36px_minmax(0,1fr)_130px_110px] items-center border-b border-[#eceef0] px-3 py-2.5 last:border-b-0"
+            >
+              <span className="text-[11px] text-[rgba(22,24,35,0.34)]">
+                {index + 1}
+              </span>
+              <span className="flex items-center gap-2 text-[12px] font-medium text-[#161823]">
+                <Icon
+                  size={14}
+                  className={
+                    stage.status === 'SUCCESS'
+                      ? 'text-[#14945f]'
+                      : stage.status === 'FAILED'
+                        ? 'text-[#d92d20]'
+                        : 'animate-spin text-[#1677ff]'
+                  }
+                />
+                {stage.label}
+              </span>
+              <span className="text-[11px] text-[rgba(22,24,35,0.56)]">
+                {stage.rows.toLocaleString()} 行
+              </span>
+              <span className="text-right text-[11px] text-[rgba(22,24,35,0.46)]">
+                {stage.durationMs} ms
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default PipelineExecutionResultRenderer;

--- a/yak-ops-ui/src/pages/data-development/workbench/execution/renderers/TableExecutionResultRenderer.tsx
+++ b/yak-ops-ui/src/pages/data-development/workbench/execution/renderers/TableExecutionResultRenderer.tsx
@@ -1,0 +1,64 @@
+import { Table, Tag } from 'antd';
+import type { TableColumnsType } from 'antd';
+import type {
+  ExecutionResultRendererProps,
+  TableExecutionResult,
+} from '../types';
+
+const TableExecutionResultRenderer = ({
+  payload,
+}: ExecutionResultRendererProps) => {
+  if (payload.kind !== 'table') return null;
+
+  const tablePayload: TableExecutionResult = payload;
+  const columns: TableColumnsType<Record<string, unknown>> =
+    tablePayload.columns.map((column) => ({
+      title: (
+        <span className="flex items-center gap-1.5">
+          <span>{column.title}</span>
+          <Tag
+            bordered={false}
+            className="!m-0 !bg-[#f2f3f5] !px-1.5 !text-[9px] !font-normal !text-[rgba(22,24,35,0.42)]"
+          >
+            {column.dataType}
+          </Tag>
+        </span>
+      ),
+      dataIndex: column.key,
+      key: column.key,
+      ellipsis: true,
+      width: 180,
+      render: (value: unknown) => (
+        <span className="font-mono text-[12px] text-[rgba(22,24,35,0.76)]">
+          {value === null || value === undefined ? 'NULL' : String(value)}
+        </span>
+      ),
+    }));
+
+  return (
+    <div className="flex h-full min-h-0 flex-col overflow-hidden">
+      <div className="flex h-9 shrink-0 items-center justify-between border-b border-[#eceef0] px-3 text-[11px] text-[rgba(22,24,35,0.46)]">
+        <span>查询结果</span>
+        <span>
+          共 {tablePayload.rows.length} 行
+          {tablePayload.affectedRows !== undefined
+            ? ` · 影响 ${tablePayload.affectedRows} 行`
+            : ''}
+        </span>
+      </div>
+      <div className="min-h-0 flex-1 overflow-auto">
+        <Table<Record<string, unknown>>
+          rowKey={(_, index) => String(index)}
+          size="small"
+          pagination={false}
+          columns={columns}
+          dataSource={tablePayload.rows}
+          scroll={{ x: 'max-content' }}
+          className="[&_.ant-table-thead>tr>th]:!bg-[#fafbfc] [&_.ant-table-thead>tr>th]:!text-[11px] [&_.ant-table-tbody>tr>td]:!py-2"
+        />
+      </div>
+    </div>
+  );
+};
+
+export default TableExecutionResultRenderer;

--- a/yak-ops-ui/src/pages/data-development/workbench/execution/renderers/TerminalExecutionResultRenderer.tsx
+++ b/yak-ops-ui/src/pages/data-development/workbench/execution/renderers/TerminalExecutionResultRenderer.tsx
@@ -1,0 +1,39 @@
+import { Tag } from 'antd';
+import type { ExecutionResultRendererProps } from '../types';
+
+const TerminalExecutionResultRenderer = ({
+  payload,
+}: ExecutionResultRendererProps) => {
+  if (payload.kind !== 'terminal') return null;
+
+  return (
+    <div className="flex h-full min-h-0 flex-col overflow-hidden bg-[#111418] text-[#d5dae0]">
+      <div className="flex h-9 shrink-0 items-center justify-between border-b border-white/10 px-3">
+        <span className="text-[11px] text-white/55">Terminal Output</span>
+        <Tag
+          bordered={false}
+          className="!m-0 !bg-white/10 !text-[10px] !text-white/70"
+        >
+          exit code {payload.exitCode}
+        </Tag>
+      </div>
+      <div className="min-h-0 flex-1 overflow-auto p-4 font-mono text-[12px] leading-6">
+        {payload.stdout.map((line, index) => (
+          <div key={`stdout-${index}`} className="whitespace-pre-wrap">
+            {line}
+          </div>
+        ))}
+        {payload.stderr.map((line, index) => (
+          <div
+            key={`stderr-${index}`}
+            className="whitespace-pre-wrap text-[#ff8c8c]"
+          >
+            {line}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default TerminalExecutionResultRenderer;

--- a/yak-ops-ui/src/pages/data-development/workbench/execution/renderers/TextExecutionResultRenderer.tsx
+++ b/yak-ops-ui/src/pages/data-development/workbench/execution/renderers/TextExecutionResultRenderer.tsx
@@ -1,0 +1,26 @@
+import { FileText } from 'lucide-react';
+import type { ExecutionResultRendererProps } from '../types';
+
+const TextExecutionResultRenderer = ({
+  payload,
+}: ExecutionResultRendererProps) => {
+  if (payload.kind !== 'text') return null;
+
+  return (
+    <div className="flex h-full items-center justify-center bg-[#fafbfc] p-8">
+      <div className="max-w-[520px] text-center">
+        <span className="mx-auto flex h-11 w-11 items-center justify-center rounded-xl bg-[var(--yak-brand-color-soft)] text-[var(--yak-brand-color)]">
+          <FileText size={21} />
+        </span>
+        <h3 className="mb-1 mt-3 text-[14px] font-semibold text-[#161823]">
+          {payload.title}
+        </h3>
+        <p className="m-0 text-[12px] leading-6 text-[rgba(22,24,35,0.5)]">
+          {payload.value}
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default TextExecutionResultRenderer;

--- a/yak-ops-ui/src/pages/data-development/workbench/execution/store/execution-panel.store.ts
+++ b/yak-ops-ui/src/pages/data-development/workbench/execution/store/execution-panel.store.ts
@@ -1,0 +1,200 @@
+import { create } from 'zustand';
+import type {
+  DevelopmentResource,
+  NodePluginDefinition,
+} from '../../core/types';
+import {
+  completeMockExecutionSession,
+  createRunningExecutionSession,
+} from '../mock-results';
+import type {
+  ExecutionPanelTabKey,
+  ExecutionSession,
+} from '../types';
+
+const PANEL_MIN_HEIGHT = 190;
+const PANEL_MAX_HEIGHT = 640;
+const PANEL_DEFAULT_HEIGHT = 330;
+
+interface ExecutionPanelStoreState {
+  sessionsById: Record<string, ExecutionSession>;
+  sessionIdsByResourceId: Record<string, string[]>;
+  activeSessionIdByResourceId: Record<string, string | undefined>;
+  visible: boolean;
+  height: number;
+  maximized: boolean;
+  activeTab: ExecutionPanelTabKey;
+
+  setVisible: (visible: boolean) => void;
+  setHeight: (height: number) => void;
+  setMaximized: (maximized: boolean) => void;
+  setActiveTab: (tab: ExecutionPanelTabKey) => void;
+  openForResource: (
+    resourceId: string,
+    tab?: ExecutionPanelTabKey,
+  ) => void;
+  startExecution: (
+    resource: DevelopmentResource,
+    plugin: NodePluginDefinition,
+  ) => string;
+  completeExecution: (
+    executionId: string,
+    resource: DevelopmentResource,
+  ) => void;
+  stopExecution: (resourceId: string) => void;
+  selectSession: (resourceId: string, sessionId: string) => void;
+  clearResourceSessions: (resourceId: string) => void;
+}
+
+const clampHeight = (height: number) =>
+  Math.min(PANEL_MAX_HEIGHT, Math.max(PANEL_MIN_HEIGHT, Math.round(height)));
+
+export const useExecutionPanelStore = create<ExecutionPanelStoreState>(
+  (set, get) => ({
+    sessionsById: {},
+    sessionIdsByResourceId: {},
+    activeSessionIdByResourceId: {},
+    visible: false,
+    height: PANEL_DEFAULT_HEIGHT,
+    maximized: false,
+    activeTab: 'result',
+
+    setVisible: (visible) => set({ visible }),
+    setHeight: (height) =>
+      set({ height: clampHeight(height), maximized: false }),
+    setMaximized: (maximized) =>
+      set({
+        maximized,
+        height: maximized ? PANEL_MAX_HEIGHT : PANEL_DEFAULT_HEIGHT,
+      }),
+    setActiveTab: (activeTab) => set({ activeTab }),
+
+    openForResource: (resourceId, tab = 'result') =>
+      set((state) => ({
+        visible: true,
+        activeTab: tab,
+        activeSessionIdByResourceId: {
+          ...state.activeSessionIdByResourceId,
+          [resourceId]:
+            state.activeSessionIdByResourceId[resourceId] ??
+            state.sessionIdsByResourceId[resourceId]?.[0],
+        },
+      })),
+
+    startExecution: (resource, plugin) => {
+      const session = createRunningExecutionSession(resource, plugin);
+
+      set((state) => ({
+        sessionsById: {
+          ...state.sessionsById,
+          [session.id]: session,
+        },
+        sessionIdsByResourceId: {
+          ...state.sessionIdsByResourceId,
+          [resource.id]: [
+            session.id,
+            ...(state.sessionIdsByResourceId[resource.id] ?? []),
+          ],
+        },
+        activeSessionIdByResourceId: {
+          ...state.activeSessionIdByResourceId,
+          [resource.id]: session.id,
+        },
+        visible: true,
+        activeTab: 'output',
+      }));
+
+      return session.id;
+    },
+
+    completeExecution: (executionId, resource) =>
+      set((state) => {
+        const session = state.sessionsById[executionId];
+        if (!session || session.status !== 'RUNNING') return state;
+
+        return {
+          sessionsById: {
+            ...state.sessionsById,
+            [executionId]: completeMockExecutionSession(session, resource),
+          },
+          activeTab:
+            state.activeSessionIdByResourceId[resource.id] === executionId
+              ? 'result'
+              : state.activeTab,
+          visible: true,
+        };
+      }),
+
+    stopExecution: (resourceId) =>
+      set((state) => {
+        const activeSessionId =
+          state.activeSessionIdByResourceId[resourceId];
+        const session = activeSessionId
+          ? state.sessionsById[activeSessionId]
+          : undefined;
+        if (!activeSessionId || !session) return state;
+
+        const finishedAt = new Date().toISOString();
+        return {
+          sessionsById: {
+            ...state.sessionsById,
+            [activeSessionId]: {
+              ...session,
+              status: 'STOPPED',
+              finishedAt,
+              durationMs:
+                new Date(finishedAt).getTime() -
+                new Date(session.startedAt).getTime(),
+              logs: [
+                ...session.logs,
+                {
+                  id: `${activeSessionId}-stopped`,
+                  level: 'WARN',
+                  timestamp: new Intl.DateTimeFormat('zh-CN', {
+                    hour: '2-digit',
+                    minute: '2-digit',
+                    second: '2-digit',
+                    hour12: false,
+                  }).format(new Date()),
+                  message: '用户提交停止请求，执行已中止',
+                },
+              ],
+            },
+          },
+          visible: true,
+          activeTab: 'output',
+        };
+      }),
+
+    selectSession: (resourceId, sessionId) =>
+      set((state) => ({
+        activeSessionIdByResourceId: {
+          ...state.activeSessionIdByResourceId,
+          [resourceId]: sessionId,
+        },
+      })),
+
+    clearResourceSessions: (resourceId) => {
+      const state = get();
+      const sessionIds = state.sessionIdsByResourceId[resourceId] ?? [];
+      const nextSessions = { ...state.sessionsById };
+      sessionIds.forEach((sessionId) => delete nextSessions[sessionId]);
+
+      set({
+        sessionsById: nextSessions,
+        sessionIdsByResourceId: {
+          ...state.sessionIdsByResourceId,
+          [resourceId]: [],
+        },
+        activeSessionIdByResourceId: {
+          ...state.activeSessionIdByResourceId,
+          [resourceId]: undefined,
+        },
+      });
+    },
+  }),
+);
+
+export const EXECUTION_PANEL_DEFAULT_HEIGHT = PANEL_DEFAULT_HEIGHT;
+export const EXECUTION_PANEL_MIN_HEIGHT = PANEL_MIN_HEIGHT;
+export const EXECUTION_PANEL_MAX_HEIGHT = PANEL_MAX_HEIGHT;

--- a/yak-ops-ui/src/pages/data-development/workbench/execution/types.ts
+++ b/yak-ops-ui/src/pages/data-development/workbench/execution/types.ts
@@ -1,0 +1,121 @@
+import type { ComponentType } from 'react';
+import type {
+  DevelopmentResource,
+  ExecutionStatus,
+  NodePluginDefinition,
+} from '../core/types';
+
+export type ExecutionPanelTabKey =
+  | 'problems'
+  | 'output'
+  | 'lineage'
+  | 'result'
+  | 'publish'
+  | 'validation'
+  | 'quality';
+
+export interface ExecutionLogEntry {
+  id: string;
+  level: 'INFO' | 'WARN' | 'ERROR';
+  timestamp: string;
+  message: string;
+}
+
+export interface TableExecutionResult {
+  kind: 'table';
+  columns: Array<{
+    key: string;
+    title: string;
+    dataType: string;
+  }>;
+  rows: Array<Record<string, string | number | boolean | null>>;
+  affectedRows?: number;
+}
+
+export interface JsonExecutionResult {
+  kind: 'json';
+  statusCode: number;
+  statusText: string;
+  elapsedMs: number;
+  headers: Record<string, string>;
+  body: unknown;
+}
+
+export interface TerminalExecutionResult {
+  kind: 'terminal';
+  exitCode: number;
+  stdout: string[];
+  stderr: string[];
+}
+
+export interface NotebookExecutionResult {
+  kind: 'notebook';
+  cells: Array<{
+    id: string;
+    label: string;
+    status: 'SUCCESS' | 'FAILED';
+    durationMs: number;
+    output: string;
+  }>;
+}
+
+export interface PipelineExecutionResult {
+  kind: 'pipeline';
+  processedRows: number;
+  writtenRows: number;
+  rejectedRows: number;
+  throughput: number;
+  stages: Array<{
+    id: string;
+    label: string;
+    status: 'SUCCESS' | 'RUNNING' | 'FAILED';
+    rows: number;
+    durationMs: number;
+  }>;
+}
+
+export interface TextExecutionResult {
+  kind: 'text';
+  title: string;
+  value: string;
+}
+
+export type ExecutionResultPayload =
+  | TableExecutionResult
+  | JsonExecutionResult
+  | TerminalExecutionResult
+  | NotebookExecutionResult
+  | PipelineExecutionResult
+  | TextExecutionResult;
+
+export interface ExecutionSession {
+  id: string;
+  resourceId: string;
+  resourceType: string;
+  resourceName: string;
+  engine: string;
+  status: ExecutionStatus;
+  submittedAt: string;
+  startedAt: string;
+  finishedAt?: string;
+  durationMs?: number;
+  logs: ExecutionLogEntry[];
+  result?: ExecutionResultPayload;
+  errorMessage?: string;
+}
+
+export interface ExecutionResultDefinition {
+  resourceType: string;
+  rendererKey: string;
+  defaultTab?: ExecutionPanelTabKey;
+}
+
+export interface ExecutionResultRendererProps {
+  resource: DevelopmentResource;
+  plugin: NodePluginDefinition;
+  session: ExecutionSession;
+  payload: ExecutionResultPayload;
+}
+
+export type ExecutionResultRendererComponent =
+  ComponentType<ExecutionResultRendererProps>;


### PR DESCRIPTION
## 变更说明

为 `/data-development/workbench` 增加与编辑区上下贴合的运行结果面板。点击运行、测试请求或运行 Notebook 后，面板会从编辑区底部展开，不使用浮层覆盖编辑器。

### 面板交互

- 编辑器与运行面板使用同一个纵向 Flex 布局，面板展开时编辑器自动让出空间
- 支持拖动顶部横向分隔条调整高度
- 支持展开、缩小、恢复默认高度和关闭
- 运行中自动打开“输出”，运行完成后切换到“结果”
- 每个开发资源独立维护运行历史和当前选中的执行会话
- 公共展示执行 ID、状态、开始时间、结束时间和耗时

### 公共标签页

- 问题
- 输出
- 血缘
- 结果
- 发布
- 深度检查
- 质量测试

血缘、发布和质量测试本次先搭建前端框架，后续再接入真实服务。

### 节点专属结果

通过 `ExecutionResultDefinitionRegistry` 与 `ExecutionResultRendererRegistry` 动态选择结果组件：

- SQL / Flink SQL：表格结果
- HTTP：状态码、响应头与 JSON Body
- Shell / Python：Terminal 输出与退出码
- Notebook：Cell 执行结果
- 数据集成：处理行数、吞吐与阶段状态
- 资源文件及未知类型：文本兜底

新增节点时只需注册 `resourceType -> rendererKey` 和对应 Renderer，无需修改底部面板外壳。

### 状态与命令

- 新增独立 Zustand `execution-panel.store`，避免编辑器文档高频更新影响执行面板
- `execution.run`、`sql.run-statement`、`http.test`、`notebook.run-all` 统一创建执行会话
- `execution.stop` 同步停止当前运行会话
- 深度检查、发布和查看 HTTP 响应可直接打开对应面板标签
- 当前使用 Mock 执行事件和结果，接口接入时可替换为后端 `executionId` 与 SSE/WebSocket 事件流

### 文档

新增 `docs/data-development/execution-bottom-panel.md`，说明：

- 面板布局与拖拽交互
- 公共能力和节点差异
- 执行会话数据模型
- Result Registry 扩展方式
- 后端运行接口与事件流建议

## 验证建议

1. 打开 `/data-development/workbench`
2. 运行 SQL，观察面板自动展开、输出日志和表格结果
3. 拖动面板顶部横线改变高度
4. 切换 HTTP、Shell、Notebook、数据集成节点并运行，检查不同结果 Renderer
5. 切换资源标签，检查各资源运行历史相互独立
6. 检查停止、关闭、展开和恢复默认高度操作

## 当前验证范围

- 已对新增和修改的 TS/TSX 文件执行 TypeScript transpile 语法检查
- 当前工具环境未执行完整 `npm install && npm run build`
- 真实执行接口、增量日志、分页结果、结果导出、血缘图和质量报告不在本 PR 范围内

因此本 PR 先保持 Draft 状态。