### PR TITLE
refactor(workflow): introduce workspace sidebar and revert visual-depth pass

### DIFF
--- a/yak-ops-ui/src/pages/workflow/definition/canvas/WorkflowCanvasTools.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/WorkflowCanvasTools.tsx
@@ -1,12 +1,7 @@
 import { Popover, Tooltip } from 'antd';
-import { Hand, History, Maximize2, MousePointer2, Plus, Redo2, Undo2, X } from 'lucide-react';
+import { Hand, History, Maximize2, MousePointer2, Redo2, Undo2, X } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { useReactFlow } from 'reactflow';
-import WorkflowTaskPicker from './WorkflowTaskPicker';
-import {
-  WORKFLOW_START_NODE_ID,
-  type WorkflowStartNodeData,
-} from './start/types';
 import type { WorkflowCanvasHistoryEntry } from './useWorkflowCanvasHistory';
 
 export type WorkflowCanvasMode = 'pointer' | 'hand';
@@ -26,9 +21,9 @@ interface WorkflowCanvasToolsProps<T> {
 }
 
 const iconButtonClass = (active = false) => [
-  'flex h-8 w-8 items-center justify-center rounded-lg border-0 transition-[background-color,color,transform] duration-150',
+  'flex h-8 w-8 items-center justify-center rounded-md border-0 transition-colors',
   active
-    ? 'bg-[rgba(254,44,85,.09)] text-[#fe2c55]'
+    ? 'bg-[rgba(254,44,85,.08)] text-[#fe2c55]'
     : 'bg-transparent text-[#667085] hover:bg-[#f2f4f7] hover:text-[#344054]',
 ].join(' ');
 
@@ -56,10 +51,6 @@ const WorkflowCanvasTools = <T,>({
 }: WorkflowCanvasToolsProps<T>) => {
   const [historyOpen, setHistoryOpen] = useState(false);
   const reactFlow = useReactFlow();
-  const startNode = reactFlow.getNode(WORKFLOW_START_NODE_ID);
-  const startData = startNode?.data as WorkflowStartNodeData | undefined;
-  const appendOptions = startData?.appendOptions || [];
-  const canAddNode = !locked && appendOptions.length > 0 && Boolean(startData?.onAppend);
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -88,7 +79,7 @@ const WorkflowCanvasTools = <T,>({
   }, [locked, onModeChange, onRedo, onUndo]);
 
   const historyContent = (
-    <div className="w-[320px] overflow-hidden rounded-xl border border-[#e4e7ec] bg-white shadow-[0_10px_30px_rgba(22,24,35,.10),0_2px_6px_rgba(22,24,35,.04)]">
+    <div className="w-[320px] overflow-hidden rounded-xl border border-[#e4e7ec] bg-white shadow-[0_12px_36px_rgba(22,24,35,.14)]">
       <div className="flex h-11 items-center justify-between px-3.5">
         <div className="text-[14px] font-medium text-[#344054]">变更历史</div>
         <button
@@ -164,60 +155,20 @@ const WorkflowCanvasTools = <T,>({
   return (
     <>
       <style>{`
-        .react-flow {
-          background: #F5F6F8 !important;
-        }
-        .react-flow__background circle,
-        .react-flow__background-pattern circle {
-          fill: #D5DAE3 !important;
-        }
         .react-flow__controls {
           display: none !important;
         }
         .react-flow__minimap {
-          right: 14px !important;
-          bottom: 14px !important;
-          width: 154px !important;
-          height: 96px !important;
-          overflow: hidden !important;
-          border: 1px solid rgba(22, 24, 35, .08) !important;
-          border-radius: 12px !important;
-          background: rgba(255, 255, 255, .88) !important;
-          box-shadow: 0 4px 14px rgba(22, 24, 35, .07), 0 1px 2px rgba(22, 24, 35, .04) !important;
-          opacity: .74;
-          transition: right 180ms ease, opacity 150ms ease, box-shadow 150ms ease;
-        }
-        .react-flow__minimap:hover {
-          opacity: 1;
-          box-shadow: 0 8px 22px rgba(22, 24, 35, .10), 0 2px 4px rgba(22, 24, 35, .04) !important;
+          right: 12px !important;
+          bottom: 12px !important;
+          transition: right 180ms ease;
         }
         div:has(> aside) > .react-flow .react-flow__minimap {
           right: 424px !important;
         }
-        div:has(> .react-flow) > aside {
-          box-shadow: 0 10px 30px rgba(22, 24, 35, .10), 0 2px 6px rgba(22, 24, 35, .04) !important;
-        }
       `}</style>
 
-      <div className="pointer-events-auto absolute left-3.5 top-3.5 z-10 flex flex-col items-center rounded-xl border border-[#e3e6ea] bg-[rgba(255,255,255,.94)] p-1 shadow-[0_4px_14px_rgba(22,24,35,.07),0_1px_2px_rgba(22,24,35,.04)] backdrop-blur-sm">
-        <WorkflowTaskPicker
-          options={appendOptions}
-          disabled={!canAddNode}
-          placement="rightTop"
-          onSelect={(taskId) => startData?.onAppend?.(WORKFLOW_START_NODE_ID, taskId)}
-        >
-          <button
-            type="button"
-            aria-label="添加节点"
-            disabled={!canAddNode}
-            className={`${iconButtonClass()} ${disabledButtonClass} text-[#fe2c55] hover:bg-[rgba(254,44,85,.08)] hover:text-[#fe2c55]`}
-          >
-            <Plus size={17} strokeWidth={2} />
-          </button>
-        </WorkflowTaskPicker>
-
-        <div className="my-1 h-px w-5 bg-[#e8eaee]" />
-
+      <div className="pointer-events-auto absolute left-3 top-3 z-10 flex flex-col items-center rounded-lg border border-[#e4e7ec] bg-white p-0.5 shadow-[0_4px_14px_rgba(22,24,35,.08)]">
         <Tooltip title="选择模式（V）" placement="right">
           <button
             type="button"
@@ -242,7 +193,7 @@ const WorkflowCanvasTools = <T,>({
           </button>
         </Tooltip>
 
-        <div className="my-1 h-px w-5 bg-[#e8eaee]" />
+        <div className="my-1 h-px w-5 bg-[#eceef1]" />
 
         <Tooltip title="适应画布" placement="right">
           <button
@@ -256,7 +207,7 @@ const WorkflowCanvasTools = <T,>({
         </Tooltip>
       </div>
 
-      <div className="pointer-events-auto absolute bottom-3.5 left-1/2 z-10 flex -translate-x-1/2 items-center rounded-xl border border-[#e3e6ea] bg-[rgba(255,255,255,.94)] p-1 shadow-[0_4px_14px_rgba(22,24,35,.07),0_1px_2px_rgba(22,24,35,.04)] backdrop-blur-sm">
+      <div className="pointer-events-auto absolute bottom-3 left-1/2 z-10 flex -translate-x-1/2 items-center rounded-lg border border-[#e4e7ec] bg-white p-0.5 shadow-[0_4px_14px_rgba(22,24,35,.08)]">
         <Tooltip title="撤销（Ctrl/Cmd + Z）">
           <button
             type="button"

--- a/yak-ops-ui/src/pages/workflow/definition/canvas/WorkflowTaskLibrary.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/WorkflowTaskLibrary.tsx
@@ -1,5 +1,22 @@
 import type { WorkflowTaskDefinition } from '@/services/workflow';
-import type { DragEvent } from 'react';
+import {
+  getWorkflowDefinition,
+  type WorkflowDefinition,
+} from '@/services/workflow/definitions';
+import { history, useParams } from '@umijs/max';
+import { Tooltip } from 'antd';
+import {
+  Activity,
+  ChevronLeft,
+  CircleHelp,
+  GitBranch,
+  History as HistoryIcon,
+  Home,
+  ScrollText,
+  Workflow,
+} from 'lucide-react';
+import type { DragEvent, ReactNode } from 'react';
+import { useEffect, useState } from 'react';
 
 interface WorkflowTaskLibraryProps {
   tasks: WorkflowTaskDefinition[];
@@ -8,13 +25,158 @@ interface WorkflowTaskLibraryProps {
   onDragStart: (event: DragEvent<HTMLDivElement>, task: WorkflowTaskDefinition) => void;
 }
 
+interface WorkspaceNavItemProps {
+  icon: ReactNode;
+  label: string;
+  active?: boolean;
+  disabled?: boolean;
+  onClick?: () => void;
+}
+
+const STATUS_LABEL: Record<string, string> = {
+  DRAFT: '草稿',
+  ONLINE: '已上线',
+  OFFLINE: '已下线',
+};
+
+const WorkspaceNavItem = ({
+  icon,
+  label,
+  active = false,
+  disabled = false,
+  onClick,
+}: WorkspaceNavItemProps) => {
+  const button = (
+    <button
+      type="button"
+      disabled={disabled}
+      className={[
+        'flex h-9 w-full items-center gap-2.5 rounded-lg border-0 px-3 text-left text-[13px] font-medium transition-colors',
+        active
+          ? 'bg-[rgba(254,44,85,.07)] text-[#fe2c55]'
+          : disabled
+            ? 'cursor-not-allowed bg-transparent text-[#c0c4cc]'
+            : 'bg-transparent text-[#475467] hover:bg-[#f5f6f7] hover:text-[#161823]',
+      ].join(' ')}
+      onClick={onClick}
+    >
+      <span className="flex h-5 w-5 shrink-0 items-center justify-center">{icon}</span>
+      <span className="truncate">{label}</span>
+    </button>
+  );
+
+  return disabled ? (
+    <Tooltip title="即将支持" placement="right">
+      <span className="block">{button}</span>
+    </Tooltip>
+  ) : button;
+};
+
 /**
- * Workflow tasks are now added through the shared Dify-style task picker from
- * node handles, edge insertion, and the inspector Next Step area. Keeping a
- * permanent task rail would duplicate those entry points and reduce canvas
- * space, so the legacy component intentionally renders nothing while its
- * public contract is kept temporarily for a low-risk editor-shell migration.
+ * The old permanent task library has been replaced by a workflow-scoped
+ * workspace sidebar. Tasks are added on demand through WorkflowTaskPicker,
+ * while this rail owns workflow-level navigation and identity.
+ *
+ * Keep the legacy props temporarily so WorkflowDefinitionEditor does not need
+ * a high-risk orchestration rewrite just for the shell migration.
  */
-const WorkflowTaskLibrary = (_props: WorkflowTaskLibraryProps) => null;
+const WorkflowTaskLibrary = (_props: WorkflowTaskLibraryProps) => {
+  const { id = '' } = useParams<{ id: string }>();
+  const [definition, setDefinition] = useState<WorkflowDefinition>();
+
+  useEffect(() => {
+    let active = true;
+    if (!id) return undefined;
+
+    void getWorkflowDefinition(id)
+      .then((value) => {
+        if (active) setDefinition(value);
+      })
+      .catch(() => {
+        // The editor already owns the primary loading/error state. This
+        // secondary identity request should never block the workspace shell.
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [id]);
+
+  const workflowName = definition?.name || '工作流';
+  const statusLabel = STATUS_LABEL[definition?.status || 'DRAFT'] || definition?.status || '草稿';
+
+  return (
+    <aside className="flex w-[216px] shrink-0 flex-col border-r border-[#e8e9ec] bg-white">
+      <div className="flex h-[52px] shrink-0 items-center gap-1.5 border-b border-[#f0f1f3] px-3">
+        <Tooltip title="返回工作流定义">
+          <button
+            type="button"
+            aria-label="返回工作流定义"
+            className="flex h-7 w-7 items-center justify-center rounded-md border-0 bg-transparent text-[#667085] hover:bg-[#f5f6f7] hover:text-[#161823]"
+            onClick={() => history.push('/workflow/definitions')}
+          >
+            <ChevronLeft size={15} />
+          </button>
+        </Tooltip>
+        <Home size={13} className="text-[#98a2b3]" />
+        <span className="text-[11px] text-[#c0c4cc]">/</span>
+        <span className="truncate text-[12px] font-semibold text-[#344054]">工作流</span>
+      </div>
+
+      <div className="px-3 pb-3 pt-4">
+        <div className="flex items-center gap-2.5 rounded-xl px-1 py-1.5">
+          <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-[rgba(254,44,85,.08)] text-[#fe2c55]">
+            <GitBranch size={19} strokeWidth={2.1} />
+          </span>
+          <div className="min-w-0 flex-1">
+            <div className="truncate text-[13px] font-semibold text-[#161823]">{workflowName}</div>
+            <div className="mt-0.5 flex items-center gap-1.5 text-[10px] text-[#98a2b3]">
+              <span>工作流</span>
+              <span className="text-[#d0d5dd]">·</span>
+              <span>{statusLabel}</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <nav className="flex-1 px-3" aria-label="工作流工作区导航">
+        <div className="space-y-1">
+          <WorkspaceNavItem
+            active
+            label="编排"
+            icon={<Workflow size={16} strokeWidth={1.9} />}
+          />
+          <WorkspaceNavItem
+            label="运行记录"
+            icon={<HistoryIcon size={16} strokeWidth={1.9} />}
+            onClick={() => history.push('/workflow/instances')}
+          />
+          <WorkspaceNavItem
+            disabled
+            label="日志"
+            icon={<ScrollText size={16} strokeWidth={1.9} />}
+          />
+          <WorkspaceNavItem
+            disabled
+            label="监控"
+            icon={<Activity size={16} strokeWidth={1.9} />}
+          />
+        </div>
+      </nav>
+
+      <div className="border-t border-[#f0f1f3] p-3">
+        <Tooltip title="帮助中心即将支持" placement="right">
+          <button
+            type="button"
+            className="flex h-9 w-full cursor-default items-center gap-2.5 rounded-lg border-0 bg-transparent px-3 text-left text-[12px] text-[#98a2b3]"
+          >
+            <CircleHelp size={15} strokeWidth={1.9} />
+            <span>帮助中心</span>
+          </button>
+        </Tooltip>
+      </div>
+    </aside>
+  );
+};
 
 export default WorkflowTaskLibrary;

--- a/yak-ops-ui/src/pages/workflow/definition/canvas/WorkflowToolbar.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/WorkflowToolbar.tsx
@@ -63,9 +63,6 @@ const WorkflowToolbar = ({
   onOffline,
 }: WorkflowToolbarProps) => {
   const status = definition?.status || 'DRAFT';
-  const statusLabel = STATUS_LABEL[status] || status;
-  const statusColor = status === 'ONLINE' ? '#fe2c55' : '#98a2b3';
-
   const runtimeConfig = (
     <div className="w-[360px] space-y-4 p-0.5">
       <div>
@@ -112,116 +109,99 @@ const WorkflowToolbar = ({
   );
 
   return (
-    <header className="flex h-[58px] shrink-0 items-center border-b border-[#e7e9ed] bg-white px-3.5 shadow-[0_1px_0_rgba(22,24,35,.02)]">
-      <div className="flex min-w-0 items-center">
+    <header className="grid h-[52px] shrink-0 grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-center border-b border-[#ebecef] bg-white px-3">
+      <div className="flex min-w-0 items-center gap-1.5">
         <Tooltip title="返回工作流定义">
           <Button
             type="text"
             size="small"
             aria-label="返回工作流定义"
             icon={<ArrowLeft size={15} />}
-            className="!h-8 !w-8 !rounded-lg"
             onClick={() => history.push('/workflow/definitions')}
           />
         </Tooltip>
 
-        <div className="mx-2 h-6 w-px bg-[#eceef1]" />
+        <div className="h-4 w-px bg-[#eceef1]" />
 
-        <div className="min-w-[180px] max-w-[320px]">
-          <Input
-            value={name}
-            disabled={locked}
-            variant="borderless"
-            onChange={(event) => onNameChange(event.target.value)}
-            className="h-7 !px-1.5 !text-[15px] !font-semibold !text-[#161823] transition-colors hover:!bg-[#f7f8fa] focus-within:!bg-[#f7f8fa]"
+        <Input
+          value={name}
+          disabled={locked}
+          variant="borderless"
+          onChange={(event) => onNameChange(event.target.value)}
+          className="max-w-[300px] min-w-[120px] !px-2 !text-[14px] !font-semibold !text-[#161823] transition-colors hover:!bg-[#f7f8fa] focus-within:!bg-[#f7f8fa]"
+        />
+
+        <span
+          className={[
+            'inline-flex h-6 shrink-0 items-center gap-1 rounded-md px-2 text-[10px] font-medium',
+            status === 'ONLINE'
+              ? 'bg-[rgba(254,44,85,.08)] text-[#d92d50]'
+              : 'bg-[#f2f4f7] text-[#667085]',
+          ].join(' ')}
+        >
+          <span
+            className={[
+              'h-1.5 w-1.5 rounded-full',
+              status === 'ONLINE' ? 'bg-[#fe2c55]' : 'bg-[#98a2b3]',
+            ].join(' ')}
           />
-          <div className="flex h-4 items-center gap-1.5 px-1.5 text-[10px] text-[#98a2b3]">
-            <span className="h-1.5 w-1.5 rounded-full" style={{ backgroundColor: statusColor }} />
-            <span>{statusLabel}</span>
-            <span className="text-[#d0d5dd]">·</span>
-            <span>{saving ? '正在保存...' : locked ? '只读模式' : '可编辑'}</span>
-          </div>
-        </div>
+          {saving ? '保存中' : STATUS_LABEL[status] || status}
+        </span>
+      </div>
 
-        <div className="ml-4 flex h-9 items-center gap-1 rounded-xl border border-[#e8eaee] bg-[#f8f9fb] p-1 shadow-[0_1px_2px_rgba(22,24,35,.03)]">
-          <Popover content={runtimeConfig} title="运行配置" trigger="click" placement="bottom">
-            <Button
-              type="text"
-              size="small"
-              icon={<Settings2 size={13} />}
-              className="!h-7 !rounded-lg !px-2.5 !text-[12px] !text-[#475467] hover:!bg-white"
-            >
-              运行配置
-            </Button>
-          </Popover>
+      <div className="flex items-center gap-2">
+        <Popover content={runtimeConfig} title="运行配置" trigger="click" placement="bottom">
+          <Button
+            size="small"
+            icon={<Settings2 size={13} />}
+            className="!h-8 !rounded-lg !border-[#e4e7ec] !bg-white !px-3 !text-[12px] !text-[#475467] shadow-none"
+          >
+            运行配置
+          </Button>
+        </Popover>
 
-          <div className="h-4 w-px bg-[#e4e7ec]" />
-
-          <span className="whitespace-nowrap px-2 text-[11px] text-[#98a2b3]">
-            {nodesCount} 节点 · {edgesCount} 连线
-          </span>
-        </div>
+        <span className="whitespace-nowrap text-[11px] text-[#98a2b3]">
+          {nodesCount} 节点 · {edgesCount} 连线
+        </span>
 
         {locked ? (
-          <span className="ml-2 whitespace-nowrap text-[10px] text-[#98a2b3]">需下线后修改</span>
+          <span className="whitespace-nowrap text-[10px] text-[#98a2b3]">已上线，需下线后修改</span>
         ) : null}
       </div>
 
-      <div className="flex-1" />
-
-      <div className="flex shrink-0 items-center gap-2">
+      <div className="flex items-center justify-end gap-1.5">
         <Popconfirm
           title="清空任务节点？开始节点与全局输入会保留。"
           disabled={locked}
           onConfirm={onClear}
         >
-          <Button
-            size="small"
-            icon={<RotateCcw size={14} />}
-            disabled={locked}
-            className="!h-8 !rounded-lg !border-[#e4e7ec] !px-3"
-          >
+          <Button size="small" icon={<RotateCcw size={14} />} disabled={locked}>
             清空
           </Button>
         </Popconfirm>
 
-        <div className="flex h-10 items-center gap-1 rounded-xl border border-[#e4e7ec] bg-[#f8f9fb] p-1 shadow-[0_4px_14px_rgba(22,24,35,.05),0_1px_2px_rgba(22,24,35,.03)]">
-          {!locked ? (
-            <Button
-              type="text"
-              size="small"
-              icon={<Save size={14} />}
-              loading={saving}
-              onClick={onSave}
-              className="!h-8 !rounded-lg !px-3 !text-[#475467] hover:!bg-white"
-            >
-              保存
-            </Button>
-          ) : null}
+        {!locked ? (
+          <Button size="small" icon={<Save size={14} />} loading={saving} onClick={onSave}>
+            保存
+          </Button>
+        ) : null}
 
-          {status === 'ONLINE' ? (
-            <Button
-              size="small"
-              icon={<CloudOff size={14} />}
-              loading={statusAction}
-              onClick={onOffline}
-              className="!h-8 !rounded-lg !px-3"
-            >
-              下线
-            </Button>
-          ) : (
-            <Button
-              type="primary"
-              size="small"
-              icon={<CloudUpload size={14} />}
-              loading={statusAction || saving}
-              onClick={onOnline}
-              className="!h-8 !rounded-lg !px-3.5"
-            >
-              保存并上线
-            </Button>
-          )}
-        </div>
+        {status === 'ONLINE' ? (
+          <Button size="small" icon={<CloudOff size={14} />} loading={statusAction} onClick={onOffline}>
+            下线
+          </Button>
+        ) : (
+          <Button
+            type="primary"
+            size="small"
+            icon={<CloudUpload size={14} />}
+            loading={statusAction || saving}
+            onClick={onOnline}
+            className="!px-3.5"
+          >
+            保存并上线
+          </Button>
+        )}
       </div>
     </header>
   );

--- a/yak-ops-ui/src/pages/workflow/definition/canvas/node/WorkflowNode.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/node/WorkflowNode.tsx
@@ -20,12 +20,12 @@ const WorkflowNode = ({ id, data, selected }: NodeProps<WorkflowNodeData>) => (
     <div
       className={[
         'relative rounded-[15px] border bg-white px-3 py-3',
-        'shadow-[0_4px_14px_rgba(22,24,35,.07),0_1px_2px_rgba(22,24,35,.04)]',
+        'shadow-[0_1px_2px_rgba(22,24,35,.06)]',
         'transition-[border-color,box-shadow] duration-150',
-        'group-hover:shadow-[0_10px_30px_rgba(22,24,35,.10),0_2px_6px_rgba(22,24,35,.04)]',
+        'group-hover:shadow-[0_6px_18px_rgba(22,24,35,.10)]',
         selected
-          ? 'border-[#fe2c55] shadow-[0_0_0_2px_rgba(254,44,85,.07),0_8px_22px_rgba(22,24,35,.09)]'
-          : 'border-[#e5e8ec] group-hover:border-[#d4d8de]',
+          ? 'border-[#fe2c55] shadow-[0_0_0_2px_rgba(254,44,85,.06)]'
+          : 'border-[#e8e9ec] group-hover:border-[#d7d9de]',
       ].join(' ')}
     >
       <div className="flex min-h-9 items-center gap-2.5">

--- a/yak-ops-ui/src/pages/workflow/definition/canvas/start/WorkflowStartNode.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/start/WorkflowStartNode.tsx
@@ -1,7 +1,5 @@
-import { GitBranch, Plus, Variable } from 'lucide-react';
+import { GitBranch, Variable } from 'lucide-react';
 import type { NodeProps } from 'reactflow';
-import { useStore } from 'reactflow';
-import WorkflowTaskPicker from '../WorkflowTaskPicker';
 import WorkflowNodeHandle from '../node/WorkflowNodeHandle';
 import type { WorkflowStartNodeData } from './types';
 
@@ -16,23 +14,18 @@ const TYPE_LABEL: Record<string, string> = {
 const WorkflowStartNode = ({ id, data, selected }: NodeProps<WorkflowStartNodeData>) => {
   const visibleInputs = data.inputs.slice(0, 3);
   const moreCount = Math.max(0, data.inputs.length - visibleInputs.length);
-  const hasNextNode = useStore((state) => state.edges.some((edge) => edge.source === id));
-  const canAddFirstNode = !data.locked
-    && !hasNextNode
-    && Boolean(data.onAppend)
-    && Boolean(data.appendOptions?.length);
 
   return (
     <div className="group relative w-60">
       <div
         className={[
           'relative overflow-hidden rounded-[15px] border bg-white',
-          'shadow-[0_4px_14px_rgba(22,24,35,.07),0_1px_2px_rgba(22,24,35,.04)]',
+          'shadow-[0_1px_2px_rgba(22,24,35,.06)]',
           'transition-[border-color,box-shadow] duration-150',
-          'group-hover:shadow-[0_10px_30px_rgba(22,24,35,.10),0_2px_6px_rgba(22,24,35,.04)]',
+          'group-hover:shadow-[0_6px_18px_rgba(22,24,35,.10)]',
           selected
-            ? 'border-[#fe2c55] shadow-[0_0_0_2px_rgba(254,44,85,.08),0_8px_22px_rgba(22,24,35,.09)]'
-            : 'border-[#e5e8ec] group-hover:border-[#d4d8de]',
+            ? 'border-[#fe2c55] shadow-[0_0_0_2px_rgba(254,44,85,.08)]'
+            : 'border-[#e8e9ec] group-hover:border-[#d7d9de]',
         ].join(' ')}
       >
         <div className="flex min-h-9 items-center gap-2.5 px-3 py-3">
@@ -64,26 +57,6 @@ const WorkflowStartNode = ({ id, data, selected }: NodeProps<WorkflowStartNodeDa
                 <div className="px-1 text-[9px] text-[#98a2b3]">还有 {moreCount} 个输入字段</div>
               ) : null}
             </div>
-          </div>
-        ) : null}
-
-        {canAddFirstNode && data.onAppend ? (
-          <div className="border-t border-[#f0f1f3] bg-[#fafbfc] p-2">
-            <WorkflowTaskPicker
-              options={data.appendOptions || []}
-              placement="rightTop"
-              onSelect={(taskId) => data.onAppend?.(id, taskId)}
-            >
-              <button
-                type="button"
-                className="nodrag nopan flex h-8 w-full items-center justify-center gap-1.5 rounded-lg border border-dashed border-[#d8dce3] bg-white text-[11px] font-medium text-[#667085] transition-colors hover:border-[rgba(254,44,85,.35)] hover:bg-[rgba(254,44,85,.035)] hover:text-[#fe2c55]"
-                onMouseDown={(event) => event.stopPropagation()}
-                onClick={(event) => event.stopPropagation()}
-              >
-                <Plus size={13} strokeWidth={2} />
-                添加第一个节点
-              </button>
-            </WorkflowTaskPicker>
           </div>
         ) : null}
       </div>


### PR DESCRIPTION
## What changed

This PR changes the workflow editor direction from “make the canvas itself carry more visual weight” to a Dify-style **Workflow Workspace** shell.

### Workspace sidebar

- Replaced the legacy/no-op `WorkflowTaskLibrary` rail with a white workflow-scoped workspace sidebar (~216px).
- Added a compact workflow breadcrumb/header at the top of the sidebar.
- Added current workflow identity:
  - workflow icon
  - workflow name
  - workflow status
- Added workspace navigation:
  - `编排` — current active editor
  - `运行记录` — opens the existing `/workflow/instances` page
  - `日志` — reserved/disabled for now
  - `监控` — reserved/disabled for now
- Added a lightweight help-center footer placeholder.
- The active item uses Yak Ops brand-red soft background/text instead of Dify blue.

The goal is to give the workflow editor its own product/workspace frame, instead of leaving the canvas visually attached directly to the global Yak Ops navigation.

### Revert #273 visual experiment

The previous visual-depth pass (#273) was intentionally rolled back in this PR because the new workspace sidebar solves the “too empty / too bright” problem at the information-architecture level instead of adding more UI inside the canvas.

Specifically restored the #272 versions of:

- `WorkflowToolbar`
- `WorkflowCanvasTools`
- `WorkflowNode`
- `WorkflowStartNode`

This removes the #273-only changes including:

- Start-node `+ 添加第一个节点` empty-state CTA
- extra add-node button in the canvas control rail
- MiniMap translucency/size experiment
- second header visual-density pass
- stronger node/control elevation changes

## Design direction

The editor hierarchy is now:

`Yak Ops global navigation -> Workflow Workspace sidebar -> Editor header/canvas -> floating node inspector`

The sidebar owns workflow-level identity/navigation, while task creation still stays on-demand through the existing Dify-style `WorkflowTaskPicker` entry points on node handles, edges, and Next Step.

## Scope

- Frontend shell/presentation only.
- No workflow API/schema changes.
- No DAG/execution behavior changes.
- No changes to Start virtual-root semantics, retry/error handling, history model, or TaskPicker behavior.
- The large `WorkflowDefinitionEditor.tsx` orchestration file is intentionally untouched; the existing task-library slot is reused for a low-risk workspace-shell migration.

## Validation

- Branch starts from the latest `main` containing merged #273.
- The four #273 presentation files are restored exactly to their #272 state.
- Final diff is limited to those reversions plus the new workspace sidebar implementation.
- Opened as Draft for visual verification of sidebar width, identity density, active state, and overall editor balance.