### PR TITLE
feat(workflow): expose published task library

### DIFF
--- a/docs/workflow/workflow-task-library-api.md
+++ b/docs/workflow/workflow-task-library-api.md
@@ -1,0 +1,146 @@
+# Workflow Published Task Library API
+
+## Scope
+
+This API is the read-only boundary between Workflow authoring and Data Development task authoring.
+
+Workflow may discover and reference published task versions, but it must not read or edit task drafts, plugin-specific definitions, compiled specifications, runtime parameters or secrets.
+
+```text
+Workflow Designer
+  -> Published Task Library API
+  -> immutable Task Version metadata
+  -> taskId + versionId + Input/Output Schema
+```
+
+## Authorization
+
+Both endpoints require:
+
+```text
+workflow:definition:read
+```
+
+The current phase applies the existing global workflow read permission. Project-scoped resource authorization remains a later platform capability.
+
+## Search published tasks
+
+```http
+GET /api/v1/data-development/tasks/library
+```
+
+The endpoint always returns only tasks that satisfy all of the following:
+
+- task status is `PUBLISHED`;
+- `published_version_id` is present;
+- the task resource is not deleted;
+- the projected version is the task's current immutable published version.
+
+### Query parameters
+
+| Parameter | Meaning |
+| --- | --- |
+| `projectId` | Exact project filter |
+| `folderId` | Exact parent folder; use `0` for project root |
+| `taskType` | Task type, normalized to uppercase |
+| `keyword` | Case-insensitive task/project/type search |
+| `favoriteOnly` | Only tasks favorited by the current user |
+| `recentlyUsed` | Only tasks executed by the current user |
+| `sortBy` | `UPDATED_AT`, `PUBLISHED_AT` or `RECENTLY_USED` |
+| `offset` | Zero-based offset, default `0` |
+| `limit` | Page size, default `50`, maximum `100` |
+
+When `recentlyUsed=true` and `sortBy` is omitted, ordering defaults to `RECENTLY_USED`.
+
+### Response
+
+```json
+{
+  "code": 200,
+  "data": {
+    "items": [
+      {
+        "taskId": "1001",
+        "name": "查询订单",
+        "description": "通过订单号查询订单",
+        "projectId": "10",
+        "projectCode": "order-center",
+        "projectName": "订单中心",
+        "folderId": "20",
+        "folderName": "接口任务",
+        "taskType": "HTTP",
+        "engineType": "HTTP",
+        "publishedVersionId": "2003",
+        "publishedVersionNumber": 3,
+        "pluginVersion": "1.0.0",
+        "schemaVersion": 1,
+        "inputSchema": {},
+        "outputSchema": {},
+        "contentDigest": "...",
+        "publishedBy": "admin",
+        "publishedAt": "2026-08-05T00:30:00",
+        "updatedAt": "2026-08-05T00:30:00",
+        "favorite": true,
+        "lastUsedAt": "2026-08-05T00:35:00"
+      }
+    ],
+    "total": 1,
+    "offset": 0,
+    "limit": 50
+  }
+}
+```
+
+IDs are serialized as strings so the Workflow V2 frontend can copy them directly into `taskRef` without JavaScript integer precision loss.
+
+## Read one immutable published version
+
+```http
+GET /api/v1/data-development/tasks/library/{taskId}/versions/{versionId}
+```
+
+This endpoint returns a safe projection for version validation and explicit version upgrades:
+
+- task and project identity;
+- task/plugin/schema versions;
+- Input Schema and Output Schema;
+- content digest and publication metadata;
+- whether the version is currently selected by the task.
+
+Historical immutable versions of an active published task may be read. Draft definitions and compiled specifications are never returned.
+
+## Deliberately excluded fields
+
+The Workflow task library never returns:
+
+```text
+definitionSnapshot
+compiledSpec
+runtime.common
+runtime.specific
+secret values or secret references
+HTTP URL / headers / body
+Shell command / environment
+SQL or Notebook source
+```
+
+Execution will resolve the referenced immutable version through the future Task Execution Gateway rather than copying task content into the workflow definition.
+
+## Frontend client
+
+The typed frontend adapter is located at:
+
+```text
+yak-ops-ui/src/pages/workflow-management/repository/workflow-task-library.repository.ts
+```
+
+It is intentionally not wired into the current Workflow V1 designer in this phase. The next designer step can use it for the left-side 300px task library and drag payload creation.
+
+## Query indexes
+
+Migration `V3__optimize_workflow_task_library.sql` adds read-path indexes for:
+
+- published task library filtering by status/project/type/version;
+- current-user recent execution lookup by creator/task/time.
+
+No new business tables or duplicated task snapshots are introduced.

--- a/yak-ops-business/yak-ops-business-data-development/pom.xml
+++ b/yak-ops-business/yak-ops-business-data-development/pom.xml
@@ -30,6 +30,11 @@
             <artifactId>yak-ops-common</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.yak.framework</groupId>
+            <artifactId>yak-security-spring-boot-starter</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/api/WorkflowTaskLibraryApi.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/api/WorkflowTaskLibraryApi.java
@@ -1,0 +1,85 @@
+package io.yak.ops.business.development.api;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.time.LocalDateTime;
+import java.util.List;
+
+/** Read-only contracts exposed to Workflow for selecting immutable published tasks. */
+public final class WorkflowTaskLibraryApi {
+
+  private WorkflowTaskLibraryApi() {
+  }
+
+  public enum SortBy {
+    UPDATED_AT,
+    PUBLISHED_AT,
+    RECENTLY_USED
+  }
+
+  public record TaskLibraryQuery(
+      Long projectId,
+      Long folderId,
+      String taskType,
+      String keyword,
+      Boolean favoriteOnly,
+      Boolean recentlyUsed,
+      SortBy sortBy,
+      Integer offset,
+      Integer limit) {
+  }
+
+  public record PublishedTaskItem(
+      String taskId,
+      String name,
+      String description,
+      String projectId,
+      String projectCode,
+      String projectName,
+      String folderId,
+      String folderName,
+      String taskType,
+      String engineType,
+      String publishedVersionId,
+      int publishedVersionNumber,
+      String pluginVersion,
+      int schemaVersion,
+      JsonNode inputSchema,
+      JsonNode outputSchema,
+      String contentDigest,
+      String publishedBy,
+      LocalDateTime publishedAt,
+      LocalDateTime updatedAt,
+      boolean favorite,
+      LocalDateTime lastUsedAt) {
+  }
+
+  public record PublishedTaskPage(
+      List<PublishedTaskItem> items,
+      long total,
+      int offset,
+      int limit) {
+
+    public PublishedTaskPage {
+      items = items == null ? List.of() : List.copyOf(items);
+    }
+  }
+
+  public record PublishedTaskVersionView(
+      String taskId,
+      String taskName,
+      String projectId,
+      String projectName,
+      String taskType,
+      String engineType,
+      String versionId,
+      int versionNumber,
+      String pluginVersion,
+      int schemaVersion,
+      JsonNode inputSchema,
+      JsonNode outputSchema,
+      String contentDigest,
+      String publishedBy,
+      LocalDateTime publishedAt,
+      boolean currentVersion) {
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/controller/v1/DataDevelopmentExceptionHandler.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/controller/v1/DataDevelopmentExceptionHandler.java
@@ -12,7 +12,8 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @ConditionalOnDataDevelopmentEnabled
 @RestControllerAdvice(assignableTypes = {
     DataDevelopmentController.class,
-    DataDevelopmentPlatformController.class
+    DataDevelopmentPlatformController.class,
+    WorkflowTaskLibraryController.class
 })
 public class DataDevelopmentExceptionHandler {
 

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/controller/v1/WorkflowTaskLibraryController.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/controller/v1/WorkflowTaskLibraryController.java
@@ -1,0 +1,71 @@
+package io.yak.ops.business.development.controller.v1;
+
+import io.yak.framework.common.Result;
+import io.yak.framework.security.web.RequiresPermission;
+import io.yak.ops.business.development.api.WorkflowTaskLibraryApi.PublishedTaskPage;
+import io.yak.ops.business.development.api.WorkflowTaskLibraryApi.PublishedTaskVersionView;
+import io.yak.ops.business.development.api.WorkflowTaskLibraryApi.SortBy;
+import io.yak.ops.business.development.api.WorkflowTaskLibraryApi.TaskLibraryQuery;
+import io.yak.ops.business.development.config.ConditionalOnDataDevelopmentEnabled;
+import io.yak.ops.business.development.service.WorkflowTaskLibraryService;
+import java.security.Principal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Read-only published task resources consumed by the Workflow designer. */
+@ConditionalOnDataDevelopmentEnabled
+@RestController
+@RequestMapping("/api/v1/data-development/tasks/library")
+@RequiresPermission("workflow:definition:read")
+public final class WorkflowTaskLibraryController {
+
+  private final WorkflowTaskLibraryService service;
+
+  public WorkflowTaskLibraryController(WorkflowTaskLibraryService service) {
+    this.service = service;
+  }
+
+  @GetMapping
+  public Result<PublishedTaskPage> search(
+      @RequestParam(required = false) Long projectId,
+      @RequestParam(required = false) Long folderId,
+      @RequestParam(required = false) String taskType,
+      @RequestParam(required = false) String keyword,
+      @RequestParam(required = false) Boolean favoriteOnly,
+      @RequestParam(required = false) Boolean recentlyUsed,
+      @RequestParam(required = false) SortBy sortBy,
+      @RequestParam(required = false) Integer offset,
+      @RequestParam(required = false) Integer limit,
+      Principal principal) {
+    return Result.success(service.search(
+        new TaskLibraryQuery(
+            projectId,
+            folderId,
+            taskType,
+            keyword,
+            favoriteOnly,
+            recentlyUsed,
+            sortBy,
+            offset,
+            limit),
+        operator(principal)));
+  }
+
+  @GetMapping("/{taskId}/versions/{versionId}")
+  public Result<PublishedTaskVersionView> getPublishedVersion(
+      @PathVariable long taskId,
+      @PathVariable long versionId,
+      Principal principal) {
+    return Result.success(
+        service.getPublishedVersion(taskId, versionId, operator(principal)));
+  }
+
+  private static String operator(Principal principal) {
+    return principal == null || principal.getName() == null || principal.getName().isBlank()
+        ? "system"
+        : principal.getName();
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/JdbcWorkflowTaskLibraryRepository.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/JdbcWorkflowTaskLibraryRepository.java
@@ -1,0 +1,245 @@
+package io.yak.ops.business.development.repository;
+
+import io.yak.ops.business.development.api.WorkflowTaskLibraryApi.PublishedTaskItem;
+import io.yak.ops.business.development.api.WorkflowTaskLibraryApi.PublishedTaskVersionView;
+import io.yak.ops.business.development.api.WorkflowTaskLibraryApi.SortBy;
+import io.yak.ops.business.development.config.ConditionalOnDataDevelopmentEnabled;
+import io.yak.ops.business.development.service.DataDevelopmentJsonCodec;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+/** JDBC projection over published task versions for the Workflow designer. */
+@ConditionalOnDataDevelopmentEnabled
+@Repository
+public final class JdbcWorkflowTaskLibraryRepository implements WorkflowTaskLibraryRepository {
+
+  private static final String BASE_FROM = """
+      FROM yak_dev_task t
+      JOIN yak_dev_resource r
+        ON r.id=t.id AND r.deleted=0 AND r.resource_kind='TASK'
+      JOIN yak_dev_project p ON p.id=t.project_id
+      JOIN yak_dev_task_version v
+        ON v.id=t.published_version_id AND v.task_id=t.id
+      LEFT JOIN yak_dev_resource folder
+        ON folder.id=r.parent_id AND folder.deleted=0 AND folder.resource_kind='FOLDER'
+      LEFT JOIN yak_dev_user_favorite favorite
+        ON favorite.resource_id=t.id AND favorite.user_id=:operator
+      LEFT JOIN (
+        SELECT task_id,MAX(created_at) AS last_used_at
+        FROM yak_dev_execution
+        WHERE created_by=:operator
+        GROUP BY task_id
+      ) recent ON recent.task_id=t.id
+      """;
+
+  private final NamedParameterJdbcTemplate jdbc;
+  private final DataDevelopmentJsonCodec json;
+
+  public JdbcWorkflowTaskLibraryRepository(
+      @Qualifier("dataDevelopmentJdbcTemplate") NamedParameterJdbcTemplate jdbc,
+      DataDevelopmentJsonCodec json) {
+    this.jdbc = jdbc;
+    this.json = json;
+  }
+
+  @Override
+  public SearchResult search(SearchCriteria criteria) {
+    MapSqlParameterSource parameters = parameters(criteria);
+    String where = where(criteria);
+    Long total = jdbc.queryForObject(
+        "SELECT COUNT(1) " + BASE_FROM + where,
+        parameters,
+        Long.class);
+
+    parameters.addValue("offset", criteria.offset());
+    parameters.addValue("limit", criteria.limit());
+    List<PublishedTaskItem> items = jdbc.query(
+        """
+        SELECT
+          t.id AS task_id,
+          r.name AS task_name,
+          r.description AS task_description,
+          p.id AS project_id,
+          p.code AS project_code,
+          p.name AS project_name,
+          folder.id AS folder_id,
+          folder.name AS folder_name,
+          v.task_type,
+          t.engine_type,
+          v.id AS published_version_id,
+          v.version_no,
+          v.plugin_version,
+          v.schema_version,
+          v.input_schema,
+          v.output_schema,
+          v.content_digest,
+          v.published_by,
+          v.published_at,
+          r.updated_at,
+          CASE WHEN favorite.resource_id IS NULL THEN 0 ELSE 1 END AS favorite,
+          recent.last_used_at
+        """ + BASE_FROM + where + orderBy(criteria.sortBy()) + " LIMIT :limit OFFSET :offset",
+        parameters,
+        this::publishedTask);
+    return new SearchResult(items, total == null ? 0L : total);
+  }
+
+  @Override
+  public Optional<PublishedTaskVersionView> findPublishedVersion(
+      long taskId,
+      long versionId,
+      String operator) {
+    List<PublishedTaskVersionView> items = jdbc.query("""
+        SELECT
+          t.id AS task_id,
+          r.name AS task_name,
+          p.id AS project_id,
+          p.name AS project_name,
+          v.task_type,
+          t.engine_type,
+          v.id AS version_id,
+          v.version_no,
+          v.plugin_version,
+          v.schema_version,
+          v.input_schema,
+          v.output_schema,
+          v.content_digest,
+          v.published_by,
+          v.published_at,
+          CASE WHEN t.published_version_id=v.id THEN 1 ELSE 0 END AS current_version
+        FROM yak_dev_task t
+        JOIN yak_dev_resource r
+          ON r.id=t.id AND r.deleted=0 AND r.resource_kind='TASK'
+        JOIN yak_dev_project p ON p.id=t.project_id
+        JOIN yak_dev_task_version v ON v.task_id=t.id
+        WHERE t.id=:taskId
+          AND v.id=:versionId
+          AND t.status='PUBLISHED'
+          AND t.published_version_id IS NOT NULL
+        """, new MapSqlParameterSource()
+        .addValue("taskId", taskId)
+        .addValue("versionId", versionId)
+        .addValue("operator", operator), this::publishedVersion);
+    return items.stream().findFirst();
+  }
+
+  private static MapSqlParameterSource parameters(SearchCriteria criteria) {
+    return new MapSqlParameterSource()
+        .addValue("operator", criteria.operator())
+        .addValue("projectId", criteria.projectId())
+        .addValue("folderId", criteria.folderId())
+        .addValue("taskType", criteria.taskType())
+        .addValue("keyword", criteria.keyword());
+  }
+
+  private static String where(SearchCriteria criteria) {
+    StringBuilder sql = new StringBuilder("""
+        WHERE t.status='PUBLISHED'
+          AND t.published_version_id IS NOT NULL
+        """);
+    if (criteria.projectId() != null) {
+      sql.append(" AND t.project_id=:projectId");
+    }
+    if (criteria.folderId() != null) {
+      sql.append(" AND r.parent_id=:folderId");
+    }
+    if (criteria.taskType() != null) {
+      sql.append(" AND v.task_type=:taskType");
+    }
+    if (criteria.keyword() != null) {
+      sql.append("""
+           AND (
+             LOCATE(:keyword,LOWER(r.name))>0
+             OR LOCATE(:keyword,LOWER(COALESCE(r.description,'')))>0
+             OR LOCATE(:keyword,LOWER(p.name))>0
+             OR LOCATE(:keyword,LOWER(p.code))>0
+             OR LOCATE(:keyword,LOWER(v.task_type))>0
+           )
+          """);
+    }
+    if (criteria.favoriteOnly()) {
+      sql.append(" AND favorite.resource_id IS NOT NULL");
+    }
+    if (criteria.recentlyUsed()) {
+      sql.append(" AND recent.last_used_at IS NOT NULL");
+    }
+    return sql.toString();
+  }
+
+  private static String orderBy(SortBy sortBy) {
+    return switch (sortBy) {
+      case PUBLISHED_AT -> " ORDER BY v.published_at DESC,r.updated_at DESC,t.id DESC";
+      case RECENTLY_USED -> " ORDER BY recent.last_used_at DESC,r.updated_at DESC,t.id DESC";
+      case UPDATED_AT -> " ORDER BY r.updated_at DESC,t.id DESC";
+    };
+  }
+
+  private PublishedTaskItem publishedTask(ResultSet resultSet, int row) throws SQLException {
+    return new PublishedTaskItem(
+        id(resultSet, "task_id"),
+        resultSet.getString("task_name"),
+        resultSet.getString("task_description"),
+        id(resultSet, "project_id"),
+        resultSet.getString("project_code"),
+        resultSet.getString("project_name"),
+        nullableId(resultSet, "folder_id"),
+        resultSet.getString("folder_name"),
+        resultSet.getString("task_type"),
+        resultSet.getString("engine_type"),
+        id(resultSet, "published_version_id"),
+        resultSet.getInt("version_no"),
+        resultSet.getString("plugin_version"),
+        resultSet.getInt("schema_version"),
+        json.readTree(resultSet.getString("input_schema")),
+        json.readTree(resultSet.getString("output_schema")),
+        resultSet.getString("content_digest"),
+        resultSet.getString("published_by"),
+        time(resultSet, "published_at"),
+        time(resultSet, "updated_at"),
+        resultSet.getBoolean("favorite"),
+        time(resultSet, "last_used_at"));
+  }
+
+  private PublishedTaskVersionView publishedVersion(ResultSet resultSet, int row)
+      throws SQLException {
+    return new PublishedTaskVersionView(
+        id(resultSet, "task_id"),
+        resultSet.getString("task_name"),
+        id(resultSet, "project_id"),
+        resultSet.getString("project_name"),
+        resultSet.getString("task_type"),
+        resultSet.getString("engine_type"),
+        id(resultSet, "version_id"),
+        resultSet.getInt("version_no"),
+        resultSet.getString("plugin_version"),
+        resultSet.getInt("schema_version"),
+        json.readTree(resultSet.getString("input_schema")),
+        json.readTree(resultSet.getString("output_schema")),
+        resultSet.getString("content_digest"),
+        resultSet.getString("published_by"),
+        time(resultSet, "published_at"),
+        resultSet.getBoolean("current_version"));
+  }
+
+  private static String id(ResultSet resultSet, String column) throws SQLException {
+    return Long.toString(resultSet.getLong(column));
+  }
+
+  private static String nullableId(ResultSet resultSet, String column) throws SQLException {
+    long value = resultSet.getLong(column);
+    return resultSet.wasNull() || value == 0L ? null : Long.toString(value);
+  }
+
+  private static LocalDateTime time(ResultSet resultSet, String column) throws SQLException {
+    Timestamp value = resultSet.getTimestamp(column);
+    return value == null ? null : value.toLocalDateTime();
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/WorkflowTaskLibraryRepository.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/WorkflowTaskLibraryRepository.java
@@ -1,0 +1,38 @@
+package io.yak.ops.business.development.repository;
+
+import io.yak.ops.business.development.api.WorkflowTaskLibraryApi.PublishedTaskItem;
+import io.yak.ops.business.development.api.WorkflowTaskLibraryApi.PublishedTaskVersionView;
+import io.yak.ops.business.development.api.WorkflowTaskLibraryApi.SortBy;
+import java.util.List;
+import java.util.Optional;
+
+/** Read-only persistence boundary used by Workflow task selection. */
+public interface WorkflowTaskLibraryRepository {
+
+  SearchResult search(SearchCriteria criteria);
+
+  Optional<PublishedTaskVersionView> findPublishedVersion(
+      long taskId,
+      long versionId,
+      String operator);
+
+  record SearchCriteria(
+      Long projectId,
+      Long folderId,
+      String taskType,
+      String keyword,
+      boolean favoriteOnly,
+      boolean recentlyUsed,
+      SortBy sortBy,
+      int offset,
+      int limit,
+      String operator) {
+  }
+
+  record SearchResult(List<PublishedTaskItem> items, long total) {
+
+    public SearchResult {
+      items = items == null ? List.of() : List.copyOf(items);
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/WorkflowTaskLibraryService.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/WorkflowTaskLibraryService.java
@@ -1,0 +1,120 @@
+package io.yak.ops.business.development.service;
+
+import io.yak.ops.business.development.api.WorkflowTaskLibraryApi.PublishedTaskPage;
+import io.yak.ops.business.development.api.WorkflowTaskLibraryApi.PublishedTaskVersionView;
+import io.yak.ops.business.development.api.WorkflowTaskLibraryApi.SortBy;
+import io.yak.ops.business.development.api.WorkflowTaskLibraryApi.TaskLibraryQuery;
+import io.yak.ops.business.development.config.ConditionalOnDataDevelopmentEnabled;
+import io.yak.ops.business.development.repository.WorkflowTaskLibraryRepository;
+import io.yak.ops.business.development.repository.WorkflowTaskLibraryRepository.SearchCriteria;
+import io.yak.ops.business.development.repository.WorkflowTaskLibraryRepository.SearchResult;
+import java.util.Locale;
+import org.springframework.stereotype.Service;
+
+/** Application boundary for Workflow's read-only published task library. */
+@ConditionalOnDataDevelopmentEnabled
+@Service
+public final class WorkflowTaskLibraryService {
+
+  private static final int DEFAULT_LIMIT = 50;
+  private static final int MAX_LIMIT = 100;
+
+  private final WorkflowTaskLibraryRepository repository;
+
+  public WorkflowTaskLibraryService(WorkflowTaskLibraryRepository repository) {
+    this.repository = repository;
+  }
+
+  public PublishedTaskPage search(TaskLibraryQuery query, String operator) {
+    TaskLibraryQuery source = query == null
+        ? new TaskLibraryQuery(null, null, null, null, null, null, null, null, null)
+        : query;
+    boolean recentlyUsed = Boolean.TRUE.equals(source.recentlyUsed());
+    SortBy sortBy = source.sortBy() == null
+        ? (recentlyUsed ? SortBy.RECENTLY_USED : SortBy.UPDATED_AT)
+        : source.sortBy();
+    SearchCriteria criteria = new SearchCriteria(
+        positiveOrNull(source.projectId(), "projectId"),
+        nonNegativeOrNull(source.folderId(), "folderId"),
+        upperOrNull(source.taskType()),
+        lowerOrNull(source.keyword()),
+        Boolean.TRUE.equals(source.favoriteOnly()),
+        recentlyUsed,
+        sortBy,
+        Math.max(0, source.offset() == null ? 0 : source.offset()),
+        normalizeLimit(source.limit()),
+        normalizeOperator(operator));
+    SearchResult result = repository.search(criteria);
+    return new PublishedTaskPage(
+        result.items(),
+        result.total(),
+        criteria.offset(),
+        criteria.limit());
+  }
+
+  public PublishedTaskVersionView getPublishedVersion(
+      long taskId,
+      long versionId,
+      String operator) {
+    if (taskId <= 0L) {
+      throw new IllegalArgumentException("taskId 必须为正整数");
+    }
+    if (versionId <= 0L) {
+      throw new IllegalArgumentException("versionId 必须为正整数");
+    }
+    return repository.findPublishedVersion(taskId, versionId, normalizeOperator(operator))
+        .orElseThrow(() -> new IllegalArgumentException(
+            "已发布任务版本不存在或不可用于工作流：taskId=" + taskId
+                + "，versionId=" + versionId));
+  }
+
+  private static int normalizeLimit(Integer value) {
+    if (value == null) {
+      return DEFAULT_LIMIT;
+    }
+    return Math.min(MAX_LIMIT, Math.max(1, value));
+  }
+
+  private static Long positiveOrNull(Long value, String field) {
+    if (value == null) {
+      return null;
+    }
+    if (value <= 0L) {
+      throw new IllegalArgumentException(field + " 必须为正整数");
+    }
+    return value;
+  }
+
+  private static Long nonNegativeOrNull(Long value, String field) {
+    if (value == null) {
+      return null;
+    }
+    if (value < 0L) {
+      throw new IllegalArgumentException(field + " 不能小于 0");
+    }
+    return value;
+  }
+
+  private static String upperOrNull(String value) {
+    String text = trimToNull(value);
+    return text == null ? null : text.toUpperCase(Locale.ROOT);
+  }
+
+  private static String lowerOrNull(String value) {
+    String text = trimToNull(value);
+    return text == null ? null : text.toLowerCase(Locale.ROOT);
+  }
+
+  private static String trimToNull(String value) {
+    if (value == null) {
+      return null;
+    }
+    String text = value.trim();
+    return text.isEmpty() ? null : text;
+  }
+
+  private static String normalizeOperator(String operator) {
+    String text = trimToNull(operator);
+    return text == null ? "system" : text;
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/resources/db/migration/yak-data-development/V3__optimize_workflow_task_library.sql
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/resources/db/migration/yak-data-development/V3__optimize_workflow_task_library.sql
@@ -1,0 +1,5 @@
+ALTER TABLE yak_dev_execution
+  ADD KEY idx_yak_dev_execution_recent_user (created_by, task_id, created_at);
+
+ALTER TABLE yak_dev_task
+  ADD KEY idx_yak_dev_task_library (status, project_id, task_type, published_version_id);

--- a/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/repository/JdbcWorkflowTaskLibraryRepositoryTest.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/repository/JdbcWorkflowTaskLibraryRepositoryTest.java
@@ -1,0 +1,73 @@
+package io.yak.ops.business.development.repository;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.development.api.WorkflowTaskLibraryApi.PublishedTaskItem;
+import io.yak.ops.business.development.api.WorkflowTaskLibraryApi.SortBy;
+import io.yak.ops.business.development.repository.WorkflowTaskLibraryRepository.SearchCriteria;
+import io.yak.ops.business.development.service.DataDevelopmentJsonCodec;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+
+class JdbcWorkflowTaskLibraryRepositoryTest {
+
+  @Test
+  void queryProjectsOnlySafePublishedTaskMetadata() {
+    NamedParameterJdbcTemplate jdbc = org.mockito.Mockito.mock(
+        NamedParameterJdbcTemplate.class);
+    when(jdbc.queryForObject(
+        anyString(),
+        any(MapSqlParameterSource.class),
+        eq(Long.class))).thenReturn(0L);
+    when(jdbc.query(
+        anyString(),
+        any(MapSqlParameterSource.class),
+        org.mockito.ArgumentMatchers.<RowMapper<PublishedTaskItem>>any()))
+        .thenReturn(List.of());
+
+    JdbcWorkflowTaskLibraryRepository repository =
+        new JdbcWorkflowTaskLibraryRepository(jdbc, new DataDevelopmentJsonCodec());
+    repository.search(new SearchCriteria(
+        10L,
+        0L,
+        "HTTP",
+        "order",
+        true,
+        true,
+        SortBy.RECENTLY_USED,
+        0,
+        50,
+        "admin"));
+
+    ArgumentCaptor<String> countSql = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<String> listSql = ArgumentCaptor.forClass(String.class);
+    verify(jdbc).queryForObject(
+        countSql.capture(),
+        any(MapSqlParameterSource.class),
+        eq(Long.class));
+    verify(jdbc).query(
+        listSql.capture(),
+        any(MapSqlParameterSource.class),
+        org.mockito.ArgumentMatchers.<RowMapper<PublishedTaskItem>>any());
+
+    String sql = countSql.getValue() + "\n" + listSql.getValue();
+    assertTrue(sql.contains("t.status='PUBLISHED'"));
+    assertTrue(sql.contains("t.published_version_id IS NOT NULL"));
+    assertTrue(sql.contains("favorite.resource_id IS NOT NULL"));
+    assertTrue(sql.contains("recent.last_used_at IS NOT NULL"));
+    assertTrue(sql.contains("v.input_schema"));
+    assertTrue(sql.contains("v.output_schema"));
+    assertFalse(sql.contains("definition_snapshot"));
+    assertFalse(sql.contains("compiled_spec"));
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/WorkflowTaskLibraryServiceTest.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/WorkflowTaskLibraryServiceTest.java
@@ -1,0 +1,169 @@
+package io.yak.ops.business.development.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.development.api.WorkflowTaskLibraryApi.PublishedTaskItem;
+import io.yak.ops.business.development.api.WorkflowTaskLibraryApi.PublishedTaskPage;
+import io.yak.ops.business.development.api.WorkflowTaskLibraryApi.PublishedTaskVersionView;
+import io.yak.ops.business.development.api.WorkflowTaskLibraryApi.SortBy;
+import io.yak.ops.business.development.api.WorkflowTaskLibraryApi.TaskLibraryQuery;
+import io.yak.ops.business.development.repository.WorkflowTaskLibraryRepository;
+import io.yak.ops.business.development.repository.WorkflowTaskLibraryRepository.SearchCriteria;
+import io.yak.ops.business.development.repository.WorkflowTaskLibraryRepository.SearchResult;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class WorkflowTaskLibraryServiceTest {
+
+  private static final ObjectMapper JSON = new ObjectMapper();
+
+  @Test
+  void normalizesFiltersAndUsesRecentOrdering() {
+    CapturingRepository repository = new CapturingRepository();
+    repository.searchResult = new SearchResult(List.of(item()), 1L);
+    WorkflowTaskLibraryService service = new WorkflowTaskLibraryService(repository);
+
+    PublishedTaskPage page = service.search(
+        new TaskLibraryQuery(
+            10L,
+            0L,
+            " http ",
+            " Order API ",
+            true,
+            true,
+            null,
+            -5,
+            500),
+        " bruce ");
+
+    SearchCriteria criteria = repository.criteria;
+    assertEquals(10L, criteria.projectId());
+    assertEquals(0L, criteria.folderId());
+    assertEquals("HTTP", criteria.taskType());
+    assertEquals("order api", criteria.keyword());
+    assertTrue(criteria.favoriteOnly());
+    assertTrue(criteria.recentlyUsed());
+    assertEquals(SortBy.RECENTLY_USED, criteria.sortBy());
+    assertEquals(0, criteria.offset());
+    assertEquals(100, criteria.limit());
+    assertEquals("bruce", criteria.operator());
+    assertEquals(1L, page.total());
+    assertEquals("1001", page.items().getFirst().taskId());
+  }
+
+  @Test
+  void rejectsInvalidProjectId() {
+    WorkflowTaskLibraryService service = new WorkflowTaskLibraryService(
+        new CapturingRepository());
+
+    IllegalArgumentException exception = assertThrows(
+        IllegalArgumentException.class,
+        () -> service.search(
+            new TaskLibraryQuery(-1L, null, null, null, null, null, null, null, null),
+            "admin"));
+
+    assertTrue(exception.getMessage().contains("projectId"));
+  }
+
+  @Test
+  void returnsOnlyRepositoryApprovedPublishedVersion() {
+    CapturingRepository repository = new CapturingRepository();
+    PublishedTaskVersionView version = version();
+    repository.version = Optional.of(version);
+    WorkflowTaskLibraryService service = new WorkflowTaskLibraryService(repository);
+
+    assertEquals(version, service.getPublishedVersion(1001L, 2003L, "admin"));
+    assertEquals(1001L, repository.taskId);
+    assertEquals(2003L, repository.versionId);
+  }
+
+  @Test
+  void reportsUnavailablePublishedVersion() {
+    WorkflowTaskLibraryService service = new WorkflowTaskLibraryService(
+        new CapturingRepository());
+
+    IllegalArgumentException exception = assertThrows(
+        IllegalArgumentException.class,
+        () -> service.getPublishedVersion(1001L, 9999L, "admin"));
+
+    assertTrue(exception.getMessage().contains("不可用于工作流"));
+  }
+
+  private static PublishedTaskItem item() {
+    LocalDateTime now = LocalDateTime.of(2026, 8, 5, 0, 30);
+    return new PublishedTaskItem(
+        "1001",
+        "查询订单",
+        "通过订单号查询订单",
+        "10",
+        "order-center",
+        "订单中心",
+        null,
+        null,
+        "HTTP",
+        "HTTP",
+        "2003",
+        3,
+        "1.0.0",
+        1,
+        JSON.createObjectNode(),
+        JSON.createObjectNode(),
+        "digest",
+        "admin",
+        now,
+        now,
+        true,
+        now);
+  }
+
+  private static PublishedTaskVersionView version() {
+    LocalDateTime now = LocalDateTime.of(2026, 8, 5, 0, 30);
+    return new PublishedTaskVersionView(
+        "1001",
+        "查询订单",
+        "10",
+        "订单中心",
+        "HTTP",
+        "HTTP",
+        "2003",
+        3,
+        "1.0.0",
+        1,
+        JSON.createObjectNode(),
+        JSON.createObjectNode(),
+        "digest",
+        "admin",
+        now,
+        true);
+  }
+
+  private static final class CapturingRepository implements WorkflowTaskLibraryRepository {
+
+    private SearchCriteria criteria;
+    private SearchResult searchResult = new SearchResult(List.of(), 0L);
+    private Optional<PublishedTaskVersionView> version = Optional.empty();
+    private long taskId;
+    private long versionId;
+
+    @Override
+    public SearchResult search(SearchCriteria criteria) {
+      this.criteria = criteria;
+      return searchResult;
+    }
+
+    @Override
+    public Optional<PublishedTaskVersionView> findPublishedVersion(
+        long taskId,
+        long versionId,
+        String operator) {
+      this.taskId = taskId;
+      this.versionId = versionId;
+      return version;
+    }
+  }
+}

--- a/yak-ops-ui/src/pages/workflow-management/repository/workflow-task-library.repository.ts
+++ b/yak-ops-ui/src/pages/workflow-management/repository/workflow-task-library.repository.ts
@@ -1,0 +1,132 @@
+import HttpUtils from '@/utils/HttpUtils';
+
+const API_PREFIX = '/api/v1/data-development/tasks/library';
+
+interface ApiResponse<T> {
+  code: number;
+  data: T;
+  msg?: string;
+  message?: string;
+}
+
+export type WorkflowTaskLibrarySortBy =
+  | 'UPDATED_AT'
+  | 'PUBLISHED_AT'
+  | 'RECENTLY_USED';
+
+export interface WorkflowTaskLibraryQuery {
+  projectId?: string;
+  folderId?: string;
+  taskType?: string;
+  keyword?: string;
+  favoriteOnly?: boolean;
+  recentlyUsed?: boolean;
+  sortBy?: WorkflowTaskLibrarySortBy;
+  offset?: number;
+  limit?: number;
+}
+
+export interface WorkflowPublishedTask {
+  taskId: string;
+  name: string;
+  description?: string;
+  projectId: string;
+  projectCode: string;
+  projectName: string;
+  folderId?: string;
+  folderName?: string;
+  taskType: string;
+  engineType?: string;
+  publishedVersionId: string;
+  publishedVersionNumber: number;
+  pluginVersion: string;
+  schemaVersion: number;
+  inputSchema: Record<string, unknown>;
+  outputSchema: Record<string, unknown>;
+  contentDigest: string;
+  publishedBy?: string;
+  publishedAt: string;
+  updatedAt: string;
+  favorite: boolean;
+  lastUsedAt?: string;
+}
+
+export interface WorkflowPublishedTaskPage {
+  items: WorkflowPublishedTask[];
+  total: number;
+  offset: number;
+  limit: number;
+}
+
+export interface WorkflowPublishedTaskVersion {
+  taskId: string;
+  taskName: string;
+  projectId: string;
+  projectName: string;
+  taskType: string;
+  engineType?: string;
+  versionId: string;
+  versionNumber: number;
+  pluginVersion: string;
+  schemaVersion: number;
+  inputSchema: Record<string, unknown>;
+  outputSchema: Record<string, unknown>;
+  contentDigest: string;
+  publishedBy?: string;
+  publishedAt: string;
+  currentVersion: boolean;
+}
+
+const unwrap = <T>(response: ApiResponse<T>): T => {
+  if (response.code !== 0 && response.code !== 200) {
+    throw new Error(response.message ?? response.msg ?? '工作流任务资源接口调用失败');
+  }
+  return response.data;
+};
+
+const append = (
+  params: URLSearchParams,
+  key: string,
+  value: string | number | boolean | undefined,
+) => {
+  if (value === undefined || value === '') return;
+  params.set(key, String(value));
+};
+
+const queryString = (query: WorkflowTaskLibraryQuery) => {
+  const params = new URLSearchParams();
+  append(params, 'projectId', query.projectId);
+  append(params, 'folderId', query.folderId);
+  append(params, 'taskType', query.taskType?.trim());
+  append(params, 'keyword', query.keyword?.trim());
+  append(params, 'favoriteOnly', query.favoriteOnly);
+  append(params, 'recentlyUsed', query.recentlyUsed);
+  append(params, 'sortBy', query.sortBy);
+  append(params, 'offset', query.offset);
+  append(params, 'limit', query.limit);
+  const value = params.toString();
+  return value ? `?${value}` : '';
+};
+
+export const workflowTaskLibraryRepository = {
+  async search(
+    query: WorkflowTaskLibraryQuery = {},
+  ): Promise<WorkflowPublishedTaskPage> {
+    return unwrap(
+      await HttpUtils.get<WorkflowPublishedTaskPage>(
+        `${API_PREFIX}${queryString(query)}`,
+      ),
+    );
+  },
+
+  async getPublishedVersion(
+    taskId: string,
+    versionId: string,
+  ): Promise<WorkflowPublishedTaskVersion> {
+    return unwrap(
+      await HttpUtils.get<WorkflowPublishedTaskVersion>(
+        `${API_PREFIX}/${encodeURIComponent(taskId)}/versions/${encodeURIComponent(versionId)}`,
+      ),
+    );
+  },
+};


### PR DESCRIPTION
## 背景

Workflow V2 已经明确只引用不可变 Task Version，但当前工作流设计器还没有一个安全、只读的任务发现边界。直接复用数据开发任务详情或版本接口会暴露草稿 Definition、Compiled Spec 和插件专属配置，也不适合作为左侧任务资源库。

本 PR 完成任务与工作流拆分计划的第二步：提供面向 Workflow 的已发布任务资源查询接口和前端类型客户端，不改动现有 Workflow V1 设计器、持久化或执行链路。

## 新增接口

```http
GET /api/v1/data-development/tasks/library
GET /api/v1/data-development/tasks/library/{taskId}/versions/{versionId}
```

两个接口均要求：

```text
workflow:definition:read
```

### 任务资源查询

资源库始终只返回：

- `status=PUBLISHED` 的任务；
- 当前 `published_version_id` 指向的不可变版本；
- 未删除的任务资源；
- 任务、项目、目录和版本展示信息；
- Input Schema 与 Output Schema；
- 当前用户的收藏状态和最近使用时间。

支持过滤：

- `projectId`
- `folderId`，其中 `0` 表示项目根目录
- `taskType`
- `keyword`
- `favoriteOnly`
- `recentlyUsed`
- `sortBy=UPDATED_AT|PUBLISHED_AT|RECENTLY_USED`
- `offset / limit`，最大 100

任务类型统一转为大写，关键字统一执行不区分大小写的参数化查询。开启 `recentlyUsed` 且未显式指定排序时，默认按最近使用时间排序。

### 发布版本安全投影

版本接口用于 Workflow 校验已绑定版本和后续显式版本升级，只返回：

- Task / Project 身份；
- Task Type、Plugin Version、Schema Version；
- Input Schema、Output Schema；
- Content Digest 和发布时间；
- 是否为任务当前发布版本。

不会返回：

```text
definitionSnapshot
compiledSpec
runtime
secret references or values
HTTP/Shell/SQL/Notebook 专属配置
```

历史不可变版本仍可通过已知 `taskId + versionId` 查询，但任务本身必须仍是有效的已发布任务。

## ID 契约

API 将 Task、Project、Folder 和 Version ID 序列化为字符串，前端可以直接写入 Workflow V2 `taskRef`，同时避免 JavaScript 大整数精度问题。

## 持久层与性能

新增独立只读边界：

- `WorkflowTaskLibraryRepository`
- `JdbcWorkflowTaskLibraryRepository`
- `WorkflowTaskLibraryService`
- `WorkflowTaskLibraryController`

Flyway V3 只增加两个查询索引：

- 已发布任务资源过滤索引；
- 当前用户最近执行任务索引。

不新增业务表，不复制任务版本快照。

## 前端客户端

新增：

```text
yak-ops-ui/src/pages/workflow-management/repository/workflow-task-library.repository.ts
```

包含任务资源、分页、过滤条件和发布版本的完整 TypeScript 类型。当前不会接入 Workflow V1 设计器，后续左侧 300px 任务资源栏可以直接复用。

## 测试与验证

- 使用 JDK 21 对新增 Java 主代码和测试完成独立语法编译；
- 服务测试覆盖 taskType / keyword 归一化、分页边界、最近使用排序和不可用版本；
- JDBC 测试锁定 `PUBLISHED`、当前版本、收藏、最近使用和 Schema 投影，并断言查询不包含 Definition / Compiled Spec；
- 使用 TypeScript 5.8 strict 模式检查前端客户端，通过；
- Maven POM 完成 XML 解析；
- Flyway V3 完成 SQL 语句与索引字段静态核对；
- GitHub compare 确认分支基于最新 `main`，只包含本步骤的 12 个文件。

当前环境无法执行完整 Maven Reactor、真实 MySQL Flyway 和项目级前端构建，需由本地或 CI 完成最终集成验证。

## 后续

下一步可以实现 Workflow V2 Reader/Writer 和发布校验，使新工作流草稿真正保存 `taskId + taskVersionId`，再进入左侧任务拖拽设计器重构。

## 合并说明

连接器按文件产生细粒度提交，建议最终使用 **Squash and merge**。