### PR TITLE
refactor(data-development): make resource nodes first-class tree metadata

### DIFF
--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/api/DevelopmentNodeApi.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/api/DevelopmentNodeApi.java
@@ -1,0 +1,17 @@
+package io.yak.ops.business.development.api;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+
+/** HTTP request contracts for data-development tree nodes. */
+public final class DevelopmentNodeApi {
+
+  private DevelopmentNodeApi() {}
+
+  public record CreateRequest(
+      @NotBlank String name,
+      @NotBlank String type,
+      @Min(0) Long projectId,
+      @Min(0) Long directoryId) {
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/controller/v1/DevelopmentNodeController.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/controller/v1/DevelopmentNodeController.java
@@ -1,0 +1,44 @@
+package io.yak.ops.business.development.controller.v1;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.yak.framework.common.Result;
+import io.yak.ops.business.development.api.DevelopmentNodeApi.CreateRequest;
+import io.yak.ops.business.development.domain.DevelopmentNode;
+import io.yak.ops.business.development.service.DevelopmentNodeService;
+import jakarta.validation.Valid;
+import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Lightweight resource-node management for the data-development tree. */
+@Tag(name = "数据开发节点接口")
+@RestController
+@RequestMapping("/api/v1/data-development/nodes")
+public class DevelopmentNodeController {
+
+  private final DevelopmentNodeService service;
+
+  public DevelopmentNodeController(DevelopmentNodeService service) {
+    this.service = service;
+  }
+
+  @Operation(summary = "查询数据开发节点")
+  @GetMapping
+  public Result<List<DevelopmentNode>> list() {
+    return Result.success(service.list());
+  }
+
+  @Operation(summary = "新建数据开发节点")
+  @PostMapping
+  public Result<DevelopmentNode> create(@Valid @RequestBody CreateRequest request) {
+    return Result.success(service.create(
+        request.name(),
+        request.type(),
+        request.projectId(),
+        request.directoryId()));
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/dao/mapper/DevelopmentNodeMapper.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/dao/mapper/DevelopmentNodeMapper.java
@@ -1,0 +1,7 @@
+package io.yak.ops.business.development.dao.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import io.yak.ops.common.bean.po.development.DevelopmentNodePO;
+
+public interface DevelopmentNodeMapper extends BaseMapper<DevelopmentNodePO> {
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/domain/DevelopmentNode.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/domain/DevelopmentNode.java
@@ -1,0 +1,15 @@
+package io.yak.ops.business.development.domain;
+
+import java.time.Instant;
+
+/** Lightweight tree node metadata for data-development resources. */
+public record DevelopmentNode(
+    Long id,
+    String name,
+    String type,
+    Long projectId,
+    Long directoryId,
+    boolean configured,
+    Instant createTime,
+    Instant updateTime) {
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/DevelopmentNodeRepository.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/DevelopmentNodeRepository.java
@@ -1,0 +1,22 @@
+package io.yak.ops.business.development.repository;
+
+import io.yak.ops.business.development.domain.DevelopmentNode;
+import java.util.List;
+import java.util.Optional;
+
+/** Durable repository for data-development tree node metadata. */
+public interface DevelopmentNodeRepository {
+
+  DevelopmentNode insert(
+      String name,
+      String type,
+      Long projectId,
+      Long directoryId,
+      boolean configured);
+
+  Optional<DevelopmentNode> findById(Long id);
+
+  List<DevelopmentNode> list();
+
+  boolean existsByName(Long directoryId, String name);
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/DevelopmentNodeRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/DevelopmentNodeRepositoryAdapter.java
@@ -1,0 +1,88 @@
+package io.yak.ops.business.development.repository;
+
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import io.yak.ops.business.development.dao.mapper.DevelopmentNodeMapper;
+import io.yak.ops.business.development.domain.DevelopmentNode;
+import io.yak.ops.common.bean.po.development.DevelopmentNodePO;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.stereotype.Repository;
+
+/** MyBatis adapter for data-development tree node metadata. */
+@Repository
+public class DevelopmentNodeRepositoryAdapter implements DevelopmentNodeRepository {
+
+  private static final long ROOT_DIRECTORY_ID = 0L;
+
+  private final DevelopmentNodeMapper mapper;
+
+  public DevelopmentNodeRepositoryAdapter(DevelopmentNodeMapper mapper) {
+    this.mapper = mapper;
+  }
+
+  @Override
+  public DevelopmentNode insert(
+      String name,
+      String type,
+      Long projectId,
+      Long directoryId,
+      boolean configured) {
+    Instant now = Instant.now();
+    DevelopmentNodePO po = new DevelopmentNodePO();
+    po.setName(name);
+    po.setType(type);
+    po.setProjectId(projectId);
+    po.setDirectoryId(toStoredDirectoryId(directoryId));
+    po.setConfigured(configured);
+    po.setDeleted(false);
+    po.setCreateTime(now);
+    po.setUpdateTime(now);
+    mapper.insert(po);
+    return toDomain(po);
+  }
+
+  @Override
+  public Optional<DevelopmentNode> findById(Long id) {
+    return Optional.ofNullable(mapper.selectById(id)).map(this::toDomain);
+  }
+
+  @Override
+  public List<DevelopmentNode> list() {
+    return mapper.selectList(
+            new LambdaQueryWrapper<DevelopmentNodePO>()
+                .orderByAsc(DevelopmentNodePO::getName)
+                .orderByAsc(DevelopmentNodePO::getId))
+        .stream()
+        .map(this::toDomain)
+        .toList();
+  }
+
+  @Override
+  public boolean existsByName(Long directoryId, String name) {
+    return mapper.selectCount(
+            new LambdaQueryWrapper<DevelopmentNodePO>()
+                .eq(DevelopmentNodePO::getDirectoryId, toStoredDirectoryId(directoryId))
+                .eq(DevelopmentNodePO::getName, name))
+        > 0L;
+  }
+
+  private Long toStoredDirectoryId(Long directoryId) {
+    return directoryId == null || directoryId <= 0L ? ROOT_DIRECTORY_ID : directoryId;
+  }
+
+  private DevelopmentNode toDomain(DevelopmentNodePO po) {
+    Long directoryId = po.getDirectoryId() == null || po.getDirectoryId() == ROOT_DIRECTORY_ID
+        ? null
+        : po.getDirectoryId();
+    return new DevelopmentNode(
+        po.getId(),
+        po.getName(),
+        po.getType(),
+        po.getProjectId(),
+        directoryId,
+        Boolean.TRUE.equals(po.getConfigured()),
+        po.getCreateTime(),
+        po.getUpdateTime());
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentNodeService.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentNodeService.java
@@ -1,0 +1,84 @@
+package io.yak.ops.business.development.service;
+
+import io.yak.ops.business.development.domain.DevelopmentNode;
+import io.yak.ops.business.development.repository.DevelopmentDirectoryRepository;
+import io.yak.ops.business.development.repository.DevelopmentNodeRepository;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/** Application service for lightweight data-development resource nodes. */
+@Service
+public class DevelopmentNodeService {
+
+  private static final Set<String> SUPPORTED_TYPES = Set.of("SQL", "SHELL", "HTTP", "PYTHON");
+
+  private final DevelopmentNodeRepository repository;
+  private final DevelopmentDirectoryRepository directoryRepository;
+
+  public DevelopmentNodeService(
+      DevelopmentNodeRepository repository,
+      DevelopmentDirectoryRepository directoryRepository) {
+    this.repository = repository;
+    this.directoryRepository = directoryRepository;
+  }
+
+  public List<DevelopmentNode> list() {
+    return repository.list();
+  }
+
+  @Transactional(transactionManager = "yakBusinessTransactionManager", rollbackFor = Exception.class)
+  public DevelopmentNode create(
+      String name,
+      String type,
+      Long projectId,
+      Long directoryId) {
+    String normalizedName = normalizeName(name);
+    String normalizedType = normalizeType(type);
+    Long normalizedProjectId = normalizeProjectId(projectId);
+    Long normalizedDirectoryId = normalizeDirectoryId(directoryId);
+
+    if (normalizedDirectoryId != null && directoryRepository.findById(normalizedDirectoryId).isEmpty()) {
+      throw new IllegalArgumentException("数据开发目录不存在：" + normalizedDirectoryId);
+    }
+    if (repository.existsByName(normalizedDirectoryId, normalizedName)) {
+      throw new IllegalStateException("当前目录下已存在同名节点：" + normalizedName);
+    }
+
+    return repository.insert(
+        normalizedName,
+        normalizedType,
+        normalizedProjectId,
+        normalizedDirectoryId,
+        false);
+  }
+
+  private String normalizeName(String name) {
+    if (name == null || name.isBlank()) throw new IllegalArgumentException("节点名称不能为空");
+    String normalized = name.trim();
+    if (normalized.length() > 200) throw new IllegalArgumentException("节点名称不能超过 200 个字符");
+    if (normalized.contains("/") || normalized.contains("\\")) {
+      throw new IllegalArgumentException("节点名称不能包含 / 或 \\");
+    }
+    return normalized;
+  }
+
+  private String normalizeType(String type) {
+    if (type == null || type.isBlank()) throw new IllegalArgumentException("节点类型不能为空");
+    String normalized = type.trim().toUpperCase(Locale.ROOT);
+    if (!SUPPORTED_TYPES.contains(normalized)) {
+      throw new IllegalArgumentException("不支持的数据开发节点类型：" + normalized);
+    }
+    return normalized;
+  }
+
+  private Long normalizeProjectId(Long projectId) {
+    return projectId == null || projectId <= 0L ? null : projectId;
+  }
+
+  private Long normalizeDirectoryId(Long directoryId) {
+    return directoryId == null || directoryId <= 0L ? null : directoryId;
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentNodeService.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentNodeService.java
@@ -40,7 +40,8 @@ public class DevelopmentNodeService {
     Long normalizedProjectId = normalizeProjectId(projectId);
     Long normalizedDirectoryId = normalizeDirectoryId(directoryId);
 
-    if (normalizedDirectoryId != null && directoryRepository.findById(normalizedDirectoryId).isEmpty()) {
+    if (normalizedDirectoryId != null
+        && directoryRepository.findById(normalizedDirectoryId).isEmpty()) {
       throw new IllegalArgumentException("数据开发目录不存在：" + normalizedDirectoryId);
     }
     if (repository.existsByName(normalizedDirectoryId, normalizedName)) {
@@ -58,9 +59,11 @@ public class DevelopmentNodeService {
   private String normalizeName(String name) {
     if (name == null || name.isBlank()) throw new IllegalArgumentException("节点名称不能为空");
     String normalized = name.trim();
-    if (normalized.length() > 200) throw new IllegalArgumentException("节点名称不能超过 200 个字符");
+    if (normalized.length() > 200) {
+      throw new IllegalArgumentException("节点名称不能超过 200 个字符");
+    }
     if (normalized.contains("/") || normalized.contains("\\")) {
-      throw new IllegalArgumentException("节点名称不能包含 / 或 \\");
+      throw new IllegalArgumentException("节点名称不能包含路径分隔符");
     }
     return normalized;
   }

--- a/yak-ops-business/yak-ops-business-data-development/src/main/resources/db/migration/yak-data-development/V5__create_development_nodes.sql
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/resources/db/migration/yak-data-development/V5__create_development_nodes.sql
@@ -1,0 +1,38 @@
+CREATE TABLE IF NOT EXISTS yak_dev_node (
+    id BIGINT NOT NULL,
+    name VARCHAR(200) NOT NULL,
+    type VARCHAR(32) NOT NULL,
+    project_id BIGINT NULL,
+    directory_id BIGINT NOT NULL DEFAULT 0,
+    configured TINYINT(1) NOT NULL DEFAULT 0,
+    deleted TINYINT(1) NOT NULL DEFAULT 0,
+    create_time DATETIME(6) NOT NULL,
+    update_time DATETIME(6) NOT NULL,
+    PRIMARY KEY (id),
+    KEY idx_yak_dev_node_directory (directory_id, name),
+    KEY idx_yak_dev_node_type (type, update_time),
+    KEY idx_yak_dev_node_project (project_id, update_time)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+INSERT IGNORE INTO yak_dev_node (
+    id,
+    name,
+    type,
+    project_id,
+    directory_id,
+    configured,
+    deleted,
+    create_time,
+    update_time
+)
+SELECT
+    id,
+    name,
+    'SQL',
+    project_id,
+    COALESCE(directory_id, 0),
+    1,
+    deleted,
+    create_time,
+    update_time
+FROM yak_dev_sql_task;

--- a/yak-ops-business/yak-ops-business-data-development/src/main/resources/db/migration/yak-data-development/V5__create_development_nodes.sql
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/resources/db/migration/yak-data-development/V5__create_development_nodes.sql
@@ -9,7 +9,7 @@ CREATE TABLE IF NOT EXISTS yak_dev_node (
     create_time DATETIME(6) NOT NULL,
     update_time DATETIME(6) NOT NULL,
     PRIMARY KEY (id),
-    UNIQUE KEY uk_yak_dev_node_sibling (directory_id, name),
+    KEY idx_yak_dev_node_directory (directory_id, name),
     KEY idx_yak_dev_node_type (type, update_time),
     KEY idx_yak_dev_node_project (project_id, update_time)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/yak-ops-business/yak-ops-business-data-development/src/main/resources/db/migration/yak-data-development/V5__create_development_nodes.sql
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/resources/db/migration/yak-data-development/V5__create_development_nodes.sql
@@ -9,7 +9,7 @@ CREATE TABLE IF NOT EXISTS yak_dev_node (
     create_time DATETIME(6) NOT NULL,
     update_time DATETIME(6) NOT NULL,
     PRIMARY KEY (id),
-    KEY idx_yak_dev_node_directory (directory_id, name),
+    UNIQUE KEY uk_yak_dev_node_sibling (directory_id, name),
     KEY idx_yak_dev_node_type (type, update_time),
     KEY idx_yak_dev_node_project (project_id, update_time)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/DevelopmentNodeServiceTest.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/DevelopmentNodeServiceTest.java
@@ -1,0 +1,140 @@
+package io.yak.ops.business.development.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import io.yak.ops.business.development.domain.DevelopmentDirectory;
+import io.yak.ops.business.development.domain.DevelopmentNode;
+import io.yak.ops.business.development.repository.DevelopmentDirectoryRepository;
+import io.yak.ops.business.development.repository.DevelopmentNodeRepository;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
+import org.junit.jupiter.api.Test;
+
+class DevelopmentNodeServiceTest {
+
+  @Test
+  void createsUnconfiguredSqlAndShellNodes() {
+    InMemoryDirectoryRepository directories = new InMemoryDirectoryRepository();
+    DevelopmentDirectory folder = directories.insert(null, "ODS");
+    DevelopmentNodeService service = new DevelopmentNodeService(
+        new InMemoryNodeRepository(),
+        directories);
+
+    DevelopmentNode sql = service.create("用户清洗", "sql", null, folder.id());
+    DevelopmentNode shell = service.create("清理临时文件", "shell", 7L, null);
+
+    assertEquals("SQL", sql.type());
+    assertEquals(folder.id(), sql.directoryId());
+    assertFalse(sql.configured());
+    assertEquals("SHELL", shell.type());
+    assertEquals(7L, shell.projectId());
+    assertFalse(shell.configured());
+  }
+
+  @Test
+  void rejectsUnknownDirectoryAndDuplicateSiblingName() {
+    InMemoryDirectoryRepository directories = new InMemoryDirectoryRepository();
+    InMemoryNodeRepository nodes = new InMemoryNodeRepository();
+    DevelopmentNodeService service = new DevelopmentNodeService(nodes, directories);
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> service.create("任务", "SQL", null, 999L));
+
+    service.create("任务", "SQL", null, null);
+    assertThrows(
+        IllegalStateException.class,
+        () -> service.create("任务", "SHELL", null, null));
+  }
+
+  private static final class InMemoryNodeRepository implements DevelopmentNodeRepository {
+
+    private final AtomicLong ids = new AtomicLong(1L);
+    private final Map<Long, DevelopmentNode> values = new LinkedHashMap<>();
+
+    @Override
+    public DevelopmentNode insert(
+        String name,
+        String type,
+        Long projectId,
+        Long directoryId,
+        boolean configured) {
+      Long id = ids.getAndIncrement();
+      Instant now = Instant.now();
+      DevelopmentNode node = new DevelopmentNode(
+          id,
+          name,
+          type,
+          projectId,
+          directoryId,
+          configured,
+          now,
+          now);
+      values.put(id, node);
+      return node;
+    }
+
+    @Override
+    public Optional<DevelopmentNode> findById(Long id) {
+      return Optional.ofNullable(values.get(id));
+    }
+
+    @Override
+    public List<DevelopmentNode> list() {
+      return new ArrayList<>(values.values());
+    }
+
+    @Override
+    public boolean existsByName(Long directoryId, String name) {
+      return values.values().stream().anyMatch(node ->
+          java.util.Objects.equals(directoryId, node.directoryId())
+              && name.equals(node.name()));
+    }
+  }
+
+  private static final class InMemoryDirectoryRepository
+      implements DevelopmentDirectoryRepository {
+
+    private final AtomicLong ids = new AtomicLong(1L);
+    private final Map<Long, DevelopmentDirectory> values = new LinkedHashMap<>();
+
+    @Override
+    public DevelopmentDirectory insert(Long parentId, String name) {
+      Long id = ids.getAndIncrement();
+      Instant now = Instant.now();
+      DevelopmentDirectory directory = new DevelopmentDirectory(
+          id,
+          parentId,
+          name,
+          null,
+          now,
+          now);
+      values.put(id, directory);
+      return directory;
+    }
+
+    @Override
+    public Optional<DevelopmentDirectory> findById(Long id) {
+      return Optional.ofNullable(values.get(id));
+    }
+
+    @Override
+    public List<DevelopmentDirectory> list() {
+      return new ArrayList<>(values.values());
+    }
+
+    @Override
+    public boolean existsByName(Long parentId, String name) {
+      return values.values().stream().anyMatch(directory ->
+          java.util.Objects.equals(parentId, directory.parentId())
+              && name.equals(directory.name()));
+    }
+  }
+}

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/development/DevelopmentNodePO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/development/DevelopmentNodePO.java
@@ -1,0 +1,24 @@
+package io.yak.ops.common.bean.po.development;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableLogic;
+import com.baomidou.mybatisplus.annotation.TableName;
+import java.time.Instant;
+import lombok.Data;
+
+/** 数据开发树节点持久化对象。 */
+@Data
+@TableName("yak_dev_node")
+public class DevelopmentNodePO {
+  @TableId(type = IdType.ASSIGN_ID)
+  private Long id;
+  private String name;
+  private String type;
+  private Long projectId;
+  private Long directoryId;
+  private Boolean configured;
+  @TableLogic private Boolean deleted;
+  private Instant createTime;
+  private Instant updateTime;
+}

--- a/yak-ops-ui/src/components/YakEmpty/index.tsx
+++ b/yak-ops-ui/src/components/YakEmpty/index.tsx
@@ -1,4 +1,4 @@
-import { FolderTree } from 'lucide-react';
+import { Folder } from 'lucide-react';
 import type { ReactNode } from 'react';
 
 interface YakEmptyProps {
@@ -27,7 +27,7 @@ const YakEmpty = ({
         compact ? 'h-10 w-10' : 'h-12 w-12',
       ].join(' ')}
     >
-      <FolderTree size={compact ? 20 : 24} strokeWidth={1.4} />
+      <Folder size={compact ? 20 : 24} strokeWidth={1.4} />
     </div>
     <div className="mt-3 text-[13px] font-medium text-[#667085]">{title}</div>
     {description ? (

--- a/yak-ops-ui/src/components/YakEmpty/index.tsx
+++ b/yak-ops-ui/src/components/YakEmpty/index.tsx
@@ -1,0 +1,41 @@
+import { FolderTree } from 'lucide-react';
+import type { ReactNode } from 'react';
+
+interface YakEmptyProps {
+  title?: ReactNode;
+  description?: ReactNode;
+  compact?: boolean;
+  className?: string;
+}
+
+const YakEmpty = ({
+  title = '暂无数据',
+  description,
+  compact = false,
+  className = '',
+}: YakEmptyProps) => (
+  <div
+    className={[
+      'flex w-full flex-col items-center justify-center px-5 text-center',
+      compact ? 'min-h-[180px] py-8' : 'min-h-[320px] py-12',
+      className,
+    ].join(' ')}
+  >
+    <div
+      className={[
+        'flex items-center justify-center rounded-xl bg-[#f6f7f8] text-[#c4c9d1]',
+        compact ? 'h-10 w-10' : 'h-12 w-12',
+      ].join(' ')}
+    >
+      <FolderTree size={compact ? 20 : 24} strokeWidth={1.4} />
+    </div>
+    <div className="mt-3 text-[13px] font-medium text-[#667085]">{title}</div>
+    {description ? (
+      <div className="mt-1 max-w-[240px] text-[11px] leading-5 text-[#98a2b3]">
+        {description}
+      </div>
+    ) : null}
+  </div>
+);
+
+export default YakEmpty;

--- a/yak-ops-ui/src/pages/data-development/components/CreateTaskModal.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/CreateTaskModal.tsx
@@ -9,6 +9,7 @@ interface CreateTaskModalProps {
   directories: DevelopmentDirectory[];
   defaultProjectId?: number;
   defaultDirectoryId?: number;
+  loading?: boolean;
   onCancel: () => void;
   onNext: (
     type: DevelopmentTaskType,
@@ -24,6 +25,7 @@ export default function CreateTaskModal({
   directories,
   defaultProjectId,
   defaultDirectoryId,
+  loading = false,
   onCancel,
   onNext,
 }: CreateTaskModalProps) {
@@ -62,7 +64,7 @@ export default function CreateTaskModal({
   const normalizedName = name.trim();
 
   const submit = () => {
-    if (!normalizedName) return;
+    if (!normalizedName || loading) return;
     onNext(
       type,
       projectId,
@@ -78,8 +80,11 @@ export default function CreateTaskModal({
       width={600}
       okText="确认"
       cancelText="取消"
+      confirmLoading={loading}
       okButtonProps={{ disabled: !normalizedName }}
       destroyOnClose
+      maskClosable={!loading}
+      closable={!loading}
       onCancel={onCancel}
       onOk={submit}
     >
@@ -92,6 +97,7 @@ export default function CreateTaskModal({
           value={type}
           options={typeOptions}
           className="w-full"
+          disabled={loading}
           onChange={(value) => setType(value as DevelopmentTaskType)}
         />
 
@@ -105,6 +111,7 @@ export default function CreateTaskModal({
           showSearch
           optionFilterProp="label"
           className="w-full"
+          disabled={loading}
           onChange={(value) => setDirectoryId(Number(value) || undefined)}
         />
 
@@ -116,6 +123,7 @@ export default function CreateTaskModal({
           autoFocus
           value={name}
           maxLength={128}
+          disabled={loading}
           placeholder="名称"
           onChange={(event) => setName(event.target.value)}
           onPressEnter={submit}

--- a/yak-ops-ui/src/pages/data-development/components/DevelopmentTreePane.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/DevelopmentTreePane.tsx
@@ -1,6 +1,7 @@
+import YakEmpty from '@/components/YakEmpty';
 import type { DataNode } from 'antd/es/tree';
 import type { MenuProps, TreeProps } from 'antd';
-import { Button, Dropdown, Empty, Input, Spin, Tooltip, Tree } from 'antd';
+import { Button, Dropdown, Input, Spin, Tooltip, Tree } from 'antd';
 import {
   ChevronDown,
   ChevronLeft,
@@ -14,7 +15,7 @@ import {
 } from 'lucide-react';
 import type { PointerEvent as ReactPointerEvent } from 'react';
 
-export type DevelopmentTreeNodeType = 'root' | 'directory' | 'task';
+export type DevelopmentTreeNodeType = 'root' | 'directory' | 'node';
 export type DevelopmentNodeCreateType = 'SQL' | 'SHELL';
 
 export interface DevelopmentTreeNode extends DataNode {
@@ -22,8 +23,9 @@ export interface DevelopmentTreeNode extends DataNode {
   title: string;
   nodeType: DevelopmentTreeNodeType;
   directoryId?: number;
-  taskId?: number;
+  nodeId?: number;
   taskType?: string;
+  configured?: boolean;
   searchText?: string;
   children?: DevelopmentTreeNode[];
 }
@@ -84,19 +86,27 @@ const DevelopmentTreePane = ({
 
   const renderTitle: TreeProps['titleRender'] = (rawNode) => {
     const node = rawNode as DevelopmentTreeNode;
-    const isTask = node.nodeType === 'task';
+    const isNode = node.nodeType === 'node';
 
     return (
       <div
         className="flex min-w-0 flex-1 items-center gap-2"
         title={node.title}
       >
-        {isTask ? (
-          <Code2
-            size={13}
-            strokeWidth={1.8}
-            className="shrink-0 text-[#667085]"
-          />
+        {isNode ? (
+          node.taskType === 'SHELL' ? (
+            <TerminalSquare
+              size={13}
+              strokeWidth={1.8}
+              className="shrink-0 text-[#667085]"
+            />
+          ) : (
+            <Code2
+              size={13}
+              strokeWidth={1.8}
+              className="shrink-0 text-[#667085]"
+            />
+          )
         ) : (
           <Folder
             size={14}
@@ -111,13 +121,13 @@ const DevelopmentTreePane = ({
         <span
           className={[
             'min-w-0 flex-1 truncate text-[13px] leading-8',
-            isTask ? 'font-normal text-[#344054]' : 'font-medium text-[#1f2937]',
+            isNode ? 'font-normal text-[#344054]' : 'font-medium text-[#1f2937]',
           ].join(' ')}
         >
           {node.title}
         </span>
 
-        {isTask && node.taskType ? (
+        {isNode && node.taskType ? (
           <span className="shrink-0 text-[10px] text-[#98a2b3]">
             {node.taskType}
           </span>
@@ -201,10 +211,14 @@ const DevelopmentTreePane = ({
                   className="development-tree bg-transparent"
                 />
               ) : (
-                <Empty
-                  image={Empty.PRESENTED_IMAGE_SIMPLE}
-                  description={searchValue.trim() ? '未找到匹配节点' : '暂无开发节点'}
-                  className="mt-10"
+                <YakEmpty
+                  compact
+                  title={searchValue.trim() ? '未找到匹配节点' : '暂无开发节点'}
+                  description={
+                    searchValue.trim()
+                      ? '换个关键词试试'
+                      : '点击右上角 + 创建目录或节点'
+                  }
                 />
               )}
             </Spin>

--- a/yak-ops-ui/src/pages/data-development/index.tsx
+++ b/yak-ops-ui/src/pages/data-development/index.tsx
@@ -29,16 +29,19 @@ import DevelopmentTreePane, {
 } from './components/DevelopmentTreePane';
 import {
   createDevelopmentDirectory,
+  createDevelopmentNode,
   listDevelopmentDirectories,
+  listDevelopmentNodes,
   listSqlTasks,
 } from './service';
 import type {
   DevelopmentDirectory,
+  DevelopmentNode,
   DevelopmentTaskRow,
   DevelopmentTaskType,
 } from './types';
 
-type TreeFilterKey = 'root' | `directory:${number}` | `task:${number}`;
+type TreeFilterKey = 'root' | `directory:${number}` | `node:${number}`;
 type PublishFilter = 'ALL' | 'DRAFT' | 'PUBLISHED';
 
 const DEFAULT_LEFT_WIDTH = 272;
@@ -48,7 +51,7 @@ const LEFT_WIDTH_STORAGE_KEY = 'yak-data-development.left-width';
 
 const directoryKey = (directoryId: number): TreeFilterKey =>
   `directory:${directoryId}`;
-const taskKey = (taskId: number): TreeFilterKey => `task:${taskId}`;
+const nodeKey = (nodeId: number): TreeFilterKey => `node:${nodeId}`;
 
 const numberFromKey = (key: string, prefix: string) => {
   if (!key.startsWith(prefix)) return undefined;
@@ -107,12 +110,14 @@ const taskTableClassName = [
 export default function DataDevelopmentPage() {
   const { projects, currentProject } = useSecurityProject();
   const [tasks, setTasks] = useState<DevelopmentTaskRow[]>([]);
+  const [nodes, setNodes] = useState<DevelopmentNode[]>([]);
   const [directories, setDirectories] = useState<DevelopmentDirectory[]>([]);
   const [dataSources, setDataSources] = useState<DataSourceRecord[]>([]);
   const [loading, setLoading] = useState(false);
   const [treeLoading, setTreeLoading] = useState(false);
   const [createOpen, setCreateOpen] = useState(false);
   const [createType, setCreateType] = useState<DevelopmentNodeCreateType>('SQL');
+  const [nodeSaving, setNodeSaving] = useState(false);
   const [directoryOpen, setDirectoryOpen] = useState(false);
   const [directorySaving, setDirectorySaving] = useState(false);
   const [treeKeyword, setTreeKeyword] = useState('');
@@ -126,14 +131,19 @@ export default function DataDevelopmentPage() {
   const [current, setCurrent] = useState(1);
   const [pageSize, setPageSize] = useState(20);
 
-  const loadDirectories = useCallback(async () => {
+  const loadTree = useCallback(async () => {
     setTreeLoading(true);
     try {
-      const response = await listDevelopmentDirectories();
-      setDirectories(responseData(response, '查询数据开发目录失败') || []);
+      const [directoryResponse, nodeResponse] = await Promise.all([
+        listDevelopmentDirectories(),
+        listDevelopmentNodes(),
+      ]);
+      setDirectories(responseData(directoryResponse, '查询数据开发目录失败') || []);
+      setNodes(responseData(nodeResponse, '查询数据开发节点失败') || []);
     } catch (error) {
-      message.error(error instanceof Error ? error.message : '查询数据开发目录失败');
+      message.error(error instanceof Error ? error.message : '查询数据开发树失败');
       setDirectories([]);
+      setNodes([]);
     } finally {
       setTreeLoading(false);
     }
@@ -164,8 +174,8 @@ export default function DataDevelopmentPage() {
 
   useEffect(() => {
     void load();
-    void loadDirectories();
-  }, [load, loadDirectories]);
+    void loadTree();
+  }, [load, loadTree]);
 
   const projectNameMap = useMemo(
     () => new Map(projects.map((project) => [Number(project.id), project.projectName])),
@@ -179,29 +189,43 @@ export default function DataDevelopmentPage() {
     () => new Map(directories.map((directory) => [Number(directory.id), directory])),
     [directories],
   );
-
-  const directoryIdForSelection = useMemo(
-    () => numberFromKey(selectedNode, 'directory:'),
-    [selectedNode],
+  const nodeMap = useMemo(
+    () => new Map(nodes.map((node) => [Number(node.id), node])),
+    [nodes],
   );
 
+  const selectedResourceNodeId = useMemo(
+    () => numberFromKey(selectedNode, 'node:'),
+    [selectedNode],
+  );
+  const directoryIdForSelection = useMemo(() => {
+    const selectedDirectoryId = numberFromKey(selectedNode, 'directory:');
+    if (selectedDirectoryId) return selectedDirectoryId;
+    if (!selectedResourceNodeId) return undefined;
+    const resourceNode = nodeMap.get(selectedResourceNodeId);
+    return resourceNode?.directoryId ? Number(resourceNode.directoryId) : undefined;
+  }, [nodeMap, selectedNode, selectedResourceNodeId]);
+
   const fullTreeData = useMemo<DevelopmentTreeNode[]>(() => {
-    const taskNodes = (directoryId?: number): DevelopmentTreeNode[] =>
-      tasks
-        .filter((task) => {
-          const taskDirectoryId = task.directoryId
-            ? Number(task.directoryId)
+    if (!directories.length && !nodes.length) return [];
+
+    const resourceNodes = (directoryId?: number): DevelopmentTreeNode[] =>
+      nodes
+        .filter((node) => {
+          const nodeDirectoryId = node.directoryId
+            ? Number(node.directoryId)
             : undefined;
-          return taskDirectoryId === directoryId;
+          return nodeDirectoryId === directoryId;
         })
         .sort((left, right) => left.name.localeCompare(right.name, 'zh-CN'))
-        .map((task) => ({
-          key: taskKey(Number(task.id)),
-          title: task.name,
-          nodeType: 'task',
-          taskId: Number(task.id),
-          taskType: task.type,
-          searchText: `${task.name} ${task.description || ''} ${task.id}`,
+        .map((node) => ({
+          key: nodeKey(Number(node.id)),
+          title: node.name,
+          nodeType: 'node',
+          nodeId: Number(node.id),
+          taskType: node.type,
+          configured: node.configured,
+          searchText: `${node.name} ${node.type} ${node.id}`,
           isLeaf: true,
         }));
 
@@ -219,7 +243,7 @@ export default function DataDevelopmentPage() {
             searchText: `${directory.name} ${directory.path || ''}`,
             children: [
               ...directoryNodes(directoryId),
-              ...taskNodes(directoryId),
+              ...resourceNodes(directoryId),
             ],
           };
         });
@@ -230,19 +254,19 @@ export default function DataDevelopmentPage() {
         title: '/',
         nodeType: 'root',
         searchText: '/',
-        children: [...directoryNodes(), ...taskNodes()],
+        children: [...directoryNodes(), ...resourceNodes()],
       },
     ];
-  }, [directories, tasks]);
+  }, [directories, nodes]);
 
   const treeData = useMemo<DevelopmentTreeNode[]>(() => {
     const normalized = treeKeyword.trim().toLowerCase();
     if (!normalized) return fullTreeData;
 
     const filterNodes = (
-      nodes: DevelopmentTreeNode[],
+      values: DevelopmentTreeNode[],
     ): DevelopmentTreeNode[] =>
-      nodes.flatMap((node) => {
+      values.flatMap((node) => {
         const children = node.children ? filterNodes(node.children) : [];
         const text = `${node.title} ${node.searchText || ''}`.toLowerCase();
         const selfMatched = node.nodeType !== 'root' && text.includes(normalized);
@@ -449,7 +473,8 @@ export default function DataDevelopmentPage() {
         await createDevelopmentDirectory({ parentId, name }),
         '新建目录失败',
       );
-      await loadDirectories();
+      setTreeKeyword('');
+      await loadTree();
       setDirectoryOpen(false);
       setSelectedNode(directoryKey(Number(created.id)));
       message.success('目录创建成功');
@@ -457,6 +482,35 @@ export default function DataDevelopmentPage() {
       message.error(error instanceof Error ? error.message : '新建目录失败');
     } finally {
       setDirectorySaving(false);
+    }
+  };
+
+  const submitNode = async (
+    type: DevelopmentTaskType,
+    projectId: number | undefined,
+    directoryId: number | undefined,
+    name: string,
+  ) => {
+    setNodeSaving(true);
+    try {
+      const created = responseData(
+        await createDevelopmentNode({
+          name,
+          type,
+          projectId,
+          directoryId,
+        }),
+        '新建节点失败',
+      );
+      setTreeKeyword('');
+      await loadTree();
+      setCreateOpen(false);
+      setSelectedNode(nodeKey(Number(created.id)));
+      message.success('节点创建成功');
+    } catch (error) {
+      message.error(error instanceof Error ? error.message : '新建节点失败');
+    } finally {
+      setNodeSaving(false);
     }
   };
 
@@ -472,7 +526,7 @@ export default function DataDevelopmentPage() {
         <div className="flex min-h-0 flex-1 overflow-hidden">
           <DevelopmentTreePane
             treeData={treeData}
-            treeLoading={treeLoading || loading}
+            treeLoading={treeLoading}
             selectedNodeKey={selectedNode}
             searchValue={treeKeyword}
             leftWidth={leftWidth}
@@ -488,13 +542,7 @@ export default function DataDevelopmentPage() {
             onSelect={(keys) => {
               const key = keys[0];
               if (!key) return;
-              const normalizedKey = String(key) as TreeFilterKey;
-              const selectedTaskId = numberFromKey(normalizedKey, 'task:');
-              if (selectedTaskId) {
-                history.push(`/data-development/task/${selectedTaskId}`);
-                return;
-              }
-              setSelectedNode(normalizedKey);
+              setSelectedNode(String(key) as TreeFilterKey);
             }}
           />
 
@@ -542,7 +590,7 @@ export default function DataDevelopmentPage() {
                   icon={<RefreshCw size={14} />}
                   onClick={() => {
                     void load();
-                    void loadDirectories();
+                    void loadTree();
                   }}
                 />
               </div>
@@ -599,15 +647,12 @@ export default function DataDevelopmentPage() {
             currentProject?.id ? Number(currentProject.id) : undefined
           }
           defaultDirectoryId={directoryIdForSelection}
-          onCancel={() => setCreateOpen(false)}
+          loading={nodeSaving}
+          onCancel={() => {
+            if (!nodeSaving) setCreateOpen(false);
+          }}
           onNext={(type, projectId, directoryId, name) => {
-            setCreateOpen(false);
-            const params = new URLSearchParams();
-            params.set('type', type);
-            params.set('directoryId', String(directoryId || 0));
-            params.set('name', name);
-            if (projectId) params.set('projectId', String(projectId));
-            history.push(`/data-development/task/new?${params.toString()}`);
+            void submitNode(type, projectId, directoryId, name);
           }}
         />
 

--- a/yak-ops-ui/src/pages/data-development/service.ts
+++ b/yak-ops-ui/src/pages/data-development/service.ts
@@ -3,7 +3,9 @@ import HttpUtils from '@/utils/HttpUtils';
 
 import type {
   CreateDevelopmentDirectoryPayload,
+  CreateDevelopmentNodePayload,
   DevelopmentDirectory,
+  DevelopmentNode,
   SqlTaskDefinition,
   SqlTaskExecution,
   SqlTaskSavePayload,
@@ -14,6 +16,7 @@ import type {
 const DATA_DEVELOPMENT_API = '/api/v1/data-development';
 const SQL_TASK_API = `${DATA_DEVELOPMENT_API}/sql-tasks`;
 const DIRECTORY_API = `${DATA_DEVELOPMENT_API}/directories`;
+const NODE_API = `${DATA_DEVELOPMENT_API}/nodes`;
 
 const queryString = (params: Record<string, unknown>) => {
   const search = new URLSearchParams();
@@ -33,6 +36,14 @@ export const createDevelopmentDirectory = (
   payload: CreateDevelopmentDirectoryPayload,
 ): Promise<ApiResponse<DevelopmentDirectory>> =>
   HttpUtils.post<DevelopmentDirectory>(DIRECTORY_API, payload);
+
+export const listDevelopmentNodes = (): Promise<ApiResponse<DevelopmentNode[]>> =>
+  HttpUtils.get<DevelopmentNode[]>(NODE_API);
+
+export const createDevelopmentNode = (
+  payload: CreateDevelopmentNodePayload,
+): Promise<ApiResponse<DevelopmentNode>> =>
+  HttpUtils.post<DevelopmentNode>(NODE_API, payload);
 
 export const listSqlTasks = (
   projectId?: number,

--- a/yak-ops-ui/src/pages/data-development/types.ts
+++ b/yak-ops-ui/src/pages/data-development/types.ts
@@ -24,6 +24,25 @@ export interface CreateDevelopmentDirectoryPayload {
   name: string;
 }
 
+export interface DevelopmentNode {
+  id: number;
+  name: string;
+  type: DevelopmentTaskType;
+  projectId?: number | null;
+  directoryId?: number | null;
+  configured: boolean;
+  createTime?: string;
+  updateTime?: string;
+}
+
+export interface CreateDevelopmentNodePayload {
+  name: string;
+  type: DevelopmentTaskType;
+  projectId?: number;
+  /** 0 或省略表示数据开发根目录。 */
+  directoryId?: number;
+}
+
 export interface SqlParameterDefinition {
   name: string;
   type: SqlParameterType;


### PR DESCRIPTION
## 目标

先完成数据开发“树节点”这一层，暂不重构右侧工作区。

本 PR 将创建流程从：

```text
新建节点 -> 跳转详情页 -> 再创建 SQL 草稿
```

调整为：

```text
新建节点 -> 创建轻量 DevelopmentNode -> 刷新左侧树 -> 留在当前页面
```

## 前端行为

### 节点创建不再跳详情

- SQL / Shell 节点都先创建为轻量树节点
- Modal 确认后调用 `/api/v1/data-development/nodes`
- 创建成功后关闭 Modal
- 重新加载 `directories + nodes`
- 左树立即出现并选中新节点
- 不再 `history.push(/data-development/task/new...)`
- 点击左侧节点当前也只做选中，不跳详情页

### 空树使用 YakEmpty

首次进入数据开发、既没有目录也没有节点时：

- 顶部仍保留“开发目录”
- 保留 `+` 创建入口
- 保留搜索框
- 树内容区使用新的通用 `YakEmpty`
- 创建第一个目录或节点后才显示 `/` 根树

`YakEmpty` 放在 `yak-ops-ui/src/components/YakEmpty`，后续右侧空白欢迎区可以复用。

### 当前目录语义

- 选中目录后创建节点：默认创建到该目录
- 选中节点后继续创建：默认使用该节点所在目录
- 创建成功后会清空树搜索，保证新节点可见

## 后端模型

新增独立 `DevelopmentNode` 元数据层：

```text
id
name
type            SQL / SHELL / HTTP / PYTHON
projectId       optional
directoryId     optional
configured      false = 仅创建节点，尚未完成业务配置
createTime
updateTime
```

接口：

- `GET /api/v1/data-development/nodes`
- `POST /api/v1/data-development/nodes`

节点创建不要求数据源、SQL、参数，因此 SQL / Shell 可以先进入开发树，再由右侧工作区逐步完成配置。

## 数据迁移

新增 `V5__create_development_nodes.sql`：

- 创建 `yak_dev_node`
- 将现有 `yak_dev_sql_task` 全量回填为 `type=SQL, configured=true` 的节点
- 沿用现有 SQL Task ID，后续可以让专业配置表和 DevelopmentNode 使用同一逻辑 ID
- 不强加同目录历史名称唯一约束，避免老 SQL 存在重名时丢失回填节点

## 扩展性

第一步 UI 暂时只显示 SQL / Shell 创建入口，但后端节点类型已经预留：

- SQL
- SHELL
- HTTP
- PYTHON

后续增加类型时，树模型不需要重构。

## 暂不处理

本 PR 刻意不重构右侧：

- 不实现“选中节点 -> 右侧编辑器”
- 不修改 SQL Editor
- 不修改 Workflow
- 不修改 SQL 发布/运行逻辑

下一步再围绕 `selected DevelopmentNode` 重做右侧工作区。

## 验证

- 分支基于最新 `main`
- compare：behind 0
- 新增 `DevelopmentNodeServiceTest`
- 保持 Draft，供本地 Maven / TypeScript 构建和页面交互确认