### PR TITLE
feat(data-development): add project task workspace and SQL editor

### DIFF
--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/api/SqlDevelopmentApi.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/api/SqlDevelopmentApi.java
@@ -15,6 +15,7 @@ public final class SqlDevelopmentApi {
   public record CreateRequest(
       @NotBlank String name,
       String description,
+      @NotNull @Min(1) Long projectId,
       @NotNull @Min(1) Long dataSourceId,
       @NotBlank String sql,
       List<SqlParameterDefinition> parameters) {
@@ -24,6 +25,7 @@ public final class SqlDevelopmentApi {
       @Min(1) long baseRevision,
       @NotBlank String name,
       String description,
+      @NotNull @Min(1) Long projectId,
       @NotNull @Min(1) Long dataSourceId,
       @NotBlank String sql,
       List<SqlParameterDefinition> parameters) {

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/api/SqlDevelopmentApi.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/api/SqlDevelopmentApi.java
@@ -15,7 +15,7 @@ public final class SqlDevelopmentApi {
   public record CreateRequest(
       @NotBlank String name,
       String description,
-      @NotNull @Min(1) Long projectId,
+      @Min(1) Long projectId,
       @NotNull @Min(1) Long dataSourceId,
       @NotBlank String sql,
       List<SqlParameterDefinition> parameters) {
@@ -25,7 +25,7 @@ public final class SqlDevelopmentApi {
       @Min(1) long baseRevision,
       @NotBlank String name,
       String description,
-      @NotNull @Min(1) Long projectId,
+      @Min(1) Long projectId,
       @NotNull @Min(1) Long dataSourceId,
       @NotBlank String sql,
       List<SqlParameterDefinition> parameters) {

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/controller/v1/SqlDevelopmentController.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/controller/v1/SqlDevelopmentController.java
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /** First-phase SQL data-development backend. */
@@ -39,6 +40,7 @@ public class SqlDevelopmentController {
     return Result.success(service.create(
         request.name(),
         request.description(),
+        request.projectId(),
         request.dataSourceId(),
         request.sql(),
         request.parameters()));
@@ -46,8 +48,9 @@ public class SqlDevelopmentController {
 
   @Operation(summary = "查询 SQL 开发任务")
   @GetMapping
-  public Result<List<Definition>> list() {
-    return Result.success(service.list());
+  public Result<List<Definition>> list(
+      @RequestParam(name = "projectId", required = false) Long projectId) {
+    return Result.success(service.list(projectId));
   }
 
   @Operation(summary = "查询 SQL 开发任务详情")
@@ -66,6 +69,7 @@ public class SqlDevelopmentController {
         request.baseRevision(),
         request.name(),
         request.description(),
+        request.projectId(),
         request.dataSourceId(),
         request.sql(),
         request.parameters()));

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/domain/SqlDevelopmentModel.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/domain/SqlDevelopmentModel.java
@@ -13,6 +13,7 @@ public final class SqlDevelopmentModel {
       Long id,
       String name,
       String description,
+      Long projectId,
       Long dataSourceId,
       String sql,
       List<SqlParameterDefinition> parameters,

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/SqlDevelopmentRepository.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/SqlDevelopmentRepository.java
@@ -14,19 +14,25 @@ public interface SqlDevelopmentRepository {
   Definition insertDefinition(
       String name,
       String description,
+      Long projectId,
       Long dataSourceId,
       String sql,
       List<SqlParameterDefinition> parameters);
 
   Optional<Definition> findDefinition(Long id);
 
-  List<Definition> listDefinitions();
+  default List<Definition> listDefinitions() {
+    return listDefinitions(null);
+  }
+
+  List<Definition> listDefinitions(Long projectId);
 
   boolean updateDraft(
       Long id,
       long baseRevision,
       String name,
       String description,
+      Long projectId,
       Long dataSourceId,
       String sql,
       List<SqlParameterDefinition> parameters);

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/SqlDevelopmentRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/SqlDevelopmentRepositoryAdapter.java
@@ -43,6 +43,7 @@ public class SqlDevelopmentRepositoryAdapter implements SqlDevelopmentRepository
   public Definition insertDefinition(
       String name,
       String description,
+      Long projectId,
       Long dataSourceId,
       String sql,
       List<SqlParameterDefinition> parameters) {
@@ -50,6 +51,7 @@ public class SqlDevelopmentRepositoryAdapter implements SqlDevelopmentRepository
     SqlTaskPO po = new SqlTaskPO();
     po.setName(name);
     po.setDescription(description);
+    po.setProjectId(projectId);
     po.setDataSourceId(dataSourceId);
     po.setSqlText(sql);
     po.setParameterJson(jsonCodec.write(parameters));
@@ -68,12 +70,11 @@ public class SqlDevelopmentRepositoryAdapter implements SqlDevelopmentRepository
   }
 
   @Override
-  public List<Definition> listDefinitions() {
-    return taskMapper.selectList(
-            new LambdaQueryWrapper<SqlTaskPO>().orderByDesc(SqlTaskPO::getUpdateTime))
-        .stream()
-        .map(this::toDefinition)
-        .toList();
+  public List<Definition> listDefinitions(Long projectId) {
+    LambdaQueryWrapper<SqlTaskPO> query = new LambdaQueryWrapper<>();
+    if (projectId != null) query.eq(SqlTaskPO::getProjectId, projectId);
+    query.orderByDesc(SqlTaskPO::getUpdateTime);
+    return taskMapper.selectList(query).stream().map(this::toDefinition).toList();
   }
 
   @Override
@@ -82,6 +83,7 @@ public class SqlDevelopmentRepositoryAdapter implements SqlDevelopmentRepository
       long baseRevision,
       String name,
       String description,
+      Long projectId,
       Long dataSourceId,
       String sql,
       List<SqlParameterDefinition> parameters) {
@@ -92,6 +94,7 @@ public class SqlDevelopmentRepositoryAdapter implements SqlDevelopmentRepository
                 .eq(SqlTaskPO::getDraftRevision, baseRevision)
                 .set(SqlTaskPO::getName, name)
                 .set(SqlTaskPO::getDescription, description)
+                .set(SqlTaskPO::getProjectId, projectId)
                 .set(SqlTaskPO::getDataSourceId, dataSourceId)
                 .set(SqlTaskPO::getSqlText, sql)
                 .set(SqlTaskPO::getParameterJson, jsonCodec.write(parameters))
@@ -261,6 +264,7 @@ public class SqlDevelopmentRepositoryAdapter implements SqlDevelopmentRepository
         po.getId(),
         po.getName(),
         po.getDescription(),
+        po.getProjectId(),
         po.getDataSourceId(),
         po.getSqlText(),
         jsonCodec.readParameters(po.getParameterJson()),

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/SqlDevelopmentService.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/SqlDevelopmentService.java
@@ -52,7 +52,7 @@ public class SqlDevelopmentService {
       Long dataSourceId,
       String sql,
       List<SqlParameterDefinition> parameters) {
-    long normalizedProjectId = requirePositive(projectId, "项目 ID");
+    Long normalizedProjectId = normalizeProjectId(projectId);
     List<SqlParameterDefinition> normalized = validate(dataSourceId, sql, parameters);
     return repository.insertDefinition(
         requireText(name, "任务名称"),
@@ -86,8 +86,8 @@ public class SqlDevelopmentService {
       Long dataSourceId,
       String sql,
       List<SqlParameterDefinition> parameters) {
-    requireDefinition(id);
-    long normalizedProjectId = requirePositive(projectId, "项目 ID");
+    Definition current = requireDefinition(id);
+    Long normalizedProjectId = projectId == null ? current.projectId() : normalizeProjectId(projectId);
     List<SqlParameterDefinition> normalized = validate(dataSourceId, sql, parameters);
     boolean updated = repository.updateDraft(
         id,
@@ -217,6 +217,10 @@ public class SqlDevelopmentService {
     if (id == null || id <= 0L) throw new IllegalArgumentException("SQL 任务 ID 不合法：" + id);
     return repository.findDefinition(id)
         .orElseThrow(() -> new IllegalArgumentException("SQL 任务不存在：" + id));
+  }
+
+  private Long normalizeProjectId(Long value) {
+    return value == null ? null : requirePositive(value, "项目 ID");
   }
 
   private long requirePositive(Long value, String name) {

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/SqlDevelopmentService.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/SqlDevelopmentService.java
@@ -48,16 +48,24 @@ public class SqlDevelopmentService {
   public Definition create(
       String name,
       String description,
+      Long projectId,
       Long dataSourceId,
       String sql,
       List<SqlParameterDefinition> parameters) {
+    long normalizedProjectId = requirePositive(projectId, "项目 ID");
     List<SqlParameterDefinition> normalized = validate(dataSourceId, sql, parameters);
     return repository.insertDefinition(
-        requireText(name, "任务名称"), trimToNull(description), dataSourceId, sql.trim(), normalized);
+        requireText(name, "任务名称"),
+        trimToNull(description),
+        normalizedProjectId,
+        dataSourceId,
+        sql.trim(),
+        normalized);
   }
 
-  public List<Definition> list() {
-    return repository.listDefinitions();
+  public List<Definition> list(Long projectId) {
+    if (projectId == null) return repository.listDefinitions();
+    return repository.listDefinitions(requirePositive(projectId, "项目 ID"));
   }
 
   public Definition get(Long id) {
@@ -70,16 +78,19 @@ public class SqlDevelopmentService {
       long baseRevision,
       String name,
       String description,
+      Long projectId,
       Long dataSourceId,
       String sql,
       List<SqlParameterDefinition> parameters) {
     requireDefinition(id);
+    long normalizedProjectId = requirePositive(projectId, "项目 ID");
     List<SqlParameterDefinition> normalized = validate(dataSourceId, sql, parameters);
     boolean updated = repository.updateDraft(
         id,
         baseRevision,
         requireText(name, "任务名称"),
         trimToNull(description),
+        normalizedProjectId,
         dataSourceId,
         sql.trim(),
         normalized);
@@ -202,6 +213,11 @@ public class SqlDevelopmentService {
     if (id == null || id <= 0L) throw new IllegalArgumentException("SQL 任务 ID 不合法：" + id);
     return repository.findDefinition(id)
         .orElseThrow(() -> new IllegalArgumentException("SQL 任务不存在：" + id));
+  }
+
+  private long requirePositive(Long value, String name) {
+    if (value == null || value <= 0L) throw new IllegalArgumentException(name + "不合法：" + value);
+    return value;
   }
 
   private String workflowTaskId(Long id) {

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/SqlDevelopmentService.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/SqlDevelopmentService.java
@@ -63,6 +63,10 @@ public class SqlDevelopmentService {
         normalized);
   }
 
+  public List<Definition> list() {
+    return list(null);
+  }
+
   public List<Definition> list(Long projectId) {
     if (projectId == null) return repository.listDefinitions();
     return repository.listDefinitions(requirePositive(projectId, "项目 ID"));

--- a/yak-ops-business/yak-ops-business-data-development/src/main/resources/db/migration/yak-data-development/V2__add_project_to_sql_task.sql
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/resources/db/migration/yak-data-development/V2__add_project_to_sql_task.sql
@@ -1,0 +1,3 @@
+ALTER TABLE yak_dev_sql_task
+    ADD COLUMN project_id BIGINT NULL AFTER description,
+    ADD KEY idx_yak_dev_sql_task_project (project_id, update_time);

--- a/yak-ops-business/yak-ops-business-data-development/src/main/resources/mapper/development/SqlTaskMapper.xml
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/resources/mapper/development/SqlTaskMapper.xml
@@ -7,6 +7,7 @@
         SELECT id,
                name,
                description,
+               project_id,
                data_source_id,
                sql_text,
                parameter_json,

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/development/SqlTaskPO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/development/SqlTaskPO.java
@@ -15,6 +15,7 @@ public class SqlTaskPO {
   private Long id;
   private String name;
   private String description;
+  private Long projectId;
   private Long dataSourceId;
   private String sqlText;
   private String parameterJson;

--- a/yak-ops-ui/src/config/navigation.ts
+++ b/yak-ops-ui/src/config/navigation.ts
@@ -27,7 +27,8 @@ export interface NavigationGroupWithRoutes extends NavigationGroup {
 
 export const navigationGroups: readonly NavigationGroup[] = [
   { id: 'integration', title: '数据集成', iconKey: 'sync', section: 'task', order: 10 },
-  { id: 'workflow', title: '工作流', iconKey: 'workflow', section: 'task', order: 20 },
+  { id: 'development', title: '数据开发', iconKey: 'api', section: 'task', order: 20 },
+  { id: 'workflow', title: '工作流', iconKey: 'workflow', section: 'task', order: 30 },
   { id: 'resources', title: '资源管理', iconKey: 'database', section: 'management', order: 20 },
   { id: 'data-quality', title: '数据质量', iconKey: 'quality', section: 'management', order: 30 },
   { id: 'system', title: '系统管理', iconKey: 'system', section: 'system', order: 40 },
@@ -46,6 +47,9 @@ export const appRoutes: readonly NavigationRoute[] = [
   { id: 'batch-link-up-single', path: '/sync/batch-link-up/:id/config/single', title: '单表同步配置', component: './batch-link-up/config/single', hidden: true, parentId: 'batch-link-up' },
   { id: 'batch-link-up-multi', path: '/sync/batch-link-up/:id/config/multi', title: '多表同步配置', component: './batch-link-up/config/multi', hidden: true, parentId: 'batch-link-up' },
   { id: 'batch-link-up-script', path: '/sync/batch-link-up/:id/config/script', title: '脚本同步配置', component: './batch-link-up/config/script', hidden: true, parentId: 'batch-link-up' },
+  { id: 'data-development', mode: 'public', path: '/data-development', title: '开发任务', component: './data-development', iconKey: 'api', menuGroup: 'development', order: 10 },
+  { id: 'data-development-task-new', path: '/data-development/task/new', title: '新建开发任务', component: './data-development/task', hidden: true, parentId: 'data-development' },
+  { id: 'data-development-task', path: '/data-development/task/:id', title: '开发任务配置', component: './data-development/task', hidden: true, parentId: 'data-development' },
   { id: 'workflow-definition', mode: 'public', path: '/workflow/definitions', title: '工作流定义', component: './workflow/management', iconKey: 'workflow', menuGroup: 'workflow', order: 10 },
   { id: 'workflow-definition-editor', path: '/workflow/definition/:id', title: '工作流配置', component: './workflow/definition', hidden: true, parentId: 'workflow-definition' },
   { id: 'workflow-instances', mode: 'public', path: '/workflow/instances', title: '工作流实例', component: './workflow/instances', iconKey: 'instance', menuGroup: 'workflow', order: 20 },

--- a/yak-ops-ui/src/pages/data-development/components/CreateTaskModal.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/CreateTaskModal.tsx
@@ -1,0 +1,150 @@
+import { Modal, Select, Tag, Typography } from 'antd';
+import { Braces, Code2, Globe2, TerminalSquare } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+
+import type { DevelopmentTaskType } from '../types';
+
+interface CreateTaskModalProps {
+  open: boolean;
+  projects: API.ProjectBrief[];
+  defaultProjectId?: number;
+  onCancel: () => void;
+  onNext: (type: DevelopmentTaskType, projectId: number) => void;
+}
+
+const taskTypes: Array<{
+  type: DevelopmentTaskType;
+  title: string;
+  description: string;
+  icon: React.ReactNode;
+  enabled: boolean;
+}> = [
+  {
+    type: 'SQL',
+    title: 'SQL',
+    description: '执行数据库 SQL，支持参数、测试运行和版本发布。',
+    icon: <Code2 size={20} strokeWidth={1.8} />,
+    enabled: true,
+  },
+  {
+    type: 'SHELL',
+    title: 'Shell',
+    description: '执行 Shell 脚本，后续通过统一执行器接入。',
+    icon: <TerminalSquare size={20} strokeWidth={1.8} />,
+    enabled: false,
+  },
+  {
+    type: 'HTTP',
+    title: 'HTTP',
+    description: '调用 HTTP API，后续通过统一执行器接入。',
+    icon: <Globe2 size={20} strokeWidth={1.8} />,
+    enabled: false,
+  },
+  {
+    type: 'PYTHON',
+    title: 'Python',
+    description: '执行 Python 脚本，后续通过统一执行器接入。',
+    icon: <Braces size={20} strokeWidth={1.8} />,
+    enabled: false,
+  },
+];
+
+export default function CreateTaskModal({
+  open,
+  projects,
+  defaultProjectId,
+  onCancel,
+  onNext,
+}: CreateTaskModalProps) {
+  const [type, setType] = useState<DevelopmentTaskType>('SQL');
+  const [projectId, setProjectId] = useState<number>();
+
+  const projectOptions = useMemo(
+    () => projects.map((project) => ({
+      label: project.projectName,
+      value: Number(project.id),
+    })),
+    [projects],
+  );
+
+  useEffect(() => {
+    if (!open) return;
+    setType('SQL');
+    setProjectId(
+      defaultProjectId ??
+        (projects[0]?.id === undefined ? undefined : Number(projects[0].id)),
+    );
+  }, [defaultProjectId, open, projects]);
+
+  return (
+    <Modal
+      open={open}
+      title="新建数据开发任务"
+      width={720}
+      okText="下一步"
+      cancelText="取消"
+      okButtonProps={{ disabled: !projectId }}
+      destroyOnClose
+      onCancel={onCancel}
+      onOk={() => {
+        if (projectId) onNext(type, projectId);
+      }}
+    >
+      <div className="pt-2">
+        <div className="mb-5">
+          <Typography.Text className="mb-2 block text-[13px] font-medium text-[#161823]">
+            所属项目
+          </Typography.Text>
+          <Select
+            value={projectId}
+            options={projectOptions}
+            className="w-full"
+            placeholder="请选择项目"
+            showSearch
+            optionFilterProp="label"
+            onChange={(value) => setProjectId(Number(value))}
+          />
+        </div>
+
+        <Typography.Text className="mb-2 block text-[13px] font-medium text-[#161823]">
+          任务类型
+        </Typography.Text>
+        <div className="grid grid-cols-2 gap-3">
+          {taskTypes.map((item) => {
+            const selected = type === item.type;
+            return (
+              <button
+                key={item.type}
+                type="button"
+                disabled={!item.enabled}
+                onClick={() => item.enabled && setType(item.type)}
+                className={[
+                  'relative min-h-[104px] rounded-xl border p-4 text-left transition-all',
+                  item.enabled
+                    ? 'cursor-pointer bg-white hover:border-[#b8bec8]'
+                    : 'cursor-not-allowed bg-[#fafafa] opacity-65',
+                  selected && item.enabled
+                    ? 'border-[#161823] shadow-[0_0_0_1px_#161823]'
+                    : 'border-[#e4e7ec]',
+                ].join(' ')}
+              >
+                <div className="mb-3 flex items-center justify-between">
+                  <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-[#f5f5f5] text-[#161823]">
+                    {item.icon}
+                  </span>
+                  {!item.enabled && <Tag className="!m-0">后续</Tag>}
+                </div>
+                <div className="text-[14px] font-semibold text-[#161823]">
+                  {item.title}
+                </div>
+                <div className="mt-1 text-[12px] leading-5 text-[rgba(22,24,35,.5)]">
+                  {item.description}
+                </div>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/yak-ops-ui/src/pages/data-development/components/CreateTaskModal.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/CreateTaskModal.tsx
@@ -1,5 +1,6 @@
 import { Modal, Select, Tag, Typography } from 'antd';
 import { Braces, Code2, Globe2, TerminalSquare } from 'lucide-react';
+import type { ReactNode } from 'react';
 import { useEffect, useMemo, useState } from 'react';
 
 import type { DevelopmentTaskType } from '../types';
@@ -16,7 +17,7 @@ const taskTypes: Array<{
   type: DevelopmentTaskType;
   title: string;
   description: string;
-  icon: React.ReactNode;
+  icon: ReactNode;
   enabled: boolean;
 }> = [
   {

--- a/yak-ops-ui/src/pages/data-development/components/SqlCodeEditor.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/SqlCodeEditor.tsx
@@ -1,0 +1,118 @@
+import { autocompletion } from '@codemirror/autocomplete';
+import {
+  defaultKeymap,
+  history,
+  historyKeymap,
+} from '@codemirror/commands';
+import { sql } from '@codemirror/lang-sql';
+import {
+  bracketMatching,
+  defaultHighlightStyle,
+  syntaxHighlighting,
+} from '@codemirror/language';
+import { EditorState } from '@codemirror/state';
+import {
+  EditorView,
+  highlightActiveLine,
+  highlightActiveLineGutter,
+  keymap,
+  lineNumbers,
+} from '@codemirror/view';
+import { useEffect, useRef } from 'react';
+
+interface SqlCodeEditorProps {
+  value: string;
+  onChange: (value: string) => void;
+  minHeight?: number;
+}
+
+export default function SqlCodeEditor({
+  value,
+  onChange,
+  minHeight = 360,
+}: SqlCodeEditorProps) {
+  const hostRef = useRef<HTMLDivElement>(null);
+  const viewRef = useRef<EditorView>();
+  const onChangeRef = useRef(onChange);
+
+  useEffect(() => {
+    onChangeRef.current = onChange;
+  }, [onChange]);
+
+  useEffect(() => {
+    if (!hostRef.current) return undefined;
+
+    const state = EditorState.create({
+      doc: value,
+      extensions: [
+        lineNumbers(),
+        highlightActiveLine(),
+        highlightActiveLineGutter(),
+        history(),
+        bracketMatching(),
+        autocompletion(),
+        sql(),
+        syntaxHighlighting(defaultHighlightStyle, { fallback: true }),
+        keymap.of([...defaultKeymap, ...historyKeymap]),
+        EditorView.lineWrapping,
+        EditorView.updateListener.of((update) => {
+          if (update.docChanged) {
+            onChangeRef.current(update.state.doc.toString());
+          }
+        }),
+        EditorView.theme({
+          '&': {
+            minHeight: `${minHeight}px`,
+            height: '100%',
+            fontSize: '13px',
+            backgroundColor: '#fff',
+          },
+          '.cm-scroller': {
+            minHeight: `${minHeight}px`,
+            fontFamily:
+              'JetBrains Mono, SFMono-Regular, Consolas, Liberation Mono, monospace',
+            lineHeight: '1.7',
+          },
+          '.cm-gutters': {
+            backgroundColor: '#fafafa',
+            borderRight: '1px solid #f0f0f0',
+          },
+          '.cm-activeLine': {
+            backgroundColor: 'rgba(0, 0, 0, 0.025)',
+          },
+          '.cm-activeLineGutter': {
+            backgroundColor: 'rgba(0, 0, 0, 0.035)',
+          },
+          '&.cm-focused': {
+            outline: 'none',
+          },
+        }),
+      ],
+    });
+
+    const view = new EditorView({ state, parent: hostRef.current });
+    viewRef.current = view;
+
+    return () => {
+      view.destroy();
+      viewRef.current = undefined;
+    };
+  }, [minHeight]);
+
+  useEffect(() => {
+    const view = viewRef.current;
+    if (!view) return;
+    const current = view.state.doc.toString();
+    if (current === value) return;
+    view.dispatch({
+      changes: { from: 0, to: current.length, insert: value },
+    });
+  }, [value]);
+
+  return (
+    <div
+      ref={hostRef}
+      className="overflow-hidden rounded-lg border border-[#e4e7ec] bg-white"
+    />
+  );
+}

--- a/yak-ops-ui/src/pages/data-development/index.tsx
+++ b/yak-ops-ui/src/pages/data-development/index.tsx
@@ -18,7 +18,6 @@ import {
 import type { ColumnsType } from 'antd/es/table';
 import dayjs from 'dayjs';
 import {
-  Code2,
   Folder,
   FolderOpen,
   Plus,

--- a/yak-ops-ui/src/pages/data-development/index.tsx
+++ b/yak-ops-ui/src/pages/data-development/index.tsx
@@ -1,0 +1,392 @@
+import { API_SUCCESS_CODE } from '@/services/http/response';
+import { useSecurityProject } from '@/contexts/SecurityProjectContext';
+import { fetchDataSourceAll } from '@/pages/data-source/service';
+import type { DataSourceRecord } from '@/pages/data-source/types';
+import { history } from '@umijs/max';
+import {
+  Button,
+  Empty,
+  Input,
+  Select,
+  Spin,
+  Table,
+  Tag,
+  Tree,
+  Typography,
+  message,
+} from 'antd';
+import type { ColumnsType } from 'antd/es/table';
+import dayjs from 'dayjs';
+import {
+  Code2,
+  Folder,
+  FolderOpen,
+  Plus,
+  RefreshCw,
+  Search,
+} from 'lucide-react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import CreateTaskModal from './components/CreateTaskModal';
+import { listSqlTasks } from './service';
+import type {
+  DevelopmentTaskRow,
+  DevelopmentTaskType,
+} from './types';
+
+type ProjectFilterKey = 'all' | 'unassigned' | `project:${number}`;
+type PublishFilter = 'ALL' | 'DRAFT' | 'PUBLISHED';
+
+const projectKey = (projectId: number): ProjectFilterKey =>
+  `project:${projectId}`;
+
+const projectIdFromKey = (key: ProjectFilterKey): number | undefined => {
+  if (!key.startsWith('project:')) return undefined;
+  const value = Number(key.substring('project:'.length));
+  return Number.isFinite(value) && value > 0 ? value : undefined;
+};
+
+const formatTime = (value?: string) =>
+  value ? dayjs(value).format('YYYY-MM-DD HH:mm:ss') : '-';
+
+export default function DataDevelopmentPage() {
+  const { projects, currentProject } = useSecurityProject();
+  const [tasks, setTasks] = useState<DevelopmentTaskRow[]>([]);
+  const [dataSources, setDataSources] = useState<DataSourceRecord[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [createOpen, setCreateOpen] = useState(false);
+  const [keyword, setKeyword] = useState('');
+  const [typeFilter, setTypeFilter] = useState<'ALL' | DevelopmentTaskType>('ALL');
+  const [publishFilter, setPublishFilter] = useState<PublishFilter>('ALL');
+  const [selectedProject, setSelectedProject] = useState<ProjectFilterKey>(() =>
+    currentProject?.id ? projectKey(Number(currentProject.id)) : 'all',
+  );
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const [taskResponse, dataSourceResponse] = await Promise.all([
+        listSqlTasks(),
+        fetchDataSourceAll(),
+      ]);
+      if (taskResponse?.code !== API_SUCCESS_CODE) {
+        throw new Error(taskResponse?.message || taskResponse?.msg || '查询数据开发任务失败');
+      }
+      if (dataSourceResponse?.code !== API_SUCCESS_CODE) {
+        throw new Error(
+          dataSourceResponse?.message || dataSourceResponse?.msg || '查询数据源失败',
+        );
+      }
+      setTasks(
+        (taskResponse.data || []).map((task) => ({
+          ...task,
+          type: 'SQL' as const,
+        })),
+      );
+      setDataSources(dataSourceResponse.data?.bizData || []);
+    } catch (error) {
+      message.error(error instanceof Error ? error.message : '查询数据开发任务失败');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const projectNameMap = useMemo(
+    () => new Map(projects.map((project) => [Number(project.id), project.projectName])),
+    [projects],
+  );
+  const dataSourceMap = useMemo(
+    () => new Map(dataSources.map((item) => [Number(item.id), item])),
+    [dataSources],
+  );
+
+  const counts = useMemo(() => {
+    const byProject = new Map<number, number>();
+    let unassigned = 0;
+    tasks.forEach((task) => {
+      if (!task.projectId) {
+        unassigned += 1;
+        return;
+      }
+      byProject.set(task.projectId, (byProject.get(task.projectId) || 0) + 1);
+    });
+    return { byProject, unassigned };
+  }, [tasks]);
+
+  const treeData = useMemo(
+    () => [
+      {
+        key: 'all',
+        title: (
+          <span className="flex w-full items-center justify-between gap-3">
+            <span className="flex items-center gap-2">
+              <FolderOpen size={15} />
+              全部任务
+            </span>
+            <span className="text-[11px] text-[rgba(22,24,35,.34)]">{tasks.length}</span>
+          </span>
+        ),
+      },
+      {
+        key: 'projects-root',
+        selectable: false,
+        title: (
+          <span className="flex items-center gap-2 text-[12px] font-medium text-[rgba(22,24,35,.5)]">
+            <Folder size={14} />
+            项目
+          </span>
+        ),
+        children: projects.map((project) => ({
+          key: projectKey(Number(project.id)),
+          title: (
+            <span className="flex w-full items-center justify-between gap-3">
+              <span className="truncate">{project.projectName}</span>
+              <span className="text-[11px] text-[rgba(22,24,35,.34)]">
+                {counts.byProject.get(Number(project.id)) || 0}
+              </span>
+            </span>
+          ),
+        })),
+      },
+      ...(counts.unassigned > 0
+        ? [
+            {
+              key: 'unassigned',
+              title: (
+                <span className="flex w-full items-center justify-between gap-3">
+                  <span className="text-[rgba(22,24,35,.55)]">未归属项目</span>
+                  <span className="text-[11px] text-[rgba(22,24,35,.34)]">
+                    {counts.unassigned}
+                  </span>
+                </span>
+              ),
+            },
+          ]
+        : []),
+    ],
+    [counts, projects, tasks.length],
+  );
+
+  const filteredTasks = useMemo(() => {
+    const normalizedKeyword = keyword.trim().toLowerCase();
+    const selectedProjectId = projectIdFromKey(selectedProject);
+    return tasks.filter((task) => {
+      if (selectedProject === 'unassigned' && task.projectId) return false;
+      if (selectedProjectId && task.projectId !== selectedProjectId) return false;
+      if (typeFilter !== 'ALL' && task.type !== typeFilter) return false;
+      if (publishFilter === 'DRAFT' && task.latestVersionNo > 0) return false;
+      if (publishFilter === 'PUBLISHED' && task.latestVersionNo <= 0) return false;
+      if (
+        normalizedKeyword &&
+        !`${task.name} ${task.description || ''}`.toLowerCase().includes(normalizedKeyword)
+      ) {
+        return false;
+      }
+      return true;
+    });
+  }, [keyword, publishFilter, selectedProject, tasks, typeFilter]);
+
+  const openTask = (task: DevelopmentTaskRow) => {
+    history.push(`/data-development/task/${task.id}`);
+  };
+
+  const columns: ColumnsType<DevelopmentTaskRow> = [
+    {
+      title: '任务名称',
+      dataIndex: 'name',
+      minWidth: 260,
+      render: (_, task) => (
+        <button
+          type="button"
+          className="border-0 bg-transparent p-0 text-left"
+          onClick={() => openTask(task)}
+        >
+          <div className="font-medium text-[#161823] hover:underline">{task.name}</div>
+          <div className="mt-1 max-w-[420px] truncate text-[12px] text-[rgba(22,24,35,.45)]">
+            {task.description || `SQL Task · ${task.id}`}
+          </div>
+        </button>
+      ),
+    },
+    {
+      title: '类型',
+      dataIndex: 'type',
+      width: 100,
+      render: () => (
+        <Tag className="!m-0 !border-[#e4e7ec] !bg-[#f7f7f8] !text-[#161823]">
+          SQL
+        </Tag>
+      ),
+    },
+    {
+      title: '所属项目',
+      dataIndex: 'projectId',
+      width: 170,
+      render: (value?: number) =>
+        value ? projectNameMap.get(Number(value)) || `项目 ${value}` : '未归属',
+    },
+    {
+      title: '数据源',
+      dataIndex: 'dataSourceId',
+      width: 180,
+      render: (value: number) => {
+        const source = dataSourceMap.get(Number(value));
+        return source ? `${source.name || '-'} · ${source.dbType || '-'}` : `#${value}`;
+      },
+    },
+    {
+      title: '状态 / 版本',
+      width: 140,
+      render: (_, task) =>
+        task.latestVersionNo > 0 ? (
+          <span className="text-[#161823]">已发布 · V{task.latestVersionNo}</span>
+        ) : (
+          <span className="text-[rgba(22,24,35,.45)]">草稿</span>
+        ),
+    },
+    {
+      title: '更新时间',
+      dataIndex: 'updateTime',
+      width: 170,
+      render: (value?: string) => formatTime(value),
+    },
+    {
+      title: '操作',
+      width: 90,
+      fixed: 'right',
+      render: (_, task) => (
+        <Button type="link" className="!px-0" onClick={() => openTask(task)}>
+          配置
+        </Button>
+      ),
+    },
+  ];
+
+  const selectedProjectId = projectIdFromKey(selectedProject);
+
+  return (
+    <section className="m-4 overflow-hidden rounded-xl border border-[#e4e7ec] bg-white">
+      <div className="flex h-[calc(100vh-80px)] min-h-[620px]">
+        <aside className="w-[228px] shrink-0 border-r border-[#e4e7ec] bg-[#fcfcfd]">
+          <div className="border-b border-[#eceef1] px-4 py-4">
+            <div className="text-[13px] font-semibold text-[#161823]">项目视图</div>
+            <div className="mt-1 text-[11px] text-[rgba(22,24,35,.4)]">
+              按项目组织数据开发任务
+            </div>
+          </div>
+          <div className="p-2">
+            <Tree
+              blockNode
+              defaultExpandAll
+              selectedKeys={[selectedProject]}
+              treeData={treeData}
+              onSelect={(keys) => {
+                const key = keys[0];
+                if (key && key !== 'projects-root') {
+                  setSelectedProject(String(key) as ProjectFilterKey);
+                }
+              }}
+            />
+          </div>
+        </aside>
+
+        <main className="min-w-0 flex-1 overflow-auto">
+          <div className="flex items-start justify-between gap-4 px-6 pb-4 pt-5">
+            <div>
+              <Typography.Title level={4} className="!mb-1 !text-[#161823]">
+                数据开发
+              </Typography.Title>
+              <Typography.Text className="text-[12px] text-[rgba(22,24,35,.45)]">
+                统一管理 SQL、Shell、HTTP、Python 等开发任务；当前阶段开放 SQL。
+              </Typography.Text>
+            </div>
+            <Button
+              type="primary"
+              icon={<Plus size={15} />}
+              onClick={() => setCreateOpen(true)}
+            >
+              新建任务
+            </Button>
+          </div>
+
+          <div className="flex items-center justify-between gap-3 border-y border-[#eceef1] bg-[#fafafa] px-6 py-3">
+            <div className="flex min-w-0 items-center gap-2">
+              <Input
+                value={keyword}
+                allowClear
+                prefix={<Search size={14} className="text-[rgba(22,24,35,.34)]" />}
+                placeholder="搜索任务名称或描述"
+                className="w-[260px]"
+                onChange={(event) => setKeyword(event.target.value)}
+              />
+              <Select
+                value={typeFilter}
+                className="w-[120px]"
+                options={[
+                  { label: '全部类型', value: 'ALL' },
+                  { label: 'SQL', value: 'SQL' },
+                ]}
+                onChange={setTypeFilter}
+              />
+              <Select
+                value={publishFilter}
+                className="w-[130px]"
+                options={[
+                  { label: '全部状态', value: 'ALL' },
+                  { label: '草稿', value: 'DRAFT' },
+                  { label: '已发布', value: 'PUBLISHED' },
+                ]}
+                onChange={setPublishFilter}
+              />
+            </div>
+            <Button
+              icon={<RefreshCw size={14} />}
+              onClick={() => void load()}
+            >
+              刷新
+            </Button>
+          </div>
+
+          <Spin spinning={loading}>
+            <Table<DevelopmentTaskRow>
+              rowKey="id"
+              size="small"
+              pagination={{ pageSize: 15, showSizeChanger: false }}
+              columns={columns}
+              dataSource={filteredTasks}
+              scroll={{ x: 1120 }}
+              locale={{
+                emptyText: (
+                  <Empty
+                    image={Empty.PRESENTED_IMAGE_SIMPLE}
+                    description="当前项目暂无数据开发任务"
+                  />
+                ),
+              }}
+            />
+          </Spin>
+        </main>
+      </div>
+
+      <CreateTaskModal
+        open={createOpen}
+        projects={projects}
+        defaultProjectId={
+          selectedProjectId ??
+          (currentProject?.id ? Number(currentProject.id) : undefined)
+        }
+        onCancel={() => setCreateOpen(false)}
+        onNext={(type, projectId) => {
+          setCreateOpen(false);
+          history.push(
+            `/data-development/task/new?type=${encodeURIComponent(type)}&projectId=${projectId}`,
+          );
+        }}
+      />
+    </section>
+  );
+}

--- a/yak-ops-ui/src/pages/data-development/service.ts
+++ b/yak-ops-ui/src/pages/data-development/service.ts
@@ -1,0 +1,80 @@
+import type { ApiResponse } from '@/services/http/response';
+import HttpUtils from '@/utils/HttpUtils';
+
+import type {
+  SqlTaskDefinition,
+  SqlTaskExecution,
+  SqlTaskSavePayload,
+  SqlTaskUpdatePayload,
+  SqlTaskVersion,
+} from './types';
+
+const SQL_TASK_API = '/api/v1/data-development/sql-tasks';
+
+const queryString = (params: Record<string, unknown>) => {
+  const search = new URLSearchParams();
+  Object.entries(params).forEach(([key, value]) => {
+    if (value !== undefined && value !== null && String(value).length > 0) {
+      search.set(key, String(value));
+    }
+  });
+  const result = search.toString();
+  return result ? `?${result}` : '';
+};
+
+export const listSqlTasks = (
+  projectId?: number,
+): Promise<ApiResponse<SqlTaskDefinition[]>> =>
+  HttpUtils.get<SqlTaskDefinition[]>(
+    `${SQL_TASK_API}${queryString({ projectId })}`,
+  );
+
+export const getSqlTask = (
+  id: number,
+): Promise<ApiResponse<SqlTaskDefinition>> =>
+  HttpUtils.get<SqlTaskDefinition>(`${SQL_TASK_API}/${id}`);
+
+export const createSqlTask = (
+  payload: SqlTaskSavePayload,
+): Promise<ApiResponse<SqlTaskDefinition>> =>
+  HttpUtils.post<SqlTaskDefinition>(SQL_TASK_API, payload);
+
+export const updateSqlTask = (
+  id: number,
+  payload: SqlTaskUpdatePayload,
+): Promise<ApiResponse<SqlTaskDefinition>> =>
+  HttpUtils.put<SqlTaskDefinition>(`${SQL_TASK_API}/${id}`, payload);
+
+export const publishSqlTask = (
+  id: number,
+  draftRevision: number,
+): Promise<ApiResponse<SqlTaskVersion>> =>
+  HttpUtils.post<SqlTaskVersion>(`${SQL_TASK_API}/${id}/publish`, {
+    draftRevision,
+  });
+
+export const listSqlTaskVersions = (
+  id: number,
+): Promise<ApiResponse<SqlTaskVersion[]>> =>
+  HttpUtils.get<SqlTaskVersion[]>(`${SQL_TASK_API}/${id}/versions`);
+
+export const runSqlTask = (
+  id: number,
+  input: Record<string, unknown>,
+): Promise<ApiResponse<SqlTaskExecution>> =>
+  HttpUtils.post<SqlTaskExecution>(`${SQL_TASK_API}/${id}/run`, { input });
+
+export const getSqlTaskExecution = (
+  executionId: number,
+): Promise<ApiResponse<SqlTaskExecution>> =>
+  HttpUtils.get<SqlTaskExecution>(
+    `${SQL_TASK_API}/executions/${executionId}`,
+  );
+
+export const cancelSqlTaskExecution = (
+  executionId: number,
+): Promise<ApiResponse<SqlTaskExecution>> =>
+  HttpUtils.post<SqlTaskExecution>(
+    `${SQL_TASK_API}/executions/${executionId}/cancel`,
+    {},
+  );

--- a/yak-ops-ui/src/pages/data-development/task/SqlTaskEditor.tsx
+++ b/yak-ops-ui/src/pages/data-development/task/SqlTaskEditor.tsx
@@ -1,0 +1,814 @@
+import { API_SUCCESS_CODE } from '@/services/http/response';
+import { useSecurityProject } from '@/contexts/SecurityProjectContext';
+import { fetchDataSourceAll } from '@/pages/data-source/service';
+import type { DataSourceRecord } from '@/pages/data-source/types';
+import { history } from '@umijs/max';
+import {
+  Alert,
+  Button,
+  Empty,
+  Input,
+  Modal,
+  Select,
+  Space,
+  Spin,
+  Switch,
+  Table,
+  Tabs,
+  Tag,
+  Typography,
+  message,
+} from 'antd';
+import type { ColumnsType } from 'antd/es/table';
+import dayjs from 'dayjs';
+import {
+  ArrowLeft,
+  CircleStop,
+  Play,
+  Plus,
+  Save,
+  Send,
+  Trash2,
+} from 'lucide-react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import SqlCodeEditor from '../components/SqlCodeEditor';
+import {
+  cancelSqlTaskExecution,
+  createSqlTask,
+  getSqlTask,
+  getSqlTaskExecution,
+  listSqlTaskVersions,
+  publishSqlTask,
+  runSqlTask,
+  updateSqlTask,
+} from '../service';
+import {
+  SQL_PARAMETER_TYPES,
+  TERMINAL_EXECUTION_STATUSES,
+  type SqlParameterDefinition,
+  type SqlTaskDefinition,
+  type SqlTaskExecution,
+  type SqlTaskSavePayload,
+  type SqlTaskVersion,
+} from '../types';
+
+interface SqlTaskEditorProps {
+  taskId?: number;
+  initialProjectId?: number;
+}
+
+interface DraftState {
+  id?: number;
+  name: string;
+  description: string;
+  projectId?: number;
+  dataSourceId?: number;
+  sql: string;
+  parameters: SqlParameterDefinition[];
+  draftRevision: number;
+  publishedVersionId?: number | null;
+  latestVersionNo: number;
+}
+
+const EMPTY_DRAFT: DraftState = {
+  name: '',
+  description: '',
+  sql: '',
+  parameters: [],
+  draftRevision: 0,
+  latestVersionNo: 0,
+};
+
+const responseData = <T,>(
+  response: { code?: number; data?: T; msg?: string; message?: string },
+  fallback: string,
+): T => {
+  if (response?.code !== API_SUCCESS_CODE || response.data === undefined) {
+    throw new Error(response?.message || response?.msg || fallback);
+  }
+  return response.data;
+};
+
+const toDraft = (task: SqlTaskDefinition): DraftState => ({
+  id: Number(task.id),
+  name: task.name || '',
+  description: task.description || '',
+  projectId: task.projectId ? Number(task.projectId) : undefined,
+  dataSourceId: Number(task.dataSourceId),
+  sql: task.sql || '',
+  parameters: Array.isArray(task.parameters) ? task.parameters : [],
+  draftRevision: Number(task.draftRevision || 0),
+  publishedVersionId: task.publishedVersionId,
+  latestVersionNo: Number(task.latestVersionNo || 0),
+});
+
+const formatTime = (value?: string | null) =>
+  value ? dayjs(value).format('YYYY-MM-DD HH:mm:ss') : '-';
+
+const executionStatusText: Record<string, string> = {
+  QUEUED: '排队中',
+  RUNNING: '运行中',
+  SUCCEEDED: '成功',
+  FAILED: '失败',
+  CANCELED: '已取消',
+  TIMED_OUT: '超时',
+  LOST: '执行丢失',
+};
+
+export default function SqlTaskEditor({
+  taskId,
+  initialProjectId,
+}: SqlTaskEditorProps) {
+  const { projects, currentProject } = useSecurityProject();
+  const [draft, setDraft] = useState<DraftState>(() => ({
+    ...EMPTY_DRAFT,
+    projectId:
+      initialProjectId ??
+      (currentProject?.id ? Number(currentProject.id) : undefined),
+  }));
+  const [dataSources, setDataSources] = useState<DataSourceRecord[]>([]);
+  const [versions, setVersions] = useState<SqlTaskVersion[]>([]);
+  const [execution, setExecution] = useState<SqlTaskExecution>();
+  const [loading, setLoading] = useState(Boolean(taskId));
+  const [saving, setSaving] = useState(false);
+  const [publishing, setPublishing] = useState(false);
+  const [running, setRunning] = useState(false);
+  const [runModalOpen, setRunModalOpen] = useState(false);
+  const [runInput, setRunInput] = useState<Record<string, unknown>>({});
+
+  const projectOptions = useMemo(
+    () => projects.map((project) => ({
+      label: project.projectName,
+      value: Number(project.id),
+    })),
+    [projects],
+  );
+  const dataSourceOptions = useMemo(
+    () => dataSources
+      .filter((item) => item.id !== undefined)
+      .map((item) => ({
+        value: Number(item.id),
+        label: `${item.name || `#${item.id}`} · ${item.dbType || '-'}`,
+      })),
+    [dataSources],
+  );
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const dataSourceResponse = await fetchDataSourceAll();
+      const sourceResult = responseData(dataSourceResponse, '查询数据源失败');
+      setDataSources(sourceResult?.bizData || []);
+
+      if (!taskId) return;
+      const [taskResponse, versionResponse] = await Promise.all([
+        getSqlTask(taskId),
+        listSqlTaskVersions(taskId),
+      ]);
+      setDraft(toDraft(responseData(taskResponse, '查询 SQL 任务失败')));
+      setVersions(responseData(versionResponse, '查询 SQL 版本失败') || []);
+    } catch (error) {
+      message.error(error instanceof Error ? error.message : '加载 SQL 任务失败');
+    } finally {
+      setLoading(false);
+    }
+  }, [taskId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  useEffect(() => {
+    setRunInput((previous) => {
+      const next: Record<string, unknown> = {};
+      draft.parameters.forEach((parameter) => {
+        if (Object.prototype.hasOwnProperty.call(previous, parameter.name)) {
+          next[parameter.name] = previous[parameter.name];
+        } else if (parameter.defaultValue !== undefined && parameter.defaultValue !== null) {
+          next[parameter.name] = parameter.defaultValue;
+        }
+      });
+      return next;
+    });
+  }, [draft.parameters]);
+
+  useEffect(() => {
+    if (!execution?.id || TERMINAL_EXECUTION_STATUSES.has(execution.status?.toUpperCase())) {
+      return undefined;
+    }
+    const timer = window.setInterval(async () => {
+      try {
+        const response = await getSqlTaskExecution(Number(execution.id));
+        const current = responseData(response, '查询 SQL 执行状态失败');
+        setExecution(current);
+      } catch {
+        // Keep the last known execution state and allow the next poll to retry.
+      }
+    }, 1200);
+    return () => window.clearInterval(timer);
+  }, [execution?.id, execution?.status]);
+
+  const updateDraftField = <K extends keyof DraftState>(
+    key: K,
+    value: DraftState[K],
+  ) => setDraft((previous) => ({ ...previous, [key]: value }));
+
+  const validateDraft = () => {
+    if (!draft.name.trim()) throw new Error('请输入任务名称');
+    if (!draft.projectId) throw new Error('请选择所属项目');
+    if (!draft.dataSourceId) throw new Error('请选择数据源');
+    if (!draft.sql.trim()) throw new Error('请输入 SQL');
+    const names = new Set<string>();
+    draft.parameters.forEach((parameter) => {
+      const name = parameter.name.trim();
+      if (!name) throw new Error('参数名称不能为空');
+      if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(name)) {
+        throw new Error(`参数名称不合法：${name}`);
+      }
+      if (names.has(name)) throw new Error(`参数名称重复：${name}`);
+      names.add(name);
+    });
+  };
+
+  const savePayload = (): SqlTaskSavePayload => ({
+    name: draft.name.trim(),
+    description: draft.description.trim() || undefined,
+    projectId: Number(draft.projectId),
+    dataSourceId: Number(draft.dataSourceId),
+    sql: draft.sql,
+    parameters: draft.parameters.map((parameter) => ({
+      ...parameter,
+      name: parameter.name.trim(),
+    })),
+  });
+
+  const persistDraft = async (showSuccess = true): Promise<SqlTaskDefinition> => {
+    validateDraft();
+    setSaving(true);
+    try {
+      const payload = savePayload();
+      const response = draft.id
+        ? await updateSqlTask(draft.id, {
+            ...payload,
+            baseRevision: draft.draftRevision,
+          })
+        : await createSqlTask(payload);
+      const saved = responseData(response, '保存 SQL 草稿失败');
+      setDraft(toDraft(saved));
+      if (!draft.id) {
+        history.replace(`/data-development/task/${saved.id}`);
+      }
+      if (showSuccess) message.success('草稿已保存');
+      return saved;
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleSave = async () => {
+    try {
+      await persistDraft(true);
+    } catch (error) {
+      message.error(error instanceof Error ? error.message : '保存 SQL 草稿失败');
+    }
+  };
+
+  const executeRun = async (input: Record<string, unknown>) => {
+    setRunning(true);
+    try {
+      const saved = await persistDraft(false);
+      const response = await runSqlTask(Number(saved.id), input);
+      const current = responseData(response, '启动 SQL 执行失败');
+      setExecution(current);
+      setRunModalOpen(false);
+      message.success('SQL 已提交执行');
+    } catch (error) {
+      message.error(error instanceof Error ? error.message : '启动 SQL 执行失败');
+    } finally {
+      setRunning(false);
+    }
+  };
+
+  const handleRun = () => {
+    try {
+      validateDraft();
+      if (draft.parameters.length > 0) {
+        setRunModalOpen(true);
+        return;
+      }
+      void executeRun({});
+    } catch (error) {
+      message.error(error instanceof Error ? error.message : 'SQL 配置不完整');
+    }
+  };
+
+  const handlePublish = async () => {
+    setPublishing(true);
+    try {
+      const saved = await persistDraft(false);
+      const published = responseData(
+        await publishSqlTask(Number(saved.id), Number(saved.draftRevision)),
+        '发布 SQL 版本失败',
+      );
+      const [taskResponse, versionResponse] = await Promise.all([
+        getSqlTask(Number(saved.id)),
+        listSqlTaskVersions(Number(saved.id)),
+      ]);
+      setDraft(toDraft(responseData(taskResponse, '刷新 SQL 任务失败')));
+      setVersions(responseData(versionResponse, '刷新版本列表失败') || []);
+      message.success(`已发布 V${published.versionNo}`);
+    } catch (error) {
+      message.error(error instanceof Error ? error.message : '发布 SQL 版本失败');
+    } finally {
+      setPublishing(false);
+    }
+  };
+
+  const handleCancelExecution = async () => {
+    if (!execution?.id) return;
+    try {
+      const current = responseData(
+        await cancelSqlTaskExecution(Number(execution.id)),
+        '取消 SQL 执行失败',
+      );
+      setExecution(current);
+      message.success('已提交取消');
+    } catch (error) {
+      message.error(error instanceof Error ? error.message : '取消 SQL 执行失败');
+    }
+  };
+
+  const addParameter = () => {
+    setDraft((previous) => ({
+      ...previous,
+      parameters: [
+        ...previous.parameters,
+        {
+          name: '',
+          type: 'STRING',
+          required: false,
+          defaultValue: undefined,
+        },
+      ],
+    }));
+  };
+
+  const updateParameter = (
+    index: number,
+    patch: Partial<SqlParameterDefinition>,
+  ) => {
+    setDraft((previous) => ({
+      ...previous,
+      parameters: previous.parameters.map((parameter, itemIndex) =>
+        itemIndex === index ? { ...parameter, ...patch } : parameter,
+      ),
+    }));
+  };
+
+  const removeParameter = (index: number) => {
+    setDraft((previous) => ({
+      ...previous,
+      parameters: previous.parameters.filter((_, itemIndex) => itemIndex !== index),
+    }));
+  };
+
+  const parameterColumns: ColumnsType<SqlParameterDefinition> = [
+    {
+      title: '参数名称',
+      width: 220,
+      render: (_, parameter, index) => (
+        <Input
+          value={parameter.name}
+          placeholder="例如 biz_date"
+          onChange={(event) => updateParameter(index, { name: event.target.value })}
+        />
+      ),
+    },
+    {
+      title: '类型',
+      width: 150,
+      render: (_, parameter, index) => (
+        <Select
+          value={parameter.type}
+          className="w-full"
+          options={SQL_PARAMETER_TYPES.map((type) => ({ label: type, value: type }))}
+          onChange={(type) => updateParameter(index, { type })}
+        />
+      ),
+    },
+    {
+      title: '必填',
+      width: 90,
+      align: 'center',
+      render: (_, parameter, index) => (
+        <Switch
+          size="small"
+          checked={parameter.required}
+          onChange={(required) => updateParameter(index, { required })}
+        />
+      ),
+    },
+    {
+      title: '默认值',
+      render: (_, parameter, index) => (
+        <Input
+          value={
+            parameter.defaultValue === undefined || parameter.defaultValue === null
+              ? ''
+              : String(parameter.defaultValue)
+          }
+          placeholder="可选"
+          onChange={(event) =>
+            updateParameter(index, {
+              defaultValue: event.target.value === '' ? undefined : event.target.value,
+            })
+          }
+        />
+      ),
+    },
+    {
+      title: '',
+      width: 50,
+      align: 'center',
+      render: (_, __, index) => (
+        <Button
+          type="text"
+          icon={<Trash2 size={14} />}
+          onClick={() => removeParameter(index)}
+        />
+      ),
+    },
+  ];
+
+  const versionColumns: ColumnsType<SqlTaskVersion> = [
+    {
+      title: '版本',
+      dataIndex: 'versionNo',
+      width: 100,
+      render: (value: number) => <span className="font-medium">V{value}</span>,
+    },
+    {
+      title: '数据源',
+      dataIndex: 'dataSourceId',
+      width: 180,
+      render: (value: number) =>
+        dataSourceOptions.find((item) => item.value === Number(value))?.label || `#${value}`,
+    },
+    {
+      title: '摘要',
+      dataIndex: 'contentDigest',
+      ellipsis: true,
+      render: (value: string) => (
+        <span className="font-mono text-[12px] text-[rgba(22,24,35,.55)]">
+          {value}
+        </span>
+      ),
+    },
+    {
+      title: '发布时间',
+      dataIndex: 'publishedAt',
+      width: 180,
+      render: (value?: string) => formatTime(value),
+    },
+  ];
+
+  const renderExecutionResult = () => {
+    if (!execution) {
+      return (
+        <Empty
+          image={Empty.PRESENTED_IMAGE_SIMPLE}
+          description="运行 SQL 后在这里查看结果"
+        />
+      );
+    }
+
+    const status = String(execution.status || '').toUpperCase();
+    const active = !TERMINAL_EXECUTION_STATUSES.has(status);
+    const output = execution.output || {};
+    const kind = String(output.kind || '').toUpperCase();
+
+    const header = (
+      <div className="mb-4 flex items-center justify-between gap-3">
+        <Space size={8}>
+          <Tag className="!m-0">{executionStatusText[status] || status}</Tag>
+          <Typography.Text className="text-[12px] text-[rgba(22,24,35,.45)]">
+            Execution #{execution.id}
+          </Typography.Text>
+          {execution.startTime && (
+            <Typography.Text className="text-[12px] text-[rgba(22,24,35,.45)]">
+              {formatTime(execution.startTime)}
+            </Typography.Text>
+          )}
+        </Space>
+        {active && (
+          <Button
+            size="small"
+            icon={<CircleStop size={14} />}
+            onClick={() => void handleCancelExecution()}
+          >
+            取消
+          </Button>
+        )}
+      </div>
+    );
+
+    if (active) {
+      return (
+        <div>
+          {header}
+          <div className="flex min-h-[180px] items-center justify-center">
+            <Spin tip="SQL 执行中..." />
+          </div>
+        </div>
+      );
+    }
+
+    if (status !== 'SUCCEEDED') {
+      return (
+        <div>
+          {header}
+          <Alert
+            type="error"
+            showIcon
+            message={executionStatusText[status] || status}
+            description={execution.errorMessage || '执行未成功完成'}
+          />
+        </div>
+      );
+    }
+
+    if (kind === 'UPDATE') {
+      return (
+        <div>
+          {header}
+          <div className="rounded-lg border border-[#e4e7ec] bg-[#fafafa] px-5 py-6">
+            <div className="text-[12px] text-[rgba(22,24,35,.45)]">影响行数</div>
+            <div className="mt-1 text-[26px] font-semibold text-[#161823]">
+              {Number(output.affectedRows ?? execution.affectedRows ?? 0)}
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    const resultColumns = Array.isArray(output.columns)
+      ? (output.columns as string[])
+      : [];
+    const rows = Array.isArray(output.rows)
+      ? (output.rows as Record<string, unknown>[])
+      : [];
+    return (
+      <div>
+        {header}
+        {output.truncated === true && (
+          <Alert
+            className="mb-3"
+            type="info"
+            showIcon
+            message="结果已截断，当前最多预览 200 行"
+          />
+        )}
+        <Table<Record<string, unknown>>
+          rowKey={(_, index) => String(index)}
+          size="small"
+          bordered
+          pagination={false}
+          scroll={{ x: 'max-content', y: 320 }}
+          dataSource={rows}
+          columns={resultColumns.map((column) => ({
+            title: column,
+            dataIndex: column,
+            key: column,
+            minWidth: 140,
+            render: (value: unknown) => {
+              if (value === null || value === undefined) {
+                return <span className="text-[rgba(22,24,35,.3)]">NULL</span>;
+              }
+              if (typeof value === 'object') return JSON.stringify(value);
+              return String(value);
+            },
+          }))}
+          locale={{ emptyText: '查询成功，无返回数据' }}
+        />
+      </div>
+    );
+  };
+
+  const editorTabs = [
+    {
+      key: 'parameters',
+      label: `参数配置${draft.parameters.length ? ` (${draft.parameters.length})` : ''}`,
+      children: (
+        <div>
+          <div className="mb-3 flex items-center justify-between">
+            <Typography.Text className="text-[12px] text-[rgba(22,24,35,.45)]">
+              SQL 中使用 :name 引用值参数；第一阶段不支持动态表名替换。
+            </Typography.Text>
+            <Button size="small" icon={<Plus size={13} />} onClick={addParameter}>
+              添加参数
+            </Button>
+          </div>
+          <Table<SqlParameterDefinition>
+            rowKey={(_, index) => String(index)}
+            size="small"
+            bordered
+            pagination={false}
+            columns={parameterColumns}
+            dataSource={draft.parameters}
+            locale={{ emptyText: '当前 SQL 无参数' }}
+          />
+        </div>
+      ),
+    },
+    {
+      key: 'result',
+      label: '运行结果',
+      children: renderExecutionResult(),
+    },
+    {
+      key: 'versions',
+      label: `版本历史${versions.length ? ` (${versions.length})` : ''}`,
+      children: (
+        <Table<SqlTaskVersion>
+          rowKey="id"
+          size="small"
+          pagination={false}
+          columns={versionColumns}
+          dataSource={versions}
+          locale={{ emptyText: '尚未发布版本' }}
+        />
+      ),
+    },
+  ];
+
+  return (
+    <section className="m-4 overflow-hidden rounded-xl border border-[#e4e7ec] bg-white">
+      <Spin spinning={loading}>
+        <header className="flex min-h-[64px] items-center justify-between gap-4 border-b border-[#e4e7ec] px-5 py-3">
+          <div className="flex min-w-0 items-center gap-3">
+            <Button
+              type="text"
+              icon={<ArrowLeft size={17} />}
+              onClick={() => history.push('/data-development')}
+            />
+            <div className="min-w-0">
+              <div className="flex items-center gap-2">
+                <Typography.Text className="truncate text-[15px] font-semibold text-[#161823]">
+                  {draft.name || '新建 SQL 任务'}
+                </Typography.Text>
+                <Tag className="!m-0 !border-[#e4e7ec] !bg-[#f7f7f8] !text-[#161823]">
+                  SQL
+                </Tag>
+                {draft.latestVersionNo > 0 ? (
+                  <Tag className="!m-0">已发布 V{draft.latestVersionNo}</Tag>
+                ) : (
+                  <Tag className="!m-0">草稿</Tag>
+                )}
+              </div>
+              <div className="mt-0.5 text-[11px] text-[rgba(22,24,35,.38)]">
+                {draft.id ? `Task #${draft.id} · Draft r${draft.draftRevision}` : '配置完成后保存为草稿'}
+              </div>
+            </div>
+          </div>
+          <Space>
+            <Button
+              icon={<Save size={14} />}
+              loading={saving}
+              onClick={() => void handleSave()}
+            >
+              保存
+            </Button>
+            <Button
+              icon={<Play size={14} />}
+              loading={running}
+              onClick={handleRun}
+            >
+              运行
+            </Button>
+            <Button
+              type="primary"
+              icon={<Send size={14} />}
+              loading={publishing}
+              onClick={() => void handlePublish()}
+            >
+              发布
+            </Button>
+          </Space>
+        </header>
+
+        <main className="p-5">
+          <div className="mb-5 grid grid-cols-12 gap-4">
+            <div className="col-span-4">
+              <div className="mb-1.5 text-[12px] font-medium text-[#161823]">任务名称</div>
+              <Input
+                value={draft.name}
+                maxLength={200}
+                placeholder="请输入任务名称"
+                onChange={(event) => updateDraftField('name', event.target.value)}
+              />
+            </div>
+            <div className="col-span-4">
+              <div className="mb-1.5 text-[12px] font-medium text-[#161823]">所属项目</div>
+              <Select
+                value={draft.projectId}
+                className="w-full"
+                showSearch
+                optionFilterProp="label"
+                placeholder="请选择项目"
+                options={projectOptions}
+                onChange={(value) => updateDraftField('projectId', Number(value))}
+              />
+            </div>
+            <div className="col-span-4">
+              <div className="mb-1.5 text-[12px] font-medium text-[#161823]">数据源</div>
+              <Select
+                value={draft.dataSourceId}
+                className="w-full"
+                showSearch
+                optionFilterProp="label"
+                placeholder="请选择数据源"
+                options={dataSourceOptions}
+                onChange={(value) => updateDraftField('dataSourceId', Number(value))}
+              />
+            </div>
+            <div className="col-span-12">
+              <div className="mb-1.5 text-[12px] font-medium text-[#161823]">任务描述</div>
+              <Input
+                value={draft.description}
+                maxLength={1000}
+                placeholder="可选，说明任务用途或数据加工逻辑"
+                onChange={(event) => updateDraftField('description', event.target.value)}
+              />
+            </div>
+          </div>
+
+          <div className="mb-5">
+            <div className="mb-2 flex items-center justify-between">
+              <div>
+                <div className="text-[13px] font-semibold text-[#161823]">SQL 配置</div>
+                <div className="mt-0.5 text-[11px] text-[rgba(22,24,35,.38)]">
+                  当前阶段一个任务绑定一个数据源和一段 SQL。
+                </div>
+              </div>
+              <Typography.Text className="text-[11px] text-[rgba(22,24,35,.38)]">
+                使用 :param 绑定参数
+              </Typography.Text>
+            </div>
+            <SqlCodeEditor
+              value={draft.sql}
+              minHeight={360}
+              onChange={(value) => updateDraftField('sql', value)}
+            />
+          </div>
+
+          <div className="border-t border-[#eceef1] pt-2">
+            <Tabs items={editorTabs} />
+          </div>
+        </main>
+      </Spin>
+
+      <Modal
+        open={runModalOpen}
+        title="运行参数"
+        okText="运行"
+        cancelText="取消"
+        confirmLoading={running}
+        onCancel={() => setRunModalOpen(false)}
+        onOk={() => void executeRun(runInput)}
+      >
+        <div className="space-y-4 pt-2">
+          {draft.parameters.map((parameter) => (
+            <div key={parameter.name || Math.random()}>
+              <div className="mb-1.5 flex items-center gap-2 text-[12px] font-medium text-[#161823]">
+                {parameter.name || '未命名参数'}
+                <Tag className="!m-0">{parameter.type}</Tag>
+                {parameter.required && (
+                  <span className="text-[rgba(254,44,85,1)]">*</span>
+                )}
+              </div>
+              <Input
+                value={
+                  runInput[parameter.name] === undefined || runInput[parameter.name] === null
+                    ? ''
+                    : String(runInput[parameter.name])
+                }
+                placeholder={
+                  parameter.defaultValue === undefined
+                    ? '请输入运行参数'
+                    : `默认值：${String(parameter.defaultValue)}`
+                }
+                onChange={(event) =>
+                  setRunInput((previous) => ({
+                    ...previous,
+                    [parameter.name]: event.target.value,
+                  }))
+                }
+              />
+            </div>
+          ))}
+        </div>
+      </Modal>
+    </section>
+  );
+}

--- a/yak-ops-ui/src/pages/data-development/task/index.tsx
+++ b/yak-ops-ui/src/pages/data-development/task/index.tsx
@@ -1,0 +1,26 @@
+import { Result } from 'antd';
+import { useLocation, useParams } from '@umijs/max';
+
+import type { DevelopmentTaskType } from '../types';
+import SqlTaskEditor from './SqlTaskEditor';
+
+export default function DataDevelopmentTaskPage() {
+  const { id } = useParams<{ id?: string }>();
+  const location = useLocation();
+  const params = new URLSearchParams(location.search);
+  const requestedType = (params.get('type') || 'SQL').toUpperCase() as DevelopmentTaskType;
+  const projectId = Number(params.get('projectId') || 0) || undefined;
+  const taskId = id ? Number(id) : undefined;
+
+  if (requestedType !== 'SQL') {
+    return (
+      <Result
+        status="info"
+        title={`${requestedType} 任务暂未开放`}
+        subTitle="数据开发已保留统一 Editor 扩展入口，当前阶段先完成 SQL。"
+      />
+    );
+  }
+
+  return <SqlTaskEditor taskId={taskId} initialProjectId={projectId} />;
+}

--- a/yak-ops-ui/src/pages/data-development/types.ts
+++ b/yak-ops-ui/src/pages/data-development/types.ts
@@ -1,0 +1,95 @@
+export type DevelopmentTaskType = 'SQL' | 'SHELL' | 'HTTP' | 'PYTHON';
+
+export type SqlParameterType =
+  | 'STRING'
+  | 'INTEGER'
+  | 'LONG'
+  | 'DOUBLE'
+  | 'DECIMAL'
+  | 'BOOLEAN'
+  | 'DATE'
+  | 'TIMESTAMP';
+
+export interface SqlParameterDefinition {
+  name: string;
+  type: SqlParameterType;
+  required: boolean;
+  defaultValue?: unknown;
+}
+
+export interface SqlTaskDefinition {
+  id: number;
+  name: string;
+  description?: string | null;
+  projectId?: number | null;
+  dataSourceId: number;
+  sql: string;
+  parameters: SqlParameterDefinition[];
+  draftRevision: number;
+  publishedVersionId?: number | null;
+  latestVersionNo: number;
+  createTime?: string;
+  updateTime?: string;
+}
+
+export interface SqlTaskVersion {
+  id: number;
+  taskId: number;
+  versionNo: number;
+  dataSourceId: number;
+  sql: string;
+  parameters: SqlParameterDefinition[];
+  contentDigest: string;
+  publishedAt?: string;
+}
+
+export interface SqlTaskExecution {
+  id: number;
+  taskId: number;
+  taskVersionId?: number | null;
+  taskVersionNo?: number | null;
+  dataSourceId: number;
+  status: string;
+  affectedRows: number;
+  output?: Record<string, unknown>;
+  errorMessage?: string | null;
+  createTime?: string;
+  startTime?: string | null;
+  finishTime?: string | null;
+}
+
+export interface SqlTaskSavePayload {
+  name: string;
+  description?: string;
+  projectId: number;
+  dataSourceId: number;
+  sql: string;
+  parameters: SqlParameterDefinition[];
+}
+
+export interface SqlTaskUpdatePayload extends SqlTaskSavePayload {
+  baseRevision: number;
+}
+
+export interface DevelopmentTaskRow extends SqlTaskDefinition {
+  type: 'SQL';
+}
+
+export const SQL_PARAMETER_TYPES: SqlParameterType[] = [
+  'STRING',
+  'INTEGER',
+  'LONG',
+  'DOUBLE',
+  'DECIMAL',
+  'BOOLEAN',
+  'DATE',
+  'TIMESTAMP',
+];
+
+export const TERMINAL_EXECUTION_STATUSES = new Set([
+  'SUCCEEDED',
+  'FAILED',
+  'CANCELED',
+  'TIMED_OUT',
+  'LOST',
+]);

--- a/yak-ops-ui/src/pages/workflow/definition/WorkflowDefinitionEditor.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/WorkflowDefinitionEditor.tsx
@@ -86,11 +86,17 @@ const parseObject = <T extends Record<string, unknown>>(raw: string, label: stri
   return value as T;
 };
 
+const taskTypeLabel = (taskType?: string) => {
+  if (!taskType || taskType === 'SYNC') return '数据同步';
+  if (taskType === 'SQL') return 'SQL';
+  return taskType;
+};
+
 const createNodeData = (task: WorkflowTaskDefinition): WorkflowNodeData => ({
   label: task.name,
   taskId: task.id,
   taskType: task.type,
-  typeLabel: task.type === 'SYNC' ? '数据同步' : task.type,
+  typeLabel: taskTypeLabel(task.type),
   triggerRule: 'ALL_SUCCESS',
   failurePolicy: 'FAIL_WORKFLOW',
   maxAttempts: 1,
@@ -179,7 +185,6 @@ const WorkflowDefinitionContent = () => {
   const nodeTypes = useMemo(() => ({ workflow: WorkflowNode, start: WorkflowStartNode, note: WorkflowNoteNode }), []);
   const edgeTypes = useMemo(() => ({ workflow: WorkflowEdge }), []);
   const selectedNode = useMemo(() => nodes.find((node) => node.selected), [nodes]);
-  const syncTasks = useMemo(() => tasks.filter((task) => task.type === 'SYNC'), [tasks]);
   // 测试运行期间锁住结构编辑，避免正在执行的 nodeId 与画布拓扑发生漂移。
   const locked = testing;
 
@@ -358,7 +363,7 @@ const WorkflowDefinitionContent = () => {
           label: task?.name || `任务 ${node.taskId}`,
           taskId: node.taskId,
           taskType: task?.type || 'SYNC',
-          typeLabel: task?.type === 'SYNC' || !task ? '数据同步' : task.type,
+          typeLabel: taskTypeLabel(task?.type),
           triggerRule: node.triggerRule,
           failurePolicy: node.failurePolicy,
           maxAttempts: node.maxAttempts,
@@ -475,7 +480,7 @@ const WorkflowDefinitionContent = () => {
 
   const handleAddTaskFromToolbar = useCallback((taskId: string) => {
     if (locked) return;
-    const task = syncTasks.find((item) => item.id === taskId);
+    const task = tasks.find((item) => item.id === taskId);
     const position = getCanvasCenterPosition(WORKFLOW_NODE_WIDTH, 72);
     if (!task || !position) return;
     const sequence = sequenceRef.current++;
@@ -487,7 +492,7 @@ const WorkflowDefinitionContent = () => {
       ...current.map((node) => ({ ...node, selected: false })),
       { id: `task-${Date.now()}-${sequence}`, type: 'workflow', position, selected: true, data: createNodeData(task) },
     ]);
-  }, [getCanvasCenterPosition, locked, markHistory, setNodes, syncTasks]);
+  }, [getCanvasCenterPosition, locked, markHistory, setNodes, tasks]);
 
   const handleAddNote = useCallback(() => {
     if (locked) return;
@@ -538,7 +543,7 @@ const WorkflowDefinitionContent = () => {
 
   const handleInsertTaskIntoEdge = useCallback((edgeId: string, source: string, target: string, taskId: string) => {
     if (locked) return;
-    const task = syncTasks.find((item) => item.id === taskId);
+    const task = tasks.find((item) => item.id === taskId);
     const sourceNode = nodes.find((node) => node.id === source);
     const targetNode = nodes.find((node) => node.id === target);
     const sourceEdge = edges.find((edge) => edge.id === edgeId);
@@ -560,11 +565,11 @@ const WorkflowDefinitionContent = () => {
       { id: `edge-${source}-${nodeId}-${sequence}`, source, sourceHandle: sourceEdge.sourceHandle, target: nodeId, type: 'workflow' },
       { id: `edge-${nodeId}-${target}-${sequence}`, source: nodeId, target, targetHandle: sourceEdge.targetHandle, type: 'workflow' },
     ]);
-  }, [edges, locked, markHistory, nodes, setEdges, setNodes, syncTasks]);
+  }, [edges, locked, markHistory, nodes, setEdges, setNodes, tasks]);
 
   const handleAppendTask = useCallback((sourceNodeId: string, taskId: string) => {
     if (locked) return;
-    const task = syncTasks.find((item) => item.id === taskId);
+    const task = tasks.find((item) => item.id === taskId);
     const sourceNode = nodes.find((node) => node.id === sourceNodeId);
     if (!task || !sourceNode) return;
     const outgoers = getOutgoers(sourceNode, nodes, edges).sort((left, right) => left.position.y - right.position.y);
@@ -592,11 +597,11 @@ const WorkflowDefinitionContent = () => {
       target: nodeId,
       type: 'workflow',
     }]);
-  }, [edges, locked, markHistory, nodes, setEdges, setNodes, syncTasks]);
+  }, [edges, locked, markHistory, nodes, setEdges, setNodes, tasks]);
 
   const handleAppendFromStart = useCallback((_startNodeId: string, taskId: string) => {
     if (locked) return;
-    const task = syncTasks.find((item) => item.id === taskId);
+    const task = tasks.find((item) => item.id === taskId);
     if (!task) return;
     const taskTargets = new Set(edges.map((edge) => edge.target));
     const currentRoots = nodes
@@ -622,7 +627,7 @@ const WorkflowDefinitionContent = () => {
       ...current,
       nextNodeIds: [...current.nextNodeIds, nodeId],
     }));
-  }, [edges, locked, markHistory, nodes, setNodes, startConfig.position.x, startConfig.position.y, syncTasks]);
+  }, [edges, locked, markHistory, nodes, setNodes, startConfig.position.x, startConfig.position.y, tasks]);
 
   const handleDuplicateNode = useCallback((nodeId: string) => {
     if (locked) return;
@@ -736,12 +741,12 @@ const WorkflowDefinitionContent = () => {
   const handleNodeMouseEnter = useCallback<NodeMouseHandler>((_, node) => setHoveredNodeId(node.id), []);
   const handleNodeMouseLeave = useCallback<NodeMouseHandler>(() => setHoveredNodeId(undefined), []);
 
-  const taskOptions = useMemo(() => syncTasks.map((task) => ({
+  const taskOptions = useMemo(() => tasks.map((task) => ({
     id: task.id,
     label: task.name,
-    typeLabel: task.type === 'SYNC' ? '数据同步' : task.type,
+    typeLabel: taskTypeLabel(task.type),
     taskType: task.type,
-  })), [syncTasks]);
+  })), [tasks]);
 
   const inspectorNextNodes = useMemo(() => {
     if (!selectedNode) return [];
@@ -990,7 +995,7 @@ const WorkflowDefinitionContent = () => {
 
   return (
     <div className="flex h-[calc(100vh-48px)] min-h-[620px] overflow-hidden" style={{ backgroundColor: '#F2F4F7' }}>
-      <WorkflowTaskLibrary tasks={syncTasks} loading={tasksLoading} locked={locked} onDragStart={handleDragStart} />
+      <WorkflowTaskLibrary tasks={tasks} loading={tasksLoading} locked={locked} onDragStart={handleDragStart} />
       <section className="flex min-w-0 flex-1 flex-col">
         <WorkflowToolbar
           definition={definition}

--- a/yak-ops-ui/src/pages/workflow/definition/canvas/node/icons/SqlNodeIcon.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/node/icons/SqlNodeIcon.tsx
@@ -1,0 +1,33 @@
+import type { SVGProps } from 'react';
+
+const SqlNodeIcon = (props: SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    aria-hidden="true"
+    {...props}
+  >
+    <ellipse cx="12" cy="6.5" rx="7" ry="3" stroke="currentColor" strokeWidth="1.6" />
+    <path
+      d="M5 6.5v5c0 1.65 3.13 3 7 3s7-1.35 7-3v-5"
+      stroke="currentColor"
+      strokeWidth="1.6"
+    />
+    <path
+      d="M5 11.5v5c0 1.65 3.13 3 7 3 1.1 0 2.14-.11 3.06-.32"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+    />
+    <path
+      d="m16.5 15.5 2 2 2.5-3"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+export default SqlNodeIcon;

--- a/yak-ops-ui/src/pages/workflow/definition/canvas/node/icons/WorkflowNodeIcon.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/node/icons/WorkflowNodeIcon.tsx
@@ -1,4 +1,5 @@
 import type { ComponentType, SVGProps } from 'react';
+import SqlNodeIcon from './SqlNodeIcon';
 import SyncNodeIcon from './SyncNodeIcon';
 
 interface WorkflowNodeIconProps {
@@ -34,6 +35,10 @@ const NODE_ICON_META: Record<string, NodeIconMeta> = {
   SYNC: {
     icon: SyncNodeIcon,
     className: 'bg-[rgba(254,44,85,.08)] text-[#fe2c55]',
+  },
+  SQL: {
+    icon: SqlNodeIcon,
+    className: 'bg-[#f4f4f5] text-[#344054]',
   },
 };
 


### PR DESCRIPTION
## 目标

按 Yak Ops 现有“列表 -> 二阶段配置”的产品方式完成数据开发前端，并与 SQL 数据开发后端及 Workflow 形成完整闭环。

## 页面结构

```text
数据开发
├─ 左侧：项目树
└─ 右侧：开发任务列表
       |
       +-- 新建任务 -> 选择项目 + 任务类型
       |
       +-- SQL -> SQL Task Editor
```

当前只开放 SQL；Shell / HTTP / Python 保留统一 TaskType / Editor 扩展位，不提供假后端能力。

## 前端

- 新增“数据开发 / 开发任务”导航
- 首页采用左项目树 + 右任务列表
- 复用现有 `SecurityProjectContext`，不新建项目管理能力
- 复用现有数据源 `/api/v1/data-source/all`
- 新建任务第一阶段统一选择项目和任务类型
- 第二阶段进入 SQL 专业配置页
- CodeMirror SQL 编辑器
- SQL 参数定义与运行参数输入
- 保存草稿
- 运行/发布前自动保存当前草稿
- 执行状态轮询与取消
- Query 结果表格 / DML affected rows
- 发布不可变版本及版本历史

## 后端联调

SQL Task 新增持久化 `projectId` 管理维度：

- Create / Update 支持 `projectId`
- Definition 返回 `projectId`
- `GET /api/v1/data-development/sql-tasks?projectId=...` 支持按项目查询
- Repository / PO / MyBatis 全链路支持项目归属
- Flyway `V2__add_project_to_sql_task.sql`
- 已有任务允许暂时处于“未归属”状态；旧客户端更新不传 `projectId` 时保留原归属
- 新 UI 创建/编辑时仍强制选择项目
- SQL Version / Execution 语义保持不变，项目归属不进入不可变执行快照

## Workflow 联调

- 移除 Workflow 编辑器残留的 `SYNC` 前端过滤
- 工具栏新增、边上插入、节点追加、开始节点追加、Inspector 任务选择统一消费全部已发布 Task
- SQL 自动进入任务选择器“数据开发”分类
- SQL 节点保留真实 `taskType=SQL`
- 新增 SQL 专属节点图标
- Workflow 保存协议仍只依赖 `taskId`，继续由后端发布时固定 `TaskVersionSnapshot`

## 扩展边界

```text
DevelopmentTaskType -> Task Editor
SQL                  -> SqlTaskEditor
Shell                 -> future ShellTaskEditor
HTTP                  -> future HttpTaskEditor
Python                -> future PythonTaskEditor
```

后端继续使用已经建立的 `TaskProvider + TaskExecutor + TaskExecutionGateway`，后续任务类型不需要修改 Workflow 核心。

## 暂不包含

- 目录/文件夹 CRUD
- Shell / HTTP / Python 实现
- GitLab / GitHub
- 文件资源依赖
- IDE 文件树
- 新的项目级请求 Header / 授权协议（继续复用现有 Security Project 边界）

## 验证

- 已按现有 strict TypeScript / Biome 规范做静态契约回查
- 已核对 Workflow 大文件 patch，除通用 Task 放开和类型标签外未改动画布/状态机行为
- 已核对前后端 SQL Execution 输出契约：Query rows/columns、Update affectedRows、运行状态与取消
- 当前仓库未针对该 PR 触发 GitHub Actions workflow
- 当前执行容器无法解析 github.com，无法直接 clone 分支执行完整 Maven / npm tsc，因此 PR 保持 Draft 供本地/CI 最终验证