### PR TITLE
fix(workflow): harden retry delay, cancel fencing and start idempotency

### DIFF
--- a/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/task/OfflineSyncTaskRunner.java
+++ b/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/task/OfflineSyncTaskRunner.java
@@ -27,6 +27,17 @@ public class OfflineSyncTaskRunner implements SyncTaskRunner {
 
   @Override
   public SyncTaskExecution start(TaskVersionSnapshot snapshot) {
+    return startSnapshot(snapshot, null);
+  }
+
+  @Override
+  public SyncTaskExecution start(TaskVersionSnapshot snapshot, String idempotencyKey) {
+    return startSnapshot(snapshot, idempotencyKey);
+  }
+
+  private SyncTaskExecution startSnapshot(
+      TaskVersionSnapshot snapshot,
+      String idempotencyKey) {
     if (snapshot == null) {
       throw new IllegalArgumentException("任务版本快照不能为空");
     }
@@ -37,14 +48,15 @@ public class OfflineSyncTaskRunner implements SyncTaskRunner {
         || snapshot.definitionSnapshotJson() == null
         || snapshot.executionConfigSnapshotJson() == null) {
       // 没有版本能力的兼容 TaskRegistry 仍走原执行入口。
-      return SyncTaskRunner.super.start(snapshot);
+      return start(snapshot.taskId());
     }
     OfflineJobExecutionVO execution = service().executeSnapshot(
         parseId(snapshot.taskId(), "taskId"),
         snapshot.version(),
         snapshot.configDigest(),
         snapshot.definitionSnapshotJson(),
-        snapshot.executionConfigSnapshotJson());
+        snapshot.executionConfigSnapshotJson(),
+        idempotencyKey);
     return toExecution(execution);
   }
 

--- a/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/task/SyncTaskRunner.java
+++ b/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/task/SyncTaskRunner.java
@@ -14,6 +14,16 @@ public interface SyncTaskRunner {
     return start(snapshot.taskId());
   }
 
+  /**
+   * 按工作流 Attempt 启动任务。
+   *
+   * <p>{@code idempotencyKey} 由工作流当前 attemptId 提供。支持远端幂等的 Runner 应覆盖该方法，
+   * 将同一个 Attempt 的重复启动请求收敛为同一次远端执行；旧 Runner 默认仍按快照启动。</p>
+   */
+  default SyncTaskExecution start(TaskVersionSnapshot snapshot, String idempotencyKey) {
+    return start(snapshot);
+  }
+
   SyncTaskExecution status(String executionId);
 
   void cancel(String executionId);

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineExecutionClaimService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineExecutionClaimService.java
@@ -53,7 +53,8 @@ public class OfflineExecutionClaimService {
         logicalJobSpec,
         triggerType,
         retryFromExecutionId,
-        attemptNo);
+        attemptNo,
+        null);
   }
 
   /**
@@ -70,6 +71,26 @@ public class OfflineExecutionClaimService {
       String definitionSnapshotJson,
       String logicalJobSpecJson,
       String triggerType) {
+    return claimSnapshot(
+        definitionId,
+        definitionVersion,
+        configDigest,
+        definitionSnapshotJson,
+        logicalJobSpecJson,
+        triggerType,
+        null);
+  }
+
+  /** 工作流 Attempt 级快照执行；idempotencyKey 通常直接使用 workflow attemptId。 */
+  @Transactional(transactionManager = "offlineSyncTransactionManager", rollbackFor = Exception.class)
+  public ClaimResult claimSnapshot(
+      Long definitionId,
+      long definitionVersion,
+      String configDigest,
+      String definitionSnapshotJson,
+      String logicalJobSpecJson,
+      String triggerType,
+      String idempotencyKey) {
     if (!StringUtils.hasText(logicalJobSpecJson)) {
       throw new IllegalArgumentException("任务版本快照缺少 JobSpec");
     }
@@ -83,7 +104,8 @@ public class OfflineExecutionClaimService {
         logicalJobSpecJson,
         triggerType,
         null,
-        1);
+        1,
+        idempotencyKey);
   }
 
   private ClaimResult createClaim(
@@ -94,7 +116,8 @@ public class OfflineExecutionClaimService {
       String logicalJobSpecJson,
       String triggerType,
       Long retryFromExecutionId,
-      int attemptNo) {
+      int attemptNo,
+      String idempotencyKey) {
     Long definitionId = definition.getId();
     if (repository.hasActiveExecution(definitionId)) {
       throw new IllegalStateException("任务已有运行中的执行实例，不能重复提交");
@@ -106,7 +129,10 @@ public class OfflineExecutionClaimService {
     execution.setDefinitionVersion((int) Math.min(Integer.MAX_VALUE, definitionVersion));
     execution.setEngineBaseUrl(properties.getEngine().getBaseUrl());
     execution.setExternalExecutionId("yak-offline-" + UUID.randomUUID());
-    execution.setIdempotencyKey(UUID.randomUUID().toString());
+    execution.setIdempotencyKey(
+        StringUtils.hasText(idempotencyKey)
+            ? idempotencyKey.trim()
+            : UUID.randomUUID().toString());
     execution.setStatus(OfflineExecutionStatus.CREATED.name());
     execution.setStateVersion(1L);
     execution.setAttemptNo(Math.max(1, attemptNo));

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineExecutionOrchestrator.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineExecutionOrchestrator.java
@@ -80,13 +80,31 @@ public class OfflineExecutionOrchestrator {
       String configDigest,
       String definitionSnapshotJson,
       String logicalJobSpecJson) {
+    return executeSnapshot(
+        definitionId,
+        definitionVersion,
+        configDigest,
+        definitionSnapshotJson,
+        logicalJobSpecJson,
+        null);
+  }
+
+  /** 按工作流版本快照和 Attempt 幂等键执行。 */
+  public OfflineJobExecutionPO executeSnapshot(
+      Long definitionId,
+      long definitionVersion,
+      String configDigest,
+      String definitionSnapshotJson,
+      String logicalJobSpecJson,
+      String idempotencyKey) {
     ClaimResult claim = claimService.claimSnapshot(
         definitionId,
         definitionVersion,
         configDigest,
         definitionSnapshotJson,
         logicalJobSpecJson,
-        "WORKFLOW");
+        "WORKFLOW",
+        idempotencyKey);
     return submitClaim(
         claim,
         definitionService.resolveExecutionJobSpec(claim.getLogicalJobSpecJson()));

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineJobExecutionService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineJobExecutionService.java
@@ -40,13 +40,31 @@ public class OfflineJobExecutionService {
       String configDigest,
       String definitionSnapshotJson,
       String logicalJobSpecJson) {
+    return executeSnapshot(
+        id,
+        version,
+        configDigest,
+        definitionSnapshotJson,
+        logicalJobSpecJson,
+        null);
+  }
+
+  /** 工作流按发布快照和 Attempt 幂等键执行。 */
+  public OfflineJobExecutionVO executeSnapshot(
+      Long id,
+      long version,
+      String configDigest,
+      String definitionSnapshotJson,
+      String logicalJobSpecJson,
+      String idempotencyKey) {
     return readService.toVO(
         orchestrator.executeSnapshot(
             id,
             version,
             configDigest,
             definitionSnapshotJson,
-            logicalJobSpecJson));
+            logicalJobSpecJson,
+            idempotencyKey));
   }
 
   public OfflineJobExecutionVO executeScheduled(Long id) {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/service/OfflineExecutionClaimServiceTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/service/OfflineExecutionClaimServiceTest.java
@@ -63,4 +63,33 @@ class OfflineExecutionClaimServiceTest {
     verify(repository).hasActiveExecution(10L);
     verify(executionDao).insert(result.getExecution());
   }
+
+  @Test
+  void shouldPersistWorkflowAttemptAsSnapshotIdempotencyKey() {
+    OfflineJobDefinitionPO definition = new OfflineJobDefinitionPO();
+    definition.setId(10L);
+
+    when(definitionService.require(10L)).thenReturn(definition);
+    when(executionDao.insert(any(OfflineJobExecutionPO.class)))
+        .thenAnswer(invocation -> {
+          OfflineJobExecutionPO execution = invocation.getArgument(0);
+          execution.setId(100L);
+          return true;
+        });
+
+    ClaimResult result = service.claimSnapshot(
+        10L,
+        3L,
+        "digest",
+        "{}",
+        "{\"job\":\"spec\"}",
+        "WORKFLOW",
+        "attempt-123");
+
+    assertThat(result.getExecution().getIdempotencyKey()).isEqualTo("attempt-123");
+    assertThat(result.getExecution().getTriggerType()).isEqualTo("WORKFLOW");
+    verify(repository).lockDefinition(10L);
+    verify(repository).hasActiveExecution(10L);
+    verify(executionDao).insert(result.getExecution());
+  }
 }

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowRuntimeService.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowRuntimeService.java
@@ -32,6 +32,7 @@ import io.yak.ops.business.workflow.model.WorkflowRunRequest.EdgeRequest;
 import io.yak.ops.business.workflow.model.WorkflowRunRequest.NodeRequest;
 import jakarta.annotation.PreDestroy;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -257,18 +258,39 @@ public class WorkflowRuntimeService {
     if (queue == null) return;
     NodeDispatch dispatch;
     while ((dispatch = queue.poll()) != null) {
-      NodeDispatch current = dispatch;
-      ioExecutor.execute(() -> startNode(current));
+      scheduleDispatch(dispatch);
     }
   }
 
+  private void scheduleDispatch(NodeDispatch dispatch) {
+    Instant availableAt = dispatch.availableAt();
+    long delayMillis = availableAt == null
+        ? 0L
+        : Math.max(0L, Duration.between(Instant.now(), availableAt).toMillis());
+    Runnable start = () -> ioExecutor.execute(() -> startNode(dispatch));
+    if (delayMillis <= 0L) {
+      start.run();
+      return;
+    }
+    runtimeScheduler.schedule(start, delayMillis, TimeUnit.MILLISECONDS);
+    log.debug(
+        "[workflow] delayed dispatch scheduled execution={}, node={}, attempt={}, delayMillis={}",
+        dispatch.workflowExecutionId(), dispatch.nodeId(), dispatch.attemptId(), delayMillis);
+  }
+
   private void startNode(NodeDispatch dispatch) {
-    NodeTaskControl control = taskControls.computeIfAbsent(dispatch.attemptId(), ignored -> new NodeTaskControl(dispatch.workflowExecutionId()));
+    NodeTaskControl control = taskControls.get(dispatch.attemptId());
+    if (control == null) {
+      log.debug(
+          "[workflow] stale queued dispatch skipped execution={}, node={}, attempt={}",
+          dispatch.workflowExecutionId(), dispatch.nodeId(), dispatch.attemptId());
+      return;
+    }
     if (control.canceled()) { cleanupAttempt(dispatch, control); return; }
     try {
       NodeMetadata node = requireMetadata(dispatch.workflowExecutionId()).nodes().get(dispatch.nodeId());
       if (node == null) throw new IllegalStateException("工作流节点运行元数据不存在：" + dispatch.nodeId());
-      SyncTaskExecution taskExecution = syncTaskRunner.start(node.task());
+      SyncTaskExecution taskExecution = syncTaskRunner.start(node.task(), dispatch.attemptId());
       control.bindTaskExecution(taskExecution.executionId());
       if (control.canceled()) {
         cancelRemote(taskExecution.executionId()); cleanupAttempt(dispatch, control); return;

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowRuntimeP0Test.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowRuntimeP0Test.java
@@ -1,0 +1,233 @@
+package io.yak.ops.business.workflow.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.yak.ops.business.job.task.SyncTaskExecution;
+import io.yak.ops.business.job.task.SyncTaskRunner;
+import io.yak.ops.business.job.task.TaskDefinition;
+import io.yak.ops.business.job.task.TaskRegistry;
+import io.yak.ops.business.job.task.TaskVersionSnapshot;
+import io.yak.ops.business.workflow.model.WorkflowInstanceVO;
+import io.yak.ops.business.workflow.model.WorkflowRunRequest;
+import io.yak.ops.business.workflow.model.WorkflowRunRequest.NodeRequest;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class WorkflowRuntimeP0Test {
+
+  private static final Set<String> TERMINAL = Set.of(
+      "SUCCESS", "SUCCESS_WITH_WARNINGS", "FAILED", "CANCELED", "TIMED_OUT");
+
+  private WorkflowRuntimeService service;
+
+  @AfterEach
+  void tearDown() {
+    if (service != null) {
+      service.shutdown();
+    }
+  }
+
+  @Test
+  void shouldHonorRetryDelayAndUseAttemptIdAsStartIdempotencyKey()
+      throws InterruptedException {
+    RecordingRunner runner = new RecordingRunner();
+    runner.failNext("task-a", 1);
+    service = service(runner, "task-a");
+
+    WorkflowRunRequest request = new WorkflowRunRequest(
+        "retry-delay",
+        List.of(new NodeRequest("a", "task-a", 2, 1L, 0L, 0L, Map.of())),
+        List.of(),
+        Map.of());
+
+    WorkflowInstanceVO started = service.run(request);
+    service.activate(started.id());
+
+    waitForStarts(runner, "task-a", 1);
+    Thread.sleep(200L);
+    assertThat(runner.started("task-a")).isEqualTo(1);
+
+    WorkflowInstanceVO completed = waitForTerminal(started.id(), 3_000L);
+    assertThat(completed.status()).isEqualTo("SUCCESS");
+    assertThat(runner.started("task-a")).isEqualTo(2);
+    assertThat(runner.startGapMillis("task-a")).isGreaterThanOrEqualTo(800L);
+
+    WorkflowInstanceVO.NodeInstanceVO node = node(completed, "a");
+    assertThat(runner.idempotencyKeys("task-a"))
+        .hasSize(2)
+        .doesNotHaveDuplicates()
+        .contains(node.currentAttemptId());
+  }
+
+  @Test
+  void shouldNotStartDelayedRetryAfterWorkflowWasCanceled()
+      throws InterruptedException {
+    RecordingRunner runner = new RecordingRunner();
+    runner.failNext("task-a", 1);
+    service = service(runner, "task-a");
+
+    WorkflowRunRequest request = new WorkflowRunRequest(
+        "cancel-delayed-retry",
+        List.of(new NodeRequest("a", "task-a", 2, 1L, 0L, 0L, Map.of())),
+        List.of(),
+        Map.of());
+
+    WorkflowInstanceVO started = service.run(request);
+    service.activate(started.id());
+    waitForAttemptCount(started.id(), "a", 2, 1_000L);
+
+    WorkflowInstanceVO canceled = service.cancel(started.id());
+    assertThat(canceled.status()).isEqualTo("CANCELED");
+
+    Thread.sleep(1_200L);
+    assertThat(runner.started("task-a")).isEqualTo(1);
+  }
+
+  private WorkflowRuntimeService service(RecordingRunner runner, String... taskIds) {
+    Map<String, TaskDefinition> tasks = new ConcurrentHashMap<>();
+    for (String taskId : taskIds) {
+      tasks.put(taskId, new TaskDefinition(taskId, taskId, "SYNC"));
+    }
+    TaskRegistry registry = new TaskRegistry() {
+      @Override
+      public List<TaskDefinition> list() {
+        return List.copyOf(tasks.values());
+      }
+
+      @Override
+      public TaskDefinition get(String taskId) {
+        TaskDefinition task = tasks.get(taskId);
+        if (task == null) {
+          throw new IllegalArgumentException("任务不存在：" + taskId);
+        }
+        return task;
+      }
+    };
+    return new WorkflowRuntimeService(
+        new WorkflowEventStreamService(), registry, runner, 2L);
+  }
+
+  private WorkflowInstanceVO waitForTerminal(String executionId, long timeoutMillis)
+      throws InterruptedException {
+    long deadline = System.nanoTime() + timeoutMillis * 1_000_000L;
+    while (System.nanoTime() < deadline) {
+      WorkflowInstanceVO current = service.getInstance(executionId);
+      if (TERMINAL.contains(current.status())) {
+        return current;
+      }
+      Thread.sleep(10L);
+    }
+    return service.getInstance(executionId);
+  }
+
+  private void waitForStarts(RecordingRunner runner, String taskId, int expected)
+      throws InterruptedException {
+    for (int i = 0; i < 100 && runner.started(taskId) < expected; i++) {
+      Thread.sleep(10L);
+    }
+  }
+
+  private void waitForAttemptCount(
+      String executionId,
+      String nodeId,
+      int expected,
+      long timeoutMillis) throws InterruptedException {
+    long deadline = System.nanoTime() + timeoutMillis * 1_000_000L;
+    while (System.nanoTime() < deadline) {
+      if (node(service.getInstance(executionId), nodeId).attemptCount() >= expected) {
+        return;
+      }
+      Thread.sleep(10L);
+    }
+  }
+
+  private WorkflowInstanceVO.NodeInstanceVO node(WorkflowInstanceVO instance, String id) {
+    return instance.nodes().stream()
+        .filter(item -> id.equals(item.id()))
+        .findFirst()
+        .orElseThrow();
+  }
+
+  private static final class RecordingRunner implements SyncTaskRunner {
+    private final AtomicLong sequence = new AtomicLong();
+    private final ConcurrentMap<String, AtomicInteger> failures = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, AtomicInteger> starts = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, ConcurrentLinkedQueue<Long>> startTimes = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, ConcurrentLinkedQueue<String>> idempotencyKeys = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, SyncTaskExecution> executions = new ConcurrentHashMap<>();
+
+    void failNext(String taskId, int count) {
+      failures.put(taskId, new AtomicInteger(count));
+    }
+
+    int started(String taskId) {
+      AtomicInteger value = starts.get(taskId);
+      return value == null ? 0 : value.get();
+    }
+
+    long startGapMillis(String taskId) {
+      Long[] values = startTimes.getOrDefault(taskId, new ConcurrentLinkedQueue<>())
+          .toArray(Long[]::new);
+      if (values.length < 2) {
+        return 0L;
+      }
+      return (values[1] - values[0]) / 1_000_000L;
+    }
+
+    List<String> idempotencyKeys(String taskId) {
+      return List.copyOf(
+          idempotencyKeys.getOrDefault(taskId, new ConcurrentLinkedQueue<>()));
+    }
+
+    @Override
+    public SyncTaskExecution start(String taskId) {
+      return startInternal(taskId);
+    }
+
+    @Override
+    public SyncTaskExecution start(TaskVersionSnapshot snapshot, String idempotencyKey) {
+      idempotencyKeys
+          .computeIfAbsent(snapshot.taskId(), ignored -> new ConcurrentLinkedQueue<>())
+          .offer(idempotencyKey);
+      return startInternal(snapshot.taskId());
+    }
+
+    private SyncTaskExecution startInternal(String taskId) {
+      starts.computeIfAbsent(taskId, ignored -> new AtomicInteger()).incrementAndGet();
+      startTimes.computeIfAbsent(taskId, ignored -> new ConcurrentLinkedQueue<>())
+          .offer(System.nanoTime());
+      AtomicInteger remaining = failures.computeIfAbsent(taskId, ignored -> new AtomicInteger());
+      boolean fail = remaining.getAndUpdate(value -> Math.max(0, value - 1)) > 0;
+      String executionId = String.valueOf(sequence.incrementAndGet());
+      SyncTaskExecution execution = new SyncTaskExecution(
+          executionId,
+          fail ? "FAILED" : "SUCCEEDED",
+          fail ? "planned failure" : null,
+          Map.of("taskId", taskId));
+      executions.put(executionId, execution);
+      return execution;
+    }
+
+    @Override
+    public SyncTaskExecution status(String executionId) {
+      SyncTaskExecution execution = executions.get(executionId);
+      if (execution == null) {
+        throw new IllegalArgumentException("execution not found: " + executionId);
+      }
+      return execution;
+    }
+
+    @Override
+    public void cancel(String executionId) {
+      // All test executions are terminal immediately; delayed retry cancellation is fenced before start.
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Close the three workflow runtime P0 gaps identified in the engine/runtime review without changing `yak-framework` workflow semantics.

### 1. Honor workflow retry delay in Yak Ops Runtime

`yak-workflow-engine` already puts the retry delay into `NodeDispatch.availableAt`, but Yak Ops previously drained every dispatch directly into the virtual-thread executor.

The runtime now schedules a dispatch against `availableAt` before invoking `startNode(...)`:

- first attempts still start immediately;
- retry attempts wait for their configured `retryDelaySeconds`;
- the engine stays scheduler-free; timing remains a Yak Ops host/runtime responsibility.

### 2. Fence queued starts after cancel / terminal cleanup

A delayed or already queued dispatch previously called `computeIfAbsent(...)` inside `startNode(...)`. If a workflow was canceled and terminal cleanup removed its control entry before that queued runnable executed, the runnable could recreate a fresh control and still start the remote task.

`startNode(...)` now only accepts an already-registered Attempt control:

- missing control means the Attempt has become stale and the queued start is ignored;
- canceled controls are cleaned up without starting the task;
- terminal cleanup therefore fences delayed retry starts instead of allowing them to recreate runtime state.

### 3. Reuse workflow `attemptId` as the remote start idempotency key

The existing offline-sync chain already persists an `idempotencyKey` and forwards it to Link-Up submission. The missing piece was connecting it to the workflow Attempt identity.

This PR adds a backward-compatible `SyncTaskRunner.start(snapshot, idempotencyKey)` overload and propagates:

`workflow attemptId -> SyncTaskRunner -> OfflineJobExecution -> Link-Up idempotencyKey`

Manual/scheduled sync executions keep their existing random idempotency keys. Versioned workflow SYNC execution uses the concrete workflow Attempt id, so duplicate delivery of the same Attempt maps to the same remote idempotency identity, while a retry receives a new Attempt id/key.

## Regression coverage

`WorkflowRuntimeP0Test` covers:

- configured retry delay is actually observed before the second remote start;
- retry Attempts use distinct idempotency keys and the current key matches the workflow `attemptId`;
- canceling while a retry is delayed prevents that queued retry from starting later.

`OfflineExecutionClaimServiceTest` additionally verifies that a supplied workflow Attempt id is persisted as the offline execution idempotency key.

## Scope

- `yak-ops-business-workflow` runtime only for dispatch timing/cancel fencing;
- `yak-ops-business-job` and offline-sync execution path only for Attempt idempotency propagation;
- no `yak-framework` changes;
- no schema changes;
- no workflow persistence/HA changes.

## Validation

- Branch is based on current `main` and is 0 commits behind.
- PR is mergeable and limited to 6 production files plus 2 focused test files.
- GitHub currently reports no configured commit statuses or workflow runs for this head SHA.
- The current execution environment does not provide a local `gh`/Maven checkout, so full Maven execution still needs to be treated as required before marking this PR ready.