### PR TITLE
refactor(data-development): refine workbench splitter details

### DIFF
--- a/yak-ops-ui/src/pages/data-development/components/DevelopmentTreePane.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/DevelopmentTreePane.tsx
@@ -306,14 +306,14 @@ const DevelopmentTreePane = ({
         aria-orientation="vertical"
         onPointerDown={collapsed ? undefined : onResizeStart}
         className={[
-          'group relative z-20 w-3 shrink-0 touch-none',
+          'group relative z-20 w-[14px] shrink-0 touch-none bg-white',
           collapsed ? 'cursor-default' : 'cursor-col-resize',
         ].join(' ')}
       >
         <div
           className={[
-            'pointer-events-none absolute inset-y-0 left-1/2',
-            'w-px -translate-x-1/2 bg-[#dfe3e8]',
+            'pointer-events-none absolute inset-y-0 left-0',
+            'w-px bg-[#dfe3e8]',
             'transition-[width,background-color] duration-150',
             !collapsed
               ? 'group-hover:w-[2px] group-hover:bg-[rgba(254,44,85,.55)] group-active:bg-[rgba(254,44,85,1)]'
@@ -327,18 +327,19 @@ const DevelopmentTreePane = ({
           onPointerDown={(event) => event.stopPropagation()}
           onClick={() => onCollapsedChange(!collapsed)}
           className={[
-            'absolute left-1/2 top-1/2 z-20',
-            'flex h-8 w-4 -translate-x-1/2 -translate-y-1/2',
-            'items-center justify-center rounded-[3px]',
-            'border border-[#dfe3e8] bg-white text-[#7b808a]',
-            'shadow-[0_1px_2px_rgba(16,24,40,0.05)]',
-            'transition-[color,border-color,box-shadow] duration-150',
+            'absolute left-px top-1/2 z-20',
+            'flex h-7 w-3 -translate-y-1/2',
+            'items-center justify-center rounded-r-[3px]',
+            'border border-l-0 border-[#dfe3e8] bg-white text-[#7b808a]',
+            'shadow-[0_1px_2px_rgba(16,24,40,0.04)]',
+            'opacity-0 transition-[opacity,color,border-color,box-shadow] duration-150',
+            'group-hover:opacity-100 focus:opacity-100',
             'hover:border-[#cfd4dc] hover:text-[#344054]',
             'focus:outline-none focus-visible:ring-2',
             'focus-visible:ring-[rgba(254,44,85,.16)]',
           ].join(' ')}
         >
-          {collapsed ? <ChevronRight size={12} /> : <ChevronLeft size={12} />}
+          {collapsed ? <ChevronRight size={11} /> : <ChevronLeft size={11} />}
         </button>
       </div>
 

--- a/yak-ops-ui/src/pages/data-development/index.tsx
+++ b/yak-ops-ui/src/pages/data-development/index.tsx
@@ -373,7 +373,7 @@ export default function DataDevelopmentPage() {
   return (
     <ConfigProvider theme={BRAND_THEME}>
       <div className="flex h-[calc(100vh-64px)] min-h-[640px] flex-col overflow-hidden bg-[#f5f5f6]">
-        <div className="flex min-h-0 flex-1 overflow-hidden border border-[#e4e7ec] bg-white shadow-[0_1px_2px_rgba(16,24,40,0.03)]">
+        <div className="flex min-h-0 flex-1 overflow-hidden border-x border-b border-[#e4e7ec] bg-white">
           <DevelopmentTreePane
             treeData={treeData}
             treeLoading={treeLoading}


### PR DESCRIPTION
## 变更说明

结合当前 Yak Ops 数据开发页面与 DataWorks Data Studio 的分栏细节，继续做一轮轻量视觉收敛：

- 将开发目录与编辑器之间的 splitter 从「分隔线居中」调整为「分隔线贴左侧目录边界」，让目录面板边界更明确，右侧保留轻量空白通道，结构更接近 DataWorks
- splitter 宽度调整为 14px，保留足够的拖拽命中范围，同时避免视觉上出现一整条“粗空白柱”
- 收起/展开按钮改为 Hover / Focus 时出现，默认不常驻，降低编辑区中间的视觉噪音
- 收起按钮缩小并改为贴边的半嵌入样式，不再像独立悬浮按钮一样突出
- splitter Hover / Active 时仍保留品牌色反馈，拖动能力不变
- Workbench 外层去掉顶部边框和轻阴影，仅保留左右/底部边界，避免与全局 Header 的底部分隔线形成双线和明显卡片感

## 设计对比

DataWorks 的左侧目录与编辑器之间并不是把分隔线放在空白通道正中，而是：

```text
目录面板 | 细分隔线 | 轻量空白通道 | 编辑器
```

本次 Yak Ops 调整为同样的视觉逻辑，同时保留现有目录面板可拖拽和可收起能力。

## 影响范围

- `yak-ops-ui/src/pages/data-development/index.tsx`
- `yak-ops-ui/src/pages/data-development/components/DevelopmentTreePane.tsx`

不修改数据开发接口、目录树数据逻辑、编辑 Tab、节点新建/重命名/删除等业务行为。

## 建议回归

- 检查目录区域与编辑 Tab 顶部的分隔是否自然连续
- Hover splitter，确认收起按钮出现且不会长期占据视觉空间
- 拖动 splitter，确认目录宽度调整正常
- 收起/展开目录，确认行为正常
- 检查全局 Header 下方是否不再出现双层边框/卡片阴影感