### PR TITLE
style(data-development): unify node type icon colors

### DIFF
--- a/yak-ops-ui/src/pages/data-development/components/DevelopmentTreePane.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/DevelopmentTreePane.tsx
@@ -60,6 +60,12 @@ interface DevelopmentTreePaneProps {
   onCollapsedChange: (collapsed: boolean) => void;
 }
 
+const nodeTypeIconClassName = (taskType?: string) => {
+  if (taskType === 'SHELL') return 'text-[#6172f3]';
+  if (taskType === 'SQL') return 'text-[#f79009]';
+  return 'text-[#667085]';
+};
+
 const DevelopmentTreePane = ({
   treeData,
   treeLoading,
@@ -84,12 +90,24 @@ const DevelopmentTreePane = ({
         {
           key: 'node-sql',
           label: 'SQL 节点',
-          icon: <Code2 size={14} strokeWidth={1.8} />,
+          icon: (
+            <Code2
+              size={14}
+              strokeWidth={1.8}
+              className="text-[#f79009]"
+            />
+          ),
         },
         {
           key: 'node-shell',
           label: 'Shell 节点',
-          icon: <TerminalSquare size={14} strokeWidth={1.8} />,
+          icon: (
+            <TerminalSquare
+              size={14}
+              strokeWidth={1.8}
+              className="text-[#6172f3]"
+            />
+          ),
         },
       ],
     },
@@ -136,12 +154,24 @@ const DevelopmentTreePane = ({
           {
             key: 'create-sql',
             label: 'SQL 节点',
-            icon: <Code2 size={14} strokeWidth={1.8} />,
+            icon: (
+              <Code2
+                size={14}
+                strokeWidth={1.8}
+                className="text-[#f79009]"
+              />
+            ),
           },
           {
             key: 'create-shell',
             label: 'Shell 节点',
-            icon: <TerminalSquare size={14} strokeWidth={1.8} />,
+            icon: (
+              <TerminalSquare
+                size={14}
+                strokeWidth={1.8}
+                className="text-[#6172f3]"
+              />
+            ),
           },
         ],
       },
@@ -177,13 +207,13 @@ const DevelopmentTreePane = ({
               <TerminalSquare
                 size={13}
                 strokeWidth={1.8}
-                className="shrink-0 text-[#667085]"
+                className={`shrink-0 ${nodeTypeIconClassName(node.taskType)}`}
               />
             ) : (
               <Code2
                 size={13}
                 strokeWidth={1.8}
-                className="shrink-0 text-[#667085]"
+                className={`shrink-0 ${nodeTypeIconClassName(node.taskType)}`}
               />
             )
           ) : (


### PR DESCRIPTION
## 变更说明

统一数据开发页面中节点类型图标的视觉颜色，解决左侧开发目录与顶部编辑 Tab 同一节点类型颜色不一致的问题。

- SQL 节点图标统一使用 `#f79009`
- Shell 节点图标统一使用 `#6172f3`
- 左侧开发目录节点图标与顶部编辑 Tab 保持一致
- 新建节点菜单 / 目录右键新建节点菜单同步使用同一套类型颜色
- 文件夹、节点名称、类型文字等仍保持现有灰色层级，不额外增加彩色背景
- 选中状态仍由背景和 Tab 底部品牌色指示，不改变节点类型本身的颜色

## 影响范围

仅修改 `yak-ops-ui/src/pages/data-development/components/DevelopmentTreePane.tsx`，不修改节点数据逻辑、Tab 交互、编辑器、运行结果面板和后端接口。