### PR TITLE
fix(data-quality): disable Flyway placeholder replacement

### DIFF
--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/config/QualityConfiguration.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/config/QualityConfiguration.java
@@ -30,6 +30,9 @@ public class QualityConfiguration {
         .table("yak_quality_schema_history")
         .baselineVersion(MigrationVersion.fromVersion("0"))
         .baselineOnMigrate(true)
+        // 质量规则的自定义 SQL 使用 ${table}/${column}/${where} 作为运行时占位符。
+        // 这些文本需要原样写入模板描述，不能被 Flyway 当作迁移占位符解析。
+        .placeholderReplacement(false)
         .load();
   }
 


### PR DESCRIPTION
## 问题

应用启动时，数据质量 Flyway 迁移解析 `V1__create_quality_mvp.sql` 失败：

```text
No value provided for placeholder: ${table}
```

迁移脚本中的 `${table}`、`${column}` 和 `${where}` 不是 Flyway 配置占位符，而是自定义 SQL 规则在运行阶段使用的模板变量。

## 修复

- 在数据质量模块的独立 Flyway 配置中关闭 `placeholderReplacement`
- 保留自定义 SQL 模板变量原样写入规则模板描述
- 不影响其他业务模块的 Flyway 配置

## 验证方式

拉取本分支后重新清理并启动：

```bash
mvn clean package -DskipTests
```

随后启动 `YakOpsApplication`，`yak_quality_schema_history` 应从基线版本 `0` 正常执行 `V1__create_quality_mvp.sql`。