### PR TITLE
refactor(workflow): align instance list with offline sync layout

### DIFF
--- a/yak-ops-ui/src/pages/workflow/instances/index.tsx
+++ b/yak-ops-ui/src/pages/workflow/instances/index.tsx
@@ -14,8 +14,30 @@ import {
   type WorkflowInstance,
   type WorkflowNodeInstance,
 } from '@/services/workflow';
-import { Button, Drawer, Empty, Popconfirm, Table, message } from 'antd';
+import {
+  CopyOutlined,
+  FilterOutlined,
+  ReloadOutlined,
+  SearchOutlined,
+} from '@ant-design/icons';
+import {
+  Button,
+  ConfigProvider,
+  DatePicker,
+  Divider,
+  Drawer,
+  Empty,
+  Input,
+  Pagination,
+  Popconfirm,
+  Popover,
+  Select,
+  Table,
+  Tooltip,
+  message,
+} from 'antd';
 import type { ColumnsType } from 'antd/es/table';
+import type { Dayjs } from 'dayjs';
 import dayjs from 'dayjs';
 import {
   Pause,
@@ -25,6 +47,8 @@ import {
   Square,
 } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+const { RangePicker } = DatePicker;
 
 const statusLabel: Record<string, string> = {
   CREATED: '已创建',
@@ -51,6 +75,50 @@ const failureReasonLabel: Record<string, string> = {
   EXECUTION_TIMEOUT: '执行超时',
 };
 
+const RUNNING_STATUSES = new Set([
+  'CREATED',
+  'RUNNING',
+  'PAUSING',
+  'PAUSED',
+  'RESUMING',
+  'WAITING',
+  'READY',
+  'SUBMITTED',
+]);
+
+const COMPLETED_STATUSES = new Set([
+  'SUCCESS',
+  'SUCCESS_WITH_WARNINGS',
+  'WARNING',
+  'CANCELED',
+]);
+
+const FAILED_STATUSES = new Set(['FAILED', 'TIMED_OUT']);
+
+type StatusGroup = 'ALL' | 'RUNNING' | 'COMPLETED' | 'FAILED';
+
+interface FilterState {
+  keyword?: string;
+  instanceId?: string;
+  definitionId?: string;
+  testRun?: 'true' | 'false';
+  startedAt?: Dayjs[];
+}
+
+interface PaginationState {
+  current: number;
+  pageSize: number;
+}
+
+const statusTabs: Array<{ label: string; value: StatusGroup }> = [
+  { label: '全部实例', value: 'ALL' },
+  { label: '运行中', value: 'RUNNING' },
+  { label: '已完成', value: 'COMPLETED' },
+  { label: '失败', value: 'FAILED' },
+];
+
+const PAGE_SIZE_OPTIONS = [10, 20, 50];
+
 const statusClassName = (status: string) => {
   if (status === 'FAILED' || status === 'TIMED_OUT') {
     return 'text-[#d92d20]';
@@ -69,13 +137,80 @@ const statusClassName = (status: string) => {
   return 'text-[rgba(22,24,35,.58)]';
 };
 
+const statusBadgeClassName = (status: string) => {
+  if (FAILED_STATUSES.has(status)) {
+    return 'border-[#ffd6d6] bg-[#fff5f5] text-[#d92d20]';
+  }
+  if (status === 'RUNNING' || status === 'RESUMING') {
+    return 'border-[#e4e7ec] bg-[#f5f5f6] text-[#344054]';
+  }
+  if (status === 'PAUSED' || status === 'PAUSING') {
+    return 'border-[#eaecf0] bg-[#f8f9fb] text-[#667085]';
+  }
+  return 'border-[#eaecf0] bg-[#fafafa] text-[#667085]';
+};
+
 const formatTime = (value?: string) =>
   value ? dayjs(value).format('YYYY-MM-DD HH:mm:ss') : '-';
+
+const formatDuration = (record: WorkflowInstance) => {
+  if (!record.startedAt) return '-';
+  const start = dayjs(record.startedAt);
+  const end = record.endedAt ? dayjs(record.endedAt) : dayjs();
+  const seconds = Math.max(0, end.diff(start, 'second'));
+  if (seconds < 60) return `${seconds} 秒`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes} 分 ${seconds % 60} 秒`;
+  const hours = Math.floor(minutes / 60);
+  return `${hours} 小时 ${minutes % 60} 分`;
+};
+
+const matchesStatusGroup = (status: string, group: StatusGroup) => {
+  if (group === 'ALL') return true;
+  if (group === 'RUNNING') return RUNNING_STATUSES.has(status);
+  if (group === 'COMPLETED') return COMPLETED_STATUSES.has(status);
+  return FAILED_STATUSES.has(status);
+};
 
 const JsonBlock = ({ value }: { value?: unknown }) => (
   <pre className="m-0 max-h-[220px] overflow-auto rounded-md bg-[#f7f7f8] p-2.5 text-[11px] leading-5 text-[rgba(22,24,35,.72)]">
     {JSON.stringify(value ?? {}, null, 2)}
   </pre>
+);
+
+interface ListPaginationProps {
+  total: number;
+  current: number;
+  pageSize: number;
+  onChange: (page: number, pageSize: number) => void;
+}
+
+const ListPagination = ({
+  total,
+  current,
+  pageSize,
+  onChange,
+}: ListPaginationProps) => (
+  <div className="flex items-center gap-3 text-[13px] text-[#667085]">
+    <Pagination
+      size="small"
+      total={total}
+      current={current}
+      pageSize={pageSize}
+      showSizeChanger={false}
+      showQuickJumper={false}
+      onChange={(page) => onChange(page, pageSize)}
+    />
+    <span className="whitespace-nowrap">每页显示：</span>
+    <Select
+      size="small"
+      value={pageSize}
+      options={PAGE_SIZE_OPTIONS.map((value) => ({ label: value, value }))}
+      onChange={(nextPageSize) => onChange(1, nextPageSize)}
+      className="w-[64px]"
+    />
+    <span className="whitespace-nowrap text-[#344054]">总 {total} 行</span>
+  </div>
 );
 
 const WorkflowInstancesPage = () => {
@@ -86,6 +221,14 @@ const WorkflowInstancesPage = () => {
   const [detail, setDetail] = useState<WorkflowInstance>();
   const [detailLoading, setDetailLoading] = useState(false);
   const [actionLoading, setActionLoading] = useState<string>();
+  const [statusGroup, setStatusGroup] = useState<StatusGroup>('ALL');
+  const [filterDraft, setFilterDraft] = useState<FilterState>({});
+  const [filters, setFilters] = useState<FilterState>({});
+  const [advancedOpen, setAdvancedOpen] = useState(false);
+  const [pagination, setPagination] = useState<PaginationState>({
+    current: 1,
+    pageSize: 10,
+  });
 
   const loadInstances = useCallback(async (showLoading = false) => {
     if (showLoading) setLoading(true);
@@ -183,19 +326,163 @@ const WorkflowInstancesPage = () => {
     message.success(successMessage);
   }, [applyDetailSnapshot, attachDetailStream]);
 
+  const copyToClipboard = useCallback(async (value: string) => {
+    try {
+      if (navigator.clipboard && window.isSecureContext) {
+        await navigator.clipboard.writeText(value);
+      } else {
+        const textarea = document.createElement('textarea');
+        textarea.value = value;
+        textarea.style.position = 'fixed';
+        textarea.style.opacity = '0';
+        document.body.appendChild(textarea);
+        textarea.focus();
+        textarea.select();
+        document.execCommand('copy');
+        document.body.removeChild(textarea);
+      }
+      message.success('实例 ID 已复制');
+    } catch {
+      message.error('复制失败，请手动复制');
+    }
+  }, []);
+
+  const applyFilters = useCallback((nextFilters: FilterState) => {
+    setFilterDraft(nextFilters);
+    setFilters(nextFilters);
+    setPagination((previous) => ({ ...previous, current: 1 }));
+  }, []);
+
+  const handleSearch = () => {
+    applyFilters({ ...filterDraft });
+  };
+
+  const handleStatusChange = (value: StatusGroup) => {
+    setStatusGroup(value);
+    setPagination((previous) => ({ ...previous, current: 1 }));
+  };
+
+  const updateFilterDraft = (
+    field: keyof FilterState,
+    value: FilterState[keyof FilterState],
+  ) => {
+    setFilterDraft((previous) => ({ ...previous, [field]: value }));
+  };
+
+  const handleAdvancedReset = () => {
+    const nextFilters: FilterState = {
+      ...filterDraft,
+      instanceId: undefined,
+      definitionId: undefined,
+      testRun: undefined,
+    };
+    applyFilters(nextFilters);
+  };
+
+  const advancedFilterCount = [
+    filterDraft.instanceId,
+    filterDraft.definitionId,
+    filterDraft.testRun,
+  ].filter(Boolean).length;
+
+  const filteredInstances = useMemo(() => {
+    const keyword = filters.keyword?.trim().toLowerCase();
+    const instanceId = filters.instanceId?.trim().toLowerCase();
+    const definitionId = filters.definitionId?.trim().toLowerCase();
+    const [rangeStart, rangeEnd] = filters.startedAt || [];
+
+    return instances.filter((record) => {
+      if (!matchesStatusGroup(record.status, statusGroup)) return false;
+
+      if (
+        keyword &&
+        !record.name.toLowerCase().includes(keyword) &&
+        !record.id.toLowerCase().includes(keyword)
+      ) {
+        return false;
+      }
+
+      if (instanceId && !record.id.toLowerCase().includes(instanceId)) {
+        return false;
+      }
+
+      if (
+        definitionId &&
+        !record.definitionId?.toLowerCase().includes(definitionId)
+      ) {
+        return false;
+      }
+
+      if (
+        filters.testRun &&
+        String(record.testRun) !== filters.testRun
+      ) {
+        return false;
+      }
+
+      if (rangeStart || rangeEnd) {
+        const startedAt = dayjs(record.startedAt);
+        if (rangeStart && startedAt.isBefore(rangeStart.startOf('day'))) {
+          return false;
+        }
+        if (rangeEnd && startedAt.isAfter(rangeEnd.endOf('day'))) {
+          return false;
+        }
+      }
+
+      return true;
+    });
+  }, [filters, instances, statusGroup]);
+
+  useEffect(() => {
+    const maxPage = Math.max(
+      1,
+      Math.ceil(filteredInstances.length / pagination.pageSize),
+    );
+    if (pagination.current > maxPage) {
+      setPagination((previous) => ({ ...previous, current: maxPage }));
+    }
+  }, [filteredInstances.length, pagination.current, pagination.pageSize]);
+
+  const pageInstances = useMemo(() => {
+    const start = (pagination.current - 1) * pagination.pageSize;
+    return filteredInstances.slice(start, start + pagination.pageSize);
+  }, [filteredInstances, pagination.current, pagination.pageSize]);
+
   const columns = useMemo<ColumnsType<WorkflowInstance>>(
     () => [
       {
-        title: '工作流 / 实例',
+        title: '名称 / ID',
         dataIndex: 'name',
-        minWidth: 320,
+        width: 320,
         render: (_, record) => (
-          <div>
-            <div className="text-[13px] font-semibold text-[#161823]">
-              {record.name}
+          <div className="min-w-0 py-0.5">
+            <div
+              className="truncate text-[13px] font-medium leading-5 text-[#344054]"
+              title={record.name}
+            >
+              {record.name || '-'}
             </div>
-            <div className="mt-0.5 font-mono text-[11px] text-[rgba(22,24,35,.42)]">
-              {record.id}
+            <div className="mt-0.5 flex h-5 items-center gap-1 text-[11px] leading-5 text-[#98a2b3]">
+              <span className="truncate">ID：{record.id}</span>
+              <Tooltip title="复制实例 ID">
+                <Button
+                  type="text"
+                  size="small"
+                  icon={<CopyOutlined className="text-[11px]" />}
+                  className="!flex !h-5 !w-5 !min-w-0 !items-center !justify-center !p-0 !text-[#98a2b3] hover:!bg-[#f2f4f7] hover:!text-[#475467]"
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    void copyToClipboard(record.id);
+                  }}
+                />
+              </Tooltip>
+            </div>
+            <div
+              className="truncate text-[11px] leading-5 text-[#b0b7c3]"
+              title={record.definitionId}
+            >
+              工作流：{record.definitionId || '-'}
             </div>
           </div>
         ),
@@ -203,52 +490,83 @@ const WorkflowInstancesPage = () => {
       {
         title: '状态',
         dataIndex: 'status',
-        width: 130,
+        width: 120,
+        align: 'center',
         render: (status: string) => (
-          <span className={statusClassName(status)}>
+          <span
+            className={[
+              'inline-flex min-h-6 items-center rounded-md border px-2 text-[12px] font-medium',
+              statusBadgeClassName(status),
+            ].join(' ')}
+          >
             {statusLabel[status] || status}
           </span>
         ),
       },
       {
-        title: '节点 / 连线',
-        width: 130,
+        title: '执行概况',
+        width: 210,
         render: (_, record) => (
-          <span className="text-[13px] text-[rgba(22,24,35,.66)]">
-            {record.nodeCount} / {record.edgeCount}
-          </span>
+          <div className="text-[12px] leading-5 text-[#667085]">
+            <div>
+              <span className="text-[#98a2b3]">节点 / 连线：</span>
+              <span className="text-[#475467]">
+                {record.nodeCount} / {record.edgeCount}
+              </span>
+            </div>
+            <div>
+              <span className="text-[#98a2b3]">运行时长：</span>
+              <span className="text-[#475467]">{formatDuration(record)}</span>
+            </div>
+          </div>
         ),
       },
       {
         title: '工作流超时',
         dataIndex: 'workflowTimeoutSeconds',
-        width: 120,
-        render: (value: number) => value > 0 ? `${value}s` : '-',
+        width: 130,
+        render: (value: number) => (
+          <span className="text-[12px] text-[#667085]">
+            {value > 0 ? `${value}s` : '-'}
+          </span>
+        ),
       },
       {
         title: '开始时间',
         dataIndex: 'startedAt',
-        width: 180,
-        render: formatTime,
+        width: 175,
+        render: (value?: string) => (
+          <span className="whitespace-nowrap text-[12px] text-[#98a2b3]">
+            {formatTime(value)}
+          </span>
+        ),
       },
       {
         title: '结束时间',
         dataIndex: 'endedAt',
-        width: 180,
-        render: formatTime,
+        width: 175,
+        render: (value?: string) => (
+          <span className="whitespace-nowrap text-[12px] text-[#98a2b3]">
+            {formatTime(value)}
+          </span>
+        ),
       },
       {
         title: '操作',
-        width: 90,
+        width: 100,
         fixed: 'right',
         render: (_, record) => (
-          <Button type="link" className="!px-0" onClick={() => openDetail(record)}>
+          <Button
+            type="link"
+            className="!h-7 !px-0 !text-[12px] !text-[#ff4d4f]"
+            onClick={() => openDetail(record)}
+          >
             查看
           </Button>
         ),
       },
     ],
-    [openDetail],
+    [copyToClipboard, openDetail],
   );
 
   const handleRerunFromNode = useCallback(async (nodeId: string) => {
@@ -348,7 +666,9 @@ const WorkflowInstancesPage = () => {
         title: 'Attempt ID',
         dataIndex: 'id',
         render: (value: string) => (
-          <span className="font-mono text-[10px] text-[rgba(22,24,35,.56)]">{value}</span>
+          <span className="font-mono text-[10px] text-[rgba(22,24,35,.56)]">
+            {value}
+          </span>
         ),
       },
       {
@@ -382,35 +702,53 @@ const WorkflowInstancesPage = () => {
         </div>
         <div>
           <span className="text-[rgba(22,24,35,.42)]">派发超时：</span>
-          <span>{record.dispatchTimeoutSeconds > 0 ? `${record.dispatchTimeoutSeconds}s` : '-'}</span>
+          <span>
+            {record.dispatchTimeoutSeconds > 0
+              ? `${record.dispatchTimeoutSeconds}s`
+              : '-'}
+          </span>
         </div>
         <div>
           <span className="text-[rgba(22,24,35,.42)]">执行超时：</span>
-          <span>{record.executionTimeoutSeconds > 0 ? `${record.executionTimeoutSeconds}s` : '-'}</span>
+          <span>
+            {record.executionTimeoutSeconds > 0
+              ? `${record.executionTimeoutSeconds}s`
+              : '-'}
+          </span>
         </div>
       </div>
 
       <div className="grid grid-cols-2 gap-3">
         <div>
-          <div className="mb-1.5 text-[11px] font-medium text-[#161823]">Input Mapping</div>
+          <div className="mb-1.5 text-[11px] font-medium text-[#161823]">
+            Input Mapping
+          </div>
           <JsonBlock value={record.inputMapping} />
         </div>
         <div>
-          <div className="mb-1.5 text-[11px] font-medium text-[#161823]">Resolved Node Input</div>
+          <div className="mb-1.5 text-[11px] font-medium text-[#161823]">
+            Resolved Node Input
+          </div>
           <JsonBlock value={record.input} />
         </div>
         <div>
-          <div className="mb-1.5 text-[11px] font-medium text-[#161823]">Direct Predecessor Outputs</div>
+          <div className="mb-1.5 text-[11px] font-medium text-[#161823]">
+            Direct Predecessor Outputs
+          </div>
           <JsonBlock value={record.predecessorOutputs} />
         </div>
         <div>
-          <div className="mb-1.5 text-[11px] font-medium text-[#161823]">Node Output</div>
+          <div className="mb-1.5 text-[11px] font-medium text-[#161823]">
+            Node Output
+          </div>
           <JsonBlock value={record.output} />
         </div>
       </div>
 
       <div>
-        <div className="mb-1.5 text-[11px] font-medium text-[#161823]">Attempt History</div>
+        <div className="mb-1.5 text-[11px] font-medium text-[#161823]">
+          Attempt History
+        </div>
         <Table<WorkflowAttempt>
           rowKey="id"
           size="small"
@@ -435,178 +773,483 @@ const WorkflowInstancesPage = () => {
   );
 
   return (
-    <div className="min-h-[calc(100vh-64px)] bg-white px-5 py-4">
-      <div className="mb-3 flex items-center justify-between">
-        <div>
-          <h1 className="m-0 text-[20px] font-semibold text-[#161823]">工作流实例</h1>
-          <div className="mt-1 text-xs text-[rgba(22,24,35,.46)]">
-            查看工作流生命周期、Attempt、超时、输入输出及恢复操作。
-          </div>
-        </div>
-        <Button
-          icon={<RefreshCw size={14} />}
-          loading={loading}
-          onClick={() => void loadInstances(true)}
-        >
-          刷新
-        </Button>
-      </div>
+    <ConfigProvider
+      theme={{
+        token: {
+          borderRadius: 10,
+          colorBorder: '#f0f0f0',
+          colorBgContainer: '#ffffff',
+        },
+        components: {
+          Button: {
+            borderRadius: 8,
+          },
+          Input: {
+            activeShadow: 'none',
+          },
+          Select: {
+            activeOutlineColor: 'transparent',
+          },
+        },
+      }}
+    >
+      <div className="flex min-h-[calc(100vh-64px)] flex-col bg-white px-5 pt-4">
+        <h1 className="m-0 text-[17px] font-semibold text-[#161823]">
+          工作流实例
+        </h1>
 
-      <Table<WorkflowInstance>
-        rowKey="id"
-        size="small"
-        bordered
-        pagination={false}
-        loading={loading}
-        dataSource={instances}
-        columns={columns}
-        scroll={{ x: 1180 }}
-        locale={{
-          emptyText: <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="暂无工作流实例" />,
-        }}
-      />
-
-      <Drawer
-        title={detail ? `${detail.name} · 实例详情` : '实例详情'}
-        width={980}
-        open={detailOpen}
-        loading={detailLoading}
-        onClose={closeDetail}
-        extra={detail ? (
-          <div className="flex items-center gap-2">
-            {detail.status === 'RUNNING' ? (
-              <Button
-                size="small"
-                icon={<Pause size={13} />}
-                loading={actionLoading === 'pause'}
-                onClick={() => void runAction(
-                  'pause',
-                  () => pauseWorkflowInstance(detail.id),
-                  '已请求暂停工作流',
-                )}
-              >暂停</Button>
-            ) : null}
-            {detail.status === 'PAUSED' ? (
-              <Button
-                size="small"
-                icon={<Play size={13} />}
-                loading={actionLoading === 'resume'}
-                onClick={() => void runAction(
-                  'resume',
-                  () => resumeWorkflowInstance(detail.id),
-                  '已请求恢复工作流',
-                )}
-              >恢复</Button>
-            ) : null}
-            {!isWorkflowTerminal(detail.status) ? (
-              <Popconfirm
-                title="取消当前工作流？"
-                onConfirm={() => void runAction(
-                  'cancel',
-                  () => cancelWorkflowInstance(detail.id),
-                  '工作流已取消',
-                )}
-              >
-                <Button
-                  size="small"
-                  danger
-                  icon={<Square size={12} />}
-                  loading={actionLoading === 'cancel'}
-                >取消</Button>
-              </Popconfirm>
-            ) : null}
-            {canRetryFailed ? (
-              <Button
-                size="small"
-                icon={<RefreshCw size={12} />}
-                loading={actionLoading === 'retryFailed'}
-                onClick={() => void runAction(
-                  'retryFailed',
-                  () => retryWorkflowFailedNodes(detail.id),
-                  '已重新调度失败/阻断节点',
-                )}
-              >重试失败节点</Button>
-            ) : null}
-            {isWorkflowTerminal(detail.status) ? (
-              <Button
-                size="small"
-                icon={<RotateCcw size={12} />}
-                loading={actionLoading === 'restart'}
-                onClick={() => void (async () => {
-                  if (actionLoading) return;
-                  setActionLoading('restart');
-                  try {
-                    const prepared = await restartWorkflowInstance(detail.id);
-                    await activateNewExecution(prepared, '已创建并启动新的完整运行实例');
-                  } catch (error) {
-                    message.error(error instanceof Error ? error.message : '整体重跑失败');
-                  } finally {
-                    setActionLoading(undefined);
-                  }
-                })()}
-              >整体重跑</Button>
-            ) : null}
-          </div>
-        ) : null}
-      >
-        {detail ? (
-          <>
-            <div className="mb-4 grid grid-cols-3 gap-x-8 gap-y-3 text-[12px]">
-              <div className="col-span-2">
-                <span className="text-[rgba(22,24,35,.45)]">实例 ID：</span>
-                <span className="font-mono text-[#161823]">{detail.id}</span>
-              </div>
-              <div>
-                <span className="text-[rgba(22,24,35,.45)]">状态：</span>
-                <span className={statusClassName(detail.status)}>
-                  {statusLabel[detail.status] || detail.status}
-                </span>
-              </div>
-              <div>
-                <span className="text-[rgba(22,24,35,.45)]">创建：</span>
-                <span>{formatTime(detail.startedAt)}</span>
-              </div>
-              <div>
-                <span className="text-[rgba(22,24,35,.45)]">当前运行段：</span>
-                <span>{formatTime(detail.runStartedAt)}</span>
-              </div>
-              <div>
-                <span className="text-[rgba(22,24,35,.45)]">结束：</span>
-                <span>{formatTime(detail.endedAt)}</span>
-              </div>
-              <div>
-                <span className="text-[rgba(22,24,35,.45)]">工作流超时：</span>
-                <span>{detail.workflowTimeoutSeconds > 0 ? `${detail.workflowTimeoutSeconds}s` : '-'}</span>
-              </div>
-              {detail.sourceExecutionId ? (
-                <div className="col-span-2">
-                  <span className="text-[rgba(22,24,35,.45)]">来源实例：</span>
-                  <span className="font-mono text-[rgba(22,24,35,.68)]">{detail.sourceExecutionId}</span>
+        <div className="mx-auto flex w-full max-w-full flex-1 flex-col">
+          <div className="mb-3">
+            <div className="border-b border-[#f0f0f0]">
+              <div className="flex min-h-[54px] items-center justify-between gap-4 py-2">
+                <div className="flex shrink-0 items-center gap-1 rounded-lg bg-[#f5f5f6] p-1">
+                  {statusTabs.map((item) => {
+                    const active = statusGroup === item.value;
+                    return (
+                      <button
+                        key={item.value}
+                        type="button"
+                        onClick={() => handleStatusChange(item.value)}
+                        className={[
+                          'h-8 rounded-md px-3.5 text-[13px] font-medium transition-all',
+                          active
+                            ? 'bg-white text-[#ff4d4f] shadow-[0_1px_4px_rgba(16,24,40,0.08)]'
+                            : 'text-[#667085] hover:bg-white/70 hover:text-[#344054]',
+                        ].join(' ')}
+                      >
+                        {item.label}
+                      </button>
+                    );
+                  })}
                 </div>
-              ) : null}
+
+                <div className="flex min-w-0 flex-1 items-center justify-end gap-2 overflow-x-auto">
+                  <Input
+                    allowClear
+                    variant="filled"
+                    value={filterDraft.keyword}
+                    prefix={<SearchOutlined className="text-[#98a2b3]" />}
+                    placeholder="搜索工作流名称 / 实例 ID"
+                    className="!h-9 !w-[260px] !min-w-[220px]"
+                    onChange={(event) =>
+                      updateFilterDraft(
+                        'keyword',
+                        event.target.value || undefined,
+                      )
+                    }
+                    onPressEnter={handleSearch}
+                  />
+
+                  <RangePicker
+                    allowClear
+                    variant="filled"
+                    value={filterDraft.startedAt as any}
+                    format="YYYY-MM-DD"
+                    placeholder={['开始日期', '结束日期']}
+                    className="!h-9 !w-[250px] !min-w-[230px]"
+                    onChange={(value) => {
+                      const nextFilters = {
+                        ...filterDraft,
+                        startedAt: value
+                          ? (value as unknown as Dayjs[])
+                          : undefined,
+                      };
+                      applyFilters(nextFilters);
+                    }}
+                  />
+
+                  <Button
+                    size="small"
+                    className="!h-9 !px-4"
+                    onClick={handleSearch}
+                  >
+                    查询
+                  </Button>
+
+                  <Popover
+                    trigger="click"
+                    placement="bottomRight"
+                    open={advancedOpen}
+                    onOpenChange={setAdvancedOpen}
+                    content={
+                      <div className="w-[430px]">
+                        <div className="mb-4">
+                          <div className="text-[14px] font-semibold text-[#101828]">
+                            高级搜索
+                          </div>
+                          <div className="mt-1 text-[12px] text-[#98a2b3]">
+                            按实例标识、工作流定义和运行类型进一步筛选
+                          </div>
+                        </div>
+
+                        <div className="grid grid-cols-2 gap-x-3 gap-y-4">
+                          <div>
+                            <div className="mb-1.5 text-[12px] text-[#667085]">
+                              实例 ID
+                            </div>
+                            <Input
+                              allowClear
+                              variant="filled"
+                              value={filterDraft.instanceId}
+                              placeholder="请输入实例 ID"
+                              onChange={(event) =>
+                                updateFilterDraft(
+                                  'instanceId',
+                                  event.target.value || undefined,
+                                )
+                              }
+                              onPressEnter={() => {
+                                handleSearch();
+                                setAdvancedOpen(false);
+                              }}
+                            />
+                          </div>
+
+                          <div>
+                            <div className="mb-1.5 text-[12px] text-[#667085]">
+                              工作流定义 ID
+                            </div>
+                            <Input
+                              allowClear
+                              variant="filled"
+                              value={filterDraft.definitionId}
+                              placeholder="请输入工作流定义 ID"
+                              onChange={(event) =>
+                                updateFilterDraft(
+                                  'definitionId',
+                                  event.target.value || undefined,
+                                )
+                              }
+                              onPressEnter={() => {
+                                handleSearch();
+                                setAdvancedOpen(false);
+                              }}
+                            />
+                          </div>
+
+                          <div>
+                            <div className="mb-1.5 text-[12px] text-[#667085]">
+                              运行类型
+                            </div>
+                            <Select
+                              allowClear
+                              variant="filled"
+                              value={filterDraft.testRun}
+                              placeholder="全部运行"
+                              className="w-full"
+                              options={[
+                                { label: '正式运行', value: 'false' },
+                                { label: '测试运行', value: 'true' },
+                              ]}
+                              onChange={(value) =>
+                                updateFilterDraft('testRun', value)
+                              }
+                            />
+                          </div>
+                        </div>
+
+                        <div className="mt-5 flex items-center justify-end gap-2 border-t border-[#f0f0f0] pt-4">
+                          <Button
+                            size="small"
+                            className="!h-8"
+                            onClick={handleAdvancedReset}
+                          >
+                            重置
+                          </Button>
+                          <Button
+                            danger
+                            type="primary"
+                            size="small"
+                            className="!h-8"
+                            onClick={() => {
+                              handleSearch();
+                              setAdvancedOpen(false);
+                            }}
+                          >
+                            应用筛选
+                          </Button>
+                        </div>
+                      </div>
+                    }
+                  >
+                    <Button
+                      size="small"
+                      icon={<FilterOutlined />}
+                      className={[
+                        '!h-9 !px-3',
+                        advancedFilterCount > 0
+                          ? '!border-[#ffccc7] !bg-[#fff1f0] !text-[#ff4d4f]'
+                          : '',
+                      ].join(' ')}
+                    >
+                      高级搜索
+                      {advancedFilterCount > 0 && (
+                        <span className="ml-1.5 inline-flex h-[18px] min-w-[18px] items-center justify-center rounded-full bg-[#ff4d4f] px-1 text-[10px] leading-[18px] text-white">
+                          {advancedFilterCount}
+                        </span>
+                      )}
+                    </Button>
+                  </Popover>
+                </div>
+              </div>
             </div>
 
-            <div className="mb-4">
-              <div className="mb-1.5 text-[11px] font-medium text-[#161823]">Workflow Input</div>
-              <JsonBlock value={detail.input} />
+            <div className="flex min-h-[48px] items-center justify-between">
+              <div className="text-[12px] text-[#98a2b3]">
+                当前筛选结果 {filteredInstances.length} 条
+              </div>
+              <Button
+                size="small"
+                icon={<ReloadOutlined spin={loading} />}
+                className="!h-8"
+                loading={loading}
+                onClick={() => void loadInstances(true)}
+              >
+                刷新
+              </Button>
             </div>
 
-            <Table<WorkflowNodeInstance>
+            <div className="flex min-h-9 items-center rounded-sm bg-[#fff7e6] px-3 text-[12px] text-[#475467]">
+              <span className="mr-2 text-[14px] text-[#faad14]">▲</span>
+              <span className="font-medium text-[#344054]">【提示】</span>
+              <span>
+                运行中的实例会自动刷新；进入详情后可执行暂停、恢复、取消、重试和重跑等操作。
+              </span>
+            </div>
+          </div>
+
+          <Divider style={{ marginTop: 4, marginBottom: 16 }} />
+
+          <div className="flex-1">
+            <Table<WorkflowInstance>
               rowKey="id"
+              bordered
               size="small"
               pagination={false}
-              dataSource={detail.nodes}
-              columns={nodeColumns}
-              scroll={{ x: 760 }}
-              expandable={{
-                expandedRowRender: renderNodeDetail,
-                rowExpandable: () => true,
+              loading={loading}
+              dataSource={pageInstances}
+              columns={columns}
+              scroll={{ x: 'max-content' }}
+              className={[
+                'compact-workflow-instance-table',
+                '[&_.ant-table]:!text-[13px]',
+                '[&_.ant-table-container]:!border-[#eaecf0]',
+                '[&_.ant-table-cell]:!align-middle',
+                '[&_.ant-table-thead>tr>th]:!h-10',
+                '[&_.ant-table-thead>tr>th]:!bg-[#f8f9fb]',
+                '[&_.ant-table-thead>tr>th]:!px-4',
+                '[&_.ant-table-thead>tr>th]:!py-2',
+                '[&_.ant-table-thead>tr>th]:!text-[12px]',
+                '[&_.ant-table-thead>tr>th]:!font-medium',
+                '[&_.ant-table-thead>tr>th]:!text-[#667085]',
+                '[&_.ant-table-thead>tr>th]:!border-[#eaecf0]',
+                '[&_.ant-table-tbody>tr>td]:!px-4',
+                '[&_.ant-table-tbody>tr>td]:!py-2.5',
+                '[&_.ant-table-tbody>tr>td]:!border-[#f0f2f5]',
+                '[&_.ant-table-tbody>tr>td]:!text-[#667085]',
+                '[&_.ant-table-tbody>tr:hover>td]:!bg-[#fafbfc]',
+                '[&_.ant-table-cell-fix-right]:!bg-white',
+                '[&_.ant-table-tbody>tr:hover_.ant-table-cell-fix-right]:!bg-[#fafbfc]',
+                '[&_.ant-table-placeholder>td]:!h-[240px]',
+              ].join(' ')}
+              locale={{
+                emptyText: (
+                  <Empty
+                    image={Empty.PRESENTED_IMAGE_SIMPLE}
+                    description={
+                      <span className="text-[12px] text-[#98a2b3]">
+                        暂无工作流实例
+                      </span>
+                    }
+                  />
+                ),
               }}
             />
-          </>
-        ) : null}
-      </Drawer>
-    </div>
+          </div>
+
+          <div className="sticky bottom-0 z-20 mt-auto flex min-h-[56px] items-center justify-end border border-t-0 border-[#e5e7eb] bg-white px-5 py-3 shadow-[0_-4px_12px_rgba(16,24,40,0.04)]">
+            <ListPagination
+              total={filteredInstances.length}
+              current={pagination.current}
+              pageSize={pagination.pageSize}
+              onChange={(current, pageSize) =>
+                setPagination({ current, pageSize })
+              }
+            />
+          </div>
+        </div>
+
+        <Drawer
+          title={detail ? `${detail.name} · 实例详情` : '实例详情'}
+          width={980}
+          open={detailOpen}
+          loading={detailLoading}
+          onClose={closeDetail}
+          extra={detail ? (
+            <div className="flex items-center gap-2">
+              {detail.status === 'RUNNING' ? (
+                <Button
+                  size="small"
+                  icon={<Pause size={13} />}
+                  loading={actionLoading === 'pause'}
+                  onClick={() => void runAction(
+                    'pause',
+                    () => pauseWorkflowInstance(detail.id),
+                    '已请求暂停工作流',
+                  )}
+                >
+                  暂停
+                </Button>
+              ) : null}
+              {detail.status === 'PAUSED' ? (
+                <Button
+                  size="small"
+                  icon={<Play size={13} />}
+                  loading={actionLoading === 'resume'}
+                  onClick={() => void runAction(
+                    'resume',
+                    () => resumeWorkflowInstance(detail.id),
+                    '已请求恢复工作流',
+                  )}
+                >
+                  恢复
+                </Button>
+              ) : null}
+              {!isWorkflowTerminal(detail.status) ? (
+                <Popconfirm
+                  title="取消当前工作流？"
+                  onConfirm={() => void runAction(
+                    'cancel',
+                    () => cancelWorkflowInstance(detail.id),
+                    '工作流已取消',
+                  )}
+                >
+                  <Button
+                    size="small"
+                    danger
+                    icon={<Square size={12} />}
+                    loading={actionLoading === 'cancel'}
+                  >
+                    取消
+                  </Button>
+                </Popconfirm>
+              ) : null}
+              {canRetryFailed ? (
+                <Button
+                  size="small"
+                  icon={<RefreshCw size={12} />}
+                  loading={actionLoading === 'retryFailed'}
+                  onClick={() => void runAction(
+                    'retryFailed',
+                    () => retryWorkflowFailedNodes(detail.id),
+                    '已重新调度失败/阻断节点',
+                  )}
+                >
+                  重试失败节点
+                </Button>
+              ) : null}
+              {isWorkflowTerminal(detail.status) ? (
+                <Button
+                  size="small"
+                  icon={<RotateCcw size={12} />}
+                  loading={actionLoading === 'restart'}
+                  onClick={() => void (async () => {
+                    if (actionLoading) return;
+                    setActionLoading('restart');
+                    try {
+                      const prepared = await restartWorkflowInstance(detail.id);
+                      await activateNewExecution(
+                        prepared,
+                        '已创建并启动新的完整运行实例',
+                      );
+                    } catch (error) {
+                      message.error(
+                        error instanceof Error ? error.message : '整体重跑失败',
+                      );
+                    } finally {
+                      setActionLoading(undefined);
+                    }
+                  })()}
+                >
+                  整体重跑
+                </Button>
+              ) : null}
+            </div>
+          ) : null}
+        >
+          {detail ? (
+            <>
+              <div className="mb-4 grid grid-cols-3 gap-x-8 gap-y-3 text-[12px]">
+                <div className="col-span-2">
+                  <span className="text-[rgba(22,24,35,.45)]">实例 ID：</span>
+                  <span className="font-mono text-[#161823]">{detail.id}</span>
+                </div>
+                <div>
+                  <span className="text-[rgba(22,24,35,.45)]">状态：</span>
+                  <span className={statusClassName(detail.status)}>
+                    {statusLabel[detail.status] || detail.status}
+                  </span>
+                </div>
+                <div>
+                  <span className="text-[rgba(22,24,35,.45)]">创建：</span>
+                  <span>{formatTime(detail.startedAt)}</span>
+                </div>
+                <div>
+                  <span className="text-[rgba(22,24,35,.45)]">
+                    当前运行段：
+                  </span>
+                  <span>{formatTime(detail.runStartedAt)}</span>
+                </div>
+                <div>
+                  <span className="text-[rgba(22,24,35,.45)]">结束：</span>
+                  <span>{formatTime(detail.endedAt)}</span>
+                </div>
+                <div>
+                  <span className="text-[rgba(22,24,35,.45)]">
+                    工作流超时：
+                  </span>
+                  <span>
+                    {detail.workflowTimeoutSeconds > 0
+                      ? `${detail.workflowTimeoutSeconds}s`
+                      : '-'}
+                  </span>
+                </div>
+                {detail.sourceExecutionId ? (
+                  <div className="col-span-2">
+                    <span className="text-[rgba(22,24,35,.45)]">
+                      来源实例：
+                    </span>
+                    <span className="font-mono text-[rgba(22,24,35,.68)]">
+                      {detail.sourceExecutionId}
+                    </span>
+                  </div>
+                ) : null}
+              </div>
+
+              <div className="mb-4">
+                <div className="mb-1.5 text-[11px] font-medium text-[#161823]">
+                  Workflow Input
+                </div>
+                <JsonBlock value={detail.input} />
+              </div>
+
+              <Table<WorkflowNodeInstance>
+                rowKey="id"
+                size="small"
+                pagination={false}
+                dataSource={detail.nodes}
+                columns={nodeColumns}
+                scroll={{ x: 760 }}
+                expandable={{
+                  expandedRowRender: renderNodeDetail,
+                  rowExpandable: () => true,
+                }}
+              />
+            </>
+          ) : null}
+        </Drawer>
+      </div>
+    </ConfigProvider>
   );
 };
 


### PR DESCRIPTION
## 变更说明

- 将「工作流实例」列表页重构为与「离线同步」一致的页面骨架和视觉密度
- 增加状态分组：全部实例 / 运行中 / 已完成 / 失败
- 增加工作流名称/实例 ID 搜索、开始日期筛选和高级搜索
- 高级搜索支持实例 ID、工作流定义 ID、正式/测试运行筛选
- 增加客户端分页，并复用离线同步页的分页交互样式
- 表格统一为紧凑型 bordered 样式，补充实例 ID 复制、执行概况和运行时长
- 保留原有详情 Drawer、实时刷新、暂停/恢复/取消、失败节点重试、节点重跑和整体重跑能力

## 交互说明

- 列表仍每 2 秒自动拉取最新实例状态
- 查询条件只影响前端展示，不改变现有工作流实例 API
- 运行中的实例详情仍优先使用 SSE 更新

## 验证

- 已确认本 PR 仅修改 `yak-ops-ui/src/pages/workflow/instances/index.tsx`
- 建议重点回归：状态筛选、日期筛选、分页、详情 Drawer 以及运行中实例的自动刷新