### PR TITLE
feat(data-development): add SQL catalog metadata completion

### DIFF
--- a/yak-ops-ui/src/pages/data-development/editors/sql/SqlEditor.tsx
+++ b/yak-ops-ui/src/pages/data-development/editors/sql/SqlEditor.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 
 import {
   updateEditorSessionContent,
@@ -9,6 +9,8 @@ import type { DevelopmentEditorContext } from '../types';
 import SqlMonacoEditor, {
   type SqlEditorPosition,
 } from './components/SqlMonacoEditor';
+import SqlMetadataContextPanel from './metadata/SqlMetadataContextPanel';
+import { useSqlMetadataContext } from './metadata/sqlMetadataContextStore';
 
 const defaultPosition: SqlEditorPosition = {
   lineNumber: 1,
@@ -18,11 +20,32 @@ const defaultPosition: SqlEditorPosition = {
 
 export const SqlEditor = ({ node }: DevelopmentEditorContext) => {
   const session = useEditorSession(node.id, node.type);
+  const metadataContext = useSqlMetadataContext(node.id);
   const [position, setPosition] = useState<SqlEditorPosition>(() => ({
     lineNumber: session.viewState?.lineNumber || 1,
     column: session.viewState?.column || 1,
     selectionLength: 0,
   }));
+
+  const metadataPath = useMemo(
+    () =>
+      [
+        metadataContext.dataSourceName ||
+          (metadataContext.dataSourceId
+            ? `DS ${metadataContext.dataSourceId}`
+            : undefined),
+        metadataContext.database,
+        metadataContext.schema,
+      ]
+        .filter(Boolean)
+        .join(' / '),
+    [
+      metadataContext.dataSourceId,
+      metadataContext.dataSourceName,
+      metadataContext.database,
+      metadataContext.schema,
+    ],
+  );
 
   return (
     <div className="flex h-full min-h-0 flex-col overflow-hidden bg-white">
@@ -49,6 +72,15 @@ export const SqlEditor = ({ node }: DevelopmentEditorContext) => {
               未保存
             </span>
           ) : null}
+          <span
+            className={[
+              'max-w-[260px] truncate',
+              metadataContext.dataSourceId ? 'text-[#667085]' : 'text-[#b0b7c3]',
+            ].join(' ')}
+            title={metadataPath || '未选择数据源'}
+          >
+            {metadataPath || '未选择数据源'}
+          </span>
         </div>
         <div className="flex shrink-0 items-center gap-3">
           {position.selectionLength > 0 ? (
@@ -64,11 +96,7 @@ export const SqlEditor = ({ node }: DevelopmentEditorContext) => {
 };
 
 export const SqlRunConfig = ({ node }: DevelopmentEditorContext) => (
-  <div className="text-[12px] leading-6 text-[#667085]">
-    <div className="font-medium text-[#344054]">SQL 运行配置</div>
-    <div className="mt-2">当前节点：{node.name}</div>
-    <div>数据源、执行参数和资源配置将在后续阶段接入。</div>
-  </div>
+  <SqlMetadataContextPanel nodeId={node.id} nodeName={node.name} />
 );
 
 export const SqlRunResult = ({ node }: DevelopmentEditorContext) => (

--- a/yak-ops-ui/src/pages/data-development/editors/sql/completion/registerSqlMetadataCompletion.ts
+++ b/yak-ops-ui/src/pages/data-development/editors/sql/completion/registerSqlMetadataCompletion.ts
@@ -69,6 +69,18 @@ const getTextBeforePosition = (
     new monaco.Range(1, 1, position.lineNumber, position.column),
   );
 
+const getCurrentStatementText = (
+  model: monaco.editor.ITextModel,
+  position: monaco.Position,
+) => {
+  const sql = model.getValue();
+  const offset = model.getOffsetAt(position);
+  const start = sql.lastIndexOf(';', Math.max(0, offset - 1)) + 1;
+  const nextSeparator = sql.indexOf(';', offset);
+  const end = nextSeparator < 0 ? sql.length : nextSeparator;
+  return sql.slice(start, end);
+};
+
 const getLexicalState = (text: string): SqlLexicalState => {
   let state: SqlLexicalState = 'code';
 
@@ -329,7 +341,10 @@ const provideMetadataSuggestions = async (
 
   const range = getCompletionRange(model, position);
   const qualifier = getQualifier(model, position);
-  const references = parseTableReferences(textBeforePosition, context);
+  const references = parseTableReferences(
+    getCurrentStatementText(model, position),
+    context,
+  );
 
   try {
     if (qualifier) {

--- a/yak-ops-ui/src/pages/data-development/editors/sql/completion/registerSqlMetadataCompletion.ts
+++ b/yak-ops-ui/src/pages/data-development/editors/sql/completion/registerSqlMetadataCompletion.ts
@@ -1,0 +1,421 @@
+import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
+
+import type { DevelopmentId } from '../../../types';
+import { loadSqlColumns, loadSqlTables } from '../metadata/sqlMetadataCache';
+import {
+  getSqlMetadataContext,
+  type SqlMetadataContext,
+} from '../metadata/sqlMetadataContextStore';
+import type {
+  SqlCatalogColumn,
+  SqlCatalogTable,
+} from '../metadata/sqlMetadataService';
+
+type SqlLexicalState =
+  | 'code'
+  | 'single-quote'
+  | 'double-quote'
+  | 'backtick'
+  | 'bracket-identifier'
+  | 'line-comment'
+  | 'block-comment';
+
+interface SqlTableReference {
+  database?: string;
+  schema?: string;
+  table: string;
+  alias?: string;
+}
+
+let providerDisposable: monaco.IDisposable | undefined;
+let providerConsumers = 0;
+const modelNodeIds = new Map<string, DevelopmentId>();
+
+const STOP_ALIAS_WORDS = new Set([
+  'WHERE',
+  'JOIN',
+  'LEFT',
+  'RIGHT',
+  'FULL',
+  'INNER',
+  'OUTER',
+  'CROSS',
+  'ON',
+  'GROUP',
+  'ORDER',
+  'HAVING',
+  'LIMIT',
+  'OFFSET',
+  'UNION',
+  'EXCEPT',
+  'INTERSECT',
+  'SET',
+  'VALUES',
+  'RETURNING',
+]);
+
+const identifierPart = '(?:`[^`]+`|"[^"]+"|\\[[^\\]]+\\]|[A-Za-z_$][\\w$]*)';
+const qualifiedIdentifier = `${identifierPart}(?:\\s*\\.\\s*${identifierPart}){0,2}`;
+const tableReferencePattern = new RegExp(
+  `\\b(?:FROM|JOIN)\\s+(${qualifiedIdentifier})(?:\\s+(?:AS\\s+)?([A-Za-z_$][\\w$]*))?`,
+  'gi',
+);
+
+const getTextBeforePosition = (
+  model: monaco.editor.ITextModel,
+  position: monaco.Position,
+) =>
+  model.getValueInRange(
+    new monaco.Range(1, 1, position.lineNumber, position.column),
+  );
+
+const getLexicalState = (text: string): SqlLexicalState => {
+  let state: SqlLexicalState = 'code';
+
+  for (let index = 0; index < text.length; index += 1) {
+    const current = text[index];
+    const next = text[index + 1];
+
+    if (state === 'line-comment') {
+      if (current === '\n') state = 'code';
+      continue;
+    }
+    if (state === 'block-comment') {
+      if (current === '*' && next === '/') {
+        state = 'code';
+        index += 1;
+      }
+      continue;
+    }
+    if (state === 'single-quote') {
+      if (current === "'" && next === "'") {
+        index += 1;
+        continue;
+      }
+      if (current === "'") state = 'code';
+      continue;
+    }
+    if (state === 'double-quote') {
+      if (current === '"' && next === '"') {
+        index += 1;
+        continue;
+      }
+      if (current === '"') state = 'code';
+      continue;
+    }
+    if (state === 'backtick') {
+      if (current === '`' && next === '`') {
+        index += 1;
+        continue;
+      }
+      if (current === '`') state = 'code';
+      continue;
+    }
+    if (state === 'bracket-identifier') {
+      if (current === ']' && next === ']') {
+        index += 1;
+        continue;
+      }
+      if (current === ']') state = 'code';
+      continue;
+    }
+
+    if (current === '-' && next === '-') {
+      state = 'line-comment';
+      index += 1;
+    } else if (current === '/' && next === '*') {
+      state = 'block-comment';
+      index += 1;
+    } else if (current === "'") {
+      state = 'single-quote';
+    } else if (current === '"') {
+      state = 'double-quote';
+    } else if (current === '`') {
+      state = 'backtick';
+    } else if (current === '[') {
+      state = 'bracket-identifier';
+    }
+  }
+
+  return state;
+};
+
+const stripQuotedValue = (value: string) => {
+  const normalized = value.trim();
+  if (
+    (normalized.startsWith('`') && normalized.endsWith('`')) ||
+    (normalized.startsWith('"') && normalized.endsWith('"')) ||
+    (normalized.startsWith('[') && normalized.endsWith(']'))
+  ) {
+    return normalized.slice(1, -1);
+  }
+  return normalized;
+};
+
+const splitQualifiedIdentifier = (value: string) => {
+  const parts: string[] = [];
+  let current = '';
+  let quote: '`' | '"' | '[' | undefined;
+
+  for (let index = 0; index < value.length; index += 1) {
+    const char = value[index];
+    if (!quote && (char === '`' || char === '"' || char === '[')) {
+      quote = char as '`' | '"' | '[';
+      current += char;
+      continue;
+    }
+    if (quote === '`' && char === '`') quote = undefined;
+    else if (quote === '"' && char === '"') quote = undefined;
+    else if (quote === '[' && char === ']') quote = undefined;
+
+    if (!quote && char === '.') {
+      if (current.trim()) parts.push(stripQuotedValue(current));
+      current = '';
+      continue;
+    }
+    current += char;
+  }
+
+  if (current.trim()) parts.push(stripQuotedValue(current));
+  return parts;
+};
+
+const tableReferenceFromParts = (
+  parts: string[],
+  alias: string | undefined,
+  context: SqlMetadataContext,
+): SqlTableReference | undefined => {
+  if (!parts.length) return undefined;
+  const table = parts[parts.length - 1];
+  if (!table) return undefined;
+
+  if (parts.length >= 3) {
+    return {
+      database: parts[parts.length - 3],
+      schema: parts[parts.length - 2],
+      table,
+      alias,
+    };
+  }
+
+  if (parts.length === 2) {
+    const first = parts[0];
+    const mysqlLike = ['MYSQL', 'MARIADB', 'DORIS'].includes(
+      (context.dbType || '').toUpperCase(),
+    );
+    return mysqlLike
+      ? { database: first, table, alias }
+      : { database: context.database, schema: first, table, alias };
+  }
+
+  return {
+    database: context.database,
+    schema: context.schema,
+    table,
+    alias,
+  };
+};
+
+const parseTableReferences = (
+  sql: string,
+  context: SqlMetadataContext,
+): SqlTableReference[] => {
+  const references: SqlTableReference[] = [];
+  tableReferencePattern.lastIndex = 0;
+  let match = tableReferencePattern.exec(sql);
+  while (match) {
+    const rawAlias = match[2];
+    const alias =
+      rawAlias && !STOP_ALIAS_WORDS.has(rawAlias.toUpperCase())
+        ? rawAlias
+        : undefined;
+    const reference = tableReferenceFromParts(
+      splitQualifiedIdentifier(match[1]),
+      alias,
+      context,
+    );
+    if (reference) references.push(reference);
+    match = tableReferencePattern.exec(sql);
+  }
+  return references;
+};
+
+const getCompletionRange = (
+  model: monaco.editor.ITextModel,
+  position: monaco.Position,
+) => {
+  const word = model.getWordUntilPosition(position);
+  return new monaco.Range(
+    position.lineNumber,
+    word.startColumn,
+    position.lineNumber,
+    word.endColumn,
+  );
+};
+
+const getQualifier = (
+  model: monaco.editor.ITextModel,
+  position: monaco.Position,
+) => {
+  const line = model.getLineContent(position.lineNumber).slice(0, position.column - 1);
+  const match = line.match(/([A-Za-z_$][\w$]*)\s*\.\s*[A-Za-z_$\d]*$/);
+  return match?.[1];
+};
+
+const isTablePosition = (textBeforePosition: string) =>
+  /\b(?:FROM|JOIN|UPDATE|INTO)\s+(?:[A-Za-z_$][\w$]*\s*\.\s*){0,2}[A-Za-z_$\d]*$/i.test(
+    textBeforePosition,
+  );
+
+const columnSuggestion = (
+  column: SqlCatalogColumn,
+  range: monaco.Range,
+  owner: string,
+): monaco.languages.CompletionItem => ({
+  label: column.name,
+  kind: monaco.languages.CompletionItemKind.Field,
+  insertText: column.name,
+  detail: [column.typeName, column.primaryKey ? 'PK' : undefined, owner]
+    .filter(Boolean)
+    .join(' · '),
+  documentation: column.remarks || undefined,
+  sortText: `1-${String(column.ordinalPosition ?? 9999).padStart(5, '0')}-${column.name}`,
+  range,
+});
+
+const tableSuggestion = (
+  table: SqlCatalogTable,
+  range: monaco.Range,
+): monaco.languages.CompletionItem => ({
+  label: table.name,
+  kind:
+    table.type?.toUpperCase() === 'VIEW'
+      ? monaco.languages.CompletionItemKind.Interface
+      : monaco.languages.CompletionItemKind.Struct,
+  insertText: table.name,
+  detail: [table.type || 'TABLE', table.database, table.schema]
+    .filter(Boolean)
+    .join(' · '),
+  documentation: table.remarks || undefined,
+  sortText: `1-${table.name}`,
+  range,
+});
+
+const findReference = (
+  qualifier: string,
+  references: SqlTableReference[],
+) => {
+  const normalized = qualifier.toLowerCase();
+  return references.find(
+    (reference) =>
+      reference.alias?.toLowerCase() === normalized ||
+      reference.table.toLowerCase() === normalized,
+  );
+};
+
+const provideMetadataSuggestions = async (
+  model: monaco.editor.ITextModel,
+  position: monaco.Position,
+  token: monaco.CancellationToken,
+): Promise<monaco.languages.CompletionList> => {
+  const nodeId = modelNodeIds.get(model.uri.toString());
+  const context = nodeId ? getSqlMetadataContext(nodeId) : undefined;
+  if (!context?.dataSourceId) return { suggestions: [] };
+
+  const textBeforePosition = getTextBeforePosition(model, position);
+  if (getLexicalState(textBeforePosition) !== 'code') {
+    return { suggestions: [] };
+  }
+
+  const range = getCompletionRange(model, position);
+  const qualifier = getQualifier(model, position);
+  const references = parseTableReferences(textBeforePosition, context);
+
+  try {
+    if (qualifier) {
+      const reference = findReference(qualifier, references);
+      if (reference) {
+        const columns = await loadSqlColumns(context, reference.table, {
+          database: reference.database,
+          schema: reference.schema,
+        });
+        if (token.isCancellationRequested) return { suggestions: [] };
+        return {
+          suggestions: columns.map((column) =>
+            columnSuggestion(column, range, reference.alias || reference.table),
+          ),
+        };
+      }
+
+      if (
+        qualifier.toLowerCase() === context.schema?.toLowerCase() ||
+        qualifier.toLowerCase() === context.database?.toLowerCase()
+      ) {
+        const tables = await loadSqlTables(context);
+        if (token.isCancellationRequested) return { suggestions: [] };
+        return { suggestions: tables.map((table) => tableSuggestion(table, range)) };
+      }
+
+      return { suggestions: [] };
+    }
+
+    if (isTablePosition(textBeforePosition)) {
+      const tables = await loadSqlTables(context);
+      if (token.isCancellationRequested) return { suggestions: [] };
+      return { suggestions: tables.map((table) => tableSuggestion(table, range)) };
+    }
+
+    if (references.length === 1) {
+      const reference = references[0];
+      const columns = await loadSqlColumns(context, reference.table, {
+        database: reference.database,
+        schema: reference.schema,
+      });
+      if (token.isCancellationRequested) return { suggestions: [] };
+      return {
+        suggestions: columns.map((column) =>
+          columnSuggestion(column, range, reference.table),
+        ),
+      };
+    }
+  } catch {
+    // Metadata completion is best-effort. Keep SQL editing/builtin completion available.
+  }
+
+  return { suggestions: [] };
+};
+
+const createProvider = () =>
+  monaco.languages.registerCompletionItemProvider('sql', {
+    triggerCharacters: ['.'],
+    provideCompletionItems: provideMetadataSuggestions,
+  });
+
+export const bindSqlMetadataModel = (
+  modelUri: string,
+  nodeId: DevelopmentId,
+): monaco.IDisposable => {
+  modelNodeIds.set(modelUri, nodeId);
+  return {
+    dispose: () => {
+      if (modelNodeIds.get(modelUri) === nodeId) modelNodeIds.delete(modelUri);
+    },
+  };
+};
+
+export const acquireSqlMetadataCompletionProvider = (): monaco.IDisposable => {
+  providerConsumers += 1;
+  if (!providerDisposable) providerDisposable = createProvider();
+
+  let released = false;
+  return {
+    dispose: () => {
+      if (released) return;
+      released = true;
+      providerConsumers = Math.max(0, providerConsumers - 1);
+      if (providerConsumers > 0) return;
+      providerDisposable?.dispose();
+      providerDisposable = undefined;
+    },
+  };
+};

--- a/yak-ops-ui/src/pages/data-development/editors/sql/components/SqlMonacoEditor.tsx
+++ b/yak-ops-ui/src/pages/data-development/editors/sql/components/SqlMonacoEditor.tsx
@@ -4,6 +4,10 @@ import { useEffect, useRef } from 'react';
 
 import type { DevelopmentEditorViewState } from '../../session/types';
 import { acquireSqlBuiltinCompletionProvider } from '../completion/registerSqlBuiltinCompletion';
+import {
+  acquireSqlMetadataCompletionProvider,
+  bindSqlMetadataModel,
+} from '../completion/registerSqlMetadataCompletion';
 import { setupMonacoEnvironment } from '../monaco/setupMonacoEnvironment';
 
 export interface SqlEditorPosition {
@@ -83,7 +87,8 @@ const SqlMonacoEditor = ({
 
     setupMonacoEnvironment();
     ensureYakSqlTheme();
-    const completionProvider = acquireSqlBuiltinCompletionProvider();
+    const builtinCompletionProvider = acquireSqlBuiltinCompletionProvider();
+    const metadataCompletionProvider = acquireSqlMetadataCompletionProvider();
 
     const uri = monaco.Uri.parse(
       `inmemory://yak-ops/data-development/sql/${encodeURIComponent(id)}.sql`,
@@ -91,6 +96,7 @@ const SqlMonacoEditor = ({
     monaco.editor.getModel(uri)?.dispose();
 
     const model = monaco.editor.createModel(value, 'sql', uri);
+    const metadataModelBinding = bindSqlMetadataModel(model.uri.toString(), id);
     const editor = monaco.editor.create(containerRef.current, {
       model,
       theme: 'yak-sql-light',
@@ -129,6 +135,9 @@ const SqlMonacoEditor = ({
         showWords: false,
         showKeywords: true,
         showFunctions: true,
+        showFields: true,
+        showStructs: true,
+        showInterfaces: true,
         snippetsPreventQuickSuggestions: false,
       },
       wordBasedSuggestions: 'off',
@@ -197,7 +206,9 @@ const SqlMonacoEditor = ({
       cursorDisposable.dispose();
       selectionDisposable.dispose();
       scrollDisposable.dispose();
-      completionProvider.dispose();
+      metadataModelBinding.dispose();
+      metadataCompletionProvider.dispose();
+      builtinCompletionProvider.dispose();
       editor.dispose();
       model.dispose();
       editorRef.current = undefined;

--- a/yak-ops-ui/src/pages/data-development/editors/sql/metadata/SqlMetadataContextPanel.tsx
+++ b/yak-ops-ui/src/pages/data-development/editors/sql/metadata/SqlMetadataContextPanel.tsx
@@ -1,0 +1,219 @@
+import { Select, message } from 'antd';
+import { Database } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+
+import type { DevelopmentId } from '../../../types';
+import {
+  selectSqlDatabaseContext,
+  selectSqlDataSourceContext,
+  selectSqlSchemaContext,
+  useSqlMetadataContext,
+} from './sqlMetadataContextStore';
+import {
+  listSqlDatabases,
+  listSqlDataSources,
+  listSqlSchemas,
+  type SqlDataSourceOption,
+} from './sqlMetadataService';
+
+interface SqlMetadataContextPanelProps {
+  nodeId: DevelopmentId;
+  nodeName: string;
+}
+
+const errorText = (error: unknown, fallback: string) =>
+  error instanceof Error ? error.message : fallback;
+
+const SqlMetadataContextPanel = ({
+  nodeId,
+  nodeName,
+}: SqlMetadataContextPanelProps) => {
+  const context = useSqlMetadataContext(nodeId);
+  const [dataSources, setDataSources] = useState<SqlDataSourceOption[]>([]);
+  const [databases, setDatabases] = useState<string[]>([]);
+  const [schemas, setSchemas] = useState<string[]>([]);
+  const [dataSourceLoading, setDataSourceLoading] = useState(false);
+  const [databaseLoading, setDatabaseLoading] = useState(false);
+  const [schemaLoading, setSchemaLoading] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    setDataSourceLoading(true);
+    listSqlDataSources()
+      .then((values) => {
+        if (active) setDataSources(values || []);
+      })
+      .catch((error) => {
+        if (active) message.error(errorText(error, '查询数据源失败'));
+      })
+      .finally(() => {
+        if (active) setDataSourceLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    let active = true;
+    if (!context.dataSourceId) {
+      setDatabases([]);
+      setSchemas([]);
+      return () => {
+        active = false;
+      };
+    }
+
+    setDatabaseLoading(true);
+    listSqlDatabases(context.dataSourceId)
+      .then((values) => {
+        if (!active) return;
+        const next = values || [];
+        setDatabases(next);
+        if (context.database && !next.includes(context.database)) {
+          selectSqlDatabaseContext(nodeId, undefined);
+        }
+      })
+      .catch((error) => {
+        if (active) message.error(errorText(error, '查询数据库失败'));
+      })
+      .finally(() => {
+        if (active) setDatabaseLoading(false);
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [context.dataSourceId, context.database, nodeId]);
+
+  useEffect(() => {
+    let active = true;
+    if (!context.dataSourceId) {
+      setSchemas([]);
+      return () => {
+        active = false;
+      };
+    }
+
+    setSchemaLoading(true);
+    listSqlSchemas(context.dataSourceId, context.database)
+      .then((values) => {
+        if (!active) return;
+        const next = values || [];
+        setSchemas(next);
+        if (context.schema && !next.includes(context.schema)) {
+          selectSqlSchemaContext(nodeId, undefined);
+        }
+      })
+      .catch((error) => {
+        if (active) message.error(errorText(error, '查询 Schema 失败'));
+      })
+      .finally(() => {
+        if (active) setSchemaLoading(false);
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [context.dataSourceId, context.database, context.schema, nodeId]);
+
+  const contextPath = useMemo(
+    () =>
+      [context.dataSourceName, context.database, context.schema]
+        .filter(Boolean)
+        .join(' / '),
+    [context.dataSourceName, context.database, context.schema],
+  );
+
+  return (
+    <div className="text-[12px] text-[#667085]">
+      <div className="flex items-center gap-2 font-medium text-[#344054]">
+        <Database size={14} strokeWidth={1.8} />
+        SQL 元数据上下文
+      </div>
+      <div className="mt-1 text-[11px] leading-5 text-[#98a2b3]">
+        为 {nodeName} 选择数据源上下文，编辑器会使用 Yak Ops Catalog 提供表和字段补全。
+      </div>
+
+      <div className="mt-4 space-y-4">
+        <label className="block">
+          <span className="mb-1.5 block text-[11px] text-[#667085]">数据源</span>
+          <Select
+            allowClear
+            showSearch
+            size="small"
+            optionFilterProp="label"
+            placeholder="选择数据源"
+            loading={dataSourceLoading}
+            value={context.dataSourceId}
+            options={dataSources.map((item) => ({
+              label: item.dbType ? `${item.label} · ${item.dbType}` : item.label,
+              value: item.value,
+            }))}
+            className="w-full"
+            onChange={(value) => {
+              const selected = dataSources.find((item) => item.value === value);
+              selectSqlDataSourceContext(
+                nodeId,
+                selected
+                  ? {
+                      id: selected.value,
+                      name: selected.label,
+                      dbType: selected.dbType,
+                    }
+                  : undefined,
+              );
+            }}
+          />
+        </label>
+
+        <label className="block">
+          <span className="mb-1.5 block text-[11px] text-[#667085]">Database</span>
+          <Select
+            allowClear
+            showSearch
+            size="small"
+            placeholder={context.dataSourceId ? '自动 / 选择 Database' : '请先选择数据源'}
+            disabled={!context.dataSourceId}
+            loading={databaseLoading}
+            value={context.database}
+            options={databases.map((value) => ({ label: value, value }))}
+            className="w-full"
+            onChange={(value) => selectSqlDatabaseContext(nodeId, value)}
+          />
+        </label>
+
+        <label className="block">
+          <span className="mb-1.5 block text-[11px] text-[#667085]">Schema</span>
+          <Select
+            allowClear
+            showSearch
+            size="small"
+            placeholder={context.dataSourceId ? '自动 / 选择 Schema' : '请先选择数据源'}
+            disabled={!context.dataSourceId}
+            loading={schemaLoading}
+            value={context.schema}
+            options={schemas.map((value) => ({ label: value, value }))}
+            className="w-full"
+            onChange={(value) => selectSqlSchemaContext(nodeId, value)}
+          />
+        </label>
+      </div>
+
+      <div className="mt-4 border-t border-[#eef0f2] pt-3 text-[11px] leading-5 text-[#98a2b3]">
+        {context.dataSourceId ? (
+          <>
+            当前补全上下文：
+            <span className="ml-1 break-all text-[#475467]">
+              {contextPath || `数据源 ${context.dataSourceId}`}
+            </span>
+          </>
+        ) : (
+          '未选择数据源时，仅保留 SQL 关键字和内置函数补全。'
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default SqlMetadataContextPanel;

--- a/yak-ops-ui/src/pages/data-development/editors/sql/metadata/sqlMetadataCache.ts
+++ b/yak-ops-ui/src/pages/data-development/editors/sql/metadata/sqlMetadataCache.ts
@@ -1,0 +1,92 @@
+import {
+  listSqlColumns,
+  listSqlTables,
+  type SqlCatalogColumn,
+  type SqlCatalogTable,
+} from './sqlMetadataService';
+import type { SqlMetadataContext } from './sqlMetadataContextStore';
+
+const CACHE_TTL = 60_000;
+
+interface CacheEntry<T> {
+  expiresAt: number;
+  value: T;
+}
+
+const tableCache = new Map<string, CacheEntry<SqlCatalogTable[]>>();
+const columnCache = new Map<string, CacheEntry<SqlCatalogColumn[]>>();
+const pendingTables = new Map<string, Promise<SqlCatalogTable[]>>();
+const pendingColumns = new Map<string, Promise<SqlCatalogColumn[]>>();
+
+const cacheKey = (...parts: Array<string | undefined>) =>
+  parts.map((part) => part || '').join('::');
+
+const readCache = <T,>(cache: Map<string, CacheEntry<T>>, key: string) => {
+  const entry = cache.get(key);
+  if (!entry) return undefined;
+  if (entry.expiresAt <= Date.now()) {
+    cache.delete(key);
+    return undefined;
+  }
+  return entry.value;
+};
+
+export const loadSqlTables = async (
+  context: SqlMetadataContext,
+  override: { database?: string; schema?: string } = {},
+) => {
+  if (!context.dataSourceId) return [];
+  const database = override.database ?? context.database;
+  const schema = override.schema ?? context.schema;
+  const key = cacheKey(context.dataSourceId, database, schema);
+  const cached = readCache(tableCache, key);
+  if (cached) return cached;
+
+  const pending = pendingTables.get(key);
+  if (pending) return pending;
+
+  const request = listSqlTables(context.dataSourceId, { database, schema })
+    .then((tables) => {
+      tableCache.set(key, { expiresAt: Date.now() + CACHE_TTL, value: tables });
+      return tables;
+    })
+    .finally(() => pendingTables.delete(key));
+  pendingTables.set(key, request);
+  return request;
+};
+
+export const loadSqlColumns = async (
+  context: SqlMetadataContext,
+  table: string,
+  override: { database?: string; schema?: string } = {},
+) => {
+  if (!context.dataSourceId || !table) return [];
+  const database = override.database ?? context.database;
+  const schema = override.schema ?? context.schema;
+  const key = cacheKey(context.dataSourceId, database, schema, table.toLowerCase());
+  const cached = readCache(columnCache, key);
+  if (cached) return cached;
+
+  const pending = pendingColumns.get(key);
+  if (pending) return pending;
+
+  const request = listSqlColumns(context.dataSourceId, {
+    database,
+    schema,
+    table,
+  })
+    .then((columns) => {
+      columnCache.set(key, { expiresAt: Date.now() + CACHE_TTL, value: columns });
+      return columns;
+    })
+    .finally(() => pendingColumns.delete(key));
+  pendingColumns.set(key, request);
+  return request;
+};
+
+export const clearSqlMetadataCache = () => {
+  tableCache.clear();
+  columnCache.clear();
+  pendingTables.clear();
+  pendingColumns.clear();
+};

--- a/yak-ops-ui/src/pages/data-development/editors/sql/metadata/sqlMetadataContextStore.ts
+++ b/yak-ops-ui/src/pages/data-development/editors/sql/metadata/sqlMetadataContextStore.ts
@@ -1,0 +1,157 @@
+import { useSyncExternalStore } from 'react';
+
+import type { DevelopmentId } from '../../../types';
+
+export interface SqlMetadataContext {
+  nodeId: DevelopmentId;
+  dataSourceId?: string;
+  dataSourceName?: string;
+  dbType?: string;
+  database?: string;
+  schema?: string;
+  updatedAt: number;
+}
+
+const STORAGE_KEY = 'yak-data-development.sql-metadata-contexts.v1';
+
+interface PersistedSqlMetadataContexts {
+  version: 1;
+  contexts: SqlMetadataContext[];
+}
+
+const contexts = new Map<DevelopmentId, SqlMetadataContext>();
+const listeners = new Set<() => void>();
+
+let hydrated = false;
+let version = 0;
+
+const isBrowser = () => typeof window !== 'undefined';
+
+const isPersistedContext = (value: unknown): value is SqlMetadataContext => {
+  if (!value || typeof value !== 'object') return false;
+  const context = value as Partial<SqlMetadataContext>;
+  return (
+    typeof context.nodeId === 'string' &&
+    typeof context.updatedAt === 'number' &&
+    (context.dataSourceId === undefined || typeof context.dataSourceId === 'string') &&
+    (context.dataSourceName === undefined || typeof context.dataSourceName === 'string') &&
+    (context.dbType === undefined || typeof context.dbType === 'string') &&
+    (context.database === undefined || typeof context.database === 'string') &&
+    (context.schema === undefined || typeof context.schema === 'string')
+  );
+};
+
+const ensureHydrated = () => {
+  if (hydrated) return;
+  hydrated = true;
+  if (!isBrowser()) return;
+
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return;
+    const parsed = JSON.parse(raw) as Partial<PersistedSqlMetadataContexts>;
+    if (parsed.version !== 1 || !Array.isArray(parsed.contexts)) return;
+    parsed.contexts.forEach((context) => {
+      if (isPersistedContext(context)) contexts.set(context.nodeId, context);
+    });
+  } catch {
+    // Ignore malformed or unavailable local storage. SQL editing still works in memory.
+  }
+};
+
+const persist = () => {
+  if (!isBrowser()) return;
+  const payload: PersistedSqlMetadataContexts = {
+    version: 1,
+    contexts: [...contexts.values()],
+  };
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+  } catch {
+    // Keep the in-memory context when local storage is unavailable or full.
+  }
+};
+
+const emitChange = () => {
+  version += 1;
+  listeners.forEach((listener) => listener());
+};
+
+const subscribe = (listener: () => void) => {
+  ensureHydrated();
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+};
+
+const getVersion = () => {
+  ensureHydrated();
+  return version;
+};
+
+export const ensureSqlMetadataContext = (
+  nodeId: DevelopmentId,
+): SqlMetadataContext => {
+  ensureHydrated();
+  const current = contexts.get(nodeId);
+  if (current) return current;
+
+  const context: SqlMetadataContext = {
+    nodeId,
+    updatedAt: Date.now(),
+  };
+  contexts.set(nodeId, context);
+  return context;
+};
+
+export const getSqlMetadataContext = (nodeId: DevelopmentId) => {
+  ensureHydrated();
+  return contexts.get(nodeId);
+};
+
+export const updateSqlMetadataContext = (
+  nodeId: DevelopmentId,
+  patch: Partial<Omit<SqlMetadataContext, 'nodeId' | 'updatedAt'>>,
+) => {
+  const current = ensureSqlMetadataContext(nodeId);
+  const next: SqlMetadataContext = {
+    ...current,
+    ...patch,
+    nodeId,
+    updatedAt: Date.now(),
+  };
+  contexts.set(nodeId, next);
+  persist();
+  emitChange();
+  return next;
+};
+
+export const selectSqlDataSourceContext = (
+  nodeId: DevelopmentId,
+  dataSource?: { id: string; name?: string; dbType?: string },
+) =>
+  updateSqlMetadataContext(nodeId, {
+    dataSourceId: dataSource?.id,
+    dataSourceName: dataSource?.name,
+    dbType: dataSource?.dbType,
+    database: undefined,
+    schema: undefined,
+  });
+
+export const selectSqlDatabaseContext = (
+  nodeId: DevelopmentId,
+  database?: string,
+) =>
+  updateSqlMetadataContext(nodeId, {
+    database,
+    schema: undefined,
+  });
+
+export const selectSqlSchemaContext = (
+  nodeId: DevelopmentId,
+  schema?: string,
+) => updateSqlMetadataContext(nodeId, { schema });
+
+export const useSqlMetadataContext = (nodeId: DevelopmentId) => {
+  useSyncExternalStore(subscribe, getVersion, getVersion);
+  return ensureSqlMetadataContext(nodeId);
+};

--- a/yak-ops-ui/src/pages/data-development/editors/sql/metadata/sqlMetadataService.ts
+++ b/yak-ops-ui/src/pages/data-development/editors/sql/metadata/sqlMetadataService.ts
@@ -1,0 +1,101 @@
+import { API_SUCCESS_CODE } from '@/services/http/response';
+import HttpUtils from '@/utils/HttpUtils';
+
+export interface SqlDataSourceOption {
+  label: string;
+  value: string;
+  dbType?: string;
+}
+
+export interface SqlCatalogTable {
+  database?: string | null;
+  schema?: string | null;
+  name: string;
+  type?: string | null;
+  remarks?: string | null;
+}
+
+export interface SqlCatalogColumn {
+  name: string;
+  typeName?: string | null;
+  jdbcType?: number | null;
+  size?: number | null;
+  scale?: number | null;
+  nullable?: boolean | null;
+  ordinalPosition?: number | null;
+  primaryKey?: boolean | null;
+  remarks?: string | null;
+}
+
+interface ApiResponse<T> {
+  code?: number;
+  data?: T;
+  msg?: string;
+  message?: string;
+}
+
+const DATA_SOURCE_API = '/api/v1/data-source';
+const CATALOG_API = `${DATA_SOURCE_API}/catalog`;
+
+const responseData = <T,>(response: ApiResponse<T>, fallback: string): T => {
+  if (response?.code !== API_SUCCESS_CODE || response.data === undefined) {
+    throw new Error(response?.message || response?.msg || fallback);
+  }
+  return response.data;
+};
+
+const queryString = (params: Record<string, string | undefined>) => {
+  const search = new URLSearchParams();
+  Object.entries(params).forEach(([key, value]) => {
+    if (value?.trim()) search.set(key, value.trim());
+  });
+  const query = search.toString();
+  return query ? `?${query}` : '';
+};
+
+export const listSqlDataSources = async (): Promise<SqlDataSourceOption[]> =>
+  responseData(
+    await HttpUtils.get<SqlDataSourceOption[]>(`${DATA_SOURCE_API}/option`),
+    '查询数据源失败',
+  );
+
+export const listSqlDatabases = async (
+  dataSourceId: string,
+): Promise<string[]> =>
+  responseData(
+    await HttpUtils.get<string[]>(`${CATALOG_API}/${dataSourceId}/databases`),
+    '查询数据库失败',
+  );
+
+export const listSqlSchemas = async (
+  dataSourceId: string,
+  database?: string,
+): Promise<string[]> =>
+  responseData(
+    await HttpUtils.get<string[]>(
+      `${CATALOG_API}/${dataSourceId}/schemas${queryString({ database })}`,
+    ),
+    '查询 Schema 失败',
+  );
+
+export const listSqlTables = async (
+  dataSourceId: string,
+  options: { database?: string; schema?: string; keyword?: string } = {},
+): Promise<SqlCatalogTable[]> =>
+  responseData(
+    await HttpUtils.get<SqlCatalogTable[]>(
+      `${CATALOG_API}/${dataSourceId}/tables${queryString(options)}`,
+    ),
+    '查询表元数据失败',
+  );
+
+export const listSqlColumns = async (
+  dataSourceId: string,
+  options: { database?: string; schema?: string; table: string },
+): Promise<SqlCatalogColumn[]> =>
+  responseData(
+    await HttpUtils.get<SqlCatalogColumn[]>(
+      `${CATALOG_API}/${dataSourceId}/columns${queryString(options)}`,
+    ),
+    '查询字段元数据失败',
+  );


### PR DESCRIPTION
## 变更说明

继续 SQL 编辑器第四阶段：在 Monaco、EditorSession 和基础 SQL 补全之上，接入 Yak Ops 已有 Datasource Catalog 元数据能力，让 SQL 编辑器开始理解当前数据源、Database、Schema、Table 和 Column 上下文。

本阶段继续遵循“小步迁移”的原则：只做编辑期元数据上下文和补全，不恢复旧 SQL 专业后端，不接 SQL 执行、保存、Parser 或结果集。

## 本阶段实现

### 1. SQL 元数据上下文

SQL 右侧「运行配置」现在提供轻量元数据上下文选择：

- 数据源
- Database
- Schema

选择结果按 SQL `nodeId` 隔离，并保存到 localStorage。切换 SQL Tab、关闭后重新打开或刷新页面后，当前编辑上下文仍可恢复。

这份上下文只服务当前编辑器的补全体验，不伪装成后端已经持久化的 SQL 任务配置。后续正式保存/运行接入时再把它升级为真实任务配置。

### 2. 复用现有 Yak Ops Catalog API

前端直接复用当前 datasource 模块已经存在的受控接口：

- `GET /api/v1/data-source/option`
- `GET /api/v1/data-source/catalog/{id}/databases`
- `GET /api/v1/data-source/catalog/{id}/schemas`
- `GET /api/v1/data-source/catalog/{id}/tables`
- `GET /api/v1/data-source/catalog/{id}/columns`

浏览器只持有数据源 ID 和元数据，不读取连接密码，也不直接连接数据库；真实 Catalog 访问仍由 Yak Ops datasource plugin 在后端完成。

### 3. Table 补全

选好数据源上下文后，在以下位置输入表名前缀会从 Catalog 返回 Table / View 候选：

```sql
SELECT * FROM us
JOIN ord
UPDATE us
INSERT INTO ord
```

候选详情会显示 Table/View 类型以及可用的 Database / Schema 信息。

### 4. Column / Alias 补全

支持轻量解析当前 SQL statement 中的 `FROM / JOIN` 表引用和别名：

```sql
SELECT *
FROM users u
WHERE u.
```

此时 `u.` 会通过 Catalog 查询 `users` 的真实字段并给出 Column 候选，包括：

- 字段名
- 数据类型
- 主键标识
- 字段备注

也支持：

```sql
users.
```

以及只有一个表引用时的裸字段补全。

为了支持常见的 `SELECT u.| FROM users u` 编辑顺序，别名解析会读取光标所在的当前 SQL statement，而不只读取光标之前的文本。

### 5. Database / Schema 兼容

当前轻量限定名规则：

- MySQL / MariaDB / Doris：两段名称按 `database.table` 理解
- 其他数据库：两段名称按 `schema.table` 理解
- 三段名称按 `database.schema.table` 理解

完整数据库方言解析仍留给后续 SQL Parser 阶段，本 PR 不尝试自己实现完整 SQL AST。

### 6. 元数据缓存

Table / Column 元数据增加 60 秒前端短期缓存，并合并同 Key 的并发请求，减少用户连续输入时重复打 Catalog 接口。

切换数据源 / Database / Schema 时使用不同缓存 Key，不会串上下文。

### 7. 降级策略

元数据补全是 best-effort：

- 未选择数据源时，第三阶段的 SQL 关键字 / 内置函数补全继续正常工作
- Catalog 请求失败时，不影响 Monaco 编辑和基础补全
- 字符串、注释、引号标识符内部仍遵循第三阶段的防打扰规则

## 结构

新增：

```text
editors/sql/
├── completion/
│   └── registerSqlMetadataCompletion.ts
└── metadata/
    ├── SqlMetadataContextPanel.tsx
    ├── sqlMetadataService.ts
    ├── sqlMetadataContextStore.ts
    └── sqlMetadataCache.ts
```

`SqlMonacoEditor` 只负责挂载/释放 Provider 和绑定 Monaco Model -> nodeId，不直接承载 Catalog 请求逻辑。

## 与 Chat2DB 的关系

继续采用“能力蒸馏 + Yak Ops 独立实现”。本阶段参考成熟 SQL 编辑器把元数据 Context、Catalog、Completion Provider 分层的思路，但实现完全围绕 Yak Ops 自己已经存在的 Datasource Catalog API 和当前 Workbench 架构完成，没有复制 Chat2DB 当前版本源码。

## 明确不做

本阶段仍不实现：

- SQL 配置后端持久化
- SQL 保存 / 发布
- SQL 执行与结果集
- 完整 SQL Parser / AST
- Marker / Hover / 语法诊断
- 多 statement / CTE / 子查询的完整作用域解析
- 多表裸字段的歧义消解
- 方言级函数和关键字管理
- SQL 格式化

这些继续拆成后续独立阶段。

## 影响范围

仅修改 `yak-ops-ui` SQL Editor，7 个文件变更；不修改后端接口、数据库迁移、Shell 编辑器和通用 EditorSession。

## 建议回归

- 打开 SQL 节点 -> 运行配置，选择数据源 / Database / Schema
- 输入 `SELECT * FROM us`，确认出现真实表候选
- 输入 `SELECT * FROM users u WHERE u.`，确认出现 users 字段
- 输入 `SELECT u. FROM users u` 并在 `u.` 后唤起补全，确认能解析光标后面的 FROM 别名
- 单表 SQL 中输入字段前缀，确认出现字段候选
- 多个 SQL 节点选择不同数据源，确认 Context 相互隔离
- 刷新后重新打开节点，确认 Context 恢复
- 清空数据源，确认关键字 / 内置函数补全仍正常
- Catalog 不可用时，确认编辑器不会失效
