### PR TITLE
refactor(workflow): simplify nodes with extensible icons

### DIFF
--- a/yak-ops-ui/src/pages/workflow/definition/canvas/node/WorkflowNode.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/node/WorkflowNode.tsx
@@ -1,86 +1,55 @@
-import { Database, RefreshCcw, Timer } from 'lucide-react';
 import type { NodeProps } from 'reactflow';
 import type { WorkflowNodeData } from '../types';
 import WorkflowNodeControl from './WorkflowNodeControl';
 import WorkflowNodeHandle from './WorkflowNodeHandle';
+import WorkflowNodeIcon from './icons/WorkflowNodeIcon';
 
-const WorkflowNode = ({ id, data, selected }: NodeProps<WorkflowNodeData>) => {
-  const hasRetry = data.maxAttempts > 1;
-  const hasTimeout = data.executionTimeoutSeconds > 0;
+const WorkflowNode = ({ id, data, selected }: NodeProps<WorkflowNodeData>) => (
+  <div className="group relative w-60">
+    <WorkflowNodeControl
+      nodeId={id}
+      selected={selected}
+      locked={data.locked}
+      onDuplicate={data.onDuplicate}
+      onDelete={data.onDelete}
+    />
 
-  return (
+    <WorkflowNodeHandle nodeId={id} type="target" selected={selected} locked={data.locked} />
+
     <div
       className={[
-        'group relative w-60 rounded-[16px] border  transition-all duration-150',
+        'relative rounded-[15px] border bg-white px-3 py-3',
+        'shadow-[0_1px_2px_rgba(22,24,35,.06)]',
+        'transition-[border-color,box-shadow] duration-150',
+        'group-hover:shadow-[0_6px_18px_rgba(22,24,35,.10)]',
         selected
-          ? 'border-[#fe2c55] '
-          : 'border-transparent',
+          ? 'border-[#fe2c55] shadow-[0_0_0_2px_rgba(254,44,85,.06)]'
+          : 'border-[#e8e9ec] group-hover:border-[#d7d9de]',
       ].join(' ')}
     >
-      <WorkflowNodeControl
-        nodeId={id}
-        selected={selected}
-        locked={data.locked}
-        onDuplicate={data.onDuplicate}
-        onDelete={data.onDelete}
-      />
+      <div className="flex min-h-9 items-center gap-2.5">
+        <WorkflowNodeIcon taskType={data.taskType} />
 
-      <WorkflowNodeHandle nodeId={id} type="target" selected={selected} locked={data.locked} />
-      <div
-        className={[
-          'relative overflow-hidden rounded-[14px] bg-workflow-block-bg hover:shadow-lg  bg-white',
-          'shadow-[0_1px_2px_rgba(22,24,35,.05)]',
-          'transition-all duration-150 group-hover:border-[#d7d9de]',
-          'group-hover:shadow-[0_6px_18px_rgba(22,24,35,.10)]',
-        ].join(' ')}
-      >
-        <div className="flex items-center gap-2.5 px-3 pb-2.5 pt-3">
-          <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-[9px] bg-[#f4f4f5] text-[#52525b]">
-            <Database size={16} strokeWidth={1.8} />
+        <div className="min-w-0 flex-1">
+          <div className="truncate text-[10px] font-medium leading-4 text-[rgba(22,24,35,.38)]">
+            {data.typeLabel}
           </div>
-
-          <div className="min-w-0 flex-1">
-            <div className="text-[9px] font-semibold uppercase tracking-[.05em] text-[rgba(22,24,35,.38)]">
-              {data.typeLabel}
-            </div>
-            <div className="mt-0.5 truncate text-[13px] font-semibold leading-5 text-[#161823]">
-              {data.label}
-            </div>
+          <div className="mt-0.5 truncate text-[14px] font-semibold leading-5 text-[#161823]">
+            {data.label}
           </div>
-        </div>
-
-        <div className="border-t border-[#f0f0f2] bg-[#fcfcfd] px-3 py-2.5">
-          <div className="truncate text-[9px] text-[rgba(22,24,35,.34)]">
-            Task ID: {data.taskId}
-          </div>
-
-          {hasRetry || hasTimeout ? (
-            <div className="mt-2 flex flex-wrap items-center gap-1.5">
-              {hasRetry ? (
-                <span className="inline-flex items-center gap-1 rounded-md bg-[#f2f4f7] px-1.5 py-1 text-[9px] text-[rgba(22,24,35,.48)]">
-                  <RefreshCcw size={10} /> 最多 {data.maxAttempts} 次
-                </span>
-              ) : null}
-              {hasTimeout ? (
-                <span className="inline-flex items-center gap-1 rounded-md bg-[#f2f4f7] px-1.5 py-1 text-[9px] text-[rgba(22,24,35,.48)]">
-                  <Timer size={10} /> {data.executionTimeoutSeconds}s
-                </span>
-              ) : null}
-            </div>
-          ) : null}
         </div>
       </div>
-
-      <WorkflowNodeHandle
-        nodeId={id}
-        type="source"
-        selected={selected}
-        locked={data.locked}
-        appendOptions={data.appendOptions}
-        onAppend={data.onAppend}
-      />
     </div>
-  );
-};
+
+    <WorkflowNodeHandle
+      nodeId={id}
+      type="source"
+      selected={selected}
+      locked={data.locked}
+      appendOptions={data.appendOptions}
+      onAppend={data.onAppend}
+    />
+  </div>
+);
 
 export default WorkflowNode;

--- a/yak-ops-ui/src/pages/workflow/definition/canvas/node/icons/SyncNodeIcon.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/node/icons/SyncNodeIcon.tsx
@@ -1,0 +1,53 @@
+import type { SVGProps } from 'react';
+
+const SyncNodeIcon = (props: SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    aria-hidden="true"
+    {...props}
+  >
+    <ellipse cx="10" cy="6.5" rx="5" ry="2.5" stroke="currentColor" strokeWidth="1.6" />
+    <path
+      d="M5 6.5v4c0 1.38 2.24 2.5 5 2.5 1.12 0 2.16-.18 3-.5"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+    />
+    <path
+      d="M5 10.5v3.5c0 1.38 2.24 2.5 5 2.5.67 0 1.31-.07 1.9-.2"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+    />
+    <path
+      d="M14.6 10.3a4.45 4.45 0 0 1 4.9 1.15"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+    />
+    <path
+      d="m18.9 9.7.7 1.9-2 .3"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M19.4 15.7a4.45 4.45 0 0 1-4.9 1.15"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+    />
+    <path
+      d="m15.1 18.3-.7-1.9 2-.3"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+export default SyncNodeIcon;

--- a/yak-ops-ui/src/pages/workflow/definition/canvas/node/icons/WorkflowNodeIcon.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/node/icons/WorkflowNodeIcon.tsx
@@ -1,0 +1,55 @@
+import type { ComponentType, SVGProps } from 'react';
+import SyncNodeIcon from './SyncNodeIcon';
+
+interface WorkflowNodeIconProps {
+  taskType?: string;
+}
+
+interface NodeIconMeta {
+  icon: ComponentType<SVGProps<SVGSVGElement>>;
+  className: string;
+}
+
+const DefaultNodeIcon = (props: SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    aria-hidden="true"
+    {...props}
+  >
+    <rect x="5" y="5" width="5" height="5" rx="1.5" stroke="currentColor" strokeWidth="1.6" />
+    <rect x="14" y="14" width="5" height="5" rx="1.5" stroke="currentColor" strokeWidth="1.6" />
+    <path d="M10 7.5h3.5a3 3 0 0 1 3 3V14" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" />
+  </svg>
+);
+
+const DEFAULT_ICON_META: NodeIconMeta = {
+  icon: DefaultNodeIcon,
+  className: 'bg-[#f4f4f5] text-[#52525b]',
+};
+
+const NODE_ICON_META: Record<string, NodeIconMeta> = {
+  SYNC: {
+    icon: SyncNodeIcon,
+    className: 'bg-[#f4f4f5] text-[#52525b]',
+  },
+};
+
+const WorkflowNodeIcon = ({ taskType }: WorkflowNodeIconProps) => {
+  const meta = NODE_ICON_META[(taskType || '').toUpperCase()] || DEFAULT_ICON_META;
+  const Icon = meta.icon;
+
+  return (
+    <span
+      className={[
+        'flex h-9 w-9 shrink-0 items-center justify-center rounded-[10px]',
+        meta.className,
+      ].join(' ')}
+    >
+      <Icon className="h-[19px] w-[19px]" />
+    </span>
+  );
+};
+
+export default WorkflowNodeIcon;


### PR DESCRIPTION
## What changed

- Simplified the workflow node card to a cleaner Dify-style single-section layout: icon, node type label, and node name only.
- Removed Task ID from the canvas node presentation.
- Temporarily removed retry/timeout badges from the node card while keeping all retry, timeout, and failure-policy data/configuration intact for a later Dify-style status row.
- Added a dedicated `WorkflowNodeIcon` registry so node visuals are selected by `taskType` instead of hard-coding icons in `WorkflowNode`.
- Added a custom SVG icon for `SYNC` tasks.
- Added a neutral fallback SVG for future/unknown task types.
- Kept existing node controls, handles, hover interactions, selection state, and edge behavior unchanged.

## Design direction

The node shell now follows the same information hierarchy as Dify's compact nodes:

- compact 240px card
- subtle border and shadow
- stronger hover shadow
- selected brand border
- 36px icon tile
- small muted type label
- prominent single-line node title

The icon registry is intentionally separate from the node shell. Future `HTTP`, `SHELL`, `SQL`, quality, notification, and other node types can add their own SVG/icon metadata without changing `WorkflowNode`.

## Scope

- Frontend only.
- 3 files changed/added under `yak-ops-ui/src/pages/workflow/definition/canvas/node/**`.
- No workflow API or persisted definition changes.
- Retry/failure configuration remains available in node data and the inspector; only the canvas presentation is simplified.

## Validation

- Branch is based on current `main` and is not behind it.
- Final diff is limited to the workflow node presentation and icon layer.
- Opened as Draft for visual verification of card density, typography, icon proportions, selected/hover states, and handle alignment.