### PR TITLE
refactor(workflow): define task separation and Workflow V2 contract

### DIFF
--- a/docs/workflow/task-workflow-separation.md
+++ b/docs/workflow/task-workflow-separation.md
@@ -1,0 +1,364 @@
+# Task 与 Workflow 职责分离及 Workflow V2 契约
+
+## 1. 目标
+
+Yak Ops 将任务开发与工作流编排拆成两个独立领域：
+
+```text
+Data Development Workbench
+  -> Task Draft
+  -> Immutable Task Version
+  -> Compiled Spec
+
+Workflow
+  -> reference immutable Task Version
+  -> bind inputs and outputs
+  -> orchestrate success and failure routes
+  -> control retry, timeout, pause and recovery
+```
+
+本阶段只建立职责边界和 Workflow V2 数据契约，不切换现有工作流持久化、设计器或执行引擎。
+
+## 2. 当前问题
+
+Workflow V1 节点同时保存了：
+
+- HTTP、Shell 等插件专属配置；
+- 节点重试、超时和失败处理；
+- 画布位置与上下游关系；
+- 插件身份和执行参数。
+
+数据开发工作台已经具备任务草稿、校验、发布版本和执行快照后，继续在工作流节点中维护任务配置会形成两个编辑入口，并带来以下问题：
+
+- 同一任务配置需要维护两份；
+- TaskPlugin 同时服务任务开发和工作流 UI；
+- 工作流无法稳定复现某次任务版本；
+- 任务升级可能隐式改变已发布工作流；
+- 重跑时难以确认使用的是哪一份任务定义。
+
+## 3. 职责边界
+
+### 3.1 Data Development / Task Authoring
+
+负责“任务是什么”：
+
+- 任务内容与插件专属配置；
+- 草稿、乐观锁和校验；
+- 测试运行；
+- 不可变发布版本；
+- Definition、Compiled Spec、Input Schema 和 Output Schema；
+- 环境、参数模板和密钥引用。
+
+任务内容的唯一编辑入口是数据开发工作台。
+
+### 3.2 TaskPlugin
+
+负责“任务如何被解释和执行”：
+
+- 默认 Definition；
+- Definition 标准化；
+- Definition 校验；
+- Compiled Spec 生成；
+- 输入输出 Schema；
+- 运行时执行与统一结果。
+
+TaskPlugin 不负责：
+
+- React Flow 节点和坐标；
+- 工作流连线；
+- 工作流节点 Panel；
+- 上下游路由；
+- 工作流失败策略和恢复策略。
+
+### 3.3 Workflow
+
+负责“任务如何被组织运行”：
+
+- 引用不可变 Task Version；
+- START、TASK、END 节点；
+- 节点依赖关系；
+- 输入输出映射；
+- SUCCESS 和 FAILURE 路由；
+- 节点级重试、超时和暂停策略；
+- 工作流发布、实例、节点实例和恢复操作。
+
+Workflow 不保存插件专属配置，不解释 HTTP、Shell、SQL 或其他任务内容。
+
+## 4. 依赖方向
+
+```text
+workflow definition
+  -> taskId + taskVersionId
+  -> task version snapshot
+  -> compiled spec
+  -> task execution gateway
+  -> task plugin / worker
+```
+
+允许的依赖：
+
+```text
+Workflow -> immutable Task Version contract
+Workflow Runtime -> Task Execution Gateway
+Task Execution Gateway -> TaskPlugin / Worker
+```
+
+禁止的依赖：
+
+```text
+Workflow UI -> HTTP/Shell/SQL configuration form
+Workflow Definition -> plugin-specific config JSON
+TaskPlugin -> React Flow node or workflow edge
+Task Authoring -> workflow runtime state
+```
+
+## 5. Workflow V2 核心原则
+
+### 5.1 版本固定
+
+TASK 节点必须保存：
+
+```text
+taskId
+taskVersionId
+taskVersionNumber
+taskType
+```
+
+`taskVersionId` 指向不可变发布版本。任务发布新版本后，现有工作流不会自动变化。工作流需要通过显式“升级版本”操作切换引用。
+
+### 5.2 只保存编排信息
+
+Workflow V2 节点不允许出现以下字段：
+
+```text
+config
+compiledSpec
+runtime secrets
+HTTP URL / headers / body
+Shell command / environment
+SQL text
+plugin-specific parameters
+```
+
+### 5.3 统一节点类型
+
+第一版定义三类节点：
+
+- `START`：声明工作流输入；
+- `TASK`：引用一个不可变 Task Version；
+- `END`：声明工作流输出。
+
+后续条件、并行、子工作流等控制节点可以扩展 `kind`，但不能重新引入任务配置。
+
+### 5.4 统一出口
+
+连线通过 `fromPort` 声明来源结果：
+
+- `SUCCESS`
+- `FAILURE`
+
+第一阶段中，超时和取消可由运行时统一映射到 FAILURE。未来如需暴露更多结果端口，应扩展端口枚举，而不是让 TaskPlugin 直接选择下游节点。
+
+### 5.5 输入输出映射
+
+绑定来源统一为：
+
+- `START_INPUT`
+- `NODE_OUTPUT`
+- `WORKFLOW_VARIABLE`
+- `LITERAL`
+
+Workflow 只根据任务发布版本中的 Input Schema 和 Output Schema 校验映射，不读取任务编辑 Definition。
+
+### 5.6 编排执行策略
+
+`executionPolicy` 只保存编排层参数：
+
+- `timeoutSeconds`
+- `retryTimes`
+- `retryIntervalSeconds`
+- `failureAction`
+
+`failureAction` 支持：
+
+- `FAIL_WORKFLOW`
+- `ROUTE_FAILURE`
+- `PAUSE`
+
+任务是否天然幂等、能否取消、结果类型等能力由 TaskPlugin 或 Task Version 声明，不在 Workflow 节点重复维护。
+
+## 6. Workflow V2 示例
+
+```json
+{
+  "schemaVersion": 2,
+  "nodes": [
+    {
+      "key": "start",
+      "name": "开始",
+      "kind": "START",
+      "positionX": 80,
+      "positionY": 220,
+      "enabled": true,
+      "inputBindings": [],
+      "outputBindings": {},
+      "executionPolicy": {
+        "timeoutSeconds": 0,
+        "retryTimes": 0,
+        "retryIntervalSeconds": 0,
+        "failureAction": "FAIL_WORKFLOW"
+      }
+    },
+    {
+      "key": "query-order",
+      "name": "查询订单",
+      "kind": "TASK",
+      "positionX": 380,
+      "positionY": 220,
+      "enabled": true,
+      "taskRef": {
+        "taskId": "1001",
+        "taskVersionId": "2003",
+        "taskVersionNumber": 3,
+        "taskType": "HTTP"
+      },
+      "inputBindings": [
+        {
+          "target": "orderId",
+          "source": {
+            "type": "START_INPUT",
+            "path": "$.orderId"
+          }
+        }
+      ],
+      "outputBindings": {},
+      "executionPolicy": {
+        "timeoutSeconds": 300,
+        "retryTimes": 2,
+        "retryIntervalSeconds": 10,
+        "failureAction": "ROUTE_FAILURE"
+      }
+    },
+    {
+      "key": "end",
+      "name": "结束",
+      "kind": "END",
+      "positionX": 700,
+      "positionY": 220,
+      "enabled": true,
+      "inputBindings": [],
+      "outputBindings": {
+        "order": {
+          "type": "NODE_OUTPUT",
+          "nodeKey": "query-order",
+          "path": "$.data"
+        }
+      },
+      "executionPolicy": {
+        "timeoutSeconds": 0,
+        "retryTimes": 0,
+        "retryIntervalSeconds": 0,
+        "failureAction": "FAIL_WORKFLOW"
+      }
+    }
+  ],
+  "edges": [
+    {
+      "from": "start",
+      "fromPort": "SUCCESS",
+      "to": "query-order"
+    },
+    {
+      "from": "query-order",
+      "fromPort": "SUCCESS",
+      "to": "end"
+    }
+  ],
+  "viewport": {
+    "x": 0,
+    "y": 0,
+    "zoom": 1
+  }
+}
+```
+
+规范化 JSON Schema 位于：
+
+```text
+docs/workflow/workflow-v2.schema.json
+```
+
+前后端类型镜像位于：
+
+```text
+yak-ops-common/.../workflow/v2/
+yak-ops-ui/src/pages/workflow-management/workflow-v2.types.ts
+```
+
+## 7. 必须满足的契约约束
+
+后续 V2 校验器必须保证：
+
+1. `schemaVersion == 2`；
+2. 节点 `key` 唯一；
+3. 至少存在一个 START 和一个 END；
+4. TASK 节点必须包含完整 `taskRef`；
+5. START 和 END 不得包含 `taskRef`；
+6. TASK 节点只能引用已发布、不可变的 Task Version；
+7. 工作流定义不得包含插件专属配置；
+8. Edge 的来源和目标节点必须存在；
+9. START 只能使用 SUCCESS 出口；
+10. FAILURE 出口只能从可执行节点产生；
+11. NODE_OUTPUT 只能引用拓扑上的上游节点；
+12. 必填任务输入必须完成绑定；
+13. `ROUTE_FAILURE` 必须存在 FAILURE 连线；
+14. 发布工作流时固化所有 Task Version 引用。
+
+本阶段只定义这些约束，实际校验和持久化切换在后续步骤实现。
+
+## 8. V1 兼容策略
+
+过渡期采用：
+
+```text
+V1 Reader
+V2 Reader
+V2 Writer（后续启用）
+```
+
+规则：
+
+- 当前 V1 持久化和执行逻辑保持不变；
+- 新增 V2 类型不会自动迁移旧数据；
+- 旧工作流继续按 V1 读取和运行；
+- 后续设计器切换后，新建工作流使用 V2；
+- 旧 HTTP/Shell 节点不能自动映射到某个真实 Task，应通过显式迁移向导选择任务；
+- 工作流发布版本和运行实例始终保留当时的完整 DAG 快照。
+
+## 9. 本阶段非目标
+
+本阶段不实现：
+
+- 工作流数据库迁移；
+- V2 API；
+- 左侧任务资源列表；
+- 任务拖拽；
+- Node Panel 重构；
+- 输入映射 UI；
+- V2 DAG 编译和执行；
+- SUCCESS / FAILURE 运行路由；
+- 节点重跑、暂停和恢复；
+- V1 自动迁移。
+
+## 10. 后续实施顺序
+
+1. 提供工作流任务资源查询接口；
+2. 增加 Workflow V2 持久化 Reader/Writer；
+3. 重构设计器为任务资源拖拽布局；
+4. 将节点配置 Panel 替换为编排 Panel；
+5. 实现输入输出映射；
+6. 通过统一 Task Execution Gateway 执行 Task Version；
+7. 实现 SUCCESS / FAILURE 路由；
+8. 实现重试、恢复和人工操作；
+9. 清理 Workflow V1 内嵌任务配置。

--- a/docs/workflow/workflow-v2.schema.json
+++ b/docs/workflow/workflow-v2.schema.json
@@ -1,0 +1,157 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://yak-ops.io/schemas/workflow-v2.schema.json",
+  "title": "Yak Ops Workflow V2 DAG",
+  "description": "Orchestration-only workflow definition referencing immutable published task versions.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schemaVersion", "nodes", "edges", "viewport"],
+  "properties": {
+    "schemaVersion": { "const": 2 },
+    "nodes": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/node" }
+    },
+    "edges": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/edge" }
+    },
+    "viewport": { "$ref": "#/$defs/viewport" }
+  },
+  "$defs": {
+    "node": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "key",
+        "name",
+        "kind",
+        "positionX",
+        "positionY",
+        "enabled",
+        "inputBindings",
+        "outputBindings",
+        "executionPolicy"
+      ],
+      "properties": {
+        "key": { "type": "string", "minLength": 1 },
+        "name": { "type": "string", "minLength": 1 },
+        "kind": { "enum": ["START", "TASK", "END"] },
+        "description": { "type": "string" },
+        "positionX": { "type": "number" },
+        "positionY": { "type": "number" },
+        "enabled": { "type": "boolean" },
+        "taskRef": { "$ref": "#/$defs/taskReference" },
+        "inputBindings": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/inputBinding" }
+        },
+        "outputBindings": {
+          "type": "object",
+          "additionalProperties": { "$ref": "#/$defs/bindingSource" }
+        },
+        "executionPolicy": { "$ref": "#/$defs/executionPolicy" }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": { "kind": { "const": "TASK" } },
+            "required": ["kind"]
+          },
+          "then": { "required": ["taskRef"] },
+          "else": { "not": { "required": ["taskRef"] } }
+        }
+      ]
+    },
+    "taskReference": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["taskId", "taskVersionId", "taskVersionNumber", "taskType"],
+      "properties": {
+        "taskId": { "type": "string", "minLength": 1 },
+        "taskVersionId": { "type": "string", "minLength": 1 },
+        "taskVersionNumber": { "type": "integer", "minimum": 1 },
+        "taskType": { "type": "string", "minLength": 1 }
+      }
+    },
+    "inputBinding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["target", "source"],
+      "properties": {
+        "target": { "type": "string", "minLength": 1 },
+        "source": { "$ref": "#/$defs/bindingSource" }
+      }
+    },
+    "bindingSource": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type"],
+      "properties": {
+        "type": {
+          "enum": ["START_INPUT", "NODE_OUTPUT", "WORKFLOW_VARIABLE", "LITERAL"]
+        },
+        "nodeKey": { "type": "string", "minLength": 1 },
+        "path": { "type": "string", "minLength": 1 },
+        "variableName": { "type": "string", "minLength": 1 },
+        "literalValue": true
+      },
+      "allOf": [
+        {
+          "if": { "properties": { "type": { "const": "START_INPUT" } } },
+          "then": { "required": ["path"] }
+        },
+        {
+          "if": { "properties": { "type": { "const": "NODE_OUTPUT" } } },
+          "then": { "required": ["nodeKey", "path"] }
+        },
+        {
+          "if": { "properties": { "type": { "const": "WORKFLOW_VARIABLE" } } },
+          "then": { "required": ["variableName"] }
+        },
+        {
+          "if": { "properties": { "type": { "const": "LITERAL" } } },
+          "then": { "required": ["literalValue"] }
+        }
+      ]
+    },
+    "executionPolicy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "timeoutSeconds",
+        "retryTimes",
+        "retryIntervalSeconds",
+        "failureAction"
+      ],
+      "properties": {
+        "timeoutSeconds": { "type": "integer", "minimum": 0 },
+        "retryTimes": { "type": "integer", "minimum": 0 },
+        "retryIntervalSeconds": { "type": "integer", "minimum": 0 },
+        "failureAction": {
+          "enum": ["FAIL_WORKFLOW", "ROUTE_FAILURE", "PAUSE"]
+        }
+      }
+    },
+    "edge": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["from", "fromPort", "to"],
+      "properties": {
+        "from": { "type": "string", "minLength": 1 },
+        "fromPort": { "enum": ["SUCCESS", "FAILURE"] },
+        "to": { "type": "string", "minLength": 1 }
+      }
+    },
+    "viewport": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["x", "y", "zoom"],
+      "properties": {
+        "x": { "type": "number" },
+        "y": { "type": "number" },
+        "zoom": { "type": "number", "exclusiveMinimum": 0 }
+      }
+    }
+  }
+}

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/entity/workflow/v2/WorkflowV2BindingSource.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/entity/workflow/v2/WorkflowV2BindingSource.java
@@ -1,0 +1,61 @@
+package io.yak.ops.common.bean.entity.workflow.v2;
+
+/** Source expression used by Workflow V2 input and end-output mappings. */
+public class WorkflowV2BindingSource {
+
+  public enum Type {
+    START_INPUT,
+    NODE_OUTPUT,
+    WORKFLOW_VARIABLE,
+    LITERAL
+  }
+
+  private Type type;
+  private String nodeKey;
+  private String path;
+  private String variableName;
+  private Object literalValue;
+
+  public WorkflowV2BindingSource() {
+  }
+
+  public Type getType() {
+    return type;
+  }
+
+  public void setType(Type type) {
+    this.type = type;
+  }
+
+  public String getNodeKey() {
+    return nodeKey;
+  }
+
+  public void setNodeKey(String nodeKey) {
+    this.nodeKey = nodeKey;
+  }
+
+  public String getPath() {
+    return path;
+  }
+
+  public void setPath(String path) {
+    this.path = path;
+  }
+
+  public String getVariableName() {
+    return variableName;
+  }
+
+  public void setVariableName(String variableName) {
+    this.variableName = variableName;
+  }
+
+  public Object getLiteralValue() {
+    return literalValue;
+  }
+
+  public void setLiteralValue(Object literalValue) {
+    this.literalValue = literalValue;
+  }
+}

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/entity/workflow/v2/WorkflowV2Dag.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/entity/workflow/v2/WorkflowV2Dag.java
@@ -1,0 +1,64 @@
+package io.yak.ops.common.bean.entity.workflow.v2;
+
+import io.yak.ops.common.bean.entity.workflow.WorkflowViewport;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Workflow V2 durable definition.
+ *
+ * <p>V2 stores orchestration metadata and immutable task-version references only. Task authoring
+ * content and plugin-specific configuration remain owned by data development.
+ */
+public class WorkflowV2Dag {
+
+  public static final int SCHEMA_VERSION = 2;
+
+  private int schemaVersion = SCHEMA_VERSION;
+  private List<WorkflowV2Node> nodes = new ArrayList<>();
+  private List<WorkflowV2Edge> edges = new ArrayList<>();
+  private WorkflowViewport viewport = new WorkflowViewport(0D, 0D, 1D);
+
+  public WorkflowV2Dag() {
+  }
+
+  public WorkflowV2Dag(List<WorkflowV2Node> nodes, List<WorkflowV2Edge> edges) {
+    setNodes(nodes);
+    setEdges(edges);
+  }
+
+  public int getSchemaVersion() {
+    return schemaVersion;
+  }
+
+  public void setSchemaVersion(int schemaVersion) {
+    if (schemaVersion != SCHEMA_VERSION) {
+      throw new IllegalArgumentException("WorkflowV2Dag schemaVersion must be 2");
+    }
+    this.schemaVersion = schemaVersion;
+  }
+
+  public List<WorkflowV2Node> getNodes() {
+    return nodes;
+  }
+
+  public void setNodes(List<WorkflowV2Node> nodes) {
+    this.nodes = nodes == null ? new ArrayList<>() : new ArrayList<>(nodes);
+  }
+
+  public List<WorkflowV2Edge> getEdges() {
+    return edges;
+  }
+
+  public void setEdges(List<WorkflowV2Edge> edges) {
+    this.edges = edges == null ? new ArrayList<>() : new ArrayList<>(edges);
+  }
+
+  public WorkflowViewport getViewport() {
+    return viewport;
+  }
+
+  public void setViewport(WorkflowViewport viewport) {
+    this.viewport = viewport == null ? new WorkflowViewport(0D, 0D, 1D) : viewport;
+  }
+}

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/entity/workflow/v2/WorkflowV2Edge.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/entity/workflow/v2/WorkflowV2Edge.java
@@ -1,0 +1,47 @@
+package io.yak.ops.common.bean.entity.workflow.v2;
+
+/** Directed Workflow V2 edge selected from a normalized node outcome port. */
+public class WorkflowV2Edge {
+
+  public enum Port {
+    SUCCESS,
+    FAILURE
+  }
+
+  private String from;
+  private Port fromPort = Port.SUCCESS;
+  private String to;
+
+  public WorkflowV2Edge() {
+  }
+
+  public WorkflowV2Edge(String from, Port fromPort, String to) {
+    this.from = from;
+    setFromPort(fromPort);
+    this.to = to;
+  }
+
+  public String getFrom() {
+    return from;
+  }
+
+  public void setFrom(String from) {
+    this.from = from;
+  }
+
+  public Port getFromPort() {
+    return fromPort;
+  }
+
+  public void setFromPort(Port fromPort) {
+    this.fromPort = fromPort == null ? Port.SUCCESS : fromPort;
+  }
+
+  public String getTo() {
+    return to;
+  }
+
+  public void setTo(String to) {
+    this.to = to;
+  }
+}

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/entity/workflow/v2/WorkflowV2ExecutionPolicy.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/entity/workflow/v2/WorkflowV2ExecutionPolicy.java
@@ -1,0 +1,51 @@
+package io.yak.ops.common.bean.entity.workflow.v2;
+
+/** Orchestration-only execution policy for one Workflow V2 task node. */
+public class WorkflowV2ExecutionPolicy {
+
+  public enum FailureAction {
+    FAIL_WORKFLOW,
+    ROUTE_FAILURE,
+    PAUSE
+  }
+
+  private int timeoutSeconds;
+  private int retryTimes;
+  private int retryIntervalSeconds;
+  private FailureAction failureAction = FailureAction.FAIL_WORKFLOW;
+
+  public WorkflowV2ExecutionPolicy() {
+  }
+
+  public int getTimeoutSeconds() {
+    return timeoutSeconds;
+  }
+
+  public void setTimeoutSeconds(int timeoutSeconds) {
+    this.timeoutSeconds = timeoutSeconds;
+  }
+
+  public int getRetryTimes() {
+    return retryTimes;
+  }
+
+  public void setRetryTimes(int retryTimes) {
+    this.retryTimes = retryTimes;
+  }
+
+  public int getRetryIntervalSeconds() {
+    return retryIntervalSeconds;
+  }
+
+  public void setRetryIntervalSeconds(int retryIntervalSeconds) {
+    this.retryIntervalSeconds = retryIntervalSeconds;
+  }
+
+  public FailureAction getFailureAction() {
+    return failureAction;
+  }
+
+  public void setFailureAction(FailureAction failureAction) {
+    this.failureAction = failureAction == null ? FailureAction.FAIL_WORKFLOW : failureAction;
+  }
+}

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/entity/workflow/v2/WorkflowV2InputBinding.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/entity/workflow/v2/WorkflowV2InputBinding.java
@@ -1,0 +1,32 @@
+package io.yak.ops.common.bean.entity.workflow.v2;
+
+/** Maps one task input path to a workflow-visible source. */
+public class WorkflowV2InputBinding {
+
+  private String target;
+  private WorkflowV2BindingSource source;
+
+  public WorkflowV2InputBinding() {
+  }
+
+  public WorkflowV2InputBinding(String target, WorkflowV2BindingSource source) {
+    this.target = target;
+    this.source = source;
+  }
+
+  public String getTarget() {
+    return target;
+  }
+
+  public void setTarget(String target) {
+    this.target = target;
+  }
+
+  public WorkflowV2BindingSource getSource() {
+    return source;
+  }
+
+  public void setSource(WorkflowV2BindingSource source) {
+    this.source = source;
+  }
+}

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/entity/workflow/v2/WorkflowV2Node.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/entity/workflow/v2/WorkflowV2Node.java
@@ -1,0 +1,123 @@
+package io.yak.ops.common.bean.entity.workflow.v2;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/** A Workflow V2 control or task-reference node. */
+public class WorkflowV2Node {
+
+  public enum Kind {
+    START,
+    TASK,
+    END
+  }
+
+  private String key;
+  private String name;
+  private Kind kind;
+  private String description;
+  private Double positionX;
+  private Double positionY;
+  private boolean enabled = true;
+  private WorkflowV2TaskReference taskRef;
+  private List<WorkflowV2InputBinding> inputBindings = new ArrayList<>();
+  private Map<String, WorkflowV2BindingSource> outputBindings = new LinkedHashMap<>();
+  private WorkflowV2ExecutionPolicy executionPolicy = new WorkflowV2ExecutionPolicy();
+
+  public WorkflowV2Node() {
+  }
+
+  public String getKey() {
+    return key;
+  }
+
+  public void setKey(String key) {
+    this.key = key;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public Kind getKind() {
+    return kind;
+  }
+
+  public void setKind(Kind kind) {
+    this.kind = kind;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public void setDescription(String description) {
+    this.description = description;
+  }
+
+  public Double getPositionX() {
+    return positionX;
+  }
+
+  public void setPositionX(Double positionX) {
+    this.positionX = positionX;
+  }
+
+  public Double getPositionY() {
+    return positionY;
+  }
+
+  public void setPositionY(Double positionY) {
+    this.positionY = positionY;
+  }
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  public WorkflowV2TaskReference getTaskRef() {
+    return taskRef;
+  }
+
+  public void setTaskRef(WorkflowV2TaskReference taskRef) {
+    this.taskRef = taskRef;
+  }
+
+  public List<WorkflowV2InputBinding> getInputBindings() {
+    return inputBindings;
+  }
+
+  public void setInputBindings(List<WorkflowV2InputBinding> inputBindings) {
+    this.inputBindings = inputBindings == null ? new ArrayList<>() : new ArrayList<>(inputBindings);
+  }
+
+  public Map<String, WorkflowV2BindingSource> getOutputBindings() {
+    return outputBindings;
+  }
+
+  public void setOutputBindings(Map<String, WorkflowV2BindingSource> outputBindings) {
+    this.outputBindings = outputBindings == null
+        ? new LinkedHashMap<>()
+        : new LinkedHashMap<>(outputBindings);
+  }
+
+  public WorkflowV2ExecutionPolicy getExecutionPolicy() {
+    return executionPolicy;
+  }
+
+  public void setExecutionPolicy(WorkflowV2ExecutionPolicy executionPolicy) {
+    this.executionPolicy = executionPolicy == null
+        ? new WorkflowV2ExecutionPolicy()
+        : executionPolicy;
+  }
+}

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/entity/workflow/v2/WorkflowV2TaskReference.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/entity/workflow/v2/WorkflowV2TaskReference.java
@@ -1,0 +1,56 @@
+package io.yak.ops.common.bean.entity.workflow.v2;
+
+/** Immutable data-development task-version reference used by a Workflow V2 task node. */
+public class WorkflowV2TaskReference {
+
+  private String taskId;
+  private String taskVersionId;
+  private long taskVersionNumber;
+  private String taskType;
+
+  public WorkflowV2TaskReference() {
+  }
+
+  public WorkflowV2TaskReference(
+      String taskId,
+      String taskVersionId,
+      long taskVersionNumber,
+      String taskType) {
+    this.taskId = taskId;
+    this.taskVersionId = taskVersionId;
+    this.taskVersionNumber = taskVersionNumber;
+    this.taskType = taskType;
+  }
+
+  public String getTaskId() {
+    return taskId;
+  }
+
+  public void setTaskId(String taskId) {
+    this.taskId = taskId;
+  }
+
+  public String getTaskVersionId() {
+    return taskVersionId;
+  }
+
+  public void setTaskVersionId(String taskVersionId) {
+    this.taskVersionId = taskVersionId;
+  }
+
+  public long getTaskVersionNumber() {
+    return taskVersionNumber;
+  }
+
+  public void setTaskVersionNumber(long taskVersionNumber) {
+    this.taskVersionNumber = taskVersionNumber;
+  }
+
+  public String getTaskType() {
+    return taskType;
+  }
+
+  public void setTaskType(String taskType) {
+    this.taskType = taskType;
+  }
+}

--- a/yak-ops-common/src/test/java/io/yak/ops/common/bean/entity/workflow/v2/WorkflowV2ContractTest.java
+++ b/yak-ops-common/src/test/java/io/yak/ops/common/bean/entity/workflow/v2/WorkflowV2ContractTest.java
@@ -1,0 +1,42 @@
+package io.yak.ops.common.bean.entity.workflow.v2;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class WorkflowV2ContractTest {
+
+  @Test
+  void defaultsToPinnedVersionOrchestrationContract() {
+    WorkflowV2Dag dag = new WorkflowV2Dag();
+    WorkflowV2ExecutionPolicy policy = new WorkflowV2ExecutionPolicy();
+    WorkflowV2Edge edge = new WorkflowV2Edge();
+
+    assertEquals(2, dag.getSchemaVersion());
+    assertEquals(WorkflowV2ExecutionPolicy.FailureAction.FAIL_WORKFLOW,
+        policy.getFailureAction());
+    assertEquals(WorkflowV2Edge.Port.SUCCESS, edge.getFromPort());
+  }
+
+  @Test
+  void copiesMutableCollectionsAtTheContractBoundary() {
+    WorkflowV2Node node = new WorkflowV2Node();
+    List<WorkflowV2InputBinding> bindings = new ArrayList<>();
+    bindings.add(new WorkflowV2InputBinding());
+
+    node.setInputBindings(bindings);
+    bindings.clear();
+
+    assertFalse(node.getInputBindings().isEmpty());
+  }
+
+  @Test
+  void rejectsNonV2SchemaVersion() {
+    WorkflowV2Dag dag = new WorkflowV2Dag();
+    assertThrows(IllegalArgumentException.class, () -> dag.setSchemaVersion(1));
+  }
+}

--- a/yak-ops-ui/src/pages/workflow-management/workflow-v2.types.ts
+++ b/yak-ops-ui/src/pages/workflow-management/workflow-v2.types.ts
@@ -1,0 +1,95 @@
+/**
+ * Workflow V2 cross-layer contract.
+ *
+ * Workflow V2 owns orchestration only. Task authoring content and plugin-specific configuration
+ * stay in data development and are referenced through an immutable published task version.
+ */
+
+export const WORKFLOW_V2_SCHEMA_VERSION = 2 as const;
+
+export type WorkflowV2NodeKind = 'START' | 'TASK' | 'END';
+export type WorkflowV2EdgePort = 'SUCCESS' | 'FAILURE';
+export type WorkflowV2FailureAction =
+  | 'FAIL_WORKFLOW'
+  | 'ROUTE_FAILURE'
+  | 'PAUSE';
+export type WorkflowV2BindingSourceType =
+  | 'START_INPUT'
+  | 'NODE_OUTPUT'
+  | 'WORKFLOW_VARIABLE'
+  | 'LITERAL';
+
+export interface WorkflowV2TaskReference {
+  taskId: string;
+  taskVersionId: string;
+  taskVersionNumber: number;
+  taskType: string;
+}
+
+export interface WorkflowV2BindingSource {
+  type: WorkflowV2BindingSourceType;
+  nodeKey?: string;
+  path?: string;
+  variableName?: string;
+  literalValue?: unknown;
+}
+
+export interface WorkflowV2InputBinding {
+  target: string;
+  source: WorkflowV2BindingSource;
+}
+
+export interface WorkflowV2ExecutionPolicy {
+  timeoutSeconds: number;
+  retryTimes: number;
+  retryIntervalSeconds: number;
+  failureAction: WorkflowV2FailureAction;
+}
+
+export interface WorkflowV2Node {
+  key: string;
+  name: string;
+  kind: WorkflowV2NodeKind;
+  description?: string;
+  positionX: number;
+  positionY: number;
+  enabled: boolean;
+
+  /** Required only when kind is TASK. */
+  taskRef?: WorkflowV2TaskReference;
+
+  /** Task input mappings. START usually has none. */
+  inputBindings: WorkflowV2InputBinding[];
+
+  /** Workflow outputs exposed by END nodes. */
+  outputBindings: Record<string, WorkflowV2BindingSource>;
+
+  /** Orchestration policy. It never contains plugin-specific task configuration. */
+  executionPolicy: WorkflowV2ExecutionPolicy;
+}
+
+export interface WorkflowV2Edge {
+  from: string;
+  fromPort: WorkflowV2EdgePort;
+  to: string;
+}
+
+export interface WorkflowV2Viewport {
+  x: number;
+  y: number;
+  zoom: number;
+}
+
+export interface WorkflowV2Dag {
+  schemaVersion: typeof WORKFLOW_V2_SCHEMA_VERSION;
+  nodes: WorkflowV2Node[];
+  edges: WorkflowV2Edge[];
+  viewport: WorkflowV2Viewport;
+}
+
+export const createWorkflowV2ExecutionPolicy = (): WorkflowV2ExecutionPolicy => ({
+  timeoutSeconds: 0,
+  retryTimes: 0,
+  retryIntervalSeconds: 0,
+  failureAction: 'FAIL_WORKFLOW',
+});


### PR DESCRIPTION
## 背景

数据开发工作台已经具备任务草稿、校验、不可变发布版本和执行快照，现有 Workflow V1 仍在节点中保存 HTTP、Shell 等插件专属配置，导致任务配置同时存在于工作台和工作流 Panel，职责重复且无法稳定绑定任务版本。

本 PR 完成拆分计划的第一步：只建立职责边界和 Workflow V2 跨层契约，不切换现有 V1 持久化、设计器或执行引擎。

## 职责边界

- Data Development 负责任务内容、草稿、校验、测试运行、发布版本、Compiled Spec 和输入输出 Schema。
- TaskPlugin 负责任务 Definition 的默认值、标准化、校验、编译和执行。
- Workflow 只负责不可变 Task Version 引用、输入输出映射、节点依赖、成功失败路由以及重试、超时和暂停等编排策略。

Workflow V2 明确禁止保存插件专属 `config`、HTTP/Shell/SQL 参数、Compiled Spec 或运行时密钥。

## Workflow V2 契约

新增公共 Java 模型：

- `WorkflowV2Dag`
- `WorkflowV2Node`，统一 `START / TASK / END`
- `WorkflowV2TaskReference`，固定 `taskId + taskVersionId + taskVersionNumber + taskType`
- `WorkflowV2InputBinding` / `WorkflowV2BindingSource`
- `WorkflowV2ExecutionPolicy`
- `WorkflowV2Edge`，支持 `SUCCESS / FAILURE` 出口

同时新增：

- 前端 TypeScript 镜像类型 `workflow-v2.types.ts`
- 跨前后端基准 JSON Schema `docs/workflow/workflow-v2.schema.json`
- 职责、依赖方向、兼容策略、约束和后续步骤文档
- 公共契约默认值与集合复制测试

## 兼容策略

过渡期约定：

```text
V1 Reader
V2 Reader
V2 Writer（后续步骤启用）
```

本 PR 不修改现有 `WorkflowDag`、`WorkflowNode`、`WorkflowEdge`、数据库结构、API、编译器或运行状态机，因此当前工作流行为保持不变，也不会自动迁移旧 HTTP/Shell 节点。

## 验证

- 使用 JDK 21 对新增 Java 主模型完成独立语法编译；
- 使用最小 JUnit API 桩对新增契约测试完成语法编译；
- 使用 TypeScript 5.8 strict 模式检查前端 V2 类型，通过；
- 使用 Python JSON parser 校验 Workflow V2 Schema，通过；
- 分支已整理为基于最新 `main` 的单个提交；
- GitHub compare 确认差异仅包含 11 个新增契约、测试和文档文件，没有修改 V1 代码。

当前环境无法执行完整 Maven Reactor 和项目级前端构建，需由本地或 CI 继续验证。

## 后续

下一步应提供面向工作流的已发布任务资源查询接口，再实现 Workflow V2 Reader/Writer、左侧任务拖拽设计器和编排 Panel。