### PR TITLE
feat(data-development): scaffold backend task authoring architecture

### DIFF
--- a/docs/data-development/backend-architecture.md
+++ b/docs/data-development/backend-architecture.md
@@ -1,0 +1,120 @@
+# Yak Ops 数据开发后端架构
+
+本文档定义数据开发控制面的后端边界。当前阶段不处理工作流和 Cron 调度，专注完成项目目录、任务开发、草稿、发布版本和测试运行快照。
+
+## 1. 领域边界
+
+```text
+Resource Workspace
+  Project -> Folder / Task / Asset
+
+Task Authoring
+  Task -> Draft Revision -> Immutable Task Version
+
+Task Execution
+  Execution -> Attempt -> Event / Result
+```
+
+资源树只保存名称、目录关系、负责人和排序；任务正文、运行参数、版本和执行结果不进入 `yak_dev_resource`。
+
+## 2. Task Plugin 统一入口
+
+新增通用 `TaskPluginFactory` 和 `TaskPluginCatalog`：
+
+- 新插件可以直接通过 Java `ServiceLoader` 实现通用 Factory；
+- 现有 `WorkflowTaskPluginFactory` 会被自动适配，因此 HTTP / Shell 不需要复制实现；
+- 数据开发与未来编排层可以共享同一个 `taskType`、插件版本和配置规范；
+- 插件负责默认定义、规范化、校验和编译；控制面只负责生命周期与持久化。
+
+当前适配链路：
+
+```text
+HTTP / Shell WorkflowTaskPluginFactory
+                ↓ adapter
+         TaskPluginCatalog
+                ↓
+     Data Development Service
+```
+
+后续新增 SQL、Flink SQL、Python、Notebook 和数据集成插件时，应优先直接实现通用 `TaskPluginFactory`。
+
+## 3. 统一任务信封
+
+```json
+{
+  "schemaVersion": 1,
+  "taskType": "HTTP",
+  "pluginVersion": "1.0.0",
+  "content": { "kind": "form", "value": {} },
+  "config": {},
+  "runtime": { "common": {}, "specific": {} },
+  "inputs": {},
+  "outputs": {}
+}
+```
+
+插件可以把可视化内容编译成不同的执行 Spec。任务版本同时保存：
+
+- `definition_snapshot`：用于回看和重新编辑；
+- `compiled_spec`：用于稳定执行；
+- 输入输出 Schema；
+- 内容 SHA-256。
+
+## 4. 草稿与发布
+
+草稿使用乐观锁：
+
+```text
+PUT draft(baseRevision = 12)
+  -> UPDATE ... WHERE revision = 12
+  -> revision = 13
+```
+
+更新行数为 0 时返回冲突，不允许静默覆盖其他用户的修改。
+
+发布过程在单个事务中完成：锁定 Task / Draft，校验 revision，插件编译，创建不可变版本，再更新当前发布版本指针。发布版本只新增，不更新历史快照。
+
+## 5. 测试运行来源
+
+`yak_dev_execution.source_type` 支持：
+
+- `DRAFT_REVISION`：执行已保存草稿；
+- `PUBLISHED_VERSION`：执行不可变发布版本；
+- `EPHEMERAL_SNAPSHOT`：执行未保存内容或 SQL 当前语句。
+
+Execution 保存完整 definition、compiled spec、runtime 和 input 快照。本 PR 先创建执行账本并提供查询、列表和取消接口，不在控制面进程内直接运行 Shell / Python；真正执行由后续 Execution Gateway / Worker 接管。
+
+## 6. 数据表
+
+第一版 Flyway 创建 `yak_dev_project`、`yak_dev_resource`、`yak_dev_task`、`yak_dev_task_draft`、`yak_dev_task_version`、`yak_dev_execution`、`yak_dev_execution_attempt`、`yak_dev_execution_event`、`yak_dev_execution_result` 和 `yak_dev_user_favorite`。
+
+其中 `resource.id == task.id`，工作台、版本和执行统一使用一个稳定 Task ID。
+
+## 7. API
+
+```text
+GET  /api/v1/data-development/task-plugins
+POST /api/v1/data-development/projects
+GET  /api/v1/data-development/projects
+GET  /api/v1/data-development/projects/{projectId}/resources
+POST /api/v1/data-development/projects/{projectId}/folders
+POST /api/v1/data-development/projects/{projectId}/tasks
+GET  /api/v1/data-development/tasks/{taskId}
+PUT  /api/v1/data-development/tasks/{taskId}/draft
+POST /api/v1/data-development/tasks/{taskId}/validate
+POST /api/v1/data-development/tasks/{taskId}/versions
+GET  /api/v1/data-development/tasks/{taskId}/versions
+POST /api/v1/data-development/tasks/{taskId}/executions
+GET  /api/v1/data-development/tasks/{taskId}/executions
+GET  /api/v1/data-development/executions/{executionId}
+POST /api/v1/data-development/executions/{executionId}/cancel
+```
+
+## 8. 后续阶段
+
+1. 前端 Workbench 从 Mock Repository 切换到上述资源、草稿和插件目录 API。
+2. 增加执行 Gateway、Attempt 状态机和 Worker 隔离。
+3. 增加 SSE 事件流，对接底部运行结果面板。
+4. SQL 表格结果使用分页 Dataset，不将大结果直接写入 MySQL。
+5. 插件增加 schema migration，支持历史任务定义升级。
+6. 增加资源权限、收藏、审计和版本 Diff。

--- a/yak-ops-boot/pom.xml
+++ b/yak-ops-boot/pom.xml
@@ -22,6 +22,11 @@
         </dependency>
         <dependency>
             <groupId>io.yak.ops</groupId>
+            <artifactId>yak-ops-business-data-development</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.yak.ops</groupId>
             <artifactId>yak-ops-business-job</artifactId>
         </dependency>
         <dependency>

--- a/yak-ops-boot/src/test/resources/application-test.yml
+++ b/yak-ops-boot/src/test/resources/application-test.yml
@@ -22,6 +22,8 @@ yak:
       enabled: false
   datasource:
     enabled: false
+  data-development:
+    enabled: false
   resource:
     enabled: false
     storage:

--- a/yak-ops-business/pom.xml
+++ b/yak-ops-business/pom.xml
@@ -19,6 +19,7 @@
 
     <modules>
         <module>yak-ops-business-datasource</module>
+        <module>yak-ops-business-data-development</module>
         <module>yak-ops-business-job</module>
         <module>yak-ops-business-workflow</module>
         <module>yak-ops-business-quality</module>

--- a/yak-ops-business/yak-ops-business-data-development/pom.xml
+++ b/yak-ops-business/yak-ops-business-data-development/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.yak.ops</groupId>
+        <artifactId>yak-ops-business</artifactId>
+        <version>1.0.0</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>yak-ops-business-data-development</artifactId>
+
+    <name>Yak Ops Business Data Development</name>
+    <description>Data-development workspace, task authoring, immutable versions and execution snapshots</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.yak.ops</groupId>
+            <artifactId>yak-ops-plugin-task-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.yak.ops</groupId>
+            <artifactId>yak-ops-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-jdbc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-mysql</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/api/DataDevelopmentApi.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/api/DataDevelopmentApi.java
@@ -1,0 +1,90 @@
+package io.yak.ops.business.development.api;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.yak.ops.business.development.domain.DataDevelopmentModel.Draft;
+import io.yak.ops.business.development.domain.DataDevelopmentModel.Resource;
+import io.yak.ops.business.development.domain.DataDevelopmentModel.Task;
+import io.yak.ops.plugin.task.api.TaskPluginFactory.Descriptor;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import java.util.List;
+
+/** REST request and composite view contracts for data development. */
+public final class DataDevelopmentApi {
+
+  private DataDevelopmentApi() {
+  }
+
+  public record CreateProjectRequest(
+      @NotBlank String code,
+      @NotBlank String name,
+      String description) {
+  }
+
+  public record CreateFolderRequest(
+      Long parentId,
+      @NotBlank String name,
+      String description,
+      Integer sortOrder) {
+  }
+
+  public record CreateTaskRequest(
+      Long parentId,
+      @NotBlank String name,
+      String description,
+      @NotBlank String taskType,
+      String engineType,
+      Integer sortOrder) {
+  }
+
+  public record UpdateResourceRequest(
+      @NotBlank String name,
+      String description,
+      Integer sortOrder) {
+  }
+
+  public record MoveResourceRequest(
+      Long parentId,
+      Integer sortOrder) {
+  }
+
+  public record SaveDraftRequest(
+      @NotNull @PositiveOrZero Long baseRevision,
+      @NotNull JsonNode definition) {
+  }
+
+  public record ValidateTaskRequest(JsonNode definition) {
+  }
+
+  public record PublishTaskRequest(
+      @NotNull @PositiveOrZero Long draftRevision,
+      String comment) {
+  }
+
+  public record CreateExecutionRequest(
+      @NotBlank String sourceType,
+      Long draftRevision,
+      Long taskVersionId,
+      JsonNode definitionSnapshot,
+      JsonNode runtime,
+      JsonNode input,
+      String idempotencyKey) {
+  }
+
+  public record TaskPluginView(Descriptor descriptor) {
+  }
+
+  public record TaskDetailView(
+      Resource resource,
+      Task task,
+      Draft draft) {
+  }
+
+  public record ValidationView(
+      boolean valid,
+      JsonNode normalizedDefinition,
+      String contentDigest,
+      List<String> warnings) {
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/config/ConditionalOnDataDevelopmentEnabled.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/config/ConditionalOnDataDevelopmentEnabled.java
@@ -1,0 +1,18 @@
+package io.yak.ops.business.development.config;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+
+/** Enables data-development control-plane beans. */
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@ConditionalOnProperty(
+    prefix = "yak.data-development",
+    name = "enabled",
+    havingValue = "true",
+    matchIfMissing = true)
+public @interface ConditionalOnDataDevelopmentEnabled {
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/config/DataDevelopmentConfiguration.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/config/DataDevelopmentConfiguration.java
@@ -1,0 +1,80 @@
+package io.yak.ops.business.development.config;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import io.yak.ops.business.development.repository.DataDevelopmentRepository;
+import io.yak.ops.business.development.service.DataDevelopmentJsonCodec;
+import io.yak.ops.plugin.task.api.TaskPluginCatalog;
+import javax.sql.DataSource;
+import org.flywaydb.core.Flyway;
+import org.flywaydb.core.api.MigrationVersion;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.transaction.PlatformTransactionManager;
+
+/** Data-development datasource, Flyway and plugin-catalog assembly. */
+@ConditionalOnDataDevelopmentEnabled
+@Configuration(proxyBeanMethods = false)
+@EnableConfigurationProperties(DataDevelopmentProperties.class)
+public class DataDevelopmentConfiguration {
+
+  @Bean(name = "dataDevelopmentDataSource", destroyMethod = "close")
+  public HikariDataSource dataDevelopmentDataSource(DataDevelopmentProperties properties) {
+    DataDevelopmentProperties.Datasource datasource = properties.getDatasource();
+    HikariConfig config = new HikariConfig();
+    config.setPoolName("YakDataDevelopmentPool");
+    config.setJdbcUrl(datasource.getUrl());
+    config.setUsername(datasource.getUsername());
+    config.setPassword(datasource.getPassword());
+    config.setDriverClassName(datasource.getDriverClassName());
+    config.setMaximumPoolSize(datasource.getMaximumPoolSize());
+    config.setMinimumIdle(datasource.getMinimumIdle());
+    config.setAutoCommit(true);
+    return new HikariDataSource(config);
+  }
+
+  @Bean(name = "dataDevelopmentTransactionManager")
+  public PlatformTransactionManager dataDevelopmentTransactionManager(
+      @Qualifier("dataDevelopmentDataSource") DataSource dataSource) {
+    return new DataSourceTransactionManager(dataSource);
+  }
+
+  @Bean(name = "dataDevelopmentJdbcTemplate")
+  public NamedParameterJdbcTemplate dataDevelopmentJdbcTemplate(
+      @Qualifier("dataDevelopmentDataSource") DataSource dataSource) {
+    return new NamedParameterJdbcTemplate(dataSource);
+  }
+
+  @Bean(initMethod = "migrate")
+  public Flyway dataDevelopmentFlyway(
+      @Qualifier("dataDevelopmentDataSource") DataSource dataSource) {
+    return Flyway.configure()
+        .dataSource(dataSource)
+        .locations("classpath:db/migration/yak-data-development")
+        .table("yak_dev_schema_history")
+        .baselineVersion(MigrationVersion.fromVersion("0"))
+        .baselineOnMigrate(true)
+        .load();
+  }
+
+  @Bean
+  public TaskPluginCatalog dataDevelopmentTaskPluginCatalog() {
+    return new TaskPluginCatalog();
+  }
+
+  @Bean
+  public DataDevelopmentJsonCodec dataDevelopmentJsonCodec() {
+    return new DataDevelopmentJsonCodec();
+  }
+
+  @Bean
+  public DataDevelopmentRepository dataDevelopmentRepository(
+      @Qualifier("dataDevelopmentJdbcTemplate") NamedParameterJdbcTemplate jdbcTemplate,
+      DataDevelopmentJsonCodec jsonCodec) {
+    return new DataDevelopmentRepository(jdbcTemplate, jsonCodec);
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/config/DataDevelopmentProperties.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/config/DataDevelopmentProperties.java
@@ -1,0 +1,81 @@
+package io.yak.ops.business.development.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/** Persistence settings for the data-development control plane. */
+@ConfigurationProperties(prefix = "yak.data-development")
+public class DataDevelopmentProperties {
+
+  private boolean enabled = true;
+  private final Datasource datasource = new Datasource();
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  public Datasource getDatasource() {
+    return datasource;
+  }
+
+  public static class Datasource {
+
+    private String url = "jdbc:mysql://127.0.0.1:3306/yak_security?useUnicode=true&allowPublicKeyRetrieval=true&characterEncoding=UTF-8&useSSL=false&serverTimezone=Asia/Shanghai";
+    private String username = "root";
+    private String password = "123456";
+    private String driverClassName = "com.mysql.cj.jdbc.Driver";
+    private int maximumPoolSize = 8;
+    private int minimumIdle = 1;
+
+    public String getUrl() {
+      return url;
+    }
+
+    public void setUrl(String url) {
+      this.url = url;
+    }
+
+    public String getUsername() {
+      return username;
+    }
+
+    public void setUsername(String username) {
+      this.username = username;
+    }
+
+    public String getPassword() {
+      return password;
+    }
+
+    public void setPassword(String password) {
+      this.password = password;
+    }
+
+    public String getDriverClassName() {
+      return driverClassName;
+    }
+
+    public void setDriverClassName(String driverClassName) {
+      this.driverClassName = driverClassName;
+    }
+
+    public int getMaximumPoolSize() {
+      return maximumPoolSize;
+    }
+
+    public void setMaximumPoolSize(int maximumPoolSize) {
+      this.maximumPoolSize = maximumPoolSize;
+    }
+
+    public int getMinimumIdle() {
+      return minimumIdle;
+    }
+
+    public void setMinimumIdle(int minimumIdle) {
+      this.minimumIdle = minimumIdle;
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/controller/v1/DataDevelopmentController.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/controller/v1/DataDevelopmentController.java
@@ -1,0 +1,187 @@
+package io.yak.ops.business.development.controller.v1;
+
+import io.yak.framework.common.Result;
+import io.yak.ops.business.development.api.DataDevelopmentApi.CreateExecutionRequest;
+import io.yak.ops.business.development.api.DataDevelopmentApi.CreateFolderRequest;
+import io.yak.ops.business.development.api.DataDevelopmentApi.CreateProjectRequest;
+import io.yak.ops.business.development.api.DataDevelopmentApi.CreateTaskRequest;
+import io.yak.ops.business.development.api.DataDevelopmentApi.MoveResourceRequest;
+import io.yak.ops.business.development.api.DataDevelopmentApi.PublishTaskRequest;
+import io.yak.ops.business.development.api.DataDevelopmentApi.SaveDraftRequest;
+import io.yak.ops.business.development.api.DataDevelopmentApi.TaskDetailView;
+import io.yak.ops.business.development.api.DataDevelopmentApi.UpdateResourceRequest;
+import io.yak.ops.business.development.api.DataDevelopmentApi.ValidateTaskRequest;
+import io.yak.ops.business.development.api.DataDevelopmentApi.ValidationView;
+import io.yak.ops.business.development.config.ConditionalOnDataDevelopmentEnabled;
+import io.yak.ops.business.development.domain.DataDevelopmentModel.Draft;
+import io.yak.ops.business.development.domain.DataDevelopmentModel.Execution;
+import io.yak.ops.business.development.domain.DataDevelopmentModel.Project;
+import io.yak.ops.business.development.domain.DataDevelopmentModel.Resource;
+import io.yak.ops.business.development.domain.DataDevelopmentModel.Version;
+import io.yak.ops.business.development.service.DataDevelopmentService;
+import io.yak.ops.business.development.service.TaskPluginCatalogService;
+import io.yak.ops.plugin.task.api.TaskPluginFactory.Descriptor;
+import jakarta.validation.Valid;
+import java.util.List;
+import java.util.Map;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Data-development workspace, task authoring, publication and execution-snapshot API. */
+@ConditionalOnDataDevelopmentEnabled
+@RestController
+@RequestMapping("/api/v1/data-development")
+public class DataDevelopmentController {
+
+  private static final String OPERATOR_HEADER = "X-Operator";
+
+  private final DataDevelopmentService service;
+  private final TaskPluginCatalogService pluginCatalogService;
+
+  public DataDevelopmentController(
+      DataDevelopmentService service,
+      TaskPluginCatalogService pluginCatalogService) {
+    this.service = service;
+    this.pluginCatalogService = pluginCatalogService;
+  }
+
+  @GetMapping("/task-plugins")
+  public Result<List<Descriptor>> listTaskPlugins() {
+    return Result.success(pluginCatalogService.list());
+  }
+
+  @GetMapping("/task-plugins/{taskType}")
+  public Result<Descriptor> getTaskPlugin(@PathVariable String taskType) {
+    return Result.success(pluginCatalogService.require(taskType));
+  }
+
+  @PostMapping("/projects")
+  public Result<Project> createProject(
+      @Valid @RequestBody CreateProjectRequest request,
+      @RequestHeader(name = OPERATOR_HEADER, defaultValue = "system") String operator) {
+    return Result.success(service.createProject(request, operator));
+  }
+
+  @GetMapping("/projects")
+  public Result<List<Project>> listProjects() {
+    return Result.success(service.listProjects());
+  }
+
+  @GetMapping("/projects/{projectId}/resources")
+  public Result<List<Resource>> listResources(@PathVariable long projectId) {
+    return Result.success(service.listResources(projectId));
+  }
+
+  @PostMapping("/projects/{projectId}/folders")
+  public Result<Resource> createFolder(
+      @PathVariable long projectId,
+      @Valid @RequestBody CreateFolderRequest request,
+      @RequestHeader(name = OPERATOR_HEADER, defaultValue = "system") String operator) {
+    return Result.success(service.createFolder(projectId, request, operator));
+  }
+
+  @PostMapping("/projects/{projectId}/tasks")
+  public Result<TaskDetailView> createTask(
+      @PathVariable long projectId,
+      @Valid @RequestBody CreateTaskRequest request,
+      @RequestHeader(name = OPERATOR_HEADER, defaultValue = "system") String operator) {
+    return Result.success(service.createTask(projectId, request, operator));
+  }
+
+  @GetMapping("/tasks/{taskId}")
+  public Result<TaskDetailView> getTask(@PathVariable long taskId) {
+    return Result.success(service.getTask(taskId));
+  }
+
+  @PutMapping("/tasks/{taskId}/draft")
+  public Result<Draft> saveDraft(
+      @PathVariable long taskId,
+      @Valid @RequestBody SaveDraftRequest request,
+      @RequestHeader(name = OPERATOR_HEADER, defaultValue = "system") String operator) {
+    return Result.success(service.saveDraft(taskId, request, operator));
+  }
+
+  @PostMapping("/tasks/{taskId}/validate")
+  public Result<ValidationView> validateTask(
+      @PathVariable long taskId,
+      @RequestBody(required = false) ValidateTaskRequest request) {
+    return Result.success(service.validateTask(taskId, request));
+  }
+
+  @PostMapping("/tasks/{taskId}/versions")
+  public Result<Version> publishTask(
+      @PathVariable long taskId,
+      @Valid @RequestBody PublishTaskRequest request,
+      @RequestHeader(name = OPERATOR_HEADER, defaultValue = "system") String operator) {
+    return Result.success(service.publishTask(taskId, request, operator));
+  }
+
+  @GetMapping("/tasks/{taskId}/versions")
+  public Result<List<Version>> listVersions(@PathVariable long taskId) {
+    return Result.success(service.listVersions(taskId));
+  }
+
+  @GetMapping("/tasks/{taskId}/versions/{versionId}")
+  public Result<Version> getVersion(
+      @PathVariable long taskId,
+      @PathVariable long versionId) {
+    return Result.success(service.getVersion(taskId, versionId));
+  }
+
+  @PostMapping("/tasks/{taskId}/executions")
+  public Result<Execution> createExecution(
+      @PathVariable long taskId,
+      @Valid @RequestBody CreateExecutionRequest request,
+      @RequestHeader(name = OPERATOR_HEADER, defaultValue = "system") String operator) {
+    return Result.success(service.createExecution(taskId, request, operator));
+  }
+
+  @GetMapping("/tasks/{taskId}/executions")
+  public Result<List<Execution>> listExecutions(
+      @PathVariable long taskId,
+      @RequestParam(defaultValue = "50") int limit) {
+    return Result.success(service.listExecutions(taskId, limit));
+  }
+
+  @GetMapping("/executions/{executionId}")
+  public Result<Execution> getExecution(@PathVariable long executionId) {
+    return Result.success(service.getExecution(executionId));
+  }
+
+  @PostMapping("/executions/{executionId}/cancel")
+  public Result<Execution> cancelExecution(@PathVariable long executionId) {
+    return Result.success(service.cancelExecution(executionId));
+  }
+
+  @PutMapping("/resources/{resourceId}")
+  public Result<Resource> updateResource(
+      @PathVariable long resourceId,
+      @Valid @RequestBody UpdateResourceRequest request,
+      @RequestHeader(name = OPERATOR_HEADER, defaultValue = "system") String operator) {
+    return Result.success(service.updateResource(resourceId, request, operator));
+  }
+
+  @PostMapping("/resources/{resourceId}/move")
+  public Result<Resource> moveResource(
+      @PathVariable long resourceId,
+      @Valid @RequestBody MoveResourceRequest request,
+      @RequestHeader(name = OPERATOR_HEADER, defaultValue = "system") String operator) {
+    return Result.success(service.moveResource(resourceId, request, operator));
+  }
+
+  @DeleteMapping("/resources/{resourceId}")
+  public Result<Map<String, Boolean>> deleteResource(
+      @PathVariable long resourceId,
+      @RequestHeader(name = OPERATOR_HEADER, defaultValue = "system") String operator) {
+    service.deleteResource(resourceId, operator);
+    return Result.success(Map.of("deleted", true));
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/domain/DataDevelopmentModel.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/domain/DataDevelopmentModel.java
@@ -1,0 +1,140 @@
+package io.yak.ops.business.development.domain;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.time.LocalDateTime;
+
+/** Compact domain records for the data-development control plane. */
+public final class DataDevelopmentModel {
+
+  private DataDevelopmentModel() {
+  }
+
+  public enum ResourceKind {
+    FOLDER,
+    TASK,
+    ASSET
+  }
+
+  public enum TaskStatus {
+    DRAFT,
+    PUBLISHED,
+    ARCHIVED
+  }
+
+  public enum ExecutionSourceType {
+    DRAFT_REVISION,
+    PUBLISHED_VERSION,
+    EPHEMERAL_SNAPSHOT
+  }
+
+  public enum ExecutionStatus {
+    CREATED,
+    QUEUED,
+    RUNNING,
+    SUCCEEDED,
+    FAILED,
+    CANCELED,
+    TIMED_OUT,
+    LOST;
+
+    public boolean terminal() {
+      return this == SUCCEEDED
+          || this == FAILED
+          || this == CANCELED
+          || this == TIMED_OUT
+          || this == LOST;
+    }
+  }
+
+  public record Project(
+      Long id,
+      String code,
+      String name,
+      String description,
+      String createdBy,
+      LocalDateTime createdAt,
+      LocalDateTime updatedAt) {
+  }
+
+  public record Resource(
+      Long id,
+      Long projectId,
+      Long parentId,
+      ResourceKind resourceKind,
+      String name,
+      String description,
+      int sortOrder,
+      String ownerId,
+      String createdBy,
+      String updatedBy,
+      boolean deleted,
+      int lockVersion,
+      LocalDateTime createdAt,
+      LocalDateTime updatedAt) {
+  }
+
+  public record Task(
+      Long id,
+      Long projectId,
+      String taskType,
+      String pluginVersion,
+      int schemaVersion,
+      TaskStatus status,
+      long draftRevision,
+      Long publishedVersionId,
+      String engineType,
+      LocalDateTime createdAt,
+      LocalDateTime updatedAt) {
+  }
+
+  public record Draft(
+      Long taskId,
+      long revision,
+      String pluginVersion,
+      int schemaVersion,
+      JsonNode definition,
+      String contentDigest,
+      String updatedBy,
+      LocalDateTime updatedAt) {
+  }
+
+  public record Version(
+      Long id,
+      Long taskId,
+      int versionNumber,
+      String taskType,
+      String pluginVersion,
+      int schemaVersion,
+      JsonNode definitionSnapshot,
+      JsonNode compiledSpec,
+      JsonNode inputSchema,
+      JsonNode outputSchema,
+      String contentDigest,
+      String publishComment,
+      String publishedBy,
+      LocalDateTime publishedAt) {
+  }
+
+  public record Execution(
+      Long id,
+      Long taskId,
+      ExecutionSourceType sourceType,
+      Long draftRevision,
+      Long taskVersionId,
+      String taskType,
+      String pluginVersion,
+      JsonNode definitionSnapshot,
+      JsonNode compiledSpecSnapshot,
+      JsonNode runtimeSnapshot,
+      JsonNode inputSnapshot,
+      ExecutionStatus status,
+      int currentAttemptNo,
+      String idempotencyKey,
+      String createdBy,
+      LocalDateTime createdAt,
+      LocalDateTime startedAt,
+      LocalDateTime finishedAt,
+      String errorCode,
+      String errorMessage) {
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/DataDevelopmentRepository.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/DataDevelopmentRepository.java
@@ -1,0 +1,330 @@
+package io.yak.ops.business.development.repository;
+
+import io.yak.ops.business.development.domain.DataDevelopmentModel.Draft;
+import io.yak.ops.business.development.domain.DataDevelopmentModel.Execution;
+import io.yak.ops.business.development.domain.DataDevelopmentModel.ExecutionSourceType;
+import io.yak.ops.business.development.domain.DataDevelopmentModel.ExecutionStatus;
+import io.yak.ops.business.development.domain.DataDevelopmentModel.Project;
+import io.yak.ops.business.development.domain.DataDevelopmentModel.Resource;
+import io.yak.ops.business.development.domain.DataDevelopmentModel.ResourceKind;
+import io.yak.ops.business.development.domain.DataDevelopmentModel.Task;
+import io.yak.ops.business.development.domain.DataDevelopmentModel.TaskStatus;
+import io.yak.ops.business.development.domain.DataDevelopmentModel.Version;
+import io.yak.ops.business.development.service.DataDevelopmentJsonCodec;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.support.GeneratedKeyHolder;
+import org.springframework.jdbc.support.KeyHolder;
+
+/** JDBC persistence adapter for the data-development control plane. */
+public final class DataDevelopmentRepository {
+
+  private final NamedParameterJdbcTemplate jdbc;
+  private final DataDevelopmentJsonCodec json;
+
+  public DataDevelopmentRepository(NamedParameterJdbcTemplate jdbc, DataDevelopmentJsonCodec json) {
+    this.jdbc = jdbc;
+    this.json = json;
+  }
+
+  public long insertProject(String code, String name, String description, String operator, LocalDateTime now) {
+    return insert("""
+        INSERT INTO yak_dev_project(code,name,description,created_by,created_at,updated_at)
+        VALUES(:code,:name,:description,:operator,:now,:now)
+        """, p().addValue("code", code).addValue("name", name).addValue("description", description)
+        .addValue("operator", operator).addValue("now", ts(now)));
+  }
+
+  public List<Project> listProjects() {
+    return jdbc.query("SELECT * FROM yak_dev_project ORDER BY updated_at DESC,id DESC", p(), this::project);
+  }
+
+  public Optional<Project> findProject(long id) {
+    return one(jdbc.query("SELECT * FROM yak_dev_project WHERE id=:id", p("id", id), this::project));
+  }
+
+  public long insertResource(long projectId, Long parentId, ResourceKind kind, String name,
+      String description, int sortOrder, String operator, LocalDateTime now) {
+    try {
+      return insert("""
+          INSERT INTO yak_dev_resource(project_id,parent_id,resource_kind,name,description,sort_order,
+            owner_id,created_by,updated_by,deleted,lock_version,created_at,updated_at)
+          VALUES(:projectId,:parentId,:kind,:name,:description,:sortOrder,
+            :operator,:operator,:operator,0,0,:now,:now)
+          """, p().addValue("projectId", projectId).addValue("parentId", parent(parentId))
+          .addValue("kind", kind.name()).addValue("name", name).addValue("description", description)
+          .addValue("sortOrder", sortOrder).addValue("operator", operator).addValue("now", ts(now)));
+    } catch (DataIntegrityViolationException exception) {
+      throw new IllegalArgumentException("同一目录下已存在同名资源：" + name, exception);
+    }
+  }
+
+  public List<Resource> listResources(long projectId) {
+    return jdbc.query("""
+        SELECT * FROM yak_dev_resource WHERE project_id=:projectId AND deleted=0
+        ORDER BY parent_id,sort_order,name,id
+        """, p("projectId", projectId), this::resource);
+  }
+
+  public Optional<Resource> findResource(long id) {
+    return one(jdbc.query("SELECT * FROM yak_dev_resource WHERE id=:id AND deleted=0",
+        p("id", id), this::resource));
+  }
+
+  public int updateResource(long id, String name, String description, int sortOrder,
+      int lockVersion, String operator, LocalDateTime now) {
+    return jdbc.update("""
+        UPDATE yak_dev_resource SET name=:name,description=:description,sort_order=:sortOrder,
+          updated_by=:operator,updated_at=:now,lock_version=lock_version+1
+        WHERE id=:id AND deleted=0 AND lock_version=:lockVersion
+        """, p("id", id).addValue("name", name).addValue("description", description)
+        .addValue("sortOrder", sortOrder).addValue("operator", operator)
+        .addValue("now", ts(now)).addValue("lockVersion", lockVersion));
+  }
+
+  public int moveResource(long id, Long parentId, int sortOrder, int lockVersion,
+      String operator, LocalDateTime now) {
+    return jdbc.update("""
+        UPDATE yak_dev_resource SET parent_id=:parentId,sort_order=:sortOrder,
+          updated_by=:operator,updated_at=:now,lock_version=lock_version+1
+        WHERE id=:id AND deleted=0 AND lock_version=:lockVersion
+        """, p("id", id).addValue("parentId", parent(parentId)).addValue("sortOrder", sortOrder)
+        .addValue("operator", operator).addValue("now", ts(now)).addValue("lockVersion", lockVersion));
+  }
+
+  public int softDeleteResource(long id, String operator, LocalDateTime now) {
+    return jdbc.update("""
+        UPDATE yak_dev_resource SET deleted=1,updated_by=:operator,updated_at=:now,
+          lock_version=lock_version+1 WHERE id=:id AND deleted=0
+        """, p("id", id).addValue("operator", operator).addValue("now", ts(now)));
+  }
+
+  public boolean hasChildren(long id) {
+    Integer count = jdbc.queryForObject(
+        "SELECT COUNT(1) FROM yak_dev_resource WHERE parent_id=:id AND deleted=0", p("id", id), Integer.class);
+    return count != null && count > 0;
+  }
+
+  public void insertTask(long id, long projectId, String taskType, String pluginVersion,
+      int schemaVersion, String engineType, LocalDateTime now) {
+    jdbc.update("""
+        INSERT INTO yak_dev_task(id,project_id,task_type,plugin_version,schema_version,status,
+          draft_revision,published_version_id,engine_type,created_at,updated_at)
+        VALUES(:id,:projectId,:taskType,:pluginVersion,:schemaVersion,'DRAFT',0,NULL,:engineType,:now,:now)
+        """, p("id", id).addValue("projectId", projectId).addValue("taskType", taskType)
+        .addValue("pluginVersion", pluginVersion).addValue("schemaVersion", schemaVersion)
+        .addValue("engineType", engineType).addValue("now", ts(now)));
+  }
+
+  public Optional<Task> findTask(long id) {
+    return one(jdbc.query("SELECT * FROM yak_dev_task WHERE id=:id", p("id", id), this::task));
+  }
+
+  public Optional<Task> findTaskForUpdate(long id) {
+    return one(jdbc.query("SELECT * FROM yak_dev_task WHERE id=:id FOR UPDATE", p("id", id), this::task));
+  }
+
+  public void insertDraft(long taskId, String pluginVersion, int schemaVersion,
+      String definition, String digest, String operator, LocalDateTime now) {
+    jdbc.update("""
+        INSERT INTO yak_dev_task_draft(task_id,revision,plugin_version,schema_version,
+          definition_json,content_digest,updated_by,updated_at)
+        VALUES(:taskId,0,:pluginVersion,:schemaVersion,:definition,:digest,:operator,:now)
+        """, p("taskId", taskId).addValue("pluginVersion", pluginVersion)
+        .addValue("schemaVersion", schemaVersion).addValue("definition", definition)
+        .addValue("digest", digest).addValue("operator", operator).addValue("now", ts(now)));
+  }
+
+  public Optional<Draft> findDraft(long taskId) {
+    return one(jdbc.query("SELECT * FROM yak_dev_task_draft WHERE task_id=:taskId",
+        p("taskId", taskId), this::draft));
+  }
+
+  public Optional<Draft> findDraftForUpdate(long taskId) {
+    return one(jdbc.query("SELECT * FROM yak_dev_task_draft WHERE task_id=:taskId FOR UPDATE",
+        p("taskId", taskId), this::draft));
+  }
+
+  public int updateDraft(long taskId, long baseRevision, long nextRevision, String pluginVersion,
+      int schemaVersion, String definition, String digest, String operator, LocalDateTime now) {
+    return jdbc.update("""
+        UPDATE yak_dev_task_draft SET revision=:nextRevision,plugin_version=:pluginVersion,
+          schema_version=:schemaVersion,definition_json=:definition,content_digest=:digest,
+          updated_by=:operator,updated_at=:now
+        WHERE task_id=:taskId AND revision=:baseRevision
+        """, p("taskId", taskId).addValue("baseRevision", baseRevision)
+        .addValue("nextRevision", nextRevision).addValue("pluginVersion", pluginVersion)
+        .addValue("schemaVersion", schemaVersion).addValue("definition", definition)
+        .addValue("digest", digest).addValue("operator", operator).addValue("now", ts(now)));
+  }
+
+  public void updateTaskDraftMetadata(long taskId, long revision, String pluginVersion,
+      int schemaVersion, LocalDateTime now) {
+    jdbc.update("""
+        UPDATE yak_dev_task SET draft_revision=:revision,plugin_version=:pluginVersion,
+          schema_version=:schemaVersion,updated_at=:now WHERE id=:taskId
+        """, p("taskId", taskId).addValue("revision", revision)
+        .addValue("pluginVersion", pluginVersion).addValue("schemaVersion", schemaVersion)
+        .addValue("now", ts(now)));
+  }
+
+  public void archiveTask(long taskId, LocalDateTime now) {
+    jdbc.update("UPDATE yak_dev_task SET status='ARCHIVED',updated_at=:now WHERE id=:taskId",
+        p("taskId", taskId).addValue("now", ts(now)));
+  }
+
+  public int nextVersionNumber(long taskId) {
+    Integer value = jdbc.queryForObject(
+        "SELECT COALESCE(MAX(version_no),0)+1 FROM yak_dev_task_version WHERE task_id=:taskId",
+        p("taskId", taskId), Integer.class);
+    return value == null ? 1 : value;
+  }
+
+  public long insertVersion(long taskId, int versionNo, String taskType, String pluginVersion,
+      int schemaVersion, String definition, String compiledSpec, String inputSchema,
+      String outputSchema, String digest, String comment, String operator, LocalDateTime now) {
+    return insert("""
+        INSERT INTO yak_dev_task_version(task_id,version_no,task_type,plugin_version,schema_version,
+          definition_snapshot,compiled_spec,input_schema,output_schema,content_digest,publish_comment,
+          published_by,published_at)
+        VALUES(:taskId,:versionNo,:taskType,:pluginVersion,:schemaVersion,:definition,:compiledSpec,
+          :inputSchema,:outputSchema,:digest,:comment,:operator,:now)
+        """, p("taskId", taskId).addValue("versionNo", versionNo).addValue("taskType", taskType)
+        .addValue("pluginVersion", pluginVersion).addValue("schemaVersion", schemaVersion)
+        .addValue("definition", definition).addValue("compiledSpec", compiledSpec)
+        .addValue("inputSchema", inputSchema).addValue("outputSchema", outputSchema)
+        .addValue("digest", digest).addValue("comment", comment).addValue("operator", operator)
+        .addValue("now", ts(now)));
+  }
+
+  public void updateTaskPublished(long taskId, long versionId, LocalDateTime now) {
+    jdbc.update("""
+        UPDATE yak_dev_task SET status='PUBLISHED',published_version_id=:versionId,updated_at=:now
+        WHERE id=:taskId
+        """, p("taskId", taskId).addValue("versionId", versionId).addValue("now", ts(now)));
+  }
+
+  public List<Version> listVersions(long taskId) {
+    return jdbc.query("SELECT * FROM yak_dev_task_version WHERE task_id=:taskId ORDER BY version_no DESC",
+        p("taskId", taskId), this::version);
+  }
+
+  public Optional<Version> findVersion(long taskId, long versionId) {
+    return one(jdbc.query("SELECT * FROM yak_dev_task_version WHERE task_id=:taskId AND id=:versionId",
+        p("taskId", taskId).addValue("versionId", versionId), this::version));
+  }
+
+  public long insertExecution(long taskId, ExecutionSourceType sourceType, Long draftRevision,
+      Long taskVersionId, String taskType, String pluginVersion, String definition,
+      String compiledSpec, String runtime, String input, String idempotencyKey,
+      String operator, LocalDateTime now) {
+    try {
+      return insert("""
+          INSERT INTO yak_dev_execution(task_id,source_type,draft_revision,task_version_id,task_type,
+            plugin_version,definition_snapshot,compiled_spec_snapshot,runtime_snapshot,input_snapshot,
+            status,current_attempt_no,idempotency_key,created_by,created_at)
+          VALUES(:taskId,:sourceType,:draftRevision,:taskVersionId,:taskType,:pluginVersion,
+            :definition,:compiledSpec,:runtime,:input,'CREATED',0,:idempotencyKey,:operator,:now)
+          """, p("taskId", taskId).addValue("sourceType", sourceType.name())
+          .addValue("draftRevision", draftRevision).addValue("taskVersionId", taskVersionId)
+          .addValue("taskType", taskType).addValue("pluginVersion", pluginVersion)
+          .addValue("definition", definition).addValue("compiledSpec", compiledSpec)
+          .addValue("runtime", runtime).addValue("input", input)
+          .addValue("idempotencyKey", idempotencyKey).addValue("operator", operator)
+          .addValue("now", ts(now)));
+    } catch (DataIntegrityViolationException exception) {
+      throw new IllegalArgumentException("执行幂等键已存在：" + idempotencyKey, exception);
+    }
+  }
+
+  public Optional<Execution> findExecution(long id) {
+    return one(jdbc.query("SELECT * FROM yak_dev_execution WHERE id=:id", p("id", id), this::execution));
+  }
+
+  public List<Execution> listExecutions(long taskId, int limit) {
+    return jdbc.query("""
+        SELECT * FROM yak_dev_execution WHERE task_id=:taskId ORDER BY id DESC LIMIT :limit
+        """, p("taskId", taskId).addValue("limit", Math.min(200, Math.max(1, limit))), this::execution);
+  }
+
+  public int cancelExecution(long id, LocalDateTime now) {
+    return jdbc.update("""
+        UPDATE yak_dev_execution SET status='CANCELED',finished_at=:now
+        WHERE id=:id AND status IN ('CREATED','QUEUED','RUNNING')
+        """, p("id", id).addValue("now", ts(now)));
+  }
+
+  private long insert(String sql, MapSqlParameterSource parameters) {
+    KeyHolder holder = new GeneratedKeyHolder();
+    jdbc.update(sql, parameters, holder, new String[] {"id"});
+    Number key = holder.getKey();
+    if (key == null) throw new IllegalStateException("Database did not return a generated ID");
+    return key.longValue();
+  }
+
+  private Project project(ResultSet rs, int row) throws SQLException {
+    return new Project(rs.getLong("id"), rs.getString("code"), rs.getString("name"),
+        rs.getString("description"), rs.getString("created_by"), time(rs, "created_at"), time(rs, "updated_at"));
+  }
+
+  private Resource resource(ResultSet rs, int row) throws SQLException {
+    return new Resource(rs.getLong("id"), rs.getLong("project_id"), nullableLong(rs, "parent_id"),
+        ResourceKind.valueOf(rs.getString("resource_kind")), rs.getString("name"), rs.getString("description"),
+        rs.getInt("sort_order"), rs.getString("owner_id"), rs.getString("created_by"), rs.getString("updated_by"),
+        rs.getBoolean("deleted"), rs.getInt("lock_version"), time(rs, "created_at"), time(rs, "updated_at"));
+  }
+
+  private Task task(ResultSet rs, int row) throws SQLException {
+    return new Task(rs.getLong("id"), rs.getLong("project_id"), rs.getString("task_type"),
+        rs.getString("plugin_version"), rs.getInt("schema_version"), TaskStatus.valueOf(rs.getString("status")),
+        rs.getLong("draft_revision"), nullableLong(rs, "published_version_id"), rs.getString("engine_type"),
+        time(rs, "created_at"), time(rs, "updated_at"));
+  }
+
+  private Draft draft(ResultSet rs, int row) throws SQLException {
+    return new Draft(rs.getLong("task_id"), rs.getLong("revision"), rs.getString("plugin_version"),
+        rs.getInt("schema_version"), json.readTree(rs.getString("definition_json")),
+        rs.getString("content_digest"), rs.getString("updated_by"), time(rs, "updated_at"));
+  }
+
+  private Version version(ResultSet rs, int row) throws SQLException {
+    return new Version(rs.getLong("id"), rs.getLong("task_id"), rs.getInt("version_no"),
+        rs.getString("task_type"), rs.getString("plugin_version"), rs.getInt("schema_version"),
+        json.readTree(rs.getString("definition_snapshot")), json.readTree(rs.getString("compiled_spec")),
+        json.readTree(rs.getString("input_schema")), json.readTree(rs.getString("output_schema")),
+        rs.getString("content_digest"), rs.getString("publish_comment"), rs.getString("published_by"),
+        time(rs, "published_at"));
+  }
+
+  private Execution execution(ResultSet rs, int row) throws SQLException {
+    return new Execution(rs.getLong("id"), rs.getLong("task_id"),
+        ExecutionSourceType.valueOf(rs.getString("source_type")), nullableLong(rs, "draft_revision"),
+        nullableLong(rs, "task_version_id"), rs.getString("task_type"), rs.getString("plugin_version"),
+        json.readTree(rs.getString("definition_snapshot")), json.readTree(rs.getString("compiled_spec_snapshot")),
+        json.readTree(rs.getString("runtime_snapshot")), json.readTree(rs.getString("input_snapshot")),
+        ExecutionStatus.valueOf(rs.getString("status")), rs.getInt("current_attempt_no"),
+        rs.getString("idempotency_key"), rs.getString("created_by"), time(rs, "created_at"),
+        time(rs, "started_at"), time(rs, "finished_at"), rs.getString("error_code"), rs.getString("error_message"));
+  }
+
+  private static MapSqlParameterSource p() { return new MapSqlParameterSource(); }
+  private static MapSqlParameterSource p(String key, Object value) { return p().addValue(key, value); }
+  private static Timestamp ts(LocalDateTime value) { return Timestamp.valueOf(value); }
+  private static long parent(Long value) { return value == null ? 0L : value; }
+  private static Long nullableLong(ResultSet rs, String column) throws SQLException {
+    long value = rs.getLong(column); return rs.wasNull() ? null : value;
+  }
+  private static LocalDateTime time(ResultSet rs, String column) throws SQLException {
+    Timestamp value = rs.getTimestamp(column); return value == null ? null : value.toLocalDateTime();
+  }
+  private static <T> Optional<T> one(List<T> values) {
+    return values.isEmpty() ? Optional.empty() : Optional.of(values.getFirst());
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DataDevelopmentJsonCodec.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DataDevelopmentJsonCodec.java
@@ -1,0 +1,77 @@
+package io.yak.ops.business.development.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/** Canonical JSON serialization and SHA-256 digest support. */
+public final class DataDevelopmentJsonCodec {
+
+  private final ObjectMapper objectMapper = new ObjectMapper()
+      .findAndRegisterModules()
+      .enable(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY)
+      .enable(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS);
+
+  public JsonNode readTree(String json) {
+    if (json == null || json.isBlank()) {
+      return objectMapper.createObjectNode();
+    }
+    try {
+      return objectMapper.readTree(json);
+    } catch (JsonProcessingException exception) {
+      throw new IllegalStateException("Stored data-development JSON is invalid", exception);
+    }
+  }
+
+  public String write(JsonNode value) {
+    try {
+      return objectMapper.writeValueAsString(value == null
+          ? objectMapper.createObjectNode()
+          : value);
+    } catch (JsonProcessingException exception) {
+      throw new IllegalArgumentException("Unable to serialize data-development JSON", exception);
+    }
+  }
+
+  public JsonNode toTree(Object value) {
+    return objectMapper.valueToTree(value);
+  }
+
+  @SuppressWarnings("unchecked")
+  public Map<String, Object> toMap(JsonNode value) {
+    if (value == null || value.isNull()) {
+      return new LinkedHashMap<>();
+    }
+    if (!value.isObject()) {
+      throw new IllegalArgumentException("Task definition must be a JSON object");
+    }
+    return objectMapper.convertValue(value, LinkedHashMap.class);
+  }
+
+  public ObjectNode objectNode() {
+    return objectMapper.createObjectNode();
+  }
+
+  public String digest(JsonNode value) {
+    try {
+      MessageDigest digest = MessageDigest.getInstance("SHA-256");
+      byte[] bytes = write(value).getBytes(StandardCharsets.UTF_8);
+      byte[] hash = digest.digest(bytes);
+      StringBuilder result = new StringBuilder(hash.length * 2);
+      for (byte item : hash) {
+        result.append(String.format("%02x", item));
+      }
+      return result.toString();
+    } catch (NoSuchAlgorithmException exception) {
+      throw new IllegalStateException("SHA-256 is not available", exception);
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DataDevelopmentService.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DataDevelopmentService.java
@@ -1,0 +1,511 @@
+package io.yak.ops.business.development.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.yak.ops.business.development.api.DataDevelopmentApi.CreateExecutionRequest;
+import io.yak.ops.business.development.api.DataDevelopmentApi.CreateFolderRequest;
+import io.yak.ops.business.development.api.DataDevelopmentApi.CreateProjectRequest;
+import io.yak.ops.business.development.api.DataDevelopmentApi.CreateTaskRequest;
+import io.yak.ops.business.development.api.DataDevelopmentApi.MoveResourceRequest;
+import io.yak.ops.business.development.api.DataDevelopmentApi.PublishTaskRequest;
+import io.yak.ops.business.development.api.DataDevelopmentApi.SaveDraftRequest;
+import io.yak.ops.business.development.api.DataDevelopmentApi.TaskDetailView;
+import io.yak.ops.business.development.api.DataDevelopmentApi.UpdateResourceRequest;
+import io.yak.ops.business.development.api.DataDevelopmentApi.ValidateTaskRequest;
+import io.yak.ops.business.development.api.DataDevelopmentApi.ValidationView;
+import io.yak.ops.business.development.config.ConditionalOnDataDevelopmentEnabled;
+import io.yak.ops.business.development.domain.DataDevelopmentModel.Draft;
+import io.yak.ops.business.development.domain.DataDevelopmentModel.Execution;
+import io.yak.ops.business.development.domain.DataDevelopmentModel.ExecutionSourceType;
+import io.yak.ops.business.development.domain.DataDevelopmentModel.Project;
+import io.yak.ops.business.development.domain.DataDevelopmentModel.Resource;
+import io.yak.ops.business.development.domain.DataDevelopmentModel.ResourceKind;
+import io.yak.ops.business.development.domain.DataDevelopmentModel.Task;
+import io.yak.ops.business.development.domain.DataDevelopmentModel.Version;
+import io.yak.ops.business.development.repository.DataDevelopmentRepository;
+import io.yak.ops.plugin.task.api.TaskPluginCatalog;
+import io.yak.ops.plugin.task.api.TaskPluginFactory.CompiledDefinition;
+import io.yak.ops.plugin.task.api.TaskPluginFactory.Descriptor;
+import java.time.LocalDateTime;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+/**
+ * Application service for workspace resources, task drafts, immutable versions and execution
+ * snapshots.
+ */
+@ConditionalOnDataDevelopmentEnabled
+@Service
+public class DataDevelopmentService {
+
+  private final DataDevelopmentRepository repository;
+  private final TaskPluginCatalog taskPluginCatalog;
+  private final DataDevelopmentJsonCodec jsonCodec;
+
+  public DataDevelopmentService(
+      DataDevelopmentRepository repository,
+      TaskPluginCatalog taskPluginCatalog,
+      DataDevelopmentJsonCodec jsonCodec) {
+    this.repository = repository;
+    this.taskPluginCatalog = taskPluginCatalog;
+    this.jsonCodec = jsonCodec;
+  }
+
+  @Transactional(transactionManager = "dataDevelopmentTransactionManager", rollbackFor = Exception.class)
+  public Project createProject(CreateProjectRequest request, String operator) {
+    LocalDateTime now = LocalDateTime.now();
+    long id = repository.insertProject(
+        requireText(request.code(), "项目编码"),
+        requireText(request.name(), "项目名称"),
+        trimToNull(request.description()),
+        operator(operator),
+        now);
+    return repository.findProject(id).orElseThrow();
+  }
+
+  public List<Project> listProjects() {
+    return repository.listProjects();
+  }
+
+  public List<Resource> listResources(long projectId) {
+    requireProject(projectId);
+    return repository.listResources(projectId);
+  }
+
+  @Transactional(transactionManager = "dataDevelopmentTransactionManager", rollbackFor = Exception.class)
+  public Resource createFolder(long projectId, CreateFolderRequest request, String operator) {
+    requireProject(projectId);
+    requireParent(projectId, request.parentId());
+    long id = repository.insertResource(
+        projectId,
+        request.parentId(),
+        ResourceKind.FOLDER,
+        requireText(request.name(), "目录名称"),
+        trimToNull(request.description()),
+        valueOrZero(request.sortOrder()),
+        operator(operator),
+        LocalDateTime.now());
+    return requireResource(id);
+  }
+
+  @Transactional(transactionManager = "dataDevelopmentTransactionManager", rollbackFor = Exception.class)
+  public TaskDetailView createTask(
+      long projectId,
+      CreateTaskRequest request,
+      String operator) {
+    requireProject(projectId);
+    requireParent(projectId, request.parentId());
+    Descriptor descriptor = taskPluginCatalog.descriptor(request.taskType());
+    String currentOperator = operator(operator);
+    LocalDateTime now = LocalDateTime.now();
+
+    long taskId = repository.insertResource(
+        projectId,
+        request.parentId(),
+        ResourceKind.TASK,
+        requireText(request.name(), "任务名称"),
+        trimToNull(request.description()),
+        valueOrZero(request.sortOrder()),
+        currentOperator,
+        now);
+    repository.insertTask(
+        taskId,
+        projectId,
+        descriptor.taskType(),
+        descriptor.pluginVersion(),
+        descriptor.schemaVersion(),
+        StringUtils.hasText(request.engineType())
+            ? request.engineType().trim()
+            : descriptor.taskType(),
+        now);
+
+    JsonNode initialDefinition = jsonCodec.toTree(
+        taskPluginCatalog.defaultDefinition(descriptor.taskType()));
+    repository.insertDraft(
+        taskId,
+        descriptor.pluginVersion(),
+        descriptor.schemaVersion(),
+        jsonCodec.write(initialDefinition),
+        jsonCodec.digest(initialDefinition),
+        currentOperator,
+        now);
+    return getTask(taskId);
+  }
+
+  public TaskDetailView getTask(long taskId) {
+    return new TaskDetailView(
+        requireResource(taskId),
+        requireTask(taskId),
+        requireDraft(taskId));
+  }
+
+  @Transactional(transactionManager = "dataDevelopmentTransactionManager", rollbackFor = Exception.class)
+  public Resource updateResource(
+      long resourceId,
+      UpdateResourceRequest request,
+      String operator) {
+    Resource resource = requireResource(resourceId);
+    int updated = repository.updateResource(
+        resourceId,
+        requireText(request.name(), "资源名称"),
+        trimToNull(request.description()),
+        request.sortOrder() == null ? resource.sortOrder() : request.sortOrder(),
+        resource.lockVersion(),
+        operator(operator),
+        LocalDateTime.now());
+    requireOptimisticUpdate(updated, "资源已经被其他用户修改，请刷新后重试");
+    return requireResource(resourceId);
+  }
+
+  @Transactional(transactionManager = "dataDevelopmentTransactionManager", rollbackFor = Exception.class)
+  public Resource moveResource(
+      long resourceId,
+      MoveResourceRequest request,
+      String operator) {
+    Resource resource = requireResource(resourceId);
+    requireParent(resource.projectId(), request.parentId());
+    if (resource.resourceKind() == ResourceKind.FOLDER) {
+      ensureNotDescendant(resource, request.parentId());
+    }
+    int updated = repository.moveResource(
+        resourceId,
+        request.parentId(),
+        request.sortOrder() == null ? resource.sortOrder() : request.sortOrder(),
+        resource.lockVersion(),
+        operator(operator),
+        LocalDateTime.now());
+    requireOptimisticUpdate(updated, "资源已经被其他用户移动，请刷新后重试");
+    return requireResource(resourceId);
+  }
+
+  @Transactional(transactionManager = "dataDevelopmentTransactionManager", rollbackFor = Exception.class)
+  public void deleteResource(long resourceId, String operator) {
+    Resource resource = requireResource(resourceId);
+    if (resource.resourceKind() == ResourceKind.FOLDER && repository.hasChildren(resourceId)) {
+      throw new IllegalStateException("目录不为空，不能删除");
+    }
+    int updated = repository.softDeleteResource(
+        resourceId,
+        operator(operator),
+        LocalDateTime.now());
+    if (updated != 1) {
+      throw new IllegalStateException("资源删除失败或已经删除");
+    }
+    if (resource.resourceKind() == ResourceKind.TASK) {
+      repository.archiveTask(resourceId, LocalDateTime.now());
+    }
+  }
+
+  @Transactional(transactionManager = "dataDevelopmentTransactionManager", rollbackFor = Exception.class)
+  public Draft saveDraft(long taskId, SaveDraftRequest request, String operator) {
+    Task task = requireTask(taskId);
+    Descriptor descriptor = taskPluginCatalog.descriptor(task.taskType());
+    Map<String, Object> normalized = taskPluginCatalog.normalizeDefinition(
+        task.taskType(),
+        jsonCodec.toMap(request.definition()));
+    taskPluginCatalog.validateDefinition(task.taskType(), normalized);
+
+    JsonNode normalizedDefinition = jsonCodec.toTree(normalized);
+    long nextRevision = request.baseRevision() + 1L;
+    LocalDateTime now = LocalDateTime.now();
+    int updated = repository.updateDraft(
+        taskId,
+        request.baseRevision(),
+        nextRevision,
+        descriptor.pluginVersion(),
+        descriptor.schemaVersion(),
+        jsonCodec.write(normalizedDefinition),
+        jsonCodec.digest(normalizedDefinition),
+        operator(operator),
+        now);
+    requireOptimisticUpdate(updated, "草稿版本冲突，请刷新后重新保存");
+    repository.updateTaskDraftMetadata(
+        taskId,
+        nextRevision,
+        descriptor.pluginVersion(),
+        descriptor.schemaVersion(),
+        now);
+    return requireDraft(taskId);
+  }
+
+  public ValidationView validateTask(long taskId, ValidateTaskRequest request) {
+    Task task = requireTask(taskId);
+    JsonNode source = request != null && request.definition() != null
+        ? request.definition()
+        : requireDraft(taskId).definition();
+    Map<String, Object> normalized = taskPluginCatalog.normalizeDefinition(
+        task.taskType(),
+        jsonCodec.toMap(source));
+    taskPluginCatalog.validateDefinition(task.taskType(), normalized);
+    JsonNode normalizedDefinition = jsonCodec.toTree(normalized);
+    return new ValidationView(
+        true,
+        normalizedDefinition,
+        jsonCodec.digest(normalizedDefinition),
+        List.of());
+  }
+
+  @Transactional(transactionManager = "dataDevelopmentTransactionManager", rollbackFor = Exception.class)
+  public Version publishTask(long taskId, PublishTaskRequest request, String operator) {
+    Task task = repository.findTaskForUpdate(taskId)
+        .orElseThrow(() -> new IllegalArgumentException("数据开发任务不存在：" + taskId));
+    Draft draft = repository.findDraftForUpdate(taskId)
+        .orElseThrow(() -> new IllegalStateException("任务草稿不存在：" + taskId));
+    if (draft.revision() != request.draftRevision()) {
+      throw new IllegalStateException(
+          "草稿已经更新，当前 revision=" + draft.revision()
+              + "，请求 revision=" + request.draftRevision());
+    }
+
+    CompiledDefinition compiled = taskPluginCatalog.compile(
+        task.taskType(),
+        jsonCodec.toMap(draft.definition()));
+    Descriptor descriptor = taskPluginCatalog.descriptor(task.taskType());
+    JsonNode definitionSnapshot = jsonCodec.toTree(compiled.definition());
+    JsonNode compiledSpec = jsonCodec.toTree(compiled.compiledSpec());
+    JsonNode inputSchema = jsonCodec.toTree(compiled.inputSchema());
+    JsonNode outputSchema = jsonCodec.toTree(compiled.outputSchema());
+    LocalDateTime now = LocalDateTime.now();
+    int versionNumber = repository.nextVersionNumber(taskId);
+    long versionId = repository.insertVersion(
+        taskId,
+        versionNumber,
+        descriptor.taskType(),
+        descriptor.pluginVersion(),
+        descriptor.schemaVersion(),
+        jsonCodec.write(definitionSnapshot),
+        jsonCodec.write(compiledSpec),
+        jsonCodec.write(inputSchema),
+        jsonCodec.write(outputSchema),
+        jsonCodec.digest(definitionSnapshot),
+        trimToNull(request.comment()),
+        operator(operator),
+        now);
+    repository.updateTaskPublished(taskId, versionId, now);
+    return requireVersion(taskId, versionId);
+  }
+
+  public List<Version> listVersions(long taskId) {
+    requireTask(taskId);
+    return repository.listVersions(taskId);
+  }
+
+  public Version getVersion(long taskId, long versionId) {
+    return requireVersion(taskId, versionId);
+  }
+
+  @Transactional(transactionManager = "dataDevelopmentTransactionManager", rollbackFor = Exception.class)
+  public Execution createExecution(
+      long taskId,
+      CreateExecutionRequest request,
+      String operator) {
+    Task task = requireTask(taskId);
+    ExecutionSourceType sourceType = parseSourceType(request.sourceType());
+    PreparedExecution prepared = prepareExecution(task, sourceType, request);
+    JsonNode runtime = request.runtime() == null
+        ? runtimeFromDefinition(prepared.definitionSnapshot())
+        : request.runtime();
+    JsonNode input = request.input() == null ? jsonCodec.objectNode() : request.input();
+    long executionId = repository.insertExecution(
+        taskId,
+        sourceType,
+        prepared.draftRevision(),
+        prepared.taskVersionId(),
+        task.taskType(),
+        prepared.pluginVersion(),
+        jsonCodec.write(prepared.definitionSnapshot()),
+        jsonCodec.write(prepared.compiledSpec()),
+        jsonCodec.write(runtime),
+        jsonCodec.write(input),
+        trimToNull(request.idempotencyKey()),
+        operator(operator),
+        LocalDateTime.now());
+    return requireExecution(executionId);
+  }
+
+  public Execution getExecution(long executionId) {
+    return requireExecution(executionId);
+  }
+
+  public List<Execution> listExecutions(long taskId, int limit) {
+    requireTask(taskId);
+    return repository.listExecutions(taskId, limit);
+  }
+
+  @Transactional(transactionManager = "dataDevelopmentTransactionManager", rollbackFor = Exception.class)
+  public Execution cancelExecution(long executionId) {
+    Execution execution = requireExecution(executionId);
+    if (execution.status().terminal()) {
+      return execution;
+    }
+    int updated = repository.cancelExecution(executionId, LocalDateTime.now());
+    if (updated != 1) {
+      throw new IllegalStateException("执行状态已经变化，无法取消");
+    }
+    return requireExecution(executionId);
+  }
+
+  private PreparedExecution prepareExecution(
+      Task task,
+      ExecutionSourceType sourceType,
+      CreateExecutionRequest request) {
+    return switch (sourceType) {
+      case DRAFT_REVISION -> prepareDraftExecution(task, request);
+      case PUBLISHED_VERSION -> prepareVersionExecution(task, request);
+      case EPHEMERAL_SNAPSHOT -> prepareEphemeralExecution(task, request);
+    };
+  }
+
+  private PreparedExecution prepareDraftExecution(Task task, CreateExecutionRequest request) {
+    Draft draft = requireDraft(task.id());
+    if (request.draftRevision() == null || request.draftRevision() != draft.revision()) {
+      throw new IllegalArgumentException("运行草稿时必须提供当前 draftRevision=" + draft.revision());
+    }
+    CompiledDefinition compiled = taskPluginCatalog.compile(
+        task.taskType(),
+        jsonCodec.toMap(draft.definition()));
+    return new PreparedExecution(
+        draft.revision(),
+        null,
+        taskPluginCatalog.descriptor(task.taskType()).pluginVersion(),
+        jsonCodec.toTree(compiled.definition()),
+        jsonCodec.toTree(compiled.compiledSpec()));
+  }
+
+  private PreparedExecution prepareVersionExecution(Task task, CreateExecutionRequest request) {
+    if (request.taskVersionId() == null) {
+      throw new IllegalArgumentException("运行发布版本时必须提供 taskVersionId");
+    }
+    Version version = requireVersion(task.id(), request.taskVersionId());
+    return new PreparedExecution(
+        null,
+        version.id(),
+        version.pluginVersion(),
+        version.definitionSnapshot(),
+        version.compiledSpec());
+  }
+
+  private PreparedExecution prepareEphemeralExecution(Task task, CreateExecutionRequest request) {
+    if (request.definitionSnapshot() == null) {
+      throw new IllegalArgumentException("临时运行必须提供 definitionSnapshot");
+    }
+    CompiledDefinition compiled = taskPluginCatalog.compile(
+        task.taskType(),
+        jsonCodec.toMap(request.definitionSnapshot()));
+    return new PreparedExecution(
+        null,
+        null,
+        taskPluginCatalog.descriptor(task.taskType()).pluginVersion(),
+        jsonCodec.toTree(compiled.definition()),
+        jsonCodec.toTree(compiled.compiledSpec()));
+  }
+
+  private JsonNode runtimeFromDefinition(JsonNode definition) {
+    JsonNode runtime = definition.path("runtime");
+    return runtime.isMissingNode() || runtime.isNull() ? jsonCodec.objectNode() : runtime;
+  }
+
+  private void ensureNotDescendant(Resource resource, Long targetParentId) {
+    if (targetParentId == null) {
+      return;
+    }
+    if (resource.id().equals(targetParentId)) {
+      throw new IllegalArgumentException("目录不能移动到自身下面");
+    }
+    Map<Long, Long> parentById = new LinkedHashMap<>();
+    repository.listResources(resource.projectId())
+        .forEach(item -> parentById.put(item.id(), item.parentId()));
+    Long cursor = targetParentId;
+    while (cursor != null) {
+      if (resource.id().equals(cursor)) {
+        throw new IllegalArgumentException("目录不能移动到自己的子目录下面");
+      }
+      cursor = parentById.get(cursor);
+    }
+  }
+
+  private void requireParent(long projectId, Long parentId) {
+    if (parentId == null) {
+      return;
+    }
+    Resource parent = requireResource(parentId);
+    if (parent.projectId() != projectId || parent.resourceKind() != ResourceKind.FOLDER) {
+      throw new IllegalArgumentException("父资源必须是当前项目中的目录");
+    }
+  }
+
+  private Project requireProject(long projectId) {
+    return repository.findProject(projectId)
+        .orElseThrow(() -> new IllegalArgumentException("数据开发项目不存在：" + projectId));
+  }
+
+  private Resource requireResource(long resourceId) {
+    return repository.findResource(resourceId)
+        .orElseThrow(() -> new IllegalArgumentException("数据开发资源不存在：" + resourceId));
+  }
+
+  private Task requireTask(long taskId) {
+    return repository.findTask(taskId)
+        .orElseThrow(() -> new IllegalArgumentException("数据开发任务不存在：" + taskId));
+  }
+
+  private Draft requireDraft(long taskId) {
+    return repository.findDraft(taskId)
+        .orElseThrow(() -> new IllegalStateException("任务草稿不存在：" + taskId));
+  }
+
+  private Version requireVersion(long taskId, long versionId) {
+    return repository.findVersion(taskId, versionId)
+        .orElseThrow(() -> new IllegalArgumentException("任务版本不存在：" + versionId));
+  }
+
+  private Execution requireExecution(long executionId) {
+    return repository.findExecution(executionId)
+        .orElseThrow(() -> new IllegalArgumentException("任务执行不存在：" + executionId));
+  }
+
+  private static ExecutionSourceType parseSourceType(String value) {
+    try {
+      return ExecutionSourceType.valueOf(requireText(value, "执行来源").toUpperCase(Locale.ROOT));
+    } catch (IllegalArgumentException exception) {
+      throw new IllegalArgumentException("不支持的执行来源：" + value, exception);
+    }
+  }
+
+  private static int valueOrZero(Integer value) {
+    return value == null ? 0 : value;
+  }
+
+  private static String operator(String operator) {
+    return StringUtils.hasText(operator) ? operator.trim() : "system";
+  }
+
+  private static String requireText(String value, String label) {
+    if (!StringUtils.hasText(value)) {
+      throw new IllegalArgumentException(label + "不能为空");
+    }
+    return value.trim();
+  }
+
+  private static String trimToNull(String value) {
+    return StringUtils.hasText(value) ? value.trim() : null;
+  }
+
+  private static void requireOptimisticUpdate(int updated, String message) {
+    if (updated != 1) {
+      throw new IllegalStateException(message);
+    }
+  }
+
+  private record PreparedExecution(
+      Long draftRevision,
+      Long taskVersionId,
+      String pluginVersion,
+      JsonNode definitionSnapshot,
+      JsonNode compiledSpec) {
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/TaskPluginCatalogService.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/TaskPluginCatalogService.java
@@ -1,0 +1,30 @@
+package io.yak.ops.business.development.service;
+
+import io.yak.ops.business.development.config.ConditionalOnDataDevelopmentEnabled;
+import io.yak.ops.plugin.task.api.TaskPluginCatalog;
+import io.yak.ops.plugin.task.api.TaskPluginFactory.Descriptor;
+import java.util.Comparator;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+/** Read facade for the installed task-plugin catalog. */
+@ConditionalOnDataDevelopmentEnabled
+@Service
+public class TaskPluginCatalogService {
+
+  private final TaskPluginCatalog catalog;
+
+  public TaskPluginCatalogService(TaskPluginCatalog catalog) {
+    this.catalog = catalog;
+  }
+
+  public List<Descriptor> list() {
+    return catalog.descriptors().stream()
+        .sorted(Comparator.comparing(Descriptor::category).thenComparing(Descriptor::name))
+        .toList();
+  }
+
+  public Descriptor require(String taskType) {
+    return catalog.descriptor(taskType);
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/resources/db/migration/yak-data-development/V1__create_data_development_control_plane.sql
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/resources/db/migration/yak-data-development/V1__create_data_development_control_plane.sql
@@ -1,0 +1,162 @@
+CREATE TABLE IF NOT EXISTS yak_dev_project (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  code VARCHAR(128) NOT NULL,
+  name VARCHAR(255) NOT NULL,
+  description VARCHAR(1000) NULL,
+  created_by VARCHAR(128) NULL,
+  created_at DATETIME(6) NOT NULL,
+  updated_at DATETIME(6) NOT NULL,
+  PRIMARY KEY (id),
+  UNIQUE KEY uk_yak_dev_project_code (code)
+);
+
+CREATE TABLE IF NOT EXISTS yak_dev_resource (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  project_id BIGINT NOT NULL,
+  parent_id BIGINT NOT NULL DEFAULT 0,
+  resource_kind VARCHAR(32) NOT NULL,
+  name VARCHAR(255) NOT NULL,
+  description VARCHAR(1000) NULL,
+  sort_order INT NOT NULL DEFAULT 0,
+  owner_id VARCHAR(128) NULL,
+  created_by VARCHAR(128) NULL,
+  updated_by VARCHAR(128) NULL,
+  deleted TINYINT(1) NOT NULL DEFAULT 0,
+  lock_version INT NOT NULL DEFAULT 0,
+  created_at DATETIME(6) NOT NULL,
+  updated_at DATETIME(6) NOT NULL,
+  PRIMARY KEY (id),
+  UNIQUE KEY uk_yak_dev_resource_name (project_id, parent_id, name, deleted),
+  KEY idx_yak_dev_resource_tree (project_id, parent_id, deleted, sort_order),
+  KEY idx_yak_dev_resource_owner (project_id, owner_id, deleted)
+);
+
+CREATE TABLE IF NOT EXISTS yak_dev_task (
+  id BIGINT NOT NULL,
+  project_id BIGINT NOT NULL,
+  task_type VARCHAR(64) NOT NULL,
+  plugin_version VARCHAR(64) NOT NULL,
+  schema_version INT NOT NULL,
+  status VARCHAR(32) NOT NULL,
+  draft_revision BIGINT NOT NULL DEFAULT 0,
+  published_version_id BIGINT NULL,
+  engine_type VARCHAR(64) NULL,
+  created_at DATETIME(6) NOT NULL,
+  updated_at DATETIME(6) NOT NULL,
+  PRIMARY KEY (id),
+  KEY idx_yak_dev_task_project_type (project_id, task_type, status),
+  KEY idx_yak_dev_task_published_version (published_version_id)
+);
+
+CREATE TABLE IF NOT EXISTS yak_dev_task_draft (
+  task_id BIGINT NOT NULL,
+  revision BIGINT NOT NULL,
+  plugin_version VARCHAR(64) NOT NULL,
+  schema_version INT NOT NULL,
+  definition_json LONGTEXT NOT NULL,
+  content_digest VARCHAR(64) NOT NULL,
+  updated_by VARCHAR(128) NULL,
+  updated_at DATETIME(6) NOT NULL,
+  PRIMARY KEY (task_id)
+);
+
+CREATE TABLE IF NOT EXISTS yak_dev_task_version (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  task_id BIGINT NOT NULL,
+  version_no INT NOT NULL,
+  task_type VARCHAR(64) NOT NULL,
+  plugin_version VARCHAR(64) NOT NULL,
+  schema_version INT NOT NULL,
+  definition_snapshot LONGTEXT NOT NULL,
+  compiled_spec LONGTEXT NOT NULL,
+  input_schema LONGTEXT NOT NULL,
+  output_schema LONGTEXT NOT NULL,
+  content_digest VARCHAR(64) NOT NULL,
+  publish_comment VARCHAR(1000) NULL,
+  published_by VARCHAR(128) NULL,
+  published_at DATETIME(6) NOT NULL,
+  PRIMARY KEY (id),
+  UNIQUE KEY uk_yak_dev_task_version (task_id, version_no),
+  KEY idx_yak_dev_task_version_task (task_id, id)
+);
+
+CREATE TABLE IF NOT EXISTS yak_dev_execution (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  task_id BIGINT NOT NULL,
+  source_type VARCHAR(32) NOT NULL,
+  draft_revision BIGINT NULL,
+  task_version_id BIGINT NULL,
+  task_type VARCHAR(64) NOT NULL,
+  plugin_version VARCHAR(64) NOT NULL,
+  definition_snapshot LONGTEXT NOT NULL,
+  compiled_spec_snapshot LONGTEXT NOT NULL,
+  runtime_snapshot LONGTEXT NOT NULL,
+  input_snapshot LONGTEXT NOT NULL,
+  status VARCHAR(32) NOT NULL,
+  current_attempt_no INT NOT NULL DEFAULT 0,
+  idempotency_key VARCHAR(128) NULL,
+  created_by VARCHAR(128) NULL,
+  created_at DATETIME(6) NOT NULL,
+  started_at DATETIME(6) NULL,
+  finished_at DATETIME(6) NULL,
+  error_code VARCHAR(128) NULL,
+  error_message LONGTEXT NULL,
+  PRIMARY KEY (id),
+  UNIQUE KEY uk_yak_dev_execution_idempotency (idempotency_key),
+  KEY idx_yak_dev_execution_task_status (task_id, status, id),
+  KEY idx_yak_dev_execution_version (task_version_id)
+);
+
+CREATE TABLE IF NOT EXISTS yak_dev_execution_attempt (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  execution_id BIGINT NOT NULL,
+  attempt_no INT NOT NULL,
+  executor_type VARCHAR(64) NOT NULL,
+  worker_id VARCHAR(128) NULL,
+  external_execution_id VARCHAR(255) NULL,
+  status VARCHAR(32) NOT NULL,
+  exit_code INT NULL,
+  error_code VARCHAR(128) NULL,
+  error_message LONGTEXT NULL,
+  started_at DATETIME(6) NULL,
+  finished_at DATETIME(6) NULL,
+  PRIMARY KEY (id),
+  UNIQUE KEY uk_yak_dev_execution_attempt (execution_id, attempt_no),
+  KEY idx_yak_dev_execution_attempt_execution (execution_id, status)
+);
+
+CREATE TABLE IF NOT EXISTS yak_dev_execution_event (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  execution_id BIGINT NOT NULL,
+  attempt_id BIGINT NULL,
+  sequence_no BIGINT NOT NULL,
+  event_type VARCHAR(64) NOT NULL,
+  payload_json LONGTEXT NULL,
+  occurred_at DATETIME(6) NOT NULL,
+  PRIMARY KEY (id),
+  UNIQUE KEY uk_yak_dev_execution_event_sequence (execution_id, sequence_no),
+  KEY idx_yak_dev_execution_event_attempt (attempt_id, sequence_no)
+);
+
+CREATE TABLE IF NOT EXISTS yak_dev_execution_result (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  execution_id BIGINT NOT NULL,
+  attempt_id BIGINT NULL,
+  result_kind VARCHAR(32) NOT NULL,
+  schema_version INT NOT NULL,
+  summary_json LONGTEXT NOT NULL,
+  payload_json LONGTEXT NULL,
+  dataset_ref VARCHAR(255) NULL,
+  truncated TINYINT(1) NOT NULL DEFAULT 0,
+  created_at DATETIME(6) NOT NULL,
+  PRIMARY KEY (id),
+  KEY idx_yak_dev_execution_result_execution (execution_id, id)
+);
+
+CREATE TABLE IF NOT EXISTS yak_dev_user_favorite (
+  user_id VARCHAR(128) NOT NULL,
+  resource_id BIGINT NOT NULL,
+  created_at DATETIME(6) NOT NULL,
+  PRIMARY KEY (user_id, resource_id),
+  KEY idx_yak_dev_user_favorite_resource (resource_id)
+);

--- a/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-api/src/main/java/io/yak/ops/plugin/task/api/TaskPluginCatalog.java
+++ b/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-api/src/main/java/io/yak/ops/plugin/task/api/TaskPluginCatalog.java
@@ -1,0 +1,196 @@
+package io.yak.ops.plugin.task.api;
+
+import io.yak.ops.plugin.task.api.TaskPluginFactory.Capabilities;
+import io.yak.ops.plugin.task.api.TaskPluginFactory.CompiledDefinition;
+import io.yak.ops.plugin.task.api.TaskPluginFactory.Descriptor;
+import io.yak.ops.plugin.task.api.TaskPluginFactory.ResultKind;
+import io.yak.ops.spi.workflow.WorkflowTaskPluginDescriptor;
+import io.yak.ops.spi.workflow.WorkflowTaskPluginFactory;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.ServiceLoader;
+import java.util.Set;
+
+/** Runtime catalog for generic task plugins. */
+public final class TaskPluginCatalog {
+
+  private final Map<String, TaskPluginFactory> factories;
+
+  public TaskPluginCatalog() {
+    this(resolveClassLoader());
+  }
+
+  public TaskPluginCatalog(ClassLoader classLoader) {
+    this(load(TaskPluginFactory.class, classLoader), load(WorkflowTaskPluginFactory.class, classLoader));
+  }
+
+  TaskPluginCatalog(
+      Collection<TaskPluginFactory> taskFactories,
+      Collection<WorkflowTaskPluginFactory> workflowFactories) {
+    Map<String, TaskPluginFactory> registered = new LinkedHashMap<>();
+    if (taskFactories != null) taskFactories.forEach(factory -> register(registered, factory));
+    if (workflowFactories != null) {
+      workflowFactories.forEach(factory -> registered.putIfAbsent(
+          normalize(factory.type()), new WorkflowTaskPluginAdapter(factory)));
+    }
+    this.factories = Collections.unmodifiableMap(registered);
+  }
+
+  public TaskPluginFactory require(String taskType) {
+    String normalized = normalize(taskType);
+    TaskPluginFactory factory = factories.get(normalized);
+    if (factory == null) {
+      throw new IllegalArgumentException("No task plugin registered for type: " + normalized);
+    }
+    return factory;
+  }
+
+  public Descriptor descriptor(String taskType) { return require(taskType).descriptor(); }
+  public List<Descriptor> descriptors() {
+    List<Descriptor> result = new ArrayList<>(factories.size());
+    factories.values().forEach(factory -> result.add(factory.descriptor()));
+    return Collections.unmodifiableList(result);
+  }
+  public Map<String, Object> defaultDefinition(String taskType) { return require(taskType).defaultDefinition(); }
+  public Map<String, Object> normalizeDefinition(String taskType, Map<String, Object> definition) {
+    return require(taskType).normalizeDefinition(definition);
+  }
+  public void validateDefinition(String taskType, Map<String, Object> definition) {
+    require(taskType).validateDefinition(definition);
+  }
+  public CompiledDefinition compile(String taskType, Map<String, Object> definition) {
+    return require(taskType).compile(definition);
+  }
+  public boolean contains(String taskType) { return factories.containsKey(normalize(taskType)); }
+  public Set<String> types() { return factories.keySet(); }
+
+  private static void register(Map<String, TaskPluginFactory> registered, TaskPluginFactory factory) {
+    Objects.requireNonNull(factory, "taskPluginFactory");
+    Descriptor descriptor = Objects.requireNonNull(factory.descriptor(), "taskPluginDescriptor");
+    String taskType = normalize(descriptor.taskType());
+    if (registered.putIfAbsent(taskType, factory) != null) {
+      throw new IllegalStateException("Duplicate task plugin type: " + taskType);
+    }
+  }
+
+  private static ClassLoader resolveClassLoader() {
+    ClassLoader current = Thread.currentThread().getContextClassLoader();
+    return current == null ? TaskPluginCatalog.class.getClassLoader() : current;
+  }
+
+  private static <T> List<T> load(Class<T> type, ClassLoader classLoader) {
+    List<T> values = new ArrayList<>();
+    ServiceLoader.load(type, classLoader).forEach(values::add);
+    return values;
+  }
+
+  private static String normalize(String taskType) {
+    if (taskType == null || taskType.isBlank()) throw new IllegalArgumentException("Task type must not be blank");
+    return taskType.trim().toUpperCase(Locale.ROOT);
+  }
+
+  private static final class WorkflowTaskPluginAdapter implements TaskPluginFactory {
+    private final WorkflowTaskPluginFactory delegate;
+    private final Descriptor descriptor;
+
+    private WorkflowTaskPluginAdapter(WorkflowTaskPluginFactory delegate) {
+      this.delegate = Objects.requireNonNull(delegate, "workflowTaskPluginFactory");
+      WorkflowTaskPluginDescriptor source = delegate.descriptor();
+      this.descriptor = new Descriptor(
+          source.getType(), source.getName(), source.getDescription(), source.getCategory(),
+          source.getVersion(), 1,
+          Capabilities.runnable(source.isCancellable(), source.isOutputCapable()),
+          resultKind(source.getType()), source.getConfigurationSchema(), Map.of(), Map.of(), Map.of());
+    }
+
+    @Override public Descriptor descriptor() { return descriptor; }
+
+    @Override
+    public Map<String, Object> defaultDefinition() {
+      Map<String, Object> defaults = defaultsFromSchema(descriptor.authoringSchema());
+      Map<String, Object> definition = new LinkedHashMap<>();
+      definition.put("schemaVersion", descriptor.schemaVersion());
+      definition.put("taskType", descriptor.taskType());
+      definition.put("pluginVersion", descriptor.pluginVersion());
+      definition.put("content", Map.of("kind", "form", "value", defaults));
+      definition.put("config", defaults);
+      definition.put("runtime", Map.of("common", Map.of(), "specific", Map.of()));
+      definition.put("inputs", Map.of());
+      definition.put("outputs", Map.of());
+      return definition;
+    }
+
+    @Override
+    public Map<String, Object> normalizeDefinition(Map<String, Object> definition) {
+      Map<String, Object> envelope = TaskPluginFactory.super.normalizeDefinition(definition);
+      envelope.put("config", delegate.normalize(extractPluginConfiguration(envelope)));
+      return envelope;
+    }
+
+    @Override
+    public void validateDefinition(Map<String, Object> definition) {
+      delegate.validate(extractPluginConfiguration(TaskPluginFactory.super.normalizeDefinition(definition)));
+    }
+
+    @Override
+    public CompiledDefinition compile(Map<String, Object> definition) {
+      Map<String, Object> normalized = normalizeDefinition(definition);
+      return new CompiledDefinition(normalized, Map.of(
+          "taskType", descriptor.taskType(),
+          "pluginVersion", descriptor.pluginVersion(),
+          "configuration", normalized.get("config")), Map.of(), Map.of());
+    }
+
+    private Map<String, Object> extractPluginConfiguration(Map<String, Object> definition) {
+      Map<String, Object> configuration = new LinkedHashMap<>();
+      mergeMap(configuration, definition.get("config"));
+      Object content = definition.get("content");
+      if (content instanceof Map<?, ?> contentMap) {
+        mergeMap(configuration, contentMap.get("value"));
+        if ("SHELL".equals(descriptor.taskType())
+            && "text".equals(contentMap.get("kind"))
+            && contentMap.get("value") instanceof String text
+            && !text.isBlank()) {
+          configuration.put("command", text);
+        }
+      }
+      if (definition.get("runtime") instanceof Map<?, ?> runtime) {
+        mergeMap(configuration, runtime.get("specific"));
+      }
+      return configuration;
+    }
+
+    private static void mergeMap(Map<String, Object> target, Object source) {
+      if (!(source instanceof Map<?, ?> map)) return;
+      map.forEach((key, value) -> { if (key != null) target.put(String.valueOf(key), value); });
+    }
+
+    private static Map<String, Object> defaultsFromSchema(Map<String, Object> schema) {
+      if (!(schema.get("fields") instanceof Map<?, ?> fields)) return Map.of();
+      Map<String, Object> defaults = new LinkedHashMap<>();
+      fields.forEach((key, value) -> {
+        if (key != null && value instanceof Map<?, ?> field && field.containsKey("defaultValue")) {
+          defaults.put(String.valueOf(key), field.get("defaultValue"));
+        }
+      });
+      return defaults;
+    }
+
+    private static ResultKind resultKind(String taskType) {
+      return switch (normalize(taskType)) {
+        case "HTTP" -> ResultKind.JSON;
+        case "SHELL", "PYTHON" -> ResultKind.TERMINAL;
+        case "SQL", "FLINK_SQL" -> ResultKind.TABLE;
+        case "NOTEBOOK" -> ResultKind.NOTEBOOK;
+        case "DATA_INTEGRATION" -> ResultKind.PIPELINE;
+        default -> ResultKind.TEXT;
+      };
+    }
+  }
+}

--- a/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-api/src/main/java/io/yak/ops/plugin/task/api/TaskPluginFactory.java
+++ b/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-api/src/main/java/io/yak/ops/plugin/task/api/TaskPluginFactory.java
@@ -1,0 +1,151 @@
+package io.yak.ops.plugin.task.api;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Generic task-plugin contract shared by data development and future orchestration runtimes.
+ *
+ * <p>The plugin owns definition normalization, validation and compilation. Execution remains a
+ * separate concern so the data-development control plane can persist immutable runnable snapshots
+ * without depending on a concrete worker implementation.
+ */
+public interface TaskPluginFactory {
+
+  Descriptor descriptor();
+
+  /** Creates the canonical initial definition used by the data-development editor. */
+  default Map<String, Object> defaultDefinition() {
+    Descriptor descriptor = descriptor();
+    Map<String, Object> definition = new LinkedHashMap<>();
+    definition.put("schemaVersion", descriptor.schemaVersion());
+    definition.put("taskType", descriptor.taskType());
+    definition.put("pluginVersion", descriptor.pluginVersion());
+    definition.put("content", Map.of("kind", "form", "value", Map.of()));
+    definition.put("config", Map.of());
+    definition.put("runtime", Map.of("common", Map.of(), "specific", Map.of()));
+    definition.put("inputs", Map.of());
+    definition.put("outputs", Map.of());
+    return definition;
+  }
+
+  /** Normalizes editor JSON into the canonical durable definition envelope. */
+  default Map<String, Object> normalizeDefinition(Map<String, Object> definition) {
+    Map<String, Object> normalized = definition == null
+        ? new LinkedHashMap<>()
+        : new LinkedHashMap<>(definition);
+    Descriptor descriptor = descriptor();
+    normalized.put("schemaVersion", descriptor.schemaVersion());
+    normalized.put("taskType", descriptor.taskType());
+    normalized.put("pluginVersion", descriptor.pluginVersion());
+    normalized.putIfAbsent("content", Map.of("kind", "form", "value", Map.of()));
+    normalized.putIfAbsent("config", Map.of());
+    normalized.putIfAbsent("runtime", Map.of("common", Map.of(), "specific", Map.of()));
+    normalized.putIfAbsent("inputs", Map.of());
+    normalized.putIfAbsent("outputs", Map.of());
+    return normalized;
+  }
+
+  /** Validates one normalized task definition. */
+  default void validateDefinition(Map<String, Object> definition) {
+    normalizeDefinition(definition);
+  }
+
+  /** Compiles the editable definition into an immutable execution specification. */
+  default CompiledDefinition compile(Map<String, Object> definition) {
+    Map<String, Object> normalized = normalizeDefinition(definition);
+    validateDefinition(normalized);
+    return new CompiledDefinition(
+        normalized,
+        normalized,
+        descriptor().inputSchema(),
+        descriptor().outputSchema());
+  }
+
+  enum ResultKind {
+    TABLE,
+    JSON,
+    TERMINAL,
+    NOTEBOOK,
+    PIPELINE,
+    TEXT
+  }
+
+  record Capabilities(
+      boolean editable,
+      boolean runnable,
+      boolean cancellable,
+      boolean publishable,
+      boolean outputCapable,
+      boolean statementRunnable,
+      boolean streaming) {
+
+    public static Capabilities runnable(boolean cancellable, boolean outputCapable) {
+      return new Capabilities(true, true, cancellable, true, outputCapable, false, false);
+    }
+  }
+
+  record Descriptor(
+      String taskType,
+      String name,
+      String description,
+      String category,
+      String pluginVersion,
+      int schemaVersion,
+      Capabilities capabilities,
+      ResultKind resultKind,
+      Map<String, Object> authoringSchema,
+      Map<String, Object> runtimeSchema,
+      Map<String, Object> inputSchema,
+      Map<String, Object> outputSchema) {
+
+    public Descriptor {
+      taskType = requireText(taskType, "taskType").toUpperCase();
+      name = requireText(name, "name");
+      description = description == null ? "" : description;
+      category = requireText(category, "category");
+      pluginVersion = requireText(pluginVersion, "pluginVersion");
+      if (schemaVersion <= 0) {
+        throw new IllegalArgumentException("Task plugin schemaVersion must be positive");
+      }
+      capabilities = Objects.requireNonNull(capabilities, "capabilities");
+      resultKind = Objects.requireNonNull(resultKind, "resultKind");
+      authoringSchema = immutableCopy(authoringSchema);
+      runtimeSchema = immutableCopy(runtimeSchema);
+      inputSchema = immutableCopy(inputSchema);
+      outputSchema = immutableCopy(outputSchema);
+    }
+  }
+
+  record CompiledDefinition(
+      Map<String, Object> definition,
+      Map<String, Object> compiledSpec,
+      Map<String, Object> inputSchema,
+      Map<String, Object> outputSchema) {
+
+    public CompiledDefinition {
+      definition = immutableCopy(definition);
+      compiledSpec = immutableCopy(compiledSpec);
+      inputSchema = immutableCopy(inputSchema);
+      outputSchema = immutableCopy(outputSchema);
+    }
+  }
+
+  private static String requireText(String value, String field) {
+    if (value == null || value.isBlank()) {
+      throw new IllegalArgumentException("Task plugin " + field + " must not be blank");
+    }
+    return value.trim();
+  }
+
+  private static Map<String, Object> immutableCopy(Map<String, Object> source) {
+    if (source == null || source.isEmpty()) {
+      return Map.of();
+    }
+    Map<String, Object> copy = new LinkedHashMap<>();
+    source.forEach((key, value) -> copy.put(Objects.requireNonNull(key, "map key"), value));
+    return Collections.unmodifiableMap(copy);
+  }
+}

--- a/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-api/src/test/java/io/yak/ops/plugin/task/api/TaskPluginCatalogTest.java
+++ b/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-api/src/test/java/io/yak/ops/plugin/task/api/TaskPluginCatalogTest.java
@@ -1,0 +1,51 @@
+package io.yak.ops.plugin.task.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.yak.ops.spi.workflow.WorkflowTaskExecutor;
+import io.yak.ops.spi.workflow.WorkflowTaskPluginDescriptor;
+import io.yak.ops.spi.workflow.WorkflowTaskContext;
+import io.yak.ops.spi.workflow.WorkflowTaskResult;
+import io.yak.ops.spi.workflow.WorkflowTaskPluginFactory;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class TaskPluginCatalogTest {
+
+  @Test
+  void adaptsExistingWorkflowPluginFactory() {
+    WorkflowTaskPluginFactory workflowFactory = new WorkflowTaskPluginFactory() {
+      @Override
+      public WorkflowTaskPluginDescriptor descriptor() {
+        return new WorkflowTaskPluginDescriptor(
+            "HTTP", "HTTP 请求", "test", "GENERAL", "1.0.0", true, true,
+            Map.of("fields", Map.of("url", Map.of("type", "string"))));
+      }
+
+      @Override
+      public Map<String, Object> normalize(Map<String, Object> configuration) {
+        return Map.of("url", String.valueOf(configuration.get("url")).trim());
+      }
+
+      @Override
+      public WorkflowTaskExecutor create() {
+        return new WorkflowTaskExecutor() {
+          @Override public String type() { return "HTTP"; }
+          @Override public WorkflowTaskResult execute(WorkflowTaskContext context) {
+            return WorkflowTaskResult.succeeded();
+          }
+        };
+      }
+    };
+
+    TaskPluginCatalog catalog = new TaskPluginCatalog(List.of(), List.of(workflowFactory));
+    Map<String, Object> normalized = catalog.normalizeDefinition(
+        "HTTP", Map.of("content", Map.of("kind", "form", "value", Map.of("url", " /api "))));
+
+    assertThat(catalog.types()).containsExactly("HTTP");
+    assertThat(catalog.descriptor("HTTP").resultKind()).isEqualTo(TaskPluginFactory.ResultKind.JSON);
+    assertThat(normalized.get("taskType")).isEqualTo("HTTP");
+    assertThat(normalized.get("config")).isEqualTo(Map.of("url", "/api"));
+  }
+}


### PR DESCRIPTION
## 变更说明

为 Yak Ops 数据开发工作台搭建后端控制面架构。本 PR 暂不处理工作流和 Cron 调度，先统一项目目录、任务开发、草稿、发布版本和测试运行快照。

### 新增业务模块

新增 `yak-ops-business-data-development`，并接入 Business 聚合模块与 Boot：

- 独立 Hikari 数据源、事务管理器和 Flyway
- 项目与资源目录树
- 可执行任务定义
- 乐观锁草稿保存
- 插件校验与编译
- 不可变发布版本
- 三类测试运行快照
- 执行记录查询与取消骨架

### Task Plugin 统一入口

在现有 `yak-ops-plugin-task-api` 中新增：

- `TaskPluginFactory`
- `TaskPluginCatalog`

通用插件协议负责：

- 插件元数据与能力声明
- 默认任务定义
- Definition 规范化
- Definition 校验
- 可执行 Spec 编译
- 输入输出 Schema
- Result Kind

`TaskPluginCatalog` 会自动适配现有 `WorkflowTaskPluginFactory`，所以当前 HTTP、Shell 插件可以直接被数据开发复用，不需要复制执行和校验实现。后续 SQL、Flink SQL、Python、Notebook、数据集成可以直接实现新的通用 Factory。

### 领域模型

```text
Resource Workspace
  Project -> Folder / Task / Asset

Task Authoring
  Task -> Draft Revision -> Immutable Task Version

Task Execution
  Execution -> Attempt -> Event / Result
```

关键约束：

- `resource.id == task.id`
- Resource 只负责目录树和元数据
- Draft 使用 `baseRevision` 乐观锁，禁止静默覆盖
- TaskVersion 只新增、不修改
- 发布版本同时保存编辑 Definition 与编译后的 Spec
- Execution 永久保存 Definition、Compiled Spec、Runtime、Input 快照

### 执行来源

- `DRAFT_REVISION`：运行已保存草稿
- `PUBLISHED_VERSION`：运行不可变发布版本
- `EPHEMERAL_SNAPSHOT`：运行未保存内容或 SQL 当前语句

本 PR 先创建执行账本，不在 Yak Ops 控制面进程中直接执行 Shell/Python。真实执行将由后续 Execution Gateway / Worker、Attempt 状态机和 SSE 事件流承接。

### Flyway

新增数据表：

- `yak_dev_project`
- `yak_dev_resource`
- `yak_dev_task`
- `yak_dev_task_draft`
- `yak_dev_task_version`
- `yak_dev_execution`
- `yak_dev_execution_attempt`
- `yak_dev_execution_event`
- `yak_dev_execution_result`
- `yak_dev_user_favorite`

### REST API

基础路径：`/api/v1/data-development`

覆盖：

- Task Plugin 目录
- Project 创建与查询
- Resource Tree 查询、创建、移动、重命名和删除
- Task 创建与详情
- Draft 保存与校验
- Version 发布与查询
- Execution 创建、列表、详情和取消

### 文档

新增 `docs/data-development/backend-architecture.md`，记录领域边界、统一任务信封、草稿与发布语义、执行快照、表结构、接口和后续阶段。

## 当前验证

- 新增 Java 主代码已通过基于依赖 Stub 的 `javac` 语法与类型检查
- 新增及修改的 Maven POM 已完成 XML 解析检查
- 新增 Task Plugin Catalog 单元测试，覆盖现有 Workflow 插件适配
- 分支基于当前最新 `main`：`922088edec848582772ece58aebce1e0c581f1b9`

当前执行环境未安装完整 Maven 依赖，也未启动 MySQL，因此完整 Reactor Build、Spring Context、Flyway 集成测试需要在本地或 CI 中补充执行。PR 先保持 Draft。

## 建议评审顺序

1. 通用 `TaskPluginFactory` / `TaskPluginCatalog` 协议
2. Resource、Task、Draft、Version、Execution 领域边界
3. Flyway 表结构和唯一约束
4. Draft 乐观锁与发布事务
5. Execution Snapshot 的三种来源
6. 前端 Workbench 后续接口对接方式
