### PR TITLE
refactor(data-development): add typed node create submenu

### DIFF
--- a/yak-ops-ui/src/pages/data-development/components/CreateTaskModal.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/CreateTaskModal.tsx
@@ -7,7 +7,6 @@ interface CreateTaskModalProps {
   open: boolean;
   type: DevelopmentTaskType;
   directories: DevelopmentDirectory[];
-  projects: API.ProjectBrief[];
   defaultProjectId?: number;
   defaultDirectoryId?: number;
   onCancel: () => void;
@@ -23,7 +22,6 @@ export default function CreateTaskModal({
   open,
   type: initialType,
   directories,
-  projects,
   defaultProjectId,
   defaultDirectoryId,
   onCancel,
@@ -63,6 +61,16 @@ export default function CreateTaskModal({
 
   const normalizedName = name.trim();
 
+  const submit = () => {
+    if (!normalizedName) return;
+    onNext(
+      type,
+      projectId,
+      directoryId && directoryId > 0 ? directoryId : undefined,
+      normalizedName,
+    );
+  };
+
   return (
     <Modal
       open={open}
@@ -73,15 +81,7 @@ export default function CreateTaskModal({
       okButtonProps={{ disabled: !normalizedName }}
       destroyOnClose
       onCancel={onCancel}
-      onOk={() => {
-        if (!normalizedName) return;
-        onNext(
-          type,
-          projectId,
-          directoryId && directoryId > 0 ? directoryId : undefined,
-          normalizedName,
-        );
-      }}
+      onOk={submit}
     >
       <div className="grid grid-cols-[88px_minmax(0,1fr)] items-center gap-y-3 pt-2">
         <Typography.Text className="text-[13px] text-[#344054]">
@@ -118,15 +118,7 @@ export default function CreateTaskModal({
           maxLength={128}
           placeholder="名称"
           onChange={(event) => setName(event.target.value)}
-          onPressEnter={() => {
-            if (!normalizedName) return;
-            onNext(
-              type,
-              projectId,
-              directoryId && directoryId > 0 ? directoryId : undefined,
-              normalizedName,
-            );
-          }}
+          onPressEnter={submit}
         />
       </div>
     </Modal>

--- a/yak-ops-ui/src/pages/data-development/components/CreateTaskModal.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/CreateTaskModal.tsx
@@ -1,145 +1,133 @@
-import { Modal, Select, Tag, Typography } from 'antd';
-import { Braces, Code2, Globe2, TerminalSquare } from 'lucide-react';
-import type { ReactNode } from 'react';
+import { Input, Modal, Select, Typography } from 'antd';
 import { useEffect, useMemo, useState } from 'react';
 
-import type { DevelopmentTaskType } from '../types';
+import type { DevelopmentDirectory, DevelopmentTaskType } from '../types';
 
 interface CreateTaskModalProps {
   open: boolean;
+  type: DevelopmentTaskType;
+  directories: DevelopmentDirectory[];
   projects: API.ProjectBrief[];
   defaultProjectId?: number;
+  defaultDirectoryId?: number;
   onCancel: () => void;
-  onNext: (type: DevelopmentTaskType, projectId?: number) => void;
+  onNext: (
+    type: DevelopmentTaskType,
+    projectId: number | undefined,
+    directoryId: number | undefined,
+    name: string,
+  ) => void;
 }
-
-const taskTypes: Array<{
-  type: DevelopmentTaskType;
-  title: string;
-  description: string;
-  icon: ReactNode;
-  enabled: boolean;
-}> = [
-  {
-    type: 'SQL',
-    title: 'SQL',
-    description: '执行数据库 SQL，支持参数、测试运行和版本发布。',
-    icon: <Code2 size={20} strokeWidth={1.8} />,
-    enabled: true,
-  },
-  {
-    type: 'SHELL',
-    title: 'Shell',
-    description: '执行 Shell 脚本，后续通过统一执行器接入。',
-    icon: <TerminalSquare size={20} strokeWidth={1.8} />,
-    enabled: false,
-  },
-  {
-    type: 'HTTP',
-    title: 'HTTP',
-    description: '调用 HTTP API，后续通过统一执行器接入。',
-    icon: <Globe2 size={20} strokeWidth={1.8} />,
-    enabled: false,
-  },
-  {
-    type: 'PYTHON',
-    title: 'Python',
-    description: '执行 Python 脚本，后续通过统一执行器接入。',
-    icon: <Braces size={20} strokeWidth={1.8} />,
-    enabled: false,
-  },
-];
 
 export default function CreateTaskModal({
   open,
+  type: initialType,
+  directories,
   projects,
   defaultProjectId,
+  defaultDirectoryId,
   onCancel,
   onNext,
 }: CreateTaskModalProps) {
-  const [type, setType] = useState<DevelopmentTaskType>('SQL');
+  const [type, setType] = useState<DevelopmentTaskType>(initialType);
   const [projectId, setProjectId] = useState<number>();
+  const [directoryId, setDirectoryId] = useState<number>();
+  const [name, setName] = useState('');
 
-  const projectOptions = useMemo(
-    () => projects.map((project) => ({
-      label: project.projectName,
-      value: Number(project.id),
-    })),
-    [projects],
+  const typeOptions = useMemo(
+    () => [
+      { label: 'SQL', value: 'SQL' },
+      { label: 'Shell', value: 'SHELL' },
+    ],
+    [],
+  );
+
+  const pathOptions = useMemo(
+    () => [
+      { label: '/', value: 0 },
+      ...directories.map((directory) => ({
+        label: directory.path,
+        value: Number(directory.id),
+      })),
+    ],
+    [directories],
   );
 
   useEffect(() => {
     if (!open) return;
-    setType('SQL');
+    setType(initialType);
     setProjectId(defaultProjectId);
-  }, [defaultProjectId, open]);
+    setDirectoryId(defaultDirectoryId);
+    setName('');
+  }, [defaultDirectoryId, defaultProjectId, initialType, open]);
+
+  const normalizedName = name.trim();
 
   return (
     <Modal
       open={open}
-      title="新建数据开发任务"
-      width={720}
-      okText="下一步"
+      title="新建节点"
+      width={600}
+      okText="确认"
       cancelText="取消"
+      okButtonProps={{ disabled: !normalizedName }}
       destroyOnClose
       onCancel={onCancel}
-      onOk={() => onNext(type, projectId)}
+      onOk={() => {
+        if (!normalizedName) return;
+        onNext(
+          type,
+          projectId,
+          directoryId && directoryId > 0 ? directoryId : undefined,
+          normalizedName,
+        );
+      }}
     >
-      <div className="pt-2">
-        <div className="mb-5">
-          <Typography.Text className="mb-2 block text-[13px] font-medium text-[#161823]">
-            所属项目（可选）
-          </Typography.Text>
-          <Select
-            allowClear
-            value={projectId}
-            options={projectOptions}
-            className="w-full"
-            placeholder="可选，未选择则不归属项目"
-            showSearch
-            optionFilterProp="label"
-            onChange={(value) => setProjectId(value ? Number(value) : undefined)}
-          />
-        </div>
-
-        <Typography.Text className="mb-2 block text-[13px] font-medium text-[#161823]">
-          任务类型
+      <div className="grid grid-cols-[88px_minmax(0,1fr)] items-center gap-y-3 pt-2">
+        <Typography.Text className="text-[13px] text-[#344054]">
+          <span className="mr-1 text-[rgba(254,44,85,1)]">*</span>
+          类型：
         </Typography.Text>
-        <div className="grid grid-cols-2 gap-3">
-          {taskTypes.map((item) => {
-            const selected = type === item.type;
-            return (
-              <button
-                key={item.type}
-                type="button"
-                disabled={!item.enabled}
-                onClick={() => item.enabled && setType(item.type)}
-                className={[
-                  'relative min-h-[104px] rounded-xl border p-4 text-left transition-all',
-                  item.enabled
-                    ? 'cursor-pointer bg-white hover:border-[#b8bec8]'
-                    : 'cursor-not-allowed bg-[#fafafa] opacity-65',
-                  selected && item.enabled
-                    ? 'border-[#161823] shadow-[0_0_0_1px_#161823]'
-                    : 'border-[#e4e7ec]',
-                ].join(' ')}
-              >
-                <div className="mb-3 flex items-center justify-between">
-                  <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-[#f5f5f5] text-[#161823]">
-                    {item.icon}
-                  </span>
-                  {!item.enabled && <Tag className="!m-0">后续</Tag>}
-                </div>
-                <div className="text-[14px] font-semibold text-[#161823]">
-                  {item.title}
-                </div>
-                <div className="mt-1 text-[12px] leading-5 text-[rgba(22,24,35,.5)]">
-                  {item.description}
-                </div>
-              </button>
+        <Select
+          value={type}
+          options={typeOptions}
+          className="w-full"
+          onChange={(value) => setType(value as DevelopmentTaskType)}
+        />
+
+        <Typography.Text className="text-[13px] text-[#344054]">
+          <span className="mr-1 text-[rgba(254,44,85,1)]">*</span>
+          路径：
+        </Typography.Text>
+        <Select
+          value={directoryId ?? 0}
+          options={pathOptions}
+          showSearch
+          optionFilterProp="label"
+          className="w-full"
+          onChange={(value) => setDirectoryId(Number(value) || undefined)}
+        />
+
+        <Typography.Text className="text-[13px] text-[#344054]">
+          <span className="mr-1 text-[rgba(254,44,85,1)]">*</span>
+          名称：
+        </Typography.Text>
+        <Input
+          autoFocus
+          value={name}
+          maxLength={128}
+          placeholder="名称"
+          onChange={(event) => setName(event.target.value)}
+          onPressEnter={() => {
+            if (!normalizedName) return;
+            onNext(
+              type,
+              projectId,
+              directoryId && directoryId > 0 ? directoryId : undefined,
+              normalizedName,
             );
-          })}
-        </div>
+          }}
+        />
       </div>
     </Modal>
   );

--- a/yak-ops-ui/src/pages/data-development/components/DevelopmentTreePane.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/DevelopmentTreePane.tsx
@@ -10,10 +10,12 @@ import {
   FolderPlus,
   Plus,
   Search,
+  TerminalSquare,
 } from 'lucide-react';
 import type { PointerEvent as ReactPointerEvent } from 'react';
 
 export type DevelopmentTreeNodeType = 'root' | 'directory' | 'task';
+export type DevelopmentNodeCreateType = 'SQL' | 'SHELL';
 
 export interface DevelopmentTreeNode extends DataNode {
   key: string;
@@ -34,7 +36,7 @@ interface DevelopmentTreePaneProps {
   leftWidth: number;
   collapsed: boolean;
   onCreateDirectory: () => void;
-  onCreateNode: () => void;
+  onCreateNode: (type: DevelopmentNodeCreateType) => void;
   onSearchChange: (value: string) => void;
   onSelect: TreeProps['onSelect'];
   onResizeStart: (event: ReactPointerEvent) => void;
@@ -60,6 +62,18 @@ const DevelopmentTreePane = ({
       key: 'node',
       label: '新建节点',
       icon: <Code2 size={14} strokeWidth={1.8} />,
+      children: [
+        {
+          key: 'node-sql',
+          label: 'SQL 节点',
+          icon: <Code2 size={14} strokeWidth={1.8} />,
+        },
+        {
+          key: 'node-shell',
+          label: 'Shell 节点',
+          icon: <TerminalSquare size={14} strokeWidth={1.8} />,
+        },
+      ],
     },
     {
       key: 'directory',
@@ -135,9 +149,13 @@ const DevelopmentTreePane = ({
               placement="bottomRight"
               menu={{
                 items: createMenuItems,
+                triggerSubMenuAction: 'hover',
+                subMenuOpenDelay: 0.05,
+                subMenuCloseDelay: 0.1,
                 onClick: ({ key }) => {
                   if (key === 'directory') onCreateDirectory();
-                  if (key === 'node') onCreateNode();
+                  if (key === 'node-sql') onCreateNode('SQL');
+                  if (key === 'node-shell') onCreateNode('SHELL');
                 },
               }}
             >

--- a/yak-ops-ui/src/pages/data-development/index.tsx
+++ b/yak-ops-ui/src/pages/data-development/index.tsx
@@ -24,6 +24,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import CreateDirectoryModal from './components/CreateDirectoryModal';
 import CreateTaskModal from './components/CreateTaskModal';
 import DevelopmentTreePane, {
+  type DevelopmentNodeCreateType,
   type DevelopmentTreeNode,
 } from './components/DevelopmentTreePane';
 import {
@@ -111,6 +112,7 @@ export default function DataDevelopmentPage() {
   const [loading, setLoading] = useState(false);
   const [treeLoading, setTreeLoading] = useState(false);
   const [createOpen, setCreateOpen] = useState(false);
+  const [createType, setCreateType] = useState<DevelopmentNodeCreateType>('SQL');
   const [directoryOpen, setDirectoryOpen] = useState(false);
   const [directorySaving, setDirectorySaving] = useState(false);
   const [treeKeyword, setTreeKeyword] = useState('');
@@ -476,7 +478,10 @@ export default function DataDevelopmentPage() {
             leftWidth={leftWidth}
             collapsed={leftCollapsed}
             onCreateDirectory={() => setDirectoryOpen(true)}
-            onCreateNode={() => setCreateOpen(true)}
+            onCreateNode={(type) => {
+              setCreateType(type);
+              setCreateOpen(true);
+            }}
             onSearchChange={setTreeKeyword}
             onResizeStart={handleResizeStart}
             onCollapsedChange={setLeftCollapsed}
@@ -588,16 +593,19 @@ export default function DataDevelopmentPage() {
 
         <CreateTaskModal
           open={createOpen}
-          projects={projects}
+          type={createType}
+          directories={directories}
           defaultProjectId={
             currentProject?.id ? Number(currentProject.id) : undefined
           }
+          defaultDirectoryId={directoryIdForSelection}
           onCancel={() => setCreateOpen(false)}
-          onNext={(type, projectId) => {
+          onNext={(type, projectId, directoryId, name) => {
             setCreateOpen(false);
             const params = new URLSearchParams();
             params.set('type', type);
-            params.set('directoryId', String(directoryIdForSelection || 0));
+            params.set('directoryId', String(directoryId || 0));
+            params.set('name', name);
             if (projectId) params.set('projectId', String(projectId));
             history.push(`/data-development/task/new?${params.toString()}`);
           }}

--- a/yak-ops-ui/src/pages/data-development/task/SqlTaskEditor.tsx
+++ b/yak-ops-ui/src/pages/data-development/task/SqlTaskEditor.tsx
@@ -57,6 +57,7 @@ import {
 
 interface SqlTaskEditorProps {
   taskId?: number;
+  initialName?: string;
   initialProjectId?: number;
   initialDirectoryId?: number;
 }
@@ -123,12 +124,14 @@ const executionStatusText: Record<string, string> = {
 
 export default function SqlTaskEditor({
   taskId,
+  initialName,
   initialProjectId,
   initialDirectoryId,
 }: SqlTaskEditorProps) {
   const { projects } = useSecurityProject();
   const [draft, setDraft] = useState<DraftState>(() => ({
     ...EMPTY_DRAFT,
+    name: initialName || '',
     projectId: initialProjectId,
     directoryId: initialDirectoryId,
   }));

--- a/yak-ops-ui/src/pages/data-development/task/index.tsx
+++ b/yak-ops-ui/src/pages/data-development/task/index.tsx
@@ -11,6 +11,7 @@ export default function DataDevelopmentTaskPage() {
   const requestedType = (params.get('type') || 'SQL').toUpperCase() as DevelopmentTaskType;
   const projectId = Number(params.get('projectId') || 0) || undefined;
   const directoryId = Number(params.get('directoryId') || 0) || undefined;
+  const initialName = params.get('name')?.trim() || undefined;
   const taskId = id ? Number(id) : undefined;
 
   if (requestedType !== 'SQL') {
@@ -26,6 +27,7 @@ export default function DataDevelopmentTaskPage() {
   return (
     <SqlTaskEditor
       taskId={taskId}
+      initialName={initialName}
       initialProjectId={projectId}
       initialDirectoryId={directoryId}
     />


### PR DESCRIPTION
## 目标

继续收口数据开发左侧资源树的创建交互，使 `+` 菜单更接近开发平台常见的二级节点创建方式。

本 PR **仅修改前端**，不调整后端、API、数据库或任务执行能力。

## 创建交互

```text
+
├─ 新建节点  >
│  ├─ SQL 节点
│  └─ Shell 节点
└─ 新建目录
```

- 点击 `+` 打开一级菜单
- Hover `新建节点` 时，右侧自动展开节点类型子菜单
- 点击 SQL / Shell 后打开统一的「新建节点」Modal

## 新建节点 Modal

Modal 收敛为最终确认信息：

- 类型：SQL / Shell
- 路径：`/` 或已有开发目录
- 名称：节点名称

行为：

- 从 SQL 子菜单进入时默认类型为 SQL
- 从 Shell 子菜单进入时默认类型为 Shell
- 当前左侧选中的目录自动作为默认路径
- Modal 内仍允许切换 SQL / Shell
- 当前 Security Project 继续作为默认项目上下文，但不再占用创建 Modal 的主要交互

## SQL 联动

SQL 节点确认后继续进入现有 SQL Editor，并将：

- 节点名称
- 目录
- 当前项目上下文

作为初始值带入，因此用户不需要进入配置页后重复填写名称和路径。

## Shell 边界

当前只开放 Shell 的统一创建入口和 Modal 交互，不伪造后端能力。

确认 Shell 节点后仍进入现有统一 Task Editor 路由，并由当前占位页明确提示 Shell 尚未开放；后续接入 Shell Editor / Executor 时可以直接复用本次创建入口。

## 变更范围

仅前端 5 个文件：

- `yak-ops-ui/src/pages/data-development/components/DevelopmentTreePane.tsx`
- `yak-ops-ui/src/pages/data-development/components/CreateTaskModal.tsx`
- `yak-ops-ui/src/pages/data-development/index.tsx`
- `yak-ops-ui/src/pages/data-development/task/index.tsx`
- `yak-ops-ui/src/pages/data-development/task/SqlTaskEditor.tsx`

## 验证

- 基于合入 #306 后的最新 `main`
- compare：behind 0
- 无后端文件变更
- 保持 Draft，供本地 TypeScript 构建和视觉交互确认