### PR TITLE
fix(workflow): align Start and pause execution semantics

### DIFF
--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowDefinitionService.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowDefinitionService.java
@@ -238,10 +238,15 @@ public class WorkflowDefinitionService {
     if (visited != nodeIds.size()) {
       throw new IllegalStateException("工作流存在循环依赖，不能上线");
     }
+
+    // Start is editor-only, but its explicit connections define which roots enter the runtime DAG.
+    WorkflowStartGraphCompiler.compile(state.nodes, state.edges, state.input);
   }
 
   private WorkflowRunRequest toRunRequest(DefinitionState state) {
-    List<WorkflowRunRequest.NodeRequest> nodes = state.nodes.stream()
+    WorkflowStartGraphCompiler.RuntimeGraph runtimeGraph =
+        WorkflowStartGraphCompiler.compile(state.nodes, state.edges, state.input);
+    List<WorkflowRunRequest.NodeRequest> nodes = runtimeGraph.nodes().stream()
         .map(node -> new WorkflowRunRequest.NodeRequest(
             node.id(),
             node.taskId(),
@@ -253,7 +258,7 @@ public class WorkflowDefinitionService {
             node.triggerRule(),
             node.failurePolicy()))
         .toList();
-    List<WorkflowRunRequest.EdgeRequest> edges = state.edges.stream()
+    List<WorkflowRunRequest.EdgeRequest> edges = runtimeGraph.edges().stream()
         .map(edge -> new WorkflowRunRequest.EdgeRequest(edge.source(), edge.target()))
         .toList();
     return new WorkflowRunRequest(

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowRuntimeService.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowRuntimeService.java
@@ -714,20 +714,13 @@ public class WorkflowRuntimeService {
 
     @Override
     public NodeControlResult pause(NodePauseRequest request) {
-      NodeTaskControl control = taskControls.get(request.attemptId());
-      if (control == null) {
-        return NodeControlResult.UNSUPPORTED;
-      }
-      boolean notStarted = control.requestPause(request);
-      if (notStarted) {
-        runtimeScheduler.execute(() -> {
-          NodePauseRequest pending = control.claimPauseAcknowledgement();
-          if (pending != null) {
-            acknowledgePaused(pending);
-          }
-        });
-      }
-      return NodeControlResult.ACCEPTED;
+      // Link-Up/SyncTaskRunner has no physical pause API. Reporting UNSUPPORTED lets the engine
+      // pause scheduling safely: the active sync task keeps running, no downstream node is
+      // dispatched, and the workflow reaches PAUSED only after the active task finishes.
+      log.debug(
+          "[workflow] sync task pause unsupported; pausing scheduling only execution={}, node={}, attempt={}",
+          request.workflowExecutionId(), request.nodeId(), request.attemptId());
+      return NodeControlResult.UNSUPPORTED;
     }
 
     @Override

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowStartGraphCompiler.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowStartGraphCompiler.java
@@ -78,6 +78,15 @@ final class WorkflowStartGraphCompiler {
       }
     }
 
+    if (selection.explicit()) {
+      for (EdgeRequest edge : edges) {
+        if (reachable.contains(edge.target()) && !reachable.contains(edge.source())) {
+          throw new IllegalStateException(
+              "开始节点未接入完整前置分支：" + edge.source() + " -> " + edge.target());
+        }
+      }
+    }
+
     List<NodeRequest> runtimeNodes = nodes.stream()
         .filter(node -> reachable.contains(node.id()))
         .toList();

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowStartGraphCompiler.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowStartGraphCompiler.java
@@ -1,0 +1,127 @@
+package io.yak.ops.business.workflow.service;
+
+import io.yak.ops.business.workflow.model.WorkflowDefinitionUpdateRequest.EdgeRequest;
+import io.yak.ops.business.workflow.model.WorkflowDefinitionUpdateRequest.NodeRequest;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/** Compiles the editor-only Start connections into the executable task DAG. */
+final class WorkflowStartGraphCompiler {
+
+  private static final String START_META_KEY = "__yak_start__";
+  private static final String NEXT_NODE_IDS_KEY = "nextNodeIds";
+
+  private WorkflowStartGraphCompiler() {}
+
+  static RuntimeGraph compile(
+      List<NodeRequest> nodes,
+      List<EdgeRequest> edges,
+      Map<String, Object> input) {
+    Map<String, NodeRequest> nodesById = new LinkedHashMap<>();
+    for (NodeRequest node : nodes) {
+      nodesById.put(node.id(), node);
+    }
+
+    Map<String, List<String>> adjacency = new LinkedHashMap<>();
+    Set<String> taskTargets = new LinkedHashSet<>();
+    for (String nodeId : nodesById.keySet()) {
+      adjacency.put(nodeId, new ArrayList<>());
+    }
+    for (EdgeRequest edge : edges) {
+      if (!nodesById.containsKey(edge.source()) || !nodesById.containsKey(edge.target())) {
+        continue;
+      }
+      adjacency.get(edge.source()).add(edge.target());
+      taskTargets.add(edge.target());
+    }
+
+    StartSelection selection = readStartSelection(input);
+    List<String> startNodeIds;
+    if (selection.explicit()) {
+      startNodeIds = selection.nodeIds();
+      if (startNodeIds.isEmpty()) {
+        throw new IllegalStateException("开始节点至少需要连接一个任务节点");
+      }
+      for (String nodeId : startNodeIds) {
+        if (!nodesById.containsKey(nodeId)) {
+          throw new IllegalStateException("开始节点连接了不存在的任务节点：" + nodeId);
+        }
+        if (taskTargets.contains(nodeId)) {
+          throw new IllegalStateException("开始节点只能连接没有前置任务的根节点：" + nodeId);
+        }
+      }
+    } else {
+      // Backward compatibility for definitions saved before explicit Start connections existed.
+      startNodeIds = nodesById.keySet().stream()
+          .filter(nodeId -> !taskTargets.contains(nodeId))
+          .toList();
+    }
+
+    if (startNodeIds.isEmpty()) {
+      throw new IllegalStateException("工作流没有可从开始节点进入的任务节点");
+    }
+
+    Set<String> reachable = new LinkedHashSet<>();
+    ArrayDeque<String> queue = new ArrayDeque<>(startNodeIds);
+    while (!queue.isEmpty()) {
+      String current = queue.removeFirst();
+      if (!reachable.add(current)) {
+        continue;
+      }
+      for (String next : adjacency.getOrDefault(current, List.of())) {
+        queue.addLast(next);
+      }
+    }
+
+    List<NodeRequest> runtimeNodes = nodes.stream()
+        .filter(node -> reachable.contains(node.id()))
+        .toList();
+    List<EdgeRequest> runtimeEdges = edges.stream()
+        .filter(edge -> reachable.contains(edge.source()) && reachable.contains(edge.target()))
+        .toList();
+    return new RuntimeGraph(runtimeNodes, runtimeEdges);
+  }
+
+  private static StartSelection readStartSelection(Map<String, Object> input) {
+    if (input == null) {
+      return StartSelection.legacy();
+    }
+    Object rawMeta = input.get(START_META_KEY);
+    if (!(rawMeta instanceof Map<?, ?> meta) || !meta.containsKey(NEXT_NODE_IDS_KEY)) {
+      return StartSelection.legacy();
+    }
+
+    Object rawNodeIds = meta.get(NEXT_NODE_IDS_KEY);
+    if (rawNodeIds == null) {
+      return StartSelection.explicit(List.of());
+    }
+    if (!(rawNodeIds instanceof List<?> values)) {
+      throw new IllegalStateException("开始节点连接信息格式不正确");
+    }
+
+    LinkedHashSet<String> nodeIds = new LinkedHashSet<>();
+    for (Object value : values) {
+      if (value instanceof String nodeId && !nodeId.isBlank()) {
+        nodeIds.add(nodeId.trim());
+      }
+    }
+    return StartSelection.explicit(List.copyOf(nodeIds));
+  }
+
+  record RuntimeGraph(List<NodeRequest> nodes, List<EdgeRequest> edges) {}
+
+  private record StartSelection(boolean explicit, List<String> nodeIds) {
+    static StartSelection legacy() {
+      return new StartSelection(false, List.of());
+    }
+
+    static StartSelection explicit(List<String> nodeIds) {
+      return new StartSelection(true, nodeIds);
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowPauseSchedulingTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowPauseSchedulingTest.java
@@ -1,0 +1,211 @@
+package io.yak.ops.business.workflow.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.yak.ops.business.job.task.SyncTaskExecution;
+import io.yak.ops.business.job.task.SyncTaskRunner;
+import io.yak.ops.business.job.task.TaskDefinition;
+import io.yak.ops.business.job.task.TaskRegistry;
+import io.yak.ops.business.workflow.model.WorkflowInstanceVO;
+import io.yak.ops.business.workflow.model.WorkflowRunRequest;
+import io.yak.ops.business.workflow.model.WorkflowRunRequest.EdgeRequest;
+import io.yak.ops.business.workflow.model.WorkflowRunRequest.NodeRequest;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class WorkflowPauseSchedulingTest {
+
+  private static final Set<String> TERMINAL = Set.of(
+      "SUCCESS", "SUCCESS_WITH_WARNINGS", "FAILED", "CANCELED", "TIMED_OUT");
+
+  private WorkflowRuntimeService service;
+
+  @AfterEach
+  void tearDown() {
+    if (service != null) {
+      service.shutdown();
+    }
+  }
+
+  @Test
+  void shouldLetRunningSyncTaskFinishBeforeWorkflowBecomesPaused() throws InterruptedException {
+    FakeRunner runner = new FakeRunner();
+    runner.duration("task-a", 300L);
+    runner.duration("task-b", 20L);
+    service = service(runner, "task-a", "task-b");
+
+    WorkflowInstanceVO prepared = service.run(new WorkflowRunRequest(
+        "pause-scheduling",
+        List.of(new NodeRequest("a", "task-a"), new NodeRequest("b", "task-b")),
+        List.of(new EdgeRequest("a", "b")),
+        Map.of()));
+    service.activate(prepared.id());
+    waitUntilStarted(runner, "task-a");
+
+    WorkflowInstanceVO pauseRequested = service.pause(prepared.id());
+    assertThat(pauseRequested.status()).isEqualTo("PAUSING");
+
+    Thread.sleep(40L);
+    WorkflowInstanceVO stillPausing = service.getInstance(prepared.id());
+    assertThat(stillPausing.status()).isEqualTo("PAUSING");
+    assertThat(node(stillPausing, "a").status()).isEqualTo("RUNNING");
+    assertThat(runner.started("task-b")).isZero();
+    assertThat(runner.cancelCount()).isZero();
+
+    WorkflowInstanceVO paused = waitForStatus(prepared.id(), "PAUSED");
+    assertThat(node(paused, "a").status()).isEqualTo("SUCCESS");
+    assertThat(runner.started("task-b")).isZero();
+
+    service.resume(prepared.id());
+    WorkflowInstanceVO completed = waitForTerminal(prepared.id());
+    assertThat(completed.status()).isEqualTo("SUCCESS");
+    assertThat(node(completed, "b").status()).isEqualTo("SUCCESS");
+    assertThat(runner.started("task-b")).isEqualTo(1);
+  }
+
+  private WorkflowRuntimeService service(FakeRunner runner, String... taskIds) {
+    Map<String, TaskDefinition> tasks = new ConcurrentHashMap<>();
+    for (String taskId : taskIds) {
+      tasks.put(taskId, new TaskDefinition(taskId, taskId, "SYNC"));
+    }
+    TaskRegistry registry = new TaskRegistry() {
+      @Override
+      public List<TaskDefinition> list() {
+        return List.copyOf(tasks.values());
+      }
+
+      @Override
+      public TaskDefinition get(String taskId) {
+        TaskDefinition task = tasks.get(taskId);
+        if (task == null) {
+          throw new IllegalArgumentException("任务不存在：" + taskId);
+        }
+        return task;
+      }
+    };
+    return new WorkflowRuntimeService(
+        new WorkflowEventStreamService(), registry, runner, 2L);
+  }
+
+  private void waitUntilStarted(FakeRunner runner, String taskId) throws InterruptedException {
+    for (int i = 0; i < 200; i++) {
+      if (runner.started(taskId) > 0) {
+        return;
+      }
+      Thread.sleep(5L);
+    }
+    assertThat(runner.started(taskId)).isGreaterThan(0);
+  }
+
+  private WorkflowInstanceVO waitForStatus(String executionId, String expected)
+      throws InterruptedException {
+    for (int i = 0; i < 400; i++) {
+      WorkflowInstanceVO current = service.getInstance(executionId);
+      if (expected.equals(current.status())) {
+        return current;
+      }
+      Thread.sleep(5L);
+    }
+    return service.getInstance(executionId);
+  }
+
+  private WorkflowInstanceVO waitForTerminal(String executionId) throws InterruptedException {
+    for (int i = 0; i < 400; i++) {
+      WorkflowInstanceVO current = service.getInstance(executionId);
+      if (TERMINAL.contains(current.status())) {
+        return current;
+      }
+      Thread.sleep(5L);
+    }
+    return service.getInstance(executionId);
+  }
+
+  private WorkflowInstanceVO.NodeInstanceVO node(WorkflowInstanceVO instance, String id) {
+    return instance.nodes().stream().filter(item -> id.equals(item.id())).findFirst().orElseThrow();
+  }
+
+  private static final class FakeRunner implements SyncTaskRunner {
+    private final AtomicLong sequence = new AtomicLong();
+    private final AtomicInteger cancels = new AtomicInteger();
+    private final ConcurrentMap<String, AtomicInteger> starts = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, Long> durations = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, State> executions = new ConcurrentHashMap<>();
+
+    void duration(String taskId, long millis) {
+      durations.put(taskId, millis);
+    }
+
+    int started(String taskId) {
+      AtomicInteger value = starts.get(taskId);
+      return value == null ? 0 : value.get();
+    }
+
+    int cancelCount() {
+      return cancels.get();
+    }
+
+    @Override
+    public SyncTaskExecution start(String taskId) {
+      String id = String.valueOf(sequence.incrementAndGet());
+      State state = new State(
+          id,
+          taskId,
+          System.nanoTime(),
+          durations.getOrDefault(taskId, 20L));
+      executions.put(id, state);
+      starts.computeIfAbsent(taskId, ignored -> new AtomicInteger()).incrementAndGet();
+      return view(state);
+    }
+
+    @Override
+    public SyncTaskExecution status(String executionId) {
+      return view(executions.get(executionId));
+    }
+
+    @Override
+    public void cancel(String executionId) {
+      State state = executions.get(executionId);
+      if (state != null) {
+        state.canceled = true;
+        cancels.incrementAndGet();
+      }
+    }
+
+    private SyncTaskExecution view(State state) {
+      if (state == null) {
+        throw new IllegalArgumentException("execution not found");
+      }
+      long elapsed = (System.nanoTime() - state.startedNanos) / 1_000_000L;
+      String status = state.canceled
+          ? "CANCELED"
+          : elapsed >= state.durationMillis ? "SUCCEEDED" : "RUNNING";
+      return new SyncTaskExecution(
+          state.executionId,
+          status,
+          null,
+          Map.of("taskId", state.taskId));
+    }
+
+    private static final class State {
+      private final String executionId;
+      private final String taskId;
+      private final long startedNanos;
+      private final long durationMillis;
+      private volatile boolean canceled;
+
+      private State(String executionId, String taskId, long startedNanos, long durationMillis) {
+        this.executionId = executionId;
+        this.taskId = taskId;
+        this.startedNanos = startedNanos;
+        this.durationMillis = durationMillis;
+      }
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowStartDefinitionExecutionTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowStartDefinitionExecutionTest.java
@@ -1,0 +1,120 @@
+package io.yak.ops.business.workflow.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.job.task.TaskDefinition;
+import io.yak.ops.business.job.task.TaskRegistry;
+import io.yak.ops.business.workflow.model.WorkflowDefinitionCreateRequest;
+import io.yak.ops.business.workflow.model.WorkflowDefinitionUpdateRequest;
+import io.yak.ops.business.workflow.model.WorkflowDefinitionUpdateRequest.EdgeRequest;
+import io.yak.ops.business.workflow.model.WorkflowDefinitionUpdateRequest.NodeRequest;
+import io.yak.ops.business.workflow.model.WorkflowDefinitionVO;
+import io.yak.ops.business.workflow.model.WorkflowInstanceVO;
+import io.yak.ops.business.workflow.model.WorkflowRunRequest;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class WorkflowStartDefinitionExecutionTest {
+
+  @Mock private WorkflowRuntimeService runtimeService;
+  @Mock private TaskRegistry taskRegistry;
+
+  private WorkflowDefinitionService service;
+
+  @BeforeEach
+  void setUp() {
+    service = new WorkflowDefinitionService(runtimeService, taskRegistry);
+  }
+
+  @Test
+  void shouldExcludeUnconnectedRootFromRuntimeRequest() {
+    WorkflowDefinitionVO created = service.create(
+        new WorkflowDefinitionCreateRequest("start-semantics", null));
+    service.update(
+        created.id(),
+        new WorkflowDefinitionUpdateRequest(
+            "start-semantics",
+            null,
+            List.of(
+                node("a", "task-a"),
+                node("b", "task-b"),
+                node("c", "task-c")),
+            List.of(new EdgeRequest("a", "c")),
+            startInput(List.of("a")),
+            0L,
+            "CONTINUE_INDEPENDENT_BRANCHES"));
+
+    when(taskRegistry.get("task-a")).thenReturn(new TaskDefinition("task-a", "A", "SYNC"));
+    when(taskRegistry.get("task-b")).thenReturn(new TaskDefinition("task-b", "B", "SYNC"));
+    when(taskRegistry.get("task-c")).thenReturn(new TaskDefinition("task-c", "C", "SYNC"));
+    service.online(created.id());
+
+    WorkflowInstanceVO prepared = instance("exec-1", "CREATED", 2, 1);
+    WorkflowInstanceVO running = instance("exec-1", "RUNNING", 2, 1);
+    ArgumentCaptor<WorkflowRunRequest> requestCaptor = ArgumentCaptor.forClass(WorkflowRunRequest.class);
+    when(runtimeService.run(requestCaptor.capture())).thenReturn(prepared);
+    when(runtimeService.activate("exec-1")).thenReturn(running);
+    when(runtimeService.getInstance("exec-1")).thenReturn(running);
+
+    service.run(created.id());
+
+    WorkflowRunRequest runtimeRequest = requestCaptor.getValue();
+    assertThat(runtimeRequest.nodes()).extracting(WorkflowRunRequest.NodeRequest::id)
+        .containsExactly("a", "c");
+    assertThat(runtimeRequest.edges())
+        .extracting(edge -> edge.source() + "->" + edge.target())
+        .containsExactly("a->c");
+  }
+
+  private Map<String, Object> startInput(List<String> nextNodeIds) {
+    Map<String, Object> input = new LinkedHashMap<>();
+    input.put("__yak_start__", Map.of(
+        "version", 2,
+        "nextNodeIds", nextNodeIds));
+    return input;
+  }
+
+  private NodeRequest node(String id, String taskId) {
+    return new NodeRequest(
+        id,
+        taskId,
+        0D,
+        0D,
+        1,
+        0L,
+        0L,
+        0L,
+        Map.of(),
+        "ALL_SUCCESS",
+        "FAIL_WORKFLOW");
+  }
+
+  private WorkflowInstanceVO instance(String id, String status, int nodeCount, int edgeCount) {
+    return new WorkflowInstanceVO(
+        id,
+        "runtime-definition",
+        null,
+        "start-semantics",
+        status,
+        "CONTINUE_INDEPENDENT_BRANCHES",
+        Instant.now(),
+        null,
+        null,
+        0L,
+        Map.of(),
+        nodeCount,
+        edgeCount,
+        List.of());
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowStartGraphCompilerTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowStartGraphCompilerTest.java
@@ -1,0 +1,93 @@
+package io.yak.ops.business.workflow.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.yak.ops.business.workflow.model.WorkflowDefinitionUpdateRequest.EdgeRequest;
+import io.yak.ops.business.workflow.model.WorkflowDefinitionUpdateRequest.NodeRequest;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class WorkflowStartGraphCompilerTest {
+
+  @Test
+  void shouldOnlyCompileNodesReachableFromExplicitStartConnections() {
+    List<NodeRequest> nodes = List.of(
+        node("a", "task-a"),
+        node("b", "task-b"),
+        node("c", "task-c"));
+    List<EdgeRequest> edges = List.of(new EdgeRequest("a", "c"));
+    Map<String, Object> input = startInput(List.of("a"));
+
+    WorkflowStartGraphCompiler.RuntimeGraph runtimeGraph =
+        WorkflowStartGraphCompiler.compile(nodes, edges, input);
+
+    assertThat(runtimeGraph.nodes()).extracting(NodeRequest::id).containsExactly("a", "c");
+    assertThat(runtimeGraph.edges())
+        .extracting(edge -> edge.source() + "->" + edge.target())
+        .containsExactly("a->c");
+  }
+
+  @Test
+  void shouldKeepLegacyDefinitionsUsingAllTaskRoots() {
+    List<NodeRequest> nodes = List.of(
+        node("a", "task-a"),
+        node("b", "task-b"),
+        node("c", "task-c"));
+    List<EdgeRequest> edges = List.of(new EdgeRequest("a", "c"));
+
+    WorkflowStartGraphCompiler.RuntimeGraph runtimeGraph =
+        WorkflowStartGraphCompiler.compile(nodes, edges, Map.of());
+
+    assertThat(runtimeGraph.nodes()).extracting(NodeRequest::id).containsExactly("a", "b", "c");
+    assertThat(runtimeGraph.edges()).hasSize(1);
+  }
+
+  @Test
+  void shouldRejectExplicitStartWithoutAnyConnectedTask() {
+    assertThatThrownBy(() -> WorkflowStartGraphCompiler.compile(
+        List.of(node("a", "task-a")),
+        List.of(),
+        startInput(List.of())))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("至少需要连接一个任务节点");
+  }
+
+  @Test
+  void shouldRejectStartConnectionToNonRootTask() {
+    List<NodeRequest> nodes = List.of(node("a", "task-a"), node("b", "task-b"));
+    List<EdgeRequest> edges = List.of(new EdgeRequest("a", "b"));
+
+    assertThatThrownBy(() -> WorkflowStartGraphCompiler.compile(
+        nodes,
+        edges,
+        startInput(List.of("b"))))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("只能连接没有前置任务的根节点");
+  }
+
+  private Map<String, Object> startInput(List<String> nextNodeIds) {
+    Map<String, Object> input = new LinkedHashMap<>();
+    input.put("__yak_start__", Map.of(
+        "version", 2,
+        "nextNodeIds", nextNodeIds));
+    return input;
+  }
+
+  private NodeRequest node(String id, String taskId) {
+    return new NodeRequest(
+        id,
+        taskId,
+        0D,
+        0D,
+        1,
+        0L,
+        0L,
+        0L,
+        Map.of(),
+        "ALL_SUCCESS",
+        "FAIL_WORKFLOW");
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowStartGraphCompilerTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowStartGraphCompilerTest.java
@@ -68,6 +68,24 @@ class WorkflowStartGraphCompilerTest {
         .hasMessageContaining("只能连接没有前置任务的根节点");
   }
 
+  @Test
+  void shouldRejectJoinWhenOneRequiredRootIsNotConnectedFromStart() {
+    List<NodeRequest> nodes = List.of(
+        node("a", "task-a"),
+        node("b", "task-b"),
+        node("join", "task-join"));
+    List<EdgeRequest> edges = List.of(
+        new EdgeRequest("a", "join"),
+        new EdgeRequest("b", "join"));
+
+    assertThatThrownBy(() -> WorkflowStartGraphCompiler.compile(
+        nodes,
+        edges,
+        startInput(List.of("a"))))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("未接入完整前置分支");
+  }
+
   private Map<String, Object> startInput(List<String> nextNodeIds) {
     Map<String, Object> input = new LinkedHashMap<>();
     input.put("__yak_start__", Map.of(


### PR DESCRIPTION
## What changed

Fix two workflow semantic mismatches together in Yak Ops.

### 1. Start connections now define the executable DAG

The editor already persists explicit Start connections in `WorkflowDefinition.input.__yak_start__.nextNodeIds`, but runtime execution previously ignored that metadata and treated every zero-indegree task as a runnable root.

This PR adds `WorkflowStartGraphCompiler` between the saved definition and `WorkflowRunRequest`:

- explicit Start targets are treated as the only runtime entry roots
- only nodes/edges reachable from those Start targets are submitted to `yak-workflow-engine`
- an unconnected root node remains on the editor canvas but is not executed
- Start may only target real task roots
- an explicit Start with no connected task is rejected before going online
- join semantics are preserved: if a reachable join still depends on an upstream root that Start did not connect, publication is rejected instead of silently dropping that predecessor
- legacy definitions without `__yak_start__.nextNodeIds` keep the previous behavior and use all structural roots, so existing workflows remain compatible

### 2. Pause no longer pretends Link-Up tasks are physically suspended

`SyncTaskRunner` / Link-Up currently has no real pause API. The previous adapter returned `NodeControlResult.ACCEPTED` and paused only the local polling thread, which could make the workflow/node appear `PAUSED` while the remote sync task kept running.

The runtime adapter now returns `NodeControlResult.UNSUPPORTED` for active SYNC attempts.

This deliberately uses the existing Yak Workflow Engine pause protocol:

- the running Link-Up task continues naturally
- the workflow stays `PAUSING` while that task is active
- no downstream nodes are dispatched during the pause transition
- once unsupported active attempts finish, the workflow reaches `PAUSED`
- resume then continues deferred downstream scheduling

No `yak-framework` changes are required because the engine already owns these semantics.

## Why

These fixes make the visible/editor workflow semantics match the actual runtime behavior:

- a task that is not connected from Start can no longer run unexpectedly
- a workflow can no longer report a physically paused SYNC task when Link-Up never paused it

## Regression coverage

Added focused tests for:

- explicit Start filtering an unconnected root out of the runtime DAG
- legacy Start behavior using all structural roots
- empty/invalid explicit Start connections
- incomplete Start coverage for a parallel join
- definition-level execution passing only the compiled Start-reachable graph to runtime
- unsupported SYNC pause staying `PAUSING` while the active task continues
- downstream tasks remaining undispatched until the workflow reaches `PAUSED` and is resumed

## Scope

- Yak Ops workflow business module only
- no database/schema changes
- no frontend persistence contract changes
- no `yak-framework` changes

## Validation

The branch is based on current `main` and is 0 commits behind. Focused regression tests were added, but this execution environment has no local GitHub checkout/toolchain and the repository currently reports no commit CI statuses, so the Draft PR should still run the normal Maven/CI checks before merge.