### PR TITLE
refactor(workflow): unify task add picker in Dify style

### DIFF
--- a/yak-ops-ui/src/pages/workflow/definition/canvas/WorkflowNextStep.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/WorkflowNextStep.tsx
@@ -1,8 +1,8 @@
-import { Select } from 'antd';
 import { Plus } from 'lucide-react';
 import type { ReactNode } from 'react';
-import type { WorkflowCanvasTaskOption } from './types';
 import WorkflowNodeIcon from './node/icons/WorkflowNodeIcon';
+import WorkflowTaskPicker from './WorkflowTaskPicker';
+import type { WorkflowCanvasTaskOption } from './types';
 
 export interface WorkflowNextStepNode {
   id: string;
@@ -25,11 +25,7 @@ const WorkflowNextStep = ({
   locked,
   onAppend,
 }: WorkflowNextStepProps) => {
-  const options = appendOptions.map((item) => ({
-    value: item.id,
-    label: item.label,
-  }));
-  const canAppend = !locked && options.length > 0;
+  const canAppend = !locked && appendOptions.length > 0;
   const addLabel = nextNodes.length ? '添加并行节点' : '选择下一步';
 
   return (
@@ -58,24 +54,23 @@ const WorkflowNextStep = ({
         ))}
 
         {canAppend ? (
-          <div className="rounded-lg border border-dashed border-[#d0d5dd] bg-[rgba(255,255,255,.42)] transition-colors hover:bg-white">
-            <Select
-              className="w-full"
-              variant="borderless"
-              value={undefined}
-              options={options}
-              popupMatchSelectWidth
-              onChange={onAppend}
-              placeholder={(
-                <span className="inline-flex items-center gap-1.5 text-[11px] font-medium text-[#98a2b3]">
-                  <span className="flex h-5 w-5 items-center justify-center rounded-[5px] bg-[#e9eaec] text-[#98a2b3]">
-                    <Plus size={12} />
-                  </span>
-                  {addLabel}
-                </span>
-              )}
-            />
-          </div>
+          <WorkflowTaskPicker
+            placement="leftTop"
+            options={appendOptions}
+            onSelect={onAppend}
+          >
+            <button
+              type="button"
+              className="flex h-9 w-full items-center rounded-lg border border-dashed border-[#d0d5dd] bg-[rgba(255,255,255,.42)] px-2 text-left transition-colors hover:bg-white"
+            >
+              <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-[5px] bg-[#e9eaec] text-[#98a2b3]">
+                <Plus size={12} />
+              </span>
+              <span className="ml-1.5 text-[11px] font-medium text-[#98a2b3]">
+                {addLabel}
+              </span>
+            </button>
+          </WorkflowTaskPicker>
         ) : null}
 
         {!nextNodes.length && !canAppend ? (

--- a/yak-ops-ui/src/pages/workflow/definition/canvas/WorkflowTaskPicker.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/WorkflowTaskPicker.tsx
@@ -1,0 +1,189 @@
+import { Input, Popover } from 'antd';
+import type { PopoverProps } from 'antd';
+import { Search } from 'lucide-react';
+import type { ReactElement } from 'react';
+import { useMemo, useState } from 'react';
+import WorkflowNodeIcon from './node/icons/WorkflowNodeIcon';
+import type { WorkflowCanvasTaskOption } from './types';
+
+export type WorkflowTaskCategory = 'sync' | 'development' | 'quality';
+
+interface WorkflowTaskPickerProps {
+  options: WorkflowCanvasTaskOption[];
+  onSelect: (taskId: string) => void;
+  children: ReactElement;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  placement?: PopoverProps['placement'];
+  disabled?: boolean;
+  defaultCategory?: WorkflowTaskCategory;
+}
+
+const CATEGORY_META: Array<{
+  key: WorkflowTaskCategory;
+  label: string;
+}> = [
+  { key: 'sync', label: '数据同步' },
+  { key: 'development', label: '数据开发' },
+  { key: 'quality', label: '数据质量' },
+];
+
+const resolveTaskCategory = (taskType?: string): WorkflowTaskCategory => {
+  const normalized = (taskType || '').trim().toUpperCase();
+
+  if (
+    normalized.includes('QUALITY')
+    || normalized.includes('CHECK')
+    || normalized.includes('VALIDATE')
+    || normalized.includes('VERIFY')
+  ) {
+    return 'quality';
+  }
+
+  if (
+    normalized.includes('SYNC')
+    || normalized.includes('CDC')
+    || normalized.includes('REPLICATION')
+  ) {
+    return 'sync';
+  }
+
+  return 'development';
+};
+
+const createSearchState = (): Record<WorkflowTaskCategory, string> => ({
+  sync: '',
+  development: '',
+  quality: '',
+});
+
+const WorkflowTaskPicker = ({
+  options,
+  onSelect,
+  children,
+  open: controlledOpen,
+  onOpenChange,
+  placement = 'rightTop',
+  disabled = false,
+  defaultCategory = 'sync',
+}: WorkflowTaskPickerProps) => {
+  const [innerOpen, setInnerOpen] = useState(false);
+  const [activeCategory, setActiveCategory] = useState<WorkflowTaskCategory>(defaultCategory);
+  const [searchText, setSearchText] = useState(createSearchState);
+  const open = controlledOpen ?? innerOpen;
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (nextOpen && disabled) return;
+    if (controlledOpen === undefined) setInnerOpen(nextOpen);
+    onOpenChange?.(nextOpen);
+  };
+
+  const groupedOptions = useMemo(() => {
+    const grouped: Record<WorkflowTaskCategory, WorkflowCanvasTaskOption[]> = {
+      sync: [],
+      development: [],
+      quality: [],
+    };
+
+    options.forEach((option) => {
+      grouped[resolveTaskCategory(option.taskType)].push(option);
+    });
+
+    return grouped;
+  }, [options]);
+
+  const activeMeta = CATEGORY_META.find((item) => item.key === activeCategory) ?? CATEGORY_META[0];
+  const keyword = searchText[activeCategory].trim().toLowerCase();
+  const filteredOptions = groupedOptions[activeCategory].filter((option) =>
+    !keyword || option.label.toLowerCase().includes(keyword));
+
+  const content = (
+    <div
+      className="w-[400px] min-w-0 overflow-hidden rounded-xl border border-[#e4e7ec] bg-white shadow-[0_12px_32px_rgba(22,24,35,.14)]"
+      onClick={(event) => event.stopPropagation()}
+    >
+      <div className="flex h-9 items-end gap-0.5 bg-[#f5f6f7] px-1 pt-1">
+        {CATEGORY_META.map((item) => {
+          const active = item.key === activeCategory;
+          return (
+            <button
+              key={item.key}
+              type="button"
+              className={[
+                'relative flex h-8 items-center rounded-t-lg border-0 px-3 text-[12px] font-medium transition-colors',
+                active
+                  ? 'bg-white text-[#fe2c55]'
+                  : 'bg-transparent text-[#667085] hover:text-[#344054]',
+              ].join(' ')}
+              onClick={() => setActiveCategory(item.key)}
+            >
+              {item.label}
+              {active ? (
+                <span className="absolute inset-x-3 bottom-0 h-0.5 rounded-full bg-[#fe2c55]" />
+              ) : null}
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="p-2">
+        <Input
+          autoFocus
+          allowClear
+          value={searchText[activeCategory]}
+          variant="filled"
+          prefix={<Search size={14} className="text-[#98a2b3]" />}
+          placeholder={`搜索${activeMeta.label}任务...`}
+          className="h-8 rounded-lg"
+          onChange={(event) => {
+            const value = event.target.value;
+            setSearchText((current) => ({ ...current, [activeCategory]: value }));
+          }}
+          onClick={(event) => event.stopPropagation()}
+          onKeyDown={(event) => event.stopPropagation()}
+        />
+      </div>
+
+      <div className="border-t border-[#f0f1f3]">
+        <div className="max-h-[420px] overflow-y-auto p-1">
+          {filteredOptions.length ? filteredOptions.map((option) => (
+            <button
+              key={option.id}
+              type="button"
+              className="flex h-9 w-full items-center rounded-lg border-0 bg-transparent px-3 text-left transition-colors hover:bg-[#f5f6f7] focus:bg-[#f5f6f7] focus:outline-none"
+              onClick={() => {
+                onSelect(option.id);
+                handleOpenChange(false);
+              }}
+            >
+              <WorkflowNodeIcon taskType={option.taskType} size="xs" />
+              <span className="ml-2 min-w-0 flex-1 truncate text-[13px] font-medium text-[#475467]">
+                {option.label}
+              </span>
+            </button>
+          )) : (
+            <div className="flex h-16 items-center justify-center text-[11px] text-[#98a2b3]">
+              {keyword ? '没有匹配的任务' : `暂无${activeMeta.label}任务`}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+
+  return (
+    <Popover
+      trigger="click"
+      arrow={false}
+      placement={placement}
+      open={open}
+      onOpenChange={handleOpenChange}
+      content={content}
+      overlayInnerStyle={{ padding: 0, background: 'transparent', boxShadow: 'none' }}
+    >
+      {children}
+    </Popover>
+  );
+};
+
+export default WorkflowTaskPicker;

--- a/yak-ops-ui/src/pages/workflow/definition/canvas/WorkflowTaskPicker.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/WorkflowTaskPicker.tsx
@@ -28,8 +28,12 @@ const CATEGORY_META: Array<{
   { key: 'quality', label: '数据质量' },
 ];
 
-const resolveTaskCategory = (taskType?: string): WorkflowTaskCategory => {
-  const normalized = (taskType || '').trim().toUpperCase();
+const resolveTaskCategory = (option: WorkflowCanvasTaskOption): WorkflowTaskCategory => {
+  if (option.typeLabel.includes('质量')) return 'quality';
+  if (option.typeLabel.includes('同步')) return 'sync';
+  if (option.typeLabel.includes('开发')) return 'development';
+
+  const normalized = (option.taskType || option.typeLabel || '').trim().toUpperCase();
 
   if (
     normalized.includes('QUALITY')
@@ -49,6 +53,12 @@ const resolveTaskCategory = (taskType?: string): WorkflowTaskCategory => {
   }
 
   return 'development';
+};
+
+const resolveIconTaskType = (option: WorkflowCanvasTaskOption) => {
+  if (option.taskType) return option.taskType;
+  if (resolveTaskCategory(option) === 'sync') return 'SYNC';
+  return undefined;
 };
 
 const createSearchState = (): Record<WorkflowTaskCategory, string> => ({
@@ -86,7 +96,7 @@ const WorkflowTaskPicker = ({
     };
 
     options.forEach((option) => {
-      grouped[resolveTaskCategory(option.taskType)].push(option);
+      grouped[resolveTaskCategory(option)].push(option);
     });
 
     return grouped;
@@ -156,7 +166,7 @@ const WorkflowTaskPicker = ({
                 handleOpenChange(false);
               }}
             >
-              <WorkflowNodeIcon taskType={option.taskType} size="xs" />
+              <WorkflowNodeIcon taskType={resolveIconTaskType(option)} size="xs" />
               <span className="ml-2 min-w-0 flex-1 truncate text-[13px] font-medium text-[#475467]">
                 {option.label}
               </span>

--- a/yak-ops-ui/src/pages/workflow/definition/canvas/edge/WorkflowEdgeInsert.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/edge/WorkflowEdgeInsert.tsx
@@ -1,6 +1,5 @@
-import { Popover } from 'antd';
 import { Plus } from 'lucide-react';
-import { useMemo } from 'react';
+import WorkflowTaskPicker from '../WorkflowTaskPicker';
 import type { WorkflowEdgeInsertOption } from '../types';
 
 interface WorkflowEdgeInsertProps {
@@ -17,64 +16,28 @@ const WorkflowEdgeInsert = ({
   options,
   onOpenChange,
   onSelect,
-}: WorkflowEdgeInsertProps) => {
-  const content = useMemo(
-    () => (
-      <div className="w-[220px] p-1">
-        <div className="px-2 pb-1.5 pt-1 text-[10px] font-medium text-[rgba(22,24,35,.42)]">
-          插入任务节点
-        </div>
-        <div className="max-h-[260px] space-y-0.5 overflow-y-auto">
-          {options.map((option) => (
-            <button
-              key={option.id}
-              type="button"
-              className="flex w-full items-center gap-2 rounded-md border-0 bg-transparent px-2 py-2 text-left hover:bg-[#f5f5f6]"
-              onClick={() => onSelect(option.id)}
-            >
-              <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-[#f2f4f7] text-[11px] font-semibold text-[#52525b]">
-                {option.typeLabel.slice(0, 1)}
-              </span>
-              <span className="min-w-0 flex-1">
-                <span className="block truncate text-[11px] font-medium text-[#161823]">
-                  {option.label}
-                </span>
-                <span className="mt-0.5 block truncate text-[9px] text-[rgba(22,24,35,.36)]">
-                  {option.typeLabel}
-                </span>
-              </span>
-            </button>
-          ))}
-        </div>
-      </div>
-    ),
-    [onSelect, options],
-  );
-
-  return (
-    <Popover
-      trigger="click"
-      placement="bottom"
-      open={open}
-      onOpenChange={onOpenChange}
-      content={content}
-      overlayInnerStyle={{ padding: 0 }}
+}: WorkflowEdgeInsertProps) => (
+  <WorkflowTaskPicker
+    open={open}
+    onOpenChange={onOpenChange}
+    placement="bottom"
+    options={options}
+    onSelect={onSelect}
+  >
+    <button
+      type="button"
+      aria-label="在连线中插入任务"
+      className={[
+        'nodrag nopan flex h-6 w-6 items-center justify-center rounded-full',
+        'border border-[#dfe1e5] bg-white text-[#667085]',
+        'shadow-[0_1px_4px_rgba(22,24,35,.12)] transition-all duration-150',
+        'hover:scale-125 hover:border-[#fe2c55] hover:text-[#fe2c55]',
+        visible || open ? 'scale-100 opacity-100' : 'scale-90 opacity-0',
+      ].join(' ')}
     >
-      <button
-        type="button"
-        aria-label="在连线中插入任务"
-        className={[
-          'nodrag nopan flex h-6 w-6 items-center justify-center rounded-full',
-          'border border-[#dfe1e5] bg-white text-[#667085]',
-          'shadow-[0_1px_4px_rgba(22,24,35,.12)] transition-all duration-150',
-          'hover:scale-125 hover:border-[#fe2c55] hover:text-[#fe2c55]',
-          visible || open ? 'scale-100 opacity-100' : 'scale-90 opacity-0',
-        ].join(' ')}
-      >
-        <Plus size={12} strokeWidth={2} />
-      </button>
-    </Popover>
-  );
-};
+      <Plus size={12} strokeWidth={2} />
+    </button>
+  </WorkflowTaskPicker>
+);
 
 export default WorkflowEdgeInsert;

--- a/yak-ops-ui/src/pages/workflow/definition/canvas/node/WorkflowNodeAppend.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/node/WorkflowNodeAppend.tsx
@@ -1,6 +1,5 @@
-import { Popover } from 'antd';
 import { Plus } from 'lucide-react';
-import { useMemo } from 'react';
+import WorkflowTaskPicker from '../WorkflowTaskPicker';
 import type { WorkflowCanvasTaskOption } from '../types';
 
 interface WorkflowNodeAppendProps {
@@ -19,67 +18,27 @@ const WorkflowNodeAppend = ({
   options,
   onOpenChange,
   onAppend,
-}: WorkflowNodeAppendProps) => {
-  const content = useMemo(
-    () => (
-      <div className="w-[220px] p-1">
-        <div className="px-2 pb-1.5 pt-1 text-[10px] font-medium text-[rgba(22,24,35,.42)]">
-          添加后续任务
-        </div>
-        <div className="max-h-[260px] space-y-0.5 overflow-y-auto">
-          {options.map((option) => (
-            <button
-              key={option.id}
-              type="button"
-              className="flex w-full items-center gap-2 rounded-md border-0 bg-transparent px-2 py-2 text-left hover:bg-[#f5f5f6]"
-              onClick={() => {
-                onAppend(nodeId, option.id);
-                onOpenChange(false);
-              }}
-            >
-              <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-[#f2f4f7] text-[11px] font-semibold text-[#52525b]">
-                {option.typeLabel.slice(0, 1)}
-              </span>
-              <span className="min-w-0 flex-1">
-                <span className="block truncate text-[11px] font-medium text-[#161823]">
-                  {option.label}
-                </span>
-                <span className="mt-0.5 block truncate text-[9px] text-[rgba(22,24,35,.36)]">
-                  {option.typeLabel}
-                </span>
-              </span>
-            </button>
-          ))}
-        </div>
-      </div>
-    ),
-    [nodeId, onAppend, onOpenChange, options],
-  );
-
-  return (
-    <Popover
-      trigger="click"
-      placement="right"
-      arrow={false}
-      open={open}
-      onOpenChange={onOpenChange}
-      content={content}
-      overlayInnerStyle={{ padding: 0 }}
+}: WorkflowNodeAppendProps) => (
+  <WorkflowTaskPicker
+    open={open}
+    onOpenChange={onOpenChange}
+    placement="rightTop"
+    options={options}
+    onSelect={(taskId) => onAppend(nodeId, taskId)}
+  >
+    <span
+      aria-hidden
+      className={[
+        'nodrag nopan pointer-events-none absolute inset-0 z-20',
+        'flex h-4 w-4 items-center justify-center rounded-full',
+        'bg-[#fe2c55] text-white shadow-[0_1px_3px_rgba(254,44,85,.22)]',
+        'transition-opacity duration-150',
+        selected || open ? 'opacity-100' : 'opacity-0 group-hover:opacity-100',
+      ].join(' ')}
     >
-      <span
-        aria-hidden
-        className={[
-          'nodrag nopan pointer-events-none absolute inset-0 z-20',
-          'flex h-4 w-4 items-center justify-center rounded-full',
-          'bg-[#fe2c55] text-white shadow-[0_1px_3px_rgba(254,44,85,.22)]',
-          'transition-opacity duration-150',
-          selected || open ? 'opacity-100' : 'opacity-0 group-hover:opacity-100',
-        ].join(' ')}
-      >
-        <Plus size={10} strokeWidth={2.4} />
-      </span>
-    </Popover>
-  );
-};
+      <Plus size={10} strokeWidth={2.4} />
+    </span>
+  </WorkflowTaskPicker>
+);
 
 export default WorkflowNodeAppend;

--- a/yak-ops-ui/src/pages/workflow/definition/canvas/node/icons/WorkflowNodeIcon.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/node/icons/WorkflowNodeIcon.tsx
@@ -3,7 +3,7 @@ import SyncNodeIcon from './SyncNodeIcon';
 
 interface WorkflowNodeIconProps {
   taskType?: string;
-  size?: 'sm' | 'md';
+  size?: 'xs' | 'sm' | 'md';
 }
 
 interface NodeIconMeta {
@@ -41,16 +41,27 @@ const WorkflowNodeIcon = ({ taskType, size = 'md' }: WorkflowNodeIconProps) => {
   const meta = NODE_ICON_META[(taskType || '').toUpperCase()] || DEFAULT_ICON_META;
   const Icon = meta.icon;
   const compact = size === 'sm';
+  const tiny = size === 'xs';
 
   return (
     <span
       className={[
         'flex shrink-0 items-center justify-center',
-        compact ? 'h-7 w-7 rounded-[8px]' : 'h-9 w-9 rounded-[10px]',
+        tiny
+          ? 'h-6 w-6 rounded-[7px]'
+          : compact
+            ? 'h-7 w-7 rounded-[8px]'
+            : 'h-9 w-9 rounded-[10px]',
         meta.className,
       ].join(' ')}
     >
-      <Icon className={compact ? 'h-[15px] w-[15px]' : 'h-[19px] w-[19px]'} />
+      <Icon
+        className={tiny
+          ? 'h-[13px] w-[13px]'
+          : compact
+            ? 'h-[15px] w-[15px]'
+            : 'h-[19px] w-[19px]'}
+      />
     </span>
   );
 };

--- a/yak-ops-ui/src/pages/workflow/definition/canvas/start/types.ts
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/start/types.ts
@@ -1,3 +1,5 @@
+import type { WorkflowCanvasTaskOption } from '../types';
+
 export const WORKFLOW_START_NODE_ID = '__yak_workflow_start__';
 export const WORKFLOW_START_META_KEY = '__yak_start__';
 
@@ -30,6 +32,6 @@ export interface WorkflowStartNodeData {
   label: string;
   locked?: boolean;
   inputs: WorkflowStartInputField[];
-  appendOptions?: Array<{ id: string; label: string; typeLabel: string }>;
+  appendOptions?: WorkflowCanvasTaskOption[];
   onAppend?: (nodeId: string, taskId: string) => void;
 }

--- a/yak-ops-ui/src/pages/workflow/definition/canvas/types.ts
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/types.ts
@@ -6,6 +6,7 @@ import type {
 export interface WorkflowCanvasTaskOption {
   id: string;
   label: string;
+  taskType: string;
   typeLabel: string;
 }
 

--- a/yak-ops-ui/src/pages/workflow/definition/canvas/types.ts
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/types.ts
@@ -6,8 +6,8 @@ import type {
 export interface WorkflowCanvasTaskOption {
   id: string;
   label: string;
-  taskType: string;
   typeLabel: string;
+  taskType?: string;
 }
 
 export interface WorkflowNodeData {


### PR DESCRIPTION
## What changed

- Added a shared `WorkflowTaskPicker` modeled after Dify's `BlockSelector` layout.
- Reused the same picker from all three workflow add-entry points:
  - node source-handle `+`
  - edge midpoint insert `+`
  - inspector `下一步 / 添加并行节点`
- Replaced the old duplicated 220px task lists and the inspector AntD `Select` with one consistent popup.
- Added the requested tabs:
  - 数据同步
  - 数据开发
  - 数据质量
- Each tab keeps its own search text and renders a compact Dify-style list.
- Task rows intentionally only show **icon + name**; no task ID, description, or secondary type text.
- Added simple category mapping for future task expansion:
  - SYNC / CDC / replication-like tasks -> 数据同步
  - QUALITY / CHECK / VALIDATE / VERIFY-like tasks -> 数据质量
  - remaining task types -> 数据开发
  Existing legacy `typeLabel` values remain supported.
- Added an extra-small reusable `WorkflowNodeIcon` size for selector rows.
- Kept existing add/insert callbacks, node placement, DAG semantics, retry/history behavior, and Start virtual-root behavior unchanged.

## Dify reference

The implementation follows Dify's shared Block Selector pattern rather than maintaining separate pickers per entry point:

- `web/app/components/workflow/block-selector/index.tsx`
  - shared popover shell and trigger model
- `web/app/components/workflow/block-selector/tabs.tsx`
  - tab header + per-tab search state + search area
- `web/app/components/workflow/block-selector/blocks.tsx`
  - compact 32px-ish icon/title rows
- `web/app/components/workflow/nodes/_base/components/next-step/add.tsx`
  - Next Step reuses BlockSelector
- `web/app/components/workflow/custom-edge.tsx`
  - edge midpoint insertion reuses BlockSelector

Yak Ops intentionally omits Dify's preview-card/description layer for this phase, keeping the requested simple `icon + name` list.

## Scope

- Frontend only.
- No backend/API/schema changes.
- No workflow execution or DAG changes.
- Current backend/editor task availability remains unchanged; tabs without available task types show a compact empty state and are ready for future data-development/data-quality task sources.

## Validation

- Branch is based on the latest `main` and is not behind it.
- Diff is limited to the shared picker plus the three add-entry integrations and picker/icon types.
- Opened as Draft for visual/interaction verification.