### PR TITLE
feat(data-quality): schedule quality rules with Yak Schedule

### DIFF
--- a/docs/data-quality/execution-engine.md
+++ b/docs/data-quality/execution-engine.md
@@ -2,12 +2,11 @@
 
 ## Scope
 
-This phase turns persisted quality rules into real manual checks and replaces the quality-report mock data with durable execution records.
-
-The execution path is intentionally local and bounded:
+Persisted quality rules can be submitted manually or by Yak Schedule. Both paths create
+the same immutable execution snapshot and use the same bounded worker.
 
 ```text
-Quality rule page
+Quality rule / Yak Schedule
   -> create immutable execution snapshot
   -> dispatch after the database transaction commits
   -> bounded quality executor
@@ -17,7 +16,9 @@ Quality rule page
   -> quality report page
 ```
 
-Cron scheduling is not activated in this phase. Rules can still persist schedule configuration, while a later phase can dispatch the same execution snapshot with `trigger_type=SCHEDULE`.
+Manual attempts use `trigger_type=MANUAL`. Cron-triggered attempts use
+`trigger_type=SCHEDULE`. Schedule registration and reconciliation are documented in
+[`scheduling.md`](./scheduling.md).
 
 ## Persistence
 
@@ -45,13 +46,17 @@ A successful execution has a separate check result:
 - `PASSED`
 - `NOT_PASSED`
 
-Infrastructure, SQL, metadata or conversion failures use `execution_status=FAILED` and `check_result=UNKNOWN`.
+Infrastructure, SQL, metadata or conversion failures use
+`execution_status=FAILED` and `check_result=UNKNOWN`.
 
-Only one `WAITING` or `RUNNING` execution is accepted for a rule at a time. The rule row is locked while creating the snapshot so concurrent clicks cannot enqueue duplicate active attempts.
+Only one `WAITING` or `RUNNING` execution is accepted for a rule at a time. The rule
+row is locked while creating the snapshot so concurrent clicks or overlapping
+schedule triggers cannot enqueue duplicate active attempts.
 
 ## SQL strategies
 
-The engine obtains an identifier-quoted `SELECT` template from the datasource plugin Catalog, then compiles a read-only metric query:
+The engine obtains an identifier-quoted `SELECT` template from the datasource plugin
+Catalog, then compiles a read-only metric query:
 
 | Rule type | Metric |
 | --- | --- |
@@ -62,17 +67,22 @@ The engine obtains an identifier-quoted `SELECT` template from the datasource pl
 | `DATA_FRESHNESS` | age in hours from `MAX(timestamp_column)` |
 | `CUSTOM_SQL` | first value of the single-row metric result |
 
-All queries are routed through `DataSourceCatalogService`. The browser never receives datasource credentials, and the existing Catalog guard only permits a single `SELECT` statement.
+All queries are routed through `DataSourceCatalogService`. The browser never receives
+datasource credentials, and the existing Catalog guard only permits a single
+`SELECT` statement.
 
 ## Recovery and capacity
 
-The executor uses a bounded `ThreadPoolTaskExecutor`. Queue rejection is persisted as a failed execution rather than being silently lost.
+The executor uses a bounded `ThreadPoolTaskExecutor`. Queue rejection is persisted
+as a failed execution rather than being silently lost.
 
 On application startup:
 
-- interrupted `RUNNING` executions are marked failed because the local worker cannot safely resume an in-flight JDBC statement;
+- interrupted `RUNNING` executions are marked failed because the local worker cannot
+  safely resume an in-flight JDBC statement;
 - persisted `WAITING` executions are dispatched again in queue order;
-- the latest rule projection is repaired to `ERROR` for interrupted attempts.
+- the latest rule projection is repaired to `ERROR` for interrupted attempts;
+- Yak Schedule definitions are rebuilt from persisted scheduled rules.
 
 ## APIs
 
@@ -82,6 +92,11 @@ POST /api/v1/data-quality/execution/page
 GET  /api/v1/data-quality/execution/{executionNo}
 ```
 
+Scheduled execution is an internal handler path and does not expose a second public
+run API. This keeps permission checks and external commands focused on manual
+execution while Quartz uses the same business service internally.
+
 ## Follow-up
 
-The same execution snapshot can later be reused by a Yak Schedule dispatcher, distributed workers, cancellation, timeout policies and alert-channel adapters without changing the rule authoring contract.
+Distributed workers, cancellation, query timeout policy and alert-channel adapters
+can extend the execution layer without changing rule authoring or schedule identity.

--- a/docs/data-quality/scheduling.md
+++ b/docs/data-quality/scheduling.md
@@ -1,0 +1,84 @@
+# Data Quality Scheduling
+
+## Scope
+
+This phase connects persisted quality-rule Cron configuration to Yak Schedule.
+
+```text
+yak_quality_rule
+  -> QualityRuleScheduleRegistrar
+  -> Yak Schedule / Quartz
+  -> QualityRuleScheduleHandler
+  -> QualityExecutionService.runScheduled
+  -> immutable quality execution snapshot
+  -> bounded quality worker
+  -> quality report
+```
+
+Manual and scheduled checks share the same execution snapshot, worker, SQL compiler,
+metric evaluator and result persistence. Only the trigger type and operator differ.
+
+## Schedule identity
+
+Each rule owns one stable schedule:
+
+```text
+namespace: data-quality
+key:       rule-{ruleId}
+handler:   qualityRuleScheduleHandler
+```
+
+The payload stores `ruleId` as a string so schedule-definition equality is stable
+across JSON number implementations.
+
+## Reconciliation
+
+`JobScheduleRegistrationCoordinator` runs once during startup and periodically
+afterwards.
+
+For each persisted rule with `schedule_mode=SCHEDULE` and a valid Cron expression,
+the registrar:
+
+- creates the schedule when it is missing;
+- replaces it when Cron, enabled state or metadata changes;
+- pauses it by saving `enabled=false`;
+- deletes the Quartz schedule after the rule is deleted or switched to manual mode;
+- removes orphaned schedules in the `data-quality` namespace.
+
+This makes the quality-rule table the source of truth. A memory Quartz JobStore can
+therefore be rebuilt after every application restart. Production may switch Yak
+Schedule to a JDBC JobStore without changing quality business code.
+
+## Trigger policy
+
+Quality schedules use:
+
+- `ConcurrencyPolicy.FORBID`;
+- `MisfirePolicy.FIRE_ONCE_NOW`;
+- Framework trigger retries `0`.
+
+The quality execution layer also locks the rule row and checks for active
+`WAITING/RUNNING` executions. If a previous check is still active, the handler
+accepts the trigger as skipped instead of creating a duplicate execution.
+
+A trigger racing with rule disable, delete or a switch to manual mode is also
+accepted as skipped. The next reconciliation removes or pauses the obsolete
+schedule.
+
+## Cron validation
+
+Rule creation and update validate Cron expressions before persistence. Invalid
+custom Cron values are rejected by the quality-rule API instead of becoming a
+schedule that repeatedly fails registration.
+
+## Operations
+
+Scheduled attempts appear in the existing quality report with:
+
+```text
+triggerType = SCHEDULE
+operator    = yak-schedule
+```
+
+They use the same `WAITING -> RUNNING -> SUCCESS/FAILED` lifecycle and the same
+`PASSED/NOT_PASSED/UNKNOWN` quality result model as manual attempts.

--- a/yak-ops-business/yak-ops-business-job/README.md
+++ b/yak-ops-business/yak-ops-business-job/README.md
@@ -1,6 +1,7 @@
 # yak-ops-business-job
 
-Yak Ops 的业务调度聚合模块。时间触发统一委托给 Yak Framework `yak-schedule`，业务模块只负责注册计划和处理触发请求。
+Yak Ops 的业务调度聚合模块。时间触发统一委托给 Yak Framework
+`yak-schedule`，业务模块只负责注册计划和处理触发请求。
 
 ## 目录约定
 
@@ -9,24 +10,23 @@ io.yak.ops.business.job.schedule
 ├── JobScheduleRegistrar
 ├── JobScheduleRegistrationCoordinator
 ├── JobScheduleConfiguration
-└── offline
-    ├── OfflineSyncScheduleRegistrar
-    ├── OfflineSyncScheduleHandler
-    └── OfflineSyncScheduleConstants
+├── offline
+│   ├── OfflineSyncScheduleRegistrar
+│   ├── OfflineSyncScheduleHandler
+│   └── OfflineSyncScheduleConstants
+└── quality
+    ├── QualityRuleScheduleRegistrar
+    ├── QualityRuleScheduleHandler
+    └── QualityScheduleConstants
 ```
 
-后续工作流和数据质量分别新增独立目录与注册器：
+后续工作流可以按相同方式新增独立目录与注册器。不要把业务状态机、
+Worker 选择或业务失败重试放进调度模块。
 
-```text
-schedule/workflow/WorkflowScheduleRegistrar
-schedule/quality/QualityScheduleRegistrar
-```
+## 离线同步接入
 
-不要把业务状态机、Worker 选择和业务失败重试放进调度模块。
-
-## 当前离线同步接入
-
-`OfflineSyncScheduleRegistrar` 周期性读取 `yak_offline_schedule`，将 Cron 计划同步到 Framework：
+`OfflineSyncScheduleRegistrar` 周期性读取 `yak_offline_schedule`，将 Cron
+计划同步到 Framework：
 
 - namespace：`offline-sync`
 - handler：`offlineSyncScheduleHandler`
@@ -34,7 +34,24 @@ schedule/quality/QualityScheduleRegistrar
 - Misfire：`FIRE_ONCE_NOW`
 - Framework 触发重试：`0`
 
-离线同步原有的失败重试、重试退避、执行对账和 Worker 调度仍由 offline-sync 模块负责。
+离线同步原有的失败重试、重试退避、执行对账和 Worker 调度仍由
+offline-sync 模块负责。
+
+## 数据质量接入
+
+`QualityRuleScheduleRegistrar` 周期性读取定时质量规则，将 Cron 计划同步到
+Framework：
+
+- namespace：`data-quality`
+- key：`rule-{ruleId}`
+- handler：`qualityRuleScheduleHandler`
+- 并发策略：`FORBID`
+- Misfire：`FIRE_ONCE_NOW`
+- Framework 触发重试：`0`
+
+Quartz 只负责时间触发。规则快照、活动执行防重、SQL 检查、指标判断和结果
+持久化仍由 `yak-ops-business-quality` 负责。规则停用、删除或切换成手动执行后，
+周期性对账会暂停或删除对应计划。
 
 ## 配置
 
@@ -63,4 +80,5 @@ yak:
       zone-id: Asia/Shanghai
 ```
 
-生产环境可将 `spring.quartz.job-store-type` 调整为 `jdbc` 并配置 Quartz 集群表。
+生产环境可将 `spring.quartz.job-store-type` 调整为 `jdbc` 并配置 Quartz
+集群表。

--- a/yak-ops-business/yak-ops-business-job/pom.xml
+++ b/yak-ops-business/yak-ops-business-job/pom.xml
@@ -26,6 +26,10 @@
             <artifactId>yak-ops-business-sync-offline</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.yak.ops</groupId>
+            <artifactId>yak-ops-business-quality</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.yak.framework</groupId>
             <artifactId>yak-schedule-spring-boot-starter</artifactId>
         </dependency>

--- a/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/schedule/quality/QualityRuleScheduleHandler.java
+++ b/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/schedule/quality/QualityRuleScheduleHandler.java
@@ -1,0 +1,38 @@
+package io.yak.ops.business.job.schedule.quality;
+
+import io.yak.framework.schedule.api.ScheduleExecutionContext;
+import io.yak.framework.schedule.api.ScheduleExecutionResult;
+import io.yak.framework.schedule.api.ScheduleHandler;
+import io.yak.ops.business.quality.config.ConditionalOnQualityEnabled;
+import io.yak.ops.business.quality.service.QualityExecutionService;
+import io.yak.ops.business.quality.service.QualityExecutionService.ScheduledSubmission;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+@Component(QualityScheduleConstants.HANDLER_NAME)
+@ConditionalOnQualityEnabled
+@ConditionalOnProperty(
+    prefix = "yak.job.schedule",
+    name = "enabled",
+    havingValue = "true",
+    matchIfMissing = true)
+public class QualityRuleScheduleHandler implements ScheduleHandler {
+
+  private final QualityExecutionService executionService;
+
+  public QualityRuleScheduleHandler(QualityExecutionService executionService) {
+    this.executionService = executionService;
+  }
+
+  @Override
+  public ScheduleExecutionResult execute(ScheduleExecutionContext context) {
+    Long ruleId = context.requiredLong(QualityScheduleConstants.PAYLOAD_RULE_ID);
+    ScheduledSubmission submission = executionService.runScheduled(ruleId);
+    if (!submission.submitted()) {
+      return ScheduleExecutionResult.accepted(null, submission.message());
+    }
+    return ScheduleExecutionResult.accepted(
+        submission.execution().id(),
+        submission.message());
+  }
+}

--- a/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/schedule/quality/QualityRuleScheduleRegistrar.java
+++ b/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/schedule/quality/QualityRuleScheduleRegistrar.java
@@ -1,0 +1,112 @@
+package io.yak.ops.business.job.schedule.quality;
+
+import io.yak.framework.schedule.api.ConcurrencyPolicy;
+import io.yak.framework.schedule.api.MisfirePolicy;
+import io.yak.framework.schedule.api.ScheduleDefinition;
+import io.yak.framework.schedule.api.ScheduleKey;
+import io.yak.framework.schedule.api.ScheduleManager;
+import io.yak.framework.schedule.api.SchedulePolicy;
+import io.yak.framework.schedule.api.ScheduleSnapshot;
+import io.yak.framework.schedule.api.ScheduleTarget;
+import io.yak.framework.schedule.api.ScheduleTrigger;
+import io.yak.ops.business.job.schedule.JobScheduleProperties;
+import io.yak.ops.business.job.schedule.JobScheduleRegistrar;
+import io.yak.ops.business.quality.api.QualityScheduleApi.ScheduleRule;
+import io.yak.ops.business.quality.config.ConditionalOnQualityEnabled;
+import io.yak.ops.business.quality.service.QualityScheduleService;
+import java.time.ZoneId;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+@Component
+@ConditionalOnQualityEnabled
+@ConditionalOnProperty(
+    prefix = "yak.job.schedule",
+    name = "enabled",
+    havingValue = "true",
+    matchIfMissing = true)
+public class QualityRuleScheduleRegistrar implements JobScheduleRegistrar {
+
+  private final ScheduleManager scheduleManager;
+  private final QualityScheduleService scheduleService;
+  private final JobScheduleProperties properties;
+
+  public QualityRuleScheduleRegistrar(
+      ScheduleManager scheduleManager,
+      QualityScheduleService scheduleService,
+      JobScheduleProperties properties) {
+    this.scheduleManager = scheduleManager;
+    this.scheduleService = scheduleService;
+    this.properties = properties;
+  }
+
+  @Override
+  public String registrationType() {
+    return QualityScheduleConstants.NAMESPACE;
+  }
+
+  @Override
+  public void synchronize() {
+    List<ScheduleRule> records = scheduleService.findAllSchedules();
+    Set<ScheduleKey> desiredKeys = new LinkedHashSet<>();
+
+    for (ScheduleRule record : records) {
+      if (!StringUtils.hasText(record.cronExpression())) {
+        continue;
+      }
+      ScheduleDefinition desired = definition(record);
+      desiredKeys.add(desired.key());
+
+      Optional<ScheduleSnapshot> current = scheduleManager.get(desired.key());
+      if (current.isEmpty()
+          || !desired.equals(current.get().definition())) {
+        scheduleManager.save(desired);
+      }
+    }
+
+    for (ScheduleSnapshot snapshot :
+        scheduleManager.list(QualityScheduleConstants.NAMESPACE)) {
+      if (!desiredKeys.contains(snapshot.definition().key())) {
+        scheduleManager.delete(snapshot.definition().key());
+      }
+    }
+  }
+
+  ScheduleDefinition definition(ScheduleRule record) {
+    Long ruleId = record.ruleId();
+    String ruleName = StringUtils.hasText(record.ruleName())
+        ? record.ruleName().trim()
+        : String.valueOf(ruleId);
+    return new ScheduleDefinition(
+        QualityScheduleConstants.key(ruleId),
+        "数据质量规则 " + ruleName,
+        ScheduleTrigger.cron(record.cronExpression(), zoneId()),
+        new ScheduleTarget(
+            QualityScheduleConstants.HANDLER_NAME,
+            Map.of(
+                QualityScheduleConstants.PAYLOAD_RULE_ID,
+                ruleId.toString())),
+        new SchedulePolicy(
+            ConcurrencyPolicy.FORBID,
+            MisfirePolicy.FIRE_ONCE_NOW,
+            0),
+        record.enabled(),
+        Map.of(
+            "businessType", "DATA_QUALITY",
+            "ruleId", ruleId.toString()));
+  }
+
+  private ZoneId zoneId() {
+    String configured = properties.getZoneId();
+    return ZoneId.of(
+        StringUtils.hasText(configured)
+            ? configured.trim()
+            : "Asia/Shanghai");
+  }
+}

--- a/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/schedule/quality/QualityScheduleConstants.java
+++ b/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/schedule/quality/QualityScheduleConstants.java
@@ -1,0 +1,20 @@
+package io.yak.ops.business.job.schedule.quality;
+
+import io.yak.framework.schedule.api.ScheduleKey;
+
+public final class QualityScheduleConstants {
+
+  public static final String NAMESPACE = "data-quality";
+  public static final String HANDLER_NAME = "qualityRuleScheduleHandler";
+  public static final String PAYLOAD_RULE_ID = "ruleId";
+
+  private QualityScheduleConstants() {
+  }
+
+  public static ScheduleKey key(Long ruleId) {
+    if (ruleId == null || ruleId <= 0L) {
+      throw new IllegalArgumentException("ruleId must be positive");
+    }
+    return new ScheduleKey(NAMESPACE, "rule-" + ruleId);
+  }
+}

--- a/yak-ops-business/yak-ops-business-job/src/test/java/io/yak/ops/business/job/schedule/quality/QualityRuleScheduleHandlerTest.java
+++ b/yak-ops-business/yak-ops-business-job/src/test/java/io/yak/ops/business/job/schedule/quality/QualityRuleScheduleHandlerTest.java
@@ -1,0 +1,93 @@
+package io.yak.ops.business.job.schedule.quality;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.yak.framework.schedule.api.ScheduleExecutionContext;
+import io.yak.framework.schedule.api.ScheduleExecutionResult;
+import io.yak.ops.business.quality.api.QualityExecutionApi.CheckResult;
+import io.yak.ops.business.quality.api.QualityExecutionApi.ExecutionStatus;
+import io.yak.ops.business.quality.api.QualityExecutionApi.ExecutionView;
+import io.yak.ops.business.quality.api.QualityExecutionApi.TriggerType;
+import io.yak.ops.business.quality.api.QualityRuleApi.RuleType;
+import io.yak.ops.business.quality.service.QualityExecutionService;
+import io.yak.ops.business.quality.service.QualityExecutionService.ScheduledSubmission;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class QualityRuleScheduleHandlerTest {
+
+  @Test
+  void createsScheduledQualityExecution() {
+    QualityExecutionService service = mock(QualityExecutionService.class);
+    ExecutionView execution = new ExecutionView(
+        "QE-1001",
+        "42",
+        "用户表行数",
+        "业务库",
+        "yak_ops.user_info",
+        RuleType.TABLE_ROW_COUNT,
+        TriggerType.SCHEDULE,
+        ExecutionStatus.WAITING,
+        CheckResult.UNKNOWN,
+        null,
+        "> 0 行",
+        LocalDateTime.of(2026, 8, 4, 23, 0),
+        null,
+        null,
+        null,
+        "yak-schedule",
+        null,
+        null);
+    when(service.runScheduled(42L))
+        .thenReturn(new ScheduledSubmission(
+            execution,
+            true,
+            "数据质量检查已提交"));
+
+    QualityRuleScheduleHandler handler =
+        new QualityRuleScheduleHandler(service);
+    ScheduleExecutionContext context = context(42L);
+
+    ScheduleExecutionResult result = handler.execute(context);
+
+    verify(service).runScheduled(42L);
+    assertThat(result.accepted()).isTrue();
+    assertThat(result.businessExecutionId()).isEqualTo("QE-1001");
+  }
+
+  @Test
+  void acceptsSkippedTriggerWithoutCreatingDuplicateExecution() {
+    QualityExecutionService service = mock(QualityExecutionService.class);
+    when(service.runScheduled(42L))
+        .thenReturn(new ScheduledSubmission(
+            null,
+            false,
+            "上一轮质量检查仍在运行，本次调度已跳过"));
+
+    ScheduleExecutionResult result =
+        new QualityRuleScheduleHandler(service).execute(context(42L));
+
+    assertThat(result.accepted()).isTrue();
+    assertThat(result.businessExecutionId()).isNull();
+  }
+
+  private static ScheduleExecutionContext context(long ruleId) {
+    return new ScheduleExecutionContext(
+        "trigger-1",
+        QualityScheduleConstants.key(ruleId),
+        "quartz",
+        QualityScheduleConstants.HANDLER_NAME,
+        Map.of(
+            QualityScheduleConstants.PAYLOAD_RULE_ID,
+            String.valueOf(ruleId)),
+        Instant.parse("2026-08-04T15:00:00Z"),
+        Instant.parse("2026-08-04T15:00:01Z"),
+        false,
+        1);
+  }
+}

--- a/yak-ops-business/yak-ops-business-job/src/test/java/io/yak/ops/business/job/schedule/quality/QualityRuleScheduleRegistrarTest.java
+++ b/yak-ops-business/yak-ops-business-job/src/test/java/io/yak/ops/business/job/schedule/quality/QualityRuleScheduleRegistrarTest.java
@@ -1,0 +1,102 @@
+package io.yak.ops.business.job.schedule.quality;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.yak.framework.schedule.api.ConcurrencyPolicy;
+import io.yak.framework.schedule.api.ScheduleDefinition;
+import io.yak.framework.schedule.api.ScheduleManager;
+import io.yak.framework.schedule.api.ScheduleSnapshot;
+import io.yak.framework.schedule.api.ScheduleStatus;
+import io.yak.ops.business.job.schedule.JobScheduleProperties;
+import io.yak.ops.business.quality.api.QualityScheduleApi.ScheduleRule;
+import io.yak.ops.business.quality.service.QualityScheduleService;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class QualityRuleScheduleRegistrarTest {
+
+  @Test
+  void registersQualityCronWithNonConcurrentPolicy() {
+    ScheduleManager manager = mock(ScheduleManager.class);
+    QualityScheduleService service = mock(QualityScheduleService.class);
+    JobScheduleProperties properties = new JobScheduleProperties();
+    properties.setZoneId("Asia/Shanghai");
+
+    ScheduleRule record =
+        new ScheduleRule(42L, "用户表行数", "0 0/5 * * * ?", true);
+    when(service.findAllSchedules()).thenReturn(List.of(record));
+    when(manager.get(QualityScheduleConstants.key(42L)))
+        .thenReturn(Optional.empty());
+    when(manager.save(any(ScheduleDefinition.class)))
+        .thenAnswer(invocation -> {
+          ScheduleDefinition definition = invocation.getArgument(0);
+          return new ScheduleSnapshot(
+              definition,
+              "quartz",
+              definition.key().value(),
+              ScheduleStatus.ENABLED,
+              Instant.parse("2026-08-04T15:00:00Z"),
+              null);
+        });
+    when(manager.list(QualityScheduleConstants.NAMESPACE))
+        .thenReturn(List.of());
+
+    new QualityRuleScheduleRegistrar(manager, service, properties)
+        .synchronize();
+
+    ArgumentCaptor<ScheduleDefinition> captor =
+        ArgumentCaptor.forClass(ScheduleDefinition.class);
+    verify(manager).save(captor.capture());
+
+    ScheduleDefinition definition = captor.getValue();
+    assertThat(definition.key())
+        .isEqualTo(QualityScheduleConstants.key(42L));
+    assertThat(definition.trigger().expression())
+        .isEqualTo("0 0/5 * * * ?");
+    assertThat(definition.trigger().zoneId())
+        .isEqualTo(ZoneId.of("Asia/Shanghai"));
+    assertThat(definition.target().handler())
+        .isEqualTo(QualityScheduleConstants.HANDLER_NAME);
+    assertThat(definition.target().payload())
+        .containsEntry(QualityScheduleConstants.PAYLOAD_RULE_ID, "42");
+    assertThat(definition.policy().concurrencyPolicy())
+        .isEqualTo(ConcurrencyPolicy.FORBID);
+    assertThat(definition.policy().triggerRetries()).isZero();
+    assertThat(definition.enabled()).isTrue();
+  }
+
+  @Test
+  void removesQuartzSchedulesAfterRuleStopsBeingScheduled() {
+    ScheduleManager manager = mock(ScheduleManager.class);
+    QualityScheduleService service = mock(QualityScheduleService.class);
+    JobScheduleProperties properties = new JobScheduleProperties();
+
+    QualityRuleScheduleRegistrar registrar =
+        new QualityRuleScheduleRegistrar(manager, service, properties);
+    ScheduleDefinition orphan = registrar.definition(
+        new ScheduleRule(99L, "孤立规则", "0 0 2 * * ?", true));
+
+    when(service.findAllSchedules()).thenReturn(List.of());
+    when(manager.list(QualityScheduleConstants.NAMESPACE))
+        .thenReturn(List.of(
+            new ScheduleSnapshot(
+                orphan,
+                "quartz",
+                orphan.key().value(),
+                ScheduleStatus.ENABLED,
+                null,
+                null)));
+
+    registrar.synchronize();
+
+    verify(manager).delete(orphan.key());
+  }
+}

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/api/QualityScheduleApi.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/api/QualityScheduleApi.java
@@ -1,0 +1,14 @@
+package io.yak.ops.business.quality.api;
+
+public final class QualityScheduleApi {
+
+  private QualityScheduleApi() {
+  }
+
+  public record ScheduleRule(
+      Long ruleId,
+      String ruleName,
+      String cronExpression,
+      boolean enabled) {
+  }
+}

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/config/QualityConfiguration.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/config/QualityConfiguration.java
@@ -9,9 +9,11 @@ import io.yak.ops.business.quality.execution.QualityMetricEvaluator;
 import io.yak.ops.business.quality.execution.QualitySqlCompiler;
 import io.yak.ops.business.quality.repository.QualityExecutionRepository;
 import io.yak.ops.business.quality.repository.QualityRuleRepository;
+import io.yak.ops.business.quality.repository.QualityScheduleRepository;
 import io.yak.ops.business.quality.service.QualityExecutionService;
 import io.yak.ops.business.quality.service.QualityExecutionStateService;
 import io.yak.ops.business.quality.service.QualityRuleService;
+import io.yak.ops.business.quality.service.QualityScheduleService;
 import javax.sql.DataSource;
 import org.flywaydb.core.Flyway;
 import org.flywaydb.core.api.MigrationVersion;
@@ -92,6 +94,12 @@ public class QualityConfiguration {
   }
 
   @Bean
+  public QualityScheduleRepository qualityScheduleRepository(
+      @Qualifier("qualityJdbcTemplate") NamedParameterJdbcTemplate jdbcTemplate) {
+    return new QualityScheduleRepository(jdbcTemplate);
+  }
+
+  @Bean
   public QualityExecutionRepository qualityExecutionRepository(
       @Qualifier("qualityJdbcTemplate") NamedParameterJdbcTemplate jdbcTemplate) {
     return new QualityExecutionRepository(jdbcTemplate);
@@ -100,6 +108,12 @@ public class QualityConfiguration {
   @Bean
   public QualityRuleService qualityRuleService(QualityRuleRepository repository) {
     return new QualityRuleService(repository);
+  }
+
+  @Bean
+  public QualityScheduleService qualityScheduleService(
+      QualityScheduleRepository repository) {
+    return new QualityScheduleService(repository);
   }
 
   @Bean

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/repository/QualityScheduleRepository.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/repository/QualityScheduleRepository.java
@@ -1,0 +1,34 @@
+package io.yak.ops.business.quality.repository;
+
+import io.yak.ops.business.quality.api.QualityScheduleApi.ScheduleRule;
+import java.util.List;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+
+public class QualityScheduleRepository {
+
+  private final NamedParameterJdbcTemplate jdbcTemplate;
+
+  public QualityScheduleRepository(NamedParameterJdbcTemplate jdbcTemplate) {
+    this.jdbcTemplate = jdbcTemplate;
+  }
+
+  public List<ScheduleRule> findAllSchedules() {
+    return jdbcTemplate.query(
+        """
+        SELECT id, rule_name, cron_expression, enabled
+        FROM yak_quality_rule
+        WHERE deleted = 0
+          AND schedule_mode = 'SCHEDULE'
+          AND cron_expression IS NOT NULL
+          AND TRIM(cron_expression) <> ''
+        ORDER BY id
+        """,
+        new MapSqlParameterSource(),
+        (rs, rowNum) -> new ScheduleRule(
+            rs.getLong("id"),
+            rs.getString("rule_name"),
+            rs.getString("cron_expression"),
+            rs.getBoolean("enabled")));
+  }
+}

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/service/QualityExecutionService.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/service/QualityExecutionService.java
@@ -4,7 +4,9 @@ import io.yak.ops.business.quality.api.QualityExecutionApi.ExecutionPageRequest;
 import io.yak.ops.business.quality.api.QualityExecutionApi.ExecutionPageView;
 import io.yak.ops.business.quality.api.QualityExecutionApi.ExecutionView;
 import io.yak.ops.business.quality.api.QualityExecutionApi.TriggerType;
+import io.yak.ops.business.quality.api.QualityRuleApi.ComparisonOperator;
 import io.yak.ops.business.quality.api.QualityRuleApi.RuleView;
+import io.yak.ops.business.quality.api.QualityRuleApi.ScheduleMode;
 import io.yak.ops.business.quality.execution.QualityExecutionGateway;
 import io.yak.ops.business.quality.execution.QualityMetricEvaluator;
 import io.yak.ops.business.quality.repository.QualityExecutionRepository;
@@ -12,6 +14,7 @@ import io.yak.ops.business.quality.repository.QualityExecutionRepository.PageRes
 import io.yak.ops.business.quality.repository.QualityRuleRepository;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronization;
@@ -21,6 +24,7 @@ public class QualityExecutionService {
 
   private static final DateTimeFormatter EXECUTION_TIME =
       DateTimeFormatter.ofPattern("yyyyMMddHHmmssSSS");
+  private static final String SCHEDULE_OPERATOR = "yak-schedule";
 
   private final QualityRuleRepository ruleRepository;
   private final QualityExecutionRepository executionRepository;
@@ -48,27 +52,32 @@ public class QualityExecutionService {
     if (executionRepository.hasActiveExecution(ruleId)) {
       throw new IllegalStateException("该质量规则已有运行中的检查任务");
     }
+    return createExecution(rule, TriggerType.MANUAL, normalizeOperator(operator));
+  }
 
-    LocalDateTime queuedAt = LocalDateTime.now();
-    String executionNo = executionNo(queuedAt);
-    String expectedDisplay = evaluator.expectedValue(
-        io.yak.ops.business.quality.api.QualityRuleApi.ComparisonOperator.fromSymbol(
-            rule.operator()),
-        rule.threshold(),
-        rule.thresholdEnd(),
-        rule.unit());
-    long executionId = executionRepository.insert(
-        executionNo,
-        rule,
-        TriggerType.MANUAL,
-        normalizeOperator(operator),
-        objectName(rule),
-        expectedDisplay,
-        queuedAt);
-    ruleRepository.markExecutionStarted(ruleId, queuedAt);
-    dispatchAfterCommit(executionId);
-    return executionRepository.findByExecutionNo(executionNo)
-        .orElseThrow(() -> new IllegalStateException("质量检查已创建，但执行记录不可见"));
+  @Transactional(transactionManager = "qualityTransactionManager")
+  public ScheduledSubmission runScheduled(long ruleId) {
+    Optional<RuleView> optionalRule = ruleRepository.findByIdForUpdate(ruleId);
+    if (optionalRule.isEmpty()) {
+      return ScheduledSubmission.skipped("质量规则不存在或已删除，本次调度已跳过");
+    }
+
+    RuleView rule = optionalRule.get();
+    if (!rule.enabled()) {
+      return ScheduledSubmission.skipped("质量规则已停用，本次调度已跳过");
+    }
+    if (rule.scheduleMode() != ScheduleMode.SCHEDULE
+        || rule.cronExpression() == null
+        || rule.cronExpression().isBlank()) {
+      return ScheduledSubmission.skipped("质量规则已切换为手动执行，本次调度已跳过");
+    }
+    if (executionRepository.hasActiveExecution(ruleId)) {
+      return ScheduledSubmission.skipped("上一轮质量检查仍在运行，本次调度已跳过");
+    }
+
+    ExecutionView execution =
+        createExecution(rule, TriggerType.SCHEDULE, SCHEDULE_OPERATOR);
+    return ScheduledSubmission.submitted(execution);
   }
 
   @Transactional(readOnly = true, transactionManager = "qualityTransactionManager")
@@ -87,6 +96,32 @@ public class QualityExecutionService {
     return executionRepository.findByExecutionNo(executionNo)
         .orElseThrow(
             () -> new IllegalArgumentException("质量执行记录不存在：" + executionNo));
+  }
+
+  private ExecutionView createExecution(
+      RuleView rule,
+      TriggerType triggerType,
+      String operator) {
+    long ruleId = Long.parseLong(rule.id());
+    LocalDateTime queuedAt = LocalDateTime.now();
+    String executionNo = executionNo(queuedAt);
+    String expectedDisplay = evaluator.expectedValue(
+        ComparisonOperator.fromSymbol(rule.operator()),
+        rule.threshold(),
+        rule.thresholdEnd(),
+        rule.unit());
+    long executionId = executionRepository.insert(
+        executionNo,
+        rule,
+        triggerType,
+        operator,
+        objectName(rule),
+        expectedDisplay,
+        queuedAt);
+    ruleRepository.markExecutionStarted(ruleId, queuedAt);
+    dispatchAfterCommit(executionId);
+    return executionRepository.findByExecutionNo(executionNo)
+        .orElseThrow(() -> new IllegalStateException("质量检查已创建，但执行记录不可见"));
   }
 
   private void dispatchAfterCommit(long executionId) {
@@ -121,5 +156,22 @@ public class QualityExecutionService {
 
   private static String normalizeOperator(String operator) {
     return operator == null || operator.isBlank() ? "system" : operator.trim();
+  }
+
+  public record ScheduledSubmission(
+      ExecutionView execution,
+      boolean submitted,
+      String message) {
+
+    public static ScheduledSubmission submitted(ExecutionView execution) {
+      if (execution == null) {
+        throw new IllegalArgumentException("execution must not be null");
+      }
+      return new ScheduledSubmission(execution, true, "数据质量检查已提交");
+    }
+
+    public static ScheduledSubmission skipped(String message) {
+      return new ScheduledSubmission(null, false, message);
+    }
   }
 }

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/service/QualityRuleService.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/service/QualityRuleService.java
@@ -12,6 +12,7 @@ import io.yak.ops.business.quality.repository.QualityRuleRepository;
 import io.yak.ops.business.quality.repository.QualityRuleRepository.PageResult;
 import io.yak.ops.business.quality.repository.QualityRuleRepository.RuleWrite;
 import java.math.BigDecimal;
+import org.springframework.scheduling.support.CronExpression;
 import org.springframework.transaction.annotation.Transactional;
 
 public class QualityRuleService {
@@ -178,7 +179,18 @@ public class QualityRuleService {
       }
       default -> throw new IllegalArgumentException("不支持的调度周期：" + preset);
     };
+    validateCron(cron);
     return new ScheduleValues(preset, cron);
+  }
+
+  private void validateCron(String cron) {
+    try {
+      CronExpression.parse(cron);
+    } catch (IllegalArgumentException exception) {
+      throw new IllegalArgumentException(
+          "Cron 表达式不合法：" + exception.getMessage(),
+          exception);
+    }
   }
 
   private RuleView requireRule(long id) {

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/service/QualityScheduleService.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/service/QualityScheduleService.java
@@ -1,0 +1,22 @@
+package io.yak.ops.business.quality.service;
+
+import io.yak.ops.business.quality.api.QualityScheduleApi.ScheduleRule;
+import io.yak.ops.business.quality.repository.QualityScheduleRepository;
+import java.util.List;
+import org.springframework.transaction.annotation.Transactional;
+
+public class QualityScheduleService {
+
+  private final QualityScheduleRepository repository;
+
+  public QualityScheduleService(QualityScheduleRepository repository) {
+    this.repository = repository;
+  }
+
+  @Transactional(
+      readOnly = true,
+      transactionManager = "qualityTransactionManager")
+  public List<ScheduleRule> findAllSchedules() {
+    return repository.findAllSchedules();
+  }
+}

--- a/yak-ops-business/yak-ops-business-quality/src/test/java/io/yak/ops/business/quality/service/QualityExecutionScheduleTest.java
+++ b/yak-ops-business/yak-ops-business-quality/src/test/java/io/yak/ops/business/quality/service/QualityExecutionScheduleTest.java
@@ -1,0 +1,105 @@
+package io.yak.ops.business.quality.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.quality.api.QualityRuleApi.Importance;
+import io.yak.ops.business.quality.api.QualityRuleApi.RuleResult;
+import io.yak.ops.business.quality.api.QualityRuleApi.RuleScope;
+import io.yak.ops.business.quality.api.QualityRuleApi.RuleType;
+import io.yak.ops.business.quality.api.QualityRuleApi.RuleView;
+import io.yak.ops.business.quality.api.QualityRuleApi.ScheduleMode;
+import io.yak.ops.business.quality.execution.QualityExecutionGateway;
+import io.yak.ops.business.quality.execution.QualityMetricEvaluator;
+import io.yak.ops.business.quality.repository.QualityExecutionRepository;
+import io.yak.ops.business.quality.repository.QualityRuleRepository;
+import java.math.BigDecimal;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class QualityExecutionScheduleTest {
+
+  @Test
+  void skipsScheduledTriggerWhenPreviousExecutionIsStillActive() {
+    QualityRuleRepository ruleRepository = mock(QualityRuleRepository.class);
+    QualityExecutionRepository executionRepository =
+        mock(QualityExecutionRepository.class);
+    QualityExecutionGateway gateway = mock(QualityExecutionGateway.class);
+    QualityExecutionService service = new QualityExecutionService(
+        ruleRepository,
+        executionRepository,
+        new QualityMetricEvaluator(),
+        gateway);
+
+    when(ruleRepository.findByIdForUpdate(42L))
+        .thenReturn(Optional.of(scheduleRule(true)));
+    when(executionRepository.hasActiveExecution(42L)).thenReturn(true);
+
+    QualityExecutionService.ScheduledSubmission submission =
+        service.runScheduled(42L);
+
+    assertThat(submission.submitted()).isFalse();
+    assertThat(submission.message()).contains("上一轮");
+    verifyNoInteractions(gateway);
+  }
+
+  @Test
+  void skipsScheduledTriggerAfterRuleIsDisabled() {
+    QualityRuleRepository ruleRepository = mock(QualityRuleRepository.class);
+    QualityExecutionRepository executionRepository =
+        mock(QualityExecutionRepository.class);
+    QualityExecutionGateway gateway = mock(QualityExecutionGateway.class);
+    QualityExecutionService service = new QualityExecutionService(
+        ruleRepository,
+        executionRepository,
+        new QualityMetricEvaluator(),
+        gateway);
+
+    when(ruleRepository.findByIdForUpdate(42L))
+        .thenReturn(Optional.of(scheduleRule(false)));
+
+    QualityExecutionService.ScheduledSubmission submission =
+        service.runScheduled(42L);
+
+    assertThat(submission.submitted()).isFalse();
+    assertThat(submission.message()).contains("停用");
+    verifyNoInteractions(executionRepository, gateway);
+  }
+
+  private static RuleView scheduleRule(boolean enabled) {
+    return new RuleView(
+        "42",
+        "用户表行数",
+        null,
+        "1",
+        "业务库",
+        "yak_ops",
+        null,
+        "yak_ops",
+        "user_info",
+        null,
+        RuleScope.TABLE,
+        RuleType.TABLE_ROW_COUNT,
+        "完整性",
+        ">",
+        BigDecimal.ZERO,
+        null,
+        "行",
+        ScheduleMode.SCHEDULE,
+        "DAILY_0200",
+        "每天 02:00",
+        "0 0 2 * * ?",
+        enabled,
+        Importance.NORMAL,
+        RuleResult.NOT_RUN,
+        null,
+        null,
+        null,
+        "tester",
+        null,
+        null,
+        null);
+  }
+}

--- a/yak-ops-business/yak-ops-business-quality/src/test/java/io/yak/ops/business/quality/service/QualityRuleServiceTest.java
+++ b/yak-ops-business/yak-ops-business-quality/src/test/java/io/yak/ops/business/quality/service/QualityRuleServiceTest.java
@@ -25,6 +25,9 @@ class QualityRuleServiceTest {
         new BigDecimal("99"),
         null,
         null,
+        null,
+        ScheduleMode.MANUAL,
+        null,
         null);
 
     assertThrows(
@@ -41,6 +44,9 @@ class QualityRuleServiceTest {
         new BigDecimal("100"),
         new BigDecimal("10"),
         "age",
+        null,
+        ScheduleMode.MANUAL,
+        null,
         null);
 
     assertThrows(
@@ -57,7 +63,29 @@ class QualityRuleServiceTest {
         BigDecimal.ZERO,
         null,
         null,
+        null,
+        ScheduleMode.MANUAL,
+        null,
         null);
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> service.create(request, "tester"));
+    verifyNoInteractions(repository);
+  }
+
+  @Test
+  void rejectsInvalidCustomCronBeforePersistence() {
+    SaveRuleRequest request = request(
+        RuleType.TABLE_ROW_COUNT,
+        ">",
+        BigDecimal.ZERO,
+        null,
+        null,
+        null,
+        ScheduleMode.SCHEDULE,
+        "CUSTOM",
+        "not-a-cron");
 
     assertThrows(
         IllegalArgumentException.class,
@@ -71,7 +99,10 @@ class QualityRuleServiceTest {
       BigDecimal threshold,
       BigDecimal thresholdEnd,
       String columnName,
-      String customSql) {
+      String customSql,
+      ScheduleMode scheduleMode,
+      String schedulePreset,
+      String cronExpression) {
     return new SaveRuleRequest(
         "测试规则",
         null,
@@ -87,9 +118,9 @@ class QualityRuleServiceTest {
         operator,
         threshold,
         thresholdEnd,
-        ScheduleMode.MANUAL,
-        null,
-        null,
+        scheduleMode,
+        schedulePreset,
+        cronExpression,
         true,
         customSql);
   }


### PR DESCRIPTION
## 本次内容

完成数据质量第 3 步：将规则中的 Cron 配置接入 Yak Schedule，形成“规则配置 → 定时触发 → 真实检查 → 运行记录”的完整闭环。

### 调度注册

新增数据质量调度注册器与处理器：

```text
yak_quality_rule
  -> QualityRuleScheduleRegistrar
  -> Yak Schedule / Quartz
  -> QualityRuleScheduleHandler
  -> QualityExecutionService.runScheduled
  -> 质量执行快照与 Worker
  -> 质量报告
```

调度身份保持稳定：

- namespace：`data-quality`
- key：`rule-{ruleId}`
- handler：`qualityRuleScheduleHandler`
- payload：`ruleId`

调度策略：

- `ConcurrencyPolicy.FORBID`
- `MisfirePolicy.FIRE_ONCE_NOW`
- Framework 触发重试为 `0`

### 规则与计划对账

质量规则表继续作为调度事实源，不新增重复的调度配置表。现有业务调度协调器启动时和运行期间周期性对账：

- 新建定时规则：创建 Yak Schedule 计划
- 修改 Cron：替换计划定义
- 停用规则：保存为暂停状态
- 重新启用：恢复计划
- 切换为手动执行：删除计划
- 删除规则：删除孤立计划
- 服务重启：从规则表恢复全部计划

内存 Quartz JobStore 和后续 JDBC JobStore 均可复用这一套业务注册逻辑。

### 统一执行链路

手动执行和定时执行共用第 2 步中的执行快照、队列、SQL 编译、指标判断和结果持久化：

- 手动触发：`triggerType=MANUAL`
- 定时触发：`triggerType=SCHEDULE`
- 定时执行人：`yak-schedule`

同一规则创建执行时继续锁定规则行，并检查是否已有 `WAITING / RUNNING` 任务。上一轮未完成时，本轮调度会被安全跳过，不会生成重复执行。

调度触发与规则停用、删除或切换手动模式并发时，也会在业务层再次校验并安全跳过。

### Cron 校验

规则创建和编辑现在使用 Spring `CronExpression` 在持久化前验证 Cron。非法自定义表达式直接返回参数错误，不会形成持续注册失败的计划。

### 前端与报告

第 2 步的质量报告页面已经使用真实执行记录，并支持 `SCHEDULE` 触发类型，因此本阶段不重复改造页面。定时执行会直接出现在现有报告和详情 Drawer 中，展示状态、检查结果、指标、SQL、耗时和异常原因。

### 测试与文档

新增测试覆盖：

- Cron 计划注册、时区、Handler payload 和并发策略
- 规则切换或删除后的孤立计划清理
- Quartz 触发后创建 `SCHEDULE` 执行
- 上一轮仍在运行时安全跳过
- 规则停用后安全跳过
- 非法自定义 Cron 在落库前被拒绝

同步更新业务调度 README、执行引擎文档，并新增数据质量调度设计文档。

## 数据库

本阶段不需要新增 Flyway 迁移。`schedule_mode`、`cron_expression`、`enabled` 和执行记录的 `trigger_type` 已在前两阶段完成持久化。

## 验证说明

- 分支基于第 2 步合并后的最新 `main`，当前落后提交为 0
- 核对 Yak Framework `ScheduleDefinition` 与 `ScheduleExecutionResult` 实际 API
- Java 21 变更源码完成语法与结构检查
- Maven POM 通过 XML 解析
- 新增调度注册、Handler、Cron 校验和重复执行保护测试

当前环境没有完整 Maven Reactor、Quartz 运行环境和 MySQL 实例，因此未声明 Spring Context、真实 Quartz 触发及端到端数据源检查已通过；请以本地或 CI 的完整构建与联调结果作为最终准入依据。