### PR TITLE
feat(workflow): add Dify-style node hover interactions

### DIFF
--- a/yak-ops-ui/src/pages/workflow/definition/WorkflowDefinitionEditor.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/WorkflowDefinitionEditor.tsx
@@ -11,7 +11,7 @@ import {
   type WorkflowDefinition,
 } from '@/services/workflow/definitions';
 import { history, useParams } from '@umijs/max';
-import { Spin, message } from 'antd';
+import { Modal, Spin, message } from 'antd';
 import type { DragEvent } from 'react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import ReactFlow, {
@@ -22,6 +22,7 @@ import ReactFlow, {
   addEdge,
   type Connection,
   type Edge,
+  type NodeMouseHandler,
   type ReactFlowInstance,
   useEdgesState,
   useNodesState,
@@ -219,11 +220,124 @@ const WorkflowDefinitionContent = () => {
     ]);
   }, [edges, locked, nodes, setEdges, setNodes, syncTasks]);
 
-  const edgeInsertOptions = useMemo(() => syncTasks.map((task) => ({
+  const handleAppendTask = useCallback((sourceNodeId: string, taskId: string) => {
+    if (locked) return;
+    const task = syncTasks.find((item) => item.id === taskId);
+    const sourceNode = nodes.find((node) => node.id === sourceNodeId);
+    if (!task || !sourceNode) return;
+
+    const sequence = sequenceRef.current++;
+    const nodeId = `task-${Date.now()}-${sequence}`;
+    const outgoingCount = edges.filter((edge) => edge.source === sourceNodeId).length;
+
+    setNodes((current) => [
+      ...current.map((node) => ({ ...node, selected: false })),
+      {
+        id: nodeId,
+        type: 'workflow',
+        selected: true,
+        position: {
+          x: sourceNode.position.x + 320,
+          y: sourceNode.position.y + outgoingCount * 120,
+        },
+        data: createNodeData(task),
+      },
+    ]);
+    setEdges((current) => [
+      ...current,
+      {
+        id: `edge-${sourceNodeId}-${nodeId}-${sequence}`,
+        source: sourceNodeId,
+        target: nodeId,
+        type: 'workflow',
+      },
+    ]);
+  }, [edges, locked, nodes, setEdges, setNodes, syncTasks]);
+
+  const handleDuplicateNode = useCallback((nodeId: string) => {
+    if (locked) return;
+    const sourceNode = nodes.find((node) => node.id === nodeId);
+    if (!sourceNode) return;
+
+    const sequence = sequenceRef.current++;
+    const duplicatedId = `task-${Date.now()}-${sequence}`;
+    setNodes((current) => [
+      ...current.map((node) => ({ ...node, selected: false })),
+      {
+        ...sourceNode,
+        id: duplicatedId,
+        selected: true,
+        position: {
+          x: sourceNode.position.x + 36,
+          y: sourceNode.position.y + 36,
+        },
+        data: { ...sourceNode.data },
+      },
+    ]);
+  }, [locked, nodes, setNodes]);
+
+  const handleDeleteNode = useCallback((nodeId: string) => {
+    if (locked) return;
+    const node = nodes.find((item) => item.id === nodeId);
+    if (!node) return;
+
+    Modal.confirm({
+      centered: true,
+      title: '删除节点？',
+      content: `即将删除「${node.data.label}」及其关联连线。`,
+      okText: '删除',
+      cancelText: '取消',
+      okButtonProps: { danger: true },
+      onOk: () => {
+        setNodes((current) => current.filter((item) => item.id !== nodeId));
+        setEdges((current) => current.filter((edge) => edge.source !== nodeId && edge.target !== nodeId));
+      },
+    });
+  }, [locked, nodes, setEdges, setNodes]);
+
+  const handleNodeMouseEnter = useCallback<NodeMouseHandler>((_, node) => {
+    setEdges((current) => current.map((edge) => {
+      if (edge.source !== node.id && edge.target !== node.id) return edge;
+      return {
+        ...edge,
+        data: {
+          ...edge.data,
+          connectedNodeHovered: true,
+        },
+      };
+    }));
+  }, [setEdges]);
+
+  const handleNodeMouseLeave = useCallback<NodeMouseHandler>(() => {
+    setEdges((current) => current.map((edge) => {
+      if (!edge.data?.connectedNodeHovered) return edge;
+      return {
+        ...edge,
+        data: {
+          ...edge.data,
+          connectedNodeHovered: false,
+        },
+      };
+    }));
+  }, [setEdges]);
+
+  const taskOptions = useMemo(() => syncTasks.map((task) => ({
     id: task.id,
     label: task.name,
     typeLabel: task.type === 'SYNC' ? '数据同步' : task.type,
   })), [syncTasks]);
+
+  const canvasNodes = useMemo(() => nodes.map((node) => ({
+    ...node,
+    data: {
+      ...node.data,
+      locked,
+      appendOptions: taskOptions,
+      onAppend: handleAppendTask,
+      onDuplicate: handleDuplicateNode,
+      onDelete: handleDeleteNode,
+    },
+  })), [handleAppendTask, handleDeleteNode, handleDuplicateNode, locked, nodes, taskOptions]);
 
   const canvasEdges = useMemo(() => edges.map((edge) => ({
     ...edge,
@@ -231,10 +345,10 @@ const WorkflowDefinitionContent = () => {
     data: {
       ...edge.data,
       locked,
-      insertOptions: edgeInsertOptions,
+      insertOptions: taskOptions,
       onInsert: handleInsertTaskIntoEdge,
     },
-  })), [edgeInsertOptions, edges, handleInsertTaskIntoEdge, locked]);
+  })), [edges, handleInsertTaskIntoEdge, locked, taskOptions]);
 
   const updateSelectedNode = (patch: Partial<WorkflowNodeData>) => {
     if (!selectedNode || locked) return;
@@ -348,7 +462,7 @@ const WorkflowDefinitionContent = () => {
         <div ref={wrapperRef} className="relative min-h-0 flex-1" onDrop={handleDrop}>
           {selectedNode ? <WorkflowNodeInspector node={selectedNode} locked={locked} onChange={updateSelectedNode} /> : null}
           <ReactFlow
-            nodes={nodes}
+            nodes={canvasNodes}
             edges={canvasEdges}
             nodeTypes={nodeTypes}
             edgeTypes={edgeTypes}
@@ -356,6 +470,8 @@ const WorkflowDefinitionContent = () => {
             onNodesChange={onNodesChange}
             onEdgesChange={onEdgesChange}
             onConnect={handleConnect}
+            onNodeMouseEnter={handleNodeMouseEnter}
+            onNodeMouseLeave={handleNodeMouseLeave}
             onInit={setReactFlowInstance}
             onDragOver={(event) => {
               event.preventDefault();

--- a/yak-ops-ui/src/pages/workflow/definition/canvas/edge/WorkflowEdge.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/edge/WorkflowEdge.tsx
@@ -36,7 +36,9 @@ const WorkflowEdge = ({
     [sourceX, sourceY, targetX, targetY],
   );
 
-  const stroke = selected
+  const connectedNodeHovered = Boolean(data?.connectedNodeHovered);
+  const highlighted = selected || connectedNodeHovered;
+  const stroke = highlighted
     ? '#fe2c55'
     : hovered || insertOpen
       ? '#8a8f99'
@@ -67,7 +69,7 @@ const WorkflowEdge = ({
         path={edgePath}
         style={{
           stroke,
-          strokeWidth: selected ? 2.2 : 2,
+          strokeWidth: highlighted ? 2.2 : 2,
           transition: 'stroke 150ms ease, stroke-width 150ms ease',
         }}
       />

--- a/yak-ops-ui/src/pages/workflow/definition/canvas/node/WorkflowNode.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/node/WorkflowNode.tsx
@@ -1,9 +1,10 @@
 import { Database, RefreshCcw, Timer } from 'lucide-react';
 import type { NodeProps } from 'reactflow';
 import type { WorkflowNodeData } from '../types';
+import WorkflowNodeControl from './WorkflowNodeControl';
 import WorkflowNodeHandle from './WorkflowNodeHandle';
 
-const WorkflowNode = ({ data, selected }: NodeProps<WorkflowNodeData>) => {
+const WorkflowNode = ({ id, data, selected }: NodeProps<WorkflowNodeData>) => {
   const hasRetry = data.maxAttempts > 1;
   const hasTimeout = data.executionTimeoutSeconds > 0;
 
@@ -16,7 +17,15 @@ const WorkflowNode = ({ data, selected }: NodeProps<WorkflowNodeData>) => {
           : 'border-transparent',
       ].join(' ')}
     >
-      <WorkflowNodeHandle type="target" selected={selected} />
+      <WorkflowNodeControl
+        nodeId={id}
+        selected={selected}
+        locked={data.locked}
+        onDuplicate={data.onDuplicate}
+        onDelete={data.onDelete}
+      />
+
+      <WorkflowNodeHandle nodeId={id} type="target" selected={selected} locked={data.locked} />
 
       <div
         className={[
@@ -63,7 +72,14 @@ const WorkflowNode = ({ data, selected }: NodeProps<WorkflowNodeData>) => {
         </div>
       </div>
 
-      <WorkflowNodeHandle type="source" selected={selected} />
+      <WorkflowNodeHandle
+        nodeId={id}
+        type="source"
+        selected={selected}
+        locked={data.locked}
+        appendOptions={data.appendOptions}
+        onAppend={data.onAppend}
+      />
     </div>
   );
 };

--- a/yak-ops-ui/src/pages/workflow/definition/canvas/node/WorkflowNodeAppend.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/node/WorkflowNodeAppend.tsx
@@ -1,0 +1,92 @@
+import { Popover } from 'antd';
+import { Plus } from 'lucide-react';
+import { useMemo, useState } from 'react';
+import type { WorkflowCanvasTaskOption } from '../types';
+
+interface WorkflowNodeAppendProps {
+  nodeId: string;
+  selected?: boolean;
+  locked?: boolean;
+  options?: WorkflowCanvasTaskOption[];
+  onAppend?: (nodeId: string, taskId: string) => void;
+}
+
+const WorkflowNodeAppend = ({
+  nodeId,
+  selected,
+  locked,
+  options = [],
+  onAppend,
+}: WorkflowNodeAppendProps) => {
+  const [open, setOpen] = useState(false);
+  const canAppend = !locked && options.length > 0 && Boolean(onAppend);
+
+  const content = useMemo(
+    () => (
+      <div className="w-[220px] p-1">
+        <div className="px-2 pb-1.5 pt-1 text-[10px] font-medium text-[rgba(22,24,35,.42)]">
+          添加后续任务
+        </div>
+        <div className="max-h-[260px] space-y-0.5 overflow-y-auto">
+          {options.map((option) => (
+            <button
+              key={option.id}
+              type="button"
+              className="flex w-full items-center gap-2 rounded-md border-0 bg-transparent px-2 py-2 text-left hover:bg-[#f5f5f6]"
+              onClick={() => {
+                onAppend?.(nodeId, option.id);
+                setOpen(false);
+              }}
+            >
+              <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-[#f2f4f7] text-[11px] font-semibold text-[#52525b]">
+                {option.typeLabel.slice(0, 1)}
+              </span>
+              <span className="min-w-0 flex-1">
+                <span className="block truncate text-[11px] font-medium text-[#161823]">
+                  {option.label}
+                </span>
+                <span className="mt-0.5 block truncate text-[9px] text-[rgba(22,24,35,.36)]">
+                  {option.typeLabel}
+                </span>
+              </span>
+            </button>
+          ))}
+        </div>
+      </div>
+    ),
+    [nodeId, onAppend, options],
+  );
+
+  if (!canAppend) return null;
+
+  return (
+    <Popover
+      trigger="click"
+      placement="rightTop"
+      open={open}
+      onOpenChange={setOpen}
+      content={content}
+      overlayInnerStyle={{ padding: 0 }}
+    >
+      <button
+        type="button"
+        aria-label="添加后续任务"
+        className={[
+          'nodrag nopan absolute top-[18px] -right-[19px] z-20',
+          'flex h-[18px] w-[18px] items-center justify-center rounded-full border',
+          'border-[#fe2c55] bg-[#fe2c55] text-white shadow-[0_1px_4px_rgba(254,44,85,.28)]',
+          'transition-all duration-150 hover:scale-110',
+          selected || open
+            ? 'pointer-events-auto scale-100 opacity-100'
+            : 'pointer-events-none scale-90 opacity-0 group-hover:pointer-events-auto group-hover:scale-100 group-hover:opacity-100',
+        ].join(' ')}
+        onMouseDown={(event) => event.stopPropagation()}
+        onClick={(event) => event.stopPropagation()}
+      >
+        <Plus size={11} strokeWidth={2.4} />
+      </button>
+    </Popover>
+  );
+};
+
+export default WorkflowNodeAppend;

--- a/yak-ops-ui/src/pages/workflow/definition/canvas/node/WorkflowNodeControl.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/node/WorkflowNodeControl.tsx
@@ -1,0 +1,83 @@
+import type { MenuProps } from 'antd';
+import { Dropdown } from 'antd';
+import { Copy, MoreHorizontal, Trash2 } from 'lucide-react';
+import { useMemo, useState } from 'react';
+
+interface WorkflowNodeControlProps {
+  nodeId: string;
+  selected?: boolean;
+  locked?: boolean;
+  onDuplicate?: (nodeId: string) => void;
+  onDelete?: (nodeId: string) => void;
+}
+
+const WorkflowNodeControl = ({
+  nodeId,
+  selected,
+  locked,
+  onDuplicate,
+  onDelete,
+}: WorkflowNodeControlProps) => {
+  const [open, setOpen] = useState(false);
+
+  const items = useMemo<MenuProps['items']>(() => [
+    {
+      key: 'duplicate',
+      icon: <Copy size={13} />,
+      label: '复制节点',
+      disabled: !onDuplicate,
+    },
+    { type: 'divider' },
+    {
+      key: 'delete',
+      icon: <Trash2 size={13} />,
+      label: '删除节点',
+      danger: true,
+      disabled: !onDelete,
+    },
+  ], [onDelete, onDuplicate]);
+
+  if (locked || (!onDuplicate && !onDelete)) return null;
+
+  return (
+    <div
+      className={[
+        'absolute -top-7 right-0 z-30 flex h-7 pb-1 transition-opacity duration-150',
+        selected || open
+          ? 'visible opacity-100'
+          : 'invisible opacity-0 group-hover:visible group-hover:opacity-100',
+      ].join(' ')}
+    >
+      <div
+        className="nodrag nopan flex h-6 items-center rounded-lg border border-[rgba(22,24,35,.08)] bg-[rgba(255,255,255,.96)] px-0.5 text-[#667085] shadow-[0_3px_10px_rgba(22,24,35,.12)] backdrop-blur-sm"
+        onMouseDown={(event) => event.stopPropagation()}
+        onClick={(event) => event.stopPropagation()}
+      >
+        <Dropdown
+          trigger={['click']}
+          placement="bottomRight"
+          open={open}
+          onOpenChange={setOpen}
+          menu={{
+            items,
+            onClick: ({ key }) => {
+              if (key === 'duplicate') onDuplicate?.(nodeId);
+              if (key === 'delete') onDelete?.(nodeId);
+              setOpen(false);
+            },
+          }}
+        >
+          <button
+            type="button"
+            aria-label="节点操作"
+            className="flex h-5 w-5 items-center justify-center rounded-md border-0 bg-transparent p-0 text-[#667085] hover:bg-[#f2f4f7] hover:text-[#161823]"
+          >
+            <MoreHorizontal size={14} strokeWidth={2} />
+          </button>
+        </Dropdown>
+      </div>
+    </div>
+  );
+};
+
+export default WorkflowNodeControl;

--- a/yak-ops-ui/src/pages/workflow/definition/canvas/node/WorkflowNodeHandle.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/node/WorkflowNodeHandle.tsx
@@ -1,9 +1,15 @@
 import type { CSSProperties } from 'react';
 import { Handle, Position } from 'reactflow';
+import type { WorkflowCanvasTaskOption } from '../types';
+import WorkflowNodeAppend from './WorkflowNodeAppend';
 
 interface WorkflowNodeHandleProps {
+  nodeId: string;
   type: 'source' | 'target';
   selected?: boolean;
+  locked?: boolean;
+  appendOptions?: WorkflowCanvasTaskOption[];
+  onAppend?: (nodeId: string, taskId: string) => void;
 }
 
 const HANDLE_STYLE: CSSProperties = {
@@ -11,25 +17,44 @@ const HANDLE_STYLE: CSSProperties = {
   transform: 'none',
 };
 
-const WorkflowNodeHandle = ({ type, selected }: WorkflowNodeHandleProps) => {
+const WorkflowNodeHandle = ({
+  nodeId,
+  type,
+  selected,
+  locked,
+  appendOptions,
+  onAppend,
+}: WorkflowNodeHandleProps) => {
   const isTarget = type === 'target';
 
   return (
-    <Handle
-      type={type}
-      position={isTarget ? Position.Left : Position.Right}
-      style={HANDLE_STYLE}
-      className={[
-        '!h-4 !w-4 !rounded-none !border-0 !bg-transparent !outline-none',
-        isTarget ? '!-left-[10px]' : '!-right-[10px]',
-        "after:absolute after:top-1 after:h-2 after:w-0.5 after:rounded-full after:content-['']",
-        isTarget ? 'after:left-[7px]' : 'after:right-[7px]',
-        selected
-          ? 'after:bg-[#fe2c55]'
-          : 'after:bg-[#c7c9ce] group-hover:after:bg-[#8a8f99]',
-        'after:transition-all hover:scale-125 hover:after:bg-[#fe2c55]',
-      ].join(' ')}
-    />
+    <>
+      <Handle
+        type={type}
+        position={isTarget ? Position.Left : Position.Right}
+        style={HANDLE_STYLE}
+        className={[
+          '!h-4 !w-4 !rounded-none !border-0 !bg-transparent !outline-none',
+          isTarget ? '!-left-[10px]' : '!-right-[10px]',
+          "after:absolute after:top-1 after:h-2 after:w-0.5 after:rounded-full after:content-['']",
+          isTarget ? 'after:left-[7px]' : 'after:right-[7px]',
+          selected
+            ? 'after:bg-[#fe2c55]'
+            : 'after:bg-[#c7c9ce] group-hover:after:bg-[#fe2c55]',
+          'after:transition-all hover:scale-125 hover:after:bg-[#fe2c55]',
+        ].join(' ')}
+      />
+
+      {!isTarget ? (
+        <WorkflowNodeAppend
+          nodeId={nodeId}
+          selected={selected}
+          locked={locked}
+          options={appendOptions}
+          onAppend={onAppend}
+        />
+      ) : null}
+    </>
   );
 };
 

--- a/yak-ops-ui/src/pages/workflow/definition/canvas/types.ts
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/types.ts
@@ -3,6 +3,12 @@ import type {
   WorkflowTriggerRule,
 } from '@/services/workflow';
 
+export interface WorkflowCanvasTaskOption {
+  id: string;
+  label: string;
+  typeLabel: string;
+}
+
 export interface WorkflowNodeData {
   label: string;
   taskId: string;
@@ -15,17 +21,19 @@ export interface WorkflowNodeData {
   dispatchTimeoutSeconds: number;
   executionTimeoutSeconds: number;
   inputMappingText: string;
+  locked?: boolean;
+  appendOptions?: WorkflowCanvasTaskOption[];
+  onAppend?: (nodeId: string, taskId: string) => void;
+  onDuplicate?: (nodeId: string) => void;
+  onDelete?: (nodeId: string) => void;
 }
 
-export interface WorkflowEdgeInsertOption {
-  id: string;
-  label: string;
-  typeLabel: string;
-}
+export type WorkflowEdgeInsertOption = WorkflowCanvasTaskOption;
 
 export interface WorkflowEdgeData {
   locked?: boolean;
-  insertOptions?: WorkflowEdgeInsertOption[];
+  connectedNodeHovered?: boolean;
+  insertOptions?: WorkflowCanvasTaskOption[];
   onInsert?: (
     edgeId: string,
     source: string,


### PR DESCRIPTION
## What changed

- Added Dify-style node hover linkage: hovering a workflow node now highlights all incoming and outgoing edges with the Yak Ops brand color.
- Added a source-side `+` action that appears on node hover/selection and opens the configured task picker.
- Selecting a task from the source `+` creates a new workflow node to the right and automatically connects it from the current node.
- Added a compact top-right `...` node action bar that appears on hover/selection.
- Added real node actions for duplicate and delete; delete removes connected edges after confirmation.
- Kept the existing edge-middle `+` insertion behavior, so users can both append from a node and insert into an existing edge.
- Updated handle hover styling so the subtle handle indicator follows the Yak Ops `#fe2c55` interaction color.

## Implementation notes

The interaction follows the same separation used by Dify's workflow canvas:

- ReactFlow `onNodeMouseEnter` / `onNodeMouseLeave` update transient edge data for connected-edge highlighting.
- `WorkflowEdge` renders the transient connected-node hover state.
- `WorkflowNodeHandle` owns the source handle visual and source append trigger.
- `WorkflowNodeControl` owns the hover action bar and node menu.
- Canvas-only callbacks/options are injected through derived `canvasNodes`; workflow persistence remains based on the original business node data.

## Impact

- Workflow definition API payloads are unchanged.
- Existing persisted nodes and edges remain compatible.
- Online workflow definitions remain locked: append, duplicate, delete, drag, and connection editing are disabled.
- No backend changes are included.

## Validation

- Compared the branch against `main`; changes are limited to `yak-ops-ui/src/pages/workflow/definition/**`.
- Checked the implementation against the repository's ReactFlow 11.11.4 usage and the Dify source interaction pattern reviewed for this task.
- Full `npm run tsc` / build could not be run in the execution container because outbound GitHub access is unavailable, so this PR is intentionally opened as Draft for integration and visual review.