### PR TITLE
feat(workflow): stream test-run state into canvas

### DIFF
--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowEventStreamService.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowEventStreamService.java
@@ -1,12 +1,18 @@
 package io.yak.ops.business.workflow.service;
 
 import io.yak.ops.business.workflow.model.WorkflowInstanceVO;
+import jakarta.annotation.PreDestroy;
 import java.io.IOException;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -18,10 +24,26 @@ public class WorkflowEventStreamService {
 
   private static final Logger log = LoggerFactory.getLogger(WorkflowEventStreamService.class);
   private static final long STREAM_TIMEOUT_MILLIS = Duration.ofHours(1).toMillis();
+  private static final long HEARTBEAT_INTERVAL_SECONDS = 15L;
   private static final String EVENT_NAME = "workflow";
+  private static final String HEARTBEAT_EVENT_NAME = "ping";
 
   private final ConcurrentMap<String, CopyOnWriteArrayList<SseEmitter>> emitters =
       new ConcurrentHashMap<>();
+  private final ScheduledExecutorService heartbeatScheduler =
+      Executors.newSingleThreadScheduledExecutor(runnable -> {
+        Thread thread = new Thread(runnable, "yak-workflow-sse-heartbeat");
+        thread.setDaemon(true);
+        return thread;
+      });
+
+  public WorkflowEventStreamService() {
+    heartbeatScheduler.scheduleAtFixedRate(
+        this::heartbeat,
+        HEARTBEAT_INTERVAL_SECONDS,
+        HEARTBEAT_INTERVAL_SECONDS,
+        TimeUnit.SECONDS);
+  }
 
   public SseEmitter subscribe(String executionId, WorkflowInstanceVO snapshot) {
     SseEmitter emitter = new SseEmitter(STREAM_TIMEOUT_MILLIS);
@@ -82,6 +104,29 @@ public class WorkflowEventStreamService {
     }
   }
 
+  /**
+   * 工作流可能数十秒都停留在 RUNNING；heartbeat 防止代理把没有业务事件的 SSE 连接当作空闲连接关闭。
+   * 前端只消费 workflow 事件，因此 ping 不会污染运行快照状态机。
+   */
+  private void heartbeat() {
+    if (emitters.isEmpty()) {
+      return;
+    }
+    Map<String, Object> payload = Map.of("timestamp", Instant.now().toString());
+    emitters.forEach((executionId, executionEmitters) -> {
+      for (SseEmitter emitter : executionEmitters) {
+        try {
+          emitter.send(SseEmitter.event()
+              .name(HEARTBEAT_EVENT_NAME)
+              .id("ping-" + System.nanoTime())
+              .data(payload));
+        } catch (IOException | IllegalStateException exception) {
+          remove(executionId, emitter);
+        }
+      }
+    });
+  }
+
   private void remove(String executionId, SseEmitter emitter) {
     emitters.computeIfPresent(executionId, (ignored, executionEmitters) -> {
       executionEmitters.remove(emitter);
@@ -96,5 +141,10 @@ public class WorkflowEventStreamService {
         || "WARNING".equals(status)
         || "CANCELED".equals(status)
         || "TIMED_OUT".equals(status);
+  }
+
+  @PreDestroy
+  void shutdown() {
+    heartbeatScheduler.shutdownNow();
   }
 }

--- a/yak-ops-ui/src/pages/workflow/definition/WorkflowDefinitionEditor.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/WorkflowDefinitionEditor.tsx
@@ -1,6 +1,9 @@
 import {
+  isWorkflowTerminal,
+  subscribeWorkflowEvents,
   getWorkflowTasks,
   type WorkflowFailureStrategy,
+  type WorkflowInstance,
   type WorkflowTaskDefinition,
 } from '@/services/workflow';
 import {
@@ -55,6 +58,7 @@ import {
   type WorkflowNoteData,
   type WorkflowNoteSnapshot,
 } from './canvas/note/types';
+import { workflowNodeRuntimeState } from './canvas/runtime';
 import WorkflowStartInspector from './canvas/start/WorkflowStartInspector';
 import WorkflowStartNode from './canvas/start/WorkflowStartNode';
 import {
@@ -72,6 +76,7 @@ import useWorkflowCanvasHistory from './canvas/useWorkflowCanvasHistory';
 import 'reactflow/dist/style.css';
 
 const START_EDGE_PREFIX = 'edge-start-';
+const RUNNING_NODE_STATUSES = new Set(['SUBMITTED', 'RUNNING', 'RESUMING']);
 
 const parseObject = <T extends Record<string, unknown>>(raw: string, label: string): T => {
   const value = raw.trim() ? JSON.parse(raw) : {};
@@ -140,6 +145,8 @@ const WorkflowDefinitionContent = () => {
   const { id = '' } = useParams<{ id: string }>();
   const wrapperRef = useRef<HTMLDivElement>(null);
   const sequenceRef = useRef(1);
+  const testRunSubscriptionRef = useRef<() => void>();
+  const focusedRuntimeNodeRef = useRef<string>();
   const [tasks, setTasks] = useState<WorkflowTaskDefinition[]>([]);
   const [tasksLoading, setTasksLoading] = useState(true);
   const [loading, setLoading] = useState(true);
@@ -147,6 +154,7 @@ const WorkflowDefinitionContent = () => {
   const [testing, setTesting] = useState(false);
   const [statusAction, setStatusAction] = useState(false);
   const [definition, setDefinition] = useState<WorkflowDefinition>();
+  const [testRunSnapshot, setTestRunSnapshot] = useState<WorkflowInstance>();
   const [workflowName, setWorkflowName] = useState('');
   const [workflowDescription, setWorkflowDescription] = useState('');
   const [workflowTimeoutSeconds, setWorkflowTimeoutSeconds] = useState(0);
@@ -172,8 +180,8 @@ const WorkflowDefinitionContent = () => {
   const edgeTypes = useMemo(() => ({ workflow: WorkflowEdge }), []);
   const selectedNode = useMemo(() => nodes.find((node) => node.selected), [nodes]);
   const syncTasks = useMemo(() => tasks.filter((task) => task.type === 'SYNC'), [tasks]);
-  // 发布版本和编辑草稿分离；ONLINE 不再锁住编辑器。
-  const locked = false;
+  // 测试运行期间锁住结构编辑，避免正在执行的 nodeId 与画布拓扑发生漂移。
+  const locked = testing;
 
   const rootNodes = useMemo(() => {
     const targets = new Set(edges.map((edge) => edge.target));
@@ -185,8 +193,12 @@ const WorkflowDefinitionContent = () => {
     return startConfig.nextNodeIds.filter((nodeId) => nodeIds.has(nodeId));
   }, [nodes, startConfig.nextNodeIds]);
 
+  const runtimeByNodeId = useMemo(() => new Map(
+    (testRunSnapshot?.nodes || []).map((node) => [node.id, workflowNodeRuntimeState(node)]),
+  ), [testRunSnapshot]);
+
   const historySnapshot = useMemo<WorkflowEditorHistorySnapshot>(() => ({
-    nodes: nodes.map((node) => ({ id: node.id, type: node.type, position: { ...node.position }, data: { ...node.data } })),
+    nodes: nodes.map((node) => ({ id: node.id, type: node.type, position: { ...node.position }, data: { ...node.data, runtime: undefined } })),
     noteNodes: noteNodes.map((node) => ({
       ...node,
       position: { ...node.position },
@@ -222,7 +234,7 @@ const WorkflowDefinitionContent = () => {
     setStartConfig({ ...snapshot.startConfig, nextNodeIds: [...snapshot.startConfig.nextNodeIds] });
     setStartSelected(false);
     setStartNodeState((current) => ({ ...current, position: snapshot.startConfig.position, selected: false, dragging: false }));
-    setNodes(snapshot.nodes.map((node) => ({ ...node, selected: false, dragging: false })));
+    setNodes(snapshot.nodes.map((node) => ({ ...node, selected: false, dragging: false, data: { ...node.data, runtime: undefined } })));
     setNoteNodes(snapshot.noteNodes.map((node) => ({ ...node, selected: false, dragging: false })));
     setEdges(snapshot.edges.map((edge) => ({ ...edge, selected: false })));
   }, [setEdges, setNodes]);
@@ -237,7 +249,63 @@ const WorkflowDefinitionContent = () => {
     redo: redoHistory,
     jumpTo: jumpToHistory,
     clear: clearHistory,
-  } = useWorkflowCanvasHistory({ snapshot: historySnapshot, historyKey: id, enabled: !loading, onRestore: restoreHistorySnapshot });
+  } = useWorkflowCanvasHistory({ snapshot: historySnapshot, historyKey: id, enabled: !loading && !testing, onRestore: restoreHistorySnapshot });
+
+  const stopTestRunSubscription = useCallback(() => {
+    testRunSubscriptionRef.current?.();
+    testRunSubscriptionRef.current = undefined;
+  }, []);
+
+  const handleTestRunSnapshot = useCallback((snapshot: WorkflowInstance) => {
+    if (!snapshot.testRun) return;
+    setTestRunSnapshot(snapshot);
+    setDefinition((current) => current ? {
+      ...current,
+      latestExecutionId: snapshot.id,
+      latestExecutionStatus: snapshot.status,
+    } : current);
+
+    if (!isWorkflowTerminal(snapshot.status)) return;
+
+    stopTestRunSubscription();
+    setTesting(false);
+    if (snapshot.status === 'SUCCESS') {
+      message.success('测试运行完成');
+    } else if (snapshot.status === 'SUCCESS_WITH_WARNINGS' || snapshot.status === 'WARNING') {
+      message.warning('测试运行完成，但存在告警节点');
+    } else if (snapshot.status === 'CANCELED') {
+      message.info('测试运行已取消');
+    } else {
+      message.error(`测试运行结束：${snapshot.status}`);
+    }
+  }, [stopTestRunSubscription]);
+
+  const subscribeTestRun = useCallback((executionId: string) => {
+    stopTestRunSubscription();
+    focusedRuntimeNodeRef.current = undefined;
+    testRunSubscriptionRef.current = subscribeWorkflowEvents(executionId, handleTestRunSnapshot);
+  }, [handleTestRunSnapshot, stopTestRunSubscription]);
+
+  useEffect(() => () => stopTestRunSubscription(), [stopTestRunSubscription]);
+
+  useEffect(() => {
+    const runningNode = testRunSnapshot?.nodes.find((node) => RUNNING_NODE_STATUSES.has(node.status));
+    if (!runningNode || !reactFlowInstance || focusedRuntimeNodeRef.current === runningNode.id) return;
+    const canvasNode = nodes.find((node) => node.id === runningNode.id);
+    if (!canvasNode) return;
+
+    focusedRuntimeNodeRef.current = runningNode.id;
+    const width = canvasNode.width ?? WORKFLOW_NODE_WIDTH;
+    const height = canvasNode.height ?? 72;
+    reactFlowInstance.setCenter(
+      canvasNode.position.x + width / 2,
+      canvasNode.position.y + height / 2,
+      {
+        zoom: Math.min(reactFlowInstance.getZoom(), 1),
+        duration: 320,
+      },
+    );
+  }, [nodes, reactFlowInstance, testRunSnapshot]);
 
   const hydrateDefinition = useCallback((value: WorkflowDefinition, taskList: WorkflowTaskDefinition[]) => {
     const taskMap = new Map(taskList.map((task) => [task.id, task]));
@@ -543,7 +611,7 @@ const WorkflowDefinitionContent = () => {
       id: duplicatedId,
       selected: true,
       position: { x: sourceNode.position.x + 36, y: sourceNode.position.y + 36 },
-      data: { ...sourceNode.data },
+      data: { ...sourceNode.data, runtime: undefined },
     }]);
   }, [locked, markHistory, nodes, setNodes]);
 
@@ -672,13 +740,14 @@ const WorkflowDefinitionContent = () => {
     ...node,
     data: {
       ...node.data,
+      runtime: runtimeByNodeId.get(node.id),
       locked,
       appendOptions: taskOptions,
       onAppend: handleAppendTask,
       onDuplicate: handleDuplicateNode,
       onDelete: handleDeleteNode,
     },
-  })), [handleAppendTask, handleDeleteNode, handleDuplicateNode, locked, nodes, taskOptions]);
+  })), [handleAppendTask, handleDeleteNode, handleDuplicateNode, locked, nodes, runtimeByNodeId, taskOptions]);
 
   const noteCanvasNodes = useMemo(() => noteNodes.map((node) => ({
     ...node,
@@ -722,11 +791,12 @@ const WorkflowDefinitionContent = () => {
     data: {
       ...edge.data,
       locked,
+      runtimeStatus: runtimeByNodeId.get(edge.target)?.status,
       connectedNodeHovered: edge.source === hoveredNodeId || edge.target === hoveredNodeId,
       insertOptions: taskOptions,
       onInsert: handleInsertTaskIntoEdge,
     },
-  })), [edges, handleInsertTaskIntoEdge, hoveredNodeId, locked, taskOptions]);
+  })), [edges, handleInsertTaskIntoEdge, hoveredNodeId, locked, runtimeByNodeId, taskOptions]);
 
   const startCanvasEdges = useMemo(() => explicitStartTargetIds.map((nodeId) => ({
     id: `${START_EDGE_PREFIX}${nodeId}`,
@@ -734,10 +804,11 @@ const WorkflowDefinitionContent = () => {
     target: nodeId,
     type: 'workflow',
     data: {
-      locked: false,
+      locked,
+      runtimeStatus: runtimeByNodeId.get(nodeId)?.status,
       connectedNodeHovered: hoveredNodeId === WORKFLOW_START_NODE_ID || hoveredNodeId === nodeId,
     },
-  })), [explicitStartTargetIds, hoveredNodeId]);
+  })), [explicitStartTargetIds, hoveredNodeId, locked, runtimeByNodeId]);
 
   const canvasEdges = useMemo(
     () => [...startCanvasEdges, ...taskCanvasEdges],
@@ -748,7 +819,7 @@ const WorkflowDefinitionContent = () => {
     if (!selectedNode || locked) return;
     markHistory(`${selectedNode.data.label} 节点配置已更新`);
     setNodes((current) => current.map((node) =>
-      node.id === selectedNode.id ? { ...node, data: { ...node.data, ...patch } } : node));
+      node.id === selectedNode.id ? { ...node, data: { ...node.data, ...patch, runtime: undefined } } : node));
   };
 
   const updateStartConfig = useCallback((nextConfig: WorkflowStartConfig) => {
@@ -819,15 +890,21 @@ const WorkflowDefinitionContent = () => {
   const handleTestRun = async () => {
     if (testing || statusAction) return;
     setTesting(true);
+    setTestRunSnapshot(undefined);
+    focusedRuntimeNodeRef.current = undefined;
+    stopTestRunSubscription();
     try {
       await saveDefinition(false);
       const tested = await testRunWorkflowDefinition(id);
       setDefinition(tested);
-      message.success('当前草稿已提交测试运行，不影响已发布版本');
+      const executionId = tested.latestExecutionId;
+      if (!executionId) throw new Error('测试运行未返回执行实例 ID');
+      subscribeTestRun(executionId);
+      message.info('测试运行已开始，画布将实时显示节点执行状态');
     } catch (error) {
-      message.error(error instanceof Error ? error.message : '测试运行失败');
-    } finally {
+      stopTestRunSubscription();
       setTesting(false);
+      message.error(error instanceof Error ? error.message : '测试运行失败');
     }
   };
 

--- a/yak-ops-ui/src/pages/workflow/definition/WorkflowDefinitionEditor.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/WorkflowDefinitionEditor.tsx
@@ -1,7 +1,7 @@
 import {
+  getWorkflowTasks,
   isWorkflowTerminal,
   subscribeWorkflowEvents,
-  getWorkflowTasks,
   type WorkflowFailureStrategy,
   type WorkflowInstance,
   type WorkflowTaskDefinition,
@@ -194,11 +194,18 @@ const WorkflowDefinitionContent = () => {
   }, [nodes, startConfig.nextNodeIds]);
 
   const runtimeByNodeId = useMemo(() => new Map(
-    (testRunSnapshot?.nodes || []).map((node) => [node.id, workflowNodeRuntimeState(node)]),
+    (testRunSnapshot?.nodes || []).map(
+      (node) => [node.id, workflowNodeRuntimeState(node)] as const,
+    ),
   ), [testRunSnapshot]);
 
   const historySnapshot = useMemo<WorkflowEditorHistorySnapshot>(() => ({
-    nodes: nodes.map((node) => ({ id: node.id, type: node.type, position: { ...node.position }, data: { ...node.data, runtime: undefined } })),
+    nodes: nodes.map((node) => ({
+      id: node.id,
+      type: node.type,
+      position: { ...node.position },
+      data: { ...node.data, runtime: undefined },
+    })),
     noteNodes: noteNodes.map((node) => ({
       ...node,
       position: { ...node.position },
@@ -233,8 +240,18 @@ const WorkflowDefinitionContent = () => {
     setFailureStrategy(snapshot.failureStrategy);
     setStartConfig({ ...snapshot.startConfig, nextNodeIds: [...snapshot.startConfig.nextNodeIds] });
     setStartSelected(false);
-    setStartNodeState((current) => ({ ...current, position: snapshot.startConfig.position, selected: false, dragging: false }));
-    setNodes(snapshot.nodes.map((node) => ({ ...node, selected: false, dragging: false, data: { ...node.data, runtime: undefined } })));
+    setStartNodeState((current) => ({
+      ...current,
+      position: snapshot.startConfig.position,
+      selected: false,
+      dragging: false,
+    }));
+    setNodes(snapshot.nodes.map((node) => ({
+      ...node,
+      selected: false,
+      dragging: false,
+      data: { ...node.data, runtime: undefined },
+    })));
     setNoteNodes(snapshot.noteNodes.map((node) => ({ ...node, selected: false, dragging: false })));
     setEdges(snapshot.edges.map((edge) => ({ ...edge, selected: false })));
   }, [setEdges, setNodes]);
@@ -249,7 +266,12 @@ const WorkflowDefinitionContent = () => {
     redo: redoHistory,
     jumpTo: jumpToHistory,
     clear: clearHistory,
-  } = useWorkflowCanvasHistory({ snapshot: historySnapshot, historyKey: id, enabled: !loading && !testing, onRestore: restoreHistorySnapshot });
+  } = useWorkflowCanvasHistory({
+    snapshot: historySnapshot,
+    historyKey: id,
+    enabled: !loading && !testing,
+    onRestore: restoreHistorySnapshot,
+  });
 
   const stopTestRunSubscription = useCallback(() => {
     testRunSubscriptionRef.current?.();
@@ -308,7 +330,7 @@ const WorkflowDefinitionContent = () => {
   }, [nodes, reactFlowInstance, testRunSnapshot]);
 
   const hydrateDefinition = useCallback((value: WorkflowDefinition, taskList: WorkflowTaskDefinition[]) => {
-    const taskMap = new Map(taskList.map((task) => [task.id, task]));
+    const taskMap = new Map(taskList.map((task) => [task.id, task] as const));
     const hydratedStartConfig = hydrateWorkflowStartConfig(value.input || {}, value.editorMeta || {});
     const hydratedNotes = hydrateWorkflowNotes(value.editorMeta || {}, value.input || {});
     setDefinition(value);
@@ -319,7 +341,12 @@ const WorkflowDefinitionContent = () => {
     setStartConfig(hydratedStartConfig);
     setStartSelected(false);
     setControlMode('pointer');
-    setStartNodeState((current) => ({ ...current, position: hydratedStartConfig.position, selected: false, dragging: false }));
+    setStartNodeState((current) => ({
+      ...current,
+      position: hydratedStartConfig.position,
+      selected: false,
+      dragging: false,
+    }));
     setNoteNodes(hydratedNotes.map(createNoteNode));
     setNodes(value.nodes.map((node) => {
       const task = taskMap.get(node.taskId);
@@ -763,6 +790,12 @@ const WorkflowDefinitionContent = () => {
     },
   })), [controlMode, handleDeleteNote, handleDuplicateNote, handleNoteChange, handleNoteCommit, locked, noteNodes]);
 
+  const startRuntimeStatus: WorkflowStartNodeData['runtimeStatus'] = testRunSnapshot
+    ? 'SUCCESS'
+    : testing
+      ? 'RUNNING'
+      : undefined;
+
   const startCanvasNode = useMemo<Node<WorkflowStartNodeData>>(() => ({
     ...startNodeState,
     id: WORKFLOW_START_NODE_ID,
@@ -775,10 +808,21 @@ const WorkflowDefinitionContent = () => {
       label: '开始',
       locked,
       inputs: startConfig.inputs,
+      runtimeStatus: startRuntimeStatus,
       appendOptions: taskOptions,
       onAppend: handleAppendFromStart,
     },
-  }), [controlMode, handleAppendFromStart, locked, startConfig.inputs, startConfig.position, startNodeState, startSelected, taskOptions]);
+  }), [
+    controlMode,
+    handleAppendFromStart,
+    locked,
+    startConfig.inputs,
+    startConfig.position,
+    startNodeState,
+    startRuntimeStatus,
+    startSelected,
+    taskOptions,
+  ]);
 
   const canvasNodes = useMemo(
     () => [startCanvasNode, ...taskCanvasNodes, ...noteCanvasNodes],
@@ -819,7 +863,9 @@ const WorkflowDefinitionContent = () => {
     if (!selectedNode || locked) return;
     markHistory(`${selectedNode.data.label} 节点配置已更新`);
     setNodes((current) => current.map((node) =>
-      node.id === selectedNode.id ? { ...node, data: { ...node.data, ...patch, runtime: undefined } } : node));
+      node.id === selectedNode.id
+        ? { ...node, data: { ...node.data, ...patch, runtime: undefined } }
+        : node));
   };
 
   const updateStartConfig = useCallback((nextConfig: WorkflowStartConfig) => {

--- a/yak-ops-ui/src/pages/workflow/definition/canvas/WorkflowToolbar.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/WorkflowToolbar.tsx
@@ -196,6 +196,7 @@ const WorkflowToolbar = (props: WorkflowToolbarProps) => {
           <Button
             block
             type="primary"
+            disabled={testing}
             loading={statusAction || saving}
             icon={<Rocket size={14} />}
             onClick={() => { onOnline(); setPublishOpen(false); }}
@@ -206,6 +207,7 @@ const WorkflowToolbar = (props: WorkflowToolbarProps) => {
         ) : null}
         <Button
           block
+          disabled={testing}
           loading={saving}
           icon={<Save size={14} />}
           onClick={() => { onSave(); setPublishOpen(false); }}
@@ -216,6 +218,7 @@ const WorkflowToolbar = (props: WorkflowToolbarProps) => {
         {status === 'ONLINE' && hasPublished ? (
           <Button
             block
+            disabled={testing}
             loading={statusAction}
             icon={<CircleStop size={14} />}
             onClick={() => { onOffline(); setPublishOpen(false); }}
@@ -265,13 +268,13 @@ const WorkflowToolbar = (props: WorkflowToolbarProps) => {
             onClick={onTestRun}
             className="!h-8 !rounded-lg !border-[#dfe2e7] !px-3 !text-[12px] !font-medium !text-[#344054] shadow-none"
           >
-            测试运行
+            {testing ? '测试运行中' : '测试运行'}
           </Button>
         </Tooltip>
 
         <Popover
           open={publishOpen}
-          onOpenChange={setPublishOpen}
+          onOpenChange={(open) => { if (!testing) setPublishOpen(open); }}
           trigger="click"
           placement="bottomRight"
           arrow={false}
@@ -281,6 +284,7 @@ const WorkflowToolbar = (props: WorkflowToolbarProps) => {
           <Button
             type="primary"
             size="small"
+            disabled={testing}
             icon={<Rocket size={14} />}
             className="!h-8 !rounded-lg !px-3.5 !text-[12px] !font-medium"
           >

--- a/yak-ops-ui/src/pages/workflow/definition/canvas/edge/WorkflowEdge.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/edge/WorkflowEdge.tsx
@@ -13,10 +13,6 @@ import WorkflowEdgeInsert from './WorkflowEdgeInsert';
 
 const runtimeStroke = (status?: string) => {
   switch (status) {
-    case 'RUNNING':
-    case 'RESUMING':
-      return '#fe2c55';
-    case 'WAITING':
     case 'READY':
     case 'SUBMITTED':
     case 'PAUSING':
@@ -24,6 +20,9 @@ const runtimeStroke = (status?: string) => {
     case 'SUCCESS_WITH_WARNINGS':
     case 'WARNING':
       return '#f79009';
+    case 'RUNNING':
+    case 'RESUMING':
+      return '#fe2c55';
     case 'SUCCESS':
       return '#12b76a';
     case 'FAILED':

--- a/yak-ops-ui/src/pages/workflow/definition/canvas/edge/WorkflowEdge.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/edge/WorkflowEdge.tsx
@@ -27,6 +27,7 @@ const runtimeStroke = (status?: string) => {
     case 'SUCCESS':
       return '#12b76a';
     case 'FAILED':
+    case 'UPSTREAM_FAILED':
     case 'TIMED_OUT':
       return '#f04438';
     case 'CANCELED':

--- a/yak-ops-ui/src/pages/workflow/definition/canvas/edge/WorkflowEdge.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/edge/WorkflowEdge.tsx
@@ -11,6 +11,32 @@ import { WORKFLOW_START_NODE_ID } from '../start/types';
 import type { WorkflowEdgeData } from '../types';
 import WorkflowEdgeInsert from './WorkflowEdgeInsert';
 
+const runtimeStroke = (status?: string) => {
+  switch (status) {
+    case 'RUNNING':
+    case 'RESUMING':
+      return '#fe2c55';
+    case 'WAITING':
+    case 'READY':
+    case 'SUBMITTED':
+    case 'PAUSING':
+    case 'PAUSED':
+    case 'SUCCESS_WITH_WARNINGS':
+    case 'WARNING':
+      return '#f79009';
+    case 'SUCCESS':
+      return '#12b76a';
+    case 'FAILED':
+    case 'TIMED_OUT':
+      return '#f04438';
+    case 'CANCELED':
+    case 'SKIPPED':
+      return '#98a2b3';
+    default:
+      return undefined;
+  }
+};
+
 const WorkflowEdge = ({
   id,
   source,
@@ -41,11 +67,13 @@ const WorkflowEdge = ({
 
   const connectedNodeHovered = Boolean(data?.connectedNodeHovered);
   const highlighted = selected || connectedNodeHovered;
-  const stroke = highlighted
-    ? '#fe2c55'
-    : hovered || insertOpen
-      ? '#8a8f99'
-      : '#cfd2d7';
+  const executionStroke = runtimeStroke(data?.runtimeStatus);
+  const stroke = executionStroke
+    || (highlighted
+      ? '#fe2c55'
+      : hovered || insertOpen
+        ? '#8a8f99'
+        : '#cfd2d7');
   const insertOptions = data?.insertOptions || [];
   const canInsert = !isStartEdge && !data?.locked && insertOptions.length > 0 && Boolean(data?.onInsert);
   const insertVisible = canInsert && (hovered || selected || insertOpen);
@@ -72,8 +100,8 @@ const WorkflowEdge = ({
         path={edgePath}
         style={{
           stroke,
-          strokeWidth: highlighted ? 2.2 : 2,
-          transition: 'stroke 150ms ease, stroke-width 150ms ease',
+          strokeWidth: executionStroke || highlighted ? 2.2 : 2,
+          transition: 'stroke 180ms ease, stroke-width 180ms ease',
         }}
       />
 

--- a/yak-ops-ui/src/pages/workflow/definition/canvas/node/WorkflowNode.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/node/WorkflowNode.tsx
@@ -1,53 +1,177 @@
+import {
+  Ban,
+  CheckCircle2,
+  Clock3,
+  LoaderCircle,
+  PauseCircle,
+  TimerOff,
+  TriangleAlert,
+  XCircle,
+} from 'lucide-react';
+import type { ReactNode } from 'react';
 import type { NodeProps } from 'reactflow';
+import {
+  formatRuntimeDuration,
+  isWorkflowNodeActive,
+  runtimeStatusLabel,
+} from '../runtime';
 import type { WorkflowNodeData } from '../types';
 import WorkflowNodeControl from './WorkflowNodeControl';
 import WorkflowNodeHandle from './WorkflowNodeHandle';
 import WorkflowNodeRetry from './WorkflowNodeRetry';
 import WorkflowNodeIcon from './icons/WorkflowNodeIcon';
 
-const WorkflowNode = ({ id, data, selected }: NodeProps<WorkflowNodeData>) => (
-  <div className="group relative w-60">
-    <WorkflowNodeControl
-      nodeId={id}
-      selected={selected}
-      locked={data.locked}
-      onDuplicate={data.onDuplicate}
-      onDelete={data.onDelete}
-    />
+interface RuntimeVisual {
+  borderClassName: string;
+  badgeClassName: string;
+  icon: ReactNode;
+}
 
-    <WorkflowNodeHandle nodeId={id} type="target" selected={selected} locked={data.locked} />
+const runtimeVisual = (status?: string): RuntimeVisual | undefined => {
+  switch (status) {
+    case 'WAITING':
+    case 'READY':
+    case 'SUBMITTED':
+      return {
+        borderClassName: 'border-[#f0b429] shadow-[0_0_0_2px_rgba(240,180,41,.08)]',
+        badgeClassName: 'bg-[#fff8e6] text-[#946200]',
+        icon: <Clock3 size={11} />,
+      };
+    case 'RUNNING':
+    case 'RESUMING':
+      return {
+        borderClassName: 'border-[#fe2c55] shadow-[0_0_0_3px_rgba(254,44,85,.08)]',
+        badgeClassName: 'bg-[#fff1f3] text-[#d92d50]',
+        icon: <LoaderCircle size={11} className="animate-spin" />,
+      };
+    case 'PAUSING':
+    case 'PAUSED':
+      return {
+        borderClassName: 'border-[#f79009] shadow-[0_0_0_2px_rgba(247,144,9,.08)]',
+        badgeClassName: 'bg-[#fff7e8] text-[#b54708]',
+        icon: <PauseCircle size={11} />,
+      };
+    case 'SUCCESS':
+      return {
+        borderClassName: 'border-[#12b76a] shadow-[0_0_0_2px_rgba(18,183,106,.07)]',
+        badgeClassName: 'bg-[#ecfdf3] text-[#067647]',
+        icon: <CheckCircle2 size={11} />,
+      };
+    case 'SUCCESS_WITH_WARNINGS':
+    case 'WARNING':
+      return {
+        borderClassName: 'border-[#f79009] shadow-[0_0_0_2px_rgba(247,144,9,.07)]',
+        badgeClassName: 'bg-[#fff7e8] text-[#b54708]',
+        icon: <TriangleAlert size={11} />,
+      };
+    case 'FAILED':
+      return {
+        borderClassName: 'border-[#f04438] shadow-[0_0_0_2px_rgba(240,68,56,.08)]',
+        badgeClassName: 'bg-[#fef3f2] text-[#b42318]',
+        icon: <XCircle size={11} />,
+      };
+    case 'TIMED_OUT':
+      return {
+        borderClassName: 'border-[#f04438] shadow-[0_0_0_2px_rgba(240,68,56,.08)]',
+        badgeClassName: 'bg-[#fef3f2] text-[#b42318]',
+        icon: <TimerOff size={11} />,
+      };
+    case 'CANCELED':
+    case 'SKIPPED':
+      return {
+        borderClassName: 'border-[#cfd2d7]',
+        badgeClassName: 'bg-[#f5f6f7] text-[#667085]',
+        icon: <Ban size={11} />,
+      };
+    default:
+      return undefined;
+  }
+};
 
-    <div
-      className={[
-        'relative rounded-[15px] border bg-white px-3 py-3',
-        'shadow-[0_1px_2px_rgba(22,24,35,.06)]',
-        'transition-[border-color,box-shadow] duration-150',
-        'group-hover:shadow-[0_6px_18px_rgba(22,24,35,.10)]',
-        selected
-          ? 'border-[#fe2c55] shadow-[0_0_0_2px_rgba(254,44,85,.06)]'
-          : 'border-[#e8e9ec] group-hover:border-[#d7d9de]',
-      ].join(' ')}
-    >
-      <div className="flex min-h-9 items-center gap-2.5">
-        <WorkflowNodeIcon taskType={data.taskType} />
+const WorkflowNode = ({ id, data, selected }: NodeProps<WorkflowNodeData>) => {
+  const runtime = data.runtime;
+  const visual = runtimeVisual(runtime?.status);
+  const duration = formatRuntimeDuration(runtime?.elapsedMillis);
+  const runtimeActive = isWorkflowNodeActive(runtime?.status);
+  const errorTitle = runtime?.errorMessage || runtime?.failureReason;
 
-        <div className="min-w-0 flex-1 truncate text-[14px] font-semibold leading-5 text-[#161823]">
-          {data.label}
+  return (
+    <div className="group relative w-60">
+      {!runtimeActive ? (
+        <WorkflowNodeControl
+          nodeId={id}
+          selected={selected}
+          locked={data.locked}
+          onDuplicate={data.onDuplicate}
+          onDelete={data.onDelete}
+        />
+      ) : null}
+
+      <WorkflowNodeHandle nodeId={id} type="target" selected={selected} locked={data.locked} />
+
+      <div
+        title={errorTitle}
+        className={[
+          'relative rounded-[15px] border bg-white px-3 py-3',
+          'shadow-[0_1px_2px_rgba(22,24,35,.06)]',
+          'transition-[border-color,box-shadow,opacity] duration-200',
+          runtimeActive ? '' : 'group-hover:shadow-[0_6px_18px_rgba(22,24,35,.10)]',
+          visual?.borderClassName
+            || (selected
+              ? 'border-[#fe2c55] shadow-[0_0_0_2px_rgba(254,44,85,.06)]'
+              : 'border-[#e8e9ec] group-hover:border-[#d7d9de]'),
+          selected && visual ? 'ring-1 ring-[rgba(254,44,85,.18)]' : '',
+        ].join(' ')}
+      >
+        <div className="flex min-h-9 items-center gap-2.5">
+          <WorkflowNodeIcon taskType={data.taskType} />
+
+          <div className="min-w-0 flex-1 truncate text-[14px] font-semibold leading-5 text-[#161823]">
+            {data.label}
+          </div>
+
+          {runtime && visual ? (
+            <span
+              className={[
+                'inline-flex h-6 shrink-0 items-center gap-1 rounded-md px-1.5',
+                'text-[10px] font-medium leading-none',
+                visual.badgeClassName,
+              ].join(' ')}
+            >
+              {visual.icon}
+              {runtimeStatusLabel(runtime.status)}
+            </span>
+          ) : null}
         </div>
+
+        <WorkflowNodeRetry data={data} />
+
+        {runtime && visual ? (
+          <div className="mt-2 flex min-h-5 items-center justify-between border-t border-[#f1f2f4] pt-2 text-[9px] text-[#98a2b3]">
+            <div className="min-w-0 flex-1 truncate">
+              {runtime.errorMessage
+                ? runtime.errorMessage
+                : runtime.attemptCount > 1
+                  ? `第 ${runtime.currentAttemptNumber || runtime.attemptCount} 次尝试`
+                  : runtimeActive
+                    ? '正在执行任务…'
+                    : '本次测试运行'}
+            </div>
+            {duration ? <span className="ml-2 shrink-0 font-medium text-[#667085]">{duration}</span> : null}
+          </div>
+        ) : null}
       </div>
 
-      <WorkflowNodeRetry data={data} />
+      <WorkflowNodeHandle
+        nodeId={id}
+        type="source"
+        selected={selected}
+        locked={data.locked}
+        appendOptions={data.appendOptions}
+        onAppend={data.onAppend}
+      />
     </div>
-
-    <WorkflowNodeHandle
-      nodeId={id}
-      type="source"
-      selected={selected}
-      locked={data.locked}
-      appendOptions={data.appendOptions}
-      onAppend={data.onAppend}
-    />
-  </div>
-);
+  );
+};
 
 export default WorkflowNode;

--- a/yak-ops-ui/src/pages/workflow/definition/canvas/node/WorkflowNode.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/node/WorkflowNode.tsx
@@ -30,6 +30,11 @@ interface RuntimeVisual {
 const runtimeVisual = (status?: string): RuntimeVisual | undefined => {
   switch (status) {
     case 'WAITING':
+      return {
+        borderClassName: 'border-[#e4e7ec]',
+        badgeClassName: 'bg-[#f5f6f7] text-[#98a2b3]',
+        icon: <Clock3 size={11} />,
+      };
     case 'READY':
     case 'SUBMITTED':
       return {

--- a/yak-ops-ui/src/pages/workflow/definition/canvas/node/WorkflowNode.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/node/WorkflowNode.tsx
@@ -65,6 +65,7 @@ const runtimeVisual = (status?: string): RuntimeVisual | undefined => {
         icon: <TriangleAlert size={11} />,
       };
     case 'FAILED':
+    case 'UPSTREAM_FAILED':
       return {
         borderClassName: 'border-[#f04438] shadow-[0_0_0_2px_rgba(240,68,56,.08)]',
         badgeClassName: 'bg-[#fef3f2] text-[#b42318]',

--- a/yak-ops-ui/src/pages/workflow/definition/canvas/runtime.test.ts
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/runtime.test.ts
@@ -1,0 +1,77 @@
+import type { WorkflowNodeInstance } from '@/services/workflow';
+import {
+  formatRuntimeDuration,
+  isWorkflowNodeActive,
+  runtimeStatusLabel,
+  workflowNodeRuntimeState,
+} from './runtime';
+
+const node = (overrides: Partial<WorkflowNodeInstance> = {}): WorkflowNodeInstance => ({
+  id: 'node-a',
+  taskId: 'task-a',
+  name: '同步订单',
+  type: 'SYNC',
+  status: 'SUCCESS',
+  triggerRule: 'ALL_SUCCESS',
+  failurePolicy: 'FAIL_WORKFLOW',
+  continuedAfterFailure: false,
+  attemptCount: 1,
+  retryMaxAttempts: 1,
+  retryDelaySeconds: 0,
+  dispatchTimeoutSeconds: 0,
+  executionTimeoutSeconds: 0,
+  inputMapping: {},
+  input: {},
+  predecessorOutputs: {},
+  output: {},
+  attempts: [],
+  ...overrides,
+});
+
+describe('workflow runtime canvas mapping', () => {
+  it('maps the latest attempt and final elapsed time into transient node state', () => {
+    const state = workflowNodeRuntimeState(node({
+      status: 'SUCCESS',
+      attemptCount: 2,
+      currentAttemptNumber: 2,
+      attempts: [
+        {
+          id: 'attempt-1',
+          attemptNumber: 1,
+          status: 'FAILED',
+          pausedMillis: 0,
+        },
+        {
+          id: 'attempt-2',
+          attemptNumber: 2,
+          status: 'SUCCESS',
+          pausedMillis: 0,
+          startedAt: '2026-08-09T06:00:00.000Z',
+          endedAt: '2026-08-09T06:00:01.250Z',
+        },
+      ],
+    }));
+
+    expect(state.status).toBe('SUCCESS');
+    expect(state.attemptCount).toBe(2);
+    expect(state.currentAttemptNumber).toBe(2);
+    expect(state.elapsedMillis).toBe(1250);
+    expect(formatRuntimeDuration(state.elapsedMillis)).toBe('1.3s');
+  });
+
+  it('treats scheduling/running/pause states as active canvas states', () => {
+    expect(isWorkflowNodeActive('WAITING')).toBe(true);
+    expect(isWorkflowNodeActive('SUBMITTED')).toBe(true);
+    expect(isWorkflowNodeActive('RUNNING')).toBe(true);
+    expect(isWorkflowNodeActive('PAUSED')).toBe(true);
+    expect(isWorkflowNodeActive('SUCCESS')).toBe(false);
+    expect(isWorkflowNodeActive('FAILED')).toBe(false);
+  });
+
+  it('provides stable labels for streamed statuses', () => {
+    expect(runtimeStatusLabel('RUNNING')).toBe('运行中');
+    expect(runtimeStatusLabel('SUCCESS')).toBe('成功');
+    expect(runtimeStatusLabel('FAILED')).toBe('失败');
+    expect(runtimeStatusLabel('TIMED_OUT')).toBe('已超时');
+  });
+});

--- a/yak-ops-ui/src/pages/workflow/definition/canvas/runtime.test.ts
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/runtime.test.ts
@@ -59,19 +59,20 @@ describe('workflow runtime canvas mapping', () => {
     expect(formatRuntimeDuration(state.elapsedMillis)).toBe('1.3s');
   });
 
-  it('treats scheduling/running/pause states as active canvas states', () => {
-    expect(isWorkflowNodeActive('WAITING')).toBe(true);
+  it('aligns active canvas states with the workflow engine state machine', () => {
+    expect(isWorkflowNodeActive('WAITING')).toBe(false);
+    expect(isWorkflowNodeActive('READY')).toBe(true);
     expect(isWorkflowNodeActive('SUBMITTED')).toBe(true);
     expect(isWorkflowNodeActive('RUNNING')).toBe(true);
     expect(isWorkflowNodeActive('PAUSED')).toBe(true);
     expect(isWorkflowNodeActive('SUCCESS')).toBe(false);
-    expect(isWorkflowNodeActive('FAILED')).toBe(false);
+    expect(isWorkflowNodeActive('UPSTREAM_FAILED')).toBe(false);
   });
 
   it('provides stable labels for streamed statuses', () => {
     expect(runtimeStatusLabel('RUNNING')).toBe('运行中');
     expect(runtimeStatusLabel('SUCCESS')).toBe('成功');
     expect(runtimeStatusLabel('FAILED')).toBe('失败');
-    expect(runtimeStatusLabel('TIMED_OUT')).toBe('已超时');
+    expect(runtimeStatusLabel('UPSTREAM_FAILED')).toBe('上游失败');
   });
 });

--- a/yak-ops-ui/src/pages/workflow/definition/canvas/runtime.ts
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/runtime.ts
@@ -1,8 +1,8 @@
 import type { WorkflowNodeInstance } from '@/services/workflow';
 import type { WorkflowNodeRuntimeState } from './types';
 
+/** 与 yak-workflow-engine NodeExecutionStatus.isActive() 保持一致。 */
 export const WORKFLOW_ACTIVE_NODE_STATUSES = new Set([
-  'WAITING',
   'READY',
   'SUBMITTED',
   'RUNNING',
@@ -61,8 +61,9 @@ export const workflowNodeRuntimeState = (
 export const runtimeStatusLabel = (status?: string) => {
   switch (status) {
     case 'WAITING':
-    case 'READY':
       return '等待中';
+    case 'READY':
+      return '就绪';
     case 'SUBMITTED':
       return '提交中';
     case 'RUNNING':

--- a/yak-ops-ui/src/pages/workflow/definition/canvas/runtime.ts
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/runtime.ts
@@ -15,6 +15,7 @@ export const WORKFLOW_TERMINAL_NODE_STATUSES = new Set([
   'SUCCESS',
   'SUCCESS_WITH_WARNINGS',
   'FAILED',
+  'UPSTREAM_FAILED',
   'WARNING',
   'CANCELED',
   'TIMED_OUT',
@@ -80,6 +81,8 @@ export const runtimeStatusLabel = (status?: string) => {
       return '告警';
     case 'FAILED':
       return '失败';
+    case 'UPSTREAM_FAILED':
+      return '上游失败';
     case 'TIMED_OUT':
       return '已超时';
     case 'CANCELED':

--- a/yak-ops-ui/src/pages/workflow/definition/canvas/runtime.ts
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/runtime.ts
@@ -1,0 +1,101 @@
+import type { WorkflowNodeInstance } from '@/services/workflow';
+import type { WorkflowNodeRuntimeState } from './types';
+
+export const WORKFLOW_ACTIVE_NODE_STATUSES = new Set([
+  'WAITING',
+  'READY',
+  'SUBMITTED',
+  'RUNNING',
+  'PAUSING',
+  'PAUSED',
+  'RESUMING',
+]);
+
+export const WORKFLOW_TERMINAL_NODE_STATUSES = new Set([
+  'SUCCESS',
+  'SUCCESS_WITH_WARNINGS',
+  'FAILED',
+  'WARNING',
+  'CANCELED',
+  'TIMED_OUT',
+  'SKIPPED',
+]);
+
+export const isWorkflowNodeActive = (status?: string) =>
+  Boolean(status && WORKFLOW_ACTIVE_NODE_STATUSES.has(status));
+
+export const isWorkflowNodeSuccessful = (status?: string) =>
+  status === 'SUCCESS' || status === 'SUCCESS_WITH_WARNINGS';
+
+const timestamp = (value?: string) => {
+  if (!value) return undefined;
+  const parsed = new Date(value).getTime();
+  return Number.isFinite(parsed) ? parsed : undefined;
+};
+
+export const workflowNodeRuntimeState = (
+  node: WorkflowNodeInstance,
+): WorkflowNodeRuntimeState => {
+  const attempt = node.attempts[node.attempts.length - 1];
+  const startedAt = attempt?.startedAt;
+  const endedAt = attempt?.endedAt;
+  const startMillis = timestamp(startedAt);
+  const endMillis = timestamp(endedAt);
+
+  return {
+    status: node.status,
+    errorMessage: node.errorMessage || attempt?.errorMessage,
+    failureReason: node.failureReason || attempt?.failureReason,
+    attemptCount: node.attemptCount,
+    currentAttemptNumber: node.currentAttemptNumber,
+    startedAt,
+    endedAt,
+    elapsedMillis:
+      startMillis !== undefined && endMillis !== undefined
+        ? Math.max(0, endMillis - startMillis)
+        : undefined,
+  };
+};
+
+export const runtimeStatusLabel = (status?: string) => {
+  switch (status) {
+    case 'WAITING':
+    case 'READY':
+      return '等待中';
+    case 'SUBMITTED':
+      return '提交中';
+    case 'RUNNING':
+      return '运行中';
+    case 'PAUSING':
+      return '暂停中';
+    case 'PAUSED':
+      return '已暂停';
+    case 'RESUMING':
+      return '恢复中';
+    case 'SUCCESS':
+      return '成功';
+    case 'SUCCESS_WITH_WARNINGS':
+      return '完成';
+    case 'WARNING':
+      return '告警';
+    case 'FAILED':
+      return '失败';
+    case 'TIMED_OUT':
+      return '已超时';
+    case 'CANCELED':
+      return '已取消';
+    case 'SKIPPED':
+      return '已跳过';
+    default:
+      return status || '';
+  }
+};
+
+export const formatRuntimeDuration = (elapsedMillis?: number) => {
+  if (elapsedMillis === undefined) return undefined;
+  if (elapsedMillis < 1000) return `${elapsedMillis}ms`;
+  if (elapsedMillis < 60_000) return `${(elapsedMillis / 1000).toFixed(elapsedMillis < 10_000 ? 1 : 0)}s`;
+  const minutes = Math.floor(elapsedMillis / 60_000);
+  const seconds = Math.round((elapsedMillis % 60_000) / 1000);
+  return `${minutes}m ${seconds}s`;
+};

--- a/yak-ops-ui/src/pages/workflow/definition/canvas/start/WorkflowStartNode.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/start/WorkflowStartNode.tsx
@@ -1,4 +1,4 @@
-import { GitBranch, Variable } from 'lucide-react';
+import { CheckCircle2, GitBranch, LoaderCircle, Variable } from 'lucide-react';
 import type { NodeProps } from 'reactflow';
 import WorkflowNodeHandle from '../node/WorkflowNodeHandle';
 import type { WorkflowStartNodeData } from './types';
@@ -14,6 +14,8 @@ const TYPE_LABEL: Record<string, string> = {
 const WorkflowStartNode = ({ id, data, selected }: NodeProps<WorkflowStartNodeData>) => {
   const visibleInputs = data.inputs.slice(0, 3);
   const moreCount = Math.max(0, data.inputs.length - visibleInputs.length);
+  const running = data.runtimeStatus === 'RUNNING';
+  const succeeded = data.runtimeStatus === 'SUCCESS';
 
   return (
     <div className="group relative w-60">
@@ -21,11 +23,14 @@ const WorkflowStartNode = ({ id, data, selected }: NodeProps<WorkflowStartNodeDa
         className={[
           'relative overflow-hidden rounded-[15px] border bg-white',
           'shadow-[0_1px_2px_rgba(22,24,35,.06)]',
-          'transition-[border-color,box-shadow] duration-150',
-          'group-hover:shadow-[0_6px_18px_rgba(22,24,35,.10)]',
-          selected
-            ? 'border-[#fe2c55] shadow-[0_0_0_2px_rgba(254,44,85,.08)]'
-            : 'border-[#e8e9ec] group-hover:border-[#d7d9de]',
+          'transition-[border-color,box-shadow] duration-200',
+          running
+            ? 'border-[#fe2c55] shadow-[0_0_0_3px_rgba(254,44,85,.08)]'
+            : succeeded
+              ? 'border-[#12b76a] shadow-[0_0_0_2px_rgba(18,183,106,.07)]'
+              : selected
+                ? 'border-[#fe2c55] shadow-[0_0_0_2px_rgba(254,44,85,.08)]'
+                : 'border-[#e8e9ec] group-hover:border-[#d7d9de] group-hover:shadow-[0_6px_18px_rgba(22,24,35,.10)]',
         ].join(' ')}
       >
         <div className="flex min-h-9 items-center gap-2.5 px-3 py-3">
@@ -35,6 +40,17 @@ const WorkflowStartNode = ({ id, data, selected }: NodeProps<WorkflowStartNodeDa
           <div className="min-w-0 flex-1 truncate text-[14px] font-semibold leading-5 text-[#161823]">
             开始
           </div>
+          {running ? (
+            <span className="inline-flex h-6 items-center gap-1 rounded-md bg-[#fff1f3] px-1.5 text-[10px] font-medium text-[#d92d50]">
+              <LoaderCircle size={11} className="animate-spin" />
+              运行中
+            </span>
+          ) : succeeded ? (
+            <span className="inline-flex h-6 items-center gap-1 rounded-md bg-[#ecfdf3] px-1.5 text-[10px] font-medium text-[#067647]">
+              <CheckCircle2 size={11} />
+              成功
+            </span>
+          ) : null}
         </div>
 
         {visibleInputs.length ? (

--- a/yak-ops-ui/src/pages/workflow/definition/canvas/start/types.ts
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/start/types.ts
@@ -34,6 +34,8 @@ export interface WorkflowStartNodeData {
   label: string;
   locked?: boolean;
   inputs: WorkflowStartInputField[];
+  /** Start 是虚拟编辑器节点，该状态只由当前测试运行前端派生，不进入后端 DAG。 */
+  runtimeStatus?: 'RUNNING' | 'SUCCESS';
   appendOptions?: WorkflowCanvasTaskOption[];
   onAppend?: (nodeId: string, taskId: string) => void;
 }

--- a/yak-ops-ui/src/pages/workflow/definition/canvas/types.ts
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/types.ts
@@ -10,6 +10,21 @@ export interface WorkflowCanvasTaskOption {
   taskType?: string;
 }
 
+/**
+ * 测试运行时由 WorkflowInstance/SSE 派生的瞬时状态。
+ * 该对象只挂在 ReactFlow 渲染节点上，不进入草稿、Undo/Redo 或发布版本。
+ */
+export interface WorkflowNodeRuntimeState {
+  status: string;
+  errorMessage?: string;
+  failureReason?: string;
+  attemptCount: number;
+  currentAttemptNumber?: number;
+  startedAt?: string;
+  endedAt?: string;
+  elapsedMillis?: number;
+}
+
 export interface WorkflowNodeData {
   label: string;
   taskId: string;
@@ -22,6 +37,8 @@ export interface WorkflowNodeData {
   dispatchTimeoutSeconds: number;
   executionTimeoutSeconds: number;
   inputMappingText: string;
+  /** 仅用于画布实时运行态，不持久化。 */
+  runtime?: WorkflowNodeRuntimeState;
   locked?: boolean;
   appendOptions?: WorkflowCanvasTaskOption[];
   onAppend?: (nodeId: string, taskId: string) => void;
@@ -34,6 +51,8 @@ export type WorkflowEdgeInsertOption = WorkflowCanvasTaskOption;
 export interface WorkflowEdgeData {
   locked?: boolean;
   connectedNodeHovered?: boolean;
+  /** 目标节点实时运行状态，用于测试运行时高亮执行路径。 */
+  runtimeStatus?: string;
   insertOptions?: WorkflowCanvasTaskOption[];
   onInsert?: (
     edgeId: string,

--- a/yak-ops-ui/src/services/workflow/index.ts
+++ b/yak-ops-ui/src/services/workflow/index.ts
@@ -214,6 +214,7 @@ const openWorkflowEventSubscription = (
   subscription.closeActive?.();
   let activeClosed = false;
   let polling = false;
+  let fallbackTimer: number | undefined;
 
   const deliver = (snapshot: WorkflowInstance) => {
     if (activeClosed || subscription.stopped) return;
@@ -222,6 +223,30 @@ const openWorkflowEventSubscription = (
     subscription.lastSignature = signature;
     subscription.onSnapshot(snapshot);
     if (isWorkflowTerminal(snapshot.status)) cleanupActive();
+  };
+
+  const poll = async () => {
+    if (activeClosed || subscription.stopped || polling) return;
+    polling = true;
+    try {
+      deliver(await getWorkflowInstance(executionId));
+    } catch {
+      // SSE/代理异常时的兜底查询失败不打断编辑器。
+    } finally {
+      polling = false;
+    }
+  };
+
+  const stopFallbackPolling = () => {
+    if (fallbackTimer === undefined) return;
+    window.clearInterval(fallbackTimer);
+    fallbackTimer = undefined;
+  };
+
+  const startFallbackPolling = () => {
+    if (activeClosed || subscription.stopped || fallbackTimer !== undefined) return;
+    fallbackTimer = window.setInterval(() => void poll(), 1000);
+    void poll();
   };
 
   const source = new EventSource(`/api/v1/workflows/instances/${encodeURIComponent(executionId)}/events`);
@@ -233,30 +258,23 @@ const openWorkflowEventSubscription = (
     }
   };
   source.addEventListener('workflow', handleWorkflowEvent);
-
-  const poll = async () => {
-    if (activeClosed || subscription.stopped || polling) return;
-    polling = true;
-    try {
-      deliver(await getWorkflowInstance(executionId));
-    } catch {
-      // SSE 正常时不把兜底查询异常暴露给页面。
-    } finally {
-      polling = false;
-    }
+  source.onopen = () => stopFallbackPolling();
+  source.onerror = () => {
+    // EventSource 会自行重连；重连期间用低频 authenticated request 保证状态不会停住。
+    startFallbackPolling();
   };
-  const timer = window.setInterval(() => void poll(), 500);
 
   function cleanupActive() {
     if (activeClosed) return;
     activeClosed = true;
-    window.clearInterval(timer);
+    stopFallbackPolling();
     source.removeEventListener('workflow', handleWorkflowEvent);
     source.close();
     if (subscription.closeActive === cleanupActive) subscription.closeActive = undefined;
   }
 
   subscription.closeActive = cleanupActive;
+  // 首帧主动读取一次，随后以 SSE 为主；不会再在健康连接下每 500ms 打接口。
   void poll();
 };
 
@@ -267,7 +285,7 @@ function resumeWorkflowEventsIfNeeded(executionId: string, snapshot: WorkflowIns
   openWorkflowEventSubscription(executionId, subscription);
 }
 
-/** SSE 为主，500ms authenticated request 作为代理/认证链路下的状态同步兜底。 */
+/** SSE 为主；只有连接异常/重连期间才启用 1s 查询兜底。 */
 export const subscribeWorkflowEvents = (
   executionId: string,
   onSnapshot: (instance: WorkflowInstance) => void,


### PR DESCRIPTION
## Summary

This Draft PR completes the workflow editor test-run experience by wiring the existing workflow SSE runtime stream into the ReactFlow canvas, following the interaction model used by Dify.

The result is:

`保存草稿 -> 创建测试执行 -> SSE 实时快照 -> 节点/连线运行态 -> 终态结果`

## Dify reference analysis

I reviewed the workflow debug/run implementation in `weifuwan/dify` rather than copying only the visual style.

Dify's core pattern is:

1. the debug run uses a streaming response and dispatches workflow events such as `workflow_started`, `node_started`, `node_finished`, and `workflow_finished`;
2. `node_started` writes `NodeRunningStatus.Running` into the ReactFlow node and updates its incoming edge;
3. `node_finished` replaces the transient node status with the final status and updates tracing/output data;
4. the base node component renders running/success/failure/exception borders from that transient runtime status;
5. the viewport follows the currently running top-level node.

Yak Ops already had an important part of this architecture before this PR: `/api/v1/workflows/instances/{executionId}/events` and `WorkflowEventStreamService` already push a complete `WorkflowInstanceVO` whenever runtime state changes. The missing link was the workflow definition editor: `测试运行` created an execution but never subscribed to its stream or mapped node snapshots back to ReactFlow.

This PR therefore keeps Yak Ops' full-snapshot SSE contract instead of replacing it with Dify's discrete event contract. A new subscriber receives the current complete snapshot immediately, so even if a node starts between the test-run HTTP response and the SSE connection, the canvas does not lose the transition.

## 1. Live test-run state on ReactFlow nodes

`WorkflowDefinitionEditor` now subscribes to the execution returned by `test-run` and keeps `testing=true` until a terminal SSE snapshot arrives.

Each `WorkflowInstance.nodes[]` entry is mapped into transient canvas-only runtime state:

- WAITING / READY
- SUBMITTED
- RUNNING
- PAUSING / PAUSED / RESUMING
- SUCCESS
- FAILED
- UPSTREAM_FAILED
- SKIPPED / CANCELED

The runtime state is deliberately derived only for rendering. It is not written into draft payloads, editor metadata, Undo/Redo history, or WorkflowVersion snapshots.

During an active test run the editor structure is locked so node IDs/topology cannot drift away from the running execution.

## 2. Dify-style visual feedback

Task nodes now render an explicit runtime badge and state border:

- running: Yak brand accent + spinner
- success: success border
- failed/upstream failed: destructive border
- paused/warning: warning border
- skipped/canceled: neutral state

Final nodes also show elapsed time from the latest attempt and retry/attempt context. Failure text is available directly on the node tooltip/footer.

Incoming edges derive their color from the target node runtime state, which makes the currently executing path visible without introducing a second runtime store.

The editor-only Start node is not fabricated as a backend NodeExecution. Its display state is derived locally: it is running while the test request is being established and becomes successful after the first execution snapshot is available.

## 3. Follow the current running node

Like Dify's `node_started` behavior, the canvas gently centers the first newly running/submitted node. The same node is not repeatedly re-centered for duplicate snapshots.

## 4. SSE is now the primary transport instead of hot polling

The existing frontend subscriber previously opened SSE and still polled `/instances/{id}` every 500ms for the entire run.

Now:

- one immediate authenticated snapshot request is made when subscribing;
- healthy SSE is the primary transport;
- fallback polling starts only while EventSource reports an error/reconnect condition;
- fallback polling runs at 1s and stops again when SSE reconnects;
- snapshot signatures still deduplicate SSE/poll overlap.

This removes continuous 2 req/s polling per active workflow when the stream is healthy.

## 5. Backend SSE keepalive

`WorkflowEventStreamService` now sends a lightweight `ping` event every 15 seconds while clients are connected.

The business event contract remains unchanged: the frontend still consumes only `workflow` snapshots. The heartbeat exists only to keep long-running executions alive through proxies/load balancers during periods with no node state transition.

## Test-run lifecycle safeguards

While a test execution is active:

- the test button remains loading and reads `测试运行中`;
- canvas structure editing and history mutation are disabled;
- publish/save/offline lifecycle actions are disabled;
- the subscription is cleaned up on terminal state, a new run, or editor unmount;
- final node colors/results remain visible after completion until the next test run/reload.

## Regression coverage

Added focused Jest coverage for runtime snapshot mapping:

- latest attempt selection
- elapsed-time calculation
- active vs terminal node classification
- streamed status labels

The implementation also explicitly covers Yak Workflow's `UPSTREAM_FAILED` and `SKIPPED` synthetic terminal states.

## Scope

- no changes to `yak-framework` state machine or execution semantics
- no changes to Link-Up task protocol
- no new workflow persistence schema
- no second global frontend runtime store
- no change to the existing `workflow` SSE snapshot event contract

## Validation

The branch is based on current `main` after merged #285 and was 0 commits behind when this Draft PR was opened.

This environment does not have a local GitHub checkout/toolchain, so full `npm run tsc`, Jest, Maven tests, and repository CI still need to be treated as required before marking the PR ready.