### PR TITLE
test(workflow): simulate node failure and verify branch propagation

### DIFF
--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/model/WorkflowRunRequest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/model/WorkflowRunRequest.java
@@ -3,6 +3,7 @@ package io.yak.ops.business.workflow.model;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Pattern;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -21,7 +22,18 @@ public record WorkflowRunRequest(
   public record NodeRequest(
       @NotBlank String id,
       @NotBlank String name,
-      @NotBlank String type) {}
+      @NotBlank String type,
+      @Pattern(regexp = "SUCCESS|FAILED", message = "mockResult must be SUCCESS or FAILED")
+      String mockResult) {
+
+    public NodeRequest {
+      mockResult = mockResult == null || mockResult.isBlank() ? "SUCCESS" : mockResult;
+    }
+
+    public NodeRequest(String id, String name, String type) {
+      this(id, name, type, "SUCCESS");
+    }
+  }
 
   public record EdgeRequest(
       @NotBlank String source,

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowRuntimeService.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowRuntimeService.java
@@ -43,6 +43,8 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 public class WorkflowRuntimeService {
 
   private static final Logger log = LoggerFactory.getLogger(WorkflowRuntimeService.class);
+  private static final String MOCK_SUCCESS = "SUCCESS";
+  private static final String MOCK_FAILED = "FAILED";
 
   private final ExecutorService workerPool;
   private final DefaultWorkflowEngine engine;
@@ -170,7 +172,9 @@ public class WorkflowRuntimeService {
         TriggerRule.ALL_SUCCESS,
         RetryPolicy.none(),
         NodeFailurePolicy.FAIL_WORKFLOW,
-        Map.of("type", node.type()));
+        Map.of(
+            "type", node.type(),
+            "mockResult", node.mockResult()));
   }
 
   private EdgeDefinition toEdgeDefinition(EdgeRequest edge) {
@@ -213,13 +217,16 @@ public class WorkflowRuntimeService {
 
   private void executeNode(NodeDispatch dispatch) {
     String type = String.valueOf(dispatch.nodeConfiguration().getOrDefault("type", "TASK"));
+    String mockResult = String.valueOf(
+        dispatch.nodeConfiguration().getOrDefault("mockResult", MOCK_SUCCESS));
     long simulatedDurationMillis = Math.max(0L, delayMillisSupplier.getAsLong());
     log.info(
-        "[workflow] node start execution={}, node={}, type={}, attempt={}, simulatedDurationMs={}",
+        "[workflow] node start execution={}, node={}, type={}, attempt={}, mockResult={}, simulatedDurationMs={}",
         dispatch.workflowExecutionId(),
         dispatch.nodeId(),
         type,
         dispatch.attemptNumber(),
+        mockResult,
         simulatedDurationMillis);
     try {
       engine.acknowledgeNodeStarted(dispatch.workflowExecutionId(), dispatch.nodeId());
@@ -227,12 +234,29 @@ public class WorkflowRuntimeService {
 
       Thread.sleep(simulatedDurationMillis);
 
+      if (MOCK_FAILED.equalsIgnoreCase(mockResult)) {
+        String errorMessage = "Simulated node failure";
+        engine.failNode(
+            dispatch.workflowExecutionId(),
+            dispatch.nodeId(),
+            errorMessage);
+        publishCurrent(dispatch.workflowExecutionId());
+        log.warn(
+            "[workflow] node simulated failure execution={}, node={}, type={}, simulatedDurationMs={}",
+            dispatch.workflowExecutionId(),
+            dispatch.nodeId(),
+            type,
+            simulatedDurationMillis);
+        return;
+      }
+
       engine.completeNode(
           dispatch.workflowExecutionId(),
           dispatch.nodeId(),
           Map.of(
               "type", type,
               "message", "executed in memory",
+              "mockResult", MOCK_SUCCESS,
               "simulatedDurationMs", simulatedDurationMillis));
       publishCurrent(dispatch.workflowExecutionId());
       log.info(

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowRuntimeServiceTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowRuntimeServiceTest.java
@@ -63,6 +63,77 @@ class WorkflowRuntimeServiceTest {
     assertThat(completed.status()).isEqualTo("SUCCESS");
   }
 
+  @Test
+  void shouldBlockFailedBranchAndContinueIndependentBranch()
+      throws InterruptedException {
+    service = new WorkflowRuntimeService(
+        new WorkflowEventStreamService(),
+        () -> 20L);
+
+    WorkflowRunRequest request = new WorkflowRunRequest(
+        "failure-branch-demo",
+        List.of(
+            successNode("a"),
+            failedNode("b"),
+            successNode("c"),
+            successNode("d"),
+            successNode("e"),
+            successNode("f")),
+        List.of(
+            new EdgeRequest("a", "b"),
+            new EdgeRequest("b", "c"),
+            new EdgeRequest("c", "f"),
+            new EdgeRequest("a", "d"),
+            new EdgeRequest("d", "e")),
+        Map.of());
+
+    WorkflowInstanceVO started = service.run(request);
+    service.activate(started.id());
+    WorkflowInstanceVO completed = waitForTerminal(started.id());
+
+    assertThat(completed.status()).isEqualTo("FAILED");
+    assertThat(statusOf(completed, "a")).isEqualTo("SUCCESS");
+    assertThat(statusOf(completed, "b")).isEqualTo("FAILED");
+    assertThat(statusOf(completed, "c")).isEqualTo("UPSTREAM_FAILED");
+    assertThat(statusOf(completed, "f")).isEqualTo("UPSTREAM_FAILED");
+    assertThat(statusOf(completed, "d")).isEqualTo("SUCCESS");
+    assertThat(statusOf(completed, "e")).isEqualTo("SUCCESS");
+  }
+
+  @Test
+  void shouldBlockJoinWhenOneRequiredPredecessorFails()
+      throws InterruptedException {
+    service = new WorkflowRuntimeService(
+        new WorkflowEventStreamService(),
+        () -> 20L);
+
+    WorkflowRunRequest request = new WorkflowRunRequest(
+        "failed-join-demo",
+        List.of(
+            successNode("a"),
+            failedNode("b"),
+            successNode("d"),
+            successNode("e"),
+            successNode("join")),
+        List.of(
+            new EdgeRequest("a", "b"),
+            new EdgeRequest("a", "d"),
+            new EdgeRequest("d", "e"),
+            new EdgeRequest("b", "join"),
+            new EdgeRequest("e", "join")),
+        Map.of());
+
+    WorkflowInstanceVO started = service.run(request);
+    service.activate(started.id());
+    WorkflowInstanceVO completed = waitForTerminal(started.id());
+
+    assertThat(completed.status()).isEqualTo("FAILED");
+    assertThat(statusOf(completed, "b")).isEqualTo("FAILED");
+    assertThat(statusOf(completed, "d")).isEqualTo("SUCCESS");
+    assertThat(statusOf(completed, "e")).isEqualTo("SUCCESS");
+    assertThat(statusOf(completed, "join")).isEqualTo("UPSTREAM_FAILED");
+  }
+
   private WorkflowRunRequest simpleSerialWorkflow() {
     return new WorkflowRunRequest(
         "demo",
@@ -71,6 +142,14 @@ class WorkflowRuntimeServiceTest {
             new NodeRequest("check", "Check", "CHECK")),
         List.of(new EdgeRequest("extract", "check")),
         Map.of());
+  }
+
+  private NodeRequest successNode(String id) {
+    return new NodeRequest(id, id.toUpperCase(), "TASK", "SUCCESS");
+  }
+
+  private NodeRequest failedNode(String id) {
+    return new NodeRequest(id, id.toUpperCase(), "TASK", "FAILED");
   }
 
   private WorkflowInstanceVO waitForNodeStatus(
@@ -89,7 +168,7 @@ class WorkflowRuntimeServiceTest {
 
   private WorkflowInstanceVO waitForTerminal(String executionId)
       throws InterruptedException {
-    for (int attempt = 0; attempt < 200; attempt++) {
+    for (int attempt = 0; attempt < 300; attempt++) {
       WorkflowInstanceVO current = service.getInstance(executionId);
       if (!"RUNNING".equals(current.status()) && !"CREATED".equals(current.status())) {
         return current;

--- a/yak-ops-ui/src/pages/workflow/definition/index.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/index.tsx
@@ -4,8 +4,9 @@ import {
   runWorkflow,
   subscribeWorkflowEvents,
   type WorkflowInstance,
+  type WorkflowMockResult,
 } from '@/services/workflow';
-import { Button, Input, Popconfirm, message } from 'antd';
+import { Button, Input, Popconfirm, Segmented, message } from 'antd';
 import {
   Bell,
   CheckCircle2,
@@ -47,6 +48,7 @@ interface WorkflowNodeData {
   label: string;
   nodeType: string;
   typeLabel: string;
+  mockResult: WorkflowMockResult;
   executionStatus?: string;
 }
 
@@ -154,8 +156,15 @@ const WorkflowNode = ({ data, selected }: NodeProps<WorkflowNodeData>) => (
     />
 
     <div className="flex items-center justify-between gap-3">
-      <div className="text-[11px] font-medium text-[rgba(22,24,35,.45)]">
-        {data.typeLabel}
+      <div className="flex items-center gap-1.5">
+        <span className="text-[11px] font-medium text-[rgba(22,24,35,.45)]">
+          {data.typeLabel}
+        </span>
+        {data.mockResult === 'FAILED' ? (
+          <span className="rounded bg-[#fff0f0] px-1.5 py-0.5 text-[9px] font-medium text-[#d92d20]">
+            模拟失败
+          </span>
+        ) : null}
       </div>
       {data.executionStatus ? (
         <span className="flex items-center gap-1 text-[10px]">
@@ -200,6 +209,10 @@ const WorkflowDefinitionContent = () => {
   const nodeTypes = useMemo(() => ({ workflow: WorkflowNode }), []);
   const workflowRunning = Boolean(
     activeInstance && !isWorkflowTerminal(activeInstance.status),
+  );
+  const selectedNode = useMemo(
+    () => nodes.find((node) => node.selected),
+    [nodes],
   );
 
   useEffect(() => () => closeStreamRef.current?.(), []);
@@ -314,9 +327,25 @@ const WorkflowDefinitionContent = () => {
           label: `${template.label} ${sequence}`,
           nodeType: template.type,
           typeLabel: template.label,
+          mockResult: 'SUCCESS',
         },
       },
     ]);
+  };
+
+  const updateSelectedMockResult = (mockResult: WorkflowMockResult) => {
+    if (!selectedNode || workflowRunning) return;
+    setNodes((current) => current.map((node) =>
+      node.id === selectedNode.id
+        ? {
+            ...node,
+            data: {
+              ...node.data,
+              mockResult,
+            },
+          }
+        : node,
+    ));
   };
 
   const resetExecutionVisuals = () => {
@@ -355,6 +384,7 @@ const WorkflowDefinitionContent = () => {
           id: node.id,
           name: node.data.label,
           type: node.data.nodeType,
+          mockResult: node.data.mockResult,
         })),
         edges: edges.map((edge: Edge) => ({
           source: edge.source,
@@ -512,7 +542,39 @@ const WorkflowDefinitionContent = () => {
           </div>
         </div>
 
-        <div ref={wrapperRef} className="min-h-0 flex-1" onDrop={handleDrop}>
+        <div
+          ref={wrapperRef}
+          className="relative min-h-0 flex-1"
+          onDrop={handleDrop}
+        >
+          {selectedNode && !workflowRunning ? (
+            <div className="absolute right-4 top-4 z-20 w-[250px] rounded-lg border border-[#e3e5e8] bg-white p-3 shadow-md">
+              <div className="text-[12px] font-semibold text-[#161823]">节点测试</div>
+              <div className="mt-1 truncate text-[11px] text-[rgba(22,24,35,.48)]">
+                {selectedNode.data.label}
+              </div>
+              <div className="mt-3 text-[11px] font-medium text-[rgba(22,24,35,.62)]">
+                本次模拟结果
+              </div>
+              <Segmented
+                block
+                size="small"
+                className="mt-2"
+                value={selectedNode.data.mockResult}
+                options={[
+                  { label: '正常成功', value: 'SUCCESS' },
+                  { label: '模拟失败', value: 'FAILED' },
+                ]}
+                onChange={(value) =>
+                  updateSelectedMockResult(value as WorkflowMockResult)
+                }
+              />
+              <div className="mt-2 text-[10px] leading-4 text-[rgba(22,24,35,.4)]">
+                仅用于内存工作流测试。模拟失败会真实触发引擎的失败传播逻辑。
+              </div>
+            </div>
+          ) : null}
+
           <ReactFlow
             nodes={nodes}
             edges={edges}

--- a/yak-ops-ui/src/services/workflow/index.ts
+++ b/yak-ops-ui/src/services/workflow/index.ts
@@ -1,10 +1,13 @@
 import { request } from '@umijs/max';
 import type { ApiResponse } from '@/services/http/response';
 
+export type WorkflowMockResult = 'SUCCESS' | 'FAILED';
+
 export interface WorkflowNodePayload {
   id: string;
   name: string;
   type: string;
+  mockResult?: WorkflowMockResult;
 }
 
 export interface WorkflowEdgePayload {


### PR DESCRIPTION
## What changed

- Add deterministic per-node mock execution result to the in-memory workflow MVP: `SUCCESS` or `FAILED`.
- Keep the default behavior as success, so existing graphs behave exactly as before.
- Pass `mockResult` into `NodeDefinition.configuration` and make the local worker call the real `yak-workflow-engine` `failNode(...)` path when a node is configured to fail.
- Preserve `WorkflowFailureStrategy.CONTINUE_INDEPENDENT_BRANCHES`, so only dependent branches are blocked while unrelated branches continue.
- Add frontend test interaction on the React Flow canvas:
  - click/select a node
  - use the lightweight top-right `节点测试` panel
  - choose `正常成功` or `模拟失败`
  - nodes configured to fail show a small `模拟失败` marker before execution
- Keep live SSE/polling visualization unchanged, so the configured node still transitions `WAITING/SUBMITTED -> RUNNING -> FAILED`, and its downstream nodes transition to `UPSTREAM_FAILED` in real time.

## Regression coverage

Adds two failure-propagation tests:

1. **Failed branch + independent branch**
   - `A -> B(fail) -> C -> F`
   - `A -> D -> E`
   - expected: `A/D/E = SUCCESS`, `B = FAILED`, `C/F = UPSTREAM_FAILED`, workflow = `FAILED`.

2. **Join with one failed predecessor**
   - `A -> B(fail) -> JOIN`
   - `A -> D -> E -> JOIN`
   - `JOIN` uses the existing `ALL_SUCCESS` trigger.
   - expected: `D/E` still finish successfully, but `JOIN = UPSTREAM_FAILED` and never runs.

## Why this matches the framework

`yak-workflow-engine` already defines `CONTINUE_INDEPENDENT_BRANCHES` as continuing independent branches while blocking branches whose trigger conditions cannot be satisfied. `DefaultWorkflowScheduler` marks those blocked nodes as `UPSTREAM_FAILED`, so Yak Ops only needs a deterministic way to trigger the real failure path for testing.

## Scope

- No database changes.
- No `yak-framework` changes.
- This remains an explicit test/simulation feature for the current in-memory workflow MVP, not random production failure injection.