### PR TITLE
fix(workflow): align connection preview endpoint

### DIFF
--- a/yak-ops-ui/src/pages/workflow/definition/canvas/edge/WorkflowConnectionLine.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/edge/WorkflowConnectionLine.tsx
@@ -17,7 +17,7 @@ const WorkflowConnectionLine = ({
     sourceX: fromX - WORKFLOW_EDGE_HANDLE_OVERLAP,
     sourceY: fromY,
     sourcePosition: fromPosition,
-    targetX: toX + WORKFLOW_EDGE_HANDLE_OVERLAP,
+    targetX: toX,
     targetY: toY,
     targetPosition: toPosition,
     curvature: 0.16,
@@ -30,10 +30,7 @@ const WorkflowConnectionLine = ({
         fill="none"
         stroke="#fe2c55"
         strokeWidth={2}
-        strokeDasharray="5 5"
-        opacity={0.78}
       />
-      <circle cx={toX} cy={toY} r={3.5} fill="#fe2c55" />
     </g>
   );
 };


### PR DESCRIPTION
## What changed

- Fixed the temporary workflow connection preview so the Bezier path ends exactly at the current pointer/target coordinate instead of extending an extra handle-overlap distance past it.
- Changed the connection preview from dashed to solid.
- Removed the trailing red endpoint circle so the preview reads as one continuous line.
- Left persisted/custom workflow edges unchanged.

## Why

The preview path previously used `targetX: toX + WORKFLOW_EDGE_HANDLE_OVERLAP` while the endpoint marker was still rendered at `toX`. This created a visible ~8px tail beyond the pointer/target point. The preview now keeps the source-side overlap for the source handle but ends directly at `toX`.

## Scope

- Frontend only.
- One file changed: `WorkflowConnectionLine.tsx`.
- No workflow API or persisted edge behavior changes.

## Validation

- Compared the branch against current `main`; it is ahead by one commit and touches only the connection preview component.
- Change is intentionally opened as Draft for quick visual verification of drag-to-connect behavior.