### PR TITLE
feat(data-quality): 重构运行记录工作台与详情页

### DIFF
--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/api/QualityExecutionWorkspaceApi.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/api/QualityExecutionWorkspaceApi.java
@@ -1,0 +1,169 @@
+package io.yak.ops.business.quality.api;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.yak.ops.business.quality.api.QualityApi.CheckResult;
+import io.yak.ops.business.quality.api.QualityApi.ExecutionStatus;
+import io.yak.ops.business.quality.api.QualityApi.RuleScope;
+import io.yak.ops.business.quality.api.QualityApi.RuleType;
+import io.yak.ops.business.quality.api.QualityApi.TriggerType;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import java.time.LocalDateTime;
+import java.util.List;
+
+/** Read-only contracts used by the execution list and execution workspace. */
+public final class QualityExecutionWorkspaceApi {
+
+  private QualityExecutionWorkspaceApi() {
+  }
+
+  public enum LogLevel { INFO, WARN, ERROR }
+
+  public record ExecutionPageRequest(
+      @Min(1) Integer current,
+      @Min(1) @Max(100) Integer pageSize,
+      String keyword,
+      String objectKeyword,
+      Long dataSourceId,
+      Long monitorId,
+      ExecutionStatus executionStatus,
+      CheckResult checkResult,
+      TriggerType triggerType,
+      Boolean hasIssues,
+      String dimension,
+      RuleScope scope,
+      @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime queuedAfter,
+      @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime queuedBefore) {
+
+    public int normalizedCurrent() {
+      return current == null ? 1 : current;
+    }
+
+    public int normalizedPageSize() {
+      return pageSize == null ? 20 : pageSize;
+    }
+  }
+
+  public record ExecutionListItem(
+      String executionNo,
+      Long monitorId,
+      String monitorName,
+      Long dataSourceId,
+      String dataSourceName,
+      String objectName,
+      TriggerType triggerType,
+      ExecutionStatus executionStatus,
+      CheckResult checkResult,
+      int totalRules,
+      int passedRules,
+      int failedRules,
+      int errorRules,
+      String operator,
+      @QualityDateTimeFormat LocalDateTime queuedAt,
+      @QualityDateTimeFormat LocalDateTime startedAt,
+      @QualityDateTimeFormat LocalDateTime finishedAt,
+      Long durationMs,
+      String errorMessage) {
+  }
+
+  public record RuleExecutionListItem(
+      Long id,
+      Long ruleId,
+      String executionNo,
+      Long monitorId,
+      String monitorName,
+      Long dataSourceId,
+      String dataSourceName,
+      String databaseName,
+      String schemaName,
+      String tableName,
+      String objectName,
+      String ruleName,
+      String templateCode,
+      RuleType ruleType,
+      RuleScope scope,
+      String dimension,
+      String columnName,
+      TriggerType triggerType,
+      ExecutionStatus executionStatus,
+      CheckResult checkResult,
+      String metricValue,
+      String expectedValue,
+      String operator,
+      @QualityDateTimeFormat LocalDateTime queuedAt,
+      @QualityDateTimeFormat LocalDateTime startedAt,
+      @QualityDateTimeFormat LocalDateTime finishedAt,
+      Long durationMs,
+      String errorMessage) {
+  }
+
+  public record RuleExecutionView(
+      Long id,
+      Long ruleId,
+      String ruleName,
+      String templateCode,
+      RuleType ruleType,
+      RuleScope scope,
+      String dimension,
+      String columnName,
+      CheckResult checkResult,
+      String metricValue,
+      String expectedValue,
+      String executedSql,
+      String errorMessage,
+      Long durationMs,
+      @QualityDateTimeFormat LocalDateTime createdAt) {
+  }
+
+  public record ExecutionView(
+      String executionNo,
+      Long monitorId,
+      String monitorName,
+      Long dataSourceId,
+      String dataSourceName,
+      String databaseName,
+      String schemaName,
+      String tableName,
+      String objectName,
+      TriggerType triggerType,
+      ExecutionStatus executionStatus,
+      CheckResult checkResult,
+      int totalRules,
+      int passedRules,
+      int failedRules,
+      int errorRules,
+      String operator,
+      @QualityDateTimeFormat LocalDateTime queuedAt,
+      @QualityDateTimeFormat LocalDateTime startedAt,
+      @QualityDateTimeFormat LocalDateTime finishedAt,
+      Long durationMs,
+      String errorMessage,
+      List<RuleExecutionView> rules) {
+  }
+
+  public record ExecutionPageView(
+      List<ExecutionListItem> records,
+      long total,
+      int current,
+      int pageSize) {
+  }
+
+  public record RuleExecutionPageView(
+      List<RuleExecutionListItem> records,
+      long total,
+      int current,
+      int pageSize) {
+  }
+
+  public record ExecutionLogLine(
+      @QualityDateTimeFormat LocalDateTime timestamp,
+      LogLevel level,
+      String stage,
+      String message) {
+  }
+
+  public record ExecutionLogView(
+      String executionNo,
+      List<ExecutionLogLine> lines) {
+  }
+}

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/controller/v1/QualityExecutionWorkspaceController.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/controller/v1/QualityExecutionWorkspaceController.java
@@ -1,0 +1,61 @@
+package io.yak.ops.business.quality.controller.v1;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.yak.framework.common.Result;
+import io.yak.framework.security.web.RequiresPermission;
+import io.yak.ops.business.quality.QualityPermissionCode;
+import io.yak.ops.business.quality.api.QualityExecutionWorkspaceApi.ExecutionLogView;
+import io.yak.ops.business.quality.api.QualityExecutionWorkspaceApi.ExecutionPageRequest;
+import io.yak.ops.business.quality.api.QualityExecutionWorkspaceApi.ExecutionPageView;
+import io.yak.ops.business.quality.api.QualityExecutionWorkspaceApi.ExecutionView;
+import io.yak.ops.business.quality.api.QualityExecutionWorkspaceApi.RuleExecutionPageView;
+import io.yak.ops.business.quality.config.ConditionalOnQualityEnabled;
+import io.yak.ops.business.quality.service.QualityExecutionWorkspaceService;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "数据质量执行工作台")
+@RestController
+@ConditionalOnQualityEnabled
+@RequestMapping("/api/v1/data-quality/execution/workspace")
+@RequiresPermission(QualityPermissionCode.EXECUTION_READ)
+public class QualityExecutionWorkspaceController {
+
+  private final QualityExecutionWorkspaceService service;
+
+  public QualityExecutionWorkspaceController(QualityExecutionWorkspaceService service) {
+    this.service = service;
+  }
+
+  @Operation(summary = "分页查询监控执行记录")
+  @PostMapping("/page")
+  public Result<ExecutionPageView> page(
+      @Valid @RequestBody(required = false) ExecutionPageRequest request) {
+    return Result.success(service.page(request));
+  }
+
+  @Operation(summary = "分页查询规则执行记录")
+  @PostMapping("/rule/page")
+  public Result<RuleExecutionPageView> pageRules(
+      @Valid @RequestBody(required = false) ExecutionPageRequest request) {
+    return Result.success(service.pageRules(request));
+  }
+
+  @Operation(summary = "查询执行工作台详情")
+  @GetMapping("/{executionNo}")
+  public Result<ExecutionView> detail(@PathVariable String executionNo) {
+    return Result.success(service.get(executionNo));
+  }
+
+  @Operation(summary = "查询执行结构化日志")
+  @GetMapping("/{executionNo}/logs")
+  public Result<ExecutionLogView> logs(@PathVariable String executionNo) {
+    return Result.success(service.logs(executionNo));
+  }
+}

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/repository/QualityExecutionWorkspaceRepository.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/repository/QualityExecutionWorkspaceRepository.java
@@ -1,0 +1,377 @@
+package io.yak.ops.business.quality.repository;
+
+import io.yak.ops.business.quality.api.QualityApi.CheckResult;
+import io.yak.ops.business.quality.api.QualityApi.ExecutionStatus;
+import io.yak.ops.business.quality.api.QualityApi.RuleType;
+import io.yak.ops.business.quality.api.QualityApi.TriggerType;
+import io.yak.ops.business.quality.api.QualityExecutionWorkspaceApi.ExecutionListItem;
+import io.yak.ops.business.quality.api.QualityExecutionWorkspaceApi.ExecutionPageRequest;
+import io.yak.ops.business.quality.api.QualityExecutionWorkspaceApi.ExecutionView;
+import io.yak.ops.business.quality.api.QualityExecutionWorkspaceApi.RuleExecutionListItem;
+import io.yak.ops.business.quality.api.QualityExecutionWorkspaceApi.RuleExecutionView;
+import io.yak.ops.business.quality.config.ConditionalOnQualityEnabled;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+@ConditionalOnQualityEnabled
+@Repository
+public class QualityExecutionWorkspaceRepository {
+
+  private static final String EXECUTION_COLUMNS = """
+      e.id, e.execution_no, e.monitor_id, e.monitor_name, e.data_source_id,
+      e.data_source_name, e.database_name, e.schema_name, e.table_name,
+      e.object_name, e.trigger_type, e.execution_status, e.check_result,
+      e.total_rules, e.passed_rules, e.failed_rules, e.error_rules,
+      e.operator_name, e.queued_at, e.started_at, e.finished_at,
+      e.duration_ms, e.error_message
+      """;
+
+  private static final String RULE_EXECUTION_COLUMNS = """
+      r.id AS rule_execution_id, r.rule_id, r.rule_name, r.template_code,
+      r.rule_type, r.column_name, r.check_result AS rule_check_result,
+      r.metric_value, r.expected_value, r.duration_ms AS rule_duration_ms,
+      r.error_message AS rule_error_message,
+      e.execution_no, e.monitor_id, e.monitor_name, e.data_source_id,
+      e.data_source_name, e.database_name, e.schema_name, e.table_name,
+      e.object_name, e.trigger_type, e.execution_status, e.operator_name,
+      e.queued_at, e.started_at, e.finished_at
+      """;
+
+  private final NamedParameterJdbcTemplate jdbcTemplate;
+  private final RowMapper<ExecutionListItem> executionMapper = this::mapExecution;
+  private final RowMapper<RuleExecutionListItem> ruleListMapper = this::mapRuleListItem;
+  private final RowMapper<RuleExecutionView> ruleExecutionMapper = this::mapRuleExecution;
+
+  public QualityExecutionWorkspaceRepository(
+      @Qualifier("qualityJdbcTemplate") NamedParameterJdbcTemplate jdbcTemplate) {
+    this.jdbcTemplate = jdbcTemplate;
+  }
+
+  public PageResult<ExecutionListItem> page(ExecutionPageRequest request) {
+    ExecutionPageRequest normalized = normalize(request);
+    StringBuilder where = new StringBuilder(" WHERE 1 = 1");
+    MapSqlParameterSource params = new MapSqlParameterSource();
+    appendFilters(normalized, where, params, false);
+
+    Long total = jdbcTemplate.queryForObject(
+        "SELECT COUNT(*) FROM yak_quality_execution e" + where,
+        params,
+        Long.class);
+    appendPagination(normalized, params);
+
+    List<ExecutionListItem> records = jdbcTemplate.query(
+        "SELECT " + EXECUTION_COLUMNS
+            + " FROM yak_quality_execution e"
+            + where
+            + " ORDER BY e.queued_at DESC, e.id DESC LIMIT :limit OFFSET :offset",
+        params,
+        executionMapper);
+    return new PageResult<>(records, total == null ? 0L : total);
+  }
+
+  public PageResult<RuleExecutionListItem> pageRules(ExecutionPageRequest request) {
+    ExecutionPageRequest normalized = normalize(request);
+    StringBuilder where = new StringBuilder(" WHERE 1 = 1");
+    MapSqlParameterSource params = new MapSqlParameterSource();
+    appendFilters(normalized, where, params, true);
+
+    String from = " FROM yak_quality_rule_execution r"
+        + " INNER JOIN yak_quality_execution e ON e.id = r.execution_id";
+    Long total = jdbcTemplate.queryForObject(
+        "SELECT COUNT(*)" + from + where,
+        params,
+        Long.class);
+    appendPagination(normalized, params);
+
+    List<RuleExecutionListItem> records = jdbcTemplate.query(
+        "SELECT " + RULE_EXECUTION_COLUMNS
+            + from
+            + where
+            + " ORDER BY e.queued_at DESC, e.id DESC, r.id ASC"
+            + " LIMIT :limit OFFSET :offset",
+        params,
+        ruleListMapper);
+    return new PageResult<>(records, total == null ? 0L : total);
+  }
+
+  public Optional<ExecutionView> find(String executionNo) {
+    try {
+      ExecutionRecord record = jdbcTemplate.queryForObject(
+          "SELECT " + EXECUTION_COLUMNS
+              + " FROM yak_quality_execution e WHERE e.execution_no = :executionNo",
+          new MapSqlParameterSource("executionNo", executionNo),
+          this::mapRecord);
+      if (record == null) {
+        return Optional.empty();
+      }
+
+      List<RuleExecutionView> rules = jdbcTemplate.query(
+          """
+          SELECT id, rule_id, rule_name, template_code, rule_type,
+                 column_name, check_result, metric_value, expected_value,
+                 executed_sql, error_message, duration_ms, created_at
+          FROM yak_quality_rule_execution
+          WHERE execution_id = :executionId
+          ORDER BY id ASC
+          """,
+          new MapSqlParameterSource("executionId", record.id()),
+          ruleExecutionMapper);
+      ExecutionListItem item = record.item();
+      return Optional.of(new ExecutionView(
+          item.executionNo(),
+          item.monitorId(),
+          item.monitorName(),
+          item.dataSourceId(),
+          item.dataSourceName(),
+          record.databaseName(),
+          record.schemaName(),
+          record.tableName(),
+          item.objectName(),
+          item.triggerType(),
+          item.executionStatus(),
+          item.checkResult(),
+          item.totalRules(),
+          item.passedRules(),
+          item.failedRules(),
+          item.errorRules(),
+          item.operator(),
+          item.queuedAt(),
+          item.startedAt(),
+          item.finishedAt(),
+          item.durationMs(),
+          item.errorMessage(),
+          rules));
+    } catch (EmptyResultDataAccessException ignored) {
+      return Optional.empty();
+    }
+  }
+
+  private static ExecutionPageRequest normalize(ExecutionPageRequest request) {
+    return request == null
+        ? new ExecutionPageRequest(
+            1, 20, null, null, null, null, null, null, null, null,
+            null, null, null, null)
+        : request;
+  }
+
+  private static void appendPagination(
+      ExecutionPageRequest request,
+      MapSqlParameterSource params) {
+    params.addValue("limit", request.normalizedPageSize());
+    params.addValue(
+        "offset",
+        (request.normalizedCurrent() - 1L) * request.normalizedPageSize());
+  }
+
+  private static void appendFilters(
+      ExecutionPageRequest request,
+      StringBuilder where,
+      MapSqlParameterSource params,
+      boolean ruleMode) {
+    if (QualityRepositorySupport.hasText(request.keyword())) {
+      where.append(ruleMode
+          ? """
+             AND (LOWER(e.execution_no) LIKE :keyword
+               OR LOWER(e.monitor_name) LIKE :keyword
+               OR LOWER(r.rule_name) LIKE :keyword
+               OR LOWER(r.template_code) LIKE :keyword)
+            """
+          : """
+             AND (LOWER(e.execution_no) LIKE :keyword
+               OR LOWER(e.monitor_name) LIKE :keyword)
+            """);
+      params.addValue(
+          "keyword", "%" + request.keyword().trim().toLowerCase() + "%");
+    }
+    if (QualityRepositorySupport.hasText(request.objectKeyword())) {
+      where.append("""
+           AND (LOWER(e.object_name) LIKE :objectKeyword
+             OR LOWER(e.table_name) LIKE :objectKeyword
+             OR LOWER(e.data_source_name) LIKE :objectKeyword)
+          """);
+      params.addValue(
+          "objectKeyword",
+          "%" + request.objectKeyword().trim().toLowerCase() + "%");
+    }
+    if (request.dataSourceId() != null) {
+      where.append(" AND e.data_source_id = :dataSourceId");
+      params.addValue("dataSourceId", request.dataSourceId());
+    }
+    if (request.monitorId() != null) {
+      where.append(" AND e.monitor_id = :monitorId");
+      params.addValue("monitorId", request.monitorId());
+    }
+    if (request.executionStatus() != null) {
+      where.append(" AND e.execution_status = :executionStatus");
+      params.addValue("executionStatus", request.executionStatus().name());
+    }
+    if (request.checkResult() != null) {
+      where.append(ruleMode
+          ? " AND r.check_result = :checkResult"
+          : " AND e.check_result = :checkResult");
+      params.addValue("checkResult", request.checkResult().name());
+    }
+    if (request.triggerType() != null) {
+      where.append(" AND e.trigger_type = :triggerType");
+      params.addValue("triggerType", request.triggerType().name());
+    }
+    if (request.hasIssues() != null) {
+      if (ruleMode) {
+        where.append(request.hasIssues()
+            ? " AND r.check_result IN ('NOT_PASSED', 'ERROR')"
+            : " AND r.check_result NOT IN ('NOT_PASSED', 'ERROR')");
+      } else {
+        where.append(request.hasIssues()
+            ? " AND (e.failed_rules + e.error_rules) > 0"
+            : " AND (e.failed_rules + e.error_rules) = 0");
+      }
+    }
+    if (request.queuedAfter() != null) {
+      where.append(" AND e.queued_at >= :queuedAfter");
+      params.addValue("queuedAfter", Timestamp.valueOf(request.queuedAfter()));
+    }
+    if (request.queuedBefore() != null) {
+      where.append(" AND e.queued_at <= :queuedBefore");
+      params.addValue("queuedBefore", Timestamp.valueOf(request.queuedBefore()));
+    }
+
+    List<String> ruleTypes = matchingRuleTypes(request);
+    boolean hasRuleTypeFilter = QualityRepositorySupport.hasText(request.dimension())
+        || request.scope() != null;
+    if (hasRuleTypeFilter && ruleTypes.isEmpty()) {
+      where.append(" AND 1 = 0");
+    } else if (hasRuleTypeFilter) {
+      params.addValue("ruleTypes", ruleTypes);
+      where.append(ruleMode
+          ? " AND r.rule_type IN (:ruleTypes)"
+          : """
+             AND EXISTS (
+               SELECT 1 FROM yak_quality_rule_execution rf
+               WHERE rf.execution_id = e.id AND rf.rule_type IN (:ruleTypes)
+             )
+            """);
+    }
+  }
+
+  private static List<String> matchingRuleTypes(ExecutionPageRequest request) {
+    List<String> types = new ArrayList<>();
+    for (RuleType type : RuleType.values()) {
+      boolean dimensionMatches = !QualityRepositorySupport.hasText(request.dimension())
+          || type.dimension().equals(request.dimension().trim());
+      boolean scopeMatches = request.scope() == null || type.scope() == request.scope();
+      if (dimensionMatches && scopeMatches) {
+        types.add(type.name());
+      }
+    }
+    return types;
+  }
+
+  private ExecutionRecord mapRecord(ResultSet rs, int rowNum) throws SQLException {
+    return new ExecutionRecord(
+        rs.getLong("id"),
+        rs.getString("database_name"),
+        rs.getString("schema_name"),
+        rs.getString("table_name"),
+        mapExecution(rs, rowNum));
+  }
+
+  private ExecutionListItem mapExecution(ResultSet rs, int rowNum) throws SQLException {
+    return new ExecutionListItem(
+        rs.getString("execution_no"),
+        rs.getLong("monitor_id"),
+        rs.getString("monitor_name"),
+        rs.getLong("data_source_id"),
+        rs.getString("data_source_name"),
+        rs.getString("object_name"),
+        TriggerType.valueOf(rs.getString("trigger_type")),
+        ExecutionStatus.valueOf(rs.getString("execution_status")),
+        QualityRepositorySupport.checkResult(rs.getString("check_result")),
+        rs.getInt("total_rules"),
+        rs.getInt("passed_rules"),
+        rs.getInt("failed_rules"),
+        rs.getInt("error_rules"),
+        rs.getString("operator_name"),
+        QualityRepositorySupport.localDateTime(rs.getTimestamp("queued_at")),
+        QualityRepositorySupport.localDateTime(rs.getTimestamp("started_at")),
+        QualityRepositorySupport.localDateTime(rs.getTimestamp("finished_at")),
+        QualityRepositorySupport.nullableLong(rs, "duration_ms"),
+        rs.getString("error_message"));
+  }
+
+  private RuleExecutionListItem mapRuleListItem(ResultSet rs, int rowNum)
+      throws SQLException {
+    RuleType ruleType = RuleType.valueOf(rs.getString("rule_type"));
+    return new RuleExecutionListItem(
+        rs.getLong("rule_execution_id"),
+        rs.getLong("rule_id"),
+        rs.getString("execution_no"),
+        rs.getLong("monitor_id"),
+        rs.getString("monitor_name"),
+        rs.getLong("data_source_id"),
+        rs.getString("data_source_name"),
+        rs.getString("database_name"),
+        rs.getString("schema_name"),
+        rs.getString("table_name"),
+        rs.getString("object_name"),
+        rs.getString("rule_name"),
+        rs.getString("template_code"),
+        ruleType,
+        ruleType.scope(),
+        ruleType.dimension(),
+        rs.getString("column_name"),
+        TriggerType.valueOf(rs.getString("trigger_type")),
+        ExecutionStatus.valueOf(rs.getString("execution_status")),
+        QualityRepositorySupport.checkResult(rs.getString("rule_check_result")),
+        rs.getString("metric_value"),
+        rs.getString("expected_value"),
+        rs.getString("operator_name"),
+        QualityRepositorySupport.localDateTime(rs.getTimestamp("queued_at")),
+        QualityRepositorySupport.localDateTime(rs.getTimestamp("started_at")),
+        QualityRepositorySupport.localDateTime(rs.getTimestamp("finished_at")),
+        QualityRepositorySupport.nullableLong(rs, "rule_duration_ms"),
+        rs.getString("rule_error_message"));
+  }
+
+  private RuleExecutionView mapRuleExecution(ResultSet rs, int rowNum) throws SQLException {
+    RuleType ruleType = RuleType.valueOf(rs.getString("rule_type"));
+    CheckResult checkResult = QualityRepositorySupport.checkResult(
+        rs.getString("check_result"));
+    return new RuleExecutionView(
+        rs.getLong("id"),
+        rs.getLong("rule_id"),
+        rs.getString("rule_name"),
+        rs.getString("template_code"),
+        ruleType,
+        ruleType.scope(),
+        ruleType.dimension(),
+        rs.getString("column_name"),
+        checkResult,
+        rs.getString("metric_value"),
+        rs.getString("expected_value"),
+        rs.getString("executed_sql"),
+        rs.getString("error_message"),
+        QualityRepositorySupport.nullableLong(rs, "duration_ms"),
+        QualityRepositorySupport.localDateTime(rs.getTimestamp("created_at")));
+  }
+
+  public record PageResult<T>(List<T> records, long total) {
+  }
+
+  private record ExecutionRecord(
+      long id,
+      String databaseName,
+      String schemaName,
+      String tableName,
+      ExecutionListItem item) {
+  }
+}

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/service/QualityExecutionWorkspaceService.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/service/QualityExecutionWorkspaceService.java
@@ -1,0 +1,175 @@
+package io.yak.ops.business.quality.service;
+
+import io.yak.ops.business.quality.api.QualityApi.CheckResult;
+import io.yak.ops.business.quality.api.QualityExecutionWorkspaceApi.ExecutionLogLine;
+import io.yak.ops.business.quality.api.QualityExecutionWorkspaceApi.ExecutionLogView;
+import io.yak.ops.business.quality.api.QualityExecutionWorkspaceApi.ExecutionPageRequest;
+import io.yak.ops.business.quality.api.QualityExecutionWorkspaceApi.ExecutionPageView;
+import io.yak.ops.business.quality.api.QualityExecutionWorkspaceApi.ExecutionView;
+import io.yak.ops.business.quality.api.QualityExecutionWorkspaceApi.LogLevel;
+import io.yak.ops.business.quality.api.QualityExecutionWorkspaceApi.RuleExecutionListItem;
+import io.yak.ops.business.quality.api.QualityExecutionWorkspaceApi.RuleExecutionPageView;
+import io.yak.ops.business.quality.api.QualityExecutionWorkspaceApi.RuleExecutionView;
+import io.yak.ops.business.quality.config.ConditionalOnQualityEnabled;
+import io.yak.ops.business.quality.repository.QualityExecutionWorkspaceRepository;
+import io.yak.ops.business.quality.repository.QualityExecutionWorkspaceRepository.PageResult;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@ConditionalOnQualityEnabled
+@Service
+public class QualityExecutionWorkspaceService {
+
+  private final QualityExecutionWorkspaceRepository repository;
+
+  public QualityExecutionWorkspaceService(QualityExecutionWorkspaceRepository repository) {
+    this.repository = repository;
+  }
+
+  @Transactional(readOnly = true, transactionManager = "yakBusinessTransactionManager")
+  public ExecutionPageView page(ExecutionPageRequest request) {
+    ExecutionPageRequest normalized = normalize(request);
+    PageResult<io.yak.ops.business.quality.api.QualityExecutionWorkspaceApi.ExecutionListItem>
+        result = repository.page(normalized);
+    return new ExecutionPageView(
+        result.records(),
+        result.total(),
+        normalized.normalizedCurrent(),
+        normalized.normalizedPageSize());
+  }
+
+  @Transactional(readOnly = true, transactionManager = "yakBusinessTransactionManager")
+  public RuleExecutionPageView pageRules(ExecutionPageRequest request) {
+    ExecutionPageRequest normalized = normalize(request);
+    PageResult<RuleExecutionListItem> result = repository.pageRules(normalized);
+    return new RuleExecutionPageView(
+        result.records(),
+        result.total(),
+        normalized.normalizedCurrent(),
+        normalized.normalizedPageSize());
+  }
+
+  @Transactional(readOnly = true, transactionManager = "yakBusinessTransactionManager")
+  public ExecutionView get(String executionNo) {
+    return repository.find(executionNo)
+        .orElseThrow(
+            () -> new IllegalArgumentException("质量执行记录不存在：" + executionNo));
+  }
+
+  @Transactional(readOnly = true, transactionManager = "yakBusinessTransactionManager")
+  public ExecutionLogView logs(String executionNo) {
+    ExecutionView execution = get(executionNo);
+    List<ExecutionLogLine> lines = new ArrayList<>();
+    lines.add(new ExecutionLogLine(
+        execution.queuedAt(),
+        LogLevel.INFO,
+        "DISPATCH",
+        "执行任务已创建，触发方式：" + triggerLabel(execution)
+            + "，操作人：" + safe(execution.operator())));
+
+    if (execution.startedAt() != null) {
+      lines.add(new ExecutionLogLine(
+          execution.startedAt(),
+          LogLevel.INFO,
+          "EXECUTION",
+          "开始执行质量检查，共 " + execution.totalRules() + " 条规则"));
+    }
+
+    for (RuleExecutionView rule : execution.rules()) {
+      lines.add(new ExecutionLogLine(
+          fallback(rule.createdAt(), execution.startedAt(), execution.queuedAt()),
+          logLevel(rule.checkResult()),
+          "RULE",
+          ruleMessage(rule)));
+    }
+
+    if (execution.errorMessage() != null && !execution.errorMessage().isBlank()) {
+      lines.add(new ExecutionLogLine(
+          fallback(execution.finishedAt(), execution.startedAt(), execution.queuedAt()),
+          LogLevel.ERROR,
+          "EXECUTION",
+          execution.errorMessage()));
+    }
+
+    if (execution.finishedAt() != null) {
+      lines.add(new ExecutionLogLine(
+          execution.finishedAt(),
+          execution.checkResult() == CheckResult.PASSED ? LogLevel.INFO : LogLevel.WARN,
+          "FINISH",
+          "执行结束：通过 " + execution.passedRules()
+              + "，未通过 " + execution.failedRules()
+              + "，异常 " + execution.errorRules()
+              + "，耗时 " + (execution.durationMs() == null ? 0 : execution.durationMs())
+              + " ms"));
+    }
+
+    return new ExecutionLogView(execution.executionNo(), List.copyOf(lines));
+  }
+
+  private static ExecutionPageRequest normalize(ExecutionPageRequest request) {
+    return request == null
+        ? new ExecutionPageRequest(
+            1, 20, null, null, null, null, null, null, null, null,
+            null, null, null, null)
+        : request;
+  }
+
+  private static String ruleMessage(RuleExecutionView rule) {
+    StringBuilder message = new StringBuilder()
+        .append("规则「")
+        .append(rule.ruleName())
+        .append("」")
+        .append(resultLabel(rule.checkResult()));
+    if (rule.metricValue() != null && !rule.metricValue().isBlank()) {
+      message.append("，实际值：").append(rule.metricValue());
+    }
+    if (rule.expectedValue() != null && !rule.expectedValue().isBlank()) {
+      message.append("，期望值：").append(rule.expectedValue());
+    }
+    if (rule.durationMs() != null) {
+      message.append("，耗时：").append(rule.durationMs()).append(" ms");
+    }
+    if (rule.errorMessage() != null && !rule.errorMessage().isBlank()) {
+      message.append("，错误：").append(rule.errorMessage());
+    }
+    return message.toString();
+  }
+
+  private static String resultLabel(CheckResult result) {
+    return switch (result) {
+      case PASSED -> "通过";
+      case NOT_PASSED -> "未通过";
+      case ERROR -> "执行异常";
+      case RUNNING -> "运行中";
+      case NOT_RUN -> "未运行";
+    };
+  }
+
+  private static LogLevel logLevel(CheckResult result) {
+    return switch (result) {
+      case PASSED, RUNNING, NOT_RUN -> LogLevel.INFO;
+      case NOT_PASSED -> LogLevel.WARN;
+      case ERROR -> LogLevel.ERROR;
+    };
+  }
+
+  private static String triggerLabel(ExecutionView execution) {
+    return execution.triggerType().name().equals("SCHEDULE") ? "调度触发" : "手动触发";
+  }
+
+  private static String safe(String value) {
+    return value == null || value.isBlank() ? "system" : value;
+  }
+
+  private static LocalDateTime fallback(LocalDateTime... values) {
+    for (LocalDateTime value : values) {
+      if (value != null) {
+        return value;
+      }
+    }
+    return LocalDateTime.now();
+  }
+}

--- a/yak-ops-ui/src/config/navigation.test.ts
+++ b/yak-ops-ui/src/config/navigation.test.ts
@@ -48,6 +48,9 @@ describe('permission-aware navigation', () => {
     expect(getActiveNavigationId('/data-quality/execution', qualityPermissions)).toBe(
       'data-quality-execution',
     );
+    expect(
+      getActiveNavigationId('/data-quality/execution/QM-20260807095619-ABC123', qualityPermissions),
+    ).toBe('data-quality-execution');
   });
 
   it('does not expose removed modules', () => {

--- a/yak-ops-ui/src/config/navigation.ts
+++ b/yak-ops-ui/src/config/navigation.ts
@@ -51,6 +51,7 @@ export const appRoutes: readonly NavigationRoute[] = [
   { id: 'data-quality-monitor-detail', path: '/data-quality/monitor/:id', title: '质量监控详情', component: './data-quality/monitor/detail', hidden: true, parentId: 'data-quality-table-config' },
   { id: 'data-quality-monitor-edit', path: '/data-quality/monitor/:id/edit', title: '编辑质量监控', component: './data-quality/monitor/editor', hidden: true, parentId: 'data-quality-table-config' },
   { id: 'data-quality-execution', mode: 'one', permission: 'quality:execution:read', path: '/data-quality/execution', title: '运行记录', component: './data-quality/execution', iconKey: 'report', menuGroup: 'data-quality', order: 20 },
+  { id: 'data-quality-execution-detail', path: '/data-quality/execution/:executionNo', title: '运行记录详情', component: './data-quality/execution/detail', hidden: true, parentId: 'data-quality-execution' },
   { id: 'data-quality-rule-template', mode: 'one', permission: 'quality:template:read', path: '/data-quality/rule-template', title: '规则模板库', component: './data-quality/rule-template', iconKey: 'quality', menuGroup: 'data-quality', order: 30 },
   { id: 'system-users', mode: 'one', permission: 'security:user:read', path: '/system/users', title: '用户管理', component: './system/users', iconKey: 'system', menuGroup: 'system', order: 10 },
   { id: 'system-roles', mode: 'one', permission: 'security:role:read', path: '/system/roles', title: '角色管理', component: './system/roles', iconKey: 'system', menuGroup: 'system', order: 20 },

--- a/yak-ops-ui/src/pages/data-quality/execution/components/ExecutionRecordTable.tsx
+++ b/yak-ops-ui/src/pages/data-quality/execution/components/ExecutionRecordTable.tsx
@@ -1,0 +1,352 @@
+import { Button, Empty, Table, Tag } from 'antd';
+import type { ColumnsType } from 'antd/es/table';
+import dayjs from 'dayjs';
+import { useMemo, type MouseEvent } from 'react';
+import { CheckResultTag, ExecutionStatusTag } from '../../components/QualityStatus';
+import { dataQualityTableClassName } from '../../components/tableStyle';
+import type {
+  ExecutionWorkspaceListItem,
+  RuleExecutionWorkspaceListItem,
+} from '../types';
+
+export type ExecutionViewMode = 'EXECUTION' | 'RULE';
+
+interface Props {
+  executionRecords: ExecutionWorkspaceListItem[];
+  ruleRecords: RuleExecutionWorkspaceListItem[];
+  loading: boolean;
+  mode: ExecutionViewMode;
+  onOpenExecution: (executionNo: string) => void;
+  onOpenMonitor: (monitorId: number) => void;
+}
+
+const formatTime = (value?: string) =>
+  value ? dayjs(value).format('YYYY-MM-DD HH:mm:ss') : '--';
+
+const triggerLabel = (value: ExecutionWorkspaceListItem['triggerType']) =>
+  value === 'SCHEDULE' ? '调度触发' : '手动触发';
+
+const scopeLabel = (value: RuleExecutionWorkspaceListItem['scope']) =>
+  value === 'TABLE' ? '表级' : '字段级';
+
+const issueCount = (record: ExecutionWorkspaceListItem) =>
+  record.failedRules + record.errorRules;
+
+const ExecutionRecordTable = ({
+  executionRecords,
+  ruleRecords,
+  loading,
+  mode,
+  onOpenExecution,
+  onOpenMonitor,
+}: Props) => {
+  const executionColumns = useMemo<ColumnsType<ExecutionWorkspaceListItem>>(
+    () => [
+      {
+        title: 'ID / 监控名称',
+        width: 270,
+        fixed: 'left',
+        render: (_, record) => (
+          <div className="min-w-0 py-0.5">
+            <div className="truncate text-[11px] text-[#98a2b3]">
+              {record.executionNo}
+            </div>
+            <button
+              type="button"
+              className="mt-1 block max-w-full cursor-pointer truncate border-0 bg-transparent p-0 text-left font-medium text-[#fe2c55]"
+              onClick={(event: MouseEvent<HTMLButtonElement>) => {
+                event.stopPropagation();
+                onOpenExecution(record.executionNo);
+              }}
+            >
+              {record.monitorName}
+            </button>
+          </div>
+        ),
+      },
+      {
+        title: '数据对象',
+        width: 250,
+        render: (_, record) => (
+          <div className="min-w-0 py-0.5">
+            <div className="truncate font-medium text-[#344054]">
+              {record.objectName}
+            </div>
+            <div className="mt-1 truncate text-[11px] text-[#98a2b3]">
+              数据源：{record.dataSourceName}
+            </div>
+          </div>
+        ),
+      },
+      {
+        title: '校验状态',
+        dataIndex: 'executionStatus',
+        width: 110,
+        render: (value) => <ExecutionStatusTag value={value} />,
+      },
+      {
+        title: '质量结果',
+        dataIndex: 'checkResult',
+        width: 110,
+        render: (value) => <CheckResultTag value={value} />,
+      },
+      {
+        title: '问题数量',
+        width: 100,
+        render: (_, record) =>
+          issueCount(record) > 0 ? (
+            <Tag color="error" className="!m-0">
+              {issueCount(record)}
+            </Tag>
+          ) : (
+            <span className="text-[#98a2b3]">0</span>
+          ),
+      },
+      {
+        title: '规则概况',
+        width: 230,
+        render: (_, record) => (
+          <div className="flex items-center gap-3 text-xs">
+            <span className="text-[#667085]">共 {record.totalRules}</span>
+            <span className="text-[#245bdb]">通过 {record.passedRules}</span>
+            <span className="text-[#d92d20]">未通过 {record.failedRules}</span>
+            <span className="text-[#b54708]">异常 {record.errorRules}</span>
+          </div>
+        ),
+      },
+      {
+        title: '触发信息',
+        width: 200,
+        render: (_, record) => (
+          <div className="space-y-1 text-xs">
+            <div className="text-[#344054]">
+              {triggerLabel(record.triggerType)} · {record.operator || 'system'}
+            </div>
+            <div className="text-[#98a2b3]">
+              {formatTime(record.startedAt || record.queuedAt)}
+            </div>
+          </div>
+        ),
+      },
+      {
+        title: '结束时间',
+        dataIndex: 'finishedAt',
+        width: 170,
+        render: formatTime,
+      },
+      {
+        title: '操作',
+        width: 120,
+        fixed: 'right',
+        render: (_, record) => (
+          <div className="flex items-center">
+            <Button
+              type="link"
+              size="small"
+              onClick={(event) => {
+                event.stopPropagation();
+                onOpenExecution(record.executionNo);
+              }}
+            >
+              详情
+            </Button>
+            <Button
+              type="link"
+              size="small"
+              onClick={(event) => {
+                event.stopPropagation();
+                onOpenMonitor(record.monitorId);
+              }}
+            >
+              规则
+            </Button>
+          </div>
+        ),
+      },
+    ],
+    [onOpenExecution, onOpenMonitor],
+  );
+
+  const ruleColumns = useMemo<ColumnsType<RuleExecutionWorkspaceListItem>>(
+    () => [
+      {
+        title: 'ID / 规则名称',
+        width: 270,
+        fixed: 'left',
+        render: (_, record) => (
+          <div className="min-w-0 py-0.5">
+            <div className="truncate text-[11px] text-[#98a2b3]">
+              {record.ruleId} · {record.executionNo}
+            </div>
+            <button
+              type="button"
+              className="mt-1 block max-w-full cursor-pointer truncate border-0 bg-transparent p-0 text-left font-medium text-[#fe2c55]"
+              onClick={(event: MouseEvent<HTMLButtonElement>) => {
+                event.stopPropagation();
+                onOpenExecution(record.executionNo);
+              }}
+            >
+              {record.ruleName}
+            </button>
+          </div>
+        ),
+      },
+      {
+        title: '质量维度',
+        dataIndex: 'dimension',
+        width: 110,
+      },
+      {
+        title: '校验状态',
+        dataIndex: 'executionStatus',
+        width: 110,
+        render: (value) => <ExecutionStatusTag value={value} />,
+      },
+      {
+        title: '问题处置',
+        width: 110,
+        render: (_, record) =>
+          ['NOT_PASSED', 'ERROR'].includes(record.checkResult) ? (
+            <span className="text-[#d92d20]">存在问题</span>
+          ) : (
+            <span className="text-[#98a2b3]">-</span>
+          ),
+      },
+      {
+        title: '结束时间',
+        dataIndex: 'finishedAt',
+        width: 170,
+        render: formatTime,
+      },
+      {
+        title: '表名',
+        width: 180,
+        render: (_, record) => (
+          <div className="min-w-0">
+            <div className="truncate text-[#344054]">{record.tableName}</div>
+            <div className="mt-1 truncate text-[11px] text-[#98a2b3]">
+              {record.dataSourceName}
+            </div>
+          </div>
+        ),
+      },
+      {
+        title: '关联范围',
+        dataIndex: 'scope',
+        width: 110,
+        render: (value) => (
+          <Tag className="!m-0 !border-0 !bg-[#fff0f3] !text-[#fe2c55]">
+            {scopeLabel(value)}
+          </Tag>
+        ),
+      },
+      {
+        title: '规则模板',
+        dataIndex: 'templateCode',
+        width: 170,
+      },
+      {
+        title: '重要程度',
+        width: 110,
+        render: () => <span className="text-[#98a2b3]">--</span>,
+      },
+      {
+        title: '监控阈值',
+        dataIndex: 'expectedValue',
+        width: 180,
+        render: (value) => value || '--',
+      },
+      {
+        title: '监控值',
+        dataIndex: 'metricValue',
+        width: 150,
+        render: (value) => value || '--',
+      },
+      {
+        title: '质量结果',
+        dataIndex: 'checkResult',
+        width: 110,
+        render: (value) => <CheckResultTag value={value} />,
+      },
+      {
+        title: '操作',
+        width: 120,
+        fixed: 'right',
+        render: (_, record) => (
+          <div className="flex items-center">
+            <Button
+              type="link"
+              size="small"
+              onClick={(event) => {
+                event.stopPropagation();
+                onOpenExecution(record.executionNo);
+              }}
+            >
+              详情
+            </Button>
+            <Button
+              type="link"
+              size="small"
+              onClick={(event) => {
+                event.stopPropagation();
+                onOpenMonitor(record.monitorId);
+              }}
+            >
+              规则
+            </Button>
+          </div>
+        ),
+      },
+    ],
+    [onOpenExecution, onOpenMonitor],
+  );
+
+  const emptyText = (
+    <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="暂无运行记录" />
+  );
+  const tableClassName = dataQualityTableClassName(
+    '[&_.ant-table-container]:!rounded-none [&_.ant-table-container]:!border-x-0',
+  );
+
+  if (mode === 'RULE') {
+    return (
+      <Table<RuleExecutionWorkspaceListItem>
+        rowKey={(record) => `${record.executionNo}-${record.id}`}
+        size="small"
+        bordered={false}
+        loading={loading}
+        pagination={false}
+        scroll={{ x: 1900 }}
+        className={tableClassName}
+        dataSource={ruleRecords}
+        columns={ruleColumns}
+        locale={{ emptyText }}
+        onRow={(record) => ({
+          onClick: () => onOpenExecution(record.executionNo),
+          className: 'cursor-pointer',
+        })}
+      />
+    );
+  }
+
+  return (
+    <Table<ExecutionWorkspaceListItem>
+      rowKey="executionNo"
+      size="small"
+      bordered={false}
+      loading={loading}
+      pagination={false}
+      scroll={{ x: 1460 }}
+      className={tableClassName}
+      dataSource={executionRecords}
+      columns={executionColumns}
+      locale={{ emptyText }}
+      onRow={(record) => ({
+        onClick: () => onOpenExecution(record.executionNo),
+        className: 'cursor-pointer',
+      })}
+    />
+  );
+};
+
+export default ExecutionRecordTable;

--- a/yak-ops-ui/src/pages/data-quality/execution/detail/index.tsx
+++ b/yak-ops-ui/src/pages/data-quality/execution/detail/index.tsx
@@ -1,0 +1,554 @@
+import { API_SUCCESS_CODE } from '@/services/http/response';
+import { BRAND_THEME } from '@/styles/brand';
+import { history, useParams } from '@umijs/max';
+import {
+  Button,
+  ConfigProvider,
+  Descriptions,
+  Empty,
+  Input,
+  Spin,
+  Table,
+  Tabs,
+  Tag,
+  Typography,
+  message,
+} from 'antd';
+import type { ColumnsType } from 'antd/es/table';
+import dayjs from 'dayjs';
+import {
+  ArrowLeft,
+  ChevronLeft,
+  ChevronRight,
+  FileText,
+  RefreshCw,
+  Search,
+  ShieldCheck,
+} from 'lucide-react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { CheckResultTag, ExecutionStatusTag } from '../../components/QualityStatus';
+import { dataQualityTableClassName } from '../../components/tableStyle';
+import { qualityExecutionWorkspaceApi } from '../service';
+import type {
+  ExecutionLogLine,
+  ExecutionLogView,
+  ExecutionWorkspaceListItem,
+  ExecutionWorkspaceRuleView,
+  ExecutionWorkspaceView,
+} from '../types';
+
+const unwrap = <T,>(response: {
+  code: number;
+  data: T;
+  message?: string;
+  msg?: string;
+}) => {
+  if (response.code !== API_SUCCESS_CODE) {
+    throw new Error(response.message || response.msg || '请求失败');
+  }
+  return response.data;
+};
+
+const formatTime = (value?: string) =>
+  value ? dayjs(value).format('YYYY-MM-DD HH:mm:ss') : '--';
+
+const formatDuration = (value?: number) =>
+  value === undefined || value === null ? '--' : `${value} ms`;
+
+const triggerLabel = (value?: ExecutionWorkspaceView['triggerType']) =>
+  value === 'SCHEDULE' ? '调度触发' : '手动触发';
+
+const scopeLabel = (value: ExecutionWorkspaceRuleView['scope']) =>
+  value === 'TABLE' ? '表级' : '字段级';
+
+const logLevelClass: Record<ExecutionLogLine['level'], string> = {
+  INFO: 'text-[#245bdb]',
+  WARN: 'text-[#b54708]',
+  ERROR: 'text-[#d92d20]',
+};
+
+const ExecutionDetailPage = () => {
+  const { executionNo = '' } = useParams<{ executionNo: string }>();
+  const [loading, setLoading] = useState(false);
+  const [historyLoading, setHistoryLoading] = useState(false);
+  const [detail, setDetail] = useState<ExecutionWorkspaceView>();
+  const [logs, setLogs] = useState<ExecutionLogView>();
+  const [historyRecords, setHistoryRecords] = useState<
+    ExecutionWorkspaceListItem[]
+  >([]);
+  const [historyKeyword, setHistoryKeyword] = useState('');
+  const [historyCollapsed, setHistoryCollapsed] = useState(false);
+  const [activeTab, setActiveTab] = useState('CURRENT');
+
+  const loadDetail = useCallback(async () => {
+    if (!executionNo) return;
+    setLoading(true);
+    try {
+      const [detailResponse, logsResponse] = await Promise.all([
+        qualityExecutionWorkspaceApi.detail(executionNo),
+        qualityExecutionWorkspaceApi.logs(executionNo),
+      ]);
+      setDetail(unwrap(detailResponse));
+      setLogs(unwrap(logsResponse));
+    } catch (error: any) {
+      message.error(error?.message || '执行详情加载失败');
+    } finally {
+      setLoading(false);
+    }
+  }, [executionNo]);
+
+  useEffect(() => {
+    void loadDetail();
+  }, [loadDetail]);
+
+  useEffect(() => {
+    if (!detail?.monitorId) return;
+    setHistoryLoading(true);
+    qualityExecutionWorkspaceApi
+      .page({ current: 1, pageSize: 50, monitorId: detail.monitorId })
+      .then((response) => setHistoryRecords(unwrap(response).records))
+      .catch((error) =>
+        message.error(error?.message || '历史运行记录加载失败'),
+      )
+      .finally(() => setHistoryLoading(false));
+  }, [detail?.monitorId]);
+
+  useEffect(() => {
+    if (!detail || !['WAITING', 'RUNNING'].includes(detail.executionStatus)) {
+      return;
+    }
+    const timer = window.setInterval(() => void loadDetail(), 3000);
+    return () => window.clearInterval(timer);
+  }, [detail, loadDetail]);
+
+  const filteredHistory = useMemo(() => {
+    const keyword = historyKeyword.trim().toLowerCase();
+    if (!keyword) return historyRecords;
+    return historyRecords.filter(
+      (record) =>
+        record.executionNo.toLowerCase().includes(keyword) ||
+        record.monitorName.toLowerCase().includes(keyword),
+    );
+  }, [historyKeyword, historyRecords]);
+
+  const issueRules = useMemo(
+    () =>
+      detail?.rules.filter((rule) =>
+        ['NOT_PASSED', 'ERROR'].includes(rule.checkResult),
+      ) || [],
+    [detail?.rules],
+  );
+
+  const ruleColumns = useMemo<ColumnsType<ExecutionWorkspaceRuleView>>(
+    () => [
+      {
+        title: '规则名称 / 模板',
+        width: 250,
+        render: (_, record) => (
+          <div className="min-w-0 py-0.5">
+            <div className="truncate font-medium text-[#172033]">
+              {record.ruleName}
+            </div>
+            <div className="mt-1 truncate text-[11px] text-[#98a2b3]">
+              {record.templateCode}
+            </div>
+          </div>
+        ),
+      },
+      {
+        title: '关联范围',
+        dataIndex: 'scope',
+        width: 100,
+        render: (value) => (
+          <Tag className="!m-0 !border-0 !bg-[#fff0f3] !text-[#fe2c55]">
+            {scopeLabel(value)}
+          </Tag>
+        ),
+      },
+      { title: '质量维度', dataIndex: 'dimension', width: 110 },
+      {
+        title: '检查字段',
+        dataIndex: 'columnName',
+        width: 140,
+        render: (value) => value || '整表',
+      },
+      {
+        title: '检查结果',
+        dataIndex: 'checkResult',
+        width: 110,
+        render: (value) => <CheckResultTag value={value} />,
+      },
+      {
+        title: '实际值 / 期望值',
+        width: 210,
+        render: (_, record) => (
+          <div className="space-y-1 text-xs">
+            <div>实际：{record.metricValue || '--'}</div>
+            <div className="text-[#98a2b3]">
+              期望：{record.expectedValue || '--'}
+            </div>
+          </div>
+        ),
+      },
+      {
+        title: '耗时',
+        dataIndex: 'durationMs',
+        width: 100,
+        render: formatDuration,
+      },
+    ],
+    [],
+  );
+
+  const historyColumns = useMemo<ColumnsType<ExecutionWorkspaceListItem>>(
+    () => [
+      {
+        title: '校验状态',
+        dataIndex: 'executionStatus',
+        width: 110,
+        render: (value) => <ExecutionStatusTag value={value} />,
+      },
+      {
+        title: '运行时间',
+        width: 190,
+        render: (_, record) => formatTime(record.startedAt || record.queuedAt),
+      },
+      {
+        title: '质量结果',
+        dataIndex: 'checkResult',
+        width: 110,
+        render: (value) => <CheckResultTag value={value} />,
+      },
+      {
+        title: '规则概况',
+        width: 260,
+        render: (_, record) =>
+          `通过 ${record.passedRules} / 未通过 ${record.failedRules} / 异常 ${record.errorRules}`,
+      },
+      {
+        title: '问题数量',
+        width: 110,
+        render: (_, record) => record.failedRules + record.errorRules,
+      },
+      {
+        title: '操作',
+        width: 90,
+        render: (_, record) => (
+          <Button
+            type="link"
+            size="small"
+            onClick={() =>
+              history.push(`/data-quality/execution/${record.executionNo}`)
+            }
+          >
+            查看
+          </Button>
+        ),
+      },
+    ],
+    [],
+  );
+
+  const renderRuleTable = (
+    records: ExecutionWorkspaceRuleView[],
+    issueMode = false,
+  ) => (
+    <Table<ExecutionWorkspaceRuleView>
+      rowKey="id"
+      size="small"
+      bordered
+      pagination={false}
+      scroll={{ x: 1080 }}
+      className={dataQualityTableClassName()}
+      dataSource={records}
+      columns={ruleColumns}
+      expandable={{
+        expandedRowRender: (record) => (
+          <div className="space-y-3 px-2 py-1">
+            {(record.errorMessage || issueMode) && (
+              <Typography.Text type="danger">
+                {record.errorMessage || '质量指标未满足预期阈值'}
+              </Typography.Text>
+            )}
+            <Typography.Paragraph
+              copyable
+              className="!mb-0 whitespace-pre-wrap rounded bg-[#f8f9fb] p-3 font-mono text-xs"
+            >
+              {record.executedSql || '未生成执行 SQL'}
+            </Typography.Paragraph>
+          </div>
+        ),
+      }}
+    />
+  );
+
+  if (!detail && !loading) {
+    return (
+      <ConfigProvider theme={BRAND_THEME}>
+        <div className="flex h-[calc(100vh-64px)] items-center justify-center bg-white">
+          <Empty description="执行记录不存在" />
+        </div>
+      </ConfigProvider>
+    );
+  }
+
+  return (
+    <ConfigProvider theme={BRAND_THEME}>
+      <Spin spinning={loading && !detail}>
+        <div className="flex h-[calc(100vh-64px)] min-h-[680px] flex-col overflow-hidden bg-white">
+          <header className="shrink-0 border-b border-[#e8e9ec] px-4 py-3">
+            <button
+              type="button"
+              className="mb-2 flex cursor-pointer items-center gap-1 border-0 bg-transparent p-0 text-xs text-[#667085] hover:text-[#fe2c55]"
+              onClick={() => history.push('/data-quality/execution')}
+            >
+              <ArrowLeft size={14} />
+              返回运行记录
+            </button>
+
+            <div className="flex items-start justify-between gap-6">
+              <div className="flex min-w-0 items-start gap-3">
+                <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-lg bg-[#fff0f3] text-[#fe2c55]">
+                  <ShieldCheck size={24} />
+                </div>
+                <div className="min-w-0">
+                  <div className="flex items-center gap-2">
+                    <h1 className="m-0 truncate text-[18px] font-semibold text-[#161823]">
+                      {detail?.monitorName || executionNo}
+                    </h1>
+                    {detail && <ExecutionStatusTag value={detail.executionStatus} />}
+                    {detail && <CheckResultTag value={detail.checkResult} />}
+                  </div>
+                  <div className="mt-1 text-xs text-[#98a2b3]">
+                    执行编号：{detail?.executionNo || executionNo}
+                  </div>
+                </div>
+              </div>
+              <Button icon={<RefreshCw size={14} />} onClick={loadDetail}>
+                刷新
+              </Button>
+            </div>
+
+            {detail && (
+              <div className="mt-3 grid grid-cols-4 gap-x-8 gap-y-1 text-xs">
+                <div>运行时间：{formatTime(detail.startedAt || detail.queuedAt)}</div>
+                <div>数据源：{detail.dataSourceName}</div>
+                <div>触发方式：{triggerLabel(detail.triggerType)}</div>
+                <div>触发人：{detail.operator || 'system'}</div>
+                <div className="col-span-2 truncate">监控对象：{detail.objectName}</div>
+                <div>规则数量：{detail.totalRules}</div>
+                <div>执行耗时：{formatDuration(detail.durationMs)}</div>
+              </div>
+            )}
+          </header>
+
+          <div className="flex min-h-0 flex-1 overflow-hidden">
+            <aside
+              className="shrink-0 overflow-hidden border-r border-[#e8e9ec] bg-white transition-[width] duration-200"
+              style={{ width: historyCollapsed ? 0 : 320 }}
+            >
+              <div className="flex h-full w-[320px] flex-col">
+                <div className="shrink-0 border-b border-[#eceef0] p-3">
+                  <Input
+                    allowClear
+                    variant="filled"
+                    value={historyKeyword}
+                    onChange={(event) => setHistoryKeyword(event.target.value)}
+                    prefix={<Search size={14} className="text-[#98a2b3]" />}
+                    placeholder="搜索执行编号"
+                  />
+                </div>
+                <Spin spinning={historyLoading}>
+                  <div className="h-[calc(100vh-270px)] overflow-y-auto">
+                    {filteredHistory.length ? (
+                      filteredHistory.map((record) => {
+                        const active = record.executionNo === executionNo;
+                        return (
+                          <button
+                            key={record.executionNo}
+                            type="button"
+                            className={`block w-full cursor-pointer border-0 border-b border-[#f0f2f5] px-3 py-3 text-left ${
+                              active
+                                ? 'border-r-2 border-r-[#fe2c55] bg-[#fff7f8]'
+                                : 'bg-white hover:bg-[#fafbfc]'
+                            }`}
+                            onClick={() =>
+                              history.push(
+                                `/data-quality/execution/${record.executionNo}`,
+                              )
+                            }
+                          >
+                            <div className="flex items-center justify-between gap-2">
+                              <span className="truncate text-[11px] text-[#98a2b3]">
+                                {record.executionNo}
+                              </span>
+                              <ExecutionStatusTag value={record.executionStatus} />
+                            </div>
+                            <div className="mt-1 truncate text-[13px] font-medium text-[#172033]">
+                              {record.monitorName}
+                            </div>
+                            <div className="mt-1 text-xs text-[#667085]">
+                              {formatTime(record.startedAt || record.queuedAt)}
+                            </div>
+                            <div className="mt-1 text-xs text-[#98a2b3]">
+                              问题 {record.failedRules + record.errorRules} ·{' '}
+                              {formatDuration(record.durationMs)}
+                            </div>
+                          </button>
+                        );
+                      })
+                    ) : (
+                      <Empty
+                        image={Empty.PRESENTED_IMAGE_SIMPLE}
+                        description="暂无历史运行记录"
+                        className="mt-16"
+                      />
+                    )}
+                  </div>
+                </Spin>
+              </div>
+            </aside>
+
+            <div className="relative flex min-w-0 flex-1 flex-col overflow-hidden">
+              <button
+                type="button"
+                className="absolute left-0 top-1/2 z-20 flex h-8 w-4 -translate-y-1/2 cursor-pointer items-center justify-center rounded-r border border-l-0 border-[#dfe1e5] bg-white text-[#7b808a]"
+                onClick={() => setHistoryCollapsed(!historyCollapsed)}
+              >
+                {historyCollapsed ? (
+                  <ChevronRight size={13} />
+                ) : (
+                  <ChevronLeft size={13} />
+                )}
+              </button>
+
+              <Tabs
+                activeKey={activeTab}
+                onChange={setActiveTab}
+                className="min-h-0 flex-1 [&_.ant-tabs-content-holder]:min-h-0 [&_.ant-tabs-content-holder]:overflow-auto [&_.ant-tabs-nav]:!mb-0 [&_.ant-tabs-nav]:!px-4"
+                items={[
+                  {
+                    key: 'CURRENT',
+                    label: '本次运行记录',
+                    children: detail ? (
+                      <div>
+                        <section className="border-b border-[#eceef0] px-5 py-4">
+                          <h2 className="m-0 mb-3 text-[15px] font-semibold text-[#161823]">
+                            监控信息
+                          </h2>
+                          <Descriptions
+                            size="small"
+                            column={2}
+                            items={[
+                              { key: 'name', label: '监控名称', children: detail.monitorName },
+                              { key: 'id', label: '监控 ID', children: detail.monitorId },
+                              { key: 'object', label: '数据范围', children: detail.objectName },
+                              { key: 'rules', label: '规则数量', children: detail.totalRules },
+                              { key: 'mode', label: '比较方式', children: '按规则阈值逐项比较' },
+                              { key: 'result', label: '质量结果', children: <CheckResultTag value={detail.checkResult} /> },
+                            ]}
+                          />
+                        </section>
+                        <section className="border-b border-[#eceef0] px-5 py-4">
+                          <h2 className="m-0 mb-3 text-[15px] font-semibold text-[#161823]">
+                            检测任务执行信息
+                          </h2>
+                          <Descriptions
+                            size="small"
+                            column={2}
+                            items={[
+                              { key: 'trigger', label: '检测触发方式', children: triggerLabel(detail.triggerType) },
+                              { key: 'queued', label: '入队时间', children: formatTime(detail.queuedAt) },
+                              { key: 'start', label: '实际开始时间', children: formatTime(detail.startedAt) },
+                              { key: 'finish', label: '实际结束时间', children: formatTime(detail.finishedAt) },
+                            ]}
+                          />
+                        </section>
+                        <section className="px-5 py-4">
+                          <h2 className="m-0 mb-3 text-[15px] font-semibold text-[#161823]">
+                            质量采集及比较状态结果
+                          </h2>
+                          {renderRuleTable(detail.rules)}
+                        </section>
+                      </div>
+                    ) : null,
+                  },
+                  {
+                    key: 'HISTORY',
+                    label: '历史运行记录',
+                    children: (
+                      <div className="p-4">
+                        <Table<ExecutionWorkspaceListItem>
+                          rowKey="executionNo"
+                          size="small"
+                          bordered
+                          loading={historyLoading}
+                          pagination={false}
+                          className={dataQualityTableClassName()}
+                          dataSource={historyRecords}
+                          columns={historyColumns}
+                        />
+                      </div>
+                    ),
+                  },
+                  {
+                    key: 'ISSUES',
+                    label: `问题数据处理${issueRules.length ? ` (${issueRules.length})` : ''}`,
+                    children: (
+                      <div className="p-4">
+                        {issueRules.length ? (
+                          renderRuleTable(issueRules, true)
+                        ) : (
+                          <Empty
+                            image={Empty.PRESENTED_IMAGE_SIMPLE}
+                            description="本次执行未产生待处理问题数据"
+                          />
+                        )}
+                      </div>
+                    ),
+                  },
+                  {
+                    key: 'LOGS',
+                    label: '原始日志',
+                    children: (
+                      <div className="min-h-[420px] bg-[#fbfcfe] p-4 font-mono text-xs leading-6">
+                        {logs?.lines.length ? (
+                          logs.lines.map((line, index) => (
+                            <div
+                              key={`${line.timestamp}-${line.stage}-${index}`}
+                              className="flex gap-3 border-b border-[#f0f2f5] py-1"
+                            >
+                              <span className="shrink-0 text-[#98a2b3]">
+                                {formatTime(line.timestamp)}
+                              </span>
+                              <span className={`w-12 shrink-0 ${logLevelClass[line.level]}`}>
+                                {line.level}
+                              </span>
+                              <span className="w-20 shrink-0 text-[#667085]">
+                                [{line.stage}]
+                              </span>
+                              <span className="min-w-0 whitespace-pre-wrap break-all text-[#344054]">
+                                {line.message}
+                              </span>
+                            </div>
+                          ))
+                        ) : (
+                          <Empty
+                            image={<FileText size={48} className="text-[#d0d5dd]" />}
+                            description="暂无原始日志"
+                          />
+                        )}
+                      </div>
+                    ),
+                  },
+                ]}
+              />
+            </div>
+          </div>
+        </div>
+      </Spin>
+    </ConfigProvider>
+  );
+};
+
+export default ExecutionDetailPage;

--- a/yak-ops-ui/src/pages/data-quality/execution/index.tsx
+++ b/yak-ops-ui/src/pages/data-quality/execution/index.tsx
@@ -1,29 +1,37 @@
 import { API_SUCCESS_CODE } from '@/services/http/response';
 import { BRAND_THEME } from '@/styles/brand';
-import { useLocation } from '@umijs/max';
+import { history } from '@umijs/max';
 import {
   Button,
   ConfigProvider,
-  Empty,
+  DatePicker,
   Input,
   Pagination,
   Select,
-  Spin,
-  Table,
   message,
 } from 'antd';
-import { RefreshCw, Search } from 'lucide-react';
+import type { Dayjs } from 'dayjs';
+import dayjs from 'dayjs';
+import { RefreshCw, RotateCcw, Search } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import ExecutionDetailDrawer from '../components/ExecutionDetailDrawer';
-import { CheckResultTag, ExecutionStatusTag } from '../components/QualityStatus';
-import { dataQualityTableClassName } from '../components/tableStyle';
-import { qualityExecutionApi } from '../service';
+import DataSourceTreePane from '../table-config/components/DataSourceTreePane';
+import { useDataSourceTree } from '../table-config/hooks/useDataSourceTree';
 import type {
   CheckResult,
-  ExecutionListItem,
-  ExecutionPageView,
   ExecutionStatus,
+  RuleScope,
+  TriggerType,
 } from '../types';
+import ExecutionRecordTable, {
+  type ExecutionViewMode,
+} from './components/ExecutionRecordTable';
+import { qualityExecutionWorkspaceApi } from './service';
+import type {
+  ExecutionWorkspaceListItem,
+  RuleExecutionWorkspaceListItem,
+} from './types';
+
+const { RangePicker } = DatePicker;
 
 const unwrap = <T,>(response: {
   code: number;
@@ -37,247 +45,399 @@ const unwrap = <T,>(response: {
   return response.data;
 };
 
+const DIMENSION_OPTIONS = [
+  '完整性',
+  '唯一性',
+  '有效性',
+  '准确性',
+  '自定义',
+].map((value) => ({ value, label: value }));
+
 const ExecutionPage = () => {
-  const location = useLocation();
-  const query = useMemo(
-    () => new URLSearchParams(location.search),
-    [location.search],
-  );
-  const monitorId = Number(query.get('monitorId')) || undefined;
-  const [data, setData] = useState<ExecutionPageView>({
-    records: [],
-    total: 0,
-    current: 1,
-    pageSize: 20,
-  });
-  const [keyword, setKeyword] = useState('');
-  const [status, setStatus] = useState<ExecutionStatus>();
-  const [result, setResult] = useState<CheckResult>();
+  const {
+    dataSourceId,
+    selectedDataSource,
+    selectedNodeKey,
+    treeData,
+    treeLoading,
+    leftWidth,
+    collapsed,
+    setCollapsed,
+    loadSourceTree,
+    selectNode,
+    startResize,
+  } = useDataSourceTree();
+
+  const [executionRecords, setExecutionRecords] = useState<
+    ExecutionWorkspaceListItem[]
+  >([]);
+  const [ruleRecords, setRuleRecords] = useState<
+    RuleExecutionWorkspaceListItem[]
+  >([]);
+  const [total, setTotal] = useState(0);
+  const [current, setCurrent] = useState(1);
+  const [pageSize, setPageSize] = useState(20);
   const [loading, setLoading] = useState(false);
-  const [executionNo, setExecutionNo] = useState<string>();
+  const [keywordDraft, setKeywordDraft] = useState('');
+  const [objectKeywordDraft, setObjectKeywordDraft] = useState('');
+  const [keyword, setKeyword] = useState('');
+  const [objectKeyword, setObjectKeyword] = useState('');
+  const [executionStatus, setExecutionStatus] = useState<ExecutionStatus>();
+  const [checkResult, setCheckResult] = useState<CheckResult>();
+  const [triggerType, setTriggerType] = useState<TriggerType>();
+  const [hasIssues, setHasIssues] = useState<boolean>();
+  const [dimension, setDimension] = useState<string>();
+  const [scope, setScope] = useState<RuleScope>();
+  const [viewMode, setViewMode] = useState<ExecutionViewMode>('RULE');
+  const [dateRange, setDateRange] = useState<[Dayjs, Dayjs] | null>([
+    dayjs().subtract(7, 'day'),
+    dayjs(),
+  ]);
+
+  useEffect(() => {
+    void loadSourceTree();
+  }, [loadSourceTree]);
 
   const load = useCallback(
-    async (current = data.current, pageSize = data.pageSize) => {
+    async (requestedCurrent = 1, requestedPageSize = pageSize) => {
+      if (!dataSourceId) {
+        setExecutionRecords([]);
+        setRuleRecords([]);
+        setTotal(0);
+        setCurrent(1);
+        return;
+      }
+
       setLoading(true);
       try {
-        setData(
-          unwrap(
-            await qualityExecutionApi.page({
-              current,
-              pageSize,
-              keyword,
-              monitorId,
-              executionStatus: status,
-              checkResult: result,
-            }),
-          ),
-        );
+        const query = {
+          current: requestedCurrent,
+          pageSize: requestedPageSize,
+          dataSourceId,
+          keyword: keyword || undefined,
+          objectKeyword: objectKeyword || undefined,
+          executionStatus,
+          checkResult,
+          triggerType,
+          hasIssues,
+          dimension,
+          scope,
+          queuedAfter: dateRange?.[0]
+            ?.startOf('day')
+            .format('YYYY-MM-DD HH:mm:ss'),
+          queuedBefore: dateRange?.[1]
+            ?.endOf('day')
+            .format('YYYY-MM-DD HH:mm:ss'),
+        };
+
+        if (viewMode === 'RULE') {
+          const result = unwrap(
+            await qualityExecutionWorkspaceApi.rulePage(query),
+          );
+          setRuleRecords(result.records);
+          setExecutionRecords([]);
+          setTotal(result.total);
+          setCurrent(result.current);
+          setPageSize(result.pageSize);
+        } else {
+          const result = unwrap(await qualityExecutionWorkspaceApi.page(query));
+          setExecutionRecords(result.records);
+          setRuleRecords([]);
+          setTotal(result.total);
+          setCurrent(result.current);
+          setPageSize(result.pageSize);
+        }
       } catch (error: any) {
-        message.error(error?.message || '执行记录加载失败');
+        message.error(error?.message || '运行记录加载失败');
       } finally {
         setLoading(false);
       }
     },
-    [data.current, data.pageSize, keyword, monitorId, result, status],
+    [
+      checkResult,
+      dataSourceId,
+      dateRange,
+      dimension,
+      executionStatus,
+      hasIssues,
+      keyword,
+      objectKeyword,
+      pageSize,
+      scope,
+      triggerType,
+      viewMode,
+    ],
   );
 
-  useEffect(() => void load(1), [status, result, monitorId]);
   useEffect(() => {
+    void load(1);
+  }, [load]);
+
+  useEffect(() => {
+    const records = viewMode === 'RULE' ? ruleRecords : executionRecords;
     if (
-      !data.records.some((item) =>
-        ['WAITING', 'RUNNING'].includes(item.executionStatus),
+      !records.some((record) =>
+        ['WAITING', 'RUNNING'].includes(record.executionStatus),
       )
     ) {
       return;
     }
-    const timer = window.setInterval(() => load(data.current), 3000);
+    const timer = window.setInterval(
+      () => void load(current, pageSize),
+      3000,
+    );
     return () => window.clearInterval(timer);
-  }, [data.current, data.records, load]);
+  }, [current, executionRecords, load, pageSize, ruleRecords, viewMode]);
+
+  const appliedFilterCount = useMemo(
+    () =>
+      [
+        keyword,
+        objectKeyword,
+        executionStatus,
+        checkResult,
+        triggerType,
+        dimension,
+        scope,
+        hasIssues === undefined ? undefined : String(hasIssues),
+      ].filter(Boolean).length,
+    [
+      checkResult,
+      dimension,
+      executionStatus,
+      hasIssues,
+      keyword,
+      objectKeyword,
+      scope,
+      triggerType,
+    ],
+  );
+
+  const applySearch = () => {
+    setKeyword(keywordDraft.trim());
+    setObjectKeyword(objectKeywordDraft.trim());
+  };
+
+  const reset = () => {
+    setKeywordDraft('');
+    setObjectKeywordDraft('');
+    setKeyword('');
+    setObjectKeyword('');
+    setExecutionStatus(undefined);
+    setCheckResult(undefined);
+    setTriggerType(undefined);
+    setHasIssues(undefined);
+    setDimension(undefined);
+    setScope(undefined);
+    setDateRange([dayjs().subtract(7, 'day'), dayjs()]);
+  };
+
+  const openExecution = (executionNo: string) => {
+    history.push(`/data-quality/execution/${executionNo}`);
+  };
 
   return (
     <ConfigProvider theme={BRAND_THEME}>
-      <div className="flex h-[calc(100vh-64px)] flex-col overflow-hidden bg-white">
-        <div className="flex h-12 shrink-0 items-center justify-between border-b border-[#e8e9ec] px-5">
-          <h1 className="m-0 text-[20px] font-semibold text-[#161823]">
+      <div className="flex h-[calc(100vh-64px)] min-h-[640px] flex-col overflow-hidden bg-white">
+        <header className="shrink-0 border-b border-[#e8e9ec] px-5 py-3">
+          <h1 className="m-0 text-[22px] font-semibold leading-8 text-[#161823]">
             运行记录
           </h1>
-          <Button icon={<RefreshCw size={14} />} onClick={() => load()}>
-            刷新
-          </Button>
-        </div>
-        <div className="flex min-h-0 flex-1 flex-col px-5 py-4">
-          <div className="mb-3 flex shrink-0 items-center gap-2">
-            <Input
-              allowClear
-              variant="filled"
-              value={keyword}
-              onChange={(event) => setKeyword(event.target.value)}
-              onPressEnter={() => load(1)}
-              prefix={<Search size={14} className="text-[#98a2b3]" />}
-              placeholder="搜索执行编号、监控名称、数据对象"
-              className="max-w-[420px]"
-            />
-            <Select
-              allowClear
-              variant="filled"
-              value={status}
-              placeholder="执行状态"
-              className="w-[150px]"
-              onChange={setStatus}
-              options={[
-                { value: 'WAITING', label: '等待中' },
-                { value: 'RUNNING', label: '运行中' },
-                { value: 'SUCCESS', label: '已完成' },
-                { value: 'FAILED', label: '执行失败' },
-              ]}
-            />
-            <Select
-              allowClear
-              variant="filled"
-              value={result}
-              placeholder="检查结果"
-              className="w-[150px]"
-              onChange={setResult}
-              options={[
-                { value: 'PASSED', label: '通过' },
-                { value: 'NOT_PASSED', label: '未通过' },
-                { value: 'ERROR', label: '异常' },
-                { value: 'RUNNING', label: '运行中' },
-              ]}
-            />
-          </div>
-          <div className="min-h-0 flex-1 overflow-auto">
-            <Spin spinning={loading}>
-              <Table<ExecutionListItem>
-                rowKey="executionNo"
-                size="small"
-                bordered
-                pagination={false}
-                scroll={{ x: 1340 }}
-                className={dataQualityTableClassName()}
-                dataSource={data.records}
-                locale={{
-                  emptyText: (
-                    <Empty
-                      image={Empty.PRESENTED_IMAGE_SIMPLE}
-                      description="暂无运行记录"
-                    />
-                  ),
-                }}
-                onRow={(record) => ({
-                  onClick: () => setExecutionNo(record.executionNo),
-                  className: 'cursor-pointer',
-                })}
-                columns={[
-                  {
-                    title: '执行编号 / 监控名称',
-                    width: 280,
-                    render: (_, record) => (
-                      <div className="min-w-0 py-1">
-                        <div className="truncate font-medium text-[#172033]">
-                          {record.monitorName}
-                        </div>
-                        <div className="mt-1 truncate text-[11px] text-[#98a2b3]">
-                          ID：{record.executionNo}
-                        </div>
-                      </div>
-                    ),
-                  },
-                  {
-                    title: '数据对象',
-                    width: 270,
-                    render: (_, record) => (
-                      <div className="min-w-0 py-1">
-                        <div className="truncate text-[#344054]">
-                          {record.objectName}
-                        </div>
-                        <div className="mt-1 truncate text-[11px] text-[#98a2b3]">
-                          数据源：{record.dataSourceName}
-                        </div>
-                      </div>
-                    ),
-                  },
-                  {
-                    title: '执行状态',
-                    dataIndex: 'executionStatus',
-                    width: 110,
-                    render: (value) => <ExecutionStatusTag value={value} />,
-                  },
-                  {
-                    title: '检查结果',
-                    dataIndex: 'checkResult',
-                    width: 110,
-                    render: (value) => <CheckResultTag value={value} />,
-                  },
-                  {
-                    title: '执行概况',
-                    width: 230,
-                    render: (_, record) => (
-                      <div className="grid grid-cols-2 gap-x-4 gap-y-1 text-xs">
-                        <span className="text-[#98a2b3]">通过：</span>
-                        <span className="text-[#344054]">{record.passedRules}</span>
-                        <span className="text-[#98a2b3]">未通过：</span>
-                        <span className="text-[#344054]">{record.failedRules}</span>
-                        <span className="text-[#98a2b3]">异常：</span>
-                        <span className="text-[#344054]">{record.errorRules}</span>
-                        <span className="text-[#98a2b3]">耗时：</span>
-                        <span className="text-[#344054]">
-                          {record.durationMs === undefined
-                            ? '--'
-                            : `${record.durationMs} ms`}
-                        </span>
-                      </div>
-                    ),
-                  },
-                  {
-                    title: '触发信息',
-                    width: 210,
-                    render: (_, record) => (
-                      <div className="space-y-1 text-xs">
-                        <div className="text-[#344054]">{record.operator}</div>
-                        <div className="text-[#98a2b3]">
-                          {record.startedAt || record.queuedAt || '--'}
-                        </div>
-                      </div>
-                    ),
-                  },
-                  {
-                    title: '操作',
-                    fixed: 'right',
-                    width: 90,
-                    render: (_, record) => (
-                      <Button
-                        type="link"
-                        size="small"
-                        onClick={(event) => {
-                          event.stopPropagation();
-                          setExecutionNo(record.executionNo);
-                        }}
-                      >
-                        查看
-                      </Button>
-                    ),
-                  },
-                ]}
+          <p className="m-0 mt-0.5 text-xs text-[#98a2b3]">
+            以质量监控粒度和规则粒度，查询和展示质量规则的运行结果。
+          </p>
+        </header>
+
+        <div className="flex min-h-0 flex-1 overflow-hidden">
+          <DataSourceTreePane
+            treeData={treeData}
+            treeLoading={treeLoading}
+            selectedNodeKey={selectedNodeKey}
+            leftWidth={leftWidth}
+            collapsed={collapsed}
+            onSelect={(keys) => {
+              const key = keys[0];
+              if (key) selectNode(String(key));
+            }}
+            onResizeStart={startResize}
+            onCollapsedChange={setCollapsed}
+          />
+
+          <main className="flex min-w-0 flex-1 flex-col overflow-hidden px-4 py-3">
+            <div className="shrink-0 border-b border-[#eceef0] pb-2">
+              <div className="flex flex-wrap items-center gap-2">
+                <Input
+                  allowClear
+                  variant="filled"
+                  value={keywordDraft}
+                  onChange={(event) => setKeywordDraft(event.target.value)}
+                  onPressEnter={applySearch}
+                  prefix={<Search size={14} className="text-[#98a2b3]" />}
+                  placeholder="请输入规则或监控名称"
+                  className="w-[210px]"
+                />
+                <Input
+                  allowClear
+                  variant="filled"
+                  value={objectKeywordDraft}
+                  onChange={(event) => setObjectKeywordDraft(event.target.value)}
+                  onPressEnter={applySearch}
+                  prefix={<Search size={14} className="text-[#98a2b3]" />}
+                  placeholder="请输入表名或数据对象"
+                  className="w-[250px]"
+                />
+                <RangePicker
+                  variant="filled"
+                  value={dateRange}
+                  showTime={false}
+                  format="YYYY-MM-DD"
+                  className="w-[280px]"
+                  onChange={(value) => {
+                    if (value?.[0] && value?.[1]) {
+                      setDateRange([value[0], value[1]]);
+                    } else {
+                      setDateRange(null);
+                    }
+                  }}
+                />
+                <Select
+                  allowClear
+                  variant="filled"
+                  value={checkResult}
+                  placeholder="质量结果"
+                  className="w-[126px]"
+                  onChange={setCheckResult}
+                  options={[
+                    { value: 'PASSED', label: '通过' },
+                    { value: 'NOT_PASSED', label: '未通过' },
+                    { value: 'ERROR', label: '异常' },
+                    { value: 'RUNNING', label: '运行中' },
+                  ]}
+                />
+                <Select
+                  allowClear
+                  variant="filled"
+                  value={hasIssues}
+                  placeholder="问题数量"
+                  className="w-[126px]"
+                  onChange={setHasIssues}
+                  options={[
+                    { value: true, label: '存在问题' },
+                    { value: false, label: '无问题' },
+                  ]}
+                />
+                <Button type="primary" onClick={applySearch}>
+                  查询
+                </Button>
+                <Button icon={<RotateCcw size={14} />} onClick={reset}>
+                  重置{appliedFilterCount ? ` (${appliedFilterCount})` : ''}
+                </Button>
+              </div>
+
+              <div className="mt-2 flex items-center justify-between gap-3">
+                <div className="flex flex-wrap items-center gap-2">
+                  <Select
+                    allowClear
+                    variant="filled"
+                    value={dimension}
+                    placeholder="质量维度"
+                    className="w-[126px]"
+                    onChange={setDimension}
+                    options={DIMENSION_OPTIONS}
+                  />
+                  <Select
+                    allowClear
+                    variant="filled"
+                    value={scope}
+                    placeholder="关联范围"
+                    className="w-[126px]"
+                    onChange={setScope}
+                    options={[
+                      { value: 'TABLE', label: '表级' },
+                      { value: 'COLUMN', label: '字段级' },
+                    ]}
+                  />
+                  <Select
+                    allowClear
+                    variant="filled"
+                    value={executionStatus}
+                    placeholder="校验状态"
+                    className="w-[126px]"
+                    onChange={setExecutionStatus}
+                    options={[
+                      { value: 'WAITING', label: '等待中' },
+                      { value: 'RUNNING', label: '运行中' },
+                      { value: 'SUCCESS', label: '已完成' },
+                      { value: 'FAILED', label: '执行失败' },
+                    ]}
+                  />
+                  <Select
+                    allowClear
+                    variant="filled"
+                    value={triggerType}
+                    placeholder="触发方式"
+                    className="w-[126px]"
+                    onChange={setTriggerType}
+                    options={[
+                      { value: 'MANUAL', label: '手动触发' },
+                      { value: 'SCHEDULE', label: '调度触发' },
+                    ]}
+                  />
+                  <span className="text-xs text-[#98a2b3]">
+                    数据源类型：{selectedDataSource?.dbType || '--'}
+                  </span>
+                </div>
+                <div className="flex shrink-0 items-center gap-2">
+                  <Select
+                    variant="filled"
+                    value={viewMode}
+                    className="w-[126px]"
+                    onChange={setViewMode}
+                    options={[
+                      { value: 'RULE', label: '规则视角' },
+                      { value: 'EXECUTION', label: '监控视角' },
+                    ]}
+                  />
+                  <Button
+                    icon={<RefreshCw size={14} />}
+                    onClick={() => void load(current, pageSize)}
+                  />
+                </div>
+              </div>
+            </div>
+
+            <div className="min-h-0 flex-1 overflow-auto pt-2">
+              <ExecutionRecordTable
+                executionRecords={executionRecords}
+                ruleRecords={ruleRecords}
+                loading={loading}
+                mode={viewMode}
+                onOpenExecution={openExecution}
+                onOpenMonitor={(monitorId) =>
+                  history.push(`/data-quality/monitor/${monitorId}`)
+                }
               />
-            </Spin>
-          </div>
-          <div className="mt-3 flex shrink-0 justify-end">
-            <Pagination
-              size="small"
-              current={data.current}
-              pageSize={data.pageSize}
-              total={data.total}
-              showSizeChanger
-              onChange={(current, pageSize) => load(current, pageSize)}
-            />
-          </div>
+            </div>
+
+            <div className="flex shrink-0 justify-end border-t border-[#f0f2f5] pt-3">
+              <Pagination
+                size="small"
+                current={current}
+                pageSize={pageSize}
+                total={total}
+                showSizeChanger
+                showTotal={(value) => `共 ${value} 条`}
+                onChange={(nextCurrent, nextPageSize) => {
+                  if (nextPageSize !== pageSize) {
+                    setPageSize(nextPageSize);
+                    return;
+                  }
+                  void load(nextCurrent, nextPageSize);
+                }}
+              />
+            </div>
+          </main>
         </div>
-        <ExecutionDetailDrawer
-          executionNo={executionNo}
-          open={Boolean(executionNo)}
-          onClose={() => setExecutionNo(undefined)}
-        />
       </div>
     </ConfigProvider>
   );

--- a/yak-ops-ui/src/pages/data-quality/execution/service.ts
+++ b/yak-ops-ui/src/pages/data-quality/execution/service.ts
@@ -1,0 +1,28 @@
+import HttpUtils from '@/utils/HttpUtils';
+import type { CommonApiResponse } from '../types';
+import type {
+  ExecutionLogView,
+  ExecutionWorkspacePageView,
+  ExecutionWorkspaceQuery,
+  ExecutionWorkspaceView,
+  RuleExecutionWorkspacePageView,
+} from './types';
+
+const PREFIX = '/api/v1/data-quality/execution/workspace';
+
+export const qualityExecutionWorkspaceApi = {
+  page: (
+    params: ExecutionWorkspaceQuery,
+  ): Promise<CommonApiResponse<ExecutionWorkspacePageView>> =>
+    HttpUtils.post<ExecutionWorkspacePageView>(`${PREFIX}/page`, params),
+  rulePage: (
+    params: ExecutionWorkspaceQuery,
+  ): Promise<CommonApiResponse<RuleExecutionWorkspacePageView>> =>
+    HttpUtils.post<RuleExecutionWorkspacePageView>(`${PREFIX}/rule/page`, params),
+  detail: (
+    executionNo: string,
+  ): Promise<CommonApiResponse<ExecutionWorkspaceView>> =>
+    HttpUtils.get<ExecutionWorkspaceView>(`${PREFIX}/${executionNo}`),
+  logs: (executionNo: string): Promise<CommonApiResponse<ExecutionLogView>> =>
+    HttpUtils.get<ExecutionLogView>(`${PREFIX}/${executionNo}/logs`),
+};

--- a/yak-ops-ui/src/pages/data-quality/execution/types.ts
+++ b/yak-ops-ui/src/pages/data-quality/execution/types.ts
@@ -1,0 +1,130 @@
+import type {
+  CheckResult,
+  ExecutionStatus,
+  RuleScope,
+  RuleType,
+  TriggerType,
+} from '../types';
+
+export interface ExecutionWorkspaceQuery {
+  current?: number;
+  pageSize?: number;
+  keyword?: string;
+  objectKeyword?: string;
+  dataSourceId?: number;
+  monitorId?: number;
+  executionStatus?: ExecutionStatus;
+  checkResult?: CheckResult;
+  triggerType?: TriggerType;
+  hasIssues?: boolean;
+  dimension?: string;
+  scope?: RuleScope;
+  queuedAfter?: string;
+  queuedBefore?: string;
+}
+
+export interface ExecutionWorkspaceListItem {
+  executionNo: string;
+  monitorId: number;
+  monitorName: string;
+  dataSourceId: number;
+  dataSourceName: string;
+  objectName: string;
+  triggerType: TriggerType;
+  executionStatus: ExecutionStatus;
+  checkResult: CheckResult;
+  totalRules: number;
+  passedRules: number;
+  failedRules: number;
+  errorRules: number;
+  operator: string;
+  queuedAt: string;
+  startedAt?: string;
+  finishedAt?: string;
+  durationMs?: number;
+  errorMessage?: string;
+}
+
+export interface RuleExecutionWorkspaceListItem {
+  id: number;
+  ruleId: number;
+  executionNo: string;
+  monitorId: number;
+  monitorName: string;
+  dataSourceId: number;
+  dataSourceName: string;
+  databaseName?: string;
+  schemaName?: string;
+  tableName: string;
+  objectName: string;
+  ruleName: string;
+  templateCode: string;
+  ruleType: RuleType;
+  scope: RuleScope;
+  dimension: string;
+  columnName?: string;
+  triggerType: TriggerType;
+  executionStatus: ExecutionStatus;
+  checkResult: CheckResult;
+  metricValue?: string;
+  expectedValue?: string;
+  operator: string;
+  queuedAt: string;
+  startedAt?: string;
+  finishedAt?: string;
+  durationMs?: number;
+  errorMessage?: string;
+}
+
+export interface ExecutionWorkspaceRuleView {
+  id: number;
+  ruleId: number;
+  ruleName: string;
+  templateCode: string;
+  ruleType: RuleType;
+  scope: RuleScope;
+  dimension: string;
+  columnName?: string;
+  checkResult: CheckResult;
+  metricValue?: string;
+  expectedValue?: string;
+  executedSql?: string;
+  errorMessage?: string;
+  durationMs?: number;
+  createdAt?: string;
+}
+
+export interface ExecutionWorkspaceView extends ExecutionWorkspaceListItem {
+  databaseName?: string;
+  schemaName?: string;
+  tableName: string;
+  rules: ExecutionWorkspaceRuleView[];
+}
+
+export interface ExecutionWorkspacePageView {
+  records: ExecutionWorkspaceListItem[];
+  total: number;
+  current: number;
+  pageSize: number;
+}
+
+export interface RuleExecutionWorkspacePageView {
+  records: RuleExecutionWorkspaceListItem[];
+  total: number;
+  current: number;
+  pageSize: number;
+}
+
+export type ExecutionLogLevel = 'INFO' | 'WARN' | 'ERROR';
+
+export interface ExecutionLogLine {
+  timestamp?: string;
+  level: ExecutionLogLevel;
+  stage: string;
+  message: string;
+}
+
+export interface ExecutionLogView {
+  executionNo: string;
+  lines: ExecutionLogLine[];
+}


### PR DESCRIPTION
## 背景

参考现有质量平台的运行记录列表与详情布局，重构 Yak Ops 数据质量「运行记录」模块，使其更适合按数据源、规则和监控任务查询运行结果，并补齐详情页与日志查询能力。

## 主要改动

### 前端

- 重构运行记录列表为「左侧数据源树 + 紧凑筛选区 + 结果表格」布局。
- 支持规则名称、数据对象、运行时间、质量结果、问题数量、质量维度、关联范围、执行状态和触发方式筛选。
- 增加「规则视角 / 监控视角」切换；规则视角展示真实规则执行记录、模板、范围、阈值、监控值与质量结果。
- 将详情由 Drawer 调整为独立工作台页面，包含：
  - 本次运行记录
  - 历史运行记录
  - 问题数据处理
  - 原始日志
- 详情页增加左侧历史执行记录列表，并支持收起、搜索和快速切换。
- 移除 AI/智能分析相关入口与页面能力，详情页仅保留确定性的运行结果、问题和日志信息。
- 新增隐藏详情路由，并补充导航继承测试。

### 后端

新增向后兼容的只读执行工作台接口，保留原有 `/api/v1/data-quality/execution` 接口不变：

- `POST /api/v1/data-quality/execution/workspace/page`
  - 监控执行记录分页查询。
- `POST /api/v1/data-quality/execution/workspace/rule/page`
  - 规则执行记录分页查询。
- `GET /api/v1/data-quality/execution/workspace/{executionNo}`
  - 查询执行详情与规则结果。
- `GET /api/v1/data-quality/execution/workspace/{executionNo}/logs`
  - 根据已持久化的执行生命周期、规则结果、SQL 与错误信息生成结构化运行日志。

查询支持数据源、监控、关键字、数据对象、执行状态、质量结果、触发方式、问题状态、质量维度、关联范围和时间区间过滤。

本次复用现有 `yak_quality_execution` 与 `yak_quality_rule_execution` 数据，不新增数据库迁移。

## 校验

- TypeScript / TSX transpile 语法检查通过。
- 使用本地接口契约桩执行聚焦 TypeScript 严格类型检查，通过。
- 使用本地依赖桩执行新增 Java 源码编译检查，通过。
- 新运行记录页面中未发现 AI/智能分析入口。

完整 Maven 构建、前端依赖构建和浏览器联调仍建议由 CI 或本地完整工程环境继续验证。

> 当前分支由多次文件级提交组成，合并时建议使用 Squash。