### PR TITLE
feat(data-development): make right panel resizable

### DIFF
--- a/yak-ops-ui/src/pages/data-development/components/DevelopmentEditorWorkspace.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/DevelopmentEditorWorkspace.tsx
@@ -12,6 +12,7 @@ import {
   TerminalSquare,
   X,
 } from 'lucide-react';
+import type { PointerEvent as ReactPointerEvent } from 'react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 
 import type {
@@ -54,6 +55,24 @@ const rightPanelItems: Array<{ key: RightPanelTab; label: string }> = [
   { key: 'versions', label: '版本' },
 ];
 
+const DEFAULT_RIGHT_PANEL_WIDTH = 380;
+const MIN_RIGHT_PANEL_WIDTH = 280;
+const MAX_RIGHT_PANEL_WIDTH = 640;
+const RIGHT_PANEL_WIDTH_STORAGE_KEY = 'yak-data-development.right-panel-width';
+
+const clampRightPanelWidth = (value: number) =>
+  Math.min(MAX_RIGHT_PANEL_WIDTH, Math.max(MIN_RIGHT_PANEL_WIDTH, value));
+
+const initialRightPanelWidth = () => {
+  if (typeof window === 'undefined') return DEFAULT_RIGHT_PANEL_WIDTH;
+  const stored = Number(
+    window.localStorage.getItem(RIGHT_PANEL_WIDTH_STORAGE_KEY),
+  );
+  return Number.isFinite(stored) && stored > 0
+    ? clampRightPanelWidth(stored)
+    : DEFAULT_RIGHT_PANEL_WIDTH;
+};
+
 const actionPlaceholder = (label: string) => {
   message.info(`${label}能力将在后续编辑器阶段接入`);
 };
@@ -77,6 +96,8 @@ const DevelopmentEditorWorkspace = ({
   const [openNodeIds, setOpenNodeIds] = useState<DevelopmentId[]>([]);
   const [activeNodeId, setActiveNodeId] = useState<DevelopmentId>();
   const [rightPanelTab, setRightPanelTab] = useState<RightPanelTab>();
+  const [rightPanelWidth, setRightPanelWidth] = useState(initialRightPanelWidth);
+  const [rightPanelResizing, setRightPanelResizing] = useState(false);
   const tabRefs = useRef(new Map<DevelopmentId, HTMLDivElement>());
 
   const nodeMap = useMemo(
@@ -171,6 +192,46 @@ const DevelopmentEditorWorkspace = ({
 
   const toggleRightPanel = (tab: RightPanelTab) => {
     setRightPanelTab((current) => (current === tab ? undefined : tab));
+  };
+
+  const handleRightPanelResizeStart = (
+    event: ReactPointerEvent<HTMLDivElement>,
+  ) => {
+    if (!rightPanelTab) return;
+    event.preventDefault();
+
+    const startX = event.clientX;
+    const startWidth = rightPanelWidth;
+    const previousCursor = document.body.style.cursor;
+    const previousUserSelect = document.body.style.userSelect;
+
+    setRightPanelResizing(true);
+    document.body.style.cursor = 'col-resize';
+    document.body.style.userSelect = 'none';
+
+    const resize = (moveEvent: PointerEvent) => {
+      setRightPanelWidth(
+        clampRightPanelWidth(startWidth + startX - moveEvent.clientX),
+      );
+    };
+
+    const finish = (upEvent: PointerEvent) => {
+      const width = clampRightPanelWidth(
+        startWidth + startX - upEvent.clientX,
+      );
+      setRightPanelWidth(width);
+      setRightPanelResizing(false);
+      window.localStorage.setItem(RIGHT_PANEL_WIDTH_STORAGE_KEY, String(width));
+      document.body.style.cursor = previousCursor;
+      document.body.style.userSelect = previousUserSelect;
+      window.removeEventListener('pointermove', resize);
+      window.removeEventListener('pointerup', finish);
+      window.removeEventListener('pointercancel', finish);
+    };
+
+    window.addEventListener('pointermove', resize);
+    window.addEventListener('pointerup', finish);
+    window.addEventListener('pointercancel', finish);
   };
 
   const editorMenuItems = useMemo(
@@ -497,45 +558,70 @@ const DevelopmentEditorWorkspace = ({
         <aside className="flex shrink-0 bg-white">
           <div
             className={[
-              'shrink-0 overflow-hidden transition-[width] duration-200 ease-out',
-              rightPanelTab
-                ? 'w-[380px] border-l border-[#e5e7eb]'
-                : 'w-0 border-l-0',
+              'relative h-full shrink-0',
+              rightPanelResizing
+                ? 'transition-none'
+                : 'transition-[width] duration-200 ease-out',
             ].join(' ')}
+            style={{ width: rightPanelTab ? rightPanelWidth : 0 }}
           >
-            <div className="flex h-full w-[380px] flex-col bg-white">
-              <div className="flex h-11 shrink-0 items-center justify-between border-b border-[#e5e7eb] px-4">
-                <span className="text-[13px] font-semibold text-[#30323b]">
-                  {activeRightPanel?.label}
-                </span>
-
-                <div className="flex items-center gap-1">
-                  <button
-                    type="button"
-                    title="刷新"
-                    aria-label={`刷新${activeRightPanel?.label || '侧边栏'}`}
-                    onClick={() =>
-                      actionPlaceholder(`${activeRightPanel?.label || ''}刷新`)
-                    }
-                    className="flex h-7 items-center gap-1 rounded-[3px] px-2 text-[11px] text-[#475467] transition-colors hover:bg-[#f5f5f6]"
-                  >
-                    <RefreshCw size={13} strokeWidth={1.8} />
-                    刷新
-                  </button>
-                  <button
-                    type="button"
-                    title="关闭"
-                    aria-label="关闭右侧面板"
-                    onClick={() => setRightPanelTab(undefined)}
-                    className="flex h-7 w-7 items-center justify-center rounded-[3px] text-[#667085] transition-colors hover:bg-[#f5f5f6] hover:text-[#344054]"
-                  >
-                    <X size={14} strokeWidth={1.8} />
-                  </button>
-                </div>
+            {rightPanelTab ? (
+              <div
+                role="separator"
+                aria-label="调整右侧面板宽度"
+                aria-orientation="vertical"
+                onPointerDown={handleRightPanelResizeStart}
+                className="group absolute inset-y-0 left-0 z-30 w-3 -translate-x-1/2 cursor-col-resize touch-none"
+              >
+                <div
+                  className={[
+                    'pointer-events-none absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-[#e5e7eb]',
+                    'transition-[width,background-color] duration-150',
+                    'group-hover:w-[2px] group-hover:bg-[rgba(254,44,85,.55)]',
+                    'group-active:w-[2px] group-active:bg-[rgba(254,44,85,1)]',
+                  ].join(' ')}
+                />
               </div>
+            ) : null}
 
-              <div className="min-h-0 flex-1 overflow-y-auto px-4 py-5">
-                {renderRightPanelContent()}
+            <div className="h-full overflow-hidden">
+              <div
+                className="flex h-full flex-col bg-white"
+                style={{ width: rightPanelWidth }}
+              >
+                <div className="flex h-11 shrink-0 items-center justify-between border-b border-[#e5e7eb] px-4">
+                  <span className="text-[13px] font-semibold text-[#30323b]">
+                    {activeRightPanel?.label}
+                  </span>
+
+                  <div className="flex items-center gap-1">
+                    <button
+                      type="button"
+                      title="刷新"
+                      aria-label={`刷新${activeRightPanel?.label || '侧边栏'}`}
+                      onClick={() =>
+                        actionPlaceholder(`${activeRightPanel?.label || ''}刷新`)
+                      }
+                      className="flex h-7 items-center gap-1 rounded-[3px] px-2 text-[11px] text-[#475467] transition-colors hover:bg-[#f5f5f6]"
+                    >
+                      <RefreshCw size={13} strokeWidth={1.8} />
+                      刷新
+                    </button>
+                    <button
+                      type="button"
+                      title="关闭"
+                      aria-label="关闭右侧面板"
+                      onClick={() => setRightPanelTab(undefined)}
+                      className="flex h-7 w-7 items-center justify-center rounded-[3px] text-[#667085] transition-colors hover:bg-[#f5f5f6] hover:text-[#344054]"
+                    >
+                      <X size={14} strokeWidth={1.8} />
+                    </button>
+                  </div>
+                </div>
+
+                <div className="min-h-0 flex-1 overflow-y-auto px-4 py-5">
+                  {renderRightPanelContent()}
+                </div>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## 变更说明

在现有 DataWorks 风格右侧面板基础上，补齐右侧展开面板的拖拽调整宽度能力：

- 右侧面板展开后，左侧分隔竖线可直接拖拽调整宽度
- 拖拽命中区域扩大到 12px，但视觉仍保持 1px 细分隔线
- Hover / 拖拽时分隔线使用 Yak Ops 品牌色反馈，方便识别可拖拽区域
- 拖拽过程中关闭宽度过渡动画，避免跟手感发黏
- 面板宽度限制在 280px ~ 640px，避免过窄或过宽
- 松开鼠标后会将宽度保存到 localStorage，下次打开继续沿用上次宽度
- 收起右侧面板后仅保留原有垂直功能栏，展开/收起交互不变

## 交互

```text
编辑器区域        │ 属性面板              │ 属性 │
                  ↑
              这里可左右拖拽
```

向左拖：右侧面板变宽；向右拖：右侧面板变窄。

## 技术说明

- 样式继续使用 TailwindCSS
- 使用 Pointer Events 处理拖拽，兼容鼠标/触控笔场景
- 不修改后端接口
- 不修改左侧目录、编辑 Tab、工具栏和右侧入口切换逻辑
- 仅修改 `yak-ops-ui/src/pages/data-development/components/DevelopmentEditorWorkspace.tsx`

## 建议回归

- 展开「属性」后从左侧竖线拖拽，确认宽度实时变化
- 分别拖到最窄/最宽，确认限制生效
- 松开后收起再展开，确认宽度保持
- 刷新页面后再次展开，确认宽度仍保持
- 确认拖拽过程中页面文字不会被误选中
- 确认竖线 Hover / Active 状态反馈正常