### PR TITLE
feat(data-development): add resource tree context actions

### DIFF
--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/api/DevelopmentDirectoryApi.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/api/DevelopmentDirectoryApi.java
@@ -13,4 +13,7 @@ public final class DevelopmentDirectoryApi {
       @Min(1) Long parentId,
       @NotBlank @Size(max = 128) String name) {
   }
+
+  public record RenameRequest(@NotBlank @Size(max = 128) String name) {
+  }
 }

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/api/DevelopmentNodeApi.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/api/DevelopmentNodeApi.java
@@ -2,6 +2,7 @@ package io.yak.ops.business.development.api;
 
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 /** HTTP request contracts for data-development tree nodes. */
 public final class DevelopmentNodeApi {
@@ -13,5 +14,8 @@ public final class DevelopmentNodeApi {
       @NotBlank String type,
       @Min(0) Long projectId,
       @Min(0) Long directoryId) {
+  }
+
+  public record RenameRequest(@NotBlank @Size(max = 200) String name) {
   }
 }

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/controller/v1/DevelopmentDirectoryController.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/controller/v1/DevelopmentDirectoryController.java
@@ -4,12 +4,16 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.yak.framework.common.Result;
 import io.yak.ops.business.development.api.DevelopmentDirectoryApi.CreateRequest;
+import io.yak.ops.business.development.api.DevelopmentDirectoryApi.RenameRequest;
 import io.yak.ops.business.development.domain.DevelopmentDirectory;
 import io.yak.ops.business.development.service.DevelopmentDirectoryService;
 import jakarta.validation.Valid;
 import java.util.List;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -36,5 +40,20 @@ public class DevelopmentDirectoryController {
   @PostMapping
   public Result<DevelopmentDirectory> create(@Valid @RequestBody CreateRequest request) {
     return Result.success(service.create(request.parentId(), request.name()));
+  }
+
+  @Operation(summary = "重命名数据开发目录")
+  @PutMapping("/{id}/name")
+  public Result<DevelopmentDirectory> rename(
+      @PathVariable("id") Long id,
+      @Valid @RequestBody RenameRequest request) {
+    return Result.success(service.rename(id, request.name()));
+  }
+
+  @Operation(summary = "删除空数据开发目录")
+  @DeleteMapping("/{id}")
+  public Result<Boolean> delete(@PathVariable("id") Long id) {
+    service.delete(id);
+    return Result.success(Boolean.TRUE);
   }
 }

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/controller/v1/DevelopmentNodeController.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/controller/v1/DevelopmentNodeController.java
@@ -4,12 +4,16 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.yak.framework.common.Result;
 import io.yak.ops.business.development.api.DevelopmentNodeApi.CreateRequest;
+import io.yak.ops.business.development.api.DevelopmentNodeApi.RenameRequest;
 import io.yak.ops.business.development.domain.DevelopmentNode;
 import io.yak.ops.business.development.service.DevelopmentNodeService;
 import jakarta.validation.Valid;
 import java.util.List;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -40,5 +44,20 @@ public class DevelopmentNodeController {
         request.type(),
         request.projectId(),
         request.directoryId()));
+  }
+
+  @Operation(summary = "重命名数据开发节点")
+  @PutMapping("/{id}/name")
+  public Result<DevelopmentNode> rename(
+      @PathVariable("id") Long id,
+      @Valid @RequestBody RenameRequest request) {
+    return Result.success(service.rename(id, request.name()));
+  }
+
+  @Operation(summary = "删除数据开发节点")
+  @DeleteMapping("/{id}")
+  public Result<Boolean> delete(@PathVariable("id") Long id) {
+    service.delete(id);
+    return Result.success(Boolean.TRUE);
   }
 }

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/DevelopmentDirectoryRepository.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/DevelopmentDirectoryRepository.java
@@ -14,4 +14,10 @@ public interface DevelopmentDirectoryRepository {
   List<DevelopmentDirectory> list();
 
   boolean existsByName(Long parentId, String name);
+
+  boolean hasChildren(Long id);
+
+  boolean updateName(Long id, String name);
+
+  boolean deleteById(Long id);
 }

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/DevelopmentDirectoryRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/DevelopmentDirectoryRepositoryAdapter.java
@@ -1,6 +1,7 @@
 package io.yak.ops.business.development.repository;
 
 import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.baomidou.mybatisplus.core.conditions.update.LambdaUpdateWrapper;
 import io.yak.ops.business.development.dao.mapper.DevelopmentDirectoryMapper;
 import io.yak.ops.business.development.domain.DevelopmentDirectory;
 import io.yak.ops.common.bean.po.development.DevelopmentDirectoryPO;
@@ -56,6 +57,30 @@ public class DevelopmentDirectoryRepositoryAdapter implements DevelopmentDirecto
                 .eq(DevelopmentDirectoryPO::getParentId, toStoredParentId(parentId))
                 .eq(DevelopmentDirectoryPO::getName, name))
         > 0L;
+  }
+
+  @Override
+  public boolean hasChildren(Long id) {
+    return mapper.selectCount(
+            new LambdaQueryWrapper<DevelopmentDirectoryPO>()
+                .eq(DevelopmentDirectoryPO::getParentId, id))
+        > 0L;
+  }
+
+  @Override
+  public boolean updateName(Long id, String name) {
+    return mapper.update(
+            null,
+            new LambdaUpdateWrapper<DevelopmentDirectoryPO>()
+                .eq(DevelopmentDirectoryPO::getId, id)
+                .set(DevelopmentDirectoryPO::getName, name)
+                .set(DevelopmentDirectoryPO::getUpdateTime, Instant.now()))
+        > 0;
+  }
+
+  @Override
+  public boolean deleteById(Long id) {
+    return mapper.deleteById(id) > 0;
   }
 
   private Long toStoredParentId(Long parentId) {

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/DevelopmentNodeRepository.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/DevelopmentNodeRepository.java
@@ -19,4 +19,10 @@ public interface DevelopmentNodeRepository {
   List<DevelopmentNode> list();
 
   boolean existsByName(Long directoryId, String name);
+
+  boolean existsInDirectory(Long directoryId);
+
+  boolean updateName(Long id, String name);
+
+  boolean deleteById(Long id);
 }

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/DevelopmentNodeRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/DevelopmentNodeRepositoryAdapter.java
@@ -1,6 +1,7 @@
 package io.yak.ops.business.development.repository;
 
 import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.baomidou.mybatisplus.core.conditions.update.LambdaUpdateWrapper;
 import io.yak.ops.business.development.dao.mapper.DevelopmentNodeMapper;
 import io.yak.ops.business.development.domain.DevelopmentNode;
 import io.yak.ops.common.bean.po.development.DevelopmentNodePO;
@@ -65,6 +66,30 @@ public class DevelopmentNodeRepositoryAdapter implements DevelopmentNodeReposito
                 .eq(DevelopmentNodePO::getDirectoryId, toStoredDirectoryId(directoryId))
                 .eq(DevelopmentNodePO::getName, name))
         > 0L;
+  }
+
+  @Override
+  public boolean existsInDirectory(Long directoryId) {
+    return mapper.selectCount(
+            new LambdaQueryWrapper<DevelopmentNodePO>()
+                .eq(DevelopmentNodePO::getDirectoryId, toStoredDirectoryId(directoryId)))
+        > 0L;
+  }
+
+  @Override
+  public boolean updateName(Long id, String name) {
+    return mapper.update(
+            null,
+            new LambdaUpdateWrapper<DevelopmentNodePO>()
+                .eq(DevelopmentNodePO::getId, id)
+                .set(DevelopmentNodePO::getName, name)
+                .set(DevelopmentNodePO::getUpdateTime, Instant.now()))
+        > 0;
+  }
+
+  @Override
+  public boolean deleteById(Long id) {
+    return mapper.deleteById(id) > 0;
   }
 
   private Long toStoredDirectoryId(Long directoryId) {

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentDirectoryService.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentDirectoryService.java
@@ -2,6 +2,7 @@ package io.yak.ops.business.development.service;
 
 import io.yak.ops.business.development.domain.DevelopmentDirectory;
 import io.yak.ops.business.development.repository.DevelopmentDirectoryRepository;
+import io.yak.ops.business.development.repository.DevelopmentNodeRepository;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -16,9 +17,13 @@ import org.springframework.transaction.annotation.Transactional;
 public class DevelopmentDirectoryService {
 
   private final DevelopmentDirectoryRepository repository;
+  private final DevelopmentNodeRepository nodeRepository;
 
-  public DevelopmentDirectoryService(DevelopmentDirectoryRepository repository) {
+  public DevelopmentDirectoryService(
+      DevelopmentDirectoryRepository repository,
+      DevelopmentNodeRepository nodeRepository) {
     this.repository = repository;
+    this.nodeRepository = nodeRepository;
   }
 
   public List<DevelopmentDirectory> list() {
@@ -50,10 +55,41 @@ public class DevelopmentDirectoryService {
     }
 
     DevelopmentDirectory created = repository.insert(normalizedParentId, normalizedName);
+    return requireFromList(created.id());
+  }
+
+  @Transactional(transactionManager = "yakBusinessTransactionManager", rollbackFor = Exception.class)
+  public DevelopmentDirectory rename(Long id, String name) {
+    DevelopmentDirectory current = repository.findById(id)
+        .orElseThrow(() -> new IllegalArgumentException("目录不存在：" + id));
+    String normalizedName = normalizeName(name);
+    if (current.name().equals(normalizedName)) return requireFromList(id);
+    if (repository.existsByName(current.parentId(), normalizedName)) {
+      throw new IllegalStateException("当前路径下已存在同名目录：" + normalizedName);
+    }
+    if (!repository.updateName(id, normalizedName)) {
+      throw new IllegalStateException("目录重命名失败：" + id);
+    }
+    return requireFromList(id);
+  }
+
+  @Transactional(transactionManager = "yakBusinessTransactionManager", rollbackFor = Exception.class)
+  public void delete(Long id) {
+    repository.findById(id)
+        .orElseThrow(() -> new IllegalArgumentException("目录不存在：" + id));
+    if (repository.hasChildren(id) || nodeRepository.existsInDirectory(id)) {
+      throw new IllegalStateException("目录不为空，请先删除目录下的节点和子目录");
+    }
+    if (!repository.deleteById(id)) {
+      throw new IllegalStateException("目录删除失败：" + id);
+    }
+  }
+
+  private DevelopmentDirectory requireFromList(Long id) {
     return list().stream()
-        .filter(directory -> directory.id().equals(created.id()))
+        .filter(directory -> directory.id().equals(id))
         .findFirst()
-        .orElseThrow(() -> new IllegalStateException("目录创建成功但无法重新读取：" + created.id()));
+        .orElseThrow(() -> new IllegalStateException("目录保存成功但无法重新读取：" + id));
   }
 
   private DevelopmentDirectory withPath(DevelopmentDirectory directory, String path) {

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentNodeService.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentNodeService.java
@@ -56,6 +56,31 @@ public class DevelopmentNodeService {
         false);
   }
 
+  @Transactional(transactionManager = "yakBusinessTransactionManager", rollbackFor = Exception.class)
+  public DevelopmentNode rename(Long id, String name) {
+    DevelopmentNode current = repository.findById(id)
+        .orElseThrow(() -> new IllegalArgumentException("节点不存在：" + id));
+    String normalizedName = normalizeName(name);
+    if (current.name().equals(normalizedName)) return current;
+    if (repository.existsByName(current.directoryId(), normalizedName)) {
+      throw new IllegalStateException("当前目录下已存在同名节点：" + normalizedName);
+    }
+    if (!repository.updateName(id, normalizedName)) {
+      throw new IllegalStateException("节点重命名失败：" + id);
+    }
+    return repository.findById(id)
+        .orElseThrow(() -> new IllegalStateException("节点重命名成功但无法重新读取：" + id));
+  }
+
+  @Transactional(transactionManager = "yakBusinessTransactionManager", rollbackFor = Exception.class)
+  public void delete(Long id) {
+    repository.findById(id)
+        .orElseThrow(() -> new IllegalArgumentException("节点不存在：" + id));
+    if (!repository.deleteById(id)) {
+      throw new IllegalStateException("节点删除失败：" + id);
+    }
+  }
+
   private String normalizeName(String name) {
     if (name == null || name.isBlank()) throw new IllegalArgumentException("节点名称不能为空");
     String normalized = name.trim();

--- a/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/DevelopmentDirectoryServiceTest.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/DevelopmentDirectoryServiceTest.java
@@ -4,7 +4,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.yak.ops.business.development.domain.DevelopmentDirectory;
+import io.yak.ops.business.development.domain.DevelopmentNode;
 import io.yak.ops.business.development.repository.DevelopmentDirectoryRepository;
+import io.yak.ops.business.development.repository.DevelopmentNodeRepository;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -19,7 +21,7 @@ class DevelopmentDirectoryServiceTest {
   @Test
   void createsNestedDirectoryPaths() {
     InMemoryDirectoryRepository repository = new InMemoryDirectoryRepository();
-    DevelopmentDirectoryService service = new DevelopmentDirectoryService(repository);
+    DevelopmentDirectoryService service = service(repository, new InMemoryNodeRepository());
 
     DevelopmentDirectory ods = service.create(null, "ODS");
     DevelopmentDirectory user = service.create(ods.id(), "用户域");
@@ -34,10 +36,48 @@ class DevelopmentDirectoryServiceTest {
   @Test
   void rejectsDuplicateSiblingDirectory() {
     InMemoryDirectoryRepository repository = new InMemoryDirectoryRepository();
-    DevelopmentDirectoryService service = new DevelopmentDirectoryService(repository);
+    DevelopmentDirectoryService service = service(repository, new InMemoryNodeRepository());
     service.create(null, "ODS");
 
     assertThrows(IllegalStateException.class, () -> service.create(null, "ODS"));
+  }
+
+  @Test
+  void renamesDirectoryAndRecomputesChildPath() {
+    InMemoryDirectoryRepository repository = new InMemoryDirectoryRepository();
+    DevelopmentDirectoryService service = service(repository, new InMemoryNodeRepository());
+    DevelopmentDirectory ods = service.create(null, "ODS");
+    DevelopmentDirectory child = service.create(ods.id(), "用户域");
+
+    service.rename(ods.id(), "DWD");
+
+    assertEquals(
+        "/DWD/用户域",
+        service.list().stream()
+            .filter(directory -> directory.id().equals(child.id()))
+            .findFirst()
+            .orElseThrow()
+            .path());
+  }
+
+  @Test
+  void onlyDeletesEmptyDirectory() {
+    InMemoryDirectoryRepository repository = new InMemoryDirectoryRepository();
+    InMemoryNodeRepository nodes = new InMemoryNodeRepository();
+    DevelopmentDirectoryService service = service(repository, nodes);
+    DevelopmentDirectory parent = service.create(null, "ODS");
+    DevelopmentDirectory child = service.create(parent.id(), "用户域");
+
+    assertThrows(IllegalStateException.class, () -> service.delete(parent.id()));
+    service.delete(child.id());
+    service.delete(parent.id());
+    assertEquals(List.of(), service.list());
+  }
+
+  private DevelopmentDirectoryService service(
+      DevelopmentDirectoryRepository directories,
+      DevelopmentNodeRepository nodes) {
+    return new DevelopmentDirectoryService(directories, nodes);
   }
 
   private static final class InMemoryDirectoryRepository
@@ -76,6 +116,73 @@ class DevelopmentDirectoryServiceTest {
       return values.values().stream().anyMatch(directory ->
           java.util.Objects.equals(parentId, directory.parentId())
               && name.equals(directory.name()));
+    }
+
+    @Override
+    public boolean hasChildren(Long id) {
+      return values.values().stream().anyMatch(directory -> id.equals(directory.parentId()));
+    }
+
+    @Override
+    public boolean updateName(Long id, String name) {
+      DevelopmentDirectory current = values.get(id);
+      if (current == null) return false;
+      values.put(id, new DevelopmentDirectory(
+          current.id(),
+          current.parentId(),
+          name,
+          null,
+          current.createTime(),
+          Instant.now()));
+      return true;
+    }
+
+    @Override
+    public boolean deleteById(Long id) {
+      return values.remove(id) != null;
+    }
+  }
+
+  private static final class InMemoryNodeRepository implements DevelopmentNodeRepository {
+
+    @Override
+    public DevelopmentNode insert(
+        String name,
+        String type,
+        Long projectId,
+        Long directoryId,
+        boolean configured) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<DevelopmentNode> findById(Long id) {
+      return Optional.empty();
+    }
+
+    @Override
+    public List<DevelopmentNode> list() {
+      return List.of();
+    }
+
+    @Override
+    public boolean existsByName(Long directoryId, String name) {
+      return false;
+    }
+
+    @Override
+    public boolean existsInDirectory(Long directoryId) {
+      return false;
+    }
+
+    @Override
+    public boolean updateName(Long id, String name) {
+      return false;
+    }
+
+    @Override
+    public boolean deleteById(Long id) {
+      return false;
     }
   }
 }

--- a/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/DevelopmentNodeServiceTest.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/DevelopmentNodeServiceTest.java
@@ -54,6 +54,20 @@ class DevelopmentNodeServiceTest {
         () -> service.create("任务", "SHELL", null, null));
   }
 
+  @Test
+  void renamesAndDeletesNode() {
+    InMemoryDirectoryRepository directories = new InMemoryDirectoryRepository();
+    InMemoryNodeRepository nodes = new InMemoryNodeRepository();
+    DevelopmentNodeService service = new DevelopmentNodeService(nodes, directories);
+    DevelopmentNode node = service.create("任务", "SQL", null, null);
+
+    DevelopmentNode renamed = service.rename(node.id(), "新任务");
+    assertEquals("新任务", renamed.name());
+
+    service.delete(node.id());
+    assertEquals(List.of(), service.list());
+  }
+
   private static final class InMemoryNodeRepository implements DevelopmentNodeRepository {
 
     private final AtomicLong ids = new AtomicLong(1L);
@@ -97,6 +111,33 @@ class DevelopmentNodeServiceTest {
           java.util.Objects.equals(directoryId, node.directoryId())
               && name.equals(node.name()));
     }
+
+    @Override
+    public boolean existsInDirectory(Long directoryId) {
+      return values.values().stream().anyMatch(node ->
+          java.util.Objects.equals(directoryId, node.directoryId()));
+    }
+
+    @Override
+    public boolean updateName(Long id, String name) {
+      DevelopmentNode current = values.get(id);
+      if (current == null) return false;
+      values.put(id, new DevelopmentNode(
+          current.id(),
+          name,
+          current.type(),
+          current.projectId(),
+          current.directoryId(),
+          current.configured(),
+          current.createTime(),
+          Instant.now()));
+      return true;
+    }
+
+    @Override
+    public boolean deleteById(Long id) {
+      return values.remove(id) != null;
+    }
   }
 
   private static final class InMemoryDirectoryRepository
@@ -135,6 +176,25 @@ class DevelopmentNodeServiceTest {
       return values.values().stream().anyMatch(directory ->
           java.util.Objects.equals(parentId, directory.parentId())
               && name.equals(directory.name()));
+    }
+
+    @Override
+    public boolean hasChildren(Long id) {
+      return values.values().stream().anyMatch(directory -> id.equals(directory.parentId()));
+    }
+
+    @Override
+    public boolean updateName(Long id, String name) {
+      DevelopmentDirectory current = values.get(id);
+      if (current == null) return false;
+      values.put(id, new DevelopmentDirectory(
+          current.id(), current.parentId(), name, null, current.createTime(), Instant.now()));
+      return true;
+    }
+
+    @Override
+    public boolean deleteById(Long id) {
+      return values.remove(id) != null;
     }
   }
 }

--- a/yak-ops-ui/src/pages/data-development/components/DevelopmentTreePane.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/DevelopmentTreePane.tsx
@@ -7,23 +7,35 @@ import {
   ChevronLeft,
   ChevronRight,
   Code2,
+  Copy,
+  FileText,
   Folder,
   FolderPlus,
+  Pencil,
   Plus,
   Search,
   TerminalSquare,
+  Trash2,
 } from 'lucide-react';
 import type { PointerEvent as ReactPointerEvent } from 'react';
 
 export type DevelopmentTreeNodeType = 'directory' | 'node';
 export type DevelopmentNodeCreateType = 'SQL' | 'SHELL';
+export type DevelopmentTreeAction =
+  | 'create-directory'
+  | 'create-sql'
+  | 'create-shell'
+  | 'copy-name'
+  | 'copy-path'
+  | 'rename'
+  | 'delete';
 
 export interface DevelopmentTreeNode extends DataNode {
   key: string;
   title: string;
   nodeType: DevelopmentTreeNodeType;
-  directoryId?: number;
-  nodeId?: number;
+  resourceId: string;
+  resourcePath: string;
   taskType?: string;
   searchText?: string;
   children?: DevelopmentTreeNode[];
@@ -38,6 +50,10 @@ interface DevelopmentTreePaneProps {
   collapsed: boolean;
   onCreateDirectory: () => void;
   onCreateNode: (type: DevelopmentNodeCreateType) => void;
+  onResourceAction: (
+    action: DevelopmentTreeAction,
+    node: DevelopmentTreeNode,
+  ) => void;
   onSearchChange: (value: string) => void;
   onSelect: TreeProps['onSelect'];
   onResizeStart: (event: ReactPointerEvent) => void;
@@ -53,6 +69,7 @@ const DevelopmentTreePane = ({
   collapsed,
   onCreateDirectory,
   onCreateNode,
+  onResourceAction,
   onSearchChange,
   onSelect,
   onResizeStart,
@@ -83,49 +100,116 @@ const DevelopmentTreePane = ({
     },
   ];
 
+  const contextMenuItems = (node: DevelopmentTreeNode): MenuProps['items'] => {
+    const commonItems: MenuProps['items'] = [
+      {
+        key: 'copy-name',
+        label: '复制名称',
+        icon: <Copy size={14} strokeWidth={1.8} />,
+      },
+      {
+        key: 'copy-path',
+        label: '复制路径',
+        icon: <FileText size={14} strokeWidth={1.8} />,
+      },
+      { type: 'divider' },
+      {
+        key: 'rename',
+        label: '重命名',
+        icon: <Pencil size={14} strokeWidth={1.8} />,
+      },
+      {
+        key: 'delete',
+        label: '删除',
+        icon: <Trash2 size={14} strokeWidth={1.8} />,
+        danger: true,
+      },
+    ];
+
+    if (node.nodeType !== 'directory') return commonItems;
+    return [
+      {
+        key: 'create-node',
+        label: '新建节点',
+        icon: <Code2 size={14} strokeWidth={1.8} />,
+        children: [
+          {
+            key: 'create-sql',
+            label: 'SQL 节点',
+            icon: <Code2 size={14} strokeWidth={1.8} />,
+          },
+          {
+            key: 'create-shell',
+            label: 'Shell 节点',
+            icon: <TerminalSquare size={14} strokeWidth={1.8} />,
+          },
+        ],
+      },
+      {
+        key: 'create-directory',
+        label: '新建目录',
+        icon: <FolderPlus size={14} strokeWidth={1.8} />,
+      },
+      { type: 'divider' },
+      ...commonItems,
+    ];
+  };
+
   const renderTitle: TreeProps['titleRender'] = (rawNode) => {
     const node = rawNode as DevelopmentTreeNode;
     const isNode = node.nodeType === 'node';
 
     return (
-      <div className="flex min-w-0 flex-1 items-center gap-2" title={node.title}>
-        {isNode ? (
-          node.taskType === 'SHELL' ? (
-            <TerminalSquare
-              size={13}
-              strokeWidth={1.8}
-              className="shrink-0 text-[#667085]"
-            />
+      <Dropdown
+        trigger={['contextMenu']}
+        menu={{
+          items: contextMenuItems(node),
+          triggerSubMenuAction: 'hover',
+          subMenuOpenDelay: 0.05,
+          subMenuCloseDelay: 0.1,
+          onClick: ({ key }) =>
+            onResourceAction(key as DevelopmentTreeAction, node),
+        }}
+      >
+        <div className="flex min-w-0 flex-1 items-center gap-2" title={node.title}>
+          {isNode ? (
+            node.taskType === 'SHELL' ? (
+              <TerminalSquare
+                size={13}
+                strokeWidth={1.8}
+                className="shrink-0 text-[#667085]"
+              />
+            ) : (
+              <Code2
+                size={13}
+                strokeWidth={1.8}
+                className="shrink-0 text-[#667085]"
+              />
+            )
           ) : (
-            <Code2
-              size={13}
+            <Folder
+              size={14}
               strokeWidth={1.8}
-              className="shrink-0 text-[#667085]"
+              className="shrink-0 text-[#98a2b3]"
             />
-          )
-        ) : (
-          <Folder
-            size={14}
-            strokeWidth={1.8}
-            className="shrink-0 text-[#98a2b3]"
-          />
-        )}
+          )}
 
-        <span
-          className={[
-            'min-w-0 flex-1 truncate text-[13px] leading-8',
-            isNode ? 'font-normal text-[#344054]' : 'font-medium text-[#1f2937]',
-          ].join(' ')}
-        >
-          {node.title}
-        </span>
-
-        {isNode && node.taskType ? (
-          <span className="shrink-0 text-[10px] text-[#98a2b3]">
-            {node.taskType}
+          <span
+            className={[
+              'min-w-0 flex-1 truncate text-[13px] leading-8',
+              isNode ? 'font-normal text-[#344054]' : 'font-medium text-[#1f2937]',
+            ].join(' ')}
+          >
+            {node.title}
           </span>
-        ) : null}
-      </div>
+
+          {isNode && node.taskType ? (
+            <span className="shrink-0 text-[10px] text-[#98a2b3]">
+              {node.taskType}
+            </span>
+          ) : null}
+        </div>
+      </Dropdown>
     );
   };
 
@@ -259,14 +343,8 @@ const DevelopmentTreePane = ({
       </div>
 
       <style>{`
-        .development-tree.ant-tree {
-          color: #344054;
-        }
-
-        .development-tree .ant-tree-list-holder-inner {
-          gap: 1px;
-        }
-
+        .development-tree.ant-tree { color: #344054; }
+        .development-tree .ant-tree-list-holder-inner { gap: 1px; }
         .development-tree .ant-tree-treenode {
           box-sizing: border-box;
           width: 100%;
@@ -276,12 +354,8 @@ const DevelopmentTreePane = ({
           border-radius: 0;
           transition: background-color 0.15s ease;
         }
-
         .development-tree .ant-tree-treenode:hover,
-        .development-tree .ant-tree-treenode:has(.ant-tree-node-selected) {
-          background: #f5f5f5;
-        }
-
+        .development-tree .ant-tree-treenode:has(.ant-tree-node-selected) { background: #f5f5f5; }
         .development-tree .ant-tree-node-content-wrapper {
           display: flex;
           min-width: 0;
@@ -293,22 +367,12 @@ const DevelopmentTreePane = ({
           background: transparent !important;
           line-height: 30px;
         }
-
         .development-tree .ant-tree-node-content-wrapper.ant-tree-node-selected {
           color: #1f2937;
           background: transparent !important;
         }
-
-        .development-tree .ant-tree-title {
-          display: flex;
-          min-width: 0;
-          flex: 1;
-        }
-
-        .development-tree .ant-tree-indent-unit {
-          width: 18px;
-        }
-
+        .development-tree .ant-tree-title { display: flex; min-width: 0; flex: 1; }
+        .development-tree .ant-tree-indent-unit { width: 18px; }
         .development-tree .ant-tree-switcher {
           display: inline-flex;
           width: 18px;
@@ -319,18 +383,9 @@ const DevelopmentTreePane = ({
           color: #98a2b3;
           line-height: 30px;
         }
-
-        .development-tree .ant-tree-switcher svg {
-          transition: transform 0.15s ease;
-        }
-
-        .development-tree .ant-tree-switcher_close svg {
-          transform: rotate(-90deg);
-        }
-
-        .development-tree .ant-tree-switcher-noop {
-          width: 18px;
-        }
+        .development-tree .ant-tree-switcher svg { transition: transform 0.15s ease; }
+        .development-tree .ant-tree-switcher_close svg { transform: rotate(-90deg); }
+        .development-tree .ant-tree-switcher-noop { width: 18px; }
       `}</style>
     </>
   );

--- a/yak-ops-ui/src/pages/data-development/components/RenameResourceModal.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/RenameResourceModal.tsx
@@ -1,0 +1,66 @@
+import { Input, Modal, Typography } from 'antd';
+import { useEffect, useState } from 'react';
+
+interface RenameResourceModalProps {
+  open: boolean;
+  resourceLabel: string;
+  initialName: string;
+  loading?: boolean;
+  onCancel: () => void;
+  onSubmit: (name: string) => void;
+}
+
+const RenameResourceModal = ({
+  open,
+  resourceLabel,
+  initialName,
+  loading = false,
+  onCancel,
+  onSubmit,
+}: RenameResourceModalProps) => {
+  const [name, setName] = useState(initialName);
+
+  useEffect(() => {
+    if (open) setName(initialName);
+  }, [initialName, open]);
+
+  const normalizedName = name.trim();
+  const submit = () => {
+    if (!normalizedName || loading) return;
+    onSubmit(normalizedName);
+  };
+
+  return (
+    <Modal
+      open={open}
+      title={`重命名${resourceLabel}`}
+      width={520}
+      okText="确认"
+      cancelText="取消"
+      confirmLoading={loading}
+      okButtonProps={{ disabled: !normalizedName }}
+      destroyOnClose
+      maskClosable={!loading}
+      closable={!loading}
+      onCancel={onCancel}
+      onOk={submit}
+    >
+      <div className="grid grid-cols-[72px_minmax(0,1fr)] items-center gap-y-3 pt-2">
+        <Typography.Text className="text-[13px] text-[#344054]">
+          名称：
+        </Typography.Text>
+        <Input
+          autoFocus
+          value={name}
+          maxLength={200}
+          placeholder="名称"
+          disabled={loading}
+          onChange={(event) => setName(event.target.value)}
+          onPressEnter={submit}
+        />
+      </div>
+    </Modal>
+  );
+};
+
+export default RenameResourceModal;

--- a/yak-ops-ui/src/pages/data-development/index.tsx
+++ b/yak-ops-ui/src/pages/data-development/index.tsx
@@ -1,7 +1,7 @@
 import { API_SUCCESS_CODE } from '@/services/http/response';
 import { useSecurityProject } from '@/contexts/SecurityProjectContext';
 import { BRAND_THEME } from '@/styles/brand';
-import { ConfigProvider, message } from 'antd';
+import { ConfigProvider, Modal, message } from 'antd';
 import type { PointerEvent as ReactPointerEvent } from 'react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
@@ -9,13 +9,19 @@ import CreateDirectoryModal from './components/CreateDirectoryModal';
 import CreateTaskModal from './components/CreateTaskModal';
 import DevelopmentTreePane, {
   type DevelopmentNodeCreateType,
+  type DevelopmentTreeAction,
   type DevelopmentTreeNode,
 } from './components/DevelopmentTreePane';
+import RenameResourceModal from './components/RenameResourceModal';
 import {
   createDevelopmentDirectory,
   createDevelopmentNode,
+  deleteDevelopmentDirectory,
+  deleteDevelopmentNode,
   listDevelopmentDirectories,
   listDevelopmentNodes,
+  renameDevelopmentDirectory,
+  renameDevelopmentNode,
 } from './service';
 import type {
   DevelopmentDirectory,
@@ -77,6 +83,10 @@ export default function DataDevelopmentPage() {
   const [nodeSaving, setNodeSaving] = useState(false);
   const [directoryOpen, setDirectoryOpen] = useState(false);
   const [directorySaving, setDirectorySaving] = useState(false);
+  const [renameTarget, setRenameTarget] = useState<DevelopmentTreeNode>();
+  const [renameSaving, setRenameSaving] = useState(false);
+  const [deleteTarget, setDeleteTarget] = useState<DevelopmentTreeNode>();
+  const [deleteSaving, setDeleteSaving] = useState(false);
 
   const loadTree = useCallback(async () => {
     setTreeLoading(true);
@@ -104,6 +114,10 @@ export default function DataDevelopmentPage() {
     () => new Map(nodes.map((node) => [node.id, node])),
     [nodes],
   );
+  const directoryPathMap = useMemo(
+    () => new Map(directories.map((directory) => [directory.id, directory.path])),
+    [directories],
+  );
 
   const directoryIdForSelection = useMemo(() => {
     const selectedDirectoryId = idFromKey(selectedNodeKey, 'directory:');
@@ -120,14 +134,19 @@ export default function DataDevelopmentPage() {
       nodes
         .filter((node) => (node.directoryId || undefined) === directoryId)
         .sort((left, right) => left.name.localeCompare(right.name, 'zh-CN'))
-        .map((node) => ({
-          key: nodeKey(node.id),
-          title: node.name,
-          nodeType: 'node',
-          taskType: node.type,
-          searchText: `${node.name} ${node.type} ${node.id}`,
-          isLeaf: true,
-        }));
+        .map((node) => {
+          const parentPath = directoryId ? directoryPathMap.get(directoryId) || '' : '';
+          return {
+            key: nodeKey(node.id),
+            title: node.name,
+            nodeType: 'node',
+            resourceId: node.id,
+            resourcePath: `${parentPath}/${node.name}`,
+            taskType: node.type,
+            searchText: `${node.name} ${node.type} ${node.id}`,
+            isLeaf: true,
+          };
+        });
 
     const directoryNodes = (parentId?: DevelopmentId): DevelopmentTreeNode[] =>
       directories
@@ -137,6 +156,8 @@ export default function DataDevelopmentPage() {
           key: directoryKey(directory.id),
           title: directory.name,
           nodeType: 'directory',
+          resourceId: directory.id,
+          resourcePath: directory.path,
           searchText: `${directory.name} ${directory.path || ''}`,
           children: [
             ...directoryNodes(directory.id),
@@ -144,9 +165,8 @@ export default function DataDevelopmentPage() {
           ],
         }));
 
-    // `/` 仅作为逻辑根目录，不渲染为树节点。
     return [...directoryNodes(), ...resourceNodes()];
-  }, [directories, nodes]);
+  }, [directories, directoryPathMap, nodes]);
 
   const treeData = useMemo<DevelopmentTreeNode[]>(() => {
     const normalized = treeKeyword.trim().toLowerCase();
@@ -253,6 +273,99 @@ export default function DataDevelopmentPage() {
     }
   };
 
+  const copyText = async (value: string, successText: string) => {
+    try {
+      await navigator.clipboard.writeText(value);
+      message.success(successText);
+    } catch {
+      message.error('复制失败，请检查浏览器剪贴板权限');
+    }
+  };
+
+  const handleResourceAction = (
+    action: DevelopmentTreeAction,
+    resource: DevelopmentTreeNode,
+  ) => {
+    setSelectedNodeKey(resource.key as TreeNodeKey);
+    if (action === 'create-directory') {
+      setDirectoryOpen(true);
+      return;
+    }
+    if (action === 'create-sql' || action === 'create-shell') {
+      setCreateType(action === 'create-sql' ? 'SQL' : 'SHELL');
+      setCreateOpen(true);
+      return;
+    }
+    if (action === 'copy-name') {
+      void copyText(resource.title, '名称已复制');
+      return;
+    }
+    if (action === 'copy-path') {
+      void copyText(resource.resourcePath, '路径已复制');
+      return;
+    }
+    if (action === 'rename') {
+      setRenameTarget(resource);
+      return;
+    }
+    if (action === 'delete') {
+      setDeleteTarget(resource);
+    }
+  };
+
+  const submitRename = async (name: string) => {
+    if (!renameTarget) return;
+    setRenameSaving(true);
+    try {
+      if (renameTarget.nodeType === 'directory') {
+        responseData(
+          await renameDevelopmentDirectory(renameTarget.resourceId, name),
+          '目录重命名失败',
+        );
+      } else {
+        responseData(
+          await renameDevelopmentNode(renameTarget.resourceId, name),
+          '节点重命名失败',
+        );
+      }
+      setRenameTarget(undefined);
+      setTreeKeyword('');
+      await loadTree();
+      message.success('重命名成功');
+    } catch (error) {
+      message.error(error instanceof Error ? error.message : '重命名失败');
+    } finally {
+      setRenameSaving(false);
+    }
+  };
+
+  const submitDelete = async () => {
+    if (!deleteTarget) return;
+    setDeleteSaving(true);
+    try {
+      if (deleteTarget.nodeType === 'directory') {
+        responseData(
+          await deleteDevelopmentDirectory(deleteTarget.resourceId),
+          '目录删除失败',
+        );
+      } else {
+        responseData(
+          await deleteDevelopmentNode(deleteTarget.resourceId),
+          '节点删除失败',
+        );
+      }
+      setDeleteTarget(undefined);
+      setSelectedNodeKey(undefined);
+      setTreeKeyword('');
+      await loadTree();
+      message.success('删除成功');
+    } catch (error) {
+      message.error(error instanceof Error ? error.message : '删除失败');
+    } finally {
+      setDeleteSaving(false);
+    }
+  };
+
   return (
     <ConfigProvider theme={BRAND_THEME}>
       <div className="flex h-[calc(100vh-64px)] min-h-[640px] flex-col overflow-hidden bg-white">
@@ -275,6 +388,7 @@ export default function DataDevelopmentPage() {
               setCreateType(type);
               setCreateOpen(true);
             }}
+            onResourceAction={handleResourceAction}
             onSearchChange={setTreeKeyword}
             onResizeStart={handleResizeStart}
             onCollapsedChange={setLeftCollapsed}
@@ -323,6 +437,41 @@ export default function DataDevelopmentPage() {
           }}
           onSubmit={(parentId, name) => void submitDirectory(parentId, name)}
         />
+
+        <RenameResourceModal
+          open={Boolean(renameTarget)}
+          resourceLabel={renameTarget?.nodeType === 'directory' ? '目录' : '节点'}
+          initialName={renameTarget?.title || ''}
+          loading={renameSaving}
+          onCancel={() => {
+            if (!renameSaving) setRenameTarget(undefined);
+          }}
+          onSubmit={(name) => void submitRename(name)}
+        />
+
+        <Modal
+          open={Boolean(deleteTarget)}
+          title={`删除${deleteTarget?.nodeType === 'directory' ? '目录' : '节点'}`}
+          okText="删除"
+          cancelText="取消"
+          okButtonProps={{ danger: true }}
+          confirmLoading={deleteSaving}
+          maskClosable={!deleteSaving}
+          closable={!deleteSaving}
+          onCancel={() => {
+            if (!deleteSaving) setDeleteTarget(undefined);
+          }}
+          onOk={() => void submitDelete()}
+        >
+          <div className="pt-2 text-[13px] leading-6 text-[#475467]">
+            确认删除“{deleteTarget?.title}”吗？
+            {deleteTarget?.nodeType === 'directory' ? (
+              <div className="mt-1 text-[#98a2b3]">
+                仅空目录可以删除；存在子目录或节点时后端会拒绝本次操作。
+              </div>
+            ) : null}
+          </div>
+        </Modal>
       </div>
     </ConfigProvider>
   );

--- a/yak-ops-ui/src/pages/data-development/service.ts
+++ b/yak-ops-ui/src/pages/data-development/service.ts
@@ -5,6 +5,7 @@ import type {
   CreateDevelopmentDirectoryPayload,
   CreateDevelopmentNodePayload,
   DevelopmentDirectory,
+  DevelopmentId,
   DevelopmentNode,
 } from './types';
 
@@ -20,6 +21,16 @@ export const createDevelopmentDirectory = (
 ): Promise<ApiResponse<DevelopmentDirectory>> =>
   HttpUtils.post<DevelopmentDirectory>(DIRECTORY_API, payload);
 
+export const renameDevelopmentDirectory = (
+  id: DevelopmentId,
+  name: string,
+): Promise<ApiResponse<DevelopmentDirectory>> =>
+  HttpUtils.put<DevelopmentDirectory>(`${DIRECTORY_API}/${id}/name`, { name });
+
+export const deleteDevelopmentDirectory = (
+  id: DevelopmentId,
+): Promise<ApiResponse<boolean>> => HttpUtils.delete<boolean>(`${DIRECTORY_API}/${id}`);
+
 export const listDevelopmentNodes = (): Promise<ApiResponse<DevelopmentNode[]>> =>
   HttpUtils.get<DevelopmentNode[]>(NODE_API);
 
@@ -27,3 +38,13 @@ export const createDevelopmentNode = (
   payload: CreateDevelopmentNodePayload,
 ): Promise<ApiResponse<DevelopmentNode>> =>
   HttpUtils.post<DevelopmentNode>(NODE_API, payload);
+
+export const renameDevelopmentNode = (
+  id: DevelopmentId,
+  name: string,
+): Promise<ApiResponse<DevelopmentNode>> =>
+  HttpUtils.put<DevelopmentNode>(`${NODE_API}/${id}/name`, { name });
+
+export const deleteDevelopmentNode = (
+  id: DevelopmentId,
+): Promise<ApiResponse<boolean>> => HttpUtils.delete<boolean>(`${NODE_API}/${id}`);


### PR DESCRIPTION
## 目标

为数据开发左侧资源树增加真正可用的右键操作，参考 IDE / DataWorks 类资源树交互，但只保留当前阶段最有价值、边界清晰的能力。

## 右键菜单

### 目录

- 新建节点
  - SQL 节点
  - Shell 节点
- 新建目录
- 复制名称
- 复制路径
- 重命名
- 删除

### 节点

- 复制名称
- 复制路径
- 重命名
- 删除

右键操作基于当前鼠标所在资源，不要求先左键选中；执行新建时会自动以当前目录作为父路径。

## 前端

- `DevelopmentTreePane` 为每个目录 / 节点增加 contextMenu Dropdown
- 节点类型感知菜单：只有目录显示“新建节点 / 新建目录”
- 新增 `RenameResourceModal`
- 删除使用确认 Modal
- 复制名称 / 路径直接写入剪贴板
- rename / delete 成功后只刷新左树，不跳页面
- 继续保持 BIGINT / Snowflake ID 全程 string 语义

## 后端

目录新增：

- `PUT /api/v1/data-development/directories/{id}/name`
- `DELETE /api/v1/data-development/directories/{id}`

节点新增：

- `PUT /api/v1/data-development/nodes/{id}/name`
- `DELETE /api/v1/data-development/nodes/{id}`

Repository / Service 同步增加 rename / delete 能力。

## 删除安全策略

目录当前只允许删除空目录：

- 有子目录 -> 拒绝删除
- 有开发节点 -> 拒绝删除
- 空目录 -> 允许删除

不做递归删除，避免误删整棵开发树。

节点删除继续使用 `yak_dev_node` 现有 MyBatis-Plus `@TableLogic` 逻辑删除。

## 暂不实现

本 PR 不做：

- 移动
- 克隆
- 收藏
- 发布历史
- 运维中心跳转
- 递归删除目录

这些能力等右侧节点生命周期稳定后再补更合适。

## 测试

更新现有两组 Service 单测，新增覆盖：

- 目录重命名后子目录 path 自动重算
- 非空目录拒绝删除
- 空目录删除
- 节点重命名
- 节点删除

## 范围

仅修改数据开发 Directory / Node 元数据能力和左侧资源树，不重新引入 SQL 专业后端，也不修改右侧工作区或 Workflow。

分支基于最新 main，compare 时 behind 0。保持 Draft，供本地 Maven / TypeScript 和右键交互验证。