### PR TITLE
fix(data-quality): qualify security migration columns

### DIFF
--- a/yak-ops-boot/src/main/resources/yak-security/db/migration/V2001__register_data_quality_mvp.sql
+++ b/yak-ops-boot/src/main/resources/yak-security/db/migration/V2001__register_data_quality_mvp.sql
@@ -3,15 +3,15 @@
 INSERT INTO yak_security_permission
 (permission_code, permission_name, parent_id, leaf, level, description,
  active, declared, menu_code, app_name)
-SELECT permission_code,
-       permission_name,
+SELECT permissions.permission_code,
+       permissions.permission_name,
        parent.id,
        1,
        2,
-       description,
+       permissions.description,
        1,
        0,
-       menu_code,
+       permissions.menu_code,
        parent.app_name
 FROM yak_security_permission parent
 JOIN (


### PR DESCRIPTION
## 问题

启动时 Yak Security 的 `V2001__register_data_quality_mvp.sql` 执行失败：

```text
Column 'permission_code' in field list is ambiguous
```

迁移首条 `INSERT ... SELECT` 同时引用了父权限表别名 `parent` 和派生权限表别名 `permissions`，两边都包含 `permission_code`、`permission_name`、`description` 等字段，但 `SELECT` 未加表别名，MySQL 无法判断字段来源。

## 修复

- 将权限字段显式限定为 `permissions.permission_code`
- 将名称、描述和菜单编码显式限定为 `permissions.*`
- 保留 `parent.id` 和 `parent.app_name` 作为父权限信息
- 保持迁移幂等逻辑和 `ON DUPLICATE KEY UPDATE` 不变

## 本地恢复提示

此前 V2001 已执行失败，MySQL/Flyway 可能在 `flyway_schema_history` 中留下 `success = 0` 的失败记录。拉取修复后，启动前需要删除该失败记录或执行 Flyway repair：

```sql
DELETE FROM flyway_schema_history
WHERE version = '2001' AND success = 0;
```

随后重新清理并启动。
