### PR TITLE
feat(data-development): add advanced SQL editor assistance

### DIFF
--- a/yak-ops-ui/src/pages/data-development/editors/sql/assistance/registerSqlHover.ts
+++ b/yak-ops-ui/src/pages/data-development/editors/sql/assistance/registerSqlHover.ts
@@ -50,10 +50,10 @@ const isFunctionCall = (
   return /^\s*\(/.test(line.slice(word.endColumn - 1));
 };
 
-const tablePath = (table: SqlCatalogTable | SqlTableReference) =>
-  [table.database, table.schema, table.table ?? (table as SqlCatalogTable).name]
-    .filter(Boolean)
-    .join('.');
+const tablePath = (value: SqlCatalogTable | SqlTableReference) => {
+  const tableName = 'table' in value ? value.table : value.name;
+  return [value.database, value.schema, tableName].filter(Boolean).join('.');
+};
 
 const columnHover = (
   range: monaco.Range,

--- a/yak-ops-ui/src/pages/data-development/editors/sql/assistance/registerSqlHover.ts
+++ b/yak-ops-ui/src/pages/data-development/editors/sql/assistance/registerSqlHover.ts
@@ -1,0 +1,232 @@
+import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
+
+import { SQL_BUILTIN_FUNCTIONS } from '../completion/sqlBuiltinCatalog';
+import { loadSqlColumns, loadSqlTables } from '../metadata/sqlMetadataCache';
+import { getSqlMetadataContext } from '../metadata/sqlMetadataContextStore';
+import type {
+  SqlCatalogColumn,
+  SqlCatalogTable,
+} from '../metadata/sqlMetadataService';
+import {
+  findSqlTableReference,
+  getCurrentSqlStatementText,
+  getSqlEditorNodeId,
+  getSqlLexicalState,
+  getSqlQualifierBeforeWord,
+  getSqlTextBeforePosition,
+  parseSqlTableReferences,
+  type SqlTableReference,
+} from './sqlTextContext';
+
+let providerDisposable: monaco.IDisposable | undefined;
+let providerConsumers = 0;
+
+const builtinFunctionMap = new Map(
+  SQL_BUILTIN_FUNCTIONS.map((definition) => [definition.name.toUpperCase(), definition]),
+);
+
+const escapeMarkdown = (value: string) =>
+  value.replace(/([\\`*_{}\[\]()#+\-.!|>])/g, '\\$1');
+
+const inlineCode = (value: string) => `\`${value.replace(/`/g, '\\`')}\``;
+
+const wordRange = (
+  position: monaco.Position,
+  word: monaco.editor.IWordAtPosition,
+) =>
+  new monaco.Range(
+    position.lineNumber,
+    word.startColumn,
+    position.lineNumber,
+    word.endColumn,
+  );
+
+const isFunctionCall = (
+  model: monaco.editor.ITextModel,
+  position: monaco.Position,
+  word: monaco.editor.IWordAtPosition,
+) => {
+  const line = model.getLineContent(position.lineNumber);
+  return /^\s*\(/.test(line.slice(word.endColumn - 1));
+};
+
+const tablePath = (table: SqlCatalogTable | SqlTableReference) =>
+  [table.database, table.schema, table.table ?? (table as SqlCatalogTable).name]
+    .filter(Boolean)
+    .join('.');
+
+const columnHover = (
+  range: monaco.Range,
+  column: SqlCatalogColumn,
+  reference: SqlTableReference,
+): monaco.languages.Hover => {
+  const flags = [
+    column.primaryKey ? 'PRIMARY KEY' : undefined,
+    column.nullable === false ? 'NOT NULL' : undefined,
+  ].filter(Boolean);
+  const type = column.typeName || '未知类型';
+  const owner = reference.alias
+    ? `${reference.alias} → ${tablePath(reference)}`
+    : tablePath(reference);
+
+  const contents: monaco.IMarkdownString[] = [
+    {
+      value: `**字段** ${inlineCode(column.name)} · ${inlineCode(type)}`,
+    },
+    {
+      value: `来源：${inlineCode(owner)}${flags.length ? ` · ${flags.join(' · ')}` : ''}`,
+    },
+  ];
+
+  if (column.size != null) {
+    contents.push({
+      value: `长度：${column.size}${column.scale != null ? `，精度：${column.scale}` : ''}`,
+    });
+  }
+  if (column.remarks?.trim()) {
+    contents.push({ value: escapeMarkdown(column.remarks.trim()) });
+  }
+
+  return { range, contents };
+};
+
+const tableHover = (
+  range: monaco.Range,
+  reference: SqlTableReference,
+  table?: SqlCatalogTable,
+): monaco.languages.Hover => {
+  const alias = reference.alias ? ` · 别名 ${inlineCode(reference.alias)}` : '';
+  const type = table?.type || 'TABLE';
+  const contents: monaco.IMarkdownString[] = [
+    {
+      value: `**${escapeMarkdown(type)}** ${inlineCode(tablePath(reference))}${alias}`,
+    },
+  ];
+
+  if (table?.remarks?.trim()) {
+    contents.push({ value: escapeMarkdown(table.remarks.trim()) });
+  }
+
+  return { range, contents };
+};
+
+const findCatalogTable = async (
+  reference: SqlTableReference,
+  context: NonNullable<ReturnType<typeof getSqlMetadataContext>>,
+) => {
+  const tables = await loadSqlTables(context, {
+    database: reference.database,
+    schema: reference.schema,
+  });
+  return tables.find(
+    (table) => table.name.toLowerCase() === reference.table.toLowerCase(),
+  );
+};
+
+const provideHover = async (
+  model: monaco.editor.ITextModel,
+  position: monaco.Position,
+  token: monaco.CancellationToken,
+): Promise<monaco.languages.Hover | undefined> => {
+  const word = model.getWordAtPosition(position);
+  if (!word) return undefined;
+
+  const textBeforePosition = getSqlTextBeforePosition(model, position);
+  if (getSqlLexicalState(textBeforePosition) !== 'code') return undefined;
+
+  const range = wordRange(position, word);
+  const builtin = builtinFunctionMap.get(word.word.toUpperCase());
+  if (builtin && isFunctionCall(model, position, word)) {
+    return {
+      range,
+      contents: [
+        { value: `**SQL 函数** ${inlineCode(builtin.signature)}` },
+        { value: escapeMarkdown(builtin.description) },
+      ],
+    };
+  }
+
+  const nodeId = getSqlEditorNodeId(model);
+  const context = nodeId ? getSqlMetadataContext(nodeId) : undefined;
+  if (!context?.dataSourceId) return undefined;
+
+  const references = parseSqlTableReferences(
+    getCurrentSqlStatementText(model, position),
+    context,
+  );
+  if (!references.length) return undefined;
+
+  try {
+    const qualifier = getSqlQualifierBeforeWord(
+      model,
+      position,
+      word.startColumn,
+    );
+
+    if (qualifier) {
+      const reference = findSqlTableReference(qualifier, references);
+      if (!reference) return undefined;
+
+      const columns = await loadSqlColumns(context, reference.table, {
+        database: reference.database,
+        schema: reference.schema,
+      });
+      if (token.isCancellationRequested) return undefined;
+      const column = columns.find(
+        (item) => item.name.toLowerCase() === word.word.toLowerCase(),
+      );
+      return column ? columnHover(range, column, reference) : undefined;
+    }
+
+    const tableReference = references.find(
+      (reference) =>
+        reference.table.toLowerCase() === word.word.toLowerCase() ||
+        reference.alias?.toLowerCase() === word.word.toLowerCase(),
+    );
+    if (tableReference) {
+      const table = await findCatalogTable(tableReference, context);
+      if (token.isCancellationRequested) return undefined;
+      return tableHover(range, tableReference, table);
+    }
+
+    if (references.length === 1) {
+      const reference = references[0];
+      const columns = await loadSqlColumns(context, reference.table, {
+        database: reference.database,
+        schema: reference.schema,
+      });
+      if (token.isCancellationRequested) return undefined;
+      const column = columns.find(
+        (item) => item.name.toLowerCase() === word.word.toLowerCase(),
+      );
+      return column ? columnHover(range, column, reference) : undefined;
+    }
+  } catch {
+    // Hover is best-effort and must never block editing when Catalog is unavailable.
+  }
+
+  return undefined;
+};
+
+const createProvider = () =>
+  monaco.languages.registerHoverProvider('sql', {
+    provideHover,
+  });
+
+export const acquireSqlHoverProvider = (): monaco.IDisposable => {
+  providerConsumers += 1;
+  if (!providerDisposable) providerDisposable = createProvider();
+
+  let released = false;
+  return {
+    dispose: () => {
+      if (released) return;
+      released = true;
+      providerConsumers = Math.max(0, providerConsumers - 1);
+      if (providerConsumers > 0) return;
+
+      providerDisposable?.dispose();
+      providerDisposable = undefined;
+    },
+  };
+};

--- a/yak-ops-ui/src/pages/data-development/editors/sql/assistance/registerSqlSignatureHelp.ts
+++ b/yak-ops-ui/src/pages/data-development/editors/sql/assistance/registerSqlSignatureHelp.ts
@@ -1,0 +1,178 @@
+import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
+
+import { SQL_BUILTIN_FUNCTIONS } from '../completion/sqlBuiltinCatalog';
+
+interface FunctionFrame {
+  name?: string;
+  commas: number;
+}
+
+type ScanState =
+  | 'code'
+  | 'single-quote'
+  | 'double-quote'
+  | 'backtick'
+  | 'line-comment'
+  | 'block-comment';
+
+let providerDisposable: monaco.IDisposable | undefined;
+let providerConsumers = 0;
+
+const functionMap = new Map(
+  SQL_BUILTIN_FUNCTIONS.map((definition) => [definition.name.toUpperCase(), definition]),
+);
+
+const previousIdentifier = (text: string, offset: number) =>
+  text.slice(0, offset).match(/([A-Za-z_][\w$]*)\s*$/)?.[1];
+
+const findActiveFunction = (text: string): FunctionFrame | undefined => {
+  const stack: FunctionFrame[] = [];
+  let state: ScanState = 'code';
+
+  for (let index = 0; index < text.length; index += 1) {
+    const current = text[index];
+    const next = text[index + 1];
+
+    if (state === 'line-comment') {
+      if (current === '\n') state = 'code';
+      continue;
+    }
+    if (state === 'block-comment') {
+      if (current === '*' && next === '/') {
+        state = 'code';
+        index += 1;
+      }
+      continue;
+    }
+    if (state === 'single-quote') {
+      if (current === "'" && next === "'") {
+        index += 1;
+        continue;
+      }
+      if (current === "'") state = 'code';
+      continue;
+    }
+    if (state === 'double-quote') {
+      if (current === '"' && next === '"') {
+        index += 1;
+        continue;
+      }
+      if (current === '"') state = 'code';
+      continue;
+    }
+    if (state === 'backtick') {
+      if (current === '`' && next === '`') {
+        index += 1;
+        continue;
+      }
+      if (current === '`') state = 'code';
+      continue;
+    }
+
+    if (current === '-' && next === '-') {
+      state = 'line-comment';
+      index += 1;
+      continue;
+    }
+    if (current === '/' && next === '*') {
+      state = 'block-comment';
+      index += 1;
+      continue;
+    }
+    if (current === "'") {
+      state = 'single-quote';
+      continue;
+    }
+    if (current === '"') {
+      state = 'double-quote';
+      continue;
+    }
+    if (current === '`') {
+      state = 'backtick';
+      continue;
+    }
+
+    if (current === '(') {
+      const name = previousIdentifier(text, index);
+      stack.push({ name, commas: 0 });
+      continue;
+    }
+    if (current === ')') {
+      stack.pop();
+      continue;
+    }
+    if (current === ',' && stack.length) {
+      stack[stack.length - 1].commas += 1;
+    }
+  }
+
+  for (let index = stack.length - 1; index >= 0; index -= 1) {
+    const frame = stack[index];
+    if (frame.name && functionMap.has(frame.name.toUpperCase())) return frame;
+  }
+  return undefined;
+};
+
+const signatureParameters = (signature: string) => {
+  const start = signature.indexOf('(');
+  const end = signature.lastIndexOf(')');
+  if (start < 0 || end <= start + 1) return [];
+
+  const content = signature.slice(start + 1, end).trim();
+  if (!content) return [];
+  return content.split(/\s*,\s*/).map((label) => ({ label }));
+};
+
+const createProvider = () =>
+  monaco.languages.registerSignatureHelpProvider('sql', {
+    signatureHelpTriggerCharacters: ['(', ','],
+    signatureHelpRetriggerCharacters: [','],
+    provideSignatureHelp: (model, position) => {
+      const text = model.getValueInRange(
+        new monaco.Range(1, 1, position.lineNumber, position.column),
+      );
+      const frame = findActiveFunction(text);
+      if (!frame?.name) return undefined;
+
+      const definition = functionMap.get(frame.name.toUpperCase());
+      if (!definition) return undefined;
+
+      const parameters = signatureParameters(definition.signature);
+      const activeParameter = parameters.length
+        ? Math.min(frame.commas, parameters.length - 1)
+        : 0;
+
+      return {
+        value: {
+          signatures: [
+            {
+              label: definition.signature,
+              documentation: definition.description,
+              parameters,
+            },
+          ],
+          activeSignature: 0,
+          activeParameter,
+        },
+        dispose: () => undefined,
+      };
+    },
+  });
+
+export const acquireSqlSignatureHelpProvider = (): monaco.IDisposable => {
+  providerConsumers += 1;
+  if (!providerDisposable) providerDisposable = createProvider();
+
+  let released = false;
+  return {
+    dispose: () => {
+      if (released) return;
+      released = true;
+      providerConsumers = Math.max(0, providerConsumers - 1);
+      if (providerConsumers > 0) return;
+
+      providerDisposable?.dispose();
+      providerDisposable = undefined;
+    },
+  };
+};

--- a/yak-ops-ui/src/pages/data-development/editors/sql/assistance/sqlTextContext.ts
+++ b/yak-ops-ui/src/pages/data-development/editors/sql/assistance/sqlTextContext.ts
@@ -1,0 +1,281 @@
+import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
+
+import type { DevelopmentId } from '../../../types';
+import type { SqlMetadataContext } from '../metadata/sqlMetadataContextStore';
+
+export type SqlLexicalState =
+  | 'code'
+  | 'single-quote'
+  | 'double-quote'
+  | 'backtick'
+  | 'bracket-identifier'
+  | 'line-comment'
+  | 'block-comment';
+
+export interface SqlTableReference {
+  database?: string;
+  schema?: string;
+  table: string;
+  alias?: string;
+}
+
+const STOP_ALIAS_WORDS = new Set([
+  'WHERE',
+  'JOIN',
+  'LEFT',
+  'RIGHT',
+  'FULL',
+  'INNER',
+  'OUTER',
+  'CROSS',
+  'ON',
+  'GROUP',
+  'ORDER',
+  'HAVING',
+  'LIMIT',
+  'OFFSET',
+  'UNION',
+  'EXCEPT',
+  'INTERSECT',
+  'SET',
+  'VALUES',
+  'RETURNING',
+]);
+
+const identifierPart =
+  '(?:`[^`]+`|"[^"]+"|\\[[^\\]]+\\]|[A-Za-z_$][\\w$]*)';
+const qualifiedIdentifier = `${identifierPart}(?:\\s*\\.\\s*${identifierPart}){0,2}`;
+const tableReferencePattern = new RegExp(
+  `\\b(?:FROM|JOIN)\\s+(${qualifiedIdentifier})(?:\\s+(?:AS\\s+)?([A-Za-z_$][\\w$]*))?`,
+  'gi',
+);
+
+export const getSqlTextBeforePosition = (
+  model: monaco.editor.ITextModel,
+  position: monaco.Position,
+) =>
+  model.getValueInRange(
+    new monaco.Range(1, 1, position.lineNumber, position.column),
+  );
+
+export const getCurrentSqlStatementText = (
+  model: monaco.editor.ITextModel,
+  position: monaco.Position,
+) => {
+  const sql = model.getValue();
+  const offset = model.getOffsetAt(position);
+  const start = sql.lastIndexOf(';', Math.max(0, offset - 1)) + 1;
+  const nextSeparator = sql.indexOf(';', offset);
+  const end = nextSeparator < 0 ? sql.length : nextSeparator;
+  return sql.slice(start, end);
+};
+
+export const getSqlLexicalState = (text: string): SqlLexicalState => {
+  let state: SqlLexicalState = 'code';
+
+  for (let index = 0; index < text.length; index += 1) {
+    const current = text[index];
+    const next = text[index + 1];
+
+    if (state === 'line-comment') {
+      if (current === '\n') state = 'code';
+      continue;
+    }
+    if (state === 'block-comment') {
+      if (current === '*' && next === '/') {
+        state = 'code';
+        index += 1;
+      }
+      continue;
+    }
+    if (state === 'single-quote') {
+      if (current === "'" && next === "'") {
+        index += 1;
+        continue;
+      }
+      if (current === "'") state = 'code';
+      continue;
+    }
+    if (state === 'double-quote') {
+      if (current === '"' && next === '"') {
+        index += 1;
+        continue;
+      }
+      if (current === '"') state = 'code';
+      continue;
+    }
+    if (state === 'backtick') {
+      if (current === '`' && next === '`') {
+        index += 1;
+        continue;
+      }
+      if (current === '`') state = 'code';
+      continue;
+    }
+    if (state === 'bracket-identifier') {
+      if (current === ']' && next === ']') {
+        index += 1;
+        continue;
+      }
+      if (current === ']') state = 'code';
+      continue;
+    }
+
+    if (current === '-' && next === '-') {
+      state = 'line-comment';
+      index += 1;
+    } else if (current === '/' && next === '*') {
+      state = 'block-comment';
+      index += 1;
+    } else if (current === "'") {
+      state = 'single-quote';
+    } else if (current === '"') {
+      state = 'double-quote';
+    } else if (current === '`') {
+      state = 'backtick';
+    } else if (current === '[') {
+      state = 'bracket-identifier';
+    }
+  }
+
+  return state;
+};
+
+const stripQuotedValue = (value: string) => {
+  const normalized = value.trim();
+  if (
+    (normalized.startsWith('`') && normalized.endsWith('`')) ||
+    (normalized.startsWith('"') && normalized.endsWith('"')) ||
+    (normalized.startsWith('[') && normalized.endsWith(']'))
+  ) {
+    return normalized.slice(1, -1);
+  }
+  return normalized;
+};
+
+const splitQualifiedIdentifier = (value: string) => {
+  const parts: string[] = [];
+  let current = '';
+  let quote: '`' | '"' | '[' | undefined;
+
+  for (let index = 0; index < value.length; index += 1) {
+    const char = value[index];
+    if (!quote && (char === '`' || char === '"' || char === '[')) {
+      quote = char as '`' | '"' | '[';
+      current += char;
+      continue;
+    }
+    if (quote === '`' && char === '`') quote = undefined;
+    else if (quote === '"' && char === '"') quote = undefined;
+    else if (quote === '[' && char === ']') quote = undefined;
+
+    if (!quote && char === '.') {
+      if (current.trim()) parts.push(stripQuotedValue(current));
+      current = '';
+      continue;
+    }
+    current += char;
+  }
+
+  if (current.trim()) parts.push(stripQuotedValue(current));
+  return parts;
+};
+
+const tableReferenceFromParts = (
+  parts: string[],
+  alias: string | undefined,
+  context: SqlMetadataContext,
+): SqlTableReference | undefined => {
+  if (!parts.length) return undefined;
+  const table = parts[parts.length - 1];
+  if (!table) return undefined;
+
+  if (parts.length >= 3) {
+    return {
+      database: parts[parts.length - 3],
+      schema: parts[parts.length - 2],
+      table,
+      alias,
+    };
+  }
+
+  if (parts.length === 2) {
+    const first = parts[0];
+    const mysqlLike = ['MYSQL', 'MARIADB', 'DORIS'].includes(
+      (context.dbType || '').toUpperCase(),
+    );
+    return mysqlLike
+      ? { database: first, table, alias }
+      : { database: context.database, schema: first, table, alias };
+  }
+
+  return {
+    database: context.database,
+    schema: context.schema,
+    table,
+    alias,
+  };
+};
+
+export const parseSqlTableReferences = (
+  sql: string,
+  context: SqlMetadataContext,
+): SqlTableReference[] => {
+  const references: SqlTableReference[] = [];
+  tableReferencePattern.lastIndex = 0;
+  let match = tableReferencePattern.exec(sql);
+
+  while (match) {
+    const rawAlias = match[2];
+    const alias =
+      rawAlias && !STOP_ALIAS_WORDS.has(rawAlias.toUpperCase())
+        ? rawAlias
+        : undefined;
+    const reference = tableReferenceFromParts(
+      splitQualifiedIdentifier(match[1]),
+      alias,
+      context,
+    );
+    if (reference) references.push(reference);
+    match = tableReferencePattern.exec(sql);
+  }
+
+  return references;
+};
+
+export const findSqlTableReference = (
+  qualifier: string,
+  references: SqlTableReference[],
+) => {
+  const normalized = qualifier.toLowerCase();
+  return references.find(
+    (reference) =>
+      reference.alias?.toLowerCase() === normalized ||
+      reference.table.toLowerCase() === normalized,
+  );
+};
+
+export const getSqlQualifierBeforeWord = (
+  model: monaco.editor.ITextModel,
+  position: monaco.Position,
+  wordStartColumn: number,
+) => {
+  const line = model.getLineContent(position.lineNumber);
+  const beforeWord = line.slice(0, Math.max(0, wordStartColumn - 1));
+  return beforeWord.match(/([A-Za-z_$][\w$]*)\s*\.\s*$/)?.[1];
+};
+
+export const getSqlEditorNodeId = (
+  model: monaco.editor.ITextModel,
+): DevelopmentId | undefined => {
+  const filename = model.uri.path.split('/').pop();
+  if (!filename?.endsWith('.sql')) return undefined;
+  const encoded = filename.slice(0, -4);
+  if (!encoded) return undefined;
+
+  try {
+    return decodeURIComponent(encoded);
+  } catch {
+    return encoded;
+  }
+};

--- a/yak-ops-ui/src/pages/data-development/editors/sql/completion/registerSqlSnippetCompletion.ts
+++ b/yak-ops-ui/src/pages/data-development/editors/sql/completion/registerSqlSnippetCompletion.ts
@@ -1,0 +1,80 @@
+import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
+
+import {
+  getSqlLexicalState,
+  getSqlTextBeforePosition,
+} from '../assistance/sqlTextContext';
+import { SQL_SNIPPETS } from './sqlSnippetCatalog';
+
+let providerDisposable: monaco.IDisposable | undefined;
+let providerConsumers = 0;
+
+const createProvider = () =>
+  monaco.languages.registerCompletionItemProvider('sql', {
+    provideCompletionItems: (model, position, context) => {
+      const textBeforePosition = getSqlTextBeforePosition(model, position);
+      if (getSqlLexicalState(textBeforePosition) !== 'code') {
+        return { suggestions: [] };
+      }
+
+      const word = model.getWordUntilPosition(position);
+      const prefix = word.word.toLowerCase();
+      const manualInvoke =
+        context.triggerKind === monaco.languages.CompletionTriggerKind.Invoke;
+
+      if (!manualInvoke && prefix.length < 2) {
+        return { suggestions: [] };
+      }
+
+      if (word.startColumn > 1) {
+        const beforeWord = model.getValueInRange(
+          new monaco.Range(
+            position.lineNumber,
+            word.startColumn - 1,
+            position.lineNumber,
+            word.startColumn,
+          ),
+        );
+        if (beforeWord === '.') return { suggestions: [] };
+      }
+
+      const range = new monaco.Range(
+        position.lineNumber,
+        word.startColumn,
+        position.lineNumber,
+        word.endColumn,
+      );
+
+      return {
+        suggestions: SQL_SNIPPETS.map((snippet, index) => ({
+          label: snippet.label,
+          kind: monaco.languages.CompletionItemKind.Snippet,
+          insertText: snippet.body,
+          insertTextRules:
+            monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet,
+          filterText: `${snippet.prefix} ${snippet.label}`,
+          detail: `${snippet.detail} · 输入 ${snippet.prefix}`,
+          sortText: `0-${String(index).padStart(2, '0')}-${snippet.prefix}`,
+          range,
+        })),
+      };
+    },
+  });
+
+export const acquireSqlSnippetCompletionProvider = (): monaco.IDisposable => {
+  providerConsumers += 1;
+  if (!providerDisposable) providerDisposable = createProvider();
+
+  let released = false;
+  return {
+    dispose: () => {
+      if (released) return;
+      released = true;
+      providerConsumers = Math.max(0, providerConsumers - 1);
+      if (providerConsumers > 0) return;
+
+      providerDisposable?.dispose();
+      providerDisposable = undefined;
+    },
+  };
+};

--- a/yak-ops-ui/src/pages/data-development/editors/sql/completion/sqlSnippetCatalog.ts
+++ b/yak-ops-ui/src/pages/data-development/editors/sql/completion/sqlSnippetCatalog.ts
@@ -1,0 +1,56 @@
+export interface SqlSnippetDefinition {
+  prefix: string;
+  label: string;
+  detail: string;
+  body: string;
+}
+
+export const SQL_SNIPPETS: SqlSnippetDefinition[] = [
+  {
+    prefix: 'sel',
+    label: 'SELECT … FROM',
+    detail: '基础查询模板',
+    body: 'SELECT ${1:*}\nFROM ${2:table_name}\n${0}',
+  },
+  {
+    prefix: 'selw',
+    label: 'SELECT … WHERE',
+    detail: '带过滤条件的查询模板',
+    body: 'SELECT ${1:*}\nFROM ${2:table_name}\nWHERE ${3:condition};\n${0}',
+  },
+  {
+    prefix: 'joinq',
+    label: 'SELECT … JOIN',
+    detail: '双表 JOIN 查询模板',
+    body:
+      'SELECT ${1:a.*}\nFROM ${2:table_a} ${3:a}\nJOIN ${4:table_b} ${5:b}\n  ON ${6:a.id = b.id}\nWHERE ${7:1 = 1};\n${0}',
+  },
+  {
+    prefix: 'cte',
+    label: 'WITH CTE',
+    detail: '公共表表达式模板',
+    body:
+      'WITH ${1:cte_name} AS (\n  SELECT ${2:*}\n  FROM ${3:table_name}\n)\nSELECT ${4:*}\nFROM ${1:cte_name};\n${0}',
+  },
+  {
+    prefix: 'casew',
+    label: 'CASE WHEN',
+    detail: '条件表达式模板',
+    body:
+      'CASE\n  WHEN ${1:condition} THEN ${2:value}\n  ELSE ${3:fallback}\nEND${0}',
+  },
+  {
+    prefix: 'ins',
+    label: 'INSERT INTO',
+    detail: '插入数据模板',
+    body:
+      'INSERT INTO ${1:table_name} (${2:column_name})\nVALUES (${3:value});\n${0}',
+  },
+  {
+    prefix: 'upd',
+    label: 'UPDATE … SET',
+    detail: '更新数据模板',
+    body:
+      'UPDATE ${1:table_name}\nSET ${2:column_name} = ${3:value}\nWHERE ${4:condition};\n${0}',
+  },
+];

--- a/yak-ops-ui/src/pages/data-development/editors/sql/components/SqlMonacoEditor.tsx
+++ b/yak-ops-ui/src/pages/data-development/editors/sql/components/SqlMonacoEditor.tsx
@@ -3,11 +3,15 @@ import 'monaco-editor/esm/vs/basic-languages/sql/sql.contribution';
 import { useEffect, useRef } from 'react';
 
 import type { DevelopmentEditorViewState } from '../../session/types';
+import { acquireSqlHoverProvider } from '../assistance/registerSqlHover';
+import { acquireSqlSignatureHelpProvider } from '../assistance/registerSqlSignatureHelp';
 import { acquireSqlBuiltinCompletionProvider } from '../completion/registerSqlBuiltinCompletion';
 import {
   acquireSqlMetadataCompletionProvider,
   bindSqlMetadataModel,
 } from '../completion/registerSqlMetadataCompletion';
+import { acquireSqlSnippetCompletionProvider } from '../completion/registerSqlSnippetCompletion';
+import { bindSqlDiagnostics } from '../diagnostics/bindSqlDiagnostics';
 import { setupMonacoEnvironment } from '../monaco/setupMonacoEnvironment';
 
 export interface SqlEditorPosition {
@@ -89,6 +93,9 @@ const SqlMonacoEditor = ({
     ensureYakSqlTheme();
     const builtinCompletionProvider = acquireSqlBuiltinCompletionProvider();
     const metadataCompletionProvider = acquireSqlMetadataCompletionProvider();
+    const snippetCompletionProvider = acquireSqlSnippetCompletionProvider();
+    const hoverProvider = acquireSqlHoverProvider();
+    const signatureHelpProvider = acquireSqlSignatureHelpProvider();
 
     const uri = monaco.Uri.parse(
       `inmemory://yak-ops/data-development/sql/${encodeURIComponent(id)}.sql`,
@@ -97,6 +104,7 @@ const SqlMonacoEditor = ({
 
     const model = monaco.editor.createModel(value, 'sql', uri);
     const metadataModelBinding = bindSqlMetadataModel(model.uri.toString(), id);
+    const diagnosticsBinding = bindSqlDiagnostics(model);
     const editor = monaco.editor.create(containerRef.current, {
       model,
       theme: 'yak-sql-light',
@@ -131,6 +139,8 @@ const SqlMonacoEditor = ({
       acceptSuggestionOnEnter: 'on',
       tabCompletion: 'on',
       suggestSelection: 'recentlyUsedByPrefix',
+      parameterHints: { enabled: true },
+      hover: { enabled: true, delay: 300, sticky: true },
       suggest: {
         showWords: false,
         showKeywords: true,
@@ -138,6 +148,7 @@ const SqlMonacoEditor = ({
         showFields: true,
         showStructs: true,
         showInterfaces: true,
+        showSnippets: true,
         snippetsPreventQuickSuggestions: false,
       },
       wordBasedSuggestions: 'off',
@@ -206,7 +217,11 @@ const SqlMonacoEditor = ({
       cursorDisposable.dispose();
       selectionDisposable.dispose();
       scrollDisposable.dispose();
+      diagnosticsBinding.dispose();
       metadataModelBinding.dispose();
+      signatureHelpProvider.dispose();
+      hoverProvider.dispose();
+      snippetCompletionProvider.dispose();
       metadataCompletionProvider.dispose();
       builtinCompletionProvider.dispose();
       editor.dispose();

--- a/yak-ops-ui/src/pages/data-development/editors/sql/components/SqlMonacoEditor.tsx
+++ b/yak-ops-ui/src/pages/data-development/editors/sql/components/SqlMonacoEditor.tsx
@@ -140,7 +140,7 @@ const SqlMonacoEditor = ({
       tabCompletion: 'on',
       suggestSelection: 'recentlyUsedByPrefix',
       parameterHints: { enabled: true },
-      hover: { enabled: true, delay: 300, sticky: true },
+      hover: { enabled: 'on', delay: 300, sticky: true },
       suggest: {
         showWords: false,
         showKeywords: true,

--- a/yak-ops-ui/src/pages/data-development/editors/sql/diagnostics/bindSqlDiagnostics.ts
+++ b/yak-ops-ui/src/pages/data-development/editors/sql/diagnostics/bindSqlDiagnostics.ts
@@ -1,0 +1,211 @@
+import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
+
+type SqlScanState =
+  | 'code'
+  | 'single-quote'
+  | 'double-quote'
+  | 'backtick'
+  | 'bracket-identifier'
+  | 'line-comment'
+  | 'block-comment';
+
+const MARKER_OWNER = 'yak-sql-structure';
+const MAX_PARENTHESES_MARKERS = 20;
+const DIAGNOSTIC_DELAY = 180;
+
+const markerAtOffset = (
+  model: monaco.editor.ITextModel,
+  offset: number,
+  message: string,
+): monaco.editor.IMarkerData => {
+  const valueLength = model.getValueLength();
+  const safeStart = Math.max(0, Math.min(offset, Math.max(0, valueLength - 1)));
+  const safeEnd = Math.max(safeStart + 1, Math.min(valueLength, safeStart + 1));
+  const start = model.getPositionAt(safeStart);
+  const end = model.getPositionAt(safeEnd);
+
+  return {
+    severity: monaco.MarkerSeverity.Warning,
+    message,
+    startLineNumber: start.lineNumber,
+    startColumn: start.column,
+    endLineNumber: end.lineNumber,
+    endColumn:
+      start.lineNumber === end.lineNumber && end.column <= start.column
+        ? start.column + 1
+        : end.column,
+  };
+};
+
+const analyzeSqlStructure = (
+  model: monaco.editor.ITextModel,
+): monaco.editor.IMarkerData[] => {
+  const sql = model.getValue();
+  if (!sql) return [];
+
+  const markers: monaco.editor.IMarkerData[] = [];
+  const parentheses: number[] = [];
+  let state: SqlScanState = 'code';
+  let stateStart = -1;
+
+  for (let index = 0; index < sql.length; index += 1) {
+    const current = sql[index];
+    const next = sql[index + 1];
+
+    if (state === 'line-comment') {
+      if (current === '\n') {
+        state = 'code';
+        stateStart = -1;
+      }
+      continue;
+    }
+    if (state === 'block-comment') {
+      if (current === '*' && next === '/') {
+        state = 'code';
+        stateStart = -1;
+        index += 1;
+      }
+      continue;
+    }
+    if (state === 'single-quote') {
+      if (current === "'" && next === "'") {
+        index += 1;
+        continue;
+      }
+      if (current === "'") {
+        state = 'code';
+        stateStart = -1;
+      }
+      continue;
+    }
+    if (state === 'double-quote') {
+      if (current === '"' && next === '"') {
+        index += 1;
+        continue;
+      }
+      if (current === '"') {
+        state = 'code';
+        stateStart = -1;
+      }
+      continue;
+    }
+    if (state === 'backtick') {
+      if (current === '`' && next === '`') {
+        index += 1;
+        continue;
+      }
+      if (current === '`') {
+        state = 'code';
+        stateStart = -1;
+      }
+      continue;
+    }
+    if (state === 'bracket-identifier') {
+      if (current === ']' && next === ']') {
+        index += 1;
+        continue;
+      }
+      if (current === ']') {
+        state = 'code';
+        stateStart = -1;
+      }
+      continue;
+    }
+
+    if (current === '-' && next === '-') {
+      state = 'line-comment';
+      stateStart = index;
+      index += 1;
+      continue;
+    }
+    if (current === '/' && next === '*') {
+      state = 'block-comment';
+      stateStart = index;
+      index += 1;
+      continue;
+    }
+    if (current === "'") {
+      state = 'single-quote';
+      stateStart = index;
+      continue;
+    }
+    if (current === '"') {
+      state = 'double-quote';
+      stateStart = index;
+      continue;
+    }
+    if (current === '`') {
+      state = 'backtick';
+      stateStart = index;
+      continue;
+    }
+    if (current === '[') {
+      state = 'bracket-identifier';
+      stateStart = index;
+      continue;
+    }
+
+    if (current === '(') {
+      parentheses.push(index);
+      continue;
+    }
+    if (current === ')') {
+      if (parentheses.length) {
+        parentheses.pop();
+      } else {
+        markers.push(markerAtOffset(model, index, '右括号没有匹配的左括号'));
+      }
+    }
+  }
+
+  if (state === 'block-comment' && stateStart >= 0) {
+    markers.push(markerAtOffset(model, stateStart, '块注释未闭合'));
+  } else if (state === 'single-quote' && stateStart >= 0) {
+    markers.push(markerAtOffset(model, stateStart, '字符串未闭合'));
+  } else if (
+    (state === 'double-quote' ||
+      state === 'backtick' ||
+      state === 'bracket-identifier') &&
+    stateStart >= 0
+  ) {
+    markers.push(markerAtOffset(model, stateStart, '标识符引号未闭合'));
+  }
+
+  parentheses
+    .slice(-MAX_PARENTHESES_MARKERS)
+    .forEach((offset) =>
+      markers.push(markerAtOffset(model, offset, '左括号没有匹配的右括号')),
+    );
+
+  return markers;
+};
+
+export const bindSqlDiagnostics = (
+  model: monaco.editor.ITextModel,
+): monaco.IDisposable => {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let disposed = false;
+
+  const run = () => {
+    if (disposed) return;
+    monaco.editor.setModelMarkers(model, MARKER_OWNER, analyzeSqlStructure(model));
+  };
+
+  const schedule = () => {
+    if (timer) clearTimeout(timer);
+    timer = setTimeout(run, DIAGNOSTIC_DELAY);
+  };
+
+  const contentDisposable = model.onDidChangeContent(schedule);
+  run();
+
+  return {
+    dispose: () => {
+      if (disposed) return;
+      disposed = true;
+      if (timer) clearTimeout(timer);
+      contentDisposable.dispose();
+      monaco.editor.setModelMarkers(model, MARKER_OWNER, []);
+    },
+  };
+};


### PR DESCRIPTION
## 变更说明

继续 SQL 编辑器第五阶段。本阶段不追求一次性把 Chat2DB 的高级能力全部迁过来，而是选择几项当前收益高、和 Yak Ops 现有 Monaco / EditorSession / Catalog 架构耦合较低的能力先落地：**Hover、函数参数提示、SQL Snippet、轻量结构诊断**。

仍然坚持“能力蒸馏 + Yak Ops 独立实现”，不复制 Chat2DB 当前版本源码，也不在这一阶段引入完整 SQL Parser、Formatter 或新的后端接口。

## 本阶段实现

### 1. SQL Hover

新增 SQL Hover Provider。

#### 内置函数 Hover

鼠标悬停在已支持的内置函数上时，可以查看函数签名和说明，例如：

```sql
COUNT(...)
COALESCE(...)
SUBSTRING(...)
ROW_NUMBER()
```

直接复用第三阶段已经维护的 `SQL_BUILTIN_FUNCTIONS`，不再维护第二份函数说明。

#### Table / Alias Hover

第四阶段选择数据源上下文后，悬停当前 statement 中的表名或别名，可以查看：

- Table / View 类型
- database / schema / table 路径
- alias 映射
- Catalog remarks

例如：

```sql
SELECT u.id
FROM users u
```

悬停 `users` 或 `u` 都可以得到当前表上下文。

#### Column Hover

支持：

```sql
u.id
```

以及单表 SQL 中的裸字段 Hover。字段信息来自 Yak Ops Datasource Catalog：

- 字段类型
- PRIMARY KEY
- NOT NULL
- 长度 / 精度
- 字段备注
- 来源表 / alias

Catalog 不可用时 Hover 自动降级，不影响正常编辑。

### 2. SQL 函数参数提示

新增 Monaco `SignatureHelpProvider`。

输入：

```sql
COALESCE(
ROUND(
REPLACE(
```

会显示当前函数签名和说明；逗号输入后会跟随当前参数位置。

支持嵌套函数的轻量括号栈，例如：

```sql
COALESCE(MAX(amount), 0)
```

仍然复用现有 SQL 内置函数 Catalog，不引入数据库方言函数库。

### 3. SQL Snippet

增加第一批轻量模板：

- `sel` -> SELECT … FROM
- `selw` -> SELECT … WHERE
- `joinq` -> JOIN 查询
- `cte` -> WITH CTE
- `casew` -> CASE WHEN
- `ins` -> INSERT INTO
- `upd` -> UPDATE … SET

Snippet 使用 Monaco 原生 placeholder，可以通过 Tab 在表名、字段、条件等位置之间切换。

字符串、注释以及 `alias.` 之后不会弹这些模板；`Ctrl/Cmd + Space` 手动唤起时也可以查看模板。

### 4. 轻量 SQL 结构诊断

新增独立 Marker owner：`yak-sql-structure`。

当前只检查确定性较高的编辑期结构问题：

- 多余的右括号
- 未闭合的左括号
- 未闭合的单引号字符串
- 未闭合的双引号 / 反引号 / `[]` 标识符
- 未闭合的 `/* ... */` 块注释

诊断采用 Warning 而不是 Error，并在输入后做短延迟刷新，避免把这层轻量扫描器伪装成完整 SQL 语法解析器。

后续真正接入 SQL Parser/AST 时，可以保留同一 Marker 边界并逐步替换实现。

### 5. Provider 生命周期

Hover、Signature Help、Snippet Completion 都继续采用共享 Provider + 引用计数：

- 多个 SQL Editor 不重复注册全局 Provider
- 最后一个 SQL Editor 卸载后自动 dispose
- Diagnostics 则绑定具体 Monaco Model，随 Model 一起释放

`SqlMonacoEditor` 仍然只负责能力挂载与生命周期，不承载 Catalog 业务实现。

## 结构

```text
editors/sql/
├── assistance/
│   ├── registerSqlHover.ts
│   ├── registerSqlSignatureHelp.ts
│   └── sqlTextContext.ts
├── completion/
│   ├── registerSqlSnippetCompletion.ts
│   └── sqlSnippetCatalog.ts
├── diagnostics/
│   └── bindSqlDiagnostics.ts
└── components/
    └── SqlMonacoEditor.tsx
```

## 本阶段刻意不做

这一次暂时不做以下能力：

- 完整 SQL Parser / AST
- 方言级语法错误 Marker
- CTE / 子查询 / 多层作用域完整语义分析
- Semantic Token / Table、Column 专属着色
- SQL Formatter
- 执行计划
- SQL 保存 / 发布 / 执行 / Result Grid

原因是这些能力要么依赖更完整的 Parser，要么应该作为独立阶段接入，不适合为了“高级能力”一次性塞进当前 PR。

## 与第四阶段的关系

- 第三阶段关键字 / 内置函数补全保持不变
- 第四阶段 Datasource Catalog Table / Column 补全保持不变
- Hover 复用第四阶段已有的 Catalog cache，所以不会再建立一套元数据缓存
- EditorSession、Workbench、Shell Editor 均不修改
- 不新增后端 API / Flyway / 数据表

## 建议回归

- Hover `COUNT` / `COALESCE`，确认显示签名和说明
- 选择数据源后 Hover `FROM users u` 的 `users` / `u`
- Hover `u.id`，确认显示字段类型、主键、NULL、备注等 Catalog 信息
- 输入 `COALESCE(` / `ROUND(`，确认出现参数提示
- 输入 `COALESCE(MAX(amount), `，确认嵌套函数后参数位置正常
- 输入 `sel` / `joinq` / `cte`，确认出现 Snippet 并可 Tab 跳转 placeholder
- 在字符串 / 注释中输入 snippet 前缀，确认不打扰编辑
- 输入未闭合 `(`、`'`、`/*`，确认出现 Warning Marker；补全后 Marker 自动消失
- 多次切换 SQL Tab，确认 Provider 不重复，EditorSession 和第四阶段元数据补全不受影响

## 验证说明

- 分支基于合入 #327 后的最新 `main`
- compare 当前 behind 0
- 修改范围仅在 `yak-ops-ui/src/pages/data-development/editors/sql`
- Monaco 仍使用仓库现有 `^0.52.0`，没有新增 npm 依赖
- 当前仓库未配置本分支的 GitHub Actions workflow，PR 保持 Draft，建议合并前执行 `npm run tsc` 和页面交互回归
