### PR TITLE
refactor(datasource): standardize domain and persistence boundaries

### DIFF
--- a/yak-ops-business/yak-ops-business-datasource/README.md
+++ b/yak-ops-business/yak-ops-business-datasource/README.md
@@ -1,0 +1,37 @@
+# Yak Ops Datasource
+
+数据源模块负责数据源注册、连接测试、Catalog 元数据访问和数据源插件配置。
+
+## 工程分层
+
+```text
+Controller -> DTO -> Service -> Domain
+           -> Repository -> Adapter -> DAO
+           -> BaseMapper / Mapper XML -> PO -> MySQL
+
+Domain -> View Mapper -> VO -> Controller
+
+Service -> Datasource Plugin SPI
+Catalog Service -> Domain Repository -> Datasource Plugin SPI
+```
+
+约束：
+
+- Controller 只通过 Service 进入业务链路，不直接依赖 Repository、DAO、Mapper 或插件实现。
+- Service 与 Catalog Service 使用 `DataSourceDefinition` 等 Domain，不直接操作 MyBatis PO。
+- Repository 接口只暴露 Domain；PO 仅存在于 Adapter / DAO / Mapper 持久化层。
+- DAO 不接收 HTTP DTO，也不返回 HTTP VO；DAO 查询使用自己的 Query/Row 投影。
+- 普通单表 CRUD 使用 MyBatis-Plus；统计等自定义 SQL 放在 `mapper/datasource/*.xml`。
+- `connectionParams`、`originalJson` 可以存在于内部 Domain，用于插件执行和密钥复用，但不得直接作为 HTTP 响应输出。
+- HTTP 详情必须通过 `DataSourceViewMapper` 和 `DataSourceSecretCodec` 做连接地址与连接 JSON 脱敏。
+- Catalog 读取使用 Repository 加载 Domain，再交给 Datasource Plugin SPI；Catalog 不直接访问 DAO/PO。
+
+## 持久化
+
+当前数据源管理只维护一张业务表：
+
+```text
+yak_ops_data_source
+```
+
+业务模块共享 `yak.database` 对应的 `yakBusinessDataSource`、MyBatis SessionFactory 和事务管理器；数据源模块继续拥有自己的 Flyway migration location/history 边界。

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/dao/DataSourceDao.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/dao/DataSourceDao.java
@@ -1,14 +1,14 @@
 package io.yak.ops.business.datasource.dao;
 
 import com.baomidou.mybatisplus.core.metadata.IPage;
-import io.yak.ops.common.bean.dto.datasource.DataSourceQueryDTO;
+import io.yak.ops.business.datasource.dao.model.DataSourceSummaryRow;
 import io.yak.ops.common.bean.po.datasource.DataSourcePO;
-import io.yak.ops.common.bean.vo.datasource.DataSourceSummaryVO;
 import io.yak.ops.common.enums.datasource.DataSourceConnStatus;
 import io.yak.ops.common.enums.datasource.DataSourceDbType;
+import io.yak.ops.common.enums.datasource.DataSourceEnvironment;
 import java.util.List;
 
-/** 数据源数据访问接口。 */
+/** 数据源数据访问接口，只暴露持久化模型和 DAO 查询条件。 */
 public interface DataSourceDao {
 
   int addDataSource(DataSourcePO dataSourcePO);
@@ -17,9 +17,9 @@ public interface DataSourceDao {
 
   DataSourcePO selectById(Long id);
 
-  IPage<DataSourcePO> selectPage(DataSourceQueryDTO queryDTO);
+  IPage<DataSourcePO> selectPage(PageQuery query);
 
-  DataSourceSummaryVO selectSummary();
+  DataSourceSummaryRow selectSummary();
 
   List<DataSourcePO> selectAll(DataSourceDbType dbType);
 
@@ -28,4 +28,14 @@ public interface DataSourceDao {
   boolean deleteById(Long id);
 
   boolean updateConnectionStatus(Long id, DataSourceConnStatus connStatus);
+
+  /** DAO 自有分页条件，不依赖 HTTP DTO。 */
+  record PageQuery(
+      int pageNo,
+      int pageSize,
+      String name,
+      String keyword,
+      DataSourceDbType dbType,
+      DataSourceEnvironment environment,
+      DataSourceConnStatus connStatus) {}
 }

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/dao/impl/DataSourceDaoImpl.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/dao/impl/DataSourceDaoImpl.java
@@ -7,9 +7,8 @@ import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
 import io.yak.ops.business.datasource.dao.DataSourceDao;
 import io.yak.ops.business.datasource.dao.mapper.DataSourceMapper;
-import io.yak.ops.common.bean.dto.datasource.DataSourceQueryDTO;
+import io.yak.ops.business.datasource.dao.model.DataSourceSummaryRow;
 import io.yak.ops.common.bean.po.datasource.DataSourcePO;
-import io.yak.ops.common.bean.vo.datasource.DataSourceSummaryVO;
 import io.yak.ops.common.enums.datasource.DataSourceConnStatus;
 import io.yak.ops.common.enums.datasource.DataSourceDbType;
 import java.util.List;
@@ -17,7 +16,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import org.springframework.util.StringUtils;
 
-/** 数据源数据访问实现。 */
+/** 基于 MyBatis-Plus 的数据源数据访问实现。 */
 @Repository
 @ConditionalOnDataSourceEnabled
 @RequiredArgsConstructor
@@ -41,17 +40,20 @@ public class DataSourceDaoImpl implements DataSourceDao {
   }
 
   @Override
-  public IPage<DataSourcePO> selectPage(DataSourceQueryDTO queryDTO) {
-    Page<DataSourcePO> page = Page.of(queryDTO.getPageNo(), queryDTO.getPageSize());
+  public IPage<DataSourcePO> selectPage(PageQuery query) {
+    PageQuery condition =
+        query == null ? new PageQuery(1, 10, null, null, null, null, null) : query;
+    Page<DataSourcePO> page =
+        Page.of(Math.max(1, condition.pageNo()), Math.max(1, condition.pageSize()));
     return dataSourceMapper.selectPage(
         page,
-        queryWrapper(queryDTO)
+        queryWrapper(condition)
             .orderByDesc(DataSourcePO::getUpdateTime)
             .orderByDesc(DataSourcePO::getId));
   }
 
   @Override
-  public DataSourceSummaryVO selectSummary() {
+  public DataSourceSummaryRow selectSummary() {
     return dataSourceMapper.selectSummary();
   }
 
@@ -66,13 +68,12 @@ public class DataSourceDaoImpl implements DataSourceDao {
 
   @Override
   public boolean existsByName(String name, Long excludeId) {
-    if (!StringUtils.hasText(name)) {
-      return false;
-    }
-    Long count = dataSourceMapper.selectCount(
-        Wrappers.<DataSourcePO>lambdaQuery()
-            .eq(DataSourcePO::getName, name)
-            .ne(excludeId != null, DataSourcePO::getId, excludeId));
+    if (!StringUtils.hasText(name)) return false;
+    Long count =
+        dataSourceMapper.selectCount(
+            Wrappers.<DataSourcePO>lambdaQuery()
+                .eq(DataSourcePO::getName, name)
+                .ne(excludeId != null, DataSourcePO::getId, excludeId));
     return count != null && count > 0;
   }
 
@@ -93,32 +94,20 @@ public class DataSourceDaoImpl implements DataSourceDao {
             > 0;
   }
 
-  private LambdaQueryWrapper<DataSourcePO> queryWrapper(DataSourceQueryDTO queryDTO) {
+  private LambdaQueryWrapper<DataSourcePO> queryWrapper(PageQuery query) {
     LambdaQueryWrapper<DataSourcePO> wrapper = Wrappers.lambdaQuery();
-    if (StringUtils.hasText(queryDTO.getKeyword())) {
+    if (StringUtils.hasText(query.keyword())) {
       wrapper.and(
           nested ->
               nested
-                  .like(DataSourcePO::getName, queryDTO.getKeyword())
+                  .like(DataSourcePO::getName, query.keyword())
                   .or()
-                  .like(DataSourcePO::getJdbcUrl, queryDTO.getKeyword()));
+                  .like(DataSourcePO::getJdbcUrl, query.keyword()));
     }
     return wrapper
-        .like(
-            StringUtils.hasText(queryDTO.getName()),
-            DataSourcePO::getName,
-            queryDTO.getName())
-        .eq(
-            StringUtils.hasText(queryDTO.getDbType()),
-            DataSourcePO::getDbType,
-            queryDTO.getDbType())
-        .eq(
-            StringUtils.hasText(queryDTO.getEnvironment()),
-            DataSourcePO::getEnvironment,
-            queryDTO.getEnvironment())
-        .eq(
-            StringUtils.hasText(queryDTO.getConnStatus()),
-            DataSourcePO::getConnStatus,
-            queryDTO.getConnStatus());
+        .like(StringUtils.hasText(query.name()), DataSourcePO::getName, query.name())
+        .eq(query.dbType() != null, DataSourcePO::getDbType, query.dbType())
+        .eq(query.environment() != null, DataSourcePO::getEnvironment, query.environment())
+        .eq(query.connStatus() != null, DataSourcePO::getConnStatus, query.connStatus());
   }
 }

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/dao/mapper/DataSourceMapper.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/dao/mapper/DataSourceMapper.java
@@ -1,26 +1,12 @@
 package io.yak.ops.business.datasource.dao.mapper;
 
 import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import io.yak.ops.business.datasource.dao.model.DataSourceSummaryRow;
 import io.yak.ops.common.bean.po.datasource.DataSourcePO;
-import io.yak.ops.common.bean.vo.datasource.DataSourceSummaryVO;
 import org.apache.ibatis.annotations.Mapper;
-import org.apache.ibatis.annotations.Select;
 
-/**
- * 数据源 MyBatis 映射接口。
- *
- * <p>当前数据源管理仅包含单表 CRUD，使用 MyBatis-Plus BaseMapper；后续多表关联查询统一放入
- * {@code mapper/datasource/*.xml}。</p>
- */
+/** 数据源 MyBatis 映射接口。 */
 @Mapper
 public interface DataSourceMapper extends BaseMapper<DataSourcePO> {
-
-  @Select(
-      "SELECT COUNT(*) AS total, "
-          + "COALESCE(SUM(CASE WHEN conn_status = 'CONNECTED' THEN 1 ELSE 0 END), 0) AS connected, "
-          + "COALESCE(SUM(CASE WHEN conn_status = 'DISCONNECTED' THEN 1 ELSE 0 END), 0) AS disconnected, "
-          + "COALESCE(SUM(CASE WHEN conn_status = 'UNKNOWN' THEN 1 ELSE 0 END), 0) AS unknown, "
-          + "COUNT(DISTINCT environment) AS environmentCount "
-          + "FROM yak_ops_data_source")
-  DataSourceSummaryVO selectSummary();
+  DataSourceSummaryRow selectSummary();
 }

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/dao/model/DataSourceSummaryRow.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/dao/model/DataSourceSummaryRow.java
@@ -1,0 +1,13 @@
+package io.yak.ops.business.datasource.dao.model;
+
+import lombok.Data;
+
+/** 数据源统计 SQL 的持久化投影，不作为 HTTP 响应模型。 */
+@Data
+public class DataSourceSummaryRow {
+  private long total;
+  private long connected;
+  private long disconnected;
+  private long unknown;
+  private long environmentCount;
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/domain/DataSourceDefinition.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/domain/DataSourceDefinition.java
@@ -1,0 +1,24 @@
+package io.yak.ops.business.datasource.domain;
+
+import io.yak.ops.common.enums.datasource.DataSourceConnStatus;
+import io.yak.ops.common.enums.datasource.DataSourceDbType;
+import io.yak.ops.common.enums.datasource.DataSourceEnvironment;
+import java.time.LocalDateTime;
+import lombok.Data;
+import lombok.ToString;
+
+/** 数据源业务定义；与 MyBatis PO 和 HTTP VO 解耦。 */
+@Data
+public class DataSourceDefinition {
+  private Long id;
+  private String name;
+  private DataSourceDbType dbType;
+  private String jdbcUrl;
+  private DataSourceEnvironment environment;
+  private DataSourceConnStatus connStatus;
+  private String remark;
+  @ToString.Exclude private String connectionParams;
+  @ToString.Exclude private String originalJson;
+  private LocalDateTime createTime;
+  private LocalDateTime updateTime;
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/domain/DataSourcePage.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/domain/DataSourcePage.java
@@ -1,0 +1,16 @@
+package io.yak.ops.business.datasource.domain;
+
+import java.util.List;
+
+/** 与具体分页框架解耦的数据源分页结果。 */
+public record DataSourcePage<T>(
+    List<T> records,
+    long total,
+    long pages,
+    long pageNo,
+    long pageSize) {
+
+  public DataSourcePage {
+    records = records == null ? List.of() : List.copyOf(records);
+  }
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/domain/DataSourceQuery.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/domain/DataSourceQuery.java
@@ -1,0 +1,15 @@
+package io.yak.ops.business.datasource.domain;
+
+import io.yak.ops.common.enums.datasource.DataSourceConnStatus;
+import io.yak.ops.common.enums.datasource.DataSourceDbType;
+import io.yak.ops.common.enums.datasource.DataSourceEnvironment;
+
+/** 数据源领域查询条件。 */
+public record DataSourceQuery(
+    int pageNo,
+    int pageSize,
+    String name,
+    String keyword,
+    DataSourceDbType dbType,
+    DataSourceEnvironment environment,
+    DataSourceConnStatus connStatus) {}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/domain/DataSourceSummary.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/domain/DataSourceSummary.java
@@ -1,0 +1,14 @@
+package io.yak.ops.business.datasource.domain;
+
+/** 数据源总览领域统计。 */
+public record DataSourceSummary(
+    long total,
+    long connected,
+    long disconnected,
+    long unknown,
+    long environmentCount) {
+
+  public static DataSourceSummary empty() {
+    return new DataSourceSummary(0L, 0L, 0L, 0L, 0L);
+  }
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/repository/DataSourceRepository.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/repository/DataSourceRepository.java
@@ -1,0 +1,31 @@
+package io.yak.ops.business.datasource.repository;
+
+import io.yak.ops.business.datasource.domain.DataSourceDefinition;
+import io.yak.ops.business.datasource.domain.DataSourcePage;
+import io.yak.ops.business.datasource.domain.DataSourceQuery;
+import io.yak.ops.business.datasource.domain.DataSourceSummary;
+import io.yak.ops.common.enums.datasource.DataSourceConnStatus;
+import io.yak.ops.common.enums.datasource.DataSourceDbType;
+import java.util.List;
+import java.util.Optional;
+
+/** 数据源领域仓储。 */
+public interface DataSourceRepository {
+  Optional<DataSourceDefinition> findById(Long id);
+
+  boolean insert(DataSourceDefinition definition);
+
+  boolean update(DataSourceDefinition definition);
+
+  boolean delete(Long id);
+
+  boolean existsByName(String name, Long excludeId);
+
+  DataSourcePage<DataSourceDefinition> page(DataSourceQuery query);
+
+  List<DataSourceDefinition> findAll(DataSourceDbType dbType);
+
+  DataSourceSummary summary();
+
+  boolean updateConnectionStatus(Long id, DataSourceConnStatus status);
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/repository/DataSourceRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/repository/DataSourceRepositoryAdapter.java
@@ -1,0 +1,112 @@
+package io.yak.ops.business.datasource.repository;
+
+import com.baomidou.mybatisplus.core.metadata.IPage;
+import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
+import io.yak.ops.business.datasource.dao.DataSourceDao;
+import io.yak.ops.business.datasource.dao.DataSourceDao.PageQuery;
+import io.yak.ops.business.datasource.dao.model.DataSourceSummaryRow;
+import io.yak.ops.business.datasource.domain.DataSourceDefinition;
+import io.yak.ops.business.datasource.domain.DataSourcePage;
+import io.yak.ops.business.datasource.domain.DataSourceQuery;
+import io.yak.ops.business.datasource.domain.DataSourceSummary;
+import io.yak.ops.common.bean.po.datasource.DataSourcePO;
+import io.yak.ops.common.enums.datasource.DataSourceConnStatus;
+import io.yak.ops.common.enums.datasource.DataSourceDbType;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.BeanUtils;
+import org.springframework.stereotype.Repository;
+
+/** MyBatis 持久化模型与数据源领域模型之间的适配器。 */
+@Repository
+@ConditionalOnDataSourceEnabled
+@RequiredArgsConstructor
+public class DataSourceRepositoryAdapter implements DataSourceRepository {
+
+  private final DataSourceDao dao;
+
+  @Override
+  public Optional<DataSourceDefinition> findById(Long id) {
+    return Optional.ofNullable(toDomain(dao.selectById(id)));
+  }
+
+  @Override
+  public boolean insert(DataSourceDefinition definition) {
+    return dao.addDataSource(toPO(definition)) > 0;
+  }
+
+  @Override
+  public boolean update(DataSourceDefinition definition) {
+    return dao.editDataSource(toPO(definition)) > 0;
+  }
+
+  @Override
+  public boolean delete(Long id) {
+    return dao.deleteById(id);
+  }
+
+  @Override
+  public boolean existsByName(String name, Long excludeId) {
+    return dao.existsByName(name, excludeId);
+  }
+
+  @Override
+  public DataSourcePage<DataSourceDefinition> page(DataSourceQuery query) {
+    DataSourceQuery condition =
+        query == null ? new DataSourceQuery(1, 10, null, null, null, null, null) : query;
+    IPage<DataSourcePO> page =
+        dao.selectPage(
+            new PageQuery(
+                condition.pageNo(),
+                condition.pageSize(),
+                condition.name(),
+                condition.keyword(),
+                condition.dbType(),
+                condition.environment(),
+                condition.connStatus()));
+    List<DataSourceDefinition> records = page.getRecords().stream().map(this::toDomain).toList();
+    return new DataSourcePage<>(
+        records,
+        page.getTotal(),
+        page.getPages(),
+        page.getCurrent(),
+        page.getSize());
+  }
+
+  @Override
+  public List<DataSourceDefinition> findAll(DataSourceDbType dbType) {
+    return dao.selectAll(dbType).stream().map(this::toDomain).toList();
+  }
+
+  @Override
+  public DataSourceSummary summary() {
+    DataSourceSummaryRow row = dao.selectSummary();
+    return row == null
+        ? DataSourceSummary.empty()
+        : new DataSourceSummary(
+            row.getTotal(),
+            row.getConnected(),
+            row.getDisconnected(),
+            row.getUnknown(),
+            row.getEnvironmentCount());
+  }
+
+  @Override
+  public boolean updateConnectionStatus(Long id, DataSourceConnStatus status) {
+    return dao.updateConnectionStatus(id, status);
+  }
+
+  private DataSourceDefinition toDomain(DataSourcePO po) {
+    if (po == null) return null;
+    DataSourceDefinition definition = new DataSourceDefinition();
+    BeanUtils.copyProperties(po, definition);
+    return definition;
+  }
+
+  private DataSourcePO toPO(DataSourceDefinition definition) {
+    DataSourcePO po = new DataSourcePO();
+    BeanUtils.copyProperties(definition, po);
+    return po;
+  }
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/service/impl/DataSourceCatalogServiceImpl.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/service/impl/DataSourceCatalogServiceImpl.java
@@ -2,11 +2,11 @@ package io.yak.ops.business.datasource.service.impl;
 
 import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
 import io.yak.ops.business.datasource.config.DataSourceProperties;
-import io.yak.ops.business.datasource.dao.DataSourceDao;
+import io.yak.ops.business.datasource.domain.DataSourceDefinition;
 import io.yak.ops.business.datasource.exception.DataSourceException;
 import io.yak.ops.business.datasource.plugin.DataSourcePluginRegistry;
+import io.yak.ops.business.datasource.repository.DataSourceRepository;
 import io.yak.ops.business.datasource.service.DataSourceCatalogService;
-import io.yak.ops.common.bean.po.datasource.DataSourcePO;
 import io.yak.ops.common.bean.vo.datasource.DataSourceCatalogColumnOptionVO;
 import io.yak.ops.common.bean.vo.datasource.DataSourceCatalogColumnVO;
 import io.yak.ops.common.bean.vo.datasource.DataSourceCatalogOptionVO;
@@ -32,7 +32,7 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-/** Catalog 服务实现，业务层只负责数据源加载、插件路由和响应模型转换。 */
+/** Catalog 服务实现，业务层只负责领域数据源加载、插件路由和响应转换。 */
 @Service
 @ConditionalOnDataSourceEnabled
 @RequiredArgsConstructor
@@ -42,7 +42,7 @@ public class DataSourceCatalogServiceImpl implements DataSourceCatalogService {
   private static final int MAX_MATCH_KEYWORD_LENGTH = 256;
   private static final Pattern READ_ONLY_SELECT = Pattern.compile("(?is)^SELECT\\b.*");
 
-  private final DataSourceDao dataSourceDao;
+  private final DataSourceRepository repository;
   private final DataSourcePluginRegistry pluginRegistry;
   private final DataSourceProperties properties;
 
@@ -110,12 +110,9 @@ public class DataSourceCatalogServiceImpl implements DataSourceCatalogService {
             catalog.listTables(new DataSourceCatalogQuery(null, null, null)).stream()
                 .map(
                     table -> {
-                      String label =
-                          isBlank(table.getRemarks()) ? table.getName() : table.getRemarks();
+                      String label = isBlank(table.getRemarks()) ? table.getName() : table.getRemarks();
                       return new DataSourceCatalogOptionVO(
-                          table.getName(),
-                          label,
-                          table.getRemarks());
+                          table.getName(), label, table.getRemarks());
                     })
                 .collect(Collectors.toList()));
   }
@@ -126,9 +123,7 @@ public class DataSourceCatalogServiceImpl implements DataSourceCatalogService {
       String matchMode,
       String keyword) {
     List<DataSourceCatalogOptionVO> options = listTable(dataSourceId);
-    if (isBlank(keyword)) {
-      return options;
-    }
+    if (isBlank(keyword)) return options;
     if (keyword.length() > MAX_MATCH_KEYWORD_LENGTH) {
       throw new DataSourceException(
           DataSourceErrorCode.INVALID_CONNECTION_PARAMS,
@@ -233,9 +228,9 @@ public class DataSourceCatalogServiceImpl implements DataSourceCatalogService {
 
   private <T> T execute(Long dataSourceId, Function<DataSourceCatalog, T> action) {
     try {
-      DataSourcePO dataSourcePO = getDataSourceOrThrow(dataSourceId);
-      DataSourcePlugin plugin = pluginRegistry.get(dataSourcePO.getDbType());
-      DataSourceConnection connection = plugin.parseConnection(dataSourcePO.getConnectionParams());
+      DataSourceDefinition definition = getDataSourceOrThrow(dataSourceId);
+      DataSourcePlugin plugin = pluginRegistry.get(definition.getDbType());
+      DataSourceConnection connection = plugin.parseConnection(definition.getConnectionParams());
       DataSourceCatalog catalog =
           plugin.createCatalog(
               connection,
@@ -256,15 +251,12 @@ public class DataSourceCatalogServiceImpl implements DataSourceCatalogService {
     }
   }
 
-  private DataSourcePO getDataSourceOrThrow(Long id) {
-    if (id == null || id <= 0) {
+  private DataSourceDefinition getDataSourceOrThrow(Long id) {
+    if (id == null || id <= 0L) {
       throw new DataSourceException(DataSourceErrorCode.NOT_FOUND);
     }
-    DataSourcePO dataSourcePO = dataSourceDao.selectById(id);
-    if (dataSourcePO == null) {
-      throw new DataSourceException(DataSourceErrorCode.NOT_FOUND);
-    }
-    return dataSourcePO;
+    return repository.findById(id)
+        .orElseThrow(() -> new DataSourceException(DataSourceErrorCode.NOT_FOUND));
   }
 
   private Map<String, Object> requireRequest(Map<String, Object> requestBody) {
@@ -282,9 +274,7 @@ public class DataSourceCatalogServiceImpl implements DataSourceCatalogService {
     String query = optionalText(request, "query", "sql");
     boolean sqlMode =
         "sql".equalsIgnoreCase(readMode) || (!isBlank(query) && isBlank(tablePath));
-    if (!sqlMode) {
-      return;
-    }
+    if (!sqlMode) return;
     if (isBlank(query)) {
       throw new DataSourceException(
           DataSourceErrorCode.INVALID_CONNECTION_PARAMS,
@@ -304,9 +294,7 @@ public class DataSourceCatalogServiceImpl implements DataSourceCatalogService {
 
   private String requiredText(Map<String, Object> request, String... keys) {
     String value = optionalText(request, keys);
-    if (!isBlank(value)) {
-      return value;
-    }
+    if (!isBlank(value)) return value;
     throw new DataSourceException(
         DataSourceErrorCode.INVALID_CONNECTION_PARAMS,
         keys[0] + " 不能为空");

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/service/impl/DataSourceServiceImpl.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/service/impl/DataSourceServiceImpl.java
@@ -1,18 +1,20 @@
 package io.yak.ops.business.datasource.service.impl;
 
-import com.baomidou.mybatisplus.core.metadata.IPage;
 import io.yak.framework.common.PagingData;
 import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
 import io.yak.ops.business.datasource.config.DataSourceProperties;
-import io.yak.ops.business.datasource.dao.DataSourceDao;
+import io.yak.ops.business.datasource.domain.DataSourceDefinition;
+import io.yak.ops.business.datasource.domain.DataSourcePage;
+import io.yak.ops.business.datasource.domain.DataSourceQuery;
 import io.yak.ops.business.datasource.exception.DataSourceException;
 import io.yak.ops.business.datasource.plugin.DataSourcePluginRegistry;
+import io.yak.ops.business.datasource.repository.DataSourceRepository;
 import io.yak.ops.business.datasource.service.DataSourceService;
+import io.yak.ops.business.datasource.service.support.DataSourceViewMapper;
 import io.yak.ops.business.datasource.util.DataSourceSecretCodec;
 import io.yak.ops.common.bean.dto.datasource.DataSourceConnectTestDTO;
 import io.yak.ops.common.bean.dto.datasource.DataSourceDTO;
 import io.yak.ops.common.bean.dto.datasource.DataSourceQueryDTO;
-import io.yak.ops.common.bean.po.datasource.DataSourcePO;
 import io.yak.ops.common.bean.vo.datasource.DataSourceOptionVO;
 import io.yak.ops.common.bean.vo.datasource.DataSourceSummaryVO;
 import io.yak.ops.common.bean.vo.datasource.DataSourceVO;
@@ -24,22 +26,22 @@ import io.yak.ops.spi.datasource.DataSourceConnection;
 import io.yak.ops.spi.datasource.DataSourcePlugin;
 import io.yak.ops.spi.datasource.DataSourcePluginException;
 import java.util.List;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
-/** 数据源管理服务实现。业务层只负责编排，连接能力由插件提供。 */
+/** 数据源管理服务实现。业务层只负责编排，持久化与展示转换由独立边界承担。 */
 @Service
 @ConditionalOnDataSourceEnabled
 @RequiredArgsConstructor
 public class DataSourceServiceImpl implements DataSourceService {
 
-  private final DataSourceDao dataSourceDao;
+  private final DataSourceRepository repository;
   private final DataSourcePluginRegistry pluginRegistry;
   private final DataSourceProperties properties;
   private final DataSourceSecretCodec secretCodec;
+  private final DataSourceViewMapper viewMapper;
 
   @Override
   @Transactional(
@@ -49,11 +51,12 @@ public class DataSourceServiceImpl implements DataSourceService {
     String name = normalizeName(dataSourceDTO.getName());
     ensureNameAvailable(name, null);
 
-    DataSourcePO dataSourcePO = buildDataSource(dataSourceDTO, dataSourceDTO.getConnectionParams());
-    dataSourcePO.setName(name);
-    dataSourcePO.setConnStatus(DataSourceConnStatus.UNKNOWN);
+    DataSourceDefinition definition =
+        buildDefinition(dataSourceDTO, dataSourceDTO.getConnectionParams());
+    definition.setName(name);
+    definition.setConnStatus(DataSourceConnStatus.UNKNOWN);
 
-    if (dataSourceDao.addDataSource(dataSourcePO) <= 0) {
+    if (!repository.insert(definition)) {
       throw new DataSourceException(DataSourceErrorCode.CREATE_FAILED);
     }
     return true;
@@ -64,7 +67,7 @@ public class DataSourceServiceImpl implements DataSourceService {
       transactionManager = "opsDataSourceTransactionManager",
       rollbackFor = Exception.class)
   public boolean updateDataSource(Long id, DataSourceDTO dataSourceDTO) {
-    DataSourcePO existing = getDataSourceOrThrow(id);
+    DataSourceDefinition existing = getDataSourceOrThrow(id);
     String name = normalizeName(dataSourceDTO.getName());
     ensureNameAvailable(name, id);
 
@@ -81,12 +84,13 @@ public class DataSourceServiceImpl implements DataSourceService {
             plugin,
             dataSourceDTO.getConnectionParams(),
             existing.getConnectionParams());
-    DataSourcePO dataSourcePO = buildDataSource(dataSourceDTO, mergedConnectionJson);
-    dataSourcePO.setId(id);
-    dataSourcePO.setName(name);
-    dataSourcePO.setConnStatus(DataSourceConnStatus.UNKNOWN);
+    DataSourceDefinition definition = buildDefinition(dataSourceDTO, mergedConnectionJson);
+    definition.setId(id);
+    definition.setName(name);
+    definition.setConnStatus(DataSourceConnStatus.UNKNOWN);
+    definition.setCreateTime(existing.getCreateTime());
 
-    if (dataSourceDao.editDataSource(dataSourcePO) <= 0) {
+    if (!repository.update(definition)) {
       throw new DataSourceException(DataSourceErrorCode.UPDATE_FAILED);
     }
     return true;
@@ -94,33 +98,29 @@ public class DataSourceServiceImpl implements DataSourceService {
 
   @Override
   public DataSourceVO getDataSource(Long id) {
-    return toVO(getDataSourceOrThrow(id), true);
+    return viewMapper.definition(getDataSourceOrThrow(id), true);
   }
 
   @Override
   public PagingData<DataSourceVO> getDataSourcePage(DataSourceQueryDTO queryDTO) {
-    normalizeQuery(queryDTO);
-    IPage<DataSourcePO> page = dataSourceDao.selectPage(queryDTO);
+    DataSourcePage<DataSourceDefinition> page = repository.page(toQuery(queryDTO));
     List<DataSourceVO> records =
-        page.getRecords().stream()
-            .map(dataSourcePO -> toVO(dataSourcePO, false))
-            .collect(Collectors.toList());
-    return new PagingData<>(records, page);
+        page.records().stream().map(value -> viewMapper.definition(value, false)).toList();
+    return pagingData(records, page.total(), page.pageNo(), page.pageSize(), page.pages());
   }
 
   @Override
   public DataSourceSummaryVO getSummary() {
-    DataSourceSummaryVO summary = dataSourceDao.selectSummary();
-    return summary == null ? new DataSourceSummaryVO() : summary;
+    return viewMapper.summary(repository.summary());
   }
 
   @Override
   public PagingData<DataSourceVO> getAllDataSources() {
     List<DataSourceVO> records =
-        dataSourceDao.selectAll(null).stream()
-            .map(dataSourcePO -> toVO(dataSourcePO, false))
-            .collect(Collectors.toList());
-    return pagingData(records, records.size(), 1, Math.max(1, records.size()));
+        repository.findAll(null).stream()
+            .map(value -> viewMapper.definition(value, false))
+            .toList();
+    return pagingData(records, records.size(), 1L, Math.max(1, records.size()), records.isEmpty() ? 0L : 1L);
   }
 
   @Override
@@ -129,7 +129,7 @@ public class DataSourceServiceImpl implements DataSourceService {
       rollbackFor = Exception.class)
   public boolean deleteDataSource(Long id) {
     getDataSourceOrThrow(id);
-    if (!dataSourceDao.deleteById(id)) {
+    if (!repository.delete(id)) {
       throw new DataSourceException(DataSourceErrorCode.DELETE_FAILED);
     }
     return true;
@@ -137,16 +137,16 @@ public class DataSourceServiceImpl implements DataSourceService {
 
   @Override
   public boolean testConnection(Long id) {
-    DataSourcePO dataSourcePO = getDataSourceOrThrow(id);
-    DataSourcePlugin plugin = pluginRegistry.get(dataSourcePO.getDbType());
-    DataSourceConnection connection = parseConnection(plugin, dataSourcePO.getConnectionParams());
+    DataSourceDefinition definition = getDataSourceOrThrow(id);
+    DataSourcePlugin plugin = pluginRegistry.get(definition.getDbType());
+    DataSourceConnection connection = parseConnection(plugin, definition.getConnectionParams());
 
     try {
       plugin.testConnection(connection, connectionTimeoutSeconds());
-      dataSourceDao.updateConnectionStatus(id, DataSourceConnStatus.CONNECTED);
+      repository.updateConnectionStatus(id, DataSourceConnStatus.CONNECTED);
       return true;
     } catch (RuntimeException exception) {
-      dataSourceDao.updateConnectionStatus(id, DataSourceConnStatus.DISCONNECTED);
+      repository.updateConnectionStatus(id, DataSourceConnStatus.DISCONNECTED);
       throw connectException(exception);
     }
   }
@@ -162,7 +162,7 @@ public class DataSourceServiceImpl implements DataSourceService {
     DataSourcePlugin plugin;
     String connectionJson = connectTestDTO.getConnJson();
     if (connectTestDTO.getDataSourceId() != null) {
-      DataSourcePO existing = getDataSourceOrThrow(connectTestDTO.getDataSourceId());
+      DataSourceDefinition existing = getDataSourceOrThrow(connectTestDTO.getDataSourceId());
       DataSourceDbType existingType = existing.getDbType();
       if (StringUtils.hasText(connectTestDTO.getDbType())
           && parseDbType(connectTestDTO.getDbType()) != existingType) {
@@ -195,19 +195,11 @@ public class DataSourceServiceImpl implements DataSourceService {
 
   @Override
   public List<DataSourceOptionVO> getOptions(String dbType) {
-    DataSourceDbType normalizedType =
-        StringUtils.hasText(dbType) ? parseDbType(dbType) : null;
-    return dataSourceDao.selectAll(normalizedType).stream()
-        .map(
-            dataSourcePO ->
-                new DataSourceOptionVO(
-                    dataSourcePO.getName(),
-                    String.valueOf(dataSourcePO.getId()),
-                    dataSourcePO.getDbType().name()))
-        .collect(Collectors.toList());
+    DataSourceDbType normalizedType = StringUtils.hasText(dbType) ? parseDbType(dbType) : null;
+    return repository.findAll(normalizedType).stream().map(viewMapper::option).toList();
   }
 
-  private DataSourcePO buildDataSource(
+  private DataSourceDefinition buildDefinition(
       DataSourceDTO dataSourceDTO,
       String connectionJson) {
     DataSourceDbType dbType = parseDbType(dataSourceDTO.getDbType());
@@ -215,14 +207,14 @@ public class DataSourceServiceImpl implements DataSourceService {
     DataSourcePlugin plugin = pluginRegistry.get(dbType);
     DataSourceConnection connection = parseConnection(plugin, connectionJson);
 
-    DataSourcePO dataSourcePO = new DataSourcePO();
-    dataSourcePO.setDbType(dbType);
-    dataSourcePO.setJdbcUrl(connection.jdbcUrl());
-    dataSourcePO.setEnvironment(environment);
-    dataSourcePO.setRemark(normalizeNullable(dataSourceDTO.getRemark()));
-    dataSourcePO.setConnectionParams(connection.normalizedJson());
-    dataSourcePO.setOriginalJson(connection.normalizedJson());
-    return dataSourcePO;
+    DataSourceDefinition definition = new DataSourceDefinition();
+    definition.setDbType(dbType);
+    definition.setJdbcUrl(connection.jdbcUrl());
+    definition.setEnvironment(environment);
+    definition.setRemark(normalizeNullable(dataSourceDTO.getRemark()));
+    definition.setConnectionParams(connection.normalizedJson());
+    definition.setOriginalJson(connection.normalizedJson());
+    return definition;
   }
 
   private DataSourceConnection parseConnection(DataSourcePlugin plugin, String connectionJson) {
@@ -242,8 +234,8 @@ public class DataSourceServiceImpl implements DataSourceService {
   }
 
   private DataSourceException connectException(RuntimeException exception) {
-    if (exception instanceof DataSourceException) {
-      return (DataSourceException) exception;
+    if (exception instanceof DataSourceException dataSourceException) {
+      return dataSourceException;
     }
     return new DataSourceException(
         DataSourceErrorCode.CONNECT_FAILED,
@@ -255,21 +247,38 @@ public class DataSourceServiceImpl implements DataSourceService {
     return Math.max(1, properties.getConnectionTest().getTimeoutSeconds());
   }
 
-  private DataSourcePO getDataSourceOrThrow(Long id) {
-    if (id == null || id <= 0) {
+  private DataSourceDefinition getDataSourceOrThrow(Long id) {
+    if (id == null || id <= 0L) {
       throw new DataSourceException(DataSourceErrorCode.NOT_FOUND);
     }
-    DataSourcePO dataSourcePO = dataSourceDao.selectById(id);
-    if (dataSourcePO == null) {
-      throw new DataSourceException(DataSourceErrorCode.NOT_FOUND);
-    }
-    return dataSourcePO;
+    return repository.findById(id)
+        .orElseThrow(() -> new DataSourceException(DataSourceErrorCode.NOT_FOUND));
   }
 
   private void ensureNameAvailable(String name, Long excludeId) {
-    if (dataSourceDao.existsByName(name, excludeId)) {
+    if (repository.existsByName(name, excludeId)) {
       throw new DataSourceException(DataSourceErrorCode.DUPLICATE_NAME);
     }
+  }
+
+  private DataSourceQuery toQuery(DataSourceQueryDTO queryDTO) {
+    if (queryDTO == null) {
+      throw new DataSourceException(
+          DataSourceErrorCode.INVALID_CONNECTION_PARAMS,
+          "分页查询参数不能为空");
+    }
+    return new DataSourceQuery(
+        queryDTO.getPageNo(),
+        queryDTO.getPageSize(),
+        normalizeNullable(queryDTO.getName()),
+        normalizeNullable(queryDTO.getKeyword()),
+        StringUtils.hasText(queryDTO.getDbType()) ? parseDbType(queryDTO.getDbType()) : null,
+        StringUtils.hasText(queryDTO.getEnvironment())
+            ? parseEnvironment(queryDTO.getEnvironment())
+            : null,
+        StringUtils.hasText(queryDTO.getConnStatus())
+            ? parseConnectionStatus(queryDTO.getConnStatus())
+            : null);
   }
 
   private String normalizeName(String name) {
@@ -283,29 +292,6 @@ public class DataSourceServiceImpl implements DataSourceService {
 
   private String normalizeNullable(String value) {
     return StringUtils.hasText(value) ? value.trim() : null;
-  }
-
-  private void normalizeQuery(DataSourceQueryDTO queryDTO) {
-    if (queryDTO == null) {
-      throw new DataSourceException(
-          DataSourceErrorCode.INVALID_CONNECTION_PARAMS,
-          "分页查询参数不能为空");
-    }
-    if (StringUtils.hasText(queryDTO.getName())) {
-      queryDTO.setName(queryDTO.getName().trim());
-    }
-    if (StringUtils.hasText(queryDTO.getKeyword())) {
-      queryDTO.setKeyword(queryDTO.getKeyword().trim());
-    }
-    if (StringUtils.hasText(queryDTO.getDbType())) {
-      queryDTO.setDbType(parseDbType(queryDTO.getDbType()).name());
-    }
-    if (StringUtils.hasText(queryDTO.getEnvironment())) {
-      queryDTO.setEnvironment(parseEnvironment(queryDTO.getEnvironment()).name());
-    }
-    if (StringUtils.hasText(queryDTO.getConnStatus())) {
-      queryDTO.setConnStatus(parseConnectionStatus(queryDTO.getConnStatus()).name());
-    }
   }
 
   private DataSourceDbType parseDbType(String value) {
@@ -341,32 +327,12 @@ public class DataSourceServiceImpl implements DataSourceService {
     }
   }
 
-  private DataSourceVO toVO(DataSourcePO dataSourcePO, boolean includeOriginalJson) {
-    DataSourceVO dataSourceVO = new DataSourceVO();
-    dataSourceVO.setId(dataSourcePO.getId());
-    dataSourceVO.setName(dataSourcePO.getName());
-    dataSourceVO.setDbType(dataSourcePO.getDbType().name());
-    dataSourceVO.setJdbcUrl(secretCodec.maskSensitiveText(dataSourcePO.getJdbcUrl()));
-    dataSourceVO.setEnvironment(dataSourcePO.getEnvironment().name());
-    dataSourceVO.setEnvironmentName(dataSourcePO.getEnvironment().getDisplayName());
-    dataSourceVO.setConnStatus(dataSourcePO.getConnStatus().name());
-    dataSourceVO.setRemark(dataSourcePO.getRemark());
-    dataSourceVO.setCreateTime(dataSourcePO.getCreateTime());
-    dataSourceVO.setUpdateTime(dataSourcePO.getUpdateTime());
-    if (includeOriginalJson) {
-      DataSourcePlugin plugin = pluginRegistry.get(dataSourcePO.getDbType());
-      dataSourceVO.setOriginalJson(
-          secretCodec.maskConnectionJson(plugin, dataSourcePO.getOriginalJson()));
-    }
-    return dataSourceVO;
-  }
-
   private PagingData<DataSourceVO> pagingData(
       List<DataSourceVO> records,
       long total,
-      int pageNo,
-      int pageSize) {
-    long pages = pageSize <= 0 ? 0 : (total + pageSize - 1) / pageSize;
+      long pageNo,
+      long pageSize,
+      long pages) {
     PagingData<DataSourceVO> pagingData = new PagingData<>();
     pagingData.setBizData(records);
     pagingData.setPagination(

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/service/support/DataSourceViewMapper.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/service/support/DataSourceViewMapper.java
@@ -1,0 +1,61 @@
+package io.yak.ops.business.datasource.service.support;
+
+import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
+import io.yak.ops.business.datasource.domain.DataSourceDefinition;
+import io.yak.ops.business.datasource.domain.DataSourceSummary;
+import io.yak.ops.business.datasource.plugin.DataSourcePluginRegistry;
+import io.yak.ops.business.datasource.util.DataSourceSecretCodec;
+import io.yak.ops.common.bean.vo.datasource.DataSourceOptionVO;
+import io.yak.ops.common.bean.vo.datasource.DataSourceSummaryVO;
+import io.yak.ops.common.bean.vo.datasource.DataSourceVO;
+import io.yak.ops.spi.datasource.DataSourcePlugin;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+/** Domain -> VO 纯输出转换，不访问数据库。 */
+@Component
+@ConditionalOnDataSourceEnabled
+@RequiredArgsConstructor
+public class DataSourceViewMapper {
+
+  private final DataSourcePluginRegistry pluginRegistry;
+  private final DataSourceSecretCodec secretCodec;
+
+  public DataSourceVO definition(DataSourceDefinition source, boolean includeOriginalJson) {
+    if (source == null) return null;
+    DataSourceVO target = new DataSourceVO();
+    target.setId(source.getId());
+    target.setName(source.getName());
+    target.setDbType(source.getDbType() == null ? null : source.getDbType().name());
+    target.setJdbcUrl(secretCodec.maskSensitiveText(source.getJdbcUrl()));
+    target.setEnvironment(source.getEnvironment() == null ? null : source.getEnvironment().name());
+    target.setEnvironmentName(
+        source.getEnvironment() == null ? null : source.getEnvironment().getDisplayName());
+    target.setConnStatus(source.getConnStatus() == null ? null : source.getConnStatus().name());
+    target.setRemark(source.getRemark());
+    target.setCreateTime(source.getCreateTime());
+    target.setUpdateTime(source.getUpdateTime());
+    if (includeOriginalJson && source.getDbType() != null) {
+      DataSourcePlugin plugin = pluginRegistry.get(source.getDbType());
+      target.setOriginalJson(secretCodec.maskConnectionJson(plugin, source.getOriginalJson()));
+    }
+    return target;
+  }
+
+  public DataSourceOptionVO option(DataSourceDefinition source) {
+    return new DataSourceOptionVO(
+        source.getName(),
+        String.valueOf(source.getId()),
+        source.getDbType() == null ? null : source.getDbType().name());
+  }
+
+  public DataSourceSummaryVO summary(DataSourceSummary source) {
+    DataSourceSummary value = source == null ? DataSourceSummary.empty() : source;
+    return new DataSourceSummaryVO(
+        value.total(),
+        value.connected(),
+        value.disconnected(),
+        value.unknown(),
+        value.environmentCount());
+  }
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/resources/mapper/datasource/DataSourceMapper.xml
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/resources/mapper/datasource/DataSourceMapper.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+    PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+    "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="io.yak.ops.business.datasource.dao.mapper.DataSourceMapper">
+
+    <select id="selectSummary"
+            resultType="io.yak.ops.business.datasource.dao.model.DataSourceSummaryRow">
+        SELECT COUNT(*) AS total,
+               COALESCE(SUM(CASE WHEN conn_status = 'CONNECTED' THEN 1 ELSE 0 END), 0) AS connected,
+               COALESCE(SUM(CASE WHEN conn_status = 'DISCONNECTED' THEN 1 ELSE 0 END), 0) AS disconnected,
+               COALESCE(SUM(CASE WHEN conn_status = 'UNKNOWN' THEN 1 ELSE 0 END), 0) AS unknown,
+               COUNT(DISTINCT environment) AS environmentCount
+        FROM yak_ops_data_source
+    </select>
+
+</mapper>

--- a/yak-ops-business/yak-ops-business-datasource/src/main/resources/mapper/datasource/DataSourceMapper.xml
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/resources/mapper/datasource/DataSourceMapper.xml
@@ -10,7 +10,7 @@
                COALESCE(SUM(CASE WHEN conn_status = 'CONNECTED' THEN 1 ELSE 0 END), 0) AS connected,
                COALESCE(SUM(CASE WHEN conn_status = 'DISCONNECTED' THEN 1 ELSE 0 END), 0) AS disconnected,
                COALESCE(SUM(CASE WHEN conn_status = 'UNKNOWN' THEN 1 ELSE 0 END), 0) AS unknown,
-               COUNT(DISTINCT environment) AS environmentCount
+               COUNT(DISTINCT environment) AS environment_count
         FROM yak_ops_data_source
     </select>
 

--- a/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/architecture/DataSourceLayeringConventionTest.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/architecture/DataSourceLayeringConventionTest.java
@@ -1,0 +1,109 @@
+package io.yak.ops.business.datasource.architecture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.baomidou.mybatisplus.annotation.TableName;
+import io.yak.ops.business.datasource.controller.v1.DataSourceCatalogController;
+import io.yak.ops.business.datasource.controller.v1.DataSourceController;
+import io.yak.ops.business.datasource.controller.v1.DataSourcePluginConfigController;
+import io.yak.ops.business.datasource.dao.DataSourceDao;
+import io.yak.ops.business.datasource.dao.mapper.DataSourceMapper;
+import io.yak.ops.business.datasource.repository.DataSourceRepository;
+import io.yak.ops.business.datasource.service.impl.DataSourceCatalogServiceImpl;
+import io.yak.ops.business.datasource.service.impl.DataSourcePluginConfigServiceImpl;
+import io.yak.ops.business.datasource.service.impl.DataSourceServiceImpl;
+import io.yak.ops.common.bean.po.datasource.DataSourcePO;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class DataSourceLayeringConventionTest {
+
+  @Test
+  void repositoryExposesOnlyDomainContracts() {
+    assertMethodsAvoid(DataSourceRepository.class, ".bean.dto.", ".bean.vo.", ".bean.po.");
+  }
+
+  @Test
+  void daoDoesNotDependOnTransportModels() {
+    assertMethodsAvoid(DataSourceDao.class, ".bean.dto.", ".bean.vo.");
+  }
+
+  @Test
+  void servicesDoNotInjectDaoOrPersistenceObjects() {
+    for (Class<?> type :
+        List.of(
+            DataSourceServiceImpl.class,
+            DataSourceCatalogServiceImpl.class,
+            DataSourcePluginConfigServiceImpl.class)) {
+      for (Field field : type.getDeclaredFields()) {
+        String fieldType = field.getGenericType().getTypeName();
+        assertThat(fieldType)
+            .as(type.getSimpleName() + "." + field.getName())
+            .doesNotContain(".business.datasource.dao.")
+            .doesNotContain(".bean.po.");
+      }
+    }
+  }
+
+  @Test
+  void controllersEnterBusinessThroughServicesOnly() {
+    for (Class<?> type :
+        List.of(
+            DataSourceController.class,
+            DataSourceCatalogController.class,
+            DataSourcePluginConfigController.class)) {
+      for (Field field : type.getDeclaredFields()) {
+        assertThat(field.getType().getPackageName())
+            .as(type.getSimpleName() + "." + field.getName())
+            .startsWith("io.yak.ops.business.datasource.service");
+      }
+    }
+  }
+
+  @Test
+  void summaryMapperReturnsPersistenceProjectionInsteadOfVo() throws Exception {
+    Method method = DataSourceMapper.class.getMethod("selectSummary");
+    assertThat(method.getReturnType().getPackageName())
+        .isEqualTo("io.yak.ops.business.datasource.dao.model");
+  }
+
+  @Test
+  void persistenceStillUsesSingleDatasourceTable() {
+    TableName tableName = DataSourcePO.class.getAnnotation(TableName.class);
+    assertThat(tableName).isNotNull();
+    assertThat(tableName.value()).isEqualTo("yak_ops_data_source");
+  }
+
+  private void assertMethodsAvoid(Class<?> owner, String... forbidden) {
+    for (Method method : owner.getMethods()) {
+      assertTypeAvoids(owner, method, method.getGenericReturnType(), forbidden);
+      for (Type parameter : method.getGenericParameterTypes()) {
+        assertTypeAvoids(owner, method, parameter, forbidden);
+      }
+    }
+  }
+
+  private void assertTypeAvoids(Class<?> owner, Method method, Type type, String... forbidden) {
+    String signature = typeName(type);
+    for (String packagePart : forbidden) {
+      assertThat(signature)
+          .as("%s.%s must not expose %s", owner.getSimpleName(), method.getName(), packagePart)
+          .doesNotContain(packagePart);
+    }
+  }
+
+  private String typeName(Type type) {
+    if (type instanceof ParameterizedType parameterized) {
+      StringBuilder value = new StringBuilder(parameterized.getRawType().getTypeName());
+      for (Type argument : parameterized.getActualTypeArguments()) {
+        value.append('<').append(typeName(argument)).append('>');
+      }
+      return value.toString();
+    }
+    return type.getTypeName();
+  }
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/repository/DataSourceRepositoryAdapterTest.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/repository/DataSourceRepositoryAdapterTest.java
@@ -1,0 +1,63 @@
+package io.yak.ops.business.datasource.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.datasource.dao.DataSourceDao;
+import io.yak.ops.business.datasource.dao.model.DataSourceSummaryRow;
+import io.yak.ops.business.datasource.domain.DataSourceDefinition;
+import io.yak.ops.business.datasource.domain.DataSourceSummary;
+import io.yak.ops.common.bean.po.datasource.DataSourcePO;
+import io.yak.ops.common.enums.datasource.DataSourceConnStatus;
+import io.yak.ops.common.enums.datasource.DataSourceDbType;
+import io.yak.ops.common.enums.datasource.DataSourceEnvironment;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class DataSourceRepositoryAdapterTest {
+
+  @Mock private DataSourceDao dao;
+
+  @Test
+  void mapsPersistenceRowToDomainIncludingRuntimeConnectionData() {
+    DataSourcePO po = new DataSourcePO();
+    po.setId(42L);
+    po.setName("orders-db");
+    po.setDbType(DataSourceDbType.MYSQL);
+    po.setEnvironment(DataSourceEnvironment.PROD);
+    po.setConnStatus(DataSourceConnStatus.CONNECTED);
+    po.setConnectionParams("{\"host\":\"127.0.0.1\"}");
+    po.setOriginalJson("{\"host\":\"127.0.0.1\"}");
+    when(dao.selectById(42L)).thenReturn(po);
+
+    DataSourceDefinition result = new DataSourceRepositoryAdapter(dao).findById(42L).orElseThrow();
+
+    assertThat(result.getId()).isEqualTo(42L);
+    assertThat(result.getDbType()).isEqualTo(DataSourceDbType.MYSQL);
+    assertThat(result.getEnvironment()).isEqualTo(DataSourceEnvironment.PROD);
+    assertThat(result.getConnStatus()).isEqualTo(DataSourceConnStatus.CONNECTED);
+    assertThat(result.getConnectionParams()).contains("127.0.0.1");
+  }
+
+  @Test
+  void mapsDaoSummaryProjectionToDomain() {
+    DataSourceSummaryRow row = new DataSourceSummaryRow();
+    row.setTotal(8L);
+    row.setConnected(5L);
+    row.setDisconnected(2L);
+    row.setUnknown(1L);
+    row.setEnvironmentCount(3L);
+    when(dao.selectSummary()).thenReturn(row);
+
+    DataSourceSummary result = new DataSourceRepositoryAdapter(dao).summary();
+
+    assertThat(result.total()).isEqualTo(8L);
+    assertThat(result.connected()).isEqualTo(5L);
+    assertThat(result.disconnected()).isEqualTo(2L);
+    assertThat(result.unknown()).isEqualTo(1L);
+    assertThat(result.environmentCount()).isEqualTo(3L);
+  }
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/service/impl/DataSourceCatalogServiceImplTest.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/service/impl/DataSourceCatalogServiceImplTest.java
@@ -5,19 +5,19 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoInteractions;
 
 import io.yak.ops.business.datasource.config.DataSourceProperties;
-import io.yak.ops.business.datasource.dao.DataSourceDao;
 import io.yak.ops.business.datasource.exception.DataSourceException;
 import io.yak.ops.business.datasource.plugin.DataSourcePluginRegistry;
+import io.yak.ops.business.datasource.repository.DataSourceRepository;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 class DataSourceCatalogServiceImplTest {
 
-  private final DataSourceDao dataSourceDao = mock(DataSourceDao.class);
+  private final DataSourceRepository repository = mock(DataSourceRepository.class);
   private final DataSourcePluginRegistry pluginRegistry = mock(DataSourcePluginRegistry.class);
   private final DataSourceProperties properties = mock(DataSourceProperties.class);
   private final DataSourceCatalogServiceImpl service =
-      new DataSourceCatalogServiceImpl(dataSourceDao, pluginRegistry, properties);
+      new DataSourceCatalogServiceImpl(repository, pluginRegistry, properties);
 
   @Test
   void shouldRejectNonSelectSqlBeforeOpeningDatasourceConnection() {
@@ -31,7 +31,7 @@ class DataSourceCatalogServiceImplTest {
         .isInstanceOf(DataSourceException.class)
         .hasMessageContaining("仅允许执行单条 SELECT 查询");
 
-    verifyNoInteractions(dataSourceDao, pluginRegistry, properties);
+    verifyNoInteractions(repository, pluginRegistry, properties);
   }
 
   @Test

--- a/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/service/impl/DataSourceServiceImplTest.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/service/impl/DataSourceServiceImplTest.java
@@ -1,0 +1,75 @@
+package io.yak.ops.business.datasource.service.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.datasource.config.DataSourceProperties;
+import io.yak.ops.business.datasource.domain.DataSourcePage;
+import io.yak.ops.business.datasource.domain.DataSourceQuery;
+import io.yak.ops.business.datasource.plugin.DataSourcePluginRegistry;
+import io.yak.ops.business.datasource.repository.DataSourceRepository;
+import io.yak.ops.business.datasource.service.support.DataSourceViewMapper;
+import io.yak.ops.business.datasource.util.DataSourceSecretCodec;
+import io.yak.ops.common.bean.dto.datasource.DataSourceQueryDTO;
+import io.yak.ops.common.enums.datasource.DataSourceConnStatus;
+import io.yak.ops.common.enums.datasource.DataSourceDbType;
+import io.yak.ops.common.enums.datasource.DataSourceEnvironment;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class DataSourceServiceImplTest {
+
+  @Mock private DataSourceRepository repository;
+  @Mock private DataSourcePluginRegistry pluginRegistry;
+  @Mock private DataSourceProperties properties;
+  @Mock private DataSourceSecretCodec secretCodec;
+  @Mock private DataSourceViewMapper viewMapper;
+
+  @Test
+  void pageConvertsHttpQueryToDomainWithoutMutatingRequest() {
+    DataSourceQueryDTO request = new DataSourceQueryDTO();
+    request.setPageNo(2);
+    request.setPageSize(50);
+    request.setName("  orders-db  ");
+    request.setKeyword("  jdbc:mysql  ");
+    request.setDbType(" mysql ");
+    request.setEnvironment(" production ");
+    request.setConnStatus(" connected ");
+
+    when(repository.page(any(DataSourceQuery.class)))
+        .thenReturn(new DataSourcePage<>(java.util.List.of(), 0L, 0L, 2L, 50L));
+
+    service().getDataSourcePage(request);
+
+    ArgumentCaptor<DataSourceQuery> captor = ArgumentCaptor.forClass(DataSourceQuery.class);
+    verify(repository).page(captor.capture());
+    DataSourceQuery query = captor.getValue();
+
+    assertThat(query.pageNo()).isEqualTo(2);
+    assertThat(query.pageSize()).isEqualTo(50);
+    assertThat(query.name()).isEqualTo("orders-db");
+    assertThat(query.keyword()).isEqualTo("jdbc:mysql");
+    assertThat(query.dbType()).isEqualTo(DataSourceDbType.MYSQL);
+    assertThat(query.environment()).isEqualTo(DataSourceEnvironment.PROD);
+    assertThat(query.connStatus()).isEqualTo(DataSourceConnStatus.CONNECTED);
+
+    assertThat(request.getName()).isEqualTo("  orders-db  ");
+    assertThat(request.getDbType()).isEqualTo(" mysql ");
+    assertThat(request.getEnvironment()).isEqualTo(" production ");
+  }
+
+  private DataSourceServiceImpl service() {
+    return new DataSourceServiceImpl(
+        repository,
+        pluginRegistry,
+        properties,
+        secretCodec,
+        viewMapper);
+  }
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/service/support/DataSourceViewMapperTest.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/service/support/DataSourceViewMapperTest.java
@@ -1,0 +1,50 @@
+package io.yak.ops.business.datasource.service.support;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.datasource.domain.DataSourceDefinition;
+import io.yak.ops.business.datasource.plugin.DataSourcePluginRegistry;
+import io.yak.ops.business.datasource.util.DataSourceSecretCodec;
+import io.yak.ops.common.bean.vo.datasource.DataSourceVO;
+import io.yak.ops.common.enums.datasource.DataSourceConnStatus;
+import io.yak.ops.common.enums.datasource.DataSourceDbType;
+import io.yak.ops.common.enums.datasource.DataSourceEnvironment;
+import io.yak.ops.spi.datasource.DataSourcePlugin;
+import org.junit.jupiter.api.Test;
+
+class DataSourceViewMapperTest {
+
+  @Test
+  void detailKeepsJdbcAndConnectionJsonMasked() {
+    DataSourcePluginRegistry registry = mock(DataSourcePluginRegistry.class);
+    DataSourceSecretCodec secretCodec = mock(DataSourceSecretCodec.class);
+    DataSourcePlugin plugin = mock(DataSourcePlugin.class);
+    DataSourceViewMapper mapper = new DataSourceViewMapper(registry, secretCodec);
+
+    DataSourceDefinition source = new DataSourceDefinition();
+    source.setId(42L);
+    source.setName("orders-db");
+    source.setDbType(DataSourceDbType.MYSQL);
+    source.setEnvironment(DataSourceEnvironment.PROD);
+    source.setConnStatus(DataSourceConnStatus.CONNECTED);
+    source.setJdbcUrl("jdbc:mysql://root:secret@127.0.0.1:3306/orders");
+    source.setOriginalJson("{\"password\":\"secret\"}");
+
+    when(registry.get(DataSourceDbType.MYSQL)).thenReturn(plugin);
+    when(secretCodec.maskSensitiveText(source.getJdbcUrl()))
+        .thenReturn("jdbc:mysql://root:******@127.0.0.1:3306/orders");
+    when(secretCodec.maskConnectionJson(plugin, source.getOriginalJson()))
+        .thenReturn("{\"password\":\"******\"}");
+
+    DataSourceVO result = mapper.definition(source, true);
+
+    assertThat(result.getJdbcUrl()).doesNotContain("secret");
+    assertThat(result.getOriginalJson()).doesNotContain("secret");
+    assertThat(result.getEnvironmentName()).isEqualTo("生产");
+    verify(secretCodec).maskSensitiveText(source.getJdbcUrl());
+    verify(secretCodec).maskConnectionJson(plugin, source.getOriginalJson());
+  }
+}


### PR DESCRIPTION
## Summary

Standardize the datasource business module with the same backend layering conventions used by Workflow, Data Quality and Offline Sync:

`Controller -> DTO -> Service -> Domain -> Repository -> Adapter -> DAO -> BaseMapper/XML -> PO -> MySQL`

This is an engineering-structure refactor. Existing datasource APIs, plugin SPI behavior, secret masking rules, Catalog semantics and the single-table schema remain unchanged.

## 1. Domain and Repository boundary

Add datasource business models for:
- `DataSourceDefinition`
- `DataSourceQuery`
- `DataSourceSummary`
- `DataSourcePage`

Add `DataSourceRepository` plus a MyBatis-backed `DataSourceRepositoryAdapter`.

`DataSourceServiceImpl` and `DataSourceCatalogServiceImpl` now operate on Domain objects and no longer directly depend on `DataSourcePO`, `DataSourceDao` or MyBatis `IPage`.

## 2. DAO no longer depends on HTTP models

`DataSourceDao` now owns its persistence query contract:

- `PageQuery` for filtering/paging;
- `DataSourceSummaryRow` for aggregate SQL projection.

It no longer accepts `DataSourceQueryDTO` and no longer returns `DataSourceSummaryVO`.

This keeps DTO/VO at the HTTP/service boundary and PO/DAO inside persistence.

## 3. Summary SQL moved to Mapper XML

The datasource aggregate summary query is moved from an annotated Mapper method into:

`mapper/datasource/DataSourceMapper.xml`

The Mapper now returns the DAO-local `DataSourceSummaryRow` rather than an HTTP VO.

The SQL uses `environment_count`; the shared Yak business MyBatis configuration already enables underscore-to-camel mapping, so it maps deterministically to `environmentCount`.

Normal single-table CRUD/search remains on MyBatis-Plus BaseMapper/LambdaWrapper.

## 4. View mapping and secret boundary

Add `DataSourceViewMapper` for Domain -> VO conversion.

Existing security behavior is preserved:
- JDBC URLs are passed through `DataSourceSecretCodec.maskSensitiveText`;
- detail `originalJson` is passed through plugin-aware `maskConnectionJson`;
- list/page responses still omit the original connection JSON.

`connectionParams` and `originalJson` may exist inside the internal Domain because Catalog execution, connection tests and edit-time secret reuse need them, but raw values do not cross the HTTP response boundary.

A focused regression test now verifies both JDBC URL and connection JSON masking.

## 5. Catalog runtime uses Domain

Catalog metadata/preview/count/SQL operations now follow:

`Catalog Service -> DataSourceRepository -> DataSourceDefinition -> Datasource Plugin SPI`

Catalog no longer reads `DataSourceDao` / `DataSourcePO` directly.

Existing behavior remains unchanged, including:
- database/schema/table/column discovery;
- preview/count;
- SQL template/resolve;
- read-only single-SELECT validation;
- regex validation;
- plugin exception mapping and timeout configuration.

## 6. Query conversion is immutable

HTTP `DataSourceQueryDTO` is converted to immutable `DataSourceQuery` before persistence access.

The service no longer trims/normalizes by mutating the caller's DTO. Tests verify whitespace normalization, enum parsing and that the original request object remains unchanged.

## 7. Existing CRUD and connection semantics preserved

The refactor keeps:
- duplicate-name protection;
- immutable datasource type on edit;
- edit-time secret merge/reuse;
- normalized plugin connection parsing;
- saved connection test status updates (`CONNECTED` / `DISCONNECTED`);
- ad-hoc connection tests;
- options/all/page/summary responses;
- existing transaction-manager and plugin SPI boundaries.

## 8. Architecture and regression coverage

Add coverage protecting:
- Repository APIs from DTO/VO/PO leakage;
- DAO APIs from DTO/VO leakage;
- Service implementations from direct DAO/PO dependencies;
- Controllers from bypassing Service;
- summary Mapper returning a persistence projection instead of VO;
- the existing single `yak_ops_data_source` table boundary;
- DTO -> Domain query conversion without request mutation;
- PO -> Domain mapping including runtime connection data;
- summary Row -> Domain mapping;
- JDBC URL and connection JSON masking after extracting the View Mapper;
- existing Catalog read-only SQL validation with the Repository boundary.

The module README now documents the layering and secret-handling rules.

## Scope intentionally unchanged

- no datasource table/Flyway changes
- no REST path or JSON contract changes
- no frontend changes
- no plugin SPI changes
- no Catalog behavior changes
- no credential-encryption-at-rest change
- no datasource pool/session-factory/transaction-manager changes

## Validation

- branch is based on current `main` and is 0 commits behind;
- final changes are confined to `yak-ops-business-datasource`;
- static patch review shows PO/MyBatis types confined to DAO/Adapter/tests rather than Service/Controller;
- DAO no longer imports datasource HTTP DTO/VO contracts;
- shared MyBatis configuration already loads `classpath*:mapper/**/*.xml` and enables underscore-to-camel mapping;
- GitHub reports this Draft PR as mergeable;
- no GitHub Actions workflow runs or commit statuses are configured for the current head.

A full local Maven/MySQL integration build was not executed in this connector environment, so the PR remains Draft pending normal module tests and startup/Flyway validation.