### PR TITLE
refactor(workflow): simplify retry and error settings

### DIFF
--- a/yak-ops-ui/src/pages/workflow/definition/canvas/WorkflowNodeInspector.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/WorkflowNodeInspector.tsx
@@ -109,7 +109,7 @@ const WorkflowNodeInspector = ({
         </div>
 
         <div className="px-4 pb-2 text-[11px] leading-5 text-[rgba(22,24,35,.36)]">
-          配置此任务节点在工作流中的编排、重试、超时和异常处理行为。
+          配置节点失败后的重试和异常处理方式。
         </div>
 
         <nav className="flex h-10 items-end gap-5 px-4" aria-label="节点配置页签">

--- a/yak-ops-ui/src/pages/workflow/definition/canvas/WorkflowNodeInspectorSettings.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/WorkflowNodeInspectorSettings.tsx
@@ -1,26 +1,18 @@
-import type {
-  WorkflowNodeFailurePolicy,
-  WorkflowTriggerRule,
-} from '@/services/workflow';
-import { Input, InputNumber, Select, Switch } from 'antd';
-import { Plus } from 'lucide-react';
+import type { WorkflowNodeFailurePolicy } from '@/services/workflow';
+import { InputNumber, Select, Slider, Switch, Tooltip } from 'antd';
+import { CircleHelp, Plus } from 'lucide-react';
 import type { Node } from 'reactflow';
 import type { WorkflowCanvasTaskOption, WorkflowNodeData } from './types';
 import WorkflowNodeIcon from './node/icons/WorkflowNodeIcon';
 
-const TRIGGER_RULE_OPTIONS = [
-  { value: 'ALL_SUCCESS', label: '全部前置成功' },
-  { value: 'ALL_DONE', label: '全部前置结束' },
-  { value: 'NONE_FAILED', label: '无前置失败' },
-  { value: 'ONE_SUCCESS', label: '至少一个成功' },
-  { value: 'ALWAYS', label: '始终执行' },
+const NODE_FAILURE_OPTIONS = [
+  { value: 'FAIL_WORKFLOW', label: '无' },
+  { value: 'BLOCK_BRANCH', label: '停止当前分支' },
+  { value: 'IGNORE_FAILURE', label: '忽略并继续' },
 ];
 
-const NODE_FAILURE_OPTIONS = [
-  { value: 'FAIL_WORKFLOW', label: '标记工作流失败' },
-  { value: 'BLOCK_BRANCH', label: '仅阻断当前分支' },
-  { value: 'IGNORE_FAILURE', label: '忽略失败继续' },
-];
+const MAX_RETRY_TIMES = 9;
+const MAX_RETRY_DELAY_SECONDS = 3600;
 
 export interface WorkflowInspectorNextNode {
   id: string;
@@ -41,11 +33,13 @@ const SectionTitle = ({ children }: { children: string }) => (
   <div className="mb-2 text-[11px] font-semibold text-[#344054]">{children}</div>
 );
 
-const FieldLabel = ({ children }: { children: string }) => (
-  <div className="mb-1.5 text-[10px] font-medium text-[rgba(22,24,35,.46)]">{children}</div>
-);
-
 const Divider = () => <div className="mx-4 border-t border-[#f0f1f3]" />;
+
+const HelpTip = ({ title }: { title: string }) => (
+  <Tooltip title={title} placement="top">
+    <CircleHelp size={13} className="ml-1 text-[#b0b4bc]" />
+  </Tooltip>
+);
 
 const WorkflowNodeInspectorSettings = ({
   node,
@@ -55,82 +49,97 @@ const WorkflowNodeInspectorSettings = ({
   onChange,
   onAppend,
 }: WorkflowNodeInspectorSettingsProps) => {
-  const retryEnabled = node.data.maxAttempts > 1;
+  const retryTimes = Math.max(0, (node.data.maxAttempts || 1) - 1);
+  const retryEnabled = retryTimes > 0;
 
   const appendSelectOptions = appendOptions.map((item) => ({
     value: item.id,
     label: item.label,
   }));
 
+  const handleRetryEnabledChange = (checked: boolean) => {
+    if (!checked) {
+      onChange({ maxAttempts: 1 });
+      return;
+    }
+
+    // maxAttempts 包含首次执行；默认开启后为“首次执行 + 3 次重试”。
+    onChange({ maxAttempts: Math.max(node.data.maxAttempts || 1, 4) });
+  };
+
+  const handleRetryTimesChange = (value: number | null) => {
+    const nextRetryTimes = Math.min(MAX_RETRY_TIMES, Math.max(1, Number(value || 1)));
+    onChange({ maxAttempts: nextRetryTimes + 1 });
+  };
+
   return (
     <div className="pb-6">
-      <section className="space-y-4 px-4 py-4">
-        <div>
-          <SectionTitle>执行条件</SectionTitle>
-          <FieldLabel>触发规则</FieldLabel>
-          <Select
-            disabled={locked}
-            variant="filled"
-            className="w-full"
-            value={node.data.triggerRule}
-            options={TRIGGER_RULE_OPTIONS}
-            onChange={(value) => onChange({ triggerRule: value as WorkflowTriggerRule })}
-          />
-        </div>
-
-        <div>
-          <SectionTitle>输入映射</SectionTitle>
-          <Input.TextArea
-            disabled={locked}
-            rows={5}
-            value={node.data.inputMappingText}
-            className="font-mono !text-[11px]"
-            onChange={(event) => onChange({ inputMappingText: event.target.value })}
-          />
-          <div className="mt-1.5 text-[10px] leading-4 text-[rgba(22,24,35,.34)]">
-            将工作流上下文映射为当前任务输入；任务自身配置仍在任务定义中维护。
-          </div>
-        </div>
-      </section>
-
-      <Divider />
-
       <section className="py-2">
-        <div className="flex min-h-11 items-center justify-between px-4 py-2">
-          <div>
-            <div className="text-[11px] font-semibold text-[#344054]">失败时重试</div>
-            <div className="mt-0.5 text-[10px] text-[rgba(22,24,35,.36)]">节点失败后按固定间隔重新执行</div>
+        <div className="flex min-h-12 items-center justify-between px-4 py-2">
+          <div className="flex items-center">
+            <div className="text-[12px] font-semibold text-[#344054]">失败时重试</div>
+            <HelpTip title="节点执行失败后自动再次尝试；开启后会在画布节点中实时显示重试次数。" />
           </div>
           <Switch
             size="small"
             disabled={locked}
             checked={retryEnabled}
-            onChange={(checked) => onChange({ maxAttempts: checked ? Math.max(3, node.data.maxAttempts) : 1 })}
+            onChange={handleRetryEnabledChange}
           />
         </div>
 
         {retryEnabled ? (
-          <div className="grid grid-cols-2 gap-2 px-4 pb-3 pt-1">
-            <div>
-              <FieldLabel>最大 Attempt</FieldLabel>
-              <InputNumber
+          <div className="space-y-3 px-4 pb-4 pt-1">
+            <div className="flex items-center gap-3">
+              <div className="w-[88px] shrink-0 text-[11px] font-medium text-[#667085]">重试次数</div>
+              <Slider
+                className="m-0 min-w-0 flex-1"
+                min={1}
+                max={MAX_RETRY_TIMES}
+                tooltip={{ open: false }}
                 disabled={locked}
-                min={2}
-                max={10}
-                value={node.data.maxAttempts}
-                className="w-full"
-                onChange={(value) => onChange({ maxAttempts: Number(value || 2) })}
+                value={retryTimes}
+                onChange={(value) => handleRetryTimesChange(value)}
               />
+              <div className="flex w-[82px] shrink-0 items-center gap-1">
+                <InputNumber
+                  size="small"
+                  controls={false}
+                  disabled={locked}
+                  min={1}
+                  max={MAX_RETRY_TIMES}
+                  value={retryTimes}
+                  className="!w-[58px]"
+                  onChange={handleRetryTimesChange}
+                />
+                <span className="text-[10px] text-[rgba(22,24,35,.42)]">次</span>
+              </div>
             </div>
-            <div>
-              <FieldLabel>重试延迟（秒）</FieldLabel>
-              <InputNumber
-                disabled={locked}
+
+            <div className="flex items-center gap-3">
+              <div className="w-[88px] shrink-0 text-[11px] font-medium text-[#667085]">重试间隔</div>
+              <Slider
+                className="m-0 min-w-0 flex-1"
                 min={0}
-                value={node.data.retryDelaySeconds}
-                className="w-full"
-                onChange={(value) => onChange({ retryDelaySeconds: Number(value || 0) })}
+                max={MAX_RETRY_DELAY_SECONDS}
+                tooltip={{ open: false }}
+                disabled={locked}
+                value={Math.min(node.data.retryDelaySeconds || 0, MAX_RETRY_DELAY_SECONDS)}
+                onChange={(value) => onChange({ retryDelaySeconds: value })}
               />
+              <div className="flex w-[82px] shrink-0 items-center gap-1">
+                <InputNumber
+                  size="small"
+                  controls={false}
+                  disabled={locked}
+                  min={0}
+                  max={MAX_RETRY_DELAY_SECONDS}
+                  value={node.data.retryDelaySeconds}
+                  className="!w-[58px]"
+                  onChange={(value) => onChange({ retryDelaySeconds: Number(value || 0) })}
+                />
+                <span className="text-[10px] text-[rgba(22,24,35,.42)]">秒</span>
+              </div>
             </div>
           </div>
         ) : null}
@@ -138,43 +147,15 @@ const WorkflowNodeInspectorSettings = ({
 
       <Divider />
 
-      <section className="px-4 py-4">
-        <SectionTitle>超时控制</SectionTitle>
-        <div className="grid grid-cols-2 gap-2">
-          <div>
-            <FieldLabel>派发超时（秒）</FieldLabel>
-            <InputNumber
-              disabled={locked}
-              min={0}
-              value={node.data.dispatchTimeoutSeconds}
-              className="w-full"
-              onChange={(value) => onChange({ dispatchTimeoutSeconds: Number(value || 0) })}
-            />
-          </div>
-          <div>
-            <FieldLabel>执行超时（秒）</FieldLabel>
-            <InputNumber
-              disabled={locked}
-              min={0}
-              value={node.data.executionTimeoutSeconds}
-              className="w-full"
-              onChange={(value) => onChange({ executionTimeoutSeconds: Number(value || 0) })}
-            />
-          </div>
-        </div>
-      </section>
-
-      <Divider />
-
       <section className="flex min-h-[64px] items-center justify-between gap-4 px-4 py-3">
-        <div>
-          <div className="text-[11px] font-semibold text-[#344054]">异常处理</div>
-          <div className="mt-0.5 text-[10px] text-[rgba(22,24,35,.36)]">当前节点最终失败时如何影响工作流</div>
+        <div className="flex items-center">
+          <div className="text-[12px] font-semibold text-[#344054]">异常处理</div>
+          <HelpTip title="节点最终仍然失败时的处理方式。“无”表示按默认方式使工作流失败。" />
         </div>
         <Select
           disabled={locked}
-          variant="filled"
-          className="w-[160px] shrink-0"
+          size="small"
+          className="w-[142px] shrink-0"
           value={node.data.failurePolicy}
           options={NODE_FAILURE_OPTIONS}
           onChange={(value) => onChange({ failurePolicy: value as WorkflowNodeFailurePolicy })}

--- a/yak-ops-ui/src/pages/workflow/definition/canvas/node/WorkflowNode.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/node/WorkflowNode.tsx
@@ -2,6 +2,7 @@ import type { NodeProps } from 'reactflow';
 import type { WorkflowNodeData } from '../types';
 import WorkflowNodeControl from './WorkflowNodeControl';
 import WorkflowNodeHandle from './WorkflowNodeHandle';
+import WorkflowNodeRetry from './WorkflowNodeRetry';
 import WorkflowNodeIcon from './icons/WorkflowNodeIcon';
 
 const WorkflowNode = ({ id, data, selected }: NodeProps<WorkflowNodeData>) => (
@@ -34,6 +35,8 @@ const WorkflowNode = ({ id, data, selected }: NodeProps<WorkflowNodeData>) => (
           {data.label}
         </div>
       </div>
+
+      <WorkflowNodeRetry data={data} />
     </div>
 
     <WorkflowNodeHandle

--- a/yak-ops-ui/src/pages/workflow/definition/canvas/node/WorkflowNodeRetry.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/node/WorkflowNodeRetry.tsx
@@ -1,0 +1,19 @@
+import type { WorkflowNodeData } from '../types';
+
+interface WorkflowNodeRetryProps {
+  data: WorkflowNodeData;
+}
+
+const WorkflowNodeRetry = ({ data }: WorkflowNodeRetryProps) => {
+  const retryTimes = Math.max(0, (data.maxAttempts || 1) - 1);
+
+  if (!retryTimes) return null;
+
+  return (
+    <div className="mt-2 rounded-md bg-[#f3f4f6] px-2 py-1 text-[11px] font-medium leading-4 text-[#667085]">
+      失败时重试 {retryTimes} 次
+    </div>
+  );
+};
+
+export default WorkflowNodeRetry;


### PR DESCRIPTION
## What changed

- Simplified the node settings panel for non-technical users by removing the visible `执行条件`, `输入映射`, and `超时控制` sections.
- Kept the underlying `triggerRule`, `inputMapping`, `dispatchTimeoutSeconds`, and `executionTimeoutSeconds` values untouched and still persisted by the existing workflow definition payload.
- Reworked `失败时重试` to follow Dify's interaction model:
  - one top-level switch
  - retry count control
  - retry interval control
  - concise help text instead of exposing `Attempt` terminology
- Normalized user-facing retry semantics: backend `maxAttempts` includes the initial execution, while the UI now shows actual retry count as `maxAttempts - 1`.
- Enabling retry defaults to 3 retries (`maxAttempts = 4`), while disabling retry restores `maxAttempts = 1`.
- Simplified `异常处理` into a single Dify-style row with user-facing options:
  - 无 (default workflow failure behavior)
  - 停止当前分支
  - 忽略并继续
- Added a dedicated `WorkflowNodeRetry` component, mirroring Dify's `RetryOnNode` separation.
- Workflow canvas nodes now update immediately to show `失败时重试 N 次` whenever retry is enabled.

## Dify reference

This follows Dify's split between `RetryOnPanel` and `RetryOnNode`: retry configuration lives in the right inspector, while the canvas node renders a compact retry summary/state row. The implementation reference is `web/app/components/workflow/nodes/_base/components/retry/retry-on-node.tsx` and the existing retry panel component.

## Scope

- Frontend only.
- No backend/API/schema changes.
- Existing hidden orchestration defaults and previously saved values are preserved.
- No changes to workflow execution logic or persistence format.

## Validation

- Branch is based on current `main` and is not behind it.
- Final diff is limited to 4 workflow inspector/node files.
- Opened as Draft for visual verification of the simplified settings flow and live retry summary on canvas nodes.