### PR TITLE
feat(offline-sync): merge Yak Ops and Link-Up execution logs

### DIFF
--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/controller/OfflineJobExecutionController.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/controller/OfflineJobExecutionController.java
@@ -10,6 +10,7 @@ import io.yak.ops.business.sync.offline.service.OfflineJobExecutionService;
 import io.yak.ops.common.bean.dto.sync.offline.OfflineBatchOperationDTO;
 import io.yak.ops.common.bean.dto.sync.offline.OfflineJobExecutionQueryDTO;
 import io.yak.ops.common.bean.vo.sync.offline.OfflineBatchOperationVO;
+import io.yak.ops.common.bean.vo.sync.offline.OfflineExecutionLogPageVO;
 import io.yak.ops.common.bean.vo.sync.offline.OfflineJobExecutionDetailVO;
 import io.yak.ops.common.bean.vo.sync.offline.OfflineJobExecutionVO;
 import jakarta.validation.Valid;
@@ -18,6 +19,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /** 离线执行命令和执行历史查询接口。 */
@@ -29,30 +31,41 @@ public class OfflineJobExecutionController {
   private final LinkUpClient linkUpClient;
 
   @GetMapping({"/api/v1/job/batch-execution/health", "/api/v1/executor/health"})
-  public Result<LinkUpNodeResponse> health() { return Result.success(linkUpClient.node()); }
+  public Result<LinkUpNodeResponse> health() {
+    return Result.success(linkUpClient.node());
+  }
 
   @PostMapping("/api/v1/job/batch-execution/{jobDefineId}/execute")
-  public Result<OfflineJobExecutionVO> execute(@PathVariable Long jobDefineId) {
+  public Result<OfflineJobExecutionVO> execute(
+      @PathVariable Long jobDefineId) {
     return Result.success(service.execute(jobDefineId));
   }
 
   @PostMapping("/api/v1/job/batch-execution/{jobInstanceId}/cancel")
-  public Result<OfflineJobExecutionVO> cancel(@PathVariable Long jobInstanceId) {
+  public Result<OfflineJobExecutionVO> cancel(
+      @PathVariable Long jobInstanceId) {
     return Result.success(service.cancel(jobInstanceId));
   }
 
   @PostMapping("/api/v1/job/batch-execution/{jobInstanceId}/retry")
-  public Result<OfflineJobExecutionVO> retry(@PathVariable Long jobInstanceId) {
+  public Result<OfflineJobExecutionVO> retry(
+      @PathVariable Long jobInstanceId) {
     return Result.success(service.retry(jobInstanceId));
   }
 
-  @PostMapping({"/api/v1/job/batch-execution/batch-execute", "/api/v1/executor/batch-execute"})
+  @PostMapping({
+      "/api/v1/job/batch-execution/batch-execute",
+      "/api/v1/executor/batch-execute"
+  })
   public Result<OfflineBatchOperationVO> batchExecute(
       @Valid @RequestBody OfflineBatchOperationDTO requestDTO) {
     return Result.success(service.batchExecute(requestDTO));
   }
 
-  @PostMapping({"/api/v1/job/batch-execution/batch-pause", "/api/v1/executor/batch-pause"})
+  @PostMapping({
+      "/api/v1/job/batch-execution/batch-pause",
+      "/api/v1/executor/batch-pause"
+  })
   public Result<OfflineBatchOperationVO> batchPause(
       @Valid @RequestBody OfflineBatchOperationDTO requestDTO) {
     return Result.success(service.batchCancel(requestDTO));
@@ -60,12 +73,14 @@ public class OfflineJobExecutionController {
 
   @PostMapping("/api/v1/job/batch-instance/page")
   public PagingResult<OfflineJobExecutionVO> instancePage(
-      @Valid @RequestBody(required = false) OfflineJobExecutionQueryDTO queryDTO) {
+      @Valid @RequestBody(required = false)
+          OfflineJobExecutionQueryDTO queryDTO) {
     return PagingResult.success(service.page(queryDTO));
   }
 
   @GetMapping("/api/v1/job/batch-instance/{id}")
-  public Result<OfflineJobExecutionDetailVO> instance(@PathVariable Long id) {
+  public Result<OfflineJobExecutionDetailVO> instance(
+      @PathVariable Long id) {
     return Result.success(service.detail(id));
   }
 
@@ -74,8 +89,17 @@ public class OfflineJobExecutionController {
     return Result.success(service.tableMetrics(id));
   }
 
+  /** 旧文本日志接口继续保留。 */
   @GetMapping("/api/v1/job/batch-instance/{id}/log")
   public Result<String> instanceLog(@PathVariable Long id) {
     return Result.success(service.logs(id));
+  }
+
+  @GetMapping("/api/v1/job/batch-instance/{id}/logs")
+  public Result<OfflineExecutionLogPageVO> instanceLogs(
+      @PathVariable Long id,
+      @RequestParam(defaultValue = "0:0") String cursor,
+      @RequestParam(defaultValue = "500") int limit) {
+    return Result.success(service.logs(id, cursor, limit));
   }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/LinkUpClient.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/LinkUpClient.java
@@ -14,6 +14,7 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -28,7 +29,8 @@ public class LinkUpClient {
   private final ObjectMapper objectMapper;
   private final OfflineSyncProperties properties;
 
-  public LinkUpClient(@Qualifier("offlineSyncHttpClient") HttpClient httpClient,
+  public LinkUpClient(
+      @Qualifier("offlineSyncHttpClient") HttpClient httpClient,
       @Qualifier("offlineSyncJsonMapper") ObjectMapper objectMapper,
       OfflineSyncProperties properties) {
     this.httpClient = httpClient;
@@ -36,14 +38,24 @@ public class LinkUpClient {
     this.properties = properties;
   }
 
-  public LinkUpNodeResponse node() { return get("/api/v1/node", LinkUpNodeResponse.class); }
-  public LinkUpNodeResponse health() { return node(); }
+  public LinkUpNodeResponse node() {
+    return get("/api/v1/node", LinkUpNodeResponse.class);
+  }
 
-  public LinkUpJobResponse submit(String externalExecutionId, String idempotencyKey,
-      int definitionVersion, JsonNode jobSpec) {
+  public LinkUpNodeResponse health() {
+    return node();
+  }
+
+  public LinkUpJobResponse submit(
+      String externalExecutionId,
+      String idempotencyKey,
+      int definitionVersion,
+      JsonNode jobSpec) {
     requireEnabled();
-    if (!StringUtils.hasText(externalExecutionId) || !StringUtils.hasText(idempotencyKey)
-        || jobSpec == null || !jobSpec.isObject()) {
+    if (!StringUtils.hasText(externalExecutionId)
+        || !StringUtils.hasText(idempotencyKey)
+        || jobSpec == null
+        || !jobSpec.isObject()) {
       throw new LinkUpProtocolException("Link-Up JobSpec 提交参数不完整");
     }
     LinkUpSubmitRequest body = new LinkUpSubmitRequest();
@@ -51,112 +63,332 @@ public class LinkUpClient {
     body.setIdempotencyKey(idempotencyKey.trim());
     body.setDefinitionVersion(definitionVersion);
     body.setJobSpec(jobSpec);
-    HttpRequest request = HttpRequest.newBuilder(uri("/api/v1/jobs"))
-        .timeout(properties.getEngine().getRequestTimeout())
-        .header("Content-Type", "application/json;charset=UTF-8")
-        .header("Accept", "application/json")
-        .POST(HttpRequest.BodyPublishers.ofString(write(body), StandardCharsets.UTF_8))
-        .build();
+    HttpRequest request =
+        HttpRequest.newBuilder(uri("/api/v1/jobs"))
+            .timeout(properties.getEngine().getRequestTimeout())
+            .header("Content-Type", "application/json;charset=UTF-8")
+            .header("Accept", "application/json")
+            .POST(
+                HttpRequest.BodyPublishers.ofString(
+                    write(body),
+                    StandardCharsets.UTF_8))
+            .build();
     return send(request, LinkUpJobResponse.class);
   }
 
-  public LinkUpJobResponse getJob(String id) { return get("/api/v1/jobs/" + encode(id), LinkUpJobResponse.class); }
-  public LinkUpJobResponse findByExternalExecutionId(String id) { return get("/api/v1/jobs/external/" + encode(id), LinkUpJobResponse.class); }
+  public LinkUpJobResponse getJob(String id) {
+    return get("/api/v1/jobs/" + encode(id), LinkUpJobResponse.class);
+  }
+
+  public LinkUpJobResponse findByExternalExecutionId(String id) {
+    return get(
+        "/api/v1/jobs/external/" + encode(id),
+        LinkUpJobResponse.class);
+  }
+
   public LinkUpJobResponse cancel(String id) {
     requireEnabled();
-    HttpRequest request = HttpRequest.newBuilder(uri("/api/v1/jobs/" + encode(id)))
-        .timeout(properties.getEngine().getRequestTimeout()).header("Accept", "application/json")
-        .DELETE().build();
+    HttpRequest request =
+        HttpRequest.newBuilder(uri("/api/v1/jobs/" + encode(id)))
+            .timeout(properties.getEngine().getRequestTimeout())
+            .header("Accept", "application/json")
+            .DELETE()
+            .build();
     return send(request, LinkUpJobResponse.class);
   }
-  public JsonNode pipelines(String id) { return get("/api/v1/jobs/" + encode(id) + "/pipelines", JsonNode.class); }
-  public JsonNode tasks(String id) { return get("/api/v1/jobs/" + encode(id) + "/tasks", JsonNode.class); }
-  public JsonNode metrics(String id) { return get("/api/v1/jobs/" + encode(id) + "/metrics", JsonNode.class); }
+
+  public JsonNode pipelines(String id) {
+    return get(
+        "/api/v1/jobs/" + encode(id) + "/pipelines",
+        JsonNode.class);
+  }
+
+  public JsonNode tasks(String id) {
+    return get(
+        "/api/v1/jobs/" + encode(id) + "/tasks",
+        JsonNode.class);
+  }
+
+  public JsonNode metrics(String id) {
+    return get(
+        "/api/v1/jobs/" + encode(id) + "/metrics",
+        JsonNode.class);
+  }
+
+  public LinkUpJobLogPageResponse logs(
+      String id,
+      long cursor,
+      int limit) {
+    if (cursor < 0L) {
+      throw new LinkUpProtocolException("Link-Up 日志 cursor 不能为负数");
+    }
+    if (limit < 1 || limit > 1000) {
+      throw new LinkUpProtocolException("Link-Up 日志 limit 必须在 1 到 1000 之间");
+    }
+    return get(
+        "/api/v1/jobs/"
+            + encode(id)
+            + "/logs?cursor="
+            + cursor
+            + "&limit="
+            + limit,
+        LinkUpJobLogPageResponse.class);
+  }
 
   private <T> T get(String path, Class<T> type) {
     requireEnabled();
-    HttpRequest request = HttpRequest.newBuilder(uri(path))
-        .timeout(properties.getEngine().getRequestTimeout()).header("Accept", "application/json")
-        .GET().build();
+    HttpRequest request =
+        HttpRequest.newBuilder(uri(path))
+            .timeout(properties.getEngine().getRequestTimeout())
+            .header("Accept", "application/json")
+            .GET()
+            .build();
     return send(request, type);
   }
 
   private <T> T send(HttpRequest request, Class<T> type) {
     try {
-      HttpResponse<String> response = httpClient.send(request,
-          HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+      HttpResponse<String> response =
+          httpClient.send(
+              request,
+              HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
       if (response.statusCode() >= 200 && response.statusCode() < 300) {
         return read(response.body(), type);
       }
       JsonNode error = readError(response.body());
-      throw new LinkUpRequestException(response.statusCode(),
+      throw new LinkUpRequestException(
+          response.statusCode(),
           error.path("code").asText("LINK-UP-HTTP-" + response.statusCode()),
           errorMessage(error, response.body()));
     } catch (InterruptedException exception) {
       Thread.currentThread().interrupt();
-      throw new LinkUpTransportException("Link-Up 请求被中断", exception, false);
+      throw new LinkUpTransportException(
+          "Link-Up 请求被中断",
+          exception,
+          false);
     } catch (IOException exception) {
-      throw new LinkUpTransportException("无法确认 Link-Up 是否已接收请求：" + baseUrl(),
-          exception, true);
+      throw new LinkUpTransportException(
+          "无法确认 Link-Up 是否已接收请求：" + baseUrl(),
+          exception,
+          true);
     }
   }
 
   private URI uri(String path) {
-    try { return URI.create(baseUrl() + path); }
-    catch (IllegalArgumentException exception) {
-      throw new LinkUpProtocolException("Link-Up 地址不合法：" + properties.getEngine().getBaseUrl(), exception);
+    try {
+      return URI.create(baseUrl() + path);
+    } catch (IllegalArgumentException exception) {
+      throw new LinkUpProtocolException(
+          "Link-Up 地址不合法：" + properties.getEngine().getBaseUrl(),
+          exception);
     }
   }
+
   private String baseUrl() {
     String value = properties.getEngine().getBaseUrl();
-    if (!StringUtils.hasText(value)) throw new LinkUpProtocolException("yak.sync.offline.engine.base-url 不能为空");
+    if (!StringUtils.hasText(value)) {
+      throw new LinkUpProtocolException(
+          "yak.sync.offline.engine.base-url 不能为空");
+    }
     String normalized = value.trim();
-    while (normalized.endsWith("/")) normalized = normalized.substring(0, normalized.length() - 1);
-    if (!normalized.startsWith("http://") && !normalized.startsWith("https://")) {
+    while (normalized.endsWith("/")) {
+      normalized = normalized.substring(0, normalized.length() - 1);
+    }
+    if (!normalized.startsWith("http://")
+        && !normalized.startsWith("https://")) {
       throw new LinkUpProtocolException("Link-Up 地址必须使用 HTTP 或 HTTPS");
     }
     return normalized;
   }
+
   private String encode(String value) {
-    if (!StringUtils.hasText(value)) throw new LinkUpProtocolException("Link-Up 标识不能为空");
-    return URLEncoder.encode(value.trim(), StandardCharsets.UTF_8).replace("+", "%20");
+    if (!StringUtils.hasText(value)) {
+      throw new LinkUpProtocolException("Link-Up 标识不能为空");
+    }
+    return URLEncoder.encode(value.trim(), StandardCharsets.UTF_8)
+        .replace("+", "%20");
   }
+
   private void requireEnabled() {
-    if (!properties.getEngine().isEnabled()) throw new LinkUpProtocolException("Link-Up 引擎对接已关闭");
+    if (!properties.getEngine().isEnabled()) {
+      throw new LinkUpProtocolException("Link-Up 引擎对接已关闭");
+    }
   }
+
   private JsonNode readError(String body) {
-    if (!StringUtils.hasText(body)) return objectMapper.createObjectNode();
-    try { return objectMapper.readTree(body); }
-    catch (JsonProcessingException exception) { return objectMapper.createObjectNode().put("message", body); }
+    if (!StringUtils.hasText(body)) {
+      return objectMapper.createObjectNode();
+    }
+    try {
+      return objectMapper.readTree(body);
+    } catch (JsonProcessingException exception) {
+      return objectMapper.createObjectNode().put("message", body);
+    }
   }
+
   private <T> T read(String body, Class<T> type) {
     try {
       if (!StringUtils.hasText(body)) {
-        if (JsonNode.class.equals(type)) return type.cast(objectMapper.createObjectNode());
+        if (JsonNode.class.equals(type)) {
+          return type.cast(objectMapper.createObjectNode());
+        }
         return type.getDeclaredConstructor().newInstance();
       }
       return objectMapper.readValue(body, type);
     } catch (ReflectiveOperationException | JsonProcessingException exception) {
-      throw new LinkUpProtocolException("Link-Up 返回了无法解析的协议数据", exception);
+      throw new LinkUpProtocolException(
+          "Link-Up 返回了无法解析的协议数据",
+          exception);
     }
   }
+
   private String write(Object value) {
-    try { return objectMapper.writeValueAsString(value); }
-    catch (JsonProcessingException exception) { throw new LinkUpProtocolException("序列化 Link-Up 提交协议失败", exception); }
+    try {
+      return objectMapper.writeValueAsString(value);
+    } catch (JsonProcessingException exception) {
+      throw new LinkUpProtocolException(
+          "序列化 Link-Up 提交协议失败",
+          exception);
+    }
   }
+
   private String errorMessage(JsonNode body, String fallback) {
     String message = body.path("message").asText(null);
-    if (!StringUtils.hasText(message)) message = body.path("error").asText(null);
+    if (!StringUtils.hasText(message)) {
+      message = body.path("error").asText(null);
+    }
     return StringUtils.hasText(message) ? message : fallback;
   }
 
-  @Data @NoArgsConstructor @JsonInclude(JsonInclude.Include.NON_NULL)
-  public static class LinkUpSubmitRequest { private String externalExecutionId; private String idempotencyKey; private Integer definitionVersion; private JsonNode jobSpec; }
-  @Data @NoArgsConstructor @JsonIgnoreProperties(ignoreUnknown = true)
-  public static class LinkUpNodeResponse { private String nodeId; private String nodeName; private String instanceId; private String version; private String status; private Long startedAtMillis; private Boolean offlineOnly; private Integer maxConcurrentJobs; private Integer maxQueuedJobs; private Integer runningJobs; private Integer queuedJobs; private Integer activeJobs; private JsonNode lifecycle; }
-  @Data @NoArgsConstructor @JsonIgnoreProperties(ignoreUnknown = true)
-  public static class LinkUpJobResponse { private String jobId; private String externalExecutionId; private String idempotencyKey; private String jobName; private Integer definitionVersion; private String workerNodeId; private String workerInstanceId; private String status; private Long stateVersion; private Boolean cancellationRequested; private Long createTimeMillis; private Long submittedTimeMillis; private Long queuedTimeMillis; private Long startTimeMillis; private Long endTimeMillis; private Long durationMillis; private JsonNode metrics; private JsonNode commitSummary; private JsonNode pipelines; private JsonNode transitions; private String errorCode; private String errorMessage; }
-  public static final class LinkUpRequestException extends RuntimeException { private final int statusCode; private final String code; public LinkUpRequestException(int statusCode, String code, String message) { super(message); this.statusCode = statusCode; this.code = code; } public int getStatusCode() { return statusCode; } public String getCode() { return code; } }
-  public static final class LinkUpTransportException extends RuntimeException { private final boolean uncertain; public LinkUpTransportException(String message, Throwable cause, boolean uncertain) { super(message, cause); this.uncertain = uncertain; } public boolean isUncertain() { return uncertain; } }
-  public static final class LinkUpProtocolException extends RuntimeException { public LinkUpProtocolException(String message) { super(message); } public LinkUpProtocolException(String message, Throwable cause) { super(message, cause); } }
+  @Data
+  @NoArgsConstructor
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  public static class LinkUpSubmitRequest {
+    private String externalExecutionId;
+    private String idempotencyKey;
+    private Integer definitionVersion;
+    private JsonNode jobSpec;
+  }
+
+  @Data
+  @NoArgsConstructor
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public static class LinkUpNodeResponse {
+    private String nodeId;
+    private String nodeName;
+    private String instanceId;
+    private String version;
+    private String status;
+    private Long startedAtMillis;
+    private Boolean offlineOnly;
+    private Integer maxConcurrentJobs;
+    private Integer maxQueuedJobs;
+    private Integer runningJobs;
+    private Integer queuedJobs;
+    private Integer activeJobs;
+    private JsonNode lifecycle;
+  }
+
+  @Data
+  @NoArgsConstructor
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public static class LinkUpJobResponse {
+    private String jobId;
+    private String externalExecutionId;
+    private String idempotencyKey;
+    private String jobName;
+    private Integer definitionVersion;
+    private String workerNodeId;
+    private String workerInstanceId;
+    private String status;
+    private Long stateVersion;
+    private Boolean cancellationRequested;
+    private Long createTimeMillis;
+    private Long submittedTimeMillis;
+    private Long queuedTimeMillis;
+    private Long startTimeMillis;
+    private Long endTimeMillis;
+    private Long durationMillis;
+    private JsonNode metrics;
+    private JsonNode commitSummary;
+    private JsonNode pipelines;
+    private JsonNode transitions;
+    private String errorCode;
+    private String errorMessage;
+  }
+
+  @Data
+  @NoArgsConstructor
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public static class LinkUpJobLogPageResponse {
+    private String jobId;
+    private String externalExecutionId;
+    private String runId;
+    private List<LinkUpJobLogEntry> items;
+    private Long nextCursor;
+    private Boolean completed;
+  }
+
+  @Data
+  @NoArgsConstructor
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public static class LinkUpJobLogEntry {
+    private Long sequence;
+    private Long timestampMillis;
+    private String source;
+    private String level;
+    private String thread;
+    private String logger;
+    private String message;
+  }
+
+  public static final class LinkUpRequestException extends RuntimeException {
+    private final int statusCode;
+    private final String code;
+
+    public LinkUpRequestException(
+        int statusCode,
+        String code,
+        String message) {
+      super(message);
+      this.statusCode = statusCode;
+      this.code = code;
+    }
+
+    public int getStatusCode() {
+      return statusCode;
+    }
+
+    public String getCode() {
+      return code;
+    }
+  }
+
+  public static final class LinkUpTransportException extends RuntimeException {
+    private final boolean uncertain;
+
+    public LinkUpTransportException(
+        String message,
+        Throwable cause,
+        boolean uncertain) {
+      super(message, cause);
+      this.uncertain = uncertain;
+    }
+
+    public boolean isUncertain() {
+      return uncertain;
+    }
+  }
+
+  public static final class LinkUpProtocolException extends RuntimeException {
+    public LinkUpProtocolException(String message) {
+      super(message);
+    }
+
+    public LinkUpProtocolException(
+        String message,
+        Throwable cause) {
+      super(message, cause);
+    }
+  }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineExecutionControlRepository.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineExecutionControlRepository.java
@@ -15,74 +15,240 @@ import org.springframework.stereotype.Repository;
 @Repository
 public class OfflineExecutionControlRepository {
   private final JdbcTemplate jdbc;
-  public OfflineExecutionControlRepository(@Qualifier("offlineSyncDataSource") DataSource dataSource) {
+
+  public OfflineExecutionControlRepository(
+      @Qualifier("offlineSyncDataSource") DataSource dataSource) {
     this.jdbc = new JdbcTemplate(dataSource);
   }
+
   public void lockDefinition(Long id) {
-    Long locked = jdbc.queryForObject("SELECT id FROM yak_offline_job_definition WHERE id=? FOR UPDATE", Long.class, id);
-    if (locked == null) throw new IllegalArgumentException("离线同步任务不存在：" + id);
+    Long locked =
+        jdbc.queryForObject(
+            "SELECT id FROM yak_offline_job_definition WHERE id=? FOR UPDATE",
+            Long.class,
+            id);
+    if (locked == null) {
+      throw new IllegalArgumentException("离线同步任务不存在：" + id);
+    }
   }
+
   public boolean hasActiveExecution(Long id) {
-    Integer count = jdbc.queryForObject("SELECT COUNT(1) FROM yak_offline_job_execution WHERE job_definition_id=? "
-        + "AND status IN ('CREATED','SUBMITTED','QUEUED','RUNNING')", Integer.class, id);
+    Integer count =
+        jdbc.queryForObject(
+            "SELECT COUNT(1) FROM yak_offline_job_execution WHERE job_definition_id=? "
+                + "AND status IN ('CREATED','SUBMITTED','QUEUED','RUNNING')",
+            Integer.class,
+            id);
     return count != null && count > 0;
   }
+
   public List<OfflineJobExecutionPO> findActiveExecutions(int limit) {
-    return jdbc.query("SELECT * FROM yak_offline_job_execution WHERE status IN "
-        + "('CREATED','SUBMITTED','QUEUED','RUNNING') ORDER BY id LIMIT ?",
-        (rs,row)->map(rs), Math.max(1, limit));
+    return jdbc.query(
+        "SELECT * FROM yak_offline_job_execution WHERE status IN "
+            + "('CREATED','SUBMITTED','QUEUED','RUNNING') ORDER BY id LIMIT ?",
+        (rs, row) -> map(rs),
+        Math.max(1, limit));
   }
-  public List<OfflineJobExecutionPO> findRetryCandidates(LocalDateTime now, int limit) {
-    return jdbc.query("SELECT * FROM yak_offline_job_execution WHERE status IN ('FAILED','LOST') "
-        + "AND retry_created=0 AND next_retry_time IS NOT NULL AND next_retry_time<=? "
-        + "ORDER BY next_retry_time LIMIT ?", (rs,row)->map(rs), Timestamp.valueOf(now), Math.max(1,limit));
+
+  public List<OfflineJobExecutionPO> findRetryCandidates(
+      LocalDateTime now,
+      int limit) {
+    return jdbc.query(
+        "SELECT * FROM yak_offline_job_execution WHERE status IN ('FAILED','LOST') "
+            + "AND retry_created=0 AND next_retry_time IS NOT NULL AND next_retry_time<=? "
+            + "ORDER BY next_retry_time LIMIT ?",
+        (rs, row) -> map(rs),
+        Timestamp.valueOf(now),
+        Math.max(1, limit));
   }
+
   public void markRetryCreated(Long id) {
-    jdbc.update("UPDATE yak_offline_job_execution SET retry_created=1, update_time=? WHERE id=?",
-        Timestamp.valueOf(LocalDateTime.now()), id);
+    jdbc.update(
+        "UPDATE yak_offline_job_execution SET retry_created=1, update_time=? WHERE id=?",
+        Timestamp.valueOf(LocalDateTime.now()),
+        id);
   }
-  public void recordExecutionEvent(Long executionId, long version, String from, String to,
-      String type, String message, String payload) {
-    jdbc.update("INSERT INTO yak_offline_execution_event "
-        + "(execution_id,state_version,from_status,to_status,event_type,message,payload_json,create_time) "
-        + "VALUES (?,?,?,?,?,?,?,?)", executionId, version, from, to, type, message, payload,
+
+  public void recordExecutionEvent(
+      Long executionId,
+      long version,
+      String from,
+      String to,
+      String type,
+      String message,
+      String payload) {
+    jdbc.update(
+        "INSERT INTO yak_offline_execution_event "
+            + "(execution_id,state_version,from_status,to_status,event_type,message,payload_json,create_time) "
+            + "VALUES (?,?,?,?,?,?,?,?)",
+        executionId,
+        version,
+        from,
+        to,
+        type,
+        message,
+        payload,
         Timestamp.valueOf(LocalDateTime.now()));
   }
+
   public List<ExecutionEventRecord> listExecutionEvents(Long id) {
-    return jdbc.query("SELECT * FROM yak_offline_execution_event WHERE execution_id=? ORDER BY id",
-        (rs,row)->new ExecutionEventRecord(rs.getLong("id"), rs.getLong("execution_id"),
-            rs.getLong("state_version"), rs.getString("from_status"), rs.getString("to_status"),
-            rs.getString("event_type"), rs.getString("message"), rs.getString("payload_json"),
-            rs.getTimestamp("create_time").toLocalDateTime()), id);
+    return jdbc.query(
+        "SELECT * FROM yak_offline_execution_event WHERE execution_id=? ORDER BY id",
+        (rs, row) -> event(rs),
+        id);
   }
-  private OfflineJobExecutionPO map(java.sql.ResultSet rs) throws java.sql.SQLException {
-    OfflineJobExecutionPO e=new OfflineJobExecutionPO();
-    e.setId(rs.getLong("id")); e.setJobDefinitionId(rs.getLong("job_definition_id"));
-    e.setDefinitionVersion(rs.getInt("definition_version")); e.setEngineBaseUrl(rs.getString("engine_base_url"));
-    e.setEngineJobId(rs.getString("engine_job_id")); e.setExternalExecutionId(rs.getString("external_execution_id"));
-    e.setIdempotencyKey(rs.getString("idempotency_key")); e.setWorkerInstanceId(rs.getString("worker_instance_id"));
-    e.setStatus(rs.getString("status")); e.setStateVersion(rs.getLong("state_version")); e.setAttemptNo(rs.getInt("attempt_no"));
-    e.setTriggerType(rs.getString("trigger_type")); e.setRetryFromExecutionId(nullableLong(rs,"retry_from_execution_id"));
-    e.setCancellationRequested(rs.getBoolean("cancellation_requested")); e.setRetryCreated(rs.getBoolean("retry_created"));
-    e.setNextRetryTime(local(rs.getTimestamp("next_retry_time"))); e.setConfigDigest(rs.getString("config_digest"));
-    e.setDefinitionSnapshotJson(rs.getString("definition_snapshot_json")); e.setSubmittedConfig(rs.getString("submitted_config"));
-    e.setEngineSnapshotJson(rs.getString("engine_snapshot_json")); e.setErrorMessage(rs.getString("error_message"));
-    e.setSourceRecordCount(rs.getLong("source_record_count")); e.setSinkSuccessRecordCount(rs.getLong("sink_success_record_count"));
-    e.setSourceReadBytes(rs.getLong("source_read_bytes")); e.setSinkWrittenBytes(rs.getLong("sink_written_bytes"));
-    e.setQps(rs.getDouble("qps")); e.setDurationMillis(rs.getLong("duration_millis"));
-    e.setCreateTime(local(rs.getTimestamp("create_time"))); e.setStartTime(local(rs.getTimestamp("start_time")));
-    e.setEndTime(local(rs.getTimestamp("end_time"))); e.setLastSyncTime(local(rs.getTimestamp("last_sync_time")));
-    e.setUpdateTime(local(rs.getTimestamp("update_time"))); return e;
+
+  public List<ExecutionEventRecord> listExecutionEventsAfter(
+      Long executionId,
+      long afterId,
+      int limit) {
+    if (afterId < 0L) {
+      throw new IllegalArgumentException("事件游标不能为负数");
+    }
+    if (limit < 1 || limit > 1000) {
+      throw new IllegalArgumentException("日志 limit 必须在 1 到 1000 之间");
+    }
+    return jdbc.query(
+        "SELECT * FROM yak_offline_execution_event "
+            + "WHERE execution_id=? AND id>? ORDER BY id LIMIT ?",
+        (rs, row) -> event(rs),
+        executionId,
+        afterId,
+        limit);
   }
-  private Long nullableLong(java.sql.ResultSet rs,String col)throws java.sql.SQLException{long v=rs.getLong(col);return rs.wasNull()?null:v;}
-  private LocalDateTime local(Timestamp t){return t==null?null:t.toLocalDateTime();}
+
+  private ExecutionEventRecord event(
+      java.sql.ResultSet rs)
+      throws java.sql.SQLException {
+    return new ExecutionEventRecord(
+        rs.getLong("id"),
+        rs.getLong("execution_id"),
+        rs.getLong("state_version"),
+        rs.getString("from_status"),
+        rs.getString("to_status"),
+        rs.getString("event_type"),
+        rs.getString("message"),
+        rs.getString("payload_json"),
+        rs.getTimestamp("create_time").toLocalDateTime());
+  }
+
+  private OfflineJobExecutionPO map(
+      java.sql.ResultSet rs)
+      throws java.sql.SQLException {
+    OfflineJobExecutionPO execution = new OfflineJobExecutionPO();
+    execution.setId(rs.getLong("id"));
+    execution.setJobDefinitionId(rs.getLong("job_definition_id"));
+    execution.setDefinitionVersion(rs.getInt("definition_version"));
+    execution.setEngineBaseUrl(rs.getString("engine_base_url"));
+    execution.setEngineJobId(rs.getString("engine_job_id"));
+    execution.setExternalExecutionId(rs.getString("external_execution_id"));
+    execution.setIdempotencyKey(rs.getString("idempotency_key"));
+    execution.setWorkerInstanceId(rs.getString("worker_instance_id"));
+    execution.setStatus(rs.getString("status"));
+    execution.setStateVersion(rs.getLong("state_version"));
+    execution.setAttemptNo(rs.getInt("attempt_no"));
+    execution.setTriggerType(rs.getString("trigger_type"));
+    execution.setRetryFromExecutionId(nullableLong(rs, "retry_from_execution_id"));
+    execution.setCancellationRequested(rs.getBoolean("cancellation_requested"));
+    execution.setRetryCreated(rs.getBoolean("retry_created"));
+    execution.setNextRetryTime(local(rs.getTimestamp("next_retry_time")));
+    execution.setConfigDigest(rs.getString("config_digest"));
+    execution.setDefinitionSnapshotJson(rs.getString("definition_snapshot_json"));
+    execution.setSubmittedConfig(rs.getString("submitted_config"));
+    execution.setEngineSnapshotJson(rs.getString("engine_snapshot_json"));
+    execution.setErrorMessage(rs.getString("error_message"));
+    execution.setSourceRecordCount(rs.getLong("source_record_count"));
+    execution.setSinkSuccessRecordCount(rs.getLong("sink_success_record_count"));
+    execution.setSourceReadBytes(rs.getLong("source_read_bytes"));
+    execution.setSinkWrittenBytes(rs.getLong("sink_written_bytes"));
+    execution.setQps(rs.getDouble("qps"));
+    execution.setDurationMillis(rs.getLong("duration_millis"));
+    execution.setCreateTime(local(rs.getTimestamp("create_time")));
+    execution.setStartTime(local(rs.getTimestamp("start_time")));
+    execution.setEndTime(local(rs.getTimestamp("end_time")));
+    execution.setLastSyncTime(local(rs.getTimestamp("last_sync_time")));
+    execution.setUpdateTime(local(rs.getTimestamp("update_time")));
+    return execution;
+  }
+
+  private Long nullableLong(
+      java.sql.ResultSet rs,
+      String column)
+      throws java.sql.SQLException {
+    long value = rs.getLong(column);
+    return rs.wasNull() ? null : value;
+  }
+
+  private LocalDateTime local(Timestamp timestamp) {
+    return timestamp == null ? null : timestamp.toLocalDateTime();
+  }
+
   public static final class ExecutionEventRecord {
-    private final Long id,executionId; private final long stateVersion; private final String fromStatus,toStatus,eventType,message,payloadJson;
+    private final Long id;
+    private final Long executionId;
+    private final long stateVersion;
+    private final String fromStatus;
+    private final String toStatus;
+    private final String eventType;
+    private final String message;
+    private final String payloadJson;
     private final LocalDateTime createTime;
-    public ExecutionEventRecord(Long id,Long executionId,long stateVersion,String from,String to,String type,String message,String payload,LocalDateTime time){
-      this.id=id;this.executionId=executionId;this.stateVersion=stateVersion;this.fromStatus=from;this.toStatus=to;this.eventType=type;this.message=message;this.payloadJson=payload;this.createTime=time;}
-    public Long getId(){return id;} public Long getExecutionId(){return executionId;} public long getStateVersion(){return stateVersion;}
-    public String getFromStatus(){return fromStatus;} public String getToStatus(){return toStatus;} public String getEventType(){return eventType;}
-    public String getMessage(){return message;} public String getPayloadJson(){return payloadJson;} public LocalDateTime getCreateTime(){return createTime;}
+
+    public ExecutionEventRecord(
+        Long id,
+        Long executionId,
+        long stateVersion,
+        String fromStatus,
+        String toStatus,
+        String eventType,
+        String message,
+        String payloadJson,
+        LocalDateTime createTime) {
+      this.id = id;
+      this.executionId = executionId;
+      this.stateVersion = stateVersion;
+      this.fromStatus = fromStatus;
+      this.toStatus = toStatus;
+      this.eventType = eventType;
+      this.message = message;
+      this.payloadJson = payloadJson;
+      this.createTime = createTime;
+    }
+
+    public Long getId() {
+      return id;
+    }
+
+    public Long getExecutionId() {
+      return executionId;
+    }
+
+    public long getStateVersion() {
+      return stateVersion;
+    }
+
+    public String getFromStatus() {
+      return fromStatus;
+    }
+
+    public String getToStatus() {
+      return toStatus;
+    }
+
+    public String getEventType() {
+      return eventType;
+    }
+
+    public String getMessage() {
+      return message;
+    }
+
+    public String getPayloadJson() {
+      return payloadJson;
+    }
+
+    public LocalDateTime getCreateTime() {
+      return createTime;
+    }
   }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineExecutionLogService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineExecutionLogService.java
@@ -41,6 +41,47 @@ public class OfflineExecutionLogService {
     this.linkUpClient = linkUpClient;
   }
 
+  public String text(OfflineJobExecutionPO execution) {
+    String cursor = "0:0";
+    String warning = null;
+    StringBuilder result =
+        new StringBuilder("# Yak Ops + Link-Up Unified Timeline\n");
+    result.append("executionId: ")
+        .append(execution == null ? "-" : execution.getId())
+        .append('\n')
+        .append("externalExecutionId: ")
+        .append(execution == null ? "-" : text(execution.getExternalExecutionId()))
+        .append('\n')
+        .append("engineJobId: ")
+        .append(execution == null ? "-" : text(execution.getEngineJobId()))
+        .append("\n\n");
+
+    for (int pageIndex = 0; pageIndex < 20; pageIndex++) {
+      OfflineExecutionLogPageVO page = logs(execution, cursor, 1000);
+      warning = page.getWarning();
+      if (page.getItems() != null) {
+        for (OfflineExecutionLogEntryVO item : page.getItems()) {
+          appendTextLine(result, item);
+        }
+      }
+      if (page.isCompleted()
+          || !StringUtils.hasText(page.getNextCursor())
+          || page.getNextCursor().equals(cursor)) {
+        break;
+      }
+      cursor = page.getNextCursor();
+    }
+
+    if (StringUtils.hasText(warning)) {
+      result.append("\n")
+          .append("- WARN [YAK_OPS] [LOG_AGGREGATION] ")
+          .append(warning)
+          .append('\n');
+    }
+
+    return result.toString();
+  }
+
   public OfflineExecutionLogPageVO logs(
       OfflineJobExecutionPO execution,
       String cursorValue,
@@ -124,6 +165,39 @@ public class OfflineExecutionLogService {
         .linkUpAvailable(linkUpAvailable)
         .warning(warning)
         .build();
+  }
+
+  private void appendTextLine(
+      StringBuilder result,
+      OfflineExecutionLogEntryVO item) {
+    result.append(
+            StringUtils.hasText(item.getTimestamp())
+                ? item.getTimestamp()
+                : "-")
+        .append(' ')
+        .append(
+            StringUtils.hasText(item.getLevel())
+                ? item.getLevel()
+                : "INFO")
+        .append(" [")
+        .append(
+            StringUtils.hasText(item.getSource())
+                ? item.getSource()
+                : "UNKNOWN")
+        .append(']');
+
+    if (StringUtils.hasText(item.getStage())) {
+      result.append(" [")
+          .append(item.getStage())
+          .append(']');
+    }
+
+    result.append(' ')
+        .append(
+            StringUtils.hasText(item.getMessage())
+                ? item.getMessage()
+                : "-")
+        .append('\n');
   }
 
   private OfflineExecutionLogEntryVO toYakOpsEntry(

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineExecutionLogService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineExecutionLogService.java
@@ -1,0 +1,284 @@
+package io.yak.ops.business.sync.offline.service;
+
+import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import io.yak.ops.business.sync.offline.domain.OfflineExecutionStatus;
+import io.yak.ops.business.sync.offline.engine.LinkUpClient;
+import io.yak.ops.business.sync.offline.engine.LinkUpClient.LinkUpJobLogEntry;
+import io.yak.ops.business.sync.offline.engine.LinkUpClient.LinkUpJobLogPageResponse;
+import io.yak.ops.business.sync.offline.engine.LinkUpClient.LinkUpProtocolException;
+import io.yak.ops.business.sync.offline.engine.LinkUpClient.LinkUpRequestException;
+import io.yak.ops.business.sync.offline.engine.LinkUpClient.LinkUpTransportException;
+import io.yak.ops.business.sync.offline.repository.OfflineExecutionControlRepository;
+import io.yak.ops.business.sync.offline.repository.OfflineExecutionControlRepository.ExecutionEventRecord;
+import io.yak.ops.common.bean.po.sync.offline.OfflineJobExecutionPO;
+import io.yak.ops.common.bean.vo.sync.offline.OfflineExecutionLogEntryVO;
+import io.yak.ops.common.bean.vo.sync.offline.OfflineExecutionLogPageVO;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+/** 将 Yak Ops 状态事件和 Link-Up 物理日志合并成统一时间线。 */
+@ConditionalOnOfflineSyncEnabled
+@Component
+public class OfflineExecutionLogService {
+  private static final DateTimeFormatter FORMAT =
+      DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS");
+
+  private final OfflineExecutionControlRepository repository;
+  private final LinkUpClient linkUpClient;
+
+  public OfflineExecutionLogService(
+      OfflineExecutionControlRepository repository,
+      LinkUpClient linkUpClient) {
+    this.repository = repository;
+    this.linkUpClient = linkUpClient;
+  }
+
+  public OfflineExecutionLogPageVO logs(
+      OfflineJobExecutionPO execution,
+      String cursorValue,
+      int limit) {
+    if (execution == null || execution.getId() == null) {
+      throw new IllegalArgumentException("离线同步执行实例不能为空");
+    }
+    if (limit < 1 || limit > 1000) {
+      throw new IllegalArgumentException("日志 limit 必须在 1 到 1000 之间");
+    }
+
+    Cursor cursor = Cursor.parse(cursorValue);
+    List<ExecutionEventRecord> events =
+        repository.listExecutionEventsAfter(
+            execution.getId(),
+            cursor.yakEventId,
+            limit);
+
+    List<OfflineExecutionLogEntryVO> items = new ArrayList<>();
+    long nextYakEventId = cursor.yakEventId;
+    for (ExecutionEventRecord event : events) {
+      items.add(toYakOpsEntry(execution, event));
+      if (event.getId() != null) {
+        nextYakEventId = Math.max(nextYakEventId, event.getId());
+      }
+    }
+
+    long nextLinkCursor = cursor.linkCursor;
+    boolean linkUpAvailable = true;
+    boolean linkUpCompleted = !StringUtils.hasText(execution.getEngineJobId());
+    String warning = null;
+
+    if (StringUtils.hasText(execution.getEngineJobId())) {
+      try {
+        LinkUpJobLogPageResponse response =
+            linkUpClient.logs(
+                execution.getEngineJobId(),
+                cursor.linkCursor,
+                limit);
+        if (response != null) {
+          nextLinkCursor = value(response.getNextCursor(), cursor.linkCursor);
+          linkUpCompleted = Boolean.TRUE.equals(response.getCompleted());
+          if (response.getItems() != null) {
+            for (LinkUpJobLogEntry entry : response.getItems()) {
+              items.add(toLinkUpEntry(execution, response, entry));
+            }
+          }
+        }
+      } catch (LinkUpRequestException exception) {
+        linkUpAvailable = false;
+        warning =
+            exception.getStatusCode() == 404 || exception.getStatusCode() == 405
+                ? "当前 Link-Up 版本尚未提供任务日志接口，请先升级 Worker"
+                : "Link-Up 日志请求失败：" + exception.getMessage();
+      } catch (LinkUpTransportException | LinkUpProtocolException exception) {
+        linkUpAvailable = false;
+        warning = "暂时无法读取 Link-Up 日志：" + exception.getMessage();
+      }
+    }
+
+    items.sort(
+        Comparator.comparing(
+                OfflineExecutionLogEntryVO::getTimestampMillis,
+                Comparator.nullsLast(Long::compareTo))
+            .thenComparing(
+                OfflineExecutionLogEntryVO::getSource,
+                Comparator.nullsLast(String::compareTo))
+            .thenComparingLong(OfflineExecutionLogEntryVO::getSequence));
+
+    boolean terminal = !OfflineExecutionStatus.isActive(execution.getStatus());
+    boolean yakCompleted = events.size() < limit;
+    boolean completed =
+        terminal
+            && yakCompleted
+            && (linkUpCompleted || !linkUpAvailable);
+
+    return OfflineExecutionLogPageVO.builder()
+        .items(items)
+        .nextCursor(Cursor.encode(nextYakEventId, nextLinkCursor))
+        .completed(completed)
+        .linkUpAvailable(linkUpAvailable)
+        .warning(warning)
+        .build();
+  }
+
+  private OfflineExecutionLogEntryVO toYakOpsEntry(
+      OfflineJobExecutionPO execution,
+      ExecutionEventRecord event) {
+    Long timestampMillis = epochMillis(event.getCreateTime());
+    String from = text(event.getFromStatus());
+    String to = text(event.getToStatus());
+    String transition = from + " -> " + to;
+    String message =
+        StringUtils.hasText(event.getMessage())
+            ? transition + " | " + event.getMessage()
+            : transition;
+
+    return OfflineExecutionLogEntryVO.builder()
+        .sequence(value(event.getId(), 0L))
+        .timestampMillis(timestampMillis)
+        .timestamp(format(timestampMillis))
+        .source("YAK_OPS")
+        .level(level(event.getToStatus()))
+        .stage(event.getEventType())
+        .externalExecutionId(execution.getExternalExecutionId())
+        .engineJobId(execution.getEngineJobId())
+        .message(message)
+        .build();
+  }
+
+  private OfflineExecutionLogEntryVO toLinkUpEntry(
+      OfflineJobExecutionPO execution,
+      LinkUpJobLogPageResponse response,
+      LinkUpJobLogEntry entry) {
+    Long timestampMillis = entry == null ? null : entry.getTimestampMillis();
+    String logger = entry == null ? null : entry.getLogger();
+    String message = entry == null ? null : entry.getMessage();
+
+    return OfflineExecutionLogEntryVO.builder()
+        .sequence(entry == null ? 0L : value(entry.getSequence(), 0L))
+        .timestampMillis(timestampMillis)
+        .timestamp(format(timestampMillis))
+        .source("LINK_UP")
+        .level(
+            entry == null || !StringUtils.hasText(entry.getLevel())
+                ? "INFO"
+                : entry.getLevel().toUpperCase(Locale.ROOT))
+        .stage(linkStage(logger, message))
+        .externalExecutionId(
+            firstText(
+                response == null ? null : response.getExternalExecutionId(),
+                execution.getExternalExecutionId()))
+        .engineJobId(
+            firstText(
+                response == null ? null : response.getJobId(),
+                execution.getEngineJobId()))
+        .runId(response == null ? null : response.getRunId())
+        .thread(entry == null ? null : entry.getThread())
+        .logger(logger)
+        .message(message)
+        .build();
+  }
+
+  private String linkStage(String logger, String message) {
+    String normalizedLogger =
+        logger == null ? "" : logger.toLowerCase(Locale.ROOT);
+    String normalizedMessage =
+        message == null ? "" : message.toLowerCase(Locale.ROOT);
+
+    if (normalizedMessage.contains("catalog sql")
+        || normalizedMessage.contains("create table")
+        || normalizedLogger.contains("catalog")) {
+      return "SCHEMA";
+    }
+    if (normalizedLogger.contains("taskexecutor")) {
+      return "TASK";
+    }
+    if (normalizedLogger.contains("jobexecution")) {
+      return "JOB";
+    }
+    if (normalizedLogger.contains("split")) {
+      return "SPLIT";
+    }
+    return "ENGINE";
+  }
+
+  private String level(String status) {
+    if (!StringUtils.hasText(status)) {
+      return "INFO";
+    }
+    String normalized = status.trim().toUpperCase(Locale.ROOT);
+    if ("FAILED".equals(normalized) || "LOST".equals(normalized)) {
+      return "ERROR";
+    }
+    if ("CANCELED".equals(normalized)
+        || "CANCELLED".equals(normalized)) {
+      return "WARN";
+    }
+    return "INFO";
+  }
+
+  private Long epochMillis(LocalDateTime value) {
+    return value == null
+        ? null
+        : value.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli();
+  }
+
+  private String format(Long timestampMillis) {
+    return timestampMillis == null
+        ? null
+        : FORMAT.format(
+            Instant.ofEpochMilli(timestampMillis)
+                .atZone(ZoneId.systemDefault()));
+  }
+
+  private String text(String value) {
+    return StringUtils.hasText(value) ? value : "-";
+  }
+
+  private String firstText(String first, String second) {
+    return StringUtils.hasText(first) ? first : second;
+  }
+
+  private long value(Long value, long fallback) {
+    return value == null ? fallback : value;
+  }
+
+  private static final class Cursor {
+    private final long yakEventId;
+    private final long linkCursor;
+
+    private Cursor(long yakEventId, long linkCursor) {
+      this.yakEventId = yakEventId;
+      this.linkCursor = linkCursor;
+    }
+
+    private static Cursor parse(String value) {
+      if (!StringUtils.hasText(value)) {
+        return new Cursor(0L, 0L);
+      }
+      String[] parts = value.trim().split(":", -1);
+      if (parts.length != 2) {
+        throw new IllegalArgumentException("日志 cursor 格式不正确");
+      }
+      try {
+        long yakEventId = Long.parseLong(parts[0]);
+        long linkCursor = Long.parseLong(parts[1]);
+        if (yakEventId < 0L || linkCursor < 0L) {
+          throw new IllegalArgumentException("日志 cursor 不能为负数");
+        }
+        return new Cursor(yakEventId, linkCursor);
+      } catch (NumberFormatException exception) {
+        throw new IllegalArgumentException("日志 cursor 格式不正确", exception);
+      }
+    }
+
+    private static String encode(long yakEventId, long linkCursor) {
+      return yakEventId + ":" + linkCursor;
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineExecutionLogService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineExecutionLogService.java
@@ -56,7 +56,7 @@ public class OfflineExecutionLogService {
         .append(execution == null ? "-" : text(execution.getEngineJobId()))
         .append("\n\n");
 
-    for (int pageIndex = 0; pageIndex < 20; pageIndex++) {
+    for (int pageIndex = 0; pageIndex < 100; pageIndex++) {
       OfflineExecutionLogPageVO page = logs(execution, cursor, 1000);
       warning = page.getWarning();
       if (page.getItems() != null) {
@@ -99,42 +99,33 @@ public class OfflineExecutionLogService {
             execution.getId(),
             cursor.yakEventId,
             limit);
-
-    List<OfflineExecutionLogEntryVO> items = new ArrayList<>();
-    long nextYakEventId = cursor.yakEventId;
+    List<OfflineExecutionLogEntryVO> yakItems = new ArrayList<>();
     for (ExecutionEventRecord event : events) {
-      items.add(toYakOpsEntry(execution, event));
-      if (event.getId() != null) {
-        nextYakEventId = Math.max(nextYakEventId, event.getId());
-      }
+      yakItems.add(toYakOpsEntry(execution, event));
     }
 
-    long nextLinkCursor = cursor.linkCursor;
+    List<OfflineExecutionLogEntryVO> linkItems = new ArrayList<>();
+    LinkUpJobLogPageResponse linkResponse = null;
     boolean linkUpAvailable = true;
-    boolean linkUpCompleted = !StringUtils.hasText(execution.getEngineJobId());
     String warning = null;
 
     if (StringUtils.hasText(execution.getEngineJobId())) {
       try {
-        LinkUpJobLogPageResponse response =
+        linkResponse =
             linkUpClient.logs(
                 execution.getEngineJobId(),
                 cursor.linkCursor,
                 limit);
-        if (response != null) {
-          nextLinkCursor = value(response.getNextCursor(), cursor.linkCursor);
-          linkUpCompleted = Boolean.TRUE.equals(response.getCompleted());
-          if (response.getItems() != null) {
-            for (LinkUpJobLogEntry entry : response.getItems()) {
-              items.add(toLinkUpEntry(execution, response, entry));
-            }
+        if (linkResponse != null && linkResponse.getItems() != null) {
+          for (LinkUpJobLogEntry entry : linkResponse.getItems()) {
+            linkItems.add(toLinkUpEntry(execution, linkResponse, entry));
           }
         }
       } catch (LinkUpRequestException exception) {
         linkUpAvailable = false;
         warning =
             exception.getStatusCode() == 404 || exception.getStatusCode() == 405
-                ? "当前 Link-Up 版本尚未提供任务日志接口，请先升级 Worker"
+                ? "Link-Up 不支持任务日志接口，或该任务日志已不在 Worker 历史中"
                 : "Link-Up 日志请求失败：" + exception.getMessage();
       } catch (LinkUpTransportException | LinkUpProtocolException exception) {
         linkUpAvailable = false;
@@ -142,29 +133,77 @@ public class OfflineExecutionLogService {
       }
     }
 
-    items.sort(
-        Comparator.comparing(
-                OfflineExecutionLogEntryVO::getTimestampMillis,
-                Comparator.nullsLast(Long::compareTo))
-            .thenComparing(
-                OfflineExecutionLogEntryVO::getSource,
-                Comparator.nullsLast(String::compareTo))
-            .thenComparingLong(OfflineExecutionLogEntryVO::getSequence));
+    List<OfflineExecutionLogEntryVO> merged = new ArrayList<>();
+    merged.addAll(yakItems);
+    merged.addAll(linkItems);
+    merged.sort(logComparator());
+
+    List<OfflineExecutionLogEntryVO> selected =
+        new ArrayList<>(merged.subList(0, Math.min(limit, merged.size())));
+
+    int selectedYakCount = count(selected, "YAK_OPS");
+    int selectedLinkCount = count(selected, "LINK_UP");
+
+    long nextYakEventId = cursor.yakEventId;
+    if (selectedYakCount > 0) {
+      nextYakEventId =
+          yakItems.get(selectedYakCount - 1).getSequence();
+    }
+
+    long nextLinkCursor = cursor.linkCursor;
+    if (selectedLinkCount < linkItems.size()) {
+      nextLinkCursor =
+          linkItems.get(selectedLinkCount).getSequence();
+    } else if (linkResponse != null) {
+      nextLinkCursor =
+          value(linkResponse.getNextCursor(), cursor.linkCursor);
+    }
 
     boolean terminal = !OfflineExecutionStatus.isActive(execution.getStatus());
-    boolean yakCompleted = events.size() < limit;
-    boolean completed =
-        terminal
-            && yakCompleted
-            && (linkUpCompleted || !linkUpAvailable);
+    boolean yakCompleted =
+        selectedYakCount == yakItems.size()
+            && events.size() < limit;
+    boolean linkCompleted;
+    if (!StringUtils.hasText(execution.getEngineJobId())) {
+      linkCompleted = true;
+    } else if (!linkUpAvailable) {
+      linkCompleted = terminal;
+    } else {
+      linkCompleted =
+          selectedLinkCount == linkItems.size()
+              && linkResponse != null
+              && Boolean.TRUE.equals(linkResponse.getCompleted());
+    }
 
     return OfflineExecutionLogPageVO.builder()
-        .items(items)
+        .items(selected)
         .nextCursor(Cursor.encode(nextYakEventId, nextLinkCursor))
-        .completed(completed)
+        .completed(terminal && yakCompleted && linkCompleted)
         .linkUpAvailable(linkUpAvailable)
         .warning(warning)
         .build();
+  }
+
+  private Comparator<OfflineExecutionLogEntryVO> logComparator() {
+    return Comparator.comparing(
+            OfflineExecutionLogEntryVO::getTimestampMillis,
+            Comparator.nullsLast(Long::compareTo))
+        .thenComparing(
+            OfflineExecutionLogEntryVO::getSource,
+            Comparator.nullsLast(String::compareTo))
+        .thenComparingLong(OfflineExecutionLogEntryVO::getSequence);
+  }
+
+  private int count(
+      List<OfflineExecutionLogEntryVO> items,
+      String source) {
+    int result = 0;
+    for (OfflineExecutionLogEntryVO item : items) {
+      if (source.equals(item.getSource())) {
+        result++;
+      }
+    }
+    return result;
   }
 
   private void appendTextLine(

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineJobExecutionService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineJobExecutionService.java
@@ -80,9 +80,9 @@ public class OfflineJobExecutionService {
     return readService.tableMetrics(id);
   }
 
-  /** 旧文本接口保留给历史页面和脚本。 */
+  /** 旧文本接口保留，并直接渲染新的统一时间线。 */
   public String logs(Long id) {
-    return readService.logs(id);
+    return logService.text(readService.require(id));
   }
 
   public OfflineExecutionLogPageVO logs(

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineJobExecutionService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineJobExecutionService.java
@@ -8,25 +8,141 @@ import io.yak.ops.common.bean.dto.sync.offline.OfflineBatchOperationDTO;
 import io.yak.ops.common.bean.dto.sync.offline.OfflineJobExecutionQueryDTO;
 import io.yak.ops.common.bean.po.sync.offline.OfflineJobDefinitionPO;
 import io.yak.ops.common.bean.po.sync.offline.OfflineJobExecutionPO;
-import io.yak.ops.common.bean.vo.sync.offline.*;
+import io.yak.ops.common.bean.vo.sync.offline.OfflineBatchOperationErrorVO;
+import io.yak.ops.common.bean.vo.sync.offline.OfflineBatchOperationVO;
+import io.yak.ops.common.bean.vo.sync.offline.OfflineExecutionLogPageVO;
+import io.yak.ops.common.bean.vo.sync.offline.OfflineJobExecutionDetailVO;
+import io.yak.ops.common.bean.vo.sync.offline.OfflineJobExecutionVO;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 /** 离线同步执行门面。 */
-@ConditionalOnOfflineSyncEnabled @Service @RequiredArgsConstructor
+@ConditionalOnOfflineSyncEnabled
+@Service
+@RequiredArgsConstructor
 public class OfflineJobExecutionService {
-  private final OfflineExecutionOrchestrator orchestrator;private final OfflineExecutionReadService readService;private final OfflineJobDefinitionService definitionService;
-  public OfflineJobExecutionVO execute(Long id){return readService.toVO(orchestrator.execute(id,"MANUAL",null,1));}
-  public OfflineJobExecutionVO executeScheduled(Long id){return readService.toVO(orchestrator.execute(id,"SCHEDULE",null,1));}
-  public OfflineJobExecutionVO retry(Long id){return readService.toVO(orchestrator.retryFrom(readService.require(id)));}
-  public OfflineJobExecutionVO retryFrom(OfflineJobExecutionPO previous){return readService.toVO(orchestrator.retryFrom(previous));}
-  public OfflineJobExecutionVO cancel(Long id){return readService.toVO(orchestrator.cancel(id));}
-  public OfflineJobExecutionVO cancelLatest(Long definitionId){OfflineJobDefinitionPO d=definitionService.require(definitionId);if(d.getLastExecutionId()==null)throw new IllegalStateException("任务没有可停止的执行实例");return cancel(d.getLastExecutionId());}
-  public OfflineBatchOperationVO batchExecute(OfflineBatchOperationDTO dto){return batch(dto,true);}public OfflineBatchOperationVO batchCancel(OfflineBatchOperationDTO dto){return batch(dto,false);}
-  public PagingData<OfflineJobExecutionVO> page(OfflineJobExecutionQueryDTO dto){return readService.page(dto);}public OfflineJobExecutionDetailVO detail(Long id){return readService.detail(id);}
-  public JsonNode tableMetrics(Long id){return readService.tableMetrics(id);}public String logs(Long id){return readService.logs(id);}
-  public void applySnapshot(OfflineJobExecutionPO e,LinkUpJobResponse r,String type){orchestrator.applySnapshot(e,r,type);}public void markLost(OfflineJobExecutionPO e,String message){orchestrator.markLost(e,message);}
-  private OfflineBatchOperationVO batch(OfflineBatchOperationDTO dto,boolean execute){if(dto==null||dto.getJobDefinitionIds()==null||dto.getJobDefinitionIds().isEmpty())throw new IllegalArgumentException("jobDefinitionIds 不能为空");int success=0;List<OfflineBatchOperationErrorVO> errors=new ArrayList<>();for(Long id:dto.getJobDefinitionIds()){try{if(id==null||id<=0)throw new IllegalArgumentException("任务定义 ID 不合法");if(execute)execute(id);else cancelLatest(id);success++;}catch(RuntimeException e){errors.add(OfflineBatchOperationErrorVO.builder().jobDefinitionId(id).message(e.getMessage()).build());}}return OfflineBatchOperationVO.builder().successCount(success).failedCount(errors.size()).errors(errors).build();}
+  private final OfflineExecutionOrchestrator orchestrator;
+  private final OfflineExecutionReadService readService;
+  private final OfflineExecutionLogService logService;
+  private final OfflineJobDefinitionService definitionService;
+
+  public OfflineJobExecutionVO execute(Long id) {
+    return readService.toVO(
+        orchestrator.execute(id, "MANUAL", null, 1));
+  }
+
+  public OfflineJobExecutionVO executeScheduled(Long id) {
+    return readService.toVO(
+        orchestrator.execute(id, "SCHEDULE", null, 1));
+  }
+
+  public OfflineJobExecutionVO retry(Long id) {
+    return readService.toVO(
+        orchestrator.retryFrom(readService.require(id)));
+  }
+
+  public OfflineJobExecutionVO retryFrom(OfflineJobExecutionPO previous) {
+    return readService.toVO(orchestrator.retryFrom(previous));
+  }
+
+  public OfflineJobExecutionVO cancel(Long id) {
+    return readService.toVO(orchestrator.cancel(id));
+  }
+
+  public OfflineJobExecutionVO cancelLatest(Long definitionId) {
+    OfflineJobDefinitionPO definition = definitionService.require(definitionId);
+    if (definition.getLastExecutionId() == null) {
+      throw new IllegalStateException("任务没有可停止的执行实例");
+    }
+    return cancel(definition.getLastExecutionId());
+  }
+
+  public OfflineBatchOperationVO batchExecute(OfflineBatchOperationDTO request) {
+    return batch(request, true);
+  }
+
+  public OfflineBatchOperationVO batchCancel(OfflineBatchOperationDTO request) {
+    return batch(request, false);
+  }
+
+  public PagingData<OfflineJobExecutionVO> page(
+      OfflineJobExecutionQueryDTO query) {
+    return readService.page(query);
+  }
+
+  public OfflineJobExecutionDetailVO detail(Long id) {
+    return readService.detail(id);
+  }
+
+  public JsonNode tableMetrics(Long id) {
+    return readService.tableMetrics(id);
+  }
+
+  /** 旧文本接口保留给历史页面和脚本。 */
+  public String logs(Long id) {
+    return readService.logs(id);
+  }
+
+  public OfflineExecutionLogPageVO logs(
+      Long id,
+      String cursor,
+      int limit) {
+    return logService.logs(
+        readService.require(id),
+        cursor,
+        limit);
+  }
+
+  public void applySnapshot(
+      OfflineJobExecutionPO execution,
+      LinkUpJobResponse response,
+      String type) {
+    orchestrator.applySnapshot(execution, response, type);
+  }
+
+  public void markLost(
+      OfflineJobExecutionPO execution,
+      String message) {
+    orchestrator.markLost(execution, message);
+  }
+
+  private OfflineBatchOperationVO batch(
+      OfflineBatchOperationDTO request,
+      boolean execute) {
+    if (request == null
+        || request.getJobDefinitionIds() == null
+        || request.getJobDefinitionIds().isEmpty()) {
+      throw new IllegalArgumentException("jobDefinitionIds 不能为空");
+    }
+
+    int success = 0;
+    List<OfflineBatchOperationErrorVO> errors = new ArrayList<>();
+    for (Long id : request.getJobDefinitionIds()) {
+      try {
+        if (id == null || id <= 0L) {
+          throw new IllegalArgumentException("任务定义 ID 不合法");
+        }
+        if (execute) {
+          execute(id);
+        } else {
+          cancelLatest(id);
+        }
+        success++;
+      } catch (RuntimeException exception) {
+        errors.add(
+            OfflineBatchOperationErrorVO.builder()
+                .jobDefinitionId(id)
+                .message(exception.getMessage())
+                .build());
+      }
+    }
+
+    return OfflineBatchOperationVO.builder()
+        .successCount(success)
+        .failedCount(errors.size())
+        .errors(errors)
+        .build();
+  }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/service/OfflineExecutionLogServiceTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/service/OfflineExecutionLogServiceTest.java
@@ -48,6 +48,8 @@ class OfflineExecutionLogServiceTest {
             eventTime);
     when(repository.listExecutionEventsAfter(3L, 0L, 100))
         .thenReturn(List.of(event));
+    when(repository.listExecutionEventsAfter(3L, 0L, 1000))
+        .thenReturn(List.of(event));
 
     LinkUpJobLogEntry linkEntry = new LinkUpJobLogEntry();
     linkEntry.setSequence(12L);
@@ -72,6 +74,8 @@ class OfflineExecutionLogServiceTest {
     linkPage.setCompleted(true);
     when(linkUpClient.logs("flux-3", 0L, 100))
         .thenReturn(linkPage);
+    when(linkUpClient.logs("flux-3", 0L, 1000))
+        .thenReturn(linkPage);
 
     OfflineExecutionLogPageVO result =
         service.logs(execution, "0:0", 100);
@@ -83,5 +87,10 @@ class OfflineExecutionLogServiceTest {
     assertTrue(result.isCompleted());
     assertTrue(result.isLinkUpAvailable());
     assertEquals("orders-1", result.getItems().get(1).getRunId());
+
+    String text = service.text(execution);
+    assertTrue(text.contains("2026-08-06 08:53:10.100"));
+    assertTrue(text.contains("[YAK_OPS]"));
+    assertTrue(text.contains("[LINK_UP]"));
   }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/service/OfflineExecutionLogServiceTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/service/OfflineExecutionLogServiceTest.java
@@ -1,0 +1,87 @@
+package io.yak.ops.business.sync.offline.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.sync.offline.engine.LinkUpClient;
+import io.yak.ops.business.sync.offline.engine.LinkUpClient.LinkUpJobLogEntry;
+import io.yak.ops.business.sync.offline.engine.LinkUpClient.LinkUpJobLogPageResponse;
+import io.yak.ops.business.sync.offline.repository.OfflineExecutionControlRepository;
+import io.yak.ops.business.sync.offline.repository.OfflineExecutionControlRepository.ExecutionEventRecord;
+import io.yak.ops.common.bean.po.sync.offline.OfflineJobExecutionPO;
+import io.yak.ops.common.bean.vo.sync.offline.OfflineExecutionLogPageVO;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class OfflineExecutionLogServiceTest {
+
+  @Test
+  void mergesControlPlaneAndWorkerLogsByTimestamp() {
+    OfflineExecutionControlRepository repository =
+        mock(OfflineExecutionControlRepository.class);
+    LinkUpClient linkUpClient = mock(LinkUpClient.class);
+    OfflineExecutionLogService service =
+        new OfflineExecutionLogService(repository, linkUpClient);
+
+    OfflineJobExecutionPO execution = new OfflineJobExecutionPO();
+    execution.setId(3L);
+    execution.setStatus("SUCCEEDED");
+    execution.setExternalExecutionId("yak-offline-3");
+    execution.setEngineJobId("flux-3");
+
+    LocalDateTime eventTime =
+        LocalDateTime.of(2026, 8, 6, 8, 53, 10, 100_000_000);
+    ExecutionEventRecord event =
+        new ExecutionEventRecord(
+            7L,
+            3L,
+            2L,
+            "CREATED",
+            "SUBMITTED",
+            "SUBMITTING",
+            "正在向 Link-Up 提交 JobSpec",
+            null,
+            eventTime);
+    when(repository.listExecutionEventsAfter(3L, 0L, 100))
+        .thenReturn(List.of(event));
+
+    LinkUpJobLogEntry linkEntry = new LinkUpJobLogEntry();
+    linkEntry.setSequence(12L);
+    linkEntry.setTimestampMillis(
+        eventTime
+                .plusNanos(100_000_000)
+                .atZone(ZoneId.systemDefault())
+                .toInstant()
+                .toEpochMilli());
+    linkEntry.setLevel("INFO");
+    linkEntry.setThread("link-up-job-1");
+    linkEntry.setLogger("c.l.u.f.e.JobExecution");
+    linkEntry.setMessage("Job started");
+
+    LinkUpJobLogPageResponse linkPage =
+        new LinkUpJobLogPageResponse();
+    linkPage.setJobId("flux-3");
+    linkPage.setExternalExecutionId("yak-offline-3");
+    linkPage.setRunId("orders-1");
+    linkPage.setItems(List.of(linkEntry));
+    linkPage.setNextCursor(120L);
+    linkPage.setCompleted(true);
+    when(linkUpClient.logs("flux-3", 0L, 100))
+        .thenReturn(linkPage);
+
+    OfflineExecutionLogPageVO result =
+        service.logs(execution, "0:0", 100);
+
+    assertEquals(2, result.getItems().size());
+    assertEquals("YAK_OPS", result.getItems().get(0).getSource());
+    assertEquals("LINK_UP", result.getItems().get(1).getSource());
+    assertEquals("7:120", result.getNextCursor());
+    assertTrue(result.isCompleted());
+    assertTrue(result.isLinkUpAvailable());
+    assertEquals("orders-1", result.getItems().get(1).getRunId());
+  }
+}

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/vo/sync/offline/OfflineExecutionLogEntryVO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/vo/sync/offline/OfflineExecutionLogEntryVO.java
@@ -1,0 +1,27 @@
+package io.yak.ops.common.bean.vo.sync.offline;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/** Yak Ops 与 Link-Up 统一执行日志条目。 */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class OfflineExecutionLogEntryVO {
+  private long sequence;
+  private Long timestampMillis;
+  private String timestamp;
+  /** YAK_OPS / LINK_UP。 */
+  private String source;
+  private String level;
+  private String stage;
+  private String externalExecutionId;
+  private String engineJobId;
+  private String runId;
+  private String thread;
+  private String logger;
+  private String message;
+}

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/vo/sync/offline/OfflineExecutionLogPageVO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/vo/sync/offline/OfflineExecutionLogPageVO.java
@@ -1,0 +1,20 @@
+package io.yak.ops.common.bean.vo.sync.offline;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/** 带复合游标的统一执行日志分页。 */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class OfflineExecutionLogPageVO {
+  private List<OfflineExecutionLogEntryVO> items;
+  private String nextCursor;
+  private boolean completed;
+  private boolean linkUpAvailable;
+  private String warning;
+}

--- a/yak-ops-ui/src/pages/batch-link-up/api.ts
+++ b/yak-ops-ui/src/pages/batch-link-up/api.ts
@@ -145,6 +145,29 @@ export interface OfflineTableMetric {
   ddlErrorMessage?: string;
 }
 
+export interface OfflineExecutionLogEntry {
+  sequence: number;
+  timestampMillis?: number;
+  timestamp?: string;
+  source: 'YAK_OPS' | 'LINK_UP' | string;
+  level: string;
+  stage?: string;
+  externalExecutionId?: string;
+  engineJobId?: string;
+  runId?: string;
+  thread?: string;
+  logger?: string;
+  message?: string;
+}
+
+export interface OfflineExecutionLogPage {
+  items: OfflineExecutionLogEntry[];
+  nextCursor: string;
+  completed: boolean;
+  linkUpAvailable: boolean;
+  warning?: string;
+}
+
 export interface OfflineBatchOperationError {
   jobDefinitionId?: string | number;
   message?: string;
@@ -275,6 +298,14 @@ export const linkupJobInstanceApi = {
     HttpUtils.get(`${instanceApiPrefix}/${id}`),
   getLog: (instanceId: string | number): Promise<ApiResponse<string>> =>
     HttpUtils.get(`${instanceApiPrefix}/${instanceId}/log`),
+  getLogs: (
+    instanceId: string | number,
+    cursor = '0:0',
+    limit = 500,
+  ): Promise<ApiResponse<OfflineExecutionLogPage>> =>
+    HttpUtils.get(
+      `${instanceApiPrefix}/${encodeURIComponent(instanceId)}/logs?cursor=${encodeURIComponent(cursor)}&limit=${limit}`,
+    ),
 };
 
 const linkupJobScheduleApiPrefix = '/api/v1/job/schedule';
@@ -319,4 +350,12 @@ export const batchJobInstanceApi = {
     ),
   log: (instanceId: string | number): Promise<ApiResponse<string>> =>
     HttpUtils.get(`/api/v1/job/batch-instance/${instanceId}/log`),
+  logs: (
+    instanceId: string | number,
+    cursor = '0:0',
+    limit = 500,
+  ): Promise<ApiResponse<OfflineExecutionLogPage>> =>
+    HttpUtils.get(
+      `/api/v1/job/batch-instance/${encodeURIComponent(instanceId)}/logs?cursor=${encodeURIComponent(cursor)}&limit=${limit}`,
+    ),
 };


### PR DESCRIPTION
## 背景

配套 `weifuwan/yak-link-up#60`，Yak Ops 需要把控制面的执行状态事件和 Worker 的物理 Job 日志合并为一条统一时间线。

当前离线同步详情页只调用：

```http
GET /api/v1/job/batch-instance/{id}/log
```

返回内容主要由执行实例字段和 `yak_offline_execution_event` 临时拼接，无法展示 Link-Up 的元数据发现、自动建表、Split、Pipeline 和 Task 日志。

## 立即生效的统一文本日志

保留原有 `/log` 接口和前端调用方式，但返回内容改为统一时间线：

```text
2026-08-06 08:53:10.100 INFO [YAK_OPS] [SUBMITTING] CREATED -> SUBMITTED | 正在向 Link-Up 提交 JobSpec
2026-08-06 08:53:13.557 INFO [LINK_UP] [SCHEMA] 执行 Catalog SQL：CREATE TABLE ...
2026-08-06 08:53:13.855 INFO [LINK_UP] [JOB] Job started
2026-08-06 08:53:19.021 INFO [LINK_UP] [JOB] Job finished: status=SUCCEEDED
2026-08-06 08:53:22.000 INFO [YAK_OPS] [RECONCILED] RUNNING -> SUCCEEDED
```

因此现有“运行日志”终端区域不需要重构即可立即显示：

- 毫秒级时间；
- 日志级别；
- `YAK_OPS / LINK_UP` 来源；
- 执行阶段；
- 按时间交错排列的两端日志。

## 新增结构化接口

```http
GET /api/v1/job/batch-instance/{id}/logs?cursor=0:0&limit=500
```

响应示例：

```json
{
  "items": [
    {
      "sequence": 7,
      "timestampMillis": 1785977590100,
      "timestamp": "2026-08-06 08:53:10.100",
      "source": "YAK_OPS",
      "level": "INFO",
      "stage": "SUBMITTING",
      "externalExecutionId": "yak-offline-3",
      "engineJobId": "flux-3",
      "message": "CREATED -> SUBMITTED | 正在向 Link-Up 提交 JobSpec"
    }
  ],
  "nextCursor": "7:226",
  "completed": false,
  "linkUpAvailable": true
}
```

复合游标由两部分组成：

```text
Yak Ops execution event ID : Link-Up log byte offset
```

服务端对两个来源执行真正的双路归并，只推进本页实际返回日志对应的游标，避免高密度 Worker 日志跨页时破坏时间顺序。

## 聚合逻辑

- Yak Ops 日志来自现有 `yak_offline_execution_event`，按事件主键增量读取；
- Link-Up 日志来自 PR #60 新增的 `/api/v1/jobs/{jobId}/logs`；
- 两端统一转换为 `OfflineExecutionLogEntryVO`；
- 按 `timestampMillis + source + sequence` 稳定排序；
- Yak Ops 事件自动映射 INFO/WARN/ERROR；
- Link-Up 日志根据 logger 和 message 归类为 `SCHEMA / SPLIT / TASK / JOB / ENGINE`；
- 终态且两边游标都到末尾时返回 `completed=true`。

## 兼容与降级

- 旧 `/log` 文本接口保留，现有页面和脚本继续工作；
- 新增 `/logs` 结构化接口及 TypeScript 类型，后续可直接增加“全部 / Yak Ops / Link-Up”、级别筛选和自动滚动；
- 连接旧 Worker、Worker 重启、任务超出 Link-Up 内存历史或 Worker 暂时不可达时，不让整个日志接口失败；
- 页面继续展示 Yak Ops 状态事件，并通过 `warning` 提示 Link-Up 日志不可用；
- 不新增日志业务表，不复制大段 Worker 日志到 MySQL；
- 不增加 Flyway 迁移，不修改执行表、状态机、重试、取消或调度结构。

## 前端契约

`batch-link-up/api.ts` 新增：

- `OfflineExecutionLogEntry`；
- `OfflineExecutionLogPage`；
- `getLogs / logs(instanceId, cursor, limit)`。

当前详情页继续使用原 `/log`，因此本 PR 合并后即可看到统一时间线；结构化接口为后续丰富的日志筛选交互预留。

## 测试

新增 `OfflineExecutionLogServiceTest`，覆盖：

- Yak Ops 与 Link-Up 日志按毫秒时间交错排序；
- 复合游标推进；
- 终态完成判断；
- runId 透出；
- 旧 `/log` 文本中包含毫秒时间、`YAK_OPS` 和 `LINK_UP`。

当前执行环境没有 Maven 和完整前端依赖，未运行完整构建。已完成源码级 Spring 注入、旧接口兼容、双路游标、降级路径和无数据库迁移复核。合并前建议执行：

```bash
mvn -pl yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline -am test
cd yak-ops-ui
npm run tsc
npm run build
```

## 依赖与发布顺序

依赖：`weifuwan/yak-link-up#60`

建议：

1. 先合并并发布 Link-Up PR #60；
2. 验证 `/api/v1/jobs/{jobId}/logs`；
3. 再合并本 PR；
4. 执行一次单表和多表任务，检查统一时间线和准备阶段失败日志。