### PR TITLE
feat(data-development): add platform capabilities

### DIFF
--- a/docs/data-development/platform-capabilities.md
+++ b/docs/data-development/platform-capabilities.md
@@ -1,0 +1,80 @@
+# Data Development Platform Capabilities
+
+## Scope
+
+Phase four turns the data-development workbench and execution engines into an operable platform. It adds runtime environments, encrypted secrets, reusable parameter templates, engine health probes, platform metrics and a durable audit trail.
+
+## Runtime resolution
+
+The execution snapshot keeps only platform references:
+
+- `runtime.common.environmentId`
+- `runtime.common.parameterTemplateId`
+- `runtime.common.secretKeys`
+
+The worker resolves them immediately before invoking the task plugin. Plaintext secrets are never written to task drafts, published versions, execution snapshots, events or results.
+
+Resolution precedence is:
+
+1. parameter-template values;
+2. environment variables;
+3. task `runtime.common.parameters`;
+4. execution input.
+
+Environment variables are available both at the top level and below `env`. Selected secrets are available below `secret`, for example `${secret.API_TOKEN}`.
+
+## Secret encryption
+
+Secrets use AES-256-GCM with a random 96-bit IV per value. The AES key is derived from the configured platform master key using SHA-256.
+
+Configure the master key through:
+
+```bash
+export YAK_DATA_DEVELOPMENT_PLATFORM_MASTER_KEY='replace-with-a-long-random-value'
+```
+
+The API never returns ciphertext or plaintext. Secret list responses contain metadata and a fixed mask only. Losing or changing the master key makes existing secrets undecryptable, so production deployments must manage this value through the deployment secret store.
+
+## Engine health
+
+Engine endpoints support three probe modes:
+
+- `LOCAL_PLUGIN`: verifies the task plugin is registered in `TaskPluginCatalog`;
+- `HTTP`: performs a bounded GET request and treats 2xx/3xx as healthy;
+- `TCP`: opens a bounded socket connection to `host:port`.
+
+Health checks update the durable endpoint status and are visible in the platform page. They are diagnostics only; execution routing remains owned by the task definition and engine plugin.
+
+## Audit
+
+The platform writes audit records for:
+
+- environment, secret, template and engine endpoint mutations;
+- individual and bulk health checks;
+- execution creation and cancellation.
+
+Audit summaries intentionally exclude secret values and full task definitions.
+
+## UI
+
+The platform page is available at `/data-development/platform` and is linked from the workbench header. It provides:
+
+- a 24-hour operational overview;
+- environment CRUD;
+- encrypted-secret CRUD;
+- parameter-template CRUD;
+- engine endpoint management and health checks;
+- recent audit records.
+
+The workbench runtime panel loads live environments, templates and secret metadata from the platform API.
+
+## Follow-up work
+
+The current phase intentionally leaves these concerns for later iterations:
+
+- external KMS/Vault integration and key rotation;
+- project-scoped RBAC beyond the existing route permissions;
+- distributed engine routing and worker-group capacity;
+- scheduled health checks and alert rules;
+- audit export and retention policies;
+- environment promotion workflows and approval gates.

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/api/DataDevelopmentPlatformApi.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/api/DataDevelopmentPlatformApi.java
@@ -1,0 +1,71 @@
+package io.yak.ops.business.development.api;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.yak.ops.business.development.domain.DataDevelopmentPlatformModel.AuditEntry;
+import io.yak.ops.business.development.domain.DataDevelopmentPlatformModel.EngineEndpoint;
+import io.yak.ops.business.development.domain.DataDevelopmentPlatformModel.Environment;
+import io.yak.ops.business.development.domain.DataDevelopmentPlatformModel.ParameterTemplate;
+import io.yak.ops.business.development.domain.DataDevelopmentPlatformModel.PlatformOverview;
+import io.yak.ops.business.development.domain.DataDevelopmentPlatformModel.SecretMetadata;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import java.util.List;
+
+/** REST contracts for data-development platform capabilities. */
+public final class DataDevelopmentPlatformApi {
+
+  private DataDevelopmentPlatformApi() {
+  }
+
+  public record SaveEnvironmentRequest(
+      Long id,
+      @NotBlank String code,
+      @NotBlank String name,
+      @NotBlank String environmentType,
+      String description,
+      boolean enabled,
+      @NotNull JsonNode variables,
+      @PositiveOrZero Integer lockVersion) {
+  }
+
+  public record SaveSecretRequest(
+      Long id,
+      @PositiveOrZero Long environmentId,
+      @NotBlank String secretKey,
+      String description,
+      String secretValue) {
+  }
+
+  public record SaveParameterTemplateRequest(
+      Long id,
+      @NotBlank String code,
+      @NotBlank String name,
+      String description,
+      boolean enabled,
+      @NotNull JsonNode parameters,
+      @PositiveOrZero Integer lockVersion) {
+  }
+
+  public record SaveEngineEndpointRequest(
+      Long id,
+      @NotBlank String taskType,
+      @NotBlank String code,
+      @NotBlank String name,
+      @NotBlank String probeType,
+      String endpoint,
+      boolean enabled,
+      @NotNull JsonNode config,
+      @PositiveOrZero Integer lockVersion) {
+  }
+
+  public record PlatformSnapshotView(
+      PlatformOverview overview,
+      List<Environment> environments,
+      List<SecretMetadata> secrets,
+      List<ParameterTemplate> parameterTemplates,
+      List<EngineEndpoint> engines,
+      List<AuditEntry> recentAudit,
+      boolean secretEncryptionConfigured) {
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/config/DataDevelopmentProperties.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/config/DataDevelopmentProperties.java
@@ -2,32 +2,22 @@ package io.yak.ops.business.development.config;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
-/** Persistence and local execution-gateway settings for data development. */
+/** Persistence, execution-gateway and platform-governance settings. */
 @ConfigurationProperties(prefix = "yak.data-development")
 public class DataDevelopmentProperties {
 
   private boolean enabled;
   private final Datasource datasource = new Datasource();
   private final Execution execution = new Execution();
+  private final Platform platform = new Platform();
 
-  public boolean isEnabled() {
-    return enabled;
-  }
-
-  public void setEnabled(boolean enabled) {
-    this.enabled = enabled;
-  }
-
-  public Datasource getDatasource() {
-    return datasource;
-  }
-
-  public Execution getExecution() {
-    return execution;
-  }
+  public boolean isEnabled() { return enabled; }
+  public void setEnabled(boolean enabled) { this.enabled = enabled; }
+  public Datasource getDatasource() { return datasource; }
+  public Execution getExecution() { return execution; }
+  public Platform getPlatform() { return platform; }
 
   public static class Datasource {
-
     private String url;
     private String username;
     private String password;
@@ -35,57 +25,21 @@ public class DataDevelopmentProperties {
     private int maximumPoolSize = 8;
     private int minimumIdle = 1;
 
-    public String getUrl() {
-      return url;
-    }
-
-    public void setUrl(String url) {
-      this.url = url;
-    }
-
-    public String getUsername() {
-      return username;
-    }
-
-    public void setUsername(String username) {
-      this.username = username;
-    }
-
-    public String getPassword() {
-      return password;
-    }
-
-    public void setPassword(String password) {
-      this.password = password;
-    }
-
-    public String getDriverClassName() {
-      return driverClassName;
-    }
-
-    public void setDriverClassName(String driverClassName) {
-      this.driverClassName = driverClassName;
-    }
-
-    public int getMaximumPoolSize() {
-      return maximumPoolSize;
-    }
-
-    public void setMaximumPoolSize(int maximumPoolSize) {
-      this.maximumPoolSize = maximumPoolSize;
-    }
-
-    public int getMinimumIdle() {
-      return minimumIdle;
-    }
-
-    public void setMinimumIdle(int minimumIdle) {
-      this.minimumIdle = minimumIdle;
-    }
+    public String getUrl() { return url; }
+    public void setUrl(String url) { this.url = url; }
+    public String getUsername() { return username; }
+    public void setUsername(String username) { this.username = username; }
+    public String getPassword() { return password; }
+    public void setPassword(String password) { this.password = password; }
+    public String getDriverClassName() { return driverClassName; }
+    public void setDriverClassName(String driverClassName) { this.driverClassName = driverClassName; }
+    public int getMaximumPoolSize() { return maximumPoolSize; }
+    public void setMaximumPoolSize(int maximumPoolSize) { this.maximumPoolSize = maximumPoolSize; }
+    public int getMinimumIdle() { return minimumIdle; }
+    public void setMinimumIdle(int minimumIdle) { this.minimumIdle = minimumIdle; }
   }
 
   public static class Execution {
-
     private int corePoolSize = 4;
     private int maximumPoolSize = 16;
     private int queueCapacity = 200;
@@ -93,52 +47,34 @@ public class DataDevelopmentProperties {
     private int eventReplayLimit = 1000;
     private String workerId = "local-worker";
 
-    public int getCorePoolSize() {
-      return corePoolSize;
-    }
+    public int getCorePoolSize() { return corePoolSize; }
+    public void setCorePoolSize(int corePoolSize) { this.corePoolSize = corePoolSize; }
+    public int getMaximumPoolSize() { return maximumPoolSize; }
+    public void setMaximumPoolSize(int maximumPoolSize) { this.maximumPoolSize = maximumPoolSize; }
+    public int getQueueCapacity() { return queueCapacity; }
+    public void setQueueCapacity(int queueCapacity) { this.queueCapacity = queueCapacity; }
+    public int getDefaultTimeoutSeconds() { return defaultTimeoutSeconds; }
+    public void setDefaultTimeoutSeconds(int defaultTimeoutSeconds) { this.defaultTimeoutSeconds = defaultTimeoutSeconds; }
+    public int getEventReplayLimit() { return eventReplayLimit; }
+    public void setEventReplayLimit(int eventReplayLimit) { this.eventReplayLimit = eventReplayLimit; }
+    public String getWorkerId() { return workerId; }
+    public void setWorkerId(String workerId) { this.workerId = workerId; }
+  }
 
-    public void setCorePoolSize(int corePoolSize) {
-      this.corePoolSize = corePoolSize;
-    }
+  public static class Platform {
+    /**
+     * Master key used to derive the AES-GCM key for stored secrets.
+     * Bind with YAK_DATA_DEVELOPMENT_PLATFORM_MASTER_KEY or
+     * YAK_DATA_DEVELOPMENT_PLATFORM_MASTER_KEY depending on deployment conventions.
+     */
+    private String masterKey;
+    private int healthCheckTimeoutSeconds = 5;
 
-    public int getMaximumPoolSize() {
-      return maximumPoolSize;
-    }
-
-    public void setMaximumPoolSize(int maximumPoolSize) {
-      this.maximumPoolSize = maximumPoolSize;
-    }
-
-    public int getQueueCapacity() {
-      return queueCapacity;
-    }
-
-    public void setQueueCapacity(int queueCapacity) {
-      this.queueCapacity = queueCapacity;
-    }
-
-    public int getDefaultTimeoutSeconds() {
-      return defaultTimeoutSeconds;
-    }
-
-    public void setDefaultTimeoutSeconds(int defaultTimeoutSeconds) {
-      this.defaultTimeoutSeconds = defaultTimeoutSeconds;
-    }
-
-    public int getEventReplayLimit() {
-      return eventReplayLimit;
-    }
-
-    public void setEventReplayLimit(int eventReplayLimit) {
-      this.eventReplayLimit = eventReplayLimit;
-    }
-
-    public String getWorkerId() {
-      return workerId;
-    }
-
-    public void setWorkerId(String workerId) {
-      this.workerId = workerId;
+    public String getMasterKey() { return masterKey; }
+    public void setMasterKey(String masterKey) { this.masterKey = masterKey; }
+    public int getHealthCheckTimeoutSeconds() { return healthCheckTimeoutSeconds; }
+    public void setHealthCheckTimeoutSeconds(int healthCheckTimeoutSeconds) {
+      this.healthCheckTimeoutSeconds = healthCheckTimeoutSeconds;
     }
   }
 }

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/controller/v1/DataDevelopmentController.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/controller/v1/DataDevelopmentController.java
@@ -156,9 +156,7 @@ public class DataDevelopmentController {
   }
 
   @GetMapping("/tasks/{taskId}/versions/{versionId}")
-  public Result<Version> getVersion(
-      @PathVariable long taskId,
-      @PathVariable long versionId) {
+  public Result<Version> getVersion(@PathVariable long taskId, @PathVariable long versionId) {
     return Result.success(service.getVersion(taskId, versionId));
   }
 
@@ -167,8 +165,8 @@ public class DataDevelopmentController {
       @PathVariable long taskId,
       @Valid @RequestBody CreateExecutionRequest request,
       Principal principal) {
-    return Result.success(
-        executionService.createExecution(taskId, request, operator(principal)));
+    return Result.success(executionService.createExecution(
+        taskId, request, operator(principal)));
   }
 
   @GetMapping("/tasks/{taskId}/executions")
@@ -185,8 +183,8 @@ public class DataDevelopmentController {
       @RequestParam(required = false) String keyword,
       @RequestParam(defaultValue = "0") int offset,
       @RequestParam(defaultValue = "50") int limit) {
-    return Result.success(
-        executionService.listExecutions(status, taskType, keyword, offset, limit));
+    return Result.success(executionService.listExecutions(
+        status, taskType, keyword, offset, limit));
   }
 
   @GetMapping("/executions/{executionId}")
@@ -209,13 +207,15 @@ public class DataDevelopmentController {
       @RequestParam(defaultValue = "0") long after,
       @RequestHeader(value = "Last-Event-ID", required = false) String lastEventId) {
     return executionEventStream.subscribe(
-        executionId,
-        Math.max(after, parseSequence(lastEventId)));
+        executionId, Math.max(after, parseSequence(lastEventId)));
   }
 
   @PostMapping("/executions/{executionId}/cancel")
-  public Result<Execution> cancelExecution(@PathVariable long executionId) {
-    return Result.success(executionService.cancelExecution(executionId));
+  public Result<Execution> cancelExecution(
+      @PathVariable long executionId,
+      Principal principal) {
+    return Result.success(
+        executionService.cancelExecution(executionId, operator(principal)));
   }
 
   @PutMapping("/resources/{resourceId}")
@@ -243,19 +243,13 @@ public class DataDevelopmentController {
   }
 
   private static long parseSequence(String value) {
-    if (value == null || value.isBlank()) {
-      return 0L;
-    }
-    try {
-      return Math.max(0L, Long.parseLong(value));
-    } catch (NumberFormatException ignored) {
-      return 0L;
-    }
+    if (value == null || value.isBlank()) return 0L;
+    try { return Math.max(0L, Long.parseLong(value)); }
+    catch (NumberFormatException ignored) { return 0L; }
   }
 
   private static String operator(Principal principal) {
     return principal == null || principal.getName() == null || principal.getName().isBlank()
-        ? "system"
-        : principal.getName();
+        ? "system" : principal.getName();
   }
 }

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/controller/v1/DataDevelopmentExceptionHandler.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/controller/v1/DataDevelopmentExceptionHandler.java
@@ -8,9 +8,12 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-/** Maps authoring conflicts to HTTP 409 so the workbench can surface a refresh action. */
+/** Maps data-development conflicts and validation failures to stable HTTP responses. */
 @ConditionalOnDataDevelopmentEnabled
-@RestControllerAdvice(assignableTypes = DataDevelopmentController.class)
+@RestControllerAdvice(assignableTypes = {
+    DataDevelopmentController.class,
+    DataDevelopmentPlatformController.class
+})
 public class DataDevelopmentExceptionHandler {
 
   @ExceptionHandler(IllegalStateException.class)
@@ -21,20 +24,17 @@ public class DataDevelopmentExceptionHandler {
   @ExceptionHandler(IllegalArgumentException.class)
   public ResponseEntity<Map<String, Object>> handleInvalidRequest(
       IllegalArgumentException exception) {
-    HttpStatus status = isRevisionConflict(exception.getMessage())
-        ? HttpStatus.CONFLICT
-        : HttpStatus.BAD_REQUEST;
+    HttpStatus status = isConflict(exception.getMessage())
+        ? HttpStatus.CONFLICT : HttpStatus.BAD_REQUEST;
     return response(status, exception.getMessage());
   }
 
-  private static boolean isRevisionConflict(String message) {
-    return message != null
-        && (message.contains("revision") || message.contains("draftRevision"));
+  private static boolean isConflict(String message) {
+    return message != null && (message.contains("revision")
+        || message.contains("draftRevision") || message.contains("其他用户更新"));
   }
 
-  private static ResponseEntity<Map<String, Object>> response(
-      HttpStatus status,
-      String message) {
+  private static ResponseEntity<Map<String, Object>> response(HttpStatus status, String message) {
     Map<String, Object> body = new LinkedHashMap<>();
     body.put("code", status.value());
     body.put("message", message);

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/controller/v1/DataDevelopmentPlatformController.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/controller/v1/DataDevelopmentPlatformController.java
@@ -1,0 +1,167 @@
+package io.yak.ops.business.development.controller.v1;
+
+import io.yak.framework.common.Result;
+import io.yak.ops.business.development.api.DataDevelopmentPlatformApi.PlatformSnapshotView;
+import io.yak.ops.business.development.api.DataDevelopmentPlatformApi.SaveEngineEndpointRequest;
+import io.yak.ops.business.development.api.DataDevelopmentPlatformApi.SaveEnvironmentRequest;
+import io.yak.ops.business.development.api.DataDevelopmentPlatformApi.SaveParameterTemplateRequest;
+import io.yak.ops.business.development.api.DataDevelopmentPlatformApi.SaveSecretRequest;
+import io.yak.ops.business.development.config.ConditionalOnDataDevelopmentEnabled;
+import io.yak.ops.business.development.domain.DataDevelopmentPlatformModel.AuditEntry;
+import io.yak.ops.business.development.domain.DataDevelopmentPlatformModel.EngineEndpoint;
+import io.yak.ops.business.development.domain.DataDevelopmentPlatformModel.Environment;
+import io.yak.ops.business.development.domain.DataDevelopmentPlatformModel.ParameterTemplate;
+import io.yak.ops.business.development.domain.DataDevelopmentPlatformModel.PlatformOverview;
+import io.yak.ops.business.development.domain.DataDevelopmentPlatformModel.SecretMetadata;
+import io.yak.ops.business.development.service.DataDevelopmentPlatformService;
+import jakarta.validation.Valid;
+import java.security.Principal;
+import java.util.List;
+import java.util.Map;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Platform configuration, governance, health and audit API. */
+@ConditionalOnDataDevelopmentEnabled
+@RestController
+@RequestMapping("/api/v1/data-development/platform")
+public final class DataDevelopmentPlatformController {
+
+  private final DataDevelopmentPlatformService service;
+
+  public DataDevelopmentPlatformController(DataDevelopmentPlatformService service) {
+    this.service = service;
+  }
+
+  @GetMapping("/snapshot")
+  public Result<PlatformSnapshotView> snapshot() { return Result.success(service.snapshot()); }
+
+  @GetMapping("/overview")
+  public Result<PlatformOverview> overview() { return Result.success(service.overview()); }
+
+  @GetMapping("/environments")
+  public Result<List<Environment>> environments() { return Result.success(service.listEnvironments()); }
+
+  @PostMapping("/environments")
+  public Result<Environment> createEnvironment(
+      @Valid @RequestBody SaveEnvironmentRequest request, Principal principal) {
+    return Result.success(service.saveEnvironment(request, operator(principal)));
+  }
+
+  @PutMapping("/environments/{id}")
+  public Result<Environment> updateEnvironment(
+      @PathVariable long id, @Valid @RequestBody SaveEnvironmentRequest request,
+      Principal principal) {
+    return Result.success(service.saveEnvironment(new SaveEnvironmentRequest(id, request.code(),
+        request.name(), request.environmentType(), request.description(), request.enabled(),
+        request.variables(), request.lockVersion()), operator(principal)));
+  }
+
+  @DeleteMapping("/environments/{id}")
+  public Result<Map<String, Boolean>> deleteEnvironment(@PathVariable long id, Principal principal) {
+    service.deleteEnvironment(id, operator(principal));
+    return Result.success(Map.of("deleted", true));
+  }
+
+  @GetMapping("/secrets")
+  public Result<List<SecretMetadata>> secrets() { return Result.success(service.listSecrets()); }
+
+  @PostMapping("/secrets")
+  public Result<SecretMetadata> createSecret(
+      @Valid @RequestBody SaveSecretRequest request, Principal principal) {
+    return Result.success(service.saveSecret(request, operator(principal)));
+  }
+
+  @PutMapping("/secrets/{id}")
+  public Result<SecretMetadata> updateSecret(
+      @PathVariable long id, @Valid @RequestBody SaveSecretRequest request,
+      Principal principal) {
+    return Result.success(service.saveSecret(new SaveSecretRequest(id, request.environmentId(),
+        request.secretKey(), request.description(), request.secretValue()), operator(principal)));
+  }
+
+  @DeleteMapping("/secrets/{id}")
+  public Result<Map<String, Boolean>> deleteSecret(@PathVariable long id, Principal principal) {
+    service.deleteSecret(id, operator(principal));
+    return Result.success(Map.of("deleted", true));
+  }
+
+  @GetMapping("/parameter-templates")
+  public Result<List<ParameterTemplate>> parameterTemplates() {
+    return Result.success(service.listParameterTemplates());
+  }
+
+  @PostMapping("/parameter-templates")
+  public Result<ParameterTemplate> createParameterTemplate(
+      @Valid @RequestBody SaveParameterTemplateRequest request, Principal principal) {
+    return Result.success(service.saveParameterTemplate(request, operator(principal)));
+  }
+
+  @PutMapping("/parameter-templates/{id}")
+  public Result<ParameterTemplate> updateParameterTemplate(
+      @PathVariable long id, @Valid @RequestBody SaveParameterTemplateRequest request,
+      Principal principal) {
+    return Result.success(service.saveParameterTemplate(new SaveParameterTemplateRequest(id,
+        request.code(), request.name(), request.description(), request.enabled(),
+        request.parameters(), request.lockVersion()), operator(principal)));
+  }
+
+  @DeleteMapping("/parameter-templates/{id}")
+  public Result<Map<String, Boolean>> deleteParameterTemplate(
+      @PathVariable long id, Principal principal) {
+    service.deleteParameterTemplate(id, operator(principal));
+    return Result.success(Map.of("deleted", true));
+  }
+
+  @GetMapping("/engines")
+  public Result<List<EngineEndpoint>> engines() { return Result.success(service.listEngines()); }
+
+  @PostMapping("/engines")
+  public Result<EngineEndpoint> createEngine(
+      @Valid @RequestBody SaveEngineEndpointRequest request, Principal principal) {
+    return Result.success(service.saveEngine(request, operator(principal)));
+  }
+
+  @PutMapping("/engines/{id}")
+  public Result<EngineEndpoint> updateEngine(
+      @PathVariable long id, @Valid @RequestBody SaveEngineEndpointRequest request,
+      Principal principal) {
+    return Result.success(service.saveEngine(new SaveEngineEndpointRequest(id,
+        request.taskType(), request.code(), request.name(), request.probeType(),
+        request.endpoint(), request.enabled(), request.config(), request.lockVersion()),
+        operator(principal)));
+  }
+
+  @PostMapping("/engines/{id}/check")
+  public Result<EngineEndpoint> checkEngine(@PathVariable long id, Principal principal) {
+    return Result.success(service.checkEngine(id, operator(principal)));
+  }
+
+  @PostMapping("/engines/check-all")
+  public Result<List<EngineEndpoint>> checkAllEngines(Principal principal) {
+    return Result.success(service.checkAllEngines(operator(principal)));
+  }
+
+  @DeleteMapping("/engines/{id}")
+  public Result<Map<String, Boolean>> deleteEngine(@PathVariable long id, Principal principal) {
+    service.deleteEngine(id, operator(principal));
+    return Result.success(Map.of("deleted", true));
+  }
+
+  @GetMapping("/audit")
+  public Result<List<AuditEntry>> audit(@RequestParam(defaultValue = "100") int limit) {
+    return Result.success(service.listAudit(limit));
+  }
+
+  private static String operator(Principal principal) {
+    return principal == null || principal.getName() == null || principal.getName().isBlank()
+        ? "system" : principal.getName();
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/domain/DataDevelopmentPlatformModel.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/domain/DataDevelopmentPlatformModel.java
@@ -1,0 +1,113 @@
+package io.yak.ops.business.development.domain;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.time.LocalDateTime;
+
+/** Platform-level environment, secret, template, engine and audit records. */
+public final class DataDevelopmentPlatformModel {
+
+  private DataDevelopmentPlatformModel() {
+  }
+
+  public enum EnvironmentType {
+    DEVELOPMENT,
+    TESTING,
+    STAGING,
+    PRODUCTION
+  }
+
+  public enum ProbeType {
+    LOCAL_PLUGIN,
+    HTTP,
+    TCP
+  }
+
+  public enum HealthStatus {
+    UNKNOWN,
+    HEALTHY,
+    DEGRADED,
+    UNHEALTHY,
+    DISABLED
+  }
+
+  public record Environment(
+      Long id,
+      String code,
+      String name,
+      EnvironmentType environmentType,
+      String description,
+      boolean enabled,
+      JsonNode variables,
+      int lockVersion,
+      String createdBy,
+      String updatedBy,
+      LocalDateTime createdAt,
+      LocalDateTime updatedAt) {
+  }
+
+  public record SecretMetadata(
+      Long id,
+      Long environmentId,
+      String secretKey,
+      String description,
+      String maskedValue,
+      String updatedBy,
+      LocalDateTime updatedAt) {
+  }
+
+  public record ParameterTemplate(
+      Long id,
+      String code,
+      String name,
+      String description,
+      boolean enabled,
+      JsonNode parameters,
+      int lockVersion,
+      String createdBy,
+      String updatedBy,
+      LocalDateTime createdAt,
+      LocalDateTime updatedAt) {
+  }
+
+  public record EngineEndpoint(
+      Long id,
+      String taskType,
+      String code,
+      String name,
+      ProbeType probeType,
+      String endpoint,
+      boolean enabled,
+      JsonNode config,
+      HealthStatus healthStatus,
+      String healthMessage,
+      LocalDateTime lastCheckedAt,
+      int lockVersion,
+      String createdBy,
+      String updatedBy,
+      LocalDateTime createdAt,
+      LocalDateTime updatedAt) {
+  }
+
+  public record AuditEntry(
+      Long id,
+      String action,
+      String resourceType,
+      String resourceId,
+      JsonNode summary,
+      String operator,
+      LocalDateTime occurredAt) {
+  }
+
+  public record PlatformOverview(
+      long projectCount,
+      long taskCount,
+      long executionCount24h,
+      long failedExecutionCount24h,
+      long environmentCount,
+      long secretCount,
+      long templateCount,
+      long healthyEngineCount,
+      long unhealthyEngineCount,
+      double successRate24h) {
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/execution/DataDevelopmentExecutionWorker.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/execution/DataDevelopmentExecutionWorker.java
@@ -8,6 +8,7 @@ import io.yak.ops.business.development.domain.DataDevelopmentModel.ExecutionStat
 import io.yak.ops.business.development.repository.DataDevelopmentExecutionRepository;
 import io.yak.ops.business.development.repository.DataDevelopmentRepository;
 import io.yak.ops.business.development.service.DataDevelopmentJsonCodec;
+import io.yak.ops.business.development.service.DataDevelopmentPlatformRuntimeResolver;
 import io.yak.ops.core.workflow.WorkflowTaskExecutorRegistry;
 import io.yak.ops.plugin.task.api.TaskPluginCatalog;
 import io.yak.ops.spi.workflow.WorkflowTaskContext;
@@ -35,6 +36,7 @@ public class DataDevelopmentExecutionWorker {
   private final WorkflowTaskExecutorRegistry executorRegistry;
   private final DataDevelopmentExecutionRuntimeRegistry runtimeRegistry;
   private final DataDevelopmentExecutionEventStream eventStream;
+  private final DataDevelopmentPlatformRuntimeResolver platformRuntimeResolver;
   private final String workerId;
 
   public DataDevelopmentExecutionWorker(
@@ -42,10 +44,10 @@ public class DataDevelopmentExecutionWorker {
       DataDevelopmentExecutionRepository executionRepository,
       DataDevelopmentJsonCodec json,
       TaskPluginCatalog taskPluginCatalog,
-      @Qualifier("dataDevelopmentTaskExecutorRegistry")
-      WorkflowTaskExecutorRegistry executorRegistry,
+      @Qualifier("dataDevelopmentTaskExecutorRegistry") WorkflowTaskExecutorRegistry executorRegistry,
       DataDevelopmentExecutionRuntimeRegistry runtimeRegistry,
       DataDevelopmentExecutionEventStream eventStream,
+      DataDevelopmentPlatformRuntimeResolver platformRuntimeResolver,
       DataDevelopmentProperties properties) {
     this.controlRepository = controlRepository;
     this.executionRepository = executionRepository;
@@ -54,53 +56,31 @@ public class DataDevelopmentExecutionWorker {
     this.executorRegistry = executorRegistry;
     this.runtimeRegistry = runtimeRegistry;
     this.eventStream = eventStream;
+    this.platformRuntimeResolver = platformRuntimeResolver;
     this.workerId = properties.getExecution().getWorkerId();
   }
 
   public void execute(long executionId) {
     Execution queued = requireExecution(executionId);
-    if (queued.status().terminal()) {
-      return;
-    }
+    if (queued.status().terminal()) return;
 
     int attemptNo = queued.currentAttemptNo() + 1;
     LocalDateTime startedAt = LocalDateTime.now();
-    if (executionRepository.markRunning(executionId, attemptNo, startedAt) != 1) {
-      return;
-    }
+    if (executionRepository.markRunning(executionId, attemptNo, startedAt) != 1) return;
 
     Execution execution = requireExecution(executionId);
     long attemptId = executionRepository.insertAttempt(
-        executionId,
-        attemptNo,
-        execution.taskType(),
-        workerId,
-        startedAt);
-    eventStream.publish(
-        executionId,
-        attemptId,
-        "EXECUTION_RUNNING",
+        executionId, attemptNo, execution.taskType(), workerId, startedAt);
+    eventStream.publish(executionId, attemptId, "EXECUTION_RUNNING",
         Map.of("status", ExecutionStatus.RUNNING.name(), "attemptNo", attemptNo));
 
     WorkflowTaskExecutor executor = executorRegistry.require(execution.taskType());
-    DataDevelopmentExecutionRuntimeRegistry.CancellationSignal cancellation =
-        runtimeRegistry.newSignal();
-    Map<String, Object> configuration = configuration(execution);
-    Map<String, Object> inputs = runtimeParameters(execution);
+    DataDevelopmentExecutionRuntimeRegistry.CancellationSignal cancellation = runtimeRegistry.newSignal();
     WorkflowTaskContext context = new WorkflowTaskContext(
-        execution.id(),
-        execution.taskId(),
-        attemptId,
-        attemptNo,
-        Long.toString(execution.taskId()),
-        execution.taskType(),
-        configuration,
-        inputs,
-        cancellation,
-        line -> eventStream.publish(
-            executionId,
-            attemptId,
-            "LOG",
+        execution.id(), execution.taskId(), attemptId, attemptNo,
+        Long.toString(execution.taskId()), execution.taskType(), configuration(execution),
+        runtimeParameters(execution), cancellation,
+        line -> eventStream.publish(executionId, attemptId, "LOG",
             Map.of("level", "INFO", "line", sanitizeLine(line))));
 
     runtimeRegistry.register(executionId, attemptId, cancellation, executor, context);
@@ -112,10 +92,7 @@ public class DataDevelopmentExecutionWorker {
         finishSucceeded(execution, attemptId, result, startedAt, startedNanos);
       } else {
         persistResult(execution, attemptId, result, startedAt, startedNanos);
-        finishFailed(
-            executionId,
-            attemptId,
-            "PLUGIN_EXECUTION_FAILED",
+        finishFailed(executionId, attemptId, "PLUGIN_EXECUTION_FAILED",
             defaultMessage(result.message(), "任务插件返回失败"));
       }
     } catch (CancellationException error) {
@@ -124,10 +101,7 @@ public class DataDevelopmentExecutionWorker {
       Thread.currentThread().interrupt();
       finishInterrupted(executionId, attemptId, "执行线程被中断");
     } catch (Exception error) {
-      finishFailed(
-          executionId,
-          attemptId,
-          error.getClass().getSimpleName(),
+      finishFailed(executionId, attemptId, error.getClass().getSimpleName(),
           defaultMessage(error.getMessage(), "任务插件执行异常"));
     } finally {
       runtimeRegistry.unregister(executionId);
@@ -135,47 +109,25 @@ public class DataDevelopmentExecutionWorker {
   }
 
   private void finishSucceeded(
-      Execution execution,
-      long attemptId,
-      WorkflowTaskResult result,
-      LocalDateTime startedAt,
-      long startedNanos) {
+      Execution execution, long attemptId, WorkflowTaskResult result,
+      LocalDateTime startedAt, long startedNanos) {
     if (currentStatus(execution.id()) != ExecutionStatus.RUNNING) {
       finishInterrupted(execution.id(), attemptId, "执行状态已被外部终止");
       return;
     }
-
-    PersistedResult persisted = persistResult(
-        execution,
-        attemptId,
-        result,
-        startedAt,
-        startedNanos);
-    executionRepository.completeAttempt(
-        attemptId,
-        ExecutionStatus.SUCCEEDED,
-        result.externalId(),
-        persisted.exitCode(),
-        null,
-        null,
-        persisted.finishedAt());
+    PersistedResult persisted = persistResult(execution, attemptId, result, startedAt, startedNanos);
+    executionRepository.completeAttempt(attemptId, ExecutionStatus.SUCCEEDED,
+        result.externalId(), persisted.exitCode(), null, null, persisted.finishedAt());
     if (executionRepository.markSucceeded(execution.id(), persisted.finishedAt()) == 1) {
-      eventStream.publish(
-          execution.id(),
-          attemptId,
-          "EXECUTION_SUCCEEDED",
-          Map.of(
-              "status", ExecutionStatus.SUCCEEDED.name(),
+      eventStream.publish(execution.id(), attemptId, "EXECUTION_SUCCEEDED",
+          Map.of("status", ExecutionStatus.SUCCEEDED.name(),
               "durationMs", persisted.durationMs()));
     }
   }
 
   private PersistedResult persistResult(
-      Execution execution,
-      long attemptId,
-      WorkflowTaskResult result,
-      LocalDateTime startedAt,
-      long startedNanos) {
+      Execution execution, long attemptId, WorkflowTaskResult result,
+      LocalDateTime startedAt, long startedNanos) {
     LocalDateTime finishedAt = LocalDateTime.now();
     long durationMs = Duration.ofNanos(System.nanoTime() - startedNanos).toMillis();
     Map<String, Object> summary = new LinkedHashMap<>();
@@ -190,46 +142,22 @@ public class DataDevelopmentExecutionWorker {
     boolean truncated = Boolean.TRUE.equals(result.outputs().get("bodyTruncated"))
         || Boolean.TRUE.equals(result.outputs().get("truncated"));
     String datasetRef = text(result.outputs().get("datasetRef"));
-    long resultId = executionRepository.insertResult(
-        execution.id(),
-        attemptId,
-        resultKind,
-        json.write(json.toTree(summary)),
-        json.write(json.toTree(result.outputs())),
-        datasetRef,
-        truncated,
-        finishedAt);
-    eventStream.publish(
-        execution.id(),
-        attemptId,
-        "RESULT",
+    long resultId = executionRepository.insertResult(execution.id(), attemptId, resultKind,
+        json.write(json.toTree(summary)), json.write(json.toTree(result.outputs())),
+        datasetRef, truncated, finishedAt);
+    eventStream.publish(execution.id(), attemptId, "RESULT",
         Map.of("resultId", resultId, "resultKind", resultKind));
     return new PersistedResult(finishedAt, durationMs, exitCode);
   }
 
-  private void finishFailed(
-      long executionId,
-      long attemptId,
-      String errorCode,
-      String errorMessage) {
+  private void finishFailed(long executionId, long attemptId, String code, String message) {
     LocalDateTime now = LocalDateTime.now();
     executionRepository.completeAttempt(
-        attemptId,
-        ExecutionStatus.FAILED,
-        null,
-        null,
-        errorCode,
-        errorMessage,
-        now);
-    if (executionRepository.markFailed(executionId, errorCode, errorMessage, now) == 1) {
-      eventStream.publish(
-          executionId,
-          attemptId,
-          "EXECUTION_FAILED",
-          Map.of(
-              "status", ExecutionStatus.FAILED.name(),
-              "errorCode", errorCode,
-              "errorMessage", errorMessage));
+        attemptId, ExecutionStatus.FAILED, null, null, code, message, now);
+    if (executionRepository.markFailed(executionId, code, message, now) == 1) {
+      eventStream.publish(executionId, attemptId, "EXECUTION_FAILED",
+          Map.of("status", ExecutionStatus.FAILED.name(),
+              "errorCode", code, "errorMessage", message));
     }
   }
 
@@ -237,54 +165,34 @@ public class DataDevelopmentExecutionWorker {
     ExecutionStatus status = currentStatus(executionId);
     LocalDateTime now = LocalDateTime.now();
     if (status == ExecutionStatus.TIMED_OUT) {
-      executionRepository.completeAttempt(
-          attemptId,
-          ExecutionStatus.TIMED_OUT,
-          null,
-          null,
-          "EXECUTION_TIMEOUT",
-          message,
-          now);
+      executionRepository.completeAttempt(attemptId, ExecutionStatus.TIMED_OUT,
+          null, null, "EXECUTION_TIMEOUT", message, now);
       return;
     }
     executionRepository.completeAttempt(
-        attemptId,
-        ExecutionStatus.CANCELED,
-        null,
-        null,
-        null,
-        message,
-        now);
-    if (status == ExecutionStatus.RUNNING || status == ExecutionStatus.QUEUED) {
-      if (executionRepository.markCanceled(executionId, now) == 1) {
-        eventStream.publish(
-            executionId,
-            attemptId,
-            "EXECUTION_CANCELED",
-            Map.of("status", ExecutionStatus.CANCELED.name()));
-      }
+        attemptId, ExecutionStatus.CANCELED, null, null, null, message, now);
+    if ((status == ExecutionStatus.RUNNING || status == ExecutionStatus.QUEUED)
+        && executionRepository.markCanceled(executionId, now) == 1) {
+      eventStream.publish(executionId, attemptId, "EXECUTION_CANCELED",
+          Map.of("status", ExecutionStatus.CANCELED.name()));
     }
   }
 
   private Map<String, Object> configuration(Execution execution) {
     JsonNode compiled = execution.compiledSpecSnapshot();
-    JsonNode configuration = compiled == null ? null : compiled.get("configuration");
-    if (configuration != null && configuration.isObject()) {
-      return json.toMap(configuration);
-    }
+    JsonNode value = compiled == null ? null : compiled.get("configuration");
+    if (value != null && value.isObject()) return json.toMap(value);
     JsonNode definition = execution.definitionSnapshot();
-    JsonNode config = definition == null ? null : definition.get("config");
-    return objectMap(config);
+    return objectMap(definition == null ? null : definition.get("config"));
   }
 
   private Map<String, Object> runtimeParameters(Execution execution) {
     Map<String, Object> values = new LinkedHashMap<>();
     JsonNode runtime = execution.runtimeSnapshot();
+    values.putAll(platformRuntimeResolver.resolve(runtime));
     if (runtime != null && runtime.isObject()) {
       JsonNode parameters = runtime.path("common").path("parameters");
-      if (parameters.isObject()) {
-        values.putAll(json.toMap(parameters));
-      }
+      if (parameters.isObject()) values.putAll(json.toMap(parameters));
     }
     values.putAll(objectMap(execution.inputSnapshot()));
     return values;
@@ -296,8 +204,7 @@ public class DataDevelopmentExecutionWorker {
 
   private ExecutionStatus currentStatus(long executionId) {
     return controlRepository.findExecution(executionId)
-        .map(Execution::status)
-        .orElse(ExecutionStatus.LOST);
+        .map(Execution::status).orElse(ExecutionStatus.LOST);
   }
 
   private Execution requireExecution(long executionId) {
@@ -306,23 +213,14 @@ public class DataDevelopmentExecutionWorker {
   }
 
   private static Integer integer(Object value) {
-    if (value == null) {
-      return null;
-    }
-    if (value instanceof Number number) {
-      return number.intValue();
-    }
-    try {
-      return Integer.valueOf(String.valueOf(value));
-    } catch (NumberFormatException ignored) {
-      return null;
-    }
+    if (value == null) return null;
+    if (value instanceof Number number) return number.intValue();
+    try { return Integer.valueOf(String.valueOf(value)); }
+    catch (NumberFormatException ignored) { return null; }
   }
 
   private static String text(Object value) {
-    if (value == null) {
-      return null;
-    }
+    if (value == null) return null;
     String result = String.valueOf(value);
     return result.isBlank() ? null : result;
   }
@@ -330,17 +228,13 @@ public class DataDevelopmentExecutionWorker {
   private static String sanitizeLine(String line) {
     String value = line == null ? "" : line;
     return value.length() <= MAX_LOG_LINE_LENGTH
-        ? value
-        : value.substring(0, MAX_LOG_LINE_LENGTH) + "...";
+        ? value : value.substring(0, MAX_LOG_LINE_LENGTH) + "...";
   }
 
   private static String defaultMessage(String value, String fallback) {
     return value == null || value.isBlank() ? fallback : value;
   }
 
-  private record PersistedResult(
-      LocalDateTime finishedAt,
-      long durationMs,
-      Integer exitCode) {
+  private record PersistedResult(LocalDateTime finishedAt, long durationMs, Integer exitCode) {
   }
 }

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/DataDevelopmentPlatformRepository.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/DataDevelopmentPlatformRepository.java
@@ -1,0 +1,359 @@
+package io.yak.ops.business.development.repository;
+
+import io.yak.ops.business.development.config.ConditionalOnDataDevelopmentEnabled;
+import io.yak.ops.business.development.domain.DataDevelopmentPlatformModel.AuditEntry;
+import io.yak.ops.business.development.domain.DataDevelopmentPlatformModel.EngineEndpoint;
+import io.yak.ops.business.development.domain.DataDevelopmentPlatformModel.Environment;
+import io.yak.ops.business.development.domain.DataDevelopmentPlatformModel.EnvironmentType;
+import io.yak.ops.business.development.domain.DataDevelopmentPlatformModel.HealthStatus;
+import io.yak.ops.business.development.domain.DataDevelopmentPlatformModel.ParameterTemplate;
+import io.yak.ops.business.development.domain.DataDevelopmentPlatformModel.PlatformOverview;
+import io.yak.ops.business.development.domain.DataDevelopmentPlatformModel.ProbeType;
+import io.yak.ops.business.development.domain.DataDevelopmentPlatformModel.SecretMetadata;
+import io.yak.ops.business.development.service.DataDevelopmentJsonCodec;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.support.GeneratedKeyHolder;
+import org.springframework.jdbc.support.KeyHolder;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Repository;
+
+/** JDBC persistence for platform environments, secrets, templates, engines and audit. */
+@ConditionalOnDataDevelopmentEnabled
+@Repository
+public final class DataDevelopmentPlatformRepository {
+
+  private final NamedParameterJdbcTemplate jdbc;
+  private final DataDevelopmentJsonCodec json;
+
+  public DataDevelopmentPlatformRepository(
+      @Qualifier("dataDevelopmentJdbcTemplate") NamedParameterJdbcTemplate jdbc,
+      DataDevelopmentJsonCodec json) {
+    this.jdbc = jdbc;
+    this.json = json;
+  }
+
+  public List<Environment> listEnvironments() {
+    return jdbc.query("""
+        SELECT * FROM yak_dev_environment ORDER BY environment_type, code
+        """, Map.of(), environmentMapper());
+  }
+
+  public Optional<Environment> findEnvironment(long id) {
+    return first(jdbc.query("SELECT * FROM yak_dev_environment WHERE id=:id",
+        Map.of("id", id), environmentMapper()));
+  }
+
+  public long insertEnvironment(
+      String code, String name, String type, String description, boolean enabled,
+      String variablesJson, String operator, LocalDateTime now) {
+    KeyHolder key = new GeneratedKeyHolder();
+    jdbc.update("""
+        INSERT INTO yak_dev_environment
+          (code,name,environment_type,description,enabled,variables_json,lock_version,
+           created_by,updated_by,created_at,updated_at)
+        VALUES (:code,:name,:type,:description,:enabled,:variables,0,:operator,:operator,:now,:now)
+        """, new MapSqlParameterSource()
+        .addValue("code", code).addValue("name", name).addValue("type", type)
+        .addValue("description", description).addValue("enabled", enabled)
+        .addValue("variables", variablesJson).addValue("operator", operator)
+        .addValue("now", now), key, new String[]{"id"});
+    return requiredKey(key);
+  }
+
+  public int updateEnvironment(
+      long id, String code, String name, String type, String description, boolean enabled,
+      String variablesJson, int lockVersion, String operator, LocalDateTime now) {
+    return jdbc.update("""
+        UPDATE yak_dev_environment
+        SET code=:code,name=:name,environment_type=:type,description=:description,
+            enabled=:enabled,variables_json=:variables,updated_by=:operator,
+            updated_at=:now,lock_version=lock_version+1
+        WHERE id=:id AND lock_version=:lockVersion
+        """, Map.ofEntries(
+        Map.entry("id", id), Map.entry("code", code), Map.entry("name", name),
+        Map.entry("type", type), Map.entry("description", nullable(description)),
+        Map.entry("enabled", enabled), Map.entry("variables", variablesJson),
+        Map.entry("operator", operator), Map.entry("now", now),
+        Map.entry("lockVersion", lockVersion)));
+  }
+
+  public int deleteEnvironment(long id) {
+    return jdbc.update("DELETE FROM yak_dev_environment WHERE id=:id", Map.of("id", id));
+  }
+
+  public List<SecretMetadata> listSecrets() {
+    return jdbc.query("""
+        SELECT id,environment_id,secret_key,description,updated_by,updated_at
+        FROM yak_dev_secret ORDER BY environment_id, secret_key
+        """, Map.of(), (rs, row) -> new SecretMetadata(
+        rs.getLong("id"), rs.getLong("environment_id"), rs.getString("secret_key"),
+        rs.getString("description"), "••••••••", rs.getString("updated_by"),
+        rs.getTimestamp("updated_at").toLocalDateTime()));
+  }
+
+  public Optional<String> findEncryptedSecret(long environmentId, String secretKey) {
+    List<String> values = jdbc.query("""
+        SELECT encrypted_value FROM yak_dev_secret
+        WHERE environment_id=:environmentId AND secret_key=:secretKey
+        """, Map.of("environmentId", environmentId, "secretKey", secretKey),
+        (rs, row) -> rs.getString(1));
+    return first(values);
+  }
+
+  public long upsertSecret(
+      Long id, long environmentId, String secretKey, String description,
+      String encryptedValue, String digest, String operator, LocalDateTime now) {
+    if (id == null) {
+      KeyHolder key = new GeneratedKeyHolder();
+      jdbc.update("""
+          INSERT INTO yak_dev_secret
+            (environment_id,secret_key,description,encrypted_value,value_digest,
+             created_by,updated_by,created_at,updated_at)
+          VALUES (:environmentId,:secretKey,:description,:encryptedValue,:digest,
+                  :operator,:operator,:now,:now)
+          """, new MapSqlParameterSource()
+          .addValue("environmentId", environmentId).addValue("secretKey", secretKey)
+          .addValue("description", description).addValue("encryptedValue", encryptedValue)
+          .addValue("digest", digest).addValue("operator", operator).addValue("now", now),
+          key, new String[]{"id"});
+      return requiredKey(key);
+    }
+    jdbc.update("""
+        UPDATE yak_dev_secret
+        SET environment_id=:environmentId,secret_key=:secretKey,description=:description,
+            encrypted_value=:encryptedValue,value_digest=:digest,updated_by=:operator,updated_at=:now
+        WHERE id=:id
+        """, Map.ofEntries(Map.entry("id", id), Map.entry("environmentId", environmentId),
+        Map.entry("secretKey", secretKey), Map.entry("description", nullable(description)),
+        Map.entry("encryptedValue", encryptedValue), Map.entry("digest", digest),
+        Map.entry("operator", operator), Map.entry("now", now)));
+    return id;
+  }
+
+  public int deleteSecret(long id) {
+    return jdbc.update("DELETE FROM yak_dev_secret WHERE id=:id", Map.of("id", id));
+  }
+
+  public int deleteSecretsByEnvironment(long environmentId) {
+    return jdbc.update("DELETE FROM yak_dev_secret WHERE environment_id=:environmentId",
+        Map.of("environmentId", environmentId));
+  }
+
+  public List<ParameterTemplate> listParameterTemplates() {
+    return jdbc.query("SELECT * FROM yak_dev_parameter_template ORDER BY code",
+        Map.of(), templateMapper());
+  }
+
+  public Optional<ParameterTemplate> findParameterTemplate(long id) {
+    return first(jdbc.query("SELECT * FROM yak_dev_parameter_template WHERE id=:id",
+        Map.of("id", id), templateMapper()));
+  }
+
+  public long insertParameterTemplate(
+      String code, String name, String description, boolean enabled, String parametersJson,
+      String operator, LocalDateTime now) {
+    KeyHolder key = new GeneratedKeyHolder();
+    jdbc.update("""
+        INSERT INTO yak_dev_parameter_template
+          (code,name,description,enabled,parameters_json,lock_version,
+           created_by,updated_by,created_at,updated_at)
+        VALUES (:code,:name,:description,:enabled,:parameters,0,:operator,:operator,:now,:now)
+        """, new MapSqlParameterSource().addValue("code", code).addValue("name", name)
+        .addValue("description", description).addValue("enabled", enabled)
+        .addValue("parameters", parametersJson).addValue("operator", operator)
+        .addValue("now", now), key, new String[]{"id"});
+    return requiredKey(key);
+  }
+
+  public int updateParameterTemplate(
+      long id, String code, String name, String description, boolean enabled,
+      String parametersJson, int lockVersion, String operator, LocalDateTime now) {
+    return jdbc.update("""
+        UPDATE yak_dev_parameter_template
+        SET code=:code,name=:name,description=:description,enabled=:enabled,
+            parameters_json=:parameters,updated_by=:operator,updated_at=:now,
+            lock_version=lock_version+1
+        WHERE id=:id AND lock_version=:lockVersion
+        """, Map.ofEntries(Map.entry("id", id), Map.entry("code", code),
+        Map.entry("name", name), Map.entry("description", nullable(description)),
+        Map.entry("enabled", enabled), Map.entry("parameters", parametersJson),
+        Map.entry("operator", operator), Map.entry("now", now),
+        Map.entry("lockVersion", lockVersion)));
+  }
+
+  public int deleteParameterTemplate(long id) {
+    return jdbc.update("DELETE FROM yak_dev_parameter_template WHERE id=:id", Map.of("id", id));
+  }
+
+  public List<EngineEndpoint> listEngineEndpoints() {
+    return jdbc.query("SELECT * FROM yak_dev_engine_endpoint ORDER BY task_type, code",
+        Map.of(), engineMapper());
+  }
+
+  public Optional<EngineEndpoint> findEngineEndpoint(long id) {
+    return first(jdbc.query("SELECT * FROM yak_dev_engine_endpoint WHERE id=:id",
+        Map.of("id", id), engineMapper()));
+  }
+
+  public long insertEngineEndpoint(
+      String taskType, String code, String name, String probeType, String endpoint,
+      boolean enabled, String configJson, String operator, LocalDateTime now) {
+    KeyHolder key = new GeneratedKeyHolder();
+    jdbc.update("""
+        INSERT INTO yak_dev_engine_endpoint
+          (task_type,code,name,probe_type,endpoint,enabled,config_json,health_status,
+           lock_version,created_by,updated_by,created_at,updated_at)
+        VALUES (:taskType,:code,:name,:probeType,:endpoint,:enabled,:config,'UNKNOWN',0,
+                :operator,:operator,:now,:now)
+        """, new MapSqlParameterSource().addValue("taskType", taskType)
+        .addValue("code", code).addValue("name", name).addValue("probeType", probeType)
+        .addValue("endpoint", endpoint).addValue("enabled", enabled)
+        .addValue("config", configJson).addValue("operator", operator).addValue("now", now),
+        key, new String[]{"id"});
+    return requiredKey(key);
+  }
+
+  public int updateEngineEndpoint(
+      long id, String taskType, String code, String name, String probeType, String endpoint,
+      boolean enabled, String configJson, int lockVersion, String operator, LocalDateTime now) {
+    return jdbc.update("""
+        UPDATE yak_dev_engine_endpoint
+        SET task_type=:taskType,code=:code,name=:name,probe_type=:probeType,
+            endpoint=:endpoint,enabled=:enabled,config_json=:config,
+            updated_by=:operator,updated_at=:now,lock_version=lock_version+1
+        WHERE id=:id AND lock_version=:lockVersion
+        """, Map.ofEntries(Map.entry("id", id), Map.entry("taskType", taskType),
+        Map.entry("code", code), Map.entry("name", name), Map.entry("probeType", probeType),
+        Map.entry("endpoint", nullable(endpoint)), Map.entry("enabled", enabled),
+        Map.entry("config", configJson), Map.entry("operator", operator),
+        Map.entry("now", now), Map.entry("lockVersion", lockVersion)));
+  }
+
+  public int updateEngineHealth(
+      long id, HealthStatus status, String message, LocalDateTime checkedAt) {
+    return jdbc.update("""
+        UPDATE yak_dev_engine_endpoint
+        SET health_status=:status,health_message=:message,last_checked_at=:checkedAt
+        WHERE id=:id
+        """, Map.of("id", id, "status", status.name(),
+        "message", nullable(message), "checkedAt", checkedAt));
+  }
+
+  public int deleteEngineEndpoint(long id) {
+    return jdbc.update("DELETE FROM yak_dev_engine_endpoint WHERE id=:id", Map.of("id", id));
+  }
+
+  public void insertAudit(
+      String action, String resourceType, String resourceId,
+      String summaryJson, String operator, LocalDateTime now) {
+    jdbc.update("""
+        INSERT INTO yak_dev_audit_log
+          (action,resource_type,resource_id,summary_json,operator,occurred_at)
+        VALUES (:action,:resourceType,:resourceId,:summary,:operator,:now)
+        """, Map.of("action", action, "resourceType", resourceType,
+        "resourceId", nullable(resourceId), "summary", summaryJson,
+        "operator", operator, "now", now));
+  }
+
+  public List<AuditEntry> listAudit(int limit) {
+    int safeLimit = Math.min(500, Math.max(1, limit));
+    return jdbc.query("""
+        SELECT * FROM yak_dev_audit_log ORDER BY occurred_at DESC, id DESC LIMIT :limit
+        """, Map.of("limit", safeLimit), (rs, row) -> new AuditEntry(
+        rs.getLong("id"), rs.getString("action"), rs.getString("resource_type"),
+        rs.getString("resource_id"), json.readTree(rs.getString("summary_json")),
+        rs.getString("operator"), rs.getTimestamp("occurred_at").toLocalDateTime()));
+  }
+
+  public PlatformOverview overview(LocalDateTime since) {
+    long projects = scalar("SELECT COUNT(*) FROM yak_dev_project", Map.of());
+    long tasks = scalar("SELECT COUNT(*) FROM yak_dev_task", Map.of());
+    long executions = scalar("SELECT COUNT(*) FROM yak_dev_execution WHERE created_at>=:since",
+        Map.of("since", since));
+    long failed = scalar("""
+        SELECT COUNT(*) FROM yak_dev_execution
+        WHERE created_at>=:since AND status IN ('FAILED','TIMED_OUT','LOST')
+        """, Map.of("since", since));
+    long succeeded = scalar("""
+        SELECT COUNT(*) FROM yak_dev_execution
+        WHERE created_at>=:since AND status='SUCCEEDED'
+        """, Map.of("since", since));
+    long environments = scalar("SELECT COUNT(*) FROM yak_dev_environment", Map.of());
+    long secrets = scalar("SELECT COUNT(*) FROM yak_dev_secret", Map.of());
+    long templates = scalar("SELECT COUNT(*) FROM yak_dev_parameter_template", Map.of());
+    long healthy = scalar("SELECT COUNT(*) FROM yak_dev_engine_endpoint WHERE health_status='HEALTHY'",
+        Map.of());
+    long unhealthy = scalar("""
+        SELECT COUNT(*) FROM yak_dev_engine_endpoint
+        WHERE enabled=1 AND health_status IN ('DEGRADED','UNHEALTHY')
+        """, Map.of());
+    long terminal = succeeded + failed;
+    double successRate = terminal == 0 ? 0D : Math.round((succeeded * 10000D) / terminal) / 100D;
+    return new PlatformOverview(projects, tasks, executions, failed, environments,
+        secrets, templates, healthy, unhealthy, successRate);
+  }
+
+  private long scalar(String sql, Map<String, ?> params) {
+    Long value = jdbc.queryForObject(sql, params, Long.class);
+    return value == null ? 0L : value;
+  }
+
+  private RowMapper<Environment> environmentMapper() {
+    return (rs, row) -> new Environment(rs.getLong("id"), rs.getString("code"),
+        rs.getString("name"), EnvironmentType.valueOf(rs.getString("environment_type")),
+        rs.getString("description"), rs.getBoolean("enabled"),
+        json.readTree(rs.getString("variables_json")), rs.getInt("lock_version"),
+        rs.getString("created_by"), rs.getString("updated_by"),
+        time(rs, "created_at"), time(rs, "updated_at"));
+  }
+
+  private RowMapper<ParameterTemplate> templateMapper() {
+    return (rs, row) -> new ParameterTemplate(rs.getLong("id"), rs.getString("code"),
+        rs.getString("name"), rs.getString("description"), rs.getBoolean("enabled"),
+        json.readTree(rs.getString("parameters_json")), rs.getInt("lock_version"),
+        rs.getString("created_by"), rs.getString("updated_by"),
+        time(rs, "created_at"), time(rs, "updated_at"));
+  }
+
+  private RowMapper<EngineEndpoint> engineMapper() {
+    return (rs, row) -> new EngineEndpoint(rs.getLong("id"), rs.getString("task_type"),
+        rs.getString("code"), rs.getString("name"),
+        ProbeType.valueOf(rs.getString("probe_type")), rs.getString("endpoint"),
+        rs.getBoolean("enabled"), json.readTree(rs.getString("config_json")),
+        HealthStatus.valueOf(rs.getString("health_status")), rs.getString("health_message"),
+        nullableTime(rs, "last_checked_at"), rs.getInt("lock_version"),
+        rs.getString("created_by"), rs.getString("updated_by"),
+        time(rs, "created_at"), time(rs, "updated_at"));
+  }
+
+  private static LocalDateTime time(ResultSet rs, String column) throws SQLException {
+    return rs.getTimestamp(column).toLocalDateTime();
+  }
+
+  private static LocalDateTime nullableTime(ResultSet rs, String column) throws SQLException {
+    var value = rs.getTimestamp(column);
+    return value == null ? null : value.toLocalDateTime();
+  }
+
+  private static long requiredKey(KeyHolder holder) {
+    Number key = holder.getKey();
+    if (key == null) throw new IllegalStateException("Database did not return generated key");
+    return key.longValue();
+  }
+
+  private static Object nullable(Object value) {
+    return value == null ? "" : value;
+  }
+
+  private static <T> Optional<T> first(List<T> values) {
+    return values.isEmpty() ? Optional.empty() : Optional.of(values.get(0));
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DataDevelopmentEngineHealthService.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DataDevelopmentEngineHealthService.java
@@ -1,0 +1,109 @@
+package io.yak.ops.business.development.service;
+
+import io.yak.ops.business.development.config.ConditionalOnDataDevelopmentEnabled;
+import io.yak.ops.business.development.config.DataDevelopmentProperties;
+import io.yak.ops.business.development.domain.DataDevelopmentPlatformModel.EngineEndpoint;
+import io.yak.ops.business.development.domain.DataDevelopmentPlatformModel.HealthStatus;
+import io.yak.ops.business.development.repository.DataDevelopmentPlatformRepository;
+import io.yak.ops.plugin.task.api.TaskPluginCatalog;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+/** Health probes for local plugins and configured external engine endpoints. */
+@ConditionalOnDataDevelopmentEnabled
+@Service
+public final class DataDevelopmentEngineHealthService {
+
+  private final DataDevelopmentPlatformRepository repository;
+  private final TaskPluginCatalog plugins;
+  private final Duration timeout;
+  private final HttpClient httpClient;
+
+  public DataDevelopmentEngineHealthService(
+      DataDevelopmentPlatformRepository repository,
+      TaskPluginCatalog plugins,
+      DataDevelopmentProperties properties) {
+    this.repository = repository;
+    this.plugins = plugins;
+    this.timeout = Duration.ofSeconds(Math.max(1,
+        properties.getPlatform().getHealthCheckTimeoutSeconds()));
+    this.httpClient = HttpClient.newBuilder().connectTimeout(timeout).build();
+  }
+
+  public EngineEndpoint check(long id) {
+    EngineEndpoint endpoint = repository.findEngineEndpoint(id)
+        .orElseThrow(() -> new IllegalArgumentException("引擎端点不存在：" + id));
+    HealthResult result = probe(endpoint);
+    repository.updateEngineHealth(id, result.status(), result.message(), LocalDateTime.now());
+    return repository.findEngineEndpoint(id).orElseThrow();
+  }
+
+  public List<EngineEndpoint> checkAll() {
+    repository.listEngineEndpoints().stream()
+        .filter(EngineEndpoint::enabled)
+        .forEach(item -> check(item.id()));
+    return repository.listEngineEndpoints();
+  }
+
+  private HealthResult probe(EngineEndpoint endpoint) {
+    if (!endpoint.enabled()) return new HealthResult(HealthStatus.DISABLED, "端点已停用");
+    try {
+      return switch (endpoint.probeType()) {
+        case LOCAL_PLUGIN -> localPlugin(endpoint.taskType());
+        case HTTP -> http(endpoint.endpoint());
+        case TCP -> tcp(endpoint.endpoint());
+      };
+    } catch (Exception error) {
+      return new HealthResult(HealthStatus.UNHEALTHY,
+          error.getMessage() == null ? error.getClass().getSimpleName() : error.getMessage());
+    }
+  }
+
+  private HealthResult localPlugin(String taskType) {
+    try {
+      var descriptor = plugins.descriptor(taskType);
+      return new HealthResult(HealthStatus.HEALTHY,
+          "插件已加载 · " + descriptor.pluginVersion());
+    } catch (Exception error) {
+      return new HealthResult(HealthStatus.UNHEALTHY, "插件未加载：" + taskType);
+    }
+  }
+
+  private HealthResult http(String endpoint) throws Exception {
+    URI uri = URI.create(requireEndpoint(endpoint));
+    HttpRequest request = HttpRequest.newBuilder(uri).timeout(timeout).GET().build();
+    int status = httpClient.send(request, HttpResponse.BodyHandlers.discarding()).statusCode();
+    if (status >= 200 && status < 400) {
+      return new HealthResult(HealthStatus.HEALTHY, "HTTP " + status);
+    }
+    return new HealthResult(HealthStatus.DEGRADED, "HTTP " + status);
+  }
+
+  private HealthResult tcp(String endpoint) throws Exception {
+    String value = requireEndpoint(endpoint);
+    URI uri = value.contains("://") ? URI.create(value) : URI.create("tcp://" + value);
+    int port = uri.getPort();
+    if (port <= 0) throw new IllegalArgumentException("TCP 端点必须包含端口");
+    try (Socket socket = new Socket()) {
+      socket.connect(new InetSocketAddress(uri.getHost(), port), (int) timeout.toMillis());
+    }
+    return new HealthResult(HealthStatus.HEALTHY, "TCP 连接成功");
+  }
+
+  private static String requireEndpoint(String value) {
+    if (!StringUtils.hasText(value)) throw new IllegalArgumentException("引擎端点不能为空");
+    return value.trim();
+  }
+
+  private record HealthResult(HealthStatus status, String message) {
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DataDevelopmentExecutionService.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DataDevelopmentExecutionService.java
@@ -18,6 +18,7 @@ import io.yak.ops.plugin.task.api.TaskPluginFactory.CompiledDefinition;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
@@ -32,55 +33,48 @@ public class DataDevelopmentExecutionService {
   private final TaskPluginCatalog taskPluginCatalog;
   private final DataDevelopmentJsonCodec json;
   private final DataDevelopmentExecutionGateway gateway;
+  private final DataDevelopmentPlatformRuntimeResolver platformRuntimeResolver;
+  private final DataDevelopmentPlatformAuditService audit;
 
   public DataDevelopmentExecutionService(
       DataDevelopmentRepository controlRepository,
       DataDevelopmentExecutionRepository executionRepository,
       TaskPluginCatalog taskPluginCatalog,
       DataDevelopmentJsonCodec json,
-      DataDevelopmentExecutionGateway gateway) {
+      DataDevelopmentExecutionGateway gateway,
+      DataDevelopmentPlatformRuntimeResolver platformRuntimeResolver,
+      DataDevelopmentPlatformAuditService audit) {
     this.controlRepository = controlRepository;
     this.executionRepository = executionRepository;
     this.taskPluginCatalog = taskPluginCatalog;
     this.json = json;
     this.gateway = gateway;
+    this.platformRuntimeResolver = platformRuntimeResolver;
+    this.audit = audit;
   }
 
-  @Transactional(
-      transactionManager = "dataDevelopmentTransactionManager",
-      rollbackFor = Exception.class)
-  public Execution createExecution(
-      long taskId,
-      CreateExecutionRequest request,
-      String operator) {
+  @Transactional(transactionManager = "dataDevelopmentTransactionManager", rollbackFor = Exception.class)
+  public Execution createExecution(long taskId, CreateExecutionRequest request, String operator) {
     Task task = requireTask(taskId);
     ExecutionSourceType sourceType = parseSourceType(request.sourceType());
     PreparedExecution prepared = prepareExecution(task, sourceType, request);
     JsonNode runtime = request.runtime() == null
-        ? runtimeFromDefinition(prepared.definitionSnapshot())
-        : request.runtime();
+        ? runtimeFromDefinition(prepared.definitionSnapshot()) : request.runtime();
+    platformRuntimeResolver.validateReferences(runtime);
     JsonNode input = request.input() == null ? json.objectNode() : request.input();
-    long executionId = controlRepository.insertExecution(
-        taskId,
-        sourceType,
-        prepared.draftRevision(),
-        prepared.taskVersionId(),
-        task.taskType(),
-        prepared.pluginVersion(),
-        json.write(prepared.definitionSnapshot()),
-        json.write(prepared.compiledSpec()),
-        json.write(runtime),
-        json.write(input),
-        trimToNull(request.idempotencyKey()),
-        operator(operator),
-        LocalDateTime.now());
+    long executionId = controlRepository.insertExecution(taskId, sourceType,
+        prepared.draftRevision(), prepared.taskVersionId(), task.taskType(),
+        prepared.pluginVersion(), json.write(prepared.definitionSnapshot()),
+        json.write(prepared.compiledSpec()), json.write(runtime), json.write(input),
+        trimToNull(request.idempotencyKey()), actor(operator), LocalDateTime.now());
+    audit.record("EXECUTION_CREATED", "EXECUTION", executionId,
+        Map.of("taskId", taskId, "taskType", task.taskType(), "sourceType", sourceType.name()),
+        operator);
     gateway.dispatchAfterCommit(executionId);
     return requireExecution(executionId);
   }
 
-  public Execution getExecution(long executionId) {
-    return requireExecution(executionId);
-  }
+  public Execution getExecution(long executionId) { return requireExecution(executionId); }
 
   public List<Execution> listTaskExecutions(long taskId, int limit) {
     requireTask(taskId);
@@ -89,8 +83,7 @@ public class DataDevelopmentExecutionService {
 
   public ExecutionDetailView getExecutionDetail(long executionId, long afterSequence) {
     Execution execution = requireExecution(executionId);
-    return new ExecutionDetailView(
-        execution,
+    return new ExecutionDetailView(execution,
         executionRepository.findTaskName(execution.taskId()).orElse("task-" + execution.taskId()),
         executionRepository.findEngineType(execution.taskId()).orElse(execution.taskType()),
         executionRepository.listAttempts(executionId),
@@ -99,33 +92,33 @@ public class DataDevelopmentExecutionService {
   }
 
   public ExecutionPageView listExecutions(
-      String status,
-      String taskType,
-      String keyword,
-      int offset,
-      int limit) {
-    int normalizedOffset = Math.max(0, offset);
-    int normalizedLimit = Math.min(500, Math.max(1, limit));
+      String status, String taskType, String keyword, int offset, int limit) {
+    int safeOffset = Math.max(0, offset);
+    int safeLimit = Math.min(500, Math.max(1, limit));
     return new ExecutionPageView(
         executionRepository.listExecutionSummaries(
-            status,
-            taskType,
-            keyword,
-            normalizedOffset,
-            normalizedLimit),
+            status, taskType, keyword, safeOffset, safeLimit),
         executionRepository.countExecutionSummaries(status, taskType, keyword),
-        normalizedOffset,
-        normalizedLimit);
+        safeOffset, safeLimit);
   }
 
   public Execution cancelExecution(long executionId) {
-    return gateway.cancel(executionId);
+    return cancelExecution(executionId, "system");
+  }
+
+  public Execution cancelExecution(long executionId, String operator) {
+    Execution result = gateway.cancel(executionId);
+    audit.record(
+        "EXECUTION_CANCELED",
+        "EXECUTION",
+        executionId,
+        Map.of("taskId", result.taskId(), "status", result.status().name()),
+        actor(operator));
+    return result;
   }
 
   private PreparedExecution prepareExecution(
-      Task task,
-      ExecutionSourceType sourceType,
-      CreateExecutionRequest request) {
+      Task task, ExecutionSourceType sourceType, CreateExecutionRequest request) {
     return switch (sourceType) {
       case DRAFT_REVISION -> prepareDraftExecution(task, request);
       case PUBLISHED_VERSION -> prepareVersionExecution(task, request);
@@ -133,55 +126,37 @@ public class DataDevelopmentExecutionService {
     };
   }
 
-  private PreparedExecution prepareDraftExecution(
-      Task task,
-      CreateExecutionRequest request) {
+  private PreparedExecution prepareDraftExecution(Task task, CreateExecutionRequest request) {
     Draft draft = requireDraft(task.id());
     if (request.draftRevision() == null || request.draftRevision() != draft.revision()) {
       throw new IllegalArgumentException(
           "运行草稿时必须提供当前 draftRevision=" + draft.revision());
     }
     CompiledDefinition compiled = taskPluginCatalog.compile(
-        task.taskType(),
-        json.toMap(draft.definition()));
-    return new PreparedExecution(
-        draft.revision(),
-        null,
+        task.taskType(), json.toMap(draft.definition()));
+    return new PreparedExecution(draft.revision(), null,
         taskPluginCatalog.descriptor(task.taskType()).pluginVersion(),
-        json.toTree(compiled.definition()),
-        json.toTree(compiled.compiledSpec()));
+        json.toTree(compiled.definition()), json.toTree(compiled.compiledSpec()));
   }
 
-  private PreparedExecution prepareVersionExecution(
-      Task task,
-      CreateExecutionRequest request) {
+  private PreparedExecution prepareVersionExecution(Task task, CreateExecutionRequest request) {
     if (request.taskVersionId() == null) {
       throw new IllegalArgumentException("运行发布版本时必须提供 taskVersionId");
     }
     Version version = requireVersion(task.id(), request.taskVersionId());
-    return new PreparedExecution(
-        null,
-        version.id(),
-        version.pluginVersion(),
-        version.definitionSnapshot(),
-        version.compiledSpec());
+    return new PreparedExecution(null, version.id(), version.pluginVersion(),
+        version.definitionSnapshot(), version.compiledSpec());
   }
 
-  private PreparedExecution prepareEphemeralExecution(
-      Task task,
-      CreateExecutionRequest request) {
+  private PreparedExecution prepareEphemeralExecution(Task task, CreateExecutionRequest request) {
     if (request.definitionSnapshot() == null) {
       throw new IllegalArgumentException("临时运行必须提供 definitionSnapshot");
     }
     CompiledDefinition compiled = taskPluginCatalog.compile(
-        task.taskType(),
-        json.toMap(request.definitionSnapshot()));
-    return new PreparedExecution(
-        null,
-        null,
+        task.taskType(), json.toMap(request.definitionSnapshot()));
+    return new PreparedExecution(null, null,
         taskPluginCatalog.descriptor(task.taskType()).pluginVersion(),
-        json.toTree(compiled.definition()),
-        json.toTree(compiled.compiledSpec()));
+        json.toTree(compiled.definition()), json.toTree(compiled.compiledSpec()));
   }
 
   private JsonNode runtimeFromDefinition(JsonNode definition) {
@@ -212,13 +187,13 @@ public class DataDevelopmentExecutionService {
   private static ExecutionSourceType parseSourceType(String value) {
     try {
       return ExecutionSourceType.valueOf(
-          requireText(value, "执行来源").toUpperCase(Locale.ROOT));
-    } catch (IllegalArgumentException exception) {
-      throw new IllegalArgumentException("不支持的执行来源：" + value, exception);
+          require(value, "执行来源").toUpperCase(Locale.ROOT));
+    } catch (IllegalArgumentException error) {
+      throw new IllegalArgumentException("不支持的执行来源：" + value, error);
     }
   }
 
-  private static String operator(String value) {
+  private static String actor(String value) {
     return StringUtils.hasText(value) ? value.trim() : "system";
   }
 
@@ -226,10 +201,8 @@ public class DataDevelopmentExecutionService {
     return StringUtils.hasText(value) ? value.trim() : null;
   }
 
-  private static String requireText(String value, String label) {
-    if (!StringUtils.hasText(value)) {
-      throw new IllegalArgumentException(label + "不能为空");
-    }
+  private static String require(String value, String label) {
+    if (!StringUtils.hasText(value)) throw new IllegalArgumentException(label + "不能为空");
     return value.trim();
   }
 

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DataDevelopmentPlatformAuditService.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DataDevelopmentPlatformAuditService.java
@@ -1,0 +1,42 @@
+package io.yak.ops.business.development.service;
+
+import io.yak.ops.business.development.config.ConditionalOnDataDevelopmentEnabled;
+import io.yak.ops.business.development.repository.DataDevelopmentPlatformRepository;
+import java.time.LocalDateTime;
+import java.util.Map;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+/** Central write-only audit boundary for platform and execution mutations. */
+@ConditionalOnDataDevelopmentEnabled
+@Service
+public final class DataDevelopmentPlatformAuditService {
+
+  private final DataDevelopmentPlatformRepository repository;
+  private final DataDevelopmentJsonCodec json;
+
+  public DataDevelopmentPlatformAuditService(
+      DataDevelopmentPlatformRepository repository,
+      DataDevelopmentJsonCodec json) {
+    this.repository = repository;
+    this.json = json;
+  }
+
+  public void record(
+      String action,
+      String resourceType,
+      Object resourceId,
+      Map<String, ?> summary,
+      String operator) {
+    repository.insertAudit(
+        require(action), require(resourceType), resourceId == null ? null : String.valueOf(resourceId),
+        json.write(json.toTree(summary == null ? Map.of() : summary)),
+        StringUtils.hasText(operator) ? operator.trim() : "system",
+        LocalDateTime.now());
+  }
+
+  private static String require(String value) {
+    if (!StringUtils.hasText(value)) throw new IllegalArgumentException("审计字段不能为空");
+    return value.trim();
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DataDevelopmentPlatformRuntimeResolver.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DataDevelopmentPlatformRuntimeResolver.java
@@ -1,0 +1,102 @@
+package io.yak.ops.business.development.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.yak.ops.business.development.config.ConditionalOnDataDevelopmentEnabled;
+import io.yak.ops.business.development.domain.DataDevelopmentPlatformModel.Environment;
+import io.yak.ops.business.development.domain.DataDevelopmentPlatformModel.ParameterTemplate;
+import io.yak.ops.business.development.repository.DataDevelopmentPlatformRepository;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.springframework.stereotype.Service;
+
+/** Resolves non-persisted platform parameters and secrets immediately before execution. */
+@ConditionalOnDataDevelopmentEnabled
+@Service
+public final class DataDevelopmentPlatformRuntimeResolver {
+
+  private final DataDevelopmentPlatformRepository repository;
+  private final DataDevelopmentSecretCipher cipher;
+  private final DataDevelopmentJsonCodec json;
+
+  public DataDevelopmentPlatformRuntimeResolver(
+      DataDevelopmentPlatformRepository repository,
+      DataDevelopmentSecretCipher cipher,
+      DataDevelopmentJsonCodec json) {
+    this.repository = repository;
+    this.cipher = cipher;
+    this.json = json;
+  }
+
+  public void validateReferences(JsonNode runtime) {
+    JsonNode common = common(runtime);
+    long environmentId = positiveLong(common.path("environmentId"));
+    long templateId = positiveLong(common.path("parameterTemplateId"));
+    if (environmentId > 0) requireEnabledEnvironment(environmentId);
+    if (templateId > 0) requireEnabledTemplate(templateId);
+    JsonNode secretKeys = common.path("secretKeys");
+    if (secretKeys.isArray() && !secretKeys.isEmpty() && environmentId <= 0) {
+      throw new IllegalArgumentException("使用平台密钥时必须选择运行环境");
+    }
+  }
+
+  public Map<String, Object> resolve(JsonNode runtime) {
+    JsonNode common = common(runtime);
+    Map<String, Object> values = new LinkedHashMap<>();
+    long templateId = positiveLong(common.path("parameterTemplateId"));
+    if (templateId > 0) {
+      ParameterTemplate template = requireEnabledTemplate(templateId);
+      values.putAll(json.toMap(template.parameters()));
+      values.put("template", json.toMap(template.parameters()));
+    }
+    long environmentId = positiveLong(common.path("environmentId"));
+    if (environmentId > 0) {
+      Environment environment = requireEnabledEnvironment(environmentId);
+      Map<String, Object> environmentValues = json.toMap(environment.variables());
+      values.putAll(environmentValues);
+      values.put("env", environmentValues);
+      Map<String, Object> secrets = new LinkedHashMap<>();
+      JsonNode secretKeys = common.path("secretKeys");
+      if (secretKeys.isArray()) {
+        for (JsonNode item : secretKeys) {
+          String key = item.asText("").trim();
+          if (key.isEmpty()) continue;
+          String encrypted = repository.findEncryptedSecret(environmentId, key)
+              .or(() -> repository.findEncryptedSecret(0L, key))
+              .orElseThrow(() -> new IllegalArgumentException("运行环境缺少密钥：" + key));
+          secrets.put(key, cipher.decrypt(encrypted));
+        }
+      }
+      values.put("secret", secrets);
+    }
+    return values;
+  }
+
+  private Environment requireEnabledEnvironment(long id) {
+    Environment value = repository.findEnvironment(id)
+        .orElseThrow(() -> new IllegalArgumentException("运行环境不存在：" + id));
+    if (!value.enabled()) throw new IllegalStateException("运行环境已停用：" + value.name());
+    return value;
+  }
+
+  private ParameterTemplate requireEnabledTemplate(long id) {
+    ParameterTemplate value = repository.findParameterTemplate(id)
+        .orElseThrow(() -> new IllegalArgumentException("参数模板不存在：" + id));
+    if (!value.enabled()) throw new IllegalStateException("参数模板已停用：" + value.name());
+    return value;
+  }
+
+  private static JsonNode common(JsonNode runtime) {
+    return runtime == null || runtime.isNull() ? nullNode() : runtime.path("common");
+  }
+
+  private static JsonNode nullNode() {
+    return com.fasterxml.jackson.databind.node.MissingNode.getInstance();
+  }
+
+  private static long positiveLong(JsonNode value) {
+    if (value == null || value.isMissingNode() || value.isNull()) return 0L;
+    if (value.isNumber()) return Math.max(0L, value.asLong());
+    try { return Math.max(0L, Long.parseLong(value.asText("0"))); }
+    catch (NumberFormatException ignored) { return 0L; }
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DataDevelopmentPlatformService.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DataDevelopmentPlatformService.java
@@ -1,0 +1,211 @@
+package io.yak.ops.business.development.service;
+
+import io.yak.ops.business.development.api.DataDevelopmentPlatformApi.PlatformSnapshotView;
+import io.yak.ops.business.development.api.DataDevelopmentPlatformApi.SaveEngineEndpointRequest;
+import io.yak.ops.business.development.api.DataDevelopmentPlatformApi.SaveEnvironmentRequest;
+import io.yak.ops.business.development.api.DataDevelopmentPlatformApi.SaveParameterTemplateRequest;
+import io.yak.ops.business.development.api.DataDevelopmentPlatformApi.SaveSecretRequest;
+import io.yak.ops.business.development.config.ConditionalOnDataDevelopmentEnabled;
+import io.yak.ops.business.development.domain.DataDevelopmentPlatformModel.AuditEntry;
+import io.yak.ops.business.development.domain.DataDevelopmentPlatformModel.EngineEndpoint;
+import io.yak.ops.business.development.domain.DataDevelopmentPlatformModel.Environment;
+import io.yak.ops.business.development.domain.DataDevelopmentPlatformModel.EnvironmentType;
+import io.yak.ops.business.development.domain.DataDevelopmentPlatformModel.ParameterTemplate;
+import io.yak.ops.business.development.domain.DataDevelopmentPlatformModel.PlatformOverview;
+import io.yak.ops.business.development.domain.DataDevelopmentPlatformModel.ProbeType;
+import io.yak.ops.business.development.domain.DataDevelopmentPlatformModel.SecretMetadata;
+import io.yak.ops.business.development.repository.DataDevelopmentPlatformRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+/** Application service for platform configuration, governance and observability. */
+@ConditionalOnDataDevelopmentEnabled
+@Service
+public final class DataDevelopmentPlatformService {
+
+  private final DataDevelopmentPlatformRepository repository;
+  private final DataDevelopmentJsonCodec json;
+  private final DataDevelopmentSecretCipher cipher;
+  private final DataDevelopmentPlatformAuditService audit;
+  private final DataDevelopmentEngineHealthService health;
+
+  public DataDevelopmentPlatformService(
+      DataDevelopmentPlatformRepository repository,
+      DataDevelopmentJsonCodec json,
+      DataDevelopmentSecretCipher cipher,
+      DataDevelopmentPlatformAuditService audit,
+      DataDevelopmentEngineHealthService health) {
+    this.repository = repository;
+    this.json = json;
+    this.cipher = cipher;
+    this.audit = audit;
+    this.health = health;
+  }
+
+  public PlatformSnapshotView snapshot() {
+    return new PlatformSnapshotView(overview(), listEnvironments(), listSecrets(),
+        listParameterTemplates(), listEngines(), listAudit(100), cipher.configured());
+  }
+
+  public PlatformOverview overview() {
+    return repository.overview(LocalDateTime.now().minusHours(24));
+  }
+
+  public List<Environment> listEnvironments() { return repository.listEnvironments(); }
+  public List<SecretMetadata> listSecrets() { return repository.listSecrets(); }
+  public List<ParameterTemplate> listParameterTemplates() {
+    return repository.listParameterTemplates();
+  }
+  public List<EngineEndpoint> listEngines() { return repository.listEngineEndpoints(); }
+  public List<AuditEntry> listAudit(int limit) { return repository.listAudit(limit); }
+
+  @Transactional(transactionManager = "dataDevelopmentTransactionManager", rollbackFor = Exception.class)
+  public Environment saveEnvironment(SaveEnvironmentRequest request, String operator) {
+    String type = enumName(EnvironmentType.class, request.environmentType(), "环境类型");
+    LocalDateTime now = LocalDateTime.now();
+    long id;
+    if (request.id() == null) {
+      id = repository.insertEnvironment(require(request.code(), "环境编码"),
+          require(request.name(), "环境名称"), type, trim(request.description()), request.enabled(),
+          json.write(requireObject(request.variables(), "环境变量")), actor(operator), now);
+    } else {
+      id = request.id();
+      int changed = repository.updateEnvironment(id, require(request.code(), "环境编码"),
+          require(request.name(), "环境名称"), type, trim(request.description()), request.enabled(),
+          json.write(requireObject(request.variables(), "环境变量")),
+          request.lockVersion() == null ? 0 : request.lockVersion(), actor(operator), now);
+      if (changed != 1) throw new IllegalStateException("运行环境已被其他用户更新，请刷新后重试");
+    }
+    audit.record("ENVIRONMENT_SAVED", "ENVIRONMENT", id,
+        Map.of("code", request.code(), "enabled", request.enabled()), operator);
+    return repository.findEnvironment(id).orElseThrow();
+  }
+
+  @Transactional(transactionManager = "dataDevelopmentTransactionManager", rollbackFor = Exception.class)
+  public void deleteEnvironment(long id, String operator) {
+    Environment value = repository.findEnvironment(id)
+        .orElseThrow(() -> new IllegalArgumentException("运行环境不存在：" + id));
+    repository.deleteSecretsByEnvironment(id);
+    repository.deleteEnvironment(id);
+    audit.record("ENVIRONMENT_DELETED", "ENVIRONMENT", id,
+        Map.of("code", value.code()), operator);
+  }
+
+  @Transactional(transactionManager = "dataDevelopmentTransactionManager", rollbackFor = Exception.class)
+  public SecretMetadata saveSecret(SaveSecretRequest request, String operator) {
+    long environmentId = request.environmentId() == null ? 0L : request.environmentId();
+    if (environmentId > 0 && repository.findEnvironment(environmentId).isEmpty()) {
+      throw new IllegalArgumentException("运行环境不存在：" + environmentId);
+    }
+    String value = require(request.secretValue(), "密钥值");
+    long id = repository.upsertSecret(request.id(), environmentId,
+        require(request.secretKey(), "密钥名称"), trim(request.description()),
+        cipher.encrypt(value), cipher.digest(value), actor(operator), LocalDateTime.now());
+    audit.record("SECRET_SAVED", "SECRET", id,
+        Map.of("environmentId", environmentId, "secretKey", request.secretKey()), operator);
+    return repository.listSecrets().stream().filter(item -> item.id() == id).findFirst().orElseThrow();
+  }
+
+  @Transactional(transactionManager = "dataDevelopmentTransactionManager", rollbackFor = Exception.class)
+  public void deleteSecret(long id, String operator) {
+    repository.deleteSecret(id);
+    audit.record("SECRET_DELETED", "SECRET", id, Map.of(), operator);
+  }
+
+  @Transactional(transactionManager = "dataDevelopmentTransactionManager", rollbackFor = Exception.class)
+  public ParameterTemplate saveParameterTemplate(
+      SaveParameterTemplateRequest request, String operator) {
+    LocalDateTime now = LocalDateTime.now();
+    long id;
+    if (request.id() == null) {
+      id = repository.insertParameterTemplate(require(request.code(), "模板编码"),
+          require(request.name(), "模板名称"), trim(request.description()), request.enabled(),
+          json.write(requireObject(request.parameters(), "模板参数")), actor(operator), now);
+    } else {
+      id = request.id();
+      int changed = repository.updateParameterTemplate(id, require(request.code(), "模板编码"),
+          require(request.name(), "模板名称"), trim(request.description()), request.enabled(),
+          json.write(requireObject(request.parameters(), "模板参数")),
+          request.lockVersion() == null ? 0 : request.lockVersion(), actor(operator), now);
+      if (changed != 1) throw new IllegalStateException("参数模板已被其他用户更新，请刷新后重试");
+    }
+    audit.record("PARAMETER_TEMPLATE_SAVED", "PARAMETER_TEMPLATE", id,
+        Map.of("code", request.code(), "enabled", request.enabled()), operator);
+    return repository.findParameterTemplate(id).orElseThrow();
+  }
+
+  @Transactional(transactionManager = "dataDevelopmentTransactionManager", rollbackFor = Exception.class)
+  public void deleteParameterTemplate(long id, String operator) {
+    repository.deleteParameterTemplate(id);
+    audit.record("PARAMETER_TEMPLATE_DELETED", "PARAMETER_TEMPLATE", id, Map.of(), operator);
+  }
+
+  @Transactional(transactionManager = "dataDevelopmentTransactionManager", rollbackFor = Exception.class)
+  public EngineEndpoint saveEngine(SaveEngineEndpointRequest request, String operator) {
+    String probeType = enumName(ProbeType.class, request.probeType(), "探测类型");
+    LocalDateTime now = LocalDateTime.now();
+    long id;
+    if (request.id() == null) {
+      id = repository.insertEngineEndpoint(require(request.taskType(), "任务类型").toUpperCase(Locale.ROOT),
+          require(request.code(), "端点编码"), require(request.name(), "端点名称"), probeType,
+          trim(request.endpoint()), request.enabled(),
+          json.write(requireObject(request.config(), "端点配置")), actor(operator), now);
+    } else {
+      id = request.id();
+      int changed = repository.updateEngineEndpoint(id,
+          require(request.taskType(), "任务类型").toUpperCase(Locale.ROOT),
+          require(request.code(), "端点编码"), require(request.name(), "端点名称"), probeType,
+          trim(request.endpoint()), request.enabled(),
+          json.write(requireObject(request.config(), "端点配置")),
+          request.lockVersion() == null ? 0 : request.lockVersion(), actor(operator), now);
+      if (changed != 1) throw new IllegalStateException("引擎端点已被其他用户更新，请刷新后重试");
+    }
+    audit.record("ENGINE_ENDPOINT_SAVED", "ENGINE_ENDPOINT", id,
+        Map.of("code", request.code(), "taskType", request.taskType()), operator);
+    return repository.findEngineEndpoint(id).orElseThrow();
+  }
+
+  @Transactional(transactionManager = "dataDevelopmentTransactionManager", rollbackFor = Exception.class)
+  public void deleteEngine(long id, String operator) {
+    repository.deleteEngineEndpoint(id);
+    audit.record("ENGINE_ENDPOINT_DELETED", "ENGINE_ENDPOINT", id, Map.of(), operator);
+  }
+
+  public EngineEndpoint checkEngine(long id, String operator) {
+    EngineEndpoint result = health.check(id);
+    audit.record("ENGINE_HEALTH_CHECKED", "ENGINE_ENDPOINT", id,
+        Map.of("status", result.healthStatus().name()), operator);
+    return result;
+  }
+
+  public List<EngineEndpoint> checkAllEngines(String operator) {
+    List<EngineEndpoint> result = health.checkAll();
+    audit.record("ENGINE_HEALTH_CHECKED_ALL", "ENGINE_ENDPOINT", null,
+        Map.of("count", result.size()), operator);
+    return result;
+  }
+
+  private com.fasterxml.jackson.databind.JsonNode requireObject(
+      com.fasterxml.jackson.databind.JsonNode value, String label) {
+    if (value == null || !value.isObject()) throw new IllegalArgumentException(label + "必须是 JSON 对象");
+    return value;
+  }
+
+  private static <E extends Enum<E>> String enumName(Class<E> type, String value, String label) {
+    try { return Enum.valueOf(type, require(value, label).toUpperCase(Locale.ROOT)).name(); }
+    catch (IllegalArgumentException error) { throw new IllegalArgumentException("不支持的" + label + "：" + value); }
+  }
+
+  private static String require(String value, String label) {
+    if (!StringUtils.hasText(value)) throw new IllegalArgumentException(label + "不能为空");
+    return value.trim();
+  }
+
+  private static String trim(String value) { return StringUtils.hasText(value) ? value.trim() : null; }
+  private static String actor(String value) { return StringUtils.hasText(value) ? value.trim() : "system"; }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DataDevelopmentSecretCipher.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DataDevelopmentSecretCipher.java
@@ -1,0 +1,104 @@
+package io.yak.ops.business.development.service;
+
+import io.yak.ops.business.development.config.ConditionalOnDataDevelopmentEnabled;
+import io.yak.ops.business.development.config.DataDevelopmentProperties;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.SecureRandom;
+import java.util.Base64;
+import javax.crypto.Cipher;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+/** AES-GCM encryption boundary for platform secrets. */
+@ConditionalOnDataDevelopmentEnabled
+@Component
+public final class DataDevelopmentSecretCipher {
+
+  private static final String PREFIX = "v1:";
+  private static final int IV_BYTES = 12;
+  private static final int TAG_BITS = 128;
+
+  private final SecureRandom random = new SecureRandom();
+  private final SecretKeySpec key;
+
+  public DataDevelopmentSecretCipher(DataDevelopmentProperties properties) {
+    String masterKey = properties.getPlatform().getMasterKey();
+    this.key = StringUtils.hasText(masterKey)
+        ? new SecretKeySpec(sha256(masterKey.getBytes(StandardCharsets.UTF_8)), "AES")
+        : null;
+  }
+
+  public boolean configured() {
+    return key != null;
+  }
+
+  public String encrypt(String plaintext) {
+    requireConfigured();
+    if (!StringUtils.hasText(plaintext)) {
+      throw new IllegalArgumentException("密钥值不能为空");
+    }
+    try {
+      byte[] iv = new byte[IV_BYTES];
+      random.nextBytes(iv);
+      Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+      cipher.init(Cipher.ENCRYPT_MODE, key, new GCMParameterSpec(TAG_BITS, iv));
+      byte[] encrypted = cipher.doFinal(plaintext.getBytes(StandardCharsets.UTF_8));
+      byte[] payload = new byte[iv.length + encrypted.length];
+      System.arraycopy(iv, 0, payload, 0, iv.length);
+      System.arraycopy(encrypted, 0, payload, iv.length, encrypted.length);
+      return PREFIX + Base64.getEncoder().encodeToString(payload);
+    } catch (Exception error) {
+      throw new IllegalStateException("平台密钥加密失败", error);
+    }
+  }
+
+  public String decrypt(String encryptedValue) {
+    requireConfigured();
+    if (encryptedValue == null || !encryptedValue.startsWith(PREFIX)) {
+      throw new IllegalStateException("平台密钥格式不受支持");
+    }
+    try {
+      byte[] payload = Base64.getDecoder().decode(encryptedValue.substring(PREFIX.length()));
+      if (payload.length <= IV_BYTES) throw new IllegalStateException("平台密钥内容损坏");
+      byte[] iv = new byte[IV_BYTES];
+      byte[] encrypted = new byte[payload.length - IV_BYTES];
+      System.arraycopy(payload, 0, iv, 0, IV_BYTES);
+      System.arraycopy(payload, IV_BYTES, encrypted, 0, encrypted.length);
+      Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+      cipher.init(Cipher.DECRYPT_MODE, key, new GCMParameterSpec(TAG_BITS, iv));
+      return new String(cipher.doFinal(encrypted), StandardCharsets.UTF_8);
+    } catch (IllegalStateException error) {
+      throw error;
+    } catch (Exception error) {
+      throw new IllegalStateException("平台密钥解密失败，请检查主密钥配置", error);
+    }
+  }
+
+  public String digest(String plaintext) {
+    return hex(sha256(plaintext.getBytes(StandardCharsets.UTF_8)));
+  }
+
+  private void requireConfigured() {
+    if (key == null) {
+      throw new IllegalStateException(
+          "未配置 YAK_DATA_DEVELOPMENT_PLATFORM_MASTER_KEY，无法读写平台密钥");
+    }
+  }
+
+  private static byte[] sha256(byte[] value) {
+    try {
+      return MessageDigest.getInstance("SHA-256").digest(value);
+    } catch (Exception error) {
+      throw new IllegalStateException("SHA-256 不可用", error);
+    }
+  }
+
+  private static String hex(byte[] value) {
+    StringBuilder result = new StringBuilder(value.length * 2);
+    for (byte item : value) result.append(String.format("%02x", item));
+    return result.toString();
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/resources/db/migration/yak-data-development/V2__create_data_development_platform.sql
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/resources/db/migration/yak-data-development/V2__create_data_development_platform.sql
@@ -1,0 +1,99 @@
+CREATE TABLE IF NOT EXISTS yak_dev_environment (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  code VARCHAR(128) NOT NULL,
+  name VARCHAR(255) NOT NULL,
+  environment_type VARCHAR(32) NOT NULL,
+  description VARCHAR(1000) NULL,
+  enabled TINYINT(1) NOT NULL DEFAULT 1,
+  variables_json LONGTEXT NOT NULL,
+  lock_version INT NOT NULL DEFAULT 0,
+  created_by VARCHAR(128) NULL,
+  updated_by VARCHAR(128) NULL,
+  created_at DATETIME(6) NOT NULL,
+  updated_at DATETIME(6) NOT NULL,
+  PRIMARY KEY (id),
+  UNIQUE KEY uk_yak_dev_environment_code (code),
+  KEY idx_yak_dev_environment_enabled (enabled, environment_type)
+);
+
+CREATE TABLE IF NOT EXISTS yak_dev_secret (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  environment_id BIGINT NOT NULL DEFAULT 0,
+  secret_key VARCHAR(255) NOT NULL,
+  description VARCHAR(1000) NULL,
+  encrypted_value LONGTEXT NOT NULL,
+  value_digest VARCHAR(64) NOT NULL,
+  created_by VARCHAR(128) NULL,
+  updated_by VARCHAR(128) NULL,
+  created_at DATETIME(6) NOT NULL,
+  updated_at DATETIME(6) NOT NULL,
+  PRIMARY KEY (id),
+  UNIQUE KEY uk_yak_dev_secret_scope (environment_id, secret_key),
+  KEY idx_yak_dev_secret_environment (environment_id, updated_at)
+);
+
+CREATE TABLE IF NOT EXISTS yak_dev_parameter_template (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  code VARCHAR(128) NOT NULL,
+  name VARCHAR(255) NOT NULL,
+  description VARCHAR(1000) NULL,
+  enabled TINYINT(1) NOT NULL DEFAULT 1,
+  parameters_json LONGTEXT NOT NULL,
+  lock_version INT NOT NULL DEFAULT 0,
+  created_by VARCHAR(128) NULL,
+  updated_by VARCHAR(128) NULL,
+  created_at DATETIME(6) NOT NULL,
+  updated_at DATETIME(6) NOT NULL,
+  PRIMARY KEY (id),
+  UNIQUE KEY uk_yak_dev_parameter_template_code (code),
+  KEY idx_yak_dev_parameter_template_enabled (enabled, updated_at)
+);
+
+CREATE TABLE IF NOT EXISTS yak_dev_engine_endpoint (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  task_type VARCHAR(64) NOT NULL,
+  code VARCHAR(128) NOT NULL,
+  name VARCHAR(255) NOT NULL,
+  probe_type VARCHAR(32) NOT NULL,
+  endpoint VARCHAR(1000) NULL,
+  enabled TINYINT(1) NOT NULL DEFAULT 1,
+  config_json LONGTEXT NOT NULL,
+  health_status VARCHAR(32) NOT NULL DEFAULT 'UNKNOWN',
+  health_message VARCHAR(1000) NULL,
+  last_checked_at DATETIME(6) NULL,
+  lock_version INT NOT NULL DEFAULT 0,
+  created_by VARCHAR(128) NULL,
+  updated_by VARCHAR(128) NULL,
+  created_at DATETIME(6) NOT NULL,
+  updated_at DATETIME(6) NOT NULL,
+  PRIMARY KEY (id),
+  UNIQUE KEY uk_yak_dev_engine_endpoint_code (code),
+  KEY idx_yak_dev_engine_endpoint_type (task_type, enabled),
+  KEY idx_yak_dev_engine_endpoint_health (health_status, last_checked_at)
+);
+
+CREATE TABLE IF NOT EXISTS yak_dev_audit_log (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  action VARCHAR(128) NOT NULL,
+  resource_type VARCHAR(64) NOT NULL,
+  resource_id VARCHAR(128) NULL,
+  summary_json LONGTEXT NOT NULL,
+  operator VARCHAR(128) NOT NULL,
+  occurred_at DATETIME(6) NOT NULL,
+  PRIMARY KEY (id),
+  KEY idx_yak_dev_audit_time (occurred_at, id),
+  KEY idx_yak_dev_audit_resource (resource_type, resource_id, occurred_at),
+  KEY idx_yak_dev_audit_operator (operator, occurred_at)
+);
+
+
+INSERT IGNORE INTO yak_dev_engine_endpoint
+  (task_type,code,name,probe_type,endpoint,enabled,config_json,health_status,
+   lock_version,created_by,updated_by,created_at,updated_at)
+VALUES
+  ('HTTP','builtin-http','HTTP 请求','LOCAL_PLUGIN',NULL,1,'{}','UNKNOWN',0,'system','system',NOW(6),NOW(6)),
+  ('SHELL','builtin-shell','Shell 任务','LOCAL_PLUGIN',NULL,1,'{}','UNKNOWN',0,'system','system',NOW(6),NOW(6)),
+  ('SQL','builtin-jdbc-sql','JDBC SQL','LOCAL_PLUGIN',NULL,1,'{}','UNKNOWN',0,'system','system',NOW(6),NOW(6)),
+  ('FLINK_SQL','builtin-flink-sql','Flink SQL Gateway','LOCAL_PLUGIN',NULL,1,'{}','UNKNOWN',0,'system','system',NOW(6),NOW(6)),
+  ('PYTHON','builtin-python','Python','LOCAL_PLUGIN',NULL,1,'{}','UNKNOWN',0,'system','system',NOW(6),NOW(6)),
+  ('NOTEBOOK','builtin-notebook','Notebook','LOCAL_PLUGIN',NULL,1,'{}','UNKNOWN',0,'system','system',NOW(6),NOW(6));

--- a/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/DataDevelopmentSecretCipherTest.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/DataDevelopmentSecretCipherTest.java
@@ -1,0 +1,37 @@
+package io.yak.ops.business.development.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.yak.ops.business.development.config.DataDevelopmentProperties;
+import org.junit.jupiter.api.Test;
+
+class DataDevelopmentSecretCipherTest {
+
+  @Test
+  void encryptsWithRandomIvAndDecrypts() {
+    DataDevelopmentProperties properties = new DataDevelopmentProperties();
+    properties.getPlatform().setMasterKey("unit-test-master-key");
+    DataDevelopmentSecretCipher cipher = new DataDevelopmentSecretCipher(properties);
+
+    String first = cipher.encrypt("secret-value");
+    String second = cipher.encrypt("secret-value");
+
+    assertThat(first).startsWith("v1:");
+    assertThat(second).isNotEqualTo(first);
+    assertThat(cipher.decrypt(first)).isEqualTo("secret-value");
+    assertThat(cipher.decrypt(second)).isEqualTo("secret-value");
+    assertThat(cipher.digest("secret-value")).hasSize(64);
+  }
+
+  @Test
+  void refusesSecretOperationsWithoutMasterKey() {
+    DataDevelopmentSecretCipher cipher =
+        new DataDevelopmentSecretCipher(new DataDevelopmentProperties());
+
+    assertThat(cipher.configured()).isFalse();
+    assertThatThrownBy(() -> cipher.encrypt("value"))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("YAK_DATA_DEVELOPMENT_PLATFORM_MASTER_KEY");
+  }
+}

--- a/yak-ops-ui/config/routes.ts
+++ b/yak-ops-ui/config/routes.ts
@@ -21,6 +21,14 @@ export default [
         path: '/',
         redirect: '/home',
       },
+      {
+        path: '/data-development/platform',
+        component: './data-development/platform',
+        access: 'isAuthenticated',
+        wrappers: ['@/components/security/RouteAccessBoundary'],
+        hideInMenu: true,
+        hideInBreadcrumb: true,
+      },
       ...appRoutes.map(({ path, component, hidden }) => ({
         path,
         component,

--- a/yak-ops-ui/src/pages/data-development/platform/index.tsx
+++ b/yak-ops-ui/src/pages/data-development/platform/index.tsx
@@ -1,0 +1,566 @@
+import RouteAccessBoundary from '@/components/security/RouteAccessBoundary';
+import type { NavigationRoute } from '@/config/navigation';
+import { BRAND_THEME } from '@/styles/brand';
+import { history } from '@umijs/max';
+import {
+  Alert,
+  Button,
+  ConfigProvider,
+  Drawer,
+  Form,
+  Input,
+  Popconfirm,
+  Select,
+  Space,
+  Spin,
+  Switch,
+  Table,
+  Tabs,
+  Tag,
+  Typography,
+  message,
+  type TableColumnsType,
+} from 'antd';
+import {
+  Activity,
+  ArrowLeft,
+  Boxes,
+  CheckCircle2,
+  Database,
+  FileJson2,
+  KeyRound,
+  Plus,
+  RefreshCw,
+  ServerCog,
+  ShieldCheck,
+  Trash2,
+} from 'lucide-react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  platformRepository,
+  type AuditEntry,
+  type EngineEndpoint,
+  type EnvironmentType,
+  type ParameterTemplate,
+  type PlatformSnapshot,
+  type ProbeType,
+  type RuntimeEnvironment,
+  type SecretMetadata,
+} from './platform.repository';
+
+const { Text } = Typography;
+
+const PLATFORM_ROUTE = {
+  id: 'data-development-platform',
+  mode: 'any',
+  permissions: ['task:batch:read', 'task:realtime:read'],
+  path: '/data-development/platform',
+  title: '平台能力',
+  component: './data-development/platform',
+  hidden: true,
+} satisfies NavigationRoute;
+
+type EditorKind = 'environment' | 'secret' | 'template' | 'engine';
+
+const parseJsonObject = (value: unknown, label: string) => {
+  if (value && typeof value === 'object' && !Array.isArray(value)) return value;
+  try {
+    const parsed = JSON.parse(String(value || '{}'));
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      throw new Error(`${label}必须是 JSON 对象`);
+    }
+    return parsed as Record<string, unknown>;
+  } catch (error) {
+    throw new Error(error instanceof Error ? error.message : `${label}格式错误`);
+  }
+};
+
+const formatDate = (value?: string) =>
+  value
+    ? new Intl.DateTimeFormat('zh-CN', {
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
+        hour12: false,
+      }).format(new Date(value))
+    : '-';
+
+const environmentLabel: Record<EnvironmentType, string> = {
+  DEVELOPMENT: '开发',
+  TESTING: '测试',
+  STAGING: '预发布',
+  PRODUCTION: '生产',
+};
+
+const healthMeta: Record<EngineEndpoint['healthStatus'], { label: string; className: string }> = {
+  UNKNOWN: { label: '未检查', className: '!bg-[#f2f3f5] !text-[#667085]' },
+  HEALTHY: { label: '健康', className: '!bg-[#f2f3f5] !text-[#344054]' },
+  DEGRADED: { label: '降级', className: '!bg-[#fff7e6] !text-[#d46b08]' },
+  UNHEALTHY: { label: '异常', className: '!bg-[#fff1f0] !text-[#ff4d4f]' },
+  DISABLED: { label: '已停用', className: '!bg-[#f2f3f5] !text-[#98a2b3]' },
+};
+
+const PlatformPage = () => {
+  const [snapshot, setSnapshot] = useState<PlatformSnapshot>();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string>();
+  const [editor, setEditor] = useState<{ kind: EditorKind; value?: any }>();
+  const [saving, setSaving] = useState(false);
+  const [checking, setChecking] = useState(false);
+  const [form] = Form.useForm();
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(undefined);
+    try {
+      setSnapshot(await platformRepository.snapshot());
+    } catch (loadError) {
+      const text = loadError instanceof Error ? loadError.message : '平台能力加载失败';
+      setError(text);
+      message.error(text);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const openEditor = (kind: EditorKind, value?: any) => {
+    setEditor({ kind, value });
+    const common = value ?? {};
+    form.setFieldsValue({
+      ...common,
+      variables: JSON.stringify(common.variables ?? {}, null, 2),
+      parameters: JSON.stringify(common.parameters ?? {}, null, 2),
+      config: JSON.stringify(common.config ?? {}, null, 2),
+      secretValue: '',
+      enabled: common.enabled ?? true,
+      environmentId: common.environmentId || 0,
+      lockVersion: common.lockVersion ?? 0,
+    });
+  };
+
+  const closeEditor = () => {
+    setEditor(undefined);
+    form.resetFields();
+  };
+
+  const save = async () => {
+    if (!editor) return;
+    const values = await form.validateFields();
+    setSaving(true);
+    try {
+      if (editor.kind === 'environment') {
+        await platformRepository.saveEnvironment({
+          ...values,
+          id: editor.value?.id,
+          variables: parseJsonObject(values.variables, '环境变量'),
+        });
+      } else if (editor.kind === 'secret') {
+        await platformRepository.saveSecret({
+          ...values,
+          id: editor.value?.id,
+        });
+      } else if (editor.kind === 'template') {
+        await platformRepository.saveTemplate({
+          ...values,
+          id: editor.value?.id,
+          parameters: parseJsonObject(values.parameters, '模板参数'),
+        });
+      } else {
+        await platformRepository.saveEngine({
+          ...values,
+          id: editor.value?.id,
+          config: parseJsonObject(values.config, '端点配置'),
+        });
+      }
+      message.success('平台配置已保存');
+      closeEditor();
+      await load();
+    } catch (saveError) {
+      message.error(saveError instanceof Error ? saveError.message : '保存失败');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const remove = async (kind: EditorKind, id: number) => {
+    try {
+      if (kind === 'environment') await platformRepository.deleteEnvironment(id);
+      if (kind === 'secret') await platformRepository.deleteSecret(id);
+      if (kind === 'template') await platformRepository.deleteTemplate(id);
+      if (kind === 'engine') await platformRepository.deleteEngine(id);
+      message.success('已删除');
+      await load();
+    } catch (removeError) {
+      message.error(removeError instanceof Error ? removeError.message : '删除失败');
+    }
+  };
+
+  const overviewItems = useMemo(() => {
+    const value = snapshot?.overview;
+    return [
+      ['项目', value?.projectCount ?? 0, <Boxes key="project" size={18} />],
+      ['任务', value?.taskCount ?? 0, <FileJson2 key="task" size={18} />],
+      ['24h 执行', value?.executionCount24h ?? 0, <Activity key="execution" size={18} />],
+      ['24h 成功率', `${value?.successRate24h ?? 0}%`, <CheckCircle2 key="rate" size={18} />],
+      ['运行环境', value?.environmentCount ?? 0, <Database key="env" size={18} />],
+      ['平台密钥', value?.secretCount ?? 0, <KeyRound key="secret" size={18} />],
+      ['参数模板', value?.templateCount ?? 0, <FileJson2 key="template" size={18} />],
+      ['异常引擎', value?.unhealthyEngineCount ?? 0, <ServerCog key="engine" size={18} />],
+    ] as const;
+  }, [snapshot]);
+
+  const operationColumn = <T extends { id: number }>(
+    kind: EditorKind,
+  ): TableColumnsType<T>[number] => ({
+    title: '操作',
+    key: 'action',
+    width: 150,
+    fixed: 'right',
+    render: (_, record) => (
+      <Space size={4}>
+        <Button type="link" size="small" onClick={() => openEditor(kind, record)}>
+          编辑
+        </Button>
+        <Popconfirm title="确认删除这条配置？" onConfirm={() => void remove(kind, record.id)}>
+          <Button type="link" danger size="small" icon={<Trash2 size={13} />}>
+            删除
+          </Button>
+        </Popconfirm>
+      </Space>
+    ),
+  });
+
+  const environmentColumns: TableColumnsType<RuntimeEnvironment> = [
+    {
+      title: '环境',
+      dataIndex: 'name',
+      render: (_, item) => (
+        <div>
+          <div className="font-medium text-[#161823]">{item.name}</div>
+          <div className="mt-0.5 font-mono text-[11px] text-[rgba(22,24,35,.42)]">{item.code}</div>
+        </div>
+      ),
+    },
+    {
+      title: '类型',
+      dataIndex: 'environmentType',
+      width: 110,
+      render: (value: EnvironmentType) => <Tag bordered={false}>{environmentLabel[value]}</Tag>,
+    },
+    {
+      title: '变量数',
+      dataIndex: 'variables',
+      width: 100,
+      render: (value: Record<string, unknown>) => Object.keys(value || {}).length,
+    },
+    {
+      title: '状态',
+      dataIndex: 'enabled',
+      width: 90,
+      render: (enabled: boolean) => <Tag bordered={false}>{enabled ? '启用' : '停用'}</Tag>,
+    },
+    { title: '更新人', dataIndex: 'updatedBy', width: 120, render: (v) => v || '-' },
+    { title: '更新时间', dataIndex: 'updatedAt', width: 180, render: formatDate },
+    operationColumn<RuntimeEnvironment>('environment'),
+  ];
+
+  const secretColumns: TableColumnsType<SecretMetadata> = [
+    {
+      title: '密钥',
+      dataIndex: 'secretKey',
+      render: (_, item) => (
+        <div>
+          <div className="font-mono font-medium text-[#161823]">{item.secretKey}</div>
+          <div className="mt-0.5 text-[11px] text-[rgba(22,24,35,.42)]">{item.maskedValue}</div>
+        </div>
+      ),
+    },
+    {
+      title: '环境',
+      dataIndex: 'environmentId',
+      width: 160,
+      render: (id: number) =>
+        id === 0
+          ? '全局'
+          : snapshot?.environments.find((item) => item.id === id)?.name || `#${id}`,
+    },
+    { title: '说明', dataIndex: 'description', ellipsis: true, render: (v) => v || '-' },
+    { title: '更新人', dataIndex: 'updatedBy', width: 120, render: (v) => v || '-' },
+    { title: '更新时间', dataIndex: 'updatedAt', width: 180, render: formatDate },
+    operationColumn<SecretMetadata>('secret'),
+  ];
+
+  const templateColumns: TableColumnsType<ParameterTemplate> = [
+    {
+      title: '参数模板',
+      dataIndex: 'name',
+      render: (_, item) => (
+        <div>
+          <div className="font-medium text-[#161823]">{item.name}</div>
+          <div className="mt-0.5 font-mono text-[11px] text-[rgba(22,24,35,.42)]">{item.code}</div>
+        </div>
+      ),
+    },
+    {
+      title: '参数数',
+      dataIndex: 'parameters',
+      width: 100,
+      render: (value: Record<string, unknown>) => Object.keys(value || {}).length,
+    },
+    { title: '说明', dataIndex: 'description', ellipsis: true, render: (v) => v || '-' },
+    {
+      title: '状态',
+      dataIndex: 'enabled',
+      width: 90,
+      render: (enabled: boolean) => <Tag bordered={false}>{enabled ? '启用' : '停用'}</Tag>,
+    },
+    { title: '更新时间', dataIndex: 'updatedAt', width: 180, render: formatDate },
+    operationColumn<ParameterTemplate>('template'),
+  ];
+
+  const engineColumns: TableColumnsType<EngineEndpoint> = [
+    {
+      title: '引擎端点',
+      dataIndex: 'name',
+      render: (_, item) => (
+        <div>
+          <div className="font-medium text-[#161823]">{item.name}</div>
+          <div className="mt-0.5 font-mono text-[11px] text-[rgba(22,24,35,.42)]">{item.code}</div>
+        </div>
+      ),
+    },
+    { title: '任务类型', dataIndex: 'taskType', width: 120, render: (v) => <Tag bordered={false}>{v}</Tag> },
+    { title: '探测', dataIndex: 'probeType', width: 120 },
+    { title: '端点', dataIndex: 'endpoint', ellipsis: true, render: (v) => v || '本地插件' },
+    {
+      title: '健康状态',
+      dataIndex: 'healthStatus',
+      width: 110,
+      render: (value: EngineEndpoint['healthStatus'], item) => (
+        <Tag bordered={false} title={item.healthMessage} className={healthMeta[value].className}>
+          {healthMeta[value].label}
+        </Tag>
+      ),
+    },
+    { title: '检查时间', dataIndex: 'lastCheckedAt', width: 180, render: formatDate },
+    {
+      title: '操作',
+      key: 'action',
+      width: 210,
+      fixed: 'right',
+      render: (_, item) => (
+        <Space size={4}>
+          <Button
+            type="link"
+            size="small"
+            onClick={async () => {
+              try {
+                await platformRepository.checkEngine(item.id);
+                message.success('健康检查完成');
+                await load();
+              } catch (checkError) {
+                message.error(checkError instanceof Error ? checkError.message : '检查失败');
+              }
+            }}
+          >
+            检查
+          </Button>
+          <Button type="link" size="small" onClick={() => openEditor('engine', item)}>编辑</Button>
+          <Popconfirm title="确认删除这个端点？" onConfirm={() => void remove('engine', item.id)}>
+            <Button type="link" danger size="small">删除</Button>
+          </Popconfirm>
+        </Space>
+      ),
+    },
+  ];
+
+  const auditColumns: TableColumnsType<AuditEntry> = [
+    { title: '时间', dataIndex: 'occurredAt', width: 180, render: formatDate },
+    { title: '操作', dataIndex: 'action', width: 220, render: (v) => <Tag bordered={false}>{v}</Tag> },
+    { title: '资源', key: 'resource', width: 180, render: (_, item) => `${item.resourceType}${item.resourceId ? ` #${item.resourceId}` : ''}` },
+    { title: '操作人', dataIndex: 'operator', width: 130 },
+    { title: '摘要', dataIndex: 'summary', render: (value) => <code className="text-[11px]">{JSON.stringify(value)}</code> },
+  ];
+
+  const tabItems = [
+    {
+      key: 'environment',
+      label: `运行环境 ${snapshot?.environments.length ?? 0}`,
+      children: (
+        <Table rowKey="id" columns={environmentColumns} dataSource={snapshot?.environments} pagination={false} scroll={{ x: 1050 }} />
+      ),
+    },
+    {
+      key: 'secret',
+      label: `密钥 ${snapshot?.secrets.length ?? 0}`,
+      children: (
+        <Table rowKey="id" columns={secretColumns} dataSource={snapshot?.secrets} pagination={false} scroll={{ x: 1050 }} />
+      ),
+    },
+    {
+      key: 'template',
+      label: `参数模板 ${snapshot?.parameterTemplates.length ?? 0}`,
+      children: (
+        <Table rowKey="id" columns={templateColumns} dataSource={snapshot?.parameterTemplates} pagination={false} scroll={{ x: 1050 }} />
+      ),
+    },
+    {
+      key: 'engine',
+      label: `引擎中心 ${snapshot?.engines.length ?? 0}`,
+      children: (
+        <Table rowKey="id" columns={engineColumns} dataSource={snapshot?.engines} pagination={false} scroll={{ x: 1200 }} />
+      ),
+    },
+    {
+      key: 'audit',
+      label: '审计日志',
+      children: (
+        <Table rowKey="id" columns={auditColumns} dataSource={snapshot?.recentAudit} pagination={{ pageSize: 20 }} scroll={{ x: 1000 }} />
+      ),
+    },
+  ];
+
+  return (
+    <RouteAccessBoundary route={PLATFORM_ROUTE}>
+      <ConfigProvider theme={BRAND_THEME}>
+      <div className="min-h-[calc(100vh-48px)] bg-white px-5 pb-6 pt-4 text-[#161823]">
+        <header className="flex min-h-11 items-center justify-between gap-4">
+          <div className="flex items-center gap-3">
+            <Button type="text" icon={<ArrowLeft size={16} />} onClick={() => history.push('/data-development/workbench')} />
+            <div>
+              <h1 className="m-0 text-[17px] font-semibold leading-6">平台能力</h1>
+              <div className="mt-0.5 text-[11px] text-[rgba(22,24,35,.42)]">统一管理运行环境、密钥、参数模板、引擎健康和审计记录</div>
+            </div>
+          </div>
+          <Space>
+            <Button loading={loading} icon={<RefreshCw size={15} />} onClick={() => void load()}>刷新</Button>
+          </Space>
+        </header>
+
+        {!snapshot?.secretEncryptionConfigured && !loading && (
+          <Alert
+            showIcon
+            type="warning"
+            className="mt-3"
+            message="平台密钥加密尚未启用"
+            description="请配置环境变量 YAK_DATA_DEVELOPMENT_PLATFORM_MASTER_KEY。未配置前，环境与模板可以使用，但无法新增或读取密钥。"
+          />
+        )}
+        {error && <Alert showIcon type="error" className="mt-3" message={error} />}
+
+        <Spin spinning={loading && !snapshot}>
+          <section className="mt-3 grid grid-cols-4 gap-2 max-[1100px]:grid-cols-2 max-[640px]:grid-cols-1">
+            {overviewItems.map(([label, value, icon]) => (
+              <div key={label} className="flex min-h-[72px] items-center gap-3 border border-[#eceef0] bg-[#fafbfc] px-4 py-3">
+                <span className="flex h-9 w-9 items-center justify-center rounded-[7px] bg-[#f2f3f5] text-[rgba(22,24,35,.58)]">{icon}</span>
+                <div>
+                  <Text type="secondary" className="!text-[11px]">{label}</Text>
+                  <div className="mt-0.5 text-lg font-semibold">{value}</div>
+                </div>
+              </div>
+            ))}
+          </section>
+
+          <section className="mt-3 border border-[#e4e7ec] bg-white">
+            <div className="flex min-h-[54px] items-center justify-between border-b border-[#eaecf0] px-3 py-2">
+              <div className="flex items-center gap-2 text-[13px] font-medium"><ShieldCheck size={16} />平台配置与治理</div>
+              <Space wrap>
+                <Button icon={<Plus size={14} />} onClick={() => openEditor('environment')}>运行环境</Button>
+                <Button icon={<KeyRound size={14} />} disabled={!snapshot?.secretEncryptionConfigured} onClick={() => openEditor('secret')}>密钥</Button>
+                <Button icon={<Plus size={14} />} onClick={() => openEditor('template')}>参数模板</Button>
+                <Button icon={<ServerCog size={14} />} onClick={() => openEditor('engine')}>引擎端点</Button>
+                <Button
+                  loading={checking}
+                  onClick={async () => {
+                    setChecking(true);
+                    try {
+                      await platformRepository.checkAllEngines();
+                      message.success('全部引擎检查完成');
+                      await load();
+                    } catch (checkError) {
+                      message.error(checkError instanceof Error ? checkError.message : '检查失败');
+                    } finally {
+                      setChecking(false);
+                    }
+                  }}
+                >
+                  检查全部
+                </Button>
+              </Space>
+            </div>
+            <Tabs className="px-3" items={tabItems} />
+          </section>
+        </Spin>
+
+        <Drawer
+          width={520}
+          open={Boolean(editor)}
+          title={editor?.value ? '编辑平台配置' : '新增平台配置'}
+          onClose={closeEditor}
+          extra={<Button type="primary" loading={saving} onClick={() => void save()}>保存</Button>}
+          destroyOnClose
+        >
+          <Form form={form} layout="vertical" variant="filled">
+            {editor?.kind === 'environment' && (
+              <>
+                <Form.Item name="code" label="环境编码" rules={[{ required: true }]}><Input placeholder="dev" /></Form.Item>
+                <Form.Item name="name" label="环境名称" rules={[{ required: true }]}><Input placeholder="开发环境" /></Form.Item>
+                <Form.Item name="environmentType" label="环境类型" rules={[{ required: true }]}>
+                  <Select options={Object.entries(environmentLabel).map(([value, label]) => ({ value, label }))} />
+                </Form.Item>
+                <Form.Item name="description" label="说明"><Input.TextArea rows={2} /></Form.Item>
+                <Form.Item name="variables" label="环境变量 JSON" rules={[{ required: true }]}><Input.TextArea rows={10} className="font-mono" /></Form.Item>
+                <Form.Item name="enabled" label="启用" valuePropName="checked"><Switch /></Form.Item>
+              </>
+            )}
+            {editor?.kind === 'secret' && (
+              <>
+                <Form.Item name="environmentId" label="所属环境" rules={[{ required: true }]}>
+                  <Select options={[{ value: 0, label: '全局' }, ...(snapshot?.environments.map((item) => ({ value: item.id, label: item.name })) ?? [])]} />
+                </Form.Item>
+                <Form.Item name="secretKey" label="密钥名称" rules={[{ required: true }]}><Input placeholder="API_TOKEN" /></Form.Item>
+                <Form.Item name="description" label="说明"><Input.TextArea rows={2} /></Form.Item>
+                <Form.Item name="secretValue" label="密钥值" rules={[{ required: true }]}><Input.Password autoComplete="new-password" /></Form.Item>
+              </>
+            )}
+            {editor?.kind === 'template' && (
+              <>
+                <Form.Item name="code" label="模板编码" rules={[{ required: true }]}><Input placeholder="daily-default" /></Form.Item>
+                <Form.Item name="name" label="模板名称" rules={[{ required: true }]}><Input placeholder="每日任务默认参数" /></Form.Item>
+                <Form.Item name="description" label="说明"><Input.TextArea rows={2} /></Form.Item>
+                <Form.Item name="parameters" label="参数 JSON" rules={[{ required: true }]}><Input.TextArea rows={12} className="font-mono" /></Form.Item>
+                <Form.Item name="enabled" label="启用" valuePropName="checked"><Switch /></Form.Item>
+              </>
+            )}
+            {editor?.kind === 'engine' && (
+              <>
+                <Form.Item name="taskType" label="任务类型" rules={[{ required: true }]}>
+                  <Select options={['SQL', 'FLINK_SQL', 'PYTHON', 'NOTEBOOK', 'HTTP', 'SHELL'].map((value) => ({ value, label: value }))} />
+                </Form.Item>
+                <Form.Item name="code" label="端点编码" rules={[{ required: true }]}><Input placeholder="flink-gateway-prod" /></Form.Item>
+                <Form.Item name="name" label="端点名称" rules={[{ required: true }]}><Input placeholder="生产 Flink SQL Gateway" /></Form.Item>
+                <Form.Item name="probeType" label="探测类型" rules={[{ required: true }]}>
+                  <Select options={(['LOCAL_PLUGIN', 'HTTP', 'TCP'] as ProbeType[]).map((value) => ({ value, label: value }))} />
+                </Form.Item>
+                <Form.Item name="endpoint" label="健康检查端点"><Input placeholder="http://flink-gateway:8083/v1/info 或 host:port" /></Form.Item>
+                <Form.Item name="config" label="端点配置 JSON" rules={[{ required: true }]}><Input.TextArea rows={8} className="font-mono" /></Form.Item>
+                <Form.Item name="enabled" label="启用" valuePropName="checked"><Switch /></Form.Item>
+              </>
+            )}
+            <Form.Item name="lockVersion" hidden><Input /></Form.Item>
+          </Form>
+        </Drawer>
+      </div>
+      </ConfigProvider>
+    </RouteAccessBoundary>
+  );
+};
+
+export default PlatformPage;

--- a/yak-ops-ui/src/pages/data-development/platform/platform.repository.ts
+++ b/yak-ops-ui/src/pages/data-development/platform/platform.repository.ts
@@ -1,0 +1,205 @@
+import HttpUtils from '@/utils/HttpUtils';
+
+const API_PREFIX = '/api/v1/data-development/platform';
+
+interface ApiResponse<T> {
+  code: number;
+  data: T;
+  msg?: string;
+  message?: string;
+}
+
+export type EnvironmentType =
+  | 'DEVELOPMENT'
+  | 'TESTING'
+  | 'STAGING'
+  | 'PRODUCTION';
+export type ProbeType = 'LOCAL_PLUGIN' | 'HTTP' | 'TCP';
+export type HealthStatus =
+  | 'UNKNOWN'
+  | 'HEALTHY'
+  | 'DEGRADED'
+  | 'UNHEALTHY'
+  | 'DISABLED';
+
+export interface PlatformOverview {
+  projectCount: number;
+  taskCount: number;
+  executionCount24h: number;
+  failedExecutionCount24h: number;
+  environmentCount: number;
+  secretCount: number;
+  templateCount: number;
+  healthyEngineCount: number;
+  unhealthyEngineCount: number;
+  successRate24h: number;
+}
+
+export interface RuntimeEnvironment {
+  id: number;
+  code: string;
+  name: string;
+  environmentType: EnvironmentType;
+  description?: string;
+  enabled: boolean;
+  variables: Record<string, unknown>;
+  lockVersion: number;
+  updatedBy?: string;
+  updatedAt: string;
+}
+
+export interface SecretMetadata {
+  id: number;
+  environmentId: number;
+  secretKey: string;
+  description?: string;
+  maskedValue: string;
+  updatedBy?: string;
+  updatedAt: string;
+}
+
+export interface ParameterTemplate {
+  id: number;
+  code: string;
+  name: string;
+  description?: string;
+  enabled: boolean;
+  parameters: Record<string, unknown>;
+  lockVersion: number;
+  updatedBy?: string;
+  updatedAt: string;
+}
+
+export interface EngineEndpoint {
+  id: number;
+  taskType: string;
+  code: string;
+  name: string;
+  probeType: ProbeType;
+  endpoint?: string;
+  enabled: boolean;
+  config: Record<string, unknown>;
+  healthStatus: HealthStatus;
+  healthMessage?: string;
+  lastCheckedAt?: string;
+  lockVersion: number;
+  updatedBy?: string;
+  updatedAt: string;
+}
+
+export interface AuditEntry {
+  id: number;
+  action: string;
+  resourceType: string;
+  resourceId?: string;
+  summary: Record<string, unknown>;
+  operator: string;
+  occurredAt: string;
+}
+
+export interface PlatformSnapshot {
+  overview: PlatformOverview;
+  environments: RuntimeEnvironment[];
+  secrets: SecretMetadata[];
+  parameterTemplates: ParameterTemplate[];
+  engines: EngineEndpoint[];
+  recentAudit: AuditEntry[];
+  secretEncryptionConfigured: boolean;
+}
+
+const unwrap = <T>(response: ApiResponse<T>): T => {
+  if (response.code !== 0 && response.code !== 200) {
+    throw new Error(response.message ?? response.msg ?? '平台接口调用失败');
+  }
+  return response.data;
+};
+
+export const platformRepository = {
+  async snapshot() {
+    return unwrap(await HttpUtils.get<PlatformSnapshot>(`${API_PREFIX}/snapshot`));
+  },
+  async saveEnvironment(payload: Record<string, unknown> & { id?: number }) {
+    return unwrap(
+      payload.id
+        ? await HttpUtils.put<RuntimeEnvironment>(
+            `${API_PREFIX}/environments/${payload.id}`,
+            payload,
+          )
+        : await HttpUtils.post<RuntimeEnvironment>(
+            `${API_PREFIX}/environments`,
+            payload,
+          ),
+    );
+  },
+  async deleteEnvironment(id: number) {
+    return unwrap(
+      await HttpUtils.delete<{ deleted: boolean }>(
+        `${API_PREFIX}/environments/${id}`,
+      ),
+    );
+  },
+  async saveSecret(payload: Record<string, unknown> & { id?: number }) {
+    return unwrap(
+      payload.id
+        ? await HttpUtils.put<SecretMetadata>(
+            `${API_PREFIX}/secrets/${payload.id}`,
+            payload,
+          )
+        : await HttpUtils.post<SecretMetadata>(`${API_PREFIX}/secrets`, payload),
+    );
+  },
+  async deleteSecret(id: number) {
+    return unwrap(
+      await HttpUtils.delete<{ deleted: boolean }>(
+        `${API_PREFIX}/secrets/${id}`,
+      ),
+    );
+  },
+  async saveTemplate(payload: Record<string, unknown> & { id?: number }) {
+    return unwrap(
+      payload.id
+        ? await HttpUtils.put<ParameterTemplate>(
+            `${API_PREFIX}/parameter-templates/${payload.id}`,
+            payload,
+          )
+        : await HttpUtils.post<ParameterTemplate>(
+            `${API_PREFIX}/parameter-templates`,
+            payload,
+          ),
+    );
+  },
+  async deleteTemplate(id: number) {
+    return unwrap(
+      await HttpUtils.delete<{ deleted: boolean }>(
+        `${API_PREFIX}/parameter-templates/${id}`,
+      ),
+    );
+  },
+  async saveEngine(payload: Record<string, unknown> & { id?: number }) {
+    return unwrap(
+      payload.id
+        ? await HttpUtils.put<EngineEndpoint>(
+            `${API_PREFIX}/engines/${payload.id}`,
+            payload,
+          )
+        : await HttpUtils.post<EngineEndpoint>(`${API_PREFIX}/engines`, payload),
+    );
+  },
+  async deleteEngine(id: number) {
+    return unwrap(
+      await HttpUtils.delete<{ deleted: boolean }>(
+        `${API_PREFIX}/engines/${id}`,
+      ),
+    );
+  },
+  async checkEngine(id: number) {
+    return unwrap(
+      await HttpUtils.post<EngineEndpoint>(`${API_PREFIX}/engines/${id}/check`, {}),
+    );
+  },
+  async checkAllEngines() {
+    return unwrap(
+      await HttpUtils.post<EngineEndpoint[]>(`${API_PREFIX}/engines/check-all`, {}),
+    );
+  },
+};

--- a/yak-ops-ui/src/pages/data-development/workbench/WorkbenchPage.tsx
+++ b/yak-ops-ui/src/pages/data-development/workbench/WorkbenchPage.tsx
@@ -2,6 +2,7 @@ import {
   BRAND_CSS_VARIABLES,
   BRAND_THEME,
 } from '@/styles/brand';
+import { history } from '@umijs/max';
 import { Alert, Button, ConfigProvider, Spin, Tooltip } from 'antd';
 import {
   ChevronRight,
@@ -10,6 +11,7 @@ import {
   Columns2,
   Maximize2,
   Minimize2,
+  Settings2,
   X,
 } from 'lucide-react';
 import { useEffect, useState } from 'react';
@@ -37,21 +39,13 @@ const WorkbenchPage = () => {
   const fullscreen = useWorkbenchStore((state) => state.fullscreen);
   const splitResourceId = useWorkbenchStore((state) => state.splitResourceId);
   const resourcesById = useWorkbenchStore((state) => state.resourcesById);
-  const workspaceLoading = useWorkbenchControlStore(
-    (state) => state.workspaceLoading,
-  );
-  const workspaceError = useWorkbenchControlStore(
-    (state) => state.workspaceError,
-  );
+  const workspaceLoading = useWorkbenchControlStore((state) => state.workspaceLoading);
+  const workspaceError = useWorkbenchControlStore((state) => state.workspaceError);
   const initialize = useWorkbenchControlStore((state) => state.initialize);
   const setExplorerWidth = useWorkbenchStore((state) => state.setExplorerWidth);
   const setFullscreen = useWorkbenchStore((state) => state.setFullscreen);
-  const setSplitResource = useWorkbenchStore(
-    (state) => state.setSplitResource,
-  );
-  const setActiveResource = useWorkbenchStore(
-    (state) => state.setActiveResource,
-  );
+  const setSplitResource = useWorkbenchStore((state) => state.setSplitResource);
+  const setActiveResource = useWorkbenchStore((state) => state.setActiveResource);
   const [createOpen, setCreateOpen] = useState(false);
   const [createType, setCreateType] = useState<ResourceType>('HTTP');
 
@@ -64,9 +58,7 @@ const WorkbenchPage = () => {
     setCreateOpen(true);
   };
 
-  const splitResource = splitResourceId
-    ? resourcesById[splitResourceId]
-    : undefined;
+  const splitResource = splitResourceId ? resourcesById[splitResourceId] : undefined;
 
   return (
     <ConfigProvider theme={BRAND_THEME}>
@@ -77,41 +69,35 @@ const WorkbenchPage = () => {
         <header className="flex h-12 shrink-0 items-center justify-between border-b border-[#e5e7ea] px-4">
           <div className="flex min-w-0 items-center gap-2 text-[13px]">
             <span className="text-[rgba(22,24,35,0.48)]">工作台</span>
-            <ChevronRight
-              size={14}
-              className="text-[rgba(22,24,35,0.26)]"
-            />
-            <strong className="truncate font-semibold text-[#161823]">
-              数据开发
-            </strong>
+            <ChevronRight size={14} className="text-[rgba(22,24,35,0.26)]" />
+            <strong className="truncate font-semibold text-[#161823]">数据开发</strong>
             <span className="ml-2 hidden rounded bg-[#f2f3f5] px-2 py-1 text-[10px] font-medium text-[rgba(22,24,35,0.48)] md:inline-flex">
-              Control Plane
+              Platform Ready
             </span>
           </div>
 
           <div className="flex items-center gap-2">
+            <Button
+              size="small"
+              icon={<Settings2 size={14} />}
+              onClick={() => history.push('/data-development/platform')}
+            >
+              平台能力
+            </Button>
             <div className="hidden items-center gap-2 rounded-md border border-[#e2e5e9] bg-[#fafbfc] px-2.5 py-1.5 text-[12px] text-[rgba(22,24,35,0.68)] sm:flex">
               <Cloud size={14} />
               {workspaceError ? '连接异常' : '开发环境'}
               <Circle
                 size={7}
                 fill={workspaceError ? '#ff4d4f' : '#20b26b'}
-                className={
-                  workspaceError ? 'text-[#ff4d4f]' : 'text-[#20b26b]'
-                }
+                className={workspaceError ? 'text-[#ff4d4f]' : 'text-[#20b26b]'}
               />
             </div>
             <Tooltip title={fullscreen ? '退出沉浸模式' : '沉浸模式'}>
               <Button
                 type="text"
                 size="small"
-                icon={
-                  fullscreen ? (
-                    <Minimize2 size={16} />
-                  ) : (
-                    <Maximize2 size={16} />
-                  )
-                }
+                icon={fullscreen ? <Minimize2 size={16} /> : <Maximize2 size={16} />}
                 onClick={() => setFullscreen(!fullscreen)}
               />
             </Tooltip>
@@ -124,11 +110,7 @@ const WorkbenchPage = () => {
             showIcon
             type="error"
             message={workspaceError}
-            action={
-              <Button size="small" onClick={() => void initialize()}>
-                重新加载
-              </Button>
-            }
+            action={<Button size="small" onClick={() => void initialize()}>重新加载</Button>}
           />
         )}
 
@@ -141,10 +123,7 @@ const WorkbenchPage = () => {
 
           {explorerVisible && !fullscreen && (
             <>
-              <div
-                style={{ width: explorerWidth }}
-                className="h-full min-w-0 shrink-0 overflow-hidden"
-              >
+              <div style={{ width: explorerWidth }} className="h-full min-w-0 shrink-0 overflow-hidden">
                 <ExplorerPanel onCreate={openCreateModal} />
               </div>
               <WorkbenchResizeHandle
@@ -195,10 +174,8 @@ const WorkbenchPage = () => {
                   </section>
                 )}
               </div>
-
               <ExecutionBottomPanel />
             </div>
-
             <StatusBar />
           </main>
 

--- a/yak-ops-ui/src/pages/data-development/workbench/components/RightPanel.tsx
+++ b/yak-ops-ui/src/pages/data-development/workbench/components/RightPanel.tsx
@@ -1,6 +1,7 @@
 import { Button, Input, message, Modal, Select, Switch } from 'antd';
 import { Trash2, X } from 'lucide-react';
-import type { ChangeEvent, ReactNode } from 'react';
+import { useEffect, useState, type ChangeEvent, type ReactNode } from 'react';
+import { platformRepository, type PlatformSnapshot } from '../../platform/platform.repository';
 import { nodePluginRegistry } from '../core/registry';
 import type { RightPanelKey } from '../core/types';
 import { SchemaDrivenForm } from '../renderers/SchemaFormRenderer';
@@ -10,17 +11,9 @@ import {
   useWorkbenchStore,
 } from '../store/workbench.store';
 
-const PanelField = ({
-  label,
-  children,
-}: {
-  label: string;
-  children: ReactNode;
-}) => (
+const PanelField = ({ label, children }: { label: string; children: ReactNode }) => (
   <label className="block">
-    <span className="mb-1.5 block text-[12px] font-medium text-[rgba(22,24,35,0.68)]">
-      {label}
-    </span>
+    <span className="mb-1.5 block text-[12px] font-medium text-[rgba(22,24,35,0.68)]">{label}</span>
     {children}
   </label>
 );
@@ -36,23 +29,38 @@ const RightPanel = () => {
   const rightPanel = useWorkbenchStore((state) => state.rightPanel);
   const resource = useWorkbenchStore(selectActiveResource);
   const document = useWorkbenchStore(selectActiveDocument);
-  const scheduleEnabledByResourceId = useWorkbenchStore(
-    (state) => state.scheduleEnabledByResourceId,
-  );
+  const scheduleEnabledByResourceId = useWorkbenchStore((state) => state.scheduleEnabledByResourceId);
   const setRightPanel = useWorkbenchStore((state) => state.setRightPanel);
   const updateResource = useWorkbenchStore((state) => state.updateResource);
   const updateDocument = useWorkbenchStore((state) => state.updateDocument);
   const deleteResource = useWorkbenchStore((state) => state.deleteResource);
-  const setScheduleEnabled = useWorkbenchStore(
-    (state) => state.setScheduleEnabled,
-  );
+  const setScheduleEnabled = useWorkbenchStore((state) => state.setScheduleEnabled);
+  const [platform, setPlatform] = useState<PlatformSnapshot>();
+
+  useEffect(() => {
+    if (rightPanel !== 'run') return;
+    void platformRepository.snapshot().then(setPlatform).catch(() => undefined);
+  }, [rightPanel]);
 
   if (!rightPanel || !resource || !document) return null;
-
   const plugin = nodePluginRegistry.get(resource.resourceType);
   if (!plugin) return null;
 
   const scheduleEnabled = scheduleEnabledByResourceId[resource.id] ?? false;
+  const common = document.runtime.common as typeof document.runtime.common & {
+    parameterTemplateId?: string;
+    secretKeys?: string[];
+  };
+
+  const updateCommon = (patch: Record<string, unknown>) =>
+    updateDocument(resource.id, (current) => ({
+      ...current,
+      runtime: {
+        ...current.runtime,
+        common: { ...current.runtime.common, ...patch },
+      },
+      dirty: true,
+    }));
 
   const confirmDelete = () => {
     Modal.confirm({
@@ -69,138 +77,99 @@ const RightPanel = () => {
     });
   };
 
+  const selectedEnvironmentId = Number(common.environmentId || 0);
+  const availableSecrets = platform?.secrets.filter(
+    (item) => item.environmentId === 0 || item.environmentId === selectedEnvironmentId,
+  ) ?? [];
+
   return (
     <aside className="flex w-[310px] shrink-0 flex-col border-l border-[#e7e9ec] bg-white">
       <div className="flex h-11 items-center justify-between border-b border-[#eceef0] px-4">
-        <strong className="text-[13px] font-semibold text-[#161823]">
-          {PANEL_TITLES[rightPanel]}
-        </strong>
-        <Button
-          type="text"
-          size="small"
-          aria-label="关闭右侧面板"
-          icon={<X size={15} />}
-          onClick={() => setRightPanel(null)}
-        />
+        <strong className="text-[13px] font-semibold text-[#161823]">{PANEL_TITLES[rightPanel]}</strong>
+        <Button type="text" size="small" aria-label="关闭右侧面板" icon={<X size={15} />} onClick={() => setRightPanel(null)} />
       </div>
 
       <div className="min-h-0 flex-1 overflow-y-auto p-4">
         {rightPanel === 'properties' && (
           <div className="space-y-4">
             <PanelField label="节点名称">
-              <Input
-                variant="filled"
-                value={resource.name}
-                onChange={(event: ChangeEvent<HTMLInputElement>) =>
-                  updateResource(resource.id, { name: event.target.value })
-                }
-              />
+              <Input variant="filled" value={resource.name} onChange={(event: ChangeEvent<HTMLInputElement>) => updateResource(resource.id, { name: event.target.value })} />
             </PanelField>
-            <PanelField label="节点类型">
-              <Input variant="filled" disabled value={plugin.metadata.label} />
-            </PanelField>
+            <PanelField label="节点类型"><Input variant="filled" disabled value={plugin.metadata.label} /></PanelField>
             <PanelField label="计算引擎">
               <Select
                 variant="filled"
                 className="w-full"
                 value={resource.engine}
-                options={
-                  plugin.metadata.engineOptions ?? [
-                    {
-                      label: plugin.metadata.defaultEngine,
-                      value: plugin.metadata.defaultEngine,
-                    },
-                  ]
-                }
+                options={plugin.metadata.engineOptions ?? [{ label: plugin.metadata.defaultEngine, value: plugin.metadata.defaultEngine }]}
                 onChange={(engine: string) => updateResource(resource.id, { engine })}
               />
             </PanelField>
             <PanelField label="描述">
-              <Input.TextArea
-                variant="filled"
-                rows={5}
-                value={resource.description}
-                placeholder="填写节点说明"
-                onChange={(event: ChangeEvent<HTMLTextAreaElement>) =>
-                  updateResource(resource.id, {
-                    description: event.target.value,
-                  })
-                }
-              />
+              <Input.TextArea variant="filled" rows={5} value={resource.description} placeholder="填写节点说明" onChange={(event: ChangeEvent<HTMLTextAreaElement>) => updateResource(resource.id, { description: event.target.value })} />
             </PanelField>
             <div className="rounded-lg bg-[#f7f8f9] p-3 text-[11px] leading-5 text-[rgba(22,24,35,0.5)]">
-              resourceType: {resource.resourceType}
-              <br />
-              schemaVersion: {resource.schemaVersion}
-              <br />
-              revision: {document.revision}
+              resourceType: {resource.resourceType}<br />schemaVersion: {resource.schemaVersion}<br />revision: {document.revision}
             </div>
             <div className="border-t border-[#eceef0] pt-4">
-              <Button
-                danger
-                block
-                icon={<Trash2 size={15} />}
-                onClick={confirmDelete}
-              >
-                删除节点
-              </Button>
+              <Button danger block icon={<Trash2 size={15} />} onClick={confirmDelete}>删除节点</Button>
             </div>
           </div>
         )}
 
         {rightPanel === 'run' && (
           <div className="space-y-4">
-            <PanelField label="公共运行参数">
+            <div className="text-[12px] font-semibold text-[#161823]">平台运行上下文</div>
+            <PanelField label="运行环境">
               <Select
+                allowClear
                 variant="filled"
                 className="w-full"
-                value={document.runtime.common.environmentId}
-                options={[
-                  { label: '开发环境', value: 'development' },
-                  { label: '测试环境', value: 'testing' },
-                  { label: '生产环境', value: 'production' },
-                ]}
-                onChange={(environmentId: string) =>
-                  updateDocument(resource.id, (current) => ({
-                    ...current,
-                    runtime: {
-                      ...current.runtime,
-                      common: {
-                        ...current.runtime.common,
-                        environmentId,
-                      },
-                    },
-                    dirty: true,
-                  }))
-                }
+                placeholder="不使用平台环境"
+                value={selectedEnvironmentId || undefined}
+                options={platform?.environments.filter((item) => item.enabled).map((item) => ({ label: `${item.name} · ${item.code}`, value: item.id }))}
+                onChange={(environmentId?: number) => updateCommon({ environmentId: environmentId ? String(environmentId) : '' })}
               />
             </PanelField>
+            <PanelField label="参数模板">
+              <Select
+                allowClear
+                variant="filled"
+                className="w-full"
+                placeholder="不使用参数模板"
+                value={Number(common.parameterTemplateId || 0) || undefined}
+                options={platform?.parameterTemplates.filter((item) => item.enabled).map((item) => ({ label: `${item.name} · ${item.code}`, value: item.id }))}
+                onChange={(parameterTemplateId?: number) => updateCommon({ parameterTemplateId: parameterTemplateId ? String(parameterTemplateId) : '' })}
+              />
+            </PanelField>
+            <PanelField label="注入密钥">
+              <Select
+                mode="multiple"
+                variant="filled"
+                className="w-full"
+                placeholder={selectedEnvironmentId ? '选择运行时密钥' : '请先选择运行环境'}
+                disabled={!selectedEnvironmentId}
+                value={common.secretKeys ?? []}
+                options={availableSecrets.map((item) => ({ label: item.secretKey, value: item.secretKey }))}
+                onChange={(secretKeys: string[]) => updateCommon({ secretKeys })}
+              />
+            </PanelField>
+            <div className="rounded-lg bg-[#f7f8f9] p-3 text-[11px] leading-5 text-[rgba(22,24,35,0.5)]">
+              环境变量与参数模板会在执行前合并；密钥只在 Worker 内存中解密，可使用 <code>${'{secret.API_TOKEN}'}</code> 引用。
+            </div>
 
             {plugin.runtime ? (
               <>
-                <div className="border-t border-[#eceef0] pt-4 text-[12px] font-semibold text-[#161823]">
-                  {plugin.metadata.label} 专属参数
-                </div>
+                <div className="border-t border-[#eceef0] pt-4 text-[12px] font-semibold text-[#161823]">{plugin.metadata.label} 专属参数</div>
                 <SchemaDrivenForm
                   compact
                   schema={plugin.runtime.schema}
                   value={document.runtime.specific}
-                  onChange={(specific) =>
-                    updateDocument(resource.id, (current) => ({
-                      ...current,
-                      runtime: {
-                        ...current.runtime,
-                        specific,
-                      },
-                      dirty: true,
-                    }))
-                  }
+                  onChange={(specific) => updateDocument(resource.id, (current) => ({ ...current, runtime: { ...current.runtime, specific }, dirty: true }))}
                 />
               </>
             ) : (
-              <div className="rounded-lg bg-[#f7f8f9] p-3 text-[12px] leading-5 text-[rgba(22,24,35,0.56)]">
-                当前节点无需专属运行参数。
-              </div>
+              <div className="rounded-lg bg-[#f7f8f9] p-3 text-[12px] leading-5 text-[rgba(22,24,35,0.56)]">当前节点无需专属运行参数。</div>
             )}
           </div>
         )}
@@ -208,54 +177,16 @@ const RightPanel = () => {
         {rightPanel === 'schedule' && (
           <div className="space-y-4">
             {!plugin.capabilities.schedulable ? (
-              <div className="rounded-lg bg-[#f7f8f9] p-3 text-[12px] leading-5 text-[rgba(22,24,35,0.56)]">
-                当前节点插件未声明调度能力。
-              </div>
+              <div className="rounded-lg bg-[#f7f8f9] p-3 text-[12px] leading-5 text-[rgba(22,24,35,0.56)]">当前节点插件未声明调度能力。</div>
             ) : (
               <>
                 <div className="flex items-center justify-between rounded-lg border border-[#e7e9ec] p-3">
-                  <div>
-                    <div className="text-[13px] font-medium text-[#161823]">
-                      开启调度
-                    </div>
-                    <div className="mt-1 text-[11px] text-[rgba(22,24,35,0.44)]">
-                      调度仅绑定已发布的不可变版本
-                    </div>
-                  </div>
-                  <Switch
-                    checked={scheduleEnabled}
-                    onChange={(enabled: boolean) =>
-                      setScheduleEnabled(resource.id, enabled)
-                    }
-                  />
+                  <div><div className="text-[13px] font-medium text-[#161823]">开启调度</div><div className="mt-1 text-[11px] text-[rgba(22,24,35,0.44)]">调度仅绑定已发布的不可变版本</div></div>
+                  <Switch checked={scheduleEnabled} onChange={(enabled: boolean) => setScheduleEnabled(resource.id, enabled)} />
                 </div>
-                <PanelField label="调度周期">
-                  <Select
-                    variant="filled"
-                    className="w-full"
-                    disabled={!scheduleEnabled}
-                    defaultValue="daily"
-                    options={[
-                      { label: '每天', value: 'daily' },
-                      { label: '每小时', value: 'hourly' },
-                      { label: '每周', value: 'weekly' },
-                    ]}
-                  />
-                </PanelField>
-                <PanelField label="Cron 表达式">
-                  <Input
-                    variant="filled"
-                    disabled={!scheduleEnabled}
-                    defaultValue="0 0 2 * * ?"
-                  />
-                </PanelField>
-                <PanelField label="失败重试次数">
-                  <Input
-                    variant="filled"
-                    disabled={!scheduleEnabled}
-                    defaultValue="2"
-                  />
-                </PanelField>
+                <PanelField label="调度周期"><Select variant="filled" className="w-full" disabled={!scheduleEnabled} defaultValue="daily" options={[{ label: '每天', value: 'daily' }, { label: '每小时', value: 'hourly' }, { label: '每周', value: 'weekly' }]} /></PanelField>
+                <PanelField label="Cron 表达式"><Input variant="filled" disabled={!scheduleEnabled} defaultValue="0 0 2 * * ?" /></PanelField>
+                <PanelField label="失败重试次数"><Input variant="filled" disabled={!scheduleEnabled} defaultValue="2" /></PanelField>
               </>
             )}
           </div>
@@ -264,54 +195,16 @@ const RightPanel = () => {
         {rightPanel === 'version' && (
           <div className="space-y-1">
             {[
-              {
-                version: `r${document.revision}`,
-                description: document.dirty ? '当前未保存草稿' : '当前草稿',
-                time: '刚刚',
-                current: true,
-              },
-              {
-                version: `v${resource.publishedVersion ?? 0}`,
-                description: '最近发布版本',
-                time: resource.updatedAt,
-                current: false,
-              },
-              {
-                version: `r${Math.max(0, document.revision - 1)}`,
-                description: '上一个保存修订',
-                time: '08-04 08:36',
-                current: false,
-              },
+              { version: `r${document.revision}`, description: document.dirty ? '当前未保存草稿' : '当前草稿', time: '刚刚', current: true },
+              { version: `v${resource.publishedVersion ?? 0}`, description: '最近发布版本', time: resource.updatedAt, current: false },
+              { version: `r${Math.max(0, document.revision - 1)}`, description: '上一个保存修订', time: '08-04 08:36', current: false },
             ].map((item) => (
-              <div
-                key={`${item.version}-${item.description}`}
-                className="relative flex gap-3 border-l border-[#e4e7ec] pb-5 pl-4 last:pb-0"
-              >
-                <span
-                  className={[
-                    'absolute -left-[4px] top-1 h-[7px] w-[7px] rounded-full',
-                    item.current
-                      ? 'bg-[var(--yak-brand-color)]'
-                      : 'bg-[#c7cad0]',
-                  ].join(' ')}
-                />
+              <div key={`${item.version}-${item.description}`} className="relative flex gap-3 border-l border-[#e4e7ec] pb-5 pl-4 last:pb-0">
+                <span className={['absolute -left-[4px] top-1 h-[7px] w-[7px] rounded-full', item.current ? 'bg-[var(--yak-brand-color)]' : 'bg-[#c7cad0]'].join(' ')} />
                 <div className="min-w-0">
-                  <div className="flex items-center gap-2">
-                    <strong className="text-[12px] text-[#161823]">
-                      {item.version}
-                    </strong>
-                    {item.current && (
-                      <span className="rounded bg-[var(--yak-brand-color-soft)] px-1.5 py-0.5 text-[10px] text-[var(--yak-brand-color)]">
-                        当前
-                      </span>
-                    )}
-                  </div>
-                  <div className="mt-1 text-[12px] leading-5 text-[rgba(22,24,35,0.62)]">
-                    {item.description}
-                  </div>
-                  <div className="mt-1 text-[11px] text-[rgba(22,24,35,0.36)]">
-                    admin · {item.time}
-                  </div>
+                  <div className="flex items-center gap-2"><strong className="text-[12px] text-[#161823]">{item.version}</strong>{item.current && <span className="rounded bg-[var(--yak-brand-color-soft)] px-1.5 py-0.5 text-[10px] text-[var(--yak-brand-color)]">当前</span>}</div>
+                  <div className="mt-1 text-[12px] leading-5 text-[rgba(22,24,35,0.62)]">{item.description}</div>
+                  <div className="mt-1 text-[11px] text-[rgba(22,24,35,0.36)]">admin · {item.time}</div>
                 </div>
               </div>
             ))}


### PR DESCRIPTION
## Summary

- add a platform configuration center for runtime environments, AES-GCM encrypted secrets, reusable parameter templates and engine endpoints
- resolve environment, template and secret references immediately before task execution without persisting plaintext secrets in drafts, versions, execution snapshots, events or results
- add local-plugin, HTTP and TCP engine health probes
- add 24-hour operational metrics and durable audit records for platform, health-check and execution mutations
- connect the Workbench runtime panel to live environments, parameter templates and secret metadata
- add a permission-gated platform page plus architecture and security documentation

## Runtime resolution

```text
parameter template
  -> environment variables
  -> task runtime parameters
  -> execution input
```

Platform references are stored in `runtime.common`. Plaintext secrets only exist briefly in Worker memory under `secret`, for example `${secret.API_TOKEN}`.

## Platform capabilities

- runtime-environment CRUD with optimistic locking
- encrypted-secret CRUD using AES-256-GCM with a random IV and masked API responses
- reusable parameter-template CRUD
- engine endpoint CRUD and individual or bulk health checks
- local plugin, HTTP and TCP probe strategies
- 24-hour project, task, execution, failure, success-rate and engine-health metrics
- durable audit logs for configuration changes, health checks, execution creation and cancellation
- Workbench selection of environment, parameter template and runtime secret references

## Security and reliability

- production deployments must configure `YAK_DATA_DEVELOPMENT_PLATFORM_MASTER_KEY`
- secret plaintext and ciphertext are excluded from API responses and audit summaries
- execution snapshots persist only environment/template/secret references
- losing or changing the master key makes existing secrets undecryptable
- HTTP and TCP health probes use bounded timeouts
- execution create and cancel operations retain the authenticated operator in the audit log

## Validation

- Java 21 compilation-level checks passed for the changed platform sources against the existing contracts
- AES-GCM encryption/decryption smoke tests passed, including random-IV behavior
- TypeScript transpilation checks passed for the platform page, repository and Workbench changes
- the Flyway migration passed statement and parenthesis sanity checks
- GitHub compare confirms one focused commit based on the latest `main`

A full Maven reactor build, dependency-aware frontend build and real MySQL migration were not available in this execution environment. External HTTP/TCP engine probes also require the deployment integration environment and should be treated as final CI verification.

## Follow-up scope

External KMS or Vault integration, master-key rotation, scheduled health checks and alerts, project-scoped RBAC, environment promotion workflows, audit export and distributed engine routing remain intentionally out of scope.