### PR TITLE
feat(offline-sync): consume Link-Up table DDL results

### DIFF
--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineExecutionReadService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineExecutionReadService.java
@@ -92,11 +92,36 @@ public class OfflineExecutionReadService {
 
   public JsonNode tableMetrics(Long id) {
     OfflineJobExecutionPO execution = require(id);
+
+    JsonNode snapshotPipelines = snapshotPipelines(execution);
+    if (snapshotPipelines.isArray() && !snapshotPipelines.isEmpty()) {
+      return OfflinePipelineMetricsMapper.flatten(
+          objectMapper,
+          snapshotPipelines);
+    }
+
     if (!StringUtils.hasText(execution.getEngineJobId())) {
       throw new IllegalStateException("当前执行实例尚未获得 Link-Up jobId");
     }
     JsonNode pipelines = linkUpClient.pipelines(execution.getEngineJobId());
     return OfflinePipelineMetricsMapper.flatten(objectMapper, pipelines);
+  }
+
+  private JsonNode snapshotPipelines(OfflineJobExecutionPO execution) {
+    if (execution == null
+        || !StringUtils.hasText(execution.getEngineSnapshotJson())) {
+      return objectMapper.createArrayNode();
+    }
+    try {
+      JsonNode snapshot =
+          objectMapper.readTree(execution.getEngineSnapshotJson());
+      JsonNode pipelines = snapshot.path("pipelines");
+      return pipelines.isArray()
+          ? pipelines
+          : objectMapper.createArrayNode();
+    } catch (Exception ignored) {
+      return objectMapper.createArrayNode();
+    }
   }
 
   public String logs(Long id) {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineExecutionReadService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineExecutionReadService.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.yak.framework.common.PagingData;
 import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
 import io.yak.ops.business.sync.offline.dao.OfflineJobExecutionDao;
+import io.yak.ops.business.sync.offline.domain.OfflineExecutionStatus;
 import io.yak.ops.business.sync.offline.engine.LinkUpClient;
 import io.yak.ops.business.sync.offline.repository.OfflineExecutionControlRepository;
 import io.yak.ops.business.sync.offline.repository.OfflineExecutionControlRepository.ExecutionEventRecord;
@@ -93,11 +94,13 @@ public class OfflineExecutionReadService {
   public JsonNode tableMetrics(Long id) {
     OfflineJobExecutionPO execution = require(id);
 
-    JsonNode snapshotPipelines = snapshotPipelines(execution);
-    if (snapshotPipelines.isArray() && !snapshotPipelines.isEmpty()) {
-      return OfflinePipelineMetricsMapper.flatten(
-          objectMapper,
-          snapshotPipelines);
+    if (!OfflineExecutionStatus.isActive(execution.getStatus())) {
+      JsonNode snapshotPipelines = snapshotPipelines(execution);
+      if (snapshotPipelines.isArray() && !snapshotPipelines.isEmpty()) {
+        return OfflinePipelineMetricsMapper.flatten(
+            objectMapper,
+            snapshotPipelines);
+      }
     }
 
     if (!StringUtils.hasText(execution.getEngineJobId())) {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflinePipelineMetricsMapper.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflinePipelineMetricsMapper.java
@@ -20,6 +20,7 @@ final class OfflinePipelineMetricsMapper {
     for (JsonNode pipeline : pipelines) {
       JsonNode source = pipeline.path("source");
       JsonNode sink = pipeline.path("sink");
+      JsonNode tableDdl = pipeline.path("tableDdl");
 
       ObjectNode row = result.addObject();
       row.put(
@@ -61,6 +62,28 @@ final class OfflinePipelineMetricsMapper {
       row.put("writeQps", decimal(sink, "averageQps", 0D));
       row.put("sourceReadBytes", number(source, "readBytes", 0L));
       row.put("sinkWrittenBytes", number(sink, "writtenBytes", 0L));
+
+      if (tableDdl.isObject()) {
+        row.set("tableDdl", tableDdl.deepCopy());
+        putNullable(row, "ddlDialect", text(tableDdl, "dialect", null));
+        putNullable(row, "createTableSql", text(tableDdl, "createTableSql", null));
+        row.put("ddlExecuted", bool(tableDdl, "executed", false));
+        putNullable(row, "ddlStatus", text(tableDdl, "status", null));
+        putNullable(row, "ddlReason", text(tableDdl, "reason", null));
+        row.put("ddlDurationMillis", number(tableDdl, "durationMillis", 0L));
+        putNullable(row, "ddlErrorCode", text(tableDdl, "errorCode", null));
+        putNullable(row, "ddlErrorMessage", text(tableDdl, "errorMessage", null));
+      } else {
+        row.putNull("tableDdl");
+        row.putNull("ddlDialect");
+        row.putNull("createTableSql");
+        row.put("ddlExecuted", false);
+        row.putNull("ddlStatus");
+        row.putNull("ddlReason");
+        row.put("ddlDurationMillis", 0L);
+        row.putNull("ddlErrorCode");
+        row.putNull("ddlErrorMessage");
+      }
       index++;
     }
     return result;
@@ -86,6 +109,17 @@ final class OfflinePipelineMetricsMapper {
     return com.fasterxml.jackson.databind.node.MissingNode.getInstance();
   }
 
+  private static void putNullable(
+      ObjectNode target,
+      String field,
+      String value) {
+    if (value == null) {
+      target.putNull(field);
+    } else {
+      target.put(field, value);
+    }
+  }
+
   private static String text(JsonNode node, String field, String fallback) {
     JsonNode value = node == null ? null : node.get(field);
     if (value == null || value.isNull() || !value.isValueNode()) {
@@ -107,5 +141,12 @@ final class OfflinePipelineMetricsMapper {
     return value == null || !value.isNumber()
         ? fallback
         : value.asDouble(fallback);
+  }
+
+  private static boolean bool(JsonNode node, String field, boolean fallback) {
+    JsonNode value = node == null ? null : node.get(field);
+    return value == null || !value.isBoolean()
+        ? fallback
+        : value.asBoolean(fallback);
   }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/service/OfflinePipelineMetricsMapperTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/service/OfflinePipelineMetricsMapperTest.java
@@ -1,6 +1,8 @@
 package io.yak.ops.business.sync.offline.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -10,7 +12,7 @@ class OfflinePipelineMetricsMapperTest {
   private final ObjectMapper objectMapper = new ObjectMapper();
 
   @Test
-  void flattensSourceAndSinkPipelineMetrics() throws Exception {
+  void flattensSourceSinkAndTableDdl() throws Exception {
     JsonNode payload =
         objectMapper.readTree(
             """
@@ -38,6 +40,16 @@ class OfflinePipelineMetricsMapperTest {
                   "unknownStateRecordCount": 0,
                   "writtenBytes": 2048,
                   "averageQps": 3369.27223
+                },
+                "tableDdl": {
+                  "dialect": "MYSQL",
+                  "sourceTable": "test1.t_test_1w",
+                  "targetTable": "test1234123",
+                  "createTableSql": "CREATE TABLE `test1234123` (`id` BIGINT NOT NULL);",
+                  "executed": true,
+                  "status": "SUCCEEDED",
+                  "reason": "TARGET_TABLE_CREATED",
+                  "durationMillis": 12
                 }
               }
             ]
@@ -58,10 +70,21 @@ class OfflinePipelineMetricsMapperTest {
     assertEquals(1024L, row.path("sourceReadBytes").asLong());
     assertEquals(2048L, row.path("sinkWrittenBytes").asLong());
     assertEquals("SUCCEEDED", row.path("status").asText());
+    assertEquals("MYSQL", row.path("ddlDialect").asText());
+    assertEquals(
+        "CREATE TABLE `test1234123` (`id` BIGINT NOT NULL);",
+        row.path("createTableSql").asText());
+    assertTrue(row.path("ddlExecuted").asBoolean());
+    assertEquals("SUCCEEDED", row.path("ddlStatus").asText());
+    assertEquals("TARGET_TABLE_CREATED", row.path("ddlReason").asText());
+    assertEquals(12L, row.path("ddlDurationMillis").asLong());
+    assertEquals(
+        "CREATE TABLE `test1234123` (`id` BIGINT NOT NULL);",
+        row.path("tableDdl").path("createTableSql").asText());
   }
 
   @Test
-  void acceptsWrappedPipelinePayload() throws Exception {
+  void acceptsWrappedPipelinePayloadWithoutDdl() throws Exception {
     JsonNode payload =
         objectMapper.readTree(
             """
@@ -82,5 +105,7 @@ class OfflinePipelineMetricsMapperTest {
     assertEquals("orders", result.get(0).path("sourceTable").asText());
     assertEquals(3L, result.get(0).path("readRowCount").asLong());
     assertEquals(2L, result.get(0).path("writeRowCount").asLong());
+    assertFalse(result.get(0).path("ddlExecuted").asBoolean());
+    assertTrue(result.get(0).path("createTableSql").isNull());
   }
 }

--- a/yak-ops-ui/src/pages/batch-link-up/api.ts
+++ b/yak-ops-ui/src/pages/batch-link-up/api.ts
@@ -100,6 +100,51 @@ export interface OfflineJobExecutionDetailVO extends OfflineJobExecutionVO {
   metrics?: Record<string, unknown>;
 }
 
+export interface OfflineTableDdl {
+  dialect?: string;
+  sourceTable?: string;
+  targetTable?: string;
+  createTableSql?: string;
+  executed: boolean;
+  status?: 'SUCCEEDED' | 'SKIPPED' | string;
+  reason?: string;
+  durationMillis: number;
+  errorCode?: string;
+  errorMessage?: string;
+}
+
+export interface OfflineTableMetric {
+  id: string;
+  pipelineId?: string;
+  dataSetId?: string;
+  status: string;
+  sourceTable: string;
+  sinkTable: string;
+  sourceConnector?: string;
+  sinkConnector?: string;
+  sourceTaskCount: number;
+  sinkTaskCount: number;
+  readRowCount: number;
+  writeRowCount: number;
+  sinkAttemptedRecordCount: number;
+  sinkCommittedRecordCount: number;
+  failedRecordCount: number;
+  unknownStateRecordCount: number;
+  readQps: number;
+  writeQps: number;
+  sourceReadBytes: number;
+  sinkWrittenBytes: number;
+  tableDdl?: OfflineTableDdl;
+  ddlDialect?: string;
+  createTableSql?: string;
+  ddlExecuted: boolean;
+  ddlStatus?: string;
+  ddlReason?: string;
+  ddlDurationMillis: number;
+  ddlErrorCode?: string;
+  ddlErrorMessage?: string;
+}
+
 export interface OfflineBatchOperationError {
   jobDefinitionId?: string | number;
   message?: string;
@@ -268,7 +313,7 @@ export const batchJobInstanceApi = {
     HttpUtils.get(`/api/v1/job/batch-instance/${id}`),
   tableMetrics: (
     instanceId: string | number,
-  ): Promise<ApiResponse<unknown>> =>
+  ): Promise<ApiResponse<OfflineTableMetric[]>> =>
     HttpUtils.get(
       `/api/v1/job/batch-instance/${instanceId}/table-metrics`,
     ),


### PR DESCRIPTION
## 背景

配套 `weifuwan/yak-link-up#58`，Yak Ops 需要接收 Link-Up 在每个 Pipeline 中返回的离线建表结果，让单表和多表任务都能在表级执行详情中查看最终 `CREATE TABLE` SQL、是否实际执行以及跳过原因。

本 PR 只消费离线建表语句，不引入实时同步、ALTER 事件或 Schema Change 管理能力。

## 返回模型

表级指标接口新增以下字段：

```json
{
  "pipelineId": "pipeline-orders",
  "sourceTable": "source_db.orders",
  "sinkTable": "target_db.orders",
  "tableDdl": {
    "dialect": "MYSQL",
    "sourceTable": "source_db.orders",
    "targetTable": "target_db.orders",
    "createTableSql": "CREATE TABLE `target_db`.`orders` (...);",
    "executed": true,
    "status": "SUCCEEDED",
    "reason": "TARGET_TABLE_CREATED",
    "durationMillis": 18
  },
  "ddlDialect": "MYSQL",
  "createTableSql": "CREATE TABLE `target_db`.`orders` (...);",
  "ddlExecuted": true,
  "ddlStatus": "SUCCEEDED",
  "ddlReason": "TARGET_TABLE_CREATED",
  "ddlDurationMillis": 18
}
```

保留嵌套 `tableDdl` 便于完整展示，同时提供扁平字段，方便现有表格直接接入。

## 实现

- 扩展 `OfflinePipelineMetricsMapper`，读取 `pipelines[].tableDdl`；
- 输出完整 `tableDdl` 以及稳定的扁平 DDL 字段；
- 兼容旧 Link-Up：不存在 `tableDdl` 时返回 `null / false / 0`，不影响原有表级指标；
- 已完成执行优先从 `engine_snapshot_json` 读取 Pipeline 和 DDL，因此 Worker 重启、离线或清理内存历史后仍可查看；
- 活动执行仍实时调用 Worker，避免使用持久化快照造成指标延迟；
- 不新增数据库字段：现有执行快照已经完整持久化 Link-Up 返回对象；
- 增加 `OfflineTableDdl`、`OfflineTableMetric` 前端类型；
- 扩展 Mapper 测试，覆盖建表成功和旧协议无 DDL 两种情况。

## 兼容性

- 不修改任务提交、状态机、调度、重试、取消或执行表结构；
- 不需要 Flyway 迁移；
- 旧执行快照没有 `tableDdl` 时继续正常展示原有指标；
- 单表和多表共用现有 Pipeline 列表，不新增模式分支。

## 依赖与发布顺序

依赖：`weifuwan/yak-link-up#58`

建议发布顺序：

1. 合并并发布 Link-Up PR #58；
2. 验证 Worker 的 `/api/v1/jobs/{jobId}/pipelines` 返回 `tableDdl`；
3. 合并并发布本 PR；
4. 执行单表和多表任务，检查表级指标中的建表 SQL。

Yak Ops 可以先部署本 PR；连接旧 Worker 时 DDL 字段为空，不会破坏现有功能。

## 验证

已完成：

- 分支基于当前 `main`，落后 0；
- 对远端响应反序列化、执行快照持久化、终态历史读取、活动任务实时指标和旧协议兼容进行源码级审查；
- 扩展 `OfflinePipelineMetricsMapperTest`，覆盖 DDL 展开和无 DDL 默认值；
- 前端 API 类型与后端返回字段完成对齐；
- GitHub 当前未返回可执行状态检查。

当前执行环境无法解析 `github.com`，且没有 Maven 和完整前端依赖，因此尚未运行完整构建。合并前建议执行：

```bash
mvn -pl yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline -am test
cd yak-ops-ui
npm run tsc
npm run build
```