### PR TITLE
style(data-development): refine workspace border and editor tabs

### DIFF
--- a/yak-ops-ui/src/pages/data-development/components/workbench/EditorTabs.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/workbench/EditorTabs.tsx
@@ -113,7 +113,7 @@ const EditorTabs = ({
   );
 
   return (
-    <div className="flex h-9 shrink-0 border-b border-[#e5e7eb] bg-[#f7f7f8]">
+    <div className="flex h-9 shrink-0 border-b border-[#e8e9ec] bg-[#f7f7f8]">
       <div className="min-w-0 flex-1 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
         <div className="flex h-9 min-w-max items-stretch">
           {openNodeIds.map((nodeId) => {
@@ -135,9 +135,9 @@ const EditorTabs = ({
                   if (event.button === 1) onClose(nodeId);
                 }}
                 className={[
-                  'group relative flex h-9 min-w-[120px] max-w-[220px] flex-none items-center border-r border-[#e5e7eb] transition-colors',
+                  'group relative flex h-9 min-w-[120px] max-w-[220px] flex-none items-center border-r border-r-[#e5e7eb] border-t-2 border-t-transparent transition-colors',
                   active
-                    ? 'bg-white text-[#344054] shadow-[inset_0_-2px_0_rgba(254,44,85,1)]'
+                    ? 'border-t-[rgba(254,44,85,1)] bg-white text-[#344054]'
                     : 'bg-[#f7f7f8] text-[#667085] hover:bg-[#f0f1f2] hover:text-[#344054]',
                 ].join(' ')}
               >

--- a/yak-ops-ui/src/pages/data-development/components/workbench/EditorTabs.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/workbench/EditorTabs.tsx
@@ -135,10 +135,10 @@ const EditorTabs = ({
                   if (event.button === 1) onClose(nodeId);
                 }}
                 className={[
-                  'group relative flex h-9 min-w-[120px] max-w-[220px] flex-none items-center border-r border-r-[#e5e7eb] border-t-2 border-t-transparent transition-colors',
+                  'group relative flex h-9 min-w-[120px] max-w-[220px] flex-none items-center border-r border-r-[#e5e7eb] border-t-2 transition-colors',
                   active
                     ? 'border-t-[rgba(254,44,85,1)] bg-white text-[#344054]'
-                    : 'bg-[#f7f7f8] text-[#667085] hover:bg-[#f0f1f2] hover:text-[#344054]',
+                    : 'border-t-transparent bg-[#f7f7f8] text-[#667085] hover:bg-[#f0f1f2] hover:text-[#344054]',
                 ].join(' ')}
               >
                 <button

--- a/yak-ops-ui/src/pages/data-development/index.tsx
+++ b/yak-ops-ui/src/pages/data-development/index.tsx
@@ -373,7 +373,7 @@ export default function DataDevelopmentPage() {
   return (
     <ConfigProvider theme={BRAND_THEME}>
       <div className="flex h-[calc(100vh-64px)] min-h-[640px] flex-col overflow-hidden bg-[#f5f5f6]">
-        <div className="flex min-h-0 flex-1 overflow-hidden border-x border-b border-[#e4e7ec] bg-white">
+        <div className="flex min-h-0 flex-1 overflow-hidden border border-[#e4e7ec] bg-white">
           <DevelopmentTreePane
             treeData={treeData}
             treeLoading={treeLoading}


### PR DESCRIPTION
## 变更说明

按照数据开发页面的截图反馈，对顶部工作区和编辑 Tab 做一轮视觉收敛：

- 数据开发工作区外框补齐顶部 `1px` 边框，四周边界保持一致，避免顶部区域看起来悬空
- 编辑 Tab 的激活色从底部移动到顶部，保持 IDE 风格的顶部状态指示
- 激活 Tab 顶部使用 Yak Ops 品牌色 `rgba(254,44,85,1)`
- Tab 区域下方改为 `#e8e9ec` 中性分隔线，与下方编辑器工具栏 / 按钮区域的边界颜色保持一致
- 非激活 Tab 保留透明的 `2px` 顶部边框，切换 Tab 时不会产生高度抖动
- 保留现有 Tab 切换、关闭、未保存状态以及更多菜单逻辑，不调整业务行为

## 影响范围

- `yak-ops-ui/src/pages/data-development/index.tsx`
- `yak-ops-ui/src/pages/data-development/components/workbench/EditorTabs.tsx`

## 建议回归

- 打开「数据开发 → 开发任务」，确认整个工作区顶部存在浅灰边界
- 同时打开多个 SQL / Shell 节点，确认当前激活 Tab 的品牌色位于顶部而不是底部
- 切换不同 Tab，确认 Tab 高度、文字和关闭按钮位置不抖动
- 确认 Tab 下方分割线与编辑器工具栏边界视觉一致
- 收起 / 展开左侧开发目录，确认顶部外框仍连续

本次仅涉及前端样式调整，不修改接口和数据开发业务逻辑。