### PR TITLE
fix(workflow): keep connection preview clear of source plus

### DIFF
--- a/yak-ops-ui/src/pages/workflow/definition/canvas/edge/WorkflowConnectionLine.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/edge/WorkflowConnectionLine.tsx
@@ -14,7 +14,7 @@ const WorkflowConnectionLine = ({
   toPosition = Position.Left,
 }: ConnectionLineComponentProps) => {
   const [path] = getBezierPath({
-    sourceX: fromX - WORKFLOW_EDGE_HANDLE_OVERLAP,
+    sourceX: fromX + WORKFLOW_EDGE_HANDLE_OVERLAP,
     sourceY: fromY,
     sourcePosition: fromPosition,
     targetX: toX,


### PR DESCRIPTION
## What changed

- Adjusted the temporary workflow connection preview so it starts at the right edge of the 16px source `+` handle instead of crossing through the handle center.
- The preview now uses `fromX + WORKFLOW_EDGE_HANDLE_OVERLAP` as its source X coordinate.
- Persisted/custom workflow edges remain unchanged.

## Why

After the previous connection-preview cleanup, the solid red preview line still passed directly through the circular source `+` button. Because the line and node content live in different ReactFlow/SVG stacking contexts, increasing the `+` z-index is not a reliable fix. Moving the preview start point to the right edge of the source handle avoids the overlap geometrically and keeps the white plus icon fully visible.

## Scope

- Frontend only.
- One file changed: `WorkflowConnectionLine.tsx`.
- No workflow API or persisted edge behavior changes.

## Validation

- Compared the branch against current `main`; it is ahead by one commit and not behind.
- Final diff is one line: source preview X moves from `fromX - overlap` to `fromX + overlap`.
- Opened as Draft for quick visual verification of drag-to-connect behavior.