### PR TITLE
refactor(workflow): align next step layout with Dify

### DIFF
--- a/yak-ops-ui/src/pages/workflow/definition/canvas/WorkflowNextStep.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/WorkflowNextStep.tsx
@@ -1,0 +1,91 @@
+import { Select } from 'antd';
+import { Plus } from 'lucide-react';
+import type { ReactNode } from 'react';
+import type { WorkflowCanvasTaskOption } from './types';
+import WorkflowNodeIcon from './node/icons/WorkflowNodeIcon';
+
+export interface WorkflowNextStepNode {
+  id: string;
+  label: string;
+  taskType: string;
+}
+
+interface WorkflowNextStepProps {
+  currentIcon: ReactNode;
+  nextNodes: WorkflowNextStepNode[];
+  appendOptions: WorkflowCanvasTaskOption[];
+  locked: boolean;
+  onAppend: (taskId: string) => void;
+}
+
+const WorkflowNextStep = ({
+  currentIcon,
+  nextNodes,
+  appendOptions,
+  locked,
+  onAppend,
+}: WorkflowNextStepProps) => {
+  const options = appendOptions.map((item) => ({
+    value: item.id,
+    label: item.label,
+  }));
+  const canAppend = !locked && options.length > 0;
+  const addLabel = nextNodes.length ? '添加并行节点' : '选择下一步';
+
+  return (
+    <div className="flex py-1">
+      <div className="relative flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-[#e4e7ec] bg-white shadow-[0_1px_2px_rgba(16,24,40,.05)]">
+        {currentIcon}
+      </div>
+
+      <svg className="h-9 w-6 shrink-0" viewBox="0 0 24 36" aria-hidden="true">
+        <path d="M0 18H24" fill="none" stroke="#d0d5dd" strokeWidth="1" />
+        <rect x="0" y="16" width="1" height="4" rx="0.5" fill="#c7c9ce" />
+        <rect x="23" y="16" width="1" height="4" rx="0.5" fill="#c7c9ce" />
+      </svg>
+
+      <div className="min-w-0 flex-1 space-y-0.5 rounded-[10px] bg-[#f5f6f7] p-0.5">
+        {nextNodes.map((item) => (
+          <div
+            key={item.id}
+            className="group flex h-9 items-center rounded-lg border border-[#e4e7ec] bg-white px-2 shadow-[0_1px_2px_rgba(16,24,40,.04)] transition-colors hover:bg-[#fafafa]"
+          >
+            <WorkflowNodeIcon taskType={item.taskType} size="sm" />
+            <div className="ml-1.5 min-w-0 flex-1 truncate text-[11px] font-medium text-[#475467]">
+              {item.label}
+            </div>
+          </div>
+        ))}
+
+        {canAppend ? (
+          <div className="rounded-lg border border-dashed border-[#d0d5dd] bg-[rgba(255,255,255,.42)] transition-colors hover:bg-white">
+            <Select
+              className="w-full"
+              variant="borderless"
+              value={undefined}
+              options={options}
+              popupMatchSelectWidth
+              onChange={onAppend}
+              placeholder={(
+                <span className="inline-flex items-center gap-1.5 text-[11px] font-medium text-[#98a2b3]">
+                  <span className="flex h-5 w-5 items-center justify-center rounded-[5px] bg-[#e9eaec] text-[#98a2b3]">
+                    <Plus size={12} />
+                  </span>
+                  {addLabel}
+                </span>
+              )}
+            />
+          </div>
+        ) : null}
+
+        {!nextNodes.length && !canAppend ? (
+          <div className="flex h-9 items-center rounded-lg border border-dashed border-[#d0d5dd] px-2 text-[11px] text-[#98a2b3]">
+            暂无后续节点
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+};
+
+export default WorkflowNextStep;

--- a/yak-ops-ui/src/pages/workflow/definition/canvas/WorkflowNodeInspectorSettings.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/WorkflowNodeInspectorSettings.tsx
@@ -1,7 +1,8 @@
 import type { WorkflowNodeFailurePolicy } from '@/services/workflow';
 import { InputNumber, Select, Slider, Switch, Tooltip } from 'antd';
-import { CircleHelp, Plus } from 'lucide-react';
+import { CircleHelp } from 'lucide-react';
 import type { Node } from 'reactflow';
+import WorkflowNextStep from './WorkflowNextStep';
 import type { WorkflowCanvasTaskOption, WorkflowNodeData } from './types';
 import WorkflowNodeIcon from './node/icons/WorkflowNodeIcon';
 
@@ -30,7 +31,7 @@ interface WorkflowNodeInspectorSettingsProps {
 }
 
 const SectionTitle = ({ children }: { children: string }) => (
-  <div className="mb-2 text-[11px] font-semibold text-[#344054]">{children}</div>
+  <div className="mb-1 text-[12px] font-semibold text-[#344054]">{children}</div>
 );
 
 const Divider = () => <div className="mx-4 border-t border-[#f0f1f3]" />;
@@ -51,11 +52,6 @@ const WorkflowNodeInspectorSettings = ({
 }: WorkflowNodeInspectorSettingsProps) => {
   const retryTimes = Math.max(0, (node.data.maxAttempts || 1) - 1);
   const retryEnabled = retryTimes > 0;
-
-  const appendSelectOptions = appendOptions.map((item) => ({
-    value: item.id,
-    label: item.label,
-  }));
 
   const handleRetryEnabledChange = (checked: boolean) => {
     if (!checked) {
@@ -166,40 +162,14 @@ const WorkflowNodeInspectorSettings = ({
 
       <section className="px-4 py-4">
         <SectionTitle>下一步</SectionTitle>
-        <div className="mb-3 text-[10px] leading-4 text-[rgba(22,24,35,.38)]">添加此节点执行完成后的下一个任务</div>
-
-        <div className="space-y-1.5">
-          {nextNodes.map((item) => (
-            <div
-              key={item.id}
-              className="flex items-center gap-2 rounded-xl border border-[#e7e9ed] bg-white px-2.5 py-2 shadow-[0_1px_2px_rgba(22,24,35,.03)]"
-            >
-              <WorkflowNodeIcon taskType={item.taskType} size="sm" />
-              <div className="min-w-0 flex-1 truncate text-[11px] font-medium text-[#344054]">{item.label}</div>
-            </div>
-          ))}
-
-          {!nextNodes.length ? (
-            <div className="rounded-xl border border-dashed border-[#dfe3e8] bg-[#fafafa] px-3 py-3 text-center text-[10px] text-[rgba(22,24,35,.36)]">
-              暂无后续节点
-            </div>
-          ) : null}
-        </div>
-
-        {!locked && appendSelectOptions.length ? (
-          <Select
-            className="mt-2 w-full"
-            variant="filled"
-            value={undefined}
-            placeholder={
-              <span className="inline-flex items-center gap-1.5 text-[rgba(22,24,35,.42)]">
-                <Plus size={13} /> 添加后续任务
-              </span>
-            }
-            options={appendSelectOptions}
-            onChange={(value) => onAppend(value)}
-          />
-        ) : null}
+        <div className="mb-3 text-[10px] leading-4 text-[rgba(22,24,35,.38)]">添加此工作流程中的下一个节点</div>
+        <WorkflowNextStep
+          currentIcon={<WorkflowNodeIcon taskType={node.data.taskType} size="sm" />}
+          nextNodes={nextNodes}
+          appendOptions={appendOptions}
+          locked={locked}
+          onAppend={onAppend}
+        />
       </section>
     </div>
   );

--- a/yak-ops-ui/src/pages/workflow/definition/canvas/start/WorkflowStartInspector.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/start/WorkflowStartInspector.tsx
@@ -3,8 +3,8 @@ import { Input, Modal, Select, Switch, message } from 'antd';
 import dayjs from 'dayjs';
 import { GitBranch, Plus, RefreshCw, Trash2, Variable, X } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import WorkflowNextStep from '../WorkflowNextStep';
 import type { WorkflowCanvasTaskOption } from '../types';
-import WorkflowNodeIcon from '../node/icons/WorkflowNodeIcon';
 import type {
   WorkflowStartConfig,
   WorkflowStartInputField,
@@ -85,6 +85,7 @@ const ValueEditor = ({
   if (type === 'FILE') {
     return <div className="text-[11px] leading-5 text-[#98a2b3]">File 类型由工作流运行时提供，不配置默认值。</div>;
   }
+
   return (
     <Input
       value={Array.isArray(value) ? value.join(', ') : String(value ?? '')}
@@ -93,6 +94,8 @@ const ValueEditor = ({
     />
   );
 };
+
+const Divider = () => <div className="mx-4 border-t border-[#f0f1f3]" />;
 
 const WorkflowStartInspector = ({
   definitionId,
@@ -110,8 +113,6 @@ const WorkflowStartInspector = ({
   const [draft, setDraft] = useState<EditorDraft>(newDraft());
   const [lastRunLoading, setLastRunLoading] = useState(false);
   const [lastRun, setLastRun] = useState<Awaited<ReturnType<typeof getWorkflowInstances>>[number]>();
-
-  const appendSelectOptions = appendOptions.map((item) => ({ value: item.id, label: item.label }));
 
   const loadLastRun = useCallback(async () => {
     setLastRunLoading(true);
@@ -169,6 +170,7 @@ const WorkflowStartInspector = ({
       message.warning('变量名需以字母或下划线开头，只能包含字母、数字和下划线');
       return;
     }
+
     const duplicate = editorKind === 'input'
       ? config.inputs.some((item) => item.name === name && item.id !== draft.id)
       : config.variables.some((item) => item.name === name && item.id !== draft.id);
@@ -207,13 +209,28 @@ const WorkflowStartInspector = ({
           : [...config.variables, item],
       });
     }
+
     closeEditor();
+  };
+
+  const removeInput = (id: string) => {
+    onChange({ ...config, inputs: config.inputs.filter((item) => item.id !== id) });
+  };
+
+  const removeVariable = (id: string) => {
+    onChange({ ...config, variables: config.variables.filter((item) => item.id !== id) });
   };
 
   const systemVariables = useMemo(() => [
     { name: 'sys.definitionId', value: definitionId },
     { name: 'sys.workflowName', value: workflowName || '--' },
   ], [definitionId, workflowName]);
+
+  const startStepIcon = (
+    <span className="flex h-6 w-6 items-center justify-center rounded-[6px] bg-[#155eef] text-white shadow-[0_1px_2px_rgba(21,94,239,.18)]">
+      <GitBranch size={14} strokeWidth={2.2} />
+    </span>
+  );
 
   return (
     <aside className="absolute bottom-3 right-3 top-3 z-20 flex w-[400px] flex-col overflow-hidden rounded-2xl border border-[#e2e5e9] bg-white shadow-[0_12px_36px_rgba(22,24,35,.12)]">
@@ -242,12 +259,12 @@ const WorkflowStartInspector = ({
               type="button"
               className={[
                 'relative h-10 border-0 bg-transparent px-0 text-[12px] font-semibold',
-                tab === key ? 'text-[#344054]' : 'text-[#667085]',
+                tab === key ? 'text-[#344054]' : 'text-[#667085] hover:text-[#344054]',
               ].join(' ')}
               onClick={() => setTab(key)}
             >
               {key === 'settings' ? '设置' : '上次运行'}
-              {tab === key ? <span className="absolute bottom-0 left-0 right-0 h-0.5 rounded-full bg-[#155eef]" /> : null}
+              {tab === key ? <span className="absolute bottom-0 left-0 right-0 h-0.5 rounded-full bg-[#fe2c55]" /> : null}
             </button>
           ))}
         </nav>
@@ -274,21 +291,33 @@ const WorkflowStartInspector = ({
 
               <div className="space-y-1.5">
                 {config.inputs.map((field) => (
-                  <button
+                  <div
                     key={field.id}
-                    type="button"
-                    disabled={locked}
-                    className="flex w-full items-center gap-2 rounded-xl border border-[#e7e9ed] bg-white px-2.5 py-2 text-left hover:bg-[#fafafa] disabled:cursor-default"
-                    onClick={() => openInputEditor(field)}
+                    className="group flex items-center gap-2 rounded-xl border border-[#e7e9ed] bg-white px-2.5 py-2 hover:bg-[#fafafa]"
                   >
                     <Variable size={14} className="shrink-0 text-[#155eef]" />
-                    <div className="min-w-0 flex-1">
+                    <button
+                      type="button"
+                      disabled={locked}
+                      className="min-w-0 flex-1 border-0 bg-transparent p-0 text-left"
+                      onClick={() => openInputEditor(field)}
+                    >
                       <div className="truncate text-[11px] font-medium text-[#344054]">inputs.{field.name}</div>
                       {field.description ? <div className="truncate text-[9px] text-[#98a2b3]">{field.description}</div> : null}
-                    </div>
+                    </button>
                     {field.required ? <span className="text-[9px] text-[#98a2b3]">必填</span> : null}
                     <span className="text-[10px] text-[#98a2b3]">{INPUT_TYPE_OPTIONS.find((item) => item.value === field.type)?.label}</span>
-                  </button>
+                    {!locked ? (
+                      <button
+                        type="button"
+                        className="hidden h-6 w-6 items-center justify-center rounded-md border-0 bg-transparent text-[#98a2b3] hover:bg-[#fff1f3] hover:text-[#d92d4f] group-hover:flex"
+                        onClick={() => removeInput(field.id)}
+                        aria-label="删除输入字段"
+                      >
+                        <Trash2 size={13} />
+                      </button>
+                    ) : null}
+                  </div>
                 ))}
                 {!config.inputs.length ? (
                   <div className="rounded-xl border border-dashed border-[#dfe3e8] bg-[#fafafa] px-4 py-6 text-center text-[10px] leading-5 text-[#98a2b3]">
@@ -298,7 +327,7 @@ const WorkflowStartInspector = ({
               </div>
             </section>
 
-            <div className="mx-4 border-t border-[#f0f1f3]" />
+            <Divider />
 
             <section className="px-4 py-4">
               <div className="mb-1 flex items-center justify-between">
@@ -332,7 +361,7 @@ const WorkflowStartInspector = ({
                       <button
                         type="button"
                         className="flex h-6 w-6 items-center justify-center rounded-md border-0 bg-transparent text-[#98a2b3] hover:bg-[#fff1f3] hover:text-[#d92d4f]"
-                        onClick={() => onChange({ ...config, variables: config.variables.filter((item) => item.id !== variable.id) })}
+                        onClick={() => removeVariable(variable.id)}
                         aria-label="删除变量"
                       >
                         <Trash2 size={13} />
@@ -343,7 +372,7 @@ const WorkflowStartInspector = ({
               </div>
             </section>
 
-            <div className="mx-4 border-t border-[#f0f1f3]" />
+            <Divider />
 
             <section className="px-4 py-4">
               <div className="mb-1 text-[12px] font-semibold text-[#344054]">系统变量</div>
@@ -362,45 +391,44 @@ const WorkflowStartInspector = ({
               </div>
             </section>
 
-            <div className="mx-4 border-t border-[#f0f1f3]" />
+            <Divider />
 
             <section className="px-4 py-4">
               <div className="mb-1 text-[12px] font-semibold text-[#344054]">下一步</div>
-              <div className="mb-3 text-[10px] text-[rgba(22,24,35,.38)]">没有前置节点的任务会自动连接到开始节点</div>
-              <div className="space-y-1.5">
-                {nextNodes.map((item) => (
-                  <div key={item.id} className="flex items-center gap-2 rounded-xl border border-[#e7e9ed] px-2.5 py-2">
-                    <WorkflowNodeIcon taskType={item.taskType} size="sm" />
-                    <div className="min-w-0 flex-1 truncate text-[11px] font-medium text-[#344054]">{item.label}</div>
-                  </div>
-                ))}
-                {!nextNodes.length ? <div className="rounded-xl border border-dashed border-[#dfe3e8] bg-[#fafafa] px-3 py-3 text-center text-[10px] text-[#98a2b3]">暂无后续节点</div> : null}
-              </div>
-              {!locked && appendSelectOptions.length ? (
-                <Select
-                  className="mt-2 w-full"
-                  variant="filled"
-                  value={undefined}
-                  placeholder={<span className="inline-flex items-center gap-1.5"><Plus size={13} /> 添加后续任务</span>}
-                  options={appendSelectOptions}
-                  onChange={onAppend}
-                />
-              ) : null}
+              <div className="mb-3 text-[10px] leading-4 text-[rgba(22,24,35,.38)]">添加此工作流程中的下一个节点</div>
+              <WorkflowNextStep
+                currentIcon={startStepIcon}
+                nextNodes={nextNodes}
+                appendOptions={appendOptions}
+                locked={locked}
+                onAppend={onAppend}
+              />
             </section>
           </div>
         ) : (
           <div className="px-4 py-4">
             <div className="mb-3 flex items-center justify-between">
               <div className="text-[12px] font-semibold text-[#344054]">最近一次运行</div>
-              <button type="button" className="flex h-7 w-7 items-center justify-center rounded-md border-0 bg-transparent text-[#98a2b3] hover:bg-[#f2f4f7]" onClick={() => void loadLastRun()}>
+              <button
+                type="button"
+                className="flex h-7 w-7 items-center justify-center rounded-md border-0 bg-transparent text-[#98a2b3] hover:bg-[#f2f4f7]"
+                onClick={() => void loadLastRun()}
+                aria-label="刷新上次运行"
+              >
                 <RefreshCw size={14} className={lastRunLoading ? 'animate-spin' : ''} />
               </button>
             </div>
             {lastRun ? (
               <div className="space-y-4">
-                <div className="grid grid-cols-2 rounded-xl border border-[#d9e6ff] bg-[#f3f7ff]">
-                  <div className="px-3 py-2.5"><div className="text-[9px] text-[#667085]">状态</div><div className="mt-1 text-[11px] font-semibold text-[#155eef]">{lastRun.status}</div></div>
-                  <div className="border-l border-[#d9e6ff] px-3 py-2.5"><div className="text-[9px] text-[#667085]">开始时间</div><div className="mt-1 text-[11px] font-semibold text-[#344054]">{dayjs(lastRun.startedAt).format('YYYY-MM-DD HH:mm:ss')}</div></div>
+                <div className="grid grid-cols-2 rounded-xl border border-[#f5c2cc] bg-[#fff6f8]">
+                  <div className="px-3 py-2.5">
+                    <div className="text-[9px] text-[#667085]">状态</div>
+                    <div className="mt-1 text-[11px] font-semibold text-[#fe2c55]">{lastRun.status}</div>
+                  </div>
+                  <div className="border-l border-[#f5c2cc] px-3 py-2.5">
+                    <div className="text-[9px] text-[#667085]">开始时间</div>
+                    <div className="mt-1 text-[11px] font-semibold text-[#344054]">{dayjs(lastRun.startedAt).format('YYYY-MM-DD HH:mm:ss')}</div>
+                  </div>
                 </div>
                 <div>
                   <div className="mb-2 text-[12px] font-semibold text-[#344054]">工作流输入</div>
@@ -429,38 +457,69 @@ const WorkflowStartInspector = ({
         <div className="space-y-4 pt-2">
           <div>
             <div className="mb-1.5 text-[12px] font-medium text-[#344054]">变量名</div>
-            <Input value={draft.name} placeholder="例如 bizDate" onChange={(event) => setDraft((current) => ({ ...current, name: event.target.value }))} />
+            <Input
+              value={draft.name}
+              placeholder="例如 bizDate"
+              onChange={(event) => setDraft((current) => ({ ...current, name: event.target.value }))}
+            />
             <div className="mt-1 text-[10px] text-[#98a2b3]">引用方式：{editorKind === 'input' ? 'inputs' : 'vars'}.{draft.name || '变量名'}</div>
           </div>
+
           {editorKind === 'input' ? (
             <div>
               <div className="mb-1.5 text-[12px] font-medium text-[#344054]">显示名称</div>
-              <Input value={draft.label} placeholder="默认与变量名相同" onChange={(event) => setDraft((current) => ({ ...current, label: event.target.value }))} />
+              <Input
+                value={draft.label}
+                placeholder="默认与变量名相同"
+                onChange={(event) => setDraft((current) => ({ ...current, label: event.target.value }))}
+              />
             </div>
           ) : null}
+
           <div>
             <div className="mb-1.5 text-[12px] font-medium text-[#344054]">类型</div>
             <Select
               className="w-full"
               value={draft.type}
               options={editorKind === 'input' ? INPUT_TYPE_OPTIONS : VARIABLE_TYPE_OPTIONS}
-              onChange={(value) => setDraft((current) => ({ ...current, type: value, value: value === 'BOOLEAN' ? false : '' }))}
+              onChange={(value) => setDraft((current) => ({
+                ...current,
+                type: value,
+                value: value === 'BOOLEAN' ? false : '',
+              }))}
             />
           </div>
+
           {editorKind === 'input' ? (
             <div className="flex items-center justify-between">
-              <div><div className="text-[12px] font-medium text-[#344054]">必填</div><div className="text-[10px] text-[#98a2b3]">运行工作流时必须提供</div></div>
-              <Switch checked={draft.required} onChange={(checked) => setDraft((current) => ({ ...current, required: checked }))} />
+              <div>
+                <div className="text-[12px] font-medium text-[#344054]">必填</div>
+                <div className="text-[10px] text-[#98a2b3]">运行工作流时必须提供</div>
+              </div>
+              <Switch
+                checked={draft.required}
+                onChange={(checked) => setDraft((current) => ({ ...current, required: checked }))}
+              />
             </div>
           ) : null}
+
           <div>
             <div className="mb-1.5 text-[12px] font-medium text-[#344054]">{editorKind === 'input' ? '默认值' : '变量值'}</div>
-            <ValueEditor type={draft.type} value={draft.value} onChange={(value) => setDraft((current) => ({ ...current, value }))} />
+            <ValueEditor
+              type={draft.type}
+              value={draft.value}
+              onChange={(value) => setDraft((current) => ({ ...current, value }))}
+            />
           </div>
+
           {editorKind === 'input' ? (
             <div>
               <div className="mb-1.5 text-[12px] font-medium text-[#344054]">说明</div>
-              <Input.TextArea rows={3} value={draft.description} onChange={(event) => setDraft((current) => ({ ...current, description: event.target.value }))} />
+              <Input.TextArea
+                rows={3}
+                value={draft.description}
+                onChange={(event) => setDraft((current) => ({ ...current, description: event.target.value }))}
+              />
             </div>
           ) : null}
         </div>

--- a/yak-ops-ui/src/pages/workflow/definition/canvas/start/WorkflowStartNode.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/start/WorkflowStartNode.tsx
@@ -24,7 +24,7 @@ const WorkflowStartNode = ({ id, data, selected }: NodeProps<WorkflowStartNodeDa
           'transition-[border-color,box-shadow] duration-150',
           'group-hover:shadow-[0_6px_18px_rgba(22,24,35,.10)]',
           selected
-            ? 'border-[#155eef] shadow-[0_0_0_2px_rgba(21,94,239,.08)]'
+            ? 'border-[#fe2c55] shadow-[0_0_0_2px_rgba(254,44,85,.08)]'
             : 'border-[#e8e9ec] group-hover:border-[#d7d9de]',
         ].join(' ')}
       >


### PR DESCRIPTION
## What changed

- Added a reusable `WorkflowNextStep` component modeled after Dify's `NextStep` structure:
  - current-node icon on the left
  - 24px connector line in the middle
  - right-side branch container
  - compact next-node cards
  - dashed add row that changes to `添加并行节点` once a next node already exists
- Replaced the existing plain next-step list/select in the Start inspector with this Dify-style layout.
- Reused the same component in normal task-node inspectors so Start and task nodes share one consistent interaction system.
- Updated Start-node selected state to use the Yak Ops brand color `#fe2c55` instead of Dify blue.
- Updated the Start inspector active-tab indicator to the Yak Ops brand color as well, while retaining the blue Start icon as the node-type identity color.

## Dify reference

The layout follows Dify's split implementation under:

- `web/app/components/workflow/nodes/_base/components/next-step/index.tsx`
- `web/app/components/workflow/nodes/_base/components/next-step/container.tsx`
- `web/app/components/workflow/nodes/_base/components/next-step/item.tsx`
- `web/app/components/workflow/nodes/_base/components/next-step/add.tsx`
- `web/app/components/workflow/nodes/_base/components/next-step/line.tsx`

The key design preserved here is `current icon -> SVG line -> branch container`, rather than rendering next nodes as an unrelated list below the section title.

## Scope

- Frontend only.
- No workflow DAG/persistence/API behavior changes.
- Existing add-next-node and add-parallel-node behavior is reused.
- Start node remains immutable and keeps its existing virtual-root semantics.

## Validation

- Branch is based on current `main` and is not behind it.
- Diff is limited to the shared next-step view, Start inspector, task inspector settings, and Start selected styling.
- Opened as Draft for visual verification against Dify.