### PR TITLE
fix(data-development): decouple directories from projects

### DIFF
--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/api/DevelopmentDirectoryApi.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/api/DevelopmentDirectoryApi.java
@@ -2,7 +2,6 @@ package io.yak.ops.business.development.api;
 
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 /** HTTP request contracts for data-development directories. */
@@ -11,7 +10,6 @@ public final class DevelopmentDirectoryApi {
   private DevelopmentDirectoryApi() {}
 
   public record CreateRequest(
-      @NotNull @Min(1) Long projectId,
       @Min(1) Long parentId,
       @NotBlank @Size(max = 128) String name) {
   }

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/api/SqlDevelopmentApi.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/api/SqlDevelopmentApi.java
@@ -15,7 +15,7 @@ public final class SqlDevelopmentApi {
   public record CreateRequest(
       @NotBlank String name,
       String description,
-      @Min(1) Long projectId,
+      @Min(0) Long projectId,
       @Min(0) Long directoryId,
       @NotNull @Min(1) Long dataSourceId,
       @NotBlank String sql,
@@ -26,7 +26,7 @@ public final class SqlDevelopmentApi {
       @Min(1) long baseRevision,
       @NotBlank String name,
       String description,
-      @Min(1) Long projectId,
+      @Min(0) Long projectId,
       @Min(0) Long directoryId,
       @NotNull @Min(1) Long dataSourceId,
       @NotBlank String sql,

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/controller/v1/DevelopmentDirectoryController.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/controller/v1/DevelopmentDirectoryController.java
@@ -12,10 +12,9 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-/** Project-scoped directory management for data development. */
+/** Hierarchical directory management for data development. */
 @Tag(name = "数据开发目录接口")
 @RestController
 @RequestMapping("/api/v1/data-development/directories")
@@ -27,19 +26,15 @@ public class DevelopmentDirectoryController {
     this.service = service;
   }
 
-  @Operation(summary = "查询项目数据开发目录")
+  @Operation(summary = "查询数据开发目录")
   @GetMapping
-  public Result<List<DevelopmentDirectory>> list(
-      @RequestParam(name = "projectId") Long projectId) {
-    return Result.success(service.list(projectId));
+  public Result<List<DevelopmentDirectory>> list() {
+    return Result.success(service.list());
   }
 
   @Operation(summary = "新建数据开发目录")
   @PostMapping
   public Result<DevelopmentDirectory> create(@Valid @RequestBody CreateRequest request) {
-    return Result.success(service.create(
-        request.projectId(),
-        request.parentId(),
-        request.name()));
+    return Result.success(service.create(request.parentId(), request.name()));
   }
 }

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/domain/DevelopmentDirectory.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/domain/DevelopmentDirectory.java
@@ -2,10 +2,9 @@ package io.yak.ops.business.development.domain;
 
 import java.time.Instant;
 
-/** Hierarchical directory used to organize data-development tasks inside a project. */
+/** Hierarchical directory used to organize data-development tasks. */
 public record DevelopmentDirectory(
     Long id,
-    Long projectId,
     Long parentId,
     String name,
     String path,

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/DevelopmentDirectoryRepository.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/DevelopmentDirectoryRepository.java
@@ -7,11 +7,11 @@ import java.util.Optional;
 /** Durable directory repository for data-development organization metadata. */
 public interface DevelopmentDirectoryRepository {
 
-  DevelopmentDirectory insert(Long projectId, Long parentId, String name);
+  DevelopmentDirectory insert(Long parentId, String name);
 
   Optional<DevelopmentDirectory> findById(Long id);
 
-  List<DevelopmentDirectory> listByProjectId(Long projectId);
+  List<DevelopmentDirectory> list();
 
-  boolean existsByName(Long projectId, Long parentId, String name);
+  boolean existsByName(Long parentId, String name);
 }

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/DevelopmentDirectoryRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/DevelopmentDirectoryRepositoryAdapter.java
@@ -22,10 +22,9 @@ public class DevelopmentDirectoryRepositoryAdapter implements DevelopmentDirecto
   }
 
   @Override
-  public DevelopmentDirectory insert(Long projectId, Long parentId, String name) {
+  public DevelopmentDirectory insert(Long parentId, String name) {
     Instant now = Instant.now();
     DevelopmentDirectoryPO po = new DevelopmentDirectoryPO();
-    po.setProjectId(projectId);
     po.setParentId(toStoredParentId(parentId));
     po.setName(name);
     po.setCreateTime(now);
@@ -40,10 +39,9 @@ public class DevelopmentDirectoryRepositoryAdapter implements DevelopmentDirecto
   }
 
   @Override
-  public List<DevelopmentDirectory> listByProjectId(Long projectId) {
+  public List<DevelopmentDirectory> list() {
     return mapper.selectList(
             new LambdaQueryWrapper<DevelopmentDirectoryPO>()
-                .eq(DevelopmentDirectoryPO::getProjectId, projectId)
                 .orderByAsc(DevelopmentDirectoryPO::getName)
                 .orderByAsc(DevelopmentDirectoryPO::getId))
         .stream()
@@ -52,10 +50,9 @@ public class DevelopmentDirectoryRepositoryAdapter implements DevelopmentDirecto
   }
 
   @Override
-  public boolean existsByName(Long projectId, Long parentId, String name) {
+  public boolean existsByName(Long parentId, String name) {
     return mapper.selectCount(
             new LambdaQueryWrapper<DevelopmentDirectoryPO>()
-                .eq(DevelopmentDirectoryPO::getProjectId, projectId)
                 .eq(DevelopmentDirectoryPO::getParentId, toStoredParentId(parentId))
                 .eq(DevelopmentDirectoryPO::getName, name))
         > 0L;
@@ -71,7 +68,6 @@ public class DevelopmentDirectoryRepositoryAdapter implements DevelopmentDirecto
         : po.getParentId();
     return new DevelopmentDirectory(
         po.getId(),
-        po.getProjectId(),
         parentId,
         po.getName(),
         null,

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentDirectoryService.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentDirectoryService.java
@@ -11,7 +11,7 @@ import java.util.Set;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-/** Application service for project-scoped hierarchical data-development directories. */
+/** Application service for hierarchical data-development directories. */
 @Service
 public class DevelopmentDirectoryService {
 
@@ -21,9 +21,8 @@ public class DevelopmentDirectoryService {
     this.repository = repository;
   }
 
-  public List<DevelopmentDirectory> list(Long projectId) {
-    long normalizedProjectId = requirePositive(projectId, "项目 ID");
-    List<DevelopmentDirectory> directories = repository.listByProjectId(normalizedProjectId);
+  public List<DevelopmentDirectory> list() {
+    List<DevelopmentDirectory> directories = repository.list();
     Map<Long, DevelopmentDirectory> byId = new HashMap<>();
     directories.forEach(directory -> byId.put(directory.id(), directory));
     Map<Long, String> pathCache = new HashMap<>();
@@ -37,28 +36,21 @@ public class DevelopmentDirectoryService {
   }
 
   @Transactional(transactionManager = "yakBusinessTransactionManager", rollbackFor = Exception.class)
-  public DevelopmentDirectory create(Long projectId, Long parentId, String name) {
-    long normalizedProjectId = requirePositive(projectId, "项目 ID");
+  public DevelopmentDirectory create(Long parentId, String name) {
     Long normalizedParentId = normalizeParentId(parentId);
     String normalizedName = normalizeName(name);
 
     if (normalizedParentId != null) {
-      DevelopmentDirectory parent = repository.findById(normalizedParentId)
+      repository.findById(normalizedParentId)
           .orElseThrow(() -> new IllegalArgumentException("父目录不存在：" + normalizedParentId));
-      if (!normalizedProjectIdEquals(parent.projectId(), normalizedProjectId)) {
-        throw new IllegalArgumentException("父目录不属于当前项目：" + normalizedParentId);
-      }
     }
 
-    if (repository.existsByName(normalizedProjectId, normalizedParentId, normalizedName)) {
+    if (repository.existsByName(normalizedParentId, normalizedName)) {
       throw new IllegalStateException("当前路径下已存在同名目录：" + normalizedName);
     }
 
-    DevelopmentDirectory created = repository.insert(
-        normalizedProjectId,
-        normalizedParentId,
-        normalizedName);
-    return list(normalizedProjectId).stream()
+    DevelopmentDirectory created = repository.insert(normalizedParentId, normalizedName);
+    return list().stream()
         .filter(directory -> directory.id().equals(created.id()))
         .findFirst()
         .orElseThrow(() -> new IllegalStateException("目录创建成功但无法重新读取：" + created.id()));
@@ -67,7 +59,6 @@ public class DevelopmentDirectoryService {
   private DevelopmentDirectory withPath(DevelopmentDirectory directory, String path) {
     return new DevelopmentDirectory(
         directory.id(),
-        directory.projectId(),
         directory.parentId(),
         directory.name(),
         path,
@@ -116,14 +107,5 @@ public class DevelopmentDirectoryService {
       throw new IllegalArgumentException("目录名称不能包含 /、\\，也不能使用 . 或 ..");
     }
     return normalized;
-  }
-
-  private long requirePositive(Long value, String name) {
-    if (value == null || value <= 0L) throw new IllegalArgumentException(name + "不合法：" + value);
-    return value;
-  }
-
-  private boolean normalizedProjectIdEquals(Long value, long expected) {
-    return value != null && value == expected;
   }
 }

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/SqlDevelopmentService.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/SqlDevelopmentService.java
@@ -1,7 +1,6 @@
 package io.yak.ops.business.development.service;
 
 import io.yak.ops.business.datasource.repository.DataSourceRepository;
-import io.yak.ops.business.development.domain.DevelopmentDirectory;
 import io.yak.ops.business.development.domain.SqlDevelopmentModel.Definition;
 import io.yak.ops.business.development.domain.SqlDevelopmentModel.Execution;
 import io.yak.ops.business.development.domain.SqlDevelopmentModel.Version;
@@ -18,7 +17,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import org.springframework.stereotype.Service;
@@ -60,7 +58,7 @@ public class SqlDevelopmentService {
       String sql,
       List<SqlParameterDefinition> parameters) {
     Long normalizedProjectId = normalizeProjectId(projectId);
-    Long normalizedDirectoryId = normalizeDirectoryAssignment(normalizedProjectId, directoryId);
+    Long normalizedDirectoryId = normalizeDirectoryAssignment(directoryId);
     List<SqlParameterDefinition> normalized = validate(dataSourceId, sql, parameters);
     return repository.insertDefinition(
         requireText(name, "任务名称"),
@@ -98,14 +96,9 @@ public class SqlDevelopmentService {
       List<SqlParameterDefinition> parameters) {
     Definition current = requireDefinition(id);
     Long normalizedProjectId = projectId == null ? current.projectId() : normalizeProjectId(projectId);
-    Long normalizedDirectoryId;
-    if (directoryId == null) {
-      normalizedDirectoryId = Objects.equals(normalizedProjectId, current.projectId())
-          ? current.directoryId()
-          : null;
-    } else {
-      normalizedDirectoryId = normalizeDirectoryAssignment(normalizedProjectId, directoryId);
-    }
+    Long normalizedDirectoryId = directoryId == null
+        ? current.directoryId()
+        : normalizeDirectoryAssignment(directoryId);
 
     List<SqlParameterDefinition> normalized = validate(dataSourceId, sql, parameters);
     boolean updated = repository.updateDraft(
@@ -193,15 +186,10 @@ public class SqlDevelopmentService {
     return execution(executionId);
   }
 
-  private Long normalizeDirectoryAssignment(Long projectId, Long directoryId) {
+  private Long normalizeDirectoryAssignment(Long directoryId) {
     if (directoryId == null || directoryId <= 0L) return null;
-    if (projectId == null) {
-      throw new IllegalArgumentException("设置目录前必须先选择所属项目");
-    }
-    DevelopmentDirectory directory = directoryRepository.findById(directoryId)
-        .orElseThrow(() -> new IllegalArgumentException("数据开发目录不存在：" + directoryId));
-    if (!Objects.equals(directory.projectId(), projectId)) {
-      throw new IllegalArgumentException("数据开发目录不属于当前项目：" + directoryId);
+    if (directoryRepository.findById(directoryId).isEmpty()) {
+      throw new IllegalArgumentException("数据开发目录不存在：" + directoryId);
     }
     return directoryId;
   }

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/SqlDevelopmentService.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/SqlDevelopmentService.java
@@ -57,7 +57,7 @@ public class SqlDevelopmentService {
       Long dataSourceId,
       String sql,
       List<SqlParameterDefinition> parameters) {
-    Long normalizedProjectId = normalizeProjectId(projectId);
+    Long normalizedProjectId = normalizeProjectAssignment(projectId);
     Long normalizedDirectoryId = normalizeDirectoryAssignment(directoryId);
     List<SqlParameterDefinition> normalized = validate(dataSourceId, sql, parameters);
     return repository.insertDefinition(
@@ -95,7 +95,9 @@ public class SqlDevelopmentService {
       String sql,
       List<SqlParameterDefinition> parameters) {
     Definition current = requireDefinition(id);
-    Long normalizedProjectId = projectId == null ? current.projectId() : normalizeProjectId(projectId);
+    Long normalizedProjectId = projectId == null
+        ? current.projectId()
+        : normalizeProjectAssignment(projectId);
     Long normalizedDirectoryId = directoryId == null
         ? current.directoryId()
         : normalizeDirectoryAssignment(directoryId);
@@ -240,8 +242,8 @@ public class SqlDevelopmentService {
         .orElseThrow(() -> new IllegalArgumentException("SQL 任务不存在：" + id));
   }
 
-  private Long normalizeProjectId(Long value) {
-    return value == null ? null : requirePositive(value, "项目 ID");
+  private Long normalizeProjectAssignment(Long value) {
+    return value == null || value <= 0L ? null : value;
   }
 
   private long requirePositive(Long value, String name) {

--- a/yak-ops-business/yak-ops-business-data-development/src/main/resources/db/migration/yak-data-development/V3__add_development_directories.sql
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/resources/db/migration/yak-data-development/V3__add_development_directories.sql
@@ -1,12 +1,13 @@
 CREATE TABLE IF NOT EXISTS yak_dev_directory (
     id BIGINT NOT NULL,
+    project_id BIGINT NOT NULL,
     parent_id BIGINT NOT NULL DEFAULT 0,
     name VARCHAR(128) NOT NULL,
     create_time DATETIME(6) NOT NULL,
     update_time DATETIME(6) NOT NULL,
     PRIMARY KEY (id),
-    UNIQUE KEY uk_yak_dev_directory_sibling (parent_id, name),
-    KEY idx_yak_dev_directory_parent (parent_id)
+    UNIQUE KEY uk_yak_dev_directory_sibling (project_id, parent_id, name),
+    KEY idx_yak_dev_directory_project_parent (project_id, parent_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 ALTER TABLE yak_dev_sql_task

--- a/yak-ops-business/yak-ops-business-data-development/src/main/resources/db/migration/yak-data-development/V3__add_development_directories.sql
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/resources/db/migration/yak-data-development/V3__add_development_directories.sql
@@ -1,13 +1,12 @@
 CREATE TABLE IF NOT EXISTS yak_dev_directory (
     id BIGINT NOT NULL,
-    project_id BIGINT NOT NULL,
     parent_id BIGINT NOT NULL DEFAULT 0,
     name VARCHAR(128) NOT NULL,
     create_time DATETIME(6) NOT NULL,
     update_time DATETIME(6) NOT NULL,
     PRIMARY KEY (id),
-    UNIQUE KEY uk_yak_dev_directory_sibling (project_id, parent_id, name),
-    KEY idx_yak_dev_directory_project_parent (project_id, parent_id)
+    UNIQUE KEY uk_yak_dev_directory_sibling (parent_id, name),
+    KEY idx_yak_dev_directory_parent (parent_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 ALTER TABLE yak_dev_sql_task

--- a/yak-ops-business/yak-ops-business-data-development/src/main/resources/db/migration/yak-data-development/V4__make_development_directories_global.sql
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/resources/db/migration/yak-data-development/V4__make_development_directories_global.sql
@@ -1,0 +1,6 @@
+ALTER TABLE yak_dev_directory
+    DROP INDEX uk_yak_dev_directory_sibling,
+    DROP INDEX idx_yak_dev_directory_project_parent,
+    DROP COLUMN project_id,
+    ADD UNIQUE KEY uk_yak_dev_directory_sibling (parent_id, name),
+    ADD KEY idx_yak_dev_directory_parent (parent_id);

--- a/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/DevelopmentDirectoryServiceTest.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/DevelopmentDirectoryServiceTest.java
@@ -21,25 +21,23 @@ class DevelopmentDirectoryServiceTest {
     InMemoryDirectoryRepository repository = new InMemoryDirectoryRepository();
     DevelopmentDirectoryService service = new DevelopmentDirectoryService(repository);
 
-    DevelopmentDirectory ods = service.create(1L, null, "ODS");
-    DevelopmentDirectory user = service.create(1L, ods.id(), "用户域");
+    DevelopmentDirectory ods = service.create(null, "ODS");
+    DevelopmentDirectory user = service.create(ods.id(), "用户域");
 
     assertEquals("/ODS", ods.path());
     assertEquals("/ODS/用户域", user.path());
     assertEquals(
         List.of("/ODS", "/ODS/用户域"),
-        service.list(1L).stream().map(DevelopmentDirectory::path).toList());
+        service.list().stream().map(DevelopmentDirectory::path).toList());
   }
 
   @Test
-  void rejectsParentDirectoryFromAnotherProject() {
+  void rejectsDuplicateSiblingDirectory() {
     InMemoryDirectoryRepository repository = new InMemoryDirectoryRepository();
     DevelopmentDirectoryService service = new DevelopmentDirectoryService(repository);
-    DevelopmentDirectory otherProject = service.create(2L, null, "ODS");
+    service.create(null, "ODS");
 
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> service.create(1L, otherProject.id(), "非法子目录"));
+    assertThrows(IllegalStateException.class, () -> service.create(null, "ODS"));
   }
 
   private static final class InMemoryDirectoryRepository
@@ -49,12 +47,11 @@ class DevelopmentDirectoryServiceTest {
     private final Map<Long, DevelopmentDirectory> values = new LinkedHashMap<>();
 
     @Override
-    public DevelopmentDirectory insert(Long projectId, Long parentId, String name) {
+    public DevelopmentDirectory insert(Long parentId, String name) {
       Long id = ids.getAndIncrement();
       Instant now = Instant.now();
       DevelopmentDirectory directory = new DevelopmentDirectory(
           id,
-          projectId,
           parentId,
           name,
           null,
@@ -70,19 +67,14 @@ class DevelopmentDirectoryServiceTest {
     }
 
     @Override
-    public List<DevelopmentDirectory> listByProjectId(Long projectId) {
-      List<DevelopmentDirectory> result = new ArrayList<>();
-      values.values().stream()
-          .filter(directory -> projectId.equals(directory.projectId()))
-          .forEach(result::add);
-      return result;
+    public List<DevelopmentDirectory> list() {
+      return new ArrayList<>(values.values());
     }
 
     @Override
-    public boolean existsByName(Long projectId, Long parentId, String name) {
+    public boolean existsByName(Long parentId, String name) {
       return values.values().stream().anyMatch(directory ->
-          projectId.equals(directory.projectId())
-              && java.util.Objects.equals(parentId, directory.parentId())
+          java.util.Objects.equals(parentId, directory.parentId())
               && name.equals(directory.name()));
     }
   }

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/development/DevelopmentDirectoryPO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/development/DevelopmentDirectoryPO.java
@@ -12,7 +12,6 @@ import lombok.Data;
 public class DevelopmentDirectoryPO {
   @TableId(type = IdType.ASSIGN_ID)
   private Long id;
-  private Long projectId;
   private Long parentId;
   private String name;
   private Instant createTime;

--- a/yak-ops-ui/src/pages/data-development/components/CreateDirectoryModal.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/CreateDirectoryModal.tsx
@@ -5,7 +5,6 @@ import type { DevelopmentDirectory } from '../types';
 
 interface CreateDirectoryModalProps {
   open: boolean;
-  projectName?: string;
   directories: DevelopmentDirectory[];
   defaultParentId?: number;
   loading?: boolean;
@@ -15,7 +14,6 @@ interface CreateDirectoryModalProps {
 
 const CreateDirectoryModal = ({
   open,
-  projectName,
   directories,
   defaultParentId,
   loading = false,
@@ -62,48 +60,39 @@ const CreateDirectoryModal = ({
         onSubmit(parentId && parentId > 0 ? parentId : undefined, normalizedName);
       }}
     >
-      <div className="pt-2">
-        {projectName ? (
-          <div className="mb-4 rounded-lg bg-[#fafafa] px-3 py-2 text-[12px] text-[rgba(22,24,35,.55)]">
-            当前项目：
-            <span className="font-medium text-[#344054]">{projectName}</span>
-          </div>
-        ) : null}
+      <div className="grid grid-cols-[88px_minmax(0,1fr)] items-center gap-y-3 pt-2">
+        <Typography.Text className="text-[13px] text-[#344054]">
+          <span className="mr-1 text-[rgba(254,44,85,1)]">*</span>
+          路径：
+        </Typography.Text>
+        <Select
+          value={parentId ?? 0}
+          options={pathOptions}
+          showSearch
+          optionFilterProp="label"
+          className="w-full"
+          onChange={(value) => setParentId(Number(value) || undefined)}
+        />
 
-        <div className="grid grid-cols-[88px_minmax(0,1fr)] items-center gap-y-3">
-          <Typography.Text className="text-[13px] text-[#344054]">
-            <span className="mr-1 text-[rgba(254,44,85,1)]">*</span>
-            路径：
-          </Typography.Text>
-          <Select
-            value={parentId ?? 0}
-            options={pathOptions}
-            showSearch
-            optionFilterProp="label"
-            className="w-full"
-            onChange={(value) => setParentId(Number(value) || undefined)}
-          />
-
-          <Typography.Text className="text-[13px] text-[#344054]">
-            <span className="mr-1 text-[rgba(254,44,85,1)]">*</span>
-            名称：
-          </Typography.Text>
-          <Input
-            autoFocus
-            value={name}
-            maxLength={128}
-            placeholder="名称"
-            onChange={(event) => setName(event.target.value)}
-            onPressEnter={() => {
-              if (normalizedName && !loading) {
-                onSubmit(
-                  parentId && parentId > 0 ? parentId : undefined,
-                  normalizedName,
-                );
-              }
-            }}
-          />
-        </div>
+        <Typography.Text className="text-[13px] text-[#344054]">
+          <span className="mr-1 text-[rgba(254,44,85,1)]">*</span>
+          名称：
+        </Typography.Text>
+        <Input
+          autoFocus
+          value={name}
+          maxLength={128}
+          placeholder="名称"
+          onChange={(event) => setName(event.target.value)}
+          onPressEnter={() => {
+            if (normalizedName && !loading) {
+              onSubmit(
+                parentId && parentId > 0 ? parentId : undefined,
+                normalizedName,
+              );
+            }
+          }}
+        />
       </div>
     </Modal>
   );

--- a/yak-ops-ui/src/pages/data-development/components/CreateTaskModal.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/CreateTaskModal.tsx
@@ -10,7 +10,7 @@ interface CreateTaskModalProps {
   projects: API.ProjectBrief[];
   defaultProjectId?: number;
   onCancel: () => void;
-  onNext: (type: DevelopmentTaskType, projectId: number) => void;
+  onNext: (type: DevelopmentTaskType, projectId?: number) => void;
 }
 
 const taskTypes: Array<{
@@ -71,11 +71,8 @@ export default function CreateTaskModal({
   useEffect(() => {
     if (!open) return;
     setType('SQL');
-    setProjectId(
-      defaultProjectId ??
-        (projects[0]?.id === undefined ? undefined : Number(projects[0].id)),
-    );
-  }, [defaultProjectId, open, projects]);
+    setProjectId(defaultProjectId);
+  }, [defaultProjectId, open]);
 
   return (
     <Modal
@@ -84,26 +81,24 @@ export default function CreateTaskModal({
       width={720}
       okText="下一步"
       cancelText="取消"
-      okButtonProps={{ disabled: !projectId }}
       destroyOnClose
       onCancel={onCancel}
-      onOk={() => {
-        if (projectId) onNext(type, projectId);
-      }}
+      onOk={() => onNext(type, projectId)}
     >
       <div className="pt-2">
         <div className="mb-5">
           <Typography.Text className="mb-2 block text-[13px] font-medium text-[#161823]">
-            所属项目
+            所属项目（可选）
           </Typography.Text>
           <Select
+            allowClear
             value={projectId}
             options={projectOptions}
             className="w-full"
-            placeholder="请选择项目"
+            placeholder="可选，未选择则不归属项目"
             showSearch
             optionFilterProp="label"
-            onChange={(value) => setProjectId(Number(value))}
+            onChange={(value) => setProjectId(value ? Number(value) : undefined)}
           />
         </div>
 

--- a/yak-ops-ui/src/pages/data-development/components/DevelopmentTreePane.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/DevelopmentTreePane.tsx
@@ -35,7 +35,6 @@ interface DevelopmentTreePaneProps {
   selectedNodeKey?: string;
   leftWidth: number;
   collapsed: boolean;
-  createDisabled?: boolean;
   onCreateDirectory: () => void;
   onSelect: TreeProps['onSelect'];
   onResizeStart: (event: ReactPointerEvent) => void;
@@ -48,7 +47,6 @@ const DevelopmentTreePane = ({
   selectedNodeKey,
   leftWidth,
   collapsed,
-  createDisabled = false,
   onCreateDirectory,
   onSelect,
   onResizeStart,
@@ -128,20 +126,14 @@ const DevelopmentTreePane = ({
             <div className="text-[13px] font-semibold text-[#161823]">
               开发目录
             </div>
-            <Tooltip
-              title={createDisabled ? '请先选择一个项目' : '新建目录'}
-              placement="right"
-            >
-              <span>
-                <Button
-                  type="text"
-                  size="small"
-                  disabled={createDisabled}
-                  icon={<FolderPlus size={15} strokeWidth={1.8} />}
-                  className="!flex !h-7 !w-7 !items-center !justify-center !p-0"
-                  onClick={onCreateDirectory}
-                />
-              </span>
+            <Tooltip title="新建目录" placement="right">
+              <Button
+                type="text"
+                size="small"
+                icon={<FolderPlus size={15} strokeWidth={1.8} />}
+                className="!flex !h-7 !w-7 !items-center !justify-center !p-0"
+                onClick={onCreateDirectory}
+              />
             </Tooltip>
           </div>
 
@@ -154,14 +146,10 @@ const DevelopmentTreePane = ({
                 <Tree
                   blockNode
                   defaultExpandAll
-                  selectedKeys={
-                    selectedNodeKey ? [selectedNodeKey] : []
-                  }
+                  selectedKeys={selectedNodeKey ? [selectedNodeKey] : []}
                   treeData={treeData}
                   titleRender={renderTitle}
-                  switcherIcon={
-                    <ChevronDown size={12} strokeWidth={1.8} />
-                  }
+                  switcherIcon={<ChevronDown size={12} strokeWidth={1.8} />}
                   onSelect={onSelect}
                   className="development-tree bg-transparent"
                 />
@@ -215,11 +203,7 @@ const DevelopmentTreePane = ({
             'focus-visible:ring-[rgba(254,44,85,.16)]',
           ].join(' ')}
         >
-          {collapsed ? (
-            <ChevronRight size={12} />
-          ) : (
-            <ChevronLeft size={12} />
-          )}
+          {collapsed ? <ChevronRight size={12} /> : <ChevronLeft size={12} />}
         </button>
       </div>
 

--- a/yak-ops-ui/src/pages/data-development/index.tsx
+++ b/yak-ops-ui/src/pages/data-development/index.tsx
@@ -38,9 +38,9 @@ import type {
 
 type TreeFilterKey =
   | 'all'
+  | 'root'
   | 'unassigned'
   | `project:${number}`
-  | `root:${number}`
   | `directory:${number}`;
 type PublishFilter = 'ALL' | 'DRAFT' | 'PUBLISHED';
 
@@ -49,12 +49,8 @@ const MIN_LEFT_WIDTH = 210;
 const MAX_LEFT_WIDTH = 420;
 const LEFT_WIDTH_STORAGE_KEY = 'yak-data-development.left-width';
 
-const projectKey = (projectId: number): TreeFilterKey =>
-  `project:${projectId}`;
-const rootKey = (projectId: number): TreeFilterKey =>
-  `root:${projectId}`;
-const directoryKey = (directoryId: number): TreeFilterKey =>
-  `directory:${directoryId}`;
+const projectKey = (projectId: number): TreeFilterKey => `project:${projectId}`;
+const directoryKey = (directoryId: number): TreeFilterKey => `directory:${directoryId}`;
 
 const numberFromKey = (key: string, prefix: string) => {
   if (!key.startsWith(prefix)) return undefined;
@@ -99,30 +95,22 @@ export default function DataDevelopmentPage() {
   const [keyword, setKeyword] = useState('');
   const [typeFilter, setTypeFilter] = useState<'ALL' | DevelopmentTaskType>('ALL');
   const [publishFilter, setPublishFilter] = useState<PublishFilter>('ALL');
-  const [selectedNode, setSelectedNode] = useState<TreeFilterKey>(() =>
-    currentProject?.id ? projectKey(Number(currentProject.id)) : 'all',
-  );
+  const [selectedNode, setSelectedNode] = useState<TreeFilterKey>('all');
   const [leftWidth, setLeftWidth] = useState(initialLeftWidth);
   const [leftCollapsed, setLeftCollapsed] = useState(false);
 
   const loadDirectories = useCallback(async () => {
     setTreeLoading(true);
     try {
-      const responses = await Promise.all(
-        projects.map(async (project) => {
-          const projectId = Number(project.id);
-          const response = await listDevelopmentDirectories(projectId);
-          return responseData(response, `查询项目“${project.projectName}”目录失败`);
-        }),
-      );
-      setDirectories(responses.flat());
+      const response = await listDevelopmentDirectories();
+      setDirectories(responseData(response, '查询数据开发目录失败') || []);
     } catch (error) {
       message.error(error instanceof Error ? error.message : '查询数据开发目录失败');
       setDirectories([]);
     } finally {
       setTreeLoading(false);
     }
-  }, [projects]);
+  }, []);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -149,11 +137,8 @@ export default function DataDevelopmentPage() {
 
   useEffect(() => {
     void load();
-  }, [load]);
-
-  useEffect(() => {
     void loadDirectories();
-  }, [loadDirectories]);
+  }, [load, loadDirectories]);
 
   const projectNameMap = useMemo(
     () => new Map(projects.map((project) => [Number(project.id), project.projectName])),
@@ -168,129 +153,106 @@ export default function DataDevelopmentPage() {
     [directories],
   );
 
-  const projectIdForSelection = useMemo(() => {
-    const projectId = numberFromKey(selectedNode, 'project:')
-      ?? numberFromKey(selectedNode, 'root:');
-    if (projectId) return projectId;
-    const directoryId = numberFromKey(selectedNode, 'directory:');
-    return directoryId ? directoryMap.get(directoryId)?.projectId : undefined;
-  }, [directoryMap, selectedNode]);
-
   const directoryIdForSelection = useMemo(
     () => numberFromKey(selectedNode, 'directory:'),
     [selectedNode],
   );
-
-  const projectDirectories = useMemo(
-    () => projectIdForSelection
-      ? directories.filter((directory) => directory.projectId === projectIdForSelection)
-      : [],
-    [directories, projectIdForSelection],
+  const projectIdForSelection = useMemo(
+    () => numberFromKey(selectedNode, 'project:'),
+    [selectedNode],
   );
 
   const counts = useMemo(() => {
     const byProject = new Map<number, number>();
     const byDirectory = new Map<number, number>();
-    const rootByProject = new Map<number, number>();
+    let rootCount = 0;
     let unassigned = 0;
 
     tasks.forEach((task) => {
-      if (!task.projectId) {
+      if (task.projectId) {
+        const projectId = Number(task.projectId);
+        byProject.set(projectId, (byProject.get(projectId) || 0) + 1);
+      } else {
         unassigned += 1;
-        return;
       }
-      const projectId = Number(task.projectId);
-      byProject.set(projectId, (byProject.get(projectId) || 0) + 1);
+
       if (task.directoryId) {
         const directoryId = Number(task.directoryId);
         byDirectory.set(directoryId, (byDirectory.get(directoryId) || 0) + 1);
       } else {
-        rootByProject.set(projectId, (rootByProject.get(projectId) || 0) + 1);
+        rootCount += 1;
       }
     });
 
-    return { byProject, byDirectory, rootByProject, unassigned };
+    return { byProject, byDirectory, rootCount, unassigned };
   }, [tasks]);
 
   const treeData = useMemo<DevelopmentTreeNode[]>(() => {
-    const buildDirectoryChildren = (
-      projectId: number,
-      parentId?: number,
-    ): DevelopmentTreeNode[] =>
+    const buildDirectoryChildren = (parentId?: number): DevelopmentTreeNode[] =>
       directories
-        .filter(
-          (directory) =>
-            directory.projectId === projectId
-            && (directory.parentId ?? undefined) === parentId,
-        )
+        .filter((directory) => (directory.parentId ?? undefined) === parentId)
         .sort((left, right) => left.name.localeCompare(right.name, 'zh-CN'))
         .map((directory) => ({
           key: directoryKey(Number(directory.id)),
           title: directory.name,
           nodeType: 'directory',
-          projectId,
           directoryId: Number(directory.id),
           count: counts.byDirectory.get(Number(directory.id)) || 0,
-          children: buildDirectoryChildren(projectId, Number(directory.id)),
+          children: buildDirectoryChildren(Number(directory.id)),
         }));
 
-    const projectNodes: DevelopmentTreeNode[] = projects.map((project) => {
-      const projectId = Number(project.id);
-      return {
-        key: projectKey(projectId),
-        title: project.projectName,
-        nodeType: 'project',
-        projectId,
-        count: counts.byProject.get(projectId) || 0,
-        children: [
-          {
-            key: rootKey(projectId),
-            title: '/',
-            nodeType: 'directory',
-            projectId,
-            count: counts.rootByProject.get(projectId) || 0,
-            children: buildDirectoryChildren(projectId),
-          },
-        ],
-      };
-    });
-
-    return [
+    const nodes: DevelopmentTreeNode[] = [
       {
         key: 'all',
         title: '全部任务',
         nodeType: 'all',
         count: tasks.length,
       },
-      ...projectNodes,
-      ...(counts.unassigned > 0
-        ? [
-            {
-              key: 'unassigned' as const,
-              title: '未归属项目',
-              nodeType: 'unassigned' as const,
-              count: counts.unassigned,
-            },
-          ]
-        : []),
+      {
+        key: 'root',
+        title: '/',
+        nodeType: 'directory',
+        count: counts.rootCount,
+        children: buildDirectoryChildren(),
+      },
     ];
+
+    if (projects.length) {
+      nodes.push(
+        ...projects.map((project) => {
+          const projectId = Number(project.id);
+          return {
+            key: projectKey(projectId),
+            title: project.projectName,
+            nodeType: 'project' as const,
+            projectId,
+            count: counts.byProject.get(projectId) || 0,
+          };
+        }),
+      );
+    }
+
+    if (counts.unassigned > 0) {
+      nodes.push({
+        key: 'unassigned',
+        title: '未归属项目',
+        nodeType: 'unassigned',
+        count: counts.unassigned,
+      });
+    }
+
+    return nodes;
   }, [counts, directories, projects, tasks.length]);
 
   const filteredTasks = useMemo(() => {
     const normalizedKeyword = keyword.trim().toLowerCase();
     const selectedProjectId = numberFromKey(selectedNode, 'project:');
-    const selectedRootProjectId = numberFromKey(selectedNode, 'root:');
     const selectedDirectoryId = numberFromKey(selectedNode, 'directory:');
 
     return tasks.filter((task) => {
+      if (selectedNode === 'root' && task.directoryId) return false;
       if (selectedNode === 'unassigned' && task.projectId) return false;
       if (selectedProjectId && Number(task.projectId) !== selectedProjectId) return false;
-      if (
-        selectedRootProjectId
-        && (Number(task.projectId) !== selectedRootProjectId || Boolean(task.directoryId))
-      ) {
-        return false;
-      }
       if (selectedDirectoryId && Number(task.directoryId) !== selectedDirectoryId) return false;
       if (typeFilter !== 'ALL' && task.type !== typeFilter) return false;
       if (publishFilter === 'DRAFT' && task.latestVersionNo > 0) return false;
@@ -339,7 +301,6 @@ export default function DataDevelopmentPage() {
     },
     {
       title: '所属项目 / 目录',
-      dataIndex: 'projectId',
       width: 220,
       render: (_, task) => {
         const projectName = task.projectId
@@ -427,24 +388,13 @@ export default function DataDevelopmentPage() {
     [leftCollapsed, leftWidth],
   );
 
-  const openCreateDirectory = () => {
-    if (!projectIdForSelection) {
-      message.info('请先在左侧选择一个项目或目录');
-      return;
-    }
-    setDirectoryOpen(true);
-  };
+  const openCreateDirectory = () => setDirectoryOpen(true);
 
   const submitDirectory = async (parentId: number | undefined, name: string) => {
-    if (!projectIdForSelection) return;
     setDirectorySaving(true);
     try {
       const created = responseData(
-        await createDevelopmentDirectory({
-          projectId: projectIdForSelection,
-          parentId,
-          name,
-        }),
+        await createDevelopmentDirectory({ parentId, name }),
         '新建目录失败',
       );
       await loadDirectories();
@@ -458,11 +408,6 @@ export default function DataDevelopmentPage() {
     }
   };
 
-  const selectedProjectName = projectIdForSelection
-    ? projectNameMap.get(projectIdForSelection)
-    : undefined;
-  const defaultDirectoryParentId = directoryIdForSelection;
-
   return (
     <section className="m-4 overflow-hidden rounded-xl border border-[#e4e7ec] bg-white">
       <div className="flex h-[calc(100vh-80px)] min-h-[620px]">
@@ -472,7 +417,6 @@ export default function DataDevelopmentPage() {
           selectedNodeKey={selectedNode}
           leftWidth={leftWidth}
           collapsed={leftCollapsed}
-          createDisabled={!projectIdForSelection}
           onCreateDirectory={openCreateDirectory}
           onResizeStart={handleResizeStart}
           onCollapsedChange={setLeftCollapsed}
@@ -573,21 +517,18 @@ export default function DataDevelopmentPage() {
         onCancel={() => setCreateOpen(false)}
         onNext={(type, projectId) => {
           setCreateOpen(false);
-          const directoryId =
-            projectId === projectIdForSelection && directoryIdForSelection
-              ? directoryIdForSelection
-              : 0;
-          history.push(
-            `/data-development/task/new?type=${encodeURIComponent(type)}&projectId=${projectId}&directoryId=${directoryId}`,
-          );
+          const params = new URLSearchParams();
+          params.set('type', type);
+          params.set('directoryId', String(directoryIdForSelection || 0));
+          if (projectId) params.set('projectId', String(projectId));
+          history.push(`/data-development/task/new?${params.toString()}`);
         }}
       />
 
       <CreateDirectoryModal
         open={directoryOpen}
-        projectName={selectedProjectName}
-        directories={projectDirectories}
-        defaultParentId={defaultDirectoryParentId}
+        directories={directories}
+        defaultParentId={directoryIdForSelection}
         loading={directorySaving}
         onCancel={() => {
           if (!directorySaving) setDirectoryOpen(false);

--- a/yak-ops-ui/src/pages/data-development/service.ts
+++ b/yak-ops-ui/src/pages/data-development/service.ts
@@ -26,12 +26,8 @@ const queryString = (params: Record<string, unknown>) => {
   return result ? `?${result}` : '';
 };
 
-export const listDevelopmentDirectories = (
-  projectId: number,
-): Promise<ApiResponse<DevelopmentDirectory[]>> =>
-  HttpUtils.get<DevelopmentDirectory[]>(
-    `${DIRECTORY_API}${queryString({ projectId })}`,
-  );
+export const listDevelopmentDirectories = (): Promise<ApiResponse<DevelopmentDirectory[]>> =>
+  HttpUtils.get<DevelopmentDirectory[]>(DIRECTORY_API);
 
 export const createDevelopmentDirectory = (
   payload: CreateDevelopmentDirectoryPayload,

--- a/yak-ops-ui/src/pages/data-development/task/SqlTaskEditor.tsx
+++ b/yak-ops-ui/src/pages/data-development/task/SqlTaskEditor.tsx
@@ -126,20 +126,17 @@ export default function SqlTaskEditor({
   initialProjectId,
   initialDirectoryId,
 }: SqlTaskEditorProps) {
-  const { projects, currentProject } = useSecurityProject();
+  const { projects } = useSecurityProject();
   const [draft, setDraft] = useState<DraftState>(() => ({
     ...EMPTY_DRAFT,
-    projectId:
-      initialProjectId ??
-      (currentProject?.id ? Number(currentProject.id) : undefined),
+    projectId: initialProjectId,
     directoryId: initialDirectoryId,
   }));
   const [directories, setDirectories] = useState<DevelopmentDirectory[]>([]);
-  const [directoryLoading, setDirectoryLoading] = useState(false);
   const [dataSources, setDataSources] = useState<DataSourceRecord[]>([]);
   const [versions, setVersions] = useState<SqlTaskVersion[]>([]);
   const [execution, setExecution] = useState<SqlTaskExecution>();
-  const [loading, setLoading] = useState(Boolean(taskId));
+  const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [publishing, setPublishing] = useState(false);
   const [running, setRunning] = useState(false);
@@ -176,9 +173,13 @@ export default function SqlTaskEditor({
   const load = useCallback(async () => {
     setLoading(true);
     try {
-      const dataSourceResponse = await fetchDataSourceAll();
+      const [dataSourceResponse, directoryResponse] = await Promise.all([
+        fetchDataSourceAll(),
+        listDevelopmentDirectories(),
+      ]);
       const sourceResult = responseData(dataSourceResponse, '查询数据源失败');
       setDataSources(sourceResult?.bizData || []);
+      setDirectories(responseData(directoryResponse, '查询数据开发目录失败') || []);
 
       if (!taskId) return;
       const [taskResponse, versionResponse] = await Promise.all([
@@ -197,33 +198,6 @@ export default function SqlTaskEditor({
   useEffect(() => {
     void load();
   }, [load]);
-
-  useEffect(() => {
-    if (!draft.projectId) {
-      setDirectories([]);
-      return undefined;
-    }
-
-    let active = true;
-    setDirectoryLoading(true);
-    void listDevelopmentDirectories(draft.projectId)
-      .then((response) => {
-        if (!active) return;
-        setDirectories(responseData(response, '查询数据开发目录失败') || []);
-      })
-      .catch((error) => {
-        if (!active) return;
-        setDirectories([]);
-        message.error(error instanceof Error ? error.message : '查询数据开发目录失败');
-      })
-      .finally(() => {
-        if (active) setDirectoryLoading(false);
-      });
-
-    return () => {
-      active = false;
-    };
-  }, [draft.projectId]);
 
   useEffect(() => {
     setRunInput((previous) => {
@@ -246,10 +220,9 @@ export default function SqlTaskEditor({
     const timer = window.setInterval(async () => {
       try {
         const response = await getSqlTaskExecution(Number(execution.id));
-        const current = responseData(response, '查询 SQL 执行状态失败');
-        setExecution(current);
+        setExecution(responseData(response, '查询 SQL 执行状态失败'));
       } catch {
-        // Keep the last known execution state and allow the next poll to retry.
+        // Keep the last known execution state and retry on the next interval.
       }
     }, 1200);
     return () => window.clearInterval(timer);
@@ -262,7 +235,6 @@ export default function SqlTaskEditor({
 
   const validateDraft = () => {
     if (!draft.name.trim()) throw new Error('请输入任务名称');
-    if (!draft.projectId) throw new Error('请选择所属项目');
     if (!draft.dataSourceId) throw new Error('请选择数据源');
     if (!draft.sql.trim()) throw new Error('请输入 SQL');
     const names = new Set<string>();
@@ -280,7 +252,7 @@ export default function SqlTaskEditor({
   const savePayload = (): SqlTaskSavePayload => ({
     name: draft.name.trim(),
     description: draft.description.trim() || undefined,
-    projectId: Number(draft.projectId),
+    projectId: draft.projectId ? Number(draft.projectId) : draft.id ? 0 : undefined,
     directoryId: draft.directoryId ? Number(draft.directoryId) : 0,
     dataSourceId: Number(draft.dataSourceId),
     sql: draft.sql,
@@ -303,9 +275,7 @@ export default function SqlTaskEditor({
         : await createSqlTask(payload);
       const saved = responseData(response, '保存 SQL 草稿失败');
       setDraft(toDraft(saved));
-      if (!draft.id) {
-        history.replace(`/data-development/task/${saved.id}`);
-      }
+      if (!draft.id) history.replace(`/data-development/task/${saved.id}`);
       if (showSuccess) message.success('草稿已保存');
       return saved;
     } finally {
@@ -326,8 +296,7 @@ export default function SqlTaskEditor({
     try {
       const saved = await persistDraft(false);
       const response = await runSqlTask(Number(saved.id), input);
-      const current = responseData(response, '启动 SQL 执行失败');
-      setExecution(current);
+      setExecution(responseData(response, '启动 SQL 执行失败'));
       setRunModalOpen(false);
       message.success('SQL 已提交执行');
     } catch (error) {
@@ -375,11 +344,10 @@ export default function SqlTaskEditor({
   const handleCancelExecution = async () => {
     if (!execution?.id) return;
     try {
-      const current = responseData(
+      setExecution(responseData(
         await cancelSqlTaskExecution(Number(execution.id)),
         '取消 SQL 执行失败',
-      );
-      setExecution(current);
+      ));
       message.success('已提交取消');
     } catch (error) {
       message.error(error instanceof Error ? error.message : '取消 SQL 执行失败');
@@ -391,12 +359,7 @@ export default function SqlTaskEditor({
       ...previous,
       parameters: [
         ...previous.parameters,
-        {
-          name: '',
-          type: 'STRING',
-          required: false,
-          defaultValue: undefined,
-        },
+        { name: '', type: 'STRING', required: false, defaultValue: undefined },
       ],
     }));
   };
@@ -599,12 +562,8 @@ export default function SqlTaskEditor({
       );
     }
 
-    const resultColumns = Array.isArray(output.columns)
-      ? (output.columns as string[])
-      : [];
-    const rows = Array.isArray(output.rows)
-      ? (output.rows as Record<string, unknown>[])
-      : [];
+    const resultColumns = Array.isArray(output.columns) ? (output.columns as string[]) : [];
+    const rows = Array.isArray(output.rows) ? (output.rows as Record<string, unknown>[]) : [];
     return (
       <div>
         {header}
@@ -719,18 +678,10 @@ export default function SqlTaskEditor({
             </div>
           </div>
           <Space>
-            <Button
-              icon={<Save size={14} />}
-              loading={saving}
-              onClick={() => void handleSave()}
-            >
+            <Button icon={<Save size={14} />} loading={saving} onClick={() => void handleSave()}>
               保存
             </Button>
-            <Button
-              icon={<Play size={14} />}
-              loading={running}
-              onClick={handleRun}
-            >
+            <Button icon={<Play size={14} />} loading={running} onClick={handleRun}>
               运行
             </Button>
             <Button
@@ -756,21 +707,16 @@ export default function SqlTaskEditor({
               />
             </div>
             <div className="col-span-3">
-              <div className="mb-1.5 text-[12px] font-medium text-[#161823]">所属项目</div>
+              <div className="mb-1.5 text-[12px] font-medium text-[#161823]">所属项目（可选）</div>
               <Select
+                allowClear
                 value={draft.projectId}
                 className="w-full"
                 showSearch
                 optionFilterProp="label"
-                placeholder="请选择项目"
+                placeholder="未归属项目"
                 options={projectOptions}
-                onChange={(value) =>
-                  setDraft((previous) => ({
-                    ...previous,
-                    projectId: Number(value),
-                    directoryId: undefined,
-                  }))
-                }
+                onChange={(value) => updateDraftField('projectId', value ? Number(value) : undefined)}
               />
             </div>
             <div className="col-span-3">
@@ -781,8 +727,6 @@ export default function SqlTaskEditor({
                 showSearch
                 optionFilterProp="label"
                 placeholder="/"
-                loading={directoryLoading}
-                disabled={!draft.projectId}
                 options={directoryOptions}
                 onChange={(value) =>
                   updateDraftField('directoryId', Number(value) > 0 ? Number(value) : undefined)
@@ -852,9 +796,7 @@ export default function SqlTaskEditor({
               <div className="mb-1.5 flex items-center gap-2 text-[12px] font-medium text-[#161823]">
                 {parameter.name || '未命名参数'}
                 <Tag className="!m-0">{parameter.type}</Tag>
-                {parameter.required && (
-                  <span className="text-[rgba(254,44,85,1)]">*</span>
-                )}
+                {parameter.required && <span className="text-[rgba(254,44,85,1)]">*</span>}
               </div>
               <Input
                 value={

--- a/yak-ops-ui/src/pages/data-development/types.ts
+++ b/yak-ops-ui/src/pages/data-development/types.ts
@@ -12,7 +12,6 @@ export type SqlParameterType =
 
 export interface DevelopmentDirectory {
   id: number;
-  projectId: number;
   parentId?: number | null;
   name: string;
   path: string;
@@ -21,7 +20,6 @@ export interface DevelopmentDirectory {
 }
 
 export interface CreateDevelopmentDirectoryPayload {
-  projectId: number;
   parentId?: number;
   name: string;
 }
@@ -78,8 +76,8 @@ export interface SqlTaskExecution {
 export interface SqlTaskSavePayload {
   name: string;
   description?: string;
-  projectId: number;
-  /** 0 表示项目根目录。 */
+  projectId?: number;
+  /** 0 表示数据开发根目录。 */
   directoryId: number;
   dataSourceId: number;
   sql: string;


### PR DESCRIPTION
## 背景

Follow-up for #303.

#303 将开发目录按项目组织，导致“当前无可用项目”时左侧新建目录按钮被禁用，用户即使只想在根路径 `/` 下创建目录也会被提示“请先选择一个项目”。这把“目录组织能力”和“项目管理能力”错误绑定了。

## 修正后的边界

```text
开发目录
├─ 全部任务
├─ /
│  ├─ ODS
│  ├─ DWD
│  └─ ADS
├─ 项目 A        # 有项目时仅作为额外任务筛选
└─ 未归属项目
```

- 目录是数据开发自身的全局层级组织能力
- `/` 永远存在，不依赖项目
- 新建目录按钮永远可用
- 项目变成任务的可选管理属性，不再是创建目录/创建 SQL 的前置条件
- 目录与项目是两个正交维度

## 后端

### Directory

- `DevelopmentDirectory` 移除 `projectId`
- `GET /api/v1/data-development/directories` 改为直接返回全局目录树数据
- `POST /api/v1/data-development/directories` 只提交 `parentId + name`
- Repository / PO / Service 去掉 project scope
- 同一父目录下仍禁止同名目录
- path 继续由 `parentId` 在 Service 层解析，不冗余存储

### SQL Task

- `directoryId` 只校验目录是否存在，不再校验目录所属项目
- `projectId` 保留，但改成可选管理属性
- `projectId=0` 用于显式清除已有项目归属；旧客户端不传 projectId 时仍保持当前归属
- SQL Version / Workflow TaskVersionSnapshot 不包含目录和项目组织信息，执行语义不变

## Flyway

保留 #303 已发布的 V3 **原文件和 checksum 不变**，新增：

- `V4__make_development_directories_global.sql`

V4 会把 `yak_dev_directory.project_id` 和项目级唯一索引迁移为全局父子目录结构，避免已经执行过 V3 的本地环境出现 Flyway checksum mismatch。

## 前端

- 左侧固定显示 `/` 根目录，即使项目列表为空
- “新建目录”不再 disabled，不再显示“请先选择一个项目”
- 新建目录弹窗只保留“路径 + 名称”
- 目录 API 只加载一次全局目录
- 项目节点有数据时作为额外筛选展示
- 新建任务时项目可选
- SQL Editor：
  - 项目可选/可清除
  - 目录始终可选，不再依赖项目
  - 无项目也可以保存、运行、发布 SQL

## 测试与验证

- 更新 `DevelopmentDirectoryServiceTest`
  - 多级 path `/ODS/用户域`
  - 同级目录重名校验
- 已检查 V3 checksum 保持不变，迁移变化单独进入 V4
- 当前分支相对 main 的额外 behind commit 仅为 main 上的 SQL executor 编译修复，不与本 PR 修改文件冲突
- 仍保持 Draft，等待本地 Maven / TypeScript 完整构建验证