### PR TITLE
fix(data-development): lock database context to datasource binding

### DIFF
--- a/yak-ops-ui/src/pages/data-development/editors/sql/metadata/SqlMetadataContextToolbar.tsx
+++ b/yak-ops-ui/src/pages/data-development/editors/sql/metadata/SqlMetadataContextToolbar.tsx
@@ -11,9 +11,8 @@ import {
   useSqlMetadataContext,
 } from './sqlMetadataContextStore';
 import {
-  listSqlDatabases,
+  getSqlDataSourceBinding,
   listSqlDataSources,
-  listSqlSchemas,
   type SqlDataSourceOption,
 } from './sqlMetadataService';
 
@@ -143,12 +142,13 @@ const ContextPicker = ({
       <button
         type="button"
         aria-label={ariaLabel}
+        title={disabled ? `${ariaLabel}由数据源管理中的连接配置固定` : undefined}
         disabled={disabled}
         className={[
           'flex h-6 max-w-[176px] items-center gap-1.5 rounded-[3px] px-1.5 text-[12px] outline-none transition-colors',
           minWidthClassName,
           disabled
-            ? 'cursor-not-allowed text-[#b7bcc5]'
+            ? 'cursor-not-allowed bg-[#f5f6f7] text-[#a4a9b2]'
             : open || displayValue
               ? 'bg-[#f1f2f4] text-[#161823]'
               : 'text-[#30323b] hover:bg-[#f5f5f6]',
@@ -158,19 +158,25 @@ const ContextPicker = ({
         <span
           className={[
             'min-w-0 flex-1 truncate text-left',
-            displayValue ? 'text-[#30323b]' : 'text-[#7b808a]',
+            disabled
+              ? 'text-[#8f959f]'
+              : displayValue
+                ? 'text-[#30323b]'
+                : 'text-[#7b808a]',
           ].join(' ')}
         >
           {displayValue || placeholder}
         </span>
-        <ChevronDown
-          size={12}
-          strokeWidth={1.8}
-          className={[
-            'shrink-0 transition-transform duration-150',
-            open ? 'rotate-180' : '',
-          ].join(' ')}
-        />
+        {!disabled ? (
+          <ChevronDown
+            size={12}
+            strokeWidth={1.8}
+            className={[
+              'shrink-0 transition-transform duration-150',
+              open ? 'rotate-180' : '',
+            ].join(' ')}
+          />
+        ) : null}
       </button>
     </Popover>
   );
@@ -181,11 +187,8 @@ const SqlMetadataContextToolbar = ({
 }: SqlMetadataContextToolbarProps) => {
   const context = useSqlMetadataContext(nodeId);
   const [dataSources, setDataSources] = useState<SqlDataSourceOption[]>([]);
-  const [databases, setDatabases] = useState<string[]>([]);
-  const [schemas, setSchemas] = useState<string[]>([]);
   const [dataSourceLoading, setDataSourceLoading] = useState(false);
-  const [databaseLoading, setDatabaseLoading] = useState(false);
-  const [schemaLoading, setSchemaLoading] = useState(false);
+  const [bindingLoading, setBindingLoading] = useState(false);
 
   useEffect(() => {
     let active = true;
@@ -209,65 +212,32 @@ const SqlMetadataContextToolbar = ({
   useEffect(() => {
     let active = true;
     if (!context.dataSourceId) {
-      setDatabases([]);
-      setSchemas([]);
+      setBindingLoading(false);
       return () => {
         active = false;
       };
     }
 
-    setDatabaseLoading(true);
-    listSqlDatabases(context.dataSourceId)
-      .then((values) => {
+    setBindingLoading(true);
+    getSqlDataSourceBinding(context.dataSourceId)
+      .then((binding) => {
         if (!active) return;
-        const next = values || [];
-        setDatabases(next);
-        if (context.database && !next.includes(context.database)) {
-          selectSqlDatabaseContext(nodeId, undefined);
-        }
+        selectSqlDatabaseContext(nodeId, binding.database);
+        selectSqlSchemaContext(nodeId, binding.schema);
       })
       .catch((error) => {
-        if (active) message.error(errorText(error, '查询数据库失败'));
+        if (!active) return;
+        selectSqlDatabaseContext(nodeId, undefined);
+        message.error(errorText(error, '读取数据源绑定库信息失败'));
       })
       .finally(() => {
-        if (active) setDatabaseLoading(false);
+        if (active) setBindingLoading(false);
       });
 
     return () => {
       active = false;
     };
-  }, [context.dataSourceId, context.database, nodeId]);
-
-  useEffect(() => {
-    let active = true;
-    if (!context.dataSourceId) {
-      setSchemas([]);
-      return () => {
-        active = false;
-      };
-    }
-
-    setSchemaLoading(true);
-    listSqlSchemas(context.dataSourceId, context.database)
-      .then((values) => {
-        if (!active) return;
-        const next = values || [];
-        setSchemas(next);
-        if (context.schema && !next.includes(context.schema)) {
-          selectSqlSchemaContext(nodeId, undefined);
-        }
-      })
-      .catch((error) => {
-        if (active) message.error(errorText(error, '查询 Schema 失败'));
-      })
-      .finally(() => {
-        if (active) setSchemaLoading(false);
-      });
-
-    return () => {
-      active = false;
-    };
-  }, [context.dataSourceId, context.database, context.schema, nodeId]);
+  }, [context.dataSourceId, nodeId]);
 
   const normalizedDbType = context.dbType?.trim().toUpperCase();
   const showSchemaPicker = Boolean(
@@ -282,16 +252,13 @@ const SqlMetadataContextToolbar = ({
     searchText: item.dbType,
     icon: <Server size={13} strokeWidth={1.8} className="text-[#1677ff]" />,
   }));
-  const databaseItems = databases.map((value) => ({
-    value,
-    label: value,
-    icon: <Database size={13} strokeWidth={1.8} className="text-[#475467]" />,
-  }));
-  const schemaItems = schemas.map((value) => ({
-    value,
-    label: value,
-    icon: <Layers3 size={13} strokeWidth={1.8} className="text-[#667085]" />,
-  }));
+
+  const databasePlaceholder = !context.dataSourceId
+    ? '<database>'
+    : bindingLoading
+      ? '加载中...'
+      : '默认 Database';
+  const schemaPlaceholder = bindingLoading ? '加载中...' : '默认 Schema';
 
   return (
     <>
@@ -318,32 +285,28 @@ const SqlMetadataContextToolbar = ({
         />
 
         <ContextPicker
-          ariaLabel="选择 Database"
+          ariaLabel="Database"
           value={context.database}
-          displayValue={context.database}
-          placeholder="<database>"
-          icon={<Database size={13} strokeWidth={1.8} className="text-[#475467]" />}
-          items={databaseItems}
-          loading={databaseLoading}
-          disabled={!context.dataSourceId}
-          popupWidth={210}
+          displayValue={bindingLoading ? undefined : context.database}
+          placeholder={databasePlaceholder}
+          icon={<Database size={13} strokeWidth={1.8} className="text-[#8f959f]" />}
+          items={[]}
+          disabled
           minWidthClassName="min-w-[112px]"
-          onSelect={(value) => selectSqlDatabaseContext(nodeId, value)}
+          onSelect={() => undefined}
         />
 
         {showSchemaPicker ? (
           <ContextPicker
-            ariaLabel="选择 Schema"
+            ariaLabel="Schema"
             value={context.schema}
-            displayValue={context.schema}
-            placeholder="<schema>"
-            icon={<Layers3 size={13} strokeWidth={1.8} className="text-[#667085]" />}
-            items={schemaItems}
-            loading={schemaLoading}
-            disabled={!context.dataSourceId}
-            popupWidth={210}
+            displayValue={bindingLoading ? undefined : context.schema}
+            placeholder={schemaPlaceholder}
+            icon={<Layers3 size={13} strokeWidth={1.8} className="text-[#8f959f]" />}
+            items={[]}
+            disabled
             minWidthClassName="min-w-[104px]"
-            onSelect={(value) => selectSqlSchemaContext(nodeId, value)}
+            onSelect={() => undefined}
           />
         ) : null}
       </div>

--- a/yak-ops-ui/src/pages/data-development/editors/sql/metadata/sqlMetadataService.ts
+++ b/yak-ops-ui/src/pages/data-development/editors/sql/metadata/sqlMetadataService.ts
@@ -7,6 +7,11 @@ export interface SqlDataSourceOption {
   dbType?: string;
 }
 
+export interface SqlDataSourceBinding {
+  database?: string;
+  schema?: string;
+}
+
 export interface SqlCatalogTable {
   database?: string | null;
   schema?: string | null;
@@ -34,6 +39,10 @@ interface ApiResponse<T> {
   message?: string;
 }
 
+interface SqlDataSourceDetail {
+  originalJson?: string | null;
+}
+
 const DATA_SOURCE_API = '/api/v1/data-source';
 const CATALOG_API = `${DATA_SOURCE_API}/catalog`;
 
@@ -53,11 +62,46 @@ const queryString = (params: Record<string, string | undefined>) => {
   return query ? `?${query}` : '';
 };
 
+const configString = (value: unknown) => {
+  if (typeof value !== 'string') return undefined;
+  const normalized = value.trim();
+  return normalized || undefined;
+};
+
+const parseConnectionConfig = (originalJson?: string | null) => {
+  if (!originalJson) return {} as Record<string, unknown>;
+  try {
+    const parsed = JSON.parse(originalJson);
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : {};
+  } catch {
+    return {} as Record<string, unknown>;
+  }
+};
+
 export const listSqlDataSources = async (): Promise<SqlDataSourceOption[]> =>
   responseData(
     await HttpUtils.get<SqlDataSourceOption[]>(`${DATA_SOURCE_API}/option`),
     '查询数据源失败',
   );
+
+export const getSqlDataSourceBinding = async (
+  dataSourceId: string,
+): Promise<SqlDataSourceBinding> => {
+  const detail = responseData(
+    await HttpUtils.get<SqlDataSourceDetail>(`${DATA_SOURCE_API}/${dataSourceId}`),
+    '查询数据源配置失败',
+  );
+  const config = parseConnectionConfig(detail.originalJson);
+
+  return {
+    database: configString(
+      config.database ?? config.databaseName ?? config.dbName ?? config.catalog,
+    ),
+    schema: configString(config.schema ?? config.schemaName),
+  };
+};
 
 export const listSqlDatabases = async (
   dataSourceId: string,


### PR DESCRIPTION
## 背景

当前数据开发 SQL 编辑器虽然已经选择了 Yak Ops 数据源，但顶部 Database / Schema 仍会通过 Catalog API 枚举并允许用户再次切换。

这与「数据源管理」的配置语义不一致：数据源在创建 / 编辑时已经绑定了 Database（以及可选 Schema），SQL 开发不应该绕过该配置再选择同一连接下的其他数据库。

例如截图中的 MySQL 数据源在数据源管理中绑定的是 `test2`，数据开发中不应该还能切换到 `test1`、`mysql`、`information_schema` 等其他库。

## 调整内容

### 1. Database / Schema 改为固定只读上下文

- 顶部仍保留「数据源」选择，用户可以切换不同 Yak Ops 数据源。
- Database 不再提供下拉选择，改为 disabled 固定展示。
- 对存在独立 Schema 概念的数据库，Schema 同样改为 disabled 固定展示。
- disabled 状态移除下拉箭头，并使用轻量灰色背景，明确表示该值不可在数据开发中修改。
- Hover title 提示：该值由「数据源管理」中的连接配置固定。

### 2. 直接读取数据源管理中的绑定库信息

选择 / 恢复数据源后调用：

- `GET /api/v1/data-source/{id}`

从数据源详情的 `originalJson` 连接配置中读取：

- `database`（兼容 `databaseName` / `dbName` / `catalog`）
- `schema`（兼容 `schemaName`）

然后同步到现有 SQL metadata context。

因此 SQL Table / Column 补全仍然复用原来的上下文 Store 和 Catalog API，但 database/schema 的值只能来自数据源绑定配置。

### 3. 修正旧本地上下文

如果某个 SQL Tab 之前在 localStorage 中保存过手工选择的 Database，例如 `test1`，重新打开后会根据当前数据源详情自动覆盖为真实绑定的 Database，例如 `test2`，避免继续使用历史错误上下文。

## 影响范围

仅修改数据开发前端：

- `yak-ops-ui/src/pages/data-development/editors/sql/metadata/SqlMetadataContextToolbar.tsx`
- `yak-ops-ui/src/pages/data-development/editors/sql/metadata/sqlMetadataService.ts`

不修改后端接口、数据源保存逻辑、SQL 编辑器、Catalog Table / Column 查询和 SQL completion 实现。

## 建议回归

- 数据源管理中将 MySQL 数据源 Database 配置为 `test2`。
- 打开「数据开发 → 开发任务 → SQL」。
- 选择该数据源，确认顶部 Database 自动显示 `test2`。
- 确认 Database 为 disabled，无法展开 `test1 / mysql / information_schema` 等库列表。
- PostgreSQL / Oracle 等存在 Schema 的数据源，确认 Schema 同样来自数据源连接配置并不可切换。
- 切换到其他数据源，确认 Database / Schema 随数据源绑定配置自动更新。
- 刷新页面或重新打开旧 SQL Tab，确认历史手工选择的 Database 会被绑定配置纠正。
- 输入表名 / 字段名，确认原有 Catalog Table / Column 补全仍然使用当前绑定 Database / Schema。

## Validation

- [x] 分支基于最新 `main`，compare `behind 0`
- [x] diff 仅包含上述 2 个前端文件
- [x] 未新增 npm 依赖
- [ ] `npm run tsc`（当前执行环境无法直接拉取 GitHub 仓库，建议合并前由本地环境回归）
- [ ] 浏览器交互回归
