### PR TITLE
feat(data-development): complete execution loop

### DIFF
--- a/docs/data-development/execution-loop.md
+++ b/docs/data-development/execution-loop.md
@@ -1,0 +1,75 @@
+# 数据开发执行闭环
+
+## 目标
+
+第二阶段在第一阶段控制面之上补齐单机执行闭环，复用现有 HTTP、Shell Task Plugin，不把插件逻辑复制到数据开发模块。
+
+```text
+Workbench
+  -> POST Execution Snapshot
+  -> Execution Gateway
+  -> bounded local queue
+  -> Task Plugin Worker
+  -> Attempt / Event / Result
+  -> SSE + execution detail API
+  -> Workbench result panel / instance list
+```
+
+## 状态机
+
+```text
+CREATED -> QUEUED -> RUNNING -> SUCCEEDED
+                            -> FAILED
+                            -> CANCELED
+                            -> TIMED_OUT
+                            -> LOST
+```
+
+Execution 是用户提交的一次稳定快照；Attempt 是 Worker 的一次物理执行。日志按递增 sequence 持久化为 Event，输出持久化为 Result。
+
+## 执行网关
+
+`DataDevelopmentExecutionGateway` 使用有界线程池和队列：
+
+- 数据库事务提交后再投递，避免 Worker 读取不到执行快照；
+- 队列满时将 Execution 标记为 `FAILED`；
+- 超时后调用插件取消钩子，并中断 Worker 线程；
+- 应用重启时重新投递 `CREATED/QUEUED`，将失去本地上下文的 `RUNNING` 标记为 `LOST`；
+- 当前阶段为单机 Worker，未来可将 Gateway 接口替换为消息队列和远程 Worker。
+
+## 插件执行
+
+Worker 通过 `WorkflowTaskExecutorRegistry` 创建真实插件执行器：
+
+- HTTP 使用 JDK HttpClient，支持取消、超时、响应头和响应体输出；
+- Shell 使用 ProcessBuilder，支持进程树终止和逐行日志；
+- runtime parameters 与 execution input 合并到插件参数命名空间；
+- 插件结果转换为统一 `yak_dev_execution_result`。
+
+## 实时事件
+
+```text
+GET /api/v1/data-development/executions/{id}/events/stream
+```
+
+SSE 支持：
+
+- `Last-Event-ID` / `after` 断点重放；
+- 日志、排队、运行、结果和终态事件；
+- 终态后主动完成连接；
+- 前端断流后自动降级为详情轮询。
+
+## 查询接口
+
+```text
+GET /api/v1/data-development/executions
+GET /api/v1/data-development/executions/{id}
+GET /api/v1/data-development/executions/{id}/detail
+POST /api/v1/data-development/executions/{id}/cancel
+```
+
+实例页通过全局查询接口展示真实状态、执行器、耗时和执行人。Workbench 使用详情接口恢复完整日志和结果。
+
+## 当前边界
+
+本阶段完成 HTTP、Shell 的单机执行闭环。SQL、Flink SQL、Python、Notebook、分布式 Worker、结果 Dataset 分页和多 Attempt 重试策略留在后续阶段。

--- a/yak-ops-business/yak-ops-business-data-development/pom.xml
+++ b/yak-ops-business/yak-ops-business-data-development/pom.xml
@@ -14,12 +14,16 @@
     <artifactId>yak-ops-business-data-development</artifactId>
 
     <name>Yak Ops Business Data Development</name>
-    <description>Data-development workspace, task authoring, immutable versions and execution snapshots</description>
+    <description>Data-development workspace, authoring, execution gateway and result streaming</description>
 
     <dependencies>
         <dependency>
             <groupId>io.yak.ops</groupId>
             <artifactId>yak-ops-plugin-task-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.yak.ops</groupId>
+            <artifactId>yak-ops-core</artifactId>
         </dependency>
         <dependency>
             <groupId>io.yak.ops</groupId>

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/api/DataDevelopmentApi.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/api/DataDevelopmentApi.java
@@ -2,6 +2,11 @@ package io.yak.ops.business.development.api;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import io.yak.ops.business.development.domain.DataDevelopmentModel.Draft;
+import io.yak.ops.business.development.domain.DataDevelopmentModel.Execution;
+import io.yak.ops.business.development.domain.DataDevelopmentModel.ExecutionAttempt;
+import io.yak.ops.business.development.domain.DataDevelopmentModel.ExecutionEvent;
+import io.yak.ops.business.development.domain.DataDevelopmentModel.ExecutionResult;
+import io.yak.ops.business.development.domain.DataDevelopmentModel.ExecutionSummary;
 import io.yak.ops.business.development.domain.DataDevelopmentModel.Project;
 import io.yak.ops.business.development.domain.DataDevelopmentModel.Resource;
 import io.yak.ops.business.development.domain.DataDevelopmentModel.Task;
@@ -82,13 +87,7 @@ public final class DataDevelopmentApi {
       Draft draft) {
   }
 
-  /**
-   * Complete authoring snapshot used by the web workbench.
-   *
-   * <p>The workspace endpoint deliberately returns task drafts in one request during the first
-   * integration phase. The API can be split into lazy resource/document loading later without
-   * changing the persisted task envelope.</p>
-   */
+  /** Complete authoring snapshot used by the web workbench. */
   public record WorkspaceView(
       Project project,
       List<TaskDetailView> tasks) {
@@ -99,5 +98,21 @@ public final class DataDevelopmentApi {
       JsonNode normalizedDefinition,
       String contentDigest,
       List<String> warnings) {
+  }
+
+  public record ExecutionDetailView(
+      Execution execution,
+      String taskName,
+      String engineType,
+      List<ExecutionAttempt> attempts,
+      List<ExecutionEvent> events,
+      List<ExecutionResult> results) {
+  }
+
+  public record ExecutionPageView(
+      List<ExecutionSummary> items,
+      long total,
+      int offset,
+      int limit) {
   }
 }

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/config/DataDevelopmentConfiguration.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/config/DataDevelopmentConfiguration.java
@@ -2,9 +2,12 @@ package io.yak.ops.business.development.config;
 
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
+import io.yak.ops.business.development.repository.DataDevelopmentExecutionRepository;
 import io.yak.ops.business.development.repository.DataDevelopmentRepository;
 import io.yak.ops.business.development.service.DataDevelopmentJsonCodec;
+import io.yak.ops.core.workflow.WorkflowTaskExecutorRegistry;
 import io.yak.ops.plugin.task.api.TaskPluginCatalog;
+import java.util.List;
 import javax.sql.DataSource;
 import org.flywaydb.core.Flyway;
 import org.flywaydb.core.api.MigrationVersion;
@@ -16,7 +19,7 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 import org.springframework.transaction.PlatformTransactionManager;
 
-/** Data-development datasource, Flyway and plugin-catalog assembly. */
+/** Data-development datasource, Flyway, plugin catalog and execution runtime assembly. */
 @ConditionalOnDataDevelopmentEnabled
 @Configuration(proxyBeanMethods = false)
 @EnableConfigurationProperties(DataDevelopmentProperties.class)
@@ -66,6 +69,11 @@ public class DataDevelopmentConfiguration {
     return new TaskPluginCatalog();
   }
 
+  @Bean(name = "dataDevelopmentTaskExecutorRegistry")
+  public WorkflowTaskExecutorRegistry dataDevelopmentTaskExecutorRegistry() {
+    return new WorkflowTaskExecutorRegistry(List.of());
+  }
+
   @Bean
   public DataDevelopmentJsonCodec dataDevelopmentJsonCodec() {
     return new DataDevelopmentJsonCodec();
@@ -76,5 +84,12 @@ public class DataDevelopmentConfiguration {
       @Qualifier("dataDevelopmentJdbcTemplate") NamedParameterJdbcTemplate jdbcTemplate,
       DataDevelopmentJsonCodec jsonCodec) {
     return new DataDevelopmentRepository(jdbcTemplate, jsonCodec);
+  }
+
+  @Bean
+  public DataDevelopmentExecutionRepository dataDevelopmentExecutionRepository(
+      @Qualifier("dataDevelopmentJdbcTemplate") NamedParameterJdbcTemplate jdbcTemplate,
+      DataDevelopmentJsonCodec jsonCodec) {
+    return new DataDevelopmentExecutionRepository(jdbcTemplate, jsonCodec);
   }
 }

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/config/DataDevelopmentProperties.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/config/DataDevelopmentProperties.java
@@ -2,12 +2,13 @@ package io.yak.ops.business.development.config;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
-/** Persistence settings for the data-development control plane. */
+/** Persistence and local execution-gateway settings for data development. */
 @ConfigurationProperties(prefix = "yak.data-development")
 public class DataDevelopmentProperties {
 
   private boolean enabled;
   private final Datasource datasource = new Datasource();
+  private final Execution execution = new Execution();
 
   public boolean isEnabled() {
     return enabled;
@@ -19,6 +20,10 @@ public class DataDevelopmentProperties {
 
   public Datasource getDatasource() {
     return datasource;
+  }
+
+  public Execution getExecution() {
+    return execution;
   }
 
   public static class Datasource {
@@ -76,6 +81,64 @@ public class DataDevelopmentProperties {
 
     public void setMinimumIdle(int minimumIdle) {
       this.minimumIdle = minimumIdle;
+    }
+  }
+
+  public static class Execution {
+
+    private int corePoolSize = 4;
+    private int maximumPoolSize = 16;
+    private int queueCapacity = 200;
+    private int defaultTimeoutSeconds = 300;
+    private int eventReplayLimit = 1000;
+    private String workerId = "local-worker";
+
+    public int getCorePoolSize() {
+      return corePoolSize;
+    }
+
+    public void setCorePoolSize(int corePoolSize) {
+      this.corePoolSize = corePoolSize;
+    }
+
+    public int getMaximumPoolSize() {
+      return maximumPoolSize;
+    }
+
+    public void setMaximumPoolSize(int maximumPoolSize) {
+      this.maximumPoolSize = maximumPoolSize;
+    }
+
+    public int getQueueCapacity() {
+      return queueCapacity;
+    }
+
+    public void setQueueCapacity(int queueCapacity) {
+      this.queueCapacity = queueCapacity;
+    }
+
+    public int getDefaultTimeoutSeconds() {
+      return defaultTimeoutSeconds;
+    }
+
+    public void setDefaultTimeoutSeconds(int defaultTimeoutSeconds) {
+      this.defaultTimeoutSeconds = defaultTimeoutSeconds;
+    }
+
+    public int getEventReplayLimit() {
+      return eventReplayLimit;
+    }
+
+    public void setEventReplayLimit(int eventReplayLimit) {
+      this.eventReplayLimit = eventReplayLimit;
+    }
+
+    public String getWorkerId() {
+      return workerId;
+    }
+
+    public void setWorkerId(String workerId) {
+      this.workerId = workerId;
     }
   }
 }

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/controller/v1/DataDevelopmentController.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/controller/v1/DataDevelopmentController.java
@@ -5,6 +5,8 @@ import io.yak.ops.business.development.api.DataDevelopmentApi.CreateExecutionReq
 import io.yak.ops.business.development.api.DataDevelopmentApi.CreateFolderRequest;
 import io.yak.ops.business.development.api.DataDevelopmentApi.CreateProjectRequest;
 import io.yak.ops.business.development.api.DataDevelopmentApi.CreateTaskRequest;
+import io.yak.ops.business.development.api.DataDevelopmentApi.ExecutionDetailView;
+import io.yak.ops.business.development.api.DataDevelopmentApi.ExecutionPageView;
 import io.yak.ops.business.development.api.DataDevelopmentApi.MoveResourceRequest;
 import io.yak.ops.business.development.api.DataDevelopmentApi.PublishTaskRequest;
 import io.yak.ops.business.development.api.DataDevelopmentApi.SaveDraftRequest;
@@ -20,6 +22,8 @@ import io.yak.ops.business.development.domain.DataDevelopmentModel.Project;
 import io.yak.ops.business.development.domain.DataDevelopmentModel.Resource;
 import io.yak.ops.business.development.domain.DataDevelopmentModel.ResourceKind;
 import io.yak.ops.business.development.domain.DataDevelopmentModel.Version;
+import io.yak.ops.business.development.execution.DataDevelopmentExecutionEventStream;
+import io.yak.ops.business.development.service.DataDevelopmentExecutionService;
 import io.yak.ops.business.development.service.DataDevelopmentService;
 import io.yak.ops.business.development.service.TaskPluginCatalogService;
 import io.yak.ops.plugin.task.api.TaskPluginFactory.Descriptor;
@@ -27,29 +31,38 @@ import jakarta.validation.Valid;
 import java.security.Principal;
 import java.util.List;
 import java.util.Map;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
-/** Data-development workspace, task authoring, publication and execution-snapshot API. */
+/** Data-development workspace, task authoring, publication and execution API. */
 @ConditionalOnDataDevelopmentEnabled
 @RestController
 @RequestMapping("/api/v1/data-development")
 public class DataDevelopmentController {
 
   private final DataDevelopmentService service;
+  private final DataDevelopmentExecutionService executionService;
+  private final DataDevelopmentExecutionEventStream executionEventStream;
   private final TaskPluginCatalogService pluginCatalogService;
 
   public DataDevelopmentController(
       DataDevelopmentService service,
+      DataDevelopmentExecutionService executionService,
+      DataDevelopmentExecutionEventStream executionEventStream,
       TaskPluginCatalogService pluginCatalogService) {
     this.service = service;
+    this.executionService = executionService;
+    this.executionEventStream = executionEventStream;
     this.pluginCatalogService = pluginCatalogService;
   }
 
@@ -154,24 +167,55 @@ public class DataDevelopmentController {
       @PathVariable long taskId,
       @Valid @RequestBody CreateExecutionRequest request,
       Principal principal) {
-    return Result.success(service.createExecution(taskId, request, operator(principal)));
+    return Result.success(
+        executionService.createExecution(taskId, request, operator(principal)));
   }
 
   @GetMapping("/tasks/{taskId}/executions")
-  public Result<List<Execution>> listExecutions(
+  public Result<List<Execution>> listTaskExecutions(
       @PathVariable long taskId,
       @RequestParam(defaultValue = "50") int limit) {
-    return Result.success(service.listExecutions(taskId, limit));
+    return Result.success(executionService.listTaskExecutions(taskId, limit));
+  }
+
+  @GetMapping("/executions")
+  public Result<ExecutionPageView> listExecutions(
+      @RequestParam(required = false) String status,
+      @RequestParam(required = false) String taskType,
+      @RequestParam(required = false) String keyword,
+      @RequestParam(defaultValue = "0") int offset,
+      @RequestParam(defaultValue = "50") int limit) {
+    return Result.success(
+        executionService.listExecutions(status, taskType, keyword, offset, limit));
   }
 
   @GetMapping("/executions/{executionId}")
   public Result<Execution> getExecution(@PathVariable long executionId) {
-    return Result.success(service.getExecution(executionId));
+    return Result.success(executionService.getExecution(executionId));
+  }
+
+  @GetMapping("/executions/{executionId}/detail")
+  public Result<ExecutionDetailView> getExecutionDetail(
+      @PathVariable long executionId,
+      @RequestParam(defaultValue = "0") long after) {
+    return Result.success(executionService.getExecutionDetail(executionId, after));
+  }
+
+  @GetMapping(
+      path = "/executions/{executionId}/events/stream",
+      produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+  public SseEmitter streamExecutionEvents(
+      @PathVariable long executionId,
+      @RequestParam(defaultValue = "0") long after,
+      @RequestHeader(value = "Last-Event-ID", required = false) String lastEventId) {
+    return executionEventStream.subscribe(
+        executionId,
+        Math.max(after, parseSequence(lastEventId)));
   }
 
   @PostMapping("/executions/{executionId}/cancel")
   public Result<Execution> cancelExecution(@PathVariable long executionId) {
-    return Result.success(service.cancelExecution(executionId));
+    return Result.success(executionService.cancelExecution(executionId));
   }
 
   @PutMapping("/resources/{resourceId}")
@@ -196,6 +240,17 @@ public class DataDevelopmentController {
       Principal principal) {
     service.deleteResource(resourceId, operator(principal));
     return Result.success(Map.of("deleted", true));
+  }
+
+  private static long parseSequence(String value) {
+    if (value == null || value.isBlank()) {
+      return 0L;
+    }
+    try {
+      return Math.max(0L, Long.parseLong(value));
+    } catch (NumberFormatException ignored) {
+      return 0L;
+    }
   }
 
   private static String operator(Principal principal) {

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/domain/DataDevelopmentModel.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/domain/DataDevelopmentModel.java
@@ -3,7 +3,7 @@ package io.yak.ops.business.development.domain;
 import com.fasterxml.jackson.databind.JsonNode;
 import java.time.LocalDateTime;
 
-/** Compact domain records for the data-development control plane. */
+/** Compact domain records for the data-development control and execution planes. */
 public final class DataDevelopmentModel {
 
   private DataDevelopmentModel() {
@@ -135,6 +135,60 @@ public final class DataDevelopmentModel {
       LocalDateTime startedAt,
       LocalDateTime finishedAt,
       String errorCode,
+      String errorMessage) {
+  }
+
+  public record ExecutionAttempt(
+      Long id,
+      Long executionId,
+      int attemptNo,
+      String executorType,
+      String workerId,
+      String externalExecutionId,
+      ExecutionStatus status,
+      Integer exitCode,
+      String errorCode,
+      String errorMessage,
+      LocalDateTime startedAt,
+      LocalDateTime finishedAt) {
+  }
+
+  public record ExecutionEvent(
+      Long id,
+      Long executionId,
+      Long attemptId,
+      long sequenceNo,
+      String eventType,
+      JsonNode payload,
+      LocalDateTime occurredAt) {
+  }
+
+  public record ExecutionResult(
+      Long id,
+      Long executionId,
+      Long attemptId,
+      String resultKind,
+      int schemaVersion,
+      JsonNode summary,
+      JsonNode payload,
+      String datasetRef,
+      boolean truncated,
+      LocalDateTime createdAt) {
+  }
+
+  public record ExecutionSummary(
+      Long id,
+      Long taskId,
+      String taskName,
+      String taskType,
+      String engineType,
+      ExecutionSourceType sourceType,
+      ExecutionStatus status,
+      int currentAttemptNo,
+      String createdBy,
+      LocalDateTime createdAt,
+      LocalDateTime startedAt,
+      LocalDateTime finishedAt,
       String errorMessage) {
   }
 }

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/execution/DataDevelopmentExecutionEventStream.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/execution/DataDevelopmentExecutionEventStream.java
@@ -1,0 +1,157 @@
+package io.yak.ops.business.development.execution;
+
+import io.yak.ops.business.development.config.ConditionalOnDataDevelopmentEnabled;
+import io.yak.ops.business.development.config.DataDevelopmentProperties;
+import io.yak.ops.business.development.domain.DataDevelopmentModel.ExecutionEvent;
+import io.yak.ops.business.development.repository.DataDevelopmentExecutionRepository;
+import io.yak.ops.business.development.repository.DataDevelopmentRepository;
+import io.yak.ops.business.development.service.DataDevelopmentJsonCodec;
+import jakarta.annotation.PreDestroy;
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+/** Persists execution events and fans them out to browser SSE subscribers. */
+@ConditionalOnDataDevelopmentEnabled
+@Component
+public class DataDevelopmentExecutionEventStream {
+
+  private static final String SSE_EVENT_NAME = "execution-event";
+
+  private final DataDevelopmentExecutionRepository repository;
+  private final DataDevelopmentRepository controlRepository;
+  private final DataDevelopmentJsonCodec json;
+  private final int replayLimit;
+  private final Map<Long, CopyOnWriteArrayList<SseEmitter>> emitters = new ConcurrentHashMap<>();
+  private final Map<Long, Object> sequenceLocks = new ConcurrentHashMap<>();
+
+  public DataDevelopmentExecutionEventStream(
+      DataDevelopmentExecutionRepository repository,
+      DataDevelopmentRepository controlRepository,
+      DataDevelopmentJsonCodec json,
+      DataDevelopmentProperties properties) {
+    this.repository = repository;
+    this.controlRepository = controlRepository;
+    this.json = json;
+    this.replayLimit = Math.max(100, properties.getExecution().getEventReplayLimit());
+  }
+
+  public ExecutionEvent publish(
+      long executionId,
+      Long attemptId,
+      String eventType,
+      Object payload) {
+    ExecutionEvent event;
+    Object lock = sequenceLocks.computeIfAbsent(executionId, ignored -> new Object());
+    synchronized (lock) {
+      long sequence = repository.nextEventSequence(executionId);
+      event = repository.insertEvent(
+          executionId,
+          attemptId,
+          sequence,
+          eventType,
+          json.write(json.toTree(payload == null ? Map.of() : payload)),
+          LocalDateTime.now());
+    }
+    broadcast(event);
+    if (terminal(eventType)) {
+      complete(executionId);
+      sequenceLocks.remove(executionId);
+    }
+    return event;
+  }
+
+  public SseEmitter subscribe(long executionId, long afterSequence) {
+    var execution = controlRepository.findExecution(executionId)
+        .orElseThrow(() -> new IllegalArgumentException("任务执行不存在：" + executionId));
+    SseEmitter emitter = new SseEmitter(0L);
+    CopyOnWriteArrayList<SseEmitter> subscribers = emitters.computeIfAbsent(
+        executionId,
+        ignored -> new CopyOnWriteArrayList<>());
+
+    try {
+      List<ExecutionEvent> replay = repository.listEvents(
+          executionId,
+          Math.max(0L, afterSequence),
+          replayLimit);
+      for (ExecutionEvent event : replay) {
+        send(emitter, event);
+      }
+      if (execution.status().terminal()) {
+        emitter.complete();
+        return emitter;
+      }
+      subscribers.add(emitter);
+      emitter.onCompletion(() -> remove(executionId, emitter));
+      emitter.onTimeout(() -> remove(executionId, emitter));
+      emitter.onError(error -> remove(executionId, emitter));
+    } catch (IOException error) {
+      emitter.completeWithError(error);
+    }
+    return emitter;
+  }
+
+  private void broadcast(ExecutionEvent event) {
+    List<SseEmitter> subscribers = emitters.getOrDefault(
+        event.executionId(),
+        new CopyOnWriteArrayList<>());
+    for (SseEmitter emitter : subscribers) {
+      try {
+        send(emitter, event);
+      } catch (IOException | IllegalStateException error) {
+        remove(event.executionId(), emitter);
+      }
+    }
+  }
+
+  private static void send(SseEmitter emitter, ExecutionEvent event) throws IOException {
+    emitter.send(SseEmitter.event()
+        .id(Long.toString(event.sequenceNo()))
+        .name(SSE_EVENT_NAME)
+        .data(event));
+  }
+
+  private void complete(long executionId) {
+    List<SseEmitter> subscribers = emitters.remove(executionId);
+    if (subscribers == null) {
+      return;
+    }
+    subscribers.forEach(emitter -> {
+      try {
+        emitter.complete();
+      } catch (IllegalStateException ignored) {
+        // The client may already have disconnected.
+      }
+    });
+  }
+
+  private void remove(long executionId, SseEmitter emitter) {
+    List<SseEmitter> subscribers = emitters.get(executionId);
+    if (subscribers == null) {
+      return;
+    }
+    subscribers.remove(emitter);
+    if (subscribers.isEmpty()) {
+      emitters.remove(executionId, subscribers);
+    }
+  }
+
+  private static boolean terminal(String eventType) {
+    return "EXECUTION_SUCCEEDED".equals(eventType)
+        || "EXECUTION_FAILED".equals(eventType)
+        || "EXECUTION_CANCELED".equals(eventType)
+        || "EXECUTION_TIMED_OUT".equals(eventType)
+        || "EXECUTION_LOST".equals(eventType);
+  }
+
+  @PreDestroy
+  public void close() {
+    emitters.values().forEach(values -> values.forEach(SseEmitter::complete));
+    emitters.clear();
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/execution/DataDevelopmentExecutionGateway.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/execution/DataDevelopmentExecutionGateway.java
@@ -1,0 +1,281 @@
+package io.yak.ops.business.development.execution;
+
+import io.yak.ops.business.development.config.ConditionalOnDataDevelopmentEnabled;
+import io.yak.ops.business.development.config.DataDevelopmentProperties;
+import io.yak.ops.business.development.domain.DataDevelopmentModel.Execution;
+import io.yak.ops.business.development.domain.DataDevelopmentModel.ExecutionStatus;
+import io.yak.ops.business.development.repository.DataDevelopmentExecutionRepository;
+import io.yak.ops.business.development.repository.DataDevelopmentRepository;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+/** Local bounded gateway that dispatches durable executions to task-plugin workers. */
+@ConditionalOnDataDevelopmentEnabled
+@DependsOn("dataDevelopmentFlyway")
+@Component
+public class DataDevelopmentExecutionGateway {
+
+  private final DataDevelopmentRepository controlRepository;
+  private final DataDevelopmentExecutionRepository executionRepository;
+  private final DataDevelopmentExecutionWorker worker;
+  private final DataDevelopmentExecutionRuntimeRegistry runtimeRegistry;
+  private final DataDevelopmentExecutionEventStream eventStream;
+  private final ThreadPoolExecutor executor;
+  private final ScheduledExecutorService scheduler;
+  private final int defaultTimeoutSeconds;
+  private final Map<Long, FutureTask<Void>> tasks = new ConcurrentHashMap<>();
+  private final Map<Long, ScheduledFuture<?>> timeouts = new ConcurrentHashMap<>();
+
+  public DataDevelopmentExecutionGateway(
+      DataDevelopmentRepository controlRepository,
+      DataDevelopmentExecutionRepository executionRepository,
+      DataDevelopmentExecutionWorker worker,
+      DataDevelopmentExecutionRuntimeRegistry runtimeRegistry,
+      DataDevelopmentExecutionEventStream eventStream,
+      DataDevelopmentProperties properties) {
+    this.controlRepository = controlRepository;
+    this.executionRepository = executionRepository;
+    this.worker = worker;
+    this.runtimeRegistry = runtimeRegistry;
+    this.eventStream = eventStream;
+
+    DataDevelopmentProperties.Execution settings = properties.getExecution();
+    int corePoolSize = Math.max(1, settings.getCorePoolSize());
+    int maximumPoolSize = Math.max(corePoolSize, settings.getMaximumPoolSize());
+    int queueCapacity = Math.max(1, settings.getQueueCapacity());
+    this.defaultTimeoutSeconds = Math.max(1, settings.getDefaultTimeoutSeconds());
+    this.executor = new ThreadPoolExecutor(
+        corePoolSize,
+        maximumPoolSize,
+        60L,
+        TimeUnit.SECONDS,
+        new LinkedBlockingQueue<>(queueCapacity),
+        namedFactory("yak-data-development-worker-"),
+        new ThreadPoolExecutor.AbortPolicy());
+    this.executor.allowCoreThreadTimeOut(true);
+    this.scheduler = java.util.concurrent.Executors.newSingleThreadScheduledExecutor(
+        namedFactory("yak-data-development-timeout-"));
+  }
+
+  public void dispatchAfterCommit(long executionId) {
+    if (!TransactionSynchronizationManager.isSynchronizationActive()) {
+      dispatch(executionId);
+      return;
+    }
+    TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+      @Override
+      public void afterCommit() {
+        dispatch(executionId);
+      }
+    });
+  }
+
+  public void dispatch(long executionId) {
+    Execution execution = requireExecution(executionId);
+    if (execution.status().terminal() || execution.status() == ExecutionStatus.RUNNING) {
+      return;
+    }
+    if (execution.status() == ExecutionStatus.CREATED) {
+      if (executionRepository.markQueued(executionId) != 1) {
+        return;
+      }
+      eventStream.publish(
+          executionId,
+          null,
+          "EXECUTION_QUEUED",
+          Map.of("status", ExecutionStatus.QUEUED.name()));
+      execution = requireExecution(executionId);
+    }
+    if (execution.status() != ExecutionStatus.QUEUED) {
+      return;
+    }
+
+    FutureTask<Void> task = new FutureTask<>(() -> {
+      worker.execute(executionId);
+      return null;
+    }) {
+      @Override
+      protected void done() {
+        tasks.remove(executionId, this);
+        ScheduledFuture<?> timeout = timeouts.remove(executionId);
+        if (timeout != null) {
+          timeout.cancel(false);
+        }
+      }
+    };
+
+    if (tasks.putIfAbsent(executionId, task) != null) {
+      return;
+    }
+    try {
+      executor.execute(task);
+      int timeoutSeconds = timeoutSeconds(execution);
+      timeouts.put(
+          executionId,
+          scheduler.schedule(
+              () -> timeout(executionId, timeoutSeconds),
+              timeoutSeconds,
+              TimeUnit.SECONDS));
+    } catch (RejectedExecutionException error) {
+      tasks.remove(executionId, task);
+      failQueueSubmission(executionId);
+    }
+  }
+
+  public Execution cancel(long executionId) {
+    Execution execution = requireExecution(executionId);
+    if (execution.status().terminal()) {
+      return execution;
+    }
+    LocalDateTime now = LocalDateTime.now();
+    if (executionRepository.markCanceled(executionId, now) == 1) {
+      executionRepository.completeRunningAttempt(
+          executionId,
+          ExecutionStatus.CANCELED,
+          null,
+          "用户取消执行",
+          now);
+      Long attemptId = runtimeRegistry.attemptId(executionId);
+      runtimeRegistry.cancel(executionId);
+      FutureTask<Void> task = tasks.get(executionId);
+      if (task != null) {
+        task.cancel(true);
+      }
+      ScheduledFuture<?> timeout = timeouts.remove(executionId);
+      if (timeout != null) {
+        timeout.cancel(false);
+      }
+      eventStream.publish(
+          executionId,
+          attemptId,
+          "EXECUTION_CANCELED",
+          Map.of("status", ExecutionStatus.CANCELED.name()));
+    }
+    return requireExecution(executionId);
+  }
+
+  private void timeout(long executionId, int timeoutSeconds) {
+    LocalDateTime now = LocalDateTime.now();
+    String message = "执行超过 " + timeoutSeconds + " 秒，已请求终止";
+    if (executionRepository.markTimedOut(executionId, message, now) != 1) {
+      return;
+    }
+    executionRepository.completeRunningAttempt(
+        executionId,
+        ExecutionStatus.TIMED_OUT,
+        "EXECUTION_TIMEOUT",
+        message,
+        now);
+    Long attemptId = runtimeRegistry.attemptId(executionId);
+    runtimeRegistry.cancel(executionId);
+    FutureTask<Void> task = tasks.get(executionId);
+    if (task != null) {
+      task.cancel(true);
+    }
+    eventStream.publish(
+        executionId,
+        attemptId,
+        "EXECUTION_TIMED_OUT",
+        Map.of(
+            "status", ExecutionStatus.TIMED_OUT.name(),
+            "timeoutSeconds", timeoutSeconds,
+            "errorMessage", message));
+  }
+
+  private void failQueueSubmission(long executionId) {
+    LocalDateTime now = LocalDateTime.now();
+    String message = "执行队列已满，请稍后重试";
+    if (executionRepository.markFailed(
+        executionId,
+        "EXECUTION_QUEUE_REJECTED",
+        message,
+        now) == 1) {
+      eventStream.publish(
+          executionId,
+          null,
+          "EXECUTION_FAILED",
+          Map.of(
+              "status", ExecutionStatus.FAILED.name(),
+              "errorCode", "EXECUTION_QUEUE_REJECTED",
+              "errorMessage", message));
+    }
+  }
+
+  private int timeoutSeconds(Execution execution) {
+    int configured = execution.runtimeSnapshot()
+        .path("common")
+        .path("timeoutSeconds")
+        .asInt(defaultTimeoutSeconds);
+    return configured > 0 ? configured : defaultTimeoutSeconds;
+  }
+
+  private Execution requireExecution(long executionId) {
+    return controlRepository.findExecution(executionId)
+        .orElseThrow(() -> new IllegalArgumentException("任务执行不存在：" + executionId));
+  }
+
+  @PostConstruct
+  public void recover() {
+    for (Long executionId : executionRepository.listRecoverableExecutionIds(500)) {
+      Execution execution = requireExecution(executionId);
+      if (execution.status() == ExecutionStatus.RUNNING) {
+        LocalDateTime now = LocalDateTime.now();
+        String message = "服务重启后无法恢复本地运行上下文";
+        executionRepository.completeRunningAttempt(
+            executionId,
+            ExecutionStatus.LOST,
+            "WORKER_RESTARTED",
+            message,
+            now);
+        if (executionRepository.markLost(executionId, message, now) == 1) {
+          eventStream.publish(
+              executionId,
+              null,
+              "EXECUTION_LOST",
+              Map.of(
+                  "status", ExecutionStatus.LOST.name(),
+                  "errorMessage", message));
+        }
+      } else {
+        dispatch(executionId);
+      }
+    }
+  }
+
+  @PreDestroy
+  public void close() {
+    tasks.values().forEach(task -> task.cancel(true));
+    runtimeRegistryCancelAll();
+    scheduler.shutdownNow();
+    executor.shutdownNow();
+  }
+
+  private void runtimeRegistryCancelAll() {
+    tasks.keySet().forEach(runtimeRegistry::cancel);
+  }
+
+  private static ThreadFactory namedFactory(String prefix) {
+    AtomicInteger sequence = new AtomicInteger();
+    return runnable -> {
+      Thread thread = new Thread(runnable, prefix + sequence.incrementAndGet());
+      thread.setDaemon(true);
+      return thread;
+    };
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/execution/DataDevelopmentExecutionRuntimeRegistry.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/execution/DataDevelopmentExecutionRuntimeRegistry.java
@@ -1,0 +1,85 @@
+package io.yak.ops.business.development.execution;
+
+import io.yak.ops.business.development.config.ConditionalOnDataDevelopmentEnabled;
+import io.yak.ops.spi.workflow.WorkflowCancellationToken;
+import io.yak.ops.spi.workflow.WorkflowTaskContext;
+import io.yak.ops.spi.workflow.WorkflowTaskExecutor;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.springframework.stereotype.Component;
+
+/** Tracks in-process plugin executions so cancel and timeout requests reach the real executor. */
+@ConditionalOnDataDevelopmentEnabled
+@Component
+public class DataDevelopmentExecutionRuntimeRegistry {
+
+  private final ConcurrentMap<Long, RunningExecution> running = new ConcurrentHashMap<>();
+
+  public CancellationSignal newSignal() {
+    return new CancellationSignal();
+  }
+
+  public void register(
+      long executionId,
+      long attemptId,
+      CancellationSignal signal,
+      WorkflowTaskExecutor executor,
+      WorkflowTaskContext context) {
+    RunningExecution value = new RunningExecution(
+        attemptId,
+        signal,
+        executor,
+        context,
+        Thread.currentThread());
+    if (running.putIfAbsent(executionId, value) != null) {
+      throw new IllegalStateException("执行已经在当前 Worker 中运行：" + executionId);
+    }
+  }
+
+  public void unregister(long executionId) {
+    running.remove(executionId);
+  }
+
+  public boolean cancel(long executionId) {
+    RunningExecution value = running.get(executionId);
+    if (value == null) {
+      return false;
+    }
+    value.signal().cancel();
+    try {
+      value.executor().cancel(value.context());
+    } catch (Exception ignored) {
+      // Cancellation remains best effort; the worker thread is interrupted below as a fallback.
+    }
+    value.thread().interrupt();
+    return true;
+  }
+
+  public Long attemptId(long executionId) {
+    RunningExecution value = running.get(executionId);
+    return value == null ? null : value.attemptId();
+  }
+
+  public static final class CancellationSignal implements WorkflowCancellationToken {
+
+    private final AtomicBoolean canceled = new AtomicBoolean();
+
+    @Override
+    public boolean isCancellationRequested() {
+      return canceled.get() || Thread.currentThread().isInterrupted();
+    }
+
+    public void cancel() {
+      canceled.set(true);
+    }
+  }
+
+  private record RunningExecution(
+      long attemptId,
+      CancellationSignal signal,
+      WorkflowTaskExecutor executor,
+      WorkflowTaskContext context,
+      Thread thread) {
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/execution/DataDevelopmentExecutionWorker.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/execution/DataDevelopmentExecutionWorker.java
@@ -1,0 +1,312 @@
+package io.yak.ops.business.development.execution;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.yak.ops.business.development.config.ConditionalOnDataDevelopmentEnabled;
+import io.yak.ops.business.development.config.DataDevelopmentProperties;
+import io.yak.ops.business.development.domain.DataDevelopmentModel.Execution;
+import io.yak.ops.business.development.domain.DataDevelopmentModel.ExecutionStatus;
+import io.yak.ops.business.development.repository.DataDevelopmentExecutionRepository;
+import io.yak.ops.business.development.repository.DataDevelopmentRepository;
+import io.yak.ops.business.development.service.DataDevelopmentJsonCodec;
+import io.yak.ops.core.workflow.WorkflowTaskExecutorRegistry;
+import io.yak.ops.plugin.task.api.TaskPluginCatalog;
+import io.yak.ops.spi.workflow.WorkflowTaskContext;
+import io.yak.ops.spi.workflow.WorkflowTaskExecutor;
+import io.yak.ops.spi.workflow.WorkflowTaskResult;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.CancellationException;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+
+/** Executes one durable data-development execution through an existing task plugin. */
+@ConditionalOnDataDevelopmentEnabled
+@Component
+public class DataDevelopmentExecutionWorker {
+
+  private static final int MAX_LOG_LINE_LENGTH = 16_000;
+
+  private final DataDevelopmentRepository controlRepository;
+  private final DataDevelopmentExecutionRepository executionRepository;
+  private final DataDevelopmentJsonCodec json;
+  private final TaskPluginCatalog taskPluginCatalog;
+  private final WorkflowTaskExecutorRegistry executorRegistry;
+  private final DataDevelopmentExecutionRuntimeRegistry runtimeRegistry;
+  private final DataDevelopmentExecutionEventStream eventStream;
+  private final String workerId;
+
+  public DataDevelopmentExecutionWorker(
+      DataDevelopmentRepository controlRepository,
+      DataDevelopmentExecutionRepository executionRepository,
+      DataDevelopmentJsonCodec json,
+      TaskPluginCatalog taskPluginCatalog,
+      @Qualifier("dataDevelopmentTaskExecutorRegistry")
+      WorkflowTaskExecutorRegistry executorRegistry,
+      DataDevelopmentExecutionRuntimeRegistry runtimeRegistry,
+      DataDevelopmentExecutionEventStream eventStream,
+      DataDevelopmentProperties properties) {
+    this.controlRepository = controlRepository;
+    this.executionRepository = executionRepository;
+    this.json = json;
+    this.taskPluginCatalog = taskPluginCatalog;
+    this.executorRegistry = executorRegistry;
+    this.runtimeRegistry = runtimeRegistry;
+    this.eventStream = eventStream;
+    this.workerId = properties.getExecution().getWorkerId();
+  }
+
+  public void execute(long executionId) {
+    Execution queued = requireExecution(executionId);
+    if (queued.status().terminal()) {
+      return;
+    }
+
+    int attemptNo = queued.currentAttemptNo() + 1;
+    LocalDateTime startedAt = LocalDateTime.now();
+    if (executionRepository.markRunning(executionId, attemptNo, startedAt) != 1) {
+      return;
+    }
+
+    Execution execution = requireExecution(executionId);
+    long attemptId = executionRepository.insertAttempt(
+        executionId,
+        attemptNo,
+        execution.taskType(),
+        workerId,
+        startedAt);
+    eventStream.publish(
+        executionId,
+        attemptId,
+        "EXECUTION_RUNNING",
+        Map.of("status", ExecutionStatus.RUNNING.name(), "attemptNo", attemptNo));
+
+    WorkflowTaskExecutor executor = executorRegistry.require(execution.taskType());
+    DataDevelopmentExecutionRuntimeRegistry.CancellationSignal cancellation =
+        runtimeRegistry.newSignal();
+    Map<String, Object> configuration = configuration(execution);
+    Map<String, Object> inputs = runtimeParameters(execution);
+    WorkflowTaskContext context = new WorkflowTaskContext(
+        execution.id(),
+        execution.taskId(),
+        attemptId,
+        attemptNo,
+        Long.toString(execution.taskId()),
+        execution.taskType(),
+        configuration,
+        inputs,
+        cancellation,
+        line -> eventStream.publish(
+            executionId,
+            attemptId,
+            "LOG",
+            Map.of("level", "INFO", "line", sanitizeLine(line))));
+
+    runtimeRegistry.register(executionId, attemptId, cancellation, executor, context);
+    long startedNanos = System.nanoTime();
+    try {
+      WorkflowTaskResult result = executor.execute(context);
+      cancellation.throwIfCancellationRequested();
+      if (result.success()) {
+        finishSucceeded(execution, attemptId, result, startedAt, startedNanos);
+      } else {
+        finishFailed(
+            executionId,
+            attemptId,
+            "PLUGIN_EXECUTION_FAILED",
+            defaultMessage(result.message(), "任务插件返回失败"));
+      }
+    } catch (CancellationException error) {
+      finishInterrupted(executionId, attemptId, error.getMessage());
+    } catch (InterruptedException error) {
+      Thread.currentThread().interrupt();
+      finishInterrupted(executionId, attemptId, "执行线程被中断");
+    } catch (Exception error) {
+      finishFailed(
+          executionId,
+          attemptId,
+          error.getClass().getSimpleName(),
+          defaultMessage(error.getMessage(), "任务插件执行异常"));
+    } finally {
+      runtimeRegistry.unregister(executionId);
+    }
+  }
+
+  private void finishSucceeded(
+      Execution execution,
+      long attemptId,
+      WorkflowTaskResult result,
+      LocalDateTime startedAt,
+      long startedNanos) {
+    LocalDateTime finishedAt = LocalDateTime.now();
+    if (currentStatus(execution.id()) != ExecutionStatus.RUNNING) {
+      finishInterrupted(execution.id(), attemptId, "执行状态已被外部终止");
+      return;
+    }
+
+    long durationMs = Duration.ofNanos(System.nanoTime() - startedNanos).toMillis();
+    Map<String, Object> summary = new LinkedHashMap<>();
+    summary.put("message", result.message());
+    summary.put("externalExecutionId", result.externalId());
+    summary.put("durationMs", durationMs);
+    summary.put("startedAt", startedAt.toString());
+    summary.put("finishedAt", finishedAt.toString());
+
+    Integer exitCode = integer(result.outputs().get("exitCode"));
+    String resultKind = taskPluginCatalog.descriptor(execution.taskType()).resultKind().name();
+    boolean truncated = Boolean.TRUE.equals(result.outputs().get("bodyTruncated"));
+    long resultId = executionRepository.insertResult(
+        execution.id(),
+        attemptId,
+        resultKind,
+        json.write(json.toTree(summary)),
+        json.write(json.toTree(result.outputs())),
+        null,
+        truncated,
+        finishedAt);
+    executionRepository.completeAttempt(
+        attemptId,
+        ExecutionStatus.SUCCEEDED,
+        result.externalId(),
+        exitCode,
+        null,
+        null,
+        finishedAt);
+    if (executionRepository.markSucceeded(execution.id(), finishedAt) == 1) {
+      eventStream.publish(
+          execution.id(),
+          attemptId,
+          "RESULT",
+          Map.of("resultId", resultId, "resultKind", resultKind));
+      eventStream.publish(
+          execution.id(),
+          attemptId,
+          "EXECUTION_SUCCEEDED",
+          Map.of("status", ExecutionStatus.SUCCEEDED.name(), "durationMs", durationMs));
+    }
+  }
+
+  private void finishFailed(
+      long executionId,
+      long attemptId,
+      String errorCode,
+      String errorMessage) {
+    LocalDateTime now = LocalDateTime.now();
+    executionRepository.completeAttempt(
+        attemptId,
+        ExecutionStatus.FAILED,
+        null,
+        null,
+        errorCode,
+        errorMessage,
+        now);
+    if (executionRepository.markFailed(executionId, errorCode, errorMessage, now) == 1) {
+      eventStream.publish(
+          executionId,
+          attemptId,
+          "EXECUTION_FAILED",
+          Map.of(
+              "status", ExecutionStatus.FAILED.name(),
+              "errorCode", errorCode,
+              "errorMessage", errorMessage));
+    }
+  }
+
+  private void finishInterrupted(long executionId, long attemptId, String message) {
+    ExecutionStatus status = currentStatus(executionId);
+    LocalDateTime now = LocalDateTime.now();
+    if (status == ExecutionStatus.TIMED_OUT) {
+      executionRepository.completeAttempt(
+          attemptId,
+          ExecutionStatus.TIMED_OUT,
+          null,
+          null,
+          "EXECUTION_TIMEOUT",
+          message,
+          now);
+      return;
+    }
+    executionRepository.completeAttempt(
+        attemptId,
+        ExecutionStatus.CANCELED,
+        null,
+        null,
+        null,
+        message,
+        now);
+    if (status == ExecutionStatus.RUNNING || status == ExecutionStatus.QUEUED) {
+      if (executionRepository.markCanceled(executionId, now) == 1) {
+        eventStream.publish(
+            executionId,
+            attemptId,
+            "EXECUTION_CANCELED",
+            Map.of("status", ExecutionStatus.CANCELED.name()));
+      }
+    }
+  }
+
+  private Map<String, Object> configuration(Execution execution) {
+    JsonNode compiled = execution.compiledSpecSnapshot();
+    JsonNode configuration = compiled == null ? null : compiled.get("configuration");
+    if (configuration != null && configuration.isObject()) {
+      return json.toMap(configuration);
+    }
+    JsonNode definition = execution.definitionSnapshot();
+    JsonNode config = definition == null ? null : definition.get("config");
+    return objectMap(config);
+  }
+
+  private Map<String, Object> runtimeParameters(Execution execution) {
+    Map<String, Object> values = new LinkedHashMap<>();
+    JsonNode runtime = execution.runtimeSnapshot();
+    if (runtime != null && runtime.isObject()) {
+      JsonNode parameters = runtime.path("common").path("parameters");
+      if (parameters.isObject()) {
+        values.putAll(json.toMap(parameters));
+      }
+    }
+    values.putAll(objectMap(execution.inputSnapshot()));
+    return values;
+  }
+
+  private Map<String, Object> objectMap(JsonNode value) {
+    return value != null && value.isObject() ? json.toMap(value) : new LinkedHashMap<>();
+  }
+
+  private ExecutionStatus currentStatus(long executionId) {
+    return controlRepository.findExecution(executionId)
+        .map(Execution::status)
+        .orElse(ExecutionStatus.LOST);
+  }
+
+  private Execution requireExecution(long executionId) {
+    return controlRepository.findExecution(executionId)
+        .orElseThrow(() -> new IllegalArgumentException("任务执行不存在：" + executionId));
+  }
+
+  private static Integer integer(Object value) {
+    if (value == null) {
+      return null;
+    }
+    if (value instanceof Number number) {
+      return number.intValue();
+    }
+    try {
+      return Integer.valueOf(String.valueOf(value));
+    } catch (NumberFormatException ignored) {
+      return null;
+    }
+  }
+
+  private static String sanitizeLine(String line) {
+    String value = line == null ? "" : line;
+    return value.length() <= MAX_LOG_LINE_LENGTH
+        ? value
+        : value.substring(0, MAX_LOG_LINE_LENGTH) + "...";
+  }
+
+  private static String defaultMessage(String value, String fallback) {
+    return value == null || value.isBlank() ? fallback : value;
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/DataDevelopmentExecutionRepository.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/DataDevelopmentExecutionRepository.java
@@ -1,0 +1,389 @@
+package io.yak.ops.business.development.repository;
+
+import io.yak.ops.business.development.domain.DataDevelopmentModel.ExecutionAttempt;
+import io.yak.ops.business.development.domain.DataDevelopmentModel.ExecutionEvent;
+import io.yak.ops.business.development.domain.DataDevelopmentModel.ExecutionResult;
+import io.yak.ops.business.development.domain.DataDevelopmentModel.ExecutionSourceType;
+import io.yak.ops.business.development.domain.DataDevelopmentModel.ExecutionStatus;
+import io.yak.ops.business.development.domain.DataDevelopmentModel.ExecutionSummary;
+import io.yak.ops.business.development.service.DataDevelopmentJsonCodec;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.support.GeneratedKeyHolder;
+import org.springframework.jdbc.support.KeyHolder;
+
+/** JDBC adapter for execution attempts, events, results and state transitions. */
+public final class DataDevelopmentExecutionRepository {
+
+  private final NamedParameterJdbcTemplate jdbc;
+  private final DataDevelopmentJsonCodec json;
+
+  public DataDevelopmentExecutionRepository(
+      NamedParameterJdbcTemplate jdbc,
+      DataDevelopmentJsonCodec json) {
+    this.jdbc = jdbc;
+    this.json = json;
+  }
+
+  public int markQueued(long executionId) {
+    return jdbc.update("""
+        UPDATE yak_dev_execution SET status='QUEUED'
+        WHERE id=:id AND status='CREATED'
+        """, p("id", executionId));
+  }
+
+  public int markRunning(long executionId, int attemptNo, LocalDateTime now) {
+    return jdbc.update("""
+        UPDATE yak_dev_execution
+        SET status='RUNNING',current_attempt_no=:attemptNo,started_at=COALESCE(started_at,:now),
+          finished_at=NULL,error_code=NULL,error_message=NULL
+        WHERE id=:id AND status IN ('CREATED','QUEUED')
+        """, p("id", executionId).addValue("attemptNo", attemptNo).addValue("now", ts(now)));
+  }
+
+  public int markSucceeded(long executionId, LocalDateTime now) {
+    return terminal(executionId, ExecutionStatus.SUCCEEDED, null, null, now);
+  }
+
+  public int markFailed(
+      long executionId,
+      String errorCode,
+      String errorMessage,
+      LocalDateTime now) {
+    return terminal(executionId, ExecutionStatus.FAILED, errorCode, errorMessage, now);
+  }
+
+  public int markCanceled(long executionId, LocalDateTime now) {
+    return jdbc.update("""
+        UPDATE yak_dev_execution
+        SET status='CANCELED',finished_at=:now,error_code=NULL,error_message=NULL
+        WHERE id=:id AND status IN ('CREATED','QUEUED','RUNNING')
+        """, p("id", executionId).addValue("now", ts(now)));
+  }
+
+  public int markTimedOut(long executionId, String message, LocalDateTime now) {
+    return terminal(executionId, ExecutionStatus.TIMED_OUT, "EXECUTION_TIMEOUT", message, now);
+  }
+
+  public int markLost(long executionId, String message, LocalDateTime now) {
+    return terminal(executionId, ExecutionStatus.LOST, "WORKER_RESTARTED", message, now);
+  }
+
+  private int terminal(
+      long executionId,
+      ExecutionStatus status,
+      String errorCode,
+      String errorMessage,
+      LocalDateTime now) {
+    return jdbc.update("""
+        UPDATE yak_dev_execution
+        SET status=:status,finished_at=:now,error_code=:errorCode,error_message=:errorMessage
+        WHERE id=:id AND status IN ('CREATED','QUEUED','RUNNING')
+        """, p("id", executionId).addValue("status", status.name())
+        .addValue("now", ts(now)).addValue("errorCode", errorCode)
+        .addValue("errorMessage", errorMessage));
+  }
+
+  public List<Long> listRecoverableExecutionIds(int limit) {
+    return jdbc.queryForList("""
+        SELECT id FROM yak_dev_execution
+        WHERE status IN ('CREATED','QUEUED','RUNNING')
+        ORDER BY id ASC LIMIT :limit
+        """, p("limit", Math.min(1000, Math.max(1, limit))), Long.class);
+  }
+
+  public long insertAttempt(
+      long executionId,
+      int attemptNo,
+      String executorType,
+      String workerId,
+      LocalDateTime now) {
+    return insert("""
+        INSERT INTO yak_dev_execution_attempt(
+          execution_id,attempt_no,executor_type,worker_id,status,started_at)
+        VALUES(:executionId,:attemptNo,:executorType,:workerId,'RUNNING',:now)
+        """, p("executionId", executionId).addValue("attemptNo", attemptNo)
+        .addValue("executorType", executorType).addValue("workerId", workerId)
+        .addValue("now", ts(now)));
+  }
+
+  public int completeAttempt(
+      long attemptId,
+      ExecutionStatus status,
+      String externalExecutionId,
+      Integer exitCode,
+      String errorCode,
+      String errorMessage,
+      LocalDateTime now) {
+    return jdbc.update("""
+        UPDATE yak_dev_execution_attempt
+        SET status=:status,external_execution_id=:externalExecutionId,exit_code=:exitCode,
+          error_code=:errorCode,error_message=:errorMessage,finished_at=:now
+        WHERE id=:id AND status='RUNNING'
+        """, p("id", attemptId).addValue("status", status.name())
+        .addValue("externalExecutionId", externalExecutionId).addValue("exitCode", exitCode)
+        .addValue("errorCode", errorCode).addValue("errorMessage", errorMessage)
+        .addValue("now", ts(now)));
+  }
+
+  public int completeRunningAttempt(
+      long executionId,
+      ExecutionStatus status,
+      String errorCode,
+      String errorMessage,
+      LocalDateTime now) {
+    return jdbc.update("""
+        UPDATE yak_dev_execution_attempt
+        SET status=:status,error_code=:errorCode,error_message=:errorMessage,finished_at=:now
+        WHERE execution_id=:executionId AND status='RUNNING'
+        """, p("executionId", executionId).addValue("status", status.name())
+        .addValue("errorCode", errorCode).addValue("errorMessage", errorMessage)
+        .addValue("now", ts(now)));
+  }
+
+  public List<ExecutionAttempt> listAttempts(long executionId) {
+    return jdbc.query("""
+        SELECT * FROM yak_dev_execution_attempt
+        WHERE execution_id=:executionId ORDER BY attempt_no,id
+        """, p("executionId", executionId), this::attempt);
+  }
+
+  public long nextEventSequence(long executionId) {
+    Long value = jdbc.queryForObject("""
+        SELECT COALESCE(MAX(sequence_no),0)+1
+        FROM yak_dev_execution_event WHERE execution_id=:executionId
+        """, p("executionId", executionId), Long.class);
+    return value == null ? 1L : value;
+  }
+
+  public ExecutionEvent insertEvent(
+      long executionId,
+      Long attemptId,
+      long sequenceNo,
+      String eventType,
+      String payload,
+      LocalDateTime now) {
+    long id = insert("""
+        INSERT INTO yak_dev_execution_event(
+          execution_id,attempt_id,sequence_no,event_type,payload_json,occurred_at)
+        VALUES(:executionId,:attemptId,:sequenceNo,:eventType,:payload,:now)
+        """, p("executionId", executionId).addValue("attemptId", attemptId)
+        .addValue("sequenceNo", sequenceNo).addValue("eventType", eventType)
+        .addValue("payload", payload).addValue("now", ts(now)));
+    return new ExecutionEvent(
+        id,
+        executionId,
+        attemptId,
+        sequenceNo,
+        eventType,
+        json.readTree(payload),
+        now);
+  }
+
+  public List<ExecutionEvent> listEvents(long executionId, long afterSequence, int limit) {
+    return jdbc.query("""
+        SELECT * FROM yak_dev_execution_event
+        WHERE execution_id=:executionId AND sequence_no>:afterSequence
+        ORDER BY sequence_no ASC LIMIT :limit
+        """, p("executionId", executionId).addValue("afterSequence", afterSequence)
+        .addValue("limit", Math.min(5000, Math.max(1, limit))), this::event);
+  }
+
+  public long insertResult(
+      long executionId,
+      Long attemptId,
+      String resultKind,
+      String summary,
+      String payload,
+      String datasetRef,
+      boolean truncated,
+      LocalDateTime now) {
+    return insert("""
+        INSERT INTO yak_dev_execution_result(
+          execution_id,attempt_id,result_kind,schema_version,summary_json,payload_json,
+          dataset_ref,truncated,created_at)
+        VALUES(:executionId,:attemptId,:resultKind,1,:summary,:payload,:datasetRef,:truncated,:now)
+        """, p("executionId", executionId).addValue("attemptId", attemptId)
+        .addValue("resultKind", resultKind).addValue("summary", summary)
+        .addValue("payload", payload).addValue("datasetRef", datasetRef)
+        .addValue("truncated", truncated).addValue("now", ts(now)));
+  }
+
+  public List<ExecutionResult> listResults(long executionId) {
+    return jdbc.query("""
+        SELECT * FROM yak_dev_execution_result
+        WHERE execution_id=:executionId ORDER BY id ASC
+        """, p("executionId", executionId), this::result);
+  }
+
+  public Optional<String> findTaskName(long taskId) {
+    return one(jdbc.queryForList(
+        "SELECT name FROM yak_dev_resource WHERE id=:taskId AND deleted=0",
+        p("taskId", taskId), String.class));
+  }
+
+  public Optional<String> findEngineType(long taskId) {
+    return one(jdbc.queryForList(
+        "SELECT engine_type FROM yak_dev_task WHERE id=:taskId",
+        p("taskId", taskId), String.class));
+  }
+
+  public List<ExecutionSummary> listExecutionSummaries(
+      String status,
+      String taskType,
+      String keyword,
+      int offset,
+      int limit) {
+    String normalizedKeyword = keyword == null || keyword.isBlank()
+        ? null
+        : "%" + keyword.trim() + "%";
+    return jdbc.query("""
+        SELECT e.id,e.task_id,r.name AS task_name,e.task_type,t.engine_type,e.source_type,
+          e.status,e.current_attempt_no,e.created_by,e.created_at,e.started_at,e.finished_at,
+          e.error_message
+        FROM yak_dev_execution e
+        JOIN yak_dev_task t ON t.id=e.task_id
+        JOIN yak_dev_resource r ON r.id=e.task_id AND r.deleted=0
+        WHERE (:status IS NULL OR e.status=:status)
+          AND (:taskType IS NULL OR e.task_type=:taskType)
+          AND (:keyword IS NULL OR r.name LIKE :keyword OR CAST(e.id AS CHAR) LIKE :keyword)
+        ORDER BY e.id DESC LIMIT :limit OFFSET :offset
+        """, filters(status, taskType, normalizedKeyword)
+        .addValue("limit", Math.min(500, Math.max(1, limit)))
+        .addValue("offset", Math.max(0, offset)), this::summary);
+  }
+
+  public long countExecutionSummaries(String status, String taskType, String keyword) {
+    String normalizedKeyword = keyword == null || keyword.isBlank()
+        ? null
+        : "%" + keyword.trim() + "%";
+    Long value = jdbc.queryForObject("""
+        SELECT COUNT(1)
+        FROM yak_dev_execution e
+        JOIN yak_dev_task t ON t.id=e.task_id
+        JOIN yak_dev_resource r ON r.id=e.task_id AND r.deleted=0
+        WHERE (:status IS NULL OR e.status=:status)
+          AND (:taskType IS NULL OR e.task_type=:taskType)
+          AND (:keyword IS NULL OR r.name LIKE :keyword OR CAST(e.id AS CHAR) LIKE :keyword)
+        """, filters(status, taskType, normalizedKeyword), Long.class);
+    return value == null ? 0L : value;
+  }
+
+  private static MapSqlParameterSource filters(
+      String status,
+      String taskType,
+      String keyword) {
+    return p().addValue("status", blankToNull(status))
+        .addValue("taskType", blankToNull(taskType))
+        .addValue("keyword", keyword);
+  }
+
+  private long insert(String sql, MapSqlParameterSource parameters) {
+    KeyHolder holder = new GeneratedKeyHolder();
+    jdbc.update(sql, parameters, holder, new String[] {"id"});
+    Number key = holder.getKey();
+    if (key == null) {
+      throw new IllegalStateException("Database did not return a generated ID");
+    }
+    return key.longValue();
+  }
+
+  private ExecutionAttempt attempt(ResultSet rs, int row) throws SQLException {
+    return new ExecutionAttempt(
+        rs.getLong("id"),
+        rs.getLong("execution_id"),
+        rs.getInt("attempt_no"),
+        rs.getString("executor_type"),
+        rs.getString("worker_id"),
+        rs.getString("external_execution_id"),
+        ExecutionStatus.valueOf(rs.getString("status")),
+        nullableInteger(rs, "exit_code"),
+        rs.getString("error_code"),
+        rs.getString("error_message"),
+        time(rs, "started_at"),
+        time(rs, "finished_at"));
+  }
+
+  private ExecutionEvent event(ResultSet rs, int row) throws SQLException {
+    return new ExecutionEvent(
+        rs.getLong("id"),
+        rs.getLong("execution_id"),
+        nullableLong(rs, "attempt_id"),
+        rs.getLong("sequence_no"),
+        rs.getString("event_type"),
+        json.readTree(rs.getString("payload_json")),
+        time(rs, "occurred_at"));
+  }
+
+  private ExecutionResult result(ResultSet rs, int row) throws SQLException {
+    return new ExecutionResult(
+        rs.getLong("id"),
+        rs.getLong("execution_id"),
+        nullableLong(rs, "attempt_id"),
+        rs.getString("result_kind"),
+        rs.getInt("schema_version"),
+        json.readTree(rs.getString("summary_json")),
+        json.readTree(rs.getString("payload_json")),
+        rs.getString("dataset_ref"),
+        rs.getBoolean("truncated"),
+        time(rs, "created_at"));
+  }
+
+  private ExecutionSummary summary(ResultSet rs, int row) throws SQLException {
+    return new ExecutionSummary(
+        rs.getLong("id"),
+        rs.getLong("task_id"),
+        rs.getString("task_name"),
+        rs.getString("task_type"),
+        rs.getString("engine_type"),
+        ExecutionSourceType.valueOf(rs.getString("source_type")),
+        ExecutionStatus.valueOf(rs.getString("status")),
+        rs.getInt("current_attempt_no"),
+        rs.getString("created_by"),
+        time(rs, "created_at"),
+        time(rs, "started_at"),
+        time(rs, "finished_at"),
+        rs.getString("error_message"));
+  }
+
+  private static MapSqlParameterSource p() {
+    return new MapSqlParameterSource();
+  }
+
+  private static MapSqlParameterSource p(String key, Object value) {
+    return p().addValue(key, value);
+  }
+
+  private static Timestamp ts(LocalDateTime value) {
+    return Timestamp.valueOf(value);
+  }
+
+  private static Long nullableLong(ResultSet rs, String column) throws SQLException {
+    long value = rs.getLong(column);
+    return rs.wasNull() ? null : value;
+  }
+
+  private static Integer nullableInteger(ResultSet rs, String column) throws SQLException {
+    int value = rs.getInt(column);
+    return rs.wasNull() ? null : value;
+  }
+
+  private static LocalDateTime time(ResultSet rs, String column) throws SQLException {
+    Timestamp value = rs.getTimestamp(column);
+    return value == null ? null : value.toLocalDateTime();
+  }
+
+  private static String blankToNull(String value) {
+    return value == null || value.isBlank() ? null : value.trim().toUpperCase();
+  }
+
+  private static <T> Optional<T> one(List<T> values) {
+    return values.isEmpty() ? Optional.empty() : Optional.ofNullable(values.getFirst());
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DataDevelopmentExecutionService.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DataDevelopmentExecutionService.java
@@ -1,0 +1,243 @@
+package io.yak.ops.business.development.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.yak.ops.business.development.api.DataDevelopmentApi.CreateExecutionRequest;
+import io.yak.ops.business.development.api.DataDevelopmentApi.ExecutionDetailView;
+import io.yak.ops.business.development.api.DataDevelopmentApi.ExecutionPageView;
+import io.yak.ops.business.development.config.ConditionalOnDataDevelopmentEnabled;
+import io.yak.ops.business.development.domain.DataDevelopmentModel.Draft;
+import io.yak.ops.business.development.domain.DataDevelopmentModel.Execution;
+import io.yak.ops.business.development.domain.DataDevelopmentModel.ExecutionSourceType;
+import io.yak.ops.business.development.domain.DataDevelopmentModel.Task;
+import io.yak.ops.business.development.domain.DataDevelopmentModel.Version;
+import io.yak.ops.business.development.execution.DataDevelopmentExecutionGateway;
+import io.yak.ops.business.development.repository.DataDevelopmentExecutionRepository;
+import io.yak.ops.business.development.repository.DataDevelopmentRepository;
+import io.yak.ops.plugin.task.api.TaskPluginCatalog;
+import io.yak.ops.plugin.task.api.TaskPluginFactory.CompiledDefinition;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Locale;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+/** Application service for durable execution snapshots and the local execution gateway. */
+@ConditionalOnDataDevelopmentEnabled
+@Service
+public class DataDevelopmentExecutionService {
+
+  private final DataDevelopmentRepository controlRepository;
+  private final DataDevelopmentExecutionRepository executionRepository;
+  private final TaskPluginCatalog taskPluginCatalog;
+  private final DataDevelopmentJsonCodec json;
+  private final DataDevelopmentExecutionGateway gateway;
+
+  public DataDevelopmentExecutionService(
+      DataDevelopmentRepository controlRepository,
+      DataDevelopmentExecutionRepository executionRepository,
+      TaskPluginCatalog taskPluginCatalog,
+      DataDevelopmentJsonCodec json,
+      DataDevelopmentExecutionGateway gateway) {
+    this.controlRepository = controlRepository;
+    this.executionRepository = executionRepository;
+    this.taskPluginCatalog = taskPluginCatalog;
+    this.json = json;
+    this.gateway = gateway;
+  }
+
+  @Transactional(
+      transactionManager = "dataDevelopmentTransactionManager",
+      rollbackFor = Exception.class)
+  public Execution createExecution(
+      long taskId,
+      CreateExecutionRequest request,
+      String operator) {
+    Task task = requireTask(taskId);
+    ExecutionSourceType sourceType = parseSourceType(request.sourceType());
+    PreparedExecution prepared = prepareExecution(task, sourceType, request);
+    JsonNode runtime = request.runtime() == null
+        ? runtimeFromDefinition(prepared.definitionSnapshot())
+        : request.runtime();
+    JsonNode input = request.input() == null ? json.objectNode() : request.input();
+    long executionId = controlRepository.insertExecution(
+        taskId,
+        sourceType,
+        prepared.draftRevision(),
+        prepared.taskVersionId(),
+        task.taskType(),
+        prepared.pluginVersion(),
+        json.write(prepared.definitionSnapshot()),
+        json.write(prepared.compiledSpec()),
+        json.write(runtime),
+        json.write(input),
+        trimToNull(request.idempotencyKey()),
+        operator(operator),
+        LocalDateTime.now());
+    gateway.dispatchAfterCommit(executionId);
+    return requireExecution(executionId);
+  }
+
+  public Execution getExecution(long executionId) {
+    return requireExecution(executionId);
+  }
+
+  public List<Execution> listTaskExecutions(long taskId, int limit) {
+    requireTask(taskId);
+    return controlRepository.listExecutions(taskId, limit);
+  }
+
+  public ExecutionDetailView getExecutionDetail(long executionId, long afterSequence) {
+    Execution execution = requireExecution(executionId);
+    return new ExecutionDetailView(
+        execution,
+        executionRepository.findTaskName(execution.taskId()).orElse("task-" + execution.taskId()),
+        executionRepository.findEngineType(execution.taskId()).orElse(execution.taskType()),
+        executionRepository.listAttempts(executionId),
+        executionRepository.listEvents(executionId, Math.max(0L, afterSequence), 5000),
+        executionRepository.listResults(executionId));
+  }
+
+  public ExecutionPageView listExecutions(
+      String status,
+      String taskType,
+      String keyword,
+      int offset,
+      int limit) {
+    int normalizedOffset = Math.max(0, offset);
+    int normalizedLimit = Math.min(500, Math.max(1, limit));
+    return new ExecutionPageView(
+        executionRepository.listExecutionSummaries(
+            status,
+            taskType,
+            keyword,
+            normalizedOffset,
+            normalizedLimit),
+        executionRepository.countExecutionSummaries(status, taskType, keyword),
+        normalizedOffset,
+        normalizedLimit);
+  }
+
+  public Execution cancelExecution(long executionId) {
+    return gateway.cancel(executionId);
+  }
+
+  private PreparedExecution prepareExecution(
+      Task task,
+      ExecutionSourceType sourceType,
+      CreateExecutionRequest request) {
+    return switch (sourceType) {
+      case DRAFT_REVISION -> prepareDraftExecution(task, request);
+      case PUBLISHED_VERSION -> prepareVersionExecution(task, request);
+      case EPHEMERAL_SNAPSHOT -> prepareEphemeralExecution(task, request);
+    };
+  }
+
+  private PreparedExecution prepareDraftExecution(
+      Task task,
+      CreateExecutionRequest request) {
+    Draft draft = requireDraft(task.id());
+    if (request.draftRevision() == null || request.draftRevision() != draft.revision()) {
+      throw new IllegalArgumentException(
+          "运行草稿时必须提供当前 draftRevision=" + draft.revision());
+    }
+    CompiledDefinition compiled = taskPluginCatalog.compile(
+        task.taskType(),
+        json.toMap(draft.definition()));
+    return new PreparedExecution(
+        draft.revision(),
+        null,
+        taskPluginCatalog.descriptor(task.taskType()).pluginVersion(),
+        json.toTree(compiled.definition()),
+        json.toTree(compiled.compiledSpec()));
+  }
+
+  private PreparedExecution prepareVersionExecution(
+      Task task,
+      CreateExecutionRequest request) {
+    if (request.taskVersionId() == null) {
+      throw new IllegalArgumentException("运行发布版本时必须提供 taskVersionId");
+    }
+    Version version = requireVersion(task.id(), request.taskVersionId());
+    return new PreparedExecution(
+        null,
+        version.id(),
+        version.pluginVersion(),
+        version.definitionSnapshot(),
+        version.compiledSpec());
+  }
+
+  private PreparedExecution prepareEphemeralExecution(
+      Task task,
+      CreateExecutionRequest request) {
+    if (request.definitionSnapshot() == null) {
+      throw new IllegalArgumentException("临时运行必须提供 definitionSnapshot");
+    }
+    CompiledDefinition compiled = taskPluginCatalog.compile(
+        task.taskType(),
+        json.toMap(request.definitionSnapshot()));
+    return new PreparedExecution(
+        null,
+        null,
+        taskPluginCatalog.descriptor(task.taskType()).pluginVersion(),
+        json.toTree(compiled.definition()),
+        json.toTree(compiled.compiledSpec()));
+  }
+
+  private JsonNode runtimeFromDefinition(JsonNode definition) {
+    JsonNode runtime = definition.path("runtime");
+    return runtime.isMissingNode() || runtime.isNull() ? json.objectNode() : runtime;
+  }
+
+  private Task requireTask(long taskId) {
+    return controlRepository.findTask(taskId)
+        .orElseThrow(() -> new IllegalArgumentException("数据开发任务不存在：" + taskId));
+  }
+
+  private Draft requireDraft(long taskId) {
+    return controlRepository.findDraft(taskId)
+        .orElseThrow(() -> new IllegalStateException("任务草稿不存在：" + taskId));
+  }
+
+  private Version requireVersion(long taskId, long versionId) {
+    return controlRepository.findVersion(taskId, versionId)
+        .orElseThrow(() -> new IllegalArgumentException("任务版本不存在：" + versionId));
+  }
+
+  private Execution requireExecution(long executionId) {
+    return controlRepository.findExecution(executionId)
+        .orElseThrow(() -> new IllegalArgumentException("任务执行不存在：" + executionId));
+  }
+
+  private static ExecutionSourceType parseSourceType(String value) {
+    try {
+      return ExecutionSourceType.valueOf(
+          requireText(value, "执行来源").toUpperCase(Locale.ROOT));
+    } catch (IllegalArgumentException exception) {
+      throw new IllegalArgumentException("不支持的执行来源：" + value, exception);
+    }
+  }
+
+  private static String operator(String value) {
+    return StringUtils.hasText(value) ? value.trim() : "system";
+  }
+
+  private static String trimToNull(String value) {
+    return StringUtils.hasText(value) ? value.trim() : null;
+  }
+
+  private static String requireText(String value, String label) {
+    if (!StringUtils.hasText(value)) {
+      throw new IllegalArgumentException(label + "不能为空");
+    }
+    return value.trim();
+  }
+
+  private record PreparedExecution(
+      Long draftRevision,
+      Long taskVersionId,
+      String pluginVersion,
+      JsonNode definitionSnapshot,
+      JsonNode compiledSpec) {
+  }
+}

--- a/yak-ops-ui/src/pages/data-development/instances/index.tsx
+++ b/yak-ops-ui/src/pages/data-development/instances/index.tsx
@@ -1,6 +1,7 @@
 import YakOpsEmpty from '@/components/YakOpsEmpty';
 import { BRAND_COLOR, BRAND_THEME } from '@/styles/brand';
 import {
+  Alert,
   Button,
   ConfigProvider,
   Empty,
@@ -11,6 +12,7 @@ import {
   Table,
   Tag,
   Typography,
+  message,
   type TableColumnsType,
 } from 'antd';
 import {
@@ -21,7 +23,12 @@ import {
   RefreshCw,
   Search,
 } from 'lucide-react';
-import { useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  executionRepository,
+  type ApiExecutionStatus,
+  type ExecutionSummaryItem,
+} from '../workbench/execution/execution.repository';
 
 const { Text } = Typography;
 
@@ -38,14 +45,8 @@ interface DevelopmentInstance {
   endTime?: string;
   duration?: string;
   operator: string;
+  errorMessage?: string;
 }
-
-const engineOptions = [
-  { label: 'Flink SQL', value: 'Flink SQL' },
-  { label: 'Spark SQL', value: 'Spark SQL' },
-  { label: 'Trino SQL', value: 'Trino SQL' },
-  { label: 'Python', value: 'Python' },
-];
 
 const statusMeta: Record<
   InstanceStatus,
@@ -69,12 +70,81 @@ const statusMeta: Record<
   },
 };
 
+const toInstanceStatus = (status: ApiExecutionStatus): InstanceStatus => {
+  if (status === 'SUCCEEDED') return 'SUCCESS';
+  if (status === 'CANCELED') return 'CANCELED';
+  if (status === 'FAILED' || status === 'TIMED_OUT' || status === 'LOST') {
+    return 'FAILED';
+  }
+  return 'RUNNING';
+};
+
+const formatTime = (value?: string) =>
+  value
+    ? new Intl.DateTimeFormat('zh-CN', {
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
+        hour12: false,
+      }).format(new Date(value))
+    : undefined;
+
+const formatDuration = (startedAt?: string, finishedAt?: string) => {
+  if (!startedAt) return undefined;
+  const end = finishedAt ? new Date(finishedAt).getTime() : Date.now();
+  const durationMs = Math.max(0, end - new Date(startedAt).getTime());
+  if (durationMs < 1000) return `${durationMs} ms`;
+  if (durationMs < 60_000) return `${(durationMs / 1000).toFixed(2)} s`;
+  const minutes = Math.floor(durationMs / 60_000);
+  const seconds = Math.floor((durationMs % 60_000) / 1000);
+  return `${minutes}m ${seconds}s`;
+};
+
+const mapInstance = (item: ExecutionSummaryItem): DevelopmentInstance => ({
+  id: String(item.id),
+  taskName: item.taskName,
+  taskType: item.taskType,
+  engine: item.engineType || item.taskType,
+  status: toInstanceStatus(item.status),
+  startTime: formatTime(item.startedAt ?? item.createdAt) ?? '-',
+  endTime: formatTime(item.finishedAt),
+  duration: formatDuration(item.startedAt ?? item.createdAt, item.finishedAt),
+  operator: item.createdBy || 'system',
+  errorMessage: item.errorMessage,
+});
+
 const DataDevelopmentInstancesPage = () => {
-  const [instances] = useState<DevelopmentInstance[]>([]);
+  const [instances, setInstances] = useState<DevelopmentInstance[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [loadError, setLoadError] = useState<string>();
   const [keyword, setKeyword] = useState('');
   const [statusFilter, setStatusFilter] =
     useState<InstanceStatusFilter>('ALL');
   const [engineFilter, setEngineFilter] = useState<string>();
+
+  const loadInstances = useCallback(async () => {
+    setLoading(true);
+    setLoadError(undefined);
+    try {
+      const page = await executionRepository.list({ limit: 500 });
+      setInstances(page.items.map(mapInstance));
+    } catch (error) {
+      const text = error instanceof Error ? error.message : '运行实例加载失败';
+      setLoadError(text);
+      message.error(text);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadInstances();
+    const timer = window.setInterval(() => void loadInstances(), 5000);
+    return () => window.clearInterval(timer);
+  }, [loadInstances]);
 
   const summary = useMemo(
     () => ({
@@ -86,9 +156,16 @@ const DataDevelopmentInstancesPage = () => {
     [instances],
   );
 
+  const engineOptions = useMemo(
+    () =>
+      Array.from(new Set(instances.map((item) => item.engine)))
+        .sort()
+        .map((engine) => ({ label: engine, value: engine })),
+    [instances],
+  );
+
   const filteredInstances = useMemo(() => {
     const normalizedKeyword = keyword.trim().toLowerCase();
-
     return instances.filter((instance) => {
       const matchesKeyword =
         !normalizedKeyword ||
@@ -97,16 +174,9 @@ const DataDevelopmentInstancesPage = () => {
       const matchesStatus =
         statusFilter === 'ALL' || instance.status === statusFilter;
       const matchesEngine = !engineFilter || instance.engine === engineFilter;
-
       return matchesKeyword && matchesStatus && matchesEngine;
     });
   }, [engineFilter, instances, keyword, statusFilter]);
-
-  const resetFilters = () => {
-    setKeyword('');
-    setStatusFilter('ALL');
-    setEngineFilter(undefined);
-  };
 
   const columns: TableColumnsType<DevelopmentInstance> = [
     {
@@ -121,7 +191,7 @@ const DataDevelopmentInstancesPage = () => {
           </span>
           <span className="min-w-0">
             <strong className="block truncate text-[13px] font-medium text-[#161823]">
-              {value}
+              #{value}
             </strong>
             <small className="block truncate text-[11px] text-[rgba(22,24,35,0.42)]">
               {instance.taskName}
@@ -138,7 +208,7 @@ const DataDevelopmentInstancesPage = () => {
       render: (value: string) => <Tag bordered={false}>{value}</Tag>,
     },
     {
-      title: '计算引擎',
+      title: '执行器',
       dataIndex: 'engine',
       key: 'engine',
       width: 130,
@@ -148,38 +218,32 @@ const DataDevelopmentInstancesPage = () => {
       dataIndex: 'status',
       key: 'status',
       width: 100,
-      render: (value: InstanceStatus) => (
-        <Tag bordered={false} className={statusMeta[value].className}>
+      render: (value: InstanceStatus, record) => (
+        <Tag
+          bordered={false}
+          title={record.errorMessage}
+          className={statusMeta[value].className}
+        >
           {statusMeta[value].label}
         </Tag>
       ),
     },
-    {
-      title: '开始时间',
-      dataIndex: 'startTime',
-      key: 'startTime',
-      width: 170,
-    },
+    { title: '开始时间', dataIndex: 'startTime', key: 'startTime', width: 180 },
     {
       title: '结束时间',
       dataIndex: 'endTime',
       key: 'endTime',
-      width: 170,
+      width: 180,
       render: (value?: string) => value || '-',
     },
     {
       title: '耗时',
       dataIndex: 'duration',
       key: 'duration',
-      width: 100,
+      width: 110,
       render: (value?: string) => value || '-',
     },
-    {
-      title: '执行人',
-      dataIndex: 'operator',
-      key: 'operator',
-      width: 120,
-    },
+    { title: '执行人', dataIndex: 'operator', key: 'operator', width: 120 },
   ];
 
   const hasFilters =
@@ -189,49 +253,53 @@ const DataDevelopmentInstancesPage = () => {
     <ConfigProvider theme={BRAND_THEME}>
       <div className="min-h-[calc(100vh-48px)] bg-white px-5 pb-5 pt-4 text-[#161823]">
         <header className="flex min-h-11 items-center justify-between gap-4">
-          <h1 className="m-0 text-[17px] font-semibold leading-6">运行实例</h1>
-          <Button icon={<RefreshCw size={15} />} onClick={resetFilters}>
-            重置筛选
+          <div>
+            <h1 className="m-0 text-[17px] font-semibold leading-6">运行实例</h1>
+            <div className="mt-0.5 text-[11px] text-[rgba(22,24,35,0.42)]">
+              展示 Execution Gateway 中的真实任务执行、耗时与最终状态
+            </div>
+          </div>
+          <Button
+            loading={loading}
+            icon={<RefreshCw size={15} />}
+            onClick={() => void loadInstances()}
+          >
+            刷新
           </Button>
         </header>
 
-        <section className="mt-2 grid grid-cols-4 gap-2 max-[980px]:grid-cols-2">
-          <div className="flex min-h-[70px] items-center gap-3 border border-[#f0f0f0] bg-[#fafbfc] px-4 py-3">
-            <span className="flex h-9 w-9 items-center justify-center rounded-[7px] bg-[#f2f3f5] text-[rgba(22,24,35,0.58)]">
-              <History size={19} />
-            </span>
-            <div>
-              <Text type="secondary" className="!text-[11px]">全部实例</Text>
-              <div className="mt-0.5 text-lg font-semibold">{summary.total}</div>
+        {loadError && (
+          <Alert
+            showIcon
+            type="error"
+            className="mt-3"
+            message="运行实例加载失败"
+            description={loadError}
+          />
+        )}
+
+        <section className="mt-3 grid grid-cols-4 gap-2 max-[980px]:grid-cols-2">
+          {[
+            ['全部实例', summary.total, <History key="all" size={19} />],
+            ['运行中', summary.running, <Clock3 key="running" size={19} />],
+            ['成功', summary.success, <CircleCheck key="success" size={19} />],
+            ['失败', summary.failed, <CircleX key="failed" size={19} />],
+          ].map(([label, value, icon]) => (
+            <div
+              key={String(label)}
+              className="flex min-h-[70px] items-center gap-3 border border-[#f0f0f0] bg-[#fafbfc] px-4 py-3"
+            >
+              <span className="flex h-9 w-9 items-center justify-center rounded-[7px] bg-[#f2f3f5] text-[rgba(22,24,35,0.58)]">
+                {icon}
+              </span>
+              <div>
+                <Text type="secondary" className="!text-[11px]">
+                  {label}
+                </Text>
+                <div className="mt-0.5 text-lg font-semibold">{value}</div>
+              </div>
             </div>
-          </div>
-          <div className="flex min-h-[70px] items-center gap-3 border border-[#f0f0f0] bg-[#fafbfc] px-4 py-3">
-            <span className="flex h-9 w-9 items-center justify-center rounded-[7px] bg-[rgba(254,44,85,0.06)] text-[#fe2c55]">
-              <Clock3 size={19} />
-            </span>
-            <div>
-              <Text type="secondary" className="!text-[11px]">运行中</Text>
-              <div className="mt-0.5 text-lg font-semibold">{summary.running}</div>
-            </div>
-          </div>
-          <div className="flex min-h-[70px] items-center gap-3 border border-[#f0f0f0] bg-[#fafbfc] px-4 py-3">
-            <span className="flex h-9 w-9 items-center justify-center rounded-[7px] bg-[#f2f3f5] text-[#344054]">
-              <CircleCheck size={19} />
-            </span>
-            <div>
-              <Text type="secondary" className="!text-[11px]">成功</Text>
-              <div className="mt-0.5 text-lg font-semibold">{summary.success}</div>
-            </div>
-          </div>
-          <div className="flex min-h-[70px] items-center gap-3 border border-[#f0f0f0] bg-[#fafbfc] px-4 py-3">
-            <span className="flex h-9 w-9 items-center justify-center rounded-[7px] bg-[#fff1f0] text-[#ff4d4f]">
-              <CircleX size={19} />
-            </span>
-            <div>
-              <Text type="secondary" className="!text-[11px]">失败</Text>
-              <div className="mt-0.5 text-lg font-semibold">{summary.failed}</div>
-            </div>
-          </div>
+          ))}
         </section>
 
         <section className="mt-3 border border-[#e4e7ec] bg-white">
@@ -263,8 +331,8 @@ const DataDevelopmentInstancesPage = () => {
               <Select
                 allowClear
                 variant="filled"
-                placeholder="全部引擎"
-                className="w-[140px]"
+                placeholder="全部执行器"
+                className="w-[150px]"
                 options={engineOptions}
                 value={engineFilter}
                 onChange={setEngineFilter}
@@ -274,10 +342,11 @@ const DataDevelopmentInstancesPage = () => {
 
           <Table<DevelopmentInstance>
             rowKey="id"
+            loading={loading}
             columns={columns}
             dataSource={filteredInstances}
-            pagination={false}
-            scroll={{ x: 1200 }}
+            pagination={{ pageSize: 20, showSizeChanger: true }}
+            scroll={{ x: 1180 }}
             locale={{
               emptyText: (
                 <Empty

--- a/yak-ops-ui/src/pages/data-development/workbench/execution/components/ExecutionPanelShared.tsx
+++ b/yak-ops-ui/src/pages/data-development/workbench/execution/components/ExecutionPanelShared.tsx
@@ -30,15 +30,17 @@ export const ExecutionStatusTag = ({
 }: {
   session: ExecutionSession;
 }) => {
+  const queued = session.status === 'QUEUED';
   const running = session.status === 'RUNNING';
   const success = session.status === 'SUCCESS';
   const stopped = session.status === 'STOPPED';
+  const active = queued || running;
 
   return (
     <Tag
       bordered={false}
       icon={
-        running ? (
+        active ? (
           <LoaderCircle size={12} className="animate-spin" />
         ) : success ? (
           <CheckCircle2 size={12} />
@@ -49,7 +51,7 @@ export const ExecutionStatusTag = ({
         )
       }
       color={
-        running
+        active
           ? 'processing'
           : success
             ? 'success'
@@ -59,13 +61,15 @@ export const ExecutionStatusTag = ({
       }
       className="!m-0"
     >
-      {running
-        ? '运行中'
-        : success
-          ? '运行成功'
-          : stopped
-            ? '已停止'
-            : '运行失败'}
+      {queued
+        ? '排队中'
+        : running
+          ? '运行中'
+          : success
+            ? '运行成功'
+            : stopped
+              ? '已停止'
+              : '运行失败'}
     </Tag>
   );
 };

--- a/yak-ops-ui/src/pages/data-development/workbench/execution/execution.repository.ts
+++ b/yak-ops-ui/src/pages/data-development/workbench/execution/execution.repository.ts
@@ -1,0 +1,303 @@
+import HttpUtils from '@/utils/HttpUtils';
+import type { ExecutionStatus } from '../core/types';
+import type {
+  ExecutionLogEntry,
+  ExecutionResultPayload,
+  ExecutionSession,
+} from './types';
+
+const API_PREFIX = '/api/v1/data-development';
+
+interface ApiResponse<T> {
+  code: number;
+  data: T;
+  msg?: string;
+  message?: string;
+}
+
+export type ApiExecutionStatus =
+  | 'CREATED'
+  | 'QUEUED'
+  | 'RUNNING'
+  | 'SUCCEEDED'
+  | 'FAILED'
+  | 'CANCELED'
+  | 'TIMED_OUT'
+  | 'LOST';
+
+interface ApiExecution {
+  id: number;
+  taskId: number;
+  taskType: string;
+  status: ApiExecutionStatus;
+  currentAttemptNo: number;
+  createdBy?: string;
+  createdAt: string;
+  startedAt?: string;
+  finishedAt?: string;
+  errorCode?: string;
+  errorMessage?: string;
+}
+
+interface ApiExecutionAttempt {
+  id: number;
+  attemptNo: number;
+  externalExecutionId?: string;
+  status: ApiExecutionStatus;
+  exitCode?: number;
+  errorMessage?: string;
+  startedAt?: string;
+  finishedAt?: string;
+}
+
+export interface ApiExecutionEvent {
+  id: number;
+  executionId: number;
+  attemptId?: number;
+  sequenceNo: number;
+  eventType: string;
+  payload: Record<string, unknown>;
+  occurredAt: string;
+}
+
+interface ApiExecutionResult {
+  id: number;
+  resultKind: 'TABLE' | 'JSON' | 'TERMINAL' | 'NOTEBOOK' | 'PIPELINE' | 'TEXT';
+  summary: Record<string, unknown>;
+  payload: Record<string, unknown>;
+  truncated: boolean;
+  createdAt: string;
+}
+
+export interface ApiExecutionDetail {
+  execution: ApiExecution;
+  taskName: string;
+  engineType: string;
+  attempts: ApiExecutionAttempt[];
+  events: ApiExecutionEvent[];
+  results: ApiExecutionResult[];
+}
+
+export interface ExecutionSummaryItem {
+  id: number;
+  taskId: number;
+  taskName: string;
+  taskType: string;
+  engineType: string;
+  sourceType: string;
+  status: ApiExecutionStatus;
+  currentAttemptNo: number;
+  createdBy?: string;
+  createdAt: string;
+  startedAt?: string;
+  finishedAt?: string;
+  errorMessage?: string;
+}
+
+export interface ExecutionPage {
+  items: ExecutionSummaryItem[];
+  total: number;
+  offset: number;
+  limit: number;
+}
+
+const unwrap = <T>(response: ApiResponse<T>): T => {
+  if (response.code !== 0 && response.code !== 200) {
+    throw new Error(response.message ?? response.msg ?? '执行接口调用失败');
+  }
+  return response.data;
+};
+
+export const toWorkbenchExecutionStatus = (
+  status: ApiExecutionStatus,
+): ExecutionStatus => {
+  switch (status) {
+    case 'CREATED':
+    case 'QUEUED':
+      return 'QUEUED';
+    case 'RUNNING':
+      return 'RUNNING';
+    case 'SUCCEEDED':
+      return 'SUCCESS';
+    case 'CANCELED':
+      return 'STOPPED';
+    case 'FAILED':
+    case 'TIMED_OUT':
+    case 'LOST':
+      return 'FAILED';
+  }
+};
+
+const asRecord = (value: unknown): Record<string, unknown> =>
+  value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+
+const asString = (value: unknown, fallback = '') =>
+  value === undefined || value === null ? fallback : String(value);
+
+const asNumber = (value: unknown, fallback = 0) => {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+};
+
+const parseBody = (value: unknown) => {
+  if (typeof value !== 'string') return value;
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
+  }
+};
+
+const formatLogTime = (value: string) =>
+  new Intl.DateTimeFormat('zh-CN', {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  }).format(new Date(value));
+
+const mapLogs = (events: ApiExecutionEvent[]): ExecutionLogEntry[] =>
+  events
+    .filter((event) => event.eventType === 'LOG')
+    .map((event) => ({
+      id: String(event.id),
+      level:
+        event.payload.level === 'ERROR'
+          ? 'ERROR'
+          : event.payload.level === 'WARN'
+            ? 'WARN'
+            : 'INFO',
+      timestamp: formatLogTime(event.occurredAt),
+      message: asString(event.payload.line),
+    }));
+
+const mapHeaders = (value: unknown): Record<string, string> => {
+  const source = asRecord(value);
+  return Object.fromEntries(
+    Object.entries(source).map(([key, item]) => [
+      key,
+      Array.isArray(item) ? item.map(String).join(', ') : asString(item),
+    ]),
+  );
+};
+
+const mapResult = (
+  detail: ApiExecutionDetail,
+  logs: ExecutionLogEntry[],
+): ExecutionResultPayload | undefined => {
+  const result = detail.results.at(-1);
+  if (!result) return undefined;
+  const payload = asRecord(result.payload);
+  const summary = asRecord(result.summary);
+
+  if (detail.execution.taskType === 'HTTP' || result.resultKind === 'JSON') {
+    const statusCode = asNumber(payload.statusCode);
+    return {
+      kind: 'json',
+      statusCode,
+      statusText: statusCode ? `HTTP ${statusCode}` : 'HTTP 响应',
+      elapsedMs: asNumber(summary.durationMs),
+      headers: mapHeaders(payload.headers),
+      body: parseBody(payload.body),
+    };
+  }
+
+  if (detail.execution.taskType === 'SHELL' || result.resultKind === 'TERMINAL') {
+    return {
+      kind: 'terminal',
+      exitCode: asNumber(payload.exitCode),
+      stdout: logs
+        .filter((log) => log.level !== 'ERROR')
+        .map((log) => log.message),
+      stderr: logs
+        .filter((log) => log.level === 'ERROR')
+        .map((log) => log.message),
+    };
+  }
+
+  return {
+    kind: 'text',
+    title: result.resultKind,
+    value: JSON.stringify(payload, null, 2),
+  };
+};
+
+export const toExecutionSession = (
+  detail: ApiExecutionDetail,
+): ExecutionSession => {
+  const execution = detail.execution;
+  const logs = mapLogs(detail.events);
+  const startedAt = execution.startedAt ?? execution.createdAt;
+  const finishedAt = execution.finishedAt;
+  return {
+    id: String(execution.id),
+    resourceId: String(execution.taskId),
+    resourceType: execution.taskType,
+    resourceName: detail.taskName,
+    engine: detail.engineType,
+    status: toWorkbenchExecutionStatus(execution.status),
+    submittedAt: execution.createdAt,
+    startedAt,
+    finishedAt,
+    durationMs:
+      finishedAt && startedAt
+        ? Math.max(0, new Date(finishedAt).getTime() - new Date(startedAt).getTime())
+        : undefined,
+    logs,
+    result: mapResult(detail, logs),
+    errorMessage: execution.errorMessage,
+  };
+};
+
+export const executionRepository = {
+  async getDetail(executionId: string, after = 0) {
+    return unwrap(
+      await HttpUtils.get<ApiExecutionDetail>(
+        `${API_PREFIX}/executions/${executionId}/detail?after=${after}`,
+      ),
+    );
+  },
+
+  async list(params: {
+    status?: string;
+    taskType?: string;
+    keyword?: string;
+    offset?: number;
+    limit?: number;
+  }) {
+    const query = new URLSearchParams();
+    Object.entries(params).forEach(([key, value]) => {
+      if (value !== undefined && value !== null && String(value).length > 0) {
+        query.set(key, String(value));
+      }
+    });
+    return unwrap(
+      await HttpUtils.get<ExecutionPage>(
+        `${API_PREFIX}/executions${query.size ? `?${query.toString()}` : ''}`,
+      ),
+    );
+  },
+
+  watch(
+    executionId: string,
+    after: number,
+    onEvent: (event: ApiExecutionEvent) => void,
+    onError?: () => void,
+  ) {
+    const source = new EventSource(
+      `${API_PREFIX}/executions/${executionId}/events/stream?after=${Math.max(0, after)}`,
+      { withCredentials: true },
+    );
+    source.addEventListener('execution-event', (event) => {
+      try {
+        onEvent(JSON.parse((event as MessageEvent<string>).data));
+      } catch {
+        onError?.();
+      }
+    });
+    source.onerror = () => onError?.();
+    return () => source.close();
+  },
+};

--- a/yak-ops-ui/src/pages/data-development/workbench/execution/execution.sync.ts
+++ b/yak-ops-ui/src/pages/data-development/workbench/execution/execution.sync.ts
@@ -1,0 +1,180 @@
+import { nodePluginRegistry } from '../core/registry';
+import type { WorkbenchActionContext } from '../core/types';
+import { useWorkbenchControlStore } from '../store/workbench-control.store';
+import { useWorkbenchStore } from '../store/workbench.store';
+import {
+  executionRepository,
+  toExecutionSession,
+  toWorkbenchExecutionStatus,
+  type ApiExecutionEvent,
+  type ApiExecutionStatus,
+} from './execution.repository';
+import { useExecutionPanelStore } from './store/execution-panel.store';
+import type { ExecutionSession } from './types';
+
+const observers = new Map<string, () => void>();
+const pollers = new Map<string, number>();
+const lastSequence = new Map<string, number>();
+
+const terminal = (status: ApiExecutionStatus) =>
+  status === 'SUCCEEDED' ||
+  status === 'FAILED' ||
+  status === 'CANCELED' ||
+  status === 'TIMED_OUT' ||
+  status === 'LOST';
+
+const upsertSession = (session: ExecutionSession) => {
+  useExecutionPanelStore.setState((state) => ({
+    sessionsById: {
+      ...state.sessionsById,
+      [session.id]: session,
+    },
+    sessionIdsByResourceId: {
+      ...state.sessionIdsByResourceId,
+      [session.resourceId]: [
+        session.id,
+        ...(state.sessionIdsByResourceId[session.resourceId] ?? []).filter(
+          (id) => id !== session.id,
+        ),
+      ],
+    },
+    activeSessionIdByResourceId: {
+      ...state.activeSessionIdByResourceId,
+      [session.resourceId]: session.id,
+    },
+    visible: true,
+    activeTab: session.status === 'SUCCESS' ? 'result' : 'output',
+  }));
+};
+
+const stopObservation = (executionId: string) => {
+  observers.get(executionId)?.();
+  observers.delete(executionId);
+  const poller = pollers.get(executionId);
+  if (poller !== undefined) window.clearInterval(poller);
+  pollers.delete(executionId);
+};
+
+const refreshExecution = async (executionId: string) => {
+  const detail = await executionRepository.getDetail(executionId);
+  const session = toExecutionSession(detail);
+  upsertSession(session);
+  const status = toWorkbenchExecutionStatus(detail.execution.status);
+  useWorkbenchStore.getState().setExecutionStatus(session.resourceId, status);
+  useWorkbenchControlStore.setState((state) => ({
+    executionIdByResourceId: {
+      ...state.executionIdByResourceId,
+      [session.resourceId]: executionId,
+    },
+  }));
+  if (terminal(detail.execution.status)) stopObservation(executionId);
+};
+
+const appendLog = (executionId: string, event: ApiExecutionEvent) => {
+  useExecutionPanelStore.setState((state) => {
+    const session = state.sessionsById[executionId];
+    if (!session) return state;
+    const level =
+      event.payload.level === 'ERROR'
+        ? 'ERROR'
+        : event.payload.level === 'WARN'
+          ? 'WARN'
+          : 'INFO';
+    return {
+      sessionsById: {
+        ...state.sessionsById,
+        [executionId]: {
+          ...session,
+          logs: [
+            ...session.logs,
+            {
+              id: String(event.id),
+              level,
+              timestamp: new Intl.DateTimeFormat('zh-CN', {
+                hour: '2-digit',
+                minute: '2-digit',
+                second: '2-digit',
+                hour12: false,
+              }).format(new Date(event.occurredAt)),
+              message: String(event.payload.line ?? ''),
+            },
+          ],
+        },
+      },
+      visible: true,
+      activeTab: 'output',
+    };
+  });
+};
+
+const startPollingFallback = (executionId: string) => {
+  if (pollers.has(executionId)) return;
+  const poller = window.setInterval(() => {
+    void refreshExecution(executionId).catch(() => undefined);
+  }, 1500);
+  pollers.set(executionId, poller);
+};
+
+export const observeExecution = (
+  context: WorkbenchActionContext,
+  executionId: string,
+) => {
+  stopObservation(executionId);
+  const submittedAt = new Date().toISOString();
+  upsertSession({
+    id: executionId,
+    resourceId: context.resource.id,
+    resourceType: context.resource.resourceType,
+    resourceName: context.resource.name,
+    engine: context.resource.engine,
+    status: 'QUEUED',
+    submittedAt,
+    startedAt: submittedAt,
+    logs: [
+      {
+        id: `${executionId}-queued`,
+        level: 'INFO',
+        timestamp: new Intl.DateTimeFormat('zh-CN', {
+          hour: '2-digit',
+          minute: '2-digit',
+          second: '2-digit',
+          hour12: false,
+        }).format(new Date()),
+        message: '执行已进入本地 Execution Gateway 队列',
+      },
+    ],
+  });
+
+  const close = executionRepository.watch(
+    executionId,
+    lastSequence.get(executionId) ?? 0,
+    (event) => {
+      lastSequence.set(executionId, event.sequenceNo);
+      if (event.eventType === 'LOG') appendLog(executionId, event);
+      if (event.eventType !== 'LOG') {
+        void refreshExecution(executionId).catch(() =>
+          startPollingFallback(executionId),
+        );
+      }
+    },
+    () => startPollingFallback(executionId),
+  );
+  observers.set(executionId, close);
+  void refreshExecution(executionId).catch(() => startPollingFallback(executionId));
+};
+
+export const observeExecutionForResource = (
+  resourceId: string,
+  executionId: string,
+) => {
+  const workbench = useWorkbenchStore.getState();
+  const resource = workbench.resourcesById[resourceId];
+  const document = workbench.documentsByResourceId[resourceId];
+  if (!resource || !document) return;
+  const plugin = nodePluginRegistry.get(resource.resourceType);
+  if (!plugin) return;
+  observeExecution(
+    { resource, document, plugin, executionStatus: 'QUEUED' },
+    executionId,
+  );
+};

--- a/yak-ops-ui/src/pages/data-development/workbench/store/workbench-control.store.ts
+++ b/yak-ops-ui/src/pages/data-development/workbench/store/workbench-control.store.ts
@@ -54,7 +54,7 @@ const indexSnapshot = (snapshot: WorkspaceSnapshot) => {
   };
 };
 
-const clearMockWorkspace = () => {
+const clearWorkspace = () => {
   useWorkbenchStore.setState({
     resourcesById: {},
     documentsByResourceId: {},
@@ -70,7 +70,7 @@ const clearMockWorkspace = () => {
   });
 };
 
-clearMockWorkspace();
+clearWorkspace();
 
 export const useWorkbenchControlStore = create<WorkbenchControlState>(
   (set, get) => ({
@@ -84,7 +84,7 @@ export const useWorkbenchControlStore = create<WorkbenchControlState>(
     initialize: async () => {
       if (get().workspaceLoading) return;
       set({ workspaceLoading: true, workspaceError: undefined });
-      clearMockWorkspace();
+      clearWorkspace();
 
       try {
         const result = await workbenchRepository.bootstrap();
@@ -123,6 +123,13 @@ export const useWorkbenchControlStore = create<WorkbenchControlState>(
           [resourceId]: executionId,
         },
       }));
+
+      if (status === 'QUEUED') {
+        void import('../execution/execution.sync').then(
+          ({ observeExecutionForResource }) =>
+            observeExecutionForResource(resourceId, executionId),
+        );
+      }
     },
 
     clearExecutionRecord: (resourceId) =>


### PR DESCRIPTION
## Summary

- add a bounded local Execution Gateway that dispatches durable execution snapshots after transaction commit
- execute the existing HTTP and Shell task plugins through `WorkflowTaskExecutorRegistry`
- persist physical attempts, ordered log/status events and typed execution results
- propagate cancel and timeout requests to the real plugin executor and worker thread
- recover queued executions after restart and mark unrecoverable running executions as `LOST`
- expose global execution listing, execution detail and resumable SSE event-stream APIs
- connect the Workbench result panel to persisted execution state with SSE and polling fallback
- replace the empty data-development instances page with real execution records, status, duration and operator data
- document the execution state machine, runtime boundaries and follow-up scope

## Execution flow

```text
Workbench
  -> immutable execution snapshot
  -> local bounded gateway
  -> HTTP / Shell task plugin
  -> attempt + event + result persistence
  -> SSE / detail API
  -> result panel + instances page
```

## Reliability behavior

- execution dispatch happens only after the snapshot transaction commits
- queue saturation becomes a durable failed execution instead of a lost request
- cancellation invokes the plugin cancellation hook and interrupts the worker as fallback
- runtime timeout uses the task runtime configuration and persists `TIMED_OUT`
- `CREATED` and `QUEUED` executions are redispatched on startup
- an interrupted local `RUNNING` execution is persisted as `LOST`
- SSE supports `Last-Event-ID` / `after` replay and the UI falls back to polling

## Validation

- TypeScript transpilation passed for the new execution repository, synchronization layer, control store and instances page
- Java parser completed without syntax errors for all changed data-development sources
- Maven POM XML parsed successfully
- GitHub compare confirms one focused commit based on the merged phase-one control-plane branch

A full Maven reactor build and frontend dependency-aware type check could not be executed in this environment because a local repository checkout and dependency cache were unavailable. CI and an environment with MySQL should be used for final integration verification.

## Scope note

This phase completes the single-node HTTP and Shell execution loop. Distributed workers, SQL/Flink/Python/Notebook executors, dataset pagination and retry-policy orchestration remain intentionally out of scope.