### PR TITLE
refactor(workflow): deepen editor visual hierarchy

### DIFF
--- a/yak-ops-ui/src/pages/workflow/definition/canvas/WorkflowCanvasTools.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/WorkflowCanvasTools.tsx
@@ -1,7 +1,12 @@
 import { Popover, Tooltip } from 'antd';
-import { Hand, History, Maximize2, MousePointer2, Redo2, Undo2, X } from 'lucide-react';
+import { Hand, History, Maximize2, MousePointer2, Plus, Redo2, Undo2, X } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { useReactFlow } from 'reactflow';
+import WorkflowTaskPicker from './WorkflowTaskPicker';
+import {
+  WORKFLOW_START_NODE_ID,
+  type WorkflowStartNodeData,
+} from './start/types';
 import type { WorkflowCanvasHistoryEntry } from './useWorkflowCanvasHistory';
 
 export type WorkflowCanvasMode = 'pointer' | 'hand';
@@ -21,9 +26,9 @@ interface WorkflowCanvasToolsProps<T> {
 }
 
 const iconButtonClass = (active = false) => [
-  'flex h-8 w-8 items-center justify-center rounded-md border-0 transition-colors',
+  'flex h-8 w-8 items-center justify-center rounded-lg border-0 transition-[background-color,color,transform] duration-150',
   active
-    ? 'bg-[rgba(254,44,85,.08)] text-[#fe2c55]'
+    ? 'bg-[rgba(254,44,85,.09)] text-[#fe2c55]'
     : 'bg-transparent text-[#667085] hover:bg-[#f2f4f7] hover:text-[#344054]',
 ].join(' ');
 
@@ -51,6 +56,10 @@ const WorkflowCanvasTools = <T,>({
 }: WorkflowCanvasToolsProps<T>) => {
   const [historyOpen, setHistoryOpen] = useState(false);
   const reactFlow = useReactFlow();
+  const startNode = reactFlow.getNode(WORKFLOW_START_NODE_ID);
+  const startData = startNode?.data as WorkflowStartNodeData | undefined;
+  const appendOptions = startData?.appendOptions || [];
+  const canAddNode = !locked && appendOptions.length > 0 && Boolean(startData?.onAppend);
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -79,7 +88,7 @@ const WorkflowCanvasTools = <T,>({
   }, [locked, onModeChange, onRedo, onUndo]);
 
   const historyContent = (
-    <div className="w-[320px] overflow-hidden rounded-xl border border-[#e4e7ec] bg-white shadow-[0_12px_36px_rgba(22,24,35,.14)]">
+    <div className="w-[320px] overflow-hidden rounded-xl border border-[#e4e7ec] bg-white shadow-[0_10px_30px_rgba(22,24,35,.10),0_2px_6px_rgba(22,24,35,.04)]">
       <div className="flex h-11 items-center justify-between px-3.5">
         <div className="text-[14px] font-medium text-[#344054]">变更历史</div>
         <button
@@ -155,20 +164,60 @@ const WorkflowCanvasTools = <T,>({
   return (
     <>
       <style>{`
+        .react-flow {
+          background: #F5F6F8 !important;
+        }
+        .react-flow__background circle,
+        .react-flow__background-pattern circle {
+          fill: #D5DAE3 !important;
+        }
         .react-flow__controls {
           display: none !important;
         }
         .react-flow__minimap {
-          right: 12px !important;
-          bottom: 12px !important;
-          transition: right 180ms ease;
+          right: 14px !important;
+          bottom: 14px !important;
+          width: 154px !important;
+          height: 96px !important;
+          overflow: hidden !important;
+          border: 1px solid rgba(22, 24, 35, .08) !important;
+          border-radius: 12px !important;
+          background: rgba(255, 255, 255, .88) !important;
+          box-shadow: 0 4px 14px rgba(22, 24, 35, .07), 0 1px 2px rgba(22, 24, 35, .04) !important;
+          opacity: .74;
+          transition: right 180ms ease, opacity 150ms ease, box-shadow 150ms ease;
+        }
+        .react-flow__minimap:hover {
+          opacity: 1;
+          box-shadow: 0 8px 22px rgba(22, 24, 35, .10), 0 2px 4px rgba(22, 24, 35, .04) !important;
         }
         div:has(> aside) > .react-flow .react-flow__minimap {
           right: 424px !important;
         }
+        div:has(> .react-flow) > aside {
+          box-shadow: 0 10px 30px rgba(22, 24, 35, .10), 0 2px 6px rgba(22, 24, 35, .04) !important;
+        }
       `}</style>
 
-      <div className="pointer-events-auto absolute left-3 top-3 z-10 flex flex-col items-center rounded-lg border border-[#e4e7ec] bg-white p-0.5 shadow-[0_4px_14px_rgba(22,24,35,.08)]">
+      <div className="pointer-events-auto absolute left-3.5 top-3.5 z-10 flex flex-col items-center rounded-xl border border-[#e3e6ea] bg-[rgba(255,255,255,.94)] p-1 shadow-[0_4px_14px_rgba(22,24,35,.07),0_1px_2px_rgba(22,24,35,.04)] backdrop-blur-sm">
+        <WorkflowTaskPicker
+          options={appendOptions}
+          disabled={!canAddNode}
+          placement="rightTop"
+          onSelect={(taskId) => startData?.onAppend?.(WORKFLOW_START_NODE_ID, taskId)}
+        >
+          <button
+            type="button"
+            aria-label="添加节点"
+            disabled={!canAddNode}
+            className={`${iconButtonClass()} ${disabledButtonClass} text-[#fe2c55] hover:bg-[rgba(254,44,85,.08)] hover:text-[#fe2c55]`}
+          >
+            <Plus size={17} strokeWidth={2} />
+          </button>
+        </WorkflowTaskPicker>
+
+        <div className="my-1 h-px w-5 bg-[#e8eaee]" />
+
         <Tooltip title="选择模式（V）" placement="right">
           <button
             type="button"
@@ -193,7 +242,7 @@ const WorkflowCanvasTools = <T,>({
           </button>
         </Tooltip>
 
-        <div className="my-1 h-px w-5 bg-[#eceef1]" />
+        <div className="my-1 h-px w-5 bg-[#e8eaee]" />
 
         <Tooltip title="适应画布" placement="right">
           <button
@@ -207,7 +256,7 @@ const WorkflowCanvasTools = <T,>({
         </Tooltip>
       </div>
 
-      <div className="pointer-events-auto absolute bottom-3 left-1/2 z-10 flex -translate-x-1/2 items-center rounded-lg border border-[#e4e7ec] bg-white p-0.5 shadow-[0_4px_14px_rgba(22,24,35,.08)]">
+      <div className="pointer-events-auto absolute bottom-3.5 left-1/2 z-10 flex -translate-x-1/2 items-center rounded-xl border border-[#e3e6ea] bg-[rgba(255,255,255,.94)] p-1 shadow-[0_4px_14px_rgba(22,24,35,.07),0_1px_2px_rgba(22,24,35,.04)] backdrop-blur-sm">
         <Tooltip title="撤销（Ctrl/Cmd + Z）">
           <button
             type="button"

--- a/yak-ops-ui/src/pages/workflow/definition/canvas/WorkflowToolbar.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/WorkflowToolbar.tsx
@@ -63,6 +63,9 @@ const WorkflowToolbar = ({
   onOffline,
 }: WorkflowToolbarProps) => {
   const status = definition?.status || 'DRAFT';
+  const statusLabel = STATUS_LABEL[status] || status;
+  const statusColor = status === 'ONLINE' ? '#fe2c55' : '#98a2b3';
+
   const runtimeConfig = (
     <div className="w-[360px] space-y-4 p-0.5">
       <div>
@@ -109,99 +112,116 @@ const WorkflowToolbar = ({
   );
 
   return (
-    <header className="grid h-[52px] shrink-0 grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-center border-b border-[#ebecef] bg-white px-3">
-      <div className="flex min-w-0 items-center gap-1.5">
+    <header className="flex h-[58px] shrink-0 items-center border-b border-[#e7e9ed] bg-white px-3.5 shadow-[0_1px_0_rgba(22,24,35,.02)]">
+      <div className="flex min-w-0 items-center">
         <Tooltip title="返回工作流定义">
           <Button
             type="text"
             size="small"
             aria-label="返回工作流定义"
             icon={<ArrowLeft size={15} />}
+            className="!h-8 !w-8 !rounded-lg"
             onClick={() => history.push('/workflow/definitions')}
           />
         </Tooltip>
 
-        <div className="h-4 w-px bg-[#eceef1]" />
+        <div className="mx-2 h-6 w-px bg-[#eceef1]" />
 
-        <Input
-          value={name}
-          disabled={locked}
-          variant="borderless"
-          onChange={(event) => onNameChange(event.target.value)}
-          className="max-w-[300px] min-w-[120px] !px-2 !text-[14px] !font-semibold !text-[#161823] transition-colors hover:!bg-[#f7f8fa] focus-within:!bg-[#f7f8fa]"
-        />
-
-        <span
-          className={[
-            'inline-flex h-6 shrink-0 items-center gap-1 rounded-md px-2 text-[10px] font-medium',
-            status === 'ONLINE'
-              ? 'bg-[rgba(254,44,85,.08)] text-[#d92d50]'
-              : 'bg-[#f2f4f7] text-[#667085]',
-          ].join(' ')}
-        >
-          <span
-            className={[
-              'h-1.5 w-1.5 rounded-full',
-              status === 'ONLINE' ? 'bg-[#fe2c55]' : 'bg-[#98a2b3]',
-            ].join(' ')}
+        <div className="min-w-[180px] max-w-[320px]">
+          <Input
+            value={name}
+            disabled={locked}
+            variant="borderless"
+            onChange={(event) => onNameChange(event.target.value)}
+            className="h-7 !px-1.5 !text-[15px] !font-semibold !text-[#161823] transition-colors hover:!bg-[#f7f8fa] focus-within:!bg-[#f7f8fa]"
           />
-          {saving ? '保存中' : STATUS_LABEL[status] || status}
-        </span>
-      </div>
+          <div className="flex h-4 items-center gap-1.5 px-1.5 text-[10px] text-[#98a2b3]">
+            <span className="h-1.5 w-1.5 rounded-full" style={{ backgroundColor: statusColor }} />
+            <span>{statusLabel}</span>
+            <span className="text-[#d0d5dd]">·</span>
+            <span>{saving ? '正在保存...' : locked ? '只读模式' : '可编辑'}</span>
+          </div>
+        </div>
 
-      <div className="flex items-center gap-2">
-        <Popover content={runtimeConfig} title="运行配置" trigger="click" placement="bottom">
-          <Button
-            size="small"
-            icon={<Settings2 size={13} />}
-            className="!h-8 !rounded-lg !border-[#e4e7ec] !bg-white !px-3 !text-[12px] !text-[#475467] shadow-none"
-          >
-            运行配置
-          </Button>
-        </Popover>
+        <div className="ml-4 flex h-9 items-center gap-1 rounded-xl border border-[#e8eaee] bg-[#f8f9fb] p-1 shadow-[0_1px_2px_rgba(22,24,35,.03)]">
+          <Popover content={runtimeConfig} title="运行配置" trigger="click" placement="bottom">
+            <Button
+              type="text"
+              size="small"
+              icon={<Settings2 size={13} />}
+              className="!h-7 !rounded-lg !px-2.5 !text-[12px] !text-[#475467] hover:!bg-white"
+            >
+              运行配置
+            </Button>
+          </Popover>
 
-        <span className="whitespace-nowrap text-[11px] text-[#98a2b3]">
-          {nodesCount} 节点 · {edgesCount} 连线
-        </span>
+          <div className="h-4 w-px bg-[#e4e7ec]" />
+
+          <span className="whitespace-nowrap px-2 text-[11px] text-[#98a2b3]">
+            {nodesCount} 节点 · {edgesCount} 连线
+          </span>
+        </div>
 
         {locked ? (
-          <span className="whitespace-nowrap text-[10px] text-[#98a2b3]">已上线，需下线后修改</span>
+          <span className="ml-2 whitespace-nowrap text-[10px] text-[#98a2b3]">需下线后修改</span>
         ) : null}
       </div>
 
-      <div className="flex items-center justify-end gap-1.5">
+      <div className="flex-1" />
+
+      <div className="flex shrink-0 items-center gap-2">
         <Popconfirm
           title="清空任务节点？开始节点与全局输入会保留。"
           disabled={locked}
           onConfirm={onClear}
         >
-          <Button size="small" icon={<RotateCcw size={14} />} disabled={locked}>
+          <Button
+            size="small"
+            icon={<RotateCcw size={14} />}
+            disabled={locked}
+            className="!h-8 !rounded-lg !border-[#e4e7ec] !px-3"
+          >
             清空
           </Button>
         </Popconfirm>
 
-        {!locked ? (
-          <Button size="small" icon={<Save size={14} />} loading={saving} onClick={onSave}>
-            保存
-          </Button>
-        ) : null}
+        <div className="flex h-10 items-center gap-1 rounded-xl border border-[#e4e7ec] bg-[#f8f9fb] p-1 shadow-[0_4px_14px_rgba(22,24,35,.05),0_1px_2px_rgba(22,24,35,.03)]">
+          {!locked ? (
+            <Button
+              type="text"
+              size="small"
+              icon={<Save size={14} />}
+              loading={saving}
+              onClick={onSave}
+              className="!h-8 !rounded-lg !px-3 !text-[#475467] hover:!bg-white"
+            >
+              保存
+            </Button>
+          ) : null}
 
-        {status === 'ONLINE' ? (
-          <Button size="small" icon={<CloudOff size={14} />} loading={statusAction} onClick={onOffline}>
-            下线
-          </Button>
-        ) : (
-          <Button
-            type="primary"
-            size="small"
-            icon={<CloudUpload size={14} />}
-            loading={statusAction || saving}
-            onClick={onOnline}
-            className="!px-3.5"
-          >
-            保存并上线
-          </Button>
-        )}
+          {status === 'ONLINE' ? (
+            <Button
+              size="small"
+              icon={<CloudOff size={14} />}
+              loading={statusAction}
+              onClick={onOffline}
+              className="!h-8 !rounded-lg !px-3"
+            >
+              下线
+            </Button>
+          ) : (
+            <Button
+              type="primary"
+              size="small"
+              icon={<CloudUpload size={14} />}
+              loading={statusAction || saving}
+              onClick={onOnline}
+              className="!h-8 !rounded-lg !px-3.5"
+            >
+              保存并上线
+            </Button>
+          )}
+        </div>
       </div>
     </header>
   );

--- a/yak-ops-ui/src/pages/workflow/definition/canvas/node/WorkflowNode.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/node/WorkflowNode.tsx
@@ -20,12 +20,12 @@ const WorkflowNode = ({ id, data, selected }: NodeProps<WorkflowNodeData>) => (
     <div
       className={[
         'relative rounded-[15px] border bg-white px-3 py-3',
-        'shadow-[0_1px_2px_rgba(22,24,35,.06)]',
+        'shadow-[0_4px_14px_rgba(22,24,35,.07),0_1px_2px_rgba(22,24,35,.04)]',
         'transition-[border-color,box-shadow] duration-150',
-        'group-hover:shadow-[0_6px_18px_rgba(22,24,35,.10)]',
+        'group-hover:shadow-[0_10px_30px_rgba(22,24,35,.10),0_2px_6px_rgba(22,24,35,.04)]',
         selected
-          ? 'border-[#fe2c55] shadow-[0_0_0_2px_rgba(254,44,85,.06)]'
-          : 'border-[#e8e9ec] group-hover:border-[#d7d9de]',
+          ? 'border-[#fe2c55] shadow-[0_0_0_2px_rgba(254,44,85,.07),0_8px_22px_rgba(22,24,35,.09)]'
+          : 'border-[#e5e8ec] group-hover:border-[#d4d8de]',
       ].join(' ')}
     >
       <div className="flex min-h-9 items-center gap-2.5">

--- a/yak-ops-ui/src/pages/workflow/definition/canvas/start/WorkflowStartNode.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/start/WorkflowStartNode.tsx
@@ -1,5 +1,7 @@
-import { GitBranch, Variable } from 'lucide-react';
+import { GitBranch, Plus, Variable } from 'lucide-react';
 import type { NodeProps } from 'reactflow';
+import { useStore } from 'reactflow';
+import WorkflowTaskPicker from '../WorkflowTaskPicker';
 import WorkflowNodeHandle from '../node/WorkflowNodeHandle';
 import type { WorkflowStartNodeData } from './types';
 
@@ -14,18 +16,23 @@ const TYPE_LABEL: Record<string, string> = {
 const WorkflowStartNode = ({ id, data, selected }: NodeProps<WorkflowStartNodeData>) => {
   const visibleInputs = data.inputs.slice(0, 3);
   const moreCount = Math.max(0, data.inputs.length - visibleInputs.length);
+  const hasNextNode = useStore((state) => state.edges.some((edge) => edge.source === id));
+  const canAddFirstNode = !data.locked
+    && !hasNextNode
+    && Boolean(data.onAppend)
+    && Boolean(data.appendOptions?.length);
 
   return (
     <div className="group relative w-60">
       <div
         className={[
           'relative overflow-hidden rounded-[15px] border bg-white',
-          'shadow-[0_1px_2px_rgba(22,24,35,.06)]',
+          'shadow-[0_4px_14px_rgba(22,24,35,.07),0_1px_2px_rgba(22,24,35,.04)]',
           'transition-[border-color,box-shadow] duration-150',
-          'group-hover:shadow-[0_6px_18px_rgba(22,24,35,.10)]',
+          'group-hover:shadow-[0_10px_30px_rgba(22,24,35,.10),0_2px_6px_rgba(22,24,35,.04)]',
           selected
-            ? 'border-[#fe2c55] shadow-[0_0_0_2px_rgba(254,44,85,.08)]'
-            : 'border-[#e8e9ec] group-hover:border-[#d7d9de]',
+            ? 'border-[#fe2c55] shadow-[0_0_0_2px_rgba(254,44,85,.08),0_8px_22px_rgba(22,24,35,.09)]'
+            : 'border-[#e5e8ec] group-hover:border-[#d4d8de]',
         ].join(' ')}
       >
         <div className="flex min-h-9 items-center gap-2.5 px-3 py-3">
@@ -57,6 +64,26 @@ const WorkflowStartNode = ({ id, data, selected }: NodeProps<WorkflowStartNodeDa
                 <div className="px-1 text-[9px] text-[#98a2b3]">还有 {moreCount} 个输入字段</div>
               ) : null}
             </div>
+          </div>
+        ) : null}
+
+        {canAddFirstNode && data.onAppend ? (
+          <div className="border-t border-[#f0f1f3] bg-[#fafbfc] p-2">
+            <WorkflowTaskPicker
+              options={data.appendOptions || []}
+              placement="rightTop"
+              onSelect={(taskId) => data.onAppend?.(id, taskId)}
+            >
+              <button
+                type="button"
+                className="nodrag nopan flex h-8 w-full items-center justify-center gap-1.5 rounded-lg border border-dashed border-[#d8dce3] bg-white text-[11px] font-medium text-[#667085] transition-colors hover:border-[rgba(254,44,85,.35)] hover:bg-[rgba(254,44,85,.035)] hover:text-[#fe2c55]"
+                onMouseDown={(event) => event.stopPropagation()}
+                onClick={(event) => event.stopPropagation()}
+              >
+                <Plus size={13} strokeWidth={2} />
+                添加第一个节点
+              </button>
+            </WorkflowTaskPicker>
           </div>
         ) : null}
       </div>


### PR DESCRIPTION
## What changed

Polished the canvas-first workflow editor introduced by #272 to add stronger visual hierarchy and reduce the overly bright / empty feeling.

- Updated the canvas surface to a softer `#F5F6F8` and strengthened the dotted grid contrast.
- Reworked the editor header again to feel more like a dedicated IDE header:
  - workflow title + status/editability are grouped as one identity area
  - runtime configuration + node/edge counts live in one compact metadata group
  - save / publish actions are grouped together on the right, inspired by Dify's compact workflow header controls
- Added a dedicated `+` entry at the top of the floating canvas controls.
  - It directly reuses the existing Start node `WorkflowTaskPicker` options and `onAppend` callback.
  - No duplicate add-node or DAG logic was introduced.
- Split the left canvas controls into clear groups with dividers:
  - add node
  - pointer / hand
  - fit view
- Added a Start empty-state CTA when the workflow has no downstream task yet:
  - `+ 添加第一个节点`
  - directly opens the same shared Dify-style task picker
- Reduced and softened the MiniMap:
  - ~154x96
  - translucent white surface
  - weaker border
  - lower default opacity, full opacity on hover
  - still shifts left automatically when the right inspector is open
- Unified editor elevation into two consistent shadow levels:
  - surface level: nodes, canvas controls, bottom history controls, MiniMap
  - panel level: node inspector / start inspector, history popover, hovered/selected nodes

## Design direction

This iteration deliberately does not add more persistent UI. The page stays canvas-first, but restores depth through background contrast, grouped controls, compact editor identity, and consistent elevation rather than bringing the old task sidebar back.

The Dify publish / test toolbar screenshots were used as layout inspiration for compact action grouping, while Yak Ops keeps its existing save / publish lifecycle and theme color.

## Scope

- Frontend presentation only.
- No workflow API/schema changes.
- No DAG/execution changes.
- No retry/error/history model changes.
- No new task-add implementation; all new add entry points reuse the existing `WorkflowTaskPicker` and Start `onAppend` path.
- No changes to the large `WorkflowDefinitionEditor.tsx` orchestration file.

## Validation

- Branch is based on the latest `main` containing merged #272 and is not behind it.
- Final diff is limited to 4 workflow presentation components.
- React Flow in this repository is `11.11.4`; the implementation stays on existing public ReactFlow hooks/instance APIs already compatible with this editor architecture.
- Opened as Draft for visual verification, especially canvas brightness, header density, MiniMap scale, and Start empty-state guidance.