### PR TITLE
fix(data-development): remove tree/editor splitter gap

### DIFF
--- a/yak-ops-ui/src/pages/data-development/components/DevelopmentTreePane.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/DevelopmentTreePane.tsx
@@ -306,10 +306,17 @@ const DevelopmentTreePane = ({
         aria-orientation="vertical"
         onPointerDown={collapsed ? undefined : onResizeStart}
         className={[
-          'group relative z-20 w-[14px] shrink-0 touch-none bg-white',
+          'group relative z-20 w-px shrink-0 touch-none',
           collapsed ? 'cursor-default' : 'cursor-col-resize',
         ].join(' ')}
       >
+        <div
+          className={[
+            'absolute inset-y-0 left-1/2 z-10 w-3 -translate-x-1/2',
+            collapsed ? 'cursor-default' : 'cursor-col-resize',
+          ].join(' ')}
+        />
+
         <div
           className={[
             'pointer-events-none absolute inset-y-0 left-0',


### PR DESCRIPTION
## 变更说明

针对数据开发页面左侧开发目录与右侧编辑器之间的空白分隔区域做收敛：

- 将原来占据 14px 布局宽度的 splitter 改为仅占 1px 的实际分隔线
- 左侧目录和右侧编辑器现在会直接贴合，不再出现中间一条明显白色空隙
- 保留原来的拖拽能力，额外使用 12px 的透明命中区域保证拖拽仍然好用
- Hover / 拖拽时仍保留品牌色反馈
- 收起 / 展开目录的按钮逻辑保持不变

## 视觉效果

调整前：

```text
开发目录 |      空白 splitter      | 编辑器
```

调整后：

```text
开发目录 | 编辑器
          ↑
      1px 分隔线
      仍可拖拽
```

## 影响范围

仅修改：

- `yak-ops-ui/src/pages/data-development/components/DevelopmentTreePane.tsx`

不修改后端接口、目录树数据逻辑、编辑器、运行结果抽屉和右侧属性栏。