### PR TITLE
fix(workflow): restore Spring runtime wiring

### DIFF
--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowRuntimeService.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowRuntimeService.java
@@ -32,6 +32,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.LongSupplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
@@ -50,6 +51,7 @@ public class WorkflowRuntimeService {
   private final Map<String, RunMetadata> metadata = new ConcurrentHashMap<>();
   private final ConcurrentLinkedDeque<String> executionOrder = new ConcurrentLinkedDeque<>();
 
+  @Autowired
   public WorkflowRuntimeService(WorkflowEventStreamService eventStreamService) {
     this(
         eventStreamService,

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowRuntimeServiceSpringTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowRuntimeServiceSpringTest.java
@@ -1,0 +1,20 @@
+package io.yak.ops.business.workflow.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+class WorkflowRuntimeServiceSpringTest {
+
+  @Test
+  void shouldCreateRuntimeServiceThroughSpring() {
+    try (AnnotationConfigApplicationContext context =
+        new AnnotationConfigApplicationContext()) {
+      context.register(WorkflowEventStreamService.class, WorkflowRuntimeService.class);
+      context.refresh();
+
+      assertThat(context.getBean(WorkflowRuntimeService.class)).isNotNull();
+    }
+  }
+}


### PR DESCRIPTION
## Root cause

`WorkflowRuntimeService` has two constructors after the SSE change: the production constructor and a package-private constructor used by tests to inject a short delay. With multiple constructors and no explicit injection annotation, Spring falls back to looking for a no-arg constructor and application startup fails with `No default constructor found`.

## Fix

- Mark the production constructor with `@Autowired` so Spring resolves `WorkflowEventStreamService` explicitly.
- Add a small Spring context regression test that creates `WorkflowRuntimeService` through `AnnotationConfigApplicationContext`.

## Scope

This PR only changes Spring bean wiring and adds the regression test. SSE behavior, random 1-10 second node execution, workflow scheduling, frontend live status, and database behavior are unchanged.