### PR TITLE
style(data-development): make editor tab divider white

### DIFF
--- a/yak-ops-ui/src/pages/data-development/components/workbench/EditorTabs.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/workbench/EditorTabs.tsx
@@ -113,7 +113,7 @@ const EditorTabs = ({
   );
 
   return (
-    <div className="flex h-9 shrink-0 border-b border-[#e8e9ec] bg-[#f7f7f8]">
+    <div className="flex h-9 shrink-0 border-b border-white bg-[#f7f7f8]">
       <div className="min-w-0 flex-1 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
         <div className="flex h-9 min-w-max items-stretch">
           {openNodeIds.map((nodeId) => {


### PR DESCRIPTION
## 变更说明

根据当前数据开发页面截图反馈，继续收尾顶部编辑区样式：

- 将编辑 Tab 区域底部原来的浅灰分隔线调整为白色
- 保留现有顶部品牌色激活线、Tab 背景、关闭按钮和未保存状态逻辑
- 不调整工具栏、编辑器、目录树及任何业务行为

## 影响范围

仅修改：

- `yak-ops-ui/src/pages/data-development/components/workbench/EditorTabs.tsx`

## 建议回归

- 打开多个 SQL / Shell 节点，确认 Tab 下方原来的灰色横线不再显眼，视觉上与下方白色工具栏连成一体
- 确认当前激活 Tab 顶部红色状态线仍正常显示
- 切换 Tab、关闭 Tab、未保存圆点和更多菜单行为保持不变

本次仅为 1 行样式调整，不涉及接口和业务逻辑。