### PR TITLE
feat(data-development): polish editor tabs and SQL toolbar

### DIFF
--- a/yak-ops-ui/src/pages/data-development/components/DevelopmentTreePane.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/DevelopmentTreePane.tsx
@@ -256,7 +256,7 @@ const DevelopmentTreePane = ({
           className="flex h-full flex-col overflow-hidden"
           style={{ width: leftWidth }}
         >
-          <div className="flex h-9 shrink-0 items-center justify-between border-b border-[#e5e7eb] bg-[#f5f5f6] px-3">
+          <div className="flex h-9 shrink-0 items-center justify-between border-b border-[#e5e7eb] bg-[#f7f7f8] px-3">
             <span className="text-[13px] font-semibold text-[#30323b]">
               开发目录
             </span>
@@ -288,7 +288,7 @@ const DevelopmentTreePane = ({
             </Dropdown>
           </div>
 
-          <div className="flex h-11 shrink-0 items-center border-b border-[#e8e9ec] px-3">
+          <div className="flex h-9 shrink-0 items-center border-b border-[#e8e9ec] px-2.5">
             <Input
               allowClear
               size="small"
@@ -297,6 +297,7 @@ const DevelopmentTreePane = ({
               prefix={<Search size={13} className="text-[#98a2b3]" />}
               placeholder="搜索名称 / 节点"
               onChange={(event) => onSearchChange(event.target.value)}
+              className="!h-7"
             />
           </div>
 

--- a/yak-ops-ui/src/pages/data-development/components/workbench/EditorTabs.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/workbench/EditorTabs.tsx
@@ -113,9 +113,9 @@ const EditorTabs = ({
   );
 
   return (
-    <div className="flex h-9 shrink-0 border-b border-[#e5e7eb] bg-[#f5f5f6]">
+    <div className="flex h-9 shrink-0 border-b border-[#e5e7eb] bg-[#f7f7f8]">
       <div className="min-w-0 flex-1 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-        <div className="flex h-9 min-w-max items-stretch gap-1 px-1">
+        <div className="flex h-9 min-w-max items-stretch">
           {openNodeIds.map((nodeId) => {
             const node = nodeMap.get(nodeId);
             if (!node) return null;
@@ -135,10 +135,10 @@ const EditorTabs = ({
                   if (event.button === 1) onClose(nodeId);
                 }}
                 className={[
-                  'group relative flex h-9 min-w-[132px] max-w-[240px] flex-none items-center border-r border-[#eaecf0] transition-colors',
+                  'group relative flex h-9 min-w-[120px] max-w-[220px] flex-none items-center border-r border-[#e5e7eb] transition-colors',
                   active
                     ? 'bg-white text-[#344054] shadow-[inset_0_-2px_0_rgba(254,44,85,1)]'
-                    : 'bg-[#f5f5f6] text-[#667085] hover:bg-[#eeeeef] hover:text-[#344054]',
+                    : 'bg-[#f7f7f8] text-[#667085] hover:bg-[#f0f1f2] hover:text-[#344054]',
                 ].join(' ')}
               >
                 <button
@@ -146,11 +146,11 @@ const EditorTabs = ({
                   title={node.name}
                   aria-current={active ? 'page' : undefined}
                   onClick={() => onFocus(nodeId)}
-                  className="flex h-full min-w-0 flex-1 items-center gap-2 bg-transparent pl-2.5 pr-1 text-left outline-none"
+                  className="flex h-full min-w-0 flex-1 items-center gap-2 bg-transparent pl-3 pr-1 text-left outline-none"
                 >
                   <span
                     className={[
-                      'flex h-5 w-5 shrink-0 items-center justify-center rounded-sm bg-white/80',
+                      'flex h-5 w-4 shrink-0 items-center justify-center',
                       definition.iconClassName,
                     ].join(' ')}
                   >
@@ -192,7 +192,7 @@ const EditorTabs = ({
         </div>
       </div>
 
-      <div className="flex h-9 w-10 shrink-0 items-center justify-center border-l border-[#e5e7eb] bg-[#f5f5f6]">
+      <div className="flex h-9 w-10 shrink-0 items-center justify-center border-l border-[#e5e7eb] bg-[#f7f7f8]">
         <Dropdown
           trigger={['click']}
           placement="bottomRight"
@@ -211,7 +211,7 @@ const EditorTabs = ({
             <button
               type="button"
               aria-label="编辑器操作"
-              className="flex h-7 w-7 items-center justify-center rounded-[4px] text-[#667085] transition-colors hover:bg-white hover:text-[#344054]"
+              className="flex h-7 w-7 items-center justify-center rounded-[3px] text-[#667085] transition-colors hover:bg-white hover:text-[#344054]"
             >
               <MoreHorizontal size={17} strokeWidth={1.8} />
             </button>

--- a/yak-ops-ui/src/pages/data-development/components/workbench/EditorToolbar.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/workbench/EditorToolbar.tsx
@@ -1,13 +1,7 @@
-import { Button, message } from 'antd';
-import {
-  Play,
-  RefreshCw,
-  Rocket,
-  Save,
-  Share2,
-  Square,
-} from 'lucide-react';
+import { Tooltip, message } from 'antd';
+import { Play, Save } from 'lucide-react';
 
+import { markEditorSessionSaved } from '../../editors/session/editorSessionStore';
 import type { DevelopmentEditorDefinition } from '../../editors/types';
 import type { DevelopmentDirectory, DevelopmentNode } from '../../types';
 
@@ -18,9 +12,8 @@ interface EditorToolbarProps {
   onRun: () => void;
 }
 
-const placeholder = (label: string) => {
-  message.info(`${label}能力将在后续编辑器阶段接入`);
-};
+const iconButtonClassName =
+  'flex h-7 w-7 shrink-0 items-center justify-center rounded-[3px] text-[#475467] outline-none transition-colors hover:bg-[#f5f5f6] hover:text-[#1f2937] focus-visible:ring-2 focus-visible:ring-[rgba(254,44,85,.16)]';
 
 const EditorToolbar = ({
   node,
@@ -28,80 +21,48 @@ const EditorToolbar = ({
   definition,
   onRun,
 }: EditorToolbarProps) => {
+  const Toolbar = definition.Toolbar;
   const capabilities = definition.capabilities;
 
   return (
-    <div className="flex h-11 shrink-0 items-center justify-between border-b border-[#e8e9ec] bg-white px-3">
-      <div className="flex items-center gap-1">
-        {capabilities.run ? (
-          <Button
-            type="text"
-            size="small"
-            icon={<Play size={14} strokeWidth={1.8} />}
-            className="!h-8 !px-2.5"
-            onClick={onRun}
-          >
-            运行
-          </Button>
-        ) : null}
-        {capabilities.stop ? (
-          <Button
-            type="text"
-            size="small"
-            icon={<Square size={13} strokeWidth={1.8} />}
-            className="!h-8 !px-2.5"
-            onClick={() => placeholder('停止')}
-          >
-            停止
-          </Button>
-        ) : null}
-        {capabilities.save ? (
-          <Button
-            type="text"
-            size="small"
-            icon={<Save size={14} strokeWidth={1.8} />}
-            className="!h-8 !px-2.5"
-            onClick={() => placeholder('保存')}
-          >
-            保存
-          </Button>
-        ) : null}
-        {capabilities.refresh ? (
-          <Button
-            type="text"
-            size="small"
-            icon={<RefreshCw size={14} strokeWidth={1.8} />}
-            className="!h-8 !px-2.5"
-            onClick={() => placeholder('刷新')}
-          >
-            刷新
-          </Button>
-        ) : null}
-        {capabilities.publish ? (
-          <Button
-            type="text"
-            size="small"
-            icon={<Rocket size={14} strokeWidth={1.8} />}
-            className="!h-8 !px-2.5"
-            onClick={() => placeholder('发布')}
-          >
-            发布
-          </Button>
-        ) : null}
-        {capabilities.share ? (
-          <Button
-            type="text"
-            size="small"
-            icon={<Share2 size={14} strokeWidth={1.8} />}
-            className="!h-8 !px-2.5"
-            onClick={() => placeholder('分享')}
-          >
-            分享
-          </Button>
-        ) : null}
+    <div className="flex h-9 shrink-0 items-center justify-between border-b border-[#e8e9ec] bg-white px-2">
+      <div className="flex h-full min-w-0 items-center">
+        {Toolbar ? (
+          <Toolbar node={node} directory={directory} onRun={onRun} />
+        ) : (
+          <div className="flex h-full items-center gap-0.5">
+            {capabilities.run ? (
+              <Tooltip title="运行" mouseEnterDelay={0.35}>
+                <button
+                  type="button"
+                  aria-label="运行"
+                  onClick={onRun}
+                  className={iconButtonClassName}
+                >
+                  <Play size={15} strokeWidth={1.8} />
+                </button>
+              </Tooltip>
+            ) : null}
+            {capabilities.save ? (
+              <Tooltip title="保存本地草稿" mouseEnterDelay={0.35}>
+                <button
+                  type="button"
+                  aria-label="保存本地草稿"
+                  onClick={() => {
+                    markEditorSessionSaved(node.id);
+                    message.success('本地草稿已保存');
+                  }}
+                  className={iconButtonClassName}
+                >
+                  <Save size={15} strokeWidth={1.8} />
+                </button>
+              </Tooltip>
+            ) : null}
+          </div>
+        )}
       </div>
 
-      <div className="truncate pl-4 text-[11px] text-[#98a2b3]">
+      <div className="min-w-0 truncate pl-4 text-[11px] text-[#98a2b3]">
         {directory?.path || '/'} / {node.name}
       </div>
     </div>

--- a/yak-ops-ui/src/pages/data-development/editors/registry.tsx
+++ b/yak-ops-ui/src/pages/data-development/editors/registry.tsx
@@ -3,6 +3,7 @@ import { Code2, TerminalSquare } from 'lucide-react';
 import type { DevelopmentTaskType } from '../types';
 import { ShellEditor, ShellRunConfig, ShellRunResult } from './shell/ShellEditor';
 import { SqlEditor, SqlRunConfig, SqlRunResult } from './sql/SqlEditor';
+import SqlToolbar from './sql/SqlToolbar';
 import type {
   DevelopmentEditorContext,
   DevelopmentEditorDefinition,
@@ -50,6 +51,7 @@ const editorRegistry: Partial<
     iconClassName: 'text-[#f79009]',
     capabilities: { ...commonCapabilities, format: true },
     Editor: SqlEditor,
+    Toolbar: SqlToolbar,
     panels: {
       'run-config': SqlRunConfig,
     },

--- a/yak-ops-ui/src/pages/data-development/editors/sql/SqlToolbar.tsx
+++ b/yak-ops-ui/src/pages/data-development/editors/sql/SqlToolbar.tsx
@@ -1,0 +1,128 @@
+import { Dropdown, Tooltip, message } from 'antd';
+import {
+  Play,
+  Redo2,
+  Save,
+  Search,
+  Settings,
+  Sparkles,
+  Undo2,
+  Wand2,
+} from 'lucide-react';
+
+import { persistEditorSessionsNow } from '../session/editorSessionStore';
+import type { DevelopmentEditorToolbarContext } from '../types';
+import {
+  executeSqlEditorCommand,
+  type SqlEditorCommand,
+} from './commands/sqlEditorCommandBus';
+
+const iconButtonClassName =
+  'flex h-7 w-7 shrink-0 items-center justify-center rounded-[3px] text-[#475467] outline-none transition-colors hover:bg-[#f5f5f6] hover:text-[#1f2937] focus-visible:ring-2 focus-visible:ring-[rgba(254,44,85,.16)]';
+
+interface ToolbarButtonProps {
+  title: string;
+  onClick: () => void;
+  children: React.ReactNode;
+}
+
+const ToolbarButton = ({ title, onClick, children }: ToolbarButtonProps) => (
+  <Tooltip title={title} mouseEnterDelay={0.35}>
+    <button
+      type="button"
+      aria-label={title}
+      onClick={onClick}
+      className={iconButtonClassName}
+    >
+      {children}
+    </button>
+  </Tooltip>
+);
+
+const ToolbarDivider = () => <span className="mx-1 h-4 w-px shrink-0 bg-[#e5e7eb]" />;
+
+const SqlToolbar = ({ node, onRun }: DevelopmentEditorToolbarContext) => {
+  const execute = (command: SqlEditorCommand, fallback: string) => {
+    if (!executeSqlEditorCommand(node.id, command)) {
+      message.info(fallback);
+    }
+  };
+
+  return (
+    <div className="flex h-full items-center gap-0.5">
+      <ToolbarButton title="运行" onClick={onRun}>
+        <Play size={15} strokeWidth={1.8} />
+      </ToolbarButton>
+
+      <ToolbarDivider />
+
+      <ToolbarButton
+        title="保存本地草稿"
+        onClick={() => {
+          persistEditorSessionsNow();
+          message.success('本地草稿已保存');
+        }}
+      >
+        <Save size={15} strokeWidth={1.8} />
+      </ToolbarButton>
+      <ToolbarButton
+        title="撤销"
+        onClick={() => execute('undo', 'SQL 编辑器尚未就绪')}
+      >
+        <Undo2 size={15} strokeWidth={1.8} />
+      </ToolbarButton>
+      <ToolbarButton
+        title="重做"
+        onClick={() => execute('redo', 'SQL 编辑器尚未就绪')}
+      >
+        <Redo2 size={15} strokeWidth={1.8} />
+      </ToolbarButton>
+      <ToolbarButton
+        title="查找"
+        onClick={() => execute('find', 'SQL 编辑器尚未就绪')}
+      >
+        <Search size={15} strokeWidth={1.8} />
+      </ToolbarButton>
+
+      <ToolbarDivider />
+
+      <ToolbarButton
+        title="格式化 SQL"
+        onClick={() => execute('format', 'SQL 编辑器尚未就绪')}
+      >
+        <Wand2 size={15} strokeWidth={1.8} />
+      </ToolbarButton>
+      <ToolbarButton
+        title="触发智能提示"
+        onClick={() => execute('suggest', 'SQL 编辑器尚未就绪')}
+      >
+        <Sparkles size={15} strokeWidth={1.8} />
+      </ToolbarButton>
+
+      <Dropdown
+        trigger={['click']}
+        placement="bottomLeft"
+        menu={{
+          items: [
+            { key: 'toggle-word-wrap', label: '切换自动换行' },
+            { key: 'toggle-minimap', label: '切换缩略图' },
+          ],
+          onClick: ({ key }) =>
+            execute(key as SqlEditorCommand, 'SQL 编辑器尚未就绪'),
+        }}
+      >
+        <Tooltip title="编辑器设置" mouseEnterDelay={0.35}>
+          <button
+            type="button"
+            aria-label="编辑器设置"
+            className={iconButtonClassName}
+          >
+            <Settings size={15} strokeWidth={1.8} />
+          </button>
+        </Tooltip>
+      </Dropdown>
+    </div>
+  );
+};
+
+export default SqlToolbar;

--- a/yak-ops-ui/src/pages/data-development/editors/sql/SqlToolbar.tsx
+++ b/yak-ops-ui/src/pages/data-development/editors/sql/SqlToolbar.tsx
@@ -9,8 +9,9 @@ import {
   Undo2,
   Wand2,
 } from 'lucide-react';
+import type { ReactNode } from 'react';
 
-import { persistEditorSessionsNow } from '../session/editorSessionStore';
+import { markEditorSessionSaved } from '../session/editorSessionStore';
 import type { DevelopmentEditorToolbarContext } from '../types';
 import {
   executeSqlEditorCommand,
@@ -23,7 +24,7 @@ const iconButtonClassName =
 interface ToolbarButtonProps {
   title: string;
   onClick: () => void;
-  children: React.ReactNode;
+  children: ReactNode;
 }
 
 const ToolbarButton = ({ title, onClick, children }: ToolbarButtonProps) => (
@@ -59,7 +60,7 @@ const SqlToolbar = ({ node, onRun }: DevelopmentEditorToolbarContext) => {
       <ToolbarButton
         title="保存本地草稿"
         onClick={() => {
-          persistEditorSessionsNow();
+          markEditorSessionSaved(node.id);
           message.success('本地草稿已保存');
         }}
       >

--- a/yak-ops-ui/src/pages/data-development/editors/sql/commands/sqlEditorCommandBus.ts
+++ b/yak-ops-ui/src/pages/data-development/editors/sql/commands/sqlEditorCommandBus.ts
@@ -1,0 +1,42 @@
+import type { DevelopmentId } from '../../../types';
+
+export type SqlEditorCommand =
+  | 'undo'
+  | 'redo'
+  | 'find'
+  | 'format'
+  | 'suggest'
+  | 'toggle-word-wrap'
+  | 'toggle-minimap';
+
+type SqlEditorCommandHandler = (
+  command: SqlEditorCommand,
+) => void | Promise<void>;
+
+const commandHandlers = new Map<DevelopmentId, SqlEditorCommandHandler>();
+
+export const registerSqlEditorCommandHandler = (
+  nodeId: DevelopmentId,
+  handler: SqlEditorCommandHandler,
+) => {
+  commandHandlers.set(nodeId, handler);
+
+  return {
+    dispose: () => {
+      if (commandHandlers.get(nodeId) === handler) {
+        commandHandlers.delete(nodeId);
+      }
+    },
+  };
+};
+
+export const executeSqlEditorCommand = (
+  nodeId: DevelopmentId,
+  command: SqlEditorCommand,
+) => {
+  const handler = commandHandlers.get(nodeId);
+  if (!handler) return false;
+
+  void handler(command);
+  return true;
+};

--- a/yak-ops-ui/src/pages/data-development/editors/sql/components/SqlMonacoEditor.tsx
+++ b/yak-ops-ui/src/pages/data-development/editors/sql/components/SqlMonacoEditor.tsx
@@ -5,6 +5,7 @@ import { useEffect, useRef } from 'react';
 import type { DevelopmentEditorViewState } from '../../session/types';
 import { acquireSqlHoverProvider } from '../assistance/registerSqlHover';
 import { acquireSqlSignatureHelpProvider } from '../assistance/registerSqlSignatureHelp';
+import { registerSqlEditorCommandHandler } from '../commands/sqlEditorCommandBus';
 import { acquireSqlBuiltinCompletionProvider } from '../completion/registerSqlBuiltinCompletion';
 import {
   acquireSqlMetadataCompletionProvider,
@@ -12,6 +13,7 @@ import {
 } from '../completion/registerSqlMetadataCompletion';
 import { acquireSqlSnippetCompletionProvider } from '../completion/registerSqlSnippetCompletion';
 import { bindSqlDiagnostics } from '../diagnostics/bindSqlDiagnostics';
+import { formatSqlText } from '../formatting/formatSqlText';
 import { setupMonacoEnvironment } from '../monaco/setupMonacoEnvironment';
 
 export interface SqlEditorPosition {
@@ -159,6 +161,49 @@ const SqlMonacoEditor = ({
     editorRef.current = editor;
     modelRef.current = model;
 
+    let wordWrapEnabled = false;
+    let minimapEnabled = false;
+    const commandBinding = registerSqlEditorCommandHandler(id, async (command) => {
+      editor.focus();
+
+      if (command === 'undo' || command === 'redo') {
+        editor.trigger('yak-sql-toolbar', command, null);
+        return;
+      }
+      if (command === 'find') {
+        await editor.getAction('actions.find')?.run();
+        return;
+      }
+      if (command === 'suggest') {
+        await editor.getAction('editor.action.triggerSuggest')?.run();
+        return;
+      }
+      if (command === 'toggle-word-wrap') {
+        wordWrapEnabled = !wordWrapEnabled;
+        editor.updateOptions({ wordWrap: wordWrapEnabled ? 'on' : 'off' });
+        return;
+      }
+      if (command === 'toggle-minimap') {
+        minimapEnabled = !minimapEnabled;
+        editor.updateOptions({ minimap: { enabled: minimapEnabled } });
+        return;
+      }
+      if (command === 'format') {
+        const formatted = formatSqlText(model.getValue());
+        if (formatted === model.getValue()) return;
+
+        editor.pushUndoStop();
+        editor.executeEdits('yak-sql-format', [
+          {
+            range: model.getFullModelRange(),
+            text: formatted,
+            forceMoveMarkers: true,
+          },
+        ]);
+        editor.pushUndoStop();
+      }
+    });
+
     if (initialViewState) {
       if (initialViewState.selection) {
         editor.setSelection(initialViewState.selection);
@@ -217,6 +262,7 @@ const SqlMonacoEditor = ({
       cursorDisposable.dispose();
       selectionDisposable.dispose();
       scrollDisposable.dispose();
+      commandBinding.dispose();
       diagnosticsBinding.dispose();
       metadataModelBinding.dispose();
       signatureHelpProvider.dispose();

--- a/yak-ops-ui/src/pages/data-development/editors/sql/formatting/formatSqlText.ts
+++ b/yak-ops-ui/src/pages/data-development/editors/sql/formatting/formatSqlText.ts
@@ -1,0 +1,125 @@
+const protectSqlSegments = (sql: string) => {
+  const segments: string[] = [];
+  let output = '';
+  let index = 0;
+
+  const pushSegment = (value: string) => {
+    const token = `__YAK_SQL_SEGMENT_${segments.length}__`;
+    segments.push(value);
+    output += token;
+  };
+
+  while (index < sql.length) {
+    const current = sql[index];
+    const next = sql[index + 1];
+
+    if (current === "'" || current === '"' || current === '`') {
+      const quote = current;
+      let end = index + 1;
+      while (end < sql.length) {
+        if (sql[end] === quote && sql[end + 1] === quote) {
+          end += 2;
+          continue;
+        }
+        if (sql[end] === quote) {
+          end += 1;
+          break;
+        }
+        end += 1;
+      }
+      pushSegment(sql.slice(index, end));
+      index = end;
+      continue;
+    }
+
+    if (current === '[') {
+      let end = index + 1;
+      while (end < sql.length) {
+        if (sql[end] === ']' && sql[end + 1] === ']') {
+          end += 2;
+          continue;
+        }
+        if (sql[end] === ']') {
+          end += 1;
+          break;
+        }
+        end += 1;
+      }
+      pushSegment(sql.slice(index, end));
+      index = end;
+      continue;
+    }
+
+    if (current === '-' && next === '-') {
+      let end = index + 2;
+      while (end < sql.length && sql[end] !== '\n') end += 1;
+      pushSegment(sql.slice(index, end));
+      index = end;
+      continue;
+    }
+
+    if (current === '/' && next === '*') {
+      let end = index + 2;
+      while (end < sql.length && !(sql[end] === '*' && sql[end + 1] === '/')) {
+        end += 1;
+      }
+      end = Math.min(sql.length, end + 2);
+      pushSegment(sql.slice(index, end));
+      index = end;
+      continue;
+    }
+
+    output += current;
+    index += 1;
+  }
+
+  return { output, segments };
+};
+
+const restoreSqlSegments = (sql: string, segments: string[]) =>
+  segments.reduce(
+    (value, segment, index) =>
+      value.replaceAll(`__YAK_SQL_SEGMENT_${index}__`, segment),
+    sql,
+  );
+
+const CLAUSE_PATTERN = [
+  'LEFT\\s+OUTER\\s+JOIN',
+  'RIGHT\\s+OUTER\\s+JOIN',
+  'FULL\\s+OUTER\\s+JOIN',
+  'LEFT\\s+JOIN',
+  'RIGHT\\s+JOIN',
+  'FULL\\s+JOIN',
+  'INNER\\s+JOIN',
+  'CROSS\\s+JOIN',
+  'GROUP\\s+BY',
+  'ORDER\\s+BY',
+  'UNION\\s+ALL',
+  'UNION',
+  'FROM',
+  'WHERE',
+  'HAVING',
+  'JOIN',
+  'SET',
+  'VALUES',
+  'LIMIT',
+  'OFFSET',
+].join('|');
+
+export const formatSqlText = (sql: string) => {
+  if (!sql.trim()) return sql;
+
+  const normalized = sql.replace(/\r\n?/g, '\n');
+  const { output, segments } = protectSqlSegments(normalized);
+
+  let formatted = output
+    .replace(/[ \t]+/g, ' ')
+    .replace(/ *\n */g, '\n')
+    .replace(new RegExp(`\\s+(${CLAUSE_PATTERN})\\s+`, 'gi'), '\n$1 ')
+    .replace(/\s+(AND|OR)\s+/gi, '\n  $1 ')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+
+  formatted = restoreSqlSegments(formatted, segments);
+  return formatted;
+};

--- a/yak-ops-ui/src/pages/data-development/editors/types.ts
+++ b/yak-ops-ui/src/pages/data-development/editors/types.ts
@@ -18,6 +18,11 @@ export interface DevelopmentEditorContext {
   directory?: DevelopmentDirectory;
 }
 
+export interface DevelopmentEditorToolbarContext
+  extends DevelopmentEditorContext {
+  onRun: () => void;
+}
+
 export interface DevelopmentEditorCapabilities {
   run: boolean;
   stop: boolean;
@@ -39,6 +44,7 @@ export interface DevelopmentEditorDefinition {
   iconClassName: string;
   capabilities: DevelopmentEditorCapabilities;
   Editor: ComponentType<DevelopmentEditorContext>;
+  Toolbar?: ComponentType<DevelopmentEditorToolbarContext>;
   panels?: Partial<
     Record<DevelopmentEditorPanelKey, ComponentType<DevelopmentEditorContext>>
   >;


### PR DESCRIPTION
## 变更说明

根据当前数据开发编辑器页面和参考 SQL IDE 的交互样式，继续优化顶部 Tab + 编辑器工具栏区域。本次重点不是单纯“换皮”，而是把原来一批占位按钮收敛为当前阶段真正可用的编辑动作，并统一上下两层 IDE chrome 的高度。

## 1. Tab / 工具栏高度统一

- 编辑器 Tab 行固定为 36px（`h-9`）。
- 下方编辑器工具栏同步固定为 36px。
- 左侧「开发目录」标题行保持 36px。
- 左侧搜索行从 44px 收敛为 36px，与右侧工具栏严格对齐。

这样顶部两层横线能够从左侧目录一直贯穿到右侧编辑器，不再出现一层高、一层矮的视觉断层。

## 2. Tab 样式向 IDE 靠拢

- 去掉 Tab 之间额外 gap，改为紧凑连续排列。
- 每个 Tab 使用轻量右边框分隔。
- 节点类型图标不再套额外白色方块，只保留类型图标本身。
- 保留 Yak Ops 当前品牌色的 active 底部指示线；不照搬参考项目颜色。
- 非激活 Tab 使用更轻的灰色 hover，关闭按钮仍保持 active 可见 / hover 出现。

## 3. SQL 工具栏改为图标型真实操作

SQL 节点现在注册自己的 `SqlToolbar`，Workbench 不再把 SQL 特有动作硬编码进去。

当前提供：

- 运行：沿用现有 Run Result Panel 入口。
- 保存本地草稿：调用 EditorSession 的保存语义，清除当前本地 dirty 状态，不伪装成服务端保存。
- 撤销 / 重做：直接调用当前 Monaco Editor。
- 查找：直接打开 Monaco Find。
- 格式化 SQL：新增轻量、保守的前端 SQL formatter。
- 触发智能提示：手动打开当前 Monaco Completion。
- 编辑器设置：切换自动换行 / minimap。

原来 Stop / Refresh / Publish / Share 这类当前阶段只有 `message.info` 的假按钮不再出现在通用工具栏中。

## 4. SQL 编辑器命令桥

新增 `sqlEditorCommandBus`，按 nodeId 把外层 Toolbar 与当前 Monaco 实例连接起来：

```text
SqlToolbar
    ↓ command
sqlEditorCommandBus
    ↓ nodeId
SqlMonacoEditor
```

这样以后 SQL Editor 增加「执行当前语句」「执行全部」「SQL 优化」等能力时，不需要让 Workbench 直接持有 Monaco 实例。

## 5. 轻量 SQL 格式化

新增 `formatSqlText`：

- 保留字符串、注释、引号标识符内容；
- 对 FROM / WHERE / JOIN / GROUP BY / ORDER BY / HAVING / SET / VALUES / LIMIT 等主要 clause 做保守换行；
- AND / OR 做条件行换行；
- 使用 Monaco `executeEdits` 写回，因此格式化可以 Undo。

本次没有引入第三方 formatter 依赖，也没有尝试实现完整 SQL AST formatter。

## 6. 架构边界

`DevelopmentEditorDefinition` 新增可选 `Toolbar`，SQL 注册自己的 Toolbar；Shell 和后续 Python / HTTP 可以继续按各自能力独立提供 Toolbar。

## 影响范围

仅修改 `yak-ops-ui` 数据开发前端，9 个文件变更，不修改后端接口、Flyway、数据模型和 Datasource Catalog。

## 建议回归

- 对比顶部「开发目录 / Tabs」与下一行「搜索 / Toolbar」高度，确认四块均为 36px 并横向对齐。
- 打开多个 SQL Tab，检查 active / hover / close / dirty 圆点行为。
- SQL 输入内容后点击“保存本地草稿”，确认 dirty 状态清除。
- 测试撤销、重做、查找、智能提示。
- 输入 `select * from t_goods where id = 1 and status = 1` 后点击格式化，确认 clause 换行且可 Undo。
- 切换自动换行和 minimap，确认只影响当前 SQL Editor。
- Shell 节点确认仍有紧凑的运行 / 本地保存工具栏，不受 SQL 专属动作影响。

## 验证说明

- 分支基于 #328 合入后的最新 main；compare 当前 behind 0。
- 没有新增 npm 依赖。
- 运行按钮仍只沿用当前已有的结果面板入口，本 PR 不伪造尚未接入的后端 SQL 执行能力。
