### PR TITLE
fix(data-quality): separate table monitor detail and edit flows

### DIFF
--- a/yak-ops-ui/src/pages/data-quality/monitor/detail/MonitorListTab.tsx
+++ b/yak-ops-ui/src/pages/data-quality/monitor/detail/MonitorListTab.tsx
@@ -1,16 +1,6 @@
-import {
-  Button,
-  Dropdown,
-  Empty,
-  Input,
-  Select,
-  Table,
-  Tag,
-  Tooltip,
-  message,
-} from 'antd';
+import { Button, Dropdown, Empty, Input, Select, Table, Tag } from 'antd';
 import type { TableColumnsType } from 'antd';
-import { MoreHorizontal, Plus, RefreshCw, Search } from 'lucide-react';
+import { MoreHorizontal, RefreshCw, Search } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import { dataQualityTableClassName } from '../../components/tableStyle';
 import type { MonitorWorkspaceView } from '../../types';
@@ -20,7 +10,6 @@ interface MonitorListTabProps {
   workspace: MonitorWorkspaceView;
   running: boolean;
   onRun: () => void;
-  onEdit: () => void;
   onRefresh: () => void;
   onRemove: () => void;
   onOpenLog: () => void;
@@ -41,7 +30,6 @@ const MonitorListTab = ({
   workspace,
   running,
   onRun,
-  onEdit,
   onRefresh,
   onRemove,
   onOpenLog,
@@ -148,16 +136,9 @@ const MonitorListTab = ({
     {
       title: '操作',
       fixed: 'right',
-      width: 190,
+      width: 160,
       render: () => (
         <div className="flex items-center gap-3 whitespace-nowrap text-xs">
-          <button
-            type="button"
-            className="border-0 bg-transparent p-0 text-[#245bdb]"
-            onClick={onEdit}
-          >
-            编辑
-          </button>
           <button
             type="button"
             className="border-0 bg-transparent p-0 text-[#245bdb]"
@@ -194,15 +175,6 @@ const MonitorListTab = ({
   return (
     <div className="min-h-0 flex-1 overflow-auto bg-white px-6 py-4">
       <div className="flex flex-wrap items-center gap-2">
-        <Tooltip title="当前数据表只允许创建一个质量监控">
-          <Button
-            type="primary"
-            icon={<Plus size={14} />}
-            onClick={() => message.info('当前数据表已经存在质量监控')}
-          >
-            新建质量监控
-          </Button>
-        </Tooltip>
         <Input
           allowClear
           value={keyword}

--- a/yak-ops-ui/src/pages/data-quality/monitor/detail/RuleManagementTab.tsx
+++ b/yak-ops-ui/src/pages/data-quality/monitor/detail/RuleManagementTab.tsx
@@ -1,27 +1,7 @@
-import {
-  Button,
-  Dropdown,
-  Empty,
-  Input,
-  Modal,
-  Select,
-  Table,
-  Tag,
-  Tooltip,
-  message,
-} from 'antd';
+import { Button, Dropdown, Empty, Input, Select, Table, Tag } from 'antd';
 import type { MenuProps, TableColumnsType } from 'antd';
-import {
-  Bell,
-  ChevronDown,
-  MoreHorizontal,
-  Play,
-  Plus,
-  RefreshCw,
-  Search,
-  Sparkles,
-} from 'lucide-react';
-import { useMemo, useState, type Key } from 'react';
+import { MoreHorizontal, Play, RefreshCw, Search } from 'lucide-react';
+import { useMemo, useState } from 'react';
 import { dataQualityTableClassName } from '../../components/tableStyle';
 import type { MonitorWorkspaceView, RuleView } from '../../types';
 import {
@@ -34,25 +14,19 @@ import {
 interface RuleManagementTabProps {
   workspace: MonitorWorkspaceView;
   running: boolean;
-  savingRules: boolean;
   onRun: () => void;
-  onEditMonitor: () => void;
   onOpenLog: () => void;
   onRefresh: () => void;
   onRemoveMonitor: () => void;
-  onUpdateRules: (rules: RuleView[]) => Promise<void>;
 }
 
 const RuleManagementTab = ({
   workspace,
   running,
-  savingRules,
   onRun,
-  onEditMonitor,
   onOpenLog,
   onRefresh,
   onRemoveMonitor,
-  onUpdateRules,
 }: RuleManagementTabProps) => {
   const { monitor, settings, stats } = workspace;
   const [keyword, setKeyword] = useState('');
@@ -60,7 +34,6 @@ const RuleManagementTab = ({
   const [scope, setScope] = useState<string>();
   const [enabled, setEnabled] = useState<boolean>();
   const [dimension, setDimension] = useState<string>();
-  const [selectedRowKeys, setSelectedRowKeys] = useState<Key[]>([]);
 
   const records = useMemo(() => {
     const normalizedKeyword = keyword.trim().toLowerCase();
@@ -100,32 +73,6 @@ const RuleManagementTab = ({
     setScope(undefined);
     setEnabled(undefined);
     setDimension(undefined);
-  };
-
-  const updateSelected = async (nextEnabled: boolean) => {
-    if (!selectedRowKeys.length) return;
-    await onUpdateRules(
-      monitor.rules.map((rule) =>
-        selectedRowKeys.includes(rule.id)
-          ? { ...rule, enabled: nextEnabled }
-          : rule,
-      ),
-    );
-    setSelectedRowKeys([]);
-  };
-
-  const removeRule = (rule: RuleView) => {
-    if (monitor.rules.length <= 1) {
-      message.warning('质量监控至少需要保留一条规则');
-      return;
-    }
-    Modal.confirm({
-      title: '删除质量规则？',
-      content: `确认删除“${rule.name}”吗？历史执行结果仍会保留。`,
-      okButtonProps: { danger: true },
-      onOk: () =>
-        onUpdateRules(monitor.rules.filter((item) => item.id !== rule.id)),
-    });
   };
 
   const columns: TableColumnsType<RuleView> = [
@@ -202,31 +149,15 @@ const RuleManagementTab = ({
     {
       title: '操作',
       fixed: 'right',
-      width: 180,
-      render: (_, rule) => (
-        <div className="flex items-center gap-3 whitespace-nowrap text-xs">
-          <button
-            type="button"
-            className="border-0 bg-transparent p-0 text-[#245bdb]"
-            onClick={onEditMonitor}
-          >
-            修改
-          </button>
-          <button
-            type="button"
-            className="border-0 bg-transparent p-0 text-[#245bdb]"
-            onClick={() => removeRule(rule)}
-          >
-            删除
-          </button>
-          <button
-            type="button"
-            className="border-0 bg-transparent p-0 text-[#245bdb]"
-            onClick={onOpenLog}
-          >
-            操作日志
-          </button>
-        </div>
+      width: 110,
+      render: () => (
+        <button
+          type="button"
+          className="border-0 bg-transparent p-0 text-xs text-[#245bdb]"
+          onClick={onOpenLog}
+        >
+          操作日志
+        </button>
       ),
     },
   ];
@@ -234,13 +165,13 @@ const RuleManagementTab = ({
   const moreMenu: MenuProps = {
     items: [
       { key: 'refresh', label: '刷新数据' },
-      { key: 'edit', label: '编辑质量监控' },
+      { key: 'log', label: '操作日志' },
       { type: 'divider' },
       { key: 'remove', label: '删除质量监控', danger: true },
     ],
     onClick: ({ key }) => {
       if (key === 'refresh') onRefresh();
-      if (key === 'edit') onEditMonitor();
+      if (key === 'log') onOpenLog();
       if (key === 'remove') onRemoveMonitor();
     },
   };
@@ -248,7 +179,7 @@ const RuleManagementTab = ({
   return (
     <div className="flex min-h-0 flex-1 bg-white">
       <aside className="w-[286px] shrink-0 border-r border-[#e5e7eb] bg-[#fbfcfe] px-5 py-5">
-        <div className="text-[14px] font-semibold text-[#172033]">规则管理</div>
+        <div className="text-[14px] font-semibold text-[#172033]">规则详情</div>
         <div className="mt-4 space-y-1 text-[13px]">
           <div className="flex items-center justify-between rounded-md bg-[#f0f3f8] px-3 py-2 font-medium text-[#27344f]">
             <span>全部规则</span>
@@ -257,29 +188,24 @@ const RuleManagementTab = ({
             </span>
           </div>
           <div className="flex items-center justify-between px-3 py-2 text-[#43506a]">
-            <span>已关联质量监控的规则</span>
-            <span>{stats.ruleCount}</span>
+            <span>已启用规则</span>
+            <span>{stats.enabledRuleCount}</span>
           </div>
           <div className="flex items-center justify-between px-3 py-2 text-[#43506a]">
-            <span>未关联质量监控的规则</span>
-            <span>0</span>
+            <span>已停用规则</span>
+            <span>{stats.ruleCount - stats.enabledRuleCount}</span>
           </div>
         </div>
 
         <div className="mt-7 flex items-center justify-between">
           <div className="text-[14px] font-semibold text-[#172033]">
-            质量监控视角
+            质量监控信息
           </div>
-          <div className="flex items-center gap-2 text-[#667085]">
-            <Tooltip title="新建质量监控">
-              <Plus size={16} />
-            </Tooltip>
-            <RefreshCw
-              size={14}
-              className="cursor-pointer"
-              onClick={onRefresh}
-            />
-          </div>
+          <RefreshCw
+            size={14}
+            className="cursor-pointer text-[#667085]"
+            onClick={onRefresh}
+          />
         </div>
         <Input
           variant="filled"
@@ -307,7 +233,7 @@ const RuleManagementTab = ({
         </div>
       </aside>
 
-      <main className="min-w-0 flex-1 px-4 py-4">
+      <main className="min-w-0 flex-1 overflow-auto px-4 py-4">
         <div className="flex flex-wrap items-center justify-between gap-3 border-b border-[#edf0f3] pb-3">
           <div className="flex min-w-0 items-center gap-2">
             <span className="truncate text-[14px] font-medium text-[#172033]">
@@ -321,13 +247,6 @@ const RuleManagementTab = ({
             >
               测试运行
             </Button>
-            <Button
-              size="small"
-              icon={<Bell size={13} />}
-              onClick={() => message.info('告警策略可在编辑质量监控中配置')}
-            >
-              告警订阅
-            </Button>
             <Dropdown menu={moreMenu} trigger={['click']}>
               <Button size="small" icon={<MoreHorizontal size={14} />} />
             </Dropdown>
@@ -340,14 +259,6 @@ const RuleManagementTab = ({
         </div>
 
         <div className="flex flex-wrap items-center gap-2 py-3">
-          <Button
-            type="primary"
-            icon={<Sparkles size={14} />}
-            onClick={onEditMonitor}
-          >
-            AI生成规则
-          </Button>
-          <Button onClick={onEditMonitor}>新建规则</Button>
           <Input
             value={keyword}
             onChange={(event) => setKeyword(event.target.value)}
@@ -402,7 +313,6 @@ const RuleManagementTab = ({
           rowKey="id"
           size="small"
           bordered
-          loading={savingRules}
           pagination={false}
           scroll={{ x: 1280 }}
           className={dataQualityTableClassName()}
@@ -415,42 +325,11 @@ const RuleManagementTab = ({
               />
             ),
           }}
-          rowSelection={{
-            selectedRowKeys,
-            onChange: setSelectedRowKeys,
-          }}
           columns={columns}
         />
 
-        <div className="mt-3 flex flex-wrap items-center justify-between gap-3">
-          <div className="flex items-center gap-2">
-            <Button
-              disabled={!selectedRowKeys.length}
-              onClick={() => updateSelected(true)}
-            >
-              启用
-            </Button>
-            <Button
-              disabled={!selectedRowKeys.length}
-              onClick={() => updateSelected(false)}
-            >
-              停用
-            </Button>
-            <Button disabled={!selectedRowKeys.length}>关联质量监控</Button>
-            <Dropdown
-              menu={{
-                items: [{ key: 'log', label: '查看操作日志' }],
-                onClick: onOpenLog,
-              }}
-            >
-              <Button disabled={!selectedRowKeys.length}>
-                更多操作 <ChevronDown size={12} />
-              </Button>
-            </Dropdown>
-          </div>
-          <div className="text-xs text-[#8b95a7]">
-            共 {records.length} 条规则
-          </div>
+        <div className="mt-3 flex justify-end text-xs text-[#8b95a7]">
+          共 {records.length} 条规则
         </div>
       </main>
     </div>

--- a/yak-ops-ui/src/pages/data-quality/monitor/detail/index.tsx
+++ b/yak-ops-ui/src/pages/data-quality/monitor/detail/index.tsx
@@ -4,22 +4,18 @@ import { history, useParams } from '@umijs/max';
 import { ConfigProvider, Modal, Spin, message } from 'antd';
 import dayjs from 'dayjs';
 import { useCallback, useEffect, useState } from 'react';
-import {
-  qualityMonitorApi,
-  qualityWorkspaceApi,
-} from '../../service';
+import { qualityMonitorApi, qualityWorkspaceApi } from '../../service';
 import type {
   MonitorReportView,
   MonitorWorkspaceView,
   OperationLogPageView,
-  RuleView,
 } from '../../types';
 import MonitorListTab from './MonitorListTab';
 import OperationLogDrawer from './OperationLogDrawer';
 import QualityReportTab from './QualityReportTab';
 import RuleManagementTab from './RuleManagementTab';
 import WorkspaceHeader from './WorkspaceHeader';
-import { toSavePayload, type WorkspaceTab } from './model';
+import type { WorkspaceTab } from './model';
 
 const unwrap = <T,>(response: {
   code: number;
@@ -56,7 +52,6 @@ const MonitorDetailPage = () => {
   const [logLoading, setLogLoading] = useState(false);
   const [logOpen, setLogOpen] = useState(false);
   const [running, setRunning] = useState(false);
-  const [savingRules, setSavingRules] = useState(false);
 
   const loadWorkspace = useCallback(async () => {
     if (!params.id) return;
@@ -133,29 +128,6 @@ const MonitorDetailPage = () => {
     }
   };
 
-  const updateRules = async (rules: RuleView[]) => {
-    if (!workspace || !params.id) return;
-    setSavingRules(true);
-    try {
-      unwrap(
-        await qualityMonitorApi.update(
-          params.id,
-          toSavePayload(workspace.monitor, workspace.settings, rules),
-        ),
-      );
-      message.success('质量规则已更新');
-      await loadWorkspace();
-      if (activeTab === 'report') {
-        await loadReport(reportDate);
-      }
-    } catch (error: any) {
-      message.error(error?.message || '质量规则更新失败');
-      throw error;
-    } finally {
-      setSavingRules(false);
-    }
-  };
-
   const removeMonitor = () => {
     if (!params.id) return;
     Modal.confirm({
@@ -196,15 +168,10 @@ const MonitorDetailPage = () => {
                 <RuleManagementTab
                   workspace={workspace}
                   running={running}
-                  savingRules={savingRules}
                   onRun={run}
-                  onEditMonitor={() =>
-                    history.push(`/data-quality/monitor/${params.id}/edit`)
-                  }
                   onOpenLog={openLog}
                   onRefresh={loadWorkspace}
                   onRemoveMonitor={removeMonitor}
-                  onUpdateRules={updateRules}
                 />
               ) : null}
 
@@ -213,9 +180,6 @@ const MonitorDetailPage = () => {
                   workspace={workspace}
                   running={running}
                   onRun={run}
-                  onEdit={() =>
-                    history.push(`/data-quality/monitor/${params.id}/edit`)
-                  }
                   onRefresh={loadWorkspace}
                   onRemove={removeMonitor}
                   onOpenLog={openLog}

--- a/yak-ops-ui/src/pages/data-quality/table-config/components/RegisteredTablePanel.tsx
+++ b/yak-ops-ui/src/pages/data-quality/table-config/components/RegisteredTablePanel.tsx
@@ -1,5 +1,5 @@
-import YakOpsEmpty from "@/components/YakOpsEmpty";
-import { DownOutlined, PlayCircleOutlined } from "@ant-design/icons";
+import YakOpsEmpty from '@/components/YakOpsEmpty';
+import { DownOutlined, PlayCircleOutlined } from '@ant-design/icons';
 import {
   Button,
   Dropdown,
@@ -13,13 +13,13 @@ import {
   Tooltip,
   message,
   type MenuProps,
-} from "antd";
-import { Eye, Plus, Search, Settings2, Trash2 } from "lucide-react";
-import { useState, type Key } from "react";
-import { CheckResultTag } from "../../components/QualityStatus";
-import { dataQualityTableClassName } from "../../components/tableStyle";
-import type { TableAssetView } from "../../types";
-import { PAGE_SIZE, type DataSourceTreeNode } from "../model";
+} from 'antd';
+import { Eye, Plus, Search, Settings2, Trash2 } from 'lucide-react';
+import { useState, type Key } from 'react';
+import { CheckResultTag } from '../../components/QualityStatus';
+import { dataQualityTableClassName } from '../../components/tableStyle';
+import type { TableAssetView } from '../../types';
+import { PAGE_SIZE, type DataSourceTreeNode } from '../model';
 
 interface RegisteredTablePanelProps {
   dataSourceId?: number;
@@ -32,7 +32,9 @@ interface RegisteredTablePanelProps {
   onAssetCurrentChange: (current: number) => void;
   onKeywordChange: (keyword: string) => void;
   onOpenRegister: () => void;
-  onOpenMonitor: (record: TableAssetView) => void;
+  onOpenMonitorDetail: (record: TableAssetView) => void;
+  onOpenMonitorEdit: (record: TableAssetView) => void;
+  onCreateMonitor: (record: TableAssetView) => void;
   onRun: (record: TableAssetView) => void | Promise<void>;
   onUnregister: (record: TableAssetView) => void;
 }
@@ -48,7 +50,9 @@ const RegisteredTablePanel = ({
   onAssetCurrentChange,
   onKeywordChange,
   onOpenRegister,
-  onOpenMonitor,
+  onOpenMonitorDetail,
+  onOpenMonitorEdit,
+  onCreateMonitor,
   onRun,
   onUnregister,
 }: RegisteredTablePanelProps) => {
@@ -56,7 +60,7 @@ const RegisteredTablePanel = ({
 
   const handleRun = async (record: TableAssetView) => {
     if (!record.monitorId) {
-      message.warning("请先新建质量监控，再执行运行操作");
+      message.warning('请先新建质量监控，再执行运行操作');
       return;
     }
 
@@ -69,37 +73,37 @@ const RegisteredTablePanel = ({
   };
 
   const getActionItems = (
-    record: TableAssetView
-  ): NonNullable<MenuProps["items"]> => {
-    const items: NonNullable<MenuProps["items"]> = [];
+    record: TableAssetView,
+  ): NonNullable<MenuProps['items']> => {
+    const items: NonNullable<MenuProps['items']> = [];
 
     if (record.monitorId) {
       items.push(
         {
-          key: "detail",
+          key: 'detail',
           icon: <Eye size={14} />,
-          label: "查看详情",
+          label: '查看详情',
         },
         {
-          key: "edit",
+          key: 'edit',
           icon: <Settings2 size={14} />,
-          label: "编辑配置",
-        }
+          label: '编辑配置',
+        },
       );
     } else {
       items.push({
-        key: "create",
+        key: 'create',
         icon: <Settings2 size={14} />,
-        label: "新建质量监控",
+        label: '新建质量监控',
       });
     }
 
     items.push(
       {
-        type: "divider",
+        type: 'divider',
       },
       {
-        key: "unregister",
+        key: 'unregister',
         danger: true,
         disabled: record.monitorCount > 0,
         icon: <Trash2 size={14} />,
@@ -109,29 +113,39 @@ const RegisteredTablePanel = ({
               <span className="block w-full">取消注册</span>
             </Tooltip>
           ) : (
-            "取消注册"
+            '取消注册'
           ),
-      }
+      },
     );
 
     return items;
   };
 
   const handleActionClick = (record: TableAssetView, key: Key) => {
-    if (key === "detail" || key === "edit" || key === "create") {
-      onOpenMonitor(record);
+    if (key === 'detail') {
+      onOpenMonitorDetail(record);
       return;
     }
 
-    if (key !== "unregister" || record.monitorCount > 0) {
+    if (key === 'edit') {
+      onOpenMonitorEdit(record);
+      return;
+    }
+
+    if (key === 'create') {
+      onCreateMonitor(record);
+      return;
+    }
+
+    if (key !== 'unregister' || record.monitorCount > 0) {
       return;
     }
 
     Modal.confirm({
-      title: "取消注册数据表",
-      content: "取消后，该表将不再出现在按表配置列表中。",
-      okText: "确认取消",
-      cancelText: "保留",
+      title: '取消注册数据表',
+      content: '取消后，该表将不再出现在按表配置列表中。',
+      okText: '确认取消',
+      cancelText: '保留',
       okButtonProps: { danger: true },
       onOk: () => onUnregister(record),
     });
@@ -199,17 +213,15 @@ const RegisteredTablePanel = ({
                   className={dataQualityTableClassName()}
                   locale={{
                     emptyText: (
-                      <div
-                        style={{ display: "flex", justifyContent: "center" }}
-                      >
-                        <YakOpsEmpty />{" "}
+                      <div style={{ display: 'flex', justifyContent: 'center' }}>
+                        <YakOpsEmpty />
                       </div>
                     ),
                   }}
                   columns={[
                     {
-                      title: "表名 / 描述 / 路径",
-                      dataIndex: "tableName",
+                      title: '表名 / 描述 / 路径',
+                      dataIndex: 'tableName',
                       minWidth: 330,
                       render: (_, record) => (
                         <div className="min-w-0 py-1">
@@ -228,13 +240,13 @@ const RegisteredTablePanel = ({
                               record.tableName,
                             ]
                               .filter(Boolean)
-                              .join(" / ")}
+                              .join(' / ')}
                           </div>
                         </div>
                       ),
                     },
                     {
-                      title: "数据源 / 类型",
+                      title: '数据源 / 类型',
                       width: 190,
                       render: (_, record) => (
                         <div className="space-y-1 py-0.5">
@@ -242,13 +254,13 @@ const RegisteredTablePanel = ({
                             {record.dataSourceName}
                           </div>
                           <Tag className="!m-0 !border-0 !bg-[#f2f4f7] !text-[11px] !text-[#667085]">
-                            {record.tableType || "TABLE"}
+                            {record.tableType || 'TABLE'}
                           </Tag>
                         </div>
                       ),
                     },
                     {
-                      title: "质量配置",
+                      title: '质量配置',
                       width: 170,
                       render: (_, record) => (
                         <div className="grid grid-cols-2 gap-x-3 gap-y-1 text-xs">
@@ -264,19 +276,19 @@ const RegisteredTablePanel = ({
                       ),
                     },
                     {
-                      title: "最近状态",
+                      title: '最近状态',
                       width: 190,
                       render: (_, record) => (
                         <div className="space-y-1.5 py-0.5">
                           <CheckResultTag value={record.lastResult} />
                           <div className="text-[11px] text-[#98a2b3]">
-                            {record.lastRunTime || "暂无运行记录"}
+                            {record.lastRunTime || '暂无运行记录'}
                           </div>
                         </div>
                       ),
                     },
                     {
-                      title: "注册信息",
+                      title: '注册信息',
                       width: 190,
                       render: (_, record) => (
                         <div className="space-y-1 text-xs">
@@ -290,9 +302,9 @@ const RegisteredTablePanel = ({
                       ),
                     },
                     {
-                      title: "操作",
+                      title: '操作',
                       width: 174,
-                      fixed: "right",
+                      fixed: 'right',
                       render: (_, record) => (
                         <div
                           className="flex items-center gap-1 whitespace-nowrap"
@@ -300,7 +312,7 @@ const RegisteredTablePanel = ({
                         >
                           <Tooltip
                             title={
-                              record.monitorId ? undefined : "请先新建质量监控"
+                              record.monitorId ? undefined : '请先新建质量监控'
                             }
                           >
                             <Popconfirm
@@ -316,22 +328,22 @@ const RegisteredTablePanel = ({
                             >
                               <Button
                                 size="small"
-                                color={record.monitorId ? "primary" : "default"}
+                                color={record.monitorId ? 'primary' : 'default'}
                                 variant="filled"
                                 loading={runningRecordId === record.id}
                                 aria-disabled={!record.monitorId}
                                 icon={<PlayCircleOutlined />}
                                 className={[
-                                  "!h-7 !rounded-md !px-2.5 !text-xs",
+                                  '!h-7 !rounded-md !px-2.5 !text-xs',
                                   !record.monitorId
-                                    ? "!cursor-not-allowed !text-[#98a2b3]"
-                                    : "",
-                                ].join(" ")}
+                                    ? '!cursor-not-allowed !text-[#98a2b3]'
+                                    : '',
+                                ].join(' ')}
                                 onClick={(event) => {
                                   event.stopPropagation();
                                   if (!record.monitorId) {
                                     message.warning(
-                                      "请先新建质量监控，再执行运行操作"
+                                      '请先新建质量监控，再执行运行操作',
                                     );
                                   }
                                 }}
@@ -342,7 +354,7 @@ const RegisteredTablePanel = ({
                           </Tooltip>
 
                           <Dropdown
-                            trigger={["click"]}
+                            trigger={['click']}
                             placement="bottomRight"
                             overlayStyle={{ minWidth: 138 }}
                             menu={{

--- a/yak-ops-ui/src/pages/data-quality/table-config/hooks/useTableAssets.ts
+++ b/yak-ops-ui/src/pages/data-quality/table-config/hooks/useTableAssets.ts
@@ -274,11 +274,23 @@ export const useTableAssets = ({
     }
   };
 
-  const openMonitor = (record: TableAssetView) => {
-    if (record.monitorId) {
-      history.push(`/data-quality/monitor/${record.monitorId}`);
+  const openMonitorDetail = (record: TableAssetView) => {
+    if (!record.monitorId) {
+      message.warning('当前数据表尚未创建质量监控');
       return;
     }
+    history.push(`/data-quality/monitor/${record.monitorId}`);
+  };
+
+  const openMonitorEdit = (record: TableAssetView) => {
+    if (!record.monitorId) {
+      message.warning('当前数据表尚未创建质量监控');
+      return;
+    }
+    history.push(`/data-quality/monitor/${record.monitorId}/edit`);
+  };
+
+  const createMonitor = (record: TableAssetView) => {
     const query = new URLSearchParams({
       dataSourceId: String(record.dataSourceId),
       dataSourceName: record.dataSourceName,
@@ -320,6 +332,8 @@ export const useTableAssets = ({
     handleRegister,
     handleUnregister,
     handleRun,
-    openMonitor,
+    openMonitorDetail,
+    openMonitorEdit,
+    createMonitor,
   };
 };

--- a/yak-ops-ui/src/pages/data-quality/table-config/index.tsx
+++ b/yak-ops-ui/src/pages/data-quality/table-config/index.tsx
@@ -80,7 +80,9 @@ const TableConfigPage = () => {
               table.setAssetCurrent(1);
             }}
             onOpenRegister={table.openRegisterDrawer}
-            onOpenMonitor={table.openMonitor}
+            onOpenMonitorDetail={table.openMonitorDetail}
+            onOpenMonitorEdit={table.openMonitorEdit}
+            onCreateMonitor={table.createMonitor}
             onRun={table.handleRun}
             onUnregister={table.handleUnregister}
           />


### PR DESCRIPTION
## What changed

- Split the table configuration action routing by responsibility:
  - **View details** opens `/data-quality/monitor/:id`
  - **Edit configuration** opens `/data-quality/monitor/:id/edit`
  - **Create quality monitor** keeps using `/data-quality/monitor/create`
- Removed edit-oriented capabilities from the monitor detail page, including rule modification, rule deletion, batch enable/disable, rule creation, and edit navigation.
- Removed the **AI-generated rules** entry from the detail page.
- Kept detail-side operational actions such as viewing logs, refreshing, test runs, and monitor deletion.

## Why

The table configuration list previously routed both “View details” and “Edit configuration” to the same page. This mixed read-only inspection with configuration changes and made page responsibilities unclear.

## Impact

- Detail pages now focus on viewing monitor, rule, report, and log information.
- Configuration changes are handled only by the dedicated editor route.
- Existing create, run, refresh, log, and delete flows remain available.

## Validation

- Reviewed the branch diff against `main`.
- Confirmed the three list actions now call distinct navigation handlers.
- Confirmed the detail components no longer expose edit or AI rule-generation controls.
- Local `npm run tsc` / `npm run lint` could not be run because this execution environment has no repository checkout or GitHub CLI; CI results should be used for final validation.