### PR TITLE
refactor(workflow): simplify node content hierarchy

### DIFF
--- a/yak-ops-ui/src/pages/workflow/definition/canvas/node/WorkflowNode.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/node/WorkflowNode.tsx
@@ -30,13 +30,8 @@ const WorkflowNode = ({ id, data, selected }: NodeProps<WorkflowNodeData>) => (
       <div className="flex min-h-9 items-center gap-2.5">
         <WorkflowNodeIcon taskType={data.taskType} />
 
-        <div className="min-w-0 flex-1">
-          <div className="truncate text-[10px] font-medium leading-4 text-[rgba(22,24,35,.38)]">
-            {data.typeLabel}
-          </div>
-          <div className="mt-0.5 truncate text-[14px] font-semibold leading-5 text-[#161823]">
-            {data.label}
-          </div>
+        <div className="min-w-0 flex-1 truncate text-[14px] font-semibold leading-5 text-[#161823]">
+          {data.label}
         </div>
       </div>
     </div>

--- a/yak-ops-ui/src/pages/workflow/definition/canvas/node/icons/WorkflowNodeIcon.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/node/icons/WorkflowNodeIcon.tsx
@@ -32,7 +32,7 @@ const DEFAULT_ICON_META: NodeIconMeta = {
 const NODE_ICON_META: Record<string, NodeIconMeta> = {
   SYNC: {
     icon: SyncNodeIcon,
-    className: 'bg-[#f4f4f5] text-[#52525b]',
+    className: 'bg-[rgba(254,44,85,.08)] text-[#fe2c55]',
   },
 };
 


### PR DESCRIPTION
## What changed

- Removed the node type label from the workflow card, so canvas nodes now show only the task icon and task name.
- Kept the existing 240px compact Dify-style card shell, hover shadow, selection state, handles, and node controls unchanged.
- Updated `SYNC` node icon styling to use a subtle Yak brand tint: light brand-red background with brand-red icon color.
- Left the icon registry structure intact so future `HTTP`, `SHELL`, `SQL`, and other task types can define their own visual treatment independently.

## Why

The type label (`数据同步`) duplicated information already conveyed by the node icon and made the card feel busier than the Dify-style reference. This change reduces the information hierarchy to the most useful canvas content: icon + business node name.

## Scope

- Frontend only.
- 2 files changed under `yak-ops-ui/src/pages/workflow/definition/canvas/node/**`.
- No workflow API, persistence, retry/failure configuration, edge behavior, or handle interaction changes.

## Validation

- Branch is based on current `main` and is not behind it.
- Final diff is limited to the node label hierarchy and SYNC icon colors.
- Opened as Draft for visual verification of spacing, title centering, truncation, and icon tint.