### PR TITLE
fix(workflow): load node last run by execution id

### DIFF
--- a/yak-ops-ui/src/pages/workflow/definition/canvas/WorkflowNodeInspectorLastRun.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/WorkflowNodeInspectorLastRun.tsx
@@ -1,9 +1,9 @@
 import {
   getWorkflowInstance,
-  getWorkflowInstances,
   type WorkflowInstance,
   type WorkflowNodeInstance,
 } from '@/services/workflow';
+import { getWorkflowDefinition } from '@/services/workflow/definitions';
 import { Spin } from 'antd';
 import dayjs from 'dayjs';
 import { RefreshCw } from 'lucide-react';
@@ -90,18 +90,19 @@ const WorkflowNodeInspectorLastRun = ({
     setLoading(true);
     setLoadError('');
     try {
-      const instances = (await getWorkflowInstances()) || [];
-      const latest = instances
-        .filter((item) => item.definitionId === definitionId)
-        .sort((left, right) => dayjs(right.startedAt).valueOf() - dayjs(left.startedAt).valueOf())[0];
+      // Runtime 的 WorkflowInstance.definitionId 是每次执行临时注册给 Yak Workflow Engine 的 ID，
+      // 不能与业务 WorkflowDefinition.id 直接比较。业务定义已维护 latestExecutionId，
+      // 因此“上次运行”直接沿稳定的 execution 关联读取最近一次执行。
+      const definition = await getWorkflowDefinition(definitionId);
+      const latestExecutionId = definition.latestExecutionId;
 
-      if (!latest) {
+      if (!latestExecutionId) {
         setInstance(undefined);
         setNodeRun(undefined);
         return;
       }
 
-      const detail = await getWorkflowInstance(latest.id);
+      const detail = await getWorkflowInstance(latestExecutionId);
       setInstance(detail);
       setNodeRun(detail.nodes?.find((node) => node.id === nodeId));
     } catch (error) {


### PR DESCRIPTION
## Summary

Fix the workflow node inspector `上次运行` tab always showing `暂无运行记录` after successful test runs.

## Root cause

The inspector queried all workflow instances and filtered with:

```ts
instance.definitionId === workflowDefinitionId
```

Those IDs are different concepts:

- `WorkflowDefinition.id` is the Yak Ops business workflow definition ID.
- `WorkflowInstance.definitionId` is the temporary engine definition ID registered by `WorkflowRuntimeService` for that specific execution.

`WorkflowRuntimeService.run()` creates a new engine definition ID for every execution, so the old filter never matches the business definition ID.

## Fix

`WorkflowDefinitionVO` already exposes the stable `latestExecutionId` association maintained by `WorkflowDefinitionService.activate()`.

The node inspector now resolves the last run as:

```text
WorkflowDefinition.id
  -> WorkflowDefinition.latestExecutionId
  -> GET /api/v1/workflows/instances/{executionId}
  -> nodes.find(node.id === selectedNodeId)
```

This also removes the unnecessary `GET /api/v1/workflows/instances` list scan from the node inspector.

## Result

After a test or official workflow execution, opening a node and switching to `上次运行` now shows the latest execution's:

- node status
- elapsed time
- attempt count
- input
- output
- error/failure details
- start/end metadata

## Scope

One frontend file only. No engine, runtime, SSE, schema, or workflow execution semantics are changed.