### PR TITLE
feat(offline-sync): add single-table data preview

### DIFF
--- a/yak-ops-ui/src/pages/batch-link-up/detail/components/SingleTableConfigSection.tsx
+++ b/yak-ops-ui/src/pages/batch-link-up/detail/components/SingleTableConfigSection.tsx
@@ -1,20 +1,24 @@
 import {
   DatabaseOutlined,
+  EyeOutlined,
   ExportOutlined,
 } from '@ant-design/icons';
 import {
+  Button,
   Input,
   Segmented,
   Select,
   Spin,
   Switch,
 } from 'antd';
-import type { ChangeEvent, ReactNode } from 'react';
+import { useState, type ChangeEvent, type ReactNode } from 'react';
 
 import type { DataSourceColumnOption } from '../hooks/useDataSourceColumns';
 import EditorSection from './EditorSection';
+import SingleTablePreviewModal from './SingleTablePreviewModal';
 
 interface SingleTableConfigSectionProps {
+  sourceDataSourceId?: string | number;
   sourceConfig: Record<string, any>;
   sinkConfig: Record<string, any>;
   sourceTables: string[];
@@ -67,6 +71,7 @@ const splitPrimaryKeys = (value: unknown): string[] =>
     .filter(Boolean);
 
 export default function SingleTableConfigSection({
+  sourceDataSourceId,
   sourceConfig,
   sinkConfig,
   sourceTables,
@@ -82,163 +87,189 @@ export default function SingleTableConfigSection({
   onSourceChange,
   onSinkChange,
 }: SingleTableConfigSectionProps) {
+  const [previewOpen, setPreviewOpen] = useState(false);
+  const sourceReadMode = sourceConfig.readMode === 'sql' ? 'sql' : 'table';
+  const previewDisabled =
+    !sourceDataSourceId ||
+    (sourceReadMode === 'sql'
+      ? !String(sourceConfig.sql || '').trim()
+      : !String(sourceConfig.table || '').trim());
+
   return (
-    <EditorSection title="单表同步配置">
-      <div className="grid grid-cols-2 items-start gap-5 max-lg:grid-cols-1">
-        <EndpointPanel icon={<DatabaseOutlined />} title="Source 来源配置">
-          <div>
-            <FieldLabel>读取方式</FieldLabel>
-            <Segmented
+    <>
+      <EditorSection title="单表同步配置">
+        <div className="grid grid-cols-2 items-start gap-5 max-lg:grid-cols-1">
+          <EndpointPanel icon={<DatabaseOutlined />} title="Source 来源配置">
+            <div>
+              <FieldLabel>读取方式</FieldLabel>
+              <Segmented
+                block
+                value={sourceConfig.readMode || 'table'}
+                options={[
+                  { label: '选择数据表', value: 'table' },
+                  { label: '自定义 SQL', value: 'sql' },
+                ]}
+                onChange={(readMode: string | number) =>
+                  onSourceChange({
+                    readMode,
+                    ...(readMode === 'table' ? { sql: '' } : { table: '' }),
+                  })
+                }
+              />
+            </div>
+
+            {sourceConfig.readMode === 'sql' ? (
+              <div>
+                <FieldLabel required>查询 SQL</FieldLabel>
+                <Input.TextArea
+                  rows={10}
+                  variant="filled"
+                  value={sourceConfig.sql || ''}
+                  placeholder="SELECT * FROM source_table"
+                  className="font-mono"
+                  onChange={(event: ChangeEvent<HTMLTextAreaElement>) => onSourceChange({ sql: event.target.value })}
+                />
+              </div>
+            ) : (
+              <div>
+                <FieldLabel required>来源表</FieldLabel>
+                <Select
+                  showSearch
+                  variant="filled"
+                  disabled={!sourceReady}
+                  value={sourceConfig.table || undefined}
+                  options={sourceTables.map((table) => ({ label: table, value: table }))}
+                  loading={sourceLoading}
+                  notFoundContent={sourceLoading ? <Spin size="small" /> : undefined}
+                  placeholder={sourceReady ? '请选择来源表' : '请先选择来源数据源'}
+                  optionFilterProp="label"
+                  className="w-full"
+                  onChange={(table: string) => onSourceChange({ table })}
+                />
+              </div>
+            )}
+
+            <Button
               block
-              value={sourceConfig.readMode || 'table'}
-              options={[
-                { label: '选择数据表', value: 'table' },
-                { label: '自定义 SQL', value: 'sql' },
-              ]}
-              onChange={(readMode: string | number) =>
-                onSourceChange({
-                  readMode,
-                  ...(readMode === 'table' ? { sql: '' } : { table: '' }),
-                })
-              }
-            />
-          </div>
+              icon={<EyeOutlined />}
+              disabled={previewDisabled}
+              onClick={() => setPreviewOpen(true)}
+            >
+              数据预览
+            </Button>
 
-          {sourceConfig.readMode === 'sql' ? (
-            <div>
-              <FieldLabel required>查询 SQL</FieldLabel>
-              <Input.TextArea
-                rows={10}
-                variant="filled"
-                value={sourceConfig.sql || ''}
-                placeholder="SELECT * FROM source_table"
-                className="font-mono"
-                onChange={(event: ChangeEvent<HTMLTextAreaElement>) => onSourceChange({ sql: event.target.value })}
-              />
-            </div>
-          ) : (
-            <div>
-              <FieldLabel required>来源表</FieldLabel>
-              <Select
-                showSearch
-                variant="filled"
-                disabled={!sourceReady}
-                value={sourceConfig.table || undefined}
-                options={sourceTables.map((table) => ({ label: table, value: table }))}
-                loading={sourceLoading}
-                notFoundContent={sourceLoading ? <Spin size="small" /> : undefined}
-                placeholder={sourceReady ? '请选择来源表' : '请先选择来源数据源'}
-                optionFilterProp="label"
-                className="w-full"
-                onChange={(table: string) => onSourceChange({ table })}
-              />
-            </div>
-          )}
+            {sourceExtraParameters}
+          </EndpointPanel>
 
-          {sourceExtraParameters}
-        </EndpointPanel>
-
-        <EndpointPanel icon={<ExportOutlined />} title="Sink 目标配置">
-          <div className="flex items-center justify-between rounded-lg bg-[#f5f5f6] px-3.5 py-3">
-            <div className="text-[12px] font-medium text-[#475467]">自动创建目标表</div>
-            <Switch
-              checked={Boolean(sinkConfig.autoCreateTable)}
-              onChange={(autoCreateTable: boolean) =>
-                onSinkChange({
-                  autoCreateTable,
-                  table: '',
-                  targetTableName: '',
-                  primaryKey: '',
-                })
-              }
-            />
-          </div>
-
-          {sinkConfig.autoCreateTable ? (
-            <div>
-              <FieldLabel required>目标表名</FieldLabel>
-              <Input
-                variant="filled"
-                disabled={!targetReady}
-                value={sinkConfig.targetTableName || ''}
-                placeholder={targetReady ? '请输入需要创建的目标表名' : '请先选择目标数据源'}
-                onChange={(event: ChangeEvent<HTMLInputElement>) => onSinkChange({ targetTableName: event.target.value })}
-              />
-            </div>
-          ) : (
-            <div>
-              <FieldLabel required>目标表</FieldLabel>
-              <Select
-                showSearch
-                variant="filled"
-                disabled={!targetReady}
-                value={sinkConfig.table || undefined}
-                options={targetTables.map((table) => ({ label: table, value: table }))}
-                loading={targetLoading}
-                placeholder={targetReady ? '请选择目标表' : '请先选择目标数据源'}
-                optionFilterProp="label"
-                className="w-full"
-                onChange={(table: string) => onSinkChange({ table, primaryKey: '' })}
-              />
-            </div>
-          )}
-
-          <div>
-            <FieldLabel required>写入模式</FieldLabel>
-            <Select
-              variant="filled"
-              value={sinkConfig.writeMode || 'append'}
-              options={[
-                { label: '追加写入 Append', value: 'append' },
-                { label: '覆盖写入 Overwrite', value: 'overwrite' },
-                { label: '主键更新 Upsert', value: 'upsert' },
-              ]}
-              className="w-full"
-              onChange={(writeMode: string) =>
-                onSinkChange({
-                  writeMode,
-                  ...(writeMode === 'upsert' ? {} : { primaryKey: '' }),
-                })
-              }
-            />
-          </div>
-
-          {sinkConfig.writeMode === 'upsert' ? (
-            <div>
-              <FieldLabel required>主键字段</FieldLabel>
-              <Select
-                mode="tags"
-                allowClear
-                showSearch
-                variant="filled"
-                value={splitPrimaryKeys(sinkConfig.primaryKey)}
-                loading={primaryKeyLoading}
-                disabled={!targetReady}
-                options={primaryKeyOptions.map((option) => ({
-                  label: option.description
-                    ? `${option.label} · ${option.description}`
-                    : option.label,
-                  value: option.value,
-                }))}
-                placeholder={
-                  primaryKeyLoading
-                    ? '正在加载字段'
-                    : primaryKeyOptions.length > 0
-                      ? '请选择一个或多个主键字段'
-                      : '请先选择来源或目标表'
-                }
-                optionFilterProp="label"
-                className="w-full"
-                onChange={(primaryKeys: string[]) =>
-                  onSinkChange({ primaryKey: primaryKeys.join(',') })
+          <EndpointPanel icon={<ExportOutlined />} title="Sink 目标配置">
+            <div className="flex items-center justify-between rounded-lg bg-[#f5f5f6] px-3.5 py-3">
+              <div className="text-[12px] font-medium text-[#475467]">自动创建目标表</div>
+              <Switch
+                checked={Boolean(sinkConfig.autoCreateTable)}
+                onChange={(autoCreateTable: boolean) =>
+                  onSinkChange({
+                    autoCreateTable,
+                    table: '',
+                    targetTableName: '',
+                    primaryKey: '',
+                  })
                 }
               />
             </div>
-          ) : null}
 
-          {sinkExtraParameters}
-        </EndpointPanel>
-      </div>
-    </EditorSection>
+            {sinkConfig.autoCreateTable ? (
+              <div>
+                <FieldLabel required>目标表名</FieldLabel>
+                <Input
+                  variant="filled"
+                  disabled={!targetReady}
+                  value={sinkConfig.targetTableName || ''}
+                  placeholder={targetReady ? '请输入需要创建的目标表名' : '请先选择目标数据源'}
+                  onChange={(event: ChangeEvent<HTMLInputElement>) => onSinkChange({ targetTableName: event.target.value })}
+                />
+              </div>
+            ) : (
+              <div>
+                <FieldLabel required>目标表</FieldLabel>
+                <Select
+                  showSearch
+                  variant="filled"
+                  disabled={!targetReady}
+                  value={sinkConfig.table || undefined}
+                  options={targetTables.map((table) => ({ label: table, value: table }))}
+                  loading={targetLoading}
+                  placeholder={targetReady ? '请选择目标表' : '请先选择目标数据源'}
+                  optionFilterProp="label"
+                  className="w-full"
+                  onChange={(table: string) => onSinkChange({ table, primaryKey: '' })}
+                />
+              </div>
+            )}
+
+            <div>
+              <FieldLabel required>写入模式</FieldLabel>
+              <Select
+                variant="filled"
+                value={sinkConfig.writeMode || 'append'}
+                options={[
+                  { label: '追加写入 Append', value: 'append' },
+                  { label: '覆盖写入 Overwrite', value: 'overwrite' },
+                  { label: '主键更新 Upsert', value: 'upsert' },
+                ]}
+                className="w-full"
+                onChange={(writeMode: string) =>
+                  onSinkChange({
+                    writeMode,
+                    ...(writeMode === 'upsert' ? {} : { primaryKey: '' }),
+                  })
+                }
+              />
+            </div>
+
+            {sinkConfig.writeMode === 'upsert' ? (
+              <div>
+                <FieldLabel required>主键字段</FieldLabel>
+                <Select
+                  mode="tags"
+                  allowClear
+                  showSearch
+                  variant="filled"
+                  value={splitPrimaryKeys(sinkConfig.primaryKey)}
+                  loading={primaryKeyLoading}
+                  disabled={!targetReady}
+                  options={primaryKeyOptions.map((option) => ({
+                    label: option.description
+                      ? `${option.label} · ${option.description}`
+                      : option.label,
+                    value: option.value,
+                  }))}
+                  placeholder={
+                    primaryKeyLoading
+                      ? '正在加载字段'
+                      : primaryKeyOptions.length > 0
+                        ? '请选择一个或多个主键字段'
+                        : '请先选择来源或目标表'
+                  }
+                  optionFilterProp="label"
+                  className="w-full"
+                  onChange={(primaryKeys: string[]) =>
+                    onSinkChange({ primaryKey: primaryKeys.join(',') })
+                  }
+                />
+              </div>
+            ) : null}
+
+            {sinkExtraParameters}
+          </EndpointPanel>
+        </div>
+      </EditorSection>
+
+      <SingleTablePreviewModal
+        open={previewOpen}
+        dataSourceId={sourceDataSourceId}
+        sourceConfig={sourceConfig}
+        onCancel={() => setPreviewOpen(false)}
+      />
+    </>
   );
 }

--- a/yak-ops-ui/src/pages/batch-link-up/detail/components/SingleTableConfigSection.tsx
+++ b/yak-ops-ui/src/pages/batch-link-up/detail/components/SingleTableConfigSection.tsx
@@ -96,173 +96,171 @@ export default function SingleTableConfigSection({
       : !String(sourceConfig.table || '').trim());
 
   return (
-    <>
-      <EditorSection title="单表同步配置">
-        <div className="grid grid-cols-2 items-start gap-5 max-lg:grid-cols-1">
-          <EndpointPanel icon={<DatabaseOutlined />} title="Source 来源配置">
-            <div>
-              <FieldLabel>读取方式</FieldLabel>
-              <Segmented
-                block
-                value={sourceConfig.readMode || 'table'}
-                options={[
-                  { label: '选择数据表', value: 'table' },
-                  { label: '自定义 SQL', value: 'sql' },
-                ]}
-                onChange={(readMode: string | number) =>
-                  onSourceChange({
-                    readMode,
-                    ...(readMode === 'table' ? { sql: '' } : { table: '' }),
-                  })
-                }
-              />
-            </div>
-
-            {sourceConfig.readMode === 'sql' ? (
-              <div>
-                <FieldLabel required>查询 SQL</FieldLabel>
-                <Input.TextArea
-                  rows={10}
-                  variant="filled"
-                  value={sourceConfig.sql || ''}
-                  placeholder="SELECT * FROM source_table"
-                  className="font-mono"
-                  onChange={(event: ChangeEvent<HTMLTextAreaElement>) => onSourceChange({ sql: event.target.value })}
-                />
-              </div>
-            ) : (
-              <div>
-                <FieldLabel required>来源表</FieldLabel>
-                <Select
-                  showSearch
-                  variant="filled"
-                  disabled={!sourceReady}
-                  value={sourceConfig.table || undefined}
-                  options={sourceTables.map((table) => ({ label: table, value: table }))}
-                  loading={sourceLoading}
-                  notFoundContent={sourceLoading ? <Spin size="small" /> : undefined}
-                  placeholder={sourceReady ? '请选择来源表' : '请先选择来源数据源'}
-                  optionFilterProp="label"
-                  className="w-full"
-                  onChange={(table: string) => onSourceChange({ table })}
-                />
-              </div>
-            )}
-
-            <Button
+    <EditorSection title="单表同步配置">
+      <div className="grid grid-cols-2 items-start gap-5 max-lg:grid-cols-1">
+        <EndpointPanel icon={<DatabaseOutlined />} title="Source 来源配置">
+          <div>
+            <FieldLabel>读取方式</FieldLabel>
+            <Segmented
               block
-              icon={<EyeOutlined />}
-              disabled={previewDisabled}
-              onClick={() => setPreviewOpen(true)}
-            >
-              数据预览
-            </Button>
+              value={sourceConfig.readMode || 'table'}
+              options={[
+                { label: '选择数据表', value: 'table' },
+                { label: '自定义 SQL', value: 'sql' },
+              ]}
+              onChange={(readMode: string | number) =>
+                onSourceChange({
+                  readMode,
+                  ...(readMode === 'table' ? { sql: '' } : { table: '' }),
+                })
+              }
+            />
+          </div>
 
-            {sourceExtraParameters}
-          </EndpointPanel>
-
-          <EndpointPanel icon={<ExportOutlined />} title="Sink 目标配置">
-            <div className="flex items-center justify-between rounded-lg bg-[#f5f5f6] px-3.5 py-3">
-              <div className="text-[12px] font-medium text-[#475467]">自动创建目标表</div>
-              <Switch
-                checked={Boolean(sinkConfig.autoCreateTable)}
-                onChange={(autoCreateTable: boolean) =>
-                  onSinkChange({
-                    autoCreateTable,
-                    table: '',
-                    targetTableName: '',
-                    primaryKey: '',
-                  })
-                }
-              />
-            </div>
-
-            {sinkConfig.autoCreateTable ? (
-              <div>
-                <FieldLabel required>目标表名</FieldLabel>
-                <Input
-                  variant="filled"
-                  disabled={!targetReady}
-                  value={sinkConfig.targetTableName || ''}
-                  placeholder={targetReady ? '请输入需要创建的目标表名' : '请先选择目标数据源'}
-                  onChange={(event: ChangeEvent<HTMLInputElement>) => onSinkChange({ targetTableName: event.target.value })}
-                />
-              </div>
-            ) : (
-              <div>
-                <FieldLabel required>目标表</FieldLabel>
-                <Select
-                  showSearch
-                  variant="filled"
-                  disabled={!targetReady}
-                  value={sinkConfig.table || undefined}
-                  options={targetTables.map((table) => ({ label: table, value: table }))}
-                  loading={targetLoading}
-                  placeholder={targetReady ? '请选择目标表' : '请先选择目标数据源'}
-                  optionFilterProp="label"
-                  className="w-full"
-                  onChange={(table: string) => onSinkChange({ table, primaryKey: '' })}
-                />
-              </div>
-            )}
-
+          {sourceConfig.readMode === 'sql' ? (
             <div>
-              <FieldLabel required>写入模式</FieldLabel>
-              <Select
+              <FieldLabel required>查询 SQL</FieldLabel>
+              <Input.TextArea
+                rows={10}
                 variant="filled"
-                value={sinkConfig.writeMode || 'append'}
-                options={[
-                  { label: '追加写入 Append', value: 'append' },
-                  { label: '覆盖写入 Overwrite', value: 'overwrite' },
-                  { label: '主键更新 Upsert', value: 'upsert' },
-                ]}
+                value={sourceConfig.sql || ''}
+                placeholder="SELECT * FROM source_table"
+                className="font-mono"
+                onChange={(event: ChangeEvent<HTMLTextAreaElement>) => onSourceChange({ sql: event.target.value })}
+              />
+            </div>
+          ) : (
+            <div>
+              <FieldLabel required>来源表</FieldLabel>
+              <Select
+                showSearch
+                variant="filled"
+                disabled={!sourceReady}
+                value={sourceConfig.table || undefined}
+                options={sourceTables.map((table) => ({ label: table, value: table }))}
+                loading={sourceLoading}
+                notFoundContent={sourceLoading ? <Spin size="small" /> : undefined}
+                placeholder={sourceReady ? '请选择来源表' : '请先选择来源数据源'}
+                optionFilterProp="label"
                 className="w-full"
-                onChange={(writeMode: string) =>
-                  onSinkChange({
-                    writeMode,
-                    ...(writeMode === 'upsert' ? {} : { primaryKey: '' }),
-                  })
+                onChange={(table: string) => onSourceChange({ table })}
+              />
+            </div>
+          )}
+
+          <Button
+            block
+            icon={<EyeOutlined />}
+            disabled={previewDisabled}
+            onClick={() => setPreviewOpen(true)}
+          >
+            数据预览
+          </Button>
+
+          {sourceExtraParameters}
+        </EndpointPanel>
+
+        <EndpointPanel icon={<ExportOutlined />} title="Sink 目标配置">
+          <div className="flex items-center justify-between rounded-lg bg-[#f5f5f6] px-3.5 py-3">
+            <div className="text-[12px] font-medium text-[#475467]">自动创建目标表</div>
+            <Switch
+              checked={Boolean(sinkConfig.autoCreateTable)}
+              onChange={(autoCreateTable: boolean) =>
+                onSinkChange({
+                  autoCreateTable,
+                  table: '',
+                  targetTableName: '',
+                  primaryKey: '',
+                })
+              }
+            />
+          </div>
+
+          {sinkConfig.autoCreateTable ? (
+            <div>
+              <FieldLabel required>目标表名</FieldLabel>
+              <Input
+                variant="filled"
+                disabled={!targetReady}
+                value={sinkConfig.targetTableName || ''}
+                placeholder={targetReady ? '请输入需要创建的目标表名' : '请先选择目标数据源'}
+                onChange={(event: ChangeEvent<HTMLInputElement>) => onSinkChange({ targetTableName: event.target.value })}
+              />
+            </div>
+          ) : (
+            <div>
+              <FieldLabel required>目标表</FieldLabel>
+              <Select
+                showSearch
+                variant="filled"
+                disabled={!targetReady}
+                value={sinkConfig.table || undefined}
+                options={targetTables.map((table) => ({ label: table, value: table }))}
+                loading={targetLoading}
+                placeholder={targetReady ? '请选择目标表' : '请先选择目标数据源'}
+                optionFilterProp="label"
+                className="w-full"
+                onChange={(table: string) => onSinkChange({ table, primaryKey: '' })}
+              />
+            </div>
+          )}
+
+          <div>
+            <FieldLabel required>写入模式</FieldLabel>
+            <Select
+              variant="filled"
+              value={sinkConfig.writeMode || 'append'}
+              options={[
+                { label: '追加写入 Append', value: 'append' },
+                { label: '覆盖写入 Overwrite', value: 'overwrite' },
+                { label: '主键更新 Upsert', value: 'upsert' },
+              ]}
+              className="w-full"
+              onChange={(writeMode: string) =>
+                onSinkChange({
+                  writeMode,
+                  ...(writeMode === 'upsert' ? {} : { primaryKey: '' }),
+                })
+              }
+            />
+          </div>
+
+          {sinkConfig.writeMode === 'upsert' ? (
+            <div>
+              <FieldLabel required>主键字段</FieldLabel>
+              <Select
+                mode="tags"
+                allowClear
+                showSearch
+                variant="filled"
+                value={splitPrimaryKeys(sinkConfig.primaryKey)}
+                loading={primaryKeyLoading}
+                disabled={!targetReady}
+                options={primaryKeyOptions.map((option) => ({
+                  label: option.description
+                    ? `${option.label} · ${option.description}`
+                    : option.label,
+                  value: option.value,
+                }))}
+                placeholder={
+                  primaryKeyLoading
+                    ? '正在加载字段'
+                    : primaryKeyOptions.length > 0
+                      ? '请选择一个或多个主键字段'
+                      : '请先选择来源或目标表'
+                }
+                optionFilterProp="label"
+                className="w-full"
+                onChange={(primaryKeys: string[]) =>
+                  onSinkChange({ primaryKey: primaryKeys.join(',') })
                 }
               />
             </div>
+          ) : null}
 
-            {sinkConfig.writeMode === 'upsert' ? (
-              <div>
-                <FieldLabel required>主键字段</FieldLabel>
-                <Select
-                  mode="tags"
-                  allowClear
-                  showSearch
-                  variant="filled"
-                  value={splitPrimaryKeys(sinkConfig.primaryKey)}
-                  loading={primaryKeyLoading}
-                  disabled={!targetReady}
-                  options={primaryKeyOptions.map((option) => ({
-                    label: option.description
-                      ? `${option.label} · ${option.description}`
-                      : option.label,
-                    value: option.value,
-                  }))}
-                  placeholder={
-                    primaryKeyLoading
-                      ? '正在加载字段'
-                      : primaryKeyOptions.length > 0
-                        ? '请选择一个或多个主键字段'
-                        : '请先选择来源或目标表'
-                  }
-                  optionFilterProp="label"
-                  className="w-full"
-                  onChange={(primaryKeys: string[]) =>
-                    onSinkChange({ primaryKey: primaryKeys.join(',') })
-                  }
-                />
-              </div>
-            ) : null}
-
-            {sinkExtraParameters}
-          </EndpointPanel>
-        </div>
-      </EditorSection>
+          {sinkExtraParameters}
+        </EndpointPanel>
+      </div>
 
       <SingleTablePreviewModal
         open={previewOpen}
@@ -270,6 +268,6 @@ export default function SingleTableConfigSection({
         sourceConfig={sourceConfig}
         onCancel={() => setPreviewOpen(false)}
       />
-    </>
+    </EditorSection>
   );
 }

--- a/yak-ops-ui/src/pages/batch-link-up/detail/components/SingleTablePreviewModal.tsx
+++ b/yak-ops-ui/src/pages/batch-link-up/detail/components/SingleTablePreviewModal.tsx
@@ -1,0 +1,286 @@
+import { ReloadOutlined } from '@ant-design/icons';
+import { Alert, Button, Empty, Modal, Table, Tag } from 'antd';
+import type { ColumnsType } from 'antd/es/table';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import { dataSourceCatalogApi } from '@/pages/data-source/service';
+import { API_SUCCESS_CODE } from '@/services/http/response';
+
+interface DataSourcePreviewColumn {
+  title?: string;
+  dataIndex?: string;
+  key?: string;
+  ellipsis?: boolean;
+}
+
+interface DataSourcePreviewResult {
+  columns?: DataSourcePreviewColumn[];
+  data?: Array<Record<string, unknown>>;
+  total?: number;
+}
+
+interface SingleTablePreviewModalProps {
+  open: boolean;
+  dataSourceId?: string | number;
+  sourceConfig: Record<string, any>;
+  onCancel: () => void;
+}
+
+type PreviewRow = Record<string, unknown> & {
+  __yakPreviewRowKey: string;
+};
+
+const emptyPreview: DataSourcePreviewResult = {
+  columns: [],
+  data: [],
+  total: 0,
+};
+
+const responseMessage = (response: any, fallback: string) =>
+  response?.message || response?.msg || fallback;
+
+const normalizeRequest = (sourceConfig: Record<string, any>) => {
+  const readMode = sourceConfig.readMode === 'sql' ? 'sql' : 'table';
+
+  if (readMode === 'sql') {
+    const query = String(sourceConfig.sql || '').trim();
+    return query
+      ? {
+          readMode,
+          read_mode: readMode,
+          query,
+          ...(Array.isArray(sourceConfig.paramsList)
+            ? { paramsList: sourceConfig.paramsList }
+            : {}),
+        }
+      : null;
+  }
+
+  const tablePath = String(sourceConfig.table || '').trim();
+  return tablePath
+    ? {
+        readMode,
+        read_mode: readMode,
+        table_path: tablePath,
+      }
+    : null;
+};
+
+const renderCellValue = (value: unknown) => {
+  if (value === null || value === undefined) {
+    return <span className="text-[#98a2b3]">NULL</span>;
+  }
+
+  if (typeof value === 'object') {
+    try {
+      return JSON.stringify(value);
+    } catch {
+      return String(value);
+    }
+  }
+
+  return String(value);
+};
+
+export default function SingleTablePreviewModal({
+  open,
+  dataSourceId,
+  sourceConfig,
+  onCancel,
+}: SingleTablePreviewModalProps) {
+  const [loading, setLoading] = useState(false);
+  const [errorMessage, setErrorMessage] = useState('');
+  const [preview, setPreview] = useState<DataSourcePreviewResult>(emptyPreview);
+  const [total, setTotal] = useState(0);
+  const requestSequence = useRef(0);
+
+  const requestBody = useMemo(
+    () => normalizeRequest(sourceConfig),
+    [sourceConfig],
+  );
+
+  const loadPreview = useCallback(async () => {
+    if (!dataSourceId) {
+      setErrorMessage('请先选择来源数据源');
+      return;
+    }
+    if (!requestBody) {
+      setErrorMessage(
+        sourceConfig.readMode === 'sql'
+          ? '请先填写查询 SQL'
+          : '请先选择来源表',
+      );
+      return;
+    }
+
+    const sequence = ++requestSequence.current;
+    setLoading(true);
+    setErrorMessage('');
+    setPreview(emptyPreview);
+    setTotal(0);
+
+    try {
+      const [previewResponse, countResponse] = await Promise.all([
+        dataSourceCatalogApi.getTop20Data(dataSourceId, requestBody),
+        dataSourceCatalogApi.count(dataSourceId, requestBody),
+      ]);
+
+      if (sequence !== requestSequence.current) return;
+
+      if (previewResponse?.code !== API_SUCCESS_CODE) {
+        throw new Error(responseMessage(previewResponse, '获取预览数据失败'));
+      }
+      if (countResponse?.code !== API_SUCCESS_CODE) {
+        throw new Error(responseMessage(countResponse, '统计数据量失败'));
+      }
+
+      const nextPreview =
+        (previewResponse?.data as DataSourcePreviewResult | undefined) ||
+        emptyPreview;
+      const nextTotal = Number(countResponse?.data ?? nextPreview.total ?? 0);
+
+      setPreview({
+        columns: Array.isArray(nextPreview.columns) ? nextPreview.columns : [],
+        data: Array.isArray(nextPreview.data) ? nextPreview.data : [],
+        total: Number.isFinite(Number(nextPreview.total))
+          ? Number(nextPreview.total)
+          : 0,
+      });
+      setTotal(Number.isFinite(nextTotal) ? nextTotal : 0);
+    } catch (error: any) {
+      if (sequence !== requestSequence.current) return;
+      setPreview(emptyPreview);
+      setTotal(0);
+      setErrorMessage(error?.message || '获取数据预览失败');
+    } finally {
+      if (sequence === requestSequence.current) {
+        setLoading(false);
+      }
+    }
+  }, [dataSourceId, requestBody, sourceConfig.readMode]);
+
+  useEffect(() => {
+    if (open) {
+      void loadPreview();
+      return;
+    }
+
+    requestSequence.current += 1;
+  }, [loadPreview, open]);
+
+  const columns = useMemo<ColumnsType<PreviewRow>>(() => {
+    const configuredColumns = Array.isArray(preview.columns)
+      ? preview.columns
+      : [];
+    const fallbackColumns = Object.keys(preview.data?.[0] || {}).map((key) => ({
+      title: key,
+      dataIndex: key,
+      key,
+      ellipsis: true,
+    }));
+
+    return (configuredColumns.length > 0
+      ? configuredColumns
+      : fallbackColumns
+    ).map((column, index) => {
+      const dataIndex = String(
+        column.dataIndex || column.key || column.title || `column_${index}`,
+      );
+
+      return {
+        title: column.title || dataIndex,
+        key: column.key || `${dataIndex}_${index}`,
+        width: 180,
+        ellipsis: column.ellipsis !== false,
+        render: (_value, record) => renderCellValue(record[dataIndex]),
+      };
+    });
+  }, [preview.columns, preview.data]);
+
+  const rows = useMemo<PreviewRow[]>(
+    () =>
+      (preview.data || []).map((row, index) => ({
+        ...row,
+        __yakPreviewRowKey: `preview-${index}`,
+      })),
+    [preview.data],
+  );
+
+  const readMode = sourceConfig.readMode === 'sql' ? 'sql' : 'table';
+  const previewTarget =
+    readMode === 'sql'
+      ? '自定义 SQL'
+      : String(sourceConfig.table || '未选择来源表');
+
+  return (
+    <Modal
+      open={open}
+      title="数据预览"
+      width={1200}
+      destroyOnClose
+      onCancel={onCancel}
+      footer={[
+        <Button
+          key="refresh"
+          icon={<ReloadOutlined />}
+          loading={loading}
+          onClick={() => void loadPreview()}
+        >
+          刷新
+        </Button>,
+        <Button key="close" type="primary" onClick={onCancel}>
+          关闭
+        </Button>,
+      ]}
+      styles={{ body: { paddingTop: 12 } }}
+    >
+      <div className="mb-4 flex flex-wrap items-center gap-2 rounded-lg bg-[#f7f7f8] px-3.5 py-3">
+        <Tag bordered={false}>{readMode === 'sql' ? 'SQL 查询' : '数据表'}</Tag>
+        <div className="min-w-0 flex-1 truncate text-[13px] font-medium text-[#344054]">
+          {previewTarget}
+        </div>
+        <div className="text-[12px] text-[#667085]">
+          总记录数：
+          <span className="ml-1 font-semibold text-[#161823]">
+            {total.toLocaleString()}
+          </span>
+        </div>
+        <div className="text-[12px] text-[#667085]">
+          本次预览：
+          <span className="ml-1 font-semibold text-[#161823]">
+            {rows.length} 条
+          </span>
+        </div>
+      </div>
+
+      {errorMessage ? (
+        <Alert
+          showIcon
+          type="error"
+          message="数据预览失败"
+          description={errorMessage}
+          className="mb-4"
+        />
+      ) : null}
+
+      <Table<PreviewRow>
+        bordered
+        size="small"
+        loading={loading}
+        columns={columns}
+        dataSource={rows}
+        rowKey="__yakPreviewRowKey"
+        pagination={false}
+        scroll={{ x: 'max-content', y: 420 }}
+        locale={{
+          emptyText: (
+            <Empty
+              image={Empty.PRESENTED_IMAGE_SIMPLE}
+              description={loading ? '正在加载预览数据' : '暂无数据'}
+            />
+          ),
+        }}
+      />
+    </Modal>
+  );
+}

--- a/yak-ops-ui/src/pages/batch-link-up/detail/components/SyncTaskEditor.tsx
+++ b/yak-ops-ui/src/pages/batch-link-up/detail/components/SyncTaskEditor.tsx
@@ -93,6 +93,7 @@ export default function SyncTaskEditor({
           />
         ) : (
           <SingleTableConfigSection
+            sourceDataSourceId={sourceId}
             sourceConfig={sourceConfig}
             sinkConfig={sinkConfig}
             sourceTables={sourceCatalog.tables}


### PR DESCRIPTION
## 变更内容

- 在单表同步 Source 配置中新增“数据预览”入口。
- 直接复用现有 Catalog 接口：
  - `POST /api/v1/data-source/catalog/getTop20Data/{id}`
  - `POST /api/v1/data-source/catalog/count/{id}`
- 表模式使用 `table_path`，SQL 模式使用 `query`，并兼容 SQL 参数列表。
- 新增独立 `SingleTablePreviewModal`：
  - 动态渲染后端返回字段
  - 展示前 20 条数据
  - 展示查询结果总记录数与本次预览行数
  - 支持横向、纵向滚动
  - 支持空值、对象值展示
  - 提供加载、错误、刷新和空数据状态
- 来源数据源、来源表或查询 SQL 未配置完整时，禁用预览按钮。
- 将当前 Source 数据源 ID 从 `SyncTaskEditor` 传入单表配置组件。

## 说明

后端预览与统计接口已经具备所需能力，本次不重复新增后端接口，仅完成单表同步编辑页的前后端联调和 Modal 展示。

## 验证

- 对新增和修改的 3 个 TSX 文件执行了 TypeScript `transpileModule` 严格语法检查，检查通过。
- 对比 `main...feature/single-table-preview`，变更仅涉及单表同步前端预览功能。
- 当前执行环境无法获取完整前端依赖，因此未执行项目级 `npm run tsc` 和 `npm run build`，PR 保持 Draft，待本地连接真实数据源后完成联调验证。