### PR TITLE
refactor(data-development): simplify page chrome into workbench shell

### DIFF
--- a/yak-ops-ui/src/pages/data-development/components/DevelopmentTreePane.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/DevelopmentTreePane.tsx
@@ -223,10 +223,10 @@ const DevelopmentTreePane = ({
         style={{ width: collapsed ? 0 : leftWidth }}
       >
         <div
-          className="flex h-full flex-col overflow-hidden py-3"
+          className="flex h-full flex-col overflow-hidden"
           style={{ width: leftWidth }}
         >
-          <div className="flex h-7 shrink-0 items-center justify-between px-4">
+          <div className="flex h-9 shrink-0 items-center justify-between border-b border-[#e5e7eb] bg-[#f5f5f6] px-3">
             <span className="text-[13px] font-semibold text-[#30323b]">
               开发目录
             </span>
@@ -251,14 +251,14 @@ const DevelopmentTreePane = ({
                   type="text"
                   size="small"
                   aria-label="新建目录或节点"
-                  icon={<Plus size={16} strokeWidth={1.8} />}
-                  className="!flex !h-7 !w-7 !items-center !justify-center !p-0"
+                  icon={<Plus size={15} strokeWidth={1.8} />}
+                  className="!flex !h-7 !w-7 !items-center !justify-center !p-0 hover:!bg-white"
                 />
               </Tooltip>
             </Dropdown>
           </div>
 
-          <div className="shrink-0 px-[14px] pb-2 pt-1">
+          <div className="flex h-11 shrink-0 items-center border-b border-[#e8e9ec] px-3">
             <Input
               allowClear
               size="small"
@@ -270,7 +270,7 @@ const DevelopmentTreePane = ({
             />
           </div>
 
-          <div className="min-h-0 flex-1 overflow-y-auto px-[14px]">
+          <div className="min-h-0 flex-1 overflow-y-auto px-3 py-2">
             <Spin spinning={treeLoading} wrapperClassName="block min-h-full">
               {treeData.length ? (
                 <Tree

--- a/yak-ops-ui/src/pages/data-development/index.tsx
+++ b/yak-ops-ui/src/pages/data-development/index.tsx
@@ -372,14 +372,8 @@ export default function DataDevelopmentPage() {
 
   return (
     <ConfigProvider theme={BRAND_THEME}>
-      <div className="flex h-[calc(100vh-64px)] min-h-[640px] flex-col overflow-hidden bg-white">
-        <header className="shrink-0 border-b border-[#e8e9ec] px-5 py-3">
-          <h1 className="m-0 text-[22px] font-semibold leading-8 text-[#161823]">
-            数据开发
-          </h1>
-        </header>
-
-        <div className="flex min-h-0 flex-1 overflow-hidden">
+      <div className="flex h-[calc(100vh-64px)] min-h-[640px] flex-col overflow-hidden bg-[#f5f5f6] p-3 pt-2">
+        <div className="flex min-h-0 flex-1 overflow-hidden rounded-[4px] border border-[#e4e7ec] bg-white shadow-[0_1px_2px_rgba(16,24,40,0.03)]">
           <DevelopmentTreePane
             treeData={treeData}
             treeLoading={treeLoading}


### PR DESCRIPTION
## 变更说明

- 移除「数据开发」页面内部重复的大标题 Header，避免与全局「开发任务」页面标题形成双层标题
- 保留轻量外部留白，并使用浅边框、极小圆角和轻阴影包裹整个数据开发工作区，强化 IDE / Workbench 的整体感
- 页面外层背景调整为浅灰，工作区保持白色，形成清晰但不过重的层级
- 将左侧「开发目录」标题行调整为与右侧编辑 Tab 同高的 36px，并统一灰色标题栏背景
- 将左侧搜索区调整为 44px 高并增加底部分隔线，与右侧编辑器工具栏高度和分隔关系保持一致
- 目录树内容区取消原来的顶部大留白，改为紧凑的工作台布局

## 页面结构

```text
全局 Header：开发任务

  ┌─────────────────────────────────────────────┐
  │ 开发目录       │ Tab1  Tab2  Tab3      ··· │
  ├────────────────┼────────────────────────────│
  │ 搜索名称/节点  │ 运行 停止 保存 刷新 发布   │
  ├────────────────┼────────────────────────────│
  │                │                            │
  │   开发目录树    │        编辑器工作区         │
  │                │                     属性   │
  └─────────────────────────────────────────────┘
```

## 设计原则

- 不再依赖额外页面标题制造层级，而由 Workbench 外框和内部横纵分隔关系提供包裹感
- 外框仅使用 `#e4e7ec` 浅边框、4px 小圆角和极轻阴影，不做后台 Card 化
- 保持 Yak Ops 当前高密度、白底、轻边界的视觉方向
- 样式继续使用 TailwindCSS，不新增独立样式文件

## 影响范围

- `yak-ops-ui/src/pages/data-development/index.tsx`
- `yak-ops-ui/src/pages/data-development/components/DevelopmentTreePane.tsx`

不修改数据开发接口、目录树行为、编辑 Tab 行为以及节点新建/重命名/删除逻辑。

## 建议回归

- 检查去掉「数据开发」Header 后页面纵向空间是否更充足
- 检查左侧「开发目录」与右侧 Tab 顶部是否处于同一水平线
- 检查左侧搜索行与右侧工具栏分隔线是否对齐
- 检查目录面板展开/收起和拖动宽度是否正常
- 检查工作区外框在常用窗口尺寸下是否保持完整