### PR TITLE
style(data-development): polish compact tree styling

### DIFF
--- a/yak-ops-ui/src/global.less
+++ b/yak-ops-ui/src/global.less
@@ -97,6 +97,51 @@ ol {
   background: rgba(0, 0, 0, 0.55)
 }
 
+// Data development tree: keep the compact, polished density used by Chat2DB.
+.development-tree.ant-tree {
+  font-size: 13px;
+}
+
+.development-tree .ant-tree-list-holder-inner {
+  gap: 0 !important;
+}
+
+.development-tree .ant-tree-treenode {
+  min-height: 26px !important;
+  padding: 0 2px !important;
+}
+
+.development-tree .ant-tree-node-content-wrapper {
+  height: 26px !important;
+  line-height: 26px !important;
+}
+
+.development-tree .ant-tree-indent-unit {
+  width: 14px !important;
+}
+
+.development-tree .ant-tree-switcher,
+.development-tree .ant-tree-switcher-noop {
+  width: 16px !important;
+}
+
+.development-tree .ant-tree-switcher {
+  height: 26px !important;
+  line-height: 26px !important;
+}
+
+.development-tree .ant-tree-title > div {
+  gap: 5px !important;
+}
+
+.development-tree .ant-tree-title > div > span {
+  line-height: 26px !important;
+}
+
+.development-tree .lucide-folder {
+  color: #f5ad18 !important;
+}
+
 // .ant-input-filled {
 //   border-width: 0px;
 // }


### PR DESCRIPTION
## 调整内容

参考 Chat2DB 左侧树的视觉密度，对数据开发目录树做一轮轻量打磨：

- 将节点高度从 30px 收紧到 26px，去掉节点之间的额外间距
- 将层级缩进从 18px 收紧到 14px，展开箭头占位同步压缩
- 缩小图标与文字之间的间距，让多层目录更紧凑
- 目录图标调整为 Chat2DB 风格的暖黄色，提升目录/任务节点的区分度
- 保留现有 SQL / SHELL 图标、类型标识、选中、展开、右键菜单等交互逻辑

## Scope

仅调整 `.development-tree` 的视觉样式，不改动数据加载与交互逻辑。

## Validation

- [x] 已检查分支与 `main` 的 diff，仅修改数据开发树相关样式
- [ ] 浏览器视觉回归：多层目录展开 / 收起
- [ ] 浏览器交互回归：选中、右键菜单、新建、拖拽面板宽度
