### PR TITLE
fix(data-development): confirm before closing unsaved tabs

### DIFF
--- a/yak-ops-ui/src/pages/data-development/components/workbench/DevelopmentWorkbench.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/workbench/DevelopmentWorkbench.tsx
@@ -1,6 +1,13 @@
+import { Button, Modal } from 'antd';
+import { TriangleAlert } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 
 import { getEditorDefinition } from '../../editors/registry';
+import {
+  getEditorSession,
+  markEditorSessionSaved,
+  updateEditorSessionContent,
+} from '../../editors/session/editorSessionStore';
 import type {
   DevelopmentDirectory,
   DevelopmentId,
@@ -19,6 +26,11 @@ interface DevelopmentWorkbenchProps {
   onNodeFocus: (nodeId?: DevelopmentId) => void;
 }
 
+interface PendingCloseRequest {
+  nodeIds: DevelopmentId[];
+  dirtyNodeIds: DevelopmentId[];
+}
+
 const DevelopmentWorkbench = ({
   nodes,
   directories,
@@ -28,6 +40,7 @@ const DevelopmentWorkbench = ({
   const [openNodeIds, setOpenNodeIds] = useState<DevelopmentId[]>([]);
   const [activeNodeId, setActiveNodeId] = useState<DevelopmentId>();
   const [runPanelOpen, setRunPanelOpen] = useState(false);
+  const [pendingClose, setPendingClose] = useState<PendingCloseRequest>();
 
   const nodeMap = useMemo(
     () => new Map(nodes.map((node) => [node.id, node])),
@@ -63,24 +76,61 @@ const DevelopmentWorkbench = ({
     onNodeFocus(nodeId);
   };
 
-  const closeNode = (nodeId: DevelopmentId) => {
-    const currentIndex = openNodeIds.indexOf(nodeId);
-    const next = openNodeIds.filter((id) => id !== nodeId);
+  const closeNodes = (nodeIds: DevelopmentId[]) => {
+    if (!nodeIds.length) return;
+
+    const closeSet = new Set(nodeIds);
+    const currentIndex = activeNodeId ? openNodeIds.indexOf(activeNodeId) : -1;
+    const next = openNodeIds.filter((id) => !closeSet.has(id));
     setOpenNodeIds(next);
 
-    if (activeNodeId !== nodeId) return;
+    if (!activeNodeId || !closeSet.has(activeNodeId)) return;
+
     const nextActiveId =
-      next[Math.min(currentIndex, next.length - 1)] || next[next.length - 1];
+      next[Math.min(Math.max(currentIndex, 0), next.length - 1)] ||
+      next[next.length - 1];
     setActiveNodeId(nextActiveId);
     onNodeFocus(nextActiveId);
     if (!nextActiveId) setRunPanelOpen(false);
   };
 
-  const closeAllNodes = () => {
-    setOpenNodeIds([]);
-    setActiveNodeId(undefined);
-    setRunPanelOpen(false);
-    onNodeFocus(undefined);
+  const requestCloseNodes = (nodeIds: DevelopmentId[]) => {
+    const targetNodeIds = openNodeIds.filter((nodeId) => nodeIds.includes(nodeId));
+    if (!targetNodeIds.length) return;
+
+    const dirtyNodeIds = targetNodeIds.filter(
+      (nodeId) => getEditorSession(nodeId)?.dirty,
+    );
+
+    if (!dirtyNodeIds.length) {
+      closeNodes(targetNodeIds);
+      return;
+    }
+
+    setPendingClose({
+      nodeIds: targetNodeIds,
+      dirtyNodeIds,
+    });
+  };
+
+  const resolvePendingClose = (save: boolean) => {
+    if (!pendingClose) return;
+
+    pendingClose.dirtyNodeIds.forEach((nodeId) => {
+      const session = getEditorSession(nodeId);
+      if (!session?.dirty) return;
+
+      if (save) {
+        markEditorSessionSaved(nodeId);
+        return;
+      }
+
+      updateEditorSessionContent(nodeId, session.originalContent);
+    });
+
+    const nodeIds = pendingClose.nodeIds;
+    setPendingClose(undefined);
+    closeNodes(nodeIds);
   };
 
   const handleTabAction = (action: EditorTabAction) => {
@@ -89,25 +139,31 @@ const DevelopmentWorkbench = ({
     if (activeIndex < 0) return;
 
     if (action === 'close-current') {
-      closeNode(activeNodeId);
+      requestCloseNodes([activeNodeId]);
       return;
     }
     if (action === 'close-all') {
-      closeAllNodes();
+      requestCloseNodes(openNodeIds);
       return;
     }
     if (action === 'close-others') {
-      setOpenNodeIds([activeNodeId]);
+      requestCloseNodes(openNodeIds.filter((nodeId) => nodeId !== activeNodeId));
       return;
     }
     if (action === 'close-left') {
-      setOpenNodeIds(openNodeIds.slice(activeIndex));
+      requestCloseNodes(openNodeIds.slice(0, activeIndex));
       return;
     }
     if (action === 'close-right') {
-      setOpenNodeIds(openNodeIds.slice(0, activeIndex + 1));
+      requestCloseNodes(openNodeIds.slice(activeIndex + 1));
     }
   };
+
+  const pendingDirtyNodes = pendingClose?.dirtyNodeIds
+    .map((nodeId) => nodeMap.get(nodeId))
+    .filter((node): node is DevelopmentNode => Boolean(node));
+  const pendingDirtyCount = pendingDirtyNodes?.length || 0;
+  const pendingDirtyName = pendingDirtyNodes?.[0]?.name || '当前编辑器';
 
   if (!openNodeIds.length || !activeNode) {
     return (
@@ -133,7 +189,7 @@ const DevelopmentWorkbench = ({
         openNodeIds={openNodeIds}
         activeNodeId={activeNodeId}
         onFocus={focusNode}
-        onClose={closeNode}
+        onClose={(nodeId) => requestCloseNodes([nodeId])}
         onAction={handleTabAction}
       />
 
@@ -166,6 +222,58 @@ const DevelopmentWorkbench = ({
           onClose={() => setRunPanelOpen(false)}
         />
       </div>
+
+      <Modal
+        open={Boolean(pendingClose)}
+        title={null}
+        footer={null}
+        width={520}
+        centered
+        maskClosable={false}
+        onCancel={() => setPendingClose(undefined)}
+      >
+        <div className="flex gap-4 px-1 py-2">
+          <div className="flex h-10 w-10 shrink-0 items-center justify-center text-[#f79009]">
+            <TriangleAlert size={36} strokeWidth={1.7} />
+          </div>
+
+          <div className="min-w-0 flex-1 pt-1">
+            <div className="text-[16px] font-medium leading-6 text-[#1f2937]">
+              {pendingDirtyCount <= 1 ? (
+                <>
+                  是否要保存对 <span className="font-semibold">{pendingDirtyName}</span>{' '}
+                  的更改？
+                </>
+              ) : (
+                <>是否要保存 {pendingDirtyCount} 个已修改编辑器的更改？</>
+              )}
+            </div>
+
+            <div className="mt-4 text-[13px] leading-5 text-[#475467]">
+              如果不保存，{pendingDirtyCount <= 1 ? '你的更改' : '这些更改'}将丢失。
+            </div>
+
+            {pendingDirtyCount > 1 ? (
+              <div
+                className="mt-2 max-w-[360px] truncate text-[12px] text-[#98a2b3]"
+                title={pendingDirtyNodes?.map((node) => node.name).join('、')}
+              >
+                {pendingDirtyNodes?.map((node) => node.name).join('、')}
+              </div>
+            ) : null}
+
+            <div className="mt-6 flex justify-end gap-2">
+              <Button type="primary" onClick={() => resolvePendingClose(true)}>
+                {pendingDirtyCount > 1 ? '保存全部' : '保存'}
+              </Button>
+              <Button onClick={() => resolvePendingClose(false)}>
+                {pendingDirtyCount > 1 ? '全部不保存' : '不保存'}
+              </Button>
+              <Button onClick={() => setPendingClose(undefined)}>取消</Button>
+            </div>
+          </div>
+        </div>
+      </Modal>
     </main>
   );
 };


### PR DESCRIPTION
## 背景

数据开发编辑器 Tab 在存在未保存修改时，点击关闭会直接关闭，容易造成误操作。

## 调整内容

- 关闭未保存的编辑器 Tab 时增加确认 Modal
- 单个 Tab 提示文案参考常见 IDE 交互：`保存 / 不保存 / 取消`
- `保存`：保存当前本地草稿后关闭 Tab
- `不保存`：回退本次未保存修改后关闭 Tab
- `取消`：保留当前 Tab 和编辑内容
- 已保存/未修改的 Tab 仍然直接关闭，不增加额外打扰
- 中键关闭、关闭当前、关闭其他、关闭左侧/右侧、全部关闭统一接入未保存保护
- 批量关闭存在多个未保存 Tab 时，统一提示 `保存全部 / 全部不保存 / 取消`

## Scope

仅调整数据开发工作台 Tab 关闭逻辑，不改动编辑器内容、数据源选择和运行逻辑。

## Validation

- [x] 已检查与 `main` 的 diff，仅修改 `DevelopmentWorkbench.tsx`
- [x] 保留原有 Tab 激活与关闭后的焦点切换逻辑
- [ ] 浏览器回归：修改 SQL 后点击 Tab 关闭按钮
- [ ] 浏览器回归：保存 / 不保存 / 取消三种路径
- [ ] 浏览器回归：关闭其他 / 左侧 / 右侧 / 全部关闭
