### PR TITLE
feat(data-development): add SQL backend and generic workflow task execution

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,11 @@
             </dependency>
             <dependency>
                 <groupId>io.yak.ops</groupId>
+                <artifactId>yak-ops-business-data-development</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.yak.ops</groupId>
                 <artifactId>yak-ops-business-resource</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/yak-ops-bom/pom.xml
+++ b/yak-ops-bom/pom.xml
@@ -73,6 +73,11 @@
             </dependency>
             <dependency>
                 <groupId>io.yak.ops</groupId>
+                <artifactId>yak-ops-business-data-development</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.yak.ops</groupId>
                 <artifactId>yak-ops-business-resource</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/yak-ops-boot/pom.xml
+++ b/yak-ops-boot/pom.xml
@@ -26,6 +26,10 @@
         </dependency>
         <dependency>
             <groupId>io.yak.ops</groupId>
+            <artifactId>yak-ops-business-data-development</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.yak.ops</groupId>
             <artifactId>yak-ops-business-resource</artifactId>
         </dependency>
         <dependency>

--- a/yak-ops-business/pom.xml
+++ b/yak-ops-business/pom.xml
@@ -20,6 +20,7 @@
     <modules>
         <module>yak-ops-business-datasource</module>
         <module>yak-ops-business-job</module>
+        <module>yak-ops-business-data-development</module>
         <module>yak-ops-business-resource</module>
         <module>yak-ops-business-sync</module>
         <module>yak-ops-business-quality</module>

--- a/yak-ops-business/yak-ops-business-data-development/pom.xml
+++ b/yak-ops-business/yak-ops-business-data-development/pom.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.yak.ops</groupId>
+        <artifactId>yak-ops-business</artifactId>
+        <version>1.0.0</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>yak-ops-business-data-development</artifactId>
+
+    <name>Yak Ops Business Data Development</name>
+    <description>SQL authoring, immutable versions and task execution integration</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.yak.ops</groupId>
+            <artifactId>yak-ops-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.yak.ops</groupId>
+            <artifactId>yak-ops-business-job</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.yak.ops</groupId>
+            <artifactId>yak-ops-business-datasource</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.yak.ops</groupId>
+            <artifactId>yak-ops-plugin-datasource-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-jdbc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.baomidou</groupId>
+            <artifactId>mybatis-plus-spring-boot3-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.baomidou</groupId>
+            <artifactId>mybatis-plus-jsqlparser-4.9</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-mysql</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/yak-ops-business/yak-ops-business-data-development/pom.xml
+++ b/yak-ops-business/yak-ops-business-data-development/pom.xml
@@ -55,6 +55,10 @@
             <artifactId>mybatis-plus-jsqlparser-4.9</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.flywaydb</groupId>
             <artifactId>flyway-core</artifactId>
         </dependency>

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/api/SqlDevelopmentApi.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/api/SqlDevelopmentApi.java
@@ -1,0 +1,35 @@
+package io.yak.ops.business.development.api;
+
+import io.yak.ops.business.development.domain.SqlParameterDefinition;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+import java.util.Map;
+
+/** HTTP request contracts for first-phase SQL development. */
+public final class SqlDevelopmentApi {
+
+  private SqlDevelopmentApi() {}
+
+  public record CreateRequest(
+      @NotBlank String name,
+      String description,
+      @NotNull @Min(1) Long dataSourceId,
+      @NotBlank String sql,
+      List<SqlParameterDefinition> parameters) {
+  }
+
+  public record UpdateRequest(
+      @Min(1) long baseRevision,
+      @NotBlank String name,
+      String description,
+      @NotNull @Min(1) Long dataSourceId,
+      @NotBlank String sql,
+      List<SqlParameterDefinition> parameters) {
+  }
+
+  public record PublishRequest(@Min(1) long draftRevision) {}
+
+  public record RunRequest(Map<String, Object> input) {}
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/config/SqlDevelopmentPersistenceConfiguration.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/config/SqlDevelopmentPersistenceConfiguration.java
@@ -1,0 +1,38 @@
+package io.yak.ops.business.development.config;
+
+import io.yak.ops.business.datasource.config.BusinessDatabaseConfiguration;
+import javax.sql.DataSource;
+import org.flywaydb.core.Flyway;
+import org.flywaydb.core.api.MigrationVersion;
+import org.mybatis.spring.annotation.MapperScan;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+/** SQL development shares the Yak business database but owns its migration history. */
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnProperty(
+    prefix = "yak.database",
+    name = "enabled",
+    havingValue = "true",
+    matchIfMissing = true)
+@Import(BusinessDatabaseConfiguration.class)
+@MapperScan(
+    basePackages = "io.yak.ops.business.development.dao.mapper",
+    sqlSessionFactoryRef = "yakBusinessSqlSessionFactory")
+public class SqlDevelopmentPersistenceConfiguration {
+
+  @Bean(initMethod = "migrate", name = "sqlDevelopmentFlyway")
+  public Flyway sqlDevelopmentFlyway(
+      @Qualifier("yakBusinessDataSource") DataSource dataSource) {
+    return Flyway.configure()
+        .dataSource(dataSource)
+        .locations("classpath:db/migration/yak-data-development")
+        .table("yak_data_development_schema_history")
+        .baselineVersion(MigrationVersion.fromVersion("0"))
+        .baselineOnMigrate(true)
+        .load();
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/controller/v1/SqlDevelopmentController.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/controller/v1/SqlDevelopmentController.java
@@ -1,0 +1,107 @@
+package io.yak.ops.business.development.controller.v1;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.yak.framework.common.Result;
+import io.yak.ops.business.development.api.SqlDevelopmentApi.CreateRequest;
+import io.yak.ops.business.development.api.SqlDevelopmentApi.PublishRequest;
+import io.yak.ops.business.development.api.SqlDevelopmentApi.RunRequest;
+import io.yak.ops.business.development.api.SqlDevelopmentApi.UpdateRequest;
+import io.yak.ops.business.development.domain.SqlDevelopmentModel.Definition;
+import io.yak.ops.business.development.domain.SqlDevelopmentModel.Execution;
+import io.yak.ops.business.development.domain.SqlDevelopmentModel.Version;
+import io.yak.ops.business.development.service.SqlDevelopmentService;
+import jakarta.validation.Valid;
+import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** First-phase SQL data-development backend. */
+@Tag(name = "SQL 数据开发接口")
+@RestController
+@RequestMapping("/api/v1/data-development/sql-tasks")
+public class SqlDevelopmentController {
+
+  private final SqlDevelopmentService service;
+
+  public SqlDevelopmentController(SqlDevelopmentService service) {
+    this.service = service;
+  }
+
+  @Operation(summary = "创建 SQL 开发任务")
+  @PostMapping
+  public Result<Definition> create(@Valid @RequestBody CreateRequest request) {
+    return Result.success(service.create(
+        request.name(),
+        request.description(),
+        request.dataSourceId(),
+        request.sql(),
+        request.parameters()));
+  }
+
+  @Operation(summary = "查询 SQL 开发任务")
+  @GetMapping
+  public Result<List<Definition>> list() {
+    return Result.success(service.list());
+  }
+
+  @Operation(summary = "查询 SQL 开发任务详情")
+  @GetMapping("/{id}")
+  public Result<Definition> detail(@PathVariable("id") Long id) {
+    return Result.success(service.get(id));
+  }
+
+  @Operation(summary = "保存 SQL 草稿")
+  @PutMapping("/{id}")
+  public Result<Definition> update(
+      @PathVariable("id") Long id,
+      @Valid @RequestBody UpdateRequest request) {
+    return Result.success(service.update(
+        id,
+        request.baseRevision(),
+        request.name(),
+        request.description(),
+        request.dataSourceId(),
+        request.sql(),
+        request.parameters()));
+  }
+
+  @Operation(summary = "发布不可变 SQL 版本")
+  @PostMapping("/{id}/publish")
+  public Result<Version> publish(
+      @PathVariable("id") Long id,
+      @Valid @RequestBody PublishRequest request) {
+    return Result.success(service.publish(id, request.draftRevision()));
+  }
+
+  @Operation(summary = "查询 SQL 发布版本")
+  @GetMapping("/{id}/versions")
+  public Result<List<Version>> versions(@PathVariable("id") Long id) {
+    return Result.success(service.versions(id));
+  }
+
+  @Operation(summary = "测试运行当前 SQL 草稿")
+  @PostMapping("/{id}/run")
+  public Result<Execution> run(
+      @PathVariable("id") Long id,
+      @RequestBody(required = false) RunRequest request) {
+    return Result.success(service.runDraft(id, request == null ? null : request.input()));
+  }
+
+  @Operation(summary = "查询 SQL 执行状态")
+  @GetMapping("/executions/{executionId}")
+  public Result<Execution> execution(@PathVariable("executionId") Long executionId) {
+    return Result.success(service.execution(executionId));
+  }
+
+  @Operation(summary = "取消 SQL 执行")
+  @PostMapping("/executions/{executionId}/cancel")
+  public Result<Execution> cancel(@PathVariable("executionId") Long executionId) {
+    return Result.success(service.cancel(executionId));
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/dao/mapper/SqlTaskExecutionMapper.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/dao/mapper/SqlTaskExecutionMapper.java
@@ -1,0 +1,6 @@
+package io.yak.ops.business.development.dao.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import io.yak.ops.common.bean.po.development.SqlTaskExecutionPO;
+
+public interface SqlTaskExecutionMapper extends BaseMapper<SqlTaskExecutionPO> {}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/dao/mapper/SqlTaskMapper.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/dao/mapper/SqlTaskMapper.java
@@ -1,0 +1,9 @@
+package io.yak.ops.business.development.dao.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import io.yak.ops.common.bean.po.development.SqlTaskPO;
+import org.apache.ibatis.annotations.Param;
+
+public interface SqlTaskMapper extends BaseMapper<SqlTaskPO> {
+  SqlTaskPO selectForUpdate(@Param("id") Long id);
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/dao/mapper/SqlTaskVersionMapper.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/dao/mapper/SqlTaskVersionMapper.java
@@ -1,0 +1,6 @@
+package io.yak.ops.business.development.dao.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import io.yak.ops.common.bean.po.development.SqlTaskVersionPO;
+
+public interface SqlTaskVersionMapper extends BaseMapper<SqlTaskVersionPO> {}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/domain/SqlDevelopmentModel.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/domain/SqlDevelopmentModel.java
@@ -1,0 +1,67 @@
+package io.yak.ops.business.development.domain;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+/** SQL development domain models. */
+public final class SqlDevelopmentModel {
+
+  private SqlDevelopmentModel() {}
+
+  public record Definition(
+      Long id,
+      String name,
+      String description,
+      Long dataSourceId,
+      String sql,
+      List<SqlParameterDefinition> parameters,
+      long draftRevision,
+      Long publishedVersionId,
+      int latestVersionNo,
+      Instant createTime,
+      Instant updateTime) {
+
+    public Definition {
+      parameters = parameters == null ? List.of() : List.copyOf(parameters);
+    }
+
+    public String workflowTaskId() {
+      return id == null ? null : "SQL:" + id;
+    }
+  }
+
+  public record Version(
+      Long id,
+      Long taskId,
+      int versionNo,
+      Long dataSourceId,
+      String sql,
+      List<SqlParameterDefinition> parameters,
+      String contentDigest,
+      Instant publishedAt) {
+
+    public Version {
+      parameters = parameters == null ? List.of() : List.copyOf(parameters);
+    }
+  }
+
+  public record Execution(
+      Long id,
+      Long taskId,
+      Long taskVersionId,
+      Integer taskVersionNo,
+      Long dataSourceId,
+      String status,
+      long affectedRows,
+      Map<String, Object> output,
+      String errorMessage,
+      Instant createTime,
+      Instant startTime,
+      Instant finishTime) {
+
+    public Execution {
+      output = output == null ? Map.of() : Map.copyOf(output);
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/domain/SqlParameterDefinition.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/domain/SqlParameterDefinition.java
@@ -1,0 +1,9 @@
+package io.yak.ops.business.development.domain;
+
+/** Named SQL parameter metadata kept in draft and immutable version snapshots. */
+public record SqlParameterDefinition(
+    String name,
+    String type,
+    boolean required,
+    Object defaultValue) {
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/domain/SqlTaskSnapshot.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/domain/SqlTaskSnapshot.java
@@ -1,0 +1,17 @@
+package io.yak.ops.business.development.domain;
+
+import java.util.List;
+
+/** JSON payloads stored inside the generic {@code TaskVersionSnapshot}. */
+public final class SqlTaskSnapshot {
+
+  private SqlTaskSnapshot() {}
+
+  public record Definition(String sql, List<SqlParameterDefinition> parameters) {
+    public Definition {
+      parameters = parameters == null ? List.of() : List.copyOf(parameters);
+    }
+  }
+
+  public record ExecutionConfig(Long dataSourceId, Long taskVersionId) {}
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/execution/NamedSqlParameterParser.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/execution/NamedSqlParameterParser.java
@@ -1,0 +1,156 @@
+package io.yak.ops.business.development.execution;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Converts value placeholders such as {@code :biz_date} to JDBC placeholders while preserving
+ * quoted strings, comments and PostgreSQL-style {@code ::} casts.
+ */
+public final class NamedSqlParameterParser {
+
+  private NamedSqlParameterParser() {}
+
+  public static ParsedSql parse(String source) {
+    if (source == null || source.isBlank()) {
+      throw new IllegalArgumentException("SQL 不能为空");
+    }
+
+    StringBuilder jdbcSql = new StringBuilder(source.length());
+    List<String> parameters = new ArrayList<>();
+    State state = State.NORMAL;
+    boolean statementEnded = false;
+
+    for (int i = 0; i < source.length(); i++) {
+      char current = source.charAt(i);
+      char next = i + 1 < source.length() ? source.charAt(i + 1) : '\0';
+
+      if (state == State.LINE_COMMENT) {
+        jdbcSql.append(current);
+        if (current == '\n' || current == '\r') state = State.NORMAL;
+        continue;
+      }
+      if (state == State.BLOCK_COMMENT) {
+        jdbcSql.append(current);
+        if (current == '*' && next == '/') {
+          jdbcSql.append(next);
+          i++;
+          state = State.NORMAL;
+        }
+        continue;
+      }
+      if (state == State.SINGLE_QUOTE) {
+        jdbcSql.append(current);
+        if (current == '\'' && next == '\'') {
+          jdbcSql.append(next);
+          i++;
+        } else if (current == '\'') {
+          state = State.NORMAL;
+        }
+        continue;
+      }
+      if (state == State.DOUBLE_QUOTE) {
+        jdbcSql.append(current);
+        if (current == '"' && next == '"') {
+          jdbcSql.append(next);
+          i++;
+        } else if (current == '"') {
+          state = State.NORMAL;
+        }
+        continue;
+      }
+      if (state == State.BACKTICK) {
+        jdbcSql.append(current);
+        if (current == '`') state = State.NORMAL;
+        continue;
+      }
+
+      if (current == '-' && next == '-') {
+        jdbcSql.append(current).append(next);
+        i++;
+        state = State.LINE_COMMENT;
+        continue;
+      }
+      if (current == '/' && next == '*') {
+        jdbcSql.append(current).append(next);
+        i++;
+        state = State.BLOCK_COMMENT;
+        continue;
+      }
+      if (current == '\'') {
+        if (statementEnded) throw multipleStatements();
+        jdbcSql.append(current);
+        state = State.SINGLE_QUOTE;
+        continue;
+      }
+      if (current == '"') {
+        if (statementEnded) throw multipleStatements();
+        jdbcSql.append(current);
+        state = State.DOUBLE_QUOTE;
+        continue;
+      }
+      if (current == '`') {
+        if (statementEnded) throw multipleStatements();
+        jdbcSql.append(current);
+        state = State.BACKTICK;
+        continue;
+      }
+      if (current == ';') {
+        if (statementEnded) throw multipleStatements();
+        statementEnded = true;
+        continue;
+      }
+      if (statementEnded) {
+        if (!Character.isWhitespace(current)) throw multipleStatements();
+        jdbcSql.append(current);
+        continue;
+      }
+      if (current == ':' && next == ':') {
+        jdbcSql.append(current).append(next);
+        i++;
+        continue;
+      }
+      if (current == ':' && isParameterStart(next)) {
+        int end = i + 2;
+        while (end < source.length() && isParameterPart(source.charAt(end))) end++;
+        String name = source.substring(i + 1, end);
+        parameters.add(name);
+        jdbcSql.append('?');
+        i = end - 1;
+        continue;
+      }
+      jdbcSql.append(current);
+    }
+
+    if (state == State.SINGLE_QUOTE || state == State.DOUBLE_QUOTE || state == State.BACKTICK
+        || state == State.BLOCK_COMMENT) {
+      throw new IllegalArgumentException("SQL 中存在未闭合的引号或注释");
+    }
+    String normalized = jdbcSql.toString().trim();
+    if (normalized.isEmpty()) throw new IllegalArgumentException("SQL 不能为空");
+    return new ParsedSql(normalized, List.copyOf(parameters));
+  }
+
+  private static boolean isParameterStart(char value) {
+    return value == '_' || Character.isLetter(value);
+  }
+
+  private static boolean isParameterPart(char value) {
+    return value == '_' || Character.isLetterOrDigit(value);
+  }
+
+  private static IllegalArgumentException multipleStatements() {
+    return new IllegalArgumentException("第一阶段 SQL 数据开发仅允许单条 SQL");
+  }
+
+  public record ParsedSql(String jdbcSql, List<String> parameterNames) {}
+
+  private enum State {
+    NORMAL,
+    SINGLE_QUOTE,
+    DOUBLE_QUOTE,
+    BACKTICK,
+    LINE_COMMENT,
+    BLOCK_COMMENT
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/execution/SqlTaskExecutor.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/execution/SqlTaskExecutor.java
@@ -1,0 +1,409 @@
+package io.yak.ops.business.development.execution;
+
+import io.yak.ops.business.datasource.domain.DataSourceDefinition;
+import io.yak.ops.business.datasource.plugin.DataSourcePluginRegistry;
+import io.yak.ops.business.datasource.repository.DataSourceRepository;
+import io.yak.ops.business.development.domain.SqlDevelopmentModel.Execution;
+import io.yak.ops.business.development.domain.SqlParameterDefinition;
+import io.yak.ops.business.development.domain.SqlTaskSnapshot;
+import io.yak.ops.business.development.repository.SqlDevelopmentRepository;
+import io.yak.ops.business.development.support.SqlDevelopmentJsonCodec;
+import io.yak.ops.business.job.task.TaskExecution;
+import io.yak.ops.business.job.task.TaskExecutor;
+import io.yak.ops.business.job.task.TaskVersionSnapshot;
+import io.yak.ops.spi.datasource.DataSourceConnection;
+import io.yak.ops.spi.datasource.DataSourcePlugin;
+import jakarta.annotation.PreDestroy;
+import java.math.BigDecimal;
+import java.sql.Blob;
+import java.sql.Clob;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Component;
+
+/** First-phase JDBC SQL executor. It is one plugin behind the generic Job execution gateway. */
+@Component
+public class SqlTaskExecutor implements TaskExecutor {
+
+  private static final int MAX_RESULT_ROWS = 200;
+  private static final int MAX_CELL_TEXT_LENGTH = 10_000;
+
+  private final SqlDevelopmentRepository repository;
+  private final DataSourceRepository dataSourceRepository;
+  private final DataSourcePluginRegistry pluginRegistry;
+  private final SqlDevelopmentJsonCodec jsonCodec;
+  private final ExecutorService executorService = Executors.newVirtualThreadPerTaskExecutor();
+  private final ConcurrentMap<String, RunningControl> running = new ConcurrentHashMap<>();
+
+  public SqlTaskExecutor(
+      SqlDevelopmentRepository repository,
+      DataSourceRepository dataSourceRepository,
+      DataSourcePluginRegistry pluginRegistry,
+      SqlDevelopmentJsonCodec jsonCodec) {
+    this.repository = repository;
+    this.dataSourceRepository = dataSourceRepository;
+    this.pluginRegistry = pluginRegistry;
+    this.jsonCodec = jsonCodec;
+  }
+
+  @Override
+  public String taskType() {
+    return "SQL";
+  }
+
+  @Override
+  public TaskExecution start(
+      TaskVersionSnapshot snapshot,
+      String idempotencyKey,
+      Map<String, Object> input) {
+    requireSqlSnapshot(snapshot);
+    if (idempotencyKey != null && !idempotencyKey.isBlank()) {
+      Execution existing = repository.findExecutionByIdempotencyKey(idempotencyKey).orElse(null);
+      if (existing != null) return toTaskExecution(existing);
+    }
+
+    SqlTaskSnapshot.Definition definition =
+        jsonCodec.read(snapshot.definitionSnapshotJson(), SqlTaskSnapshot.Definition.class);
+    SqlTaskSnapshot.ExecutionConfig config =
+        jsonCodec.read(snapshot.executionConfigSnapshotJson(), SqlTaskSnapshot.ExecutionConfig.class);
+    NamedSqlParameterParser.ParsedSql parsed = NamedSqlParameterParser.parse(definition.sql());
+    validateDeclaredParameters(parsed.parameterNames(), definition.parameters());
+    Long taskId = parseTaskId(snapshot.taskId());
+    Integer versionNo = snapshot.version() > 0L ? Math.toIntExact(snapshot.version()) : null;
+
+    Execution execution;
+    try {
+      execution = repository.insertExecution(
+          taskId,
+          config.taskVersionId(),
+          versionNo,
+          requireDataSourceId(config.dataSourceId()),
+          definition.sql(),
+          input,
+          idempotencyKey);
+    } catch (DataIntegrityViolationException duplicate) {
+      if (idempotencyKey == null || idempotencyKey.isBlank()) throw duplicate;
+      execution = repository.findExecutionByIdempotencyKey(idempotencyKey).orElseThrow(() -> duplicate);
+      return toTaskExecution(execution);
+    }
+
+    String executionId = String.valueOf(execution.id());
+    RunningControl control = new RunningControl();
+    RunningControl duplicateControl = running.putIfAbsent(executionId, control);
+    if (duplicateControl != null) return toTaskExecution(execution);
+    control.future = executorService.submit(
+        () -> execute(execution.id(), config.dataSourceId(), parsed, definition.parameters(), input, control));
+    return toTaskExecution(execution);
+  }
+
+  @Override
+  public TaskExecution status(String executionId) {
+    Long id = parseExecutionId(executionId);
+    Execution execution = requireExecution(id);
+    if (isActive(execution.status()) && !running.containsKey(executionId)) {
+      repository.markLost(id, "SQL 执行进程已丢失；当前版本不会在进程重启后自动重复提交 SQL");
+      execution = requireExecution(id);
+    }
+    return toTaskExecution(execution);
+  }
+
+  @Override
+  public void cancel(String executionId) {
+    Long id = parseExecutionId(executionId);
+    RunningControl control = running.get(executionId);
+    if (control != null) {
+      control.canceled.set(true);
+      PreparedStatement statement = control.statement;
+      if (statement != null) {
+        try {
+          statement.cancel();
+        } catch (Exception ignored) {
+          // State transition below remains the local source of truth.
+        }
+      }
+      Future<?> future = control.future;
+      if (future != null) future.cancel(true);
+    }
+    repository.markCanceled(id);
+  }
+
+  private void execute(
+      Long executionId,
+      Long dataSourceId,
+      NamedSqlParameterParser.ParsedSql parsed,
+      List<SqlParameterDefinition> parameters,
+      Map<String, Object> input,
+      RunningControl control) {
+    String key = String.valueOf(executionId);
+    try {
+      if (control.canceled.get()) {
+        repository.markCanceled(executionId);
+        return;
+      }
+      if (!repository.markRunning(executionId)) return;
+
+      try (Connection connection = openConnection(dataSourceId);
+           PreparedStatement statement = connection.prepareStatement(parsed.jdbcSql())) {
+        connection.setAutoCommit(true);
+        control.statement = statement;
+        bind(statement, parsed.parameterNames(), parameters, input);
+        boolean hasResult = statement.execute();
+        if (control.canceled.get()) {
+          repository.markCanceled(executionId);
+          return;
+        }
+
+        SqlResult result = hasResult
+            ? readResultSet(statement.getResultSet())
+            : updateResult(statement.getUpdateCount());
+        repository.markSucceeded(executionId, result.affectedRows(), result.output());
+      }
+    } catch (Exception exception) {
+      if (control.canceled.get() || Thread.currentThread().isInterrupted()) {
+        repository.markCanceled(executionId);
+      } else {
+        repository.markFailed(executionId, conciseMessage(exception));
+      }
+    } finally {
+      control.statement = null;
+      running.remove(key, control);
+    }
+  }
+
+  private Connection openConnection(Long dataSourceId) throws Exception {
+    DataSourceDefinition definition = dataSourceRepository.findById(dataSourceId)
+        .orElseThrow(() -> new IllegalArgumentException("数据源不存在：" + dataSourceId));
+    DataSourcePlugin plugin = pluginRegistry.get(definition.getDbType());
+    DataSourceConnection connection = plugin.parseConnection(definition.getConnectionParams());
+    if (connection.driverClassName() != null && !connection.driverClassName().isBlank()) {
+      Class.forName(connection.driverClassName());
+    }
+    Properties properties = new Properties();
+    if (connection.properties() != null) properties.putAll(connection.properties());
+    if (connection.username() != null) properties.setProperty("user", connection.username());
+    if (connection.password() != null) properties.setProperty("password", connection.password());
+    return DriverManager.getConnection(connection.jdbcUrl(), properties);
+  }
+
+  private void bind(
+      PreparedStatement statement,
+      List<String> parameterNames,
+      List<SqlParameterDefinition> definitions,
+      Map<String, Object> input) throws Exception {
+    Map<String, SqlParameterDefinition> definitionsByName = new HashMap<>();
+    for (SqlParameterDefinition definition : definitions) {
+      definitionsByName.put(definition.name(), definition);
+    }
+    Map<String, Object> values = input == null ? Map.of() : input;
+    for (int index = 0; index < parameterNames.size(); index++) {
+      String name = parameterNames.get(index);
+      SqlParameterDefinition definition = definitionsByName.get(name);
+      if (definition == null) throw new IllegalArgumentException("SQL 参数未声明：" + name);
+      boolean supplied = values.containsKey(name);
+      Object value = supplied ? values.get(name) : definition.defaultValue();
+      if (value == null && definition.required()) {
+        throw new IllegalArgumentException("缺少必填 SQL 参数：" + name);
+      }
+      statement.setObject(index + 1, convertValue(definition.type(), value));
+    }
+  }
+
+  private Object convertValue(String type, Object value) {
+    if (value == null) return null;
+    String normalized = type == null ? "STRING" : type.trim().toUpperCase(Locale.ROOT);
+    String text = String.valueOf(value);
+    return switch (normalized) {
+      case "STRING" -> text;
+      case "INTEGER" -> value instanceof Number number ? number.intValue() : Integer.valueOf(text);
+      case "LONG" -> value instanceof Number number ? number.longValue() : Long.valueOf(text);
+      case "DOUBLE" -> value instanceof Number number ? number.doubleValue() : Double.valueOf(text);
+      case "DECIMAL" -> value instanceof BigDecimal decimal ? decimal : new BigDecimal(text);
+      case "BOOLEAN" -> value instanceof Boolean bool ? bool : parseBoolean(text);
+      case "DATE" -> value instanceof LocalDate date ? date : LocalDate.parse(text);
+      case "TIMESTAMP" -> value instanceof LocalDateTime dateTime ? dateTime : LocalDateTime.parse(text);
+      default -> throw new IllegalArgumentException("不支持的 SQL 参数类型：" + normalized);
+    };
+  }
+
+  private Boolean parseBoolean(String value) {
+    if ("true".equalsIgnoreCase(value) || "1".equals(value) || "yes".equalsIgnoreCase(value)) {
+      return Boolean.TRUE;
+    }
+    if ("false".equalsIgnoreCase(value) || "0".equals(value) || "no".equalsIgnoreCase(value)) {
+      return Boolean.FALSE;
+    }
+    throw new IllegalArgumentException("BOOLEAN 参数值不合法：" + value);
+  }
+
+  private SqlResult readResultSet(ResultSet resultSet) throws Exception {
+    if (resultSet == null) return new SqlResult(0L, Map.of("kind", "QUERY", "rows", List.of()));
+    ResultSetMetaData metadata = resultSet.getMetaData();
+    int columnCount = metadata.getColumnCount();
+    List<String> columns = new ArrayList<>(columnCount);
+    for (int i = 1; i <= columnCount; i++) {
+      String label = metadata.getColumnLabel(i);
+      columns.add(label == null || label.isBlank() ? metadata.getColumnName(i) : label);
+    }
+
+    List<Map<String, Object>> rows = new ArrayList<>();
+    boolean truncated = false;
+    while (resultSet.next()) {
+      if (rows.size() >= MAX_RESULT_ROWS) {
+        truncated = true;
+        break;
+      }
+      Map<String, Object> row = new LinkedHashMap<>();
+      for (int i = 1; i <= columnCount; i++) {
+        row.put(columns.get(i - 1), normalizeJdbcValue(resultSet.getObject(i)));
+      }
+      rows.add(row);
+    }
+    Map<String, Object> output = new LinkedHashMap<>();
+    output.put("kind", "QUERY");
+    output.put("columns", columns);
+    output.put("rows", rows);
+    output.put("rowCount", rows.size());
+    output.put("truncated", truncated);
+    return new SqlResult(0L, output);
+  }
+
+  private SqlResult updateResult(int updateCount) {
+    long affectedRows = Math.max(0, updateCount);
+    return new SqlResult(
+        affectedRows,
+        Map.of("kind", "UPDATE", "affectedRows", affectedRows));
+  }
+
+  private Object normalizeJdbcValue(Object value) throws Exception {
+    if (value == null) return null;
+    if (value instanceof byte[] bytes) return Base64.getEncoder().encodeToString(bytes);
+    if (value instanceof Clob clob) {
+      long length = Math.min(clob.length(), MAX_CELL_TEXT_LENGTH);
+      return clob.getSubString(1L, (int) length);
+    }
+    if (value instanceof Blob blob) {
+      int length = (int) Math.min(blob.length(), MAX_CELL_TEXT_LENGTH);
+      return Base64.getEncoder().encodeToString(blob.getBytes(1L, length));
+    }
+    if (value instanceof CharSequence text && text.length() > MAX_CELL_TEXT_LENGTH) {
+      return text.subSequence(0, MAX_CELL_TEXT_LENGTH).toString();
+    }
+    if (value instanceof Number || value instanceof Boolean || value instanceof CharSequence
+        || value instanceof LocalDate || value instanceof LocalDateTime) {
+      return value;
+    }
+    return String.valueOf(value);
+  }
+
+  private void validateDeclaredParameters(
+      List<String> usedParameters,
+      List<SqlParameterDefinition> definitions) {
+    Map<String, SqlParameterDefinition> byName = new HashMap<>();
+    for (SqlParameterDefinition definition : definitions) {
+      if (definition == null || definition.name() == null || definition.name().isBlank()) {
+        throw new IllegalArgumentException("SQL 参数定义不完整");
+      }
+      if (byName.putIfAbsent(definition.name(), definition) != null) {
+        throw new IllegalArgumentException("SQL 参数重复：" + definition.name());
+      }
+    }
+    for (String name : usedParameters) {
+      if (!byName.containsKey(name)) throw new IllegalArgumentException("SQL 参数未声明：" + name);
+    }
+  }
+
+  private void requireSqlSnapshot(TaskVersionSnapshot snapshot) {
+    if (snapshot == null || !"SQL".equalsIgnoreCase(snapshot.type())) {
+      throw new IllegalArgumentException("SqlTaskExecutor 仅支持 SQL 任务快照");
+    }
+    if (snapshot.definitionSnapshotJson() == null || snapshot.executionConfigSnapshotJson() == null) {
+      throw new IllegalArgumentException("SQL 任务快照不完整：" + snapshot.taskId());
+    }
+  }
+
+  private Long requireDataSourceId(Long dataSourceId) {
+    if (dataSourceId == null || dataSourceId <= 0L) {
+      throw new IllegalArgumentException("SQL 快照缺少有效 dataSourceId");
+    }
+    return dataSourceId;
+  }
+
+  private Long parseTaskId(String taskId) {
+    if (taskId == null || !taskId.startsWith("SQL:")) {
+      throw new IllegalArgumentException("SQL taskId 不合法：" + taskId);
+    }
+    try {
+      long id = Long.parseLong(taskId.substring(4));
+      if (id <= 0L) throw new NumberFormatException(taskId);
+      return id;
+    } catch (RuntimeException exception) {
+      throw new IllegalArgumentException("SQL taskId 不合法：" + taskId, exception);
+    }
+  }
+
+  private Long parseExecutionId(String executionId) {
+    try {
+      long id = Long.parseLong(executionId);
+      if (id <= 0L) throw new NumberFormatException(executionId);
+      return id;
+    } catch (RuntimeException exception) {
+      throw new IllegalArgumentException("SQL executionId 不合法：" + executionId, exception);
+    }
+  }
+
+  private Execution requireExecution(Long id) {
+    return repository.findExecution(id)
+        .orElseThrow(() -> new IllegalArgumentException("SQL 执行不存在：" + id));
+  }
+
+  private TaskExecution toTaskExecution(Execution execution) {
+    return new TaskExecution(
+        String.valueOf(execution.id()),
+        execution.status(),
+        execution.errorMessage(),
+        execution.output());
+  }
+
+  private boolean isActive(String status) {
+    return "QUEUED".equalsIgnoreCase(status) || "RUNNING".equalsIgnoreCase(status);
+  }
+
+  private String conciseMessage(Exception exception) {
+    String message = exception.getMessage();
+    if (message == null || message.isBlank()) message = exception.getClass().getSimpleName();
+    return message.length() <= 4000 ? message : message.substring(0, 4000);
+  }
+
+  @PreDestroy
+  void shutdown() {
+    executorService.shutdownNow();
+  }
+
+  private record SqlResult(long affectedRows, Map<String, Object> output) {}
+
+  private static final class RunningControl {
+    private final AtomicBoolean canceled = new AtomicBoolean();
+    private volatile PreparedStatement statement;
+    private volatile Future<?> future;
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/SqlDevelopmentRepository.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/SqlDevelopmentRepository.java
@@ -1,0 +1,74 @@
+package io.yak.ops.business.development.repository;
+
+import io.yak.ops.business.development.domain.SqlDevelopmentModel.Definition;
+import io.yak.ops.business.development.domain.SqlDevelopmentModel.Execution;
+import io.yak.ops.business.development.domain.SqlDevelopmentModel.Version;
+import io.yak.ops.business.development.domain.SqlParameterDefinition;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/** Durable SQL development repository. Persistence implementation details stay behind this boundary. */
+public interface SqlDevelopmentRepository {
+
+  Definition insertDefinition(
+      String name,
+      String description,
+      Long dataSourceId,
+      String sql,
+      List<SqlParameterDefinition> parameters);
+
+  Optional<Definition> findDefinition(Long id);
+
+  List<Definition> listDefinitions();
+
+  boolean updateDraft(
+      Long id,
+      long baseRevision,
+      String name,
+      String description,
+      Long dataSourceId,
+      String sql,
+      List<SqlParameterDefinition> parameters);
+
+  Optional<Definition> lockDefinition(Long id);
+
+  Version insertVersion(
+      Long taskId,
+      int versionNo,
+      Long dataSourceId,
+      String sql,
+      List<SqlParameterDefinition> parameters,
+      String contentDigest);
+
+  boolean markPublished(Long taskId, Long versionId, int versionNo);
+
+  Optional<Version> findVersion(Long versionId);
+
+  Optional<Version> findPublishedVersion(Long taskId);
+
+  List<Version> listVersions(Long taskId);
+
+  Execution insertExecution(
+      Long taskId,
+      Long taskVersionId,
+      Integer taskVersionNo,
+      Long dataSourceId,
+      String sql,
+      Map<String, Object> input,
+      String idempotencyKey);
+
+  Optional<Execution> findExecution(Long executionId);
+
+  Optional<Execution> findExecutionByIdempotencyKey(String idempotencyKey);
+
+  boolean markRunning(Long executionId);
+
+  boolean markSucceeded(Long executionId, long affectedRows, Map<String, Object> output);
+
+  boolean markFailed(Long executionId, String errorMessage);
+
+  boolean markCanceled(Long executionId);
+
+  boolean markLost(Long executionId, String errorMessage);
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/SqlDevelopmentRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/SqlDevelopmentRepositoryAdapter.java
@@ -1,0 +1,301 @@
+package io.yak.ops.business.development.repository;
+
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.baomidou.mybatisplus.core.conditions.update.LambdaUpdateWrapper;
+import io.yak.ops.business.development.dao.mapper.SqlTaskExecutionMapper;
+import io.yak.ops.business.development.dao.mapper.SqlTaskMapper;
+import io.yak.ops.business.development.dao.mapper.SqlTaskVersionMapper;
+import io.yak.ops.business.development.domain.SqlDevelopmentModel.Definition;
+import io.yak.ops.business.development.domain.SqlDevelopmentModel.Execution;
+import io.yak.ops.business.development.domain.SqlDevelopmentModel.Version;
+import io.yak.ops.business.development.domain.SqlParameterDefinition;
+import io.yak.ops.business.development.support.SqlDevelopmentJsonCodec;
+import io.yak.ops.common.bean.po.development.SqlTaskExecutionPO;
+import io.yak.ops.common.bean.po.development.SqlTaskPO;
+import io.yak.ops.common.bean.po.development.SqlTaskVersionPO;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.springframework.stereotype.Repository;
+
+/** MyBatis adapter for SQL development metadata and execution state. */
+@Repository
+public class SqlDevelopmentRepositoryAdapter implements SqlDevelopmentRepository {
+
+  private final SqlTaskMapper taskMapper;
+  private final SqlTaskVersionMapper versionMapper;
+  private final SqlTaskExecutionMapper executionMapper;
+  private final SqlDevelopmentJsonCodec jsonCodec;
+
+  public SqlDevelopmentRepositoryAdapter(
+      SqlTaskMapper taskMapper,
+      SqlTaskVersionMapper versionMapper,
+      SqlTaskExecutionMapper executionMapper,
+      SqlDevelopmentJsonCodec jsonCodec) {
+    this.taskMapper = taskMapper;
+    this.versionMapper = versionMapper;
+    this.executionMapper = executionMapper;
+    this.jsonCodec = jsonCodec;
+  }
+
+  @Override
+  public Definition insertDefinition(
+      String name,
+      String description,
+      Long dataSourceId,
+      String sql,
+      List<SqlParameterDefinition> parameters) {
+    Instant now = Instant.now();
+    SqlTaskPO po = new SqlTaskPO();
+    po.setName(name);
+    po.setDescription(description);
+    po.setDataSourceId(dataSourceId);
+    po.setSqlText(sql);
+    po.setParameterJson(jsonCodec.write(parameters));
+    po.setDraftRevision(1L);
+    po.setLatestVersionNo(0);
+    po.setDeleted(false);
+    po.setCreateTime(now);
+    po.setUpdateTime(now);
+    taskMapper.insert(po);
+    return toDefinition(po);
+  }
+
+  @Override
+  public Optional<Definition> findDefinition(Long id) {
+    return Optional.ofNullable(taskMapper.selectById(id)).map(this::toDefinition);
+  }
+
+  @Override
+  public List<Definition> listDefinitions() {
+    return taskMapper.selectList(
+            new LambdaQueryWrapper<SqlTaskPO>().orderByDesc(SqlTaskPO::getUpdateTime))
+        .stream()
+        .map(this::toDefinition)
+        .toList();
+  }
+
+  @Override
+  public boolean updateDraft(
+      Long id,
+      long baseRevision,
+      String name,
+      String description,
+      Long dataSourceId,
+      String sql,
+      List<SqlParameterDefinition> parameters) {
+    return taskMapper.update(
+            null,
+            new LambdaUpdateWrapper<SqlTaskPO>()
+                .eq(SqlTaskPO::getId, id)
+                .eq(SqlTaskPO::getDraftRevision, baseRevision)
+                .set(SqlTaskPO::getName, name)
+                .set(SqlTaskPO::getDescription, description)
+                .set(SqlTaskPO::getDataSourceId, dataSourceId)
+                .set(SqlTaskPO::getSqlText, sql)
+                .set(SqlTaskPO::getParameterJson, jsonCodec.write(parameters))
+                .set(SqlTaskPO::getDraftRevision, baseRevision + 1L)
+                .set(SqlTaskPO::getUpdateTime, Instant.now()))
+        == 1;
+  }
+
+  @Override
+  public Optional<Definition> lockDefinition(Long id) {
+    return Optional.ofNullable(taskMapper.selectForUpdate(id)).map(this::toDefinition);
+  }
+
+  @Override
+  public Version insertVersion(
+      Long taskId,
+      int versionNo,
+      Long dataSourceId,
+      String sql,
+      List<SqlParameterDefinition> parameters,
+      String contentDigest) {
+    SqlTaskVersionPO po = new SqlTaskVersionPO();
+    po.setTaskId(taskId);
+    po.setVersionNo(versionNo);
+    po.setDataSourceId(dataSourceId);
+    po.setSqlSnapshot(sql);
+    po.setParameterSnapshotJson(jsonCodec.write(parameters));
+    po.setContentDigest(contentDigest);
+    po.setPublishedAt(Instant.now());
+    versionMapper.insert(po);
+    return toVersion(po);
+  }
+
+  @Override
+  public boolean markPublished(Long taskId, Long versionId, int versionNo) {
+    return taskMapper.update(
+            null,
+            new LambdaUpdateWrapper<SqlTaskPO>()
+                .eq(SqlTaskPO::getId, taskId)
+                .set(SqlTaskPO::getPublishedVersionId, versionId)
+                .set(SqlTaskPO::getLatestVersionNo, versionNo)
+                .set(SqlTaskPO::getUpdateTime, Instant.now()))
+        == 1;
+  }
+
+  @Override
+  public Optional<Version> findVersion(Long versionId) {
+    return Optional.ofNullable(versionMapper.selectById(versionId)).map(this::toVersion);
+  }
+
+  @Override
+  public Optional<Version> findPublishedVersion(Long taskId) {
+    SqlTaskPO task = taskMapper.selectById(taskId);
+    if (task == null || task.getPublishedVersionId() == null) return Optional.empty();
+    return findVersion(task.getPublishedVersionId());
+  }
+
+  @Override
+  public List<Version> listVersions(Long taskId) {
+    return versionMapper.selectList(
+            new LambdaQueryWrapper<SqlTaskVersionPO>()
+                .eq(SqlTaskVersionPO::getTaskId, taskId)
+                .orderByDesc(SqlTaskVersionPO::getVersionNo))
+        .stream()
+        .map(this::toVersion)
+        .toList();
+  }
+
+  @Override
+  public Execution insertExecution(
+      Long taskId,
+      Long taskVersionId,
+      Integer taskVersionNo,
+      Long dataSourceId,
+      String sql,
+      Map<String, Object> input,
+      String idempotencyKey) {
+    SqlTaskExecutionPO po = new SqlTaskExecutionPO();
+    po.setTaskId(taskId);
+    po.setTaskVersionId(taskVersionId);
+    po.setTaskVersionNo(taskVersionNo);
+    po.setDataSourceId(dataSourceId);
+    po.setSqlSnapshot(sql);
+    po.setInputJson(jsonCodec.write(input == null ? Map.of() : input));
+    po.setIdempotencyKey(idempotencyKey);
+    po.setStatus("QUEUED");
+    po.setAffectedRows(0L);
+    po.setCreateTime(Instant.now());
+    executionMapper.insert(po);
+    return toExecution(po);
+  }
+
+  @Override
+  public Optional<Execution> findExecution(Long executionId) {
+    return Optional.ofNullable(executionMapper.selectById(executionId)).map(this::toExecution);
+  }
+
+  @Override
+  public Optional<Execution> findExecutionByIdempotencyKey(String idempotencyKey) {
+    if (idempotencyKey == null || idempotencyKey.isBlank()) return Optional.empty();
+    return Optional.ofNullable(
+            executionMapper.selectOne(
+                new LambdaQueryWrapper<SqlTaskExecutionPO>()
+                    .eq(SqlTaskExecutionPO::getIdempotencyKey, idempotencyKey)
+                    .last("LIMIT 1")))
+        .map(this::toExecution);
+  }
+
+  @Override
+  public boolean markRunning(Long executionId) {
+    return executionMapper.update(
+            null,
+            activeUpdate(executionId, List.of("QUEUED"))
+                .set(SqlTaskExecutionPO::getStatus, "RUNNING")
+                .set(SqlTaskExecutionPO::getStartTime, Instant.now()))
+        == 1;
+  }
+
+  @Override
+  public boolean markSucceeded(Long executionId, long affectedRows, Map<String, Object> output) {
+    return executionMapper.update(
+            null,
+            activeUpdate(executionId, List.of("RUNNING"))
+                .set(SqlTaskExecutionPO::getStatus, "SUCCEEDED")
+                .set(SqlTaskExecutionPO::getAffectedRows, affectedRows)
+                .set(SqlTaskExecutionPO::getOutputJson, jsonCodec.write(output))
+                .set(SqlTaskExecutionPO::getFinishTime, Instant.now()))
+        == 1;
+  }
+
+  @Override
+  public boolean markFailed(Long executionId, String errorMessage) {
+    return finish(executionId, "FAILED", errorMessage);
+  }
+
+  @Override
+  public boolean markCanceled(Long executionId) {
+    return finish(executionId, "CANCELED", null);
+  }
+
+  @Override
+  public boolean markLost(Long executionId, String errorMessage) {
+    return finish(executionId, "LOST", errorMessage);
+  }
+
+  private boolean finish(Long executionId, String status, String errorMessage) {
+    LambdaUpdateWrapper<SqlTaskExecutionPO> update =
+        activeUpdate(executionId, List.of("QUEUED", "RUNNING"))
+            .set(SqlTaskExecutionPO::getStatus, status)
+            .set(SqlTaskExecutionPO::getFinishTime, Instant.now());
+    if (errorMessage != null) {
+      update.set(SqlTaskExecutionPO::getErrorMessage, errorMessage);
+    }
+    return executionMapper.update(null, update) == 1;
+  }
+
+  private LambdaUpdateWrapper<SqlTaskExecutionPO> activeUpdate(
+      Long executionId,
+      List<String> statuses) {
+    return new LambdaUpdateWrapper<SqlTaskExecutionPO>()
+        .eq(SqlTaskExecutionPO::getId, executionId)
+        .in(SqlTaskExecutionPO::getStatus, statuses);
+  }
+
+  private Definition toDefinition(SqlTaskPO po) {
+    return new Definition(
+        po.getId(),
+        po.getName(),
+        po.getDescription(),
+        po.getDataSourceId(),
+        po.getSqlText(),
+        jsonCodec.readParameters(po.getParameterJson()),
+        po.getDraftRevision() == null ? 0L : po.getDraftRevision(),
+        po.getPublishedVersionId(),
+        po.getLatestVersionNo() == null ? 0 : po.getLatestVersionNo(),
+        po.getCreateTime(),
+        po.getUpdateTime());
+  }
+
+  private Version toVersion(SqlTaskVersionPO po) {
+    return new Version(
+        po.getId(),
+        po.getTaskId(),
+        po.getVersionNo() == null ? 0 : po.getVersionNo(),
+        po.getDataSourceId(),
+        po.getSqlSnapshot(),
+        jsonCodec.readParameters(po.getParameterSnapshotJson()),
+        po.getContentDigest(),
+        po.getPublishedAt());
+  }
+
+  private Execution toExecution(SqlTaskExecutionPO po) {
+    return new Execution(
+        po.getId(),
+        po.getTaskId(),
+        po.getTaskVersionId(),
+        po.getTaskVersionNo(),
+        po.getDataSourceId(),
+        po.getStatus(),
+        po.getAffectedRows() == null ? 0L : po.getAffectedRows(),
+        jsonCodec.readMap(po.getOutputJson()),
+        po.getErrorMessage(),
+        po.getCreateTime(),
+        po.getStartTime(),
+        po.getFinishTime());
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/SqlDevelopmentService.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/SqlDevelopmentService.java
@@ -1,0 +1,221 @@
+package io.yak.ops.business.development.service;
+
+import io.yak.ops.business.datasource.repository.DataSourceRepository;
+import io.yak.ops.business.development.domain.SqlDevelopmentModel.Definition;
+import io.yak.ops.business.development.domain.SqlDevelopmentModel.Execution;
+import io.yak.ops.business.development.domain.SqlDevelopmentModel.Version;
+import io.yak.ops.business.development.domain.SqlParameterDefinition;
+import io.yak.ops.business.development.domain.SqlTaskSnapshot;
+import io.yak.ops.business.development.execution.NamedSqlParameterParser;
+import io.yak.ops.business.development.repository.SqlDevelopmentRepository;
+import io.yak.ops.business.development.support.SqlDevelopmentJsonCodec;
+import io.yak.ops.business.job.task.TaskExecution;
+import io.yak.ops.business.job.task.TaskExecutionGateway;
+import io.yak.ops.business.job.task.TaskVersionSnapshot;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/** SQL development application service: draft, immutable publish and direct test run. */
+@Service
+public class SqlDevelopmentService {
+
+  private static final Set<String> PARAMETER_TYPES = Set.of(
+      "STRING", "INTEGER", "LONG", "DOUBLE", "DECIMAL", "BOOLEAN", "DATE", "TIMESTAMP");
+
+  private final SqlDevelopmentRepository repository;
+  private final DataSourceRepository dataSourceRepository;
+  private final SqlDevelopmentJsonCodec jsonCodec;
+  private final TaskExecutionGateway executionGateway;
+
+  public SqlDevelopmentService(
+      SqlDevelopmentRepository repository,
+      DataSourceRepository dataSourceRepository,
+      SqlDevelopmentJsonCodec jsonCodec,
+      TaskExecutionGateway executionGateway) {
+    this.repository = repository;
+    this.dataSourceRepository = dataSourceRepository;
+    this.jsonCodec = jsonCodec;
+    this.executionGateway = executionGateway;
+  }
+
+  @Transactional(transactionManager = "yakBusinessTransactionManager", rollbackFor = Exception.class)
+  public Definition create(
+      String name,
+      String description,
+      Long dataSourceId,
+      String sql,
+      List<SqlParameterDefinition> parameters) {
+    List<SqlParameterDefinition> normalized = validate(dataSourceId, sql, parameters);
+    return repository.insertDefinition(
+        requireText(name, "任务名称"), trimToNull(description), dataSourceId, sql.trim(), normalized);
+  }
+
+  public List<Definition> list() {
+    return repository.listDefinitions();
+  }
+
+  public Definition get(Long id) {
+    return requireDefinition(id);
+  }
+
+  @Transactional(transactionManager = "yakBusinessTransactionManager", rollbackFor = Exception.class)
+  public Definition update(
+      Long id,
+      long baseRevision,
+      String name,
+      String description,
+      Long dataSourceId,
+      String sql,
+      List<SqlParameterDefinition> parameters) {
+    requireDefinition(id);
+    List<SqlParameterDefinition> normalized = validate(dataSourceId, sql, parameters);
+    boolean updated = repository.updateDraft(
+        id,
+        baseRevision,
+        requireText(name, "任务名称"),
+        trimToNull(description),
+        dataSourceId,
+        sql.trim(),
+        normalized);
+    if (!updated) {
+      throw new IllegalStateException("SQL 草稿已经被其他请求修改，请刷新后重试");
+    }
+    return requireDefinition(id);
+  }
+
+  @Transactional(transactionManager = "yakBusinessTransactionManager", rollbackFor = Exception.class)
+  public Version publish(Long id, long draftRevision) {
+    Definition definition = repository.lockDefinition(id)
+        .orElseThrow(() -> new IllegalArgumentException("SQL 任务不存在：" + id));
+    if (definition.draftRevision() != draftRevision) {
+      throw new IllegalStateException(
+          "SQL 草稿版本冲突，当前 revision=" + definition.draftRevision()
+              + "，请求 revision=" + draftRevision);
+    }
+    List<SqlParameterDefinition> normalized =
+        validate(definition.dataSourceId(), definition.sql(), definition.parameters());
+    int versionNo = definition.latestVersionNo() + 1;
+    String digest = jsonCodec.digest(definition.sql(), normalized, definition.dataSourceId());
+    Version version = repository.insertVersion(
+        id,
+        versionNo,
+        definition.dataSourceId(),
+        definition.sql(),
+        normalized,
+        digest);
+    if (!repository.markPublished(id, version.id(), versionNo)) {
+      throw new IllegalStateException("SQL 发布版本写入成功，但任务发布指针更新失败：" + id);
+    }
+    return version;
+  }
+
+  public List<Version> versions(Long id) {
+    requireDefinition(id);
+    return repository.listVersions(id);
+  }
+
+  public Execution runDraft(Long id, Map<String, Object> input) {
+    Definition definition = requireDefinition(id);
+    List<SqlParameterDefinition> normalized =
+        validate(definition.dataSourceId(), definition.sql(), definition.parameters());
+    TaskVersionSnapshot snapshot = new TaskVersionSnapshot(
+        workflowTaskId(id),
+        definition.name(),
+        "SQL",
+        0L,
+        jsonCodec.digest(definition.sql(), normalized, definition.dataSourceId()),
+        jsonCodec.write(new SqlTaskSnapshot.Definition(definition.sql(), normalized)),
+        jsonCodec.write(new SqlTaskSnapshot.ExecutionConfig(definition.dataSourceId(), null)));
+    TaskExecution started = executionGateway.start(
+        snapshot,
+        "manual:" + UUID.randomUUID(),
+        input == null ? Map.of() : input);
+    return execution(Long.parseLong(started.executionId()));
+  }
+
+  public Execution execution(Long executionId) {
+    return repository.findExecution(executionId)
+        .orElseThrow(() -> new IllegalArgumentException("SQL 执行不存在：" + executionId));
+  }
+
+  public Execution cancel(Long executionId) {
+    Execution execution = execution(executionId);
+    if (!isTerminal(execution.status())) {
+      executionGateway.cancel("SQL", String.valueOf(executionId));
+    }
+    return execution(executionId);
+  }
+
+  private List<SqlParameterDefinition> validate(
+      Long dataSourceId,
+      String sql,
+      List<SqlParameterDefinition> parameters) {
+    if (dataSourceId == null || dataSourceId <= 0L
+        || dataSourceRepository.findById(dataSourceId).isEmpty()) {
+      throw new IllegalArgumentException("数据源不存在：" + dataSourceId);
+    }
+    NamedSqlParameterParser.ParsedSql parsed = NamedSqlParameterParser.parse(sql);
+    List<SqlParameterDefinition> normalized = normalizeParameters(parameters);
+    Set<String> declared = new HashSet<>();
+    for (SqlParameterDefinition parameter : normalized) declared.add(parameter.name());
+    for (String name : parsed.parameterNames()) {
+      if (!declared.contains(name)) {
+        throw new IllegalArgumentException("SQL 参数未声明：" + name);
+      }
+    }
+    return normalized;
+  }
+
+  private List<SqlParameterDefinition> normalizeParameters(List<SqlParameterDefinition> parameters) {
+    if (parameters == null || parameters.isEmpty()) return List.of();
+    Set<String> names = new HashSet<>();
+    return parameters.stream().map(parameter -> {
+      if (parameter == null) throw new IllegalArgumentException("SQL 参数定义不能为空");
+      String name = requireText(parameter.name(), "参数名称");
+      if (!name.matches("[A-Za-z_][A-Za-z0-9_]*")) {
+        throw new IllegalArgumentException("SQL 参数名称不合法：" + name);
+      }
+      if (!names.add(name)) throw new IllegalArgumentException("SQL 参数重复：" + name);
+      String type = parameter.type() == null || parameter.type().isBlank()
+          ? "STRING"
+          : parameter.type().trim().toUpperCase(Locale.ROOT);
+      if (!PARAMETER_TYPES.contains(type)) {
+        throw new IllegalArgumentException("不支持的 SQL 参数类型：" + type);
+      }
+      return new SqlParameterDefinition(name, type, parameter.required(), parameter.defaultValue());
+    }).toList();
+  }
+
+  private Definition requireDefinition(Long id) {
+    if (id == null || id <= 0L) throw new IllegalArgumentException("SQL 任务 ID 不合法：" + id);
+    return repository.findDefinition(id)
+        .orElseThrow(() -> new IllegalArgumentException("SQL 任务不存在：" + id));
+  }
+
+  private String workflowTaskId(Long id) {
+    return "SQL:" + id;
+  }
+
+  private String requireText(String value, String name) {
+    if (value == null || value.isBlank()) throw new IllegalArgumentException(name + "不能为空");
+    return value.trim();
+  }
+
+  private String trimToNull(String value) {
+    return value == null || value.isBlank() ? null : value.trim();
+  }
+
+  private boolean isTerminal(String status) {
+    return "SUCCEEDED".equalsIgnoreCase(status)
+        || "FAILED".equalsIgnoreCase(status)
+        || "CANCELED".equalsIgnoreCase(status)
+        || "TIMED_OUT".equalsIgnoreCase(status)
+        || "LOST".equalsIgnoreCase(status);
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/support/SqlDevelopmentJsonCodec.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/support/SqlDevelopmentJsonCodec.java
@@ -1,0 +1,70 @@
+package io.yak.ops.business.development.support;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.development.domain.SqlParameterDefinition;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Map;
+import org.springframework.stereotype.Component;
+
+/** JSON and digest boundary for durable SQL snapshots. */
+@Component
+public class SqlDevelopmentJsonCodec {
+
+  private static final TypeReference<List<SqlParameterDefinition>> PARAMETER_TYPE =
+      new TypeReference<>() {};
+  private static final TypeReference<Map<String, Object>> MAP_TYPE = new TypeReference<>() {};
+
+  private final ObjectMapper objectMapper;
+
+  public SqlDevelopmentJsonCodec(ObjectMapper objectMapper) {
+    this.objectMapper = objectMapper;
+  }
+
+  public String write(Object value) {
+    try {
+      return objectMapper.writeValueAsString(value);
+    } catch (Exception exception) {
+      throw new IllegalStateException("SQL 数据开发 JSON 序列化失败", exception);
+    }
+  }
+
+  public List<SqlParameterDefinition> readParameters(String json) {
+    if (json == null || json.isBlank()) return List.of();
+    try {
+      return List.copyOf(objectMapper.readValue(json, PARAMETER_TYPE));
+    } catch (Exception exception) {
+      throw new IllegalStateException("SQL 参数快照解析失败", exception);
+    }
+  }
+
+  public Map<String, Object> readMap(String json) {
+    if (json == null || json.isBlank()) return Map.of();
+    try {
+      return objectMapper.readValue(json, MAP_TYPE);
+    } catch (Exception exception) {
+      throw new IllegalStateException("SQL 执行 JSON 解析失败", exception);
+    }
+  }
+
+  public <T> T read(String json, Class<T> type) {
+    try {
+      return objectMapper.readValue(json, type);
+    } catch (Exception exception) {
+      throw new IllegalStateException("SQL 快照解析失败", exception);
+    }
+  }
+
+  public String digest(String sql, List<SqlParameterDefinition> parameters, Long dataSourceId) {
+    try {
+      MessageDigest digest = MessageDigest.getInstance("SHA-256");
+      String canonical = dataSourceId + "\n" + sql + "\n" + write(parameters);
+      return HexFormat.of().formatHex(digest.digest(canonical.getBytes(StandardCharsets.UTF_8)));
+    } catch (Exception exception) {
+      throw new IllegalStateException("SQL 快照摘要计算失败", exception);
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/workflow/SqlTaskProvider.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/workflow/SqlTaskProvider.java
@@ -1,0 +1,70 @@
+package io.yak.ops.business.development.workflow;
+
+import io.yak.ops.business.development.domain.SqlDevelopmentModel.Definition;
+import io.yak.ops.business.development.domain.SqlDevelopmentModel.Version;
+import io.yak.ops.business.development.domain.SqlTaskSnapshot;
+import io.yak.ops.business.development.repository.SqlDevelopmentRepository;
+import io.yak.ops.business.development.support.SqlDevelopmentJsonCodec;
+import io.yak.ops.business.job.task.TaskDefinition;
+import io.yak.ops.business.job.task.TaskProvider;
+import io.yak.ops.business.job.task.TaskVersionSnapshot;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+/** Projects immutable published SQL versions into the generic workflow task library. */
+@Component
+public class SqlTaskProvider implements TaskProvider {
+
+  private final SqlDevelopmentRepository repository;
+  private final SqlDevelopmentJsonCodec jsonCodec;
+
+  public SqlTaskProvider(
+      SqlDevelopmentRepository repository,
+      SqlDevelopmentJsonCodec jsonCodec) {
+    this.repository = repository;
+    this.jsonCodec = jsonCodec;
+  }
+
+  @Override
+  public List<TaskDefinition> list() {
+    return repository.listDefinitions().stream()
+        .filter(definition -> definition.publishedVersionId() != null)
+        .map(definition -> new TaskDefinition(
+            workflowTaskId(definition.id()), definition.name(), "SQL"))
+        .toList();
+  }
+
+  @Override
+  public TaskVersionSnapshot snapshot(String taskId) {
+    Long id = parseTaskId(taskId);
+    Definition definition = repository.findDefinition(id)
+        .orElseThrow(() -> new IllegalArgumentException("SQL 任务不存在：" + taskId));
+    Version version = repository.findPublishedVersion(id)
+        .orElseThrow(() -> new IllegalArgumentException("SQL 任务尚未发布：" + taskId));
+    return new TaskVersionSnapshot(
+        workflowTaskId(id),
+        definition.name(),
+        "SQL",
+        version.versionNo(),
+        version.contentDigest(),
+        jsonCodec.write(new SqlTaskSnapshot.Definition(version.sql(), version.parameters())),
+        jsonCodec.write(new SqlTaskSnapshot.ExecutionConfig(version.dataSourceId(), version.id())));
+  }
+
+  private String workflowTaskId(Long id) {
+    return "SQL:" + id;
+  }
+
+  private Long parseTaskId(String taskId) {
+    if (taskId == null || !taskId.startsWith("SQL:")) {
+      throw new IllegalArgumentException("SQL 工作流任务 ID 不合法：" + taskId);
+    }
+    try {
+      long id = Long.parseLong(taskId.substring("SQL:".length()));
+      if (id <= 0L) throw new NumberFormatException(taskId);
+      return id;
+    } catch (RuntimeException exception) {
+      throw new IllegalArgumentException("SQL 工作流任务 ID 不合法：" + taskId, exception);
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/resources/db/migration/yak-data-development/V1__create_sql_data_development_tables.sql
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/resources/db/migration/yak-data-development/V1__create_sql_data_development_tables.sql
@@ -1,0 +1,53 @@
+CREATE TABLE IF NOT EXISTS yak_dev_sql_task (
+    id BIGINT NOT NULL,
+    name VARCHAR(200) NOT NULL,
+    description VARCHAR(1000) NULL,
+    data_source_id BIGINT NOT NULL,
+    sql_text LONGTEXT NOT NULL,
+    parameter_json LONGTEXT NOT NULL,
+    draft_revision BIGINT NOT NULL DEFAULT 1,
+    published_version_id BIGINT NULL,
+    latest_version_no INT NOT NULL DEFAULT 0,
+    deleted TINYINT(1) NOT NULL DEFAULT 0,
+    create_time DATETIME(6) NOT NULL,
+    update_time DATETIME(6) NOT NULL,
+    PRIMARY KEY (id),
+    KEY idx_yak_dev_sql_task_datasource (data_source_id),
+    KEY idx_yak_dev_sql_task_updated (update_time)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS yak_dev_sql_task_version (
+    id BIGINT NOT NULL,
+    task_id BIGINT NOT NULL,
+    version_no INT NOT NULL,
+    data_source_id BIGINT NOT NULL,
+    sql_snapshot LONGTEXT NOT NULL,
+    parameter_snapshot_json LONGTEXT NOT NULL,
+    content_digest VARCHAR(64) NOT NULL,
+    published_at DATETIME(6) NOT NULL,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_yak_dev_sql_version (task_id, version_no),
+    KEY idx_yak_dev_sql_version_datasource (data_source_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS yak_dev_sql_task_execution (
+    id BIGINT NOT NULL,
+    task_id BIGINT NOT NULL,
+    task_version_id BIGINT NULL,
+    task_version_no INT NULL,
+    data_source_id BIGINT NOT NULL,
+    sql_snapshot LONGTEXT NOT NULL,
+    input_json LONGTEXT NOT NULL,
+    idempotency_key VARCHAR(160) NULL,
+    status VARCHAR(32) NOT NULL,
+    affected_rows BIGINT NOT NULL DEFAULT 0,
+    output_json LONGTEXT NULL,
+    error_message TEXT NULL,
+    create_time DATETIME(6) NOT NULL,
+    start_time DATETIME(6) NULL,
+    finish_time DATETIME(6) NULL,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_yak_dev_sql_execution_idempotency (idempotency_key),
+    KEY idx_yak_dev_sql_execution_task (task_id, create_time),
+    KEY idx_yak_dev_sql_execution_status (status, create_time)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/yak-ops-business/yak-ops-business-data-development/src/main/resources/mapper/development/SqlTaskMapper.xml
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/resources/mapper/development/SqlTaskMapper.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+    PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+    "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="io.yak.ops.business.development.dao.mapper.SqlTaskMapper">
+    <select id="selectForUpdate" resultType="io.yak.ops.common.bean.po.development.SqlTaskPO">
+        SELECT id,
+               name,
+               description,
+               data_source_id,
+               sql_text,
+               parameter_json,
+               draft_revision,
+               published_version_id,
+               latest_version_no,
+               deleted,
+               create_time,
+               update_time
+        FROM yak_dev_sql_task
+        WHERE id = #{id}
+          AND deleted = 0
+        FOR UPDATE
+    </select>
+</mapper>

--- a/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/execution/NamedSqlParameterParserTest.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/execution/NamedSqlParameterParserTest.java
@@ -1,0 +1,32 @@
+package io.yak.ops.business.development.execution;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class NamedSqlParameterParserTest {
+
+  @Test
+  void shouldParseNamedValueParametersWithoutTouchingQuotesCommentsOrCasts() {
+    NamedSqlParameterParser.ParsedSql parsed = NamedSqlParameterParser.parse("""
+        SELECT ':literal' AS literal,
+               created_at::date AS created_date
+        FROM orders
+        WHERE biz_date = :biz_date
+          AND tenant_id = :tenant_id
+          -- :ignored
+        """);
+
+    assertThat(parsed.parameterNames()).containsExactly("biz_date", "tenant_id");
+    assertThat(parsed.jdbcSql()).contains("biz_date = ?", "tenant_id = ?", "created_at::date");
+    assertThat(parsed.jdbcSql()).contains("':literal'", "-- :ignored");
+  }
+
+  @Test
+  void shouldRejectMultipleStatements() {
+    assertThatThrownBy(() -> NamedSqlParameterParser.parse("select 1; delete from t"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("单条 SQL");
+  }
+}

--- a/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/task/InMemoryTaskRegistry.java
+++ b/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/task/InMemoryTaskRegistry.java
@@ -13,7 +13,7 @@ import java.util.concurrent.ConcurrentMap;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.stereotype.Service;
 
-/** 第一阶段任务注册表；同步任务元数据由离线同步定义服务投影。 */
+/** Workflow task registry. Concrete business domains contribute tasks through {@link TaskProvider}. */
 @Service
 public class InMemoryTaskRegistry implements TaskRegistry {
 
@@ -21,11 +21,15 @@ public class InMemoryTaskRegistry implements TaskRegistry {
   private static final String RELEASE_STATE_ONLINE = "ONLINE";
 
   private final ObjectProvider<OfflineJobDefinitionService> definitionServiceProvider;
+  private final ObjectProvider<TaskProvider> taskProviderProvider;
   private final ConcurrentMap<String, TaskDefinition> tasks = new ConcurrentHashMap<>();
   private final ConcurrentMap<String, TaskVersionSnapshot> snapshots = new ConcurrentHashMap<>();
 
-  public InMemoryTaskRegistry(ObjectProvider<OfflineJobDefinitionService> definitionServiceProvider) {
+  public InMemoryTaskRegistry(
+      ObjectProvider<OfflineJobDefinitionService> definitionServiceProvider,
+      ObjectProvider<TaskProvider> taskProviderProvider) {
     this.definitionServiceProvider = definitionServiceProvider;
+    this.taskProviderProvider = taskProviderProvider;
   }
 
   @Override
@@ -58,15 +62,23 @@ public class InMemoryTaskRegistry implements TaskRegistry {
   }
 
   private void refresh() {
-    OfflineJobDefinitionService service = definitionServiceProvider.getIfAvailable();
-    if (service == null) {
-      tasks.clear();
-      snapshots.clear();
-      return;
-    }
-
     Map<String, TaskDefinition> taskSnapshot = new LinkedHashMap<>();
     Map<String, TaskVersionSnapshot> versionSnapshot = new LinkedHashMap<>();
+    appendOfflineSyncTasks(taskSnapshot, versionSnapshot);
+    appendProvidedTasks(taskSnapshot, versionSnapshot);
+
+    tasks.clear();
+    tasks.putAll(taskSnapshot);
+    snapshots.clear();
+    snapshots.putAll(versionSnapshot);
+  }
+
+  private void appendOfflineSyncTasks(
+      Map<String, TaskDefinition> taskSnapshot,
+      Map<String, TaskVersionSnapshot> versionSnapshot) {
+    OfflineJobDefinitionService service = definitionServiceProvider.getIfAvailable();
+    if (service == null) return;
+
     int pageNo = 1;
     while (true) {
       PageData<OfflineJobDefinition> page = service.pageDomain(
@@ -89,10 +101,10 @@ public class InMemoryTaskRegistry implements TaskRegistry {
           String logicalJobSpec = service.resolveLogicalJobSpec(current);
           String id = String.valueOf(current.getId());
           String name = current.getJobName();
-          TaskDefinition task = new TaskDefinition(id, name, "SYNC");
-          taskSnapshot.put(id, task);
-          versionSnapshot.put(
-              id,
+          putTask(
+              taskSnapshot,
+              versionSnapshot,
+              new TaskDefinition(id, name, "SYNC"),
               new TaskVersionSnapshot(
                   id,
                   name,
@@ -108,11 +120,34 @@ public class InMemoryTaskRegistry implements TaskRegistry {
       if (pageNo >= page.pages()) break;
       pageNo++;
     }
+  }
 
-    tasks.clear();
-    tasks.putAll(taskSnapshot);
-    snapshots.clear();
-    snapshots.putAll(versionSnapshot);
+  private void appendProvidedTasks(
+      Map<String, TaskDefinition> taskSnapshot,
+      Map<String, TaskVersionSnapshot> versionSnapshot) {
+    for (TaskProvider provider : taskProviderProvider.orderedStream().toList()) {
+      for (TaskDefinition task : provider.list()) {
+        if (task == null || task.id() == null || task.id().isBlank()) continue;
+        TaskVersionSnapshot snapshot = provider.snapshot(task.id());
+        putTask(taskSnapshot, versionSnapshot, task, snapshot);
+      }
+    }
+  }
+
+  private void putTask(
+      Map<String, TaskDefinition> taskSnapshot,
+      Map<String, TaskVersionSnapshot> versionSnapshot,
+      TaskDefinition task,
+      TaskVersionSnapshot snapshot) {
+    if (snapshot == null || !task.id().equals(snapshot.taskId())) {
+      throw new IllegalStateException("任务定义与版本快照不匹配：" + task.id());
+    }
+    TaskDefinition existing = taskSnapshot.putIfAbsent(task.id(), task);
+    if (existing != null) {
+      throw new IllegalStateException(
+          "重复的工作流任务 ID：" + task.id() + "，类型=" + existing.type() + "/" + task.type());
+    }
+    versionSnapshot.put(task.id(), snapshot);
   }
 
   static boolean isWorkflowEligible(OfflineJobDefinition definition) {

--- a/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/task/SyncTaskExecutorAdapter.java
+++ b/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/task/SyncTaskExecutorAdapter.java
@@ -1,0 +1,46 @@
+package io.yak.ops.business.job.task;
+
+import java.util.Map;
+import org.springframework.stereotype.Service;
+
+/** Keeps the existing offline-sync runner behind the generic task execution contract. */
+@Service
+public class SyncTaskExecutorAdapter implements TaskExecutor {
+
+  private final SyncTaskRunner runner;
+
+  public SyncTaskExecutorAdapter(SyncTaskRunner runner) {
+    this.runner = runner;
+  }
+
+  @Override
+  public String taskType() {
+    return "SYNC";
+  }
+
+  @Override
+  public TaskExecution start(
+      TaskVersionSnapshot snapshot,
+      String idempotencyKey,
+      Map<String, Object> input) {
+    return convert(runner.start(snapshot, idempotencyKey));
+  }
+
+  @Override
+  public TaskExecution status(String executionId) {
+    return convert(runner.status(executionId));
+  }
+
+  @Override
+  public void cancel(String executionId) {
+    runner.cancel(executionId);
+  }
+
+  private TaskExecution convert(SyncTaskExecution execution) {
+    return new TaskExecution(
+        execution.executionId(),
+        execution.status(),
+        execution.errorMessage(),
+        execution.output());
+  }
+}

--- a/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/task/TaskExecution.java
+++ b/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/task/TaskExecution.java
@@ -1,5 +1,7 @@
 package io.yak.ops.business.job.task;
 
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.Locale;
 import java.util.Map;
 
@@ -14,7 +16,9 @@ public record TaskExecution(
     if (executionId == null || executionId.isBlank()) {
       throw new IllegalArgumentException("executionId 不能为空");
     }
-    output = output == null ? Map.of() : Map.copyOf(output);
+    output = output == null
+        ? Map.of()
+        : Collections.unmodifiableMap(new LinkedHashMap<>(output));
   }
 
   public boolean terminal() {

--- a/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/task/TaskExecution.java
+++ b/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/task/TaskExecution.java
@@ -1,0 +1,36 @@
+package io.yak.ops.business.job.task;
+
+import java.util.Locale;
+import java.util.Map;
+
+/** Workflow and manual runs observe every task type through this stable execution view. */
+public record TaskExecution(
+    String executionId,
+    String status,
+    String errorMessage,
+    Map<String, Object> output) {
+
+  public TaskExecution {
+    if (executionId == null || executionId.isBlank()) {
+      throw new IllegalArgumentException("executionId 不能为空");
+    }
+    output = output == null ? Map.of() : Map.copyOf(output);
+  }
+
+  public boolean terminal() {
+    String normalized = normalizedStatus();
+    return "SUCCEEDED".equals(normalized)
+        || "FAILED".equals(normalized)
+        || "CANCELED".equals(normalized)
+        || "TIMED_OUT".equals(normalized)
+        || "LOST".equals(normalized);
+  }
+
+  public boolean successful() {
+    return "SUCCEEDED".equals(normalizedStatus());
+  }
+
+  private String normalizedStatus() {
+    return status == null ? "" : status.trim().toUpperCase(Locale.ROOT);
+  }
+}

--- a/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/task/TaskExecutionGateway.java
+++ b/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/task/TaskExecutionGateway.java
@@ -1,0 +1,69 @@
+package io.yak.ops.business.job.task;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import org.springframework.stereotype.Service;
+
+/** Generic execution gateway shared by workflow and direct task runs. */
+@Service
+public class TaskExecutionGateway {
+
+  private final Map<String, TaskExecutor> executors;
+
+  public TaskExecutionGateway(List<TaskExecutor> taskExecutors) {
+    Map<String, TaskExecutor> discovered = new LinkedHashMap<>();
+    for (TaskExecutor executor : taskExecutors) {
+      String type = normalize(executor.taskType());
+      TaskExecutor existing = discovered.putIfAbsent(type, executor);
+      if (existing != null) {
+        throw new IllegalStateException(
+            "重复的任务执行器：" + type + " -> "
+                + existing.getClass().getName() + ", " + executor.getClass().getName());
+      }
+    }
+    this.executors = Map.copyOf(discovered);
+  }
+
+  public boolean supports(String taskType) {
+    return executors.containsKey(normalize(taskType));
+  }
+
+  public TaskExecution start(
+      TaskVersionSnapshot snapshot,
+      String idempotencyKey,
+      Map<String, Object> input) {
+    if (snapshot == null) {
+      throw new IllegalArgumentException("任务版本快照不能为空");
+    }
+    return require(snapshot.type()).start(
+        snapshot,
+        idempotencyKey,
+        input == null ? Map.of() : Map.copyOf(input));
+  }
+
+  public TaskExecution status(String taskType, String executionId) {
+    return require(taskType).status(executionId);
+  }
+
+  public void cancel(String taskType, String executionId) {
+    require(taskType).cancel(executionId);
+  }
+
+  private TaskExecutor require(String taskType) {
+    String normalized = normalize(taskType);
+    TaskExecutor executor = executors.get(normalized);
+    if (executor == null) {
+      throw new IllegalArgumentException("不支持的任务类型：" + normalized);
+    }
+    return executor;
+  }
+
+  private String normalize(String taskType) {
+    if (taskType == null || taskType.isBlank()) {
+      throw new IllegalArgumentException("taskType 不能为空");
+    }
+    return taskType.trim().toUpperCase(Locale.ROOT);
+  }
+}

--- a/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/task/TaskExecutionGateway.java
+++ b/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/task/TaskExecutionGateway.java
@@ -1,5 +1,6 @@
 package io.yak.ops.business.job.task;
 
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
@@ -37,10 +38,10 @@ public class TaskExecutionGateway {
     if (snapshot == null) {
       throw new IllegalArgumentException("任务版本快照不能为空");
     }
-    return require(snapshot.type()).start(
-        snapshot,
-        idempotencyKey,
-        input == null ? Map.of() : Map.copyOf(input));
+    Map<String, Object> safeInput = input == null
+        ? Map.of()
+        : Collections.unmodifiableMap(new LinkedHashMap<>(input));
+    return require(snapshot.type()).start(snapshot, idempotencyKey, safeInput);
   }
 
   public TaskExecution status(String taskType, String executionId) {

--- a/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/task/TaskExecutor.java
+++ b/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/task/TaskExecutor.java
@@ -1,0 +1,23 @@
+package io.yak.ops.business.job.task;
+
+import java.util.Map;
+
+/**
+ * Executes one immutable task snapshot.
+ *
+ * <p>Workflow only depends on this contract. SQL, SYNC, HTTP, Shell and future task types plug in
+ * independently without leaking task-specific configuration into the workflow runtime.</p>
+ */
+public interface TaskExecutor {
+
+  String taskType();
+
+  TaskExecution start(
+      TaskVersionSnapshot snapshot,
+      String idempotencyKey,
+      Map<String, Object> input);
+
+  TaskExecution status(String executionId);
+
+  void cancel(String executionId);
+}

--- a/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/task/TaskProvider.java
+++ b/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/task/TaskProvider.java
@@ -1,0 +1,11 @@
+package io.yak.ops.business.job.task;
+
+import java.util.List;
+
+/** Supplies workflow-visible tasks without making the Job module depend on concrete business domains. */
+public interface TaskProvider {
+
+  List<TaskDefinition> list();
+
+  TaskVersionSnapshot snapshot(String taskId);
+}

--- a/yak-ops-business/yak-ops-business-job/src/test/java/io/yak/ops/business/job/task/TaskExecutionGatewayTest.java
+++ b/yak-ops-business/yak-ops-business-job/src/test/java/io/yak/ops/business/job/task/TaskExecutionGatewayTest.java
@@ -1,0 +1,61 @@
+package io.yak.ops.business.job.task;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class TaskExecutionGatewayTest {
+
+  @Test
+  void shouldRouteByTaskType() {
+    TaskExecutionGateway gateway = new TaskExecutionGateway(List.of(new FakeExecutor("SQL")));
+    TaskVersionSnapshot snapshot =
+        new TaskVersionSnapshot("SQL:1", "demo", "sql", 1L, "digest", "{}", "{}");
+
+    TaskExecution execution = gateway.start(snapshot, "attempt-1", Map.of("biz_date", "2026-08-10"));
+
+    assertThat(execution.executionId()).isEqualTo("SQL-1");
+    assertThat(gateway.supports("sql")).isTrue();
+    assertThat(gateway.status("SQL", execution.executionId()).successful()).isTrue();
+  }
+
+  @Test
+  void shouldRejectDuplicateTaskTypes() {
+    assertThatThrownBy(() -> new TaskExecutionGateway(
+            List.of(new FakeExecutor("SQL"), new FakeExecutor("sql"))))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("重复的任务执行器");
+  }
+
+  private static final class FakeExecutor implements TaskExecutor {
+    private final String type;
+
+    private FakeExecutor(String type) {
+      this.type = type;
+    }
+
+    @Override
+    public String taskType() {
+      return type;
+    }
+
+    @Override
+    public TaskExecution start(
+        TaskVersionSnapshot snapshot,
+        String idempotencyKey,
+        Map<String, Object> input) {
+      return new TaskExecution("SQL-1", "SUCCEEDED", null, input);
+    }
+
+    @Override
+    public TaskExecution status(String executionId) {
+      return new TaskExecution(executionId, "SUCCEEDED", null, Map.of());
+    }
+
+    @Override
+    public void cancel(String executionId) {}
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowRuntimeService.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowRuntimeService.java
@@ -32,8 +32,10 @@ import io.yak.framework.workflow.engine.support.InMemoryExecutionRepository;
 import io.yak.framework.workflow.engine.support.InMemoryWorkflowDefinitionRepository;
 import io.yak.framework.workflow.engine.support.LocalExecutionLock;
 import io.yak.framework.workflow.engine.support.UuidIdGenerator;
-import io.yak.ops.business.job.task.SyncTaskExecution;
+import io.yak.ops.business.job.task.SyncTaskExecutorAdapter;
 import io.yak.ops.business.job.task.SyncTaskRunner;
+import io.yak.ops.business.job.task.TaskExecution;
+import io.yak.ops.business.job.task.TaskExecutionGateway;
 import io.yak.ops.business.job.task.TaskRegistry;
 import io.yak.ops.business.job.task.TaskVersionSnapshot;
 import io.yak.ops.business.workflow.domain.WorkflowEdgeSpec;
@@ -80,14 +82,14 @@ public class WorkflowRuntimeService {
   private static final Logger log = LoggerFactory.getLogger(WorkflowRuntimeService.class);
   private static final long TASK_POLL_INTERVAL_MILLIS = 500L;
 
-  /** 每次远程 start/status/cancel 都是短生命周期 I/O；不会为任务全生命周期占用固定平台线程。 */
+  /** 每次 task start/status/cancel 都是短生命周期 I/O；不会为任务全生命周期占用固定平台线程。 */
   private final ExecutorService ioExecutor;
   private final ScheduledExecutorService runtimeScheduler;
   private final DefaultWorkflowEngine engine;
   private final WorkflowRecoveryCoordinator recoveryCoordinator;
   private final WorkflowEventStreamService eventStreamService;
   private final TaskRegistry taskRegistry;
-  private final SyncTaskRunner syncTaskRunner;
+  private final TaskExecutionGateway taskExecutionGateway;
   private final WorkflowRuntimePersistence runtimePersistence;
   private final long taskPollIntervalMillis;
   private final ConcurrentMap<String, ConcurrentLinkedQueue<NodeDispatch>> pendingDispatches =
@@ -103,7 +105,7 @@ public class WorkflowRuntimeService {
   public WorkflowRuntimeService(
       WorkflowEventStreamService eventStreamService,
       TaskRegistry taskRegistry,
-      SyncTaskRunner syncTaskRunner,
+      TaskExecutionGateway taskExecutionGateway,
       ObjectProvider<WorkflowDefinitionRepository> definitionRepository,
       ObjectProvider<ExecutionRepository> executionRepository,
       ObjectProvider<WorkflowRuntimePersistence> runtimePersistence,
@@ -111,7 +113,7 @@ public class WorkflowRuntimeService {
     this(
         eventStreamService,
         taskRegistry,
-        syncTaskRunner,
+        taskExecutionGateway,
         TASK_POLL_INTERVAL_MILLIS,
         resolvePersistence(
             definitionRepository,
@@ -139,7 +141,7 @@ public class WorkflowRuntimeService {
     this(
         eventStreamService,
         taskRegistry,
-        syncTaskRunner,
+        legacyGateway(syncTaskRunner),
         taskPollIntervalMillis,
         new InMemoryWorkflowDefinitionRepository(),
         new InMemoryExecutionRepository(),
@@ -163,6 +165,7 @@ public class WorkflowRuntimeService {
             + componentName);
   }
 
+  /** Backward-compatible constructor used by existing SYNC-focused runtime tests. */
   WorkflowRuntimeService(
       WorkflowEventStreamService eventStreamService,
       TaskRegistry taskRegistry,
@@ -171,9 +174,27 @@ public class WorkflowRuntimeService {
       WorkflowDefinitionRepository definitionRepository,
       ExecutionRepository executionRepository,
       WorkflowRuntimePersistence runtimePersistence) {
+    this(
+        eventStreamService,
+        taskRegistry,
+        legacyGateway(syncTaskRunner),
+        taskPollIntervalMillis,
+        definitionRepository,
+        executionRepository,
+        runtimePersistence);
+  }
+
+  WorkflowRuntimeService(
+      WorkflowEventStreamService eventStreamService,
+      TaskRegistry taskRegistry,
+      TaskExecutionGateway taskExecutionGateway,
+      long taskPollIntervalMillis,
+      WorkflowDefinitionRepository definitionRepository,
+      ExecutionRepository executionRepository,
+      WorkflowRuntimePersistence runtimePersistence) {
     this.eventStreamService = eventStreamService;
     this.taskRegistry = taskRegistry;
-    this.syncTaskRunner = syncTaskRunner;
+    this.taskExecutionGateway = taskExecutionGateway;
     this.runtimePersistence = runtimePersistence;
     this.taskPollIntervalMillis = Math.max(1L, taskPollIntervalMillis);
     this.ioExecutor = Executors.newVirtualThreadPerTaskExecutor();
@@ -206,6 +227,10 @@ public class WorkflowRuntimeService {
         clock);
     this.runtimeScheduler.scheduleAtFixedRate(
         this::scanTimeouts, 250L, 250L, TimeUnit.MILLISECONDS);
+  }
+
+  private static TaskExecutionGateway legacyGateway(SyncTaskRunner syncTaskRunner) {
+    return new TaskExecutionGateway(List.of(new SyncTaskExecutorAdapter(syncTaskRunner)));
   }
 
   /** 直接运行 API：DTO 只存在于接口边界，进入 Runtime 后立即转换为领域规格。 */
@@ -472,8 +497,9 @@ public class WorkflowRuntimeService {
       if (!node.taskId().equals(task.taskId())) {
         throw new IllegalArgumentException("工作流节点任务快照不匹配：" + node.id());
       }
-      if (!"SYNC".equalsIgnoreCase(task.type())) {
-        throw new IllegalArgumentException("第一阶段工作流仅支持 SYNC 任务：" + task.taskId());
+      if (!taskExecutionGateway.supports(task.type())) {
+        throw new IllegalArgumentException(
+            "工作流没有可用的任务执行器：type=" + task.type() + "，task=" + task.taskId());
       }
       result.put(node.id(), task);
     }
@@ -495,7 +521,7 @@ public class WorkflowRuntimeService {
         NodeFailurePolicy.valueOf(node.failurePolicy()),
         timeout,
         NodeInputMapping.of(node.inputMapping()),
-        Map.of("taskId", task.taskId(), "taskVersion", task.version()));
+        Map.of("taskId", task.taskId(), "taskVersion", task.version(), "taskType", task.type()));
   }
 
   private EdgeDefinition toEdgeDefinition(WorkflowEdgeSpec edge) {
@@ -630,11 +656,12 @@ public class WorkflowRuntimeService {
       if (node == null) {
         throw new IllegalStateException("工作流节点运行元数据不存在：" + dispatch.nodeId());
       }
-      SyncTaskExecution taskExecution = syncTaskRunner.start(node.task(), dispatch.attemptId());
+      TaskExecution taskExecution = taskExecutionGateway.start(
+          node.task(), dispatch.attemptId(), dispatch.nodeInput());
       runtimePersistence.bindExternalExecution(dispatch.attemptId(), taskExecution.executionId());
-      control.bindTaskExecution(taskExecution.executionId());
+      control.bindTaskExecution(node.task().type(), taskExecution.executionId());
       if (control.canceled()) {
-        cancelRemote(taskExecution.executionId());
+        cancelRemote(node.task().type(), taskExecution.executionId());
         cleanupAttempt(dispatch, control);
         return;
       }
@@ -642,11 +669,12 @@ public class WorkflowRuntimeService {
           dispatch.workflowExecutionId(), dispatch.nodeId(), dispatch.attemptId());
       publishCurrent(dispatch.workflowExecutionId());
       log.info(
-          "[workflow] sync task started workflowExecution={}, node={}, attempt={}, task={}, taskVersion={}, taskExecution={}",
+          "[workflow] task started workflowExecution={}, node={}, attempt={}, task={}, type={}, taskVersion={}, taskExecution={}",
           dispatch.workflowExecutionId(),
           dispatch.nodeId(),
           dispatch.attemptId(),
           node.task().taskId(),
+          node.task().type(),
           node.task().version(),
           taskExecution.executionId());
       handleTaskSnapshot(dispatch, control, node, taskExecution);
@@ -668,7 +696,8 @@ public class WorkflowRuntimeService {
         enqueueDispatch(dispatch);
         return;
       }
-      SyncTaskExecution taskExecution = syncTaskRunner.status(taskExecutionId);
+      TaskExecution taskExecution =
+          taskExecutionGateway.status(node.task().type(), taskExecutionId);
       if (recovery.attemptStatus() == NodeAttemptStatus.SUBMITTED && !taskExecution.terminal()) {
         engine.acknowledgeNodeStarted(
             dispatch.workflowExecutionId(), dispatch.nodeId(), dispatch.attemptId());
@@ -685,9 +714,13 @@ public class WorkflowRuntimeService {
     try {
       String taskExecutionId = control.taskExecutionId();
       if (taskExecutionId == null) {
-        throw new IllegalStateException("同步任务执行 ID 不存在");
+        throw new IllegalStateException("任务执行 ID 不存在");
       }
-      handleTaskSnapshot(dispatch, control, node, syncTaskRunner.status(taskExecutionId));
+      handleTaskSnapshot(
+          dispatch,
+          control,
+          node,
+          taskExecutionGateway.status(node.task().type(), taskExecutionId));
     } catch (RuntimeException exception) {
       failNode(dispatch, control, exception);
     }
@@ -697,7 +730,7 @@ public class WorkflowRuntimeService {
       NodeDispatch dispatch,
       NodeTaskControl control,
       NodeMetadata node,
-      SyncTaskExecution taskExecution) {
+      TaskExecution taskExecution) {
     if (control.canceled()) return;
     if (!taskExecution.terminal()) {
       runtimeScheduler.schedule(
@@ -713,8 +746,12 @@ public class WorkflowRuntimeService {
         output.put("taskName", node.task().name());
         output.put("taskType", node.task().type());
         output.put("taskVersion", node.task().version());
-        output.put("syncExecutionId", taskExecution.executionId());
-        output.put("syncStatus", taskExecution.status());
+        output.put("taskExecutionId", taskExecution.executionId());
+        output.put("taskExecutionStatus", taskExecution.status());
+        if ("SYNC".equalsIgnoreCase(node.task().type())) {
+          output.put("syncExecutionId", taskExecution.executionId());
+          output.put("syncStatus", taskExecution.status());
+        }
         output.put("receivedInput", dispatch.nodeInput());
         output.put("taskOutput", taskExecution.output());
         engine.completeNode(
@@ -722,7 +759,7 @@ public class WorkflowRuntimeService {
       } else {
         String message = taskExecution.errorMessage();
         if (message == null || message.isBlank()) {
-          message = "同步任务执行失败，状态：" + taskExecution.status();
+          message = "任务执行失败，类型=" + node.task().type() + "，状态=" + taskExecution.status();
         }
         engine.failNode(
             dispatch.workflowExecutionId(), dispatch.nodeId(), dispatch.attemptId(), message);
@@ -769,12 +806,13 @@ public class WorkflowRuntimeService {
     drainDispatches(dispatch.workflowExecutionId());
   }
 
-  private void cancelRemote(String taskExecutionId) {
+  private void cancelRemote(String taskType, String taskExecutionId) {
     try {
-      syncTaskRunner.cancel(taskExecutionId);
+      taskExecutionGateway.cancel(taskType, taskExecutionId);
     } catch (RuntimeException exception) {
       log.warn(
-          "[workflow] sync task cancel ignored taskExecution={}, message={}",
+          "[workflow] task cancel ignored type={}, taskExecution={}, message={}",
+          taskType,
           taskExecutionId,
           exception.getMessage());
     }
@@ -894,7 +932,7 @@ public class WorkflowRuntimeService {
         node.nodeId(),
         task == null ? null : task.taskId(),
         task == null ? node.nodeId() : task.name(),
-        task == null ? "SYNC" : task.type(),
+        task == null ? "UNKNOWN" : task.type(),
         node.status().name(),
         nodeMetadata == null ? TriggerRule.ALL_SUCCESS.name() : nodeMetadata.triggerRule(),
         nodeMetadata == null ? NodeFailurePolicy.FAIL_WORKFLOW.name() : nodeMetadata.failurePolicy(),
@@ -977,7 +1015,12 @@ public class WorkflowRuntimeService {
       NodeTaskControl control = taskControls.computeIfAbsent(
           dispatch.attemptId(),
           ignored -> new NodeTaskControl(dispatch.workflowExecutionId()));
-      runtimePersistence.findExternalExecution(dispatch.attemptId()).ifPresent(control::bindTaskExecution);
+      NodeMetadata node = requireMetadata(dispatch.workflowExecutionId()).nodes().get(dispatch.nodeId());
+      if (node == null) {
+        throw new IllegalStateException("工作流节点恢复元数据不存在：" + dispatch.nodeId());
+      }
+      runtimePersistence.findExternalExecution(dispatch.attemptId())
+          .ifPresent(id -> control.bindTaskExecution(node.task().type(), id));
 
       if (recovery.attemptStatus() == NodeAttemptStatus.PAUSED) {
         return;
@@ -995,15 +1038,16 @@ public class WorkflowRuntimeService {
       if (control == null) return;
       control.cancel();
       String taskExecutionId = control.taskExecutionId();
-      if (taskExecutionId != null) {
-        ioExecutor.execute(() -> cancelRemote(taskExecutionId));
+      String taskType = control.taskType();
+      if (taskExecutionId != null && taskType != null) {
+        ioExecutor.execute(() -> cancelRemote(taskType, taskExecutionId));
       }
     }
 
     @Override
     public NodeControlResult pause(NodePauseRequest request) {
       log.debug(
-          "[workflow] sync task pause unsupported; pausing scheduling only execution={}, node={}, attempt={}",
+          "[workflow] task pause unsupported by runtime adapter; pausing scheduling only execution={}, node={}, attempt={}",
           request.workflowExecutionId(),
           request.nodeId(),
           request.attemptId());
@@ -1018,6 +1062,7 @@ public class WorkflowRuntimeService {
 
   private static final class NodeTaskControl {
     private final String workflowExecutionId;
+    private volatile String taskType;
     private volatile String taskExecutionId;
     private volatile boolean canceled;
 
@@ -1029,11 +1074,16 @@ public class WorkflowRuntimeService {
       return workflowExecutionId;
     }
 
+    String taskType() {
+      return taskType;
+    }
+
     String taskExecutionId() {
       return taskExecutionId;
     }
 
-    void bindTaskExecution(String id) {
+    void bindTaskExecution(String type, String id) {
+      this.taskType = type;
       this.taskExecutionId = id;
     }
 

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowRuntimeGenericTaskTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowRuntimeGenericTaskTest.java
@@ -1,0 +1,120 @@
+package io.yak.ops.business.workflow.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.yak.framework.workflow.engine.support.InMemoryExecutionRepository;
+import io.yak.framework.workflow.engine.support.InMemoryWorkflowDefinitionRepository;
+import io.yak.ops.business.job.task.TaskDefinition;
+import io.yak.ops.business.job.task.TaskExecution;
+import io.yak.ops.business.job.task.TaskExecutionGateway;
+import io.yak.ops.business.job.task.TaskExecutor;
+import io.yak.ops.business.job.task.TaskRegistry;
+import io.yak.ops.business.job.task.TaskVersionSnapshot;
+import io.yak.ops.business.workflow.domain.WorkflowNodeSpec;
+import io.yak.ops.business.workflow.domain.WorkflowRunSpec;
+import io.yak.ops.business.workflow.persistence.InMemoryWorkflowRuntimePersistence;
+import io.yak.ops.common.bean.vo.workflow.WorkflowInstanceVO;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class WorkflowRuntimeGenericTaskTest {
+
+  private WorkflowRuntimeService service;
+
+  @AfterEach
+  void tearDown() {
+    if (service != null) service.shutdown();
+  }
+
+  @Test
+  void shouldExecuteNonSyncTaskWhenExecutorIsRegistered() throws InterruptedException {
+    TaskRegistry registry = new TaskRegistry() {
+      @Override
+      public List<TaskDefinition> list() {
+        return List.of(new TaskDefinition("SQL:1", "用户清洗 SQL", "SQL"));
+      }
+
+      @Override
+      public TaskDefinition get(String taskId) {
+        return list().getFirst();
+      }
+
+      @Override
+      public TaskVersionSnapshot snapshot(String taskId) {
+        return new TaskVersionSnapshot(
+            taskId, "用户清洗 SQL", "SQL", 3L, "digest", "{}", "{}");
+      }
+    };
+    TaskExecutionGateway gateway = new TaskExecutionGateway(List.of(new ImmediateSqlExecutor()));
+    service = new WorkflowRuntimeService(
+        new WorkflowEventStreamService(),
+        registry,
+        gateway,
+        2L,
+        new InMemoryWorkflowDefinitionRepository(),
+        new InMemoryExecutionRepository(),
+        new InMemoryWorkflowRuntimePersistence());
+
+    WorkflowInstanceVO started = service.run(new WorkflowRunSpec(
+        "sql-workflow",
+        List.of(new WorkflowNodeSpec(
+            "sql-node",
+            "SQL:1",
+            0D,
+            0D,
+            1,
+            0L,
+            0L,
+            0L,
+            Map.of("biz_date", "$workflow.biz_date"),
+            "ALL_SUCCESS",
+            "FAIL_WORKFLOW")),
+        List.of(),
+        Map.of("biz_date", "2026-08-10"),
+        0L,
+        "CONTINUE_INDEPENDENT_BRANCHES"));
+    service.activate(started.id());
+
+    WorkflowInstanceVO completed = waitForTerminal(started.id());
+    WorkflowInstanceVO.NodeInstanceVO node = completed.nodes().getFirst();
+    assertThat(completed.status()).isEqualTo("SUCCESS");
+    assertThat(node.taskType()).isEqualTo("SQL");
+    assertThat(node.output()).containsEntry("taskType", "SQL");
+    assertThat(node.output()).containsEntry("taskExecutionId", "sql-execution-1");
+  }
+
+  private WorkflowInstanceVO waitForTerminal(String executionId) throws InterruptedException {
+    for (int i = 0; i < 200; i++) {
+      WorkflowInstanceVO current = service.getInstance(executionId);
+      if ("SUCCESS".equals(current.status()) || "FAILED".equals(current.status())) return current;
+      Thread.sleep(5L);
+    }
+    return service.getInstance(executionId);
+  }
+
+  private static final class ImmediateSqlExecutor implements TaskExecutor {
+    @Override
+    public String taskType() {
+      return "SQL";
+    }
+
+    @Override
+    public TaskExecution start(
+        TaskVersionSnapshot snapshot,
+        String idempotencyKey,
+        Map<String, Object> input) {
+      return new TaskExecution(
+          "sql-execution-1", "SUCCEEDED", null, Map.of("received", input));
+    }
+
+    @Override
+    public TaskExecution status(String executionId) {
+      return new TaskExecution(executionId, "SUCCEEDED", null, Map.of());
+    }
+
+    @Override
+    public void cancel(String executionId) {}
+  }
+}

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/development/SqlTaskExecutionPO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/development/SqlTaskExecutionPO.java
@@ -1,0 +1,29 @@
+package io.yak.ops.common.bean.po.development;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import java.time.Instant;
+import lombok.Data;
+
+/** SQL task execution ledger used by manual and workflow runs. */
+@Data
+@TableName("yak_dev_sql_task_execution")
+public class SqlTaskExecutionPO {
+  @TableId(type = IdType.ASSIGN_ID)
+  private Long id;
+  private Long taskId;
+  private Long taskVersionId;
+  private Integer taskVersionNo;
+  private Long dataSourceId;
+  private String sqlSnapshot;
+  private String inputJson;
+  private String idempotencyKey;
+  private String status;
+  private Long affectedRows;
+  private String outputJson;
+  private String errorMessage;
+  private Instant createTime;
+  private Instant startTime;
+  private Instant finishTime;
+}

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/development/SqlTaskPO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/development/SqlTaskPO.java
@@ -1,0 +1,27 @@
+package io.yak.ops.common.bean.po.development;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableLogic;
+import com.baomidou.mybatisplus.annotation.TableName;
+import java.time.Instant;
+import lombok.Data;
+
+/** SQL 数据开发任务当前草稿投影。 */
+@Data
+@TableName("yak_dev_sql_task")
+public class SqlTaskPO {
+  @TableId(type = IdType.ASSIGN_ID)
+  private Long id;
+  private String name;
+  private String description;
+  private Long dataSourceId;
+  private String sqlText;
+  private String parameterJson;
+  private Long draftRevision;
+  private Long publishedVersionId;
+  private Integer latestVersionNo;
+  @TableLogic private Boolean deleted;
+  private Instant createTime;
+  private Instant updateTime;
+}

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/development/SqlTaskVersionPO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/development/SqlTaskVersionPO.java
@@ -1,0 +1,22 @@
+package io.yak.ops.common.bean.po.development;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import java.time.Instant;
+import lombok.Data;
+
+/** SQL 数据开发任务不可变发布版本。 */
+@Data
+@TableName("yak_dev_sql_task_version")
+public class SqlTaskVersionPO {
+  @TableId(type = IdType.ASSIGN_ID)
+  private Long id;
+  private Long taskId;
+  private Integer versionNo;
+  private Long dataSourceId;
+  private String sqlSnapshot;
+  private String parameterSnapshotJson;
+  private String contentDigest;
+  private Instant publishedAt;
+}


### PR DESCRIPTION
## 目标

第一阶段只完成 SQL 数据开发后端，并接入现有 Workflow；同时把任务执行边界抽成通用能力，后续 Shell / HTTP / Python 等任务类型只需要新增 Provider + Executor，不再修改 Workflow 核心状态机。

## 核心设计

```text
SQL Development
  Draft -> Immutable Version -> TaskVersionSnapshot
                         |
                         v
TaskProvider -> TaskRegistry -> Workflow
                         |
                         v
              TaskExecutionGateway
                 |             |
               SYNC            SQL
                 |             |
          SyncTaskRunner    JDBC Executor
```

### 1. 通用 Job 执行边界

新增：

- `TaskExecution`
- `TaskExecutor`
- `TaskExecutionGateway`
- `TaskProvider`
- `SyncTaskExecutorAdapter`

`InMemoryTaskRegistry` 继续保留现有离线同步投影，同时合并各业务域贡献的 `TaskProvider`。

Workflow Runtime 不再硬编码 `SYNC`，改为按 `taskType` 查询 `TaskExecutionGateway`，统一处理 start / status / cancel。

为了兼容已有调用方，SYNC 节点仍保留 `syncExecutionId` / `syncStatus` 输出，同时新增通用的 `taskExecutionId` / `taskExecutionStatus`。

### 2. SQL 数据开发后端

新增模块：

- `yak-ops-business-data-development`

第一阶段能力：

- 创建 SQL 开发任务
- 乐观锁保存 SQL 草稿
- 单数据源绑定
- 命名值参数 `:param`
- SQL 校验（第一阶段单条 SQL）
- 发布不可变 SQL Version
- 手动测试运行当前草稿
- SQL Execution 持久化
- 查询执行状态
- 取消执行
- Workflow 引用已发布 SQL Version

SQL Workflow task id 使用 `SQL:<taskId>` 命名空间，避免与当前数字型 SYNC task id 冲突。

### 3. SQL 执行

`SqlTaskExecutor` 使用已有 DataSource + DataSourcePlugin 解析连接，不复制数据源密码到 SQL Version：

- Version 固定：`dataSourceId + SQL + parameter definitions + digest`
- 运行时通过数据源中心解析当前凭据
- JDBC `PreparedStatement` 绑定值参数
- Query 最多返回 200 行预览
- DML 返回 `affectedRows`
- Workflow attempt id 作为幂等键
- 支持 `Statement.cancel()`
- 进程重启后未完成 SQL 标记 `LOST`，第一阶段不自动重复提交写 SQL，避免双写

### 4. 持久化

新增独立 Flyway history：`yak_data_development_schema_history`

新增表：

- `yak_dev_sql_task`
- `yak_dev_sql_task_version`
- `yak_dev_sql_task_execution`

草稿可编辑，发布版本只新增不修改。

### 5. REST API

基础路径：`/api/v1/data-development/sql-tasks`

- `POST /` 创建任务
- `GET /` 查询任务
- `GET /{id}` 详情
- `PUT /{id}` 保存草稿
- `POST /{id}/publish` 发布版本
- `GET /{id}/versions` 查询版本
- `POST /{id}/run` 测试运行草稿
- `GET /executions/{executionId}` 查询执行
- `POST /executions/{executionId}/cancel` 取消执行

## 扩展性

后续新增 Shell / HTTP / Python 时，预期只增加：

```text
XxxTaskProvider
XxxTaskExecutor
```

Workflow 不再增加 `if SQL / if SHELL / if HTTP` 分支。

## 兼容性

- 保留现有 `SyncTaskRunner`
- 通过 `SyncTaskExecutorAdapter` 接入通用 Gateway
- `WorkflowRuntimeService` 保留 SYNC 测试使用的兼容构造器
- 不修改 yak-framework workflow engine 状态机
- 不修改现有前端

## 测试

新增：

- `NamedSqlParameterParserTest`
- `TaskExecutionGatewayTest`
- `WorkflowRuntimeGenericTaskTest`

当前 PR 保持 Draft，继续做最终静态检查 / CI 校验后再进入 review。
