### PR TITLE
feat(data-development): add task draft and revision lifecycle

### DIFF
--- a/docs/data-development/task-authoring-stage-3.md
+++ b/docs/data-development/task-authoring-stage-3.md
@@ -1,0 +1,203 @@
+# 数据开发任务草稿与发布版本（阶段 3）
+
+> 状态：Implemented（阶段 3）  
+> 范围：打通数据开发 `TaskDraft -> Publish -> TaskRevision`，不实现真实任务执行与 Workflow Task Catalog。
+
+## 1. 目标
+
+阶段 1 已固定 `DevelopmentNode / TaskDraft / TaskRevision / TaskAsset / TaskExecution` 的统一语义，阶段 2 已建立平台级 `TaskPlugin -> ServiceLoader -> TaskPluginRegistry` 骨架。
+
+阶段 3 让数据开发工作台首次拥有服务端任务内容生命周期：
+
+```text
+DevelopmentNode
+      |
+      v
+  TaskDraft       可反复保存
+      |
+      | publish
+      v
+TaskRevision v1   不可变
+      |
+      | edit + save + publish
+      v
+TaskRevision v2   不可变
+```
+
+本阶段仍不创建 TaskAsset，也不会让发布任务直接进入 Workflow；Task Catalog 属于后续阶段。
+
+## 2. 数据边界
+
+开发节点继续只承担树元数据：
+
+```text
+yak_dev_node
+  id / name / type / project_id / directory_id / configured
+```
+
+任务正文不回填到 `yak_dev_node`，也不恢复历史的 `yak_dev_sql_task` 专属模型。
+
+新增两张通用表：
+
+```text
+yak_dev_task_draft
+  node_id                 PK
+  task_type
+  schema_version
+  content
+  config_json
+  draft_revision
+  create_time
+  update_time
+
+
+yak_dev_task_revision
+  id                      PK
+  node_id
+  revision_no             node 内单调递增
+  source_draft_revision
+  task_type
+  schema_version
+  content
+  config_json
+  checksum                SHA-256
+  create_time
+```
+
+插件私有参数继续放在 `TaskDefinition.configJson` 中。平台只理解统一信封，不增加 `SQL/Shell/Python` 专属任务表。
+
+## 3. Draft 语义
+
+草稿是可变工作副本。
+
+保存接口：
+
+```http
+PUT /api/v1/data-development/nodes/{nodeId}/draft
+```
+
+请求携带：
+
+```json
+{
+  "taskType": "SQL",
+  "schemaVersion": 1,
+  "content": "select 1",
+  "configJson": "{\"dataSourceId\":\"123\"}",
+  "baseRevision": 3
+}
+```
+
+`baseRevision` 是乐观锁基线：
+
+```text
+客户端 A 读取 Draft #3
+客户端 B 读取 Draft #3
+
+A 保存 -> Draft #4
+B 仍以 #3 保存 -> HTTP 409
+```
+
+因此多浏览器 / 多 Tab 不会静默覆盖更晚的服务端草稿。
+
+未保存过的节点通过读取草稿接口得到一个临时 `draftRevision=0` 的空 Definition；第一次保存成功后进入 `draftRevision=1`。
+
+## 4. Publish 语义
+
+发布接口：
+
+```http
+POST /api/v1/data-development/nodes/{nodeId}/publish
+```
+
+请求必须携带希望发布的 `draftRevision`。
+
+发布事务执行：
+
+1. 锁定当前 Draft；
+2. 检查请求的 Draft Revision 是否仍是当前版本；
+3. 根据 DevelopmentNode 校验 taskType 不可漂移；
+4. 规范化 `configJson`；
+5. 从 `TaskPluginRegistry` 找到对应 Task Plugin；
+6. 调用 `TaskPlugin.validate(TaskDefinition)`；
+7. 计算 Definition SHA-256；
+8. 写入新的不可变 `TaskRevision`。
+
+SQL 阶段 2 插件当前会检查：
+
+- `taskType=SQL`；
+- `schemaVersion=1`；
+- SQL content 非空。
+
+因此空 SQL 可以先保存为草稿，但不能发布。
+
+## 5. Revision 不可变规则
+
+已发布 Revision 不提供 update/delete API。
+
+例如：
+
+```text
+今天统计
+  Draft #5 -> Publish -> v1
+  Draft #6 -> Publish -> v2
+```
+
+后续修改只会形成新的 Draft Revision，再发布出新的 Task Revision。
+
+同一个未变化的 Draft 重复点击发布时，如果最新 Revision 已来自该 Draft 且 checksum 相同，则直接返回现有 Revision，避免因为重复点击产生无意义版本。
+
+## 6. API
+
+```http
+GET  /api/v1/data-development/nodes/{nodeId}/draft
+PUT  /api/v1/data-development/nodes/{nodeId}/draft
+POST /api/v1/data-development/nodes/{nodeId}/publish
+GET  /api/v1/data-development/nodes/{nodeId}/revisions
+GET  /api/v1/data-development/nodes/{nodeId}/revisions/{revisionNo}
+```
+
+版本列表只返回轻量元数据；版本详情才返回完整不可变 `TaskDefinition`。
+
+## 7. 前端工作台
+
+数据开发编辑器由本地 Session 升级为“本地编辑态 + 服务端 Draft”两层：
+
+```text
+Monaco / Editor Session
+        |
+        | 保存草稿
+        v
+Server TaskDraft
+        |
+        | 发布版本
+        v
+Server TaskRevision
+```
+
+具体行为：
+
+- 打开节点时读取服务端 Draft；
+- 本地已有未保存修改时，不用服务端响应覆盖本地 dirty Session；
+- 保存按钮真正调用 Draft API，不再把 localStorage 当成服务端保存；
+- SQL 数据源持久化只保存稳定 `dataSourceId`，Database / Schema 仍由数据源管理绑定配置解析；
+- SQL 发布前如果当前内容未保存，会先保存 Draft，再发布明确 Draft Revision；
+- 关闭 dirty Tab 时，“保存”会真正保存到服务端；
+- “不保存”回退到最近一次已保存 Draft 基线；
+- 右侧“版本”面板展示发布版本列表，并可查看某个 Revision 的 SQL 内容与 checksum。
+
+当前只有 SQL Task Plugin 可发布。Shell / HTTP / Python 可以保存通用 Draft，但发布入口暂不开放，直到对应 Task Plugin 正式接入。
+
+## 8. 与后续阶段的边界
+
+本阶段明确不做：
+
+- 不执行 SQL；
+- 不创建 TaskExecution；
+- 不创建 TaskAsset / Task Catalog；
+- 发布后暂不自动出现在 Workflow；
+- Workflow 暂不引用 Revision；
+- 不做 Schedule；
+- 不做 Shell/Python Worker。
+
+后续阶段 4 将让 SQL Task Plugin 复用现有 DataSource Plugin，打通数据开发手动运行；阶段 5 再把已发布 Revision 注册为 Task Catalog 资产，使 Workflow 的“数据开发”任务库自动可见。

--- a/yak-ops-business/yak-ops-business-data-development/pom.xml
+++ b/yak-ops-business/yak-ops-business-data-development/pom.xml
@@ -14,12 +14,24 @@
     <artifactId>yak-ops-business-data-development</artifactId>
 
     <name>Yak Ops Business Data Development</name>
-    <description>Data-development directory and resource-node metadata</description>
+    <description>Data-development directory, task authoring and immutable revision lifecycle</description>
 
     <dependencies>
         <dependency>
             <groupId>io.yak.ops</groupId>
             <artifactId>yak-ops-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.yak.ops</groupId>
+            <artifactId>yak-ops-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.yak.ops</groupId>
+            <artifactId>yak-ops-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.yak.ops</groupId>
+            <artifactId>yak-ops-plugin-task-api</artifactId>
         </dependency>
         <dependency>
             <groupId>io.yak.ops</groupId>

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/api/DevelopmentTaskApi.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/api/DevelopmentTaskApi.java
@@ -1,0 +1,26 @@
+package io.yak.ops.business.development.api;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
+
+/** HTTP request contracts for data-development task authoring. */
+public final class DevelopmentTaskApi {
+
+  private DevelopmentTaskApi() {
+  }
+
+  public record SaveDraftRequest(
+      @NotBlank String taskType,
+      @Min(1) int schemaVersion,
+      String content,
+      String configJson,
+      @PositiveOrZero Long baseRevision) {
+  }
+
+  public record PublishRequest(
+      @NotNull @Positive Long draftRevision) {
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/config/DataDevelopmentTaskPluginConfiguration.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/config/DataDevelopmentTaskPluginConfiguration.java
@@ -1,0 +1,17 @@
+package io.yak.ops.business.development.config;
+
+import io.yak.ops.core.plugin.task.TaskPluginRegistry;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/** Makes the platform TaskPlugin registry available to data-development authoring services. */
+@Configuration(proxyBeanMethods = false)
+public class DataDevelopmentTaskPluginConfiguration {
+
+  @Bean
+  @ConditionalOnMissingBean(TaskPluginRegistry.class)
+  public TaskPluginRegistry taskPluginRegistry() {
+    return TaskPluginRegistry.load();
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/controller/v1/DevelopmentTaskController.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/controller/v1/DevelopmentTaskController.java
@@ -1,0 +1,76 @@
+package io.yak.ops.business.development.controller.v1;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.yak.framework.common.Result;
+import io.yak.ops.business.development.api.DevelopmentTaskApi.PublishRequest;
+import io.yak.ops.business.development.api.DevelopmentTaskApi.SaveDraftRequest;
+import io.yak.ops.business.development.domain.DevelopmentTaskDraft;
+import io.yak.ops.business.development.domain.DevelopmentTaskRevision;
+import io.yak.ops.business.development.domain.DevelopmentTaskRevisionSummary;
+import io.yak.ops.business.development.service.DevelopmentTaskService;
+import jakarta.validation.Valid;
+import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Draft, publish and immutable revision APIs for one development node. */
+@Tag(name = "数据开发任务接口")
+@RestController
+@RequestMapping("/api/v1/data-development/nodes")
+public class DevelopmentTaskController {
+
+  private final DevelopmentTaskService service;
+
+  public DevelopmentTaskController(DevelopmentTaskService service) {
+    this.service = service;
+  }
+
+  @Operation(summary = "读取节点草稿")
+  @GetMapping("/{nodeId}/draft")
+  public Result<DevelopmentTaskDraft> getDraft(@PathVariable("nodeId") Long nodeId) {
+    return Result.success(service.getDraft(nodeId));
+  }
+
+  @Operation(summary = "保存节点草稿")
+  @PutMapping("/{nodeId}/draft")
+  public Result<DevelopmentTaskDraft> saveDraft(
+      @PathVariable("nodeId") Long nodeId,
+      @Valid @RequestBody SaveDraftRequest request) {
+    return Result.success(service.saveDraft(
+        nodeId,
+        request.taskType(),
+        request.schemaVersion(),
+        request.content(),
+        request.configJson(),
+        request.baseRevision()));
+  }
+
+  @Operation(summary = "发布节点版本")
+  @PostMapping("/{nodeId}/publish")
+  public Result<DevelopmentTaskRevision> publish(
+      @PathVariable("nodeId") Long nodeId,
+      @Valid @RequestBody PublishRequest request) {
+    return Result.success(service.publish(nodeId, request.draftRevision()));
+  }
+
+  @Operation(summary = "查询节点发布版本")
+  @GetMapping("/{nodeId}/revisions")
+  public Result<List<DevelopmentTaskRevisionSummary>> listRevisions(
+      @PathVariable("nodeId") Long nodeId) {
+    return Result.success(service.listRevisions(nodeId));
+  }
+
+  @Operation(summary = "查询节点发布版本详情")
+  @GetMapping("/{nodeId}/revisions/{revisionNo}")
+  public Result<DevelopmentTaskRevision> getRevision(
+      @PathVariable("nodeId") Long nodeId,
+      @PathVariable("revisionNo") int revisionNo) {
+    return Result.success(service.getRevision(nodeId, revisionNo));
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/controller/v1/DevelopmentTaskExceptionHandler.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/controller/v1/DevelopmentTaskExceptionHandler.java
@@ -1,0 +1,42 @@
+package io.yak.ops.business.development.controller.v1;
+
+import io.yak.ops.business.development.service.DevelopmentDraftConflictException;
+import io.yak.ops.business.development.service.DevelopmentTaskValidationException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+/** Focused HTTP error mapping for task-authoring endpoints. */
+@RestControllerAdvice(assignableTypes = DevelopmentTaskController.class)
+public class DevelopmentTaskExceptionHandler {
+
+  @ExceptionHandler(DevelopmentDraftConflictException.class)
+  public ResponseEntity<Map<String, Object>> handleConflict(
+      DevelopmentDraftConflictException exception) {
+    return ResponseEntity.status(HttpStatus.CONFLICT)
+        .body(errorBody(exception.getMessage()));
+  }
+
+  @ExceptionHandler(DevelopmentTaskValidationException.class)
+  public ResponseEntity<Map<String, Object>> handleValidation(
+      DevelopmentTaskValidationException exception) {
+    Map<String, Object> body = errorBody(exception.getMessage());
+    body.put("issues", exception.issues());
+    return ResponseEntity.badRequest().body(body);
+  }
+
+  @ExceptionHandler(IllegalArgumentException.class)
+  public ResponseEntity<Map<String, Object>> handleIllegalArgument(
+      IllegalArgumentException exception) {
+    return ResponseEntity.badRequest().body(errorBody(exception.getMessage()));
+  }
+
+  private Map<String, Object> errorBody(String message) {
+    Map<String, Object> body = new LinkedHashMap<>();
+    body.put("message", message == null || message.isBlank() ? "数据开发任务请求失败" : message);
+    return body;
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/dao/mapper/DevelopmentTaskDraftMapper.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/dao/mapper/DevelopmentTaskDraftMapper.java
@@ -1,0 +1,18 @@
+package io.yak.ops.business.development.dao.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import io.yak.ops.common.bean.po.development.DevelopmentTaskDraftPO;
+import org.apache.ibatis.annotations.Param;
+import org.apache.ibatis.annotations.Select;
+
+public interface DevelopmentTaskDraftMapper extends BaseMapper<DevelopmentTaskDraftPO> {
+
+  @Select("""
+      SELECT node_id, task_type, schema_version, content, config_json,
+             draft_revision, create_time, update_time
+      FROM yak_dev_task_draft
+      WHERE node_id = #{nodeId}
+      FOR UPDATE
+      """)
+  DevelopmentTaskDraftPO selectForUpdate(@Param("nodeId") Long nodeId);
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/dao/mapper/DevelopmentTaskRevisionMapper.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/dao/mapper/DevelopmentTaskRevisionMapper.java
@@ -1,0 +1,12 @@
+package io.yak.ops.business.development.dao.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import io.yak.ops.common.bean.po.development.DevelopmentTaskRevisionPO;
+import org.apache.ibatis.annotations.Param;
+import org.apache.ibatis.annotations.Select;
+
+public interface DevelopmentTaskRevisionMapper extends BaseMapper<DevelopmentTaskRevisionPO> {
+
+  @Select("SELECT COALESCE(MAX(revision_no), 0) FROM yak_dev_task_revision WHERE node_id = #{nodeId}")
+  Integer selectMaxRevisionNo(@Param("nodeId") Long nodeId);
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/domain/DevelopmentTaskDraft.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/domain/DevelopmentTaskDraft.java
@@ -1,0 +1,15 @@
+package io.yak.ops.business.development.domain;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import io.yak.ops.spi.task.model.TaskDefinition;
+import java.time.Instant;
+
+/** Mutable authoring draft for one data-development node. */
+public record DevelopmentTaskDraft(
+    @JsonSerialize(using = ToStringSerializer.class) Long nodeId,
+    TaskDefinition definition,
+    long draftRevision,
+    Instant createTime,
+    Instant updateTime) {
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/domain/DevelopmentTaskRevision.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/domain/DevelopmentTaskRevision.java
@@ -1,0 +1,17 @@
+package io.yak.ops.business.development.domain;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import io.yak.ops.spi.task.model.TaskDefinition;
+import java.time.Instant;
+
+/** Immutable published task revision. */
+public record DevelopmentTaskRevision(
+    @JsonSerialize(using = ToStringSerializer.class) Long id,
+    @JsonSerialize(using = ToStringSerializer.class) Long nodeId,
+    int revisionNo,
+    long sourceDraftRevision,
+    TaskDefinition definition,
+    String checksum,
+    Instant createTime) {
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/domain/DevelopmentTaskRevisionSummary.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/domain/DevelopmentTaskRevisionSummary.java
@@ -1,0 +1,15 @@
+package io.yak.ops.business.development.domain;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import java.time.Instant;
+
+/** Lightweight immutable revision metadata used by the versions panel. */
+public record DevelopmentTaskRevisionSummary(
+    @JsonSerialize(using = ToStringSerializer.class) Long id,
+    @JsonSerialize(using = ToStringSerializer.class) Long nodeId,
+    int revisionNo,
+    long sourceDraftRevision,
+    String checksum,
+    Instant createTime) {
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/DevelopmentNodeRepository.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/DevelopmentNodeRepository.java
@@ -24,5 +24,7 @@ public interface DevelopmentNodeRepository {
 
   boolean updateName(Long id, String name);
 
+  boolean updateConfigured(Long id, boolean configured);
+
   boolean deleteById(Long id);
 }

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/DevelopmentNodeRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/DevelopmentNodeRepositoryAdapter.java
@@ -88,6 +88,17 @@ public class DevelopmentNodeRepositoryAdapter implements DevelopmentNodeReposito
   }
 
   @Override
+  public boolean updateConfigured(Long id, boolean configured) {
+    return mapper.update(
+            null,
+            new LambdaUpdateWrapper<DevelopmentNodePO>()
+                .eq(DevelopmentNodePO::getId, id)
+                .set(DevelopmentNodePO::getConfigured, configured)
+                .set(DevelopmentNodePO::getUpdateTime, Instant.now()))
+        > 0;
+  }
+
+  @Override
   public boolean deleteById(Long id) {
     return mapper.deleteById(id) > 0;
   }

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/DevelopmentTaskDraftRepository.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/DevelopmentTaskDraftRepository.java
@@ -1,0 +1,19 @@
+package io.yak.ops.business.development.repository;
+
+import io.yak.ops.business.development.domain.DevelopmentTaskDraft;
+import io.yak.ops.spi.task.model.TaskDefinition;
+import java.util.Optional;
+
+/** Durable mutable draft repository with optimistic revision checks. */
+public interface DevelopmentTaskDraftRepository {
+
+  Optional<DevelopmentTaskDraft> findByNodeId(Long nodeId);
+
+  Optional<DevelopmentTaskDraft> findByNodeIdForUpdate(Long nodeId);
+
+  /** Returns empty when the expected base revision no longer matches the stored draft. */
+  Optional<DevelopmentTaskDraft> save(
+      Long nodeId,
+      TaskDefinition definition,
+      long expectedBaseRevision);
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/DevelopmentTaskDraftRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/DevelopmentTaskDraftRepositoryAdapter.java
@@ -1,0 +1,96 @@
+package io.yak.ops.business.development.repository;
+
+import com.baomidou.mybatisplus.core.conditions.update.LambdaUpdateWrapper;
+import io.yak.ops.business.development.dao.mapper.DevelopmentTaskDraftMapper;
+import io.yak.ops.business.development.domain.DevelopmentTaskDraft;
+import io.yak.ops.common.bean.po.development.DevelopmentTaskDraftPO;
+import io.yak.ops.spi.task.model.TaskDefinition;
+import java.time.Instant;
+import java.util.Optional;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.stereotype.Repository;
+
+/** MyBatis adapter for mutable development-task drafts. */
+@Repository
+public class DevelopmentTaskDraftRepositoryAdapter implements DevelopmentTaskDraftRepository {
+
+  private final DevelopmentTaskDraftMapper mapper;
+
+  public DevelopmentTaskDraftRepositoryAdapter(DevelopmentTaskDraftMapper mapper) {
+    this.mapper = mapper;
+  }
+
+  @Override
+  public Optional<DevelopmentTaskDraft> findByNodeId(Long nodeId) {
+    return Optional.ofNullable(mapper.selectById(nodeId)).map(this::toDomain);
+  }
+
+  @Override
+  public Optional<DevelopmentTaskDraft> findByNodeIdForUpdate(Long nodeId) {
+    return Optional.ofNullable(mapper.selectForUpdate(nodeId)).map(this::toDomain);
+  }
+
+  @Override
+  public Optional<DevelopmentTaskDraft> save(
+      Long nodeId,
+      TaskDefinition definition,
+      long expectedBaseRevision) {
+    DevelopmentTaskDraftPO current = mapper.selectById(nodeId);
+    Instant now = Instant.now();
+
+    if (current == null) {
+      if (expectedBaseRevision != 0L) return Optional.empty();
+
+      DevelopmentTaskDraftPO created = new DevelopmentTaskDraftPO();
+      created.setNodeId(nodeId);
+      applyDefinition(created, definition);
+      created.setDraftRevision(1L);
+      created.setCreateTime(now);
+      created.setUpdateTime(now);
+      try {
+        mapper.insert(created);
+      } catch (DuplicateKeyException conflict) {
+        return Optional.empty();
+      }
+      return Optional.of(toDomain(created));
+    }
+
+    long currentRevision = current.getDraftRevision() == null ? 0L : current.getDraftRevision();
+    if (currentRevision != expectedBaseRevision) return Optional.empty();
+
+    long nextRevision = currentRevision + 1L;
+    int updated = mapper.update(
+        null,
+        new LambdaUpdateWrapper<DevelopmentTaskDraftPO>()
+            .eq(DevelopmentTaskDraftPO::getNodeId, nodeId)
+            .eq(DevelopmentTaskDraftPO::getDraftRevision, currentRevision)
+            .set(DevelopmentTaskDraftPO::getTaskType, definition.taskType())
+            .set(DevelopmentTaskDraftPO::getSchemaVersion, definition.schemaVersion())
+            .set(DevelopmentTaskDraftPO::getContent, definition.content())
+            .set(DevelopmentTaskDraftPO::getConfigJson, definition.configJson())
+            .set(DevelopmentTaskDraftPO::getDraftRevision, nextRevision)
+            .set(DevelopmentTaskDraftPO::getUpdateTime, now));
+    if (updated <= 0) return Optional.empty();
+    return findByNodeId(nodeId);
+  }
+
+  private void applyDefinition(DevelopmentTaskDraftPO po, TaskDefinition definition) {
+    po.setTaskType(definition.taskType());
+    po.setSchemaVersion(definition.schemaVersion());
+    po.setContent(definition.content());
+    po.setConfigJson(definition.configJson());
+  }
+
+  private DevelopmentTaskDraft toDomain(DevelopmentTaskDraftPO po) {
+    return new DevelopmentTaskDraft(
+        po.getNodeId(),
+        new TaskDefinition(
+            po.getTaskType(),
+            po.getSchemaVersion() == null ? 1 : po.getSchemaVersion(),
+            po.getContent(),
+            po.getConfigJson()),
+        po.getDraftRevision() == null ? 0L : po.getDraftRevision(),
+        po.getCreateTime(),
+        po.getUpdateTime());
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/DevelopmentTaskRevisionRepository.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/DevelopmentTaskRevisionRepository.java
@@ -1,0 +1,26 @@
+package io.yak.ops.business.development.repository;
+
+import io.yak.ops.business.development.domain.DevelopmentTaskRevision;
+import io.yak.ops.business.development.domain.DevelopmentTaskRevisionSummary;
+import io.yak.ops.spi.task.model.TaskDefinition;
+import java.util.List;
+import java.util.Optional;
+
+/** Durable immutable published revision repository. */
+public interface DevelopmentTaskRevisionRepository {
+
+  int nextRevisionNo(Long nodeId);
+
+  DevelopmentTaskRevision insert(
+      Long nodeId,
+      int revisionNo,
+      long sourceDraftRevision,
+      TaskDefinition definition,
+      String checksum);
+
+  Optional<DevelopmentTaskRevision> findLatestByNodeId(Long nodeId);
+
+  Optional<DevelopmentTaskRevision> findByRevisionNo(Long nodeId, int revisionNo);
+
+  List<DevelopmentTaskRevisionSummary> listByNodeId(Long nodeId);
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/DevelopmentTaskRevisionRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/DevelopmentTaskRevisionRepositoryAdapter.java
@@ -1,0 +1,107 @@
+package io.yak.ops.business.development.repository;
+
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import io.yak.ops.business.development.dao.mapper.DevelopmentTaskRevisionMapper;
+import io.yak.ops.business.development.domain.DevelopmentTaskRevision;
+import io.yak.ops.business.development.domain.DevelopmentTaskRevisionSummary;
+import io.yak.ops.common.bean.po.development.DevelopmentTaskRevisionPO;
+import io.yak.ops.spi.task.model.TaskDefinition;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.stereotype.Repository;
+
+/** MyBatis adapter for immutable published task revisions. */
+@Repository
+public class DevelopmentTaskRevisionRepositoryAdapter
+    implements DevelopmentTaskRevisionRepository {
+
+  private final DevelopmentTaskRevisionMapper mapper;
+
+  public DevelopmentTaskRevisionRepositoryAdapter(DevelopmentTaskRevisionMapper mapper) {
+    this.mapper = mapper;
+  }
+
+  @Override
+  public int nextRevisionNo(Long nodeId) {
+    Integer max = mapper.selectMaxRevisionNo(nodeId);
+    return (max == null ? 0 : max) + 1;
+  }
+
+  @Override
+  public DevelopmentTaskRevision insert(
+      Long nodeId,
+      int revisionNo,
+      long sourceDraftRevision,
+      TaskDefinition definition,
+      String checksum) {
+    DevelopmentTaskRevisionPO po = new DevelopmentTaskRevisionPO();
+    po.setNodeId(nodeId);
+    po.setRevisionNo(revisionNo);
+    po.setSourceDraftRevision(sourceDraftRevision);
+    po.setTaskType(definition.taskType());
+    po.setSchemaVersion(definition.schemaVersion());
+    po.setContent(definition.content());
+    po.setConfigJson(definition.configJson());
+    po.setChecksum(checksum);
+    po.setCreateTime(Instant.now());
+    mapper.insert(po);
+    return toDomain(po);
+  }
+
+  @Override
+  public Optional<DevelopmentTaskRevision> findLatestByNodeId(Long nodeId) {
+    return Optional.ofNullable(mapper.selectOne(
+            new LambdaQueryWrapper<DevelopmentTaskRevisionPO>()
+                .eq(DevelopmentTaskRevisionPO::getNodeId, nodeId)
+                .orderByDesc(DevelopmentTaskRevisionPO::getRevisionNo)
+                .last("LIMIT 1")))
+        .map(this::toDomain);
+  }
+
+  @Override
+  public Optional<DevelopmentTaskRevision> findByRevisionNo(Long nodeId, int revisionNo) {
+    return Optional.ofNullable(mapper.selectOne(
+            new LambdaQueryWrapper<DevelopmentTaskRevisionPO>()
+                .eq(DevelopmentTaskRevisionPO::getNodeId, nodeId)
+                .eq(DevelopmentTaskRevisionPO::getRevisionNo, revisionNo)
+                .last("LIMIT 1")))
+        .map(this::toDomain);
+  }
+
+  @Override
+  public List<DevelopmentTaskRevisionSummary> listByNodeId(Long nodeId) {
+    return mapper.selectList(
+            new LambdaQueryWrapper<DevelopmentTaskRevisionPO>()
+                .eq(DevelopmentTaskRevisionPO::getNodeId, nodeId)
+                .orderByDesc(DevelopmentTaskRevisionPO::getRevisionNo))
+        .stream()
+        .map(this::toSummary)
+        .toList();
+  }
+
+  private DevelopmentTaskRevision toDomain(DevelopmentTaskRevisionPO po) {
+    return new DevelopmentTaskRevision(
+        po.getId(),
+        po.getNodeId(),
+        po.getRevisionNo() == null ? 0 : po.getRevisionNo(),
+        po.getSourceDraftRevision() == null ? 0L : po.getSourceDraftRevision(),
+        new TaskDefinition(
+            po.getTaskType(),
+            po.getSchemaVersion() == null ? 1 : po.getSchemaVersion(),
+            po.getContent(),
+            po.getConfigJson()),
+        po.getChecksum(),
+        po.getCreateTime());
+  }
+
+  private DevelopmentTaskRevisionSummary toSummary(DevelopmentTaskRevisionPO po) {
+    return new DevelopmentTaskRevisionSummary(
+        po.getId(),
+        po.getNodeId(),
+        po.getRevisionNo() == null ? 0 : po.getRevisionNo(),
+        po.getSourceDraftRevision() == null ? 0L : po.getSourceDraftRevision(),
+        po.getChecksum(),
+        po.getCreateTime());
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentDraftConflictException.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentDraftConflictException.java
@@ -1,0 +1,9 @@
+package io.yak.ops.business.development.service;
+
+/** Raised when a client tries to overwrite a newer server-side draft revision. */
+public class DevelopmentDraftConflictException extends RuntimeException {
+
+  public DevelopmentDraftConflictException(String message) {
+    super(message);
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentTaskService.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentTaskService.java
@@ -1,0 +1,228 @@
+package io.yak.ops.business.development.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.development.domain.DevelopmentNode;
+import io.yak.ops.business.development.domain.DevelopmentTaskDraft;
+import io.yak.ops.business.development.domain.DevelopmentTaskRevision;
+import io.yak.ops.business.development.domain.DevelopmentTaskRevisionSummary;
+import io.yak.ops.business.development.repository.DevelopmentNodeRepository;
+import io.yak.ops.business.development.repository.DevelopmentTaskDraftRepository;
+import io.yak.ops.business.development.repository.DevelopmentTaskRevisionRepository;
+import io.yak.ops.core.plugin.task.TaskPluginRegistry;
+import io.yak.ops.plugin.task.api.TaskPlugin;
+import io.yak.ops.plugin.task.api.TaskValidationIssue;
+import io.yak.ops.plugin.task.api.TaskValidationResult;
+import io.yak.ops.spi.task.model.TaskDefinition;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/** Authoring lifecycle: mutable draft -> validated immutable published revision. */
+@Service
+public class DevelopmentTaskService {
+
+  private final DevelopmentNodeRepository nodeRepository;
+  private final DevelopmentTaskDraftRepository draftRepository;
+  private final DevelopmentTaskRevisionRepository revisionRepository;
+  private final TaskPluginRegistry pluginRegistry;
+  private final ObjectMapper objectMapper;
+
+  public DevelopmentTaskService(
+      DevelopmentNodeRepository nodeRepository,
+      DevelopmentTaskDraftRepository draftRepository,
+      DevelopmentTaskRevisionRepository revisionRepository,
+      TaskPluginRegistry pluginRegistry,
+      ObjectMapper objectMapper) {
+    this.nodeRepository = nodeRepository;
+    this.draftRepository = draftRepository;
+    this.revisionRepository = revisionRepository;
+    this.pluginRegistry = pluginRegistry;
+    this.objectMapper = objectMapper;
+  }
+
+  public DevelopmentTaskDraft getDraft(Long nodeId) {
+    DevelopmentNode node = requireNode(nodeId);
+    return draftRepository.findByNodeId(nodeId)
+        .orElseGet(() -> emptyDraft(node));
+  }
+
+  @Transactional(transactionManager = "yakBusinessTransactionManager", rollbackFor = Exception.class)
+  public DevelopmentTaskDraft saveDraft(
+      Long nodeId,
+      String taskType,
+      int schemaVersion,
+      String content,
+      String configJson,
+      Long baseRevision) {
+    DevelopmentNode node = requireNode(nodeId);
+    TaskDefinition definition = normalizeDefinition(
+        node,
+        taskType,
+        schemaVersion,
+        content,
+        configJson);
+    long expectedRevision = baseRevision == null ? 0L : baseRevision;
+
+    DevelopmentTaskDraft saved = draftRepository.save(nodeId, definition, expectedRevision)
+        .orElseThrow(() -> new DevelopmentDraftConflictException(
+            "草稿已被其他会话更新，请刷新后重新保存（当前基线：" + expectedRevision + "）"));
+    nodeRepository.updateConfigured(nodeId, true);
+    return saved;
+  }
+
+  @Transactional(transactionManager = "yakBusinessTransactionManager", rollbackFor = Exception.class)
+  public DevelopmentTaskRevision publish(Long nodeId, long expectedDraftRevision) {
+    DevelopmentNode node = requireNode(nodeId);
+    DevelopmentTaskDraft draft = draftRepository.findByNodeIdForUpdate(nodeId)
+        .orElseThrow(() -> new IllegalArgumentException("节点尚未保存草稿：" + nodeId));
+
+    if (draft.draftRevision() != expectedDraftRevision) {
+      throw new DevelopmentDraftConflictException(
+          "发布失败：草稿版本已变化，期望 "
+              + expectedDraftRevision
+              + "，当前 "
+              + draft.draftRevision());
+    }
+
+    TaskDefinition definition = normalizeDefinition(
+        node,
+        draft.definition().taskType(),
+        draft.definition().schemaVersion(),
+        draft.definition().content(),
+        draft.definition().configJson());
+    validateForPublish(definition);
+
+    String checksum = checksum(definition);
+    DevelopmentTaskRevision latest = revisionRepository.findLatestByNodeId(nodeId).orElse(null);
+    if (latest != null
+        && latest.sourceDraftRevision() == draft.draftRevision()
+        && Objects.equals(latest.checksum(), checksum)) {
+      return latest;
+    }
+
+    int revisionNo = revisionRepository.nextRevisionNo(nodeId);
+    DevelopmentTaskRevision published = revisionRepository.insert(
+        nodeId,
+        revisionNo,
+        draft.draftRevision(),
+        definition,
+        checksum);
+    nodeRepository.updateConfigured(nodeId, true);
+    return published;
+  }
+
+  public List<DevelopmentTaskRevisionSummary> listRevisions(Long nodeId) {
+    requireNode(nodeId);
+    return revisionRepository.listByNodeId(nodeId);
+  }
+
+  public DevelopmentTaskRevision getRevision(Long nodeId, int revisionNo) {
+    requireNode(nodeId);
+    if (revisionNo <= 0) throw new IllegalArgumentException("revisionNo 必须大于 0");
+    return revisionRepository.findByRevisionNo(nodeId, revisionNo)
+        .orElseThrow(() -> new IllegalArgumentException(
+            "发布版本不存在：nodeId=" + nodeId + ", revisionNo=" + revisionNo));
+  }
+
+  private DevelopmentNode requireNode(Long nodeId) {
+    if (nodeId == null || nodeId <= 0L) throw new IllegalArgumentException("节点 ID 非法");
+    return nodeRepository.findById(nodeId)
+        .orElseThrow(() -> new IllegalArgumentException("节点不存在：" + nodeId));
+  }
+
+  private DevelopmentTaskDraft emptyDraft(DevelopmentNode node) {
+    int schemaVersion = pluginRegistry.find(node.type())
+        .map(plugin -> plugin.descriptor().schemaVersion())
+        .orElse(1);
+    return new DevelopmentTaskDraft(
+        node.id(),
+        new TaskDefinition(node.type(), schemaVersion, "", "{}"),
+        0L,
+        null,
+        null);
+  }
+
+  private TaskDefinition normalizeDefinition(
+      DevelopmentNode node,
+      String taskType,
+      int schemaVersion,
+      String content,
+      String configJson) {
+    if (taskType == null || taskType.isBlank()) {
+      throw new IllegalArgumentException("taskType 不能为空");
+    }
+    String normalizedType = taskType.trim().toUpperCase(Locale.ROOT);
+    if (!normalizedType.equals(node.type().trim().toUpperCase(Locale.ROOT))) {
+      throw new IllegalArgumentException(
+          "任务类型与节点类型不一致：node=" + node.type() + ", definition=" + normalizedType);
+    }
+    if (schemaVersion <= 0) {
+      throw new IllegalArgumentException("schemaVersion 必须大于 0");
+    }
+
+    return new TaskDefinition(
+        normalizedType,
+        schemaVersion,
+        content == null ? "" : content,
+        normalizeConfigJson(configJson));
+  }
+
+  private String normalizeConfigJson(String configJson) {
+    String raw = configJson == null || configJson.isBlank() ? "{}" : configJson.trim();
+    try {
+      JsonNode node = objectMapper.readTree(raw);
+      if (node == null || !node.isObject()) {
+        throw new IllegalArgumentException("configJson 必须是 JSON Object");
+      }
+      return objectMapper.writeValueAsString(node);
+    } catch (JsonProcessingException exception) {
+      throw new IllegalArgumentException("configJson 不是合法 JSON", exception);
+    }
+  }
+
+  private void validateForPublish(TaskDefinition definition) {
+    TaskPlugin plugin = pluginRegistry.find(definition.taskType())
+        .orElseThrow(() -> new DevelopmentTaskValidationException(
+            "当前未安装 " + definition.taskType() + " Task Plugin，无法发布",
+            List.of(new TaskValidationIssue(
+                "TASK_PLUGIN_NOT_INSTALLED",
+                "taskType",
+                "Task plugin is not installed: " + definition.taskType()))));
+
+    TaskValidationResult validation = plugin.validate(definition);
+    if (!validation.valid()) {
+      String summary = validation.issues().stream()
+          .map(TaskValidationIssue::message)
+          .limit(3)
+          .reduce((left, right) -> left + "；" + right)
+          .orElse("任务定义校验失败");
+      throw new DevelopmentTaskValidationException(summary, validation.issues());
+    }
+  }
+
+  private String checksum(TaskDefinition definition) {
+    try {
+      MessageDigest digest = MessageDigest.getInstance("SHA-256");
+      updateDigest(digest, definition.taskType());
+      updateDigest(digest, Integer.toString(definition.schemaVersion()));
+      updateDigest(digest, definition.content());
+      updateDigest(digest, definition.configJson());
+      return HexFormat.of().formatHex(digest.digest());
+    } catch (NoSuchAlgorithmException impossible) {
+      throw new IllegalStateException("SHA-256 is unavailable", impossible);
+    }
+  }
+
+  private void updateDigest(MessageDigest digest, String value) {
+    if (value != null) digest.update(value.getBytes(StandardCharsets.UTF_8));
+    digest.update((byte) 0);
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentTaskValidationException.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentTaskValidationException.java
@@ -1,0 +1,19 @@
+package io.yak.ops.business.development.service;
+
+import io.yak.ops.plugin.task.api.TaskValidationIssue;
+import java.util.List;
+
+/** Structured publish-time validation failure returned by a TaskPlugin. */
+public class DevelopmentTaskValidationException extends RuntimeException {
+
+  private final List<TaskValidationIssue> issues;
+
+  public DevelopmentTaskValidationException(String message, List<TaskValidationIssue> issues) {
+    super(message);
+    this.issues = issues == null ? List.of() : List.copyOf(issues);
+  }
+
+  public List<TaskValidationIssue> issues() {
+    return issues;
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/resources/db/migration/yak-data-development/V7__create_task_authoring_tables.sql
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/resources/db/migration/yak-data-development/V7__create_task_authoring_tables.sql
@@ -1,0 +1,32 @@
+-- Stage 3: generic mutable drafts and immutable published revisions.
+-- Task-specific content/config stays plugin-owned; data-development owns authoring lifecycle only.
+
+CREATE TABLE IF NOT EXISTS yak_dev_task_draft (
+    node_id BIGINT NOT NULL,
+    task_type VARCHAR(32) NOT NULL,
+    schema_version INT NOT NULL,
+    content LONGTEXT NOT NULL,
+    config_json LONGTEXT NOT NULL,
+    draft_revision BIGINT NOT NULL,
+    create_time DATETIME(6) NOT NULL,
+    update_time DATETIME(6) NOT NULL,
+    PRIMARY KEY (node_id),
+    KEY idx_yak_dev_task_draft_update (update_time)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS yak_dev_task_revision (
+    id BIGINT NOT NULL,
+    node_id BIGINT NOT NULL,
+    revision_no INT NOT NULL,
+    source_draft_revision BIGINT NOT NULL,
+    task_type VARCHAR(32) NOT NULL,
+    schema_version INT NOT NULL,
+    content LONGTEXT NOT NULL,
+    config_json LONGTEXT NOT NULL,
+    checksum CHAR(64) NOT NULL,
+    create_time DATETIME(6) NOT NULL,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_yak_dev_task_revision_node_no (node_id, revision_no),
+    KEY idx_yak_dev_task_revision_node_time (node_id, create_time),
+    KEY idx_yak_dev_task_revision_checksum (node_id, checksum)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/DevelopmentTaskServiceTest.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/DevelopmentTaskServiceTest.java
@@ -1,0 +1,138 @@
+package io.yak.ops.business.development.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.development.domain.DevelopmentNode;
+import io.yak.ops.business.development.domain.DevelopmentTaskDraft;
+import io.yak.ops.business.development.domain.DevelopmentTaskRevision;
+import io.yak.ops.business.development.repository.DevelopmentNodeRepository;
+import io.yak.ops.business.development.repository.DevelopmentTaskDraftRepository;
+import io.yak.ops.business.development.repository.DevelopmentTaskRevisionRepository;
+import io.yak.ops.core.plugin.task.TaskPluginRegistry;
+import io.yak.ops.plugin.task.api.TaskPlugin;
+import io.yak.ops.plugin.task.api.TaskPluginDescriptor;
+import io.yak.ops.plugin.task.api.TaskValidationIssue;
+import io.yak.ops.plugin.task.api.TaskValidationResult;
+import io.yak.ops.spi.task.model.TaskDefinition;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class DevelopmentTaskServiceTest {
+
+  private DevelopmentNodeRepository nodeRepository;
+  private DevelopmentTaskDraftRepository draftRepository;
+  private DevelopmentTaskRevisionRepository revisionRepository;
+  private DevelopmentTaskService service;
+
+  @BeforeEach
+  void setUp() {
+    nodeRepository = mock(DevelopmentNodeRepository.class);
+    draftRepository = mock(DevelopmentTaskDraftRepository.class);
+    revisionRepository = mock(DevelopmentTaskRevisionRepository.class);
+    service = new DevelopmentTaskService(
+        nodeRepository,
+        draftRepository,
+        revisionRepository,
+        TaskPluginRegistry.from(List.of(new TestSqlPlugin())),
+        new ObjectMapper());
+
+    Instant now = Instant.parse("2026-08-12T00:00:00Z");
+    when(nodeRepository.findById(1L)).thenReturn(Optional.of(
+        new DevelopmentNode(1L, "今天统计", "SQL", null, null, false, now, now)));
+  }
+
+  @Test
+  void saveDraftUsesOptimisticBaseRevisionAndMarksNodeConfigured() {
+    TaskDefinition definition = new TaskDefinition("SQL", 1, "select 1", "{}");
+    DevelopmentTaskDraft saved = new DevelopmentTaskDraft(
+        1L, definition, 1L, Instant.now(), Instant.now());
+    when(draftRepository.save(eq(1L), any(TaskDefinition.class), eq(0L)))
+        .thenReturn(Optional.of(saved));
+
+    DevelopmentTaskDraft result = service.saveDraft(
+        1L, "sql", 1, "select 1", "{ }", 0L);
+
+    assertEquals(1L, result.draftRevision());
+    assertEquals("{}", result.definition().configJson());
+    verify(nodeRepository).updateConfigured(1L, true);
+  }
+
+  @Test
+  void saveDraftRejectsConcurrentOverwrite() {
+    when(draftRepository.save(eq(1L), any(TaskDefinition.class), eq(2L)))
+        .thenReturn(Optional.empty());
+
+    assertThrows(
+        DevelopmentDraftConflictException.class,
+        () -> service.saveDraft(1L, "SQL", 1, "select 2", "{}", 2L));
+  }
+
+  @Test
+  void publishCreatesImmutableRevisionFromLockedDraft() {
+    TaskDefinition definition = new TaskDefinition("SQL", 1, "select 1", "{}");
+    DevelopmentTaskDraft draft = new DevelopmentTaskDraft(
+        1L, definition, 3L, Instant.now(), Instant.now());
+    when(draftRepository.findByNodeIdForUpdate(1L)).thenReturn(Optional.of(draft));
+    when(revisionRepository.findLatestByNodeId(1L)).thenReturn(Optional.empty());
+    when(revisionRepository.nextRevisionNo(1L)).thenReturn(1);
+    when(revisionRepository.insert(eq(1L), eq(1), eq(3L), eq(definition), any(String.class)))
+        .thenAnswer(invocation -> new DevelopmentTaskRevision(
+            100L,
+            1L,
+            1,
+            3L,
+            definition,
+            invocation.getArgument(4),
+            Instant.now()));
+
+    DevelopmentTaskRevision published = service.publish(1L, 3L);
+
+    assertEquals(1, published.revisionNo());
+    assertEquals(3L, published.sourceDraftRevision());
+    assertEquals(64, published.checksum().length());
+    verify(nodeRepository).updateConfigured(1L, true);
+  }
+
+  @Test
+  void publishRejectsPluginValidationErrors() {
+    TaskDefinition definition = new TaskDefinition("SQL", 1, "", "{}");
+    DevelopmentTaskDraft draft = new DevelopmentTaskDraft(
+        1L, definition, 1L, Instant.now(), Instant.now());
+    when(draftRepository.findByNodeIdForUpdate(1L)).thenReturn(Optional.of(draft));
+
+    DevelopmentTaskValidationException exception = assertThrows(
+        DevelopmentTaskValidationException.class,
+        () -> service.publish(1L, 1L));
+
+    assertTrue(exception.issues().stream()
+        .anyMatch(issue -> "SQL_CONTENT_REQUIRED".equals(issue.code())));
+  }
+
+  private static final class TestSqlPlugin implements TaskPlugin {
+
+    @Override
+    public TaskPluginDescriptor descriptor() {
+      return new TaskPluginDescriptor("SQL", "SQL", "test", "1.0.0", 1, false, false);
+    }
+
+    @Override
+    public TaskValidationResult validate(TaskDefinition definition) {
+      if (definition.content() == null || definition.content().isBlank()) {
+        return TaskValidationResult.invalid(
+            new TaskValidationIssue("SQL_CONTENT_REQUIRED", "content", "SQL content required"));
+      }
+      return TaskValidationResult.ok();
+    }
+  }
+}

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/development/DevelopmentTaskDraftPO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/development/DevelopmentTaskDraftPO.java
@@ -1,0 +1,24 @@
+package io.yak.ops.common.bean.po.development;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import java.time.Instant;
+import lombok.Data;
+
+/** Mutable data-development task draft. */
+@Data
+@TableName("yak_dev_task_draft")
+public class DevelopmentTaskDraftPO {
+
+  @TableId(type = IdType.INPUT)
+  private Long nodeId;
+
+  private String taskType;
+  private Integer schemaVersion;
+  private String content;
+  private String configJson;
+  private Long draftRevision;
+  private Instant createTime;
+  private Instant updateTime;
+}

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/development/DevelopmentTaskRevisionPO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/development/DevelopmentTaskRevisionPO.java
@@ -1,0 +1,26 @@
+package io.yak.ops.common.bean.po.development;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import java.time.Instant;
+import lombok.Data;
+
+/** Immutable published data-development task revision. */
+@Data
+@TableName("yak_dev_task_revision")
+public class DevelopmentTaskRevisionPO {
+
+  @TableId(type = IdType.ASSIGN_ID)
+  private Long id;
+
+  private Long nodeId;
+  private Integer revisionNo;
+  private Long sourceDraftRevision;
+  private String taskType;
+  private Integer schemaVersion;
+  private String content;
+  private String configJson;
+  private String checksum;
+  private Instant createTime;
+}

--- a/yak-ops-ui/src/pages/data-development/components/workbench/DevelopmentWorkbench.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/workbench/DevelopmentWorkbench.tsx
@@ -1,4 +1,5 @@
-import { Button, Modal } from 'antd';
+import { API_SUCCESS_CODE } from '@/services/http/response';
+import { Button, Modal, message } from 'antd';
 import { TriangleAlert } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 
@@ -6,12 +7,22 @@ import { getEditorDefinition } from '../../editors/registry';
 import {
   getEditorSession,
   markEditorSessionSaved,
-  updateEditorSessionContent,
 } from '../../editors/session/editorSessionStore';
+import {
+  hydrateDevelopmentTaskDraft,
+  prepareDevelopmentTaskDefinition,
+  restoreDevelopmentTaskOriginal,
+} from '../../editors/taskPersistence';
+import {
+  getDevelopmentTaskDraft,
+  publishDevelopmentTask,
+  saveDevelopmentTaskDraft,
+} from '../../service';
 import type {
   DevelopmentDirectory,
   DevelopmentId,
   DevelopmentNode,
+  DevelopmentTaskDraft,
 } from '../../types';
 import EditorHost from './EditorHost';
 import EditorTabs, { type EditorTabAction } from './EditorTabs';
@@ -24,6 +35,7 @@ interface DevelopmentWorkbenchProps {
   directories: DevelopmentDirectory[];
   selectedNodeId?: DevelopmentId;
   onNodeFocus: (nodeId?: DevelopmentId) => void;
+  onNodesChanged?: () => void | Promise<void>;
 }
 
 interface PendingCloseRequest {
@@ -31,16 +43,31 @@ interface PendingCloseRequest {
   dirtyNodeIds: DevelopmentId[];
 }
 
+const responseData = <T,>(
+  response: { code?: number; data?: T; msg?: string; message?: string },
+  fallback: string,
+): T => {
+  if (response?.code !== API_SUCCESS_CODE || response.data === undefined) {
+    throw new Error(response?.message || response?.msg || fallback);
+  }
+  return response.data;
+};
+
 const DevelopmentWorkbench = ({
   nodes,
   directories,
   selectedNodeId,
   onNodeFocus,
+  onNodesChanged,
 }: DevelopmentWorkbenchProps) => {
   const [openNodeIds, setOpenNodeIds] = useState<DevelopmentId[]>([]);
   const [activeNodeId, setActiveNodeId] = useState<DevelopmentId>();
   const [runPanelOpen, setRunPanelOpen] = useState(false);
   const [pendingClose, setPendingClose] = useState<PendingCloseRequest>();
+  const [saving, setSaving] = useState(false);
+  const [publishing, setPublishing] = useState(false);
+  const [closeSaving, setCloseSaving] = useState(false);
+  const [versionsRefreshKey, setVersionsRefreshKey] = useState(0);
 
   const nodeMap = useMemo(
     () => new Map(nodes.map((node) => [node.id, node])),
@@ -66,6 +93,28 @@ const DevelopmentWorkbench = ({
     );
   }, [nodeMap]);
 
+  useEffect(() => {
+    if (!activeNodeId) return;
+    const node = nodeMap.get(activeNodeId);
+    if (!node) return;
+
+    let active = true;
+    getDevelopmentTaskDraft(node.id)
+      .then((response) => {
+        if (!active) return;
+        const draft = responseData(response, '加载任务草稿失败');
+        hydrateDevelopmentTaskDraft(node, draft);
+      })
+      .catch((error) => {
+        if (!active) return;
+        message.error(error instanceof Error ? error.message : '加载任务草稿失败');
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [activeNodeId, nodeMap]);
+
   const activeNode = activeNodeId ? nodeMap.get(activeNodeId) : undefined;
   const activeDirectory = activeNode?.directoryId
     ? directoryMap.get(activeNode.directoryId)
@@ -74,6 +123,65 @@ const DevelopmentWorkbench = ({
   const focusNode = (nodeId: DevelopmentId) => {
     setActiveNodeId(nodeId);
     onNodeFocus(nodeId);
+  };
+
+  const persistDraft = async (nodeId: DevelopmentId): Promise<DevelopmentTaskDraft> => {
+    const node = nodeMap.get(nodeId);
+    if (!node) throw new Error(`节点不存在：${nodeId}`);
+
+    const definition = prepareDevelopmentTaskDefinition(node);
+    const session = getEditorSession(nodeId);
+    const draft = responseData(
+      await saveDevelopmentTaskDraft(nodeId, {
+        ...definition,
+        baseRevision: session?.draftRevision || 0,
+      }),
+      '保存草稿失败',
+    );
+
+    markEditorSessionSaved(nodeId, draft.draftRevision);
+    await onNodesChanged?.();
+    return draft;
+  };
+
+  const saveActiveDraft = async () => {
+    if (!activeNode) return;
+    setSaving(true);
+    try {
+      const draft = await persistDraft(activeNode.id);
+      message.success(`草稿已保存 · Draft #${draft.draftRevision}`);
+    } catch (error) {
+      message.error(error instanceof Error ? error.message : '保存草稿失败');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const publishActiveTask = async () => {
+    if (!activeNode) return;
+    setPublishing(true);
+    try {
+      prepareDevelopmentTaskDefinition(activeNode);
+      let session = getEditorSession(activeNode.id);
+      if (!session || session.dirty || !session.draftRevision) {
+        await persistDraft(activeNode.id);
+        session = getEditorSession(activeNode.id);
+      }
+      if (!session?.draftRevision) {
+        throw new Error('发布前请先保存草稿');
+      }
+
+      const published = responseData(
+        await publishDevelopmentTask(activeNode.id, session.draftRevision),
+        '发布任务失败',
+      );
+      setVersionsRefreshKey((current) => current + 1);
+      message.success(`已发布 v${published.revisionNo}`);
+    } catch (error) {
+      message.error(error instanceof Error ? error.message : '发布任务失败');
+    } finally {
+      setPublishing(false);
+    }
   };
 
   const closeNodes = (nodeIds: DevelopmentId[]) => {
@@ -113,20 +221,29 @@ const DevelopmentWorkbench = ({
     });
   };
 
-  const resolvePendingClose = (save: boolean) => {
+  const resolvePendingClose = async (save: boolean) => {
     if (!pendingClose) return;
 
-    pendingClose.dirtyNodeIds.forEach((nodeId) => {
-      const session = getEditorSession(nodeId);
-      if (!session?.dirty) return;
-
-      if (save) {
-        markEditorSessionSaved(nodeId);
+    if (save) {
+      setCloseSaving(true);
+      try {
+        for (const nodeId of pendingClose.dirtyNodeIds) {
+          if (getEditorSession(nodeId)?.dirty) {
+            await persistDraft(nodeId);
+          }
+        }
+      } catch (error) {
+        message.error(error instanceof Error ? error.message : '保存草稿失败');
+        setCloseSaving(false);
         return;
       }
-
-      updateEditorSessionContent(nodeId, session.originalContent);
-    });
+      setCloseSaving(false);
+    } else {
+      pendingClose.dirtyNodeIds.forEach((nodeId) => {
+        const node = nodeMap.get(nodeId);
+        if (node) restoreDevelopmentTaskOriginal(node);
+      });
+    }
 
     const nodeIds = pendingClose.nodeIds;
     setPendingClose(undefined);
@@ -198,6 +315,10 @@ const DevelopmentWorkbench = ({
         directory={activeDirectory}
         definition={definition}
         onRun={() => setRunPanelOpen(true)}
+        onSave={() => void saveActiveDraft()}
+        onPublish={() => void publishActiveTask()}
+        saving={saving}
+        publishing={publishing}
       />
 
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
@@ -211,6 +332,7 @@ const DevelopmentWorkbench = ({
             node={activeNode}
             directory={activeDirectory}
             definition={definition}
+            versionsRefreshKey={versionsRefreshKey}
           />
         </div>
 
@@ -230,7 +352,10 @@ const DevelopmentWorkbench = ({
         width={520}
         centered
         maskClosable={false}
-        onCancel={() => setPendingClose(undefined)}
+        closable={!closeSaving}
+        onCancel={() => {
+          if (!closeSaving) setPendingClose(undefined);
+        }}
       >
         <div className="flex gap-4 px-1 py-2">
           <div className="flex h-10 w-10 shrink-0 items-center justify-center text-[#f79009]">
@@ -263,13 +388,25 @@ const DevelopmentWorkbench = ({
             ) : null}
 
             <div className="mt-6 flex justify-end gap-2">
-              <Button type="primary" onClick={() => resolvePendingClose(true)}>
+              <Button
+                type="primary"
+                loading={closeSaving}
+                onClick={() => void resolvePendingClose(true)}
+              >
                 {pendingDirtyCount > 1 ? '保存全部' : '保存'}
               </Button>
-              <Button onClick={() => resolvePendingClose(false)}>
+              <Button
+                disabled={closeSaving}
+                onClick={() => void resolvePendingClose(false)}
+              >
                 {pendingDirtyCount > 1 ? '全部不保存' : '不保存'}
               </Button>
-              <Button onClick={() => setPendingClose(undefined)}>取消</Button>
+              <Button
+                disabled={closeSaving}
+                onClick={() => setPendingClose(undefined)}
+              >
+                取消
+              </Button>
             </div>
           </div>
         </div>

--- a/yak-ops-ui/src/pages/data-development/components/workbench/EditorToolbar.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/workbench/EditorToolbar.tsx
@@ -1,7 +1,6 @@
-import { Tooltip, message } from 'antd';
-import { Play, Save } from 'lucide-react';
+import { Tooltip } from 'antd';
+import { LoaderCircle, Play, Rocket, Save } from 'lucide-react';
 
-import { markEditorSessionSaved } from '../../editors/session/editorSessionStore';
 import type { DevelopmentEditorDefinition } from '../../editors/types';
 import type { DevelopmentDirectory, DevelopmentNode } from '../../types';
 
@@ -10,16 +9,24 @@ interface EditorToolbarProps {
   directory?: DevelopmentDirectory;
   definition: DevelopmentEditorDefinition;
   onRun: () => void;
+  onSave: () => void;
+  onPublish: () => void;
+  saving: boolean;
+  publishing: boolean;
 }
 
 const iconButtonClassName =
-  'flex h-7 w-7 shrink-0 items-center justify-center rounded-[3px] text-[#475467] outline-none transition-colors hover:bg-[#f5f5f6] hover:text-[#1f2937] focus-visible:ring-2 focus-visible:ring-[rgba(254,44,85,.16)]';
+  'flex h-7 w-7 shrink-0 items-center justify-center rounded-[3px] text-[#475467] outline-none transition-colors hover:bg-[#f5f5f6] hover:text-[#1f2937] focus-visible:ring-2 focus-visible:ring-[rgba(254,44,85,.16)] disabled:cursor-not-allowed disabled:opacity-45 disabled:hover:bg-transparent';
 
 const EditorToolbar = ({
   node,
   directory,
   definition,
   onRun,
+  onSave,
+  onPublish,
+  saving,
+  publishing,
 }: EditorToolbarProps) => {
   const Toolbar = definition.Toolbar;
   const capabilities = definition.capabilities;
@@ -28,7 +35,15 @@ const EditorToolbar = ({
     <div className="flex h-9 shrink-0 items-center justify-between border-b border-[#e8e9ec] bg-white px-2">
       {Toolbar ? (
         <div className="flex h-full min-w-0 flex-1 items-center">
-          <Toolbar node={node} directory={directory} onRun={onRun} />
+          <Toolbar
+            node={node}
+            directory={directory}
+            onRun={onRun}
+            onSave={onSave}
+            onPublish={onPublish}
+            saving={saving}
+            publishing={publishing}
+          />
         </div>
       ) : (
         <>
@@ -47,17 +62,36 @@ const EditorToolbar = ({
                 </Tooltip>
               ) : null}
               {capabilities.save ? (
-                <Tooltip title="保存本地草稿" mouseEnterDelay={0.35}>
+                <Tooltip title="保存草稿" mouseEnterDelay={0.35}>
                   <button
                     type="button"
-                    aria-label="保存本地草稿"
-                    onClick={() => {
-                      markEditorSessionSaved(node.id);
-                      message.success('本地草稿已保存');
-                    }}
+                    aria-label="保存草稿"
+                    disabled={saving || publishing}
+                    onClick={onSave}
                     className={iconButtonClassName}
                   >
-                    <Save size={15} strokeWidth={1.8} />
+                    {saving ? (
+                      <LoaderCircle size={15} className="animate-spin" />
+                    ) : (
+                      <Save size={15} strokeWidth={1.8} />
+                    )}
+                  </button>
+                </Tooltip>
+              ) : null}
+              {capabilities.publish ? (
+                <Tooltip title="发布版本" mouseEnterDelay={0.35}>
+                  <button
+                    type="button"
+                    aria-label="发布版本"
+                    disabled={saving || publishing}
+                    onClick={onPublish}
+                    className={iconButtonClassName}
+                  >
+                    {publishing ? (
+                      <LoaderCircle size={15} className="animate-spin" />
+                    ) : (
+                      <Rocket size={15} strokeWidth={1.8} />
+                    )}
                   </button>
                 </Tooltip>
               ) : null}

--- a/yak-ops-ui/src/pages/data-development/components/workbench/RightPanel.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/workbench/RightPanel.tsx
@@ -9,11 +9,13 @@ import type {
   DevelopmentEditorPanelKey,
 } from '../../editors/types';
 import type { DevelopmentDirectory, DevelopmentNode } from '../../types';
+import TaskVersionsPanel from './TaskVersionsPanel';
 
 interface RightPanelProps {
   node: DevelopmentNode;
   directory?: DevelopmentDirectory;
   definition: DevelopmentEditorDefinition;
+  versionsRefreshKey?: number;
 }
 
 const DEFAULT_WIDTH = 380;
@@ -43,10 +45,16 @@ const allItems: Array<{
   { key: 'versions', label: '版本', capability: 'versions' },
 ];
 
-const RightPanel = ({ node, directory, definition }: RightPanelProps) => {
+const RightPanel = ({
+  node,
+  directory,
+  definition,
+  versionsRefreshKey = 0,
+}: RightPanelProps) => {
   const [activeTab, setActiveTab] = useState<DevelopmentEditorPanelKey>();
   const [width, setWidth] = useState(initialWidth);
   const [resizing, setResizing] = useState(false);
+  const [manualRefreshKey, setManualRefreshKey] = useState(0);
 
   const items = useMemo(
     () =>
@@ -92,6 +100,15 @@ const RightPanel = ({ node, directory, definition }: RightPanelProps) => {
   const renderContent = () => {
     if (!activeTab) return null;
 
+    if (activeTab === 'versions') {
+      return (
+        <TaskVersionsPanel
+          node={node}
+          refreshKey={versionsRefreshKey + manualRefreshKey}
+        />
+      );
+    }
+
     const CustomPanel = definition.panels?.[activeTab];
     if (CustomPanel) {
       return <CustomPanel node={node} directory={directory} />;
@@ -129,24 +146,10 @@ const RightPanel = ({ node, directory, definition }: RightPanelProps) => {
       );
     }
 
-    if (activeTab === 'schedule-config') {
-      return (
-        <div className="text-[12px] leading-6 text-[#667085]">
-          <div className="font-medium text-[#344054]">调度配置</div>
-          <div className="mt-2">调度周期、依赖关系和生效时间将在后续阶段接入。</div>
-        </div>
-      );
-    }
-
     return (
-      <div className="border-b border-[#f0f1f3] pb-3 text-[12px]">
-        <div className="flex items-center justify-between gap-3">
-          <span className="font-medium text-[#475467]">当前草稿</span>
-          <span className="text-[10px] text-[#98a2b3]">v1</span>
-        </div>
-        <div className="mt-1 text-[11px] leading-5 text-[#98a2b3]">
-          版本管理能力将在后续阶段接入
-        </div>
+      <div className="text-[12px] leading-6 text-[#667085]">
+        <div className="font-medium text-[#344054]">调度配置</div>
+        <div className="mt-2">调度周期、依赖关系和生效时间将在后续阶段接入。</div>
       </div>
     );
   };
@@ -182,7 +185,13 @@ const RightPanel = ({ node, directory, definition }: RightPanelProps) => {
                 <button
                   type="button"
                   title="刷新"
-                  onClick={() => message.info(`${activeItem?.label || ''}刷新能力将在后续阶段接入`)}
+                  onClick={() => {
+                    if (activeTab === 'versions') {
+                      setManualRefreshKey((current) => current + 1);
+                    } else {
+                      message.info(`${activeItem?.label || ''}刷新能力将在后续阶段接入`);
+                    }
+                  }}
                   className="flex h-7 items-center gap-1 rounded-[3px] px-2 text-[11px] text-[#475467] transition-colors hover:bg-[#f5f5f6]"
                 >
                   <RefreshCw size={13} strokeWidth={1.8} />

--- a/yak-ops-ui/src/pages/data-development/components/workbench/TaskVersionsPanel.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/workbench/TaskVersionsPanel.tsx
@@ -1,0 +1,151 @@
+import { API_SUCCESS_CODE } from '@/services/http/response';
+import { Spin, message } from 'antd';
+import { FileCode2 } from 'lucide-react';
+import { useEffect, useState } from 'react';
+
+import {
+  getDevelopmentTaskRevision,
+  listDevelopmentTaskRevisions,
+} from '../../service';
+import type {
+  DevelopmentNode,
+  DevelopmentTaskRevision,
+  DevelopmentTaskRevisionSummary,
+} from '../../types';
+
+interface TaskVersionsPanelProps {
+  node: DevelopmentNode;
+  refreshKey: number;
+}
+
+const responseData = <T,>(
+  response: { code?: number; data?: T; msg?: string; message?: string },
+  fallback: string,
+): T => {
+  if (response?.code !== API_SUCCESS_CODE || response.data === undefined) {
+    throw new Error(response?.message || response?.msg || fallback);
+  }
+  return response.data;
+};
+
+const formatTime = (value?: string) => {
+  if (!value) return '-';
+  const date = new Date(value);
+  return Number.isNaN(date.getTime())
+    ? value
+    : date.toLocaleString('zh-CN', { hour12: false });
+};
+
+const TaskVersionsPanel = ({ node, refreshKey }: TaskVersionsPanelProps) => {
+  const [versions, setVersions] = useState<DevelopmentTaskRevisionSummary[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [detailLoading, setDetailLoading] = useState(false);
+  const [detail, setDetail] = useState<DevelopmentTaskRevision>();
+
+  useEffect(() => {
+    let active = true;
+    setLoading(true);
+    setDetail(undefined);
+    listDevelopmentTaskRevisions(node.id)
+      .then((response) => {
+        if (!active) return;
+        setVersions(responseData(response, '查询发布版本失败') || []);
+      })
+      .catch((error) => {
+        if (active) message.error(error instanceof Error ? error.message : '查询发布版本失败');
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [node.id, refreshKey]);
+
+  const openDetail = async (revisionNo: number) => {
+    setDetailLoading(true);
+    try {
+      setDetail(
+        responseData(
+          await getDevelopmentTaskRevision(node.id, revisionNo),
+          '查询版本详情失败',
+        ),
+      );
+    } catch (error) {
+      message.error(error instanceof Error ? error.message : '查询版本详情失败');
+    } finally {
+      setDetailLoading(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex h-24 items-center justify-center">
+        <Spin size="small" />
+      </div>
+    );
+  }
+
+  if (!versions.length) {
+    return (
+      <div className="py-8 text-center text-[11px] leading-5 text-[#98a2b3]">
+        暂无已发布版本
+        <div className="mt-1">保存草稿后点击顶部“发布版本”即可生成 v1。</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3 text-[12px]">
+      <div className="space-y-1.5">
+        {versions.map((version, index) => (
+          <button
+            key={version.id}
+            type="button"
+            onClick={() => void openDetail(version.revisionNo)}
+            className="flex w-full items-center gap-2 rounded-[3px] border border-[#eaecf0] px-2.5 py-2 text-left transition-colors hover:bg-[#f8f9fa]"
+          >
+            <FileCode2 size={14} className="shrink-0 text-[#667085]" strokeWidth={1.7} />
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center gap-2">
+                <span className="font-medium text-[#344054]">v{version.revisionNo}</span>
+                {index === 0 ? (
+                  <span className="rounded bg-[#f2f4f7] px-1.5 py-0.5 text-[10px] text-[#667085]">
+                    最新
+                  </span>
+                ) : null}
+              </div>
+              <div className="mt-0.5 truncate text-[10px] text-[#98a2b3]">
+                {formatTime(version.createTime)} · {version.checksum.slice(0, 10)}
+              </div>
+            </div>
+          </button>
+        ))}
+      </div>
+
+      {detailLoading ? (
+        <div className="flex h-16 items-center justify-center border-t border-[#eef0f2]">
+          <Spin size="small" />
+        </div>
+      ) : detail ? (
+        <div className="border-t border-[#eef0f2] pt-3">
+          <div className="flex items-center justify-between gap-3">
+            <span className="font-medium text-[#344054]">v{detail.revisionNo} 内容</span>
+            <span className="text-[10px] text-[#98a2b3]">
+              Draft #{detail.sourceDraftRevision}
+            </span>
+          </div>
+          <pre className="mt-2 max-h-[300px] overflow-auto whitespace-pre-wrap break-words rounded-[3px] bg-[#f8f9fa] p-2.5 font-mono text-[11px] leading-5 text-[#475467]">
+            {detail.definition.content || '(空内容)'}
+          </pre>
+          <div className="mt-2 break-all font-mono text-[9px] leading-4 text-[#b0b7c3]">
+            SHA-256 {detail.checksum}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+};
+
+export default TaskVersionsPanel;

--- a/yak-ops-ui/src/pages/data-development/editors/registry.tsx
+++ b/yak-ops-ui/src/pages/data-development/editors/registry.tsx
@@ -14,7 +14,7 @@ const commonCapabilities = {
   stop: true,
   save: true,
   refresh: true,
-  publish: true,
+  publish: false,
   share: true,
   properties: true,
   runConfig: true,
@@ -49,7 +49,7 @@ const editorRegistry: Partial<
     label: 'SQL',
     icon: Code2,
     iconClassName: 'text-[#f79009]',
-    capabilities: { ...commonCapabilities, format: true },
+    capabilities: { ...commonCapabilities, publish: true, format: true },
     Editor: SqlEditor,
     Toolbar: SqlToolbar,
     panels: {

--- a/yak-ops-ui/src/pages/data-development/editors/session/editorSessionStore.ts
+++ b/yak-ops-ui/src/pages/data-development/editors/session/editorSessionStore.ts
@@ -36,6 +36,13 @@ const isBrowser = () => typeof window !== 'undefined';
 const isFiniteNumber = (value: unknown): value is number =>
   typeof value === 'number' && Number.isFinite(value);
 
+const normalizedConfigJson = (value?: string) => value || '{}';
+
+const calculateDirty = (session: DevelopmentEditorSession) =>
+  session.content !== session.originalContent ||
+  normalizedConfigJson(session.configJson) !==
+    normalizedConfigJson(session.originalConfigJson);
+
 const isSelection = (value: unknown): value is DevelopmentEditorSelection => {
   if (!value || typeof value !== 'object') return false;
   const selection = value as Partial<DevelopmentEditorSelection>;
@@ -126,6 +133,11 @@ const isPersistedSession = (
     typeof session.originalContent === 'string' &&
     typeof session.dirty === 'boolean' &&
     isFiniteNumber(session.updatedAt) &&
+    (session.schemaVersion === undefined || isFiniteNumber(session.schemaVersion)) &&
+    (session.configJson === undefined || typeof session.configJson === 'string') &&
+    (session.originalConfigJson === undefined ||
+      typeof session.originalConfigJson === 'string') &&
+    (session.draftRevision === undefined || isFiniteNumber(session.draftRevision)) &&
     (session.viewState === undefined || isViewState(session.viewState))
   );
 };
@@ -146,9 +158,15 @@ const ensureHydrated = () => {
 
     parsed.sessions.forEach((session) => {
       if (!isPersistedSession(session)) return;
-      sessions.set(session.nodeId, {
+      const normalized: DevelopmentEditorSession = {
         ...session,
-        dirty: session.content !== session.originalContent,
+        schemaVersion: session.schemaVersion || 1,
+        configJson: normalizedConfigJson(session.configJson),
+        originalConfigJson: normalizedConfigJson(session.originalConfigJson),
+      };
+      sessions.set(session.nodeId, {
+        ...normalized,
+        dirty: calculateDirty(normalized),
       });
     });
   } catch {
@@ -176,6 +194,7 @@ export const ensureEditorSession = (
   nodeId: DevelopmentId,
   nodeType: DevelopmentTaskType,
   initialContent = '',
+  initialConfigJson = '{}',
 ) => {
   ensureHydrated();
   const current = sessions.get(nodeId);
@@ -184,8 +203,12 @@ export const ensureEditorSession = (
   const session: DevelopmentEditorSession = {
     nodeId,
     nodeType,
+    schemaVersion: 1,
     content: initialContent,
     originalContent: initialContent,
+    configJson: initialConfigJson,
+    originalConfigJson: initialConfigJson,
+    draftRevision: 0,
     dirty: false,
     updatedAt: Date.now(),
   };
@@ -198,6 +221,37 @@ export const getEditorSession = (nodeId: DevelopmentId) => {
   return sessions.get(nodeId);
 };
 
+export const hydrateEditorSession = (
+  nodeId: DevelopmentId,
+  nodeType: DevelopmentTaskType,
+  schemaVersion: number,
+  content: string,
+  configJson: string,
+  draftRevision: number,
+) => {
+  ensureHydrated();
+  const current = sessions.get(nodeId);
+  if (current?.dirty) return current;
+
+  const next: DevelopmentEditorSession = {
+    ...(current || {}),
+    nodeId,
+    nodeType,
+    schemaVersion,
+    content,
+    originalContent: content,
+    configJson,
+    originalConfigJson: configJson,
+    draftRevision,
+    dirty: false,
+    updatedAt: Date.now(),
+  };
+  sessions.set(nodeId, next);
+  schedulePersist();
+  emitChange();
+  return next;
+};
+
 export const updateEditorSessionContent = (
   nodeId: DevelopmentId,
   content: string,
@@ -206,11 +260,37 @@ export const updateEditorSessionContent = (
   const current = sessions.get(nodeId);
   if (!current || current.content === content) return;
 
-  sessions.set(nodeId, {
+  const next: DevelopmentEditorSession = {
     ...current,
     content,
-    dirty: content !== current.originalContent,
     updatedAt: Date.now(),
+  };
+  sessions.set(nodeId, {
+    ...next,
+    dirty: calculateDirty(next),
+  });
+  schedulePersist();
+  emitChange();
+};
+
+export const updateEditorSessionConfig = (
+  nodeId: DevelopmentId,
+  configJson: string,
+) => {
+  ensureHydrated();
+  const current = sessions.get(nodeId);
+  if (!current || normalizedConfigJson(current.configJson) === normalizedConfigJson(configJson)) {
+    return;
+  }
+
+  const next: DevelopmentEditorSession = {
+    ...current,
+    configJson: normalizedConfigJson(configJson),
+    updatedAt: Date.now(),
+  };
+  sessions.set(nodeId, {
+    ...next,
+    dirty: calculateDirty(next),
   });
   schedulePersist();
   emitChange();
@@ -232,19 +312,43 @@ export const updateEditorSessionViewState = (
   schedulePersist();
 };
 
-export const markEditorSessionSaved = (nodeId: DevelopmentId) => {
+export const markEditorSessionSaved = (
+  nodeId: DevelopmentId,
+  draftRevision?: number,
+) => {
   ensureHydrated();
   const current = sessions.get(nodeId);
-  if (!current || !current.dirty) return;
+  if (!current) return;
 
   sessions.set(nodeId, {
     ...current,
     originalContent: current.content,
+    configJson: normalizedConfigJson(current.configJson),
+    originalConfigJson: normalizedConfigJson(current.configJson),
+    draftRevision: draftRevision ?? current.draftRevision,
     dirty: false,
     updatedAt: Date.now(),
   });
   schedulePersist();
   emitChange();
+};
+
+export const restoreEditorSessionOriginal = (nodeId: DevelopmentId) => {
+  ensureHydrated();
+  const current = sessions.get(nodeId);
+  if (!current) return undefined;
+
+  const restored: DevelopmentEditorSession = {
+    ...current,
+    content: current.originalContent,
+    configJson: normalizedConfigJson(current.originalConfigJson),
+    dirty: false,
+    updatedAt: Date.now(),
+  };
+  sessions.set(nodeId, restored);
+  schedulePersist();
+  emitChange();
+  return restored;
 };
 
 export const useEditorSession = (

--- a/yak-ops-ui/src/pages/data-development/editors/session/types.ts
+++ b/yak-ops-ui/src/pages/data-development/editors/session/types.ts
@@ -21,8 +21,12 @@ export interface DevelopmentEditorViewState {
 export interface DevelopmentEditorSession {
   nodeId: DevelopmentId;
   nodeType: DevelopmentTaskType;
+  schemaVersion?: number;
   content: string;
   originalContent: string;
+  configJson?: string;
+  originalConfigJson?: string;
+  draftRevision?: number;
   dirty: boolean;
   viewState?: DevelopmentEditorViewState;
   updatedAt: number;

--- a/yak-ops-ui/src/pages/data-development/editors/sql/SqlToolbar.tsx
+++ b/yak-ops-ui/src/pages/data-development/editors/sql/SqlToolbar.tsx
@@ -1,7 +1,9 @@
 import { Dropdown, Tooltip, message } from 'antd';
 import {
+  LoaderCircle,
   Play,
   Redo2,
+  Rocket,
   Save,
   Search,
   Settings,
@@ -11,7 +13,6 @@ import {
 } from 'lucide-react';
 import type { ReactNode } from 'react';
 
-import { markEditorSessionSaved } from '../session/editorSessionStore';
 import type { DevelopmentEditorToolbarContext } from '../types';
 import {
   executeSqlEditorCommand,
@@ -20,19 +21,21 @@ import {
 import SqlMetadataContextToolbar from './metadata/SqlMetadataContextToolbar';
 
 const iconButtonClassName =
-  'flex h-7 w-7 shrink-0 items-center justify-center rounded-[3px] text-[#475467] outline-none transition-colors hover:bg-[#f5f5f6] hover:text-[#1f2937] focus-visible:ring-2 focus-visible:ring-[rgba(254,44,85,.16)]';
+  'flex h-7 w-7 shrink-0 items-center justify-center rounded-[3px] text-[#475467] outline-none transition-colors hover:bg-[#f5f5f6] hover:text-[#1f2937] focus-visible:ring-2 focus-visible:ring-[rgba(254,44,85,.16)] disabled:cursor-not-allowed disabled:opacity-45 disabled:hover:bg-transparent';
 
 interface ToolbarButtonProps {
   title: string;
   onClick: () => void;
+  disabled?: boolean;
   children: ReactNode;
 }
 
-const ToolbarButton = ({ title, onClick, children }: ToolbarButtonProps) => (
+const ToolbarButton = ({ title, onClick, disabled, children }: ToolbarButtonProps) => (
   <Tooltip title={title} mouseEnterDelay={0.35}>
     <button
       type="button"
       aria-label={title}
+      disabled={disabled}
       onClick={onClick}
       className={iconButtonClassName}
     >
@@ -43,7 +46,14 @@ const ToolbarButton = ({ title, onClick, children }: ToolbarButtonProps) => (
 
 const ToolbarDivider = () => <span className="mx-1 h-4 w-px shrink-0 bg-[#e5e7eb]" />;
 
-const SqlToolbar = ({ node, onRun }: DevelopmentEditorToolbarContext) => {
+const SqlToolbar = ({
+  node,
+  onRun,
+  onSave,
+  onPublish,
+  saving,
+  publishing,
+}: DevelopmentEditorToolbarContext) => {
   const execute = (command: SqlEditorCommand, fallback: string) => {
     if (!executeSqlEditorCommand(node.id, command)) {
       message.info(fallback);
@@ -60,13 +70,26 @@ const SqlToolbar = ({ node, onRun }: DevelopmentEditorToolbarContext) => {
         <ToolbarDivider />
 
         <ToolbarButton
-          title="保存本地草稿"
-          onClick={() => {
-            markEditorSessionSaved(node.id);
-            message.success('本地草稿已保存');
-          }}
+          title="保存草稿"
+          disabled={saving || publishing}
+          onClick={onSave}
         >
-          <Save size={15} strokeWidth={1.8} />
+          {saving ? (
+            <LoaderCircle size={15} className="animate-spin" />
+          ) : (
+            <Save size={15} strokeWidth={1.8} />
+          )}
+        </ToolbarButton>
+        <ToolbarButton
+          title="发布版本"
+          disabled={saving || publishing}
+          onClick={onPublish}
+        >
+          {publishing ? (
+            <LoaderCircle size={15} className="animate-spin" />
+          ) : (
+            <Rocket size={15} strokeWidth={1.8} />
+          )}
         </ToolbarButton>
         <ToolbarButton
           title="撤销"

--- a/yak-ops-ui/src/pages/data-development/editors/sql/metadata/SqlMetadataContextToolbar.tsx
+++ b/yak-ops-ui/src/pages/data-development/editors/sql/metadata/SqlMetadataContextToolbar.tsx
@@ -211,6 +211,17 @@ const SqlMetadataContextToolbar = ({
   }, []);
 
   useEffect(() => {
+    if (!context.dataSourceId || context.dataSourceName || !dataSources.length) return;
+    const selected = dataSources.find((item) => item.value === context.dataSourceId);
+    if (!selected) return;
+    selectSqlDataSourceContext(nodeId, {
+      id: selected.value,
+      name: selected.label,
+      dbType: selected.dbType,
+    });
+  }, [context.dataSourceId, context.dataSourceName, dataSources, nodeId]);
+
+  useEffect(() => {
     let active = true;
     if (!context.dataSourceId) {
       setBindingLoading(false);

--- a/yak-ops-ui/src/pages/data-development/editors/sql/metadata/sqlMetadataContextStore.ts
+++ b/yak-ops-ui/src/pages/data-development/editors/sql/metadata/sqlMetadataContextStore.ts
@@ -1,5 +1,6 @@
 import { useSyncExternalStore } from 'react';
 
+import { updateEditorSessionConfig } from '../../session/editorSessionStore';
 import type { DevelopmentId } from '../../../types';
 
 export interface SqlMetadataContext {
@@ -88,6 +89,9 @@ const getVersion = () => {
   return version;
 };
 
+const configJsonForDataSource = (dataSourceId?: string) =>
+  JSON.stringify(dataSourceId ? { dataSourceId } : {});
+
 export const ensureSqlMetadataContext = (
   nodeId: DevelopmentId,
 ): SqlMetadataContext => {
@@ -108,6 +112,9 @@ export const getSqlMetadataContext = (nodeId: DevelopmentId) => {
   return contexts.get(nodeId);
 };
 
+export const getSqlTaskConfigJson = (nodeId: DevelopmentId) =>
+  configJsonForDataSource(ensureSqlMetadataContext(nodeId).dataSourceId);
+
 export const updateSqlMetadataContext = (
   nodeId: DevelopmentId,
   patch: Partial<Omit<SqlMetadataContext, 'nodeId' | 'updatedAt'>>,
@@ -125,17 +132,50 @@ export const updateSqlMetadataContext = (
   return next;
 };
 
+export const hydrateSqlTaskConfig = (
+  nodeId: DevelopmentId,
+  configJson: string,
+) => {
+  let dataSourceId: string | undefined;
+  try {
+    const parsed = JSON.parse(configJson || '{}') as { dataSourceId?: unknown };
+    dataSourceId = typeof parsed.dataSourceId === 'string' ? parsed.dataSourceId : undefined;
+  } catch {
+    dataSourceId = undefined;
+  }
+
+  const current = ensureSqlMetadataContext(nodeId);
+  const sameDataSource = current.dataSourceId === dataSourceId;
+  const next: SqlMetadataContext = {
+    ...current,
+    nodeId,
+    dataSourceId,
+    dataSourceName: sameDataSource ? current.dataSourceName : undefined,
+    dbType: sameDataSource ? current.dbType : undefined,
+    database: sameDataSource ? current.database : undefined,
+    schema: sameDataSource ? current.schema : undefined,
+    updatedAt: Date.now(),
+  };
+  contexts.set(nodeId, next);
+  persist();
+  emitChange();
+  return next;
+};
+
 export const selectSqlDataSourceContext = (
   nodeId: DevelopmentId,
   dataSource?: { id: string; name?: string; dbType?: string },
-) =>
-  updateSqlMetadataContext(nodeId, {
+) => {
+  const next = updateSqlMetadataContext(nodeId, {
     dataSourceId: dataSource?.id,
     dataSourceName: dataSource?.name,
     dbType: dataSource?.dbType,
     database: undefined,
     schema: undefined,
   });
+  updateEditorSessionConfig(nodeId, configJsonForDataSource(next.dataSourceId));
+  return next;
+};
 
 export const selectSqlDatabaseContext = (
   nodeId: DevelopmentId,

--- a/yak-ops-ui/src/pages/data-development/editors/taskPersistence.ts
+++ b/yak-ops-ui/src/pages/data-development/editors/taskPersistence.ts
@@ -1,0 +1,65 @@
+import type {
+  DevelopmentNode,
+  DevelopmentTaskDefinition,
+  DevelopmentTaskDraft,
+} from '../types';
+import {
+  ensureEditorSession,
+  getEditorSession,
+  hydrateEditorSession,
+  restoreEditorSessionOriginal,
+  updateEditorSessionConfig,
+} from './session/editorSessionStore';
+import {
+  getSqlTaskConfigJson,
+  hydrateSqlTaskConfig,
+} from './sql/metadata/sqlMetadataContextStore';
+
+/** Maps editor-local state into the plugin-neutral TaskDefinition envelope. */
+export const prepareDevelopmentTaskDefinition = (
+  node: DevelopmentNode,
+): DevelopmentTaskDefinition => {
+  ensureEditorSession(node.id, node.type);
+
+  if (node.type === 'SQL') {
+    updateEditorSessionConfig(node.id, getSqlTaskConfigJson(node.id));
+  }
+
+  const session = getEditorSession(node.id) || ensureEditorSession(node.id, node.type);
+  return {
+    taskType: node.type,
+    schemaVersion: session.schemaVersion || 1,
+    content: session.content,
+    configJson: session.configJson || '{}',
+  };
+};
+
+/** Hydrates a server draft unless a local unsaved session must be preserved. */
+export const hydrateDevelopmentTaskDraft = (
+  node: DevelopmentNode,
+  draft: DevelopmentTaskDraft,
+) => {
+  const current = getEditorSession(node.id);
+  if (current?.dirty) return false;
+
+  hydrateEditorSession(
+    node.id,
+    node.type,
+    draft.definition.schemaVersion,
+    draft.definition.content || '',
+    draft.definition.configJson || '{}',
+    draft.draftRevision,
+  );
+
+  if (node.type === 'SQL') {
+    hydrateSqlTaskConfig(node.id, draft.definition.configJson || '{}');
+  }
+  return true;
+};
+
+export const restoreDevelopmentTaskOriginal = (node: DevelopmentNode) => {
+  const restored = restoreEditorSessionOriginal(node.id);
+  if (node.type === 'SQL' && restored) {
+    hydrateSqlTaskConfig(node.id, restored.originalConfigJson || '{}');
+  }
+};

--- a/yak-ops-ui/src/pages/data-development/editors/types.ts
+++ b/yak-ops-ui/src/pages/data-development/editors/types.ts
@@ -21,6 +21,10 @@ export interface DevelopmentEditorContext {
 export interface DevelopmentEditorToolbarContext
   extends DevelopmentEditorContext {
   onRun: () => void;
+  onSave: () => void;
+  onPublish: () => void;
+  saving: boolean;
+  publishing: boolean;
 }
 
 export interface DevelopmentEditorCapabilities {

--- a/yak-ops-ui/src/pages/data-development/service.ts
+++ b/yak-ops-ui/src/pages/data-development/service.ts
@@ -7,6 +7,10 @@ import type {
   DevelopmentDirectory,
   DevelopmentId,
   DevelopmentNode,
+  DevelopmentTaskDraft,
+  DevelopmentTaskRevision,
+  DevelopmentTaskRevisionSummary,
+  SaveDevelopmentTaskDraftPayload,
 } from './types';
 
 const DATA_DEVELOPMENT_API = '/api/v1/data-development';
@@ -48,3 +52,35 @@ export const renameDevelopmentNode = (
 export const deleteDevelopmentNode = (
   id: DevelopmentId,
 ): Promise<ApiResponse<boolean>> => HttpUtils.delete<boolean>(`${NODE_API}/${id}`);
+
+export const getDevelopmentTaskDraft = (
+  nodeId: DevelopmentId,
+): Promise<ApiResponse<DevelopmentTaskDraft>> =>
+  HttpUtils.get<DevelopmentTaskDraft>(`${NODE_API}/${nodeId}/draft`);
+
+export const saveDevelopmentTaskDraft = (
+  nodeId: DevelopmentId,
+  payload: SaveDevelopmentTaskDraftPayload,
+): Promise<ApiResponse<DevelopmentTaskDraft>> =>
+  HttpUtils.put<DevelopmentTaskDraft>(`${NODE_API}/${nodeId}/draft`, payload);
+
+export const publishDevelopmentTask = (
+  nodeId: DevelopmentId,
+  draftRevision: number,
+): Promise<ApiResponse<DevelopmentTaskRevision>> =>
+  HttpUtils.post<DevelopmentTaskRevision>(`${NODE_API}/${nodeId}/publish`, {
+    draftRevision,
+  });
+
+export const listDevelopmentTaskRevisions = (
+  nodeId: DevelopmentId,
+): Promise<ApiResponse<DevelopmentTaskRevisionSummary[]>> =>
+  HttpUtils.get<DevelopmentTaskRevisionSummary[]>(`${NODE_API}/${nodeId}/revisions`);
+
+export const getDevelopmentTaskRevision = (
+  nodeId: DevelopmentId,
+  revisionNo: number,
+): Promise<ApiResponse<DevelopmentTaskRevision>> =>
+  HttpUtils.get<DevelopmentTaskRevision>(
+    `${NODE_API}/${nodeId}/revisions/${revisionNo}`,
+  );

--- a/yak-ops-ui/src/pages/data-development/types.ts
+++ b/yak-ops-ui/src/pages/data-development/types.ts
@@ -33,3 +33,35 @@ export interface CreateDevelopmentNodePayload {
   /** 省略表示数据开发根目录。 */
   directoryId?: DevelopmentId;
 }
+
+export interface DevelopmentTaskDefinition {
+  taskType: DevelopmentTaskType;
+  schemaVersion: number;
+  content: string;
+  configJson: string;
+}
+
+export interface DevelopmentTaskDraft {
+  nodeId: DevelopmentId;
+  definition: DevelopmentTaskDefinition;
+  draftRevision: number;
+  createTime?: string | null;
+  updateTime?: string | null;
+}
+
+export interface SaveDevelopmentTaskDraftPayload extends DevelopmentTaskDefinition {
+  baseRevision: number;
+}
+
+export interface DevelopmentTaskRevisionSummary {
+  id: DevelopmentId;
+  nodeId: DevelopmentId;
+  revisionNo: number;
+  sourceDraftRevision: number;
+  checksum: string;
+  createTime?: string;
+}
+
+export interface DevelopmentTaskRevision extends DevelopmentTaskRevisionSummary {
+  definition: DevelopmentTaskDefinition;
+}


### PR DESCRIPTION
## 背景

Task Plugin 阶段 1 已固定统一任务模型，阶段 2 已建立 `TaskPlugin -> ServiceLoader -> TaskPluginRegistry` 平台级插件骨架。本 PR 完成阶段 3：让数据开发从前端本地 Session 正式进入服务端 `TaskDraft -> Publish -> TaskRevision` 生命周期。

本阶段仍不执行 SQL，也不创建 Task Catalog / Workflow 绑定；重点先把“编辑、保存、发布、版本”这条链稳定下来。

## 后端

### 1. 通用 Draft / Revision 存储

新增 Flyway V7：

```text
yak_dev_task_draft
  node_id                 PK
  task_type
  schema_version
  content
  config_json
  draft_revision
  create_time
  update_time


yak_dev_task_revision
  id                      PK
  node_id
  revision_no
  source_draft_revision
  task_type
  schema_version
  content
  config_json
  checksum
  create_time
```

不恢复 `yak_dev_sql_task / yak_dev_shell_task / ...` 专属表。插件私有参数继续放在统一 `TaskDefinition.configJson` 中。

### 2. Draft 乐观锁

保存草稿时客户端携带 `baseRevision`：

```text
Draft #3
  A 保存 -> #4
  B 仍以 #3 保存 -> 409 Conflict
```

避免多浏览器 / 多 Tab 静默覆盖较新的服务端草稿。

未保存过的节点读取时返回临时 `draftRevision=0` 空草稿，第一次保存后进入 `draftRevision=1`。

### 3. Publish -> Immutable Revision

发布时：

1. `SELECT ... FOR UPDATE` 锁定当前 Draft；
2. 校验请求的 draftRevision 仍为当前版本；
3. 校验 TaskDefinition 的 taskType 与 DevelopmentNode 一致；
4. 规范化 `configJson`；
5. 从 `TaskPluginRegistry` 获取插件；
6. 调用 `TaskPlugin.validate(...)`；
7. 计算 Definition SHA-256；
8. 生成不可变 `TaskRevision vN`。

同一未变化 Draft 重复发布会直接返回已有最新 Revision，不制造无意义版本。

当前 SQL Task Plugin 会阻止空 SQL 发布；但空内容仍允许先保存成 Draft。

### 4. API

新增：

```http
GET  /api/v1/data-development/nodes/{nodeId}/draft
PUT  /api/v1/data-development/nodes/{nodeId}/draft
POST /api/v1/data-development/nodes/{nodeId}/publish
GET  /api/v1/data-development/nodes/{nodeId}/revisions
GET  /api/v1/data-development/nodes/{nodeId}/revisions/{revisionNo}
```

版本列表返回轻量元数据；版本详情返回完整不可变 TaskDefinition。

## 前端 Workbench

### 1. 打开 / 保存真实 Draft

- 打开开发节点时加载服务端 Draft；
- 如果本地 Session 已有未保存修改，不用异步服务端响应覆盖 dirty 内容；
- 顶部“保存”从 `localStorage mark saved` 改成真实 Draft API；
- 本地 EditorSession 记录 `draftRevision / schemaVersion / configJson`；
- 关闭 dirty Tab 时，“保存”也会真正保存服务端 Draft；
- “不保存”回退到最近一次服务端保存基线。

### 2. SQL 配置持久化边界

SQL Draft 的插件配置目前只保存稳定引用：

```json
{"dataSourceId":"..."}
```

Database / Schema 不重复写入任务定义，仍由数据源管理中的绑定配置解析。重新打开 SQL Draft 后，会用 `dataSourceId` 恢复数据源上下文，再补齐展示名称 / DB Type / Database / Schema。

### 3. 发布与版本面板

- SQL 工具栏新增真实“发布版本”入口；
- 当前内容未保存时，发布会先保存 Draft，再发布明确 draftRevision；
- 发布成功显示 `v1 / v2 / ...`；
- 右侧“版本”面板接入真实版本列表；
- 点击某个版本可查看不可变 SQL 内容、来源 Draft Revision 与 SHA-256 checksum。

当前只有 SQL Task Plugin 支持发布入口。Shell / HTTP / Python 可保存通用 Draft，但在对应 Task Plugin 正式接入前不开放发布按钮。

## 并发 / 版本约束

```text
DevelopmentNode: 今天统计
      |
      v
Draft #5  -- publish --> Revision v1
      |
   continue edit
      v
Draft #6  -- publish --> Revision v2
```

`v1` 不会因为 Draft #6 出现而改变。后续 Workflow 将绑定明确 Revision，而不是读取最新草稿。

## 文档

新增：

```text
docs/data-development/task-authoring-stage-3.md
```

记录 Draft、Publish、Revision、乐观锁、API、前端映射和后续阶段边界。

## Tests / Validation

新增 `DevelopmentTaskServiceTest`，覆盖：

- Draft 乐观锁基线保存；
- 并发覆盖冲突；
- Draft 发布为不可变 Revision；
- Task Plugin 发布期校验失败。

分支已重新基于当前 `main` 整理为 1 个提交，GitHub compare 为 `ahead 1 / behind 0`。

当前执行环境无法解析 GitHub 域名拉取完整仓库，因此无法执行完整 Maven / npm Reactor。建议合并前本地执行：

```bash
mvn -pl yak-ops-business/yak-ops-business-data-development -am test
mvn -pl yak-ops-boot -am package -DskipTests

cd yak-ops-ui
npm run tsc
npm run build
```

并使用真实 MySQL 回归 Flyway V7、Draft 保存冲突、发布 v1/v2 与版本面板。

## Deliberately out of scope

本阶段不做：

- 不执行 SQL / 不产生 TaskExecution
- 不实现 SQL Result Grid / 日志
- 不创建 TaskAsset / Task Catalog
- 发布任务暂不自动进入 Workflow
- Workflow 暂不保存 `taskAssetId + taskRevisionId`
- 不实现 Schedule / Worker / Shell / Python 执行

## Next

阶段 4：实现真实 `SQL Task Plugin` 执行，复用现有 DataSource Plugin，打通数据开发手动运行、结果集与执行状态。