### PR TITLE
fix(data-development): reconcile SQL execution status and finalize task boundary

### DIFF
--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/SqlDevelopmentService.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/SqlDevelopmentService.java
@@ -140,8 +140,14 @@ public class SqlDevelopmentService {
   }
 
   public Execution execution(Long executionId) {
-    return repository.findExecution(executionId)
+    Execution current = repository.findExecution(executionId)
         .orElseThrow(() -> new IllegalArgumentException("SQL 执行不存在：" + executionId));
+    if (!isTerminal(current.status())) {
+      executionGateway.status("SQL", String.valueOf(executionId));
+      current = repository.findExecution(executionId)
+          .orElseThrow(() -> new IllegalArgumentException("SQL 执行不存在：" + executionId));
+    }
+    return current;
   }
 
   public Execution cancel(Long executionId) {

--- a/yak-ops-business/yak-ops-business-job/pom.xml
+++ b/yak-ops-business/yak-ops-business-job/pom.xml
@@ -14,7 +14,7 @@
     <artifactId>yak-ops-business-job</artifactId>
 
     <name>Yak Ops Business Job</name>
-    <description>Offline synchronization scheduling aggregation</description>
+    <description>Workflow-visible task discovery and generic task execution routing</description>
 
     <dependencies>
         <dependency>


### PR DESCRIPTION
## 背景

SQL 数据开发 + Workflow 通用任务执行主实现已在 #300 合入。该 PR 原本创建为 Draft，但在最终检查期间已被合并，因此这里保留一个真正的 Draft follow-up，收口最后两个边界问题。

## 本 PR

- 手动 SQL 执行状态查询统一经过 `TaskExecutionGateway.status(...)`
  - 与 Workflow 的执行状态观察逻辑保持一致
  - 服务重启后，如果执行记录仍为 `QUEUED/RUNNING` 但本地执行上下文已经丢失，会由 `SqlTaskExecutor` 安全标记为 `LOST`
  - 不会自动重放写 SQL，避免双写
- 更新 `yak-ops-business-job` 模块描述
  - 从离线同步专用描述调整为通用任务发现与执行路由
  - 与 `TaskProvider / TaskExecutor / TaskExecutionGateway` 当前职责一致

## 说明

主实现仍保持以下扩展边界：

```text
TaskProvider + TaskExecutor
        |
        +-- SYNC
        +-- SQL
        +-- Shell (future)
        +-- HTTP  (future)
        +-- Python(future)
```

Workflow 不需要为后续节点类型继续增加 task-specific 分支。

保持 Draft，供代码 review。