### PR TITLE
feat(data-quality): add registered table workflow

### DIFF
--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/api/QualityApi.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/api/QualityApi.java
@@ -252,6 +252,84 @@ public final class QualityApi {
       LocalDateTime lastRunTime) {
   }
 
+  public record TableAssetPageRequest(
+      @Min(1) Integer current,
+      @Min(1) @Max(100) Integer pageSize,
+      @NotNull Long dataSourceId,
+      String databaseName,
+      String schemaName,
+      String keyword) {
+
+    public int normalizedCurrent() {
+      return current == null ? 1 : current;
+    }
+
+    public int normalizedPageSize() {
+      return pageSize == null ? 20 : pageSize;
+    }
+  }
+
+  public record TableAssetView(
+      Long id,
+      Long dataSourceId,
+      String dataSourceName,
+      String databaseName,
+      String schemaName,
+      String tableName,
+      String tableType,
+      String remarks,
+      Long monitorId,
+      String monitorName,
+      int monitorCount,
+      int ruleCount,
+      CheckResult lastResult,
+      LocalDateTime lastRunTime,
+      String registeredBy,
+      LocalDateTime registeredAt) {
+  }
+
+  public record TableAssetPageView(
+      List<TableAssetView> records,
+      long total,
+      int current,
+      int pageSize) {
+  }
+
+  public record TableCandidateView(
+      String databaseName,
+      String schemaName,
+      String tableName,
+      String tableType,
+      String remarks) {
+  }
+
+  public record TableCandidatePageView(
+      List<TableCandidateView> records,
+      long total,
+      int current,
+      int pageSize) {
+  }
+
+  public record RegisterTableItem(
+      @Size(max = 128) String databaseName,
+      @Size(max = 128) String schemaName,
+      @NotBlank @Size(max = 256) String tableName,
+      @Size(max = 40) String tableType,
+      @Size(max = 1000) String remarks) {
+  }
+
+  public record RegisterTablesRequest(
+      @NotNull Long dataSourceId,
+      @NotBlank @Size(max = 128) String dataSourceName,
+      @Size(max = 128) String databaseName,
+      @NotEmpty List<@Valid RegisterTableItem> tables) {
+  }
+
+  public record RegisterTablesView(
+      int requested,
+      int registered) {
+  }
+
   public record RunView(
       String executionNo,
       ExecutionStatus executionStatus,

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/controller/v1/QualityTableAssetController.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/controller/v1/QualityTableAssetController.java
@@ -1,0 +1,87 @@
+package io.yak.ops.business.quality.controller.v1;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.yak.framework.common.Result;
+import io.yak.framework.security.web.RequiresPermission;
+import io.yak.ops.business.quality.QualityPermissionCode;
+import io.yak.ops.business.quality.api.QualityApi.RegisterTablesRequest;
+import io.yak.ops.business.quality.api.QualityApi.RegisterTablesView;
+import io.yak.ops.business.quality.api.QualityApi.TableAssetPageRequest;
+import io.yak.ops.business.quality.api.QualityApi.TableAssetPageView;
+import io.yak.ops.business.quality.api.QualityApi.TableCandidatePageView;
+import io.yak.ops.business.quality.config.ConditionalOnQualityEnabled;
+import io.yak.ops.business.quality.service.QualityTableAssetService;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import java.security.Principal;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "数据质量注册表")
+@Validated
+@RestController
+@ConditionalOnQualityEnabled
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/data-quality/table-asset")
+@RequiresPermission(QualityPermissionCode.MONITOR_READ)
+public class QualityTableAssetController {
+
+  private final QualityTableAssetService service;
+
+  @Operation(summary = "分页查询已注册数据表")
+  @PostMapping("/page")
+  public Result<TableAssetPageView> page(
+      @Valid @RequestBody TableAssetPageRequest request) {
+    return Result.success(service.page(request));
+  }
+
+  @Operation(summary = "从数据源插件分页查询可注册数据表")
+  @GetMapping("/candidates")
+  public Result<TableCandidatePageView> candidates(
+      @RequestParam long dataSourceId,
+      @RequestParam(value = "databaseName", required = false) String databaseName,
+      @RequestParam(value = "schemaName", required = false) String schemaName,
+      @RequestParam(value = "keyword", required = false) String keyword,
+      @RequestParam(defaultValue = "1") @Min(1) int current,
+      @RequestParam(defaultValue = "20") @Min(1) @Max(100) int pageSize) {
+    return Result.success(service.candidates(
+        dataSourceId,
+        databaseName,
+        schemaName,
+        keyword,
+        current,
+        pageSize));
+  }
+
+  @Operation(summary = "批量注册数据表")
+  @PostMapping("/register")
+  @RequiresPermission(QualityPermissionCode.MONITOR_CREATE)
+  public Result<RegisterTablesView> register(
+      @Valid @RequestBody RegisterTablesRequest request,
+      Principal principal) {
+    return Result.success(service.register(request, operator(principal)));
+  }
+
+  @Operation(summary = "取消注册数据表")
+  @DeleteMapping("/{id}")
+  @RequiresPermission(QualityPermissionCode.MONITOR_DELETE)
+  public Result<Boolean> unregister(@PathVariable long id) {
+    return Result.success(service.unregister(id));
+  }
+
+  private static String operator(Principal principal) {
+    return principal == null || principal.getName() == null || principal.getName().isBlank()
+        ? "system"
+        : principal.getName();
+  }
+}

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/repository/QualityRepository.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/repository/QualityRepository.java
@@ -63,6 +63,14 @@ public class QualityRepository {
     return tableAssets.listTargets(dataSourceId, databaseName);
   }
 
+  public boolean existsTableAssetTarget(
+      long dataSourceId,
+      String databaseName,
+      String schemaName,
+      String tableName) {
+    return tableAssets.existsTarget(dataSourceId, databaseName, schemaName, tableName);
+  }
+
   public int registerTableAssets(List<TableAssetWrite> writes) {
     return tableAssets.register(writes);
   }

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/repository/QualityRepository.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/repository/QualityRepository.java
@@ -11,6 +11,8 @@ import io.yak.ops.business.quality.api.QualityApi.MonitorView;
 import io.yak.ops.business.quality.api.QualityApi.RuleScope;
 import io.yak.ops.business.quality.api.QualityApi.RuleType;
 import io.yak.ops.business.quality.api.QualityApi.RuleView;
+import io.yak.ops.business.quality.api.QualityApi.TableAssetPageRequest;
+import io.yak.ops.business.quality.api.QualityApi.TableAssetView;
 import io.yak.ops.business.quality.api.QualityApi.TableMonitorSummary;
 import io.yak.ops.business.quality.api.QualityApi.TemplateQuery;
 import io.yak.ops.business.quality.api.QualityApi.TemplateView;
@@ -22,20 +24,23 @@ import java.util.List;
 import java.util.Optional;
 import org.springframework.stereotype.Repository;
 
-/** Facade over the template, monitor and execution persistence components. */
+/** Facade over the template, registered-table, monitor and execution persistence components. */
 @ConditionalOnQualityEnabled
 @Repository
 public class QualityRepository {
 
   private final QualityTemplateRepository templates;
+  private final QualityTableAssetRepository tableAssets;
   private final QualityMonitorRepository monitors;
   private final QualityExecutionRepository executions;
 
   public QualityRepository(
       QualityTemplateRepository templates,
+      QualityTableAssetRepository tableAssets,
       QualityMonitorRepository monitors,
       QualityExecutionRepository executions) {
     this.templates = templates;
+    this.tableAssets = tableAssets;
     this.monitors = monitors;
     this.executions = executions;
   }
@@ -46,6 +51,28 @@ public class QualityRepository {
 
   public Optional<TemplateView> findTemplate(long id) {
     return templates.find(id);
+  }
+
+  public PageResult<TableAssetView> pageTableAssets(TableAssetPageRequest request) {
+    return tableAssets.page(request);
+  }
+
+  public List<TableAssetTarget> listTableAssetTargets(
+      long dataSourceId,
+      String databaseName) {
+    return tableAssets.listTargets(dataSourceId, databaseName);
+  }
+
+  public int registerTableAssets(List<TableAssetWrite> writes) {
+    return tableAssets.register(writes);
+  }
+
+  public int countMonitorsForTableAsset(long assetId) {
+    return tableAssets.countMonitors(assetId);
+  }
+
+  public boolean deleteTableAsset(long assetId) {
+    return tableAssets.delete(assetId);
   }
 
   public PageResult<MonitorListItem> pageMonitors(MonitorPageRequest request) {
@@ -158,6 +185,23 @@ public class QualityRepository {
   }
 
   public record PageResult<T>(List<T> records, long total) {
+  }
+
+  public record TableAssetWrite(
+      long dataSourceId,
+      String dataSourceName,
+      String databaseName,
+      String schemaName,
+      String tableName,
+      String tableType,
+      String remarks,
+      String registeredBy) {
+  }
+
+  public record TableAssetTarget(
+      String databaseName,
+      String schemaName,
+      String tableName) {
   }
 
   public record MonitorWrite(

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/repository/QualityTableAssetRepository.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/repository/QualityTableAssetRepository.java
@@ -1,0 +1,250 @@
+package io.yak.ops.business.quality.repository;
+
+import io.yak.ops.business.quality.api.QualityApi.TableAssetPageRequest;
+import io.yak.ops.business.quality.api.QualityApi.TableAssetView;
+import io.yak.ops.business.quality.config.ConditionalOnQualityEnabled;
+import io.yak.ops.business.quality.repository.QualityRepository.PageResult;
+import io.yak.ops.business.quality.repository.QualityRepository.TableAssetTarget;
+import io.yak.ops.business.quality.repository.QualityRepository.TableAssetWrite;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+@ConditionalOnQualityEnabled
+@Repository
+class QualityTableAssetRepository {
+
+  private final NamedParameterJdbcTemplate jdbcTemplate;
+
+  QualityTableAssetRepository(
+      @Qualifier("qualityJdbcTemplate") NamedParameterJdbcTemplate jdbcTemplate) {
+    this.jdbcTemplate = jdbcTemplate;
+  }
+
+  PageResult<TableAssetView> page(TableAssetPageRequest request) {
+    StringBuilder where = new StringBuilder(
+        " WHERE asset.deleted = 0 AND asset.data_source_id = :dataSourceId");
+    MapSqlParameterSource params = new MapSqlParameterSource()
+        .addValue("dataSourceId", request.dataSourceId());
+    appendNullableFilter(
+        where, params, "asset.database_name", "databaseName", request.databaseName());
+    appendNullableFilter(
+        where, params, "asset.schema_name", "schemaName", request.schemaName());
+    if (QualityRepositorySupport.hasText(request.keyword())) {
+      where.append("""
+           AND (LOWER(asset.table_name) LIKE :keyword
+             OR LOWER(COALESCE(asset.remarks, '')) LIKE :keyword)
+          """);
+      params.addValue("keyword", "%" + request.keyword().trim().toLowerCase() + "%");
+    }
+
+    Long total = jdbcTemplate.queryForObject(
+        "SELECT COUNT(*) FROM yak_quality_table_asset asset" + where,
+        params,
+        Long.class);
+    params.addValue("limit", request.normalizedPageSize());
+    params.addValue(
+        "offset", (request.normalizedCurrent() - 1L) * request.normalizedPageSize());
+
+    List<TableAssetView> records = jdbcTemplate.query(
+        """
+        SELECT asset.id,
+               asset.data_source_id,
+               asset.data_source_name,
+               asset.database_name,
+               asset.schema_name,
+               asset.table_name,
+               asset.table_type,
+               asset.remarks,
+               asset.registered_by,
+               asset.registered_at,
+               MIN(monitor.id) AS monitor_id,
+               MIN(monitor.monitor_name) AS monitor_name,
+               COUNT(DISTINCT monitor.id) AS monitor_count,
+               COUNT(DISTINCT rule_row.id) AS rule_count,
+               SUBSTRING_INDEX(
+                 GROUP_CONCAT(
+                   monitor.last_result
+                   ORDER BY monitor.last_run_time DESC, monitor.id DESC),
+                 ',', 1) AS last_result,
+               MAX(monitor.last_run_time) AS last_run_time
+        FROM yak_quality_table_asset asset
+        LEFT JOIN yak_quality_monitor monitor
+          ON monitor.data_source_id = asset.data_source_id
+         AND COALESCE(monitor.database_name, '') = asset.database_name
+         AND COALESCE(monitor.schema_name, '') = asset.schema_name
+         AND monitor.table_name = asset.table_name
+         AND monitor.deleted = 0
+        LEFT JOIN yak_quality_rule rule_row
+          ON rule_row.monitor_id = monitor.id
+         AND rule_row.deleted = 0
+        """ + where
+            + """
+             GROUP BY asset.id,
+                      asset.data_source_id,
+                      asset.data_source_name,
+                      asset.database_name,
+                      asset.schema_name,
+                      asset.table_name,
+                      asset.table_type,
+                      asset.remarks,
+                      asset.registered_by,
+                      asset.registered_at
+             ORDER BY asset.table_name ASC, asset.id ASC
+             LIMIT :limit OFFSET :offset
+            """,
+        params,
+        this::mapAsset);
+    return new PageResult<>(records, total == null ? 0L : total);
+  }
+
+  List<TableAssetTarget> listTargets(long dataSourceId, String databaseName) {
+    StringBuilder where = new StringBuilder(
+        " WHERE deleted = 0 AND data_source_id = :dataSourceId");
+    MapSqlParameterSource params = new MapSqlParameterSource("dataSourceId", dataSourceId);
+    appendNullableFilter(
+        where, params, "database_name", "databaseName", databaseName);
+    return jdbcTemplate.query(
+        "SELECT database_name, schema_name, table_name"
+            + " FROM yak_quality_table_asset"
+            + where,
+        params,
+        (rs, rowNum) -> new TableAssetTarget(
+            blankToNull(rs.getString("database_name")),
+            blankToNull(rs.getString("schema_name")),
+            rs.getString("table_name")));
+  }
+
+  int register(List<TableAssetWrite> writes) {
+    int registered = 0;
+    for (TableAssetWrite write : writes) {
+      jdbcTemplate.update(
+          """
+          INSERT INTO yak_quality_table_asset (
+            data_source_id,
+            data_source_name,
+            database_name,
+            schema_name,
+            table_name,
+            table_type,
+            remarks,
+            registered_by,
+            registered_at,
+            deleted
+          ) VALUES (
+            :dataSourceId,
+            :dataSourceName,
+            :databaseName,
+            :schemaName,
+            :tableName,
+            :tableType,
+            :remarks,
+            :registeredBy,
+            CURRENT_TIMESTAMP(3),
+            0
+          )
+          ON DUPLICATE KEY UPDATE
+            data_source_name = VALUES(data_source_name),
+            table_type = VALUES(table_type),
+            remarks = VALUES(remarks),
+            registered_by = VALUES(registered_by),
+            registered_at = CURRENT_TIMESTAMP(3),
+            deleted = 0,
+            updated_at = CURRENT_TIMESTAMP(3)
+          """,
+          new MapSqlParameterSource()
+              .addValue("dataSourceId", write.dataSourceId())
+              .addValue("dataSourceName", write.dataSourceName())
+              .addValue("databaseName", blankToEmpty(write.databaseName()))
+              .addValue("schemaName", blankToEmpty(write.schemaName()))
+              .addValue("tableName", write.tableName())
+              .addValue("tableType", QualityRepositorySupport.trimToNull(write.tableType()))
+              .addValue("remarks", QualityRepositorySupport.trimToNull(write.remarks()))
+              .addValue("registeredBy", write.registeredBy()));
+      registered++;
+    }
+    return registered;
+  }
+
+  int countMonitors(long assetId) {
+    Integer count = jdbcTemplate.queryForObject(
+        """
+        SELECT COUNT(*)
+        FROM yak_quality_table_asset asset
+        JOIN yak_quality_monitor monitor
+          ON monitor.data_source_id = asset.data_source_id
+         AND COALESCE(monitor.database_name, '') = asset.database_name
+         AND COALESCE(monitor.schema_name, '') = asset.schema_name
+         AND monitor.table_name = asset.table_name
+         AND monitor.deleted = 0
+        WHERE asset.id = :id
+          AND asset.deleted = 0
+        """,
+        new MapSqlParameterSource("id", assetId),
+        Integer.class);
+    return count == null ? 0 : count;
+  }
+
+  boolean delete(long assetId) {
+    return jdbcTemplate.update(
+        """
+        UPDATE yak_quality_table_asset
+        SET deleted = 1,
+            updated_at = CURRENT_TIMESTAMP(3)
+        WHERE id = :id
+          AND deleted = 0
+        """,
+        new MapSqlParameterSource("id", assetId)) == 1;
+  }
+
+  private TableAssetView mapAsset(ResultSet rs, int rowNum) throws SQLException {
+    return new TableAssetView(
+        rs.getLong("id"),
+        rs.getLong("data_source_id"),
+        rs.getString("data_source_name"),
+        blankToNull(rs.getString("database_name")),
+        blankToNull(rs.getString("schema_name")),
+        rs.getString("table_name"),
+        rs.getString("table_type"),
+        rs.getString("remarks"),
+        QualityRepositorySupport.nullableLong(rs, "monitor_id"),
+        rs.getString("monitor_name"),
+        rs.getInt("monitor_count"),
+        rs.getInt("rule_count"),
+        QualityRepositorySupport.checkResult(rs.getString("last_result")),
+        QualityRepositorySupport.localDateTime(rs.getTimestamp("last_run_time")),
+        rs.getString("registered_by"),
+        QualityRepositorySupport.localDateTime(rs.getTimestamp("registered_at")));
+  }
+
+  private void appendNullableFilter(
+      StringBuilder where,
+      MapSqlParameterSource params,
+      String column,
+      String parameter,
+      String value) {
+    if (value == null) {
+      return;
+    }
+    String normalized = QualityRepositorySupport.trimToNull(value);
+    if (normalized == null) {
+      where.append(" AND ").append(column).append(" = ''");
+    } else {
+      where.append(" AND ").append(column).append(" = :").append(parameter);
+      params.addValue(parameter, normalized);
+    }
+  }
+
+  private static String blankToEmpty(String value) {
+    String normalized = QualityRepositorySupport.trimToNull(value);
+    return normalized == null ? "" : normalized;
+  }
+
+  private static String blankToNull(String value) {
+    return QualityRepositorySupport.trimToNull(value);
+  }
+}

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/repository/QualityTableAssetRepository.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/repository/QualityTableAssetRepository.java
@@ -119,6 +119,30 @@ class QualityTableAssetRepository {
             rs.getString("table_name")));
   }
 
+  boolean existsTarget(
+      long dataSourceId,
+      String databaseName,
+      String schemaName,
+      String tableName) {
+    Integer count = jdbcTemplate.queryForObject(
+        """
+        SELECT COUNT(*)
+        FROM yak_quality_table_asset
+        WHERE deleted = 0
+          AND data_source_id = :dataSourceId
+          AND database_name = :databaseName
+          AND schema_name = :schemaName
+          AND table_name = :tableName
+        """,
+        new MapSqlParameterSource()
+            .addValue("dataSourceId", dataSourceId)
+            .addValue("databaseName", blankToEmpty(databaseName))
+            .addValue("schemaName", blankToEmpty(schemaName))
+            .addValue("tableName", tableName),
+        Integer.class);
+    return count != null && count > 0;
+  }
+
   int register(List<TableAssetWrite> writes) {
     int registered = 0;
     for (TableAssetWrite write : writes) {

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/service/QualityMonitorService.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/service/QualityMonitorService.java
@@ -1,6 +1,5 @@
 package io.yak.ops.business.quality.service;
 
-import io.yak.ops.business.quality.config.ConditionalOnQualityEnabled;
 import io.yak.ops.business.quality.api.QualityApi.ComparisonOperator;
 import io.yak.ops.business.quality.api.QualityApi.MonitorPageRequest;
 import io.yak.ops.business.quality.api.QualityApi.MonitorPageView;
@@ -12,6 +11,7 @@ import io.yak.ops.business.quality.api.QualityApi.SaveMonitorRequest;
 import io.yak.ops.business.quality.api.QualityApi.SaveRuleRequest;
 import io.yak.ops.business.quality.api.QualityApi.TableMonitorSummary;
 import io.yak.ops.business.quality.api.QualityApi.TemplateView;
+import io.yak.ops.business.quality.config.ConditionalOnQualityEnabled;
 import io.yak.ops.business.quality.repository.QualityRepository;
 import io.yak.ops.business.quality.repository.QualityRepository.MonitorWrite;
 import io.yak.ops.business.quality.repository.QualityRepository.PageResult;
@@ -107,12 +107,20 @@ public class QualityMonitorService {
     if (request.dataSourceId() == null || request.dataSourceId() <= 0) {
       throw new IllegalArgumentException("请选择有效的数据源");
     }
+    String tableName = request.tableName().trim();
+    if (!repository.existsTableAssetTarget(
+        request.dataSourceId(),
+        request.databaseName(),
+        request.schemaName(),
+        tableName)) {
+      throw new IllegalStateException("当前数据表尚未注册，请先在按表配置页面注册数据表");
+    }
     if (repository.existsMonitorForTarget(
         excludeId,
         request.dataSourceId(),
         request.databaseName(),
         request.schemaName(),
-        request.tableName().trim())) {
+        tableName)) {
       throw new IllegalStateException("当前数据表已经创建质量监控，请直接进入监控详情");
     }
     validateWhereClause(request.whereClause());

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/service/QualityTableAssetService.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/service/QualityTableAssetService.java
@@ -1,0 +1,206 @@
+package io.yak.ops.business.quality.service;
+
+import io.yak.ops.business.datasource.service.DataSourceCatalogService;
+import io.yak.ops.business.quality.api.QualityApi.RegisterTableItem;
+import io.yak.ops.business.quality.api.QualityApi.RegisterTablesRequest;
+import io.yak.ops.business.quality.api.QualityApi.RegisterTablesView;
+import io.yak.ops.business.quality.api.QualityApi.TableAssetPageRequest;
+import io.yak.ops.business.quality.api.QualityApi.TableAssetPageView;
+import io.yak.ops.business.quality.api.QualityApi.TableAssetView;
+import io.yak.ops.business.quality.api.QualityApi.TableCandidatePageView;
+import io.yak.ops.business.quality.api.QualityApi.TableCandidateView;
+import io.yak.ops.business.quality.config.ConditionalOnQualityEnabled;
+import io.yak.ops.business.quality.repository.QualityRepository;
+import io.yak.ops.business.quality.repository.QualityRepository.PageResult;
+import io.yak.ops.business.quality.repository.QualityRepository.TableAssetTarget;
+import io.yak.ops.business.quality.repository.QualityRepository.TableAssetWrite;
+import io.yak.ops.common.bean.vo.datasource.DataSourceCatalogTableVO;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@ConditionalOnQualityEnabled
+@Service
+public class QualityTableAssetService {
+
+  private final QualityRepository repository;
+  private final DataSourceCatalogService catalogService;
+
+  public QualityTableAssetService(
+      QualityRepository repository,
+      DataSourceCatalogService catalogService) {
+    this.repository = repository;
+    this.catalogService = catalogService;
+  }
+
+  @Transactional(readOnly = true, transactionManager = "yakBusinessTransactionManager")
+  public TableAssetPageView page(TableAssetPageRequest request) {
+    validateDataSourceId(request.dataSourceId());
+    PageResult<TableAssetView> result = repository.pageTableAssets(request);
+    return new TableAssetPageView(
+        result.records(),
+        result.total(),
+        request.normalizedCurrent(),
+        request.normalizedPageSize());
+  }
+
+  @Transactional(readOnly = true, transactionManager = "yakBusinessTransactionManager")
+  public TableCandidatePageView candidates(
+      long dataSourceId,
+      String databaseName,
+      String schemaName,
+      String keyword,
+      int current,
+      int pageSize) {
+    validateDataSourceId(dataSourceId);
+    int safeCurrent = Math.max(1, current);
+    int safePageSize = Math.max(1, Math.min(pageSize, 100));
+
+    Set<String> registeredTargets = repository
+        .listTableAssetTargets(dataSourceId, databaseName)
+        .stream()
+        .map(target -> targetKey(
+            target.databaseName(), target.schemaName(), target.tableName()))
+        .collect(Collectors.toSet());
+
+    List<TableCandidateView> available = catalogService
+        .listTables(dataSourceId, databaseName, schemaName, trimToNull(keyword))
+        .stream()
+        .map(table -> toCandidate(table, databaseName))
+        .filter(table -> !registeredTargets.contains(targetKey(
+            table.databaseName(), table.schemaName(), table.tableName())))
+        .sorted(Comparator.comparing(
+            TableCandidateView::tableName,
+            String.CASE_INSENSITIVE_ORDER))
+        .toList();
+
+    int fromIndex = Math.min((safeCurrent - 1) * safePageSize, available.size());
+    int toIndex = Math.min(fromIndex + safePageSize, available.size());
+    return new TableCandidatePageView(
+        available.subList(fromIndex, toIndex),
+        available.size(),
+        safeCurrent,
+        safePageSize);
+  }
+
+  @Transactional(transactionManager = "yakBusinessTransactionManager")
+  public RegisterTablesView register(RegisterTablesRequest request, String operator) {
+    validateDataSourceId(request.dataSourceId());
+    String selectedDatabase = trimToNull(request.databaseName());
+    List<DataSourceCatalogTableVO> physicalTables = catalogService.listTables(
+        request.dataSourceId(), selectedDatabase, null, null);
+
+    Map<String, DataSourceCatalogTableVO> physicalTableMap = physicalTables.stream()
+        .collect(Collectors.toMap(
+            table -> targetKey(
+                firstNonBlank(table.getDatabase(), selectedDatabase),
+                table.getSchema(),
+                table.getName()),
+            table -> table,
+            (left, right) -> left,
+            LinkedHashMap::new));
+
+    Map<String, RegisterTableItem> requestedTables = new LinkedHashMap<>();
+    for (RegisterTableItem item : request.tables()) {
+      String database = firstNonBlank(item.databaseName(), selectedDatabase);
+      requestedTables.putIfAbsent(
+          targetKey(database, item.schemaName(), item.tableName()),
+          item);
+    }
+
+    String registeredBy = normalizeOperator(operator);
+    List<TableAssetWrite> writes = requestedTables.entrySet().stream()
+        .map(entry -> {
+          RegisterTableItem requested = entry.getValue();
+          DataSourceCatalogTableVO physical = physicalTableMap.get(entry.getKey());
+          if (physical == null) {
+            throw new IllegalArgumentException(
+                "数据表已不存在或无法通过数据源插件发现：" + requested.tableName());
+          }
+          return new TableAssetWrite(
+              request.dataSourceId(),
+              request.dataSourceName().trim(),
+              firstNonBlank(physical.getDatabase(), selectedDatabase),
+              trimToNull(physical.getSchema()),
+              physical.getName(),
+              trimToNull(physical.getType()),
+              trimToNull(physical.getRemarks()),
+              registeredBy);
+        })
+        .toList();
+
+    int registered = repository.registerTableAssets(writes);
+    return new RegisterTablesView(request.tables().size(), registered);
+  }
+
+  @Transactional(transactionManager = "yakBusinessTransactionManager")
+  public boolean unregister(long id) {
+    if (id <= 0) {
+      throw new IllegalArgumentException("注册表编号无效");
+    }
+    if (repository.countMonitorsForTableAsset(id) > 0) {
+      throw new IllegalStateException("当前数据表已配置质量监控，请先删除监控后再取消注册");
+    }
+    if (!repository.deleteTableAsset(id)) {
+      throw new IllegalArgumentException("注册数据表不存在：" + id);
+    }
+    return true;
+  }
+
+  private TableCandidateView toCandidate(
+      DataSourceCatalogTableVO table,
+      String selectedDatabase) {
+    return new TableCandidateView(
+        firstNonBlank(table.getDatabase(), selectedDatabase),
+        trimToNull(table.getSchema()),
+        table.getName(),
+        trimToNull(table.getType()),
+        trimToNull(table.getRemarks()));
+  }
+
+  private void validateDataSourceId(Long dataSourceId) {
+    if (dataSourceId == null || dataSourceId <= 0) {
+      throw new IllegalArgumentException("数据源编号无效");
+    }
+  }
+
+  private static String targetKey(
+      String databaseName,
+      String schemaName,
+      String tableName) {
+    return String.join(
+        "\u0001",
+        normalizeKeyPart(databaseName),
+        normalizeKeyPart(schemaName),
+        normalizeKeyPart(tableName));
+  }
+
+  private static String normalizeKeyPart(String value) {
+    String normalized = trimToNull(value);
+    return normalized == null ? "" : normalized.toLowerCase(Locale.ROOT);
+  }
+
+  private static String firstNonBlank(String first, String second) {
+    String normalized = trimToNull(first);
+    return normalized == null ? trimToNull(second) : normalized;
+  }
+
+  private static String normalizeOperator(String operator) {
+    String normalized = trimToNull(operator);
+    return normalized == null ? "system" : normalized;
+  }
+
+  private static String trimToNull(String value) {
+    if (value == null) {
+      return null;
+    }
+    String trimmed = value.trim();
+    return trimmed.isEmpty() ? null : trimmed;
+  }
+}

--- a/yak-ops-business/yak-ops-business-quality/src/main/resources/db/migration/yak-quality/V2__create_quality_table_asset.sql
+++ b/yak-ops-business/yak-ops-business-quality/src/main/resources/db/migration/yak-quality/V2__create_quality_table_asset.sql
@@ -1,0 +1,58 @@
+CREATE TABLE IF NOT EXISTS yak_quality_table_asset (
+    id BIGINT NOT NULL AUTO_INCREMENT COMMENT '数据质量表资产 ID',
+    data_source_id BIGINT NOT NULL COMMENT '数据源 ID',
+    data_source_name VARCHAR(128) NOT NULL COMMENT '数据源名称快照',
+    database_name VARCHAR(128) NOT NULL DEFAULT '' COMMENT '数据库名称',
+    schema_name VARCHAR(128) NOT NULL DEFAULT '' COMMENT 'Schema 名称',
+    table_name VARCHAR(256) NOT NULL COMMENT '数据表名称',
+    table_type VARCHAR(40) NULL COMMENT 'TABLE/VIEW 等插件类型',
+    remarks VARCHAR(1000) NULL COMMENT '数据表描述快照',
+    registered_by VARCHAR(128) NOT NULL DEFAULT 'system' COMMENT '注册人',
+    registered_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) COMMENT '注册时间',
+    deleted TINYINT(1) NOT NULL DEFAULT 0 COMMENT '逻辑删除',
+    created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    updated_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3)
+        ON UPDATE CURRENT_TIMESTAMP(3),
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_yak_quality_table_asset_target
+      (data_source_id, database_name, schema_name, table_name),
+    KEY idx_yak_quality_table_asset_query
+      (data_source_id, database_name, deleted, table_name)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+  COMMENT='数据质量已注册数据表';
+
+-- 已经创建质量监控的数据表自动纳入注册资产，避免升级后列表丢失。
+INSERT INTO yak_quality_table_asset (
+    data_source_id,
+    data_source_name,
+    database_name,
+    schema_name,
+    table_name,
+    table_type,
+    remarks,
+    registered_by,
+    registered_at,
+    deleted
+)
+SELECT
+    monitor.data_source_id,
+    MAX(monitor.data_source_name),
+    COALESCE(monitor.database_name, ''),
+    COALESCE(monitor.schema_name, ''),
+    monitor.table_name,
+    NULL,
+    NULL,
+    'system',
+    MIN(monitor.created_at),
+    0
+FROM yak_quality_monitor monitor
+WHERE monitor.deleted = 0
+GROUP BY
+    monitor.data_source_id,
+    COALESCE(monitor.database_name, ''),
+    COALESCE(monitor.schema_name, ''),
+    monitor.table_name
+ON DUPLICATE KEY UPDATE
+    data_source_name = VALUES(data_source_name),
+    deleted = 0,
+    updated_at = CURRENT_TIMESTAMP(3);

--- a/yak-ops-business/yak-ops-business-quality/src/test/java/io/yak/ops/business/quality/service/QualityTableAssetServiceTest.java
+++ b/yak-ops-business/yak-ops-business-quality/src/test/java/io/yak/ops/business/quality/service/QualityTableAssetServiceTest.java
@@ -1,0 +1,94 @@
+package io.yak.ops.business.quality.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.datasource.service.DataSourceCatalogService;
+import io.yak.ops.business.quality.api.QualityApi.RegisterTableItem;
+import io.yak.ops.business.quality.api.QualityApi.RegisterTablesRequest;
+import io.yak.ops.business.quality.repository.QualityRepository;
+import io.yak.ops.business.quality.repository.QualityRepository.TableAssetTarget;
+import io.yak.ops.business.quality.repository.QualityRepository.TableAssetWrite;
+import io.yak.ops.common.bean.vo.datasource.DataSourceCatalogTableVO;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+class QualityTableAssetServiceTest {
+
+  @Mock
+  private QualityRepository repository;
+
+  @Mock
+  private DataSourceCatalogService catalogService;
+
+  private QualityTableAssetService service;
+
+  @BeforeEach
+  void setUp() {
+    MockitoAnnotations.openMocks(this);
+    service = new QualityTableAssetService(repository, catalogService);
+  }
+
+  @Test
+  void shouldReturnOnlyUnregisteredPluginTables() {
+    when(repository.listTableAssetTargets(1L, "demo"))
+        .thenReturn(List.of(new TableAssetTarget("demo", null, "registered_table")));
+    when(catalogService.listTables(1L, "demo", null, null))
+        .thenReturn(List.of(
+            table("registered_table", "已注册"),
+            table("order_info", "订单表"),
+            table("user_info", "用户表")));
+
+    var result = service.candidates(1L, "demo", null, null, 1, 20);
+
+    assertThat(result.total()).isEqualTo(2);
+    assertThat(result.records())
+        .extracting(record -> record.tableName())
+        .containsExactly("order_info", "user_info");
+  }
+
+  @Test
+  void shouldPersistMetadataReturnedByDatasourcePlugin() {
+    DataSourceCatalogTableVO physicalTable = table("user_info", "插件中的用户表描述");
+    when(catalogService.listTables(1L, "demo", null, null))
+        .thenReturn(List.of(physicalTable));
+    when(repository.registerTableAssets(anyList())).thenReturn(1);
+
+    var result = service.register(
+        new RegisterTablesRequest(
+            1L,
+            "测试数据源",
+            "demo",
+            List.of(new RegisterTableItem(
+                "demo", null, "user_info", "CLIENT_VALUE", "客户端描述"))),
+        "tester");
+
+    ArgumentCaptor<List<TableAssetWrite>> captor = ArgumentCaptor.forClass(List.class);
+    verify(repository).registerTableAssets(captor.capture());
+    TableAssetWrite write = captor.getValue().get(0);
+    assertThat(write.tableType()).isEqualTo("TABLE");
+    assertThat(write.remarks()).isEqualTo("插件中的用户表描述");
+    assertThat(write.registeredBy()).isEqualTo("tester");
+    assertThat(result.registered()).isEqualTo(1);
+  }
+
+  @Test
+  void shouldBlockUnregisterWhenMonitorExists() {
+    when(repository.countMonitorsForTableAsset(10L)).thenReturn(1);
+
+    assertThatThrownBy(() -> service.unregister(10L))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("先删除监控");
+  }
+
+  private DataSourceCatalogTableVO table(String name, String remarks) {
+    return new DataSourceCatalogTableVO("demo", null, name, "TABLE", remarks);
+  }
+}

--- a/yak-ops-ui/src/pages/data-quality/service.ts
+++ b/yak-ops-ui/src/pages/data-quality/service.ts
@@ -5,8 +5,12 @@ import type {
   ExecutionView,
   MonitorPageView,
   MonitorView,
+  RegisterTablesPayload,
+  RegisterTablesView,
   RunView,
   SaveMonitorPayload,
+  TableAssetPageView,
+  TableCandidatePageView,
   TableMonitorSummary,
   TemplateListView,
 } from './types';
@@ -27,6 +31,23 @@ const queryString = (params: Record<string, unknown>) => {
 export const qualityTemplateApi = {
   list: (params: Record<string, unknown> = {}): Promise<CommonApiResponse<TemplateListView>> =>
     HttpUtils.get<TemplateListView>(`${PREFIX}/template${queryString(params)}`),
+};
+
+export const qualityTableAssetApi = {
+  page: (params: Record<string, unknown>): Promise<CommonApiResponse<TableAssetPageView>> =>
+    HttpUtils.post<TableAssetPageView>(`${PREFIX}/table-asset/page`, params),
+  candidates: (
+    params: Record<string, unknown>,
+  ): Promise<CommonApiResponse<TableCandidatePageView>> =>
+    HttpUtils.get<TableCandidatePageView>(
+      `${PREFIX}/table-asset/candidates${queryString(params)}`,
+    ),
+  register: (
+    payload: RegisterTablesPayload,
+  ): Promise<CommonApiResponse<RegisterTablesView>> =>
+    HttpUtils.post<RegisterTablesView>(`${PREFIX}/table-asset/register`, payload),
+  remove: (id: number | string): Promise<CommonApiResponse<boolean>> =>
+    HttpUtils.delete<boolean>(`${PREFIX}/table-asset/${id}`),
 };
 
 export const qualityMonitorApi = {

--- a/yak-ops-ui/src/pages/data-quality/table-config/index.tsx
+++ b/yak-ops-ui/src/pages/data-quality/table-config/index.tsx
@@ -10,8 +10,11 @@ import type { TreeProps } from 'antd';
 import {
   Button,
   ConfigProvider,
+  Drawer,
   Empty,
   Input,
+  Pagination,
+  Popconfirm,
   Spin,
   Table,
   Tooltip,
@@ -23,9 +26,11 @@ import {
   ChevronRight,
   Database,
   Play,
+  Plus,
   RefreshCw,
   Search,
   Settings2,
+  X,
 } from 'lucide-react';
 import {
   useCallback,
@@ -36,12 +41,14 @@ import {
   type PointerEvent as ReactPointerEvent,
 } from 'react';
 import { CheckResultTag } from '../components/QualityStatus';
-import { qualityMonitorApi } from '../service';
-import type { CatalogTable, TableMonitorSummary } from '../types';
+import { qualityMonitorApi, qualityTableAssetApi } from '../service';
+import type { TableAssetView, TableCandidateView } from '../types';
 
 const DEFAULT_LEFT_WIDTH = 280;
 const MIN_LEFT_WIDTH = 220;
 const MAX_LEFT_WIDTH = 480;
+const PAGE_SIZE = 20;
+const CANDIDATE_PAGE_SIZE = 20;
 
 interface DatabaseTreeNode {
   key: string;
@@ -69,18 +76,38 @@ const normalizeDataSourceType = (value?: string) =>
 const databaseNodeKey = (dataSourceId: number, databaseName: string) =>
   `database:${dataSourceId}:${databaseName}`;
 
+const tableTargetKey = (record: TableCandidateView) =>
+  [record.databaseName || '', record.schemaName || '', record.tableName].join(
+    '\u0001',
+  );
+
 const TableConfigPage = () => {
   const [dataSources, setDataSources] = useState<DataSourceRecord[]>([]);
   const [databaseNodes, setDatabaseNodes] = useState<DatabaseTreeNode[]>([]);
   const [selectedNodeKey, setSelectedNodeKey] = useState<string>();
   const [dataSourceId, setDataSourceId] = useState<number>();
   const [databaseName, setDatabaseName] = useState<string>();
-  const [tables, setTables] = useState<CatalogTable[]>([]);
-  const [summaries, setSummaries] = useState<TableMonitorSummary[]>([]);
+
+  const [assets, setAssets] = useState<TableAssetView[]>([]);
+  const [assetTotal, setAssetTotal] = useState(0);
+  const [assetCurrent, setAssetCurrent] = useState(1);
   const [keyword, setKeyword] = useState('');
   const [queryKeyword, setQueryKeyword] = useState('');
   const [treeLoading, setTreeLoading] = useState(false);
-  const [loading, setLoading] = useState(false);
+  const [assetLoading, setAssetLoading] = useState(false);
+
+  const [registerOpen, setRegisterOpen] = useState(false);
+  const [candidates, setCandidates] = useState<TableCandidateView[]>([]);
+  const [candidateTotal, setCandidateTotal] = useState(0);
+  const [candidateCurrent, setCandidateCurrent] = useState(1);
+  const [candidateKeyword, setCandidateKeyword] = useState('');
+  const [candidateQueryKeyword, setCandidateQueryKeyword] = useState('');
+  const [candidateLoading, setCandidateLoading] = useState(false);
+  const [registering, setRegistering] = useState(false);
+  const [selectedCandidates, setSelectedCandidates] = useState<
+    Map<string, TableCandidateView>
+  >(new Map());
+
   const [leftWidth, setLeftWidth] = useState(DEFAULT_LEFT_WIDTH);
   const [collapsed, setCollapsed] = useState(false);
   const dragRef = useRef<{ x: number; width: number }>();
@@ -95,9 +122,14 @@ const TableConfigPage = () => {
     [databaseNodes, selectedNodeKey],
   );
 
-  const summaryMap = useMemo(
-    () => new Map(summaries.map((item) => [item.tableName, item])),
-    [summaries],
+  const selectedCandidateKeys = useMemo(
+    () => Array.from(selectedCandidates.keys()),
+    [selectedCandidates],
+  );
+
+  const selectedCandidateRecords = useMemo(
+    () => Array.from(selectedCandidates.values()),
+    [selectedCandidates],
   );
 
   const treeData = useMemo<NonNullable<TreeProps['treeData']>>(() => {
@@ -215,32 +247,67 @@ const TableConfigPage = () => {
     }
   }, []);
 
-  const loadTables = useCallback(async () => {
-    if (!dataSourceId || !databaseName) {
-      setTables([]);
-      setSummaries([]);
-      return;
-    }
+  const requestAssets = useCallback(
+    async (
+      targetDataSourceId: number,
+      targetDatabaseName: string,
+      current: number,
+      searchKeyword: string,
+    ) => {
+      setAssetLoading(true);
+      try {
+        const result = unwrap(
+          await qualityTableAssetApi.page({
+            current,
+            pageSize: PAGE_SIZE,
+            dataSourceId: targetDataSourceId,
+            databaseName: targetDatabaseName,
+            keyword: searchKeyword,
+          }),
+        );
+        setAssets(result.records || []);
+        setAssetTotal(result.total || 0);
+      } catch (error: any) {
+        setAssets([]);
+        setAssetTotal(0);
+        message.error(error?.message || '已注册数据表加载失败');
+      } finally {
+        setAssetLoading(false);
+      }
+    },
+    [],
+  );
 
-    setLoading(true);
-    try {
-      const [tableResult, summaryResult] = await Promise.all([
-        dataSourceCatalogApi.listTables(
-          dataSourceId,
-          databaseName,
-          undefined,
-          queryKeyword,
-        ),
-        qualityMonitorApi.tableSummary({ dataSourceId, databaseName }),
-      ]);
-      setTables(unwrap(tableResult));
-      setSummaries(unwrap(summaryResult));
-    } catch (error: any) {
-      message.error(error?.message || '数据表加载失败');
-    } finally {
-      setLoading(false);
-    }
-  }, [dataSourceId, databaseName, queryKeyword]);
+  const requestCandidates = useCallback(
+    async (
+      targetDataSourceId: number,
+      targetDatabaseName: string,
+      current: number,
+      searchKeyword: string,
+    ) => {
+      setCandidateLoading(true);
+      try {
+        const result = unwrap(
+          await qualityTableAssetApi.candidates({
+            dataSourceId: targetDataSourceId,
+            databaseName: targetDatabaseName,
+            current,
+            pageSize: CANDIDATE_PAGE_SIZE,
+            keyword: searchKeyword,
+          }),
+        );
+        setCandidates(result.records || []);
+        setCandidateTotal(result.total || 0);
+      } catch (error: any) {
+        setCandidates([]);
+        setCandidateTotal(0);
+        message.error(error?.message || '可注册数据表加载失败');
+      } finally {
+        setCandidateLoading(false);
+      }
+    },
+    [],
+  );
 
   useEffect(() => {
     void loadSourceTree();
@@ -254,8 +321,48 @@ const TableConfigPage = () => {
   }, [keyword]);
 
   useEffect(() => {
-    void loadTables();
-  }, [loadTables]);
+    const timer = window.setTimeout(() => {
+      setCandidateQueryKeyword(candidateKeyword.trim());
+    }, 250);
+    return () => window.clearTimeout(timer);
+  }, [candidateKeyword]);
+
+  useEffect(() => {
+    if (!dataSourceId || !databaseName) {
+      setAssets([]);
+      setAssetTotal(0);
+      return;
+    }
+    void requestAssets(
+      dataSourceId,
+      databaseName,
+      assetCurrent,
+      queryKeyword,
+    );
+  }, [
+    assetCurrent,
+    dataSourceId,
+    databaseName,
+    queryKeyword,
+    requestAssets,
+  ]);
+
+  useEffect(() => {
+    if (!registerOpen || !dataSourceId || !databaseName) return;
+    void requestCandidates(
+      dataSourceId,
+      databaseName,
+      candidateCurrent,
+      candidateQueryKeyword,
+    );
+  }, [
+    candidateCurrent,
+    candidateQueryKeyword,
+    dataSourceId,
+    databaseName,
+    registerOpen,
+    requestCandidates,
+  ]);
 
   const handleTreeSelect: TreeProps['onSelect'] = (keys) => {
     const key = String(keys[0] || '');
@@ -265,11 +372,112 @@ const TableConfigPage = () => {
     setSelectedNodeKey(node.key);
     setDataSourceId(node.dataSourceId);
     setDatabaseName(node.databaseName);
+    setAssetCurrent(1);
+    setKeyword('');
+    setQueryKeyword('');
+    setRegisterOpen(false);
+    setSelectedCandidates(new Map());
   };
 
   const refreshPage = async () => {
-    await loadSourceTree(selectedNodeKey);
-    await loadTables();
+    const selected = await loadSourceTree(selectedNodeKey);
+    if (selected) {
+      await requestAssets(
+        selected.dataSourceId,
+        selected.databaseName,
+        assetCurrent,
+        queryKeyword,
+      );
+    }
+  };
+
+  const openRegisterDrawer = () => {
+    if (!dataSourceId || !databaseName) {
+      message.warning('请先从左侧选择数据库');
+      return;
+    }
+    setSelectedCandidates(new Map());
+    setCandidateKeyword('');
+    setCandidateQueryKeyword('');
+    setCandidateCurrent(1);
+    setRegisterOpen(true);
+  };
+
+  const closeRegisterDrawer = () => {
+    if (registering) return;
+    setRegisterOpen(false);
+    setSelectedCandidates(new Map());
+  };
+
+  const updateCandidateSelection = (
+    record: TableCandidateView,
+    selected: boolean,
+  ) => {
+    setSelectedCandidates((previous) => {
+      const next = new Map(previous);
+      const key = tableTargetKey(record);
+      if (selected) {
+        next.set(key, record);
+      } else {
+        next.delete(key);
+      }
+      return next;
+    });
+  };
+
+  const handleRegister = async () => {
+    if (!dataSourceId || !databaseName || !selectedDataSource) return;
+    if (!selectedCandidates.size) {
+      message.warning('请至少选择一张数据表');
+      return;
+    }
+
+    setRegistering(true);
+    try {
+      const result = unwrap(
+        await qualityTableAssetApi.register({
+          dataSourceId,
+          dataSourceName:
+            selectedDataSource.name || selectedDatabaseNode?.dataSourceName || '',
+          databaseName,
+          tables: selectedCandidateRecords.map((record) => ({
+            databaseName: record.databaseName,
+            schemaName: record.schemaName,
+            tableName: record.tableName,
+            tableType: record.tableType,
+            remarks: record.remarks,
+          })),
+        }),
+      );
+      message.success(`已注册 ${result.registered} 张数据表`);
+      setRegisterOpen(false);
+      setSelectedCandidates(new Map());
+      setAssetCurrent(1);
+      await requestAssets(dataSourceId, databaseName, 1, queryKeyword);
+    } catch (error: any) {
+      message.error(error?.message || '数据表注册失败');
+    } finally {
+      setRegistering(false);
+    }
+  };
+
+  const handleUnregister = async (record: TableAssetView) => {
+    try {
+      unwrap(await qualityTableAssetApi.remove(record.id));
+      message.success('已取消注册');
+      if (assets.length === 1 && assetCurrent > 1) {
+        setAssetCurrent((value) => value - 1);
+      } else if (dataSourceId && databaseName) {
+        await requestAssets(
+          dataSourceId,
+          databaseName,
+          assetCurrent,
+          queryKeyword,
+        );
+      }
+    } catch (error: any) {
+      message.error(error?.message || '取消注册失败');
+    }
   };
 
   const startResize = (event: ReactPointerEvent<HTMLDivElement>) => {
@@ -304,13 +512,13 @@ const TableConfigPage = () => {
     window.addEventListener('pointerup', end);
   };
 
-  const targetQuery = (record: CatalogTable) =>
+  const targetQuery = (record: TableAssetView) =>
     new URLSearchParams({
-      dataSourceId: String(dataSourceId),
-      dataSourceName: selectedDataSource?.name || '',
-      databaseName: record.database || databaseName || '',
-      schemaName: record.schema || '',
-      tableName: record.name,
+      dataSourceId: String(record.dataSourceId),
+      dataSourceName: record.dataSourceName,
+      databaseName: record.databaseName || '',
+      schemaName: record.schemaName || '',
+      tableName: record.tableName,
     }).toString();
 
   return (
@@ -322,7 +530,7 @@ const TableConfigPage = () => {
           </h1>
           <Button
             icon={<RefreshCw size={14} />}
-            loading={loading || treeLoading}
+            loading={assetLoading || treeLoading}
             onClick={refreshPage}
           >
             刷新
@@ -409,102 +617,113 @@ const TableConfigPage = () => {
                   allowClear
                   variant="filled"
                   value={keyword}
-                  onChange={(event) => setKeyword(event.target.value)}
+                  onChange={(event) => {
+                    setKeyword(event.target.value);
+                    setAssetCurrent(1);
+                  }}
                   prefix={<Search size={14} className="text-[#98a2b3]" />}
-                  placeholder="搜索表名或描述"
+                  placeholder="搜索已注册的表名或描述"
                   className="min-w-[260px] flex-1"
                 />
+
+                <Button
+                  type="primary"
+                  icon={<Plus size={14} />}
+                  disabled={!dataSourceId || !databaseName}
+                  onClick={openRegisterDrawer}
+                >
+                  注册数据表
+                </Button>
               </div>
 
-              <div className="min-h-0 flex-1 overflow-auto">
-                {!dataSourceId || !databaseName ? (
-                  <div className="flex h-full items-center justify-center">
-                    <Empty
-                      image={Empty.PRESENTED_IMAGE_SIMPLE}
-                      description="请从左侧选择数据库"
-                    />
-                  </div>
-                ) : (
-                  <Spin spinning={loading}>
-                    <Table<CatalogTable>
-                      rowKey={(record) =>
-                        `${record.database || databaseName}.${
-                          record.schema || ''
-                        }.${record.name}`
-                      }
-                      size="small"
-                      pagination={false}
-                      dataSource={tables}
-                      locale={{
-                        emptyText: (
-                          <Empty
-                            image={Empty.PRESENTED_IMAGE_SIMPLE}
-                            description="暂无数据表"
-                          />
-                        ),
-                      }}
-                      columns={[
-                        {
-                          title: '表名/描述/路径',
-                          dataIndex: 'name',
-                          render: (_, record) => (
-                            <div>
-                              <div className="font-medium text-[#161823]">
-                                {record.name}
-                              </div>
-                              {record.remarks && (
-                                <div className="mt-0.5 text-xs text-[#8a8f99]">
-                                  {record.remarks}
+              {!dataSourceId || !databaseName ? (
+                <div className="flex min-h-0 flex-1 items-center justify-center">
+                  <Empty
+                    image={Empty.PRESENTED_IMAGE_SIMPLE}
+                    description="请从左侧选择数据库"
+                  />
+                </div>
+              ) : (
+                <Spin spinning={assetLoading} wrapperClassName="min-h-0 flex-1">
+                  <div className="flex h-full min-h-0 flex-col">
+                    <div className="min-h-0 flex-1 overflow-auto">
+                      <Table<TableAssetView>
+                        rowKey="id"
+                        size="small"
+                        pagination={false}
+                        dataSource={assets}
+                        scroll={{ x: 1080 }}
+                        locale={{
+                          emptyText: (
+                            <Empty
+                              image={Empty.PRESENTED_IMAGE_SIMPLE}
+                              description="当前数据库还没有注册数据表"
+                            >
+                              <Button
+                                type="primary"
+                                icon={<Plus size={14} />}
+                                onClick={openRegisterDrawer}
+                              >
+                                注册数据表
+                              </Button>
+                            </Empty>
+                          ),
+                        }}
+                        columns={[
+                          {
+                            title: '表名/描述/路径',
+                            dataIndex: 'tableName',
+                            render: (_, record) => (
+                              <div>
+                                <div className="font-medium text-[#161823]">
+                                  {record.tableName}
                                 </div>
-                              )}
-                              <div className="mt-0.5 text-xs text-[#98a2b3]">
-                                {[
-                                  record.database || databaseName,
-                                  record.schema,
-                                  record.name,
-                                ]
-                                  .filter(Boolean)
-                                  .join(' / ')}
+                                {record.remarks && (
+                                  <div className="mt-0.5 text-xs text-[#8a8f99]">
+                                    {record.remarks}
+                                  </div>
+                                )}
+                                <div className="mt-0.5 text-xs text-[#98a2b3]">
+                                  {[
+                                    record.databaseName,
+                                    record.schemaName,
+                                    record.tableName,
+                                  ]
+                                    .filter(Boolean)
+                                    .join(' / ')}
+                                </div>
                               </div>
-                            </div>
-                          ),
-                        },
-                        {
-                          title: '监控数',
-                          width: 100,
-                          render: (_, record) =>
-                            summaryMap.get(record.name)?.monitorCount || 0,
-                        },
-                        {
-                          title: '规则数',
-                          width: 100,
-                          render: (_, record) =>
-                            summaryMap.get(record.name)?.ruleCount || 0,
-                        },
-                        {
-                          title: '最近结果',
-                          width: 120,
-                          render: (_, record) => (
-                            <CheckResultTag
-                              value={summaryMap.get(record.name)?.lastResult}
-                            />
-                          ),
-                        },
-                        {
-                          title: '最近运行',
-                          width: 170,
-                          render: (_, record) =>
-                            summaryMap.get(record.name)?.lastRunTime || '--',
-                        },
-                        {
-                          title: '操作',
-                          width: 230,
-                          fixed: 'right',
-                          render: (_, record) => {
-                            const summary = summaryMap.get(record.name);
-                            return (
+                            ),
+                          },
+                          {
+                            title: '监控数',
+                            dataIndex: 'monitorCount',
+                            width: 100,
+                          },
+                          {
+                            title: '规则数',
+                            dataIndex: 'ruleCount',
+                            width: 100,
+                          },
+                          {
+                            title: '最近结果',
+                            dataIndex: 'lastResult',
+                            width: 120,
+                            render: (value) => <CheckResultTag value={value} />,
+                          },
+                          {
+                            title: '最近运行',
+                            dataIndex: 'lastRunTime',
+                            width: 180,
+                            render: (value) => value || '--',
+                          },
+                          {
+                            title: '操作',
+                            width: 300,
+                            fixed: 'right',
+                            render: (_, record) => (
                               <div className="flex items-center gap-1">
-                                {summary?.monitorId ? (
+                                {record.monitorId ? (
                                   <>
                                     <Button
                                       type="link"
@@ -512,7 +731,7 @@ const TableConfigPage = () => {
                                       icon={<Settings2 size={13} />}
                                       onClick={() =>
                                         history.push(
-                                          `/data-quality/monitor/${summary.monitorId}`,
+                                          `/data-quality/monitor/${record.monitorId}`,
                                         )
                                       }
                                     >
@@ -527,11 +746,16 @@ const TableConfigPage = () => {
                                           try {
                                             unwrap(
                                               await qualityMonitorApi.run(
-                                                summary.monitorId!,
+                                                record.monitorId!,
                                               ),
                                             );
                                             message.success('质量检查已提交');
-                                            void loadTables();
+                                            await requestAssets(
+                                              record.dataSourceId,
+                                              record.databaseName || '',
+                                              assetCurrent,
+                                              queryKeyword,
+                                            );
                                           } catch (error: any) {
                                             message.error(
                                               error?.message || '运行失败',
@@ -556,19 +780,279 @@ const TableConfigPage = () => {
                                     新建质量监控
                                   </Button>
                                 )}
+
+                                {record.monitorCount > 0 ? (
+                                  <Tooltip title="请先删除该表的质量监控">
+                                    <span>
+                                      <Button type="text" size="small" disabled>
+                                        取消注册
+                                      </Button>
+                                    </span>
+                                  </Tooltip>
+                                ) : (
+                                  <Popconfirm
+                                    title="取消注册数据表"
+                                    description="取消后，该表将不再出现在按表配置列表中。"
+                                    okText="确认取消"
+                                    cancelText="保留"
+                                    onConfirm={() => handleUnregister(record)}
+                                  >
+                                    <Button type="text" size="small">
+                                      取消注册
+                                    </Button>
+                                  </Popconfirm>
+                                )}
                               </div>
-                            );
+                            ),
                           },
-                        },
-                      ]}
-                    />
-                  </Spin>
-                )}
-              </div>
+                        ]}
+                      />
+                    </div>
+
+                    {assetTotal > 0 && (
+                      <div className="flex shrink-0 justify-end border-t border-[#f0f0f1] px-3 py-3">
+                        <Pagination
+                          size="small"
+                          current={assetCurrent}
+                          pageSize={PAGE_SIZE}
+                          total={assetTotal}
+                          showSizeChanger={false}
+                          showTotal={(total) => `共 ${total} 张已注册表`}
+                          onChange={setAssetCurrent}
+                        />
+                      </div>
+                    )}
+                  </div>
+                </Spin>
+              )}
             </div>
           </main>
         </div>
       </div>
+
+      <Drawer
+        title={
+          <div>
+            <div className="text-[16px] font-semibold text-[#161823]">
+              注册数据表
+            </div>
+            <div className="mt-1 text-xs font-normal text-[#8a8f99]">
+              从数据源插件发现表，并将需要质量管理的数据表注册到当前数据库。
+            </div>
+          </div>
+        }
+        width={960}
+        open={registerOpen}
+        destroyOnClose
+        maskClosable={!registering}
+        closable={!registering}
+        onClose={closeRegisterDrawer}
+        styles={{ body: { padding: 0 }, footer: { padding: '12px 20px' } }}
+        footer={
+          <div className="flex items-center justify-between">
+            <span className="text-xs text-[#8a8f99]">
+              已选择 {selectedCandidates.size} 张数据表
+            </span>
+            <div className="flex items-center gap-2">
+              <Button disabled={registering} onClick={closeRegisterDrawer}>
+                取消
+              </Button>
+              <Button
+                type="primary"
+                loading={registering}
+                disabled={!selectedCandidates.size}
+                onClick={handleRegister}
+              >
+                注册所选数据表
+              </Button>
+            </div>
+          </div>
+        }
+      >
+        <div className="grid h-full min-h-[580px] grid-cols-[minmax(0,1.35fr)_minmax(320px,.65fr)]">
+          <div className="flex min-w-0 flex-col border-r border-[#e8e9ec] p-4">
+            <div className="mb-3 flex items-center justify-between">
+              <div>
+                <div className="text-sm font-semibold text-[#161823]">
+                  可注册的数据表
+                </div>
+                <div className="mt-0.5 text-xs text-[#98a2b3]">
+                  数据实时来自当前数据源插件
+                </div>
+              </div>
+              <span className="text-xs text-[#8a8f99]">
+                共 {candidateTotal} 张
+              </span>
+            </div>
+
+            <Input
+              allowClear
+              variant="filled"
+              value={candidateKeyword}
+              onChange={(event) => {
+                setCandidateKeyword(event.target.value);
+                setCandidateCurrent(1);
+              }}
+              prefix={<Search size={14} className="text-[#98a2b3]" />}
+              placeholder="搜索表名或描述"
+              className="mb-3"
+            />
+
+            <div className="min-h-0 flex-1 overflow-hidden">
+              <Spin spinning={candidateLoading}>
+                <Table<TableCandidateView>
+                  rowKey={tableTargetKey}
+                  size="small"
+                  pagination={false}
+                  dataSource={candidates}
+                  scroll={{ y: 410 }}
+                  rowSelection={{
+                    preserveSelectedRowKeys: true,
+                    selectedRowKeys: selectedCandidateKeys,
+                    onSelect: updateCandidateSelection,
+                    onSelectAll: (selected, _rows, changedRows) => {
+                      setSelectedCandidates((previous) => {
+                        const next = new Map(previous);
+                        changedRows.forEach((record) => {
+                          const key = tableTargetKey(record);
+                          if (selected) {
+                            next.set(key, record);
+                          } else {
+                            next.delete(key);
+                          }
+                        });
+                        return next;
+                      });
+                    },
+                  }}
+                  locale={{
+                    emptyText: (
+                      <Empty
+                        image={Empty.PRESENTED_IMAGE_SIMPLE}
+                        description="没有可注册的数据表"
+                      />
+                    ),
+                  }}
+                  columns={[
+                    {
+                      title: '表名/描述',
+                      dataIndex: 'tableName',
+                      render: (_, record) => (
+                        <div className="min-w-0">
+                          <div className="truncate font-medium text-[#161823]">
+                            {record.tableName}
+                          </div>
+                          {record.remarks && (
+                            <div className="mt-0.5 truncate text-xs text-[#8a8f99]">
+                              {record.remarks}
+                            </div>
+                          )}
+                          <div className="mt-0.5 truncate text-xs text-[#98a2b3]">
+                            {[
+                              record.databaseName,
+                              record.schemaName,
+                              record.tableName,
+                            ]
+                              .filter(Boolean)
+                              .join(' / ')}
+                          </div>
+                        </div>
+                      ),
+                    },
+                    {
+                      title: '类型',
+                      dataIndex: 'tableType',
+                      width: 90,
+                      render: (value) => value || '--',
+                    },
+                  ]}
+                />
+              </Spin>
+            </div>
+
+            {candidateTotal > 0 && (
+              <div className="mt-3 flex shrink-0 justify-end">
+                <Pagination
+                  size="small"
+                  current={candidateCurrent}
+                  pageSize={CANDIDATE_PAGE_SIZE}
+                  total={candidateTotal}
+                  showSizeChanger={false}
+                  onChange={setCandidateCurrent}
+                />
+              </div>
+            )}
+          </div>
+
+          <div className="flex min-w-0 flex-col bg-[#fafafa] p-4">
+            <div className="mb-3 flex items-center justify-between">
+              <div>
+                <div className="text-sm font-semibold text-[#161823]">
+                  已选择的数据表
+                </div>
+                <div className="mt-0.5 text-xs text-[#98a2b3]">
+                  支持跨页选择，确认后统一注册
+                </div>
+              </div>
+              {!!selectedCandidates.size && (
+                <Button
+                  type="link"
+                  size="small"
+                  onClick={() => setSelectedCandidates(new Map())}
+                >
+                  清空
+                </Button>
+              )}
+            </div>
+
+            <div className="min-h-0 flex-1 overflow-y-auto">
+              {selectedCandidateRecords.length ? (
+                <div className="space-y-2">
+                  {selectedCandidateRecords.map((record) => (
+                    <div
+                      key={tableTargetKey(record)}
+                      className="flex items-start gap-2 border border-[#e4e7ec] bg-white px-3 py-2.5"
+                    >
+                      <Database
+                        size={14}
+                        className="mt-0.5 shrink-0 text-[#667085]"
+                      />
+                      <div className="min-w-0 flex-1">
+                        <div className="truncate text-[13px] font-medium text-[#161823]">
+                          {record.tableName}
+                        </div>
+                        <div className="mt-0.5 truncate text-xs text-[#98a2b3]">
+                          {[
+                            record.databaseName,
+                            record.schemaName,
+                            record.tableName,
+                          ]
+                            .filter(Boolean)
+                            .join(' / ')}
+                        </div>
+                      </div>
+                      <Button
+                        type="text"
+                        size="small"
+                        aria-label={`移除 ${record.tableName}`}
+                        icon={<X size={14} />}
+                        onClick={() => updateCandidateSelection(record, false)}
+                      />
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <div className="flex h-full items-center justify-center">
+                  <Empty
+                    image={Empty.PRESENTED_IMAGE_SIMPLE}
+                    description="尚未选择数据表"
+                  />
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      </Drawer>
     </ConfigProvider>
   );
 };

--- a/yak-ops-ui/src/pages/data-quality/types.ts
+++ b/yak-ops-ui/src/pages/data-quality/types.ts
@@ -118,6 +118,67 @@ export interface TableMonitorSummary {
   lastRunTime?: string;
 }
 
+export interface TableAssetView {
+  id: number;
+  dataSourceId: number;
+  dataSourceName: string;
+  databaseName?: string;
+  schemaName?: string;
+  tableName: string;
+  tableType?: string;
+  remarks?: string;
+  monitorId?: number;
+  monitorName?: string;
+  monitorCount: number;
+  ruleCount: number;
+  lastResult: CheckResult;
+  lastRunTime?: string;
+  registeredBy: string;
+  registeredAt: string;
+}
+
+export interface TableAssetPageView {
+  records: TableAssetView[];
+  total: number;
+  current: number;
+  pageSize: number;
+}
+
+export interface TableCandidateView {
+  databaseName?: string;
+  schemaName?: string;
+  tableName: string;
+  tableType?: string;
+  remarks?: string;
+}
+
+export interface TableCandidatePageView {
+  records: TableCandidateView[];
+  total: number;
+  current: number;
+  pageSize: number;
+}
+
+export interface RegisterTableItem {
+  databaseName?: string;
+  schemaName?: string;
+  tableName: string;
+  tableType?: string;
+  remarks?: string;
+}
+
+export interface RegisterTablesPayload {
+  dataSourceId: number;
+  dataSourceName: string;
+  databaseName?: string;
+  tables: RegisterTableItem[];
+}
+
+export interface RegisterTablesView {
+  requested: number;
+  registered: number;
+}
+
 export interface RunView {
   executionNo: string;
   executionStatus: ExecutionStatus;


### PR DESCRIPTION
## 变更说明

将“按表配置”调整为先注册数据表、再配置质量监控的两阶段流程，并保持在同一个页面内完成。

### 后端

- 新增 `yak_quality_table_asset`，用于保存数据质量已纳管的数据表。
- 升级时自动将已有质量监控对应的数据表回填为注册资产。
- 新增已注册表分页、候选表分页、批量注册和取消注册接口。
- 候选表和注册校验统一通过 `DataSourceCatalogService` 获取，底层继续由数据源插件负责元数据发现。
- 注册时以后端插件返回的表类型、描述等元数据为准，不信任前端快照。
- 已存在质量监控的数据表禁止取消注册。
- 新建或修改质量监控时校验目标表已经注册。

### 前端

- 点击左侧数据库后，右侧只查询并展示已注册的数据表，不再直接加载全部物理表。
- 新增“注册数据表”抽屉。
- 抽屉采用双列表布局，支持搜索、分页、当前页批量选择和跨页保留选择。
- 注册完成后刷新当前数据库的已注册表列表。
- 未配置监控的表可以取消注册；已配置监控的表给出操作限制提示。
- 保留监控详情、新建质量监控和手动运行能力。

### 测试

- 新增 `QualityTableAssetServiceTest`，覆盖候选表过滤、插件元数据落库和取消注册保护。
- 当前仓库没有可用的 GitHub Actions 工作流，本环境也未安装 Maven、未挂载前端依赖，因此尚未执行完整 Maven 测试和前端 `tsc`；请在本地或测试环境验证后再转为 Ready。