### PR TITLE
fix(workflow): only expose online sync tasks with scheduling paused

### DIFF
--- a/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/task/InMemoryTaskRegistry.java
+++ b/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/task/InMemoryTaskRegistry.java
@@ -23,6 +23,8 @@ import org.springframework.stereotype.Service;
 public class InMemoryTaskRegistry implements TaskRegistry {
 
   private static final int PAGE_SIZE = 200;
+  private static final String RELEASE_STATE_ONLINE = "ONLINE";
+  private static final String SCHEDULE_STATUS_PAUSED = "PAUSED";
 
   private final ObjectProvider<OfflineJobDefinitionService> definitionServiceProvider;
   private final ConcurrentMap<String, TaskDefinition> tasks = new ConcurrentHashMap<>();
@@ -68,7 +70,7 @@ public class InMemoryTaskRegistry implements TaskRegistry {
       query.setPageSize(PAGE_SIZE);
       PagingData<OfflineJobDefinitionVO> page = service.page(query);
       for (OfflineJobDefinitionVO definition : page.getBizData()) {
-        if (definition.getId() == null || definition.getJobName() == null) {
+        if (!isWorkflowEligible(definition)) {
           continue;
         }
         try {
@@ -87,5 +89,13 @@ public class InMemoryTaskRegistry implements TaskRegistry {
 
     tasks.clear();
     tasks.putAll(snapshot);
+  }
+
+  static boolean isWorkflowEligible(OfflineJobDefinitionVO definition) {
+    return definition != null
+        && definition.getId() != null
+        && definition.getJobName() != null
+        && RELEASE_STATE_ONLINE.equalsIgnoreCase(definition.getReleaseState())
+        && SCHEDULE_STATUS_PAUSED.equalsIgnoreCase(definition.getScheduleStatus());
   }
 }

--- a/yak-ops-business/yak-ops-business-job/src/test/java/io/yak/ops/business/job/task/InMemoryTaskRegistryTest.java
+++ b/yak-ops-business/yak-ops-business-job/src/test/java/io/yak/ops/business/job/task/InMemoryTaskRegistryTest.java
@@ -1,0 +1,37 @@
+package io.yak.ops.business.job.task;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.yak.ops.common.bean.vo.sync.offline.OfflineJobDefinitionVO;
+import org.junit.jupiter.api.Test;
+
+class InMemoryTaskRegistryTest {
+
+  @Test
+  void shouldOnlyExposeOnlineTasksWithSchedulePaused() {
+    assertThat(InMemoryTaskRegistry.isWorkflowEligible(task("ONLINE", "PAUSED"))).isTrue();
+
+    assertThat(InMemoryTaskRegistry.isWorkflowEligible(task("OFFLINE", "PAUSED"))).isFalse();
+    assertThat(InMemoryTaskRegistry.isWorkflowEligible(task("ONLINE", "NORMAL"))).isFalse();
+  }
+
+  @Test
+  void shouldRejectIncompleteTaskMetadata() {
+    assertThat(InMemoryTaskRegistry.isWorkflowEligible(null)).isFalse();
+    assertThat(InMemoryTaskRegistry.isWorkflowEligible(
+        OfflineJobDefinitionVO.builder()
+            .jobName("未完成任务")
+            .releaseState("ONLINE")
+            .scheduleStatus("PAUSED")
+            .build())).isFalse();
+  }
+
+  private OfflineJobDefinitionVO task(String releaseState, String scheduleStatus) {
+    return OfflineJobDefinitionVO.builder()
+        .id(1001L)
+        .jobName("用户数据同步")
+        .releaseState(releaseState)
+        .scheduleStatus(scheduleStatus)
+        .build();
+  }
+}


### PR DESCRIPTION
## Summary

Tighten the workflow task registry so the left-side task list only exposes sync tasks that are safe for workflow orchestration.

A sync task is now visible to Workflow only when:

- `releaseState = ONLINE`
- `scheduleStatus = PAUSED`
- the task still has a valid executable JobSpec

This prevents offline tasks and tasks already driven by their own scheduler from being selected in Workflow.

## Scope

- update `InMemoryTaskRegistry` eligibility filtering
- add focused unit coverage for `ONLINE + PAUSED`, `OFFLINE + PAUSED`, and `ONLINE + NORMAL`
- no changes to sync task scheduling, workflow engine semantics, or frontend code

## Validation

Added `InMemoryTaskRegistryTest` covering the new visibility rule. The repository currently does not expose PR CI checks through GitHub Actions, so this PR includes code-level/static validation rather than a reported CI pass.