### PR TITLE
perf(workflow): harden durable runtime ownership and recovery

### DIFF
--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/persistence/JdbcWorkflowEngineDefinitionRepository.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/persistence/JdbcWorkflowEngineDefinitionRepository.java
@@ -74,7 +74,7 @@ public class JdbcWorkflowEngineDefinitionRepository implements WorkflowDefinitio
       stored = stored(definition.id());
     }
 
-    if (!json.equals(stored.json())) {
+    if (!sameJson(json, stored.json())) {
       throw new IllegalStateException(
           "工作流版本的 Engine Definition 已固定，禁止覆盖：" + definition.id());
     }
@@ -102,6 +102,15 @@ public class JdbcWorkflowEngineDefinitionRepository implements WorkflowDefinitio
     return values.isEmpty()
         ? new StoredDefinition(false, null)
         : new StoredDefinition(true, values.get(0));
+  }
+
+  private boolean sameJson(String left, String right) {
+    if (left == null || right == null) return left == right;
+    try {
+      return objectMapper.readTree(left).equals(objectMapper.readTree(right));
+    } catch (JsonProcessingException exception) {
+      throw new IllegalStateException("比较 Engine Definition JSON 失败", exception);
+    }
   }
 
   private String write(EngineDefinitionSnapshot snapshot) {

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/persistence/JdbcWorkflowEngineDefinitionRepository.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/persistence/JdbcWorkflowEngineDefinitionRepository.java
@@ -50,11 +50,8 @@ public class JdbcWorkflowEngineDefinitionRepository implements WorkflowDefinitio
   @Override
   public void save(WorkflowDefinition definition) {
     String json = write(EngineDefinitionSnapshot.from(definition));
-    int updated = jdbc.update(
-        "UPDATE yak_workflow_version SET engine_definition_json=? WHERE id=?",
-        json,
-        definition.id());
-    if (updated == 0) {
+    StoredDefinition stored = stored(definition.id());
+    if (!stored.exists()) {
       jdbc.update(
           "INSERT INTO yak_workflow_version "
               + "(id,workflow_id,version_no,version_kind,draft_revision,engine_definition_json,create_time) "
@@ -62,6 +59,24 @@ public class JdbcWorkflowEngineDefinitionRepository implements WorkflowDefinitio
           definition.id(),
           json,
           Timestamp.from(Instant.now()));
+      return;
+    }
+
+    if (stored.json() == null || stored.json().isBlank()) {
+      int updated = jdbc.update(
+          "UPDATE yak_workflow_version SET engine_definition_json=? "
+              + "WHERE id=? AND engine_definition_json IS NULL",
+          json,
+          definition.id());
+      if (updated > 0) {
+        return;
+      }
+      stored = stored(definition.id());
+    }
+
+    if (!json.equals(stored.json())) {
+      throw new IllegalStateException(
+          "工作流版本的 Engine Definition 已固定，禁止覆盖：" + definition.id());
     }
   }
 
@@ -79,6 +94,16 @@ public class JdbcWorkflowEngineDefinitionRepository implements WorkflowDefinitio
     }
   }
 
+  private StoredDefinition stored(String definitionId) {
+    List<String> values = jdbc.query(
+        "SELECT engine_definition_json FROM yak_workflow_version WHERE id=?",
+        (rs, row) -> rs.getString(1),
+        definitionId);
+    return values.isEmpty()
+        ? new StoredDefinition(false, null)
+        : new StoredDefinition(true, values.get(0));
+  }
+
   private String write(EngineDefinitionSnapshot snapshot) {
     try {
       return objectMapper.writeValueAsString(snapshot);
@@ -93,6 +118,9 @@ public class JdbcWorkflowEngineDefinitionRepository implements WorkflowDefinitio
     } catch (JsonProcessingException exception) {
       throw new IllegalStateException("读取 Engine Definition 失败", exception);
     }
+  }
+
+  private record StoredDefinition(boolean exists, String json) {
   }
 
   private record EngineDefinitionSnapshot(

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/persistence/JdbcWorkflowRuntimeRepository.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/persistence/JdbcWorkflowRuntimeRepository.java
@@ -34,12 +34,26 @@ public class JdbcWorkflowRuntimeRepository implements WorkflowRuntimePersistence
 
   @Override
   public void prepareMetadata(String definitionId, RuntimeMetadataRecord metadata) {
-    int updated = jdbc.update(
-        "UPDATE yak_workflow_version SET runtime_metadata_json=? WHERE id=?",
-        write(metadata),
+    String json = write(metadata);
+    jdbc.update(
+        "UPDATE yak_workflow_version "
+            + "SET runtime_metadata_json=COALESCE(runtime_metadata_json,?) WHERE id=?",
+        json,
         definitionId);
-    if (updated == 0) {
-      throw new IllegalArgumentException("工作流运行定义不存在：" + definitionId);
+    try {
+      String stored = jdbc.queryForObject(
+          "SELECT runtime_metadata_json FROM yak_workflow_version WHERE id=?",
+          String.class,
+          definitionId);
+      if (stored == null || stored.isBlank()) {
+        throw new IllegalStateException("工作流运行元数据保存失败：" + definitionId);
+      }
+      if (!json.equals(stored)) {
+        throw new IllegalStateException(
+            "工作流版本的 Runtime Metadata 已固定，禁止覆盖：" + definitionId);
+      }
+    } catch (EmptyResultDataAccessException exception) {
+      throw new IllegalArgumentException("工作流运行定义不存在：" + definitionId, exception);
     }
   }
 
@@ -88,9 +102,14 @@ public class JdbcWorkflowRuntimeRepository implements WorkflowRuntimePersistence
 
   @Override
   public List<String> findRecoverableExecutionIds() {
+    // Only executions that were successfully linked as the workflow's active/latest run are
+    // recoverable. A prepared execution whose business activation failed must stay orphaned and
+    // must never start unexpectedly after a process restart.
     return jdbc.queryForList(
-        "SELECT id FROM yak_workflow_execution WHERE status IN "
-            + "('CREATED','RUNNING','PAUSING','PAUSED','RESUMING') ORDER BY created_at",
+        "SELECT e.id FROM yak_workflow_execution e "
+            + "JOIN yak_workflow_definition d ON d.latest_execution_id=e.id "
+            + "WHERE e.status IN ('CREATED','RUNNING','PAUSING','PAUSED','RESUMING') "
+            + "ORDER BY e.created_at",
         String.class);
   }
 

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/persistence/JdbcWorkflowRuntimeRepository.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/persistence/JdbcWorkflowRuntimeRepository.java
@@ -48,7 +48,7 @@ public class JdbcWorkflowRuntimeRepository implements WorkflowRuntimePersistence
       if (stored == null || stored.isBlank()) {
         throw new IllegalStateException("工作流运行元数据保存失败：" + definitionId);
       }
-      if (!json.equals(stored)) {
+      if (!sameJson(json, stored)) {
         throw new IllegalStateException(
             "工作流版本的 Runtime Metadata 已固定，禁止覆盖：" + definitionId);
       }
@@ -146,6 +146,15 @@ public class JdbcWorkflowRuntimeRepository implements WorkflowRuntimePersistence
           attemptId));
     } catch (EmptyResultDataAccessException ignored) {
       return Optional.empty();
+    }
+  }
+
+  private boolean sameJson(String left, String right) {
+    if (left == null || right == null) return left == right;
+    try {
+      return objectMapper.readTree(left).equals(objectMapper.readTree(right));
+    } catch (JsonProcessingException exception) {
+      throw new IllegalStateException("比较 Workflow Runtime Metadata JSON 失败", exception);
     }
   }
 

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/persistence/WorkflowPersistenceConfiguration.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/persistence/WorkflowPersistenceConfiguration.java
@@ -1,5 +1,7 @@
 package io.yak.ops.business.workflow.persistence;
 
+import io.yak.framework.workflow.engine.spi.ExecutionRepository;
+import io.yak.framework.workflow.engine.support.CachingExecutionRepository;
 import io.yak.ops.business.datasource.config.BusinessDatabaseConfiguration;
 import javax.sql.DataSource;
 import org.flywaydb.core.Flyway;
@@ -9,6 +11,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
 
 /** Workflow persistence shares the Yak Ops business database but owns its Flyway history. */
 @Configuration(proxyBeanMethods = false)
@@ -30,5 +33,17 @@ public class WorkflowPersistenceConfiguration {
         .baselineVersion(MigrationVersion.fromVersion("0"))
         .baselineOnMigrate(true)
         .load();
+  }
+
+  /**
+   * Active executions use a write-through cache while the JDBC repository remains the restart and
+   * history source of truth. This keeps high-frequency timeout scans off the database when state has
+   * not changed.
+   */
+  @Bean
+  @Primary
+  public ExecutionRepository workflowExecutionRepository(
+      JdbcWorkflowExecutionRepository durableRepository) {
+    return new CachingExecutionRepository(durableRepository);
   }
 }

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/persistence/WorkflowRuntimeSingleMasterGuard.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/persistence/WorkflowRuntimeSingleMasterGuard.java
@@ -1,0 +1,130 @@
+package io.yak.ops.business.workflow.persistence;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.HexFormat;
+import javax.sql.DataSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.stereotype.Component;
+
+/**
+ * First-phase single-Master guard for the durable workflow runtime.
+ *
+ * <p>Yak Workflow does not implement distributed Master election yet. A dedicated MySQL named lock
+ * makes that deployment boundary explicit: a second Yak Ops instance pointing at the same business
+ * database fails fast instead of concurrently recovering and driving the same executions.</p>
+ */
+@Component
+@DependsOn("workflowFlyway")
+@ConditionalOnProperty(
+    prefix = "yak.database",
+    name = "enabled",
+    havingValue = "true",
+    matchIfMissing = true)
+@ConditionalOnProperty(
+    prefix = "yak.workflow.runtime",
+    name = "single-master-guard-enabled",
+    havingValue = "true",
+    matchIfMissing = true)
+public class WorkflowRuntimeSingleMasterGuard {
+  private static final Logger log = LoggerFactory.getLogger(WorkflowRuntimeSingleMasterGuard.class);
+
+  private final DataSource dataSource;
+  private Connection ownershipConnection;
+  private String lockName;
+
+  public WorkflowRuntimeSingleMasterGuard(
+      @Qualifier("yakBusinessDataSource") DataSource dataSource) {
+    this.dataSource = dataSource;
+  }
+
+  @PostConstruct
+  void acquire() {
+    try {
+      ownershipConnection = dataSource.getConnection();
+      lockName = lockName(databaseName(ownershipConnection));
+      Integer acquired = queryInteger(
+          ownershipConnection,
+          "SELECT GET_LOCK(?, 0)",
+          lockName);
+      if (acquired == null || acquired != 1) {
+        closeConnection();
+        throw new IllegalStateException(
+            "Workflow Runtime 已被其他 Yak Ops 实例占用；第一阶段只支持单 Master：" + lockName);
+      }
+      log.info("[workflow] acquired single-master runtime lock={}", lockName);
+    } catch (SQLException exception) {
+      closeConnection();
+      throw new IllegalStateException("获取 Workflow Runtime 单 Master 锁失败", exception);
+    }
+  }
+
+  @PreDestroy
+  void release() {
+    Connection connection = ownershipConnection;
+    if (connection == null) return;
+    try {
+      if (!connection.isClosed() && lockName != null) {
+        queryInteger(connection, "SELECT RELEASE_LOCK(?)", lockName);
+        log.info("[workflow] released single-master runtime lock={}", lockName);
+      }
+    } catch (SQLException exception) {
+      log.warn("[workflow] release single-master lock failed lock={}, message={}",
+          lockName, exception.getMessage());
+    } finally {
+      closeConnection();
+    }
+  }
+
+  private String databaseName(Connection connection) throws SQLException {
+    try (PreparedStatement statement = connection.prepareStatement("SELECT DATABASE()");
+         ResultSet result = statement.executeQuery()) {
+      if (!result.next()) {
+        throw new SQLException("Unable to resolve current database");
+      }
+      String database = result.getString(1);
+      return database == null || database.isBlank() ? "default" : database;
+    }
+  }
+
+  private Integer queryInteger(Connection connection, String sql, String value) throws SQLException {
+    try (PreparedStatement statement = connection.prepareStatement(sql)) {
+      statement.setString(1, value);
+      try (ResultSet result = statement.executeQuery()) {
+        return result.next() ? result.getObject(1, Integer.class) : null;
+      }
+    }
+  }
+
+  private String lockName(String database) {
+    try {
+      byte[] digest = MessageDigest.getInstance("SHA-256")
+          .digest(database.getBytes(StandardCharsets.UTF_8));
+      return "yak-ops-workflow-" + HexFormat.of().formatHex(digest, 0, 12);
+    } catch (NoSuchAlgorithmException exception) {
+      throw new IllegalStateException("SHA-256 is unavailable", exception);
+    }
+  }
+
+  private void closeConnection() {
+    Connection connection = ownershipConnection;
+    ownershipConnection = null;
+    if (connection == null) return;
+    try {
+      connection.close();
+    } catch (SQLException ignored) {
+      // Best effort during startup failure or shutdown.
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/persistence/WorkflowRuntimeSingleMasterGuard.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/persistence/WorkflowRuntimeSingleMasterGuard.java
@@ -14,6 +14,7 @@ import javax.sql.DataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.DependsOn;
 import org.springframework.stereotype.Component;
@@ -32,25 +33,27 @@ import org.springframework.stereotype.Component;
     name = "enabled",
     havingValue = "true",
     matchIfMissing = true)
-@ConditionalOnProperty(
-    prefix = "yak.workflow.runtime",
-    name = "single-master-guard-enabled",
-    havingValue = "true",
-    matchIfMissing = true)
 public class WorkflowRuntimeSingleMasterGuard {
   private static final Logger log = LoggerFactory.getLogger(WorkflowRuntimeSingleMasterGuard.class);
 
   private final DataSource dataSource;
+  private final boolean enabled;
   private Connection ownershipConnection;
   private String lockName;
 
   public WorkflowRuntimeSingleMasterGuard(
-      @Qualifier("yakBusinessDataSource") DataSource dataSource) {
+      @Qualifier("yakBusinessDataSource") DataSource dataSource,
+      @Value("${yak.workflow.runtime.single-master-guard-enabled:true}") boolean enabled) {
     this.dataSource = dataSource;
+    this.enabled = enabled;
   }
 
   @PostConstruct
   void acquire() {
+    if (!enabled) {
+      log.warn("[workflow] single-master runtime guard is disabled");
+      return;
+    }
     try {
       ownershipConnection = dataSource.getConnection();
       lockName = lockName(databaseName(ownershipConnection));

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowRecoveryService.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowRecoveryService.java
@@ -1,6 +1,6 @@
 package io.yak.ops.business.workflow.service;
 
-import io.yak.ops.business.workflow.persistence.JdbcWorkflowRuntimeRepository;
+import io.yak.ops.business.workflow.persistence.WorkflowRuntimePersistence;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -19,20 +19,20 @@ public class WorkflowRecoveryService {
   private static final Logger log = LoggerFactory.getLogger(WorkflowRecoveryService.class);
 
   private final WorkflowRuntimeService runtimeService;
-  private final JdbcWorkflowRuntimeRepository runtimeRepository;
+  private final WorkflowRuntimePersistence runtimePersistence;
 
   public WorkflowRecoveryService(
       WorkflowRuntimeService runtimeService,
-      JdbcWorkflowRuntimeRepository runtimeRepository) {
+      WorkflowRuntimePersistence runtimePersistence) {
     this.runtimeService = runtimeService;
-    this.runtimeRepository = runtimeRepository;
+    this.runtimePersistence = runtimePersistence;
   }
 
   @EventListener(ApplicationReadyEvent.class)
   public void recover() {
     // Register executions as active before reconciliation. This does not execute a node by itself;
     // it only guarantees that a recovered SUBMITTED dispatch drains immediately when reconstructed.
-    for (String executionId : runtimeRepository.findRecoverableExecutionIds()) {
+    for (String executionId : runtimePersistence.findRecoverableExecutionIds()) {
       try {
         runtimeService.activate(executionId);
       } catch (RuntimeException exception) {

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/persistence/WorkflowRuntimeSingleMasterGuardTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/persistence/WorkflowRuntimeSingleMasterGuardTest.java
@@ -1,0 +1,78 @@
+package io.yak.ops.business.workflow.persistence;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.Test;
+
+class WorkflowRuntimeSingleMasterGuardTest {
+
+  @Test
+  void acquiresAndReleasesMysqlNamedLock() throws Exception {
+    Fixtures fixtures = fixtures(1);
+    WorkflowRuntimeSingleMasterGuard guard =
+        new WorkflowRuntimeSingleMasterGuard(fixtures.dataSource, true);
+
+    guard.acquire();
+    guard.release();
+
+    verify(fixtures.lockStatement).setString(org.mockito.ArgumentMatchers.eq(1), anyString());
+    verify(fixtures.releaseStatement).setString(org.mockito.ArgumentMatchers.eq(1), anyString());
+    verify(fixtures.connection).close();
+  }
+
+  @Test
+  void failsFastWhenAnotherRuntimeOwnsTheLock() throws Exception {
+    Fixtures fixtures = fixtures(0);
+    WorkflowRuntimeSingleMasterGuard guard =
+        new WorkflowRuntimeSingleMasterGuard(fixtures.dataSource, true);
+
+    assertThrows(IllegalStateException.class, guard::acquire);
+    verify(fixtures.connection).close();
+  }
+
+  private Fixtures fixtures(int acquired) throws Exception {
+    DataSource dataSource = mock(DataSource.class);
+    Connection connection = mock(Connection.class);
+    PreparedStatement databaseStatement = mock(PreparedStatement.class);
+    PreparedStatement lockStatement = mock(PreparedStatement.class);
+    PreparedStatement releaseStatement = mock(PreparedStatement.class);
+    ResultSet databaseResult = mock(ResultSet.class);
+    ResultSet lockResult = mock(ResultSet.class);
+    ResultSet releaseResult = mock(ResultSet.class);
+
+    when(dataSource.getConnection()).thenReturn(connection);
+    when(connection.prepareStatement("SELECT DATABASE()")).thenReturn(databaseStatement);
+    when(connection.prepareStatement("SELECT GET_LOCK(?, 0)")).thenReturn(lockStatement);
+    when(connection.prepareStatement("SELECT RELEASE_LOCK(?)")).thenReturn(releaseStatement);
+    when(connection.isClosed()).thenReturn(false);
+
+    when(databaseStatement.executeQuery()).thenReturn(databaseResult);
+    when(databaseResult.next()).thenReturn(true);
+    when(databaseResult.getString(1)).thenReturn("yak_ops");
+
+    when(lockStatement.executeQuery()).thenReturn(lockResult);
+    when(lockResult.next()).thenReturn(true);
+    when(lockResult.getObject(1, Integer.class)).thenReturn(acquired);
+
+    when(releaseStatement.executeQuery()).thenReturn(releaseResult);
+    when(releaseResult.next()).thenReturn(true);
+    when(releaseResult.getObject(1, Integer.class)).thenReturn(1);
+
+    return new Fixtures(dataSource, connection, lockStatement, releaseStatement);
+  }
+
+  private record Fixtures(
+      DataSource dataSource,
+      Connection connection,
+      PreparedStatement lockStatement,
+      PreparedStatement releaseStatement) {
+  }
+}


### PR DESCRIPTION
## Summary

Harden the durable Yak Ops workflow runtime for the first production-oriented single-Master phase without expanding the workflow feature set.

> Depends on `weifuwan/yak-framework#92` for `CachingExecutionRepository`.

## 1. Keep timeout scans off the database hot path

Wire the framework `CachingExecutionRepository` as the primary `ExecutionRepository` in front of `JdbcWorkflowExecutionRepository`.

The JDBC repository remains the durable restart/history source of truth, while non-terminal executions use an immutable write-through snapshot cache:

- repeated active reads stay in memory;
- identical engine `save()` calls are suppressed;
- actual state transitions still synchronously persist through JDBC;
- terminal executions are evicted and historical detail reads fall back to JDBC.

This specifically removes the current persistence amplification caused by high-frequency timeout scanning without moving persistence logic into the engine.

## 2. Prevent orphan executions from starting after restart

Startup recovery no longer scans every non-terminal execution row.

`findRecoverableExecutionIds()` now only returns executions that were successfully linked through `yak_workflow_definition.latest_execution_id`.

This closes the unsafe window:

1. engine execution/attempt rows are prepared;
2. business activation/pointer persistence fails;
3. API reports failure;
4. process restarts;
5. the prepared orphan execution must **not** suddenly start.

The existing ordering remains useful: the business execution pointer is persisted before pending remote dispatch is activated.

## 3. Enforce the first-phase single-Master deployment boundary

Add `WorkflowRuntimeSingleMasterGuard`.

- uses one dedicated MySQL named lock scoped from the current business database;
- the first Yak Ops runtime owns the lock for the application lifetime;
- a second Yak Ops instance pointing at the same business database fails fast instead of concurrently recovering/driving the same workflow executions;
- no Master table, heartbeat, lease, or election protocol is introduced;
- the guard can be explicitly disabled with `yak.workflow.runtime.single-master-guard-enabled=false`, but that is not intended as a production multi-Master mode.

This makes the current architecture's single-Master assumption executable rather than merely documented.

## 4. Make published/runtime version snapshots actually immutable

`JdbcWorkflowEngineDefinitionRepository` no longer overwrites an existing `engine_definition_json`.

- missing runtime definition rows may still be created;
- an existing empty published version may receive its Engine Definition once;
- subsequent identical semantic JSON is accepted idempotently;
- a different definition for the same version id is rejected.

`runtime_metadata_json` on the immutable workflow version follows the same first-write-wins rule. JSON comparison is semantic (`JsonNode`) rather than raw string ordering.

## 5. Keep recovery behind the persistence SPI

`WorkflowRecoveryService` now depends on `WorkflowRuntimePersistence` rather than the JDBC concrete class.

## Regression coverage

Add a focused `WorkflowRuntimeSingleMasterGuardTest` covering:

- successful named-lock acquisition/release;
- fail-fast when another runtime already owns the lock.

Framework PR #92 separately covers active execution caching and bounded local lock stripes.

## Scope intentionally not included

- no workflow command table;
- no leader election/heartbeat/lease;
- no multi-Master execution ownership;
- no new workflow states;
- no loop/sub-workflow/condition-expression work;
- no history API redesign in this PR.

## Validation

- branch is based on current `main` and was 0 commits behind when prepared;
- no workflow schema/table changes are required;
- full Maven + MySQL/Flyway integration validation is still recommended before marking ready;
- merge framework PR #92 / publish the updated snapshot artifact before validating this Yak Ops branch.