### PR TITLE
fix(ui): restore navigation helper exports

### DIFF
--- a/yak-ops-ui/src/config/navigation.ts
+++ b/yak-ops-ui/src/config/navigation.ts
@@ -518,6 +518,24 @@ export const getNavigationGroups = (
     .filter((group) => group.routes.length > 0)
     .sort(sortByOrder);
 
+export const getMainNavigationGroups = getNavigationGroups;
+
+export const getQuickCreateRoutes = (
+  permissionCodes?: readonly string[] | null,
+) =>
+  appRoutes
+    .filter(
+      (route) =>
+        Boolean(route.quickCreateLabel) &&
+        canAccessNavigationRoute(route, permissionCodes) &&
+        (!route.quickCreateRequirement ||
+          satisfiesPermissionRequirement(
+            permissionCodes,
+            route.quickCreateRequirement,
+          )),
+    )
+    .sort(sortByOrder);
+
 export const getStandaloneNavigationRoutes = (
   permissionCodes?: readonly string[] | null,
 ) =>


### PR DESCRIPTION
## What changed

- restore the `getMainNavigationGroups` export as a compatibility alias for `getNavigationGroups`
- restore `getQuickCreateRoutes` with its existing route and create-permission filtering

## Root cause

The workflow-removal refactor introduced `getNavigationGroups`, but removed two exports that are still consumed by `SiteLayout` and the existing navigation tests:

```text
getMainNavigationGroups
getQuickCreateRoutes
```

Mako/esbuild validates named exports during startup, so `yarn start` stopped with `No matching export` before the application could compile.

## Impact

- `SiteLayout` can compile again
- navigation groups continue using the new centralized implementation
- quick-create entries remain filtered independently by read and create permissions

## Validation

- confirmed both missing names are imported by `src/layouts/SiteLayout/index.tsx`
- confirmed `src/config/navigation.test.ts` already covers group filtering and quick-create permissions
- reviewed the branch diff: only 18 lines added to `src/config/navigation.ts`

Recommended local verification:

```bash
cd yak-ops-ui
yarn start
```
