### PR TITLE
fix(workflow): reduce initial canvas zoom

### DIFF
--- a/yak-ops-ui/src/pages/workflow/definition/canvas/WorkflowCanvasTools.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/WorkflowCanvasTools.tsx
@@ -10,8 +10,8 @@ import {
   Undo2,
   X,
 } from 'lucide-react';
-import { useEffect, useState } from 'react';
-import { useReactFlow } from 'reactflow';
+import { useEffect, useRef, useState } from 'react';
+import { useNodesInitialized, useReactFlow } from 'reactflow';
 import WorkflowTaskPicker from './WorkflowTaskPicker';
 import type { WorkflowCanvasTaskOption } from './types';
 import type { WorkflowCanvasHistoryEntry } from './useWorkflowCanvasHistory';
@@ -69,13 +69,18 @@ const WorkflowCanvasTools = <T,>({
 }: WorkflowCanvasToolsProps<T>) => {
   const [historyOpen, setHistoryOpen] = useState(false);
   const reactFlow = useReactFlow();
+  const nodesInitialized = useNodesInitialized();
+  const initialFitDoneRef = useRef(false);
 
   useEffect(() => {
+    if (!nodesInitialized || initialFitDoneRef.current) return;
+    initialFitDoneRef.current = true;
+
     const frame = window.requestAnimationFrame(() => {
-      void reactFlow.fitView({ padding: 0.18, maxZoom: 1, duration: 0 });
+      void reactFlow.fitView({ padding: 0.18, maxZoom: 0.9, duration: 0 });
     });
     return () => window.cancelAnimationFrame(frame);
-  }, [reactFlow]);
+  }, [nodesInitialized, reactFlow]);
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {


### PR DESCRIPTION
## What changed

Fixes the workflow editor opening with a single/few nodes visually zoomed in too far.

### Root cause

`WorkflowCanvasTools` previously called `fitView()` immediately after mount. At that point ReactFlow could still be measuring node dimensions, so the guarded `maxZoom` could run too early and the later viewport calculation could leave a single Start node looking close to 2x scale.

### Fix

- Wait for ReactFlow `useNodesInitialized()` before performing the initial fit.
- Run the guarded initial fit only once per editor mount.
- Cap initial zoom at `0.9` for a calmer default canvas density.
- Keep the manual “适应画布” action unchanged at `maxZoom: 1`.
- Do not change the physical size of Start/task/note nodes.

## Scope

Only `WorkflowCanvasTools.tsx` changes.

No DAG, node data, Start semantics, Note editor, task picker, history, workspace sidebar, or backend changes.

Opened as Draft for visual verification against the supplied first-entry recording.