### PR TITLE
fix(workflow): make durable persistence wiring type-safe

### DIFF
--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowDefinitionService.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowDefinitionService.java
@@ -11,7 +11,6 @@ import io.yak.ops.business.workflow.model.WorkflowInstanceVO;
 import io.yak.ops.business.workflow.model.WorkflowRunRequest;
 import io.yak.ops.business.workflow.model.WorkflowVersionVO;
 import io.yak.ops.business.workflow.model.WorkflowVersionVO.TaskBindingVO;
-import io.yak.ops.business.workflow.persistence.JdbcWorkflowCatalogRepository;
 import io.yak.ops.business.workflow.persistence.NoopWorkflowDefinitionPersistence;
 import io.yak.ops.business.workflow.persistence.WorkflowDefinitionPersistence;
 import io.yak.ops.business.workflow.persistence.WorkflowDefinitionPersistence.DefinitionRecord;
@@ -33,6 +32,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
@@ -51,18 +51,31 @@ public class WorkflowDefinitionService {
   public WorkflowDefinitionService(
       WorkflowRuntimeService runtimeService,
       TaskRegistry taskRegistry,
-      ObjectProvider<JdbcWorkflowCatalogRepository> persistence) {
-    this(
-        runtimeService,
-        taskRegistry,
-        persistence.getIfAvailable(() -> NoopWorkflowDefinitionPersistence.INSTANCE));
+      ObjectProvider<WorkflowDefinitionPersistence> persistence,
+      @Value("${yak.database.enabled:true}") boolean databaseEnabled) {
+    this(runtimeService, taskRegistry, resolvePersistence(persistence, databaseEnabled));
   }
 
-  /** Focused tests and database-disabled development retain the lightweight in-memory catalog. */
+  /** Focused tests and explicit database-disabled development retain the lightweight catalog. */
   WorkflowDefinitionService(
       WorkflowRuntimeService runtimeService,
       TaskRegistry taskRegistry) {
     this(runtimeService, taskRegistry, NoopWorkflowDefinitionPersistence.INSTANCE);
+  }
+
+  private static WorkflowDefinitionPersistence resolvePersistence(
+      ObjectProvider<WorkflowDefinitionPersistence> provider,
+      boolean databaseEnabled) {
+    WorkflowDefinitionPersistence resolved = provider.getIfAvailable();
+    if (resolved != null) {
+      return resolved;
+    }
+    if (!databaseEnabled) {
+      return NoopWorkflowDefinitionPersistence.INSTANCE;
+    }
+    throw new IllegalStateException(
+        "Workflow durable persistence bean is missing while yak.database.enabled=true: "
+            + "WorkflowDefinitionPersistence");
   }
 
   WorkflowDefinitionService(

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowRuntimeService.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowRuntimeService.java
@@ -43,9 +43,6 @@ import io.yak.ops.business.workflow.model.WorkflowRunRequest;
 import io.yak.ops.business.workflow.model.WorkflowRunRequest.EdgeRequest;
 import io.yak.ops.business.workflow.model.WorkflowRunRequest.NodeRequest;
 import io.yak.ops.business.workflow.persistence.InMemoryWorkflowRuntimePersistence;
-import io.yak.ops.business.workflow.persistence.JdbcWorkflowEngineDefinitionRepository;
-import io.yak.ops.business.workflow.persistence.JdbcWorkflowExecutionRepository;
-import io.yak.ops.business.workflow.persistence.JdbcWorkflowRuntimeRepository;
 import io.yak.ops.business.workflow.persistence.WorkflowRuntimePersistence;
 import io.yak.ops.business.workflow.persistence.WorkflowRuntimePersistence.NodeMetadataRecord;
 import io.yak.ops.business.workflow.persistence.WorkflowRuntimePersistence.RuntimeMetadataRecord;
@@ -67,10 +64,12 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
@@ -104,20 +103,33 @@ public class WorkflowRuntimeService {
       WorkflowEventStreamService eventStreamService,
       TaskRegistry taskRegistry,
       SyncTaskRunner syncTaskRunner,
-      ObjectProvider<JdbcWorkflowEngineDefinitionRepository> definitionRepository,
-      ObjectProvider<JdbcWorkflowExecutionRepository> executionRepository,
-      ObjectProvider<JdbcWorkflowRuntimeRepository> runtimePersistence) {
+      ObjectProvider<WorkflowDefinitionRepository> definitionRepository,
+      ObjectProvider<ExecutionRepository> executionRepository,
+      ObjectProvider<WorkflowRuntimePersistence> runtimePersistence,
+      @Value("${yak.database.enabled:true}") boolean databaseEnabled) {
     this(
         eventStreamService,
         taskRegistry,
         syncTaskRunner,
         TASK_POLL_INTERVAL_MILLIS,
-        definitionRepository.getIfAvailable(InMemoryWorkflowDefinitionRepository::new),
-        executionRepository.getIfAvailable(InMemoryExecutionRepository::new),
-        runtimePersistence.getIfAvailable(InMemoryWorkflowRuntimePersistence::new));
+        resolvePersistence(
+            definitionRepository,
+            databaseEnabled,
+            InMemoryWorkflowDefinitionRepository::new,
+            "WorkflowDefinitionRepository"),
+        resolvePersistence(
+            executionRepository,
+            databaseEnabled,
+            InMemoryExecutionRepository::new,
+            "ExecutionRepository"),
+        resolvePersistence(
+            runtimePersistence,
+            databaseEnabled,
+            InMemoryWorkflowRuntimePersistence::new,
+            "WorkflowRuntimePersistence"));
   }
 
-  /** Focused tests and database-disabled development keep the original lightweight constructor. */
+  /** Focused tests and explicit database-disabled development keep the lightweight runtime. */
   WorkflowRuntimeService(
       WorkflowEventStreamService eventStreamService,
       TaskRegistry taskRegistry,
@@ -131,6 +143,23 @@ public class WorkflowRuntimeService {
         new InMemoryWorkflowDefinitionRepository(),
         new InMemoryExecutionRepository(),
         new InMemoryWorkflowRuntimePersistence());
+  }
+
+  private static <T> T resolvePersistence(
+      ObjectProvider<T> provider,
+      boolean databaseEnabled,
+      Supplier<T> fallback,
+      String componentName) {
+    T resolved = provider.getIfAvailable();
+    if (resolved != null) {
+      return resolved;
+    }
+    if (!databaseEnabled) {
+      return fallback.get();
+    }
+    throw new IllegalStateException(
+        "Workflow durable persistence bean is missing while yak.database.enabled=true: "
+            + componentName);
   }
 
   WorkflowRuntimeService(

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowPersistenceWiringTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowPersistenceWiringTest.java
@@ -1,0 +1,70 @@
+package io.yak.ops.business.workflow.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
+import io.yak.framework.workflow.engine.spi.ExecutionRepository;
+import io.yak.framework.workflow.engine.spi.WorkflowDefinitionRepository;
+import io.yak.ops.business.job.task.SyncTaskRunner;
+import io.yak.ops.business.job.task.TaskRegistry;
+import io.yak.ops.business.workflow.persistence.WorkflowDefinitionPersistence;
+import io.yak.ops.business.workflow.persistence.WorkflowRuntimePersistence;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+
+class WorkflowPersistenceWiringTest {
+
+  @Test
+  void runtimeShouldFailFastWhenDatabaseIsEnabledButRepositoriesAreMissing() {
+    DefaultListableBeanFactory beans = new DefaultListableBeanFactory();
+
+    assertThatThrownBy(() -> new WorkflowRuntimeService(
+        new WorkflowEventStreamService(),
+        mock(TaskRegistry.class),
+        mock(SyncTaskRunner.class),
+        provider(beans, WorkflowDefinitionRepository.class),
+        provider(beans, ExecutionRepository.class),
+        provider(beans, WorkflowRuntimePersistence.class),
+        true))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("WorkflowDefinitionRepository");
+  }
+
+  @Test
+  void definitionServiceShouldFailFastWhenDatabaseIsEnabledButCatalogIsMissing() {
+    DefaultListableBeanFactory beans = new DefaultListableBeanFactory();
+
+    assertThatThrownBy(() -> new WorkflowDefinitionService(
+        mock(WorkflowRuntimeService.class),
+        mock(TaskRegistry.class),
+        provider(beans, WorkflowDefinitionPersistence.class),
+        true))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("WorkflowDefinitionPersistence");
+  }
+
+  @Test
+  void runtimeShouldAllowExplicitDatabaseDisabledMode() {
+    DefaultListableBeanFactory beans = new DefaultListableBeanFactory();
+    WorkflowRuntimeService runtime = new WorkflowRuntimeService(
+        new WorkflowEventStreamService(),
+        mock(TaskRegistry.class),
+        mock(SyncTaskRunner.class),
+        provider(beans, WorkflowDefinitionRepository.class),
+        provider(beans, ExecutionRepository.class),
+        provider(beans, WorkflowRuntimePersistence.class),
+        false);
+    try {
+      // Construction itself proves the explicit in-memory development/test path remains available.
+    } finally {
+      runtime.shutdown();
+    }
+  }
+
+  private static <T> ObjectProvider<T> provider(
+      DefaultListableBeanFactory beans,
+      Class<T> type) {
+    return beans.getBeanProvider(type);
+  }
+}


### PR DESCRIPTION
## Summary

Fix the workflow persistence wiring compile error introduced after durable workflow persistence was merged, and make the production persistence boundary explicit.

## Root cause

`WorkflowRuntimeService` injected concrete providers such as:

```java
ObjectProvider<JdbcWorkflowEngineDefinitionRepository>
```

but supplied framework in-memory implementations as `getIfAvailable(...)` fallbacks. The fallback must return the concrete provider type, so `InMemoryWorkflowDefinitionRepository` / `InMemoryExecutionRepository` are not assignment-compatible with the JDBC implementation classes even though they implement the same SPIs.

`WorkflowDefinitionService` had the same design issue with `JdbcWorkflowCatalogRepository` versus `NoopWorkflowDefinitionPersistence`.

## Changes

### Depend on SPI boundaries, not JDBC implementations

`WorkflowRuntimeService` now resolves:

- `WorkflowDefinitionRepository`
- `ExecutionRepository`
- `WorkflowRuntimePersistence`

`WorkflowDefinitionService` now resolves:

- `WorkflowDefinitionPersistence`

The services no longer import or depend on the concrete JDBC adapter classes. Spring chooses the production JDBC implementations through the existing repository beans.

### Production persistence is fail-fast

When `yak.database.enabled=true` (the default), all durable workflow persistence beans are mandatory.

If a required repository is missing, application startup fails with an explicit error instead of silently falling back to process memory.

This prevents a dangerous production mode where workflow APIs appear healthy while definitions/executions are actually non-durable.

### Keep explicit DB-disabled test/development mode

When `yak.database.enabled=false`, the existing lightweight in-memory/no-op implementations are still allowed. This preserves focused unit tests and the current test profile without turning those implementations into an automatic production fallback.

The framework's `InMemoryWorkflowDefinitionRepository` and `InMemoryExecutionRepository` remain unchanged; they are still useful for the standalone pure-Java workflow engine and tests.

### Regression coverage

Add `WorkflowPersistenceWiringTest` covering:

- database enabled + missing runtime repositories => fail fast;
- database enabled + missing definition catalog => fail fast;
- explicit database-disabled mode => lightweight runtime construction remains supported.

## Scope

- no workflow schema changes;
- no workflow execution/state-machine semantics changes;
- no retry/cancel/recovery behavior changes;
- no `yak-framework` changes;
- no change to the existing JDBC persistence implementations.

## Validation

- branch is based on current `main` and is 0 commits behind;
- diff is limited to two workflow services plus one focused wiring test;
- this environment does not provide a full local Maven checkout, so repository/build validation is still required before marking the PR ready.