### PR TITLE
feat(task-catalog): publish development tasks for workflow discovery

### DIFF
--- a/docs/task-catalog-stage-5.md
+++ b/docs/task-catalog-stage-5.md
@@ -1,0 +1,214 @@
+# Task Catalog Stage 5
+
+Stage 5 turns a published task revision into a platform-level task asset that orchestration surfaces can discover without reaching into a source domain's tables.
+
+## Goal
+
+```text
+Data Development node: 今天统计
+        |
+        | save
+        v
+TaskDraft #5
+        |
+        | publish
+        v
+TaskRevision v1 (immutable)
+        |
+        | upsert
+        v
+TaskAsset
+  source = DATA_DEVELOPMENT
+  sourceRef = <development node id>
+  taskType = SQL
+  status = ONLINE
+  currentRevision = v1
+        |
+        v
+Task Catalog
+        |
+        v
+Workflow task picker / 数据开发
+```
+
+A draft is never a task asset. Only a successfully validated published revision enters the catalog.
+
+## Module boundary
+
+A new neutral business module owns discovery metadata:
+
+```text
+yak-ops-business-task-catalog
+  |- domain/TaskAsset
+  |- repository/TaskAssetRepository
+  |- service/TaskCatalogService
+  |- controller/v1/TaskCatalogController
+  `- db/migration/yak-task-catalog
+```
+
+Data Development depends on Task Catalog, not the other way around. Workflow discovers catalog assets through the catalog API and does not read `yak_dev_node`, `yak_dev_task_draft` or `yak_dev_task_revision` directly.
+
+## Persistence
+
+`yak_task_asset` is a small source-neutral index:
+
+```text
+id
+source
+source_ref
+project_id
+name
+task_type
+status
+current_revision_id
+current_revision_no
+create_time
+update_time
+```
+
+`(source, source_ref)` is unique. Publishing v2 updates the same asset instead of creating another asset.
+
+The catalog deliberately does not duplicate SQL text or plugin configuration. Immutable executable content remains in the source revision table. `current_revision_id/current_revision_no` are discovery pointers.
+
+## Publish semantics
+
+Data Development publishing remains one business transaction:
+
+1. lock Draft;
+2. validate TaskDefinition through TaskPlugin;
+3. create/reuse immutable TaskRevision;
+4. mark the development node configured;
+5. upsert the corresponding `DATA_DEVELOPMENT` TaskAsset as `ONLINE`.
+
+Even an idempotent re-publish of an unchanged Draft calls Task Catalog again. This lets the publish operation repair a missing/stale catalog row without manufacturing another TaskRevision.
+
+Example:
+
+```text
+今天统计
+  publish -> revision v1 -> asset currentRevision=v1
+  edit
+  publish -> revision v2 -> same asset currentRevision=v2
+```
+
+## Source lifecycle synchronization
+
+For an already-published Data Development node:
+
+- rename updates TaskAsset display metadata;
+- deleting the source node marks the asset `OFFLINE`;
+- the asset retains its latest revision pointer so historical references are not erased.
+
+An unpublished node rename/delete does not create a catalog row because catalog metadata updates are no-ops when `(source, source_ref)` does not exist.
+
+## API
+
+```http
+GET /api/v1/task-catalog/assets
+```
+
+Filters:
+
+```text
+source  = DATA_DEVELOPMENT | DATA_INTEGRATION | DATA_QUALITY | INTERNAL
+status  = ONLINE | OFFLINE | ARCHIVED | DRAFT
+keyword = name/sourceRef fuzzy search
+```
+
+`status` defaults to `ONLINE` so orchestration discovery does not accidentally surface offline assets.
+
+Example response shape:
+
+```json
+{
+  "id": 12,
+  "source": "DATA_DEVELOPMENT",
+  "sourceRef": "10001",
+  "name": "今天统计",
+  "taskType": "SQL",
+  "status": "ONLINE",
+  "currentRevision": {
+    "taskAssetId": 12,
+    "taskRevisionId": 90001,
+    "revisionNo": 2
+  }
+}
+```
+
+## Workflow discovery in Stage 5
+
+`WorkflowTaskPicker` loads:
+
+```http
+GET /api/v1/task-catalog/assets?source=DATA_DEVELOPMENT&status=ONLINE
+```
+
+Published assets appear under the existing **数据开发** category together with their current revision badge, for example `已发布 v2`.
+
+They are intentionally discovery-only in this stage. The picker disables adding the catalog item and explains that fixed revision binding is introduced in Stage 6.
+
+This is important because enabling selection now would make Workflow persist the legacy generic `taskId`, which cannot yet express the required pair:
+
+```text
+taskAssetId + taskRevisionId
+```
+
+Stage 5 therefore proves publication and discovery without creating a temporary binding format that must later be migrated.
+
+## Why Workflow does not query Data Development directly
+
+The same catalog contract will later accept assets from:
+
+```text
+DATA_INTEGRATION
+DATA_DEVELOPMENT
+DATA_QUALITY
+INTERNAL
+```
+
+Workflow remains source-neutral and only depends on task assets. Source-specific draft tables stay private to their authoring domains.
+
+## Transaction and failure behavior
+
+Data Development and Task Catalog use the same Yak business datasource and `yakBusinessTransactionManager`. Catalog publication joins the existing publish transaction. A catalog write failure therefore fails the publish transaction instead of leaving a revision reported as successfully published but invisible to orchestration.
+
+Task Catalog has an independent Flyway location/history table:
+
+```text
+classpath:db/migration/yak-task-catalog
+flyway_schema_history_task_catalog
+```
+
+## Tests
+
+Stage 5 adds/updates tests for:
+
+- TaskAsset publish/upsert normalization;
+- default `ONLINE` catalog filtering;
+- Development publish -> catalog registration;
+- unchanged re-publish -> catalog reconciliation without duplicate TaskRevision;
+- development node rename -> catalog metadata sync;
+- source deletion -> asset `OFFLINE`.
+
+## Deliberately out of scope
+
+Stage 5 does not:
+
+- persist `taskAssetId + taskRevisionId` on Workflow nodes;
+- allow catalog assets to be dragged/added to the Workflow graph yet;
+- silently upgrade an existing Workflow to a newer task revision;
+- execute SQL from Workflow/Schedule through the unified Task Runtime;
+- add durable TaskExecution/Attempt persistence;
+- implement Shell/Python/HTTP execution or Worker backends.
+
+## Next: Stage 6
+
+Stage 6 should make a Workflow node bind explicitly to:
+
+```text
+taskAssetId = 12
+taskRevisionId = 90001
+revisionNo = 2
+```
+
+After that, a later Data Development publish to v3 changes the catalog's `currentRevision`, but the existing Workflow stays on v2 until the user explicitly upgrades it.

--- a/yak-ops-bom/pom.xml
+++ b/yak-ops-bom/pom.xml
@@ -73,6 +73,11 @@
             </dependency>
             <dependency>
                 <groupId>io.yak.ops</groupId>
+                <artifactId>yak-ops-business-task-catalog</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.yak.ops</groupId>
                 <artifactId>yak-ops-business-data-development</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/yak-ops-boot/pom.xml
+++ b/yak-ops-boot/pom.xml
@@ -26,6 +26,10 @@
         </dependency>
         <dependency>
             <groupId>io.yak.ops</groupId>
+            <artifactId>yak-ops-business-task-catalog</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.yak.ops</groupId>
             <artifactId>yak-ops-business-data-development</artifactId>
         </dependency>
         <dependency>

--- a/yak-ops-business/pom.xml
+++ b/yak-ops-business/pom.xml
@@ -20,6 +20,7 @@
     <modules>
         <module>yak-ops-business-datasource</module>
         <module>yak-ops-business-job</module>
+        <module>yak-ops-business-task-catalog</module>
         <module>yak-ops-business-data-development</module>
         <module>yak-ops-business-resource</module>
         <module>yak-ops-business-sync</module>

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentNodeService.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentNodeService.java
@@ -3,6 +3,8 @@ package io.yak.ops.business.development.service;
 import io.yak.ops.business.development.domain.DevelopmentNode;
 import io.yak.ops.business.development.repository.DevelopmentDirectoryRepository;
 import io.yak.ops.business.development.repository.DevelopmentNodeRepository;
+import io.yak.ops.business.taskcatalog.service.TaskCatalogService;
+import io.yak.ops.spi.task.model.TaskAssetSource;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
@@ -17,12 +19,15 @@ public class DevelopmentNodeService {
 
   private final DevelopmentNodeRepository repository;
   private final DevelopmentDirectoryRepository directoryRepository;
+  private final TaskCatalogService taskCatalogService;
 
   public DevelopmentNodeService(
       DevelopmentNodeRepository repository,
-      DevelopmentDirectoryRepository directoryRepository) {
+      DevelopmentDirectoryRepository directoryRepository,
+      TaskCatalogService taskCatalogService) {
     this.repository = repository;
     this.directoryRepository = directoryRepository;
+    this.taskCatalogService = taskCatalogService;
   }
 
   public List<DevelopmentNode> list() {
@@ -68,17 +73,27 @@ public class DevelopmentNodeService {
     if (!repository.updateName(id, normalizedName)) {
       throw new IllegalStateException("节点重命名失败：" + id);
     }
-    return repository.findById(id)
+    DevelopmentNode renamed = repository.findById(id)
         .orElseThrow(() -> new IllegalStateException("节点重命名成功但无法重新读取：" + id));
+    taskCatalogService.updateSourceMetadata(
+        TaskAssetSource.DATA_DEVELOPMENT,
+        String.valueOf(renamed.id()),
+        renamed.projectId(),
+        renamed.name(),
+        renamed.type());
+    return renamed;
   }
 
   @Transactional(transactionManager = "yakBusinessTransactionManager", rollbackFor = Exception.class)
   public void delete(Long id) {
-    repository.findById(id)
+    DevelopmentNode current = repository.findById(id)
         .orElseThrow(() -> new IllegalArgumentException("节点不存在：" + id));
     if (!repository.deleteById(id)) {
       throw new IllegalStateException("节点删除失败：" + id);
     }
+    taskCatalogService.offlineSource(
+        TaskAssetSource.DATA_DEVELOPMENT,
+        String.valueOf(current.id()));
   }
 
   private String normalizeName(String name) {

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentTaskService.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentTaskService.java
@@ -10,10 +10,12 @@ import io.yak.ops.business.development.domain.DevelopmentTaskRevisionSummary;
 import io.yak.ops.business.development.repository.DevelopmentNodeRepository;
 import io.yak.ops.business.development.repository.DevelopmentTaskDraftRepository;
 import io.yak.ops.business.development.repository.DevelopmentTaskRevisionRepository;
+import io.yak.ops.business.taskcatalog.service.TaskCatalogService;
 import io.yak.ops.core.plugin.task.TaskPluginRegistry;
 import io.yak.ops.plugin.task.api.TaskPlugin;
 import io.yak.ops.plugin.task.api.TaskValidationIssue;
 import io.yak.ops.plugin.task.api.TaskValidationResult;
+import io.yak.ops.spi.task.model.TaskAssetSource;
 import io.yak.ops.spi.task.model.TaskDefinition;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
@@ -25,13 +27,14 @@ import java.util.Objects;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-/** Authoring lifecycle: mutable draft -> validated immutable published revision. */
+/** Authoring lifecycle: mutable draft -> validated immutable published revision -> Task Catalog. */
 @Service
 public class DevelopmentTaskService {
 
   private final DevelopmentNodeRepository nodeRepository;
   private final DevelopmentTaskDraftRepository draftRepository;
   private final DevelopmentTaskRevisionRepository revisionRepository;
+  private final TaskCatalogService taskCatalogService;
   private final TaskPluginRegistry pluginRegistry;
   private final ObjectMapper objectMapper;
 
@@ -39,11 +42,13 @@ public class DevelopmentTaskService {
       DevelopmentNodeRepository nodeRepository,
       DevelopmentTaskDraftRepository draftRepository,
       DevelopmentTaskRevisionRepository revisionRepository,
+      TaskCatalogService taskCatalogService,
       TaskPluginRegistry pluginRegistry,
       ObjectMapper objectMapper) {
     this.nodeRepository = nodeRepository;
     this.draftRepository = draftRepository;
     this.revisionRepository = revisionRepository;
+    this.taskCatalogService = taskCatalogService;
     this.pluginRegistry = pluginRegistry;
     this.objectMapper = objectMapper;
   }
@@ -102,20 +107,30 @@ public class DevelopmentTaskService {
 
     String checksum = checksum(definition);
     DevelopmentTaskRevision latest = revisionRepository.findLatestByNodeId(nodeId).orElse(null);
+    DevelopmentTaskRevision published;
     if (latest != null
         && latest.sourceDraftRevision() == draft.draftRevision()
         && Objects.equals(latest.checksum(), checksum)) {
-      return latest;
+      published = latest;
+    } else {
+      int revisionNo = revisionRepository.nextRevisionNo(nodeId);
+      published = revisionRepository.insert(
+          nodeId,
+          revisionNo,
+          draft.draftRevision(),
+          definition,
+          checksum);
     }
 
-    int revisionNo = revisionRepository.nextRevisionNo(nodeId);
-    DevelopmentTaskRevision published = revisionRepository.insert(
-        nodeId,
-        revisionNo,
-        draft.draftRevision(),
-        definition,
-        checksum);
     nodeRepository.updateConfigured(nodeId, true);
+    taskCatalogService.publish(
+        TaskAssetSource.DATA_DEVELOPMENT,
+        String.valueOf(node.id()),
+        node.projectId(),
+        node.name(),
+        definition.taskType(),
+        published.id(),
+        published.revisionNo());
     return published;
   }
 

--- a/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/DevelopmentNodeServiceTest.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/DevelopmentNodeServiceTest.java
@@ -3,11 +3,15 @@ package io.yak.ops.business.development.service;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 import io.yak.ops.business.development.domain.DevelopmentDirectory;
 import io.yak.ops.business.development.domain.DevelopmentNode;
 import io.yak.ops.business.development.repository.DevelopmentDirectoryRepository;
 import io.yak.ops.business.development.repository.DevelopmentNodeRepository;
+import io.yak.ops.business.taskcatalog.service.TaskCatalogService;
+import io.yak.ops.spi.task.model.TaskAssetSource;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -25,7 +29,8 @@ class DevelopmentNodeServiceTest {
     DevelopmentDirectory folder = directories.insert(null, "ODS");
     DevelopmentNodeService service = new DevelopmentNodeService(
         new InMemoryNodeRepository(),
-        directories);
+        directories,
+        mock(TaskCatalogService.class));
 
     DevelopmentNode sql = service.create("用户清洗", "sql", null, folder.id());
     DevelopmentNode shell = service.create("清理临时文件", "shell", 7L, null);
@@ -42,7 +47,10 @@ class DevelopmentNodeServiceTest {
   void rejectsUnknownDirectoryAndDuplicateSiblingName() {
     InMemoryDirectoryRepository directories = new InMemoryDirectoryRepository();
     InMemoryNodeRepository nodes = new InMemoryNodeRepository();
-    DevelopmentNodeService service = new DevelopmentNodeService(nodes, directories);
+    DevelopmentNodeService service = new DevelopmentNodeService(
+        nodes,
+        directories,
+        mock(TaskCatalogService.class));
 
     assertThrows(
         IllegalArgumentException.class,
@@ -55,17 +63,30 @@ class DevelopmentNodeServiceTest {
   }
 
   @Test
-  void renamesAndDeletesNode() {
+  void renamesAndDeletesNodeWhileKeepingCatalogLifecycleAligned() {
     InMemoryDirectoryRepository directories = new InMemoryDirectoryRepository();
     InMemoryNodeRepository nodes = new InMemoryNodeRepository();
-    DevelopmentNodeService service = new DevelopmentNodeService(nodes, directories);
+    TaskCatalogService taskCatalogService = mock(TaskCatalogService.class);
+    DevelopmentNodeService service = new DevelopmentNodeService(
+        nodes,
+        directories,
+        taskCatalogService);
     DevelopmentNode node = service.create("任务", "SQL", null, null);
 
     DevelopmentNode renamed = service.rename(node.id(), "新任务");
     assertEquals("新任务", renamed.name());
+    verify(taskCatalogService).updateSourceMetadata(
+        TaskAssetSource.DATA_DEVELOPMENT,
+        String.valueOf(node.id()),
+        null,
+        "新任务",
+        "SQL");
 
     service.delete(node.id());
     assertEquals(List.of(), service.list());
+    verify(taskCatalogService).offlineSource(
+        TaskAssetSource.DATA_DEVELOPMENT,
+        String.valueOf(node.id()));
   }
 
   private static final class InMemoryNodeRepository implements DevelopmentNodeRepository {
@@ -129,6 +150,22 @@ class DevelopmentNodeServiceTest {
           current.projectId(),
           current.directoryId(),
           current.configured(),
+          current.createTime(),
+          Instant.now()));
+      return true;
+    }
+
+    @Override
+    public boolean updateConfigured(Long id, boolean configured) {
+      DevelopmentNode current = values.get(id);
+      if (current == null) return false;
+      values.put(id, new DevelopmentNode(
+          current.id(),
+          current.name(),
+          current.type(),
+          current.projectId(),
+          current.directoryId(),
+          configured,
           current.createTime(),
           Instant.now()));
       return true;

--- a/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/DevelopmentTaskServiceTest.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/DevelopmentTaskServiceTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -16,11 +17,13 @@ import io.yak.ops.business.development.domain.DevelopmentTaskRevision;
 import io.yak.ops.business.development.repository.DevelopmentNodeRepository;
 import io.yak.ops.business.development.repository.DevelopmentTaskDraftRepository;
 import io.yak.ops.business.development.repository.DevelopmentTaskRevisionRepository;
+import io.yak.ops.business.taskcatalog.service.TaskCatalogService;
 import io.yak.ops.core.plugin.task.TaskPluginRegistry;
 import io.yak.ops.plugin.task.api.TaskPlugin;
 import io.yak.ops.plugin.task.api.TaskPluginDescriptor;
 import io.yak.ops.plugin.task.api.TaskValidationIssue;
 import io.yak.ops.plugin.task.api.TaskValidationResult;
+import io.yak.ops.spi.task.model.TaskAssetSource;
 import io.yak.ops.spi.task.model.TaskDefinition;
 import java.time.Instant;
 import java.util.List;
@@ -33,6 +36,7 @@ class DevelopmentTaskServiceTest {
   private DevelopmentNodeRepository nodeRepository;
   private DevelopmentTaskDraftRepository draftRepository;
   private DevelopmentTaskRevisionRepository revisionRepository;
+  private TaskCatalogService taskCatalogService;
   private DevelopmentTaskService service;
 
   @BeforeEach
@@ -40,10 +44,12 @@ class DevelopmentTaskServiceTest {
     nodeRepository = mock(DevelopmentNodeRepository.class);
     draftRepository = mock(DevelopmentTaskDraftRepository.class);
     revisionRepository = mock(DevelopmentTaskRevisionRepository.class);
+    taskCatalogService = mock(TaskCatalogService.class);
     service = new DevelopmentTaskService(
         nodeRepository,
         draftRepository,
         revisionRepository,
+        taskCatalogService,
         TaskPluginRegistry.from(List.of(new TestSqlPlugin())),
         new ObjectMapper());
 
@@ -79,7 +85,7 @@ class DevelopmentTaskServiceTest {
   }
 
   @Test
-  void publishCreatesImmutableRevisionFromLockedDraft() {
+  void publishCreatesImmutableRevisionAndReconcilesTaskCatalog() {
     TaskDefinition definition = new TaskDefinition("SQL", 1, "select 1", "{}");
     DevelopmentTaskDraft draft = new DevelopmentTaskDraft(
         1L, definition, 3L, Instant.now(), Instant.now());
@@ -102,6 +108,29 @@ class DevelopmentTaskServiceTest {
     assertEquals(3L, published.sourceDraftRevision());
     assertEquals(64, published.checksum().length());
     verify(nodeRepository).updateConfigured(1L, true);
+    verify(taskCatalogService).publish(
+        TaskAssetSource.DATA_DEVELOPMENT,
+        "1",
+        null,
+        "今天统计",
+        "SQL",
+        100L,
+        1);
+
+    // Re-publishing the unchanged draft reuses v1 but still repairs/advances catalog state idempotently.
+    when(revisionRepository.findLatestByNodeId(1L)).thenReturn(Optional.of(published));
+    DevelopmentTaskRevision repeated = service.publish(1L, 3L);
+    assertEquals(published, repeated);
+    verify(revisionRepository, times(1))
+        .insert(eq(1L), eq(1), eq(3L), eq(definition), any(String.class));
+    verify(taskCatalogService, times(2)).publish(
+        TaskAssetSource.DATA_DEVELOPMENT,
+        "1",
+        null,
+        "今天统计",
+        "SQL",
+        100L,
+        1);
   }
 
   @Test

--- a/yak-ops-business/yak-ops-business-task-catalog/pom.xml
+++ b/yak-ops-business/yak-ops-business-task-catalog/pom.xml
@@ -11,10 +11,10 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <artifactId>yak-ops-business-data-development</artifactId>
+    <artifactId>yak-ops-business-task-catalog</artifactId>
 
-    <name>Yak Ops Business Data Development</name>
-    <description>Data-development directory, task authoring, revisions and manual execution</description>
+    <name>Yak Ops Business Task Catalog</name>
+    <description>Published task asset catalog shared by authoring domains and workflow discovery</description>
 
     <dependencies>
         <dependency>
@@ -27,23 +27,7 @@
         </dependency>
         <dependency>
             <groupId>io.yak.ops</groupId>
-            <artifactId>yak-ops-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.yak.ops</groupId>
-            <artifactId>yak-ops-plugin-task-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.yak.ops</groupId>
-            <artifactId>yak-ops-plugin-datasource-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.yak.ops</groupId>
             <artifactId>yak-ops-business-datasource</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.yak.ops</groupId>
-            <artifactId>yak-ops-business-task-catalog</artifactId>
         </dependency>
 
         <dependency>
@@ -52,15 +36,7 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-validation</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-jdbc</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.baomidou</groupId>
-            <artifactId>mybatis-plus-spring-boot3-starter</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springdoc</groupId>
@@ -74,11 +50,7 @@
             <groupId>org.flywaydb</groupId>
             <artifactId>flyway-mysql</artifactId>
         </dependency>
-        <dependency>
-            <groupId>com.mysql</groupId>
-            <artifactId>mysql-connector-j</artifactId>
-            <scope>runtime</scope>
-        </dependency>
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>

--- a/yak-ops-business/yak-ops-business-task-catalog/src/main/java/io/yak/ops/business/taskcatalog/config/TaskCatalogPersistenceConfiguration.java
+++ b/yak-ops-business/yak-ops-business-task-catalog/src/main/java/io/yak/ops/business/taskcatalog/config/TaskCatalogPersistenceConfiguration.java
@@ -1,0 +1,31 @@
+package io.yak.ops.business.taskcatalog.config;
+
+import io.yak.ops.business.datasource.config.BusinessDatabaseConfiguration;
+import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
+import io.yak.ops.business.datasource.config.DataSourceProperties;
+import javax.sql.DataSource;
+import org.flywaydb.core.Flyway;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+/** Task Catalog reuses the Yak business database while keeping an isolated Flyway history. */
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnDataSourceEnabled
+@EnableConfigurationProperties(DataSourceProperties.class)
+@Import(BusinessDatabaseConfiguration.class)
+public class TaskCatalogPersistenceConfiguration {
+
+  @Bean(name = "yakTaskCatalogFlyway", initMethod = "migrate")
+  public Flyway taskCatalogFlyway(
+      @Qualifier("yakBusinessDataSource") DataSource dataSource) {
+    return Flyway.configure()
+        .dataSource(dataSource)
+        .locations("classpath:db/migration/yak-task-catalog")
+        .table("flyway_schema_history_task_catalog")
+        .baselineOnMigrate(true)
+        .load();
+  }
+}

--- a/yak-ops-business/yak-ops-business-task-catalog/src/main/java/io/yak/ops/business/taskcatalog/controller/v1/TaskCatalogController.java
+++ b/yak-ops-business/yak-ops-business-task-catalog/src/main/java/io/yak/ops/business/taskcatalog/controller/v1/TaskCatalogController.java
@@ -1,0 +1,36 @@
+package io.yak.ops.business.taskcatalog.controller.v1;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.yak.framework.common.Result;
+import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
+import io.yak.ops.business.taskcatalog.domain.TaskAsset;
+import io.yak.ops.business.taskcatalog.service.TaskCatalogService;
+import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Read-only discovery API for published task assets. */
+@Tag(name = "任务资产目录")
+@RestController
+@RequestMapping("/api/v1/task-catalog/assets")
+@ConditionalOnDataSourceEnabled
+public class TaskCatalogController {
+
+  private final TaskCatalogService service;
+
+  public TaskCatalogController(TaskCatalogService service) {
+    this.service = service;
+  }
+
+  @Operation(summary = "查询已发布任务资产")
+  @GetMapping
+  public Result<List<TaskAsset>> list(
+      @RequestParam(value = "source", required = false) String source,
+      @RequestParam(value = "status", required = false, defaultValue = "ONLINE") String status,
+      @RequestParam(value = "keyword", required = false) String keyword) {
+    return Result.success(service.list(source, status, keyword));
+  }
+}

--- a/yak-ops-business/yak-ops-business-task-catalog/src/main/java/io/yak/ops/business/taskcatalog/domain/TaskAsset.java
+++ b/yak-ops-business/yak-ops-business-task-catalog/src/main/java/io/yak/ops/business/taskcatalog/domain/TaskAsset.java
@@ -1,0 +1,37 @@
+package io.yak.ops.business.taskcatalog.domain;
+
+import io.yak.ops.spi.task.model.TaskAssetSource;
+import io.yak.ops.spi.task.model.TaskAssetStatus;
+import io.yak.ops.spi.task.model.TaskRevisionRef;
+import java.time.Instant;
+import java.util.Objects;
+
+/** Published task asset discoverable by orchestration surfaces. */
+public record TaskAsset(
+    long id,
+    TaskAssetSource source,
+    String sourceRef,
+    Long projectId,
+    String name,
+    String taskType,
+    TaskAssetStatus status,
+    TaskRevisionRef currentRevision,
+    Instant createTime,
+    Instant updateTime) {
+
+  public TaskAsset {
+    if (id <= 0L) throw new IllegalArgumentException("Task asset id must be positive");
+    source = Objects.requireNonNull(source, "source");
+    if (sourceRef == null || sourceRef.isBlank()) {
+      throw new IllegalArgumentException("Task asset sourceRef must not be blank");
+    }
+    if (name == null || name.isBlank()) {
+      throw new IllegalArgumentException("Task asset name must not be blank");
+    }
+    if (taskType == null || taskType.isBlank()) {
+      throw new IllegalArgumentException("Task asset taskType must not be blank");
+    }
+    status = Objects.requireNonNull(status, "status");
+    currentRevision = Objects.requireNonNull(currentRevision, "currentRevision");
+  }
+}

--- a/yak-ops-business/yak-ops-business-task-catalog/src/main/java/io/yak/ops/business/taskcatalog/repository/JdbcTaskAssetRepository.java
+++ b/yak-ops-business/yak-ops-business-task-catalog/src/main/java/io/yak/ops/business/taskcatalog/repository/JdbcTaskAssetRepository.java
@@ -1,0 +1,158 @@
+package io.yak.ops.business.taskcatalog.repository;
+
+import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
+import io.yak.ops.business.taskcatalog.domain.TaskAsset;
+import io.yak.ops.spi.task.model.TaskAssetSource;
+import io.yak.ops.spi.task.model.TaskAssetStatus;
+import io.yak.ops.spi.task.model.TaskRevisionRef;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import javax.sql.DataSource;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+/** JDBC storage for the small, source-neutral task asset index. */
+@Repository
+@ConditionalOnDataSourceEnabled
+public class JdbcTaskAssetRepository implements TaskAssetRepository {
+
+  private static final String SELECT_COLUMNS =
+      "SELECT id, source, source_ref, project_id, name, task_type, status, "
+          + "current_revision_id, current_revision_no, create_time, update_time "
+          + "FROM yak_task_asset";
+
+  private final JdbcTemplate jdbcTemplate;
+
+  public JdbcTaskAssetRepository(
+      @Qualifier("yakBusinessDataSource") DataSource dataSource) {
+    this.jdbcTemplate = new JdbcTemplate(dataSource);
+  }
+
+  @Override
+  public TaskAsset upsertPublished(
+      TaskAssetSource source,
+      String sourceRef,
+      Long projectId,
+      String name,
+      String taskType,
+      long revisionId,
+      int revisionNo) {
+    jdbcTemplate.update(
+        """
+        INSERT INTO yak_task_asset (
+            source, source_ref, project_id, name, task_type, status,
+            current_revision_id, current_revision_no, create_time, update_time)
+        VALUES (?, ?, ?, ?, ?, 'ONLINE', ?, ?, NOW(6), NOW(6))
+        ON DUPLICATE KEY UPDATE
+            project_id = VALUES(project_id),
+            name = VALUES(name),
+            task_type = VALUES(task_type),
+            status = 'ONLINE',
+            current_revision_id = VALUES(current_revision_id),
+            current_revision_no = VALUES(current_revision_no),
+            update_time = NOW(6)
+        """,
+        source.name(),
+        sourceRef,
+        projectId,
+        name,
+        taskType,
+        revisionId,
+        revisionNo);
+    return findBySource(source, sourceRef)
+        .orElseThrow(() -> new IllegalStateException("任务资产发布后无法重新读取：" + source + "/" + sourceRef));
+  }
+
+  @Override
+  public Optional<TaskAsset> findBySource(TaskAssetSource source, String sourceRef) {
+    List<TaskAsset> values = jdbcTemplate.query(
+        SELECT_COLUMNS + " WHERE source = ? AND source_ref = ? LIMIT 1",
+        JdbcTaskAssetRepository::mapRow,
+        source.name(),
+        sourceRef);
+    return values.stream().findFirst();
+  }
+
+  @Override
+  public List<TaskAsset> list(
+      TaskAssetSource source,
+      TaskAssetStatus status,
+      String keyword) {
+    StringBuilder sql = new StringBuilder(SELECT_COLUMNS).append(" WHERE 1 = 1");
+    List<Object> args = new ArrayList<>();
+    if (source != null) {
+      sql.append(" AND source = ?");
+      args.add(source.name());
+    }
+    if (status != null) {
+      sql.append(" AND status = ?");
+      args.add(status.name());
+    }
+    if (keyword != null && !keyword.isBlank()) {
+      sql.append(" AND (name LIKE ? OR source_ref LIKE ?)");
+      String pattern = "%" + keyword.trim() + "%";
+      args.add(pattern);
+      args.add(pattern);
+    }
+    sql.append(" ORDER BY update_time DESC, id DESC");
+    return jdbcTemplate.query(sql.toString(), JdbcTaskAssetRepository::mapRow, args.toArray());
+  }
+
+  @Override
+  public boolean updateSourceMetadata(
+      TaskAssetSource source,
+      String sourceRef,
+      Long projectId,
+      String name,
+      String taskType) {
+    return jdbcTemplate.update(
+        "UPDATE yak_task_asset SET project_id = ?, name = ?, task_type = ?, update_time = NOW(6) "
+            + "WHERE source = ? AND source_ref = ?",
+        projectId,
+        name,
+        taskType,
+        source.name(),
+        sourceRef) > 0;
+  }
+
+  @Override
+  public boolean updateStatus(
+      TaskAssetSource source,
+      String sourceRef,
+      TaskAssetStatus status) {
+    return jdbcTemplate.update(
+        "UPDATE yak_task_asset SET status = ?, update_time = NOW(6) WHERE source = ? AND source_ref = ?",
+        status.name(),
+        source.name(),
+        sourceRef) > 0;
+  }
+
+  private static TaskAsset mapRow(ResultSet resultSet, int rowNum) throws SQLException {
+    long id = resultSet.getLong("id");
+    Object projectValue = resultSet.getObject("project_id");
+    Long projectId = projectValue == null ? null : resultSet.getLong("project_id");
+    long revisionId = resultSet.getLong("current_revision_id");
+    int revisionNo = resultSet.getInt("current_revision_no");
+    return new TaskAsset(
+        id,
+        TaskAssetSource.valueOf(resultSet.getString("source")),
+        resultSet.getString("source_ref"),
+        projectId,
+        resultSet.getString("name"),
+        resultSet.getString("task_type"),
+        TaskAssetStatus.valueOf(resultSet.getString("status")),
+        new TaskRevisionRef(id, revisionId, revisionNo),
+        instant(resultSet.getTimestamp("create_time")),
+        instant(resultSet.getTimestamp("update_time")));
+  }
+
+  private static Instant instant(Timestamp value) {
+    return value == null ? null : value.toInstant();
+  }
+}

--- a/yak-ops-business/yak-ops-business-task-catalog/src/main/java/io/yak/ops/business/taskcatalog/repository/TaskAssetRepository.java
+++ b/yak-ops-business/yak-ops-business-task-catalog/src/main/java/io/yak/ops/business/taskcatalog/repository/TaskAssetRepository.java
@@ -1,0 +1,33 @@
+package io.yak.ops.business.taskcatalog.repository;
+
+import io.yak.ops.business.taskcatalog.domain.TaskAsset;
+import io.yak.ops.spi.task.model.TaskAssetSource;
+import io.yak.ops.spi.task.model.TaskAssetStatus;
+import java.util.List;
+import java.util.Optional;
+
+/** Persistent Task Catalog port. */
+public interface TaskAssetRepository {
+
+  TaskAsset upsertPublished(
+      TaskAssetSource source,
+      String sourceRef,
+      Long projectId,
+      String name,
+      String taskType,
+      long revisionId,
+      int revisionNo);
+
+  Optional<TaskAsset> findBySource(TaskAssetSource source, String sourceRef);
+
+  List<TaskAsset> list(TaskAssetSource source, TaskAssetStatus status, String keyword);
+
+  boolean updateSourceMetadata(
+      TaskAssetSource source,
+      String sourceRef,
+      Long projectId,
+      String name,
+      String taskType);
+
+  boolean updateStatus(TaskAssetSource source, String sourceRef, TaskAssetStatus status);
+}

--- a/yak-ops-business/yak-ops-business-task-catalog/src/main/java/io/yak/ops/business/taskcatalog/service/TaskCatalogService.java
+++ b/yak-ops-business/yak-ops-business-task-catalog/src/main/java/io/yak/ops/business/taskcatalog/service/TaskCatalogService.java
@@ -1,0 +1,131 @@
+package io.yak.ops.business.taskcatalog.service;
+
+import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
+import io.yak.ops.business.taskcatalog.domain.TaskAsset;
+import io.yak.ops.business.taskcatalog.repository.TaskAssetRepository;
+import io.yak.ops.spi.task.model.TaskAssetSource;
+import io.yak.ops.spi.task.model.TaskAssetStatus;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import org.springframework.stereotype.Service;
+
+/** Application service for the published task asset catalog. */
+@Service
+@ConditionalOnDataSourceEnabled
+public class TaskCatalogService {
+
+  private final TaskAssetRepository repository;
+
+  public TaskCatalogService(TaskAssetRepository repository) {
+    this.repository = repository;
+  }
+
+  public TaskAsset publish(
+      TaskAssetSource source,
+      String sourceRef,
+      Long projectId,
+      String name,
+      String taskType,
+      long revisionId,
+      int revisionNo) {
+    if (source == null) throw new IllegalArgumentException("任务资产来源不能为空");
+    if (revisionId <= 0L) throw new IllegalArgumentException("任务版本 ID 必须大于 0");
+    if (revisionNo <= 0) throw new IllegalArgumentException("任务版本号必须大于 0");
+    return repository.upsertPublished(
+        source,
+        normalizeSourceRef(sourceRef),
+        normalizeProjectId(projectId),
+        normalizeName(name),
+        normalizeTaskType(taskType),
+        revisionId,
+        revisionNo);
+  }
+
+  public List<TaskAsset> list(String source, String status, String keyword) {
+    return repository.list(
+        parseSource(source),
+        parseStatus(status),
+        normalizeKeyword(keyword));
+  }
+
+  public Optional<TaskAsset> findBySource(TaskAssetSource source, String sourceRef) {
+    if (source == null) return Optional.empty();
+    return repository.findBySource(source, normalizeSourceRef(sourceRef));
+  }
+
+  /** Keeps an already-published asset aligned with its source node without creating draft assets. */
+  public void updateSourceMetadata(
+      TaskAssetSource source,
+      String sourceRef,
+      Long projectId,
+      String name,
+      String taskType) {
+    if (source == null) throw new IllegalArgumentException("任务资产来源不能为空");
+    repository.updateSourceMetadata(
+        source,
+        normalizeSourceRef(sourceRef),
+        normalizeProjectId(projectId),
+        normalizeName(name),
+        normalizeTaskType(taskType));
+  }
+
+  /** Offline assets disappear from new orchestration discovery while retaining their revision pointer. */
+  public void offlineSource(TaskAssetSource source, String sourceRef) {
+    if (source == null) throw new IllegalArgumentException("任务资产来源不能为空");
+    repository.updateStatus(
+        source,
+        normalizeSourceRef(sourceRef),
+        TaskAssetStatus.OFFLINE);
+  }
+
+  private TaskAssetSource parseSource(String value) {
+    if (value == null || value.isBlank()) return null;
+    try {
+      return TaskAssetSource.valueOf(value.trim().toUpperCase(Locale.ROOT));
+    } catch (IllegalArgumentException exception) {
+      throw new IllegalArgumentException("未知任务资产来源：" + value, exception);
+    }
+  }
+
+  private TaskAssetStatus parseStatus(String value) {
+    String normalized = value == null || value.isBlank() ? "ONLINE" : value.trim();
+    try {
+      return TaskAssetStatus.valueOf(normalized.toUpperCase(Locale.ROOT));
+    } catch (IllegalArgumentException exception) {
+      throw new IllegalArgumentException("未知任务资产状态：" + value, exception);
+    }
+  }
+
+  private String normalizeSourceRef(String value) {
+    if (value == null || value.isBlank()) throw new IllegalArgumentException("sourceRef 不能为空");
+    String normalized = value.trim();
+    if (normalized.length() > 128) throw new IllegalArgumentException("sourceRef 不能超过 128 个字符");
+    return normalized;
+  }
+
+  private String normalizeName(String value) {
+    if (value == null || value.isBlank()) throw new IllegalArgumentException("任务资产名称不能为空");
+    String normalized = value.trim();
+    if (normalized.length() > 200) throw new IllegalArgumentException("任务资产名称不能超过 200 个字符");
+    return normalized;
+  }
+
+  private String normalizeTaskType(String value) {
+    if (value == null || value.isBlank()) throw new IllegalArgumentException("taskType 不能为空");
+    String normalized = value.trim().toUpperCase(Locale.ROOT);
+    if (normalized.length() > 64) throw new IllegalArgumentException("taskType 不能超过 64 个字符");
+    return normalized;
+  }
+
+  private Long normalizeProjectId(Long value) {
+    return value == null || value <= 0L ? null : value;
+  }
+
+  private String normalizeKeyword(String value) {
+    if (value == null || value.isBlank()) return null;
+    String normalized = value.trim();
+    if (normalized.length() > 200) throw new IllegalArgumentException("搜索关键字不能超过 200 个字符");
+    return normalized;
+  }
+}

--- a/yak-ops-business/yak-ops-business-task-catalog/src/main/resources/db/migration/yak-task-catalog/V1__create_task_asset_catalog.sql
+++ b/yak-ops-business/yak-ops-business-task-catalog/src/main/resources/db/migration/yak-task-catalog/V1__create_task_asset_catalog.sql
@@ -1,0 +1,22 @@
+-- Stage 5: source-neutral published task asset catalog.
+-- The catalog stores discovery metadata and a current revision pointer only;
+-- immutable task content remains owned by the source domain.
+
+CREATE TABLE IF NOT EXISTS yak_task_asset (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    source VARCHAR(32) NOT NULL,
+    source_ref VARCHAR(128) NOT NULL,
+    project_id BIGINT NULL,
+    name VARCHAR(200) NOT NULL,
+    task_type VARCHAR(64) NOT NULL,
+    status VARCHAR(32) NOT NULL,
+    current_revision_id BIGINT NOT NULL,
+    current_revision_no INT NOT NULL,
+    create_time DATETIME(6) NOT NULL,
+    update_time DATETIME(6) NOT NULL,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_yak_task_asset_source_ref (source, source_ref),
+    KEY idx_yak_task_asset_catalog (status, source, task_type),
+    KEY idx_yak_task_asset_project (project_id, status),
+    KEY idx_yak_task_asset_update (update_time)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/yak-ops-business/yak-ops-business-task-catalog/src/test/java/io/yak/ops/business/taskcatalog/service/TaskCatalogServiceTest.java
+++ b/yak-ops-business/yak-ops-business-task-catalog/src/test/java/io/yak/ops/business/taskcatalog/service/TaskCatalogServiceTest.java
@@ -1,0 +1,80 @@
+package io.yak.ops.business.taskcatalog.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.taskcatalog.domain.TaskAsset;
+import io.yak.ops.business.taskcatalog.repository.TaskAssetRepository;
+import io.yak.ops.spi.task.model.TaskAssetSource;
+import io.yak.ops.spi.task.model.TaskAssetStatus;
+import io.yak.ops.spi.task.model.TaskRevisionRef;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class TaskCatalogServiceTest {
+
+  @Test
+  void publishCreatesOrAdvancesOneOnlineAsset() {
+    TaskAssetRepository repository = mock(TaskAssetRepository.class);
+    TaskCatalogService service = new TaskCatalogService(repository);
+    TaskAsset expected = asset(9L, 101L, 2);
+    when(repository.upsertPublished(
+            TaskAssetSource.DATA_DEVELOPMENT,
+            "12",
+            7L,
+            "今天统计",
+            "SQL",
+            101L,
+            2))
+        .thenReturn(expected);
+
+    TaskAsset result = service.publish(
+        TaskAssetSource.DATA_DEVELOPMENT,
+        " 12 ",
+        7L,
+        " 今天统计 ",
+        "sql",
+        101L,
+        2);
+
+    assertEquals(expected, result);
+    assertEquals(2, result.currentRevision().revisionNo());
+  }
+
+  @Test
+  void listDefaultsToOnlineAndNormalizesFilters() {
+    TaskAssetRepository repository = mock(TaskAssetRepository.class);
+    TaskCatalogService service = new TaskCatalogService(repository);
+    when(repository.list(
+            TaskAssetSource.DATA_DEVELOPMENT,
+            TaskAssetStatus.ONLINE,
+            "统计"))
+        .thenReturn(List.of(asset(9L, 101L, 2)));
+
+    List<TaskAsset> result = service.list("data_development", null, " 统计 ");
+
+    assertEquals(1, result.size());
+    verify(repository).list(
+        TaskAssetSource.DATA_DEVELOPMENT,
+        TaskAssetStatus.ONLINE,
+        "统计");
+  }
+
+  private TaskAsset asset(long id, long revisionId, int revisionNo) {
+    Instant now = Instant.parse("2026-08-12T03:30:00Z");
+    return new TaskAsset(
+        id,
+        TaskAssetSource.DATA_DEVELOPMENT,
+        "12",
+        7L,
+        "今天统计",
+        "SQL",
+        TaskAssetStatus.ONLINE,
+        new TaskRevisionRef(id, revisionId, revisionNo),
+        now,
+        now);
+  }
+}

--- a/yak-ops-ui/src/pages/workflow/definition/canvas/WorkflowTaskPicker.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/WorkflowTaskPicker.tsx
@@ -1,8 +1,10 @@
-import { Input, Popover } from 'antd';
+import { API_SUCCESS_CODE, type ApiResponse } from '@/services/http/response';
+import { request } from '@umijs/max';
+import { Input, Popover, Tooltip } from 'antd';
 import type { PopoverProps } from 'antd';
 import { Search } from 'lucide-react';
 import type { ReactElement } from 'react';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import WorkflowNodeIcon from './node/icons/WorkflowNodeIcon';
 import type { WorkflowCanvasTaskOption } from './types';
 
@@ -18,6 +20,28 @@ interface WorkflowTaskPickerProps {
   disabled?: boolean;
   defaultCategory?: WorkflowTaskCategory;
 }
+
+interface TaskCatalogRevisionRef {
+  taskAssetId: string | number;
+  taskRevisionId: string | number;
+  revisionNo: number;
+}
+
+interface TaskCatalogAsset {
+  id: string | number;
+  source: string;
+  sourceRef: string;
+  name: string;
+  taskType: string;
+  status: string;
+  currentRevision: TaskCatalogRevisionRef;
+}
+
+type PickerTaskOption = WorkflowCanvasTaskOption & {
+  disabled?: boolean;
+  disabledReason?: string;
+  meta?: string;
+};
 
 const CATEGORY_META: Array<{
   key: WorkflowTaskCategory;
@@ -67,6 +91,16 @@ const createSearchState = (): Record<WorkflowTaskCategory, string> => ({
   quality: '',
 });
 
+const catalogOption = (asset: TaskCatalogAsset): PickerTaskOption => ({
+  id: `task-asset:${asset.id}`,
+  label: asset.name,
+  typeLabel: '数据开发',
+  taskType: asset.taskType,
+  disabled: true,
+  disabledReason: `已发布 v${asset.currentRevision.revisionNo}；固定版本引用将在下一阶段接入后开放添加到工作流`,
+  meta: `已发布 v${asset.currentRevision.revisionNo}`,
+});
+
 const WorkflowTaskPicker = ({
   options,
   onSelect,
@@ -80,6 +114,8 @@ const WorkflowTaskPicker = ({
   const [innerOpen, setInnerOpen] = useState(false);
   const [activeCategory, setActiveCategory] = useState<WorkflowTaskCategory>(defaultCategory);
   const [searchText, setSearchText] = useState(createSearchState);
+  const [catalogOptions, setCatalogOptions] = useState<PickerTaskOption[]>([]);
+  const [catalogLoading, setCatalogLoading] = useState(false);
   const open = controlledOpen ?? innerOpen;
 
   const handleOpenChange = (nextOpen: boolean) => {
@@ -88,8 +124,39 @@ const WorkflowTaskPicker = ({
     onOpenChange?.(nextOpen);
   };
 
+  useEffect(() => {
+    if (!open) return undefined;
+    let active = true;
+    setCatalogLoading(true);
+
+    void request<ApiResponse<TaskCatalogAsset[]>>('/api/v1/task-catalog/assets', {
+      params: {
+        source: 'DATA_DEVELOPMENT',
+        status: 'ONLINE',
+      },
+    })
+      .then((response) => {
+        if (!active) return;
+        if (response.code !== API_SUCCESS_CODE || !Array.isArray(response.data)) {
+          setCatalogOptions([]);
+          return;
+        }
+        setCatalogOptions(response.data.map(catalogOption));
+      })
+      .catch(() => {
+        if (active) setCatalogOptions([]);
+      })
+      .finally(() => {
+        if (active) setCatalogLoading(false);
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [open]);
+
   const groupedOptions = useMemo(() => {
-    const grouped: Record<WorkflowTaskCategory, WorkflowCanvasTaskOption[]> = {
+    const grouped: Record<WorkflowTaskCategory, PickerTaskOption[]> = {
       sync: [],
       development: [],
       quality: [],
@@ -98,9 +165,12 @@ const WorkflowTaskPicker = ({
     options.forEach((option) => {
       grouped[resolveTaskCategory(option)].push(option);
     });
+    catalogOptions.forEach((option) => {
+      grouped[resolveTaskCategory(option)].push(option);
+    });
 
     return grouped;
-  }, [options]);
+  }, [catalogOptions, options]);
 
   const activeMeta = CATEGORY_META.find((item) => item.key === activeCategory) ?? CATEGORY_META[0];
   const keyword = searchText[activeCategory].trim().toLowerCase();
@@ -156,24 +226,59 @@ const WorkflowTaskPicker = ({
 
       <div className="border-t border-[#f0f1f3]">
         <div className="max-h-[420px] overflow-y-auto p-1">
-          {filteredOptions.length ? filteredOptions.map((option) => (
-            <button
-              key={option.id}
-              type="button"
-              className="flex h-9 w-full items-center rounded-lg border-0 bg-transparent px-3 text-left transition-colors hover:bg-[#f5f6f7] focus:bg-[#f5f6f7] focus:outline-none"
-              onClick={() => {
-                onSelect(option.id);
-                handleOpenChange(false);
-              }}
-            >
-              <WorkflowNodeIcon taskType={resolveIconTaskType(option)} size="xs" />
-              <span className="ml-2 min-w-0 flex-1 truncate text-[13px] font-medium text-[#475467]">
-                {option.label}
-              </span>
-            </button>
-          )) : (
+          {filteredOptions.length ? filteredOptions.map((option) => {
+            const optionDisabled = Boolean(option.disabled);
+            const button = (
+              <button
+                type="button"
+                disabled={optionDisabled}
+                className={[
+                  'flex h-9 w-full items-center rounded-lg border-0 bg-transparent px-3 text-left transition-colors focus:outline-none',
+                  optionDisabled
+                    ? 'cursor-not-allowed text-[#98a2b3]'
+                    : 'hover:bg-[#f5f6f7] focus:bg-[#f5f6f7]',
+                ].join(' ')}
+                onClick={() => {
+                  if (optionDisabled) return;
+                  onSelect(option.id);
+                  handleOpenChange(false);
+                }}
+              >
+                <span className={optionDisabled ? 'opacity-55' : undefined}>
+                  <WorkflowNodeIcon taskType={resolveIconTaskType(option)} size="xs" />
+                </span>
+                <span
+                  className={[
+                    'ml-2 min-w-0 flex-1 truncate text-[13px] font-medium',
+                    optionDisabled ? 'text-[#667085]' : 'text-[#475467]',
+                  ].join(' ')}
+                >
+                  {option.label}
+                </span>
+                {option.meta ? (
+                  <span className="ml-2 shrink-0 text-[10px] font-medium text-[#98a2b3]">
+                    {option.meta}
+                  </span>
+                ) : null}
+              </button>
+            );
+
+            return (
+              <Tooltip
+                key={option.id}
+                title={optionDisabled ? option.disabledReason : undefined}
+                placement="right"
+              >
+                <span className="block">{button}</span>
+              </Tooltip>
+            );
+          }) : (
             <div className="flex h-16 items-center justify-center text-[11px] text-[#98a2b3]">
-              {keyword ? '没有匹配的任务' : `暂无${activeMeta.label}任务`}
+              {catalogLoading && activeCategory === 'development'
+                ? '正在加载已发布任务...'
+                : keyword
+                  ? '没有匹配的任务'
+                  : `暂无${activeMeta.label}任务`}
             </div>
           )}
         </div>


### PR DESCRIPTION
## 背景

前 4 个阶段已经完成统一 Task 模型、Task Plugin / Registry、Data Development Draft/Revision 生命周期和真实 SQL 手动执行。本 PR 完成第 5 阶段：引入平台级 `TaskAsset / Task Catalog`，让数据开发任务发布后自动成为可发现的任务资产，并在 Workflow 的「数据开发」任务选择器中展示。

本阶段严格保持边界：**只完成发布资产化 + Workflow 发现，不提前实现 Workflow 的固定版本绑定。**

## 1. 新增独立 Task Catalog 业务模块

新增：

```text
yak-ops-business/yak-ops-business-task-catalog
```

核心结构：

```text
TaskAsset
TaskAssetRepository
JdbcTaskAssetRepository
TaskCatalogService
TaskCatalogController
TaskCatalogPersistenceConfiguration
```

Task Catalog 是 source-neutral 的平台层，不依赖 Data Development。后续 `DATA_INTEGRATION / DATA_QUALITY / INTERNAL` 都可以复用同一套资产目录。

## 2. TaskAsset 持久化

新增独立 Flyway：

```text
classpath:db/migration/yak-task-catalog
flyway_schema_history_task_catalog
```

新增表：

```text
yak_task_asset
  id
  source
  source_ref
  project_id
  name
  task_type
  status
  current_revision_id
  current_revision_no
  create_time
  update_time
```

`(source, source_ref)` 唯一，因此：

```text
今天统计 publish v1 -> 创建一个 TaskAsset
今天统计 publish v2 -> 更新同一个 TaskAsset.currentRevision
```

不会每发布一个版本就创建一份新资产。

TaskAsset 不复制 SQL / configJson；可执行内容仍由不可变 TaskRevision 持有。

## 3. Data Development 发布自动进入 Task Catalog

发布链路现在为：

```text
DevelopmentNode
    ↓
TaskDraft
    ↓ publish
TaskRevision vN
    ↓
TaskCatalogService.publish(...)
    ↓
TaskAsset ONLINE
```

发布成功后写入：

```text
source = DATA_DEVELOPMENT
sourceRef = development node id
taskType = SQL / ...
currentRevisionId = published revision id
currentRevisionNo = vN
status = ONLINE
```

发布与 Catalog upsert 继续加入同一个 `yakBusinessTransactionManager` 事务。

### 幂等发布

未变化 Draft 重复发布仍然复用原 TaskRevision，但会再次执行 Catalog upsert，用于自动修复缺失/陈旧的资产目录记录，不制造重复 Revision。

## 4. Source 生命周期同步

已发布数据开发节点：

- 重命名 -> 同步 TaskAsset 名称/元数据；
- 删除 -> TaskAsset 标记 `OFFLINE`；
- Offline 不删除最新 Revision 指针，给后续历史 Workflow 引用保留基础。

未发布节点不会因为 rename/delete 被动创建 TaskAsset。

## 5. Task Catalog API

新增：

```http
GET /api/v1/task-catalog/assets
```

支持：

```text
source
status
keyword
```

`status` 默认 `ONLINE`，避免 Workflow 等消费端误展示已下线任务。

典型返回：

```json
{
  "id": "12",
  "source": "DATA_DEVELOPMENT",
  "sourceRef": "10001",
  "name": "今天统计",
  "taskType": "SQL",
  "status": "ONLINE",
  "currentRevision": {
    "taskAssetId": "12",
    "taskRevisionId": "90001",
    "revisionNo": 2
  }
}
```

> Stage 6 已在独立后续 PR 中继续完善固定 Revision 绑定；Stage 5 仍保持 discovery-only 边界。

## 6. Workflow「数据开发」自动展示已发布资产

`WorkflowTaskPicker` 打开时加载：

```http
GET /api/v1/task-catalog/assets?source=DATA_DEVELOPMENT&status=ONLINE
```

发布后的 SQL 会自动出现在已有「数据开发」分类，并显示：

```text
今天统计                       已发布 v2
```

### Stage 5 的安全边界

Catalog 任务当前**只展示，不允许添加到画布**，并通过 Tooltip 说明原因。

这是有意设计的：现有 Workflow 仍只持久化 legacy `taskId`，而下一阶段需要正式保存：

```text
taskAssetId + taskRevisionId
```

如果本阶段直接允许拖入，会制造一套临时绑定格式并留下迁移债务。因此 Stage 6 完成固定 Revision 引用后再开放选择。

## 7. Tests

新增/更新单测覆盖：

- TaskAsset publish/upsert 参数与状态；
- Catalog 查询默认 `ONLINE`；
- Data Development publish -> Task Catalog；
- 未变化 Draft 重复 publish -> 复用 Revision + Catalog reconciliation；
- 节点 rename -> Catalog metadata 同步；
- 节点 delete -> Asset OFFLINE。

## 8. 文档

新增：

```text
docs/task-catalog-stage-5.md
```

记录 Task Catalog 数据模型、发布事务、API、Workflow discovery 和 Stage 6 边界。

## Validation

分支已整理为单个提交，并确认相对 `main`：

```text
ahead 1
behind 0
```

本次通过 GitHub connector 直接落代码，没有完整本地 checkout，因此尚未实际执行 Maven / npm 全量构建。合并前建议执行：

```bash
mvn -pl yak-ops-business/yak-ops-business-task-catalog -am test
mvn -pl yak-ops-business/yak-ops-business-data-development -am test
mvn -pl yak-ops-boot -am package -DskipTests

cd yak-ops-ui
npm run tsc
npm run build
```

真实 MySQL/MariaDB 建议回归：首次 publish v1、publish v2、重复 publish、rename、delete/offline，以及 Workflow 数据开发任务列表刷新。

## Deliberately out of scope

本阶段不做：

- Workflow node 持久化 `taskAssetId + taskRevisionId`
- Catalog Task 拖入/添加到 Workflow
- Workflow 自动升级到最新 Revision
- Workflow/Schedule 真实 SQL Task Runtime
- durable TaskExecution / Attempt
- Shell / Python / HTTP execution
- Worker / Docker / Kubernetes backend

## Next

Stage 6：Workflow 节点正式绑定 `TaskAsset + immutable TaskRevision`，发布新版本后原 Workflow 保持旧 Revision，并提供显式升级能力。