### PR TITLE
fix(ui): remove stale workflow designer routes

### DIFF
--- a/yak-ops-ui/config/routes.ts
+++ b/yak-ops-ui/config/routes.ts
@@ -1,18 +1,5 @@
 import { appRoutes } from '../src/config/navigation';
 
-const applicationRoutes = appRoutes.filter(
-  ({ id }) => id !== 'workflow-designer',
-);
-
-const protectedHiddenRoute = (path: string, component: string) => ({
-  path,
-  component,
-  access: 'isAuthenticated',
-  wrappers: ['@/components/security/WorkflowDefinitionRouteBoundary'],
-  hideInMenu: true,
-  hideInBreadcrumb: true,
-});
-
 /**
  * 站内页面统一使用自定义 SiteLayout。
  * 登录页和异常页保持独立，不进入后台导航框架。
@@ -42,19 +29,7 @@ export default [
         hideInMenu: true,
         hideInBreadcrumb: true,
       },
-      protectedHiddenRoute(
-        '/workflow-management/v1/:id/designer',
-        './workflow-management/designer',
-      ),
-      protectedHiddenRoute(
-        '/workflow-management/v2/:id/designer',
-        './workflow-management/designer-v2',
-      ),
-      protectedHiddenRoute(
-        '/workflow-management/:id/designer',
-        './workflow-management/designer-router',
-      ),
-      ...applicationRoutes.map(({ path, component, hidden }) => ({
+      ...appRoutes.map(({ path, component, hidden }) => ({
         path,
         component,
         access: 'isAuthenticated',


### PR DESCRIPTION
## What changed

- remove the three hidden workflow designer routes from the Umi route configuration
- remove the now-unused `protectedHiddenRoute` helper and stale `workflow-designer` filtering
- map the current `appRoutes` collection directly

## Root cause

The workflow frontend was removed during the task-plugin/workflow boundary refactor, including:

- `src/pages/workflow-management/designer`
- `src/pages/workflow-management/designer-v2`
- `src/pages/workflow-management/designer-router`
- `WorkflowDefinitionRouteBoundary`

`config/routes.ts` still referenced those deleted components. Umi resolves every configured route at startup, so `yarn start` failed with:

```text
Cannot find module './workflow-management/designer'
```

## Impact

The UI development server can finish route generation without resolving deleted workflow pages.

## Validation

- confirmed all three referenced workflow designer page directories were deleted in the workflow removal refactor
- reviewed the final diff: only `yak-ops-ui/config/routes.ts` changes
- branch is based on the latest `main`

Recommended local verification:

```bash
cd yak-ops-ui
yarn start
```
