### PR TITLE
feat(task-plugin): scaffold platform task plugin architecture

### DIFF
--- a/docs/task-plugin-stage-2.md
+++ b/docs/task-plugin-stage-2.md
@@ -1,0 +1,113 @@
+# Task Plugin 阶段 2：插件骨架与发现机制
+
+> 状态：Implemented（阶段 2）  
+> 范围：建立平台级 Task Plugin API、SQL 占位插件、ServiceLoader 发现与核心 Registry；不实现真实 SQL 执行。
+
+## 1. 模块结构
+
+```text
+yak-ops-plugins/yak-ops-plugin-task
+├── yak-ops-plugin-task-api
+├── yak-ops-plugin-task-sql
+└── yak-ops-plugin-task-all
+```
+
+依赖方向：
+
+```text
+business / future task-runtime
+             |
+             v
+         yak-ops-core
+             |
+             v
+ yak-ops-plugin-task-api
+             ^
+             |
+       concrete plugins
+             |
+             v
+          task-all
+```
+
+`yak-ops-boot` 只依赖 `task-all` 完成内置插件装配，业务模块不直接依赖 SQL 等具体插件。
+
+## 2. 稳定插件契约
+
+阶段 2 固定以下最小契约：
+
+- `TaskPlugin`：声明插件元数据、校验 Definition、按 Attempt 创建 Executor；
+- `TaskPluginDescriptor`：任务类型、名称、插件版本、Schema 版本与执行能力；
+- `TaskValidationResult / TaskValidationIssue`：结构化定义校验结果；
+- `TaskExecutionContext`：Task Runtime 提供给插件的最小运行上下文；
+- `TaskExecutor`：一次物理 Attempt 的执行器，并预留取消能力；
+- `TaskExecutionResult`：统一执行状态、消息与输出。
+
+这些接口属于平台级 Task Plugin，不属于 Workflow。后续 Manual / Workflow / Schedule 都应通过统一 Task Runtime 使用同一插件。
+
+## 3. 插件发现
+
+具体插件使用 Java `ServiceLoader` 注册：
+
+```text
+META-INF/services/io.yak.ops.plugin.task.api.TaskPlugin
+```
+
+`yak-ops-core` 中的 `TaskPluginRegistry` 负责：
+
+- 按当前线程 Context ClassLoader 发现插件；
+- 将 Task Type 统一规范为大写；
+- 拒绝重复 Task Type；
+- 提供 `find / require / descriptors` 统一查询入口；
+- 返回不可变插件目录。
+
+第一阶段不引入 PF4J、插件热卸载、独立 ClassLoader 或注册中心。等真正出现运行时动态安装需求后再评估。
+
+## 4. SQL 占位插件
+
+`yak-ops-plugin-task-sql` 当前只用于验证架构链路：
+
+```text
+SQL TaskPlugin
+    -> ServiceLoader
+    -> TaskPluginRegistry
+```
+
+目前只校验：
+
+- `taskType=SQL`；
+- `schemaVersion=1`；
+- SQL `content` 非空。
+
+`descriptor.executable=false`，也没有实现 `createExecutor`。这意味着阶段 2 **不会连接数据库、不会执行 SQL、不会读取数据源凭据**。
+
+真实 SQL 执行放在后续 SQL Task Plugin 阶段，并复用 Yak Ops 已有 `DataSourcePlugin`，避免按 MySQL/Doris/PostgreSQL 重复建设任务插件。
+
+## 5. 当前边界
+
+本阶段明确不做：
+
+- 不新增数据库表和 Flyway；
+- 不实现 Draft / Revision / Publish；
+- 不实现 Task Catalog；
+- 不修改 Workflow 持久化和运行逻辑；
+- 不修改 Data Development API；
+- 不实现 SQL/Shell/Python/HTTP 真实执行；
+- 不引入 Worker、Docker 或 Kubernetes Execution Backend。
+
+## 6. 下一步
+
+阶段 3 开始实现数据开发控制面的：
+
+```text
+DevelopmentNode
+      |
+      v
+   TaskDraft
+      |
+   publish
+      v
+ TaskRevision
+```
+
+先完成草稿保存、不可变发布版本与版本查询，再进入 SQL 手动运行和 Task Catalog。

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,7 @@
         <module>yak-ops-business</module>
         <module>yak-ops-plugins/yak-ops-plugin-datasource</module>
         <module>yak-ops-plugins/yak-ops-plugin-storage</module>
+        <module>yak-ops-plugins/yak-ops-plugin-task</module>
         <module>yak-ops-boot</module>
         <module>yak-ops-ui</module>
         <module>yak-ops-dist</module>
@@ -177,6 +178,22 @@
             <dependency>
                 <groupId>io.yak.ops</groupId>
                 <artifactId>yak-ops-plugin-storage-all</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.yak.ops</groupId>
+                <artifactId>yak-ops-plugin-task-api</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.yak.ops</groupId>
+                <artifactId>yak-ops-plugin-task-sql</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.yak.ops</groupId>
+                <artifactId>yak-ops-plugin-task-all</artifactId>
                 <version>${project.version}</version>
             </dependency>
 

--- a/yak-ops-bom/pom.xml
+++ b/yak-ops-bom/pom.xml
@@ -136,6 +136,22 @@
 
             <dependency>
                 <groupId>io.yak.ops</groupId>
+                <artifactId>yak-ops-plugin-task-api</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.yak.ops</groupId>
+                <artifactId>yak-ops-plugin-task-sql</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.yak.ops</groupId>
+                <artifactId>yak-ops-plugin-task-all</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.yak.ops</groupId>
                 <artifactId>yak-ops-boot</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/yak-ops-boot/pom.xml
+++ b/yak-ops-boot/pom.xml
@@ -53,6 +53,10 @@
             <artifactId>yak-ops-plugin-storage-all</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.yak.ops</groupId>
+            <artifactId>yak-ops-plugin-task-all</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.yak.framework</groupId>
             <artifactId>yak-security-spring-boot-starter</artifactId>
         </dependency>

--- a/yak-ops-core/src/main/java/io/yak/ops/core/plugin/task/TaskPluginRegistry.java
+++ b/yak-ops-core/src/main/java/io/yak/ops/core/plugin/task/TaskPluginRegistry.java
@@ -1,0 +1,102 @@
+package io.yak.ops.core.plugin.task;
+
+import io.yak.ops.plugin.task.api.TaskPlugin;
+import io.yak.ops.plugin.task.api.TaskPluginDescriptor;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.ServiceLoader;
+import java.util.TreeMap;
+
+/** Discovers task plugins through Java ServiceLoader and provides stable type-based routing. */
+public final class TaskPluginRegistry {
+
+  private final Map<String, TaskPlugin> plugins;
+
+  private TaskPluginRegistry(Map<String, TaskPlugin> plugins) {
+    this.plugins = Collections.unmodifiableMap(new LinkedHashMap<>(plugins));
+  }
+
+  public static TaskPluginRegistry load() {
+    ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+    if (classLoader == null) {
+      classLoader = TaskPlugin.class.getClassLoader();
+    }
+    return load(classLoader);
+  }
+
+  public static TaskPluginRegistry load(ClassLoader classLoader) {
+    Objects.requireNonNull(classLoader, "classLoader");
+    return from(ServiceLoader.load(TaskPlugin.class, classLoader));
+  }
+
+  public static TaskPluginRegistry from(Iterable<TaskPlugin> candidates) {
+    Objects.requireNonNull(candidates, "candidates");
+
+    Map<String, TaskPlugin> discovered = new TreeMap<>();
+    for (TaskPlugin plugin : candidates) {
+      Objects.requireNonNull(plugin, "Task plugin must not be null");
+      String type = normalizeType(plugin.type());
+      TaskPlugin previous = discovered.putIfAbsent(type, plugin);
+      if (previous != null) {
+        throw new IllegalStateException(
+            "Duplicate task plugin for type "
+                + type
+                + ": "
+                + previous.getClass().getName()
+                + " and "
+                + plugin.getClass().getName());
+      }
+    }
+    return new TaskPluginRegistry(discovered);
+  }
+
+  public Optional<TaskPlugin> find(String type) {
+    String normalized = normalizeNullableType(type);
+    return normalized == null ? Optional.empty() : Optional.ofNullable(plugins.get(normalized));
+  }
+
+  public TaskPlugin require(String type) {
+    String normalized = normalizeNullableType(type);
+    if (normalized == null) {
+      throw new IllegalArgumentException("Task plugin type must not be blank");
+    }
+    TaskPlugin plugin = plugins.get(normalized);
+    if (plugin == null) {
+      throw new IllegalArgumentException("Task plugin not found: " + normalized);
+    }
+    return plugin;
+  }
+
+  public Map<String, TaskPlugin> plugins() {
+    return plugins;
+  }
+
+  public List<TaskPluginDescriptor> descriptors() {
+    List<TaskPluginDescriptor> descriptors = new ArrayList<>(plugins.size());
+    for (TaskPlugin plugin : plugins.values()) {
+      descriptors.add(plugin.descriptor());
+    }
+    return List.copyOf(descriptors);
+  }
+
+  private static String normalizeType(String type) {
+    String normalized = normalizeNullableType(type);
+    if (normalized == null) {
+      throw new IllegalArgumentException("Task plugin type must not be blank");
+    }
+    return normalized;
+  }
+
+  private static String normalizeNullableType(String type) {
+    if (type == null || type.trim().isEmpty()) {
+      return null;
+    }
+    return type.trim().toUpperCase(Locale.ROOT);
+  }
+}

--- a/yak-ops-core/src/main/java/io/yak/ops/core/plugin/task/package-info.java
+++ b/yak-ops-core/src/main/java/io/yak/ops/core/plugin/task/package-info.java
@@ -1,0 +1,2 @@
+/** Runtime discovery and routing for platform-level task plugins. */
+package io.yak.ops.core.plugin.task;

--- a/yak-ops-core/src/test/java/io/yak/ops/core/plugin/task/TaskPluginRegistryTest.java
+++ b/yak-ops-core/src/test/java/io/yak/ops/core/plugin/task/TaskPluginRegistryTest.java
@@ -1,0 +1,61 @@
+package io.yak.ops.core.plugin.task;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.yak.ops.plugin.task.api.TaskPlugin;
+import io.yak.ops.plugin.task.api.TaskPluginDescriptor;
+import io.yak.ops.plugin.task.api.TaskValidationResult;
+import io.yak.ops.spi.task.model.TaskDefinition;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class TaskPluginRegistryTest {
+
+  @Test
+  void routesPluginsByNormalizedType() {
+    TaskPluginRegistry registry = TaskPluginRegistry.from(List.of(new StubPlugin("sql")));
+
+    assertTrue(registry.find(" SQL ").isPresent());
+    assertEquals("SQL", registry.require("sql").type());
+    assertEquals(List.of("SQL"), registry.descriptors().stream().map(TaskPluginDescriptor::type).toList());
+  }
+
+  @Test
+  void rejectsDuplicateTypesIgnoringCase() {
+    IllegalStateException exception =
+        assertThrows(
+            IllegalStateException.class,
+            () -> TaskPluginRegistry.from(List.of(new StubPlugin("sql"), new StubPlugin("SQL"))));
+
+    assertTrue(exception.getMessage().contains("Duplicate task plugin for type SQL"));
+  }
+
+  @Test
+  void rejectsMissingPlugin() {
+    TaskPluginRegistry registry = TaskPluginRegistry.from(List.of(new StubPlugin("SQL")));
+
+    assertThrows(IllegalArgumentException.class, () -> registry.require("PYTHON"));
+  }
+
+  private static final class StubPlugin implements TaskPlugin {
+
+    private final TaskPluginDescriptor descriptor;
+
+    private StubPlugin(String type) {
+      descriptor =
+          new TaskPluginDescriptor(type, type, "test", "1.0.0", 1, false, false);
+    }
+
+    @Override
+    public TaskPluginDescriptor descriptor() {
+      return descriptor;
+    }
+
+    @Override
+    public TaskValidationResult validate(TaskDefinition definition) {
+      return TaskValidationResult.ok();
+    }
+  }
+}

--- a/yak-ops-plugins/yak-ops-plugin-task/pom.xml
+++ b/yak-ops-plugins/yak-ops-plugin-task/pom.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.yak.ops</groupId>
+        <artifactId>yak-ops</artifactId>
+        <version>1.0.0</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>yak-ops-plugin-task</artifactId>
+    <packaging>pom</packaging>
+
+    <name>Yak Ops Task Plugins</name>
+    <description>Yak Ops task-plugin module aggregation</description>
+
+    <modules>
+        <module>yak-ops-plugin-task-api</module>
+        <module>yak-ops-plugin-task-sql</module>
+        <module>yak-ops-plugin-task-all</module>
+    </modules>
+</project>

--- a/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-all/pom.xml
+++ b/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-all/pom.xml
@@ -3,22 +3,28 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>io.yak.ops</groupId>
-        <artifactId>yak-ops</artifactId>
+        <artifactId>yak-ops-plugin-task</artifactId>
         <version>1.0.0</version>
+        <relativePath>../pom.xml</relativePath>
     </parent>
-    <artifactId>yak-ops-core</artifactId>
-    <name>Yak Ops Core</name>
-    <description>Plugin registry, runtime coordination and execution mechanisms</description>
+
+    <artifactId>yak-ops-plugin-task-all</artifactId>
+
+    <name>Yak Ops All Task Plugins</name>
+    <description>Runtime aggregation of all built-in Yak Ops task plugins</description>
+
     <dependencies>
         <dependency>
             <groupId>io.yak.ops</groupId>
-            <artifactId>yak-ops-spi</artifactId>
+            <artifactId>yak-ops-plugin-task-sql</artifactId>
         </dependency>
         <dependency>
             <groupId>io.yak.ops</groupId>
-            <artifactId>yak-ops-plugin-task-api</artifactId>
+            <artifactId>yak-ops-core</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-all/src/test/java/io/yak/ops/plugin/task/all/TaskPluginAssemblyTest.java
+++ b/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-all/src/test/java/io/yak/ops/plugin/task/all/TaskPluginAssemblyTest.java
@@ -1,0 +1,25 @@
+package io.yak.ops.plugin.task.all;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.yak.ops.core.plugin.task.TaskPluginRegistry;
+import io.yak.ops.plugin.task.api.TaskPlugin;
+import io.yak.ops.spi.task.model.TaskDefinition;
+import org.junit.jupiter.api.Test;
+
+class TaskPluginAssemblyTest {
+
+  @Test
+  void discoversSqlPluginThroughServiceLoader() {
+    TaskPluginRegistry registry =
+        TaskPluginRegistry.load(Thread.currentThread().getContextClassLoader());
+
+    TaskPlugin sql = registry.require("SQL");
+
+    assertEquals("SQL", sql.descriptor().type());
+    assertFalse(sql.descriptor().executable());
+    assertTrue(sql.validate(new TaskDefinition("SQL", 1, "select 1", "{}")).valid());
+  }
+}

--- a/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-api/pom.xml
+++ b/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-api/pom.xml
@@ -3,27 +3,23 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>io.yak.ops</groupId>
-        <artifactId>yak-ops</artifactId>
+        <artifactId>yak-ops-plugin-task</artifactId>
         <version>1.0.0</version>
+        <relativePath>../pom.xml</relativePath>
     </parent>
-    <artifactId>yak-ops-core</artifactId>
-    <name>Yak Ops Core</name>
-    <description>Plugin registry, runtime coordination and execution mechanisms</description>
+
+    <artifactId>yak-ops-plugin-task-api</artifactId>
+
+    <name>Yak Ops Task Plugin API</name>
+    <description>Stable task plugin contracts shared by data development, workflow and scheduling runtimes</description>
+
     <dependencies>
         <dependency>
             <groupId>io.yak.ops</groupId>
             <artifactId>yak-ops-spi</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.yak.ops</groupId>
-            <artifactId>yak-ops-plugin-task-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-api/src/main/java/io/yak/ops/plugin/task/api/TaskExecutionContext.java
+++ b/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-api/src/main/java/io/yak/ops/plugin/task/api/TaskExecutionContext.java
@@ -1,0 +1,17 @@
+package io.yak.ops.plugin.task.api;
+
+import io.yak.ops.spi.task.model.TaskExecutionTrigger;
+import java.util.Map;
+
+/**
+ * Minimal runtime context visible to task plugins.
+ *
+ * <p>The contract intentionally stays small in stage 2. Task Runtime may add backward-compatible
+ * default capabilities later without leaking Workflow-specific state into plugins.
+ */
+public interface TaskExecutionContext {
+
+  TaskExecutionTrigger trigger();
+
+  Map<String, Object> parameters();
+}

--- a/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-api/src/main/java/io/yak/ops/plugin/task/api/TaskExecutionResult.java
+++ b/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-api/src/main/java/io/yak/ops/plugin/task/api/TaskExecutionResult.java
@@ -1,0 +1,22 @@
+package io.yak.ops.plugin.task.api;
+
+import io.yak.ops.spi.task.model.TaskExecutionStatus;
+import java.util.Map;
+import java.util.Objects;
+
+/** Result returned by one physical task execution attempt. */
+public record TaskExecutionResult(
+    TaskExecutionStatus status,
+    String message,
+    Map<String, Object> output) {
+
+  public TaskExecutionResult {
+    status = Objects.requireNonNull(status, "status");
+    message = message == null ? "" : message;
+    output = output == null ? Map.of() : Map.copyOf(output);
+  }
+
+  public static TaskExecutionResult success(Map<String, Object> output) {
+    return new TaskExecutionResult(TaskExecutionStatus.SUCCESS, "", output);
+  }
+}

--- a/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-api/src/main/java/io/yak/ops/plugin/task/api/TaskExecutor.java
+++ b/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-api/src/main/java/io/yak/ops/plugin/task/api/TaskExecutor.java
@@ -1,0 +1,11 @@
+package io.yak.ops.plugin.task.api;
+
+/** Fresh executor instance used for one physical task execution attempt. */
+public interface TaskExecutor {
+
+  TaskExecutionResult execute() throws Exception;
+
+  default void cancel() {
+    // Optional capability. Plugins that advertise cancellable=true must override this method.
+  }
+}

--- a/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-api/src/main/java/io/yak/ops/plugin/task/api/TaskPlugin.java
+++ b/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-api/src/main/java/io/yak/ops/plugin/task/api/TaskPlugin.java
@@ -1,0 +1,27 @@
+package io.yak.ops.plugin.task.api;
+
+import io.yak.ops.spi.task.model.TaskDefinition;
+
+/**
+ * Stable platform-level task plugin contract.
+ *
+ * <p>Data development, Workflow and Schedule consume this contract through Task Runtime instead of
+ * owning separate SQL/Shell/Python execution implementations.
+ */
+public interface TaskPlugin {
+
+  TaskPluginDescriptor descriptor();
+
+  default String type() {
+    return descriptor().type();
+  }
+
+  TaskValidationResult validate(TaskDefinition definition);
+
+  default TaskExecutor createExecutor(
+      TaskDefinition definition,
+      TaskExecutionContext context) {
+    throw new UnsupportedOperationException(
+        "Task plugin is not executable yet: " + type());
+  }
+}

--- a/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-api/src/main/java/io/yak/ops/plugin/task/api/TaskPluginDescriptor.java
+++ b/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-api/src/main/java/io/yak/ops/plugin/task/api/TaskPluginDescriptor.java
@@ -1,0 +1,36 @@
+package io.yak.ops.plugin.task.api;
+
+import java.util.Locale;
+import java.util.Objects;
+
+/** Stable metadata exposed by a task plugin. */
+public record TaskPluginDescriptor(
+    String type,
+    String displayName,
+    String description,
+    String version,
+    int schemaVersion,
+    boolean executable,
+    boolean cancellable) {
+
+  public TaskPluginDescriptor {
+    type = normalizeType(type);
+    displayName = requireText(displayName, "displayName");
+    description = Objects.requireNonNullElse(description, "");
+    version = requireText(version, "version");
+    if (schemaVersion <= 0) {
+      throw new IllegalArgumentException("schemaVersion must be positive");
+    }
+  }
+
+  private static String normalizeType(String value) {
+    return requireText(value, "type").toUpperCase(Locale.ROOT);
+  }
+
+  private static String requireText(String value, String field) {
+    if (value == null || value.trim().isEmpty()) {
+      throw new IllegalArgumentException(field + " must not be blank");
+    }
+    return value.trim();
+  }
+}

--- a/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-api/src/main/java/io/yak/ops/plugin/task/api/TaskValidationIssue.java
+++ b/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-api/src/main/java/io/yak/ops/plugin/task/api/TaskValidationIssue.java
@@ -1,0 +1,20 @@
+package io.yak.ops.plugin.task.api;
+
+/** One structured task-definition validation issue. */
+public record TaskValidationIssue(
+    String code,
+    String field,
+    String message) {
+
+  public TaskValidationIssue {
+    if (code == null || code.trim().isEmpty()) {
+      throw new IllegalArgumentException("code must not be blank");
+    }
+    code = code.trim();
+    field = field == null || field.trim().isEmpty() ? null : field.trim();
+    if (message == null || message.trim().isEmpty()) {
+      throw new IllegalArgumentException("message must not be blank");
+    }
+    message = message.trim();
+  }
+}

--- a/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-api/src/main/java/io/yak/ops/plugin/task/api/TaskValidationResult.java
+++ b/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-api/src/main/java/io/yak/ops/plugin/task/api/TaskValidationResult.java
@@ -1,0 +1,33 @@
+package io.yak.ops.plugin.task.api;
+
+import java.util.Arrays;
+import java.util.List;
+
+/** Immutable validation result returned by a task plugin. */
+public record TaskValidationResult(List<TaskValidationIssue> issues) {
+
+  private static final TaskValidationResult OK = new TaskValidationResult(List.of());
+
+  public TaskValidationResult {
+    issues = issues == null ? List.of() : List.copyOf(issues);
+  }
+
+  public boolean valid() {
+    return issues.isEmpty();
+  }
+
+  public static TaskValidationResult ok() {
+    return OK;
+  }
+
+  public static TaskValidationResult invalid(TaskValidationIssue... issues) {
+    if (issues == null || issues.length == 0) {
+      throw new IllegalArgumentException("At least one validation issue is required");
+    }
+    return new TaskValidationResult(Arrays.asList(issues));
+  }
+
+  public static TaskValidationResult of(List<TaskValidationIssue> issues) {
+    return new TaskValidationResult(issues);
+  }
+}

--- a/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-api/src/main/java/io/yak/ops/plugin/task/api/package-info.java
+++ b/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-api/src/main/java/io/yak/ops/plugin/task/api/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Stable task plugin contracts shared by authoring and execution entry points.
+ *
+ * <p>Concrete plugins must not depend on Workflow or Data Development business modules.
+ */
+package io.yak.ops.plugin.task.api;

--- a/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-sql/pom.xml
+++ b/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-sql/pom.xml
@@ -3,27 +3,23 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>io.yak.ops</groupId>
-        <artifactId>yak-ops</artifactId>
+        <artifactId>yak-ops-plugin-task</artifactId>
         <version>1.0.0</version>
+        <relativePath>../pom.xml</relativePath>
     </parent>
-    <artifactId>yak-ops-core</artifactId>
-    <name>Yak Ops Core</name>
-    <description>Plugin registry, runtime coordination and execution mechanisms</description>
+
+    <artifactId>yak-ops-plugin-task-sql</artifactId>
+
+    <name>Yak Ops SQL Task Plugin</name>
+    <description>SQL task plugin skeleton; real datasource-backed execution is introduced in a later stage</description>
+
     <dependencies>
         <dependency>
             <groupId>io.yak.ops</groupId>
-            <artifactId>yak-ops-spi</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.yak.ops</groupId>
             <artifactId>yak-ops-plugin-task-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-sql/src/main/java/io/yak/ops/plugin/task/sql/SqlTaskPlugin.java
+++ b/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-sql/src/main/java/io/yak/ops/plugin/task/sql/SqlTaskPlugin.java
@@ -1,0 +1,72 @@
+package io.yak.ops.plugin.task.sql;
+
+import io.yak.ops.plugin.task.api.TaskPlugin;
+import io.yak.ops.plugin.task.api.TaskPluginDescriptor;
+import io.yak.ops.plugin.task.api.TaskValidationIssue;
+import io.yak.ops.plugin.task.api.TaskValidationResult;
+import io.yak.ops.spi.task.model.TaskDefinition;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Stage-2 SQL task plugin skeleton.
+ *
+ * <p>This plugin proves SPI discovery and definition validation only. Datasource-backed SQL
+ * execution is deliberately deferred to the SQL execution stage.
+ */
+public final class SqlTaskPlugin implements TaskPlugin {
+
+  public static final String TYPE = "SQL";
+  private static final int SCHEMA_VERSION = 1;
+
+  private static final TaskPluginDescriptor DESCRIPTOR =
+      new TaskPluginDescriptor(
+          TYPE,
+          "SQL",
+          "SQL task definition",
+          "1.0.0",
+          SCHEMA_VERSION,
+          false,
+          false);
+
+  @Override
+  public TaskPluginDescriptor descriptor() {
+    return DESCRIPTOR;
+  }
+
+  @Override
+  public TaskValidationResult validate(TaskDefinition definition) {
+    if (definition == null) {
+      return TaskValidationResult.invalid(
+          new TaskValidationIssue(
+              "TASK_DEFINITION_REQUIRED",
+              null,
+              "Task definition is required"));
+    }
+
+    List<TaskValidationIssue> issues = new ArrayList<>();
+    if (!TYPE.equalsIgnoreCase(definition.taskType())) {
+      issues.add(
+          new TaskValidationIssue(
+              "TASK_TYPE_MISMATCH",
+              "taskType",
+              "SQL plugin only accepts taskType=SQL"));
+    }
+    if (definition.schemaVersion() != SCHEMA_VERSION) {
+      issues.add(
+          new TaskValidationIssue(
+              "UNSUPPORTED_SCHEMA_VERSION",
+              "schemaVersion",
+              "SQL plugin currently supports schemaVersion=1"));
+    }
+    if (definition.content() == null || definition.content().isBlank()) {
+      issues.add(
+          new TaskValidationIssue(
+              "SQL_CONTENT_REQUIRED",
+              "content",
+              "SQL content must not be blank"));
+    }
+
+    return issues.isEmpty() ? TaskValidationResult.ok() : TaskValidationResult.of(issues);
+  }
+}

--- a/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-sql/src/main/resources/META-INF/services/io.yak.ops.plugin.task.api.TaskPlugin
+++ b/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-sql/src/main/resources/META-INF/services/io.yak.ops.plugin.task.api.TaskPlugin
@@ -1,0 +1,1 @@
+io.yak.ops.plugin.task.sql.SqlTaskPlugin


### PR DESCRIPTION
## Summary

完成 Task Plugin 架构第 2 阶段：在第 1 阶段统一任务模型基础上，建立平台级 Task Plugin 模块骨架、稳定 SPI、ServiceLoader 发现机制和 SQL 占位插件。

本 PR **不实现真实 SQL 执行**，先验证 `TaskPlugin -> ServiceLoader -> TaskPluginRegistry` 这条平台级扩展链路。

## 模块结构

新增：

```text
yak-ops-plugins/yak-ops-plugin-task
├── yak-ops-plugin-task-api
├── yak-ops-plugin-task-sql
└── yak-ops-plugin-task-all
```

并完成：

- 根 Reactor / dependencyManagement 接入
- `yak-ops-bom` 依赖版本对齐
- `yak-ops-core` 接入 task plugin API，用于统一 Registry
- `yak-ops-boot` 只通过 `yak-ops-plugin-task-all` 装配内置任务插件

业务模块不直接依赖 SQL 等具体 Task Plugin。

## Task Plugin API

新增最小平台级契约：

- `TaskPlugin`
- `TaskPluginDescriptor`
- `TaskValidationIssue`
- `TaskValidationResult`
- `TaskExecutionContext`
- `TaskExecutor`
- `TaskExecutionResult`

设计原则：

- Task Plugin 属于平台能力，不属于 Workflow；
- Manual / Workflow / Schedule 后续统一通过 Task Runtime 消费同一插件；
- `TaskExecutor` 按一次物理 Attempt 创建，预留取消能力；
- 运行上下文当前保持最小，避免阶段 2 提前泄漏 Workflow 专属字段。

## TaskPluginRegistry

在 `yak-ops-core` 新增 `TaskPluginRegistry`：

- 使用 Java `ServiceLoader<TaskPlugin>` 发现插件；
- 优先使用 Thread Context ClassLoader，兼容 Boot 运行时装配；
- Task Type 统一大写归一化；
- 重复 Task Type 启动时直接失败，避免静默覆盖；
- 提供 `find / require / plugins / descriptors` 统一路由和目录能力；
- Registry 对外暴露不可变视图。

当前不引入 PF4J、独立插件 ClassLoader、热卸载或注册中心。

## SQL Plugin Skeleton

新增 `SqlTaskPlugin` 并通过：

```text
META-INF/services/io.yak.ops.plugin.task.api.TaskPlugin
```

注册。

阶段 2 只校验：

- `taskType=SQL`
- `schemaVersion=1`
- SQL content 非空

SQL Descriptor 明确 `executable=false`，未实现 `createExecutor`，因此本 PR 不会连接数据库、读取数据源凭据或执行 SQL。

真实 SQL 执行留到后续阶段，并复用现有 `DataSourcePlugin`。

## Tests / Validation

新增：

- `TaskPluginRegistryTest`
  - 类型归一化路由
  - 重复类型拒绝
  - 未安装插件拒绝
- `TaskPluginAssemblyTest`
  - 通过 ServiceLoader 发现 SQL Plugin
  - 验证 SQL Descriptor 和 Definition 校验

本次已完成：

- 8 个新增/修改 Maven POM 的 XML 解析检查
- 使用 JDK 21 对本阶段新增主 Java 源码进行隔离语法/类型编译
- ServiceLoader 本地 smoke test：成功发现 `SQL` 插件并通过 `select 1` Definition 校验
- GitHub compare：当前分支相对 `main` ahead 1 / behind 0

当前执行环境没有完整仓库 checkout 和 Maven 依赖缓存，因此未执行完整 Reactor：

```bash
mvn -pl yak-ops-plugins/yak-ops-plugin-task -am test
mvn -pl yak-ops-boot -am test
```

建议合并前由本地或 CI 再跑完整 Maven 验证。

## Deliberately out of scope

本阶段不做：

- 不新增数据库表 / Flyway
- 不实现 Draft / Revision / Publish
- 不实现 Task Catalog
- 不修改 Data Development API/运行逻辑
- 不修改 Workflow 持久化/运行逻辑
- 不实现真实 SQL / Shell / Python / HTTP 执行
- 不引入 Worker / Docker / Kubernetes Execution Backend

## Next

阶段 3：完成数据开发 `TaskDraft -> publish -> TaskRevision` 后端，建立草稿保存、不可变发布版本与版本查询，为后续 SQL 手动运行和 Task Catalog 做准备。