### PR TITLE
feat(workflow): animate live node-by-node execution

### DIFF
--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/controller/v1/WorkflowController.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/controller/v1/WorkflowController.java
@@ -29,11 +29,18 @@ public class WorkflowController {
     this.workflowRuntimeService = workflowRuntimeService;
   }
 
-  @Operation(summary = "运行工作流")
+  @Operation(summary = "创建工作流运行实例")
   @PostMapping("/run")
   public Result<WorkflowInstanceVO> run(
       @Valid @RequestBody WorkflowRunRequest request) {
     return Result.success(workflowRuntimeService.run(request));
+  }
+
+  @Operation(summary = "激活工作流运行实例")
+  @PostMapping("/instances/{executionId}/activate")
+  public Result<WorkflowInstanceVO> activate(
+      @PathVariable("executionId") String executionId) {
+    return Result.success(workflowRuntimeService.activate(executionId));
   }
 
   @Operation(summary = "查询工作流实例")

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowRuntimeService.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowRuntimeService.java
@@ -50,6 +50,7 @@ public class WorkflowRuntimeService {
   private final LongSupplier delayMillisSupplier;
   private final ConcurrentMap<String, ConcurrentLinkedQueue<NodeDispatch>> pendingDispatches =
       new ConcurrentHashMap<>();
+  private final ConcurrentMap<String, Object> publishLocks = new ConcurrentHashMap<>();
   private final Set<String> activeExecutions = ConcurrentHashMap.newKeySet();
   private final Map<String, RunMetadata> metadata = new ConcurrentHashMap<>();
   private final ConcurrentLinkedDeque<String> executionOrder = new ConcurrentLinkedDeque<>();
@@ -207,10 +208,7 @@ public class WorkflowRuntimeService {
       NodeDispatch current = dispatch;
       workerPool.execute(() -> executeNode(current));
     }
-
-    if (queue.isEmpty()) {
-      pendingDispatches.remove(executionId, queue);
-    }
+    // 空队列保留到工作流终态再清理，避免并发 enqueue 与 remove 导致 dispatch 丢失。
   }
 
   private void executeNode(NodeDispatch dispatch) {
@@ -282,19 +280,23 @@ public class WorkflowRuntimeService {
   }
 
   private void publishCurrent(String executionId) {
-    RunMetadata runMetadata = metadata.get(executionId);
-    if (runMetadata == null) {
-      return;
+    Object publishLock = publishLocks.computeIfAbsent(executionId, ignored -> new Object());
+    synchronized (publishLock) {
+      RunMetadata runMetadata = metadata.get(executionId);
+      if (runMetadata == null) {
+        return;
+      }
+      engine.findExecution(executionId)
+          .map(execution -> toView(execution, runMetadata))
+          .ifPresent(snapshot -> {
+            eventStreamService.publish(snapshot);
+            if (isTerminal(snapshot.status())) {
+              activeExecutions.remove(executionId);
+              pendingDispatches.remove(executionId);
+              publishLocks.remove(executionId, publishLock);
+            }
+          });
     }
-    engine.findExecution(executionId)
-        .map(execution -> toView(execution, runMetadata))
-        .ifPresent(snapshot -> {
-          eventStreamService.publish(snapshot);
-          if (isTerminal(snapshot.status())) {
-            activeExecutions.remove(executionId);
-            pendingDispatches.remove(executionId);
-          }
-        });
   }
 
   private boolean isTerminal(String status) {

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowRuntimeService.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowRuntimeService.java
@@ -114,6 +114,11 @@ public class WorkflowRuntimeService {
     return started;
   }
 
+  public WorkflowInstanceVO activate(String executionId) {
+    activateExecution(executionId);
+    return getInstance(executionId);
+  }
+
   public List<WorkflowInstanceVO> listInstances() {
     List<WorkflowInstanceVO> instances = new ArrayList<>();
     for (String executionId : executionOrder) {
@@ -149,8 +154,10 @@ public class WorkflowRuntimeService {
   }
 
   void activateExecution(String executionId) {
+    // 先校验实例存在，避免把不存在的 executionId 放进 active 集合。
+    getInstance(executionId);
     if (activeExecutions.add(executionId)) {
-      log.info("[workflow] activated execution={} after live subscriber attached", executionId);
+      log.info("[workflow] activated execution={}", executionId);
     }
     drainDispatches(executionId);
   }

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowRuntimeService.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowRuntimeService.java
@@ -21,10 +21,12 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadLocalRandom;
@@ -46,8 +48,9 @@ public class WorkflowRuntimeService {
   private final DefaultWorkflowEngine engine;
   private final WorkflowEventStreamService eventStreamService;
   private final LongSupplier delayMillisSupplier;
-  private final ConcurrentLinkedQueue<NodeDispatch> pendingDispatches =
-      new ConcurrentLinkedQueue<>();
+  private final ConcurrentMap<String, ConcurrentLinkedQueue<NodeDispatch>> pendingDispatches =
+      new ConcurrentHashMap<>();
+  private final Set<String> activeExecutions = ConcurrentHashMap.newKeySet();
   private final Map<String, RunMetadata> metadata = new ConcurrentHashMap<>();
   private final ConcurrentLinkedDeque<String> executionOrder = new ConcurrentLinkedDeque<>();
 
@@ -72,7 +75,7 @@ public class WorkflowRuntimeService {
           thread.setDaemon(true);
           return thread;
         });
-    this.engine = DefaultWorkflowEngine.inMemory(pendingDispatches::add);
+    this.engine = DefaultWorkflowEngine.inMemory(this::enqueueDispatch);
   }
 
   public WorkflowInstanceVO run(WorkflowRunRequest request) {
@@ -101,15 +104,13 @@ public class WorkflowRuntimeService {
     executionOrder.addFirst(execution.id());
 
     WorkflowInstanceVO started = toView(execution, runMetadata);
-    eventStreamService.publish(started);
     log.info(
-        "[workflow] started execution={}, definition={}, name={}, nodes={}, edges={}",
+        "[workflow] prepared execution={}, definition={}, name={}, nodes={}, edges={}",
         execution.id(),
         definitionId,
         request.name(),
         request.nodes().size(),
         request.edges().size());
-    drainDispatches();
     return started;
   }
 
@@ -140,9 +141,18 @@ public class WorkflowRuntimeService {
   public SseEmitter subscribe(String executionId) {
     WorkflowInstanceVO snapshot = getInstance(executionId);
     SseEmitter emitter = eventStreamService.subscribe(executionId, snapshot);
-    // 再推一次最新快照，覆盖“读取快照”和“注册订阅者”之间可能发生的状态变化。
-    eventStreamService.publish(getInstance(executionId));
+
+    // 先把 SSE 客户端挂上，再真正启动首批节点，避免前端错过 RUNNING 状态。
+    activateExecution(executionId);
+    publishCurrent(executionId);
     return emitter;
+  }
+
+  void activateExecution(String executionId) {
+    if (activeExecutions.add(executionId)) {
+      log.info("[workflow] activated execution={} after live subscriber attached", executionId);
+    }
+    drainDispatches(executionId);
   }
 
   private NodeDefinition toNodeDefinition(NodeRequest node) {
@@ -167,11 +177,32 @@ public class WorkflowRuntimeService {
     return Map.copyOf(result);
   }
 
-  private void drainDispatches() {
+  private void enqueueDispatch(NodeDispatch dispatch) {
+    pendingDispatches
+        .computeIfAbsent(
+            dispatch.workflowExecutionId(),
+            ignored -> new ConcurrentLinkedQueue<>())
+        .offer(dispatch);
+
+    if (activeExecutions.contains(dispatch.workflowExecutionId())) {
+      drainDispatches(dispatch.workflowExecutionId());
+    }
+  }
+
+  private void drainDispatches(String executionId) {
+    ConcurrentLinkedQueue<NodeDispatch> queue = pendingDispatches.get(executionId);
+    if (queue == null) {
+      return;
+    }
+
     NodeDispatch dispatch;
-    while ((dispatch = pendingDispatches.poll()) != null) {
+    while ((dispatch = queue.poll()) != null) {
       NodeDispatch current = dispatch;
       workerPool.execute(() -> executeNode(current));
+    }
+
+    if (queue.isEmpty()) {
+      pendingDispatches.remove(executionId, queue);
     }
   }
 
@@ -214,7 +245,7 @@ public class WorkflowRuntimeService {
           exception.getMessage() == null ? exception.getClass().getSimpleName() : exception.getMessage(),
           exception);
     } finally {
-      drainDispatches();
+      drainDispatches(dispatch.workflowExecutionId());
     }
   }
 
@@ -250,7 +281,20 @@ public class WorkflowRuntimeService {
     }
     engine.findExecution(executionId)
         .map(execution -> toView(execution, runMetadata))
-        .ifPresent(eventStreamService::publish);
+        .ifPresent(snapshot -> {
+          eventStreamService.publish(snapshot);
+          if (isTerminal(snapshot.status())) {
+            activeExecutions.remove(executionId);
+            pendingDispatches.remove(executionId);
+          }
+        });
+  }
+
+  private boolean isTerminal(String status) {
+    return "SUCCESS".equals(status)
+        || "FAILED".equals(status)
+        || "WARNING".equals(status)
+        || "CANCELED".equals(status);
   }
 
   private WorkflowInstanceVO toView(WorkflowExecution execution, RunMetadata runMetadata) {

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowRuntimeServiceTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowRuntimeServiceTest.java
@@ -33,6 +33,11 @@ class WorkflowRuntimeServiceTest {
         Map.of());
 
     WorkflowInstanceVO started = service.run(request);
+    assertThat(started.nodes())
+        .extracting(WorkflowInstanceVO.NodeInstanceVO::status)
+        .contains("SUBMITTED", "WAITING");
+
+    service.activateExecution(started.id());
     WorkflowInstanceVO completed = waitForTerminal(started.id());
 
     assertThat(completed.status()).isEqualTo("SUCCESS");

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowRuntimeServiceTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowRuntimeServiceTest.java
@@ -13,31 +13,28 @@ import org.junit.jupiter.api.Test;
 
 class WorkflowRuntimeServiceTest {
 
-  private final WorkflowRuntimeService service = new WorkflowRuntimeService(
-      new WorkflowEventStreamService(),
-      () -> 5L);
+  private WorkflowRuntimeService service;
 
   @AfterEach
   void tearDown() {
-    service.shutdown();
+    if (service != null) {
+      service.shutdown();
+    }
   }
 
   @Test
   void shouldExecuteSimpleDagInMemory() throws InterruptedException {
-    WorkflowRunRequest request = new WorkflowRunRequest(
-        "demo",
-        List.of(
-            new NodeRequest("extract", "Extract", "DATA"),
-            new NodeRequest("check", "Check", "CHECK")),
-        List.of(new EdgeRequest("extract", "check")),
-        Map.of());
+    service = new WorkflowRuntimeService(
+        new WorkflowEventStreamService(),
+        () -> 5L);
+
+    WorkflowRunRequest request = simpleSerialWorkflow();
 
     WorkflowInstanceVO started = service.run(request);
-    assertThat(started.nodes())
-        .extracting(WorkflowInstanceVO.NodeInstanceVO::status)
-        .contains("SUBMITTED", "WAITING");
+    assertThat(statusOf(started, "extract")).isEqualTo("SUBMITTED");
+    assertThat(statusOf(started, "check")).isEqualTo("WAITING");
 
-    service.activateExecution(started.id());
+    service.activate(started.id());
     WorkflowInstanceVO completed = waitForTerminal(started.id());
 
     assertThat(completed.status()).isEqualTo("SUCCESS");
@@ -46,15 +43,67 @@ class WorkflowRuntimeServiceTest {
         .containsOnly("SUCCESS");
   }
 
+  @Test
+  void shouldExposeRunningThenSuccessBeforeStartingNextNode()
+      throws InterruptedException {
+    service = new WorkflowRuntimeService(
+        new WorkflowEventStreamService(),
+        () -> 120L);
+
+    WorkflowInstanceVO started = service.run(simpleSerialWorkflow());
+    service.activate(started.id());
+
+    WorkflowInstanceVO firstRunning = waitForNodeStatus(started.id(), "extract", "RUNNING");
+    assertThat(statusOf(firstRunning, "check")).isEqualTo("WAITING");
+
+    WorkflowInstanceVO secondRunning = waitForNodeStatus(started.id(), "check", "RUNNING");
+    assertThat(statusOf(secondRunning, "extract")).isEqualTo("SUCCESS");
+
+    WorkflowInstanceVO completed = waitForTerminal(started.id());
+    assertThat(completed.status()).isEqualTo("SUCCESS");
+  }
+
+  private WorkflowRunRequest simpleSerialWorkflow() {
+    return new WorkflowRunRequest(
+        "demo",
+        List.of(
+            new NodeRequest("extract", "Extract", "DATA"),
+            new NodeRequest("check", "Check", "CHECK")),
+        List.of(new EdgeRequest("extract", "check")),
+        Map.of());
+  }
+
+  private WorkflowInstanceVO waitForNodeStatus(
+      String executionId,
+      String nodeId,
+      String expectedStatus) throws InterruptedException {
+    for (int attempt = 0; attempt < 100; attempt++) {
+      WorkflowInstanceVO current = service.getInstance(executionId);
+      if (expectedStatus.equals(statusOf(current, nodeId))) {
+        return current;
+      }
+      Thread.sleep(10L);
+    }
+    return service.getInstance(executionId);
+  }
+
   private WorkflowInstanceVO waitForTerminal(String executionId)
       throws InterruptedException {
-    for (int attempt = 0; attempt < 100; attempt++) {
+    for (int attempt = 0; attempt < 200; attempt++) {
       WorkflowInstanceVO current = service.getInstance(executionId);
       if (!"RUNNING".equals(current.status()) && !"CREATED".equals(current.status())) {
         return current;
       }
-      Thread.sleep(20L);
+      Thread.sleep(10L);
     }
     return service.getInstance(executionId);
+  }
+
+  private String statusOf(WorkflowInstanceVO instance, String nodeId) {
+    return instance.nodes().stream()
+        .filter(node -> node.id().equals(nodeId))
+        .findFirst()
+        .orElseThrow()
+        .status();
   }
 }

--- a/yak-ops-ui/src/pages/workflow/definition/index.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/index.tsx
@@ -1,4 +1,5 @@
 import {
+  activateWorkflowInstance,
   isWorkflowTerminal,
   runWorkflow,
   subscribeWorkflowEvents,
@@ -86,7 +87,7 @@ const NODE_TEMPLATES: NodeTemplate[] = [
 const statusLabel: Record<string, string> = {
   WAITING: '等待中',
   READY: '就绪',
-  SUBMITTED: '排队中',
+  SUBMITTED: '待执行',
   RUNNING: '运行中',
   SUCCESS: '成功',
   FAILED: '失败',
@@ -109,38 +110,73 @@ const statusIcon = (status?: string) => {
   return <CircleEllipsis size={13} className="text-[rgba(22,24,35,.42)]" />;
 };
 
-const nodeBorderClass = (status?: string, selected?: boolean) => {
-  if (status === 'RUNNING') return 'border-[#fe2c55] shadow-[0_0_0_2px_rgba(254,44,85,.08)]';
-  if (status === 'FAILED' || status === 'UPSTREAM_FAILED') return 'border-[#d92d20]';
-  if (status === 'SUCCESS') return 'border-[#b8bbc2]';
-  if (selected) return 'border-[#fe2c55]';
-  return 'border-[#dfe1e5]';
+const nodeStateClass = (status?: string, selected?: boolean) => {
+  if (status === 'RUNNING') {
+    return 'border-[#fe2c55] bg-[#fff7f8] shadow-[0_0_0_3px_rgba(254,44,85,.10)]';
+  }
+  if (status === 'FAILED' || status === 'UPSTREAM_FAILED') {
+    return 'border-[#d92d20] bg-[#fff6f4] shadow-[0_0_0_2px_rgba(217,45,32,.06)]';
+  }
+  if (status === 'SUCCESS') {
+    return 'border-[rgba(22,24,35,.45)] bg-[#f7f7f8]';
+  }
+  if (status === 'SUBMITTED' || status === 'READY') {
+    return 'border-[#aeb2ba] bg-[#fafafa]';
+  }
+  if (selected) return 'border-[#fe2c55] bg-white';
+  return 'border-[#dfe1e5] bg-white';
+};
+
+const statusTextClass = (status?: string) => {
+  if (status === 'RUNNING') return 'font-medium text-[#fe2c55]';
+  if (status === 'FAILED' || status === 'UPSTREAM_FAILED') {
+    return 'font-medium text-[#d92d20]';
+  }
+  if (status === 'SUCCESS') return 'font-medium text-[#161823]';
+  return 'text-[rgba(22,24,35,.52)]';
 };
 
 const WorkflowNode = ({ data, selected }: NodeProps<WorkflowNodeData>) => (
   <div
     className={[
-      'relative min-w-[168px] rounded-lg border bg-white px-3 py-2.5 shadow-sm transition-all duration-200',
-      nodeBorderClass(data.executionStatus, selected),
+      'relative min-w-[174px] rounded-lg border px-3 py-2.5 shadow-sm transition-[border-color,background-color,box-shadow] duration-300',
+      nodeStateClass(data.executionStatus, selected),
     ].join(' ')}
   >
+    {data.executionStatus === 'RUNNING' ? (
+      <span className="pointer-events-none absolute -inset-[4px] -z-10 animate-pulse rounded-[11px] border border-[rgba(254,44,85,.18)]" />
+    ) : null}
+
     <Handle
       type="target"
       position={Position.Left}
       className="!h-2.5 !w-2.5 !border-2 !border-white !bg-[#8a8f99]"
     />
-    <div className="text-[11px] font-medium text-[rgba(22,24,35,.45)]">
-      {data.typeLabel}
+
+    <div className="flex items-center justify-between gap-3">
+      <div className="text-[11px] font-medium text-[rgba(22,24,35,.45)]">
+        {data.typeLabel}
+      </div>
+      {data.executionStatus ? (
+        <span className="flex items-center gap-1 text-[10px]">
+          {statusIcon(data.executionStatus)}
+          <span className={statusTextClass(data.executionStatus)}>
+            {statusLabel[data.executionStatus] || data.executionStatus}
+          </span>
+        </span>
+      ) : null}
     </div>
-    <div className="mt-1 text-[13px] font-semibold text-[#161823]">
+
+    <div className="mt-1.5 text-[13px] font-semibold text-[#161823]">
       {data.label}
     </div>
-    {data.executionStatus ? (
-      <div className="mt-2 flex items-center gap-1.5 border-t border-[#f0f0f1] pt-2 text-[11px] text-[rgba(22,24,35,.58)]">
-        {statusIcon(data.executionStatus)}
-        <span>{statusLabel[data.executionStatus] || data.executionStatus}</span>
+
+    {data.executionStatus === 'RUNNING' ? (
+      <div className="mt-2 h-[2px] overflow-hidden rounded-full bg-[rgba(254,44,85,.10)]">
+        <div className="h-full w-1/2 animate-pulse rounded-full bg-[#fe2c55]" />
       </div>
     ) : null}
+
     <Handle
       type="source"
       position={Position.Right}
@@ -170,9 +206,11 @@ const WorkflowDefinitionContent = () => {
 
   const applySnapshot = (snapshot: WorkflowInstance) => {
     setActiveInstance(snapshot);
+
     const statusByNodeId = new Map(
       snapshot.nodes.map((node) => [node.id, node.status]),
     );
+
     setNodes((current) => current.map((node) => ({
       ...node,
       data: {
@@ -180,6 +218,47 @@ const WorkflowDefinitionContent = () => {
         executionStatus: statusByNodeId.get(node.id) ?? node.data.executionStatus,
       },
     })));
+
+    setEdges((current) => current.map((edge) => {
+      const sourceStatus = statusByNodeId.get(edge.source);
+      const targetStatus = statusByNodeId.get(edge.target);
+      const targetRunning = targetStatus === 'RUNNING';
+      const failedPath =
+        sourceStatus === 'FAILED' ||
+        sourceStatus === 'UPSTREAM_FAILED' ||
+        targetStatus === 'FAILED' ||
+        targetStatus === 'UPSTREAM_FAILED';
+      const completedPath =
+        sourceStatus === 'SUCCESS' && targetStatus === 'SUCCESS';
+      const readyPath = sourceStatus === 'SUCCESS';
+
+      let stroke = '#d9dce1';
+      let strokeWidth = 1.4;
+      if (failedPath) {
+        stroke = '#d92d20';
+        strokeWidth = 1.8;
+      } else if (targetRunning) {
+        stroke = '#fe2c55';
+        strokeWidth = 2.2;
+      } else if (completedPath) {
+        stroke = '#555b66';
+        strokeWidth = 1.8;
+      } else if (readyPath) {
+        stroke = '#8a8f99';
+        strokeWidth = 1.7;
+      }
+
+      return {
+        ...edge,
+        animated: targetRunning,
+        style: {
+          ...edge.style,
+          stroke,
+          strokeWidth,
+          transition: 'stroke 240ms ease, stroke-width 240ms ease',
+        },
+      };
+    }));
   };
 
   const handleConnect = (connection: Connection) => {
@@ -188,6 +267,7 @@ const WorkflowDefinitionContent = () => {
         {
           ...connection,
           type: 'smoothstep',
+          style: { stroke: '#d9dce1', strokeWidth: 1.4 },
         },
         current,
       ),
@@ -210,7 +290,7 @@ const WorkflowDefinitionContent = () => {
 
   const handleDrop = (event: DragEvent<HTMLDivElement>) => {
     event.preventDefault();
-    if (!reactFlowInstance || !wrapperRef.current) return;
+    if (workflowRunning || !reactFlowInstance || !wrapperRef.current) return;
 
     const raw = event.dataTransfer.getData('application/yak-workflow-node');
     if (!raw) return;
@@ -221,7 +301,8 @@ const WorkflowDefinitionContent = () => {
       x: event.clientX - bounds.left,
       y: event.clientY - bounds.top,
     });
-    const id = `${template.type.toLowerCase()}-${Date.now()}-${sequenceRef.current++}`;
+    const sequence = sequenceRef.current++;
+    const id = `${template.type.toLowerCase()}-${Date.now()}-${sequence}`;
 
     setNodes((current) => [
       ...current,
@@ -230,12 +311,28 @@ const WorkflowDefinitionContent = () => {
         type: 'workflow',
         position,
         data: {
-          label: `${template.label} ${sequenceRef.current - 1}`,
+          label: `${template.label} ${sequence}`,
           nodeType: template.type,
           typeLabel: template.label,
         },
       },
     ]);
+  };
+
+  const resetExecutionVisuals = () => {
+    setNodes((current) => current.map((node) => ({
+      ...node,
+      data: { ...node.data, executionStatus: 'WAITING' },
+    })));
+    setEdges((current) => current.map((edge) => ({
+      ...edge,
+      animated: false,
+      style: {
+        ...edge.style,
+        stroke: '#d9dce1',
+        strokeWidth: 1.4,
+      },
+    })));
   };
 
   const handleRun = async () => {
@@ -247,13 +344,11 @@ const WorkflowDefinitionContent = () => {
     closeStreamRef.current?.();
     closeStreamRef.current = null;
     setActiveInstance(undefined);
-    setNodes((current) => current.map((node) => ({
-      ...node,
-      data: { ...node.data, executionStatus: 'WAITING' },
-    })));
+    resetExecutionVisuals();
     setSubmitting(true);
 
     try {
+      // 第一步只创建执行实例，不立即消费首批节点。
       const instance = await runWorkflow({
         name: workflowName.trim() || '未命名工作流',
         nodes: nodes.map((node) => ({
@@ -269,9 +364,16 @@ const WorkflowDefinitionContent = () => {
       });
 
       applySnapshot(instance);
+
+      // 第二步先监听，再激活。这样第一个节点 RUNNING 也不会被错过。
       closeStreamRef.current = subscribeWorkflowEvents(instance.id, applySnapshot);
-      message.success('工作流已启动，节点状态将实时更新');
+      const activated = await activateWorkflowInstance(instance.id);
+      applySnapshot(activated);
+
+      message.success('工作流已启动，将按节点实时展示执行状态');
     } catch (error) {
+      closeStreamRef.current?.();
+      closeStreamRef.current = null;
       message.error(error instanceof Error ? error.message : '工作流运行失败');
     } finally {
       setSubmitting(false);
@@ -285,6 +387,25 @@ const WorkflowDefinitionContent = () => {
     setNodes([]);
     setEdges([]);
   };
+
+  const executionCounts = useMemo(() => {
+    const result = {
+      running: 0,
+      success: 0,
+      failed: 0,
+      waiting: 0,
+    };
+    activeInstance?.nodes.forEach((node) => {
+      if (node.status === 'RUNNING') result.running += 1;
+      else if (node.status === 'SUCCESS') result.success += 1;
+      else if (node.status === 'FAILED' || node.status === 'UPSTREAM_FAILED') {
+        result.failed += 1;
+      } else {
+        result.waiting += 1;
+      }
+    });
+    return result;
+  }, [activeInstance]);
 
   return (
     <div className="flex h-[calc(100vh-48px)] min-h-[620px] overflow-hidden bg-white">
@@ -302,7 +423,12 @@ const WorkflowDefinitionContent = () => {
               key={template.type}
               draggable={!workflowRunning}
               onDragStart={(event) => handleDragStart(event, template)}
-              className="cursor-grab rounded-lg border border-[#e3e5e8] bg-white px-3 py-2.5 transition-shadow hover:shadow-sm active:cursor-grabbing"
+              className={[
+                'rounded-lg border border-[#e3e5e8] bg-white px-3 py-2.5 transition-shadow',
+                workflowRunning
+                  ? 'cursor-not-allowed opacity-60'
+                  : 'cursor-grab hover:shadow-sm active:cursor-grabbing',
+              ].join(' ')}
             >
               <div className="flex items-center gap-2 text-[13px] font-semibold text-[#161823]">
                 <span className="flex h-7 w-7 items-center justify-center rounded-md bg-[#f4f4f5] text-[rgba(22,24,35,.66)]">
@@ -333,15 +459,32 @@ const WorkflowDefinitionContent = () => {
             <span className="text-xs text-[rgba(22,24,35,.4)]">
               {nodes.length} 节点 · {edges.length} 连线
             </span>
+
             {activeInstance ? (
-              <span className="flex items-center gap-1.5 text-xs text-[rgba(22,24,35,.58)]">
-                {workflowRunning ? (
-                  <LoaderCircle size={13} className="animate-spin text-[#fe2c55]" />
-                ) : (
-                  statusIcon(activeInstance.status)
-                )}
-                实时 · {statusLabel[activeInstance.status] || activeInstance.status}
-              </span>
+              <div className="flex items-center gap-3 border-l border-[#ececef] pl-3 text-[11px]">
+                <span className="flex items-center gap-1.5 text-[#fe2c55]">
+                  {workflowRunning ? (
+                    <LoaderCircle size={12} className="animate-spin" />
+                  ) : (
+                    statusIcon(activeInstance.status)
+                  )}
+                  {statusLabel[activeInstance.status] || activeInstance.status}
+                </span>
+                <span className="text-[rgba(22,24,35,.48)]">
+                  运行 {executionCounts.running}
+                </span>
+                <span className="text-[rgba(22,24,35,.48)]">
+                  成功 {executionCounts.success}
+                </span>
+                {executionCounts.failed > 0 ? (
+                  <span className="text-[#d92d20]">
+                    失败 {executionCounts.failed}
+                  </span>
+                ) : null}
+                <span className="text-[rgba(22,24,35,.38)]">
+                  等待 {executionCounts.waiting}
+                </span>
+              </div>
             ) : null}
           </div>
 
@@ -387,7 +530,10 @@ const WorkflowDefinitionContent = () => {
             elementsSelectable={!workflowRunning}
             fitView
             deleteKeyCode={workflowRunning ? null : ['Backspace', 'Delete']}
-            defaultEdgeOptions={{ type: 'smoothstep' }}
+            defaultEdgeOptions={{
+              type: 'smoothstep',
+              style: { stroke: '#d9dce1', strokeWidth: 1.4 },
+            }}
           >
             <Background gap={18} size={1} />
             <Controls position="bottom-right" />

--- a/yak-ops-ui/src/services/workflow/index.ts
+++ b/yak-ops-ui/src/services/workflow/index.ts
@@ -60,6 +60,14 @@ export const runWorkflow = async (payload: WorkflowRunPayload) => {
   return response.data;
 };
 
+export const activateWorkflowInstance = async (executionId: string) => {
+  const response = await request<ApiResponse<WorkflowInstance>>(
+    `/api/v1/workflows/instances/${encodeURIComponent(executionId)}/activate`,
+    { method: 'POST' },
+  );
+  return response.data;
+};
+
 export const getWorkflowInstances = async () => {
   const response = await request<ApiResponse<WorkflowInstance[]>>(
     '/api/v1/workflows/instances',
@@ -74,26 +82,79 @@ export const getWorkflowInstance = async (executionId: string) => {
   return response.data;
 };
 
+const snapshotSignature = (instance: WorkflowInstance) =>
+  [
+    instance.status,
+    ...instance.nodes.map((node) => `${node.id}:${node.status}:${node.errorMessage || ''}`),
+  ].join('|');
+
+/**
+ * SSE 为主，短周期查询作为兜底。
+ *
+ * 原生 EventSource 无法复用 Umi request 的请求拦截器/自定义 Header，
+ * 因此保留 authenticated request 轮询，可避免 SSE 被代理或认证链路阻断时
+ * 画布只能看到最终状态。
+ */
 export const subscribeWorkflowEvents = (
   executionId: string,
   onSnapshot: (instance: WorkflowInstance) => void,
 ) => {
+  let closed = false;
+  let lastSignature = '';
+  let polling = false;
+
+  const deliver = (snapshot: WorkflowInstance) => {
+    if (closed) return;
+    const signature = snapshotSignature(snapshot);
+    if (signature === lastSignature) return;
+    lastSignature = signature;
+    onSnapshot(snapshot);
+    if (isWorkflowTerminal(snapshot.status)) {
+      cleanup();
+    }
+  };
+
   const source = new EventSource(
     `/api/v1/workflows/instances/${encodeURIComponent(executionId)}/events`,
   );
 
   const handleWorkflowEvent = (event: Event) => {
-    const snapshot = JSON.parse((event as MessageEvent<string>).data) as WorkflowInstance;
-    onSnapshot(snapshot);
-    if (isWorkflowTerminal(snapshot.status)) {
-      source.close();
+    try {
+      const snapshot = JSON.parse(
+        (event as MessageEvent<string>).data,
+      ) as WorkflowInstance;
+      deliver(snapshot);
+    } catch {
+      // 单次异常事件不关闭连接，继续等待后续快照。
     }
   };
 
   source.addEventListener('workflow', handleWorkflowEvent);
 
-  return () => {
+  const poll = async () => {
+    if (closed || polling) return;
+    polling = true;
+    try {
+      deliver(await getWorkflowInstance(executionId));
+    } catch {
+      // SSE 正常时无需把兜底查询异常暴露给页面。
+    } finally {
+      polling = false;
+    }
+  };
+
+  const timer = window.setInterval(() => {
+    void poll();
+  }, 500);
+
+  function cleanup() {
+    if (closed) return;
+    closed = true;
+    window.clearInterval(timer);
     source.removeEventListener('workflow', handleWorkflowEvent);
     source.close();
-  };
+  }
+
+  void poll();
+  return cleanup;
 };


### PR DESCRIPTION
## What changed

- Change workflow execution into a two-phase flow: create the execution first, then activate it after live status watching is attached.
- Add `POST /api/v1/workflows/instances/{executionId}/activate` as an idempotent activation endpoint.
- Queue node dispatches per execution so the first `RUNNING` transition is not lost before the browser subscribes.
- Keep SSE as the primary push channel, plus a 500ms authenticated status sync fallback for cases where native `EventSource` is affected by proxy/auth/header behavior.
- Serialize live snapshot publication per execution to avoid parallel branches publishing stale snapshots out of order.
- Keep random node execution duration at 1-10 seconds.
- Update the React Flow canvas so nodes visibly transition through execution states:
  - waiting / submitted: gray
  - running: brand red, pulse/loading animation
  - success: dark neutral completed state
  - failed/upstream failed: red error state
- Animate and recolor edges as execution advances through the DAG.
- Show live counts for running/success/failed/waiting nodes in the workflow header.
- Keep canvas editing locked while an execution is active.
- Add a runtime regression test that verifies a serial DAG is observed as `node1 RUNNING -> node1 SUCCESS + node2 RUNNING -> both SUCCESS` instead of jumping directly to the final state.

## Expected UX

Clicking Run now returns quickly. The page attaches live watching before activation, then the first node changes color immediately when it starts. After its random 1-10 second execution completes, it changes to success/failure and the next scheduled node changes to running. Parallel branches can enter running simultaneously; join nodes only change to running after their trigger conditions are satisfied by `yak-workflow-engine`.

## Why the extra polling fallback

`EventSource` is intentionally kept for real-time server push, but unlike the normal Umi `request` client it cannot automatically reuse custom request interceptors/headers. The lightweight 500ms authenticated sync prevents the UI from collapsing into a single final update when SSE is buffered or blocked by a local proxy/auth chain.

## Validation

- Branch is based on current `main`, including the Spring constructor wiring fix from PR #246.
- Added staged state assertions for a two-node serial workflow.
- No database schema changes and no changes to `yak-framework` are required.