### PR TITLE
feat(data-quality): implement custom rule templates

### DIFF
--- a/yak-ops-boot/src/main/resources/yak-security/db/migration/V2002__register_custom_quality_template_permissions.sql
+++ b/yak-ops-boot/src/main/resources/yak-security/db/migration/V2002__register_custom_quality_template_permissions.sql
@@ -1,0 +1,64 @@
+-- 自定义规则模板目录与模板的写权限。
+
+INSERT INTO yak_security_permission
+(permission_code, permission_name, parent_id, leaf, level, description,
+ active, declared, menu_code, app_name)
+SELECT permissions.permission_code,
+       permissions.permission_name,
+       parent.id,
+       1,
+       2,
+       permissions.description,
+       1,
+       0,
+       NULL,
+       parent.app_name
+FROM yak_security_permission parent
+JOIN (
+    SELECT 'quality:template:create' AS permission_code,
+           '创建自定义规则模板' AS permission_name,
+           '创建自定义规则模板及模板目录' AS description
+    UNION ALL
+    SELECT 'quality:template:update',
+           '更新自定义规则模板',
+           '编辑、复制和移动自定义规则模板及模板目录'
+    UNION ALL
+    SELECT 'quality:template:delete',
+           '删除自定义规则模板',
+           '删除自定义规则模板及空目录'
+) permissions
+WHERE parent.permission_code = 'quality'
+  AND parent.app_name = '${appName}'
+  AND parent.is_delete = 0
+ON DUPLICATE KEY UPDATE
+permission_name = VALUES(permission_name),
+parent_id = VALUES(parent_id),
+leaf = VALUES(leaf),
+level = VALUES(level),
+description = VALUES(description),
+active = VALUES(active),
+declared = VALUES(declared),
+is_delete = 0;
+
+-- root 角色始终获得新增权限。
+INSERT INTO yak_security_role_permission(role_id, permission_id, app_name)
+SELECT DISTINCT root_permission.role_id,
+                quality_permission.id,
+                root_permission.app_name
+FROM yak_security_role_permission root_permission
+JOIN yak_security_permission root_row
+  ON root_row.id = root_permission.permission_id
+ AND root_row.permission_code = 'security:root'
+ AND root_row.app_name = root_permission.app_name
+ AND root_row.is_delete = 0
+JOIN yak_security_permission quality_permission
+  ON quality_permission.permission_code IN (
+      'quality:template:create',
+      'quality:template:update',
+      'quality:template:delete')
+ AND quality_permission.app_name = root_permission.app_name
+ AND quality_permission.is_delete = 0
+ AND quality_permission.active = 1
+WHERE root_permission.app_name = '${appName}'
+  AND root_permission.is_delete = 0
+ON DUPLICATE KEY UPDATE is_delete = 0;

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/QualityPermissionCode.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/QualityPermissionCode.java
@@ -3,6 +3,9 @@ package io.yak.ops.business.quality;
 public final class QualityPermissionCode {
 
   public static final String TEMPLATE_READ = "quality:template:read";
+  public static final String TEMPLATE_CREATE = "quality:template:create";
+  public static final String TEMPLATE_UPDATE = "quality:template:update";
+  public static final String TEMPLATE_DELETE = "quality:template:delete";
   public static final String MONITOR_READ = "quality:monitor:read";
   public static final String MONITOR_CREATE = "quality:monitor:create";
   public static final String MONITOR_UPDATE = "quality:monitor:update";

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/api/CustomTemplateApi.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/api/CustomTemplateApi.java
@@ -41,8 +41,8 @@ public final class CustomTemplateApi {
       CheckType checkType,
       CheckMethod checkMethod,
       String createdBy,
-      LocalDateTime createdAt,
-      LocalDateTime updatedAt) {}
+      @QualityDateTimeFormat LocalDateTime createdAt,
+      @QualityDateTimeFormat LocalDateTime updatedAt) {}
 
   public record Summary(
       long total,
@@ -59,8 +59,8 @@ public final class CustomTemplateApi {
       int sortOrder,
       long templateCount,
       long childCount,
-      LocalDateTime createdAt,
-      LocalDateTime updatedAt) {}
+      @QualityDateTimeFormat LocalDateTime createdAt,
+      @QualityDateTimeFormat LocalDateTime updatedAt) {}
 
   public record SaveFolderRequest(
       @NotBlank @Size(max = 100) String name,

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/api/CustomTemplateApi.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/api/CustomTemplateApi.java
@@ -1,0 +1,85 @@
+package io.yak.ops.business.quality.api;
+
+import io.yak.ops.business.quality.api.QualityApi.ComparisonOperator;
+import io.yak.ops.business.quality.api.QualityApi.RuleScope;
+import io.yak.ops.business.quality.api.QualityApi.RuleType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+public final class CustomTemplateApi {
+
+  private CustomTemplateApi() {
+  }
+
+  public enum CheckType { NUMERIC }
+  public enum CheckMethod { FIXED_VALUE }
+
+  public record Query(String keyword, String dimension, Long folderId) {}
+
+  public record TemplateView(
+      Long id,
+      String code,
+      String name,
+      String description,
+      RuleType ruleType,
+      RuleScope scope,
+      String dimension,
+      String parameterSchema,
+      boolean builtin,
+      boolean enabled,
+      long ruleCount,
+      int sortOrder,
+      Long folderId,
+      String folderName,
+      String templateSql,
+      String setFlag,
+      CheckType checkType,
+      CheckMethod checkMethod,
+      String createdBy,
+      LocalDateTime createdAt,
+      LocalDateTime updatedAt) {}
+
+  public record Summary(
+      long total,
+      long systemTotal,
+      long customTotal,
+      Map<String, Long> dimensions) {}
+
+  public record ListView(List<TemplateView> records, Summary summary) {}
+
+  public record FolderView(
+      Long id,
+      Long parentId,
+      String name,
+      int sortOrder,
+      long templateCount,
+      long childCount,
+      LocalDateTime createdAt,
+      LocalDateTime updatedAt) {}
+
+  public record SaveFolderRequest(
+      @NotBlank @Size(max = 100) String name,
+      Long parentId) {}
+
+  public record SaveTemplateRequest(
+      @NotBlank @Size(max = 100) String name,
+      @Size(max = 500) String description,
+      @NotBlank @Size(max = 40) String dimension,
+      Long folderId,
+      @Size(max = 1000) String setFlag,
+      CheckType checkType,
+      CheckMethod checkMethod,
+      @NotBlank @Size(max = 20000) String customSql,
+      ComparisonOperator defaultOperator,
+      @NotNull BigDecimal defaultThreshold,
+      BigDecimal defaultThresholdEnd) {}
+
+  public record CopyTemplateRequest(
+      @NotBlank @Size(max = 100) String name,
+      Long folderId) {}
+}

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/api/QualityDateTimeFormat.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/api/QualityDateTimeFormat.java
@@ -1,0 +1,27 @@
+package io.yak.ops.business.quality.api;
+
+import com.fasterxml.jackson.annotation.JacksonAnnotationsInside;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Formats data-quality response timestamps to second precision.
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({
+    ElementType.FIELD,
+    ElementType.METHOD,
+    ElementType.PARAMETER,
+    ElementType.RECORD_COMPONENT
+})
+@JacksonAnnotationsInside
+@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = QualityDateTimeFormat.PATTERN)
+public @interface QualityDateTimeFormat {
+
+  String PATTERN = "yyyy-MM-dd HH:mm:ss";
+}

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/controller/v1/CustomTemplateController.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/controller/v1/CustomTemplateController.java
@@ -1,0 +1,133 @@
+package io.yak.ops.business.quality.controller.v1;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.yak.framework.common.Result;
+import io.yak.framework.security.web.RequiresPermission;
+import io.yak.ops.business.quality.QualityPermissionCode;
+import io.yak.ops.business.quality.api.CustomTemplateApi.CopyTemplateRequest;
+import io.yak.ops.business.quality.api.CustomTemplateApi.FolderView;
+import io.yak.ops.business.quality.api.CustomTemplateApi.ListView;
+import io.yak.ops.business.quality.api.CustomTemplateApi.Query;
+import io.yak.ops.business.quality.api.CustomTemplateApi.SaveFolderRequest;
+import io.yak.ops.business.quality.api.CustomTemplateApi.SaveTemplateRequest;
+import io.yak.ops.business.quality.api.CustomTemplateApi.TemplateView;
+import io.yak.ops.business.quality.config.ConditionalOnQualityEnabled;
+import io.yak.ops.business.quality.service.CustomTemplateService;
+import jakarta.validation.Valid;
+import java.security.Principal;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "数据质量自定义规则模板")
+@RestController
+@ConditionalOnQualityEnabled
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/data-quality/template")
+@RequiresPermission(QualityPermissionCode.TEMPLATE_READ)
+public class CustomTemplateController {
+
+  private final CustomTemplateService service;
+
+  @Operation(summary = "查询自定义规则模板")
+  @GetMapping("/custom")
+  public Result<ListView> list(
+      @RequestParam(value = "keyword", required = false) String keyword,
+      @RequestParam(value = "dimension", required = false) String dimension,
+      @RequestParam(value = "folderId", required = false) Long folderId) {
+    return Result.success(service.list(new Query(keyword, dimension, folderId)));
+  }
+
+  @Operation(summary = "查询自定义规则模板详情")
+  @GetMapping("/custom/{id}")
+  public Result<TemplateView> detail(@PathVariable long id) {
+    return Result.success(service.get(id));
+  }
+
+  @Operation(summary = "查询自定义模板目录")
+  @GetMapping("/folder")
+  public Result<List<FolderView>> folders() {
+    return Result.success(service.folders());
+  }
+
+  @Operation(summary = "创建自定义模板目录")
+  @PostMapping("/folder")
+  @RequiresPermission(QualityPermissionCode.TEMPLATE_CREATE)
+  public Result<FolderView> createFolder(
+      @Valid @RequestBody SaveFolderRequest request,
+      Principal principal) {
+    return Result.success(service.createFolder(request, operator(principal)));
+  }
+
+  @Operation(summary = "更新自定义模板目录")
+  @PutMapping("/folder/{id}")
+  @RequiresPermission(QualityPermissionCode.TEMPLATE_UPDATE)
+  public Result<FolderView> updateFolder(
+      @PathVariable long id,
+      @Valid @RequestBody SaveFolderRequest request,
+      Principal principal) {
+    return Result.success(service.updateFolder(id, request, operator(principal)));
+  }
+
+  @Operation(summary = "删除自定义模板目录")
+  @DeleteMapping("/folder/{id}")
+  @RequiresPermission(QualityPermissionCode.TEMPLATE_DELETE)
+  public Result<Boolean> deleteFolder(
+      @PathVariable long id,
+      Principal principal) {
+    return Result.success(service.deleteFolder(id, operator(principal)));
+  }
+
+  @Operation(summary = "创建自定义规则模板")
+  @PostMapping("/custom")
+  @RequiresPermission(QualityPermissionCode.TEMPLATE_CREATE)
+  public Result<TemplateView> create(
+      @Valid @RequestBody SaveTemplateRequest request,
+      Principal principal) {
+    return Result.success(service.create(request, operator(principal)));
+  }
+
+  @Operation(summary = "更新自定义规则模板")
+  @PutMapping("/custom/{id}")
+  @RequiresPermission(QualityPermissionCode.TEMPLATE_UPDATE)
+  public Result<TemplateView> update(
+      @PathVariable long id,
+      @Valid @RequestBody SaveTemplateRequest request,
+      Principal principal) {
+    return Result.success(service.update(id, request, operator(principal)));
+  }
+
+  @Operation(summary = "复制自定义规则模板")
+  @PostMapping("/custom/{id}/copy")
+  @RequiresPermission(QualityPermissionCode.TEMPLATE_CREATE)
+  public Result<TemplateView> copy(
+      @PathVariable long id,
+      @Valid @RequestBody CopyTemplateRequest request,
+      Principal principal) {
+    return Result.success(service.copy(id, request, operator(principal)));
+  }
+
+  @Operation(summary = "删除自定义规则模板")
+  @DeleteMapping("/custom/{id}")
+  @RequiresPermission(QualityPermissionCode.TEMPLATE_DELETE)
+  public Result<Boolean> delete(@PathVariable long id) {
+    return Result.success(service.delete(id));
+  }
+
+  private static String operator(Principal principal) {
+    return principal == null
+            || principal.getName() == null
+            || principal.getName().isBlank()
+        ? "system"
+        : principal.getName();
+  }
+}

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/controller/v1/QualityExceptionHandler.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/controller/v1/QualityExceptionHandler.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @ConditionalOnQualityEnabled
 @RestControllerAdvice(assignableTypes = {
     QualityTemplateController.class,
+    CustomTemplateController.class,
     QualityMonitorController.class,
     QualityExecutionController.class
 })
@@ -22,6 +23,8 @@ public class QualityExceptionHandler {
     String message = exception.getMessage();
     HttpStatus status = message != null
             && (message.startsWith("规则模板不存在")
+                || message.startsWith("自定义规则模板不存在")
+                || message.startsWith("规则模板目录不存在")
                 || message.startsWith("质量监控不存在")
                 || message.startsWith("质量执行记录不存在"))
         ? HttpStatus.NOT_FOUND

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/repository/CustomTemplateRepository.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/repository/CustomTemplateRepository.java
@@ -1,0 +1,323 @@
+package io.yak.ops.business.quality.repository;
+
+import io.yak.ops.business.quality.api.CustomTemplateApi.CheckMethod;
+import io.yak.ops.business.quality.api.CustomTemplateApi.CheckType;
+import io.yak.ops.business.quality.api.CustomTemplateApi.FolderView;
+import io.yak.ops.business.quality.api.CustomTemplateApi.Query;
+import io.yak.ops.business.quality.api.CustomTemplateApi.TemplateView;
+import io.yak.ops.business.quality.api.QualityApi.RuleScope;
+import io.yak.ops.business.quality.api.QualityApi.RuleType;
+import io.yak.ops.business.quality.config.ConditionalOnQualityEnabled;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.support.GeneratedKeyHolder;
+import org.springframework.jdbc.support.KeyHolder;
+import org.springframework.stereotype.Repository;
+
+@ConditionalOnQualityEnabled
+@Repository
+public class CustomTemplateRepository {
+
+  private static final String SELECT = """
+      SELECT t.id, t.template_code, t.template_name, t.description,
+             t.rule_type, t.rule_scope, t.quality_dimension,
+             t.parameter_schema_json, t.builtin, t.enabled, t.sort_order,
+             t.folder_id, f.folder_name, t.template_sql, t.set_flag,
+             t.check_type, t.check_method, t.created_by,
+             t.created_at, t.updated_at,
+             COUNT(r.id) AS rule_count
+      FROM yak_quality_rule_template t
+      LEFT JOIN yak_quality_template_folder f
+        ON f.id = t.folder_id AND f.deleted = 0
+      LEFT JOIN yak_quality_rule r
+        ON r.template_id = t.id AND r.deleted = 0
+      """;
+
+  private static final String GROUP_BY = """
+       GROUP BY t.id, t.template_code, t.template_name, t.description,
+                t.rule_type, t.rule_scope, t.quality_dimension,
+                t.parameter_schema_json, t.builtin, t.enabled, t.sort_order,
+                t.folder_id, f.folder_name, t.template_sql, t.set_flag,
+                t.check_type, t.check_method, t.created_by,
+                t.created_at, t.updated_at
+      """;
+
+  private final NamedParameterJdbcTemplate jdbcTemplate;
+  private final RowMapper<TemplateView> templateMapper = this::mapTemplate;
+  private final RowMapper<FolderView> folderMapper = this::mapFolder;
+
+  public CustomTemplateRepository(
+      @Qualifier("qualityJdbcTemplate") NamedParameterJdbcTemplate jdbcTemplate) {
+    this.jdbcTemplate = jdbcTemplate;
+  }
+
+  public List<TemplateView> list(Query query) {
+    Query normalized = query == null ? new Query(null, null, null) : query;
+    StringBuilder where = new StringBuilder(
+        " WHERE t.builtin = 0 AND t.enabled = 1 AND t.deleted = 0");
+    MapSqlParameterSource params = new MapSqlParameterSource();
+    if (hasText(normalized.keyword())) {
+      where.append(" AND (LOWER(t.template_name) LIKE :keyword"
+          + " OR LOWER(t.template_code) LIKE :keyword"
+          + " OR LOWER(COALESCE(t.description, '')) LIKE :keyword)");
+      params.addValue("keyword", "%" + normalized.keyword().trim().toLowerCase() + "%");
+    }
+    if (hasText(normalized.dimension())) {
+      where.append(" AND t.quality_dimension = :dimension");
+      params.addValue("dimension", normalized.dimension().trim());
+    }
+    if (normalized.folderId() != null) {
+      if (normalized.folderId() == 0L) {
+        where.append(" AND t.folder_id IS NULL");
+      } else {
+        where.append(" AND t.folder_id = :folderId");
+        params.addValue("folderId", normalized.folderId());
+      }
+    }
+    return jdbcTemplate.query(
+        SELECT + where + GROUP_BY
+            + " ORDER BY t.sort_order ASC, t.updated_at DESC, t.id ASC",
+        params,
+        templateMapper);
+  }
+
+  public List<TemplateView> listAllCustom() {
+    return list(new Query(null, null, null));
+  }
+
+  public long countSystem() {
+    Long value = jdbcTemplate.queryForObject(
+        "SELECT COUNT(*) FROM yak_quality_rule_template WHERE builtin = 1 AND enabled = 1",
+        new MapSqlParameterSource(),
+        Long.class);
+    return value == null ? 0L : value;
+  }
+
+  public Optional<TemplateView> find(long id) {
+    try {
+      return Optional.ofNullable(jdbcTemplate.queryForObject(
+          SELECT + " WHERE t.id = :id AND t.builtin = 0" + GROUP_BY,
+          new MapSqlParameterSource("id", id),
+          templateMapper));
+    } catch (EmptyResultDataAccessException ignored) {
+      return Optional.empty();
+    }
+  }
+
+  public List<FolderView> listFolders() {
+    String sql = """
+        SELECT f.id, f.parent_id, f.folder_name, f.sort_order,
+               COUNT(DISTINCT t.id) AS template_count,
+               COUNT(DISTINCT child.id) AS child_count,
+               f.created_at, f.updated_at
+        FROM yak_quality_template_folder f
+        LEFT JOIN yak_quality_rule_template t
+          ON t.folder_id = f.id AND t.builtin = 0 AND t.deleted = 0 AND t.enabled = 1
+        LEFT JOIN yak_quality_template_folder child
+          ON child.parent_id = f.id AND child.deleted = 0
+        WHERE f.deleted = 0
+        GROUP BY f.id, f.parent_id, f.folder_name, f.sort_order,
+                 f.created_at, f.updated_at
+        ORDER BY f.sort_order ASC, f.folder_name ASC, f.id ASC
+        """;
+    return jdbcTemplate.query(sql, new MapSqlParameterSource(), folderMapper);
+  }
+
+  public Optional<FolderView> findFolder(long id) {
+    return listFolders().stream().filter(folder -> folder.id() == id).findFirst();
+  }
+
+  public boolean folderNameExists(Long parentId, String name, Long excludeId) {
+    Integer count = jdbcTemplate.queryForObject(
+        """
+        SELECT COUNT(*) FROM yak_quality_template_folder
+        WHERE deleted = 0 AND LOWER(folder_name) = LOWER(:name)
+          AND ((:parentId IS NULL AND parent_id IS NULL) OR parent_id = :parentId)
+          AND (:excludeId IS NULL OR id <> :excludeId)
+        """,
+        new MapSqlParameterSource().addValue("name", name)
+            .addValue("parentId", parentId).addValue("excludeId", excludeId),
+        Integer.class);
+    return count != null && count > 0;
+  }
+
+  public long insertFolder(FolderWrite write) {
+    KeyHolder keyHolder = new GeneratedKeyHolder();
+    jdbcTemplate.update(
+        """
+        INSERT INTO yak_quality_template_folder
+        (parent_id, folder_name, sort_order, created_by, updated_by)
+        VALUES (:parentId, :name, 10, :operator, :operator)
+        """,
+        new MapSqlParameterSource().addValue("parentId", write.parentId())
+            .addValue("name", write.name()).addValue("operator", write.operator()),
+        keyHolder,
+        new String[]{"id"});
+    return requiredKey(keyHolder, "创建规则模板目录失败");
+  }
+
+  public boolean updateFolder(long id, FolderWrite write) {
+    return jdbcTemplate.update(
+        """
+        UPDATE yak_quality_template_folder
+        SET parent_id = :parentId, folder_name = :name,
+            updated_by = :operator, updated_at = CURRENT_TIMESTAMP(3)
+        WHERE id = :id AND deleted = 0
+        """,
+        new MapSqlParameterSource("id", id).addValue("parentId", write.parentId())
+            .addValue("name", write.name()).addValue("operator", write.operator())) > 0;
+  }
+
+  public boolean deleteFolder(long id, String operator) {
+    return jdbcTemplate.update(
+        """
+        UPDATE yak_quality_template_folder
+        SET deleted = 1, updated_by = :operator, updated_at = CURRENT_TIMESTAMP(3)
+        WHERE id = :id AND deleted = 0
+        """,
+        new MapSqlParameterSource("id", id).addValue("operator", operator)) > 0;
+  }
+
+  public boolean templateNameExists(Long folderId, String name, Long excludeId) {
+    Integer count = jdbcTemplate.queryForObject(
+        """
+        SELECT COUNT(*) FROM yak_quality_rule_template
+        WHERE builtin = 0 AND deleted = 0
+          AND LOWER(template_name) = LOWER(:name)
+          AND ((:folderId IS NULL AND folder_id IS NULL) OR folder_id = :folderId)
+          AND (:excludeId IS NULL OR id <> :excludeId)
+        """,
+        new MapSqlParameterSource().addValue("name", name)
+            .addValue("folderId", folderId).addValue("excludeId", excludeId),
+        Integer.class);
+    return count != null && count > 0;
+  }
+
+  public long insertTemplate(TemplateWrite write) {
+    KeyHolder keyHolder = new GeneratedKeyHolder();
+    jdbcTemplate.update(
+        """
+        INSERT INTO yak_quality_rule_template
+        (template_code, template_name, description, rule_type, rule_scope,
+         quality_dimension, parameter_schema_json, builtin, enabled, sort_order,
+         folder_id, template_sql, set_flag, check_type, check_method, created_by, deleted)
+        VALUES
+        (:code, :name, :description, 'CUSTOM_SQL', 'TABLE',
+         :dimension, :parameterSchema, 0, 1, 1000,
+         :folderId, :templateSql, :setFlag, :checkType, :checkMethod, :operator, 0)
+        """,
+        templateParameters(write),
+        keyHolder,
+        new String[]{"id"});
+    return requiredKey(keyHolder, "创建自定义规则模板失败");
+  }
+
+  public boolean updateTemplate(long id, TemplateWrite write) {
+    return jdbcTemplate.update(
+        """
+        UPDATE yak_quality_rule_template
+        SET template_name = :name, description = :description,
+            quality_dimension = :dimension, parameter_schema_json = :parameterSchema,
+            folder_id = :folderId, template_sql = :templateSql, set_flag = :setFlag,
+            check_type = :checkType, check_method = :checkMethod,
+            updated_at = CURRENT_TIMESTAMP(3)
+        WHERE id = :id AND builtin = 0 AND deleted = 0
+        """,
+        templateParameters(write).addValue("id", id)) > 0;
+  }
+
+  public boolean deleteTemplate(long id) {
+    return jdbcTemplate.update(
+        """
+        UPDATE yak_quality_rule_template
+        SET enabled = 0, deleted = 1, updated_at = CURRENT_TIMESTAMP(3)
+        WHERE id = :id AND builtin = 0 AND deleted = 0
+        """,
+        new MapSqlParameterSource("id", id)) > 0;
+  }
+
+  private MapSqlParameterSource templateParameters(TemplateWrite write) {
+    return new MapSqlParameterSource().addValue("code", write.code())
+        .addValue("name", write.name()).addValue("description", write.description())
+        .addValue("dimension", write.dimension())
+        .addValue("parameterSchema", write.parameterSchema())
+        .addValue("folderId", write.folderId()).addValue("templateSql", write.templateSql())
+        .addValue("setFlag", write.setFlag()).addValue("checkType", write.checkType().name())
+        .addValue("checkMethod", write.checkMethod().name())
+        .addValue("operator", write.operator());
+  }
+
+  private TemplateView mapTemplate(ResultSet rs, int rowNum) throws SQLException {
+    return new TemplateView(
+        rs.getLong("id"), rs.getString("template_code"), rs.getString("template_name"),
+        rs.getString("description"), RuleType.valueOf(rs.getString("rule_type")),
+        RuleScope.valueOf(rs.getString("rule_scope")), rs.getString("quality_dimension"),
+        rs.getString("parameter_schema_json"), rs.getBoolean("builtin"),
+        rs.getBoolean("enabled"), rs.getLong("rule_count"), rs.getInt("sort_order"),
+        nullableLong(rs, "folder_id"), rs.getString("folder_name"),
+        rs.getString("template_sql"), rs.getString("set_flag"),
+        enumValue(CheckType.class, rs.getString("check_type"), CheckType.NUMERIC),
+        enumValue(CheckMethod.class, rs.getString("check_method"), CheckMethod.FIXED_VALUE),
+        rs.getString("created_by"), timestamp(rs, "created_at"), timestamp(rs, "updated_at"));
+  }
+
+  private FolderView mapFolder(ResultSet rs, int rowNum) throws SQLException {
+    return new FolderView(
+        rs.getLong("id"), nullableLong(rs, "parent_id"), rs.getString("folder_name"),
+        rs.getInt("sort_order"), rs.getLong("template_count"), rs.getLong("child_count"),
+        timestamp(rs, "created_at"), timestamp(rs, "updated_at"));
+  }
+
+  private static long requiredKey(KeyHolder keyHolder, String message) {
+    Number key = keyHolder.getKey();
+    if (key == null) {
+      throw new IllegalStateException(message + "：未返回编号");
+    }
+    return key.longValue();
+  }
+
+  private static Long nullableLong(ResultSet rs, String column) throws SQLException {
+    Number value = (Number) rs.getObject(column);
+    return value == null ? null : value.longValue();
+  }
+
+  private static java.time.LocalDateTime timestamp(ResultSet rs, String column)
+      throws SQLException {
+    Timestamp value = rs.getTimestamp(column);
+    return value == null ? null : value.toLocalDateTime();
+  }
+
+  private static <T extends Enum<T>> T enumValue(
+      Class<T> type,
+      String value,
+      T fallback) {
+    return value == null || value.isBlank() ? fallback : Enum.valueOf(type, value);
+  }
+
+  private static boolean hasText(String value) {
+    return value != null && !value.isBlank();
+  }
+
+  public record FolderWrite(Long parentId, String name, String operator) {}
+
+  public record TemplateWrite(
+      String code,
+      String name,
+      String description,
+      String dimension,
+      String parameterSchema,
+      Long folderId,
+      String templateSql,
+      String setFlag,
+      CheckType checkType,
+      CheckMethod checkMethod,
+      String operator) {}
+}

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/repository/QualityTemplateRepository.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/repository/QualityTemplateRepository.java
@@ -72,7 +72,7 @@ class QualityTemplateRepository {
     try {
       return Optional.ofNullable(jdbcTemplate.queryForObject(
           SELECT
-              + " WHERE t.id = :id AND t.enabled = 1"
+              + " WHERE t.id = :id"
               + GROUP_BY,
           new MapSqlParameterSource("id", id),
           mapper));

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/service/CustomTemplateService.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/service/CustomTemplateService.java
@@ -1,0 +1,274 @@
+package io.yak.ops.business.quality.service;
+
+import io.yak.ops.business.quality.api.CustomTemplateApi.*;
+import io.yak.ops.business.quality.api.QualityApi.ComparisonOperator;
+import io.yak.ops.business.quality.config.ConditionalOnQualityEnabled;
+import io.yak.ops.business.quality.repository.CustomTemplateRepository;
+import io.yak.ops.business.quality.repository.CustomTemplateRepository.FolderWrite;
+import io.yak.ops.business.quality.repository.CustomTemplateRepository.TemplateWrite;
+import java.math.BigDecimal;
+import java.util.*;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@ConditionalOnQualityEnabled
+@Service
+public class CustomTemplateService {
+
+  private final CustomTemplateRepository repository;
+
+  public CustomTemplateService(CustomTemplateRepository repository) {
+    this.repository = repository;
+  }
+
+  @Transactional(readOnly = true, transactionManager = "yakBusinessTransactionManager")
+  public ListView list(Query query) {
+    Query value = query == null ? new Query(null, null, null)
+        : new Query(text(query.keyword()), text(query.dimension()), folderId(query.folderId()));
+    List<TemplateView> all = repository.listAllCustom();
+    List<TemplateView> scope = repository.list(new Query(null, null, value.folderId()));
+    Map<String, Long> dimensions = new LinkedHashMap<>();
+    scope.forEach(template -> dimensions.merge(template.dimension(), 1L, Long::sum));
+    return new ListView(repository.list(value),
+        new Summary(scope.size(), repository.countSystem(), all.size(), dimensions));
+  }
+
+  @Transactional(readOnly = true, transactionManager = "yakBusinessTransactionManager")
+  public TemplateView get(long id) {
+    return repository.find(id)
+        .orElseThrow(() -> new IllegalArgumentException("自定义规则模板不存在：" + id));
+  }
+
+  @Transactional(readOnly = true, transactionManager = "yakBusinessTransactionManager")
+  public List<FolderView> folders() {
+    return repository.listFolders();
+  }
+
+  @Transactional(transactionManager = "yakBusinessTransactionManager")
+  public FolderView createFolder(SaveFolderRequest request, String operator) {
+    Long parentId = folderId(request.parentId());
+    validateParent(parentId, null);
+    uniqueFolder(parentId, request.name().trim(), null);
+    return folder(repository.insertFolder(
+        new FolderWrite(parentId, request.name().trim(), operator(operator))));
+  }
+
+  @Transactional(transactionManager = "yakBusinessTransactionManager")
+  public FolderView updateFolder(long id, SaveFolderRequest request, String operator) {
+    folder(id);
+    Long parentId = folderId(request.parentId());
+    validateParent(parentId, id);
+    uniqueFolder(parentId, request.name().trim(), id);
+    if (!repository.updateFolder(id,
+        new FolderWrite(parentId, request.name().trim(), operator(operator)))) {
+      throw new IllegalArgumentException("规则模板目录不存在：" + id);
+    }
+    return folder(id);
+  }
+
+  @Transactional(transactionManager = "yakBusinessTransactionManager")
+  public boolean deleteFolder(long id, String operator) {
+    FolderView value = folder(id);
+    if (value.childCount() > 0) {
+      throw new IllegalStateException("当前目录包含子目录，请先删除或移动子目录");
+    }
+    if (value.templateCount() > 0) {
+      throw new IllegalStateException("当前目录包含自定义模板，请先删除或移动模板");
+    }
+    if (!repository.deleteFolder(id, operator(operator))) {
+      throw new IllegalArgumentException("规则模板目录不存在：" + id);
+    }
+    return true;
+  }
+
+  @Transactional(transactionManager = "yakBusinessTransactionManager")
+  public TemplateView create(SaveTemplateRequest request, String operator) {
+    Long folderId = folderId(request.folderId());
+    validateFolder(folderId);
+    uniqueTemplate(folderId, request.name().trim(), null);
+    return get(repository.insertTemplate(
+        write(code(), request, folderId, operator(operator))));
+  }
+
+  @Transactional(transactionManager = "yakBusinessTransactionManager")
+  public TemplateView update(long id, SaveTemplateRequest request, String operator) {
+    TemplateView existing = get(id);
+    Long folderId = folderId(request.folderId());
+    validateFolder(folderId);
+    uniqueTemplate(folderId, request.name().trim(), id);
+    if (!repository.updateTemplate(id,
+        write(existing.code(), request, folderId, operator(operator)))) {
+      throw new IllegalArgumentException("自定义规则模板不存在：" + id);
+    }
+    return get(id);
+  }
+
+  @Transactional(transactionManager = "yakBusinessTransactionManager")
+  public TemplateView copy(long id, CopyTemplateRequest request, String operator) {
+    TemplateView source = get(id);
+    Long folderId = folderId(request.folderId());
+    validateFolder(folderId);
+    uniqueTemplate(folderId, request.name().trim(), null);
+    long copiedId = repository.insertTemplate(new TemplateWrite(
+        code(), request.name().trim(), source.description(), source.dimension(),
+        source.parameterSchema(), folderId, source.templateSql(), source.setFlag(),
+        source.checkType(), source.checkMethod(), operator(operator)));
+    return get(copiedId);
+  }
+
+  @Transactional(transactionManager = "yakBusinessTransactionManager")
+  public boolean delete(long id) {
+    get(id);
+    if (!repository.deleteTemplate(id)) {
+      throw new IllegalArgumentException("自定义规则模板不存在：" + id);
+    }
+    return true;
+  }
+
+  private TemplateWrite write(String code, SaveTemplateRequest request,
+      Long folderId, String operator) {
+    CheckType type = request.checkType() == null
+        ? CheckType.NUMERIC : request.checkType();
+    CheckMethod method = request.checkMethod() == null
+        ? CheckMethod.FIXED_VALUE : request.checkMethod();
+    if (type != CheckType.NUMERIC || method != CheckMethod.FIXED_VALUE) {
+      throw new IllegalArgumentException("当前版本仅支持数值型自定义 SQL 与固定值比较");
+    }
+    ComparisonOperator comparison = request.defaultOperator() == null
+        ? ComparisonOperator.EQ : request.defaultOperator();
+    BigDecimal threshold = request.defaultThreshold();
+    if (threshold == null) {
+      throw new IllegalArgumentException("默认阈值不能为空");
+    }
+    if (comparison == ComparisonOperator.BETWEEN
+        && request.defaultThresholdEnd() == null) {
+      throw new IllegalArgumentException("区间比较必须填写默认最大值");
+    }
+    String sql = sql(request.customSql());
+    return new TemplateWrite(code, request.name().trim(), text(request.description()),
+        request.dimension().trim(), schema(comparison, threshold,
+        request.defaultThresholdEnd(), sql), folderId, sql, flags(request.setFlag()),
+        type, method, operator);
+  }
+
+  private String schema(ComparisonOperator operator, BigDecimal threshold,
+      BigDecimal end, String sql) {
+    String fields = operator == ComparisonOperator.BETWEEN
+        ? "[\"customSql\",\"operator\",\"threshold\",\"thresholdEnd\"]"
+        : "[\"customSql\",\"operator\",\"threshold\"]";
+    StringBuilder json = new StringBuilder("{\"fields\":").append(fields)
+        .append(",\"defaultOperator\":\"").append(operator.name())
+        .append("\",\"defaultThreshold\":").append(number(threshold));
+    if (end != null) {
+      json.append(",\"defaultThresholdEnd\":").append(number(end));
+    }
+    return json.append(",\"defaultSql\":\"")
+        .append(escape(sql)).append("\"}").toString();
+  }
+
+  private String sql(String value) {
+    String sql = text(value);
+    if (sql == null) {
+      throw new IllegalArgumentException("自定义 SQL 不能为空");
+    }
+    if (sql.endsWith(";")) {
+      sql = sql.substring(0, sql.length() - 1).trim();
+    }
+    sql = sql.replace("${tableName}", "${table}");
+    if (!sql.regionMatches(true, 0, "SELECT", 0, 6)
+        || sql.contains(";") || sql.contains("--") || sql.contains("/*")) {
+      throw new IllegalArgumentException("自定义 SQL 仅允许执行单条只读 SELECT 查询");
+    }
+    return sql;
+  }
+
+  private String flags(String value) {
+    String flags = text(value);
+    if (flags == null) {
+      return null;
+    }
+    if (flags.contains(";")) {
+      throw new IllegalArgumentException(
+          "Set Flag 多条语句请使用英文逗号分隔，不要填写分号");
+    }
+    String result = String.join(",", Arrays.stream(flags.split(","))
+        .map(String::trim).filter(item -> !item.isEmpty()).toList());
+    return result.isEmpty() ? null : result;
+  }
+
+  private void validateParent(Long parentId, Long currentId) {
+    if (parentId == null) {
+      return;
+    }
+    if (parentId.equals(currentId)) {
+      throw new IllegalArgumentException("规则模板目录不能选择自身作为上级目录");
+    }
+    folder(parentId);
+    if (currentId == null) {
+      return;
+    }
+    Map<Long, Long> parents = new HashMap<>();
+    repository.listFolders().forEach(
+        value -> parents.put(value.id(), value.parentId()));
+    for (Long cursor = parentId; cursor != null; cursor = parents.get(cursor)) {
+      if (cursor.equals(currentId)) {
+        throw new IllegalArgumentException("规则模板目录不能移动到自己的子目录中");
+      }
+    }
+  }
+
+  private void validateFolder(Long id) {
+    if (id != null) {
+      folder(id);
+    }
+  }
+
+  private FolderView folder(long id) {
+    return repository.findFolder(id)
+        .orElseThrow(() -> new IllegalArgumentException("规则模板目录不存在：" + id));
+  }
+
+  private void uniqueFolder(Long parent, String name, Long exclude) {
+    if (repository.folderNameExists(parent, name, exclude)) {
+      throw new IllegalStateException(
+          "同级目录下已经存在名称为“" + name + "”的目录");
+    }
+  }
+
+  private void uniqueTemplate(Long folder, String name, Long exclude) {
+    if (repository.templateNameExists(folder, name, exclude)) {
+      throw new IllegalStateException(
+          "当前目录下已经存在名称为“" + name + "”的规则模板");
+    }
+  }
+
+  private static String code() {
+    return "CUSTOM_SQL_"
+        + UUID.randomUUID().toString().replace("-", "").toUpperCase();
+  }
+
+  private static String number(BigDecimal value) {
+    return value.stripTrailingZeros().toPlainString();
+  }
+
+  private static String escape(String value) {
+    return value.replace("\\", "\\\\").replace("\"", "\\\"")
+        .replace("\r", "\\r").replace("\n", "\\n");
+  }
+
+  private static Long folderId(Long value) {
+    return value == null || value <= 0 ? null : value;
+  }
+
+  private static String operator(String value) {
+    return value == null || value.isBlank() ? "system" : value.trim();
+  }
+
+  private static String text(String value) {
+    if (value == null) {
+      return null;
+    }
+    String result = value.trim();
+    return result.isEmpty() ? null : result;
+  }
+}

--- a/yak-ops-business/yak-ops-business-quality/src/main/resources/db/migration/yak-quality/V4__add_custom_rule_templates.sql
+++ b/yak-ops-business/yak-ops-business-quality/src/main/resources/db/migration/yak-quality/V4__add_custom_rule_templates.sql
@@ -1,0 +1,38 @@
+CREATE TABLE IF NOT EXISTS yak_quality_template_folder (
+    id BIGINT NOT NULL AUTO_INCREMENT COMMENT '自定义规则模板目录 ID',
+    parent_id BIGINT NULL COMMENT '上级目录 ID，NULL 表示根目录',
+    folder_name VARCHAR(100) NOT NULL COMMENT '目录名称',
+    sort_order INT NOT NULL DEFAULT 0 COMMENT '排序',
+    deleted TINYINT(1) NOT NULL DEFAULT 0 COMMENT '逻辑删除',
+    created_by VARCHAR(128) NOT NULL DEFAULT 'system' COMMENT '创建人',
+    updated_by VARCHAR(128) NOT NULL DEFAULT 'system' COMMENT '更新人',
+    created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    updated_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3)
+        ON UPDATE CURRENT_TIMESTAMP(3),
+    PRIMARY KEY (id),
+    KEY idx_yak_quality_template_folder_parent (parent_id, deleted, sort_order),
+    KEY idx_yak_quality_template_folder_name (folder_name, deleted)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+  COMMENT='数据质量自定义规则模板目录';
+
+ALTER TABLE yak_quality_rule_template
+    ADD COLUMN folder_id BIGINT NULL COMMENT '自定义模板目录 ID' AFTER sort_order,
+    ADD COLUMN template_sql MEDIUMTEXT NULL COMMENT '自定义模板 SQL' AFTER folder_id,
+    ADD COLUMN set_flag VARCHAR(1000) NULL COMMENT 'SQL 前置 Set Flag，英文逗号分隔' AFTER template_sql,
+    ADD COLUMN check_type VARCHAR(32) NOT NULL DEFAULT 'NUMERIC'
+        COMMENT '自定义模板校验类型' AFTER set_flag,
+    ADD COLUMN check_method VARCHAR(64) NOT NULL DEFAULT 'FIXED_VALUE'
+        COMMENT '自定义模板校验方式' AFTER check_type,
+    ADD COLUMN created_by VARCHAR(128) NOT NULL DEFAULT 'system'
+        COMMENT '模板创建人' AFTER check_method,
+    ADD COLUMN deleted TINYINT(1) NOT NULL DEFAULT 0
+        COMMENT '逻辑删除' AFTER created_by,
+    ADD KEY idx_yak_quality_template_folder (folder_id, builtin, deleted, enabled),
+    ADD KEY idx_yak_quality_template_source (builtin, deleted, enabled, sort_order);
+
+UPDATE yak_quality_rule_template
+SET check_type = 'NUMERIC',
+    check_method = 'FIXED_VALUE',
+    created_by = COALESCE(NULLIF(created_by, ''), 'system'),
+    deleted = 0
+WHERE builtin = 1;

--- a/yak-ops-business/yak-ops-business-quality/src/test/java/io/yak/ops/business/quality/service/CustomTemplateServiceTest.java
+++ b/yak-ops-business/yak-ops-business-quality/src/test/java/io/yak/ops/business/quality/service/CustomTemplateServiceTest.java
@@ -1,0 +1,118 @@
+package io.yak.ops.business.quality.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.quality.api.CustomTemplateApi.CheckMethod;
+import io.yak.ops.business.quality.api.CustomTemplateApi.CheckType;
+import io.yak.ops.business.quality.api.CustomTemplateApi.SaveTemplateRequest;
+import io.yak.ops.business.quality.api.CustomTemplateApi.TemplateView;
+import io.yak.ops.business.quality.api.QualityApi.ComparisonOperator;
+import io.yak.ops.business.quality.api.QualityApi.RuleScope;
+import io.yak.ops.business.quality.api.QualityApi.RuleType;
+import io.yak.ops.business.quality.repository.CustomTemplateRepository;
+import io.yak.ops.business.quality.repository.CustomTemplateRepository.TemplateWrite;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+class CustomTemplateServiceTest {
+
+  @Mock
+  private CustomTemplateRepository repository;
+
+  private CustomTemplateService service;
+
+  @BeforeEach
+  void setUp() {
+    MockitoAnnotations.openMocks(this);
+    service = new CustomTemplateService(repository);
+  }
+
+  @Test
+  void shouldCreateExecutableCustomTemplateDefaults() {
+    when(repository.insertTemplate(any())).thenReturn(7L);
+    when(repository.find(7L)).thenReturn(Optional.of(template(7L)));
+
+    TemplateView result = service.create(
+        new SaveTemplateRequest(
+            "订单数量校验",
+            "统计订单数量",
+            "完整性",
+            null,
+            "set demo=value",
+            CheckType.NUMERIC,
+            CheckMethod.FIXED_VALUE,
+            "SELECT COUNT(*) FROM ${tableName} WHERE ${where};",
+            ComparisonOperator.GTE,
+            BigDecimal.ONE,
+            null),
+        "tester");
+
+    ArgumentCaptor<TemplateWrite> captor =
+        ArgumentCaptor.forClass(TemplateWrite.class);
+    verify(repository).insertTemplate(captor.capture());
+    TemplateWrite write = captor.getValue();
+    assertThat(write.templateSql())
+        .isEqualTo("SELECT COUNT(*) FROM ${table} WHERE ${where}");
+    assertThat(write.parameterSchema())
+        .contains("\"defaultOperator\":\"GTE\"")
+        .contains("\"defaultSql\"");
+    assertThat(write.operator()).isEqualTo("tester");
+    assertThat(result.id()).isEqualTo(7L);
+  }
+
+  @Test
+  void shouldRejectMultipleStatements() {
+    assertThatThrownBy(() -> service.create(
+        new SaveTemplateRequest(
+            "多语句模板",
+            null,
+            "自定义",
+            null,
+            null,
+            CheckType.NUMERIC,
+            CheckMethod.FIXED_VALUE,
+            "SELECT 1; SELECT 2",
+            ComparisonOperator.EQ,
+            BigDecimal.ZERO,
+            null),
+        "tester"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("单条只读 SELECT");
+  }
+
+  private TemplateView template(long id) {
+    LocalDateTime now = LocalDateTime.now();
+    return new TemplateView(
+        id,
+        "CUSTOM_SQL_TEST",
+        "订单数量校验",
+        "统计订单数量",
+        RuleType.CUSTOM_SQL,
+        RuleScope.TABLE,
+        "完整性",
+        "{\"fields\":[\"customSql\",\"operator\",\"threshold\"]}",
+        false,
+        true,
+        0,
+        1000,
+        null,
+        null,
+        "SELECT COUNT(*) FROM ${table}",
+        null,
+        CheckType.NUMERIC,
+        CheckMethod.FIXED_VALUE,
+        "tester",
+        now,
+        now);
+  }
+}

--- a/yak-ops-ui/src/constants/yakOpsPermissions.ts
+++ b/yak-ops-ui/src/constants/yakOpsPermissions.ts
@@ -16,6 +16,9 @@ export const YAK_OPS_PERMISSIONS = {
   },
   quality: {
     templateRead: 'quality:template:read',
+    templateCreate: 'quality:template:create',
+    templateUpdate: 'quality:template:update',
+    templateDelete: 'quality:template:delete',
     monitorRead: 'quality:monitor:read',
     monitorCreate: 'quality:monitor:create',
     monitorUpdate: 'quality:monitor:update',

--- a/yak-ops-ui/src/pages/data-quality/monitor/editor/model.ts
+++ b/yak-ops-ui/src/pages/data-quality/monitor/editor/model.ts
@@ -63,9 +63,33 @@ export const OPERATORS: Array<{ value: ComparisonOperator; label: string }> = [
   { value: 'BETWEEN', label: '区间' },
 ];
 
+interface ParameterDefaults {
+  defaultOperator?: ComparisonOperator;
+  defaultThreshold?: number;
+  defaultThresholdEnd?: number;
+  defaultSql?: string;
+}
+
+const parseDefaults = (value?: string): ParameterDefaults => {
+  if (!value) return {};
+  try {
+    return JSON.parse(value) as ParameterDefaults;
+  } catch {
+    return {};
+  }
+};
+
 export const ruleDefaults = (template: TemplateView): EditorRule => {
+  const schema = parseDefaults(template.parameterSchema);
   const percentRule =
-    template.ruleType === 'COLUMN_NOT_NULL' || template.ruleType === 'COLUMN_UNIQUE';
+    template.ruleType === 'COLUMN_NOT_NULL'
+    || template.ruleType === 'COLUMN_UNIQUE';
+  const fallbackOperator: ComparisonOperator =
+    template.ruleType === 'TABLE_ROW_COUNT'
+      ? 'GT'
+      : percentRule
+        ? 'GTE'
+        : 'EQ';
   return {
     key: `${template.id}-${Date.now()}-${Math.random()}`,
     templateId: template.id,
@@ -74,12 +98,15 @@ export const ruleDefaults = (template: TemplateView): EditorRule => {
     ruleType: template.ruleType,
     scope: template.scope,
     dimension: template.dimension,
-    operator: template.ruleType === 'TABLE_ROW_COUNT' ? 'GT' : percentRule ? 'GTE' : 'EQ',
-    threshold: percentRule ? 100 : 0,
+    operator: schema.defaultOperator || fallbackOperator,
+    threshold: schema.defaultThreshold ?? (percentRule ? 100 : 0),
+    thresholdEnd: schema.defaultThresholdEnd,
     enumValues: [],
     customSql:
       template.ruleType === 'CUSTOM_SQL'
-        ? 'SELECT COUNT(*) AS metric_value FROM ${table} WHERE ${where}'
+        ? template.templateSql
+          || schema.defaultSql
+          || 'SELECT COUNT(*) AS metric_value FROM ${table} WHERE ${where}'
         : undefined,
     enabled: true,
   };
@@ -103,7 +130,9 @@ export const monitorRules = (monitor: MonitorView): EditorRule[] =>
     enabled: rule.enabled,
   }));
 
-export const runtimeFromSettings = (settings: MonitorSettingsView): RuntimeFormState => ({
+export const runtimeFromSettings = (
+  settings: MonitorSettingsView,
+): RuntimeFormState => ({
   runMode: settings.runMode || 'MANUAL',
   scheduleFrequency: settings.scheduleFrequency || 'DAILY',
   scheduleTime: settings.scheduleTime || '09:00',
@@ -111,7 +140,9 @@ export const runtimeFromSettings = (settings: MonitorSettingsView): RuntimeFormS
   cronExpression: settings.cronExpression || '0 0 9 * * *',
 });
 
-export const strategyFromSettings = (settings: MonitorSettingsView): IssueStrategyState => ({
+export const strategyFromSettings = (
+  settings: MonitorSettingsView,
+): IssueStrategyState => ({
   ruleFailureAction: settings.ruleFailureAction || 'CONTINUE',
   notifyEnabled: Boolean(settings.notifyEnabled),
   notifyChannel: settings.notifyChannel || 'MESSAGE',
@@ -150,17 +181,23 @@ export const validateEditorSettings = (
   strategy: IssueStrategyState,
 ) => {
   if (runtime.runMode === 'SCHEDULE') {
-    if (runtime.scheduleFrequency === 'CRON' && !runtime.cronExpression.trim()) {
+    if (
+      runtime.scheduleFrequency === 'CRON'
+      && !runtime.cronExpression.trim()
+    ) {
       throw new Error('请输入 Cron 表达式');
     }
-    if (runtime.scheduleFrequency !== 'CRON' && !runtime.scheduleTime) {
+    if (
+      runtime.scheduleFrequency !== 'CRON'
+      && !runtime.scheduleTime
+    ) {
       throw new Error('请选择执行时间');
     }
   }
   if (
-    strategy.notifyEnabled &&
-    strategy.notifyChannel !== 'MESSAGE' &&
-    !strategy.notifyTarget.trim()
+    strategy.notifyEnabled
+    && strategy.notifyChannel !== 'MESSAGE'
+    && !strategy.notifyTarget.trim()
   ) {
     throw new Error(
       strategy.notifyChannel === 'EMAIL'

--- a/yak-ops-ui/src/pages/data-quality/rule-template/CustomTemplateDrawer.tsx
+++ b/yak-ops-ui/src/pages/data-quality/rule-template/CustomTemplateDrawer.tsx
@@ -1,0 +1,329 @@
+import {
+  Alert,
+  Button,
+  Drawer,
+  Form,
+  Input,
+  InputNumber,
+  Select,
+  Space,
+} from 'antd';
+import { useEffect } from 'react';
+import type {
+  ComparisonOperator,
+  SaveCustomTemplatePayload,
+  TemplateFolderView,
+  TemplateView,
+} from '../types';
+
+type DrawerMode = 'create' | 'edit';
+
+interface CustomTemplateDrawerProps {
+  open: boolean;
+  mode: DrawerMode;
+  template?: TemplateView;
+  folders: TemplateFolderView[];
+  defaultFolderId?: number;
+  submitting?: boolean;
+  onClose: () => void;
+  onSubmit: (payload: SaveCustomTemplatePayload) => void;
+}
+
+type FormValues = SaveCustomTemplatePayload;
+
+const DIMENSIONS = [
+  '完整性',
+  '唯一性',
+  '有效性',
+  '准确性',
+  '一致性',
+  '及时性',
+  '规范性',
+  '自定义',
+];
+
+const OPERATORS: Array<{
+  value: ComparisonOperator;
+  label: string;
+}> = [
+  { value: 'GT', label: '大于（>）' },
+  { value: 'GTE', label: '大于等于（>=）' },
+  { value: 'EQ', label: '等于（=）' },
+  { value: 'LTE', label: '小于等于（<=）' },
+  { value: 'LT', label: '小于（<）' },
+  { value: 'BETWEEN', label: '区间' },
+];
+
+const parseDefaults = (schema?: string) => {
+  try {
+    return schema ? JSON.parse(schema) : {};
+  } catch {
+    return {};
+  }
+};
+
+const folderOptions = (folders: TemplateFolderView[]) => {
+  const children = new Map<number | undefined, TemplateFolderView[]>();
+  folders.forEach((folder) => {
+    const items = children.get(folder.parentId) || [];
+    items.push(folder);
+    children.set(folder.parentId, items);
+  });
+
+  const result: Array<{ value: number; label: string }> = [];
+  const walk = (parentId: number | undefined, depth: number) => {
+    (children.get(parentId) || []).forEach((folder) => {
+      result.push({
+        value: folder.id,
+        label: `${'　'.repeat(depth)}${folder.name}`,
+      });
+      walk(folder.id, depth + 1);
+    });
+  };
+  walk(undefined, 0);
+  return result;
+};
+
+const CustomTemplateDrawer = ({
+  open,
+  mode,
+  template,
+  folders,
+  defaultFolderId,
+  submitting,
+  onClose,
+  onSubmit,
+}: CustomTemplateDrawerProps) => {
+  const [form] = Form.useForm<FormValues>();
+  const operator = Form.useWatch('defaultOperator', form);
+
+  useEffect(() => {
+    if (!open) return;
+    const defaults = parseDefaults(template?.parameterSchema);
+    form.setFieldsValue({
+      name: template?.name || '',
+      description: template?.description || '',
+      dimension: template?.dimension || '自定义',
+      folderId: template?.folderId || defaultFolderId,
+      setFlag: template?.setFlag || '',
+      checkType: 'NUMERIC',
+      checkMethod: 'FIXED_VALUE',
+      customSql:
+        template?.templateSql
+        || 'SELECT COUNT(*) AS metric_value FROM ${tableName} WHERE ${where}',
+      defaultOperator: defaults.defaultOperator || 'EQ',
+      defaultThreshold: defaults.defaultThreshold ?? 0,
+      defaultThresholdEnd: defaults.defaultThresholdEnd,
+    });
+  }, [defaultFolderId, form, open, template]);
+
+  return (
+    <Drawer
+      width={620}
+      title={
+        mode === 'create'
+          ? '新建自定义规则模板'
+          : '编辑自定义规则模板'
+      }
+      open={open}
+      onClose={onClose}
+      destroyOnClose
+      footer={
+        <div className="flex justify-end gap-2">
+          <Button onClick={onClose}>取消</Button>
+          <Button
+            type="primary"
+            loading={submitting}
+            onClick={() => form.validateFields().then(onSubmit)}
+          >
+            {mode === 'create' ? '创建模板' : '保存修改'}
+          </Button>
+        </div>
+      }
+    >
+      <Alert
+        type="info"
+        showIcon
+        className="mb-5"
+        message="自定义模板当前支持单条只读 SELECT，查询结果必须为一行一列的数值。模板修改只影响后续引用，不会改变已有质量规则。"
+      />
+
+      <Form<FormValues>
+        form={form}
+        layout="vertical"
+        requiredMark="optional"
+        initialValues={{
+          dimension: '自定义',
+          checkType: 'NUMERIC',
+          checkMethod: 'FIXED_VALUE',
+          defaultOperator: 'EQ',
+          defaultThreshold: 0,
+        }}
+      >
+        <Form.Item
+          label="模板名称"
+          name="name"
+          rules={[
+            {
+              required: true,
+              whitespace: true,
+              message: '请输入模板名称',
+            },
+          ]}
+        >
+          <Input
+            variant="filled"
+            maxLength={100}
+            placeholder="请输入自定义模板名称"
+          />
+        </Form.Item>
+
+        <div className="grid grid-cols-2 gap-4">
+          <Form.Item
+            label="质量维度"
+            name="dimension"
+            rules={[{ required: true }]}
+          >
+            <Select
+              variant="filled"
+              options={DIMENSIONS.map((value) => ({
+                value,
+                label: value,
+              }))}
+            />
+          </Form.Item>
+          <Form.Item label="目标文件夹" name="folderId">
+            <Select
+              allowClear
+              variant="filled"
+              placeholder="根目录"
+              options={folderOptions(folders)}
+            />
+          </Form.Item>
+        </div>
+
+        <div className="grid grid-cols-2 gap-4">
+          <Form.Item
+            label="校验类型"
+            name="checkType"
+            rules={[{ required: true }]}
+          >
+            <Select
+              variant="filled"
+              disabled
+              options={[{ value: 'NUMERIC', label: '数值型' }]}
+            />
+          </Form.Item>
+          <Form.Item
+            label="校验方式"
+            name="checkMethod"
+            rules={[{ required: true }]}
+          >
+            <Select
+              variant="filled"
+              disabled
+              options={[
+                { value: 'FIXED_VALUE', label: '与固定值比较' },
+              ]}
+            />
+          </Form.Item>
+        </div>
+
+        <Form.Item
+          label="Set Flag"
+          name="setFlag"
+          extra="多条前置 set 语句使用英文逗号分隔，不要添加分号。当前版本仅保存该配置，执行器暂不下发 Set Flag。"
+        >
+          <Input.TextArea
+            variant="filled"
+            rows={2}
+            maxLength={1000}
+            placeholder="例如：set spark.sql.shuffle.partitions=10"
+          />
+        </Form.Item>
+
+        <Form.Item
+          label="自定义 SQL"
+          name="customSql"
+          rules={[
+            {
+              required: true,
+              whitespace: true,
+              message: '请输入自定义 SQL',
+            },
+          ]}
+          extra="可使用 ${tableName} 表示目标表，也支持 ${table}、${column}、${where}。"
+        >
+          <Input.TextArea
+            variant="filled"
+            rows={8}
+            maxLength={20000}
+            placeholder="SELECT COUNT(*) AS metric_value FROM ${tableName} WHERE ${where}"
+            className="font-mono"
+          />
+        </Form.Item>
+
+        <Form.Item label="默认比较条件" required>
+          <Space.Compact block>
+            <Form.Item
+              name="defaultOperator"
+              noStyle
+              rules={[{ required: true }]}
+            >
+              <Select
+                className="w-[190px]"
+                variant="filled"
+                options={OPERATORS}
+              />
+            </Form.Item>
+            <Form.Item
+              name="defaultThreshold"
+              noStyle
+              rules={[
+                {
+                  required: true,
+                  message: '请输入默认阈值',
+                },
+              ]}
+            >
+              <InputNumber
+                className="!w-full"
+                variant="filled"
+                placeholder="默认阈值"
+              />
+            </Form.Item>
+            {operator === 'BETWEEN' ? (
+              <Form.Item
+                name="defaultThresholdEnd"
+                noStyle
+                rules={[
+                  {
+                    required: true,
+                    message: '请输入区间最大值',
+                  },
+                ]}
+              >
+                <InputNumber
+                  className="!w-full"
+                  variant="filled"
+                  placeholder="区间最大值"
+                />
+              </Form.Item>
+            ) : null}
+          </Space.Compact>
+        </Form.Item>
+
+        <Form.Item label="模板描述" name="description">
+          <Input.TextArea
+            variant="filled"
+            rows={3}
+            maxLength={500}
+            placeholder="说明模板用途、指标口径及适用范围"
+          />
+        </Form.Item>
+      </Form>
+    </Drawer>
+  );
+};
+
+export default CustomTemplateDrawer;

--- a/yak-ops-ui/src/pages/data-quality/rule-template/index.tsx
+++ b/yak-ops-ui/src/pages/data-quality/rule-template/index.tsx
@@ -1,58 +1,91 @@
-import { API_SUCCESS_CODE } from "@/services/http/response";
-import { BRAND_COLOR, BRAND_COLOR_SOFT, BRAND_THEME } from "@/styles/brand";
+import { API_SUCCESS_CODE } from '@/services/http/response';
 import {
+  BRAND_COLOR,
+  BRAND_COLOR_SOFT,
+  BRAND_THEME,
+} from '@/styles/brand';
+import {
+  Button,
   ConfigProvider,
+  Dropdown,
   Empty,
+  Form,
   Input,
+  Modal,
+  Select,
   Spin,
   Table,
   Tabs,
   Tag,
   message,
-} from "antd";
-import { ChevronLeft, ChevronRight, Search } from "lucide-react";
+} from 'antd';
 import {
+  ChevronLeft,
+  ChevronRight,
+  Copy,
+  Ellipsis,
+  Folder,
+  FolderPlus,
+  Pencil,
+  Plus,
+  RefreshCw,
+  Search,
+  Trash2,
+} from 'lucide-react';
+import {
+  useCallback,
   useEffect,
   useMemo,
   useRef,
   useState,
   type PointerEvent as ReactPointerEvent,
-} from "react";
-
-import { dataQualityTableClassName } from "../components/tableStyle";
-import { qualityTemplateApi } from "../service";
-import type { TemplateListView, TemplateView } from "../types";
+} from 'react';
+import { dataQualityTableClassName } from '../components/tableStyle';
+import { qualityTemplateApi } from '../service';
+import type {
+  CopyCustomTemplatePayload,
+  SaveCustomTemplatePayload,
+  SaveTemplateFolderPayload,
+  TemplateFolderView,
+  TemplateListView,
+  TemplateView,
+} from '../types';
+import CustomTemplateDrawer from './CustomTemplateDrawer';
 
 const DEFAULT_LEFT_WIDTH = 280;
-const MIN_LEFT_WIDTH = 220;
-const MAX_LEFT_WIDTH = 480;
+const MIN_LEFT_WIDTH = 230;
+const MAX_LEFT_WIDTH = 460;
 
-type TemplateTabKey = "SYSTEM" | "CUSTOM";
+type TemplateTabKey = 'SYSTEM' | 'CUSTOM';
+type FolderSelection = 'ALL' | 'ROOT' | number;
+type FolderDialogMode = 'create' | 'edit';
 
-type TemplateRecordWithSource = TemplateView & {
-  templateType?: string;
-  templateSource?: string;
-  sourceType?: string;
-  source?: string;
-  isSystem?: boolean;
-};
+interface CatalogMeta {
+  systemTotal: number;
+  customTotal: number;
+  systemDimensions: Record<string, number>;
+  customDimensions: Record<string, number>;
+}
 
 const DIMENSION_DESCRIPTIONS: Record<string, string> = {
-  全部: "汇总展示全部质量维度下的规则模板，可通过质量维度、模板类型和关键字快速定位所需模板。",
+  全部:
+    '汇总展示全部质量维度下的规则模板，可通过维度、模板类型和关键字快速定位。',
   完整性:
-    "完整性用于衡量数据是否按照预设要求完整填充，可判断必填字段、必要记录或关联数据是否存在缺失。",
+    '完整性用于衡量数据是否按照预设要求完整填充，可识别必要数据缺失。',
   唯一性:
-    "唯一性用于衡量数据是否存在重复，可判断主键、业务编码或组合字段是否满足唯一约束。",
+    '唯一性用于衡量数据是否存在重复，可判断业务键或字段组合是否唯一。',
   有效性:
-    "有效性用于衡量数据对预设定义要求的匹配程度，可判断已具备数据定义或业务定义的字段是否出现不匹配格式要求的数据。",
+    '有效性用于判断数据是否符合预设格式、范围和业务定义。',
   一致性:
-    "一致性用于衡量不同字段、不同数据表或不同系统之间的数据表达是否保持一致。",
+    '一致性用于衡量字段、数据表或系统之间的数据表达是否保持一致。',
   准确性:
-    "准确性用于衡量数据是否能够正确反映实际业务对象，可识别异常值、错误值以及不符合业务事实的数据。",
+    '准确性用于衡量数据是否正确反映实际业务对象。',
   及时性:
-    "及时性用于衡量数据是否在规定时间内产生、更新或同步，可判断数据处理是否存在延迟。",
+    '及时性用于衡量数据是否在规定时间内产生、更新或同步。',
   规范性:
-    "规范性用于衡量数据是否符合统一的数据标准、编码规则、格式约束和业务填写规范。",
+    '规范性用于衡量数据是否符合统一的数据标准和编码规则。',
+  自定义:
+    '自定义维度用于承载团队自行定义的数据质量指标和检查口径。',
 };
 
 const unwrap = <T,>(response: {
@@ -62,36 +95,36 @@ const unwrap = <T,>(response: {
   msg?: string;
 }) => {
   if (response.code !== API_SUCCESS_CODE) {
-    throw new Error(response.message || response.msg || "请求失败");
+    throw new Error(response.message || response.msg || '请求失败');
   }
-
   return response.data;
 };
 
-const getDimensionDescription = (dimension: string) => {
-  return (
-    DIMENSION_DESCRIPTIONS[dimension] ||
-    `${dimension}用于衡量数据是否符合对应的数据质量要求，可通过关联规则识别不满足要求的数据。`
+interface FolderRow extends TemplateFolderView {
+  depth: number;
+}
+
+const flattenFolders = (folders: TemplateFolderView[]) => {
+  const groups = new Map<number | undefined, TemplateFolderView[]>();
+  folders.forEach((folder) => {
+    const values = groups.get(folder.parentId) || [];
+    values.push(folder);
+    groups.set(folder.parentId, values);
+  });
+  groups.forEach((values) =>
+    values.sort(
+      (a, b) => a.sortOrder - b.sortOrder || a.name.localeCompare(b.name),
+    ),
   );
-};
-
-const isCustomTemplate = (record: TemplateView) => {
-  const current = record as TemplateRecordWithSource;
-
-  if (typeof current.isSystem === "boolean") {
-    return !current.isSystem;
-  }
-
-  const source = [
-    current.templateType,
-    current.templateSource,
-    current.sourceType,
-    current.source,
-  ]
-    .find(Boolean)
-    ?.toUpperCase();
-
-  return ["CUSTOM", "USER", "SELF", "CUSTOMIZED"].includes(source || "");
+  const result: FolderRow[] = [];
+  const walk = (parentId: number | undefined, depth: number) => {
+    (groups.get(parentId) || []).forEach((folder) => {
+      result.push({ ...folder, depth });
+      walk(folder.id, depth + 1);
+    });
+  };
+  walk(undefined, 0);
+  return result;
 };
 
 const TemplateLibraryPage = () => {
@@ -99,151 +132,337 @@ const TemplateLibraryPage = () => {
     records: [],
     summary: {
       total: 0,
+      systemTotal: 0,
+      customTotal: 0,
       dimensions: {},
     },
   });
-
-  const [dimension, setDimension] = useState("全部");
-  const [activeTab, setActiveTab] = useState<TemplateTabKey>("SYSTEM");
-  const [keyword, setKeyword] = useState("");
+  const [folders, setFolders] = useState<TemplateFolderView[]>([]);
+  const [catalogMeta, setCatalogMeta] = useState<CatalogMeta>({
+    systemTotal: 0,
+    customTotal: 0,
+    systemDimensions: {},
+    customDimensions: {},
+  });
+  const [dimension, setDimension] = useState('全部');
+  const [activeTab, setActiveTab] = useState<TemplateTabKey>('SYSTEM');
+  const [selectedFolder, setSelectedFolder] =
+    useState<FolderSelection>('ALL');
+  const [keyword, setKeyword] = useState('');
+  const [folderKeyword, setFolderKeyword] = useState('');
   const [loading, setLoading] = useState(false);
-
+  const [folderLoading, setFolderLoading] = useState(false);
   const [leftWidth, setLeftWidth] = useState(DEFAULT_LEFT_WIDTH);
   const [collapsed, setCollapsed] = useState(false);
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [drawerMode, setDrawerMode] = useState<'create' | 'edit'>('create');
+  const [editingTemplate, setEditingTemplate] = useState<TemplateView>();
+  const [submitting, setSubmitting] = useState(false);
+  const [folderDialogOpen, setFolderDialogOpen] = useState(false);
+  const [folderDialogMode, setFolderDialogMode] =
+    useState<FolderDialogMode>('create');
+  const [editingFolder, setEditingFolder] =
+    useState<TemplateFolderView>();
+  const [copyTemplate, setCopyTemplate] = useState<TemplateView>();
+  const [folderForm] = Form.useForm<SaveTemplateFolderPayload>();
+  const [copyForm] = Form.useForm<CopyCustomTemplatePayload>();
+  const dragRef = useRef<{ x: number; width: number } | null>(null);
 
-  const dragRef = useRef<{
-    x: number;
-    width: number;
-  } | null>(null);
+  const loadFolders = useCallback(() => {
+    setFolderLoading(true);
+    qualityTemplateApi
+      .folders()
+      .then((response) => setFolders(unwrap(response)))
+      .catch((error) =>
+        message.error(error?.message || '自定义模板目录加载失败'),
+      )
+      .finally(() => setFolderLoading(false));
+  }, []);
 
-  const dimensions = useMemo(
-    () => [
-      {
-        label: "全部",
-        count: data.summary.total,
-      },
-      ...Object.entries(data.summary.dimensions).map(([label, count]) => ({
+  const loadCatalogMeta = useCallback(() => {
+    Promise.all([
+      qualityTemplateApi.list(),
+      qualityTemplateApi.customList(),
+    ])
+      .then(([systemResponse, customResponse]) => {
+        const allTemplates = unwrap(systemResponse).records;
+        const systemRecords = allTemplates.filter(
+          (template) => template.builtin,
+        );
+        const systemDimensions: Record<string, number> = {};
+        systemRecords.forEach((template) => {
+          systemDimensions[template.dimension] =
+            (systemDimensions[template.dimension] || 0) + 1;
+        });
+        const customData = unwrap(customResponse);
+        setCatalogMeta({
+          systemTotal: systemRecords.length,
+          customTotal:
+            customData.summary.customTotal ?? customData.records.length,
+          systemDimensions,
+          customDimensions: customData.summary.dimensions || {},
+        });
+      })
+      .catch((error) =>
+        message.error(error?.message || '模板统计加载失败'),
+      );
+  }, []);
+
+  const loadTemplates = useCallback(() => {
+    setLoading(true);
+    const folderId =
+      activeTab !== 'CUSTOM' || selectedFolder === 'ALL'
+        ? undefined
+        : selectedFolder === 'ROOT'
+          ? 0
+          : selectedFolder;
+    const request =
+      activeTab === 'CUSTOM'
+        ? qualityTemplateApi.customList({
+            keyword: keyword.trim() || undefined,
+            dimension: dimension === '全部' ? undefined : dimension,
+            folderId,
+          })
+        : qualityTemplateApi.list({
+            keyword: keyword.trim() || undefined,
+            dimension: dimension === '全部' ? undefined : dimension,
+          });
+    request
+      .then((response) => {
+        const value = unwrap(response);
+        setData({
+          records:
+            activeTab === 'SYSTEM'
+              ? value.records.filter((template) => template.builtin)
+              : value.records,
+          summary: value.summary,
+        });
+      })
+      .catch((error) =>
+        message.error(error?.message || '规则模板加载失败'),
+      )
+      .finally(() => setLoading(false));
+  }, [activeTab, dimension, keyword, selectedFolder]);
+
+  useEffect(() => loadFolders(), [loadFolders]);
+  useEffect(() => loadCatalogMeta(), [loadCatalogMeta]);
+  useEffect(() => loadTemplates(), [loadTemplates]);
+
+  const dimensions = useMemo(() => {
+    const source =
+      activeTab === 'SYSTEM'
+        ? catalogMeta.systemDimensions
+        : catalogMeta.customDimensions;
+    const total =
+      activeTab === 'SYSTEM'
+        ? catalogMeta.systemTotal
+        : catalogMeta.customTotal;
+    return [
+      { label: '全部', count: total },
+      ...Object.entries(source).map(([label, count]) => ({
         label,
         count,
       })),
-    ],
-    [data.summary]
-  );
+    ];
+  }, [activeTab, catalogMeta]);
 
-  const systemRecords = useMemo(
-    () => data.records.filter((record) => !isCustomTemplate(record)),
-    [data.records]
-  );
-
-  const customRecords = useMemo(
-    () => data.records.filter((record) => isCustomTemplate(record)),
-    [data.records]
-  );
-
-  const currentRecords = useMemo(
-    () => (activeTab === "SYSTEM" ? systemRecords : customRecords),
-    [activeTab, customRecords, systemRecords]
-  );
+  const visibleFolders = useMemo(() => {
+    const flattened = flattenFolders(folders);
+    const normalized = folderKeyword.trim().toLowerCase();
+    return normalized
+      ? flattened.filter((folder) =>
+          folder.name.toLowerCase().includes(normalized),
+        )
+      : flattened;
+  }, [folderKeyword, folders]);
 
   const relatedRuleCount = useMemo(
     () =>
-      currentRecords.reduce((total, record) => {
-        const count = Number(record.ruleCount || 0);
-        return total + (Number.isNaN(count) ? 0 : count);
-      }, 0),
-    [currentRecords]
+      data.records.reduce(
+        (total, template) => total + Number(template.ruleCount || 0),
+        0,
+      ),
+    [data.records],
   );
 
-  const tabItems = useMemo(
-    () => [
-      {
-        key: "SYSTEM",
-        label: (
-          <span>
-            系统模板
-            <span className="ml-1">({systemRecords.length})</span>
-          </span>
-        ),
-      },
-      {
-        key: "CUSTOM",
-        label: (
-          <span>
-            自定义模板
-            <span className="ml-1">({customRecords.length})</span>
-          </span>
-        ),
-      },
-    ],
-    [customRecords.length, systemRecords.length]
-  );
-
-  useEffect(() => {
-    setLoading(true);
-
-    qualityTemplateApi
-      .list({
-        keyword,
-        dimension: dimension === "全部" ? undefined : dimension,
-      })
-      .then((response) => {
-        setData(unwrap(response));
-      })
-      .catch((error) => {
-        message.error(error?.message || "规则模板加载失败");
-      })
-      .finally(() => {
-        setLoading(false);
-      });
-  }, [dimension, keyword]);
+  const selectedFolderId =
+    typeof selectedFolder === 'number' ? selectedFolder : undefined;
 
   const startResize = (event: ReactPointerEvent<HTMLDivElement>) => {
-    if (event.button !== 0) {
-      return;
-    }
-
+    if (event.button !== 0) return;
     event.preventDefault();
-
     const initialWidth = collapsed ? MIN_LEFT_WIDTH : leftWidth;
+    if (collapsed) setCollapsed(false);
+    dragRef.current = { x: event.clientX, width: initialWidth };
 
-    if (collapsed) {
-      setCollapsed(false);
-    }
-
-    dragRef.current = {
-      x: event.clientX,
-      width: initialWidth,
-    };
-
-    const handlePointerMove = (currentEvent: PointerEvent) => {
-      const dragData = dragRef.current;
-
-      if (!dragData) {
-        return;
-      }
-
-      const nextWidth = dragData.width + currentEvent.clientX - dragData.x;
-
+    const move = (current: PointerEvent) => {
+      if (!dragRef.current) return;
       setLeftWidth(
-        Math.min(MAX_LEFT_WIDTH, Math.max(MIN_LEFT_WIDTH, nextWidth))
+        Math.min(
+          MAX_LEFT_WIDTH,
+          Math.max(
+            MIN_LEFT_WIDTH,
+            dragRef.current.width + current.clientX - dragRef.current.x,
+          ),
+        ),
       );
     };
 
-    const handlePointerUp = () => {
+    const end = () => {
       dragRef.current = null;
-
-      window.removeEventListener("pointermove", handlePointerMove);
-      window.removeEventListener("pointerup", handlePointerUp);
-
-      document.body.style.cursor = "";
-      document.body.style.userSelect = "";
+      window.removeEventListener('pointermove', move);
+      window.removeEventListener('pointerup', end);
+      document.body.style.cursor = '';
+      document.body.style.userSelect = '';
     };
 
-    document.body.style.cursor = "col-resize";
-    document.body.style.userSelect = "none";
+    document.body.style.cursor = 'col-resize';
+    document.body.style.userSelect = 'none';
+    window.addEventListener('pointermove', move);
+    window.addEventListener('pointerup', end);
+  };
 
-    window.addEventListener("pointermove", handlePointerMove);
-    window.addEventListener("pointerup", handlePointerUp);
+  const openCreateFolder = (parentId?: number) => {
+    setFolderDialogMode('create');
+    setEditingFolder(undefined);
+    folderForm.setFieldsValue({ name: '', parentId });
+    setFolderDialogOpen(true);
+  };
+
+  const openEditFolder = (folder: TemplateFolderView) => {
+    setFolderDialogMode('edit');
+    setEditingFolder(folder);
+    folderForm.setFieldsValue({
+      name: folder.name,
+      parentId: folder.parentId,
+    });
+    setFolderDialogOpen(true);
+  };
+
+  const saveFolder = async () => {
+    const payload = await folderForm.validateFields();
+    setSubmitting(true);
+    try {
+      if (folderDialogMode === 'edit' && editingFolder) {
+        unwrap(
+          await qualityTemplateApi.updateFolder(
+            editingFolder.id,
+            payload,
+          ),
+        );
+        message.success('目录已更新');
+      } else {
+        unwrap(await qualityTemplateApi.createFolder(payload));
+        message.success('目录已创建');
+      }
+      setFolderDialogOpen(false);
+      loadFolders();
+      loadCatalogMeta();
+      loadTemplates();
+    } catch (error: any) {
+      message.error(error?.message || '目录保存失败');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const removeFolder = (folder: TemplateFolderView) => {
+    Modal.confirm({
+      title: `删除目录“${folder.name}”？`,
+      content: '只有不包含子目录和模板的空目录可以删除。',
+      okText: '删除',
+      okButtonProps: { danger: true },
+      onOk: async () => {
+        unwrap(await qualityTemplateApi.removeFolder(folder.id));
+        if (selectedFolder === folder.id) setSelectedFolder('ALL');
+        message.success('目录已删除');
+        loadFolders();
+        loadCatalogMeta();
+        loadTemplates();
+      },
+    });
+  };
+
+  const openCreateTemplate = () => {
+    setDrawerMode('create');
+    setEditingTemplate(undefined);
+    setDrawerOpen(true);
+  };
+
+  const openEditTemplate = (template: TemplateView) => {
+    setDrawerMode('edit');
+    setEditingTemplate(template);
+    setDrawerOpen(true);
+  };
+
+  const saveTemplate = async (payload: SaveCustomTemplatePayload) => {
+    setSubmitting(true);
+    try {
+      if (drawerMode === 'edit' && editingTemplate) {
+        unwrap(
+          await qualityTemplateApi.updateCustom(
+            editingTemplate.id,
+            payload,
+          ),
+        );
+        message.success('自定义模板已更新，已有规则不会被修改');
+      } else {
+        unwrap(await qualityTemplateApi.createCustom(payload));
+        message.success('自定义模板已创建');
+      }
+      setDrawerOpen(false);
+      loadFolders();
+      loadCatalogMeta();
+      loadTemplates();
+    } catch (error: any) {
+      message.error(error?.message || '自定义模板保存失败');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const removeTemplate = (template: TemplateView) => {
+    Modal.confirm({
+      title: `删除模板“${template.name}”？`,
+      content: `该操作不会删除已引用此模板创建的 ${template.ruleCount} 条存量规则。`,
+      okText: '删除',
+      okButtonProps: { danger: true },
+      onOk: async () => {
+        unwrap(await qualityTemplateApi.removeCustom(template.id));
+        message.success('自定义模板已删除');
+        loadFolders();
+        loadCatalogMeta();
+        loadTemplates();
+      },
+    });
+  };
+
+  const openCopy = (template: TemplateView) => {
+    setCopyTemplate(template);
+    copyForm.setFieldsValue({
+      name: `${template.name}-副本`,
+      folderId: template.folderId,
+    });
+  };
+
+  const saveCopy = async () => {
+    if (!copyTemplate) return;
+    const payload = await copyForm.validateFields();
+    setSubmitting(true);
+    try {
+      unwrap(
+        await qualityTemplateApi.copyCustom(copyTemplate.id, payload),
+      );
+      message.success('模板已复制');
+      setCopyTemplate(undefined);
+      loadFolders();
+      loadCatalogMeta();
+      loadTemplates();
+    } catch (error: any) {
+      message.error(error?.message || '模板复制失败');
+    } finally {
+      setSubmitting(false);
+    }
   };
 
   return (
@@ -258,48 +477,36 @@ const TemplateLibraryPage = () => {
         <div className="flex min-h-0 flex-1 overflow-hidden">
           <aside
             className="shrink-0 overflow-hidden transition-[width] duration-200"
-            style={{
-              width: collapsed ? 0 : leftWidth,
-            }}
+            style={{ width: collapsed ? 0 : leftWidth }}
           >
             <div
               className="h-full overflow-y-auto px-4 py-3"
-              style={{
-                width: leftWidth,
-              }}
+              style={{ width: leftWidth }}
             >
               <div className="mb-2 text-xs font-semibold text-[#161823]">
                 质量维度
               </div>
-
               <div className="space-y-1">
                 {dimensions.map((item) => {
                   const selected = dimension === item.label;
-
                   return (
                     <button
                       key={item.label}
                       type="button"
                       onClick={() => setDimension(item.label)}
-                      className={[
-                        "flex h-8 w-full cursor-pointer items-center",
-                        "justify-between border-0 px-2 text-left text-[13px]",
-                        "transition-colors duration-150",
+                      className={`flex h-8 w-full items-center justify-between border-0 px-2 text-left text-[13px] transition-colors ${
                         selected
-                          ? "bg-[rgba(254,44,85,.08)] font-medium text-[#fe2c55]"
-                          : "bg-transparent text-[#30323b] hover:bg-[#f5f5f6]",
-                      ].join(" ")}
+                          ? 'bg-[rgba(254,44,85,.08)] font-medium text-[var(--yak-brand-color)]'
+                          : 'bg-transparent text-[#30323b] hover:bg-[#f5f5f6]'
+                      }`}
                     >
                       <span className="truncate">{item.label}</span>
-
                       <span
-                        className={[
-                          "ml-3 min-w-7 shrink-0 rounded-full px-2",
-                          "text-center text-xs leading-5",
+                        className={`ml-3 min-w-7 rounded-full px-2 text-center text-xs leading-5 ${
                           selected
-                            ? "bg-white text-[#fe2c55]"
-                            : "bg-[#f2f3f5] text-[#5d616b]",
-                        ].join(" ")}
+                            ? 'bg-white text-[var(--yak-brand-color)]'
+                            : 'bg-[#f2f3f5] text-[#5d616b]'
+                        }`}
                       >
                         {item.count}
                       </span>
@@ -309,12 +516,135 @@ const TemplateLibraryPage = () => {
               </div>
 
               <div className="mt-5 border-t border-[#eceef0] pt-4">
-                <div className="mb-2 text-xs font-semibold text-[#161823]">
-                  模板范围
+                <div className="mb-2 flex items-center justify-between">
+                  <div className="text-xs font-semibold text-[#161823]">
+                    自定义模板类目
+                  </div>
+                  <div className="flex items-center gap-0.5">
+                    <Button
+                      type="text"
+                      size="small"
+                      icon={<FolderPlus size={14} />}
+                      onClick={() => openCreateFolder(selectedFolderId)}
+                    />
+                    <Button
+                      type="text"
+                      size="small"
+                      icon={<RefreshCw size={14} />}
+                      loading={folderLoading}
+                      onClick={loadFolders}
+                    />
+                  </div>
                 </div>
+                <Input
+                  allowClear
+                  variant="filled"
+                  size="small"
+                  value={folderKeyword}
+                  onChange={(event) =>
+                    setFolderKeyword(event.target.value)
+                  }
+                  prefix={
+                    <Search size={13} className="text-[#98a2b3]" />
+                  }
+                  placeholder="搜索模板类目"
+                  className="mb-2"
+                />
+                <button
+                  type="button"
+                  onClick={() => {
+                    setSelectedFolder('ALL');
+                    setActiveTab('CUSTOM');
+                  }}
+                  className={`flex h-8 w-full items-center gap-2 border-0 px-2 text-left text-[13px] ${
+                    selectedFolder === 'ALL'
+                      ? 'bg-[rgba(254,44,85,.08)] text-[var(--yak-brand-color)]'
+                      : 'bg-transparent text-[#30323b] hover:bg-[#f5f5f6]'
+                  }`}
+                >
+                  <Folder size={14} />
+                  <span className="flex-1">全部</span>
+                  <span className="text-xs text-[#8a8f99]">
+                    {catalogMeta.customTotal}
+                  </span>
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setSelectedFolder('ROOT');
+                    setActiveTab('CUSTOM');
+                  }}
+                  className={`flex h-8 w-full items-center gap-2 border-0 px-2 text-left text-[13px] ${
+                    selectedFolder === 'ROOT'
+                      ? 'bg-[rgba(254,44,85,.08)] text-[var(--yak-brand-color)]'
+                      : 'bg-transparent text-[#30323b] hover:bg-[#f5f5f6]'
+                  }`}
+                >
+                  <Folder size={14} />
+                  <span className="flex-1">未分类</span>
+                </button>
 
-                <div className="text-xs leading-6 text-[#8a8f99]">
-                  系统模板由平台统一维护，可直接关联数据质量规则。自定义模板可用于承载业务侧扩展的检查要求。
+                <Spin spinning={folderLoading} size="small">
+                  <div className="mt-0.5 space-y-0.5">
+                    {visibleFolders.map((folder) => (
+                      <Dropdown
+                        key={folder.id}
+                        trigger={['contextMenu']}
+                        menu={{
+                          items: [
+                            {
+                              key: 'child',
+                              icon: <FolderPlus size={14} />,
+                              label: '新建子目录',
+                              onClick: () =>
+                                openCreateFolder(folder.id),
+                            },
+                            {
+                              key: 'edit',
+                              icon: <Pencil size={14} />,
+                              label: '重命名或移动',
+                              onClick: () => openEditFolder(folder),
+                            },
+                            { type: 'divider' },
+                            {
+                              key: 'delete',
+                              danger: true,
+                              icon: <Trash2 size={14} />,
+                              label: '删除目录',
+                              onClick: () => removeFolder(folder),
+                            },
+                          ],
+                        }}
+                      >
+                        <button
+                          type="button"
+                          onClick={() => {
+                            setSelectedFolder(folder.id);
+                            setActiveTab('CUSTOM');
+                          }}
+                          className={`flex h-8 w-full items-center gap-2 border-0 pr-2 text-left text-[13px] ${
+                            selectedFolder === folder.id
+                              ? 'bg-[rgba(254,44,85,.08)] text-[var(--yak-brand-color)]'
+                              : 'bg-transparent text-[#30323b] hover:bg-[#f5f5f6]'
+                          }`}
+                          style={{
+                            paddingLeft: 8 + folder.depth * 16,
+                          }}
+                        >
+                          <Folder size={14} />
+                          <span className="min-w-0 flex-1 truncate">
+                            {folder.name}
+                          </span>
+                          <span className="text-xs text-[#8a8f99]">
+                            {folder.templateCount}
+                          </span>
+                        </button>
+                      </Dropdown>
+                    ))}
+                  </div>
+                </Spin>
+                <div className="mt-2 text-[11px] leading-5 text-[#98a2b3]">
+                  右键目录可新建子目录、重命名、移动或删除。
                 </div>
               </div>
             </div>
@@ -322,24 +652,15 @@ const TemplateLibraryPage = () => {
 
           <div
             role="separator"
-            aria-label="调整左侧区域宽度"
             onPointerDown={startResize}
             className="relative w-3 shrink-0 cursor-col-resize"
           >
             <div className="absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-[#e4e7ec]" />
-
             <button
               type="button"
-              aria-label={collapsed ? "展开左侧区域" : "收起左侧区域"}
               onPointerDown={(event) => event.stopPropagation()}
               onClick={() => setCollapsed((value) => !value)}
-              className={[
-                "absolute left-1/2 top-1/2 z-10 flex h-8 w-4",
-                "-translate-x-1/2 -translate-y-1/2 items-center justify-center",
-                "cursor-pointer rounded border border-[#dfe1e5] bg-white",
-                "text-[#7b808a] shadow-sm transition-colors",
-                "hover:border-[#c8cbd1] hover:text-[#161823]",
-              ].join(" ")}
+              className="absolute left-1/2 top-1/2 z-10 flex h-8 w-4 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded border border-[#dfe1e5] bg-white text-[#7b808a]"
             >
               {collapsed ? (
                 <ChevronRight size={13} />
@@ -357,152 +678,364 @@ const TemplateLibraryPage = () => {
                     <h2 className="m-0 text-[15px] font-semibold leading-6 text-[#161823]">
                       {dimension}
                     </h2>
-
                     <div className="mt-1 max-w-[900px] text-[13px] leading-6 text-[#8a8f99]">
-                      {getDimensionDescription(dimension)}
+                      {DIMENSION_DESCRIPTIONS[dimension]
+                        || `${dimension}用于衡量数据是否符合对应的数据质量要求。`}
                     </div>
                   </div>
-
-                  <Input
-                    allowClear
-                    variant="filled"
-                    value={keyword}
-                    onChange={(event) => setKeyword(event.target.value)}
-                    prefix={
-                      <Search size={14} className="shrink-0 text-[#98a2b3]" />
-                    }
-                    placeholder="搜索模板名称或描述"
-                    className="w-[340px] shrink-0"
-                  />
+                  <div className="flex shrink-0 items-center gap-2">
+                    <Input
+                      allowClear
+                      variant="filled"
+                      value={keyword}
+                      onChange={(event) =>
+                        setKeyword(event.target.value)
+                      }
+                      prefix={
+                        <Search
+                          size={14}
+                          className="text-[#98a2b3]"
+                        />
+                      }
+                      placeholder="搜索模板名称、编码或描述"
+                      className="w-[330px]"
+                    />
+                    <Button
+                      icon={<RefreshCw size={14} />}
+                      onClick={() => {
+                        loadCatalogMeta();
+                        loadTemplates();
+                      }}
+                    />
+                  </div>
                 </div>
 
                 <div className="mt-2.5 flex flex-wrap items-center gap-2">
                   <div className="inline-flex h-7 items-center rounded bg-[#f5f5f6] px-2.5 text-xs text-[#60646f]">
-                    <span>维度类型：</span>
-                    <span className="font-semibold text-[#30323b]">
+                    维度类型：
+                    <strong className="ml-1 text-[#30323b]">
                       系统维度
-                    </span>
+                    </strong>
                   </div>
-
                   <div className="inline-flex h-7 items-center rounded bg-[#f5f5f6] px-2.5 text-xs text-[#60646f]">
-                    <span>关联模板数：</span>
-                    <span className="font-semibold text-[#30323b]">
-                      {currentRecords.length}
-                    </span>
+                    关联模板数：
+                    <strong className="ml-1 text-[#30323b]">
+                      {data.records.length}
+                    </strong>
                   </div>
-
                   <div className="inline-flex h-7 items-center rounded bg-[#f5f5f6] px-2.5 text-xs text-[#60646f]">
-                    <span>关联规则数：</span>
-                    <span className="font-semibold text-[#30323b]">
+                    关联规则数：
+                    <strong className="ml-1 text-[#30323b]">
                       {relatedRuleCount}
-                    </span>
+                    </strong>
                   </div>
                 </div>
 
                 <Tabs
                   activeKey={activeTab}
                   animated={false}
-                  items={tabItems}
-                  tabBarGutter={16}
-                  onChange={(key) => setActiveTab(key as TemplateTabKey)}
-                  className={[
-                    "mt-2",
-                    "[&_.ant-tabs-nav]:!mb-0",
-                    "[&_.ant-tabs-nav]:before:!border-[#e8e9ec]",
-                    "[&_.ant-tabs-tab]:!px-3",
-                    "[&_.ant-tabs-tab]:!py-2.5",
-                    "[&_.ant-tabs-tab-btn]:!text-[13px]",
-                  ].join(" ")}
+                  items={[
+                    {
+                      key: 'SYSTEM',
+                      label: `系统模板 (${catalogMeta.systemTotal})`,
+                    },
+                    {
+                      key: 'CUSTOM',
+                      label: `自定义模板 (${catalogMeta.customTotal})`,
+                    },
+                  ]}
+                  onChange={(key) =>
+                    setActiveTab(key as TemplateTabKey)
+                  }
+                  className="mt-2 [&_.ant-tabs-nav]:!mb-0 [&_.ant-tabs-tab]:!px-3 [&_.ant-tabs-tab]:!py-2.5 [&_.ant-tabs-tab-btn]:!text-[13px]"
                 />
               </section>
 
-              <section className="min-h-0 flex-1 overflow-auto pt-3">
-                <Spin spinning={loading}>
-                  <Table<TemplateView>
-                    rowKey="id"
-                    size="small"
-                    bordered
-                    pagination={false}
-                    scroll={{
-                      x: 980,
-                    }}
-                    className={dataQualityTableClassName()}
-                    dataSource={currentRecords}
-                    locale={{
-                      emptyText: (
-                        <Empty
-                          image={Empty.PRESENTED_IMAGE_SIMPLE}
-                          description={
-                            activeTab === "CUSTOM"
-                              ? "暂无自定义模板"
-                              : "暂无系统模板"
-                          }
-                        />
-                      ),
-                    }}
-                    columns={[
-                      {
-                        title: "模板名称",
-                        dataIndex: "name",
-                        width: 260,
-                        render: (_, record) => (
-                          <div className="min-w-0 py-1">
-                            <div className="truncate font-medium text-[#172033]">
-                              {record.name}
+              <section className="min-h-0 flex flex-1 flex-col overflow-hidden pt-3">
+                {activeTab === 'CUSTOM' ? (
+                  <div className="mb-3 flex shrink-0 items-center justify-between">
+                    <Button
+                      type="primary"
+                      icon={<Plus size={14} />}
+                      onClick={openCreateTemplate}
+                    >
+                      新建规则模板
+                    </Button>
+                    <div className="text-xs text-[#8a8f99]">
+                      模板变更仅影响后续引用，不会修改存量质量规则。
+                    </div>
+                  </div>
+                ) : null}
+
+                <div className="min-h-0 flex-1 overflow-auto">
+                  <Spin spinning={loading}>
+                    <Table<TemplateView>
+                      rowKey="id"
+                      size="small"
+                      bordered
+                      pagination={false}
+                      scroll={{ x: 1080 }}
+                      className={dataQualityTableClassName()}
+                      dataSource={data.records}
+                      locale={{
+                        emptyText: (
+                          <Empty
+                            image={Empty.PRESENTED_IMAGE_SIMPLE}
+                            description={
+                              activeTab === 'CUSTOM'
+                                ? '当前目录暂无自定义模板'
+                                : '暂无系统模板'
+                            }
+                          />
+                        ),
+                      }}
+                      columns={[
+                        {
+                          title: '模板名称 / 编码',
+                          dataIndex: 'name',
+                          width: 260,
+                          render: (_, record) => (
+                            <div className="min-w-0 py-1">
+                              <button
+                                type="button"
+                                className={`block max-w-full truncate border-0 bg-transparent p-0 text-left font-medium ${
+                                  record.builtin
+                                    ? 'cursor-default text-[#172033]'
+                                    : 'cursor-pointer text-[var(--yak-brand-color)]'
+                                }`}
+                                onClick={() =>
+                                  !record.builtin
+                                  && openEditTemplate(record)
+                                }
+                              >
+                                {record.name}
+                              </button>
+                              <div className="mt-1 truncate text-[11px] text-[#98a2b3]">
+                                {record.code}
+                              </div>
                             </div>
-                          </div>
-                        ),
-                      },
-                      {
-                        title: "质量维度",
-                        dataIndex: "dimension",
-                        width: 120,
-                        render: (value) => (
-                          <Tag className="!m-0 !border-0 !bg-[#f2f4f7] !text-[#667085]">
-                            {value}
-                          </Tag>
-                        ),
-                      },
-                      {
-                        title: "关联范围",
-                        dataIndex: "scope",
-                        width: 110,
-                        render: (value) => (
-                          <div
-                            className="!m-0 !border-0 font-medium text-[#667085]"
-                            
-                          >
-                            {value === "TABLE" ? "表级" : "字段级"}
-                          </div>
-                        ),
-                      },
-                      {
-                        title: "关联规则数",
-                        dataIndex: "ruleCount",
-                        width: 120,
-                        render: (value) => (
-                          <span className="font-medium text-[#344054]">
-                            {value}
-                          </span>
-                        ),
-                      },
-                      {
-                        title: "模板描述",
-                        dataIndex: "description",
-                        render: (value) => (
-                          <div className="line-clamp-2 leading-5 text-[#667085]">
-                            {value || "--"}
-                          </div>
-                        ),
-                      },
-                    ]}
-                  />
-                </Spin>
+                          ),
+                        },
+                        {
+                          title: '质量维度',
+                          dataIndex: 'dimension',
+                          width: 110,
+                          render: (value) => (
+                            <Tag className="!m-0 !border-0 !bg-[#f2f4f7] !text-[#667085]">
+                              {value}
+                            </Tag>
+                          ),
+                        },
+                        {
+                          title: '关联范围',
+                          dataIndex: 'scope',
+                          width: 100,
+                          render: (value) => (
+                            <Tag
+                              className="!m-0 !border-0"
+                              style={{
+                                color: BRAND_COLOR,
+                                backgroundColor: BRAND_COLOR_SOFT,
+                              }}
+                            >
+                              {value === 'TABLE' ? '表级' : '字段级'}
+                            </Tag>
+                          ),
+                        },
+                        {
+                          title: '规则数',
+                          dataIndex: 'ruleCount',
+                          width: 90,
+                          render: (value) => (
+                            <span className="font-medium text-[#344054]">
+                              {value}
+                            </span>
+                          ),
+                        },
+                        ...(activeTab === 'CUSTOM'
+                          ? [
+                              {
+                                title: '所属目录',
+                                dataIndex: 'folderName',
+                                width: 130,
+                                render: (value: string) =>
+                                  value || '未分类',
+                              },
+                            ]
+                          : []),
+                        {
+                          title: '模板描述',
+                          dataIndex: 'description',
+                          render: (value) => (
+                            <div className="line-clamp-2 leading-5 text-[#667085]">
+                              {value || '--'}
+                            </div>
+                          ),
+                        },
+                        ...(activeTab === 'CUSTOM'
+                          ? [
+                              {
+                                title: '操作',
+                                fixed: 'right' as const,
+                                width: 150,
+                                render: (
+                                  _: unknown,
+                                  record: TemplateView,
+                                ) => (
+                                  <div className="flex items-center gap-1">
+                                    <Button
+                                      type="link"
+                                      size="small"
+                                      onClick={() =>
+                                        openEditTemplate(record)
+                                      }
+                                    >
+                                      编辑
+                                    </Button>
+                                    <Dropdown
+                                      menu={{
+                                        items: [
+                                          {
+                                            key: 'copy',
+                                            icon: <Copy size={14} />,
+                                            label: '复制模板',
+                                            onClick: () =>
+                                              openCopy(record),
+                                          },
+                                          {
+                                            key: 'delete',
+                                            danger: true,
+                                            icon: <Trash2 size={14} />,
+                                            label: '删除模板',
+                                            onClick: () =>
+                                              removeTemplate(record),
+                                          },
+                                        ],
+                                      }}
+                                    >
+                                      <Button
+                                        type="text"
+                                        size="small"
+                                        icon={
+                                          <Ellipsis size={15} />
+                                        }
+                                      />
+                                    </Dropdown>
+                                  </div>
+                                ),
+                              },
+                            ]
+                          : []),
+                      ]}
+                    />
+                  </Spin>
+                </div>
               </section>
             </div>
           </main>
         </div>
       </div>
+
+      <CustomTemplateDrawer
+        open={drawerOpen}
+        mode={drawerMode}
+        template={editingTemplate}
+        folders={folders}
+        defaultFolderId={selectedFolderId}
+        submitting={submitting}
+        onClose={() => setDrawerOpen(false)}
+        onSubmit={saveTemplate}
+      />
+
+      <Modal
+        title={
+          folderDialogMode === 'create'
+            ? '新建模板目录'
+            : '编辑模板目录'
+        }
+        open={folderDialogOpen}
+        confirmLoading={submitting}
+        onOk={saveFolder}
+        onCancel={() => setFolderDialogOpen(false)}
+        destroyOnClose
+      >
+        <Form
+          form={folderForm}
+          layout="vertical"
+          className="pt-3"
+        >
+          <Form.Item
+            name="name"
+            label="目录名称"
+            rules={[
+              {
+                required: true,
+                whitespace: true,
+                message: '请输入目录名称',
+              },
+            ]}
+          >
+            <Input
+              variant="filled"
+              maxLength={100}
+              placeholder="请输入目录名称"
+            />
+          </Form.Item>
+          <Form.Item name="parentId" label="上级目录">
+            <Select
+              allowClear
+              variant="filled"
+              placeholder="根目录"
+              options={flattenFolders(folders)
+                .filter((folder) => folder.id !== editingFolder?.id)
+                .map((folder) => ({
+                  value: folder.id,
+                  label: `${'　'.repeat(folder.depth)}${folder.name}`,
+                }))}
+            />
+          </Form.Item>
+        </Form>
+      </Modal>
+
+      <Modal
+        title="复制自定义规则模板"
+        open={Boolean(copyTemplate)}
+        confirmLoading={submitting}
+        onOk={saveCopy}
+        onCancel={() => setCopyTemplate(undefined)}
+        destroyOnClose
+      >
+        <Form
+          form={copyForm}
+          layout="vertical"
+          className="pt-3"
+        >
+          <Form.Item
+            name="name"
+            label="模板名称"
+            rules={[
+              {
+                required: true,
+                whitespace: true,
+                message: '请输入模板名称',
+              },
+            ]}
+          >
+            <Input variant="filled" maxLength={100} />
+          </Form.Item>
+          <Form.Item name="folderId" label="目标文件夹">
+            <Select
+              allowClear
+              variant="filled"
+              placeholder="未分类"
+              options={flattenFolders(folders).map((folder) => ({
+                value: folder.id,
+                label: `${'　'.repeat(folder.depth)}${folder.name}`,
+              }))}
+            />
+          </Form.Item>
+        </Form>
+      </Modal>
     </ConfigProvider>
   );
 };

--- a/yak-ops-ui/src/pages/data-quality/service.ts
+++ b/yak-ops-ui/src/pages/data-quality/service.ts
@@ -1,6 +1,7 @@
 import HttpUtils from '@/utils/HttpUtils';
 import type {
   CommonApiResponse,
+  CopyCustomTemplatePayload,
   ExecutionPageView,
   ExecutionView,
   MonitorPageView,
@@ -12,11 +13,15 @@ import type {
   RegisterTablesPayload,
   RegisterTablesView,
   RunView,
+  SaveCustomTemplatePayload,
   SaveMonitorPayload,
+  SaveTemplateFolderPayload,
   TableAssetPageView,
   TableCandidatePageView,
   TableMonitorSummary,
+  TemplateFolderView,
   TemplateListView,
+  TemplateView,
 } from './types';
 
 const PREFIX = '/api/v1/data-quality';
@@ -35,6 +40,35 @@ const queryString = (params: Record<string, unknown>) => {
 export const qualityTemplateApi = {
   list: (params: Record<string, unknown> = {}): Promise<CommonApiResponse<TemplateListView>> =>
     HttpUtils.get<TemplateListView>(`${PREFIX}/template${queryString(params)}`),
+  customList: (params: Record<string, unknown> = {}): Promise<CommonApiResponse<TemplateListView>> =>
+    HttpUtils.get<TemplateListView>(`${PREFIX}/template/custom${queryString(params)}`),
+  detail: (id: number | string): Promise<CommonApiResponse<TemplateView>> =>
+    HttpUtils.get<TemplateView>(`${PREFIX}/template/${id}`),
+  folders: (): Promise<CommonApiResponse<TemplateFolderView[]>> =>
+    HttpUtils.get<TemplateFolderView[]>(`${PREFIX}/template/folder`),
+  createFolder: (payload: SaveTemplateFolderPayload): Promise<CommonApiResponse<TemplateFolderView>> =>
+    HttpUtils.post<TemplateFolderView>(`${PREFIX}/template/folder`, payload),
+  updateFolder: (
+    id: number | string,
+    payload: SaveTemplateFolderPayload,
+  ): Promise<CommonApiResponse<TemplateFolderView>> =>
+    HttpUtils.put<TemplateFolderView>(`${PREFIX}/template/folder/${id}`, payload),
+  removeFolder: (id: number | string): Promise<CommonApiResponse<boolean>> =>
+    HttpUtils.delete<boolean>(`${PREFIX}/template/folder/${id}`),
+  createCustom: (payload: SaveCustomTemplatePayload): Promise<CommonApiResponse<TemplateView>> =>
+    HttpUtils.post<TemplateView>(`${PREFIX}/template/custom`, payload),
+  updateCustom: (
+    id: number | string,
+    payload: SaveCustomTemplatePayload,
+  ): Promise<CommonApiResponse<TemplateView>> =>
+    HttpUtils.put<TemplateView>(`${PREFIX}/template/custom/${id}`, payload),
+  copyCustom: (
+    id: number | string,
+    payload: CopyCustomTemplatePayload,
+  ): Promise<CommonApiResponse<TemplateView>> =>
+    HttpUtils.post<TemplateView>(`${PREFIX}/template/custom/${id}/copy`, payload),
+  removeCustom: (id: number | string): Promise<CommonApiResponse<boolean>> =>
+    HttpUtils.delete<boolean>(`${PREFIX}/template/custom/${id}`),
 };
 
 export const qualityTableAssetApi = {

--- a/yak-ops-ui/src/pages/data-quality/types.ts
+++ b/yak-ops-ui/src/pages/data-quality/types.ts
@@ -7,6 +7,9 @@ export type RuleType =
   | 'COLUMN_ENUM'
   | 'CUSTOM_SQL';
 export type ComparisonOperator = 'GT' | 'GTE' | 'EQ' | 'LTE' | 'LT' | 'BETWEEN';
+export type TemplateSource = 'SYSTEM' | 'CUSTOM';
+export type CustomCheckType = 'NUMERIC';
+export type CustomCheckMethod = 'FIXED_VALUE';
 export type ExecutionStatus = 'WAITING' | 'RUNNING' | 'SUCCESS' | 'FAILED';
 export type CheckResult = 'PASSED' | 'NOT_PASSED' | 'ERROR' | 'RUNNING' | 'NOT_RUN';
 export type TriggerType = 'MANUAL' | 'SCHEDULE';
@@ -37,11 +40,63 @@ export interface TemplateView {
   enabled: boolean;
   ruleCount: number;
   sortOrder: number;
+  folderId?: number;
+  folderName?: string;
+  templateSql?: string;
+  setFlag?: string;
+  checkType?: CustomCheckType;
+  checkMethod?: CustomCheckMethod;
+  createdBy?: string;
+  createdAt?: string;
+  updatedAt?: string;
+  source?: TemplateSource;
+}
+
+export interface TemplateSummary {
+  total: number;
+  systemTotal: number;
+  customTotal: number;
+  dimensions: Record<string, number>;
 }
 
 export interface TemplateListView {
   records: TemplateView[];
-  summary: { total: number; dimensions: Record<string, number> };
+  summary: TemplateSummary;
+}
+
+export interface TemplateFolderView {
+  id: number;
+  parentId?: number;
+  name: string;
+  sortOrder: number;
+  templateCount: number;
+  childCount: number;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export interface SaveTemplateFolderPayload {
+  name: string;
+  parentId?: number;
+}
+
+export interface SaveCustomTemplatePayload {
+  name: string;
+  description?: string;
+  dimension: string;
+  folderId?: number;
+  setFlag?: string;
+  checkType: CustomCheckType;
+  checkMethod: CustomCheckMethod;
+  customSql: string;
+  defaultOperator: ComparisonOperator;
+  defaultThreshold: number;
+  defaultThresholdEnd?: number;
+}
+
+export interface CopyCustomTemplatePayload {
+  name: string;
+  folderId?: number;
 }
 
 export interface SaveRulePayload {


### PR DESCRIPTION
## 变更说明

完成数据质量「规则模板库」中的自定义模板前后端闭环，并参考现有页面补充目录化管理交互。

### 前端
- 增加自定义模板 Tab、目录树、目录搜索和右键菜单
- 支持目录新建、重命名、移动和删除
- 支持自定义模板新建、编辑、复制和删除
- 新建/编辑使用右侧 Drawer，支持质量维度、目标目录、Set Flag、自定义 SQL、默认比较方式和阈值
- 关联范围标签统一复用 Yak Ops 品牌色
- 自定义模板可在监控规则编辑器中直接选择，并自动带入 SQL、比较方式和默认阈值

### 后端
- 新增自定义模板目录和模板 CRUD API
- 新增模板名称/目录名称唯一性校验、目录循环校验和非空目录删除保护
- 自定义 SQL 限制为单条只读 SELECT，并兼容 `${tableName}`、`${table}`、`${column}`、`${where}` 占位符
- 模板更新和删除不改写已经创建的存量质量规则；已有规则继续使用保存时的快照
- 新增创建、更新、删除权限并默认授予 root 角色

### 数据库
- 新增 `yak_quality_template_folder`
- 扩展 `yak_quality_rule_template`，保存目录、SQL、Set Flag、校验类型、校验方式和创建人

### 校验
- 新增 `CustomTemplateServiceTest`
- 已对新增 Java API/Repository/Service 使用本地编译桩执行语法与类型校验
- 已使用 TypeScript `transpileModule` 校验本次修改的 TS/TSX 文件

## 当前范围

当前执行引擎支持「数值型 + 与固定值比较」，因此本次自定义模板完整接入该能力。Set Flag 已支持配置、持久化和编辑，但当前执行器暂不下发 Set Flag；页面中已明确提示，避免形成不可见行为。