### PR TITLE
style(data-development): mirror IDE SQL context selectors

### DIFF
--- a/yak-ops-ui/src/pages/data-development/editors/sql/metadata/SqlMetadataContextToolbar.tsx
+++ b/yak-ops-ui/src/pages/data-development/editors/sql/metadata/SqlMetadataContextToolbar.tsx
@@ -106,10 +106,8 @@ const ContextPicker = ({
                   setKeyword('');
                 }}
                 className={[
-                  'flex h-8 w-full items-center gap-2 rounded-[2px] px-2 text-left text-[12px] transition-colors',
-                  selected
-                    ? 'bg-[#f2f3f5] text-[#161823]'
-                    : 'text-[#30323b] hover:bg-[#f5f5f6]',
+                  'flex h-8 w-full items-center gap-2 rounded-[2px] px-2 text-left text-[12px] transition-colors hover:bg-[#f5f5f6]',
+                  selected ? 'text-[#161823]' : 'text-[#30323b]',
                 ].join(' ')}
               >
                 <span className="flex h-4 w-4 shrink-0 items-center justify-center">
@@ -147,11 +145,11 @@ const ContextPicker = ({
         aria-label={ariaLabel}
         disabled={disabled}
         className={[
-          'flex h-7 max-w-[176px] items-center gap-1.5 rounded-[3px] px-2 text-[12px] outline-none transition-colors',
+          'flex h-6 max-w-[176px] items-center gap-1.5 rounded-[3px] px-1.5 text-[12px] outline-none transition-colors',
           minWidthClassName,
           disabled
             ? 'cursor-not-allowed text-[#b7bcc5]'
-            : open
+            : open || displayValue
               ? 'bg-[#f1f2f4] text-[#161823]'
               : 'text-[#30323b] hover:bg-[#f5f5f6]',
         ].join(' ')}
@@ -297,7 +295,7 @@ const SqlMetadataContextToolbar = ({
 
   return (
     <>
-      <div className="flex min-w-0 shrink-0 items-center gap-0.5">
+      <div className="flex min-w-0 shrink-0 items-center gap-1">
         <ContextPicker
           ariaLabel="选择 SQL 数据源"
           value={context.dataSourceId}
@@ -307,7 +305,7 @@ const SqlMetadataContextToolbar = ({
           items={dataSourceItems}
           loading={dataSourceLoading}
           popupWidth={210}
-          minWidthClassName="min-w-[112px]"
+          minWidthClassName="min-w-[108px]"
           onSelect={(value) => {
             const selected = dataSources.find((item) => item.value === value);
             if (!selected) return;
@@ -329,7 +327,7 @@ const SqlMetadataContextToolbar = ({
           loading={databaseLoading}
           disabled={!context.dataSourceId}
           popupWidth={210}
-          minWidthClassName="min-w-[116px]"
+          minWidthClassName="min-w-[112px]"
           onSelect={(value) => selectSqlDatabaseContext(nodeId, value)}
         />
 
@@ -344,7 +342,7 @@ const SqlMetadataContextToolbar = ({
             loading={schemaLoading}
             disabled={!context.dataSourceId}
             popupWidth={210}
-            minWidthClassName="min-w-[108px]"
+            minWidthClassName="min-w-[104px]"
             onSelect={(value) => selectSqlSchemaContext(nodeId, value)}
           />
         ) : null}

--- a/yak-ops-ui/src/pages/data-development/editors/sql/metadata/SqlMetadataContextToolbar.tsx
+++ b/yak-ops-ui/src/pages/data-development/editors/sql/metadata/SqlMetadataContextToolbar.tsx
@@ -1,6 +1,7 @@
-import { Select, Tooltip, message } from 'antd';
-import { Database } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { Popover, Spin, message } from 'antd';
+import { ChevronDown, Database, Layers3, Search, Server } from 'lucide-react';
+import type { ReactNode } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import type { DevelopmentId } from '../../../types';
 import {
@@ -20,11 +21,162 @@ interface SqlMetadataContextToolbarProps {
   nodeId: DevelopmentId;
 }
 
+interface ContextPickerItem {
+  value: string;
+  label: string;
+  searchText?: string;
+  icon?: ReactNode;
+}
+
+interface ContextPickerProps {
+  ariaLabel: string;
+  value?: string;
+  displayValue?: string;
+  placeholder: string;
+  icon: ReactNode;
+  items: ContextPickerItem[];
+  loading?: boolean;
+  disabled?: boolean;
+  popupWidth?: number;
+  minWidthClassName?: string;
+  onSelect: (value: string) => void;
+}
+
 const errorText = (error: unknown, fallback: string) =>
   error instanceof Error ? error.message : fallback;
 
-const contextControlClassName =
-  'flex h-7 shrink-0 items-center rounded-[3px] border border-[#dfe3e8] bg-white transition-colors hover:border-[#cfd4dc]';
+const ContextPicker = ({
+  ariaLabel,
+  value,
+  displayValue,
+  placeholder,
+  icon,
+  items,
+  loading = false,
+  disabled = false,
+  popupWidth = 210,
+  minWidthClassName = 'min-w-[108px]',
+  onSelect,
+}: ContextPickerProps) => {
+  const [open, setOpen] = useState(false);
+  const [keyword, setKeyword] = useState('');
+  const normalizedKeyword = keyword.trim().toLowerCase();
+
+  const filteredItems = useMemo(
+    () =>
+      normalizedKeyword
+        ? items.filter((item) =>
+            `${item.label} ${item.searchText || ''}`
+              .toLowerCase()
+              .includes(normalizedKeyword),
+          )
+        : items,
+    [items, normalizedKeyword],
+  );
+
+  const popup = (
+    <div style={{ width: popupWidth }}>
+      <div className="flex h-8 items-center gap-1.5 border-b border-[#e5e7eb] px-2.5">
+        <Search size={13} strokeWidth={1.8} className="shrink-0 text-[#6b7280]" />
+        <input
+          autoFocus
+          value={keyword}
+          placeholder="搜索"
+          onChange={(event) => setKeyword(event.target.value)}
+          className="h-full min-w-0 flex-1 border-0 bg-transparent p-0 text-[12px] text-[#30323b] outline-none placeholder:text-[#9ca3af]"
+        />
+      </div>
+
+      <div className="max-h-[240px] overflow-y-auto p-1">
+        {loading ? (
+          <div className="flex h-10 items-center justify-center">
+            <Spin size="small" />
+          </div>
+        ) : filteredItems.length ? (
+          filteredItems.map((item) => {
+            const selected = item.value === value;
+            return (
+              <button
+                key={item.value}
+                type="button"
+                title={item.label}
+                onClick={() => {
+                  onSelect(item.value);
+                  setOpen(false);
+                  setKeyword('');
+                }}
+                className={[
+                  'flex h-8 w-full items-center gap-2 rounded-[2px] px-2 text-left text-[12px] transition-colors',
+                  selected
+                    ? 'bg-[#f2f3f5] text-[#161823]'
+                    : 'text-[#30323b] hover:bg-[#f5f5f6]',
+                ].join(' ')}
+              >
+                <span className="flex h-4 w-4 shrink-0 items-center justify-center">
+                  {item.icon || icon}
+                </span>
+                <span className="min-w-0 flex-1 truncate">{item.label}</span>
+              </button>
+            );
+          })
+        ) : (
+          <div className="flex h-10 items-center justify-center text-[11px] text-[#98a2b3]">
+            暂无匹配项
+          </div>
+        )}
+      </div>
+    </div>
+  );
+
+  return (
+    <Popover
+      trigger="click"
+      placement="bottomLeft"
+      arrow={false}
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (disabled) return;
+        setOpen(nextOpen);
+        if (!nextOpen) setKeyword('');
+      }}
+      overlayClassName="sql-metadata-context-popover"
+      content={popup}
+    >
+      <button
+        type="button"
+        aria-label={ariaLabel}
+        disabled={disabled}
+        className={[
+          'flex h-7 max-w-[176px] items-center gap-1.5 rounded-[3px] px-2 text-[12px] outline-none transition-colors',
+          minWidthClassName,
+          disabled
+            ? 'cursor-not-allowed text-[#b7bcc5]'
+            : open
+              ? 'bg-[#f1f2f4] text-[#161823]'
+              : 'text-[#30323b] hover:bg-[#f5f5f6]',
+        ].join(' ')}
+      >
+        <span className="flex h-4 w-4 shrink-0 items-center justify-center">{icon}</span>
+        <span
+          className={[
+            'min-w-0 flex-1 truncate text-left',
+            displayValue ? 'text-[#30323b]' : 'text-[#7b808a]',
+          ].join(' ')}
+        >
+          {displayValue || placeholder}
+        </span>
+        <ChevronDown
+          size={12}
+          strokeWidth={1.8}
+          className={[
+            'shrink-0 transition-transform duration-150',
+            open ? 'rotate-180' : '',
+          ].join(' ')}
+        />
+      </button>
+    </Popover>
+  );
+};
 
 const SqlMetadataContextToolbar = ({
   nodeId,
@@ -119,92 +271,98 @@ const SqlMetadataContextToolbar = ({
     };
   }, [context.dataSourceId, context.database, context.schema, nodeId]);
 
+  const normalizedDbType = context.dbType?.trim().toUpperCase();
+  const showSchemaPicker = Boolean(
+    context.dataSourceId &&
+      normalizedDbType &&
+      !['MYSQL', 'MARIADB', 'SQLITE'].includes(normalizedDbType),
+  );
+
+  const dataSourceItems = dataSources.map((item) => ({
+    value: item.value,
+    label: `@${item.label}`,
+    searchText: item.dbType,
+    icon: <Server size={13} strokeWidth={1.8} className="text-[#1677ff]" />,
+  }));
+  const databaseItems = databases.map((value) => ({
+    value,
+    label: value,
+    icon: <Database size={13} strokeWidth={1.8} className="text-[#475467]" />,
+  }));
+  const schemaItems = schemas.map((value) => ({
+    value,
+    label: value,
+    icon: <Layers3 size={13} strokeWidth={1.8} className="text-[#667085]" />,
+  }));
+
   return (
-    <div className="flex min-w-0 shrink-0 items-center gap-1.5">
-      <Tooltip title="SQL 数据源" mouseEnterDelay={0.35}>
-        <div className={`${contextControlClassName} w-[176px]`}>
-          <Database
-            size={13}
-            strokeWidth={1.8}
-            className="ml-2 shrink-0 text-[#667085]"
-          />
-          <Select
-            allowClear
-            showSearch
-            size="small"
-            variant="borderless"
-            optionFilterProp="label"
-            placeholder="选择数据源"
-            loading={dataSourceLoading}
-            value={context.dataSourceId}
-            options={dataSources.map((item) => ({
-              label: `@${item.label}`,
-              value: item.value,
-              title: item.dbType ? `${item.label} · ${item.dbType}` : item.label,
-            }))}
-            popupMatchSelectWidth={260}
-            className="min-w-0 flex-1"
-            onChange={(value) => {
-              const selected = dataSources.find((item) => item.value === value);
-              selectSqlDataSourceContext(
-                nodeId,
-                selected
-                  ? {
-                      id: selected.value,
-                      name: selected.label,
-                      dbType: selected.dbType,
-                    }
-                  : undefined,
-              );
-            }}
-          />
-        </div>
-      </Tooltip>
+    <>
+      <div className="flex min-w-0 shrink-0 items-center gap-0.5">
+        <ContextPicker
+          ariaLabel="选择 SQL 数据源"
+          value={context.dataSourceId}
+          displayValue={context.dataSourceName ? `@${context.dataSourceName}` : undefined}
+          placeholder="@datasource"
+          icon={<Server size={13} strokeWidth={1.8} className="text-[#1677ff]" />}
+          items={dataSourceItems}
+          loading={dataSourceLoading}
+          popupWidth={210}
+          minWidthClassName="min-w-[112px]"
+          onSelect={(value) => {
+            const selected = dataSources.find((item) => item.value === value);
+            if (!selected) return;
+            selectSqlDataSourceContext(nodeId, {
+              id: selected.value,
+              name: selected.label,
+              dbType: selected.dbType,
+            });
+          }}
+        />
 
-      <Tooltip title="Database" mouseEnterDelay={0.35}>
-        <div className={`${contextControlClassName} w-[140px]`}>
-          <span className="ml-2 shrink-0 text-[10px] font-medium text-[#98a2b3]">
-            DB
-          </span>
-          <Select
-            allowClear
-            showSearch
-            size="small"
-            variant="borderless"
-            placeholder="<database>"
-            disabled={!context.dataSourceId}
-            loading={databaseLoading}
-            value={context.database}
-            options={databases.map((value) => ({ label: value, value }))}
-            popupMatchSelectWidth={220}
-            className="min-w-0 flex-1"
-            onChange={(value) => selectSqlDatabaseContext(nodeId, value)}
-          />
-        </div>
-      </Tooltip>
+        <ContextPicker
+          ariaLabel="选择 Database"
+          value={context.database}
+          displayValue={context.database}
+          placeholder="<database>"
+          icon={<Database size={13} strokeWidth={1.8} className="text-[#475467]" />}
+          items={databaseItems}
+          loading={databaseLoading}
+          disabled={!context.dataSourceId}
+          popupWidth={210}
+          minWidthClassName="min-w-[116px]"
+          onSelect={(value) => selectSqlDatabaseContext(nodeId, value)}
+        />
 
-      <Tooltip title="Schema" mouseEnterDelay={0.35}>
-        <div className={`${contextControlClassName} w-[124px]`}>
-          <span className="ml-2 shrink-0 text-[10px] font-medium text-[#98a2b3]">
-            S
-          </span>
-          <Select
-            allowClear
-            showSearch
-            size="small"
-            variant="borderless"
-            placeholder="<schema>"
-            disabled={!context.dataSourceId}
-            loading={schemaLoading}
+        {showSchemaPicker ? (
+          <ContextPicker
+            ariaLabel="选择 Schema"
             value={context.schema}
-            options={schemas.map((value) => ({ label: value, value }))}
-            popupMatchSelectWidth={200}
-            className="min-w-0 flex-1"
-            onChange={(value) => selectSqlSchemaContext(nodeId, value)}
+            displayValue={context.schema}
+            placeholder="<schema>"
+            icon={<Layers3 size={13} strokeWidth={1.8} className="text-[#667085]" />}
+            items={schemaItems}
+            loading={schemaLoading}
+            disabled={!context.dataSourceId}
+            popupWidth={210}
+            minWidthClassName="min-w-[108px]"
+            onSelect={(value) => selectSqlSchemaContext(nodeId, value)}
           />
-        </div>
-      </Tooltip>
-    </div>
+        ) : null}
+      </div>
+
+      <style>{`
+        .sql-metadata-context-popover .ant-popover-inner {
+          padding: 0;
+          overflow: hidden;
+          border: 1px solid #dfe3e8;
+          border-radius: 3px;
+          box-shadow: 0 4px 12px rgba(16, 24, 40, 0.10);
+        }
+        .sql-metadata-context-popover .ant-popover-inner-content {
+          padding: 0;
+        }
+      `}</style>
+    </>
   );
 };
 


### PR DESCRIPTION
## 变更说明

根据最新截图反馈，上一版 SQL 工具栏右侧的数据源 / Database / Schema 仍然太像 Ant Design 表单控件。本次直接按参考 IDE 的顶部数据库上下文样式重新实现。

### 1. 数据源 / Database 改成 IDE 顶部轻量按钮

- 去掉原来的 Select 外框、DB / S 前缀和大块输入框视觉
- 数据源采用 `图标 + @数据源名称 + 下拉箭头` 的紧凑样式
- Database 采用 `数据库图标 + <database> / 当前 Database + 下拉箭头`
- 控件高度收敛到 24px，与参考图一致，选中的数据源使用浅灰背景
- 两个选择器之间仅保留很小的间距，不再像三个独立表单框

### 2. 下拉面板按参考图重做

不再直接使用 AntD Select 默认 popup，而是使用轻量 Popover 自定义面板：

- 约 210px 宽
- 顶部固定搜索栏，样式为 `搜索图标 + 搜索`
- 下方为扁平数据源 / Database 列表
- 1px 浅灰边框、3px 圆角、轻量阴影
- 不显示多余的选中高亮块、Tag、描述信息
- 点击条目后立即切换上下文并收起

### 3. 真实接口逻辑保持不变

继续使用 #333 已接入的真实 Catalog API 和现有 SQL metadata context store：

- 数据源仍来自 `/api/v1/data-source/option`
- Database 仍来自 `/api/v1/data-source/catalog/{id}/databases`
- Schema 仍来自 `/api/v1/data-source/catalog/{id}/schemas`
- SQL 补全、nodeId 隔离、本地持久化逻辑均不变

### 4. Schema 做数据库类型适配

参考图是 MySQL 风格，只展示数据源和 Database。因此：

- MySQL / MariaDB / SQLite 只显示两个选择器，和参考图保持一致
- 对存在独立 Schema 概念的其他数据库类型，仍保留同风格的 Schema 选择器，避免为了样式复刻破坏原有能力

## 影响范围

仅修改：

- `yak-ops-ui/src/pages/data-development/editors/sql/metadata/SqlMetadataContextToolbar.tsx`

不修改后端接口、SQL 执行、Catalog 服务、补全逻辑和其他编辑器。

## 建议回归

- 选择 MySQL 数据源，确认右侧只显示 `@数据源` + `<database>` 两个轻量控件
- 打开数据源下拉，确认搜索栏和列表结构与参考截图接近
- 切换数据源后确认 Database 列表来自真实 Catalog API
- 选择 Database 后确认 SQL metadata completion 上下文正常变化
- 切换 SQL Tab，确认不同节点上下文仍相互隔离
- PostgreSQL / Oracle 等存在 Schema 的数据源确认 Schema 入口仍可使用

本次为纯前端视觉和交互收敛，没有新增 npm 依赖。