### PR TITLE
fix(workflow): stabilize source handle tooltip

### DIFF
--- a/yak-ops-ui/src/pages/workflow/definition/canvas/node/WorkflowNodeHandle.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/node/WorkflowNodeHandle.tsx
@@ -66,13 +66,15 @@ const WorkflowNodeHandle = ({
       ].join(' ')}
     >
       {canAppend ? (
-        <div className="pointer-events-none absolute -top-1 left-1/2 z-30 hidden -translate-x-1/2 -translate-y-full rounded-lg border border-[#e8e9ec] bg-white px-2 py-1.5 shadow-[0_4px_12px_rgba(22,24,35,.10)] group-hover/handle:block">
-          <div className="whitespace-nowrap text-[9px] leading-4 text-[rgba(22,24,35,.52)]">
+        <div className="pointer-events-none absolute -top-2 left-1/2 z-30 hidden origin-bottom -translate-x-1/2 -translate-y-full scale-[.8] rounded-lg border border-[#e8e9ec] bg-white px-2.5 py-2 shadow-[0_4px_12px_rgba(22,24,35,.10)] group-hover/handle:block">
+          <div className="whitespace-nowrap text-[11px] leading-[18px] text-[rgba(22,24,35,.52)]">
             <div>
-              <span className="font-medium text-[#52525b]">点击</span> 添加节点
+              <span className="font-medium text-[#161823]">点击</span>
+              <span className="ml-1">添加节点</span>
             </div>
             <div>
-              <span className="font-medium text-[#52525b]">拖拽</span> 连接节点
+              <span className="font-medium text-[#161823]">拖拽</span>
+              <span className="ml-1">连接节点</span>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## What changed

- Increased the source-handle guidance tooltip text from 9px to 11px for clearer Chinese text rendering.
- Added a little more spacing between the tooltip and the source `+` handle.
- Added an inverse `scale-[.8]` on the tooltip so the parent handle can still use `hover:scale-125` while the tooltip remains visually at its normal size.
- Kept the `+` hover growth, click-to-add behavior, and drag-to-connect behavior unchanged.
- Slightly refined typography and spacing for the two guidance rows:
  - 点击 添加节点
  - 拖拽 连接节点

## Why

The tooltip is rendered inside the ReactFlow source handle. Because the handle scales to 125% on hover, the tooltip inherited that transform and appeared too small/blurry and crowded in practice. The inverse scale keeps the handle animation while preventing the tooltip itself from visually scaling.

## Scope

- Frontend only.
- One file changed: `WorkflowNodeHandle.tsx`.
- No workflow API, node persistence, edge geometry, or add/connect behavior changes.

## Validation

- Branch is based on current `main` and is ahead by one commit with no unrelated changes.
- Final diff is limited to tooltip spacing, typography, and transform treatment.
- Opened as Draft for quick visual verification of tooltip clarity and placement.