### PR TITLE
feat(workflow): add immutable start node and global context

### DIFF
--- a/yak-ops-ui/src/pages/workflow/definition/WorkflowDefinitionEditor.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/WorkflowDefinitionEditor.tsx
@@ -23,6 +23,8 @@ import ReactFlow, {
   getOutgoers,
   type Connection,
   type Edge,
+  type Node,
+  type NodeChange,
   type NodeMouseHandler,
   type ReactFlowInstance,
   useEdgesState,
@@ -39,6 +41,17 @@ import {
 import WorkflowConnectionLine from './canvas/edge/WorkflowConnectionLine';
 import WorkflowEdge from './canvas/edge/WorkflowEdge';
 import WorkflowNode from './canvas/node/WorkflowNode';
+import WorkflowStartInspector from './canvas/start/WorkflowStartInspector';
+import WorkflowStartNode from './canvas/start/WorkflowStartNode';
+import {
+  hydrateWorkflowStartConfig,
+  serializeWorkflowStartContext,
+} from './canvas/start/context';
+import {
+  WORKFLOW_START_NODE_ID,
+  type WorkflowStartConfig,
+  type WorkflowStartNodeData,
+} from './canvas/start/types';
 import type { WorkflowEdgeData, WorkflowNodeData } from './canvas/types';
 import 'reactflow/dist/style.css';
 
@@ -64,6 +77,12 @@ const createNodeData = (task: WorkflowTaskDefinition): WorkflowNodeData => ({
   inputMappingText: '{}',
 });
 
+const DEFAULT_START_CONFIG: WorkflowStartConfig = {
+  position: { x: 80, y: 160 },
+  inputs: [],
+  variables: [],
+};
+
 const WorkflowDefinitionContent = () => {
   const { id = '' } = useParams<{ id: string }>();
   const wrapperRef = useRef<HTMLDivElement>(null);
@@ -77,17 +96,24 @@ const WorkflowDefinitionContent = () => {
   const [workflowName, setWorkflowName] = useState('');
   const [workflowDescription, setWorkflowDescription] = useState('');
   const [workflowTimeoutSeconds, setWorkflowTimeoutSeconds] = useState(0);
-  const [workflowInputText, setWorkflowInputText] = useState('{}');
   const [failureStrategy, setFailureStrategy] = useState<WorkflowFailureStrategy>('CONTINUE_INDEPENDENT_BRANCHES');
+  const [startConfig, setStartConfig] = useState<WorkflowStartConfig>(DEFAULT_START_CONFIG);
+  const [startSelected, setStartSelected] = useState(false);
+  const [hoveredNodeId, setHoveredNodeId] = useState<string>();
   const [nodes, setNodes, onNodesChange] = useNodesState<WorkflowNodeData>([]);
   const [edges, setEdges, onEdgesChange] = useEdgesState<WorkflowEdgeData>([]);
   const [reactFlowInstance, setReactFlowInstance] = useState<ReactFlowInstance | null>(null);
 
-  const nodeTypes = useMemo(() => ({ workflow: WorkflowNode }), []);
+  const nodeTypes = useMemo(() => ({ workflow: WorkflowNode, start: WorkflowStartNode }), []);
   const edgeTypes = useMemo(() => ({ workflow: WorkflowEdge }), []);
   const selectedNode = useMemo(() => nodes.find((node) => node.selected), [nodes]);
   const syncTasks = useMemo(() => tasks.filter((task) => task.type === 'SYNC'), [tasks]);
   const locked = definition?.status === 'ONLINE';
+
+  const rootNodes = useMemo(() => {
+    const targets = new Set(edges.map((edge) => edge.target));
+    return nodes.filter((node) => !targets.has(node.id));
+  }, [edges, nodes]);
 
   const hydrateDefinition = useCallback((value: WorkflowDefinition, taskList: WorkflowTaskDefinition[]) => {
     const taskMap = new Map(taskList.map((task) => [task.id, task]));
@@ -95,8 +121,9 @@ const WorkflowDefinitionContent = () => {
     setWorkflowName(value.name);
     setWorkflowDescription(value.description || '');
     setWorkflowTimeoutSeconds(value.workflowTimeoutSeconds || 0);
-    setWorkflowInputText(JSON.stringify(value.input || {}, null, 2));
     setFailureStrategy(value.failureStrategy || 'CONTINUE_INDEPENDENT_BRANCHES');
+    setStartConfig(hydrateWorkflowStartConfig(value.input || {}));
+    setStartSelected(false);
     setNodes(value.nodes.map((node) => {
       const task = taskMap.get(node.taskId);
       return {
@@ -157,7 +184,16 @@ const WorkflowDefinitionContent = () => {
   }, [hydrateDefinition, id]);
 
   const handleConnect = (connection: Connection) => {
-    if (!locked) setEdges((current) => addEdge({ ...connection, type: 'workflow' }, current));
+    if (locked) return;
+    if (connection.source === WORKFLOW_START_NODE_ID) {
+      if (!connection.target) return;
+      const hasTaskPredecessor = edges.some((edge) => edge.target === connection.target);
+      if (hasTaskPredecessor) {
+        message.warning('开始节点只能连接没有前置任务的根节点');
+      }
+      return;
+    }
+    setEdges((current) => addEdge({ ...connection, type: 'workflow' }, current));
   };
 
   const handleDragStart = (event: DragEvent<HTMLDivElement>, task: WorkflowTaskDefinition) => {
@@ -173,6 +209,7 @@ const WorkflowDefinitionContent = () => {
     const task = JSON.parse(raw) as WorkflowTaskDefinition;
     const bounds = wrapperRef.current.getBoundingClientRect();
     const sequence = sequenceRef.current++;
+    setStartSelected(false);
     setNodes((current) => [...current, {
       id: `task-${Date.now()}-${sequence}`,
       type: 'workflow',
@@ -194,6 +231,7 @@ const WorkflowDefinitionContent = () => {
 
     const sequence = sequenceRef.current++;
     const nodeId = `task-${Date.now()}-${sequence}`;
+    setStartSelected(false);
     setNodes((current) => [
       ...current.map((node) => ({ ...node, selected: false })),
       {
@@ -237,7 +275,6 @@ const WorkflowDefinitionContent = () => {
     const lastOutgoer = outgoers[outgoers.length - 1];
     const sourceWidth = sourceNode.width ?? WORKFLOW_NODE_WIDTH;
     const fallbackHeight = sourceNode.height ?? 96;
-
     const sequence = sequenceRef.current++;
     const nodeId = `task-${Date.now()}-${sequence}`;
     const position = lastOutgoer
@@ -252,6 +289,7 @@ const WorkflowDefinitionContent = () => {
           y: sourceNode.position.y,
         };
 
+    setStartSelected(false);
     setNodes((current) => [
       ...current.map((node) => ({ ...node, selected: false })),
       {
@@ -273,13 +311,48 @@ const WorkflowDefinitionContent = () => {
     ]);
   }, [edges, locked, nodes, setEdges, setNodes, syncTasks]);
 
+  const handleAppendFromStart = useCallback((_startNodeId: string, taskId: string) => {
+    if (locked) return;
+    const task = syncTasks.find((item) => item.id === taskId);
+    if (!task) return;
+
+    const taskTargets = new Set(edges.map((edge) => edge.target));
+    const currentRoots = nodes
+      .filter((node) => !taskTargets.has(node.id))
+      .sort((left, right) => left.position.y - right.position.y);
+    const lastRoot = currentRoots[currentRoots.length - 1];
+    const sequence = sequenceRef.current++;
+    const nodeId = `task-${Date.now()}-${sequence}`;
+    const position = lastRoot
+      ? {
+          x: lastRoot.position.x,
+          y: lastRoot.position.y + (lastRoot.height ?? 72) + WORKFLOW_NODE_VERTICAL_GAP,
+        }
+      : {
+          x: startConfig.position.x + WORKFLOW_NODE_WIDTH + WORKFLOW_NODE_HORIZONTAL_GAP,
+          y: startConfig.position.y,
+        };
+
+    setStartSelected(false);
+    setNodes((current) => [
+      ...current.map((node) => ({ ...node, selected: false })),
+      {
+        id: nodeId,
+        type: 'workflow',
+        selected: true,
+        position,
+        data: createNodeData(task),
+      },
+    ]);
+  }, [edges, locked, nodes, setNodes, startConfig.position.x, startConfig.position.y, syncTasks]);
+
   const handleDuplicateNode = useCallback((nodeId: string) => {
     if (locked) return;
     const sourceNode = nodes.find((node) => node.id === nodeId);
     if (!sourceNode) return;
-
     const sequence = sequenceRef.current++;
     const duplicatedId = `task-${Date.now()}-${sequence}`;
+    setStartSelected(false);
     setNodes((current) => [
       ...current.map((node) => ({ ...node, selected: false })),
       {
@@ -296,10 +369,9 @@ const WorkflowDefinitionContent = () => {
   }, [locked, nodes, setNodes]);
 
   const handleDeleteNode = useCallback((nodeId: string) => {
-    if (locked) return;
+    if (locked || nodeId === WORKFLOW_START_NODE_ID) return;
     const node = nodes.find((item) => item.id === nodeId);
     if (!node) return;
-
     Modal.confirm({
       centered: true,
       title: '删除节点？',
@@ -314,31 +386,29 @@ const WorkflowDefinitionContent = () => {
     });
   }, [locked, nodes, setEdges, setNodes]);
 
+  const handleCanvasNodesChange = useCallback((changes: NodeChange[]) => {
+    const taskChanges: NodeChange[] = [];
+    changes.forEach((change) => {
+      if (change.id === WORKFLOW_START_NODE_ID) {
+        if (change.type === 'position' && change.position && !locked) {
+          setStartConfig((current) => ({ ...current, position: change.position! }));
+        }
+        if (change.type === 'select') setStartSelected(change.selected);
+        return;
+      }
+      if (change.type === 'select' && change.selected) setStartSelected(false);
+      taskChanges.push(change);
+    });
+    if (taskChanges.length) onNodesChange(taskChanges);
+  }, [locked, onNodesChange]);
+
   const handleNodeMouseEnter = useCallback<NodeMouseHandler>((_, node) => {
-    setEdges((current) => current.map((edge) => {
-      if (edge.source !== node.id && edge.target !== node.id) return edge;
-      return {
-        ...edge,
-        data: {
-          ...edge.data,
-          connectedNodeHovered: true,
-        },
-      };
-    }));
-  }, [setEdges]);
+    setHoveredNodeId(node.id);
+  }, []);
 
   const handleNodeMouseLeave = useCallback<NodeMouseHandler>(() => {
-    setEdges((current) => current.map((edge) => {
-      if (!edge.data?.connectedNodeHovered) return edge;
-      return {
-        ...edge,
-        data: {
-          ...edge.data,
-          connectedNodeHovered: false,
-        },
-      };
-    }));
-  }, [setEdges]);
+    setHoveredNodeId(undefined);
+  }, []);
 
   const taskOptions = useMemo(() => syncTasks.map((task) => ({
     id: task.id,
@@ -353,19 +423,23 @@ const WorkflowDefinitionContent = () => {
     );
     return nodes
       .filter((node) => targetIds.has(node.id))
-      .map((node) => ({
-        id: node.id,
-        label: node.data.label,
-        taskType: node.data.taskType,
-      }));
+      .map((node) => ({ id: node.id, label: node.data.label, taskType: node.data.taskType }));
   }, [edges, nodes, selectedNode]);
+
+  const startNextNodes = useMemo(() => rootNodes.map((node) => ({
+    id: node.id,
+    label: node.data.label,
+    taskType: node.data.taskType,
+  })), [rootNodes]);
 
   const closeNodeInspector = useCallback(() => {
     setNodes((current) => current.map((node) =>
       node.selected ? { ...node, selected: false } : node));
   }, [setNodes]);
 
-  const canvasNodes = useMemo(() => nodes.map((node) => ({
+  const closeStartInspector = useCallback(() => setStartSelected(false), []);
+
+  const taskCanvasNodes = useMemo(() => nodes.map((node) => ({
     ...node,
     data: {
       ...node.data,
@@ -377,16 +451,48 @@ const WorkflowDefinitionContent = () => {
     },
   })), [handleAppendTask, handleDeleteNode, handleDuplicateNode, locked, nodes, taskOptions]);
 
-  const canvasEdges = useMemo(() => edges.map((edge) => ({
+  const startCanvasNode = useMemo<Node<WorkflowStartNodeData>>(() => ({
+    id: WORKFLOW_START_NODE_ID,
+    type: 'start',
+    position: startConfig.position,
+    selected: startSelected,
+    deletable: false,
+    draggable: !locked,
+    data: {
+      label: '开始',
+      locked,
+      inputs: startConfig.inputs,
+      appendOptions: taskOptions,
+      onAppend: handleAppendFromStart,
+    },
+  }), [handleAppendFromStart, locked, startConfig.inputs, startConfig.position, startSelected, taskOptions]);
+
+  const canvasNodes = useMemo(() => [startCanvasNode, ...taskCanvasNodes], [startCanvasNode, taskCanvasNodes]);
+
+  const taskCanvasEdges = useMemo(() => edges.map((edge) => ({
     ...edge,
     type: 'workflow',
     data: {
       ...edge.data,
       locked,
+      connectedNodeHovered: edge.source === hoveredNodeId || edge.target === hoveredNodeId,
       insertOptions: taskOptions,
       onInsert: handleInsertTaskIntoEdge,
     },
-  })), [edges, handleInsertTaskIntoEdge, locked, taskOptions]);
+  })), [edges, handleInsertTaskIntoEdge, hoveredNodeId, locked, taskOptions]);
+
+  const startCanvasEdges = useMemo(() => rootNodes.map((node, index) => ({
+    id: `edge-start-${node.id}-${index}`,
+    source: WORKFLOW_START_NODE_ID,
+    target: node.id,
+    type: 'workflow',
+    data: {
+      locked: true,
+      connectedNodeHovered: hoveredNodeId === WORKFLOW_START_NODE_ID || hoveredNodeId === node.id,
+    },
+  })), [hoveredNodeId, rootNodes]);
+
+  const canvasEdges = useMemo(() => [...startCanvasEdges, ...taskCanvasEdges], [startCanvasEdges, taskCanvasEdges]);
 
   const updateSelectedNode = (patch: Partial<WorkflowNodeData>) => {
     if (!selectedNode || locked) return;
@@ -411,7 +517,10 @@ const WorkflowDefinitionContent = () => {
       inputMapping: parseObject<Record<string, string>>(node.data.inputMappingText, `${node.data.label} 输入映射`),
     })),
     edges: edges.map((edge: Edge) => ({ source: edge.source, target: edge.target })),
-    input: parseObject<Record<string, unknown>>(workflowInputText, '工作流输入'),
+    input: serializeWorkflowStartContext(startConfig, {
+      definitionId: id,
+      workflowName: workflowName.trim(),
+    }),
     workflowTimeoutSeconds,
     failureStrategy,
   });
@@ -423,6 +532,7 @@ const WorkflowDefinitionContent = () => {
     try {
       const saved = await updateWorkflowDefinition(id, buildPayload());
       setDefinition(saved);
+      setStartConfig(hydrateWorkflowStartConfig(saved.input || {}));
       if (showMessage) message.success('工作流配置已保存');
       return saved;
     } finally {
@@ -440,7 +550,7 @@ const WorkflowDefinitionContent = () => {
 
   const handleOnline = async () => {
     if (!nodes.length) {
-      message.warning('请先拖入至少一个任务节点');
+      message.warning('请先添加至少一个任务节点');
       return;
     }
     setStatusAction(true);
@@ -472,33 +582,49 @@ const WorkflowDefinitionContent = () => {
   }
 
   return (
-    <div className="flex h-[calc(100vh-48px)] min-h-[620px] overflow-hidden " style={{backgroundColor: "#F2F4F7"}}>
+    <div className="flex h-[calc(100vh-48px)] min-h-[620px] overflow-hidden" style={{ backgroundColor: '#F2F4F7' }}>
       <WorkflowTaskLibrary tasks={syncTasks} loading={tasksLoading} locked={locked} onDragStart={handleDragStart} />
       <section className="flex min-w-0 flex-1 flex-col">
         <WorkflowToolbar
           definition={definition}
           name={workflowName}
           description={workflowDescription}
-          workflowInputText={workflowInputText}
           workflowTimeoutSeconds={workflowTimeoutSeconds}
           failureStrategy={failureStrategy}
-          nodesCount={nodes.length}
-          edgesCount={edges.length}
+          nodesCount={nodes.length + 1}
+          edgesCount={edges.length + rootNodes.length}
           locked={locked}
           saving={saving}
           statusAction={statusAction}
           onNameChange={setWorkflowName}
           onDescriptionChange={setWorkflowDescription}
-          onWorkflowInputChange={setWorkflowInputText}
           onWorkflowTimeoutChange={setWorkflowTimeoutSeconds}
           onFailureStrategyChange={setFailureStrategy}
-          onClear={() => { if (!locked) { setNodes([]); setEdges([]); } }}
+          onClear={() => {
+            if (!locked) {
+              setNodes([]);
+              setEdges([]);
+              setStartSelected(true);
+            }
+          }}
           onSave={() => void handleSave()}
           onOnline={() => void handleOnline()}
           onOffline={() => void handleOffline()}
         />
         <div ref={wrapperRef} className="relative min-h-0 flex-1 bg-[#f2f4f7]" onDrop={handleDrop}>
-          {selectedNode ? (
+          {startSelected ? (
+            <WorkflowStartInspector
+              definitionId={id}
+              workflowName={workflowName}
+              config={startConfig}
+              locked={locked}
+              nextNodes={startNextNodes}
+              appendOptions={taskOptions}
+              onChange={setStartConfig}
+              onClose={closeStartInspector}
+              onAppend={(taskId) => handleAppendFromStart(WORKFLOW_START_NODE_ID, taskId)}
+            />
+          ) : selectedNode ? (
             <WorkflowNodeInspector
               node={selectedNode}
               locked={locked}
@@ -518,9 +644,21 @@ const WorkflowDefinitionContent = () => {
             nodeTypes={nodeTypes}
             edgeTypes={edgeTypes}
             connectionLineComponent={WorkflowConnectionLine}
-            onNodesChange={onNodesChange}
+            onNodesChange={handleCanvasNodesChange}
             onEdgesChange={onEdgesChange}
             onConnect={handleConnect}
+            onNodeClick={(_, node) => {
+              if (node.id === WORKFLOW_START_NODE_ID) {
+                setStartSelected(true);
+                setNodes((current) => current.map((item) => item.selected ? { ...item, selected: false } : item));
+              } else {
+                setStartSelected(false);
+              }
+            }}
+            onPaneClick={() => {
+              setStartSelected(false);
+              closeNodeInspector();
+            }}
             onNodeMouseEnter={handleNodeMouseEnter}
             onNodeMouseLeave={handleNodeMouseLeave}
             onInit={setReactFlowInstance}

--- a/yak-ops-ui/src/pages/workflow/definition/canvas/WorkflowToolbar.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/WorkflowToolbar.tsx
@@ -21,7 +21,6 @@ interface WorkflowToolbarProps {
   definition?: WorkflowDefinition;
   name: string;
   description: string;
-  workflowInputText: string;
   workflowTimeoutSeconds: number;
   failureStrategy: WorkflowFailureStrategy;
   nodesCount: number;
@@ -31,7 +30,6 @@ interface WorkflowToolbarProps {
   statusAction: boolean;
   onNameChange: (value: string) => void;
   onDescriptionChange: (value: string) => void;
-  onWorkflowInputChange: (value: string) => void;
   onWorkflowTimeoutChange: (value: number) => void;
   onFailureStrategyChange: (value: WorkflowFailureStrategy) => void;
   onClear: () => void;
@@ -48,7 +46,6 @@ const WorkflowToolbar = ({
   definition,
   name,
   description,
-  workflowInputText,
   workflowTimeoutSeconds,
   failureStrategy,
   nodesCount,
@@ -58,7 +55,6 @@ const WorkflowToolbar = ({
   statusAction,
   onNameChange,
   onDescriptionChange,
-  onWorkflowInputChange,
   onWorkflowTimeoutChange,
   onFailureStrategyChange,
   onClear,
@@ -83,11 +79,8 @@ const WorkflowToolbar = ({
           <span className="text-[11px] text-[rgba(22,24,35,.44)]">秒，0 表示不限制</span>
         </div>
       </div>
-      <div>
-        <ConfigLabel>Workflow Input</ConfigLabel>
-        <Input.TextArea rows={5} value={workflowInputText}
-          onChange={(event) => onWorkflowInputChange(event.target.value)}
-          disabled={locked} className="mt-1 font-mono !text-[11px]" />
+      <div className="rounded-lg bg-[#f7f8fa] px-3 py-2 text-[10px] leading-5 text-[rgba(22,24,35,.46)]">
+        工作流输入与全局变量已统一移动到画布中的“开始”节点维护。
       </div>
       <div>
         <ConfigLabel>描述</ConfigLabel>
@@ -121,7 +114,7 @@ const WorkflowToolbar = ({
         {locked ? <span className="text-[10px] text-[rgba(22,24,35,.38)]">已上线，需下线后修改</span> : null}
       </div>
       <div className="flex items-center gap-2">
-        <Popconfirm title="清空当前画布？" disabled={locked} onConfirm={onClear}>
+        <Popconfirm title="清空任务节点？开始节点与全局输入会保留。" disabled={locked} onConfirm={onClear}>
           <Button icon={<RotateCcw size={14} />} disabled={locked}>清空</Button>
         </Popconfirm>
         {!locked ? <Button icon={<Save size={14} />} loading={saving} onClick={onSave}>保存</Button> : null}

--- a/yak-ops-ui/src/pages/workflow/definition/canvas/start/WorkflowStartInspector.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/start/WorkflowStartInspector.tsx
@@ -1,0 +1,472 @@
+import { getWorkflowInstances } from '@/services/workflow';
+import { Input, Modal, Select, Switch, message } from 'antd';
+import dayjs from 'dayjs';
+import { GitBranch, Plus, RefreshCw, Trash2, Variable, X } from 'lucide-react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import type { WorkflowCanvasTaskOption } from '../types';
+import WorkflowNodeIcon from '../node/icons/WorkflowNodeIcon';
+import type {
+  WorkflowStartConfig,
+  WorkflowStartInputField,
+  WorkflowStartValueType,
+  WorkflowStartVariable,
+} from './types';
+
+interface WorkflowStartNextNode {
+  id: string;
+  label: string;
+  taskType: string;
+}
+
+interface WorkflowStartInspectorProps {
+  definitionId: string;
+  workflowName: string;
+  config: WorkflowStartConfig;
+  locked: boolean;
+  nextNodes: WorkflowStartNextNode[];
+  appendOptions: WorkflowCanvasTaskOption[];
+  onChange: (config: WorkflowStartConfig) => void;
+  onClose: () => void;
+  onAppend: (taskId: string) => void;
+}
+
+type TabKey = 'settings' | 'lastRun';
+type EditorKind = 'input' | 'variable';
+
+interface EditorDraft {
+  id?: string;
+  name: string;
+  label: string;
+  type: WorkflowStartValueType;
+  required: boolean;
+  description: string;
+  value: unknown;
+}
+
+const INPUT_TYPE_OPTIONS = [
+  { value: 'STRING', label: 'String' },
+  { value: 'NUMBER', label: 'Number' },
+  { value: 'BOOLEAN', label: 'Boolean' },
+  { value: 'FILE', label: 'File' },
+  { value: 'ARRAY_STRING', label: 'Array[String]' },
+];
+
+const VARIABLE_TYPE_OPTIONS = INPUT_TYPE_OPTIONS.filter((item) => item.value !== 'FILE');
+const NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+const newDraft = (): EditorDraft => ({
+  name: '',
+  label: '',
+  type: 'STRING',
+  required: false,
+  description: '',
+  value: '',
+});
+
+const valuePreview = (value: unknown) => {
+  if (Array.isArray(value)) return value.join(', ');
+  if (typeof value === 'boolean') return value ? 'true' : 'false';
+  if (value === undefined || value === null || value === '') return '--';
+  return String(value);
+};
+
+const ValueEditor = ({
+  type,
+  value,
+  onChange,
+}: {
+  type: WorkflowStartValueType;
+  value: unknown;
+  onChange: (value: unknown) => void;
+}) => {
+  if (type === 'BOOLEAN') {
+    return <Switch checked={Boolean(value)} onChange={onChange} />;
+  }
+  if (type === 'FILE') {
+    return <div className="text-[11px] leading-5 text-[#98a2b3]">File 类型由工作流运行时提供，不配置默认值。</div>;
+  }
+  return (
+    <Input
+      value={Array.isArray(value) ? value.join(', ') : String(value ?? '')}
+      placeholder={type === 'ARRAY_STRING' ? '多个值用英文逗号分隔' : '默认值'}
+      onChange={(event) => onChange(event.target.value)}
+    />
+  );
+};
+
+const WorkflowStartInspector = ({
+  definitionId,
+  workflowName,
+  config,
+  locked,
+  nextNodes,
+  appendOptions,
+  onChange,
+  onClose,
+  onAppend,
+}: WorkflowStartInspectorProps) => {
+  const [tab, setTab] = useState<TabKey>('settings');
+  const [editorKind, setEditorKind] = useState<EditorKind>();
+  const [draft, setDraft] = useState<EditorDraft>(newDraft());
+  const [lastRunLoading, setLastRunLoading] = useState(false);
+  const [lastRun, setLastRun] = useState<Awaited<ReturnType<typeof getWorkflowInstances>>[number]>();
+
+  const appendSelectOptions = appendOptions.map((item) => ({ value: item.id, label: item.label }));
+
+  const loadLastRun = useCallback(async () => {
+    setLastRunLoading(true);
+    try {
+      const instances = (await getWorkflowInstances()) || [];
+      const latest = instances
+        .filter((item) => item.definitionId === definitionId)
+        .sort((left, right) => dayjs(right.startedAt).valueOf() - dayjs(left.startedAt).valueOf())[0];
+      setLastRun(latest);
+    } catch (error) {
+      message.error(error instanceof Error ? error.message : '上次运行加载失败');
+    } finally {
+      setLastRunLoading(false);
+    }
+  }, [definitionId]);
+
+  useEffect(() => {
+    if (tab === 'lastRun') void loadLastRun();
+  }, [loadLastRun, tab]);
+
+  const openInputEditor = (field?: WorkflowStartInputField) => {
+    setEditorKind('input');
+    setDraft(field ? {
+      id: field.id,
+      name: field.name,
+      label: field.label,
+      type: field.type,
+      required: field.required,
+      description: field.description || '',
+      value: field.defaultValue,
+    } : newDraft());
+  };
+
+  const openVariableEditor = (variable?: WorkflowStartVariable) => {
+    setEditorKind('variable');
+    setDraft(variable ? {
+      id: variable.id,
+      name: variable.name,
+      label: variable.name,
+      type: variable.type,
+      required: false,
+      description: '',
+      value: variable.value,
+    } : newDraft());
+  };
+
+  const closeEditor = () => {
+    setEditorKind(undefined);
+    setDraft(newDraft());
+  };
+
+  const saveEditor = () => {
+    const name = draft.name.trim();
+    if (!NAME_PATTERN.test(name)) {
+      message.warning('变量名需以字母或下划线开头，只能包含字母、数字和下划线');
+      return;
+    }
+    const duplicate = editorKind === 'input'
+      ? config.inputs.some((item) => item.name === name && item.id !== draft.id)
+      : config.variables.some((item) => item.name === name && item.id !== draft.id);
+    if (duplicate) {
+      message.warning(`变量 ${name} 已存在`);
+      return;
+    }
+
+    if (editorKind === 'input') {
+      const item: WorkflowStartInputField = {
+        id: draft.id || `input-${Date.now()}`,
+        name,
+        label: draft.label.trim() || name,
+        type: draft.type,
+        required: draft.required,
+        description: draft.description.trim() || undefined,
+        defaultValue: draft.type === 'FILE' ? undefined : draft.value,
+      };
+      onChange({
+        ...config,
+        inputs: draft.id
+          ? config.inputs.map((field) => field.id === draft.id ? item : field)
+          : [...config.inputs, item],
+      });
+    } else if (editorKind === 'variable') {
+      const item: WorkflowStartVariable = {
+        id: draft.id || `var-${Date.now()}`,
+        name,
+        type: draft.type === 'FILE' ? 'STRING' : draft.type,
+        value: draft.value,
+      };
+      onChange({
+        ...config,
+        variables: draft.id
+          ? config.variables.map((variable) => variable.id === draft.id ? item : variable)
+          : [...config.variables, item],
+      });
+    }
+    closeEditor();
+  };
+
+  const systemVariables = useMemo(() => [
+    { name: 'sys.definitionId', value: definitionId },
+    { name: 'sys.workflowName', value: workflowName || '--' },
+  ], [definitionId, workflowName]);
+
+  return (
+    <aside className="absolute bottom-3 right-3 top-3 z-20 flex w-[400px] flex-col overflow-hidden rounded-2xl border border-[#e2e5e9] bg-white shadow-[0_12px_36px_rgba(22,24,35,.12)]">
+      <header className="shrink-0 border-b border-[#eceef1] bg-white">
+        <div className="flex items-center gap-2 px-4 pb-2 pt-4">
+          <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-[8px] bg-[#eaf2ff] text-[#155eef]">
+            <GitBranch size={15} strokeWidth={2.2} />
+          </span>
+          <div className="min-w-0 flex-1 text-[14px] font-semibold text-[#161823]">开始</div>
+          <button
+            type="button"
+            aria-label="关闭"
+            className="flex h-7 w-7 items-center justify-center rounded-md border-0 bg-transparent text-[#667085] hover:bg-[#f2f4f7]"
+            onClick={onClose}
+          >
+            <X size={16} />
+          </button>
+        </div>
+        <div className="px-4 pb-2 text-[11px] leading-5 text-[rgba(22,24,35,.36)]">
+          定义工作流输入和可供后续所有节点引用的上下文变量。
+        </div>
+        <nav className="flex h-10 items-end gap-5 px-4">
+          {(['settings', 'lastRun'] as TabKey[]).map((key) => (
+            <button
+              key={key}
+              type="button"
+              className={[
+                'relative h-10 border-0 bg-transparent px-0 text-[12px] font-semibold',
+                tab === key ? 'text-[#344054]' : 'text-[#667085]',
+              ].join(' ')}
+              onClick={() => setTab(key)}
+            >
+              {key === 'settings' ? '设置' : '上次运行'}
+              {tab === key ? <span className="absolute bottom-0 left-0 right-0 h-0.5 rounded-full bg-[#155eef]" /> : null}
+            </button>
+          ))}
+        </nav>
+      </header>
+
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        {tab === 'settings' ? (
+          <div className="pb-6">
+            <section className="px-4 py-4">
+              <div className="mb-1 flex items-center justify-between">
+                <div className="text-[12px] font-semibold text-[#344054]">输入字段</div>
+                {!locked ? (
+                  <button
+                    type="button"
+                    className="flex h-7 w-7 items-center justify-center rounded-md border-0 bg-transparent text-[#667085] hover:bg-[#f2f4f7]"
+                    onClick={() => openInputEditor()}
+                    aria-label="添加输入字段"
+                  >
+                    <Plus size={15} />
+                  </button>
+                ) : null}
+              </div>
+              <div className="mb-3 text-[10px] text-[rgba(22,24,35,.38)]">运行工作流时提供，后续节点通过 inputs.* 引用</div>
+
+              <div className="space-y-1.5">
+                {config.inputs.map((field) => (
+                  <button
+                    key={field.id}
+                    type="button"
+                    disabled={locked}
+                    className="flex w-full items-center gap-2 rounded-xl border border-[#e7e9ed] bg-white px-2.5 py-2 text-left hover:bg-[#fafafa] disabled:cursor-default"
+                    onClick={() => openInputEditor(field)}
+                  >
+                    <Variable size={14} className="shrink-0 text-[#155eef]" />
+                    <div className="min-w-0 flex-1">
+                      <div className="truncate text-[11px] font-medium text-[#344054]">inputs.{field.name}</div>
+                      {field.description ? <div className="truncate text-[9px] text-[#98a2b3]">{field.description}</div> : null}
+                    </div>
+                    {field.required ? <span className="text-[9px] text-[#98a2b3]">必填</span> : null}
+                    <span className="text-[10px] text-[#98a2b3]">{INPUT_TYPE_OPTIONS.find((item) => item.value === field.type)?.label}</span>
+                  </button>
+                ))}
+                {!config.inputs.length ? (
+                  <div className="rounded-xl border border-dashed border-[#dfe3e8] bg-[#fafafa] px-4 py-6 text-center text-[10px] leading-5 text-[#98a2b3]">
+                    暂无输入字段<br />点击右上角 + 添加
+                  </div>
+                ) : null}
+              </div>
+            </section>
+
+            <div className="mx-4 border-t border-[#f0f1f3]" />
+
+            <section className="px-4 py-4">
+              <div className="mb-1 flex items-center justify-between">
+                <div className="text-[12px] font-semibold text-[#344054]">工作流变量</div>
+                {!locked ? (
+                  <button
+                    type="button"
+                    className="flex h-7 w-7 items-center justify-center rounded-md border-0 bg-transparent text-[#667085] hover:bg-[#f2f4f7]"
+                    onClick={() => openVariableEditor()}
+                    aria-label="添加工作流变量"
+                  >
+                    <Plus size={15} />
+                  </button>
+                ) : null}
+              </div>
+              <div className="mb-3 text-[10px] text-[rgba(22,24,35,.38)]">整个工作流共享，后续节点通过 vars.* 引用</div>
+              <div className="space-y-1.5">
+                {config.variables.map((variable) => (
+                  <div key={variable.id} className="flex items-center gap-2 rounded-xl border border-[#e7e9ed] px-2.5 py-2">
+                    <Variable size={14} className="shrink-0 text-[#7f56d9]" />
+                    <button
+                      type="button"
+                      disabled={locked}
+                      className="min-w-0 flex-1 border-0 bg-transparent p-0 text-left"
+                      onClick={() => openVariableEditor(variable)}
+                    >
+                      <div className="truncate text-[11px] font-medium text-[#344054]">vars.{variable.name}</div>
+                      <div className="truncate text-[9px] text-[#98a2b3]">{valuePreview(variable.value)}</div>
+                    </button>
+                    {!locked ? (
+                      <button
+                        type="button"
+                        className="flex h-6 w-6 items-center justify-center rounded-md border-0 bg-transparent text-[#98a2b3] hover:bg-[#fff1f3] hover:text-[#d92d4f]"
+                        onClick={() => onChange({ ...config, variables: config.variables.filter((item) => item.id !== variable.id) })}
+                        aria-label="删除变量"
+                      >
+                        <Trash2 size={13} />
+                      </button>
+                    ) : null}
+                  </div>
+                ))}
+              </div>
+            </section>
+
+            <div className="mx-4 border-t border-[#f0f1f3]" />
+
+            <section className="px-4 py-4">
+              <div className="mb-1 text-[12px] font-semibold text-[#344054]">系统变量</div>
+              <div className="mb-3 text-[10px] text-[rgba(22,24,35,.38)]">Yak Ops 自动提供，只读，通过 sys.* 引用</div>
+              <div className="space-y-1.5">
+                {systemVariables.map((item) => (
+                  <div key={item.name} className="flex items-center gap-2 rounded-xl bg-[#f7f8fa] px-2.5 py-2">
+                    <Variable size={14} className="shrink-0 text-[#667085]" />
+                    <div className="min-w-0 flex-1">
+                      <div className="truncate text-[11px] font-medium text-[#475467]">{item.name}</div>
+                      <div className="truncate text-[9px] text-[#98a2b3]">{item.value}</div>
+                    </div>
+                    <span className="text-[9px] text-[#98a2b3]">只读</span>
+                  </div>
+                ))}
+              </div>
+            </section>
+
+            <div className="mx-4 border-t border-[#f0f1f3]" />
+
+            <section className="px-4 py-4">
+              <div className="mb-1 text-[12px] font-semibold text-[#344054]">下一步</div>
+              <div className="mb-3 text-[10px] text-[rgba(22,24,35,.38)]">没有前置节点的任务会自动连接到开始节点</div>
+              <div className="space-y-1.5">
+                {nextNodes.map((item) => (
+                  <div key={item.id} className="flex items-center gap-2 rounded-xl border border-[#e7e9ed] px-2.5 py-2">
+                    <WorkflowNodeIcon taskType={item.taskType} size="sm" />
+                    <div className="min-w-0 flex-1 truncate text-[11px] font-medium text-[#344054]">{item.label}</div>
+                  </div>
+                ))}
+                {!nextNodes.length ? <div className="rounded-xl border border-dashed border-[#dfe3e8] bg-[#fafafa] px-3 py-3 text-center text-[10px] text-[#98a2b3]">暂无后续节点</div> : null}
+              </div>
+              {!locked && appendSelectOptions.length ? (
+                <Select
+                  className="mt-2 w-full"
+                  variant="filled"
+                  value={undefined}
+                  placeholder={<span className="inline-flex items-center gap-1.5"><Plus size={13} /> 添加后续任务</span>}
+                  options={appendSelectOptions}
+                  onChange={onAppend}
+                />
+              ) : null}
+            </section>
+          </div>
+        ) : (
+          <div className="px-4 py-4">
+            <div className="mb-3 flex items-center justify-between">
+              <div className="text-[12px] font-semibold text-[#344054]">最近一次运行</div>
+              <button type="button" className="flex h-7 w-7 items-center justify-center rounded-md border-0 bg-transparent text-[#98a2b3] hover:bg-[#f2f4f7]" onClick={() => void loadLastRun()}>
+                <RefreshCw size={14} className={lastRunLoading ? 'animate-spin' : ''} />
+              </button>
+            </div>
+            {lastRun ? (
+              <div className="space-y-4">
+                <div className="grid grid-cols-2 rounded-xl border border-[#d9e6ff] bg-[#f3f7ff]">
+                  <div className="px-3 py-2.5"><div className="text-[9px] text-[#667085]">状态</div><div className="mt-1 text-[11px] font-semibold text-[#155eef]">{lastRun.status}</div></div>
+                  <div className="border-l border-[#d9e6ff] px-3 py-2.5"><div className="text-[9px] text-[#667085]">开始时间</div><div className="mt-1 text-[11px] font-semibold text-[#344054]">{dayjs(lastRun.startedAt).format('YYYY-MM-DD HH:mm:ss')}</div></div>
+                </div>
+                <div>
+                  <div className="mb-2 text-[12px] font-semibold text-[#344054]">工作流输入</div>
+                  <pre className="m-0 max-h-[320px] overflow-auto whitespace-pre-wrap rounded-xl bg-[#f5f6f7] p-3 font-mono text-[11px] leading-[18px] text-[#344054]">{JSON.stringify(lastRun.input || {}, null, 2)}</pre>
+                </div>
+              </div>
+            ) : (
+              <div className="rounded-xl border border-dashed border-[#dfe3e8] bg-[#fafafa] px-4 py-10 text-center text-[11px] text-[#98a2b3]">
+                {lastRunLoading ? '正在加载...' : '暂无运行记录'}
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+
+      <Modal
+        open={Boolean(editorKind)}
+        centered
+        title={editorKind === 'input' ? `${draft.id ? '编辑' : '添加'}输入字段` : `${draft.id ? '编辑' : '添加'}工作流变量`}
+        okText="确定"
+        cancelText="取消"
+        onCancel={closeEditor}
+        onOk={saveEditor}
+        destroyOnClose
+      >
+        <div className="space-y-4 pt-2">
+          <div>
+            <div className="mb-1.5 text-[12px] font-medium text-[#344054]">变量名</div>
+            <Input value={draft.name} placeholder="例如 bizDate" onChange={(event) => setDraft((current) => ({ ...current, name: event.target.value }))} />
+            <div className="mt-1 text-[10px] text-[#98a2b3]">引用方式：{editorKind === 'input' ? 'inputs' : 'vars'}.{draft.name || '变量名'}</div>
+          </div>
+          {editorKind === 'input' ? (
+            <div>
+              <div className="mb-1.5 text-[12px] font-medium text-[#344054]">显示名称</div>
+              <Input value={draft.label} placeholder="默认与变量名相同" onChange={(event) => setDraft((current) => ({ ...current, label: event.target.value }))} />
+            </div>
+          ) : null}
+          <div>
+            <div className="mb-1.5 text-[12px] font-medium text-[#344054]">类型</div>
+            <Select
+              className="w-full"
+              value={draft.type}
+              options={editorKind === 'input' ? INPUT_TYPE_OPTIONS : VARIABLE_TYPE_OPTIONS}
+              onChange={(value) => setDraft((current) => ({ ...current, type: value, value: value === 'BOOLEAN' ? false : '' }))}
+            />
+          </div>
+          {editorKind === 'input' ? (
+            <div className="flex items-center justify-between">
+              <div><div className="text-[12px] font-medium text-[#344054]">必填</div><div className="text-[10px] text-[#98a2b3]">运行工作流时必须提供</div></div>
+              <Switch checked={draft.required} onChange={(checked) => setDraft((current) => ({ ...current, required: checked }))} />
+            </div>
+          ) : null}
+          <div>
+            <div className="mb-1.5 text-[12px] font-medium text-[#344054]">{editorKind === 'input' ? '默认值' : '变量值'}</div>
+            <ValueEditor type={draft.type} value={draft.value} onChange={(value) => setDraft((current) => ({ ...current, value }))} />
+          </div>
+          {editorKind === 'input' ? (
+            <div>
+              <div className="mb-1.5 text-[12px] font-medium text-[#344054]">说明</div>
+              <Input.TextArea rows={3} value={draft.description} onChange={(event) => setDraft((current) => ({ ...current, description: event.target.value }))} />
+            </div>
+          ) : null}
+        </div>
+      </Modal>
+    </aside>
+  );
+};
+
+export default WorkflowStartInspector;

--- a/yak-ops-ui/src/pages/workflow/definition/canvas/start/WorkflowStartNode.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/start/WorkflowStartNode.tsx
@@ -1,0 +1,77 @@
+import { GitBranch, Variable } from 'lucide-react';
+import type { NodeProps } from 'reactflow';
+import WorkflowNodeHandle from '../node/WorkflowNodeHandle';
+import type { WorkflowStartNodeData } from './types';
+
+const TYPE_LABEL: Record<string, string> = {
+  STRING: 'String',
+  NUMBER: 'Number',
+  BOOLEAN: 'Boolean',
+  FILE: 'File',
+  ARRAY_STRING: 'Array[String]',
+};
+
+const WorkflowStartNode = ({ id, data, selected }: NodeProps<WorkflowStartNodeData>) => {
+  const visibleInputs = data.inputs.slice(0, 3);
+  const moreCount = Math.max(0, data.inputs.length - visibleInputs.length);
+
+  return (
+    <div className="group relative w-60">
+      <div
+        className={[
+          'relative overflow-hidden rounded-[15px] border bg-white',
+          'shadow-[0_1px_2px_rgba(22,24,35,.06)]',
+          'transition-[border-color,box-shadow] duration-150',
+          'group-hover:shadow-[0_6px_18px_rgba(22,24,35,.10)]',
+          selected
+            ? 'border-[#155eef] shadow-[0_0_0_2px_rgba(21,94,239,.08)]'
+            : 'border-[#e8e9ec] group-hover:border-[#d7d9de]',
+        ].join(' ')}
+      >
+        <div className="flex min-h-[60px] items-center gap-2.5 px-3 py-3">
+          <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-[10px] bg-[#eaf2ff] text-[#155eef]">
+            <GitBranch size={18} strokeWidth={2.2} />
+          </span>
+          <div className="min-w-0 flex-1">
+            <div className="truncate text-[14px] font-semibold leading-5 text-[#161823]">开始</div>
+            <div className="mt-0.5 text-[10px] text-[rgba(22,24,35,.38)]">工作流输入与上下文</div>
+          </div>
+        </div>
+
+        {visibleInputs.length ? (
+          <div className="border-t border-[#f0f1f3] px-3 py-2">
+            <div className="space-y-1">
+              {visibleInputs.map((field) => (
+                <div
+                  key={field.id}
+                  className="flex h-6 items-center gap-1.5 rounded-md bg-[#f5f6f7] px-1.5 text-[10px]"
+                >
+                  <Variable size={12} className="shrink-0 text-[#155eef]" />
+                  <span className="min-w-0 flex-1 truncate text-[#475467]">{field.name}</span>
+                  {field.required ? (
+                    <span className="shrink-0 text-[9px] font-medium text-[#98a2b3]">必填</span>
+                  ) : null}
+                  <span className="shrink-0 text-[9px] text-[#98a2b3]">{TYPE_LABEL[field.type] || field.type}</span>
+                </div>
+              ))}
+              {moreCount ? (
+                <div className="px-1 text-[9px] text-[#98a2b3]">还有 {moreCount} 个输入字段</div>
+              ) : null}
+            </div>
+          </div>
+        ) : null}
+      </div>
+
+      <WorkflowNodeHandle
+        nodeId={id}
+        type="source"
+        selected={selected}
+        locked={data.locked}
+        appendOptions={data.appendOptions}
+        onAppend={data.onAppend}
+      />
+    </div>
+  );
+};
+
+export default WorkflowStartNode;

--- a/yak-ops-ui/src/pages/workflow/definition/canvas/start/WorkflowStartNode.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/start/WorkflowStartNode.tsx
@@ -28,13 +28,12 @@ const WorkflowStartNode = ({ id, data, selected }: NodeProps<WorkflowStartNodeDa
             : 'border-[#e8e9ec] group-hover:border-[#d7d9de]',
         ].join(' ')}
       >
-        <div className="flex min-h-[60px] items-center gap-2.5 px-3 py-3">
+        <div className="flex min-h-9 items-center gap-2.5 px-3 py-3">
           <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-[10px] bg-[#eaf2ff] text-[#155eef]">
             <GitBranch size={18} strokeWidth={2.2} />
           </span>
-          <div className="min-w-0 flex-1">
-            <div className="truncate text-[14px] font-semibold leading-5 text-[#161823]">开始</div>
-            <div className="mt-0.5 text-[10px] text-[rgba(22,24,35,.38)]">工作流输入与上下文</div>
+          <div className="min-w-0 flex-1 truncate text-[14px] font-semibold leading-5 text-[#161823]">
+            开始
           </div>
         </div>
 

--- a/yak-ops-ui/src/pages/workflow/definition/canvas/start/context.ts
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/start/context.ts
@@ -1,0 +1,127 @@
+import {
+  WORKFLOW_START_META_KEY,
+  type WorkflowStartConfig,
+  type WorkflowStartInputField,
+  type WorkflowStartValueType,
+  type WorkflowStartVariable,
+} from './types';
+
+interface StartMetaV1 {
+  version: 1;
+  position?: { x?: number; y?: number };
+  inputFields?: Array<Omit<WorkflowStartInputField, 'defaultValue'>>;
+  variables?: Array<Omit<WorkflowStartVariable, 'value'>>;
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  Boolean(value) && !Array.isArray(value) && typeof value === 'object';
+
+const inferType = (value: unknown): WorkflowStartValueType => {
+  if (typeof value === 'number') return 'NUMBER';
+  if (typeof value === 'boolean') return 'BOOLEAN';
+  if (Array.isArray(value)) return 'ARRAY_STRING';
+  return 'STRING';
+};
+
+const createId = (scope: string, name: string, index: number) =>
+  `${scope}-${name || 'field'}-${index}`;
+
+const normalizePosition = (value?: { x?: number; y?: number }) => ({
+  x: Number.isFinite(value?.x) ? Number(value?.x) : 80,
+  y: Number.isFinite(value?.y) ? Number(value?.y) : 160,
+});
+
+export const hydrateWorkflowStartConfig = (
+  rawInput?: Record<string, unknown>,
+): WorkflowStartConfig => {
+  const input = rawInput || {};
+  const meta = isRecord(input[WORKFLOW_START_META_KEY])
+    ? (input[WORKFLOW_START_META_KEY] as StartMetaV1)
+    : undefined;
+  const inputValues = isRecord(input.inputs) ? input.inputs : undefined;
+  const variableValues = isRecord(input.vars) ? input.vars : {};
+
+  let inputs: WorkflowStartInputField[];
+  if (meta?.inputFields?.length) {
+    inputs = meta.inputFields.map((field, index) => ({
+      ...field,
+      id: field.id || createId('input', field.name, index),
+      label: field.label || field.name,
+      defaultValue: inputValues?.[field.name],
+    }));
+  } else {
+    const legacyValues = inputValues || Object.fromEntries(
+      Object.entries(input).filter(([key]) => key !== WORKFLOW_START_META_KEY && key !== 'vars' && key !== 'sys'),
+    );
+    inputs = Object.entries(legacyValues).map(([name, value], index) => ({
+      id: createId('input', name, index),
+      name,
+      label: name,
+      type: inferType(value),
+      required: false,
+      defaultValue: value,
+    }));
+  }
+
+  let variables: WorkflowStartVariable[];
+  if (meta?.variables?.length) {
+    variables = meta.variables.map((variable, index) => ({
+      ...variable,
+      id: variable.id || createId('var', variable.name, index),
+      value: variableValues[variable.name],
+    }));
+  } else {
+    variables = Object.entries(variableValues).map(([name, value], index) => ({
+      id: createId('var', name, index),
+      name,
+      type: inferType(value) === 'FILE' ? 'STRING' : inferType(value) as WorkflowStartVariable['type'],
+      value,
+    }));
+  }
+
+  return {
+    position: normalizePosition(meta?.position),
+    inputs,
+    variables,
+  };
+};
+
+const serializeValue = (type: WorkflowStartValueType, value: unknown) => {
+  if (type === 'NUMBER') {
+    if (value === '' || value === undefined || value === null) return 0;
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+  if (type === 'BOOLEAN') return Boolean(value);
+  if (type === 'ARRAY_STRING') {
+    if (Array.isArray(value)) return value.map(String);
+    return String(value || '')
+      .split(',')
+      .map((item) => item.trim())
+      .filter(Boolean);
+  }
+  if (type === 'FILE') return value ?? null;
+  return value === undefined || value === null ? '' : String(value);
+};
+
+export const serializeWorkflowStartContext = (
+  config: WorkflowStartConfig,
+  system: { definitionId: string; workflowName: string },
+): Record<string, unknown> => ({
+  sys: {
+    definitionId: system.definitionId,
+    workflowName: system.workflowName,
+  },
+  inputs: Object.fromEntries(
+    config.inputs.map((field) => [field.name, serializeValue(field.type, field.defaultValue)]),
+  ),
+  vars: Object.fromEntries(
+    config.variables.map((variable) => [variable.name, serializeValue(variable.type, variable.value)]),
+  ),
+  [WORKFLOW_START_META_KEY]: {
+    version: 1,
+    position: config.position,
+    inputFields: config.inputs.map(({ defaultValue: _defaultValue, ...field }) => field),
+    variables: config.variables.map(({ value: _value, ...variable }) => variable),
+  } satisfies StartMetaV1,
+});

--- a/yak-ops-ui/src/pages/workflow/definition/canvas/start/types.ts
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/start/types.ts
@@ -1,0 +1,35 @@
+export const WORKFLOW_START_NODE_ID = '__yak_workflow_start__';
+export const WORKFLOW_START_META_KEY = '__yak_start__';
+
+export type WorkflowStartValueType = 'STRING' | 'NUMBER' | 'BOOLEAN' | 'FILE' | 'ARRAY_STRING';
+
+export interface WorkflowStartInputField {
+  id: string;
+  name: string;
+  label: string;
+  type: WorkflowStartValueType;
+  required: boolean;
+  description?: string;
+  defaultValue?: unknown;
+}
+
+export interface WorkflowStartVariable {
+  id: string;
+  name: string;
+  type: Exclude<WorkflowStartValueType, 'FILE'>;
+  value?: unknown;
+}
+
+export interface WorkflowStartConfig {
+  position: { x: number; y: number };
+  inputs: WorkflowStartInputField[];
+  variables: WorkflowStartVariable[];
+}
+
+export interface WorkflowStartNodeData {
+  label: string;
+  locked?: boolean;
+  inputs: WorkflowStartInputField[];
+  appendOptions?: Array<{ id: string; label: string; typeLabel: string }>;
+  onAppend?: (nodeId: string, taskId: string) => void;
+}


### PR DESCRIPTION
## What changed

- Added a Dify-style **Start** node that is always present when opening a workflow definition.
- The Start node is a virtual workflow root, not a normal task:
  - cannot be deleted
  - cannot be duplicated
  - has no target handle
  - keeps the same source `+` interaction as other nodes
  - clearing the canvas removes task nodes/edges but keeps Start and its context configuration
- Start automatically connects to every task node that has no task predecessor. These synthetic Start edges are derived in the canvas and are **not** written into the backend task DAG.
- Added a Dify-inspired Start inspector with `设置 / 上次运行` tabs.
- Added structured workflow context configuration:
  - `inputs.*` — workflow runtime input fields
  - `vars.*` — user-defined workflow-wide variables
  - `sys.*` — read-only system values (`definitionId`, `workflowName` for this phase)
- Input fields support String / Number / Boolean / File / Array[String], required flags, display labels, descriptions, and default values.
- Workflow variables support typed values and are available to downstream nodes through the `vars` namespace.
- Moved the raw `Workflow Input {}` editor out of the top runtime popover; workflow input is now maintained through the Start node UI.
- Added compatibility migration for existing workflow input objects. Existing top-level input values are inferred as Start input fields when the workflow is first opened.
- Start position, input-field schema, and variable schema are persisted inside the existing `WorkflowDefinition.input` JSON without introducing a Start task or changing the task-node/edge backend schema.
- The actual persisted runtime context now has a predictable shape:

```json
{
  "sys": {
    "definitionId": "...",
    "workflowName": "..."
  },
  "inputs": {
    "bizDate": "2026-08-08"
  },
  "vars": {
    "environment": "prod"
  }
}
```

A reserved `__yak_start__` metadata entry is stored alongside the runtime context so the UI can restore field types, required flags, labels, and Start position.

## Dify reference

This follows Dify's Start-node architecture rather than modeling Start as a worker task. In Dify, Start is a singleton node whose panel owns input variables and whose node body renders those variables directly. Relevant upstream references:

- `web/app/components/workflow/nodes/start/default.ts` — singleton/start metadata
- `web/app/components/workflow/nodes/start/panel.tsx` — input-field management
- `web/app/components/workflow/nodes/start/node.tsx` — compact variable rendering inside the canvas node

## DAG semantics

Yak Ops keeps its existing backend DAG untouched:

- persisted `nodes` remain executable task nodes only
- persisted `edges` remain task-to-task edges only
- Start-to-root edges are derived from nodes with no task predecessor
- when an incoming task edge is added/removed, the Start connection updates automatically
- Start is never submitted to the executor/worker

## Scope

- Frontend implementation plus use of the existing `WorkflowDefinition.input` JSON field.
- No database migration.
- No backend task-node schema change.
- Existing retry, failure handling, timeout defaults, task edges, node execution, and last-run behavior remain intact.

## Validation

- Branch is based on current `main` and is not behind it.
- Final diff is limited to the workflow definition editor, toolbar, and the new `canvas/start` components/utilities.
- Opened as Draft for visual and interaction verification, especially existing-workflow input migration and Start/root-edge behavior.