### PR TITLE
refactor(database): unify Yak Ops business datasource

### DIFF
--- a/yak-ops-boot/src/main/resources/application.yml
+++ b/yak-ops-boot/src/main/resources/application.yml
@@ -5,11 +5,12 @@ server:
 spring:
   application:
     name: yak-ops
-  # 各业务模块分别维护自己的数据源与事务管理器。
+  # Yak Security 保留独立数据源；Yak Ops 业务模块统一复用 yak.database。
   autoconfigure:
     exclude:
       - org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
       - org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration
+  # 各业务模块继续维护独立 Flyway 历史表，但共享同一个业务数据源。
   flyway:
     enabled: false
   servlet:
@@ -74,15 +75,18 @@ yak:
       test-on-borrow: false
       test-on-return: false
 
+  database:
+    enabled: ${YAK_DATABASE_ENABLED:true}
+    # 兼容原 yak.datasource.database、yak.resource.database、yak.sync.offline.datasource 配置及环境变量。
+    url: ${YAK_DATABASE_URL:${yak.datasource.database.url:${yak.resource.database.url:${yak.sync.offline.datasource.url:${YAK_DATASOURCE_URL:${YAK_RESOURCE_DATASOURCE_URL:${YAK_OFFLINE_SYNC_DATASOURCE_URL:${YAK_SECURITY_DATASOURCE_URL:jdbc:mysql://127.0.0.1:3306/yak_security?useUnicode=true&allowPublicKeyRetrieval=true&characterEncoding=UTF-8&useSSL=false&serverTimezone=Asia/Shanghai}}}}}}}}
+    username: ${YAK_DATABASE_USERNAME:${yak.datasource.database.username:${yak.resource.database.username:${yak.sync.offline.datasource.username:${YAK_DATASOURCE_USERNAME:${YAK_RESOURCE_DATASOURCE_USERNAME:${YAK_OFFLINE_SYNC_DATASOURCE_USERNAME:${YAK_SECURITY_DATASOURCE_USERNAME:root}}}}}}}}
+    password: ${YAK_DATABASE_PASSWORD:${yak.datasource.database.password:${yak.resource.database.password:${yak.sync.offline.datasource.password:${YAK_DATASOURCE_PASSWORD:${YAK_RESOURCE_DATASOURCE_PASSWORD:${YAK_OFFLINE_SYNC_DATASOURCE_PASSWORD:${YAK_SECURITY_DATASOURCE_PASSWORD:123456}}}}}}}}
+    driver-class-name: ${YAK_DATABASE_DRIVER:${yak.datasource.database.driver-class-name:${yak.resource.database.driver-class-name:${yak.sync.offline.datasource.driver-class-name:${YAK_DATASOURCE_DRIVER:${YAK_RESOURCE_DATASOURCE_DRIVER:${YAK_OFFLINE_SYNC_DATASOURCE_DRIVER:com.mysql.cj.jdbc.Driver}}}}}}}
+    minimum-idle: ${YAK_DATABASE_MINIMUM_IDLE:${yak.datasource.database.minimum-idle:${yak.resource.database.minimum-idle:${yak.sync.offline.datasource.minimum-idle:1}}}}
+    maximum-pool-size: ${YAK_DATABASE_MAXIMUM_POOL_SIZE:${yak.datasource.database.maximum-pool-size:${yak.resource.database.maximum-pool-size:${yak.sync.offline.datasource.maximum-pool-size:8}}}}
+
   datasource:
     enabled: true
-    database:
-      url: ${YAK_DATASOURCE_URL:${YAK_SECURITY_DATASOURCE_URL:jdbc:mysql://127.0.0.1:3306/yak_security?useUnicode=true&allowPublicKeyRetrieval=true&characterEncoding=UTF-8&useSSL=false&serverTimezone=Asia/Shanghai}}
-      username: ${YAK_DATASOURCE_USERNAME:${YAK_SECURITY_DATASOURCE_USERNAME:root}}
-      password: ${YAK_DATASOURCE_PASSWORD:${YAK_SECURITY_DATASOURCE_PASSWORD:123456}}
-      driver-class-name: ${YAK_DATASOURCE_DRIVER:com.mysql.cj.jdbc.Driver}
-      minimum-idle: 1
-      maximum-pool-size: 8
     connection-test:
       timeout-seconds: ${YAK_DATASOURCE_CONNECT_TIMEOUT_SECONDS:5}
 
@@ -90,13 +94,6 @@ yak:
     enabled: ${YAK_RESOURCE_ENABLED:true}
     max-file-size: ${YAK_RESOURCE_MAX_FILE_BYTES:104857600}
     editable-max-bytes: ${YAK_RESOURCE_EDITABLE_MAX_BYTES:2097152}
-    database:
-      url: ${YAK_RESOURCE_DATASOURCE_URL:${YAK_SECURITY_DATASOURCE_URL:jdbc:mysql://127.0.0.1:3306/yak_security?useUnicode=true&allowPublicKeyRetrieval=true&characterEncoding=UTF-8&useSSL=false&serverTimezone=Asia/Shanghai}}
-      username: ${YAK_RESOURCE_DATASOURCE_USERNAME:${YAK_SECURITY_DATASOURCE_USERNAME:root}}
-      password: ${YAK_RESOURCE_DATASOURCE_PASSWORD:${YAK_SECURITY_DATASOURCE_PASSWORD:123456}}
-      driver-class-name: ${YAK_RESOURCE_DATASOURCE_DRIVER:com.mysql.cj.jdbc.Driver}
-      minimum-idle: 1
-      maximum-pool-size: 8
     storage:
       type: ${YAK_RESOURCE_STORAGE_TYPE:LOCAL}
       local:
@@ -121,13 +118,6 @@ yak:
   sync:
     offline:
       enabled: ${YAK_OFFLINE_SYNC_ENABLED:true}
-      datasource:
-        url: ${YAK_OFFLINE_SYNC_DATASOURCE_URL:${YAK_SECURITY_DATASOURCE_URL:jdbc:mysql://127.0.0.1:3306/yak_security?useUnicode=true&allowPublicKeyRetrieval=true&characterEncoding=UTF-8&useSSL=false&serverTimezone=Asia/Shanghai}}
-        username: ${YAK_OFFLINE_SYNC_DATASOURCE_USERNAME:${YAK_SECURITY_DATASOURCE_USERNAME:root}}
-        password: ${YAK_OFFLINE_SYNC_DATASOURCE_PASSWORD:${YAK_SECURITY_DATASOURCE_PASSWORD:123456}}
-        driver-class-name: ${YAK_OFFLINE_SYNC_DATASOURCE_DRIVER:com.mysql.cj.jdbc.Driver}
-        minimum-idle: 1
-        maximum-pool-size: 8
       engine:
         enabled: ${YAK_LINK_UP_ENABLED:true}
         base-url: ${YAK_LINK_UP_BASE_URL:http://127.0.0.1:18080}

--- a/yak-ops-boot/src/test/resources/application-test.yml
+++ b/yak-ops-boot/src/test/resources/application-test.yml
@@ -20,6 +20,8 @@ yak:
       enabled: false
     bootstrap:
       enabled: false
+  database:
+    enabled: false
   datasource:
     enabled: false
   resource:

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/config/BusinessDatabaseConfiguration.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/config/BusinessDatabaseConfiguration.java
@@ -1,0 +1,108 @@
+package io.yak.ops.business.datasource.config;
+
+import com.baomidou.mybatisplus.annotation.DbType;
+import com.baomidou.mybatisplus.extension.plugins.MybatisPlusInterceptor;
+import com.baomidou.mybatisplus.extension.plugins.inner.PaginationInnerInterceptor;
+import com.baomidou.mybatisplus.extension.spring.MybatisSqlSessionFactoryBean;
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import io.yak.ops.common.mybatis.MybatisPlusFactorySupport;
+import javax.sql.DataSource;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.mybatis.spring.SqlSessionTemplate;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.transaction.PlatformTransactionManager;
+
+/** Yak Ops 业务模块共享的数据源、MyBatis 与事务基础设施。 */
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnProperty(
+    prefix = "yak.database",
+    name = "enabled",
+    havingValue = "true",
+    matchIfMissing = true)
+@EnableConfigurationProperties(BusinessDatabaseProperties.class)
+public class BusinessDatabaseConfiguration {
+
+  @Bean(
+      name = {
+          "yakBusinessDataSource",
+          "opsDataSource",
+          "opsResourceDataSource",
+          "offlineSyncDataSource"
+      },
+      destroyMethod = "close")
+  public HikariDataSource yakBusinessDataSource(BusinessDatabaseProperties properties) {
+    HikariConfig config = new HikariConfig();
+    config.setPoolName("YakBusinessDatabasePool");
+    config.setJdbcUrl(properties.getUrl());
+    config.setUsername(properties.getUsername());
+    config.setPassword(properties.getPassword());
+    config.setDriverClassName(properties.getDriverClassName());
+    config.setMinimumIdle(properties.getMinimumIdle());
+    config.setMaximumPoolSize(properties.getMaximumPoolSize());
+    config.setAutoCommit(true);
+    return new HikariDataSource(config);
+  }
+
+  @Bean(
+      name = {
+          "yakBusinessTransactionManager",
+          "opsDataSourceTransactionManager",
+          "opsResourceTransactionManager",
+          "offlineSyncTransactionManager"
+      })
+  public PlatformTransactionManager yakBusinessTransactionManager(
+      @Qualifier("yakBusinessDataSource") DataSource dataSource) {
+    return new DataSourceTransactionManager(dataSource);
+  }
+
+  @Bean(
+      name = {
+          "yakBusinessSqlSessionFactory",
+          "opsDataSourceSqlSessionFactory",
+          "opsResourceSqlSessionFactory",
+          "offlineSyncSqlSessionFactory"
+      })
+  public SqlSessionFactory yakBusinessSqlSessionFactory(
+      @Qualifier("yakBusinessDataSource") DataSource dataSource) throws Exception {
+    MybatisSqlSessionFactoryBean factory = new MybatisSqlSessionFactoryBean();
+    factory.setDataSource(dataSource);
+    factory.setTypeAliasesPackage(
+        "io.yak.ops.common.bean.po.datasource,"
+            + "io.yak.ops.common.bean.po.resource,"
+            + "io.yak.ops.common.bean.po.sync.offline");
+
+    Resource[] mapperLocations = new PathMatchingResourcePatternResolver()
+        .getResources("classpath*:mapper/datasource/*.xml");
+    if (mapperLocations.length > 0) {
+      factory.setMapperLocations(mapperLocations);
+    }
+
+    factory.setConfiguration(MybatisPlusFactorySupport.createConfiguration());
+    factory.setGlobalConfig(MybatisPlusFactorySupport.createGlobalConfig());
+
+    MybatisPlusInterceptor interceptor = new MybatisPlusInterceptor();
+    interceptor.addInnerInterceptor(new PaginationInnerInterceptor(DbType.MYSQL));
+    factory.setPlugins(interceptor);
+    return factory.getObject();
+  }
+
+  @Bean(
+      name = {
+          "yakBusinessSqlSessionTemplate",
+          "opsDataSourceSqlSessionTemplate",
+          "opsResourceSqlSessionTemplate",
+          "offlineSyncSqlSessionTemplate"
+      })
+  public SqlSessionTemplate yakBusinessSqlSessionTemplate(
+      @Qualifier("yakBusinessSqlSessionFactory") SqlSessionFactory sqlSessionFactory) {
+    return new SqlSessionTemplate(sqlSessionFactory);
+  }
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/config/BusinessDatabaseProperties.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/config/BusinessDatabaseProperties.java
@@ -1,0 +1,75 @@
+package io.yak.ops.business.datasource.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/** Yak Ops 业务模块共享数据库配置。 */
+@ConfigurationProperties(prefix = "yak.database")
+public class BusinessDatabaseProperties {
+
+  private boolean enabled = true;
+  private String url =
+      "jdbc:mysql://127.0.0.1:3306/yak_security"
+          + "?useUnicode=true&allowPublicKeyRetrieval=true&characterEncoding=UTF-8"
+          + "&useSSL=false&serverTimezone=Asia/Shanghai";
+  private String username = "root";
+  private String password = "123456";
+  private String driverClassName = "com.mysql.cj.jdbc.Driver";
+  private int minimumIdle = 1;
+  private int maximumPoolSize = 8;
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  public String getUrl() {
+    return url;
+  }
+
+  public void setUrl(String url) {
+    this.url = url;
+  }
+
+  public String getUsername() {
+    return username;
+  }
+
+  public void setUsername(String username) {
+    this.username = username;
+  }
+
+  public String getPassword() {
+    return password;
+  }
+
+  public void setPassword(String password) {
+    this.password = password;
+  }
+
+  public String getDriverClassName() {
+    return driverClassName;
+  }
+
+  public void setDriverClassName(String driverClassName) {
+    this.driverClassName = driverClassName;
+  }
+
+  public int getMinimumIdle() {
+    return minimumIdle;
+  }
+
+  public void setMinimumIdle(int minimumIdle) {
+    this.minimumIdle = minimumIdle;
+  }
+
+  public int getMaximumPoolSize() {
+    return maximumPoolSize;
+  }
+
+  public void setMaximumPoolSize(int maximumPoolSize) {
+    this.maximumPoolSize = maximumPoolSize;
+  }
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/config/DataSourceConfiguration.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/config/DataSourceConfiguration.java
@@ -1,87 +1,28 @@
 package io.yak.ops.business.datasource.config;
 
-import com.baomidou.mybatisplus.annotation.DbType;
-import com.baomidou.mybatisplus.extension.plugins.MybatisPlusInterceptor;
-import com.baomidou.mybatisplus.extension.plugins.inner.PaginationInnerInterceptor;
-import com.baomidou.mybatisplus.extension.spring.MybatisSqlSessionFactoryBean;
-import com.zaxxer.hikari.HikariConfig;
-import com.zaxxer.hikari.HikariDataSource;
-import io.yak.ops.common.mybatis.MybatisPlusFactorySupport;
 import javax.sql.DataSource;
-import org.apache.ibatis.session.SqlSessionFactory;
 import org.flywaydb.core.Flyway;
 import org.flywaydb.core.api.MigrationVersion;
-import org.mybatis.spring.SqlSessionTemplate;
 import org.mybatis.spring.annotation.MapperScan;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.io.Resource;
-import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
-import org.springframework.jdbc.datasource.DataSourceTransactionManager;
-import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.context.annotation.Import;
 
 /** 数据源管理模块基础设施配置。 */
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnDataSourceEnabled
 @EnableConfigurationProperties(DataSourceProperties.class)
+@Import(BusinessDatabaseConfiguration.class)
 @MapperScan(
     basePackages = "io.yak.ops.business.datasource.dao.mapper",
-    sqlSessionFactoryRef = "opsDataSourceSqlSessionFactory")
+    sqlSessionFactoryRef = "yakBusinessSqlSessionFactory")
 public class DataSourceConfiguration {
 
-  @Bean(name = "opsDataSource", destroyMethod = "close")
-  public HikariDataSource opsDataSource(DataSourceProperties properties) {
-    DataSourceProperties.Database database = properties.getDatabase();
-    HikariConfig config = new HikariConfig();
-    config.setPoolName("YakOpsDatasourcePool");
-    config.setJdbcUrl(database.getUrl());
-    config.setUsername(database.getUsername());
-    config.setPassword(database.getPassword());
-    config.setDriverClassName(database.getDriverClassName());
-    config.setMinimumIdle(database.getMinimumIdle());
-    config.setMaximumPoolSize(database.getMaximumPoolSize());
-    config.setAutoCommit(true);
-    return new HikariDataSource(config);
-  }
-
-  @Bean(name = "opsDataSourceTransactionManager")
-  public PlatformTransactionManager opsDataSourceTransactionManager(
-      @Qualifier("opsDataSource") DataSource dataSource) {
-    return new DataSourceTransactionManager(dataSource);
-  }
-
-  @Bean(name = "opsDataSourceSqlSessionFactory")
-  public SqlSessionFactory opsDataSourceSqlSessionFactory(
-      @Qualifier("opsDataSource") DataSource dataSource) throws Exception {
-    MybatisSqlSessionFactoryBean factory = new MybatisSqlSessionFactoryBean();
-    factory.setDataSource(dataSource);
-    factory.setTypeAliasesPackage("io.yak.ops.common.bean.po.datasource");
-
-    Resource[] mapperLocations = new PathMatchingResourcePatternResolver()
-        .getResources("classpath*:mapper/datasource/*.xml");
-    if (mapperLocations.length > 0) {
-      factory.setMapperLocations(mapperLocations);
-    }
-
-    factory.setConfiguration(MybatisPlusFactorySupport.createConfiguration());
-    factory.setGlobalConfig(MybatisPlusFactorySupport.createGlobalConfig());
-
-    MybatisPlusInterceptor interceptor = new MybatisPlusInterceptor();
-    interceptor.addInnerInterceptor(new PaginationInnerInterceptor(DbType.MYSQL));
-    factory.setPlugins(interceptor);
-    return factory.getObject();
-  }
-
-  @Bean(name = "opsDataSourceSqlSessionTemplate")
-  public SqlSessionTemplate opsDataSourceSqlSessionTemplate(
-      @Qualifier("opsDataSourceSqlSessionFactory") SqlSessionFactory sqlSessionFactory) {
-    return new SqlSessionTemplate(sqlSessionFactory);
-  }
-
   @Bean(initMethod = "migrate")
-  public Flyway opsDataSourceFlyway(@Qualifier("opsDataSource") DataSource dataSource) {
+  public Flyway opsDataSourceFlyway(
+      @Qualifier("yakBusinessDataSource") DataSource dataSource) {
     return Flyway.configure()
         .dataSource(dataSource)
         .locations("classpath:db/migration/yak-datasource")

--- a/yak-ops-business/yak-ops-business-resource/pom.xml
+++ b/yak-ops-business/yak-ops-business-resource/pom.xml
@@ -23,6 +23,10 @@
         </dependency>
         <dependency>
             <groupId>io.yak.ops</groupId>
+            <artifactId>yak-ops-business-datasource</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.yak.ops</groupId>
             <artifactId>yak-ops-spi</artifactId>
         </dependency>
         <dependency>

--- a/yak-ops-business/yak-ops-business-resource/src/main/java/io/yak/ops/business/resource/config/ResourceConfiguration.java
+++ b/yak-ops-business/yak-ops-business-resource/src/main/java/io/yak/ops/business/resource/config/ResourceConfiguration.java
@@ -1,78 +1,29 @@
 package io.yak.ops.business.resource.config;
 
-import com.baomidou.mybatisplus.annotation.DbType;
-import com.baomidou.mybatisplus.extension.plugins.MybatisPlusInterceptor;
-import com.baomidou.mybatisplus.extension.plugins.inner.PaginationInnerInterceptor;
-import com.baomidou.mybatisplus.extension.spring.MybatisSqlSessionFactoryBean;
-import com.zaxxer.hikari.HikariConfig;
-import com.zaxxer.hikari.HikariDataSource;
-import io.yak.ops.common.mybatis.MybatisPlusFactorySupport;
+import io.yak.ops.business.datasource.config.BusinessDatabaseConfiguration;
 import javax.sql.DataSource;
-import org.apache.ibatis.session.SqlSessionFactory;
 import org.flywaydb.core.Flyway;
 import org.flywaydb.core.api.MigrationVersion;
-import org.mybatis.spring.SqlSessionTemplate;
 import org.mybatis.spring.annotation.MapperScan;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.jdbc.datasource.DataSourceTransactionManager;
-import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.context.annotation.Import;
 
 /** 资源管理模块基础设施配置。 */
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnResourceEnabled
 @EnableConfigurationProperties(ResourceProperties.class)
+@Import(BusinessDatabaseConfiguration.class)
 @MapperScan(
     basePackages = "io.yak.ops.business.resource.dao.mapper",
-    sqlSessionFactoryRef = "opsResourceSqlSessionFactory")
+    sqlSessionFactoryRef = "yakBusinessSqlSessionFactory")
 public class ResourceConfiguration {
 
-  @Bean(name = "opsResourceDataSource", destroyMethod = "close")
-  public HikariDataSource opsResourceDataSource(ResourceProperties properties) {
-    ResourceProperties.Database database = properties.getDatabase();
-    HikariConfig config = new HikariConfig();
-    config.setPoolName("YakOpsResourcePool");
-    config.setJdbcUrl(database.getUrl());
-    config.setUsername(database.getUsername());
-    config.setPassword(database.getPassword());
-    config.setDriverClassName(database.getDriverClassName());
-    config.setMinimumIdle(database.getMinimumIdle());
-    config.setMaximumPoolSize(database.getMaximumPoolSize());
-    config.setAutoCommit(true);
-    return new HikariDataSource(config);
-  }
-
-  @Bean(name = "opsResourceTransactionManager")
-  public PlatformTransactionManager opsResourceTransactionManager(
-      @Qualifier("opsResourceDataSource") DataSource dataSource) {
-    return new DataSourceTransactionManager(dataSource);
-  }
-
-  @Bean(name = "opsResourceSqlSessionFactory")
-  public SqlSessionFactory opsResourceSqlSessionFactory(
-      @Qualifier("opsResourceDataSource") DataSource dataSource) throws Exception {
-    MybatisSqlSessionFactoryBean factory = new MybatisSqlSessionFactoryBean();
-    factory.setDataSource(dataSource);
-    factory.setTypeAliasesPackage("io.yak.ops.common.bean.po.resource");
-    factory.setConfiguration(MybatisPlusFactorySupport.createConfiguration());
-    factory.setGlobalConfig(MybatisPlusFactorySupport.createGlobalConfig());
-
-    MybatisPlusInterceptor interceptor = new MybatisPlusInterceptor();
-    interceptor.addInnerInterceptor(new PaginationInnerInterceptor(DbType.MYSQL));
-    factory.setPlugins(interceptor);
-    return factory.getObject();
-  }
-
-  @Bean(name = "opsResourceSqlSessionTemplate")
-  public SqlSessionTemplate opsResourceSqlSessionTemplate(
-      @Qualifier("opsResourceSqlSessionFactory") SqlSessionFactory sqlSessionFactory) {
-    return new SqlSessionTemplate(sqlSessionFactory);
-  }
-
   @Bean(initMethod = "migrate")
-  public Flyway opsResourceFlyway(@Qualifier("opsResourceDataSource") DataSource dataSource) {
+  public Flyway opsResourceFlyway(
+      @Qualifier("yakBusinessDataSource") DataSource dataSource) {
     return Flyway.configure()
         .dataSource(dataSource)
         .locations("classpath:db/migration/yak-resource")

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/config/OfflineSyncConfiguration.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/config/OfflineSyncConfiguration.java
@@ -1,80 +1,34 @@
 package io.yak.ops.business.sync.offline.config;
 
-import com.baomidou.mybatisplus.annotation.DbType;
-import com.baomidou.mybatisplus.extension.plugins.MybatisPlusInterceptor;
-import com.baomidou.mybatisplus.extension.plugins.inner.PaginationInnerInterceptor;
-import com.baomidou.mybatisplus.extension.spring.MybatisSqlSessionFactoryBean;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.zaxxer.hikari.HikariConfig;
-import com.zaxxer.hikari.HikariDataSource;
-import io.yak.ops.common.mybatis.MybatisPlusFactorySupport;
+import io.yak.ops.business.datasource.config.BusinessDatabaseConfiguration;
 import java.net.http.HttpClient;
 import javax.sql.DataSource;
-import org.apache.ibatis.session.SqlSessionFactory;
 import org.flywaydb.core.Flyway;
 import org.flywaydb.core.api.MigrationVersion;
-import org.mybatis.spring.SqlSessionTemplate;
 import org.mybatis.spring.annotation.MapperScan;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.context.annotation.Import;
 import org.springframework.scheduling.annotation.EnableScheduling;
-import org.springframework.transaction.PlatformTransactionManager;
 
 /** 离线同步一期基础设施配置。 */
 @ConditionalOnOfflineSyncEnabled
 @Configuration(proxyBeanMethods = false)
 @EnableScheduling
 @EnableConfigurationProperties(OfflineSyncProperties.class)
-@MapperScan(basePackages = "io.yak.ops.business.sync.offline.dao.mapper",
-    sqlSessionFactoryRef = "offlineSyncSqlSessionFactory")
+@Import(BusinessDatabaseConfiguration.class)
+@MapperScan(
+    basePackages = "io.yak.ops.business.sync.offline.dao.mapper",
+    sqlSessionFactoryRef = "yakBusinessSqlSessionFactory")
 public class OfflineSyncConfiguration {
 
-  @Bean(name = "offlineSyncDataSource", destroyMethod = "close")
-  public HikariDataSource offlineSyncDataSource(OfflineSyncProperties properties) {
-    OfflineSyncProperties.Datasource datasource = properties.getDatasource();
-    HikariConfig config = new HikariConfig();
-    config.setPoolName("YakOfflineSyncPool");
-    config.setJdbcUrl(datasource.getUrl());
-    config.setUsername(datasource.getUsername());
-    config.setPassword(datasource.getPassword());
-    config.setDriverClassName(datasource.getDriverClassName());
-    config.setMaximumPoolSize(datasource.getMaximumPoolSize());
-    config.setMinimumIdle(datasource.getMinimumIdle());
-    return new HikariDataSource(config);
-  }
-
-  @Bean(name = "offlineSyncTransactionManager")
-  public PlatformTransactionManager offlineSyncTransactionManager(
-      @Qualifier("offlineSyncDataSource") DataSource dataSource) {
-    return new DataSourceTransactionManager(dataSource);
-  }
-
-  @Bean(name = "offlineSyncSqlSessionFactory")
-  public SqlSessionFactory offlineSyncSqlSessionFactory(
-      @Qualifier("offlineSyncDataSource") DataSource dataSource) throws Exception {
-    MybatisSqlSessionFactoryBean factory = new MybatisSqlSessionFactoryBean();
-    factory.setDataSource(dataSource);
-    factory.setTypeAliasesPackage("io.yak.ops.common.bean.po.sync.offline");
-    factory.setConfiguration(MybatisPlusFactorySupport.createConfiguration());
-    factory.setGlobalConfig(MybatisPlusFactorySupport.createGlobalConfig());
-    MybatisPlusInterceptor interceptor = new MybatisPlusInterceptor();
-    interceptor.addInnerInterceptor(new PaginationInnerInterceptor(DbType.MYSQL));
-    factory.setPlugins(interceptor);
-    return factory.getObject();
-  }
-
-  @Bean(name = "offlineSyncSqlSessionTemplate")
-  public SqlSessionTemplate offlineSyncSqlSessionTemplate(
-      @Qualifier("offlineSyncSqlSessionFactory") SqlSessionFactory factory) {
-    return new SqlSessionTemplate(factory);
-  }
-
   @Bean(initMethod = "migrate")
-  public Flyway offlineSyncFlyway(@Qualifier("offlineSyncDataSource") DataSource dataSource) {
+  public Flyway offlineSyncFlyway(
+      @Qualifier("yakBusinessDataSource") DataSource dataSource) {
     return Flyway.configure()
         .dataSource(dataSource)
         .locations("classpath:db/migration/yak-offline-sync")


### PR DESCRIPTION
## What changed

- Added a single `yak.database` configuration for Yak Ops business persistence.
- Reused one Hikari `DataSource`, one MyBatis `SqlSessionFactory`, one `SqlSessionTemplate`, and one transaction manager across datasource, resource, and offline-sync modules.
- Kept the former datasource, session factory, template, and transaction-manager bean names as aliases to the same shared instances.
- Kept each module's Flyway location and schema-history table independent while running migrations against the shared business database.
- Removed `yak.resource.database` and `yak.sync.offline.datasource` from the default application configuration.
- Added compatibility fallbacks for the former property paths and environment variables.
- Kept Yak Security on its existing independent datasource.

## Why

The three business modules previously created separate pools and transaction managers even though their default URLs pointed to the same physical database. This increased connection usage and made cross-module transaction boundaries unnecessarily complex.

## Impact

Existing `@Transactional` qualifiers and Mapper references continue to work through bean aliases. New deployments should use `yak.database.*` or `YAK_DATABASE_*`; legacy datasource settings remain accepted as fallbacks. If multiple legacy datasource configurations are supplied, the compatibility fallback order is datasource, resource, then offline sync.

## Validation

- Compared the branch against `main`; the change is limited to shared persistence configuration, module wiring, and application configuration.
- GitHub reports the branch as mergeable.
- No GitHub Actions workflow runs or commit status checks were registered for the head commit, so the PR remains draft pending a local Maven build and startup verification.