### PR TITLE
feat(data-development): add hierarchical directories and resizable tree

### DIFF
--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/api/DevelopmentDirectoryApi.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/api/DevelopmentDirectoryApi.java
@@ -1,0 +1,18 @@
+package io.yak.ops.business.development.api;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+/** HTTP request contracts for data-development directories. */
+public final class DevelopmentDirectoryApi {
+
+  private DevelopmentDirectoryApi() {}
+
+  public record CreateRequest(
+      @NotNull @Min(1) Long projectId,
+      @Min(1) Long parentId,
+      @NotBlank @Size(max = 128) String name) {
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/api/SqlDevelopmentApi.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/api/SqlDevelopmentApi.java
@@ -16,6 +16,7 @@ public final class SqlDevelopmentApi {
       @NotBlank String name,
       String description,
       @Min(1) Long projectId,
+      @Min(0) Long directoryId,
       @NotNull @Min(1) Long dataSourceId,
       @NotBlank String sql,
       List<SqlParameterDefinition> parameters) {
@@ -26,6 +27,7 @@ public final class SqlDevelopmentApi {
       @NotBlank String name,
       String description,
       @Min(1) Long projectId,
+      @Min(0) Long directoryId,
       @NotNull @Min(1) Long dataSourceId,
       @NotBlank String sql,
       List<SqlParameterDefinition> parameters) {

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/controller/v1/DevelopmentDirectoryController.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/controller/v1/DevelopmentDirectoryController.java
@@ -1,0 +1,45 @@
+package io.yak.ops.business.development.controller.v1;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.yak.framework.common.Result;
+import io.yak.ops.business.development.api.DevelopmentDirectoryApi.CreateRequest;
+import io.yak.ops.business.development.domain.DevelopmentDirectory;
+import io.yak.ops.business.development.service.DevelopmentDirectoryService;
+import jakarta.validation.Valid;
+import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Project-scoped directory management for data development. */
+@Tag(name = "数据开发目录接口")
+@RestController
+@RequestMapping("/api/v1/data-development/directories")
+public class DevelopmentDirectoryController {
+
+  private final DevelopmentDirectoryService service;
+
+  public DevelopmentDirectoryController(DevelopmentDirectoryService service) {
+    this.service = service;
+  }
+
+  @Operation(summary = "查询项目数据开发目录")
+  @GetMapping
+  public Result<List<DevelopmentDirectory>> list(
+      @RequestParam(name = "projectId") Long projectId) {
+    return Result.success(service.list(projectId));
+  }
+
+  @Operation(summary = "新建数据开发目录")
+  @PostMapping
+  public Result<DevelopmentDirectory> create(@Valid @RequestBody CreateRequest request) {
+    return Result.success(service.create(
+        request.projectId(),
+        request.parentId(),
+        request.name()));
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/controller/v1/SqlDevelopmentController.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/controller/v1/SqlDevelopmentController.java
@@ -41,6 +41,7 @@ public class SqlDevelopmentController {
         request.name(),
         request.description(),
         request.projectId(),
+        request.directoryId(),
         request.dataSourceId(),
         request.sql(),
         request.parameters()));
@@ -70,6 +71,7 @@ public class SqlDevelopmentController {
         request.name(),
         request.description(),
         request.projectId(),
+        request.directoryId(),
         request.dataSourceId(),
         request.sql(),
         request.parameters()));

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/dao/mapper/DevelopmentDirectoryMapper.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/dao/mapper/DevelopmentDirectoryMapper.java
@@ -1,0 +1,7 @@
+package io.yak.ops.business.development.dao.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import io.yak.ops.common.bean.po.development.DevelopmentDirectoryPO;
+
+public interface DevelopmentDirectoryMapper extends BaseMapper<DevelopmentDirectoryPO> {
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/domain/DevelopmentDirectory.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/domain/DevelopmentDirectory.java
@@ -1,0 +1,14 @@
+package io.yak.ops.business.development.domain;
+
+import java.time.Instant;
+
+/** Hierarchical directory used to organize data-development tasks inside a project. */
+public record DevelopmentDirectory(
+    Long id,
+    Long projectId,
+    Long parentId,
+    String name,
+    String path,
+    Instant createTime,
+    Instant updateTime) {
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/domain/SqlDevelopmentModel.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/domain/SqlDevelopmentModel.java
@@ -14,6 +14,7 @@ public final class SqlDevelopmentModel {
       String name,
       String description,
       Long projectId,
+      Long directoryId,
       Long dataSourceId,
       String sql,
       List<SqlParameterDefinition> parameters,

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/DevelopmentDirectoryRepository.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/DevelopmentDirectoryRepository.java
@@ -1,0 +1,17 @@
+package io.yak.ops.business.development.repository;
+
+import io.yak.ops.business.development.domain.DevelopmentDirectory;
+import java.util.List;
+import java.util.Optional;
+
+/** Durable directory repository for data-development organization metadata. */
+public interface DevelopmentDirectoryRepository {
+
+  DevelopmentDirectory insert(Long projectId, Long parentId, String name);
+
+  Optional<DevelopmentDirectory> findById(Long id);
+
+  List<DevelopmentDirectory> listByProjectId(Long projectId);
+
+  boolean existsByName(Long projectId, Long parentId, String name);
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/DevelopmentDirectoryRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/DevelopmentDirectoryRepositoryAdapter.java
@@ -1,0 +1,81 @@
+package io.yak.ops.business.development.repository;
+
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import io.yak.ops.business.development.dao.mapper.DevelopmentDirectoryMapper;
+import io.yak.ops.business.development.domain.DevelopmentDirectory;
+import io.yak.ops.common.bean.po.development.DevelopmentDirectoryPO;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.stereotype.Repository;
+
+/** MyBatis adapter for hierarchical data-development directories. */
+@Repository
+public class DevelopmentDirectoryRepositoryAdapter implements DevelopmentDirectoryRepository {
+
+  private static final long ROOT_PARENT_ID = 0L;
+
+  private final DevelopmentDirectoryMapper mapper;
+
+  public DevelopmentDirectoryRepositoryAdapter(DevelopmentDirectoryMapper mapper) {
+    this.mapper = mapper;
+  }
+
+  @Override
+  public DevelopmentDirectory insert(Long projectId, Long parentId, String name) {
+    Instant now = Instant.now();
+    DevelopmentDirectoryPO po = new DevelopmentDirectoryPO();
+    po.setProjectId(projectId);
+    po.setParentId(toStoredParentId(parentId));
+    po.setName(name);
+    po.setCreateTime(now);
+    po.setUpdateTime(now);
+    mapper.insert(po);
+    return toDomain(po);
+  }
+
+  @Override
+  public Optional<DevelopmentDirectory> findById(Long id) {
+    return Optional.ofNullable(mapper.selectById(id)).map(this::toDomain);
+  }
+
+  @Override
+  public List<DevelopmentDirectory> listByProjectId(Long projectId) {
+    return mapper.selectList(
+            new LambdaQueryWrapper<DevelopmentDirectoryPO>()
+                .eq(DevelopmentDirectoryPO::getProjectId, projectId)
+                .orderByAsc(DevelopmentDirectoryPO::getName)
+                .orderByAsc(DevelopmentDirectoryPO::getId))
+        .stream()
+        .map(this::toDomain)
+        .toList();
+  }
+
+  @Override
+  public boolean existsByName(Long projectId, Long parentId, String name) {
+    return mapper.selectCount(
+            new LambdaQueryWrapper<DevelopmentDirectoryPO>()
+                .eq(DevelopmentDirectoryPO::getProjectId, projectId)
+                .eq(DevelopmentDirectoryPO::getParentId, toStoredParentId(parentId))
+                .eq(DevelopmentDirectoryPO::getName, name))
+        > 0L;
+  }
+
+  private Long toStoredParentId(Long parentId) {
+    return parentId == null || parentId <= 0L ? ROOT_PARENT_ID : parentId;
+  }
+
+  private DevelopmentDirectory toDomain(DevelopmentDirectoryPO po) {
+    Long parentId = po.getParentId() == null || po.getParentId() == ROOT_PARENT_ID
+        ? null
+        : po.getParentId();
+    return new DevelopmentDirectory(
+        po.getId(),
+        po.getProjectId(),
+        parentId,
+        po.getName(),
+        null,
+        po.getCreateTime(),
+        po.getUpdateTime());
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/SqlDevelopmentRepository.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/SqlDevelopmentRepository.java
@@ -15,6 +15,7 @@ public interface SqlDevelopmentRepository {
       String name,
       String description,
       Long projectId,
+      Long directoryId,
       Long dataSourceId,
       String sql,
       List<SqlParameterDefinition> parameters);
@@ -33,6 +34,7 @@ public interface SqlDevelopmentRepository {
       String name,
       String description,
       Long projectId,
+      Long directoryId,
       Long dataSourceId,
       String sql,
       List<SqlParameterDefinition> parameters);

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/SqlDevelopmentRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/SqlDevelopmentRepositoryAdapter.java
@@ -44,6 +44,7 @@ public class SqlDevelopmentRepositoryAdapter implements SqlDevelopmentRepository
       String name,
       String description,
       Long projectId,
+      Long directoryId,
       Long dataSourceId,
       String sql,
       List<SqlParameterDefinition> parameters) {
@@ -52,6 +53,7 @@ public class SqlDevelopmentRepositoryAdapter implements SqlDevelopmentRepository
     po.setName(name);
     po.setDescription(description);
     po.setProjectId(projectId);
+    po.setDirectoryId(directoryId);
     po.setDataSourceId(dataSourceId);
     po.setSqlText(sql);
     po.setParameterJson(jsonCodec.write(parameters));
@@ -84,6 +86,7 @@ public class SqlDevelopmentRepositoryAdapter implements SqlDevelopmentRepository
       String name,
       String description,
       Long projectId,
+      Long directoryId,
       Long dataSourceId,
       String sql,
       List<SqlParameterDefinition> parameters) {
@@ -95,6 +98,7 @@ public class SqlDevelopmentRepositoryAdapter implements SqlDevelopmentRepository
                 .set(SqlTaskPO::getName, name)
                 .set(SqlTaskPO::getDescription, description)
                 .set(SqlTaskPO::getProjectId, projectId)
+                .set(SqlTaskPO::getDirectoryId, directoryId)
                 .set(SqlTaskPO::getDataSourceId, dataSourceId)
                 .set(SqlTaskPO::getSqlText, sql)
                 .set(SqlTaskPO::getParameterJson, jsonCodec.write(parameters))
@@ -265,6 +269,7 @@ public class SqlDevelopmentRepositoryAdapter implements SqlDevelopmentRepository
         po.getName(),
         po.getDescription(),
         po.getProjectId(),
+        po.getDirectoryId(),
         po.getDataSourceId(),
         po.getSqlText(),
         jsonCodec.readParameters(po.getParameterJson()),

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentDirectoryService.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentDirectoryService.java
@@ -1,0 +1,129 @@
+package io.yak.ops.business.development.service;
+
+import io.yak.ops.business.development.domain.DevelopmentDirectory;
+import io.yak.ops.business.development.repository.DevelopmentDirectoryRepository;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/** Application service for project-scoped hierarchical data-development directories. */
+@Service
+public class DevelopmentDirectoryService {
+
+  private final DevelopmentDirectoryRepository repository;
+
+  public DevelopmentDirectoryService(DevelopmentDirectoryRepository repository) {
+    this.repository = repository;
+  }
+
+  public List<DevelopmentDirectory> list(Long projectId) {
+    long normalizedProjectId = requirePositive(projectId, "项目 ID");
+    List<DevelopmentDirectory> directories = repository.listByProjectId(normalizedProjectId);
+    Map<Long, DevelopmentDirectory> byId = new HashMap<>();
+    directories.forEach(directory -> byId.put(directory.id(), directory));
+    Map<Long, String> pathCache = new HashMap<>();
+
+    return directories.stream()
+        .map(directory -> withPath(
+            directory,
+            resolvePath(directory, byId, pathCache, new HashSet<>())))
+        .sorted(Comparator.comparing(DevelopmentDirectory::path, String.CASE_INSENSITIVE_ORDER))
+        .toList();
+  }
+
+  @Transactional(transactionManager = "yakBusinessTransactionManager", rollbackFor = Exception.class)
+  public DevelopmentDirectory create(Long projectId, Long parentId, String name) {
+    long normalizedProjectId = requirePositive(projectId, "项目 ID");
+    Long normalizedParentId = normalizeParentId(parentId);
+    String normalizedName = normalizeName(name);
+
+    if (normalizedParentId != null) {
+      DevelopmentDirectory parent = repository.findById(normalizedParentId)
+          .orElseThrow(() -> new IllegalArgumentException("父目录不存在：" + normalizedParentId));
+      if (!normalizedProjectIdEquals(parent.projectId(), normalizedProjectId)) {
+        throw new IllegalArgumentException("父目录不属于当前项目：" + normalizedParentId);
+      }
+    }
+
+    if (repository.existsByName(normalizedProjectId, normalizedParentId, normalizedName)) {
+      throw new IllegalStateException("当前路径下已存在同名目录：" + normalizedName);
+    }
+
+    DevelopmentDirectory created = repository.insert(
+        normalizedProjectId,
+        normalizedParentId,
+        normalizedName);
+    return list(normalizedProjectId).stream()
+        .filter(directory -> directory.id().equals(created.id()))
+        .findFirst()
+        .orElseThrow(() -> new IllegalStateException("目录创建成功但无法重新读取：" + created.id()));
+  }
+
+  private DevelopmentDirectory withPath(DevelopmentDirectory directory, String path) {
+    return new DevelopmentDirectory(
+        directory.id(),
+        directory.projectId(),
+        directory.parentId(),
+        directory.name(),
+        path,
+        directory.createTime(),
+        directory.updateTime());
+  }
+
+  private String resolvePath(
+      DevelopmentDirectory directory,
+      Map<Long, DevelopmentDirectory> byId,
+      Map<Long, String> pathCache,
+      Set<Long> visiting) {
+    String cached = pathCache.get(directory.id());
+    if (cached != null) return cached;
+    if (!visiting.add(directory.id())) {
+      throw new IllegalStateException("数据开发目录存在循环引用：" + directory.id());
+    }
+
+    String path;
+    if (directory.parentId() == null) {
+      path = "/" + directory.name();
+    } else {
+      DevelopmentDirectory parent = byId.get(directory.parentId());
+      if (parent == null) {
+        throw new IllegalStateException(
+            "数据开发目录父节点不存在：" + directory.id() + " -> " + directory.parentId());
+      }
+      path = resolvePath(parent, byId, pathCache, visiting) + "/" + directory.name();
+    }
+
+    visiting.remove(directory.id());
+    pathCache.put(directory.id(), path);
+    return path;
+  }
+
+  private Long normalizeParentId(Long parentId) {
+    return parentId == null || parentId <= 0L ? null : parentId;
+  }
+
+  private String normalizeName(String name) {
+    if (name == null || name.isBlank()) throw new IllegalArgumentException("目录名称不能为空");
+    String normalized = name.trim();
+    if (normalized.length() > 128) throw new IllegalArgumentException("目录名称不能超过 128 个字符");
+    if (".".equals(normalized) || "..".equals(normalized)
+        || normalized.contains("/") || normalized.contains("\\")) {
+      throw new IllegalArgumentException("目录名称不能包含 /、\\，也不能使用 . 或 ..");
+    }
+    return normalized;
+  }
+
+  private long requirePositive(Long value, String name) {
+    if (value == null || value <= 0L) throw new IllegalArgumentException(name + "不合法：" + value);
+    return value;
+  }
+
+  private boolean normalizedProjectIdEquals(Long value, long expected) {
+    return value != null && value == expected;
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/SqlDevelopmentService.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/SqlDevelopmentService.java
@@ -1,12 +1,14 @@
 package io.yak.ops.business.development.service;
 
 import io.yak.ops.business.datasource.repository.DataSourceRepository;
+import io.yak.ops.business.development.domain.DevelopmentDirectory;
 import io.yak.ops.business.development.domain.SqlDevelopmentModel.Definition;
 import io.yak.ops.business.development.domain.SqlDevelopmentModel.Execution;
 import io.yak.ops.business.development.domain.SqlDevelopmentModel.Version;
 import io.yak.ops.business.development.domain.SqlParameterDefinition;
 import io.yak.ops.business.development.domain.SqlTaskSnapshot;
 import io.yak.ops.business.development.execution.NamedSqlParameterParser;
+import io.yak.ops.business.development.repository.DevelopmentDirectoryRepository;
 import io.yak.ops.business.development.repository.SqlDevelopmentRepository;
 import io.yak.ops.business.development.support.SqlDevelopmentJsonCodec;
 import io.yak.ops.business.job.task.TaskExecution;
@@ -16,6 +18,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import org.springframework.stereotype.Service;
@@ -29,16 +32,19 @@ public class SqlDevelopmentService {
       "STRING", "INTEGER", "LONG", "DOUBLE", "DECIMAL", "BOOLEAN", "DATE", "TIMESTAMP");
 
   private final SqlDevelopmentRepository repository;
+  private final DevelopmentDirectoryRepository directoryRepository;
   private final DataSourceRepository dataSourceRepository;
   private final SqlDevelopmentJsonCodec jsonCodec;
   private final TaskExecutionGateway executionGateway;
 
   public SqlDevelopmentService(
       SqlDevelopmentRepository repository,
+      DevelopmentDirectoryRepository directoryRepository,
       DataSourceRepository dataSourceRepository,
       SqlDevelopmentJsonCodec jsonCodec,
       TaskExecutionGateway executionGateway) {
     this.repository = repository;
+    this.directoryRepository = directoryRepository;
     this.dataSourceRepository = dataSourceRepository;
     this.jsonCodec = jsonCodec;
     this.executionGateway = executionGateway;
@@ -49,15 +55,18 @@ public class SqlDevelopmentService {
       String name,
       String description,
       Long projectId,
+      Long directoryId,
       Long dataSourceId,
       String sql,
       List<SqlParameterDefinition> parameters) {
     Long normalizedProjectId = normalizeProjectId(projectId);
+    Long normalizedDirectoryId = normalizeDirectoryAssignment(normalizedProjectId, directoryId);
     List<SqlParameterDefinition> normalized = validate(dataSourceId, sql, parameters);
     return repository.insertDefinition(
         requireText(name, "任务名称"),
         trimToNull(description),
         normalizedProjectId,
+        normalizedDirectoryId,
         dataSourceId,
         sql.trim(),
         normalized);
@@ -83,11 +92,21 @@ public class SqlDevelopmentService {
       String name,
       String description,
       Long projectId,
+      Long directoryId,
       Long dataSourceId,
       String sql,
       List<SqlParameterDefinition> parameters) {
     Definition current = requireDefinition(id);
     Long normalizedProjectId = projectId == null ? current.projectId() : normalizeProjectId(projectId);
+    Long normalizedDirectoryId;
+    if (directoryId == null) {
+      normalizedDirectoryId = Objects.equals(normalizedProjectId, current.projectId())
+          ? current.directoryId()
+          : null;
+    } else {
+      normalizedDirectoryId = normalizeDirectoryAssignment(normalizedProjectId, directoryId);
+    }
+
     List<SqlParameterDefinition> normalized = validate(dataSourceId, sql, parameters);
     boolean updated = repository.updateDraft(
         id,
@@ -95,6 +114,7 @@ public class SqlDevelopmentService {
         requireText(name, "任务名称"),
         trimToNull(description),
         normalizedProjectId,
+        normalizedDirectoryId,
         dataSourceId,
         sql.trim(),
         normalized);
@@ -171,6 +191,19 @@ public class SqlDevelopmentService {
       executionGateway.cancel("SQL", String.valueOf(executionId));
     }
     return execution(executionId);
+  }
+
+  private Long normalizeDirectoryAssignment(Long projectId, Long directoryId) {
+    if (directoryId == null || directoryId <= 0L) return null;
+    if (projectId == null) {
+      throw new IllegalArgumentException("设置目录前必须先选择所属项目");
+    }
+    DevelopmentDirectory directory = directoryRepository.findById(directoryId)
+        .orElseThrow(() -> new IllegalArgumentException("数据开发目录不存在：" + directoryId));
+    if (!Objects.equals(directory.projectId(), projectId)) {
+      throw new IllegalArgumentException("数据开发目录不属于当前项目：" + directoryId);
+    }
+    return directoryId;
   }
 
   private List<SqlParameterDefinition> validate(

--- a/yak-ops-business/yak-ops-business-data-development/src/main/resources/db/migration/yak-data-development/V3__add_development_directories.sql
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/resources/db/migration/yak-data-development/V3__add_development_directories.sql
@@ -1,0 +1,15 @@
+CREATE TABLE IF NOT EXISTS yak_dev_directory (
+    id BIGINT NOT NULL,
+    project_id BIGINT NOT NULL,
+    parent_id BIGINT NOT NULL DEFAULT 0,
+    name VARCHAR(128) NOT NULL,
+    create_time DATETIME(6) NOT NULL,
+    update_time DATETIME(6) NOT NULL,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_yak_dev_directory_sibling (project_id, parent_id, name),
+    KEY idx_yak_dev_directory_project_parent (project_id, parent_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+ALTER TABLE yak_dev_sql_task
+    ADD COLUMN directory_id BIGINT NULL AFTER project_id,
+    ADD KEY idx_yak_dev_sql_task_directory (directory_id);

--- a/yak-ops-business/yak-ops-business-data-development/src/main/resources/mapper/development/SqlTaskMapper.xml
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/resources/mapper/development/SqlTaskMapper.xml
@@ -8,6 +8,7 @@
                name,
                description,
                project_id,
+               directory_id,
                data_source_id,
                sql_text,
                parameter_json,

--- a/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/DevelopmentDirectoryServiceTest.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/DevelopmentDirectoryServiceTest.java
@@ -1,0 +1,89 @@
+package io.yak.ops.business.development.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import io.yak.ops.business.development.domain.DevelopmentDirectory;
+import io.yak.ops.business.development.repository.DevelopmentDirectoryRepository;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
+import org.junit.jupiter.api.Test;
+
+class DevelopmentDirectoryServiceTest {
+
+  @Test
+  void createsNestedDirectoryPaths() {
+    InMemoryDirectoryRepository repository = new InMemoryDirectoryRepository();
+    DevelopmentDirectoryService service = new DevelopmentDirectoryService(repository);
+
+    DevelopmentDirectory ods = service.create(1L, null, "ODS");
+    DevelopmentDirectory user = service.create(1L, ods.id(), "用户域");
+
+    assertEquals("/ODS", ods.path());
+    assertEquals("/ODS/用户域", user.path());
+    assertEquals(
+        List.of("/ODS", "/ODS/用户域"),
+        service.list(1L).stream().map(DevelopmentDirectory::path).toList());
+  }
+
+  @Test
+  void rejectsParentDirectoryFromAnotherProject() {
+    InMemoryDirectoryRepository repository = new InMemoryDirectoryRepository();
+    DevelopmentDirectoryService service = new DevelopmentDirectoryService(repository);
+    DevelopmentDirectory otherProject = service.create(2L, null, "ODS");
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> service.create(1L, otherProject.id(), "非法子目录"));
+  }
+
+  private static final class InMemoryDirectoryRepository
+      implements DevelopmentDirectoryRepository {
+
+    private final AtomicLong ids = new AtomicLong(1L);
+    private final Map<Long, DevelopmentDirectory> values = new LinkedHashMap<>();
+
+    @Override
+    public DevelopmentDirectory insert(Long projectId, Long parentId, String name) {
+      Long id = ids.getAndIncrement();
+      Instant now = Instant.now();
+      DevelopmentDirectory directory = new DevelopmentDirectory(
+          id,
+          projectId,
+          parentId,
+          name,
+          null,
+          now,
+          now);
+      values.put(id, directory);
+      return directory;
+    }
+
+    @Override
+    public Optional<DevelopmentDirectory> findById(Long id) {
+      return Optional.ofNullable(values.get(id));
+    }
+
+    @Override
+    public List<DevelopmentDirectory> listByProjectId(Long projectId) {
+      List<DevelopmentDirectory> result = new ArrayList<>();
+      values.values().stream()
+          .filter(directory -> projectId.equals(directory.projectId()))
+          .forEach(result::add);
+      return result;
+    }
+
+    @Override
+    public boolean existsByName(Long projectId, Long parentId, String name) {
+      return values.values().stream().anyMatch(directory ->
+          projectId.equals(directory.projectId())
+              && java.util.Objects.equals(parentId, directory.parentId())
+              && name.equals(directory.name()));
+    }
+  }
+}

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/development/DevelopmentDirectoryPO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/development/DevelopmentDirectoryPO.java
@@ -1,0 +1,20 @@
+package io.yak.ops.common.bean.po.development;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import java.time.Instant;
+import lombok.Data;
+
+/** 数据开发目录持久化对象。 */
+@Data
+@TableName("yak_dev_directory")
+public class DevelopmentDirectoryPO {
+  @TableId(type = IdType.ASSIGN_ID)
+  private Long id;
+  private Long projectId;
+  private Long parentId;
+  private String name;
+  private Instant createTime;
+  private Instant updateTime;
+}

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/development/SqlTaskPO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/development/SqlTaskPO.java
@@ -16,6 +16,7 @@ public class SqlTaskPO {
   private String name;
   private String description;
   private Long projectId;
+  private Long directoryId;
   private Long dataSourceId;
   private String sqlText;
   private String parameterJson;

--- a/yak-ops-ui/src/pages/data-development/components/CreateDirectoryModal.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/CreateDirectoryModal.tsx
@@ -1,0 +1,112 @@
+import { Input, Modal, Select, Typography } from 'antd';
+import { useEffect, useMemo, useState } from 'react';
+
+import type { DevelopmentDirectory } from '../types';
+
+interface CreateDirectoryModalProps {
+  open: boolean;
+  projectName?: string;
+  directories: DevelopmentDirectory[];
+  defaultParentId?: number;
+  loading?: boolean;
+  onCancel: () => void;
+  onSubmit: (parentId: number | undefined, name: string) => void;
+}
+
+const CreateDirectoryModal = ({
+  open,
+  projectName,
+  directories,
+  defaultParentId,
+  loading = false,
+  onCancel,
+  onSubmit,
+}: CreateDirectoryModalProps) => {
+  const [parentId, setParentId] = useState<number>();
+  const [name, setName] = useState('');
+
+  const pathOptions = useMemo(
+    () => [
+      { label: '/', value: 0 },
+      ...directories.map((directory) => ({
+        label: directory.path,
+        value: Number(directory.id),
+      })),
+    ],
+    [directories],
+  );
+
+  useEffect(() => {
+    if (!open) return;
+    setParentId(defaultParentId);
+    setName('');
+  }, [defaultParentId, open]);
+
+  const normalizedName = name.trim();
+
+  return (
+    <Modal
+      open={open}
+      title="新建目录"
+      width={600}
+      okText="确认"
+      cancelText="取消"
+      confirmLoading={loading}
+      okButtonProps={{ disabled: !normalizedName }}
+      destroyOnClose
+      maskClosable={!loading}
+      closable={!loading}
+      onCancel={onCancel}
+      onOk={() => {
+        if (!normalizedName) return;
+        onSubmit(parentId && parentId > 0 ? parentId : undefined, normalizedName);
+      }}
+    >
+      <div className="pt-2">
+        {projectName ? (
+          <div className="mb-4 rounded-lg bg-[#fafafa] px-3 py-2 text-[12px] text-[rgba(22,24,35,.55)]">
+            当前项目：
+            <span className="font-medium text-[#344054]">{projectName}</span>
+          </div>
+        ) : null}
+
+        <div className="grid grid-cols-[88px_minmax(0,1fr)] items-center gap-y-3">
+          <Typography.Text className="text-[13px] text-[#344054]">
+            <span className="mr-1 text-[rgba(254,44,85,1)]">*</span>
+            路径：
+          </Typography.Text>
+          <Select
+            value={parentId ?? 0}
+            options={pathOptions}
+            showSearch
+            optionFilterProp="label"
+            className="w-full"
+            onChange={(value) => setParentId(Number(value) || undefined)}
+          />
+
+          <Typography.Text className="text-[13px] text-[#344054]">
+            <span className="mr-1 text-[rgba(254,44,85,1)]">*</span>
+            名称：
+          </Typography.Text>
+          <Input
+            autoFocus
+            value={name}
+            maxLength={128}
+            placeholder="名称"
+            onChange={(event) => setName(event.target.value)}
+            onPressEnter={() => {
+              if (normalizedName && !loading) {
+                onSubmit(
+                  parentId && parentId > 0 ? parentId : undefined,
+                  normalizedName,
+                );
+              }
+            }}
+          />
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default CreateDirectoryModal;

--- a/yak-ops-ui/src/pages/data-development/components/DevelopmentTreePane.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/DevelopmentTreePane.tsx
@@ -1,0 +1,306 @@
+import type { DataNode } from 'antd/es/tree';
+import type { TreeProps } from 'antd';
+import { Button, Empty, Spin, Tooltip, Tree } from 'antd';
+import {
+  ChevronDown,
+  ChevronLeft,
+  ChevronRight,
+  Folder,
+  FolderOpen,
+  FolderPlus,
+  Layers3,
+  Workflow,
+} from 'lucide-react';
+import type { PointerEvent as ReactPointerEvent } from 'react';
+
+export type DevelopmentTreeNodeType =
+  | 'all'
+  | 'project'
+  | 'directory'
+  | 'unassigned';
+
+export interface DevelopmentTreeNode extends DataNode {
+  key: string;
+  title: string;
+  nodeType: DevelopmentTreeNodeType;
+  projectId?: number;
+  directoryId?: number;
+  count?: number;
+  children?: DevelopmentTreeNode[];
+}
+
+interface DevelopmentTreePaneProps {
+  treeData: DevelopmentTreeNode[];
+  treeLoading: boolean;
+  selectedNodeKey?: string;
+  leftWidth: number;
+  collapsed: boolean;
+  createDisabled?: boolean;
+  onCreateDirectory: () => void;
+  onSelect: TreeProps['onSelect'];
+  onResizeStart: (event: ReactPointerEvent) => void;
+  onCollapsedChange: (collapsed: boolean) => void;
+}
+
+const DevelopmentTreePane = ({
+  treeData,
+  treeLoading,
+  selectedNodeKey,
+  leftWidth,
+  collapsed,
+  createDisabled = false,
+  onCreateDirectory,
+  onSelect,
+  onResizeStart,
+  onCollapsedChange,
+}: DevelopmentTreePaneProps) => {
+  const renderTitle: TreeProps['titleRender'] = (rawNode) => {
+    const node = rawNode as DevelopmentTreeNode;
+    const isDirectory = node.nodeType === 'directory';
+    const isProject = node.nodeType === 'project';
+    const isAll = node.nodeType === 'all';
+
+    return (
+      <div
+        className="flex min-w-0 flex-1 items-center gap-2"
+        title={node.title}
+      >
+        {isProject ? (
+          <Workflow
+            size={14}
+            strokeWidth={2}
+            className="shrink-0 text-[#ff7a00]"
+          />
+        ) : isDirectory ? (
+          <Folder
+            size={14}
+            strokeWidth={1.8}
+            className="shrink-0 text-[#98a2b3]"
+          />
+        ) : isAll ? (
+          <Layers3
+            size={14}
+            strokeWidth={1.8}
+            className="shrink-0 text-[#667085]"
+          />
+        ) : (
+          <FolderOpen
+            size={14}
+            strokeWidth={1.8}
+            className="shrink-0 text-[#98a2b3]"
+          />
+        )}
+
+        <span
+          className={[
+            'min-w-0 flex-1 truncate text-[13px] leading-8',
+            isProject
+              ? 'font-medium text-[#1f2937]'
+              : 'font-normal text-[#344054]',
+          ].join(' ')}
+        >
+          {node.title}
+        </span>
+
+        {typeof node.count === 'number' ? (
+          <span className="shrink-0 text-[10px] text-[rgba(22,24,35,.3)]">
+            {node.count}
+          </span>
+        ) : null}
+      </div>
+    );
+  };
+
+  return (
+    <>
+      <aside
+        className={[
+          'group relative shrink-0 overflow-hidden bg-white',
+          'transition-[width] duration-200 ease-out',
+        ].join(' ')}
+        style={{ width: collapsed ? 0 : leftWidth }}
+      >
+        <div
+          className="flex h-full flex-col overflow-hidden py-3"
+          style={{ width: leftWidth }}
+        >
+          <div className="flex h-8 items-center justify-between px-[14px]">
+            <div className="text-[13px] font-semibold text-[#161823]">
+              开发目录
+            </div>
+            <Tooltip
+              title={createDisabled ? '请先选择一个项目' : '新建目录'}
+              placement="right"
+            >
+              <span>
+                <Button
+                  type="text"
+                  size="small"
+                  disabled={createDisabled}
+                  icon={<FolderPlus size={15} strokeWidth={1.8} />}
+                  className="!flex !h-7 !w-7 !items-center !justify-center !p-0"
+                  onClick={onCreateDirectory}
+                />
+              </span>
+            </Tooltip>
+          </div>
+
+          <div className="mt-1 min-h-0 flex-1 overflow-y-auto px-[14px]">
+            <Spin
+              spinning={treeLoading}
+              wrapperClassName="block min-h-full"
+            >
+              {treeData.length ? (
+                <Tree
+                  blockNode
+                  defaultExpandAll
+                  selectedKeys={
+                    selectedNodeKey ? [selectedNodeKey] : []
+                  }
+                  treeData={treeData}
+                  titleRender={renderTitle}
+                  switcherIcon={
+                    <ChevronDown size={12} strokeWidth={1.8} />
+                  }
+                  onSelect={onSelect}
+                  className="development-tree bg-transparent"
+                />
+              ) : (
+                <Empty
+                  image={Empty.PRESENTED_IMAGE_SIMPLE}
+                  description="暂无开发目录"
+                  className="mt-10"
+                />
+              )}
+            </Spin>
+          </div>
+        </div>
+      </aside>
+
+      <div
+        role="separator"
+        aria-label="调整开发目录面板宽度"
+        aria-orientation="vertical"
+        onPointerDown={collapsed ? undefined : onResizeStart}
+        className={[
+          'group relative z-20 w-3 shrink-0 touch-none',
+          collapsed ? 'cursor-default' : 'cursor-col-resize',
+        ].join(' ')}
+      >
+        <div
+          className={[
+            'pointer-events-none absolute inset-y-0 left-1/2',
+            'w-px -translate-x-1/2 bg-[#dfe3e8]',
+            'transition-[width,background-color] duration-150',
+            !collapsed
+              ? 'group-hover:w-[2px] group-hover:bg-[rgba(254,44,85,.55)] group-active:bg-[rgba(254,44,85,1)]'
+              : '',
+          ].join(' ')}
+        />
+
+        <button
+          type="button"
+          aria-label={collapsed ? '展开开发目录面板' : '收起开发目录面板'}
+          onPointerDown={(event) => event.stopPropagation()}
+          onClick={() => onCollapsedChange(!collapsed)}
+          className={[
+            'absolute left-1/2 top-1/2 z-20',
+            'flex h-8 w-4 -translate-x-1/2 -translate-y-1/2',
+            'items-center justify-center rounded-[3px]',
+            'border border-[#dfe3e8] bg-white text-[#7b808a]',
+            'shadow-[0_1px_2px_rgba(16,24,40,0.05)]',
+            'transition-[color,border-color,box-shadow] duration-150',
+            'hover:border-[#cfd4dc] hover:text-[#344054]',
+            'focus:outline-none focus-visible:ring-2',
+            'focus-visible:ring-[rgba(254,44,85,.16)]',
+          ].join(' ')}
+        >
+          {collapsed ? (
+            <ChevronRight size={12} />
+          ) : (
+            <ChevronLeft size={12} />
+          )}
+        </button>
+      </div>
+
+      <style>{`
+        .development-tree.ant-tree {
+          color: #344054;
+        }
+
+        .development-tree .ant-tree-list-holder-inner {
+          gap: 2px;
+        }
+
+        .development-tree .ant-tree-treenode {
+          box-sizing: border-box;
+          width: 100%;
+          min-height: 32px;
+          padding: 0 8px !important;
+          align-items: center;
+          border-radius: 0;
+          transition: background-color 0.15s ease;
+        }
+
+        .development-tree .ant-tree-treenode:hover,
+        .development-tree
+          .ant-tree-treenode:has(.ant-tree-node-selected) {
+          background: #f5f5f5;
+        }
+
+        .development-tree .ant-tree-node-content-wrapper {
+          display: flex;
+          min-width: 0;
+          height: 32px;
+          flex: 1;
+          align-items: center;
+          padding: 0 !important;
+          border-radius: 0 !important;
+          background: transparent !important;
+          line-height: 32px;
+        }
+
+        .development-tree
+          .ant-tree-node-content-wrapper.ant-tree-node-selected {
+          color: #1f2937;
+          background: transparent !important;
+        }
+
+        .development-tree .ant-tree-title {
+          display: flex;
+          min-width: 0;
+          flex: 1;
+        }
+
+        .development-tree .ant-tree-indent-unit {
+          width: 22px;
+        }
+
+        .development-tree .ant-tree-switcher {
+          display: inline-flex;
+          width: 20px;
+          height: 32px;
+          flex: none;
+          align-items: center;
+          justify-content: center;
+          color: #98a2b3;
+          line-height: 32px;
+        }
+
+        .development-tree .ant-tree-switcher svg {
+          transition: transform 0.15s ease;
+        }
+
+        .development-tree .ant-tree-switcher_close svg {
+          transform: rotate(-90deg);
+        }
+
+        .development-tree .ant-tree-switcher-noop {
+          width: 20px;
+        }
+      `}</style>
+    </>
+  );
+};
+
+export default DevelopmentTreePane;

--- a/yak-ops-ui/src/pages/data-development/index.tsx
+++ b/yak-ops-ui/src/pages/data-development/index.tsx
@@ -11,55 +11,118 @@ import {
   Spin,
   Table,
   Tag,
-  Tree,
   Typography,
   message,
 } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
 import dayjs from 'dayjs';
-import {
-  Folder,
-  FolderOpen,
-  Plus,
-  RefreshCw,
-  Search,
-} from 'lucide-react';
+import { Plus, RefreshCw, Search } from 'lucide-react';
+import type { PointerEvent as ReactPointerEvent } from 'react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
+import CreateDirectoryModal from './components/CreateDirectoryModal';
 import CreateTaskModal from './components/CreateTaskModal';
-import { listSqlTasks } from './service';
+import DevelopmentTreePane, {
+  type DevelopmentTreeNode,
+} from './components/DevelopmentTreePane';
+import {
+  createDevelopmentDirectory,
+  listDevelopmentDirectories,
+  listSqlTasks,
+} from './service';
 import type {
+  DevelopmentDirectory,
   DevelopmentTaskRow,
   DevelopmentTaskType,
 } from './types';
 
-type ProjectFilterKey = 'all' | 'unassigned' | `project:${number}`;
+type TreeFilterKey =
+  | 'all'
+  | 'unassigned'
+  | `project:${number}`
+  | `root:${number}`
+  | `directory:${number}`;
 type PublishFilter = 'ALL' | 'DRAFT' | 'PUBLISHED';
 
-const projectKey = (projectId: number): ProjectFilterKey =>
-  `project:${projectId}`;
+const DEFAULT_LEFT_WIDTH = 252;
+const MIN_LEFT_WIDTH = 210;
+const MAX_LEFT_WIDTH = 420;
+const LEFT_WIDTH_STORAGE_KEY = 'yak-data-development.left-width';
 
-const projectIdFromKey = (key: ProjectFilterKey): number | undefined => {
-  if (!key.startsWith('project:')) return undefined;
-  const value = Number(key.substring('project:'.length));
+const projectKey = (projectId: number): TreeFilterKey =>
+  `project:${projectId}`;
+const rootKey = (projectId: number): TreeFilterKey =>
+  `root:${projectId}`;
+const directoryKey = (directoryId: number): TreeFilterKey =>
+  `directory:${directoryId}`;
+
+const numberFromKey = (key: string, prefix: string) => {
+  if (!key.startsWith(prefix)) return undefined;
+  const value = Number(key.substring(prefix.length));
   return Number.isFinite(value) && value > 0 ? value : undefined;
+};
+
+const clampLeftWidth = (value: number) =>
+  Math.min(MAX_LEFT_WIDTH, Math.max(MIN_LEFT_WIDTH, value));
+
+const initialLeftWidth = () => {
+  if (typeof window === 'undefined') return DEFAULT_LEFT_WIDTH;
+  const stored = Number(window.localStorage.getItem(LEFT_WIDTH_STORAGE_KEY));
+  return Number.isFinite(stored) && stored > 0
+    ? clampLeftWidth(stored)
+    : DEFAULT_LEFT_WIDTH;
 };
 
 const formatTime = (value?: string) =>
   value ? dayjs(value).format('YYYY-MM-DD HH:mm:ss') : '-';
 
+const responseData = <T,>(
+  response: { code?: number; data?: T; msg?: string; message?: string },
+  fallback: string,
+): T => {
+  if (response?.code !== API_SUCCESS_CODE || response.data === undefined) {
+    throw new Error(response?.message || response?.msg || fallback);
+  }
+  return response.data;
+};
+
 export default function DataDevelopmentPage() {
   const { projects, currentProject } = useSecurityProject();
   const [tasks, setTasks] = useState<DevelopmentTaskRow[]>([]);
+  const [directories, setDirectories] = useState<DevelopmentDirectory[]>([]);
   const [dataSources, setDataSources] = useState<DataSourceRecord[]>([]);
   const [loading, setLoading] = useState(false);
+  const [treeLoading, setTreeLoading] = useState(false);
   const [createOpen, setCreateOpen] = useState(false);
+  const [directoryOpen, setDirectoryOpen] = useState(false);
+  const [directorySaving, setDirectorySaving] = useState(false);
   const [keyword, setKeyword] = useState('');
   const [typeFilter, setTypeFilter] = useState<'ALL' | DevelopmentTaskType>('ALL');
   const [publishFilter, setPublishFilter] = useState<PublishFilter>('ALL');
-  const [selectedProject, setSelectedProject] = useState<ProjectFilterKey>(() =>
+  const [selectedNode, setSelectedNode] = useState<TreeFilterKey>(() =>
     currentProject?.id ? projectKey(Number(currentProject.id)) : 'all',
   );
+  const [leftWidth, setLeftWidth] = useState(initialLeftWidth);
+  const [leftCollapsed, setLeftCollapsed] = useState(false);
+
+  const loadDirectories = useCallback(async () => {
+    setTreeLoading(true);
+    try {
+      const responses = await Promise.all(
+        projects.map(async (project) => {
+          const projectId = Number(project.id);
+          const response = await listDevelopmentDirectories(projectId);
+          return responseData(response, `查询项目“${project.projectName}”目录失败`);
+        }),
+      );
+      setDirectories(responses.flat());
+    } catch (error) {
+      message.error(error instanceof Error ? error.message : '查询数据开发目录失败');
+      setDirectories([]);
+    } finally {
+      setTreeLoading(false);
+    }
+  }, [projects]);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -68,21 +131,15 @@ export default function DataDevelopmentPage() {
         listSqlTasks(),
         fetchDataSourceAll(),
       ]);
-      if (taskResponse?.code !== API_SUCCESS_CODE) {
-        throw new Error(taskResponse?.message || taskResponse?.msg || '查询数据开发任务失败');
-      }
-      if (dataSourceResponse?.code !== API_SUCCESS_CODE) {
-        throw new Error(
-          dataSourceResponse?.message || dataSourceResponse?.msg || '查询数据源失败',
-        );
-      }
+      const taskList = responseData(taskResponse, '查询数据开发任务失败');
+      const sourceResult = responseData(dataSourceResponse, '查询数据源失败');
       setTasks(
-        (taskResponse.data || []).map((task) => ({
+        (taskList || []).map((task) => ({
           ...task,
           type: 'SQL' as const,
         })),
       );
-      setDataSources(dataSourceResponse.data?.bizData || []);
+      setDataSources(sourceResult?.bizData || []);
     } catch (error) {
       message.error(error instanceof Error ? error.message : '查询数据开发任务失败');
     } finally {
@@ -94,6 +151,10 @@ export default function DataDevelopmentPage() {
     void load();
   }, [load]);
 
+  useEffect(() => {
+    void loadDirectories();
+  }, [loadDirectories]);
+
   const projectNameMap = useMemo(
     () => new Map(projects.map((project) => [Number(project.id), project.projectName])),
     [projects],
@@ -102,92 +163,147 @@ export default function DataDevelopmentPage() {
     () => new Map(dataSources.map((item) => [Number(item.id), item])),
     [dataSources],
   );
+  const directoryMap = useMemo(
+    () => new Map(directories.map((directory) => [Number(directory.id), directory])),
+    [directories],
+  );
+
+  const projectIdForSelection = useMemo(() => {
+    const projectId = numberFromKey(selectedNode, 'project:')
+      ?? numberFromKey(selectedNode, 'root:');
+    if (projectId) return projectId;
+    const directoryId = numberFromKey(selectedNode, 'directory:');
+    return directoryId ? directoryMap.get(directoryId)?.projectId : undefined;
+  }, [directoryMap, selectedNode]);
+
+  const directoryIdForSelection = useMemo(
+    () => numberFromKey(selectedNode, 'directory:'),
+    [selectedNode],
+  );
+
+  const projectDirectories = useMemo(
+    () => projectIdForSelection
+      ? directories.filter((directory) => directory.projectId === projectIdForSelection)
+      : [],
+    [directories, projectIdForSelection],
+  );
 
   const counts = useMemo(() => {
     const byProject = new Map<number, number>();
+    const byDirectory = new Map<number, number>();
+    const rootByProject = new Map<number, number>();
     let unassigned = 0;
+
     tasks.forEach((task) => {
       if (!task.projectId) {
         unassigned += 1;
         return;
       }
-      byProject.set(task.projectId, (byProject.get(task.projectId) || 0) + 1);
+      const projectId = Number(task.projectId);
+      byProject.set(projectId, (byProject.get(projectId) || 0) + 1);
+      if (task.directoryId) {
+        const directoryId = Number(task.directoryId);
+        byDirectory.set(directoryId, (byDirectory.get(directoryId) || 0) + 1);
+      } else {
+        rootByProject.set(projectId, (rootByProject.get(projectId) || 0) + 1);
+      }
     });
-    return { byProject, unassigned };
+
+    return { byProject, byDirectory, rootByProject, unassigned };
   }, [tasks]);
 
-  const treeData = useMemo(
-    () => [
+  const treeData = useMemo<DevelopmentTreeNode[]>(() => {
+    const buildDirectoryChildren = (
+      projectId: number,
+      parentId?: number,
+    ): DevelopmentTreeNode[] =>
+      directories
+        .filter(
+          (directory) =>
+            directory.projectId === projectId
+            && (directory.parentId ?? undefined) === parentId,
+        )
+        .sort((left, right) => left.name.localeCompare(right.name, 'zh-CN'))
+        .map((directory) => ({
+          key: directoryKey(Number(directory.id)),
+          title: directory.name,
+          nodeType: 'directory',
+          projectId,
+          directoryId: Number(directory.id),
+          count: counts.byDirectory.get(Number(directory.id)) || 0,
+          children: buildDirectoryChildren(projectId, Number(directory.id)),
+        }));
+
+    const projectNodes: DevelopmentTreeNode[] = projects.map((project) => {
+      const projectId = Number(project.id);
+      return {
+        key: projectKey(projectId),
+        title: project.projectName,
+        nodeType: 'project',
+        projectId,
+        count: counts.byProject.get(projectId) || 0,
+        children: [
+          {
+            key: rootKey(projectId),
+            title: '/',
+            nodeType: 'directory',
+            projectId,
+            count: counts.rootByProject.get(projectId) || 0,
+            children: buildDirectoryChildren(projectId),
+          },
+        ],
+      };
+    });
+
+    return [
       {
         key: 'all',
-        title: (
-          <span className="flex w-full items-center justify-between gap-3">
-            <span className="flex items-center gap-2">
-              <FolderOpen size={15} />
-              全部任务
-            </span>
-            <span className="text-[11px] text-[rgba(22,24,35,.34)]">{tasks.length}</span>
-          </span>
-        ),
+        title: '全部任务',
+        nodeType: 'all',
+        count: tasks.length,
       },
-      {
-        key: 'projects-root',
-        selectable: false,
-        title: (
-          <span className="flex items-center gap-2 text-[12px] font-medium text-[rgba(22,24,35,.5)]">
-            <Folder size={14} />
-            项目
-          </span>
-        ),
-        children: projects.map((project) => ({
-          key: projectKey(Number(project.id)),
-          title: (
-            <span className="flex w-full items-center justify-between gap-3">
-              <span className="truncate">{project.projectName}</span>
-              <span className="text-[11px] text-[rgba(22,24,35,.34)]">
-                {counts.byProject.get(Number(project.id)) || 0}
-              </span>
-            </span>
-          ),
-        })),
-      },
+      ...projectNodes,
       ...(counts.unassigned > 0
         ? [
             {
-              key: 'unassigned',
-              title: (
-                <span className="flex w-full items-center justify-between gap-3">
-                  <span className="text-[rgba(22,24,35,.55)]">未归属项目</span>
-                  <span className="text-[11px] text-[rgba(22,24,35,.34)]">
-                    {counts.unassigned}
-                  </span>
-                </span>
-              ),
+              key: 'unassigned' as const,
+              title: '未归属项目',
+              nodeType: 'unassigned' as const,
+              count: counts.unassigned,
             },
           ]
         : []),
-    ],
-    [counts, projects, tasks.length],
-  );
+    ];
+  }, [counts, directories, projects, tasks.length]);
 
   const filteredTasks = useMemo(() => {
     const normalizedKeyword = keyword.trim().toLowerCase();
-    const selectedProjectId = projectIdFromKey(selectedProject);
+    const selectedProjectId = numberFromKey(selectedNode, 'project:');
+    const selectedRootProjectId = numberFromKey(selectedNode, 'root:');
+    const selectedDirectoryId = numberFromKey(selectedNode, 'directory:');
+
     return tasks.filter((task) => {
-      if (selectedProject === 'unassigned' && task.projectId) return false;
-      if (selectedProjectId && task.projectId !== selectedProjectId) return false;
+      if (selectedNode === 'unassigned' && task.projectId) return false;
+      if (selectedProjectId && Number(task.projectId) !== selectedProjectId) return false;
+      if (
+        selectedRootProjectId
+        && (Number(task.projectId) !== selectedRootProjectId || Boolean(task.directoryId))
+      ) {
+        return false;
+      }
+      if (selectedDirectoryId && Number(task.directoryId) !== selectedDirectoryId) return false;
       if (typeFilter !== 'ALL' && task.type !== typeFilter) return false;
       if (publishFilter === 'DRAFT' && task.latestVersionNo > 0) return false;
       if (publishFilter === 'PUBLISHED' && task.latestVersionNo <= 0) return false;
       if (
-        normalizedKeyword &&
-        !`${task.name} ${task.description || ''}`.toLowerCase().includes(normalizedKeyword)
+        normalizedKeyword
+        && !`${task.name} ${task.description || ''}`.toLowerCase().includes(normalizedKeyword)
       ) {
         return false;
       }
       return true;
     });
-  }, [keyword, publishFilter, selectedProject, tasks, typeFilter]);
+  }, [keyword, publishFilter, selectedNode, tasks, typeFilter]);
 
   const openTask = (task: DevelopmentTaskRow) => {
     history.push(`/data-development/task/${task.id}`);
@@ -222,11 +338,25 @@ export default function DataDevelopmentPage() {
       ),
     },
     {
-      title: '所属项目',
+      title: '所属项目 / 目录',
       dataIndex: 'projectId',
-      width: 170,
-      render: (value?: number) =>
-        value ? projectNameMap.get(Number(value)) || `项目 ${value}` : '未归属',
+      width: 220,
+      render: (_, task) => {
+        const projectName = task.projectId
+          ? projectNameMap.get(Number(task.projectId)) || `项目 ${task.projectId}`
+          : '未归属';
+        const path = task.directoryId
+          ? directoryMap.get(Number(task.directoryId))?.path || `目录 #${task.directoryId}`
+          : '/';
+        return (
+          <div className="min-w-0">
+            <div className="truncate text-[#344054]">{projectName}</div>
+            <div className="mt-0.5 truncate text-[11px] text-[rgba(22,24,35,.38)]">
+              {path}
+            </div>
+          </div>
+        );
+      },
     },
     {
       title: '数据源',
@@ -265,33 +395,92 @@ export default function DataDevelopmentPage() {
     },
   ];
 
-  const selectedProjectId = projectIdFromKey(selectedProject);
+  const handleResizeStart = useCallback(
+    (event: ReactPointerEvent) => {
+      if (leftCollapsed) return;
+      event.preventDefault();
+      const startX = event.clientX;
+      const startWidth = leftWidth;
+      const previousCursor = document.body.style.cursor;
+      const previousUserSelect = document.body.style.userSelect;
+      document.body.style.cursor = 'col-resize';
+      document.body.style.userSelect = 'none';
+
+      const handlePointerMove = (moveEvent: PointerEvent) => {
+        setLeftWidth(clampLeftWidth(startWidth + moveEvent.clientX - startX));
+      };
+      const finish = (upEvent: PointerEvent) => {
+        const width = clampLeftWidth(startWidth + upEvent.clientX - startX);
+        setLeftWidth(width);
+        window.localStorage.setItem(LEFT_WIDTH_STORAGE_KEY, String(width));
+        document.body.style.cursor = previousCursor;
+        document.body.style.userSelect = previousUserSelect;
+        window.removeEventListener('pointermove', handlePointerMove);
+        window.removeEventListener('pointerup', finish);
+        window.removeEventListener('pointercancel', finish);
+      };
+
+      window.addEventListener('pointermove', handlePointerMove);
+      window.addEventListener('pointerup', finish);
+      window.addEventListener('pointercancel', finish);
+    },
+    [leftCollapsed, leftWidth],
+  );
+
+  const openCreateDirectory = () => {
+    if (!projectIdForSelection) {
+      message.info('请先在左侧选择一个项目或目录');
+      return;
+    }
+    setDirectoryOpen(true);
+  };
+
+  const submitDirectory = async (parentId: number | undefined, name: string) => {
+    if (!projectIdForSelection) return;
+    setDirectorySaving(true);
+    try {
+      const created = responseData(
+        await createDevelopmentDirectory({
+          projectId: projectIdForSelection,
+          parentId,
+          name,
+        }),
+        '新建目录失败',
+      );
+      await loadDirectories();
+      setDirectoryOpen(false);
+      setSelectedNode(directoryKey(Number(created.id)));
+      message.success('目录创建成功');
+    } catch (error) {
+      message.error(error instanceof Error ? error.message : '新建目录失败');
+    } finally {
+      setDirectorySaving(false);
+    }
+  };
+
+  const selectedProjectName = projectIdForSelection
+    ? projectNameMap.get(projectIdForSelection)
+    : undefined;
+  const defaultDirectoryParentId = directoryIdForSelection;
 
   return (
     <section className="m-4 overflow-hidden rounded-xl border border-[#e4e7ec] bg-white">
       <div className="flex h-[calc(100vh-80px)] min-h-[620px]">
-        <aside className="w-[228px] shrink-0 border-r border-[#e4e7ec] bg-[#fcfcfd]">
-          <div className="border-b border-[#eceef1] px-4 py-4">
-            <div className="text-[13px] font-semibold text-[#161823]">项目视图</div>
-            <div className="mt-1 text-[11px] text-[rgba(22,24,35,.4)]">
-              按项目组织数据开发任务
-            </div>
-          </div>
-          <div className="p-2">
-            <Tree
-              blockNode
-              defaultExpandAll
-              selectedKeys={[selectedProject]}
-              treeData={treeData}
-              onSelect={(keys) => {
-                const key = keys[0];
-                if (key && key !== 'projects-root') {
-                  setSelectedProject(String(key) as ProjectFilterKey);
-                }
-              }}
-            />
-          </div>
-        </aside>
+        <DevelopmentTreePane
+          treeData={treeData}
+          treeLoading={treeLoading}
+          selectedNodeKey={selectedNode}
+          leftWidth={leftWidth}
+          collapsed={leftCollapsed}
+          createDisabled={!projectIdForSelection}
+          onCreateDirectory={openCreateDirectory}
+          onResizeStart={handleResizeStart}
+          onCollapsedChange={setLeftCollapsed}
+          onSelect={(keys) => {
+            const key = keys[0];
+            if (key) setSelectedNode(String(key) as TreeFilterKey);
+          }}
+        />
 
         <main className="min-w-0 flex-1 overflow-auto">
           <div className="flex items-start justify-between gap-4 px-6 pb-4 pt-5">
@@ -344,7 +533,10 @@ export default function DataDevelopmentPage() {
             </div>
             <Button
               icon={<RefreshCw size={14} />}
-              onClick={() => void load()}
+              onClick={() => {
+                void load();
+                void loadDirectories();
+              }}
             >
               刷新
             </Button>
@@ -357,12 +549,12 @@ export default function DataDevelopmentPage() {
               pagination={{ pageSize: 15, showSizeChanger: false }}
               columns={columns}
               dataSource={filteredTasks}
-              scroll={{ x: 1120 }}
+              scroll={{ x: 1180 }}
               locale={{
                 emptyText: (
                   <Empty
                     image={Empty.PRESENTED_IMAGE_SIMPLE}
-                    description="当前项目暂无数据开发任务"
+                    description="当前目录暂无数据开发任务"
                   />
                 ),
               }}
@@ -375,16 +567,32 @@ export default function DataDevelopmentPage() {
         open={createOpen}
         projects={projects}
         defaultProjectId={
-          selectedProjectId ??
-          (currentProject?.id ? Number(currentProject.id) : undefined)
+          projectIdForSelection
+          ?? (currentProject?.id ? Number(currentProject.id) : undefined)
         }
         onCancel={() => setCreateOpen(false)}
         onNext={(type, projectId) => {
           setCreateOpen(false);
+          const directoryId =
+            projectId === projectIdForSelection && directoryIdForSelection
+              ? directoryIdForSelection
+              : 0;
           history.push(
-            `/data-development/task/new?type=${encodeURIComponent(type)}&projectId=${projectId}`,
+            `/data-development/task/new?type=${encodeURIComponent(type)}&projectId=${projectId}&directoryId=${directoryId}`,
           );
         }}
+      />
+
+      <CreateDirectoryModal
+        open={directoryOpen}
+        projectName={selectedProjectName}
+        directories={projectDirectories}
+        defaultParentId={defaultDirectoryParentId}
+        loading={directorySaving}
+        onCancel={() => {
+          if (!directorySaving) setDirectoryOpen(false);
+        }}
+        onSubmit={(parentId, name) => void submitDirectory(parentId, name)}
       />
     </section>
   );

--- a/yak-ops-ui/src/pages/data-development/service.ts
+++ b/yak-ops-ui/src/pages/data-development/service.ts
@@ -2,6 +2,8 @@ import type { ApiResponse } from '@/services/http/response';
 import HttpUtils from '@/utils/HttpUtils';
 
 import type {
+  CreateDevelopmentDirectoryPayload,
+  DevelopmentDirectory,
   SqlTaskDefinition,
   SqlTaskExecution,
   SqlTaskSavePayload,
@@ -9,7 +11,9 @@ import type {
   SqlTaskVersion,
 } from './types';
 
-const SQL_TASK_API = '/api/v1/data-development/sql-tasks';
+const DATA_DEVELOPMENT_API = '/api/v1/data-development';
+const SQL_TASK_API = `${DATA_DEVELOPMENT_API}/sql-tasks`;
+const DIRECTORY_API = `${DATA_DEVELOPMENT_API}/directories`;
 
 const queryString = (params: Record<string, unknown>) => {
   const search = new URLSearchParams();
@@ -21,6 +25,18 @@ const queryString = (params: Record<string, unknown>) => {
   const result = search.toString();
   return result ? `?${result}` : '';
 };
+
+export const listDevelopmentDirectories = (
+  projectId: number,
+): Promise<ApiResponse<DevelopmentDirectory[]>> =>
+  HttpUtils.get<DevelopmentDirectory[]>(
+    `${DIRECTORY_API}${queryString({ projectId })}`,
+  );
+
+export const createDevelopmentDirectory = (
+  payload: CreateDevelopmentDirectoryPayload,
+): Promise<ApiResponse<DevelopmentDirectory>> =>
+  HttpUtils.post<DevelopmentDirectory>(DIRECTORY_API, payload);
 
 export const listSqlTasks = (
   projectId?: number,

--- a/yak-ops-ui/src/pages/data-development/task/SqlTaskEditor.tsx
+++ b/yak-ops-ui/src/pages/data-development/task/SqlTaskEditor.tsx
@@ -38,6 +38,7 @@ import {
   createSqlTask,
   getSqlTask,
   getSqlTaskExecution,
+  listDevelopmentDirectories,
   listSqlTaskVersions,
   publishSqlTask,
   runSqlTask,
@@ -46,6 +47,7 @@ import {
 import {
   SQL_PARAMETER_TYPES,
   TERMINAL_EXECUTION_STATUSES,
+  type DevelopmentDirectory,
   type SqlParameterDefinition,
   type SqlTaskDefinition,
   type SqlTaskExecution,
@@ -56,6 +58,7 @@ import {
 interface SqlTaskEditorProps {
   taskId?: number;
   initialProjectId?: number;
+  initialDirectoryId?: number;
 }
 
 interface DraftState {
@@ -63,6 +66,7 @@ interface DraftState {
   name: string;
   description: string;
   projectId?: number;
+  directoryId?: number;
   dataSourceId?: number;
   sql: string;
   parameters: SqlParameterDefinition[];
@@ -95,6 +99,7 @@ const toDraft = (task: SqlTaskDefinition): DraftState => ({
   name: task.name || '',
   description: task.description || '',
   projectId: task.projectId ? Number(task.projectId) : undefined,
+  directoryId: task.directoryId ? Number(task.directoryId) : undefined,
   dataSourceId: Number(task.dataSourceId),
   sql: task.sql || '',
   parameters: Array.isArray(task.parameters) ? task.parameters : [],
@@ -119,6 +124,7 @@ const executionStatusText: Record<string, string> = {
 export default function SqlTaskEditor({
   taskId,
   initialProjectId,
+  initialDirectoryId,
 }: SqlTaskEditorProps) {
   const { projects, currentProject } = useSecurityProject();
   const [draft, setDraft] = useState<DraftState>(() => ({
@@ -126,7 +132,10 @@ export default function SqlTaskEditor({
     projectId:
       initialProjectId ??
       (currentProject?.id ? Number(currentProject.id) : undefined),
+    directoryId: initialDirectoryId,
   }));
+  const [directories, setDirectories] = useState<DevelopmentDirectory[]>([]);
+  const [directoryLoading, setDirectoryLoading] = useState(false);
   const [dataSources, setDataSources] = useState<DataSourceRecord[]>([]);
   const [versions, setVersions] = useState<SqlTaskVersion[]>([]);
   const [execution, setExecution] = useState<SqlTaskExecution>();
@@ -143,6 +152,16 @@ export default function SqlTaskEditor({
       value: Number(project.id),
     })),
     [projects],
+  );
+  const directoryOptions = useMemo(
+    () => [
+      { label: '/', value: 0 },
+      ...directories.map((directory) => ({
+        label: directory.path,
+        value: Number(directory.id),
+      })),
+    ],
+    [directories],
   );
   const dataSourceOptions = useMemo(
     () => dataSources
@@ -178,6 +197,33 @@ export default function SqlTaskEditor({
   useEffect(() => {
     void load();
   }, [load]);
+
+  useEffect(() => {
+    if (!draft.projectId) {
+      setDirectories([]);
+      return undefined;
+    }
+
+    let active = true;
+    setDirectoryLoading(true);
+    void listDevelopmentDirectories(draft.projectId)
+      .then((response) => {
+        if (!active) return;
+        setDirectories(responseData(response, '查询数据开发目录失败') || []);
+      })
+      .catch((error) => {
+        if (!active) return;
+        setDirectories([]);
+        message.error(error instanceof Error ? error.message : '查询数据开发目录失败');
+      })
+      .finally(() => {
+        if (active) setDirectoryLoading(false);
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [draft.projectId]);
 
   useEffect(() => {
     setRunInput((previous) => {
@@ -235,6 +281,7 @@ export default function SqlTaskEditor({
     name: draft.name.trim(),
     description: draft.description.trim() || undefined,
     projectId: Number(draft.projectId),
+    directoryId: draft.directoryId ? Number(draft.directoryId) : 0,
     dataSourceId: Number(draft.dataSourceId),
     sql: draft.sql,
     parameters: draft.parameters.map((parameter) => ({
@@ -699,7 +746,7 @@ export default function SqlTaskEditor({
 
         <main className="p-5">
           <div className="mb-5 grid grid-cols-12 gap-4">
-            <div className="col-span-4">
+            <div className="col-span-3">
               <div className="mb-1.5 text-[12px] font-medium text-[#161823]">任务名称</div>
               <Input
                 value={draft.name}
@@ -708,7 +755,7 @@ export default function SqlTaskEditor({
                 onChange={(event) => updateDraftField('name', event.target.value)}
               />
             </div>
-            <div className="col-span-4">
+            <div className="col-span-3">
               <div className="mb-1.5 text-[12px] font-medium text-[#161823]">所属项目</div>
               <Select
                 value={draft.projectId}
@@ -717,10 +764,32 @@ export default function SqlTaskEditor({
                 optionFilterProp="label"
                 placeholder="请选择项目"
                 options={projectOptions}
-                onChange={(value) => updateDraftField('projectId', Number(value))}
+                onChange={(value) =>
+                  setDraft((previous) => ({
+                    ...previous,
+                    projectId: Number(value),
+                    directoryId: undefined,
+                  }))
+                }
               />
             </div>
-            <div className="col-span-4">
+            <div className="col-span-3">
+              <div className="mb-1.5 text-[12px] font-medium text-[#161823]">所属目录</div>
+              <Select
+                value={draft.directoryId ?? 0}
+                className="w-full"
+                showSearch
+                optionFilterProp="label"
+                placeholder="/"
+                loading={directoryLoading}
+                disabled={!draft.projectId}
+                options={directoryOptions}
+                onChange={(value) =>
+                  updateDraftField('directoryId', Number(value) > 0 ? Number(value) : undefined)
+                }
+              />
+            </div>
+            <div className="col-span-3">
               <div className="mb-1.5 text-[12px] font-medium text-[#161823]">数据源</div>
               <Select
                 value={draft.dataSourceId}
@@ -778,8 +847,8 @@ export default function SqlTaskEditor({
         onOk={() => void executeRun(runInput)}
       >
         <div className="space-y-4 pt-2">
-          {draft.parameters.map((parameter) => (
-            <div key={parameter.name || Math.random()}>
+          {draft.parameters.map((parameter, index) => (
+            <div key={`${parameter.name || 'parameter'}-${index}`}>
               <div className="mb-1.5 flex items-center gap-2 text-[12px] font-medium text-[#161823]">
                 {parameter.name || '未命名参数'}
                 <Tag className="!m-0">{parameter.type}</Tag>

--- a/yak-ops-ui/src/pages/data-development/task/index.tsx
+++ b/yak-ops-ui/src/pages/data-development/task/index.tsx
@@ -10,6 +10,7 @@ export default function DataDevelopmentTaskPage() {
   const params = new URLSearchParams(location.search);
   const requestedType = (params.get('type') || 'SQL').toUpperCase() as DevelopmentTaskType;
   const projectId = Number(params.get('projectId') || 0) || undefined;
+  const directoryId = Number(params.get('directoryId') || 0) || undefined;
   const taskId = id ? Number(id) : undefined;
 
   if (requestedType !== 'SQL') {
@@ -22,5 +23,11 @@ export default function DataDevelopmentTaskPage() {
     );
   }
 
-  return <SqlTaskEditor taskId={taskId} initialProjectId={projectId} />;
+  return (
+    <SqlTaskEditor
+      taskId={taskId}
+      initialProjectId={projectId}
+      initialDirectoryId={directoryId}
+    />
+  );
 }

--- a/yak-ops-ui/src/pages/data-development/types.ts
+++ b/yak-ops-ui/src/pages/data-development/types.ts
@@ -10,6 +10,22 @@ export type SqlParameterType =
   | 'DATE'
   | 'TIMESTAMP';
 
+export interface DevelopmentDirectory {
+  id: number;
+  projectId: number;
+  parentId?: number | null;
+  name: string;
+  path: string;
+  createTime?: string;
+  updateTime?: string;
+}
+
+export interface CreateDevelopmentDirectoryPayload {
+  projectId: number;
+  parentId?: number;
+  name: string;
+}
+
 export interface SqlParameterDefinition {
   name: string;
   type: SqlParameterType;
@@ -22,6 +38,7 @@ export interface SqlTaskDefinition {
   name: string;
   description?: string | null;
   projectId?: number | null;
+  directoryId?: number | null;
   dataSourceId: number;
   sql: string;
   parameters: SqlParameterDefinition[];
@@ -62,6 +79,8 @@ export interface SqlTaskSavePayload {
   name: string;
   description?: string;
   projectId: number;
+  /** 0 表示项目根目录。 */
+  directoryId: number;
   dataSourceId: number;
   sql: string;
   parameters: SqlParameterDefinition[];


### PR DESCRIPTION
## 目标

优化数据开发首页左侧资源树，使其从固定宽度的项目列表升级为可真正组织开发任务的目录树，并参考现有 DataSourceTreePane 的交互实现可拖拽分割线与收起/展开。

## 交互结构

```text
数据开发
├─ 全部任务
├─ 项目 A
│  └─ /
│     ├─ ODS
│     │  └─ 用户域
│     └─ DWD
└─ 项目 B
   └─ /
```

- 点击项目：查看项目全部任务
- 点击 `/`：只查看项目根目录任务
- 点击具体目录：只查看该目录任务
- 左右分割线支持拖拽调整宽度
- 分割线中间按钮支持收起/展开目录面板
- 面板宽度保存在 localStorage

## 新建目录

新增“新建目录”能力：

- 左侧“开发目录”标题旁提供新建目录入口
- 只有选中项目或目录后才能创建
- 弹窗采用“路径 + 名称”方式
- 路径支持 `/` 以及项目下已有任意目录
- 从某个目录触发时默认以当前目录作为父路径
- 创建完成后刷新树并自动选中新目录
- 同一路径禁止同名目录
- 目录名称禁止 `/`、`\\`、`.`、`..`

## 后端目录模型

新增项目级层级目录：

- `yak_dev_directory`
  - `id`
  - `project_id`
  - `parent_id`（0 表示根目录）
  - `name`
  - create/update time
- 唯一约束：`project_id + parent_id + name`
- 数据库不冗余保存完整 path，服务层根据 parentId 解析 `/ODS/用户域`，避免未来移动/重命名目录时批量更新整棵子树

新增 API：

- `GET /api/v1/data-development/directories?projectId=...`
- `POST /api/v1/data-development/directories`

## SQL Task 目录归属

`yak_dev_sql_task` 新增可选 `directory_id`：

- Create / Update 支持 `directoryId`
- Definition 返回 `directoryId`
- `directoryId=0` 表示回到项目根目录 `/`
- 更新任务切换项目时，如果没有明确指定新目录，会清除旧项目目录引用
- 后端校验目录必须属于当前 project
- SQL 编辑器新增“所属目录”选择
- 从左侧目录新建任务时自动带入当前目录

目录和项目一样只属于开发管理元数据：**不会进入 SQL Version / Workflow TaskVersionSnapshot**，移动目录不会改变已发布版本的执行语义。

## 前端

新增：

- `DevelopmentTreePane`
  - 参考 DataSourceTreePane 的 Tree 样式
  - 可拖拽 divider
  - 居中 collapse/expand handle
  - project / folder / all-task 图标层级
- `CreateDirectoryModal`
  - 路径选择
  - 目录名称
- 任务列表增加“所属项目 / 目录”展示
- SQL Task Editor 增加目录选择

## 暂不包含

- 目录重命名
- 目录删除
- 目录拖拽移动
- 跨项目移动目录
- 将目录信息写入已发布 Task Version

这些能力可以在当前 `projectId + parentId + directoryId` 模型上继续增加，不需要修改 Workflow。

## 验证说明

- 分支基于最新 main 创建，当前 compare 为 behind 0
- 已检查 MyBatis MapperScan 会覆盖新增 `DevelopmentDirectoryMapper`
- 已回查 SQL Task 的 API / Service / Repository / PO / Mapper 全链路 `directoryId`
- 已按现有 strict TypeScript / AntD Tree 类型约束做静态回查
- 新增 `DevelopmentDirectoryServiceTest`
  - 覆盖多级目录 path：`/ODS/用户域`
  - 覆盖禁止跨项目使用父目录
- 已核对核心 PR patch，目录元数据没有进入 SQL Version / Workflow TaskVersionSnapshot
- 当前 PR head 没有触发 GitHub Actions / status checks
- 当前执行环境没有可用的本地仓库与完整依赖，因此新增测试和完整 Maven / npm tsc 仍需本地或 CI 最终执行

保持 Draft，供视觉交互、数据库迁移和完整构建验证。