### PR TITLE
feat(task-runtime): add real SQL execution for data development

### DIFF
--- a/docs/data-development/sql-task-runtime-stage-4.md
+++ b/docs/data-development/sql-task-runtime-stage-4.md
@@ -1,0 +1,220 @@
+# Data Development SQL Task Runtime - Stage 4
+
+## 1. Goal
+
+Stage 4 turns the SQL Task Plugin from a validation-only skeleton into a real executable plugin and connects the Data Development `Run` action to the existing datasource plugin system.
+
+The stage deliberately keeps authoring and execution separate:
+
+```text
+current editor definition
+        |
+        | POST /nodes/{id}/run
+        v
+DevelopmentTaskRunService
+        |
+        v
+TaskPluginRegistry
+        |
+        v
+SqlTaskPlugin
+        |
+        | TaskExecutionContext capability
+        v
+DataSourceExecutionProvider
+        |
+        v
+DataSourcePluginRegistry
+        |
+        v
+Datasource Plugin
+        |
+        v
+DataSourceSqlExecutor
+        |
+        v
+Database
+```
+
+A manual run executes the current editor content. It does **not** implicitly save a Draft and does **not** publish a Revision.
+
+## 2. Datasource execution contract
+
+The datasource plugin API now exposes a small SQL execution boundary:
+
+- `DataSourceExecutionProvider`: resolves a durable datasource reference without exposing credentials to Task Plugins.
+- `DataSourceSqlExecutor`: one physical SQL execution attempt with optional cancellation.
+- `DataSourceSqlRequest`: SQL text, row limit and statement timeout.
+- `DataSourceSqlResult`: result-set/update-count response.
+- `DataSourceSqlColumn`: JDBC-neutral column metadata.
+
+`DataSourcePlugin#createSqlExecutor` defaults to unsupported. JDBC datasource plugins opt in through `AbstractJdbcDataSourcePlugin`, so MySQL/PostgreSQL/Oracle/SQL Server/Dameng/Kingbase and Doris can reuse the same physical execution mechanism while keeping datasource-specific connection parsing in their own plugins.
+
+The SQL Task Plugin never receives connection passwords, JDBC URLs or repository objects. It persists only a datasource ID in `TaskDefinition.configJson` and asks the runtime capability for an executor when a task attempt starts.
+
+## 3. SQL Task Plugin schemaVersion=1
+
+The SQL plugin currently understands:
+
+```json
+{
+  "dataSourceId": "123",
+  "maxRows": 200,
+  "timeoutSeconds": 30
+}
+```
+
+Only `dataSourceId` is currently written by the UI. Runtime defaults are:
+
+- `maxRows = 200`
+- `timeoutSeconds = 30`
+
+Hard guards in this stage:
+
+- max rows: `1..500`
+- timeout: `1..300` seconds
+
+The descriptor is now `executable=true` and `cancellable=true`. The plugin validates SQL content, schema version, datasource reference and runtime config before creating an executor.
+
+## 4. JDBC execution behavior
+
+`JdbcDataSourceSqlExecutor` uses `Statement.execute(...)`, so one SQL task can return either:
+
+### Result set
+
+```text
+columns
+rows
+returnedRows
+truncated
+```
+
+The executor requests `maxRows + 1` rows internally to detect truncation without returning the extra row.
+
+### Update / DDL count
+
+```text
+affectedRows
+```
+
+Statement timeout is applied with JDBC `setQueryTimeout` when supported. Cancellation is best-effort through `Statement.cancel()` and connection close.
+
+Large values are bounded before leaving the datasource layer: long text is truncated, large binary values are represented by a placeholder, and common temporal/vendor values are converted into JSON-safe strings.
+
+## 5. Data Development manual run API
+
+New endpoint:
+
+```http
+POST /api/v1/data-development/nodes/{nodeId}/run
+```
+
+Request uses the plugin-neutral definition envelope:
+
+```json
+{
+  "taskType": "SQL",
+  "schemaVersion": 1,
+  "content": "select 1",
+  "configJson": "{\"dataSourceId\":\"123\"}"
+}
+```
+
+Response:
+
+```json
+{
+  "status": "SUCCESS",
+  "message": "",
+  "durationMs": 12,
+  "output": {
+    "kind": "RESULT_SET",
+    "columns": [],
+    "rows": [],
+    "returnedRows": 0,
+    "affectedRows": -1,
+    "truncated": false,
+    "dataSourceId": "123"
+  }
+}
+```
+
+The current endpoint is synchronous because Stage 4 only proves the real SQL execution path. `TaskExecution` persistence, asynchronous attempt handles, cross-request cancellation and unified Manual/Workflow/Schedule runtime belong to the later Task Runtime stage.
+
+## 6. Frontend behavior
+
+The Data Development workbench now:
+
+1. Executes the current in-memory SQL and datasource selection, including unsaved editor changes.
+2. Opens the bottom result panel immediately and shows `RUNNING` state.
+3. Renders real result-set rows/columns in a compact grid.
+4. Shows update/DDL affected rows.
+5. Shows backend execution duration.
+6. Surfaces datasource/JDBC/plugin errors in the result panel and message notification.
+7. Indicates when the result is truncated by the row guard.
+
+Only SQL advertises `run=true` in the frontend registry in Stage 4. Shell/HTTP/Python keep their authoring placeholders until their Task Plugins are executable.
+
+## 7. Boundary with Draft / Revision
+
+Manual Run and Publish intentionally differ:
+
+```text
+Run
+  current editor -> execute now
+  no Draft mutation
+  no Revision creation
+
+Save
+  current editor -> TaskDraft
+
+Publish
+  TaskDraft -> immutable TaskRevision
+```
+
+This preserves the Stage 3 concurrency/version guarantees while still allowing IDE-style exploratory execution before saving.
+
+## 8. Tests
+
+Added/updated unit coverage for:
+
+- SQL plugin datasource validation and execution through a typed runtime capability.
+- SQL plugin ServiceLoader assembly now advertising executable/cancellable.
+- Data Development manual run routing the current definition through Task Plugin.
+
+Recommended local verification before Ready for Review:
+
+```bash
+mvn -pl yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-sql -am test
+mvn -pl yak-ops-business/yak-ops-business-data-development -am test
+mvn -pl yak-ops-boot -am package -DskipTests
+
+cd yak-ops-ui
+npm run tsc
+npm run build
+```
+
+Use at least one real MySQL/PostgreSQL/Doris datasource to verify:
+
+- SELECT result grid
+- empty result set
+- DML affected rows
+- SQL syntax error
+- missing datasource
+- row truncation
+- statement timeout
+
+## 9. Deliberately out of scope
+
+Stage 4 does not add:
+
+- durable `TaskExecution` / attempt tables
+- asynchronous run polling
+- HTTP stop/cancel endpoint
+- Workflow or Schedule execution
+- Task Asset / Task Catalog
+- Workflow `taskAssetId + taskRevisionId` binding
+- Shell/Python/HTTP execution
+- worker/container/Kubernetes backends
+
+Those boundaries keep this stage focused on proving that the same platform Task Plugin can execute real SQL by consuming the existing datasource plugin capability.

--- a/yak-ops-business/yak-ops-business-data-development/pom.xml
+++ b/yak-ops-business/yak-ops-business-data-development/pom.xml
@@ -14,7 +14,7 @@
     <artifactId>yak-ops-business-data-development</artifactId>
 
     <name>Yak Ops Business Data Development</name>
-    <description>Data-development directory, task authoring and immutable revision lifecycle</description>
+    <description>Data-development directory, task authoring, revisions and manual execution</description>
 
     <dependencies>
         <dependency>
@@ -32,6 +32,10 @@
         <dependency>
             <groupId>io.yak.ops</groupId>
             <artifactId>yak-ops-plugin-task-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.yak.ops</groupId>
+            <artifactId>yak-ops-plugin-datasource-api</artifactId>
         </dependency>
         <dependency>
             <groupId>io.yak.ops</groupId>

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/api/DevelopmentTaskApi.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/api/DevelopmentTaskApi.java
@@ -6,7 +6,7 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.PositiveOrZero;
 
-/** HTTP request contracts for data-development task authoring. */
+/** HTTP request contracts for data-development task authoring and manual execution. */
 public final class DevelopmentTaskApi {
 
   private DevelopmentTaskApi() {
@@ -22,5 +22,13 @@ public final class DevelopmentTaskApi {
 
   public record PublishRequest(
       @NotNull @Positive Long draftRevision) {
+  }
+
+  /** Runs the current editor definition without implicitly saving or publishing it. */
+  public record RunRequest(
+      @NotBlank String taskType,
+      @Min(1) int schemaVersion,
+      String content,
+      String configJson) {
   }
 }

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/controller/v1/DevelopmentTaskController.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/controller/v1/DevelopmentTaskController.java
@@ -4,10 +4,13 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.yak.framework.common.Result;
 import io.yak.ops.business.development.api.DevelopmentTaskApi.PublishRequest;
+import io.yak.ops.business.development.api.DevelopmentTaskApi.RunRequest;
 import io.yak.ops.business.development.api.DevelopmentTaskApi.SaveDraftRequest;
 import io.yak.ops.business.development.domain.DevelopmentTaskDraft;
 import io.yak.ops.business.development.domain.DevelopmentTaskRevision;
 import io.yak.ops.business.development.domain.DevelopmentTaskRevisionSummary;
+import io.yak.ops.business.development.domain.DevelopmentTaskRunResult;
+import io.yak.ops.business.development.service.DevelopmentTaskRunService;
 import io.yak.ops.business.development.service.DevelopmentTaskService;
 import jakarta.validation.Valid;
 import java.util.List;
@@ -19,16 +22,20 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-/** Draft, publish and immutable revision APIs for one development node. */
+/** Draft, publish, revision and manual-run APIs for one development node. */
 @Tag(name = "数据开发任务接口")
 @RestController
 @RequestMapping("/api/v1/data-development/nodes")
 public class DevelopmentTaskController {
 
   private final DevelopmentTaskService service;
+  private final DevelopmentTaskRunService runService;
 
-  public DevelopmentTaskController(DevelopmentTaskService service) {
+  public DevelopmentTaskController(
+      DevelopmentTaskService service,
+      DevelopmentTaskRunService runService) {
     this.service = service;
+    this.runService = runService;
   }
 
   @Operation(summary = "读取节点草稿")
@@ -42,13 +49,28 @@ public class DevelopmentTaskController {
   public Result<DevelopmentTaskDraft> saveDraft(
       @PathVariable("nodeId") Long nodeId,
       @Valid @RequestBody SaveDraftRequest request) {
-    return Result.success(service.saveDraft(
-        nodeId,
-        request.taskType(),
-        request.schemaVersion(),
-        request.content(),
-        request.configJson(),
-        request.baseRevision()));
+    return Result.success(
+        service.saveDraft(
+            nodeId,
+            request.taskType(),
+            request.schemaVersion(),
+            request.content(),
+            request.configJson(),
+            request.baseRevision()));
+  }
+
+  @Operation(summary = "运行当前编辑器任务")
+  @PostMapping("/{nodeId}/run")
+  public Result<DevelopmentTaskRunResult> run(
+      @PathVariable("nodeId") Long nodeId,
+      @Valid @RequestBody RunRequest request) {
+    return Result.success(
+        runService.run(
+            nodeId,
+            request.taskType(),
+            request.schemaVersion(),
+            request.content(),
+            request.configJson()));
   }
 
   @Operation(summary = "发布节点版本")

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/domain/DevelopmentTaskRunResult.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/domain/DevelopmentTaskRunResult.java
@@ -1,0 +1,20 @@
+package io.yak.ops.business.development.domain;
+
+import io.yak.ops.spi.task.model.TaskExecutionStatus;
+import java.util.Map;
+import java.util.Objects;
+
+/** Synchronous manual-run response; durable TaskExecution persistence is introduced later. */
+public record DevelopmentTaskRunResult(
+    TaskExecutionStatus status,
+    String message,
+    long durationMs,
+    Map<String, Object> output) {
+
+  public DevelopmentTaskRunResult {
+    status = Objects.requireNonNull(status, "status");
+    message = message == null ? "" : message;
+    durationMs = Math.max(0L, durationMs);
+    output = output == null ? Map.of() : Map.copyOf(output);
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentTaskRunService.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentTaskRunService.java
@@ -1,0 +1,195 @@
+package io.yak.ops.business.development.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.development.domain.DevelopmentNode;
+import io.yak.ops.business.development.domain.DevelopmentTaskRunResult;
+import io.yak.ops.business.development.repository.DevelopmentNodeRepository;
+import io.yak.ops.core.plugin.task.TaskPluginRegistry;
+import io.yak.ops.plugin.task.api.TaskExecutionContext;
+import io.yak.ops.plugin.task.api.TaskExecutionResult;
+import io.yak.ops.plugin.task.api.TaskExecutor;
+import io.yak.ops.plugin.task.api.TaskPlugin;
+import io.yak.ops.plugin.task.api.TaskValidationIssue;
+import io.yak.ops.plugin.task.api.TaskValidationResult;
+import io.yak.ops.spi.datasource.execution.DataSourceExecutionProvider;
+import io.yak.ops.spi.task.model.TaskDefinition;
+import io.yak.ops.spi.task.model.TaskExecutionStatus;
+import io.yak.ops.spi.task.model.TaskExecutionTrigger;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.stereotype.Service;
+
+/** Executes the current editor definition through the platform TaskPlugin contract. */
+@Service
+public class DevelopmentTaskRunService {
+
+  private final DevelopmentNodeRepository nodeRepository;
+  private final TaskPluginRegistry pluginRegistry;
+  private final ObjectProvider<DataSourceExecutionProvider> dataSourceExecutionProvider;
+  private final ObjectMapper objectMapper;
+
+  public DevelopmentTaskRunService(
+      DevelopmentNodeRepository nodeRepository,
+      TaskPluginRegistry pluginRegistry,
+      ObjectProvider<DataSourceExecutionProvider> dataSourceExecutionProvider,
+      ObjectMapper objectMapper) {
+    this.nodeRepository = nodeRepository;
+    this.pluginRegistry = pluginRegistry;
+    this.dataSourceExecutionProvider = dataSourceExecutionProvider;
+    this.objectMapper = objectMapper;
+  }
+
+  public DevelopmentTaskRunResult run(
+      Long nodeId,
+      String taskType,
+      int schemaVersion,
+      String content,
+      String configJson) {
+    DevelopmentNode node = requireNode(nodeId);
+    TaskDefinition definition =
+        normalizeDefinition(node, taskType, schemaVersion, content, configJson);
+    TaskPlugin plugin =
+        pluginRegistry
+            .find(definition.taskType())
+            .orElseThrow(
+                () ->
+                    new DevelopmentTaskValidationException(
+                        "当前未安装 " + definition.taskType() + " Task Plugin，无法运行",
+                        List.of(
+                            new TaskValidationIssue(
+                                "TASK_PLUGIN_NOT_INSTALLED",
+                                "taskType",
+                                "Task plugin is not installed: " + definition.taskType()))));
+    if (!plugin.descriptor().executable()) {
+      throw new DevelopmentTaskValidationException(
+          definition.taskType() + " Task Plugin 暂不支持执行",
+          List.of(
+              new TaskValidationIssue(
+                  "TASK_PLUGIN_NOT_EXECUTABLE",
+                  "taskType",
+                  "Task plugin is not executable: " + definition.taskType())));
+    }
+    validate(plugin, definition);
+
+    long started = System.nanoTime();
+    try {
+      TaskExecutor executor =
+          plugin.createExecutor(
+              definition,
+              new ManualExecutionContext(
+                  nodeId,
+                  dataSourceExecutionProvider.getIfAvailable()));
+      TaskExecutionResult result = executor.execute();
+      return new DevelopmentTaskRunResult(
+          result.status(),
+          result.message(),
+          elapsedMillis(started),
+          result.output());
+    } catch (DevelopmentTaskValidationException exception) {
+      throw exception;
+    } catch (Exception exception) {
+      String message = safeMessage(exception);
+      return new DevelopmentTaskRunResult(
+          TaskExecutionStatus.FAILED,
+          message,
+          elapsedMillis(started),
+          Map.of());
+    }
+  }
+
+  private void validate(TaskPlugin plugin, TaskDefinition definition) {
+    TaskValidationResult validation = plugin.validate(definition);
+    if (validation.valid()) return;
+    String summary =
+        validation.issues().stream()
+            .map(TaskValidationIssue::message)
+            .limit(3)
+            .reduce((left, right) -> left + "；" + right)
+            .orElse("任务定义校验失败");
+    throw new DevelopmentTaskValidationException(summary, validation.issues());
+  }
+
+  private DevelopmentNode requireNode(Long nodeId) {
+    if (nodeId == null || nodeId <= 0L) throw new IllegalArgumentException("节点 ID 非法");
+    return nodeRepository
+        .findById(nodeId)
+        .orElseThrow(() -> new IllegalArgumentException("节点不存在：" + nodeId));
+  }
+
+  private TaskDefinition normalizeDefinition(
+      DevelopmentNode node,
+      String taskType,
+      int schemaVersion,
+      String content,
+      String configJson) {
+    if (taskType == null || taskType.isBlank()) {
+      throw new IllegalArgumentException("taskType 不能为空");
+    }
+    String normalizedType = taskType.trim().toUpperCase(Locale.ROOT);
+    if (!normalizedType.equals(node.type().trim().toUpperCase(Locale.ROOT))) {
+      throw new IllegalArgumentException(
+          "任务类型与节点类型不一致：node=" + node.type() + ", definition=" + normalizedType);
+    }
+    if (schemaVersion <= 0) throw new IllegalArgumentException("schemaVersion 必须大于 0");
+    return new TaskDefinition(
+        normalizedType,
+        schemaVersion,
+        content == null ? "" : content,
+        normalizeConfigJson(configJson));
+  }
+
+  private String normalizeConfigJson(String configJson) {
+    String raw = configJson == null || configJson.isBlank() ? "{}" : configJson.trim();
+    try {
+      JsonNode node = objectMapper.readTree(raw);
+      if (node == null || !node.isObject()) {
+        throw new IllegalArgumentException("configJson 必须是 JSON Object");
+      }
+      return objectMapper.writeValueAsString(node);
+    } catch (JsonProcessingException exception) {
+      throw new IllegalArgumentException("configJson 不是合法 JSON", exception);
+    }
+  }
+
+  private long elapsedMillis(long started) {
+    return Math.max(0L, (System.nanoTime() - started) / 1_000_000L);
+  }
+
+  private String safeMessage(Throwable throwable) {
+    String message = throwable == null ? null : throwable.getMessage();
+    if (message == null || message.isBlank()) {
+      return throwable == null ? "任务执行失败" : throwable.getClass().getSimpleName();
+    }
+    return message.length() > 500 ? message.substring(0, 500) : message;
+  }
+
+  private record ManualExecutionContext(
+      Long nodeId,
+      DataSourceExecutionProvider dataSourceExecutionProvider)
+      implements TaskExecutionContext {
+
+    @Override
+    public TaskExecutionTrigger trigger() {
+      return TaskExecutionTrigger.MANUAL;
+    }
+
+    @Override
+    public Map<String, Object> parameters() {
+      return Map.of("nodeId", String.valueOf(nodeId));
+    }
+
+    @Override
+    public <T> Optional<T> capability(Class<T> capabilityType) {
+      if (dataSourceExecutionProvider != null
+          && capabilityType.isInstance(dataSourceExecutionProvider)) {
+        return Optional.of(capabilityType.cast(dataSourceExecutionProvider));
+      }
+      return Optional.empty();
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/DevelopmentTaskRunServiceTest.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/DevelopmentTaskRunServiceTest.java
@@ -1,0 +1,88 @@
+package io.yak.ops.business.development.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.development.domain.DevelopmentNode;
+import io.yak.ops.business.development.domain.DevelopmentTaskRunResult;
+import io.yak.ops.business.development.repository.DevelopmentNodeRepository;
+import io.yak.ops.core.plugin.task.TaskPluginRegistry;
+import io.yak.ops.plugin.task.api.TaskExecutionContext;
+import io.yak.ops.plugin.task.api.TaskExecutionResult;
+import io.yak.ops.plugin.task.api.TaskExecutor;
+import io.yak.ops.plugin.task.api.TaskPlugin;
+import io.yak.ops.plugin.task.api.TaskPluginDescriptor;
+import io.yak.ops.plugin.task.api.TaskValidationResult;
+import io.yak.ops.spi.datasource.execution.DataSourceExecutionProvider;
+import io.yak.ops.spi.task.model.TaskDefinition;
+import io.yak.ops.spi.task.model.TaskExecutionStatus;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+
+class DevelopmentTaskRunServiceTest {
+
+  private DevelopmentTaskRunService service;
+
+  @BeforeEach
+  void setUp() {
+    DevelopmentNodeRepository nodeRepository = mock(DevelopmentNodeRepository.class);
+    Instant now = Instant.parse("2026-08-12T00:00:00Z");
+    when(nodeRepository.findById(1L))
+        .thenReturn(
+            Optional.of(
+                new DevelopmentNode(1L, "今天统计", "SQL", null, null, true, now, now)));
+
+    @SuppressWarnings("unchecked")
+    ObjectProvider<DataSourceExecutionProvider> provider = mock(ObjectProvider.class);
+    service =
+        new DevelopmentTaskRunService(
+            nodeRepository,
+            TaskPluginRegistry.from(List.of(new TestExecutablePlugin())),
+            provider,
+            new ObjectMapper());
+  }
+
+  @Test
+  void runsCurrentDefinitionWithoutDraftOrRevisionDependency() {
+    DevelopmentTaskRunResult result =
+        service.run(1L, "sql", 1, "select 42", "{\"dataSourceId\":\"7\"}");
+
+    assertEquals(TaskExecutionStatus.SUCCESS, result.status());
+    assertEquals("select 42", result.output().get("sql"));
+    assertEquals("MANUAL", result.output().get("trigger"));
+    assertTrue(result.durationMs() >= 0L);
+  }
+
+  private static final class TestExecutablePlugin implements TaskPlugin {
+
+    @Override
+    public TaskPluginDescriptor descriptor() {
+      return new TaskPluginDescriptor("SQL", "SQL", "test", "1.0.0", 1, true, false);
+    }
+
+    @Override
+    public TaskValidationResult validate(TaskDefinition definition) {
+      return TaskValidationResult.ok();
+    }
+
+    @Override
+    public TaskExecutor createExecutor(
+        TaskDefinition definition,
+        TaskExecutionContext context) {
+      return () ->
+          TaskExecutionResult.success(
+              Map.of(
+                  "sql", definition.content(),
+                  "trigger", context.trigger().name()));
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/service/support/BusinessDataSourceExecutionProvider.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/service/support/BusinessDataSourceExecutionProvider.java
@@ -1,0 +1,58 @@
+package io.yak.ops.business.datasource.service.support;
+
+import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
+import io.yak.ops.business.datasource.config.DataSourceProperties;
+import io.yak.ops.business.datasource.domain.DataSourceDefinition;
+import io.yak.ops.business.datasource.plugin.DataSourcePluginRegistry;
+import io.yak.ops.business.datasource.repository.DataSourceRepository;
+import io.yak.ops.spi.datasource.DataSourceConnection;
+import io.yak.ops.spi.datasource.DataSourcePlugin;
+import io.yak.ops.spi.datasource.execution.DataSourceExecutionProvider;
+import io.yak.ops.spi.datasource.execution.DataSourceSqlExecutor;
+import org.springframework.stereotype.Component;
+
+/** Resolves platform datasource IDs without exposing connection credentials to Task Plugins. */
+@Component
+@ConditionalOnDataSourceEnabled
+public class BusinessDataSourceExecutionProvider implements DataSourceExecutionProvider {
+
+  private final DataSourceRepository repository;
+  private final DataSourcePluginRegistry pluginRegistry;
+  private final DataSourceProperties properties;
+
+  public BusinessDataSourceExecutionProvider(
+      DataSourceRepository repository,
+      DataSourcePluginRegistry pluginRegistry,
+      DataSourceProperties properties) {
+    this.repository = repository;
+    this.pluginRegistry = pluginRegistry;
+    this.properties = properties;
+  }
+
+  @Override
+  public DataSourceSqlExecutor open(String dataSourceReference) {
+    long dataSourceId = parseDataSourceId(dataSourceReference);
+    DataSourceDefinition definition =
+        repository
+            .findById(dataSourceId)
+            .orElseThrow(() -> new IllegalArgumentException("数据源不存在：" + dataSourceReference));
+    DataSourcePlugin plugin = pluginRegistry.get(definition.getDbType());
+    DataSourceConnection connection = plugin.parseConnection(definition.getConnectionParams());
+    return plugin.createSqlExecutor(
+        connection,
+        Math.max(1, properties.getConnectionTest().getTimeoutSeconds()));
+  }
+
+  private long parseDataSourceId(String reference) {
+    if (reference == null || reference.isBlank()) {
+      throw new IllegalArgumentException("数据源 ID 不能为空");
+    }
+    try {
+      long value = Long.parseLong(reference.trim());
+      if (value <= 0L) throw new NumberFormatException("non-positive");
+      return value;
+    } catch (NumberFormatException exception) {
+      throw new IllegalArgumentException("数据源 ID 非法：" + reference, exception);
+    }
+  }
+}

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-api/src/main/java/io/yak/ops/spi/datasource/DataSourcePlugin.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-api/src/main/java/io/yak/ops/spi/datasource/DataSourcePlugin.java
@@ -2,6 +2,7 @@ package io.yak.ops.spi.datasource;
 
 import io.yak.ops.common.bean.vo.datasource.DataSourcePluginConfigVO;
 import io.yak.ops.common.enums.datasource.DataSourceDbType;
+import io.yak.ops.spi.datasource.execution.DataSourceSqlExecutor;
 
 /** 数据源插件稳定扩展契约。 */
 public interface DataSourcePlugin {
@@ -20,6 +21,20 @@ public interface DataSourcePlugin {
 
   /** 创建由插件实现的 Catalog 元数据访问器。 */
   DataSourceCatalog createCatalog(DataSourceConnection connection, int timeoutSeconds);
+
+  /**
+   * 创建一次 SQL 物理执行器。
+   *
+   * <p>默认不支持，JDBC 等具备 SQL 执行能力的插件显式覆盖。Task Plugin 不直接接触 JDBC
+   * Connection 或凭据，只通过这个稳定契约获得执行能力。
+   */
+  default DataSourceSqlExecutor createSqlExecutor(
+      DataSourceConnection connection,
+      int connectionTimeoutSeconds) {
+    throw new DataSourcePluginException(
+        DataSourcePluginException.Operation.EXECUTION,
+        "当前数据源插件不支持 SQL 执行：" + dbType());
+  }
 
   /** 插件是否理解指定连接地址。 */
   default boolean acceptsUrl(String jdbcUrl) {

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-api/src/main/java/io/yak/ops/spi/datasource/DataSourcePluginException.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-api/src/main/java/io/yak/ops/spi/datasource/DataSourcePluginException.java
@@ -1,6 +1,6 @@
 package io.yak.ops.spi.datasource;
 
-/** 数据源插件参数、连接或元数据访问异常。 */
+/** 数据源插件参数、连接、元数据访问或 SQL 执行异常。 */
 public class DataSourcePluginException extends RuntimeException {
 
   private static final long serialVersionUID = 1L;
@@ -25,6 +25,7 @@ public class DataSourcePluginException extends RuntimeException {
   public enum Operation {
     PARAMETER,
     CONNECTIVITY,
-    CATALOG
+    CATALOG,
+    EXECUTION
   }
 }

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-api/src/main/java/io/yak/ops/spi/datasource/execution/DataSourceExecutionProvider.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-api/src/main/java/io/yak/ops/spi/datasource/execution/DataSourceExecutionProvider.java
@@ -1,0 +1,12 @@
+package io.yak.ops.spi.datasource.execution;
+
+/**
+ * Runtime bridge that resolves a durable datasource reference into a fresh physical SQL executor.
+ *
+ * <p>The provider owns datasource lookup and credential resolution. Callers only persist/reference
+ * datasource IDs and never receive connection secrets.
+ */
+public interface DataSourceExecutionProvider {
+
+  DataSourceSqlExecutor open(String dataSourceReference);
+}

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-api/src/main/java/io/yak/ops/spi/datasource/execution/DataSourceSqlColumn.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-api/src/main/java/io/yak/ops/spi/datasource/execution/DataSourceSqlColumn.java
@@ -1,0 +1,10 @@
+package io.yak.ops.spi.datasource.execution;
+
+/** JDBC-neutral column metadata returned by a SQL execution. */
+public record DataSourceSqlColumn(
+    String name,
+    String label,
+    String typeName,
+    int jdbcType,
+    boolean nullable) {
+}

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-api/src/main/java/io/yak/ops/spi/datasource/execution/DataSourceSqlExecutor.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-api/src/main/java/io/yak/ops/spi/datasource/execution/DataSourceSqlExecutor.java
@@ -1,0 +1,17 @@
+package io.yak.ops.spi.datasource.execution;
+
+/** Fresh datasource SQL executor used by one task execution attempt. */
+public interface DataSourceSqlExecutor extends AutoCloseable {
+
+  DataSourceSqlResult execute(DataSourceSqlRequest request);
+
+  /** Best-effort cancellation for a currently running statement. */
+  default void cancel() {
+    // Optional capability.
+  }
+
+  @Override
+  default void close() {
+    // Optional cleanup capability.
+  }
+}

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-api/src/main/java/io/yak/ops/spi/datasource/execution/DataSourceSqlRequest.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-api/src/main/java/io/yak/ops/spi/datasource/execution/DataSourceSqlRequest.java
@@ -1,0 +1,21 @@
+package io.yak.ops.spi.datasource.execution;
+
+/** Immutable SQL execution request shared by task plugins and datasource plugins. */
+public record DataSourceSqlRequest(
+    String sql,
+    int maxRows,
+    int timeoutSeconds) {
+
+  public DataSourceSqlRequest {
+    if (sql == null || sql.isBlank()) {
+      throw new IllegalArgumentException("sql must not be blank");
+    }
+    sql = sql.trim();
+    if (maxRows < 1 || maxRows > 10_000) {
+      throw new IllegalArgumentException("maxRows must be between 1 and 10000");
+    }
+    if (timeoutSeconds < 1 || timeoutSeconds > 3_600) {
+      throw new IllegalArgumentException("timeoutSeconds must be between 1 and 3600");
+    }
+  }
+}

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-api/src/main/java/io/yak/ops/spi/datasource/execution/DataSourceSqlResult.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-api/src/main/java/io/yak/ops/spi/datasource/execution/DataSourceSqlResult.java
@@ -1,0 +1,44 @@
+package io.yak.ops.spi.datasource.execution;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/** Result of one SQL statement, supporting both result-set and update-count statements. */
+public record DataSourceSqlResult(
+    boolean resultSet,
+    List<DataSourceSqlColumn> columns,
+    List<List<Object>> rows,
+    long affectedRows,
+    boolean truncated) {
+
+  public DataSourceSqlResult {
+    columns = columns == null ? List.of() : List.copyOf(columns);
+    rows = immutableRows(rows);
+  }
+
+  public int returnedRows() {
+    return rows.size();
+  }
+
+  public static DataSourceSqlResult query(
+      List<DataSourceSqlColumn> columns,
+      List<List<Object>> rows,
+      boolean truncated) {
+    return new DataSourceSqlResult(true, columns, rows, -1L, truncated);
+  }
+
+  public static DataSourceSqlResult update(long affectedRows) {
+    return new DataSourceSqlResult(false, List.of(), List.of(), affectedRows, false);
+  }
+
+  private static List<List<Object>> immutableRows(List<List<Object>> rows) {
+    if (rows == null || rows.isEmpty()) return List.of();
+    List<List<Object>> copy = new ArrayList<>(rows.size());
+    for (List<Object> row : rows) {
+      List<Object> values = row == null ? new ArrayList<>() : new ArrayList<>(row);
+      copy.add(Collections.unmodifiableList(values));
+    }
+    return Collections.unmodifiableList(copy);
+  }
+}

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-api/src/main/java/io/yak/ops/spi/datasource/execution/package-info.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-api/src/main/java/io/yak/ops/spi/datasource/execution/package-info.java
@@ -1,0 +1,2 @@
+/** Runtime SQL execution contracts exposed by datasource plugins. */
+package io.yak.ops.spi.datasource.execution;

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/AbstractJdbcDataSourcePlugin.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/AbstractJdbcDataSourcePlugin.java
@@ -12,6 +12,7 @@ import io.yak.ops.spi.datasource.DataSourceConnection;
 import io.yak.ops.spi.datasource.DataSourcePlugin;
 import io.yak.ops.spi.datasource.DataSourcePluginException;
 import io.yak.ops.spi.datasource.DataSourcePluginException.Operation;
+import io.yak.ops.spi.datasource.execution.DataSourceSqlExecutor;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.util.ArrayList;
@@ -22,7 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
-/** JDBC 数据源插件基座，统一负责参数解析、表单配置和连接测试。 */
+/** JDBC 数据源插件基座，统一负责参数解析、表单配置、连接测试和 SQL 执行。 */
 public abstract class AbstractJdbcDataSourcePlugin implements DataSourcePlugin {
 
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
@@ -221,6 +222,15 @@ public abstract class AbstractJdbcDataSourcePlugin implements DataSourcePlugin {
   @Override
   public DataSourceCatalog createCatalog(DataSourceConnection connection, int timeoutSeconds) {
     return createJdbcCatalog(requireJdbcConnection(connection), Math.max(1, timeoutSeconds));
+  }
+
+  @Override
+  public DataSourceSqlExecutor createSqlExecutor(
+      DataSourceConnection connection,
+      int connectionTimeoutSeconds) {
+    return new JdbcDataSourceSqlExecutor(
+        requireJdbcConnection(connection),
+        Math.max(1, connectionTimeoutSeconds));
   }
 
   protected DataSourceCatalog createJdbcCatalog(

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/JdbcDataSourceSqlExecutor.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/JdbcDataSourceSqlExecutor.java
@@ -1,0 +1,228 @@
+package io.yak.ops.plugin.database.jdbc;
+
+import io.yak.ops.spi.datasource.DataSourcePluginException;
+import io.yak.ops.spi.datasource.DataSourcePluginException.Operation;
+import io.yak.ops.spi.datasource.execution.DataSourceSqlColumn;
+import io.yak.ops.spi.datasource.execution.DataSourceSqlExecutor;
+import io.yak.ops.spi.datasource.execution.DataSourceSqlRequest;
+import io.yak.ops.spi.datasource.execution.DataSourceSqlResult;
+import java.sql.Blob;
+import java.sql.Clob;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLFeatureNotSupportedException;
+import java.sql.SQLXML;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+/** JDBC implementation of one cancellable SQL execution attempt. */
+public final class JdbcDataSourceSqlExecutor implements DataSourceSqlExecutor {
+
+  private static final int MAX_TEXT_CHARS = 65_536;
+  private static final int MAX_INLINE_BINARY_BYTES = 4_096;
+
+  private final JdbcConnectionProperties connection;
+  private final int connectionTimeoutSeconds;
+  private final AtomicBoolean cancelled = new AtomicBoolean(false);
+  private final AtomicReference<Connection> activeConnection = new AtomicReference<>();
+  private final AtomicReference<Statement> activeStatement = new AtomicReference<>();
+
+  public JdbcDataSourceSqlExecutor(
+      JdbcConnectionProperties connection,
+      int connectionTimeoutSeconds) {
+    this.connection = connection;
+    this.connectionTimeoutSeconds = Math.max(1, connectionTimeoutSeconds);
+  }
+
+  @Override
+  public DataSourceSqlResult execute(DataSourceSqlRequest request) {
+    if (cancelled.get()) {
+      throw executionError("SQL 执行已取消", null);
+    }
+
+    try {
+      Class.forName(connection.driverClassName());
+      DriverManager.setLoginTimeout(connectionTimeoutSeconds);
+      try (Connection opened =
+          DriverManager.getConnection(connection.jdbcUrl(), connectionProperties())) {
+        activeConnection.set(opened);
+        if (cancelled.get()) {
+          throw executionError("SQL 执行已取消", null);
+        }
+
+        try (Statement statement = opened.createStatement()) {
+          activeStatement.set(statement);
+          try {
+            statement.setQueryTimeout(request.timeoutSeconds());
+          } catch (SQLFeatureNotSupportedException ignored) {
+            // Some JDBC drivers do not implement query timeout. Cancellation still remains available.
+          }
+          statement.setMaxRows(Math.min(Integer.MAX_VALUE - 1, request.maxRows() + 1));
+
+          boolean hasResultSet = statement.execute(request.sql());
+          if (!hasResultSet) {
+            return DataSourceSqlResult.update(statement.getUpdateCount());
+          }
+
+          try (ResultSet resultSet = statement.getResultSet()) {
+            return readResultSet(resultSet, request.maxRows());
+          }
+        } finally {
+          activeStatement.set(null);
+        }
+      } finally {
+        activeConnection.set(null);
+      }
+    } catch (DataSourcePluginException exception) {
+      throw exception;
+    } catch (ClassNotFoundException exception) {
+      throw executionError("数据库驱动未安装：" + connection.driverClassName(), exception);
+    } catch (Exception exception) {
+      throw executionError(safeMessage(exception), exception);
+    }
+  }
+
+  @Override
+  public void cancel() {
+    cancelled.set(true);
+    Statement statement = activeStatement.get();
+    if (statement != null) {
+      try {
+        statement.cancel();
+      } catch (Exception ignored) {
+        // Best effort; closing the connection below is the fallback.
+      }
+    }
+    Connection opened = activeConnection.get();
+    if (opened != null) {
+      try {
+        opened.close();
+      } catch (Exception ignored) {
+        // Best effort cancellation.
+      }
+    }
+  }
+
+  @Override
+  public void close() {
+    Statement statement = activeStatement.get();
+    Connection opened = activeConnection.get();
+    if (statement == null && opened == null) return;
+    cancel();
+  }
+
+  private DataSourceSqlResult readResultSet(ResultSet resultSet, int maxRows) throws Exception {
+    ResultSetMetaData metadata = resultSet.getMetaData();
+    List<DataSourceSqlColumn> columns = columns(metadata);
+    List<List<Object>> rows = new ArrayList<>();
+    boolean truncated = false;
+
+    while (resultSet.next()) {
+      if (rows.size() >= maxRows) {
+        truncated = true;
+        break;
+      }
+      List<Object> row = new ArrayList<>(metadata.getColumnCount());
+      for (int index = 1; index <= metadata.getColumnCount(); index++) {
+        row.add(normalizeValue(resultSet.getObject(index)));
+      }
+      rows.add(row);
+    }
+    return DataSourceSqlResult.query(columns, rows, truncated);
+  }
+
+  private List<DataSourceSqlColumn> columns(ResultSetMetaData metadata) throws Exception {
+    List<DataSourceSqlColumn> columns = new ArrayList<>(metadata.getColumnCount());
+    for (int index = 1; index <= metadata.getColumnCount(); index++) {
+      String name = metadata.getColumnName(index);
+      String label = metadata.getColumnLabel(index);
+      columns.add(
+          new DataSourceSqlColumn(
+              name,
+              label == null || label.isBlank() ? name : label,
+              metadata.getColumnTypeName(index),
+              metadata.getColumnType(index),
+              metadata.isNullable(index) != ResultSetMetaData.columnNoNulls));
+    }
+    return columns;
+  }
+
+  private Object normalizeValue(Object value) throws Exception {
+    if (value == null
+        || value instanceof Number
+        || value instanceof Boolean
+        || value instanceof Character) {
+      return value;
+    }
+    if (value instanceof String text) {
+      return limitText(text);
+    }
+    if (value instanceof byte[] bytes) {
+      if (bytes.length > MAX_INLINE_BINARY_BYTES) {
+        return "<BINARY " + bytes.length + " bytes>";
+      }
+      return Base64.getEncoder().encodeToString(bytes);
+    }
+    if (value instanceof Blob blob) {
+      return "<BLOB " + blob.length() + " bytes>";
+    }
+    if (value instanceof Clob clob) {
+      long length = clob.length();
+      int readLength = (int) Math.min(length, MAX_TEXT_CHARS);
+      String text = clob.getSubString(1L, readLength);
+      return length > MAX_TEXT_CHARS ? text + "…" : text;
+    }
+    if (value instanceof SQLXML xml) {
+      return limitText(xml.getString());
+    }
+    if (value instanceof java.sql.Date
+        || value instanceof java.sql.Time
+        || value instanceof java.sql.Timestamp
+        || value instanceof java.time.temporal.TemporalAccessor
+        || value instanceof java.util.UUID) {
+      return value.toString();
+    }
+    return limitText(String.valueOf(value));
+  }
+
+  private String limitText(String value) {
+    if (value == null || value.length() <= MAX_TEXT_CHARS) return value;
+    return value.substring(0, MAX_TEXT_CHARS) + "…";
+  }
+
+  private Properties connectionProperties() {
+    Properties properties = new Properties();
+    properties.putAll(connection.properties());
+    if (connection.username() != null && !connection.username().isBlank()) {
+      properties.setProperty("user", connection.username());
+    }
+    if (connection.password() != null) {
+      properties.setProperty("password", connection.password());
+    }
+    return properties;
+  }
+
+  private DataSourcePluginException executionError(String message, Throwable cause) {
+    String safe = message == null || message.isBlank() ? "SQL 执行失败" : message;
+    return cause == null
+        ? new DataSourcePluginException(Operation.EXECUTION, safe)
+        : new DataSourcePluginException(Operation.EXECUTION, safe, cause);
+  }
+
+  private String safeMessage(Throwable throwable) {
+    String message = throwable == null ? null : throwable.getMessage();
+    if (message == null || message.isBlank()) {
+      return throwable == null ? "SQL 执行失败" : throwable.getClass().getSimpleName();
+    }
+    String sanitized =
+        message.replaceAll("(?i)(password|pwd)=([^;&\\s]+)", "$1=******");
+    return sanitized.length() > 500 ? sanitized.substring(0, 500) : sanitized;
+  }
+}

--- a/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-all/src/test/java/io/yak/ops/plugin/task/all/TaskPluginAssemblyTest.java
+++ b/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-all/src/test/java/io/yak/ops/plugin/task/all/TaskPluginAssemblyTest.java
@@ -1,7 +1,6 @@
 package io.yak.ops.plugin.task.all;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.yak.ops.core.plugin.task.TaskPluginRegistry;
@@ -19,7 +18,15 @@ class TaskPluginAssemblyTest {
     TaskPlugin sql = registry.require("SQL");
 
     assertEquals("SQL", sql.descriptor().type());
-    assertFalse(sql.descriptor().executable());
-    assertTrue(sql.validate(new TaskDefinition("SQL", 1, "select 1", "{}")).valid());
+    assertTrue(sql.descriptor().executable());
+    assertTrue(sql.descriptor().cancellable());
+    assertTrue(
+        sql.validate(
+                new TaskDefinition(
+                    "SQL",
+                    1,
+                    "select 1",
+                    "{\"dataSourceId\":\"1\"}"))
+            .valid());
   }
 }

--- a/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-api/src/main/java/io/yak/ops/plugin/task/api/TaskExecutionContext.java
+++ b/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-api/src/main/java/io/yak/ops/plugin/task/api/TaskExecutionContext.java
@@ -2,16 +2,35 @@ package io.yak.ops.plugin.task.api;
 
 import io.yak.ops.spi.task.model.TaskExecutionTrigger;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 
 /**
- * Minimal runtime context visible to task plugins.
+ * Runtime context visible to task plugins.
  *
- * <p>The contract intentionally stays small in stage 2. Task Runtime may add backward-compatible
- * default capabilities later without leaking Workflow-specific state into plugins.
+ * <p>Parameters carry serializable runtime values, while capabilities expose typed in-process
+ * services such as datasource execution. This keeps task plugins independent from Spring and from
+ * concrete business modules.
  */
 public interface TaskExecutionContext {
 
   TaskExecutionTrigger trigger();
 
   Map<String, Object> parameters();
+
+  /** Resolve one optional runtime capability by its stable interface type. */
+  default <T> Optional<T> capability(Class<T> capabilityType) {
+    Objects.requireNonNull(capabilityType, "capabilityType");
+    return Optional.empty();
+  }
+
+  /** Resolve one required runtime capability or fail with a clear runtime error. */
+  default <T> T requireCapability(Class<T> capabilityType) {
+    Objects.requireNonNull(capabilityType, "capabilityType");
+    return capability(capabilityType)
+        .orElseThrow(
+            () ->
+                new IllegalStateException(
+                    "Task runtime capability is not available: " + capabilityType.getName()));
+  }
 }

--- a/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-sql/pom.xml
+++ b/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-sql/pom.xml
@@ -14,12 +14,25 @@
     <artifactId>yak-ops-plugin-task-sql</artifactId>
 
     <name>Yak Ops SQL Task Plugin</name>
-    <description>SQL task plugin skeleton; real datasource-backed execution is introduced in a later stage</description>
+    <description>Datasource-backed SQL task validation and execution plugin</description>
 
     <dependencies>
         <dependency>
             <groupId>io.yak.ops</groupId>
             <artifactId>yak-ops-plugin-task-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.yak.ops</groupId>
+            <artifactId>yak-ops-plugin-datasource-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-sql/src/main/java/io/yak/ops/plugin/task/sql/SqlTaskConfig.java
+++ b/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-sql/src/main/java/io/yak/ops/plugin/task/sql/SqlTaskConfig.java
@@ -1,0 +1,69 @@
+package io.yak.ops.plugin.task.sql;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/** SQL task plugin-owned schemaVersion=1 configuration. */
+record SqlTaskConfig(
+    String dataSourceId,
+    int maxRows,
+    int timeoutSeconds) {
+
+  static final int DEFAULT_MAX_ROWS = 200;
+  static final int MAX_ROWS = 500;
+  static final int DEFAULT_TIMEOUT_SECONDS = 30;
+  static final int MAX_TIMEOUT_SECONDS = 300;
+
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  static SqlTaskConfig parse(String configJson) {
+    String raw = configJson == null || configJson.isBlank() ? "{}" : configJson.trim();
+    try {
+      JsonNode root = OBJECT_MAPPER.readTree(raw);
+      if (root == null || !root.isObject()) {
+        throw new IllegalArgumentException("SQL configJson must be a JSON object");
+      }
+      String dataSourceId = text(root, "dataSourceId");
+      int maxRows = integer(root, "maxRows", DEFAULT_MAX_ROWS, 1, MAX_ROWS);
+      int timeoutSeconds =
+          integer(
+              root,
+              "timeoutSeconds",
+              DEFAULT_TIMEOUT_SECONDS,
+              1,
+              MAX_TIMEOUT_SECONDS);
+      return new SqlTaskConfig(dataSourceId, maxRows, timeoutSeconds);
+    } catch (IllegalArgumentException exception) {
+      throw exception;
+    } catch (Exception exception) {
+      throw new IllegalArgumentException("SQL configJson is not valid JSON", exception);
+    }
+  }
+
+  private static String text(JsonNode root, String key) {
+    JsonNode value = root.get(key);
+    if (value == null || value.isNull()) return null;
+    String text = value.asText();
+    return text == null || text.isBlank() ? null : text.trim();
+  }
+
+  private static int integer(
+      JsonNode root,
+      String key,
+      int defaultValue,
+      int min,
+      int max) {
+    JsonNode value = root.get(key);
+    if (value == null || value.isNull() || value.asText().isBlank()) return defaultValue;
+    int parsed;
+    try {
+      parsed = value.isNumber() ? value.intValue() : Integer.parseInt(value.asText().trim());
+    } catch (Exception exception) {
+      throw new IllegalArgumentException(key + " must be an integer", exception);
+    }
+    if (parsed < min || parsed > max) {
+      throw new IllegalArgumentException(key + " must be between " + min + " and " + max);
+    }
+    return parsed;
+  }
+}

--- a/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-sql/src/main/java/io/yak/ops/plugin/task/sql/SqlTaskExecutor.java
+++ b/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-sql/src/main/java/io/yak/ops/plugin/task/sql/SqlTaskExecutor.java
@@ -1,0 +1,110 @@
+package io.yak.ops.plugin.task.sql;
+
+import io.yak.ops.plugin.task.api.TaskExecutionResult;
+import io.yak.ops.plugin.task.api.TaskExecutor;
+import io.yak.ops.spi.datasource.execution.DataSourceExecutionProvider;
+import io.yak.ops.spi.datasource.execution.DataSourceSqlExecutor;
+import io.yak.ops.spi.datasource.execution.DataSourceSqlRequest;
+import io.yak.ops.spi.datasource.execution.DataSourceSqlResult;
+import io.yak.ops.spi.task.model.TaskDefinition;
+import io.yak.ops.spi.task.model.TaskExecutionStatus;
+import java.sql.SQLTimeoutException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+/** One physical SQL task execution attempt. */
+final class SqlTaskExecutor implements TaskExecutor {
+
+  private final TaskDefinition definition;
+  private final SqlTaskConfig config;
+  private final DataSourceExecutionProvider dataSourceProvider;
+  private final AtomicBoolean cancelled = new AtomicBoolean(false);
+  private final AtomicReference<DataSourceSqlExecutor> activeExecutor = new AtomicReference<>();
+
+  SqlTaskExecutor(
+      TaskDefinition definition,
+      SqlTaskConfig config,
+      DataSourceExecutionProvider dataSourceProvider) {
+    this.definition = definition;
+    this.config = config;
+    this.dataSourceProvider = dataSourceProvider;
+  }
+
+  @Override
+  public TaskExecutionResult execute() {
+    if (cancelled.get()) {
+      return cancelledResult("SQL execution was cancelled before start");
+    }
+
+    try (DataSourceSqlExecutor executor = dataSourceProvider.open(config.dataSourceId())) {
+      activeExecutor.set(executor);
+      if (cancelled.get()) {
+        executor.cancel();
+        return cancelledResult("SQL execution was cancelled before statement execution");
+      }
+
+      DataSourceSqlResult result =
+          executor.execute(
+              new DataSourceSqlRequest(
+                  definition.content(),
+                  config.maxRows(),
+                  config.timeoutSeconds()));
+      Map<String, Object> output = new LinkedHashMap<>();
+      output.put("kind", result.resultSet() ? "RESULT_SET" : "UPDATE_COUNT");
+      output.put("columns", result.columns());
+      output.put("rows", result.rows());
+      output.put("returnedRows", result.returnedRows());
+      output.put("affectedRows", result.affectedRows());
+      output.put("truncated", result.truncated());
+      output.put("dataSourceId", config.dataSourceId());
+      return TaskExecutionResult.success(output);
+    } catch (Exception exception) {
+      if (cancelled.get()) {
+        return cancelledResult(safeMessage(exception));
+      }
+      TaskExecutionStatus status =
+          causedBy(exception, SQLTimeoutException.class)
+              ? TaskExecutionStatus.TIMEOUT
+              : TaskExecutionStatus.FAILED;
+      return new TaskExecutionResult(
+          status,
+          safeMessage(exception),
+          Map.of("dataSourceId", config.dataSourceId()));
+    } finally {
+      activeExecutor.set(null);
+    }
+  }
+
+  @Override
+  public void cancel() {
+    cancelled.set(true);
+    DataSourceSqlExecutor executor = activeExecutor.get();
+    if (executor != null) executor.cancel();
+  }
+
+  private TaskExecutionResult cancelledResult(String message) {
+    return new TaskExecutionResult(
+        TaskExecutionStatus.CANCELLED,
+        message == null ? "SQL execution cancelled" : message,
+        Map.of("dataSourceId", config.dataSourceId()));
+  }
+
+  private boolean causedBy(Throwable throwable, Class<? extends Throwable> expected) {
+    Throwable current = throwable;
+    while (current != null) {
+      if (expected.isInstance(current)) return true;
+      current = current.getCause();
+    }
+    return false;
+  }
+
+  private String safeMessage(Throwable throwable) {
+    String message = throwable == null ? null : throwable.getMessage();
+    if (message == null || message.isBlank()) {
+      return throwable == null ? "SQL execution failed" : throwable.getClass().getSimpleName();
+    }
+    return message.length() > 500 ? message.substring(0, 500) : message;
+  }
+}

--- a/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-sql/src/main/java/io/yak/ops/plugin/task/sql/SqlTaskPlugin.java
+++ b/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-sql/src/main/java/io/yak/ops/plugin/task/sql/SqlTaskPlugin.java
@@ -1,19 +1,17 @@
 package io.yak.ops.plugin.task.sql;
 
+import io.yak.ops.plugin.task.api.TaskExecutionContext;
+import io.yak.ops.plugin.task.api.TaskExecutor;
 import io.yak.ops.plugin.task.api.TaskPlugin;
 import io.yak.ops.plugin.task.api.TaskPluginDescriptor;
 import io.yak.ops.plugin.task.api.TaskValidationIssue;
 import io.yak.ops.plugin.task.api.TaskValidationResult;
+import io.yak.ops.spi.datasource.execution.DataSourceExecutionProvider;
 import io.yak.ops.spi.task.model.TaskDefinition;
 import java.util.ArrayList;
 import java.util.List;
 
-/**
- * Stage-2 SQL task plugin skeleton.
- *
- * <p>This plugin proves SPI discovery and definition validation only. Datasource-backed SQL
- * execution is deliberately deferred to the SQL execution stage.
- */
+/** Datasource-backed SQL Task Plugin. */
 public final class SqlTaskPlugin implements TaskPlugin {
 
   public static final String TYPE = "SQL";
@@ -23,11 +21,11 @@ public final class SqlTaskPlugin implements TaskPlugin {
       new TaskPluginDescriptor(
           TYPE,
           "SQL",
-          "SQL task definition",
-          "1.0.0",
+          "Execute SQL against a Yak Ops datasource reference",
+          "1.1.0",
           SCHEMA_VERSION,
-          false,
-          false);
+          true,
+          true);
 
   @Override
   public TaskPluginDescriptor descriptor() {
@@ -67,6 +65,43 @@ public final class SqlTaskPlugin implements TaskPlugin {
               "SQL content must not be blank"));
     }
 
+    try {
+      SqlTaskConfig config = SqlTaskConfig.parse(definition.configJson());
+      if (config.dataSourceId() == null || config.dataSourceId().isBlank()) {
+        issues.add(
+            new TaskValidationIssue(
+                "SQL_DATASOURCE_REQUIRED",
+                "config.dataSourceId",
+                "SQL task requires a datasource"));
+      }
+    } catch (IllegalArgumentException exception) {
+      issues.add(
+          new TaskValidationIssue(
+              "SQL_CONFIG_INVALID",
+              "configJson",
+              exception.getMessage() == null ? "SQL config is invalid" : exception.getMessage()));
+    }
+
     return issues.isEmpty() ? TaskValidationResult.ok() : TaskValidationResult.of(issues);
+  }
+
+  @Override
+  public TaskExecutor createExecutor(
+      TaskDefinition definition,
+      TaskExecutionContext context) {
+    TaskValidationResult validation = validate(definition);
+    if (!validation.valid()) {
+      String summary =
+          validation.issues().stream()
+              .map(TaskValidationIssue::message)
+              .limit(3)
+              .reduce((left, right) -> left + "; " + right)
+              .orElse("SQL task validation failed");
+      throw new IllegalArgumentException(summary);
+    }
+    SqlTaskConfig config = SqlTaskConfig.parse(definition.configJson());
+    DataSourceExecutionProvider provider =
+        context.requireCapability(DataSourceExecutionProvider.class);
+    return new SqlTaskExecutor(definition, config, provider);
   }
 }

--- a/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-sql/src/test/java/io/yak/ops/plugin/task/sql/SqlTaskPluginTest.java
+++ b/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-sql/src/test/java/io/yak/ops/plugin/task/sql/SqlTaskPluginTest.java
@@ -1,0 +1,93 @@
+package io.yak.ops.plugin.task.sql;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.yak.ops.plugin.task.api.TaskExecutionContext;
+import io.yak.ops.plugin.task.api.TaskExecutionResult;
+import io.yak.ops.plugin.task.api.TaskExecutor;
+import io.yak.ops.spi.datasource.execution.DataSourceExecutionProvider;
+import io.yak.ops.spi.datasource.execution.DataSourceSqlColumn;
+import io.yak.ops.spi.datasource.execution.DataSourceSqlExecutor;
+import io.yak.ops.spi.datasource.execution.DataSourceSqlRequest;
+import io.yak.ops.spi.datasource.execution.DataSourceSqlResult;
+import io.yak.ops.spi.task.model.TaskDefinition;
+import io.yak.ops.spi.task.model.TaskExecutionStatus;
+import io.yak.ops.spi.task.model.TaskExecutionTrigger;
+import java.sql.Types;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+
+class SqlTaskPluginTest {
+
+  @Test
+  void validatesDatasourceAndExecutesThroughRuntimeCapability() throws Exception {
+    SqlTaskPlugin plugin = new SqlTaskPlugin();
+    TaskDefinition definition =
+        new TaskDefinition(
+            "SQL",
+            1,
+            "select 1 as value",
+            "{\"dataSourceId\":\"42\",\"maxRows\":10,\"timeoutSeconds\":5}");
+    AtomicReference<DataSourceSqlRequest> captured = new AtomicReference<>();
+    DataSourceExecutionProvider provider =
+        reference ->
+            new DataSourceSqlExecutor() {
+              @Override
+              public DataSourceSqlResult execute(DataSourceSqlRequest request) {
+                captured.set(request);
+                return DataSourceSqlResult.query(
+                    List.of(new DataSourceSqlColumn("VALUE", "value", "INTEGER", Types.INTEGER, true)),
+                    List.of(List.of(1)),
+                    false);
+              }
+            };
+
+    TaskExecutionContext context =
+        new TaskExecutionContext() {
+          @Override
+          public TaskExecutionTrigger trigger() {
+            return TaskExecutionTrigger.MANUAL;
+          }
+
+          @Override
+          public Map<String, Object> parameters() {
+            return Map.of();
+          }
+
+          @Override
+          public <T> Optional<T> capability(Class<T> capabilityType) {
+            return capabilityType.isInstance(provider)
+                ? Optional.of(capabilityType.cast(provider))
+                : Optional.empty();
+          }
+        };
+
+    assertTrue(plugin.descriptor().executable());
+    assertTrue(plugin.descriptor().cancellable());
+    assertTrue(plugin.validate(definition).valid());
+
+    TaskExecutor executor = plugin.createExecutor(definition, context);
+    TaskExecutionResult result = executor.execute();
+
+    assertEquals(TaskExecutionStatus.SUCCESS, result.status());
+    assertEquals("RESULT_SET", result.output().get("kind"));
+    assertEquals(10, captured.get().maxRows());
+    assertEquals(5, captured.get().timeoutSeconds());
+  }
+
+  @Test
+  void rejectsMissingDatasourceReference() {
+    SqlTaskPlugin plugin = new SqlTaskPlugin();
+    TaskDefinition definition = new TaskDefinition("SQL", 1, "select 1", "{}");
+
+    assertFalse(plugin.validate(definition).valid());
+    assertTrue(
+        plugin.validate(definition).issues().stream()
+            .anyMatch(issue -> "SQL_DATASOURCE_REQUIRED".equals(issue.code())));
+  }
+}

--- a/yak-ops-ui/src/pages/data-development/components/workbench/DevelopmentWorkbench.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/workbench/DevelopmentWorkbench.tsx
@@ -16,6 +16,7 @@ import {
 import {
   getDevelopmentTaskDraft,
   publishDevelopmentTask,
+  runDevelopmentTask,
   saveDevelopmentTaskDraft,
 } from '../../service';
 import type {
@@ -23,6 +24,7 @@ import type {
   DevelopmentId,
   DevelopmentNode,
   DevelopmentTaskDraft,
+  DevelopmentTaskRunResult,
 } from '../../types';
 import EditorHost from './EditorHost';
 import EditorTabs, { type EditorTabAction } from './EditorTabs';
@@ -63,6 +65,10 @@ const DevelopmentWorkbench = ({
   const [openNodeIds, setOpenNodeIds] = useState<DevelopmentId[]>([]);
   const [activeNodeId, setActiveNodeId] = useState<DevelopmentId>();
   const [runPanelOpen, setRunPanelOpen] = useState(false);
+  const [runResults, setRunResults] = useState<
+    Partial<Record<DevelopmentId, DevelopmentTaskRunResult>>
+  >({});
+  const [runningNodeIds, setRunningNodeIds] = useState<DevelopmentId[]>([]);
   const [pendingClose, setPendingClose] = useState<PendingCloseRequest>();
   const [saving, setSaving] = useState(false);
   const [publishing, setPublishing] = useState(false);
@@ -119,6 +125,9 @@ const DevelopmentWorkbench = ({
   const activeDirectory = activeNode?.directoryId
     ? directoryMap.get(activeNode.directoryId)
     : undefined;
+  const activeRunning = activeNode
+    ? runningNodeIds.includes(activeNode.id)
+    : false;
 
   const focusNode = (nodeId: DevelopmentId) => {
     setActiveNodeId(nodeId);
@@ -154,6 +163,49 @@ const DevelopmentWorkbench = ({
       message.error(error instanceof Error ? error.message : '保存草稿失败');
     } finally {
       setSaving(false);
+    }
+  };
+
+  const runActiveTask = async () => {
+    if (!activeNode || runningNodeIds.includes(activeNode.id)) return;
+    const node = activeNode;
+    const startedAt = Date.now();
+    setRunPanelOpen(true);
+    setRunningNodeIds((current) => [...current, node.id]);
+    setRunResults((current) => ({
+      ...current,
+      [node.id]: {
+        status: 'RUNNING',
+        message: '',
+        durationMs: 0,
+        output: {},
+      },
+    }));
+
+    try {
+      const definition = prepareDevelopmentTaskDefinition(node);
+      const result = responseData(
+        await runDevelopmentTask(node.id, definition),
+        '运行任务失败',
+      );
+      setRunResults((current) => ({ ...current, [node.id]: result }));
+      if (result.status === 'FAILED' || result.status === 'TIMEOUT') {
+        message.error(result.message || 'SQL 执行失败');
+      }
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : '运行任务失败';
+      setRunResults((current) => ({
+        ...current,
+        [node.id]: {
+          status: 'FAILED',
+          message: errorMessage,
+          durationMs: Math.max(0, Date.now() - startedAt),
+          output: {},
+        },
+      }));
+      message.error(errorMessage);
+    } finally {
+      setRunningNodeIds((current) => current.filter((nodeId) => nodeId !== node.id));
     }
   };
 
@@ -314,9 +366,10 @@ const DevelopmentWorkbench = ({
         node={activeNode}
         directory={activeDirectory}
         definition={definition}
-        onRun={() => setRunPanelOpen(true)}
+        onRun={() => void runActiveTask()}
         onSave={() => void saveActiveDraft()}
         onPublish={() => void publishActiveTask()}
+        running={activeRunning}
         saving={saving}
         publishing={publishing}
       />
@@ -341,6 +394,7 @@ const DevelopmentWorkbench = ({
           node={activeNode}
           directory={activeDirectory}
           definition={definition}
+          result={runResults[activeNode.id]}
           onClose={() => setRunPanelOpen(false)}
         />
       </div>

--- a/yak-ops-ui/src/pages/data-development/components/workbench/EditorToolbar.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/workbench/EditorToolbar.tsx
@@ -11,6 +11,7 @@ interface EditorToolbarProps {
   onRun: () => void;
   onSave: () => void;
   onPublish: () => void;
+  running: boolean;
   saving: boolean;
   publishing: boolean;
 }
@@ -25,6 +26,7 @@ const EditorToolbar = ({
   onRun,
   onSave,
   onPublish,
+  running,
   saving,
   publishing,
 }: EditorToolbarProps) => {
@@ -41,6 +43,7 @@ const EditorToolbar = ({
             onRun={onRun}
             onSave={onSave}
             onPublish={onPublish}
+            running={running}
             saving={saving}
             publishing={publishing}
           />
@@ -50,14 +53,19 @@ const EditorToolbar = ({
           <div className="flex h-full min-w-0 items-center">
             <div className="flex h-full items-center gap-0.5">
               {capabilities.run ? (
-                <Tooltip title="运行" mouseEnterDelay={0.35}>
+                <Tooltip title={running ? '运行中' : '运行'} mouseEnterDelay={0.35}>
                   <button
                     type="button"
                     aria-label="运行"
+                    disabled={running}
                     onClick={onRun}
                     className={iconButtonClassName}
                   >
-                    <Play size={15} strokeWidth={1.8} />
+                    {running ? (
+                      <LoaderCircle size={15} className="animate-spin" />
+                    ) : (
+                      <Play size={15} strokeWidth={1.8} />
+                    )}
                   </button>
                 </Tooltip>
               ) : null}
@@ -66,7 +74,7 @@ const EditorToolbar = ({
                   <button
                     type="button"
                     aria-label="保存草稿"
-                    disabled={saving || publishing}
+                    disabled={saving || publishing || running}
                     onClick={onSave}
                     className={iconButtonClassName}
                   >
@@ -83,7 +91,7 @@ const EditorToolbar = ({
                   <button
                     type="button"
                     aria-label="发布版本"
-                    disabled={saving || publishing}
+                    disabled={saving || publishing || running}
                     onClick={onPublish}
                     className={iconButtonClassName}
                   >

--- a/yak-ops-ui/src/pages/data-development/components/workbench/RunResultPanel.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/workbench/RunResultPanel.tsx
@@ -1,15 +1,20 @@
-import { X } from 'lucide-react';
+import { LoaderCircle, X } from 'lucide-react';
 import type { PointerEvent as ReactPointerEvent } from 'react';
 import { useState } from 'react';
 
 import type { DevelopmentEditorDefinition } from '../../editors/types';
-import type { DevelopmentDirectory, DevelopmentNode } from '../../types';
+import type {
+  DevelopmentDirectory,
+  DevelopmentNode,
+  DevelopmentTaskRunResult,
+} from '../../types';
 
 interface RunResultPanelProps {
   open: boolean;
   node: DevelopmentNode;
   directory?: DevelopmentDirectory;
   definition: DevelopmentEditorDefinition;
+  result?: DevelopmentTaskRunResult;
   onClose: () => void;
 }
 
@@ -29,11 +34,22 @@ const initialHeight = () => {
     : DEFAULT_HEIGHT;
 };
 
+const statusText = (result?: DevelopmentTaskRunResult) => {
+  if (!result) return undefined;
+  if (result.status === 'RUNNING') return '运行中';
+  if (result.status === 'SUCCESS') return `完成 · ${result.durationMs} ms`;
+  if (result.status === 'CANCELLED') return '已取消';
+  if (result.status === 'TIMEOUT') return `超时 · ${result.durationMs} ms`;
+  if (result.status === 'FAILED') return `失败 · ${result.durationMs} ms`;
+  return result.status;
+};
+
 const RunResultPanel = ({
   open,
   node,
   directory,
   definition,
+  result,
   onClose,
 }: RunResultPanelProps) => {
   const [height, setHeight] = useState(initialHeight);
@@ -104,6 +120,16 @@ const RunResultPanel = ({
                 <span className="truncate text-[11px] text-[#98a2b3]">
                   当前节点：{node.name}
                 </span>
+                {result?.status === 'RUNNING' ? (
+                  <span className="inline-flex shrink-0 items-center gap-1 text-[11px] text-[#667085]">
+                    <LoaderCircle size={12} className="animate-spin" />
+                    运行中
+                  </span>
+                ) : statusText(result) ? (
+                  <span className="shrink-0 text-[11px] text-[#667085]">
+                    {statusText(result)}
+                  </span>
+                ) : null}
               </div>
               <button
                 type="button"
@@ -116,16 +142,18 @@ const RunResultPanel = ({
               </button>
             </div>
 
-            <div className="flex min-h-0 flex-1 items-center justify-center overflow-auto bg-white">
+            <div className="min-h-0 flex-1 overflow-hidden bg-white">
               {Result ? (
-                <Result node={node} directory={directory} />
+                <Result node={node} directory={directory} result={result} />
               ) : (
-                <div className="text-center">
-                  <div className="text-[13px] font-medium text-[#475467]">
-                    运行结果区域
-                  </div>
-                  <div className="mt-1 text-[11px] text-[#98a2b3]">
-                    执行日志和结果内容将在后续阶段接入
+                <div className="flex h-full items-center justify-center text-center">
+                  <div>
+                    <div className="text-[13px] font-medium text-[#475467]">
+                      运行结果区域
+                    </div>
+                    <div className="mt-1 text-[11px] text-[#98a2b3]">
+                      当前节点类型暂未接入执行结果渲染
+                    </div>
                   </div>
                 </div>
               )}

--- a/yak-ops-ui/src/pages/data-development/editors/registry.tsx
+++ b/yak-ops-ui/src/pages/data-development/editors/registry.tsx
@@ -10,8 +10,8 @@ import type {
 } from './types';
 
 const commonCapabilities = {
-  run: true,
-  stop: true,
+  run: false,
+  stop: false,
   save: true,
   refresh: true,
   publish: false,
@@ -49,7 +49,12 @@ const editorRegistry: Partial<
     label: 'SQL',
     icon: Code2,
     iconClassName: 'text-[#f79009]',
-    capabilities: { ...commonCapabilities, publish: true, format: true },
+    capabilities: {
+      ...commonCapabilities,
+      run: true,
+      publish: true,
+      format: true,
+    },
     Editor: SqlEditor,
     Toolbar: SqlToolbar,
     panels: {

--- a/yak-ops-ui/src/pages/data-development/editors/sql/SqlEditor.tsx
+++ b/yak-ops-ui/src/pages/data-development/editors/sql/SqlEditor.tsx
@@ -1,11 +1,19 @@
+import { LoaderCircle } from 'lucide-react';
 import { useMemo, useState } from 'react';
 
+import type {
+  DevelopmentSqlResultColumn,
+  DevelopmentSqlRunOutput,
+} from '../../types';
 import {
   updateEditorSessionContent,
   updateEditorSessionViewState,
   useEditorSession,
 } from '../session/editorSessionStore';
-import type { DevelopmentEditorContext } from '../types';
+import type {
+  DevelopmentEditorContext,
+  DevelopmentEditorRunResultContext,
+} from '../types';
 import SqlMonacoEditor, {
   type SqlEditorPosition,
 } from './components/SqlMonacoEditor';
@@ -98,19 +106,169 @@ export const SqlRunConfig = ({ node }: DevelopmentEditorContext) => (
   <div className="text-[12px] leading-6 text-[#667085]">
     <div className="font-medium text-[#344054]">SQL 运行配置</div>
     <div className="mt-2 text-[11px] leading-5 text-[#98a2b3]">
-      {node.name} 的数据源、Database、Schema 已迁移到编辑器工具栏右侧，可直接切换真实 Catalog 上下文。
+      {node.name} 的数据源、Database、Schema 由编辑器工具栏右侧选择，运行时通过数据源插件解析真实连接。
     </div>
     <div className="mt-3 border-t border-[#eef0f2] pt-3 text-[11px] leading-5 text-[#98a2b3]">
-      执行参数、资源配置等运行期设置将在后续阶段继续接入。
+      当前默认最多返回 200 行、执行超时 30 秒；Task Plugin 已预留 maxRows 和 timeoutSeconds 配置字段，后续可开放到运行配置面板。
     </div>
   </div>
 );
 
-export const SqlRunResult = ({ node }: DevelopmentEditorContext) => (
-  <div className="text-center">
-    <div className="text-[13px] font-medium text-[#475467]">SQL 运行结果区域</div>
-    <div className="mt-1 text-[11px] text-[#98a2b3]">
-      {node.name} 的结果集、执行日志将在后续阶段接入
+const asSqlOutput = (value: Record<string, unknown>): DevelopmentSqlRunOutput =>
+  value as DevelopmentSqlRunOutput;
+
+const formatCell = (value: unknown) => {
+  if (value === null) return 'NULL';
+  if (value === undefined) return '';
+  if (typeof value === 'object') {
+    try {
+      return JSON.stringify(value);
+    } catch {
+      return String(value);
+    }
+  }
+  return String(value);
+};
+
+const columnTitle = (column: DevelopmentSqlResultColumn, index: number) =>
+  column.label || column.name || `Column ${index + 1}`;
+
+export const SqlRunResult = ({ result }: DevelopmentEditorRunResultContext) => {
+  if (!result) {
+    return (
+      <div className="flex h-full items-center justify-center text-center">
+        <div>
+          <div className="text-[13px] font-medium text-[#475467]">SQL 运行结果</div>
+          <div className="mt-1 text-[11px] text-[#98a2b3]">
+            点击顶部运行按钮执行当前编辑器中的 SQL
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (result.status === 'RUNNING') {
+    return (
+      <div className="flex h-full items-center justify-center text-[12px] text-[#667085]">
+        <LoaderCircle size={16} className="mr-2 animate-spin" />
+        正在执行 SQL…
+      </div>
+    );
+  }
+
+  if (result.status !== 'SUCCESS') {
+    return (
+      <div className="flex h-full items-center justify-center px-6 text-center">
+        <div className="max-w-[680px]">
+          <div className="text-[13px] font-medium text-[#b42318]">
+            {result.status === 'CANCELLED'
+              ? 'SQL 已取消'
+              : result.status === 'TIMEOUT'
+                ? 'SQL 执行超时'
+                : 'SQL 执行失败'}
+          </div>
+          <div className="mt-2 break-words text-[11px] leading-5 text-[#667085]">
+            {result.message || '数据库未返回更多错误信息'}
+          </div>
+          <div className="mt-2 text-[10px] text-[#98a2b3]">
+            耗时 {result.durationMs} ms
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const output = asSqlOutput(result.output);
+  if (output.kind === 'UPDATE_COUNT') {
+    const affectedRows =
+      typeof output.affectedRows === 'number' && output.affectedRows >= 0
+        ? output.affectedRows
+        : '—';
+    return (
+      <div className="flex h-full items-center justify-center text-center">
+        <div>
+          <div className="text-[13px] font-medium text-[#344054]">SQL 执行完成</div>
+          <div className="mt-2 text-[12px] text-[#475467]">
+            影响行数：{affectedRows}
+          </div>
+          <div className="mt-1 text-[10px] text-[#98a2b3]">
+            耗时 {result.durationMs} ms
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const columns = Array.isArray(output.columns) ? output.columns : [];
+  const rows = Array.isArray(output.rows) ? output.rows : [];
+
+  return (
+    <div className="flex h-full min-h-0 flex-col overflow-hidden">
+      <div className="flex h-8 shrink-0 items-center gap-4 border-b border-[#eef0f2] px-3 text-[10px] text-[#667085]">
+        <span>{output.returnedRows ?? rows.length} 行</span>
+        <span>{columns.length} 列</span>
+        <span>{result.durationMs} ms</span>
+        {output.truncated ? (
+          <span className="text-[#b54708]">结果已达到返回上限</span>
+        ) : null}
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-auto">
+        {columns.length ? (
+          <table className="min-w-full border-separate border-spacing-0 whitespace-nowrap text-[11px]">
+            <thead className="sticky top-0 z-10 bg-[#fafafa] text-[#475467]">
+              <tr>
+                <th className="sticky left-0 z-20 w-12 border-b border-r border-[#e5e7eb] bg-[#fafafa] px-2 py-1.5 text-right font-medium text-[#98a2b3]">
+                  #
+                </th>
+                {columns.map((column, index) => (
+                  <th
+                    key={`${column.name || column.label || 'column'}-${index}`}
+                    title={column.typeName || undefined}
+                    className="min-w-[120px] border-b border-r border-[#e5e7eb] px-2.5 py-1.5 text-left font-medium"
+                  >
+                    <span>{columnTitle(column, index)}</span>
+                    {column.typeName ? (
+                      <span className="ml-2 font-normal text-[#a4a9b2]">
+                        {column.typeName}
+                      </span>
+                    ) : null}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody className="text-[#344054]">
+              {rows.map((row, rowIndex) => (
+                <tr key={rowIndex} className="hover:bg-[#fafafa]">
+                  <td className="sticky left-0 border-b border-r border-[#eef0f2] bg-white px-2 py-1.5 text-right text-[#98a2b3]">
+                    {rowIndex + 1}
+                  </td>
+                  {columns.map((column, columnIndex) => {
+                    const value = row?.[columnIndex];
+                    const display = formatCell(value);
+                    return (
+                      <td
+                        key={`${column.name || columnIndex}-${columnIndex}`}
+                        title={display}
+                        className={[
+                          'max-w-[420px] border-b border-r border-[#eef0f2] px-2.5 py-1.5',
+                          value === null ? 'italic text-[#98a2b3]' : '',
+                        ].join(' ')}
+                      >
+                        <div className="max-w-[400px] truncate">{display}</div>
+                      </td>
+                    );
+                  })}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        ) : (
+          <div className="flex h-full items-center justify-center text-[11px] text-[#98a2b3]">
+            SQL 执行成功，结果集没有可展示的字段
+          </div>
+        )}
+      </div>
     </div>
-  </div>
-);
+  );
+};

--- a/yak-ops-ui/src/pages/data-development/editors/sql/SqlToolbar.tsx
+++ b/yak-ops-ui/src/pages/data-development/editors/sql/SqlToolbar.tsx
@@ -51,6 +51,7 @@ const SqlToolbar = ({
   onRun,
   onSave,
   onPublish,
+  running,
   saving,
   publishing,
 }: DevelopmentEditorToolbarContext) => {
@@ -63,15 +64,23 @@ const SqlToolbar = ({
   return (
     <div className="flex h-full w-full min-w-0 items-center justify-between gap-3">
       <div className="flex shrink-0 items-center gap-0.5">
-        <ToolbarButton title="运行" onClick={onRun}>
-          <Play size={15} strokeWidth={1.8} />
+        <ToolbarButton
+          title={running ? 'SQL 运行中' : '运行当前 SQL'}
+          disabled={running}
+          onClick={onRun}
+        >
+          {running ? (
+            <LoaderCircle size={15} className="animate-spin" />
+          ) : (
+            <Play size={15} strokeWidth={1.8} />
+          )}
         </ToolbarButton>
 
         <ToolbarDivider />
 
         <ToolbarButton
           title="保存草稿"
-          disabled={saving || publishing}
+          disabled={saving || publishing || running}
           onClick={onSave}
         >
           {saving ? (
@@ -82,7 +91,7 @@ const SqlToolbar = ({
         </ToolbarButton>
         <ToolbarButton
           title="发布版本"
-          disabled={saving || publishing}
+          disabled={saving || publishing || running}
           onClick={onPublish}
         >
           {publishing ? (
@@ -93,12 +102,14 @@ const SqlToolbar = ({
         </ToolbarButton>
         <ToolbarButton
           title="撤销"
+          disabled={running}
           onClick={() => execute('undo', 'SQL 编辑器尚未就绪')}
         >
           <Undo2 size={15} strokeWidth={1.8} />
         </ToolbarButton>
         <ToolbarButton
           title="重做"
+          disabled={running}
           onClick={() => execute('redo', 'SQL 编辑器尚未就绪')}
         >
           <Redo2 size={15} strokeWidth={1.8} />
@@ -114,6 +125,7 @@ const SqlToolbar = ({
 
         <ToolbarButton
           title="格式化 SQL"
+          disabled={running}
           onClick={() => execute('format', 'SQL 编辑器尚未就绪')}
         >
           <Wand2 size={15} strokeWidth={1.8} />

--- a/yak-ops-ui/src/pages/data-development/editors/types.ts
+++ b/yak-ops-ui/src/pages/data-development/editors/types.ts
@@ -4,6 +4,7 @@ import type { ComponentType } from 'react';
 import type {
   DevelopmentDirectory,
   DevelopmentNode,
+  DevelopmentTaskRunResult,
   DevelopmentTaskType,
 } from '../types';
 
@@ -23,8 +24,14 @@ export interface DevelopmentEditorToolbarContext
   onRun: () => void;
   onSave: () => void;
   onPublish: () => void;
+  running: boolean;
   saving: boolean;
   publishing: boolean;
+}
+
+export interface DevelopmentEditorRunResultContext
+  extends DevelopmentEditorContext {
+  result?: DevelopmentTaskRunResult;
 }
 
 export interface DevelopmentEditorCapabilities {
@@ -52,5 +59,5 @@ export interface DevelopmentEditorDefinition {
   panels?: Partial<
     Record<DevelopmentEditorPanelKey, ComponentType<DevelopmentEditorContext>>
   >;
-  RunResult?: ComponentType<DevelopmentEditorContext>;
+  RunResult?: ComponentType<DevelopmentEditorRunResultContext>;
 }

--- a/yak-ops-ui/src/pages/data-development/service.ts
+++ b/yak-ops-ui/src/pages/data-development/service.ts
@@ -7,9 +7,11 @@ import type {
   DevelopmentDirectory,
   DevelopmentId,
   DevelopmentNode,
+  DevelopmentTaskDefinition,
   DevelopmentTaskDraft,
   DevelopmentTaskRevision,
   DevelopmentTaskRevisionSummary,
+  DevelopmentTaskRunResult,
   SaveDevelopmentTaskDraftPayload,
 } from './types';
 
@@ -63,6 +65,13 @@ export const saveDevelopmentTaskDraft = (
   payload: SaveDevelopmentTaskDraftPayload,
 ): Promise<ApiResponse<DevelopmentTaskDraft>> =>
   HttpUtils.put<DevelopmentTaskDraft>(`${NODE_API}/${nodeId}/draft`, payload);
+
+/** Execute the current editor definition; this does not implicitly save or publish it. */
+export const runDevelopmentTask = (
+  nodeId: DevelopmentId,
+  payload: DevelopmentTaskDefinition,
+): Promise<ApiResponse<DevelopmentTaskRunResult>> =>
+  HttpUtils.post<DevelopmentTaskRunResult>(`${NODE_API}/${nodeId}/run`, payload);
 
 export const publishDevelopmentTask = (
   nodeId: DevelopmentId,

--- a/yak-ops-ui/src/pages/data-development/types.ts
+++ b/yak-ops-ui/src/pages/data-development/types.ts
@@ -65,3 +65,36 @@ export interface DevelopmentTaskRevisionSummary {
 export interface DevelopmentTaskRevision extends DevelopmentTaskRevisionSummary {
   definition: DevelopmentTaskDefinition;
 }
+
+export type DevelopmentTaskExecutionStatus =
+  | 'PENDING'
+  | 'RUNNING'
+  | 'SUCCESS'
+  | 'FAILED'
+  | 'CANCELLED'
+  | 'TIMEOUT';
+
+export interface DevelopmentTaskRunResult {
+  status: DevelopmentTaskExecutionStatus;
+  message: string;
+  durationMs: number;
+  output: Record<string, unknown>;
+}
+
+export interface DevelopmentSqlResultColumn {
+  name: string;
+  label: string;
+  typeName?: string;
+  jdbcType?: number;
+  nullable?: boolean;
+}
+
+export interface DevelopmentSqlRunOutput {
+  kind?: 'RESULT_SET' | 'UPDATE_COUNT';
+  columns?: DevelopmentSqlResultColumn[];
+  rows?: unknown[][];
+  returnedRows?: number;
+  affectedRows?: number;
+  truncated?: boolean;
+  dataSourceId?: string;
+}


### PR DESCRIPTION
## 背景

前 3 个阶段已经完成统一 Task 模型、Task Plugin / Registry 骨架，以及数据开发 `TaskDraft -> Publish -> TaskRevision` 生命周期。本 PR 完成第 4 阶段：让 `SQL Task Plugin` 真正可执行，并把数据开发页面顶部“运行”按钮接到真实数据源和真实结果集。

本阶段重点验证这条执行链：

```text
Data Development 当前编辑器
        ↓
POST /nodes/{nodeId}/run
        ↓
DevelopmentTaskRunService
        ↓
TaskPluginRegistry
        ↓
SqlTaskPlugin
        ↓
TaskExecutionContext capability
        ↓
DataSourceExecutionProvider
        ↓
DataSourcePluginRegistry
        ↓
Datasource Plugin
        ↓
JDBC SQL Executor
        ↓
Database
```

## 1. SQL Task Plugin 变成真实可执行插件

`SqlTaskPlugin` Descriptor 现在为：

```text
executable = true
cancellable = true
version = 1.1.0
```

schemaVersion=1 配置支持：

```json
{
  "dataSourceId": "123",
  "maxRows": 200,
  "timeoutSeconds": 30
}
```

当前 UI 仍只持久化稳定的 `dataSourceId`；`maxRows` / `timeoutSeconds` 先使用插件默认值，后续再开放到运行配置面板。

校验补充：

- SQL 内容不能为空
- 必须选择数据源
- maxRows 范围 `1..500`
- timeoutSeconds 范围 `1..300`

## 2. DataSource Plugin 增加 SQL Execution SPI

没有让 SQL Task Plugin 直接使用 JDBC，也没有让它访问数据源表或连接密码。

新增 datasource runtime contracts：

- `DataSourceExecutionProvider`
- `DataSourceSqlExecutor`
- `DataSourceSqlRequest`
- `DataSourceSqlResult`
- `DataSourceSqlColumn`

`DataSourcePlugin#createSqlExecutor(...)` 默认不支持，JDBC 数据源插件通过 `AbstractJdbcDataSourcePlugin` 显式提供实现。

业务层新增 `BusinessDataSourceExecutionProvider`：

```text
dataSourceId
   ↓
DataSourceRepository
   ↓
DataSourcePluginRegistry
   ↓
plugin.parseConnection(...)
   ↓
plugin.createSqlExecutor(...)
```

因此 Task Plugin 永远只持有数据源 ID，不会拿到密码、JDBC URL 或 Repository。

## 3. JDBC 真正执行 SQL

新增 `JdbcDataSourceSqlExecutor`，支持：

- `Statement.execute(...)`
- SELECT ResultSet
- INSERT / UPDATE / DELETE 影响行数
- DDL 执行
- JDBC Query Timeout
- ResultSet 列元数据
- 结果集最大行数保护
- 超限 `truncated` 标识
- `Statement.cancel()` + Connection close 的 best-effort cancel
- JDBC `SQLTimeoutException -> TIMEOUT`
- SQL / 连接错误信息回传
- 大文本、二进制、LOB 等结果值的安全边界处理

默认：

```text
maxRows = 200
timeoutSeconds = 30
```

## 4. TaskExecutionContext 增加 typed capability

Task Plugin 不依赖 Spring / Business Module。

`TaskExecutionContext` 新增：

```java
<T> Optional<T> capability(Class<T> capabilityType)
<T> T requireCapability(Class<T> capabilityType)
```

SQL Plugin 运行时通过：

```java
context.requireCapability(DataSourceExecutionProvider.class)
```

获得平台数据源执行能力。

这样以后 Workflow / Schedule 的 Task Runtime 可以提供同一 capability，不需要 SQL Plugin 感知触发入口。

## 5. 数据开发 Manual Run API

新增：

```http
POST /api/v1/data-development/nodes/{nodeId}/run
```

请求直接使用当前插件无关的 TaskDefinition：

```json
{
  "taskType": "SQL",
  "schemaVersion": 1,
  "content": "select 1",
  "configJson": "{\"dataSourceId\":\"123\"}"
}
```

响应包含：

```text
status
message
durationMs
output
```

SQL output 支持：

```text
RESULT_SET:
  columns
  rows
  returnedRows
  truncated

UPDATE_COUNT:
  affectedRows
```

### 特别说明

**点击运行不会自动保存草稿，也不会自动发布版本。**

因此 IDE 使用体验是：

```text
编辑未保存 SQL
      ↓
点击运行
      ↓
直接执行当前编辑器内容
```

而：

```text
保存 -> TaskDraft
发布 -> immutable TaskRevision
```

三者继续保持独立。

## 6. 前端接入真实运行结果

数据开发 Workbench 已接入真实运行：

- 点击 SQL“运行”立即打开底部结果面板
- 按钮显示运行中 Spinner
- 使用当前编辑器 SQL + 当前数据源上下文执行
- 未保存 SQL 也可直接试运行
- 查询结果展示真实列和数据行
- 表头展示 JDBC 类型
- NULL 单独展示
- 横向 / 纵向滚动 Result Grid
- 显示行数、列数、耗时
- 超过返回上限显示截断提示
- DML 展示影响行数
- SQL 错误展示错误信息
- Timeout 展示独立状态

本阶段只有 SQL 在前端声明 `run=true`；Shell / HTTP / Python 暂时不展示可执行能力。

## 7. Tests

新增 / 更新测试：

- `SqlTaskPluginTest`
  - 数据源配置校验
  - typed runtime capability
  - SQL executor 输出
- `TaskPluginAssemblyTest`
  - ServiceLoader 仍可发现 SQL Plugin
  - executable / cancellable Descriptor
- `DevelopmentTaskRunServiceTest`
  - 当前编辑器 Definition 直接进入 Task Plugin
  - Manual trigger 语义

## 8. 文档

新增：

```text
docs/data-development/sql-task-runtime-stage-4.md
```

记录 Execution SPI、SQL Plugin、Datasource Provider、Manual Run API、结果边界以及后续阶段关系。

## Deliberately out of scope

本阶段仍然不做：

- 不新增 durable `TaskExecution` / Attempt 表
- 不做异步 Run polling
- 不提供 HTTP Stop/Cancel 接口
- 不接 Workflow / Schedule 真实执行
- 不创建 TaskAsset / Task Catalog
- 不实现 Workflow `taskAssetId + taskRevisionId`
- 不实现 Shell / Python / HTTP 执行
- 不引入 Worker / Docker / Kubernetes Execution Backend

SQL Plugin 内部已经具备 cancel 能力，但跨 HTTP 请求的停止动作需要后续统一 Task Runtime 持有 execution handle 后才能正确实现。

## Validation

当前分支已重新整理为单个提交，并确认相对 `main`：

```text
ahead 1
behind 0
```

本次通过 GitHub connector 直接修改仓库，没有完整本地 checkout，因此尚未实际执行 Maven / npm 全量构建。合并前建议运行：

```bash
mvn -pl yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-sql -am test
mvn -pl yak-ops-business/yak-ops-business-data-development -am test
mvn -pl yak-ops-boot -am package -DskipTests

cd yak-ops-ui
npm run tsc
npm run build
```

并至少使用一个真实 MySQL / PostgreSQL / Doris 数据源回归：SELECT、空结果集、DML、SQL 语法错误、结果截断和超时。

## Next

阶段 5：增加 `TaskAsset / Task Catalog`，让数据开发发布后的任务自动成为 Workflow 左侧“数据开发”任务资产。