### PR TITLE
refactor(data-quality): move quality rules to second step

### DIFF
--- a/yak-ops-ui/src/pages/data-quality/monitor/editor/EditorLayout.tsx
+++ b/yak-ops-ui/src/pages/data-quality/monitor/editor/EditorLayout.tsx
@@ -2,9 +2,9 @@ import type { ReactNode } from 'react';
 
 export const SECTION_ITEMS = [
   { key: 'basic-config', label: '基本配置' },
+  { key: 'quality-rules', label: '选择质量规则' },
   { key: 'run-settings', label: '运行设置' },
   { key: 'issue-strategy', label: '质量问题处理策略' },
-  { key: 'quality-rules', label: '选择质量规则' },
 ] as const;
 export type SectionKey = (typeof SECTION_ITEMS)[number]['key'];
 

--- a/yak-ops-ui/src/pages/data-quality/monitor/editor/MonitorEditorPage.tsx
+++ b/yak-ops-ui/src/pages/data-quality/monitor/editor/MonitorEditorPage.tsx
@@ -237,18 +237,18 @@ const MonitorEditorPage = () => {
                       dataSourceName={selectedSource?.name}
                       tables={tables}
                     />
-                    <RuntimeSettings
-                      value={runtime}
-                      onChange={setRuntime}
-                      nextRunTime={nextRunTime}
-                    />
-                    <IssueStrategy value={strategy} onChange={setStrategy} />
                     <QualityRuleEditor
                       rules={rules}
                       onChange={setRules}
                       columns={columns}
                       templates={templates}
                     />
+                    <RuntimeSettings
+                      value={runtime}
+                      onChange={setRuntime}
+                      nextRunTime={nextRunTime}
+                    />
+                    <IssueStrategy value={strategy} onChange={setStrategy} />
                   </main>
                 </Form>
               </Spin>


### PR DESCRIPTION
## What changed

- Move **选择质量规则** from the fourth step to the second step in the monitor editor.
- Keep the page content order and the right-side **快速定位** order consistent.
- New configuration flow:
  1. 基本配置
  2. 选择质量规则
  3. 运行设置
  4. 质量问题处理策略

## Why

Quality-rule selection is part of defining what the monitor checks, so placing it immediately after the basic monitor configuration makes the setup flow more natural before configuring runtime and issue-handling behavior.

## Impact

Frontend layout/order only. No API, validation, persistence, or backend behavior changes.

## Validation

- Branch created from the latest `main`.
- Diff contains only two editor files and only section-order changes.