### PR TITLE
feat(workflow): add in-memory React Flow workflow MVP

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,11 @@
             </dependency>
             <dependency>
                 <groupId>io.yak.framework</groupId>
+                <artifactId>yak-workflow-engine</artifactId>
+                <version>${yak-framework.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.yak.framework</groupId>
                 <artifactId>yak-file</artifactId>
                 <version>${yak-framework.version}</version>
             </dependency>
@@ -115,6 +120,11 @@
             <dependency>
                 <groupId>io.yak.ops</groupId>
                 <artifactId>yak-ops-business-quality</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.yak.ops</groupId>
+                <artifactId>yak-ops-business-workflow</artifactId>
                 <version>${project.version}</version>
             </dependency>
 

--- a/yak-ops-boot/pom.xml
+++ b/yak-ops-boot/pom.xml
@@ -38,6 +38,10 @@
         </dependency>
         <dependency>
             <groupId>io.yak.ops</groupId>
+            <artifactId>yak-ops-business-workflow</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.yak.ops</groupId>
             <artifactId>yak-ops-plugin-datasource-all</artifactId>
         </dependency>
         <dependency>

--- a/yak-ops-business/pom.xml
+++ b/yak-ops-business/pom.xml
@@ -23,5 +23,6 @@
         <module>yak-ops-business-resource</module>
         <module>yak-ops-business-sync</module>
         <module>yak-ops-business-quality</module>
+        <module>yak-ops-business-workflow</module>
     </modules>
 </project>

--- a/yak-ops-business/yak-ops-business-workflow/pom.xml
+++ b/yak-ops-business/yak-ops-business-workflow/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.yak.ops</groupId>
+        <artifactId>yak-ops-business</artifactId>
+        <version>1.0.0</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>yak-ops-business-workflow</artifactId>
+
+    <name>Yak Ops Business Workflow</name>
+    <description>In-memory workflow integration backed by Yak Framework workflow engine</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.yak.ops</groupId>
+            <artifactId>yak-ops-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.yak.framework</groupId>
+            <artifactId>yak-workflow-engine</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/yak-ops-business/yak-ops-business-workflow/pom.xml
+++ b/yak-ops-business/yak-ops-business-workflow/pom.xml
@@ -34,6 +34,10 @@
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/controller/v1/WorkflowController.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/controller/v1/WorkflowController.java
@@ -1,0 +1,49 @@
+package io.yak.ops.business.workflow.controller.v1;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.yak.framework.common.Result;
+import io.yak.ops.business.workflow.model.WorkflowInstanceVO;
+import io.yak.ops.business.workflow.model.WorkflowRunRequest;
+import io.yak.ops.business.workflow.service.WorkflowRuntimeService;
+import jakarta.validation.Valid;
+import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** 工作流内存运行接口。 */
+@Tag(name = "工作流接口")
+@RestController
+@RequestMapping("/api/v1/workflows")
+public class WorkflowController {
+
+  private final WorkflowRuntimeService workflowRuntimeService;
+
+  public WorkflowController(WorkflowRuntimeService workflowRuntimeService) {
+    this.workflowRuntimeService = workflowRuntimeService;
+  }
+
+  @Operation(summary = "运行工作流")
+  @PostMapping("/run")
+  public Result<WorkflowInstanceVO> run(
+      @Valid @RequestBody WorkflowRunRequest request) {
+    return Result.success(workflowRuntimeService.run(request));
+  }
+
+  @Operation(summary = "查询工作流实例")
+  @GetMapping("/instances")
+  public Result<List<WorkflowInstanceVO>> instances() {
+    return Result.success(workflowRuntimeService.listInstances());
+  }
+
+  @Operation(summary = "查询工作流实例详情")
+  @GetMapping("/instances/{executionId}")
+  public Result<WorkflowInstanceVO> instance(
+      @PathVariable("executionId") String executionId) {
+    return Result.success(workflowRuntimeService.getInstance(executionId));
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/model/WorkflowInstanceVO.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/model/WorkflowInstanceVO.java
@@ -1,0 +1,23 @@
+package io.yak.ops.business.workflow.model;
+
+import java.time.Instant;
+import java.util.List;
+
+public record WorkflowInstanceVO(
+    String id,
+    String definitionId,
+    String name,
+    String status,
+    Instant startedAt,
+    Instant endedAt,
+    int nodeCount,
+    int edgeCount,
+    List<NodeInstanceVO> nodes) {
+
+  public record NodeInstanceVO(
+      String id,
+      String name,
+      String type,
+      String status,
+      String errorMessage) {}
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/model/WorkflowRunRequest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/model/WorkflowRunRequest.java
@@ -1,0 +1,29 @@
+package io.yak.ops.business.workflow.model;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public record WorkflowRunRequest(
+    @NotBlank String name,
+    @NotEmpty List<@Valid NodeRequest> nodes,
+    List<@Valid EdgeRequest> edges,
+    Map<String, Object> input) {
+
+  public WorkflowRunRequest {
+    edges = edges == null ? List.of() : List.copyOf(edges);
+    input = input == null ? Map.of() : Map.copyOf(new LinkedHashMap<>(input));
+  }
+
+  public record NodeRequest(
+      @NotBlank String id,
+      @NotBlank String name,
+      @NotBlank String type) {}
+
+  public record EdgeRequest(
+      @NotBlank String source,
+      @NotBlank String target) {}
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowRuntimeService.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowRuntimeService.java
@@ -1,0 +1,219 @@
+package io.yak.ops.business.workflow.service;
+
+import io.yak.framework.workflow.engine.api.DefaultWorkflowEngine;
+import io.yak.framework.workflow.engine.definition.EdgeDefinition;
+import io.yak.framework.workflow.engine.definition.NodeDefinition;
+import io.yak.framework.workflow.engine.definition.NodeFailurePolicy;
+import io.yak.framework.workflow.engine.definition.RetryPolicy;
+import io.yak.framework.workflow.engine.definition.TriggerRule;
+import io.yak.framework.workflow.engine.definition.WorkflowDefinition;
+import io.yak.framework.workflow.engine.definition.WorkflowFailureStrategy;
+import io.yak.framework.workflow.engine.execution.NodeExecution;
+import io.yak.framework.workflow.engine.execution.WorkflowExecution;
+import io.yak.framework.workflow.engine.spi.NodeDispatch;
+import io.yak.ops.business.workflow.model.WorkflowInstanceVO;
+import io.yak.ops.business.workflow.model.WorkflowInstanceVO.NodeInstanceVO;
+import io.yak.ops.business.workflow.model.WorkflowRunRequest;
+import io.yak.ops.business.workflow.model.WorkflowRunRequest.EdgeRequest;
+import io.yak.ops.business.workflow.model.WorkflowRunRequest.NodeRequest;
+import jakarta.annotation.PreDestroy;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+/** Yak Framework 工作流引擎的轻量内存适配层。 */
+@Service
+public class WorkflowRuntimeService {
+
+  private static final Logger log = LoggerFactory.getLogger(WorkflowRuntimeService.class);
+
+  private final ExecutorService workerPool;
+  private final DefaultWorkflowEngine engine;
+  private final Map<String, RunMetadata> metadata = new ConcurrentHashMap<>();
+  private final ConcurrentLinkedDeque<String> executionOrder = new ConcurrentLinkedDeque<>();
+
+  public WorkflowRuntimeService() {
+    AtomicInteger workerIndex = new AtomicInteger();
+    this.workerPool = Executors.newFixedThreadPool(
+        Math.max(2, Runtime.getRuntime().availableProcessors()),
+        runnable -> {
+          Thread thread = new Thread(runnable);
+          thread.setName("yak-workflow-" + workerIndex.incrementAndGet());
+          thread.setDaemon(true);
+          return thread;
+        });
+    this.engine = DefaultWorkflowEngine.inMemory(
+        dispatch -> workerPool.execute(() -> executeNode(dispatch)));
+  }
+
+  public WorkflowInstanceVO run(WorkflowRunRequest request) {
+    String definitionId = "workflow-" + UUID.randomUUID();
+    List<NodeDefinition> nodes = request.nodes().stream()
+        .map(this::toNodeDefinition)
+        .toList();
+    List<EdgeDefinition> edges = request.edges().stream()
+        .map(this::toEdgeDefinition)
+        .toList();
+
+    WorkflowDefinition definition = new WorkflowDefinition(
+        definitionId,
+        request.name(),
+        WorkflowFailureStrategy.CONTINUE_INDEPENDENT_BRANCHES,
+        nodes,
+        edges);
+    engine.registerDefinition(definition);
+
+    WorkflowExecution execution = engine.start(definitionId, request.input());
+    RunMetadata runMetadata = new RunMetadata(
+        request.name(),
+        request.edges().size(),
+        nodeMetadata(request.nodes()));
+    metadata.put(execution.id(), runMetadata);
+    executionOrder.addFirst(execution.id());
+
+    log.info(
+        "[workflow] started execution={}, definition={}, name={}, nodes={}, edges={}",
+        execution.id(),
+        definitionId,
+        request.name(),
+        request.nodes().size(),
+        request.edges().size());
+    return toView(execution, runMetadata);
+  }
+
+  public List<WorkflowInstanceVO> listInstances() {
+    List<WorkflowInstanceVO> instances = new ArrayList<>();
+    for (String executionId : executionOrder) {
+      RunMetadata runMetadata = metadata.get(executionId);
+      if (runMetadata == null) {
+        continue;
+      }
+      engine.findExecution(executionId)
+          .map(execution -> toView(execution, runMetadata))
+          .ifPresent(instances::add);
+    }
+    return instances;
+  }
+
+  public WorkflowInstanceVO getInstance(String executionId) {
+    RunMetadata runMetadata = metadata.get(executionId);
+    WorkflowExecution execution = engine.findExecution(executionId)
+        .orElseThrow(() -> new IllegalArgumentException("Workflow execution not found: " + executionId));
+    if (runMetadata == null) {
+      throw new IllegalArgumentException("Workflow execution metadata not found: " + executionId);
+    }
+    return toView(execution, runMetadata);
+  }
+
+  private NodeDefinition toNodeDefinition(NodeRequest node) {
+    return new NodeDefinition(
+        node.id(),
+        node.name(),
+        TriggerRule.ALL_SUCCESS,
+        RetryPolicy.none(),
+        NodeFailurePolicy.FAIL_WORKFLOW,
+        Map.of("type", node.type()));
+  }
+
+  private EdgeDefinition toEdgeDefinition(EdgeRequest edge) {
+    return new EdgeDefinition(edge.source(), edge.target());
+  }
+
+  private Map<String, NodeMetadata> nodeMetadata(List<NodeRequest> nodes) {
+    Map<String, NodeMetadata> result = new LinkedHashMap<>();
+    for (NodeRequest node : nodes) {
+      result.put(node.id(), new NodeMetadata(node.name(), node.type()));
+    }
+    return Map.copyOf(result);
+  }
+
+  private void executeNode(NodeDispatch dispatch) {
+    String type = String.valueOf(dispatch.nodeConfiguration().getOrDefault("type", "TASK"));
+    log.info(
+        "[workflow] node start execution={}, node={}, type={}, attempt={}",
+        dispatch.workflowExecutionId(),
+        dispatch.nodeId(),
+        type,
+        dispatch.attemptNumber());
+    try {
+      engine.acknowledgeNodeStarted(dispatch.workflowExecutionId(), dispatch.nodeId());
+      engine.completeNode(
+          dispatch.workflowExecutionId(),
+          dispatch.nodeId(),
+          Map.of("type", type, "message", "executed in memory"));
+      log.info(
+          "[workflow] node success execution={}, node={}, type={}",
+          dispatch.workflowExecutionId(),
+          dispatch.nodeId(),
+          type);
+    } catch (RuntimeException exception) {
+      log.error(
+          "[workflow] node failed execution={}, node={}, message={}",
+          dispatch.workflowExecutionId(),
+          dispatch.nodeId(),
+          exception.getMessage(),
+          exception);
+      try {
+        engine.failNode(
+            dispatch.workflowExecutionId(),
+            dispatch.nodeId(),
+            exception.getMessage() == null ? exception.getClass().getSimpleName() : exception.getMessage());
+      } catch (RuntimeException callbackException) {
+        log.warn(
+            "[workflow] failure callback skipped execution={}, node={}, message={}",
+            dispatch.workflowExecutionId(),
+            dispatch.nodeId(),
+            callbackException.getMessage());
+      }
+    }
+  }
+
+  private WorkflowInstanceVO toView(WorkflowExecution execution, RunMetadata runMetadata) {
+    List<NodeInstanceVO> nodes = execution.nodes().values().stream()
+        .map(node -> toNodeView(node, runMetadata.nodes().get(node.nodeId())))
+        .toList();
+    return new WorkflowInstanceVO(
+        execution.id(),
+        execution.definitionId(),
+        runMetadata.name(),
+        execution.status().name(),
+        execution.createdAt(),
+        execution.endedAt(),
+        nodes.size(),
+        runMetadata.edgeCount(),
+        nodes);
+  }
+
+  private NodeInstanceVO toNodeView(NodeExecution node, NodeMetadata nodeMetadata) {
+    String name = nodeMetadata == null ? node.nodeId() : nodeMetadata.name();
+    String type = nodeMetadata == null ? "TASK" : nodeMetadata.type();
+    return new NodeInstanceVO(
+        node.nodeId(),
+        name,
+        type,
+        node.status().name(),
+        node.errorMessage());
+  }
+
+  @PreDestroy
+  void shutdown() {
+    workerPool.shutdownNow();
+  }
+
+  private record RunMetadata(
+      String name,
+      int edgeCount,
+      Map<String, NodeMetadata> nodes) {}
+
+  private record NodeMetadata(String name, String type) {}
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowRuntimeService.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowRuntimeService.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -39,6 +40,8 @@ public class WorkflowRuntimeService {
 
   private final ExecutorService workerPool;
   private final DefaultWorkflowEngine engine;
+  private final ConcurrentLinkedQueue<NodeDispatch> pendingDispatches =
+      new ConcurrentLinkedQueue<>();
   private final Map<String, RunMetadata> metadata = new ConcurrentHashMap<>();
   private final ConcurrentLinkedDeque<String> executionOrder = new ConcurrentLinkedDeque<>();
 
@@ -52,8 +55,7 @@ public class WorkflowRuntimeService {
           thread.setDaemon(true);
           return thread;
         });
-    this.engine = DefaultWorkflowEngine.inMemory(
-        dispatch -> workerPool.execute(() -> executeNode(dispatch)));
+    this.engine = DefaultWorkflowEngine.inMemory(pendingDispatches::add);
   }
 
   public WorkflowInstanceVO run(WorkflowRunRequest request) {
@@ -88,6 +90,7 @@ public class WorkflowRuntimeService {
         request.name(),
         request.nodes().size(),
         request.edges().size());
+    drainDispatches();
     return toView(execution, runMetadata);
   }
 
@@ -137,6 +140,14 @@ public class WorkflowRuntimeService {
     return Map.copyOf(result);
   }
 
+  private void drainDispatches() {
+    NodeDispatch dispatch;
+    while ((dispatch = pendingDispatches.poll()) != null) {
+      NodeDispatch current = dispatch;
+      workerPool.execute(() -> executeNode(current));
+    }
+  }
+
   private void executeNode(NodeDispatch dispatch) {
     String type = String.valueOf(dispatch.nodeConfiguration().getOrDefault("type", "TASK"));
     log.info(
@@ -175,6 +186,8 @@ public class WorkflowRuntimeService {
             dispatch.nodeId(),
             callbackException.getMessage());
       }
+    } finally {
+      drainDispatches();
     }
   }
 

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowRuntimeServiceTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowRuntimeServiceTest.java
@@ -1,0 +1,53 @@
+package io.yak.ops.business.workflow.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.yak.ops.business.workflow.model.WorkflowInstanceVO;
+import io.yak.ops.business.workflow.model.WorkflowRunRequest;
+import io.yak.ops.business.workflow.model.WorkflowRunRequest.EdgeRequest;
+import io.yak.ops.business.workflow.model.WorkflowRunRequest.NodeRequest;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class WorkflowRuntimeServiceTest {
+
+  private final WorkflowRuntimeService service = new WorkflowRuntimeService();
+
+  @AfterEach
+  void tearDown() {
+    service.shutdown();
+  }
+
+  @Test
+  void shouldExecuteSimpleDagInMemory() throws InterruptedException {
+    WorkflowRunRequest request = new WorkflowRunRequest(
+        "demo",
+        List.of(
+            new NodeRequest("extract", "Extract", "DATA"),
+            new NodeRequest("check", "Check", "CHECK")),
+        List.of(new EdgeRequest("extract", "check")),
+        Map.of());
+
+    WorkflowInstanceVO started = service.run(request);
+    WorkflowInstanceVO completed = waitForTerminal(started.id());
+
+    assertThat(completed.status()).isEqualTo("SUCCESS");
+    assertThat(completed.nodes())
+        .extracting(WorkflowInstanceVO.NodeInstanceVO::status)
+        .containsOnly("SUCCESS");
+  }
+
+  private WorkflowInstanceVO waitForTerminal(String executionId)
+      throws InterruptedException {
+    for (int attempt = 0; attempt < 100; attempt++) {
+      WorkflowInstanceVO current = service.getInstance(executionId);
+      if (!"RUNNING".equals(current.status()) && !"CREATED".equals(current.status())) {
+        return current;
+      }
+      Thread.sleep(20L);
+    }
+    return service.getInstance(executionId);
+  }
+}

--- a/yak-ops-ui/src/config/navigation.ts
+++ b/yak-ops-ui/src/config/navigation.ts
@@ -5,7 +5,7 @@ import {
 
 export type NavigationIconKey =
   | 'home' | 'database' | 'sync' | 'realtime' | 'client' | 'connector'
-  | 'instance' | 'quality' | 'report' | 'monitor' | 'alarm'
+  | 'workflow' | 'project' | 'instance' | 'quality' | 'report' | 'monitor' | 'alarm'
   | 'knowledge' | 'api' | 'insight' | 'system';
 export type NavigationSectionKey = 'task' | 'management' | 'system';
 
@@ -27,6 +27,7 @@ export interface NavigationGroupWithRoutes extends NavigationGroup {
 
 export const navigationGroups: readonly NavigationGroup[] = [
   { id: 'integration', title: '数据集成', iconKey: 'sync', section: 'task', order: 10 },
+  { id: 'workflow', title: '工作流', iconKey: 'workflow', section: 'task', order: 20 },
   { id: 'resources', title: '资源管理', iconKey: 'database', section: 'management', order: 20 },
   { id: 'data-quality', title: '数据质量', iconKey: 'quality', section: 'management', order: 30 },
   { id: 'system', title: '系统管理', iconKey: 'system', section: 'system', order: 40 },
@@ -45,6 +46,8 @@ export const appRoutes: readonly NavigationRoute[] = [
   { id: 'batch-link-up-single', path: '/sync/batch-link-up/:id/config/single', title: '单表同步配置', component: './batch-link-up/config/single', hidden: true, parentId: 'batch-link-up' },
   { id: 'batch-link-up-multi', path: '/sync/batch-link-up/:id/config/multi', title: '多表同步配置', component: './batch-link-up/config/multi', hidden: true, parentId: 'batch-link-up' },
   { id: 'batch-link-up-script', path: '/sync/batch-link-up/:id/config/script', title: '脚本同步配置', component: './batch-link-up/config/script', hidden: true, parentId: 'batch-link-up' },
+  { id: 'workflow-definition', mode: 'public', path: '/workflow/definition', title: '工作流定义', component: './workflow/definition', iconKey: 'workflow', menuGroup: 'workflow', order: 10 },
+  { id: 'workflow-instances', mode: 'public', path: '/workflow/instances', title: '工作流实例', component: './workflow/instances', iconKey: 'instance', menuGroup: 'workflow', order: 20 },
   { id: 'resource-management', mode: 'one', permission: 'resource:view', path: '/resource-management', title: '文件资源', component: './resource-management', iconKey: 'database', menuGroup: 'resources', order: 10 },
   { id: 'data-quality-table-config', mode: 'one', permission: 'quality:monitor:read', path: '/data-quality/table-config', title: '数据表监控', component: './data-quality/table-config', iconKey: 'quality', menuGroup: 'data-quality', order: 10 },
   { id: 'data-quality-monitor-create', path: '/data-quality/monitor/create', title: '新增监控', component: './data-quality/monitor/editor', hidden: true, parentId: 'data-quality-table-config' },

--- a/yak-ops-ui/src/pages/workflow/definition/index.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/index.tsx
@@ -8,7 +8,13 @@ import {
   RotateCcw,
   ShieldCheck,
 } from 'lucide-react';
-import { useMemo, useRef, useState } from 'react';
+import {
+  type DragEvent,
+  type ReactNode,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import ReactFlow, {
   Background,
   Controls,
@@ -19,7 +25,6 @@ import ReactFlow, {
   addEdge,
   type Connection,
   type Edge,
-  type Node,
   type NodeProps,
   type ReactFlowInstance,
   useEdgesState,
@@ -37,7 +42,7 @@ interface NodeTemplate {
   type: string;
   label: string;
   description: string;
-  icon: React.ReactNode;
+  icon: ReactNode;
 }
 
 const NODE_TEMPLATES: NodeTemplate[] = [
@@ -118,7 +123,7 @@ const WorkflowDefinitionContent = () => {
   };
 
   const handleDragStart = (
-    event: React.DragEvent<HTMLDivElement>,
+    event: DragEvent<HTMLDivElement>,
     template: NodeTemplate,
   ) => {
     event.dataTransfer.setData(
@@ -131,7 +136,7 @@ const WorkflowDefinitionContent = () => {
     event.dataTransfer.effectAllowed = 'move';
   };
 
-  const handleDrop = (event: React.DragEvent<HTMLDivElement>) => {
+  const handleDrop = (event: DragEvent<HTMLDivElement>) => {
     event.preventDefault();
     if (!reactFlowInstance || !wrapperRef.current) return;
 

--- a/yak-ops-ui/src/pages/workflow/definition/index.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/index.tsx
@@ -1,0 +1,300 @@
+import { runWorkflow } from '@/services/workflow';
+import { Button, Input, Popconfirm, message } from 'antd';
+import {
+  Bell,
+  CirclePlay,
+  Database,
+  Play,
+  RotateCcw,
+  ShieldCheck,
+} from 'lucide-react';
+import { useMemo, useRef, useState } from 'react';
+import ReactFlow, {
+  Background,
+  Controls,
+  Handle,
+  MiniMap,
+  Position,
+  ReactFlowProvider,
+  addEdge,
+  type Connection,
+  type Edge,
+  type Node,
+  type NodeProps,
+  type ReactFlowInstance,
+  useEdgesState,
+  useNodesState,
+} from 'reactflow';
+import 'reactflow/dist/style.css';
+
+interface WorkflowNodeData {
+  label: string;
+  nodeType: string;
+  typeLabel: string;
+}
+
+interface NodeTemplate {
+  type: string;
+  label: string;
+  description: string;
+  icon: React.ReactNode;
+}
+
+const NODE_TEMPLATES: NodeTemplate[] = [
+  {
+    type: 'TASK',
+    label: '任务节点',
+    description: '通用任务执行节点',
+    icon: <CirclePlay size={16} />,
+  },
+  {
+    type: 'DATA',
+    label: '数据处理',
+    description: '模拟数据处理任务',
+    icon: <Database size={16} />,
+  },
+  {
+    type: 'CHECK',
+    label: '校验节点',
+    description: '模拟规则或质量校验',
+    icon: <ShieldCheck size={16} />,
+  },
+  {
+    type: 'NOTICE',
+    label: '通知节点',
+    description: '模拟消息通知任务',
+    icon: <Bell size={16} />,
+  },
+];
+
+const WorkflowNode = ({ data, selected }: NodeProps<WorkflowNodeData>) => (
+  <div
+    className={[
+      'relative min-w-[168px] rounded-lg border bg-white px-3 py-2.5 shadow-sm',
+      selected ? 'border-[#fe2c55]' : 'border-[#dfe1e5]',
+    ].join(' ')}
+  >
+    <Handle
+      type="target"
+      position={Position.Left}
+      className="!h-2.5 !w-2.5 !border-2 !border-white !bg-[#8a8f99]"
+    />
+    <div className="text-[11px] font-medium text-[rgba(22,24,35,.45)]">
+      {data.typeLabel}
+    </div>
+    <div className="mt-1 text-[13px] font-semibold text-[#161823]">
+      {data.label}
+    </div>
+    <Handle
+      type="source"
+      position={Position.Right}
+      className="!h-2.5 !w-2.5 !border-2 !border-white !bg-[#8a8f99]"
+    />
+  </div>
+);
+
+const WorkflowDefinitionContent = () => {
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const sequenceRef = useRef(1);
+  const [workflowName, setWorkflowName] = useState('内存工作流');
+  const [nodes, setNodes, onNodesChange] = useNodesState<WorkflowNodeData>([]);
+  const [edges, setEdges, onEdgesChange] = useEdgesState([]);
+  const [reactFlowInstance, setReactFlowInstance] =
+    useState<ReactFlowInstance | null>(null);
+  const [running, setRunning] = useState(false);
+
+  const nodeTypes = useMemo(() => ({ workflow: WorkflowNode }), []);
+
+  const handleConnect = (connection: Connection) => {
+    setEdges((current) =>
+      addEdge(
+        {
+          ...connection,
+          type: 'smoothstep',
+        },
+        current,
+      ),
+    );
+  };
+
+  const handleDragStart = (
+    event: React.DragEvent<HTMLDivElement>,
+    template: NodeTemplate,
+  ) => {
+    event.dataTransfer.setData(
+      'application/yak-workflow-node',
+      JSON.stringify({
+        type: template.type,
+        label: template.label,
+      }),
+    );
+    event.dataTransfer.effectAllowed = 'move';
+  };
+
+  const handleDrop = (event: React.DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    if (!reactFlowInstance || !wrapperRef.current) return;
+
+    const raw = event.dataTransfer.getData('application/yak-workflow-node');
+    if (!raw) return;
+
+    const template = JSON.parse(raw) as { type: string; label: string };
+    const bounds = wrapperRef.current.getBoundingClientRect();
+    const position = reactFlowInstance.project({
+      x: event.clientX - bounds.left,
+      y: event.clientY - bounds.top,
+    });
+    const id = `${template.type.toLowerCase()}-${Date.now()}-${sequenceRef.current++}`;
+
+    setNodes((current) => [
+      ...current,
+      {
+        id,
+        type: 'workflow',
+        position,
+        data: {
+          label: `${template.label} ${sequenceRef.current - 1}`,
+          nodeType: template.type,
+          typeLabel: template.label,
+        },
+      },
+    ]);
+  };
+
+  const handleRun = async () => {
+    if (!nodes.length) {
+      message.warning('请先拖入至少一个节点');
+      return;
+    }
+    setRunning(true);
+    try {
+      const instance = await runWorkflow({
+        name: workflowName.trim() || '未命名工作流',
+        nodes: nodes.map((node) => ({
+          id: node.id,
+          name: node.data.label,
+          type: node.data.nodeType,
+        })),
+        edges: edges.map((edge: Edge) => ({
+          source: edge.source,
+          target: edge.target,
+        })),
+        input: {},
+      });
+      message.success(`工作流已运行：${instance.id}`);
+    } catch (error) {
+      message.error(error instanceof Error ? error.message : '工作流运行失败');
+    } finally {
+      setRunning(false);
+    }
+  };
+
+  return (
+    <div className="flex h-[calc(100vh-48px)] min-h-[620px] overflow-hidden bg-white">
+      <aside className="w-[232px] shrink-0 border-r border-[#e8e9ec] bg-[#fafafa]">
+        <div className="border-b border-[#e8e9ec] px-4 py-3.5">
+          <div className="text-[14px] font-semibold text-[#161823]">节点</div>
+          <div className="mt-1 text-xs leading-5 text-[rgba(22,24,35,.48)]">
+            拖拽到右侧画布后连接节点
+          </div>
+        </div>
+
+        <div className="space-y-2 p-3">
+          {NODE_TEMPLATES.map((template) => (
+            <div
+              key={template.type}
+              draggable
+              onDragStart={(event) => handleDragStart(event, template)}
+              className="cursor-grab rounded-lg border border-[#e3e5e8] bg-white px-3 py-2.5 transition-shadow hover:shadow-sm active:cursor-grabbing"
+            >
+              <div className="flex items-center gap-2 text-[13px] font-semibold text-[#161823]">
+                <span className="flex h-7 w-7 items-center justify-center rounded-md bg-[#f4f4f5] text-[rgba(22,24,35,.66)]">
+                  {template.icon}
+                </span>
+                {template.label}
+              </div>
+              <div className="mt-1.5 pl-9 text-[11px] text-[rgba(22,24,35,.45)]">
+                {template.description}
+              </div>
+            </div>
+          ))}
+        </div>
+      </aside>
+
+      <section className="flex min-w-0 flex-1 flex-col">
+        <div className="flex h-12 shrink-0 items-center justify-between border-b border-[#e8e9ec] px-4">
+          <div className="flex min-w-0 items-center gap-3">
+            <div className="text-[15px] font-semibold text-[#161823]">工作流定义</div>
+            <Input
+              value={workflowName}
+              onChange={(event) => setWorkflowName(event.target.value)}
+              variant="filled"
+              className="w-[240px]"
+              placeholder="输入工作流名称"
+            />
+            <span className="text-xs text-[rgba(22,24,35,.4)]">
+              {nodes.length} 节点 · {edges.length} 连线
+            </span>
+          </div>
+
+          <div className="flex items-center gap-2">
+            <Popconfirm
+              title="清空当前画布？"
+              okText="清空"
+              cancelText="取消"
+              onConfirm={() => {
+                setNodes([]);
+                setEdges([]);
+              }}
+            >
+              <Button icon={<RotateCcw size={14} />}>清空</Button>
+            </Popconfirm>
+            <Button
+              type="primary"
+              icon={<Play size={14} />}
+              loading={running}
+              onClick={handleRun}
+            >
+              运行
+            </Button>
+          </div>
+        </div>
+
+        <div ref={wrapperRef} className="min-h-0 flex-1" onDrop={handleDrop}>
+          <ReactFlow
+            nodes={nodes}
+            edges={edges}
+            nodeTypes={nodeTypes}
+            onNodesChange={onNodesChange}
+            onEdgesChange={onEdgesChange}
+            onConnect={handleConnect}
+            onInit={setReactFlowInstance}
+            onDragOver={(event) => {
+              event.preventDefault();
+              event.dataTransfer.dropEffect = 'move';
+            }}
+            fitView
+            deleteKeyCode={['Backspace', 'Delete']}
+            defaultEdgeOptions={{ type: 'smoothstep' }}
+          >
+            <Background gap={18} size={1} />
+            <Controls position="bottom-right" />
+            <MiniMap
+              pannable
+              zoomable
+              className="!border !border-[#e8e9ec] !bg-white"
+            />
+          </ReactFlow>
+        </div>
+      </section>
+    </div>
+  );
+};
+
+const WorkflowDefinitionPage = () => (
+  <ReactFlowProvider>
+    <WorkflowDefinitionContent />
+  </ReactFlowProvider>
+);
+
+export default WorkflowDefinitionPage;

--- a/yak-ops-ui/src/pages/workflow/instances/index.tsx
+++ b/yak-ops-ui/src/pages/workflow/instances/index.tsx
@@ -63,7 +63,7 @@ const WorkflowInstancesPage = () => {
     return () => window.clearInterval(timer);
   }, [loadInstances]);
 
-  const openDetail = async (record: WorkflowInstance) => {
+  const openDetail = useCallback(async (record: WorkflowInstance) => {
     setDetail(record);
     setDetailOpen(true);
     setDetailLoading(true);
@@ -74,7 +74,7 @@ const WorkflowInstancesPage = () => {
     } finally {
       setDetailLoading(false);
     }
-  };
+  }, []);
 
   const columns = useMemo<ColumnsType<WorkflowInstance>>(
     () => [
@@ -135,7 +135,7 @@ const WorkflowInstancesPage = () => {
         ),
       },
     ],
-    [],
+    [openDetail],
   );
 
   const nodeColumns = useMemo<ColumnsType<WorkflowNodeInstance>>(

--- a/yak-ops-ui/src/pages/workflow/instances/index.tsx
+++ b/yak-ops-ui/src/pages/workflow/instances/index.tsx
@@ -1,0 +1,250 @@
+import {
+  getWorkflowInstance,
+  getWorkflowInstances,
+  type WorkflowInstance,
+  type WorkflowNodeInstance,
+} from '@/services/workflow';
+import { Button, Drawer, Empty, Table, message } from 'antd';
+import type { ColumnsType } from 'antd/es/table';
+import dayjs from 'dayjs';
+import { RefreshCw } from 'lucide-react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+const statusLabel: Record<string, string> = {
+  CREATED: '已创建',
+  RUNNING: '运行中',
+  SUCCESS: '成功',
+  FAILED: '失败',
+  WARNING: '告警',
+  CANCELED: '已取消',
+  WAITING: '等待中',
+  READY: '就绪',
+  SUBMITTED: '已提交',
+  UPSTREAM_FAILED: '上游失败',
+  SKIPPED: '已跳过',
+};
+
+const statusClassName = (status: string) => {
+  if (status === 'FAILED' || status === 'UPSTREAM_FAILED') {
+    return 'text-[#d92d20]';
+  }
+  if (status === 'RUNNING' || status === 'SUBMITTED' || status === 'READY') {
+    return 'font-medium text-[#161823]';
+  }
+  return 'text-[rgba(22,24,35,.58)]';
+};
+
+const formatTime = (value?: string) =>
+  value ? dayjs(value).format('YYYY-MM-DD HH:mm:ss') : '-';
+
+const WorkflowInstancesPage = () => {
+  const [instances, setInstances] = useState<WorkflowInstance[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [detailOpen, setDetailOpen] = useState(false);
+  const [detail, setDetail] = useState<WorkflowInstance>();
+  const [detailLoading, setDetailLoading] = useState(false);
+
+  const loadInstances = useCallback(async (showLoading = false) => {
+    if (showLoading) setLoading(true);
+    try {
+      setInstances(await getWorkflowInstances());
+    } catch (error) {
+      if (showLoading) {
+        message.error(error instanceof Error ? error.message : '工作流实例加载失败');
+      }
+    } finally {
+      if (showLoading) setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadInstances(true);
+    const timer = window.setInterval(() => void loadInstances(false), 2000);
+    return () => window.clearInterval(timer);
+  }, [loadInstances]);
+
+  const openDetail = async (record: WorkflowInstance) => {
+    setDetail(record);
+    setDetailOpen(true);
+    setDetailLoading(true);
+    try {
+      setDetail(await getWorkflowInstance(record.id));
+    } catch (error) {
+      message.error(error instanceof Error ? error.message : '实例详情加载失败');
+    } finally {
+      setDetailLoading(false);
+    }
+  };
+
+  const columns = useMemo<ColumnsType<WorkflowInstance>>(
+    () => [
+      {
+        title: '工作流 / 实例',
+        dataIndex: 'name',
+        minWidth: 320,
+        render: (_, record) => (
+          <div>
+            <div className="text-[13px] font-semibold text-[#161823]">
+              {record.name}
+            </div>
+            <div className="mt-0.5 font-mono text-[11px] text-[rgba(22,24,35,.42)]">
+              {record.id}
+            </div>
+          </div>
+        ),
+      },
+      {
+        title: '状态',
+        dataIndex: 'status',
+        width: 120,
+        render: (status: string) => (
+          <span className={statusClassName(status)}>
+            {statusLabel[status] || status}
+          </span>
+        ),
+      },
+      {
+        title: '节点 / 连线',
+        width: 130,
+        render: (_, record) => (
+          <span className="text-[13px] text-[rgba(22,24,35,.66)]">
+            {record.nodeCount} / {record.edgeCount}
+          </span>
+        ),
+      },
+      {
+        title: '开始时间',
+        dataIndex: 'startedAt',
+        width: 180,
+        render: formatTime,
+      },
+      {
+        title: '结束时间',
+        dataIndex: 'endedAt',
+        width: 180,
+        render: formatTime,
+      },
+      {
+        title: '操作',
+        width: 90,
+        fixed: 'right',
+        render: (_, record) => (
+          <Button type="link" className="!px-0" onClick={() => openDetail(record)}>
+            查看
+          </Button>
+        ),
+      },
+    ],
+    [],
+  );
+
+  const nodeColumns = useMemo<ColumnsType<WorkflowNodeInstance>>(
+    () => [
+      {
+        title: '节点',
+        dataIndex: 'name',
+        render: (_, record) => (
+          <div>
+            <div className="font-medium text-[#161823]">{record.name}</div>
+            <div className="mt-0.5 text-[11px] text-[rgba(22,24,35,.42)]">
+              {record.type} · {record.id}
+            </div>
+          </div>
+        ),
+      },
+      {
+        title: '状态',
+        dataIndex: 'status',
+        width: 120,
+        render: (status: string) => (
+          <span className={statusClassName(status)}>
+            {statusLabel[status] || status}
+          </span>
+        ),
+      },
+      {
+        title: '错误信息',
+        dataIndex: 'errorMessage',
+        width: 240,
+        render: (value?: string) => value || '-',
+      },
+    ],
+    [],
+  );
+
+  return (
+    <div className="min-h-[calc(100vh-48px)] bg-white px-5 py-4">
+      <div className="mb-3 flex items-center justify-between">
+        <div>
+          <h1 className="m-0 text-[20px] font-semibold text-[#161823]">工作流实例</h1>
+          <div className="mt-1 text-xs text-[rgba(22,24,35,.46)]">
+            当前实例仅保存在内存中，服务重启后会清空。
+          </div>
+        </div>
+        <Button
+          icon={<RefreshCw size={14} />}
+          loading={loading}
+          onClick={() => void loadInstances(true)}
+        >
+          刷新
+        </Button>
+      </div>
+
+      <Table<WorkflowInstance>
+        rowKey="id"
+        size="small"
+        bordered
+        pagination={false}
+        loading={loading}
+        dataSource={instances}
+        columns={columns}
+        scroll={{ x: 1080 }}
+        locale={{
+          emptyText: <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="暂无工作流实例" />,
+        }}
+      />
+
+      <Drawer
+        title={detail ? `${detail.name} · 实例详情` : '实例详情'}
+        width={720}
+        open={detailOpen}
+        loading={detailLoading}
+        onClose={() => setDetailOpen(false)}
+      >
+        {detail ? (
+          <>
+            <div className="mb-4 grid grid-cols-2 gap-x-8 gap-y-3 text-[13px]">
+              <div>
+                <span className="text-[rgba(22,24,35,.45)]">实例 ID：</span>
+                <span className="font-mono text-[#161823]">{detail.id}</span>
+              </div>
+              <div>
+                <span className="text-[rgba(22,24,35,.45)]">状态：</span>
+                <span className={statusClassName(detail.status)}>
+                  {statusLabel[detail.status] || detail.status}
+                </span>
+              </div>
+              <div>
+                <span className="text-[rgba(22,24,35,.45)]">开始：</span>
+                <span>{formatTime(detail.startedAt)}</span>
+              </div>
+              <div>
+                <span className="text-[rgba(22,24,35,.45)]">结束：</span>
+                <span>{formatTime(detail.endedAt)}</span>
+              </div>
+            </div>
+            <Table<WorkflowNodeInstance>
+              rowKey="id"
+              size="small"
+              pagination={false}
+              dataSource={detail.nodes}
+              columns={nodeColumns}
+            />
+          </>
+        ) : null}
+      </Drawer>
+    </div>
+  );
+};
+
+export default WorkflowInstancesPage;

--- a/yak-ops-ui/src/services/workflow/index.ts
+++ b/yak-ops-ui/src/services/workflow/index.ts
@@ -1,0 +1,65 @@
+import { request } from '@umijs/max';
+import type { ApiResponse } from '@/services/http/response';
+
+export interface WorkflowNodePayload {
+  id: string;
+  name: string;
+  type: string;
+}
+
+export interface WorkflowEdgePayload {
+  source: string;
+  target: string;
+}
+
+export interface WorkflowRunPayload {
+  name: string;
+  nodes: WorkflowNodePayload[];
+  edges: WorkflowEdgePayload[];
+  input?: Record<string, unknown>;
+}
+
+export interface WorkflowNodeInstance {
+  id: string;
+  name: string;
+  type: string;
+  status: string;
+  errorMessage?: string;
+}
+
+export interface WorkflowInstance {
+  id: string;
+  definitionId: string;
+  name: string;
+  status: string;
+  startedAt: string;
+  endedAt?: string;
+  nodeCount: number;
+  edgeCount: number;
+  nodes: WorkflowNodeInstance[];
+}
+
+export const runWorkflow = async (payload: WorkflowRunPayload) => {
+  const response = await request<ApiResponse<WorkflowInstance>>(
+    '/api/v1/workflows/run',
+    {
+      method: 'POST',
+      data: payload,
+    },
+  );
+  return response.data;
+};
+
+export const getWorkflowInstances = async () => {
+  const response = await request<ApiResponse<WorkflowInstance[]>>(
+    '/api/v1/workflows/instances',
+  );
+  return response.data;
+};
+
+export const getWorkflowInstance = async (executionId: string) => {
+  const response = await request<ApiResponse<WorkflowInstance>>(
+    `/api/v1/workflows/instances/${encodeURIComponent(executionId)}`,
+  );
+  return response.data;
+};


### PR DESCRIPTION
## What changed

- Integrate `io.yak.framework:yak-workflow-engine` into Yak Ops through a new `yak-ops-business-workflow` module.
- Add an in-memory workflow runtime adapter with no database tables or migrations.
- Add workflow APIs:
  - `POST /api/v1/workflows/run`
  - `GET /api/v1/workflows/instances`
  - `GET /api/v1/workflows/instances/{executionId}`
- Add a local worker executor that prints workflow/node start and completion events to the application log and completes nodes through the framework callbacks.
- Add the `工作流` menu with two submenus:
  - `工作流定义`
  - `工作流实例`
- Add a React Flow editor with a draggable node palette, connections, deletion, canvas reset, minimap/controls, and direct in-memory execution.
- Add an instance list/detail view with periodic status refresh and per-node execution state.
- Add a simple two-node DAG unit test for the in-memory runtime.

## Design

The workflow engine remains framework-owned. Yak Ops only translates the React Flow graph into `WorkflowDefinition` / `NodeDefinition` / `EdgeDefinition` and provides the execution adapter and HTTP/UI layer.

Definitions and execution metadata are intentionally memory-only for this MVP. Restarting Yak Ops clears the instance history.

The initial framework dispatch is queued until `DefaultWorkflowEngine.start(...)` has fully returned, avoiding an early callback racing with the engine's final start-state save.

## Validation

- Reviewed the integration against the current `yak-workflow-engine` public APIs and Yak Ops navigation/API conventions.
- Added `WorkflowRuntimeServiceTest` covering a two-node serial DAG reaching `SUCCESS`.
- No GitHub Actions workflow/status was reported for this branch, and this environment does not provide a local repository/dependency toolchain to execute Maven/npm checks, so the added test and frontend typecheck still need to run in the normal development/CI environment.