### PR TITLE
docs(task): define unified task plugin core model

### DIFF
--- a/docs/task-plugin-core-model.md
+++ b/docs/task-plugin-core-model.md
@@ -1,0 +1,253 @@
+# Task Plugin 核心模型设计
+
+> 状态：Accepted（阶段 1）  
+> 范围：统一 Yak Ops 数据开发、工作流与调度之间的任务语义；本阶段不实现具体任务插件与执行器。
+
+## 1. 背景
+
+Yak Ops 的数据开发页面已经具备 SQL、Shell 等开发节点的前端雏形，工作流也已经存在任务编排入口。后续如果分别在数据开发、工作流、调度中实现 SQL/Shell/Python 执行逻辑，会产生重复实现和行为不一致。
+
+因此统一采用“任务资产 + 不可变发布版本 + Task Plugin + Task Runtime”的方向：
+
+- 数据开发负责开发、保存草稿、调试和发布；
+- Task Catalog 负责暴露可被编排的已发布任务资产；
+- Workflow 只引用已发布任务版本，不复制任务内容；
+- Schedule/Workflow/手动运行最终都进入统一 Task Runtime；
+- Task Plugin 只负责某一种任务能力如何校验和执行。
+
+该设计借鉴 DolphinScheduler 的 Task Plugin 职责拆分，以及 Chat2DB 的 SPI/Plugin 隔离方式，但保持 Yak Ops 当前 `business / spi / plugins` 的模块边界，不引入独立 Master/Worker、注册中心或动态前端插件系统。
+
+## 2. 核心概念
+
+### 2.1 DevelopmentNode
+
+数据开发目录中的设计态节点，负责“它是谁、叫什么、放在哪里”。
+
+典型字段：`id / name / type / projectId / directoryId`。
+
+约束：
+
+- `DevelopmentNode` 不是生产执行的事实来源；
+- 节点名称、目录位置可以修改；
+- SQL/Shell/Python 的具体内容不继续扩散为 `yak_dev_sql_task / yak_dev_shell_task / ...` 多套业务模型。
+
+### 2.2 TaskDraft
+
+任务的可变工作副本。
+
+- 保存只更新 Draft；
+- Draft 可以被反复修改；
+- Draft 不进入 Task Catalog；
+- Draft 不允许被 Workflow 新建引用；
+- 发布时由 Draft 固化出新的不可变 TaskRevision。
+
+### 2.3 TaskDefinition
+
+插件无关的任务定义载荷，也是后续 Task Plugin 与 Task Runtime 之间的稳定输入模型：
+
+```text
+TaskDefinition
+  taskType       SQL / SHELL / PYTHON / HTTP / ...
+  schemaVersion  插件配置结构版本
+  content        SQL、脚本等主内容，可为空
+  configJson     插件私有配置 JSON
+```
+
+本阶段在 `yak-ops-spi` 中提供最小不可变模型 `TaskDefinition`，但不提供插件执行接口。
+
+### 2.4 TaskRevision
+
+一次“发布”产生的不可变快照。
+
+```text
+TaskRevision
+  revisionId
+  assetId
+  revisionNo
+  definition
+  checksum
+  createdBy
+  createdTime
+```
+
+约束：
+
+- `revisionNo` 对同一 TaskAsset 单调递增；
+- 已发布 Revision 不原地修改；
+- Workflow/调度运行必须最终解析到明确的 Revision；
+- 新发布 v2 不得让已绑定 v1 的生产 Workflow 静默升级。
+
+### 2.5 TaskAsset
+
+平台统一“任务资产目录”中的稳定身份，解决“上线一个数据开发任务后自动出现在 Workflow 中”的问题。
+
+```text
+TaskAsset
+  assetId
+  name
+  source
+  sourceId
+  taskType
+  currentRevisionId
+  status
+```
+
+`source` 第一阶段统一为：
+
+- `DATA_DEVELOPMENT`
+- `DATA_INTEGRATION`
+- `DATA_QUALITY`
+
+Workflow 左侧的“数据同步 / 数据开发 / 数据质量”只是 Task Catalog 的不同 source 视图，不直接查询各业务模块表。
+
+资产状态：
+
+- `ONLINE`：允许被新的 Workflow 引用；
+- `OFFLINE`：不允许新增引用，但历史 Revision 与已有引用保留；
+- `DISABLED`：运行层禁止执行，用于强制停用。
+
+### 2.6 TaskExecution
+
+一次实际运行记录。它必须引用明确的 TaskRevision，而不是读取“最新草稿”。
+
+触发来源统一为：
+
+- `MANUAL`：数据开发/任务详情手动运行；
+- `WORKFLOW`：工作流节点运行；
+- `SCHEDULE`：调度直接触发任务或后续统一调度入口。
+
+基础状态语义统一为：`PENDING / RUNNING / SUCCESS / FAILED / CANCELLED / TIMEOUT`。
+
+本阶段只固定语义，不落运行表、不实现执行器。
+
+### 2.7 TaskPlugin
+
+TaskPlugin 是“某种任务怎么校验、怎么执行”的能力插件，不是用户创建的任务本身。
+
+未来计划：
+
+```text
+TaskPlugin
+  type()
+  descriptor()
+  validate(TaskDefinition)
+  createExecutor(TaskDefinition, TaskExecutionContext)
+```
+
+本阶段不创建 `TaskPlugin`/`TaskExecutor` 接口；它们属于阶段 2 的 `yak-ops-plugin-task-api` 骨架。
+
+## 3. 生命周期
+
+```text
+DevelopmentNode
+      |
+      v
+  TaskDraft  <------ 保存 / 编辑 / 调试
+      |
+      | publish
+      v
+TaskRevision v1  ---- immutable
+      |
+      v
+ TaskAsset ONLINE
+      |
+      v
+   Task Catalog
+      |
+      +---------- Workflow 选择/拖入
+      |                 |
+      |                 v
+      |       assetId + revisionId(v1)
+      |
+      +---------- Manual / Schedule
+                        |
+                        v
+                  TaskExecution
+                        |
+                        v
+                   Task Runtime
+                        |
+                        v
+                    TaskPlugin
+```
+
+再次修改并发布：
+
+```text
+Draft -> Revision v2
+
+Workflow A -> v1（保持不变，可提示有新版本）
+Workflow B -> v2（新建时使用当前发布版本）
+```
+
+## 4. Workflow 集成规则
+
+1. Workflow 任务选择器查询 Task Catalog，不直接查询 `yak_dev_node`、同步任务表或质量任务表。
+2. 拖入任务时保存 `taskAssetId + taskRevisionId`。
+3. Workflow 发布后，引用的 Revision 必须保持稳定。
+4. TaskAsset 发布新版本后，可提示 Workflow “有新版本可升级”，但不得自动替换。
+5. `OFFLINE` 仅阻止新增引用；已有 Workflow 仍保留其历史 Revision。
+6. `DISABLED` 在 Task Runtime 层拒绝新的执行。
+7. Workflow 不直接依赖 SQL/Shell/Python 具体插件实现。
+
+## 5. 模块与依赖方向
+
+目标依赖方向：
+
+```text
+yak-ops-ui
+   |
+   +--> business-data-development
+   +--> business-workflow
+   +--> future task-catalog / task-runtime
+                         |
+                         v
+                 task-plugin-api
+                         |
+          +--------------+--------------+
+          v              v              v
+       sql plugin     shell plugin    python plugin
+          |
+          v
+  datasource plugin api
+```
+
+约束：
+
+- `business-*` 不依赖具体任务插件；
+- Workflow 不自建一套 SQL/Shell 执行器；
+- SQL Task Plugin 复用现有 DataSource Plugin，不按数据库重复建设 SQL Task Plugin；
+- 插件私有参数进入 `TaskDefinition.configJson`，平台只负责版本、资产、权限、审计与运行编排；
+- TaskDraft/TaskAsset/TaskRevision/TaskExecution 属于业务/运行时聚合，不塞进具体插件模块。
+
+## 6. 阶段 1 代码边界
+
+本阶段只在 `yak-ops-spi.task.model` 放置后续跨模块会共同使用的最小词汇：
+
+- `TaskDefinition`
+- `TaskRevisionRef`
+- `TaskAssetSource`
+- `TaskAssetStatus`
+- `TaskExecutionTrigger`
+- `TaskExecutionStatus`
+
+这些类型不是数据库实体，也不代表已经实现 Task Runtime。
+
+本阶段明确不做：
+
+- 不新增数据库表或 Flyway Migration；
+- 不新增 `yak-ops-plugin-task-*` Maven 模块；
+- 不实现 `TaskPluginRegistry` / `ServiceLoader`；
+- 不实现 SQL/Shell/Python 执行；
+- 不修改 Workflow 运行逻辑；
+- 不修改数据开发现有 API 行为。
+
+## 7. 后续阶段
+
+1. 阶段 2：建立 `yak-ops-plugin-task-api / sql / all` 骨架和 `TaskPluginRegistry`。
+2. 阶段 3：实现 Draft / Revision / Publish 后端与版本模型。
+3. 阶段 4：实现 SQL Task Plugin，复用 DataSource Plugin，打通手动运行。
+4. 阶段 5：建立 Task Catalog，发布任务自动进入 Workflow 任务库。
+5. 阶段 6：Workflow 节点绑定 `TaskAsset + TaskRevision`。
+6. 阶段 7：Manual/Workflow/Schedule 统一进入 Task Runtime。
+7. 阶段 8：扩展 Shell/Python/HTTP 与可选 Worker/Container Execution Backend。

--- a/docs/workflow-task-plugin-integration.md
+++ b/docs/workflow-task-plugin-integration.md
@@ -1,68 +1,132 @@
 # Workflow 与 Task Plugin 集成设计
 
+> 本文已按统一 Task Plugin 核心模型修订。Workflow 不再拥有一套独立的任务插件执行模型，而是通过 Task Catalog 引用已发布任务，并在运行时统一进入 Task Runtime。
+
 ## 设计目标
 
-Yak Ops 借鉴 DolphinScheduler 的任务插件职责拆分，但保持当前单进程工作流引擎的轻量定位，不引入 Master、Worker 或注册中心。
+Yak Ops 借鉴 DolphinScheduler 的任务插件职责拆分，但保持当前架构轻量，不在 Workflow 模块中复制 SQL/Shell/Python 执行逻辑，也不在当前阶段引入 Master、Worker 或注册中心。
 
-对应关系：
-
-| DolphinScheduler | Yak Ops | 职责 |
-| --- | --- | --- |
-| `TaskChannelFactory` | `WorkflowTaskPluginFactory` | 插件身份、元数据、配置校验和执行器创建 |
-| `TaskChannel` | `WorkflowTaskExecutorRegistry` | 插件发现、类型唯一性和运行时路由 |
-| `AbstractTask` | `WorkflowTaskExecutor` | 一次物理 Attempt 的执行与取消 |
-| `AbstractParameters` | 插件 `configurationSchema` 与 `validate` | 参数结构描述和发布期校验 |
-| `TaskExecutionContext` | `WorkflowTaskContext` | 工作流实例、任务实例、Attempt、参数、日志和取消信号 |
-
-## 生命周期
+统一关系：
 
 ```text
-应用启动
-  -> ServiceLoader 发现 WorkflowTaskPluginFactory
-  -> WorkflowTaskExecutorRegistry 建立插件目录
-
-设计器打开
-  -> GET /api/v1/workflows/task-plugins
-  -> 节点选择器合并后端插件目录
-  -> 未提供专属表单的插件使用通用 JSON 配置
-
-保存草稿
-  -> 保存 taskType + config
-
-发布工作流
-  -> WorkflowDagCompiler 校验 DAG
-  -> WorkflowTaskExecutorRegistry.validate(taskType, config)
-  -> 插件执行静态参数校验
-
-运行工作流
-  -> 每个物理 Attempt 调用 factory.create()
-  -> 创建独立 WorkflowTaskExecutor
-  -> 注入 WorkflowTaskContext
-  -> 执行、日志、取消、超时、重试和结果落库
+数据开发 / 数据同步 / 数据质量
+          |
+          | publish
+          v
+      Task Catalog
+          |
+          | assetId + revisionId
+          v
+       Workflow
+          |
+          v
+     Task Runtime
+          |
+          v
+  TaskPluginRegistry
 ```
 
-## 参数命名空间
+核心模型与生命周期以 [`task-plugin-core-model.md`](./task-plugin-core-model.md) 为准。
 
-任务插件统一从 `WorkflowTaskContext.parameters()` 读取参数：
+## Workflow 的职责
+
+Workflow 只负责：
+
+- 编排任务依赖关系；
+- 保存任务资产与发布版本引用；
+- 传递工作流上下文、参数和触发信息；
+- 展示运行实例、节点状态和日志入口；
+- 将节点执行请求交给统一 Task Runtime。
+
+Workflow 不负责：
+
+- 解析 SQL 数据源参数；
+- 启动 Shell/Python 进程；
+- 根据数据库类型选择 JDBC 实现；
+- 直接发现或加载具体 Task Plugin；
+- 保存一份独立于 TaskRevision 的任务正文副本。
+
+## 任务选择器
+
+工作流设计器左侧的“数据同步 / 数据开发 / 数据质量”统一查询 Task Catalog：
 
 ```text
-${name}                       兼容原有全局参数
-${global.name}                显式全局参数
-${system.workflowInstanceId}  工作流实例 ID
-${system.taskInstanceId}      任务实例 ID
-${system.attemptId}           物理尝试 ID
-${system.attemptNo}           当前尝试次数
-${system.nodeKey}             节点编码
-${system.taskType}            插件类型
+DATA_INTEGRATION
+DATA_DEVELOPMENT
+DATA_QUALITY
 ```
 
-## 插件扩展步骤
+只有 `ONLINE` 资产允许新增引用。
 
-1. 新建独立 Maven 模块，例如 `yak-ops-plugin-task-python`。
-2. 实现 `WorkflowTaskExecutor`，负责单次 Attempt 的执行和取消。
-3. 实现 `WorkflowTaskPluginFactory`，提供描述信息、配置 Schema 和执行器创建。
-4. 在 `META-INF/services/io.yak.ops.spi.workflow.WorkflowTaskPluginFactory` 声明 Factory。
-5. 将模块加入 `yak-ops-plugin-task-all`。
-6. 增加参数校验、执行、取消和 ServiceLoader 发现测试。
+拖入画布时，Workflow Node 保存：
 
-工作流业务模块不得直接依赖具体任务插件。Boot 通过 `task-all` 完成最终装配。
+```text
+taskAssetId
+taskRevisionId
+```
+
+而不是只保存业务模块自己的 `sourceId`，也不复制 SQL/Shell 内容。
+
+## 版本规则
+
+假设数据开发任务“今天统计”已经发布 v1：
+
+```text
+今天统计
+  v1 <- Workflow A
+```
+
+之后开发人员修改并发布 v2：
+
+```text
+今天统计
+  v1 <- Workflow A（保持不变）
+  v2 <- current
+```
+
+Workflow A 可以提示存在 v2，但必须由用户显式升级引用。生产 Workflow 不允许因为上游任务再次发布而静默改变行为。
+
+## 运行时规则
+
+未来统一由 Task Runtime 处理：
+
+```text
+Manual Run ----+
+Workflow Run --+--> Task Runtime --> TaskPlugin
+Schedule Run --+
+```
+
+Workflow 只提供触发上下文，例如：
+
+```text
+workflowDefinitionId
+workflowInstanceId
+workflowNodeKey
+taskAssetId
+taskRevisionId
+parameters
+```
+
+Task Runtime 再构造插件执行上下文、运行记录、取消信号、超时和日志能力。
+
+## 与旧方案的差异
+
+旧设计曾考虑由 Workflow 直接维护 `WorkflowTaskPluginFactory / WorkflowTaskExecutorRegistry / WorkflowTaskExecutor`。该方式会让 Workflow 成为任务插件的唯一宿主，后续数据开发手动运行和独立调度还需要再实现一套入口。
+
+现在统一调整为：
+
+```text
+Workflow -> Task Runtime -> Task Plugin
+```
+
+因此后续不再新增 Workflow 专属 Task Plugin SPI。插件能力属于平台级 Task Plugin，供数据开发、Workflow、Schedule 共同复用。
+
+## 实施顺序
+
+1. 固定 Task 核心模型与版本语义；
+2. 建立平台级 `yak-ops-plugin-task` 插件骨架；
+3. 完成数据开发 Draft/Revision/Publish；
+4. SQL 插件打通手动运行；
+5. Task Catalog 接入 Workflow 任务选择器；
+6. Workflow 固定绑定 TaskRevision；
+7. 三种触发方式统一进入 Task Runtime。

--- a/yak-ops-spi/src/main/java/io/yak/ops/spi/task/model/TaskAssetSource.java
+++ b/yak-ops-spi/src/main/java/io/yak/ops/spi/task/model/TaskAssetSource.java
@@ -1,0 +1,8 @@
+package io.yak.ops.spi.task.model;
+
+/** Platform module that owns the source task before it is published to the task catalog. */
+public enum TaskAssetSource {
+  DATA_DEVELOPMENT,
+  DATA_INTEGRATION,
+  DATA_QUALITY
+}

--- a/yak-ops-spi/src/main/java/io/yak/ops/spi/task/model/TaskAssetStatus.java
+++ b/yak-ops-spi/src/main/java/io/yak/ops/spi/task/model/TaskAssetStatus.java
@@ -1,0 +1,8 @@
+package io.yak.ops.spi.task.model;
+
+/** Lifecycle state of a published task asset in the platform task catalog. */
+public enum TaskAssetStatus {
+  ONLINE,
+  OFFLINE,
+  DISABLED
+}

--- a/yak-ops-spi/src/main/java/io/yak/ops/spi/task/model/TaskDefinition.java
+++ b/yak-ops-spi/src/main/java/io/yak/ops/spi/task/model/TaskDefinition.java
@@ -1,0 +1,16 @@
+package io.yak.ops.spi.task.model;
+
+/**
+ * Plugin-neutral immutable task payload.
+ *
+ * @param taskType stable task type, for example SQL or SHELL
+ * @param schemaVersion version of the plugin-owned configuration schema
+ * @param content primary task content, for example SQL or script text
+ * @param configJson plugin-owned configuration serialized as JSON
+ */
+public record TaskDefinition(
+    String taskType,
+    int schemaVersion,
+    String content,
+    String configJson) {
+}

--- a/yak-ops-spi/src/main/java/io/yak/ops/spi/task/model/TaskExecutionStatus.java
+++ b/yak-ops-spi/src/main/java/io/yak/ops/spi/task/model/TaskExecutionStatus.java
@@ -1,0 +1,11 @@
+package io.yak.ops.spi.task.model;
+
+/** Common lifecycle state for one physical task execution. */
+public enum TaskExecutionStatus {
+  PENDING,
+  RUNNING,
+  SUCCESS,
+  FAILED,
+  CANCELLED,
+  TIMEOUT
+}

--- a/yak-ops-spi/src/main/java/io/yak/ops/spi/task/model/TaskExecutionTrigger.java
+++ b/yak-ops-spi/src/main/java/io/yak/ops/spi/task/model/TaskExecutionTrigger.java
@@ -1,0 +1,8 @@
+package io.yak.ops.spi.task.model;
+
+/** Entry point that caused one task execution. */
+public enum TaskExecutionTrigger {
+  MANUAL,
+  WORKFLOW,
+  SCHEDULE
+}

--- a/yak-ops-spi/src/main/java/io/yak/ops/spi/task/model/TaskRevisionRef.java
+++ b/yak-ops-spi/src/main/java/io/yak/ops/spi/task/model/TaskRevisionRef.java
@@ -1,0 +1,8 @@
+package io.yak.ops.spi.task.model;
+
+/** Stable reference to one immutable published task revision. */
+public record TaskRevisionRef(
+    Long assetId,
+    Long revisionId,
+    int revisionNo) {
+}

--- a/yak-ops-spi/src/main/java/io/yak/ops/spi/task/model/package-info.java
+++ b/yak-ops-spi/src/main/java/io/yak/ops/spi/task/model/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * Shared task vocabulary used across data development, task catalog, workflow and task runtime.
+ *
+ * <p>This package contains transport/domain-neutral value types only. Persistence entities,
+ * plugin discovery and concrete task execution belong to later layers.
+ */
+package io.yak.ops.spi.task.model;


### PR DESCRIPTION
## Summary

完成 Task Plugin 架构阶段 1：先固定 Yak Ops 跨数据开发、Workflow、Schedule 的统一任务语义，不实现具体 SQL/Shell/Python 执行。

### 本次内容

- 新增 `docs/task-plugin-core-model.md`
  - 明确 `DevelopmentNode / TaskDraft / TaskDefinition / TaskRevision / TaskAsset / TaskExecution / TaskPlugin` 职责边界
  - 明确 Draft -> Publish -> Revision -> Task Catalog -> Workflow -> Task Runtime 生命周期
  - 明确 Workflow 绑定 `taskAssetId + taskRevisionId`，新版本不静默升级
  - 明确 `ONLINE / OFFLINE / DISABLED` 资产语义
  - 明确 Manual / Workflow / Schedule 最终统一进入 Task Runtime
  - 明确 SQL Task Plugin 后续复用现有 DataSource Plugin
- 修订 `docs/workflow-task-plugin-integration.md`
  - 废弃 Workflow 专属 Task Plugin SPI 思路
  - 调整为 `Workflow -> Task Runtime -> Task Plugin`
- 在 `yak-ops-spi.task.model` 增加最小跨模块词汇：
  - `TaskDefinition`
  - `TaskRevisionRef`
  - `TaskAssetSource`
  - `TaskAssetStatus`
  - `TaskExecutionTrigger`
  - `TaskExecutionStatus`

## Deliberately out of scope

本 PR 不新增数据库表、不新增 task plugin Maven 模块、不实现 ServiceLoader/Registry、不实现 SQL/Shell/Python 执行，也不修改现有 Workflow/Data Development 运行逻辑。

## Next

下一阶段再建立 `yak-ops-plugin-task-api / sql / all` 骨架与 `TaskPluginRegistry`，用最小插件验证统一 SPI。