### PR TITLE
feat(workflow): persist workflow state and recover after restart

### DIFF
--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineExecutionIdempotencyRepository.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineExecutionIdempotencyRepository.java
@@ -1,0 +1,36 @@
+package io.yak.ops.business.sync.offline.repository;
+
+import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import io.yak.ops.business.sync.offline.dao.OfflineJobExecutionDao;
+import io.yak.ops.common.bean.po.sync.offline.OfflineJobExecutionPO;
+import java.util.List;
+import java.util.Optional;
+import javax.sql.DataSource;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+/** Small lookup adapter used to make workflow Attempt submission locally idempotent. */
+@ConditionalOnOfflineSyncEnabled
+@Repository
+public class OfflineExecutionIdempotencyRepository {
+  private final JdbcTemplate jdbc;
+  private final OfflineJobExecutionDao executionDao;
+
+  public OfflineExecutionIdempotencyRepository(
+      @Qualifier("offlineSyncDataSource") DataSource dataSource,
+      OfflineJobExecutionDao executionDao) {
+    this.jdbc = new JdbcTemplate(dataSource);
+    this.executionDao = executionDao;
+  }
+
+  public Optional<OfflineJobExecutionPO> findByKey(String idempotencyKey) {
+    if (idempotencyKey == null || idempotencyKey.isBlank()) return Optional.empty();
+    List<Long> ids = jdbc.queryForList(
+        "SELECT id FROM yak_offline_job_execution WHERE idempotency_key=? LIMIT 1",
+        Long.class,
+        idempotencyKey.trim());
+    if (ids.isEmpty()) return Optional.empty();
+    return Optional.ofNullable(executionDao.selectById(ids.get(0)));
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineExecutionClaimService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineExecutionClaimService.java
@@ -201,6 +201,14 @@ public class OfflineExecutionClaimService {
     private final OfflineJobExecutionPO execution;
     private final boolean reused;
 
+    /** Backward-compatible constructor for existing callers that create fresh claims. */
+    public ClaimResult(
+        OfflineJobDefinitionPO definition,
+        String logicalJobSpecJson,
+        OfflineJobExecutionPO execution) {
+      this(definition, logicalJobSpecJson, execution, false);
+    }
+
     public ClaimResult(
         OfflineJobDefinitionPO definition,
         String logicalJobSpecJson,

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineExecutionClaimService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineExecutionClaimService.java
@@ -5,9 +5,11 @@ import io.yak.ops.business.sync.offline.config.OfflineSyncProperties;
 import io.yak.ops.business.sync.offline.dao.OfflineJobExecutionDao;
 import io.yak.ops.business.sync.offline.domain.OfflineExecutionStatus;
 import io.yak.ops.business.sync.offline.repository.OfflineExecutionControlRepository;
+import io.yak.ops.business.sync.offline.repository.OfflineExecutionIdempotencyRepository;
 import io.yak.ops.common.bean.po.sync.offline.OfflineJobDefinitionPO;
 import io.yak.ops.common.bean.po.sync.offline.OfflineJobExecutionPO;
 import java.time.LocalDateTime;
+import java.util.Objects;
 import java.util.UUID;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,16 +22,19 @@ public class OfflineExecutionClaimService {
   private final OfflineJobDefinitionService definitionService;
   private final OfflineJobExecutionDao executionDao;
   private final OfflineExecutionControlRepository repository;
+  private final OfflineExecutionIdempotencyRepository idempotencyRepository;
   private final OfflineSyncProperties properties;
 
   public OfflineExecutionClaimService(
       OfflineJobDefinitionService definitionService,
       OfflineJobExecutionDao executionDao,
       OfflineExecutionControlRepository repository,
+      OfflineExecutionIdempotencyRepository idempotencyRepository,
       OfflineSyncProperties properties) {
     this.definitionService = definitionService;
     this.executionDao = executionDao;
     this.repository = repository;
+    this.idempotencyRepository = idempotencyRepository;
     this.properties = properties;
   }
 
@@ -96,6 +101,20 @@ public class OfflineExecutionClaimService {
     }
     repository.lockDefinition(definitionId);
     OfflineJobDefinitionPO current = definitionService.require(definitionId);
+    String normalizedKey = StringUtils.hasText(idempotencyKey) ? idempotencyKey.trim() : null;
+    if (normalizedKey != null) {
+      OfflineJobExecutionPO existing = idempotencyRepository.findByKey(normalizedKey).orElse(null);
+      if (existing != null) {
+        validateIdempotentReuse(
+            existing,
+            definitionId,
+            definitionVersion,
+            configDigest,
+            definitionSnapshotJson,
+            logicalJobSpecJson);
+        return new ClaimResult(current, logicalJobSpecJson, existing, true);
+      }
+    }
     return createClaim(
         current,
         Math.max(1L, definitionVersion),
@@ -105,7 +124,7 @@ public class OfflineExecutionClaimService {
         triggerType,
         null,
         1,
-        idempotencyKey);
+        normalizedKey);
   }
 
   private ClaimResult createClaim(
@@ -154,21 +173,43 @@ public class OfflineExecutionClaimService {
     if (!executionDao.insert(execution) || execution.getId() == null) {
       throw new IllegalStateException("创建离线同步执行实例失败");
     }
-    return new ClaimResult(definition, logicalJobSpecJson, execution);
+    return new ClaimResult(definition, logicalJobSpecJson, execution, false);
+  }
+
+  private void validateIdempotentReuse(
+      OfflineJobExecutionPO existing,
+      Long definitionId,
+      long definitionVersion,
+      String configDigest,
+      String definitionSnapshotJson,
+      String logicalJobSpecJson) {
+    int version = (int) Math.min(Integer.MAX_VALUE, Math.max(1L, definitionVersion));
+    boolean same = Objects.equals(existing.getJobDefinitionId(), definitionId)
+        && Objects.equals(existing.getDefinitionVersion(), version)
+        && Objects.equals(existing.getConfigDigest(), configDigest)
+        && Objects.equals(existing.getDefinitionSnapshotJson(), definitionSnapshotJson)
+        && Objects.equals(existing.getSubmittedConfig(), logicalJobSpecJson);
+    if (!same) {
+      throw new IllegalStateException(
+          "幂等键已被不同任务执行占用：" + existing.getIdempotencyKey());
+    }
   }
 
   public static final class ClaimResult {
     private final OfflineJobDefinitionPO definition;
     private final String logicalJobSpecJson;
     private final OfflineJobExecutionPO execution;
+    private final boolean reused;
 
     public ClaimResult(
         OfflineJobDefinitionPO definition,
         String logicalJobSpecJson,
-        OfflineJobExecutionPO execution) {
+        OfflineJobExecutionPO execution,
+        boolean reused) {
       this.definition = definition;
       this.logicalJobSpecJson = logicalJobSpecJson;
       this.execution = execution;
+      this.reused = reused;
     }
 
     public OfflineJobDefinitionPO getDefinition() {
@@ -181,6 +222,10 @@ public class OfflineExecutionClaimService {
 
     public OfflineJobExecutionPO getExecution() {
       return execution;
+    }
+
+    public boolean isReused() {
+      return reused;
     }
   }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/resources/db/migration/yak-offline-sync/V3__execution_idempotency_constraint.sql
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/resources/db/migration/yak-offline-sync/V3__execution_idempotency_constraint.sql
@@ -1,2 +1,0 @@
-ALTER TABLE yak_offline_job_execution
-    ADD UNIQUE KEY uk_yak_offline_execution_idempotency (idempotency_key);

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/resources/db/migration/yak-offline-sync/V3__execution_idempotency_constraint.sql
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/resources/db/migration/yak-offline-sync/V3__execution_idempotency_constraint.sql
@@ -1,0 +1,2 @@
+ALTER TABLE yak_offline_job_execution
+    ADD UNIQUE KEY uk_yak_offline_execution_idempotency (idempotency_key);

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/service/OfflineExecutionClaimServiceTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/service/OfflineExecutionClaimServiceTest.java
@@ -2,15 +2,18 @@ package io.yak.ops.business.sync.offline.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.yak.ops.business.sync.offline.config.OfflineSyncProperties;
 import io.yak.ops.business.sync.offline.dao.OfflineJobExecutionDao;
 import io.yak.ops.business.sync.offline.repository.OfflineExecutionControlRepository;
+import io.yak.ops.business.sync.offline.repository.OfflineExecutionIdempotencyRepository;
 import io.yak.ops.business.sync.offline.service.OfflineExecutionClaimService.ClaimResult;
 import io.yak.ops.common.bean.po.sync.offline.OfflineJobDefinitionPO;
 import io.yak.ops.common.bean.po.sync.offline.OfflineJobExecutionPO;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -23,6 +26,7 @@ class OfflineExecutionClaimServiceTest {
   @Mock private OfflineJobDefinitionService definitionService;
   @Mock private OfflineJobExecutionDao executionDao;
   @Mock private OfflineExecutionControlRepository repository;
+  @Mock private OfflineExecutionIdempotencyRepository idempotencyRepository;
 
   private OfflineExecutionClaimService service;
 
@@ -32,6 +36,7 @@ class OfflineExecutionClaimServiceTest {
         definitionService,
         executionDao,
         repository,
+        idempotencyRepository,
         new OfflineSyncProperties());
   }
 
@@ -70,6 +75,7 @@ class OfflineExecutionClaimServiceTest {
     definition.setId(10L);
 
     when(definitionService.require(10L)).thenReturn(definition);
+    when(idempotencyRepository.findByKey("attempt-123")).thenReturn(Optional.empty());
     when(executionDao.insert(any(OfflineJobExecutionPO.class)))
         .thenAnswer(invocation -> {
           OfflineJobExecutionPO execution = invocation.getArgument(0);
@@ -88,8 +94,43 @@ class OfflineExecutionClaimServiceTest {
 
     assertThat(result.getExecution().getIdempotencyKey()).isEqualTo("attempt-123");
     assertThat(result.getExecution().getTriggerType()).isEqualTo("WORKFLOW");
+    assertThat(result.isReused()).isFalse();
     verify(repository).lockDefinition(10L);
     verify(repository).hasActiveExecution(10L);
     verify(executionDao).insert(result.getExecution());
+  }
+
+  @Test
+  void shouldReuseSameWorkflowAttemptInsteadOfCreatingAnotherOfflineExecution() {
+    OfflineJobDefinitionPO definition = new OfflineJobDefinitionPO();
+    definition.setId(10L);
+    when(definitionService.require(10L)).thenReturn(definition);
+
+    OfflineJobExecutionPO existing = new OfflineJobExecutionPO();
+    existing.setId(101L);
+    existing.setJobDefinitionId(10L);
+    existing.setDefinitionVersion(3);
+    existing.setConfigDigest("digest");
+    existing.setDefinitionSnapshotJson("{}");
+    existing.setSubmittedConfig("{\"job\":\"spec\"}");
+    existing.setIdempotencyKey("attempt-123");
+    existing.setStatus("SUBMITTED");
+    when(idempotencyRepository.findByKey("attempt-123"))
+        .thenReturn(Optional.of(existing));
+
+    ClaimResult result = service.claimSnapshot(
+        10L,
+        3L,
+        "digest",
+        "{}",
+        "{\"job\":\"spec\"}",
+        "WORKFLOW",
+        "attempt-123");
+
+    assertThat(result.getExecution()).isSameAs(existing);
+    assertThat(result.isReused()).isTrue();
+    verify(repository).lockDefinition(10L);
+    verify(repository, never()).hasActiveExecution(10L);
+    verify(executionDao, never()).insert(any(OfflineJobExecutionPO.class));
   }
 }

--- a/yak-ops-business/yak-ops-business-workflow/pom.xml
+++ b/yak-ops-business/yak-ops-business-workflow/pom.xml
@@ -14,7 +14,7 @@
     <artifactId>yak-ops-business-workflow</artifactId>
 
     <name>Yak Ops Business Workflow</name>
-    <description>In-memory workflow integration backed by Yak Framework workflow engine</description>
+    <description>Durable workflow definition, execution and recovery integration backed by Yak Framework</description>
 
     <dependencies>
         <dependency>
@@ -24,6 +24,10 @@
         <dependency>
             <groupId>io.yak.ops</groupId>
             <artifactId>yak-ops-business-job</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.yak.ops</groupId>
+            <artifactId>yak-ops-business-datasource</artifactId>
         </dependency>
         <dependency>
             <groupId>io.yak.framework</groupId>
@@ -36,6 +40,18 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-jdbc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-mysql</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springdoc</groupId>

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/persistence/InMemoryWorkflowRuntimePersistence.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/persistence/InMemoryWorkflowRuntimePersistence.java
@@ -1,0 +1,67 @@
+package io.yak.ops.business.workflow.persistence;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.ConcurrentMap;
+
+/** In-process fallback used by focused runtime tests and database-disabled development. */
+public final class InMemoryWorkflowRuntimePersistence implements WorkflowRuntimePersistence {
+
+  private final ConcurrentMap<String, RuntimeMetadataRecord> metadata = new ConcurrentHashMap<>();
+  private final ConcurrentMap<String, String> externalExecutions = new ConcurrentHashMap<>();
+  private final ConcurrentMap<String, String> executionStatuses = new ConcurrentHashMap<>();
+  private final ConcurrentLinkedDeque<String> executionOrder = new ConcurrentLinkedDeque<>();
+
+  @Override
+  public void saveMetadata(String executionId, RuntimeMetadataRecord value) {
+    metadata.put(executionId, value);
+    executionOrder.remove(executionId);
+    executionOrder.addFirst(executionId);
+  }
+
+  public void markExecutionStatus(String executionId, String status) {
+    if (status != null) executionStatuses.put(executionId, status);
+  }
+
+  @Override
+  public Optional<RuntimeMetadataRecord> findMetadata(String executionId) {
+    return Optional.ofNullable(metadata.get(executionId));
+  }
+
+  @Override
+  public List<String> listExecutionIds() {
+    return List.copyOf(executionOrder);
+  }
+
+  @Override
+  public List<String> findRecoverableExecutionIds() {
+    List<String> result = new ArrayList<>();
+    for (String id : executionOrder) {
+      String status = executionStatuses.get(id);
+      if (status == null
+          || "CREATED".equals(status)
+          || "RUNNING".equals(status)
+          || "PAUSING".equals(status)
+          || "PAUSED".equals(status)
+          || "RESUMING".equals(status)) {
+        result.add(id);
+      }
+    }
+    return List.copyOf(result);
+  }
+
+  @Override
+  public void bindExternalExecution(String attemptId, String externalExecutionId) {
+    if (attemptId != null && externalExecutionId != null) {
+      externalExecutions.put(attemptId, externalExecutionId);
+    }
+  }
+
+  @Override
+  public Optional<String> findExternalExecution(String attemptId) {
+    return Optional.ofNullable(externalExecutions.get(attemptId));
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/persistence/InMemoryWorkflowRuntimePersistence.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/persistence/InMemoryWorkflowRuntimePersistence.java
@@ -10,10 +10,23 @@ import java.util.concurrent.ConcurrentMap;
 /** In-process fallback used by focused runtime tests and database-disabled development. */
 public final class InMemoryWorkflowRuntimePersistence implements WorkflowRuntimePersistence {
 
+  private final ConcurrentMap<String, RuntimeMetadataRecord> definitionMetadata =
+      new ConcurrentHashMap<>();
   private final ConcurrentMap<String, RuntimeMetadataRecord> metadata = new ConcurrentHashMap<>();
+  private final ConcurrentMap<String, String> executionDefinitions = new ConcurrentHashMap<>();
   private final ConcurrentMap<String, String> externalExecutions = new ConcurrentHashMap<>();
   private final ConcurrentMap<String, String> executionStatuses = new ConcurrentHashMap<>();
   private final ConcurrentLinkedDeque<String> executionOrder = new ConcurrentLinkedDeque<>();
+
+  @Override
+  public void prepareMetadata(String definitionId, RuntimeMetadataRecord value) {
+    definitionMetadata.put(definitionId, value);
+  }
+
+  /** Test/runtime helper to associate an execution with its durable engine definition. */
+  public void bindDefinition(String executionId, String definitionId) {
+    executionDefinitions.put(executionId, definitionId);
+  }
 
   @Override
   public void saveMetadata(String executionId, RuntimeMetadataRecord value) {
@@ -28,7 +41,12 @@ public final class InMemoryWorkflowRuntimePersistence implements WorkflowRuntime
 
   @Override
   public Optional<RuntimeMetadataRecord> findMetadata(String executionId) {
-    return Optional.ofNullable(metadata.get(executionId));
+    RuntimeMetadataRecord direct = metadata.get(executionId);
+    if (direct != null) return Optional.of(direct);
+    String definitionId = executionDefinitions.get(executionId);
+    return definitionId == null
+        ? Optional.empty()
+        : Optional.ofNullable(definitionMetadata.get(definitionId));
   }
 
   @Override

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/persistence/JdbcWorkflowCatalogRepository.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/persistence/JdbcWorkflowCatalogRepository.java
@@ -1,0 +1,212 @@
+package io.yak.ops.business.workflow.persistence;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.job.task.TaskVersionSnapshot;
+import io.yak.ops.business.workflow.model.WorkflowDefinitionUpdateRequest.EdgeRequest;
+import io.yak.ops.business.workflow.model.WorkflowDefinitionUpdateRequest.NodeRequest;
+import io.yak.ops.business.workflow.model.WorkflowRunRequest;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import javax.sql.DataSource;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+/** JDBC catalog for editable workflow definitions and immutable published versions. */
+@Repository
+@DependsOn("workflowFlyway")
+@ConditionalOnProperty(
+    prefix = "yak.database",
+    name = "enabled",
+    havingValue = "true",
+    matchIfMissing = true)
+public class JdbcWorkflowCatalogRepository implements WorkflowDefinitionPersistence {
+
+  private static final TypeReference<Map<String, TaskVersionSnapshot>> TASK_VERSIONS =
+      new TypeReference<>() { };
+
+  private final JdbcTemplate jdbc;
+  private final ObjectMapper objectMapper;
+
+  public JdbcWorkflowCatalogRepository(
+      @Qualifier("yakBusinessDataSource") DataSource dataSource,
+      ObjectMapper objectMapper) {
+    this.jdbc = new JdbcTemplate(dataSource);
+    this.objectMapper = objectMapper;
+  }
+
+  @Override
+  public List<DefinitionRecord> loadDefinitions() {
+    return jdbc.query(
+        "SELECT * FROM yak_workflow_definition ORDER BY update_time DESC",
+        this::mapDefinition);
+  }
+
+  @Override
+  public List<VersionRecord> loadVersions(String workflowId) {
+    return jdbc.query(
+        "SELECT * FROM yak_workflow_version "
+            + "WHERE workflow_id=? AND version_kind='PUBLISHED' ORDER BY version_no",
+        this::mapVersion,
+        workflowId);
+  }
+
+  @Override
+  public void saveDefinition(DefinitionRecord definition) {
+    DraftPayload payload = new DraftPayload(
+        definition.failureStrategy(),
+        definition.nodes(),
+        definition.edges(),
+        definition.input(),
+        definition.editorMeta(),
+        definition.workflowTimeoutSeconds());
+    jdbc.update(
+        "INSERT INTO yak_workflow_definition "
+            + "(id,name,description,status,draft_revision,latest_version_no,active_version_id,"
+            + "draft_json,latest_execution_id,latest_execution_status,create_time,update_time) "
+            + "VALUES (?,?,?,?,?,?,?,?,?,?,?,?) "
+            + "ON DUPLICATE KEY UPDATE name=VALUES(name),description=VALUES(description),"
+            + "status=VALUES(status),draft_revision=VALUES(draft_revision),"
+            + "latest_version_no=VALUES(latest_version_no),active_version_id=VALUES(active_version_id),"
+            + "draft_json=VALUES(draft_json),latest_execution_id=VALUES(latest_execution_id),"
+            + "latest_execution_status=VALUES(latest_execution_status),update_time=VALUES(update_time)",
+        definition.id(),
+        definition.name(),
+        definition.description(),
+        definition.status(),
+        definition.draftRevision(),
+        definition.latestVersionNo(),
+        definition.activeVersionId(),
+        write(payload),
+        definition.latestExecutionId(),
+        definition.latestExecutionStatus(),
+        timestamp(definition.createTime()),
+        timestamp(definition.updateTime()));
+  }
+
+  @Override
+  public void saveVersion(VersionRecord version) {
+    jdbc.update(
+        "INSERT INTO yak_workflow_version "
+            + "(id,workflow_id,version_no,version_kind,draft_revision,run_request_json,"
+            + "editor_meta_json,task_versions_json,create_time) VALUES (?,?,?,?,?,?,?,?,?)",
+        version.id(),
+        version.workflowId(),
+        version.versionNo(),
+        "PUBLISHED",
+        version.draftRevision(),
+        write(version.runRequest()),
+        write(version.editorMeta()),
+        write(version.taskVersionsByNode()),
+        timestamp(version.publishedAt()));
+  }
+
+  @Override
+  public void deleteDefinition(String workflowId) {
+    // Published versions are intentionally retained because historical executions still reference them.
+    jdbc.update("DELETE FROM yak_workflow_definition WHERE id=?", workflowId);
+  }
+
+  private DefinitionRecord mapDefinition(ResultSet rs, int row) throws SQLException {
+    DraftPayload draft = read(rs.getString("draft_json"), DraftPayload.class);
+    return new DefinitionRecord(
+        rs.getString("id"),
+        rs.getString("name"),
+        rs.getString("description"),
+        rs.getString("status"),
+        draft.failureStrategy(),
+        draft.nodes(),
+        draft.edges(),
+        draft.input(),
+        draft.editorMeta(),
+        draft.workflowTimeoutSeconds(),
+        rs.getLong("draft_revision"),
+        rs.getInt("latest_version_no"),
+        rs.getString("active_version_id"),
+        rs.getString("latest_execution_id"),
+        rs.getString("latest_execution_status"),
+        instant(rs.getTimestamp("create_time")),
+        instant(rs.getTimestamp("update_time")));
+  }
+
+  private VersionRecord mapVersion(ResultSet rs, int row) throws SQLException {
+    return new VersionRecord(
+        rs.getString("id"),
+        rs.getString("workflow_id"),
+        rs.getInt("version_no"),
+        rs.getLong("draft_revision"),
+        read(rs.getString("run_request_json"), WorkflowRunRequest.class),
+        readMap(rs.getString("editor_meta_json")),
+        readTaskVersions(rs.getString("task_versions_json")),
+        instant(rs.getTimestamp("create_time")));
+  }
+
+  private String write(Object value) {
+    try {
+      return objectMapper.writeValueAsString(value == null ? Map.of() : value);
+    } catch (JsonProcessingException exception) {
+      throw new IllegalStateException("序列化工作流持久化快照失败", exception);
+    }
+  }
+
+  private <T> T read(String json, Class<T> type) {
+    try {
+      return objectMapper.readValue(json, type);
+    } catch (JsonProcessingException exception) {
+      throw new IllegalStateException("读取工作流持久化快照失败", exception);
+    }
+  }
+
+  private Map<String, Object> readMap(String json) {
+    if (json == null || json.isBlank()) return Map.of();
+    try {
+      return objectMapper.readValue(json, new TypeReference<Map<String, Object>>() { });
+    } catch (JsonProcessingException exception) {
+      throw new IllegalStateException("读取工作流 JSON Map 失败", exception);
+    }
+  }
+
+  private Map<String, TaskVersionSnapshot> readTaskVersions(String json) {
+    if (json == null || json.isBlank()) return Map.of();
+    try {
+      return objectMapper.readValue(json, TASK_VERSIONS);
+    } catch (JsonProcessingException exception) {
+      throw new IllegalStateException("读取工作流任务版本快照失败", exception);
+    }
+  }
+
+  private Timestamp timestamp(Instant instant) {
+    return instant == null ? null : Timestamp.from(instant);
+  }
+
+  private Instant instant(Timestamp timestamp) {
+    return timestamp == null ? null : timestamp.toInstant();
+  }
+
+  private record DraftPayload(
+      String failureStrategy,
+      List<NodeRequest> nodes,
+      List<EdgeRequest> edges,
+      Map<String, Object> input,
+      Map<String, Object> editorMeta,
+      long workflowTimeoutSeconds) {
+
+    private DraftPayload {
+      nodes = nodes == null ? List.of() : List.copyOf(nodes);
+      edges = edges == null ? List.of() : List.copyOf(edges);
+      input = input == null ? Map.of() : Map.copyOf(input);
+      editorMeta = editorMeta == null ? Map.of() : Map.copyOf(editorMeta);
+      failureStrategy = failureStrategy == null || failureStrategy.isBlank()
+          ? "CONTINUE_INDEPENDENT_BRANCHES"
+          : failureStrategy;
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/persistence/JdbcWorkflowCatalogRepository.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/persistence/JdbcWorkflowCatalogRepository.java
@@ -19,6 +19,8 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.DependsOn;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
 
 /** JDBC catalog for editable workflow definitions and immutable published versions. */
 @Repository
@@ -35,12 +37,15 @@ public class JdbcWorkflowCatalogRepository implements WorkflowDefinitionPersiste
 
   private final JdbcTemplate jdbc;
   private final ObjectMapper objectMapper;
+  private final TransactionTemplate transaction;
 
   public JdbcWorkflowCatalogRepository(
       @Qualifier("yakBusinessDataSource") DataSource dataSource,
+      @Qualifier("yakBusinessTransactionManager") PlatformTransactionManager transactionManager,
       ObjectMapper objectMapper) {
     this.jdbc = new JdbcTemplate(dataSource);
     this.objectMapper = objectMapper;
+    this.transaction = new TransactionTemplate(transactionManager);
   }
 
   @Override
@@ -61,6 +66,24 @@ public class JdbcWorkflowCatalogRepository implements WorkflowDefinitionPersiste
 
   @Override
   public void saveDefinition(DefinitionRecord definition) {
+    upsertDefinition(definition);
+  }
+
+  @Override
+  public void publish(DefinitionRecord definition, VersionRecord version) {
+    transaction.executeWithoutResult(status -> {
+      insertVersion(version);
+      upsertDefinition(definition);
+    });
+  }
+
+  @Override
+  public void deleteDefinition(String workflowId) {
+    // Published versions are intentionally retained because historical executions still reference them.
+    jdbc.update("DELETE FROM yak_workflow_definition WHERE id=?", workflowId);
+  }
+
+  private void upsertDefinition(DefinitionRecord definition) {
     DraftPayload payload = new DraftPayload(
         definition.failureStrategy(),
         definition.nodes(),
@@ -92,8 +115,7 @@ public class JdbcWorkflowCatalogRepository implements WorkflowDefinitionPersiste
         timestamp(definition.updateTime()));
   }
 
-  @Override
-  public void saveVersion(VersionRecord version) {
+  private void insertVersion(VersionRecord version) {
     jdbc.update(
         "INSERT INTO yak_workflow_version "
             + "(id,workflow_id,version_no,version_kind,draft_revision,run_request_json,"
@@ -107,12 +129,6 @@ public class JdbcWorkflowCatalogRepository implements WorkflowDefinitionPersiste
         write(version.editorMeta()),
         write(version.taskVersionsByNode()),
         timestamp(version.publishedAt()));
-  }
-
-  @Override
-  public void deleteDefinition(String workflowId) {
-    // Published versions are intentionally retained because historical executions still reference them.
-    jdbc.update("DELETE FROM yak_workflow_definition WHERE id=?", workflowId);
   }
 
   private DefinitionRecord mapDefinition(ResultSet rs, int row) throws SQLException {

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/persistence/JdbcWorkflowEngineDefinitionRepository.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/persistence/JdbcWorkflowEngineDefinitionRepository.java
@@ -1,0 +1,181 @@
+package io.yak.ops.business.workflow.persistence;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.framework.workflow.engine.definition.EdgeDefinition;
+import io.yak.framework.workflow.engine.definition.NodeDefinition;
+import io.yak.framework.workflow.engine.definition.NodeFailurePolicy;
+import io.yak.framework.workflow.engine.definition.NodeInputMapping;
+import io.yak.framework.workflow.engine.definition.NodeTimeoutPolicy;
+import io.yak.framework.workflow.engine.definition.RetryPolicy;
+import io.yak.framework.workflow.engine.definition.TriggerRule;
+import io.yak.framework.workflow.engine.definition.WorkflowDefinition;
+import io.yak.framework.workflow.engine.definition.WorkflowFailureStrategy;
+import io.yak.framework.workflow.engine.definition.WorkflowTimeoutPolicy;
+import io.yak.framework.workflow.engine.spi.WorkflowDefinitionRepository;
+import java.sql.Timestamp;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import javax.sql.DataSource;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+/** Database-backed Yak Framework definition repository using immutable workflow-version rows. */
+@Repository
+@DependsOn("workflowFlyway")
+@ConditionalOnProperty(
+    prefix = "yak.database",
+    name = "enabled",
+    havingValue = "true",
+    matchIfMissing = true)
+public class JdbcWorkflowEngineDefinitionRepository implements WorkflowDefinitionRepository {
+
+  private final JdbcTemplate jdbc;
+  private final ObjectMapper objectMapper;
+
+  public JdbcWorkflowEngineDefinitionRepository(
+      @Qualifier("yakBusinessDataSource") DataSource dataSource,
+      ObjectMapper objectMapper) {
+    this.jdbc = new JdbcTemplate(dataSource);
+    this.objectMapper = objectMapper;
+  }
+
+  @Override
+  public void save(WorkflowDefinition definition) {
+    String json = write(EngineDefinitionSnapshot.from(definition));
+    int updated = jdbc.update(
+        "UPDATE yak_workflow_version SET engine_definition_json=? WHERE id=?",
+        json,
+        definition.id());
+    if (updated == 0) {
+      jdbc.update(
+          "INSERT INTO yak_workflow_version "
+              + "(id,workflow_id,version_no,version_kind,draft_revision,engine_definition_json,create_time) "
+              + "VALUES (?,NULL,NULL,'RUNTIME',NULL,?,?)",
+          definition.id(),
+          json,
+          Timestamp.from(Instant.now()));
+    }
+  }
+
+  @Override
+  public Optional<WorkflowDefinition> findById(String definitionId) {
+    try {
+      String json = jdbc.queryForObject(
+          "SELECT engine_definition_json FROM yak_workflow_version WHERE id=?",
+          String.class,
+          definitionId);
+      if (json == null || json.isBlank()) return Optional.empty();
+      return Optional.of(read(json).toDefinition());
+    } catch (EmptyResultDataAccessException ignored) {
+      return Optional.empty();
+    }
+  }
+
+  private String write(EngineDefinitionSnapshot snapshot) {
+    try {
+      return objectMapper.writeValueAsString(snapshot);
+    } catch (JsonProcessingException exception) {
+      throw new IllegalStateException("序列化 Engine Definition 失败", exception);
+    }
+  }
+
+  private EngineDefinitionSnapshot read(String json) {
+    try {
+      return objectMapper.readValue(json, EngineDefinitionSnapshot.class);
+    } catch (JsonProcessingException exception) {
+      throw new IllegalStateException("读取 Engine Definition 失败", exception);
+    }
+  }
+
+  private record EngineDefinitionSnapshot(
+      String id,
+      String name,
+      String failureStrategy,
+      long workflowTimeoutMillis,
+      List<NodeSnapshot> nodes,
+      List<EdgeSnapshot> edges) {
+
+    static EngineDefinitionSnapshot from(WorkflowDefinition definition) {
+      return new EngineDefinitionSnapshot(
+          definition.id(),
+          definition.name(),
+          definition.failureStrategy().name(),
+          definition.timeoutPolicy().timeout().toMillis(),
+          definition.nodes().values().stream().map(NodeSnapshot::from).toList(),
+          definition.edges().stream().map(EdgeSnapshot::from).toList());
+    }
+
+    WorkflowDefinition toDefinition() {
+      return new WorkflowDefinition(
+          id,
+          name,
+          WorkflowFailureStrategy.valueOf(failureStrategy),
+          workflowTimeoutMillis > 0L
+              ? WorkflowTimeoutPolicy.of(Duration.ofMillis(workflowTimeoutMillis))
+              : WorkflowTimeoutPolicy.none(),
+          nodes.stream().map(NodeSnapshot::toDefinition).toList(),
+          edges.stream().map(EdgeSnapshot::toDefinition).toList());
+    }
+  }
+
+  private record NodeSnapshot(
+      String id,
+      String name,
+      String triggerRule,
+      int maxAttempts,
+      long retryDelayMillis,
+      String failurePolicy,
+      long dispatchTimeoutMillis,
+      long executionTimeoutMillis,
+      Map<String, String> inputMapping,
+      Map<String, Object> configuration) {
+
+    static NodeSnapshot from(NodeDefinition node) {
+      return new NodeSnapshot(
+          node.id(),
+          node.name(),
+          node.triggerRule().name(),
+          node.retryPolicy().maxAttempts(),
+          node.retryPolicy().delay().toMillis(),
+          node.failurePolicy().name(),
+          node.timeoutPolicy().dispatchTimeout().toMillis(),
+          node.timeoutPolicy().executionTimeout().toMillis(),
+          node.inputMapping().bindings(),
+          node.configuration());
+    }
+
+    NodeDefinition toDefinition() {
+      return new NodeDefinition(
+          id,
+          name,
+          TriggerRule.valueOf(triggerRule),
+          maxAttempts > 1
+              ? RetryPolicy.fixed(maxAttempts, Duration.ofMillis(retryDelayMillis))
+              : RetryPolicy.none(),
+          NodeFailurePolicy.valueOf(failurePolicy),
+          NodeTimeoutPolicy.of(
+              Duration.ofMillis(dispatchTimeoutMillis),
+              Duration.ofMillis(executionTimeoutMillis)),
+          NodeInputMapping.of(inputMapping),
+          configuration);
+    }
+  }
+
+  private record EdgeSnapshot(String fromNodeId, String toNodeId) {
+    static EdgeSnapshot from(EdgeDefinition edge) {
+      return new EdgeSnapshot(edge.fromNodeId(), edge.toNodeId());
+    }
+
+    EdgeDefinition toDefinition() {
+      return new EdgeDefinition(fromNodeId, toNodeId);
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/persistence/JdbcWorkflowExecutionRepository.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/persistence/JdbcWorkflowExecutionRepository.java
@@ -1,0 +1,283 @@
+package io.yak.ops.business.workflow.persistence;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.framework.workflow.engine.definition.NodeFailurePolicy;
+import io.yak.framework.workflow.engine.execution.NodeAttemptSnapshot;
+import io.yak.framework.workflow.engine.execution.NodeExecutionSnapshot;
+import io.yak.framework.workflow.engine.execution.WorkflowExecution;
+import io.yak.framework.workflow.engine.execution.WorkflowExecutionSnapshot;
+import io.yak.framework.workflow.engine.spi.ExecutionRepository;
+import io.yak.framework.workflow.engine.state.NodeAttemptFailureReason;
+import io.yak.framework.workflow.engine.state.NodeAttemptStatus;
+import io.yak.framework.workflow.engine.state.NodeExecutionStatus;
+import io.yak.framework.workflow.engine.state.WorkflowExecutionStatus;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import javax.sql.DataSource;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+/** Database-backed Yak Framework execution repository. */
+@Repository
+@DependsOn("workflowFlyway")
+@ConditionalOnProperty(
+    prefix = "yak.database",
+    name = "enabled",
+    havingValue = "true",
+    matchIfMissing = true)
+public class JdbcWorkflowExecutionRepository implements ExecutionRepository {
+
+  private static final TypeReference<Map<String, Object>> JSON_MAP = new TypeReference<>() { };
+
+  private final JdbcTemplate jdbc;
+  private final ObjectMapper objectMapper;
+  private final TransactionTemplate transaction;
+
+  public JdbcWorkflowExecutionRepository(
+      @Qualifier("yakBusinessDataSource") DataSource dataSource,
+      @Qualifier("yakBusinessTransactionManager") PlatformTransactionManager transactionManager,
+      ObjectMapper objectMapper) {
+    this.jdbc = new JdbcTemplate(dataSource);
+    this.objectMapper = objectMapper;
+    this.transaction = new TransactionTemplate(transactionManager);
+  }
+
+  @Override
+  public void save(WorkflowExecution execution) {
+    WorkflowExecutionSnapshot snapshot = execution.snapshot();
+    transaction.executeWithoutResult(status -> {
+      upsertExecution(snapshot);
+      for (NodeExecutionSnapshot node : snapshot.nodes()) {
+        upsertNode(node);
+        for (NodeAttemptSnapshot attempt : node.attempts()) {
+          upsertAttempt(snapshot.id(), node, attempt);
+        }
+      }
+    });
+  }
+
+  @Override
+  public Optional<WorkflowExecution> findById(String executionId) {
+    List<ExecutionRow> executions = jdbc.query(
+        "SELECT * FROM yak_workflow_execution WHERE id=?",
+        this::mapExecution,
+        executionId);
+    if (executions.isEmpty()) return Optional.empty();
+    ExecutionRow root = executions.get(0);
+
+    Map<String, List<NodeAttemptSnapshot>> attemptsByNodeExecution = new LinkedHashMap<>();
+    jdbc.query(
+        "SELECT * FROM yak_workflow_node_attempt WHERE workflow_execution_id=? "
+            + "ORDER BY node_execution_id,attempt_no",
+        (rs, row) -> {
+          attemptsByNodeExecution
+              .computeIfAbsent(rs.getString("node_execution_id"), ignored -> new ArrayList<>())
+              .add(mapAttempt(rs));
+          return null;
+        },
+        executionId);
+
+    List<NodeExecutionSnapshot> nodes = jdbc.query(
+        "SELECT * FROM yak_workflow_node_execution WHERE workflow_execution_id=? ORDER BY id",
+        (rs, row) -> mapNode(
+            rs,
+            attemptsByNodeExecution.getOrDefault(rs.getString("id"), List.of())),
+        executionId);
+
+    WorkflowExecutionSnapshot snapshot = new WorkflowExecutionSnapshot(
+        root.id(),
+        root.definitionId(),
+        root.sourceExecutionId(),
+        root.input(),
+        nodes,
+        root.createdAt(),
+        root.status(),
+        root.schedulingStopped(),
+        root.runStartedAt(),
+        root.pausedAt(),
+        root.pausedDuration(),
+        root.updatedAt(),
+        root.endedAt());
+    return Optional.of(WorkflowExecution.restore(snapshot));
+  }
+
+  private void upsertExecution(WorkflowExecutionSnapshot value) {
+    jdbc.update(
+        "INSERT INTO yak_workflow_execution "
+            + "(id,definition_id,source_execution_id,status,input_json,scheduling_stopped,"
+            + "run_started_at,paused_at,paused_duration_ms,created_at,updated_at,ended_at) "
+            + "VALUES (?,?,?,?,?,?,?,?,?,?,?,?) "
+            + "ON DUPLICATE KEY UPDATE definition_id=VALUES(definition_id),"
+            + "source_execution_id=VALUES(source_execution_id),status=VALUES(status),"
+            + "input_json=VALUES(input_json),scheduling_stopped=VALUES(scheduling_stopped),"
+            + "run_started_at=VALUES(run_started_at),paused_at=VALUES(paused_at),"
+            + "paused_duration_ms=VALUES(paused_duration_ms),updated_at=VALUES(updated_at),"
+            + "ended_at=VALUES(ended_at)",
+        value.id(),
+        value.definitionId(),
+        value.sourceExecutionId(),
+        value.status().name(),
+        writeMap(value.input()),
+        value.schedulingStopped(),
+        timestamp(value.runStartedAt()),
+        timestamp(value.pausedAt()),
+        value.pausedDuration().toMillis(),
+        timestamp(value.createdAt()),
+        timestamp(value.updatedAt()),
+        timestamp(value.endedAt()));
+  }
+
+  private void upsertNode(NodeExecutionSnapshot value) {
+    jdbc.update(
+        "INSERT INTO yak_workflow_node_execution "
+            + "(id,workflow_execution_id,node_id,failure_policy,status,output_json,error_message,"
+            + "failure_handled,downstream_continuation_allowed) VALUES (?,?,?,?,?,?,?,?,?) "
+            + "ON DUPLICATE KEY UPDATE failure_policy=VALUES(failure_policy),status=VALUES(status),"
+            + "output_json=VALUES(output_json),error_message=VALUES(error_message),"
+            + "failure_handled=VALUES(failure_handled),"
+            + "downstream_continuation_allowed=VALUES(downstream_continuation_allowed)",
+        value.id(),
+        value.workflowExecutionId(),
+        value.nodeId(),
+        value.failurePolicy().name(),
+        value.status().name(),
+        writeMap(value.output()),
+        value.errorMessage(),
+        value.failureHandled(),
+        value.downstreamContinuationAllowed());
+  }
+
+  private void upsertAttempt(
+      String workflowExecutionId,
+      NodeExecutionSnapshot node,
+      NodeAttemptSnapshot value) {
+    jdbc.update(
+        "INSERT INTO yak_workflow_node_attempt "
+            + "(id,node_execution_id,workflow_execution_id,node_id,attempt_no,available_at,status,"
+            + "resume_target_status,started_at,paused_at,paused_duration_ms,ended_at,error_message,"
+            + "failure_reason) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?) "
+            + "ON DUPLICATE KEY UPDATE available_at=VALUES(available_at),status=VALUES(status),"
+            + "resume_target_status=VALUES(resume_target_status),started_at=VALUES(started_at),"
+            + "paused_at=VALUES(paused_at),paused_duration_ms=VALUES(paused_duration_ms),"
+            + "ended_at=VALUES(ended_at),error_message=VALUES(error_message),"
+            + "failure_reason=VALUES(failure_reason)",
+        value.id(),
+        node.id(),
+        workflowExecutionId,
+        node.nodeId(),
+        value.attemptNumber(),
+        timestamp(value.availableAt()),
+        value.status().name(),
+        value.resumeTargetStatus() == null ? null : value.resumeTargetStatus().name(),
+        timestamp(value.startedAt()),
+        timestamp(value.pausedAt()),
+        value.pausedDuration().toMillis(),
+        timestamp(value.endedAt()),
+        value.errorMessage(),
+        value.failureReason() == null ? null : value.failureReason().name());
+  }
+
+  private ExecutionRow mapExecution(ResultSet rs, int row) throws SQLException {
+    return new ExecutionRow(
+        rs.getString("id"),
+        rs.getString("definition_id"),
+        rs.getString("source_execution_id"),
+        WorkflowExecutionStatus.valueOf(rs.getString("status")),
+        readMap(rs.getString("input_json")),
+        rs.getBoolean("scheduling_stopped"),
+        instant(rs.getTimestamp("run_started_at")),
+        instant(rs.getTimestamp("paused_at")),
+        Duration.ofMillis(rs.getLong("paused_duration_ms")),
+        instant(rs.getTimestamp("created_at")),
+        instant(rs.getTimestamp("updated_at")),
+        instant(rs.getTimestamp("ended_at")));
+  }
+
+  private NodeExecutionSnapshot mapNode(
+      ResultSet rs,
+      List<NodeAttemptSnapshot> attempts) throws SQLException {
+    return new NodeExecutionSnapshot(
+        rs.getString("id"),
+        rs.getString("workflow_execution_id"),
+        rs.getString("node_id"),
+        NodeFailurePolicy.valueOf(rs.getString("failure_policy")),
+        NodeExecutionStatus.valueOf(rs.getString("status")),
+        attempts,
+        readMap(rs.getString("output_json")),
+        rs.getString("error_message"),
+        rs.getBoolean("failure_handled"),
+        rs.getBoolean("downstream_continuation_allowed"));
+  }
+
+  private NodeAttemptSnapshot mapAttempt(ResultSet rs) throws SQLException {
+    String resume = rs.getString("resume_target_status");
+    String reason = rs.getString("failure_reason");
+    return new NodeAttemptSnapshot(
+        rs.getString("id"),
+        rs.getInt("attempt_no"),
+        instant(rs.getTimestamp("available_at")),
+        NodeAttemptStatus.valueOf(rs.getString("status")),
+        resume == null ? null : NodeAttemptStatus.valueOf(resume),
+        instant(rs.getTimestamp("started_at")),
+        instant(rs.getTimestamp("paused_at")),
+        Duration.ofMillis(rs.getLong("paused_duration_ms")),
+        instant(rs.getTimestamp("ended_at")),
+        rs.getString("error_message"),
+        reason == null ? null : NodeAttemptFailureReason.valueOf(reason));
+  }
+
+  private String writeMap(Map<String, Object> value) {
+    try {
+      return objectMapper.writeValueAsString(value == null ? Map.of() : value);
+    } catch (JsonProcessingException exception) {
+      throw new IllegalStateException("序列化工作流执行 JSON 失败", exception);
+    }
+  }
+
+  private Map<String, Object> readMap(String json) {
+    if (json == null || json.isBlank()) return Map.of();
+    try {
+      return objectMapper.readValue(json, JSON_MAP);
+    } catch (JsonProcessingException exception) {
+      throw new IllegalStateException("读取工作流执行 JSON 失败", exception);
+    }
+  }
+
+  private Timestamp timestamp(Instant instant) {
+    return instant == null ? null : Timestamp.from(instant);
+  }
+
+  private Instant instant(Timestamp timestamp) {
+    return timestamp == null ? null : timestamp.toInstant();
+  }
+
+  private record ExecutionRow(
+      String id,
+      String definitionId,
+      String sourceExecutionId,
+      WorkflowExecutionStatus status,
+      Map<String, Object> input,
+      boolean schedulingStopped,
+      Instant runStartedAt,
+      Instant pausedAt,
+      Duration pausedDuration,
+      Instant createdAt,
+      Instant updatedAt,
+      Instant endedAt) {
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/persistence/JdbcWorkflowRuntimeRepository.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/persistence/JdbcWorkflowRuntimeRepository.java
@@ -1,0 +1,135 @@
+package io.yak.ops.business.workflow.persistence;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import java.util.Optional;
+import javax.sql.DataSource;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+/** JDBC runtime index used for history reads, restart scanning and external task reconciliation. */
+@Repository
+@DependsOn("workflowFlyway")
+@ConditionalOnProperty(
+    prefix = "yak.database",
+    name = "enabled",
+    havingValue = "true",
+    matchIfMissing = true)
+public class JdbcWorkflowRuntimeRepository implements WorkflowRuntimePersistence {
+
+  private final JdbcTemplate jdbc;
+  private final ObjectMapper objectMapper;
+
+  public JdbcWorkflowRuntimeRepository(
+      @Qualifier("yakBusinessDataSource") DataSource dataSource,
+      ObjectMapper objectMapper) {
+    this.jdbc = new JdbcTemplate(dataSource);
+    this.objectMapper = objectMapper;
+  }
+
+  @Override
+  public void saveMetadata(String executionId, RuntimeMetadataRecord metadata) {
+    int updated = jdbc.update(
+        "UPDATE yak_workflow_execution SET workflow_name=?,workflow_version_id=?,"
+            + "workflow_version_no=?,test_run=?,edge_count=?,workflow_timeout_seconds=?,"
+            + "failure_strategy=?,runtime_metadata_json=? WHERE id=?",
+        metadata.name(),
+        metadata.workflowVersionId(),
+        metadata.workflowVersionNo(),
+        metadata.testRun(),
+        metadata.edgeCount(),
+        metadata.workflowTimeoutSeconds(),
+        metadata.failureStrategy(),
+        write(metadata),
+        executionId);
+    if (updated == 0) {
+      throw new IllegalArgumentException("工作流执行实例不存在：" + executionId);
+    }
+  }
+
+  @Override
+  public Optional<RuntimeMetadataRecord> findMetadata(String executionId) {
+    try {
+      String json = jdbc.queryForObject(
+          "SELECT runtime_metadata_json FROM yak_workflow_execution WHERE id=?",
+          String.class,
+          executionId);
+      if (json == null || json.isBlank()) return Optional.empty();
+      return Optional.of(read(json));
+    } catch (EmptyResultDataAccessException ignored) {
+      return Optional.empty();
+    }
+  }
+
+  @Override
+  public List<String> listExecutionIds() {
+    return jdbc.queryForList(
+        "SELECT id FROM yak_workflow_execution ORDER BY created_at DESC",
+        String.class);
+  }
+
+  @Override
+  public List<String> findRecoverableExecutionIds() {
+    return jdbc.queryForList(
+        "SELECT id FROM yak_workflow_execution WHERE status IN "
+            + "('CREATED','RUNNING','PAUSING','PAUSED','RESUMING') ORDER BY created_at",
+        String.class);
+  }
+
+  @Override
+  public void bindExternalExecution(String attemptId, String externalExecutionId) {
+    if (attemptId == null || attemptId.isBlank()
+        || externalExecutionId == null || externalExecutionId.isBlank()) {
+      throw new IllegalArgumentException("attemptId 和 externalExecutionId 不能为空");
+    }
+    int updated = jdbc.update(
+        "UPDATE yak_workflow_node_attempt SET external_execution_id=? WHERE id=? "
+            + "AND (external_execution_id IS NULL OR external_execution_id=?)",
+        externalExecutionId,
+        attemptId,
+        externalExecutionId);
+    if (updated == 0) {
+      String existing = findExternalExecution(attemptId).orElse(null);
+      if (existing == null) {
+        throw new IllegalArgumentException("工作流 Attempt 不存在：" + attemptId);
+      }
+      if (!externalExecutionId.equals(existing)) {
+        throw new IllegalStateException(
+            "工作流 Attempt 已绑定其他远端执行：" + attemptId + " -> " + existing);
+      }
+    }
+  }
+
+  @Override
+  public Optional<String> findExternalExecution(String attemptId) {
+    try {
+      return Optional.ofNullable(jdbc.queryForObject(
+          "SELECT external_execution_id FROM yak_workflow_node_attempt WHERE id=?",
+          String.class,
+          attemptId));
+    } catch (EmptyResultDataAccessException ignored) {
+      return Optional.empty();
+    }
+  }
+
+  private String write(RuntimeMetadataRecord metadata) {
+    try {
+      return objectMapper.writeValueAsString(metadata);
+    } catch (JsonProcessingException exception) {
+      throw new IllegalStateException("序列化工作流 Runtime Metadata 失败", exception);
+    }
+  }
+
+  private RuntimeMetadataRecord read(String json) {
+    try {
+      return objectMapper.readValue(json, RuntimeMetadataRecord.class);
+    } catch (JsonProcessingException exception) {
+      throw new IllegalStateException("读取工作流 Runtime Metadata 失败", exception);
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/persistence/JdbcWorkflowRuntimeRepository.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/persistence/JdbcWorkflowRuntimeRepository.java
@@ -33,6 +33,17 @@ public class JdbcWorkflowRuntimeRepository implements WorkflowRuntimePersistence
   }
 
   @Override
+  public void prepareMetadata(String definitionId, RuntimeMetadataRecord metadata) {
+    int updated = jdbc.update(
+        "UPDATE yak_workflow_version SET runtime_metadata_json=? WHERE id=?",
+        write(metadata),
+        definitionId);
+    if (updated == 0) {
+      throw new IllegalArgumentException("工作流运行定义不存在：" + definitionId);
+    }
+  }
+
+  @Override
   public void saveMetadata(String executionId, RuntimeMetadataRecord metadata) {
     int updated = jdbc.update(
         "UPDATE yak_workflow_execution SET workflow_name=?,workflow_version_id=?,"
@@ -56,7 +67,9 @@ public class JdbcWorkflowRuntimeRepository implements WorkflowRuntimePersistence
   public Optional<RuntimeMetadataRecord> findMetadata(String executionId) {
     try {
       String json = jdbc.queryForObject(
-          "SELECT runtime_metadata_json FROM yak_workflow_execution WHERE id=?",
+          "SELECT COALESCE(e.runtime_metadata_json,v.runtime_metadata_json) "
+              + "FROM yak_workflow_execution e "
+              + "LEFT JOIN yak_workflow_version v ON v.id=e.definition_id WHERE e.id=?",
           String.class,
           executionId);
       if (json == null || json.isBlank()) return Optional.empty();

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/persistence/NoopWorkflowDefinitionPersistence.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/persistence/NoopWorkflowDefinitionPersistence.java
@@ -1,0 +1,38 @@
+package io.yak.ops.business.workflow.persistence;
+
+import java.util.List;
+
+/** Fallback used when the shared Yak business database is explicitly disabled. */
+public final class NoopWorkflowDefinitionPersistence implements WorkflowDefinitionPersistence {
+
+  public static final NoopWorkflowDefinitionPersistence INSTANCE =
+      new NoopWorkflowDefinitionPersistence();
+
+  private NoopWorkflowDefinitionPersistence() {
+  }
+
+  @Override
+  public List<DefinitionRecord> loadDefinitions() {
+    return List.of();
+  }
+
+  @Override
+  public List<VersionRecord> loadVersions(String workflowId) {
+    return List.of();
+  }
+
+  @Override
+  public void saveDefinition(DefinitionRecord definition) {
+    // In-memory WorkflowDefinitionService remains the fallback fact source.
+  }
+
+  @Override
+  public void saveVersion(VersionRecord version) {
+    // In-memory WorkflowDefinitionService remains the fallback fact source.
+  }
+
+  @Override
+  public void deleteDefinition(String workflowId) {
+    // No durable state to remove.
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/persistence/NoopWorkflowDefinitionPersistence.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/persistence/NoopWorkflowDefinitionPersistence.java
@@ -27,7 +27,7 @@ public final class NoopWorkflowDefinitionPersistence implements WorkflowDefiniti
   }
 
   @Override
-  public void saveVersion(VersionRecord version) {
+  public void publish(DefinitionRecord definition, VersionRecord version) {
     // In-memory WorkflowDefinitionService remains the fallback fact source.
   }
 

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/persistence/WorkflowDefinitionPersistence.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/persistence/WorkflowDefinitionPersistence.java
@@ -17,7 +17,8 @@ public interface WorkflowDefinitionPersistence {
 
   void saveDefinition(DefinitionRecord definition);
 
-  void saveVersion(VersionRecord version);
+  /** Persist a new immutable version and advance the current definition projection atomically. */
+  void publish(DefinitionRecord definition, VersionRecord version);
 
   void deleteDefinition(String workflowId);
 

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/persistence/WorkflowDefinitionPersistence.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/persistence/WorkflowDefinitionPersistence.java
@@ -1,0 +1,54 @@
+package io.yak.ops.business.workflow.persistence;
+
+import io.yak.ops.business.job.task.TaskVersionSnapshot;
+import io.yak.ops.business.workflow.model.WorkflowDefinitionUpdateRequest.EdgeRequest;
+import io.yak.ops.business.workflow.model.WorkflowDefinitionUpdateRequest.NodeRequest;
+import io.yak.ops.business.workflow.model.WorkflowRunRequest;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+/** Durable business catalog boundary for editable workflows and immutable published versions. */
+public interface WorkflowDefinitionPersistence {
+
+  List<DefinitionRecord> loadDefinitions();
+
+  List<VersionRecord> loadVersions(String workflowId);
+
+  void saveDefinition(DefinitionRecord definition);
+
+  void saveVersion(VersionRecord version);
+
+  void deleteDefinition(String workflowId);
+
+  record DefinitionRecord(
+      String id,
+      String name,
+      String description,
+      String status,
+      String failureStrategy,
+      List<NodeRequest> nodes,
+      List<EdgeRequest> edges,
+      Map<String, Object> input,
+      Map<String, Object> editorMeta,
+      long workflowTimeoutSeconds,
+      long draftRevision,
+      int latestVersionNo,
+      String activeVersionId,
+      String latestExecutionId,
+      String latestExecutionStatus,
+      Instant createTime,
+      Instant updateTime) {
+  }
+
+  record VersionRecord(
+      String id,
+      String workflowId,
+      int versionNo,
+      long draftRevision,
+      WorkflowRunRequest runRequest,
+      Map<String, Object> editorMeta,
+      Map<String, TaskVersionSnapshot> taskVersionsByNode,
+      Instant publishedAt) {
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/persistence/WorkflowPersistenceConfiguration.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/persistence/WorkflowPersistenceConfiguration.java
@@ -1,0 +1,34 @@
+package io.yak.ops.business.workflow.persistence;
+
+import io.yak.ops.business.datasource.config.BusinessDatabaseConfiguration;
+import javax.sql.DataSource;
+import org.flywaydb.core.Flyway;
+import org.flywaydb.core.api.MigrationVersion;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+/** Workflow persistence shares the Yak Ops business database but owns its Flyway history. */
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnProperty(
+    prefix = "yak.database",
+    name = "enabled",
+    havingValue = "true",
+    matchIfMissing = true)
+@Import(BusinessDatabaseConfiguration.class)
+public class WorkflowPersistenceConfiguration {
+
+  @Bean(initMethod = "migrate", name = "workflowFlyway")
+  public Flyway workflowFlyway(
+      @Qualifier("yakBusinessDataSource") DataSource dataSource) {
+    return Flyway.configure()
+        .dataSource(dataSource)
+        .locations("classpath:db/migration/yak-workflow")
+        .table("yak_workflow_schema_history")
+        .baselineVersion(MigrationVersion.fromVersion("0"))
+        .baselineOnMigrate(true)
+        .load();
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/persistence/WorkflowRuntimePersistence.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/persistence/WorkflowRuntimePersistence.java
@@ -1,0 +1,52 @@
+package io.yak.ops.business.workflow.persistence;
+
+import io.yak.ops.business.job.task.TaskVersionSnapshot;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/** Durable runtime metadata and external-attempt binding needed for restart recovery. */
+public interface WorkflowRuntimePersistence {
+
+  void saveMetadata(String executionId, RuntimeMetadataRecord metadata);
+
+  Optional<RuntimeMetadataRecord> findMetadata(String executionId);
+
+  List<String> listExecutionIds();
+
+  List<String> findRecoverableExecutionIds();
+
+  void bindExternalExecution(String attemptId, String externalExecutionId);
+
+  Optional<String> findExternalExecution(String attemptId);
+
+  record RuntimeMetadataRecord(
+      String name,
+      int edgeCount,
+      long workflowTimeoutSeconds,
+      String failureStrategy,
+      String workflowVersionId,
+      Integer workflowVersionNo,
+      boolean testRun,
+      Map<String, NodeMetadataRecord> nodes) {
+
+    public RuntimeMetadataRecord {
+      nodes = nodes == null ? Map.of() : Map.copyOf(nodes);
+    }
+  }
+
+  record NodeMetadataRecord(
+      TaskVersionSnapshot task,
+      String triggerRule,
+      String failurePolicy,
+      int maxAttempts,
+      long retryDelaySeconds,
+      long dispatchTimeoutSeconds,
+      long executionTimeoutSeconds,
+      Map<String, String> inputMapping) {
+
+    public NodeMetadataRecord {
+      inputMapping = inputMapping == null ? Map.of() : Map.copyOf(inputMapping);
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/persistence/WorkflowRuntimePersistence.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/persistence/WorkflowRuntimePersistence.java
@@ -8,8 +8,13 @@ import java.util.Optional;
 /** Durable runtime metadata and external-attempt binding needed for restart recovery. */
 public interface WorkflowRuntimePersistence {
 
+  /** Persist recovery metadata on the immutable engine definition before an execution is created. */
+  void prepareMetadata(String definitionId, RuntimeMetadataRecord metadata);
+
+  /** Copy recovery metadata to the concrete execution after the engine creates it. */
   void saveMetadata(String executionId, RuntimeMetadataRecord metadata);
 
+  /** Load execution metadata, falling back to its immutable definition snapshot when necessary. */
   Optional<RuntimeMetadataRecord> findMetadata(String executionId);
 
   List<String> listExecutionIds();

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowDefinitionService.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowDefinitionService.java
@@ -11,6 +11,11 @@ import io.yak.ops.business.workflow.model.WorkflowInstanceVO;
 import io.yak.ops.business.workflow.model.WorkflowRunRequest;
 import io.yak.ops.business.workflow.model.WorkflowVersionVO;
 import io.yak.ops.business.workflow.model.WorkflowVersionVO.TaskBindingVO;
+import io.yak.ops.business.workflow.persistence.JdbcWorkflowCatalogRepository;
+import io.yak.ops.business.workflow.persistence.NoopWorkflowDefinitionPersistence;
+import io.yak.ops.business.workflow.persistence.WorkflowDefinitionPersistence;
+import io.yak.ops.business.workflow.persistence.WorkflowDefinitionPersistence.DefinitionRecord;
+import io.yak.ops.business.workflow.persistence.WorkflowDefinitionPersistence.VersionRecord;
 import java.time.Instant;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -26,60 +31,93 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
-/** 工作流草稿、发布版本和运行入口。当前存储仍为进程内存。 */
+/** 工作流草稿、不可变发布版本和运行入口。数据库是生产环境事实来源。 */
 @Service
 public class WorkflowDefinitionService {
   private static final Set<String> ACTIVE = Set.of(
       "CREATED", "WAITING", "READY", "SUBMITTED", "RUNNING", "PAUSING", "PAUSED", "RESUMING");
+
   private final WorkflowRuntimeService runtimeService;
   private final TaskRegistry taskRegistry;
+  private final WorkflowDefinitionPersistence persistence;
   private final ConcurrentMap<String, DefinitionState> definitions = new ConcurrentHashMap<>();
 
-  public WorkflowDefinitionService(WorkflowRuntimeService runtimeService, TaskRegistry taskRegistry) {
+  @Autowired
+  public WorkflowDefinitionService(
+      WorkflowRuntimeService runtimeService,
+      TaskRegistry taskRegistry,
+      ObjectProvider<JdbcWorkflowCatalogRepository> persistence) {
+    this(
+        runtimeService,
+        taskRegistry,
+        persistence.getIfAvailable(() -> NoopWorkflowDefinitionPersistence.INSTANCE));
+  }
+
+  /** Focused tests and database-disabled development retain the lightweight in-memory catalog. */
+  WorkflowDefinitionService(
+      WorkflowRuntimeService runtimeService,
+      TaskRegistry taskRegistry) {
+    this(runtimeService, taskRegistry, NoopWorkflowDefinitionPersistence.INSTANCE);
+  }
+
+  WorkflowDefinitionService(
+      WorkflowRuntimeService runtimeService,
+      TaskRegistry taskRegistry,
+      WorkflowDefinitionPersistence persistence) {
     this.runtimeService = runtimeService;
     this.taskRegistry = taskRegistry;
+    this.persistence = persistence;
+    restoreCatalog();
   }
 
   public List<WorkflowDefinitionVO> list(String keyword, String status) {
-    String k = normalize(keyword), s = normalizeUpper(status);
+    String k = normalize(keyword);
+    String s = normalizeUpper(status);
     return definitions.values().stream()
-        .filter(x -> k == null || x.name.toLowerCase(Locale.ROOT).contains(k)
+        .filter(x -> k == null
+            || x.name.toLowerCase(Locale.ROOT).contains(k)
             || text(x.description).toLowerCase(Locale.ROOT).contains(k))
         .filter(x -> s == null || s.equals(x.status))
         .sorted(Comparator.comparing((DefinitionState x) -> x.updateTime).reversed())
-        .map(this::toView).toList();
+        .map(this::toView)
+        .toList();
   }
 
   public WorkflowDefinitionVO create(WorkflowDefinitionCreateRequest request) {
     if (request == null) throw new IllegalArgumentException("工作流创建参数不能为空");
-    DefinitionState s = new DefinitionState();
+    DefinitionState state = new DefinitionState();
     Instant now = Instant.now();
-    s.id = "workflow-" + UUID.randomUUID();
-    s.name = required(request.name(), "工作流名称不能为空");
-    s.description = trim(request.description());
-    s.status = "DRAFT";
-    s.nodes = List.of();
-    s.edges = List.of();
-    s.input = Map.of();
-    s.editorMeta = Map.of();
-    s.failureStrategy = "CONTINUE_INDEPENDENT_BRANCHES";
-    s.draftRevision = 1L;
-    s.versions = new ArrayList<>();
-    s.createTime = now;
-    s.updateTime = now;
-    definitions.put(s.id, s);
-    return toView(s);
+    state.id = "workflow-" + UUID.randomUUID();
+    state.name = required(request.name(), "工作流名称不能为空");
+    state.description = trim(request.description());
+    state.status = "DRAFT";
+    state.nodes = List.of();
+    state.edges = List.of();
+    state.input = Map.of();
+    state.editorMeta = Map.of();
+    state.failureStrategy = "CONTINUE_INDEPENDENT_BRANCHES";
+    state.draftRevision = 1L;
+    state.versions = new ArrayList<>();
+    state.createTime = now;
+    state.updateTime = now;
+    persistence.saveDefinition(toRecord(state));
+    definitions.put(state.id, state);
+    return toView(state);
   }
 
-  public WorkflowDefinitionVO get(String id) { return toView(require(id)); }
+  public WorkflowDefinitionVO get(String id) {
+    return toView(require(id));
+  }
 
   public WorkflowDefinitionVO update(String id, WorkflowDefinitionUpdateRequest request) {
     if (request == null) throw new IllegalArgumentException("工作流配置不能为空");
-    DefinitionState s = require(id);
-    synchronized (s) {
+    DefinitionState state = require(id);
+    synchronized (state) {
       String nextName = required(request.name(), "工作流名称不能为空");
       String nextDescription = trim(request.description());
       List<NodeRequest> nextNodes = List.copyOf(request.nodes());
@@ -88,285 +126,463 @@ public class WorkflowDefinitionService {
       Map<String, Object> nextEditorMeta = Map.copyOf(new LinkedHashMap<>(request.editorMeta()));
       long nextTimeout = request.workflowTimeoutSeconds();
       String nextFailureStrategy = request.failureStrategy();
-      boolean changed = !Objects.equals(s.name, nextName)
-          || !Objects.equals(s.description, nextDescription)
-          || !Objects.equals(s.nodes, nextNodes)
-          || !Objects.equals(s.edges, nextEdges)
-          || !Objects.equals(s.input, nextInput)
-          || !Objects.equals(s.editorMeta, nextEditorMeta)
-          || s.workflowTimeoutSeconds != nextTimeout
-          || !Objects.equals(s.failureStrategy, nextFailureStrategy);
+      boolean changed = !Objects.equals(state.name, nextName)
+          || !Objects.equals(state.description, nextDescription)
+          || !Objects.equals(state.nodes, nextNodes)
+          || !Objects.equals(state.edges, nextEdges)
+          || !Objects.equals(state.input, nextInput)
+          || !Objects.equals(state.editorMeta, nextEditorMeta)
+          || state.workflowTimeoutSeconds != nextTimeout
+          || !Objects.equals(state.failureStrategy, nextFailureStrategy);
 
-      s.name = nextName;
-      s.description = nextDescription;
-      s.nodes = nextNodes;
-      s.edges = nextEdges;
-      s.input = nextInput;
-      s.editorMeta = nextEditorMeta;
-      s.workflowTimeoutSeconds = nextTimeout;
-      s.failureStrategy = nextFailureStrategy;
-      if (changed) {
-        s.draftRevision++;
-        s.updateTime = Instant.now();
+      if (!changed) return toView(state);
+
+      DefinitionStateSnapshot previous = DefinitionStateSnapshot.capture(state);
+      state.name = nextName;
+      state.description = nextDescription;
+      state.nodes = nextNodes;
+      state.edges = nextEdges;
+      state.input = nextInput;
+      state.editorMeta = nextEditorMeta;
+      state.workflowTimeoutSeconds = nextTimeout;
+      state.failureStrategy = nextFailureStrategy;
+      state.draftRevision++;
+      state.updateTime = Instant.now();
+      try {
+        persistence.saveDefinition(toRecord(state));
+      } catch (RuntimeException exception) {
+        previous.restore(state);
+        throw exception;
       }
-      return toView(s);
+      return toView(state);
     }
   }
 
   public WorkflowDefinitionVO online(String id) {
-    DefinitionState s = require(id);
-    synchronized (s) {
-      if (s.activeVersion == null || draftChanged(s)) {
-        PreparedDraft draft = prepare(s);
-        WorkflowVersion v = new WorkflowVersion(
-            "workflow-version-" + UUID.randomUUID(),
-            s.id,
-            ++s.latestVersionNo,
-            s.draftRevision,
-            draft.request(),
-            s.editorMeta,
-            draft.tasks(),
-            Instant.now());
-        s.versions.add(v);
-        s.activeVersion = v;
+    DefinitionState state = require(id);
+    synchronized (state) {
+      DefinitionStateSnapshot previous = DefinitionStateSnapshot.capture(state);
+      WorkflowVersion published = null;
+      try {
+        if (state.activeVersion == null || draftChanged(state)) {
+          PreparedDraft draft = prepare(state);
+          published = new WorkflowVersion(
+              "workflow-version-" + UUID.randomUUID(),
+              state.id,
+              state.latestVersionNo + 1,
+              state.draftRevision,
+              draft.request(),
+              state.editorMeta,
+              draft.tasks(),
+              Instant.now());
+          state.latestVersionNo = published.versionNo();
+          state.versions.add(published);
+          state.activeVersion = published;
+        }
+        state.status = "ONLINE";
+        state.updateTime = Instant.now();
+        if (published == null) {
+          persistence.saveDefinition(toRecord(state));
+        } else {
+          persistence.publish(toRecord(state), toRecord(published));
+        }
+      } catch (RuntimeException exception) {
+        if (published != null) state.versions.remove(published);
+        previous.restore(state);
+        throw exception;
       }
-      s.status = "ONLINE";
-      s.updateTime = Instant.now();
-      return toView(s);
+      return toView(state);
     }
   }
 
   /** 下线只阻止新的正式运行，已经启动的版本实例继续完成。 */
   public WorkflowDefinitionVO offline(String id) {
-    DefinitionState s = require(id);
-    synchronized (s) {
-      if (s.activeVersion == null) throw new IllegalStateException("工作流还没有已发布版本");
-      s.status = "OFFLINE";
-      s.updateTime = Instant.now();
-      return toView(s);
+    DefinitionState state = require(id);
+    synchronized (state) {
+      if (state.activeVersion == null) {
+        throw new IllegalStateException("工作流还没有已发布版本");
+      }
+      String previousStatus = state.status;
+      Instant previousUpdateTime = state.updateTime;
+      state.status = "OFFLINE";
+      state.updateTime = Instant.now();
+      try {
+        persistence.saveDefinition(toRecord(state));
+      } catch (RuntimeException exception) {
+        state.status = previousStatus;
+        state.updateTime = previousUpdateTime;
+        throw exception;
+      }
+      return toView(state);
     }
   }
 
   public WorkflowDefinitionVO run(String id) {
-    DefinitionState s = require(id);
-    synchronized (s) {
-      if (!"ONLINE".equals(s.status) || s.activeVersion == null) {
+    DefinitionState state = require(id);
+    synchronized (state) {
+      if (!"ONLINE".equals(state.status) || state.activeVersion == null) {
         throw new IllegalStateException("工作流没有启用的发布版本，不能正式执行");
       }
-      ensureIdle(s);
-      WorkflowVersion v = s.activeVersion;
-      return activate(s, runtimeService.run(
-          v.runRequest(), v.taskVersionsByNode(), v.id(), v.versionNo(), false));
+      ensureIdle(state);
+      WorkflowVersion version = state.activeVersion;
+      return activate(
+          state,
+          runtimeService.run(
+              version.runRequest(),
+              version.taskVersionsByNode(),
+              version.id(),
+              version.versionNo(),
+              false));
     }
   }
 
   /** 直接执行当前草稿；不要求发布，也不改变激活版本。 */
   public WorkflowDefinitionVO testRun(String id) {
-    DefinitionState s = require(id);
-    synchronized (s) {
-      ensureIdle(s);
-      PreparedDraft draft = prepare(s);
-      return activate(s, runtimeService.run(draft.request(), draft.tasks(), null, null, true));
+    DefinitionState state = require(id);
+    synchronized (state) {
+      ensureIdle(state);
+      PreparedDraft draft = prepare(state);
+      return activate(
+          state,
+          runtimeService.run(draft.request(), draft.tasks(), null, null, true));
     }
   }
 
   public List<WorkflowVersionVO> versions(String id) {
-    DefinitionState s = require(id);
-    synchronized (s) {
-      String activeId = s.activeVersion == null ? null : s.activeVersion.id();
-      return s.versions.stream()
+    DefinitionState state = require(id);
+    synchronized (state) {
+      String activeId = state.activeVersion == null ? null : state.activeVersion.id();
+      return state.versions.stream()
           .sorted(Comparator.comparingInt(WorkflowVersion::versionNo).reversed())
-          .map(v -> versionView(v, v.id().equals(activeId)))
+          .map(version -> versionView(version, version.id().equals(activeId)))
           .toList();
     }
   }
 
   public WorkflowDefinitionVO pause(String id) {
-    DefinitionState s = require(id);
-    synchronized (s) {
-      WorkflowInstanceVO v = runtimeService.pause(requireLatestExecution(s));
-      s.latestExecutionStatus = v.status();
-      s.updateTime = Instant.now();
-      return toView(s);
+    DefinitionState state = require(id);
+    synchronized (state) {
+      WorkflowInstanceVO execution = runtimeService.pause(requireLatestExecution(state));
+      state.latestExecutionStatus = execution.status();
+      state.updateTime = Instant.now();
+      persistence.saveDefinition(toRecord(state));
+      return toView(state);
     }
   }
 
   public WorkflowDefinitionVO resume(String id) {
-    DefinitionState s = require(id);
-    synchronized (s) {
-      WorkflowInstanceVO v = runtimeService.resume(requireLatestExecution(s));
-      s.latestExecutionStatus = v.status();
-      s.updateTime = Instant.now();
-      return toView(s);
+    DefinitionState state = require(id);
+    synchronized (state) {
+      WorkflowInstanceVO execution = runtimeService.resume(requireLatestExecution(state));
+      state.latestExecutionStatus = execution.status();
+      state.updateTime = Instant.now();
+      persistence.saveDefinition(toRecord(state));
+      return toView(state);
     }
   }
 
   public void delete(String id) {
-    DefinitionState s = require(id);
-    synchronized (s) {
-      refresh(s);
-      if (isActive(s.latestExecutionStatus)) throw new IllegalStateException("工作流正在运行，不能删除");
-      if ("ONLINE".equals(s.status)) throw new IllegalStateException("已启用工作流请先下线后再删除");
-      definitions.remove(s.id, s);
-    }
-  }
-
-  private WorkflowDefinitionVO activate(DefinitionState s, WorkflowInstanceVO prepared) {
-    WorkflowInstanceVO v = runtimeService.activate(prepared.id());
-    s.latestExecutionId = v.id();
-    s.latestExecutionStatus = v.status();
-    s.updateTime = Instant.now();
-    return toView(s);
-  }
-
-  private void ensureIdle(DefinitionState s) {
-    refresh(s);
-    if (isActive(s.latestExecutionStatus)) throw new IllegalStateException("工作流已有运行中的执行实例");
-  }
-
-  private PreparedDraft prepare(DefinitionState s) {
-    validateGraph(s);
-    WorkflowStartGraphCompiler.RuntimeGraph graph = WorkflowStartGraphCompiler.compile(
-        s.nodes, s.edges, s.editorMeta, s.input);
-    Map<String, TaskVersionSnapshot> tasks = new LinkedHashMap<>();
-    for (NodeRequest n : graph.nodes()) {
-      TaskVersionSnapshot task = taskRegistry.snapshot(n.taskId());
-      if (!"SYNC".equalsIgnoreCase(task.type())) {
-        throw new IllegalStateException("第一阶段工作流仅支持 SYNC 任务：" + n.taskId());
+    DefinitionState state = require(id);
+    synchronized (state) {
+      refresh(state);
+      if (isActive(state.latestExecutionStatus)) {
+        throw new IllegalStateException("工作流正在运行，不能删除");
       }
-      tasks.put(n.id(), task);
+      if ("ONLINE".equals(state.status)) {
+        throw new IllegalStateException("已启用工作流请先下线后再删除");
+      }
+      persistence.deleteDefinition(state.id);
+      definitions.remove(state.id, state);
     }
-    return new PreparedDraft(toRunRequest(s, graph), Map.copyOf(tasks));
   }
 
-  private void validateGraph(DefinitionState s) {
-    if (s.nodes.isEmpty()) throw new IllegalStateException("请先配置至少一个任务节点");
+  private WorkflowDefinitionVO activate(
+      DefinitionState state,
+      WorkflowInstanceVO prepared) {
+    // Persist the execution pointer before any pending remote dispatch is activated.
+    String previousExecutionId = state.latestExecutionId;
+    String previousExecutionStatus = state.latestExecutionStatus;
+    Instant previousUpdateTime = state.updateTime;
+    state.latestExecutionId = prepared.id();
+    state.latestExecutionStatus = prepared.status();
+    state.updateTime = Instant.now();
+    try {
+      persistence.saveDefinition(toRecord(state));
+    } catch (RuntimeException exception) {
+      state.latestExecutionId = previousExecutionId;
+      state.latestExecutionStatus = previousExecutionStatus;
+      state.updateTime = previousUpdateTime;
+      throw exception;
+    }
+
+    WorkflowInstanceVO execution = runtimeService.activate(prepared.id());
+    if (!Objects.equals(state.latestExecutionStatus, execution.status())) {
+      state.latestExecutionStatus = execution.status();
+      state.updateTime = Instant.now();
+      persistence.saveDefinition(toRecord(state));
+    }
+    return toView(state);
+  }
+
+  private void ensureIdle(DefinitionState state) {
+    refresh(state);
+    if (isActive(state.latestExecutionStatus)) {
+      throw new IllegalStateException("工作流已有运行中的执行实例");
+    }
+  }
+
+  private PreparedDraft prepare(DefinitionState state) {
+    validateGraph(state);
+    WorkflowStartGraphCompiler.RuntimeGraph graph = WorkflowStartGraphCompiler.compile(
+        state.nodes,
+        state.edges,
+        state.editorMeta,
+        state.input);
+    Map<String, TaskVersionSnapshot> tasks = new LinkedHashMap<>();
+    for (NodeRequest node : graph.nodes()) {
+      TaskVersionSnapshot task = taskRegistry.snapshot(node.taskId());
+      if (!"SYNC".equalsIgnoreCase(task.type())) {
+        throw new IllegalStateException("第一阶段工作流仅支持 SYNC 任务：" + node.taskId());
+      }
+      tasks.put(node.id(), task);
+    }
+    return new PreparedDraft(toRunRequest(state, graph), Map.copyOf(tasks));
+  }
+
+  private void validateGraph(DefinitionState state) {
+    if (state.nodes.isEmpty()) throw new IllegalStateException("请先配置至少一个任务节点");
     Set<String> ids = new HashSet<>();
-    for (NodeRequest n : s.nodes) {
-      if (!ids.add(n.id())) throw new IllegalStateException("工作流存在重复节点 ID：" + n.id());
+    for (NodeRequest node : state.nodes) {
+      if (!ids.add(node.id())) {
+        throw new IllegalStateException("工作流存在重复节点 ID：" + node.id());
+      }
     }
     Map<String, Integer> in = new HashMap<>();
     Map<String, List<String>> next = new HashMap<>();
-    ids.forEach(x -> { in.put(x, 0); next.put(x, new ArrayList<>()); });
-    for (EdgeRequest e : s.edges) {
-      if (!ids.contains(e.source()) || !ids.contains(e.target())) {
-        throw new IllegalStateException("连线引用了不存在的节点：" + e.source() + " -> " + e.target());
+    ids.forEach(nodeId -> {
+      in.put(nodeId, 0);
+      next.put(nodeId, new ArrayList<>());
+    });
+    for (EdgeRequest edge : state.edges) {
+      if (!ids.contains(edge.source()) || !ids.contains(edge.target())) {
+        throw new IllegalStateException(
+            "连线引用了不存在的节点：" + edge.source() + " -> " + edge.target());
       }
-      if (e.source().equals(e.target())) {
-        throw new IllegalStateException("工作流节点不能连接自身：" + e.source());
+      if (edge.source().equals(edge.target())) {
+        throw new IllegalStateException("工作流节点不能连接自身：" + edge.source());
       }
-      next.get(e.source()).add(e.target());
-      in.compute(e.target(), (k, v) -> v == null ? 1 : v + 1);
+      next.get(edge.source()).add(edge.target());
+      in.compute(edge.target(), (key, value) -> value == null ? 1 : value + 1);
     }
-    ArrayDeque<String> q = new ArrayDeque<>();
-    in.forEach((x, d) -> { if (d == 0) q.add(x); });
+    ArrayDeque<String> queue = new ArrayDeque<>();
+    in.forEach((nodeId, degree) -> {
+      if (degree == 0) queue.add(nodeId);
+    });
     int visited = 0;
-    while (!q.isEmpty()) {
-      String x = q.removeFirst();
+    while (!queue.isEmpty()) {
+      String current = queue.removeFirst();
       visited++;
-      for (String y : next.get(x)) {
-        if (in.compute(y, (k, v) -> v == null ? 0 : v - 1) == 0) q.addLast(y);
+      for (String successor : next.get(current)) {
+        if (in.compute(successor, (key, value) -> value == null ? 0 : value - 1) == 0) {
+          queue.addLast(successor);
+        }
       }
     }
-    if (visited != ids.size()) throw new IllegalStateException("工作流存在循环依赖，不能发布或测试");
+    if (visited != ids.size()) {
+      throw new IllegalStateException("工作流存在循环依赖，不能发布或测试");
+    }
   }
 
   private WorkflowRunRequest toRunRequest(
-      DefinitionState s,
+      DefinitionState state,
       WorkflowStartGraphCompiler.RuntimeGraph graph) {
     List<WorkflowRunRequest.NodeRequest> nodes = graph.nodes().stream()
-        .map(n -> new WorkflowRunRequest.NodeRequest(
-            n.id(),
-            n.taskId(),
-            n.maxAttempts(),
-            n.retryDelaySeconds(),
-            n.dispatchTimeoutSeconds(),
-            n.executionTimeoutSeconds(),
-            n.inputMapping(),
-            n.triggerRule(),
-            n.failurePolicy()))
+        .map(node -> new WorkflowRunRequest.NodeRequest(
+            node.id(),
+            node.taskId(),
+            node.maxAttempts(),
+            node.retryDelaySeconds(),
+            node.dispatchTimeoutSeconds(),
+            node.executionTimeoutSeconds(),
+            node.inputMapping(),
+            node.triggerRule(),
+            node.failurePolicy()))
         .toList();
     List<WorkflowRunRequest.EdgeRequest> edges = graph.edges().stream()
-        .map(e -> new WorkflowRunRequest.EdgeRequest(e.source(), e.target()))
+        .map(edge -> new WorkflowRunRequest.EdgeRequest(edge.source(), edge.target()))
         .toList();
     // Runtime 只接收 input；editorMeta 不进入 Yak Framework execution input。
     return new WorkflowRunRequest(
-        s.name, nodes, edges, s.input, s.workflowTimeoutSeconds, s.failureStrategy);
+        state.name,
+        nodes,
+        edges,
+        state.input,
+        state.workflowTimeoutSeconds,
+        state.failureStrategy);
   }
 
-  private WorkflowVersionVO versionView(WorkflowVersion v, boolean active) {
-    List<TaskBindingVO> bindings = v.taskVersionsByNode().entrySet().stream()
-        .map(e -> new TaskBindingVO(
-            e.getKey(), e.getValue().taskId(), e.getValue().name(), e.getValue().version()))
+  private WorkflowVersionVO versionView(WorkflowVersion version, boolean active) {
+    List<TaskBindingVO> bindings = version.taskVersionsByNode().entrySet().stream()
+        .map(entry -> new TaskBindingVO(
+            entry.getKey(),
+            entry.getValue().taskId(),
+            entry.getValue().name(),
+            entry.getValue().version()))
         .toList();
     return new WorkflowVersionVO(
-        v.id(),
-        v.versionNo(),
+        version.id(),
+        version.versionNo(),
         active,
-        v.runRequest().nodes().size(),
-        v.runRequest().edges().size(),
+        version.runRequest().nodes().size(),
+        version.runRequest().edges().size(),
         bindings,
-        v.publishedAt());
+        version.publishedAt());
   }
 
-  private WorkflowDefinitionVO toView(DefinitionState s) {
-    synchronized (s) {
-      refresh(s);
-      WorkflowVersion a = s.activeVersion;
+  private WorkflowDefinitionVO toView(DefinitionState state) {
+    synchronized (state) {
+      refresh(state);
+      WorkflowVersion active = state.activeVersion;
       return new WorkflowDefinitionVO(
-          s.id,
-          s.name,
-          s.description,
-          s.status,
-          s.nodes.size(),
-          s.edges.size(),
-          s.nodes,
-          s.edges,
-          s.input,
-          s.editorMeta,
-          s.workflowTimeoutSeconds,
-          s.failureStrategy,
-          a == null ? null : a.id(),
-          a == null ? null : a.versionNo(),
-          s.latestVersionNo,
-          draftChanged(s),
-          s.latestExecutionId,
-          s.latestExecutionStatus,
-          s.createTime,
-          s.updateTime);
+          state.id,
+          state.name,
+          state.description,
+          state.status,
+          state.nodes.size(),
+          state.edges.size(),
+          state.nodes,
+          state.edges,
+          state.input,
+          state.editorMeta,
+          state.workflowTimeoutSeconds,
+          state.failureStrategy,
+          active == null ? null : active.id(),
+          active == null ? null : active.versionNo(),
+          state.latestVersionNo,
+          draftChanged(state),
+          state.latestExecutionId,
+          state.latestExecutionStatus,
+          state.createTime,
+          state.updateTime);
     }
   }
 
-  private boolean draftChanged(DefinitionState s) {
-    return s.activeVersion == null || s.activeVersion.draftRevision() != s.draftRevision;
+  private boolean draftChanged(DefinitionState state) {
+    return state.activeVersion == null
+        || state.activeVersion.draftRevision() != state.draftRevision;
   }
 
-  private void refresh(DefinitionState s) {
-    if (!StringUtils.hasText(s.latestExecutionId)) return;
-    try {
-      s.latestExecutionStatus = runtimeService.getInstance(s.latestExecutionId).status();
-    } catch (RuntimeException ignored) {
-      // Runtime storage is currently in-process; keep the last known state if it was restarted.
+  private void refresh(DefinitionState state) {
+    if (!StringUtils.hasText(state.latestExecutionId)) return;
+    String current = runtimeService.getInstance(state.latestExecutionId).status();
+    if (!Objects.equals(state.latestExecutionStatus, current)) {
+      state.latestExecutionStatus = current;
+      state.updateTime = Instant.now();
+      persistence.saveDefinition(toRecord(state));
     }
   }
 
   private DefinitionState require(String id) {
     if (!StringUtils.hasText(id)) throw new IllegalArgumentException("工作流 ID 不能为空");
-    DefinitionState s = definitions.get(id.trim());
-    if (s == null) throw new IllegalArgumentException("工作流定义不存在：" + id);
-    return s;
+    DefinitionState state = definitions.get(id.trim());
+    if (state == null) throw new IllegalArgumentException("工作流定义不存在：" + id);
+    return state;
   }
 
-  private String requireLatestExecution(DefinitionState s) {
-    refresh(s);
-    if (!StringUtils.hasText(s.latestExecutionId)) {
+  private String requireLatestExecution(DefinitionState state) {
+    refresh(state);
+    if (!StringUtils.hasText(state.latestExecutionId)) {
       throw new IllegalStateException("工作流还没有可控制的执行实例");
     }
-    return s.latestExecutionId;
+    return state.latestExecutionId;
   }
 
   private boolean isActive(String status) {
     return status != null && ACTIVE.contains(status.toUpperCase(Locale.ROOT));
+  }
+
+  private void restoreCatalog() {
+    for (DefinitionRecord record : persistence.loadDefinitions()) {
+      DefinitionState state = fromRecord(record);
+      List<WorkflowVersion> versions = persistence.loadVersions(record.id()).stream()
+          .map(this::fromRecord)
+          .toList();
+      state.versions = new ArrayList<>(versions);
+      if (StringUtils.hasText(record.activeVersionId())) {
+        state.activeVersion = versions.stream()
+            .filter(version -> record.activeVersionId().equals(version.id()))
+            .findFirst()
+            .orElseThrow(() -> new IllegalStateException(
+                "工作流激活版本不存在：" + record.id() + " -> " + record.activeVersionId()));
+      }
+      definitions.put(state.id, state);
+    }
+  }
+
+  private DefinitionRecord toRecord(DefinitionState state) {
+    return new DefinitionRecord(
+        state.id,
+        state.name,
+        state.description,
+        state.status,
+        state.failureStrategy,
+        state.nodes,
+        state.edges,
+        state.input,
+        state.editorMeta,
+        state.workflowTimeoutSeconds,
+        state.draftRevision,
+        state.latestVersionNo,
+        state.activeVersion == null ? null : state.activeVersion.id(),
+        state.latestExecutionId,
+        state.latestExecutionStatus,
+        state.createTime,
+        state.updateTime);
+  }
+
+  private VersionRecord toRecord(WorkflowVersion version) {
+    return new VersionRecord(
+        version.id(),
+        version.workflowId(),
+        version.versionNo(),
+        version.draftRevision(),
+        version.runRequest(),
+        version.editorMeta(),
+        version.taskVersionsByNode(),
+        version.publishedAt());
+  }
+
+  private DefinitionState fromRecord(DefinitionRecord record) {
+    DefinitionState state = new DefinitionState();
+    state.id = record.id();
+    state.name = record.name();
+    state.description = record.description();
+    state.status = record.status();
+    state.failureStrategy = record.failureStrategy();
+    state.latestExecutionId = record.latestExecutionId();
+    state.latestExecutionStatus = record.latestExecutionStatus();
+    state.nodes = List.copyOf(record.nodes());
+    state.edges = List.copyOf(record.edges());
+    state.input = Map.copyOf(record.input());
+    state.editorMeta = Map.copyOf(record.editorMeta());
+    state.workflowTimeoutSeconds = record.workflowTimeoutSeconds();
+    state.draftRevision = record.draftRevision();
+    state.latestVersionNo = record.latestVersionNo();
+    state.createTime = record.createTime();
+    state.updateTime = record.updateTime();
+    return state;
+  }
+
+  private WorkflowVersion fromRecord(VersionRecord record) {
+    return new WorkflowVersion(
+        record.id(),
+        record.workflowId(),
+        record.versionNo(),
+        record.draftRevision(),
+        record.runRequest(),
+        record.editorMeta(),
+        record.taskVersionsByNode(),
+        record.publishedAt());
   }
 
   private String required(String value, String message) {
@@ -374,14 +590,26 @@ public class WorkflowDefinitionService {
     return value.trim();
   }
 
-  private String trim(String value) { return StringUtils.hasText(value) ? value.trim() : null; }
-  private String text(String value) { return value == null ? "" : value; }
-  private String normalize(String v) { return StringUtils.hasText(v) ? v.trim().toLowerCase(Locale.ROOT) : null; }
-  private String normalizeUpper(String v) { return StringUtils.hasText(v) ? v.trim().toUpperCase(Locale.ROOT) : null; }
+  private String trim(String value) {
+    return StringUtils.hasText(value) ? value.trim() : null;
+  }
+
+  private String text(String value) {
+    return value == null ? "" : value;
+  }
+
+  private String normalize(String value) {
+    return StringUtils.hasText(value) ? value.trim().toLowerCase(Locale.ROOT) : null;
+  }
+
+  private String normalizeUpper(String value) {
+    return StringUtils.hasText(value) ? value.trim().toUpperCase(Locale.ROOT) : null;
+  }
 
   private record PreparedDraft(
       WorkflowRunRequest request,
-      Map<String, TaskVersionSnapshot> tasks) { }
+      Map<String, TaskVersionSnapshot> tasks) {
+  }
 
   private static final class DefinitionState {
     String id;
@@ -402,5 +630,60 @@ public class WorkflowDefinitionService {
     WorkflowVersion activeVersion;
     Instant createTime;
     Instant updateTime;
+  }
+
+  private record DefinitionStateSnapshot(
+      String name,
+      String description,
+      String status,
+      String failureStrategy,
+      String latestExecutionId,
+      String latestExecutionStatus,
+      List<NodeRequest> nodes,
+      List<EdgeRequest> edges,
+      Map<String, Object> input,
+      Map<String, Object> editorMeta,
+      long workflowTimeoutSeconds,
+      long draftRevision,
+      int latestVersionNo,
+      WorkflowVersion activeVersion,
+      Instant updateTime) {
+
+    static DefinitionStateSnapshot capture(DefinitionState state) {
+      return new DefinitionStateSnapshot(
+          state.name,
+          state.description,
+          state.status,
+          state.failureStrategy,
+          state.latestExecutionId,
+          state.latestExecutionStatus,
+          state.nodes,
+          state.edges,
+          state.input,
+          state.editorMeta,
+          state.workflowTimeoutSeconds,
+          state.draftRevision,
+          state.latestVersionNo,
+          state.activeVersion,
+          state.updateTime);
+    }
+
+    void restore(DefinitionState state) {
+      state.name = name;
+      state.description = description;
+      state.status = status;
+      state.failureStrategy = failureStrategy;
+      state.latestExecutionId = latestExecutionId;
+      state.latestExecutionStatus = latestExecutionStatus;
+      state.nodes = nodes;
+      state.edges = edges;
+      state.input = input;
+      state.editorMeta = editorMeta;
+      state.workflowTimeoutSeconds = workflowTimeoutSeconds;
+      state.draftRevision = draftRevision;
+      state.latestVersionNo = latestVersionNo;
+      state.activeVersion = activeVersion;
+      state.updateTime = updateTime;
+    }
   }
 }

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowRecoveryService.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowRecoveryService.java
@@ -1,0 +1,33 @@
+package io.yak.ops.business.workflow.service;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Service;
+
+/** Rebuilds non-terminal workflow runtime state after Yak Ops has fully started. */
+@Service
+@ConditionalOnProperty(
+    prefix = "yak.database",
+    name = "enabled",
+    havingValue = "true",
+    matchIfMissing = true)
+public class WorkflowRecoveryService {
+  private static final Logger log = LoggerFactory.getLogger(WorkflowRecoveryService.class);
+
+  private final WorkflowRuntimeService runtimeService;
+
+  public WorkflowRecoveryService(WorkflowRuntimeService runtimeService) {
+    this.runtimeService = runtimeService;
+  }
+
+  @EventListener(ApplicationReadyEvent.class)
+  public void recover() {
+    int recovered = runtimeService.recoverPersistedExecutions();
+    if (recovered > 0) {
+      log.info("[workflow] startup recovery completed executions={}", recovered);
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowRecoveryService.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowRecoveryService.java
@@ -1,5 +1,6 @@
 package io.yak.ops.business.workflow.service;
 
+import io.yak.ops.business.workflow.persistence.JdbcWorkflowRuntimeRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -18,13 +19,31 @@ public class WorkflowRecoveryService {
   private static final Logger log = LoggerFactory.getLogger(WorkflowRecoveryService.class);
 
   private final WorkflowRuntimeService runtimeService;
+  private final JdbcWorkflowRuntimeRepository runtimeRepository;
 
-  public WorkflowRecoveryService(WorkflowRuntimeService runtimeService) {
+  public WorkflowRecoveryService(
+      WorkflowRuntimeService runtimeService,
+      JdbcWorkflowRuntimeRepository runtimeRepository) {
     this.runtimeService = runtimeService;
+    this.runtimeRepository = runtimeRepository;
   }
 
   @EventListener(ApplicationReadyEvent.class)
   public void recover() {
+    // Register executions as active before reconciliation. This does not execute a node by itself;
+    // it only guarantees that a recovered SUBMITTED dispatch drains immediately when reconstructed.
+    for (String executionId : runtimeRepository.findRecoverableExecutionIds()) {
+      try {
+        runtimeService.activate(executionId);
+      } catch (RuntimeException exception) {
+        log.error(
+            "[workflow] pre-recovery activation failed execution={}, message={}",
+            executionId,
+            exception.getMessage(),
+            exception);
+      }
+    }
+
     int recovered = runtimeService.recoverPersistedExecutions();
     if (recovered > 0) {
       log.info("[workflow] startup recovery completed executions={}", recovered);

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowRuntimeService.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowRuntimeService.java
@@ -1,6 +1,7 @@
 package io.yak.ops.business.workflow.service;
 
 import io.yak.framework.workflow.engine.api.DefaultWorkflowEngine;
+import io.yak.framework.workflow.engine.api.WorkflowRecoveryCoordinator;
 import io.yak.framework.workflow.engine.definition.EdgeDefinition;
 import io.yak.framework.workflow.engine.definition.NodeDefinition;
 import io.yak.framework.workflow.engine.definition.NodeFailurePolicy;
@@ -11,26 +12,45 @@ import io.yak.framework.workflow.engine.definition.TriggerRule;
 import io.yak.framework.workflow.engine.definition.WorkflowDefinition;
 import io.yak.framework.workflow.engine.definition.WorkflowFailureStrategy;
 import io.yak.framework.workflow.engine.definition.WorkflowTimeoutPolicy;
+import io.yak.framework.workflow.engine.event.WorkflowEventListener;
 import io.yak.framework.workflow.engine.execution.NodeAttempt;
 import io.yak.framework.workflow.engine.execution.NodeExecution;
 import io.yak.framework.workflow.engine.execution.WorkflowExecution;
+import io.yak.framework.workflow.engine.spi.ExecutionLock;
+import io.yak.framework.workflow.engine.spi.ExecutionRepository;
+import io.yak.framework.workflow.engine.spi.IdGenerator;
 import io.yak.framework.workflow.engine.spi.NodeCancellation;
 import io.yak.framework.workflow.engine.spi.NodeControlResult;
 import io.yak.framework.workflow.engine.spi.NodeDispatch;
 import io.yak.framework.workflow.engine.spi.NodeExecutor;
 import io.yak.framework.workflow.engine.spi.NodePauseRequest;
+import io.yak.framework.workflow.engine.spi.NodeRecovery;
 import io.yak.framework.workflow.engine.spi.NodeResumeRequest;
+import io.yak.framework.workflow.engine.spi.WorkflowDefinitionRepository;
+import io.yak.framework.workflow.engine.state.NodeAttemptStatus;
+import io.yak.framework.workflow.engine.support.InMemoryExecutionRepository;
+import io.yak.framework.workflow.engine.support.InMemoryWorkflowDefinitionRepository;
+import io.yak.framework.workflow.engine.support.LocalExecutionLock;
+import io.yak.framework.workflow.engine.support.UuidIdGenerator;
 import io.yak.ops.business.job.task.SyncTaskExecution;
 import io.yak.ops.business.job.task.SyncTaskRunner;
-import io.yak.ops.business.job.task.TaskVersionSnapshot;
 import io.yak.ops.business.job.task.TaskRegistry;
+import io.yak.ops.business.job.task.TaskVersionSnapshot;
 import io.yak.ops.business.workflow.model.WorkflowInstanceVO;
 import io.yak.ops.business.workflow.model.WorkflowInstanceVO.AttemptVO;
 import io.yak.ops.business.workflow.model.WorkflowInstanceVO.NodeInstanceVO;
 import io.yak.ops.business.workflow.model.WorkflowRunRequest;
 import io.yak.ops.business.workflow.model.WorkflowRunRequest.EdgeRequest;
 import io.yak.ops.business.workflow.model.WorkflowRunRequest.NodeRequest;
+import io.yak.ops.business.workflow.persistence.InMemoryWorkflowRuntimePersistence;
+import io.yak.ops.business.workflow.persistence.JdbcWorkflowEngineDefinitionRepository;
+import io.yak.ops.business.workflow.persistence.JdbcWorkflowExecutionRepository;
+import io.yak.ops.business.workflow.persistence.JdbcWorkflowRuntimeRepository;
+import io.yak.ops.business.workflow.persistence.WorkflowRuntimePersistence;
+import io.yak.ops.business.workflow.persistence.WorkflowRuntimePersistence.NodeMetadataRecord;
+import io.yak.ops.business.workflow.persistence.WorkflowRuntimePersistence.RuntimeMetadataRecord;
 import jakarta.annotation.PreDestroy;
+import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -40,7 +60,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutorService;
@@ -50,48 +69,82 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
-/** Yak Framework 工作流引擎的轻量内存适配层。 */
+/** Yak Framework 工作流引擎的可持久化运行时适配层。 */
 @Service
 public class WorkflowRuntimeService {
   private static final Logger log = LoggerFactory.getLogger(WorkflowRuntimeService.class);
   private static final long TASK_POLL_INTERVAL_MILLIS = 500L;
 
-  /** 每次远程 start/status/cancel 都是短生命周期 I/O；不会再为任务全生命周期占用固定平台线程。 */
+  /** 每次远程 start/status/cancel 都是短生命周期 I/O；不会为任务全生命周期占用固定平台线程。 */
   private final ExecutorService ioExecutor;
   private final ScheduledExecutorService runtimeScheduler;
   private final DefaultWorkflowEngine engine;
+  private final WorkflowRecoveryCoordinator recoveryCoordinator;
   private final WorkflowEventStreamService eventStreamService;
   private final TaskRegistry taskRegistry;
   private final SyncTaskRunner syncTaskRunner;
+  private final WorkflowRuntimePersistence runtimePersistence;
   private final long taskPollIntervalMillis;
-  private final ConcurrentMap<String, ConcurrentLinkedQueue<NodeDispatch>> pendingDispatches = new ConcurrentHashMap<>();
+  private final ConcurrentMap<String, ConcurrentLinkedQueue<NodeDispatch>> pendingDispatches =
+      new ConcurrentHashMap<>();
   private final ConcurrentMap<String, Object> publishLocks = new ConcurrentHashMap<>();
   private final ConcurrentMap<String, NodeTaskControl> taskControls = new ConcurrentHashMap<>();
-  private final ConcurrentMap<String, ConcurrentMap<String, NodeDispatch>> latestDispatches = new ConcurrentHashMap<>();
+  private final ConcurrentMap<String, ConcurrentMap<String, NodeDispatch>> latestDispatches =
+      new ConcurrentHashMap<>();
   private final Set<String> activeExecutions = ConcurrentHashMap.newKeySet();
   private final Map<String, RunMetadata> metadata = new ConcurrentHashMap<>();
-  private final ConcurrentLinkedDeque<String> executionOrder = new ConcurrentLinkedDeque<>();
 
   @Autowired
   public WorkflowRuntimeService(
       WorkflowEventStreamService eventStreamService,
       TaskRegistry taskRegistry,
-      SyncTaskRunner syncTaskRunner) {
-    this(eventStreamService, taskRegistry, syncTaskRunner, TASK_POLL_INTERVAL_MILLIS);
+      SyncTaskRunner syncTaskRunner,
+      ObjectProvider<JdbcWorkflowEngineDefinitionRepository> definitionRepository,
+      ObjectProvider<JdbcWorkflowExecutionRepository> executionRepository,
+      ObjectProvider<JdbcWorkflowRuntimeRepository> runtimePersistence) {
+    this(
+        eventStreamService,
+        taskRegistry,
+        syncTaskRunner,
+        TASK_POLL_INTERVAL_MILLIS,
+        definitionRepository.getIfAvailable(InMemoryWorkflowDefinitionRepository::new),
+        executionRepository.getIfAvailable(InMemoryExecutionRepository::new),
+        runtimePersistence.getIfAvailable(InMemoryWorkflowRuntimePersistence::new));
+  }
+
+  /** Focused tests and database-disabled development keep the original lightweight constructor. */
+  WorkflowRuntimeService(
+      WorkflowEventStreamService eventStreamService,
+      TaskRegistry taskRegistry,
+      SyncTaskRunner syncTaskRunner,
+      long taskPollIntervalMillis) {
+    this(
+        eventStreamService,
+        taskRegistry,
+        syncTaskRunner,
+        taskPollIntervalMillis,
+        new InMemoryWorkflowDefinitionRepository(),
+        new InMemoryExecutionRepository(),
+        new InMemoryWorkflowRuntimePersistence());
   }
 
   WorkflowRuntimeService(
       WorkflowEventStreamService eventStreamService,
       TaskRegistry taskRegistry,
       SyncTaskRunner syncTaskRunner,
-      long taskPollIntervalMillis) {
+      long taskPollIntervalMillis,
+      WorkflowDefinitionRepository definitionRepository,
+      ExecutionRepository executionRepository,
+      WorkflowRuntimePersistence runtimePersistence) {
     this.eventStreamService = eventStreamService;
     this.taskRegistry = taskRegistry;
     this.syncTaskRunner = syncTaskRunner;
+    this.runtimePersistence = runtimePersistence;
     this.taskPollIntervalMillis = Math.max(1L, taskPollIntervalMillis);
     this.ioExecutor = Executors.newVirtualThreadPerTaskExecutor();
     AtomicInteger schedulerIndex = new AtomicInteger();
@@ -101,14 +154,36 @@ public class WorkflowRuntimeService {
       thread.setDaemon(true);
       return thread;
     });
-    this.engine = DefaultWorkflowEngine.inMemory(new RuntimeNodeExecutor());
-    this.runtimeScheduler.scheduleAtFixedRate(this::scanTimeouts, 250L, 250L, TimeUnit.MILLISECONDS);
+
+    RuntimeNodeExecutor nodeExecutor = new RuntimeNodeExecutor();
+    ExecutionLock executionLock = new LocalExecutionLock();
+    IdGenerator idGenerator = new UuidIdGenerator();
+    Clock clock = Clock.systemUTC();
+    this.engine = new DefaultWorkflowEngine(
+        definitionRepository,
+        executionRepository,
+        nodeExecutor,
+        executionLock,
+        idGenerator,
+        clock,
+        WorkflowEventListener.noop());
+    this.recoveryCoordinator = new WorkflowRecoveryCoordinator(
+        definitionRepository,
+        executionRepository,
+        nodeExecutor,
+        executionLock,
+        idGenerator,
+        clock);
+    this.runtimeScheduler.scheduleAtFixedRate(
+        this::scanTimeouts, 250L, 250L, TimeUnit.MILLISECONDS);
   }
 
   /** 兼容直接运行 API：执行开始前固定一次当前任务快照。 */
   public WorkflowInstanceVO run(WorkflowRunRequest request) {
     Map<String, TaskVersionSnapshot> snapshots = new LinkedHashMap<>();
-    for (NodeRequest node : request.nodes()) snapshots.put(node.id(), taskRegistry.snapshot(node.taskId()));
+    for (NodeRequest node : request.nodes()) {
+      snapshots.put(node.id(), taskRegistry.snapshot(node.taskId()));
+    }
     return run(request, snapshots, null, null, false);
   }
 
@@ -119,9 +194,14 @@ public class WorkflowRuntimeService {
       String workflowVersionId,
       Integer workflowVersionNo,
       boolean testRun) {
-    String definitionId = "workflow-" + UUID.randomUUID();
-    Map<String, TaskVersionSnapshot> tasks = validateTaskSnapshots(request.nodes(), taskVersionsByNode);
-    List<NodeDefinition> nodes = request.nodes().stream().map(n -> toNodeDefinition(n, tasks.get(n.id()))).toList();
+    String definitionId = workflowVersionId == null || workflowVersionId.isBlank()
+        ? "workflow-runtime-" + UUID.randomUUID()
+        : workflowVersionId;
+    Map<String, TaskVersionSnapshot> tasks =
+        validateTaskSnapshots(request.nodes(), taskVersionsByNode);
+    List<NodeDefinition> nodes = request.nodes().stream()
+        .map(node -> toNodeDefinition(node, tasks.get(node.id())))
+        .toList();
     List<EdgeDefinition> edges = request.edges().stream().map(this::toEdgeDefinition).toList();
     WorkflowDefinition definition = new WorkflowDefinition(
         definitionId,
@@ -132,23 +212,44 @@ public class WorkflowRuntimeService {
             : WorkflowTimeoutPolicy.none(),
         nodes,
         edges);
+    RunMetadata runMetadata = new RunMetadata(
+        request.name(),
+        request.edges().size(),
+        request.workflowTimeoutSeconds(),
+        request.failureStrategy(),
+        workflowVersionId,
+        workflowVersionNo,
+        testRun,
+        nodeMetadata(request.nodes(), tasks));
+
+    // Definition + runtime bindings are durable before the first execution row is created.
     engine.registerDefinition(definition);
+    runtimePersistence.prepareMetadata(definitionId, toPersistence(runMetadata));
 
     WorkflowExecution execution = engine.start(definitionId, request.input());
-    RunMetadata runMetadata = new RunMetadata(
-        request.name(), request.edges().size(), request.workflowTimeoutSeconds(), request.failureStrategy(),
-        workflowVersionId, workflowVersionNo, testRun, nodeMetadata(request.nodes(), tasks));
     registerExecution(execution, runMetadata);
     WorkflowInstanceVO started = toView(execution, runMetadata);
     log.info(
         "[workflow] prepared execution={}, engineDefinition={}, workflowVersion={}, versionNo={}, testRun={}, nodes={}, edges={}",
-        execution.id(), definitionId, workflowVersionId, workflowVersionNo, testRun,
-        request.nodes().size(), request.edges().size());
+        execution.id(),
+        definitionId,
+        workflowVersionId,
+        workflowVersionNo,
+        testRun,
+        request.nodes().size(),
+        request.edges().size());
     return started;
   }
 
-  public WorkflowInstanceVO activate(String executionId) { activateExecution(executionId); return getInstance(executionId); }
-  public WorkflowInstanceVO pause(String executionId) { return publishAndView(engine.pause(executionId, "Paused from Yak Ops")); }
+  public WorkflowInstanceVO activate(String executionId) {
+    activateExecution(executionId);
+    return getInstance(executionId);
+  }
+
+  public WorkflowInstanceVO pause(String executionId) {
+    return publishAndView(engine.pause(executionId, "Paused from Yak Ops"));
+  }
+
   public WorkflowInstanceVO resume(String executionId) {
     WorkflowExecution execution = engine.resume(executionId);
     activeExecutions.add(executionId);
@@ -156,71 +257,163 @@ public class WorkflowRuntimeService {
     drainDispatches(executionId);
     return snapshot;
   }
-  public WorkflowInstanceVO cancel(String executionId) { return publishAndView(engine.cancel(executionId, "Canceled from Yak Ops")); }
+
+  public WorkflowInstanceVO cancel(String executionId) {
+    return publishAndView(engine.cancel(executionId, "Canceled from Yak Ops"));
+  }
 
   public WorkflowInstanceVO continueAfterFailure(String executionId, String nodeId) {
     WorkflowExecution execution = engine.continueAfterFailure(executionId, nodeId);
-    WorkflowInstanceVO snapshot = publishAndView(execution); reactivateExecution(executionId); return snapshot;
+    WorkflowInstanceVO snapshot = publishAndView(execution);
+    reactivateExecution(executionId);
+    return snapshot;
   }
+
   public WorkflowInstanceVO retryFailedNode(String executionId, String nodeId) {
-    requireMetadata(executionId); WorkflowInstanceVO snapshot = publishAndView(engine.retryFailedNode(executionId, nodeId));
-    reactivateExecution(executionId); return snapshot;
+    requireMetadata(executionId);
+    WorkflowInstanceVO snapshot = publishAndView(engine.retryFailedNode(executionId, nodeId));
+    reactivateExecution(executionId);
+    return snapshot;
   }
+
   public WorkflowInstanceVO retryFailedNodes(String executionId) {
-    requireExecution(executionId); WorkflowInstanceVO snapshot = publishAndView(engine.retryFailedNodes(executionId));
-    reactivateExecution(executionId); return snapshot;
+    requireExecution(executionId);
+    WorkflowInstanceVO snapshot = publishAndView(engine.retryFailedNodes(executionId));
+    reactivateExecution(executionId);
+    return snapshot;
   }
+
   public WorkflowInstanceVO restart(String executionId) {
-    RunMetadata source = requireMetadata(executionId); WorkflowExecution execution = engine.restart(executionId);
-    registerExecution(execution, source); return toView(execution, source);
+    RunMetadata source = requireMetadata(executionId);
+    WorkflowExecution execution = engine.restart(executionId);
+    registerExecution(execution, source);
+    return toView(execution, source);
   }
+
   public WorkflowInstanceVO rerunFromNode(String executionId, String nodeId) {
-    RunMetadata source = requireMetadata(executionId); WorkflowExecution execution = engine.rerunFromNode(executionId, nodeId);
-    registerExecution(execution, source); return toView(execution, source);
+    RunMetadata source = requireMetadata(executionId);
+    WorkflowExecution execution = engine.rerunFromNode(executionId, nodeId);
+    registerExecution(execution, source);
+    return toView(execution, source);
   }
 
   public List<WorkflowInstanceVO> listInstances() {
     List<WorkflowInstanceVO> result = new ArrayList<>();
-    for (String id : executionOrder) {
-      RunMetadata m = metadata.get(id);
-      if (m != null) engine.findExecution(id).map(x -> toView(x, m)).ifPresent(result::add);
+    for (String id : runtimePersistence.listExecutionIds()) {
+      RunMetadata runMetadata = findMetadata(id);
+      if (runMetadata != null) {
+        engine.findExecution(id)
+            .map(execution -> toView(execution, runMetadata))
+            .ifPresent(result::add);
+      }
     }
     return result;
   }
-  public WorkflowInstanceVO getInstance(String executionId) { return toView(requireExecution(executionId), requireMetadata(executionId)); }
+
+  public WorkflowInstanceVO getInstance(String executionId) {
+    return toView(requireExecution(executionId), requireMetadata(executionId));
+  }
+
   public SseEmitter subscribe(String executionId) {
     WorkflowInstanceVO snapshot = getInstance(executionId);
     SseEmitter emitter = eventStreamService.subscribe(executionId, snapshot);
-    activateExecution(executionId); publishCurrent(executionId); return emitter;
+    activateExecution(executionId);
+    publishCurrent(executionId);
+    return emitter;
+  }
+
+  /** Called once after application startup to rebuild only non-terminal runtime state. */
+  public int recoverPersistedExecutions() {
+    int recovered = 0;
+    for (String executionId : runtimePersistence.findRecoverableExecutionIds()) {
+      try {
+        RunMetadata runMetadata = requireMetadata(executionId);
+        WorkflowExecution before = requireExecution(executionId);
+        if (before.status().isTerminal()) continue;
+
+        metadata.put(executionId, runMetadata);
+        WorkflowExecution execution = recoveryCoordinator.recover(executionId);
+        if (!execution.status().isTerminal()) {
+          activeExecutions.add(executionId);
+        }
+        publishCurrent(executionId);
+        recovered++;
+        log.info(
+            "[workflow] recovered execution={}, status={}, definition={}",
+            executionId,
+            execution.status(),
+            execution.definitionId());
+      } catch (RuntimeException exception) {
+        log.error(
+            "[workflow] recovery failed execution={}, message={}",
+            executionId,
+            exception.getMessage(),
+            exception);
+      }
+    }
+    return recovered;
   }
 
   void activateExecution(String executionId) {
     getInstance(executionId);
-    if (activeExecutions.add(executionId)) log.info("[workflow] activated execution={}", executionId);
+    if (activeExecutions.add(executionId)) {
+      log.info("[workflow] activated execution={}", executionId);
+    }
     drainDispatches(executionId);
   }
+
   private void reactivateExecution(String executionId) {
-    if (activeExecutions.add(executionId)) log.info("[workflow] reactivated execution={}", executionId);
+    if (activeExecutions.add(executionId)) {
+      log.info("[workflow] reactivated execution={}", executionId);
+    }
     drainDispatches(executionId);
   }
-  private void registerExecution(WorkflowExecution execution, RunMetadata m) {
-    metadata.put(execution.id(), m); executionOrder.remove(execution.id()); executionOrder.addFirst(execution.id());
+
+  private void registerExecution(WorkflowExecution execution, RunMetadata runMetadata) {
+    runtimePersistence.saveMetadata(execution.id(), toPersistence(runMetadata));
+    metadata.put(execution.id(), runMetadata);
   }
+
   private RunMetadata requireMetadata(String id) {
-    RunMetadata m = metadata.get(id); if (m == null) throw new IllegalArgumentException("Workflow execution metadata not found: " + id); return m;
+    RunMetadata runMetadata = findMetadata(id);
+    if (runMetadata == null) {
+      throw new IllegalArgumentException("Workflow execution metadata not found: " + id);
+    }
+    return runMetadata;
   }
+
+  private RunMetadata findMetadata(String id) {
+    RunMetadata cached = metadata.get(id);
+    if (cached != null) return cached;
+    return runtimePersistence.findMetadata(id)
+        .map(this::fromPersistence)
+        .map(value -> {
+          metadata.put(id, value);
+          return value;
+        })
+        .orElse(null);
+  }
+
   private WorkflowExecution requireExecution(String id) {
-    return engine.findExecution(id).orElseThrow(() -> new IllegalArgumentException("Workflow execution not found: " + id));
+    return engine.findExecution(id)
+        .orElseThrow(() -> new IllegalArgumentException("Workflow execution not found: " + id));
   }
 
   private Map<String, TaskVersionSnapshot> validateTaskSnapshots(
-      List<NodeRequest> nodes, Map<String, TaskVersionSnapshot> supplied) {
+      List<NodeRequest> nodes,
+      Map<String, TaskVersionSnapshot> supplied) {
     Map<String, TaskVersionSnapshot> result = new LinkedHashMap<>();
     for (NodeRequest node : nodes) {
       TaskVersionSnapshot task = supplied == null ? null : supplied.get(node.id());
-      if (task == null) throw new IllegalArgumentException("工作流节点缺少任务版本快照：" + node.id());
-      if (!node.taskId().equals(task.taskId())) throw new IllegalArgumentException("工作流节点任务快照不匹配：" + node.id());
-      if (!"SYNC".equalsIgnoreCase(task.type())) throw new IllegalArgumentException("第一阶段工作流仅支持 SYNC 任务：" + task.taskId());
+      if (task == null) {
+        throw new IllegalArgumentException("工作流节点缺少任务版本快照：" + node.id());
+      }
+      if (!node.taskId().equals(task.taskId())) {
+        throw new IllegalArgumentException("工作流节点任务快照不匹配：" + node.id());
+      }
+      if (!"SYNC".equalsIgnoreCase(task.type())) {
+        throw new IllegalArgumentException("第一阶段工作流仅支持 SYNC 任务：" + task.taskId());
+      }
       result.put(node.id(), task);
     }
     return Map.copyOf(result);
@@ -228,29 +421,105 @@ public class WorkflowRuntimeService {
 
   private NodeDefinition toNodeDefinition(NodeRequest node, TaskVersionSnapshot task) {
     RetryPolicy retry = node.maxAttempts() > 1
-        ? RetryPolicy.fixed(node.maxAttempts(), Duration.ofSeconds(node.retryDelaySeconds())) : RetryPolicy.none();
+        ? RetryPolicy.fixed(node.maxAttempts(), Duration.ofSeconds(node.retryDelaySeconds()))
+        : RetryPolicy.none();
     NodeTimeoutPolicy timeout = NodeTimeoutPolicy.of(
-        Duration.ofSeconds(node.dispatchTimeoutSeconds()), Duration.ofSeconds(node.executionTimeoutSeconds()));
-    return new NodeDefinition(node.id(), task.name(), TriggerRule.valueOf(node.triggerRule()), retry,
-        NodeFailurePolicy.valueOf(node.failurePolicy()), timeout, NodeInputMapping.of(node.inputMapping()),
+        Duration.ofSeconds(node.dispatchTimeoutSeconds()),
+        Duration.ofSeconds(node.executionTimeoutSeconds()));
+    return new NodeDefinition(
+        node.id(),
+        task.name(),
+        TriggerRule.valueOf(node.triggerRule()),
+        retry,
+        NodeFailurePolicy.valueOf(node.failurePolicy()),
+        timeout,
+        NodeInputMapping.of(node.inputMapping()),
         Map.of("taskId", task.taskId(), "taskVersion", task.version()));
   }
-  private EdgeDefinition toEdgeDefinition(EdgeRequest edge) { return new EdgeDefinition(edge.source(), edge.target()); }
 
-  private Map<String, NodeMetadata> nodeMetadata(List<NodeRequest> nodes, Map<String, TaskVersionSnapshot> tasks) {
+  private EdgeDefinition toEdgeDefinition(EdgeRequest edge) {
+    return new EdgeDefinition(edge.source(), edge.target());
+  }
+
+  private Map<String, NodeMetadata> nodeMetadata(
+      List<NodeRequest> nodes,
+      Map<String, TaskVersionSnapshot> tasks) {
     Map<String, NodeMetadata> result = new LinkedHashMap<>();
     for (NodeRequest node : nodes) {
       TaskVersionSnapshot task = tasks.get(node.id());
-      result.put(node.id(), new NodeMetadata(task, node.triggerRule(), node.failurePolicy(), node.maxAttempts(),
-          node.retryDelaySeconds(), node.dispatchTimeoutSeconds(), node.executionTimeoutSeconds(), node.inputMapping()));
+      result.put(
+          node.id(),
+          new NodeMetadata(
+              task,
+              node.triggerRule(),
+              node.failurePolicy(),
+              node.maxAttempts(),
+              node.retryDelaySeconds(),
+              node.dispatchTimeoutSeconds(),
+              node.executionTimeoutSeconds(),
+              node.inputMapping()));
     }
     return Map.copyOf(result);
   }
 
+  private RuntimeMetadataRecord toPersistence(RunMetadata value) {
+    Map<String, NodeMetadataRecord> nodes = new LinkedHashMap<>();
+    value.nodes().forEach((nodeId, node) -> nodes.put(
+        nodeId,
+        new NodeMetadataRecord(
+            node.task(),
+            node.triggerRule(),
+            node.failurePolicy(),
+            node.maxAttempts(),
+            node.retryDelaySeconds(),
+            node.dispatchTimeoutSeconds(),
+            node.executionTimeoutSeconds(),
+            node.inputMapping())));
+    return new RuntimeMetadataRecord(
+        value.name(),
+        value.edgeCount(),
+        value.workflowTimeoutSeconds(),
+        value.failureStrategy(),
+        value.workflowVersionId(),
+        value.workflowVersionNo(),
+        value.testRun(),
+        nodes);
+  }
+
+  private RunMetadata fromPersistence(RuntimeMetadataRecord value) {
+    Map<String, NodeMetadata> nodes = new LinkedHashMap<>();
+    value.nodes().forEach((nodeId, node) -> nodes.put(
+        nodeId,
+        new NodeMetadata(
+            node.task(),
+            node.triggerRule(),
+            node.failurePolicy(),
+            node.maxAttempts(),
+            node.retryDelaySeconds(),
+            node.dispatchTimeoutSeconds(),
+            node.executionTimeoutSeconds(),
+            node.inputMapping())));
+    return new RunMetadata(
+        value.name(),
+        value.edgeCount(),
+        value.workflowTimeoutSeconds(),
+        value.failureStrategy(),
+        value.workflowVersionId(),
+        value.workflowVersionNo(),
+        value.testRun(),
+        Map.copyOf(nodes));
+  }
+
   private void enqueueDispatch(NodeDispatch dispatch) {
-    latestDispatches.computeIfAbsent(dispatch.workflowExecutionId(), ignored -> new ConcurrentHashMap<>()).put(dispatch.nodeId(), dispatch);
-    pendingDispatches.computeIfAbsent(dispatch.workflowExecutionId(), ignored -> new ConcurrentLinkedQueue<>()).offer(dispatch);
-    if (activeExecutions.contains(dispatch.workflowExecutionId())) drainDispatches(dispatch.workflowExecutionId());
+    latestDispatches
+        .computeIfAbsent(dispatch.workflowExecutionId(), ignored -> new ConcurrentHashMap<>())
+        .put(dispatch.nodeId(), dispatch);
+    pendingDispatches
+        .computeIfAbsent(dispatch.workflowExecutionId(), ignored -> new ConcurrentLinkedQueue<>())
+        .offer(dispatch);
+    if (activeExecutions.contains(dispatch.workflowExecutionId())) {
+      drainDispatches(dispatch.workflowExecutionId());
+    }
   }
 
   private void drainDispatches(String executionId) {
@@ -275,7 +544,10 @@ public class WorkflowRuntimeService {
     runtimeScheduler.schedule(start, delayMillis, TimeUnit.MILLISECONDS);
     log.debug(
         "[workflow] delayed dispatch scheduled execution={}, node={}, attempt={}, delayMillis={}",
-        dispatch.workflowExecutionId(), dispatch.nodeId(), dispatch.attemptId(), delayMillis);
+        dispatch.workflowExecutionId(),
+        dispatch.nodeId(),
+        dispatch.attemptId(),
+        delayMillis);
   }
 
   private void startNode(NodeDispatch dispatch) {
@@ -283,23 +555,64 @@ public class WorkflowRuntimeService {
     if (control == null) {
       log.debug(
           "[workflow] stale queued dispatch skipped execution={}, node={}, attempt={}",
-          dispatch.workflowExecutionId(), dispatch.nodeId(), dispatch.attemptId());
+          dispatch.workflowExecutionId(),
+          dispatch.nodeId(),
+          dispatch.attemptId());
       return;
     }
-    if (control.canceled()) { cleanupAttempt(dispatch, control); return; }
+    if (control.canceled()) {
+      cleanupAttempt(dispatch, control);
+      return;
+    }
     try {
       NodeMetadata node = requireMetadata(dispatch.workflowExecutionId()).nodes().get(dispatch.nodeId());
-      if (node == null) throw new IllegalStateException("工作流节点运行元数据不存在：" + dispatch.nodeId());
+      if (node == null) {
+        throw new IllegalStateException("工作流节点运行元数据不存在：" + dispatch.nodeId());
+      }
       SyncTaskExecution taskExecution = syncTaskRunner.start(node.task(), dispatch.attemptId());
+      runtimePersistence.bindExternalExecution(dispatch.attemptId(), taskExecution.executionId());
       control.bindTaskExecution(taskExecution.executionId());
       if (control.canceled()) {
-        cancelRemote(taskExecution.executionId()); cleanupAttempt(dispatch, control); return;
+        cancelRemote(taskExecution.executionId());
+        cleanupAttempt(dispatch, control);
+        return;
       }
-      engine.acknowledgeNodeStarted(dispatch.workflowExecutionId(), dispatch.nodeId(), dispatch.attemptId());
+      engine.acknowledgeNodeStarted(
+          dispatch.workflowExecutionId(), dispatch.nodeId(), dispatch.attemptId());
       publishCurrent(dispatch.workflowExecutionId());
-      log.info("[workflow] sync task started workflowExecution={}, node={}, attempt={}, task={}, taskVersion={}, taskExecution={}",
-          dispatch.workflowExecutionId(), dispatch.nodeId(), dispatch.attemptId(), node.task().taskId(),
-          node.task().version(), taskExecution.executionId());
+      log.info(
+          "[workflow] sync task started workflowExecution={}, node={}, attempt={}, task={}, taskVersion={}, taskExecution={}",
+          dispatch.workflowExecutionId(),
+          dispatch.nodeId(),
+          dispatch.attemptId(),
+          node.task().taskId(),
+          node.task().version(),
+          taskExecution.executionId());
+      handleTaskSnapshot(dispatch, control, node, taskExecution);
+    } catch (RuntimeException exception) {
+      failNode(dispatch, control, exception);
+    }
+  }
+
+  private void reconcileRecoveredAttempt(NodeRecovery recovery, NodeTaskControl control) {
+    NodeDispatch dispatch = recovery.dispatch();
+    if (control.canceled() || taskControls.get(dispatch.attemptId()) != control) return;
+    try {
+      NodeMetadata node = requireMetadata(dispatch.workflowExecutionId()).nodes().get(dispatch.nodeId());
+      if (node == null) {
+        throw new IllegalStateException("工作流节点恢复元数据不存在：" + dispatch.nodeId());
+      }
+      String taskExecutionId = control.taskExecutionId();
+      if (taskExecutionId == null) {
+        enqueueDispatch(dispatch);
+        return;
+      }
+      SyncTaskExecution taskExecution = syncTaskRunner.status(taskExecutionId);
+      if (recovery.attemptStatus() == NodeAttemptStatus.SUBMITTED && !taskExecution.terminal()) {
+        engine.acknowledgeNodeStarted(
+            dispatch.workflowExecutionId(), dispatch.nodeId(), dispatch.attemptId());
+        publishCurrent(dispatch.workflowExecutionId());
+      }
       handleTaskSnapshot(dispatch, control, node, taskExecution);
     } catch (RuntimeException exception) {
       failNode(dispatch, control, exception);
@@ -310,7 +623,9 @@ public class WorkflowRuntimeService {
     if (control.canceled() || taskControls.get(dispatch.attemptId()) != control) return;
     try {
       String taskExecutionId = control.taskExecutionId();
-      if (taskExecutionId == null) throw new IllegalStateException("同步任务执行 ID 不存在");
+      if (taskExecutionId == null) {
+        throw new IllegalStateException("同步任务执行 ID 不存在");
+      }
       handleTaskSnapshot(dispatch, control, node, syncTaskRunner.status(taskExecutionId));
     } catch (RuntimeException exception) {
       failNode(dispatch, control, exception);
@@ -318,7 +633,10 @@ public class WorkflowRuntimeService {
   }
 
   private void handleTaskSnapshot(
-      NodeDispatch dispatch, NodeTaskControl control, NodeMetadata node, SyncTaskExecution taskExecution) {
+      NodeDispatch dispatch,
+      NodeTaskControl control,
+      NodeMetadata node,
+      SyncTaskExecution taskExecution) {
     if (control.canceled()) return;
     if (!taskExecution.terminal()) {
       runtimeScheduler.schedule(
@@ -330,15 +648,23 @@ public class WorkflowRuntimeService {
     try {
       if (taskExecution.successful()) {
         Map<String, Object> output = new LinkedHashMap<>();
-        output.put("taskId", node.task().taskId()); output.put("taskName", node.task().name());
-        output.put("taskType", node.task().type()); output.put("taskVersion", node.task().version());
-        output.put("syncExecutionId", taskExecution.executionId()); output.put("syncStatus", taskExecution.status());
-        output.put("receivedInput", dispatch.nodeInput()); output.put("taskOutput", taskExecution.output());
-        engine.completeNode(dispatch.workflowExecutionId(), dispatch.nodeId(), dispatch.attemptId(), output);
+        output.put("taskId", node.task().taskId());
+        output.put("taskName", node.task().name());
+        output.put("taskType", node.task().type());
+        output.put("taskVersion", node.task().version());
+        output.put("syncExecutionId", taskExecution.executionId());
+        output.put("syncStatus", taskExecution.status());
+        output.put("receivedInput", dispatch.nodeInput());
+        output.put("taskOutput", taskExecution.output());
+        engine.completeNode(
+            dispatch.workflowExecutionId(), dispatch.nodeId(), dispatch.attemptId(), output);
       } else {
         String message = taskExecution.errorMessage();
-        if (message == null || message.isBlank()) message = "同步任务执行失败，状态：" + taskExecution.status();
-        engine.failNode(dispatch.workflowExecutionId(), dispatch.nodeId(), dispatch.attemptId(), message);
+        if (message == null || message.isBlank()) {
+          message = "同步任务执行失败，状态：" + taskExecution.status();
+        }
+        engine.failNode(
+            dispatch.workflowExecutionId(), dispatch.nodeId(), dispatch.attemptId(), message);
       }
       publishCurrent(dispatch.workflowExecutionId());
     } finally {
@@ -347,16 +673,31 @@ public class WorkflowRuntimeService {
   }
 
   private void failNode(NodeDispatch dispatch, NodeTaskControl control, RuntimeException exception) {
-    if (control.canceled()) { cleanupAttempt(dispatch, control); return; }
-    String message = exception.getMessage() == null ? exception.getClass().getSimpleName() : exception.getMessage();
-    log.error("[workflow] node failed execution={}, node={}, attempt={}, message={}",
-        dispatch.workflowExecutionId(), dispatch.nodeId(), dispatch.attemptId(), message, exception);
+    if (control.canceled()) {
+      cleanupAttempt(dispatch, control);
+      return;
+    }
+    String message = exception.getMessage() == null
+        ? exception.getClass().getSimpleName()
+        : exception.getMessage();
+    log.error(
+        "[workflow] node failed execution={}, node={}, attempt={}, message={}",
+        dispatch.workflowExecutionId(),
+        dispatch.nodeId(),
+        dispatch.attemptId(),
+        message,
+        exception);
     try {
-      engine.failNode(dispatch.workflowExecutionId(), dispatch.nodeId(), dispatch.attemptId(), message);
+      engine.failNode(
+          dispatch.workflowExecutionId(), dispatch.nodeId(), dispatch.attemptId(), message);
       publishCurrent(dispatch.workflowExecutionId());
     } catch (RuntimeException callback) {
-      log.warn("[workflow] failure callback skipped execution={}, node={}, attempt={}, message={}",
-          dispatch.workflowExecutionId(), dispatch.nodeId(), dispatch.attemptId(), callback.getMessage());
+      log.warn(
+          "[workflow] failure callback skipped execution={}, node={}, attempt={}, message={}",
+          dispatch.workflowExecutionId(),
+          dispatch.nodeId(),
+          dispatch.attemptId(),
+          callback.getMessage());
     } finally {
       cleanupAttempt(dispatch, control);
     }
@@ -368,107 +709,250 @@ public class WorkflowRuntimeService {
   }
 
   private void cancelRemote(String taskExecutionId) {
-    try { syncTaskRunner.cancel(taskExecutionId); }
-    catch (RuntimeException exception) { log.warn("[workflow] sync task cancel ignored taskExecution={}, message={}", taskExecutionId, exception.getMessage()); }
+    try {
+      syncTaskRunner.cancel(taskExecutionId);
+    } catch (RuntimeException exception) {
+      log.warn(
+          "[workflow] sync task cancel ignored taskExecution={}, message={}",
+          taskExecutionId,
+          exception.getMessage());
+    }
   }
 
   private void scanTimeouts() {
     for (String executionId : List.copyOf(activeExecutions)) {
       try {
-        WorkflowExecution before = requireExecution(executionId); String signature = runtimeSignature(before);
+        WorkflowExecution before = requireExecution(executionId);
+        String signature = runtimeSignature(before);
         WorkflowExecution after = engine.checkTimeouts(executionId);
-        if (!signature.equals(runtimeSignature(after))) publishCurrent(executionId);
+        if (!signature.equals(runtimeSignature(after))) {
+          publishCurrent(executionId);
+        }
       } catch (RuntimeException exception) {
-        log.debug("[workflow] timeout scan skipped execution={}, message={}", executionId, exception.getMessage());
+        log.debug(
+            "[workflow] timeout scan skipped execution={}, message={}",
+            executionId,
+            exception.getMessage());
       }
     }
   }
+
   private String runtimeSignature(WorkflowExecution execution) {
-    StringBuilder s = new StringBuilder(execution.status().name());
+    StringBuilder signature = new StringBuilder(execution.status().name());
     execution.nodes().values().forEach(node -> {
-      s.append('|').append(node.nodeId()).append(':').append(node.status().name());
+      signature.append('|').append(node.nodeId()).append(':').append(node.status().name());
       if (!node.attempts().isEmpty()) {
-        NodeAttempt a = node.attempts().get(node.attempts().size() - 1);
-        s.append(':').append(a.id()).append(':').append(a.status().name());
+        NodeAttempt attempt = node.attempts().get(node.attempts().size() - 1);
+        signature.append(':').append(attempt.id()).append(':').append(attempt.status().name());
       }
-    }); return s.toString();
+    });
+    return signature.toString();
   }
 
   private WorkflowInstanceVO publishAndView(WorkflowExecution execution) {
-    RunMetadata m = requireMetadata(execution.id()); WorkflowInstanceVO snapshot = toView(execution, m);
-    eventStreamService.publish(snapshot); if (isTerminal(snapshot.status())) cleanupTerminalRuntime(execution.id()); return snapshot;
+    RunMetadata runMetadata = requireMetadata(execution.id());
+    WorkflowInstanceVO snapshot = toView(execution, runMetadata);
+    eventStreamService.publish(snapshot);
+    if (isTerminal(snapshot.status())) {
+      cleanupTerminalRuntime(execution.id());
+    }
+    return snapshot;
   }
+
   private void publishCurrent(String executionId) {
     Object lock = publishLocks.computeIfAbsent(executionId, ignored -> new Object());
     synchronized (lock) {
-      RunMetadata m = metadata.get(executionId); if (m == null) return;
-      engine.findExecution(executionId).map(x -> toView(x, m)).ifPresent(snapshot -> {
-        eventStreamService.publish(snapshot);
-        if (isTerminal(snapshot.status())) { cleanupTerminalRuntime(executionId); publishLocks.remove(executionId, lock); }
-      });
+      RunMetadata runMetadata = findMetadata(executionId);
+      if (runMetadata == null) return;
+      engine.findExecution(executionId)
+          .map(execution -> toView(execution, runMetadata))
+          .ifPresent(snapshot -> {
+            eventStreamService.publish(snapshot);
+            if (isTerminal(snapshot.status())) {
+              cleanupTerminalRuntime(executionId);
+              publishLocks.remove(executionId, lock);
+            }
+          });
     }
   }
+
   private void cleanupTerminalRuntime(String executionId) {
-    activeExecutions.remove(executionId); pendingDispatches.remove(executionId);
-    taskControls.entrySet().removeIf(e -> executionId.equals(e.getValue().workflowExecutionId()));
-  }
-  private boolean isTerminal(String s) {
-    return "SUCCESS".equals(s) || "SUCCESS_WITH_WARNINGS".equals(s) || "FAILED".equals(s)
-        || "WARNING".equals(s) || "CANCELED".equals(s) || "TIMED_OUT".equals(s);
+    activeExecutions.remove(executionId);
+    pendingDispatches.remove(executionId);
+    latestDispatches.remove(executionId);
+    metadata.remove(executionId);
+    taskControls.entrySet()
+        .removeIf(entry -> executionId.equals(entry.getValue().workflowExecutionId()));
   }
 
-  private WorkflowInstanceVO toView(WorkflowExecution execution, RunMetadata m) {
-    List<NodeInstanceVO> nodes = execution.nodes().values().stream().map(n -> toNodeView(execution.id(), n, m.nodes().get(n.nodeId()))).toList();
-    return new WorkflowInstanceVO(execution.id(), execution.definitionId(), execution.sourceExecutionId(), m.name(),
-        execution.status().name(), m.failureStrategy(), execution.createdAt(), execution.runStartedAt(), execution.endedAt(),
-        m.workflowTimeoutSeconds(), execution.input(), nodes.size(), m.edgeCount(), nodes,
-        m.workflowVersionId(), m.workflowVersionNo(), m.testRun());
+  private boolean isTerminal(String status) {
+    return "SUCCESS".equals(status)
+        || "SUCCESS_WITH_WARNINGS".equals(status)
+        || "FAILED".equals(status)
+        || "WARNING".equals(status)
+        || "CANCELED".equals(status)
+        || "TIMED_OUT".equals(status);
   }
-  private NodeInstanceVO toNodeView(String executionId, NodeExecution node, NodeMetadata m) {
-    TaskVersionSnapshot task = m == null ? null : m.task();
+
+  private WorkflowInstanceVO toView(WorkflowExecution execution, RunMetadata runMetadata) {
+    List<NodeInstanceVO> nodes = execution.nodes().values().stream()
+        .map(node -> toNodeView(execution.id(), node, runMetadata.nodes().get(node.nodeId())))
+        .toList();
+    return new WorkflowInstanceVO(
+        execution.id(),
+        execution.definitionId(),
+        execution.sourceExecutionId(),
+        runMetadata.name(),
+        execution.status().name(),
+        runMetadata.failureStrategy(),
+        execution.createdAt(),
+        execution.runStartedAt(),
+        execution.endedAt(),
+        runMetadata.workflowTimeoutSeconds(),
+        execution.input(),
+        nodes.size(),
+        runMetadata.edgeCount(),
+        nodes,
+        runMetadata.workflowVersionId(),
+        runMetadata.workflowVersionNo(),
+        runMetadata.testRun());
+  }
+
+  private NodeInstanceVO toNodeView(
+      String executionId,
+      NodeExecution node,
+      NodeMetadata nodeMetadata) {
+    TaskVersionSnapshot task = nodeMetadata == null ? null : nodeMetadata.task();
     List<AttemptVO> attempts = node.attempts().stream().map(this::toAttemptView).toList();
-    NodeAttempt a = node.attempts().isEmpty() ? null : node.attempts().get(node.attempts().size() - 1);
-    ConcurrentMap<String, NodeDispatch> ds = latestDispatches.get(executionId); NodeDispatch d = ds == null ? null : ds.get(node.nodeId());
-    return new NodeInstanceVO(node.nodeId(), task == null ? null : task.taskId(), task == null ? node.nodeId() : task.name(),
-        task == null ? "SYNC" : task.type(), node.status().name(), m == null ? TriggerRule.ALL_SUCCESS.name() : m.triggerRule(),
-        m == null ? NodeFailurePolicy.FAIL_WORKFLOW.name() : m.failurePolicy(), node.errorMessage(),
-        a == null || a.failureReason() == null ? null : a.failureReason().name(), node.downstreamContinuationAllowed(), attempts.size(),
-        a == null ? null : a.id(), a == null ? null : a.attemptNumber(), m == null ? 1 : m.maxAttempts(),
-        m == null ? 0L : m.retryDelaySeconds(), m == null ? 0L : m.dispatchTimeoutSeconds(), m == null ? 0L : m.executionTimeoutSeconds(),
-        m == null ? Map.of() : m.inputMapping(), d == null ? Map.of() : d.nodeInput(), d == null ? Map.of() : d.predecessorOutputs(),
-        node.output(), attempts);
+    NodeAttempt attempt = node.attempts().isEmpty()
+        ? null
+        : node.attempts().get(node.attempts().size() - 1);
+    ConcurrentMap<String, NodeDispatch> dispatches = latestDispatches.get(executionId);
+    NodeDispatch dispatch = dispatches == null ? null : dispatches.get(node.nodeId());
+    return new NodeInstanceVO(
+        node.nodeId(),
+        task == null ? null : task.taskId(),
+        task == null ? node.nodeId() : task.name(),
+        task == null ? "SYNC" : task.type(),
+        node.status().name(),
+        nodeMetadata == null ? TriggerRule.ALL_SUCCESS.name() : nodeMetadata.triggerRule(),
+        nodeMetadata == null ? NodeFailurePolicy.FAIL_WORKFLOW.name() : nodeMetadata.failurePolicy(),
+        node.errorMessage(),
+        attempt == null || attempt.failureReason() == null
+            ? null
+            : attempt.failureReason().name(),
+        node.downstreamContinuationAllowed(),
+        attempts.size(),
+        attempt == null ? null : attempt.id(),
+        attempt == null ? null : attempt.attemptNumber(),
+        nodeMetadata == null ? 1 : nodeMetadata.maxAttempts(),
+        nodeMetadata == null ? 0L : nodeMetadata.retryDelaySeconds(),
+        nodeMetadata == null ? 0L : nodeMetadata.dispatchTimeoutSeconds(),
+        nodeMetadata == null ? 0L : nodeMetadata.executionTimeoutSeconds(),
+        nodeMetadata == null ? Map.of() : nodeMetadata.inputMapping(),
+        dispatch == null ? Map.of() : dispatch.nodeInput(),
+        dispatch == null ? Map.of() : dispatch.predecessorOutputs(),
+        node.output(),
+        attempts);
   }
-  private AttemptVO toAttemptView(NodeAttempt a) {
-    return new AttemptVO(a.id(), a.attemptNumber(), a.status().name(), a.failureReason() == null ? null : a.failureReason().name(),
-        a.errorMessage(), a.availableAt(), a.startedAt(), a.pausedAt(), a.pausedDuration().toMillis(), a.endedAt());
+
+  private AttemptVO toAttemptView(NodeAttempt attempt) {
+    return new AttemptVO(
+        attempt.id(),
+        attempt.attemptNumber(),
+        attempt.status().name(),
+        attempt.failureReason() == null ? null : attempt.failureReason().name(),
+        attempt.errorMessage(),
+        attempt.availableAt(),
+        attempt.startedAt(),
+        attempt.pausedAt(),
+        attempt.pausedDuration().toMillis(),
+        attempt.endedAt());
   }
 
   @PreDestroy
-  void shutdown() { runtimeScheduler.shutdownNow(); ioExecutor.shutdownNow(); }
+  void shutdown() {
+    runtimeScheduler.shutdownNow();
+    ioExecutor.shutdownNow();
+  }
 
   private record RunMetadata(
-      String name, int edgeCount, long workflowTimeoutSeconds, String failureStrategy,
-      String workflowVersionId, Integer workflowVersionNo, boolean testRun, Map<String, NodeMetadata> nodes) {}
+      String name,
+      int edgeCount,
+      long workflowTimeoutSeconds,
+      String failureStrategy,
+      String workflowVersionId,
+      Integer workflowVersionNo,
+      boolean testRun,
+      Map<String, NodeMetadata> nodes) {
+  }
+
   private record NodeMetadata(
-      TaskVersionSnapshot task, String triggerRule, String failurePolicy, int maxAttempts,
-      long retryDelaySeconds, long dispatchTimeoutSeconds, long executionTimeoutSeconds, Map<String, String> inputMapping) {}
+      TaskVersionSnapshot task,
+      String triggerRule,
+      String failurePolicy,
+      int maxAttempts,
+      long retryDelaySeconds,
+      long dispatchTimeoutSeconds,
+      long executionTimeoutSeconds,
+      Map<String, String> inputMapping) {
+  }
 
   private final class RuntimeNodeExecutor implements NodeExecutor {
-    @Override public void submit(NodeDispatch dispatch) {
-      taskControls.computeIfAbsent(dispatch.attemptId(), ignored -> new NodeTaskControl(dispatch.workflowExecutionId()));
+    @Override
+    public void submit(NodeDispatch dispatch) {
+      taskControls.computeIfAbsent(
+          dispatch.attemptId(),
+          ignored -> new NodeTaskControl(dispatch.workflowExecutionId()));
       enqueueDispatch(dispatch);
     }
-    @Override public void cancel(NodeCancellation cancellation) {
-      NodeTaskControl control = taskControls.get(cancellation.attemptId()); if (control == null) return;
-      control.cancel(); String taskExecutionId = control.taskExecutionId();
-      if (taskExecutionId != null) ioExecutor.execute(() -> cancelRemote(taskExecutionId));
+
+    @Override
+    public void recover(NodeRecovery recovery) {
+      NodeDispatch dispatch = recovery.dispatch();
+      latestDispatches
+          .computeIfAbsent(dispatch.workflowExecutionId(), ignored -> new ConcurrentHashMap<>())
+          .put(dispatch.nodeId(), dispatch);
+      NodeTaskControl control = taskControls.computeIfAbsent(
+          dispatch.attemptId(),
+          ignored -> new NodeTaskControl(dispatch.workflowExecutionId()));
+      runtimePersistence.findExternalExecution(dispatch.attemptId()).ifPresent(control::bindTaskExecution);
+
+      if (recovery.attemptStatus() == NodeAttemptStatus.PAUSED) {
+        return;
+      }
+      if (control.taskExecutionId() == null) {
+        // The process may have crashed before or just after remote submission. Reusing the same
+        // attemptId as the runner idempotency key makes this a safe find-or-create operation.
+        enqueueDispatch(dispatch);
+        return;
+      }
+      ioExecutor.execute(() -> reconcileRecoveredAttempt(recovery, control));
     }
-    @Override public NodeControlResult pause(NodePauseRequest request) {
-      log.debug("[workflow] sync task pause unsupported; pausing scheduling only execution={}, node={}, attempt={}",
-          request.workflowExecutionId(), request.nodeId(), request.attemptId());
+
+    @Override
+    public void cancel(NodeCancellation cancellation) {
+      NodeTaskControl control = taskControls.get(cancellation.attemptId());
+      if (control == null) return;
+      control.cancel();
+      String taskExecutionId = control.taskExecutionId();
+      if (taskExecutionId != null) {
+        ioExecutor.execute(() -> cancelRemote(taskExecutionId));
+      }
+    }
+
+    @Override
+    public NodeControlResult pause(NodePauseRequest request) {
+      log.debug(
+          "[workflow] sync task pause unsupported; pausing scheduling only execution={}, node={}, attempt={}",
+          request.workflowExecutionId(),
+          request.nodeId(),
+          request.attemptId());
       return NodeControlResult.UNSUPPORTED;
     }
-    @Override public void resume(NodeResumeRequest request) {
+
+    @Override
+    public void resume(NodeResumeRequest request) {
       // UNSUPPORTED attempts are never physically resumed; engine resume only releases deferred scheduling.
     }
   }
@@ -477,11 +961,29 @@ public class WorkflowRuntimeService {
     private final String workflowExecutionId;
     private volatile String taskExecutionId;
     private volatile boolean canceled;
-    NodeTaskControl(String workflowExecutionId) { this.workflowExecutionId = workflowExecutionId; }
-    String workflowExecutionId() { return workflowExecutionId; }
-    String taskExecutionId() { return taskExecutionId; }
-    void bindTaskExecution(String id) { this.taskExecutionId = id; }
-    void cancel() { this.canceled = true; }
-    boolean canceled() { return canceled; }
+
+    NodeTaskControl(String workflowExecutionId) {
+      this.workflowExecutionId = workflowExecutionId;
+    }
+
+    String workflowExecutionId() {
+      return workflowExecutionId;
+    }
+
+    String taskExecutionId() {
+      return taskExecutionId;
+    }
+
+    void bindTaskExecution(String id) {
+      this.taskExecutionId = id;
+    }
+
+    void cancel() {
+      this.canceled = true;
+    }
+
+    boolean canceled() {
+      return canceled;
+    }
   }
 }

--- a/yak-ops-business/yak-ops-business-workflow/src/main/resources/db/migration/yak-workflow/V1__workflow_persistence.sql
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/resources/db/migration/yak-workflow/V1__workflow_persistence.sql
@@ -1,0 +1,96 @@
+CREATE TABLE IF NOT EXISTS yak_workflow_definition (
+    id VARCHAR(80) NOT NULL,
+    name VARCHAR(200) NOT NULL,
+    description VARCHAR(1000) NULL,
+    status VARCHAR(32) NOT NULL,
+    draft_revision BIGINT NOT NULL DEFAULT 1,
+    latest_version_no INT NOT NULL DEFAULT 0,
+    active_version_id VARCHAR(80) NULL,
+    draft_json LONGTEXT NOT NULL,
+    latest_execution_id VARCHAR(80) NULL,
+    latest_execution_status VARCHAR(32) NULL,
+    create_time DATETIME(3) NOT NULL,
+    update_time DATETIME(3) NOT NULL,
+    PRIMARY KEY (id),
+    KEY idx_yak_workflow_definition_status (status),
+    KEY idx_yak_workflow_definition_update_time (update_time)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS yak_workflow_version (
+    id VARCHAR(80) NOT NULL,
+    workflow_id VARCHAR(80) NULL,
+    version_no INT NULL,
+    version_kind VARCHAR(16) NOT NULL DEFAULT 'PUBLISHED',
+    draft_revision BIGINT NULL,
+    run_request_json LONGTEXT NULL,
+    editor_meta_json LONGTEXT NULL,
+    task_versions_json LONGTEXT NULL,
+    engine_definition_json LONGTEXT NULL,
+    create_time DATETIME(3) NOT NULL,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_yak_workflow_version_no (workflow_id, version_no),
+    KEY idx_yak_workflow_version_workflow (workflow_id, create_time)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS yak_workflow_execution (
+    id VARCHAR(80) NOT NULL,
+    definition_id VARCHAR(80) NOT NULL,
+    source_execution_id VARCHAR(80) NULL,
+    status VARCHAR(32) NOT NULL,
+    input_json LONGTEXT NOT NULL,
+    scheduling_stopped TINYINT(1) NOT NULL DEFAULT 0,
+    run_started_at DATETIME(3) NULL,
+    paused_at DATETIME(3) NULL,
+    paused_duration_ms BIGINT NOT NULL DEFAULT 0,
+    created_at DATETIME(3) NOT NULL,
+    updated_at DATETIME(3) NOT NULL,
+    ended_at DATETIME(3) NULL,
+    workflow_name VARCHAR(200) NULL,
+    workflow_version_id VARCHAR(80) NULL,
+    workflow_version_no INT NULL,
+    test_run TINYINT(1) NOT NULL DEFAULT 0,
+    edge_count INT NOT NULL DEFAULT 0,
+    workflow_timeout_seconds BIGINT NOT NULL DEFAULT 0,
+    failure_strategy VARCHAR(64) NULL,
+    PRIMARY KEY (id),
+    KEY idx_yak_workflow_execution_status (status, updated_at),
+    KEY idx_yak_workflow_execution_version (workflow_version_id),
+    KEY idx_yak_workflow_execution_created (created_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS yak_workflow_node_execution (
+    id VARCHAR(80) NOT NULL,
+    workflow_execution_id VARCHAR(80) NOT NULL,
+    node_id VARCHAR(120) NOT NULL,
+    failure_policy VARCHAR(32) NOT NULL,
+    status VARCHAR(32) NOT NULL,
+    output_json LONGTEXT NOT NULL,
+    error_message TEXT NULL,
+    failure_handled TINYINT(1) NOT NULL DEFAULT 0,
+    downstream_continuation_allowed TINYINT(1) NOT NULL DEFAULT 0,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_yak_workflow_node_execution (workflow_execution_id, node_id),
+    KEY idx_yak_workflow_node_status (workflow_execution_id, status)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS yak_workflow_node_attempt (
+    id VARCHAR(80) NOT NULL,
+    node_execution_id VARCHAR(80) NOT NULL,
+    workflow_execution_id VARCHAR(80) NOT NULL,
+    node_id VARCHAR(120) NOT NULL,
+    attempt_no INT NOT NULL,
+    available_at DATETIME(3) NOT NULL,
+    status VARCHAR(32) NOT NULL,
+    resume_target_status VARCHAR(32) NULL,
+    started_at DATETIME(3) NULL,
+    paused_at DATETIME(3) NULL,
+    paused_duration_ms BIGINT NOT NULL DEFAULT 0,
+    ended_at DATETIME(3) NULL,
+    error_message TEXT NULL,
+    failure_reason VARCHAR(64) NULL,
+    external_execution_id VARCHAR(120) NULL,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_yak_workflow_attempt_no (node_execution_id, attempt_no),
+    KEY idx_yak_workflow_attempt_workflow (workflow_execution_id, status),
+    KEY idx_yak_workflow_attempt_external (external_execution_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/yak-ops-business/yak-ops-business-workflow/src/main/resources/db/migration/yak-workflow/V1__workflow_persistence.sql
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/resources/db/migration/yak-workflow/V1__workflow_persistence.sql
@@ -26,6 +26,7 @@ CREATE TABLE IF NOT EXISTS yak_workflow_version (
     editor_meta_json LONGTEXT NULL,
     task_versions_json LONGTEXT NULL,
     engine_definition_json LONGTEXT NULL,
+    runtime_metadata_json LONGTEXT NULL,
     create_time DATETIME(3) NOT NULL,
     PRIMARY KEY (id),
     UNIQUE KEY uk_yak_workflow_version_no (workflow_id, version_no),

--- a/yak-ops-business/yak-ops-business-workflow/src/main/resources/db/migration/yak-workflow/V1__workflow_persistence.sql
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/resources/db/migration/yak-workflow/V1__workflow_persistence.sql
@@ -52,6 +52,7 @@ CREATE TABLE IF NOT EXISTS yak_workflow_execution (
     edge_count INT NOT NULL DEFAULT 0,
     workflow_timeout_seconds BIGINT NOT NULL DEFAULT 0,
     failure_strategy VARCHAR(64) NULL,
+    runtime_metadata_json LONGTEXT NULL,
     PRIMARY KEY (id),
     KEY idx_yak_workflow_execution_status (status, updated_at),
     KEY idx_yak_workflow_execution_version (workflow_version_id),

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowRuntimeRecoveryTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowRuntimeRecoveryTest.java
@@ -1,0 +1,204 @@
+package io.yak.ops.business.workflow.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.yak.framework.workflow.engine.support.InMemoryExecutionRepository;
+import io.yak.framework.workflow.engine.support.InMemoryWorkflowDefinitionRepository;
+import io.yak.ops.business.job.task.SyncTaskExecution;
+import io.yak.ops.business.job.task.SyncTaskRunner;
+import io.yak.ops.business.job.task.TaskDefinition;
+import io.yak.ops.business.job.task.TaskRegistry;
+import io.yak.ops.business.job.task.TaskVersionSnapshot;
+import io.yak.ops.business.workflow.model.WorkflowInstanceVO;
+import io.yak.ops.business.workflow.model.WorkflowRunRequest;
+import io.yak.ops.business.workflow.model.WorkflowRunRequest.NodeRequest;
+import io.yak.ops.business.workflow.persistence.InMemoryWorkflowRuntimePersistence;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class WorkflowRuntimeRecoveryTest {
+
+  private WorkflowRuntimeService first;
+  private WorkflowRuntimeService second;
+
+  @AfterEach
+  void tearDown() {
+    if (first != null) first.shutdown();
+    if (second != null) second.shutdown();
+  }
+
+  @Test
+  void shouldRestartPersistedSubmittedAttemptWithSameAttemptId()
+      throws InterruptedException {
+    InMemoryWorkflowDefinitionRepository definitions = new InMemoryWorkflowDefinitionRepository();
+    InMemoryExecutionRepository executions = new InMemoryExecutionRepository();
+    InMemoryWorkflowRuntimePersistence runtime = new InMemoryWorkflowRuntimePersistence();
+    RecordingRunner runner = new RecordingRunner();
+    TaskRegistry registry = registry();
+
+    first = service(registry, runner, definitions, executions, runtime);
+    WorkflowInstanceVO prepared = first.run(request());
+    String attemptId = node(prepared).currentAttemptId();
+    assertThat(runner.starts()).isZero();
+    first.shutdown();
+    first = null;
+
+    second = service(registry, runner, definitions, executions, runtime);
+    // Startup recovery pre-registers persisted executions as active before reconciliation.
+    second.activate(prepared.id());
+    assertThat(second.recoverPersistedExecutions()).isEqualTo(1);
+    waitFor(() -> runner.starts() == 1);
+
+    WorkflowInstanceVO recovered = second.getInstance(prepared.id());
+    assertThat(node(recovered).currentAttemptId()).isEqualTo(attemptId);
+    assertThat(node(recovered).attemptCount()).isEqualTo(1);
+    assertThat(runner.idempotencyKey()).isEqualTo(attemptId);
+  }
+
+  @Test
+  void shouldPollBoundRemoteExecutionWithoutStartingAnotherOne()
+      throws InterruptedException {
+    InMemoryWorkflowDefinitionRepository definitions = new InMemoryWorkflowDefinitionRepository();
+    InMemoryExecutionRepository executions = new InMemoryExecutionRepository();
+    InMemoryWorkflowRuntimePersistence runtime = new InMemoryWorkflowRuntimePersistence();
+    RecordingRunner runner = new RecordingRunner();
+    TaskRegistry registry = registry();
+
+    first = service(registry, runner, definitions, executions, runtime);
+    WorkflowInstanceVO prepared = first.run(request());
+    first.activate(prepared.id());
+    waitFor(() -> runner.starts() == 1);
+    waitFor(() -> "RUNNING".equals(node(first.getInstance(prepared.id())).status()));
+    String attemptId = node(first.getInstance(prepared.id())).currentAttemptId();
+    first.shutdown();
+    first = null;
+
+    second = service(registry, runner, definitions, executions, runtime);
+    second.activate(prepared.id());
+    assertThat(second.recoverPersistedExecutions()).isEqualTo(1);
+    waitFor(() -> runner.statusCalls() > 0);
+
+    assertThat(runner.starts()).isEqualTo(1);
+    assertThat(node(second.getInstance(prepared.id())).currentAttemptId()).isEqualTo(attemptId);
+  }
+
+  private WorkflowRuntimeService service(
+      TaskRegistry registry,
+      RecordingRunner runner,
+      InMemoryWorkflowDefinitionRepository definitions,
+      InMemoryExecutionRepository executions,
+      InMemoryWorkflowRuntimePersistence runtime) {
+    return new WorkflowRuntimeService(
+        new WorkflowEventStreamService(),
+        registry,
+        runner,
+        10_000L,
+        definitions,
+        executions,
+        runtime);
+  }
+
+  private TaskRegistry registry() {
+    return new TaskRegistry() {
+      @Override
+      public List<TaskDefinition> list() {
+        return List.of(new TaskDefinition("task-a", "Task A", "SYNC"));
+      }
+
+      @Override
+      public TaskDefinition get(String taskId) {
+        return new TaskDefinition(taskId, "Task A", "SYNC");
+      }
+    };
+  }
+
+  private WorkflowRunRequest request() {
+    return new WorkflowRunRequest(
+        "recovery",
+        List.of(new NodeRequest("a", "task-a")),
+        List.of(),
+        Map.of());
+  }
+
+  private WorkflowInstanceVO.NodeInstanceVO node(WorkflowInstanceVO instance) {
+    return instance.nodes().stream()
+        .filter(node -> "a".equals(node.id()))
+        .findFirst()
+        .orElseThrow();
+  }
+
+  private void waitFor(Check check) throws InterruptedException {
+    for (int i = 0; i < 200; i++) {
+      if (check.done()) return;
+      Thread.sleep(10L);
+    }
+    assertThat(check.done()).isTrue();
+  }
+
+  @FunctionalInterface
+  private interface Check {
+    boolean done();
+  }
+
+  private static final class RecordingRunner implements SyncTaskRunner {
+    private final AtomicInteger starts = new AtomicInteger();
+    private final AtomicInteger statusCalls = new AtomicInteger();
+    private final ConcurrentMap<String, SyncTaskExecution> executions = new ConcurrentHashMap<>();
+    private volatile String idempotencyKey;
+
+    int starts() {
+      return starts.get();
+    }
+
+    int statusCalls() {
+      return statusCalls.get();
+    }
+
+    String idempotencyKey() {
+      return idempotencyKey;
+    }
+
+    @Override
+    public SyncTaskExecution start(String taskId) {
+      return startInternal(null);
+    }
+
+    @Override
+    public SyncTaskExecution start(TaskVersionSnapshot snapshot, String key) {
+      idempotencyKey = key;
+      return startInternal(key);
+    }
+
+    private SyncTaskExecution startInternal(String key) {
+      int number = starts.incrementAndGet();
+      String id = "remote-" + number;
+      SyncTaskExecution execution = new SyncTaskExecution(
+          id,
+          "RUNNING",
+          null,
+          Map.of("idempotencyKey", key == null ? "" : key));
+      executions.put(id, execution);
+      return execution;
+    }
+
+    @Override
+    public SyncTaskExecution status(String executionId) {
+      statusCalls.incrementAndGet();
+      SyncTaskExecution execution = executions.get(executionId);
+      if (execution == null) {
+        throw new IllegalArgumentException("execution not found: " + executionId);
+      }
+      return execution;
+    }
+
+    @Override
+    public void cancel(String executionId) {
+      // Not used by these recovery tests.
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Move Yak Ops workflow from process-memory state to durable production-oriented persistence while keeping `yak-workflow-engine` database-agnostic and small.

> Depends on framework Draft PR: weifuwan/yak-framework#91

## Persistence model

Add five workflow tables, intentionally stopping short of DolphinScheduler-style command/master/event infrastructure:

1. `yak_workflow_definition` — current editable draft projection and active version pointer
2. `yak_workflow_version` — immutable published/runtime definition snapshots
3. `yak_workflow_execution` — one workflow run
4. `yak_workflow_node_execution` — one logical node state inside a run
5. `yak_workflow_node_attempt` — concrete retry/attempt lifecycle and external execution binding

Definition/version use JSON snapshots where immutable document storage is appropriate. Runtime workflow/node/attempt state is structured for recovery, history, monitoring and queries.

Workflow Flyway shares the existing `yak.database` business datasource but owns an independent `yak_workflow_schema_history` table.

## Durable definition/version catalog

`WorkflowDefinitionService` no longer treats its `ConcurrentMap` as the production fact source.

- editable drafts are persisted in `yak_workflow_definition`;
- publish inserts an immutable `PUBLISHED` workflow version and advances `active_version_id` in one database transaction;
- published versions keep pinned `TaskVersionSnapshot` bindings;
- delete removes only the editable current projection; historical published versions remain available for old executions;
- the in-memory catalog remains only as a database-disabled/test fallback.

Formal runs use the published workflow-version id as the engine definition id. Draft/direct runs receive a durable `RUNTIME` definition row instead of a JVM-only temporary DAG.

## Durable engine execution repository

Add JDBC adapters for the existing framework repository SPIs:

- `JdbcWorkflowEngineDefinitionRepository`
- `JdbcWorkflowExecutionRepository`

`JdbcWorkflowExecutionRepository` persists the framework aggregate transactionally and rehydrates it through the snapshot/restore APIs from framework PR #91. It does not replay the DAG to reconstruct state.

The execution snapshot persists workflow/node/attempt state including original attempt ids, retry `availableAt`, pause duration, input/output, lifecycle timestamps and failure-handling flags.

## Runtime recovery metadata

Runtime-only maps remain as acceleration, not historical fact sources.

Pinned task bindings and node runtime policies are persisted as `runtime_metadata_json` on the immutable version/runtime-definition row before `engine.start()`, then copied to the concrete execution row. This closes the crash window where an execution row could exist before its task-binding metadata was durable.

History reads now reload executions and metadata from durable repositories after terminal in-memory caches are cleared.

## Startup crash recovery

Add `WorkflowRecoveryService` and integrate framework `WorkflowRecoveryCoordinator`.

On startup Yak Ops finds only non-terminal executions, rebuilds transient runtime controls, restores immutable definition + execution/node/attempt state, reconciles existing Attempts without changing their identity, and resumes timeout scanning / remote polling.

Recovery matrix:

- persisted `SUBMITTED`, no external execution binding -> re-submit with the **same attemptId** and original `availableAt`;
- external execution already bound -> do **not** start a second task; query/poll the original execution;
- terminal node -> never re-run it;
- paused attempt -> restore binding without automatically starting it;
- persisted WAITING/READY nodes -> framework scheduler advances them only when the workflow is RUNNING and scheduling is enabled.

## Local + remote start idempotency

PR #288 already propagated `workflow attemptId -> SyncTaskRunner -> OfflineExecution.idempotencyKey -> Link-Up`.

This PR completes the local find-or-create side:

- reuse the existing V2 `idempotency_key VARCHAR(128)` + unique index `uk_yak_offline_idempotency`; no new offline-sync schema migration is needed;
- add `OfflineExecutionIdempotencyRepository`;
- `OfflineExecutionClaimService.claimSnapshot(...)` reuses an existing execution for the same workflow Attempt instead of inserting another row;
- mismatched payload/version using the same idempotency key is rejected as an idempotency conflict;
- keep `ClaimResult` source-compatible for existing callers.

Therefore a crash after local persistence, during uncertain Link-Up submission, or before the workflow runtime binds the returned execution id can safely retry the same Attempt identity.

## Regression coverage

Add/extend tests for framework snapshot/restore, same-Attempt recovery, workflow Attempt idempotency reuse, restart before remote start, and restart after an external execution is already bound without starting a duplicate.

## Scope intentionally not included

- no workflow command table;
- no event sourcing table;
- no Master election / lease / heartbeat;
- no distributed resource queue;
- no loop/sub-workflow/dynamic-node work;
- no persistence framework inside `yak-framework`.

Those can be added later if Yak Ops moves to multi-Master workflow ownership; they are not necessary for the first durable single-Master production runtime.

## Validation

- branch is based on current `main` and was 0 commits behind at PR creation time;
- previous workflow runtime P0 PR #288 is already merged into this base;
- framework PR #91 is Draft and mergeable; this PR intentionally depends on its new snapshot/recovery APIs;
- GitHub currently reports no configured commit-status checks for these heads;
- this execution environment cannot obtain a full local checkout, so full Maven/Flyway integration execution remains required before either PR is marked ready.