### PR TITLE
fix(data-development): preserve directory ids and use tree path selector

### DIFF
--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/domain/DevelopmentDirectory.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/domain/DevelopmentDirectory.java
@@ -1,11 +1,13 @@
 package io.yak.ops.business.development.domain;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 import java.time.Instant;
 
 /** Hierarchical directory used to organize data-development tasks. */
 public record DevelopmentDirectory(
-    Long id,
-    Long parentId,
+    @JsonSerialize(using = ToStringSerializer.class) Long id,
+    @JsonSerialize(using = ToStringSerializer.class) Long parentId,
     String name,
     String path,
     Instant createTime,

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/domain/DevelopmentNode.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/domain/DevelopmentNode.java
@@ -1,14 +1,16 @@
 package io.yak.ops.business.development.domain;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 import java.time.Instant;
 
 /** Lightweight tree node metadata for data-development resources. */
 public record DevelopmentNode(
-    Long id,
+    @JsonSerialize(using = ToStringSerializer.class) Long id,
     String name,
     String type,
-    Long projectId,
-    Long directoryId,
+    @JsonSerialize(using = ToStringSerializer.class) Long projectId,
+    @JsonSerialize(using = ToStringSerializer.class) Long directoryId,
     boolean configured,
     Instant createTime,
     Instant updateTime) {

--- a/yak-ops-ui/src/pages/data-development/components/CreateDirectoryModal.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/CreateDirectoryModal.tsx
@@ -1,16 +1,27 @@
-import { Input, Modal, Select, Typography } from 'antd';
+import { Input, Modal, TreeSelect, Typography } from 'antd';
 import { useEffect, useMemo, useState } from 'react';
 
-import type { DevelopmentDirectory } from '../types';
+import type { DevelopmentDirectory, DevelopmentId } from '../types';
 
 interface CreateDirectoryModalProps {
   open: boolean;
   directories: DevelopmentDirectory[];
-  defaultParentId?: number;
+  defaultParentId?: DevelopmentId;
   loading?: boolean;
   onCancel: () => void;
-  onSubmit: (parentId: number | undefined, name: string) => void;
+  onSubmit: (parentId: DevelopmentId | undefined, name: string) => void;
 }
+
+interface DirectoryTreeOption {
+  title: string;
+  pathLabel: string;
+  value: string;
+  key: string;
+  searchText: string;
+  children?: DirectoryTreeOption[];
+}
+
+const ROOT_VALUE = '__root__';
 
 const CreateDirectoryModal = ({
   open,
@@ -20,19 +31,34 @@ const CreateDirectoryModal = ({
   onCancel,
   onSubmit,
 }: CreateDirectoryModalProps) => {
-  const [parentId, setParentId] = useState<number>();
+  const [parentId, setParentId] = useState<DevelopmentId>();
   const [name, setName] = useState('');
 
-  const pathOptions = useMemo(
-    () => [
-      { label: '/', value: 0 },
-      ...directories.map((directory) => ({
-        label: directory.path,
-        value: Number(directory.id),
-      })),
-    ],
-    [directories],
-  );
+  const pathTreeData = useMemo<DirectoryTreeOption[]>(() => {
+    const childrenOf = (parent?: DevelopmentId): DirectoryTreeOption[] =>
+      directories
+        .filter((directory) => (directory.parentId || undefined) === parent)
+        .sort((left, right) => left.name.localeCompare(right.name, 'zh-CN'))
+        .map((directory) => ({
+          title: directory.name,
+          pathLabel: directory.path,
+          value: directory.id,
+          key: directory.id,
+          searchText: `${directory.name} ${directory.path}`,
+          children: childrenOf(directory.id),
+        }));
+
+    return [
+      {
+        title: '/',
+        pathLabel: '/',
+        value: ROOT_VALUE,
+        key: ROOT_VALUE,
+        searchText: '/',
+        children: childrenOf(),
+      },
+    ];
+  }, [directories]);
 
   useEffect(() => {
     if (!open) return;
@@ -41,6 +67,11 @@ const CreateDirectoryModal = ({
   }, [defaultParentId, open]);
 
   const normalizedName = name.trim();
+
+  const submit = () => {
+    if (!normalizedName || loading) return;
+    onSubmit(parentId, normalizedName);
+  };
 
   return (
     <Modal
@@ -55,23 +86,29 @@ const CreateDirectoryModal = ({
       maskClosable={!loading}
       closable={!loading}
       onCancel={onCancel}
-      onOk={() => {
-        if (!normalizedName) return;
-        onSubmit(parentId && parentId > 0 ? parentId : undefined, normalizedName);
-      }}
+      onOk={submit}
     >
       <div className="grid grid-cols-[88px_minmax(0,1fr)] items-center gap-y-3 pt-2">
         <Typography.Text className="text-[13px] text-[#344054]">
           <span className="mr-1 text-[rgba(254,44,85,1)]">*</span>
           路径：
         </Typography.Text>
-        <Select
-          value={parentId ?? 0}
-          options={pathOptions}
+        <TreeSelect
+          value={parentId ?? ROOT_VALUE}
+          treeData={pathTreeData}
+          treeDefaultExpandAll
+          treeLine
+          treeNodeLabelProp="pathLabel"
           showSearch
-          optionFilterProp="label"
+          treeNodeFilterProp="searchText"
+          popupMatchSelectWidth
           className="w-full"
-          onChange={(value) => setParentId(Number(value) || undefined)}
+          disabled={loading}
+          placeholder="请选择父目录"
+          onChange={(value) => {
+            const selected = String(value);
+            setParentId(selected === ROOT_VALUE ? undefined : selected);
+          }}
         />
 
         <Typography.Text className="text-[13px] text-[#344054]">
@@ -82,16 +119,10 @@ const CreateDirectoryModal = ({
           autoFocus
           value={name}
           maxLength={128}
+          disabled={loading}
           placeholder="名称"
           onChange={(event) => setName(event.target.value)}
-          onPressEnter={() => {
-            if (normalizedName && !loading) {
-              onSubmit(
-                parentId && parentId > 0 ? parentId : undefined,
-                normalizedName,
-              );
-            }
-          }}
+          onPressEnter={submit}
         />
       </div>
     </Modal>

--- a/yak-ops-ui/src/pages/data-development/components/CreateTaskModal.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/CreateTaskModal.tsx
@@ -1,23 +1,29 @@
 import { Input, Modal, Select, Typography } from 'antd';
 import { useEffect, useMemo, useState } from 'react';
 
-import type { DevelopmentDirectory, DevelopmentTaskType } from '../types';
+import type {
+  DevelopmentDirectory,
+  DevelopmentId,
+  DevelopmentTaskType,
+} from '../types';
 
 interface CreateTaskModalProps {
   open: boolean;
   type: DevelopmentTaskType;
   directories: DevelopmentDirectory[];
-  defaultProjectId?: number;
-  defaultDirectoryId?: number;
+  defaultProjectId?: DevelopmentId;
+  defaultDirectoryId?: DevelopmentId;
   loading?: boolean;
   onCancel: () => void;
   onNext: (
     type: DevelopmentTaskType,
-    projectId: number | undefined,
-    directoryId: number | undefined,
+    projectId: DevelopmentId | undefined,
+    directoryId: DevelopmentId | undefined,
     name: string,
   ) => void;
 }
+
+const ROOT_VALUE = '__root__';
 
 export default function CreateTaskModal({
   open,
@@ -30,8 +36,8 @@ export default function CreateTaskModal({
   onNext,
 }: CreateTaskModalProps) {
   const [type, setType] = useState<DevelopmentTaskType>(initialType);
-  const [projectId, setProjectId] = useState<number>();
-  const [directoryId, setDirectoryId] = useState<number>();
+  const [projectId, setProjectId] = useState<DevelopmentId>();
+  const [directoryId, setDirectoryId] = useState<DevelopmentId>();
   const [name, setName] = useState('');
 
   const typeOptions = useMemo(
@@ -44,10 +50,10 @@ export default function CreateTaskModal({
 
   const pathOptions = useMemo(
     () => [
-      { label: '/', value: 0 },
+      { label: '/', value: ROOT_VALUE },
       ...directories.map((directory) => ({
         label: directory.path,
-        value: Number(directory.id),
+        value: directory.id,
       })),
     ],
     [directories],
@@ -65,12 +71,7 @@ export default function CreateTaskModal({
 
   const submit = () => {
     if (!normalizedName || loading) return;
-    onNext(
-      type,
-      projectId,
-      directoryId && directoryId > 0 ? directoryId : undefined,
-      normalizedName,
-    );
+    onNext(type, projectId, directoryId, normalizedName);
   };
 
   return (
@@ -106,13 +107,16 @@ export default function CreateTaskModal({
           路径：
         </Typography.Text>
         <Select
-          value={directoryId ?? 0}
+          value={directoryId ?? ROOT_VALUE}
           options={pathOptions}
           showSearch
           optionFilterProp="label"
           className="w-full"
           disabled={loading}
-          onChange={(value) => setDirectoryId(Number(value) || undefined)}
+          onChange={(value) => {
+            const selected = String(value);
+            setDirectoryId(selected === ROOT_VALUE ? undefined : selected);
+          }}
         />
 
         <Typography.Text className="text-[13px] text-[#344054]">

--- a/yak-ops-ui/src/pages/data-development/index.tsx
+++ b/yak-ops-ui/src/pages/data-development/index.tsx
@@ -19,25 +19,26 @@ import {
 } from './service';
 import type {
   DevelopmentDirectory,
+  DevelopmentId,
   DevelopmentNode,
   DevelopmentTaskType,
 } from './types';
 
-type TreeNodeKey = `directory:${number}` | `node:${number}`;
+type TreeNodeKey = `directory:${string}` | `node:${string}`;
 
 const DEFAULT_LEFT_WIDTH = 300;
 const MIN_LEFT_WIDTH = 220;
 const MAX_LEFT_WIDTH = 440;
 const LEFT_WIDTH_STORAGE_KEY = 'yak-data-development.left-width';
 
-const directoryKey = (directoryId: number): TreeNodeKey =>
+const directoryKey = (directoryId: DevelopmentId): TreeNodeKey =>
   `directory:${directoryId}`;
-const nodeKey = (nodeId: number): TreeNodeKey => `node:${nodeId}`;
+const nodeKey = (nodeId: DevelopmentId): TreeNodeKey => `node:${nodeId}`;
 
-const numberFromKey = (key: string | undefined, prefix: string) => {
+const idFromKey = (key: string | undefined, prefix: string) => {
   if (!key?.startsWith(prefix)) return undefined;
-  const value = Number(key.substring(prefix.length));
-  return Number.isFinite(value) && value > 0 ? value : undefined;
+  const value = key.substring(prefix.length).trim();
+  return value || undefined;
 };
 
 const clampLeftWidth = (value: number) =>
@@ -100,60 +101,48 @@ export default function DataDevelopmentPage() {
   }, [loadTree]);
 
   const nodeMap = useMemo(
-    () => new Map(nodes.map((node) => [Number(node.id), node])),
+    () => new Map(nodes.map((node) => [node.id, node])),
     [nodes],
   );
 
   const directoryIdForSelection = useMemo(() => {
-    const selectedDirectoryId = numberFromKey(selectedNodeKey, 'directory:');
+    const selectedDirectoryId = idFromKey(selectedNodeKey, 'directory:');
     if (selectedDirectoryId) return selectedDirectoryId;
 
-    const selectedResourceNodeId = numberFromKey(selectedNodeKey, 'node:');
+    const selectedResourceNodeId = idFromKey(selectedNodeKey, 'node:');
     if (!selectedResourceNodeId) return undefined;
     const selectedResourceNode = nodeMap.get(selectedResourceNodeId);
-    return selectedResourceNode?.directoryId
-      ? Number(selectedResourceNode.directoryId)
-      : undefined;
+    return selectedResourceNode?.directoryId || undefined;
   }, [nodeMap, selectedNodeKey]);
 
   const fullTreeData = useMemo<DevelopmentTreeNode[]>(() => {
-    const resourceNodes = (directoryId?: number): DevelopmentTreeNode[] =>
+    const resourceNodes = (directoryId?: DevelopmentId): DevelopmentTreeNode[] =>
       nodes
-        .filter((node) => {
-          const nodeDirectoryId = node.directoryId
-            ? Number(node.directoryId)
-            : undefined;
-          return nodeDirectoryId === directoryId;
-        })
+        .filter((node) => (node.directoryId || undefined) === directoryId)
         .sort((left, right) => left.name.localeCompare(right.name, 'zh-CN'))
         .map((node) => ({
-          key: nodeKey(Number(node.id)),
+          key: nodeKey(node.id),
           title: node.name,
           nodeType: 'node',
-          nodeId: Number(node.id),
           taskType: node.type,
           searchText: `${node.name} ${node.type} ${node.id}`,
           isLeaf: true,
         }));
 
-    const directoryNodes = (parentId?: number): DevelopmentTreeNode[] =>
+    const directoryNodes = (parentId?: DevelopmentId): DevelopmentTreeNode[] =>
       directories
-        .filter((directory) => (directory.parentId ?? undefined) === parentId)
+        .filter((directory) => (directory.parentId || undefined) === parentId)
         .sort((left, right) => left.name.localeCompare(right.name, 'zh-CN'))
-        .map((directory) => {
-          const directoryId = Number(directory.id);
-          return {
-            key: directoryKey(directoryId),
-            title: directory.name,
-            nodeType: 'directory',
-            directoryId,
-            searchText: `${directory.name} ${directory.path || ''}`,
-            children: [
-              ...directoryNodes(directoryId),
-              ...resourceNodes(directoryId),
-            ],
-          };
-        });
+        .map((directory) => ({
+          key: directoryKey(directory.id),
+          title: directory.name,
+          nodeType: 'directory',
+          searchText: `${directory.name} ${directory.path || ''}`,
+          children: [
+            ...directoryNodes(directory.id),
+            ...resourceNodes(directory.id),
+          ],
+        }));
 
     // `/` 仅作为逻辑根目录，不渲染为树节点。
     return [...directoryNodes(), ...resourceNodes()];
@@ -213,7 +202,10 @@ export default function DataDevelopmentPage() {
     [leftCollapsed, leftWidth],
   );
 
-  const submitDirectory = async (parentId: number | undefined, name: string) => {
+  const submitDirectory = async (
+    parentId: DevelopmentId | undefined,
+    name: string,
+  ) => {
     setDirectorySaving(true);
     try {
       const created = responseData(
@@ -223,7 +215,7 @@ export default function DataDevelopmentPage() {
       setDirectoryOpen(false);
       setTreeKeyword('');
       await loadTree();
-      setSelectedNodeKey(directoryKey(Number(created.id)));
+      setSelectedNodeKey(directoryKey(created.id));
       message.success('目录创建成功');
     } catch (error) {
       message.error(error instanceof Error ? error.message : '新建目录失败');
@@ -234,8 +226,8 @@ export default function DataDevelopmentPage() {
 
   const submitNode = async (
     type: DevelopmentTaskType,
-    projectId: number | undefined,
-    directoryId: number | undefined,
+    projectId: DevelopmentId | undefined,
+    directoryId: DevelopmentId | undefined,
     name: string,
   ) => {
     setNodeSaving(true);
@@ -252,7 +244,7 @@ export default function DataDevelopmentPage() {
       setCreateOpen(false);
       setTreeKeyword('');
       await loadTree();
-      setSelectedNodeKey(nodeKey(Number(created.id)));
+      setSelectedNodeKey(nodeKey(created.id));
       message.success('节点创建成功');
     } catch (error) {
       message.error(error instanceof Error ? error.message : '新建节点失败');
@@ -310,7 +302,7 @@ export default function DataDevelopmentPage() {
           directories={directories}
           loading={nodeSaving}
           defaultProjectId={
-            currentProject?.id ? Number(currentProject.id) : undefined
+            currentProject?.id ? String(currentProject.id) : undefined
           }
           defaultDirectoryId={directoryIdForSelection}
           onCancel={() => {

--- a/yak-ops-ui/src/pages/data-development/types.ts
+++ b/yak-ops-ui/src/pages/data-development/types.ts
@@ -1,8 +1,9 @@
 export type DevelopmentTaskType = 'SQL' | 'SHELL' | 'HTTP' | 'PYTHON';
+export type DevelopmentId = string;
 
 export interface DevelopmentDirectory {
-  id: number;
-  parentId?: number | null;
+  id: DevelopmentId;
+  parentId?: DevelopmentId | null;
   name: string;
   path: string;
   createTime?: string;
@@ -10,16 +11,16 @@ export interface DevelopmentDirectory {
 }
 
 export interface CreateDevelopmentDirectoryPayload {
-  parentId?: number;
+  parentId?: DevelopmentId;
   name: string;
 }
 
 export interface DevelopmentNode {
-  id: number;
+  id: DevelopmentId;
   name: string;
   type: DevelopmentTaskType;
-  projectId?: number | null;
-  directoryId?: number | null;
+  projectId?: DevelopmentId | null;
+  directoryId?: DevelopmentId | null;
   configured: boolean;
   createTime?: string;
   updateTime?: string;
@@ -28,7 +29,7 @@ export interface DevelopmentNode {
 export interface CreateDevelopmentNodePayload {
   name: string;
   type: DevelopmentTaskType;
-  projectId?: number;
-  /** 0 或省略表示数据开发根目录。 */
-  directoryId?: number;
+  projectId?: DevelopmentId;
+  /** 省略表示数据开发根目录。 */
+  directoryId?: DevelopmentId;
 }


### PR DESCRIPTION
## 问题

在数据开发中选择已有目录作为父路径，再创建子目录时，后端可能报：

```text
java.lang.IllegalArgumentException: 父目录不存在：2086774986910167000
```

根因不是父目录真实不存在，而是目录 ID 使用 BIGINT / Snowflake，已经超过 JavaScript `Number.MAX_SAFE_INTEGER`。前端此前大量使用 `Number(directory.id)`，JSON 解析和再次提交时会发生精度丢失，导致提交给后端的 parentId 与数据库真实 ID 不一致。

## 修复

### BIGINT ID 全链路按字符串处理

后端 `DevelopmentDirectory`：

- `id` 序列化为字符串
- `parentId` 序列化为字符串

后端 `DevelopmentNode`：

- `id` 序列化为字符串
- `projectId` 序列化为字符串
- `directoryId` 序列化为字符串

前端：

- `DevelopmentId = string`
- Directory / Node ID 不再转 `Number`
- Tree key 直接使用原始字符串 ID
- 父子目录比较直接使用字符串
- 创建目录 / 创建节点时原样提交 ID

因此类似：

```text
2086774986910167000
```

不会再经过 JS number 转换。

## 新建目录路径改为树结构

`CreateDirectoryModal` 的“路径”从普通 Select 改成 `TreeSelect`：

```text
/
└─ gaga
   ├─ test
   └─ child
```

- 支持多级展开
- 默认展开目录树
- 支持搜索目录名称 / 完整路径
- 选择后输入框展示完整路径，例如 `/gaga/test`
- `/` 仍表示逻辑根目录

## 同步修复节点创建

虽然本次问题出现在“新建目录”，但“新建节点”此前也会把 directoryId 转成 Number，因此同步改成字符串 ID，避免后续在大 ID 目录下创建 SQL / Shell 节点遇到相同问题。

## 范围

本 PR 只修改 6 个文件：

- 2 个后端 domain JSON ID 序列化
- 4 个数据开发前端文件

不修改目录表、节点表、Flyway、右侧工作区或 SQL 业务逻辑。

## 验证重点

建议本地重点验证：

1. 根目录创建 `gaga`
2. 打开“新建目录”
3. TreeSelect 选择 `/gaga`
4. 创建 `test`
5. 后端收到的 parentId 与 `gaga.id` 完全一致
6. 左树刷新后显示 `gaga -> test`

分支基于最新 main，compare：behind 0。保持 Draft，供本地 TypeScript / Maven 和页面交互确认。