### PR TITLE
feat(workflow): polish source handle hover interaction

### DIFF
--- a/yak-ops-ui/src/pages/workflow/definition/canvas/node/WorkflowNodeHandle.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/node/WorkflowNodeHandle.tsx
@@ -19,7 +19,6 @@ interface WorkflowNodeHandleProps {
 
 const HANDLE_STYLE: CSSProperties = {
   top: WORKFLOW_HANDLE_TOP,
-  transform: 'none',
 };
 
 const WorkflowNodeHandle = ({
@@ -57,15 +56,28 @@ const WorkflowNodeHandle = ({
       isConnectable={!locked}
       onClick={handleClick}
       className={[
-        'group/handle !h-4 !w-4 !rounded-none !border-0 !bg-transparent !outline-none',
+        'group/handle !h-4 !w-4 !translate-y-0 !rounded-none !border-0 !bg-transparent !outline-none',
         "after:absolute after:top-1 after:h-2 after:w-0.5 after:rounded-full after:content-['']",
         isTarget ? 'after:left-[7px]' : 'after:right-[7px]',
         selected || appendOpen
           ? 'after:bg-[#fe2c55]'
           : 'after:bg-[#c7c9ce] group-hover:after:bg-[#fe2c55]',
-        'after:transition-colors after:duration-150 hover:after:bg-[#fe2c55]',
+        'transition-all duration-150 hover:scale-125 hover:after:bg-[#fe2c55]',
       ].join(' ')}
     >
+      {canAppend ? (
+        <div className="pointer-events-none absolute -top-1 left-1/2 z-30 hidden -translate-x-1/2 -translate-y-full rounded-lg border border-[#e8e9ec] bg-white px-2 py-1.5 shadow-[0_4px_12px_rgba(22,24,35,.10)] group-hover/handle:block">
+          <div className="whitespace-nowrap text-[9px] leading-4 text-[rgba(22,24,35,.52)]">
+            <div>
+              <span className="font-medium text-[#52525b]">点击</span> 添加节点
+            </div>
+            <div>
+              <span className="font-medium text-[#52525b]">拖拽</span> 连接节点
+            </div>
+          </div>
+        </div>
+      ) : null}
+
       {canAppend && onAppend ? (
         <WorkflowNodeAppend
           nodeId={nodeId}


### PR DESCRIPTION
## What changed

- Ported Dify-style source-handle hover behavior into the workflow canvas.
- The 16px ReactFlow handle now scales to 125% on hover, so the visible `+` grows with the actual interactive handle instead of using a separate animation layer.
- Added a lightweight two-line hover hint directly inside the source handle:
  - 点击 添加节点
  - 拖拽 连接节点
- Kept click-to-open task selection and drag-to-connect on the same ReactFlow handle area.
- Replaced the previous inline `transform: none` with `translate-y-0` utility styling so the hover scale transform can take effect without shifting the handle anchor.

## Dify reference

This follows Dify's `NodeSourceHandle` pattern in `web/app/components/workflow/nodes/_base/components/node-handle.tsx`, where the handle uses `transition-all hover:scale-125`, renders the add selector inside the handle, and shows click/drag guidance on handle hover.

## Scope

- Frontend only.
- One file changed: `WorkflowNodeHandle.tsx`.
- No workflow API, node persistence, edge persistence, or connection geometry changes.

## Validation

- Branch is based on current `main` and is ahead by one commit with no unrelated changes.
- Yak Ops uses Tailwind CSS v3, which supports named groups such as `group/handle` and `group-hover/handle` used by this interaction.
- Opened as Draft for quick visual verification of the hover scale, tooltip, click-to-add, and drag-to-connect behavior.