### PR TITLE
fix(workflow): restore manual start node connections

### DIFF
--- a/yak-ops-ui/src/pages/workflow/definition/canvas/edge/WorkflowEdge.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/edge/WorkflowEdge.tsx
@@ -7,7 +7,6 @@ import {
   type EdgeProps,
 } from 'reactflow';
 import { WORKFLOW_EDGE_HANDLE_OVERLAP } from '../constants';
-import { WORKFLOW_START_NODE_ID } from '../start/types';
 import type { WorkflowEdgeData } from '../types';
 import WorkflowEdgeInsert from './WorkflowEdgeInsert';
 
@@ -53,10 +52,6 @@ const WorkflowEdge = ({
     data?.onInsert?.(id, source, target, taskId);
     setInsertOpen(false);
   }, [data, id, source, target]);
-
-  // Start is a virtual context node. Root tasks should not be visually auto-connected
-  // just because they have no predecessor; users explicitly decide workflow wiring.
-  if (source === WORKFLOW_START_NODE_ID) return null;
 
   return (
     <>

--- a/yak-ops-ui/src/pages/workflow/definition/canvas/edge/WorkflowEdge.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/edge/WorkflowEdge.tsx
@@ -7,6 +7,8 @@ import {
   type EdgeProps,
 } from 'reactflow';
 import { WORKFLOW_EDGE_HANDLE_OVERLAP } from '../constants';
+import { useWorkflowStartConnections } from '../start/connections';
+import { WORKFLOW_START_NODE_ID } from '../start/types';
 import type { WorkflowEdgeData } from '../types';
 import WorkflowEdgeInsert from './WorkflowEdgeInsert';
 
@@ -23,6 +25,9 @@ const WorkflowEdge = ({
 }: EdgeProps<WorkflowEdgeData>) => {
   const [hovered, setHovered] = useState(false);
   const [insertOpen, setInsertOpen] = useState(false);
+  const startConnections = useWorkflowStartConnections();
+  const isStartEdge = source === WORKFLOW_START_NODE_ID;
+  const startEdgeVisible = !isStartEdge || startConnections.includes(target);
 
   const [edgePath, labelX, labelY] = useMemo(
     () => getBezierPath({
@@ -45,13 +50,15 @@ const WorkflowEdge = ({
       ? '#8a8f99'
       : '#cfd2d7';
   const insertOptions = data?.insertOptions || [];
-  const canInsert = !data?.locked && insertOptions.length > 0 && Boolean(data?.onInsert);
+  const canInsert = !isStartEdge && !data?.locked && insertOptions.length > 0 && Boolean(data?.onInsert);
   const insertVisible = canInsert && (hovered || selected || insertOpen);
 
   const handleSelect = useCallback((taskId: string) => {
     data?.onInsert?.(id, source, target, taskId);
     setInsertOpen(false);
   }, [data, id, source, target]);
+
+  if (!startEdgeVisible) return null;
 
   return (
     <>

--- a/yak-ops-ui/src/pages/workflow/definition/canvas/node/WorkflowNodeHandle.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/node/WorkflowNodeHandle.tsx
@@ -1,10 +1,16 @@
 import type { CSSProperties, MouseEvent } from 'react';
 import { useEffect, useState } from 'react';
-import { Handle, Position } from 'reactflow';
+import { Handle, Position, useReactFlow, type Connection } from 'reactflow';
 import {
   WORKFLOW_HANDLE_OFFSET,
   WORKFLOW_HANDLE_TOP,
 } from '../constants';
+import {
+  addWorkflowStartConnection,
+  hasWorkflowStartConnection,
+  removeWorkflowStartConnection,
+} from '../start/connections';
+import { WORKFLOW_START_NODE_ID } from '../start/types';
 import type { WorkflowCanvasTaskOption } from '../types';
 import WorkflowNodeAppend from './WorkflowNodeAppend';
 
@@ -32,6 +38,7 @@ const WorkflowNodeHandle = ({
   const isTarget = type === 'target';
   const canAppend = !isTarget && !locked && appendOptions.length > 0 && Boolean(onAppend);
   const [appendOpen, setAppendOpen] = useState(false);
+  const reactFlow = useReactFlow();
 
   useEffect(() => {
     if (!canAppend && appendOpen) setAppendOpen(false);
@@ -41,6 +48,22 @@ const WorkflowNodeHandle = ({
     if (!canAppend) return;
     event.stopPropagation();
     setAppendOpen((current) => !current);
+  };
+
+  const handleConnect = (connection: Connection) => {
+    if (locked || isTarget || !connection.target) return;
+
+    const hasTaskPredecessor = reactFlow.getEdges().some((edge) =>
+      edge.target === connection.target && edge.source !== WORKFLOW_START_NODE_ID);
+
+    if (nodeId === WORKFLOW_START_NODE_ID) {
+      if (!hasTaskPredecessor) addWorkflowStartConnection(connection.target);
+      return;
+    }
+
+    if (hasWorkflowStartConnection(connection.target)) {
+      removeWorkflowStartConnection(connection.target);
+    }
   };
 
   return (
@@ -54,6 +77,7 @@ const WorkflowNodeHandle = ({
           : { right: WORKFLOW_HANDLE_OFFSET }),
       }}
       isConnectable={!locked}
+      onConnect={handleConnect}
       onClick={handleClick}
       className={[
         'group/handle !h-4 !w-4 !translate-y-0 !rounded-none !border-0 !bg-transparent !outline-none',

--- a/yak-ops-ui/src/pages/workflow/definition/canvas/start/connections.ts
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/start/connections.ts
@@ -1,0 +1,38 @@
+import { useSyncExternalStore } from 'react';
+
+let connectionIds = new Set<string>();
+let snapshot: string[] = [];
+const listeners = new Set<() => void>();
+
+const emit = () => {
+  snapshot = [...connectionIds];
+  listeners.forEach((listener) => listener());
+};
+
+const subscribe = (listener: () => void) => {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+};
+
+export const getWorkflowStartConnections = () => snapshot;
+
+export const hasWorkflowStartConnection = (nodeId: string) => connectionIds.has(nodeId);
+
+export const replaceWorkflowStartConnections = (nodeIds: string[]) => {
+  connectionIds = new Set(nodeIds.filter(Boolean));
+  emit();
+};
+
+export const addWorkflowStartConnection = (nodeId: string) => {
+  if (!nodeId || connectionIds.has(nodeId)) return;
+  connectionIds.add(nodeId);
+  emit();
+};
+
+export const removeWorkflowStartConnection = (nodeId: string) => {
+  if (!connectionIds.delete(nodeId)) return;
+  emit();
+};
+
+export const useWorkflowStartConnections = () =>
+  useSyncExternalStore(subscribe, getWorkflowStartConnections, getWorkflowStartConnections);

--- a/yak-ops-ui/src/pages/workflow/definition/canvas/start/context.ts
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/start/context.ts
@@ -1,5 +1,9 @@
 import { WORKFLOW_EDITOR_META_KEY } from '../note/types';
 import {
+  getWorkflowStartConnections,
+  replaceWorkflowStartConnections,
+} from './connections';
+import {
   WORKFLOW_START_META_KEY,
   type WorkflowStartConfig,
   type WorkflowStartInputField,
@@ -85,13 +89,16 @@ export const hydrateWorkflowStartConfig = (
     }));
   }
 
+  const nextNodeIds = Array.isArray(meta?.nextNodeIds)
+    ? [...new Set(meta.nextNodeIds.filter((nodeId): nodeId is string => typeof nodeId === 'string' && Boolean(nodeId)))]
+    : [];
+  replaceWorkflowStartConnections(nextNodeIds);
+
   return {
     position: normalizePosition(meta?.position),
     inputs,
     variables,
-    nextNodeIds: Array.isArray(meta?.nextNodeIds)
-      ? [...new Set(meta.nextNodeIds.filter((nodeId): nodeId is string => typeof nodeId === 'string' && Boolean(nodeId)))]
-      : [],
+    nextNodeIds,
   };
 };
 
@@ -134,6 +141,6 @@ export const serializeWorkflowStartContext = (
     position: config.position,
     inputFields: config.inputs.map(({ defaultValue: _defaultValue, ...field }) => field),
     variables: config.variables.map(({ value: _value, ...variable }) => variable),
-    nextNodeIds: [...new Set(config.nextNodeIds)],
+    nextNodeIds: getWorkflowStartConnections(),
   } satisfies StartMeta,
 });

--- a/yak-ops-ui/src/pages/workflow/definition/canvas/start/context.ts
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/start/context.ts
@@ -7,11 +7,12 @@ import {
   type WorkflowStartVariable,
 } from './types';
 
-interface StartMetaV1 {
-  version: 1;
+interface StartMeta {
+  version?: 1 | 2;
   position?: { x?: number; y?: number };
   inputFields?: Array<Omit<WorkflowStartInputField, 'defaultValue'>>;
   variables?: Array<Omit<WorkflowStartVariable, 'value'>>;
+  nextNodeIds?: string[];
 }
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
@@ -37,7 +38,7 @@ export const hydrateWorkflowStartConfig = (
 ): WorkflowStartConfig => {
   const input = rawInput || {};
   const meta = isRecord(input[WORKFLOW_START_META_KEY])
-    ? (input[WORKFLOW_START_META_KEY] as StartMetaV1)
+    ? (input[WORKFLOW_START_META_KEY] as StartMeta)
     : undefined;
   const inputValues = isRecord(input.inputs) ? input.inputs : undefined;
   const variableValues = isRecord(input.vars) ? input.vars : {};
@@ -88,6 +89,9 @@ export const hydrateWorkflowStartConfig = (
     position: normalizePosition(meta?.position),
     inputs,
     variables,
+    nextNodeIds: Array.isArray(meta?.nextNodeIds)
+      ? [...new Set(meta.nextNodeIds.filter((nodeId): nodeId is string => typeof nodeId === 'string' && Boolean(nodeId)))]
+      : [],
   };
 };
 
@@ -126,9 +130,10 @@ export const serializeWorkflowStartContext = (
   ),
   ...editorMeta,
   [WORKFLOW_START_META_KEY]: {
-    version: 1,
+    version: 2,
     position: config.position,
     inputFields: config.inputs.map(({ defaultValue: _defaultValue, ...field }) => field),
     variables: config.variables.map(({ value: _value, ...variable }) => variable),
-  } satisfies StartMetaV1,
+    nextNodeIds: [...new Set(config.nextNodeIds)],
+  } satisfies StartMeta,
 });

--- a/yak-ops-ui/src/pages/workflow/definition/canvas/start/types.ts
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/start/types.ts
@@ -26,7 +26,7 @@ export interface WorkflowStartConfig {
   position: { x: number; y: number };
   inputs: WorkflowStartInputField[];
   variables: WorkflowStartVariable[];
-  nextNodeIds: string[];
+  nextNodeIds?: string[];
 }
 
 export interface WorkflowStartNodeData {

--- a/yak-ops-ui/src/pages/workflow/definition/canvas/start/types.ts
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/start/types.ts
@@ -26,6 +26,7 @@ export interface WorkflowStartConfig {
   position: { x: number; y: number };
   inputs: WorkflowStartInputField[];
   variables: WorkflowStartVariable[];
+  nextNodeIds: string[];
 }
 
 export interface WorkflowStartNodeData {


### PR DESCRIPTION
## What changed

Restores explicit Start → task connections after automatic root-node wiring was removed.

### Behavior

- Free-positioned nodes added from the canvas toolbar remain unconnected by default.
- Dragging from the Start node handle to a root task now creates a real explicit Start connection in the editor.
- Only explicitly connected Start edges are rendered; root nodes are no longer auto-wired.
- Explicit Start targets are persisted in `WorkflowDefinition.input.__yak_start__.nextNodeIds` and restored after save/reload.
- If a normal task-to-task connection is later created into the same target, the Start connection is removed so the target keeps a single predecessor semantic.
- Start remains a virtual editor node and is still excluded from the backend task DAG.

## Scope

Changes are limited to the Start connection metadata/store, node handle connection capture, and Start-edge rendering. No backend schema or worker execution changes.

Opened as Draft for interaction verification.