### PR TITLE
fix(workflow): persist sync startup failures and surface node errors

### DIFF
--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/service/OfflineExecutionOrchestratorTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/service/OfflineExecutionOrchestratorTest.java
@@ -1,1 +1,0 @@
-package io.yak.ops.business.sync.offline.service;

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/service/OfflineExecutionOrchestratorTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/service/OfflineExecutionOrchestratorTest.java
@@ -1,0 +1,1 @@
+package io.yak.ops.business.sync.offline.service;

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/LinkUpClient.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/LinkUpClient.java
@@ -73,7 +73,7 @@ public class LinkUpClient {
                     write(body),
                     StandardCharsets.UTF_8))
             .build();
-    return send(request, LinkUpJobResponse.class);
+    return send(request, LinkUpJobResponse.class, true);
   }
 
   public LinkUpJobResponse getJob(String id) {
@@ -94,7 +94,7 @@ public class LinkUpClient {
             .header("Accept", "application/json")
             .DELETE()
             .build();
-    return send(request, LinkUpJobResponse.class);
+    return send(request, LinkUpJobResponse.class, true);
   }
 
   public JsonNode pipelines(String id) {
@@ -143,10 +143,13 @@ public class LinkUpClient {
             .header("Accept", "application/json")
             .GET()
             .build();
-    return send(request, type);
+    return send(request, type, false);
   }
 
-  private <T> T send(HttpRequest request, Class<T> type) {
+  private <T> T send(
+      HttpRequest request,
+      Class<T> type,
+      boolean uncertainOnTransportFailure) {
     try {
       HttpResponse<String> response =
           httpClient.send(
@@ -167,10 +170,13 @@ public class LinkUpClient {
           exception,
           false);
     } catch (IOException exception) {
+      String message = uncertainOnTransportFailure
+          ? "无法确认 Link-Up 是否已接收请求：" + baseUrl()
+          : "无法连接 Link-Up Server：" + baseUrl();
       throw new LinkUpTransportException(
-          "无法确认 Link-Up 是否已接收请求：" + baseUrl(),
+          message,
           exception,
-          true);
+          uncertainOnTransportFailure);
     }
   }
 

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineExecutionClaimService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineExecutionClaimService.java
@@ -4,8 +4,6 @@ import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
 import io.yak.ops.business.sync.offline.config.OfflineSyncProperties;
 import io.yak.ops.business.sync.offline.dao.OfflineJobExecutionDao;
 import io.yak.ops.business.sync.offline.domain.OfflineExecutionStatus;
-import io.yak.ops.business.sync.offline.engine.LinkUpClient;
-import io.yak.ops.business.sync.offline.engine.LinkUpClient.LinkUpNodeResponse;
 import io.yak.ops.business.sync.offline.repository.OfflineExecutionControlRepository;
 import io.yak.ops.common.bean.po.sync.offline.OfflineJobDefinitionPO;
 import io.yak.ops.common.bean.po.sync.offline.OfflineJobExecutionPO;
@@ -19,19 +17,19 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class OfflineExecutionClaimService {
   private final OfflineJobDefinitionService definitionService; private final OfflineJobExecutionDao executionDao;
-  private final OfflineExecutionControlRepository repository; private final LinkUpClient linkUpClient; private final OfflineSyncProperties properties;
+  private final OfflineExecutionControlRepository repository; private final OfflineSyncProperties properties;
   public OfflineExecutionClaimService(OfflineJobDefinitionService definitionService,OfflineJobExecutionDao executionDao,
-      OfflineExecutionControlRepository repository,LinkUpClient linkUpClient,OfflineSyncProperties properties){this.definitionService=definitionService;this.executionDao=executionDao;this.repository=repository;this.linkUpClient=linkUpClient;this.properties=properties;}
+      OfflineExecutionControlRepository repository,OfflineSyncProperties properties){this.definitionService=definitionService;this.executionDao=executionDao;this.repository=repository;this.properties=properties;}
 
   @Transactional(transactionManager="offlineSyncTransactionManager",rollbackFor=Exception.class)
   public ClaimResult claim(Long definitionId,String triggerType,Long retryFromExecutionId,int attemptNo){
     repository.lockDefinition(definitionId);OfflineJobDefinitionPO d=definitionService.require(definitionId);
     if(!"ONLINE".equalsIgnoreCase(d.getReleaseState()))throw new IllegalStateException("请先上线任务，再执行运行操作");
     if(repository.hasActiveExecution(definitionId))throw new IllegalStateException("任务已有运行中的执行实例，不能重复提交");
-    String logical=definitionService.resolveLogicalJobSpec(d);LinkUpNodeResponse node=linkUpClient.node();
+    String logical=definitionService.resolveLogicalJobSpec(d);
     LocalDateTime now=LocalDateTime.now();OfflineJobExecutionPO e=new OfflineJobExecutionPO();
     e.setJobDefinitionId(definitionId);e.setDefinitionVersion(Math.max(1,d.getVersion()==null?1:d.getVersion()));e.setEngineBaseUrl(properties.getEngine().getBaseUrl());
-    e.setWorkerInstanceId(node.getInstanceId());e.setExternalExecutionId("yak-offline-"+UUID.randomUUID());e.setIdempotencyKey(UUID.randomUUID().toString());e.setStatus(OfflineExecutionStatus.CREATED.name());e.setStateVersion(1L);e.setAttemptNo(Math.max(1,attemptNo));
+    e.setExternalExecutionId("yak-offline-"+UUID.randomUUID());e.setIdempotencyKey(UUID.randomUUID().toString());e.setStatus(OfflineExecutionStatus.CREATED.name());e.setStateVersion(1L);e.setAttemptNo(Math.max(1,attemptNo));
     e.setTriggerType(triggerType);e.setRetryFromExecutionId(retryFromExecutionId);e.setCancellationRequested(false);e.setRetryCreated(false);
     e.setConfigDigest(d.getConfigDigest());e.setDefinitionSnapshotJson(d.getDefinitionJson());e.setSubmittedConfig(logical);
     e.setSourceRecordCount(0L);e.setSinkSuccessRecordCount(0L);e.setSourceReadBytes(0L);e.setSinkWrittenBytes(0L);e.setQps(0D);e.setDurationMillis(0L);e.setCreateTime(now);e.setUpdateTime(now);

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineExecutionOrchestrator.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineExecutionOrchestrator.java
@@ -10,6 +10,7 @@ import io.yak.ops.business.sync.offline.dao.OfflineJobExecutionDao;
 import io.yak.ops.business.sync.offline.domain.OfflineExecutionStatus;
 import io.yak.ops.business.sync.offline.engine.LinkUpClient;
 import io.yak.ops.business.sync.offline.engine.LinkUpClient.LinkUpJobResponse;
+import io.yak.ops.business.sync.offline.engine.LinkUpClient.LinkUpNodeResponse;
 import io.yak.ops.business.sync.offline.engine.LinkUpClient.LinkUpRequestException;
 import io.yak.ops.business.sync.offline.engine.LinkUpClient.LinkUpTransportException;
 import io.yak.ops.business.sync.offline.repository.OfflineExecutionControlRepository;
@@ -76,6 +77,11 @@ public class OfflineExecutionOrchestrator {
         "使用 application.yml 中的固定 Link-Up 地址",
         null);
     try {
+      LinkUpNodeResponse node = linkUpClient.node();
+      execution.setWorkerInstanceId(node.getInstanceId());
+      execution.setUpdateTime(LocalDateTime.now());
+      executionDao.updateById(execution);
+
       String resolved = definitionService.resolveExecutionJobSpec(claim.getDefinition());
       JsonNode jobSpec = readJobSpec(resolved);
       transition(

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/service/OfflineExecutionClaimServiceTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/service/OfflineExecutionClaimServiceTest.java
@@ -1,0 +1,66 @@
+package io.yak.ops.business.sync.offline.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.sync.offline.config.OfflineSyncProperties;
+import io.yak.ops.business.sync.offline.dao.OfflineJobExecutionDao;
+import io.yak.ops.business.sync.offline.repository.OfflineExecutionControlRepository;
+import io.yak.ops.business.sync.offline.service.OfflineExecutionClaimService.ClaimResult;
+import io.yak.ops.common.bean.po.sync.offline.OfflineJobDefinitionPO;
+import io.yak.ops.common.bean.po.sync.offline.OfflineJobExecutionPO;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class OfflineExecutionClaimServiceTest {
+
+  @Mock private OfflineJobDefinitionService definitionService;
+  @Mock private OfflineJobExecutionDao executionDao;
+  @Mock private OfflineExecutionControlRepository repository;
+
+  private OfflineExecutionClaimService service;
+
+  @BeforeEach
+  void setUp() {
+    service = new OfflineExecutionClaimService(
+        definitionService,
+        executionDao,
+        repository,
+        new OfflineSyncProperties());
+  }
+
+  @Test
+  void shouldPersistCreatedExecutionBeforeAnyEngineProbe() {
+    OfflineJobDefinitionPO definition = new OfflineJobDefinitionPO();
+    definition.setId(10L);
+    definition.setReleaseState("ONLINE");
+    definition.setVersion(3);
+    definition.setConfigDigest("digest");
+    definition.setDefinitionJson("{}");
+
+    when(definitionService.require(10L)).thenReturn(definition);
+    when(definitionService.resolveLogicalJobSpec(definition)).thenReturn("{\"job\":\"spec\"}");
+    when(executionDao.insert(any(OfflineJobExecutionPO.class)))
+        .thenAnswer(invocation -> {
+          OfflineJobExecutionPO execution = invocation.getArgument(0);
+          execution.setId(99L);
+          return true;
+        });
+
+    ClaimResult result = service.claim(10L, "WORKFLOW", null, 1);
+
+    assertThat(result.getExecution().getId()).isEqualTo(99L);
+    assertThat(result.getExecution().getStatus()).isEqualTo("CREATED");
+    assertThat(result.getExecution().getWorkerInstanceId()).isNull();
+    assertThat(result.getExecution().getEngineBaseUrl()).isEqualTo("http://127.0.0.1:18080");
+    verify(repository).lockDefinition(10L);
+    verify(repository).hasActiveExecution(10L);
+    verify(executionDao).insert(result.getExecution());
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/service/OfflineExecutionOrchestratorTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/service/OfflineExecutionOrchestratorTest.java
@@ -1,0 +1,102 @@
+package io.yak.ops.business.sync.offline.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.sync.offline.config.OfflineSyncProperties;
+import io.yak.ops.business.sync.offline.dao.OfflineJobDefinitionDao;
+import io.yak.ops.business.sync.offline.dao.OfflineJobExecutionDao;
+import io.yak.ops.business.sync.offline.engine.LinkUpClient;
+import io.yak.ops.business.sync.offline.engine.LinkUpClient.LinkUpTransportException;
+import io.yak.ops.business.sync.offline.repository.OfflineExecutionControlRepository;
+import io.yak.ops.business.sync.offline.repository.OfflineScheduleRepository;
+import io.yak.ops.business.sync.offline.service.OfflineExecutionClaimService.ClaimResult;
+import io.yak.ops.common.bean.po.sync.offline.OfflineJobDefinitionPO;
+import io.yak.ops.common.bean.po.sync.offline.OfflineJobExecutionPO;
+import java.net.ConnectException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class OfflineExecutionOrchestratorTest {
+
+  @Mock private OfflineJobDefinitionService definitionService;
+  @Mock private OfflineExecutionClaimService claimService;
+  @Mock private OfflineJobDefinitionDao definitionDao;
+  @Mock private OfflineJobExecutionDao executionDao;
+  @Mock private OfflineExecutionControlRepository executionRepository;
+  @Mock private OfflineScheduleRepository scheduleRepository;
+  @Mock private LinkUpClient linkUpClient;
+
+  private OfflineExecutionOrchestrator service;
+
+  @BeforeEach
+  void setUp() {
+    service = new OfflineExecutionOrchestrator(
+        definitionService,
+        claimService,
+        definitionDao,
+        executionDao,
+        executionRepository,
+        scheduleRepository,
+        linkUpClient,
+        new OfflineSyncProperties(),
+        new ObjectMapper());
+  }
+
+  @Test
+  void shouldPersistFailureWhenLinkUpCannotBeReached() {
+    OfflineJobDefinitionPO definition = new OfflineJobDefinitionPO();
+    definition.setId(10L);
+
+    OfflineJobExecutionPO execution = new OfflineJobExecutionPO();
+    execution.setId(99L);
+    execution.setJobDefinitionId(10L);
+    execution.setStatus("CREATED");
+    execution.setStateVersion(1L);
+    execution.setAttemptNo(1);
+
+    when(claimService.claim(10L, "WORKFLOW", null, 1))
+        .thenReturn(new ClaimResult(definition, "{}", execution));
+    when(definitionDao.selectById(10L)).thenReturn(definition);
+    when(linkUpClient.node())
+        .thenThrow(new LinkUpTransportException(
+            "无法连接 Link-Up Server：http://127.0.0.1:18080",
+            new ConnectException(),
+            false));
+
+    assertThatThrownBy(() -> service.execute(10L, "WORKFLOW", null, 1))
+        .isInstanceOf(LinkUpTransportException.class)
+        .hasMessage("无法连接 Link-Up Server：http://127.0.0.1:18080");
+
+    assertThat(execution.getStatus()).isEqualTo("FAILED");
+    assertThat(execution.getErrorMessage())
+        .isEqualTo("无法连接 Link-Up Server：http://127.0.0.1:18080");
+    assertThat(execution.getEndTime()).isNotNull();
+    verify(executionDao, atLeastOnce()).updateById(execution);
+    verify(executionRepository).recordExecutionEvent(
+        eq(99L),
+        eq(1L),
+        eq(null),
+        eq("CREATED"),
+        eq("EXECUTION_CREATED"),
+        eq("使用 application.yml 中的固定 Link-Up 地址"),
+        eq(null));
+    verify(executionRepository).recordExecutionEvent(
+        eq(99L),
+        eq(2L),
+        eq("CREATED"),
+        eq("FAILED"),
+        eq("FAILED"),
+        eq("无法连接 Link-Up Server：http://127.0.0.1:18080"),
+        eq(null));
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/service/OfflineExecutionOrchestratorTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/service/OfflineExecutionOrchestratorTest.java
@@ -3,6 +3,7 @@ package io.yak.ops.business.sync.offline.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -85,11 +86,11 @@ class OfflineExecutionOrchestratorTest {
     verify(executionRepository).recordExecutionEvent(
         eq(99L),
         eq(1L),
-        eq(null),
+        isNull(),
         eq("CREATED"),
         eq("EXECUTION_CREATED"),
         eq("使用 application.yml 中的固定 Link-Up 地址"),
-        eq(null));
+        isNull());
     verify(executionRepository).recordExecutionEvent(
         eq(99L),
         eq(2L),
@@ -97,6 +98,6 @@ class OfflineExecutionOrchestratorTest {
         eq("FAILED"),
         eq("FAILED"),
         eq("无法连接 Link-Up Server：http://127.0.0.1:18080"),
-        eq(null));
+        isNull());
   }
 }

--- a/yak-ops-ui/src/pages/workflow/definition/index.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/index.tsx
@@ -72,6 +72,10 @@ interface WorkflowNodeData {
   executionTimeoutSeconds: number;
   inputMappingText: string;
   executionStatus?: string;
+  executionError?: string;
+  failureReason?: string;
+  attemptCount?: number;
+  currentAttemptNumber?: number;
   continuedAfterFailure?: boolean;
 }
 
@@ -132,7 +136,7 @@ const nodeStateClass = (status?: string, selected?: boolean) => {
 
 const WorkflowNode = ({ data, selected }: NodeProps<WorkflowNodeData>) => (
   <div className={[
-    'relative min-w-[190px] rounded-lg border px-3 py-2.5 shadow-sm transition-all',
+    'relative min-w-[190px] max-w-[280px] rounded-lg border px-3 py-2.5 shadow-sm transition-all',
     nodeStateClass(data.executionStatus, selected),
   ].join(' ')}>
     <Handle type="target" position={Position.Left} className="!h-2.5 !w-2.5 !border-2 !border-white !bg-[#8a8f99]" />
@@ -147,6 +151,14 @@ const WorkflowNode = ({ data, selected }: NodeProps<WorkflowNodeData>) => (
     </div>
     <div className="mt-1.5 text-[13px] font-semibold text-[#161823]">{data.label}</div>
     <div className="mt-1 truncate text-[9px] text-[rgba(22,24,35,.34)]">Task ID: {data.taskId}</div>
+    {data.executionStatus === 'FAILED' && data.executionError ? (
+      <div
+        className="mt-2 max-h-10 overflow-hidden rounded-md bg-[#fff0f0] px-2 py-1.5 text-[10px] leading-4 text-[#d92d20]"
+        title={data.executionError}
+      >
+        {data.executionError}
+      </div>
+    ) : null}
     {data.maxAttempts > 1 || data.executionTimeoutSeconds > 0 ? (
       <div className="mt-1.5 text-[9px] text-[rgba(22,24,35,.38)]">
         {data.maxAttempts > 1 ? `最多 ${data.maxAttempts} 次` : ''}
@@ -215,15 +227,23 @@ const WorkflowDefinitionContent = () => {
     snapshot.nodes.forEach((node) => {
       if (node.continuedAfterFailure) continuedFailureNodeIdsRef.current.add(node.id);
     });
+    const runtimeNodeById = new Map(snapshot.nodes.map((node) => [node.id, node]));
     const statusByNodeId = new Map(snapshot.nodes.map((node) => [node.id, node.status]));
-    setNodes((current) => current.map((node) => ({
-      ...node,
-      data: {
-        ...node.data,
-        executionStatus: statusByNodeId.get(node.id) ?? node.data.executionStatus,
-        continuedAfterFailure: continuedFailureNodeIdsRef.current.has(node.id),
-      },
-    })));
+    setNodes((current) => current.map((node) => {
+      const runtimeNode = runtimeNodeById.get(node.id);
+      return {
+        ...node,
+        data: {
+          ...node.data,
+          executionStatus: runtimeNode?.status ?? node.data.executionStatus,
+          executionError: runtimeNode?.errorMessage,
+          failureReason: runtimeNode?.failureReason,
+          attemptCount: runtimeNode?.attemptCount,
+          currentAttemptNumber: runtimeNode?.currentAttemptNumber,
+          continuedAfterFailure: continuedFailureNodeIdsRef.current.has(node.id),
+        },
+      };
+    }));
     setEdges((current) => current.map((edge) => {
       const sourceStatus = statusByNodeId.get(edge.source);
       const targetStatus = statusByNodeId.get(edge.target);
@@ -291,7 +311,15 @@ const WorkflowDefinitionContent = () => {
     setContextMenu(undefined);
     setNodes((current) => current.map((node) => ({
       ...node,
-      data: { ...node.data, executionStatus: 'WAITING', continuedAfterFailure: false },
+      data: {
+        ...node.data,
+        executionStatus: 'WAITING',
+        executionError: undefined,
+        failureReason: undefined,
+        attemptCount: undefined,
+        currentAttemptNumber: undefined,
+        continuedAfterFailure: false,
+      },
     })));
   };
 
@@ -483,23 +511,72 @@ const WorkflowDefinitionContent = () => {
         </div>
 
         <div ref={wrapperRef} className="relative min-h-0 flex-1" onDrop={handleDrop}>
-          {selectedNode && !workflowLocked ? (
-            <div className="absolute right-4 top-4 z-20 w-[330px] rounded-lg border border-[#e3e5e8] bg-white p-3 shadow-md">
+          {selectedNode ? (
+            <div className="absolute right-4 top-4 z-20 w-[350px] rounded-lg border border-[#e3e5e8] bg-white p-3 shadow-md">
               <div className="text-[12px] font-semibold text-[#161823]">任务节点</div>
               <div className="mt-3 grid grid-cols-2 gap-2 rounded-md bg-[#f7f7f8] p-2.5">
                 <div><div className="text-[10px] text-[rgba(22,24,35,.4)]">任务名称</div><div className="mt-1 truncate text-[12px] font-medium">{selectedNode.data.label}</div></div>
                 <div><div className="text-[10px] text-[rgba(22,24,35,.4)]">任务类型</div><div className="mt-1 text-[12px] font-medium">{selectedNode.data.typeLabel}</div></div>
               </div>
-              <div className="mt-3 grid grid-cols-2 gap-2">
-                <div><div className="text-[10px] text-[rgba(22,24,35,.48)]">触发规则</div><Select className="mt-1 w-full" size="small" value={selectedNode.data.triggerRule} options={TRIGGER_RULE_OPTIONS} onChange={(value) => updateSelectedNode({ triggerRule: value as WorkflowTriggerRule })} /></div>
-                <div><div className="text-[10px] text-[rgba(22,24,35,.48)]">失败策略</div><Select className="mt-1 w-full" size="small" value={selectedNode.data.failurePolicy} options={NODE_FAILURE_OPTIONS} onChange={(value) => updateSelectedNode({ failurePolicy: value as WorkflowNodeFailurePolicy })} /></div>
-                <div><div className="text-[10px] text-[rgba(22,24,35,.48)]">最大 Attempt</div><InputNumber min={1} value={selectedNode.data.maxAttempts} onChange={(value) => updateSelectedNode({ maxAttempts: Number(value || 1) })} className="mt-1 w-full" /></div>
-                <div><div className="text-[10px] text-[rgba(22,24,35,.48)]">重试延迟（秒）</div><InputNumber min={0} value={selectedNode.data.retryDelaySeconds} onChange={(value) => updateSelectedNode({ retryDelaySeconds: Number(value || 0) })} className="mt-1 w-full" /></div>
-                <div><div className="text-[10px] text-[rgba(22,24,35,.48)]">派发超时（秒）</div><InputNumber min={0} value={selectedNode.data.dispatchTimeoutSeconds} onChange={(value) => updateSelectedNode({ dispatchTimeoutSeconds: Number(value || 0) })} className="mt-1 w-full" /></div>
-                <div><div className="text-[10px] text-[rgba(22,24,35,.48)]">执行超时（秒）</div><InputNumber min={0} value={selectedNode.data.executionTimeoutSeconds} onChange={(value) => updateSelectedNode({ executionTimeoutSeconds: Number(value || 0) })} className="mt-1 w-full" /></div>
+
+              {selectedNode.data.executionStatus ? (
+                <div className="mt-3 rounded-md border border-[#ececef] bg-[#fafafa] p-2.5">
+                  <div className="flex items-center justify-between">
+                    <div className="text-[10px] font-medium text-[rgba(22,24,35,.5)]">运行结果</div>
+                    <div className={[
+                      'flex items-center gap-1 text-[11px] font-medium',
+                      selectedNode.data.executionStatus === 'FAILED' || selectedNode.data.executionStatus === 'TIMED_OUT'
+                        ? 'text-[#d92d20]'
+                        : 'text-[rgba(22,24,35,.68)]',
+                    ].join(' ')}>
+                      {statusIcon(selectedNode.data.executionStatus)}
+                      {statusLabel[selectedNode.data.executionStatus] || selectedNode.data.executionStatus}
+                    </div>
+                  </div>
+                  <div className="mt-2 text-[10px] text-[rgba(22,24,35,.42)]">
+                    Attempt {selectedNode.data.currentAttemptNumber ?? selectedNode.data.attemptCount ?? '-'}
+                  </div>
+                  {selectedNode.data.executionError ? (
+                    <div className="mt-2">
+                      <div className="text-[10px] font-medium text-[#d92d20]">失败原因</div>
+                      <div className="mt-1 break-all rounded bg-[#fff0f0] px-2 py-1.5 text-[11px] leading-5 text-[#d92d20]">
+                        {selectedNode.data.executionError}
+                      </div>
+                    </div>
+                  ) : null}
+                  {selectedNode.data.failureReason ? (
+                    <div className="mt-1.5 text-[9px] text-[rgba(22,24,35,.34)]">
+                      Failure reason: {selectedNode.data.failureReason}
+                    </div>
+                  ) : null}
+                  {activeInstance
+                    && isWorkflowTerminal(activeInstance.status)
+                    && selectedNode.data.executionStatus === 'FAILED'
+                    && !selectedNode.data.continuedAfterFailure ? (
+                      <Button
+                        className="mt-2"
+                        size="small"
+                        icon={<RefreshCw size={13} />}
+                        loading={recoveringNodeId === selectedNode.id}
+                        onClick={() => void handleRetryFailedNode(selectedNode.id)}
+                      >
+                        重新执行
+                      </Button>
+                    ) : null}
+                </div>
+              ) : null}
+
+              <div className="mt-3 text-[10px] font-medium text-[rgba(22,24,35,.5)]">运行配置</div>
+              <div className="mt-2 grid grid-cols-2 gap-2">
+                <div><div className="text-[10px] text-[rgba(22,24,35,.48)]">触发规则</div><Select disabled={workflowLocked} className="mt-1 w-full" size="small" value={selectedNode.data.triggerRule} options={TRIGGER_RULE_OPTIONS} onChange={(value) => updateSelectedNode({ triggerRule: value as WorkflowTriggerRule })} /></div>
+                <div><div className="text-[10px] text-[rgba(22,24,35,.48)]">失败策略</div><Select disabled={workflowLocked} className="mt-1 w-full" size="small" value={selectedNode.data.failurePolicy} options={NODE_FAILURE_OPTIONS} onChange={(value) => updateSelectedNode({ failurePolicy: value as WorkflowNodeFailurePolicy })} /></div>
+                <div><div className="text-[10px] text-[rgba(22,24,35,.48)]">最大 Attempt</div><InputNumber disabled={workflowLocked} min={1} value={selectedNode.data.maxAttempts} onChange={(value) => updateSelectedNode({ maxAttempts: Number(value || 1) })} className="mt-1 w-full" /></div>
+                <div><div className="text-[10px] text-[rgba(22,24,35,.48)]">重试延迟（秒）</div><InputNumber disabled={workflowLocked} min={0} value={selectedNode.data.retryDelaySeconds} onChange={(value) => updateSelectedNode({ retryDelaySeconds: Number(value || 0) })} className="mt-1 w-full" /></div>
+                <div><div className="text-[10px] text-[rgba(22,24,35,.48)]">派发超时（秒）</div><InputNumber disabled={workflowLocked} min={0} value={selectedNode.data.dispatchTimeoutSeconds} onChange={(value) => updateSelectedNode({ dispatchTimeoutSeconds: Number(value || 0) })} className="mt-1 w-full" /></div>
+                <div><div className="text-[10px] text-[rgba(22,24,35,.48)]">执行超时（秒）</div><InputNumber disabled={workflowLocked} min={0} value={selectedNode.data.executionTimeoutSeconds} onChange={(value) => updateSelectedNode({ executionTimeoutSeconds: Number(value || 0) })} className="mt-1 w-full" /></div>
               </div>
               <div className="mt-3 text-[10px] text-[rgba(22,24,35,.48)]">Input Mapping</div>
-              <Input.TextArea rows={4} className="mt-1 font-mono !text-[10px]"
+              <Input.TextArea disabled={workflowLocked} rows={4} className="mt-1 font-mono !text-[10px]"
                 value={selectedNode.data.inputMappingText}
                 onChange={(event) => updateSelectedNode({ inputMappingText: event.target.value })} />
               <div className="mt-1.5 text-[9px] leading-4 text-[rgba(22,24,35,.38)]">任务自身配置不在工作流中编辑；这里只配置编排行为。</div>
@@ -548,7 +625,7 @@ const WorkflowDefinitionContent = () => {
             }}
             nodesDraggable={!workflowLocked}
             nodesConnectable={!workflowLocked}
-            elementsSelectable={!workflowLocked}
+            elementsSelectable
             fitView
             deleteKeyCode={workflowLocked ? null : ['Backspace', 'Delete']}
             defaultEdgeOptions={{ type: 'smoothstep', style: { stroke: '#d9dce1', strokeWidth: 1.4 } }}


### PR DESCRIPTION
## Summary

Improve observability when a Workflow SYNC node fails before Link-Up accepts a job.

The original failure path called `LinkUpClient.node()` inside `OfflineExecutionClaimService` before the offline execution row was inserted. If Link-Up was unavailable, the transaction failed before an `OfflineJobExecution` existed, so the sync execution history and unified Yak Ops timeline had nothing to display. Workflow itself received the exception, but the canvas only showed a generic failed state.

## Changes

### Persist sync execution before probing Link-Up

- `OfflineExecutionClaimService` now only performs the local atomic claim and creates the `CREATED` execution record.
- the Link-Up node probe moves into `OfflineExecutionOrchestrator`, after `EXECUTION_CREATED` has already been recorded.
- when `/api/v1/node` cannot be reached, the existing execution is transitioned to `FAILED`, `errorMessage` is persisted, the definition's last execution/error state is updated, and a local execution event is written.
- no new table or log subsystem is introduced; the existing Yak Ops + Link-Up unified timeline is reused.

### Make transport errors more accurate

- read-only Link-Up requests now report `无法连接 Link-Up Server：<baseUrl>` on transport failure.
- side-effecting submit/cancel requests keep the existing uncertain-delivery wording because the server may have received the request even if the client did not receive a response.

### Surface Workflow node failure reasons

- map workflow node `errorMessage`, failure reason and attempt information into React Flow node data.
- failed nodes show a compact failure reason directly on the canvas.
- selecting a node shows a `运行结果 / 失败原因 / Attempt` section in the right-side panel.
- nodes remain selectable while a workflow is running so a failed node can be inspected immediately, while drag/connect/config editing stays locked.
- terminal failed nodes expose a direct `重新执行` action in the detail panel.

## Validation

Added focused unit coverage for:

- creating the offline execution locally before any Link-Up probe is attempted.
- persisting a `FAILED` execution and Yak Ops execution event when Link-Up cannot be reached.

The repository does not currently expose PR CI checks through GitHub Actions, so validation here is code-level/static plus the added unit tests rather than a reported CI pass.

## Scope

This PR intentionally does not add a new log center, workflow persistence, or workflow-engine changes. It reuses the existing sync execution/event model and the existing workflow `errorMessage` propagation.