### PR TITLE
feat(workflow-ui): build published task drag designer

### DIFF
--- a/docs/workflow/workflow-v2-designer.md
+++ b/docs/workflow/workflow-v2-designer.md
@@ -1,0 +1,133 @@
+# Workflow V2 已发布任务拖拽设计器
+
+## 目标
+
+本阶段将新建工作流切换到 Workflow V2，并提供只消费已发布任务版本的可视化编排入口。
+
+```text
+Data Development
+  -> publish immutable Task Version
+  -> Published Task Library API
+  -> drag task reference into Workflow V2 canvas
+  -> save taskId + taskVersionId
+```
+
+设计器不再提供 HTTP、Shell、SQL、Python 或 Notebook 的任务配置表单。
+
+## 路由兼容
+
+统一入口仍然是：
+
+```text
+/workflow-management/:id/designer
+```
+
+入口页读取定义的 `schemaVersion` 后分流：
+
+```text
+schemaVersion=1 -> /workflow-management/v1/:id/designer
+schemaVersion=2 -> /workflow-management/v2/:id/designer
+create          -> /workflow-management/v2/create/designer
+```
+
+因此历史 V1 工作流继续使用原设计器，新建工作流默认采用 V2。没有隐式迁移或格式转换。
+
+## 页面布局
+
+Workflow V2 设计器采用：
+
+```text
+52px header
+300px published task library | React Flow canvas
+```
+
+左侧资源库支持：
+
+- 关键字搜索；
+- 任务类型筛选；
+- 全部、收藏、最近使用切换；
+- 双击快速插入；
+- 原生 HTML5 拖拽到画布；
+- 显示项目、任务类型和发布版本号。
+
+接口一次最多加载 100 条。结果超过 100 条时提示继续使用搜索或类型筛选缩小范围。
+
+## 拖拽契约
+
+拖拽 MIME：
+
+```text
+application/x-yak-workflow-published-task
+```
+
+拖入画布后只创建：
+
+```json
+{
+  "kind": "TASK",
+  "taskRef": {
+    "taskId": "1001",
+    "taskVersionId": "2003",
+    "taskVersionNumber": 3,
+    "taskType": "HTTP"
+  }
+}
+```
+
+不会复制：
+
+```text
+config
+definition
+compiledSpec
+runtime
+secret
+HTTP/Shell/SQL plugin parameters
+```
+
+任务名称、项目名称、输入输出 Schema 等只作为前端展示元数据，不会被写入 Workflow V2 的任务内容。
+
+## 节点和连线
+
+画布包含三类节点：
+
+- START：只有 SUCCESS 出口；
+- TASK：一个输入、SUCCESS 出口和 FAILURE 出口；
+- END：只有输入。
+
+React Flow 的 `sourceHandle` 被映射为 Workflow V2 `fromPort`：
+
+```text
+SUCCESS -> fromPort=SUCCESS
+FAILURE -> fromPort=FAILURE
+```
+
+开始和结束节点不能被删除。任务节点删除时会同步删除关联连线。
+
+## 保存与发布
+
+保存使用：
+
+```http
+PUT /api/v1/workflows/{workflowId}/draft/v2
+```
+
+发布使用：
+
+```http
+POST /api/v1/workflows/{workflowId}/publish
+```
+
+保存过程只序列化 Workflow V2 编排字段。发布继续由后端验证不可变任务版本、任务类型、版本号和必填输入绑定。
+
+## 当前边界
+
+本阶段不实现：
+
+- 任务版本升级选择；
+- 输入输出映射编辑器；
+- 节点重试、超时和失败策略面板；
+- V2 运行；
+- V1 到 V2 自动迁移。
+
+这些能力由后续编排面板、输入映射和统一 Task Execution Gateway 阶段实现。

--- a/yak-ops-ui/config/routes.ts
+++ b/yak-ops-ui/config/routes.ts
@@ -1,5 +1,18 @@
 import { appRoutes } from '../src/config/navigation';
 
+const applicationRoutes = appRoutes.filter(
+  ({ id }) => id !== 'workflow-designer',
+);
+
+const protectedHiddenRoute = (path: string, component: string) => ({
+  path,
+  component,
+  access: 'isAuthenticated',
+  wrappers: ['@/components/security/WorkflowDefinitionRouteBoundary'],
+  hideInMenu: true,
+  hideInBreadcrumb: true,
+});
+
 /**
  * 站内页面统一使用自定义 SiteLayout。
  * 登录页和异常页保持独立，不进入后台导航框架。
@@ -29,7 +42,19 @@ export default [
         hideInMenu: true,
         hideInBreadcrumb: true,
       },
-      ...appRoutes.map(({ path, component, hidden }) => ({
+      protectedHiddenRoute(
+        '/workflow-management/v1/:id/designer',
+        './workflow-management/designer',
+      ),
+      protectedHiddenRoute(
+        '/workflow-management/v2/:id/designer',
+        './workflow-management/designer-v2',
+      ),
+      protectedHiddenRoute(
+        '/workflow-management/:id/designer',
+        './workflow-management/designer-router',
+      ),
+      ...applicationRoutes.map(({ path, component, hidden }) => ({
         path,
         component,
         access: 'isAuthenticated',

--- a/yak-ops-ui/src/components/security/WorkflowDefinitionRouteBoundary/index.tsx
+++ b/yak-ops-ui/src/components/security/WorkflowDefinitionRouteBoundary/index.tsx
@@ -1,0 +1,29 @@
+import { useLocation } from '@umijs/max';
+
+import type { NavigationRoute } from '@/config/navigation';
+import RouteAccessBoundary from '../RouteAccessBoundary';
+
+const readRoute: NavigationRoute = {
+  id: 'workflow-designer-versioned',
+  mode: 'one',
+  permission: 'workflow:definition:read',
+  path: '/workflow-management/:id/designer',
+  title: '工作流设计',
+  component: './workflow-management/designer-router',
+  hidden: true,
+  parentId: 'workflow-management',
+};
+
+const createRoute: NavigationRoute = {
+  ...readRoute,
+  id: 'workflow-designer-v2-create',
+  permission: 'workflow:definition:create',
+};
+
+export default function WorkflowDefinitionRouteBoundary() {
+  const location = useLocation();
+  const createMode = /\/workflow-management\/(?:v2\/)?create\/designer$/.test(
+    location.pathname,
+  );
+  return <RouteAccessBoundary route={createMode ? createRoute : readRoute} />;
+}

--- a/yak-ops-ui/src/pages/workflow-management/designer-router/index.tsx
+++ b/yak-ops-ui/src/pages/workflow-management/designer-router/index.tsx
@@ -1,0 +1,77 @@
+import { BRAND_CSS_VARIABLES, BRAND_THEME } from '@/styles/brand';
+import { history, useParams } from '@umijs/max';
+import { Button, ConfigProvider, Result, Spin } from 'antd';
+import { useEffect, useState } from 'react';
+
+import { workflowV2Repository } from '../workflow-v2.repository';
+
+const WorkflowDesignerRouterPage = () => {
+  const params = useParams<{ id: string }>();
+  const workflowId = params.id || '';
+  const [error, setError] = useState<string>();
+
+  useEffect(() => {
+    let active = true;
+    const route = async () => {
+      if (!workflowId) {
+        setError('缺少工作流 ID');
+        return;
+      }
+      if (workflowId === 'create') {
+        history.replace('/workflow-management/v2/create/designer');
+        return;
+      }
+      try {
+        const response = await workflowV2Repository.detail(workflowId);
+        if (!active) return;
+        if (response.code !== 200 || !response.data) {
+          setError(response.message || '工作流不存在或无法读取');
+          return;
+        }
+        history.replace(
+          response.data.schemaVersion === 2
+            ? `/workflow-management/v2/${workflowId}/designer`
+            : `/workflow-management/v1/${workflowId}/designer`,
+        );
+      } catch (reason) {
+        if (!active) return;
+        setError(
+          reason instanceof Error ? reason.message : '工作流路由解析失败',
+        );
+      }
+    };
+    void route();
+    return () => {
+      active = false;
+    };
+  }, [workflowId]);
+
+  return (
+    <ConfigProvider theme={BRAND_THEME}>
+      <div
+        style={BRAND_CSS_VARIABLES}
+        className="fixed inset-0 z-[130] flex items-center justify-center bg-[#f7f7f8]"
+      >
+        {error ? (
+          <Result
+            status="error"
+            title="无法打开工作流"
+            subTitle={error}
+            extra={
+              <Button
+                type="primary"
+                onClick={() => history.replace('/workflow-management')}
+              >
+                返回工作流列表
+              </Button>
+            }
+          />
+        ) : (
+          <Spin tip="正在识别工作流版本..." />
+        )}
+      </div>
+    </ConfigProvider>
+  );
+};
+
+export default WorkflowDesignerRouterPage;

--- a/yak-ops-ui/src/pages/workflow-management/designer-v2/CreateWorkflowV2.tsx
+++ b/yak-ops-ui/src/pages/workflow-management/designer-v2/CreateWorkflowV2.tsx
@@ -1,0 +1,220 @@
+import { history } from '@umijs/max';
+import { Alert, Button, Form, Input, message } from 'antd';
+import {
+  ArrowLeft,
+  ArrowRight,
+  DatabaseZap,
+  GitBranch,
+  Play,
+  Workflow,
+} from 'lucide-react';
+import { useEffect, useState } from 'react';
+
+import { workflowV2Repository } from '../workflow-v2.repository';
+import { createInitialWorkflowV2Dag } from './model';
+
+interface CreateWorkflowValues {
+  name: string;
+  description?: string;
+}
+
+const createWorkflowCode = () =>
+  `workflow_v2_${Date.now().toString(36)}`;
+
+const CreateWorkflowV2 = () => {
+  const [form] = Form.useForm<CreateWorkflowValues>();
+  const [saving, setSaving] = useState(false);
+  const name = Form.useWatch('name', form);
+
+  const create = async (values: CreateWorkflowValues) => {
+    const normalizedName = values.name?.trim();
+    if (!normalizedName) {
+      message.warning('请输入工作流名称');
+      return;
+    }
+    try {
+      setSaving(true);
+      const response = await workflowV2Repository.create({
+        code: createWorkflowCode(),
+        name: normalizedName,
+        description: values.description?.trim() || undefined,
+        failureStrategy: 'FAIL_FAST',
+        maxParallelism: 4,
+        dag: createInitialWorkflowV2Dag(),
+      });
+      if (response.code !== 200 || !response.data?.workflowId) {
+        message.error(response.message || '创建 Workflow V2 失败');
+        return;
+      }
+      message.success('工作流已创建，开始拖入任务吧');
+      history.replace(
+        `/workflow-management/v2/${response.data.workflowId}/designer`,
+      );
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  useEffect(() => {
+    const keydown = (event: KeyboardEvent) => {
+      if ((event.ctrlKey || event.metaKey) && event.key === 'Enter') {
+        event.preventDefault();
+        if (!saving) form.submit();
+      }
+    };
+    window.addEventListener('keydown', keydown);
+    return () => window.removeEventListener('keydown', keydown);
+  }, [form, saving]);
+
+  return (
+    <div className="fixed inset-0 z-[120] overflow-hidden bg-[#f7f7f8] text-[#161823]">
+      <header className="flex h-[56px] items-center border-b border-[#e4e7ec] bg-white px-5">
+        <Button
+          type="text"
+          icon={<ArrowLeft size={16} />}
+          onClick={() => history.push('/workflow-management')}
+        >
+          返回工作流列表
+        </Button>
+      </header>
+
+      <main className="grid h-[calc(100vh-56px)] grid-cols-[520px_minmax(620px,1fr)] overflow-hidden max-xl:grid-cols-1">
+        <section className="overflow-y-auto border-r border-[#e4e7ec] bg-white px-14 py-14 max-xl:border-r-0 max-sm:px-6">
+          <span className="inline-flex h-10 w-10 items-center justify-center rounded-xl bg-[var(--yak-brand-color-soft)] text-[var(--yak-brand-color)]">
+            <Workflow size={20} />
+          </span>
+          <h1 className="mb-0 mt-5 text-[24px] font-semibold leading-8 text-[#161823]">
+            创建任务编排工作流
+          </h1>
+          <p className="mb-0 mt-2 text-[13px] leading-6 text-[#667085]">
+            工作流只保存已发布任务版本引用，不再重复维护 HTTP、Shell、SQL 等任务配置。
+          </p>
+
+          <Alert
+            className="mt-6"
+            type="info"
+            showIcon
+            message="Workflow V2"
+            description="创建后会自动生成开始和结束节点。你只需要从左侧资源库拖入已发布任务并连接顺序。"
+          />
+
+          <Form<CreateWorkflowValues>
+            form={form}
+            layout="vertical"
+            requiredMark={false}
+            className="mt-7 [&_.ant-form-item]:mb-5"
+            onFinish={(values: CreateWorkflowValues) => void create(values)}
+          >
+            <Form.Item
+              name="name"
+              label="工作流名称"
+              rules={[
+                { required: true, message: '请输入工作流名称' },
+                { max: 255, message: '名称不能超过 255 个字符' },
+              ]}
+            >
+              <Input
+                autoFocus
+                variant="filled"
+                size="large"
+                maxLength={255}
+                placeholder="例如：订单同步与结果通知"
+              />
+            </Form.Item>
+
+            <Form.Item name="description" label="描述（可选）">
+              <Input.TextArea
+                variant="filled"
+                rows={4}
+                maxLength={1000}
+                placeholder="说明这个工作流解决什么问题"
+              />
+            </Form.Item>
+
+            <div className="flex items-center justify-end gap-2 pt-2">
+              <Button onClick={() => history.push('/workflow-management')}>
+                取消
+              </Button>
+              <Button
+                type="primary"
+                htmlType="submit"
+                loading={saving}
+                disabled={!name?.trim()}
+                icon={<ArrowRight size={15} />}
+                iconPosition="end"
+              >
+                创建并进入画布
+              </Button>
+            </div>
+          </Form>
+        </section>
+
+        <section className="relative overflow-hidden bg-[#f7f7f8] max-xl:hidden">
+          <div className="absolute inset-8 overflow-hidden border border-[#dfe3e8] bg-white shadow-[0_16px_44px_rgba(16,24,40,0.10)]">
+            <div className="flex h-12 items-center justify-between border-b border-[#e4e7ec] px-4">
+              <div className="flex items-center gap-2">
+                <span className="flex h-7 w-7 items-center justify-center rounded-lg bg-[var(--yak-brand-color-soft)] text-[var(--yak-brand-color)]">
+                  <Workflow size={15} />
+                </span>
+                <strong className="text-xs text-[#344054]">任务编排画布</strong>
+              </div>
+              <span className="rounded bg-[#f2f4f7] px-2 py-1 text-[10px] text-[#667085]">
+                Schema V2
+              </span>
+            </div>
+
+            <div className="flex h-[calc(100%-48px)]">
+              <aside className="w-[210px] border-r border-[#e4e7ec] bg-white p-3">
+                <strong className="text-[11px] text-[#475467]">已发布任务</strong>
+                <div className="mt-3 space-y-2">
+                  {['查询订单', '转换数据', '发送通知'].map((item, index) => (
+                    <div
+                      key={item}
+                      className="rounded-lg border border-[#e4e7ec] bg-[#f7f7f8] px-2.5 py-2"
+                    >
+                      <div className="flex items-center gap-2">
+                        <DatabaseZap size={13} className="text-[var(--yak-brand-color)]" />
+                        <span className="text-[10px] font-medium text-[#344054]">
+                          {item}
+                        </span>
+                        <span className="ml-auto rounded bg-white px-1 text-[8px] text-[#98a2b3]">
+                          v{index + 1}
+                        </span>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </aside>
+
+              <div className="relative flex-1 bg-[radial-gradient(#d8dde5_1px,transparent_1px)] [background-size:18px_18px]">
+                <div className="absolute left-[7%] top-[42%] flex items-center gap-6">
+                  <div className="w-[120px] rounded-xl border border-[#dfe3e8] bg-white p-3 shadow-sm">
+                    <div className="flex items-center gap-2 text-[10px] font-semibold text-[#344054]">
+                      <Play size={13} />开始
+                    </div>
+                  </div>
+                  <ArrowRight size={20} className="text-[#98a2b3]" />
+                  <div className="w-[150px] rounded-xl border border-[var(--yak-brand-color-border)] bg-white p-3 shadow-md">
+                    <div className="flex items-center gap-2 text-[10px] font-semibold text-[#344054]">
+                      <DatabaseZap size={13} className="text-[var(--yak-brand-color)]" />
+                      查询订单
+                    </div>
+                    <div className="mt-2 flex items-center gap-1 text-[8px] text-[#98a2b3]">
+                      <GitBranch size={10} /> HTTP · v3
+                    </div>
+                  </div>
+                  <ArrowRight size={20} className="text-[#98a2b3]" />
+                  <div className="w-[120px] rounded-xl border border-[#dfe3e8] bg-white p-3 shadow-sm">
+                    <div className="text-[10px] font-semibold text-[#344054]">结束</div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+      </main>
+    </div>
+  );
+};
+
+export default CreateWorkflowV2;

--- a/yak-ops-ui/src/pages/workflow-management/designer-v2/components/TaskLibraryPanel.tsx
+++ b/yak-ops-ui/src/pages/workflow-management/designer-v2/components/TaskLibraryPanel.tsx
@@ -1,0 +1,292 @@
+import {
+  AppstoreOutlined,
+  ClockCircleOutlined,
+  StarFilled,
+  StarOutlined,
+} from '@ant-design/icons';
+import {
+  Button,
+  Empty,
+  Input,
+  Segmented,
+  Select,
+  Spin,
+  Tooltip,
+  message,
+} from 'antd';
+import { Braces, GripVertical, Plus, RefreshCw, Search } from 'lucide-react';
+import {
+  useEffect,
+  useMemo,
+  useState,
+  type ChangeEvent,
+  type DragEvent,
+  type MouseEvent,
+} from 'react';
+
+import {
+  workflowTaskLibraryRepository,
+  type WorkflowPublishedTask,
+} from '../../repository/workflow-task-library.repository';
+import {
+  WORKFLOW_TASK_DRAG_TYPE,
+  encodeTaskDragPayload,
+} from '../model';
+
+type LibraryView = 'all' | 'favorite' | 'recent';
+
+interface TaskLibraryPanelProps {
+  onInsert(task: WorkflowPublishedTask): void;
+}
+
+const viewOptions = [
+  {
+    label: (
+      <span className="inline-flex items-center gap-1.5">
+        <AppstoreOutlined />全部
+      </span>
+    ),
+    value: 'all',
+  },
+  {
+    label: (
+      <span className="inline-flex items-center gap-1.5">
+        <StarOutlined />收藏
+      </span>
+    ),
+    value: 'favorite',
+  },
+  {
+    label: (
+      <span className="inline-flex items-center gap-1.5">
+        <ClockCircleOutlined />最近
+      </span>
+    ),
+    value: 'recent',
+  },
+];
+
+const TaskLibraryPanel = ({ onInsert }: TaskLibraryPanelProps) => {
+  const [loading, setLoading] = useState(false);
+  const [keyword, setKeyword] = useState('');
+  const [debouncedKeyword, setDebouncedKeyword] = useState('');
+  const [taskType, setTaskType] = useState<string>();
+  const [view, setView] = useState<LibraryView>('all');
+  const [items, setItems] = useState<WorkflowPublishedTask[]>([]);
+  const [total, setTotal] = useState(0);
+  const [loadVersion, setLoadVersion] = useState(0);
+
+  useEffect(() => {
+    const timer = window.setTimeout(
+      () => setDebouncedKeyword(keyword.trim()),
+      260,
+    );
+    return () => window.clearTimeout(timer);
+  }, [keyword]);
+
+  useEffect(() => {
+    let active = true;
+    const load = async () => {
+      try {
+        setLoading(true);
+        const page = await workflowTaskLibraryRepository.search({
+          keyword: debouncedKeyword || undefined,
+          taskType,
+          favoriteOnly: view === 'favorite' ? true : undefined,
+          recentlyUsed: view === 'recent' ? true : undefined,
+          sortBy: view === 'recent' ? 'RECENTLY_USED' : 'UPDATED_AT',
+          offset: 0,
+          limit: 100,
+        });
+        if (!active) return;
+        setItems(page.items);
+        setTotal(page.total);
+      } catch (error) {
+        if (!active) return;
+        setItems([]);
+        setTotal(0);
+        message.error(
+          error instanceof Error ? error.message : '加载已发布任务失败',
+        );
+      } finally {
+        if (active) setLoading(false);
+      }
+    };
+    void load();
+    return () => {
+      active = false;
+    };
+  }, [debouncedKeyword, loadVersion, taskType, view]);
+
+  const taskTypeOptions = useMemo(
+    () =>
+      Array.from(new Set(items.map((item) => item.taskType)))
+        .sort((left, right) => left.localeCompare(right))
+        .map((value) => ({ value, label: value })),
+    [items],
+  );
+
+  const startDrag = (
+    event: DragEvent<HTMLDivElement>,
+    task: WorkflowPublishedTask,
+  ) => {
+    event.dataTransfer.effectAllowed = 'copy';
+    event.dataTransfer.setData(
+      WORKFLOW_TASK_DRAG_TYPE,
+      encodeTaskDragPayload(task),
+    );
+    event.dataTransfer.setData('text/plain', task.name);
+  };
+
+  return (
+    <aside className="flex h-full w-[300px] shrink-0 flex-col border-r border-[#e4e7ec] bg-white">
+      <div className="border-b border-[#edf0f3] px-4 pb-3 pt-4">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <h2 className="m-0 text-[15px] font-semibold text-[#161823]">
+              已发布任务
+            </h2>
+            <p className="mb-0 mt-1 text-[11px] leading-4 text-[#98a2b3]">
+              拖入画布后固定当前不可变版本
+            </p>
+          </div>
+          <Tooltip title="刷新任务资源">
+            <Button
+              type="text"
+              size="small"
+              icon={<RefreshCw size={14} className={loading ? 'animate-spin' : ''} />}
+              onClick={() => setLoadVersion((value) => value + 1)}
+            />
+          </Tooltip>
+        </div>
+
+        <div className="mt-3">
+          <Input
+            allowClear
+            variant="filled"
+            value={keyword}
+            prefix={<Search size={14} className="text-[#98a2b3]" />}
+            placeholder="搜索任务、项目或类型"
+            onChange={(event: ChangeEvent<HTMLInputElement>) =>
+              setKeyword(event.target.value)
+            }
+          />
+        </div>
+
+        <Segmented
+          block
+          size="small"
+          className="mt-2.5"
+          value={view}
+          options={viewOptions}
+          onChange={(value: string | number) =>
+            setView(value as LibraryView)
+          }
+        />
+
+        <Select
+          allowClear
+          variant="filled"
+          size="small"
+          className="mt-2.5 w-full"
+          value={taskType}
+          placeholder="全部任务类型"
+          options={taskTypeOptions}
+          onChange={(value: string | undefined) => setTaskType(value)}
+        />
+      </div>
+
+      <div className="flex items-center justify-between px-4 py-2 text-[10px] text-[#98a2b3]">
+        <span>共 {total} 个任务</span>
+        {total > 100 && <span>请使用筛选缩小范围</span>}
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto px-2.5 pb-4">
+        <Spin spinning={loading}>
+          {!loading && items.length === 0 ? (
+            <div className="flex min-h-[280px] items-center justify-center">
+              <Empty
+                image={Empty.PRESENTED_IMAGE_SIMPLE}
+                description={
+                  <span className="text-xs text-[#98a2b3]">
+                    没有匹配的已发布任务
+                  </span>
+                }
+              />
+            </div>
+          ) : (
+            <div className="space-y-1.5">
+              {items.map((task) => (
+                <div
+                  key={`${task.taskId}:${task.publishedVersionId}`}
+                  draggable
+                  className={[
+                    'group cursor-grab rounded-lg border border-transparent bg-[#f7f7f8] px-2.5 py-2.5',
+                    'transition-[border-color,background-color,box-shadow,transform] active:cursor-grabbing',
+                    'hover:-translate-y-px hover:border-[#dfe3e8] hover:bg-white hover:shadow-[0_5px_14px_rgba(16,24,40,0.08)]',
+                  ].join(' ')}
+                  onDragStart={(event: DragEvent<HTMLDivElement>) =>
+                    startDrag(event, task)
+                  }
+                  onDoubleClick={() => onInsert(task)}
+                >
+                  <div className="flex items-start gap-2">
+                    <GripVertical
+                      size={14}
+                      className="mt-0.5 shrink-0 text-[#c4c9d1] group-hover:text-[#98a2b3]"
+                    />
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-1.5">
+                        <strong className="min-w-0 flex-1 truncate text-[12px] font-semibold text-[#344054]">
+                          {task.name}
+                        </strong>
+                        {task.favorite && (
+                          <StarFilled className="text-[10px] text-[#f79009]" />
+                        )}
+                        <span className="rounded bg-white px-1.5 py-0.5 text-[9px] font-semibold text-[#667085] shadow-[inset_0_0_0_1px_#e4e7ec]">
+                          v{task.publishedVersionNumber}
+                        </span>
+                      </div>
+
+                      <div className="mt-1 flex items-center gap-1.5 text-[10px] text-[#98a2b3]">
+                        <Braces size={11} className="shrink-0" />
+                        <span className="truncate">{task.taskType}</span>
+                        <span>·</span>
+                        <span className="truncate">{task.projectName}</span>
+                      </div>
+
+                      {task.description && (
+                        <p className="mb-0 mt-1.5 line-clamp-2 text-[10px] leading-[15px] text-[#667085]">
+                          {task.description}
+                        </p>
+                      )}
+                    </div>
+
+                    <Tooltip title="添加到画布">
+                      <Button
+                        type="text"
+                        size="small"
+                        className="!h-6 !w-6 !min-w-6 shrink-0 opacity-0 group-hover:opacity-100"
+                        icon={<Plus size={13} />}
+                        onClick={(event: MouseEvent<HTMLElement>) => {
+                          event.stopPropagation();
+                          onInsert(task);
+                        }}
+                      />
+                    </Tooltip>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </Spin>
+      </div>
+
+      <div className="border-t border-[#edf0f3] px-4 py-2.5 text-[10px] leading-4 text-[#98a2b3]">
+        拖拽只复制任务引用，不复制 HTTP、Shell、SQL 等任务配置。
+      </div>
+    </aside>
+  );
+};
+
+export default TaskLibraryPanel;

--- a/yak-ops-ui/src/pages/workflow-management/designer-v2/components/WorkflowV2NodeCard.tsx
+++ b/yak-ops-ui/src/pages/workflow-management/designer-v2/components/WorkflowV2NodeCard.tsx
@@ -1,0 +1,146 @@
+import {
+  Braces,
+  Check,
+  CircleStop,
+  DatabaseZap,
+  GitBranch,
+  Play,
+} from 'lucide-react';
+import {
+  Handle,
+  Position,
+  type NodeProps,
+} from 'reactflow';
+
+import type { WorkflowV2CanvasNodeData } from '../model';
+
+const iconFor = (kind: WorkflowV2CanvasNodeData['kind']) => {
+  if (kind === 'START') return <Play size={16} />;
+  if (kind === 'END') return <CircleStop size={16} />;
+  return <DatabaseZap size={16} />;
+};
+
+const kindLabel = (kind: WorkflowV2CanvasNodeData['kind']) => {
+  if (kind === 'START') return 'START';
+  if (kind === 'END') return 'END';
+  return 'TASK VERSION';
+};
+
+const iconClass = (kind: WorkflowV2CanvasNodeData['kind']) => {
+  if (kind === 'TASK') {
+    return 'bg-[var(--yak-brand-color-soft)] text-[var(--yak-brand-color)]';
+  }
+  return 'bg-[#f2f4f7] text-[#344054]';
+};
+
+const handleClass =
+  '!h-3 !w-3 !border-[2px] !border-white !shadow-[0_0_0_1px_rgba(16,24,40,0.18)]';
+
+const WorkflowV2NodeCard = ({
+  data,
+  selected,
+}: NodeProps<WorkflowV2CanvasNodeData>) => {
+  const task = data.taskRef;
+  const meta = data.taskMeta;
+  const subtitle =
+    data.kind === 'TASK'
+      ? [meta?.projectName, meta?.folderName].filter(Boolean).join(' / ') ||
+        '已发布任务'
+      : data.description;
+
+  return (
+    <div
+      className={[
+        'group relative w-[252px] overflow-hidden rounded-xl border bg-white',
+        'shadow-[0_5px_16px_rgba(16,24,40,0.07)] transition-[border-color,box-shadow,transform]',
+        selected
+          ? 'border-[var(--yak-brand-color)] shadow-[0_0_0_3px_var(--yak-brand-color-outline),0_10px_24px_rgba(16,24,40,0.12)]'
+          : 'border-[#dfe3e8] hover:-translate-y-px hover:border-[#c7ccd4] hover:shadow-[0_9px_22px_rgba(16,24,40,0.10)]',
+        data.enabled ? '' : 'opacity-55',
+      ].join(' ')}
+    >
+      {data.kind !== 'START' && (
+        <Handle
+          id="INPUT"
+          type="target"
+          position={Position.Left}
+          className={`${handleClass} !bg-[#667085]`}
+        />
+      )}
+
+      <div className="flex min-h-[54px] items-center gap-2.5 px-3.5 py-2.5">
+        <span
+          className={[
+            'flex h-8 w-8 shrink-0 items-center justify-center rounded-lg',
+            iconClass(data.kind),
+          ].join(' ')}
+        >
+          {iconFor(data.kind)}
+        </span>
+
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <strong className="block min-w-0 flex-1 truncate text-[13px] font-semibold text-[#161823]">
+              {data.title}
+            </strong>
+            {data.kind === 'TASK' && task && (
+              <span className="shrink-0 rounded bg-[#f2f4f7] px-1.5 py-0.5 text-[9px] font-semibold text-[#667085]">
+                v{task.taskVersionNumber}
+              </span>
+            )}
+          </div>
+          <span className="mt-0.5 block truncate text-[10px] font-medium uppercase tracking-[0.055em] text-[#98a2b3]">
+            {kindLabel(data.kind)}
+          </span>
+        </div>
+      </div>
+
+      <div className="border-t border-[#f0f1f3] px-3.5 py-2.5">
+        <p className="m-0 line-clamp-2 min-h-[34px] text-[11px] leading-[17px] text-[#667085]">
+          {subtitle || '暂无描述'}
+        </p>
+
+        {data.kind === 'TASK' && task && (
+          <div className="mt-2 flex items-center justify-between gap-2 border-t border-[#f2f4f7] pt-2">
+            <span className="inline-flex min-w-0 items-center gap-1.5 text-[10px] font-medium text-[#475467]">
+              <Braces size={12} className="shrink-0" />
+              <span className="truncate">{task.taskType}</span>
+            </span>
+            <span className="inline-flex items-center gap-1 text-[9px] text-[#98a2b3]">
+              <Check size={11} />
+              固定发布版本
+            </span>
+          </div>
+        )}
+      </div>
+
+      {data.kind !== 'END' && (
+        <Handle
+          id="SUCCESS"
+          type="source"
+          position={Position.Right}
+          className={`${handleClass} !bg-[#667085]`}
+          style={{ top: data.kind === 'TASK' ? '42%' : '50%' }}
+        />
+      )}
+
+      {data.kind === 'TASK' && (
+        <>
+          <Handle
+            id="FAILURE"
+            type="source"
+            position={Position.Right}
+            className={`${handleClass} !bg-[#f04438]`}
+            style={{ top: '76%' }}
+          />
+          <span className="pointer-events-none absolute -right-[72px] top-[calc(76%-8px)] inline-flex items-center gap-1 rounded bg-white/90 px-1.5 py-0.5 text-[9px] text-[#d92d20] opacity-0 shadow-sm transition-opacity group-hover:opacity-100">
+            <GitBranch size={10} />
+            失败
+          </span>
+        </>
+      )}
+    </div>
+  );
+};
+
+export default WorkflowV2NodeCard;

--- a/yak-ops-ui/src/pages/workflow-management/designer-v2/index.tsx
+++ b/yak-ops-ui/src/pages/workflow-management/designer-v2/index.tsx
@@ -1,0 +1,578 @@
+import { API_SUCCESS_CODE } from '@/services/http/response';
+import { BRAND_CSS_VARIABLES, BRAND_THEME } from '@/styles/brand';
+import { history, useParams } from '@umijs/max';
+import {
+  Button,
+  ConfigProvider,
+  message,
+  Popconfirm,
+  Spin,
+  Tag,
+  Tooltip,
+} from 'antd';
+import {
+  ArrowLeft,
+  CheckCircle2,
+  CloudUpload,
+  GitBranch,
+  Save,
+  Trash2,
+  Workflow,
+} from 'lucide-react';
+import {
+  addEdge,
+  Background,
+  BackgroundVariant,
+  Controls,
+  MarkerType,
+  MiniMap,
+  ReactFlow,
+  ReactFlowProvider,
+  SelectionMode,
+  useEdgesState,
+  useNodesState,
+  useReactFlow,
+  type Connection,
+  type EdgeChange,
+  type NodeChange,
+  type OnMoveEnd,
+} from 'reactflow';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type DragEvent,
+} from 'react';
+import 'reactflow/dist/style.css';
+
+import type { WorkflowPublishedTask } from '../repository/workflow-task-library.repository';
+import {
+  workflowV2Repository,
+  type WorkflowDefinitionDocument,
+} from '../workflow-v2.repository';
+import CreateWorkflowV2 from './CreateWorkflowV2';
+import TaskLibraryPanel from './components/TaskLibraryPanel';
+import WorkflowV2NodeCard from './components/WorkflowV2NodeCard';
+import {
+  WORKFLOW_TASK_DRAG_TYPE,
+  createInitialWorkflowV2Dag,
+  createTaskFlowNode,
+  decodeTaskDragPayload,
+  isControlNode,
+  toFlowEdges,
+  toFlowNodes,
+  toWorkflowV2Dag,
+  workflowV2EdgeStyle,
+  type WorkflowV2CanvasNodeData,
+  type WorkflowV2FlowEdge,
+  type WorkflowV2FlowNode,
+} from './model';
+
+const nodeTypes = {
+  workflowV2Node: WorkflowV2NodeCard,
+};
+
+const WorkflowV2DesignerContent = () => {
+  const params = useParams<{ id: string }>();
+  const workflowId = params.id || '';
+  const reactFlow = useReactFlow<WorkflowV2CanvasNodeData>();
+  const loadingRequestRef = useRef(0);
+
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [publishing, setPublishing] = useState(false);
+  const [dirty, setDirty] = useState(false);
+  const [workflow, setWorkflow] = useState<WorkflowDefinitionDocument>();
+  const [selectedNodeId, setSelectedNodeId] = useState<string>();
+  const [selectedEdgeId, setSelectedEdgeId] = useState<string>();
+  const [nodes, setNodes, onNodesChangeBase] =
+    useNodesState<WorkflowV2CanvasNodeData>([]);
+  const [edges, setEdges, onEdgesChangeBase] = useEdgesState([]);
+
+  const selectedNode = useMemo(
+    () => nodes.find((node) => node.id === selectedNodeId),
+    [nodes, selectedNodeId],
+  );
+
+  const load = useCallback(async () => {
+    if (!workflowId || workflowId === 'create') return;
+    const requestId = ++loadingRequestRef.current;
+    try {
+      setLoading(true);
+      const response = await workflowV2Repository.detail(workflowId);
+      if (requestId !== loadingRequestRef.current) return;
+      if (response.code !== API_SUCCESS_CODE || !response.data) {
+        message.error(response.message || '加载 Workflow V2 失败');
+        history.replace('/workflow-management');
+        return;
+      }
+      if (response.data.schemaVersion !== 2) {
+        history.replace(`/workflow-management/v1/${workflowId}/designer`);
+        return;
+      }
+
+      const dag = response.data.draftV2 ?? createInitialWorkflowV2Dag();
+      const flowNodes = toFlowNodes(dag);
+      const flowEdges = toFlowEdges(dag);
+      setWorkflow(response.data);
+      setNodes(flowNodes);
+      setEdges(flowEdges);
+      setSelectedNodeId(undefined);
+      setSelectedEdgeId(undefined);
+      setDirty(false);
+      requestAnimationFrame(() => {
+        if (dag.viewport) {
+          reactFlow.setViewport(dag.viewport, { duration: 0 });
+        } else if (flowNodes.length) {
+          reactFlow.fitView({ padding: 0.24, duration: 0 });
+        }
+      });
+    } finally {
+      if (requestId === loadingRequestRef.current) setLoading(false);
+    }
+  }, [reactFlow, setEdges, setNodes, workflowId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  useEffect(() => {
+    const beforeUnload = (event: BeforeUnloadEvent) => {
+      if (!dirty) return;
+      event.preventDefault();
+      event.returnValue = '';
+    };
+    window.addEventListener('beforeunload', beforeUnload);
+    return () => window.removeEventListener('beforeunload', beforeUnload);
+  }, [dirty]);
+
+  const markDirty = useCallback(() => setDirty(true), []);
+
+  const onNodesChange = useCallback(
+    (changes: NodeChange[]) => {
+      onNodesChangeBase(changes);
+      if (changes.some((change) => change.type !== 'select')) markDirty();
+    },
+    [markDirty, onNodesChangeBase],
+  );
+
+  const onEdgesChange = useCallback(
+    (changes: EdgeChange[]) => {
+      onEdgesChangeBase(changes);
+      if (changes.some((change) => change.type !== 'select')) markDirty();
+    },
+    [markDirty, onEdgesChangeBase],
+  );
+
+  const onConnect = useCallback(
+    (connection: Connection) => {
+      if (!connection.source || !connection.target) return;
+      if (connection.source === connection.target) {
+        message.warning('节点不能连接到自身');
+        return;
+      }
+      const fromPort =
+        connection.sourceHandle === 'FAILURE' ? 'FAILURE' : 'SUCCESS';
+      const duplicated = edges.some(
+        (edge) =>
+          edge.source === connection.source &&
+          edge.target === connection.target &&
+          (edge.sourceHandle ?? 'SUCCESS') === fromPort,
+      );
+      if (duplicated) return;
+
+      setEdges((current) =>
+        addEdge(
+          {
+            ...connection,
+            sourceHandle: fromPort,
+            id: `edge_${connection.source}_${fromPort}_${connection.target}_${Date.now()}`,
+            type: 'smoothstep',
+            markerEnd: { type: MarkerType.ArrowClosed },
+            style: workflowV2EdgeStyle(fromPort),
+            data: { fromPort },
+          },
+          current,
+        ),
+      );
+      markDirty();
+    },
+    [edges, markDirty, setEdges],
+  );
+
+  const insertTask = useCallback(
+    (task: WorkflowPublishedTask, position?: { x: number; y: number }) => {
+      const flowPosition =
+        position ??
+        reactFlow.screenToFlowPosition({
+          x: Math.max(460, window.innerWidth * 0.58),
+          y: window.innerHeight * 0.52,
+        });
+      const node = createTaskFlowNode(task, flowPosition);
+      setNodes((current) => [...current, node]);
+      setSelectedNodeId(node.id);
+      setSelectedEdgeId(undefined);
+      markDirty();
+      requestAnimationFrame(() => {
+        reactFlow.setCenter(flowPosition.x + 120, flowPosition.y + 60, {
+          zoom: Math.max(reactFlow.getZoom(), 0.75),
+          duration: 220,
+        });
+      });
+    },
+    [markDirty, reactFlow, setNodes],
+  );
+
+  const onDrop = useCallback(
+    (event: DragEvent<HTMLDivElement>) => {
+      event.preventDefault();
+      const task = decodeTaskDragPayload(
+        event.dataTransfer.getData(WORKFLOW_TASK_DRAG_TYPE),
+      );
+      if (!task) {
+        message.warning('无法识别拖入的任务资源');
+        return;
+      }
+      insertTask(
+        task,
+        reactFlow.screenToFlowPosition({
+          x: event.clientX,
+          y: event.clientY,
+        }),
+      );
+    },
+    [insertTask, reactFlow],
+  );
+
+  const removeNode = useCallback(
+    (nodeId: string) => {
+      const node = nodes.find((item) => item.id === nodeId);
+      if (!node) return;
+      if (isControlNode(node)) {
+        message.info('开始和结束节点不能删除');
+        return;
+      }
+      setNodes((current) => current.filter((item) => item.id !== nodeId));
+      setEdges((current) =>
+        current.filter(
+          (edge) => edge.source !== nodeId && edge.target !== nodeId,
+        ),
+      );
+      setSelectedNodeId(undefined);
+      setSelectedEdgeId(undefined);
+      markDirty();
+    },
+    [markDirty, nodes, setEdges, setNodes],
+  );
+
+  const removeEdge = useCallback(
+    (edgeId: string) => {
+      setEdges((current) => current.filter((edge) => edge.id !== edgeId));
+      setSelectedEdgeId(undefined);
+      markDirty();
+    },
+    [markDirty, setEdges],
+  );
+
+  const saveDraft = useCallback(
+    async (showSuccess = true): Promise<boolean> => {
+      if (!workflow) return false;
+      const invalid = nodes.find((node) => !node.data.title.trim());
+      if (invalid) {
+        setSelectedNodeId(invalid.id);
+        message.warning('节点名称不能为空');
+        return false;
+      }
+      try {
+        setSaving(true);
+        const response = await workflowV2Repository.update(workflow.id, {
+          name: workflow.name,
+          description: workflow.description,
+          failureStrategy: workflow.failureStrategy,
+          maxParallelism: workflow.maxParallelism,
+          dag: toWorkflowV2Dag(nodes, edges, reactFlow.getViewport()),
+        });
+        if (response.code !== API_SUCCESS_CODE) {
+          message.error(response.message || '保存 Workflow V2 草稿失败');
+          return false;
+        }
+        setDirty(false);
+        if (showSuccess) message.success('Workflow V2 草稿已保存');
+        return true;
+      } finally {
+        setSaving(false);
+      }
+    },
+    [edges, nodes, reactFlow, workflow],
+  );
+
+  const publish = useCallback(async () => {
+    if (!workflow) return;
+    try {
+      setPublishing(true);
+      if (!(await saveDraft(false))) return;
+      const response = await workflowV2Repository.publish(workflow.id);
+      if (response.code !== API_SUCCESS_CODE || !response.data) {
+        message.error(response.message || '发布 Workflow V2 失败');
+        return;
+      }
+      const publishedVersion = response.data.version;
+      setWorkflow((current) =>
+        current
+          ? {
+              ...current,
+              state: 'PUBLISHED',
+              currentVersion: publishedVersion,
+            }
+          : current,
+      );
+      message.success(`工作流版本 v${publishedVersion} 已发布`);
+    } finally {
+      setPublishing(false);
+    }
+  }, [saveDraft, workflow]);
+
+  useEffect(() => {
+    const keydown = (event: KeyboardEvent) => {
+      const target = event.target as HTMLElement | null;
+      const editing =
+        target?.tagName === 'INPUT' ||
+        target?.tagName === 'TEXTAREA' ||
+        target?.isContentEditable;
+      if (editing) return;
+      const modifier = event.ctrlKey || event.metaKey;
+      if (modifier && event.key.toLowerCase() === 's') {
+        event.preventDefault();
+        void saveDraft();
+        return;
+      }
+      if (['Delete', 'Backspace'].includes(event.key)) {
+        if (selectedNodeId) {
+          event.preventDefault();
+          removeNode(selectedNodeId);
+        } else if (selectedEdgeId) {
+          event.preventDefault();
+          removeEdge(selectedEdgeId);
+        }
+      }
+      if (event.key === 'Escape') {
+        setSelectedNodeId(undefined);
+        setSelectedEdgeId(undefined);
+      }
+    };
+    window.addEventListener('keydown', keydown);
+    return () => window.removeEventListener('keydown', keydown);
+  }, [removeEdge, removeNode, saveDraft, selectedEdgeId, selectedNodeId]);
+
+  const onMoveEnd = useCallback<OnMoveEnd>(() => markDirty(), [markDirty]);
+
+  if (loading && !workflow) {
+    return (
+      <div className="fixed inset-0 z-[120] flex items-center justify-center bg-[#f7f7f8]">
+        <Spin tip="加载 Workflow V2..." />
+      </div>
+    );
+  }
+
+  return (
+    <div className="fixed inset-0 z-[110] flex flex-col overflow-hidden bg-[#f7f7f8] text-[#161823]">
+      <header className="flex h-[52px] shrink-0 items-center justify-between border-b border-[#e4e7ec] bg-white px-4">
+        <div className="flex min-w-0 items-center gap-3">
+          <Button
+            type="text"
+            size="small"
+            icon={<ArrowLeft size={16} />}
+            onClick={() => history.push('/workflow-management')}
+          >
+            返回
+          </Button>
+          <div className="h-5 w-px bg-[#e4e7ec]" />
+          <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-[var(--yak-brand-color-soft)] text-[var(--yak-brand-color)]">
+            <Workflow size={15} />
+          </span>
+          <div className="min-w-0">
+            <div className="flex items-center gap-2">
+              <strong className="max-w-[360px] truncate text-[13px] font-semibold text-[#161823]">
+                {workflow?.name ?? 'Workflow V2'}
+              </strong>
+              <Tag bordered={false} className="!m-0 !bg-[#f2f4f7] !text-[10px] !text-[#667085]">
+                Schema V2
+              </Tag>
+              {dirty && (
+                <span className="text-[10px] text-[#f79009]">未保存</span>
+              )}
+            </div>
+            <span className="block text-[10px] text-[#98a2b3]">
+              已发布任务资源编排 · 固定不可变任务版本
+            </span>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-2">
+          {workflow?.currentVersion && (
+            <span className="inline-flex items-center gap-1 text-[10px] text-[#667085]">
+              <CheckCircle2 size={12} />
+              当前 v{workflow.currentVersion}
+            </span>
+          )}
+          <Button
+            icon={<Save size={14} />}
+            loading={saving}
+            onClick={() => void saveDraft()}
+          >
+            保存草稿
+          </Button>
+          <Button
+            type="primary"
+            icon={<CloudUpload size={14} />}
+            loading={publishing}
+            onClick={() => void publish()}
+          >
+            发布
+          </Button>
+        </div>
+      </header>
+
+      <div className="flex min-h-0 flex-1">
+        <TaskLibraryPanel onInsert={(task) => insertTask(task)} />
+
+        <main
+          className="relative min-w-0 flex-1 overflow-hidden bg-[#f7f7f8]"
+          onDragOver={(event: DragEvent<HTMLDivElement>) => {
+            event.preventDefault();
+            event.dataTransfer.dropEffect = 'copy';
+          }}
+          onDrop={onDrop}
+        >
+          <ReactFlow
+            nodes={nodes}
+            edges={edges}
+            nodeTypes={nodeTypes}
+            onNodesChange={onNodesChange}
+            onEdgesChange={onEdgesChange}
+            onConnect={onConnect}
+            onMoveEnd={onMoveEnd}
+            onNodeClick={(_: unknown, node: WorkflowV2FlowNode) => {
+              setSelectedNodeId(node.id);
+              setSelectedEdgeId(undefined);
+            }}
+            onEdgeClick={(_: unknown, edge: WorkflowV2FlowEdge) => {
+              setSelectedEdgeId(edge.id);
+              setSelectedNodeId(undefined);
+            }}
+            onPaneClick={() => {
+              setSelectedNodeId(undefined);
+              setSelectedEdgeId(undefined);
+            }}
+            minZoom={0.25}
+            maxZoom={2}
+            deleteKeyCode={null}
+            selectionOnDrag
+            selectionMode={SelectionMode.Partial}
+            multiSelectionKeyCode={['Meta', 'Control', 'Shift']}
+            defaultEdgeOptions={{
+              type: 'smoothstep',
+              markerEnd: { type: MarkerType.ArrowClosed },
+            }}
+            connectionLineStyle={{
+              stroke: 'var(--yak-brand-color)',
+              strokeWidth: 1.8,
+            }}
+            proOptions={{ hideAttribution: true }}
+          >
+            <Background
+              variant={BackgroundVariant.Dots}
+              gap={18}
+              size={1.1}
+              color="#d7dce3"
+            />
+            <MiniMap
+              pannable
+              zoomable
+              className="!border !border-[#e4e7ec] !bg-white"
+            />
+            <Controls
+              showInteractive={false}
+              className="!overflow-hidden !rounded-lg !border !border-[#e4e7ec] !shadow-[0_4px_14px_rgba(16,24,40,0.08)]"
+            />
+          </ReactFlow>
+
+          <div className="pointer-events-none absolute left-4 top-4 rounded-lg border border-[#e4e7ec] bg-white/92 px-3 py-2 text-[10px] leading-4 text-[#667085] shadow-[0_4px_14px_rgba(16,24,40,0.06)] backdrop-blur">
+            从左侧拖入已发布任务。灰色出口表示成功，红色出口表示失败。
+          </div>
+
+          {selectedEdgeId && (
+            <div className="absolute bottom-4 left-1/2 flex -translate-x-1/2 items-center gap-2 rounded-lg border border-[#e4e7ec] bg-white px-3 py-2 shadow-[0_7px_20px_rgba(16,24,40,0.10)]">
+              <span className="text-[10px] text-[#667085]">已选择连线</span>
+              <Button
+                danger
+                type="text"
+                size="small"
+                icon={<Trash2 size={13} />}
+                onClick={() => removeEdge(selectedEdgeId)}
+              >
+                删除
+              </Button>
+            </div>
+          )}
+
+          {selectedNode?.data.kind === 'TASK' && (
+            <div className="absolute right-4 top-4 flex min-w-[270px] items-center gap-3 rounded-lg border border-[#e4e7ec] bg-white px-3 py-2.5 shadow-[0_7px_20px_rgba(16,24,40,0.10)]">
+              <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-[var(--yak-brand-color-soft)] text-[var(--yak-brand-color)]">
+                <GitBranch size={15} />
+              </span>
+              <div className="min-w-0 flex-1">
+                <strong className="block truncate text-[12px] text-[#344054]">
+                  {selectedNode.data.title}
+                </strong>
+                <span className="block truncate text-[10px] text-[#98a2b3]">
+                  {selectedNode.data.taskRef?.taskType} · v
+                  {selectedNode.data.taskRef?.taskVersionNumber}
+                </span>
+              </div>
+              <Popconfirm
+                title="删除任务节点"
+                description="关联连线也会一起删除。"
+                okText="删除"
+                cancelText="取消"
+                onConfirm={() => removeNode(selectedNode.id)}
+              >
+                <Tooltip title="删除节点">
+                  <Button
+                    danger
+                    type="text"
+                    size="small"
+                    icon={<Trash2 size={14} />}
+                  />
+                </Tooltip>
+              </Popconfirm>
+            </div>
+          )}
+        </main>
+      </div>
+    </div>
+  );
+};
+
+const WorkflowV2DesignerPage = () => {
+  const params = useParams<{ id: string }>();
+  const createMode = params.id === 'create';
+
+  return (
+    <ConfigProvider theme={BRAND_THEME}>
+      <div style={BRAND_CSS_VARIABLES}>
+        {createMode ? (
+          <CreateWorkflowV2 />
+        ) : (
+          <ReactFlowProvider>
+            <WorkflowV2DesignerContent />
+          </ReactFlowProvider>
+        )}
+      </div>
+    </ConfigProvider>
+  );
+};
+
+export default WorkflowV2DesignerPage;

--- a/yak-ops-ui/src/pages/workflow-management/designer-v2/model.test.ts
+++ b/yak-ops-ui/src/pages/workflow-management/designer-v2/model.test.ts
@@ -1,0 +1,122 @@
+import type { WorkflowPublishedTask } from '../repository/workflow-task-library.repository';
+import {
+  createInitialWorkflowV2Dag,
+  createTaskFlowNode,
+  decodeTaskDragPayload,
+  encodeTaskDragPayload,
+  toWorkflowV2Dag,
+} from './model';
+
+const task = (): WorkflowPublishedTask => ({
+  taskId: '1001',
+  name: '查询订单',
+  description: '根据订单号查询订单',
+  projectId: '10',
+  projectCode: 'order',
+  projectName: '订单中心',
+  folderId: '20',
+  folderName: '接口任务',
+  taskType: 'HTTP',
+  engineType: 'HTTP',
+  publishedVersionId: '2003',
+  publishedVersionNumber: 3,
+  pluginVersion: '1.0.0',
+  schemaVersion: 1,
+  inputSchema: { required: ['orderId'] },
+  outputSchema: { type: 'object' },
+  contentDigest: 'digest',
+  publishedBy: 'admin',
+  publishedAt: '2026-08-05T00:30:00',
+  updatedAt: '2026-08-05T00:30:00',
+  favorite: false,
+});
+
+describe('Workflow V2 designer model', () => {
+  it('creates a valid START to END initial workflow', () => {
+    const dag = createInitialWorkflowV2Dag();
+    expect(dag.schemaVersion).toBe(2);
+    expect(dag.nodes.map((node) => node.kind)).toEqual(['START', 'END']);
+    expect(dag.edges).toEqual([
+      { from: 'start', fromPort: 'SUCCESS', to: 'end' },
+    ]);
+  });
+
+  it('copies only an immutable task reference into a dropped task node', () => {
+    const node = createTaskFlowNode(task(), { x: 300, y: 200 });
+    expect(node.data.taskRef).toEqual({
+      taskId: '1001',
+      taskVersionId: '2003',
+      taskVersionNumber: 3,
+      taskType: 'HTTP',
+    });
+    expect(node.data).not.toHaveProperty('config');
+    expect(node.data).not.toHaveProperty('definition');
+    expect(node.data).not.toHaveProperty('compiledSpec');
+  });
+
+  it('preserves SUCCESS and FAILURE source ports when saving', () => {
+    const initial = createInitialWorkflowV2Dag();
+    const taskNode = createTaskFlowNode(task(), { x: 420, y: 220 });
+    const nodes = [
+      {
+        id: 'start',
+        type: 'workflowV2Node',
+        position: { x: 140, y: 220 },
+        data: {
+          title: initial.nodes[0].name,
+          description: initial.nodes[0].description,
+          kind: initial.nodes[0].kind,
+          enabled: true,
+          inputBindings: [],
+          outputBindings: {},
+          executionPolicy: initial.nodes[0].executionPolicy,
+        },
+      },
+      taskNode,
+      {
+        id: 'end',
+        type: 'workflowV2Node',
+        position: { x: 760, y: 220 },
+        data: {
+          title: initial.nodes[1].name,
+          description: initial.nodes[1].description,
+          kind: initial.nodes[1].kind,
+          enabled: true,
+          inputBindings: [],
+          outputBindings: {},
+          executionPolicy: initial.nodes[1].executionPolicy,
+        },
+      },
+    ];
+    const dag = toWorkflowV2Dag(
+      nodes,
+      [
+        {
+          id: 'success',
+          source: 'start',
+          sourceHandle: 'SUCCESS',
+          target: taskNode.id,
+        },
+        {
+          id: 'failure',
+          source: taskNode.id,
+          sourceHandle: 'FAILURE',
+          target: 'end',
+        },
+      ],
+      { x: 0, y: 0, zoom: 1 },
+    );
+    expect(dag.edges).toEqual([
+      { from: 'start', fromPort: 'SUCCESS', to: taskNode.id },
+      { from: taskNode.id, fromPort: 'FAILURE', to: 'end' },
+    ]);
+  });
+
+  it('rejects malformed drag payloads', () => {
+    expect(decodeTaskDragPayload('')).toBeUndefined();
+    expect(decodeTaskDragPayload('{"taskId":"1"}')).toBeUndefined();
+    expect(decodeTaskDragPayload(encodeTaskDragPayload(task()))?.taskId).toBe(
+      '1001',
+    );
+  });
+});

--- a/yak-ops-ui/src/pages/workflow-management/designer-v2/model.ts
+++ b/yak-ops-ui/src/pages/workflow-management/designer-v2/model.ts
@@ -1,0 +1,269 @@
+import {
+  MarkerType,
+  type Edge,
+  type Node,
+  type Viewport,
+  type XYPosition,
+} from 'reactflow';
+
+import type {
+  WorkflowPublishedTask,
+} from '../repository/workflow-task-library.repository';
+import {
+  WORKFLOW_V2_SCHEMA_VERSION,
+  createWorkflowV2ExecutionPolicy,
+  type WorkflowV2BindingSource,
+  type WorkflowV2Dag,
+  type WorkflowV2Edge,
+  type WorkflowV2ExecutionPolicy,
+  type WorkflowV2InputBinding,
+  type WorkflowV2NodeKind,
+  type WorkflowV2TaskReference,
+} from '../workflow-v2.types';
+
+export const WORKFLOW_TASK_DRAG_TYPE =
+  'application/x-yak-workflow-published-task';
+
+export interface WorkflowV2CanvasTaskMeta {
+  projectName?: string;
+  folderName?: string;
+  pluginVersion?: string;
+  publishedAt?: string;
+  inputSchema?: Record<string, unknown>;
+  outputSchema?: Record<string, unknown>;
+}
+
+export interface WorkflowV2CanvasNodeData {
+  title: string;
+  description?: string;
+  kind: WorkflowV2NodeKind;
+  enabled: boolean;
+  taskRef?: WorkflowV2TaskReference;
+  taskMeta?: WorkflowV2CanvasTaskMeta;
+  inputBindings: WorkflowV2InputBinding[];
+  outputBindings: Record<string, WorkflowV2BindingSource>;
+  executionPolicy: WorkflowV2ExecutionPolicy;
+}
+
+export type WorkflowV2FlowNode = Node<WorkflowV2CanvasNodeData>;
+export type WorkflowV2FlowEdge = Edge;
+
+const copyJson = <T,>(value: T): T =>
+  JSON.parse(JSON.stringify(value)) as T;
+
+const uniqueTaskNodeKey = (taskId: string) => {
+  const compactTaskId = taskId.replace(/[^A-Za-z0-9_-]/g, '').slice(-20);
+  const suffix = `${Date.now().toString(36)}_${Math.random()
+    .toString(36)
+    .slice(2, 6)}`;
+  return `task_${compactTaskId || 'node'}_${suffix}`.slice(0, 64);
+};
+
+export const createInitialWorkflowV2Dag = (): WorkflowV2Dag => ({
+  schemaVersion: WORKFLOW_V2_SCHEMA_VERSION,
+  nodes: [
+    {
+      key: 'start',
+      name: '开始',
+      kind: 'START',
+      description: '工作流输入入口',
+      positionX: 140,
+      positionY: 220,
+      enabled: true,
+      inputBindings: [],
+      outputBindings: {},
+      executionPolicy: createWorkflowV2ExecutionPolicy(),
+    },
+    {
+      key: 'end',
+      name: '结束',
+      kind: 'END',
+      description: '工作流输出出口',
+      positionX: 760,
+      positionY: 220,
+      enabled: true,
+      inputBindings: [],
+      outputBindings: {},
+      executionPolicy: createWorkflowV2ExecutionPolicy(),
+    },
+  ],
+  edges: [
+    {
+      from: 'start',
+      fromPort: 'SUCCESS',
+      to: 'end',
+    },
+  ],
+  viewport: {
+    x: 0,
+    y: 0,
+    zoom: 1,
+  },
+});
+
+export const createTaskFlowNode = (
+  task: WorkflowPublishedTask,
+  position: XYPosition,
+): WorkflowV2FlowNode => ({
+  id: uniqueTaskNodeKey(task.taskId),
+  type: 'workflowV2Node',
+  position,
+  data: {
+    title: task.name,
+    description: task.description,
+    kind: 'TASK',
+    enabled: true,
+    taskRef: {
+      taskId: task.taskId,
+      taskVersionId: task.publishedVersionId,
+      taskVersionNumber: task.publishedVersionNumber,
+      taskType: task.taskType,
+    },
+    taskMeta: {
+      projectName: task.projectName,
+      folderName: task.folderName,
+      pluginVersion: task.pluginVersion,
+      publishedAt: task.publishedAt,
+      inputSchema: copyJson(task.inputSchema),
+      outputSchema: copyJson(task.outputSchema),
+    },
+    inputBindings: [],
+    outputBindings: {},
+    executionPolicy: createWorkflowV2ExecutionPolicy(),
+  },
+});
+
+export const toFlowNodes = (dag: WorkflowV2Dag): WorkflowV2FlowNode[] =>
+  dag.nodes.map((node, index) => ({
+    id: node.key,
+    type: 'workflowV2Node',
+    position: {
+      x: node.positionX ?? 120 + index * 300,
+      y: node.positionY ?? 220,
+    },
+    data: {
+      title: node.name,
+      description: node.description,
+      kind: node.kind,
+      enabled: node.enabled,
+      taskRef: node.taskRef ? copyJson(node.taskRef) : undefined,
+      taskMeta:
+        node.kind === 'TASK' && node.taskRef
+          ? {
+              pluginVersion: undefined,
+              projectName: undefined,
+              folderName: undefined,
+            }
+          : undefined,
+      inputBindings: copyJson(node.inputBindings ?? []),
+      outputBindings: copyJson(node.outputBindings ?? {}),
+      executionPolicy: copyJson(
+        node.executionPolicy ?? createWorkflowV2ExecutionPolicy(),
+      ),
+    },
+  }));
+
+const edgeStyle = (port: WorkflowV2Edge['fromPort']) =>
+  port === 'FAILURE'
+    ? { stroke: '#f04438', strokeWidth: 1.8 }
+    : { stroke: '#98a2b3', strokeWidth: 1.8 };
+
+export const toFlowEdges = (dag: WorkflowV2Dag): WorkflowV2FlowEdge[] =>
+  dag.edges.map((edge, index) => ({
+    id: `edge_${edge.from}_${edge.fromPort}_${edge.to}_${index}`,
+    source: edge.from,
+    sourceHandle: edge.fromPort,
+    target: edge.to,
+    type: 'smoothstep',
+    markerEnd: { type: MarkerType.ArrowClosed },
+    style: edgeStyle(edge.fromPort),
+    data: { fromPort: edge.fromPort },
+  }));
+
+export const toWorkflowV2Dag = (
+  nodes: WorkflowV2FlowNode[],
+  edges: WorkflowV2FlowEdge[],
+  viewport: Viewport,
+): WorkflowV2Dag => ({
+  schemaVersion: WORKFLOW_V2_SCHEMA_VERSION,
+  nodes: nodes.map((node) => ({
+    key: node.id,
+    name: node.data.title.trim(),
+    kind: node.data.kind,
+    description: node.data.description,
+    positionX: node.position.x,
+    positionY: node.position.y,
+    enabled: node.data.enabled,
+    taskRef:
+      node.data.kind === 'TASK' && node.data.taskRef
+        ? copyJson(node.data.taskRef)
+        : undefined,
+    inputBindings: copyJson(node.data.inputBindings),
+    outputBindings: copyJson(node.data.outputBindings),
+    executionPolicy: copyJson(node.data.executionPolicy),
+  })),
+  edges: edges.map((edge) => ({
+    from: edge.source,
+    fromPort:
+      edge.sourceHandle === 'FAILURE' || edge.data?.fromPort === 'FAILURE'
+        ? 'FAILURE'
+        : 'SUCCESS',
+    to: edge.target,
+  })),
+  viewport: {
+    x: viewport.x,
+    y: viewport.y,
+    zoom: viewport.zoom,
+  },
+});
+
+export const encodeTaskDragPayload = (task: WorkflowPublishedTask) =>
+  JSON.stringify(task);
+
+export const decodeTaskDragPayload = (
+  value: string,
+): WorkflowPublishedTask | undefined => {
+  if (!value.trim()) return undefined;
+  try {
+    const parsed = JSON.parse(value) as Partial<WorkflowPublishedTask>;
+    if (
+      typeof parsed.taskId !== 'string' ||
+      typeof parsed.name !== 'string' ||
+      typeof parsed.projectId !== 'string' ||
+      typeof parsed.projectName !== 'string' ||
+      typeof parsed.taskType !== 'string' ||
+      typeof parsed.publishedVersionId !== 'string' ||
+      typeof parsed.publishedVersionNumber !== 'number' ||
+      typeof parsed.pluginVersion !== 'string'
+    ) {
+      return undefined;
+    }
+    return {
+      ...parsed,
+      description: parsed.description,
+      folderId: parsed.folderId,
+      folderName: parsed.folderName,
+      engineType: parsed.engineType,
+      schemaVersion: Number(parsed.schemaVersion ?? 1),
+      inputSchema:
+        parsed.inputSchema && typeof parsed.inputSchema === 'object'
+          ? parsed.inputSchema
+          : {},
+      outputSchema:
+        parsed.outputSchema && typeof parsed.outputSchema === 'object'
+          ? parsed.outputSchema
+          : {},
+      contentDigest: String(parsed.contentDigest ?? ''),
+      publishedAt: String(parsed.publishedAt ?? ''),
+      updatedAt: String(parsed.updatedAt ?? ''),
+      favorite: Boolean(parsed.favorite),
+    } as WorkflowPublishedTask;
+  } catch {
+    return undefined;
+  }
+};
+
+export const isControlNode = (node: WorkflowV2FlowNode) =>
+  node.data.kind === 'START' || node.data.kind === 'END';
+
+export const workflowV2EdgeStyle = edgeStyle;


### PR DESCRIPTION
## 背景

前三步已经完成 Workflow V2 编排契约、已发布任务资源查询接口，以及 V2 Reader / Writer 与发布校验。现有前端设计器仍然按照 Workflow V1 的节点目录运行，并在节点中维护 HTTP、Shell 等任务配置，无法体现任务开发与工作流编排的职责分离。

本 PR 完成第四步：新增 Workflow V2 专用设计器，提供左侧 300px 已发布任务资源库和 React Flow 拖拽画布，同时保留历史 Workflow V1 设计器。

## V1 / V2 路由兼容

新增版本化路由：

```text
/workflow-management/v1/:id/designer
/workflow-management/v2/:id/designer
```

统一入口继续兼容：

```text
/workflow-management/:id/designer
```

统一入口会读取定义的 `schemaVersion` 后自动分流：

```text
schemaVersion=1 -> V1 设计器
schemaVersion=2 -> V2 设计器
create          -> V2 创建页
```

历史 V1 工作流不会迁移或改写，新建工作流默认创建 Schema V2。

路由权限按场景区分：

- 创建：`workflow:definition:create`
- 打开和编辑：`workflow:definition:read`

## V2 页面布局

设计器采用：

```text
52px 顶部栏
300px 已发布任务资源库 | React Flow 画布
```

整体继续使用白底、高密度布局、Ant Design filled 控件和 Yak Ops 品牌变量。

## 已发布任务资源库

左侧资源库直接调用：

```http
GET /api/v1/data-development/tasks/library
```

支持：

- 关键字搜索；
- 任务类型筛选；
- 全部、收藏、最近使用切换；
- 手动刷新；
- 双击快速插入；
- 原生 HTML5 拖拽到画布；
- 展示项目、任务类型和发布版本号。

接口单次最多加载 100 条，结果超过 100 条时提示继续使用搜索或类型筛选缩小范围。

## 拖拽与节点模型

拖拽 MIME：

```text
application/x-yak-workflow-published-task
```

拖入画布后仅生成不可变任务版本引用：

```json
{
  "kind": "TASK",
  "taskRef": {
    "taskId": "1001",
    "taskVersionId": "2003",
    "taskVersionNumber": 3,
    "taskType": "HTTP"
  }
}
```

不会复制或持久化：

```text
config
definition
definitionSnapshot
compiledSpec
runtime
secret
HTTP / Shell / SQL / Python / Notebook 专属参数
```

项目名称、插件版本、发布时间和 Input / Output Schema 仅作为当前前端展示元数据，不进入 Workflow V2 DAG 的任务内容。

## React Flow 画布

画布提供：

- START、TASK、END 三类节点；
- 新建工作流自动生成 START -> END；
- TASK 左侧输入连接点；
- TASK 的 SUCCESS 与 FAILURE 双出口；
- START 仅 SUCCESS 出口；
- END 仅输入；
- 连线选择和删除；
- 任务节点选择和删除；
- START / END 删除保护；
- MiniMap、缩放和画布移动；
- `Ctrl/Cmd + S` 保存草稿；
- 未保存离开提醒。

React Flow 的 `sourceHandle` 会映射为：

```text
SUCCESS -> fromPort=SUCCESS
FAILURE -> fromPort=FAILURE
```

## 保存与发布

草稿保存调用：

```http
PUT /api/v1/workflows/{workflowId}/draft/v2
```

发布调用：

```http
POST /api/v1/workflows/{workflowId}/publish
```

保存前端只序列化 Workflow V2 编排字段。发布继续由后端校验任务版本存在性、版本号、任务类型和必填输入绑定。

## 当前边界

本步骤不实现：

- 任务版本升级选择；
- 输入输出映射编辑器；
- 节点重试、超时和失败策略面板；
- Workflow V2 运行；
- V1 到 V2 自动迁移。

因此，引用了必填输入任务但尚未配置输入映射时，后端会按现有发布校验规则拒绝发布；V2 运行仍保持步骤三中的明确禁用提示。

## 测试与验证

已完成：

- TypeScript 5.8 对 9 个新增或修改 TS / TSX 文件的语法转译检查；
- Workflow V2 纯模型 strict 类型检查；
- V2 页面、路由与权限包装组件的 strict 类型检查；
- 模型测试覆盖初始 START -> END、不可变 taskRef、SUCCESS / FAILURE 序列化和非法拖拽数据；
- 静态扫描确认设计器持久化模型不包含任务 `config`、Definition 或 Compiled Spec；
- GitHub compare 确认分支基于最新 `main`，落后 0，只包含本步骤的 10 个文件。

当前环境没有完整仓库依赖和浏览器运行环境，因此没有执行真实 `npm run tsc`、Jest、Umi production build 和浏览器拖拽联调；这些需由本地或 CI 完成最终验证。

## 合并说明

连接器按文件产生细粒度提交，建议使用 **Squash and merge**。