### PR TITLE
style(data-development): unify SQL context and sidebar accent color

### DIFF
--- a/yak-ops-ui/src/pages/data-development/components/workbench/RightPanel.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/workbench/RightPanel.tsx
@@ -221,7 +221,7 @@ const RightPanel = ({ node, directory, definition }: RightPanelProps) => {
                 '[writing-mode:vertical-rl] [letter-spacing:3px]',
                 index === 0 ? 'border-t' : '',
                 active
-                  ? 'text-[#245bdb] opacity-100 before:absolute before:inset-y-0 before:left-0 before:w-px before:bg-[#245bdb]'
+                  ? 'text-[#1677ff] opacity-100 before:absolute before:inset-y-0 before:left-0 before:w-px before:bg-[#1677ff]'
                   : 'text-[#475467] opacity-70 hover:bg-[#f7f8fa] hover:text-[#344054] hover:opacity-100',
               ].join(' ')}
             >


### PR DESCRIPTION
## 背景

根据数据开发页面最新截图，顶部 SQL 数据源入口与右侧面板激活态虽然都使用蓝色，但实际色值不一致：

- SQL 数据源图标：`#1677ff`
- 右侧「属性 / 运行配置 / 调度配置 / 版本」激活态：`#245bdb`

视觉上会出现同一层级交互强调色不统一的问题。

## 调整内容

- 将右侧面板激活文字颜色统一为 `#1677ff`
- 将右侧面板左侧激活竖线同步统一为 `#1677ff`
- 与顶部 SQL 数据源图标保持完全一致
- 不调整非激活态、Hover、面板内容、拖拽和展开/收起逻辑

## 影响范围

仅修改：

- `yak-ops-ui/src/pages/data-development/components/workbench/RightPanel.tsx`

本次为纯样式调整，不涉及接口和业务逻辑。

## Validation

- [x] 基于 #338 合入后的最新 `main`
- [x] compare `behind 0`
- [x] 仅 1 个文件、1 行色值调整
- [ ] 浏览器视觉回归：确认顶部数据源图标与右侧激活文字/竖线颜色一致
