### PR TITLE
feat(data-development): connect workbench control plane

### DIFF
--- a/yak-ops-boot/src/main/resources/application.yml
+++ b/yak-ops-boot/src/main/resources/application.yml
@@ -94,6 +94,16 @@ yak:
     connection-test:
       timeout-seconds: ${YAK_DATASOURCE_CONNECT_TIMEOUT_SECONDS:5}
 
+  data-development:
+    enabled: ${YAK_DATA_DEVELOPMENT_ENABLED:true}
+    datasource:
+      url: ${YAK_DATA_DEVELOPMENT_DATASOURCE_URL:${YAK_SECURITY_DATASOURCE_URL:jdbc:mysql://127.0.0.1:3306/yak_security?useUnicode=true&allowPublicKeyRetrieval=true&characterEncoding=UTF-8&useSSL=false&serverTimezone=Asia/Shanghai}}
+      username: ${YAK_DATA_DEVELOPMENT_DATASOURCE_USERNAME:${YAK_SECURITY_DATASOURCE_USERNAME:root}}
+      password: ${YAK_DATA_DEVELOPMENT_DATASOURCE_PASSWORD:${YAK_SECURITY_DATASOURCE_PASSWORD:123456}}
+      driver-class-name: ${YAK_DATA_DEVELOPMENT_DATASOURCE_DRIVER:com.mysql.cj.jdbc.Driver}
+      minimum-idle: 1
+      maximum-pool-size: 8
+
   resource:
     enabled: ${YAK_RESOURCE_ENABLED:true}
     max-file-size: ${YAK_RESOURCE_MAX_FILE_BYTES:104857600}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/api/DataDevelopmentApi.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/api/DataDevelopmentApi.java
@@ -2,6 +2,7 @@ package io.yak.ops.business.development.api;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import io.yak.ops.business.development.domain.DataDevelopmentModel.Draft;
+import io.yak.ops.business.development.domain.DataDevelopmentModel.Project;
 import io.yak.ops.business.development.domain.DataDevelopmentModel.Resource;
 import io.yak.ops.business.development.domain.DataDevelopmentModel.Task;
 import io.yak.ops.plugin.task.api.TaskPluginFactory.Descriptor;
@@ -79,6 +80,18 @@ public final class DataDevelopmentApi {
       Resource resource,
       Task task,
       Draft draft) {
+  }
+
+  /**
+   * Complete authoring snapshot used by the web workbench.
+   *
+   * <p>The workspace endpoint deliberately returns task drafts in one request during the first
+   * integration phase. The API can be split into lazy resource/document loading later without
+   * changing the persisted task envelope.</p>
+   */
+  public record WorkspaceView(
+      Project project,
+      List<TaskDetailView> tasks) {
   }
 
   public record ValidationView(

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/config/ConditionalOnDataDevelopmentEnabled.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/config/ConditionalOnDataDevelopmentEnabled.java
@@ -13,6 +13,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
     prefix = "yak.data-development",
     name = "enabled",
     havingValue = "true",
-    matchIfMissing = true)
+    matchIfMissing = false)
 public @interface ConditionalOnDataDevelopmentEnabled {
 }

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/config/DataDevelopmentProperties.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/config/DataDevelopmentProperties.java
@@ -6,7 +6,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(prefix = "yak.data-development")
 public class DataDevelopmentProperties {
 
-  private boolean enabled = true;
+  private boolean enabled;
   private final Datasource datasource = new Datasource();
 
   public boolean isEnabled() {
@@ -23,9 +23,9 @@ public class DataDevelopmentProperties {
 
   public static class Datasource {
 
-    private String url = "jdbc:mysql://127.0.0.1:3306/yak_security?useUnicode=true&allowPublicKeyRetrieval=true&characterEncoding=UTF-8&useSSL=false&serverTimezone=Asia/Shanghai";
-    private String username = "root";
-    private String password = "123456";
+    private String url;
+    private String username;
+    private String password;
     private String driverClassName = "com.mysql.cj.jdbc.Driver";
     private int maximumPoolSize = 8;
     private int minimumIdle = 1;

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/controller/v1/DataDevelopmentController.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/controller/v1/DataDevelopmentController.java
@@ -12,16 +12,19 @@ import io.yak.ops.business.development.api.DataDevelopmentApi.TaskDetailView;
 import io.yak.ops.business.development.api.DataDevelopmentApi.UpdateResourceRequest;
 import io.yak.ops.business.development.api.DataDevelopmentApi.ValidateTaskRequest;
 import io.yak.ops.business.development.api.DataDevelopmentApi.ValidationView;
+import io.yak.ops.business.development.api.DataDevelopmentApi.WorkspaceView;
 import io.yak.ops.business.development.config.ConditionalOnDataDevelopmentEnabled;
 import io.yak.ops.business.development.domain.DataDevelopmentModel.Draft;
 import io.yak.ops.business.development.domain.DataDevelopmentModel.Execution;
 import io.yak.ops.business.development.domain.DataDevelopmentModel.Project;
 import io.yak.ops.business.development.domain.DataDevelopmentModel.Resource;
+import io.yak.ops.business.development.domain.DataDevelopmentModel.ResourceKind;
 import io.yak.ops.business.development.domain.DataDevelopmentModel.Version;
 import io.yak.ops.business.development.service.DataDevelopmentService;
 import io.yak.ops.business.development.service.TaskPluginCatalogService;
 import io.yak.ops.plugin.task.api.TaskPluginFactory.Descriptor;
 import jakarta.validation.Valid;
+import java.security.Principal;
 import java.util.List;
 import java.util.Map;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -30,7 +33,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -40,8 +42,6 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/data-development")
 public class DataDevelopmentController {
-
-  private static final String OPERATOR_HEADER = "X-Operator";
 
   private final DataDevelopmentService service;
   private final TaskPluginCatalogService pluginCatalogService;
@@ -66,8 +66,8 @@ public class DataDevelopmentController {
   @PostMapping("/projects")
   public Result<Project> createProject(
       @Valid @RequestBody CreateProjectRequest request,
-      @RequestHeader(name = OPERATOR_HEADER, defaultValue = "system") String operator) {
-    return Result.success(service.createProject(request, operator));
+      Principal principal) {
+    return Result.success(service.createProject(request, operator(principal)));
   }
 
   @GetMapping("/projects")
@@ -80,20 +80,33 @@ public class DataDevelopmentController {
     return Result.success(service.listResources(projectId));
   }
 
+  @GetMapping("/projects/{projectId}/workspace")
+  public Result<WorkspaceView> getWorkspace(@PathVariable long projectId) {
+    Project project = service.listProjects().stream()
+        .filter(item -> item.id() == projectId)
+        .findFirst()
+        .orElseThrow(() -> new IllegalArgumentException("数据开发项目不存在：" + projectId));
+    List<TaskDetailView> tasks = service.listResources(projectId).stream()
+        .filter(resource -> resource.resourceKind() == ResourceKind.TASK)
+        .map(resource -> service.getTask(resource.id()))
+        .toList();
+    return Result.success(new WorkspaceView(project, tasks));
+  }
+
   @PostMapping("/projects/{projectId}/folders")
   public Result<Resource> createFolder(
       @PathVariable long projectId,
       @Valid @RequestBody CreateFolderRequest request,
-      @RequestHeader(name = OPERATOR_HEADER, defaultValue = "system") String operator) {
-    return Result.success(service.createFolder(projectId, request, operator));
+      Principal principal) {
+    return Result.success(service.createFolder(projectId, request, operator(principal)));
   }
 
   @PostMapping("/projects/{projectId}/tasks")
   public Result<TaskDetailView> createTask(
       @PathVariable long projectId,
       @Valid @RequestBody CreateTaskRequest request,
-      @RequestHeader(name = OPERATOR_HEADER, defaultValue = "system") String operator) {
-    return Result.success(service.createTask(projectId, request, operator));
+      Principal principal) {
+    return Result.success(service.createTask(projectId, request, operator(principal)));
   }
 
   @GetMapping("/tasks/{taskId}")
@@ -105,8 +118,8 @@ public class DataDevelopmentController {
   public Result<Draft> saveDraft(
       @PathVariable long taskId,
       @Valid @RequestBody SaveDraftRequest request,
-      @RequestHeader(name = OPERATOR_HEADER, defaultValue = "system") String operator) {
-    return Result.success(service.saveDraft(taskId, request, operator));
+      Principal principal) {
+    return Result.success(service.saveDraft(taskId, request, operator(principal)));
   }
 
   @PostMapping("/tasks/{taskId}/validate")
@@ -120,8 +133,8 @@ public class DataDevelopmentController {
   public Result<Version> publishTask(
       @PathVariable long taskId,
       @Valid @RequestBody PublishTaskRequest request,
-      @RequestHeader(name = OPERATOR_HEADER, defaultValue = "system") String operator) {
-    return Result.success(service.publishTask(taskId, request, operator));
+      Principal principal) {
+    return Result.success(service.publishTask(taskId, request, operator(principal)));
   }
 
   @GetMapping("/tasks/{taskId}/versions")
@@ -140,8 +153,8 @@ public class DataDevelopmentController {
   public Result<Execution> createExecution(
       @PathVariable long taskId,
       @Valid @RequestBody CreateExecutionRequest request,
-      @RequestHeader(name = OPERATOR_HEADER, defaultValue = "system") String operator) {
-    return Result.success(service.createExecution(taskId, request, operator));
+      Principal principal) {
+    return Result.success(service.createExecution(taskId, request, operator(principal)));
   }
 
   @GetMapping("/tasks/{taskId}/executions")
@@ -165,23 +178,29 @@ public class DataDevelopmentController {
   public Result<Resource> updateResource(
       @PathVariable long resourceId,
       @Valid @RequestBody UpdateResourceRequest request,
-      @RequestHeader(name = OPERATOR_HEADER, defaultValue = "system") String operator) {
-    return Result.success(service.updateResource(resourceId, request, operator));
+      Principal principal) {
+    return Result.success(service.updateResource(resourceId, request, operator(principal)));
   }
 
   @PostMapping("/resources/{resourceId}/move")
   public Result<Resource> moveResource(
       @PathVariable long resourceId,
       @Valid @RequestBody MoveResourceRequest request,
-      @RequestHeader(name = OPERATOR_HEADER, defaultValue = "system") String operator) {
-    return Result.success(service.moveResource(resourceId, request, operator));
+      Principal principal) {
+    return Result.success(service.moveResource(resourceId, request, operator(principal)));
   }
 
   @DeleteMapping("/resources/{resourceId}")
   public Result<Map<String, Boolean>> deleteResource(
       @PathVariable long resourceId,
-      @RequestHeader(name = OPERATOR_HEADER, defaultValue = "system") String operator) {
-    service.deleteResource(resourceId, operator);
+      Principal principal) {
+    service.deleteResource(resourceId, operator(principal));
     return Result.success(Map.of("deleted", true));
+  }
+
+  private static String operator(Principal principal) {
+    return principal == null || principal.getName() == null || principal.getName().isBlank()
+        ? "system"
+        : principal.getName();
   }
 }

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/controller/v1/DataDevelopmentExceptionHandler.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/controller/v1/DataDevelopmentExceptionHandler.java
@@ -1,0 +1,43 @@
+package io.yak.ops.business.development.controller.v1;
+
+import io.yak.ops.business.development.config.ConditionalOnDataDevelopmentEnabled;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+/** Maps authoring conflicts to HTTP 409 so the workbench can surface a refresh action. */
+@ConditionalOnDataDevelopmentEnabled
+@RestControllerAdvice(assignableTypes = DataDevelopmentController.class)
+public class DataDevelopmentExceptionHandler {
+
+  @ExceptionHandler(IllegalStateException.class)
+  public ResponseEntity<Map<String, Object>> handleConflict(IllegalStateException exception) {
+    return response(HttpStatus.CONFLICT, exception.getMessage());
+  }
+
+  @ExceptionHandler(IllegalArgumentException.class)
+  public ResponseEntity<Map<String, Object>> handleInvalidRequest(
+      IllegalArgumentException exception) {
+    HttpStatus status = isRevisionConflict(exception.getMessage())
+        ? HttpStatus.CONFLICT
+        : HttpStatus.BAD_REQUEST;
+    return response(status, exception.getMessage());
+  }
+
+  private static boolean isRevisionConflict(String message) {
+    return message != null
+        && (message.contains("revision") || message.contains("draftRevision"));
+  }
+
+  private static ResponseEntity<Map<String, Object>> response(
+      HttpStatus status,
+      String message) {
+    Map<String, Object> body = new LinkedHashMap<>();
+    body.put("code", status.value());
+    body.put("message", message);
+    return ResponseEntity.status(status).body(body);
+  }
+}

--- a/yak-ops-ui/src/pages/data-development/workbench/WorkbenchPage.tsx
+++ b/yak-ops-ui/src/pages/data-development/workbench/WorkbenchPage.tsx
@@ -2,7 +2,7 @@ import {
   BRAND_CSS_VARIABLES,
   BRAND_THEME,
 } from '@/styles/brand';
-import { Button, ConfigProvider, Tooltip } from 'antd';
+import { Alert, Button, ConfigProvider, Spin, Tooltip } from 'antd';
 import {
   ChevronRight,
   Circle,
@@ -12,7 +12,7 @@ import {
   Minimize2,
   X,
 } from 'lucide-react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import CreateResourceModal from './components/CreateResourceModal';
 import EditorTabs from './components/EditorTabs';
 import ExplorerPanel from './components/ExplorerPanel';
@@ -24,6 +24,7 @@ import WorkbenchResizeHandle from './components/WorkbenchResizeHandle';
 import WorkbenchToolbar from './components/WorkbenchToolbar';
 import type { ResourceType } from './core/types';
 import ExecutionBottomPanel from './execution/components/ExecutionBottomPanel';
+import { useWorkbenchControlStore } from './store/workbench-control.store';
 import { useWorkbenchStore } from './store/workbench.store';
 
 const EXPLORER_MIN_WIDTH = 300;
@@ -36,6 +37,13 @@ const WorkbenchPage = () => {
   const fullscreen = useWorkbenchStore((state) => state.fullscreen);
   const splitResourceId = useWorkbenchStore((state) => state.splitResourceId);
   const resourcesById = useWorkbenchStore((state) => state.resourcesById);
+  const workspaceLoading = useWorkbenchControlStore(
+    (state) => state.workspaceLoading,
+  );
+  const workspaceError = useWorkbenchControlStore(
+    (state) => state.workspaceError,
+  );
+  const initialize = useWorkbenchControlStore((state) => state.initialize);
   const setExplorerWidth = useWorkbenchStore((state) => state.setExplorerWidth);
   const setFullscreen = useWorkbenchStore((state) => state.setFullscreen);
   const setSplitResource = useWorkbenchStore(
@@ -45,9 +53,13 @@ const WorkbenchPage = () => {
     (state) => state.setActiveResource,
   );
   const [createOpen, setCreateOpen] = useState(false);
-  const [createType, setCreateType] = useState<ResourceType>('SQL');
+  const [createType, setCreateType] = useState<ResourceType>('HTTP');
 
-  const openCreateModal = (resourceType: ResourceType = 'SQL') => {
+  useEffect(() => {
+    void initialize();
+  }, [initialize]);
+
+  const openCreateModal = (resourceType: ResourceType = 'HTTP') => {
     setCreateType(resourceType);
     setCreateOpen(true);
   };
@@ -73,18 +85,20 @@ const WorkbenchPage = () => {
               数据开发
             </strong>
             <span className="ml-2 hidden rounded bg-[#f2f3f5] px-2 py-1 text-[10px] font-medium text-[rgba(22,24,35,0.48)] md:inline-flex">
-              Plugin Workbench
+              Control Plane
             </span>
           </div>
 
           <div className="flex items-center gap-2">
             <div className="hidden items-center gap-2 rounded-md border border-[#e2e5e9] bg-[#fafbfc] px-2.5 py-1.5 text-[12px] text-[rgba(22,24,35,0.68)] sm:flex">
               <Cloud size={14} />
-              开发环境
+              {workspaceError ? '连接异常' : '开发环境'}
               <Circle
                 size={7}
-                fill="#20b26b"
-                className="text-[#20b26b]"
+                fill={workspaceError ? '#ff4d4f' : '#20b26b'}
+                className={
+                  workspaceError ? 'text-[#ff4d4f]' : 'text-[#20b26b]'
+                }
               />
             </div>
             <Tooltip title={fullscreen ? '退出沉浸模式' : '沉浸模式'}>
@@ -104,7 +118,27 @@ const WorkbenchPage = () => {
           </div>
         </header>
 
-        <div className="flex min-h-0 flex-1">
+        {workspaceError && (
+          <Alert
+            banner
+            showIcon
+            type="error"
+            message={workspaceError}
+            action={
+              <Button size="small" onClick={() => void initialize()}>
+                重新加载
+              </Button>
+            }
+          />
+        )}
+
+        <div className="relative flex min-h-0 flex-1">
+          {workspaceLoading && (
+            <div className="absolute inset-0 z-50 flex items-center justify-center bg-white/75">
+              <Spin tip="正在加载数据开发工作区" />
+            </div>
+          )}
+
           {explorerVisible && !fullscreen && (
             <>
               <div
@@ -131,7 +165,7 @@ const WorkbenchPage = () => {
             <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
               <div className="flex min-h-0 flex-1 overflow-hidden">
                 <section className="min-w-0 flex-1 overflow-hidden">
-                  <ResourceView onCreate={() => openCreateModal('SQL')} />
+                  <ResourceView onCreate={() => openCreateModal('HTTP')} />
                 </section>
 
                 {splitResource && !fullscreen && (

--- a/yak-ops-ui/src/pages/data-development/workbench/components/CreateResourceModal.tsx
+++ b/yak-ops-ui/src/pages/data-development/workbench/components/CreateResourceModal.tsx
@@ -1,8 +1,12 @@
 import { Form, Input, Modal, Select, message } from 'antd';
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { nodePluginRegistry } from '../core/registry';
 import type { ResourceType } from '../core/types';
-import { createNewResource } from '../mock/workspace';
+import {
+  workbenchErrorMessage,
+  workbenchRepository,
+} from '../repository/workbench.repository';
+import { useWorkbenchControlStore } from '../store/workbench-control.store';
 import { useWorkbenchStore } from '../store/workbench.store';
 
 interface CreateResourceValues {
@@ -22,40 +26,69 @@ const CreateResourceModal = ({
   onClose,
 }: CreateResourceModalProps) => {
   const [form] = Form.useForm<CreateResourceValues>();
-  const createResource = useWorkbenchStore((state) => state.createResource);
-  const plugins = useMemo(
-    () =>
-      nodePluginRegistry
-        .list()
-        .slice()
-        .sort(
-          (left, right) =>
-            left.metadata.folderOrder - right.metadata.folderOrder ||
-            left.metadata.label.localeCompare(right.metadata.label),
-        ),
-    [],
+  const [submitting, setSubmitting] = useState(false);
+  const projectId = useWorkbenchControlStore((state) => state.projectId);
+  const supportedTaskTypes = useWorkbenchControlStore(
+    (state) => state.supportedTaskTypes,
   );
+  const createResource = useWorkbenchStore((state) => state.createResource);
+  const plugins = useMemo(() => {
+    const supported = new Set(supportedTaskTypes);
+    return nodePluginRegistry
+      .list()
+      .filter((plugin) => supported.has(plugin.type.toUpperCase()))
+      .slice()
+      .sort(
+        (left, right) =>
+          left.metadata.folderOrder - right.metadata.folderOrder ||
+          left.metadata.label.localeCompare(right.metadata.label),
+      );
+  }, [supportedTaskTypes]);
 
   useEffect(() => {
     if (!open) return;
+    const requested = plugins.some(
+      (plugin) => plugin.type === initialResourceType,
+    )
+      ? initialResourceType
+      : plugins[0]?.type;
     form.setFieldsValue({
-      resourceType: initialResourceType ?? plugins[0]?.type,
+      resourceType: requested,
       name: '',
     });
   }, [form, initialResourceType, open, plugins]);
 
-  const handleCreate = ({ resourceType, name }: CreateResourceValues) => {
+  const handleCreate = async ({
+    resourceType,
+    name,
+  }: CreateResourceValues) => {
     const plugin = nodePluginRegistry.get(resourceType);
     if (!plugin) {
       message.error(`未找到节点插件：${resourceType}`);
       return;
     }
+    if (!projectId) {
+      message.error('数据开发项目尚未加载');
+      return;
+    }
 
-    const { resource, document } = createNewResource(plugin, name);
-    createResource(resource, document);
-    message.success(`${plugin.metadata.label} 已创建`);
-    form.resetFields();
-    onClose();
+    setSubmitting(true);
+    try {
+      const { resource, document } = await workbenchRepository.createTask(
+        projectId,
+        resourceType,
+        name,
+        plugin.metadata.defaultEngine,
+      );
+      createResource(resource, document);
+      message.success(`${plugin.metadata.label} 已创建并保存`);
+      form.resetFields();
+      onClose();
+    } catch (error) {
+      message.error(workbenchErrorMessage(error));
+    } finally {
+      setSubmitting(false);
+    }
   };
 
   return (
@@ -66,6 +99,8 @@ const CreateResourceModal = ({
       width={540}
       okText="创建节点"
       cancelText="取消"
+      confirmLoading={submitting}
+      okButtonProps={{ disabled: plugins.length === 0 }}
       destroyOnHidden
       onCancel={() => {
         form.resetFields();
@@ -87,6 +122,9 @@ const CreateResourceModal = ({
         >
           <Select
             variant="filled"
+            placeholder={
+              plugins.length === 0 ? '后端没有注册可用任务插件' : undefined
+            }
             options={plugins.map((plugin) => ({
               value: plugin.type,
               label: `${plugin.metadata.category} / ${plugin.metadata.label}`,
@@ -102,11 +140,12 @@ const CreateResourceModal = ({
             { max: 80, message: '节点名称不能超过 80 个字符' },
           ]}
         >
-          <Input variant="filled" placeholder="例如：mysql_sql_etl" />
+          <Input variant="filled" placeholder="例如：http_user_profile" />
         </Form.Item>
 
         <div className="rounded-lg bg-[#f7f8f9] p-3 text-[11px] leading-5 text-[rgba(22,24,35,0.5)]">
-          节点由 NodePluginDefinition 注册。创建后，渲染器、运行参数、工具栏动作和能力开关会自动按插件定义加载。
+          节点类型由后端 TaskPluginCatalog 与前端 NodePluginDefinition
+          共同确认。未在后端注册的节点不会出现在创建列表中。
         </div>
       </Form>
     </Modal>

--- a/yak-ops-ui/src/pages/data-development/workbench/components/ExplorerPanel.tsx
+++ b/yak-ops-ui/src/pages/data-development/workbench/components/ExplorerPanel.tsx
@@ -17,6 +17,7 @@ import type {
   ResourceType,
   WorkbenchFolderDefinition,
 } from '../core/types';
+import { useWorkbenchControlStore } from '../store/workbench-control.store';
 import { useWorkbenchStore } from '../store/workbench.store';
 import ResourceContextMenu from './ResourceContextMenu';
 
@@ -24,9 +25,11 @@ interface ExplorerPanelProps {
   onCreate: (resourceType: ResourceType) => void;
 }
 
-const PROJECT_LABEL = '用户数据平台';
-
 const ExplorerPanel = ({ onCreate }: ExplorerPanelProps) => {
+  const projectName = useWorkbenchControlStore((state) => state.projectName);
+  const supportedTaskTypes = useWorkbenchControlStore(
+    (state) => state.supportedTaskTypes,
+  );
   const resourcesById = useWorkbenchStore((state) => state.resourcesById);
   const documentsByResourceId = useWorkbenchStore(
     (state) => state.documentsByResourceId,
@@ -53,7 +56,12 @@ const ExplorerPanel = ({ onCreate }: ExplorerPanelProps) => {
     (state) => state.setExplorerVisible,
   );
 
-  const plugins = nodePluginRegistry.list();
+  const plugins = useMemo(() => {
+    const supported = new Set(supportedTaskTypes);
+    return nodePluginRegistry
+      .list()
+      .filter((plugin) => supported.has(plugin.type.toUpperCase()));
+  }, [supportedTaskTypes]);
 
   const folders = useMemo(() => {
     const folderMap = new Map<string, WorkbenchFolderDefinition>();
@@ -95,8 +103,7 @@ const ExplorerPanel = ({ onCreate }: ExplorerPanelProps) => {
         resource.updatedBy.toLowerCase().includes(normalizedKeyword);
       const matchesFilter =
         explorerFilter === 'all' ||
-        (explorerFilter === 'owned' && resource.owner === 'me') ||
-        (explorerFilter === 'favorite' && resource.favorite);
+        (explorerFilter === 'owned' && resource.owner === 'me');
       return matchesKeyword && matchesFilter;
     })
     .map((resource) => resource.id);
@@ -126,7 +133,7 @@ const ExplorerPanel = ({ onCreate }: ExplorerPanelProps) => {
         key={resource.id}
         resource={resource}
         folders={folders}
-        projectLabel={PROJECT_LABEL}
+        projectLabel={projectName}
       >
         <button
           type="button"
@@ -147,13 +154,6 @@ const ExplorerPanel = ({ onCreate }: ExplorerPanelProps) => {
             <span className="min-w-0 flex-1 truncate" title={resource.name}>
               {resource.name}
             </span>
-            {resource.favorite && (
-              <Circle
-                size={6}
-                fill="currentColor"
-                className="shrink-0 text-[rgba(22,24,35,0.24)]"
-              />
-            )}
             {document?.dirty && (
               <Circle
                 size={6}
@@ -192,11 +192,8 @@ const ExplorerPanel = ({ onCreate }: ExplorerPanelProps) => {
           <Select
             variant="borderless"
             className="min-w-0 flex-1 [&_.ant-select-selector]:!px-0"
-            defaultValue="user-data-platform"
-            options={[
-              { label: PROJECT_LABEL, value: 'user-data-platform' },
-              { label: '实时数仓项目', value: 'realtime-warehouse' },
-            ]}
+            value="current-project"
+            options={[{ label: projectName, value: 'current-project' }]}
           />
           <Tooltip title="收起项目目录">
             <Button
@@ -224,7 +221,6 @@ const ExplorerPanel = ({ onCreate }: ExplorerPanelProps) => {
           {[
             ['all', '全部'],
             ['owned', '我负责的'],
-            ['favorite', '我收藏的'],
           ].map(([value, label]) => (
             <button
               key={value}
@@ -251,6 +247,7 @@ const ExplorerPanel = ({ onCreate }: ExplorerPanelProps) => {
             <Button
               type="primary"
               size="small"
+              disabled={plugins.length === 0}
               aria-label="新建开发节点"
               icon={<Plus size={15} />}
               className="!h-7 !w-7 !px-0"

--- a/yak-ops-ui/src/pages/data-development/workbench/components/ResourceContextMenu.tsx
+++ b/yak-ops-ui/src/pages/data-development/workbench/components/ResourceContextMenu.tsx
@@ -1,28 +1,25 @@
 import { history } from '@umijs/max';
-import {
-  Dropdown,
-  Input,
-  Modal,
-  Select,
-  message,
-  type MenuProps,
-} from 'antd';
+import { Dropdown, Input, Modal, message, type MenuProps } from 'antd';
 import {
   Activity,
   Columns2,
   Copy,
   Files,
-  Folder,
   History,
   Pencil,
-  Star,
   Trash2,
 } from 'lucide-react';
 import { useMemo, useState, type ReactElement } from 'react';
 import type {
+  DevelopmentDocument,
   DevelopmentResource,
   WorkbenchFolderDefinition,
 } from '../core/types';
+import {
+  workbenchErrorMessage,
+  workbenchRepository,
+} from '../repository/workbench.repository';
+import { useWorkbenchControlStore } from '../store/workbench-control.store';
 import { useWorkbenchStore } from '../store/workbench.store';
 
 interface ResourceContextMenuProps {
@@ -71,9 +68,9 @@ const ResourceContextMenu = ({
   projectLabel,
   children,
 }: ResourceContextMenuProps) => {
-  const cloneResource = useWorkbenchStore((state) => state.cloneResource);
+  const projectId = useWorkbenchControlStore((state) => state.projectId);
+  const createResource = useWorkbenchStore((state) => state.createResource);
   const deleteResource = useWorkbenchStore((state) => state.deleteResource);
-  const moveResource = useWorkbenchStore((state) => state.moveResource);
   const updateResource = useWorkbenchStore((state) => state.updateResource);
   const openResource = useWorkbenchStore((state) => state.openResource);
   const setActiveResource = useWorkbenchStore(
@@ -89,8 +86,7 @@ const ResourceContextMenu = ({
 
   const [renameOpen, setRenameOpen] = useState(false);
   const [renameValue, setRenameValue] = useState(resource.name);
-  const [moveOpen, setMoveOpen] = useState(false);
-  const [moveFolderId, setMoveFolderId] = useState(resource.folderId);
+  const [submitting, setSubmitting] = useState(false);
 
   const folderLabel =
     folders.find((folder) => folder.id === resource.folderId)?.label ??
@@ -131,24 +127,7 @@ const ResourceContextMenu = ({
         icon: <Columns2 size={14} />,
         label: <MenuLabel shortcut="Ctrl+Enter">在侧边打开</MenuLabel>,
       },
-      {
-        key: 'favorite',
-        icon: (
-          <Star
-            size={14}
-            fill={resource.favorite ? 'currentColor' : 'none'}
-          />
-        ),
-        label: (
-          <MenuLabel>{resource.favorite ? '取消收藏' : '收藏'}</MenuLabel>
-        ),
-      },
       { type: 'divider' },
-      {
-        key: 'move',
-        icon: <Folder size={14} />,
-        label: <MenuLabel>移动...</MenuLabel>,
-      },
       {
         key: 'rename',
         icon: <Pencil size={14} />,
@@ -161,18 +140,69 @@ const ResourceContextMenu = ({
         label: <MenuLabel shortcut="Delete">删除</MenuLabel>,
       },
     ],
-    [resource.favorite],
+    [],
   );
+
+  const cloneTask = async () => {
+    if (!projectId || !document) return;
+    const key = `clone-${resource.id}`;
+    message.loading({ content: '正在克隆节点', key });
+    try {
+      const created = await workbenchRepository.createTask(
+        projectId,
+        resource.resourceType,
+        `${resource.name} 副本`,
+        resource.engine,
+      );
+      const clonedDocument: DevelopmentDocument = {
+        ...created.document,
+        content: structuredClone(document.content),
+        config: structuredClone(document.config),
+        runtime: structuredClone(document.runtime),
+        dirty: true,
+      };
+      const saved = await workbenchRepository.saveDraft(
+        created.resource,
+        clonedDocument,
+      );
+      createResource(created.resource, saved);
+      message.success({ content: '节点已克隆并保存', key });
+    } catch (error) {
+      message.error({ content: workbenchErrorMessage(error), key });
+    }
+  };
+
+  const handleDelete = () => {
+    Modal.confirm({
+      centered: true,
+      title: '删除开发节点',
+      content: document?.dirty
+        ? `“${resource.name}”存在未保存的更改，删除后无法恢复。`
+        : `确认删除“${resource.name}”吗？删除后无法恢复。`,
+      okText: '删除',
+      cancelText: '取消',
+      okButtonProps: { danger: true },
+      onOk: async () => {
+        try {
+          await workbenchRepository.deleteResource(resource.id);
+          deleteResource(resource.id);
+          useWorkbenchControlStore.getState().clearExecutionRecord(resource.id);
+          message.success('节点已删除');
+        } catch (error) {
+          message.error(workbenchErrorMessage(error));
+          throw error;
+        }
+      },
+    });
+  };
 
   const handleMenuClick: MenuProps['onClick'] = async ({ key, domEvent }) => {
     domEvent.stopPropagation();
 
     switch (key) {
-      case 'clone': {
-        const clonedId = cloneResource(resource.id);
-        if (clonedId) message.success('节点已克隆并打开');
+      case 'clone':
+        await cloneTask();
         break;
-      }
       case 'copy-name':
         await copyText(resource.name);
         message.success('名称已复制');
@@ -195,56 +225,39 @@ const ResourceContextMenu = ({
         openResource(resource.id, { pinned: true });
         setSplitResource(resource.id);
         break;
-      case 'favorite':
-        updateResource(resource.id, { favorite: !resource.favorite });
-        message.success(resource.favorite ? '已取消收藏' : '已收藏');
-        break;
-      case 'move':
-        setMoveFolderId(resource.folderId);
-        setMoveOpen(true);
-        break;
       case 'rename':
         setRenameValue(resource.name);
         setRenameOpen(true);
         break;
       case 'delete':
-        Modal.confirm({
-          centered: true,
-          title: '删除开发节点',
-          content: document?.dirty
-            ? `“${resource.name}”存在未保存的更改，删除后无法恢复。`
-            : `确认删除“${resource.name}”吗？删除后无法恢复。`,
-          okText: '删除',
-          cancelText: '取消',
-          okButtonProps: { danger: true },
-          onOk: () => {
-            deleteResource(resource.id);
-            message.success('节点已删除');
-          },
-        });
+        handleDelete();
         break;
       default:
         break;
     }
   };
 
-  const submitRename = () => {
+  const submitRename = async () => {
     const nextName = renameValue.trim();
     if (!nextName) {
       message.warning('请输入节点名称');
       return;
     }
 
-    updateResource(resource.id, { name: nextName });
-    setRenameOpen(false);
-    message.success('节点已重命名');
-  };
-
-  const submitMove = () => {
-    if (!moveFolderId) return;
-    moveResource(resource.id, moveFolderId);
-    setMoveOpen(false);
-    message.success('节点已移动');
+    setSubmitting(true);
+    try {
+      await workbenchRepository.updateResource(resource, {
+        name: nextName,
+        description: resource.description,
+      });
+      updateResource(resource.id, { name: nextName });
+      setRenameOpen(false);
+      message.success('节点已重命名');
+    } catch (error) {
+      message.error(workbenchErrorMessage(error));
+    } finally {
+      setSubmitting(false);
+    }
   };
 
   return (
@@ -263,8 +276,9 @@ const ResourceContextMenu = ({
         width={440}
         okText="确定"
         cancelText="取消"
+        confirmLoading={submitting}
         destroyOnHidden
-        onOk={submitRename}
+        onOk={() => void submitRename()}
         onCancel={() => setRenameOpen(false)}
       >
         <Input
@@ -273,30 +287,7 @@ const ResourceContextMenu = ({
           value={renameValue}
           maxLength={120}
           onChange={(event) => setRenameValue(event.target.value)}
-          onPressEnter={submitRename}
-        />
-      </Modal>
-
-      <Modal
-        title="移动节点"
-        open={moveOpen}
-        centered
-        width={440}
-        okText="移动"
-        cancelText="取消"
-        destroyOnHidden
-        onOk={submitMove}
-        onCancel={() => setMoveOpen(false)}
-      >
-        <Select
-          variant="filled"
-          className="w-full"
-          value={moveFolderId}
-          options={folders.map((folder) => ({
-            value: folder.id,
-            label: folder.label,
-          }))}
-          onChange={setMoveFolderId}
+          onPressEnter={() => void submitRename()}
         />
       </Modal>
     </>

--- a/yak-ops-ui/src/pages/data-development/workbench/components/WorkbenchToolbar.tsx
+++ b/yak-ops-ui/src/pages/data-development/workbench/components/WorkbenchToolbar.tsx
@@ -6,10 +6,16 @@ import {
   nodePluginRegistry,
 } from '../core/registry';
 import type {
+  DevelopmentDocument,
   ToolbarGroup,
   WorkbenchActionContext,
   WorkbenchActionDefinition,
 } from '../core/types';
+import {
+  workbenchErrorMessage,
+  workbenchRepository,
+} from '../repository/workbench.repository';
+import { useWorkbenchControlStore } from '../store/workbench-control.store';
 import {
   selectActiveDocument,
   selectActiveResource,
@@ -62,10 +68,10 @@ const ToolbarActionButton = ({
 const WorkbenchToolbar = () => {
   const resource = useWorkbenchStore(selectActiveResource);
   const document = useWorkbenchStore(selectActiveDocument);
+  const projectId = useWorkbenchControlStore((state) => state.projectId);
   const executionStatusByResourceId = useWorkbenchStore(
     (state) => state.executionStatusByResourceId,
   );
-  const updateResource = useWorkbenchStore((state) => state.updateResource);
   const createResource = useWorkbenchStore((state) => state.createResource);
   const deleteResource = useWorkbenchStore((state) => state.deleteResource);
   const setRightPanel = useWorkbenchStore((state) => state.setRightPanel);
@@ -99,25 +105,33 @@ const WorkbenchToolbar = () => {
         left.order - right.order,
     );
 
-  const duplicateResource = () => {
-    const copyId = `${resource.resourceType.toLowerCase()}-${Date.now()}`;
-    const nextResource = {
-      ...resource,
-      id: copyId,
-      name: `${resource.name} 副本`,
-      status: 'DRAFT' as const,
-      publishedVersion: undefined,
-      latestRevision: 0,
-      favorite: false,
-    };
-    const nextDocument = {
-      ...document,
-      resourceId: copyId,
-      revision: 0,
-      dirty: true,
-    };
-    createResource(nextResource, nextDocument);
-    message.success('节点副本已创建');
+  const duplicateResource = async () => {
+    if (!projectId) return;
+    const key = `toolbar-clone-${resource.id}`;
+    message.loading({ content: '正在复制节点', key });
+    try {
+      const created = await workbenchRepository.createTask(
+        projectId,
+        resource.resourceType,
+        `${resource.name} 副本`,
+        resource.engine,
+      );
+      const copiedDocument: DevelopmentDocument = {
+        ...created.document,
+        content: structuredClone(document.content),
+        config: structuredClone(document.config),
+        runtime: structuredClone(document.runtime),
+        dirty: true,
+      };
+      const saved = await workbenchRepository.saveDraft(
+        created.resource,
+        copiedDocument,
+      );
+      createResource(created.resource, saved);
+      message.success({ content: '节点副本已创建并保存', key });
+    } catch (error) {
+      message.error({ content: workbenchErrorMessage(error), key });
+    }
   };
 
   const confirmDelete = () => {
@@ -128,9 +142,16 @@ const WorkbenchToolbar = () => {
       okText: '删除',
       cancelText: '取消',
       okButtonProps: { danger: true },
-      onOk: () => {
-        deleteResource(resource.id);
-        message.success('节点已删除');
+      onOk: async () => {
+        try {
+          await workbenchRepository.deleteResource(resource.id);
+          deleteResource(resource.id);
+          useWorkbenchControlStore.getState().clearExecutionRecord(resource.id);
+          message.success('节点已删除');
+        } catch (error) {
+          message.error(workbenchErrorMessage(error));
+          throw error;
+        }
       },
     });
   };
@@ -143,6 +164,7 @@ const WorkbenchToolbar = () => {
           size="small"
           className="w-[125px] shrink-0"
           value={resource.engine}
+          disabled
           options={
             plugin.metadata.engineOptions ?? [
               {
@@ -151,7 +173,6 @@ const WorkbenchToolbar = () => {
               },
             ]
           }
-          onChange={(engine: string) => updateResource(resource.id, { engine })}
         />
 
         <span className="mx-1 h-5 w-px shrink-0 bg-[#e4e6e9]" />
@@ -190,7 +211,7 @@ const WorkbenchToolbar = () => {
             },
           ],
           onClick: ({ key }: { key: string }) => {
-            if (key === 'copy') duplicateResource();
+            if (key === 'copy') void duplicateResource();
             if (key === 'history') setRightPanel('version');
             if (key === 'delete') confirmDelete();
           },

--- a/yak-ops-ui/src/pages/data-development/workbench/core/actions.tsx
+++ b/yak-ops-ui/src/pages/data-development/workbench/core/actions.tsx
@@ -11,7 +11,10 @@ import {
   Square,
   WandSparkles,
 } from 'lucide-react';
-import type { WorkbenchActionDefinition } from './types';
+import type { ExecutionStatus, WorkbenchActionDefinition } from './types';
+
+const isExecutionActive = (status: ExecutionStatus) =>
+  status === 'RUNNING' || status === 'QUEUED';
 
 export const BUILTIN_ACTIONS: WorkbenchActionDefinition[] = [
   {
@@ -22,7 +25,7 @@ export const BUILTIN_ACTIONS: WorkbenchActionDefinition[] = [
     group: 'primary',
     order: 10,
     visible: ({ plugin, executionStatus }) =>
-      plugin.capabilities.runnable && executionStatus !== 'RUNNING',
+      plugin.capabilities.runnable && !isExecutionActive(executionStatus),
     enabled: ({ document }) => document.loadStatus === 'READY',
   },
   {
@@ -33,7 +36,7 @@ export const BUILTIN_ACTIONS: WorkbenchActionDefinition[] = [
     group: 'primary',
     order: 10,
     visible: ({ plugin, executionStatus }) =>
-      plugin.type === 'HTTP' && executionStatus !== 'RUNNING',
+      plugin.type === 'HTTP' && !isExecutionActive(executionStatus),
   },
   {
     id: 'notebook.run-all',
@@ -43,7 +46,7 @@ export const BUILTIN_ACTIONS: WorkbenchActionDefinition[] = [
     group: 'primary',
     order: 10,
     visible: ({ plugin, executionStatus }) =>
-      plugin.type === 'NOTEBOOK' && executionStatus !== 'RUNNING',
+      plugin.type === 'NOTEBOOK' && !isExecutionActive(executionStatus),
   },
   {
     id: 'execution.stop',
@@ -53,8 +56,8 @@ export const BUILTIN_ACTIONS: WorkbenchActionDefinition[] = [
     group: 'primary',
     order: 20,
     visible: ({ plugin, executionStatus }) =>
-      plugin.capabilities.stoppable && executionStatus === 'RUNNING',
-    enabled: ({ executionStatus }) => executionStatus === 'RUNNING',
+      plugin.capabilities.stoppable && isExecutionActive(executionStatus),
+    enabled: ({ executionStatus }) => isExecutionActive(executionStatus),
   },
   {
     id: 'document.save',
@@ -138,7 +141,7 @@ export const BUILTIN_ACTIONS: WorkbenchActionDefinition[] = [
     order: 10,
     visible: ({ plugin }) => plugin.capabilities.publishable,
     enabled: ({ document, executionStatus }) =>
-      !document.dirty && executionStatus !== 'RUNNING',
+      !document.dirty && !isExecutionActive(executionStatus),
   },
   {
     id: 'resource.share',

--- a/yak-ops-ui/src/pages/data-development/workbench/core/commands.ts
+++ b/yak-ops-ui/src/pages/data-development/workbench/core/commands.ts
@@ -1,6 +1,13 @@
 import { message } from 'antd';
 import { useExecutionPanelStore } from '../execution/store/execution-panel.store';
+import {
+  isWorkbenchConflict,
+  workbenchErrorMessage,
+  workbenchRepository,
+} from '../repository/workbench.repository';
+import { useWorkbenchControlStore } from '../store/workbench-control.store';
 import { useWorkbenchStore } from '../store/workbench.store';
+import type { ExecutionSession } from '../execution/types';
 import type {
   DevelopmentDocument,
   ResourceContent,
@@ -18,77 +25,156 @@ const updateContent = (
   updatedAt: new Date().toISOString(),
 });
 
-const runResource = (
+const recordSubmittedExecution = (
   context: WorkbenchActionContext,
-  successText: string,
+  executionId: string,
 ) => {
-  const workbenchStore = useWorkbenchStore.getState();
-  const executionPanelStore = useExecutionPanelStore.getState();
-  const resourceId = context.resource.id;
-  const executionId = executionPanelStore.startExecution(
-    context.resource,
-    context.plugin,
-  );
+  const submittedAt = new Date().toISOString();
+  const session: ExecutionSession = {
+    id: executionId,
+    resourceId: context.resource.id,
+    resourceType: context.resource.resourceType,
+    resourceName: context.resource.name,
+    engine: context.resource.engine,
+    status: 'RUNNING',
+    submittedAt,
+    startedAt: submittedAt,
+    logs: [
+      {
+        id: `${executionId}-submitted`,
+        level: 'INFO',
+        timestamp: new Intl.DateTimeFormat('zh-CN', {
+          hour: '2-digit',
+          minute: '2-digit',
+          second: '2-digit',
+          hour12: false,
+        }).format(new Date()),
+        message: '执行快照已保存，等待 Execution Gateway 接管',
+      },
+    ],
+  };
 
-  workbenchStore.setExecutionStatus(resourceId, 'RUNNING');
+  useExecutionPanelStore.setState((state) => ({
+    sessionsById: {
+      ...state.sessionsById,
+      [executionId]: session,
+    },
+    sessionIdsByResourceId: {
+      ...state.sessionIdsByResourceId,
+      [context.resource.id]: [
+        executionId,
+        ...(state.sessionIdsByResourceId[context.resource.id] ?? []),
+      ],
+    },
+    activeSessionIdByResourceId: {
+      ...state.activeSessionIdByResourceId,
+      [context.resource.id]: executionId,
+    },
+    visible: true,
+    activeTab: 'output',
+  }));
+};
+
+const runResource = async (
+  context: WorkbenchActionContext,
+  loadingText: string,
+) => {
+  const store = useWorkbenchStore.getState();
+  const controlStore = useWorkbenchControlStore.getState();
+  const resourceId = context.resource.id;
+
+  store.setExecutionStatus(resourceId, 'RUNNING');
   message.loading({
-    content: `${successText}：${context.resource.name}`,
+    content: `${loadingText}：${context.resource.name}`,
     key: `run-${resourceId}`,
   });
 
-  window.setTimeout(() => {
-    const currentSession =
-      useExecutionPanelStore.getState().sessionsById[executionId];
-    if (!currentSession || currentSession.status !== 'RUNNING') return;
-
-    useWorkbenchStore.getState().setExecutionStatus(resourceId, 'SUCCESS');
-    useExecutionPanelStore
-      .getState()
-      .completeExecution(executionId, context.resource);
+  try {
+    const execution = await workbenchRepository.createExecution(
+      context.resource,
+      context.document,
+    );
+    controlStore.setExecutionRecord(resourceId, execution.id, 'QUEUED');
+    recordSubmittedExecution(context, execution.id);
     message.success({
-      content: '运行完成，结果已进入底部运行面板',
+      content: `执行记录 #${execution.id} 已创建，等待执行网关接管`,
       key: `run-${resourceId}`,
     });
-  }, 1100);
+  } catch (error) {
+    store.setExecutionStatus(resourceId, 'FAILED');
+    message.error({
+      content: workbenchErrorMessage(error),
+      key: `run-${resourceId}`,
+    });
+  }
 };
 
 export const BUILTIN_COMMANDS: WorkbenchCommandDefinition[] = [
   {
     id: 'execution.run',
-    execute: (context) => runResource(context, '正在运行'),
+    execute: (context) => runResource(context, '正在提交运行'),
   },
   {
     id: 'sql.run-statement',
-    execute: (context) => runResource(context, '正在运行当前 SQL'),
+    execute: (context) => runResource(context, '正在提交当前 SQL'),
   },
   {
     id: 'http.test',
-    execute: (context) => runResource(context, '正在发送测试请求'),
+    execute: (context) => runResource(context, '正在提交测试请求'),
   },
   {
     id: 'notebook.run-all',
-    execute: (context) => runResource(context, '正在运行全部 Cell'),
+    execute: (context) => runResource(context, '正在提交全部 Cell'),
   },
   {
     id: 'execution.stop',
-    execute: ({ resource }) => {
-      useWorkbenchStore.getState().setExecutionStatus(resource.id, 'STOPPED');
-      useExecutionPanelStore.getState().stopExecution(resource.id);
-      message.success('停止请求已提交');
+    execute: async ({ resource }) => {
+      const store = useWorkbenchStore.getState();
+      const controlStore = useWorkbenchControlStore.getState();
+      const executionId = controlStore.executionIdByResourceId[resource.id];
+      if (!executionId) {
+        message.warning('当前节点没有可取消的执行记录');
+        return;
+      }
+
+      try {
+        await workbenchRepository.cancelExecution(executionId);
+        store.setExecutionStatus(resource.id, 'STOPPED');
+        useExecutionPanelStore.getState().stopExecution(resource.id);
+        message.success(`执行记录 #${executionId} 已取消`);
+      } catch (error) {
+        message.error(workbenchErrorMessage(error));
+      }
     },
   },
   {
     id: 'document.save',
-    execute: async ({ resource }) => {
+    execute: async ({ resource, document }) => {
       const store = useWorkbenchStore.getState();
-      store.updateDocument(resource.id, (document) => ({
-        ...document,
+      store.updateDocument(resource.id, (current) => ({
+        ...current,
         saveStatus: 'SAVING',
       }));
 
-      await new Promise((resolve) => window.setTimeout(resolve, 260));
-      useWorkbenchStore.getState().markDocumentSaved(resource.id);
-      message.success(`${resource.name} 已保存`);
+      try {
+        const saved = await workbenchRepository.saveDraft(resource, document);
+        store.updateDocument(resource.id, () => saved);
+        store.updateResource(resource.id, {
+          latestRevision: saved.revision,
+          updatedAt: saved.updatedAt,
+        });
+        message.success(`${resource.name} 已保存，Revision ${saved.revision}`);
+      } catch (error) {
+        store.updateDocument(resource.id, (current) => ({
+          ...current,
+          saveStatus: isWorkbenchConflict(error) ? 'CONFLICT' : 'ERROR',
+        }));
+        message.error(
+          isWorkbenchConflict(error)
+            ? '草稿已被其他用户更新，请刷新工作区后再保存'
+            : workbenchErrorMessage(error),
+        );
+      }
     },
   },
   {
@@ -122,34 +208,63 @@ export const BUILTIN_COMMANDS: WorkbenchCommandDefinition[] = [
   },
   {
     id: 'document.refresh',
-    execute: ({ resource }) => {
-      message.success(`${resource.name} 已刷新`);
+    execute: async ({ resource }) => {
+      await useWorkbenchControlStore.getState().initialize();
+      message.success(`${resource.name} 已从服务端刷新`);
     },
   },
   {
     id: 'document.validate',
-    execute: ({ resource, plugin }) => {
-      useExecutionPanelStore
-        .getState()
-        .openForResource(resource.id, 'validation');
-      message.success(`${plugin.metadata.label} 语法、依赖与运行参数检查通过`);
+    execute: async ({ resource, document, plugin }) => {
+      try {
+        const result = await workbenchRepository.validate(resource, document);
+        useExecutionPanelStore
+          .getState()
+          .openForResource(resource.id, 'validation');
+        message.success(
+          `${plugin.metadata.label} 校验通过 · ${result.contentDigest.slice(0, 12)}`,
+        );
+      } catch (error) {
+        useExecutionPanelStore
+          .getState()
+          .openForResource(resource.id, 'problems');
+        message.error(workbenchErrorMessage(error));
+      }
     },
   },
   {
     id: 'version.publish',
-    execute: ({ resource }) => {
-      const store = useWorkbenchStore.getState();
-      store.updateResource(resource.id, {
-        status: 'PUBLISHED',
-        publishedVersion: (resource.publishedVersion ?? 0) + 1,
-      });
-      useExecutionPanelStore.getState().openForResource(resource.id, 'publish');
-      message.success('已创建不可变发布版本');
+    execute: async ({ resource, document }) => {
+      if (document.dirty) {
+        message.warning('请先保存草稿，再创建发布版本');
+        return;
+      }
+
+      try {
+        const version = await workbenchRepository.publish(resource, document);
+        useWorkbenchStore.getState().updateResource(resource.id, {
+          status: 'PUBLISHED',
+          publishedVersion: version.versionNumber,
+        });
+        useExecutionPanelStore
+          .getState()
+          .openForResource(resource.id, 'publish');
+        message.success(`已创建不可变发布版本 V${version.versionNumber}`);
+      } catch (error) {
+        message.error(
+          isWorkbenchConflict(error)
+            ? '草稿版本已变化，请刷新后重新发布'
+            : workbenchErrorMessage(error),
+        );
+      }
     },
   },
   {
     id: 'resource.share',
-    execute: () => {
+    execute: async ({ resource }) => {
+      const url = new URL(window.location.href);
+      url.searchParams.set('resourceId', resource.id);
+      await navigator.clipboard.writeText(url.toString());
       message.success('分享链接已复制');
     },
   },

--- a/yak-ops-ui/src/pages/data-development/workbench/plugins/http.tsx
+++ b/yak-ops-ui/src/pages/data-development/workbench/plugins/http.tsx
@@ -13,10 +13,12 @@ const HTTP_SCHEMA: WorkbenchFormSchema = {
       label: '请求方式',
       type: 'select',
       required: true,
-      options: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'].map((value) => ({
-        label: value,
-        value,
-      })),
+      options: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS'].map(
+        (value) => ({
+          label: value,
+          value,
+        }),
+      ),
     },
     {
       key: 'url',
@@ -49,15 +51,8 @@ const HTTP_RUNTIME_SCHEMA: WorkbenchFormSchema = {
   columns: 1,
   fields: [
     {
-      key: 'connectTimeoutSeconds',
-      label: '连接超时',
-      type: 'number',
-      min: 1,
-      max: 300,
-    },
-    {
-      key: 'readTimeoutSeconds',
-      label: '读取超时',
+      key: 'requestTimeoutSeconds',
+      label: '请求超时',
       type: 'number',
       min: 1,
       max: 3600,
@@ -66,12 +61,14 @@ const HTTP_RUNTIME_SCHEMA: WorkbenchFormSchema = {
       key: 'successCodes',
       label: '成功状态码',
       type: 'text',
-      placeholder: '200,201,204',
+      placeholder: '留空表示 200-299；也可填写 200,201,204',
     },
     {
-      key: 'followRedirects',
-      label: '自动跟随重定向',
-      type: 'switch',
+      key: 'maxResponseBodyCharacters',
+      label: '最大响应体字符数',
+      type: 'number',
+      min: 1,
+      max: 10_000_000,
     },
   ],
 };
@@ -81,7 +78,7 @@ export const httpPlugin: NodePluginDefinition = {
   version: 1,
   metadata: {
     label: 'HTTP 请求',
-    description: '通过 JSON Schema 驱动的表单配置 HTTP API 调用。',
+    description: '调用 HTTP 接口并保存状态码、响应头与响应体。',
     category: '数据处理',
     folderId: 'http',
     folderLabel: 'HTTP',
@@ -111,10 +108,9 @@ export const httpPlugin: NodePluginDefinition = {
   runtime: {
     schema: HTTP_RUNTIME_SCHEMA,
     defaultValue: () => ({
-      connectTimeoutSeconds: 10,
-      readTimeoutSeconds: 60,
-      successCodes: '200,201,204',
-      followRedirects: true,
+      requestTimeoutSeconds: 60,
+      successCodes: '',
+      maxResponseBodyCharacters: 1_000_000,
     }),
   },
   toolbar: [

--- a/yak-ops-ui/src/pages/data-development/workbench/plugins/shell.tsx
+++ b/yak-ops-ui/src/pages/data-development/workbench/plugins/shell.tsx
@@ -41,32 +41,23 @@ export const shellPlugin: NodePluginDefinition = {
       columns: 1,
       fields: [
         {
-          key: 'shell',
-          label: 'Shell',
-          type: 'select',
-          options: [
-            { label: 'bash', value: 'bash' },
-            { label: 'sh', value: 'sh' },
-          ],
-        },
-        {
-          key: 'workingDirectory',
+          key: 'workDirectory',
           label: '工作目录',
           type: 'text',
           placeholder: '/data/yak-ops/work',
         },
         {
-          key: 'environmentVariables',
+          key: 'environment',
           label: '环境变量（JSON）',
           type: 'textarea',
           rows: 6,
+          placeholder: '{\n  "BIZ_DATE": "${bizdate}"\n}',
         },
       ],
     },
     defaultValue: () => ({
-      shell: 'bash',
-      workingDirectory: '',
-      environmentVariables: '{}',
+      workDirectory: '',
+      environment: '{}',
     }),
   },
   toolbar: [

--- a/yak-ops-ui/src/pages/data-development/workbench/repository/workbench.repository.ts
+++ b/yak-ops-ui/src/pages/data-development/workbench/repository/workbench.repository.ts
@@ -1,0 +1,601 @@
+import HttpUtils from '@/utils/HttpUtils';
+import dayjs from 'dayjs';
+import {
+  DEFAULT_COMMON_RUNTIME,
+  type DevelopmentDocument,
+  type DevelopmentResource,
+  type FormResourceContent,
+  type ResourceContent,
+  type ResourceStatus,
+  type WorkspaceSnapshot,
+} from '../core/types';
+
+const API_PREFIX = '/api/v1/data-development';
+const DEFAULT_PROJECT_CODE = 'default';
+const DEFAULT_PROJECT_NAME = '用户数据平台';
+
+interface ApiResponse<T> {
+  code: number;
+  data: T;
+  msg?: string;
+  message?: string;
+}
+
+interface ApiProject {
+  id: number;
+  code: string;
+  name: string;
+  description?: string;
+  createdBy?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface ApiResource {
+  id: number;
+  projectId: number;
+  parentId?: number | null;
+  resourceKind: 'FOLDER' | 'TASK' | 'ASSET';
+  name: string;
+  description?: string;
+  sortOrder: number;
+  ownerId?: string;
+  createdBy?: string;
+  updatedBy?: string;
+  lockVersion: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface ApiTask {
+  id: number;
+  projectId: number;
+  taskType: string;
+  pluginVersion: string;
+  schemaVersion: number;
+  status: ResourceStatus;
+  draftRevision: number;
+  publishedVersionId?: number;
+  engineType?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface ApiDraft {
+  taskId: number;
+  revision: number;
+  pluginVersion: string;
+  schemaVersion: number;
+  definition: Record<string, unknown>;
+  contentDigest: string;
+  updatedBy?: string;
+  updatedAt: string;
+}
+
+interface ApiTaskDetail {
+  resource: ApiResource;
+  task: ApiTask;
+  draft: ApiDraft;
+}
+
+interface ApiWorkspace {
+  project: ApiProject;
+  tasks: ApiTaskDetail[];
+}
+
+interface ApiTaskPlugin {
+  taskType: string;
+  name: string;
+  description: string;
+  category: string;
+  pluginVersion: string;
+  schemaVersion: number;
+}
+
+interface ApiVersion {
+  id: number;
+  taskId: number;
+  versionNumber: number;
+  publishedAt: string;
+}
+
+interface ApiExecution {
+  id: number;
+  taskId: number;
+  status:
+    | 'CREATED'
+    | 'QUEUED'
+    | 'RUNNING'
+    | 'SUCCEEDED'
+    | 'FAILED'
+    | 'CANCELED'
+    | 'TIMED_OUT'
+    | 'LOST';
+  createdAt: string;
+}
+
+export interface WorkbenchBootstrapResult {
+  project: ApiProject;
+  supportedTaskTypes: string[];
+  snapshot: WorkspaceSnapshot;
+}
+
+export interface CreatedExecution {
+  id: string;
+  status: ApiExecution['status'];
+}
+
+const unwrap = <T>(response: ApiResponse<T>): T => {
+  if (response.code !== 0 && response.code !== 200) {
+    throw new Error(response.message ?? response.msg ?? '数据开发接口调用失败');
+  }
+  return response.data;
+};
+
+const formatDateTime = (value?: string) =>
+  value ? dayjs(value).format('YYYY-MM-DD HH:mm') : '-';
+
+const folderIdFor = (taskType: string) =>
+  taskType.trim().toLowerCase().replaceAll('_', '-');
+
+const cloneJson = <T>(value: T): T => structuredClone(value);
+
+const asRecord = (value: unknown): Record<string, unknown> =>
+  value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+
+const parseJsonRecord = (
+  value: unknown,
+  label: string,
+): Record<string, unknown> => {
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  if (typeof value !== 'string' || !value.trim()) return {};
+  try {
+    const parsed = JSON.parse(value);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      throw new Error(`${label}必须是 JSON 对象`);
+    }
+    return parsed as Record<string, unknown>;
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      throw new Error(`${label}不是合法的 JSON`);
+    }
+    throw error;
+  }
+};
+
+const parseIntegerList = (value: unknown): number[] => {
+  if (Array.isArray(value)) {
+    return value
+      .map((item) => Number(item))
+      .filter((item) => Number.isInteger(item));
+  }
+  if (typeof value !== 'string') return [];
+  return value
+    .split(',')
+    .map((item) => Number(item.trim()))
+    .filter((item) => Number.isInteger(item));
+};
+
+const toEditorContent = (
+  taskType: string,
+  content: ResourceContent,
+  config: Record<string, unknown>,
+): ResourceContent => {
+  if (taskType === 'SHELL') {
+    if (content.kind === 'text') return cloneJson(content);
+    const value = content.kind === 'form' ? asRecord(content.value) : {};
+    return {
+      kind: 'text',
+      language: 'shell',
+      value: String(value.command ?? config.command ?? ''),
+    };
+  }
+
+  if (taskType !== 'HTTP' || content.kind !== 'form') return cloneJson(content);
+  const value = asRecord(content.value);
+  return {
+    ...content,
+    value: {
+      ...value,
+      headers:
+        typeof value.headers === 'string'
+          ? value.headers
+          : JSON.stringify(asRecord(value.headers), null, 2),
+    },
+  } satisfies FormResourceContent;
+};
+
+const toEditorRuntimeSpecific = (
+  taskType: string,
+  runtime: Record<string, unknown>,
+): Record<string, unknown> => {
+  if (taskType === 'HTTP') {
+    return {
+      ...runtime,
+      successCodes: Array.isArray(runtime.successCodes)
+        ? runtime.successCodes.join(',')
+        : (runtime.successCodes ?? ''),
+    };
+  }
+  if (taskType === 'SHELL') {
+    return {
+      ...runtime,
+      environment:
+        typeof runtime.environment === 'string'
+          ? runtime.environment
+          : JSON.stringify(asRecord(runtime.environment), null, 2),
+    };
+  }
+  return cloneJson(runtime);
+};
+
+const toApiContent = (
+  taskType: string,
+  content: ResourceContent,
+): ResourceContent => {
+  if (taskType !== 'HTTP' || content.kind !== 'form') return cloneJson(content);
+  const value = asRecord(content.value);
+  return {
+    ...content,
+    value: {
+      ...value,
+      headers: parseJsonRecord(value.headers, '请求头'),
+    },
+  };
+};
+
+const toApiRuntimeSpecific = (
+  taskType: string,
+  runtime: Record<string, unknown>,
+): Record<string, unknown> => {
+  if (taskType === 'HTTP') {
+    return {
+      requestTimeoutSeconds: Number(runtime.requestTimeoutSeconds ?? 60),
+      successCodes: parseIntegerList(runtime.successCodes),
+      maxResponseBodyCharacters: Number(
+        runtime.maxResponseBodyCharacters ?? 1_000_000,
+      ),
+    };
+  }
+  if (taskType === 'SHELL') {
+    return {
+      workDirectory: String(runtime.workDirectory ?? ''),
+      environment: parseJsonRecord(runtime.environment, '环境变量'),
+    };
+  }
+  return cloneJson(runtime);
+};
+
+const toDefinition = (
+  resource: DevelopmentResource,
+  document: DevelopmentDocument,
+) => {
+  const content = toApiContent(resource.resourceType, document.content);
+  const specific = toApiRuntimeSpecific(
+    resource.resourceType,
+    document.runtime.specific,
+  );
+  const contentValue = content.kind === 'form' ? content.value : {};
+  const config =
+    resource.resourceType === 'SHELL' && content.kind === 'text'
+      ? { command: content.value, ...specific }
+      : { ...asRecord(contentValue), ...specific };
+
+  return {
+    schemaVersion: document.schemaVersion,
+    taskType: resource.resourceType,
+    pluginVersion: String(document.config.pluginVersion ?? ''),
+    content,
+    config,
+    runtime: {
+      common: cloneJson(document.runtime.common),
+      specific,
+    },
+    inputs: asRecord(document.config.inputs),
+    outputs: asRecord(document.config.outputs),
+  };
+};
+
+const mapTaskDetail = (
+  detail: ApiTaskDetail,
+): { resource: DevelopmentResource; document: DevelopmentDocument } => {
+  const { resource: source, task, draft } = detail;
+  const definition = asRecord(draft.definition);
+  const runtime = asRecord(definition.runtime);
+  const config = asRecord(definition.config);
+  const content =
+    (definition.content as ResourceContent | undefined) ??
+    ({ kind: 'form', value: {} } satisfies FormResourceContent);
+
+  const resource: DevelopmentResource = {
+    id: String(source.id),
+    projectId: String(source.projectId),
+    parentId: source.parentId ? String(source.parentId) : null,
+    folderId: folderIdFor(task.taskType),
+    nodeType: 'ARTIFACT',
+    resourceType: task.taskType,
+    name: source.name,
+    description: source.description,
+    owner: 'me',
+    updatedBy: source.updatedBy ?? source.ownerId ?? 'system',
+    favorite: false,
+    engine: task.engineType ?? task.taskType,
+    status: task.status,
+    schemaVersion: task.schemaVersion,
+    latestRevision: task.draftRevision,
+    publishedVersion: task.publishedVersionId,
+    createdAt: formatDateTime(source.createdAt),
+    updatedAt: formatDateTime(source.updatedAt),
+  };
+
+  const document: DevelopmentDocument = {
+    resourceId: String(source.id),
+    revision: draft.revision,
+    schemaVersion: draft.schemaVersion,
+    content: toEditorContent(task.taskType, content, config),
+    config: {
+      ...config,
+      pluginVersion: draft.pluginVersion,
+      inputs: asRecord(definition.inputs),
+      outputs: asRecord(definition.outputs),
+    },
+    runtime: {
+      common: {
+        ...DEFAULT_COMMON_RUNTIME,
+        ...asRecord(runtime.common),
+      },
+      specific: toEditorRuntimeSpecific(task.taskType, {
+        ...config,
+        ...asRecord(runtime.specific),
+      }),
+    },
+    dirty: false,
+    loadStatus: 'READY',
+    saveStatus: 'IDLE',
+    updatedAt: formatDateTime(draft.updatedAt),
+  };
+
+  return { resource, document };
+};
+
+const getErrorStatus = (error: unknown): number | undefined => {
+  const candidate = error as {
+    response?: { status?: number };
+    status?: number;
+  };
+  return candidate?.response?.status ?? candidate?.status;
+};
+
+const getErrorMessage = (error: unknown): string => {
+  const candidate = error as {
+    response?: { data?: { message?: string; msg?: string } };
+    message?: string;
+  };
+  return (
+    candidate?.response?.data?.message ??
+    candidate?.response?.data?.msg ??
+    candidate?.message ??
+    '数据开发接口调用失败'
+  );
+};
+
+export const isWorkbenchConflict = (error: unknown) =>
+  getErrorStatus(error) === 409 || getErrorMessage(error).includes('冲突');
+
+export const workbenchErrorMessage = getErrorMessage;
+
+const listProjects = async () =>
+  unwrap(await HttpUtils.get<ApiProject[]>(`${API_PREFIX}/projects`));
+
+const ensureProject = async (): Promise<ApiProject> => {
+  const existing = await listProjects();
+  const defaultProject = existing.find(
+    (project) => project.code === DEFAULT_PROJECT_CODE,
+  );
+  if (defaultProject) return defaultProject;
+  if (existing.length > 0) return existing[0];
+
+  try {
+    return unwrap(
+      await HttpUtils.post<ApiProject>(`${API_PREFIX}/projects`, {
+        code: DEFAULT_PROJECT_CODE,
+        name: DEFAULT_PROJECT_NAME,
+        description: 'Yak Ops 数据开发默认项目',
+      }),
+    );
+  } catch {
+    const projects = await listProjects();
+    if (projects.length > 0) return projects[0];
+    throw new Error('默认数据开发项目创建失败');
+  }
+};
+
+export const workbenchRepository = {
+  async bootstrap(): Promise<WorkbenchBootstrapResult> {
+    const [project, plugins] = await Promise.all([
+      ensureProject(),
+      HttpUtils.get<ApiTaskPlugin[]>(`${API_PREFIX}/task-plugins`).then(unwrap),
+    ]);
+    const workspace = unwrap(
+      await HttpUtils.get<ApiWorkspace>(
+        `${API_PREFIX}/projects/${project.id}/workspace`,
+      ),
+    );
+    const mapped = workspace.tasks.map(mapTaskDetail);
+    const resources = mapped.map((item) => item.resource);
+    const documents = mapped.map((item) => item.document);
+
+    return {
+      project: workspace.project,
+      supportedTaskTypes: plugins.map((plugin) => plugin.taskType),
+      snapshot: {
+        resources,
+        documents,
+        openResourceIds: resources.slice(0, 1).map((resource) => resource.id),
+        activeResourceId: resources[0]?.id,
+      },
+    };
+  },
+
+  async createTask(
+    projectId: string,
+    taskType: string,
+    name: string,
+    engineType: string,
+  ) {
+    const detail = unwrap(
+      await HttpUtils.post<ApiTaskDetail>(
+        `${API_PREFIX}/projects/${projectId}/tasks`,
+        {
+          parentId: null,
+          name: name.trim(),
+          taskType,
+          engineType,
+          sortOrder: 0,
+        },
+      ),
+    );
+    return mapTaskDetail(detail);
+  },
+
+  async saveDraft(
+    resource: DevelopmentResource,
+    document: DevelopmentDocument,
+  ): Promise<DevelopmentDocument> {
+    const draft = unwrap(
+      await HttpUtils.put<ApiDraft>(
+        `${API_PREFIX}/tasks/${resource.id}/draft`,
+        {
+          baseRevision: document.revision,
+          definition: toDefinition(resource, document),
+        },
+      ),
+    );
+    return mapTaskDetail({
+      resource: {
+        id: Number(resource.id),
+        projectId: Number(resource.projectId),
+        parentId: resource.parentId ? Number(resource.parentId) : null,
+        resourceKind: 'TASK',
+        name: resource.name,
+        description: resource.description,
+        sortOrder: 0,
+        ownerId: resource.updatedBy,
+        updatedBy: draft.updatedBy,
+        lockVersion: 0,
+        createdAt: resource.createdAt,
+        updatedAt: draft.updatedAt,
+      },
+      task: {
+        id: Number(resource.id),
+        projectId: Number(resource.projectId),
+        taskType: resource.resourceType,
+        pluginVersion: draft.pluginVersion,
+        schemaVersion: draft.schemaVersion,
+        status: resource.status,
+        draftRevision: draft.revision,
+        publishedVersionId: resource.publishedVersion,
+        engineType: resource.engine,
+        createdAt: resource.createdAt,
+        updatedAt: draft.updatedAt,
+      },
+      draft,
+    }).document;
+  },
+
+  async validate(
+    resource: DevelopmentResource,
+    document: DevelopmentDocument,
+  ) {
+    return unwrap(
+      await HttpUtils.post<{
+        valid: boolean;
+        normalizedDefinition: Record<string, unknown>;
+        contentDigest: string;
+        warnings: string[];
+      }>(`${API_PREFIX}/tasks/${resource.id}/validate`, {
+        definition: toDefinition(resource, document),
+      }),
+    );
+  },
+
+  async publish(
+    resource: DevelopmentResource,
+    document: DevelopmentDocument,
+    comment?: string,
+  ) {
+    return unwrap(
+      await HttpUtils.post<ApiVersion>(
+        `${API_PREFIX}/tasks/${resource.id}/versions`,
+        {
+          draftRevision: document.revision,
+          comment,
+        },
+      ),
+    );
+  },
+
+  async createExecution(
+    resource: DevelopmentResource,
+    document: DevelopmentDocument,
+  ): Promise<CreatedExecution> {
+    const execution = unwrap(
+      await HttpUtils.post<ApiExecution>(
+        `${API_PREFIX}/tasks/${resource.id}/executions`,
+        {
+          sourceType: document.dirty
+            ? 'EPHEMERAL_SNAPSHOT'
+            : 'DRAFT_REVISION',
+          draftRevision: document.dirty ? undefined : document.revision,
+          definitionSnapshot: document.dirty
+            ? toDefinition(resource, document)
+            : undefined,
+          runtime: document.runtime,
+          input: {},
+          idempotencyKey:
+            globalThis.crypto?.randomUUID?.() ??
+            `${resource.id}-${Date.now()}-${Math.random()}`,
+        },
+      ),
+    );
+    return { id: String(execution.id), status: execution.status };
+  },
+
+  async cancelExecution(executionId: string): Promise<CreatedExecution> {
+    const execution = unwrap(
+      await HttpUtils.post<ApiExecution>(
+        `${API_PREFIX}/executions/${executionId}/cancel`,
+        {},
+      ),
+    );
+    return { id: String(execution.id), status: execution.status };
+  },
+
+  async updateResource(
+    resource: DevelopmentResource,
+    patch: Pick<DevelopmentResource, 'name' | 'description'>,
+  ) {
+    return unwrap(
+      await HttpUtils.put<ApiResource>(
+        `${API_PREFIX}/resources/${resource.id}`,
+        {
+          name: patch.name,
+          description: patch.description,
+          sortOrder: 0,
+        },
+      ),
+    );
+  },
+
+  async deleteResource(resourceId: string) {
+    return unwrap(
+      await HttpUtils.delete<{ deleted: boolean }>(
+        `${API_PREFIX}/resources/${resourceId}`,
+      ),
+    );
+  },
+};

--- a/yak-ops-ui/src/pages/data-development/workbench/store/workbench-control.store.ts
+++ b/yak-ops-ui/src/pages/data-development/workbench/store/workbench-control.store.ts
@@ -1,0 +1,135 @@
+import { create } from 'zustand';
+import type { ExecutionStatus, WorkspaceSnapshot } from '../core/types';
+import {
+  workbenchErrorMessage,
+  workbenchRepository,
+} from '../repository/workbench.repository';
+import { useWorkbenchStore } from './workbench.store';
+
+interface WorkbenchControlState {
+  projectId?: string;
+  projectName: string;
+  supportedTaskTypes: string[];
+  workspaceLoading: boolean;
+  workspaceError?: string;
+  executionIdByResourceId: Record<string, string>;
+
+  initialize: () => Promise<void>;
+  setExecutionRecord: (
+    resourceId: string,
+    executionId: string,
+    status: ExecutionStatus,
+  ) => void;
+  clearExecutionRecord: (resourceId: string) => void;
+}
+
+const indexSnapshot = (snapshot: WorkspaceSnapshot) => {
+  const resourcesById = Object.fromEntries(
+    snapshot.resources.map((resource) => [resource.id, resource]),
+  );
+  const documentsByResourceId = Object.fromEntries(
+    snapshot.documents.map((document) => [document.resourceId, document]),
+  );
+  const resourceIdsByFolder = snapshot.resources.reduce<
+    Record<string, string[]>
+  >((groups, resource) => {
+    groups[resource.folderId] = [
+      ...(groups[resource.folderId] ?? []),
+      resource.id,
+    ];
+    return groups;
+  }, {});
+  const expandedFolderIds = Object.keys(resourceIdsByFolder).reduce<
+    Record<string, boolean>
+  >((result, folderId) => {
+    result[folderId] = true;
+    return result;
+  }, {});
+
+  return {
+    resourcesById,
+    documentsByResourceId,
+    resourceIdsByFolder,
+    expandedFolderIds,
+  };
+};
+
+const clearMockWorkspace = () => {
+  useWorkbenchStore.setState({
+    resourcesById: {},
+    documentsByResourceId: {},
+    resourceIdsByFolder: {},
+    openResourceIds: [],
+    activeResourceId: undefined,
+    previewResourceId: undefined,
+    pinnedResourceIds: [],
+    splitResourceId: undefined,
+    expandedFolderIds: {},
+    executionStatusByResourceId: {},
+    scheduleEnabledByResourceId: {},
+  });
+};
+
+clearMockWorkspace();
+
+export const useWorkbenchControlStore = create<WorkbenchControlState>(
+  (set, get) => ({
+    projectId: undefined,
+    projectName: '用户数据平台',
+    supportedTaskTypes: [],
+    workspaceLoading: false,
+    workspaceError: undefined,
+    executionIdByResourceId: {},
+
+    initialize: async () => {
+      if (get().workspaceLoading) return;
+      set({ workspaceLoading: true, workspaceError: undefined });
+      clearMockWorkspace();
+
+      try {
+        const result = await workbenchRepository.bootstrap();
+        const snapshot = result.snapshot;
+        useWorkbenchStore.setState({
+          ...indexSnapshot(snapshot),
+          openResourceIds: snapshot.openResourceIds,
+          activeResourceId: snapshot.activeResourceId,
+          previewResourceId: undefined,
+          pinnedResourceIds: snapshot.openResourceIds,
+          splitResourceId: undefined,
+          executionStatusByResourceId: {},
+          scheduleEnabledByResourceId: {},
+        });
+        set({
+          projectId: String(result.project.id),
+          projectName: result.project.name,
+          supportedTaskTypes: result.supportedTaskTypes,
+          workspaceLoading: false,
+          workspaceError: undefined,
+          executionIdByResourceId: {},
+        });
+      } catch (error) {
+        set({
+          workspaceLoading: false,
+          workspaceError: workbenchErrorMessage(error),
+        });
+      }
+    },
+
+    setExecutionRecord: (resourceId, executionId, status) => {
+      useWorkbenchStore.getState().setExecutionStatus(resourceId, status);
+      set((state) => ({
+        executionIdByResourceId: {
+          ...state.executionIdByResourceId,
+          [resourceId]: executionId,
+        },
+      }));
+    },
+
+    clearExecutionRecord: (resourceId) =>
+      set((state) => {
+        const next = { ...state.executionIdByResourceId };
+        delete next[resourceId];
+        return { executionIdByResourceId: next };
+      }),
+  }),
+);


### PR DESCRIPTION
## Summary

- connect the data-development Workbench to the real project, plugin catalog and workspace APIs
- persist task creation, rename, clone, delete, optimistic draft saves, validation and immutable publication
- create and cancel real execution-ledger records while keeping Gateway/Worker execution out of the control-plane process
- align the frontend HTTP and Shell authoring contracts with the backend task plugins
- add a workspace aggregate endpoint, authenticated operator resolution and HTTP 409 conflict responses
- move data-development datasource defaults into environment-backed application configuration

## User impact

The Workbench no longer boots from mock workspace data for the backend-supported HTTP and Shell task types. Authoring changes now survive refreshes and revision conflicts are surfaced instead of silently overwriting another edit.

## Validation

- TypeScript syntax transpilation passed for the changed Workbench files
- Java source syntax structure check passed
- `application.yml` parsed successfully
- GitHub compare confirms one focused commit with 17 changed files

Full Maven and npm builds could not be run in the execution environment because the repository dependencies/toolchain were unavailable. CI should be treated as the final build verification.

## Scope note

Execution Gateway, Worker dispatch, SSE logs and persisted execution results remain intentionally out of scope for this first control-plane integration phase.