### PR TITLE
refactor(data-quality): lock monitor target to registered table

### DIFF
--- a/yak-ops-ui/src/pages/data-quality/monitor/editor/BasicConfig.tsx
+++ b/yak-ops-ui/src/pages/data-quality/monitor/editor/BasicConfig.tsx
@@ -1,130 +1,137 @@
 import { history } from '@umijs/max';
-import { Alert, Button, Form, Input, Select, Switch } from 'antd';
+import { Alert, Button, Form, Input, Switch } from 'antd';
 import { EditorField, EditorSection } from './EditorLayout';
 
 export const BasicConfig = ({
   dataSourceId,
   dataSourceName,
-  tables,
+  databaseName,
+  schemaName,
+  tableName,
 }: {
   dataSourceId?: number;
   dataSourceName?: string;
-  tables: Array<{ name: string; remarks?: string }>;
-}) => (
-  <EditorSection
-    id="basic-config"
-    title="基本配置"
-    description=""
-  >
-    <div className="space-y-5">
-      <EditorField label="监控名称" required>
-        <Form.Item
-          name="name"
-          rules={[{ required: true, message: '请输入监控名称' }]}
-          className="!mb-0"
-        >
-          <Input
-            variant="filled"
-            maxLength={100}
-            showCount
-            placeholder="例如：订单表每日质量检查"
-          />
-        </Form.Item>
-      </EditorField>
+  databaseName?: string;
+  schemaName?: string;
+  tableName?: string;
+}) => {
+  const objectPath = [dataSourceName, databaseName, schemaName]
+    .filter(Boolean)
+    .join(' / ');
 
-      <EditorField label="负责人" required>
-        <Form.Item
-          name="owner"
-          rules={[{ required: true, message: '请输入负责人' }]}
-          className="!mb-0"
-        >
-          <Input variant="filled" placeholder="请输入质量监控负责人" />
-        </Form.Item>
-      </EditorField>
-
-      <EditorField label="监控对象" required>
-        {dataSourceId ? (
+  return (
+    <EditorSection
+      id="basic-config"
+      title="基本配置"
+      description=""
+    >
+      <div className="space-y-5">
+        <EditorField label="监控名称" required>
           <Form.Item
-            name="tableName"
-            rules={[{ required: true, message: '请选择数据表' }]}
+            name="name"
+            rules={[{ required: true, message: '请输入监控名称' }]}
             className="!mb-0"
           >
-            <Select
+            <Input
               variant="filled"
-              showSearch
-              optionFilterProp="label"
-              placeholder="请选择需要监控的数据表"
-              options={tables.map((item) => ({
-                value: item.name,
-                label: item.remarks ? `${item.name} · ${item.remarks}` : item.name,
-              }))}
+              maxLength={100}
+              showCount
+              placeholder="例如：订单表每日质量检查"
             />
           </Form.Item>
-        ) : (
-          <Alert
-            type="warning"
-            showIcon
-            message="尚未指定监控对象"
-            description="请先从按表配置页面选择数据表，再创建质量监控。"
-            action={
-              <Button
-                size="small"
-                onClick={() => history.push('/data-quality/table-config')}
-              >
-                返回按表配置
-              </Button>
-            }
-          />
-        )}
-        {dataSourceId && dataSourceName ? (
-          <div className="mt-2 text-[11px] text-[#98a2b3]">
-            已关联 {dataSourceName}，数据库与 Schema 路径自动继承。
-          </div>
-        ) : null}
-      </EditorField>
+        </EditorField>
 
-      <EditorField
-        label="数据范围"
-        hint="仅填写 WHERE 后的条件；留空时检查整张表。"
-      >
-        <Form.Item name="whereClause" className="!mb-0">
-          <Input.TextArea
-            variant="filled"
-            rows={4}
-            maxLength={4000}
-            showCount
-            placeholder="例如：dt = '${bizdate}' AND status = 1"
-          />
-        </Form.Item>
-      </EditorField>
-
-      <EditorField label="监控描述">
-        <Form.Item name="description" className="!mb-0">
-          <Input.TextArea
-            variant="filled"
-            rows={4}
-            maxLength={500}
-            showCount
-            placeholder="请说明监控目的、质量要求和异常处理方式"
-          />
-        </Form.Item>
-      </EditorField>
-
-      <EditorField label="启用状态">
-        <div className="flex min-h-12 items-center justify-between rounded-lg bg-[#f5f5f6] px-3 py-2">
-          <div>
-            <div className="text-[13px] font-medium text-[#344054]">
-              创建后立即启用
-            </div>
-            <div className="mt-0.5 text-[11px] text-[#98a2b3]">
-              停用后调度不会运行，仍可保留全部配置。
-            </div>
-          </div>
-          <Form.Item name="enabled" valuePropName="checked" className="!mb-0">
-            <Switch />
+        <EditorField label="负责人" required>
+          <Form.Item
+            name="owner"
+            rules={[{ required: true, message: '请输入负责人' }]}
+            className="!mb-0"
+          >
+            <Input variant="filled" placeholder="请输入质量监控负责人" />
           </Form.Item>
-        </div>
-      </EditorField>
-    </div>
-  </EditorSection>
-);
+        </EditorField>
+
+        <EditorField label="监控对象" required>
+          {dataSourceId && tableName ? (
+            <div className="rounded-lg bg-[#f5f5f6] px-3 py-2.5">
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0 flex-1">
+                  <div className="truncate text-[13px] font-medium text-[#344054]">
+                    {tableName}
+                  </div>
+                  <div className="mt-1 truncate text-[11px] text-[#8a8f99]">
+                    {objectPath || `数据源 ID：${dataSourceId}`}
+                  </div>
+                </div>
+                <span className="shrink-0 rounded bg-white px-2 py-0.5 text-[11px] text-[#667085]">
+                  已固定
+                </span>
+              </div>
+              <div className="mt-2 border-t border-[#e8e9ec] pt-2 text-[11px] leading-5 text-[#98a2b3]">
+                监控对象来自数据表监控中的已注册数据表，创建过程中不可切换。
+              </div>
+            </div>
+          ) : (
+            <Alert
+              type="warning"
+              showIcon
+              message="尚未指定监控对象"
+              description="请先从数据表监控页面选择已注册的数据表，再创建质量监控。"
+              action={
+                <Button
+                  size="small"
+                  onClick={() => history.push('/data-quality/table-config')}
+                >
+                  返回数据表监控
+                </Button>
+              }
+            />
+          )}
+        </EditorField>
+
+        <EditorField
+          label="数据范围"
+          hint="仅填写 WHERE 后的条件；留空时检查整张表。"
+        >
+          <Form.Item name="whereClause" className="!mb-0">
+            <Input.TextArea
+              variant="filled"
+              rows={4}
+              maxLength={4000}
+              showCount
+              placeholder="例如：dt = '${bizdate}' AND status = 1"
+            />
+          </Form.Item>
+        </EditorField>
+
+        <EditorField label="监控描述">
+          <Form.Item name="description" className="!mb-0">
+            <Input.TextArea
+              variant="filled"
+              rows={4}
+              maxLength={500}
+              showCount
+              placeholder="请说明监控目的、质量要求和异常处理方式"
+            />
+          </Form.Item>
+        </EditorField>
+
+        <EditorField label="启用状态">
+          <div className="flex min-h-12 items-center justify-between rounded-lg bg-[#f5f5f6] px-3 py-2">
+            <div>
+              <div className="text-[13px] font-medium text-[#344054]">
+                创建后立即启用
+              </div>
+              <div className="mt-0.5 text-[11px] text-[#98a2b3]">
+                停用后调度不会运行，仍可保留全部配置。
+              </div>
+            </div>
+            <Form.Item name="enabled" valuePropName="checked" className="!mb-0">
+              <Switch />
+            </Form.Item>
+          </div>
+        </EditorField>
+      </div>
+    </EditorSection>
+  );
+};

--- a/yak-ops-ui/src/pages/data-quality/monitor/editor/MonitorEditorPage.tsx
+++ b/yak-ops-ui/src/pages/data-quality/monitor/editor/MonitorEditorPage.tsx
@@ -57,9 +57,6 @@ const MonitorEditorPage = () => {
   const { pageRootRef, activeSection, locateSection } = useSectionNavigation();
 
   const [dataSources, setDataSources] = useState<DataSourceRecord[]>([]);
-  const [tables, setTables] = useState<
-    Array<{ name: string; remarks?: string }>
-  >([]);
   const [columns, setColumns] = useState<CatalogColumn[]>([]);
   const [templates, setTemplates] = useState<TemplateView[]>([]);
   const [rules, setRules] = useState<EditorRule[]>([]);
@@ -71,6 +68,7 @@ const MonitorEditorPage = () => {
   const [saving, setSaving] = useState(false);
 
   const dataSourceId = Form.useWatch('dataSourceId', form);
+  const storedDataSourceName = Form.useWatch('dataSourceName', form);
   const databaseName = Form.useWatch('databaseName', form);
   const schemaName = Form.useWatch('schemaName', form);
   const tableName = Form.useWatch('tableName', form);
@@ -143,19 +141,6 @@ const MonitorEditorPage = () => {
   ]);
 
   useEffect(() => {
-    if (!dataSourceId) {
-      setTables([]);
-      return;
-    }
-    dataSourceCatalogApi
-      .listTables(dataSourceId, databaseName, schemaName)
-      .then((response) => setTables(unwrap(response)))
-      .catch((error) =>
-        message.error(error?.message || '数据表加载失败'),
-      );
-  }, [dataSourceId, databaseName, schemaName]);
-
-  useEffect(() => {
     if (!dataSourceId || !tableName) {
       setColumns([]);
       return;
@@ -171,6 +156,9 @@ const MonitorEditorPage = () => {
   const save = async () => {
     try {
       const values = await form.validateFields();
+      if (!values.dataSourceId || !values.tableName) {
+        throw new Error('监控对象无效，请从数据表监控页面重新创建');
+      }
       validateEditorSettings(runtime, strategy);
       validateRules(rules);
       const source = dataSources.find(
@@ -230,12 +218,17 @@ const MonitorEditorPage = () => {
                   <Form.Item name="schemaName" hidden>
                     <Input />
                   </Form.Item>
+                  <Form.Item name="tableName" hidden>
+                    <Input />
+                  </Form.Item>
 
                   <main className="space-y-5 pb-4">
                     <BasicConfig
                       dataSourceId={dataSourceId}
-                      dataSourceName={selectedSource?.name}
-                      tables={tables}
+                      dataSourceName={selectedSource?.name || storedDataSourceName}
+                      databaseName={databaseName}
+                      schemaName={schemaName}
+                      tableName={tableName}
                     />
                     <QualityRuleEditor
                       rules={rules}
@@ -258,6 +251,7 @@ const MonitorEditorPage = () => {
                   <Button
                     type="primary"
                     loading={saving}
+                    disabled={!dataSourceId || !tableName}
                     className="!h-9 !min-w-[120px] !rounded-lg"
                     onClick={save}
                   >


### PR DESCRIPTION
## What changed

- make the monitor target read-only in `BasicConfig` instead of allowing users to select another table
- keep the registered table context (`dataSourceId`, `databaseName`, `schemaName`, `tableName`) as hidden form values for save payloads
- remove the unnecessary `listTables` request from the monitor editor
- continue loading columns only for the fixed target table
- disable save and show a fallback warning when the monitor target context is missing

## Why

The monitor creation entry already comes from a registered `TableAssetView` and passes the selected table through query parameters. Allowing the create page to switch to another catalog table could select an unregistered table and cause monitor creation to fail. The editor should preserve the registered table selected by the entry page.

## Validation

- branch is based on current `main`
- diff check: 2 files changed, branch is 2 commits ahead / 0 behind
- no GitHub Actions workflow runs are configured for the head commit

## Notes

Kept as Draft for UI/interaction review.