### PR TITLE
fix(workflow): refine default canvas layout

### DIFF
--- a/yak-ops-ui/src/pages/workflow/definition/canvas/WorkflowCanvasTools.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/WorkflowCanvasTools.tsx
@@ -53,6 +53,13 @@ const WorkflowCanvasTools = <T,>({
   const reactFlow = useReactFlow();
 
   useEffect(() => {
+    const frame = window.requestAnimationFrame(() => {
+      void reactFlow.fitView({ padding: 0.18, maxZoom: 1, duration: 0 });
+    });
+    return () => window.cancelAnimationFrame(frame);
+  }, [reactFlow]);
+
+  useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
       if (locked || isEditableTarget(event.target)) return;
 
@@ -168,7 +175,7 @@ const WorkflowCanvasTools = <T,>({
         }
       `}</style>
 
-      <div className="pointer-events-auto absolute left-3 top-3 z-10 flex flex-col items-center rounded-lg border border-[#e4e7ec] bg-white p-0.5 shadow-[0_4px_14px_rgba(22,24,35,.08)]">
+      <div className="pointer-events-auto absolute left-3 top-1/2 z-10 flex -translate-y-1/2 flex-col items-center rounded-lg border border-[#e4e7ec] bg-white p-0.5 shadow-[0_4px_14px_rgba(22,24,35,.08)]">
         <Tooltip title="选择模式（V）" placement="right">
           <button
             type="button"
@@ -200,14 +207,14 @@ const WorkflowCanvasTools = <T,>({
             type="button"
             aria-label="适应画布"
             className={iconButtonClass()}
-            onClick={() => void reactFlow.fitView({ padding: 0.18, duration: 250 })}
+            onClick={() => void reactFlow.fitView({ padding: 0.18, maxZoom: 1, duration: 250 })}
           >
             <Maximize2 size={15} strokeWidth={1.9} />
           </button>
         </Tooltip>
       </div>
 
-      <div className="pointer-events-auto absolute bottom-3 left-1/2 z-10 flex -translate-x-1/2 items-center rounded-lg border border-[#e4e7ec] bg-white p-0.5 shadow-[0_4px_14px_rgba(22,24,35,.08)]">
+      <div className="pointer-events-auto absolute bottom-2 left-1/2 z-10 flex -translate-x-1/2 items-center rounded-lg border border-[#e4e7ec] bg-white p-0.5 shadow-[0_4px_14px_rgba(22,24,35,.08)]">
         <Tooltip title="撤销（Ctrl/Cmd + Z）">
           <button
             type="button"


### PR DESCRIPTION
## What changed

Refined the default workflow canvas layout based on the latest Workspace Sidebar design review.

- Vertically centered the floating canvas control rail instead of pinning it to the top-left.
- Prevented a single Start node from being over-enlarged by ReactFlow `fitView` on initial load.
  - the editor now performs a post-mount `fitView` with `maxZoom: 1`
  - manual “适应画布” uses the same `maxZoom: 1` constraint
- Moved Undo / Redo / Change History closer to the bottom edge (`bottom-2`).

## Why

With only the virtual Start node on a new workflow, ReactFlow's automatic fit behavior could zoom it far beyond its normal CSS size, making the empty workflow feel visually oversized. Limiting fit-view zoom keeps node sizing consistent without changing the actual Start/Task node dimensions.

## Scope

- One presentation component only: `WorkflowCanvasTools.tsx`.
- No workflow schema/API changes.
- No DAG or node semantics changes.
- No changes to Workspace Sidebar, Header, Inspector, TaskPicker, Retry, or History data model.

## Validation

- Branch is based on the latest `main` containing merged #274 and is not behind it.
- Final diff: 1 file, 10 additions, 3 deletions.
- Opened as Draft for visual verification of control positioning and initial canvas zoom.