### PR TITLE
fix(data-quality): normalize datetime response format

### DIFF
--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/api/QualityApi.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/api/QualityApi.java
@@ -138,7 +138,7 @@ public final class QualityApi {
       String scheduleTime,
       ScheduleWeekday scheduleWeekday,
       String cronExpression,
-      LocalDateTime nextRunTime,
+      @QualityDateTimeFormat LocalDateTime nextRunTime,
       RuleFailureAction ruleFailureAction,
       boolean notifyEnabled,
       NotifyChannel notifyChannel,
@@ -191,9 +191,9 @@ public final class QualityApi {
       int ruleCount,
       CheckResult lastResult,
       String lastExecutionNo,
-      LocalDateTime lastRunTime,
-      LocalDateTime createTime,
-      LocalDateTime updateTime) {}
+      @QualityDateTimeFormat LocalDateTime lastRunTime,
+      @QualityDateTimeFormat LocalDateTime createTime,
+      @QualityDateTimeFormat LocalDateTime updateTime) {}
 
   public record MonitorView(
       Long id,
@@ -209,9 +209,9 @@ public final class QualityApi {
       boolean enabled,
       CheckResult lastResult,
       String lastExecutionNo,
-      LocalDateTime lastRunTime,
-      LocalDateTime createTime,
-      LocalDateTime updateTime,
+      @QualityDateTimeFormat LocalDateTime lastRunTime,
+      @QualityDateTimeFormat LocalDateTime createTime,
+      @QualityDateTimeFormat LocalDateTime updateTime,
       List<RuleView> rules) {}
 
   public record MonitorPageView(
@@ -227,7 +227,7 @@ public final class QualityApi {
       int monitorCount,
       int ruleCount,
       CheckResult lastResult,
-      LocalDateTime lastRunTime) {}
+      @QualityDateTimeFormat LocalDateTime lastRunTime) {}
 
   public record TableAssetPageRequest(
       @Min(1) Integer current,
@@ -254,9 +254,9 @@ public final class QualityApi {
       int monitorCount,
       int ruleCount,
       CheckResult lastResult,
-      LocalDateTime lastRunTime,
+      @QualityDateTimeFormat LocalDateTime lastRunTime,
       String registeredBy,
-      LocalDateTime registeredAt) {}
+      @QualityDateTimeFormat LocalDateTime registeredAt) {}
 
   public record TableAssetPageView(
       List<TableAssetView> records,
@@ -335,9 +335,9 @@ public final class QualityApi {
       int failedRules,
       int errorRules,
       String operator,
-      LocalDateTime queuedAt,
-      LocalDateTime startedAt,
-      LocalDateTime finishedAt,
+      @QualityDateTimeFormat LocalDateTime queuedAt,
+      @QualityDateTimeFormat LocalDateTime startedAt,
+      @QualityDateTimeFormat LocalDateTime finishedAt,
       Long durationMs,
       String errorMessage) {}
 
@@ -357,9 +357,9 @@ public final class QualityApi {
       int failedRules,
       int errorRules,
       String operator,
-      LocalDateTime queuedAt,
-      LocalDateTime startedAt,
-      LocalDateTime finishedAt,
+      @QualityDateTimeFormat LocalDateTime queuedAt,
+      @QualityDateTimeFormat LocalDateTime startedAt,
+      @QualityDateTimeFormat LocalDateTime finishedAt,
       Long durationMs,
       String errorMessage,
       List<RuleExecutionView> rules) {}

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/api/QualityDateTimeFormat.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/api/QualityDateTimeFormat.java
@@ -1,0 +1,27 @@
+package io.yak.ops.business.quality.api;
+
+import com.fasterxml.jackson.annotation.JacksonAnnotationsInside;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Formats data-quality response timestamps to second precision.
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({
+    ElementType.FIELD,
+    ElementType.METHOD,
+    ElementType.PARAMETER,
+    ElementType.RECORD_COMPONENT
+})
+@JacksonAnnotationsInside
+@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = QualityDateTimeFormat.PATTERN)
+public @interface QualityDateTimeFormat {
+
+  String PATTERN = "yyyy-MM-dd HH:mm:ss";
+}

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/api/QualityWorkspaceApi.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/api/QualityWorkspaceApi.java
@@ -16,7 +16,7 @@ public final class QualityWorkspaceApi {
       int enabledRuleCount,
       int executionCount,
       int issueExecutionCount,
-      LocalDateTime latestExecutionTime) {
+      @QualityDateTimeFormat LocalDateTime latestExecutionTime) {
   }
 
   public record MonitorWorkspaceView(
@@ -73,7 +73,7 @@ public final class QualityWorkspaceApi {
   public record OperationLogItem(
       String id,
       String operator,
-      LocalDateTime operationTime,
+      @QualityDateTimeFormat LocalDateTime operationTime,
       String actionType,
       String content) {
   }

--- a/yak-ops-business/yak-ops-business-quality/src/test/java/io/yak/ops/business/quality/api/QualityDateTimeFormatTest.java
+++ b/yak-ops-business/yak-ops-business-quality/src/test/java/io/yak/ops/business/quality/api/QualityDateTimeFormatTest.java
@@ -1,0 +1,54 @@
+package io.yak.ops.business.quality.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import java.lang.reflect.RecordComponent;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+
+class QualityDateTimeFormatTest {
+
+  private final ObjectMapper objectMapper = new ObjectMapper()
+      .registerModule(new JavaTimeModule());
+
+  @Test
+  void serializesTimestampToSecondPrecisionWithSpaceSeparator() throws Exception {
+    QualityWorkspaceApi.WorkspaceStats stats = new QualityWorkspaceApi.WorkspaceStats(
+        3,
+        2,
+        8,
+        1,
+        LocalDateTime.of(2026, 8, 6, 18, 20, 6, 653_000_000));
+
+    String actual = objectMapper
+        .readTree(objectMapper.writeValueAsString(stats))
+        .get("latestExecutionTime")
+        .asText();
+
+    assertThat(actual).isEqualTo("2026-08-06 18:20:06");
+  }
+
+  @Test
+  void everyQualityResponseTimestampUsesTheSharedFormat() {
+    RecordComponent[] timestampComponents = Stream.concat(
+            Arrays.stream(QualityApi.class.getDeclaredClasses()),
+            Arrays.stream(QualityWorkspaceApi.class.getDeclaredClasses()))
+        .filter(Class::isRecord)
+        .flatMap(type -> Arrays.stream(type.getRecordComponents()))
+        .filter(component -> component.getType() == LocalDateTime.class)
+        .toArray(RecordComponent[]::new);
+
+    assertThat(timestampComponents)
+        .isNotEmpty()
+        .allSatisfy(component -> assertThat(
+            component.isAnnotationPresent(QualityDateTimeFormat.class))
+            .as("%s.%s should declare @QualityDateTimeFormat",
+                component.getDeclaringRecord().getSimpleName(),
+                component.getName())
+            .isTrue());
+  }
+}


### PR DESCRIPTION
## 背景

数据质量接口当前直接返回 `LocalDateTime`，Jackson 默认序列化结果类似：

```text
2026-08-06T18:20:06.653
```

前端页面希望统一为秒级时间格式：

```text
2026-08-06 18:20:06
```

## 本次调整

### 统一数据质量时间格式

新增数据质量专用注解：

```text
@QualityDateTimeFormat
```

格式固定为：

```text
yyyy-MM-dd HH:mm:ss
```

该方案只作用于数据质量对外响应模型，不修改全局 Jackson 配置，避免影响数据源、调度、安全等其他模块现有接口。

### 覆盖字段

已覆盖数据质量 API 中全部 `LocalDateTime` 响应字段，包括：

- 质量监控下一次运行时间
- 监控创建、更新和最近运行时间
- 已注册数据表注册时间和最近运行时间
- 执行排队、开始和完成时间
- 工作台最近执行时间
- 操作日志时间

### 精度处理

- 去除 ISO 时间中的 `T`
- 去除毫秒和纳秒
- 保留到秒级
- `null` 时间仍返回 `null`

## 示例

调整前：

```json
{
  "updateTime": "2026-08-06T18:20:06.653"
}
```

调整后：

```json
{
  "updateTime": "2026-08-06 18:20:06"
}
```

## 测试

新增时间格式测试：

- 验证带毫秒的 `LocalDateTime` 输出为秒级格式
- 通过反射检查 `QualityApi` 和 `QualityWorkspaceApi` 中所有 `LocalDateTime` 响应字段都使用统一注解
- 分支基于最新 `main`，无落后提交

## 影响范围

- 仅修改数据质量接口的 JSON 时间展示格式
- 不修改数据库字段和持久化精度
- 不修改时间计算、调度及查询逻辑
- 前端字段类型仍为字符串，无需同步修改