### PR TITLE
feat(data-development): redesign workbench quick-create menu

### DIFF
--- a/yak-ops-ui/src/pages/data-development/workbench/WorkbenchPage.tsx
+++ b/yak-ops-ui/src/pages/data-development/workbench/WorkbenchPage.tsx
@@ -48,13 +48,18 @@ const WorkbenchPage = () => {
   const setActiveResource = useWorkbenchStore((state) => state.setActiveResource);
   const [createOpen, setCreateOpen] = useState(false);
   const [createType, setCreateType] = useState<ResourceType>('HTTP');
+  const [createEngineType, setCreateEngineType] = useState<string>();
 
   useEffect(() => {
     void initialize();
   }, [initialize]);
 
-  const openCreateModal = (resourceType: ResourceType = 'HTTP') => {
+  const openCreateModal = (
+    resourceType: ResourceType = 'HTTP',
+    engineType?: string,
+  ) => {
     setCreateType(resourceType);
+    setCreateEngineType(engineType);
     setCreateOpen(true);
   };
 
@@ -144,7 +149,7 @@ const WorkbenchPage = () => {
             <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
               <div className="flex min-h-0 flex-1 overflow-hidden">
                 <section className="min-w-0 flex-1 overflow-hidden">
-                  <ResourceView onCreate={() => openCreateModal('HTTP')} />
+                  <ResourceView onCreate={() => openCreateModal('HTTP', 'HTTP')} />
                 </section>
 
                 {splitResource && !fullscreen && (
@@ -186,6 +191,7 @@ const WorkbenchPage = () => {
         <CreateResourceModal
           open={createOpen}
           initialResourceType={createType}
+          initialEngineType={createEngineType}
           onClose={() => setCreateOpen(false)}
         />
       </div>

--- a/yak-ops-ui/src/pages/data-development/workbench/components/CreateFolderModal.tsx
+++ b/yak-ops-ui/src/pages/data-development/workbench/components/CreateFolderModal.tsx
@@ -1,0 +1,91 @@
+import { Form, Input, Modal, message } from 'antd';
+import { useState } from 'react';
+import {
+  projectFolderRepository,
+  type ProjectFolder,
+} from '../repository/project-folder.repository';
+import { workbenchErrorMessage } from '../repository/workbench.repository';
+
+interface CreateFolderValues {
+  name: string;
+}
+
+interface CreateFolderModalProps {
+  open: boolean;
+  projectId?: string;
+  onClose: () => void;
+  onCreated: (folder: ProjectFolder) => void;
+}
+
+const CreateFolderModal = ({
+  open,
+  projectId,
+  onClose,
+  onCreated,
+}: CreateFolderModalProps) => {
+  const [form] = Form.useForm<CreateFolderValues>();
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleCreate = async ({ name }: CreateFolderValues) => {
+    if (!projectId) {
+      message.error('数据开发项目尚未加载');
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const folder = await projectFolderRepository.create(projectId, name);
+      onCreated(folder);
+      message.success('目录已创建');
+      form.resetFields();
+      onClose();
+    } catch (error) {
+      message.error(workbenchErrorMessage(error));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Modal
+      title="新建目录"
+      open={open}
+      centered
+      width={440}
+      okText="创建目录"
+      cancelText="取消"
+      confirmLoading={submitting}
+      destroyOnHidden
+      onCancel={() => {
+        form.resetFields();
+        onClose();
+      }}
+      onOk={() => form.submit()}
+    >
+      <Form<CreateFolderValues>
+        form={form}
+        layout="vertical"
+        requiredMark={false}
+        onFinish={handleCreate}
+        className="pt-3"
+      >
+        <Form.Item
+          name="name"
+          label="目录名称"
+          rules={[
+            { required: true, whitespace: true, message: '请输入目录名称' },
+            { max: 80, message: '目录名称不能超过 80 个字符' },
+          ]}
+        >
+          <Input
+            autoFocus
+            variant="filled"
+            placeholder="例如：订单数据开发"
+          />
+        </Form.Item>
+      </Form>
+    </Modal>
+  );
+};
+
+export default CreateFolderModal;

--- a/yak-ops-ui/src/pages/data-development/workbench/components/CreateResourceModal.tsx
+++ b/yak-ops-ui/src/pages/data-development/workbench/components/CreateResourceModal.tsx
@@ -11,18 +11,21 @@ import { useWorkbenchStore } from '../store/workbench.store';
 
 interface CreateResourceValues {
   resourceType: ResourceType;
+  engineType: string;
   name: string;
 }
 
 interface CreateResourceModalProps {
   open: boolean;
   initialResourceType?: ResourceType;
+  initialEngineType?: string;
   onClose: () => void;
 }
 
 const CreateResourceModal = ({
   open,
   initialResourceType,
+  initialEngineType,
   onClose,
 }: CreateResourceModalProps) => {
   const [form] = Form.useForm<CreateResourceValues>();
@@ -32,6 +35,8 @@ const CreateResourceModal = ({
     (state) => state.supportedTaskTypes,
   );
   const createResource = useWorkbenchStore((state) => state.createResource);
+  const selectedResourceType = Form.useWatch('resourceType', form);
+
   const plugins = useMemo(() => {
     const supported = new Set(supportedTaskTypes);
     return nodePluginRegistry
@@ -45,21 +50,47 @@ const CreateResourceModal = ({
       );
   }, [supportedTaskTypes]);
 
+  const selectedPlugin = selectedResourceType
+    ? nodePluginRegistry.get(selectedResourceType)
+    : undefined;
+  const engineOptions = selectedPlugin
+    ? selectedPlugin.metadata.engineOptions ?? [
+        {
+          label: selectedPlugin.metadata.defaultEngine,
+          value: selectedPlugin.metadata.defaultEngine,
+        },
+      ]
+    : [];
+
   useEffect(() => {
     if (!open) return;
-    const requested = plugins.some(
-      (plugin) => plugin.type === initialResourceType,
+
+    const requestedPlugin =
+      plugins.find((plugin) => plugin.type === initialResourceType) ?? plugins[0];
+    const requestedEngineOptions = requestedPlugin
+      ? requestedPlugin.metadata.engineOptions ?? [
+          {
+            label: requestedPlugin.metadata.defaultEngine,
+            value: requestedPlugin.metadata.defaultEngine,
+          },
+        ]
+      : [];
+    const requestedEngine = requestedEngineOptions.some(
+      (option) => option.value === initialEngineType,
     )
-      ? initialResourceType
-      : plugins[0]?.type;
+      ? initialEngineType
+      : requestedPlugin?.metadata.defaultEngine;
+
     form.setFieldsValue({
-      resourceType: requested,
+      resourceType: requestedPlugin?.type,
+      engineType: requestedEngine,
       name: '',
     });
-  }, [form, initialResourceType, open, plugins]);
+  }, [form, initialEngineType, initialResourceType, open, plugins]);
 
   const handleCreate = async ({
     resourceType,
+    engineType,
     name,
   }: CreateResourceValues) => {
     const plugin = nodePluginRegistry.get(resourceType);
@@ -78,7 +109,7 @@ const CreateResourceModal = ({
         projectId,
         resourceType,
         name,
-        plugin.metadata.defaultEngine,
+        engineType || plugin.metadata.defaultEngine,
       );
       createResource(resource, document);
       message.success(`${plugin.metadata.label} 已创建并保存`);
@@ -113,6 +144,14 @@ const CreateResourceModal = ({
         layout="vertical"
         requiredMark={false}
         onFinish={handleCreate}
+        onValuesChange={(changedValues) => {
+          if (!('resourceType' in changedValues)) return;
+          const nextResourceType = changedValues.resourceType;
+          const plugin = nextResourceType
+            ? nodePluginRegistry.get(nextResourceType)
+            : undefined;
+          form.setFieldValue('engineType', plugin?.metadata.defaultEngine);
+        }}
         className="pt-3"
       >
         <Form.Item
@@ -130,6 +169,14 @@ const CreateResourceModal = ({
               label: `${plugin.metadata.category} / ${plugin.metadata.label}`,
             }))}
           />
+        </Form.Item>
+
+        <Form.Item
+          name="engineType"
+          label="执行引擎"
+          rules={[{ required: true, message: '请选择执行引擎' }]}
+        >
+          <Select variant="filled" options={engineOptions} />
         </Form.Item>
 
         <Form.Item

--- a/yak-ops-ui/src/pages/data-development/workbench/components/ExplorerPanel.tsx
+++ b/yak-ops-ui/src/pages/data-development/workbench/components/ExplorerPanel.tsx
@@ -1,31 +1,100 @@
-import { Button, Dropdown, Input, Select, Tooltip, type MenuProps } from 'antd';
+import {
+  Button,
+  Dropdown,
+  Input,
+  Select,
+  Tooltip,
+  message,
+  type MenuProps,
+} from 'antd';
 import {
   ChevronDown,
   ChevronRight,
   Circle,
+  Database,
   Folder,
   FolderOpen,
+  FolderPlus,
+  Globe2,
   PanelLeftClose,
   Plus,
   Search,
   Trash2,
 } from 'lucide-react';
-import { useMemo, type ChangeEvent } from 'react';
+import { useEffect, useMemo, useState, type ChangeEvent } from 'react';
 import { nodePluginRegistry } from '../core/registry';
 import type {
   ExplorerFilter,
   ResourceType,
   WorkbenchFolderDefinition,
 } from '../core/types';
+import {
+  projectFolderRepository,
+  type ProjectFolder,
+} from '../repository/project-folder.repository';
+import { workbenchErrorMessage } from '../repository/workbench.repository';
 import { useWorkbenchControlStore } from '../store/workbench-control.store';
 import { useWorkbenchStore } from '../store/workbench.store';
+import CreateFolderModal from './CreateFolderModal';
 import ResourceContextMenu from './ResourceContextMenu';
 
 interface ExplorerPanelProps {
-  onCreate: (resourceType: ResourceType) => void;
+  onCreate: (resourceType: ResourceType, engineType?: string) => void;
 }
 
+const QUICK_CREATE_MENU_CLASS = [
+  '!min-w-[178px] !rounded-[10px] !border !border-[#e5e7eb] !bg-white !p-1.5',
+  '!shadow-[0_12px_32px_rgba(22,24,35,0.12)]',
+  '[&_.ant-dropdown-menu-item]:!flex [&_.ant-dropdown-menu-item]:!h-8',
+  '[&_.ant-dropdown-menu-item]:!items-center [&_.ant-dropdown-menu-item]:!rounded-md',
+  '[&_.ant-dropdown-menu-item]:!px-2.5 [&_.ant-dropdown-menu-item]:!text-[13px]',
+  '[&_.ant-dropdown-menu-submenu-title]:!flex [&_.ant-dropdown-menu-submenu-title]:!h-8',
+  '[&_.ant-dropdown-menu-submenu-title]:!items-center',
+  '[&_.ant-dropdown-menu-submenu-title]:!rounded-md',
+  '[&_.ant-dropdown-menu-submenu-title]:!px-2.5',
+  '[&_.ant-dropdown-menu-submenu-title]:!text-[13px]',
+  '[&_.ant-dropdown-menu-item:hover]:!bg-[var(--yak-brand-color-soft)]',
+  '[&_.ant-dropdown-menu-item:hover]:!text-[var(--yak-brand-color)]',
+  '[&_.ant-dropdown-menu-submenu-title:hover]:!bg-[var(--yak-brand-color-soft)]',
+  '[&_.ant-dropdown-menu-submenu-title:hover]:!text-[var(--yak-brand-color)]',
+  '[&_.ant-dropdown-menu-item-divider]:!mx-1',
+  '[&_.ant-dropdown-menu-item-divider]:!my-1.5',
+].join(' ');
+
+const QUICK_CREATE_SUBMENU_CLASS = [
+  '[&_.ant-dropdown-menu]:!min-w-[176px]',
+  '[&_.ant-dropdown-menu]:!rounded-[10px]',
+  '[&_.ant-dropdown-menu]:!border',
+  '[&_.ant-dropdown-menu]:!border-[#e5e7eb]',
+  '[&_.ant-dropdown-menu]:!bg-white',
+  '[&_.ant-dropdown-menu]:!p-1.5',
+  '[&_.ant-dropdown-menu]:!shadow-[0_12px_32px_rgba(22,24,35,0.12)]',
+  '[&_.ant-dropdown-menu-item]:!flex',
+  '[&_.ant-dropdown-menu-item]:!h-8',
+  '[&_.ant-dropdown-menu-item]:!items-center',
+  '[&_.ant-dropdown-menu-item]:!rounded-md',
+  '[&_.ant-dropdown-menu-item]:!px-2.5',
+  '[&_.ant-dropdown-menu-item]:!text-[13px]',
+  '[&_.ant-dropdown-menu-submenu-title]:!flex',
+  '[&_.ant-dropdown-menu-submenu-title]:!h-8',
+  '[&_.ant-dropdown-menu-submenu-title]:!items-center',
+  '[&_.ant-dropdown-menu-submenu-title]:!rounded-md',
+  '[&_.ant-dropdown-menu-submenu-title]:!px-2.5',
+  '[&_.ant-dropdown-menu-submenu-title]:!text-[13px]',
+  '[&_.ant-dropdown-menu-item:hover]:!bg-[var(--yak-brand-color-soft)]',
+  '[&_.ant-dropdown-menu-item:hover]:!text-[var(--yak-brand-color)]',
+  '[&_.ant-dropdown-menu-submenu-title:hover]:!bg-[var(--yak-brand-color-soft)]',
+  '[&_.ant-dropdown-menu-submenu-title:hover]:!text-[var(--yak-brand-color)]',
+].join(' ');
+
+const sortProjectFolders = (folders: ProjectFolder[]) =>
+  folders.slice().sort((left, right) => {
+    const order = left.sortOrder - right.sortOrder;
+    return order || left.name.localeCompare(right.name);
+  });
+
 const ExplorerPanel = ({ onCreate }: ExplorerPanelProps) => {
+  const projectId = useWorkbenchControlStore((state) => state.projectId);
   const projectName = useWorkbenchControlStore((state) => state.projectName);
   const supportedTaskTypes = useWorkbenchControlStore(
     (state) => state.supportedTaskTypes,
@@ -55,6 +124,8 @@ const ExplorerPanel = ({ onCreate }: ExplorerPanelProps) => {
   const setExplorerVisible = useWorkbenchStore(
     (state) => state.setExplorerVisible,
   );
+  const [createFolderOpen, setCreateFolderOpen] = useState(false);
+  const [projectFolders, setProjectFolders] = useState<ProjectFolder[]>([]);
 
   const plugins = useMemo(() => {
     const supported = new Set(supportedTaskTypes);
@@ -63,7 +134,7 @@ const ExplorerPanel = ({ onCreate }: ExplorerPanelProps) => {
       .filter((plugin) => supported.has(plugin.type.toUpperCase()));
   }, [supportedTaskTypes]);
 
-  const folders = useMemo(() => {
+  const pluginFolders = useMemo(() => {
     const folderMap = new Map<string, WorkbenchFolderDefinition>();
     plugins.forEach((plugin) => {
       folderMap.set(plugin.metadata.folderId, {
@@ -77,21 +148,104 @@ const ExplorerPanel = ({ onCreate }: ExplorerPanelProps) => {
     );
   }, [plugins]);
 
-  const createMenuItems: MenuProps['items'] = plugins
-    .slice()
-    .sort(
-      (left, right) =>
-        left.metadata.folderOrder - right.metadata.folderOrder ||
-        left.metadata.label.localeCompare(right.metadata.label),
-    )
-    .map((plugin) => {
-      const Icon = plugin.metadata.icon;
-      return {
-        key: plugin.type,
-        label: plugin.metadata.label,
-        icon: <Icon size={15} className={plugin.metadata.iconClassName} />,
-      };
-    });
+  useEffect(() => {
+    if (!projectId) {
+      setProjectFolders([]);
+      return;
+    }
+
+    let disposed = false;
+    void projectFolderRepository
+      .list(projectId)
+      .then((folders) => {
+        if (!disposed) setProjectFolders(folders);
+      })
+      .catch((error) => {
+        if (!disposed) message.error(workbenchErrorMessage(error));
+      });
+
+    return () => {
+      disposed = true;
+    };
+  }, [projectId]);
+
+  const supportedTypeSet = useMemo(
+    () => new Set(plugins.map((plugin) => plugin.type.toUpperCase())),
+    [plugins],
+  );
+  const sqlSupported = supportedTypeSet.has('SQL');
+  const httpSupported = supportedTypeSet.has('HTTP');
+
+  const createMenuItems: MenuProps['items'] = [
+    {
+      key: 'create-node',
+      label: '新建节点',
+      disabled: !sqlSupported && !httpSupported,
+      popupClassName: QUICK_CREATE_SUBMENU_CLASS,
+      children: [
+        {
+          key: 'database',
+          label: '数据库',
+          icon: <Database size={14} />,
+          disabled: !sqlSupported,
+          popupClassName: QUICK_CREATE_SUBMENU_CLASS,
+          children: [
+            {
+              key: 'create-sql-mysql',
+              label: 'MySQL',
+              disabled: !sqlSupported,
+            },
+            {
+              key: 'create-sql-oracle',
+              label: 'ORACLE',
+              disabled: !sqlSupported,
+            },
+          ],
+        },
+        {
+          key: 'general',
+          label: '通用',
+          icon: <Globe2 size={14} />,
+          disabled: !httpSupported,
+          popupClassName: QUICK_CREATE_SUBMENU_CLASS,
+          children: [
+            {
+              key: 'create-http',
+              label: 'HTTP 节点',
+              disabled: !httpSupported,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      type: 'divider',
+    },
+    {
+      key: 'create-folder',
+      label: '新建目录',
+      icon: <FolderPlus size={14} />,
+      disabled: !projectId,
+    },
+  ];
+
+  const handleCreateMenuClick: MenuProps['onClick'] = ({ key }) => {
+    if (key === 'create-sql-mysql') {
+      onCreate('SQL', 'MySQL');
+      return;
+    }
+    if (key === 'create-sql-oracle') {
+      onCreate('SQL', 'Oracle');
+      return;
+    }
+    if (key === 'create-http') {
+      onCreate('HTTP', 'HTTP');
+      return;
+    }
+    if (key === 'create-folder') {
+      setCreateFolderOpen(true);
+    }
+  };
 
   const normalizedKeyword = explorerKeyword.trim().toLowerCase();
   const visibleResourceIds = Object.values(resourcesById)
@@ -108,6 +262,10 @@ const ExplorerPanel = ({ onCreate }: ExplorerPanelProps) => {
     })
     .map((resource) => resource.id);
   const visibleResourceIdSet = new Set(visibleResourceIds);
+  const visibleProjectFolders = projectFolders.filter(
+    (folder) =>
+      !normalizedKeyword || folder.name.toLowerCase().includes(normalizedKeyword),
+  );
 
   const showUpdatedBy = explorerWidth >= 360;
   const showUpdatedAt = explorerWidth >= 450;
@@ -132,7 +290,7 @@ const ExplorerPanel = ({ onCreate }: ExplorerPanelProps) => {
       <ResourceContextMenu
         key={resource.id}
         resource={resource}
-        folders={folders}
+        folders={pluginFolders}
         projectLabel={projectName}
       >
         <button
@@ -186,143 +344,175 @@ const ExplorerPanel = ({ onCreate }: ExplorerPanelProps) => {
   };
 
   return (
-    <aside className="flex h-full w-full min-w-0 flex-col bg-[#fbfbfc]">
-      <div className="border-b border-[#e7e9ec] p-3">
-        <div className="flex items-center justify-between gap-2">
-          <Select
-            variant="borderless"
-            className="min-w-0 flex-1 [&_.ant-select-selector]:!px-0"
-            value="current-project"
-            options={[{ label: projectName, value: 'current-project' }]}
-          />
-          <Tooltip title="收起项目目录">
-            <Button
-              type="text"
-              size="small"
-              icon={<PanelLeftClose size={15} />}
-              onClick={() => setExplorerVisible(false)}
+    <>
+      <aside className="flex h-full w-full min-w-0 flex-col bg-[#fbfbfc]">
+        <div className="border-b border-[#e7e9ec] p-3">
+          <div className="flex items-center justify-between gap-2">
+            <Select
+              variant="borderless"
+              className="min-w-0 flex-1 [&_.ant-select-selector]:!px-0"
+              value="current-project"
+              options={[{ label: projectName, value: 'current-project' }]}
             />
-          </Tooltip>
+            <Tooltip title="收起项目目录">
+              <Button
+                type="text"
+                size="small"
+                icon={<PanelLeftClose size={15} />}
+                onClick={() => setExplorerVisible(false)}
+              />
+            </Tooltip>
+          </div>
+
+          <Input
+            allowClear
+            variant="filled"
+            prefix={<Search size={14} />}
+            placeholder="搜索名称 / 节点 ID / 修改人"
+            value={explorerKeyword}
+            onChange={(event: ChangeEvent<HTMLInputElement>) =>
+              setExplorerKeyword(event.target.value)
+            }
+            className="mt-2"
+          />
+
+          <div className="mt-2 flex items-center gap-1">
+            {[
+              ['all', '全部'],
+              ['owned', '我负责的'],
+            ].map(([value, label]) => (
+              <button
+                key={value}
+                type="button"
+                onClick={() => setExplorerFilter(value as ExplorerFilter)}
+                className={[
+                  'h-7 flex-1 rounded-md border-0 px-2 text-[11px] transition-colors',
+                  explorerFilter === value
+                    ? 'bg-[var(--yak-brand-color-soft)] font-medium text-[var(--yak-brand-color)]'
+                    : 'bg-transparent text-[rgba(22,24,35,0.56)] hover:bg-[#f0f1f2]',
+                ].join(' ')}
+              >
+                {label}
+              </button>
+            ))}
+
+            <Dropdown
+              trigger={['click']}
+              placement="bottomLeft"
+              menu={{
+                items: createMenuItems,
+                onClick: handleCreateMenuClick,
+                className: QUICK_CREATE_MENU_CLASS,
+              }}
+            >
+              <Button
+                type="primary"
+                size="small"
+                disabled={!projectId}
+                aria-label="新建节点或目录"
+                icon={<Plus size={15} />}
+                className="!h-7 !w-7 !rounded-md !px-0 shadow-[0_4px_12px_rgba(254,44,85,0.2)]"
+              />
+            </Dropdown>
+          </div>
         </div>
 
-        <Input
-          allowClear
-          variant="filled"
-          prefix={<Search size={14} />}
-          placeholder="搜索名称 / 节点 ID / 修改人"
-          value={explorerKeyword}
-          onChange={(event: ChangeEvent<HTMLInputElement>) =>
-            setExplorerKeyword(event.target.value)
-          }
-          className="mt-2"
-        />
+        <div className="min-h-0 flex-1 overflow-y-auto overflow-x-hidden px-2 pb-2">
+          <div
+            className={`sticky top-0 z-10 grid h-8 items-center gap-x-2 border-b border-[#eceef0] bg-[#fbfbfc] px-2 text-[10px] font-medium text-[rgba(22,24,35,0.38)] ${gridClassName}`}
+          >
+            <span>名称</span>
+            {showUpdatedBy && <span>修改人</span>}
+            {showUpdatedAt && <span className="text-right">修改时间</span>}
+          </div>
 
-        <div className="mt-2 flex items-center gap-1">
-          {[
-            ['all', '全部'],
-            ['owned', '我负责的'],
-          ].map(([value, label]) => (
+          <div className="px-2 pb-1 pt-2 text-[11px] font-semibold text-[rgba(22,24,35,0.48)]">
+            项目目录
+          </div>
+
+          {visibleProjectFolders.map((folder) => (
             <button
-              key={value}
+              key={folder.id}
               type="button"
-              onClick={() => setExplorerFilter(value as ExplorerFilter)}
-              className={[
-                'h-7 flex-1 rounded-md border-0 px-2 text-[11px] transition-colors',
-                explorerFilter === value
-                  ? 'bg-[var(--yak-brand-color-soft)] font-medium text-[var(--yak-brand-color)]'
-                  : 'bg-transparent text-[rgba(22,24,35,0.56)] hover:bg-[#f0f1f2]',
-              ].join(' ')}
+              className="flex h-8 w-full items-center gap-1.5 rounded-[5px] border-0 bg-transparent px-1.5 text-left text-[12px] font-medium text-[rgba(22,24,35,0.76)] hover:bg-[#f2f3f4]"
             >
-              {label}
+              <ChevronRight size={13} className="text-[rgba(22,24,35,0.34)]" />
+              <Folder size={15} className="text-[#f2a800]" />
+              <span className="min-w-0 flex-1 truncate" title={folder.name}>
+                {folder.name}
+              </span>
             </button>
           ))}
 
-          <Dropdown
-            trigger={['click']}
-            menu={{
-              items: createMenuItems,
-              onClick: ({ key }: { key: string }) => onCreate(key),
-            }}
-          >
-            <Button
-              type="primary"
-              size="small"
-              disabled={plugins.length === 0}
-              aria-label="新建开发节点"
-              icon={<Plus size={15} />}
-              className="!h-7 !w-7 !px-0"
-            />
-          </Dropdown>
-        </div>
-      </div>
+          {pluginFolders.map((folder) => {
+            const resourceIds = (resourceIdsByFolder[folder.id] ?? []).filter(
+              (id) => visibleResourceIdSet.has(id),
+            );
+            const expanded = expandedFolderIds[folder.id] ?? true;
 
-      <div className="min-h-0 flex-1 overflow-y-auto overflow-x-hidden px-2 pb-2">
-        <div
-          className={`sticky top-0 z-10 grid h-8 items-center gap-x-2 border-b border-[#eceef0] bg-[#fbfbfc] px-2 text-[10px] font-medium text-[rgba(22,24,35,0.38)] ${gridClassName}`}
-        >
-          <span>名称</span>
-          {showUpdatedBy && <span>修改人</span>}
-          {showUpdatedAt && <span className="text-right">修改时间</span>}
-        </div>
+            if (resourceIds.length === 0 && explorerKeyword) return null;
 
-        <div className="px-2 pb-1 pt-2 text-[11px] font-semibold text-[rgba(22,24,35,0.48)]">
-          项目目录
-        </div>
-
-        {folders.map((folder) => {
-          const resourceIds = (resourceIdsByFolder[folder.id] ?? []).filter(
-            (id) => visibleResourceIdSet.has(id),
-          );
-          const expanded = expandedFolderIds[folder.id] ?? true;
-
-          if (resourceIds.length === 0 && explorerKeyword) return null;
-
-          return (
-            <div key={folder.id} className="mb-0.5">
-              <button
-                type="button"
-                onClick={() => toggleFolder(folder.id)}
-                className="flex h-8 w-full items-center gap-1.5 rounded-[5px] border-0 bg-transparent px-1.5 text-left text-[12px] font-medium text-[rgba(22,24,35,0.76)] hover:bg-[#f2f3f4]"
-              >
-                {expanded ? (
-                  <ChevronDown size={13} />
-                ) : (
-                  <ChevronRight size={13} />
-                )}
-                {expanded ? (
-                  <FolderOpen size={15} className="text-[#f2a800]" />
-                ) : (
-                  <Folder size={15} className="text-[#f2a800]" />
-                )}
-                <span className="min-w-0 flex-1 truncate">{folder.label}</span>
-                <span className="text-[10px] font-normal text-[rgba(22,24,35,0.3)]">
-                  {resourceIds.length}
-                </span>
-              </button>
-
-              {expanded && (
-                <div className="ml-[20px] border-l border-[#e6e8eb] pl-1.5">
-                  {resourceIds.length > 0 ? (
-                    resourceIds.map(renderResourceRow)
+            return (
+              <div key={folder.id} className="mb-0.5">
+                <button
+                  type="button"
+                  onClick={() => toggleFolder(folder.id)}
+                  className="flex h-8 w-full items-center gap-1.5 rounded-[5px] border-0 bg-transparent px-1.5 text-left text-[12px] font-medium text-[rgba(22,24,35,0.76)] hover:bg-[#f2f3f4]"
+                >
+                  {expanded ? (
+                    <ChevronDown size={13} />
                   ) : (
-                    <div className="px-2 py-1 text-[11px] text-[rgba(22,24,35,0.32)]">
-                      暂无节点
-                    </div>
+                    <ChevronRight size={13} />
                   )}
-                </div>
-              )}
-            </div>
-          );
-        })}
-      </div>
+                  {expanded ? (
+                    <FolderOpen size={15} className="text-[#f2a800]" />
+                  ) : (
+                    <Folder size={15} className="text-[#f2a800]" />
+                  )}
+                  <span className="min-w-0 flex-1 truncate">{folder.label}</span>
+                  <span className="text-[10px] font-normal text-[rgba(22,24,35,0.3)]">
+                    {resourceIds.length}
+                  </span>
+                </button>
 
-      <div className="flex h-9 shrink-0 items-center justify-between border-t border-[#e7e9ec] px-3 text-[11px] text-[rgba(22,24,35,0.46)]">
-        <span className="flex items-center gap-1.5">
-          <Trash2 size={13} /> 回收站
-        </span>
-        <span>{Object.keys(resourcesById).length} 个节点</span>
-      </div>
-    </aside>
+                {expanded && (
+                  <div className="ml-[20px] border-l border-[#e6e8eb] pl-1.5">
+                    {resourceIds.length > 0 ? (
+                      resourceIds.map(renderResourceRow)
+                    ) : (
+                      <div className="px-2 py-1 text-[11px] text-[rgba(22,24,35,0.32)]">
+                        暂无节点
+                      </div>
+                    )}
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+
+        <div className="flex h-9 shrink-0 items-center justify-between border-t border-[#e7e9ec] px-3 text-[11px] text-[rgba(22,24,35,0.46)]">
+          <span className="flex items-center gap-1.5">
+            <Trash2 size={13} /> 回收站
+          </span>
+          <span>{Object.keys(resourcesById).length} 个节点</span>
+        </div>
+      </aside>
+
+      <CreateFolderModal
+        open={createFolderOpen}
+        projectId={projectId}
+        onClose={() => setCreateFolderOpen(false)}
+        onCreated={(folder) =>
+          setProjectFolders((current) =>
+            sortProjectFolders([
+              ...current.filter((item) => item.id !== folder.id),
+              folder,
+            ]),
+          )
+        }
+      />
+    </>
   );
 };
 

--- a/yak-ops-ui/src/pages/data-development/workbench/plugins/sql.tsx
+++ b/yak-ops-ui/src/pages/data-development/workbench/plugins/sql.tsx
@@ -22,6 +22,7 @@ export const sqlPlugin: NodePluginDefinition = {
     defaultEngine: 'JDBC SQL',
     engineOptions: [
       { label: 'MySQL', value: 'MySQL' },
+      { label: 'ORACLE', value: 'Oracle' },
       { label: 'PostgreSQL', value: 'PostgreSQL' },
       { label: 'Doris', value: 'Doris' },
       { label: '通用 JDBC', value: 'JDBC SQL' },

--- a/yak-ops-ui/src/pages/data-development/workbench/repository/project-folder.repository.ts
+++ b/yak-ops-ui/src/pages/data-development/workbench/repository/project-folder.repository.ts
@@ -1,0 +1,90 @@
+import HttpUtils from '@/utils/HttpUtils';
+
+const API_PREFIX = '/api/v1/data-development';
+
+interface ApiResponse<T> {
+  code: number;
+  data: T;
+  msg?: string;
+  message?: string;
+}
+
+interface ApiResource {
+  id: number;
+  projectId: number;
+  parentId?: number | null;
+  resourceKind: 'FOLDER' | 'TASK' | 'ASSET';
+  name: string;
+  description?: string;
+  sortOrder: number;
+  updatedBy?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ProjectFolder {
+  id: string;
+  projectId: string;
+  parentId: string | null;
+  name: string;
+  description?: string;
+  sortOrder: number;
+  updatedBy: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+const unwrap = <T>(response: ApiResponse<T>): T => {
+  if (response.code !== 0 && response.code !== 200) {
+    throw new Error(response.message ?? response.msg ?? '目录接口调用失败');
+  }
+  return response.data;
+};
+
+const mapFolder = (resource: ApiResource): ProjectFolder => ({
+  id: String(resource.id),
+  projectId: String(resource.projectId),
+  parentId: resource.parentId ? String(resource.parentId) : null,
+  name: resource.name,
+  description: resource.description,
+  sortOrder: resource.sortOrder,
+  updatedBy: resource.updatedBy ?? 'system',
+  createdAt: resource.createdAt,
+  updatedAt: resource.updatedAt,
+});
+
+const sortFolders = (folders: ProjectFolder[]) =>
+  folders.slice().sort((left, right) => {
+    const order = left.sortOrder - right.sortOrder;
+    return order || left.name.localeCompare(right.name);
+  });
+
+export const projectFolderRepository = {
+  async list(projectId: string): Promise<ProjectFolder[]> {
+    const resources = unwrap(
+      await HttpUtils.get<ApiResource[]>(
+        `${API_PREFIX}/projects/${projectId}/resources`,
+      ),
+    );
+    return sortFolders(
+      resources
+        .filter((resource) => resource.resourceKind === 'FOLDER')
+        .map(mapFolder),
+    );
+  },
+
+  async create(projectId: string, name: string): Promise<ProjectFolder> {
+    const resource = unwrap(
+      await HttpUtils.post<ApiResource>(
+        `${API_PREFIX}/projects/${projectId}/folders`,
+        {
+          parentId: null,
+          name: name.trim(),
+          description: '',
+          sortOrder: 0,
+        },
+      ),
+    );
+    return mapFolder(resource);
+  },
+};


### PR DESCRIPTION
## 变更说明

将数据开发工作台左侧“+”新增入口改为 DataWorks 风格的三级级联菜单，同时保持 Yak Ops 的白底、高密度和品牌色交互，样式全部使用 TailwindCSS。

### 新增入口

```text
新建节点
├── 数据库
│   ├── MySQL
│   └── ORACLE
└── 通用
    └── HTTP 节点

新建目录
```

### 节点创建

- MySQL / ORACLE 复用现有 SQL TaskPlugin，并预选对应执行引擎
- HTTP 节点复用现有 HTTP TaskPlugin
- 新建节点弹窗增加执行引擎选择，菜单预选值仍可手动调整
- SQL 引擎列表补充 ORACLE

### 目录创建

- 接入现有数据开发项目目录 API
- 支持在工作台直接新建根目录
- 加载并展示项目已有目录，创建成功后立即回填目录区域

### 样式

- 三级弹出菜单使用 TailwindCSS utility 和 arbitrary selectors
- 使用 Yak Ops 品牌色 hover、白底、浅边框、圆角和轻阴影
- 未新增独立 CSS / Less 文件

## 验证

已完成：

- TypeScript 5.8 对 6 个新增或修改 TS / TSX 文件执行语法转译检查
- 菜单 key 与 SQL / HTTP TaskPlugin 可用状态静态核对
- 新建目录 API 路径与后端现有接口静态核对
- 分支基于最新 `main`，behind 0，仅包含本次 6 个文件的调整

当前环境没有执行完整依赖感知构建和浏览器交互验证：

```bash
cd yak-ops-ui
npm run tsc
npm run build
```

请在本地或 CI 完成完整类型检查、构建和三级菜单交互验证后再转 Ready。