### PR TITLE
feat(data-quality): redesign monitor detail workspace

### DIFF
--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/api/QualityWorkspaceApi.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/api/QualityWorkspaceApi.java
@@ -1,0 +1,87 @@
+package io.yak.ops.business.quality.api;
+
+import io.yak.ops.business.quality.api.QualityApi.MonitorSettingsView;
+import io.yak.ops.business.quality.api.QualityApi.MonitorView;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public final class QualityWorkspaceApi {
+
+  private QualityWorkspaceApi() {
+  }
+
+  public record WorkspaceStats(
+      int ruleCount,
+      int enabledRuleCount,
+      int executionCount,
+      int issueExecutionCount,
+      LocalDateTime latestExecutionTime) {
+  }
+
+  public record MonitorWorkspaceView(
+      MonitorView monitor,
+      MonitorSettingsView settings,
+      WorkspaceStats stats) {
+  }
+
+  public record ReportOverview(
+      int totalRules,
+      int enabledRules,
+      int executedRules,
+      int issueRules,
+      int errorRules,
+      double passRate) {
+  }
+
+  public record DimensionReport(
+      String dimension,
+      int total,
+      int passed,
+      int notPassed,
+      int errors,
+      double passRate) {
+  }
+
+  public record TrendPoint(
+      LocalDate date,
+      String dimension,
+      int total,
+      int passed,
+      int issues,
+      double passRate) {
+  }
+
+  public record ColumnReport(
+      String columnName,
+      String dimension,
+      int total,
+      int passed,
+      int issues,
+      double passRate) {
+  }
+
+  public record MonitorReportView(
+      LocalDate reportDate,
+      LocalDate trendStartDate,
+      ReportOverview overview,
+      List<DimensionReport> dimensions,
+      List<TrendPoint> trend,
+      List<ColumnReport> columns) {
+  }
+
+  public record OperationLogItem(
+      String id,
+      String operator,
+      LocalDateTime operationTime,
+      String actionType,
+      String content) {
+  }
+
+  public record OperationLogPageView(
+      List<OperationLogItem> records,
+      long total,
+      int current,
+      int pageSize) {
+  }
+}

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/controller/v1/QualityWorkspaceController.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/controller/v1/QualityWorkspaceController.java
@@ -1,0 +1,57 @@
+package io.yak.ops.business.quality.controller.v1;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.yak.framework.common.Result;
+import io.yak.framework.security.web.RequiresPermission;
+import io.yak.ops.business.quality.QualityPermissionCode;
+import io.yak.ops.business.quality.api.QualityWorkspaceApi.MonitorReportView;
+import io.yak.ops.business.quality.api.QualityWorkspaceApi.MonitorWorkspaceView;
+import io.yak.ops.business.quality.api.QualityWorkspaceApi.OperationLogPageView;
+import io.yak.ops.business.quality.config.ConditionalOnQualityEnabled;
+import io.yak.ops.business.quality.service.QualityWorkspaceService;
+import java.time.LocalDate;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "数据质量监控工作台")
+@RestController
+@ConditionalOnQualityEnabled
+@RequestMapping("/api/v1/data-quality/monitor")
+@RequiresPermission(QualityPermissionCode.MONITOR_READ)
+public class QualityWorkspaceController {
+
+  private final QualityWorkspaceService service;
+
+  public QualityWorkspaceController(QualityWorkspaceService service) {
+    this.service = service;
+  }
+
+  @Operation(summary = "查询质量监控工作台")
+  @GetMapping("/{id}/workspace")
+  public Result<MonitorWorkspaceView> workspace(@PathVariable long id) {
+    return Result.success(service.workspace(id));
+  }
+
+  @Operation(summary = "查询质量监控报告")
+  @GetMapping("/{id}/report")
+  public Result<MonitorReportView> report(
+      @PathVariable long id,
+      @RequestParam(value = "date", required = false)
+      @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
+    return Result.success(service.report(id, date));
+  }
+
+  @Operation(summary = "查询质量监控操作日志")
+  @GetMapping("/{id}/operation-log")
+  public Result<OperationLogPageView> operationLog(
+      @PathVariable long id,
+      @RequestParam(value = "current", required = false) Integer current,
+      @RequestParam(value = "pageSize", required = false) Integer pageSize) {
+    return Result.success(service.operationLogs(id, current, pageSize));
+  }
+}

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/repository/QualityWorkspaceRepository.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/repository/QualityWorkspaceRepository.java
@@ -1,0 +1,344 @@
+package io.yak.ops.business.quality.repository;
+
+import io.yak.ops.business.quality.api.QualityWorkspaceApi.ColumnReport;
+import io.yak.ops.business.quality.api.QualityWorkspaceApi.DimensionReport;
+import io.yak.ops.business.quality.api.QualityWorkspaceApi.OperationLogItem;
+import io.yak.ops.business.quality.api.QualityWorkspaceApi.ReportOverview;
+import io.yak.ops.business.quality.api.QualityWorkspaceApi.TrendPoint;
+import io.yak.ops.business.quality.api.QualityWorkspaceApi.WorkspaceStats;
+import io.yak.ops.business.quality.config.ConditionalOnQualityEnabled;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+@ConditionalOnQualityEnabled
+@Repository
+public class QualityWorkspaceRepository {
+
+  private final NamedParameterJdbcTemplate jdbcTemplate;
+
+  public QualityWorkspaceRepository(
+      @Qualifier("qualityJdbcTemplate") NamedParameterJdbcTemplate jdbcTemplate) {
+    this.jdbcTemplate = jdbcTemplate;
+  }
+
+  public WorkspaceStats stats(long monitorId) {
+    MapSqlParameterSource params = new MapSqlParameterSource("monitorId", monitorId);
+    return jdbcTemplate.queryForObject(
+        """
+        SELECT
+          (SELECT COUNT(*) FROM yak_quality_rule r
+             WHERE r.monitor_id = :monitorId AND r.deleted = 0) AS rule_count,
+          (SELECT COUNT(*) FROM yak_quality_rule r
+             WHERE r.monitor_id = :monitorId AND r.deleted = 0 AND r.enabled = 1)
+             AS enabled_rule_count,
+          (SELECT COUNT(*) FROM yak_quality_execution e
+             WHERE e.monitor_id = :monitorId) AS execution_count,
+          (SELECT COUNT(*) FROM yak_quality_execution e
+             WHERE e.monitor_id = :monitorId
+               AND e.check_result IN ('NOT_PASSED', 'ERROR')) AS issue_execution_count,
+          (SELECT MAX(e.queued_at) FROM yak_quality_execution e
+             WHERE e.monitor_id = :monitorId) AS latest_execution_time
+        """,
+        params,
+        (rs, rowNum) -> new WorkspaceStats(
+            rs.getInt("rule_count"),
+            rs.getInt("enabled_rule_count"),
+            rs.getInt("execution_count"),
+            rs.getInt("issue_execution_count"),
+            localDateTime(rs.getTimestamp("latest_execution_time"))));
+  }
+
+  public ReportOverview overview(
+      long monitorId,
+      LocalDateTime reportStart,
+      LocalDateTime reportEnd) {
+    MapSqlParameterSource params = reportParams(monitorId, reportStart, reportEnd);
+    return jdbcTemplate.queryForObject(
+        """
+        SELECT
+          (SELECT COUNT(*) FROM yak_quality_rule r
+             WHERE r.monitor_id = :monitorId AND r.deleted = 0) AS total_rules,
+          (SELECT COUNT(*) FROM yak_quality_rule r
+             WHERE r.monitor_id = :monitorId AND r.deleted = 0 AND r.enabled = 1)
+             AS enabled_rules,
+          SUM(CASE WHEN re.check_result <> 'NOT_RUN' THEN 1 ELSE 0 END)
+             AS executed_rules,
+          SUM(CASE WHEN re.check_result = 'NOT_PASSED' THEN 1 ELSE 0 END)
+             AS issue_rules,
+          SUM(CASE WHEN re.check_result = 'ERROR' THEN 1 ELSE 0 END)
+             AS error_rules,
+          SUM(CASE WHEN re.check_result = 'PASSED' THEN 1 ELSE 0 END)
+             AS passed_rules
+        FROM yak_quality_execution e
+        LEFT JOIN yak_quality_rule_execution re ON re.execution_id = e.id
+        WHERE e.monitor_id = :monitorId
+          AND e.queued_at >= :reportStart
+          AND e.queued_at < :reportEnd
+        """,
+        params,
+        (rs, rowNum) -> {
+          int executed = rs.getInt("executed_rules");
+          int passed = rs.getInt("passed_rules");
+          return new ReportOverview(
+              rs.getInt("total_rules"),
+              rs.getInt("enabled_rules"),
+              executed,
+              rs.getInt("issue_rules"),
+              rs.getInt("error_rules"),
+              rate(passed, executed));
+        });
+  }
+
+  public List<DimensionReport> dimensions(
+      long monitorId,
+      LocalDateTime reportStart,
+      LocalDateTime reportEnd) {
+    return jdbcTemplate.query(
+        """
+        SELECT d.dimension,
+               COALESCE(a.total_count, 0) AS total_count,
+               COALESCE(a.passed_count, 0) AS passed_count,
+               COALESCE(a.not_passed_count, 0) AS not_passed_count,
+               COALESCE(a.error_count, 0) AS error_count
+        FROM (
+          SELECT DISTINCT COALESCE(NULLIF(quality_dimension, ''), '其他') AS dimension
+          FROM yak_quality_rule
+          WHERE monitor_id = :monitorId AND deleted = 0
+        ) d
+        LEFT JOIN (
+          SELECT COALESCE(NULLIF(r.quality_dimension, ''), '其他') AS dimension,
+                 SUM(CASE WHEN re.check_result <> 'NOT_RUN' THEN 1 ELSE 0 END)
+                    AS total_count,
+                 SUM(CASE WHEN re.check_result = 'PASSED' THEN 1 ELSE 0 END)
+                    AS passed_count,
+                 SUM(CASE WHEN re.check_result = 'NOT_PASSED' THEN 1 ELSE 0 END)
+                    AS not_passed_count,
+                 SUM(CASE WHEN re.check_result = 'ERROR' THEN 1 ELSE 0 END)
+                    AS error_count
+          FROM yak_quality_rule_execution re
+          JOIN yak_quality_execution e ON e.id = re.execution_id
+          LEFT JOIN yak_quality_rule r ON r.id = re.rule_id
+          WHERE e.monitor_id = :monitorId
+            AND e.queued_at >= :reportStart
+            AND e.queued_at < :reportEnd
+          GROUP BY COALESCE(NULLIF(r.quality_dimension, ''), '其他')
+        ) a ON a.dimension = d.dimension
+        ORDER BY FIELD(d.dimension, '完整性', '准确性', '一致性', '唯一性', '时效性', '有效性'),
+                 d.dimension
+        """,
+        reportParams(monitorId, reportStart, reportEnd),
+        (rs, rowNum) -> {
+          int total = rs.getInt("total_count");
+          int passed = rs.getInt("passed_count");
+          return new DimensionReport(
+              rs.getString("dimension"),
+              total,
+              passed,
+              rs.getInt("not_passed_count"),
+              rs.getInt("error_count"),
+              rate(passed, total));
+        });
+  }
+
+  public List<TrendPoint> trend(
+      long monitorId,
+      LocalDateTime trendStart,
+      LocalDateTime reportEnd) {
+    return jdbcTemplate.query(
+        """
+        SELECT DATE(e.queued_at) AS report_date,
+               COALESCE(NULLIF(r.quality_dimension, ''), '其他') AS dimension,
+               SUM(CASE WHEN re.check_result <> 'NOT_RUN' THEN 1 ELSE 0 END)
+                  AS total_count,
+               SUM(CASE WHEN re.check_result = 'PASSED' THEN 1 ELSE 0 END)
+                  AS passed_count,
+               SUM(CASE WHEN re.check_result IN ('NOT_PASSED', 'ERROR') THEN 1 ELSE 0 END)
+                  AS issue_count
+        FROM yak_quality_rule_execution re
+        JOIN yak_quality_execution e ON e.id = re.execution_id
+        LEFT JOIN yak_quality_rule r ON r.id = re.rule_id
+        WHERE e.monitor_id = :monitorId
+          AND e.queued_at >= :trendStart
+          AND e.queued_at < :reportEnd
+        GROUP BY DATE(e.queued_at),
+                 COALESCE(NULLIF(r.quality_dimension, ''), '其他')
+        ORDER BY report_date ASC, dimension ASC
+        """,
+        new MapSqlParameterSource()
+            .addValue("monitorId", monitorId)
+            .addValue("trendStart", Timestamp.valueOf(trendStart))
+            .addValue("reportEnd", Timestamp.valueOf(reportEnd)),
+        (rs, rowNum) -> {
+          int total = rs.getInt("total_count");
+          int passed = rs.getInt("passed_count");
+          return new TrendPoint(
+              rs.getDate("report_date").toLocalDate(),
+              rs.getString("dimension"),
+              total,
+              passed,
+              rs.getInt("issue_count"),
+              rate(passed, total));
+        });
+  }
+
+  public List<ColumnReport> columns(
+      long monitorId,
+      LocalDateTime reportStart,
+      LocalDateTime reportEnd) {
+    return jdbcTemplate.query(
+        """
+        SELECT COALESCE(NULLIF(re.column_name, ''), '表级') AS column_name,
+               COALESCE(NULLIF(r.quality_dimension, ''), '其他') AS dimension,
+               SUM(CASE WHEN re.check_result <> 'NOT_RUN' THEN 1 ELSE 0 END)
+                  AS total_count,
+               SUM(CASE WHEN re.check_result = 'PASSED' THEN 1 ELSE 0 END)
+                  AS passed_count,
+               SUM(CASE WHEN re.check_result IN ('NOT_PASSED', 'ERROR') THEN 1 ELSE 0 END)
+                  AS issue_count
+        FROM yak_quality_rule_execution re
+        JOIN yak_quality_execution e ON e.id = re.execution_id
+        LEFT JOIN yak_quality_rule r ON r.id = re.rule_id
+        WHERE e.monitor_id = :monitorId
+          AND e.queued_at >= :reportStart
+          AND e.queued_at < :reportEnd
+        GROUP BY COALESCE(NULLIF(re.column_name, ''), '表级'),
+                 COALESCE(NULLIF(r.quality_dimension, ''), '其他')
+        ORDER BY issue_count DESC, column_name ASC
+        """,
+        reportParams(monitorId, reportStart, reportEnd),
+        (rs, rowNum) -> {
+          int total = rs.getInt("total_count");
+          int passed = rs.getInt("passed_count");
+          return new ColumnReport(
+              rs.getString("column_name"),
+              rs.getString("dimension"),
+              total,
+              passed,
+              rs.getInt("issue_count"),
+              rate(passed, total));
+        });
+  }
+
+  public long countOperationLogs(long monitorId) {
+    Long total = jdbcTemplate.queryForObject(
+        """
+        SELECT
+          1
+          + CASE WHEN m.updated_at > DATE_ADD(m.created_at, INTERVAL 1 SECOND)
+              THEN 1 ELSE 0 END
+          + (SELECT COUNT(*) FROM yak_quality_rule r WHERE r.monitor_id = m.id)
+          + (SELECT COUNT(*) FROM yak_quality_execution e WHERE e.monitor_id = m.id)
+        FROM yak_quality_monitor m
+        WHERE m.id = :monitorId AND m.deleted = 0
+        """,
+        new MapSqlParameterSource("monitorId", monitorId),
+        Long.class);
+    return total == null ? 0L : total;
+  }
+
+  public List<OperationLogItem> operationLogs(
+      long monitorId,
+      int current,
+      int pageSize) {
+    return jdbcTemplate.query(
+        """
+        SELECT log_id, operator_name, operation_time, action_type, action_content
+        FROM (
+          SELECT CONCAT('monitor-create-', m.id) AS log_id,
+                 m.owner AS operator_name,
+                 m.created_at AS operation_time,
+                 'CREATE_MONITOR' AS action_type,
+                 CONCAT('创建质量监控「', m.monitor_name, '」，监控对象：',
+                        COALESCE(NULLIF(m.database_name, ''), ''),
+                        CASE WHEN m.database_name IS NULL OR m.database_name = '' THEN '' ELSE '.' END,
+                        COALESCE(NULLIF(m.schema_name, ''), ''),
+                        CASE WHEN m.schema_name IS NULL OR m.schema_name = '' THEN '' ELSE '.' END,
+                        m.table_name) AS action_content
+          FROM yak_quality_monitor m
+          WHERE m.id = :monitorId AND m.deleted = 0
+
+          UNION ALL
+
+          SELECT CONCAT('monitor-update-', m.id),
+                 m.owner,
+                 m.updated_at,
+                 'UPDATE_MONITOR',
+                 CONCAT('更新质量监控「', m.monitor_name, '」的基础配置、运行设置或问题处理策略')
+          FROM yak_quality_monitor m
+          WHERE m.id = :monitorId
+            AND m.deleted = 0
+            AND m.updated_at > DATE_ADD(m.created_at, INTERVAL 1 SECOND)
+
+          UNION ALL
+
+          SELECT CONCAT('rule-', r.id),
+                 m.owner,
+                 r.created_at,
+                 'SAVE_RULE',
+                 CONCAT('保存质量规则「', r.rule_name, '」，规则模板：', r.template_code,
+                        '，关联范围：', CASE WHEN r.rule_scope = 'TABLE' THEN '表级' ELSE '字段级' END,
+                        CASE WHEN r.column_name IS NULL OR r.column_name = ''
+                             THEN '' ELSE CONCAT('，字段：', r.column_name) END)
+          FROM yak_quality_rule r
+          JOIN yak_quality_monitor m ON m.id = r.monitor_id
+          WHERE r.monitor_id = :monitorId
+
+          UNION ALL
+
+          SELECT CONCAT('execution-', e.id),
+                 e.operator_name,
+                 e.queued_at,
+                 'RUN_MONITOR',
+                 CONCAT('触发质量检查，执行编号：', e.execution_no,
+                        '，触发方式：', e.trigger_type,
+                        '，检查结果：', e.check_result)
+          FROM yak_quality_execution e
+          WHERE e.monitor_id = :monitorId
+        ) logs
+        ORDER BY operation_time DESC, log_id DESC
+        LIMIT :limit OFFSET :offset
+        """,
+        new MapSqlParameterSource()
+            .addValue("monitorId", monitorId)
+            .addValue("limit", pageSize)
+            .addValue("offset", (current - 1L) * pageSize),
+        this::mapOperationLog);
+  }
+
+  private OperationLogItem mapOperationLog(ResultSet rs, int rowNum) throws SQLException {
+    return new OperationLogItem(
+        rs.getString("log_id"),
+        rs.getString("operator_name"),
+        localDateTime(rs.getTimestamp("operation_time")),
+        rs.getString("action_type"),
+        rs.getString("action_content"));
+  }
+
+  private MapSqlParameterSource reportParams(
+      long monitorId,
+      LocalDateTime reportStart,
+      LocalDateTime reportEnd) {
+    return new MapSqlParameterSource()
+        .addValue("monitorId", monitorId)
+        .addValue("reportStart", Timestamp.valueOf(reportStart))
+        .addValue("reportEnd", Timestamp.valueOf(reportEnd));
+  }
+
+  private static LocalDateTime localDateTime(Timestamp value) {
+    return value == null ? null : value.toLocalDateTime();
+  }
+
+  private static double rate(int passed, int total) {
+    if (total <= 0) {
+      return 0D;
+    }
+    return Math.round((passed * 10000D) / total) / 100D;
+  }
+}

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/service/QualityWorkspaceService.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/service/QualityWorkspaceService.java
@@ -1,0 +1,68 @@
+package io.yak.ops.business.quality.service;
+
+import io.yak.ops.business.quality.api.QualityApi.MonitorSettingsView;
+import io.yak.ops.business.quality.api.QualityApi.MonitorView;
+import io.yak.ops.business.quality.api.QualityWorkspaceApi.MonitorReportView;
+import io.yak.ops.business.quality.api.QualityWorkspaceApi.MonitorWorkspaceView;
+import io.yak.ops.business.quality.api.QualityWorkspaceApi.OperationLogPageView;
+import io.yak.ops.business.quality.config.ConditionalOnQualityEnabled;
+import io.yak.ops.business.quality.repository.QualityWorkspaceRepository;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@ConditionalOnQualityEnabled
+@Service
+public class QualityWorkspaceService {
+
+  private final QualityMonitorService monitorService;
+  private final QualityWorkspaceRepository repository;
+
+  public QualityWorkspaceService(
+      QualityMonitorService monitorService,
+      QualityWorkspaceRepository repository) {
+    this.monitorService = monitorService;
+    this.repository = repository;
+  }
+
+  @Transactional(readOnly = true, transactionManager = "yakBusinessTransactionManager")
+  public MonitorWorkspaceView workspace(long monitorId) {
+    MonitorView monitor = monitorService.get(monitorId);
+    MonitorSettingsView settings = monitorService.getSettings(monitorId);
+    return new MonitorWorkspaceView(monitor, settings, repository.stats(monitorId));
+  }
+
+  @Transactional(readOnly = true, transactionManager = "yakBusinessTransactionManager")
+  public MonitorReportView report(long monitorId, LocalDate reportDate) {
+    monitorService.get(monitorId);
+    LocalDate normalizedDate = reportDate == null
+        ? LocalDate.now().minusDays(1)
+        : reportDate;
+    LocalDate trendStartDate = normalizedDate.minusDays(6);
+    LocalDateTime reportStart = normalizedDate.atStartOfDay();
+    LocalDateTime reportEnd = normalizedDate.plusDays(1).atStartOfDay();
+    return new MonitorReportView(
+        normalizedDate,
+        trendStartDate,
+        repository.overview(monitorId, reportStart, reportEnd),
+        repository.dimensions(monitorId, reportStart, reportEnd),
+        repository.trend(monitorId, trendStartDate.atStartOfDay(), reportEnd),
+        repository.columns(monitorId, reportStart, reportEnd));
+  }
+
+  @Transactional(readOnly = true, transactionManager = "yakBusinessTransactionManager")
+  public OperationLogPageView operationLogs(
+      long monitorId,
+      Integer current,
+      Integer pageSize) {
+    monitorService.get(monitorId);
+    int normalizedCurrent = current == null || current < 1 ? 1 : current;
+    int normalizedPageSize = pageSize == null ? 10 : Math.min(Math.max(pageSize, 1), 100);
+    return new OperationLogPageView(
+        repository.operationLogs(monitorId, normalizedCurrent, normalizedPageSize),
+        repository.countOperationLogs(monitorId),
+        normalizedCurrent,
+        normalizedPageSize);
+  }
+}

--- a/yak-ops-ui/src/pages/data-quality/monitor/detail/MonitorListTab.tsx
+++ b/yak-ops-ui/src/pages/data-quality/monitor/detail/MonitorListTab.tsx
@@ -1,0 +1,246 @@
+import {
+  Button,
+  Dropdown,
+  Empty,
+  Input,
+  Select,
+  Table,
+  Tag,
+  Tooltip,
+  message,
+} from 'antd';
+import type { TableColumnsType } from 'antd';
+import { MoreHorizontal, Plus, RefreshCw, Search } from 'lucide-react';
+import { useMemo, useState } from 'react';
+import type { MonitorWorkspaceView } from '../../types';
+import { RUN_MODE_LABEL } from './model';
+
+interface MonitorListTabProps {
+  workspace: MonitorWorkspaceView;
+  running: boolean;
+  onRun: () => void;
+  onEdit: () => void;
+  onRefresh: () => void;
+  onRemove: () => void;
+  onOpenLog: () => void;
+}
+
+interface MonitorRecord {
+  id: number;
+  name: string;
+  description?: string;
+  trigger: string;
+  enabled: boolean;
+  ruleCount: number;
+  owner: string;
+  updateTime: string;
+}
+
+const MonitorListTab = ({
+  workspace,
+  running,
+  onRun,
+  onEdit,
+  onRefresh,
+  onRemove,
+  onOpenLog,
+}: MonitorListTabProps) => {
+  const { monitor, settings, stats } = workspace;
+  const [keyword, setKeyword] = useState('');
+  const [owner, setOwner] = useState<string>();
+  const [runMode, setRunMode] = useState<string>();
+
+  const records = useMemo<MonitorRecord[]>(() => {
+    const source: MonitorRecord[] = [
+      {
+        id: monitor.id,
+        name: monitor.name,
+        description: monitor.description,
+        trigger: RUN_MODE_LABEL[settings.runMode],
+        enabled: monitor.enabled,
+        ruleCount: stats.ruleCount,
+        owner: monitor.owner,
+        updateTime: monitor.updateTime,
+      },
+    ];
+    const normalized = keyword.trim().toLowerCase();
+    return source.filter((record) => {
+      if (
+        normalized &&
+        !`${record.id} ${record.name} ${record.description || ''}`
+          .toLowerCase()
+          .includes(normalized)
+      ) {
+        return false;
+      }
+      if (owner && record.owner !== owner) return false;
+      if (runMode && settings.runMode !== runMode) return false;
+      return true;
+    });
+  }, [keyword, monitor, owner, runMode, settings.runMode, stats.ruleCount]);
+
+  const columns: TableColumnsType<MonitorRecord> = [
+    {
+      title: 'ID/名称/描述',
+      minWidth: 360,
+      render: (_, record) => (
+        <div className="py-1">
+          <div className="text-xs text-[#8b95a7]">{record.id}</div>
+          <div className="mt-0.5 text-[13px] font-medium text-[#172033]">
+            {record.name}
+          </div>
+          {record.description ? (
+            <div className="mt-0.5 line-clamp-1 text-xs text-[#8b95a7]">
+              {record.description}
+            </div>
+          ) : null}
+        </div>
+      ),
+    },
+    { title: '触发方式', dataIndex: 'trigger', width: 180 },
+    {
+      title: '已启用/总规则数',
+      width: 150,
+      render: () => (
+        <span>
+          <span className="text-[#245bdb]">{stats.enabledRuleCount}</span>/{stats.ruleCount}
+        </span>
+      ),
+    },
+    { title: '责任人', dataIndex: 'owner', width: 180 },
+    { title: '最近更新时间', dataIndex: 'updateTime', width: 190 },
+    {
+      title: '状态',
+      dataIndex: 'enabled',
+      width: 90,
+      render: (value) => (
+        <Tag className="!m-0 !border-0" color={value ? 'processing' : 'default'}>
+          {value ? '启用' : '停用'}
+        </Tag>
+      ),
+    },
+    {
+      title: '操作',
+      fixed: 'right',
+      width: 190,
+      render: () => (
+        <div className="flex items-center gap-3 whitespace-nowrap text-xs">
+          <button
+            type="button"
+            className="border-0 bg-transparent p-0 text-[#245bdb]"
+            onClick={onEdit}
+          >
+            编辑
+          </button>
+          <button
+            type="button"
+            className="border-0 bg-transparent p-0 text-[#245bdb]"
+            onClick={onRun}
+          >
+            {running ? '提交中' : '测试'}
+          </button>
+          <Dropdown
+            trigger={['click']}
+            menu={{
+              items: [
+                { key: 'log', label: '操作日志' },
+                { type: 'divider' },
+                { key: 'remove', label: '删除', danger: true },
+              ],
+              onClick: ({ key }) => {
+                if (key === 'log') onOpenLog();
+                if (key === 'remove') onRemove();
+              },
+            }}
+          >
+            <button
+              type="button"
+              className="inline-flex items-center gap-1 border-0 bg-transparent p-0 text-[#245bdb]"
+            >
+              更多 <MoreHorizontal size={13} />
+            </button>
+          </Dropdown>
+        </div>
+      ),
+    },
+  ];
+
+  return (
+    <div className="min-h-0 flex-1 overflow-auto bg-white px-6 py-4">
+      <div className="flex flex-wrap items-center gap-2">
+        <Tooltip title="当前数据表只允许创建一个质量监控">
+          <Button
+            type="primary"
+            icon={<Plus size={14} />}
+            onClick={() => message.info('当前数据表已经存在质量监控')}
+          >
+            新建质量监控
+          </Button>
+        </Tooltip>
+        <Input
+          allowClear
+          value={keyword}
+          onChange={(event) => setKeyword(event.target.value)}
+          placeholder="请输入关键词搜索"
+          prefix={<Search size={14} className="text-[#98a2b3]" />}
+          className="w-[220px]"
+        />
+        <Select
+          allowClear
+          value={owner}
+          placeholder="责任人"
+          options={[{ value: monitor.owner, label: monitor.owner }]}
+          onChange={setOwner}
+          className="w-[220px]"
+        />
+        <Select
+          allowClear
+          value={runMode}
+          placeholder="触发方式"
+          options={[
+            { value: 'MANUAL', label: '手动触发' },
+            { value: 'SCHEDULE', label: '生产调度触发' },
+          ]}
+          onChange={setRunMode}
+          className="w-[180px]"
+        />
+        <Button
+          type="text"
+          icon={<RefreshCw size={13} />}
+          onClick={() => {
+            setKeyword('');
+            setOwner(undefined);
+            setRunMode(undefined);
+            onRefresh();
+          }}
+        >
+          重置
+        </Button>
+      </div>
+
+      <Table<MonitorRecord>
+        rowKey="id"
+        size="small"
+        className="mt-3"
+        pagination={false}
+        scroll={{ x: 1250 }}
+        dataSource={records}
+        columns={columns}
+        locale={{
+          emptyText: (
+            <Empty
+              image={Empty.PRESENTED_IMAGE_SIMPLE}
+              description="暂无质量监控"
+            />
+          ),
+        }}
+      />
+
+      <div className="mt-4 flex justify-end text-xs text-[#8b95a7]">
+        共 {records.length} 条
+      </div>
+    </div>
+  );
+};
+
+export default MonitorListTab;

--- a/yak-ops-ui/src/pages/data-quality/monitor/detail/OperationLogDrawer.tsx
+++ b/yak-ops-ui/src/pages/data-quality/monitor/detail/OperationLogDrawer.tsx
@@ -1,0 +1,71 @@
+import { Drawer, Pagination, Table, Tag } from 'antd';
+import type { TableColumnsType } from 'antd';
+import type { OperationLogItem, OperationLogPageView } from '../../types';
+import { ACTION_TYPE_LABEL } from './model';
+
+interface OperationLogDrawerProps {
+  open: boolean;
+  loading: boolean;
+  data: OperationLogPageView;
+  onClose: () => void;
+  onPageChange: (current: number, pageSize: number) => void;
+}
+
+const OperationLogDrawer = ({
+  open,
+  loading,
+  data,
+  onClose,
+  onPageChange,
+}: OperationLogDrawerProps) => {
+  const columns: TableColumnsType<OperationLogItem> = [
+    { title: '操作人', dataIndex: 'operator', width: 130 },
+    { title: '操作时间', dataIndex: 'operationTime', width: 190 },
+    {
+      title: '类型',
+      dataIndex: 'actionType',
+      width: 100,
+      render: (value) => (
+        <Tag className="!m-0 !border-0 !bg-[#f2f4f7] !text-[#43506a]">
+          {ACTION_TYPE_LABEL[value] || value}
+        </Tag>
+      ),
+    },
+    { title: '操作内容', dataIndex: 'content' },
+  ];
+
+  return (
+    <Drawer
+      title="操作日志"
+      width="min(720px, 92vw)"
+      open={open}
+      onClose={onClose}
+      destroyOnClose
+      footer={
+        <div className="flex justify-end">
+          <Pagination
+            size="small"
+            current={data.current}
+            pageSize={data.pageSize}
+            total={data.total}
+            showSizeChanger
+            onChange={onPageChange}
+          />
+        </div>
+      }
+    >
+      <Table<OperationLogItem>
+        rowKey="id"
+        size="small"
+        loading={loading}
+        pagination={false}
+        scroll={{ x: 760 }}
+        dataSource={data.records}
+        columns={columns}
+        locale={{ emptyText: '暂无操作日志' }}
+      />
+    </Drawer>
+  );
+};
+
+export default OperationLogDrawer;

--- a/yak-ops-ui/src/pages/data-quality/monitor/detail/QualityReportTab.tsx
+++ b/yak-ops-ui/src/pages/data-quality/monitor/detail/QualityReportTab.tsx
@@ -1,0 +1,341 @@
+import { Button, DatePicker, Empty, Progress, Spin, Table, message } from 'antd';
+import type { TableColumnsType } from 'antd';
+import dayjs from 'dayjs';
+import { CalendarDays, Info } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+import type {
+  ColumnReport,
+  DimensionReport,
+  MonitorReportView,
+  TrendPoint,
+} from '../../types';
+import { DIMENSION_ORDER } from './model';
+
+interface QualityReportTabProps {
+  report?: MonitorReportView;
+  loading: boolean;
+  reportDate: string;
+  onDateChange: (date: string) => void;
+}
+
+const percentText = (value: number) => `${Number(value || 0).toFixed(1)}%`;
+
+const Sparkline = ({ values }: { values: number[] }) => {
+  const normalized = values.length ? values : [0, 0];
+  const width = 150;
+  const height = 34;
+  const points = normalized
+    .map((value, index) => {
+      const x = normalized.length === 1 ? width / 2 : (index / (normalized.length - 1)) * width;
+      const y = height - Math.max(0, Math.min(100, value)) * (height / 100);
+      return `${x},${y}`;
+    })
+    .join(' ');
+
+  return (
+    <svg width={width} height={height} viewBox={`0 0 ${width} ${height}`} role="img">
+      <line x1="0" y1={height - 1} x2={width} y2={height - 1} stroke="#edf0f5" />
+      <polyline
+        points={points}
+        fill="none"
+        stroke="#6f5cff"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+};
+
+const FocusCard = ({
+  title,
+  value,
+  hint,
+}: {
+  title: string;
+  value: number;
+  hint: string;
+}) => (
+  <div className="min-h-[116px] bg-[#f7f8fa] px-4 py-3">
+    <div className="flex items-center gap-1 text-xs text-[#667085]">
+      {title}
+      <Info size={12} className="text-[#98a2b3]" />
+    </div>
+    <div className="mt-4 text-[24px] font-semibold leading-none text-[#172033]">
+      {value}
+    </div>
+    <div className="mt-4 text-xs text-[#8b95a7]">{hint}</div>
+  </div>
+);
+
+const QualityReportTab = ({
+  report,
+  loading,
+  reportDate,
+  onDateChange,
+}: QualityReportTabProps) => {
+  const [activeDimension, setActiveDimension] = useState('全部');
+
+  const dimensions = report?.dimensions || [];
+  useEffect(() => {
+    if (
+      activeDimension !== '全部' &&
+      !dimensions.some((item) => item.dimension === activeDimension)
+    ) {
+      setActiveDimension('全部');
+    }
+  }, [activeDimension, dimensions]);
+
+  const dimensionNames = useMemo(() => {
+    const available = dimensions.map((item) => item.dimension);
+    return [
+      ...DIMENSION_ORDER.filter((item) => available.includes(item)),
+      ...available.filter((item) => !DIMENSION_ORDER.includes(item)),
+    ];
+  }, [dimensions]);
+
+  const filteredTrend = useMemo(() => {
+    if (!report) return [];
+    if (activeDimension === '全部') return report.trend;
+    return report.trend.filter((item) => item.dimension === activeDimension);
+  }, [activeDimension, report]);
+
+  const trendRows = useMemo(() => {
+    const grouped = new Map<string, TrendPoint[]>();
+    filteredTrend.forEach((item) => {
+      const values = grouped.get(item.dimension) || [];
+      values.push(item);
+      grouped.set(item.dimension, values);
+    });
+    if (!grouped.size && dimensions.length) {
+      dimensions.forEach((item) => {
+        if (activeDimension === '全部' || activeDimension === item.dimension) {
+          grouped.set(item.dimension, []);
+        }
+      });
+    }
+    return Array.from(grouped.entries()).map(([dimension, values]) => ({
+      key: dimension,
+      dimension,
+      values: values.sort((left, right) => left.date.localeCompare(right.date)),
+    }));
+  }, [activeDimension, dimensions, filteredTrend]);
+
+  const trendColumns: TableColumnsType<{
+    key: string;
+    dimension: string;
+    values: TrendPoint[];
+  }> = [
+    { title: '质量维度', dataIndex: 'dimension', width: 120 },
+    {
+      title: '质量规则数',
+      width: 120,
+      render: (_, record) =>
+        record.values.reduce((total, item) => total + item.total, 0) || '--',
+    },
+    {
+      title: '异常规则数/实例数',
+      width: 170,
+      render: (_, record) => {
+        const total = record.values.reduce((value, item) => value + item.total, 0);
+        const issues = record.values.reduce((value, item) => value + item.issues, 0);
+        return total ? `${issues}/${total}` : '-/-';
+      },
+    },
+    {
+      title: '通过率趋势',
+      width: 210,
+      render: (_, record) => (
+        <Sparkline values={record.values.map((item) => item.passRate)} />
+      ),
+    },
+    {
+      title: '操作',
+      width: 100,
+      render: () => (
+        <Button type="link" size="small" onClick={() => message.info('趋势明细已在运行记录中保留')}>
+          查看详情
+        </Button>
+      ),
+    },
+  ];
+
+  const columnColumns: TableColumnsType<ColumnReport> = [
+    { title: '字段/关联范围', dataIndex: 'columnName', minWidth: 150 },
+    { title: '质量维度', dataIndex: 'dimension', width: 100 },
+    { title: '评估次数', dataIndex: 'total', width: 100 },
+    { title: '正常', dataIndex: 'passed', width: 90 },
+    { title: '异常', dataIndex: 'issues', width: 90 },
+    {
+      title: '通过率',
+      dataIndex: 'passRate',
+      width: 150,
+      render: (value) => (
+        <div className="flex items-center gap-2">
+          <Progress percent={Number(value || 0)} showInfo={false} size="small" />
+          <span className="w-12 text-right text-xs">{percentText(value)}</span>
+        </div>
+      ),
+    },
+  ];
+
+  const yesterday = dayjs().subtract(1, 'day').format('YYYY-MM-DD');
+  const dayBefore = dayjs().subtract(2, 'day').format('YYYY-MM-DD');
+  const overview = report?.overview;
+
+  return (
+    <div className="min-h-0 flex-1 overflow-auto bg-[#f5f6f8] px-4 pb-6 pt-4">
+      <div className="mb-3 flex justify-end gap-2">
+        <Button
+          type={reportDate === yesterday ? 'primary' : 'default'}
+          onClick={() => onDateChange(yesterday)}
+        >
+          昨日
+        </Button>
+        <Button
+          type={reportDate === dayBefore ? 'primary' : 'default'}
+          onClick={() => onDateChange(dayBefore)}
+        >
+          前日
+        </Button>
+        <DatePicker
+          allowClear={false}
+          value={dayjs(reportDate)}
+          suffixIcon={<CalendarDays size={14} />}
+          onChange={(value) => value && onDateChange(value.format('YYYY-MM-DD'))}
+        />
+      </div>
+
+      <Spin spinning={loading}>
+        <div className="grid grid-cols-2 gap-2 max-xl:grid-cols-1">
+          <section className="min-h-[326px] border border-[#dfe3e8] bg-white p-4">
+            <h2 className="m-0 text-[15px] font-semibold text-[#172033]">
+              质量维度通过率
+            </h2>
+            <div className="mt-8 grid grid-cols-[270px_minmax(0,1fr)] items-center gap-4 max-md:grid-cols-1">
+              <div className="flex justify-center">
+                <Progress
+                  type="circle"
+                  size={192}
+                  percent={overview?.passRate || 0}
+                  strokeWidth={9}
+                  format={(value) => (
+                    <div>
+                      <div className="text-[30px] font-medium text-[#172033]">
+                        {Number(value || 0).toFixed(0)}%
+                      </div>
+                      <div className="mt-2 text-xs text-[#667085]">表质量通过率</div>
+                    </div>
+                  )}
+                />
+              </div>
+              <div className="space-y-3">
+                {dimensions.length ? (
+                  dimensions.map((item, index) => (
+                    <div key={item.dimension} className="grid grid-cols-[120px_minmax(0,1fr)_52px] items-center gap-2 text-xs">
+                      <span className="truncate text-[#43506a]">
+                        {index + 1}　{item.dimension}：{item.passed}/{item.total}
+                      </span>
+                      <Progress percent={item.passRate} showInfo={false} size="small" />
+                      <span className="text-right text-[#667085]">{percentText(item.passRate)}</span>
+                    </div>
+                  ))
+                ) : (
+                  <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="当前日期暂无质量结果" />
+                )}
+              </div>
+            </div>
+          </section>
+
+          <section className="min-h-[326px] border border-[#dfe3e8] bg-white p-4">
+            <h2 className="m-0 text-[15px] font-semibold text-[#172033]">重点关注</h2>
+            <div className="mt-3 grid grid-cols-2 gap-2 max-md:grid-cols-1">
+              <FocusCard
+                title="总质量规则数"
+                value={overview?.totalRules || 0}
+                hint={`已启用规则数：${overview?.enabledRules || 0}`}
+              />
+              <FocusCard
+                title="问题质量规则数"
+                value={overview?.issueRules || 0}
+                hint={`已检测规则数：${overview?.executedRules || 0}`}
+              />
+              <FocusCard
+                title="未通过规则数"
+                value={overview?.issueRules || 0}
+                hint="质量结果未达到监控阈值"
+              />
+              <FocusCard
+                title="执行异常规则数"
+                value={overview?.errorRules || 0}
+                hint="SQL 或数据源执行过程中发生异常"
+              />
+            </div>
+          </section>
+        </div>
+
+        <div className="mt-2 flex flex-wrap items-center gap-0">
+          {['全部', ...dimensionNames].map((item) => (
+            <button
+              key={item}
+              type="button"
+              className={[
+                'h-8 border border-[#dfe3e8] px-4 text-xs',
+                activeDimension === item
+                  ? 'border-[var(--yak-brand-color)] bg-[var(--yak-brand-color)] text-white'
+                  : 'bg-white text-[#43506a] hover:bg-[#f8f9fb]',
+              ].join(' ')}
+              onClick={() => setActiveDimension(item)}
+            >
+              {item}
+            </button>
+          ))}
+        </div>
+
+        <div className="mt-2 grid grid-cols-2 gap-2 max-xl:grid-cols-1">
+          <section className="min-h-[330px] border border-[#dfe3e8] bg-white p-4">
+            <h2 className="m-0 text-[15px] font-semibold text-[#172033]">
+              各维度趋势分析
+            </h2>
+            <Table
+              rowKey="key"
+              size="small"
+              className="mt-3"
+              pagination={false}
+              dataSource={trendRows}
+              columns={trendColumns}
+              locale={{ emptyText: '暂无趋势数据' }}
+            />
+          </section>
+
+          <section className="min-h-[330px] border border-[#dfe3e8] bg-white p-4">
+            <div className="flex flex-wrap items-end justify-between gap-2">
+              <div>
+                <h2 className="m-0 text-[15px] font-semibold text-[#172033]">
+                  字段质量维度分析
+                </h2>
+                <div className="mt-2 text-xs text-[#8b95a7]">
+                  评估字段总数：{report?.columns.length || 0}　
+                  正常：{report?.columns.filter((item) => item.issues === 0).length || 0}　
+                  异常：{report?.columns.filter((item) => item.issues > 0).length || 0}
+                </div>
+              </div>
+            </div>
+            <Table<ColumnReport>
+              rowKey={(record) => `${record.columnName}-${record.dimension}`}
+              size="small"
+              className="mt-3"
+              pagination={false}
+              scroll={{ x: 700 }}
+              dataSource={report?.columns || []}
+              columns={columnColumns}
+              locale={{ emptyText: '当前日期暂无字段质量结果' }}
+            />
+          </section>
+        </div>
+      </Spin>
+    </div>
+  );
+};
+
+export default QualityReportTab;

--- a/yak-ops-ui/src/pages/data-quality/monitor/detail/RuleManagementTab.tsx
+++ b/yak-ops-ui/src/pages/data-quality/monitor/detail/RuleManagementTab.tsx
@@ -1,0 +1,433 @@
+import {
+  Button,
+  Dropdown,
+  Empty,
+  Input,
+  Modal,
+  Select,
+  Table,
+  Tag,
+  Tooltip,
+  message,
+} from 'antd';
+import type { MenuProps, TableColumnsType } from 'antd';
+import {
+  Bell,
+  ChevronDown,
+  MoreHorizontal,
+  Play,
+  Plus,
+  RefreshCw,
+  Search,
+  Sparkles,
+} from 'lucide-react';
+import { useMemo, useState, type Key } from 'react';
+import type { MonitorWorkspaceView, RuleView } from '../../types';
+import {
+  DIMENSION_ORDER,
+  RUN_MODE_LABEL,
+  ruleParameter,
+  scopeLabel,
+} from './model';
+
+interface RuleManagementTabProps {
+  workspace: MonitorWorkspaceView;
+  running: boolean;
+  savingRules: boolean;
+  onRun: () => void;
+  onEditMonitor: () => void;
+  onOpenLog: () => void;
+  onRefresh: () => void;
+  onRemoveMonitor: () => void;
+  onUpdateRules: (rules: RuleView[]) => Promise<void>;
+}
+
+const RuleManagementTab = ({
+  workspace,
+  running,
+  savingRules,
+  onRun,
+  onEditMonitor,
+  onOpenLog,
+  onRefresh,
+  onRemoveMonitor,
+  onUpdateRules,
+}: RuleManagementTabProps) => {
+  const { monitor, settings, stats } = workspace;
+  const [keyword, setKeyword] = useState('');
+  const [template, setTemplate] = useState<string>();
+  const [scope, setScope] = useState<string>();
+  const [enabled, setEnabled] = useState<boolean>();
+  const [dimension, setDimension] = useState<string>();
+  const [selectedRowKeys, setSelectedRowKeys] = useState<Key[]>([]);
+
+  const records = useMemo(() => {
+    const normalizedKeyword = keyword.trim().toLowerCase();
+    return monitor.rules.filter((rule) => {
+      if (
+        normalizedKeyword &&
+        !`${rule.id} ${rule.name} ${rule.templateCode} ${rule.columnName || ''}`
+          .toLowerCase()
+          .includes(normalizedKeyword)
+      ) {
+        return false;
+      }
+      if (template && rule.templateCode !== template) return false;
+      if (scope && rule.scope !== scope) return false;
+      if (enabled !== undefined && rule.enabled !== enabled) return false;
+      if (dimension && rule.dimension !== dimension) return false;
+      return true;
+    });
+  }, [dimension, enabled, keyword, monitor.rules, scope, template]);
+
+  const templates = useMemo(
+    () =>
+      Array.from(
+        new Map(
+          monitor.rules.map((rule) => [
+            rule.templateCode,
+            { value: rule.templateCode, label: rule.templateCode },
+          ]),
+        ).values(),
+      ),
+    [monitor.rules],
+  );
+
+  const reset = () => {
+    setKeyword('');
+    setTemplate(undefined);
+    setScope(undefined);
+    setEnabled(undefined);
+    setDimension(undefined);
+  };
+
+  const updateSelected = async (nextEnabled: boolean) => {
+    if (!selectedRowKeys.length) return;
+    await onUpdateRules(
+      monitor.rules.map((rule) =>
+        selectedRowKeys.includes(rule.id)
+          ? { ...rule, enabled: nextEnabled }
+          : rule,
+      ),
+    );
+    setSelectedRowKeys([]);
+  };
+
+  const removeRule = (rule: RuleView) => {
+    if (monitor.rules.length <= 1) {
+      message.warning('质量监控至少需要保留一条规则');
+      return;
+    }
+    Modal.confirm({
+      title: '删除质量规则？',
+      content: `确认删除“${rule.name}”吗？历史执行结果仍会保留。`,
+      okButtonProps: { danger: true },
+      onOk: () => onUpdateRules(monitor.rules.filter((item) => item.id !== rule.id)),
+    });
+  };
+
+  const columns: TableColumnsType<RuleView> = [
+    {
+      title: 'ID/规则名称',
+      dataIndex: 'name',
+      minWidth: 300,
+      render: (_, rule) => (
+        <div className="min-w-0 py-1">
+          <div className="text-xs text-[#9aa3b2]">{rule.id}</div>
+          <div className="mt-0.5 truncate text-[13px] font-medium text-[#172033]">
+            {rule.name}
+          </div>
+        </div>
+      ),
+    },
+    {
+      title: '重要程度',
+      width: 110,
+      render: () => <span className="text-[#43506a]">弱规则</span>,
+    },
+    {
+      title: '关联范围',
+      width: 120,
+      render: (_, rule) => scopeLabel(rule),
+    },
+    {
+      title: '规则模板',
+      dataIndex: 'templateCode',
+      width: 180,
+      render: (value) => <span className="text-[#43506a]">{value}</span>,
+    },
+    {
+      title: '监控阈值',
+      width: 190,
+      render: (_, rule) => (
+        <div>
+          <div className="text-[#43506a]">{ruleParameter(rule)}</div>
+          <div className="mt-1 flex items-center gap-1.5 text-[11px]">
+            <span className="h-1.5 w-1.5 rounded-full bg-[#ff4d4f]" />
+            <span className="text-[#ff4d4f]">异常</span>
+            <span className="h-1.5 w-1.5 rounded-full bg-[#12a150]" />
+            <span className="text-[#12a150]">正常</span>
+          </div>
+        </div>
+      ),
+    },
+    { title: '维度', dataIndex: 'dimension', width: 100 },
+    {
+      title: '状态',
+      dataIndex: 'enabled',
+      width: 90,
+      render: (value) => (
+        <Tag
+          className="!m-0 !border-0"
+          color={value ? 'processing' : 'default'}
+        >
+          {value ? '启用' : '停用'}
+        </Tag>
+      ),
+    },
+    {
+      title: '操作',
+      fixed: 'right',
+      width: 180,
+      render: (_, rule) => (
+        <div className="flex items-center gap-3 whitespace-nowrap text-xs">
+          <button
+            type="button"
+            className="border-0 bg-transparent p-0 text-[#245bdb]"
+            onClick={onEditMonitor}
+          >
+            修改
+          </button>
+          <button
+            type="button"
+            className="border-0 bg-transparent p-0 text-[#245bdb]"
+            onClick={() => removeRule(rule)}
+          >
+            删除
+          </button>
+          <button
+            type="button"
+            className="border-0 bg-transparent p-0 text-[#245bdb]"
+            onClick={onOpenLog}
+          >
+            操作日志
+          </button>
+        </div>
+      ),
+    },
+  ];
+
+  const moreMenu: MenuProps = {
+    items: [
+      { key: 'refresh', label: '刷新数据' },
+      { key: 'edit', label: '编辑质量监控' },
+      { type: 'divider' },
+      { key: 'remove', label: '删除质量监控', danger: true },
+    ],
+    onClick: ({ key }) => {
+      if (key === 'refresh') onRefresh();
+      if (key === 'edit') onEditMonitor();
+      if (key === 'remove') onRemoveMonitor();
+    },
+  };
+
+  return (
+    <div className="flex min-h-0 flex-1 bg-white">
+      <aside className="w-[286px] shrink-0 border-r border-[#e5e7eb] bg-[#fbfcfe] px-5 py-5">
+        <div className="text-[14px] font-semibold text-[#172033]">规则管理</div>
+        <div className="mt-4 space-y-1 text-[13px]">
+          <div className="flex items-center justify-between rounded-md bg-[#f0f3f8] px-3 py-2 font-medium text-[#27344f]">
+            <span>全部规则</span>
+            <span className="rounded-full bg-white px-1.5 text-xs">{stats.ruleCount}</span>
+          </div>
+          <div className="flex items-center justify-between px-3 py-2 text-[#43506a]">
+            <span>已关联质量监控的规则</span>
+            <span>{stats.ruleCount}</span>
+          </div>
+          <div className="flex items-center justify-between px-3 py-2 text-[#43506a]">
+            <span>未关联质量监控的规则</span>
+            <span>0</span>
+          </div>
+        </div>
+
+        <div className="mt-7 flex items-center justify-between">
+          <div className="text-[14px] font-semibold text-[#172033]">
+            质量监控视角
+          </div>
+          <div className="flex items-center gap-2 text-[#667085]">
+            <Tooltip title="新建质量监控">
+              <Plus size={16} />
+            </Tooltip>
+            <RefreshCw size={14} className="cursor-pointer" onClick={onRefresh} />
+          </div>
+        </div>
+        <Input
+          variant="filled"
+          allowClear
+          value={keyword}
+          onChange={(event) => setKeyword(event.target.value)}
+          placeholder="请输入关键字搜索"
+          prefix={<Search size={14} className="text-[#98a2b3]" />}
+          className="mt-3"
+        />
+
+        <div className="mt-3 rounded-md border border-[#cfdaf8] bg-[#eef3ff] px-3 py-3">
+          <div className="text-xs text-[#7583a1]">ID: {monitor.id}</div>
+          <div className="mt-1 line-clamp-2 text-[13px] font-semibold leading-5 text-[#172033]">
+            {monitor.name}
+          </div>
+          <div className="mt-2 space-y-1 text-xs text-[#667085]">
+            <div>数据范围：{monitor.whereClause || '全表'}</div>
+            <div>触发方式：{RUN_MODE_LABEL[settings.runMode]}</div>
+            <div>
+              规则数：启用{stats.enabledRuleCount} / 总数{stats.ruleCount}
+            </div>
+            <div>配置来源：数据质量</div>
+          </div>
+        </div>
+      </aside>
+
+      <main className="min-w-0 flex-1 px-4 py-4">
+        <div className="flex flex-wrap items-center justify-between gap-3 border-b border-[#edf0f3] pb-3">
+          <div className="flex min-w-0 items-center gap-2">
+            <span className="truncate text-[14px] font-medium text-[#172033]">
+              {monitor.name}
+            </span>
+            <Button
+              size="small"
+              icon={<Play size={13} />}
+              loading={running}
+              onClick={onRun}
+            >
+              测试运行
+            </Button>
+            <Button
+              size="small"
+              icon={<Bell size={13} />}
+              onClick={() => message.info('告警策略可在编辑质量监控中配置')}
+            >
+              告警订阅
+            </Button>
+            <Dropdown menu={moreMenu} trigger={['click']}>
+              <Button size="small" icon={<MoreHorizontal size={14} />} />
+            </Dropdown>
+            {settings.runMode === 'MANUAL' ? (
+              <Tag color="orange" className="!m-0">
+                未开启调度
+              </Tag>
+            ) : null}
+          </div>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2 py-3">
+          <Button
+            type="primary"
+            icon={<Sparkles size={14} />}
+            onClick={onEditMonitor}
+          >
+            AI生成规则
+          </Button>
+          <Button onClick={onEditMonitor}>新建规则</Button>
+          <Input
+            value={keyword}
+            onChange={(event) => setKeyword(event.target.value)}
+            placeholder="名称  输入名称或ID搜索"
+            prefix={<Search size={14} className="text-[#98a2b3]" />}
+            className="w-[220px]"
+          />
+          <Select
+            allowClear
+            value={template}
+            placeholder="规则模板"
+            options={templates}
+            onChange={setTemplate}
+            className="w-[170px]"
+          />
+          <Select
+            allowClear
+            value={scope}
+            placeholder="关联范围"
+            options={[
+              { value: 'TABLE', label: '表级' },
+              { value: 'COLUMN', label: '字段级' },
+            ]}
+            onChange={setScope}
+            className="w-[140px]"
+          />
+          <Select
+            allowClear
+            value={enabled}
+            placeholder="启用状态"
+            options={[
+              { value: true, label: '启用' },
+              { value: false, label: '停用' },
+            ]}
+            onChange={setEnabled}
+            className="w-[130px]"
+          />
+          <Select
+            allowClear
+            value={dimension}
+            placeholder="质量维度"
+            options={DIMENSION_ORDER.map((value) => ({ value, label: value }))}
+            onChange={setDimension}
+            className="w-[130px]"
+          />
+          <Button type="text" icon={<RefreshCw size={13} />} onClick={reset}>
+            重置
+          </Button>
+        </div>
+
+        <Table<RuleView>
+          rowKey="id"
+          size="small"
+          loading={savingRules}
+          pagination={false}
+          scroll={{ x: 1280 }}
+          dataSource={records}
+          locale={{
+            emptyText: (
+              <Empty
+                image={Empty.PRESENTED_IMAGE_SIMPLE}
+                description="暂无符合条件的质量规则"
+              />
+            ),
+          }}
+          rowSelection={{
+            selectedRowKeys,
+            onChange: setSelectedRowKeys,
+          }}
+          columns={columns}
+        />
+
+        <div className="mt-3 flex flex-wrap items-center justify-between gap-3">
+          <div className="flex items-center gap-2">
+            <Button
+              disabled={!selectedRowKeys.length}
+              onClick={() => updateSelected(true)}
+            >
+              启用
+            </Button>
+            <Button
+              disabled={!selectedRowKeys.length}
+              onClick={() => updateSelected(false)}
+            >
+              停用
+            </Button>
+            <Button disabled={!selectedRowKeys.length}>关联质量监控</Button>
+            <Dropdown
+              menu={{ items: [{ key: 'log', label: '查看操作日志' }], onClick: onOpenLog }}
+            >
+              <Button disabled={!selectedRowKeys.length}>
+                更多操作 <ChevronDown size={12} />
+              </Button>
+            </Dropdown>
+          </div>
+          <div className="text-xs text-[#8b95a7]">共 {records.length} 条规则</div>
+        </div>
+      </main>
+    </div>
+  );
+};
+
+export default RuleManagementTab;

--- a/yak-ops-ui/src/pages/data-quality/monitor/detail/WorkspaceHeader.tsx
+++ b/yak-ops-ui/src/pages/data-quality/monitor/detail/WorkspaceHeader.tsx
@@ -1,0 +1,96 @@
+import { Button, Tabs } from 'antd';
+import { Database, ExternalLink } from 'lucide-react';
+import type { MonitorWorkspaceView } from '../../types';
+import type { WorkspaceTab } from './model';
+
+interface WorkspaceHeaderProps {
+  workspace?: MonitorWorkspaceView;
+  activeTab: WorkspaceTab;
+  onTabChange: (value: WorkspaceTab) => void;
+  onBack: () => void;
+}
+
+const WorkspaceHeader = ({
+  workspace,
+  activeTab,
+  onTabChange,
+  onBack,
+}: WorkspaceHeaderProps) => {
+  const monitor = workspace?.monitor;
+  const path = [
+    monitor?.dataSourceName,
+    monitor?.databaseName,
+    monitor?.schemaName,
+  ].filter(Boolean);
+
+  return (
+    <header className="shrink-0 border-b border-[#e5e7eb] bg-white">
+      <div className="flex min-h-[86px] items-center gap-4 px-6 py-3">
+        <div className="flex h-14 w-14 shrink-0 items-center justify-center rounded-md bg-[#eef3ff] text-[#3451d1]">
+          <Database size={25} strokeWidth={1.8} />
+        </div>
+
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+            <h1 className="m-0 truncate text-[18px] font-semibold leading-7 text-[#172033]">
+              {monitor?.tableName || '质量监控详情'}
+            </h1>
+            <Button
+              type="link"
+              size="small"
+              className="!h-6 !px-0 !text-xs"
+              onClick={onBack}
+            >
+              返回按表配置 <ExternalLink size={12} />
+            </Button>
+          </div>
+
+          <div className="mt-0.5 truncate text-xs text-[#8b95a7]">
+            {monitor?.description || '暂无数据表描述'}
+          </div>
+
+          <div className="mt-2 flex flex-wrap items-center gap-x-6 gap-y-1 text-xs text-[#667085]">
+            <span className="flex min-w-0 items-center gap-1.5">
+              <span>路径：</span>
+              {path.length ? (
+                path.map((item, index) => (
+                  <span key={`${item}-${index}`} className="flex items-center gap-1.5">
+                    {index > 0 ? <span className="text-[#c4c9d2]">›</span> : null}
+                    <span className="max-w-40 truncate text-[#43506a]">{item}</span>
+                  </span>
+                ))
+              ) : (
+                <span>--</span>
+              )}
+            </span>
+            <span>
+              表责任人：
+              <span className="ml-1 text-[#43506a]">{monitor?.owner || '--'}</span>
+            </span>
+            <span>
+              最近运行：
+              <span className="ml-1 text-[#43506a]">
+                {workspace?.stats.latestExecutionTime || monitor?.lastRunTime || '--'}
+              </span>
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <div className="px-4">
+        <Tabs
+          activeKey={activeTab}
+          onChange={(value) => onTabChange(value as WorkspaceTab)}
+          items={[
+            { key: 'rules', label: '规则管理' },
+            { key: 'monitors', label: '质量监控' },
+            { key: 'report', label: '质量报告' },
+          ]}
+          className="workspace-tabs"
+        />
+      </div>
+    </header>
+  );
+};
+
+export default WorkspaceHeader;

--- a/yak-ops-ui/src/pages/data-quality/monitor/detail/index.tsx
+++ b/yak-ops-ui/src/pages/data-quality/monitor/detail/index.tsx
@@ -1,73 +1,131 @@
 import { API_SUCCESS_CODE } from '@/services/http/response';
 import { BRAND_THEME } from '@/styles/brand';
 import { history, useParams } from '@umijs/max';
-import {
-  Button,
-  ConfigProvider,
-  Descriptions,
-  Empty,
-  Modal,
-  Pagination,
-  Spin,
-  Table,
-  Tag,
-  message,
-} from 'antd';
-import { ArrowLeft, Pencil, Play, RefreshCw, Trash2 } from 'lucide-react';
+import { ConfigProvider, Modal, Spin, message } from 'antd';
+import dayjs from 'dayjs';
 import { useCallback, useEffect, useState } from 'react';
-import ExecutionDetailDrawer from '../../components/ExecutionDetailDrawer';
-import { CheckResultTag, ExecutionStatusTag } from '../../components/QualityStatus';
-import { qualityExecutionApi, qualityMonitorApi } from '../../service';
-import type { ExecutionListItem, ExecutionPageView, MonitorView, RuleView } from '../../types';
+import {
+  qualityMonitorApi,
+  qualityWorkspaceApi,
+} from '../../service';
+import type {
+  MonitorReportView,
+  MonitorWorkspaceView,
+  OperationLogPageView,
+  RuleView,
+} from '../../types';
+import MonitorListTab from './MonitorListTab';
+import OperationLogDrawer from './OperationLogDrawer';
+import QualityReportTab from './QualityReportTab';
+import RuleManagementTab from './RuleManagementTab';
+import WorkspaceHeader from './WorkspaceHeader';
+import { toSavePayload, type WorkspaceTab } from './model';
 
-const unwrap = <T,>(response: { code: number; data: T; message?: string; msg?: string }) => {
+const unwrap = <T,>(response: {
+  code: number;
+  data: T;
+  message?: string;
+  msg?: string;
+}) => {
   if (response.code !== API_SUCCESS_CODE) {
     throw new Error(response.message || response.msg || '请求失败');
   }
   return response.data;
 };
 
+const EMPTY_OPERATION_LOG: OperationLogPageView = {
+  records: [],
+  total: 0,
+  current: 1,
+  pageSize: 10,
+};
+
 const MonitorDetailPage = () => {
   const params = useParams<{ id: string }>();
-  const [monitor, setMonitor] = useState<MonitorView>();
-  const [executions, setExecutions] = useState<ExecutionPageView>({ records: [], total: 0, current: 1, pageSize: 10 });
+  const [activeTab, setActiveTab] = useState<WorkspaceTab>('rules');
+  const [workspace, setWorkspace] = useState<MonitorWorkspaceView>();
+  const [report, setReport] = useState<MonitorReportView>();
+  const [reportDate, setReportDate] = useState(
+    dayjs().subtract(1, 'day').format('YYYY-MM-DD'),
+  );
+  const [operationLog, setOperationLog] = useState<OperationLogPageView>(
+    EMPTY_OPERATION_LOG,
+  );
   const [loading, setLoading] = useState(true);
+  const [reportLoading, setReportLoading] = useState(false);
+  const [logLoading, setLogLoading] = useState(false);
+  const [logOpen, setLogOpen] = useState(false);
   const [running, setRunning] = useState(false);
-  const [executionNo, setExecutionNo] = useState<string>();
+  const [savingRules, setSavingRules] = useState(false);
 
-  const load = useCallback(async (current = executions.current) => {
+  const loadWorkspace = useCallback(async () => {
     if (!params.id) return;
     setLoading(true);
     try {
-      const [monitorResponse, executionResponse] = await Promise.all([
-        qualityMonitorApi.detail(params.id),
-        qualityExecutionApi.page({ current, pageSize: executions.pageSize, monitorId: Number(params.id) }),
-      ]);
-      setMonitor(unwrap(monitorResponse));
-      setExecutions(unwrap(executionResponse));
+      setWorkspace(unwrap(await qualityWorkspaceApi.workspace(params.id)));
     } catch (error: any) {
-      message.error(error?.message || '质量监控加载失败');
+      message.error(error?.message || '质量监控工作台加载失败');
     } finally {
       setLoading(false);
     }
-  }, [executions.current, executions.pageSize, params.id]);
+  }, [params.id]);
 
-  useEffect(() => void load(1), []);
+  const loadReport = useCallback(
+    async (date: string) => {
+      if (!params.id) return;
+      setReportLoading(true);
+      try {
+        setReport(
+          unwrap(await qualityWorkspaceApi.report(params.id, { date })),
+        );
+      } catch (error: any) {
+        message.error(error?.message || '质量报告加载失败');
+      } finally {
+        setReportLoading(false);
+      }
+    },
+    [params.id],
+  );
+
+  const loadOperationLog = useCallback(
+    async (current = operationLog.current, pageSize = operationLog.pageSize) => {
+      if (!params.id) return;
+      setLogLoading(true);
+      try {
+        setOperationLog(
+          unwrap(
+            await qualityWorkspaceApi.operationLogs(params.id, {
+              current,
+              pageSize,
+            }),
+          ),
+        );
+      } catch (error: any) {
+        message.error(error?.message || '操作日志加载失败');
+      } finally {
+        setLogLoading(false);
+      }
+    },
+    [operationLog.current, operationLog.pageSize, params.id],
+  );
+
   useEffect(() => {
-    const active = executions.records.some((item) => item.executionStatus === 'WAITING' || item.executionStatus === 'RUNNING');
-    if (!active) return;
-    const timer = window.setInterval(() => load(executions.current), 2500);
-    return () => window.clearInterval(timer);
-  }, [executions.current, executions.records, load]);
+    void loadWorkspace();
+  }, [loadWorkspace]);
+
+  useEffect(() => {
+    if (activeTab === 'report') {
+      void loadReport(reportDate);
+    }
+  }, [activeTab, loadReport, reportDate]);
 
   const run = async () => {
     if (!params.id) return;
     setRunning(true);
     try {
       const result = unwrap(await qualityMonitorApi.run(params.id));
-      message.success('质量检查已提交');
-      setExecutionNo(result.executionNo);
-      load(1);
+      message.success(`质量检查已提交：${result.executionNo}`);
+      window.setTimeout(() => void loadWorkspace(), 1800);
     } catch (error: any) {
       message.error(error?.message || '运行失败');
     } finally {
@@ -75,7 +133,31 @@ const MonitorDetailPage = () => {
     }
   };
 
-  const remove = () => {
+  const updateRules = async (rules: RuleView[]) => {
+    if (!workspace || !params.id) return;
+    setSavingRules(true);
+    try {
+      unwrap(
+        await qualityMonitorApi.update(
+          params.id,
+          toSavePayload(workspace.monitor, workspace.settings, rules),
+        ),
+      );
+      message.success('质量规则已更新');
+      await loadWorkspace();
+      if (activeTab === 'report') {
+        await loadReport(reportDate);
+      }
+    } catch (error: any) {
+      message.error(error?.message || '质量规则更新失败');
+      throw error;
+    } finally {
+      setSavingRules(false);
+    }
+  };
+
+  const removeMonitor = () => {
+    if (!params.id) return;
     Modal.confirm({
       title: '删除质量监控？',
       content: '删除后将保留历史执行记录，但不再允许继续运行。',
@@ -92,108 +174,75 @@ const MonitorDetailPage = () => {
     });
   };
 
+  const openLog = () => {
+    setLogOpen(true);
+    void loadOperationLog(1, operationLog.pageSize);
+  };
+
   return (
     <ConfigProvider theme={BRAND_THEME}>
-      <div className="min-h-[calc(100vh-64px)] bg-white">
-        <div className="flex h-14 items-center justify-between border-b border-[#e8e9ec] px-5">
-          <div className="flex items-center gap-3">
-            <Button type="text" icon={<ArrowLeft size={17} />} onClick={() => history.push('/data-quality/table-config')} />
-            <h1 className="m-0 text-[20px] font-semibold text-[#161823]">质量监控详情</h1>
-          </div>
-          <div className="flex items-center gap-2">
-            <Button icon={<RefreshCw size={14} />} onClick={() => load()}>刷新</Button>
-            <Button icon={<Pencil size={14} />} onClick={() => history.push(`/data-quality/monitor/${params.id}/edit`)}>编辑</Button>
-            <Button danger icon={<Trash2 size={14} />} onClick={remove}>删除</Button>
-            <Button type="primary" loading={running} icon={<Play size={14} />} onClick={run}>手动运行</Button>
-          </div>
-        </div>
+      <div className="flex h-[calc(100vh-64px)] min-h-[620px] flex-col overflow-hidden bg-white">
+        <WorkspaceHeader
+          workspace={workspace}
+          activeTab={activeTab}
+          onTabChange={setActiveTab}
+          onBack={() => history.push('/data-quality/table-config')}
+        />
 
-        <Spin spinning={loading}>
-          <div className="mx-auto max-w-[1500px] px-6 py-5">
-            {monitor && (
-              <>
-                <Descriptions bordered size="small" column={3}>
-                  <Descriptions.Item label="监控名称">{monitor.name}</Descriptions.Item>
-                  <Descriptions.Item label="监控对象">
-                    {[monitor.databaseName, monitor.schemaName, monitor.tableName].filter(Boolean).join('.')}
-                  </Descriptions.Item>
-                  <Descriptions.Item label="最近结果"><CheckResultTag value={monitor.lastResult} /></Descriptions.Item>
-                  <Descriptions.Item label="数据源">{monitor.dataSourceName}</Descriptions.Item>
-                  <Descriptions.Item label="负责人">{monitor.owner}</Descriptions.Item>
-                  <Descriptions.Item label="启用状态"><Tag color={monitor.enabled ? 'processing' : undefined}>{monitor.enabled ? '启用' : '停用'}</Tag></Descriptions.Item>
-                  <Descriptions.Item label="数据范围" span={3}>{monitor.whereClause || '全表'}</Descriptions.Item>
-                  <Descriptions.Item label="描述" span={3}>{monitor.description || '--'}</Descriptions.Item>
-                </Descriptions>
-
-                <section className="mt-6">
-                  <h2 className="mb-3 text-base font-semibold text-[#161823]">质量规则</h2>
-                  <Table<RuleView>
-                    rowKey="id"
-                    size="small"
-                    pagination={false}
-                    dataSource={monitor.rules}
-                    columns={[
-                      { title: '规则名称', dataIndex: 'name' },
-                      { title: '质量维度', dataIndex: 'dimension', width: 110 },
-                      { title: '范围', dataIndex: 'scope', width: 90, render: (v) => (v === 'TABLE' ? '表级' : '字段级') },
-                      { title: '字段', dataIndex: 'columnName', width: 150, render: (v) => v || '--' },
-                      {
-                        title: '规则参数',
-                        width: 260,
-                        render: (_, rule) => {
-                          if (rule.ruleType === 'COLUMN_RANGE') return `${rule.threshold} ~ ${rule.thresholdEnd}`;
-                          if (rule.ruleType === 'COLUMN_ENUM') return (rule.enumValues || []).join(', ');
-                          if (rule.ruleType === 'CUSTOM_SQL') return '自定义 SQL';
-                          return `${rule.operator} ${rule.threshold}`;
-                        },
-                      },
-                      { title: '状态', dataIndex: 'enabled', width: 90, render: (v) => (v ? '启用' : '停用') },
-                    ]}
-                  />
-                </section>
-              </>
-            )}
-
-            <section className="mt-6">
-              <div className="mb-3 flex items-center justify-between">
-                <h2 className="m-0 text-base font-semibold text-[#161823]">运行记录</h2>
-                <Button type="link" onClick={() => history.push(`/data-quality/execution?monitorId=${params.id}`)}>查看全部</Button>
-              </div>
-              <Table<ExecutionListItem>
-                rowKey="executionNo"
-                size="small"
-                pagination={false}
-                dataSource={executions.records}
-                locale={{ emptyText: <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="暂无运行记录" /> }}
-                onRow={(record) => ({ onClick: () => setExecutionNo(record.executionNo), className: 'cursor-pointer' })}
-                columns={[
-                  { title: '执行编号', dataIndex: 'executionNo', width: 220 },
-                  { title: '执行状态', dataIndex: 'executionStatus', width: 110, render: (v) => <ExecutionStatusTag value={v} /> },
-                  { title: '检查结果', dataIndex: 'checkResult', width: 110, render: (v) => <CheckResultTag value={v} /> },
-                  { title: '规则统计', width: 210, render: (_, r) => `${r.passedRules} 通过 / ${r.failedRules} 未通过 / ${r.errorRules} 异常` },
-                  { title: '触发人', dataIndex: 'operator', width: 130 },
-                  { title: '开始时间', dataIndex: 'startedAt', width: 180, render: (v) => v || '--' },
-                  { title: '耗时', dataIndex: 'durationMs', width: 100, render: (v) => (v === undefined ? '--' : `${v} ms`) },
-                ]}
-              />
-              <div className="mt-3 flex justify-end">
-                <Pagination
-                  size="small"
-                  current={executions.current}
-                  pageSize={executions.pageSize}
-                  total={executions.total}
-                  showSizeChanger
-                  onChange={(current, pageSize) => {
-                    setExecutions((value) => ({ ...value, current, pageSize }));
-                    load(current);
-                  }}
+        <Spin spinning={loading} wrapperClassName="min-h-0 flex-1 overflow-hidden">
+          {workspace ? (
+            <div className="flex h-full min-h-0 flex-col">
+              {activeTab === 'rules' ? (
+                <RuleManagementTab
+                  workspace={workspace}
+                  running={running}
+                  savingRules={savingRules}
+                  onRun={run}
+                  onEditMonitor={() =>
+                    history.push(`/data-quality/monitor/${params.id}/edit`)
+                  }
+                  onOpenLog={openLog}
+                  onRefresh={loadWorkspace}
+                  onRemoveMonitor={removeMonitor}
+                  onUpdateRules={updateRules}
                 />
-              </div>
-            </section>
-          </div>
+              ) : null}
+
+              {activeTab === 'monitors' ? (
+                <MonitorListTab
+                  workspace={workspace}
+                  running={running}
+                  onRun={run}
+                  onEdit={() =>
+                    history.push(`/data-quality/monitor/${params.id}/edit`)
+                  }
+                  onRefresh={loadWorkspace}
+                  onRemove={removeMonitor}
+                  onOpenLog={openLog}
+                />
+              ) : null}
+
+              {activeTab === 'report' ? (
+                <QualityReportTab
+                  report={report}
+                  loading={reportLoading}
+                  reportDate={reportDate}
+                  onDateChange={setReportDate}
+                />
+              ) : null}
+            </div>
+          ) : null}
         </Spin>
 
-        <ExecutionDetailDrawer executionNo={executionNo} open={Boolean(executionNo)} onClose={() => setExecutionNo(undefined)} />
+        <OperationLogDrawer
+          open={logOpen}
+          loading={logLoading}
+          data={operationLog}
+          onClose={() => setLogOpen(false)}
+          onPageChange={(current, pageSize) =>
+            void loadOperationLog(current, pageSize)
+          }
+        />
       </div>
     </ConfigProvider>
   );

--- a/yak-ops-ui/src/pages/data-quality/monitor/detail/model.ts
+++ b/yak-ops-ui/src/pages/data-quality/monitor/detail/model.ts
@@ -1,0 +1,129 @@
+import type {
+  AlertLevel,
+  CheckResult,
+  MonitorSettingsPayload,
+  MonitorSettingsView,
+  MonitorView,
+  NotifyChannel,
+  RuleFailureAction,
+  RuleView,
+  RunMode,
+  SaveMonitorPayload,
+  SaveRulePayload,
+  ScheduleFrequency,
+  ScheduleWeekday,
+} from '../../types';
+
+export type WorkspaceTab = 'rules' | 'monitors' | 'report';
+
+export const DIMENSION_ORDER = [
+  '完整性',
+  '准确性',
+  '一致性',
+  '唯一性',
+  '时效性',
+  '有效性',
+];
+
+export const CHECK_RESULT_LABEL: Record<CheckResult, string> = {
+  PASSED: '通过',
+  NOT_PASSED: '未通过',
+  ERROR: '异常',
+  RUNNING: '运行中',
+  NOT_RUN: '未运行',
+};
+
+export const RUN_MODE_LABEL: Record<RunMode, string> = {
+  MANUAL: '手动触发',
+  SCHEDULE: '生产调度触发',
+};
+
+export const ACTION_TYPE_LABEL: Record<string, string> = {
+  CREATE_MONITOR: '创建监控',
+  UPDATE_MONITOR: '更新监控',
+  SAVE_RULE: '保存规则',
+  RUN_MONITOR: '运行监控',
+};
+
+export const objectName = (monitor?: MonitorView) =>
+  [monitor?.databaseName, monitor?.schemaName, monitor?.tableName]
+    .filter(Boolean)
+    .join('.');
+
+export const scopeLabel = (rule: RuleView) =>
+  rule.scope === 'TABLE' ? '表级' : rule.columnName || '字段级';
+
+export const ruleParameter = (rule: RuleView) => {
+  if (rule.ruleType === 'COLUMN_RANGE') {
+    return `${rule.threshold ?? '--'} ~ ${rule.thresholdEnd ?? '--'}`;
+  }
+  if (rule.ruleType === 'COLUMN_ENUM') {
+    return (rule.enumValues || []).join(', ') || '--';
+  }
+  if (rule.ruleType === 'CUSTOM_SQL') {
+    return '自定义 SQL';
+  }
+  return `${rule.operator || '='} ${rule.threshold ?? '--'}`;
+};
+
+const toRulePayload = (rule: RuleView): SaveRulePayload => ({
+  templateId: rule.templateId,
+  name: rule.name,
+  columnName: rule.columnName,
+  operator: rule.operator,
+  threshold: rule.threshold,
+  thresholdEnd: rule.thresholdEnd,
+  enumValues: rule.enumValues,
+  customSql: rule.customSql,
+  enabled: rule.enabled,
+});
+
+const toSettingsPayload = (
+  settings: MonitorSettingsView,
+): MonitorSettingsPayload => ({
+  runMode: settings.runMode,
+  scheduleFrequency: settings.scheduleFrequency,
+  scheduleTime: settings.scheduleTime,
+  scheduleWeekday: settings.scheduleWeekday,
+  cronExpression: settings.cronExpression,
+  ruleFailureAction: settings.ruleFailureAction,
+  notifyEnabled: settings.notifyEnabled,
+  notifyChannel: settings.notifyChannel,
+  notifyTarget: settings.notifyTarget,
+  alertLevel: settings.alertLevel,
+});
+
+export const toSavePayload = (
+  monitor: MonitorView,
+  settings: MonitorSettingsView,
+  rules: RuleView[],
+): SaveMonitorPayload => ({
+  name: monitor.name,
+  description: monitor.description,
+  dataSourceId: monitor.dataSourceId,
+  dataSourceName: monitor.dataSourceName,
+  databaseName: monitor.databaseName,
+  schemaName: monitor.schemaName,
+  tableName: monitor.tableName,
+  whereClause: monitor.whereClause,
+  owner: monitor.owner,
+  enabled: monitor.enabled,
+  settings: toSettingsPayload(settings),
+  rules: rules.map(toRulePayload),
+});
+
+export const defaultsForSettings = (): MonitorSettingsView => ({
+  runMode: 'MANUAL' as RunMode,
+  ruleFailureAction: 'CONTINUE' as RuleFailureAction,
+  notifyEnabled: false,
+  notifyChannel: 'MESSAGE' as NotifyChannel,
+  alertLevel: 'WARNING' as AlertLevel,
+});
+
+export type {
+  AlertLevel,
+  NotifyChannel,
+  RuleFailureAction,
+  ScheduleFrequency,
+  ScheduleWeekday,
+};

--- a/yak-ops-ui/src/pages/data-quality/service.ts
+++ b/yak-ops-ui/src/pages/data-quality/service.ts
@@ -4,8 +4,11 @@ import type {
   ExecutionPageView,
   ExecutionView,
   MonitorPageView,
+  MonitorReportView,
   MonitorSettingsView,
   MonitorView,
+  MonitorWorkspaceView,
+  OperationLogPageView,
   RegisterTablesPayload,
   RegisterTablesView,
   RunView,
@@ -77,6 +80,27 @@ export const qualityMonitorApi = {
     HttpUtils.delete<boolean>(`${PREFIX}/monitor/${id}`),
   run: (id: number | string): Promise<CommonApiResponse<RunView>> =>
     HttpUtils.post<RunView>(`${PREFIX}/monitor/${id}/run`, {}),
+};
+
+export const qualityWorkspaceApi = {
+  workspace: (
+    id: number | string,
+  ): Promise<CommonApiResponse<MonitorWorkspaceView>> =>
+    HttpUtils.get<MonitorWorkspaceView>(`${PREFIX}/monitor/${id}/workspace`),
+  report: (
+    id: number | string,
+    params: { date?: string } = {},
+  ): Promise<CommonApiResponse<MonitorReportView>> =>
+    HttpUtils.get<MonitorReportView>(
+      `${PREFIX}/monitor/${id}/report${queryString(params)}`,
+    ),
+  operationLogs: (
+    id: number | string,
+    params: { current?: number; pageSize?: number } = {},
+  ): Promise<CommonApiResponse<OperationLogPageView>> =>
+    HttpUtils.get<OperationLogPageView>(
+      `${PREFIX}/monitor/${id}/operation-log${queryString(params)}`,
+    ),
 };
 
 export const qualityExecutionApi = {

--- a/yak-ops-ui/src/pages/data-quality/types.ts
+++ b/yak-ops-ui/src/pages/data-quality/types.ts
@@ -256,6 +256,80 @@ export interface ExecutionPageView {
   pageSize: number;
 }
 
+export interface WorkspaceStats {
+  ruleCount: number;
+  enabledRuleCount: number;
+  executionCount: number;
+  issueExecutionCount: number;
+  latestExecutionTime?: string;
+}
+
+export interface MonitorWorkspaceView {
+  monitor: MonitorView;
+  settings: MonitorSettingsView;
+  stats: WorkspaceStats;
+}
+
+export interface ReportOverview {
+  totalRules: number;
+  enabledRules: number;
+  executedRules: number;
+  issueRules: number;
+  errorRules: number;
+  passRate: number;
+}
+
+export interface DimensionReport {
+  dimension: string;
+  total: number;
+  passed: number;
+  notPassed: number;
+  errors: number;
+  passRate: number;
+}
+
+export interface TrendPoint {
+  date: string;
+  dimension: string;
+  total: number;
+  passed: number;
+  issues: number;
+  passRate: number;
+}
+
+export interface ColumnReport {
+  columnName: string;
+  dimension: string;
+  total: number;
+  passed: number;
+  issues: number;
+  passRate: number;
+}
+
+export interface MonitorReportView {
+  reportDate: string;
+  trendStartDate: string;
+  overview: ReportOverview;
+  dimensions: DimensionReport[];
+  trend: TrendPoint[];
+  columns: ColumnReport[];
+}
+
+export interface OperationLogItem {
+  id: string;
+  operator: string;
+  operationTime: string;
+  actionType: string;
+  content: string;
+}
+
+export interface OperationLogPageView {
+  records: OperationLogItem[];
+  total: number;
+  current: number;
+  pageSize: number;
+}
+
 export interface CatalogTable {
   database?: string;
   schema?: string;


### PR DESCRIPTION
## 背景

当前质量监控详情页采用“基础信息 + 规则表格 + 运行记录”的普通详情布局，与参考页面中围绕数据表展开的规则管理、质量监控和质量报告工作台差异较大。

本 PR 参考提供的页面结构，对质量监控详情页进行整体重构，并补充质量报告聚合和操作日志查询能力。

## 前端调整

### 数据表工作台头部

- 以数据表作为页面主对象，展示表名、描述、数据路径、责任人和最近运行时间
- 顶部增加三个工作视角：
  - 规则管理
  - 质量监控
  - 质量报告
- 保留返回按表配置、编辑、删除、测试运行和刷新等既有能力

### 规则管理

- 增加左侧规则分类与质量监控视角栏
- 展示全部规则、已关联规则和未关联规则数量
- 增加监控摘要卡片，展示数据范围、触发方式和启用规则数量
- 复刻规则筛选区和规则列表布局
- 支持规则关键字、模板、关联范围、启用状态和质量维度筛选
- 支持批量启用、批量停用、单条删除和操作日志查看
- 规则变更继续复用现有质量监控更新接口，并保留运行设置和问题处理策略

### 质量监控

- 复刻质量监控列表视角
- 展示监控名称、触发方式、启用规则数、责任人、更新时间和状态
- 保留编辑、测试运行、删除和操作日志入口

### 质量报告

- 支持昨日、前日和指定日期切换
- 增加质量维度通过率环图
- 增加总规则数、问题规则数、未通过规则数和执行异常规则数卡片
- 增加质量维度筛选
- 增加各维度趋势分析和轻量趋势折线
- 增加字段质量维度分析
- 无执行数据时展示完整空状态，不使用伪造指标

### 操作日志

- 增加右侧操作日志抽屉
- 展示操作人、操作时间、操作类型和操作内容
- 支持分页和每页数量切换

## 后端调整

新增质量监控工作台只读接口：

```text
GET /api/v1/data-quality/monitor/{id}/workspace
GET /api/v1/data-quality/monitor/{id}/report?date=YYYY-MM-DD
GET /api/v1/data-quality/monitor/{id}/operation-log
```

### 工作台摘要

聚合现有质量监控、运行设置、规则数、启用规则数、执行次数、问题执行次数和最近执行时间。

### 质量报告

基于现有 `yak_quality_execution`、`yak_quality_rule_execution` 和 `yak_quality_rule` 实时聚合：

- 指定日期质量概览
- 各质量维度通过率
- 最近七日维度趋势
- 字段级质量统计

### 操作日志

本阶段不新建审计表，基于已有监控、规则和执行记录生成可读操作日志，包括创建监控、更新监控、保存规则和触发检查。

## 数据库影响

- 无新增表
- 无 Flyway 迁移
- 不修改现有质量执行和监控持久化结构

## 验证

- [x] TS/TSX 已完成 TypeScript 解析与转译检查
- [x] 前端组件使用本地类型桩完成类型级检查
- [x] 新增 Java 源码使用本地依赖桩完成语法和内部接口编译检查
- [x] 规则批量启停和删除保留现有监控设置后再提交
- [x] 报告数据来自真实执行结果聚合，无数据时返回零值和空集合
- [ ] 待完整项目环境执行 Maven 全量测试
- [ ] 待连接实际 MySQL 执行聚合 SQL 验证
- [ ] 待前端开发环境完成浏览器联调和最终截图确认

## 影响范围

本 PR 主要影响质量监控详情页及其新增只读聚合接口，不改变新建质量监控、调度执行、告警和现有运行记录接口。