### PR TITLE
fix(data-quality): move menu to top-level navigation

### DIFF
--- a/yak-ops-boot/src/main/resources/yak-security/db/migration/V2000__register_data_quality_rule_template_menu.sql
+++ b/yak-ops-boot/src/main/resources/yak-security/db/migration/V2000__register_data_quality_rule_template_menu.sql
@@ -48,13 +48,14 @@ declared = VALUES(declared),
 menu_code = VALUES(menu_code),
 is_delete = 0;
 
--- 3. 菜单层级：资源管理 -> 数据质量 -> 规则模板库。
+-- 3. 菜单层级：数据质量 -> 规则模板库。
+-- 数据质量与资源管理同为一级目录。
 INSERT INTO yak_security_menu
 (menu_code, menu_name, parent_code, route_path, icon_key, menu_type,
  sort_order, visible, active, required_permission_code, description, app_name)
 VALUES
-('data-quality', '数据质量', 'resources', NULL, 'quality', 1,
- 30, 1, 1, NULL, '数据质量页面目录', '${appName}'),
+('data-quality', '数据质量', NULL, NULL, 'quality', 1,
+ 30, 1, 1, NULL, '数据质量页面入口', '${appName}'),
 ('data-quality-rule-template', '规则模板库', 'data-quality',
  '/data-quality/rule-template', 'quality', 2,
  10, 1, 1, 'quality:template:read', '数据质量规则模板库', '${appName}')
@@ -92,7 +93,7 @@ WHERE role_permission.app_name = '${appName}'
   AND role_permission.is_delete = 0
 ON DUPLICATE KEY UPDATE is_delete = 0;
 
--- 5. 回填数据质量目录和资源管理根目录。
+-- 5. 回填规则模板库所属的数据质量一级目录。
 INSERT INTO yak_security_role_menu(role_id, menu_id, app_name)
 SELECT DISTINCT role_menu.role_id,
                 parent_menu.id,
@@ -112,26 +113,7 @@ WHERE role_menu.app_name = '${appName}'
   AND role_menu.is_delete = 0
 ON DUPLICATE KEY UPDATE is_delete = 0;
 
-INSERT INTO yak_security_role_menu(role_id, menu_id, app_name)
-SELECT DISTINCT role_menu.role_id,
-                parent_menu.id,
-                role_menu.app_name
-FROM yak_security_role_menu role_menu
-JOIN yak_security_menu child_menu
-  ON child_menu.id = role_menu.menu_id
- AND child_menu.menu_code = 'data-quality'
- AND child_menu.app_name = role_menu.app_name
- AND child_menu.is_delete = 0
-JOIN yak_security_menu parent_menu
-  ON parent_menu.menu_code = 'resources'
- AND parent_menu.app_name = role_menu.app_name
- AND parent_menu.is_delete = 0
- AND parent_menu.active = 1
-WHERE role_menu.app_name = '${appName}'
-  AND role_menu.is_delete = 0
-ON DUPLICATE KEY UPDATE is_delete = 0;
-
--- 6. root 角色直接获得新增的目录和页面菜单。
+-- 6. root 角色直接获得新增的数据质量目录和页面菜单。
 INSERT INTO yak_security_role_menu(role_id, menu_id, app_name)
 SELECT DISTINCT role_permission.role_id,
                 menu_row.id,
@@ -143,7 +125,7 @@ JOIN yak_security_permission permission_row
  AND permission_row.permission_code = 'security:root'
  AND permission_row.is_delete = 0
 JOIN yak_security_menu menu_row
-  ON menu_row.menu_code IN ('resources', 'data-quality', 'data-quality-rule-template')
+  ON menu_row.menu_code IN ('data-quality', 'data-quality-rule-template')
  AND menu_row.app_name = role_permission.app_name
  AND menu_row.is_delete = 0
  AND menu_row.active = 1

--- a/yak-ops-ui/src/config/navigation.test.ts
+++ b/yak-ops-ui/src/config/navigation.test.ts
@@ -26,13 +26,15 @@ describe('permission-aware navigation', () => {
     expect(getQuickCreateRoutes([...batchRead, 'task:batch:create']).map((route) => route.id)).toEqual(['batch-link-up']);
   });
 
-  it('registers the rule template library below resource management', () => {
+  it('registers data quality as a top-level group with rule template library', () => {
     const qualityRead = ['quality:template:read'];
     const groups = getMainNavigationGroups(qualityRead);
-    expect(groups.map((group) => group.id)).toEqual(['resources']);
+    expect(groups.map((group) => group.id)).toEqual(['data-quality']);
+    expect(groups[0].title).toBe('数据质量');
     expect(groups[0].routes.map((route) => route.id)).toEqual([
       'data-quality-rule-template',
     ]);
+    expect(groups[0].routes[0].title).toBe('规则模板库');
     expect(getActiveNavigationId('/data-quality/rule-template', qualityRead)).toBe(
       'data-quality-rule-template',
     );

--- a/yak-ops-ui/src/config/navigation.ts
+++ b/yak-ops-ui/src/config/navigation.ts
@@ -28,7 +28,8 @@ export interface NavigationGroupWithRoutes extends NavigationGroup {
 export const navigationGroups: readonly NavigationGroup[] = [
   { id: 'integration', title: '数据集成', iconKey: 'sync', section: 'task', order: 10 },
   { id: 'resources', title: '资源管理', iconKey: 'database', section: 'management', order: 20 },
-  { id: 'system', title: '系统管理', iconKey: 'system', section: 'system', order: 30 },
+  { id: 'data-quality', title: '数据质量', iconKey: 'quality', section: 'management', order: 30 },
+  { id: 'system', title: '系统管理', iconKey: 'system', section: 'system', order: 40 },
 ];
 
 export const appRoutes: readonly NavigationRoute[] = [
@@ -45,7 +46,7 @@ export const appRoutes: readonly NavigationRoute[] = [
   { id: 'batch-link-up-multi', path: '/sync/batch-link-up/:id/config/multi', title: '多表同步配置', component: './batch-link-up/config/multi', hidden: true, parentId: 'batch-link-up' },
   { id: 'batch-link-up-script', path: '/sync/batch-link-up/:id/config/script', title: '脚本同步配置', component: './batch-link-up/config/script', hidden: true, parentId: 'batch-link-up' },
   { id: 'resource-management', mode: 'one', permission: 'resource:view', path: '/resource-management', title: '文件资源', component: './resource-management', iconKey: 'database', menuGroup: 'resources', order: 10 },
-  { id: 'data-quality-rule-template', mode: 'one', permission: 'quality:template:read', path: '/data-quality/rule-template', title: '数据质量', component: './data-quality/rule-template', iconKey: 'quality', menuGroup: 'resources', order: 20 },
+  { id: 'data-quality-rule-template', mode: 'one', permission: 'quality:template:read', path: '/data-quality/rule-template', title: '规则模板库', component: './data-quality/rule-template', iconKey: 'quality', menuGroup: 'data-quality', order: 10 },
   { id: 'system-users', mode: 'one', permission: 'security:user:read', path: '/system/users', title: '用户管理', component: './system/users', iconKey: 'system', menuGroup: 'system', order: 10 },
   { id: 'system-roles', mode: 'one', permission: 'security:role:read', path: '/system/roles', title: '角色管理', component: './system/roles', iconKey: 'system', menuGroup: 'system', order: 20 },
   { id: 'system-permissions', mode: 'one', permission: 'security:permission:read', path: '/system/permissions', title: '权限管理', component: './system/permissions', iconKey: 'system', menuGroup: 'system', order: 30 },


### PR DESCRIPTION
## Summary

- move `数据质量` out of `资源管理`
- register `数据质量` as a first-level navigation group alongside `资源管理`
- rename the child navigation item to `规则模板库`
- update the Yak Security menu hierarchy to `数据质量 -> 规则模板库`
- remove the unnecessary Resource Management parent-menu authorization backfill
- update navigation tests for the corrected hierarchy

## Expected navigation

```text
数据集成
资源管理
数据质量
└── 规则模板库
系统管理
```

## Scope

This follow-up only corrects the frontend and backend menu hierarchy. The existing rule template page is unchanged.