### PR TITLE
refactor(workflow): rebuild node inspector in Dify style

### DIFF
--- a/yak-ops-ui/src/pages/workflow/definition/WorkflowDefinitionEditor.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/WorkflowDefinitionEditor.tsx
@@ -346,6 +346,25 @@ const WorkflowDefinitionContent = () => {
     typeLabel: task.type === 'SYNC' ? '数据同步' : task.type,
   })), [syncTasks]);
 
+  const inspectorNextNodes = useMemo(() => {
+    if (!selectedNode) return [];
+    const targetIds = new Set(
+      edges.filter((edge) => edge.source === selectedNode.id).map((edge) => edge.target),
+    );
+    return nodes
+      .filter((node) => targetIds.has(node.id))
+      .map((node) => ({
+        id: node.id,
+        label: node.data.label,
+        taskType: node.data.taskType,
+      }));
+  }, [edges, nodes, selectedNode]);
+
+  const closeNodeInspector = useCallback(() => {
+    setNodes((current) => current.map((node) =>
+      node.selected ? { ...node, selected: false } : node));
+  }, [setNodes]);
+
   const canvasNodes = useMemo(() => nodes.map((node) => ({
     ...node,
     data: {
@@ -479,7 +498,20 @@ const WorkflowDefinitionContent = () => {
           onOffline={() => void handleOffline()}
         />
         <div ref={wrapperRef} className="relative min-h-0 flex-1 bg-[#f2f4f7]" onDrop={handleDrop}>
-          {selectedNode ? <WorkflowNodeInspector node={selectedNode} locked={locked} onChange={updateSelectedNode} /> : null}
+          {selectedNode ? (
+            <WorkflowNodeInspector
+              node={selectedNode}
+              locked={locked}
+              definitionId={id}
+              nextNodes={inspectorNextNodes}
+              appendOptions={taskOptions}
+              onChange={updateSelectedNode}
+              onClose={closeNodeInspector}
+              onDuplicate={() => handleDuplicateNode(selectedNode.id)}
+              onDelete={() => handleDeleteNode(selectedNode.id)}
+              onAppend={(taskId) => handleAppendTask(selectedNode.id, taskId)}
+            />
+          ) : null}
           <ReactFlow
             nodes={canvasNodes}
             edges={canvasEdges}

--- a/yak-ops-ui/src/pages/workflow/definition/canvas/WorkflowNodeInspector.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/WorkflowNodeInspector.tsx
@@ -1,91 +1,158 @@
-import type {
-  WorkflowNodeFailurePolicy,
-  WorkflowTriggerRule,
-} from '@/services/workflow';
-import { Input, InputNumber, Select } from 'antd';
-import type { ReactNode } from 'react';
+import { Dropdown } from 'antd';
+import type { MenuProps } from 'antd';
+import { Copy, Ellipsis, Trash2, X } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
 import type { Node } from 'reactflow';
-import type { WorkflowNodeData } from './types';
+import type { WorkflowCanvasTaskOption, WorkflowNodeData } from './types';
+import WorkflowNodeIcon from './node/icons/WorkflowNodeIcon';
+import WorkflowNodeInspectorLastRun from './WorkflowNodeInspectorLastRun';
+import WorkflowNodeInspectorSettings from './WorkflowNodeInspectorSettings';
+import type { WorkflowInspectorNextNode } from './WorkflowNodeInspectorSettings';
 
-const TRIGGER_RULE_OPTIONS = [
-  { value: 'ALL_SUCCESS', label: '全部前置成功' },
-  { value: 'ALL_DONE', label: '全部前置结束' },
-  { value: 'NONE_FAILED', label: '无前置失败' },
-  { value: 'ONE_SUCCESS', label: '至少一个成功' },
-  { value: 'ALWAYS', label: '始终执行' },
-];
-
-const NODE_FAILURE_OPTIONS = [
-  { value: 'FAIL_WORKFLOW', label: '标记工作流失败' },
-  { value: 'BLOCK_BRANCH', label: '仅阻断当前分支' },
-  { value: 'IGNORE_FAILURE', label: '忽略失败继续' },
-];
+type InspectorTab = 'settings' | 'lastRun';
 
 interface WorkflowNodeInspectorProps {
   node: Node<WorkflowNodeData>;
   locked: boolean;
+  definitionId: string;
+  nextNodes: WorkflowInspectorNextNode[];
+  appendOptions: WorkflowCanvasTaskOption[];
   onChange: (patch: Partial<WorkflowNodeData>) => void;
+  onClose: () => void;
+  onDuplicate: () => void;
+  onDelete: () => void;
+  onAppend: (taskId: string) => void;
 }
 
-const FieldLabel = ({ children }: { children: ReactNode }) => (
-  <div className="text-[10px] text-[rgba(22,24,35,.48)]">{children}</div>
+const ActionButton = ({
+  label,
+  children,
+  onClick,
+}: {
+  label: string;
+  children: React.ReactNode;
+  onClick?: () => void;
+}) => (
+  <button
+    type="button"
+    aria-label={label}
+    className="flex h-7 w-7 items-center justify-center rounded-md border-0 bg-transparent text-[#667085] transition-colors hover:bg-[#f2f4f7] hover:text-[#344054]"
+    onClick={onClick}
+  >
+    {children}
+  </button>
 );
 
-const WorkflowNodeInspector = ({ node, locked, onChange }: WorkflowNodeInspectorProps) => (
-  <div className="absolute right-4 top-4 z-20 w-[340px] rounded-xl border border-[#e3e5e8] bg-white p-3 shadow-[0_10px_30px_rgba(22,24,35,.10)]">
-    <div className="text-[12px] font-semibold text-[#161823]">任务节点</div>
-    <div className="mt-3 grid grid-cols-2 gap-2 rounded-lg bg-[#f7f7f8] p-2.5">
-      <div>
-        <FieldLabel>任务名称</FieldLabel>
-        <div className="mt-1 truncate text-[12px] font-medium">{node.data.label}</div>
+const WorkflowNodeInspector = ({
+  node,
+  locked,
+  definitionId,
+  nextNodes,
+  appendOptions,
+  onChange,
+  onClose,
+  onDuplicate,
+  onDelete,
+  onAppend,
+}: WorkflowNodeInspectorProps) => {
+  const [activeTab, setActiveTab] = useState<InspectorTab>('settings');
+
+  useEffect(() => {
+    setActiveTab('settings');
+  }, [node.id]);
+
+  const menuItems = useMemo<MenuProps['items']>(() => [
+    {
+      key: 'duplicate',
+      icon: <Copy size={14} />,
+      label: '复制节点',
+      disabled: locked,
+      onClick: onDuplicate,
+    },
+    { type: 'divider' },
+    {
+      key: 'delete',
+      icon: <Trash2 size={14} />,
+      label: '删除节点',
+      danger: true,
+      disabled: locked,
+      onClick: onDelete,
+    },
+  ], [locked, onDelete, onDuplicate]);
+
+  return (
+    <aside className="absolute bottom-3 right-3 top-3 z-20 flex w-[400px] flex-col overflow-hidden rounded-2xl border border-[#e2e5e9] bg-white shadow-[0_12px_36px_rgba(22,24,35,.12)]">
+      <header className="shrink-0 border-b border-[#eceef1] bg-white">
+        <div className="flex items-center gap-2 px-4 pb-2 pt-4">
+          <WorkflowNodeIcon taskType={node.data.taskType} size="sm" />
+          <div className="min-w-0 flex-1 truncate text-[14px] font-semibold text-[#161823]">
+            {node.data.label}
+          </div>
+
+          <div className="flex shrink-0 items-center gap-0.5">
+            <ActionButton label="复制节点" onClick={locked ? undefined : onDuplicate}>
+              <Copy size={15} />
+            </ActionButton>
+            <Dropdown menu={{ items: menuItems }} trigger={['click']} placement="bottomRight">
+              <span>
+                <ActionButton label="更多操作">
+                  <Ellipsis size={16} />
+                </ActionButton>
+              </span>
+            </Dropdown>
+            <div className="mx-1 h-4 w-px bg-[#e7e9ed]" />
+            <ActionButton label="关闭" onClick={onClose}>
+              <X size={16} />
+            </ActionButton>
+          </div>
+        </div>
+
+        <div className="px-4 pb-2 text-[11px] leading-5 text-[rgba(22,24,35,.36)]">
+          配置此任务节点在工作流中的编排、重试、超时和异常处理行为。
+        </div>
+
+        <nav className="flex h-10 items-end gap-5 px-4" aria-label="节点配置页签">
+          <button
+            type="button"
+            className={[
+              'relative h-10 border-0 bg-transparent px-0 text-[12px] font-semibold transition-colors',
+              activeTab === 'settings' ? 'text-[#344054]' : 'text-[#667085] hover:text-[#344054]',
+            ].join(' ')}
+            onClick={() => setActiveTab('settings')}
+          >
+            设置
+            {activeTab === 'settings' ? <span className="absolute bottom-0 left-0 right-0 h-0.5 rounded-full bg-[#fe2c55]" /> : null}
+          </button>
+          <button
+            type="button"
+            className={[
+              'relative h-10 border-0 bg-transparent px-0 text-[12px] font-semibold transition-colors',
+              activeTab === 'lastRun' ? 'text-[#344054]' : 'text-[#667085] hover:text-[#344054]',
+            ].join(' ')}
+            onClick={() => setActiveTab('lastRun')}
+          >
+            上次运行
+            {activeTab === 'lastRun' ? <span className="absolute bottom-0 left-0 right-0 h-0.5 rounded-full bg-[#fe2c55]" /> : null}
+          </button>
+        </nav>
+      </header>
+
+      <div className="min-h-0 flex-1 overflow-y-auto bg-white">
+        {activeTab === 'settings' ? (
+          <WorkflowNodeInspectorSettings
+            node={node}
+            locked={locked}
+            nextNodes={nextNodes}
+            appendOptions={appendOptions}
+            onChange={onChange}
+            onAppend={onAppend}
+          />
+        ) : (
+          <WorkflowNodeInspectorLastRun definitionId={definitionId} nodeId={node.id} />
+        )}
       </div>
-      <div>
-        <FieldLabel>任务类型</FieldLabel>
-        <div className="mt-1 text-[12px] font-medium">{node.data.typeLabel}</div>
-      </div>
-    </div>
-    <div className="mt-3 grid grid-cols-2 gap-2">
-      <div>
-        <FieldLabel>触发规则</FieldLabel>
-        <Select disabled={locked} className="mt-1 w-full" size="small"
-          value={node.data.triggerRule} options={TRIGGER_RULE_OPTIONS}
-          onChange={(value) => onChange({ triggerRule: value as WorkflowTriggerRule })} />
-      </div>
-      <div>
-        <FieldLabel>失败策略</FieldLabel>
-        <Select disabled={locked} className="mt-1 w-full" size="small"
-          value={node.data.failurePolicy} options={NODE_FAILURE_OPTIONS}
-          onChange={(value) => onChange({ failurePolicy: value as WorkflowNodeFailurePolicy })} />
-      </div>
-      <div>
-        <FieldLabel>最大 Attempt</FieldLabel>
-        <InputNumber disabled={locked} min={1} value={node.data.maxAttempts}
-          onChange={(value) => onChange({ maxAttempts: Number(value || 1) })} className="mt-1 w-full" />
-      </div>
-      <div>
-        <FieldLabel>重试延迟（秒）</FieldLabel>
-        <InputNumber disabled={locked} min={0} value={node.data.retryDelaySeconds}
-          onChange={(value) => onChange({ retryDelaySeconds: Number(value || 0) })} className="mt-1 w-full" />
-      </div>
-      <div>
-        <FieldLabel>派发超时（秒）</FieldLabel>
-        <InputNumber disabled={locked} min={0} value={node.data.dispatchTimeoutSeconds}
-          onChange={(value) => onChange({ dispatchTimeoutSeconds: Number(value || 0) })} className="mt-1 w-full" />
-      </div>
-      <div>
-        <FieldLabel>执行超时（秒）</FieldLabel>
-        <InputNumber disabled={locked} min={0} value={node.data.executionTimeoutSeconds}
-          onChange={(value) => onChange({ executionTimeoutSeconds: Number(value || 0) })} className="mt-1 w-full" />
-      </div>
-    </div>
-    <div className="mt-3"><FieldLabel>Input Mapping</FieldLabel></div>
-    <Input.TextArea disabled={locked} rows={4} className="mt-1 font-mono !text-[10px]"
-      value={node.data.inputMappingText}
-      onChange={(event) => onChange({ inputMappingText: event.target.value })} />
-    <div className="mt-1.5 text-[9px] leading-4 text-[rgba(22,24,35,.38)]">
-      任务自身配置不在工作流中编辑；这里只配置编排行为。
-    </div>
-  </div>
-);
+    </aside>
+  );
+};
 
 export default WorkflowNodeInspector;

--- a/yak-ops-ui/src/pages/workflow/definition/canvas/WorkflowNodeInspector.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/WorkflowNodeInspector.tsx
@@ -2,6 +2,7 @@ import { Dropdown } from 'antd';
 import type { MenuProps } from 'antd';
 import { Copy, Ellipsis, Trash2, X } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
+import type { ReactNode } from 'react';
 import type { Node } from 'reactflow';
 import type { WorkflowCanvasTaskOption, WorkflowNodeData } from './types';
 import WorkflowNodeIcon from './node/icons/WorkflowNodeIcon';
@@ -30,7 +31,7 @@ const ActionButton = ({
   onClick,
 }: {
   label: string;
-  children: React.ReactNode;
+  children: ReactNode;
   onClick?: () => void;
 }) => (
   <button

--- a/yak-ops-ui/src/pages/workflow/definition/canvas/WorkflowNodeInspectorLastRun.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/WorkflowNodeInspectorLastRun.tsx
@@ -1,4 +1,5 @@
 import {
+  getWorkflowInstance,
   getWorkflowInstances,
   type WorkflowInstance,
   type WorkflowNodeInstance,
@@ -92,10 +93,17 @@ const WorkflowNodeInspectorLastRun = ({
       const instances = (await getWorkflowInstances()) || [];
       const latest = instances
         .filter((item) => item.definitionId === definitionId)
-        .sort((left, right) => dayjs(right.startedAt).valueOf() - dayjs(left.startedAt).valueOf())
-        .find((item) => item.nodes?.some((node) => node.id === nodeId));
-      setInstance(latest);
-      setNodeRun(latest?.nodes?.find((node) => node.id === nodeId));
+        .sort((left, right) => dayjs(right.startedAt).valueOf() - dayjs(left.startedAt).valueOf())[0];
+
+      if (!latest) {
+        setInstance(undefined);
+        setNodeRun(undefined);
+        return;
+      }
+
+      const detail = await getWorkflowInstance(latest.id);
+      setInstance(detail);
+      setNodeRun(detail.nodes?.find((node) => node.id === nodeId));
     } catch (error) {
       setInstance(undefined);
       setNodeRun(undefined);

--- a/yak-ops-ui/src/pages/workflow/definition/canvas/WorkflowNodeInspectorLastRun.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/WorkflowNodeInspectorLastRun.tsx
@@ -1,0 +1,208 @@
+import {
+  getWorkflowInstances,
+  type WorkflowInstance,
+  type WorkflowNodeInstance,
+} from '@/services/workflow';
+import { Spin } from 'antd';
+import dayjs from 'dayjs';
+import { RefreshCw } from 'lucide-react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+interface WorkflowNodeInspectorLastRunProps {
+  definitionId: string;
+  nodeId: string;
+}
+
+const STATUS_META: Record<string, { label: string; className: string; dotClassName: string }> = {
+  SUCCESS: {
+    label: 'SUCCESS',
+    className: 'border-[#86d9a8] bg-[linear-gradient(110deg,#effcf4,#e7fbf2)] text-[#138a4b]',
+    dotClassName: 'bg-[#22c55e]',
+  },
+  SUCCESS_WITH_WARNINGS: {
+    label: 'SUCCESS WITH WARNINGS',
+    className: 'border-[#f4d68f] bg-[#fffaf0] text-[#b7791f]',
+    dotClassName: 'bg-[#f59e0b]',
+  },
+  RUNNING: {
+    label: 'RUNNING',
+    className: 'border-[#a9c7ff] bg-[#f2f7ff] text-[#2563eb]',
+    dotClassName: 'bg-[#3b82f6]',
+  },
+  FAILED: {
+    label: 'FAILED',
+    className: 'border-[#ffc1ce] bg-[#fff4f6] text-[#d92d4a]',
+    dotClassName: 'bg-[#fe2c55]',
+  },
+  CANCELED: {
+    label: 'CANCELED',
+    className: 'border-[#dadde3] bg-[#f7f7f8] text-[#667085]',
+    dotClassName: 'bg-[#98a2b3]',
+  },
+  TIMED_OUT: {
+    label: 'TIMED OUT',
+    className: 'border-[#ffc1ce] bg-[#fff4f6] text-[#d92d4a]',
+    dotClassName: 'bg-[#fe2c55]',
+  },
+};
+
+const jsonText = (value: unknown) => JSON.stringify(value ?? {}, null, 2);
+
+const formatElapsed = (node?: WorkflowNodeInstance) => {
+  const attempt = node?.attempts?.[node.attempts.length - 1];
+  if (!attempt?.startedAt) return '--';
+  const end = attempt.endedAt ? dayjs(attempt.endedAt) : dayjs();
+  const duration = Math.max(0, end.diff(dayjs(attempt.startedAt), 'millisecond'));
+  if (duration < 1000) return `${duration}ms`;
+  return `${(duration / 1000).toFixed(3)}s`;
+};
+
+const JsonBlock = ({ title, value }: { title: string; value: unknown }) => (
+  <section>
+    <div className="mb-2 text-[12px] font-semibold text-[#344054]">{title}</div>
+    <div className="max-h-[210px] overflow-auto rounded-xl bg-[#f5f6f7] px-3 py-3">
+      <pre className="m-0 whitespace-pre-wrap break-words font-mono text-[11px] leading-[18px] text-[#344054]">
+        {jsonText(value)}
+      </pre>
+    </div>
+  </section>
+);
+
+const MetaRow = ({ label, value }: { label: string; value?: string | number }) => (
+  <div className="flex min-h-7 items-center justify-between gap-4 text-[11px]">
+    <span className="shrink-0 text-[rgba(22,24,35,.42)]">{label}</span>
+    <span className="min-w-0 truncate text-right font-medium text-[#475467]">{value ?? '--'}</span>
+  </div>
+);
+
+const WorkflowNodeInspectorLastRun = ({
+  definitionId,
+  nodeId,
+}: WorkflowNodeInspectorLastRunProps) => {
+  const [loading, setLoading] = useState(false);
+  const [instance, setInstance] = useState<WorkflowInstance>();
+  const [nodeRun, setNodeRun] = useState<WorkflowNodeInstance>();
+  const [loadError, setLoadError] = useState('');
+
+  const load = useCallback(async () => {
+    if (!definitionId || !nodeId) return;
+    setLoading(true);
+    setLoadError('');
+    try {
+      const instances = (await getWorkflowInstances()) || [];
+      const latest = instances
+        .filter((item) => item.definitionId === definitionId)
+        .sort((left, right) => dayjs(right.startedAt).valueOf() - dayjs(left.startedAt).valueOf())
+        .find((item) => item.nodes?.some((node) => node.id === nodeId));
+      setInstance(latest);
+      setNodeRun(latest?.nodes?.find((node) => node.id === nodeId));
+    } catch (error) {
+      setInstance(undefined);
+      setNodeRun(undefined);
+      setLoadError(error instanceof Error ? error.message : '上次运行加载失败');
+    } finally {
+      setLoading(false);
+    }
+  }, [definitionId, nodeId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const statusMeta = useMemo(() => {
+    const status = nodeRun?.status || '';
+    return STATUS_META[status] || {
+      label: status || '--',
+      className: 'border-[#e4e7ec] bg-[#f7f7f8] text-[#667085]',
+      dotClassName: 'bg-[#98a2b3]',
+    };
+  }, [nodeRun?.status]);
+
+  if (loading) {
+    return (
+      <div className="flex h-full min-h-[360px] items-center justify-center">
+        <Spin size="small" />
+      </div>
+    );
+  }
+
+  if (!nodeRun) {
+    return (
+      <div className="flex h-full min-h-[360px] flex-col items-center justify-center px-8 text-center">
+        <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-[#f5f6f7] text-[#98a2b3]">
+          <RefreshCw size={17} />
+        </div>
+        <div className="mt-3 text-[13px] font-semibold text-[#344054]">暂无运行记录</div>
+        <div className="mt-1 text-[11px] leading-5 text-[rgba(22,24,35,.42)]">
+          {loadError || '运行过工作流后，这里会展示该节点最近一次真实的输入、输出和执行状态。'}
+        </div>
+        <button
+          type="button"
+          className="mt-4 rounded-lg border border-[#e4e7ec] bg-white px-3 py-1.5 text-[11px] font-medium text-[#475467] shadow-sm hover:bg-[#f7f7f8]"
+          onClick={() => void load()}
+        >
+          重新加载
+        </button>
+      </div>
+    );
+  }
+
+  const attempt = nodeRun.attempts?.[nodeRun.attempts.length - 1];
+
+  return (
+    <div className="space-y-5 px-4 pb-6 pt-4">
+      <div className="flex items-center justify-between">
+        <div className="text-[12px] font-semibold text-[#344054]">最近一次运行</div>
+        <button
+          type="button"
+          className="flex h-7 w-7 items-center justify-center rounded-md border-0 bg-transparent text-[#98a2b3] hover:bg-[#f2f4f7] hover:text-[#475467]"
+          onClick={() => void load()}
+          aria-label="刷新上次运行"
+        >
+          <RefreshCw size={14} />
+        </button>
+      </div>
+
+      <div className={`grid grid-cols-3 overflow-hidden rounded-xl border ${statusMeta.className}`}>
+        <div className="px-3 py-2.5">
+          <div className="text-[9px] text-current opacity-60">状态</div>
+          <div className="mt-1 flex items-center gap-1.5 text-[11px] font-semibold">
+            <span className={`h-1.5 w-1.5 rounded-full ${statusMeta.dotClassName}`} />
+            {statusMeta.label}
+          </div>
+        </div>
+        <div className="border-l border-current/10 px-3 py-2.5">
+          <div className="text-[9px] text-current opacity-60">运行时间</div>
+          <div className="mt-1 text-[11px] font-semibold">{formatElapsed(nodeRun)}</div>
+        </div>
+        <div className="border-l border-current/10 px-3 py-2.5">
+          <div className="text-[9px] text-current opacity-60">Attempt</div>
+          <div className="mt-1 text-[11px] font-semibold">{nodeRun.attemptCount || nodeRun.attempts?.length || 0}</div>
+        </div>
+      </div>
+
+      <JsonBlock title="输入" value={nodeRun.input} />
+      <JsonBlock title="输出" value={nodeRun.output} />
+
+      {(nodeRun.errorMessage || nodeRun.failureReason) ? (
+        <section>
+          <div className="mb-2 text-[12px] font-semibold text-[#344054]">错误信息</div>
+          <div className="rounded-xl border border-[#ffc7d2] bg-[#fff5f7] px-3 py-2.5 text-[11px] leading-5 text-[#b4233f]">
+            {nodeRun.errorMessage || nodeRun.failureReason}
+          </div>
+        </section>
+      ) : null}
+
+      <section className="border-t border-[#f0f1f3] pt-4">
+        <div className="mb-2 text-[12px] font-semibold text-[#344054]">元数据</div>
+        <MetaRow label="节点状态" value={nodeRun.status} />
+        <MetaRow label="工作流状态" value={instance?.status} />
+        <MetaRow label="当前 Attempt" value={nodeRun.currentAttemptNumber || attempt?.attemptNumber} />
+        <MetaRow label="开始时间" value={attempt?.startedAt ? dayjs(attempt.startedAt).format('YYYY-MM-DD HH:mm:ss') : '--'} />
+        <MetaRow label="结束时间" value={attempt?.endedAt ? dayjs(attempt.endedAt).format('YYYY-MM-DD HH:mm:ss') : '--'} />
+      </section>
+    </div>
+  );
+};
+
+export default WorkflowNodeInspectorLastRun;

--- a/yak-ops-ui/src/pages/workflow/definition/canvas/WorkflowNodeInspectorSettings.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/WorkflowNodeInspectorSettings.tsx
@@ -1,0 +1,227 @@
+import type {
+  WorkflowNodeFailurePolicy,
+  WorkflowTriggerRule,
+} from '@/services/workflow';
+import { Input, InputNumber, Select, Switch } from 'antd';
+import { Plus } from 'lucide-react';
+import type { Node } from 'reactflow';
+import type { WorkflowCanvasTaskOption, WorkflowNodeData } from './types';
+import WorkflowNodeIcon from './node/icons/WorkflowNodeIcon';
+
+const TRIGGER_RULE_OPTIONS = [
+  { value: 'ALL_SUCCESS', label: '全部前置成功' },
+  { value: 'ALL_DONE', label: '全部前置结束' },
+  { value: 'NONE_FAILED', label: '无前置失败' },
+  { value: 'ONE_SUCCESS', label: '至少一个成功' },
+  { value: 'ALWAYS', label: '始终执行' },
+];
+
+const NODE_FAILURE_OPTIONS = [
+  { value: 'FAIL_WORKFLOW', label: '标记工作流失败' },
+  { value: 'BLOCK_BRANCH', label: '仅阻断当前分支' },
+  { value: 'IGNORE_FAILURE', label: '忽略失败继续' },
+];
+
+export interface WorkflowInspectorNextNode {
+  id: string;
+  label: string;
+  taskType: string;
+}
+
+interface WorkflowNodeInspectorSettingsProps {
+  node: Node<WorkflowNodeData>;
+  locked: boolean;
+  nextNodes: WorkflowInspectorNextNode[];
+  appendOptions: WorkflowCanvasTaskOption[];
+  onChange: (patch: Partial<WorkflowNodeData>) => void;
+  onAppend: (taskId: string) => void;
+}
+
+const SectionTitle = ({ children }: { children: string }) => (
+  <div className="mb-2 text-[11px] font-semibold text-[#344054]">{children}</div>
+);
+
+const FieldLabel = ({ children }: { children: string }) => (
+  <div className="mb-1.5 text-[10px] font-medium text-[rgba(22,24,35,.46)]">{children}</div>
+);
+
+const Divider = () => <div className="mx-4 border-t border-[#f0f1f3]" />;
+
+const WorkflowNodeInspectorSettings = ({
+  node,
+  locked,
+  nextNodes,
+  appendOptions,
+  onChange,
+  onAppend,
+}: WorkflowNodeInspectorSettingsProps) => {
+  const retryEnabled = node.data.maxAttempts > 1;
+
+  const appendSelectOptions = appendOptions.map((item) => ({
+    value: item.id,
+    label: item.label,
+  }));
+
+  return (
+    <div className="pb-6">
+      <section className="space-y-4 px-4 py-4">
+        <div>
+          <SectionTitle>执行条件</SectionTitle>
+          <FieldLabel>触发规则</FieldLabel>
+          <Select
+            disabled={locked}
+            variant="filled"
+            className="w-full"
+            value={node.data.triggerRule}
+            options={TRIGGER_RULE_OPTIONS}
+            onChange={(value) => onChange({ triggerRule: value as WorkflowTriggerRule })}
+          />
+        </div>
+
+        <div>
+          <SectionTitle>输入映射</SectionTitle>
+          <Input.TextArea
+            disabled={locked}
+            rows={5}
+            value={node.data.inputMappingText}
+            className="font-mono !text-[11px]"
+            onChange={(event) => onChange({ inputMappingText: event.target.value })}
+          />
+          <div className="mt-1.5 text-[10px] leading-4 text-[rgba(22,24,35,.34)]">
+            将工作流上下文映射为当前任务输入；任务自身配置仍在任务定义中维护。
+          </div>
+        </div>
+      </section>
+
+      <Divider />
+
+      <section className="py-2">
+        <div className="flex min-h-11 items-center justify-between px-4 py-2">
+          <div>
+            <div className="text-[11px] font-semibold text-[#344054]">失败时重试</div>
+            <div className="mt-0.5 text-[10px] text-[rgba(22,24,35,.36)]">节点失败后按固定间隔重新执行</div>
+          </div>
+          <Switch
+            size="small"
+            disabled={locked}
+            checked={retryEnabled}
+            onChange={(checked) => onChange({ maxAttempts: checked ? Math.max(3, node.data.maxAttempts) : 1 })}
+          />
+        </div>
+
+        {retryEnabled ? (
+          <div className="grid grid-cols-2 gap-2 px-4 pb-3 pt-1">
+            <div>
+              <FieldLabel>最大 Attempt</FieldLabel>
+              <InputNumber
+                disabled={locked}
+                min={2}
+                max={10}
+                value={node.data.maxAttempts}
+                className="w-full"
+                onChange={(value) => onChange({ maxAttempts: Number(value || 2) })}
+              />
+            </div>
+            <div>
+              <FieldLabel>重试延迟（秒）</FieldLabel>
+              <InputNumber
+                disabled={locked}
+                min={0}
+                value={node.data.retryDelaySeconds}
+                className="w-full"
+                onChange={(value) => onChange({ retryDelaySeconds: Number(value || 0) })}
+              />
+            </div>
+          </div>
+        ) : null}
+      </section>
+
+      <Divider />
+
+      <section className="px-4 py-4">
+        <SectionTitle>超时控制</SectionTitle>
+        <div className="grid grid-cols-2 gap-2">
+          <div>
+            <FieldLabel>派发超时（秒）</FieldLabel>
+            <InputNumber
+              disabled={locked}
+              min={0}
+              value={node.data.dispatchTimeoutSeconds}
+              className="w-full"
+              onChange={(value) => onChange({ dispatchTimeoutSeconds: Number(value || 0) })}
+            />
+          </div>
+          <div>
+            <FieldLabel>执行超时（秒）</FieldLabel>
+            <InputNumber
+              disabled={locked}
+              min={0}
+              value={node.data.executionTimeoutSeconds}
+              className="w-full"
+              onChange={(value) => onChange({ executionTimeoutSeconds: Number(value || 0) })}
+            />
+          </div>
+        </div>
+      </section>
+
+      <Divider />
+
+      <section className="flex min-h-[64px] items-center justify-between gap-4 px-4 py-3">
+        <div>
+          <div className="text-[11px] font-semibold text-[#344054]">异常处理</div>
+          <div className="mt-0.5 text-[10px] text-[rgba(22,24,35,.36)]">当前节点最终失败时如何影响工作流</div>
+        </div>
+        <Select
+          disabled={locked}
+          variant="filled"
+          className="w-[160px] shrink-0"
+          value={node.data.failurePolicy}
+          options={NODE_FAILURE_OPTIONS}
+          onChange={(value) => onChange({ failurePolicy: value as WorkflowNodeFailurePolicy })}
+        />
+      </section>
+
+      <Divider />
+
+      <section className="px-4 py-4">
+        <SectionTitle>下一步</SectionTitle>
+        <div className="mb-3 text-[10px] leading-4 text-[rgba(22,24,35,.38)]">添加此节点执行完成后的下一个任务</div>
+
+        <div className="space-y-1.5">
+          {nextNodes.map((item) => (
+            <div
+              key={item.id}
+              className="flex items-center gap-2 rounded-xl border border-[#e7e9ed] bg-white px-2.5 py-2 shadow-[0_1px_2px_rgba(22,24,35,.03)]"
+            >
+              <WorkflowNodeIcon taskType={item.taskType} size="sm" />
+              <div className="min-w-0 flex-1 truncate text-[11px] font-medium text-[#344054]">{item.label}</div>
+            </div>
+          ))}
+
+          {!nextNodes.length ? (
+            <div className="rounded-xl border border-dashed border-[#dfe3e8] bg-[#fafafa] px-3 py-3 text-center text-[10px] text-[rgba(22,24,35,.36)]">
+              暂无后续节点
+            </div>
+          ) : null}
+        </div>
+
+        {!locked && appendSelectOptions.length ? (
+          <Select
+            className="mt-2 w-full"
+            variant="filled"
+            value={undefined}
+            placeholder={
+              <span className="inline-flex items-center gap-1.5 text-[rgba(22,24,35,.42)]">
+                <Plus size={13} /> 添加后续任务
+              </span>
+            }
+            options={appendSelectOptions}
+            onChange={(value) => onAppend(value)}
+          />
+        ) : null}
+      </section>
+    </div>
+  );
+};
+
+export default WorkflowNodeInspectorSettings;

--- a/yak-ops-ui/src/pages/workflow/definition/canvas/node/icons/WorkflowNodeIcon.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/node/icons/WorkflowNodeIcon.tsx
@@ -3,6 +3,7 @@ import SyncNodeIcon from './SyncNodeIcon';
 
 interface WorkflowNodeIconProps {
   taskType?: string;
+  size?: 'sm' | 'md';
 }
 
 interface NodeIconMeta {
@@ -36,18 +37,20 @@ const NODE_ICON_META: Record<string, NodeIconMeta> = {
   },
 };
 
-const WorkflowNodeIcon = ({ taskType }: WorkflowNodeIconProps) => {
+const WorkflowNodeIcon = ({ taskType, size = 'md' }: WorkflowNodeIconProps) => {
   const meta = NODE_ICON_META[(taskType || '').toUpperCase()] || DEFAULT_ICON_META;
   const Icon = meta.icon;
+  const compact = size === 'sm';
 
   return (
     <span
       className={[
-        'flex h-9 w-9 shrink-0 items-center justify-center rounded-[10px]',
+        'flex shrink-0 items-center justify-center',
+        compact ? 'h-7 w-7 rounded-[8px]' : 'h-9 w-9 rounded-[10px]',
         meta.className,
       ].join(' ')}
     >
-      <Icon className="h-[19px] w-[19px]" />
+      <Icon className={compact ? 'h-[15px] w-[15px]' : 'h-[19px] w-[19px]'} />
     </span>
   );
 };


### PR DESCRIPTION
## What changed

- Rebuilt the workflow node inspector as a full-height 400px Dify-style side panel instead of the previous compact floating form card.
- Added a unified header with node icon/name, duplicate action, overflow menu, delete action, and close control.
- Added sticky `设置 / 上次运行` tabs.
- Split node configuration into a dedicated settings panel with clearer Dify-inspired sections:
  - trigger rule
  - input mapping
  - retry-on-failure switch and retry parameters
  - timeout controls
  - error/failure handling
  - next-step preview and quick append
- Added a real `上次运行` panel backed by existing workflow instance APIs. It loads the latest instance for the current definition, fetches the detailed instance, and displays the selected node's:
  - status
  - elapsed time
  - attempt count
  - input JSON
  - output JSON
  - error/failure details
  - execution metadata and timestamps
- Extended `WorkflowNodeIcon` with a compact size so the same icon system can be reused consistently in the inspector header and next-step cards.

## Dify design reference

This follows Dify's workflow panel architecture rather than only copying styles. Dify's base `WorkflowPanel` owns the shared panel shell, sticky header, node actions, tabs, retry/error handling, next-step area, and last-run rendering, while node-specific panels only own their settings content. The relevant upstream implementation was introduced in `langgenius/dify#21369` (`feat: last run frontend`), especially:

- `workflow-panel/index.tsx`
- `workflow-panel/tab.tsx`
- `workflow-panel/last-run/index.tsx`
- shared retry and error-handle panel components

Yak Ops now mirrors that separation with `WorkflowNodeInspector`, `WorkflowNodeInspectorSettings`, and `WorkflowNodeInspectorLastRun`.

## Scope

- Frontend only.
- No workflow definition payload/schema changes.
- No backend API changes.
- Existing retry, timeout, trigger, failure-policy, input-mapping, duplicate/delete, and append-node behavior is preserved.
- Last-run data reuses existing `/api/v1/workflows/instances` and instance-detail APIs; no mock data is introduced.

## Validation

- Branch is based on current `main` and is not behind it.
- Final diff is limited to the workflow definition editor / inspector presentation and the reusable node-icon size option.
- Opened as Draft for visual verification of panel density, scroll behavior, tabs, retry/error sections, next-step cards, and real last-run data rendering.