### PR TITLE
feat(workflow-ui): implement V2 input and output mappings

### DIFF
--- a/docs/workflow/workflow-v2-input-output-mapping.md
+++ b/docs/workflow/workflow-v2-input-output-mapping.md
@@ -1,0 +1,144 @@
+# Workflow V2 输入输出映射
+
+## 目标
+
+Workflow V2 只保存任务版本引用与编排关系。本阶段补齐编排层输入输出映射，不恢复 HTTP、Shell、SQL、Python、Notebook 等任务内部配置。
+
+```text
+Published Task Version
+  -> Input Schema / Output Schema
+  -> Workflow mapping panel
+  -> WorkflowV2 inputBindings / outputBindings
+```
+
+## Schema 回填
+
+拖入任务时，资源库响应已经包含任务版本 Input/Output Schema。
+
+工作流草稿重新打开后，DAG 中只保留不可变任务引用，因此设计器会按固定版本调用：
+
+```http
+GET /api/v1/data-development/tasks/library/{taskId}/versions/{versionId}
+```
+
+并回填项目、插件版本、发布时间以及 Input/Output Schema。
+
+Schema 请求以 `taskId + versionId` 缓存。回填结果只用于前端映射展示，不会写入 Workflow V2 DAG，也不会因为打开草稿而产生未保存状态。
+
+## TASK 输入映射
+
+点击 TASK 节点后，右侧显示“输入映射”编排面板。
+
+Input Schema 的根级 `properties` 作为任务输入目标，根级 `required` 用于标记必填字段。
+
+每个输入支持以下来源：
+
+```text
+START_INPUT       开始输入路径
+NODE_OUTPUT       拓扑上游任务输出
+WORKFLOW_VARIABLE 工作流变量
+LITERAL           固定值
+```
+
+持久化示例：
+
+```json
+{
+  "target": "orderId",
+  "source": {
+    "type": "START_INPUT",
+    "path": "orderId"
+  }
+}
+```
+
+对于没有声明 JSON Schema 的任务，可以添加自定义输入目标。
+
+## 上游输出约束
+
+`NODE_OUTPUT` 只能选择当前节点的拓扑祖先节点。
+
+```text
+START -> Task A -> Task B
+```
+
+Task B 可以引用 Task A，不能引用下游节点或没有依赖关系的旁路节点。
+
+任务 Output Schema 会被展开为可选路径，例如：
+
+```text
+data
+data.id
+data.status
+```
+
+也允许手工填写路径，以兼容动态输出结构。
+
+## END 工作流输出
+
+点击 END 节点后，右侧显示“工作流输出”面板。
+
+每个工作流输出由稳定名称和来源组成：
+
+```json
+{
+  "order": {
+    "type": "NODE_OUTPUT",
+    "nodeKey": "task_query_order",
+    "path": "data"
+  }
+}
+```
+
+输出来源同样支持开始输入、上游任务输出、工作流变量和固定值。
+
+## 保存与发布
+
+映射模型支持检查：
+
+- 输入目标不能为空或重复；
+- 开始输入路径不能为空；
+- 工作流变量名不能为空；
+- 上游输出必须包含节点和路径；
+- NODE_OUTPUT 必须仍然是拓扑上游；
+- 工作流输出名称不能为空；
+- 已启用任务的 required 输入是否全部映射。
+
+草稿允许逐步补充必填输入。发布仍由后端 `WorkflowV2DagValidator` 与 `WorkflowV2PublicationValidator` 承担最终可信校验。
+
+## 节点展示
+
+TASK 节点卡片展示：
+
+```text
+已映射输入数 / 声明输入数
+Schema 加载状态
+必填映射是否完整
+```
+
+END 节点卡片展示工作流输出数量。
+
+## 职责边界
+
+映射面板只编辑：
+
+```text
+inputBindings
+outputBindings
+```
+
+不会编辑或持久化：
+
+```text
+Task config
+Definition / Definition Snapshot
+Compiled Spec
+Runtime / Secret
+HTTP / Shell / SQL / Python / Notebook 专属参数
+```
+
+## 当前边界
+
+本阶段没有定义 START 节点输入 Schema 管理页面，`START_INPUT.path` 采用自由路径输入。
+
+工作流变量来源已经支持，但变量声明与密钥管理仍由后续独立的工作流变量能力完成。

--- a/yak-ops-ui/src/pages/workflow-management/designer-v2/components/HydratedMappingPanel.tsx
+++ b/yak-ops-ui/src/pages/workflow-management/designer-v2/components/HydratedMappingPanel.tsx
@@ -90,13 +90,15 @@ const HydratedMappingPanel = ({
     hydratedNodes.find((current) => current.id === node.id) ?? node;
 
   return (
-    <MappingPanel
-      node={hydratedNode}
-      nodes={hydratedNodes}
-      edges={edges}
-      onChange={onChange}
-      onClose={onClose}
-    />
+    <div className="flex h-full">
+      <MappingPanel
+        node={hydratedNode}
+        nodes={hydratedNodes}
+        edges={edges}
+        onChange={onChange}
+        onClose={onClose}
+      />
+    </div>
   );
 };
 

--- a/yak-ops-ui/src/pages/workflow-management/designer-v2/components/HydratedMappingPanel.tsx
+++ b/yak-ops-ui/src/pages/workflow-management/designer-v2/components/HydratedMappingPanel.tsx
@@ -1,0 +1,103 @@
+import { useEffect, useMemo, useState } from 'react';
+
+import { getUpstreamTaskNodes } from '../mapping';
+import type {
+  WorkflowV2CanvasNodeData,
+  WorkflowV2CanvasTaskMeta,
+  WorkflowV2FlowEdge,
+  WorkflowV2FlowNode,
+} from '../model';
+import {
+  loadPublishedTaskVersion,
+  publishedVersionToTaskMeta,
+  taskSchemaErrorMeta,
+} from '../task-schema';
+import MappingPanel from './MappingPanel';
+
+interface HydratedMappingPanelProps {
+  node: WorkflowV2FlowNode;
+  nodes: WorkflowV2FlowNode[];
+  edges: WorkflowV2FlowEdge[];
+  onChange: (data: WorkflowV2CanvasNodeData) => void;
+  onClose: () => void;
+}
+
+const HydratedMappingPanel = ({
+  node,
+  nodes,
+  edges,
+  onChange,
+  onClose,
+}: HydratedMappingPanelProps) => {
+  const relevantNodes = useMemo(() => {
+    const upstream = getUpstreamTaskNodes(node.id, nodes, edges);
+    return node.data.kind === 'TASK' ? [node, ...upstream] : upstream;
+  }, [edges, node, nodes]);
+  const [metaByNode, setMetaByNode] = useState<
+    Record<string, WorkflowV2CanvasTaskMeta>
+  >({});
+
+  useEffect(() => {
+    let active = true;
+    relevantNodes.forEach((current) => {
+      const ref = current.data.taskRef;
+      if (!ref || current.data.taskMeta?.schemaStatus === 'ready') return;
+      setMetaByNode((state) => ({
+        ...state,
+        [current.id]: {
+          ...current.data.taskMeta,
+          schemaStatus: 'loading',
+        },
+      }));
+      loadPublishedTaskVersion(ref)
+        .then((version) => {
+          if (!active) return;
+          setMetaByNode((state) => ({
+            ...state,
+            [current.id]: publishedVersionToTaskMeta(
+              version,
+              state[current.id] ?? current.data.taskMeta,
+            ),
+          }));
+        })
+        .catch((error: unknown) => {
+          if (!active) return;
+          setMetaByNode((state) => ({
+            ...state,
+            [current.id]: taskSchemaErrorMeta(
+              error,
+              state[current.id] ?? current.data.taskMeta,
+            ),
+          }));
+        });
+    });
+    return () => {
+      active = false;
+    };
+  }, [relevantNodes]);
+
+  const hydratedNodes = nodes.map((current) => {
+    const taskMeta =
+      metaByNode[current.id] ??
+      (current.data.taskMeta?.schemaStatus === 'ready'
+        ? current.data.taskMeta
+        : undefined);
+    return taskMeta
+      ? { ...current, data: { ...current.data, taskMeta } }
+      : current;
+  });
+  const hydratedNode =
+    hydratedNodes.find((current) => current.id === node.id) ?? node;
+
+  return (
+    <MappingPanel
+      node={hydratedNode}
+      nodes={hydratedNodes}
+      edges={edges}
+      onChange={onChange}
+      onClose={onClose}
+    />
+  );
+};
+
+export default HydratedMappingPanel;

--- a/yak-ops-ui/src/pages/workflow-management/designer-v2/components/MappingPanel.tsx
+++ b/yak-ops-ui/src/pages/workflow-management/designer-v2/components/MappingPanel.tsx
@@ -1,0 +1,596 @@
+import {
+  Alert,
+  AutoComplete,
+  Button,
+  Empty,
+  Input,
+  message,
+  Select,
+  Spin,
+  Tag,
+} from 'antd';
+import {
+  ArrowRightLeft,
+  Braces,
+  CircleDot,
+  Plus,
+  Variable,
+  X,
+} from 'lucide-react';
+import { useMemo, type ChangeEvent } from 'react';
+
+import type {
+  WorkflowV2BindingSource,
+  WorkflowV2BindingSourceType,
+} from '../../workflow-v2.types';
+import {
+  createDefaultBindingSource,
+  extractInputSchemaFields,
+  extractOutputSchemaFields,
+  findInputBinding,
+  formatLiteralValue,
+  getUpstreamTaskNodes,
+  parseLiteralValue,
+  renameInputBinding,
+  replaceInputBinding,
+  type WorkflowV2SchemaField,
+} from '../mapping';
+import type {
+  WorkflowV2CanvasNodeData,
+  WorkflowV2FlowEdge,
+  WorkflowV2FlowNode,
+} from '../model';
+
+interface MappingPanelProps {
+  node: WorkflowV2FlowNode;
+  nodes: WorkflowV2FlowNode[];
+  edges: WorkflowV2FlowEdge[];
+  onChange: (data: WorkflowV2CanvasNodeData) => void;
+  onClose: () => void;
+}
+
+const SOURCE_OPTIONS: Array<{
+  value: WorkflowV2BindingSourceType | 'UNMAPPED';
+  label: string;
+}> = [
+  { value: 'UNMAPPED', label: '未映射' },
+  { value: 'START_INPUT', label: '开始输入' },
+  { value: 'NODE_OUTPUT', label: '上游节点输出' },
+  { value: 'WORKFLOW_VARIABLE', label: '工作流变量' },
+  { value: 'LITERAL', label: '固定值' },
+];
+
+const SourceEditor = ({
+  source,
+  target,
+  upstreamNodes,
+  onChange,
+}: {
+  source: WorkflowV2BindingSource;
+  target: string;
+  upstreamNodes: WorkflowV2FlowNode[];
+  onChange: (source: WorkflowV2BindingSource) => void;
+}) => {
+  if (source.type === 'START_INPUT') {
+    return (
+      <Input
+        variant="filled"
+        size="small"
+        value={source.path}
+        placeholder={`开始输入路径，例如 ${target || 'orderId'}`}
+        onChange={(event: ChangeEvent<HTMLInputElement>) =>
+          onChange({ ...source, path: event.target.value })
+        }
+      />
+    );
+  }
+
+  if (source.type === 'WORKFLOW_VARIABLE') {
+    return (
+      <Input
+        variant="filled"
+        size="small"
+        value={source.variableName}
+        placeholder="工作流变量名"
+        prefix={<Variable size={13} />}
+        onChange={(event: ChangeEvent<HTMLInputElement>) =>
+          onChange({ ...source, variableName: event.target.value })
+        }
+      />
+    );
+  }
+
+  if (source.type === 'LITERAL') {
+    return (
+      <Input.TextArea
+        variant="filled"
+        size="small"
+        autoSize={{ minRows: 1, maxRows: 4 }}
+        value={formatLiteralValue(source.literalValue)}
+        placeholder="固定值；对象或数组可填写 JSON"
+        onChange={(event: ChangeEvent<HTMLTextAreaElement>) =>
+          onChange({
+            ...source,
+            literalValue: parseLiteralValue(event.target.value),
+          })
+        }
+      />
+    );
+  }
+
+  const selectedNode = upstreamNodes.find(
+    (node) => node.id === source.nodeKey,
+  );
+  const outputOptions = extractOutputSchemaFields(
+    selectedNode?.data.taskMeta?.outputSchema,
+  ).map((field) => ({
+    value: field.path,
+    label: `${field.path} · ${field.type}`,
+  }));
+
+  return (
+    <div className="grid grid-cols-[minmax(0,1fr)_minmax(0,1fr)] gap-2">
+      <Select
+        variant="filled"
+        size="small"
+        value={source.nodeKey}
+        placeholder="上游节点"
+        options={upstreamNodes.map((node) => ({
+          value: node.id,
+          label: node.data.title,
+        }))}
+        onChange={(nodeKey: string) => {
+          const node = upstreamNodes.find((item) => item.id === nodeKey);
+          const firstPath = extractOutputSchemaFields(
+            node?.data.taskMeta?.outputSchema,
+          )[0]?.path;
+          onChange({
+            type: 'NODE_OUTPUT',
+            nodeKey,
+            path: firstPath || source.path || '$',
+          });
+        }}
+      />
+      <AutoComplete
+        size="small"
+        value={source.path}
+        placeholder="输出路径"
+        options={outputOptions}
+        onChange={(path: string) => onChange({ ...source, path })}
+      />
+    </div>
+  );
+};
+
+const SchemaFieldLabel = ({ field }: { field: WorkflowV2SchemaField }) => (
+  <div className="min-w-0">
+    <div className="flex items-center gap-1.5">
+      <strong className="truncate text-[12px] font-semibold text-[#344054]">
+        {field.path}
+      </strong>
+      {field.required && (
+        <span className="shrink-0 text-[10px] font-semibold text-[#d92d20]">
+          必填
+        </span>
+      )}
+      <Tag
+        bordered={false}
+        className="!m-0 !bg-[#f2f4f7] !px-1.5 !text-[9px] !text-[#667085]"
+      >
+        {field.type}
+      </Tag>
+    </div>
+    {field.description && (
+      <p className="mb-0 mt-0.5 line-clamp-2 text-[10px] leading-4 text-[#98a2b3]">
+        {field.description}
+      </p>
+    )}
+  </div>
+);
+
+const InputMappingRow = ({
+  field,
+  custom,
+  node,
+  upstreamNodes,
+  onChange,
+}: {
+  field: WorkflowV2SchemaField;
+  custom?: boolean;
+  node: WorkflowV2FlowNode;
+  upstreamNodes: WorkflowV2FlowNode[];
+  onChange: (data: WorkflowV2CanvasNodeData) => void;
+}) => {
+  const binding = findInputBinding(node.data.inputBindings, field.path);
+
+  const changeSourceType = (
+    type: WorkflowV2BindingSourceType | 'UNMAPPED',
+  ) => {
+    const source =
+      type === 'UNMAPPED'
+        ? undefined
+        : createDefaultBindingSource(type, field.path, upstreamNodes);
+    if (type === 'NODE_OUTPUT' && !source) {
+      message.info('当前节点还没有可引用的上游任务输出');
+      return;
+    }
+    onChange({
+      ...node.data,
+      inputBindings: replaceInputBinding(
+        node.data.inputBindings,
+        field.path,
+        source,
+      ),
+    });
+  };
+
+  return (
+    <div className="rounded-lg border border-[#eaecf0] bg-white p-3">
+      <div className="mb-2 flex items-start justify-between gap-3">
+        {custom ? (
+          <Input
+            variant="filled"
+            size="small"
+            value={field.path}
+            placeholder="输入目标字段"
+            onChange={(event: ChangeEvent<HTMLInputElement>) => {
+              const nextTarget = event.target.value;
+              if (
+                nextTarget !== field.path &&
+                node.data.inputBindings.some(
+                  (item) => item.target === nextTarget,
+                )
+              ) {
+                message.warning('输入目标字段不能重复');
+                return;
+              }
+              onChange({
+                ...node.data,
+                inputBindings: renameInputBinding(
+                  node.data.inputBindings,
+                  field.path,
+                  nextTarget,
+                ),
+              });
+            }}
+          />
+        ) : (
+          <SchemaFieldLabel field={field} />
+        )}
+        <Select
+          variant="filled"
+          size="small"
+          className="w-[124px] shrink-0"
+          value={binding?.source.type ?? 'UNMAPPED'}
+          options={SOURCE_OPTIONS.map((option) => ({
+            ...option,
+            disabled:
+              option.value === 'NODE_OUTPUT' && !upstreamNodes.length,
+          }))}
+          onChange={changeSourceType}
+        />
+      </div>
+
+      {binding && (
+        <SourceEditor
+          source={binding.source}
+          target={field.path}
+          upstreamNodes={upstreamNodes}
+          onChange={(source) =>
+            onChange({
+              ...node.data,
+              inputBindings: replaceInputBinding(
+                node.data.inputBindings,
+                field.path,
+                source,
+              ),
+            })
+          }
+        />
+      )}
+    </div>
+  );
+};
+
+const TaskInputMappings = ({
+  node,
+  nodes,
+  edges,
+  onChange,
+}: Omit<MappingPanelProps, 'onClose'>) => {
+  const schemaFields = extractInputSchemaFields(node.data.taskMeta?.inputSchema);
+  const declared = new Set(schemaFields.map((field) => field.path));
+  const customFields: WorkflowV2SchemaField[] = node.data.inputBindings
+    .filter((binding) => !declared.has(binding.target))
+    .map((binding) => ({
+      path: binding.target,
+      label: binding.target,
+      type: 'custom',
+      required: false,
+    }));
+  const upstreamNodes = getUpstreamTaskNodes(node.id, nodes, edges);
+  const required = schemaFields.filter((field) => field.required);
+  const mapped = new Set(node.data.inputBindings.map((item) => item.target));
+  const missing = required.filter((field) => !mapped.has(field.path));
+
+  const addCustom = () => {
+    let index = 1;
+    let target = `param_${index}`;
+    while (node.data.inputBindings.some((item) => item.target === target)) {
+      index += 1;
+      target = `param_${index}`;
+    }
+    onChange({
+      ...node.data,
+      inputBindings: [
+        ...node.data.inputBindings,
+        {
+          target,
+          source: { type: 'START_INPUT', path: target },
+        },
+      ],
+    });
+  };
+
+  if (node.data.taskMeta?.schemaStatus === 'loading') {
+    return (
+      <div className="flex min-h-[220px] items-center justify-center">
+        <Spin size="small" tip="加载任务输入 Schema..." />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {node.data.taskMeta?.schemaStatus === 'error' && (
+        <Alert
+          type="warning"
+          showIcon
+          message="任务 Schema 加载失败"
+          description={
+            node.data.taskMeta.schemaError ||
+            '仍可添加自定义映射，但发布前建议刷新任务版本信息。'
+          }
+        />
+      )}
+
+      <div className="flex items-center justify-between rounded-lg bg-[#f7f7f8] px-3 py-2">
+        <span className="text-[11px] text-[#667085]">
+          声明 {schemaFields.length} 个输入，必填 {required.length} 个
+        </span>
+        <span
+          className={[
+            'text-[10px] font-semibold',
+            missing.length ? 'text-[#d92d20]' : 'text-[#027a48]',
+          ].join(' ')}
+        >
+          {missing.length ? `缺少 ${missing.length} 个必填映射` : '必填映射完整'}
+        </span>
+      </div>
+
+      {!schemaFields.length && !customFields.length ? (
+        <Empty
+          image={Empty.PRESENTED_IMAGE_SIMPLE}
+          description="任务版本没有声明输入字段"
+        />
+      ) : (
+        [...schemaFields, ...customFields].map((field) => (
+          <InputMappingRow
+            key={field.path}
+            field={field}
+            custom={field.type === 'custom'}
+            node={node}
+            upstreamNodes={upstreamNodes}
+            onChange={onChange}
+          />
+        ))
+      )}
+
+      <Button
+        block
+        type="dashed"
+        icon={<Plus size={14} />}
+        onClick={addCustom}
+      >
+        添加自定义输入映射
+      </Button>
+    </div>
+  );
+};
+
+const WorkflowOutputMappings = ({
+  node,
+  nodes,
+  edges,
+  onChange,
+}: Omit<MappingPanelProps, 'onClose'>) => {
+  const upstreamNodes = getUpstreamTaskNodes(node.id, nodes, edges);
+  const entries = Object.entries(node.data.outputBindings);
+
+  const changeOutputName = (previous: string, next: string) => {
+    if (next !== previous && node.data.outputBindings[next]) {
+      message.warning('工作流输出名称不能重复');
+      return;
+    }
+    const outputBindings = Object.fromEntries(
+      entries.map(([name, source]) => [name === previous ? next : name, source]),
+    );
+    onChange({ ...node.data, outputBindings });
+  };
+
+  const updateOutput = (name: string, source: WorkflowV2BindingSource) => {
+    onChange({
+      ...node.data,
+      outputBindings: { ...node.data.outputBindings, [name]: source },
+    });
+  };
+
+  const removeOutput = (name: string) => {
+    const { [name]: ignored, ...outputBindings } = node.data.outputBindings;
+    void ignored;
+    onChange({ ...node.data, outputBindings });
+  };
+
+  const addOutput = () => {
+    let index = 1;
+    let name = 'result';
+    while (node.data.outputBindings[name]) {
+      index += 1;
+      name = `result_${index}`;
+    }
+    const source =
+      createDefaultBindingSource('NODE_OUTPUT', name, upstreamNodes) ??
+      createDefaultBindingSource('START_INPUT', name, upstreamNodes)!;
+    onChange({
+      ...node.data,
+      outputBindings: { ...node.data.outputBindings, [name]: source },
+    });
+  };
+
+  return (
+    <div className="space-y-3">
+      <Alert
+        type="info"
+        showIcon
+        message="工作流输出"
+        description="为调用方暴露稳定输出名称，来源可以是上游任务输出、开始输入、变量或固定值。"
+      />
+
+      {!entries.length ? (
+        <Empty
+          image={Empty.PRESENTED_IMAGE_SIMPLE}
+          description="尚未定义工作流输出"
+        />
+      ) : (
+        entries.map(([name, source]) => (
+          <div
+            key={name}
+            className="rounded-lg border border-[#eaecf0] bg-white p-3"
+          >
+            <div className="mb-2 flex items-center gap-2">
+              <Input
+                variant="filled"
+                size="small"
+                value={name}
+                prefix={<CircleDot size={12} />}
+                placeholder="输出名称"
+                onChange={(event: ChangeEvent<HTMLInputElement>) =>
+                  changeOutputName(name, event.target.value)
+                }
+              />
+              <Button
+                danger
+                type="text"
+                size="small"
+                icon={<X size={13} />}
+                onClick={() => removeOutput(name)}
+              />
+            </div>
+            <div className="mb-2">
+              <Select
+                variant="filled"
+                size="small"
+                className="w-full"
+                value={source.type}
+                options={SOURCE_OPTIONS.filter(
+                  (option) => option.value !== 'UNMAPPED',
+                ).map((option) => ({
+                  ...option,
+                  disabled:
+                    option.value === 'NODE_OUTPUT' && !upstreamNodes.length,
+                }))}
+                onChange={(type: WorkflowV2BindingSourceType) => {
+                  const next = createDefaultBindingSource(
+                    type,
+                    name,
+                    upstreamNodes,
+                  );
+                  if (next) updateOutput(name, next);
+                }}
+              />
+            </div>
+            <SourceEditor
+              source={source}
+              target={name}
+              upstreamNodes={upstreamNodes}
+              onChange={(next) => updateOutput(name, next)}
+            />
+          </div>
+        ))
+      )}
+
+      <Button
+        block
+        type="dashed"
+        icon={<Plus size={14} />}
+        onClick={addOutput}
+      >
+        添加工作流输出
+      </Button>
+    </div>
+  );
+};
+
+const MappingPanel = ({
+  node,
+  nodes,
+  edges,
+  onChange,
+  onClose,
+}: MappingPanelProps) => {
+  const title = node.data.kind === 'TASK' ? '输入映射' : '工作流输出';
+  const subtitle =
+    node.data.kind === 'TASK'
+      ? `${node.data.taskRef?.taskType || 'TASK'} · v${node.data.taskRef?.taskVersionNumber || '-'}`
+      : 'END 节点输出契约';
+
+  return (
+    <aside className="flex w-[410px] shrink-0 flex-col border-l border-[#e4e7ec] bg-white">
+      <header className="flex h-[52px] shrink-0 items-center justify-between border-b border-[#eaecf0] px-4">
+        <div className="flex min-w-0 items-center gap-2.5">
+          <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-[var(--yak-brand-color-soft)] text-[var(--yak-brand-color)]">
+            {node.data.kind === 'TASK' ? (
+              <ArrowRightLeft size={15} />
+            ) : (
+              <Braces size={15} />
+            )}
+          </span>
+          <div className="min-w-0">
+            <strong className="block truncate text-[13px] font-semibold text-[#161823]">
+              {title}
+            </strong>
+            <span className="block truncate text-[10px] text-[#98a2b3]">
+              {node.data.title} · {subtitle}
+            </span>
+          </div>
+        </div>
+        <Button
+          type="text"
+          size="small"
+          icon={<X size={15} />}
+          onClick={onClose}
+        />
+      </header>
+
+      <div className="min-h-0 flex-1 overflow-y-auto bg-[#fcfcfd] p-4">
+        {node.data.kind === 'TASK' ? (
+          <TaskInputMappings
+            node={node}
+            nodes={nodes}
+            edges={edges}
+            onChange={onChange}
+          />
+        ) : (
+          <WorkflowOutputMappings
+            node={node}
+            nodes={nodes}
+            edges={edges}
+            onChange={onChange}
+          />
+        )}
+      </div>
+    </aside>
+  );
+};
+
+export default MappingPanel;

--- a/yak-ops-ui/src/pages/workflow-management/designer-v2/components/WorkflowV2NodeCard.tsx
+++ b/yak-ops-ui/src/pages/workflow-management/designer-v2/components/WorkflowV2NodeCard.tsx
@@ -95,6 +95,9 @@ const WorkflowV2NodeCard = ({
   const reactFlow = useReactFlow<WorkflowV2CanvasNodeData>();
   const nodes = useNodes<WorkflowV2CanvasNodeData>() as WorkflowV2FlowNode[];
   const edges = useEdges() as WorkflowV2FlowEdge[];
+  const mappingOwnerId = nodes.find(
+    (node) => node.selected && node.data.kind !== 'START',
+  )?.id;
   const subtitle =
     data.kind === 'TASK'
       ? [meta?.projectName, meta?.folderName].filter(Boolean).join(' / ') ||
@@ -126,7 +129,10 @@ const WorkflowV2NodeCard = ({
   }, [reactFlow]);
 
   const mappingPanel =
-    selected && data.kind !== 'START' && typeof document !== 'undefined'
+    selected &&
+    mappingOwnerId === id &&
+    data.kind !== 'START' &&
+    typeof document !== 'undefined'
       ? createPortal(
           <div
             className="nodrag nopan nowheel fixed bottom-0 right-0 top-[52px] z-[150]"

--- a/yak-ops-ui/src/pages/workflow-management/designer-v2/components/WorkflowV2NodeCard.tsx
+++ b/yak-ops-ui/src/pages/workflow-management/designer-v2/components/WorkflowV2NodeCard.tsx
@@ -5,13 +5,11 @@ import {
   DatabaseZap,
   GitBranch,
   Play,
+  Route,
 } from 'lucide-react';
-import {
-  Handle,
-  Position,
-  type NodeProps,
-} from 'reactflow';
+import { Handle, Position, type NodeProps } from 'reactflow';
 
+import { inputMappingProgress } from '../mapping';
 import type { WorkflowV2CanvasNodeData } from '../model';
 
 const iconFor = (kind: WorkflowV2CanvasNodeData['kind']) => {
@@ -35,6 +33,41 @@ const iconClass = (kind: WorkflowV2CanvasNodeData['kind']) => {
 
 const handleClass =
   '!h-3 !w-3 !border-[2px] !border-white !shadow-[0_0_0_1px_rgba(16,24,40,0.18)]';
+
+const MappingStatus = ({ data }: { data: WorkflowV2CanvasNodeData }) => {
+  if (data.kind === 'END') {
+    const count = Object.keys(data.outputBindings).length;
+    return (
+      <span className="inline-flex items-center gap-1 text-[9px] text-[#667085]">
+        <Route size={11} />
+        {count ? `${count} 个工作流输出` : '未定义工作流输出'}
+      </span>
+    );
+  }
+  if (data.kind !== 'TASK') return null;
+  if (data.taskMeta?.schemaStatus === 'loading') {
+    return <span className="text-[9px] text-[#98a2b3]">正在加载 Schema</span>;
+  }
+  if (data.taskMeta?.schemaStatus === 'error') {
+    return <span className="text-[9px] text-[#d92d20]">Schema 加载失败</span>;
+  }
+  const progress = inputMappingProgress({ data });
+  if (!progress.declared) {
+    return <span className="text-[9px] text-[#98a2b3]">无声明输入</span>;
+  }
+  const complete = progress.requiredMapped === progress.required;
+  return (
+    <span
+      className={[
+        'inline-flex items-center gap-1 text-[9px]',
+        complete ? 'text-[#027a48]' : 'text-[#d92d20]',
+      ].join(' ')}
+    >
+      <Route size={11} />
+      {progress.mapped}/{progress.declared} 输入已映射
+    </span>
+  );
+};
 
 const WorkflowV2NodeCard = ({
   data,
@@ -100,12 +133,25 @@ const WorkflowV2NodeCard = ({
           {subtitle || '暂无描述'}
         </p>
 
-        {data.kind === 'TASK' && task && (
+        {(data.kind === 'TASK' || data.kind === 'END') && (
           <div className="mt-2 flex items-center justify-between gap-2 border-t border-[#f2f4f7] pt-2">
-            <span className="inline-flex min-w-0 items-center gap-1.5 text-[10px] font-medium text-[#475467]">
-              <Braces size={12} className="shrink-0" />
-              <span className="truncate">{task.taskType}</span>
-            </span>
+            {data.kind === 'TASK' && task ? (
+              <span className="inline-flex min-w-0 items-center gap-1.5 text-[10px] font-medium text-[#475467]">
+                <Braces size={12} className="shrink-0" />
+                <span className="truncate">{task.taskType}</span>
+              </span>
+            ) : (
+              <span className="inline-flex items-center gap-1 text-[10px] text-[#475467]">
+                <Braces size={12} />
+                输出契约
+              </span>
+            )}
+            <MappingStatus data={data} />
+          </div>
+        )}
+
+        {data.kind === 'TASK' && task && (
+          <div className="mt-1.5 flex justify-end">
             <span className="inline-flex items-center gap-1 text-[9px] text-[#98a2b3]">
               <Check size={11} />
               固定发布版本

--- a/yak-ops-ui/src/pages/workflow-management/designer-v2/components/WorkflowV2NodeCard.tsx
+++ b/yak-ops-ui/src/pages/workflow-management/designer-v2/components/WorkflowV2NodeCard.tsx
@@ -7,7 +7,7 @@ import {
   Play,
   Route,
 } from 'lucide-react';
-import { useCallback, useEffect } from 'react';
+import { useCallback } from 'react';
 import { createPortal } from 'react-dom';
 import {
   Handle,
@@ -18,16 +18,14 @@ import {
   type NodeProps,
 } from 'reactflow';
 
-import { workflowTaskLibraryRepository } from '../../repository/workflow-task-library.repository';
 import { inputMappingProgress } from '../mapping';
-import {
-  applyPublishedTaskVersion,
-  markTaskSchemaError,
-  type WorkflowV2CanvasNodeData,
-  type WorkflowV2FlowEdge,
-  type WorkflowV2FlowNode,
+import type {
+  WorkflowV2CanvasNodeData,
+  WorkflowV2FlowEdge,
+  WorkflowV2FlowNode,
 } from '../model';
-import MappingPanel from './MappingPanel';
+import { usePublishedTaskSchema } from '../task-schema';
+import HydratedMappingPanel from './HydratedMappingPanel';
 
 const iconFor = (kind: WorkflowV2CanvasNodeData['kind']) => {
   if (kind === 'START') return <Play size={16} />;
@@ -92,7 +90,8 @@ const WorkflowV2NodeCard = ({
   selected,
 }: NodeProps<WorkflowV2CanvasNodeData>) => {
   const task = data.taskRef;
-  const meta = data.taskMeta;
+  const hydratedMeta = usePublishedTaskSchema(task, data.taskMeta);
+  const meta = hydratedMeta;
   const reactFlow = useReactFlow<WorkflowV2CanvasNodeData>();
   const nodes = useNodes<WorkflowV2CanvasNodeData>() as WorkflowV2FlowNode[];
   const edges = useEdges() as WorkflowV2FlowEdge[];
@@ -102,50 +101,10 @@ const WorkflowV2NodeCard = ({
         '已发布任务'
       : data.description;
 
-  useEffect(() => {
-    if (
-      data.kind !== 'TASK' ||
-      !task ||
-      data.taskMeta?.schemaStatus !== 'loading'
-    ) {
-      return;
-    }
-
-    let active = true;
-    workflowTaskLibraryRepository
-      .getPublishedVersion(task.taskId, task.taskVersionId)
-      .then((version) => {
-        if (!active) return;
-        reactFlow.setNodes((current) =>
-          current.map((node) =>
-            node.id === id
-              ? applyPublishedTaskVersion(node as WorkflowV2FlowNode, version)
-              : node,
-          ),
-        );
-      })
-      .catch((error: unknown) => {
-        if (!active) return;
-        reactFlow.setNodes((current) =>
-          current.map((node) =>
-            node.id === id
-              ? markTaskSchemaError(node as WorkflowV2FlowNode, error)
-              : node,
-          ),
-        );
-      });
-
-    return () => {
-      active = false;
-    };
-  }, [
-    data.kind,
-    data.taskMeta?.schemaStatus,
-    id,
-    reactFlow,
-    task?.taskId,
-    task?.taskVersionId,
-  ]);
+  const effectiveData: WorkflowV2CanvasNodeData = {
+    ...data,
+    taskMeta: hydratedMeta,
+  };
 
   const updateData = useCallback(
     (nextData: WorkflowV2CanvasNodeData) => {
@@ -178,12 +137,12 @@ const WorkflowV2NodeCard = ({
               event.stopPropagation()
             }
           >
-            <MappingPanel
+            <HydratedMappingPanel
               node={{
                 id,
                 type: 'workflowV2Node',
                 position: { x: 0, y: 0 },
-                data,
+                data: effectiveData,
               }}
               nodes={nodes}
               edges={edges}
@@ -261,7 +220,7 @@ const WorkflowV2NodeCard = ({
                   输出契约
                 </span>
               )}
-              <MappingStatus data={data} />
+              <MappingStatus data={effectiveData} />
             </div>
           )}
 

--- a/yak-ops-ui/src/pages/workflow-management/designer-v2/components/WorkflowV2NodeCard.tsx
+++ b/yak-ops-ui/src/pages/workflow-management/designer-v2/components/WorkflowV2NodeCard.tsx
@@ -7,10 +7,27 @@ import {
   Play,
   Route,
 } from 'lucide-react';
-import { Handle, Position, type NodeProps } from 'reactflow';
+import { useCallback, useEffect } from 'react';
+import { createPortal } from 'react-dom';
+import {
+  Handle,
+  Position,
+  useEdges,
+  useNodes,
+  useReactFlow,
+  type NodeProps,
+} from 'reactflow';
 
+import { workflowTaskLibraryRepository } from '../../repository/workflow-task-library.repository';
 import { inputMappingProgress } from '../mapping';
-import type { WorkflowV2CanvasNodeData } from '../model';
+import {
+  applyPublishedTaskVersion,
+  markTaskSchemaError,
+  type WorkflowV2CanvasNodeData,
+  type WorkflowV2FlowEdge,
+  type WorkflowV2FlowNode,
+} from '../model';
+import MappingPanel from './MappingPanel';
 
 const iconFor = (kind: WorkflowV2CanvasNodeData['kind']) => {
   if (kind === 'START') return <Play size={16} />;
@@ -70,122 +87,222 @@ const MappingStatus = ({ data }: { data: WorkflowV2CanvasNodeData }) => {
 };
 
 const WorkflowV2NodeCard = ({
+  id,
   data,
   selected,
 }: NodeProps<WorkflowV2CanvasNodeData>) => {
   const task = data.taskRef;
   const meta = data.taskMeta;
+  const reactFlow = useReactFlow<WorkflowV2CanvasNodeData>();
+  const nodes = useNodes<WorkflowV2CanvasNodeData>() as WorkflowV2FlowNode[];
+  const edges = useEdges() as WorkflowV2FlowEdge[];
   const subtitle =
     data.kind === 'TASK'
       ? [meta?.projectName, meta?.folderName].filter(Boolean).join(' / ') ||
         '已发布任务'
       : data.description;
 
+  useEffect(() => {
+    if (
+      data.kind !== 'TASK' ||
+      !task ||
+      data.taskMeta?.schemaStatus !== 'loading'
+    ) {
+      return;
+    }
+
+    let active = true;
+    workflowTaskLibraryRepository
+      .getPublishedVersion(task.taskId, task.taskVersionId)
+      .then((version) => {
+        if (!active) return;
+        reactFlow.setNodes((current) =>
+          current.map((node) =>
+            node.id === id
+              ? applyPublishedTaskVersion(node as WorkflowV2FlowNode, version)
+              : node,
+          ),
+        );
+      })
+      .catch((error: unknown) => {
+        if (!active) return;
+        reactFlow.setNodes((current) =>
+          current.map((node) =>
+            node.id === id
+              ? markTaskSchemaError(node as WorkflowV2FlowNode, error)
+              : node,
+          ),
+        );
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [
+    data.kind,
+    data.taskMeta?.schemaStatus,
+    id,
+    reactFlow,
+    task?.taskId,
+    task?.taskVersionId,
+  ]);
+
+  const updateData = useCallback(
+    (nextData: WorkflowV2CanvasNodeData) => {
+      reactFlow.setNodes((current) =>
+        current.map((node) =>
+          node.id === id ? { ...node, data: nextData } : node,
+        ),
+      );
+    },
+    [id, reactFlow],
+  );
+
+  const closeMapping = useCallback(() => {
+    reactFlow.setNodes((current) =>
+      current.map((node) =>
+        node.selected ? { ...node, selected: false } : node,
+      ),
+    );
+  }, [reactFlow]);
+
+  const mappingPanel =
+    selected && data.kind !== 'START' && typeof document !== 'undefined'
+      ? createPortal(
+          <div
+            className="nodrag nopan nowheel fixed bottom-0 right-0 top-[52px] z-[150]"
+            onMouseDown={(event: { stopPropagation: () => void }) =>
+              event.stopPropagation()
+            }
+            onClick={(event: { stopPropagation: () => void }) =>
+              event.stopPropagation()
+            }
+          >
+            <MappingPanel
+              node={{
+                id,
+                type: 'workflowV2Node',
+                position: { x: 0, y: 0 },
+                data,
+              }}
+              nodes={nodes}
+              edges={edges}
+              onChange={updateData}
+              onClose={closeMapping}
+            />
+          </div>,
+          document.body,
+        )
+      : null;
+
   return (
-    <div
-      className={[
-        'group relative w-[252px] overflow-hidden rounded-xl border bg-white',
-        'shadow-[0_5px_16px_rgba(16,24,40,0.07)] transition-[border-color,box-shadow,transform]',
-        selected
-          ? 'border-[var(--yak-brand-color)] shadow-[0_0_0_3px_var(--yak-brand-color-outline),0_10px_24px_rgba(16,24,40,0.12)]'
-          : 'border-[#dfe3e8] hover:-translate-y-px hover:border-[#c7ccd4] hover:shadow-[0_9px_22px_rgba(16,24,40,0.10)]',
-        data.enabled ? '' : 'opacity-55',
-      ].join(' ')}
-    >
-      {data.kind !== 'START' && (
-        <Handle
-          id="INPUT"
-          type="target"
-          position={Position.Left}
-          className={`${handleClass} !bg-[#667085]`}
-        />
-      )}
-
-      <div className="flex min-h-[54px] items-center gap-2.5 px-3.5 py-2.5">
-        <span
-          className={[
-            'flex h-8 w-8 shrink-0 items-center justify-center rounded-lg',
-            iconClass(data.kind),
-          ].join(' ')}
-        >
-          {iconFor(data.kind)}
-        </span>
-
-        <div className="min-w-0 flex-1">
-          <div className="flex items-center gap-2">
-            <strong className="block min-w-0 flex-1 truncate text-[13px] font-semibold text-[#161823]">
-              {data.title}
-            </strong>
-            {data.kind === 'TASK' && task && (
-              <span className="shrink-0 rounded bg-[#f2f4f7] px-1.5 py-0.5 text-[9px] font-semibold text-[#667085]">
-                v{task.taskVersionNumber}
-              </span>
-            )}
-          </div>
-          <span className="mt-0.5 block truncate text-[10px] font-medium uppercase tracking-[0.055em] text-[#98a2b3]">
-            {kindLabel(data.kind)}
-          </span>
-        </div>
-      </div>
-
-      <div className="border-t border-[#f0f1f3] px-3.5 py-2.5">
-        <p className="m-0 line-clamp-2 min-h-[34px] text-[11px] leading-[17px] text-[#667085]">
-          {subtitle || '暂无描述'}
-        </p>
-
-        {(data.kind === 'TASK' || data.kind === 'END') && (
-          <div className="mt-2 flex items-center justify-between gap-2 border-t border-[#f2f4f7] pt-2">
-            {data.kind === 'TASK' && task ? (
-              <span className="inline-flex min-w-0 items-center gap-1.5 text-[10px] font-medium text-[#475467]">
-                <Braces size={12} className="shrink-0" />
-                <span className="truncate">{task.taskType}</span>
-              </span>
-            ) : (
-              <span className="inline-flex items-center gap-1 text-[10px] text-[#475467]">
-                <Braces size={12} />
-                输出契约
-              </span>
-            )}
-            <MappingStatus data={data} />
-          </div>
+    <>
+      <div
+        className={[
+          'group relative w-[252px] overflow-hidden rounded-xl border bg-white',
+          'shadow-[0_5px_16px_rgba(16,24,40,0.07)] transition-[border-color,box-shadow,transform]',
+          selected
+            ? 'border-[var(--yak-brand-color)] shadow-[0_0_0_3px_var(--yak-brand-color-outline),0_10px_24px_rgba(16,24,40,0.12)]'
+            : 'border-[#dfe3e8] hover:-translate-y-px hover:border-[#c7ccd4] hover:shadow-[0_9px_22px_rgba(16,24,40,0.10)]',
+          data.enabled ? '' : 'opacity-55',
+        ].join(' ')}
+      >
+        {data.kind !== 'START' && (
+          <Handle
+            id="INPUT"
+            type="target"
+            position={Position.Left}
+            className={`${handleClass} !bg-[#667085]`}
+          />
         )}
 
-        {data.kind === 'TASK' && task && (
-          <div className="mt-1.5 flex justify-end">
-            <span className="inline-flex items-center gap-1 text-[9px] text-[#98a2b3]">
-              <Check size={11} />
-              固定发布版本
+        <div className="flex min-h-[54px] items-center gap-2.5 px-3.5 py-2.5">
+          <span
+            className={[
+              'flex h-8 w-8 shrink-0 items-center justify-center rounded-lg',
+              iconClass(data.kind),
+            ].join(' ')}
+          >
+            {iconFor(data.kind)}
+          </span>
+
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-2">
+              <strong className="block min-w-0 flex-1 truncate text-[13px] font-semibold text-[#161823]">
+                {data.title}
+              </strong>
+              {data.kind === 'TASK' && task && (
+                <span className="shrink-0 rounded bg-[#f2f4f7] px-1.5 py-0.5 text-[9px] font-semibold text-[#667085]">
+                  v{task.taskVersionNumber}
+                </span>
+              )}
+            </div>
+            <span className="mt-0.5 block truncate text-[10px] font-medium uppercase tracking-[0.055em] text-[#98a2b3]">
+              {kindLabel(data.kind)}
             </span>
           </div>
-        )}
-      </div>
+        </div>
 
-      {data.kind !== 'END' && (
-        <Handle
-          id="SUCCESS"
-          type="source"
-          position={Position.Right}
-          className={`${handleClass} !bg-[#667085]`}
-          style={{ top: data.kind === 'TASK' ? '42%' : '50%' }}
-        />
-      )}
+        <div className="border-t border-[#f0f1f3] px-3.5 py-2.5">
+          <p className="m-0 line-clamp-2 min-h-[34px] text-[11px] leading-[17px] text-[#667085]">
+            {subtitle || '暂无描述'}
+          </p>
 
-      {data.kind === 'TASK' && (
-        <>
+          {(data.kind === 'TASK' || data.kind === 'END') && (
+            <div className="mt-2 flex items-center justify-between gap-2 border-t border-[#f2f4f7] pt-2">
+              {data.kind === 'TASK' && task ? (
+                <span className="inline-flex min-w-0 items-center gap-1.5 text-[10px] font-medium text-[#475467]">
+                  <Braces size={12} className="shrink-0" />
+                  <span className="truncate">{task.taskType}</span>
+                </span>
+              ) : (
+                <span className="inline-flex items-center gap-1 text-[10px] text-[#475467]">
+                  <Braces size={12} />
+                  输出契约
+                </span>
+              )}
+              <MappingStatus data={data} />
+            </div>
+          )}
+
+          {data.kind === 'TASK' && task && (
+            <div className="mt-1.5 flex justify-end">
+              <span className="inline-flex items-center gap-1 text-[9px] text-[#98a2b3]">
+                <Check size={11} />
+                固定发布版本
+              </span>
+            </div>
+          )}
+        </div>
+
+        {data.kind !== 'END' && (
           <Handle
-            id="FAILURE"
+            id="SUCCESS"
             type="source"
             position={Position.Right}
-            className={`${handleClass} !bg-[#f04438]`}
-            style={{ top: '76%' }}
+            className={`${handleClass} !bg-[#667085]`}
+            style={{ top: data.kind === 'TASK' ? '42%' : '50%' }}
           />
-          <span className="pointer-events-none absolute -right-[72px] top-[calc(76%-8px)] inline-flex items-center gap-1 rounded bg-white/90 px-1.5 py-0.5 text-[9px] text-[#d92d20] opacity-0 shadow-sm transition-opacity group-hover:opacity-100">
-            <GitBranch size={10} />
-            失败
-          </span>
-        </>
-      )}
-    </div>
+        )}
+
+        {data.kind === 'TASK' && (
+          <>
+            <Handle
+              id="FAILURE"
+              type="source"
+              position={Position.Right}
+              className={`${handleClass} !bg-[#f04438]`}
+              style={{ top: '76%' }}
+            />
+            <span className="pointer-events-none absolute -right-[72px] top-[calc(76%-8px)] inline-flex items-center gap-1 rounded bg-white/90 px-1.5 py-0.5 text-[9px] text-[#d92d20] opacity-0 shadow-sm transition-opacity group-hover:opacity-100">
+              <GitBranch size={10} />
+              失败
+            </span>
+          </>
+        )}
+      </div>
+      {mappingPanel}
+    </>
   );
 };
 

--- a/yak-ops-ui/src/pages/workflow-management/designer-v2/mapping.test.ts
+++ b/yak-ops-ui/src/pages/workflow-management/designer-v2/mapping.test.ts
@@ -1,0 +1,147 @@
+import type { WorkflowV2FlowEdge, WorkflowV2FlowNode } from './model';
+import {
+  collectMappingIssues,
+  collectMissingRequiredInputs,
+  extractInputSchemaFields,
+  extractOutputSchemaFields,
+  getUpstreamNodeIds,
+  replaceInputBinding,
+} from './mapping';
+
+const node = (
+  id: string,
+  kind: 'START' | 'TASK' | 'END',
+): WorkflowV2FlowNode => ({
+  id,
+  type: 'workflowV2Node',
+  position: { x: 0, y: 0 },
+  data: {
+    title: id,
+    kind,
+    enabled: true,
+    inputBindings: [],
+    outputBindings: {},
+    executionPolicy: {
+      timeoutSeconds: 0,
+      retryTimes: 0,
+      retryIntervalSeconds: 0,
+      failureAction: 'FAIL_WORKFLOW',
+    },
+  },
+});
+
+const edges: WorkflowV2FlowEdge[] = [
+  { id: '1', source: 'start', target: 'a' },
+  { id: '2', source: 'a', target: 'b' },
+  { id: '3', source: 'b', target: 'end' },
+];
+
+describe('Workflow V2 mapping model', () => {
+  it('reads JSON Schema input fields and required markers', () => {
+    expect(
+      extractInputSchemaFields({
+        type: 'object',
+        required: ['orderId'],
+        properties: {
+          orderId: { type: 'string', description: '订单号' },
+          limit: { type: 'integer' },
+        },
+      }),
+    ).toEqual([
+      {
+        path: 'orderId',
+        label: 'orderId',
+        type: 'string',
+        description: '订单号',
+        required: true,
+        enumValues: undefined,
+      },
+      {
+        path: 'limit',
+        label: 'limit',
+        type: 'integer',
+        description: undefined,
+        required: false,
+        enumValues: undefined,
+      },
+    ]);
+  });
+
+  it('flattens nested output schema paths', () => {
+    expect(
+      extractOutputSchemaFields({
+        properties: {
+          data: {
+            type: 'object',
+            properties: { id: { type: 'string' } },
+          },
+        },
+      }).map((field) => field.path),
+    ).toEqual(['data', 'data.id']);
+  });
+
+  it('returns transitive upstream nodes only', () => {
+    expect([...getUpstreamNodeIds('end', edges)]).toEqual(['b', 'a', 'start']);
+    expect([...getUpstreamNodeIds('a', edges)]).toEqual(['start']);
+  });
+
+  it('replaces a binding by target without duplicates', () => {
+    const bindings = replaceInputBinding([], 'orderId', {
+      type: 'START_INPUT',
+      path: 'orderId',
+    });
+    expect(
+      replaceInputBinding(bindings, 'orderId', {
+        type: 'WORKFLOW_VARIABLE',
+        variableName: 'orderId',
+      }),
+    ).toEqual([
+      {
+        target: 'orderId',
+        source: {
+          type: 'WORKFLOW_VARIABLE',
+          variableName: 'orderId',
+        },
+      },
+    ]);
+  });
+
+  it('reports missing required task inputs before publication', () => {
+    const task = node('a', 'TASK');
+    task.data.taskMeta = {
+      schemaStatus: 'ready',
+      inputSchema: {
+        required: ['orderId'],
+        properties: { orderId: { type: 'string' } },
+      },
+    };
+    expect(collectMissingRequiredInputs([task])).toEqual([
+      {
+        nodeId: 'a',
+        nodeName: 'a',
+        field: 'orderId',
+        message: '必填输入尚未映射',
+      },
+    ]);
+  });
+
+  it('rejects node output mappings that are no longer upstream', () => {
+    const start = node('start', 'START');
+    const a = node('a', 'TASK');
+    const b = node('b', 'TASK');
+    a.data.inputBindings = [
+      {
+        target: 'value',
+        source: { type: 'NODE_OUTPUT', nodeKey: 'b', path: 'result' },
+      },
+    ];
+    expect(collectMappingIssues([start, a, b], edges)).toEqual([
+      {
+        nodeId: 'a',
+        nodeName: 'a',
+        field: 'value',
+        message: '只能引用拓扑上游节点',
+      },
+    ]);
+  });
+});

--- a/yak-ops-ui/src/pages/workflow-management/designer-v2/mapping.ts
+++ b/yak-ops-ui/src/pages/workflow-management/designer-v2/mapping.ts
@@ -1,0 +1,321 @@
+import type {
+  WorkflowV2BindingSource,
+  WorkflowV2BindingSourceType,
+  WorkflowV2InputBinding,
+} from '../workflow-v2.types';
+import type {
+  WorkflowV2FlowEdge,
+  WorkflowV2FlowNode,
+} from './model';
+
+export interface WorkflowV2SchemaField {
+  path: string;
+  label: string;
+  type: string;
+  description?: string;
+  required: boolean;
+  enumValues?: unknown[];
+}
+
+export interface WorkflowV2MappingIssue {
+  nodeId: string;
+  nodeName: string;
+  field?: string;
+  message: string;
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+
+const schemaType = (schema: Record<string, unknown>): string => {
+  const value = schema.type;
+  if (Array.isArray(value)) return value.map(String).join(' | ');
+  if (typeof value === 'string') return value;
+  if (isRecord(schema.properties)) return 'object';
+  return 'unknown';
+};
+
+const schemaDescription = (schema: Record<string, unknown>) =>
+  typeof schema.description === 'string' ? schema.description : undefined;
+
+const schemaLabel = (name: string, schema: Record<string, unknown>) =>
+  typeof schema.title === 'string' && schema.title.trim()
+    ? schema.title.trim()
+    : name;
+
+const schemaEnum = (schema: Record<string, unknown>) =>
+  Array.isArray(schema.enum) ? schema.enum : undefined;
+
+export const extractInputSchemaFields = (
+  schema?: Record<string, unknown>,
+): WorkflowV2SchemaField[] => {
+  if (!schema || !isRecord(schema.properties)) return [];
+  const required = new Set(
+    Array.isArray(schema.required)
+      ? schema.required.filter((item): item is string => typeof item === 'string')
+      : [],
+  );
+  return Object.entries(schema.properties).map(([name, raw]) => {
+    const property = isRecord(raw) ? raw : {};
+    return {
+      path: name,
+      label: schemaLabel(name, property),
+      type: schemaType(property),
+      description: schemaDescription(property),
+      required: required.has(name),
+      enumValues: schemaEnum(property),
+    };
+  });
+};
+
+const collectOutputFields = (
+  properties: Record<string, unknown>,
+  prefix: string,
+  result: WorkflowV2SchemaField[],
+) => {
+  Object.entries(properties).forEach(([name, raw]) => {
+    const property = isRecord(raw) ? raw : {};
+    const path = prefix ? `${prefix}.${name}` : name;
+    const nested = isRecord(property.properties) ? property.properties : undefined;
+    result.push({
+      path,
+      label: schemaLabel(name, property),
+      type: schemaType(property),
+      description: schemaDescription(property),
+      required: false,
+      enumValues: schemaEnum(property),
+    });
+    if (nested) collectOutputFields(nested, path, result);
+  });
+};
+
+export const extractOutputSchemaFields = (
+  schema?: Record<string, unknown>,
+): WorkflowV2SchemaField[] => {
+  if (!schema || !isRecord(schema.properties)) return [];
+  const result: WorkflowV2SchemaField[] = [];
+  collectOutputFields(schema.properties, '', result);
+  return result;
+};
+
+export const getUpstreamNodeIds = (
+  ownerId: string,
+  edges: WorkflowV2FlowEdge[],
+): Set<string> => {
+  const predecessors = new Map<string, Set<string>>();
+  edges.forEach((edge) => {
+    const values = predecessors.get(edge.target) ?? new Set<string>();
+    values.add(edge.source);
+    predecessors.set(edge.target, values);
+  });
+
+  const result = new Set<string>();
+  const queue = [...(predecessors.get(ownerId) ?? [])];
+  while (queue.length) {
+    const current = queue.shift()!;
+    if (result.has(current)) continue;
+    result.add(current);
+    queue.push(...(predecessors.get(current) ?? []));
+  }
+  return result;
+};
+
+export const getUpstreamTaskNodes = (
+  ownerId: string,
+  nodes: WorkflowV2FlowNode[],
+  edges: WorkflowV2FlowEdge[],
+) => {
+  const upstream = getUpstreamNodeIds(ownerId, edges);
+  return nodes.filter(
+    (node) => upstream.has(node.id) && node.data.kind === 'TASK',
+  );
+};
+
+export const findInputBinding = (
+  bindings: WorkflowV2InputBinding[],
+  target: string,
+) => bindings.find((binding) => binding.target === target);
+
+export const replaceInputBinding = (
+  bindings: WorkflowV2InputBinding[],
+  target: string,
+  source?: WorkflowV2BindingSource,
+): WorkflowV2InputBinding[] => {
+  const next = bindings.filter((binding) => binding.target !== target);
+  return source ? [...next, { target, source }] : next;
+};
+
+export const renameInputBinding = (
+  bindings: WorkflowV2InputBinding[],
+  previousTarget: string,
+  nextTarget: string,
+): WorkflowV2InputBinding[] =>
+  bindings.map((binding) =>
+    binding.target === previousTarget
+      ? { ...binding, target: nextTarget }
+      : binding,
+  );
+
+export const createDefaultBindingSource = (
+  type: WorkflowV2BindingSourceType,
+  target: string,
+  upstreamNodes: WorkflowV2FlowNode[],
+): WorkflowV2BindingSource | undefined => {
+  if (type === 'START_INPUT') return { type, path: target || 'input' };
+  if (type === 'WORKFLOW_VARIABLE') {
+    return { type, variableName: target || 'variable' };
+  }
+  if (type === 'LITERAL') return { type, literalValue: '' };
+
+  const firstNode = upstreamNodes[0];
+  if (!firstNode) return undefined;
+  const firstPath = extractOutputSchemaFields(
+    firstNode.data.taskMeta?.outputSchema,
+  )[0]?.path;
+  return {
+    type: 'NODE_OUTPUT',
+    nodeKey: firstNode.id,
+    path: firstPath || '$',
+  };
+};
+
+const hasText = (value: unknown): value is string =>
+  typeof value === 'string' && Boolean(value.trim());
+
+export const validateBindingSource = (
+  source: WorkflowV2BindingSource,
+  owner: WorkflowV2FlowNode,
+  nodes: WorkflowV2FlowNode[],
+  edges: WorkflowV2FlowEdge[],
+): string | undefined => {
+  if (source.type === 'START_INPUT' && !hasText(source.path)) {
+    return '开始输入路径不能为空';
+  }
+  if (source.type === 'WORKFLOW_VARIABLE' && !hasText(source.variableName)) {
+    return '工作流变量名不能为空';
+  }
+  if (source.type === 'NODE_OUTPUT') {
+    if (!hasText(source.nodeKey)) return '请选择上游节点';
+    if (!hasText(source.path)) return '请选择或填写输出路径';
+    const upstream = getUpstreamNodeIds(owner.id, edges);
+    if (!upstream.has(source.nodeKey)) return '只能引用拓扑上游节点';
+    if (!nodes.some((node) => node.id === source.nodeKey)) {
+      return '引用的上游节点不存在';
+    }
+  }
+  return undefined;
+};
+
+export const collectMappingIssues = (
+  nodes: WorkflowV2FlowNode[],
+  edges: WorkflowV2FlowEdge[],
+): WorkflowV2MappingIssue[] => {
+  const issues: WorkflowV2MappingIssue[] = [];
+  nodes.forEach((node) => {
+    const targets = new Set<string>();
+    node.data.inputBindings.forEach((binding) => {
+      if (!binding.target.trim()) {
+        issues.push({
+          nodeId: node.id,
+          nodeName: node.data.title,
+          message: '存在目标字段为空的输入映射',
+        });
+        return;
+      }
+      if (targets.has(binding.target)) {
+        issues.push({
+          nodeId: node.id,
+          nodeName: node.data.title,
+          field: binding.target,
+          message: '输入目标字段重复',
+        });
+      }
+      targets.add(binding.target);
+      const message = validateBindingSource(binding.source, node, nodes, edges);
+      if (message) {
+        issues.push({
+          nodeId: node.id,
+          nodeName: node.data.title,
+          field: binding.target,
+          message,
+        });
+      }
+    });
+
+    Object.entries(node.data.outputBindings).forEach(([name, source]) => {
+      if (!name.trim()) {
+        issues.push({
+          nodeId: node.id,
+          nodeName: node.data.title,
+          message: '工作流输出名称不能为空',
+        });
+      }
+      const message = validateBindingSource(source, node, nodes, edges);
+      if (message) {
+        issues.push({
+          nodeId: node.id,
+          nodeName: node.data.title,
+          field: name,
+          message,
+        });
+      }
+    });
+  });
+  return issues;
+};
+
+export const collectMissingRequiredInputs = (
+  nodes: WorkflowV2FlowNode[],
+): WorkflowV2MappingIssue[] => {
+  const issues: WorkflowV2MappingIssue[] = [];
+  nodes
+    .filter((node) => node.data.kind === 'TASK' && node.data.enabled)
+    .forEach((node) => {
+      const bound = new Set(node.data.inputBindings.map((binding) => binding.target));
+      extractInputSchemaFields(node.data.taskMeta?.inputSchema)
+        .filter((field) => field.required && !bound.has(field.path))
+        .forEach((field) => {
+          issues.push({
+            nodeId: node.id,
+            nodeName: node.data.title,
+            field: field.path,
+            message: '必填输入尚未映射',
+          });
+        });
+    });
+  return issues;
+};
+
+export const inputMappingProgress = (
+  node: Pick<WorkflowV2FlowNode, 'data'>,
+) => {
+  const fields = extractInputSchemaFields(node.data.taskMeta?.inputSchema);
+  const required = fields.filter((field) => field.required);
+  const bound = new Set(node.data.inputBindings.map((binding) => binding.target));
+  return {
+    declared: fields.length,
+    required: required.length,
+    mapped: fields.filter((field) => bound.has(field.path)).length,
+    requiredMapped: required.filter((field) => bound.has(field.path)).length,
+  };
+};
+
+export const parseLiteralValue = (value: string): unknown => {
+  const trimmed = value.trim();
+  if (!trimmed) return '';
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return value;
+  }
+};
+
+export const formatLiteralValue = (value: unknown): string => {
+  if (typeof value === 'string') return value;
+  if (value === undefined) return '';
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+};

--- a/yak-ops-ui/src/pages/workflow-management/designer-v2/model.test.ts
+++ b/yak-ops-ui/src/pages/workflow-management/designer-v2/model.test.ts
@@ -1,5 +1,9 @@
-import type { WorkflowPublishedTask } from '../repository/workflow-task-library.repository';
+import type {
+  WorkflowPublishedTask,
+  WorkflowPublishedTaskVersion,
+} from '../repository/workflow-task-library.repository';
 import {
+  applyPublishedTaskVersion,
   createInitialWorkflowV2Dag,
   createTaskFlowNode,
   decodeTaskDragPayload,
@@ -23,13 +27,37 @@ const task = (): WorkflowPublishedTask => ({
   publishedVersionNumber: 3,
   pluginVersion: '1.0.0',
   schemaVersion: 1,
-  inputSchema: { required: ['orderId'] },
-  outputSchema: { type: 'object' },
+  inputSchema: {
+    type: 'object',
+    required: ['orderId'],
+    properties: { orderId: { type: 'string' } },
+  },
+  outputSchema: {
+    type: 'object',
+    properties: { data: { type: 'object' } },
+  },
   contentDigest: 'digest',
   publishedBy: 'admin',
   publishedAt: '2026-08-05T00:30:00',
   updatedAt: '2026-08-05T00:30:00',
   favorite: false,
+});
+
+const version = (): WorkflowPublishedTaskVersion => ({
+  taskId: '1001',
+  taskName: '查询订单',
+  projectId: '10',
+  projectName: '订单中心',
+  taskType: 'HTTP',
+  versionId: '2003',
+  versionNumber: 3,
+  pluginVersion: '1.0.0',
+  schemaVersion: 1,
+  inputSchema: task().inputSchema,
+  outputSchema: task().outputSchema,
+  contentDigest: 'digest',
+  publishedAt: '2026-08-05T00:30:00',
+  currentVersion: true,
 });
 
 describe('Workflow V2 designer model', () => {
@@ -44,26 +72,26 @@ describe('Workflow V2 designer model', () => {
 
   it('copies only an immutable task reference into a dropped task node', () => {
     const node = createTaskFlowNode(task(), { x: 300, y: 200 });
-    expect(node.deletable).toBe(true);
     expect(node.data.taskRef).toEqual({
       taskId: '1001',
       taskVersionId: '2003',
       taskVersionNumber: 3,
       taskType: 'HTTP',
     });
+    expect(node.data.taskMeta?.schemaStatus).toBe('ready');
     expect(node.data).not.toHaveProperty('config');
     expect(node.data).not.toHaveProperty('definition');
     expect(node.data).not.toHaveProperty('compiledSpec');
   });
 
-  it('protects control nodes while keeping task nodes deletable', () => {
+  it('hydrates schemas for a restored immutable task version', () => {
     const dag = createInitialWorkflowV2Dag();
     dag.nodes.splice(1, 0, {
       key: 'task_1',
-      name: '任务',
+      name: '查询订单',
       kind: 'TASK',
-      positionX: 420,
-      positionY: 220,
+      positionX: 400,
+      positionY: 200,
       enabled: true,
       taskRef: {
         taskId: '1001',
@@ -75,47 +103,61 @@ describe('Workflow V2 designer model', () => {
       outputBindings: {},
       executionPolicy: dag.nodes[0].executionPolicy,
     });
+    const restored = toFlowNodes(dag).find((node) => node.id === 'task_1')!;
+    expect(restored.data.taskMeta?.schemaStatus).toBe('loading');
+    const hydrated = applyPublishedTaskVersion(restored, version());
+    expect(hydrated.data.taskMeta?.schemaStatus).toBe('ready');
+    expect(hydrated.data.taskMeta?.inputSchema).toEqual(task().inputSchema);
+  });
 
-    const nodes = toFlowNodes(dag);
-    expect(nodes.find((node) => node.id === 'start')?.deletable).toBe(false);
-    expect(nodes.find((node) => node.id === 'end')?.deletable).toBe(false);
-    expect(nodes.find((node) => node.id === 'task_1')?.deletable).toBe(true);
+  it('preserves input and output bindings when saving', () => {
+    const initial = createInitialWorkflowV2Dag();
+    const taskNode = createTaskFlowNode(task(), { x: 420, y: 220 });
+    taskNode.data.inputBindings = [
+      {
+        target: 'orderId',
+        source: { type: 'START_INPUT', path: 'orderId' },
+      },
+    ];
+    const nodes = toFlowNodes(initial);
+    nodes.splice(1, 0, taskNode);
+    const end = nodes.find((node) => node.id === 'end')!;
+    end.data.outputBindings = {
+      order: {
+        type: 'NODE_OUTPUT',
+        nodeKey: taskNode.id,
+        path: 'data',
+      },
+    };
+    const dag = toWorkflowV2Dag(
+      nodes,
+      [
+        {
+          id: 'success',
+          source: 'start',
+          sourceHandle: 'SUCCESS',
+          target: taskNode.id,
+        },
+        {
+          id: 'end-edge',
+          source: taskNode.id,
+          sourceHandle: 'SUCCESS',
+          target: 'end',
+        },
+      ],
+      { x: 0, y: 0, zoom: 1 },
+    );
+    expect(dag.nodes.find((node) => node.key === taskNode.id)?.inputBindings)
+      .toEqual(taskNode.data.inputBindings);
+    expect(dag.nodes.find((node) => node.key === 'end')?.outputBindings)
+      .toEqual(end.data.outputBindings);
   });
 
   it('preserves SUCCESS and FAILURE source ports when saving', () => {
     const initial = createInitialWorkflowV2Dag();
     const taskNode = createTaskFlowNode(task(), { x: 420, y: 220 });
-    const nodes = [
-      {
-        id: 'start',
-        type: 'workflowV2Node',
-        position: { x: 140, y: 220 },
-        data: {
-          title: initial.nodes[0].name,
-          description: initial.nodes[0].description,
-          kind: initial.nodes[0].kind,
-          enabled: true,
-          inputBindings: [],
-          outputBindings: {},
-          executionPolicy: initial.nodes[0].executionPolicy,
-        },
-      },
-      taskNode,
-      {
-        id: 'end',
-        type: 'workflowV2Node',
-        position: { x: 760, y: 220 },
-        data: {
-          title: initial.nodes[1].name,
-          description: initial.nodes[1].description,
-          kind: initial.nodes[1].kind,
-          enabled: true,
-          inputBindings: [],
-          outputBindings: {},
-          executionPolicy: initial.nodes[1].executionPolicy,
-        },
-      },
-    ];
+    const nodes = toFlowNodes(initial);
+    nodes.splice(1, 0, taskNode);
     const dag = toWorkflowV2Dag(
       nodes,
       [
@@ -138,6 +180,13 @@ describe('Workflow V2 designer model', () => {
       { from: 'start', fromPort: 'SUCCESS', to: taskNode.id },
       { from: taskNode.id, fromPort: 'FAILURE', to: 'end' },
     ]);
+  });
+
+  it('protects control nodes while task nodes remain deletable', () => {
+    const controlNodes = toFlowNodes(createInitialWorkflowV2Dag());
+    expect(controlNodes.find((node) => node.id === 'start')?.deletable).toBe(false);
+    expect(controlNodes.find((node) => node.id === 'end')?.deletable).toBe(false);
+    expect(createTaskFlowNode(task(), { x: 0, y: 0 }).deletable).toBe(true);
   });
 
   it('rejects malformed drag payloads', () => {

--- a/yak-ops-ui/src/pages/workflow-management/designer-v2/model.ts
+++ b/yak-ops-ui/src/pages/workflow-management/designer-v2/model.ts
@@ -8,6 +8,7 @@ import {
 
 import type {
   WorkflowPublishedTask,
+  WorkflowPublishedTaskVersion,
 } from '../repository/workflow-task-library.repository';
 import {
   WORKFLOW_V2_SCHEMA_VERSION,
@@ -31,6 +32,8 @@ export interface WorkflowV2CanvasTaskMeta {
   publishedAt?: string;
   inputSchema?: Record<string, unknown>;
   outputSchema?: Record<string, unknown>;
+  schemaStatus?: 'loading' | 'ready' | 'error';
+  schemaError?: string;
 }
 
 export interface WorkflowV2CanvasNodeData {
@@ -127,6 +130,7 @@ export const createTaskFlowNode = (
       publishedAt: task.publishedAt,
       inputSchema: copyJson(task.inputSchema),
       outputSchema: copyJson(task.outputSchema),
+      schemaStatus: 'ready',
     },
     inputBindings: [],
     outputBindings: {},
@@ -155,6 +159,7 @@ export const toFlowNodes = (dag: WorkflowV2Dag): WorkflowV2FlowNode[] =>
               pluginVersion: undefined,
               projectName: undefined,
               folderName: undefined,
+              schemaStatus: 'loading',
             }
           : undefined,
       inputBindings: copyJson(node.inputBindings ?? []),
@@ -164,6 +169,41 @@ export const toFlowNodes = (dag: WorkflowV2Dag): WorkflowV2FlowNode[] =>
       ),
     },
   }));
+
+export const applyPublishedTaskVersion = (
+  node: WorkflowV2FlowNode,
+  version: WorkflowPublishedTaskVersion,
+): WorkflowV2FlowNode => ({
+  ...node,
+  data: {
+    ...node.data,
+    taskMeta: {
+      ...node.data.taskMeta,
+      projectName: version.projectName,
+      pluginVersion: version.pluginVersion,
+      publishedAt: version.publishedAt,
+      inputSchema: copyJson(version.inputSchema),
+      outputSchema: copyJson(version.outputSchema),
+      schemaStatus: 'ready',
+      schemaError: undefined,
+    },
+  },
+});
+
+export const markTaskSchemaError = (
+  node: WorkflowV2FlowNode,
+  error: unknown,
+): WorkflowV2FlowNode => ({
+  ...node,
+  data: {
+    ...node.data,
+    taskMeta: {
+      ...node.data.taskMeta,
+      schemaStatus: 'error',
+      schemaError: error instanceof Error ? error.message : '任务 Schema 加载失败',
+    },
+  },
+});
 
 const edgeStyle = (port: WorkflowV2Edge['fromPort']) =>
   port === 'FAILURE'

--- a/yak-ops-ui/src/pages/workflow-management/designer-v2/task-schema.ts
+++ b/yak-ops-ui/src/pages/workflow-management/designer-v2/task-schema.ts
@@ -1,0 +1,89 @@
+import { useEffect, useState } from 'react';
+
+import {
+  workflowTaskLibraryRepository,
+  type WorkflowPublishedTaskVersion,
+} from '../repository/workflow-task-library.repository';
+import type { WorkflowV2TaskReference } from '../workflow-v2.types';
+import type { WorkflowV2CanvasTaskMeta } from './model';
+
+const versionRequests = new Map<string, Promise<WorkflowPublishedTaskVersion>>();
+
+const cacheKey = (taskRef: WorkflowV2TaskReference) =>
+  `${taskRef.taskId}:${taskRef.taskVersionId}`;
+
+export const loadPublishedTaskVersion = (
+  taskRef: WorkflowV2TaskReference,
+): Promise<WorkflowPublishedTaskVersion> => {
+  const key = cacheKey(taskRef);
+  const current = versionRequests.get(key);
+  if (current) return current;
+  const request = workflowTaskLibraryRepository
+    .getPublishedVersion(taskRef.taskId, taskRef.taskVersionId)
+    .catch((error) => {
+      versionRequests.delete(key);
+      throw error;
+    });
+  versionRequests.set(key, request);
+  return request;
+};
+
+export const publishedVersionToTaskMeta = (
+  version: WorkflowPublishedTaskVersion,
+  previous?: WorkflowV2CanvasTaskMeta,
+): WorkflowV2CanvasTaskMeta => ({
+  ...previous,
+  projectName: version.projectName,
+  pluginVersion: version.pluginVersion,
+  publishedAt: version.publishedAt,
+  inputSchema: version.inputSchema,
+  outputSchema: version.outputSchema,
+  schemaStatus: 'ready',
+  schemaError: undefined,
+});
+
+export const taskSchemaErrorMeta = (
+  error: unknown,
+  previous?: WorkflowV2CanvasTaskMeta,
+): WorkflowV2CanvasTaskMeta => ({
+  ...previous,
+  schemaStatus: 'error',
+  schemaError: error instanceof Error ? error.message : '任务 Schema 加载失败',
+});
+
+export const usePublishedTaskSchema = (
+  taskRef?: WorkflowV2TaskReference,
+  initialMeta?: WorkflowV2CanvasTaskMeta,
+) => {
+  const [meta, setMeta] = useState<WorkflowV2CanvasTaskMeta | undefined>(
+    initialMeta,
+  );
+
+  useEffect(() => {
+    if (!taskRef || initialMeta?.schemaStatus === 'ready') {
+      setMeta(initialMeta);
+      return;
+    }
+    let active = true;
+    setMeta((current) => ({ ...current, schemaStatus: 'loading' }));
+    loadPublishedTaskVersion(taskRef)
+      .then((version) => {
+        if (active) {
+          setMeta((current) => publishedVersionToTaskMeta(version, current));
+        }
+      })
+      .catch((error: unknown) => {
+        if (active) setMeta((current) => taskSchemaErrorMeta(error, current));
+      });
+    return () => {
+      active = false;
+    };
+  }, [
+    initialMeta,
+    taskRef?.taskId,
+    taskRef?.taskVersionId,
+    taskRef?.taskVersionNumber,
+  ]);
+
+  return meta;
+};


### PR DESCRIPTION
## 背景

Workflow V2 已经完成不可变任务版本引用、任务资源拖拽和任务配置 Panel 删除，但还缺少真正可用的编排数据传递能力：任务输入无法从开始参数或上游节点取值，END 节点也无法定义工作流最终输出。

本 PR 完成第六步：实现 Workflow V2 输入输出映射。映射能力只编辑编排层的 `inputBindings / outputBindings`，不会恢复 HTTP、Shell、SQL、Python、Notebook 等任务内部配置。

## 交互入口

点击节点后的行为调整为：

```text
START -> 仅选中，不打开映射面板
TASK  -> 打开右侧输入映射面板
END   -> 打开右侧工作流输出面板
```

映射面板宽度为 410px，通过 Portal 固定在设计器右侧，并具有独立滚动区域。多选节点时只会打开一个映射面板。

## 任务 Schema 回填

新拖入的任务直接使用任务资源库响应中的 Input/Output Schema。

重新打开工作流草稿时，DAG 只保留不可变 `taskRef`。节点会通过以下接口按固定版本重新读取 Schema：

```http
GET /api/v1/data-development/tasks/library/{taskId}/versions/{versionId}
```

请求以 `taskId + versionId` 缓存，多个节点或面板读取同一版本时复用请求。

Schema、项目名称和插件版本只存在于前端展示元数据中，不进入 Workflow V2 DAG。Schema 回填也不会把刚打开的草稿误标记为“未保存”。

## TASK 输入映射

Input Schema 根级 `properties` 会显示为输入目标，根级 `required` 会标记必填字段。

每个输入支持四种来源：

```text
START_INPUT       开始输入路径
NODE_OUTPUT       拓扑上游任务输出
WORKFLOW_VARIABLE 工作流变量
LITERAL           固定值
```

示例：

```json
{
  "target": "orderId",
  "source": {
    "type": "START_INPUT",
    "path": "orderId"
  }
}
```

对于未声明 Input Schema 或需要额外参数的任务，可添加自定义输入映射。

## NODE_OUTPUT 拓扑约束

上游输出选择只展示当前节点的拓扑祖先 TASK 节点。

```text
START -> Task A -> Task B
```

Task B 可以引用 Task A 的输出，不能引用下游节点或无依赖关系的旁路节点。

Output Schema 会展开为路径选项，例如：

```text
data
data.id
data.status
```

同时允许手工填写路径，以兼容动态输出结构。

## END 工作流输出

点击 END 节点可定义调用方看到的稳定输出契约：

```json
{
  "order": {
    "type": "NODE_OUTPUT",
    "nodeKey": "task_query_order",
    "path": "data"
  }
}
```

工作流输出同样支持上游节点输出、开始输入、工作流变量和固定值，可以添加、删除或修改输出名称。

## 节点状态

TASK 节点展示：

```text
Schema 加载中 / 加载失败
已映射输入数 / 声明输入数
必填映射是否完整
```

END 节点展示已经定义的工作流输出数量。

## 校验边界

前端映射模型能够检查：

- 输入目标为空或重复；
- START_INPUT 路径为空；
- WORKFLOW_VARIABLE 名称为空；
- NODE_OUTPUT 缺少节点或路径；
- NODE_OUTPUT 不再是拓扑上游；
- 工作流输出名称为空；
- required 输入是否完成映射。

面板在编辑过程中展示必填映射进度。保存和发布的最终可信校验仍由后端 `WorkflowV2DagValidator` 与 `WorkflowV2PublicationValidator` 执行，因此绕过前端也不能发布无效映射。

## 持久化边界

保存时只写入：

```text
inputBindings
outputBindings
```

不会写入：

```text
Task config
Input / Output Schema 展示副本
Definition / Definition Snapshot
Compiled Spec
Runtime / Secret
HTTP / Shell / SQL / Python / Notebook 专属参数
```

## 测试与验证

新增和扩展测试覆盖：

- JSON Schema 输入字段和 required 提取；
- 嵌套 Output Schema 路径展开；
- 传递性拓扑上游计算；
- 输入绑定按 target 替换且不重复；
- required 输入缺失识别；
- 非上游 NODE_OUTPUT 拒绝；
- 固定任务版本 Schema 回填；
- inputBindings / outputBindings 保存往返；
- 原有不可变 taskRef 与 SUCCESS / FAILURE 连线回归。

已完成：

- TypeScript 5.8 strict 检查；
- 8 个新增或修改 TS / TSX 文件语法转译；
- Schema 提取、拓扑祖先、固定值解析运行断言；
- 静态扫描确认映射代码不存在任务配置、Definition 或 Compiled Spec 持久化路径；
- GitHub compare 确认分支基于最新 `main`，落后 0，只包含本步骤的 9 个文件。

当前环境没有完整仓库前端依赖和浏览器运行环境，因此没有执行真实 `npm run tsc`、Biome、Jest、Umi production build 以及浏览器端映射交互联调；这些需由本地或 CI 最终确认。

## 当前边界

- START 节点输入 Schema 管理页面尚未实现，`START_INPUT.path` 当前使用自由路径；
- WORKFLOW_VARIABLE 来源已经支持，但变量声明和密钥管理仍由后续独立能力实现；
- Workflow V2 运行仍等待统一 Task Execution Gateway。

## 合并说明

连接器产生了细粒度提交，建议使用 **Squash and merge**。