### PR TITLE
fix(ui): align sidebar navigation sections

### DIFF
--- a/yak-ops-ui/config/routes.ts
+++ b/yak-ops-ui/config/routes.ts
@@ -19,7 +19,7 @@ export default [
     routes: [
       {
         path: '/',
-        redirect: '/data-source',
+        redirect: '/home',
       },
       ...appRoutes.map(({ path, component, hidden }) => ({
         path,

--- a/yak-ops-ui/src/config/navigation.test.ts
+++ b/yak-ops-ui/src/config/navigation.test.ts
@@ -4,6 +4,7 @@ import {
   getActiveNavigationId,
   getMainNavigationGroups,
   getQuickCreateRoutes,
+  getStandaloneNavigationRoutes,
 } from './navigation';
 
 describe('permission-aware navigation', () => {
@@ -19,11 +20,46 @@ describe('permission-aware navigation', () => {
     expect(getActiveNavigationId('/sync/batch-link-up/42/detail', batchRead)).toBe('batch-link-up');
   });
 
-  it('removes empty groups and filters quick-create independently', () => {
-    expect(getMainNavigationGroups([])).toEqual([]);
-    expect(getMainNavigationGroups(batchRead).map((group) => group.id)).toEqual(['integration']);
+  it('keeps public groups while filtering permission-protected groups and quick-create independently', () => {
+    expect(getMainNavigationGroups([]).map((group) => group.id)).toEqual([
+      'development',
+      'workflow',
+    ]);
+    expect(getMainNavigationGroups(batchRead).map((group) => group.id)).toEqual([
+      'integration',
+      'development',
+      'workflow',
+    ]);
     expect(getQuickCreateRoutes(batchRead)).toEqual([]);
     expect(getQuickCreateRoutes([...batchRead, 'task:batch:create']).map((route) => route.id)).toEqual(['batch-link-up']);
+  });
+
+  it('keeps sidebar groups contiguous by navigation section', () => {
+    const groups = getMainNavigationGroups(['security:root']);
+    expect(groups.map((group) => group.id)).toEqual([
+      'integration',
+      'development',
+      'workflow',
+      'resources',
+      'data-quality',
+      'system',
+    ]);
+    expect(groups.map((group) => group.section)).toEqual([
+      'task',
+      'task',
+      'task',
+      'management',
+      'management',
+      'system',
+    ]);
+  });
+
+  it('registers home before other standalone navigation', () => {
+    expect(getStandaloneNavigationRoutes(['security:root']).map((route) => route.id)).toEqual([
+      'home',
+      'data-source',
+    ]);
+    expect(getActiveNavigationId('/home', [])).toBe('home');
   });
 
   it('registers the data-quality MVP pages and hidden monitor routes', () => {
@@ -33,8 +69,8 @@ describe('permission-aware navigation', () => {
       'quality:template:read',
     ];
     const groups = getMainNavigationGroups(qualityPermissions);
-    expect(groups.map((group) => group.id)).toEqual(['data-quality']);
-    expect(groups[0].routes.map((route) => route.id)).toEqual([
+    const qualityGroup = groups.find((group) => group.id === 'data-quality');
+    expect(qualityGroup?.routes.map((route) => route.id)).toEqual([
       'data-quality-table-config',
       'data-quality-execution',
       'data-quality-rule-template',
@@ -54,7 +90,6 @@ describe('permission-aware navigation', () => {
   });
 
   it('does not expose removed modules', () => {
-    expect(getActiveNavigationId('/home', [])).toBeUndefined();
     expect(getActiveNavigationId('/sync/realtime-link-up', ['task:realtime:read'])).toBeUndefined();
     expect(getActiveNavigationId('/data-development/workbench', batchRead)).toBeUndefined();
     expect(getActiveNavigationId('/data-quality/report', ['quality:report:read'])).toBeUndefined();

--- a/yak-ops-ui/src/config/navigation.ts
+++ b/yak-ops-ui/src/config/navigation.ts
@@ -35,6 +35,7 @@ export const navigationGroups: readonly NavigationGroup[] = [
 ];
 
 export const appRoutes: readonly NavigationRoute[] = [
+  { id: 'home', mode: 'public', path: '/home', title: '首页', component: './home', iconKey: 'home', order: 0 },
   { id: 'data-source', mode: 'one', permission: 'resource:data-source:read', path: '/data-source', title: '数据源管理', component: './data-source', iconKey: 'database', order: 10 },
   {
     id: 'batch-link-up', mode: 'one', permission: 'task:batch:read',
@@ -74,6 +75,14 @@ export const appRoutes: readonly NavigationRoute[] = [
 
 const sortByOrder = <T extends { order?: number }>(left: T, right: T) =>
   (left.order ?? 0) - (right.order ?? 0);
+const navigationSectionOrder: Record<NavigationSectionKey, number> = {
+  task: 10,
+  management: 20,
+  system: 30,
+};
+const sortNavigationGroups = (left: NavigationGroup, right: NavigationGroup) =>
+  navigationSectionOrder[left.section] - navigationSectionOrder[right.section]
+  || sortByOrder(left, right);
 const routeMap = new Map(appRoutes.map((route) => [route.id, route]));
 
 export const canAccessNavigationRoute = (
@@ -105,7 +114,7 @@ export const getNavigationGroups = (
         .sort(sortByOrder),
     }))
     .filter((group) => group.routes.length > 0)
-    .sort(sortByOrder);
+    .sort(sortNavigationGroups);
 export const getMainNavigationGroups = getNavigationGroups;
 export const getQuickCreateRoutes = (
   permissionCodes?: readonly string[] | null,


### PR DESCRIPTION
## Summary

- restore the Home route as the first standalone navigation item and route `/` to `/home`
- sort sidebar groups by semantic section before per-section order so task, management, and system groups stay contiguous
- keep the sidebar hierarchy as:
  - 首页
  - 数据源管理 / 数据集成 / 数据开发 / 工作流
  - 资源管理 / 数据质量
  - 系统管理
- update navigation tests for public groups, Home routing, and section ordering

## Why

The sidebar previously sorted navigation groups only by each group's numeric `order`. Because different sections reused overlapping order values, task and management groups interleaved, causing extra separators between 资源管理、工作流、数据质量. Sorting by section first keeps separators only at the intended section boundaries.

## Verification

- added/updated Jest coverage in `src/config/navigation.test.ts`
- branch is based on current `main` and only changes navigation configuration/tests
