### PR TITLE
fix(workflow): remove automatic start connections

### DIFF
--- a/yak-ops-ui/src/pages/workflow/definition/canvas/edge/WorkflowEdge.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/edge/WorkflowEdge.tsx
@@ -7,6 +7,7 @@ import {
   type EdgeProps,
 } from 'reactflow';
 import { WORKFLOW_EDGE_HANDLE_OVERLAP } from '../constants';
+import { WORKFLOW_START_NODE_ID } from '../start/types';
 import type { WorkflowEdgeData } from '../types';
 import WorkflowEdgeInsert from './WorkflowEdgeInsert';
 
@@ -52,6 +53,10 @@ const WorkflowEdge = ({
     data?.onInsert?.(id, source, target, taskId);
     setInsertOpen(false);
   }, [data, id, source, target]);
+
+  // Start is a virtual context node. Root tasks should not be visually auto-connected
+  // just because they have no predecessor; users explicitly decide workflow wiring.
+  if (source === WORKFLOW_START_NODE_ID) return null;
 
   return (
     <>


### PR DESCRIPTION
Removes the automatic visual Start → root-node connections from the workflow canvas.

After the Dify-style candidate placement change, nodes added from the left toolbar are free-positioned and should remain visually unconnected until the user explicitly wires the workflow.

This change only suppresses synthetic edges whose source is the virtual Start node. Task-to-task edges, manual wiring, edge insertion, DAG persistence, candidate placement, and execution data are unchanged.

Scope: one file (`WorkflowEdge.tsx`), 5 added lines.