### PR TITLE
feat(workflow): persist and validate Workflow V2 definitions

### DIFF
--- a/docs/workflow/workflow-v2-reader-writer.md
+++ b/docs/workflow/workflow-v2-reader-writer.md
@@ -1,0 +1,90 @@
+# Workflow V2 Reader / Writer 与发布校验
+
+## 目标
+
+本阶段让 Workflow V2 成为可持久化、可读取、可发布的正式定义格式，同时保持 Workflow V1 的读取、编辑、发布和运行行为不变。
+
+## API
+
+新增 V2 写入入口：
+
+```http
+POST /api/v1/workflows/v2
+PUT  /api/v1/workflows/{workflowId}/draft/v2
+```
+
+现有读取和发布入口同时支持 V1/V2：
+
+```http
+GET  /api/v1/workflows/{workflowId}
+POST /api/v1/workflows/{workflowId}/publish
+GET  /api/v1/workflows/{workflowId}/versions/{version}
+```
+
+响应通过 `schemaVersion` 区分格式：
+
+- V1：`schemaVersion=1`，DAG 位于 `draft` / `dag`；
+- V2：`schemaVersion=2`，DAG 位于 `draftV2` / `dagV2`。
+
+旧客户端可以继续读取 V1 字段；新设计器根据 `schemaVersion` 选择对应 Reader。
+
+## 持久化
+
+Flyway 为定义和版本增加格式列：
+
+```text
+yak_wf_definition.draft_schema_version
+yak_wf_version.schema_version
+```
+
+历史数据默认值为 `1`。DAG JSON 仍保存在原有 `draft_json` 和 `dag_json` 中，不复制快照，不新增平行定义表。
+
+## Writer 约束
+
+- V1 创建和编辑始终写入 schema 1；
+- V2 创建和编辑始终写入 schema 2；
+- V1/V2 编辑入口不能静默转换已有工作流格式；
+- 格式迁移必须由后续显式迁移流程完成。
+
+## V2 DAG 校验
+
+保存草稿时执行结构校验和规范化：
+
+- 必须且只能有一个 START，至少一个 END；
+- 节点编码唯一且符合规范；
+- TASK 必须绑定完整不可变 Task Version；
+- START/END 禁止携带 taskRef；
+- 连线节点必须存在，DAG 不得成环；
+- START 不得有上游，END 不得有下游；
+- FAILURE 只能来自 TASK；
+- ROUTE_FAILURE 必须存在 FAILURE 连线；
+- NODE_OUTPUT 只能引用拓扑上游节点；
+- 输入目标不能重复；
+- 重试和超时不能为负数。
+
+## 发布校验
+
+V2 发布前通过 `PublishedTaskVersionCatalog` 逐个校验启用的 TASK 节点：
+
+- taskId + taskVersionId 对应的发布版本存在；
+- taskVersionNumber 与真实版本一致；
+- taskType 与真实版本一致；
+- Input Schema 中的 required 字段已经绑定。
+
+工作流允许固定历史不可变版本，不强制跟随任务当前最新版本。
+
+Workflow 只依赖公共只读端口。Data Development 提供适配器，Workflow 不直接查询 `yak_dev_*` 表，也不会读取 Definition、Compiled Spec 或密钥。
+
+## 运行边界
+
+本阶段没有实现 V2 运行时。运行一个已发布 V2 工作流会收到明确错误：
+
+```text
+Workflow V2 执行将在统一 Task Execution Gateway 阶段启用
+```
+
+这比把 V2 JSON 误读成 V1 节点并错误执行更安全。
+
+## 后续
+
+下一步可直接基于 V2 Writer 重构设计器：左侧加载已发布任务资源，拖入后生成 `taskRef`，右侧仅编辑输入映射和编排策略。

--- a/docs/workflow/workflow-v2-reader-writer.md
+++ b/docs/workflow/workflow-v2-reader-writer.md
@@ -64,14 +64,14 @@ yak_wf_version.schema_version
 
 ## 发布校验
 
-V2 发布前通过 `PublishedTaskVersionCatalog` 逐个校验启用的 TASK 节点：
+V2 发布前通过 `PublishedTaskVersionCatalog` 逐个校验所有 TASK 节点：
 
 - taskId + taskVersionId 对应的发布版本存在；
 - taskVersionNumber 与真实版本一致；
 - taskType 与真实版本一致；
 - Input Schema 中的 required 字段已经绑定。
 
-工作流允许固定历史不可变版本，不强制跟随任务当前最新版本。
+工作流允许固定历史不可变版本，不强制跟随任务当前最新版本。即使节点暂时禁用，发布快照中的 taskRef 也必须保持有效，避免以后启用时暴露悬空引用。
 
 Workflow 只依赖公共只读端口。Data Development 提供适配器，Workflow 不直接查询 `yak_dev_*` 表，也不会读取 Definition、Compiled Spec 或密钥。
 

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DataDevelopmentPublishedTaskVersionCatalog.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DataDevelopmentPublishedTaskVersionCatalog.java
@@ -1,0 +1,41 @@
+package io.yak.ops.business.development.service;
+
+import io.yak.ops.business.development.api.WorkflowTaskLibraryApi.PublishedTaskVersionView;
+import io.yak.ops.business.development.config.ConditionalOnDataDevelopmentEnabled;
+import io.yak.ops.common.port.workflow.PublishedTaskVersionCatalog;
+import java.util.Optional;
+import org.springframework.stereotype.Component;
+
+/** Bridges the data-development published task library into Workflow's validation port. */
+@ConditionalOnDataDevelopmentEnabled
+@Component
+public final class DataDevelopmentPublishedTaskVersionCatalog
+    implements PublishedTaskVersionCatalog {
+
+  private final WorkflowTaskLibraryService taskLibraryService;
+
+  public DataDevelopmentPublishedTaskVersionCatalog(
+      WorkflowTaskLibraryService taskLibraryService) {
+    this.taskLibraryService = taskLibraryService;
+  }
+
+  @Override
+  public Optional<PublishedTaskVersion> findPublishedVersion(long taskId, long versionId) {
+    try {
+      PublishedTaskVersionView source = taskLibraryService.getPublishedVersion(
+          taskId, versionId, "workflow-publish-validator");
+      return Optional.of(new PublishedTaskVersion(
+          Long.parseLong(source.taskId()),
+          Long.parseLong(source.versionId()),
+          source.versionNumber(),
+          source.taskType(),
+          source.inputSchema(),
+          source.outputSchema(),
+          source.contentDigest(),
+          source.publishedAt(),
+          source.currentVersion()));
+    } catch (IllegalArgumentException exception) {
+      return Optional.empty();
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/controller/v1/WorkflowController.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/controller/v1/WorkflowController.java
@@ -9,6 +9,8 @@ import io.yak.ops.common.bean.dto.workflow.WorkflowDTO;
 import io.yak.ops.common.bean.dto.workflow.WorkflowScheduleDTO;
 import io.yak.ops.common.bean.dto.workflow.WorkflowTriggerDTO;
 import io.yak.ops.common.bean.dto.workflow.WorkflowUpdateDTO;
+import io.yak.ops.common.bean.dto.workflow.WorkflowV2DTO;
+import io.yak.ops.common.bean.dto.workflow.WorkflowV2UpdateDTO;
 import io.yak.ops.common.bean.vo.workflow.WorkflowDefinitionVO;
 import io.yak.ops.common.bean.vo.workflow.WorkflowInstanceVO;
 import io.yak.ops.common.bean.vo.workflow.WorkflowScheduleVO;
@@ -57,11 +59,29 @@ public class WorkflowController {
     return Result.success(Map.of("workflowId", workflowId));
   }
 
+  @PostMapping("/v2")
+  public Result<Map<String, Long>> addWorkflowV2(
+      @Valid @RequestBody WorkflowV2DTO workflowDTO,
+      @RequestHeader(
+          name = "X-Operator",
+          defaultValue = WorkflowConstant.SYSTEM_OPERATOR) String operator) {
+    Long workflowId = definitionService.addWorkflowV2(workflowDTO, operator);
+    return Result.success(Map.of("workflowId", workflowId));
+  }
+
   @PutMapping({"/{workflowId}", "/{workflowId}/draft"})
   public Result<Boolean> editWorkflow(
       @PathVariable Long workflowId,
       @Valid @RequestBody WorkflowUpdateDTO workflowDTO) {
     definitionService.editWorkflow(workflowId, workflowDTO);
+    return Result.success(true);
+  }
+
+  @PutMapping("/{workflowId}/draft/v2")
+  public Result<Boolean> editWorkflowV2(
+      @PathVariable Long workflowId,
+      @Valid @RequestBody WorkflowV2UpdateDTO workflowDTO) {
+    definitionService.editWorkflowV2(workflowId, workflowDTO);
     return Result.success(true);
   }
 
@@ -96,6 +116,13 @@ public class WorkflowController {
   @GetMapping("/{workflowId}")
   public Result<WorkflowDefinitionVO> getWorkflow(@PathVariable Long workflowId) {
     return Result.success(definitionService.getWorkflow(workflowId));
+  }
+
+  @GetMapping("/{workflowId}/versions/{version}")
+  public Result<WorkflowVersionVO> getWorkflowVersion(
+      @PathVariable Long workflowId,
+      @PathVariable Integer version) {
+    return Result.success(definitionService.getWorkflowVersion(workflowId, version));
   }
 
   @PostMapping("/{workflowId}/run")

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dag/WorkflowV2DagValidator.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dag/WorkflowV2DagValidator.java
@@ -1,0 +1,317 @@
+package io.yak.ops.business.workflow.dag;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.workflow.config.ConditionalOnWorkflowEnabled;
+import io.yak.ops.common.bean.entity.workflow.v2.WorkflowV2BindingSource;
+import io.yak.ops.common.bean.entity.workflow.v2.WorkflowV2Dag;
+import io.yak.ops.common.bean.entity.workflow.v2.WorkflowV2Edge;
+import io.yak.ops.common.bean.entity.workflow.v2.WorkflowV2ExecutionPolicy;
+import io.yak.ops.common.bean.entity.workflow.v2.WorkflowV2InputBinding;
+import io.yak.ops.common.bean.entity.workflow.v2.WorkflowV2Node;
+import io.yak.ops.common.bean.entity.workflow.v2.WorkflowV2TaskReference;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+import org.springframework.stereotype.Component;
+
+/** Normalizes and validates the orchestration-only Workflow V2 DAG contract. */
+@ConditionalOnWorkflowEnabled
+@Component
+public final class WorkflowV2DagValidator {
+
+  private static final Pattern NODE_KEY = Pattern.compile("[A-Za-z][A-Za-z0-9_-]{0,63}");
+
+  private final ObjectMapper objectMapper;
+
+  public WorkflowV2DagValidator(ObjectMapper objectMapper) {
+    this.objectMapper = objectMapper;
+  }
+
+  public WorkflowV2Dag normalizeAndValidate(WorkflowV2Dag source) {
+    if (source == null) {
+      throw new IllegalArgumentException("Workflow V2 DAG 不能为空");
+    }
+    WorkflowV2Dag dag = objectMapper.convertValue(
+        objectMapper.valueToTree(source), WorkflowV2Dag.class);
+    if (dag.getSchemaVersion() != WorkflowV2Dag.SCHEMA_VERSION) {
+      throw new IllegalArgumentException("Workflow V2 schemaVersion 必须为 2");
+    }
+    if (dag.getNodes().isEmpty()) {
+      throw new IllegalArgumentException("Workflow V2 至少需要一个节点");
+    }
+
+    Map<String, WorkflowV2Node> nodes = new LinkedHashMap<>();
+    int startCount = 0;
+    int endCount = 0;
+    for (WorkflowV2Node node : dag.getNodes()) {
+      normalizeNode(node);
+      validateNode(node);
+      if (nodes.putIfAbsent(node.getKey(), node) != null) {
+        throw new IllegalArgumentException("Workflow V2 节点编码重复：" + node.getKey());
+      }
+      if (node.getKind() == WorkflowV2Node.Kind.START) startCount++;
+      if (node.getKind() == WorkflowV2Node.Kind.END) endCount++;
+    }
+    if (startCount != 1) {
+      throw new IllegalArgumentException("Workflow V2 必须且只能包含一个 START 节点");
+    }
+    if (endCount < 1) {
+      throw new IllegalArgumentException("Workflow V2 至少需要一个 END 节点");
+    }
+
+    Map<String, Set<String>> predecessors = new LinkedHashMap<>();
+    Map<String, Set<String>> successors = new LinkedHashMap<>();
+    nodes.keySet().forEach(key -> {
+      predecessors.put(key, new LinkedHashSet<>());
+      successors.put(key, new LinkedHashSet<>());
+    });
+
+    Set<String> edgeKeys = new LinkedHashSet<>();
+    List<WorkflowV2Edge> normalizedEdges = new ArrayList<>();
+    for (WorkflowV2Edge edge : dag.getEdges()) {
+      if (edge == null) {
+        throw new IllegalArgumentException("Workflow V2 连线不能为空");
+      }
+      edge.setFrom(trim(edge.getFrom()));
+      edge.setTo(trim(edge.getTo()));
+      if (!nodes.containsKey(edge.getFrom()) || !nodes.containsKey(edge.getTo())) {
+        throw new IllegalArgumentException(
+            "Workflow V2 连线引用了不存在的节点：" + edge.getFrom() + " -> " + edge.getTo());
+      }
+      if (edge.getFrom().equals(edge.getTo())) {
+        throw new IllegalArgumentException("Workflow V2 节点不能连接自身：" + edge.getFrom());
+      }
+      WorkflowV2Node from = nodes.get(edge.getFrom());
+      WorkflowV2Node to = nodes.get(edge.getTo());
+      if (from.getKind() == WorkflowV2Node.Kind.END) {
+        throw new IllegalArgumentException("END 节点不能连接下游：" + from.getKey());
+      }
+      if (to.getKind() == WorkflowV2Node.Kind.START) {
+        throw new IllegalArgumentException("START 节点不能存在上游：" + to.getKey());
+      }
+      if (edge.getFromPort() == WorkflowV2Edge.Port.FAILURE
+          && from.getKind() != WorkflowV2Node.Kind.TASK) {
+        throw new IllegalArgumentException("FAILURE 出口只能由 TASK 节点产生：" + from.getKey());
+      }
+      String edgeKey = edge.getFrom() + '\u0000' + edge.getFromPort() + '\u0000' + edge.getTo();
+      if (edgeKeys.add(edgeKey)) {
+        normalizedEdges.add(edge);
+        predecessors.get(edge.getTo()).add(edge.getFrom());
+        successors.get(edge.getFrom()).add(edge.getTo());
+      }
+    }
+    dag.setEdges(normalizedEdges);
+
+    List<String> topologicalOrder = topologicalSort(predecessors, successors);
+    validateFailureRoutes(nodes, normalizedEdges);
+    validateBindings(nodes, predecessors, topologicalOrder);
+    return dag;
+  }
+
+  private static void normalizeNode(WorkflowV2Node node) {
+    if (node == null) {
+      throw new IllegalArgumentException("Workflow V2 节点不能为空");
+    }
+    node.setKey(trim(node.getKey()));
+    node.setName(trim(node.getName()));
+    if (node.getTaskRef() != null) {
+      WorkflowV2TaskReference ref = node.getTaskRef();
+      ref.setTaskId(trim(ref.getTaskId()));
+      ref.setTaskVersionId(trim(ref.getTaskVersionId()));
+      ref.setTaskType(upper(ref.getTaskType()));
+    }
+    for (WorkflowV2InputBinding binding : node.getInputBindings()) {
+      if (binding != null) {
+        binding.setTarget(trim(binding.getTarget()));
+        normalizeSource(binding.getSource());
+      }
+    }
+    node.getOutputBindings().forEach((ignored, value) -> normalizeSource(value));
+  }
+
+  private static void normalizeSource(WorkflowV2BindingSource source) {
+    if (source == null) return;
+    source.setNodeKey(trim(source.getNodeKey()));
+    source.setPath(trim(source.getPath()));
+    source.setVariableName(trim(source.getVariableName()));
+  }
+
+  private static void validateNode(WorkflowV2Node node) {
+    if (node.getKey() == null || !NODE_KEY.matcher(node.getKey()).matches()) {
+      throw new IllegalArgumentException(
+          "Workflow V2 节点编码必须匹配 " + NODE_KEY.pattern() + "：" + node.getKey());
+    }
+    if (node.getName() == null) {
+      throw new IllegalArgumentException("Workflow V2 节点名称不能为空：" + node.getKey());
+    }
+    if (node.getKind() == null) {
+      throw new IllegalArgumentException("Workflow V2 节点类型不能为空：" + node.getKey());
+    }
+    if (node.getKind() == WorkflowV2Node.Kind.TASK) {
+      validateTaskReference(node);
+    } else if (node.getTaskRef() != null) {
+      throw new IllegalArgumentException(node.getKind() + " 节点不能包含 taskRef：" + node.getKey());
+    }
+    WorkflowV2ExecutionPolicy policy = node.getExecutionPolicy();
+    if (policy.getTimeoutSeconds() < 0
+        || policy.getRetryTimes() < 0
+        || policy.getRetryIntervalSeconds() < 0) {
+      throw new IllegalArgumentException("Workflow V2 重试和超时不能为负数：" + node.getKey());
+    }
+  }
+
+  private static void validateTaskReference(WorkflowV2Node node) {
+    WorkflowV2TaskReference ref = node.getTaskRef();
+    if (ref == null) {
+      throw new IllegalArgumentException("TASK 节点必须绑定 taskRef：" + node.getKey());
+    }
+    positiveId(ref.getTaskId(), "taskId", node.getKey());
+    positiveId(ref.getTaskVersionId(), "taskVersionId", node.getKey());
+    if (ref.getTaskVersionNumber() <= 0) {
+      throw new IllegalArgumentException("taskVersionNumber 必须为正整数：" + node.getKey());
+    }
+    if (ref.getTaskType() == null) {
+      throw new IllegalArgumentException("taskType 不能为空：" + node.getKey());
+    }
+  }
+
+  private static void validateFailureRoutes(
+      Map<String, WorkflowV2Node> nodes,
+      List<WorkflowV2Edge> edges) {
+    Set<String> failureSources = new LinkedHashSet<>();
+    edges.stream()
+        .filter(edge -> edge.getFromPort() == WorkflowV2Edge.Port.FAILURE)
+        .forEach(edge -> failureSources.add(edge.getFrom()));
+    nodes.values().stream()
+        .filter(node -> node.getKind() == WorkflowV2Node.Kind.TASK)
+        .filter(node -> node.getExecutionPolicy().getFailureAction()
+            == WorkflowV2ExecutionPolicy.FailureAction.ROUTE_FAILURE)
+        .filter(node -> !failureSources.contains(node.getKey()))
+        .findFirst()
+        .ifPresent(node -> {
+          throw new IllegalArgumentException(
+              "失败策略为 ROUTE_FAILURE 时必须配置 FAILURE 连线：" + node.getKey());
+        });
+  }
+
+  private static void validateBindings(
+      Map<String, WorkflowV2Node> nodes,
+      Map<String, Set<String>> predecessors,
+      List<String> topologicalOrder) {
+    Map<String, Set<String>> ancestors = new LinkedHashMap<>();
+    for (String nodeKey : topologicalOrder) {
+      Set<String> values = new LinkedHashSet<>();
+      for (String predecessor : predecessors.get(nodeKey)) {
+        values.add(predecessor);
+        values.addAll(ancestors.getOrDefault(predecessor, Set.of()));
+      }
+      ancestors.put(nodeKey, values);
+    }
+
+    for (WorkflowV2Node node : nodes.values()) {
+      Set<String> targets = new LinkedHashSet<>();
+      for (WorkflowV2InputBinding binding : node.getInputBindings()) {
+        if (binding == null || binding.getTarget() == null || binding.getSource() == null) {
+          throw new IllegalArgumentException("输入映射不完整：" + node.getKey());
+        }
+        if (!targets.add(binding.getTarget())) {
+          throw new IllegalArgumentException(
+              "输入映射目标重复：" + node.getKey() + "/" + binding.getTarget());
+        }
+        validateBindingSource(node, binding.getSource(), nodes, ancestors);
+      }
+      for (Map.Entry<String, WorkflowV2BindingSource> entry : node.getOutputBindings().entrySet()) {
+        if (trim(entry.getKey()) == null || entry.getValue() == null) {
+          throw new IllegalArgumentException("输出映射不完整：" + node.getKey());
+        }
+        validateBindingSource(node, entry.getValue(), nodes, ancestors);
+      }
+    }
+  }
+
+  private static void validateBindingSource(
+      WorkflowV2Node owner,
+      WorkflowV2BindingSource source,
+      Map<String, WorkflowV2Node> nodes,
+      Map<String, Set<String>> ancestors) {
+    if (source.getType() == null) {
+      throw new IllegalArgumentException("映射来源类型不能为空：" + owner.getKey());
+    }
+    switch (source.getType()) {
+      case START_INPUT -> requireText(source.getPath(), "START_INPUT path", owner.getKey());
+      case WORKFLOW_VARIABLE -> requireText(
+          source.getVariableName(), "WORKFLOW_VARIABLE variableName", owner.getKey());
+      case LITERAL -> { }
+      case NODE_OUTPUT -> {
+        requireText(source.getNodeKey(), "NODE_OUTPUT nodeKey", owner.getKey());
+        requireText(source.getPath(), "NODE_OUTPUT path", owner.getKey());
+        if (!nodes.containsKey(source.getNodeKey())) {
+          throw new IllegalArgumentException(
+              "NODE_OUTPUT 引用了不存在的节点：" + source.getNodeKey());
+        }
+        if (!ancestors.getOrDefault(owner.getKey(), Set.of()).contains(source.getNodeKey())) {
+          throw new IllegalArgumentException(
+              "NODE_OUTPUT 只能引用拓扑上游节点：" + owner.getKey() + " <- " + source.getNodeKey());
+        }
+      }
+    }
+  }
+
+  private static List<String> topologicalSort(
+      Map<String, Set<String>> predecessors,
+      Map<String, Set<String>> successors) {
+    Map<String, Integer> indegrees = new LinkedHashMap<>();
+    predecessors.forEach((key, value) -> indegrees.put(key, value.size()));
+    Deque<String> ready = new ArrayDeque<>();
+    indegrees.forEach((key, value) -> {
+      if (value == 0) ready.addLast(key);
+    });
+    List<String> result = new ArrayList<>();
+    while (!ready.isEmpty()) {
+      String key = ready.removeFirst();
+      result.add(key);
+      for (String successor : successors.getOrDefault(key, Set.of())) {
+        int value = indegrees.computeIfPresent(successor, (ignored, current) -> current - 1);
+        if (value == 0) ready.addLast(successor);
+      }
+    }
+    if (result.size() != predecessors.size()) {
+      throw new IllegalArgumentException("Workflow V2 DAG 存在环");
+    }
+    return result;
+  }
+
+  private static long positiveId(String value, String field, String nodeKey) {
+    try {
+      long result = Long.parseLong(value);
+      if (result <= 0L) throw new NumberFormatException();
+      return result;
+    } catch (NumberFormatException exception) {
+      throw new IllegalArgumentException(field + " 必须是正整数：" + nodeKey);
+    }
+  }
+
+  private static void requireText(String value, String field, String nodeKey) {
+    if (trim(value) == null) {
+      throw new IllegalArgumentException(field + " 不能为空：" + nodeKey);
+    }
+  }
+
+  private static String trim(String value) {
+    if (value == null) return null;
+    String text = value.trim();
+    return text.isEmpty() ? null : text;
+  }
+
+  private static String upper(String value) {
+    String text = trim(value);
+    return text == null ? null : text.toUpperCase(Locale.ROOT);
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dag/WorkflowV2PublicationValidator.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dag/WorkflowV2PublicationValidator.java
@@ -1,0 +1,81 @@
+package io.yak.ops.business.workflow.dag;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.yak.ops.business.workflow.config.ConditionalOnWorkflowEnabled;
+import io.yak.ops.common.bean.entity.workflow.v2.WorkflowV2Dag;
+import io.yak.ops.common.bean.entity.workflow.v2.WorkflowV2Node;
+import io.yak.ops.common.bean.entity.workflow.v2.WorkflowV2TaskReference;
+import io.yak.ops.common.port.workflow.PublishedTaskVersionCatalog;
+import io.yak.ops.common.port.workflow.PublishedTaskVersionCatalog.PublishedTaskVersion;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import org.springframework.stereotype.Component;
+
+/** Validates every Workflow V2 task reference immediately before publication. */
+@ConditionalOnWorkflowEnabled
+@Component
+public final class WorkflowV2PublicationValidator {
+
+  private final List<PublishedTaskVersionCatalog> catalogs;
+
+  public WorkflowV2PublicationValidator(List<PublishedTaskVersionCatalog> catalogs) {
+    this.catalogs = catalogs == null ? List.of() : List.copyOf(catalogs);
+  }
+
+  public void validate(WorkflowV2Dag dag) {
+    if (catalogs.isEmpty()) {
+      throw new IllegalStateException(
+          "Workflow V2 发布校验不可用：未装配已发布任务版本目录");
+    }
+    if (catalogs.size() > 1) {
+      throw new IllegalStateException(
+          "Workflow V2 发布校验配置错误：存在多个已发布任务版本目录");
+    }
+    PublishedTaskVersionCatalog catalog = catalogs.get(0);
+    for (WorkflowV2Node node : dag.getNodes()) {
+      if (node.getKind() != WorkflowV2Node.Kind.TASK || !node.isEnabled()) continue;
+      validateTaskNode(node, catalog);
+    }
+  }
+
+  private static void validateTaskNode(
+      WorkflowV2Node node,
+      PublishedTaskVersionCatalog catalog) {
+    WorkflowV2TaskReference ref = node.getTaskRef();
+    long taskId = Long.parseLong(ref.getTaskId());
+    long versionId = Long.parseLong(ref.getTaskVersionId());
+    PublishedTaskVersion version = catalog.findPublishedVersion(taskId, versionId)
+        .orElseThrow(() -> new IllegalArgumentException(
+            "节点引用的已发布任务版本不存在或不可用：" + node.getKey()
+                + "，taskId=" + taskId + "，versionId=" + versionId));
+    if (version.versionNumber() != ref.getTaskVersionNumber()) {
+      throw new IllegalArgumentException(
+          "节点任务版本号不匹配：" + node.getKey() + "，引用="
+              + ref.getTaskVersionNumber() + "，实际=" + version.versionNumber());
+    }
+    String actualType = version.taskType() == null
+        ? "" : version.taskType().trim().toUpperCase(Locale.ROOT);
+    if (!actualType.equals(ref.getTaskType())) {
+      throw new IllegalArgumentException(
+          "节点任务类型不匹配：" + node.getKey() + "，引用="
+              + ref.getTaskType() + "，实际=" + actualType);
+    }
+    validateRequiredInputs(node, version.inputSchema());
+  }
+
+  private static void validateRequiredInputs(WorkflowV2Node node, JsonNode inputSchema) {
+    if (inputSchema == null || !inputSchema.isObject()) return;
+    JsonNode required = inputSchema.path("required");
+    if (!required.isArray()) return;
+    Set<String> boundTargets = new LinkedHashSet<>();
+    node.getInputBindings().forEach(binding -> boundTargets.add(binding.getTarget()));
+    for (JsonNode item : required) {
+      if (item.isTextual() && !boundTargets.contains(item.asText())) {
+        throw new IllegalArgumentException(
+            "节点必填输入未绑定：" + node.getKey() + "/" + item.asText());
+      }
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dag/WorkflowV2PublicationValidator.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dag/WorkflowV2PublicationValidator.java
@@ -25,6 +25,12 @@ public final class WorkflowV2PublicationValidator {
   }
 
   public void validate(WorkflowV2Dag dag) {
+    List<WorkflowV2Node> taskNodes = dag.getNodes().stream()
+        .filter(node -> node.getKind() == WorkflowV2Node.Kind.TASK)
+        .toList();
+    if (taskNodes.isEmpty()) {
+      return;
+    }
     if (catalogs.isEmpty()) {
       throw new IllegalStateException(
           "Workflow V2 发布校验不可用：未装配已发布任务版本目录");
@@ -34,10 +40,7 @@ public final class WorkflowV2PublicationValidator {
           "Workflow V2 发布校验配置错误：存在多个已发布任务版本目录");
     }
     PublishedTaskVersionCatalog catalog = catalogs.get(0);
-    for (WorkflowV2Node node : dag.getNodes()) {
-      if (node.getKind() != WorkflowV2Node.Kind.TASK || !node.isEnabled()) continue;
-      validateTaskNode(node, catalog);
-    }
+    taskNodes.forEach(node -> validateTaskNode(node, catalog));
   }
 
   private static void validateTaskNode(

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/impl/WorkflowDefinitionDaoImpl.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/impl/WorkflowDefinitionDaoImpl.java
@@ -5,8 +5,8 @@ import io.yak.ops.business.workflow.config.ConditionalOnWorkflowEnabled;
 import io.yak.ops.business.workflow.dao.WorkflowDefinitionDao;
 import io.yak.ops.business.workflow.dao.mapper.WorkflowDefinitionMapper;
 import io.yak.ops.business.workflow.dao.mapper.WorkflowVersionMapper;
-import io.yak.ops.business.workflow.util.WorkflowConvertUtils;
 import io.yak.ops.business.workflow.util.WorkflowJsonCodec;
+import io.yak.ops.business.workflow.util.WorkflowV2ConvertUtils;
 import io.yak.ops.common.bean.entity.workflow.WorkflowDefinition;
 import io.yak.ops.common.bean.entity.workflow.WorkflowVersion;
 import io.yak.ops.common.bean.po.workflow.WorkflowDefinitionPO;
@@ -53,7 +53,7 @@ public class WorkflowDefinitionDaoImpl implements WorkflowDefinitionDao {
 
   @Override
   public WorkflowDefinition selectDefinitionById(Long workflowId) {
-    return WorkflowConvertUtils.toDefinition(definitionMapper.selectById(workflowId), jsonCodec);
+    return WorkflowV2ConvertUtils.toDefinition(definitionMapper.selectById(workflowId), jsonCodec);
   }
 
   @Override
@@ -63,7 +63,7 @@ public class WorkflowDefinitionDaoImpl implements WorkflowDefinitionDao {
                 .orderByDesc(WorkflowDefinitionPO::getUpdatedAt)
                 .orderByDesc(WorkflowDefinitionPO::getId))
         .stream()
-        .map(item -> WorkflowConvertUtils.toDefinition(item, jsonCodec))
+        .map(item -> WorkflowV2ConvertUtils.toDefinition(item, jsonCodec))
         .collect(Collectors.toList());
   }
 
@@ -78,6 +78,6 @@ public class WorkflowDefinitionDaoImpl implements WorkflowDefinitionDao {
         Wrappers.<WorkflowVersionPO>lambdaQuery()
             .eq(WorkflowVersionPO::getWorkflowId, workflowId)
             .eq(WorkflowVersionPO::getVersion, version));
-    return WorkflowConvertUtils.toVersion(versionPO, jsonCodec);
+    return WorkflowV2ConvertUtils.toVersion(versionPO, jsonCodec);
   }
 }

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowDefinitionService.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowDefinitionService.java
@@ -2,6 +2,8 @@ package io.yak.ops.business.workflow.service;
 
 import io.yak.ops.common.bean.dto.workflow.WorkflowDTO;
 import io.yak.ops.common.bean.dto.workflow.WorkflowUpdateDTO;
+import io.yak.ops.common.bean.dto.workflow.WorkflowV2DTO;
+import io.yak.ops.common.bean.dto.workflow.WorkflowV2UpdateDTO;
 import io.yak.ops.common.bean.vo.workflow.WorkflowDefinitionVO;
 import io.yak.ops.common.bean.vo.workflow.WorkflowVersionVO;
 import java.util.List;
@@ -11,13 +13,19 @@ public interface WorkflowDefinitionService {
 
   Long addWorkflow(WorkflowDTO workflowDTO, String operator);
 
+  Long addWorkflowV2(WorkflowV2DTO workflowDTO, String operator);
+
   void editWorkflow(Long workflowId, WorkflowUpdateDTO workflowDTO);
+
+  void editWorkflowV2(Long workflowId, WorkflowV2UpdateDTO workflowDTO);
 
   void deleteWorkflow(Long workflowId);
 
   WorkflowVersionVO publishWorkflow(Long workflowId, String operator);
 
   WorkflowDefinitionVO getWorkflow(Long workflowId);
+
+  WorkflowVersionVO getWorkflowVersion(Long workflowId, Integer version);
 
   List<WorkflowDefinitionVO> getWorkflowList();
 }

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/impl/WorkflowDefinitionServiceImpl.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/impl/WorkflowDefinitionServiceImpl.java
@@ -2,17 +2,22 @@ package io.yak.ops.business.workflow.service.impl;
 
 import io.yak.ops.business.workflow.config.ConditionalOnWorkflowEnabled;
 import io.yak.ops.business.workflow.dag.WorkflowDagCompiler;
+import io.yak.ops.business.workflow.dag.WorkflowV2DagValidator;
+import io.yak.ops.business.workflow.dag.WorkflowV2PublicationValidator;
 import io.yak.ops.business.workflow.dao.WorkflowDefinitionDao;
 import io.yak.ops.business.workflow.dao.WorkflowExecutionDao;
 import io.yak.ops.business.workflow.service.WorkflowDefinitionService;
 import io.yak.ops.business.workflow.service.WorkflowScheduleService;
-import io.yak.ops.business.workflow.util.WorkflowConvertUtils;
 import io.yak.ops.business.workflow.util.WorkflowJsonCodec;
+import io.yak.ops.business.workflow.util.WorkflowV2ConvertUtils;
 import io.yak.ops.common.bean.dto.workflow.WorkflowDTO;
 import io.yak.ops.common.bean.dto.workflow.WorkflowUpdateDTO;
+import io.yak.ops.common.bean.dto.workflow.WorkflowV2DTO;
+import io.yak.ops.common.bean.dto.workflow.WorkflowV2UpdateDTO;
 import io.yak.ops.common.bean.entity.workflow.WorkflowDag;
 import io.yak.ops.common.bean.entity.workflow.WorkflowDefinition;
 import io.yak.ops.common.bean.entity.workflow.WorkflowVersion;
+import io.yak.ops.common.bean.entity.workflow.v2.WorkflowV2Dag;
 import io.yak.ops.common.bean.po.workflow.WorkflowDefinitionPO;
 import io.yak.ops.common.bean.po.workflow.WorkflowVersionPO;
 import io.yak.ops.common.bean.vo.workflow.WorkflowDefinitionVO;
@@ -37,6 +42,8 @@ public class WorkflowDefinitionServiceImpl implements WorkflowDefinitionService 
   private final WorkflowExecutionDao executionDao;
   private final WorkflowScheduleService scheduleService;
   private final WorkflowDagCompiler dagCompiler;
+  private final WorkflowV2DagValidator v2DagValidator;
+  private final WorkflowV2PublicationValidator v2PublicationValidator;
   private final WorkflowJsonCodec jsonCodec;
 
   @Override
@@ -44,20 +51,56 @@ public class WorkflowDefinitionServiceImpl implements WorkflowDefinitionService 
   public Long addWorkflow(WorkflowDTO workflowDTO, String operator) {
     validate(workflowDTO);
     WorkflowDag normalizedDag = dagCompiler.normalizeAndValidate(workflowDTO.getDag());
-    String code = workflowDTO.getCode().trim();
+    return addDefinition(
+        workflowDTO.getCode(),
+        workflowDTO.getName(),
+        workflowDTO.getDescription(),
+        workflowDTO.getFailureStrategy(),
+        workflowDTO.getMaxParallelism(),
+        1,
+        normalizedDag,
+        operator);
+  }
+
+  @Override
+  @Transactional(transactionManager = "workflowTransactionManager")
+  public Long addWorkflowV2(WorkflowV2DTO workflowDTO, String operator) {
+    validate(workflowDTO);
+    WorkflowV2Dag normalizedDag = v2DagValidator.normalizeAndValidate(workflowDTO.getDag());
+    return addDefinition(
+        workflowDTO.getCode(),
+        workflowDTO.getName(),
+        workflowDTO.getDescription(),
+        workflowDTO.getFailureStrategy(),
+        workflowDTO.getMaxParallelism(),
+        WorkflowV2Dag.SCHEMA_VERSION,
+        normalizedDag,
+        operator);
+  }
+
+  private Long addDefinition(
+      String codeValue,
+      String nameValue,
+      String description,
+      FailureStrategy failureStrategy,
+      int maxParallelism,
+      int schemaVersion,
+      Object dag,
+      String operator) {
+    String code = codeValue.trim();
     if (definitionDao.existsDefinitionByCode(code)) {
       throw new IllegalArgumentException("工作流编码已存在：" + code);
     }
-
     Date now = new Date();
     WorkflowDefinitionPO definitionPO = new WorkflowDefinitionPO();
     definitionPO.setCode(code);
-    definitionPO.setName(workflowDTO.getName().trim());
-    definitionPO.setDescription(workflowDTO.getDescription());
+    definitionPO.setName(nameValue.trim());
+    definitionPO.setDescription(description);
     definitionPO.setState(DefinitionState.DRAFT.name());
-    definitionPO.setFailureStrategy(strategy(workflowDTO.getFailureStrategy()).name());
-    definitionPO.setMaxParallelism(workflowDTO.getMaxParallelism());
-    definitionPO.setDraftJson(jsonCodec.write(normalizedDag));
+    definitionPO.setFailureStrategy(strategy(failureStrategy).name());
+    definitionPO.setMaxParallelism(maxParallelism);
+    definitionPO.setDraftSchemaVersion(schemaVersion);
+    definitionPO.setDraftJson(jsonCodec.write(dag));
     definitionPO.setCreatedBy(operator);
     definitionPO.setCreatedAt(now);
     definitionPO.setUpdatedAt(now);
@@ -69,15 +112,52 @@ public class WorkflowDefinitionServiceImpl implements WorkflowDefinitionService 
   @Transactional(transactionManager = "workflowTransactionManager")
   public void editWorkflow(Long workflowId, WorkflowUpdateDTO workflowDTO) {
     validate(workflowDTO);
+    WorkflowDefinition definition = requireWorkflow(workflowId);
+    requireSchema(definition, 1, "V1");
     WorkflowDag normalizedDag = dagCompiler.normalizeAndValidate(workflowDTO.getDag());
-    requireWorkflow(workflowId);
+    editDefinition(
+        workflowId,
+        workflowDTO.getName(),
+        workflowDTO.getDescription(),
+        workflowDTO.getFailureStrategy(),
+        workflowDTO.getMaxParallelism(),
+        1,
+        normalizedDag);
+  }
+
+  @Override
+  @Transactional(transactionManager = "workflowTransactionManager")
+  public void editWorkflowV2(Long workflowId, WorkflowV2UpdateDTO workflowDTO) {
+    validate(workflowDTO);
+    WorkflowDefinition definition = requireWorkflow(workflowId);
+    requireSchema(definition, WorkflowV2Dag.SCHEMA_VERSION, "V2");
+    WorkflowV2Dag normalizedDag = v2DagValidator.normalizeAndValidate(workflowDTO.getDag());
+    editDefinition(
+        workflowId,
+        workflowDTO.getName(),
+        workflowDTO.getDescription(),
+        workflowDTO.getFailureStrategy(),
+        workflowDTO.getMaxParallelism(),
+        WorkflowV2Dag.SCHEMA_VERSION,
+        normalizedDag);
+  }
+
+  private void editDefinition(
+      Long workflowId,
+      String name,
+      String description,
+      FailureStrategy failureStrategy,
+      int maxParallelism,
+      int schemaVersion,
+      Object dag) {
     WorkflowDefinitionPO definitionPO = new WorkflowDefinitionPO();
     definitionPO.setId(workflowId);
-    definitionPO.setName(workflowDTO.getName().trim());
-    definitionPO.setDescription(workflowDTO.getDescription());
-    definitionPO.setFailureStrategy(strategy(workflowDTO.getFailureStrategy()).name());
-    definitionPO.setMaxParallelism(workflowDTO.getMaxParallelism());
-    definitionPO.setDraftJson(jsonCodec.write(normalizedDag));
+    definitionPO.setName(name.trim());
+    definitionPO.setDescription(description);
+    definitionPO.setFailureStrategy(strategy(failureStrategy).name());
+    definitionPO.setMaxParallelism(maxParallelism);
+    definitionPO.setDraftSchemaVersion(schemaVersion);
+    definitionPO.setDraftJson(jsonCodec.write(dag));
     definitionPO.setUpdatedAt(new Date());
     if (definitionDao.editDefinition(definitionPO) != 1) {
       throw new IllegalArgumentException("工作流定义不存在：" + workflowId);
@@ -101,17 +181,29 @@ public class WorkflowDefinitionServiceImpl implements WorkflowDefinitionService 
   @Transactional(transactionManager = "workflowTransactionManager")
   public WorkflowVersionVO publishWorkflow(Long workflowId, String operator) {
     WorkflowDefinition definition = requireWorkflow(workflowId);
-    dagCompiler.compile(definition.getDraft());
+    Object normalizedDag;
+    if (definition.getSchemaVersion() == 1) {
+      dagCompiler.compile(definition.getDraft());
+      normalizedDag = definition.getDraft();
+    } else if (definition.getSchemaVersion() == WorkflowV2Dag.SCHEMA_VERSION) {
+      WorkflowV2Dag dag = v2DagValidator.normalizeAndValidate(definition.getDraftV2());
+      v2PublicationValidator.validate(dag);
+      normalizedDag = dag;
+    } else {
+      throw new IllegalStateException(
+          "不支持的工作流 schemaVersion：" + definition.getSchemaVersion());
+    }
+
     int version = definition.getCurrentVersion() == null
         ? 1
         : definition.getCurrentVersion() + 1;
     Date now = new Date();
-
     WorkflowVersionPO versionPO = new WorkflowVersionPO();
     versionPO.setWorkflowId(workflowId);
     versionPO.setVersion(version);
-    versionPO.setDagJson(jsonCodec.write(definition.getDraft()));
-    versionPO.setContentHash(jsonCodec.sha256(definition.getDraft()));
+    versionPO.setSchemaVersion(definition.getSchemaVersion());
+    versionPO.setDagJson(jsonCodec.write(normalizedDag));
+    versionPO.setContentHash(jsonCodec.sha256(normalizedDag));
     versionPO.setPublishedBy(operator);
     versionPO.setPublishedAt(now);
     definitionDao.addVersion(versionPO);
@@ -123,19 +215,23 @@ public class WorkflowDefinitionServiceImpl implements WorkflowDefinitionService 
     definitionPO.setUpdatedAt(now);
     definitionDao.editDefinition(definitionPO);
 
-    WorkflowVersion published = definitionDao.selectVersion(workflowId, version);
-    return WorkflowConvertUtils.toVO(published);
+    return WorkflowV2ConvertUtils.toVO(requireVersion(workflowId, version));
   }
 
   @Override
   public WorkflowDefinitionVO getWorkflow(Long workflowId) {
-    return WorkflowConvertUtils.toVO(requireWorkflow(workflowId));
+    return WorkflowV2ConvertUtils.toVO(requireWorkflow(workflowId));
+  }
+
+  @Override
+  public WorkflowVersionVO getWorkflowVersion(Long workflowId, Integer version) {
+    return WorkflowV2ConvertUtils.toVO(requireVersion(workflowId, version));
   }
 
   @Override
   public List<WorkflowDefinitionVO> getWorkflowList() {
     return definitionDao.selectAllDefinition().stream()
-        .map(WorkflowConvertUtils::toVO)
+        .map(WorkflowV2ConvertUtils::toVO)
         .collect(Collectors.toList());
   }
 
@@ -147,21 +243,54 @@ public class WorkflowDefinitionServiceImpl implements WorkflowDefinitionService 
     return definition;
   }
 
-  private static void validate(WorkflowDTO workflowDTO) {
-    if (workflowDTO == null) {
-      throw new IllegalArgumentException("工作流定义不能为空");
+  private WorkflowVersion requireVersion(Long workflowId, Integer version) {
+    if (version == null || version <= 0) {
+      throw new IllegalArgumentException("工作流版本号必须为正整数");
     }
-    requireText(workflowDTO.getCode(), "工作流编码");
-    requireText(workflowDTO.getName(), "工作流名称");
-    validateParallelism(workflowDTO.getMaxParallelism());
+    WorkflowVersion result = definitionDao.selectVersion(workflowId, version);
+    if (result == null) {
+      throw new IllegalArgumentException("工作流版本不存在：" + workflowId + "/" + version);
+    }
+    return result;
   }
 
-  private static void validate(WorkflowUpdateDTO workflowDTO) {
-    if (workflowDTO == null) {
-      throw new IllegalArgumentException("工作流草稿不能为空");
+  private static void requireSchema(
+      WorkflowDefinition definition,
+      int expected,
+      String writerName) {
+    if (definition.getSchemaVersion() != expected) {
+      throw new IllegalStateException(
+          writerName + " Writer 不能修改 schemaVersion=" + definition.getSchemaVersion()
+              + " 的工作流；格式迁移必须显式执行");
     }
-    requireText(workflowDTO.getName(), "工作流名称");
-    validateParallelism(workflowDTO.getMaxParallelism());
+  }
+
+  private static void validate(WorkflowDTO dto) {
+    if (dto == null) throw new IllegalArgumentException("工作流定义不能为空");
+    validateCommon(dto.getCode(), dto.getName(), dto.getMaxParallelism());
+  }
+
+  private static void validate(WorkflowV2DTO dto) {
+    if (dto == null) throw new IllegalArgumentException("Workflow V2 定义不能为空");
+    validateCommon(dto.getCode(), dto.getName(), dto.getMaxParallelism());
+  }
+
+  private static void validate(WorkflowUpdateDTO dto) {
+    if (dto == null) throw new IllegalArgumentException("工作流草稿不能为空");
+    requireText(dto.getName(), "工作流名称");
+    validateParallelism(dto.getMaxParallelism());
+  }
+
+  private static void validate(WorkflowV2UpdateDTO dto) {
+    if (dto == null) throw new IllegalArgumentException("Workflow V2 草稿不能为空");
+    requireText(dto.getName(), "工作流名称");
+    validateParallelism(dto.getMaxParallelism());
+  }
+
+  private static void validateCommon(String code, String name, int maxParallelism) {
+    requireText(code, "工作流编码");
+    requireText(name, "工作流名称");
+    validateParallelism(maxParallelism);
   }
 
   private static void validateParallelism(int maxParallelism) {

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/impl/WorkflowExecutionServiceImpl.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/impl/WorkflowExecutionServiceImpl.java
@@ -95,6 +95,10 @@ public class WorkflowExecutionServiceImpl implements WorkflowExecutionService {
       throw new IllegalStateException(
           "已发布的工作流版本不存在：" + workflowId + "/" + definition.getCurrentVersion());
     }
+    if (version.getSchemaVersion() != 1) {
+      throw new IllegalStateException(
+          "Workflow V2 执行将在统一 Task Execution Gateway 阶段启用：" + workflowId);
+    }
 
     Date now = new Date();
     WorkflowInstancePO instancePO = new WorkflowInstancePO();

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/util/WorkflowJsonCodec.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/util/WorkflowJsonCodec.java
@@ -2,9 +2,11 @@ package io.yak.ops.business.workflow.util;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.yak.ops.common.bean.entity.workflow.WorkflowDag;
 import io.yak.ops.business.workflow.config.ConditionalOnWorkflowEnabled;
+import io.yak.ops.common.bean.entity.workflow.WorkflowDag;
+import io.yak.ops.common.bean.entity.workflow.v2.WorkflowV2Dag;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -35,13 +37,19 @@ public class WorkflowJsonCodec {
   }
 
   public WorkflowDag readDag(String json) {
-    if (json == null || json.isBlank()) {
-      return new WorkflowDag();
-    }
+    return read(json, WorkflowDag.class, new WorkflowDag(), "工作流 V1 DAG 反序列化失败");
+  }
+
+  public WorkflowV2Dag readV2Dag(String json) {
+    return read(json, WorkflowV2Dag.class, new WorkflowV2Dag(), "工作流 V2 DAG 反序列化失败");
+  }
+
+  public JsonNode readTree(String json) {
+    if (json == null || json.isBlank()) return objectMapper.createObjectNode();
     try {
-      return objectMapper.readValue(json, WorkflowDag.class);
+      return objectMapper.readTree(json);
     } catch (JsonProcessingException error) {
-      throw new IllegalStateException("工作流 DAG 反序列化失败", error);
+      throw new IllegalStateException("工作流 JSON 反序列化失败", error);
     }
   }
 
@@ -63,6 +71,15 @@ public class WorkflowJsonCodec {
       return HexFormat.of().formatHex(digest);
     } catch (NoSuchAlgorithmException error) {
       throw new IllegalStateException("当前运行环境不支持 SHA-256", error);
+    }
+  }
+
+  private <T> T read(String json, Class<T> type, T emptyValue, String message) {
+    if (json == null || json.isBlank()) return emptyValue;
+    try {
+      return objectMapper.readValue(json, type);
+    } catch (JsonProcessingException error) {
+      throw new IllegalStateException(message, error);
     }
   }
 }

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/util/WorkflowV2ConvertUtils.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/util/WorkflowV2ConvertUtils.java
@@ -1,0 +1,122 @@
+package io.yak.ops.business.workflow.util;
+
+import io.yak.ops.common.bean.entity.workflow.WorkflowDag;
+import io.yak.ops.common.bean.entity.workflow.WorkflowDefinition;
+import io.yak.ops.common.bean.entity.workflow.WorkflowVersion;
+import io.yak.ops.common.bean.po.workflow.WorkflowDefinitionPO;
+import io.yak.ops.common.bean.po.workflow.WorkflowVersionPO;
+import io.yak.ops.common.bean.vo.workflow.WorkflowDefinitionVO;
+import io.yak.ops.common.bean.vo.workflow.WorkflowVersionVO;
+import io.yak.ops.common.enums.workflow.DefinitionState;
+import io.yak.ops.common.enums.workflow.FailureStrategy;
+
+/** Schema-aware conversion support kept separate from the legacy V1 converter. */
+public final class WorkflowV2ConvertUtils {
+
+  private WorkflowV2ConvertUtils() {
+  }
+
+  public static WorkflowDefinition toDefinition(
+      WorkflowDefinitionPO source,
+      WorkflowJsonCodec codec) {
+    if (source == null) return null;
+    int schemaVersion = schema(source.getDraftSchemaVersion());
+    if (schemaVersion == 1) {
+      WorkflowDefinition target = WorkflowConvertUtils.toDefinition(source, codec);
+      target.setSchemaVersion(1);
+      return target;
+    }
+    if (schemaVersion != 2) {
+      throw new IllegalStateException("不支持的工作流草稿 schemaVersion：" + schemaVersion);
+    }
+    WorkflowDefinition target = new WorkflowDefinition();
+    target.setId(source.getId());
+    target.setCode(source.getCode());
+    target.setName(source.getName());
+    target.setDescription(source.getDescription());
+    target.setState(DefinitionState.valueOf(source.getState()));
+    target.setCurrentVersion(source.getCurrentVersion());
+    target.setFailureStrategy(FailureStrategy.valueOf(source.getFailureStrategy()));
+    target.setMaxParallelism(source.getMaxParallelism() == null ? 0 : source.getMaxParallelism());
+    target.setSchemaVersion(2);
+    target.setDraft(new WorkflowDag());
+    target.setDraftV2(codec.readV2Dag(source.getDraftJson()));
+    target.setCreatedBy(source.getCreatedBy());
+    target.setCreatedAt(source.getCreatedAt());
+    target.setUpdatedAt(source.getUpdatedAt());
+    return target;
+  }
+
+  public static WorkflowVersion toVersion(
+      WorkflowVersionPO source,
+      WorkflowJsonCodec codec) {
+    if (source == null) return null;
+    int schemaVersion = schema(source.getSchemaVersion());
+    if (schemaVersion == 1) {
+      WorkflowVersion target = WorkflowConvertUtils.toVersion(source, codec);
+      target.setSchemaVersion(1);
+      return target;
+    }
+    if (schemaVersion != 2) {
+      throw new IllegalStateException("不支持的工作流版本 schemaVersion：" + schemaVersion);
+    }
+    WorkflowVersion target = new WorkflowVersion();
+    target.setId(source.getId());
+    target.setWorkflowId(source.getWorkflowId());
+    target.setVersion(source.getVersion() == null ? 0 : source.getVersion());
+    target.setSchemaVersion(2);
+    target.setDag(new WorkflowDag());
+    target.setDagV2(codec.readV2Dag(source.getDagJson()));
+    target.setContentHash(source.getContentHash());
+    target.setPublishedBy(source.getPublishedBy());
+    target.setPublishedAt(source.getPublishedAt());
+    return target;
+  }
+
+  public static WorkflowDefinitionVO toVO(WorkflowDefinition source) {
+    if (source.getSchemaVersion() == 1) {
+      WorkflowDefinitionVO target = WorkflowConvertUtils.toVO(source);
+      target.setSchemaVersion(1);
+      return target;
+    }
+    WorkflowDefinitionVO target = new WorkflowDefinitionVO();
+    target.setId(source.getId());
+    target.setCode(source.getCode());
+    target.setName(source.getName());
+    target.setDescription(source.getDescription());
+    target.setState(source.getState());
+    target.setCurrentVersion(source.getCurrentVersion());
+    target.setFailureStrategy(source.getFailureStrategy());
+    target.setMaxParallelism(source.getMaxParallelism());
+    target.setSchemaVersion(2);
+    target.setDraft(source.getDraft());
+    target.setDraftV2(source.getDraftV2());
+    target.setCreatedBy(source.getCreatedBy());
+    target.setCreatedAt(source.getCreatedAt());
+    target.setUpdatedAt(source.getUpdatedAt());
+    return target;
+  }
+
+  public static WorkflowVersionVO toVO(WorkflowVersion source) {
+    if (source.getSchemaVersion() == 1) {
+      WorkflowVersionVO target = WorkflowConvertUtils.toVO(source);
+      target.setSchemaVersion(1);
+      return target;
+    }
+    WorkflowVersionVO target = new WorkflowVersionVO();
+    target.setId(source.getId());
+    target.setWorkflowId(source.getWorkflowId());
+    target.setVersion(source.getVersion());
+    target.setSchemaVersion(2);
+    target.setDag(source.getDag());
+    target.setDagV2(source.getDagV2());
+    target.setContentHash(source.getContentHash());
+    target.setPublishedBy(source.getPublishedBy());
+    target.setPublishedAt(source.getPublishedAt());
+    return target;
+  }
+
+  private static int schema(Integer value) {
+    return value == null ? 1 : value;
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/main/resources/db/migration/yak-workflow/V3__add_workflow_schema_version.sql
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/resources/db/migration/yak-workflow/V3__add_workflow_schema_version.sql
@@ -1,0 +1,5 @@
+ALTER TABLE yak_wf_definition
+  ADD COLUMN draft_schema_version INT NOT NULL DEFAULT 1 AFTER max_parallelism;
+
+ALTER TABLE yak_wf_version
+  ADD COLUMN schema_version INT NOT NULL DEFAULT 1 AFTER version;

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/WorkflowSchemaVersionMigrationTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/WorkflowSchemaVersionMigrationTest.java
@@ -1,0 +1,22 @@
+package io.yak.ops.business.workflow;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+
+class WorkflowSchemaVersionMigrationTest {
+
+  @Test
+  void migrationAddsSchemaVersionColumnsWithV1Defaults() throws Exception {
+    String resource = "db/migration/yak-workflow/V3__add_workflow_schema_version.sql";
+    try (InputStream input = getClass().getClassLoader().getResourceAsStream(resource)) {
+      if (input == null) throw new AssertionError("Migration not found: " + resource);
+      String sql = new String(input.readAllBytes(), StandardCharsets.UTF_8).toLowerCase();
+      assertTrue(sql.contains("draft_schema_version"));
+      assertTrue(sql.contains("schema_version"));
+      assertTrue(sql.contains("default 1"));
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/dag/WorkflowV2DagValidatorTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/dag/WorkflowV2DagValidatorTest.java
@@ -1,0 +1,98 @@
+package io.yak.ops.business.workflow.dag;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.common.bean.entity.workflow.v2.WorkflowV2BindingSource;
+import io.yak.ops.common.bean.entity.workflow.v2.WorkflowV2Dag;
+import io.yak.ops.common.bean.entity.workflow.v2.WorkflowV2Edge;
+import io.yak.ops.common.bean.entity.workflow.v2.WorkflowV2ExecutionPolicy;
+import io.yak.ops.common.bean.entity.workflow.v2.WorkflowV2InputBinding;
+import io.yak.ops.common.bean.entity.workflow.v2.WorkflowV2Node;
+import io.yak.ops.common.bean.entity.workflow.v2.WorkflowV2TaskReference;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class WorkflowV2DagValidatorTest {
+
+  private final WorkflowV2DagValidator validator = new WorkflowV2DagValidator(new ObjectMapper());
+
+  @Test
+  void normalizesTaskReferenceAndAcceptsValidDag() {
+    WorkflowV2Node start = node("start", WorkflowV2Node.Kind.START);
+    WorkflowV2Node task = task("taskA");
+    task.getTaskRef().setTaskType(" http ");
+    WorkflowV2Node end = node("end", WorkflowV2Node.Kind.END);
+
+    WorkflowV2Dag dag = dag(
+        List.of(start, task, end),
+        List.of(
+            new WorkflowV2Edge("start", WorkflowV2Edge.Port.SUCCESS, "taskA"),
+            new WorkflowV2Edge("taskA", WorkflowV2Edge.Port.SUCCESS, "end")));
+
+    WorkflowV2Dag normalized = validator.normalizeAndValidate(dag);
+
+    assertEquals("HTTP", normalized.getNodes().get(1).getTaskRef().getTaskType());
+    assertEquals(2, normalized.getSchemaVersion());
+  }
+
+  @Test
+  void rejectsFailureRoutingWithoutFailureEdge() {
+    WorkflowV2Node start = node("start", WorkflowV2Node.Kind.START);
+    WorkflowV2Node task = task("taskA");
+    task.getExecutionPolicy().setFailureAction(
+        WorkflowV2ExecutionPolicy.FailureAction.ROUTE_FAILURE);
+    WorkflowV2Node end = node("end", WorkflowV2Node.Kind.END);
+
+    WorkflowV2Dag dag = dag(
+        List.of(start, task, end),
+        List.of(
+            new WorkflowV2Edge("start", WorkflowV2Edge.Port.SUCCESS, "taskA"),
+            new WorkflowV2Edge("taskA", WorkflowV2Edge.Port.SUCCESS, "end")));
+
+    assertThrows(IllegalArgumentException.class, () -> validator.normalizeAndValidate(dag));
+  }
+
+  @Test
+  void rejectsNodeOutputFromNonUpstreamNode() {
+    WorkflowV2Node start = node("start", WorkflowV2Node.Kind.START);
+    WorkflowV2Node first = task("first");
+    WorkflowV2Node second = task("second");
+    WorkflowV2BindingSource source = new WorkflowV2BindingSource();
+    source.setType(WorkflowV2BindingSource.Type.NODE_OUTPUT);
+    source.setNodeKey("second");
+    source.setPath("$.value");
+    first.setInputBindings(List.of(new WorkflowV2InputBinding("value", source)));
+    WorkflowV2Node end = node("end", WorkflowV2Node.Kind.END);
+
+    WorkflowV2Dag dag = dag(
+        List.of(start, first, second, end),
+        List.of(
+            new WorkflowV2Edge("start", WorkflowV2Edge.Port.SUCCESS, "first"),
+            new WorkflowV2Edge("first", WorkflowV2Edge.Port.SUCCESS, "second"),
+            new WorkflowV2Edge("second", WorkflowV2Edge.Port.SUCCESS, "end")));
+
+    assertThrows(IllegalArgumentException.class, () -> validator.normalizeAndValidate(dag));
+  }
+
+  private static WorkflowV2Dag dag(
+      List<WorkflowV2Node> nodes,
+      List<WorkflowV2Edge> edges) {
+    return new WorkflowV2Dag(nodes, edges);
+  }
+
+  private static WorkflowV2Node node(String key, WorkflowV2Node.Kind kind) {
+    WorkflowV2Node node = new WorkflowV2Node();
+    node.setKey(key);
+    node.setName(key);
+    node.setKind(kind);
+    return node;
+  }
+
+  private static WorkflowV2Node task(String key) {
+    WorkflowV2Node node = node(key, WorkflowV2Node.Kind.TASK);
+    node.setTaskRef(new WorkflowV2TaskReference("10", "20", 3, "HTTP"));
+    return node;
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/dag/WorkflowV2PublicationValidatorTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/dag/WorkflowV2PublicationValidatorTest.java
@@ -1,0 +1,91 @@
+package io.yak.ops.business.workflow.dag;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.common.bean.entity.workflow.v2.WorkflowV2BindingSource;
+import io.yak.ops.common.bean.entity.workflow.v2.WorkflowV2Dag;
+import io.yak.ops.common.bean.entity.workflow.v2.WorkflowV2InputBinding;
+import io.yak.ops.common.bean.entity.workflow.v2.WorkflowV2Node;
+import io.yak.ops.common.bean.entity.workflow.v2.WorkflowV2TaskReference;
+import io.yak.ops.common.port.workflow.PublishedTaskVersionCatalog;
+import io.yak.ops.common.port.workflow.PublishedTaskVersionCatalog.PublishedTaskVersion;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class WorkflowV2PublicationValidatorTest {
+
+  private final ObjectMapper mapper = new ObjectMapper();
+
+  @Test
+  void acceptsPinnedPublishedVersionWithRequiredInputsBound() {
+    WorkflowV2Node task = task();
+    WorkflowV2BindingSource source = new WorkflowV2BindingSource();
+    source.setType(WorkflowV2BindingSource.Type.START_INPUT);
+    source.setPath("$.orderId");
+    task.setInputBindings(List.of(new WorkflowV2InputBinding("orderId", source)));
+
+    WorkflowV2PublicationValidator validator = new WorkflowV2PublicationValidator(
+        List.of(catalog("HTTP", 3, "{\"required\":[\"orderId\"]}")));
+
+    WorkflowV2Dag dag = new WorkflowV2Dag();
+    dag.setNodes(List.of(task));
+    assertDoesNotThrow(() -> validator.validate(dag));
+  }
+
+  @Test
+  void rejectsMismatchedTaskType() {
+    WorkflowV2PublicationValidator validator = new WorkflowV2PublicationValidator(
+        List.of(catalog("SHELL", 3, "{}")));
+    WorkflowV2Dag dag = new WorkflowV2Dag();
+    dag.setNodes(List.of(task()));
+
+    assertThrows(IllegalArgumentException.class, () -> validator.validate(dag));
+  }
+
+  @Test
+  void rejectsMissingRequiredInputBinding() {
+    WorkflowV2PublicationValidator validator = new WorkflowV2PublicationValidator(
+        List.of(catalog("HTTP", 3, "{\"required\":[\"orderId\"]}")));
+    WorkflowV2Dag dag = new WorkflowV2Dag();
+    dag.setNodes(List.of(task()));
+
+    assertThrows(IllegalArgumentException.class, () -> validator.validate(dag));
+  }
+
+  private PublishedTaskVersionCatalog catalog(
+      String taskType,
+      long versionNumber,
+      String inputSchema) {
+    return (taskId, versionId) -> Optional.of(new PublishedTaskVersion(
+        taskId,
+        versionId,
+        versionNumber,
+        taskType,
+        read(inputSchema),
+        mapper.createObjectNode(),
+        "digest",
+        LocalDateTime.now(),
+        false));
+  }
+
+  private com.fasterxml.jackson.databind.JsonNode read(String value) {
+    try {
+      return mapper.readTree(value);
+    } catch (Exception exception) {
+      throw new IllegalArgumentException(exception);
+    }
+  }
+
+  private static WorkflowV2Node task() {
+    WorkflowV2Node node = new WorkflowV2Node();
+    node.setKey("taskA");
+    node.setName("taskA");
+    node.setKind(WorkflowV2Node.Kind.TASK);
+    node.setTaskRef(new WorkflowV2TaskReference("10", "20", 3, "HTTP"));
+    return node;
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/impl/WorkflowDefinitionServiceV2Test.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/impl/WorkflowDefinitionServiceV2Test.java
@@ -1,0 +1,143 @@
+package io.yak.ops.business.workflow.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.workflow.dag.WorkflowDagCompiler;
+import io.yak.ops.business.workflow.dag.WorkflowV2DagValidator;
+import io.yak.ops.business.workflow.dag.WorkflowV2PublicationValidator;
+import io.yak.ops.business.workflow.dao.WorkflowDefinitionDao;
+import io.yak.ops.business.workflow.dao.WorkflowExecutionDao;
+import io.yak.ops.business.workflow.service.WorkflowScheduleService;
+import io.yak.ops.business.workflow.util.WorkflowJsonCodec;
+import io.yak.ops.common.bean.dto.workflow.WorkflowV2DTO;
+import io.yak.ops.common.bean.dto.workflow.WorkflowV2UpdateDTO;
+import io.yak.ops.common.bean.entity.workflow.WorkflowDefinition;
+import io.yak.ops.common.bean.entity.workflow.WorkflowVersion;
+import io.yak.ops.common.bean.entity.workflow.v2.WorkflowV2Dag;
+import io.yak.ops.common.bean.entity.workflow.v2.WorkflowV2Edge;
+import io.yak.ops.common.bean.entity.workflow.v2.WorkflowV2Node;
+import io.yak.ops.common.bean.po.workflow.WorkflowDefinitionPO;
+import io.yak.ops.common.bean.po.workflow.WorkflowVersionPO;
+import io.yak.ops.common.enums.workflow.DefinitionState;
+import io.yak.ops.common.enums.workflow.FailureStrategy;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class WorkflowDefinitionServiceV2Test {
+
+  private final WorkflowDefinitionDao definitionDao = mock(WorkflowDefinitionDao.class);
+  private final WorkflowExecutionDao executionDao = mock(WorkflowExecutionDao.class);
+  private final WorkflowScheduleService scheduleService = mock(WorkflowScheduleService.class);
+  private final WorkflowDagCompiler v1Compiler = mock(WorkflowDagCompiler.class);
+  private final WorkflowV2PublicationValidator publicationValidator =
+      new WorkflowV2PublicationValidator(
+          List.of((taskId, versionId) -> java.util.Optional.empty()));
+  private final WorkflowJsonCodec codec = new WorkflowJsonCodec(new ObjectMapper());
+  private final WorkflowDefinitionServiceImpl service = new WorkflowDefinitionServiceImpl(
+      definitionDao,
+      executionDao,
+      scheduleService,
+      v1Compiler,
+      new WorkflowV2DagValidator(new ObjectMapper()),
+      publicationValidator,
+      codec);
+
+  @Test
+  void writesV2DraftWithSchemaMarker() {
+    when(definitionDao.existsDefinitionByCode("flow-v2")).thenReturn(false);
+    doAnswer(invocation -> {
+      invocation.<WorkflowDefinitionPO>getArgument(0).setId(88L);
+      return 1;
+    }).when(definitionDao).addDefinition(any(WorkflowDefinitionPO.class));
+
+    WorkflowV2DTO request = new WorkflowV2DTO();
+    request.setCode(" flow-v2 ");
+    request.setName(" V2 Flow ");
+    request.setMaxParallelism(4);
+    request.setDag(minimalDag());
+
+    assertEquals(88L, service.addWorkflowV2(request, "tester"));
+    ArgumentCaptor<WorkflowDefinitionPO> captor =
+        ArgumentCaptor.forClass(WorkflowDefinitionPO.class);
+    org.mockito.Mockito.verify(definitionDao).addDefinition(captor.capture());
+    assertEquals(2, captor.getValue().getDraftSchemaVersion());
+    assertEquals(true, captor.getValue().getDraftJson().contains("\"schemaVersion\":2"));
+  }
+
+  @Test
+  void preventsV2WriterFromSilentlyConvertingV1Definition() {
+    WorkflowDefinition v1 = new WorkflowDefinition();
+    v1.setId(88L);
+    v1.setSchemaVersion(1);
+    when(definitionDao.selectDefinitionById(88L)).thenReturn(v1);
+
+    WorkflowV2UpdateDTO request = new WorkflowV2UpdateDTO();
+    request.setName("V2 Flow");
+    request.setMaxParallelism(4);
+    request.setDag(minimalDag());
+
+    assertThrows(IllegalStateException.class, () -> service.editWorkflowV2(88L, request));
+  }
+
+  @Test
+  void publishesV2VersionWithSchemaMarker() {
+    WorkflowDefinition definition = new WorkflowDefinition();
+    definition.setId(88L);
+    definition.setCode("flow-v2");
+    definition.setName("V2 Flow");
+    definition.setState(DefinitionState.DRAFT);
+    definition.setFailureStrategy(FailureStrategy.FAIL_FAST);
+    definition.setMaxParallelism(4);
+    definition.setSchemaVersion(2);
+    definition.setDraftV2(minimalDag());
+    when(definitionDao.selectDefinitionById(88L)).thenReturn(definition);
+
+    AtomicReference<WorkflowVersionPO> inserted = new AtomicReference<>();
+    doAnswer(invocation -> {
+      WorkflowVersionPO value = invocation.getArgument(0);
+      value.setId(101L);
+      inserted.set(value);
+      return 1;
+    }).when(definitionDao).addVersion(any(WorkflowVersionPO.class));
+    when(definitionDao.selectVersion(88L, 1)).thenAnswer(ignored -> {
+      WorkflowVersionPO value = inserted.get();
+      WorkflowVersion result = new WorkflowVersion();
+      result.setId(value.getId());
+      result.setWorkflowId(value.getWorkflowId());
+      result.setVersion(value.getVersion());
+      result.setSchemaVersion(value.getSchemaVersion());
+      result.setDagV2(codec.readV2Dag(value.getDagJson()));
+      result.setContentHash(value.getContentHash());
+      result.setPublishedBy(value.getPublishedBy());
+      result.setPublishedAt(value.getPublishedAt());
+      return result;
+    });
+
+    assertEquals(2, service.publishWorkflow(88L, "tester").getSchemaVersion());
+    assertEquals(2, inserted.get().getSchemaVersion());
+  }
+
+  private static WorkflowV2Dag minimalDag() {
+    WorkflowV2Node start = node("start", WorkflowV2Node.Kind.START);
+    WorkflowV2Node end = node("end", WorkflowV2Node.Kind.END);
+    return new WorkflowV2Dag(
+        List.of(start, end),
+        List.of(new WorkflowV2Edge("start", WorkflowV2Edge.Port.SUCCESS, "end")));
+  }
+
+  private static WorkflowV2Node node(String key, WorkflowV2Node.Kind kind) {
+    WorkflowV2Node node = new WorkflowV2Node();
+    node.setKey(key);
+    node.setName(key);
+    node.setKind(kind);
+    return node;
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/util/WorkflowV2ConvertUtilsTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/util/WorkflowV2ConvertUtilsTest.java
@@ -1,0 +1,75 @@
+package io.yak.ops.business.workflow.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.common.bean.entity.workflow.WorkflowDefinition;
+import io.yak.ops.common.bean.entity.workflow.WorkflowVersion;
+import io.yak.ops.common.bean.po.workflow.WorkflowDefinitionPO;
+import io.yak.ops.common.bean.po.workflow.WorkflowVersionPO;
+import java.util.Date;
+import org.junit.jupiter.api.Test;
+
+class WorkflowV2ConvertUtilsTest {
+
+  private final WorkflowJsonCodec codec = new WorkflowJsonCodec(new ObjectMapper());
+
+  @Test
+  void readsV2DraftWithoutParsingItAsLegacyDag() {
+    WorkflowDefinitionPO source = new WorkflowDefinitionPO();
+    source.setId(10L);
+    source.setCode("flow-v2");
+    source.setName("Flow V2");
+    source.setState("DRAFT");
+    source.setFailureStrategy("FAIL_FAST");
+    source.setMaxParallelism(4);
+    source.setDraftSchemaVersion(2);
+    source.setDraftJson("{\"schemaVersion\":2,\"nodes\":[],\"edges\":[],"
+        + "\"viewport\":{\"x\":0,\"y\":0,\"zoom\":1}}");
+    source.setCreatedAt(new Date());
+    source.setUpdatedAt(new Date());
+
+    WorkflowDefinition result = WorkflowV2ConvertUtils.toDefinition(source, codec);
+
+    assertEquals(2, result.getSchemaVersion());
+    assertNotNull(result.getDraftV2());
+    assertEquals(2, result.getDraftV2().getSchemaVersion());
+    assertNotNull(result.getDraft());
+  }
+
+  @Test
+  void readsV2PublishedVersionIntoDagV2() {
+    WorkflowVersionPO source = new WorkflowVersionPO();
+    source.setId(20L);
+    source.setWorkflowId(10L);
+    source.setVersion(3);
+    source.setSchemaVersion(2);
+    source.setDagJson("{\"schemaVersion\":2,\"nodes\":[],\"edges\":[],"
+        + "\"viewport\":{\"x\":0,\"y\":0,\"zoom\":1}}");
+
+    WorkflowVersion result = WorkflowV2ConvertUtils.toVersion(source, codec);
+
+    assertEquals(2, result.getSchemaVersion());
+    assertNotNull(result.getDagV2());
+    assertEquals(3, result.getVersion());
+    assertNotNull(result.getDag());
+  }
+
+  @Test
+  void treatsMissingSchemaMarkerAsV1() {
+    WorkflowVersionPO source = new WorkflowVersionPO();
+    source.setId(20L);
+    source.setWorkflowId(10L);
+    source.setVersion(1);
+    source.setDagJson("{\"nodes\":[],\"edges\":[],"
+        + "\"viewport\":{\"x\":0,\"y\":0,\"zoom\":1}}");
+
+    WorkflowVersion result = WorkflowV2ConvertUtils.toVersion(source, codec);
+
+    assertEquals(1, result.getSchemaVersion());
+    assertNotNull(result.getDag());
+    assertNull(result.getDagV2());
+  }
+}

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/dto/workflow/WorkflowV2DTO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/dto/workflow/WorkflowV2DTO.java
@@ -1,0 +1,25 @@
+package io.yak.ops.common.bean.dto.workflow;
+
+import io.yak.ops.common.bean.entity.workflow.v2.WorkflowV2Dag;
+import io.yak.ops.common.enums.workflow.FailureStrategy;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+/** Workflow V2 create request. */
+@Data
+public class WorkflowV2DTO {
+  @NotBlank
+  private String code;
+  @NotBlank
+  private String name;
+  private String description;
+  private FailureStrategy failureStrategy = FailureStrategy.FAIL_FAST;
+  @Min(1)
+  @Max(256)
+  private int maxParallelism = 4;
+  @Valid
+  private WorkflowV2Dag dag = new WorkflowV2Dag();
+}

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/dto/workflow/WorkflowV2UpdateDTO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/dto/workflow/WorkflowV2UpdateDTO.java
@@ -1,0 +1,23 @@
+package io.yak.ops.common.bean.dto.workflow;
+
+import io.yak.ops.common.bean.entity.workflow.v2.WorkflowV2Dag;
+import io.yak.ops.common.enums.workflow.FailureStrategy;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+/** Workflow V2 draft update request. */
+@Data
+public class WorkflowV2UpdateDTO {
+  @NotBlank
+  private String name;
+  private String description;
+  private FailureStrategy failureStrategy = FailureStrategy.FAIL_FAST;
+  @Min(1)
+  @Max(256)
+  private int maxParallelism = 4;
+  @Valid
+  private WorkflowV2Dag dag = new WorkflowV2Dag();
+}

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/entity/workflow/WorkflowDefinition.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/entity/workflow/WorkflowDefinition.java
@@ -1,5 +1,6 @@
 package io.yak.ops.common.bean.entity.workflow;
 
+import io.yak.ops.common.bean.entity.workflow.v2.WorkflowV2Dag;
 import io.yak.ops.common.enums.workflow.DefinitionState;
 import io.yak.ops.common.enums.workflow.FailureStrategy;
 import java.util.Date;
@@ -12,6 +13,36 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class WorkflowDefinition {
+
+  /** Backward-compatible Workflow V1 constructor. */
+  public WorkflowDefinition(
+      Long id,
+      String code,
+      String name,
+      String description,
+      DefinitionState state,
+      Integer currentVersion,
+      FailureStrategy failureStrategy,
+      int maxParallelism,
+      WorkflowDag draft,
+      String createdBy,
+      Date createdAt,
+      Date updatedAt) {
+    this.id = id;
+    this.code = code;
+    this.name = name;
+    this.description = description;
+    this.state = state;
+    this.currentVersion = currentVersion;
+    this.failureStrategy = failureStrategy;
+    this.maxParallelism = maxParallelism;
+    this.schemaVersion = 1;
+    this.draft = draft;
+    this.createdBy = createdBy;
+    this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
+  }
+
   private Long id;
   private String code;
   private String name;
@@ -20,7 +51,9 @@ public class WorkflowDefinition {
   private Integer currentVersion;
   private FailureStrategy failureStrategy;
   private int maxParallelism;
+  private int schemaVersion = 1;
   private WorkflowDag draft;
+  private WorkflowV2Dag draftV2;
   private String createdBy;
   private Date createdAt;
   private Date updatedAt;

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/entity/workflow/WorkflowVersion.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/entity/workflow/WorkflowVersion.java
@@ -1,5 +1,6 @@
 package io.yak.ops.common.bean.entity.workflow;
 
+import io.yak.ops.common.bean.entity.workflow.v2.WorkflowV2Dag;
 import java.util.Date;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -10,10 +11,32 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class WorkflowVersion {
+
+  /** Backward-compatible Workflow V1 constructor. */
+  public WorkflowVersion(
+      Long id,
+      Long workflowId,
+      int version,
+      WorkflowDag dag,
+      String contentHash,
+      String publishedBy,
+      Date publishedAt) {
+    this.id = id;
+    this.workflowId = workflowId;
+    this.version = version;
+    this.schemaVersion = 1;
+    this.dag = dag;
+    this.contentHash = contentHash;
+    this.publishedBy = publishedBy;
+    this.publishedAt = publishedAt;
+  }
+
   private Long id;
   private Long workflowId;
   private int version;
+  private int schemaVersion = 1;
   private WorkflowDag dag;
+  private WorkflowV2Dag dagV2;
   private String contentHash;
   private String publishedBy;
   private Date publishedAt;

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/workflow/WorkflowDefinitionPO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/workflow/WorkflowDefinitionPO.java
@@ -19,6 +19,7 @@ public class WorkflowDefinitionPO {
   private Integer currentVersion;
   private String failureStrategy;
   private Integer maxParallelism;
+  private Integer draftSchemaVersion;
   private String draftJson;
   private String createdBy;
   private Date createdAt;

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/workflow/WorkflowVersionPO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/workflow/WorkflowVersionPO.java
@@ -14,6 +14,7 @@ public class WorkflowVersionPO {
   private Long id;
   private Long workflowId;
   private Integer version;
+  private Integer schemaVersion;
   private String dagJson;
   private String contentHash;
   private String publishedBy;

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/vo/workflow/WorkflowDefinitionVO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/vo/workflow/WorkflowDefinitionVO.java
@@ -1,8 +1,9 @@
 package io.yak.ops.common.bean.vo.workflow;
 
+import io.yak.ops.common.bean.entity.workflow.WorkflowDag;
+import io.yak.ops.common.bean.entity.workflow.v2.WorkflowV2Dag;
 import io.yak.ops.common.enums.workflow.DefinitionState;
 import io.yak.ops.common.enums.workflow.FailureStrategy;
-import io.yak.ops.common.bean.entity.workflow.WorkflowDag;
 import java.util.Date;
 import lombok.Data;
 
@@ -17,7 +18,9 @@ public class WorkflowDefinitionVO {
   private Integer currentVersion;
   private FailureStrategy failureStrategy;
   private int maxParallelism;
+  private int schemaVersion = 1;
   private WorkflowDag draft;
+  private WorkflowV2Dag draftV2;
   private String createdBy;
   private Date createdAt;
   private Date updatedAt;

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/vo/workflow/WorkflowVersionVO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/vo/workflow/WorkflowVersionVO.java
@@ -1,6 +1,7 @@
 package io.yak.ops.common.bean.vo.workflow;
 
 import io.yak.ops.common.bean.entity.workflow.WorkflowDag;
+import io.yak.ops.common.bean.entity.workflow.v2.WorkflowV2Dag;
 import java.util.Date;
 import lombok.Data;
 
@@ -10,7 +11,9 @@ public class WorkflowVersionVO {
   private Long id;
   private Long workflowId;
   private int version;
+  private int schemaVersion = 1;
   private WorkflowDag dag;
+  private WorkflowV2Dag dagV2;
   private String contentHash;
   private String publishedBy;
   private Date publishedAt;

--- a/yak-ops-common/src/main/java/io/yak/ops/common/port/workflow/PublishedTaskVersionCatalog.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/port/workflow/PublishedTaskVersionCatalog.java
@@ -1,0 +1,27 @@
+package io.yak.ops.common.port.workflow;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+/**
+ * Read-only port used by Workflow to validate immutable data-development task versions.
+ *
+ * <p>The contract intentionally excludes task definitions, compiled specs and runtime secrets.
+ */
+public interface PublishedTaskVersionCatalog {
+
+  Optional<PublishedTaskVersion> findPublishedVersion(long taskId, long versionId);
+
+  record PublishedTaskVersion(
+      long taskId,
+      long versionId,
+      long versionNumber,
+      String taskType,
+      JsonNode inputSchema,
+      JsonNode outputSchema,
+      String contentDigest,
+      LocalDateTime publishedAt,
+      boolean currentVersion) {
+  }
+}

--- a/yak-ops-ui/src/pages/workflow-management/workflow-v2.repository.ts
+++ b/yak-ops-ui/src/pages/workflow-management/workflow-v2.repository.ts
@@ -1,0 +1,108 @@
+import HttpUtils, { type ApiResponse } from '@/utils/HttpUtils';
+import type { CommonApiResponse } from './types';
+import type { WorkflowV2Dag } from './workflow-v2.types';
+
+const API_PREFIX = '/api/v1/workflows';
+
+export type WorkflowSchemaVersion = 1 | 2;
+export type WorkflowFailureStrategy = 'FAIL_FAST' | 'CONTINUE';
+
+export interface WorkflowV2CreatePayload {
+  code: string;
+  name: string;
+  description?: string;
+  failureStrategy: WorkflowFailureStrategy;
+  maxParallelism: number;
+  dag: WorkflowV2Dag;
+}
+
+export type WorkflowV2UpdatePayload = Omit<WorkflowV2CreatePayload, 'code'>;
+
+export interface WorkflowDefinitionDocument {
+  id: number;
+  code: string;
+  name: string;
+  description?: string;
+  state: 'DRAFT' | 'PUBLISHED';
+  currentVersion?: number;
+  failureStrategy: WorkflowFailureStrategy;
+  maxParallelism: number;
+  schemaVersion: WorkflowSchemaVersion;
+  draft?: unknown;
+  draftV2?: WorkflowV2Dag;
+  createdBy?: string;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export interface WorkflowVersionDocument {
+  id: number;
+  workflowId: number;
+  version: number;
+  schemaVersion: WorkflowSchemaVersion;
+  dag?: unknown;
+  dagV2?: WorkflowV2Dag;
+  contentHash: string;
+  publishedBy?: string;
+  publishedAt?: string;
+}
+
+const normalize = <T>(response: ApiResponse<T>): CommonApiResponse<T> => ({
+  code: response.code,
+  data: response.data,
+  message: response.message ?? response.msg,
+});
+
+export const workflowV2Repository = {
+  async create(
+    payload: WorkflowV2CreatePayload,
+  ): Promise<CommonApiResponse<{ workflowId: number }>> {
+    return normalize(
+      await HttpUtils.post<{ workflowId: number }>(`${API_PREFIX}/v2`, payload),
+    );
+  },
+
+  async update(
+    workflowId: string | number,
+    payload: WorkflowV2UpdatePayload,
+  ): Promise<CommonApiResponse<boolean>> {
+    return normalize(
+      await HttpUtils.put<boolean>(
+        `${API_PREFIX}/${workflowId}/draft/v2`,
+        payload,
+      ),
+    );
+  },
+
+  async detail(
+    workflowId: string | number,
+  ): Promise<CommonApiResponse<WorkflowDefinitionDocument>> {
+    return normalize(
+      await HttpUtils.get<WorkflowDefinitionDocument>(
+        `${API_PREFIX}/${workflowId}`,
+      ),
+    );
+  },
+
+  async publish(
+    workflowId: string | number,
+  ): Promise<CommonApiResponse<WorkflowVersionDocument>> {
+    return normalize(
+      await HttpUtils.post<WorkflowVersionDocument>(
+        `${API_PREFIX}/${workflowId}/publish`,
+        {},
+      ),
+    );
+  },
+
+  async version(
+    workflowId: string | number,
+    version: number,
+  ): Promise<CommonApiResponse<WorkflowVersionDocument>> {
+    return normalize(
+      await HttpUtils.get<WorkflowVersionDocument>(
+        `${API_PREFIX}/${workflowId}/versions/${version}`,
+      ),
+    );
+  },
+};


### PR DESCRIPTION
## 背景

前两步已经完成 Workflow V2 编排契约和已发布任务资源查询边界，但现有工作流定义服务仍然只能把 `WorkflowDag` 作为 V1 JSON 保存和发布。V2 目前只是类型定义，尚不能形成正式草稿与不可变工作流版本。

本 PR 完成任务与工作流拆分计划的第三步：实现 Workflow V1/V2 Reader、Workflow V2 Writer，以及基于不可变任务版本的发布校验。现有 Workflow V1 编辑、发布和运行行为保持不变。

## API

新增 V2 Writer：

```http
POST /api/v1/workflows/v2
PUT  /api/v1/workflows/{workflowId}/draft/v2
```

现有 Reader 与发布入口同时支持 V1/V2：

```http
GET  /api/v1/workflows/{workflowId}
POST /api/v1/workflows/{workflowId}/publish
GET  /api/v1/workflows/{workflowId}/versions/{version}
```

响应通过 `schemaVersion` 分派：

- V1：`schemaVersion=1`，读取 `draft / dag`；
- V2：`schemaVersion=2`，读取 `draftV2 / dagV2`。

V1 Writer 不能修改 V2 工作流，V2 Writer 也不能静默转换 V1 工作流。后续如需迁移，必须通过显式迁移流程完成。

## 持久化

Flyway V3 在现有表增加格式标记：

```text
yak_wf_definition.draft_schema_version DEFAULT 1
yak_wf_version.schema_version DEFAULT 1
```

历史数据自动视为 V1。DAG JSON 继续保存在原有 `draft_json / dag_json`，没有新建平行定义表，也没有复制工作流快照。

## Workflow V2 DAG 校验

保存 V2 草稿时执行规范化与结构校验：

- 必须且只能存在一个 START，至少一个 END；
- 节点编码唯一且符合规范；
- TASK 节点必须携带完整 `taskRef`；
- START / END 禁止携带 `taskRef`；
- TASK ID、Version ID 和 Version Number 必须有效；
- 连线引用的节点必须存在，DAG 不得成环；
- START 不得有上游，END 不得有下游；
- FAILURE 出口只能来自 TASK；
- `ROUTE_FAILURE` 必须存在 FAILURE 连线；
- `NODE_OUTPUT` 只能引用拓扑上游节点；
- 输入目标不能重复；
- 重试、间隔和超时不能为负数。

## 发布校验

新增公共只读端口：

```text
PublishedTaskVersionCatalog
```

Data Development 通过适配器实现该端口。Workflow 不直接读取 `yak_dev_*` 表，也不依赖 TaskPlugin 实现。

V2 发布前会校验所有 TASK 节点：

- `taskId + taskVersionId` 对应的不可变发布版本存在；
- `taskVersionNumber` 与真实版本一致；
- `taskType` 与真实版本一致；
- Input Schema 中的 `required` 字段已经完成绑定。

允许工作流固定历史不可变版本，不要求自动跟随任务当前最新版本。即使节点暂时禁用，其发布快照中的 taskRef 也不能是悬空引用。

## 运行边界

本步骤没有提前实现 V2 执行。现有执行引擎仍只接受 Workflow V1。运行已发布的 V2 工作流时会明确返回：

```text
Workflow V2 执行将在统一 Task Execution Gateway 阶段启用
```

这样可避免 V2 taskRef 被误读成旧插件 `config` 后产生错误执行。

## 前端契约

新增：

```text
yak-ops-ui/src/pages/workflow-management/workflow-v2.repository.ts
```

提供 V2 创建、草稿更新、详情、发布和版本读取的完整 TypeScript 客户端。当前不改造旧设计器，下一步左侧任务资源拖拽页面可以直接接入。

## 兼容处理

- 历史 Schema 字段为空时按 V1 读取；
- 保留 WorkflowDefinition / WorkflowVersion 的旧构造器；
- V1 Converter、V1 Compiler 与 V1 Runtime 不改变；
- V2 JSON 不会被 V1 Reader 解析；
- 工作流列表可以同时返回 V1/V2 定义。

## 测试与验证

新增测试覆盖：

- V2 DAG 规范化、失败出口和上游引用；
- 发布任务类型、版本号和必填输入校验；
- V1/V2 Reader 分派与历史空 Schema 兼容；
- V2 Writer 的 Schema 2 持久化；
- 禁止 V2 Writer 静默转换 V1；
- V2 发布版本保留 Schema 2；
- Flyway 历史数据默认 Schema 1。

已完成：

- TypeScript 5.8 strict 检查通过；
- 使用 JDK 21 对新增和修改 Java 源码执行语法结构检查，未发现语法结构错误；
- Flyway V3 SQL 与字段映射完成静态核对；
- GitHub compare 确认分支基于最新 `main`，落后 0，只包含本步骤的 27 个文件。

当前环境没有 Maven，也没有真实 MySQL，因此完整 Reactor 编译、Spring Context、真实 Flyway 升级和模块测试仍需由本地或 CI 完成最终验证。

## 后续

下一步可以重构 Workflow 设计器：左侧展示已发布任务资源，拖入后写入 `taskRef`，右侧只保留版本、输入映射和编排策略。

## 合并说明

连接器按文件产生细粒度提交，建议使用 **Squash and merge**。