### PR TITLE
feat(data-development): add stage-one SQL Monaco editor

### DIFF
--- a/yak-ops-ui/package.json
+++ b/yak-ops-ui/package.json
@@ -63,6 +63,7 @@
     "gsap": "^3.14.2",
     "legendary-cursor": "^1.0.2",
     "lucide-react": "^0.577.0",
+    "monaco-editor": "^0.52.0",
     "ogl": "^1.0.11",
     "postcss": "^8.5.8",
     "react": "^18.3.0",

--- a/yak-ops-ui/src/pages/data-development/components/workbench/EditorHost.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/workbench/EditorHost.tsx
@@ -12,7 +12,7 @@ const EditorHost = ({ node, directory, definition }: EditorHostProps) => {
 
   return (
     <section className="min-w-0 flex-1 overflow-hidden bg-white">
-      <Editor node={node} directory={directory} />
+      <Editor key={String(node.id)} node={node} directory={directory} />
     </section>
   );
 };

--- a/yak-ops-ui/src/pages/data-development/editors/sql/SqlEditor.tsx
+++ b/yak-ops-ui/src/pages/data-development/editors/sql/SqlEditor.tsx
@@ -1,25 +1,59 @@
-import { Code2 } from 'lucide-react';
+import { useMemo, useState } from 'react';
 
 import type { DevelopmentEditorContext } from '../types';
+import SqlMonacoEditor, {
+  type SqlEditorPosition,
+} from './components/SqlMonacoEditor';
 
-export const SqlEditor = ({ node }: DevelopmentEditorContext) => (
-  <div className="flex h-full min-h-0 items-center justify-center overflow-auto bg-white">
-    <div className="text-center">
-      <div className="inline-flex h-10 w-10 items-center justify-center rounded-lg bg-[#f5f5f6] text-[#f79009]">
-        <Code2 size={18} strokeWidth={1.8} />
+const inMemorySqlDrafts = new Map<string, string>();
+
+const defaultPosition: SqlEditorPosition = {
+  lineNumber: 1,
+  column: 1,
+  selectionLength: 0,
+};
+
+export const SqlEditor = ({ node }: DevelopmentEditorContext) => {
+  const initialValue = useMemo(
+    () => inMemorySqlDrafts.get(String(node.id)) || '',
+    [node.id],
+  );
+  const [value, setValue] = useState(initialValue);
+  const [position, setPosition] = useState(defaultPosition);
+
+  const handleChange = (nextValue: string) => {
+    setValue(nextValue);
+    inMemorySqlDrafts.set(String(node.id), nextValue);
+  };
+
+  return (
+    <div className="flex h-full min-h-0 flex-col overflow-hidden bg-white">
+      <div className="min-h-0 flex-1">
+        <SqlMonacoEditor
+          id={String(node.id)}
+          value={value}
+          onChange={handleChange}
+          onPositionChange={setPosition}
+        />
       </div>
-      <div className="mt-3 text-[15px] font-semibold text-[#344054]">
-        SQL 编辑器区域
-      </div>
-      <div className="mt-1 text-[12px] text-[#98a2b3]">
-        当前节点：{node.name}
-      </div>
-      <div className="mt-3 text-[12px] text-[#b0b7c3]">
-        SQL 编辑器内容将在下一阶段接入
+
+      <div className="flex h-6 shrink-0 items-center justify-between border-t border-[#eef0f2] bg-[#fafafa] px-2.5 text-[10px] text-[#7b808a]">
+        <div className="flex min-w-0 items-center gap-3">
+          <span className="font-medium text-[#667085]">SQL</span>
+          <span className="truncate">{node.name}</span>
+        </div>
+        <div className="flex shrink-0 items-center gap-3">
+          {position.selectionLength > 0 ? (
+            <span>已选择 {position.selectionLength} 字符</span>
+          ) : null}
+          <span>
+            Ln {position.lineNumber}, Col {position.column}
+          </span>
+        </div>
       </div>
     </div>
-  </div>
-);
+  );
+};
 
 export const SqlRunConfig = ({ node }: DevelopmentEditorContext) => (
   <div className="text-[12px] leading-6 text-[#667085]">

--- a/yak-ops-ui/src/pages/data-development/editors/sql/components/SqlMonacoEditor.tsx
+++ b/yak-ops-ui/src/pages/data-development/editors/sql/components/SqlMonacoEditor.tsx
@@ -1,0 +1,164 @@
+import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
+import 'monaco-editor/esm/vs/basic-languages/sql/sql.contribution';
+import { useEffect, useRef } from 'react';
+
+import { setupMonacoEnvironment } from '../monaco/setupMonacoEnvironment';
+
+export interface SqlEditorPosition {
+  lineNumber: number;
+  column: number;
+  selectionLength: number;
+}
+
+interface SqlMonacoEditorProps {
+  id: string;
+  value: string;
+  onChange: (value: string) => void;
+  onPositionChange?: (position: SqlEditorPosition) => void;
+}
+
+let themeRegistered = false;
+
+const ensureYakSqlTheme = () => {
+  if (themeRegistered) return;
+  themeRegistered = true;
+
+  monaco.editor.defineTheme('yak-sql-light', {
+    base: 'vs',
+    inherit: true,
+    rules: [
+      { token: 'keyword.sql', foreground: '245BDB', fontStyle: 'bold' },
+      { token: 'string.sql', foreground: '027A48' },
+      { token: 'number.sql', foreground: 'B54708' },
+      { token: 'comment.sql', foreground: '98A2B3', fontStyle: 'italic' },
+    ],
+    colors: {
+      'editor.background': '#ffffff',
+      'editor.foreground': '#344054',
+      'editorLineNumber.foreground': '#b0b7c3',
+      'editorLineNumber.activeForeground': '#667085',
+      'editorCursor.foreground': '#344054',
+      'editor.selectionBackground': '#dbeafe',
+      'editor.inactiveSelectionBackground': '#eef4ff',
+      'editor.lineHighlightBackground': '#fafafa',
+      'editorIndentGuide.background1': '#f0f1f3',
+      'editorIndentGuide.activeBackground1': '#d0d5dd',
+    },
+  });
+};
+
+const SqlMonacoEditor = ({
+  id,
+  value,
+  onChange,
+  onPositionChange,
+}: SqlMonacoEditorProps) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const editorRef = useRef<monaco.editor.IStandaloneCodeEditor>();
+  const modelRef = useRef<monaco.editor.ITextModel>();
+  const onChangeRef = useRef(onChange);
+  const onPositionChangeRef = useRef(onPositionChange);
+
+  useEffect(() => {
+    onChangeRef.current = onChange;
+  }, [onChange]);
+
+  useEffect(() => {
+    onPositionChangeRef.current = onPositionChange;
+  }, [onPositionChange]);
+
+  useEffect(() => {
+    if (!containerRef.current) return undefined;
+
+    setupMonacoEnvironment();
+    ensureYakSqlTheme();
+
+    const uri = monaco.Uri.parse(
+      `inmemory://yak-ops/data-development/sql/${encodeURIComponent(id)}.sql`,
+    );
+    monaco.editor.getModel(uri)?.dispose();
+
+    const model = monaco.editor.createModel(value, 'sql', uri);
+    const editor = monaco.editor.create(containerRef.current, {
+      model,
+      theme: 'yak-sql-light',
+      automaticLayout: true,
+      minimap: { enabled: false },
+      fontSize: 13,
+      lineHeight: 22,
+      fontFamily:
+        "'JetBrains Mono', 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace",
+      tabSize: 2,
+      insertSpaces: true,
+      scrollBeyondLastLine: false,
+      smoothScrolling: true,
+      cursorSmoothCaretAnimation: 'on',
+      cursorBlinking: 'smooth',
+      renderLineHighlight: 'line',
+      renderWhitespace: 'selection',
+      wordWrap: 'off',
+      folding: true,
+      glyphMargin: false,
+      lineNumbersMinChars: 3,
+      overviewRulerLanes: 0,
+      hideCursorInOverviewRuler: true,
+      fixedOverflowWidgets: true,
+      padding: { top: 12, bottom: 12 },
+      suggest: { showWords: false },
+      wordBasedSuggestions: 'off',
+      bracketPairColorization: { enabled: true },
+      guides: { bracketPairs: true, indentation: true },
+    });
+
+    editorRef.current = editor;
+    modelRef.current = model;
+
+    const emitPosition = () => {
+      const position = editor.getPosition();
+      const selection = editor.getSelection();
+      if (!position) return;
+
+      const selectionLength = selection
+        ? model.getValueInRange(selection).length
+        : 0;
+      onPositionChangeRef.current?.({
+        lineNumber: position.lineNumber,
+        column: position.column,
+        selectionLength,
+      });
+    };
+
+    const contentDisposable = model.onDidChangeContent(() => {
+      onChangeRef.current(model.getValue());
+    });
+    const cursorDisposable = editor.onDidChangeCursorPosition(emitPosition);
+    const selectionDisposable = editor.onDidChangeCursorSelection(emitPosition);
+
+    emitPosition();
+
+    return () => {
+      contentDisposable.dispose();
+      cursorDisposable.dispose();
+      selectionDisposable.dispose();
+      editor.dispose();
+      model.dispose();
+      editorRef.current = undefined;
+      modelRef.current = undefined;
+    };
+  }, [id]);
+
+  useEffect(() => {
+    const model = modelRef.current;
+    if (!model || model.getValue() === value) return;
+
+    model.pushEditOperations(
+      [],
+      [{ range: model.getFullModelRange(), text: value }],
+      () => null,
+    );
+  }, [value]);
+
+  return <div ref={containerRef} className="h-full min-h-0 w-full" />;
+};
+
+export default SqlMonacoEditor;

--- a/yak-ops-ui/src/pages/data-development/editors/sql/monaco/setupMonacoEnvironment.ts
+++ b/yak-ops-ui/src/pages/data-development/editors/sql/monaco/setupMonacoEnvironment.ts
@@ -1,0 +1,33 @@
+type MonacoEnvironment = {
+  getWorker?: (_moduleId: string, label: string) => Worker;
+};
+
+type MonacoGlobal = typeof globalThis & {
+  MonacoEnvironment?: MonacoEnvironment;
+};
+
+let initialized = false;
+
+/**
+ * Configure the worker used by Monaco's editor core.
+ *
+ * SQL currently only needs the generic editor worker. Language-specific workers
+ * can be routed here later when JSON / TypeScript editors are introduced.
+ */
+export const setupMonacoEnvironment = () => {
+  if (initialized || typeof window === 'undefined') return;
+  initialized = true;
+
+  const monacoGlobal = globalThis as MonacoGlobal;
+  monacoGlobal.MonacoEnvironment = {
+    ...monacoGlobal.MonacoEnvironment,
+    getWorker: () =>
+      new Worker(
+        new URL(
+          'monaco-editor/esm/vs/editor/editor.worker.js',
+          import.meta.url,
+        ),
+        { type: 'module' },
+      ),
+  };
+};


### PR DESCRIPTION
## 变更说明

完成数据开发 SQL 编辑器第一个阶段：先把真正可编辑的 Monaco SQL 编辑器接入现有 `SqlEditor`，不引入 SQL Parser、智能补全、执行接口等后续能力。

### 本阶段实现

- 新增 `SqlMonacoEditor`，直接使用 `monaco-editor` ESM API
- 注册 SQL language contribution，SQL 节点进入后显示真实 Monaco 编辑器
- 使用独立 Monaco Model URI：`inmemory://yak-ops/data-development/sql/<nodeId>.sql`
- 支持基础 SQL 语法高亮、光标、Selection、撤销/重做等 Monaco 原生编辑能力
- 开启 `automaticLayout`，适配现有 Workbench、右侧面板和底部运行结果区的尺寸变化
- 增加 Yak Ops 浅色 Monaco Theme，继续保持白底、高密度 IDE 风格
- 底部增加轻量状态栏，显示 SQL、节点名称、Ln / Col 和选中字符数
- Monaco Editor / Model / event listeners 在节点切换和组件卸载时统一 dispose
- `EditorHost` 按 nodeId 隔离编辑器实例，避免 SQL 节点之间复用错误的本地组件状态
- 增加当前页面生命周期内的 SQL 草稿缓存；切换 Tab 后回到同一 SQL 节点，当前输入不会立即丢失。刷新页面后的正式草稿恢复留到下一阶段 `EditorSession`

### Monaco Worker

新增独立 `setupMonacoEnvironment`，当前只路由 Monaco 通用 editor worker。后续接 JSON / TypeScript / Python 等编辑器时再按 language 扩展 worker，不把这些逻辑塞进 `SqlEditor`。

### 与 Chat2DB 的关系

本 PR 只借鉴 Chat2DB 已验证的产品方向和模块职责：Monaco 基础层与 SQL 业务层分离、Model 按资源隔离、显式管理 Monaco 生命周期。实现代码按 Yak Ops 当前 Workbench 架构重新编写，没有直接复制 Chat2DB 当前受限许可证版本的 SQL Editor 代码。

### 明确不做

本阶段不实现：

- SQL 自动补全
- 数据源 / schema / table / column 元数据提示
- SQL Parser / Marker / Hover
- SQL 格式化
- SQL 执行与结果集
- 跨刷新持久化 EditorSession

这些能力后续按独立 PR 逐步蒸馏和接入。

### 影响范围

- `yak-ops-ui/package.json`：新增 `monaco-editor`
- `editors/sql/components/SqlMonacoEditor.tsx`
- `editors/sql/monaco/setupMonacoEnvironment.ts`
- `editors/sql/SqlEditor.tsx`
- `components/workbench/EditorHost.tsx`

不修改后端接口，不影响 Shell 编辑器和数据开发目录树逻辑。

### 建议回归

- 打开 SQL 节点确认 Monaco 正常渲染并可输入 SQL
- 验证关键字 / 字符串 / 注释等基础高亮
- 验证光标位置、Selection 字符数状态栏
- 打开右侧属性面板并拖拽，确认 Monaco 自动重新布局
- 打开底部运行结果并上下拖拽，确认 Monaco 自动重新布局
- SQL 节点之间切换后返回，确认当前页面生命周期内草稿仍存在
- SQL / Shell Tab 交替切换，确认 Shell 原有占位编辑器不受影响
