### PR TITLE
feat(workflow): stream live node execution status

### DIFF
--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/controller/v1/WorkflowController.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/controller/v1/WorkflowController.java
@@ -8,12 +8,14 @@ import io.yak.ops.business.workflow.model.WorkflowRunRequest;
 import io.yak.ops.business.workflow.service.WorkflowRuntimeService;
 import jakarta.validation.Valid;
 import java.util.List;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 /** 工作流内存运行接口。 */
 @Tag(name = "工作流接口")
@@ -45,5 +47,14 @@ public class WorkflowController {
   public Result<WorkflowInstanceVO> instance(
       @PathVariable("executionId") String executionId) {
     return Result.success(workflowRuntimeService.getInstance(executionId));
+  }
+
+  @Operation(summary = "订阅工作流实例实时状态")
+  @GetMapping(
+      value = "/instances/{executionId}/events",
+      produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+  public SseEmitter events(
+      @PathVariable("executionId") String executionId) {
+    return workflowRuntimeService.subscribe(executionId);
   }
 }

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowEventStreamService.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowEventStreamService.java
@@ -1,0 +1,98 @@
+package io.yak.ops.business.workflow.service;
+
+import io.yak.ops.business.workflow.model.WorkflowInstanceVO;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+/** 工作流实例状态 SSE 推送。 */
+@Service
+public class WorkflowEventStreamService {
+
+  private static final Logger log = LoggerFactory.getLogger(WorkflowEventStreamService.class);
+  private static final long STREAM_TIMEOUT_MILLIS = Duration.ofHours(1).toMillis();
+  private static final String EVENT_NAME = "workflow";
+
+  private final ConcurrentMap<String, CopyOnWriteArrayList<SseEmitter>> emitters =
+      new ConcurrentHashMap<>();
+
+  public SseEmitter subscribe(String executionId, WorkflowInstanceVO snapshot) {
+    SseEmitter emitter = new SseEmitter(STREAM_TIMEOUT_MILLIS);
+    CopyOnWriteArrayList<SseEmitter> executionEmitters =
+        emitters.computeIfAbsent(executionId, ignored -> new CopyOnWriteArrayList<>());
+    executionEmitters.add(emitter);
+
+    Runnable cleanup = () -> remove(executionId, emitter);
+    emitter.onCompletion(cleanup);
+    emitter.onTimeout(cleanup);
+    emitter.onError(ignored -> cleanup.run());
+
+    if (!send(executionId, emitter, snapshot)) {
+      return emitter;
+    }
+    if (isTerminal(snapshot.status())) {
+      cleanup.run();
+      emitter.complete();
+    }
+    return emitter;
+  }
+
+  public void publish(WorkflowInstanceVO snapshot) {
+    List<SseEmitter> executionEmitters = emitters.get(snapshot.id());
+    if (executionEmitters == null || executionEmitters.isEmpty()) {
+      return;
+    }
+
+    for (SseEmitter emitter : executionEmitters) {
+      send(snapshot.id(), emitter, snapshot);
+    }
+
+    if (isTerminal(snapshot.status())) {
+      CopyOnWriteArrayList<SseEmitter> terminalEmitters = emitters.remove(snapshot.id());
+      if (terminalEmitters != null) {
+        terminalEmitters.forEach(SseEmitter::complete);
+      }
+    }
+  }
+
+  private boolean send(
+      String executionId,
+      SseEmitter emitter,
+      WorkflowInstanceVO snapshot) {
+    try {
+      emitter.send(SseEmitter.event()
+          .name(EVENT_NAME)
+          .id(Long.toString(System.nanoTime()))
+          .data(snapshot));
+      return true;
+    } catch (IOException | IllegalStateException exception) {
+      remove(executionId, emitter);
+      log.debug(
+          "[workflow] SSE client disconnected execution={}, message={}",
+          executionId,
+          exception.getMessage());
+      return false;
+    }
+  }
+
+  private void remove(String executionId, SseEmitter emitter) {
+    emitters.computeIfPresent(executionId, (ignored, executionEmitters) -> {
+      executionEmitters.remove(emitter);
+      return executionEmitters.isEmpty() ? null : executionEmitters;
+    });
+  }
+
+  private boolean isTerminal(String status) {
+    return "SUCCESS".equals(status)
+        || "FAILED".equals(status)
+        || "WARNING".equals(status)
+        || "CANCELED".equals(status);
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowRuntimeService.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowRuntimeService.java
@@ -136,7 +136,11 @@ public class WorkflowRuntimeService {
   }
 
   public SseEmitter subscribe(String executionId) {
-    return eventStreamService.subscribe(executionId, getInstance(executionId));
+    WorkflowInstanceVO snapshot = getInstance(executionId);
+    SseEmitter emitter = eventStreamService.subscribe(executionId, snapshot);
+    // 再推一次最新快照，覆盖“读取快照”和“注册订阅者”之间可能发生的状态变化。
+    eventStreamService.publish(getInstance(executionId));
+    return emitter;
   }
 
   private NodeDefinition toNodeDefinition(NodeRequest node) {

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowRuntimeService.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowRuntimeService.java
@@ -27,10 +27,13 @@ import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.LongSupplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 /** Yak Framework 工作流引擎的轻量内存适配层。 */
 @Service
@@ -40,12 +43,24 @@ public class WorkflowRuntimeService {
 
   private final ExecutorService workerPool;
   private final DefaultWorkflowEngine engine;
+  private final WorkflowEventStreamService eventStreamService;
+  private final LongSupplier delayMillisSupplier;
   private final ConcurrentLinkedQueue<NodeDispatch> pendingDispatches =
       new ConcurrentLinkedQueue<>();
   private final Map<String, RunMetadata> metadata = new ConcurrentHashMap<>();
   private final ConcurrentLinkedDeque<String> executionOrder = new ConcurrentLinkedDeque<>();
 
-  public WorkflowRuntimeService() {
+  public WorkflowRuntimeService(WorkflowEventStreamService eventStreamService) {
+    this(
+        eventStreamService,
+        () -> ThreadLocalRandom.current().nextLong(1_000L, 10_001L));
+  }
+
+  WorkflowRuntimeService(
+      WorkflowEventStreamService eventStreamService,
+      LongSupplier delayMillisSupplier) {
+    this.eventStreamService = eventStreamService;
+    this.delayMillisSupplier = delayMillisSupplier;
     AtomicInteger workerIndex = new AtomicInteger();
     this.workerPool = Executors.newFixedThreadPool(
         Math.max(2, Runtime.getRuntime().availableProcessors()),
@@ -83,6 +98,8 @@ public class WorkflowRuntimeService {
     metadata.put(execution.id(), runMetadata);
     executionOrder.addFirst(execution.id());
 
+    WorkflowInstanceVO started = toView(execution, runMetadata);
+    eventStreamService.publish(started);
     log.info(
         "[workflow] started execution={}, definition={}, name={}, nodes={}, edges={}",
         execution.id(),
@@ -91,7 +108,7 @@ public class WorkflowRuntimeService {
         request.nodes().size(),
         request.edges().size());
     drainDispatches();
-    return toView(execution, runMetadata);
+    return started;
   }
 
   public List<WorkflowInstanceVO> listInstances() {
@@ -116,6 +133,10 @@ public class WorkflowRuntimeService {
       throw new IllegalArgumentException("Workflow execution metadata not found: " + executionId);
     }
     return toView(execution, runMetadata);
+  }
+
+  public SseEmitter subscribe(String executionId) {
+    return eventStreamService.subscribe(executionId, getInstance(executionId));
   }
 
   private NodeDefinition toNodeDefinition(NodeRequest node) {
@@ -150,45 +171,80 @@ public class WorkflowRuntimeService {
 
   private void executeNode(NodeDispatch dispatch) {
     String type = String.valueOf(dispatch.nodeConfiguration().getOrDefault("type", "TASK"));
+    long simulatedDurationMillis = Math.max(0L, delayMillisSupplier.getAsLong());
     log.info(
-        "[workflow] node start execution={}, node={}, type={}, attempt={}",
+        "[workflow] node start execution={}, node={}, type={}, attempt={}, simulatedDurationMs={}",
         dispatch.workflowExecutionId(),
         dispatch.nodeId(),
         type,
-        dispatch.attemptNumber());
+        dispatch.attemptNumber(),
+        simulatedDurationMillis);
     try {
       engine.acknowledgeNodeStarted(dispatch.workflowExecutionId(), dispatch.nodeId());
+      publishCurrent(dispatch.workflowExecutionId());
+
+      Thread.sleep(simulatedDurationMillis);
+
       engine.completeNode(
           dispatch.workflowExecutionId(),
           dispatch.nodeId(),
-          Map.of("type", type, "message", "executed in memory"));
+          Map.of(
+              "type", type,
+              "message", "executed in memory",
+              "simulatedDurationMs", simulatedDurationMillis));
+      publishCurrent(dispatch.workflowExecutionId());
       log.info(
-          "[workflow] node success execution={}, node={}, type={}",
+          "[workflow] node success execution={}, node={}, type={}, simulatedDurationMs={}",
           dispatch.workflowExecutionId(),
           dispatch.nodeId(),
-          type);
+          type,
+          simulatedDurationMillis);
+    } catch (InterruptedException exception) {
+      Thread.currentThread().interrupt();
+      failNode(dispatch, "Node execution interrupted", exception);
     } catch (RuntimeException exception) {
-      log.error(
-          "[workflow] node failed execution={}, node={}, message={}",
-          dispatch.workflowExecutionId(),
-          dispatch.nodeId(),
-          exception.getMessage(),
+      failNode(
+          dispatch,
+          exception.getMessage() == null ? exception.getClass().getSimpleName() : exception.getMessage(),
           exception);
-      try {
-        engine.failNode(
-            dispatch.workflowExecutionId(),
-            dispatch.nodeId(),
-            exception.getMessage() == null ? exception.getClass().getSimpleName() : exception.getMessage());
-      } catch (RuntimeException callbackException) {
-        log.warn(
-            "[workflow] failure callback skipped execution={}, node={}, message={}",
-            dispatch.workflowExecutionId(),
-            dispatch.nodeId(),
-            callbackException.getMessage());
-      }
     } finally {
       drainDispatches();
     }
+  }
+
+  private void failNode(
+      NodeDispatch dispatch,
+      String errorMessage,
+      Exception exception) {
+    log.error(
+        "[workflow] node failed execution={}, node={}, message={}",
+        dispatch.workflowExecutionId(),
+        dispatch.nodeId(),
+        errorMessage,
+        exception);
+    try {
+      engine.failNode(
+          dispatch.workflowExecutionId(),
+          dispatch.nodeId(),
+          errorMessage);
+      publishCurrent(dispatch.workflowExecutionId());
+    } catch (RuntimeException callbackException) {
+      log.warn(
+          "[workflow] failure callback skipped execution={}, node={}, message={}",
+          dispatch.workflowExecutionId(),
+          dispatch.nodeId(),
+          callbackException.getMessage());
+    }
+  }
+
+  private void publishCurrent(String executionId) {
+    RunMetadata runMetadata = metadata.get(executionId);
+    if (runMetadata == null) {
+      return;
+    }
+    engine.findExecution(executionId)
+        .map(execution -> toView(execution, runMetadata))
+        .ifPresent(eventStreamService::publish);
   }
 
   private WorkflowInstanceVO toView(WorkflowExecution execution, RunMetadata runMetadata) {

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowRuntimeServiceTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowRuntimeServiceTest.java
@@ -13,7 +13,9 @@ import org.junit.jupiter.api.Test;
 
 class WorkflowRuntimeServiceTest {
 
-  private final WorkflowRuntimeService service = new WorkflowRuntimeService();
+  private final WorkflowRuntimeService service = new WorkflowRuntimeService(
+      new WorkflowEventStreamService(),
+      () -> 5L);
 
   @AfterEach
   void tearDown() {

--- a/yak-ops-ui/src/pages/workflow/definition/index.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/index.tsx
@@ -1,16 +1,26 @@
-import { runWorkflow } from '@/services/workflow';
+import {
+  isWorkflowTerminal,
+  runWorkflow,
+  subscribeWorkflowEvents,
+  type WorkflowInstance,
+} from '@/services/workflow';
 import { Button, Input, Popconfirm, message } from 'antd';
 import {
   Bell,
+  CheckCircle2,
+  CircleEllipsis,
   CirclePlay,
   Database,
+  LoaderCircle,
   Play,
   RotateCcw,
   ShieldCheck,
+  XCircle,
 } from 'lucide-react';
 import {
   type DragEvent,
   type ReactNode,
+  useEffect,
   useMemo,
   useRef,
   useState,
@@ -36,6 +46,7 @@ interface WorkflowNodeData {
   label: string;
   nodeType: string;
   typeLabel: string;
+  executionStatus?: string;
 }
 
 interface NodeTemplate {
@@ -72,11 +83,45 @@ const NODE_TEMPLATES: NodeTemplate[] = [
   },
 ];
 
+const statusLabel: Record<string, string> = {
+  WAITING: '等待中',
+  READY: '就绪',
+  SUBMITTED: '排队中',
+  RUNNING: '运行中',
+  SUCCESS: '成功',
+  FAILED: '失败',
+  WARNING: '告警',
+  CANCELED: '已取消',
+  UPSTREAM_FAILED: '上游失败',
+  SKIPPED: '已跳过',
+};
+
+const statusIcon = (status?: string) => {
+  if (status === 'RUNNING') {
+    return <LoaderCircle size={13} className="animate-spin text-[#fe2c55]" />;
+  }
+  if (status === 'SUCCESS') {
+    return <CheckCircle2 size={13} className="text-[#161823]" />;
+  }
+  if (status === 'FAILED' || status === 'UPSTREAM_FAILED') {
+    return <XCircle size={13} className="text-[#d92d20]" />;
+  }
+  return <CircleEllipsis size={13} className="text-[rgba(22,24,35,.42)]" />;
+};
+
+const nodeBorderClass = (status?: string, selected?: boolean) => {
+  if (status === 'RUNNING') return 'border-[#fe2c55] shadow-[0_0_0_2px_rgba(254,44,85,.08)]';
+  if (status === 'FAILED' || status === 'UPSTREAM_FAILED') return 'border-[#d92d20]';
+  if (status === 'SUCCESS') return 'border-[#b8bbc2]';
+  if (selected) return 'border-[#fe2c55]';
+  return 'border-[#dfe1e5]';
+};
+
 const WorkflowNode = ({ data, selected }: NodeProps<WorkflowNodeData>) => (
   <div
     className={[
-      'relative min-w-[168px] rounded-lg border bg-white px-3 py-2.5 shadow-sm',
-      selected ? 'border-[#fe2c55]' : 'border-[#dfe1e5]',
+      'relative min-w-[168px] rounded-lg border bg-white px-3 py-2.5 shadow-sm transition-all duration-200',
+      nodeBorderClass(data.executionStatus, selected),
     ].join(' ')}
   >
     <Handle
@@ -90,6 +135,12 @@ const WorkflowNode = ({ data, selected }: NodeProps<WorkflowNodeData>) => (
     <div className="mt-1 text-[13px] font-semibold text-[#161823]">
       {data.label}
     </div>
+    {data.executionStatus ? (
+      <div className="mt-2 flex items-center gap-1.5 border-t border-[#f0f0f1] pt-2 text-[11px] text-[rgba(22,24,35,.58)]">
+        {statusIcon(data.executionStatus)}
+        <span>{statusLabel[data.executionStatus] || data.executionStatus}</span>
+      </div>
+    ) : null}
     <Handle
       type="source"
       position={Position.Right}
@@ -101,14 +152,35 @@ const WorkflowNode = ({ data, selected }: NodeProps<WorkflowNodeData>) => (
 const WorkflowDefinitionContent = () => {
   const wrapperRef = useRef<HTMLDivElement>(null);
   const sequenceRef = useRef(1);
+  const closeStreamRef = useRef<(() => void) | null>(null);
   const [workflowName, setWorkflowName] = useState('内存工作流');
   const [nodes, setNodes, onNodesChange] = useNodesState<WorkflowNodeData>([]);
   const [edges, setEdges, onEdgesChange] = useEdgesState([]);
   const [reactFlowInstance, setReactFlowInstance] =
     useState<ReactFlowInstance | null>(null);
-  const [running, setRunning] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [activeInstance, setActiveInstance] = useState<WorkflowInstance>();
 
   const nodeTypes = useMemo(() => ({ workflow: WorkflowNode }), []);
+  const workflowRunning = Boolean(
+    activeInstance && !isWorkflowTerminal(activeInstance.status),
+  );
+
+  useEffect(() => () => closeStreamRef.current?.(), []);
+
+  const applySnapshot = (snapshot: WorkflowInstance) => {
+    setActiveInstance(snapshot);
+    const statusByNodeId = new Map(
+      snapshot.nodes.map((node) => [node.id, node.status]),
+    );
+    setNodes((current) => current.map((node) => ({
+      ...node,
+      data: {
+        ...node.data,
+        executionStatus: statusByNodeId.get(node.id) ?? node.data.executionStatus,
+      },
+    })));
+  };
 
   const handleConnect = (connection: Connection) => {
     setEdges((current) =>
@@ -171,7 +243,16 @@ const WorkflowDefinitionContent = () => {
       message.warning('请先拖入至少一个节点');
       return;
     }
-    setRunning(true);
+
+    closeStreamRef.current?.();
+    closeStreamRef.current = null;
+    setActiveInstance(undefined);
+    setNodes((current) => current.map((node) => ({
+      ...node,
+      data: { ...node.data, executionStatus: 'WAITING' },
+    })));
+    setSubmitting(true);
+
     try {
       const instance = await runWorkflow({
         name: workflowName.trim() || '未命名工作流',
@@ -186,12 +267,23 @@ const WorkflowDefinitionContent = () => {
         })),
         input: {},
       });
-      message.success(`工作流已运行：${instance.id}`);
+
+      applySnapshot(instance);
+      closeStreamRef.current = subscribeWorkflowEvents(instance.id, applySnapshot);
+      message.success('工作流已启动，节点状态将实时更新');
     } catch (error) {
       message.error(error instanceof Error ? error.message : '工作流运行失败');
     } finally {
-      setRunning(false);
+      setSubmitting(false);
     }
+  };
+
+  const clearCanvas = () => {
+    closeStreamRef.current?.();
+    closeStreamRef.current = null;
+    setActiveInstance(undefined);
+    setNodes([]);
+    setEdges([]);
   };
 
   return (
@@ -208,7 +300,7 @@ const WorkflowDefinitionContent = () => {
           {NODE_TEMPLATES.map((template) => (
             <div
               key={template.type}
-              draggable
+              draggable={!workflowRunning}
               onDragStart={(event) => handleDragStart(event, template)}
               className="cursor-grab rounded-lg border border-[#e3e5e8] bg-white px-3 py-2.5 transition-shadow hover:shadow-sm active:cursor-grabbing"
             >
@@ -236,10 +328,21 @@ const WorkflowDefinitionContent = () => {
               variant="filled"
               className="w-[240px]"
               placeholder="输入工作流名称"
+              disabled={workflowRunning}
             />
             <span className="text-xs text-[rgba(22,24,35,.4)]">
               {nodes.length} 节点 · {edges.length} 连线
             </span>
+            {activeInstance ? (
+              <span className="flex items-center gap-1.5 text-xs text-[rgba(22,24,35,.58)]">
+                {workflowRunning ? (
+                  <LoaderCircle size={13} className="animate-spin text-[#fe2c55]" />
+                ) : (
+                  statusIcon(activeInstance.status)
+                )}
+                实时 · {statusLabel[activeInstance.status] || activeInstance.status}
+              </span>
+            ) : null}
           </div>
 
           <div className="flex items-center gap-2">
@@ -247,20 +350,21 @@ const WorkflowDefinitionContent = () => {
               title="清空当前画布？"
               okText="清空"
               cancelText="取消"
-              onConfirm={() => {
-                setNodes([]);
-                setEdges([]);
-              }}
+              disabled={workflowRunning}
+              onConfirm={clearCanvas}
             >
-              <Button icon={<RotateCcw size={14} />}>清空</Button>
+              <Button icon={<RotateCcw size={14} />} disabled={workflowRunning}>
+                清空
+              </Button>
             </Popconfirm>
             <Button
               type="primary"
               icon={<Play size={14} />}
-              loading={running}
+              loading={submitting}
+              disabled={workflowRunning}
               onClick={handleRun}
             >
-              运行
+              {workflowRunning ? '运行中' : '运行'}
             </Button>
           </div>
         </div>
@@ -276,10 +380,13 @@ const WorkflowDefinitionContent = () => {
             onInit={setReactFlowInstance}
             onDragOver={(event) => {
               event.preventDefault();
-              event.dataTransfer.dropEffect = 'move';
+              event.dataTransfer.dropEffect = workflowRunning ? 'none' : 'move';
             }}
+            nodesDraggable={!workflowRunning}
+            nodesConnectable={!workflowRunning}
+            elementsSelectable={!workflowRunning}
             fitView
-            deleteKeyCode={['Backspace', 'Delete']}
+            deleteKeyCode={workflowRunning ? null : ['Backspace', 'Delete']}
             defaultEdgeOptions={{ type: 'smoothstep' }}
           >
             <Background gap={18} size={1} />

--- a/yak-ops-ui/src/pages/workflow/instances/index.tsx
+++ b/yak-ops-ui/src/pages/workflow/instances/index.tsx
@@ -1,6 +1,8 @@
 import {
   getWorkflowInstance,
   getWorkflowInstances,
+  isWorkflowTerminal,
+  subscribeWorkflowEvents,
   type WorkflowInstance,
   type WorkflowNodeInstance,
 } from '@/services/workflow';
@@ -8,7 +10,7 @@ import { Button, Drawer, Empty, Table, message } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
 import dayjs from 'dayjs';
 import { RefreshCw } from 'lucide-react';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 const statusLabel: Record<string, string> = {
   CREATED: '已创建',
@@ -38,6 +40,7 @@ const formatTime = (value?: string) =>
   value ? dayjs(value).format('YYYY-MM-DD HH:mm:ss') : '-';
 
 const WorkflowInstancesPage = () => {
+  const detailStreamRef = useRef<(() => void) | null>(null);
   const [instances, setInstances] = useState<WorkflowInstance[]>([]);
   const [loading, setLoading] = useState(false);
   const [detailOpen, setDetailOpen] = useState(false);
@@ -60,21 +63,46 @@ const WorkflowInstancesPage = () => {
   useEffect(() => {
     void loadInstances(true);
     const timer = window.setInterval(() => void loadInstances(false), 2000);
-    return () => window.clearInterval(timer);
+    return () => {
+      window.clearInterval(timer);
+      detailStreamRef.current?.();
+    };
   }, [loadInstances]);
 
+  const applyDetailSnapshot = useCallback((snapshot: WorkflowInstance) => {
+    setDetail(snapshot);
+    setInstances((current) => current.map((item) =>
+      item.id === snapshot.id ? snapshot : item,
+    ));
+  }, []);
+
   const openDetail = useCallback(async (record: WorkflowInstance) => {
+    detailStreamRef.current?.();
+    detailStreamRef.current = null;
     setDetail(record);
     setDetailOpen(true);
     setDetailLoading(true);
     try {
-      setDetail(await getWorkflowInstance(record.id));
+      const current = await getWorkflowInstance(record.id);
+      applyDetailSnapshot(current);
+      if (!isWorkflowTerminal(current.status)) {
+        detailStreamRef.current = subscribeWorkflowEvents(
+          current.id,
+          applyDetailSnapshot,
+        );
+      }
     } catch (error) {
       message.error(error instanceof Error ? error.message : '实例详情加载失败');
     } finally {
       setDetailLoading(false);
     }
-  }, []);
+  }, [applyDetailSnapshot]);
+
+  const closeDetail = () => {
+    detailStreamRef.current?.();
+    detailStreamRef.current = null;
+    setDetailOpen(false);
+  };
 
   const columns = useMemo<ColumnsType<WorkflowInstance>>(
     () => [
@@ -178,7 +206,7 @@ const WorkflowInstancesPage = () => {
         <div>
           <h1 className="m-0 text-[20px] font-semibold text-[#161823]">工作流实例</h1>
           <div className="mt-1 text-xs text-[rgba(22,24,35,.46)]">
-            当前实例仅保存在内存中，服务重启后会清空。
+            当前实例仅保存在内存中；打开实例详情后通过 SSE 实时更新节点状态。
           </div>
         </div>
         <Button
@@ -209,7 +237,7 @@ const WorkflowInstancesPage = () => {
         width={720}
         open={detailOpen}
         loading={detailLoading}
-        onClose={() => setDetailOpen(false)}
+        onClose={closeDetail}
       >
         {detail ? (
           <>

--- a/yak-ops-ui/src/services/workflow/index.ts
+++ b/yak-ops-ui/src/services/workflow/index.ts
@@ -39,6 +39,16 @@ export interface WorkflowInstance {
   nodes: WorkflowNodeInstance[];
 }
 
+const TERMINAL_STATUSES = new Set([
+  'SUCCESS',
+  'FAILED',
+  'WARNING',
+  'CANCELED',
+]);
+
+export const isWorkflowTerminal = (status?: string) =>
+  Boolean(status && TERMINAL_STATUSES.has(status));
+
 export const runWorkflow = async (payload: WorkflowRunPayload) => {
   const response = await request<ApiResponse<WorkflowInstance>>(
     '/api/v1/workflows/run',
@@ -62,4 +72,28 @@ export const getWorkflowInstance = async (executionId: string) => {
     `/api/v1/workflows/instances/${encodeURIComponent(executionId)}`,
   );
   return response.data;
+};
+
+export const subscribeWorkflowEvents = (
+  executionId: string,
+  onSnapshot: (instance: WorkflowInstance) => void,
+) => {
+  const source = new EventSource(
+    `/api/v1/workflows/instances/${encodeURIComponent(executionId)}/events`,
+  );
+
+  const handleWorkflowEvent = (event: Event) => {
+    const snapshot = JSON.parse((event as MessageEvent<string>).data) as WorkflowInstance;
+    onSnapshot(snapshot);
+    if (isWorkflowTerminal(snapshot.status)) {
+      source.close();
+    }
+  };
+
+  source.addEventListener('workflow', handleWorkflowEvent);
+
+  return () => {
+    source.removeEventListener('workflow', handleWorkflowEvent);
+    source.close();
+  };
 };


### PR DESCRIPTION
## What changed

- Add an SSE endpoint for workflow execution snapshots:
  - `GET /api/v1/workflows/instances/{executionId}/events`
- Add `WorkflowEventStreamService` to manage per-execution `SseEmitter` subscribers in memory.
- Simulate each node execution with a random duration from 1 to 10 seconds.
- Publish a fresh workflow snapshot when a node enters `RUNNING`, succeeds, fails, or the workflow reaches a terminal state.
- Include the simulated duration in node output and application logs.
- Update the React Flow definition page so every node displays its live execution state directly on the canvas.
- Lock graph editing while the current workflow is running to keep the displayed graph aligned with the running DAG.
- Update the workflow instance detail drawer to subscribe to SSE and update node states in real time.
- Keep the existing lightweight list polling for instance discovery while using SSE for active execution detail.
- Keep tests fast by injecting a short delay supplier in `WorkflowRuntimeServiceTest`.

## Why SSE

This workflow UI currently only needs one-way server-to-browser status updates. SSE keeps the MVP smaller than a WebSocket/STOMP setup, works with Spring MVC's built-in `SseEmitter`, and uses the browser-native `EventSource` API with no new frontend dependency.

## Runtime behavior

A node is acknowledged as `RUNNING`, its current workflow snapshot is pushed immediately, then the simulated worker waits a random 1-10 seconds before completing the node. Downstream nodes are still scheduled entirely by `yak-workflow-engine`, so serial, parallel, and join semantics remain framework-owned.

The SSE subscription sends an initial snapshot immediately and then re-publishes the latest snapshot after registration to close the small race window between reading the current execution and attaching the subscriber.

## Validation

- Branch is based directly on the merged workflow MVP (`main`) and is currently not behind `main`.
- Existing workflow runtime test was adapted to inject a 5ms simulated delay so tests do not wait for the production 1-10 second range.
- No GitHub Actions workflow run is currently reported for the branch, so Maven/frontend type checks still need to run in the normal local or CI environment.