### PR TITLE
feat(data-development): add persistent editor sessions

### DIFF
--- a/yak-ops-ui/src/pages/data-development/components/workbench/EditorTabs.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/workbench/EditorTabs.tsx
@@ -3,6 +3,10 @@ import { Check, MoreHorizontal, X } from 'lucide-react';
 import { useEffect, useMemo, useRef } from 'react';
 
 import { getEditorDefinition } from '../../editors/registry';
+import {
+  getEditorSession,
+  useEditorSessionVersion,
+} from '../../editors/session/editorSessionStore';
 import type { DevelopmentId, DevelopmentNode } from '../../types';
 
 export type EditorTabAction =
@@ -30,6 +34,7 @@ const EditorTabs = ({
   onAction,
 }: EditorTabsProps) => {
   const tabRefs = useRef(new Map<DevelopmentId, HTMLDivElement>());
+  useEditorSessionVersion();
 
   useEffect(() => {
     if (!activeNodeId) return;
@@ -52,6 +57,7 @@ const EditorTabs = ({
           const node = nodeMap.get(nodeId);
           const active = nodeId === activeNodeId;
           const definition = node ? getEditorDefinition(node.type) : undefined;
+          const session = getEditorSession(nodeId);
           const Icon = definition?.icon;
 
           return {
@@ -63,8 +69,16 @@ const EditorTabs = ({
             ) : undefined,
             label: (
               <div className="flex min-w-[190px] items-center justify-between gap-3">
-                <span className="max-w-[220px] truncate">
-                  {node?.name || nodeId}
+                <span className="flex min-w-0 items-center gap-2">
+                  <span className="max-w-[200px] truncate">
+                    {node?.name || nodeId}
+                  </span>
+                  {session?.dirty ? (
+                    <span
+                      className="h-1.5 w-1.5 shrink-0 rounded-full bg-[#667085]"
+                      title="未保存"
+                    />
+                  ) : null}
                 </span>
                 {active ? (
                   <Check size={13} className="shrink-0 text-[#667085]" />
@@ -107,6 +121,7 @@ const EditorTabs = ({
             if (!node) return null;
             const active = nodeId === activeNodeId;
             const definition = getEditorDefinition(node.type);
+            const session = getEditorSession(nodeId);
             const Icon = definition.icon;
 
             return (
@@ -149,6 +164,12 @@ const EditorTabs = ({
                   >
                     {node.name}
                   </span>
+                  {session?.dirty ? (
+                    <span
+                      className="h-1.5 w-1.5 shrink-0 rounded-full bg-[#667085]"
+                      title="未保存"
+                    />
+                  ) : null}
                 </button>
 
                 <button

--- a/yak-ops-ui/src/pages/data-development/components/workbench/EditorTabs.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/workbench/EditorTabs.tsx
@@ -34,7 +34,7 @@ const EditorTabs = ({
   onAction,
 }: EditorTabsProps) => {
   const tabRefs = useRef(new Map<DevelopmentId, HTMLDivElement>());
-  useEditorSessionVersion();
+  const sessionVersion = useEditorSessionVersion();
 
   useEffect(() => {
     if (!activeNodeId) return;
@@ -109,7 +109,7 @@ const EditorTabs = ({
       },
       { key: 'close-all', label: '全部关闭' },
     ],
-    [activeNodeId, nodeMap, openNodeIds],
+    [activeNodeId, nodeMap, openNodeIds, sessionVersion],
   );
 
   return (

--- a/yak-ops-ui/src/pages/data-development/editors/session/editorSessionStore.ts
+++ b/yak-ops-ui/src/pages/data-development/editors/session/editorSessionStore.ts
@@ -1,0 +1,223 @@
+import { useSyncExternalStore } from 'react';
+
+import type {
+  DevelopmentId,
+  DevelopmentTaskType,
+} from '../../types';
+import type {
+  DevelopmentEditorSession,
+  DevelopmentEditorViewState,
+} from './types';
+
+const STORAGE_KEY = 'yak-data-development.editor-sessions.v1';
+const PERSIST_DELAY = 200;
+
+interface PersistedEditorSessions {
+  version: 1;
+  sessions: DevelopmentEditorSession[];
+}
+
+const sessions = new Map<DevelopmentId, DevelopmentEditorSession>();
+const listeners = new Set<() => void>();
+
+let hydrated = false;
+let version = 0;
+let persistTimer: number | undefined;
+let pageHideBound = false;
+
+const isBrowser = () => typeof window !== 'undefined';
+
+const sameViewState = (
+  left?: DevelopmentEditorViewState,
+  right?: DevelopmentEditorViewState,
+) => {
+  if (left === right) return true;
+  if (!left || !right) return false;
+
+  const leftSelection = left.selection;
+  const rightSelection = right.selection;
+
+  return (
+    left.lineNumber === right.lineNumber &&
+    left.column === right.column &&
+    left.scrollTop === right.scrollTop &&
+    left.scrollLeft === right.scrollLeft &&
+    leftSelection?.startLineNumber === rightSelection?.startLineNumber &&
+    leftSelection?.startColumn === rightSelection?.startColumn &&
+    leftSelection?.endLineNumber === rightSelection?.endLineNumber &&
+    leftSelection?.endColumn === rightSelection?.endColumn
+  );
+};
+
+const persistNow = () => {
+  if (!isBrowser()) return;
+  if (persistTimer !== undefined) {
+    window.clearTimeout(persistTimer);
+    persistTimer = undefined;
+  }
+
+  const payload: PersistedEditorSessions = {
+    version: 1,
+    sessions: [...sessions.values()],
+  };
+
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+  } catch {
+    // Local storage can be unavailable or full. The in-memory session still works.
+  }
+};
+
+const schedulePersist = () => {
+  if (!isBrowser()) return;
+  if (persistTimer !== undefined) window.clearTimeout(persistTimer);
+  persistTimer = window.setTimeout(persistNow, PERSIST_DELAY);
+};
+
+const bindPageHide = () => {
+  if (!isBrowser() || pageHideBound) return;
+  pageHideBound = true;
+  window.addEventListener('pagehide', persistNow);
+};
+
+const isPersistedSession = (
+  value: unknown,
+): value is DevelopmentEditorSession => {
+  if (!value || typeof value !== 'object') return false;
+  const session = value as Partial<DevelopmentEditorSession>;
+
+  return (
+    typeof session.nodeId === 'string' &&
+    typeof session.nodeType === 'string' &&
+    typeof session.content === 'string' &&
+    typeof session.originalContent === 'string' &&
+    typeof session.dirty === 'boolean' &&
+    typeof session.updatedAt === 'number'
+  );
+};
+
+const ensureHydrated = () => {
+  if (hydrated) return;
+  hydrated = true;
+  bindPageHide();
+
+  if (!isBrowser()) return;
+
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return;
+
+    const parsed = JSON.parse(raw) as Partial<PersistedEditorSessions>;
+    if (parsed.version !== 1 || !Array.isArray(parsed.sessions)) return;
+
+    parsed.sessions.forEach((session) => {
+      if (!isPersistedSession(session)) return;
+      sessions.set(session.nodeId, session);
+    });
+  } catch {
+    // Ignore malformed or unavailable persisted state and start with a clean store.
+  }
+};
+
+const emitChange = () => {
+  version += 1;
+  listeners.forEach((listener) => listener());
+};
+
+const subscribe = (listener: () => void) => {
+  ensureHydrated();
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+};
+
+const getVersion = () => {
+  ensureHydrated();
+  return version;
+};
+
+export const ensureEditorSession = (
+  nodeId: DevelopmentId,
+  nodeType: DevelopmentTaskType,
+  initialContent = '',
+) => {
+  ensureHydrated();
+  const current = sessions.get(nodeId);
+  if (current) return current;
+
+  const session: DevelopmentEditorSession = {
+    nodeId,
+    nodeType,
+    content: initialContent,
+    originalContent: initialContent,
+    dirty: false,
+    updatedAt: Date.now(),
+  };
+  sessions.set(nodeId, session);
+  return session;
+};
+
+export const getEditorSession = (nodeId: DevelopmentId) => {
+  ensureHydrated();
+  return sessions.get(nodeId);
+};
+
+export const updateEditorSessionContent = (
+  nodeId: DevelopmentId,
+  content: string,
+) => {
+  ensureHydrated();
+  const current = sessions.get(nodeId);
+  if (!current || current.content === content) return;
+
+  sessions.set(nodeId, {
+    ...current,
+    content,
+    dirty: content !== current.originalContent,
+    updatedAt: Date.now(),
+  });
+  schedulePersist();
+  emitChange();
+};
+
+export const updateEditorSessionViewState = (
+  nodeId: DevelopmentId,
+  viewState: DevelopmentEditorViewState,
+) => {
+  ensureHydrated();
+  const current = sessions.get(nodeId);
+  if (!current || sameViewState(current.viewState, viewState)) return;
+
+  sessions.set(nodeId, {
+    ...current,
+    viewState,
+    updatedAt: Date.now(),
+  });
+  schedulePersist();
+};
+
+export const markEditorSessionSaved = (nodeId: DevelopmentId) => {
+  ensureHydrated();
+  const current = sessions.get(nodeId);
+  if (!current || !current.dirty) return;
+
+  sessions.set(nodeId, {
+    ...current,
+    originalContent: current.content,
+    dirty: false,
+    updatedAt: Date.now(),
+  });
+  schedulePersist();
+  emitChange();
+};
+
+export const useEditorSession = (
+  nodeId: DevelopmentId,
+  nodeType: DevelopmentTaskType,
+  initialContent = '',
+) => {
+  useSyncExternalStore(subscribe, getVersion, getVersion);
+  return ensureEditorSession(nodeId, nodeType, initialContent);
+};
+
+export const useEditorSessionVersion = () =>
+  useSyncExternalStore(subscribe, getVersion, getVersion);

--- a/yak-ops-ui/src/pages/data-development/editors/session/editorSessionStore.ts
+++ b/yak-ops-ui/src/pages/data-development/editors/session/editorSessionStore.ts
@@ -5,12 +5,19 @@ import type {
   DevelopmentTaskType,
 } from '../../types';
 import type {
+  DevelopmentEditorSelection,
   DevelopmentEditorSession,
   DevelopmentEditorViewState,
 } from './types';
 
 const STORAGE_KEY = 'yak-data-development.editor-sessions.v1';
 const PERSIST_DELAY = 200;
+const TASK_TYPES = new Set<DevelopmentTaskType>([
+  'SQL',
+  'SHELL',
+  'HTTP',
+  'PYTHON',
+]);
 
 interface PersistedEditorSessions {
   version: 1;
@@ -26,6 +33,31 @@ let persistTimer: number | undefined;
 let pageHideBound = false;
 
 const isBrowser = () => typeof window !== 'undefined';
+const isFiniteNumber = (value: unknown): value is number =>
+  typeof value === 'number' && Number.isFinite(value);
+
+const isSelection = (value: unknown): value is DevelopmentEditorSelection => {
+  if (!value || typeof value !== 'object') return false;
+  const selection = value as Partial<DevelopmentEditorSelection>;
+  return (
+    isFiniteNumber(selection.startLineNumber) &&
+    isFiniteNumber(selection.startColumn) &&
+    isFiniteNumber(selection.endLineNumber) &&
+    isFiniteNumber(selection.endColumn)
+  );
+};
+
+const isViewState = (value: unknown): value is DevelopmentEditorViewState => {
+  if (!value || typeof value !== 'object') return false;
+  const viewState = value as Partial<DevelopmentEditorViewState>;
+  return (
+    isFiniteNumber(viewState.lineNumber) &&
+    isFiniteNumber(viewState.column) &&
+    isFiniteNumber(viewState.scrollTop) &&
+    isFiniteNumber(viewState.scrollLeft) &&
+    (viewState.selection === undefined || isSelection(viewState.selection))
+  );
+};
 
 const sameViewState = (
   left?: DevelopmentEditorViewState,
@@ -89,10 +121,12 @@ const isPersistedSession = (
   return (
     typeof session.nodeId === 'string' &&
     typeof session.nodeType === 'string' &&
+    TASK_TYPES.has(session.nodeType as DevelopmentTaskType) &&
     typeof session.content === 'string' &&
     typeof session.originalContent === 'string' &&
     typeof session.dirty === 'boolean' &&
-    typeof session.updatedAt === 'number'
+    isFiniteNumber(session.updatedAt) &&
+    (session.viewState === undefined || isViewState(session.viewState))
   );
 };
 
@@ -112,7 +146,10 @@ const ensureHydrated = () => {
 
     parsed.sessions.forEach((session) => {
       if (!isPersistedSession(session)) return;
-      sessions.set(session.nodeId, session);
+      sessions.set(session.nodeId, {
+        ...session,
+        dirty: session.content !== session.originalContent,
+      });
     });
   } catch {
     // Ignore malformed or unavailable persisted state and start with a clean store.

--- a/yak-ops-ui/src/pages/data-development/editors/session/types.ts
+++ b/yak-ops-ui/src/pages/data-development/editors/session/types.ts
@@ -1,0 +1,29 @@
+import type {
+  DevelopmentId,
+  DevelopmentTaskType,
+} from '../../types';
+
+export interface DevelopmentEditorSelection {
+  startLineNumber: number;
+  startColumn: number;
+  endLineNumber: number;
+  endColumn: number;
+}
+
+export interface DevelopmentEditorViewState {
+  lineNumber: number;
+  column: number;
+  selection?: DevelopmentEditorSelection;
+  scrollTop: number;
+  scrollLeft: number;
+}
+
+export interface DevelopmentEditorSession {
+  nodeId: DevelopmentId;
+  nodeType: DevelopmentTaskType;
+  content: string;
+  originalContent: string;
+  dirty: boolean;
+  viewState?: DevelopmentEditorViewState;
+  updatedAt: number;
+}

--- a/yak-ops-ui/src/pages/data-development/editors/sql/SqlEditor.tsx
+++ b/yak-ops-ui/src/pages/data-development/editors/sql/SqlEditor.tsx
@@ -1,11 +1,14 @@
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 
+import {
+  updateEditorSessionContent,
+  updateEditorSessionViewState,
+  useEditorSession,
+} from '../session/editorSessionStore';
 import type { DevelopmentEditorContext } from '../types';
 import SqlMonacoEditor, {
   type SqlEditorPosition,
 } from './components/SqlMonacoEditor';
-
-const inMemorySqlDrafts = new Map<string, string>();
 
 const defaultPosition: SqlEditorPosition = {
   lineNumber: 1,
@@ -14,26 +17,25 @@ const defaultPosition: SqlEditorPosition = {
 };
 
 export const SqlEditor = ({ node }: DevelopmentEditorContext) => {
-  const initialValue = useMemo(
-    () => inMemorySqlDrafts.get(String(node.id)) || '',
-    [node.id],
-  );
-  const [value, setValue] = useState(initialValue);
-  const [position, setPosition] = useState(defaultPosition);
-
-  const handleChange = (nextValue: string) => {
-    setValue(nextValue);
-    inMemorySqlDrafts.set(String(node.id), nextValue);
-  };
+  const session = useEditorSession(node.id, node.type);
+  const [position, setPosition] = useState<SqlEditorPosition>(() => ({
+    lineNumber: session.viewState?.lineNumber || 1,
+    column: session.viewState?.column || 1,
+    selectionLength: 0,
+  }));
 
   return (
     <div className="flex h-full min-h-0 flex-col overflow-hidden bg-white">
       <div className="min-h-0 flex-1">
         <SqlMonacoEditor
           id={String(node.id)}
-          value={value}
-          onChange={handleChange}
+          value={session.content}
+          initialViewState={session.viewState}
+          onChange={(value) => updateEditorSessionContent(node.id, value)}
           onPositionChange={setPosition}
+          onViewStateChange={(viewState) =>
+            updateEditorSessionViewState(node.id, viewState)
+          }
         />
       </div>
 
@@ -41,6 +43,12 @@ export const SqlEditor = ({ node }: DevelopmentEditorContext) => {
         <div className="flex min-w-0 items-center gap-3">
           <span className="font-medium text-[#667085]">SQL</span>
           <span className="truncate">{node.name}</span>
+          {session.dirty ? (
+            <span className="inline-flex shrink-0 items-center gap-1 text-[#667085]">
+              <span className="h-1.5 w-1.5 rounded-full bg-[#667085]" />
+              未保存
+            </span>
+          ) : null}
         </div>
         <div className="flex shrink-0 items-center gap-3">
           {position.selectionLength > 0 ? (

--- a/yak-ops-ui/src/pages/data-development/editors/sql/components/SqlMonacoEditor.tsx
+++ b/yak-ops-ui/src/pages/data-development/editors/sql/components/SqlMonacoEditor.tsx
@@ -2,6 +2,7 @@ import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
 import 'monaco-editor/esm/vs/basic-languages/sql/sql.contribution';
 import { useEffect, useRef } from 'react';
 
+import type { DevelopmentEditorViewState } from '../../session/types';
 import { setupMonacoEnvironment } from '../monaco/setupMonacoEnvironment';
 
 export interface SqlEditorPosition {
@@ -13,8 +14,10 @@ export interface SqlEditorPosition {
 interface SqlMonacoEditorProps {
   id: string;
   value: string;
+  initialViewState?: DevelopmentEditorViewState;
   onChange: (value: string) => void;
   onPositionChange?: (position: SqlEditorPosition) => void;
+  onViewStateChange?: (viewState: DevelopmentEditorViewState) => void;
 }
 
 let themeRegistered = false;
@@ -50,14 +53,17 @@ const ensureYakSqlTheme = () => {
 const SqlMonacoEditor = ({
   id,
   value,
+  initialViewState,
   onChange,
   onPositionChange,
+  onViewStateChange,
 }: SqlMonacoEditorProps) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const editorRef = useRef<monaco.editor.IStandaloneCodeEditor>();
   const modelRef = useRef<monaco.editor.ITextModel>();
   const onChangeRef = useRef(onChange);
   const onPositionChangeRef = useRef(onPositionChange);
+  const onViewStateChangeRef = useRef(onViewStateChange);
 
   useEffect(() => {
     onChangeRef.current = onChange;
@@ -66,6 +72,10 @@ const SqlMonacoEditor = ({
   useEffect(() => {
     onPositionChangeRef.current = onPositionChange;
   }, [onPositionChange]);
+
+  useEffect(() => {
+    onViewStateChangeRef.current = onViewStateChange;
+  }, [onViewStateChange]);
 
   useEffect(() => {
     if (!containerRef.current) return undefined;
@@ -113,7 +123,20 @@ const SqlMonacoEditor = ({
     editorRef.current = editor;
     modelRef.current = model;
 
-    const emitPosition = () => {
+    if (initialViewState) {
+      if (initialViewState.selection) {
+        editor.setSelection(initialViewState.selection);
+      } else {
+        editor.setPosition({
+          lineNumber: initialViewState.lineNumber,
+          column: initialViewState.column,
+        });
+      }
+      editor.setScrollTop(initialViewState.scrollTop);
+      editor.setScrollLeft(initialViewState.scrollLeft);
+    }
+
+    const emitEditorState = () => {
       const position = editor.getPosition();
       const selection = editor.getSelection();
       if (!position) return;
@@ -126,20 +149,38 @@ const SqlMonacoEditor = ({
         column: position.column,
         selectionLength,
       });
+
+      onViewStateChangeRef.current?.({
+        lineNumber: position.lineNumber,
+        column: position.column,
+        selection: selection
+          ? {
+              startLineNumber: selection.startLineNumber,
+              startColumn: selection.startColumn,
+              endLineNumber: selection.endLineNumber,
+              endColumn: selection.endColumn,
+            }
+          : undefined,
+        scrollTop: editor.getScrollTop(),
+        scrollLeft: editor.getScrollLeft(),
+      });
     };
 
     const contentDisposable = model.onDidChangeContent(() => {
       onChangeRef.current(model.getValue());
     });
-    const cursorDisposable = editor.onDidChangeCursorPosition(emitPosition);
-    const selectionDisposable = editor.onDidChangeCursorSelection(emitPosition);
+    const cursorDisposable = editor.onDidChangeCursorPosition(emitEditorState);
+    const selectionDisposable = editor.onDidChangeCursorSelection(emitEditorState);
+    const scrollDisposable = editor.onDidScrollChange(emitEditorState);
 
-    emitPosition();
+    emitEditorState();
 
     return () => {
+      emitEditorState();
       contentDisposable.dispose();
       cursorDisposable.dispose();
       selectionDisposable.dispose();
+      scrollDisposable.dispose();
       editor.dispose();
       model.dispose();
       editorRef.current = undefined;


### PR DESCRIPTION
## 变更说明

继续数据开发 SQL 编辑器第二阶段：在第一阶段 Monaco 基础编辑器之上，引入独立 EditorSession 层，把 SQL 草稿、dirty 状态和编辑器视图状态从 `SqlEditor` 本地状态中抽离出来。

### 本阶段实现

- 新增通用 `DevelopmentEditorSession` 模型，包含：
  - `content`
  - `originalContent`
  - `dirty`
  - 光标位置
  - Selection
  - `scrollTop / scrollLeft`
  - `updatedAt`
- 新增 `editorSessionStore`，以 `nodeId` 为单位管理编辑会话，SQL 编辑器不再自己维护内存草稿 Map
- EditorSession 使用 localStorage 做轻量持久化，刷新页面后重新打开同一 SQL 节点可以恢复本地草稿
- 本地持久化采用 200ms 合并写入，`pagehide` 时同步 flush，减少每次按键直接写 localStorage 的阻塞
- localStorage 不可用、容量不足或数据损坏时自动降级为当前页面内存会话，不影响继续编辑
- 对持久化结构做版本号和字段校验，避免异常本地数据直接灌入编辑器

### Monaco 视图状态

`SqlMonacoEditor` 现在会保存并恢复：

- 当前行 / 列
- 选区范围
- 垂直滚动位置
- 水平滚动位置

因此 SQL Tab 切换、关闭后重新打开，以及刷新后重新进入同一节点时，可以继续从上一次编辑位置工作。

### Dirty 状态

- SQL 内容与 `originalContent` 不一致时自动标记 `dirty`
- 顶部编辑 Tab 增加灰色小圆点表示未保存修改
- 编辑器底部状态栏同步显示「未保存」
- 编辑器更多菜单中的已打开节点也同步展示 dirty 标识
- 关闭 Tab 不会删除 EditorSession，因此重新打开后本地草稿仍可恢复

当前「保存」仍然是占位能力，本 PR 不会把本地草稿伪装成后端已保存数据；`markEditorSessionSaved` 已作为后续真实保存接口接入时的会话基线能力预留。

### 架构边界

EditorSession 是数据开发编辑器的通用层，不放在 SQL 组件内部。后续 Shell / Python / HTTP 编辑器可以复用同一个会话模型和 Store；SQL 只负责把 Monaco 的内容和 ViewState 映射到 EditorSession。

### 明确不做

本阶段仍不实现：

- 后端 SQL 内容加载 / 保存
- SQL 自动补全
- SQL Parser / Marker / Hover
- 数据源元数据提示
- SQL 执行与结果集
- 工作区打开 Tab 列表的跨刷新自动恢复

### 影响范围

- `editors/session/types.ts`
- `editors/session/editorSessionStore.ts`
- `editors/sql/SqlEditor.tsx`
- `editors/sql/components/SqlMonacoEditor.tsx`
- `components/workbench/EditorTabs.tsx`

不修改后端接口，不影响 Shell 编辑器、右侧面板、底部运行结果面板和目录树逻辑。

### 建议回归

- SQL 中输入内容，确认 Tab 和底部状态栏出现未保存标识
- SQL Tab 来回切换，确认内容、光标、选区和滚动位置保持
- 关闭 SQL Tab 后重新点击左侧同一节点，确认草稿和位置恢复
- 刷新页面后重新打开同一 SQL 节点，确认本地草稿恢复
- 打开多个 SQL 节点，确认每个节点 Session 相互隔离
- SQL / Shell Tab 交替切换，确认 Shell 原有行为不受影响
