### PR TITLE
refactor(data-development): unify directory and task resource tree

### DIFF
--- a/yak-ops-ui/src/pages/data-development/components/DevelopmentTreePane.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/DevelopmentTreePane.tsx
@@ -1,31 +1,28 @@
 import type { DataNode } from 'antd/es/tree';
-import type { TreeProps } from 'antd';
-import { Button, Empty, Spin, Tooltip, Tree } from 'antd';
+import type { MenuProps, TreeProps } from 'antd';
+import { Button, Dropdown, Empty, Input, Spin, Tooltip, Tree } from 'antd';
 import {
   ChevronDown,
   ChevronLeft,
   ChevronRight,
+  Code2,
   Folder,
-  FolderOpen,
   FolderPlus,
-  Layers3,
-  Workflow,
+  Plus,
+  Search,
 } from 'lucide-react';
 import type { PointerEvent as ReactPointerEvent } from 'react';
 
-export type DevelopmentTreeNodeType =
-  | 'all'
-  | 'project'
-  | 'directory'
-  | 'unassigned';
+export type DevelopmentTreeNodeType = 'root' | 'directory' | 'task';
 
 export interface DevelopmentTreeNode extends DataNode {
   key: string;
   title: string;
   nodeType: DevelopmentTreeNodeType;
-  projectId?: number;
   directoryId?: number;
-  count?: number;
+  taskId?: number;
+  taskType?: string;
+  searchText?: string;
   children?: DevelopmentTreeNode[];
 }
 
@@ -33,9 +30,12 @@ interface DevelopmentTreePaneProps {
   treeData: DevelopmentTreeNode[];
   treeLoading: boolean;
   selectedNodeKey?: string;
+  searchValue: string;
   leftWidth: number;
   collapsed: boolean;
   onCreateDirectory: () => void;
+  onCreateNode: () => void;
+  onSearchChange: (value: string) => void;
   onSelect: TreeProps['onSelect'];
   onResizeStart: (event: ReactPointerEvent) => void;
   onCollapsedChange: (collapsed: boolean) => void;
@@ -45,64 +45,67 @@ const DevelopmentTreePane = ({
   treeData,
   treeLoading,
   selectedNodeKey,
+  searchValue,
   leftWidth,
   collapsed,
   onCreateDirectory,
+  onCreateNode,
+  onSearchChange,
   onSelect,
   onResizeStart,
   onCollapsedChange,
 }: DevelopmentTreePaneProps) => {
+  const createMenuItems: MenuProps['items'] = [
+    {
+      key: 'node',
+      label: '新建节点',
+      icon: <Code2 size={14} strokeWidth={1.8} />,
+    },
+    {
+      key: 'directory',
+      label: '新建目录',
+      icon: <FolderPlus size={14} strokeWidth={1.8} />,
+    },
+  ];
+
   const renderTitle: TreeProps['titleRender'] = (rawNode) => {
     const node = rawNode as DevelopmentTreeNode;
-    const isDirectory = node.nodeType === 'directory';
-    const isProject = node.nodeType === 'project';
-    const isAll = node.nodeType === 'all';
+    const isTask = node.nodeType === 'task';
 
     return (
       <div
         className="flex min-w-0 flex-1 items-center gap-2"
         title={node.title}
       >
-        {isProject ? (
-          <Workflow
-            size={14}
-            strokeWidth={2}
-            className="shrink-0 text-[#ff7a00]"
-          />
-        ) : isDirectory ? (
-          <Folder
-            size={14}
-            strokeWidth={1.8}
-            className="shrink-0 text-[#98a2b3]"
-          />
-        ) : isAll ? (
-          <Layers3
-            size={14}
+        {isTask ? (
+          <Code2
+            size={13}
             strokeWidth={1.8}
             className="shrink-0 text-[#667085]"
           />
         ) : (
-          <FolderOpen
+          <Folder
             size={14}
             strokeWidth={1.8}
-            className="shrink-0 text-[#98a2b3]"
+            className={[
+              'shrink-0',
+              node.nodeType === 'root' ? 'text-[#475467]' : 'text-[#98a2b3]',
+            ].join(' ')}
           />
         )}
 
         <span
           className={[
             'min-w-0 flex-1 truncate text-[13px] leading-8',
-            isProject
-              ? 'font-medium text-[#1f2937]'
-              : 'font-normal text-[#344054]',
+            isTask ? 'font-normal text-[#344054]' : 'font-medium text-[#1f2937]',
           ].join(' ')}
         >
           {node.title}
         </span>
 
-        {typeof node.count === 'number' ? (
-          <span className="shrink-0 text-[10px] text-[rgba(22,24,35,.3)]">
-            {node.count}
+        {isTask && node.taskType ? (
+          <span className="shrink-0 text-[10px] text-[#98a2b3]">
+            {node.taskType}
           </span>
         ) : null}
       </div>
@@ -126,18 +129,43 @@ const DevelopmentTreePane = ({
             <span className="text-[13px] font-semibold text-[#30323b]">
               开发目录
             </span>
-            <Tooltip title="新建目录" placement="right">
-              <Button
-                type="text"
-                size="small"
-                icon={<FolderPlus size={15} strokeWidth={1.8} />}
-                className="!flex !h-7 !w-7 !items-center !justify-center !p-0"
-                onClick={onCreateDirectory}
-              />
-            </Tooltip>
+
+            <Dropdown
+              trigger={['click']}
+              placement="bottomRight"
+              menu={{
+                items: createMenuItems,
+                onClick: ({ key }) => {
+                  if (key === 'directory') onCreateDirectory();
+                  if (key === 'node') onCreateNode();
+                },
+              }}
+            >
+              <Tooltip title="新建" placement="right">
+                <Button
+                  type="text"
+                  size="small"
+                  aria-label="新建目录或节点"
+                  icon={<Plus size={16} strokeWidth={1.8} />}
+                  className="!flex !h-7 !w-7 !items-center !justify-center !p-0"
+                />
+              </Tooltip>
+            </Dropdown>
           </div>
 
-          <div className="mt-1 min-h-0 flex-1 overflow-y-auto px-[14px]">
+          <div className="shrink-0 px-[14px] pb-2 pt-1">
+            <Input
+              allowClear
+              size="small"
+              variant="filled"
+              value={searchValue}
+              prefix={<Search size={13} className="text-[#98a2b3]" />}
+              placeholder="搜索名称 / 节点"
+              onChange={(event) => onSearchChange(event.target.value)}
+            />
+          </div>
+
+          <div className="min-h-0 flex-1 overflow-y-auto px-[14px]">
             <Spin
               spinning={treeLoading}
               wrapperClassName="block min-h-full"
@@ -146,6 +174,7 @@ const DevelopmentTreePane = ({
                 <Tree
                   blockNode
                   defaultExpandAll
+                  autoExpandParent={Boolean(searchValue.trim())}
                   selectedKeys={selectedNodeKey ? [selectedNodeKey] : []}
                   treeData={treeData}
                   titleRender={renderTitle}
@@ -156,7 +185,7 @@ const DevelopmentTreePane = ({
               ) : (
                 <Empty
                   image={Empty.PRESENTED_IMAGE_SIMPLE}
-                  description="暂无开发目录"
+                  description={searchValue.trim() ? '未找到匹配节点' : '暂无开发节点'}
                   className="mt-10"
                 />
               )}
@@ -213,14 +242,14 @@ const DevelopmentTreePane = ({
         }
 
         .development-tree .ant-tree-list-holder-inner {
-          gap: 2px;
+          gap: 1px;
         }
 
         .development-tree .ant-tree-treenode {
           box-sizing: border-box;
           width: 100%;
-          min-height: 32px;
-          padding: 0 8px !important;
+          min-height: 30px;
+          padding: 0 6px !important;
           align-items: center;
           border-radius: 0;
           transition: background-color 0.15s ease;
@@ -235,13 +264,13 @@ const DevelopmentTreePane = ({
         .development-tree .ant-tree-node-content-wrapper {
           display: flex;
           min-width: 0;
-          height: 32px;
+          height: 30px;
           flex: 1;
           align-items: center;
           padding: 0 !important;
           border-radius: 0 !important;
           background: transparent !important;
-          line-height: 32px;
+          line-height: 30px;
         }
 
         .development-tree
@@ -257,18 +286,18 @@ const DevelopmentTreePane = ({
         }
 
         .development-tree .ant-tree-indent-unit {
-          width: 22px;
+          width: 18px;
         }
 
         .development-tree .ant-tree-switcher {
           display: inline-flex;
-          width: 20px;
-          height: 32px;
+          width: 18px;
+          height: 30px;
           flex: none;
           align-items: center;
           justify-content: center;
           color: #98a2b3;
-          line-height: 32px;
+          line-height: 30px;
         }
 
         .development-tree .ant-tree-switcher svg {
@@ -280,7 +309,7 @@ const DevelopmentTreePane = ({
         }
 
         .development-tree .ant-tree-switcher-noop {
-          width: 20px;
+          width: 18px;
         }
       `}</style>
     </>

--- a/yak-ops-ui/src/pages/data-development/index.tsx
+++ b/yak-ops-ui/src/pages/data-development/index.tsx
@@ -17,7 +17,7 @@ import {
 } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
 import dayjs from 'dayjs';
-import { Plus, RefreshCw, Search } from 'lucide-react';
+import { RefreshCw, Search } from 'lucide-react';
 import type { PointerEvent as ReactPointerEvent } from 'react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
@@ -37,21 +37,17 @@ import type {
   DevelopmentTaskType,
 } from './types';
 
-type TreeFilterKey =
-  | 'all'
-  | 'root'
-  | 'unassigned'
-  | `project:${number}`
-  | `directory:${number}`;
+type TreeFilterKey = 'root' | `directory:${number}` | `task:${number}`;
 type PublishFilter = 'ALL' | 'DRAFT' | 'PUBLISHED';
 
-const DEFAULT_LEFT_WIDTH = 252;
-const MIN_LEFT_WIDTH = 210;
-const MAX_LEFT_WIDTH = 420;
+const DEFAULT_LEFT_WIDTH = 272;
+const MIN_LEFT_WIDTH = 220;
+const MAX_LEFT_WIDTH = 440;
 const LEFT_WIDTH_STORAGE_KEY = 'yak-data-development.left-width';
 
-const projectKey = (projectId: number): TreeFilterKey => `project:${projectId}`;
-const directoryKey = (directoryId: number): TreeFilterKey => `directory:${directoryId}`;
+const directoryKey = (directoryId: number): TreeFilterKey =>
+  `directory:${directoryId}`;
+const taskKey = (taskId: number): TreeFilterKey => `task:${taskId}`;
 
 const numberFromKey = (key: string, prefix: string) => {
   if (!key.startsWith(prefix)) return undefined;
@@ -117,11 +113,12 @@ export default function DataDevelopmentPage() {
   const [createOpen, setCreateOpen] = useState(false);
   const [directoryOpen, setDirectoryOpen] = useState(false);
   const [directorySaving, setDirectorySaving] = useState(false);
+  const [treeKeyword, setTreeKeyword] = useState('');
   const [keywordDraft, setKeywordDraft] = useState('');
   const [keyword, setKeyword] = useState('');
   const [typeFilter, setTypeFilter] = useState<'ALL' | DevelopmentTaskType>('ALL');
   const [publishFilter, setPublishFilter] = useState<PublishFilter>('ALL');
-  const [selectedNode, setSelectedNode] = useState<TreeFilterKey>('all');
+  const [selectedNode, setSelectedNode] = useState<TreeFilterKey>('root');
   const [leftWidth, setLeftWidth] = useState(initialLeftWidth);
   const [leftCollapsed, setLeftCollapsed] = useState(false);
   const [current, setCurrent] = useState(1);
@@ -185,109 +182,100 @@ export default function DataDevelopmentPage() {
     () => numberFromKey(selectedNode, 'directory:'),
     [selectedNode],
   );
-  const projectIdForSelection = useMemo(
-    () => numberFromKey(selectedNode, 'project:'),
-    [selectedNode],
-  );
 
-  const counts = useMemo(() => {
-    const byProject = new Map<number, number>();
-    const byDirectory = new Map<number, number>();
-    let rootCount = 0;
-    let unassigned = 0;
+  const fullTreeData = useMemo<DevelopmentTreeNode[]>(() => {
+    const taskNodes = (directoryId?: number): DevelopmentTreeNode[] =>
+      tasks
+        .filter((task) => {
+          const taskDirectoryId = task.directoryId
+            ? Number(task.directoryId)
+            : undefined;
+          return taskDirectoryId === directoryId;
+        })
+        .sort((left, right) => left.name.localeCompare(right.name, 'zh-CN'))
+        .map((task) => ({
+          key: taskKey(Number(task.id)),
+          title: task.name,
+          nodeType: 'task',
+          taskId: Number(task.id),
+          taskType: task.type,
+          searchText: `${task.name} ${task.description || ''} ${task.id}`,
+          isLeaf: true,
+        }));
 
-    tasks.forEach((task) => {
-      if (task.projectId) {
-        const projectId = Number(task.projectId);
-        byProject.set(projectId, (byProject.get(projectId) || 0) + 1);
-      } else {
-        unassigned += 1;
-      }
-
-      if (task.directoryId) {
-        const directoryId = Number(task.directoryId);
-        byDirectory.set(directoryId, (byDirectory.get(directoryId) || 0) + 1);
-      } else {
-        rootCount += 1;
-      }
-    });
-
-    return { byProject, byDirectory, rootCount, unassigned };
-  }, [tasks]);
-
-  const treeData = useMemo<DevelopmentTreeNode[]>(() => {
-    const buildDirectoryChildren = (parentId?: number): DevelopmentTreeNode[] =>
+    const directoryNodes = (parentId?: number): DevelopmentTreeNode[] =>
       directories
         .filter((directory) => (directory.parentId ?? undefined) === parentId)
         .sort((left, right) => left.name.localeCompare(right.name, 'zh-CN'))
-        .map((directory) => ({
-          key: directoryKey(Number(directory.id)),
-          title: directory.name,
-          nodeType: 'directory',
-          directoryId: Number(directory.id),
-          count: counts.byDirectory.get(Number(directory.id)) || 0,
-          children: buildDirectoryChildren(Number(directory.id)),
-        }));
+        .map((directory) => {
+          const directoryId = Number(directory.id);
+          return {
+            key: directoryKey(directoryId),
+            title: directory.name,
+            nodeType: 'directory',
+            directoryId,
+            searchText: `${directory.name} ${directory.path || ''}`,
+            children: [
+              ...directoryNodes(directoryId),
+              ...taskNodes(directoryId),
+            ],
+          };
+        });
 
-    const nodes: DevelopmentTreeNode[] = [
-      {
-        key: 'all',
-        title: '全部任务',
-        nodeType: 'all',
-        count: tasks.length,
-      },
+    return [
       {
         key: 'root',
         title: '/',
-        nodeType: 'directory',
-        count: counts.rootCount,
-        children: buildDirectoryChildren(),
+        nodeType: 'root',
+        searchText: '/',
+        children: [...directoryNodes(), ...taskNodes()],
       },
     ];
+  }, [directories, tasks]);
 
-    if (projects.length) {
-      nodes.push(
-        ...projects.map((project) => {
-          const projectId = Number(project.id);
-          return {
-            key: projectKey(projectId),
-            title: project.projectName,
-            nodeType: 'project' as const,
-            projectId,
-            count: counts.byProject.get(projectId) || 0,
-          };
-        }),
-      );
-    }
+  const treeData = useMemo<DevelopmentTreeNode[]>(() => {
+    const normalized = treeKeyword.trim().toLowerCase();
+    if (!normalized) return fullTreeData;
 
-    if (counts.unassigned > 0) {
-      nodes.push({
-        key: 'unassigned',
-        title: '未归属项目',
-        nodeType: 'unassigned',
-        count: counts.unassigned,
+    const filterNodes = (
+      nodes: DevelopmentTreeNode[],
+    ): DevelopmentTreeNode[] =>
+      nodes.flatMap((node) => {
+        const children = node.children ? filterNodes(node.children) : [];
+        const text = `${node.title} ${node.searchText || ''}`.toLowerCase();
+        const selfMatched = node.nodeType !== 'root' && text.includes(normalized);
+
+        if (selfMatched) {
+          return [{ ...node, children: node.children }];
+        }
+        if (children.length) {
+          return [{ ...node, children }];
+        }
+        return [];
       });
-    }
 
-    return nodes;
-  }, [counts, directories, projects, tasks.length]);
+    return filterNodes(fullTreeData);
+  }, [fullTreeData, treeKeyword]);
 
   const filteredTasks = useMemo(() => {
     const normalizedKeyword = keyword.trim().toLowerCase();
-    const selectedProjectId = numberFromKey(selectedNode, 'project:');
     const selectedDirectoryId = numberFromKey(selectedNode, 'directory:');
 
     return tasks.filter((task) => {
-      if (selectedNode === 'root' && task.directoryId) return false;
-      if (selectedNode === 'unassigned' && task.projectId) return false;
-      if (selectedProjectId && Number(task.projectId) !== selectedProjectId) return false;
-      if (selectedDirectoryId && Number(task.directoryId) !== selectedDirectoryId) return false;
+      if (
+        selectedDirectoryId
+        && Number(task.directoryId) !== selectedDirectoryId
+      ) {
+        return false;
+      }
       if (typeFilter !== 'ALL' && task.type !== typeFilter) return false;
       if (publishFilter === 'DRAFT' && task.latestVersionNo > 0) return false;
       if (publishFilter === 'PUBLISHED' && task.latestVersionNo <= 0) return false;
       if (
         normalizedKeyword
-        && !`${task.name} ${task.description || ''}`.toLowerCase().includes(normalizedKeyword)
+        && !`${task.name} ${task.description || ''}`
+          .toLowerCase()
+          .includes(normalizedKeyword)
       ) {
         return false;
       }
@@ -408,7 +396,12 @@ export default function DataDevelopmentPage() {
       width: 90,
       fixed: 'right',
       render: (_, task) => (
-        <Button type="link" size="small" className="!px-0" onClick={() => openTask(task)}>
+        <Button
+          type="link"
+          size="small"
+          className="!px-0"
+          onClick={() => openTask(task)}
+        >
           配置
         </Button>
       ),
@@ -447,8 +440,6 @@ export default function DataDevelopmentPage() {
     [leftCollapsed, leftWidth],
   );
 
-  const openCreateDirectory = () => setDirectoryOpen(true);
-
   const submitDirectory = async (parentId: number | undefined, name: string) => {
     setDirectorySaving(true);
     try {
@@ -479,77 +470,76 @@ export default function DataDevelopmentPage() {
         <div className="flex min-h-0 flex-1 overflow-hidden">
           <DevelopmentTreePane
             treeData={treeData}
-            treeLoading={treeLoading}
+            treeLoading={treeLoading || loading}
             selectedNodeKey={selectedNode}
+            searchValue={treeKeyword}
             leftWidth={leftWidth}
             collapsed={leftCollapsed}
-            onCreateDirectory={openCreateDirectory}
+            onCreateDirectory={() => setDirectoryOpen(true)}
+            onCreateNode={() => setCreateOpen(true)}
+            onSearchChange={setTreeKeyword}
             onResizeStart={handleResizeStart}
             onCollapsedChange={setLeftCollapsed}
             onSelect={(keys) => {
               const key = keys[0];
-              if (key) setSelectedNode(String(key) as TreeFilterKey);
+              if (!key) return;
+              const normalizedKey = String(key) as TreeFilterKey;
+              const selectedTaskId = numberFromKey(normalizedKey, 'task:');
+              if (selectedTaskId) {
+                history.push(`/data-development/task/${selectedTaskId}`);
+                return;
+              }
+              setSelectedNode(normalizedKey);
             }}
           />
 
           <main className="flex min-w-0 flex-1 flex-col overflow-hidden px-4 py-3">
             <div className="shrink-0 border-b border-[#eceef0] pb-2">
-              <div className="flex min-w-0 flex-nowrap items-center gap-3 overflow-x-auto">
+              <div className="flex min-w-0 flex-nowrap items-center justify-end gap-2 overflow-x-auto">
+                <Input
+                  allowClear
+                  variant="filled"
+                  value={keywordDraft}
+                  onChange={(event) => setKeywordDraft(event.target.value)}
+                  onPressEnter={applySearch}
+                  prefix={<Search size={14} className="text-[#98a2b3]" />}
+                  placeholder="搜索任务名称或描述"
+                  className="w-[220px] shrink-0"
+                />
+
+                <Select
+                  variant="filled"
+                  value={typeFilter}
+                  className="w-[120px] shrink-0"
+                  options={[
+                    { label: '全部类型', value: 'ALL' },
+                    { label: 'SQL', value: 'SQL' },
+                  ]}
+                  onChange={setTypeFilter}
+                />
+
+                <Select
+                  variant="filled"
+                  value={publishFilter}
+                  className="w-[130px] shrink-0"
+                  options={[
+                    { label: '全部状态', value: 'ALL' },
+                    { label: '草稿', value: 'DRAFT' },
+                    { label: '已发布', value: 'PUBLISHED' },
+                  ]}
+                  onChange={setPublishFilter}
+                />
+
+                <Button onClick={applySearch}>查询</Button>
+
                 <Button
-                  type="primary"
-                  icon={<Plus size={14} />}
-                  className="shrink-0"
-                  onClick={() => setCreateOpen(true)}
-                >
-                  新建任务
-                </Button>
-
-                <div className="ml-auto flex shrink-0 items-center gap-2">
-                  <Input
-                    allowClear
-                    variant="filled"
-                    value={keywordDraft}
-                    onChange={(event) => setKeywordDraft(event.target.value)}
-                    onPressEnter={applySearch}
-                    prefix={<Search size={14} className="text-[#98a2b3]" />}
-                    placeholder="搜索任务名称或描述"
-                    className="w-[220px]"
-                  />
-
-                  <Select
-                    variant="filled"
-                    value={typeFilter}
-                    className="w-[120px]"
-                    options={[
-                      { label: '全部类型', value: 'ALL' },
-                      { label: 'SQL', value: 'SQL' },
-                    ]}
-                    onChange={setTypeFilter}
-                  />
-
-                  <Select
-                    variant="filled"
-                    value={publishFilter}
-                    className="w-[130px]"
-                    options={[
-                      { label: '全部状态', value: 'ALL' },
-                      { label: '草稿', value: 'DRAFT' },
-                      { label: '已发布', value: 'PUBLISHED' },
-                    ]}
-                    onChange={setPublishFilter}
-                  />
-
-                  <Button onClick={applySearch}>查询</Button>
-
-                  <Button
-                    aria-label="刷新"
-                    icon={<RefreshCw size={14} />}
-                    onClick={() => {
-                      void load();
-                      void loadDirectories();
-                    }}
-                  />
-                </div>
+                  aria-label="刷新"
+                  icon={<RefreshCw size={14} />}
+                  onClick={() => {
+                    void load();
+                    void loadDirectories();
+                  }}
+                />
               </div>
             </div>
 
@@ -600,8 +590,7 @@ export default function DataDevelopmentPage() {
           open={createOpen}
           projects={projects}
           defaultProjectId={
-            projectIdForSelection
-            ?? (currentProject?.id ? Number(currentProject.id) : undefined)
+            currentProject?.id ? Number(currentProject.id) : undefined
           }
           onCancel={() => setCreateOpen(false)}
           onNext={(type, projectId) => {


### PR DESCRIPTION
## 目标

继续优化数据开发左侧开发树，使目录和任务节点真正成为同一棵资源树，参考 DataWorks/开发资源树的使用方式，减少“目录筛选”和“任务列表”割裂感。

本 PR **仅修改前端**，不调整后端、API、数据库或数据开发领域模型。

## 核心调整

### 1. 删除“全部任务”节点

左侧不再额外显示“全部任务”。根节点 `/` 直接作为开发空间根节点：

```text
开发目录                         +
[ 搜索名称 / 节点 ]

/
├─ ODS
│  ├─ 用户清洗 SQL
│  └─ 用户统计 SQL
├─ DWD
│  └─ ...
└─ 根目录 SQL
```

- 选择 `/`：右侧显示全部任务
- 选择具体目录：右侧过滤到该目录任务
- 点击任务节点：直接进入任务配置页

### 2. 目录和任务合并成一棵树

- 目录节点继续使用现有目录 API
- SQL Task 直接投影为叶子节点挂在对应目录下
- 根目录任务直接挂在 `/` 下
- 目录优先展示，任务节点随后展示
- Task 节点保留 `SQL` 类型提示，后续 Shell / HTTP / Python 可复用同一树模型

### 3. `+` 统一创建入口

左侧标题右侧只保留一个 `+`：

- 新建节点
- 新建目录

`新建节点` 继续复用现有二阶段 `CreateTaskModal`，没有新造业务流程；在当前目录下触发时会自动带入当前 `directoryId`。

`新建目录` 继续复用现有 `CreateDirectoryModal`，在当前目录下触发时默认以当前目录作为父路径。

### 4. 左侧新增树搜索

在标题下方新增搜索框：

- 支持搜索目录名称 / path
- 支持搜索任务名称 / 描述 / taskId
- 命中子节点时保留父目录链路
- 命中目录时保留该目录下内容，方便继续浏览

### 5. 右侧保持列表管理能力

右侧继续保留现有：

- 任务名称搜索
- 类型筛选
- 草稿 / 已发布筛选
- compact Table
- 独立分页
- 刷新

移除右侧“新建任务”按钮，避免和左侧统一 `+` 形成两个创建入口。

## 变更范围

仅 2 个前端文件：

- `yak-ops-ui/src/pages/data-development/index.tsx`
- `yak-ops-ui/src/pages/data-development/components/DevelopmentTreePane.tsx`

无后端变更。

## 验证

- 基于最新 `main` 创建分支
- compare：ahead 2 / behind 0
- diff 仅包含 `yak-ops-ui` 下两个文件
- 保持 Draft，供本地 TypeScript 构建和视觉交互确认