### PR TITLE
style(data-development): reuse global brand color

### DIFF
--- a/yak-ops-ui/src/pages/data-development/components/workbench/RightPanel.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/workbench/RightPanel.tsx
@@ -1,3 +1,4 @@
+import { BRAND_CSS_VARIABLES } from '@/styles/brand';
 import { message } from 'antd';
 import { RefreshCw, X } from 'lucide-react';
 import type { PointerEvent as ReactPointerEvent } from 'react';
@@ -151,7 +152,7 @@ const RightPanel = ({ node, directory, definition }: RightPanelProps) => {
   };
 
   return (
-    <aside className="flex shrink-0 bg-white">
+    <aside className="flex shrink-0 bg-white" style={BRAND_CSS_VARIABLES}>
       <div
         className={[
           'relative h-full shrink-0',
@@ -221,7 +222,7 @@ const RightPanel = ({ node, directory, definition }: RightPanelProps) => {
                 '[writing-mode:vertical-rl] [letter-spacing:3px]',
                 index === 0 ? 'border-t' : '',
                 active
-                  ? 'text-[#1677ff] opacity-100 before:absolute before:inset-y-0 before:left-0 before:w-px before:bg-[#1677ff]'
+                  ? 'text-[var(--yak-brand-color)] opacity-100 before:absolute before:inset-y-0 before:left-0 before:w-px before:bg-[var(--yak-brand-color)]'
                   : 'text-[#475467] opacity-70 hover:bg-[#f7f8fa] hover:text-[#344054] hover:opacity-100',
               ].join(' ')}
             >

--- a/yak-ops-ui/src/pages/data-development/editors/sql/metadata/SqlMetadataContextToolbar.tsx
+++ b/yak-ops-ui/src/pages/data-development/editors/sql/metadata/SqlMetadataContextToolbar.tsx
@@ -1,3 +1,4 @@
+import { BRAND_CSS_VARIABLES } from '@/styles/brand';
 import { Popover, Spin, message } from 'antd';
 import { ChevronDown, Database, Layers3, Search, Server } from 'lucide-react';
 import type { ReactNode } from 'react';
@@ -250,7 +251,13 @@ const SqlMetadataContextToolbar = ({
     value: item.value,
     label: `@${item.label}`,
     searchText: item.dbType,
-    icon: <Server size={13} strokeWidth={1.8} className="text-[#1677ff]" />,
+    icon: (
+      <Server
+        size={13}
+        strokeWidth={1.8}
+        className="text-[var(--yak-brand-color)]"
+      />
+    ),
   }));
 
   const databasePlaceholder = !context.dataSourceId
@@ -262,13 +269,22 @@ const SqlMetadataContextToolbar = ({
 
   return (
     <>
-      <div className="flex min-w-0 shrink-0 items-center gap-1">
+      <div
+        className="flex min-w-0 shrink-0 items-center gap-1"
+        style={BRAND_CSS_VARIABLES}
+      >
         <ContextPicker
           ariaLabel="选择 SQL 数据源"
           value={context.dataSourceId}
           displayValue={context.dataSourceName ? `@${context.dataSourceName}` : undefined}
           placeholder="@datasource"
-          icon={<Server size={13} strokeWidth={1.8} className="text-[#1677ff]" />}
+          icon={
+            <Server
+              size={13}
+              strokeWidth={1.8}
+              className="text-[var(--yak-brand-color)]"
+            />
+          }
           items={dataSourceItems}
           loading={dataSourceLoading}
           popupWidth={210}


### PR DESCRIPTION
## 背景

#339 先把数据开发页面顶部 SQL 数据源图标与右侧面板激活态统一成了同一个蓝色，但这两处仍然是局部硬编码 `#1677ff`。

Yak Ops 已经在 `@/styles/brand` 中维护统一品牌色和 CSS 变量，因此数据开发这里应该直接复用全局品牌来源，避免后续品牌色调整时各组件再次逐个修改。

## 调整内容

- SQL 数据源 `Server` 图标改为使用 `var(--yak-brand-color)`
- 右侧「属性 / 运行配置 / 调度配置 / 版本」激活文字改为使用 `var(--yak-brand-color)`
- 右侧激活竖线同步使用 `var(--yak-brand-color)`
- 两个组件直接复用 `BRAND_CSS_VARIABLES`，颜色最终来源于 `BRAND_COLOR = rgba(254,44,85,1)`
- 后续只需要修改 `@/styles/brand`，这两处视觉会自动跟随

## 影响范围

仅修改数据开发前端：

- `yak-ops-ui/src/pages/data-development/components/workbench/RightPanel.tsx`
- `yak-ops-ui/src/pages/data-development/editors/sql/metadata/SqlMetadataContextToolbar.tsx`

不修改业务逻辑、数据源接口、SQL metadata context、右侧面板交互及 Ant Design 主题配置。

## Validation

- [x] 基于当前最新 `main`
- [x] compare `behind 0`
- [x] 目标位置不再硬编码 `#1677ff`
- [x] 统一复用 `@/styles/brand` 中的 `BRAND_CSS_VARIABLES`
- [ ] 浏览器视觉回归：确认顶部数据源图标与右侧激活态均显示 Yak Ops 品牌红
