### PR TITLE
style(data-development): keep divider except under active tab

### DIFF
--- a/yak-ops-ui/src/pages/data-development/components/workbench/EditorTabs.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/workbench/EditorTabs.tsx
@@ -113,7 +113,7 @@ const EditorTabs = ({
   );
 
   return (
-    <div className="flex h-9 shrink-0 border-b border-white bg-[#f7f7f8]">
+    <div className="flex h-9 shrink-0 border-b border-[#e8e9ec] bg-[#f7f7f8]">
       <div className="min-w-0 flex-1 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
         <div className="flex h-9 min-w-max items-stretch">
           {openNodeIds.map((nodeId) => {
@@ -135,9 +135,9 @@ const EditorTabs = ({
                   if (event.button === 1) onClose(nodeId);
                 }}
                 className={[
-                  'group relative flex h-9 min-w-[120px] max-w-[220px] flex-none items-center border-r border-r-[#e5e7eb] border-t-2 transition-colors',
+                  'group relative flex h-9 min-w-[120px] max-w-[220px] flex-none items-center border-b border-b-transparent border-r border-r-[#e5e7eb] border-t-2 transition-colors',
                   active
-                    ? 'border-t-[rgba(254,44,85,1)] bg-white text-[#344054]'
+                    ? 'z-10 border-b-white border-t-[rgba(254,44,85,1)] bg-white text-[#344054]'
                     : 'border-t-transparent bg-[#f7f7f8] text-[#667085] hover:bg-[#f0f1f2] hover:text-[#344054]',
                 ].join(' ')}
               >


### PR DESCRIPTION
## 变更说明

修正上一版 Tab 底部分隔线处理：

- Tab 区域整体底部分隔线恢复为原来的 `#e8e9ec`
- 仅当前选中的 Tab 底部使用白色边框，视觉上把激活 Tab 与下方白色工具栏连成一体
- 未选中的 Tab 继续保留原来的浅灰分隔线
- 顶部品牌色激活线、关闭按钮、未保存状态及现有交互保持不变

## 影响范围

仅修改：

- `yak-ops-ui/src/pages/data-development/components/workbench/EditorTabs.tsx`

## 建议回归

- 打开多个 SQL / Shell 节点，确认未选中 Tab 下方仍能看到原来的浅灰线
- 确认当前选中 Tab 下方对应区域为白色，不再显示灰线
- 切换不同 Tab，确认白色底边会跟随当前激活 Tab
- 确认顶部红色激活线、关闭按钮和未保存圆点正常

本次只修正 Tab 边框视觉，不涉及业务逻辑。