### PR TITLE
style(data-quality): unify table presentation

### DIFF
--- a/yak-ops-ui/src/pages/data-quality/components/ExecutionDetailDrawer.tsx
+++ b/yak-ops-ui/src/pages/data-quality/components/ExecutionDetailDrawer.tsx
@@ -1,9 +1,18 @@
 import { API_SUCCESS_CODE } from '@/services/http/response';
-import { Descriptions, Drawer, Empty, Spin, Table, Typography, message } from 'antd';
+import {
+  Descriptions,
+  Drawer,
+  Empty,
+  Spin,
+  Table,
+  Typography,
+  message,
+} from 'antd';
 import { useEffect, useState } from 'react';
 import { qualityExecutionApi } from '../service';
 import type { ExecutionView, RuleExecutionView } from '../types';
 import { CheckResultTag, ExecutionStatusTag } from './QualityStatus';
+import { dataQualityTableClassName } from './tableStyle';
 
 interface Props {
   executionNo?: string;
@@ -53,7 +62,8 @@ const ExecutionDetailDrawer = ({ executionNo, open, onClose }: Props) => {
                 <CheckResultTag value={detail.checkResult} />
               </Descriptions.Item>
               <Descriptions.Item label="规则统计">
-                {detail.passedRules} 通过 / {detail.failedRules} 未通过 / {detail.errorRules} 异常
+                {detail.passedRules} 通过 / {detail.failedRules} 未通过 /{' '}
+                {detail.errorRules} 异常
               </Descriptions.Item>
               <Descriptions.Item label="执行耗时">
                 {detail.durationMs === undefined ? '--' : `${detail.durationMs} ms`}
@@ -65,28 +75,73 @@ const ExecutionDetailDrawer = ({ executionNo, open, onClose }: Props) => {
             <Table<RuleExecutionView>
               rowKey="id"
               size="small"
+              bordered
               pagination={false}
+              className={dataQualityTableClassName()}
               dataSource={detail.rules}
               columns={[
-                { title: '规则名称', dataIndex: 'ruleName', width: 180 },
-                { title: '字段', dataIndex: 'columnName', width: 130, render: (v) => v || '--' },
                 {
-                  title: '结果',
+                  title: '规则名称 / 模板',
+                  dataIndex: 'ruleName',
+                  width: 220,
+                  render: (_, record) => (
+                    <div className="min-w-0 py-0.5">
+                      <div className="truncate font-medium text-[#172033]">
+                        {record.ruleName}
+                      </div>
+                      <div className="mt-1 truncate text-[11px] text-[#98a2b3]">
+                        {record.templateCode}
+                      </div>
+                    </div>
+                  ),
+                },
+                {
+                  title: '检查字段',
+                  dataIndex: 'columnName',
+                  width: 130,
+                  render: (value) => value || '表级规则',
+                },
+                {
+                  title: '检查结果',
                   dataIndex: 'checkResult',
-                  width: 100,
+                  width: 110,
                   render: (value) => <CheckResultTag value={value} />,
                 },
-                { title: '实际值', dataIndex: 'metricValue', width: 110, render: (v) => v || '--' },
-                { title: '期望值', dataIndex: 'expectedValue', width: 180, render: (v) => v || '--' },
-                { title: '耗时', dataIndex: 'durationMs', width: 90, render: (v) => `${v ?? 0} ms` },
+                {
+                  title: '实际值 / 期望值',
+                  width: 210,
+                  render: (_, record) => (
+                    <div className="space-y-1 text-xs">
+                      <div>
+                        <span className="text-[#98a2b3]">实际：</span>
+                        <span className="text-[#344054]">{record.metricValue || '--'}</span>
+                      </div>
+                      <div>
+                        <span className="text-[#98a2b3]">期望：</span>
+                        <span className="text-[#344054]">{record.expectedValue || '--'}</span>
+                      </div>
+                    </div>
+                  ),
+                },
+                {
+                  title: '耗时',
+                  dataIndex: 'durationMs',
+                  width: 90,
+                  render: (value) => `${value ?? 0} ms`,
+                },
               ]}
               expandable={{
                 expandedRowRender: (record) => (
                   <div className="space-y-2 px-2 py-1">
                     {record.errorMessage && (
-                      <Typography.Text type="danger">{record.errorMessage}</Typography.Text>
+                      <Typography.Text type="danger">
+                        {record.errorMessage}
+                      </Typography.Text>
                     )}
-                    <Typography.Paragraph copyable className="!mb-0 whitespace-pre-wrap text-xs">
+                    <Typography.Paragraph
+                      copyable
+                      className="!mb-0 whitespace-pre-wrap text-xs"
+                    >
                       {record.executedSql || '未生成执行 SQL'}
                     </Typography.Paragraph>
                   </div>

--- a/yak-ops-ui/src/pages/data-quality/components/tableStyle.test.ts
+++ b/yak-ops-ui/src/pages/data-quality/components/tableStyle.test.ts
@@ -1,0 +1,22 @@
+import {
+  DATA_QUALITY_TABLE_CLASS_NAME,
+  dataQualityTableClassName,
+} from './tableStyle';
+
+describe('data-quality table style', () => {
+  it('contains the shared table selectors', () => {
+    expect(DATA_QUALITY_TABLE_CLASS_NAME).toContain(
+      '[&_.ant-table-thead>tr>th]:!bg-[#f8f9fb]',
+    );
+    expect(DATA_QUALITY_TABLE_CLASS_NAME).toContain(
+      '[&_.ant-table-tbody>tr:hover>td]:!bg-[#fafbfc]',
+    );
+    expect(DATA_QUALITY_TABLE_CLASS_NAME).toContain(
+      '[&_.ant-table-cell-fix-right]:!bg-white',
+    );
+  });
+
+  it('merges page-specific class names', () => {
+    expect(dataQualityTableClassName('mt-3')).toContain('mt-3');
+  });
+});

--- a/yak-ops-ui/src/pages/data-quality/components/tableStyle.ts
+++ b/yak-ops-ui/src/pages/data-quality/components/tableStyle.ts
@@ -1,0 +1,40 @@
+export const DATA_QUALITY_TABLE_CLASS_NAME = [
+  // 表格整体
+  '[&_.ant-table]:!text-[13px]',
+  '[&_.ant-table-container]:!overflow-hidden',
+  '[&_.ant-table-container]:!rounded-xl',
+  '[&_.ant-table-container]:!border-[#eaecf0]',
+  '[&_.ant-table-cell]:!align-middle',
+
+  // 表头
+  '[&_.ant-table-thead>tr>th]:!h-10',
+  '[&_.ant-table-thead>tr>th]:!bg-[#f8f9fb]',
+  '[&_.ant-table-thead>tr>th]:!px-4',
+  '[&_.ant-table-thead>tr>th]:!py-2',
+  '[&_.ant-table-thead>tr>th]:!text-[12px]',
+  '[&_.ant-table-thead>tr>th]:!font-medium',
+  '[&_.ant-table-thead>tr>th]:!text-[#667085]',
+  '[&_.ant-table-thead>tr>th]:!border-[#eaecf0]',
+
+  // 表体
+  '[&_.ant-table-tbody>tr>td]:!px-4',
+  '[&_.ant-table-tbody>tr>td]:!py-2.5',
+  '[&_.ant-table-tbody>tr>td]:!border-[#f0f2f5]',
+  '[&_.ant-table-tbody>tr>td]:!text-[#667085]',
+  '[&_.ant-table-tbody>tr:hover>td]:!bg-[#fafbfc]',
+
+  // 固定操作列
+  '[&_.ant-table-cell-fix-right]:!bg-white',
+  '[&_.ant-table-tbody>tr:hover_.ant-table-cell-fix-right]:!bg-[#fafbfc]',
+
+  // 复选框
+  '[&_.ant-checkbox-inner]:!h-4',
+  '[&_.ant-checkbox-inner]:!w-4',
+
+  // 展开行和空状态
+  '[&_.ant-table-expanded-row>td]:!bg-[#fafbfc]',
+  '[&_.ant-table-placeholder>td]:!h-[240px]',
+].join(' ');
+
+export const dataQualityTableClassName = (...classNames: Array<string | undefined | false>) =>
+  [DATA_QUALITY_TABLE_CLASS_NAME, ...classNames].filter(Boolean).join(' ');

--- a/yak-ops-ui/src/pages/data-quality/execution/index.tsx
+++ b/yak-ops-ui/src/pages/data-quality/execution/index.tsx
@@ -1,44 +1,95 @@
 import { API_SUCCESS_CODE } from '@/services/http/response';
 import { BRAND_THEME } from '@/styles/brand';
 import { useLocation } from '@umijs/max';
-import { Button, ConfigProvider, Empty, Input, Pagination, Select, Spin, Table, message } from 'antd';
+import {
+  Button,
+  ConfigProvider,
+  Empty,
+  Input,
+  Pagination,
+  Select,
+  Spin,
+  Table,
+  message,
+} from 'antd';
 import { RefreshCw, Search } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import ExecutionDetailDrawer from '../components/ExecutionDetailDrawer';
 import { CheckResultTag, ExecutionStatusTag } from '../components/QualityStatus';
+import { dataQualityTableClassName } from '../components/tableStyle';
 import { qualityExecutionApi } from '../service';
-import type { CheckResult, ExecutionListItem, ExecutionPageView, ExecutionStatus } from '../types';
+import type {
+  CheckResult,
+  ExecutionListItem,
+  ExecutionPageView,
+  ExecutionStatus,
+} from '../types';
 
-const unwrap = <T,>(response: { code: number; data: T; message?: string; msg?: string }) => {
-  if (response.code !== API_SUCCESS_CODE) throw new Error(response.message || response.msg || '请求失败');
+const unwrap = <T,>(response: {
+  code: number;
+  data: T;
+  message?: string;
+  msg?: string;
+}) => {
+  if (response.code !== API_SUCCESS_CODE) {
+    throw new Error(response.message || response.msg || '请求失败');
+  }
   return response.data;
 };
 
 const ExecutionPage = () => {
   const location = useLocation();
-  const query = useMemo(() => new URLSearchParams(location.search), [location.search]);
+  const query = useMemo(
+    () => new URLSearchParams(location.search),
+    [location.search],
+  );
   const monitorId = Number(query.get('monitorId')) || undefined;
-  const [data, setData] = useState<ExecutionPageView>({ records: [], total: 0, current: 1, pageSize: 20 });
+  const [data, setData] = useState<ExecutionPageView>({
+    records: [],
+    total: 0,
+    current: 1,
+    pageSize: 20,
+  });
   const [keyword, setKeyword] = useState('');
   const [status, setStatus] = useState<ExecutionStatus>();
   const [result, setResult] = useState<CheckResult>();
   const [loading, setLoading] = useState(false);
   const [executionNo, setExecutionNo] = useState<string>();
 
-  const load = useCallback(async (current = data.current, pageSize = data.pageSize) => {
-    setLoading(true);
-    try {
-      setData(unwrap(await qualityExecutionApi.page({ current, pageSize, keyword, monitorId, executionStatus: status, checkResult: result })));
-    } catch (error: any) {
-      message.error(error?.message || '执行记录加载失败');
-    } finally {
-      setLoading(false);
-    }
-  }, [data.current, data.pageSize, keyword, monitorId, result, status]);
+  const load = useCallback(
+    async (current = data.current, pageSize = data.pageSize) => {
+      setLoading(true);
+      try {
+        setData(
+          unwrap(
+            await qualityExecutionApi.page({
+              current,
+              pageSize,
+              keyword,
+              monitorId,
+              executionStatus: status,
+              checkResult: result,
+            }),
+          ),
+        );
+      } catch (error: any) {
+        message.error(error?.message || '执行记录加载失败');
+      } finally {
+        setLoading(false);
+      }
+    },
+    [data.current, data.pageSize, keyword, monitorId, result, status],
+  );
 
   useEffect(() => void load(1), [status, result, monitorId]);
   useEffect(() => {
-    if (!data.records.some((item) => ['WAITING', 'RUNNING'].includes(item.executionStatus))) return;
+    if (
+      !data.records.some((item) =>
+        ['WAITING', 'RUNNING'].includes(item.executionStatus),
+      )
+    ) {
+      return;
+    }
     const timer = window.setInterval(() => load(data.current), 3000);
     return () => window.clearInterval(timer);
   }, [data.current, data.records, load]);
@@ -47,8 +98,12 @@ const ExecutionPage = () => {
     <ConfigProvider theme={BRAND_THEME}>
       <div className="flex h-[calc(100vh-64px)] flex-col overflow-hidden bg-white">
         <div className="flex h-12 shrink-0 items-center justify-between border-b border-[#e8e9ec] px-5">
-          <h1 className="m-0 text-[20px] font-semibold text-[#161823]">运行记录</h1>
-          <Button icon={<RefreshCw size={14} />} onClick={() => load()}>刷新</Button>
+          <h1 className="m-0 text-[20px] font-semibold text-[#161823]">
+            运行记录
+          </h1>
+          <Button icon={<RefreshCw size={14} />} onClick={() => load()}>
+            刷新
+          </Button>
         </div>
         <div className="flex min-h-0 flex-1 flex-col px-5 py-4">
           <div className="mb-3 flex shrink-0 items-center gap-2">
@@ -96,20 +151,113 @@ const ExecutionPage = () => {
               <Table<ExecutionListItem>
                 rowKey="executionNo"
                 size="small"
+                bordered
                 pagination={false}
+                scroll={{ x: 1340 }}
+                className={dataQualityTableClassName()}
                 dataSource={data.records}
-                locale={{ emptyText: <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="暂无运行记录" /> }}
-                onRow={(record) => ({ onClick: () => setExecutionNo(record.executionNo), className: 'cursor-pointer' })}
+                locale={{
+                  emptyText: (
+                    <Empty
+                      image={Empty.PRESENTED_IMAGE_SIMPLE}
+                      description="暂无运行记录"
+                    />
+                  ),
+                }}
+                onRow={(record) => ({
+                  onClick: () => setExecutionNo(record.executionNo),
+                  className: 'cursor-pointer',
+                })}
                 columns={[
-                  { title: '执行编号', dataIndex: 'executionNo', width: 220 },
-                  { title: '监控名称', dataIndex: 'monitorName', width: 180 },
-                  { title: '监控对象', dataIndex: 'objectName' },
-                  { title: '执行状态', dataIndex: 'executionStatus', width: 110, render: (v) => <ExecutionStatusTag value={v} /> },
-                  { title: '检查结果', dataIndex: 'checkResult', width: 110, render: (v) => <CheckResultTag value={v} /> },
-                  { title: '规则统计', width: 210, render: (_, r) => `${r.passedRules} / ${r.failedRules} / ${r.errorRules}` },
-                  { title: '触发人', dataIndex: 'operator', width: 130 },
-                  { title: '开始时间', dataIndex: 'startedAt', width: 180, render: (v) => v || '--' },
-                  { title: '耗时', dataIndex: 'durationMs', width: 100, render: (v) => (v === undefined ? '--' : `${v} ms`) },
+                  {
+                    title: '执行编号 / 监控名称',
+                    width: 280,
+                    render: (_, record) => (
+                      <div className="min-w-0 py-1">
+                        <div className="truncate font-medium text-[#172033]">
+                          {record.monitorName}
+                        </div>
+                        <div className="mt-1 truncate text-[11px] text-[#98a2b3]">
+                          ID：{record.executionNo}
+                        </div>
+                      </div>
+                    ),
+                  },
+                  {
+                    title: '数据对象',
+                    width: 270,
+                    render: (_, record) => (
+                      <div className="min-w-0 py-1">
+                        <div className="truncate text-[#344054]">
+                          {record.objectName}
+                        </div>
+                        <div className="mt-1 truncate text-[11px] text-[#98a2b3]">
+                          数据源：{record.dataSourceName}
+                        </div>
+                      </div>
+                    ),
+                  },
+                  {
+                    title: '执行状态',
+                    dataIndex: 'executionStatus',
+                    width: 110,
+                    render: (value) => <ExecutionStatusTag value={value} />,
+                  },
+                  {
+                    title: '检查结果',
+                    dataIndex: 'checkResult',
+                    width: 110,
+                    render: (value) => <CheckResultTag value={value} />,
+                  },
+                  {
+                    title: '执行概况',
+                    width: 230,
+                    render: (_, record) => (
+                      <div className="grid grid-cols-2 gap-x-4 gap-y-1 text-xs">
+                        <span className="text-[#98a2b3]">通过：</span>
+                        <span className="text-[#344054]">{record.passedRules}</span>
+                        <span className="text-[#98a2b3]">未通过：</span>
+                        <span className="text-[#344054]">{record.failedRules}</span>
+                        <span className="text-[#98a2b3]">异常：</span>
+                        <span className="text-[#344054]">{record.errorRules}</span>
+                        <span className="text-[#98a2b3]">耗时：</span>
+                        <span className="text-[#344054]">
+                          {record.durationMs === undefined
+                            ? '--'
+                            : `${record.durationMs} ms`}
+                        </span>
+                      </div>
+                    ),
+                  },
+                  {
+                    title: '触发信息',
+                    width: 210,
+                    render: (_, record) => (
+                      <div className="space-y-1 text-xs">
+                        <div className="text-[#344054]">{record.operator}</div>
+                        <div className="text-[#98a2b3]">
+                          {record.startedAt || record.queuedAt || '--'}
+                        </div>
+                      </div>
+                    ),
+                  },
+                  {
+                    title: '操作',
+                    fixed: 'right',
+                    width: 90,
+                    render: (_, record) => (
+                      <Button
+                        type="link"
+                        size="small"
+                        onClick={(event) => {
+                          event.stopPropagation();
+                          setExecutionNo(record.executionNo);
+                        }}
+                      >
+                        查看
+                      </Button>
+                    ),
+                  },
                 ]}
               />
             </Spin>
@@ -125,7 +273,11 @@ const ExecutionPage = () => {
             />
           </div>
         </div>
-        <ExecutionDetailDrawer executionNo={executionNo} open={Boolean(executionNo)} onClose={() => setExecutionNo(undefined)} />
+        <ExecutionDetailDrawer
+          executionNo={executionNo}
+          open={Boolean(executionNo)}
+          onClose={() => setExecutionNo(undefined)}
+        />
       </div>
     </ConfigProvider>
   );

--- a/yak-ops-ui/src/pages/data-quality/monitor/detail/MonitorListTab.tsx
+++ b/yak-ops-ui/src/pages/data-quality/monitor/detail/MonitorListTab.tsx
@@ -12,6 +12,7 @@ import {
 import type { TableColumnsType } from 'antd';
 import { MoreHorizontal, Plus, RefreshCw, Search } from 'lucide-react';
 import { useMemo, useState } from 'react';
+import { dataQualityTableClassName } from '../../components/tableStyle';
 import type { MonitorWorkspaceView } from '../../types';
 import { RUN_MODE_LABEL } from './model';
 
@@ -81,34 +82,59 @@ const MonitorListTab = ({
 
   const columns: TableColumnsType<MonitorRecord> = [
     {
-      title: 'ID/名称/描述',
+      title: '名称 / ID / 描述',
       minWidth: 360,
       render: (_, record) => (
-        <div className="py-1">
-          <div className="text-xs text-[#8b95a7]">{record.id}</div>
-          <div className="mt-0.5 text-[13px] font-medium text-[#172033]">
+        <div className="min-w-0 py-1">
+          <div className="truncate text-[13px] font-medium text-[#172033]">
             {record.name}
           </div>
+          <div className="mt-1 text-[11px] text-[#98a2b3]">ID：{record.id}</div>
           {record.description ? (
-            <div className="mt-0.5 line-clamp-1 text-xs text-[#8b95a7]">
+            <div className="mt-1 line-clamp-1 text-xs text-[#667085]">
               {record.description}
             </div>
           ) : null}
         </div>
       ),
     },
-    { title: '触发方式', dataIndex: 'trigger', width: 180 },
     {
-      title: '已启用/总规则数',
-      width: 150,
-      render: () => (
-        <span>
-          <span className="text-[#245bdb]">{stats.enabledRuleCount}</span>/{stats.ruleCount}
-        </span>
+      title: '触发方式',
+      width: 190,
+      render: (_, record) => (
+        <div className="space-y-1 py-0.5">
+          <div className="text-[#344054]">{record.trigger}</div>
+          <div className="text-[11px] text-[#98a2b3]">
+            {settings.nextRunTime ? `下次：${settings.nextRunTime}` : '未配置下次运行'}
+          </div>
+        </div>
       ),
     },
-    { title: '责任人', dataIndex: 'owner', width: 180 },
-    { title: '最近更新时间', dataIndex: 'updateTime', width: 190 },
+    {
+      title: '已启用 / 总规则数',
+      width: 160,
+      render: () => (
+        <div className="flex items-baseline gap-1">
+          <span className="text-[15px] font-semibold text-[#245bdb]">
+            {stats.enabledRuleCount}
+          </span>
+          <span className="text-[#98a2b3]">/</span>
+          <span className="text-[#344054]">{stats.ruleCount}</span>
+        </div>
+      ),
+    },
+    {
+      title: '责任人',
+      dataIndex: 'owner',
+      width: 180,
+      render: (value) => <span className="text-[#344054]">{value}</span>,
+    },
+    {
+      title: '最近更新时间',
+      dataIndex: 'updateTime',
+      width: 190,
+      render: (value) => <span className="text-xs text-[#667085]">{value}</span>,
+    },
     {
       title: '状态',
       dataIndex: 'enabled',
@@ -221,9 +247,10 @@ const MonitorListTab = ({
       <Table<MonitorRecord>
         rowKey="id"
         size="small"
-        className="mt-3"
+        bordered
         pagination={false}
-        scroll={{ x: 1250 }}
+        scroll={{ x: 1280 }}
+        className={dataQualityTableClassName('mt-3')}
         dataSource={records}
         columns={columns}
         locale={{

--- a/yak-ops-ui/src/pages/data-quality/monitor/detail/OperationLogDrawer.tsx
+++ b/yak-ops-ui/src/pages/data-quality/monitor/detail/OperationLogDrawer.tsx
@@ -1,5 +1,6 @@
-import { Drawer, Pagination, Table, Tag } from 'antd';
+import { Drawer, Empty, Pagination, Table, Tag } from 'antd';
 import type { TableColumnsType } from 'antd';
+import { dataQualityTableClassName } from '../../components/tableStyle';
 import type { OperationLogItem, OperationLogPageView } from '../../types';
 import { ACTION_TYPE_LABEL } from './model';
 
@@ -19,19 +20,37 @@ const OperationLogDrawer = ({
   onPageChange,
 }: OperationLogDrawerProps) => {
   const columns: TableColumnsType<OperationLogItem> = [
-    { title: '操作人', dataIndex: 'operator', width: 130 },
-    { title: '操作时间', dataIndex: 'operationTime', width: 190 },
     {
-      title: '类型',
+      title: '操作人 / 时间',
+      width: 210,
+      render: (_, record) => (
+        <div className="space-y-1 py-0.5">
+          <div className="font-medium text-[#172033]">{record.operator}</div>
+          <div className="text-[11px] text-[#98a2b3]">
+            {record.operationTime}
+          </div>
+        </div>
+      ),
+    },
+    {
+      title: '操作类型',
       dataIndex: 'actionType',
-      width: 100,
+      width: 120,
       render: (value) => (
         <Tag className="!m-0 !border-0 !bg-[#f2f4f7] !text-[#43506a]">
           {ACTION_TYPE_LABEL[value] || value}
         </Tag>
       ),
     },
-    { title: '操作内容', dataIndex: 'content' },
+    {
+      title: '操作内容',
+      dataIndex: 'content',
+      render: (value) => (
+        <div className="whitespace-pre-wrap leading-5 text-[#475467]">
+          {value}
+        </div>
+      ),
+    },
   ];
 
   return (
@@ -57,12 +76,21 @@ const OperationLogDrawer = ({
       <Table<OperationLogItem>
         rowKey="id"
         size="small"
+        bordered
         loading={loading}
         pagination={false}
-        scroll={{ x: 760 }}
+        scroll={{ x: 700 }}
+        className={dataQualityTableClassName()}
         dataSource={data.records}
         columns={columns}
-        locale={{ emptyText: '暂无操作日志' }}
+        locale={{
+          emptyText: (
+            <Empty
+              image={Empty.PRESENTED_IMAGE_SIMPLE}
+              description="暂无操作日志"
+            />
+          ),
+        }}
       />
     </Drawer>
   );

--- a/yak-ops-ui/src/pages/data-quality/monitor/detail/QualityReportTab.tsx
+++ b/yak-ops-ui/src/pages/data-quality/monitor/detail/QualityReportTab.tsx
@@ -1,8 +1,17 @@
-import { Button, DatePicker, Empty, Progress, Spin, Table, message } from 'antd';
+import {
+  Button,
+  DatePicker,
+  Empty,
+  Progress,
+  Spin,
+  Table,
+  message,
+} from 'antd';
 import type { TableColumnsType } from 'antd';
 import dayjs from 'dayjs';
 import { CalendarDays, Info } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
+import { dataQualityTableClassName } from '../../components/tableStyle';
 import type {
   ColumnReport,
   DimensionReport,
@@ -26,7 +35,10 @@ const Sparkline = ({ values }: { values: number[] }) => {
   const height = 34;
   const points = normalized
     .map((value, index) => {
-      const x = normalized.length === 1 ? width / 2 : (index / (normalized.length - 1)) * width;
+      const x =
+        normalized.length === 1
+          ? width / 2
+          : (index / (normalized.length - 1)) * width;
       const y = height - Math.max(0, Math.min(100, value)) * (height / 100);
       return `${x},${y}`;
     })
@@ -34,7 +46,13 @@ const Sparkline = ({ values }: { values: number[] }) => {
 
   return (
     <svg width={width} height={height} viewBox={`0 0 ${width} ${height}`} role="img">
-      <line x1="0" y1={height - 1} x2={width} y2={height - 1} stroke="#edf0f5" />
+      <line
+        x1="0"
+        y1={height - 1}
+        x2={width}
+        y2={height - 1}
+        stroke="#edf0f5"
+      />
       <polyline
         points={points}
         fill="none"
@@ -134,11 +152,14 @@ const QualityReportTab = ({
         record.values.reduce((total, item) => total + item.total, 0) || '--',
     },
     {
-      title: '异常规则数/实例数',
+      title: '异常规则数 / 实例数',
       width: 170,
       render: (_, record) => {
         const total = record.values.reduce((value, item) => value + item.total, 0);
-        const issues = record.values.reduce((value, item) => value + item.issues, 0);
+        const issues = record.values.reduce(
+          (value, item) => value + item.issues,
+          0,
+        );
         return total ? `${issues}/${total}` : '-/-';
       },
     },
@@ -153,7 +174,11 @@ const QualityReportTab = ({
       title: '操作',
       width: 100,
       render: () => (
-        <Button type="link" size="small" onClick={() => message.info('趋势明细已在运行记录中保留')}>
+        <Button
+          type="link"
+          size="small"
+          onClick={() => message.info('趋势明细已在运行记录中保留')}
+        >
           查看详情
         </Button>
       ),
@@ -161,7 +186,12 @@ const QualityReportTab = ({
   ];
 
   const columnColumns: TableColumnsType<ColumnReport> = [
-    { title: '字段/关联范围', dataIndex: 'columnName', minWidth: 150 },
+    {
+      title: '字段 / 关联范围',
+      dataIndex: 'columnName',
+      minWidth: 150,
+      render: (value) => <span className="font-medium text-[#172033]">{value}</span>,
+    },
     { title: '质量维度', dataIndex: 'dimension', width: 100 },
     { title: '评估次数', dataIndex: 'total', width: 100 },
     { title: '正常', dataIndex: 'passed', width: 90 },
@@ -202,7 +232,9 @@ const QualityReportTab = ({
           allowClear={false}
           value={dayjs(reportDate)}
           suffixIcon={<CalendarDays size={14} />}
-          onChange={(value) => value && onDateChange(value.format('YYYY-MM-DD'))}
+          onChange={(value) =>
+            value && onDateChange(value.format('YYYY-MM-DD'))
+          }
         />
       </div>
 
@@ -224,7 +256,9 @@ const QualityReportTab = ({
                       <div className="text-[30px] font-medium text-[#172033]">
                         {Number(value || 0).toFixed(0)}%
                       </div>
-                      <div className="mt-2 text-xs text-[#667085]">表质量通过率</div>
+                      <div className="mt-2 text-xs text-[#667085]">
+                        表质量通过率
+                      </div>
                     </div>
                   )}
                 />
@@ -232,23 +266,37 @@ const QualityReportTab = ({
               <div className="space-y-3">
                 {dimensions.length ? (
                   dimensions.map((item, index) => (
-                    <div key={item.dimension} className="grid grid-cols-[120px_minmax(0,1fr)_52px] items-center gap-2 text-xs">
+                    <div
+                      key={item.dimension}
+                      className="grid grid-cols-[120px_minmax(0,1fr)_52px] items-center gap-2 text-xs"
+                    >
                       <span className="truncate text-[#43506a]">
                         {index + 1}　{item.dimension}：{item.passed}/{item.total}
                       </span>
-                      <Progress percent={item.passRate} showInfo={false} size="small" />
-                      <span className="text-right text-[#667085]">{percentText(item.passRate)}</span>
+                      <Progress
+                        percent={item.passRate}
+                        showInfo={false}
+                        size="small"
+                      />
+                      <span className="text-right text-[#667085]">
+                        {percentText(item.passRate)}
+                      </span>
                     </div>
                   ))
                 ) : (
-                  <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="当前日期暂无质量结果" />
+                  <Empty
+                    image={Empty.PRESENTED_IMAGE_SIMPLE}
+                    description="当前日期暂无质量结果"
+                  />
                 )}
               </div>
             </div>
           </section>
 
           <section className="min-h-[326px] border border-[#dfe3e8] bg-white p-4">
-            <h2 className="m-0 text-[15px] font-semibold text-[#172033]">重点关注</h2>
+            <h2 className="m-0 text-[15px] font-semibold text-[#172033]">
+              重点关注
+            </h2>
             <div className="mt-3 grid grid-cols-2 gap-2 max-md:grid-cols-1">
               <FocusCard
                 title="总质量规则数"
@@ -300,8 +348,9 @@ const QualityReportTab = ({
             <Table
               rowKey="key"
               size="small"
-              className="mt-3"
+              bordered
               pagination={false}
+              className={dataQualityTableClassName('mt-3')}
               dataSource={trendRows}
               columns={trendColumns}
               locale={{ emptyText: '暂无趋势数据' }}
@@ -315,18 +364,20 @@ const QualityReportTab = ({
                   字段质量维度分析
                 </h2>
                 <div className="mt-2 text-xs text-[#8b95a7]">
-                  评估字段总数：{report?.columns.length || 0}　
-                  正常：{report?.columns.filter((item) => item.issues === 0).length || 0}　
-                  异常：{report?.columns.filter((item) => item.issues > 0).length || 0}
+                  评估字段总数：{report?.columns.length || 0}　 正常：
+                  {report?.columns.filter((item) => item.issues === 0).length || 0}
+                  　 异常：
+                  {report?.columns.filter((item) => item.issues > 0).length || 0}
                 </div>
               </div>
             </div>
             <Table<ColumnReport>
               rowKey={(record) => `${record.columnName}-${record.dimension}`}
               size="small"
-              className="mt-3"
+              bordered
               pagination={false}
               scroll={{ x: 700 }}
+              className={dataQualityTableClassName('mt-3')}
               dataSource={report?.columns || []}
               columns={columnColumns}
               locale={{ emptyText: '当前日期暂无字段质量结果' }}

--- a/yak-ops-ui/src/pages/data-quality/monitor/detail/RuleManagementTab.tsx
+++ b/yak-ops-ui/src/pages/data-quality/monitor/detail/RuleManagementTab.tsx
@@ -22,6 +22,7 @@ import {
   Sparkles,
 } from 'lucide-react';
 import { useMemo, useState, type Key } from 'react';
+import { dataQualityTableClassName } from '../../components/tableStyle';
 import type { MonitorWorkspaceView, RuleView } from '../../types';
 import {
   DIMENSION_ORDER,
@@ -122,20 +123,24 @@ const RuleManagementTab = ({
       title: '删除质量规则？',
       content: `确认删除“${rule.name}”吗？历史执行结果仍会保留。`,
       okButtonProps: { danger: true },
-      onOk: () => onUpdateRules(monitor.rules.filter((item) => item.id !== rule.id)),
+      onOk: () =>
+        onUpdateRules(monitor.rules.filter((item) => item.id !== rule.id)),
     });
   };
 
   const columns: TableColumnsType<RuleView> = [
     {
-      title: 'ID/规则名称',
+      title: '规则名称 / ID',
       dataIndex: 'name',
       minWidth: 300,
       render: (_, rule) => (
         <div className="min-w-0 py-1">
-          <div className="text-xs text-[#9aa3b2]">{rule.id}</div>
-          <div className="mt-0.5 truncate text-[13px] font-medium text-[#172033]">
+          <div className="truncate text-[13px] font-medium text-[#172033]">
             {rule.name}
+          </div>
+          <div className="mt-1 text-[11px] text-[#98a2b3]">
+            ID：{rule.id}
+            {rule.columnName ? ` · 字段：${rule.columnName}` : ' · 表级规则'}
           </div>
         </div>
       ),
@@ -143,7 +148,11 @@ const RuleManagementTab = ({
     {
       title: '重要程度',
       width: 110,
-      render: () => <span className="text-[#43506a]">弱规则</span>,
+      render: () => (
+        <Tag className="!m-0 !border-0 !bg-[#f2f4f7] !text-[#667085]">
+          弱规则
+        </Tag>
+      ),
     },
     {
       title: '关联范围',
@@ -154,24 +163,29 @@ const RuleManagementTab = ({
       title: '规则模板',
       dataIndex: 'templateCode',
       width: 180,
-      render: (value) => <span className="text-[#43506a]">{value}</span>,
+      render: (value) => <span className="text-[#344054]">{value}</span>,
     },
     {
       title: '监控阈值',
       width: 190,
       render: (_, rule) => (
         <div>
-          <div className="text-[#43506a]">{ruleParameter(rule)}</div>
+          <div className="font-medium text-[#344054]">{ruleParameter(rule)}</div>
           <div className="mt-1 flex items-center gap-1.5 text-[11px]">
             <span className="h-1.5 w-1.5 rounded-full bg-[#ff4d4f]" />
             <span className="text-[#ff4d4f]">异常</span>
-            <span className="h-1.5 w-1.5 rounded-full bg-[#12a150]" />
+            <span className="ml-1 h-1.5 w-1.5 rounded-full bg-[#12a150]" />
             <span className="text-[#12a150]">正常</span>
           </div>
         </div>
       ),
     },
-    { title: '维度', dataIndex: 'dimension', width: 100 },
+    {
+      title: '质量维度',
+      dataIndex: 'dimension',
+      width: 110,
+      render: (value) => <span className="text-[#344054]">{value}</span>,
+    },
     {
       title: '状态',
       dataIndex: 'enabled',
@@ -238,7 +252,9 @@ const RuleManagementTab = ({
         <div className="mt-4 space-y-1 text-[13px]">
           <div className="flex items-center justify-between rounded-md bg-[#f0f3f8] px-3 py-2 font-medium text-[#27344f]">
             <span>全部规则</span>
-            <span className="rounded-full bg-white px-1.5 text-xs">{stats.ruleCount}</span>
+            <span className="rounded-full bg-white px-1.5 text-xs">
+              {stats.ruleCount}
+            </span>
           </div>
           <div className="flex items-center justify-between px-3 py-2 text-[#43506a]">
             <span>已关联质量监控的规则</span>
@@ -258,7 +274,11 @@ const RuleManagementTab = ({
             <Tooltip title="新建质量监控">
               <Plus size={16} />
             </Tooltip>
-            <RefreshCw size={14} className="cursor-pointer" onClick={onRefresh} />
+            <RefreshCw
+              size={14}
+              className="cursor-pointer"
+              onClick={onRefresh}
+            />
           </div>
         </div>
         <Input
@@ -381,9 +401,11 @@ const RuleManagementTab = ({
         <Table<RuleView>
           rowKey="id"
           size="small"
+          bordered
           loading={savingRules}
           pagination={false}
           scroll={{ x: 1280 }}
+          className={dataQualityTableClassName()}
           dataSource={records}
           locale={{
             emptyText: (
@@ -416,14 +438,19 @@ const RuleManagementTab = ({
             </Button>
             <Button disabled={!selectedRowKeys.length}>关联质量监控</Button>
             <Dropdown
-              menu={{ items: [{ key: 'log', label: '查看操作日志' }], onClick: onOpenLog }}
+              menu={{
+                items: [{ key: 'log', label: '查看操作日志' }],
+                onClick: onOpenLog,
+              }}
             >
               <Button disabled={!selectedRowKeys.length}>
                 更多操作 <ChevronDown size={12} />
               </Button>
             </Dropdown>
           </div>
-          <div className="text-xs text-[#8b95a7]">共 {records.length} 条规则</div>
+          <div className="text-xs text-[#8b95a7]">
+            共 {records.length} 条规则
+          </div>
         </div>
       </main>
     </div>

--- a/yak-ops-ui/src/pages/data-quality/monitor/editor/RuleEditor.tsx
+++ b/yak-ops-ui/src/pages/data-quality/monitor/editor/RuleEditor.tsx
@@ -11,13 +11,14 @@ import {
 } from 'antd';
 import { Plus, Trash2 } from 'lucide-react';
 import { useState } from 'react';
-import type { CatalogColumn, ComparisonOperator, TemplateView } from '../../types';
+import { dataQualityTableClassName } from '../../components/tableStyle';
+import type {
+  CatalogColumn,
+  ComparisonOperator,
+  TemplateView,
+} from '../../types';
 import { EditorSection } from './EditorLayout';
-import {
-  OPERATORS,
-  ruleDefaults,
-  type EditorRule,
-} from './model';
+import { OPERATORS, ruleDefaults, type EditorRule } from './model';
 
 export const validateRules = (rules: EditorRule[]) => {
   if (!rules.length) throw new Error('至少添加一条质量规则');
@@ -185,21 +186,55 @@ export const QualityRuleEditor = ({
         <Table<TemplateView>
           rowKey="id"
           size="small"
+          bordered
           pagination={false}
           dataSource={templates}
           scroll={{ y: 440 }}
+          className={dataQualityTableClassName()}
           columns={[
-            { title: '模板名称', dataIndex: 'name', width: 180 },
-            { title: '质量维度', dataIndex: 'dimension', width: 100 },
             {
-              title: '范围',
+              title: '模板名称 / 编码',
+              dataIndex: 'name',
+              width: 220,
+              render: (_, template) => (
+                <div className="min-w-0 py-0.5">
+                  <div className="truncate font-medium text-[#172033]">
+                    {template.name}
+                  </div>
+                  <div className="mt-1 truncate text-[11px] text-[#98a2b3]">
+                    {template.code}
+                  </div>
+                </div>
+              ),
+            },
+            {
+              title: '质量维度',
+              dataIndex: 'dimension',
+              width: 110,
+              render: (value) => (
+                <Tag className="!m-0 !border-0 !bg-[#f2f4f7] !text-[#667085]">
+                  {value}
+                </Tag>
+              ),
+            },
+            {
+              title: '关联范围',
               dataIndex: 'scope',
-              width: 90,
+              width: 100,
               render: (value) => (value === 'TABLE' ? '表级' : '字段级'),
             },
-            { title: '说明', dataIndex: 'description' },
+            {
+              title: '模板说明',
+              dataIndex: 'description',
+              render: (value) => (
+                <div className="line-clamp-2 leading-5 text-[#667085]">
+                  {value || '--'}
+                </div>
+              ),
+            },
             {
               title: '操作',
+              fixed: 'right',
               width: 80,
               render: (_, template) => (
                 <Button

--- a/yak-ops-ui/src/pages/data-quality/rule-template/index.tsx
+++ b/yak-ops-ui/src/pages/data-quality/rule-template/index.tsx
@@ -1,6 +1,14 @@
 import { API_SUCCESS_CODE } from '@/services/http/response';
 import { BRAND_THEME } from '@/styles/brand';
-import { ConfigProvider, Empty, Input, Spin, Table, Tag, message } from 'antd';
+import {
+  ConfigProvider,
+  Empty,
+  Input,
+  Spin,
+  Table,
+  Tag,
+  message,
+} from 'antd';
 import { ChevronLeft, ChevronRight, Search } from 'lucide-react';
 import {
   useEffect,
@@ -9,6 +17,7 @@ import {
   useState,
   type PointerEvent as ReactPointerEvent,
 } from 'react';
+import { dataQualityTableClassName } from '../components/tableStyle';
 import { qualityTemplateApi } from '../service';
 import type { TemplateListView, TemplateView } from '../types';
 
@@ -16,13 +25,23 @@ const DEFAULT_LEFT_WIDTH = 280;
 const MIN_LEFT_WIDTH = 220;
 const MAX_LEFT_WIDTH = 480;
 
-const unwrap = <T,>(response: { code: number; data: T; message?: string; msg?: string }) => {
-  if (response.code !== API_SUCCESS_CODE) throw new Error(response.message || response.msg || '请求失败');
+const unwrap = <T,>(response: {
+  code: number;
+  data: T;
+  message?: string;
+  msg?: string;
+}) => {
+  if (response.code !== API_SUCCESS_CODE) {
+    throw new Error(response.message || response.msg || '请求失败');
+  }
   return response.data;
 };
 
 const TemplateLibraryPage = () => {
-  const [data, setData] = useState<TemplateListView>({ records: [], summary: { total: 0, dimensions: {} } });
+  const [data, setData] = useState<TemplateListView>({
+    records: [],
+    summary: { total: 0, dimensions: {} },
+  });
   const [dimension, setDimension] = useState('全部');
   const [keyword, setKeyword] = useState('');
   const [loading, setLoading] = useState(false);
@@ -33,7 +52,10 @@ const TemplateLibraryPage = () => {
   const dimensions = useMemo(
     () => [
       { label: '全部', count: data.summary.total },
-      ...Object.entries(data.summary.dimensions).map(([label, count]) => ({ label, count })),
+      ...Object.entries(data.summary.dimensions).map(([label, count]) => ({
+        label,
+        count,
+      })),
     ],
     [data.summary],
   );
@@ -41,7 +63,10 @@ const TemplateLibraryPage = () => {
   useEffect(() => {
     setLoading(true);
     qualityTemplateApi
-      .list({ keyword, dimension: dimension === '全部' ? undefined : dimension })
+      .list({
+        keyword,
+        dimension: dimension === '全部' ? undefined : dimension,
+      })
       .then((response) => setData(unwrap(response)))
       .catch((error) => message.error(error?.message || '规则模板加载失败'))
       .finally(() => setLoading(false));
@@ -56,7 +81,12 @@ const TemplateLibraryPage = () => {
     const move = (current: PointerEvent) => {
       const drag = dragRef.current;
       if (!drag) return;
-      setLeftWidth(Math.min(MAX_LEFT_WIDTH, Math.max(MIN_LEFT_WIDTH, drag.width + current.clientX - drag.x)));
+      setLeftWidth(
+        Math.min(
+          MAX_LEFT_WIDTH,
+          Math.max(MIN_LEFT_WIDTH, drag.width + current.clientX - drag.x),
+        ),
+      );
     };
     const end = () => {
       dragRef.current = undefined;
@@ -75,12 +105,22 @@ const TemplateLibraryPage = () => {
     <ConfigProvider theme={BRAND_THEME}>
       <div className="flex h-[calc(100vh-64px)] min-h-[620px] flex-col overflow-hidden bg-white">
         <div className="flex h-12 shrink-0 items-center border-b border-[#e8e9ec] px-5">
-          <h1 className="m-0 text-[20px] font-semibold text-[#161823]">规则模板库</h1>
+          <h1 className="m-0 text-[20px] font-semibold text-[#161823]">
+            规则模板库
+          </h1>
         </div>
         <div className="flex min-h-0 flex-1 overflow-hidden">
-          <aside className="shrink-0 overflow-hidden" style={{ width: collapsed ? 0 : leftWidth }}>
-            <div className="h-full overflow-y-auto px-4 py-3" style={{ width: leftWidth }}>
-              <div className="mb-2 text-xs font-semibold text-[#161823]">质量维度</div>
+          <aside
+            className="shrink-0 overflow-hidden"
+            style={{ width: collapsed ? 0 : leftWidth }}
+          >
+            <div
+              className="h-full overflow-y-auto px-4 py-3"
+              style={{ width: leftWidth }}
+            >
+              <div className="mb-2 text-xs font-semibold text-[#161823]">
+                质量维度
+              </div>
               <div className="space-y-1">
                 {dimensions.map((item) => (
                   <button
@@ -94,20 +134,29 @@ const TemplateLibraryPage = () => {
                     }`}
                   >
                     <span>{item.label}</span>
-                    <span className="rounded-full bg-[#f2f3f5] px-2 text-xs text-[#5d616b]">{item.count}</span>
+                    <span className="rounded-full bg-[#f2f3f5] px-2 text-xs text-[#5d616b]">
+                      {item.count}
+                    </span>
                   </button>
                 ))}
               </div>
               <div className="mt-5 border-t border-[#eceef0] pt-4">
-                <div className="mb-2 text-xs font-semibold text-[#161823]">模板范围</div>
+                <div className="mb-2 text-xs font-semibold text-[#161823]">
+                  模板范围
+                </div>
                 <div className="text-xs leading-6 text-[#8a8f99]">
-                  第一阶段只提供 6 个系统模板。自定义模板分类、发布版本和参数 Schema 编辑将在后续阶段补充。
+                  第一阶段只提供 6 个系统模板。自定义模板分类、发布版本和参数
+                  Schema 编辑将在后续阶段补充。
                 </div>
               </div>
             </div>
           </aside>
 
-          <div role="separator" onPointerDown={startResize} className="relative w-3 shrink-0 cursor-col-resize">
+          <div
+            role="separator"
+            onPointerDown={startResize}
+            className="relative w-3 shrink-0 cursor-col-resize"
+          >
             <div className="absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-[#e4e7ec]" />
             <button
               type="button"
@@ -115,7 +164,11 @@ const TemplateLibraryPage = () => {
               onClick={() => setCollapsed((value) => !value)}
               className="absolute left-1/2 top-1/2 z-10 flex h-8 w-4 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded border border-[#dfe1e5] bg-white text-[#7b808a]"
             >
-              {collapsed ? <ChevronRight size={13} /> : <ChevronLeft size={13} />}
+              {collapsed ? (
+                <ChevronRight size={13} />
+              ) : (
+                <ChevronLeft size={13} />
+              )}
             </button>
           </div>
 
@@ -123,8 +176,12 @@ const TemplateLibraryPage = () => {
             <div className="flex h-full flex-col overflow-hidden">
               <div className="mb-3 flex shrink-0 items-center justify-between">
                 <div>
-                  <h2 className="m-0 text-sm font-semibold text-[#161823]">{dimension}</h2>
-                  <div className="mt-1 text-xs text-[#8a8f99]">共 {data.records.length} 个可用模板</div>
+                  <h2 className="m-0 text-sm font-semibold text-[#161823]">
+                    {dimension}
+                  </h2>
+                  <div className="mt-1 text-xs text-[#8a8f99]">
+                    共 {data.records.length} 个可用模板
+                  </div>
                 </div>
                 <Input
                   allowClear
@@ -141,15 +198,72 @@ const TemplateLibraryPage = () => {
                   <Table<TemplateView>
                     rowKey="id"
                     size="small"
+                    bordered
                     pagination={false}
+                    scroll={{ x: 980 }}
+                    className={dataQualityTableClassName()}
                     dataSource={data.records}
-                    locale={{ emptyText: <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="暂无规则模板" /> }}
+                    locale={{
+                      emptyText: (
+                        <Empty
+                          image={Empty.PRESENTED_IMAGE_SIMPLE}
+                          description="暂无规则模板"
+                        />
+                      ),
+                    }}
                     columns={[
-                      { title: '模板名称', dataIndex: 'name', width: 210 },
-                      { title: '质量维度', dataIndex: 'dimension', width: 120 },
-                      { title: '关联范围', dataIndex: 'scope', width: 110, render: (value) => <Tag>{value === 'TABLE' ? '表级' : '字段级'}</Tag> },
-                      { title: '关联规则数', dataIndex: 'ruleCount', width: 120 },
-                      { title: '模板描述', dataIndex: 'description' },
+                      {
+                        title: '模板名称 / 编码',
+                        dataIndex: 'name',
+                        width: 260,
+                        render: (_, record) => (
+                          <div className="min-w-0 py-1">
+                            <div className="truncate font-medium text-[#172033]">
+                              {record.name}
+                            </div>
+                            <div className="mt-1 truncate text-[11px] text-[#98a2b3]">
+                              {record.code}
+                            </div>
+                          </div>
+                        ),
+                      },
+                      {
+                        title: '质量维度',
+                        dataIndex: 'dimension',
+                        width: 120,
+                        render: (value) => (
+                          <Tag className="!m-0 !border-0 !bg-[#f2f4f7] !text-[#667085]">
+                            {value}
+                          </Tag>
+                        ),
+                      },
+                      {
+                        title: '关联范围',
+                        dataIndex: 'scope',
+                        width: 110,
+                        render: (value) => (
+                          <Tag className="!m-0 !border-0 !bg-[#eef3ff] !text-[#245bdb]">
+                            {value === 'TABLE' ? '表级' : '字段级'}
+                          </Tag>
+                        ),
+                      },
+                      {
+                        title: '关联规则数',
+                        dataIndex: 'ruleCount',
+                        width: 120,
+                        render: (value) => (
+                          <span className="font-medium text-[#344054]">{value}</span>
+                        ),
+                      },
+                      {
+                        title: '模板描述',
+                        dataIndex: 'description',
+                        render: (value) => (
+                          <div className="line-clamp-2 leading-5 text-[#667085]">
+                            {value || '--'}
+                          </div>
+                        ),
+                      },
                     ]}
                     expandable={{
                       expandedRowRender: (record) => (

--- a/yak-ops-ui/src/pages/data-quality/table-config/components/RegisterTableDrawer.tsx
+++ b/yak-ops-ui/src/pages/data-quality/table-config/components/RegisterTableDrawer.tsx
@@ -1,5 +1,15 @@
-import { Button, Drawer, Empty, Input, Pagination, Spin, Table } from 'antd';
+import {
+  Button,
+  Drawer,
+  Empty,
+  Input,
+  Pagination,
+  Spin,
+  Table,
+  Tag,
+} from 'antd';
 import { Database, Search, X } from 'lucide-react';
+import { dataQualityTableClassName } from '../../components/tableStyle';
 import type { TableCandidateView } from '../../types';
 import { CANDIDATE_PAGE_SIZE, tableTargetKey } from '../model';
 
@@ -19,10 +29,7 @@ interface RegisterTableDrawerProps {
   onCandidateCurrentChange: (current: number) => void;
   onCandidateKeywordChange: (keyword: string) => void;
   onSelect: (record: TableCandidateView, selected: boolean) => void;
-  onSelectAll: (
-    selected: boolean,
-    changedRows: TableCandidateView[],
-  ) => void;
+  onSelectAll: (selected: boolean, changedRows: TableCandidateView[]) => void;
   onClear: () => void;
 }
 
@@ -95,9 +102,7 @@ const RegisterTableDrawer = ({
               数据实时来自当前数据源插件
             </div>
           </div>
-          <span className="text-xs text-[#8a8f99]">
-            共 {candidateTotal} 张
-          </span>
+          <span className="text-xs text-[#8a8f99]">共 {candidateTotal} 张</span>
         </div>
 
         <Input
@@ -115,9 +120,11 @@ const RegisterTableDrawer = ({
             <Table<TableCandidateView>
               rowKey={tableTargetKey}
               size="small"
+              bordered
               pagination={false}
               dataSource={candidates}
               scroll={{ y: 410 }}
+              className={dataQualityTableClassName()}
               rowSelection={{
                 preserveSelectedRowKeys: true,
                 selectedRowKeys: selectedCandidateKeys,
@@ -135,24 +142,21 @@ const RegisterTableDrawer = ({
               }}
               columns={[
                 {
-                  title: '表名/描述',
+                  title: '表名 / 描述 / 路径',
                   dataIndex: 'tableName',
                   render: (_, record) => (
-                    <div className="min-w-0">
-                      <div className="truncate font-medium text-[#161823]">
+                    <div className="min-w-0 py-1">
+                      <div className="truncate font-medium text-[#172033]">
                         {record.tableName}
                       </div>
-                      {record.remarks && (
-                        <div className="mt-0.5 truncate text-xs text-[#8a8f99]">
+                      {record.remarks ? (
+                        <div className="mt-1 truncate text-xs text-[#667085]">
                           {record.remarks}
                         </div>
-                      )}
-                      <div className="mt-0.5 truncate text-xs text-[#98a2b3]">
-                        {[
-                          record.databaseName,
-                          record.schemaName,
-                          record.tableName,
-                        ]
+                      ) : null}
+                      <div className="mt-1 truncate text-[11px] text-[#98a2b3]">
+                        路径：
+                        {[record.databaseName, record.schemaName, record.tableName]
                           .filter(Boolean)
                           .join(' / ')}
                       </div>
@@ -160,17 +164,21 @@ const RegisterTableDrawer = ({
                   ),
                 },
                 {
-                  title: '类型',
+                  title: '表类型',
                   dataIndex: 'tableType',
-                  width: 90,
-                  render: (value) => value || '--',
+                  width: 100,
+                  render: (value) => (
+                    <Tag className="!m-0 !border-0 !bg-[#f2f4f7] !text-[#667085]">
+                      {value || 'TABLE'}
+                    </Tag>
+                  ),
                 },
               ]}
             />
           </Spin>
         </div>
 
-        {candidateTotal > 0 && (
+        {candidateTotal > 0 ? (
           <div className="mt-3 flex shrink-0 justify-end">
             <Pagination
               size="small"
@@ -181,7 +189,7 @@ const RegisterTableDrawer = ({
               onChange={onCandidateCurrentChange}
             />
           </div>
-        )}
+        ) : null}
       </div>
 
       <div className="flex min-w-0 flex-col bg-[#fafafa] p-4">
@@ -207,7 +215,7 @@ const RegisterTableDrawer = ({
               {selectedCandidateRecords.map((record) => (
                 <div
                   key={tableTargetKey(record)}
-                  className="flex items-start gap-2 border border-[#e4e7ec] bg-white px-3 py-2.5"
+                  className="flex items-start gap-2 rounded-lg border border-[#e4e7ec] bg-white px-3 py-2.5"
                 >
                   <Database
                     size={14}
@@ -218,11 +226,7 @@ const RegisterTableDrawer = ({
                       {record.tableName}
                     </div>
                     <div className="mt-0.5 truncate text-xs text-[#98a2b3]">
-                      {[
-                        record.databaseName,
-                        record.schemaName,
-                        record.tableName,
-                      ]
+                      {[record.databaseName, record.schemaName, record.tableName]
                         .filter(Boolean)
                         .join(' / ')}
                     </div>

--- a/yak-ops-ui/src/pages/data-quality/table-config/components/RegisteredTablePanel.tsx
+++ b/yak-ops-ui/src/pages/data-quality/table-config/components/RegisteredTablePanel.tsx
@@ -1,6 +1,17 @@
-import { Button, Empty, Input, Pagination, Popconfirm, Spin, Table, Tooltip } from 'antd';
+import {
+  Button,
+  Empty,
+  Input,
+  Pagination,
+  Popconfirm,
+  Spin,
+  Table,
+  Tag,
+  Tooltip,
+} from 'antd';
 import { Play, Plus, Search, Settings2 } from 'lucide-react';
 import { CheckResultTag } from '../../components/QualityStatus';
+import { dataQualityTableClassName } from '../../components/tableStyle';
 import type { TableAssetView } from '../../types';
 import { PAGE_SIZE, type DataSourceTreeNode } from '../model';
 
@@ -39,7 +50,7 @@ const RegisteredTablePanel = ({
     <div className="flex h-full flex-col overflow-hidden">
       <div className="mb-3 flex shrink-0 items-center gap-2">
         {selectedSourceNode && (
-          <div className="flex h-8 shrink-0 items-center gap-3 bg-[#f5f5f6] px-3 text-xs text-[#667085]">
+          <div className="flex h-8 shrink-0 items-center gap-3 rounded-md bg-[#f5f5f6] px-3 text-xs text-[#667085]">
             <span>
               数据源类型：
               <span className="font-medium text-[#30323b]">
@@ -90,9 +101,11 @@ const RegisteredTablePanel = ({
               <Table<TableAssetView>
                 rowKey="id"
                 size="small"
+                bordered
                 pagination={false}
                 dataSource={assets}
-                scroll={{ x: 1080 }}
+                scroll={{ x: 1380 }}
+                className={dataQualityTableClassName()}
                 locale={{
                   emptyText: (
                     <Empty
@@ -111,19 +124,24 @@ const RegisteredTablePanel = ({
                 }}
                 columns={[
                   {
-                    title: '表名/描述/路径',
+                    title: '表名 / ID / 描述',
                     dataIndex: 'tableName',
+                    minWidth: 330,
                     render: (_, record) => (
-                      <div>
-                        <div className="font-medium text-[#161823]">
+                      <div className="min-w-0 py-1">
+                        <div className="truncate font-medium text-[#172033]">
                           {record.tableName}
                         </div>
-                        {record.remarks && (
-                          <div className="mt-0.5 text-xs text-[#8a8f99]">
+                        <div className="mt-1 text-[11px] text-[#98a2b3]">
+                          ID：{record.id}
+                        </div>
+                        {record.remarks ? (
+                          <div className="mt-1 line-clamp-1 text-xs text-[#667085]">
                             {record.remarks}
                           </div>
-                        )}
-                        <div className="mt-0.5 text-xs text-[#98a2b3]">
+                        ) : null}
+                        <div className="mt-1 truncate text-[11px] text-[#98a2b3]">
+                          路径：
                           {[
                             record.databaseName,
                             record.schemaName,
@@ -136,33 +154,63 @@ const RegisteredTablePanel = ({
                     ),
                   },
                   {
-                    title: '监控数',
-                    dataIndex: 'monitorCount',
-                    width: 100,
+                    title: '数据源 / 类型',
+                    width: 190,
+                    render: (_, record) => (
+                      <div className="space-y-1 py-0.5">
+                        <div className="truncate text-[#344054]">
+                          {record.dataSourceName}
+                        </div>
+                        <Tag className="!m-0 !border-0 !bg-[#f2f4f7] !text-[11px] !text-[#667085]">
+                          {record.tableType || 'TABLE'}
+                        </Tag>
+                      </div>
+                    ),
                   },
                   {
-                    title: '规则数',
-                    dataIndex: 'ruleCount',
-                    width: 100,
+                    title: '质量配置',
+                    width: 170,
+                    render: (_, record) => (
+                      <div className="grid grid-cols-2 gap-x-3 gap-y-1 text-xs">
+                        <span className="text-[#98a2b3]">监控数：</span>
+                        <span className="font-medium text-[#344054]">
+                          {record.monitorCount}
+                        </span>
+                        <span className="text-[#98a2b3]">规则数：</span>
+                        <span className="font-medium text-[#344054]">
+                          {record.ruleCount}
+                        </span>
+                      </div>
+                    ),
                   },
                   {
-                    title: '最近结果',
-                    dataIndex: 'lastResult',
-                    width: 120,
-                    render: (value) => <CheckResultTag value={value} />,
+                    title: '最近状态',
+                    width: 190,
+                    render: (_, record) => (
+                      <div className="space-y-1.5 py-0.5">
+                        <CheckResultTag value={record.lastResult} />
+                        <div className="text-[11px] text-[#98a2b3]">
+                          {record.lastRunTime || '暂无运行记录'}
+                        </div>
+                      </div>
+                    ),
                   },
                   {
-                    title: '最近运行',
-                    dataIndex: 'lastRunTime',
-                    width: 180,
-                    render: (value) => value || '--',
+                    title: '注册信息',
+                    width: 190,
+                    render: (_, record) => (
+                      <div className="space-y-1 text-xs">
+                        <div className="text-[#344054]">{record.registeredBy}</div>
+                        <div className="text-[#98a2b3]">{record.registeredAt}</div>
+                      </div>
+                    ),
                   },
                   {
                     title: '操作',
-                    width: 300,
+                    width: 280,
                     fixed: 'right',
                     render: (_, record) => (
-                      <div className="flex items-center gap-1">
+                      <div className="flex items-center gap-1 whitespace-nowrap">
                         {record.monitorId ? (
                           <>
                             <Button


### PR DESCRIPTION
## 背景

数据质量功能已经完成主要业务流程，但不同页面中的 Ant Design Table 在表头高度、单元格间距、文字颜色、悬停状态、固定操作列和空状态等方面存在差异；部分列表仍采用简单的单字段平铺方式，与离线同步列表的高密度信息展示风格不一致。

本 PR 统一数据质量模块的表格视觉规范，并重新整理重点列表的行内容。

## 公共表格规范

新增统一样式工具：

```text
yak-ops-ui/src/pages/data-quality/components/tableStyle.ts
```

统一处理：

- 表格字号与单元格垂直对齐
- 浅灰表头、固定高度、字号和字重
- 表体水平及垂直间距
- 行分割线与 Hover 背景
- 固定操作列背景及 Hover 联动
- 复选框尺寸
- 展开行背景
- 空状态高度
- 表格圆角和外边框

各页面通过 `dataQualityTableClassName()` 复用，避免继续复制较长的 Tailwind 选择器。

## 行内容优化

参考离线同步列表的设计，将相关信息组合为主次两层或指标分组展示：

### 已注册数据表

- 表名、ID、描述和完整路径合并展示
- 数据源和表类型合并展示
- 监控数和规则数归为质量配置
- 最近结果和最近运行时间合并展示
- 增加注册人和注册时间
- 操作列保持固定

### 运行记录

- 监控名称和执行编号合并展示
- 数据对象和数据源合并展示
- 通过、未通过、异常和耗时归为执行概况
- 触发人和执行时间合并展示
- 增加固定“查看”操作列

### 质量监控与规则管理

- 名称、ID、描述或字段信息采用主次结构
- 触发方式补充下一次运行时间
- 启用规则数和总规则数突出展示
- 规则重要程度、状态和质量维度使用轻量标签
- 固定操作列与表体 Hover 状态保持一致

## 覆盖范围

统一以下表格：

- 按表配置已注册数据表
- 注册数据表抽屉候选表
- 运行记录
- 执行详情规则结果
- 质量监控详情中的规则管理
- 质量监控列表
- 质量报告趋势及字段分析
- 操作日志抽屉
- 新建监控时的规则模板选择
- 规则模板库

## 测试

- 新增共享表格样式帮助方法测试
- [x] 分支基于最新 `main`，无落后提交
- [x] 所有变更仅涉及数据质量前端样式和信息布局
- [x] 后端接口、数据结构及业务行为未调整
- [ ] 仓库当前没有针对该提交运行的 GitHub Actions 工作流
- [ ] 待本地前端依赖环境执行完整 TypeScript 构建和浏览器截图确认

## 影响说明

本 PR 不修改后端，也不改变查询、保存、运行、调度和质量判断逻辑。主要目标是统一数据质量模块的表格视觉语言，提高单行信息密度和扫描效率。