### PR TITLE
refactor(offline-sync): standardize domain and MyBatis boundaries

### DIFF
--- a/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/schedule/offline/OfflineSyncScheduleRegistrar.java
+++ b/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/schedule/offline/OfflineSyncScheduleRegistrar.java
@@ -12,8 +12,8 @@ import io.yak.framework.schedule.api.ScheduleTrigger;
 import io.yak.ops.business.job.schedule.JobScheduleProperties;
 import io.yak.ops.business.job.schedule.JobScheduleRegistrar;
 import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import io.yak.ops.business.sync.offline.domain.OfflineSchedule;
 import io.yak.ops.business.sync.offline.repository.OfflineScheduleRepository;
-import io.yak.ops.business.sync.offline.repository.OfflineScheduleRepository.ScheduleRecord;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -26,11 +26,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
-/**
- * 将离线同步调度配置注册到 Yak Schedule。
- *
- * <p>该注册器只负责时间触发。业务失败重试、Worker 选择、状态对账仍由离线同步模块负责。</p>
- */
+/** 将离线同步调度配置注册到 Yak Schedule。 */
 @Component
 @ConditionalOnOfflineSyncEnabled
 @ConditionalOnProperty(
@@ -60,14 +56,11 @@ public class OfflineSyncScheduleRegistrar implements JobScheduleRegistrar {
 
   @Override
   public void synchronize() {
-    List<ScheduleRecord> records = scheduleRepository.findAllSchedules();
+    List<OfflineSchedule> records = scheduleRepository.findAllSchedules();
     Set<ScheduleKey> desiredKeys = new LinkedHashSet<>();
 
-    for (ScheduleRecord record : records) {
-      if (!StringUtils.hasText(record.getCronExpression())) {
-        continue;
-      }
-
+    for (OfflineSchedule record : records) {
+      if (!StringUtils.hasText(record.cronExpression())) continue;
       ScheduleDefinition desired = definition(record);
       desiredKeys.add(desired.key());
 
@@ -78,52 +71,38 @@ public class OfflineSyncScheduleRegistrar implements JobScheduleRegistrar {
               : scheduleManager.save(desired);
 
       scheduleRepository.updateRuntimeState(
-          record.getJobDefinitionId(),
+          record.jobDefinitionId(),
           localDateTime(snapshot.lastFireTime()),
           localDateTime(snapshot.nextFireTime()));
     }
 
-    for (ScheduleSnapshot snapshot :
-        scheduleManager.list(OfflineSyncScheduleConstants.NAMESPACE)) {
+    for (ScheduleSnapshot snapshot : scheduleManager.list(OfflineSyncScheduleConstants.NAMESPACE)) {
       if (!desiredKeys.contains(snapshot.definition().key())) {
         scheduleManager.delete(snapshot.definition().key());
       }
     }
   }
 
-  ScheduleDefinition definition(ScheduleRecord record) {
-    Long definitionId = record.getJobDefinitionId();
-    ScheduleKey key = OfflineSyncScheduleConstants.key(definitionId);
+  ScheduleDefinition definition(OfflineSchedule record) {
+    Long definitionId = record.jobDefinitionId();
     return new ScheduleDefinition(
-        key,
+        OfflineSyncScheduleConstants.key(definitionId),
         "离线同步任务定义 " + definitionId,
-        ScheduleTrigger.cron(record.getCronExpression(), zoneId()),
+        ScheduleTrigger.cron(record.cronExpression(), zoneId()),
         new ScheduleTarget(
             OfflineSyncScheduleConstants.HANDLER_NAME,
-            Map.of(
-                OfflineSyncScheduleConstants.PAYLOAD_DEFINITION_ID,
-                definitionId.toString())),
-        new SchedulePolicy(
-            ConcurrencyPolicy.FORBID,
-            MisfirePolicy.FIRE_ONCE_NOW,
-            0),
-        record.isEnabled(),
-        Map.of(
-            "businessType", "OFFLINE_SYNC",
-            "definitionId", definitionId.toString()));
+            Map.of(OfflineSyncScheduleConstants.PAYLOAD_DEFINITION_ID, definitionId.toString())),
+        new SchedulePolicy(ConcurrencyPolicy.FORBID, MisfirePolicy.FIRE_ONCE_NOW, 0),
+        record.enabled(),
+        Map.of("businessType", "OFFLINE_SYNC", "definitionId", definitionId.toString()));
   }
 
   private ZoneId zoneId() {
     String configured = properties.getZoneId();
-    return ZoneId.of(
-        StringUtils.hasText(configured)
-            ? configured.trim()
-            : "Asia/Shanghai");
+    return ZoneId.of(StringUtils.hasText(configured) ? configured.trim() : "Asia/Shanghai");
   }
 
   private LocalDateTime localDateTime(Instant instant) {
-    return instant == null
-        ? null
-        : LocalDateTime.ofInstant(instant, zoneId());
+    return instant == null ? null : LocalDateTime.ofInstant(instant, zoneId());
   }
 }

--- a/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/task/InMemoryTaskRegistry.java
+++ b/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/task/InMemoryTaskRegistry.java
@@ -1,9 +1,9 @@
 package io.yak.ops.business.job.task;
 
 import io.yak.framework.common.PagingData;
+import io.yak.ops.business.sync.offline.domain.OfflineJobDefinition;
 import io.yak.ops.business.sync.offline.service.OfflineJobDefinitionService;
 import io.yak.ops.common.bean.dto.sync.offline.OfflineJobDefinitionQueryDTO;
-import io.yak.ops.common.bean.po.sync.offline.OfflineJobDefinitionPO;
 import io.yak.ops.common.bean.vo.sync.offline.OfflineJobDefinitionVO;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
@@ -14,12 +14,7 @@ import java.util.concurrent.ConcurrentMap;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.stereotype.Service;
 
-/**
- * 第一阶段任务注册表。
- *
- * <p>注册表本身仅保存在内存中，数据同步任务元数据从现有离线同步定义服务投影而来，
- * 不新增任务表。工作流发布时可从这里取得当前任务版本和逻辑 JobSpec 的不可变快照。</p>
- */
+/** 第一阶段任务注册表；同步任务元数据由离线同步定义服务投影。 */
 @Service
 public class InMemoryTaskRegistry implements TaskRegistry {
 
@@ -31,17 +26,14 @@ public class InMemoryTaskRegistry implements TaskRegistry {
   private final ConcurrentMap<String, TaskDefinition> tasks = new ConcurrentHashMap<>();
   private final ConcurrentMap<String, TaskVersionSnapshot> snapshots = new ConcurrentHashMap<>();
 
-  public InMemoryTaskRegistry(
-      ObjectProvider<OfflineJobDefinitionService> definitionServiceProvider) {
+  public InMemoryTaskRegistry(ObjectProvider<OfflineJobDefinitionService> definitionServiceProvider) {
     this.definitionServiceProvider = definitionServiceProvider;
   }
 
   @Override
   public List<TaskDefinition> list() {
     refresh();
-    return tasks.values().stream()
-        .sorted(Comparator.comparing(TaskDefinition::name))
-        .toList();
+    return tasks.values().stream().sorted(Comparator.comparing(TaskDefinition::name)).toList();
   }
 
   @Override
@@ -49,9 +41,7 @@ public class InMemoryTaskRegistry implements TaskRegistry {
     String normalized = requireTaskId(taskId);
     refresh();
     TaskDefinition task = tasks.get(normalized);
-    if (task == null) {
-      throw new IllegalArgumentException("任务不存在或尚不可执行：" + taskId);
-    }
+    if (task == null) throw new IllegalArgumentException("任务不存在或尚不可执行：" + taskId);
     return task;
   }
 
@@ -60,16 +50,12 @@ public class InMemoryTaskRegistry implements TaskRegistry {
     String normalized = requireTaskId(taskId);
     refresh();
     TaskVersionSnapshot snapshot = snapshots.get(normalized);
-    if (snapshot == null) {
-      throw new IllegalArgumentException("任务不存在或尚不可执行：" + taskId);
-    }
+    if (snapshot == null) throw new IllegalArgumentException("任务不存在或尚不可执行：" + taskId);
     return snapshot;
   }
 
   private String requireTaskId(String taskId) {
-    if (taskId == null || taskId.isBlank()) {
-      throw new IllegalArgumentException("taskId 不能为空");
-    }
+    if (taskId == null || taskId.isBlank()) throw new IllegalArgumentException("taskId 不能为空");
     return taskId.trim();
   }
 
@@ -90,11 +76,9 @@ public class InMemoryTaskRegistry implements TaskRegistry {
       query.setPageSize(PAGE_SIZE);
       PagingData<OfflineJobDefinitionVO> page = service.page(query);
       for (OfflineJobDefinitionVO definition : page.getBizData()) {
-        if (!isWorkflowEligible(definition)) {
-          continue;
-        }
+        if (!isWorkflowEligible(definition)) continue;
         try {
-          OfflineJobDefinitionPO current = service.require(definition.getId());
+          OfflineJobDefinition current = service.require(definition.getId());
           String logicalJobSpec = service.resolveLogicalJobSpec(current);
           String id = String.valueOf(current.getId());
           String name = current.getJobName();
@@ -114,9 +98,7 @@ public class InMemoryTaskRegistry implements TaskRegistry {
           // 草稿或没有可执行 JobSpec 的同步任务不进入工作流任务列表。
         }
       }
-      if (page.getPagination() == null || pageNo >= page.getPagination().getPages()) {
-        break;
-      }
+      if (page.getPagination() == null || pageNo >= page.getPagination().getPages()) break;
       pageNo++;
     }
 

--- a/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/task/InMemoryTaskRegistry.java
+++ b/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/task/InMemoryTaskRegistry.java
@@ -85,9 +85,10 @@ public class InMemoryTaskRegistry implements TaskRegistry {
       for (OfflineJobDefinition definition : page.records()) {
         if (!isWorkflowEligible(definition)) continue;
         try {
-          String logicalJobSpec = service.resolveLogicalJobSpec(definition);
-          String id = String.valueOf(definition.getId());
-          String name = definition.getJobName();
+          OfflineJobDefinition current = service.require(definition.getId());
+          String logicalJobSpec = service.resolveLogicalJobSpec(current);
+          String id = String.valueOf(current.getId());
+          String name = current.getJobName();
           TaskDefinition task = new TaskDefinition(id, name, "SYNC");
           taskSnapshot.put(id, task);
           versionSnapshot.put(
@@ -96,12 +97,12 @@ public class InMemoryTaskRegistry implements TaskRegistry {
                   id,
                   name,
                   "SYNC",
-                  Math.max(1, definition.getVersion() == null ? 1 : definition.getVersion()),
-                  definition.getConfigDigest(),
-                  definition.getDefinitionJson(),
+                  Math.max(1, current.getVersion() == null ? 1 : current.getVersion()),
+                  current.getConfigDigest(),
+                  current.getDefinitionJson(),
                   logicalJobSpec));
         } catch (RuntimeException ignored) {
-          // 草稿或没有可执行 JobSpec 的同步任务不进入工作流任务列表。
+          // 草稿、被删除或没有可执行 JobSpec 的同步任务不进入工作流任务列表。
         }
       }
       if (pageNo >= page.pages()) break;

--- a/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/task/InMemoryTaskRegistry.java
+++ b/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/task/InMemoryTaskRegistry.java
@@ -1,10 +1,9 @@
 package io.yak.ops.business.job.task;
 
-import io.yak.framework.common.PagingData;
+import io.yak.ops.business.sync.offline.domain.OfflineDefinitionQuery;
 import io.yak.ops.business.sync.offline.domain.OfflineJobDefinition;
+import io.yak.ops.business.sync.offline.domain.OfflinePage;
 import io.yak.ops.business.sync.offline.service.OfflineJobDefinitionService;
-import io.yak.ops.common.bean.dto.sync.offline.OfflineJobDefinitionQueryDTO;
-import io.yak.ops.common.bean.vo.sync.offline.OfflineJobDefinitionVO;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -20,7 +19,6 @@ public class InMemoryTaskRegistry implements TaskRegistry {
 
   private static final int PAGE_SIZE = 200;
   private static final String RELEASE_STATE_ONLINE = "ONLINE";
-  private static final String SCHEDULE_STATUS_PAUSED = "PAUSED";
 
   private final ObjectProvider<OfflineJobDefinitionService> definitionServiceProvider;
   private final ConcurrentMap<String, TaskDefinition> tasks = new ConcurrentHashMap<>();
@@ -71,17 +69,25 @@ public class InMemoryTaskRegistry implements TaskRegistry {
     Map<String, TaskVersionSnapshot> versionSnapshot = new LinkedHashMap<>();
     int pageNo = 1;
     while (true) {
-      OfflineJobDefinitionQueryDTO query = new OfflineJobDefinitionQueryDTO();
-      query.setCurrent(pageNo);
-      query.setPageSize(PAGE_SIZE);
-      PagingData<OfflineJobDefinitionVO> page = service.page(query);
-      for (OfflineJobDefinitionVO definition : page.getBizData()) {
+      OfflinePage<OfflineJobDefinition> page = service.pageDomain(
+          new OfflineDefinitionQuery(
+              pageNo,
+              PAGE_SIZE,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null));
+      for (OfflineJobDefinition definition : page.records()) {
         if (!isWorkflowEligible(definition)) continue;
         try {
-          OfflineJobDefinition current = service.require(definition.getId());
-          String logicalJobSpec = service.resolveLogicalJobSpec(current);
-          String id = String.valueOf(current.getId());
-          String name = current.getJobName();
+          String logicalJobSpec = service.resolveLogicalJobSpec(definition);
+          String id = String.valueOf(definition.getId());
+          String name = definition.getJobName();
           TaskDefinition task = new TaskDefinition(id, name, "SYNC");
           taskSnapshot.put(id, task);
           versionSnapshot.put(
@@ -90,15 +96,15 @@ public class InMemoryTaskRegistry implements TaskRegistry {
                   id,
                   name,
                   "SYNC",
-                  Math.max(1, current.getVersion() == null ? 1 : current.getVersion()),
-                  current.getConfigDigest(),
-                  current.getDefinitionJson(),
+                  Math.max(1, definition.getVersion() == null ? 1 : definition.getVersion()),
+                  definition.getConfigDigest(),
+                  definition.getDefinitionJson(),
                   logicalJobSpec));
         } catch (RuntimeException ignored) {
           // 草稿或没有可执行 JobSpec 的同步任务不进入工作流任务列表。
         }
       }
-      if (page.getPagination() == null || pageNo >= page.getPagination().getPages()) break;
+      if (pageNo >= page.pages()) break;
       pageNo++;
     }
 
@@ -108,11 +114,11 @@ public class InMemoryTaskRegistry implements TaskRegistry {
     snapshots.putAll(versionSnapshot);
   }
 
-  static boolean isWorkflowEligible(OfflineJobDefinitionVO definition) {
+  static boolean isWorkflowEligible(OfflineJobDefinition definition) {
     return definition != null
         && definition.getId() != null
         && definition.getJobName() != null
         && RELEASE_STATE_ONLINE.equalsIgnoreCase(definition.getReleaseState())
-        && SCHEDULE_STATUS_PAUSED.equalsIgnoreCase(definition.getScheduleStatus());
+        && !Boolean.TRUE.equals(definition.getScheduleEnabled());
   }
 }

--- a/yak-ops-business/yak-ops-business-job/src/test/java/io/yak/ops/business/job/schedule/offline/OfflineSyncScheduleRegistrarTest.java
+++ b/yak-ops-business/yak-ops-business-job/src/test/java/io/yak/ops/business/job/schedule/offline/OfflineSyncScheduleRegistrarTest.java
@@ -14,8 +14,8 @@ import io.yak.framework.schedule.api.ScheduleManager;
 import io.yak.framework.schedule.api.ScheduleSnapshot;
 import io.yak.framework.schedule.api.ScheduleStatus;
 import io.yak.ops.business.job.schedule.JobScheduleProperties;
+import io.yak.ops.business.sync.offline.domain.OfflineSchedule;
 import io.yak.ops.business.sync.offline.repository.OfflineScheduleRepository;
-import io.yak.ops.business.sync.offline.repository.OfflineScheduleRepository.ScheduleRecord;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -33,16 +33,15 @@ class OfflineSyncScheduleRegistrarTest {
     JobScheduleProperties properties = new JobScheduleProperties();
     properties.setZoneId("Asia/Shanghai");
 
-    ScheduleRecord record =
-        new ScheduleRecord(
-            42L,
-            "0 0/5 * * * ?",
-            true,
-            4,
-            60,
-            null,
-            null,
-            "{}");
+    OfflineSchedule record = new OfflineSchedule(
+        42L,
+        "0 0/5 * * * ?",
+        true,
+        4,
+        60,
+        null,
+        null,
+        "{}");
     when(repository.findAllSchedules()).thenReturn(List.of(record));
     when(manager.get(OfflineSyncScheduleConstants.key(42L))).thenReturn(Optional.empty());
     when(manager.save(any(ScheduleDefinition.class)))
@@ -60,20 +59,17 @@ class OfflineSyncScheduleRegistrarTest {
 
     new OfflineSyncScheduleRegistrar(manager, repository, properties).synchronize();
 
-    ArgumentCaptor<ScheduleDefinition> captor =
-        ArgumentCaptor.forClass(ScheduleDefinition.class);
+    ArgumentCaptor<ScheduleDefinition> captor = ArgumentCaptor.forClass(ScheduleDefinition.class);
     verify(manager).save(captor.capture());
 
     ScheduleDefinition definition = captor.getValue();
     assertThat(definition.key()).isEqualTo(OfflineSyncScheduleConstants.key(42L));
     assertThat(definition.trigger().expression()).isEqualTo("0 0/5 * * * ?");
     assertThat(definition.trigger().zoneId()).isEqualTo(ZoneId.of("Asia/Shanghai"));
-    assertThat(definition.target().handler())
-        .isEqualTo(OfflineSyncScheduleConstants.HANDLER_NAME);
+    assertThat(definition.target().handler()).isEqualTo(OfflineSyncScheduleConstants.HANDLER_NAME);
     assertThat(definition.target().payload())
         .containsEntry(OfflineSyncScheduleConstants.PAYLOAD_DEFINITION_ID, "42");
-    assertThat(definition.policy().concurrencyPolicy())
-        .isEqualTo(ConcurrencyPolicy.FORBID);
+    assertThat(definition.policy().concurrencyPolicy()).isEqualTo(ConcurrencyPolicy.FORBID);
     assertThat(definition.policy().triggerRetries()).isZero();
 
     verify(repository).updateRuntimeState(
@@ -90,16 +86,15 @@ class OfflineSyncScheduleRegistrarTest {
 
     ScheduleDefinition orphan =
         new OfflineSyncScheduleRegistrar(manager, repository, properties)
-            .definition(
-                new ScheduleRecord(
-                    99L,
-                    "0 0 2 * * ?",
-                    true,
-                    1,
-                    30,
-                    null,
-                    null,
-                    "{}"));
+            .definition(new OfflineSchedule(
+                99L,
+                "0 0 2 * * ?",
+                true,
+                1,
+                30,
+                null,
+                null,
+                "{}"));
 
     when(repository.findAllSchedules()).thenReturn(List.of());
     when(manager.list(OfflineSyncScheduleConstants.NAMESPACE))
@@ -113,7 +108,6 @@ class OfflineSyncScheduleRegistrarTest {
                 null)));
 
     new OfflineSyncScheduleRegistrar(manager, repository, properties).synchronize();
-
     verify(manager).delete(orphan.key());
   }
 }

--- a/yak-ops-business/yak-ops-business-job/src/test/java/io/yak/ops/business/job/task/InMemoryTaskRegistryTest.java
+++ b/yak-ops-business/yak-ops-business-job/src/test/java/io/yak/ops/business/job/task/InMemoryTaskRegistryTest.java
@@ -2,36 +2,35 @@ package io.yak.ops.business.job.task;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.yak.ops.common.bean.vo.sync.offline.OfflineJobDefinitionVO;
+import io.yak.ops.business.sync.offline.domain.OfflineJobDefinition;
 import org.junit.jupiter.api.Test;
 
 class InMemoryTaskRegistryTest {
 
   @Test
-  void shouldOnlyExposeOnlineTasksWithSchedulePaused() {
-    assertThat(InMemoryTaskRegistry.isWorkflowEligible(task("ONLINE", "PAUSED"))).isTrue();
+  void shouldOnlyExposeOnlineTasksWithoutEnabledSchedule() {
+    assertThat(InMemoryTaskRegistry.isWorkflowEligible(task("ONLINE", false))).isTrue();
 
-    assertThat(InMemoryTaskRegistry.isWorkflowEligible(task("OFFLINE", "PAUSED"))).isFalse();
-    assertThat(InMemoryTaskRegistry.isWorkflowEligible(task("ONLINE", "NORMAL"))).isFalse();
+    assertThat(InMemoryTaskRegistry.isWorkflowEligible(task("OFFLINE", false))).isFalse();
+    assertThat(InMemoryTaskRegistry.isWorkflowEligible(task("ONLINE", true))).isFalse();
   }
 
   @Test
   void shouldRejectIncompleteTaskMetadata() {
     assertThat(InMemoryTaskRegistry.isWorkflowEligible(null)).isFalse();
-    assertThat(InMemoryTaskRegistry.isWorkflowEligible(
-        OfflineJobDefinitionVO.builder()
-            .jobName("未完成任务")
-            .releaseState("ONLINE")
-            .scheduleStatus("PAUSED")
-            .build())).isFalse();
+    OfflineJobDefinition incomplete = new OfflineJobDefinition();
+    incomplete.setJobName("未完成任务");
+    incomplete.setReleaseState("ONLINE");
+    incomplete.setScheduleEnabled(false);
+    assertThat(InMemoryTaskRegistry.isWorkflowEligible(incomplete)).isFalse();
   }
 
-  private OfflineJobDefinitionVO task(String releaseState, String scheduleStatus) {
-    return OfflineJobDefinitionVO.builder()
-        .id(1001L)
-        .jobName("用户数据同步")
-        .releaseState(releaseState)
-        .scheduleStatus(scheduleStatus)
-        .build();
+  private OfflineJobDefinition task(String releaseState, boolean scheduleEnabled) {
+    OfflineJobDefinition definition = new OfflineJobDefinition();
+    definition.setId(1001L);
+    definition.setJobName("用户数据同步");
+    definition.setReleaseState(releaseState);
+    definition.setScheduleEnabled(scheduleEnabled);
+    return definition;
   }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/README.md
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/README.md
@@ -21,6 +21,27 @@ yak:
 
 不再提供客户端管理、Connector 管理、多 Worker 调度、能力匹配、Preflight、动态注册和告警投递。
 
+## 工程分层
+
+离线同步遵循 Yak Ops 统一业务模块边界：
+
+```text
+Controller -> DTO -> Service -> Domain
+           -> Repository -> Adapter -> DAO
+           -> BaseMapper / Mapper XML -> PO -> MySQL
+
+Domain -> View Mapper -> VO -> Controller
+```
+
+约束：
+
+- Controller 只通过 Service 进入业务链路，不直接依赖 Repository、DAO 或 Link-Up Client。
+- Service 和执行状态机使用 Domain，不直接操作 MyBatis PO。
+- Repository 接口只暴露 Domain；PO 与 DAO 仅存在于持久化适配层。
+- DAO 不接收 HTTP DTO；分页筛选使用 DAO 自己的查询条件。
+- 普通单表操作使用 MyBatis-Plus，只有行锁等数据库原子语义进入 Mapper XML。
+- Link-Up 协议对象只存在于 engine/service 内部，不作为 HTTP 响应模型直接暴露。
+
 ## 数据表
 
 仅保留：

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/pom.xml
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/pom.xml
@@ -74,16 +74,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>8</source>
-                    <target>8</target>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/controller/OfflineControlPlaneController.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/controller/OfflineControlPlaneController.java
@@ -2,8 +2,8 @@ package io.yak.ops.business.sync.offline.controller;
 
 import io.yak.framework.common.Result;
 import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
-import io.yak.ops.business.sync.offline.repository.OfflineExecutionControlRepository;
-import io.yak.ops.business.sync.offline.repository.OfflineExecutionControlRepository.ExecutionEventRecord;
+import io.yak.ops.business.sync.offline.service.OfflineJobExecutionService;
+import io.yak.ops.common.bean.vo.sync.offline.OfflineExecutionEventVO;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -17,10 +17,10 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/job/batch-control")
 @RequiredArgsConstructor
 public class OfflineControlPlaneController {
-  private final OfflineExecutionControlRepository repository;
+  private final OfflineJobExecutionService service;
 
   @GetMapping("/executions/{executionId}/events")
-  public Result<List<ExecutionEventRecord>> events(@PathVariable Long executionId) {
-    return Result.success(repository.listExecutionEvents(executionId));
+  public Result<List<OfflineExecutionEventVO>> events(@PathVariable Long executionId) {
+    return Result.success(service.events(executionId));
   }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/controller/OfflineJobExecutionController.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/controller/OfflineJobExecutionController.java
@@ -4,12 +4,11 @@ import com.fasterxml.jackson.databind.JsonNode;
 import io.yak.framework.common.PagingResult;
 import io.yak.framework.common.Result;
 import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
-import io.yak.ops.business.sync.offline.engine.LinkUpClient;
-import io.yak.ops.business.sync.offline.engine.LinkUpClient.LinkUpNodeResponse;
 import io.yak.ops.business.sync.offline.service.OfflineJobExecutionService;
 import io.yak.ops.common.bean.dto.sync.offline.OfflineBatchOperationDTO;
 import io.yak.ops.common.bean.dto.sync.offline.OfflineJobExecutionQueryDTO;
 import io.yak.ops.common.bean.vo.sync.offline.OfflineBatchOperationVO;
+import io.yak.ops.common.bean.vo.sync.offline.OfflineEngineHealthVO;
 import io.yak.ops.common.bean.vo.sync.offline.OfflineExecutionLogPageVO;
 import io.yak.ops.common.bean.vo.sync.offline.OfflineJobExecutionDetailVO;
 import io.yak.ops.common.bean.vo.sync.offline.OfflineJobExecutionVO;
@@ -28,28 +27,24 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class OfflineJobExecutionController {
   private final OfflineJobExecutionService service;
-  private final LinkUpClient linkUpClient;
 
   @GetMapping({"/api/v1/job/batch-execution/health", "/api/v1/executor/health"})
-  public Result<LinkUpNodeResponse> health() {
-    return Result.success(linkUpClient.node());
+  public Result<OfflineEngineHealthVO> health() {
+    return Result.success(service.health());
   }
 
   @PostMapping("/api/v1/job/batch-execution/{jobDefineId}/execute")
-  public Result<OfflineJobExecutionVO> execute(
-      @PathVariable Long jobDefineId) {
+  public Result<OfflineJobExecutionVO> execute(@PathVariable Long jobDefineId) {
     return Result.success(service.execute(jobDefineId));
   }
 
   @PostMapping("/api/v1/job/batch-execution/{jobInstanceId}/cancel")
-  public Result<OfflineJobExecutionVO> cancel(
-      @PathVariable Long jobInstanceId) {
+  public Result<OfflineJobExecutionVO> cancel(@PathVariable Long jobInstanceId) {
     return Result.success(service.cancel(jobInstanceId));
   }
 
   @PostMapping("/api/v1/job/batch-execution/{jobInstanceId}/retry")
-  public Result<OfflineJobExecutionVO> retry(
-      @PathVariable Long jobInstanceId) {
+  public Result<OfflineJobExecutionVO> retry(@PathVariable Long jobInstanceId) {
     return Result.success(service.retry(jobInstanceId));
   }
 
@@ -73,14 +68,12 @@ public class OfflineJobExecutionController {
 
   @PostMapping("/api/v1/job/batch-instance/page")
   public PagingResult<OfflineJobExecutionVO> instancePage(
-      @Valid @RequestBody(required = false)
-          OfflineJobExecutionQueryDTO queryDTO) {
+      @Valid @RequestBody(required = false) OfflineJobExecutionQueryDTO queryDTO) {
     return PagingResult.success(service.page(queryDTO));
   }
 
   @GetMapping("/api/v1/job/batch-instance/{id}")
-  public Result<OfflineJobExecutionDetailVO> instance(
-      @PathVariable Long id) {
+  public Result<OfflineJobExecutionDetailVO> instance(@PathVariable Long id) {
     return Result.success(service.detail(id));
   }
 

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/dao/OfflineExecutionEventDao.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/dao/OfflineExecutionEventDao.java
@@ -1,0 +1,11 @@
+package io.yak.ops.business.sync.offline.dao;
+
+import io.yak.ops.common.bean.po.sync.offline.OfflineExecutionEventPO;
+import java.util.List;
+
+/** 离线同步执行事件数据访问接口。 */
+public interface OfflineExecutionEventDao {
+  boolean insert(OfflineExecutionEventPO event);
+  List<OfflineExecutionEventPO> selectByExecutionId(Long executionId);
+  List<OfflineExecutionEventPO> selectAfter(Long executionId, long afterId, int limit);
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/dao/OfflineJobDefinitionDao.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/dao/OfflineJobDefinitionDao.java
@@ -24,6 +24,25 @@ public interface OfflineJobDefinitionDao {
 
   Long lockById(Long id);
 
+  boolean updateSchedule(
+      Long id,
+      String scheduleJson,
+      boolean enabled,
+      String cronExpression,
+      int retryMaxAttempts,
+      int retryBackoffSeconds,
+      LocalDateTime lastFireTime,
+      LocalDateTime nextFireTime,
+      LocalDateTime updateTime);
+
+  void updateScheduleRuntime(
+      Long id,
+      LocalDateTime lastFireTime,
+      LocalDateTime nextFireTime,
+      LocalDateTime updateTime);
+
+  void clearSchedule(Long id, LocalDateTime updateTime);
+
   record PageQuery(
       int current,
       int pageSize,

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/dao/OfflineJobDefinitionDao.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/dao/OfflineJobDefinitionDao.java
@@ -31,7 +31,6 @@ public interface OfflineJobDefinitionDao {
       String cronExpression,
       int retryMaxAttempts,
       int retryBackoffSeconds,
-      LocalDateTime lastFireTime,
       LocalDateTime nextFireTime,
       LocalDateTime updateTime);
 

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/dao/OfflineJobDefinitionDao.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/dao/OfflineJobDefinitionDao.java
@@ -1,14 +1,11 @@
 package io.yak.ops.business.sync.offline.dao;
 
 import com.baomidou.mybatisplus.core.metadata.IPage;
-import io.yak.ops.common.bean.dto.sync.offline.OfflineJobDefinitionQueryDTO;
 import io.yak.ops.common.bean.po.sync.offline.OfflineJobDefinitionPO;
+import java.time.LocalDateTime;
+import java.util.List;
 
-/**
- * 离线同步任务定义数据访问接口。
- *
- * @author weifuwan
- */
+/** 离线同步任务定义数据访问接口，只暴露持久化模型和 DAO 查询条件。 */
 public interface OfflineJobDefinitionDao {
 
   OfflineJobDefinitionPO selectById(Long id);
@@ -21,5 +18,22 @@ public interface OfflineJobDefinitionDao {
 
   boolean existsByName(String jobName, Long excludeId);
 
-  IPage<OfflineJobDefinitionPO> selectPage(OfflineJobDefinitionQueryDTO queryDTO);
+  IPage<OfflineJobDefinitionPO> selectPage(PageQuery query);
+
+  List<OfflineJobDefinitionPO> selectWithCron();
+
+  Long lockById(Long id);
+
+  record PageQuery(
+      int current,
+      int pageSize,
+      Long id,
+      String jobName,
+      String status,
+      String sourceType,
+      String sinkType,
+      String sourceTable,
+      String sinkTable,
+      LocalDateTime createTimeStart,
+      LocalDateTime createTimeEnd) {}
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/dao/OfflineJobExecutionDao.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/dao/OfflineJobExecutionDao.java
@@ -1,21 +1,34 @@
 package io.yak.ops.business.sync.offline.dao;
 
 import com.baomidou.mybatisplus.core.metadata.IPage;
-import io.yak.ops.common.bean.dto.sync.offline.OfflineJobExecutionQueryDTO;
 import io.yak.ops.common.bean.po.sync.offline.OfflineJobExecutionPO;
+import java.time.LocalDateTime;
+import java.util.List;
 
-/**
- * 离线同步任务实例数据访问接口。
- *
- * @author weifuwan
- */
+/** 离线同步任务实例数据访问接口，只暴露持久化模型和 DAO 查询条件。 */
 public interface OfflineJobExecutionDao {
 
   OfflineJobExecutionPO selectById(Long id);
+
+  OfflineJobExecutionPO selectByIdempotencyKey(String idempotencyKey);
 
   boolean insert(OfflineJobExecutionPO executionPO);
 
   boolean updateById(OfflineJobExecutionPO executionPO);
 
-  IPage<OfflineJobExecutionPO> selectPage(OfflineJobExecutionQueryDTO queryDTO);
+  boolean hasActiveExecution(Long definitionId);
+
+  List<OfflineJobExecutionPO> selectActiveExecutions(int limit);
+
+  List<OfflineJobExecutionPO> selectRetryCandidates(LocalDateTime now, int limit);
+
+  void markRetryCreated(Long executionId, LocalDateTime updateTime);
+
+  IPage<OfflineJobExecutionPO> selectPage(PageQuery query);
+
+  record PageQuery(
+      int current,
+      int pageSize,
+      Long jobDefinitionId,
+      String status) {}
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/dao/impl/OfflineExecutionEventDaoImpl.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/dao/impl/OfflineExecutionEventDaoImpl.java
@@ -1,0 +1,41 @@
+package io.yak.ops.business.sync.offline.dao.impl;
+
+import com.baomidou.mybatisplus.core.toolkit.Wrappers;
+import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import io.yak.ops.business.sync.offline.dao.OfflineExecutionEventDao;
+import io.yak.ops.business.sync.offline.dao.mapper.OfflineExecutionEventMapper;
+import io.yak.ops.common.bean.po.sync.offline.OfflineExecutionEventPO;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+/** 基于 MyBatis-Plus 的执行事件数据访问实现。 */
+@ConditionalOnOfflineSyncEnabled
+@Repository
+@RequiredArgsConstructor
+public class OfflineExecutionEventDaoImpl implements OfflineExecutionEventDao {
+  private final OfflineExecutionEventMapper mapper;
+
+  @Override
+  public boolean insert(OfflineExecutionEventPO event) {
+    return mapper.insert(event) > 0;
+  }
+
+  @Override
+  public List<OfflineExecutionEventPO> selectByExecutionId(Long executionId) {
+    return mapper.selectList(
+        Wrappers.<OfflineExecutionEventPO>lambdaQuery()
+            .eq(OfflineExecutionEventPO::getExecutionId, executionId)
+            .orderByAsc(OfflineExecutionEventPO::getId));
+  }
+
+  @Override
+  public List<OfflineExecutionEventPO> selectAfter(Long executionId, long afterId, int limit) {
+    return mapper.selectList(
+        Wrappers.<OfflineExecutionEventPO>lambdaQuery()
+            .eq(OfflineExecutionEventPO::getExecutionId, executionId)
+            .gt(OfflineExecutionEventPO::getId, afterId)
+            .orderByAsc(OfflineExecutionEventPO::getId)
+            .last("LIMIT " + Math.max(1, limit)));
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/dao/impl/OfflineJobDefinitionDaoImpl.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/dao/impl/OfflineJobDefinitionDaoImpl.java
@@ -115,7 +115,6 @@ public class OfflineJobDefinitionDaoImpl implements OfflineJobDefinitionDao {
       String cronExpression,
       int retryMaxAttempts,
       int retryBackoffSeconds,
-      LocalDateTime lastFireTime,
       LocalDateTime nextFireTime,
       LocalDateTime updateTime) {
     return mapper.update(
@@ -127,7 +126,6 @@ public class OfflineJobDefinitionDaoImpl implements OfflineJobDefinitionDao {
             .set(OfflineJobDefinitionPO::getCronExpression, cronExpression)
             .set(OfflineJobDefinitionPO::getRetryMaxAttempts, retryMaxAttempts)
             .set(OfflineJobDefinitionPO::getRetryBackoffSeconds, retryBackoffSeconds)
-            .set(OfflineJobDefinitionPO::getScheduleLastFireTime, lastFireTime)
             .set(OfflineJobDefinitionPO::getScheduleNextFireTime, nextFireTime)
             .set(OfflineJobDefinitionPO::getUpdateTime, updateTime)) > 0;
   }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/dao/impl/OfflineJobDefinitionDaoImpl.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/dao/impl/OfflineJobDefinitionDaoImpl.java
@@ -6,7 +6,7 @@ import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
 import io.yak.ops.business.sync.offline.dao.OfflineJobDefinitionDao;
 import io.yak.ops.business.sync.offline.dao.mapper.OfflineJobDefinitionMapper;
-import io.yak.ops.common.bean.dto.sync.offline.OfflineJobDefinitionQueryDTO;
+import io.yak.ops.business.sync.offline.dao.mapper.OfflineWriteMapper;
 import io.yak.ops.common.bean.po.sync.offline.OfflineJobDefinitionPO;
 import java.util.List;
 import java.util.Locale;
@@ -14,11 +14,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import org.springframework.util.StringUtils;
 
-/**
- * 基于 MyBatis-Plus 的离线同步任务定义数据访问实现。
- *
- * @author weifuwan
- */
+/** 基于 MyBatis-Plus 的离线同步任务定义数据访问实现。 */
 @ConditionalOnOfflineSyncEnabled
 @Repository
 @RequiredArgsConstructor
@@ -28,6 +24,7 @@ public class OfflineJobDefinitionDaoImpl implements OfflineJobDefinitionDao {
       List.of("CREATED", "SUBMITTED", "QUEUED", "RUNNING");
 
   private final OfflineJobDefinitionMapper mapper;
+  private final OfflineWriteMapper writeMapper;
 
   @Override
   public OfflineJobDefinitionPO selectById(Long id) {
@@ -54,54 +51,65 @@ public class OfflineJobDefinitionDaoImpl implements OfflineJobDefinitionDao {
     LambdaQueryWrapper<OfflineJobDefinitionPO> query =
         new LambdaQueryWrapper<OfflineJobDefinitionPO>()
             .eq(OfflineJobDefinitionPO::getJobName, jobName);
-    if (excludeId != null) {
-      query.ne(OfflineJobDefinitionPO::getId, excludeId);
-    }
+    if (excludeId != null) query.ne(OfflineJobDefinitionPO::getId, excludeId);
     return mapper.selectCount(query) > 0L;
   }
 
   @Override
-  public IPage<OfflineJobDefinitionPO> selectPage(OfflineJobDefinitionQueryDTO queryDTO) {
-    OfflineJobDefinitionQueryDTO condition =
-        queryDTO == null ? new OfflineJobDefinitionQueryDTO() : queryDTO;
-    LambdaQueryWrapper<OfflineJobDefinitionPO> query = new LambdaQueryWrapper<>();
-    if (StringUtils.hasText(condition.getJobName())) {
-      query.like(OfflineJobDefinitionPO::getJobName, condition.getJobName().trim());
+  public IPage<OfflineJobDefinitionPO> selectPage(PageQuery query) {
+    PageQuery condition = query == null
+        ? new PageQuery(1, 10, null, null, null, null, null, null, null, null, null)
+        : query;
+    LambdaQueryWrapper<OfflineJobDefinitionPO> wrapper = new LambdaQueryWrapper<>();
+    if (StringUtils.hasText(condition.jobName())) {
+      wrapper.like(OfflineJobDefinitionPO::getJobName, condition.jobName().trim());
     }
-    if (condition.getId() != null && condition.getId() > 0L) {
-      query.eq(OfflineJobDefinitionPO::getId, condition.getId());
+    if (condition.id() != null && condition.id() > 0L) {
+      wrapper.eq(OfflineJobDefinitionPO::getId, condition.id());
     }
-    if (StringUtils.hasText(condition.getStatus())) {
-      String status = normalizeStatus(condition.getStatus());
+    if (StringUtils.hasText(condition.status())) {
+      String status = normalizeStatus(condition.status());
       if ("RUNNING".equals(status)) {
-        query.in(OfflineJobDefinitionPO::getLastJobStatus, ACTIVE_STATUSES);
+        wrapper.in(OfflineJobDefinitionPO::getLastJobStatus, ACTIVE_STATUSES);
       } else {
-        query.eq(OfflineJobDefinitionPO::getLastJobStatus, status);
+        wrapper.eq(OfflineJobDefinitionPO::getLastJobStatus, status);
       }
     }
-    addLike(query, OfflineJobDefinitionPO::getSourceType, condition.getSourceType());
-    addLike(query, OfflineJobDefinitionPO::getSinkType, condition.getSinkType());
-    addLike(query, OfflineJobDefinitionPO::getSourceTable, condition.getSourceTable());
-    addLike(query, OfflineJobDefinitionPO::getSinkTable, condition.getSinkTable());
-    if (condition.getCreateTimeStart() != null) {
-      query.ge(OfflineJobDefinitionPO::getCreateTime, condition.getCreateTimeStart());
+    addLike(wrapper, OfflineJobDefinitionPO::getSourceType, condition.sourceType());
+    addLike(wrapper, OfflineJobDefinitionPO::getSinkType, condition.sinkType());
+    addLike(wrapper, OfflineJobDefinitionPO::getSourceTable, condition.sourceTable());
+    addLike(wrapper, OfflineJobDefinitionPO::getSinkTable, condition.sinkTable());
+    if (condition.createTimeStart() != null) {
+      wrapper.ge(OfflineJobDefinitionPO::getCreateTime, condition.createTimeStart());
     }
-    if (condition.getCreateTimeEnd() != null) {
-      query.le(OfflineJobDefinitionPO::getCreateTime, condition.getCreateTimeEnd());
+    if (condition.createTimeEnd() != null) {
+      wrapper.le(OfflineJobDefinitionPO::getCreateTime, condition.createTimeEnd());
     }
-    query.orderByDesc(OfflineJobDefinitionPO::getUpdateTime)
+    wrapper.orderByDesc(OfflineJobDefinitionPO::getUpdateTime)
         .orderByDesc(OfflineJobDefinitionPO::getId);
     return mapper.selectPage(
-        new Page<>(condition.getCurrent(), condition.getPageSize()), query);
+        new Page<>(Math.max(1, condition.current()), Math.max(1, condition.pageSize())),
+        wrapper);
+  }
+
+  @Override
+  public List<OfflineJobDefinitionPO> selectWithCron() {
+    return mapper.selectList(
+        new LambdaQueryWrapper<OfflineJobDefinitionPO>()
+            .isNotNull(OfflineJobDefinitionPO::getCronExpression)
+            .orderByAsc(OfflineJobDefinitionPO::getId));
+  }
+
+  @Override
+  public Long lockById(Long id) {
+    return writeMapper.lockDefinition(id);
   }
 
   private <T> void addLike(
       LambdaQueryWrapper<OfflineJobDefinitionPO> query,
       com.baomidou.mybatisplus.core.toolkit.support.SFunction<OfflineJobDefinitionPO, T> column,
       String value) {
-    if (StringUtils.hasText(value)) {
-      query.like(column, value.trim());
-    }
+    if (StringUtils.hasText(value)) query.like(column, value.trim());
   }
 
   private String normalizeStatus(String status) {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/dao/impl/OfflineJobDefinitionDaoImpl.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/dao/impl/OfflineJobDefinitionDaoImpl.java
@@ -2,12 +2,14 @@ package io.yak.ops.business.sync.offline.dao.impl;
 
 import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
 import com.baomidou.mybatisplus.core.metadata.IPage;
+import com.baomidou.mybatisplus.core.toolkit.Wrappers;
 import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
 import io.yak.ops.business.sync.offline.dao.OfflineJobDefinitionDao;
 import io.yak.ops.business.sync.offline.dao.mapper.OfflineJobDefinitionMapper;
 import io.yak.ops.business.sync.offline.dao.mapper.OfflineWriteMapper;
 import io.yak.ops.common.bean.po.sync.offline.OfflineJobDefinitionPO;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Locale;
 import lombok.RequiredArgsConstructor;
@@ -103,6 +105,62 @@ public class OfflineJobDefinitionDaoImpl implements OfflineJobDefinitionDao {
   @Override
   public Long lockById(Long id) {
     return writeMapper.lockDefinition(id);
+  }
+
+  @Override
+  public boolean updateSchedule(
+      Long id,
+      String scheduleJson,
+      boolean enabled,
+      String cronExpression,
+      int retryMaxAttempts,
+      int retryBackoffSeconds,
+      LocalDateTime lastFireTime,
+      LocalDateTime nextFireTime,
+      LocalDateTime updateTime) {
+    return mapper.update(
+        null,
+        Wrappers.<OfflineJobDefinitionPO>lambdaUpdate()
+            .eq(OfflineJobDefinitionPO::getId, id)
+            .set(OfflineJobDefinitionPO::getScheduleJson, scheduleJson)
+            .set(OfflineJobDefinitionPO::getScheduleEnabled, enabled)
+            .set(OfflineJobDefinitionPO::getCronExpression, cronExpression)
+            .set(OfflineJobDefinitionPO::getRetryMaxAttempts, retryMaxAttempts)
+            .set(OfflineJobDefinitionPO::getRetryBackoffSeconds, retryBackoffSeconds)
+            .set(OfflineJobDefinitionPO::getScheduleLastFireTime, lastFireTime)
+            .set(OfflineJobDefinitionPO::getScheduleNextFireTime, nextFireTime)
+            .set(OfflineJobDefinitionPO::getUpdateTime, updateTime)) > 0;
+  }
+
+  @Override
+  public void updateScheduleRuntime(
+      Long id,
+      LocalDateTime lastFireTime,
+      LocalDateTime nextFireTime,
+      LocalDateTime updateTime) {
+    mapper.update(
+        null,
+        Wrappers.<OfflineJobDefinitionPO>lambdaUpdate()
+            .eq(OfflineJobDefinitionPO::getId, id)
+            .set(OfflineJobDefinitionPO::getScheduleLastFireTime, lastFireTime)
+            .set(OfflineJobDefinitionPO::getScheduleNextFireTime, nextFireTime)
+            .set(OfflineJobDefinitionPO::getUpdateTime, updateTime));
+  }
+
+  @Override
+  public void clearSchedule(Long id, LocalDateTime updateTime) {
+    mapper.update(
+        null,
+        Wrappers.<OfflineJobDefinitionPO>lambdaUpdate()
+            .eq(OfflineJobDefinitionPO::getId, id)
+            .set(OfflineJobDefinitionPO::getScheduleJson, null)
+            .set(OfflineJobDefinitionPO::getScheduleEnabled, false)
+            .set(OfflineJobDefinitionPO::getCronExpression, null)
+            .set(OfflineJobDefinitionPO::getRetryMaxAttempts, 1)
+            .set(OfflineJobDefinitionPO::getRetryBackoffSeconds, 60)
+            .set(OfflineJobDefinitionPO::getScheduleLastFireTime, null)
+            .set(OfflineJobDefinitionPO::getScheduleNextFireTime, null)
+            .set(OfflineJobDefinitionPO::getUpdateTime, updateTime));
   }
 
   private <T> void addLike(

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/dao/impl/OfflineJobExecutionDaoImpl.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/dao/impl/OfflineJobExecutionDaoImpl.java
@@ -2,32 +2,42 @@ package io.yak.ops.business.sync.offline.dao.impl;
 
 import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
 import com.baomidou.mybatisplus.core.metadata.IPage;
+import com.baomidou.mybatisplus.core.toolkit.Wrappers;
 import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
 import io.yak.ops.business.sync.offline.dao.OfflineJobExecutionDao;
 import io.yak.ops.business.sync.offline.dao.mapper.OfflineJobExecutionMapper;
-import io.yak.ops.common.bean.dto.sync.offline.OfflineJobExecutionQueryDTO;
 import io.yak.ops.common.bean.po.sync.offline.OfflineJobExecutionPO;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Locale;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import org.springframework.util.StringUtils;
 
-/**
- * 基于 MyBatis-Plus 的离线同步任务实例数据访问实现。
- *
- * @author weifuwan
- */
+/** 基于 MyBatis-Plus 的离线同步任务实例数据访问实现。 */
 @ConditionalOnOfflineSyncEnabled
 @Repository
 @RequiredArgsConstructor
 public class OfflineJobExecutionDaoImpl implements OfflineJobExecutionDao {
+
+  private static final List<String> ACTIVE_STATUSES =
+      List.of("CREATED", "SUBMITTED", "QUEUED", "RUNNING");
 
   private final OfflineJobExecutionMapper mapper;
 
   @Override
   public OfflineJobExecutionPO selectById(Long id) {
     return mapper.selectById(id);
+  }
+
+  @Override
+  public OfflineJobExecutionPO selectByIdempotencyKey(String idempotencyKey) {
+    if (!StringUtils.hasText(idempotencyKey)) return null;
+    return mapper.selectOne(
+        Wrappers.<OfflineJobExecutionPO>lambdaQuery()
+            .eq(OfflineJobExecutionPO::getIdempotencyKey, idempotencyKey.trim())
+            .last("LIMIT 1"));
   }
 
   @Override
@@ -41,20 +51,59 @@ public class OfflineJobExecutionDaoImpl implements OfflineJobExecutionDao {
   }
 
   @Override
-  public IPage<OfflineJobExecutionPO> selectPage(OfflineJobExecutionQueryDTO queryDTO) {
-    OfflineJobExecutionQueryDTO condition =
-        queryDTO == null ? new OfflineJobExecutionQueryDTO() : queryDTO;
-    LambdaQueryWrapper<OfflineJobExecutionPO> query = new LambdaQueryWrapper<>();
-    if (condition.getJobDefinitionId() != null && condition.getJobDefinitionId() > 0L) {
-      query.eq(OfflineJobExecutionPO::getJobDefinitionId, condition.getJobDefinitionId());
+  public boolean hasActiveExecution(Long definitionId) {
+    return mapper.selectCount(
+        Wrappers.<OfflineJobExecutionPO>lambdaQuery()
+            .eq(OfflineJobExecutionPO::getJobDefinitionId, definitionId)
+            .in(OfflineJobExecutionPO::getStatus, ACTIVE_STATUSES)) > 0L;
+  }
+
+  @Override
+  public List<OfflineJobExecutionPO> selectActiveExecutions(int limit) {
+    return mapper.selectList(
+        Wrappers.<OfflineJobExecutionPO>lambdaQuery()
+            .in(OfflineJobExecutionPO::getStatus, ACTIVE_STATUSES)
+            .orderByAsc(OfflineJobExecutionPO::getId)
+            .last("LIMIT " + Math.max(1, limit)));
+  }
+
+  @Override
+  public List<OfflineJobExecutionPO> selectRetryCandidates(LocalDateTime now, int limit) {
+    return mapper.selectList(
+        Wrappers.<OfflineJobExecutionPO>lambdaQuery()
+            .in(OfflineJobExecutionPO::getStatus, List.of("FAILED", "LOST"))
+            .eq(OfflineJobExecutionPO::getRetryCreated, false)
+            .isNotNull(OfflineJobExecutionPO::getNextRetryTime)
+            .le(OfflineJobExecutionPO::getNextRetryTime, now)
+            .orderByAsc(OfflineJobExecutionPO::getNextRetryTime)
+            .last("LIMIT " + Math.max(1, limit)));
+  }
+
+  @Override
+  public void markRetryCreated(Long executionId, LocalDateTime updateTime) {
+    mapper.update(
+        null,
+        Wrappers.<OfflineJobExecutionPO>lambdaUpdate()
+            .eq(OfflineJobExecutionPO::getId, executionId)
+            .set(OfflineJobExecutionPO::getRetryCreated, true)
+            .set(OfflineJobExecutionPO::getUpdateTime, updateTime));
+  }
+
+  @Override
+  public IPage<OfflineJobExecutionPO> selectPage(PageQuery query) {
+    PageQuery condition = query == null ? new PageQuery(1, 10, null, null) : query;
+    LambdaQueryWrapper<OfflineJobExecutionPO> wrapper = new LambdaQueryWrapper<>();
+    if (condition.jobDefinitionId() != null && condition.jobDefinitionId() > 0L) {
+      wrapper.eq(OfflineJobExecutionPO::getJobDefinitionId, condition.jobDefinitionId());
     }
-    if (StringUtils.hasText(condition.getStatus())) {
-      query.eq(
+    if (StringUtils.hasText(condition.status())) {
+      wrapper.eq(
           OfflineJobExecutionPO::getStatus,
-          condition.getStatus().trim().toUpperCase(Locale.ROOT));
+          condition.status().trim().toUpperCase(Locale.ROOT));
     }
-    query.orderByDesc(OfflineJobExecutionPO::getId);
+    wrapper.orderByDesc(OfflineJobExecutionPO::getId);
     return mapper.selectPage(
-        new Page<>(condition.getCurrent(), condition.getPageSize()), query);
+        new Page<>(Math.max(1, condition.current()), Math.max(1, condition.pageSize())),
+        wrapper);
   }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/dao/mapper/OfflineExecutionEventMapper.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/dao/mapper/OfflineExecutionEventMapper.java
@@ -1,0 +1,7 @@
+package io.yak.ops.business.sync.offline.dao.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import io.yak.ops.common.bean.po.sync.offline.OfflineExecutionEventPO;
+
+/** 离线同步执行事件 Mapper。 */
+public interface OfflineExecutionEventMapper extends BaseMapper<OfflineExecutionEventPO> {}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/dao/mapper/OfflineWriteMapper.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/dao/mapper/OfflineWriteMapper.java
@@ -1,0 +1,10 @@
+package io.yak.ops.business.sync.offline.dao.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+/** 只承载需要数据库原子语义、无法拆成普通 BaseMapper CRUD 的操作。 */
+@Mapper
+public interface OfflineWriteMapper {
+  Long lockDefinition(@Param("id") Long id);
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/domain/OfflineDefinitionQuery.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/domain/OfflineDefinitionQuery.java
@@ -1,0 +1,17 @@
+package io.yak.ops.business.sync.offline.domain;
+
+import java.time.LocalDateTime;
+
+/** 任务定义业务查询条件，不依赖 HTTP DTO。 */
+public record OfflineDefinitionQuery(
+    int current,
+    int pageSize,
+    Long id,
+    String jobName,
+    String status,
+    String sourceType,
+    String sinkType,
+    String sourceTable,
+    String sinkTable,
+    LocalDateTime createTimeStart,
+    LocalDateTime createTimeEnd) {}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/domain/OfflineExecutionEvent.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/domain/OfflineExecutionEvent.java
@@ -1,0 +1,24 @@
+package io.yak.ops.business.sync.offline.domain;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/** 离线同步执行状态事件领域模型。 */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class OfflineExecutionEvent {
+  private Long id;
+  private Long executionId;
+  private Long stateVersion;
+  private String fromStatus;
+  private String toStatus;
+  private String eventType;
+  private String message;
+  private String payloadJson;
+  private LocalDateTime createTime;
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/domain/OfflineExecutionQuery.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/domain/OfflineExecutionQuery.java
@@ -1,0 +1,8 @@
+package io.yak.ops.business.sync.offline.domain;
+
+/** 执行实例业务查询条件，不依赖 HTTP DTO。 */
+public record OfflineExecutionQuery(
+    int current,
+    int pageSize,
+    Long jobDefinitionId,
+    String status) {}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/domain/OfflineJobDefinition.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/domain/OfflineJobDefinition.java
@@ -1,0 +1,51 @@
+package io.yak.ops.business.sync.offline.domain;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/** 离线同步任务定义领域模型。 */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class OfflineJobDefinition {
+  private Long id;
+  private String jobName;
+  private String jobDesc;
+  private String mode;
+  private String definitionJson;
+  private String jobSpecJson;
+  private String configDigest;
+  private String releaseState;
+  private String sourceType;
+  private String sinkType;
+  private Long sourceDatasourceId;
+  private Long sinkDatasourceId;
+  private String sourceDatasourceName;
+  private String sinkDatasourceName;
+  private String sourceTable;
+  private String sinkTable;
+  private String scheduleJson;
+  private Boolean scheduleEnabled;
+  private String cronExpression;
+  private Integer retryMaxAttempts;
+  private Integer retryBackoffSeconds;
+  private LocalDateTime scheduleLastFireTime;
+  private LocalDateTime scheduleNextFireTime;
+  private Integer version;
+  private Long lastExecutionId;
+  private String lastEngineJobId;
+  private String lastJobStatus;
+  private String lastErrorMessage;
+  private Long lastDurationMillis;
+  private Long lastReadRowCount;
+  private Double lastQps;
+  private Long lastSyncBytes;
+  private LocalDateTime lastStartTime;
+  private LocalDateTime lastEndTime;
+  private LocalDateTime createTime;
+  private LocalDateTime updateTime;
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/domain/OfflineJobExecution.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/domain/OfflineJobExecution.java
@@ -1,0 +1,55 @@
+package io.yak.ops.business.sync.offline.domain;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/** 离线同步执行实例领域模型。 */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class OfflineJobExecution {
+  private Long id;
+  private Long jobDefinitionId;
+  private Integer definitionVersion;
+  private String engineBaseUrl;
+  private String engineJobId;
+  private String externalExecutionId;
+  private String idempotencyKey;
+  private String workerInstanceId;
+  private String status;
+  private Long stateVersion;
+  private Integer attemptNo;
+  private String triggerType;
+  private Long retryFromExecutionId;
+  private Boolean cancellationRequested;
+  private Boolean retryCreated;
+  private LocalDateTime nextRetryTime;
+  private String configDigest;
+  private String definitionSnapshotJson;
+  private String submittedConfig;
+  private String engineSnapshotJson;
+  private String errorMessage;
+  private Long sourceRecordCount;
+  private Long sinkAttemptedRecordCount;
+  private Long sinkSuccessRecordCount;
+  private Long sinkCommittedRecordCount;
+  private Long sourceReadBytes;
+  private Long sinkWrittenBytes;
+  private Double sourceAverageQps;
+  private Double sinkAverageQps;
+  private Long failedRecordCount;
+  private Long skippedRecordCount;
+  private Long databaseCommitMillis;
+  private Long sqlExecutionMillis;
+  private Double qps;
+  private Long durationMillis;
+  private LocalDateTime createTime;
+  private LocalDateTime startTime;
+  private LocalDateTime endTime;
+  private LocalDateTime lastSyncTime;
+  private LocalDateTime updateTime;
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/domain/OfflinePage.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/domain/OfflinePage.java
@@ -1,0 +1,11 @@
+package io.yak.ops.business.sync.offline.domain;
+
+import java.util.List;
+
+/** 与具体分页框架无关的业务分页结果。 */
+public record OfflinePage<T>(
+    List<T> records,
+    long total,
+    long pages,
+    long current,
+    long pageSize) {}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/domain/OfflineSchedule.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/domain/OfflineSchedule.java
@@ -1,0 +1,14 @@
+package io.yak.ops.business.sync.offline.domain;
+
+import java.time.LocalDateTime;
+
+/** 离线同步任务级调度投影；持久化仍落在任务定义表。 */
+public record OfflineSchedule(
+    Long jobDefinitionId,
+    String cronExpression,
+    boolean enabled,
+    int retryMaxAttempts,
+    int retryBackoffSeconds,
+    LocalDateTime nextFireTime,
+    LocalDateTime lastFireTime,
+    String scheduleJson) {}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineExecutionControlRepository.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineExecutionControlRepository.java
@@ -1,72 +1,43 @@
 package io.yak.ops.business.sync.offline.repository;
 
 import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
-import io.yak.ops.common.bean.po.sync.offline.OfflineJobExecutionPO;
-import java.sql.Timestamp;
+import io.yak.ops.business.sync.offline.domain.OfflineExecutionEvent;
+import io.yak.ops.business.sync.offline.domain.OfflineJobExecution;
 import java.time.LocalDateTime;
 import java.util.List;
-import javax.sql.DataSource;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.stereotype.Repository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
 
-/** 执行领取、对账、重试和状态事件持久化。 */
+/**
+ * @deprecated 兼容旧内部调用；新代码直接依赖 Definition/Execution/Event Repository。
+ */
+@Deprecated(forRemoval = true)
 @ConditionalOnOfflineSyncEnabled
-@Repository
+@Component
+@RequiredArgsConstructor
 public class OfflineExecutionControlRepository {
-  private final JdbcTemplate jdbc;
-
-  public OfflineExecutionControlRepository(
-      @Qualifier("offlineSyncDataSource") DataSource dataSource) {
-    this.jdbc = new JdbcTemplate(dataSource);
-  }
+  private final OfflineJobDefinitionRepository definitionRepository;
+  private final OfflineJobExecutionRepository executionRepository;
+  private final OfflineExecutionEventRepository eventRepository;
 
   public void lockDefinition(Long id) {
-    Long locked =
-        jdbc.queryForObject(
-            "SELECT id FROM yak_offline_job_definition WHERE id=? FOR UPDATE",
-            Long.class,
-            id);
-    if (locked == null) {
-      throw new IllegalArgumentException("离线同步任务不存在：" + id);
-    }
+    definitionRepository.lock(id);
   }
 
   public boolean hasActiveExecution(Long id) {
-    Integer count =
-        jdbc.queryForObject(
-            "SELECT COUNT(1) FROM yak_offline_job_execution WHERE job_definition_id=? "
-                + "AND status IN ('CREATED','SUBMITTED','QUEUED','RUNNING')",
-            Integer.class,
-            id);
-    return count != null && count > 0;
+    return executionRepository.hasActiveExecution(id);
   }
 
-  public List<OfflineJobExecutionPO> findActiveExecutions(int limit) {
-    return jdbc.query(
-        "SELECT * FROM yak_offline_job_execution WHERE status IN "
-            + "('CREATED','SUBMITTED','QUEUED','RUNNING') ORDER BY id LIMIT ?",
-        (rs, row) -> map(rs),
-        Math.max(1, limit));
+  public List<OfflineJobExecution> findActiveExecutions(int limit) {
+    return executionRepository.findActiveExecutions(limit);
   }
 
-  public List<OfflineJobExecutionPO> findRetryCandidates(
-      LocalDateTime now,
-      int limit) {
-    return jdbc.query(
-        "SELECT * FROM yak_offline_job_execution WHERE status IN ('FAILED','LOST') "
-            + "AND retry_created=0 AND next_retry_time IS NOT NULL AND next_retry_time<=? "
-            + "ORDER BY next_retry_time LIMIT ?",
-        (rs, row) -> map(rs),
-        Timestamp.valueOf(now),
-        Math.max(1, limit));
+  public List<OfflineJobExecution> findRetryCandidates(LocalDateTime now, int limit) {
+    return executionRepository.findRetryCandidates(now, limit);
   }
 
   public void markRetryCreated(Long id) {
-    jdbc.update(
-        "UPDATE yak_offline_job_execution SET retry_created=1, update_time=? WHERE id=?",
-        Timestamp.valueOf(LocalDateTime.now()),
-        id);
+    executionRepository.markRetryCreated(id);
   }
 
   public void recordExecutionEvent(
@@ -77,178 +48,24 @@ public class OfflineExecutionControlRepository {
       String type,
       String message,
       String payload) {
-    jdbc.update(
-        "INSERT INTO yak_offline_execution_event "
-            + "(execution_id,state_version,from_status,to_status,event_type,message,payload_json,create_time) "
-            + "VALUES (?,?,?,?,?,?,?,?)",
-        executionId,
-        version,
-        from,
-        to,
-        type,
-        message,
-        payload,
-        Timestamp.valueOf(LocalDateTime.now()));
+    eventRepository.append(
+        OfflineExecutionEvent.builder()
+            .executionId(executionId)
+            .stateVersion(version)
+            .fromStatus(from)
+            .toStatus(to)
+            .eventType(type)
+            .message(message)
+            .payloadJson(payload)
+            .createTime(LocalDateTime.now())
+            .build());
   }
 
-  public List<ExecutionEventRecord> listExecutionEvents(Long id) {
-    return jdbc.query(
-        "SELECT * FROM yak_offline_execution_event WHERE execution_id=? ORDER BY id",
-        (rs, row) -> event(rs),
-        id);
+  public List<OfflineExecutionEvent> listExecutionEvents(Long id) {
+    return eventRepository.list(id);
   }
 
-  public List<ExecutionEventRecord> listExecutionEventsAfter(
-      Long executionId,
-      long afterId,
-      int limit) {
-    if (afterId < 0L) {
-      throw new IllegalArgumentException("事件游标不能为负数");
-    }
-    if (limit < 1 || limit > 1000) {
-      throw new IllegalArgumentException("日志 limit 必须在 1 到 1000 之间");
-    }
-    return jdbc.query(
-        "SELECT * FROM yak_offline_execution_event "
-            + "WHERE execution_id=? AND id>? ORDER BY id LIMIT ?",
-        (rs, row) -> event(rs),
-        executionId,
-        afterId,
-        limit);
-  }
-
-  private ExecutionEventRecord event(
-      java.sql.ResultSet rs)
-      throws java.sql.SQLException {
-    return new ExecutionEventRecord(
-        rs.getLong("id"),
-        rs.getLong("execution_id"),
-        rs.getLong("state_version"),
-        rs.getString("from_status"),
-        rs.getString("to_status"),
-        rs.getString("event_type"),
-        rs.getString("message"),
-        rs.getString("payload_json"),
-        rs.getTimestamp("create_time").toLocalDateTime());
-  }
-
-  private OfflineJobExecutionPO map(
-      java.sql.ResultSet rs)
-      throws java.sql.SQLException {
-    OfflineJobExecutionPO execution = new OfflineJobExecutionPO();
-    execution.setId(rs.getLong("id"));
-    execution.setJobDefinitionId(rs.getLong("job_definition_id"));
-    execution.setDefinitionVersion(rs.getInt("definition_version"));
-    execution.setEngineBaseUrl(rs.getString("engine_base_url"));
-    execution.setEngineJobId(rs.getString("engine_job_id"));
-    execution.setExternalExecutionId(rs.getString("external_execution_id"));
-    execution.setIdempotencyKey(rs.getString("idempotency_key"));
-    execution.setWorkerInstanceId(rs.getString("worker_instance_id"));
-    execution.setStatus(rs.getString("status"));
-    execution.setStateVersion(rs.getLong("state_version"));
-    execution.setAttemptNo(rs.getInt("attempt_no"));
-    execution.setTriggerType(rs.getString("trigger_type"));
-    execution.setRetryFromExecutionId(nullableLong(rs, "retry_from_execution_id"));
-    execution.setCancellationRequested(rs.getBoolean("cancellation_requested"));
-    execution.setRetryCreated(rs.getBoolean("retry_created"));
-    execution.setNextRetryTime(local(rs.getTimestamp("next_retry_time")));
-    execution.setConfigDigest(rs.getString("config_digest"));
-    execution.setDefinitionSnapshotJson(rs.getString("definition_snapshot_json"));
-    execution.setSubmittedConfig(rs.getString("submitted_config"));
-    execution.setEngineSnapshotJson(rs.getString("engine_snapshot_json"));
-    execution.setErrorMessage(rs.getString("error_message"));
-    execution.setSourceRecordCount(rs.getLong("source_record_count"));
-    execution.setSinkSuccessRecordCount(rs.getLong("sink_success_record_count"));
-    execution.setSourceReadBytes(rs.getLong("source_read_bytes"));
-    execution.setSinkWrittenBytes(rs.getLong("sink_written_bytes"));
-    execution.setQps(rs.getDouble("qps"));
-    execution.setDurationMillis(rs.getLong("duration_millis"));
-    execution.setCreateTime(local(rs.getTimestamp("create_time")));
-    execution.setStartTime(local(rs.getTimestamp("start_time")));
-    execution.setEndTime(local(rs.getTimestamp("end_time")));
-    execution.setLastSyncTime(local(rs.getTimestamp("last_sync_time")));
-    execution.setUpdateTime(local(rs.getTimestamp("update_time")));
-    return execution;
-  }
-
-  private Long nullableLong(
-      java.sql.ResultSet rs,
-      String column)
-      throws java.sql.SQLException {
-    long value = rs.getLong(column);
-    return rs.wasNull() ? null : value;
-  }
-
-  private LocalDateTime local(Timestamp timestamp) {
-    return timestamp == null ? null : timestamp.toLocalDateTime();
-  }
-
-  public static final class ExecutionEventRecord {
-    private final Long id;
-    private final Long executionId;
-    private final long stateVersion;
-    private final String fromStatus;
-    private final String toStatus;
-    private final String eventType;
-    private final String message;
-    private final String payloadJson;
-    private final LocalDateTime createTime;
-
-    public ExecutionEventRecord(
-        Long id,
-        Long executionId,
-        long stateVersion,
-        String fromStatus,
-        String toStatus,
-        String eventType,
-        String message,
-        String payloadJson,
-        LocalDateTime createTime) {
-      this.id = id;
-      this.executionId = executionId;
-      this.stateVersion = stateVersion;
-      this.fromStatus = fromStatus;
-      this.toStatus = toStatus;
-      this.eventType = eventType;
-      this.message = message;
-      this.payloadJson = payloadJson;
-      this.createTime = createTime;
-    }
-
-    public Long getId() {
-      return id;
-    }
-
-    public Long getExecutionId() {
-      return executionId;
-    }
-
-    public long getStateVersion() {
-      return stateVersion;
-    }
-
-    public String getFromStatus() {
-      return fromStatus;
-    }
-
-    public String getToStatus() {
-      return toStatus;
-    }
-
-    public String getEventType() {
-      return eventType;
-    }
-
-    public String getMessage() {
-      return message;
-    }
-
-    public String getPayloadJson() {
-      return payloadJson;
-    }
-
-    public LocalDateTime getCreateTime() {
-      return createTime;
-    }
+  public List<OfflineExecutionEvent> listExecutionEventsAfter(Long id, long afterId, int limit) {
+    return eventRepository.listAfter(id, afterId, limit);
   }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineExecutionEventRepository.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineExecutionEventRepository.java
@@ -1,0 +1,11 @@
+package io.yak.ops.business.sync.offline.repository;
+
+import io.yak.ops.business.sync.offline.domain.OfflineExecutionEvent;
+import java.util.List;
+
+/** 离线同步执行事件领域仓储。 */
+public interface OfflineExecutionEventRepository {
+  void append(OfflineExecutionEvent event);
+  List<OfflineExecutionEvent> list(Long executionId);
+  List<OfflineExecutionEvent> listAfter(Long executionId, long afterId, int limit);
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineExecutionEventRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineExecutionEventRepositoryAdapter.java
@@ -1,0 +1,44 @@
+package io.yak.ops.business.sync.offline.repository;
+
+import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import io.yak.ops.business.sync.offline.dao.OfflineExecutionEventDao;
+import io.yak.ops.business.sync.offline.domain.OfflineExecutionEvent;
+import io.yak.ops.common.bean.po.sync.offline.OfflineExecutionEventPO;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.BeanUtils;
+import org.springframework.stereotype.Repository;
+
+/** 执行事件 PO 与领域模型之间的持久化适配器。 */
+@ConditionalOnOfflineSyncEnabled
+@Repository
+@RequiredArgsConstructor
+public class OfflineExecutionEventRepositoryAdapter implements OfflineExecutionEventRepository {
+  private final OfflineExecutionEventDao dao;
+
+  @Override
+  public void append(OfflineExecutionEvent event) {
+    OfflineExecutionEventPO po = new OfflineExecutionEventPO();
+    BeanUtils.copyProperties(event, po);
+    if (!dao.insert(po)) throw new IllegalStateException("记录离线同步执行事件失败");
+    event.setId(po.getId());
+  }
+
+  @Override
+  public List<OfflineExecutionEvent> list(Long executionId) {
+    return dao.selectByExecutionId(executionId).stream().map(this::toDomain).toList();
+  }
+
+  @Override
+  public List<OfflineExecutionEvent> listAfter(Long executionId, long afterId, int limit) {
+    if (afterId < 0L) throw new IllegalArgumentException("事件游标不能为负数");
+    if (limit < 1 || limit > 1000) throw new IllegalArgumentException("日志 limit 必须在 1 到 1000 之间");
+    return dao.selectAfter(executionId, afterId, limit).stream().map(this::toDomain).toList();
+  }
+
+  private OfflineExecutionEvent toDomain(OfflineExecutionEventPO po) {
+    OfflineExecutionEvent value = new OfflineExecutionEvent();
+    BeanUtils.copyProperties(po, value);
+    return value;
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineExecutionIdempotencyRepository.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineExecutionIdempotencyRepository.java
@@ -1,36 +1,22 @@
 package io.yak.ops.business.sync.offline.repository;
 
 import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
-import io.yak.ops.business.sync.offline.dao.OfflineJobExecutionDao;
-import io.yak.ops.common.bean.po.sync.offline.OfflineJobExecutionPO;
-import java.util.List;
+import io.yak.ops.business.sync.offline.domain.OfflineJobExecution;
 import java.util.Optional;
-import javax.sql.DataSource;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.stereotype.Repository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
 
-/** Small lookup adapter used to make workflow Attempt submission locally idempotent. */
+/**
+ * @deprecated 兼容旧内部调用；新代码直接使用 OfflineJobExecutionRepository。
+ */
+@Deprecated(forRemoval = true)
 @ConditionalOnOfflineSyncEnabled
-@Repository
+@Component
+@RequiredArgsConstructor
 public class OfflineExecutionIdempotencyRepository {
-  private final JdbcTemplate jdbc;
-  private final OfflineJobExecutionDao executionDao;
+  private final OfflineJobExecutionRepository executionRepository;
 
-  public OfflineExecutionIdempotencyRepository(
-      @Qualifier("offlineSyncDataSource") DataSource dataSource,
-      OfflineJobExecutionDao executionDao) {
-    this.jdbc = new JdbcTemplate(dataSource);
-    this.executionDao = executionDao;
-  }
-
-  public Optional<OfflineJobExecutionPO> findByKey(String idempotencyKey) {
-    if (idempotencyKey == null || idempotencyKey.isBlank()) return Optional.empty();
-    List<Long> ids = jdbc.queryForList(
-        "SELECT id FROM yak_offline_job_execution WHERE idempotency_key=? LIMIT 1",
-        Long.class,
-        idempotencyKey.trim());
-    if (ids.isEmpty()) return Optional.empty();
-    return Optional.ofNullable(executionDao.selectById(ids.get(0)));
+  public Optional<OfflineJobExecution> findByKey(String idempotencyKey) {
+    return executionRepository.findByIdempotencyKey(idempotencyKey);
   }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineJobDefinitionRepository.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineJobDefinitionRepository.java
@@ -1,0 +1,17 @@
+package io.yak.ops.business.sync.offline.repository;
+
+import io.yak.ops.business.sync.offline.domain.OfflineDefinitionQuery;
+import io.yak.ops.business.sync.offline.domain.OfflineJobDefinition;
+import io.yak.ops.business.sync.offline.domain.OfflinePage;
+import java.util.Optional;
+
+/** 离线同步任务定义领域仓储。 */
+public interface OfflineJobDefinitionRepository {
+  void lock(Long id);
+  Optional<OfflineJobDefinition> findById(Long id);
+  boolean insert(OfflineJobDefinition definition);
+  boolean update(OfflineJobDefinition definition);
+  boolean delete(Long id);
+  boolean existsByName(String jobName, Long excludeId);
+  OfflinePage<OfflineJobDefinition> page(OfflineDefinitionQuery query);
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineJobDefinitionRepository.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineJobDefinitionRepository.java
@@ -9,6 +9,7 @@ import java.util.Optional;
 public interface OfflineJobDefinitionRepository {
   void lock(Long id);
   Optional<OfflineJobDefinition> findById(Long id);
+  Optional<OfflineJobDefinition> findForViewById(Long id);
   boolean insert(OfflineJobDefinition definition);
   boolean update(OfflineJobDefinition definition);
   boolean delete(Long id);

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineJobDefinitionRepository.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineJobDefinitionRepository.java
@@ -15,4 +15,5 @@ public interface OfflineJobDefinitionRepository {
   boolean delete(Long id);
   boolean existsByName(String jobName, Long excludeId);
   OfflinePage<OfflineJobDefinition> page(OfflineDefinitionQuery query);
+  OfflinePage<OfflineJobDefinition> pageForView(OfflineDefinitionQuery query);
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineJobDefinitionRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineJobDefinitionRepositoryAdapter.java
@@ -63,6 +63,17 @@ public class OfflineJobDefinitionRepositoryAdapter implements OfflineJobDefiniti
 
   @Override
   public OfflinePage<OfflineJobDefinition> page(OfflineDefinitionQuery query) {
+    return page(query, false);
+  }
+
+  @Override
+  public OfflinePage<OfflineJobDefinition> pageForView(OfflineDefinitionQuery query) {
+    return page(query, true);
+  }
+
+  private OfflinePage<OfflineJobDefinition> page(
+      OfflineDefinitionQuery query,
+      boolean includeDisplayNames) {
     OfflineDefinitionQuery q = query == null
         ? new OfflineDefinitionQuery(1, 10, null, null, null, null, null, null, null, null, null)
         : query;
@@ -72,7 +83,7 @@ public class OfflineJobDefinitionRepositoryAdapter implements OfflineJobDefiniti
             q.sourceType(), q.sinkType(), q.sourceTable(), q.sinkTable(),
             q.createTimeStart(), q.createTimeEnd()));
     List<OfflineJobDefinition> records = page.getRecords().stream()
-        .map(po -> toDomain(po, true))
+        .map(po -> toDomain(po, includeDisplayNames))
         .toList();
     return new OfflinePage<>(records, page.getTotal(), page.getPages(), page.getCurrent(), page.getSize());
   }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineJobDefinitionRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineJobDefinitionRepositoryAdapter.java
@@ -1,12 +1,14 @@
 package io.yak.ops.business.sync.offline.repository;
 
 import com.baomidou.mybatisplus.core.metadata.IPage;
+import io.yak.ops.business.datasource.dao.DataSourceDao;
 import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
 import io.yak.ops.business.sync.offline.dao.OfflineJobDefinitionDao;
 import io.yak.ops.business.sync.offline.dao.OfflineJobDefinitionDao.PageQuery;
 import io.yak.ops.business.sync.offline.domain.OfflineDefinitionQuery;
 import io.yak.ops.business.sync.offline.domain.OfflineJobDefinition;
 import io.yak.ops.business.sync.offline.domain.OfflinePage;
+import io.yak.ops.common.bean.po.datasource.DataSourcePO;
 import io.yak.ops.common.bean.po.sync.offline.OfflineJobDefinitionPO;
 import java.util.List;
 import java.util.Optional;
@@ -20,6 +22,7 @@ import org.springframework.stereotype.Repository;
 @RequiredArgsConstructor
 public class OfflineJobDefinitionRepositoryAdapter implements OfflineJobDefinitionRepository {
   private final OfflineJobDefinitionDao dao;
+  private final DataSourceDao dataSourceDao;
 
   @Override
   public void lock(Long id) {
@@ -30,7 +33,12 @@ public class OfflineJobDefinitionRepositoryAdapter implements OfflineJobDefiniti
 
   @Override
   public Optional<OfflineJobDefinition> findById(Long id) {
-    return Optional.ofNullable(toDomain(dao.selectById(id)));
+    return Optional.ofNullable(toDomain(dao.selectById(id), false));
+  }
+
+  @Override
+  public Optional<OfflineJobDefinition> findForViewById(Long id) {
+    return Optional.ofNullable(toDomain(dao.selectById(id), true));
   }
 
   @Override
@@ -63,14 +71,20 @@ public class OfflineJobDefinitionRepositoryAdapter implements OfflineJobDefiniti
             q.current(), q.pageSize(), q.id(), q.jobName(), q.status(),
             q.sourceType(), q.sinkType(), q.sourceTable(), q.sinkTable(),
             q.createTimeStart(), q.createTimeEnd()));
-    List<OfflineJobDefinition> records = page.getRecords().stream().map(this::toDomain).toList();
+    List<OfflineJobDefinition> records = page.getRecords().stream()
+        .map(po -> toDomain(po, true))
+        .toList();
     return new OfflinePage<>(records, page.getTotal(), page.getPages(), page.getCurrent(), page.getSize());
   }
 
-  private OfflineJobDefinition toDomain(OfflineJobDefinitionPO po) {
+  private OfflineJobDefinition toDomain(OfflineJobDefinitionPO po, boolean includeDisplayNames) {
     if (po == null) return null;
     OfflineJobDefinition value = new OfflineJobDefinition();
     BeanUtils.copyProperties(po, value);
+    if (includeDisplayNames) {
+      value.setSourceDatasourceName(dataSourceName(po.getSourceDatasourceId()));
+      value.setSinkDatasourceName(dataSourceName(po.getSinkDatasourceId()));
+    }
     return value;
   }
 
@@ -78,5 +92,11 @@ public class OfflineJobDefinitionRepositoryAdapter implements OfflineJobDefiniti
     OfflineJobDefinitionPO po = new OfflineJobDefinitionPO();
     BeanUtils.copyProperties(value, po);
     return po;
+  }
+
+  private String dataSourceName(Long id) {
+    if (id == null) return null;
+    DataSourcePO dataSource = dataSourceDao.selectById(id);
+    return dataSource == null ? null : dataSource.getName();
   }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineJobDefinitionRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineJobDefinitionRepositoryAdapter.java
@@ -1,14 +1,12 @@
 package io.yak.ops.business.sync.offline.repository;
 
 import com.baomidou.mybatisplus.core.metadata.IPage;
-import io.yak.ops.business.datasource.dao.DataSourceDao;
 import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
 import io.yak.ops.business.sync.offline.dao.OfflineJobDefinitionDao;
 import io.yak.ops.business.sync.offline.dao.OfflineJobDefinitionDao.PageQuery;
 import io.yak.ops.business.sync.offline.domain.OfflineDefinitionQuery;
 import io.yak.ops.business.sync.offline.domain.OfflineJobDefinition;
 import io.yak.ops.business.sync.offline.domain.OfflinePage;
-import io.yak.ops.common.bean.po.datasource.DataSourcePO;
 import io.yak.ops.common.bean.po.sync.offline.OfflineJobDefinitionPO;
 import java.util.List;
 import java.util.Optional;
@@ -22,7 +20,6 @@ import org.springframework.stereotype.Repository;
 @RequiredArgsConstructor
 public class OfflineJobDefinitionRepositoryAdapter implements OfflineJobDefinitionRepository {
   private final OfflineJobDefinitionDao dao;
-  private final DataSourceDao dataSourceDao;
 
   @Override
   public void lock(Long id) {
@@ -74,8 +71,6 @@ public class OfflineJobDefinitionRepositoryAdapter implements OfflineJobDefiniti
     if (po == null) return null;
     OfflineJobDefinition value = new OfflineJobDefinition();
     BeanUtils.copyProperties(po, value);
-    value.setSourceDatasourceName(dataSourceName(po.getSourceDatasourceId()));
-    value.setSinkDatasourceName(dataSourceName(po.getSinkDatasourceId()));
     return value;
   }
 
@@ -83,11 +78,5 @@ public class OfflineJobDefinitionRepositoryAdapter implements OfflineJobDefiniti
     OfflineJobDefinitionPO po = new OfflineJobDefinitionPO();
     BeanUtils.copyProperties(value, po);
     return po;
-  }
-
-  private String dataSourceName(Long id) {
-    if (id == null) return null;
-    DataSourcePO dataSource = dataSourceDao.selectById(id);
-    return dataSource == null ? null : dataSource.getName();
   }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineJobDefinitionRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineJobDefinitionRepositoryAdapter.java
@@ -1,0 +1,93 @@
+package io.yak.ops.business.sync.offline.repository;
+
+import com.baomidou.mybatisplus.core.metadata.IPage;
+import io.yak.ops.business.datasource.dao.DataSourceDao;
+import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import io.yak.ops.business.sync.offline.dao.OfflineJobDefinitionDao;
+import io.yak.ops.business.sync.offline.dao.OfflineJobDefinitionDao.PageQuery;
+import io.yak.ops.business.sync.offline.domain.OfflineDefinitionQuery;
+import io.yak.ops.business.sync.offline.domain.OfflineJobDefinition;
+import io.yak.ops.business.sync.offline.domain.OfflinePage;
+import io.yak.ops.common.bean.po.datasource.DataSourcePO;
+import io.yak.ops.common.bean.po.sync.offline.OfflineJobDefinitionPO;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.BeanUtils;
+import org.springframework.stereotype.Repository;
+
+/** MyBatis 持久化模型与任务定义领域模型之间的适配器。 */
+@ConditionalOnOfflineSyncEnabled
+@Repository
+@RequiredArgsConstructor
+public class OfflineJobDefinitionRepositoryAdapter implements OfflineJobDefinitionRepository {
+  private final OfflineJobDefinitionDao dao;
+  private final DataSourceDao dataSourceDao;
+
+  @Override
+  public void lock(Long id) {
+    if (dao.lockById(id) == null) {
+      throw new IllegalArgumentException("离线同步任务不存在：" + id);
+    }
+  }
+
+  @Override
+  public Optional<OfflineJobDefinition> findById(Long id) {
+    return Optional.ofNullable(toDomain(dao.selectById(id)));
+  }
+
+  @Override
+  public boolean insert(OfflineJobDefinition definition) {
+    return dao.insert(toPO(definition));
+  }
+
+  @Override
+  public boolean update(OfflineJobDefinition definition) {
+    return dao.updateById(toPO(definition));
+  }
+
+  @Override
+  public boolean delete(Long id) {
+    return dao.deleteById(id);
+  }
+
+  @Override
+  public boolean existsByName(String jobName, Long excludeId) {
+    return dao.existsByName(jobName, excludeId);
+  }
+
+  @Override
+  public OfflinePage<OfflineJobDefinition> page(OfflineDefinitionQuery query) {
+    OfflineDefinitionQuery q = query == null
+        ? new OfflineDefinitionQuery(1, 10, null, null, null, null, null, null, null, null, null)
+        : query;
+    IPage<OfflineJobDefinitionPO> page = dao.selectPage(
+        new PageQuery(
+            q.current(), q.pageSize(), q.id(), q.jobName(), q.status(),
+            q.sourceType(), q.sinkType(), q.sourceTable(), q.sinkTable(),
+            q.createTimeStart(), q.createTimeEnd()));
+    List<OfflineJobDefinition> records = page.getRecords().stream().map(this::toDomain).toList();
+    return new OfflinePage<>(records, page.getTotal(), page.getPages(), page.getCurrent(), page.getSize());
+  }
+
+  private OfflineJobDefinition toDomain(OfflineJobDefinitionPO po) {
+    if (po == null) return null;
+    OfflineJobDefinition value = new OfflineJobDefinition();
+    BeanUtils.copyProperties(po, value);
+    value.setSourceDatasourceName(dataSourceName(po.getSourceDatasourceId()));
+    value.setSinkDatasourceName(dataSourceName(po.getSinkDatasourceId()));
+    return value;
+  }
+
+  private OfflineJobDefinitionPO toPO(OfflineJobDefinition value) {
+    OfflineJobDefinitionPO po = new OfflineJobDefinitionPO();
+    BeanUtils.copyProperties(value, po);
+    return po;
+  }
+
+  private String dataSourceName(Long id) {
+    if (id == null) return null;
+    DataSourcePO dataSource = dataSourceDao.selectById(id);
+    return dataSource == null ? null : dataSource.getName();
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineJobExecutionRepository.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineJobExecutionRepository.java
@@ -1,0 +1,21 @@
+package io.yak.ops.business.sync.offline.repository;
+
+import io.yak.ops.business.sync.offline.domain.OfflineExecutionQuery;
+import io.yak.ops.business.sync.offline.domain.OfflineJobExecution;
+import io.yak.ops.business.sync.offline.domain.OfflinePage;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+/** 离线同步执行实例领域仓储。 */
+public interface OfflineJobExecutionRepository {
+  Optional<OfflineJobExecution> findById(Long id);
+  Optional<OfflineJobExecution> findByIdempotencyKey(String idempotencyKey);
+  boolean insert(OfflineJobExecution execution);
+  boolean update(OfflineJobExecution execution);
+  boolean hasActiveExecution(Long definitionId);
+  List<OfflineJobExecution> findActiveExecutions(int limit);
+  List<OfflineJobExecution> findRetryCandidates(LocalDateTime now, int limit);
+  void markRetryCreated(Long executionId);
+  OfflinePage<OfflineJobExecution> page(OfflineExecutionQuery query);
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineJobExecutionRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineJobExecutionRepositoryAdapter.java
@@ -1,0 +1,90 @@
+package io.yak.ops.business.sync.offline.repository;
+
+import com.baomidou.mybatisplus.core.metadata.IPage;
+import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import io.yak.ops.business.sync.offline.dao.OfflineJobExecutionDao;
+import io.yak.ops.business.sync.offline.dao.OfflineJobExecutionDao.PageQuery;
+import io.yak.ops.business.sync.offline.domain.OfflineExecutionQuery;
+import io.yak.ops.business.sync.offline.domain.OfflineJobExecution;
+import io.yak.ops.business.sync.offline.domain.OfflinePage;
+import io.yak.ops.common.bean.po.sync.offline.OfflineJobExecutionPO;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.BeanUtils;
+import org.springframework.stereotype.Repository;
+
+/** MyBatis 持久化模型与执行实例领域模型之间的适配器。 */
+@ConditionalOnOfflineSyncEnabled
+@Repository
+@RequiredArgsConstructor
+public class OfflineJobExecutionRepositoryAdapter implements OfflineJobExecutionRepository {
+  private final OfflineJobExecutionDao dao;
+
+  @Override
+  public Optional<OfflineJobExecution> findById(Long id) {
+    return Optional.ofNullable(toDomain(dao.selectById(id)));
+  }
+
+  @Override
+  public Optional<OfflineJobExecution> findByIdempotencyKey(String idempotencyKey) {
+    return Optional.ofNullable(toDomain(dao.selectByIdempotencyKey(idempotencyKey)));
+  }
+
+  @Override
+  public boolean insert(OfflineJobExecution execution) {
+    OfflineJobExecutionPO po = toPO(execution);
+    boolean inserted = dao.insert(po);
+    if (inserted) execution.setId(po.getId());
+    return inserted;
+  }
+
+  @Override
+  public boolean update(OfflineJobExecution execution) {
+    return dao.updateById(toPO(execution));
+  }
+
+  @Override
+  public boolean hasActiveExecution(Long definitionId) {
+    return dao.hasActiveExecution(definitionId);
+  }
+
+  @Override
+  public List<OfflineJobExecution> findActiveExecutions(int limit) {
+    return dao.selectActiveExecutions(limit).stream().map(this::toDomain).toList();
+  }
+
+  @Override
+  public List<OfflineJobExecution> findRetryCandidates(LocalDateTime now, int limit) {
+    return dao.selectRetryCandidates(now, limit).stream().map(this::toDomain).toList();
+  }
+
+  @Override
+  public void markRetryCreated(Long executionId) {
+    dao.markRetryCreated(executionId, LocalDateTime.now());
+  }
+
+  @Override
+  public OfflinePage<OfflineJobExecution> page(OfflineExecutionQuery query) {
+    OfflineExecutionQuery q = query == null ? new OfflineExecutionQuery(1, 10, null, null) : query;
+    IPage<OfflineJobExecutionPO> page = dao.selectPage(
+        new PageQuery(q.current(), q.pageSize(), q.jobDefinitionId(), q.status()));
+    return new OfflinePage<>(
+        page.getRecords().stream().map(this::toDomain).toList(),
+        page.getTotal(), page.getPages(), page.getCurrent(), page.getSize());
+  }
+
+  private OfflineJobExecution toDomain(OfflineJobExecutionPO po) {
+    if (po == null) return null;
+    OfflineJobExecution value = new OfflineJobExecution();
+    BeanUtils.copyProperties(po, value);
+    return value;
+  }
+
+  private OfflineJobExecutionPO toPO(OfflineJobExecution value) {
+    OfflineJobExecutionPO po = new OfflineJobExecutionPO();
+    BeanUtils.copyProperties(value, po);
+    return po;
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineScheduleRepository.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineScheduleRepository.java
@@ -1,141 +1,14 @@
 package io.yak.ops.business.sync.offline.repository;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
-import java.sql.Timestamp;
+import io.yak.ops.business.sync.offline.domain.OfflineSchedule;
 import java.time.LocalDateTime;
 import java.util.List;
-import javax.sql.DataSource;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.scheduling.support.CronExpression;
-import org.springframework.stereotype.Repository;
-import org.springframework.util.StringUtils;
 
-/** 调度配置直接存放在任务定义表中。 */
-@ConditionalOnOfflineSyncEnabled
-@Repository
-public class OfflineScheduleRepository {
-  private final JdbcTemplate jdbc;
-  private final ObjectMapper objectMapper;
-
-  public OfflineScheduleRepository(@Qualifier("offlineSyncDataSource") DataSource dataSource,
-      @Qualifier("offlineSyncJsonMapper") ObjectMapper objectMapper) {
-    this.jdbc = new JdbcTemplate(dataSource);
-    this.objectMapper = objectMapper;
-  }
-
-  public ScheduleRecord saveSchedule(Long definitionId, JsonNode schedule) {
-    String cron = firstText(schedule, "cron", "cronExpression");
-    boolean enabled = enabled(schedule, cron);
-    if (enabled && !StringUtils.hasText(cron)) {
-      throw new IllegalArgumentException("启用调度时必须填写 Cron 表达式");
-    }
-    if (StringUtils.hasText(cron)) CronExpression.parse(cron);
-    int attempts = maxAttempts(schedule);
-    int backoff = backoffSeconds(schedule);
-    LocalDateTime next = enabled ? CronExpression.parse(cron).next(LocalDateTime.now()) : null;
-    jdbc.update("UPDATE yak_offline_job_definition SET schedule_json=?, schedule_enabled=?, "
-            + "cron_expression=?, retry_max_attempts=?, retry_backoff_seconds=?, "
-            + "schedule_next_fire_time=?, update_time=? WHERE id=?",
-        writeNullable(schedule), enabled, cron, Math.max(1, attempts), Math.max(1, backoff),
-        timestamp(next), Timestamp.valueOf(LocalDateTime.now()), definitionId);
-    return findSchedule(definitionId);
-  }
-
-  public ScheduleRecord findSchedule(Long definitionId) {
-    List<ScheduleRecord> values = jdbc.query(selectSql() + " WHERE id=?",
-        (rs, row) -> map(rs), definitionId);
-    return values.isEmpty() ? null : values.get(0);
-  }
-
-  public List<ScheduleRecord> findAllSchedules() {
-    return jdbc.query(selectSql() + " WHERE cron_expression IS NOT NULL ORDER BY id",
-        (rs, row) -> map(rs));
-  }
-
-  public void updateRuntimeState(Long definitionId, LocalDateTime last, LocalDateTime next) {
-    jdbc.update("UPDATE yak_offline_job_definition SET schedule_last_fire_time=?, "
-            + "schedule_next_fire_time=?, update_time=? WHERE id=?",
-        timestamp(last), timestamp(next), Timestamp.valueOf(LocalDateTime.now()), definitionId);
-  }
-
-  public void deleteSchedule(Long definitionId) {
-    jdbc.update("UPDATE yak_offline_job_definition SET schedule_json=NULL, schedule_enabled=0, "
-            + "cron_expression=NULL, retry_max_attempts=1, retry_backoff_seconds=60, "
-            + "schedule_last_fire_time=NULL, schedule_next_fire_time=NULL WHERE id=?", definitionId);
-  }
-
-  private String selectSql() {
-    return "SELECT id, cron_expression, schedule_enabled, retry_max_attempts, "
-        + "retry_backoff_seconds, schedule_next_fire_time, schedule_last_fire_time, schedule_json "
-        + "FROM yak_offline_job_definition";
-  }
-
-  private ScheduleRecord map(java.sql.ResultSet rs) throws java.sql.SQLException {
-    return new ScheduleRecord(rs.getLong("id"), rs.getString("cron_expression"),
-        rs.getBoolean("schedule_enabled"), rs.getInt("retry_max_attempts"),
-        rs.getInt("retry_backoff_seconds"), local(rs.getTimestamp("schedule_next_fire_time")),
-        local(rs.getTimestamp("schedule_last_fire_time")), rs.getString("schedule_json"));
-  }
-
-  private boolean enabled(JsonNode node, String cron) {
-    if (node == null || node.isNull()) return false;
-    if (node.hasNonNull("enabled")) return node.path("enabled").asBoolean(false);
-    String type = text(node, "scheduleRunType");
-    return StringUtils.hasText(type)
-        ? !"pause".equalsIgnoreCase(type) && !"paused".equalsIgnoreCase(type)
-        : StringUtils.hasText(cron);
-  }
-
-  private int maxAttempts(JsonNode node) {
-    if (node == null || node.isNull()) return 1;
-    if (node.hasNonNull("retryOnFailure")) return node.path("retryOnFailure").asBoolean() ? 2 : 1;
-    if (!node.path("autoRetry").asBoolean(true)) return 1;
-    int configured = node.path("retryPolicy").path("maxAttempts").asInt(0);
-    return configured > 0 ? configured : Math.max(1, node.path("retryTimes").asInt(0) + 1);
-  }
-
-  private int backoffSeconds(JsonNode node) {
-    if (node == null || node.isNull()) return 60;
-    int value = node.path("retryPolicy").path("backoffSeconds").asInt(0);
-    if (value > 0) return value;
-    value = node.path("retryIntervalSeconds").asInt(0);
-    if (value > 0) return value;
-    return Math.max(1, node.path("retryInterval").asInt(1)) * 60;
-  }
-
-  private String firstText(JsonNode node, String first, String second) {
-    String value = text(node, first);
-    return StringUtils.hasText(value) ? value : text(node, second);
-  }
-  private String text(JsonNode node, String field) {
-    if (node == null || !node.hasNonNull(field)) return null;
-    String value = node.path(field).asText(null);
-    return StringUtils.hasText(value) ? value.trim() : null;
-  }
-  private String writeNullable(JsonNode node) {
-    if (node == null || node.isNull()) return null;
-    try { return objectMapper.writeValueAsString(node); }
-    catch (Exception e) { throw new IllegalStateException("序列化调度配置失败", e); }
-  }
-  private Timestamp timestamp(LocalDateTime value) { return value == null ? null : Timestamp.valueOf(value); }
-  private LocalDateTime local(Timestamp value) { return value == null ? null : value.toLocalDateTime(); }
-
-  public static final class ScheduleRecord {
-    private final Long jobDefinitionId; private final String cronExpression; private final boolean enabled;
-    private final int retryMaxAttempts; private final int retryBackoffSeconds;
-    private final LocalDateTime nextFireTime; private final LocalDateTime lastFireTime; private final String scheduleJson;
-    public ScheduleRecord(Long id, String cron, boolean enabled, int attempts, int backoff,
-        LocalDateTime next, LocalDateTime last, String json) {
-      this.jobDefinitionId=id; this.cronExpression=cron; this.enabled=enabled;
-      this.retryMaxAttempts=attempts; this.retryBackoffSeconds=backoff;
-      this.nextFireTime=next; this.lastFireTime=last; this.scheduleJson=json;
-    }
-    public Long getJobDefinitionId(){return jobDefinitionId;} public String getCronExpression(){return cronExpression;}
-    public boolean isEnabled(){return enabled;} public int getRetryMaxAttempts(){return retryMaxAttempts;}
-    public int getRetryBackoffSeconds(){return retryBackoffSeconds;} public LocalDateTime getNextFireTime(){return nextFireTime;}
-    public LocalDateTime getLastFireTime(){return lastFireTime;} public String getScheduleJson(){return scheduleJson;}
-  }
+/** 调度配置领域仓储；数据仍直接保存在 yak_offline_job_definition。 */
+public interface OfflineScheduleRepository {
+  OfflineSchedule saveSchedule(OfflineSchedule schedule);
+  OfflineSchedule findSchedule(Long definitionId);
+  List<OfflineSchedule> findAllSchedules();
+  void updateRuntimeState(Long definitionId, LocalDateTime last, LocalDateTime next);
+  void deleteSchedule(Long definitionId);
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineScheduleRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineScheduleRepositoryAdapter.java
@@ -1,0 +1,85 @@
+package io.yak.ops.business.sync.offline.repository;
+
+import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import io.yak.ops.business.sync.offline.dao.OfflineJobDefinitionDao;
+import io.yak.ops.business.sync.offline.domain.OfflineSchedule;
+import io.yak.ops.common.bean.po.sync.offline.OfflineJobDefinitionPO;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+/** 将任务级调度投影持久化到任务定义表。 */
+@ConditionalOnOfflineSyncEnabled
+@Repository
+@RequiredArgsConstructor
+public class OfflineScheduleRepositoryAdapter implements OfflineScheduleRepository {
+  private final OfflineJobDefinitionDao dao;
+
+  @Override
+  public OfflineSchedule saveSchedule(OfflineSchedule schedule) {
+    if (schedule == null || schedule.jobDefinitionId() == null) {
+      throw new IllegalArgumentException("调度配置缺少任务定义 ID");
+    }
+    OfflineJobDefinitionPO po = new OfflineJobDefinitionPO();
+    po.setId(schedule.jobDefinitionId());
+    po.setScheduleJson(schedule.scheduleJson());
+    po.setScheduleEnabled(schedule.enabled());
+    po.setCronExpression(schedule.cronExpression());
+    po.setRetryMaxAttempts(Math.max(1, schedule.retryMaxAttempts()));
+    po.setRetryBackoffSeconds(Math.max(1, schedule.retryBackoffSeconds()));
+    po.setScheduleLastFireTime(schedule.lastFireTime());
+    po.setScheduleNextFireTime(schedule.nextFireTime());
+    po.setUpdateTime(LocalDateTime.now());
+    if (!dao.updateById(po)) throw new IllegalArgumentException("离线同步任务不存在：" + schedule.jobDefinitionId());
+    return findSchedule(schedule.jobDefinitionId());
+  }
+
+  @Override
+  public OfflineSchedule findSchedule(Long definitionId) {
+    return from(dao.selectById(definitionId));
+  }
+
+  @Override
+  public List<OfflineSchedule> findAllSchedules() {
+    return dao.selectWithCron().stream().map(this::from).toList();
+  }
+
+  @Override
+  public void updateRuntimeState(Long definitionId, LocalDateTime last, LocalDateTime next) {
+    OfflineJobDefinitionPO po = new OfflineJobDefinitionPO();
+    po.setId(definitionId);
+    po.setScheduleLastFireTime(last);
+    po.setScheduleNextFireTime(next);
+    po.setUpdateTime(LocalDateTime.now());
+    dao.updateById(po);
+  }
+
+  @Override
+  public void deleteSchedule(Long definitionId) {
+    OfflineJobDefinitionPO po = new OfflineJobDefinitionPO();
+    po.setId(definitionId);
+    po.setScheduleJson(null);
+    po.setScheduleEnabled(false);
+    po.setCronExpression(null);
+    po.setRetryMaxAttempts(1);
+    po.setRetryBackoffSeconds(60);
+    po.setScheduleLastFireTime(null);
+    po.setScheduleNextFireTime(null);
+    po.setUpdateTime(LocalDateTime.now());
+    dao.updateById(po);
+  }
+
+  private OfflineSchedule from(OfflineJobDefinitionPO po) {
+    if (po == null) return null;
+    return new OfflineSchedule(
+        po.getId(),
+        po.getCronExpression(),
+        Boolean.TRUE.equals(po.getScheduleEnabled()),
+        po.getRetryMaxAttempts() == null ? 1 : po.getRetryMaxAttempts(),
+        po.getRetryBackoffSeconds() == null ? 60 : po.getRetryBackoffSeconds(),
+        po.getScheduleNextFireTime(),
+        po.getScheduleLastFireTime(),
+        po.getScheduleJson());
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineScheduleRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineScheduleRepositoryAdapter.java
@@ -21,17 +21,19 @@ public class OfflineScheduleRepositoryAdapter implements OfflineScheduleReposito
     if (schedule == null || schedule.jobDefinitionId() == null) {
       throw new IllegalArgumentException("调度配置缺少任务定义 ID");
     }
-    OfflineJobDefinitionPO po = new OfflineJobDefinitionPO();
-    po.setId(schedule.jobDefinitionId());
-    po.setScheduleJson(schedule.scheduleJson());
-    po.setScheduleEnabled(schedule.enabled());
-    po.setCronExpression(schedule.cronExpression());
-    po.setRetryMaxAttempts(Math.max(1, schedule.retryMaxAttempts()));
-    po.setRetryBackoffSeconds(Math.max(1, schedule.retryBackoffSeconds()));
-    po.setScheduleLastFireTime(schedule.lastFireTime());
-    po.setScheduleNextFireTime(schedule.nextFireTime());
-    po.setUpdateTime(LocalDateTime.now());
-    if (!dao.updateById(po)) throw new IllegalArgumentException("离线同步任务不存在：" + schedule.jobDefinitionId());
+    LocalDateTime now = LocalDateTime.now();
+    if (!dao.updateSchedule(
+        schedule.jobDefinitionId(),
+        schedule.scheduleJson(),
+        schedule.enabled(),
+        schedule.cronExpression(),
+        Math.max(1, schedule.retryMaxAttempts()),
+        Math.max(1, schedule.retryBackoffSeconds()),
+        schedule.lastFireTime(),
+        schedule.nextFireTime(),
+        now)) {
+      throw new IllegalArgumentException("离线同步任务不存在：" + schedule.jobDefinitionId());
+    }
     return findSchedule(schedule.jobDefinitionId());
   }
 
@@ -47,27 +49,12 @@ public class OfflineScheduleRepositoryAdapter implements OfflineScheduleReposito
 
   @Override
   public void updateRuntimeState(Long definitionId, LocalDateTime last, LocalDateTime next) {
-    OfflineJobDefinitionPO po = new OfflineJobDefinitionPO();
-    po.setId(definitionId);
-    po.setScheduleLastFireTime(last);
-    po.setScheduleNextFireTime(next);
-    po.setUpdateTime(LocalDateTime.now());
-    dao.updateById(po);
+    dao.updateScheduleRuntime(definitionId, last, next, LocalDateTime.now());
   }
 
   @Override
   public void deleteSchedule(Long definitionId) {
-    OfflineJobDefinitionPO po = new OfflineJobDefinitionPO();
-    po.setId(definitionId);
-    po.setScheduleJson(null);
-    po.setScheduleEnabled(false);
-    po.setCronExpression(null);
-    po.setRetryMaxAttempts(1);
-    po.setRetryBackoffSeconds(60);
-    po.setScheduleLastFireTime(null);
-    po.setScheduleNextFireTime(null);
-    po.setUpdateTime(LocalDateTime.now());
-    dao.updateById(po);
+    dao.clearSchedule(definitionId, LocalDateTime.now());
   }
 
   private OfflineSchedule from(OfflineJobDefinitionPO po) {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineScheduleRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineScheduleRepositoryAdapter.java
@@ -29,7 +29,6 @@ public class OfflineScheduleRepositoryAdapter implements OfflineScheduleReposito
         schedule.cronExpression(),
         Math.max(1, schedule.retryMaxAttempts()),
         Math.max(1, schedule.retryBackoffSeconds()),
-        schedule.lastFireTime(),
         schedule.nextFireTime(),
         now)) {
       throw new IllegalArgumentException("离线同步任务不存在：" + schedule.jobDefinitionId());

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineDefinitionSupport.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineDefinitionSupport.java
@@ -4,122 +4,290 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import io.yak.ops.business.datasource.dao.DataSourceDao;
 import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import io.yak.ops.business.sync.offline.domain.OfflineJobDefinition;
 import io.yak.ops.business.sync.offline.engine.LinkUpJobSpecFactory;
 import io.yak.ops.business.sync.offline.engine.OfflineDefinitionModelAdapter;
 import io.yak.ops.common.bean.dto.sync.offline.OfflineJobDefinitionDTO;
 import io.yak.ops.common.bean.po.datasource.DataSourcePO;
-import io.yak.ops.common.bean.po.sync.offline.OfflineJobDefinitionPO;
-import io.yak.ops.common.bean.vo.sync.offline.OfflineJobDefinitionVO;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.HexFormat;
-import java.util.Locale;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
-/** 离线同步任务定义序列化与 JobSpec 构建。 */
+/** 离线同步任务定义规范化、JobSpec 构建与运行时凭据解析。 */
 @ConditionalOnOfflineSyncEnabled
 @Component
 public class OfflineDefinitionSupport {
-  private static final DateTimeFormatter FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
   private final LinkUpJobSpecFactory jobSpecFactory;
-  private final DataSourceDao dataSourceDao;
   private final ObjectMapper objectMapper;
 
-  public OfflineDefinitionSupport(LinkUpJobSpecFactory jobSpecFactory, DataSourceDao dataSourceDao,
+  public OfflineDefinitionSupport(
+      LinkUpJobSpecFactory jobSpecFactory,
       @Qualifier("offlineSyncJsonMapper") ObjectMapper objectMapper) {
-    this.jobSpecFactory=jobSpecFactory; this.dataSourceDao=dataSourceDao; this.objectMapper=objectMapper;
+    this.jobSpecFactory = jobSpecFactory;
+    this.objectMapper = objectMapper;
   }
 
   public PreparedDefinition prepare(OfflineJobDefinitionDTO dto) {
-    ObjectNode request=object(dto); JsonNode basic=request.path("basic");
-    String name=requiredText(basic,"jobName","任务名称不能为空"); String mode=mode(basic);
-    JsonNode buildRequest=OfflineDefinitionModelAdapter.forJobSpec(request,objectMapper);
-    LinkUpJobSpecFactory.BuildResult result=jobSpecFactory.build(buildRequest);
-    return new PreparedDefinition(request,name.trim(),trim(text(basic,"jobDesc",null)),mode,write(request),
-        result.getJobSpecJson(),result.getSourceDataSource(),result.getSinkDataSource(),
-        result.getSourceConnectorId(),result.getSinkConnectorId(),result.getSourceTable(),result.getSinkTable(),
+    ObjectNode request = object(dto);
+    JsonNode basic = request.path("basic");
+    String name = requiredText(basic, "jobName", "任务名称不能为空");
+    String mode = mode(basic);
+    JsonNode buildRequest = OfflineDefinitionModelAdapter.forJobSpec(request, objectMapper);
+    LinkUpJobSpecFactory.BuildResult result = jobSpecFactory.build(buildRequest);
+    DataSourcePO source = result.getSourceDataSource();
+    DataSourcePO sink = result.getSinkDataSource();
+    return new PreparedDefinition(
+        request,
+        name.trim(),
+        trim(text(basic, "jobDesc", null)),
+        mode,
+        write(request),
+        result.getJobSpecJson(),
+        id(source),
+        id(sink),
+        displayType(source, result.getSourceConnectorId()),
+        displayType(sink, result.getSinkConnectorId()),
+        result.getSourceTable(),
+        result.getSinkTable(),
         digest(result.getJobSpecJson()));
   }
 
   public DraftDefinition prepareDraft(OfflineJobDefinitionDTO dto) {
-    ObjectNode request=object(dto); JsonNode basic=request.path("basic");
-    return new DraftDefinition(request,requiredText(basic,"jobName","任务名称不能为空").trim(),
-        trim(text(basic,"jobDesc",null)),mode(basic),write(request),
-        endpointType(request.path("source"),"来源类型不能为空"),endpointType(request.path("sink"),"目标类型不能为空"));
+    ObjectNode request = object(dto);
+    JsonNode basic = request.path("basic");
+    return new DraftDefinition(
+        request,
+        requiredText(basic, "jobName", "任务名称不能为空").trim(),
+        trim(text(basic, "jobDesc", null)),
+        mode(basic),
+        write(request),
+        endpointType(request.path("source"), "来源类型不能为空"),
+        endpointType(request.path("sink"), "目标类型不能为空"));
   }
 
-  public String buildJobSpec(OfflineJobDefinitionDTO dto){return prepare(dto).getJobSpecJson();}
-  public String resolveExecutionJobSpec(String logicalJobSpec){return jobSpecFactory.resolveForExecution(logicalJobSpec);}
+  public String buildJobSpec(OfflineJobDefinitionDTO dto) {
+    return prepare(dto).getJobSpecJson();
+  }
 
-  public JsonNode editDetail(OfflineJobDefinitionPO d) {
-    JsonNode parsed=read(d.getDefinitionJson()); ObjectNode detail=parsed!=null&&parsed.isObject()?(ObjectNode)parsed.deepCopy():objectMapper.createObjectNode();
-    detail.put("id",d.getId()); ObjectNode state=detail.with("state");
-    state.put("releaseState",d.getReleaseState()); state.put("lastJobStatus",d.getLastJobStatus());
-    state.put("lastErrorMessage",d.getLastErrorMessage()); state.set("lastExecutionId",objectMapper.valueToTree(d.getLastExecutionId()));
-    state.put("lastEngineJobId",d.getLastEngineJobId()); state.put("draft",!StringUtils.hasText(d.getJobSpecJson()));
+  public String resolveExecutionJobSpec(String logicalJobSpec) {
+    return jobSpecFactory.resolveForExecution(logicalJobSpec);
+  }
+
+  public JsonNode editDetail(OfflineJobDefinition definition) {
+    JsonNode parsed = read(definition.getDefinitionJson());
+    ObjectNode detail = parsed != null && parsed.isObject()
+        ? (ObjectNode) parsed.deepCopy()
+        : objectMapper.createObjectNode();
+    detail.put("id", definition.getId());
+    ObjectNode state = detail.with("state");
+    state.put("releaseState", definition.getReleaseState());
+    state.put("lastJobStatus", definition.getLastJobStatus());
+    state.put("lastErrorMessage", definition.getLastErrorMessage());
+    state.set("lastExecutionId", objectMapper.valueToTree(definition.getLastExecutionId()));
+    state.put("lastEngineJobId", definition.getLastEngineJobId());
+    state.put("draft", !StringUtils.hasText(definition.getJobSpecJson()));
     return detail;
   }
 
-  public OfflineJobDefinitionVO toVO(OfflineJobDefinitionPO d) {
-    DataSourcePO source=dataSource(d.getSourceDatasourceId()), sink=dataSource(d.getSinkDatasourceId());
-    boolean scheduled=Boolean.TRUE.equals(d.getScheduleEnabled());
-    return OfflineJobDefinitionVO.builder().id(d.getId()).jobName(d.getJobName()).jobDesc(d.getJobDesc())
-        .jobType("BATCH").mode(d.getMode()).releaseState(d.getReleaseState()).sourceType(d.getSourceType()).sinkType(d.getSinkType())
-        .sourceDatasourceId(d.getSourceDatasourceId()).sinkDatasourceId(d.getSinkDatasourceId())
-        .sourceDatasourceName(source==null?null:source.getName()).sinkDatasourceName(sink==null?null:sink.getName())
-        .sourceTable(d.getSourceTable()).sinkTable(d.getSinkTable()).lastJobStatus(d.getLastJobStatus())
-        .lastErrorMessage(d.getLastErrorMessage()).instanceId(d.getLastExecutionId()).engineJobId(d.getLastEngineJobId())
-        .runMode(scheduled?"SCHEDULE":"MANUAL").duration(seconds(d.getLastDurationMillis())).readRowCount(value(d.getLastReadRowCount()))
-        .qps(value(d.getLastQps())).syncSize(formatBytes(d.getLastSyncBytes())).cronExpression(d.getCronExpression())
-        .scheduleStatus(scheduled?"NORMAL":"PAUSED").lastScheduleTime(format(d.getScheduleLastFireTime()==null?d.getLastStartTime():d.getScheduleLastFireTime()))
-        .nextScheduleTime(format(d.getScheduleNextFireTime())).createTime(format(d.getCreateTime())).updateTime(format(d.getUpdateTime())).build();
+  private ObjectNode object(OfflineJobDefinitionDTO dto) {
+    if (dto == null) throw new IllegalArgumentException("任务定义不能为空");
+    JsonNode value = objectMapper.valueToTree(dto);
+    if (!value.isObject()) throw new IllegalArgumentException("任务定义格式不正确");
+    ObjectNode request = (ObjectNode) value;
+    requireObject(request.path("basic"), "basic 配置不能为空");
+    normalizeEndpoint(request, "source");
+    normalizeEndpoint(request, "sink");
+    normalizeChannel(request);
+    OfflineDefinitionModelAdapter.sanitizeForPersistence(request);
+    return request;
   }
 
-  public String writeNullable(JsonNode value){return value==null||value.isNull()||value.isMissingNode()?null:write(value);}
-  private ObjectNode object(OfflineJobDefinitionDTO dto){
-    if(dto==null)throw new IllegalArgumentException("任务定义不能为空"); JsonNode value=objectMapper.valueToTree(dto);
-    if(!value.isObject())throw new IllegalArgumentException("任务定义格式不正确"); ObjectNode request=(ObjectNode)value;
-    requireObject(request.path("basic"),"basic 配置不能为空"); normalizeEndpoint(request,"source"); normalizeEndpoint(request,"sink"); normalizeChannel(request);
-    OfflineDefinitionModelAdapter.sanitizeForPersistence(request); return request;
+  private void normalizeEndpoint(ObjectNode request, String field) {
+    requireObject(request.get(field), field + " 配置不能为空");
   }
-  private void normalizeEndpoint(ObjectNode request,String field){JsonNode value=request.get(field);requireObject(value,field+" 配置不能为空");}
-  private void normalizeChannel(ObjectNode request){JsonNode value=request.get("channel");ObjectNode channel;
-    if(value==null||value.isNull())channel=request.putObject("channel");else{requireObject(value,"channel 配置必须是 JSON 对象");channel=(ObjectNode)value;}
-    if(!channel.hasNonNull("parallelism"))channel.put("parallelism",1); if(!channel.hasNonNull("speedLimitEnabled"))channel.put("speedLimitEnabled",false);
-    if(!channel.hasNonNull("recordsPerSecond"))channel.put("recordsPerSecond",10000L); if(!channel.hasNonNull("dirtyDataPolicy"))channel.put("dirtyDataPolicy","STOP");
-    if(!channel.hasNonNull("dirtyDataLimit"))channel.put("dirtyDataLimit",0L);
+
+  private void normalizeChannel(ObjectNode request) {
+    JsonNode value = request.get("channel");
+    ObjectNode channel;
+    if (value == null || value.isNull()) {
+      channel = request.putObject("channel");
+    } else {
+      requireObject(value, "channel 配置必须是 JSON 对象");
+      channel = (ObjectNode) value;
+    }
+    if (!channel.hasNonNull("parallelism")) channel.put("parallelism", 1);
+    if (!channel.hasNonNull("speedLimitEnabled")) channel.put("speedLimitEnabled", false);
+    if (!channel.hasNonNull("recordsPerSecond")) channel.put("recordsPerSecond", 10000L);
+    if (!channel.hasNonNull("dirtyDataPolicy")) channel.put("dirtyDataPolicy", "STOP");
+    if (!channel.hasNonNull("dirtyDataLimit")) channel.put("dirtyDataLimit", 0L);
   }
-  private String mode(JsonNode basic){String value=text(basic,"mode","GUIDE_SINGLE");if(!"GUIDE_SINGLE".equals(value)&&!"GUIDE_MULTI".equals(value))throw new IllegalArgumentException("离线同步仅支持 GUIDE_SINGLE 和 GUIDE_MULTI 模式");return value;}
-  private String endpointType(JsonNode endpoint,String message){String value=text(endpoint,"dbType",null);if(!StringUtils.hasText(value))throw new IllegalArgumentException(message);return value.trim();}
-  private void requireObject(JsonNode node,String message){if(node==null||!node.isObject())throw new IllegalArgumentException(message);}
-  private JsonNode read(String value){if(!StringUtils.hasText(value))return objectMapper.createObjectNode();try{return objectMapper.readTree(value);}catch(JsonProcessingException e){throw new IllegalStateException("任务定义 JSON 已损坏",e);}}
-  private String write(JsonNode value){try{return objectMapper.writeValueAsString(value);}catch(JsonProcessingException e){throw new IllegalStateException("序列化任务定义失败",e);}}
-  private String digest(String value){try{return HexFormat.of().formatHex(MessageDigest.getInstance("SHA-256").digest(value.getBytes(StandardCharsets.UTF_8)));}catch(Exception e){throw new IllegalStateException("生成 JobSpec 摘要失败",e);}}
-  private String requiredText(JsonNode node,String field,String message){String value=text(node,field,null);if(!StringUtils.hasText(value))throw new IllegalArgumentException(message);return value;}
-  private String text(JsonNode node,String field,String fallback){JsonNode value=node==null?null:node.get(field);return value==null||value.isNull()||!value.isValueNode()?fallback:value.asText(fallback);}
-  private String trim(String value){return StringUtils.hasText(value)?value.trim():null;} private DataSourcePO dataSource(Long id){return id==null?null:dataSourceDao.selectById(id);}
-  private String format(LocalDateTime value){return value==null?null:value.format(FORMAT);} private long seconds(Long millis){return millis==null?0L:Math.max(0,millis/1000L);}
-  private long value(Long v){return v==null?0L:v;} private double value(Double v){return v==null?0D:v;}
-  private String formatBytes(Long bytes){if(bytes==null||bytes<=0)return "-";double size=bytes;String[] units={"B","KB","MB","GB","TB"};int unit=0;while(size>=1024&&unit<units.length-1){size/=1024;unit++;}return String.format(Locale.ROOT,"%.2f %s",size,units[unit]);}
+
+  private String mode(JsonNode basic) {
+    String value = text(basic, "mode", "GUIDE_SINGLE");
+    if (!"GUIDE_SINGLE".equals(value) && !"GUIDE_MULTI".equals(value)) {
+      throw new IllegalArgumentException("离线同步仅支持 GUIDE_SINGLE 和 GUIDE_MULTI 模式");
+    }
+    return value;
+  }
+
+  private String endpointType(JsonNode endpoint, String message) {
+    String value = text(endpoint, "dbType", null);
+    if (!StringUtils.hasText(value)) throw new IllegalArgumentException(message);
+    return value.trim();
+  }
+
+  private void requireObject(JsonNode node, String message) {
+    if (node == null || !node.isObject()) throw new IllegalArgumentException(message);
+  }
+
+  private JsonNode read(String value) {
+    if (!StringUtils.hasText(value)) return objectMapper.createObjectNode();
+    try {
+      return objectMapper.readTree(value);
+    } catch (JsonProcessingException exception) {
+      throw new IllegalStateException("任务定义 JSON 已损坏", exception);
+    }
+  }
+
+  private String write(JsonNode value) {
+    try {
+      return objectMapper.writeValueAsString(value);
+    } catch (JsonProcessingException exception) {
+      throw new IllegalStateException("序列化任务定义失败", exception);
+    }
+  }
+
+  private String digest(String value) {
+    try {
+      return HexFormat.of().formatHex(
+          MessageDigest.getInstance("SHA-256").digest(value.getBytes(StandardCharsets.UTF_8)));
+    } catch (Exception exception) {
+      throw new IllegalStateException("生成 JobSpec 摘要失败", exception);
+    }
+  }
+
+  private String requiredText(JsonNode node, String field, String message) {
+    String value = text(node, field, null);
+    if (!StringUtils.hasText(value)) throw new IllegalArgumentException(message);
+    return value;
+  }
+
+  private String text(JsonNode node, String field, String fallback) {
+    JsonNode value = node == null ? null : node.get(field);
+    return value == null || value.isNull() || !value.isValueNode()
+        ? fallback
+        : value.asText(fallback);
+  }
+
+  private String trim(String value) {
+    return StringUtils.hasText(value) ? value.trim() : null;
+  }
+
+  private Long id(DataSourcePO dataSource) {
+    return dataSource == null ? null : dataSource.getId();
+  }
+
+  private String displayType(DataSourcePO dataSource, String connectorId) {
+    return dataSource != null && dataSource.getDbType() != null
+        ? dataSource.getDbType().name()
+        : connectorId;
+  }
 
   public static final class DraftDefinition {
-    private final ObjectNode request; private final String jobName,jobDesc,mode,definitionJson,sourceType,sinkType;
-    public DraftDefinition(ObjectNode request,String jobName,String jobDesc,String mode,String definitionJson,String sourceType,String sinkType){this.request=request;this.jobName=jobName;this.jobDesc=jobDesc;this.mode=mode;this.definitionJson=definitionJson;this.sourceType=sourceType;this.sinkType=sinkType;}
-    public ObjectNode getRequest(){return request;} public String getJobName(){return jobName;} public String getJobDesc(){return jobDesc;} public String getMode(){return mode;}
-    public String getDefinitionJson(){return definitionJson;} public String getSourceType(){return sourceType;} public String getSinkType(){return sinkType;}
+    private final ObjectNode request;
+    private final String jobName;
+    private final String jobDesc;
+    private final String mode;
+    private final String definitionJson;
+    private final String sourceType;
+    private final String sinkType;
+
+    public DraftDefinition(
+        ObjectNode request,
+        String jobName,
+        String jobDesc,
+        String mode,
+        String definitionJson,
+        String sourceType,
+        String sinkType) {
+      this.request = request;
+      this.jobName = jobName;
+      this.jobDesc = jobDesc;
+      this.mode = mode;
+      this.definitionJson = definitionJson;
+      this.sourceType = sourceType;
+      this.sinkType = sinkType;
+    }
+
+    public ObjectNode getRequest() { return request; }
+    public String getJobName() { return jobName; }
+    public String getJobDesc() { return jobDesc; }
+    public String getMode() { return mode; }
+    public String getDefinitionJson() { return definitionJson; }
+    public String getSourceType() { return sourceType; }
+    public String getSinkType() { return sinkType; }
   }
+
   public static final class PreparedDefinition {
-    private final ObjectNode request; private final String jobName,jobDesc,mode,definitionJson,jobSpecJson,sourceConnectorId,sinkConnectorId,sourceTable,sinkTable,digest;
-    private final DataSourcePO source,sink;
-    public PreparedDefinition(ObjectNode request,String jobName,String jobDesc,String mode,String definitionJson,String jobSpecJson,DataSourcePO source,DataSourcePO sink,String sourceConnectorId,String sinkConnectorId,String sourceTable,String sinkTable,String digest){this.request=request;this.jobName=jobName;this.jobDesc=jobDesc;this.mode=mode;this.definitionJson=definitionJson;this.jobSpecJson=jobSpecJson;this.source=source;this.sink=sink;this.sourceConnectorId=sourceConnectorId;this.sinkConnectorId=sinkConnectorId;this.sourceTable=sourceTable;this.sinkTable=sinkTable;this.digest=digest;}
-    public ObjectNode getRequest(){return request;} public String getJobName(){return jobName;} public String getJobDesc(){return jobDesc;} public String getMode(){return mode;}
-    public String getDefinitionJson(){return definitionJson;} public String getJobSpecJson(){return jobSpecJson;} public DataSourcePO getSource(){return source;} public DataSourcePO getSink(){return sink;} public DataSourcePO getSourceDataSource(){return source;} public DataSourcePO getSinkDataSource(){return sink;}
-    public String getSourceConnectorId(){return sourceConnectorId;} public String getSinkConnectorId(){return sinkConnectorId;} public String getSourceTable(){return sourceTable;} public String getSinkTable(){return sinkTable;} public String getDigest(){return digest;}
+    private final ObjectNode request;
+    private final String jobName;
+    private final String jobDesc;
+    private final String mode;
+    private final String definitionJson;
+    private final String jobSpecJson;
+    private final Long sourceDatasourceId;
+    private final Long sinkDatasourceId;
+    private final String sourceType;
+    private final String sinkType;
+    private final String sourceTable;
+    private final String sinkTable;
+    private final String digest;
+
+    public PreparedDefinition(
+        ObjectNode request,
+        String jobName,
+        String jobDesc,
+        String mode,
+        String definitionJson,
+        String jobSpecJson,
+        Long sourceDatasourceId,
+        Long sinkDatasourceId,
+        String sourceType,
+        String sinkType,
+        String sourceTable,
+        String sinkTable,
+        String digest) {
+      this.request = request;
+      this.jobName = jobName;
+      this.jobDesc = jobDesc;
+      this.mode = mode;
+      this.definitionJson = definitionJson;
+      this.jobSpecJson = jobSpecJson;
+      this.sourceDatasourceId = sourceDatasourceId;
+      this.sinkDatasourceId = sinkDatasourceId;
+      this.sourceType = sourceType;
+      this.sinkType = sinkType;
+      this.sourceTable = sourceTable;
+      this.sinkTable = sinkTable;
+      this.digest = digest;
+    }
+
+    public ObjectNode getRequest() { return request; }
+    public String getJobName() { return jobName; }
+    public String getJobDesc() { return jobDesc; }
+    public String getMode() { return mode; }
+    public String getDefinitionJson() { return definitionJson; }
+    public String getJobSpecJson() { return jobSpecJson; }
+    public Long getSourceDatasourceId() { return sourceDatasourceId; }
+    public Long getSinkDatasourceId() { return sinkDatasourceId; }
+    public String getSourceType() { return sourceType; }
+    public String getSinkType() { return sinkType; }
+    public String getSourceTable() { return sourceTable; }
+    public String getSinkTable() { return sinkTable; }
+    public String getDigest() { return digest; }
   }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineExecutionClaimService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineExecutionClaimService.java
@@ -2,12 +2,11 @@ package io.yak.ops.business.sync.offline.service;
 
 import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
 import io.yak.ops.business.sync.offline.config.OfflineSyncProperties;
-import io.yak.ops.business.sync.offline.dao.OfflineJobExecutionDao;
 import io.yak.ops.business.sync.offline.domain.OfflineExecutionStatus;
-import io.yak.ops.business.sync.offline.repository.OfflineExecutionControlRepository;
-import io.yak.ops.business.sync.offline.repository.OfflineExecutionIdempotencyRepository;
-import io.yak.ops.common.bean.po.sync.offline.OfflineJobDefinitionPO;
-import io.yak.ops.common.bean.po.sync.offline.OfflineJobExecutionPO;
+import io.yak.ops.business.sync.offline.domain.OfflineJobDefinition;
+import io.yak.ops.business.sync.offline.domain.OfflineJobExecution;
+import io.yak.ops.business.sync.offline.repository.OfflineJobDefinitionRepository;
+import io.yak.ops.business.sync.offline.repository.OfflineJobExecutionRepository;
 import java.time.LocalDateTime;
 import java.util.Objects;
 import java.util.UUID;
@@ -20,21 +19,18 @@ import org.springframework.util.StringUtils;
 @Service
 public class OfflineExecutionClaimService {
   private final OfflineJobDefinitionService definitionService;
-  private final OfflineJobExecutionDao executionDao;
-  private final OfflineExecutionControlRepository repository;
-  private final OfflineExecutionIdempotencyRepository idempotencyRepository;
+  private final OfflineJobDefinitionRepository definitionRepository;
+  private final OfflineJobExecutionRepository executionRepository;
   private final OfflineSyncProperties properties;
 
   public OfflineExecutionClaimService(
       OfflineJobDefinitionService definitionService,
-      OfflineJobExecutionDao executionDao,
-      OfflineExecutionControlRepository repository,
-      OfflineExecutionIdempotencyRepository idempotencyRepository,
+      OfflineJobDefinitionRepository definitionRepository,
+      OfflineJobExecutionRepository executionRepository,
       OfflineSyncProperties properties) {
     this.definitionService = definitionService;
-    this.executionDao = executionDao;
-    this.repository = repository;
-    this.idempotencyRepository = idempotencyRepository;
+    this.definitionRepository = definitionRepository;
+    this.executionRepository = executionRepository;
     this.properties = properties;
   }
 
@@ -44,8 +40,8 @@ public class OfflineExecutionClaimService {
       String triggerType,
       Long retryFromExecutionId,
       int attemptNo) {
-    repository.lockDefinition(definitionId);
-    OfflineJobDefinitionPO definition = definitionService.require(definitionId);
+    definitionRepository.lock(definitionId);
+    OfflineJobDefinition definition = definitionService.require(definitionId);
     if (!"ONLINE".equalsIgnoreCase(definition.getReleaseState())) {
       throw new IllegalStateException("请先上线任务，再执行运行操作");
     }
@@ -62,12 +58,7 @@ public class OfflineExecutionClaimService {
         null);
   }
 
-  /**
-   * 按工作流发布时保存的任务快照创建执行。
-   *
-   * <p>这里不要求任务当前仍处于 ONLINE，也不要求当前 version 与快照一致；工作流发布版本
-   * 已经完成过可执行性校验。仍对任务定义行加锁并检查活跃实例，沿用现有同步任务并发保护。</p>
-   */
+  /** 工作流按发布时保存的任务快照创建执行，不要求当前任务仍处于 ONLINE。 */
   @Transactional(transactionManager = "offlineSyncTransactionManager", rollbackFor = Exception.class)
   public ClaimResult claimSnapshot(
       Long definitionId,
@@ -99,11 +90,11 @@ public class OfflineExecutionClaimService {
     if (!StringUtils.hasText(logicalJobSpecJson)) {
       throw new IllegalArgumentException("任务版本快照缺少 JobSpec");
     }
-    repository.lockDefinition(definitionId);
-    OfflineJobDefinitionPO current = definitionService.require(definitionId);
+    definitionRepository.lock(definitionId);
+    OfflineJobDefinition current = definitionService.require(definitionId);
     String normalizedKey = StringUtils.hasText(idempotencyKey) ? idempotencyKey.trim() : null;
     if (normalizedKey != null) {
-      OfflineJobExecutionPO existing = idempotencyRepository.findByKey(normalizedKey).orElse(null);
+      OfflineJobExecution existing = executionRepository.findByIdempotencyKey(normalizedKey).orElse(null);
       if (existing != null) {
         validateIdempotentReuse(
             existing,
@@ -128,7 +119,7 @@ public class OfflineExecutionClaimService {
   }
 
   private ClaimResult createClaim(
-      OfflineJobDefinitionPO definition,
+      OfflineJobDefinition definition,
       long definitionVersion,
       String configDigest,
       String definitionSnapshotJson,
@@ -138,20 +129,18 @@ public class OfflineExecutionClaimService {
       int attemptNo,
       String idempotencyKey) {
     Long definitionId = definition.getId();
-    if (repository.hasActiveExecution(definitionId)) {
+    if (executionRepository.hasActiveExecution(definitionId)) {
       throw new IllegalStateException("任务已有运行中的执行实例，不能重复提交");
     }
 
     LocalDateTime now = LocalDateTime.now();
-    OfflineJobExecutionPO execution = new OfflineJobExecutionPO();
+    OfflineJobExecution execution = new OfflineJobExecution();
     execution.setJobDefinitionId(definitionId);
     execution.setDefinitionVersion((int) Math.min(Integer.MAX_VALUE, definitionVersion));
     execution.setEngineBaseUrl(properties.getEngine().getBaseUrl());
     execution.setExternalExecutionId("yak-offline-" + UUID.randomUUID());
     execution.setIdempotencyKey(
-        StringUtils.hasText(idempotencyKey)
-            ? idempotencyKey.trim()
-            : UUID.randomUUID().toString());
+        StringUtils.hasText(idempotencyKey) ? idempotencyKey.trim() : UUID.randomUUID().toString());
     execution.setStatus(OfflineExecutionStatus.CREATED.name());
     execution.setStateVersion(1L);
     execution.setAttemptNo(Math.max(1, attemptNo));
@@ -170,14 +159,14 @@ public class OfflineExecutionClaimService {
     execution.setDurationMillis(0L);
     execution.setCreateTime(now);
     execution.setUpdateTime(now);
-    if (!executionDao.insert(execution) || execution.getId() == null) {
+    if (!executionRepository.insert(execution) || execution.getId() == null) {
       throw new IllegalStateException("创建离线同步执行实例失败");
     }
     return new ClaimResult(definition, logicalJobSpecJson, execution, false);
   }
 
   private void validateIdempotentReuse(
-      OfflineJobExecutionPO existing,
+      OfflineJobExecution existing,
       Long definitionId,
       long definitionVersion,
       String configDigest,
@@ -190,29 +179,27 @@ public class OfflineExecutionClaimService {
         && Objects.equals(existing.getDefinitionSnapshotJson(), definitionSnapshotJson)
         && Objects.equals(existing.getSubmittedConfig(), logicalJobSpecJson);
     if (!same) {
-      throw new IllegalStateException(
-          "幂等键已被不同任务执行占用：" + existing.getIdempotencyKey());
+      throw new IllegalStateException("幂等键已被不同任务执行占用：" + existing.getIdempotencyKey());
     }
   }
 
   public static final class ClaimResult {
-    private final OfflineJobDefinitionPO definition;
+    private final OfflineJobDefinition definition;
     private final String logicalJobSpecJson;
-    private final OfflineJobExecutionPO execution;
+    private final OfflineJobExecution execution;
     private final boolean reused;
 
-    /** Backward-compatible constructor for existing callers that create fresh claims. */
     public ClaimResult(
-        OfflineJobDefinitionPO definition,
+        OfflineJobDefinition definition,
         String logicalJobSpecJson,
-        OfflineJobExecutionPO execution) {
+        OfflineJobExecution execution) {
       this(definition, logicalJobSpecJson, execution, false);
     }
 
     public ClaimResult(
-        OfflineJobDefinitionPO definition,
+        OfflineJobDefinition definition,
         String logicalJobSpecJson,
-        OfflineJobExecutionPO execution,
+        OfflineJobExecution execution,
         boolean reused) {
       this.definition = definition;
       this.logicalJobSpecJson = logicalJobSpecJson;
@@ -220,20 +207,9 @@ public class OfflineExecutionClaimService {
       this.reused = reused;
     }
 
-    public OfflineJobDefinitionPO getDefinition() {
-      return definition;
-    }
-
-    public String getLogicalJobSpecJson() {
-      return logicalJobSpecJson;
-    }
-
-    public OfflineJobExecutionPO getExecution() {
-      return execution;
-    }
-
-    public boolean isReused() {
-      return reused;
-    }
+    public OfflineJobDefinition getDefinition() { return definition; }
+    public String getLogicalJobSpecJson() { return logicalJobSpecJson; }
+    public OfflineJobExecution getExecution() { return execution; }
+    public boolean isReused() { return reused; }
   }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineExecutionLogService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineExecutionLogService.java
@@ -1,16 +1,16 @@
 package io.yak.ops.business.sync.offline.service;
 
 import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import io.yak.ops.business.sync.offline.domain.OfflineExecutionEvent;
 import io.yak.ops.business.sync.offline.domain.OfflineExecutionStatus;
+import io.yak.ops.business.sync.offline.domain.OfflineJobExecution;
 import io.yak.ops.business.sync.offline.engine.LinkUpClient;
 import io.yak.ops.business.sync.offline.engine.LinkUpClient.LinkUpJobLogEntry;
 import io.yak.ops.business.sync.offline.engine.LinkUpClient.LinkUpJobLogPageResponse;
 import io.yak.ops.business.sync.offline.engine.LinkUpClient.LinkUpProtocolException;
 import io.yak.ops.business.sync.offline.engine.LinkUpClient.LinkUpRequestException;
 import io.yak.ops.business.sync.offline.engine.LinkUpClient.LinkUpTransportException;
-import io.yak.ops.business.sync.offline.repository.OfflineExecutionControlRepository;
-import io.yak.ops.business.sync.offline.repository.OfflineExecutionControlRepository.ExecutionEventRecord;
-import io.yak.ops.common.bean.po.sync.offline.OfflineJobExecutionPO;
+import io.yak.ops.business.sync.offline.repository.OfflineExecutionEventRepository;
 import io.yak.ops.common.bean.vo.sync.offline.OfflineExecutionLogEntryVO;
 import io.yak.ops.common.bean.vo.sync.offline.OfflineExecutionLogPageVO;
 import java.time.Instant;
@@ -31,21 +31,20 @@ public class OfflineExecutionLogService {
   private static final DateTimeFormatter FORMAT =
       DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS");
 
-  private final OfflineExecutionControlRepository repository;
+  private final OfflineExecutionEventRepository eventRepository;
   private final LinkUpClient linkUpClient;
 
   public OfflineExecutionLogService(
-      OfflineExecutionControlRepository repository,
+      OfflineExecutionEventRepository eventRepository,
       LinkUpClient linkUpClient) {
-    this.repository = repository;
+    this.eventRepository = eventRepository;
     this.linkUpClient = linkUpClient;
   }
 
-  public String text(OfflineJobExecutionPO execution) {
+  public String text(OfflineJobExecution execution) {
     String cursor = "0:0";
     String warning = null;
-    StringBuilder result =
-        new StringBuilder("# Yak Ops + Link-Up Unified Timeline\n");
+    StringBuilder result = new StringBuilder("# Yak Ops + Link-Up Unified Timeline\n");
     result.append("executionId: ")
         .append(execution == null ? "-" : execution.getId())
         .append('\n')
@@ -60,9 +59,7 @@ public class OfflineExecutionLogService {
       OfflineExecutionLogPageVO page = logs(execution, cursor, 1000);
       warning = page.getWarning();
       if (page.getItems() != null) {
-        for (OfflineExecutionLogEntryVO item : page.getItems()) {
-          appendTextLine(result, item);
-        }
+        for (OfflineExecutionLogEntryVO item : page.getItems()) appendTextLine(result, item);
       }
       if (page.isCompleted()
           || !StringUtils.hasText(page.getNextCursor())
@@ -73,17 +70,15 @@ public class OfflineExecutionLogService {
     }
 
     if (StringUtils.hasText(warning)) {
-      result.append("\n")
-          .append("- WARN [YAK_OPS] [LOG_AGGREGATION] ")
+      result.append("\n- WARN [YAK_OPS] [LOG_AGGREGATION] ")
           .append(warning)
           .append('\n');
     }
-
     return result.toString();
   }
 
   public OfflineExecutionLogPageVO logs(
-      OfflineJobExecutionPO execution,
+      OfflineJobExecution execution,
       String cursorValue,
       int limit) {
     if (execution == null || execution.getId() == null) {
@@ -94,15 +89,10 @@ public class OfflineExecutionLogService {
     }
 
     Cursor cursor = Cursor.parse(cursorValue);
-    List<ExecutionEventRecord> events =
-        repository.listExecutionEventsAfter(
-            execution.getId(),
-            cursor.yakEventId,
-            limit);
+    List<OfflineExecutionEvent> events =
+        eventRepository.listAfter(execution.getId(), cursor.yakEventId, limit);
     List<OfflineExecutionLogEntryVO> yakItems = new ArrayList<>();
-    for (ExecutionEventRecord event : events) {
-      yakItems.add(toYakOpsEntry(execution, event));
-    }
+    for (OfflineExecutionEvent event : events) yakItems.add(toYakOpsEntry(execution, event));
 
     List<OfflineExecutionLogEntryVO> linkItems = new ArrayList<>();
     LinkUpJobLogPageResponse linkResponse = null;
@@ -111,11 +101,7 @@ public class OfflineExecutionLogService {
 
     if (StringUtils.hasText(execution.getEngineJobId())) {
       try {
-        linkResponse =
-            linkUpClient.logs(
-                execution.getEngineJobId(),
-                cursor.linkCursor,
-                limit);
+        linkResponse = linkUpClient.logs(execution.getEngineJobId(), cursor.linkCursor, limit);
         if (linkResponse != null && linkResponse.getItems() != null) {
           for (LinkUpJobLogEntry entry : linkResponse.getItems()) {
             linkItems.add(toLinkUpEntry(execution, linkResponse, entry));
@@ -123,10 +109,9 @@ public class OfflineExecutionLogService {
         }
       } catch (LinkUpRequestException exception) {
         linkUpAvailable = false;
-        warning =
-            exception.getStatusCode() == 404 || exception.getStatusCode() == 405
-                ? "Link-Up 不支持任务日志接口，或该任务日志已不在 Worker 历史中"
-                : "Link-Up 日志请求失败：" + exception.getMessage();
+        warning = exception.getStatusCode() == 404 || exception.getStatusCode() == 405
+            ? "Link-Up 不支持任务日志接口，或该任务日志已不在 Worker 历史中"
+            : "Link-Up 日志请求失败：" + exception.getMessage();
       } catch (LinkUpTransportException | LinkUpProtocolException exception) {
         linkUpAvailable = false;
         warning = "暂时无法读取 Link-Up 日志：" + exception.getMessage();
@@ -137,42 +122,32 @@ public class OfflineExecutionLogService {
     merged.addAll(yakItems);
     merged.addAll(linkItems);
     merged.sort(logComparator());
-
     List<OfflineExecutionLogEntryVO> selected =
         new ArrayList<>(merged.subList(0, Math.min(limit, merged.size())));
 
     int selectedYakCount = count(selected, "YAK_OPS");
     int selectedLinkCount = count(selected, "LINK_UP");
-
     long nextYakEventId = cursor.yakEventId;
-    if (selectedYakCount > 0) {
-      nextYakEventId =
-          yakItems.get(selectedYakCount - 1).getSequence();
-    }
+    if (selectedYakCount > 0) nextYakEventId = yakItems.get(selectedYakCount - 1).getSequence();
 
     long nextLinkCursor = cursor.linkCursor;
     if (selectedLinkCount < linkItems.size()) {
-      nextLinkCursor =
-          linkItems.get(selectedLinkCount).getSequence();
+      nextLinkCursor = linkItems.get(selectedLinkCount).getSequence();
     } else if (linkResponse != null) {
-      nextLinkCursor =
-          value(linkResponse.getNextCursor(), cursor.linkCursor);
+      nextLinkCursor = value(linkResponse.getNextCursor(), cursor.linkCursor);
     }
 
     boolean terminal = !OfflineExecutionStatus.isActive(execution.getStatus());
-    boolean yakCompleted =
-        selectedYakCount == yakItems.size()
-            && events.size() < limit;
+    boolean yakCompleted = selectedYakCount == yakItems.size() && events.size() < limit;
     boolean linkCompleted;
     if (!StringUtils.hasText(execution.getEngineJobId())) {
       linkCompleted = true;
     } else if (!linkUpAvailable) {
       linkCompleted = terminal;
     } else {
-      linkCompleted =
-          selectedLinkCount == linkItems.size()
-              && linkResponse != null
-              && Boolean.TRUE.equals(linkResponse.getCompleted());
+      linkCompleted = selectedLinkCount == linkItems.size()
+          && linkResponse != null
+          && Boolean.TRUE.equals(linkResponse.getCompleted());
     }
 
     return OfflineExecutionLogPageVO.builder()
@@ -194,63 +169,33 @@ public class OfflineExecutionLogService {
         .thenComparingLong(OfflineExecutionLogEntryVO::getSequence);
   }
 
-  private int count(
-      List<OfflineExecutionLogEntryVO> items,
-      String source) {
+  private int count(List<OfflineExecutionLogEntryVO> items, String source) {
     int result = 0;
-    for (OfflineExecutionLogEntryVO item : items) {
-      if (source.equals(item.getSource())) {
-        result++;
-      }
-    }
+    for (OfflineExecutionLogEntryVO item : items) if (source.equals(item.getSource())) result++;
     return result;
   }
 
-  private void appendTextLine(
-      StringBuilder result,
-      OfflineExecutionLogEntryVO item) {
-    result.append(
-            StringUtils.hasText(item.getTimestamp())
-                ? item.getTimestamp()
-                : "-")
+  private void appendTextLine(StringBuilder result, OfflineExecutionLogEntryVO item) {
+    result.append(StringUtils.hasText(item.getTimestamp()) ? item.getTimestamp() : "-")
         .append(' ')
-        .append(
-            StringUtils.hasText(item.getLevel())
-                ? item.getLevel()
-                : "INFO")
+        .append(StringUtils.hasText(item.getLevel()) ? item.getLevel() : "INFO")
         .append(" [")
-        .append(
-            StringUtils.hasText(item.getSource())
-                ? item.getSource()
-                : "UNKNOWN")
+        .append(StringUtils.hasText(item.getSource()) ? item.getSource() : "UNKNOWN")
         .append(']');
-
-    if (StringUtils.hasText(item.getStage())) {
-      result.append(" [")
-          .append(item.getStage())
-          .append(']');
-    }
-
+    if (StringUtils.hasText(item.getStage())) result.append(" [").append(item.getStage()).append(']');
     result.append(' ')
-        .append(
-            StringUtils.hasText(item.getMessage())
-                ? item.getMessage()
-                : "-")
+        .append(StringUtils.hasText(item.getMessage()) ? item.getMessage() : "-")
         .append('\n');
   }
 
   private OfflineExecutionLogEntryVO toYakOpsEntry(
-      OfflineJobExecutionPO execution,
-      ExecutionEventRecord event) {
+      OfflineJobExecution execution,
+      OfflineExecutionEvent event) {
     Long timestampMillis = epochMillis(event.getCreateTime());
-    String from = text(event.getFromStatus());
-    String to = text(event.getToStatus());
-    String transition = from + " -> " + to;
-    String message =
-        StringUtils.hasText(event.getMessage())
-            ? transition + " | " + event.getMessage()
-            : transition;
-
+    String transition = text(event.getFromStatus()) + " -> " + text(event.getToStatus());
+    String message = StringUtils.hasText(event.getMessage())
+        ? transition + " | " + event.getMessage()
+        : transition;
     return OfflineExecutionLogEntryVO.builder()
         .sequence(value(event.getId(), 0L))
         .timestampMillis(timestampMillis)
@@ -265,31 +210,25 @@ public class OfflineExecutionLogService {
   }
 
   private OfflineExecutionLogEntryVO toLinkUpEntry(
-      OfflineJobExecutionPO execution,
+      OfflineJobExecution execution,
       LinkUpJobLogPageResponse response,
       LinkUpJobLogEntry entry) {
     Long timestampMillis = entry == null ? null : entry.getTimestampMillis();
     String logger = entry == null ? null : entry.getLogger();
     String message = entry == null ? null : entry.getMessage();
-
     return OfflineExecutionLogEntryVO.builder()
         .sequence(entry == null ? 0L : value(entry.getSequence(), 0L))
         .timestampMillis(timestampMillis)
         .timestamp(format(timestampMillis))
         .source("LINK_UP")
-        .level(
-            entry == null || !StringUtils.hasText(entry.getLevel())
-                ? "INFO"
-                : entry.getLevel().toUpperCase(Locale.ROOT))
+        .level(entry == null || !StringUtils.hasText(entry.getLevel())
+            ? "INFO"
+            : entry.getLevel().toUpperCase(Locale.ROOT))
         .stage(linkStage(logger, message))
-        .externalExecutionId(
-            firstText(
-                response == null ? null : response.getExternalExecutionId(),
-                execution.getExternalExecutionId()))
-        .engineJobId(
-            firstText(
-                response == null ? null : response.getJobId(),
-                execution.getEngineJobId()))
+        .externalExecutionId(firstText(
+            response == null ? null : response.getExternalExecutionId(),
+            execution.getExternalExecutionId()))
+        .engineJobId(firstText(response == null ? null : response.getJobId(), execution.getEngineJobId()))
         .runId(response == null ? null : response.getRunId())
         .thread(entry == null ? null : entry.getThread())
         .logger(logger)
@@ -298,68 +237,38 @@ public class OfflineExecutionLogService {
   }
 
   private String linkStage(String logger, String message) {
-    String normalizedLogger =
-        logger == null ? "" : logger.toLowerCase(Locale.ROOT);
-    String normalizedMessage =
-        message == null ? "" : message.toLowerCase(Locale.ROOT);
-
+    String normalizedLogger = logger == null ? "" : logger.toLowerCase(Locale.ROOT);
+    String normalizedMessage = message == null ? "" : message.toLowerCase(Locale.ROOT);
     if (normalizedMessage.contains("catalog sql")
         || normalizedMessage.contains("create table")
-        || normalizedLogger.contains("catalog")) {
-      return "SCHEMA";
-    }
-    if (normalizedLogger.contains("taskexecutor")) {
-      return "TASK";
-    }
-    if (normalizedLogger.contains("jobexecution")) {
-      return "JOB";
-    }
-    if (normalizedLogger.contains("split")) {
-      return "SPLIT";
-    }
+        || normalizedLogger.contains("catalog")) return "SCHEMA";
+    if (normalizedLogger.contains("taskexecutor")) return "TASK";
+    if (normalizedLogger.contains("jobexecution")) return "JOB";
+    if (normalizedLogger.contains("split")) return "SPLIT";
     return "ENGINE";
   }
 
   private String level(String status) {
-    if (!StringUtils.hasText(status)) {
-      return "INFO";
-    }
+    if (!StringUtils.hasText(status)) return "INFO";
     String normalized = status.trim().toUpperCase(Locale.ROOT);
-    if ("FAILED".equals(normalized) || "LOST".equals(normalized)) {
-      return "ERROR";
-    }
-    if ("CANCELED".equals(normalized)
-        || "CANCELLED".equals(normalized)) {
-      return "WARN";
-    }
+    if ("FAILED".equals(normalized) || "LOST".equals(normalized)) return "ERROR";
+    if ("CANCELED".equals(normalized) || "CANCELLED".equals(normalized)) return "WARN";
     return "INFO";
   }
 
   private Long epochMillis(LocalDateTime value) {
-    return value == null
-        ? null
-        : value.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli();
+    return value == null ? null : value.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli();
   }
 
   private String format(Long timestampMillis) {
     return timestampMillis == null
         ? null
-        : FORMAT.format(
-            Instant.ofEpochMilli(timestampMillis)
-                .atZone(ZoneId.systemDefault()));
+        : FORMAT.format(Instant.ofEpochMilli(timestampMillis).atZone(ZoneId.systemDefault()));
   }
 
-  private String text(String value) {
-    return StringUtils.hasText(value) ? value : "-";
-  }
-
-  private String firstText(String first, String second) {
-    return StringUtils.hasText(first) ? first : second;
-  }
-
-  private long value(Long value, long fallback) {
-    return value == null ? fallback : value;
-  }
+  private String text(String value) { return StringUtils.hasText(value) ? value : "-"; }
+  private String firstText(String first, String second) { return StringUtils.hasText(first) ? first : second; }
+  private long value(Long value, long fallback) { return value == null ? fallback : value; }
 
   private static final class Cursor {
     private final long yakEventId;
@@ -371,13 +280,9 @@ public class OfflineExecutionLogService {
     }
 
     private static Cursor parse(String value) {
-      if (!StringUtils.hasText(value)) {
-        return new Cursor(0L, 0L);
-      }
+      if (!StringUtils.hasText(value)) return new Cursor(0L, 0L);
       String[] parts = value.trim().split(":", -1);
-      if (parts.length != 2) {
-        throw new IllegalArgumentException("日志 cursor 格式不正确");
-      }
+      if (parts.length != 2) throw new IllegalArgumentException("日志 cursor 格式不正确");
       try {
         long yakEventId = Long.parseLong(parts[0]);
         long linkCursor = Long.parseLong(parts[1]);

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineExecutionOrchestrator.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineExecutionOrchestrator.java
@@ -5,20 +5,21 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
 import io.yak.ops.business.sync.offline.config.OfflineSyncProperties;
-import io.yak.ops.business.sync.offline.dao.OfflineJobDefinitionDao;
-import io.yak.ops.business.sync.offline.dao.OfflineJobExecutionDao;
+import io.yak.ops.business.sync.offline.domain.OfflineExecutionEvent;
 import io.yak.ops.business.sync.offline.domain.OfflineExecutionStatus;
+import io.yak.ops.business.sync.offline.domain.OfflineJobDefinition;
+import io.yak.ops.business.sync.offline.domain.OfflineJobExecution;
+import io.yak.ops.business.sync.offline.domain.OfflineSchedule;
 import io.yak.ops.business.sync.offline.engine.LinkUpClient;
 import io.yak.ops.business.sync.offline.engine.LinkUpClient.LinkUpJobResponse;
 import io.yak.ops.business.sync.offline.engine.LinkUpClient.LinkUpNodeResponse;
 import io.yak.ops.business.sync.offline.engine.LinkUpClient.LinkUpRequestException;
 import io.yak.ops.business.sync.offline.engine.LinkUpClient.LinkUpTransportException;
-import io.yak.ops.business.sync.offline.repository.OfflineExecutionControlRepository;
+import io.yak.ops.business.sync.offline.repository.OfflineExecutionEventRepository;
+import io.yak.ops.business.sync.offline.repository.OfflineJobDefinitionRepository;
+import io.yak.ops.business.sync.offline.repository.OfflineJobExecutionRepository;
 import io.yak.ops.business.sync.offline.repository.OfflineScheduleRepository;
-import io.yak.ops.business.sync.offline.repository.OfflineScheduleRepository.ScheduleRecord;
 import io.yak.ops.business.sync.offline.service.OfflineExecutionClaimService.ClaimResult;
-import io.yak.ops.common.bean.po.sync.offline.OfflineJobDefinitionPO;
-import io.yak.ops.common.bean.po.sync.offline.OfflineJobExecutionPO;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -32,9 +33,9 @@ import org.springframework.util.StringUtils;
 public class OfflineExecutionOrchestrator {
   private final OfflineJobDefinitionService definitionService;
   private final OfflineExecutionClaimService claimService;
-  private final OfflineJobDefinitionDao definitionDao;
-  private final OfflineJobExecutionDao executionDao;
-  private final OfflineExecutionControlRepository executionRepository;
+  private final OfflineJobDefinitionRepository definitionRepository;
+  private final OfflineJobExecutionRepository executionRepository;
+  private final OfflineExecutionEventRepository eventRepository;
   private final OfflineScheduleRepository scheduleRepository;
   private final LinkUpClient linkUpClient;
   private final OfflineSyncProperties properties;
@@ -43,38 +44,35 @@ public class OfflineExecutionOrchestrator {
   public OfflineExecutionOrchestrator(
       OfflineJobDefinitionService definitionService,
       OfflineExecutionClaimService claimService,
-      OfflineJobDefinitionDao definitionDao,
-      OfflineJobExecutionDao executionDao,
-      OfflineExecutionControlRepository executionRepository,
+      OfflineJobDefinitionRepository definitionRepository,
+      OfflineJobExecutionRepository executionRepository,
+      OfflineExecutionEventRepository eventRepository,
       OfflineScheduleRepository scheduleRepository,
       LinkUpClient linkUpClient,
       OfflineSyncProperties properties,
       @Qualifier("offlineSyncJsonMapper") ObjectMapper objectMapper) {
     this.definitionService = definitionService;
     this.claimService = claimService;
-    this.definitionDao = definitionDao;
-    this.executionDao = executionDao;
+    this.definitionRepository = definitionRepository;
     this.executionRepository = executionRepository;
+    this.eventRepository = eventRepository;
     this.scheduleRepository = scheduleRepository;
     this.linkUpClient = linkUpClient;
     this.properties = properties;
     this.objectMapper = objectMapper;
   }
 
-  public OfflineJobExecutionPO execute(
+  public OfflineJobExecution execute(
       Long definitionId,
       String triggerType,
       Long retryFromExecutionId,
       int attemptNo) {
-    ClaimResult claim =
-        claimService.claim(definitionId, triggerType, retryFromExecutionId, attemptNo);
-    return submitClaim(
-        claim,
-        definitionService.resolveExecutionJobSpec(claim.getDefinition()));
+    ClaimResult claim = claimService.claim(definitionId, triggerType, retryFromExecutionId, attemptNo);
+    return submitClaim(claim, definitionService.resolveExecutionJobSpec(claim.getDefinition()));
   }
 
   /** 按工作流版本固定的任务配置快照执行，不回读任务当前 JobSpec。 */
-  public OfflineJobExecutionPO executeSnapshot(
+  public OfflineJobExecution executeSnapshot(
       Long definitionId,
       long definitionVersion,
       String configDigest,
@@ -90,7 +88,7 @@ public class OfflineExecutionOrchestrator {
   }
 
   /** 按工作流版本快照和 Attempt 幂等键执行。 */
-  public OfflineJobExecutionPO executeSnapshot(
+  public OfflineJobExecution executeSnapshot(
       Long definitionId,
       long definitionVersion,
       String configDigest,
@@ -110,10 +108,8 @@ public class OfflineExecutionOrchestrator {
         definitionService.resolveExecutionJobSpec(claim.getLogicalJobSpecJson()));
   }
 
-  private OfflineJobExecutionPO submitClaim(
-      ClaimResult claim,
-      String resolvedExecutionJobSpec) {
-    OfflineJobExecutionPO execution = claim.getExecution();
+  private OfflineJobExecution submitClaim(ClaimResult claim, String resolvedExecutionJobSpec) {
+    OfflineJobExecution execution = claim.getExecution();
     record(
         execution,
         null,
@@ -125,7 +121,7 @@ public class OfflineExecutionOrchestrator {
       LinkUpNodeResponse node = linkUpClient.node();
       execution.setWorkerInstanceId(node.getInstanceId());
       execution.setUpdateTime(LocalDateTime.now());
-      executionDao.updateById(execution);
+      executionRepository.update(execution);
 
       JsonNode jobSpec = readJobSpec(resolvedExecutionJobSpec);
       transition(
@@ -134,56 +130,45 @@ public class OfflineExecutionOrchestrator {
           "SUBMITTING",
           "正在向 Link-Up 提交 JobSpec",
           null);
-      LinkUpJobResponse response =
-          linkUpClient.submit(
-              execution.getExternalExecutionId(),
-              execution.getIdempotencyKey(),
-              execution.getDefinitionVersion(),
-              jobSpec);
+      LinkUpJobResponse response = linkUpClient.submit(
+          execution.getExternalExecutionId(),
+          execution.getIdempotencyKey(),
+          execution.getDefinitionVersion(),
+          jobSpec);
       applySnapshot(execution, response, "SUBMITTED");
       return execution;
-    } catch (LinkUpRequestException e) {
+    } catch (LinkUpRequestException exception) {
       markTerminal(
           execution,
           OfflineExecutionStatus.FAILED,
-          e.getCode() + "：" + e.getMessage(),
+          exception.getCode() + "：" + exception.getMessage(),
           null,
-          e.getStatusCode() == 429 || e.getStatusCode() >= 500);
-      throw e;
-    } catch (LinkUpTransportException e) {
-      if (e.isUncertain()) {
-        execution.setErrorMessage(e.getMessage());
+          exception.getStatusCode() == 429 || exception.getStatusCode() >= 500);
+      throw exception;
+    } catch (LinkUpTransportException exception) {
+      if (exception.isUncertain()) {
+        execution.setErrorMessage(exception.getMessage());
         execution.setLastSyncTime(LocalDateTime.now());
         execution.setUpdateTime(LocalDateTime.now());
-        executionDao.updateById(execution);
+        executionRepository.update(execution);
         record(
             execution,
             execution.getStatus(),
             execution.getStatus(),
             "SUBMIT_UNCERTAIN",
-            e.getMessage(),
+            exception.getMessage(),
             null);
         return execution;
       }
-      markTerminal(
-          execution,
-          OfflineExecutionStatus.FAILED,
-          e.getMessage(),
-          null,
-          true);
-      throw e;
-    } catch (RuntimeException e) {
-      markTerminal(
-          execution,
-          OfflineExecutionStatus.FAILED,
-          e.getMessage(),
-          null,
-          false);
-      throw e;
+      markTerminal(execution, OfflineExecutionStatus.FAILED, exception.getMessage(), null, true);
+      throw exception;
+    } catch (RuntimeException exception) {
+      markTerminal(execution, OfflineExecutionStatus.FAILED, exception.getMessage(), null, false);
+      throw exception;
     }
   }
 
-  public OfflineJobExecutionPO retryFrom(OfflineJobExecutionPO previous) {
+  public OfflineJobExecution retryFrom(OfflineJobExecution previous) {
     if (previous == null || previous.getId() == null) {
       throw new IllegalArgumentException("重试来源实例不能为空");
     }
@@ -194,14 +179,14 @@ public class OfflineExecutionOrchestrator {
         value(previous.getAttemptNo(), 1) + 1);
   }
 
-  public OfflineJobExecutionPO cancel(Long id) {
-    OfflineJobExecutionPO execution = require(id);
+  public OfflineJobExecution cancel(Long id) {
+    OfflineJobExecution execution = require(id);
     if (!OfflineExecutionStatus.isActive(execution.getStatus())) {
       throw new IllegalStateException("当前执行实例已结束，无需停止");
     }
     execution.setCancellationRequested(true);
     execution.setUpdateTime(LocalDateTime.now());
-    executionDao.updateById(execution);
+    executionRepository.update(execution);
     record(
         execution,
         execution.getStatus(),
@@ -210,51 +195,40 @@ public class OfflineExecutionOrchestrator {
         "Yak Ops 已记录取消意图",
         null);
     if (StringUtils.hasText(execution.getEngineJobId())) {
-      applySnapshot(
-          execution,
-          linkUpClient.cancel(execution.getEngineJobId()),
-          "CANCEL_ACCEPTED");
+      applySnapshot(execution, linkUpClient.cancel(execution.getEngineJobId()), "CANCEL_ACCEPTED");
     }
     return execution;
   }
 
   public void applySnapshot(
-      OfflineJobExecutionPO execution,
+      OfflineJobExecution execution,
       LinkUpJobResponse response,
       String eventType) {
-    if (execution == null || response == null) {
-      return;
-    }
+    if (execution == null || response == null) return;
 
     String previous = execution.getStatus();
-    OfflineExecutionStatus next =
-        StringUtils.hasText(response.getStatus())
-            ? OfflineExecutionStatus.parse(response.getStatus())
-            : OfflineExecutionStatus.parse(execution.getStatus());
+    OfflineExecutionStatus next = StringUtils.hasText(response.getStatus())
+        ? OfflineExecutionStatus.parse(response.getStatus())
+        : OfflineExecutionStatus.parse(execution.getStatus());
 
     execution.setEngineJobId(first(response.getJobId(), execution.getEngineJobId()));
-    execution.setWorkerInstanceId(
-        first(response.getWorkerInstanceId(), execution.getWorkerInstanceId()));
+    execution.setWorkerInstanceId(first(response.getWorkerInstanceId(), execution.getWorkerInstanceId()));
     execution.setStatus(next.name());
     execution.setStateVersion(
-        Math.max(
-            value(execution.getStateVersion(), 0L),
-            value(response.getStateVersion(), 0L)));
+        Math.max(value(execution.getStateVersion(), 0L), value(response.getStateVersion(), 0L)));
     execution.setCancellationRequested(
         Boolean.TRUE.equals(response.getCancellationRequested())
             || Boolean.TRUE.equals(execution.getCancellationRequested()));
     execution.setEngineSnapshotJson(write(response));
     execution.setErrorMessage(response.getErrorMessage());
-
     applyMetrics(execution, response);
-
     execution.setDurationMillis(value(response.getDurationMillis(), 0L));
     execution.setStartTime(time(response.getStartTimeMillis()));
     execution.setEndTime(time(response.getEndTimeMillis()));
     execution.setLastSyncTime(LocalDateTime.now());
     execution.setUpdateTime(LocalDateTime.now());
     configureRetry(execution, next, retryable(response, next));
-    executionDao.updateById(execution);
+    executionRepository.update(execution);
     updateDefinition(execution, next);
 
     if (!next.name().equals(previous)) {
@@ -268,9 +242,7 @@ public class OfflineExecutionOrchestrator {
     }
   }
 
-  private void applyMetrics(
-      OfflineJobExecutionPO execution,
-      LinkUpJobResponse response) {
+  private void applyMetrics(OfflineJobExecution execution, LinkUpJobResponse response) {
     JsonNode metrics = response.getMetrics();
     JsonNode commitSummary = response.getCommitSummary();
 
@@ -278,9 +250,7 @@ public class OfflineExecutionOrchestrator {
     long sinkAttemptedRecordCount = number(metrics, "sinkAttemptedRecordCount", 0L);
     long sinkSuccessRecordCount = number(metrics, "sinkSuccessRecordCount", 0L);
     long sinkCommittedRecordCount = number(
-        commitSummary,
-        "successfullyCommittedRecordCount",
-        sinkSuccessRecordCount);
+        commitSummary, "successfullyCommittedRecordCount", sinkSuccessRecordCount);
     double sourceAverageQps = decimal(metrics, "sourceAverageQps", 0D);
     double sinkAverageQps = decimal(metrics, "sinkAverageQps", 0D);
 
@@ -299,30 +269,20 @@ public class OfflineExecutionOrchestrator {
     execution.setQps(sourceAverageQps > 0D ? sourceAverageQps : sinkAverageQps);
   }
 
-  public void markLost(OfflineJobExecutionPO execution, String message) {
+  public void markLost(OfflineJobExecution execution, String message) {
     if (execution != null && OfflineExecutionStatus.isActive(execution.getStatus())) {
-      markTerminal(
-          execution,
-          OfflineExecutionStatus.LOST,
-          message,
-          null,
-          true);
+      markTerminal(execution, OfflineExecutionStatus.LOST, message, null, true);
     }
   }
 
-  public OfflineJobExecutionPO require(Long id) {
-    if (id == null || id <= 0L) {
-      throw new IllegalArgumentException("任务实例 ID 不合法");
-    }
-    OfflineJobExecutionPO execution = executionDao.selectById(id);
-    if (execution == null) {
-      throw new IllegalArgumentException("离线同步任务实例不存在：" + id);
-    }
-    return execution;
+  public OfflineJobExecution require(Long id) {
+    if (id == null || id <= 0L) throw new IllegalArgumentException("任务实例 ID 不合法");
+    return executionRepository.findById(id)
+        .orElseThrow(() -> new IllegalArgumentException("离线同步任务实例不存在：" + id));
   }
 
   private void markTerminal(
-      OfflineJobExecutionPO execution,
+      OfflineJobExecution execution,
       OfflineExecutionStatus status,
       String message,
       String payload,
@@ -335,25 +295,14 @@ public class OfflineExecutionOrchestrator {
     execution.setLastSyncTime(LocalDateTime.now());
     execution.setUpdateTime(LocalDateTime.now());
     configureRetry(execution, status, retryable);
-    executionDao.updateById(execution);
+    executionRepository.update(execution);
     updateDefinition(execution, status);
-    record(
-        execution,
-        previous,
-        status.name(),
-        status.name(),
-        message,
-        payload);
+    record(execution, previous, status.name(), status.name(), message, payload);
   }
 
-  private void updateDefinition(
-      OfflineJobExecutionPO execution,
-      OfflineExecutionStatus status) {
-    OfflineJobDefinitionPO definition =
-        definitionDao.selectById(execution.getJobDefinitionId());
-    if (definition == null) {
-      return;
-    }
+  private void updateDefinition(OfflineJobExecution execution, OfflineExecutionStatus status) {
+    OfflineJobDefinition definition = definitionRepository.findById(execution.getJobDefinitionId()).orElse(null);
+    if (definition == null) return;
     definition.setLastExecutionId(execution.getId());
     definition.setLastEngineJobId(execution.getEngineJobId());
     definition.setLastJobStatus(status.name());
@@ -362,17 +311,15 @@ public class OfflineExecutionOrchestrator {
     definition.setLastReadRowCount(execution.getSourceRecordCount());
     definition.setLastQps(execution.getQps());
     definition.setLastSyncBytes(
-        Math.max(
-            value(execution.getSourceReadBytes(), 0L),
-            value(execution.getSinkWrittenBytes(), 0L)));
+        Math.max(value(execution.getSourceReadBytes(), 0L), value(execution.getSinkWrittenBytes(), 0L)));
     definition.setLastStartTime(execution.getStartTime());
     definition.setLastEndTime(execution.getEndTime());
     definition.setUpdateTime(LocalDateTime.now());
-    definitionDao.updateById(definition);
+    definitionRepository.update(definition);
   }
 
   private void transition(
-      OfflineJobExecutionPO execution,
+      OfflineJobExecution execution,
       OfflineExecutionStatus target,
       String type,
       String message,
@@ -381,53 +328,36 @@ public class OfflineExecutionOrchestrator {
     execution.setStatus(target.name());
     execution.setStateVersion(value(execution.getStateVersion(), 0L) + 1L);
     execution.setUpdateTime(LocalDateTime.now());
-    executionDao.updateById(execution);
-    record(
-        execution,
-        previous,
-        target.name(),
-        type,
-        message,
-        payload);
+    executionRepository.update(execution);
+    record(execution, previous, target.name(), type, message, payload);
   }
 
   private void configureRetry(
-      OfflineJobExecutionPO execution,
+      OfflineJobExecution execution,
       OfflineExecutionStatus status,
       boolean retryable) {
     execution.setNextRetryTime(null);
     if (!retryable
-        || (status != OfflineExecutionStatus.FAILED
-            && status != OfflineExecutionStatus.LOST)) {
+        || (status != OfflineExecutionStatus.FAILED && status != OfflineExecutionStatus.LOST)) {
       return;
     }
-    ScheduleRecord schedule =
-        scheduleRepository.findSchedule(execution.getJobDefinitionId());
+    OfflineSchedule schedule = scheduleRepository.findSchedule(execution.getJobDefinitionId());
     int attempts = schedule == null
         ? properties.getControl().getDefaultMaxAttempts()
-        : schedule.getRetryMaxAttempts();
+        : schedule.retryMaxAttempts();
     int backoff = schedule == null
         ? properties.getControl().getDefaultRetryBackoffSeconds()
-        : schedule.getRetryBackoffSeconds();
+        : schedule.retryBackoffSeconds();
     if (value(execution.getAttemptNo(), 1) < Math.max(1, attempts)) {
-      execution.setNextRetryTime(
-          LocalDateTime.now().plusSeconds(Math.max(1, backoff)));
+      execution.setNextRetryTime(LocalDateTime.now().plusSeconds(Math.max(1, backoff)));
     }
   }
 
-  private boolean retryable(
-      LinkUpJobResponse response,
-      OfflineExecutionStatus status) {
-    if (status == OfflineExecutionStatus.LOST) {
-      return true;
-    }
-    if (status != OfflineExecutionStatus.FAILED) {
-      return false;
-    }
+  private boolean retryable(LinkUpJobResponse response, OfflineExecutionStatus status) {
+    if (status == OfflineExecutionStatus.LOST) return true;
+    if (status != OfflineExecutionStatus.FAILED) return false;
     String code = response == null ? null : response.getErrorCode();
-    if (!StringUtils.hasText(code)) {
-      return true;
-    }
+    if (!StringUtils.hasText(code)) return true;
     String normalized = code.toUpperCase(java.util.Locale.ROOT);
     return !(normalized.contains("CONFIG")
         || normalized.contains("VALIDATION")
@@ -437,9 +367,7 @@ public class OfflineExecutionOrchestrator {
   }
 
   private JsonNode readJobSpec(String value) {
-    if (!StringUtils.hasText(value)) {
-      throw new IllegalStateException("任务缺少 Link-Up JobSpec");
-    }
+    if (!StringUtils.hasText(value)) throw new IllegalStateException("任务缺少 Link-Up JobSpec");
     try {
       JsonNode node = objectMapper.readTree(value);
       if (node == null || !node.isObject()) {
@@ -452,20 +380,23 @@ public class OfflineExecutionOrchestrator {
   }
 
   private void record(
-      OfflineJobExecutionPO execution,
+      OfflineJobExecution execution,
       String from,
       String to,
       String type,
       String message,
       String payload) {
-    executionRepository.recordExecutionEvent(
-        execution.getId(),
-        value(execution.getStateVersion(), 0L),
-        from,
-        to,
-        type,
-        message,
-        payload);
+    eventRepository.append(
+        OfflineExecutionEvent.builder()
+            .executionId(execution.getId())
+            .stateVersion(value(execution.getStateVersion(), 0L))
+            .fromStatus(from)
+            .toStatus(to)
+            .eventType(type)
+            .message(message)
+            .payloadJson(payload)
+            .createTime(LocalDateTime.now())
+            .build());
   }
 
   private String write(Object value) {
@@ -489,9 +420,7 @@ public class OfflineExecutionOrchestrator {
   private LocalDateTime time(Long millis) {
     return millis == null || millis <= 0L
         ? null
-        : LocalDateTime.ofInstant(
-            Instant.ofEpochMilli(millis),
-            ZoneId.systemDefault());
+        : LocalDateTime.ofInstant(Instant.ofEpochMilli(millis), ZoneId.systemDefault());
   }
 
   private String first(String value, String fallback) {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineExecutionReadService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineExecutionReadService.java
@@ -1,22 +1,24 @@
 package io.yak.ops.business.sync.offline.service;
 
-import com.baomidou.mybatisplus.core.metadata.IPage;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.yak.framework.common.PagingData;
 import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
-import io.yak.ops.business.sync.offline.dao.OfflineJobExecutionDao;
+import io.yak.ops.business.sync.offline.domain.OfflineExecutionEvent;
+import io.yak.ops.business.sync.offline.domain.OfflineExecutionQuery;
 import io.yak.ops.business.sync.offline.domain.OfflineExecutionStatus;
+import io.yak.ops.business.sync.offline.domain.OfflineJobExecution;
+import io.yak.ops.business.sync.offline.domain.OfflinePage;
 import io.yak.ops.business.sync.offline.engine.LinkUpClient;
-import io.yak.ops.business.sync.offline.repository.OfflineExecutionControlRepository;
-import io.yak.ops.business.sync.offline.repository.OfflineExecutionControlRepository.ExecutionEventRecord;
+import io.yak.ops.business.sync.offline.repository.OfflineExecutionEventRepository;
+import io.yak.ops.business.sync.offline.repository.OfflineJobExecutionRepository;
+import io.yak.ops.business.sync.offline.service.support.OfflineSyncViewMapper;
 import io.yak.ops.common.bean.dto.sync.offline.OfflineJobExecutionQueryDTO;
-import io.yak.ops.common.bean.po.sync.offline.OfflineJobExecutionPO;
+import io.yak.ops.common.bean.vo.sync.offline.OfflineExecutionEventVO;
 import io.yak.ops.common.bean.vo.sync.offline.OfflineJobExecutionDetailVO;
 import io.yak.ops.common.bean.vo.sync.offline.OfflineJobExecutionVO;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
@@ -26,60 +28,60 @@ import org.springframework.util.StringUtils;
 @ConditionalOnOfflineSyncEnabled
 @Component
 public class OfflineExecutionReadService {
-  private static final DateTimeFormatter FORMAT =
-      DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+  private static final DateTimeFormatter FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
 
-  private final OfflineJobExecutionDao executionDao;
-  private final OfflineExecutionControlRepository repository;
+  private final OfflineJobExecutionRepository executionRepository;
+  private final OfflineExecutionEventRepository eventRepository;
   private final LinkUpClient linkUpClient;
   private final ObjectMapper objectMapper;
+  private final OfflineSyncViewMapper viewMapper;
 
   public OfflineExecutionReadService(
-      OfflineJobExecutionDao executionDao,
-      OfflineExecutionControlRepository repository,
+      OfflineJobExecutionRepository executionRepository,
+      OfflineExecutionEventRepository eventRepository,
       LinkUpClient linkUpClient,
-      @Qualifier("offlineSyncJsonMapper") ObjectMapper objectMapper) {
-    this.executionDao = executionDao;
-    this.repository = repository;
+      @Qualifier("offlineSyncJsonMapper") ObjectMapper objectMapper,
+      OfflineSyncViewMapper viewMapper) {
+    this.executionRepository = executionRepository;
+    this.eventRepository = eventRepository;
     this.linkUpClient = linkUpClient;
     this.objectMapper = objectMapper;
+    this.viewMapper = viewMapper;
   }
 
-  public OfflineJobExecutionPO require(Long id) {
-    if (id == null || id <= 0L) {
-      throw new IllegalArgumentException("任务实例 ID 不合法");
-    }
-    OfflineJobExecutionPO execution = executionDao.selectById(id);
-    if (execution == null) {
-      throw new IllegalArgumentException("离线同步任务实例不存在：" + id);
-    }
-    return execution;
+  public OfflineJobExecution require(Long id) {
+    if (id == null || id <= 0L) throw new IllegalArgumentException("任务实例 ID 不合法");
+    return executionRepository.findById(id)
+        .orElseThrow(() -> new IllegalArgumentException("离线同步任务实例不存在：" + id));
   }
 
-  public PagingData<OfflineJobExecutionVO> page(
-      OfflineJobExecutionQueryDTO queryDTO) {
-    IPage<OfflineJobExecutionPO> page = executionDao.selectPage(queryDTO);
-    List<OfflineJobExecutionVO> records =
-        new ArrayList<>(page.getRecords().size());
-    for (OfflineJobExecutionPO execution : page.getRecords()) {
-      records.add(toVO(execution));
-    }
-    return new PagingData<>(records, page);
+  public PagingData<OfflineJobExecutionVO> page(OfflineJobExecutionQueryDTO queryDTO) {
+    OfflineJobExecutionQueryDTO query = queryDTO == null ? new OfflineJobExecutionQueryDTO() : queryDTO;
+    OfflinePage<OfflineJobExecution> page = executionRepository.page(
+        new OfflineExecutionQuery(
+            query.getCurrent(), query.getPageSize(), query.getJobDefinitionId(), query.getStatus()));
+    List<OfflineJobExecutionVO> records = page.records().stream().map(viewMapper::execution).toList();
+    return new PagingData<>(
+        records,
+        PagingData.Pagination.builder()
+            .total(page.total())
+            .pages(page.pages())
+            .pageNo(page.current())
+            .pageSize(page.pageSize())
+            .build());
   }
 
   public OfflineJobExecutionDetailVO detail(Long id) {
-    OfflineJobExecutionPO execution = require(id);
-    OfflineJobExecutionVO summary = toVO(execution);
-    OfflineJobExecutionDetailVO detail =
-        OfflineJobExecutionDetailVO.builder()
-            .execution(summary)
-            .summary(summary)
-            .build();
+    OfflineJobExecution execution = require(id);
+    OfflineJobExecutionVO summary = viewMapper.execution(execution);
+    OfflineJobExecutionDetailVO detail = OfflineJobExecutionDetailVO.builder()
+        .execution(summary)
+        .summary(summary)
+        .build();
 
     if (StringUtils.hasText(execution.getEngineSnapshotJson())) {
       try {
-        JsonNode snapshot =
-            objectMapper.readTree(execution.getEngineSnapshotJson());
+        JsonNode snapshot = objectMapper.readTree(execution.getEngineSnapshotJson());
         detail.setJob(snapshot);
         detail.setPipelines(snapshot.path("pipelines"));
         detail.setTasks(snapshot.path("tasks"));
@@ -92,155 +94,74 @@ public class OfflineExecutionReadService {
   }
 
   public JsonNode tableMetrics(Long id) {
-    OfflineJobExecutionPO execution = require(id);
-
+    OfflineJobExecution execution = require(id);
     if (!OfflineExecutionStatus.isActive(execution.getStatus())) {
       JsonNode snapshotPipelines = snapshotPipelines(execution);
       if (snapshotPipelines.isArray() && !snapshotPipelines.isEmpty()) {
-        return OfflinePipelineMetricsMapper.flatten(
-            objectMapper,
-            snapshotPipelines);
+        return OfflinePipelineMetricsMapper.flatten(objectMapper, snapshotPipelines);
       }
     }
-
     if (!StringUtils.hasText(execution.getEngineJobId())) {
       throw new IllegalStateException("当前执行实例尚未获得 Link-Up jobId");
     }
-    JsonNode pipelines = linkUpClient.pipelines(execution.getEngineJobId());
-    return OfflinePipelineMetricsMapper.flatten(objectMapper, pipelines);
+    return OfflinePipelineMetricsMapper.flatten(
+        objectMapper,
+        linkUpClient.pipelines(execution.getEngineJobId()));
   }
 
-  private JsonNode snapshotPipelines(OfflineJobExecutionPO execution) {
-    if (execution == null
-        || !StringUtils.hasText(execution.getEngineSnapshotJson())) {
-      return objectMapper.createArrayNode();
-    }
-    try {
-      JsonNode snapshot =
-          objectMapper.readTree(execution.getEngineSnapshotJson());
-      JsonNode pipelines = snapshot.path("pipelines");
-      return pipelines.isArray()
-          ? pipelines
-          : objectMapper.createArrayNode();
-    } catch (Exception ignored) {
-      return objectMapper.createArrayNode();
-    }
+  public List<OfflineExecutionEventVO> events(Long executionId) {
+    return eventRepository.list(executionId).stream().map(viewMapper::event).toList();
   }
 
+  /** 保留旧文本状态事件视图；统一物理日志由 OfflineExecutionLogService 提供。 */
   public String logs(Long id) {
-    OfflineJobExecutionPO execution = require(id);
+    OfflineJobExecution execution = require(id);
     StringBuilder log = new StringBuilder("# Yak Ops Offline Sync\n");
-    log.append("definitionId: ")
-        .append(execution.getJobDefinitionId())
-        .append('\n')
-        .append("executionId: ")
-        .append(execution.getId())
-        .append('\n')
-        .append("definitionVersion: ")
-        .append(value(execution.getDefinitionVersion()))
-        .append('\n')
-        .append("externalExecutionId: ")
-        .append(text(execution.getExternalExecutionId()))
-        .append('\n')
-        .append("engineBaseUrl: ")
-        .append(text(execution.getEngineBaseUrl()))
-        .append('\n')
-        .append("workerInstanceId: ")
-        .append(text(execution.getWorkerInstanceId()))
-        .append('\n')
-        .append("engineJobId: ")
-        .append(text(execution.getEngineJobId()))
-        .append('\n')
-        .append("status: ")
-        .append(text(execution.getStatus()))
-        .append('\n')
-        .append("attemptNo: ")
-        .append(value(execution.getAttemptNo()))
-        .append('\n')
-        .append("sourceRecordCount: ")
-        .append(value(execution.getSourceRecordCount()))
-        .append('\n')
-        .append("sinkAttemptedRecordCount: ")
-        .append(value(execution.getSinkAttemptedRecordCount()))
-        .append('\n')
-        .append("sinkSuccessRecordCount: ")
-        .append(value(execution.getSinkSuccessRecordCount()))
-        .append('\n')
-        .append("sinkCommittedRecordCount: ")
-        .append(value(execution.getSinkCommittedRecordCount()))
-        .append('\n')
-        .append("sourceAverageQps: ")
-        .append(decimal(execution.getSourceAverageQps()))
-        .append('\n')
-        .append("sinkAverageQps: ")
-        .append(decimal(execution.getSinkAverageQps()))
-        .append('\n')
-        .append("durationMillis: ")
-        .append(value(execution.getDurationMillis()))
-        .append('\n');
+    log.append("definitionId: ").append(execution.getJobDefinitionId()).append('\n')
+        .append("executionId: ").append(execution.getId()).append('\n')
+        .append("definitionVersion: ").append(value(execution.getDefinitionVersion())).append('\n')
+        .append("externalExecutionId: ").append(text(execution.getExternalExecutionId())).append('\n')
+        .append("engineBaseUrl: ").append(text(execution.getEngineBaseUrl())).append('\n')
+        .append("workerInstanceId: ").append(text(execution.getWorkerInstanceId())).append('\n')
+        .append("engineJobId: ").append(text(execution.getEngineJobId())).append('\n')
+        .append("status: ").append(text(execution.getStatus())).append('\n')
+        .append("attemptNo: ").append(value(execution.getAttemptNo())).append('\n')
+        .append("sourceRecordCount: ").append(value(execution.getSourceRecordCount())).append('\n')
+        .append("sinkAttemptedRecordCount: ").append(value(execution.getSinkAttemptedRecordCount())).append('\n')
+        .append("sinkSuccessRecordCount: ").append(value(execution.getSinkSuccessRecordCount())).append('\n')
+        .append("sinkCommittedRecordCount: ").append(value(execution.getSinkCommittedRecordCount())).append('\n')
+        .append("sourceAverageQps: ").append(decimal(execution.getSourceAverageQps())).append('\n')
+        .append("sinkAverageQps: ").append(decimal(execution.getSinkAverageQps())).append('\n')
+        .append("durationMillis: ").append(value(execution.getDurationMillis())).append('\n');
     if (StringUtils.hasText(execution.getErrorMessage())) {
-      log.append("error: ")
-          .append(execution.getErrorMessage())
-          .append('\n');
+      log.append("error: ").append(execution.getErrorMessage()).append('\n');
     }
-
     log.append("\n# State Events\n");
-    for (ExecutionEventRecord event : repository.listExecutionEvents(id)) {
+    for (OfflineExecutionEvent event : eventRepository.list(id)) {
       log.append(format(event.getCreateTime()))
-          .append(" [")
-          .append(event.getEventType())
-          .append("] ")
-          .append(text(event.getFromStatus()))
-          .append(" -> ")
-          .append(text(event.getToStatus()));
-      if (StringUtils.hasText(event.getMessage())) {
-        log.append(" | ").append(event.getMessage());
-      }
+          .append(" [").append(event.getEventType()).append("] ")
+          .append(text(event.getFromStatus())).append(" -> ").append(text(event.getToStatus()));
+      if (StringUtils.hasText(event.getMessage())) log.append(" | ").append(event.getMessage());
       log.append('\n');
     }
     return log.toString();
   }
 
-  public OfflineJobExecutionVO toVO(OfflineJobExecutionPO execution) {
-    return OfflineJobExecutionVO.builder()
-        .id(execution.getId())
-        .jobDefinitionId(execution.getJobDefinitionId())
-        .definitionVersion(execution.getDefinitionVersion())
-        .engineBaseUrl(execution.getEngineBaseUrl())
-        .engineJobId(execution.getEngineJobId())
-        .externalExecutionId(execution.getExternalExecutionId())
-        .workerInstanceId(execution.getWorkerInstanceId())
-        .status(execution.getStatus())
-        .stateVersion(value(execution.getStateVersion()))
-        .attemptNo(value(execution.getAttemptNo()))
-        .triggerType(execution.getTriggerType())
-        .retryFromExecutionId(execution.getRetryFromExecutionId())
-        .cancellationRequested(
-            Boolean.TRUE.equals(execution.getCancellationRequested()))
-        .errorMessage(execution.getErrorMessage())
-        .sourceRecordCount(value(execution.getSourceRecordCount()))
-        .sinkAttemptedRecordCount(
-            value(execution.getSinkAttemptedRecordCount()))
-        .sinkSuccessRecordCount(value(execution.getSinkSuccessRecordCount()))
-        .sinkCommittedRecordCount(
-            value(execution.getSinkCommittedRecordCount()))
-        .sourceReadBytes(value(execution.getSourceReadBytes()))
-        .sinkWrittenBytes(value(execution.getSinkWrittenBytes()))
-        .sourceAverageQps(value(execution.getSourceAverageQps()))
-        .sinkAverageQps(value(execution.getSinkAverageQps()))
-        .failedRecordCount(value(execution.getFailedRecordCount()))
-        .skippedRecordCount(value(execution.getSkippedRecordCount()))
-        .databaseCommitMillis(value(execution.getDatabaseCommitMillis()))
-        .sqlExecutionMillis(value(execution.getSqlExecutionMillis()))
-        .qps(value(execution.getQps()))
-        .durationMillis(value(execution.getDurationMillis()))
-        .createTime(format(execution.getCreateTime()))
-        .startTime(format(execution.getStartTime()))
-        .endTime(format(execution.getEndTime()))
-        .nextRetryTime(format(execution.getNextRetryTime()))
-        .lastSyncTime(format(execution.getLastSyncTime()))
-        .updateTime(format(execution.getUpdateTime()))
-        .build();
+  public OfflineJobExecutionVO toVO(OfflineJobExecution execution) {
+    return viewMapper.execution(execution);
+  }
+
+  private JsonNode snapshotPipelines(OfflineJobExecution execution) {
+    if (execution == null || !StringUtils.hasText(execution.getEngineSnapshotJson())) {
+      return objectMapper.createArrayNode();
+    }
+    try {
+      JsonNode snapshot = objectMapper.readTree(execution.getEngineSnapshotJson());
+      JsonNode pipelines = snapshot.path("pipelines");
+      return pipelines.isArray() ? pipelines : objectMapper.createArrayNode();
+    } catch (Exception ignored) {
+      return objectMapper.createArrayNode();
+    }
   }
 
   private String format(LocalDateTime value) {
@@ -252,20 +173,9 @@ public class OfflineExecutionReadService {
   }
 
   private String decimal(Double value) {
-    return value == null
-        ? "0"
-        : String.format(java.util.Locale.ROOT, "%.3f", value);
+    return value == null ? "0" : String.format(java.util.Locale.ROOT, "%.3f", value);
   }
 
-  private long value(Long value) {
-    return value == null ? 0L : value;
-  }
-
-  private int value(Integer value) {
-    return value == null ? 0 : value;
-  }
-
-  private double value(Double value) {
-    return value == null ? 0D : value;
-  }
+  private long value(Long value) { return value == null ? 0L : value; }
+  private int value(Integer value) { return value == null ? 0 : value; }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineExecutionReconciler.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineExecutionReconciler.java
@@ -2,11 +2,11 @@ package io.yak.ops.business.sync.offline.service;
 
 import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
 import io.yak.ops.business.sync.offline.config.OfflineSyncProperties;
+import io.yak.ops.business.sync.offline.domain.OfflineJobExecution;
 import io.yak.ops.business.sync.offline.engine.LinkUpClient;
 import io.yak.ops.business.sync.offline.engine.LinkUpClient.LinkUpJobResponse;
 import io.yak.ops.business.sync.offline.engine.LinkUpClient.LinkUpNodeResponse;
-import io.yak.ops.business.sync.offline.repository.OfflineExecutionControlRepository;
-import io.yak.ops.common.bean.po.sync.offline.OfflineJobExecutionPO;
+import io.yak.ops.business.sync.offline.repository.OfflineJobExecutionRepository;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -18,14 +18,95 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
 /** 使用 YAML 固定地址持续对账，并通过 instanceId 识别 Worker 重启。 */
-@ConditionalOnOfflineSyncEnabled @Component @RequiredArgsConstructor
+@ConditionalOnOfflineSyncEnabled
+@Component
+@RequiredArgsConstructor
 public class OfflineExecutionReconciler {
-  private static final Logger LOG=LoggerFactory.getLogger(OfflineExecutionReconciler.class);
-  private final OfflineExecutionControlRepository repository;private final OfflineJobExecutionService executionService;private final LinkUpClient linkUpClient;private final OfflineSyncProperties properties;
-  @Scheduled(initialDelayString="${yak.sync.offline.control.reconcile-delay-millis:5000}",fixedDelayString="${yak.sync.offline.control.reconcile-delay-millis:5000}")
-  public void reconcile(){int limit=Math.max(1,properties.getControl().getScanBatchSize());List<OfflineJobExecutionPO> executions=repository.findActiveExecutions(limit);LinkUpNodeResponse node=null;RuntimeException probeError=null;try{node=linkUpClient.node();}catch(RuntimeException e){probeError=e;}for(OfflineJobExecutionPO execution:executions)reconcileExecution(execution,node,probeError);for(OfflineJobExecutionPO execution:repository.findRetryCandidates(LocalDateTime.now(),limit))retry(execution);}
-  private void reconcileExecution(OfflineJobExecutionPO e,LinkUpNodeResponse node,RuntimeException probeError){try{if(probeError!=null)throw probeError;if(node!=null&&StringUtils.hasText(e.getWorkerInstanceId())&&StringUtils.hasText(node.getInstanceId())&&!e.getWorkerInstanceId().equals(node.getInstanceId())){executionService.markLost(e,"Link-Up instanceId 已变化，旧实例执行结果无法继续确认");return;}LinkUpJobResponse response=StringUtils.hasText(e.getEngineJobId())?linkUpClient.getJob(e.getEngineJobId()):linkUpClient.findByExternalExecutionId(e.getExternalExecutionId());executionService.applySnapshot(e,response,"RECONCILED");if(Boolean.TRUE.equals(e.getCancellationRequested())&&StringUtils.hasText(e.getEngineJobId())&&response!=null&&isActive(response.getStatus()))executionService.applySnapshot(e,linkUpClient.cancel(e.getEngineJobId()),"CANCEL_RECONCILED");}catch(RuntimeException ex){if(isPastLostDeadline(e))executionService.markLost(e,"Link-Up 状态对账超时："+ex.getMessage());else LOG.debug("Offline execution reconcile failed, executionId={}",e.getId(),ex);}}
-  private void retry(OfflineJobExecutionPO e){try{executionService.retryFrom(e);repository.markRetryCreated(e.getId());}catch(RuntimeException ex){LOG.warn("Offline execution retry failed, executionId={}",e.getId(),ex);}}
-  private boolean isPastLostDeadline(OfflineJobExecutionPO e){LocalDateTime reference=e.getLastSyncTime()==null?e.getCreateTime():e.getLastSyncTime();return reference!=null&&Duration.between(reference,LocalDateTime.now()).toMillis()>=Math.max(1000,properties.getControl().getLostAfterMillis());}
-  private boolean isActive(String s){return "CREATED".equalsIgnoreCase(s)||"SUBMITTED".equalsIgnoreCase(s)||"QUEUED".equalsIgnoreCase(s)||"RUNNING".equalsIgnoreCase(s);}
+  private static final Logger LOG = LoggerFactory.getLogger(OfflineExecutionReconciler.class);
+
+  private final OfflineJobExecutionRepository executionRepository;
+  private final OfflineJobExecutionService executionService;
+  private final LinkUpClient linkUpClient;
+  private final OfflineSyncProperties properties;
+
+  @Scheduled(
+      initialDelayString = "${yak.sync.offline.control.reconcile-delay-millis:5000}",
+      fixedDelayString = "${yak.sync.offline.control.reconcile-delay-millis:5000}")
+  public void reconcile() {
+    int limit = Math.max(1, properties.getControl().getScanBatchSize());
+    List<OfflineJobExecution> executions = executionRepository.findActiveExecutions(limit);
+    LinkUpNodeResponse node = null;
+    RuntimeException probeError = null;
+    try {
+      node = linkUpClient.node();
+    } catch (RuntimeException exception) {
+      probeError = exception;
+    }
+    for (OfflineJobExecution execution : executions) {
+      reconcileExecution(execution, node, probeError);
+    }
+    for (OfflineJobExecution execution : executionRepository.findRetryCandidates(LocalDateTime.now(), limit)) {
+      retry(execution);
+    }
+  }
+
+  private void reconcileExecution(
+      OfflineJobExecution execution,
+      LinkUpNodeResponse node,
+      RuntimeException probeError) {
+    try {
+      if (probeError != null) throw probeError;
+      if (node != null
+          && StringUtils.hasText(execution.getWorkerInstanceId())
+          && StringUtils.hasText(node.getInstanceId())
+          && !execution.getWorkerInstanceId().equals(node.getInstanceId())) {
+        executionService.markLost(execution, "Link-Up instanceId 已变化，旧实例执行结果无法继续确认");
+        return;
+      }
+      LinkUpJobResponse response = StringUtils.hasText(execution.getEngineJobId())
+          ? linkUpClient.getJob(execution.getEngineJobId())
+          : linkUpClient.findByExternalExecutionId(execution.getExternalExecutionId());
+      executionService.applySnapshot(execution, response, "RECONCILED");
+      if (Boolean.TRUE.equals(execution.getCancellationRequested())
+          && StringUtils.hasText(execution.getEngineJobId())
+          && response != null
+          && isActive(response.getStatus())) {
+        executionService.applySnapshot(
+            execution,
+            linkUpClient.cancel(execution.getEngineJobId()),
+            "CANCEL_RECONCILED");
+      }
+    } catch (RuntimeException exception) {
+      if (isPastLostDeadline(execution)) {
+        executionService.markLost(execution, "Link-Up 状态对账超时：" + exception.getMessage());
+      } else {
+        LOG.debug("Offline execution reconcile failed, executionId={}", execution.getId(), exception);
+      }
+    }
+  }
+
+  private void retry(OfflineJobExecution execution) {
+    try {
+      executionService.retryFrom(execution);
+      executionRepository.markRetryCreated(execution.getId());
+    } catch (RuntimeException exception) {
+      LOG.warn("Offline execution retry failed, executionId={}", execution.getId(), exception);
+    }
+  }
+
+  private boolean isPastLostDeadline(OfflineJobExecution execution) {
+    LocalDateTime reference = execution.getLastSyncTime() == null
+        ? execution.getCreateTime()
+        : execution.getLastSyncTime();
+    return reference != null
+        && Duration.between(reference, LocalDateTime.now()).toMillis()
+            >= Math.max(1000, properties.getControl().getLostAfterMillis());
+  }
+
+  private boolean isActive(String status) {
+    return "CREATED".equalsIgnoreCase(status)
+        || "SUBMITTED".equalsIgnoreCase(status)
+        || "QUEUED".equalsIgnoreCase(status)
+        || "RUNNING".equalsIgnoreCase(status);
+  }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineJobDefinitionService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineJobDefinitionService.java
@@ -150,7 +150,10 @@ public class OfflineJobDefinitionService {
   }
 
   public OfflineJobDefinitionVO get(Long id) {
-    return viewMapper.definition(require(id));
+    if (id == null || id <= 0L) throw new IllegalArgumentException("任务定义 ID 不合法");
+    OfflineJobDefinition definition = definitionRepository.findForViewById(id)
+        .orElseThrow(() -> new IllegalArgumentException("离线同步任务不存在：" + id));
+    return viewMapper.definition(definition);
   }
 
   public JsonNode getEditDetail(Long id) {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineJobDefinitionService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineJobDefinitionService.java
@@ -1,22 +1,23 @@
 package io.yak.ops.business.sync.offline.service;
 
-import com.baomidou.mybatisplus.core.metadata.IPage;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.yak.framework.common.PagingData;
 import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
-import io.yak.ops.business.sync.offline.dao.OfflineJobDefinitionDao;
+import io.yak.ops.business.sync.offline.domain.OfflineDefinitionQuery;
 import io.yak.ops.business.sync.offline.domain.OfflineExecutionStatus;
-import io.yak.ops.business.sync.offline.repository.OfflineExecutionControlRepository;
+import io.yak.ops.business.sync.offline.domain.OfflineJobDefinition;
+import io.yak.ops.business.sync.offline.domain.OfflinePage;
+import io.yak.ops.business.sync.offline.repository.OfflineJobDefinitionRepository;
+import io.yak.ops.business.sync.offline.repository.OfflineJobExecutionRepository;
 import io.yak.ops.business.sync.offline.repository.OfflineScheduleRepository;
 import io.yak.ops.business.sync.offline.service.OfflineDefinitionSupport.DraftDefinition;
 import io.yak.ops.business.sync.offline.service.OfflineDefinitionSupport.PreparedDefinition;
+import io.yak.ops.business.sync.offline.service.support.OfflineScheduleSupport;
+import io.yak.ops.business.sync.offline.service.support.OfflineSyncViewMapper;
 import io.yak.ops.common.bean.dto.sync.offline.OfflineJobDefinitionDTO;
 import io.yak.ops.common.bean.dto.sync.offline.OfflineJobDefinitionQueryDTO;
-import io.yak.ops.common.bean.po.datasource.DataSourcePO;
-import io.yak.ops.common.bean.po.sync.offline.OfflineJobDefinitionPO;
 import io.yak.ops.common.bean.vo.sync.offline.OfflineJobDefinitionVO;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 import lombok.RequiredArgsConstructor;
@@ -29,16 +30,18 @@ import org.springframework.util.StringUtils;
 @Service
 @RequiredArgsConstructor
 public class OfflineJobDefinitionService {
-  private final OfflineJobDefinitionDao definitionDao;
+  private final OfflineJobDefinitionRepository definitionRepository;
+  private final OfflineJobExecutionRepository executionRepository;
   private final OfflineScheduleRepository scheduleRepository;
-  private final OfflineExecutionControlRepository executionRepository;
   private final OfflineDefinitionSupport support;
+  private final OfflineScheduleSupport scheduleSupport;
+  private final OfflineSyncViewMapper viewMapper;
   private final AtomicLong idSequence = new AtomicLong(System.currentTimeMillis() * 1000L);
 
   public Long nextId() {
     long floor = System.currentTimeMillis() * 1000L;
     long value = idSequence.updateAndGet(current -> Math.max(current + 1, floor));
-    while (definitionDao.selectById(value) != null) value = idSequence.incrementAndGet();
+    while (definitionRepository.findById(value).isPresent()) value = idSequence.incrementAndGet();
     return value;
   }
 
@@ -46,40 +49,41 @@ public class OfflineJobDefinitionService {
   public Long saveDraft(OfflineJobDefinitionDTO dto) {
     if (dto == null) throw new IllegalArgumentException("任务定义不能为空");
     Long id = dto.getId();
-    if (id == null || id <= 0) {
+    if (id == null || id <= 0L) {
       id = nextId();
       dto.setId(id);
     }
-    OfflineJobDefinitionPO existing = definitionDao.selectById(id);
+    OfflineJobDefinition existing = definitionRepository.findById(id).orElse(null);
     ensureEditable(existing);
     if (existing != null && StringUtils.hasText(existing.getJobSpecJson())) {
       throw new IllegalStateException("已生成可执行配置的任务不能退回草稿");
     }
     DraftDefinition draft = support.prepareDraft(dto);
-    if (definitionDao.existsByName(draft.getJobName(), id)) {
+    if (definitionRepository.existsByName(draft.getJobName(), id)) {
       throw new IllegalArgumentException("离线同步任务名称已存在：" + draft.getJobName());
     }
     LocalDateTime now = LocalDateTime.now();
-    OfflineJobDefinitionPO d = existing == null ? new OfflineJobDefinitionPO() : existing;
-    d.setId(id);
-    d.setJobName(draft.getJobName());
-    d.setJobDesc(draft.getJobDesc());
-    d.setMode(draft.getMode());
-    d.setDefinitionJson(draft.getDefinitionJson());
-    d.setJobSpecJson(null);
-    d.setConfigDigest(null);
-    d.setReleaseState("OFFLINE");
-    d.setSourceType(draft.getSourceType());
-    d.setSinkType(draft.getSinkType());
-    d.setSourceDatasourceId(null);
-    d.setSinkDatasourceId(null);
-    d.setSourceTable(null);
-    d.setSinkTable(null);
-    d.setVersion(0);
-    d.setCreateTime(existing == null ? now : existing.getCreateTime());
-    d.setUpdateTime(now);
-    if (existing == null) definitionDao.insert(d); else definitionDao.updateById(d);
-    scheduleRepository.saveSchedule(id, draft.getRequest().get("schedule"));
+    OfflineJobDefinition definition = existing == null ? new OfflineJobDefinition() : existing;
+    definition.setId(id);
+    definition.setJobName(draft.getJobName());
+    definition.setJobDesc(draft.getJobDesc());
+    definition.setMode(draft.getMode());
+    definition.setDefinitionJson(draft.getDefinitionJson());
+    definition.setJobSpecJson(null);
+    definition.setConfigDigest(null);
+    definition.setReleaseState("OFFLINE");
+    definition.setSourceType(draft.getSourceType());
+    definition.setSinkType(draft.getSinkType());
+    definition.setSourceDatasourceId(null);
+    definition.setSinkDatasourceId(null);
+    definition.setSourceTable(null);
+    definition.setSinkTable(null);
+    definition.setVersion(0);
+    definition.setCreateTime(existing == null ? now : existing.getCreateTime());
+    definition.setUpdateTime(now);
+    if (existing == null) definitionRepository.insert(definition); else definitionRepository.update(definition);
+    scheduleRepository.saveSchedule(
+        scheduleSupport.prepare(id, draft.getRequest().get("schedule")));
     return id;
   }
 
@@ -87,37 +91,38 @@ public class OfflineJobDefinitionService {
   public Long saveGuide(OfflineJobDefinitionDTO dto) {
     if (dto == null) throw new IllegalArgumentException("任务定义不能为空");
     Long id = dto.getId();
-    if (id == null || id <= 0) {
+    if (id == null || id <= 0L) {
       id = nextId();
       dto.setId(id);
     }
-    OfflineJobDefinitionPO existing = definitionDao.selectById(id);
+    OfflineJobDefinition existing = definitionRepository.findById(id).orElse(null);
     ensureEditable(existing);
-    PreparedDefinition p = support.prepare(dto);
-    if (definitionDao.existsByName(p.getJobName(), id)) {
-      throw new IllegalArgumentException("离线同步任务名称已存在：" + p.getJobName());
+    PreparedDefinition prepared = support.prepare(dto);
+    if (definitionRepository.existsByName(prepared.getJobName(), id)) {
+      throw new IllegalArgumentException("离线同步任务名称已存在：" + prepared.getJobName());
     }
     LocalDateTime now = LocalDateTime.now();
-    OfflineJobDefinitionPO d = existing == null ? new OfflineJobDefinitionPO() : existing;
-    d.setId(id);
-    d.setJobName(p.getJobName());
-    d.setJobDesc(p.getJobDesc());
-    d.setMode(p.getMode());
-    d.setDefinitionJson(p.getDefinitionJson());
-    d.setJobSpecJson(p.getJobSpecJson());
-    d.setConfigDigest(p.getDigest());
-    d.setReleaseState(existing == null ? "OFFLINE" : existing.getReleaseState());
-    d.setSourceType(displayType(p.getSource(), p.getSourceConnectorId()));
-    d.setSinkType(displayType(p.getSink(), p.getSinkConnectorId()));
-    d.setSourceDatasourceId(id(p.getSource()));
-    d.setSinkDatasourceId(id(p.getSink()));
-    d.setSourceTable(p.getSourceTable());
-    d.setSinkTable(p.getSinkTable());
-    d.setVersion((existing == null || existing.getVersion() == null ? 0 : Math.max(0, existing.getVersion())) + 1);
-    d.setCreateTime(existing == null ? now : existing.getCreateTime());
-    d.setUpdateTime(now);
-    if (existing == null) definitionDao.insert(d); else definitionDao.updateById(d);
-    scheduleRepository.saveSchedule(id, p.getRequest().get("schedule"));
+    OfflineJobDefinition definition = existing == null ? new OfflineJobDefinition() : existing;
+    definition.setId(id);
+    definition.setJobName(prepared.getJobName());
+    definition.setJobDesc(prepared.getJobDesc());
+    definition.setMode(prepared.getMode());
+    definition.setDefinitionJson(prepared.getDefinitionJson());
+    definition.setJobSpecJson(prepared.getJobSpecJson());
+    definition.setConfigDigest(prepared.getDigest());
+    definition.setReleaseState(existing == null ? "OFFLINE" : existing.getReleaseState());
+    definition.setSourceType(prepared.getSourceType());
+    definition.setSinkType(prepared.getSinkType());
+    definition.setSourceDatasourceId(prepared.getSourceDatasourceId());
+    definition.setSinkDatasourceId(prepared.getSinkDatasourceId());
+    definition.setSourceTable(prepared.getSourceTable());
+    definition.setSinkTable(prepared.getSinkTable());
+    definition.setVersion((existing == null || existing.getVersion() == null ? 0 : Math.max(0, existing.getVersion())) + 1);
+    definition.setCreateTime(existing == null ? now : existing.getCreateTime());
+    definition.setUpdateTime(now);
+    if (existing == null) definitionRepository.insert(definition); else definitionRepository.update(definition);
+    scheduleRepository.saveSchedule(
+        scheduleSupport.prepare(id, prepared.getRequest().get("schedule")));
     return id;
   }
 
@@ -125,15 +130,15 @@ public class OfflineJobDefinitionService {
     return support.buildJobSpec(dto);
   }
 
-  public String resolveLogicalJobSpec(OfflineJobDefinitionPO d) {
-    if (d == null || !StringUtils.hasText(d.getJobSpecJson())) {
+  public String resolveLogicalJobSpec(OfflineJobDefinition definition) {
+    if (definition == null || !StringUtils.hasText(definition.getJobSpecJson())) {
       throw new IllegalStateException("任务仍是草稿，请完成配置并保存");
     }
-    return d.getJobSpecJson();
+    return definition.getJobSpecJson();
   }
 
-  public String resolveExecutionJobSpec(OfflineJobDefinitionPO d) {
-    return resolveExecutionJobSpec(resolveLogicalJobSpec(d));
+  public String resolveExecutionJobSpec(OfflineJobDefinition definition) {
+    return resolveExecutionJobSpec(resolveLogicalJobSpec(definition));
   }
 
   /** 使用已固化的逻辑 JobSpec，在提交前解析最新数据源凭据。 */
@@ -145,75 +150,77 @@ public class OfflineJobDefinitionService {
   }
 
   public OfflineJobDefinitionVO get(Long id) {
-    return support.toVO(require(id));
+    return viewMapper.definition(require(id));
   }
 
   public JsonNode getEditDetail(Long id) {
     return support.editDetail(require(id));
   }
 
-  public PagingData<OfflineJobDefinitionVO> page(OfflineJobDefinitionQueryDTO query) {
-    IPage<OfflineJobDefinitionPO> page = definitionDao.selectPage(query);
-    List<OfflineJobDefinitionVO> list = new ArrayList<>();
-    for (OfflineJobDefinitionPO d : page.getRecords()) list.add(support.toVO(d));
-    return new PagingData<>(list, page);
+  public PagingData<OfflineJobDefinitionVO> page(OfflineJobDefinitionQueryDTO queryDTO) {
+    OfflineJobDefinitionQueryDTO query = queryDTO == null ? new OfflineJobDefinitionQueryDTO() : queryDTO;
+    OfflinePage<OfflineJobDefinition> page = definitionRepository.page(
+        new OfflineDefinitionQuery(
+            query.getCurrent(), query.getPageSize(), query.getId(), query.getJobName(), query.getStatus(),
+            query.getSourceType(), query.getSinkType(), query.getSourceTable(), query.getSinkTable(),
+            query.getCreateTimeStart(), query.getCreateTimeEnd()));
+    List<OfflineJobDefinitionVO> records = page.records().stream().map(viewMapper::definition).toList();
+    return new PagingData<>(
+        records,
+        PagingData.Pagination.builder()
+            .total(page.total())
+            .pages(page.pages())
+            .pageNo(page.current())
+            .pageSize(page.pageSize())
+            .build());
   }
 
   @Transactional(transactionManager = "offlineSyncTransactionManager", rollbackFor = Exception.class)
   public boolean online(Long id) {
-    OfflineJobDefinitionPO d = require(id);
-    resolveLogicalJobSpec(d);
-    d.setReleaseState("ONLINE");
-    d.setUpdateTime(LocalDateTime.now());
-    return definitionDao.updateById(d);
+    OfflineJobDefinition definition = require(id);
+    resolveLogicalJobSpec(definition);
+    definition.setReleaseState("ONLINE");
+    definition.setUpdateTime(LocalDateTime.now());
+    return definitionRepository.update(definition);
   }
 
   @Transactional(transactionManager = "offlineSyncTransactionManager", rollbackFor = Exception.class)
   public boolean offline(Long id) {
-    OfflineJobDefinitionPO d = require(id);
+    OfflineJobDefinition definition = require(id);
     if (executionRepository.hasActiveExecution(id)) {
       throw new IllegalStateException("运行中的任务不能下线，请先停止任务");
     }
-    d.setReleaseState("OFFLINE");
-    d.setUpdateTime(LocalDateTime.now());
-    return definitionDao.updateById(d);
+    definition.setReleaseState("OFFLINE");
+    definition.setUpdateTime(LocalDateTime.now());
+    return definitionRepository.update(definition);
   }
 
   @Transactional(transactionManager = "offlineSyncTransactionManager", rollbackFor = Exception.class)
   public boolean delete(Long id) {
-    OfflineJobDefinitionPO d = require(id);
-    if ("ONLINE".equalsIgnoreCase(d.getReleaseState())) {
+    OfflineJobDefinition definition = require(id);
+    if ("ONLINE".equalsIgnoreCase(definition.getReleaseState())) {
       throw new IllegalStateException("已上线任务不能删除，请先下线");
     }
     if (executionRepository.hasActiveExecution(id)) {
       throw new IllegalStateException("运行中的任务不能删除");
     }
-    return definitionDao.deleteById(id);
+    return definitionRepository.delete(id);
   }
 
-  public OfflineJobDefinitionPO require(Long id) {
-    if (id == null || id <= 0) throw new IllegalArgumentException("任务定义 ID 不合法");
-    OfflineJobDefinitionPO d = definitionDao.selectById(id);
-    if (d == null) throw new IllegalArgumentException("离线同步任务不存在：" + id);
-    return d;
+  public OfflineJobDefinition require(Long id) {
+    if (id == null || id <= 0L) throw new IllegalArgumentException("任务定义 ID 不合法");
+    return definitionRepository.findById(id)
+        .orElseThrow(() -> new IllegalArgumentException("离线同步任务不存在：" + id));
   }
 
-  private void ensureEditable(OfflineJobDefinitionPO d) {
-    if (d == null) return;
-    if ("ONLINE".equalsIgnoreCase(d.getReleaseState())) {
+  private void ensureEditable(OfflineJobDefinition definition) {
+    if (definition == null) return;
+    if ("ONLINE".equalsIgnoreCase(definition.getReleaseState())) {
       throw new IllegalStateException("已上线任务不能修改，请先下线");
     }
-    if (OfflineExecutionStatus.isActive(d.getLastJobStatus())
-        || executionRepository.hasActiveExecution(d.getId())) {
+    if (OfflineExecutionStatus.isActive(definition.getLastJobStatus())
+        || executionRepository.hasActiveExecution(definition.getId())) {
       throw new IllegalStateException("运行中的任务不能修改");
     }
-  }
-
-  private Long id(DataSourcePO source) {
-    return source == null ? null : source.getId();
-  }
-
-  private String displayType(DataSourcePO source, String connectorId) {
-    return source != null && source.getDbType() != null ? source.getDbType().name() : connectorId;
   }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineJobDefinitionService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineJobDefinitionService.java
@@ -160,13 +160,18 @@ public class OfflineJobDefinitionService {
     return support.editDetail(require(id));
   }
 
+  /** 业务模块之间使用 Domain 分页，不经过 HTTP DTO/VO。 */
+  public OfflinePage<OfflineJobDefinition> pageDomain(OfflineDefinitionQuery query) {
+    return definitionRepository.page(query);
+  }
+
   public PagingData<OfflineJobDefinitionVO> page(OfflineJobDefinitionQueryDTO queryDTO) {
     OfflineJobDefinitionQueryDTO query = queryDTO == null ? new OfflineJobDefinitionQueryDTO() : queryDTO;
-    OfflinePage<OfflineJobDefinition> page = definitionRepository.page(
-        new OfflineDefinitionQuery(
-            query.getCurrent(), query.getPageSize(), query.getId(), query.getJobName(), query.getStatus(),
-            query.getSourceType(), query.getSinkType(), query.getSourceTable(), query.getSinkTable(),
-            query.getCreateTimeStart(), query.getCreateTimeEnd()));
+    OfflineDefinitionQuery domainQuery = new OfflineDefinitionQuery(
+        query.getCurrent(), query.getPageSize(), query.getId(), query.getJobName(), query.getStatus(),
+        query.getSourceType(), query.getSinkType(), query.getSourceTable(), query.getSinkTable(),
+        query.getCreateTimeStart(), query.getCreateTimeEnd());
+    OfflinePage<OfflineJobDefinition> page = definitionRepository.pageForView(domainQuery);
     List<OfflineJobDefinitionVO> records = page.records().stream().map(viewMapper::definition).toList();
     return new PagingData<>(
         records,

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineJobExecutionService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineJobExecutionService.java
@@ -5,11 +5,14 @@ import io.yak.framework.common.PagingData;
 import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
 import io.yak.ops.business.sync.offline.domain.OfflineJobDefinition;
 import io.yak.ops.business.sync.offline.domain.OfflineJobExecution;
+import io.yak.ops.business.sync.offline.engine.LinkUpClient;
 import io.yak.ops.business.sync.offline.engine.LinkUpClient.LinkUpJobResponse;
+import io.yak.ops.business.sync.offline.service.support.OfflineSyncViewMapper;
 import io.yak.ops.common.bean.dto.sync.offline.OfflineBatchOperationDTO;
 import io.yak.ops.common.bean.dto.sync.offline.OfflineJobExecutionQueryDTO;
 import io.yak.ops.common.bean.vo.sync.offline.OfflineBatchOperationErrorVO;
 import io.yak.ops.common.bean.vo.sync.offline.OfflineBatchOperationVO;
+import io.yak.ops.common.bean.vo.sync.offline.OfflineEngineHealthVO;
 import io.yak.ops.common.bean.vo.sync.offline.OfflineExecutionEventVO;
 import io.yak.ops.common.bean.vo.sync.offline.OfflineExecutionLogPageVO;
 import io.yak.ops.common.bean.vo.sync.offline.OfflineJobExecutionDetailVO;
@@ -28,6 +31,12 @@ public class OfflineJobExecutionService {
   private final OfflineExecutionReadService readService;
   private final OfflineExecutionLogService logService;
   private final OfflineJobDefinitionService definitionService;
+  private final LinkUpClient linkUpClient;
+  private final OfflineSyncViewMapper viewMapper;
+
+  public OfflineEngineHealthVO health() {
+    return viewMapper.engineHealth(linkUpClient.node());
+  }
 
   public OfflineJobExecutionVO execute(Long id) {
     return readService.toVO(orchestrator.execute(id, "MANUAL", null, 1));

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineJobExecutionService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineJobExecutionService.java
@@ -3,13 +3,14 @@ package io.yak.ops.business.sync.offline.service;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.yak.framework.common.PagingData;
 import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import io.yak.ops.business.sync.offline.domain.OfflineJobDefinition;
+import io.yak.ops.business.sync.offline.domain.OfflineJobExecution;
 import io.yak.ops.business.sync.offline.engine.LinkUpClient.LinkUpJobResponse;
 import io.yak.ops.common.bean.dto.sync.offline.OfflineBatchOperationDTO;
 import io.yak.ops.common.bean.dto.sync.offline.OfflineJobExecutionQueryDTO;
-import io.yak.ops.common.bean.po.sync.offline.OfflineJobDefinitionPO;
-import io.yak.ops.common.bean.po.sync.offline.OfflineJobExecutionPO;
 import io.yak.ops.common.bean.vo.sync.offline.OfflineBatchOperationErrorVO;
 import io.yak.ops.common.bean.vo.sync.offline.OfflineBatchOperationVO;
+import io.yak.ops.common.bean.vo.sync.offline.OfflineExecutionEventVO;
 import io.yak.ops.common.bean.vo.sync.offline.OfflineExecutionLogPageVO;
 import io.yak.ops.common.bean.vo.sync.offline.OfflineJobExecutionDetailVO;
 import io.yak.ops.common.bean.vo.sync.offline.OfflineJobExecutionVO;
@@ -29,8 +30,7 @@ public class OfflineJobExecutionService {
   private final OfflineJobDefinitionService definitionService;
 
   public OfflineJobExecutionVO execute(Long id) {
-    return readService.toVO(
-        orchestrator.execute(id, "MANUAL", null, 1));
+    return readService.toVO(orchestrator.execute(id, "MANUAL", null, 1));
   }
 
   /** 工作流按发布时固定的任务版本快照执行。 */
@@ -40,13 +40,7 @@ public class OfflineJobExecutionService {
       String configDigest,
       String definitionSnapshotJson,
       String logicalJobSpecJson) {
-    return executeSnapshot(
-        id,
-        version,
-        configDigest,
-        definitionSnapshotJson,
-        logicalJobSpecJson,
-        null);
+    return executeSnapshot(id, version, configDigest, definitionSnapshotJson, logicalJobSpecJson, null);
   }
 
   /** 工作流按发布快照和 Attempt 幂等键执行。 */
@@ -68,16 +62,14 @@ public class OfflineJobExecutionService {
   }
 
   public OfflineJobExecutionVO executeScheduled(Long id) {
-    return readService.toVO(
-        orchestrator.execute(id, "SCHEDULE", null, 1));
+    return readService.toVO(orchestrator.execute(id, "SCHEDULE", null, 1));
   }
 
   public OfflineJobExecutionVO retry(Long id) {
-    return readService.toVO(
-        orchestrator.retryFrom(readService.require(id)));
+    return readService.toVO(orchestrator.retryFrom(readService.require(id)));
   }
 
-  public OfflineJobExecutionVO retryFrom(OfflineJobExecutionPO previous) {
+  public OfflineJobExecutionVO retryFrom(OfflineJobExecution previous) {
     return readService.toVO(orchestrator.retryFrom(previous));
   }
 
@@ -86,7 +78,7 @@ public class OfflineJobExecutionService {
   }
 
   public OfflineJobExecutionVO cancelLatest(Long definitionId) {
-    OfflineJobDefinitionPO definition = definitionService.require(definitionId);
+    OfflineJobDefinition definition = definitionService.require(definitionId);
     if (definition.getLastExecutionId() == null) {
       throw new IllegalStateException("任务没有可停止的执行实例");
     }
@@ -101,8 +93,7 @@ public class OfflineJobExecutionService {
     return batch(request, false);
   }
 
-  public PagingData<OfflineJobExecutionVO> page(
-      OfflineJobExecutionQueryDTO query) {
+  public PagingData<OfflineJobExecutionVO> page(OfflineJobExecutionQueryDTO query) {
     return readService.page(query);
   }
 
@@ -114,37 +105,28 @@ public class OfflineJobExecutionService {
     return readService.tableMetrics(id);
   }
 
+  public List<OfflineExecutionEventVO> events(Long id) {
+    return readService.events(id);
+  }
+
   /** 旧文本接口保留，并直接渲染新的统一时间线。 */
   public String logs(Long id) {
     return logService.text(readService.require(id));
   }
 
-  public OfflineExecutionLogPageVO logs(
-      Long id,
-      String cursor,
-      int limit) {
-    return logService.logs(
-        readService.require(id),
-        cursor,
-        limit);
+  public OfflineExecutionLogPageVO logs(Long id, String cursor, int limit) {
+    return logService.logs(readService.require(id), cursor, limit);
   }
 
-  public void applySnapshot(
-      OfflineJobExecutionPO execution,
-      LinkUpJobResponse response,
-      String type) {
+  public void applySnapshot(OfflineJobExecution execution, LinkUpJobResponse response, String type) {
     orchestrator.applySnapshot(execution, response, type);
   }
 
-  public void markLost(
-      OfflineJobExecutionPO execution,
-      String message) {
+  public void markLost(OfflineJobExecution execution, String message) {
     orchestrator.markLost(execution, message);
   }
 
-  private OfflineBatchOperationVO batch(
-      OfflineBatchOperationDTO request,
-      boolean execute) {
+  private OfflineBatchOperationVO batch(OfflineBatchOperationDTO request, boolean execute) {
     if (request == null
         || request.getJobDefinitionIds() == null
         || request.getJobDefinitionIds().isEmpty()) {
@@ -155,14 +137,8 @@ public class OfflineJobExecutionService {
     List<OfflineBatchOperationErrorVO> errors = new ArrayList<>();
     for (Long id : request.getJobDefinitionIds()) {
       try {
-        if (id == null || id <= 0L) {
-          throw new IllegalArgumentException("任务定义 ID 不合法");
-        }
-        if (execute) {
-          execute(id);
-        } else {
-          cancelLatest(id);
-        }
+        if (id == null || id <= 0L) throw new IllegalArgumentException("任务定义 ID 不合法");
+        if (execute) execute(id); else cancelLatest(id);
         success++;
       } catch (RuntimeException exception) {
         errors.add(

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/support/OfflineScheduleSupport.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/support/OfflineScheduleSupport.java
@@ -1,0 +1,82 @@
+package io.yak.ops.business.sync.offline.service.support;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import io.yak.ops.business.sync.offline.domain.OfflineSchedule;
+import java.time.LocalDateTime;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.scheduling.support.CronExpression;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+/** 解析和校验任务级调度配置，不承担数据库访问。 */
+@ConditionalOnOfflineSyncEnabled
+@Component
+public class OfflineScheduleSupport {
+  private final ObjectMapper objectMapper;
+
+  public OfflineScheduleSupport(@Qualifier("offlineSyncJsonMapper") ObjectMapper objectMapper) {
+    this.objectMapper = objectMapper;
+  }
+
+  public OfflineSchedule prepare(Long definitionId, JsonNode schedule) {
+    String cron = firstText(schedule, "cron", "cronExpression");
+    boolean enabled = enabled(schedule, cron);
+    if (enabled && !StringUtils.hasText(cron)) {
+      throw new IllegalArgumentException("启用调度时必须填写 Cron 表达式");
+    }
+    if (StringUtils.hasText(cron)) CronExpression.parse(cron);
+    int attempts = Math.max(1, maxAttempts(schedule));
+    int backoff = Math.max(1, backoffSeconds(schedule));
+    LocalDateTime next = enabled ? CronExpression.parse(cron).next(LocalDateTime.now()) : null;
+    return new OfflineSchedule(
+        definitionId, cron, enabled, attempts, backoff, next, null, writeNullable(schedule));
+  }
+
+  private boolean enabled(JsonNode node, String cron) {
+    if (node == null || node.isNull()) return false;
+    if (node.hasNonNull("enabled")) return node.path("enabled").asBoolean(false);
+    String type = text(node, "scheduleRunType");
+    return StringUtils.hasText(type)
+        ? !"pause".equalsIgnoreCase(type) && !"paused".equalsIgnoreCase(type)
+        : StringUtils.hasText(cron);
+  }
+
+  private int maxAttempts(JsonNode node) {
+    if (node == null || node.isNull()) return 1;
+    if (node.hasNonNull("retryOnFailure")) return node.path("retryOnFailure").asBoolean() ? 2 : 1;
+    if (!node.path("autoRetry").asBoolean(true)) return 1;
+    int configured = node.path("retryPolicy").path("maxAttempts").asInt(0);
+    return configured > 0 ? configured : Math.max(1, node.path("retryTimes").asInt(0) + 1);
+  }
+
+  private int backoffSeconds(JsonNode node) {
+    if (node == null || node.isNull()) return 60;
+    int value = node.path("retryPolicy").path("backoffSeconds").asInt(0);
+    if (value > 0) return value;
+    value = node.path("retryIntervalSeconds").asInt(0);
+    if (value > 0) return value;
+    return Math.max(1, node.path("retryInterval").asInt(1)) * 60;
+  }
+
+  private String firstText(JsonNode node, String first, String second) {
+    String value = text(node, first);
+    return StringUtils.hasText(value) ? value : text(node, second);
+  }
+
+  private String text(JsonNode node, String field) {
+    if (node == null || !node.hasNonNull(field)) return null;
+    String value = node.path(field).asText(null);
+    return StringUtils.hasText(value) ? value.trim() : null;
+  }
+
+  private String writeNullable(JsonNode node) {
+    if (node == null || node.isNull()) return null;
+    try {
+      return objectMapper.writeValueAsString(node);
+    } catch (Exception exception) {
+      throw new IllegalStateException("序列化调度配置失败", exception);
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/support/OfflineSyncViewMapper.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/support/OfflineSyncViewMapper.java
@@ -3,6 +3,8 @@ package io.yak.ops.business.sync.offline.service.support;
 import io.yak.ops.business.sync.offline.domain.OfflineExecutionEvent;
 import io.yak.ops.business.sync.offline.domain.OfflineJobDefinition;
 import io.yak.ops.business.sync.offline.domain.OfflineJobExecution;
+import io.yak.ops.business.sync.offline.engine.LinkUpClient.LinkUpNodeResponse;
+import io.yak.ops.common.bean.vo.sync.offline.OfflineEngineHealthVO;
 import io.yak.ops.common.bean.vo.sync.offline.OfflineExecutionEventVO;
 import io.yak.ops.common.bean.vo.sync.offline.OfflineJobDefinitionVO;
 import io.yak.ops.common.bean.vo.sync.offline.OfflineJobExecutionVO;
@@ -101,6 +103,24 @@ public class OfflineSyncViewMapper {
         .message(event.getMessage())
         .payloadJson(event.getPayloadJson())
         .createTime(event.getCreateTime())
+        .build();
+  }
+
+  public OfflineEngineHealthVO engineHealth(LinkUpNodeResponse node) {
+    return OfflineEngineHealthVO.builder()
+        .nodeId(node.getNodeId())
+        .nodeName(node.getNodeName())
+        .instanceId(node.getInstanceId())
+        .version(node.getVersion())
+        .status(node.getStatus())
+        .startedAtMillis(node.getStartedAtMillis())
+        .offlineOnly(node.getOfflineOnly())
+        .maxConcurrentJobs(node.getMaxConcurrentJobs())
+        .maxQueuedJobs(node.getMaxQueuedJobs())
+        .runningJobs(node.getRunningJobs())
+        .queuedJobs(node.getQueuedJobs())
+        .activeJobs(node.getActiveJobs())
+        .lifecycle(node.getLifecycle())
         .build();
   }
 

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/support/OfflineSyncViewMapper.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/support/OfflineSyncViewMapper.java
@@ -1,0 +1,138 @@
+package io.yak.ops.business.sync.offline.service.support;
+
+import io.yak.ops.business.sync.offline.domain.OfflineExecutionEvent;
+import io.yak.ops.business.sync.offline.domain.OfflineJobDefinition;
+import io.yak.ops.business.sync.offline.domain.OfflineJobExecution;
+import io.yak.ops.common.bean.vo.sync.offline.OfflineExecutionEventVO;
+import io.yak.ops.common.bean.vo.sync.offline.OfflineJobDefinitionVO;
+import io.yak.ops.common.bean.vo.sync.offline.OfflineJobExecutionVO;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+import org.springframework.stereotype.Component;
+
+/** 纯输出模型转换；不访问数据库、不承担业务判断。 */
+@Component
+public class OfflineSyncViewMapper {
+  private static final DateTimeFormatter FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+  public OfflineJobDefinitionVO definition(OfflineJobDefinition d) {
+    boolean scheduled = Boolean.TRUE.equals(d.getScheduleEnabled());
+    return OfflineJobDefinitionVO.builder()
+        .id(d.getId())
+        .jobName(d.getJobName())
+        .jobDesc(d.getJobDesc())
+        .jobType("BATCH")
+        .mode(d.getMode())
+        .releaseState(d.getReleaseState())
+        .sourceType(d.getSourceType())
+        .sinkType(d.getSinkType())
+        .sourceDatasourceId(d.getSourceDatasourceId())
+        .sinkDatasourceId(d.getSinkDatasourceId())
+        .sourceDatasourceName(d.getSourceDatasourceName())
+        .sinkDatasourceName(d.getSinkDatasourceName())
+        .sourceTable(d.getSourceTable())
+        .sinkTable(d.getSinkTable())
+        .lastJobStatus(d.getLastJobStatus())
+        .lastErrorMessage(d.getLastErrorMessage())
+        .instanceId(d.getLastExecutionId())
+        .engineJobId(d.getLastEngineJobId())
+        .runMode(scheduled ? "SCHEDULE" : "MANUAL")
+        .duration(seconds(d.getLastDurationMillis()))
+        .readRowCount(value(d.getLastReadRowCount()))
+        .qps(value(d.getLastQps()))
+        .syncSize(formatBytes(d.getLastSyncBytes()))
+        .cronExpression(d.getCronExpression())
+        .scheduleStatus(scheduled ? "NORMAL" : "PAUSED")
+        .lastScheduleTime(format(d.getScheduleLastFireTime() == null ? d.getLastStartTime() : d.getScheduleLastFireTime()))
+        .nextScheduleTime(format(d.getScheduleNextFireTime()))
+        .createTime(format(d.getCreateTime()))
+        .updateTime(format(d.getUpdateTime()))
+        .build();
+  }
+
+  public OfflineJobExecutionVO execution(OfflineJobExecution execution) {
+    return OfflineJobExecutionVO.builder()
+        .id(execution.getId())
+        .jobDefinitionId(execution.getJobDefinitionId())
+        .definitionVersion(execution.getDefinitionVersion())
+        .engineBaseUrl(execution.getEngineBaseUrl())
+        .engineJobId(execution.getEngineJobId())
+        .externalExecutionId(execution.getExternalExecutionId())
+        .workerInstanceId(execution.getWorkerInstanceId())
+        .status(execution.getStatus())
+        .stateVersion(value(execution.getStateVersion()))
+        .attemptNo(value(execution.getAttemptNo()))
+        .triggerType(execution.getTriggerType())
+        .retryFromExecutionId(execution.getRetryFromExecutionId())
+        .cancellationRequested(Boolean.TRUE.equals(execution.getCancellationRequested()))
+        .errorMessage(execution.getErrorMessage())
+        .sourceRecordCount(value(execution.getSourceRecordCount()))
+        .sinkAttemptedRecordCount(value(execution.getSinkAttemptedRecordCount()))
+        .sinkSuccessRecordCount(value(execution.getSinkSuccessRecordCount()))
+        .sinkCommittedRecordCount(value(execution.getSinkCommittedRecordCount()))
+        .sourceReadBytes(value(execution.getSourceReadBytes()))
+        .sinkWrittenBytes(value(execution.getSinkWrittenBytes()))
+        .sourceAverageQps(value(execution.getSourceAverageQps()))
+        .sinkAverageQps(value(execution.getSinkAverageQps()))
+        .failedRecordCount(value(execution.getFailedRecordCount()))
+        .skippedRecordCount(value(execution.getSkippedRecordCount()))
+        .databaseCommitMillis(value(execution.getDatabaseCommitMillis()))
+        .sqlExecutionMillis(value(execution.getSqlExecutionMillis()))
+        .qps(value(execution.getQps()))
+        .durationMillis(value(execution.getDurationMillis()))
+        .createTime(format(execution.getCreateTime()))
+        .startTime(format(execution.getStartTime()))
+        .endTime(format(execution.getEndTime()))
+        .nextRetryTime(format(execution.getNextRetryTime()))
+        .lastSyncTime(format(execution.getLastSyncTime()))
+        .updateTime(format(execution.getUpdateTime()))
+        .build();
+  }
+
+  public OfflineExecutionEventVO event(OfflineExecutionEvent event) {
+    return OfflineExecutionEventVO.builder()
+        .id(event.getId())
+        .executionId(event.getExecutionId())
+        .stateVersion(event.getStateVersion())
+        .fromStatus(event.getFromStatus())
+        .toStatus(event.getToStatus())
+        .eventType(event.getEventType())
+        .message(event.getMessage())
+        .payloadJson(event.getPayloadJson())
+        .createTime(event.getCreateTime())
+        .build();
+  }
+
+  private String format(LocalDateTime value) {
+    return value == null ? null : value.format(FORMAT);
+  }
+
+  private long seconds(Long millis) {
+    return millis == null ? 0L : Math.max(0L, millis / 1000L);
+  }
+
+  private long value(Long value) {
+    return value == null ? 0L : value;
+  }
+
+  private int value(Integer value) {
+    return value == null ? 0 : value;
+  }
+
+  private double value(Double value) {
+    return value == null ? 0D : value;
+  }
+
+  private String formatBytes(Long bytes) {
+    if (bytes == null || bytes <= 0L) return "-";
+    double size = bytes;
+    String[] units = {"B", "KB", "MB", "GB", "TB"};
+    int unit = 0;
+    while (size >= 1024D && unit < units.length - 1) {
+      size /= 1024D;
+      unit++;
+    }
+    return String.format(Locale.ROOT, "%.2f %s", size, units[unit]);
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/resources/mapper/offline/OfflineWriteMapper.xml
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/resources/mapper/offline/OfflineWriteMapper.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="io.yak.ops.business.sync.offline.dao.mapper.OfflineWriteMapper">
+  <select id="lockDefinition" resultType="long">
+    SELECT id
+    FROM yak_offline_job_definition
+    WHERE id = #{id}
+    FOR UPDATE
+  </select>
+</mapper>

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/architecture/OfflineSyncLayeringConventionTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/architecture/OfflineSyncLayeringConventionTest.java
@@ -1,0 +1,90 @@
+package io.yak.ops.business.sync.offline.architecture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.baomidou.mybatisplus.annotation.TableName;
+import io.yak.ops.business.sync.offline.dao.OfflineExecutionEventDao;
+import io.yak.ops.business.sync.offline.dao.OfflineJobDefinitionDao;
+import io.yak.ops.business.sync.offline.dao.OfflineJobExecutionDao;
+import io.yak.ops.business.sync.offline.repository.OfflineExecutionControlRepository;
+import io.yak.ops.business.sync.offline.repository.OfflineExecutionEventRepository;
+import io.yak.ops.business.sync.offline.repository.OfflineExecutionIdempotencyRepository;
+import io.yak.ops.business.sync.offline.repository.OfflineJobDefinitionRepository;
+import io.yak.ops.business.sync.offline.repository.OfflineJobExecutionRepository;
+import io.yak.ops.business.sync.offline.repository.OfflineScheduleRepository;
+import io.yak.ops.common.bean.po.sync.offline.OfflineExecutionEventPO;
+import io.yak.ops.common.bean.po.sync.offline.OfflineJobDefinitionPO;
+import io.yak.ops.common.bean.po.sync.offline.OfflineJobExecutionPO;
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class OfflineSyncLayeringConventionTest {
+
+  @Test
+  void repositoriesExposeOnlyDomainContracts() {
+    for (Class<?> type : List.of(
+        OfflineJobDefinitionRepository.class,
+        OfflineJobExecutionRepository.class,
+        OfflineExecutionEventRepository.class,
+        OfflineScheduleRepository.class,
+        OfflineExecutionControlRepository.class,
+        OfflineExecutionIdempotencyRepository.class)) {
+      assertMethodsAvoid(type, ".bean.dto.", ".bean.vo.", ".bean.po.");
+    }
+  }
+
+  @Test
+  void daosDoNotDependOnTransportModels() {
+    for (Class<?> type : List.of(
+        OfflineJobDefinitionDao.class,
+        OfflineJobExecutionDao.class,
+        OfflineExecutionEventDao.class)) {
+      assertMethodsAvoid(type, ".bean.dto.", ".bean.vo.");
+    }
+  }
+
+  @Test
+  void phaseOnePersistenceRemainsThreeTables() {
+    assertTable(OfflineJobDefinitionPO.class, "yak_offline_job_definition");
+    assertTable(OfflineJobExecutionPO.class, "yak_offline_job_execution");
+    assertTable(OfflineExecutionEventPO.class, "yak_offline_execution_event");
+  }
+
+  private void assertMethodsAvoid(Class<?> owner, String... forbidden) {
+    for (Method method : owner.getMethods()) {
+      assertTypeAvoids(owner, method, method.getGenericReturnType(), forbidden);
+      for (Type parameter : method.getGenericParameterTypes()) {
+        assertTypeAvoids(owner, method, parameter, forbidden);
+      }
+    }
+  }
+
+  private void assertTypeAvoids(Class<?> owner, Method method, Type type, String... forbidden) {
+    String signature = typeName(type);
+    for (String packagePart : forbidden) {
+      assertThat(signature)
+          .as("%s.%s must not expose %s", owner.getSimpleName(), method.getName(), packagePart)
+          .doesNotContain(packagePart);
+    }
+  }
+
+  private String typeName(Type type) {
+    if (type instanceof ParameterizedType parameterized) {
+      StringBuilder value = new StringBuilder(parameterized.getRawType().getTypeName());
+      for (Type argument : parameterized.getActualTypeArguments()) {
+        value.append('<').append(typeName(argument)).append('>');
+      }
+      return value.toString();
+    }
+    return type.getTypeName();
+  }
+
+  private void assertTable(Class<?> poType, String tableName) {
+    TableName mapping = poType.getAnnotation(TableName.class);
+    assertThat(mapping).as(poType.getSimpleName() + " must declare @TableName").isNotNull();
+    assertThat(mapping.value()).isEqualTo(tableName);
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/architecture/OfflineSyncLayeringConventionTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/architecture/OfflineSyncLayeringConventionTest.java
@@ -3,6 +3,9 @@ package io.yak.ops.business.sync.offline.architecture;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.baomidou.mybatisplus.annotation.TableName;
+import io.yak.ops.business.sync.offline.controller.OfflineControlPlaneController;
+import io.yak.ops.business.sync.offline.controller.OfflineJobDefinitionController;
+import io.yak.ops.business.sync.offline.controller.OfflineJobExecutionController;
 import io.yak.ops.business.sync.offline.dao.OfflineExecutionEventDao;
 import io.yak.ops.business.sync.offline.dao.OfflineJobDefinitionDao;
 import io.yak.ops.business.sync.offline.dao.OfflineJobExecutionDao;
@@ -15,6 +18,7 @@ import io.yak.ops.business.sync.offline.repository.OfflineScheduleRepository;
 import io.yak.ops.common.bean.po.sync.offline.OfflineExecutionEventPO;
 import io.yak.ops.common.bean.po.sync.offline.OfflineJobDefinitionPO;
 import io.yak.ops.common.bean.po.sync.offline.OfflineJobExecutionPO;
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
@@ -22,6 +26,23 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class OfflineSyncLayeringConventionTest {
+
+  @Test
+  void controllersDependOnServicesInsteadOfPersistenceOrEngineClients() {
+    for (Class<?> type : List.of(
+        OfflineJobDefinitionController.class,
+        OfflineJobExecutionController.class,
+        OfflineControlPlaneController.class)) {
+      for (Field field : type.getDeclaredFields()) {
+        String dependency = field.getType().getName();
+        assertThat(dependency)
+            .as("%s.%s must not bypass Service", type.getSimpleName(), field.getName())
+            .doesNotContain(".repository.")
+            .doesNotContain(".dao.")
+            .doesNotContain(".engine.");
+      }
+    }
+  }
 
   @Test
   void repositoriesExposeOnlyDomainContracts() {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/repository/OfflineJobDefinitionRepositoryAdapterTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/repository/OfflineJobDefinitionRepositoryAdapterTest.java
@@ -1,0 +1,68 @@
+package io.yak.ops.business.sync.offline.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.datasource.dao.DataSourceDao;
+import io.yak.ops.business.sync.offline.dao.OfflineJobDefinitionDao;
+import io.yak.ops.business.sync.offline.domain.OfflineJobDefinition;
+import io.yak.ops.common.bean.po.datasource.DataSourcePO;
+import io.yak.ops.common.bean.po.sync.offline.OfflineJobDefinitionPO;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class OfflineJobDefinitionRepositoryAdapterTest {
+
+  @Mock private OfflineJobDefinitionDao dao;
+  @Mock private DataSourceDao dataSourceDao;
+
+  @Test
+  void runtimeReadDoesNotLoadDatasourceDisplayMetadata() {
+    OfflineJobDefinitionPO po = definition();
+    when(dao.selectById(42L)).thenReturn(po);
+
+    OfflineJobDefinition result =
+        new OfflineJobDefinitionRepositoryAdapter(dao, dataSourceDao)
+            .findById(42L)
+            .orElseThrow();
+
+    assertThat(result.getSourceDatasourceName()).isNull();
+    assertThat(result.getSinkDatasourceName()).isNull();
+    verifyNoInteractions(dataSourceDao);
+  }
+
+  @Test
+  void displayReadEnrichesDatasourceNames() {
+    OfflineJobDefinitionPO po = definition();
+    DataSourcePO source = new DataSourcePO();
+    source.setId(1L);
+    source.setName("source-mysql");
+    DataSourcePO sink = new DataSourcePO();
+    sink.setId(2L);
+    sink.setName("sink-mysql");
+    when(dao.selectById(42L)).thenReturn(po);
+    when(dataSourceDao.selectById(1L)).thenReturn(source);
+    when(dataSourceDao.selectById(2L)).thenReturn(sink);
+
+    OfflineJobDefinition result =
+        new OfflineJobDefinitionRepositoryAdapter(dao, dataSourceDao)
+            .findForViewById(42L)
+            .orElseThrow();
+
+    assertThat(result.getSourceDatasourceName()).isEqualTo("source-mysql");
+    assertThat(result.getSinkDatasourceName()).isEqualTo("sink-mysql");
+  }
+
+  private OfflineJobDefinitionPO definition() {
+    OfflineJobDefinitionPO po = new OfflineJobDefinitionPO();
+    po.setId(42L);
+    po.setJobName("demo");
+    po.setSourceDatasourceId(1L);
+    po.setSinkDatasourceId(2L);
+    return po;
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/repository/OfflineScheduleRepositoryAdapterTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/repository/OfflineScheduleRepositoryAdapterTest.java
@@ -1,0 +1,66 @@
+package io.yak.ops.business.sync.offline.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.sync.offline.dao.OfflineJobDefinitionDao;
+import io.yak.ops.business.sync.offline.domain.OfflineSchedule;
+import io.yak.ops.common.bean.po.sync.offline.OfflineJobDefinitionPO;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class OfflineScheduleRepositoryAdapterTest {
+
+  @Mock private OfflineJobDefinitionDao dao;
+
+  @Test
+  void saveScheduleUsesScopedUpdateAndPreservesLastFireHistory() {
+    OfflineScheduleRepositoryAdapter repository = new OfflineScheduleRepositoryAdapter(dao);
+    LocalDateTime previousLastFire = LocalDateTime.of(2026, 8, 8, 9, 0);
+    LocalDateTime nextFire = LocalDateTime.of(2026, 8, 10, 9, 0);
+
+    OfflineJobDefinitionPO stored = new OfflineJobDefinitionPO();
+    stored.setId(42L);
+    stored.setCronExpression("0 0 9 * * ?");
+    stored.setScheduleEnabled(true);
+    stored.setRetryMaxAttempts(3);
+    stored.setRetryBackoffSeconds(60);
+    stored.setScheduleLastFireTime(previousLastFire);
+    stored.setScheduleNextFireTime(nextFire);
+    stored.setScheduleJson("{\"enabled\":true}");
+
+    when(dao.updateSchedule(
+            eq(42L),
+            eq("{\"enabled\":true}"),
+            eq(true),
+            eq("0 0 9 * * ?"),
+            eq(3),
+            eq(60),
+            eq(nextFire),
+            any(LocalDateTime.class)))
+        .thenReturn(true);
+    when(dao.selectById(42L)).thenReturn(stored);
+
+    OfflineSchedule result = repository.saveSchedule(
+        new OfflineSchedule(
+            42L,
+            "0 0 9 * * ?",
+            true,
+            3,
+            60,
+            nextFire,
+            null,
+            "{\"enabled\":true}"));
+
+    assertThat(result.lastFireTime()).isEqualTo(previousLastFire);
+    verify(dao, never()).updateById(any(OfflineJobDefinitionPO.class));
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/service/OfflineExecutionClaimServiceTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/service/OfflineExecutionClaimServiceTest.java
@@ -7,12 +7,11 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.yak.ops.business.sync.offline.config.OfflineSyncProperties;
-import io.yak.ops.business.sync.offline.dao.OfflineJobExecutionDao;
-import io.yak.ops.business.sync.offline.repository.OfflineExecutionControlRepository;
-import io.yak.ops.business.sync.offline.repository.OfflineExecutionIdempotencyRepository;
+import io.yak.ops.business.sync.offline.domain.OfflineJobDefinition;
+import io.yak.ops.business.sync.offline.domain.OfflineJobExecution;
+import io.yak.ops.business.sync.offline.repository.OfflineJobDefinitionRepository;
+import io.yak.ops.business.sync.offline.repository.OfflineJobExecutionRepository;
 import io.yak.ops.business.sync.offline.service.OfflineExecutionClaimService.ClaimResult;
-import io.yak.ops.common.bean.po.sync.offline.OfflineJobDefinitionPO;
-import io.yak.ops.common.bean.po.sync.offline.OfflineJobExecutionPO;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -24,9 +23,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class OfflineExecutionClaimServiceTest {
 
   @Mock private OfflineJobDefinitionService definitionService;
-  @Mock private OfflineJobExecutionDao executionDao;
-  @Mock private OfflineExecutionControlRepository repository;
-  @Mock private OfflineExecutionIdempotencyRepository idempotencyRepository;
+  @Mock private OfflineJobDefinitionRepository definitionRepository;
+  @Mock private OfflineJobExecutionRepository executionRepository;
 
   private OfflineExecutionClaimService service;
 
@@ -34,15 +32,14 @@ class OfflineExecutionClaimServiceTest {
   void setUp() {
     service = new OfflineExecutionClaimService(
         definitionService,
-        executionDao,
-        repository,
-        idempotencyRepository,
+        definitionRepository,
+        executionRepository,
         new OfflineSyncProperties());
   }
 
   @Test
   void shouldPersistCreatedExecutionBeforeAnyEngineProbe() {
-    OfflineJobDefinitionPO definition = new OfflineJobDefinitionPO();
+    OfflineJobDefinition definition = new OfflineJobDefinition();
     definition.setId(10L);
     definition.setReleaseState("ONLINE");
     definition.setVersion(3);
@@ -51,9 +48,9 @@ class OfflineExecutionClaimServiceTest {
 
     when(definitionService.require(10L)).thenReturn(definition);
     when(definitionService.resolveLogicalJobSpec(definition)).thenReturn("{\"job\":\"spec\"}");
-    when(executionDao.insert(any(OfflineJobExecutionPO.class)))
+    when(executionRepository.insert(any(OfflineJobExecution.class)))
         .thenAnswer(invocation -> {
-          OfflineJobExecutionPO execution = invocation.getArgument(0);
+          OfflineJobExecution execution = invocation.getArgument(0);
           execution.setId(99L);
           return true;
         });
@@ -64,21 +61,20 @@ class OfflineExecutionClaimServiceTest {
     assertThat(result.getExecution().getStatus()).isEqualTo("CREATED");
     assertThat(result.getExecution().getWorkerInstanceId()).isNull();
     assertThat(result.getExecution().getEngineBaseUrl()).isEqualTo("http://127.0.0.1:18080");
-    verify(repository).lockDefinition(10L);
-    verify(repository).hasActiveExecution(10L);
-    verify(executionDao).insert(result.getExecution());
+    verify(definitionRepository).lock(10L);
+    verify(executionRepository).hasActiveExecution(10L);
+    verify(executionRepository).insert(result.getExecution());
   }
 
   @Test
   void shouldPersistWorkflowAttemptAsSnapshotIdempotencyKey() {
-    OfflineJobDefinitionPO definition = new OfflineJobDefinitionPO();
+    OfflineJobDefinition definition = new OfflineJobDefinition();
     definition.setId(10L);
-
     when(definitionService.require(10L)).thenReturn(definition);
-    when(idempotencyRepository.findByKey("attempt-123")).thenReturn(Optional.empty());
-    when(executionDao.insert(any(OfflineJobExecutionPO.class)))
+    when(executionRepository.findByIdempotencyKey("attempt-123")).thenReturn(Optional.empty());
+    when(executionRepository.insert(any(OfflineJobExecution.class)))
         .thenAnswer(invocation -> {
-          OfflineJobExecutionPO execution = invocation.getArgument(0);
+          OfflineJobExecution execution = invocation.getArgument(0);
           execution.setId(100L);
           return true;
         });
@@ -95,18 +91,18 @@ class OfflineExecutionClaimServiceTest {
     assertThat(result.getExecution().getIdempotencyKey()).isEqualTo("attempt-123");
     assertThat(result.getExecution().getTriggerType()).isEqualTo("WORKFLOW");
     assertThat(result.isReused()).isFalse();
-    verify(repository).lockDefinition(10L);
-    verify(repository).hasActiveExecution(10L);
-    verify(executionDao).insert(result.getExecution());
+    verify(definitionRepository).lock(10L);
+    verify(executionRepository).hasActiveExecution(10L);
+    verify(executionRepository).insert(result.getExecution());
   }
 
   @Test
   void shouldReuseSameWorkflowAttemptInsteadOfCreatingAnotherOfflineExecution() {
-    OfflineJobDefinitionPO definition = new OfflineJobDefinitionPO();
+    OfflineJobDefinition definition = new OfflineJobDefinition();
     definition.setId(10L);
     when(definitionService.require(10L)).thenReturn(definition);
 
-    OfflineJobExecutionPO existing = new OfflineJobExecutionPO();
+    OfflineJobExecution existing = new OfflineJobExecution();
     existing.setId(101L);
     existing.setJobDefinitionId(10L);
     existing.setDefinitionVersion(3);
@@ -115,7 +111,7 @@ class OfflineExecutionClaimServiceTest {
     existing.setSubmittedConfig("{\"job\":\"spec\"}");
     existing.setIdempotencyKey("attempt-123");
     existing.setStatus("SUBMITTED");
-    when(idempotencyRepository.findByKey("attempt-123"))
+    when(executionRepository.findByIdempotencyKey("attempt-123"))
         .thenReturn(Optional.of(existing));
 
     ClaimResult result = service.claimSnapshot(
@@ -129,8 +125,8 @@ class OfflineExecutionClaimServiceTest {
 
     assertThat(result.getExecution()).isSameAs(existing);
     assertThat(result.isReused()).isTrue();
-    verify(repository).lockDefinition(10L);
-    verify(repository, never()).hasActiveExecution(10L);
-    verify(executionDao, never()).insert(any(OfflineJobExecutionPO.class));
+    verify(definitionRepository).lock(10L);
+    verify(executionRepository, never()).hasActiveExecution(10L);
+    verify(executionRepository, never()).insert(any(OfflineJobExecution.class));
   }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/service/support/OfflineSyncViewMapperTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/service/support/OfflineSyncViewMapperTest.java
@@ -1,0 +1,45 @@
+package io.yak.ops.business.sync.offline.service.support;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.sync.offline.engine.LinkUpClient.LinkUpNodeResponse;
+import io.yak.ops.common.bean.vo.sync.offline.OfflineEngineHealthVO;
+import org.junit.jupiter.api.Test;
+
+class OfflineSyncViewMapperTest {
+
+  @Test
+  void engineHealthKeepsLinkUpResponseFields() {
+    LinkUpNodeResponse node = new LinkUpNodeResponse();
+    node.setNodeId("node-1");
+    node.setNodeName("link-up");
+    node.setInstanceId("instance-1");
+    node.setVersion("1.0.0");
+    node.setStatus("UP");
+    node.setStartedAtMillis(1000L);
+    node.setOfflineOnly(true);
+    node.setMaxConcurrentJobs(4);
+    node.setMaxQueuedJobs(20);
+    node.setRunningJobs(2);
+    node.setQueuedJobs(3);
+    node.setActiveJobs(5);
+    node.setLifecycle(new ObjectMapper().createObjectNode().put("phase", "READY"));
+
+    OfflineEngineHealthVO result = new OfflineSyncViewMapper().engineHealth(node);
+
+    assertThat(result.getNodeId()).isEqualTo("node-1");
+    assertThat(result.getNodeName()).isEqualTo("link-up");
+    assertThat(result.getInstanceId()).isEqualTo("instance-1");
+    assertThat(result.getVersion()).isEqualTo("1.0.0");
+    assertThat(result.getStatus()).isEqualTo("UP");
+    assertThat(result.getStartedAtMillis()).isEqualTo(1000L);
+    assertThat(result.getOfflineOnly()).isTrue();
+    assertThat(result.getMaxConcurrentJobs()).isEqualTo(4);
+    assertThat(result.getMaxQueuedJobs()).isEqualTo(20);
+    assertThat(result.getRunningJobs()).isEqualTo(2);
+    assertThat(result.getQueuedJobs()).isEqualTo(3);
+    assertThat(result.getActiveJobs()).isEqualTo(5);
+    assertThat(result.getLifecycle().path("phase").asText()).isEqualTo("READY");
+  }
+}

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/sync/offline/OfflineExecutionEventPO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/sync/offline/OfflineExecutionEventPO.java
@@ -1,0 +1,23 @@
+package io.yak.ops.common.bean.po.sync.offline;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import java.time.LocalDateTime;
+import lombok.Data;
+
+/** 离线同步执行状态事件。 */
+@Data
+@TableName("yak_offline_execution_event")
+public class OfflineExecutionEventPO {
+  @TableId(type = IdType.AUTO)
+  private Long id;
+  private Long executionId;
+  private Long stateVersion;
+  private String fromStatus;
+  private String toStatus;
+  private String eventType;
+  private String message;
+  private String payloadJson;
+  private LocalDateTime createTime;
+}

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/vo/sync/offline/OfflineEngineHealthVO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/vo/sync/offline/OfflineEngineHealthVO.java
@@ -1,0 +1,28 @@
+package io.yak.ops.common.bean.vo.sync.offline;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/** Link-Up 固定执行引擎健康状态响应。 */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class OfflineEngineHealthVO {
+  private String nodeId;
+  private String nodeName;
+  private String instanceId;
+  private String version;
+  private String status;
+  private Long startedAtMillis;
+  private Boolean offlineOnly;
+  private Integer maxConcurrentJobs;
+  private Integer maxQueuedJobs;
+  private Integer runningJobs;
+  private Integer queuedJobs;
+  private Integer activeJobs;
+  private JsonNode lifecycle;
+}

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/vo/sync/offline/OfflineExecutionEventVO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/vo/sync/offline/OfflineExecutionEventVO.java
@@ -1,0 +1,24 @@
+package io.yak.ops.common.bean.vo.sync.offline;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/** 离线同步执行状态事件响应。 */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class OfflineExecutionEventVO {
+  private Long id;
+  private Long executionId;
+  private Long stateVersion;
+  private String fromStatus;
+  private String toStatus;
+  private String eventType;
+  private String message;
+  private String payloadJson;
+  private LocalDateTime createTime;
+}


### PR DESCRIPTION
## Summary

Standardize the first-phase offline-sync module with the same backend layering conventions now used by Workflow and Data Quality:

`Controller -> DTO -> Service -> Domain -> Repository -> Adapter -> DAO -> BaseMapper/XML -> PO -> MySQL`

The module intentionally remains the small three-table fixed-Link-Up control plane. This PR is an engineering-structure refactor, not a feature expansion.

## 1. Domain and repository boundaries

Add business models for job definition, execution instance, execution event, schedule projection, definition/execution queries and framework-neutral paging.

Repository contracts and adapters now isolate persistence from business runtime. Services and orchestration no longer operate directly on MyBatis PO/DAO objects.

Definition reads explicitly distinguish three use cases:
- `findById()` / `page()` are runtime/business Domain reads and do not load datasource display metadata;
- `findForViewById()` / `pageForView()` enrich datasource names only for HTTP response views;
- `OfflineJobDefinitionService.pageDomain()` gives other business modules a Domain-to-Domain API without routing through HTTP DTO/VO.

This prevents execution reconciliation and workflow task discovery from performing unrelated presentation queries.

## 2. Remove HTTP DTOs from DAO and cross-business calls

`OfflineJobDefinitionDao` and `OfflineJobExecutionDao` now use DAO-local query records rather than HTTP DTOs.

The Workflow/Job task registry now consumes `OfflineDefinitionQuery -> OfflinePage<OfflineJobDefinition>` directly. It no longer creates `OfflineJobDefinitionQueryDTO`, consumes `OfflineJobDefinitionVO`, or touches `OfflineJobDefinitionPO`. Before building an immutable workflow task snapshot it still re-reads the current Domain by ID, preserving the previous freshness behavior.

## 3. Remove handwritten JDBC as the fact source

The old execution-control, idempotency and schedule persistence code no longer owns JdbcTemplate SQL. Persistence is backed by MyBatis-Plus DAOs and repository adapters.

The two old execution lookup/control classes are temporarily retained only as deprecated Domain-only compatibility facades because repository-file deletion was not available through the current GitHub safety path. They contain no JDBC and are no longer used by the primary runtime path.

## 4. Three tables remain three tables

No Flyway migration or schema change is introduced:
1. `yak_offline_job_definition`
2. `yak_offline_job_execution`
3. `yak_offline_execution_event`

The existing event table now has a standard `OfflineExecutionEventPO` and `BaseMapper`.

## 5. Simple CRUD vs atomic SQL

- normal single-table operations use MyBatis-Plus BaseMapper/LambdaWrapper;
- definition row locking uses `OfflineWriteMapper.xml` with `SELECT ... FOR UPDATE`;
- schedule persistence uses scoped LambdaUpdate operations rather than a partial PO `updateById`.

This is important because several `OfflineJobDefinitionPO` fields use `FieldStrategy.ALWAYS`; updating with a partial PO could otherwise clear unrelated JobSpec, datasource and runtime columns to NULL.

Schedule save/edit also preserves existing `schedule_last_fire_time`, matching the old behavior. Last-fire history is cleared only when the schedule itself is explicitly removed.

## 6. Runtime semantics preserved

`OfflineExecutionClaimService`, `OfflineExecutionOrchestrator`, read service, merged log service and reconciler now operate on Domain objects and repositories while preserving:
- durable local execution creation before Link-Up submission;
- workflow Attempt idempotency reuse;
- active-execution fencing;
- fixed Link-Up base URL behavior;
- uncertain-submit handling;
- retry/backoff rules;
- LOST detection and reconciliation;
- cancellation convergence;
- persisted execution events and merged Link-Up logs.

## 7. Controller and Link-Up protocol boundaries

Core offline-sync controllers enter business logic only through Services.

The engine health endpoint no longer injects `LinkUpClient` or returns `LinkUpNodeResponse` directly. `OfflineJobExecutionService` maps it to `OfflineEngineHealthVO` with the same JSON fields, keeping the external contract unchanged while Link-Up protocol models stay internal.

The execution-event endpoint likewise routes through Service and returns `OfflineExecutionEventVO` rather than a repository record.

## 8. Schedule integration

Yak Schedule consumes the `OfflineSchedule` Domain model rather than a JDBC repository nested record. Existing namespace, key, handler, payload, cron, timezone, FORBID concurrency, FIRE_ONCE_NOW and business retry semantics remain unchanged.

## 9. Output mapping

`OfflineSyncViewMapper` centralizes Domain/protocol -> VO conversion and performs no database access.

## 10. Java level

Remove the module-local Maven compiler override that forced source/target 8. Offline sync now inherits the Yak Ops project Java level.

## 11. Architecture and regression coverage

Coverage now protects:
- Repository APIs from DTO/VO/PO leakage;
- DAO APIs from DTO/VO leakage;
- Controllers from bypassing Service into Repository/DAO/engine clients;
- the intentional three-table persistence boundary;
- workflow Attempt idempotency reuse;
- schedule registrar Domain integration;
- scoped schedule updates without partial-PO overwrite;
- preservation of lastFireTime when editing a schedule;
- runtime and Domain-page reads avoiding datasource display queries;
- display reads enriching datasource names;
- Link-Up health VO field compatibility;
- workflow task eligibility using the Domain model.

The module README now records these layering rules for future changes.

## Scope intentionally unchanged

- no new tables or Flyway changes
- no multi-worker scheduling
- no connector capability/preflight infrastructure
- no Link-Up protocol changes
- no execution state-machine changes
- no API route changes
- no frontend changes
- no scheduler/retry semantic changes

## Validation

- branch is based on current `main` and is 0 commits behind;
- final PR patch scan shows no new `org.springframework.jdbc` imports;
- final patch scan shows no new offline HTTP DTO imports in the persistence changes;
- offline PO imports are confined to DAO/Adapter/tests where persistence types belong;
- Link-Up engine imports are confined to Service/Support/tests, not Controllers;
- no GitHub Actions workflow runs or commit statuses are configured for the current head;
- the available container cannot resolve `github.com`, so a full local Maven/MySQL reactor build could not be executed here.

The PR therefore remains Draft pending the normal local/CI Maven tests plus startup/Flyway validation.