### PR TITLE
feat(workflow): add retry-current recovery for failed nodes

### DIFF
--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/controller/v1/WorkflowController.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/controller/v1/WorkflowController.java
@@ -51,6 +51,14 @@ public class WorkflowController {
     return Result.success(workflowRuntimeService.continueAfterFailure(executionId, nodeId));
   }
 
+  @Operation(summary = "重新执行当前失败节点")
+  @PostMapping("/instances/{executionId}/nodes/{nodeId}/retry")
+  public Result<WorkflowInstanceVO> retryFailedNode(
+      @PathVariable("executionId") String executionId,
+      @PathVariable("nodeId") String nodeId) {
+    return Result.success(workflowRuntimeService.retryFailedNode(executionId, nodeId));
+  }
+
   @Operation(summary = "查询工作流实例")
   @GetMapping("/instances")
   public Result<List<WorkflowInstanceVO>> instances() {

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowRuntimeService.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowRuntimeService.java
@@ -54,6 +54,7 @@ public class WorkflowRuntimeService {
       new ConcurrentHashMap<>();
   private final ConcurrentMap<String, Object> publishLocks = new ConcurrentHashMap<>();
   private final Set<String> activeExecutions = ConcurrentHashMap.newKeySet();
+  private final Set<String> manualRetrySuccessNodes = ConcurrentHashMap.newKeySet();
   private final Map<String, RunMetadata> metadata = new ConcurrentHashMap<>();
   private final ConcurrentLinkedDeque<String> executionOrder = new ConcurrentLinkedDeque<>();
 
@@ -123,20 +124,38 @@ public class WorkflowRuntimeService {
   }
 
   public WorkflowInstanceVO continueAfterFailure(String executionId, String nodeId) {
-    RunMetadata runMetadata = metadata.get(executionId);
-    if (runMetadata == null) {
-      throw new IllegalArgumentException("Workflow execution metadata not found: " + executionId);
-    }
-
+    RunMetadata runMetadata = requireMetadata(executionId);
     WorkflowExecution execution = engine.continueAfterFailure(executionId, nodeId);
     WorkflowInstanceVO snapshot = toView(execution, runMetadata);
     eventStreamService.publish(snapshot);
+    reactivateExecution(executionId);
     log.info(
         "[workflow] manual continue execution={}, failedNode={}, status={}",
         executionId,
         nodeId,
         snapshot.status());
     return snapshot;
+  }
+
+  public WorkflowInstanceVO retryFailedNode(String executionId, String nodeId) {
+    RunMetadata runMetadata = requireMetadata(executionId);
+    String retryKey = retryKey(executionId, nodeId);
+    manualRetrySuccessNodes.add(retryKey);
+    try {
+      WorkflowExecution execution = engine.retryFailedNode(executionId, nodeId);
+      WorkflowInstanceVO snapshot = toView(execution, runMetadata);
+      eventStreamService.publish(snapshot);
+      reactivateExecution(executionId);
+      log.info(
+          "[workflow] manual retry execution={}, failedNode={}, status={}",
+          executionId,
+          nodeId,
+          snapshot.status());
+      return snapshot;
+    } catch (RuntimeException exception) {
+      manualRetrySuccessNodes.remove(retryKey);
+      throw exception;
+    }
   }
 
   public List<WorkflowInstanceVO> listInstances() {
@@ -154,12 +173,9 @@ public class WorkflowRuntimeService {
   }
 
   public WorkflowInstanceVO getInstance(String executionId) {
-    RunMetadata runMetadata = metadata.get(executionId);
+    RunMetadata runMetadata = requireMetadata(executionId);
     WorkflowExecution execution = engine.findExecution(executionId)
         .orElseThrow(() -> new IllegalArgumentException("Workflow execution not found: " + executionId));
-    if (runMetadata == null) {
-      throw new IllegalArgumentException("Workflow execution metadata not found: " + executionId);
-    }
     return toView(execution, runMetadata);
   }
 
@@ -174,12 +190,26 @@ public class WorkflowRuntimeService {
   }
 
   void activateExecution(String executionId) {
-    // 先校验实例存在，避免把不存在的 executionId 放进 active 集合。
     getInstance(executionId);
     if (activeExecutions.add(executionId)) {
       log.info("[workflow] activated execution={}", executionId);
     }
     drainDispatches(executionId);
+  }
+
+  private void reactivateExecution(String executionId) {
+    if (activeExecutions.add(executionId)) {
+      log.info("[workflow] reactivated execution={}", executionId);
+    }
+    drainDispatches(executionId);
+  }
+
+  private RunMetadata requireMetadata(String executionId) {
+    RunMetadata runMetadata = metadata.get(executionId);
+    if (runMetadata == null) {
+      throw new IllegalArgumentException("Workflow execution metadata not found: " + executionId);
+    }
+    return runMetadata;
   }
 
   private NodeDefinition toNodeDefinition(NodeRequest node) {
@@ -229,21 +259,25 @@ public class WorkflowRuntimeService {
       NodeDispatch current = dispatch;
       workerPool.execute(() -> executeNode(current));
     }
-    // 空队列保留到工作流终态再清理，避免并发 enqueue 与 remove 导致 dispatch 丢失。
   }
 
   private void executeNode(NodeDispatch dispatch) {
     String type = String.valueOf(dispatch.nodeConfiguration().getOrDefault("type", "TASK"));
-    String mockResult = String.valueOf(
+    String configuredMockResult = String.valueOf(
         dispatch.nodeConfiguration().getOrDefault("mockResult", MOCK_SUCCESS));
+    boolean manualRetrySuccess = dispatch.attemptNumber() > 1
+        && manualRetrySuccessNodes.remove(
+            retryKey(dispatch.workflowExecutionId(), dispatch.nodeId()));
+    String mockResult = manualRetrySuccess ? MOCK_SUCCESS : configuredMockResult;
     long simulatedDurationMillis = Math.max(0L, delayMillisSupplier.getAsLong());
     log.info(
-        "[workflow] node start execution={}, node={}, type={}, attempt={}, mockResult={}, simulatedDurationMs={}",
+        "[workflow] node start execution={}, node={}, type={}, attempt={}, mockResult={}, manualRetry={}, simulatedDurationMs={}",
         dispatch.workflowExecutionId(),
         dispatch.nodeId(),
         type,
         dispatch.attemptNumber(),
         mockResult,
+        manualRetrySuccess,
         simulatedDurationMillis);
     try {
       engine.acknowledgeNodeStarted(dispatch.workflowExecutionId(), dispatch.nodeId());
@@ -272,15 +306,18 @@ public class WorkflowRuntimeService {
           dispatch.nodeId(),
           Map.of(
               "type", type,
-              "message", "executed in memory",
+              "message", manualRetrySuccess
+                  ? "manually retried in memory"
+                  : "executed in memory",
               "mockResult", MOCK_SUCCESS,
               "simulatedDurationMs", simulatedDurationMillis));
       publishCurrent(dispatch.workflowExecutionId());
       log.info(
-          "[workflow] node success execution={}, node={}, type={}, simulatedDurationMs={}",
+          "[workflow] node success execution={}, node={}, type={}, manualRetry={}, simulatedDurationMs={}",
           dispatch.workflowExecutionId(),
           dispatch.nodeId(),
           type,
+          manualRetrySuccess,
           simulatedDurationMillis);
     } catch (InterruptedException exception) {
       Thread.currentThread().interrupt();
@@ -346,6 +383,10 @@ public class WorkflowRuntimeService {
         || "FAILED".equals(status)
         || "WARNING".equals(status)
         || "CANCELED".equals(status);
+  }
+
+  private String retryKey(String executionId, String nodeId) {
+    return executionId + "::" + nodeId;
   }
 
   private WorkflowInstanceVO toView(WorkflowExecution execution, RunMetadata runMetadata) {

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowRuntimeServiceTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowRuntimeServiceTest.java
@@ -86,6 +86,40 @@ class WorkflowRuntimeServiceTest {
   }
 
   @Test
+  void shouldRetryCurrentFailedNodeThenContinueItsDescendants()
+      throws InterruptedException {
+    service = new WorkflowRuntimeService(
+        new WorkflowEventStreamService(),
+        () -> 40L);
+
+    WorkflowInstanceVO started = service.run(failureBranchWorkflow());
+    service.activate(started.id());
+    WorkflowInstanceVO failed = waitForTerminal(started.id());
+
+    assertThat(failed.status()).isEqualTo("FAILED");
+    assertThat(statusOf(failed, "b")).isEqualTo("FAILED");
+    assertThat(statusOf(failed, "c")).isEqualTo("UPSTREAM_FAILED");
+    assertThat(statusOf(failed, "f")).isEqualTo("UPSTREAM_FAILED");
+
+    WorkflowInstanceVO retried = service.retryFailedNode(started.id(), "b");
+    assertThat(retried.status()).isEqualTo("RUNNING");
+    assertThat(statusOf(retried, "b")).isEqualTo("SUBMITTED");
+    assertThat(statusOf(retried, "c")).isEqualTo("WAITING");
+    assertThat(statusOf(retried, "f")).isEqualTo("WAITING");
+
+    WorkflowInstanceVO retryRunning = waitForNodeStatus(started.id(), "b", "RUNNING");
+    assertThat(statusOf(retryRunning, "c")).isEqualTo("WAITING");
+
+    WorkflowInstanceVO completed = waitForTerminal(started.id());
+    assertThat(completed.status()).isEqualTo("SUCCESS");
+    assertThat(statusOf(completed, "b")).isEqualTo("SUCCESS");
+    assertThat(statusOf(completed, "c")).isEqualTo("SUCCESS");
+    assertThat(statusOf(completed, "f")).isEqualTo("SUCCESS");
+    assertThat(statusOf(completed, "d")).isEqualTo("SUCCESS");
+    assertThat(statusOf(completed, "e")).isEqualTo("SUCCESS");
+  }
+
+  @Test
   void shouldContinueBlockedDescendantsWithoutRetryingFailedNode()
       throws InterruptedException {
     service = new WorkflowRuntimeService(
@@ -107,8 +141,6 @@ class WorkflowRuntimeServiceTest {
     assertThat(statusOf(continued, "c")).isEqualTo("SUBMITTED");
     assertThat(statusOf(continued, "f")).isEqualTo("WAITING");
 
-    // 实际页面重新建立 SSE 后会激活积压的 dispatch；测试中直接调用 activate 模拟该过程。
-    service.activate(started.id());
     WorkflowInstanceVO completed = waitForTerminal(started.id());
 
     assertThat(completed.status()).isEqualTo("SUCCESS_WITH_WARNINGS");

--- a/yak-ops-ui/src/pages/workflow/definition/index.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/index.tsx
@@ -2,6 +2,7 @@ import {
   activateWorkflowInstance,
   continueWorkflowAfterFailure,
   isWorkflowTerminal,
+  retryWorkflowFailedNode,
   runWorkflow,
   subscribeWorkflowEvents,
   type WorkflowInstance,
@@ -18,6 +19,7 @@ import {
   Database,
   LoaderCircle,
   Play,
+  RefreshCw,
   RotateCcw,
   ShieldCheck,
   XCircle,
@@ -237,7 +239,7 @@ const WorkflowDefinitionContent = () => {
   const [submitting, setSubmitting] = useState(false);
   const [activeInstance, setActiveInstance] = useState<WorkflowInstance>();
   const [contextMenu, setContextMenu] = useState<NodeContextMenuState>();
-  const [continuingNodeId, setContinuingNodeId] = useState<string>();
+  const [recoveringNodeId, setRecoveringNodeId] = useState<string>();
 
   const nodeTypes = useMemo(() => ({ workflow: WorkflowNode }), []);
   const workflowRunning = Boolean(
@@ -457,12 +459,55 @@ const WorkflowDefinitionContent = () => {
     }
   };
 
-  const handleContinueAfterFailure = async (nodeId: string) => {
-    if (!activeInstance || continuingNodeId) return;
+  const restartStreamIfNeeded = (
+    executionId: string,
+    previousStatus: string,
+    snapshot: WorkflowInstance,
+  ) => {
+    if (isWorkflowTerminal(previousStatus) && !isWorkflowTerminal(snapshot.status)) {
+      closeStreamRef.current?.();
+      closeStreamRef.current = subscribeWorkflowEvents(executionId, applySnapshot);
+    }
+  };
+
+  const handleRetryFailedNode = async (nodeId: string) => {
+    if (!activeInstance || recoveringNodeId) return;
 
     const executionId = activeInstance.id;
-    const streamNeedsRestart = isWorkflowTerminal(activeInstance.status);
-    setContinuingNodeId(nodeId);
+    const previousStatus = activeInstance.status;
+    setRecoveringNodeId(nodeId);
+    setContextMenu(undefined);
+
+    try {
+      const retried = await retryWorkflowFailedNode(executionId, nodeId);
+      continuedFailureNodeIdsRef.current.delete(nodeId);
+      setNodes((current) => current.map((node) =>
+        node.id === nodeId
+          ? {
+              ...node,
+              data: {
+                ...node.data,
+                continuedAfterFailure: false,
+              },
+            }
+          : node,
+      ));
+      applySnapshot(retried);
+      restartStreamIfNeeded(executionId, previousStatus, retried);
+      message.success('已从当前失败节点重新执行，成功后将继续调度后续节点');
+    } catch (error) {
+      message.error(error instanceof Error ? error.message : '重新执行当前节点失败');
+    } finally {
+      setRecoveringNodeId(undefined);
+    }
+  };
+
+  const handleContinueAfterFailure = async (nodeId: string) => {
+    if (!activeInstance || recoveringNodeId) return;
+
+    const executionId = activeInstance.id;
+    const previousStatus = activeInstance.status;
+    setRecoveringNodeId(nodeId);
     setContextMenu(undefined);
 
     try {
@@ -480,17 +525,12 @@ const WorkflowDefinitionContent = () => {
           : node,
       ));
       applySnapshot(continued);
-
-      if (streamNeedsRestart && !isWorkflowTerminal(continued.status)) {
-        closeStreamRef.current?.();
-        closeStreamRef.current = subscribeWorkflowEvents(executionId, applySnapshot);
-      }
-
-      message.success('已保留当前失败结果，并继续调度后续可执行节点');
+      restartStreamIfNeeded(executionId, previousStatus, continued);
+      message.success('已保留当前失败结果，并从下一个可执行节点继续');
     } catch (error) {
       message.error(error instanceof Error ? error.message : '继续执行失败');
     } finally {
-      setContinuingNodeId(undefined);
+      setRecoveringNodeId(undefined);
     }
   };
 
@@ -667,22 +707,38 @@ const WorkflowDefinitionContent = () => {
 
           {contextMenu ? (
             <div
-              className="absolute z-30 w-[220px] rounded-lg border border-[#e1e4e8] bg-white p-1.5 shadow-lg"
+              className="absolute z-30 w-[248px] rounded-lg border border-[#e1e4e8] bg-white p-1.5 shadow-lg"
               style={{ left: contextMenu.x, top: contextMenu.y }}
               onMouseDown={(event) => event.stopPropagation()}
             >
               <Button
                 type="text"
                 block
+                icon={<RefreshCw size={14} />}
+                loading={recoveringNodeId === contextMenu.nodeId}
+                className="!flex !h-8 !items-center !justify-start !px-2 !text-[12px]"
+                onClick={() => void handleRetryFailedNode(contextMenu.nodeId)}
+              >
+                重新执行当前节点
+              </Button>
+              <div className="px-2 pb-1 text-[10px] leading-4 text-[rgba(22,24,35,.42)]">
+                当前节点重新执行，成功后再继续后续节点。
+              </div>
+
+              <div className="mx-2 my-1 border-t border-[#f0f0f1]" />
+
+              <Button
+                type="text"
+                block
                 icon={<ArrowRightCircle size={14} />}
-                loading={continuingNodeId === contextMenu.nodeId}
+                disabled={Boolean(recoveringNodeId)}
                 className="!flex !h-8 !items-center !justify-start !px-2 !text-[12px]"
                 onClick={() => void handleContinueAfterFailure(contextMenu.nodeId)}
               >
-                继续执行后续节点
+                跳过当前失败，继续后续节点
               </Button>
-              <div className="px-2 pb-1 pt-0.5 text-[10px] leading-4 text-[rgba(22,24,35,.42)]">
-                保留当前失败结果，仅解除受它影响的后继阻断。
+              <div className="px-2 pb-1 text-[10px] leading-4 text-[rgba(22,24,35,.42)]">
+                保留当前失败结果，直接解除受它影响的后继阻断。
               </div>
             </div>
           ) : null}
@@ -711,8 +767,8 @@ const WorkflowDefinitionContent = () => {
               }
 
               const bounds = wrapperRef.current.getBoundingClientRect();
-              const menuWidth = 220;
-              const menuHeight = 72;
+              const menuWidth = 248;
+              const menuHeight = 142;
               setContextMenu({
                 nodeId: node.id,
                 x: Math.max(

--- a/yak-ops-ui/src/services/workflow/index.ts
+++ b/yak-ops-ui/src/services/workflow/index.ts
@@ -83,6 +83,17 @@ export const continueWorkflowAfterFailure = async (
   return response.data;
 };
 
+export const retryWorkflowFailedNode = async (
+  executionId: string,
+  nodeId: string,
+) => {
+  const response = await request<ApiResponse<WorkflowInstance>>(
+    `/api/v1/workflows/instances/${encodeURIComponent(executionId)}/nodes/${encodeURIComponent(nodeId)}/retry`,
+    { method: 'POST' },
+  );
+  return response.data;
+};
+
 export const getWorkflowInstances = async () => {
   const response = await request<ApiResponse<WorkflowInstance[]>>(
     '/api/v1/workflows/instances',


### PR DESCRIPTION
## What changed

### Two right-click recovery choices

A real `FAILED` React Flow node now exposes two distinct actions:

1. **重新执行当前节点**
   - retry the failed node in the same workflow execution
   - the node transitions through `SUBMITTED/RUNNING/SUCCESS` again
   - previously blocked descendants return to `WAITING`
   - downstream only continues after this retry succeeds

2. **跳过当前失败，继续后续节点**
   - keep the current node `FAILED`
   - keep the existing `已放行` marker
   - directly release downstream scheduling without rerunning the failed node

### Backend/API

- Add `POST /api/v1/workflows/instances/{executionId}/nodes/{nodeId}/retry`.
- Use the new framework `retryFailedNode(...)` API instead of retrying the whole workflow.
- Re-activate the in-memory worker automatically for both retry and continue recovery after a workflow already reached a terminal state.
- Fix the previous recovery path so callers no longer need an extra `activate()` to consume newly queued dispatches.

### In-memory test behavior

A node configured as `mockResult=FAILED` would otherwise fail forever on every retry. For this current in-memory MVP, an explicit manual retry gets a one-time simulated success while preserving the original node configuration. Re-running the whole workflow later still reproduces the configured failure.

### Regression coverage

- Verify a failed node and its downstream become blocked while an independent branch succeeds.
- Retry only the failed node and verify it enters `RUNNING` again.
- Verify its blocked descendants stay waiting until the retry succeeds, then execute normally.
- Verify the independent successful branch is not rerun.
- Verify final workflow status becomes `SUCCESS` when the retry path succeeds.
- Keep coverage for the existing skip/continue path, which still finishes `SUCCESS_WITH_WARNINGS` and preserves the original `FAILED` node.

## Dependency

Depends on Yak Framework Draft PR #84:
https://github.com/weifuwan/yak-framework/pull/84

No database changes.