### PR TITLE
refactor(quality): finalize shared paging contract

### DIFF
--- a/yak-ops-business/yak-ops-business-quality/README.md
+++ b/yak-ops-business/yak-ops-business-quality/README.md
@@ -18,9 +18,10 @@ DAO / Mapper             Repository / Service             HTTP
 约束：
 
 - Repository 对外分页统一使用 `io.yak.framework.common.PageData<T>`，不暴露 MyBatis `IPage`。
-- `QualityDomain.Page` 仅作为第一阶段兼容旧 Adapter 实现的废弃别名，不再作为 Repository 契约；后续清理 Adapter 时直接删除。
-- Service 继续按现有 VO 契约输出 `records/total/current/pageSize` 等质量模块接口字段，本次不修改 HTTP JSON。
+- Data Quality 不再维护 `QualityDomain.Page` 等模块私有普通分页容器。
+- Repository Adapter 负责根据 `total/current/pageSize` 计算完整的 `pages` 元数据并构造 `PageData`。
+- Service 继续按现有 VO 契约输出 `records/total/current/pageSize` 等质量模块接口字段，不修改 HTTP JSON。
 - DAO / Mapper 仍可使用持久化层自己的分页参数、limit/offset 和 MyBatis 能力。
-- 新增分页功能不得再创建模块私有 `Page/XxxPage` 类型，应直接复用 `PageData<T>`。
+- 新增分页功能不得再创建普通 `Page/XxxPage` 类型，应直接复用 `PageData<T>`；只有包含独立业务语义的分页类型才允许例外。
 
 全局分页边界规范由 Yak Framework `docs/pagination-conventions.md` 定义。

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/domain/QualityDomain.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/domain/QualityDomain.java
@@ -1,6 +1,5 @@
 package io.yak.ops.business.quality.domain;
 
-import io.yak.framework.common.PageData;
 import io.yak.ops.common.enums.quality.QualityEnums.AlertLevel;
 import io.yak.ops.common.enums.quality.QualityEnums.CheckMethod;
 import io.yak.ops.common.enums.quality.QualityEnums.CheckResult;
@@ -23,23 +22,6 @@ import java.util.List;
 /** 数据质量业务领域模型。HTTP DTO/VO 与数据库 PO 不进入该层。 */
 public final class QualityDomain {
   private QualityDomain() {}
-
-  /**
-   * 第一阶段兼容别名。Repository 对外统一暴露 {@link PageData}；该类型仅用于兼容现有 Adapter 实现。
-   *
-   * @deprecated 新代码直接使用 {@link PageData}
-   */
-  @Deprecated(forRemoval = false)
-  public static class Page<T> extends PageData<T> {
-    public Page(List<T> records, long total) {
-      super(
-          records,
-          total,
-          total == 0L ? 0L : 1L,
-          1L,
-          records == null ? 0L : records.size());
-    }
-  }
 
   public record Template(
       Long id, String code, String name, String description,

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/repository/QualityExecutionWorkspaceRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/repository/QualityExecutionWorkspaceRepositoryAdapter.java
@@ -1,9 +1,9 @@
 package io.yak.ops.business.quality.repository;
 
+import io.yak.framework.common.PageData;
 import io.yak.ops.business.quality.config.ConditionalOnQualityEnabled;
 import io.yak.ops.business.quality.dao.QualityExecutionDao;
 import io.yak.ops.business.quality.domain.QualityDomain.Execution;
-import io.yak.ops.business.quality.domain.QualityDomain.Page;
 import io.yak.ops.business.quality.domain.QualityDomain.RuleExecution;
 import io.yak.ops.business.quality.domain.QualityDomain.RuleExecutionWorkspaceItem;
 import io.yak.ops.business.quality.domain.QualityQuery;
@@ -12,7 +12,6 @@ import io.yak.ops.common.bean.po.quality.QualityQueryPO.RuleExecutionWorkspaceRo
 import io.yak.ops.common.bean.po.quality.QualityRuleExecutionPO;
 import io.yak.ops.common.enums.quality.QualityEnums.CheckResult;
 import io.yak.ops.common.enums.quality.QualityEnums.ExecutionStatus;
-import io.yak.ops.common.enums.quality.QualityEnums.RuleScope;
 import io.yak.ops.common.enums.quality.QualityEnums.RuleType;
 import io.yak.ops.common.enums.quality.QualityEnums.TriggerType;
 import java.util.ArrayList;
@@ -34,21 +33,23 @@ public class QualityExecutionWorkspaceRepositoryAdapter
   private final QualityExecutionDao executionDao;
 
   @Override
-  public Page<Execution> page(QualityQuery.ExecutionWorkspace query) {
+  public PageData<Execution> page(QualityQuery.ExecutionWorkspace query) {
     Map<String, Object> params = params(query);
     long total = executionDao.countExecutionWorkspace(params);
     paginate(params, query.current(), query.pageSize());
-    return new Page<>(executionDao.selectExecutionWorkspace(params).stream()
-        .map(po -> execution(po, List.of())).toList(), total);
+    List<Execution> records = executionDao.selectExecutionWorkspace(params).stream()
+        .map(po -> execution(po, List.of())).toList();
+    return pageData(records, total, query.current(), query.pageSize());
   }
 
   @Override
-  public Page<RuleExecutionWorkspaceItem> pageRules(QualityQuery.ExecutionWorkspace query) {
+  public PageData<RuleExecutionWorkspaceItem> pageRules(QualityQuery.ExecutionWorkspace query) {
     Map<String, Object> params = params(query);
     long total = executionDao.countRuleExecutionWorkspace(params);
     paginate(params, query.current(), query.pageSize());
-    return new Page<>(executionDao.selectRuleExecutionWorkspace(params).stream()
-        .map(this::ruleItem).toList(), total);
+    List<RuleExecutionWorkspaceItem> records = executionDao.selectRuleExecutionWorkspace(params).stream()
+        .map(this::ruleItem).toList();
+    return pageData(records, total, query.current(), query.pageSize());
   }
 
   @Override
@@ -122,6 +123,15 @@ public class QualityExecutionWorkspaceRepositoryAdapter
   private static void paginate(Map<String, Object> params, int current, int pageSize) {
     params.put("limit", pageSize);
     params.put("offset", (current - 1L) * pageSize);
+  }
+
+  private static <T> PageData<T> pageData(
+      List<T> records,
+      long total,
+      int current,
+      int pageSize) {
+    long pages = pageSize <= 0 ? 0L : (total + pageSize - 1L) / pageSize;
+    return new PageData<>(records, total, pages, current, pageSize);
   }
 
   private static void putLike(Map<String, Object> params, String key, String value) {

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/repository/QualityExecutionWorkspaceRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/repository/QualityExecutionWorkspaceRepositoryAdapter.java
@@ -39,7 +39,7 @@ public class QualityExecutionWorkspaceRepositoryAdapter
     paginate(params, query.current(), query.pageSize());
     List<Execution> records = executionDao.selectExecutionWorkspace(params).stream()
         .map(po -> execution(po, List.of())).toList();
-    return PageData.of(records, total, query.current(), query.pageSize());
+    return pageData(records, total, query.current(), query.pageSize());
   }
 
   @Override
@@ -49,7 +49,7 @@ public class QualityExecutionWorkspaceRepositoryAdapter
     paginate(params, query.current(), query.pageSize());
     List<RuleExecutionWorkspaceItem> records = executionDao.selectRuleExecutionWorkspace(params).stream()
         .map(this::ruleItem).toList();
-    return PageData.of(records, total, query.current(), query.pageSize());
+    return pageData(records, total, query.current(), query.pageSize());
   }
 
   @Override
@@ -123,6 +123,15 @@ public class QualityExecutionWorkspaceRepositoryAdapter
   private static void paginate(Map<String, Object> params, int current, int pageSize) {
     params.put("limit", pageSize);
     params.put("offset", (current - 1L) * pageSize);
+  }
+
+  private static <T> PageData<T> pageData(
+      List<T> records,
+      long total,
+      int current,
+      int pageSize) {
+    long pages = pageSize <= 0 ? 0L : (total + pageSize - 1L) / pageSize;
+    return new PageData<>(records, total, pages, current, pageSize);
   }
 
   private static void putLike(Map<String, Object> params, String key, String value) {

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/repository/QualityExecutionWorkspaceRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/repository/QualityExecutionWorkspaceRepositoryAdapter.java
@@ -39,7 +39,7 @@ public class QualityExecutionWorkspaceRepositoryAdapter
     paginate(params, query.current(), query.pageSize());
     List<Execution> records = executionDao.selectExecutionWorkspace(params).stream()
         .map(po -> execution(po, List.of())).toList();
-    return pageData(records, total, query.current(), query.pageSize());
+    return PageData.of(records, total, query.current(), query.pageSize());
   }
 
   @Override
@@ -49,7 +49,7 @@ public class QualityExecutionWorkspaceRepositoryAdapter
     paginate(params, query.current(), query.pageSize());
     List<RuleExecutionWorkspaceItem> records = executionDao.selectRuleExecutionWorkspace(params).stream()
         .map(this::ruleItem).toList();
-    return pageData(records, total, query.current(), query.pageSize());
+    return PageData.of(records, total, query.current(), query.pageSize());
   }
 
   @Override
@@ -123,15 +123,6 @@ public class QualityExecutionWorkspaceRepositoryAdapter
   private static void paginate(Map<String, Object> params, int current, int pageSize) {
     params.put("limit", pageSize);
     params.put("offset", (current - 1L) * pageSize);
-  }
-
-  private static <T> PageData<T> pageData(
-      List<T> records,
-      long total,
-      int current,
-      int pageSize) {
-    long pages = pageSize <= 0 ? 0L : (total + pageSize - 1L) / pageSize;
-    return new PageData<>(records, total, pages, current, pageSize);
   }
 
   private static void putLike(Map<String, Object> params, String key, String value) {

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/repository/QualityRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/repository/QualityRepositoryAdapter.java
@@ -3,18 +3,17 @@ package io.yak.ops.business.quality.repository;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.framework.common.PageData;
 import io.yak.ops.business.quality.config.ConditionalOnQualityEnabled;
 import io.yak.ops.business.quality.dao.QualityCatalogDao;
 import io.yak.ops.business.quality.dao.QualityExecutionDao;
 import io.yak.ops.business.quality.dao.QualityMonitorDao;
-import io.yak.ops.business.quality.domain.QualityDomain;
 import io.yak.ops.business.quality.domain.QualityDomain.AlertEventSpec;
 import io.yak.ops.business.quality.domain.QualityDomain.Execution;
 import io.yak.ops.business.quality.domain.QualityDomain.Monitor;
 import io.yak.ops.business.quality.domain.QualityDomain.MonitorSettings;
 import io.yak.ops.business.quality.domain.QualityDomain.MonitorSettingsSpec;
 import io.yak.ops.business.quality.domain.QualityDomain.MonitorSpec;
-import io.yak.ops.business.quality.domain.QualityDomain.Page;
 import io.yak.ops.business.quality.domain.QualityDomain.Rule;
 import io.yak.ops.business.quality.domain.QualityDomain.RuleExecution;
 import io.yak.ops.business.quality.domain.QualityDomain.RuleExecutionSpec;
@@ -94,12 +93,13 @@ public class QualityRepositoryAdapter implements QualityRepository {
   }
 
   @Override
-  public Page<TableAsset> pageTableAssets(QualityQuery.TableAsset query) {
+  public PageData<TableAsset> pageTableAssets(QualityQuery.TableAsset query) {
     Map<String, Object> params = tableAssetParams(query);
     long total = monitorDao.countTableAssets(params);
     params.put("limit", query.pageSize());
     params.put("offset", (query.current() - 1L) * query.pageSize());
-    return new Page<>(monitorDao.selectTableAssets(params).stream().map(this::tableAsset).toList(), total);
+    List<TableAsset> records = monitorDao.selectTableAssets(params).stream().map(this::tableAsset).toList();
+    return pageData(records, total, query.current(), query.pageSize());
   }
 
   @Override
@@ -124,12 +124,14 @@ public class QualityRepositoryAdapter implements QualityRepository {
   @Override public boolean deleteTableAsset(long assetId) { return monitorDao.softDeleteTableAsset(assetId); }
 
   @Override
-  public Page<Monitor> pageMonitors(QualityQuery.Monitor query) {
+  public PageData<Monitor> pageMonitors(QualityQuery.Monitor query) {
     Map<String, Object> params = monitorParams(query);
     long total = monitorDao.countMonitors(params);
     params.put("limit", query.pageSize());
     params.put("offset", (query.current() - 1L) * query.pageSize());
-    return new Page<>(monitorDao.selectMonitors(params).stream().map(row -> monitor(row, List.of())).toList(), total);
+    List<Monitor> records = monitorDao.selectMonitors(params).stream()
+        .map(row -> monitor(row, List.of())).toList();
+    return pageData(records, total, query.current(), query.pageSize());
   }
 
   @Override
@@ -231,11 +233,14 @@ public class QualityRepositoryAdapter implements QualityRepository {
   @Override public boolean updateMonitorResult(long monitorId, String executionNo, CheckResult result, LocalDateTime runTime) { return monitorDao.updateMonitorResult(monitorId, executionNo, result.name(), runTime); }
 
   @Override
-  public Page<Execution> pageExecutions(QualityQuery.Execution query) {
+  public PageData<Execution> pageExecutions(QualityQuery.Execution query) {
     Map<String, Object> params = executionParams(query);
     long total = executionDao.countExecutions(params);
-    params.put("limit", query.pageSize()); params.put("offset", (query.current() - 1L) * query.pageSize());
-    return new Page<>(executionDao.selectExecutions(params).stream().map(po -> execution(po, List.of())).toList(), total);
+    params.put("limit", query.pageSize());
+    params.put("offset", (query.current() - 1L) * query.pageSize());
+    List<Execution> records = executionDao.selectExecutions(params).stream()
+        .map(po -> execution(po, List.of())).toList();
+    return pageData(records, total, query.current(), query.pageSize());
   }
 
   @Override
@@ -391,6 +396,15 @@ public class QualityRepositoryAdapter implements QualityRepository {
     if (!hasText(json)) return List.of();
     try { return objectMapper.readValue(json, new TypeReference<>() {}); }
     catch (JsonProcessingException e) { throw new IllegalStateException("数据库中的枚举值配置无法解析", e); }
+  }
+
+  private static <T> PageData<T> pageData(
+      List<T> records,
+      long total,
+      int current,
+      int pageSize) {
+    long pages = pageSize <= 0 ? 0L : (total + pageSize - 1L) / pageSize;
+    return new PageData<>(records, total, pages, current, pageSize);
   }
 
   private static CheckResult checkResult(String value) { return hasText(value) ? CheckResult.valueOf(value) : CheckResult.NOT_RUN; }

--- a/yak-ops-business/yak-ops-business-quality/src/test/java/io/yak/ops/business/quality/architecture/QualityLayeringConventionTest.java
+++ b/yak-ops-business/yak-ops-business-quality/src/test/java/io/yak/ops/business/quality/architecture/QualityLayeringConventionTest.java
@@ -8,6 +8,7 @@ import io.yak.ops.business.quality.dao.QualityAnalyticsDao;
 import io.yak.ops.business.quality.dao.QualityCatalogDao;
 import io.yak.ops.business.quality.dao.QualityExecutionDao;
 import io.yak.ops.business.quality.dao.QualityMonitorDao;
+import io.yak.ops.business.quality.domain.QualityDomain;
 import io.yak.ops.business.quality.domain.QualityQuery;
 import io.yak.ops.business.quality.repository.CustomTemplateRepository;
 import io.yak.ops.business.quality.repository.QualityExecutionWorkspaceRepository;
@@ -24,6 +25,7 @@ import io.yak.ops.common.bean.po.quality.QualityTableAssetPO;
 import io.yak.ops.common.bean.po.quality.QualityTemplateFolderPO;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
+import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
@@ -40,15 +42,26 @@ class QualityLayeringConventionTest {
 
   @Test
   void repositoryPagingUsesSharedPageData() throws Exception {
+    Method tableAssets =
+        QualityRepository.class.getMethod("pageTableAssets", QualityQuery.TableAsset.class);
     Method monitors = QualityRepository.class.getMethod("pageMonitors", QualityQuery.Monitor.class);
     Method executions = QualityRepository.class.getMethod("pageExecutions", QualityQuery.Execution.class);
     Method workspace =
         QualityExecutionWorkspaceRepository.class.getMethod("page", QualityQuery.ExecutionWorkspace.class);
-    for (Method method : List.of(monitors, executions, workspace)) {
+    Method workspaceRules =
+        QualityExecutionWorkspaceRepository.class.getMethod("pageRules", QualityQuery.ExecutionWorkspace.class);
+    for (Method method : List.of(tableAssets, monitors, executions, workspace, workspaceRules)) {
       assertThat(((ParameterizedType) method.getGenericReturnType()).getRawType())
           .as(method.getName())
           .isEqualTo(PageData.class);
     }
+  }
+
+  @Test
+  void qualityDomainDoesNotReintroducePrivatePagingContainers() {
+    assertThat(Arrays.stream(QualityDomain.class.getDeclaredClasses())
+            .map(Class::getSimpleName))
+        .doesNotContain("Page", "PageData", "PagingData");
   }
 
   @Test


### PR DESCRIPTION
## Summary

Complete pagination Phase 2 on the Yak Ops side by removing the final Data Quality compatibility paging alias and using the shared Framework `PageData<T>` contract directly.

This PR is intentionally small and should be merged **before** the companion Yak Framework Phase 2 PR.

## 1. Remove `QualityDomain.Page<T>`

Phase 1 temporarily kept:

```java
QualityDomain.Page<T> extends PageData<T>
```

as an Adapter-only compatibility alias. This PR removes it completely.

Data Quality no longer owns a generic business paging container.

## 2. Repository Adapters return `PageData<T>` directly

Update:

- `QualityRepositoryAdapter`
- `QualityExecutionWorkspaceRepositoryAdapter`

Paging methods now construct `PageData<T>` directly and preserve complete metadata:

```text
records
total
pages
pageNo
pageSize
```

For the existing `limit / offset` queries, `pages` is calculated from `total` and `pageSize` rather than using the Phase 1 compatibility alias's placeholder metadata.

Repository interfaces were already standardized to `PageData<T>` in Phase 1, so this PR only removes the remaining implementation compatibility layer.

## 3. Architecture protection

Extend `QualityLayeringConventionTest` to verify:

- all Data Quality Repository paging methods use shared `PageData<T>`;
- Repository signatures do not expose MyBatis types;
- `QualityDomain` does not reintroduce `Page`, `PageData` or `PagingData` nested wrappers.

## 4. Documentation

Update the Data Quality README so the module rule is now final:

```text
DAO / Mapper / limit-offset query
        ↓
Repository Adapter
        ↓
PageData<Domain>
        ↓
Service / existing HTTP VO
```

No module-private generic `Page/XxxPage<T>` is allowed unless it carries real additional business semantics.

## Scope intentionally unchanged

- no REST path changes;
- no HTTP JSON field changes;
- no front-end changes;
- no database/Flyway changes;
- no SQL/filter semantic changes;
- no quality execution/runtime behavior changes.

## Merge order

Merge this PR first, then merge the companion Yak Framework Phase 2 PR.

Reason: the Framework PR makes `PageData` final to prevent future `XxxPage extends PageData` aliases. Current Yak Ops main still contains the temporary `QualityDomain.Page extends PageData`; removing that alias first avoids a transient cross-repository compilation break.

## Validation

Branch is based on current `main` and is 0 commits behind.

The available execution environment cannot resolve `github.com`, so a full local Maven reactor build was not available here. Before marking Ready, run:

```bash
mvn -pl yak-ops-business/yak-ops-business-quality -am test
mvn -pl yak-ops-boot -am package -DskipTests
```
