### PR TITLE
refactor(workflow): rebuild editor shell around the canvas

### DIFF
--- a/yak-ops-ui/src/pages/workflow/definition/canvas/WorkflowCanvasTools.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/WorkflowCanvasTools.tsx
@@ -1,6 +1,7 @@
 import { Popover, Tooltip } from 'antd';
-import { Hand, History, MousePointer2, Redo2, Undo2, X } from 'lucide-react';
+import { Hand, History, Maximize2, MousePointer2, Redo2, Undo2, X } from 'lucide-react';
 import { useEffect, useState } from 'react';
+import { useReactFlow } from 'reactflow';
 import type { WorkflowCanvasHistoryEntry } from './useWorkflowCanvasHistory';
 
 export type WorkflowCanvasMode = 'pointer' | 'hand';
@@ -49,6 +50,7 @@ const WorkflowCanvasTools = <T,>({
   onClearHistory,
 }: WorkflowCanvasToolsProps<T>) => {
   const [historyOpen, setHistoryOpen] = useState(false);
+  const reactFlow = useReactFlow();
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -94,33 +96,37 @@ const WorkflowCanvasTools = <T,>({
         {historyEntries.length <= 1 ? (
           <div className="py-10 text-center text-[12px] text-[#98a2b3]">暂无变更记录</div>
         ) : (
-          [...historyEntries].map((entry, index) => ({ entry, index })).reverse().map(({ entry, index }) => {
-            const diff = index - currentHistoryIndex;
-            const stepText = diff === 0
-              ? '当前状态'
-              : diff < 0
-                ? `${Math.abs(diff)} 步后退`
-                : `${diff} 步前进`;
-            return (
-              <button
-                key={entry.id}
-                type="button"
-                className={[
-                  'mb-0.5 flex w-full items-center rounded-lg border-0 px-2.5 py-2 text-left transition-colors',
-                  diff === 0 ? 'bg-[#f2f4f7]' : 'bg-transparent hover:bg-[#f7f8fa]',
-                ].join(' ')}
-                onClick={() => {
-                  onJumpToHistory(index);
-                  setHistoryOpen(false);
-                }}
-              >
-                <div className="min-w-0 flex-1">
-                  <div className="truncate text-[12px] font-medium text-[#475467]">{entry.label}</div>
-                  <div className="mt-0.5 text-[10px] text-[#98a2b3]">{stepText}</div>
-                </div>
-              </button>
-            );
-          })
+          [...historyEntries]
+            .map((entry, index) => ({ entry, index }))
+            .reverse()
+            .map(({ entry, index }) => {
+              const diff = index - currentHistoryIndex;
+              const stepText = diff === 0
+                ? '当前状态'
+                : diff < 0
+                  ? `${Math.abs(diff)} 步后退`
+                  : `${diff} 步前进`;
+
+              return (
+                <button
+                  key={entry.id}
+                  type="button"
+                  className={[
+                    'mb-0.5 flex w-full items-center rounded-lg border-0 px-2.5 py-2 text-left transition-colors',
+                    diff === 0 ? 'bg-[#f2f4f7]' : 'bg-transparent hover:bg-[#f7f8fa]',
+                  ].join(' ')}
+                  onClick={() => {
+                    onJumpToHistory(index);
+                    setHistoryOpen(false);
+                  }}
+                >
+                  <div className="min-w-0 flex-1">
+                    <div className="truncate text-[12px] font-medium text-[#475467]">{entry.label}</div>
+                    <div className="mt-0.5 text-[10px] text-[#98a2b3]">{stepText}</div>
+                  </div>
+                </button>
+              );
+            })
         )}
       </div>
 
@@ -148,6 +154,20 @@ const WorkflowCanvasTools = <T,>({
 
   return (
     <>
+      <style>{`
+        .react-flow__controls {
+          display: none !important;
+        }
+        .react-flow__minimap {
+          right: 12px !important;
+          bottom: 12px !important;
+          transition: right 180ms ease;
+        }
+        div:has(> aside) > .react-flow .react-flow__minimap {
+          right: 424px !important;
+        }
+      `}</style>
+
       <div className="pointer-events-auto absolute left-3 top-3 z-10 flex flex-col items-center rounded-lg border border-[#e4e7ec] bg-white p-0.5 shadow-[0_4px_14px_rgba(22,24,35,.08)]">
         <Tooltip title="选择模式（V）" placement="right">
           <button
@@ -160,6 +180,7 @@ const WorkflowCanvasTools = <T,>({
             <MousePointer2 size={16} strokeWidth={1.9} />
           </button>
         </Tooltip>
+
         <Tooltip title="画布拖拽模式（H）" placement="right">
           <button
             type="button"
@@ -169,6 +190,19 @@ const WorkflowCanvasTools = <T,>({
             onClick={() => onModeChange('hand')}
           >
             <Hand size={16} strokeWidth={1.9} />
+          </button>
+        </Tooltip>
+
+        <div className="my-1 h-px w-5 bg-[#eceef1]" />
+
+        <Tooltip title="适应画布" placement="right">
+          <button
+            type="button"
+            aria-label="适应画布"
+            className={iconButtonClass()}
+            onClick={() => void reactFlow.fitView({ padding: 0.18, duration: 250 })}
+          >
+            <Maximize2 size={15} strokeWidth={1.9} />
           </button>
         </Tooltip>
       </div>
@@ -185,6 +219,7 @@ const WorkflowCanvasTools = <T,>({
             <Undo2 size={16} strokeWidth={1.9} />
           </button>
         </Tooltip>
+
         <Tooltip title="重做（Ctrl/Cmd + Shift + Z）">
           <button
             type="button"
@@ -196,7 +231,9 @@ const WorkflowCanvasTools = <T,>({
             <Redo2 size={16} strokeWidth={1.9} />
           </button>
         </Tooltip>
+
         <div className="mx-1 h-4 w-px bg-[#e4e7ec]" />
+
         <Popover
           open={historyOpen}
           onOpenChange={(open) => !locked && setHistoryOpen(open)}

--- a/yak-ops-ui/src/pages/workflow/definition/canvas/WorkflowTaskLibrary.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/WorkflowTaskLibrary.tsx
@@ -1,6 +1,4 @@
 import type { WorkflowTaskDefinition } from '@/services/workflow';
-import { Empty, Spin } from 'antd';
-import { Database } from 'lucide-react';
 import type { DragEvent } from 'react';
 
 interface WorkflowTaskLibraryProps {
@@ -10,40 +8,13 @@ interface WorkflowTaskLibraryProps {
   onDragStart: (event: DragEvent<HTMLDivElement>, task: WorkflowTaskDefinition) => void;
 }
 
-const WorkflowTaskLibrary = ({ tasks, loading, locked, onDragStart }: WorkflowTaskLibraryProps) => (
-  <aside className="w-[250px] shrink-0 border-r border-[#e8e9ec] bg-[#fafafa]">
-    <div className="border-b border-[#e8e9ec] px-4 py-3.5">
-      <div className="text-[14px] font-semibold text-[#161823]">已配置任务</div>
-      <div className="mt-1 text-xs leading-5 text-[rgba(22,24,35,.48)]">拖拽任务到右侧画布进行编排</div>
-    </div>
-    <div className="p-3">
-      <div className="mb-2 flex items-center gap-2 px-1 text-[11px] font-medium text-[rgba(22,24,35,.52)]">
-        <Database size={14} /> 数据同步
-      </div>
-      {loading ? <div className="flex justify-center py-8"><Spin size="small" /></div> : null}
-      {!loading && !tasks.length ? (
-        <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="暂无可用于工作流的同步任务" />
-      ) : null}
-      <div className="space-y-2">
-        {tasks.map((task) => (
-          <div
-            key={task.id}
-            draggable={!locked}
-            onDragStart={(event) => onDragStart(event, task)}
-            className={[
-              'rounded-lg border border-[#e3e5e8] bg-white px-3 py-2.5 transition-all',
-              locked
-                ? 'cursor-not-allowed opacity-60'
-                : 'cursor-grab hover:border-[#cfd2d7] hover:shadow-sm',
-            ].join(' ')}
-          >
-            <div className="truncate text-[13px] font-semibold text-[#161823]">{task.name}</div>
-            <div className="mt-1 truncate text-[10px] text-[rgba(22,24,35,.38)]">ID {task.id}</div>
-          </div>
-        ))}
-      </div>
-    </div>
-  </aside>
-);
+/**
+ * Workflow tasks are now added through the shared Dify-style task picker from
+ * node handles, edge insertion, and the inspector Next Step area. Keeping a
+ * permanent task rail would duplicate those entry points and reduce canvas
+ * space, so the legacy component intentionally renders nothing while its
+ * public contract is kept temporarily for a low-risk editor-shell migration.
+ */
+const WorkflowTaskLibrary = (_props: WorkflowTaskLibraryProps) => null;
 
 export default WorkflowTaskLibrary;

--- a/yak-ops-ui/src/pages/workflow/definition/canvas/WorkflowToolbar.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/WorkflowToolbar.tsx
@@ -1,7 +1,7 @@
 import type { WorkflowFailureStrategy } from '@/services/workflow';
 import type { WorkflowDefinition } from '@/services/workflow/definitions';
 import { history } from '@umijs/max';
-import { Button, Input, InputNumber, Popconfirm, Popover, Select } from 'antd';
+import { Button, Input, InputNumber, Popconfirm, Popover, Select, Tooltip } from 'antd';
 import { ArrowLeft, CloudOff, CloudUpload, RotateCcw, Save, Settings2 } from 'lucide-react';
 import type { ReactNode } from 'react';
 
@@ -39,7 +39,7 @@ interface WorkflowToolbarProps {
 }
 
 const ConfigLabel = ({ children }: { children: ReactNode }) => (
-  <div className="text-[12px] font-medium text-[#161823]">{children}</div>
+  <div className="text-[12px] font-medium text-[#344054]">{children}</div>
 );
 
 const WorkflowToolbar = ({
@@ -62,70 +62,148 @@ const WorkflowToolbar = ({
   onOnline,
   onOffline,
 }: WorkflowToolbarProps) => {
+  const status = definition?.status || 'DRAFT';
   const runtimeConfig = (
-    <div className="w-[360px] space-y-3">
+    <div className="w-[360px] space-y-4 p-0.5">
       <div>
         <ConfigLabel>失败策略</ConfigLabel>
-        <Select className="mt-1 w-full" value={failureStrategy} disabled={locked}
+        <Select
+          className="mt-1.5 w-full"
+          value={failureStrategy}
+          disabled={locked}
           options={WORKFLOW_FAILURE_OPTIONS}
-          onChange={(value) => onFailureStrategyChange(value as WorkflowFailureStrategy)} />
+          onChange={(value) => onFailureStrategyChange(value as WorkflowFailureStrategy)}
+        />
       </div>
+
       <div>
         <ConfigLabel>工作流超时</ConfigLabel>
-        <div className="mt-1 flex items-center gap-2">
-          <InputNumber min={0} value={workflowTimeoutSeconds}
+        <div className="mt-1.5 flex items-center gap-2">
+          <InputNumber
+            min={0}
+            value={workflowTimeoutSeconds}
             onChange={(value) => onWorkflowTimeoutChange(Number(value || 0))}
-            disabled={locked} className="w-[150px]" />
-          <span className="text-[11px] text-[rgba(22,24,35,.44)]">秒，0 表示不限制</span>
+            disabled={locked}
+            className="w-[150px]"
+          />
+          <span className="text-[11px] text-[#98a2b3]">秒，0 表示不限制</span>
         </div>
       </div>
-      <div className="rounded-lg bg-[#f7f8fa] px-3 py-2 text-[10px] leading-5 text-[rgba(22,24,35,.46)]">
-        工作流输入与全局变量已统一移动到画布中的“开始”节点维护。
+
+      <div className="rounded-lg bg-[#f7f8fa] px-3 py-2 text-[11px] leading-5 text-[#667085]">
+        工作流输入和全局变量统一在“开始”节点中维护。
       </div>
+
       <div>
         <ConfigLabel>描述</ConfigLabel>
-        <Input.TextArea rows={3} value={description}
+        <Input.TextArea
+          rows={3}
+          value={description}
           onChange={(event) => onDescriptionChange(event.target.value)}
-          disabled={locked} className="mt-1 !text-[11px]" />
+          disabled={locked}
+          className="mt-1.5 !text-[12px]"
+          placeholder="添加工作流描述..."
+        />
       </div>
     </div>
   );
 
   return (
-    <div className="flex h-12 shrink-0 items-center justify-between border-b border-[#e8e9ec] px-4">
-      <div className="flex min-w-0 items-center gap-2.5">
-        <Button type="text" size="small" icon={<ArrowLeft size={14} />}
-          onClick={() => history.push('/workflow/definitions')}>返回</Button>
-        <div className="h-5 w-px bg-[#ececef]" />
-        <Input value={name} onChange={(event) => onNameChange(event.target.value)}
-          variant="filled" className="w-[240px]" disabled={locked} />
-        <span className={[
-          'rounded-md px-2 py-1 text-[10px] font-medium',
-          definition?.status === 'ONLINE'
-            ? 'bg-[#fff0f3] text-[#d92d50]'
-            : 'bg-[#f2f4f7] text-[#667085]',
-        ].join(' ')}>
-          {STATUS_LABEL[definition?.status || 'DRAFT'] || definition?.status}
+    <header className="grid h-[52px] shrink-0 grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-center border-b border-[#ebecef] bg-white px-3">
+      <div className="flex min-w-0 items-center gap-1.5">
+        <Tooltip title="返回工作流定义">
+          <Button
+            type="text"
+            size="small"
+            aria-label="返回工作流定义"
+            icon={<ArrowLeft size={15} />}
+            onClick={() => history.push('/workflow/definitions')}
+          />
+        </Tooltip>
+
+        <div className="h-4 w-px bg-[#eceef1]" />
+
+        <Input
+          value={name}
+          disabled={locked}
+          variant="borderless"
+          onChange={(event) => onNameChange(event.target.value)}
+          className="max-w-[300px] min-w-[120px] !px-2 !text-[14px] !font-semibold !text-[#161823] transition-colors hover:!bg-[#f7f8fa] focus-within:!bg-[#f7f8fa]"
+        />
+
+        <span
+          className={[
+            'inline-flex h-6 shrink-0 items-center gap-1 rounded-md px-2 text-[10px] font-medium',
+            status === 'ONLINE'
+              ? 'bg-[rgba(254,44,85,.08)] text-[#d92d50]'
+              : 'bg-[#f2f4f7] text-[#667085]',
+          ].join(' ')}
+        >
+          <span
+            className={[
+              'h-1.5 w-1.5 rounded-full',
+              status === 'ONLINE' ? 'bg-[#fe2c55]' : 'bg-[#98a2b3]',
+            ].join(' ')}
+          />
+          {saving ? '保存中' : STATUS_LABEL[status] || status}
         </span>
-        <Popover content={runtimeConfig} title="运行配置" trigger="click">
-          <Button size="small" icon={<Settings2 size={13} />}>运行配置</Button>
-        </Popover>
-        <span className="text-[11px] text-[rgba(22,24,35,.38)]">{nodesCount} 节点 · {edgesCount} 连线</span>
-        {locked ? <span className="text-[10px] text-[rgba(22,24,35,.38)]">已上线，需下线后修改</span> : null}
       </div>
+
       <div className="flex items-center gap-2">
-        <Popconfirm title="清空任务节点？开始节点与全局输入会保留。" disabled={locked} onConfirm={onClear}>
-          <Button icon={<RotateCcw size={14} />} disabled={locked}>清空</Button>
+        <Popover content={runtimeConfig} title="运行配置" trigger="click" placement="bottom">
+          <Button
+            size="small"
+            icon={<Settings2 size={13} />}
+            className="!h-8 !rounded-lg !border-[#e4e7ec] !bg-white !px-3 !text-[12px] !text-[#475467] shadow-none"
+          >
+            运行配置
+          </Button>
+        </Popover>
+
+        <span className="whitespace-nowrap text-[11px] text-[#98a2b3]">
+          {nodesCount} 节点 · {edgesCount} 连线
+        </span>
+
+        {locked ? (
+          <span className="whitespace-nowrap text-[10px] text-[#98a2b3]">已上线，需下线后修改</span>
+        ) : null}
+      </div>
+
+      <div className="flex items-center justify-end gap-1.5">
+        <Popconfirm
+          title="清空任务节点？开始节点与全局输入会保留。"
+          disabled={locked}
+          onConfirm={onClear}
+        >
+          <Button size="small" icon={<RotateCcw size={14} />} disabled={locked}>
+            清空
+          </Button>
         </Popconfirm>
-        {!locked ? <Button icon={<Save size={14} />} loading={saving} onClick={onSave}>保存</Button> : null}
-        {definition?.status === 'ONLINE' ? (
-          <Button icon={<CloudOff size={14} />} loading={statusAction} onClick={onOffline}>下线</Button>
+
+        {!locked ? (
+          <Button size="small" icon={<Save size={14} />} loading={saving} onClick={onSave}>
+            保存
+          </Button>
+        ) : null}
+
+        {status === 'ONLINE' ? (
+          <Button size="small" icon={<CloudOff size={14} />} loading={statusAction} onClick={onOffline}>
+            下线
+          </Button>
         ) : (
-          <Button type="primary" icon={<CloudUpload size={14} />} loading={statusAction || saving}
-            onClick={onOnline}>保存并上线</Button>
+          <Button
+            type="primary"
+            size="small"
+            icon={<CloudUpload size={14} />}
+            loading={statusAction || saving}
+            onClick={onOnline}
+            className="!px-3.5"
+          >
+            保存并上线
+          </Button>
         )}
       </div>
-    </div>
+    </header>
   );
 };
 


### PR DESCRIPTION
## What changed

- Reworked the workflow definition page from a management-page layout into a canvas-first editor shell.
- Retired the permanently visible `已配置任务` rail. Task creation now relies on the existing shared picker entry points, so the canvas receives the full available width.
- Rebuilt `WorkflowToolbar` as a compact 52px editor header with three clear zones:
  - left: back navigation, inline workflow title, workflow status
  - center: runtime configuration and node/edge counts
  - right: clear, save, publish/offline actions
- Made the workflow name visually behave like an editor title instead of a permanently boxed form input.
- Kept runtime policy configuration in the header while Start-node input/global variables remain owned by Start.
- Consolidated canvas controls:
  - Pointer / Hand remain on the floating left toolbar
  - added Fit View to the same toolbar
  - ReactFlow's built-in Controls are hidden to avoid duplicated control systems
- Kept Undo / Redo / Change History centered at the bottom.
- Normalized MiniMap placement to the bottom-right and automatically shifts it left when a right-side inspector is present, so it is not covered by the floating inspector.

## Design direction

This moves Yak Ops closer to a dedicated workflow IDE instead of a workflow feature embedded in a traditional admin page:

- Workflow lifecycle actions live in the top editor header.
- Canvas operations live in the floating left toolbar.
- Edit history remains in the bottom action bar.
- Node configuration stays in the existing floating right inspector.
- Task/node selection remains on-demand through the Dify-style task picker rather than consuming permanent horizontal space.

## Scope

- Frontend presentation/editor-shell only.
- No workflow API/schema changes.
- No DAG or execution behavior changes.
- No changes to Start semantics, node/edge interaction, retry/error settings, task picker, or history snapshots.
- The legacy `WorkflowTaskLibrary` contract is kept temporarily but renders nothing, allowing this shell migration without touching the large editor orchestration file.

## Validation

- Branch is based on the latest `main` and is not behind it.
- Final diff is limited to 3 existing workflow canvas/header components.
- Repository network access is unavailable in the execution container, so a local clone/`tsc` run could not be performed here; the change was kept intentionally type-light and presentation-only.
- Opened as Draft for visual verification on wide and narrow editor widths.