### PR TITLE
fix(paging): migrate remaining PagingResult envelopes

### DIFF
--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/controller/v1/DataSourceController.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/controller/v1/DataSourceController.java
@@ -3,7 +3,6 @@ package io.yak.ops.business.datasource.controller.v1;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.yak.framework.common.PagingData;
-import io.yak.framework.common.PagingResult;
 import io.yak.framework.common.Result;
 import io.yak.framework.security.web.RequiresPermission;
 import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
@@ -72,9 +71,9 @@ public class DataSourceController {
 
   @Operation(summary = "分页查询数据源")
   @PostMapping("/page")
-  public PagingResult<DataSourceVO> page(
+  public Result<PagingData<DataSourceVO>> page(
       @Valid @RequestBody DataSourceQueryDTO queryDTO) {
-    return PagingResult.success(dataSourceService.getDataSourcePage(queryDTO));
+    return Result.success(dataSourceService.getDataSourcePage(queryDTO));
   }
 
   @Operation(summary = "查询数据源总览统计")

--- a/yak-ops-business/yak-ops-business-resource/src/main/java/io/yak/ops/business/resource/controller/v1/ResourcesController.java
+++ b/yak-ops-business/yak-ops-business-resource/src/main/java/io/yak/ops/business/resource/controller/v1/ResourcesController.java
@@ -2,7 +2,7 @@ package io.yak.ops.business.resource.controller.v1;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import io.yak.framework.common.PagingResult;
+import io.yak.framework.common.PagingData;
 import io.yak.framework.common.Result;
 import io.yak.framework.security.web.RequiresPermission;
 import io.yak.ops.business.resource.config.ConditionalOnResourceEnabled;
@@ -97,9 +97,9 @@ public class ResourcesController {
 
   @Operation(summary = "分页查询资源")
   @PostMapping("/page")
-  public PagingResult<ResourceVO> page(
+  public Result<PagingData<ResourceVO>> page(
       @Valid @RequestBody(required = false) ResourceQueryDTO queryDTO) {
-    return PagingResult.success(resourceService.page(queryDTO));
+    return Result.success(resourceService.page(queryDTO));
   }
 
   @Operation(summary = "查询完整资源树")

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/controller/OfflineJobDefinitionController.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/controller/OfflineJobDefinitionController.java
@@ -1,7 +1,7 @@
 package io.yak.ops.business.sync.offline.controller;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import io.yak.framework.common.PagingResult;
+import io.yak.framework.common.PagingData;
 import io.yak.framework.common.Result;
 import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
 import io.yak.ops.business.sync.offline.service.OfflineJobDefinitionService;
@@ -67,9 +67,9 @@ public class OfflineJobDefinitionController {
   }
 
   @PostMapping("/page")
-  public PagingResult<OfflineJobDefinitionVO> page(
+  public Result<PagingData<OfflineJobDefinitionVO>> page(
       @Valid @RequestBody(required = false) OfflineJobDefinitionQueryDTO queryDTO) {
-    return PagingResult.success(service.page(queryDTO));
+    return Result.success(service.page(queryDTO));
   }
 
   @PutMapping("/{id}/online")

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/controller/OfflineJobExecutionController.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/controller/OfflineJobExecutionController.java
@@ -1,7 +1,7 @@
 package io.yak.ops.business.sync.offline.controller;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import io.yak.framework.common.PagingResult;
+import io.yak.framework.common.PagingData;
 import io.yak.framework.common.Result;
 import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
 import io.yak.ops.business.sync.offline.service.OfflineJobExecutionService;
@@ -67,9 +67,9 @@ public class OfflineJobExecutionController {
   }
 
   @PostMapping("/api/v1/job/batch-instance/page")
-  public PagingResult<OfflineJobExecutionVO> instancePage(
+  public Result<PagingData<OfflineJobExecutionVO>> instancePage(
       @Valid @RequestBody(required = false) OfflineJobExecutionQueryDTO queryDTO) {
-    return PagingResult.success(service.page(queryDTO));
+    return Result.success(service.page(queryDTO));
   }
 
   @GetMapping("/api/v1/job/batch-instance/{id}")


### PR DESCRIPTION
## Summary

Align the remaining Yak Ops paging controllers with the finalized Yak Framework pagination contract after `PagingResult<T>` was removed from `yak-common`.

The remaining controllers still referenced the deleted framework type and would fail compilation after updating Yak Framework.

## Final HTTP paging envelope

```java
Result<PagingData<T>>
```

instead of:

```java
PagingResult<T>
```

## Affected controllers

- `DataSourceController`
- `ResourcesController`
- `OfflineJobDefinitionController`
- `OfflineJobExecutionController`

Each paging endpoint now changes from:

```java
public PagingResult<DataSourceVO> page(...) {
    return PagingResult.success(service.page(...));
}
```

to:

```java
public Result<PagingData<DataSourceVO>> page(...) {
    return Result.success(service.page(...));
}
```

## Compatibility

The HTTP JSON contract is unchanged because both envelopes use the same `BaseResult` fields and the existing `PagingData<T>` payload:

```json
{
  "code": 0,
  "message": "success",
  "data": {
    "bizData": [],
    "pagination": {
      "total": 0,
      "pages": 0,
      "pageNo": 1,
      "pageSize": 20
    }
  }
}
```

No front-end changes are required.

## Scope intentionally unchanged

- no REST path changes;
- no request DTO changes;
- no response field changes;
- no service/repository/DAO changes;
- no database/Flyway changes;
- no paging semantics changes.

The underlying Datasource, Resource and Offline Sync services already use the shared `PageData<T> -> PagingData<T>` boundary from the previous pagination refactor. This PR only completes the HTTP envelope migration.

## Validation

Branch is based on the current Yak Ops `main` and is 0 commits behind.

Recommended local validation after installing the latest Yak Framework snapshot:

```bash
mvn -pl yak-ops-business/yak-ops-business-datasource -am test
mvn -pl yak-ops-business/yak-ops-business-resource -am test
mvn -pl yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline -am test
```

Then run the full reactor:

```bash
mvn clean test
```
