### PR TITLE
refactor(data-development): polish editor tab experience

### DIFF
--- a/yak-ops-ui/src/pages/data-development/components/DevelopmentEditorWorkspace.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/DevelopmentEditorWorkspace.tsx
@@ -1,7 +1,9 @@
-import { Button, Tooltip, message } from 'antd';
+import { Button, Dropdown, Tooltip, message } from 'antd';
 import {
+  Check,
   Code2,
   History,
+  MoreHorizontal,
   Play,
   RefreshCw,
   Rocket,
@@ -12,7 +14,7 @@ import {
   TerminalSquare,
   X,
 } from 'lucide-react';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
 import type {
   DevelopmentDirectory,
@@ -28,6 +30,12 @@ interface DevelopmentEditorWorkspaceProps {
 }
 
 type RightPanelTab = 'properties' | 'versions';
+type EditorTabAction =
+  | 'close-current'
+  | 'close-others'
+  | 'close-left'
+  | 'close-right'
+  | 'close-all';
 
 const nodeTypeLabel: Record<string, string> = {
   SQL: 'SQL',
@@ -47,6 +55,9 @@ const NodeTypeIcon = ({ type, size = 14 }: { type: string; size?: number }) =>
     <Code2 size={size} strokeWidth={1.8} />
   );
 
+const nodeIconClassName = (type: string) =>
+  type === 'SHELL' ? 'text-[#6172f3]' : 'text-[#f79009]';
+
 const DevelopmentEditorWorkspace = ({
   nodes,
   directories,
@@ -57,6 +68,7 @@ const DevelopmentEditorWorkspace = ({
   const [activeNodeId, setActiveNodeId] = useState<DevelopmentId>();
   const [rightPanelTab, setRightPanelTab] =
     useState<RightPanelTab>('properties');
+  const tabRefs = useRef(new Map<DevelopmentId, HTMLDivElement>());
 
   const nodeMap = useMemo(
     () => new Map(nodes.map((node) => [node.id, node])),
@@ -82,6 +94,18 @@ const DevelopmentEditorWorkspace = ({
     );
   }, [nodeMap]);
 
+  useEffect(() => {
+    if (!activeNodeId) return;
+    const frame = window.requestAnimationFrame(() => {
+      tabRefs.current.get(activeNodeId)?.scrollIntoView({
+        behavior: 'smooth',
+        block: 'nearest',
+        inline: 'nearest',
+      });
+    });
+    return () => window.cancelAnimationFrame(frame);
+  }, [activeNodeId]);
+
   const activeNode = activeNodeId ? nodeMap.get(activeNodeId) : undefined;
   const activeDirectory = activeNode?.directoryId
     ? directoryMap.get(activeNode.directoryId)
@@ -104,6 +128,86 @@ const DevelopmentEditorWorkspace = ({
     onNodeFocus(nextActiveId);
   };
 
+  const closeAllNodes = () => {
+    setOpenNodeIds([]);
+    setActiveNodeId(undefined);
+    onNodeFocus(undefined);
+  };
+
+  const handleTabAction = (action: EditorTabAction) => {
+    if (!activeNodeId) return;
+    const activeIndex = openNodeIds.indexOf(activeNodeId);
+    if (activeIndex < 0) return;
+
+    if (action === 'close-current') {
+      closeNode(activeNodeId);
+      return;
+    }
+    if (action === 'close-all') {
+      closeAllNodes();
+      return;
+    }
+    if (action === 'close-others') {
+      setOpenNodeIds([activeNodeId]);
+      return;
+    }
+    if (action === 'close-left') {
+      setOpenNodeIds(openNodeIds.slice(activeIndex));
+      return;
+    }
+    if (action === 'close-right') {
+      setOpenNodeIds(openNodeIds.slice(0, activeIndex + 1));
+    }
+  };
+
+  const editorMenuItems = useMemo(
+    () => [
+      {
+        key: 'opened-editors',
+        label: `已打开的编辑器（${openNodeIds.length}）`,
+        children: openNodeIds.map((nodeId) => {
+          const node = nodeMap.get(nodeId);
+          const active = nodeId === activeNodeId;
+          return {
+            key: `focus:${nodeId}`,
+            icon: node ? (
+              <span className={nodeIconClassName(node.type)}>
+                <NodeTypeIcon type={node.type} size={13} />
+              </span>
+            ) : undefined,
+            label: (
+              <div className="flex min-w-[190px] items-center justify-between gap-3">
+                <span className="max-w-[220px] truncate">{node?.name || nodeId}</span>
+                {active ? <Check size={13} className="shrink-0 text-[#667085]" /> : null}
+              </div>
+            ),
+          };
+        }),
+      },
+      { type: 'divider' as const },
+      { key: 'close-current', label: '关闭当前编辑器' },
+      {
+        key: 'close-others',
+        label: '关闭其他编辑器',
+        disabled: openNodeIds.length <= 1,
+      },
+      {
+        key: 'close-left',
+        label: '关闭左侧编辑器',
+        disabled: !activeNodeId || openNodeIds.indexOf(activeNodeId) <= 0,
+      },
+      {
+        key: 'close-right',
+        label: '关闭右侧编辑器',
+        disabled:
+          !activeNodeId ||
+          openNodeIds.indexOf(activeNodeId) >= openNodeIds.length - 1,
+      },
+      { key: 'close-all', label: '全部关闭' },
+    ],
+    [activeNodeId, nodeMap, openNodeIds],
+  );
+
   if (!openNodeIds.length || !activeNode) {
     return (
       <main className="flex min-w-0 flex-1 items-center justify-center overflow-hidden bg-white">
@@ -121,45 +225,102 @@ const DevelopmentEditorWorkspace = ({
 
   return (
     <main className="flex min-w-0 flex-1 flex-col overflow-hidden bg-white">
-      <div className="flex h-10 shrink-0 items-end overflow-x-auto border-b border-[#e5e7eb] bg-[#fafafa] px-1.5 pt-1">
-        {openNodeIds.map((nodeId) => {
-          const node = nodeMap.get(nodeId);
-          if (!node) return null;
-          const active = nodeId === activeNodeId;
+      <div className="flex h-9 shrink-0 border-b border-[#e5e7eb] bg-[#f5f5f6]">
+        <div className="min-w-0 flex-1 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+          <div className="flex h-9 min-w-max items-stretch gap-1 px-1">
+            {openNodeIds.map((nodeId) => {
+              const node = nodeMap.get(nodeId);
+              if (!node) return null;
+              const active = nodeId === activeNodeId;
 
-          return (
-            <div
-              key={nodeId}
-              className={[
-                'group flex h-9 min-w-[150px] max-w-[230px] items-center border-x border-t transition-colors',
-                active
-                  ? 'relative -mb-px border-[#dfe3e8] bg-white text-[#161823]'
-                  : 'border-transparent bg-transparent text-[#667085] hover:bg-[#f5f5f5] hover:text-[#344054]',
-              ].join(' ')}
-            >
+              return (
+                <div
+                  key={nodeId}
+                  ref={(element) => {
+                    if (element) tabRefs.current.set(nodeId, element);
+                    else tabRefs.current.delete(nodeId);
+                  }}
+                  onAuxClick={(event) => {
+                    if (event.button === 1) closeNode(nodeId);
+                  }}
+                  className={[
+                    'group relative flex h-9 min-w-[132px] max-w-[240px] flex-none items-center border-r border-[#eaecf0] transition-colors',
+                    active
+                      ? 'bg-white text-[#344054] shadow-[inset_0_-2px_0_rgba(254,44,85,1)]'
+                      : 'bg-[#f5f5f6] text-[#667085] hover:bg-[#eeeeef] hover:text-[#344054]',
+                  ].join(' ')}
+                >
+                  <button
+                    type="button"
+                    title={node.name}
+                    aria-current={active ? 'page' : undefined}
+                    onClick={() => focusNode(nodeId)}
+                    className="flex h-full min-w-0 flex-1 items-center gap-2 bg-transparent pl-2.5 pr-1 text-left outline-none"
+                  >
+                    <span
+                      className={[
+                        'flex h-5 w-5 shrink-0 items-center justify-center rounded-sm bg-white/80',
+                        nodeIconClassName(node.type),
+                      ].join(' ')}
+                    >
+                      <NodeTypeIcon type={node.type} size={13} />
+                    </span>
+                    <span
+                      className={[
+                        'min-w-0 flex-1 truncate text-[12px] leading-5',
+                        active ? 'font-medium text-[#344054]' : 'font-normal',
+                      ].join(' ')}
+                    >
+                      {node.name}
+                    </span>
+                  </button>
+
+                  <button
+                    type="button"
+                    aria-label={`关闭 ${node.name}`}
+                    title="关闭"
+                    onClick={() => closeNode(nodeId)}
+                    className={[
+                      'mr-1 flex h-6 w-6 shrink-0 items-center justify-center rounded-[3px] text-[#98a2b3] transition-all',
+                      active
+                        ? 'opacity-100 hover:bg-[#f2f4f7] hover:text-[#475467]'
+                        : 'opacity-0 group-hover:opacity-100 hover:bg-[#e4e7ec] hover:text-[#475467]',
+                    ].join(' ')}
+                  >
+                    <X size={13} strokeWidth={1.8} />
+                  </button>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        <div className="flex h-9 w-10 shrink-0 items-center justify-center border-l border-[#e5e7eb] bg-[#f5f5f6]">
+          <Dropdown
+            trigger={['click']}
+            placement="bottomRight"
+            menu={{
+              items: editorMenuItems,
+              onClick: ({ key }) => {
+                if (key.startsWith('focus:')) {
+                  focusNode(key.substring('focus:'.length));
+                  return;
+                }
+                handleTabAction(key as EditorTabAction);
+              },
+            }}
+          >
+            <Tooltip title="编辑器操作" placement="bottomRight">
               <button
                 type="button"
-                onClick={() => focusNode(nodeId)}
-                className="flex h-full min-w-0 flex-1 items-center gap-2 bg-transparent px-3 text-left"
+                aria-label="编辑器操作"
+                className="flex h-7 w-7 items-center justify-center rounded-[4px] text-[#667085] transition-colors hover:bg-white hover:text-[#344054]"
               >
-                <span className="shrink-0 text-[#98a2b3]">
-                  <NodeTypeIcon type={node.type} size={13} />
-                </span>
-                <span className="min-w-0 flex-1 truncate text-[12px] font-medium">
-                  {node.name}
-                </span>
+                <MoreHorizontal size={17} strokeWidth={1.8} />
               </button>
-              <button
-                type="button"
-                aria-label={`关闭 ${node.name}`}
-                onClick={() => closeNode(nodeId)}
-                className="mr-1 flex h-5 w-5 shrink-0 items-center justify-center rounded-sm text-[#98a2b3] opacity-0 transition group-hover:opacity-100 hover:bg-[#eceff3] hover:text-[#475467]"
-              >
-                <X size={12} strokeWidth={1.8} />
-              </button>
-            </div>
-          );
-        })}
+            </Tooltip>
+          </Dropdown>
+        </div>
       </div>
 
       <div className="flex h-11 shrink-0 items-center justify-between border-b border-[#e8e9ec] bg-white px-3">


### PR DESCRIPTION
## 变更说明

- 基于已经合并的编辑器工作区，继续优化「数据开发」编辑 Tab 的样式和交互
- 参考 DataWorks / Monaco 编辑器的 Tab 布局，但按 Yak Ops 当前视觉体系做了轻量化适配
- Tab 区统一为紧凑的编辑器栏：灰色底、白色激活态、品牌色底部指示线
- SQL / Shell 使用不同的节点类型图标色，名称过长自动省略
- 激活 Tab 的关闭按钮常显，非激活 Tab 仅 Hover 时显示，减少视觉噪音
- 支持鼠标中键关闭 Tab
- Tab 数量较多时横向滚动；切换节点后活动 Tab 自动滚入可视区域
- 右侧固定新增「更多」入口，避免 Tab 过多时操作入口被挤走

## 编辑器操作

更多菜单目前只提供 Yak Ops 已具备且真实可执行的 Tab 管理能力：

- 查看并快速切换已打开的编辑器
- 关闭当前编辑器
- 关闭其他编辑器
- 关闭左侧编辑器
- 关闭右侧编辑器
- 全部关闭

暂不加入「拆分编辑器 / 预览编辑器 / 锁定组」等尚未实现的能力，避免出现只有 UI 没有实际行为的入口。

## 技术说明

- Tab 样式全部使用 TailwindCSS class 实现
- 不新增 CSS 文件，不依赖 Monaco 样式
- 不改数据开发后端接口
- 不影响现有目录树、工具栏、属性 / 版本面板逻辑
- 本 PR 仅修改 `DevelopmentEditorWorkspace.tsx`

## 建议回归

- 连续打开 8~10 个节点，确认 Tab 横向滚动和活动 Tab 自动可见
- 切换左侧节点与右侧 Tab，确认双向选中联动正常
- 验证关闭当前 / 其他 / 左侧 / 右侧 / 全部关闭
- 验证激活 Tab 和非激活 Tab 的 Hover / Close 状态
- 验证中键关闭 Tab 后活动节点切换正常