### PR TITLE
refactor(workflow-ui): remove V2 task configuration panel

### DIFF
--- a/docs/workflow/workflow-v2-remove-task-config-panel.md
+++ b/docs/workflow/workflow-v2-remove-task-config-panel.md
@@ -1,0 +1,86 @@
+# Workflow V2 删除节点任务配置 Panel
+
+## 目标
+
+Workflow V2 只负责任务版本引用和编排，不负责任务内部配置。
+
+本阶段删除 V2 设计器中选中任务节点后出现在画布右上角的浮动 Panel，避免用户误以为可以在工作流中编辑 HTTP、Shell、SQL、Python 或 Notebook 等任务定义。
+
+## 交互变化
+
+调整前：
+
+```text
+点击 TASK 节点
+  -> 选中节点
+  -> 画布右上角显示任务节点浮层
+  -> 浮层展示任务类型、版本和删除按钮
+```
+
+调整后：
+
+```text
+点击 TASK 节点
+  -> 仅选中节点
+  -> 不打开侧栏、抽屉、Popover 或任务配置 Panel
+```
+
+删除任务节点统一使用 React Flow 原生交互：
+
+```text
+选中 TASK
+  -> Delete / Backspace
+  -> 删除节点及关联连线
+```
+
+连线仍保留底部轻量删除工具条，因为它属于工作流编排关系，不属于任务配置。
+
+## 删除保护
+
+节点模型现在明确设置：
+
+```text
+START deletable=false
+END   deletable=false
+TASK  deletable=true
+```
+
+因此 React Flow 原生删除不会移除 START 和 END，也不再需要通过任务配置 Panel 承担删除保护。
+
+## 职责边界
+
+Workflow V2 页面不会提供或恢复以下任务配置入口：
+
+```text
+HTTP URL / Method / Header / Body
+Shell Command / Args / Environment
+SQL / Python / Notebook Source
+Plugin-specific config
+Definition / Compiled Spec
+Runtime / Secret
+```
+
+任务节点仍可以展示任务名称、任务类型和固定发布版本号，但这些都是不可变引用的只读信息。
+
+后续输入映射、输出映射、重试、超时和失败路由属于工作流编排能力，应通过独立的编排属性区域实现，不能复用旧任务配置 Panel。
+
+## V1 兼容
+
+本阶段仅删除 Workflow V2 的节点任务配置 Panel。
+
+Workflow V1 设计器仍保留原 `NodePanel`，因为历史 V1 定义把插件配置直接存储在工作流 DAG 中。在 V1 到 V2 显式迁移工具完成前直接删除它，会导致历史工作流无法维护。
+
+```text
+Workflow V1 -> 兼容编辑，暂时保留旧 NodePanel
+Workflow V2 -> 不允许任务配置 Panel
+```
+
+## 测试
+
+模型测试覆盖：
+
+- 新拖入 TASK 默认可删除；
+- 从 V2 DAG 恢复时 TASK 可删除；
+- START 和 END 不可删除；
+- 删除能力不会进入 Workflow V2 持久化 JSON；
+- taskRef 仍保持不可变任务版本引用。

--- a/yak-ops-ui/src/pages/workflow-management/designer-v2/index.tsx
+++ b/yak-ops-ui/src/pages/workflow-management/designer-v2/index.tsx
@@ -1,20 +1,11 @@
 import { API_SUCCESS_CODE } from '@/services/http/response';
 import { BRAND_CSS_VARIABLES, BRAND_THEME } from '@/styles/brand';
 import { history, useParams } from '@umijs/max';
-import {
-  Button,
-  ConfigProvider,
-  message,
-  Popconfirm,
-  Spin,
-  Tag,
-  Tooltip,
-} from 'antd';
+import { Button, ConfigProvider, message, Spin, Tag } from 'antd';
 import {
   ArrowLeft,
   CheckCircle2,
   CloudUpload,
-  GitBranch,
   Save,
   Trash2,
   Workflow,
@@ -40,7 +31,6 @@ import {
 import {
   useCallback,
   useEffect,
-  useMemo,
   useRef,
   useState,
   type DragEvent,
@@ -60,7 +50,6 @@ import {
   createInitialWorkflowV2Dag,
   createTaskFlowNode,
   decodeTaskDragPayload,
-  isControlNode,
   toFlowEdges,
   toFlowNodes,
   toWorkflowV2Dag,
@@ -90,11 +79,6 @@ const WorkflowV2DesignerContent = () => {
   const [nodes, setNodes, onNodesChangeBase] =
     useNodesState<WorkflowV2CanvasNodeData>([]);
   const [edges, setEdges, onEdgesChangeBase] = useEdgesState([]);
-
-  const selectedNode = useMemo(
-    () => nodes.find((node) => node.id === selectedNodeId),
-    [nodes, selectedNodeId],
-  );
 
   const load = useCallback(async () => {
     if (!workflowId || workflowId === 'create') return;
@@ -246,27 +230,6 @@ const WorkflowV2DesignerContent = () => {
     [insertTask, reactFlow],
   );
 
-  const removeNode = useCallback(
-    (nodeId: string) => {
-      const node = nodes.find((item) => item.id === nodeId);
-      if (!node) return;
-      if (isControlNode(node)) {
-        message.info('开始和结束节点不能删除');
-        return;
-      }
-      setNodes((current) => current.filter((item) => item.id !== nodeId));
-      setEdges((current) =>
-        current.filter(
-          (edge) => edge.source !== nodeId && edge.target !== nodeId,
-        ),
-      );
-      setSelectedNodeId(undefined);
-      setSelectedEdgeId(undefined);
-      markDirty();
-    },
-    [markDirty, nodes, setEdges, setNodes],
-  );
-
   const removeEdge = useCallback(
     (edgeId: string) => {
       setEdges((current) => current.filter((edge) => edge.id !== edgeId));
@@ -348,15 +311,6 @@ const WorkflowV2DesignerContent = () => {
         void saveDraft();
         return;
       }
-      if (['Delete', 'Backspace'].includes(event.key)) {
-        if (selectedNodeId) {
-          event.preventDefault();
-          removeNode(selectedNodeId);
-        } else if (selectedEdgeId) {
-          event.preventDefault();
-          removeEdge(selectedEdgeId);
-        }
-      }
       if (event.key === 'Escape') {
         setSelectedNodeId(undefined);
         setSelectedEdgeId(undefined);
@@ -364,7 +318,7 @@ const WorkflowV2DesignerContent = () => {
     };
     window.addEventListener('keydown', keydown);
     return () => window.removeEventListener('keydown', keydown);
-  }, [removeEdge, removeNode, saveDraft, selectedEdgeId, selectedNodeId]);
+  }, [saveDraft]);
 
   const onMoveEnd = useCallback<OnMoveEnd>(() => markDirty(), [markDirty]);
 
@@ -397,7 +351,10 @@ const WorkflowV2DesignerContent = () => {
               <strong className="max-w-[360px] truncate text-[13px] font-semibold text-[#161823]">
                 {workflow?.name ?? 'Workflow V2'}
               </strong>
-              <Tag bordered={false} className="!m-0 !bg-[#f2f4f7] !text-[10px] !text-[#667085]">
+              <Tag
+                bordered={false}
+                className="!m-0 !bg-[#f2f4f7] !text-[10px] !text-[#667085]"
+              >
                 Schema V2
               </Tag>
               {dirty && (
@@ -454,6 +411,15 @@ const WorkflowV2DesignerContent = () => {
             onEdgesChange={onEdgesChange}
             onConnect={onConnect}
             onMoveEnd={onMoveEnd}
+            onNodesDelete={() => {
+              setSelectedNodeId(undefined);
+              setSelectedEdgeId(undefined);
+              markDirty();
+            }}
+            onEdgesDelete={() => {
+              setSelectedEdgeId(undefined);
+              markDirty();
+            }}
             onNodeClick={(_: unknown, node: WorkflowV2FlowNode) => {
               setSelectedNodeId(node.id);
               setSelectedEdgeId(undefined);
@@ -468,7 +434,7 @@ const WorkflowV2DesignerContent = () => {
             }}
             minZoom={0.25}
             maxZoom={2}
-            deleteKeyCode={null}
+            deleteKeyCode={['Backspace', 'Delete']}
             selectionOnDrag
             selectionMode={SelectionMode.Partial}
             multiSelectionKeyCode={['Meta', 'Control', 'Shift']}
@@ -500,7 +466,8 @@ const WorkflowV2DesignerContent = () => {
           </ReactFlow>
 
           <div className="pointer-events-none absolute left-4 top-4 rounded-lg border border-[#e4e7ec] bg-white/92 px-3 py-2 text-[10px] leading-4 text-[#667085] shadow-[0_4px_14px_rgba(16,24,40,0.06)] backdrop-blur">
-            从左侧拖入已发布任务。灰色出口表示成功，红色出口表示失败。
+            从左侧拖入已发布任务。点击节点仅选中，按 Delete 删除任务节点。
+            灰色出口表示成功，红色出口表示失败。
           </div>
 
           {selectedEdgeId && (
@@ -515,39 +482,6 @@ const WorkflowV2DesignerContent = () => {
               >
                 删除
               </Button>
-            </div>
-          )}
-
-          {selectedNode?.data.kind === 'TASK' && (
-            <div className="absolute right-4 top-4 flex min-w-[270px] items-center gap-3 rounded-lg border border-[#e4e7ec] bg-white px-3 py-2.5 shadow-[0_7px_20px_rgba(16,24,40,0.10)]">
-              <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-[var(--yak-brand-color-soft)] text-[var(--yak-brand-color)]">
-                <GitBranch size={15} />
-              </span>
-              <div className="min-w-0 flex-1">
-                <strong className="block truncate text-[12px] text-[#344054]">
-                  {selectedNode.data.title}
-                </strong>
-                <span className="block truncate text-[10px] text-[#98a2b3]">
-                  {selectedNode.data.taskRef?.taskType} · v
-                  {selectedNode.data.taskRef?.taskVersionNumber}
-                </span>
-              </div>
-              <Popconfirm
-                title="删除任务节点"
-                description="关联连线也会一起删除。"
-                okText="删除"
-                cancelText="取消"
-                onConfirm={() => removeNode(selectedNode.id)}
-              >
-                <Tooltip title="删除节点">
-                  <Button
-                    danger
-                    type="text"
-                    size="small"
-                    icon={<Trash2 size={14} />}
-                  />
-                </Tooltip>
-              </Popconfirm>
             </div>
           )}
         </main>

--- a/yak-ops-ui/src/pages/workflow-management/designer-v2/model.test.ts
+++ b/yak-ops-ui/src/pages/workflow-management/designer-v2/model.test.ts
@@ -4,6 +4,7 @@ import {
   createTaskFlowNode,
   decodeTaskDragPayload,
   encodeTaskDragPayload,
+  toFlowNodes,
   toWorkflowV2Dag,
 } from './model';
 
@@ -43,6 +44,7 @@ describe('Workflow V2 designer model', () => {
 
   it('copies only an immutable task reference into a dropped task node', () => {
     const node = createTaskFlowNode(task(), { x: 300, y: 200 });
+    expect(node.deletable).toBe(true);
     expect(node.data.taskRef).toEqual({
       taskId: '1001',
       taskVersionId: '2003',
@@ -52,6 +54,32 @@ describe('Workflow V2 designer model', () => {
     expect(node.data).not.toHaveProperty('config');
     expect(node.data).not.toHaveProperty('definition');
     expect(node.data).not.toHaveProperty('compiledSpec');
+  });
+
+  it('protects control nodes while keeping task nodes deletable', () => {
+    const dag = createInitialWorkflowV2Dag();
+    dag.nodes.splice(1, 0, {
+      key: 'task_1',
+      name: '任务',
+      kind: 'TASK',
+      positionX: 420,
+      positionY: 220,
+      enabled: true,
+      taskRef: {
+        taskId: '1001',
+        taskVersionId: '2003',
+        taskVersionNumber: 3,
+        taskType: 'HTTP',
+      },
+      inputBindings: [],
+      outputBindings: {},
+      executionPolicy: dag.nodes[0].executionPolicy,
+    });
+
+    const nodes = toFlowNodes(dag);
+    expect(nodes.find((node) => node.id === 'start')?.deletable).toBe(false);
+    expect(nodes.find((node) => node.id === 'end')?.deletable).toBe(false);
+    expect(nodes.find((node) => node.id === 'task_1')?.deletable).toBe(true);
   });
 
   it('preserves SUCCESS and FAILURE source ports when saving', () => {

--- a/yak-ops-ui/src/pages/workflow-management/designer-v2/model.ts
+++ b/yak-ops-ui/src/pages/workflow-management/designer-v2/model.ts
@@ -108,6 +108,7 @@ export const createTaskFlowNode = (
   id: uniqueTaskNodeKey(task.taskId),
   type: 'workflowV2Node',
   position,
+  deletable: true,
   data: {
     title: task.name,
     description: task.description,
@@ -141,6 +142,7 @@ export const toFlowNodes = (dag: WorkflowV2Dag): WorkflowV2FlowNode[] =>
       x: node.positionX ?? 120 + index * 300,
       y: node.positionY ?? 220,
     },
+    deletable: node.kind === 'TASK',
     data: {
       title: node.name,
       description: node.description,


### PR DESCRIPTION
## 背景

Workflow V2 已经改为引用数据开发中的不可变已发布任务版本，不再拥有 HTTP、Shell、SQL、Python、Notebook 等任务内部配置。

步骤四新增的 V2 设计器虽然没有真正的插件配置表单，但选中 TASK 节点后仍会在画布右上角显示一个任务节点浮层，包含任务类型、版本和删除按钮。这个交互仍然很像节点任务配置 Panel，容易让用户误认为任务配置属于 Workflow。

本 PR 完成第五步：删除 Workflow V2 节点任务配置 Panel，让节点点击只承担选中，不再打开侧栏、抽屉、Popover 或浮动任务配置卡片。

## 主要调整

### 删除 V2 任务节点浮层

移除选中 TASK 后显示的右上角浮层，以及相关依赖：

```text
Popconfirm
Tooltip
GitBranch
selectedNode 任务浮层渲染
```

点击 TASK 现在只会触发 React Flow 选中高亮，不会打开任何任务配置入口。

### 使用 React Flow 原生删除

任务节点和连线改为使用 React Flow 原生键盘删除：

```text
Delete
Backspace
```

删除 TASK 时，React Flow 会同步删除关联连线；页面通过 `onNodesDelete / onEdgesDelete` 标记草稿为未保存。

连线仍保留底部轻量删除工具条，因为它属于编排关系，不属于任务配置。

### START / END 删除保护

节点模型明确设置：

```text
START deletable=false
END   deletable=false
TASK  deletable=true
```

因此删除保护在模型层完成，不再依赖右上角任务 Panel 中的删除按钮。

### 画布提示更新

画布提示调整为：

```text
点击节点仅选中，按 Delete 删除任务节点。
```

强调工作流只负责编排，不负责编辑任务内部定义。

## 职责边界

Workflow V2 不提供以下配置入口：

```text
HTTP URL / Method / Header / Body
Shell Command / Args / Environment
SQL / Python / Notebook Source
Plugin-specific config
Definition / Compiled Spec
Runtime / Secret
```

任务名称、任务类型和固定发布版本号仍可在节点卡片中只读展示。

后续输入映射、输出映射、重试、超时和失败路由属于编排能力，应通过独立的编排属性区域实现，不能恢复旧任务配置 Panel。

## V1 兼容

本 PR 仅删除 Workflow V2 的任务节点 Panel。

Workflow V1 仍然保留旧 `NodePanel`，因为历史 V1 DAG 直接存储插件配置。在显式 V1 -> V2 迁移工具完成之前删除旧 Panel，会导致历史工作流无法维护。

```text
Workflow V1 -> 保留旧兼容编辑
Workflow V2 -> 禁止任务配置 Panel
```

## 测试与验证

已完成：

- TypeScript 5.8 对修改后的 V2 页面、模型和测试执行语法转译检查；
- 测试新拖入 TASK 默认 `deletable=true`；
- 测试从 V2 DAG 恢复后 TASK 仍可删除；
- 测试 START 和 END 均为 `deletable=false`；
- 原有不可变 `taskRef`、无 `config / definition / compiledSpec`、SUCCESS / FAILURE 序列化测试继续保留；
- 静态复核确认 V2 页面不再引用 `Popconfirm / Tooltip / GitBranch`，也不再渲染选中任务浮层；
- GitHub compare 确认分支基于最新 `main`，落后 0，只修改 4 个步骤五相关文件。

当前环境没有完整前端依赖和浏览器运行环境，因此没有执行完整 `npm run tsc`、Biome、Jest、Umi production build 和浏览器键盘删除联调；这些需由本地或 CI 完成最终验证。

## 合并说明

连接器按文件产生细粒度提交，建议使用 **Squash and merge**。