### PR TITLE
feat(workflow): bind catalog tasks to immutable revisions

### DIFF
--- a/docs/workflow-task-revision-stage-6.md
+++ b/docs/workflow-task-revision-stage-6.md
@@ -1,0 +1,324 @@
+# Stage 6 — Workflow 固定 TaskAsset + immutable TaskRevision
+
+## 目标
+
+Stage 5 已经把数据开发发布任务提升为平台级 `TaskAsset`，Workflow 可以发现这些资产。
+
+Stage 6 解决的是另一个问题：**Workflow 引用任务时必须固定到一个不可变版本，而不是每次运行都读取 TaskAsset 的 latest revision。**
+
+目标语义：
+
+```text
+Data Development
+  今天统计 v1
+       ↓ publish
+TaskAsset #12
+  currentRevision = v1
+       ↓ add to Workflow
+Workflow Node
+  taskAssetId = 12
+  taskRevisionId = 101
+  taskRevisionNo = 1
+       ↓
+Workflow v1 发布并固定 TaskRevision v1
+
+随后数据开发发布 今天统计 v2：
+
+TaskAsset #12
+  currentRevision = v2
+
+Workflow 草稿/已发布版本仍固定 v1
+  ↓ 用户显式点击“升级到 v2”
+Workflow draft -> v2
+  ↓ 重新发布 Workflow
+Workflow v2 -> TaskRevision v2
+```
+
+## 设计原则
+
+### 1. TaskAsset 是逻辑身份，TaskRevision 是执行身份
+
+`TaskAsset` 表示“今天统计”这个长期存在的任务资产；`TaskRevision` 表示它某次发布产生的不可变执行版本。
+
+Workflow 节点正式保存：
+
+```text
+taskId          = task-asset:12
+taskAssetId     = 12
+taskRevisionId  = 101
+taskRevisionNo  = 1
+```
+
+其中 `taskId` 是兼容现有 Workflow / runtime 结构的稳定逻辑 ID，真正保证可复现的是 `taskAssetId + taskRevisionId`。
+
+### 2. 普通保存绝不静默升级
+
+当 Workflow 已经固定 `v1`，即使 Task Catalog 当前已经是 `v2`：
+
+```text
+保存工作流
+移动节点
+修改重试次数
+修改输入映射
+重新打开编辑器
+```
+
+都不会把绑定从 v1 改成 v2。
+
+只有显式升级动作才能推进 Revision。
+
+### 3. 升级先改草稿，再重新发布
+
+显式升级接口：
+
+```http
+POST /api/v1/workflows/definitions/{workflowId}/nodes/{nodeId}/upgrade-task-revision
+```
+
+该操作只修改 Workflow draft：
+
+```text
+v1 -> v2
+```
+
+不会修改当前 active WorkflowVersion。
+
+因此线上工作流仍然使用旧版本，直到用户重新发布 Workflow。
+
+### 4. 已发布 WorkflowVersion 自包含不可变执行快照
+
+Workflow 发布时，从固定 Revision 解析：
+
+```text
+TaskDefinition
+checksum
+task type
+configJson
+revisionNo
+```
+
+并继续写入现有 `TaskVersionSnapshot`。
+
+正式运行读取 WorkflowVersion 的 snapshot，而不是重新查询 TaskAsset.currentRevision。
+
+因此：
+
+```text
+TaskAsset currentRevision: v1 -> v2 -> v3
+```
+
+不会改变已经发布的 Workflow v1。
+
+## Source-neutral Revision Resolver
+
+Task Catalog 新增扩展边界：
+
+```text
+TaskAssetRevisionProvider
+        ↓
+TaskAssetSource
+        ↓
+resolve(sourceRef, revisionId)
+        ↓
+TaskSourceRevision
+```
+
+当前接入：
+
+```text
+DATA_DEVELOPMENT
+  -> DataDevelopmentTaskRevisionProvider
+  -> DevelopmentTaskRevisionRepository.findById(...)
+```
+
+Task Catalog 本身不依赖 Data Development 的 Repository/表结构。
+
+未来可以继续增加：
+
+```text
+DATA_INTEGRATION -> DataIntegrationTaskRevisionProvider
+DATA_QUALITY     -> DataQualityTaskRevisionProvider
+INTERNAL         -> InternalTaskRevisionProvider
+```
+
+而 Workflow 不需要感知具体来源。
+
+## Task Catalog API
+
+Stage 6 增加资产详情：
+
+```http
+GET /api/v1/task-catalog/assets/{assetId}
+```
+
+用于首次固定 Revision 和刷新最新版本信息。
+
+TaskAsset / Revision 的 Long ID 对前端统一按字符串输出，避免 JavaScript Number 精度问题。
+
+## Workflow API 模型
+
+Workflow Node 返回：
+
+```json
+{
+  "id": "task-node-1",
+  "taskId": "task-asset:12",
+  "taskAssetId": "12",
+  "taskRevisionId": "101",
+  "taskRevisionNo": 1,
+  "taskAssetName": "今天统计",
+  "taskType": "SQL",
+  "taskAssetStatus": "ONLINE",
+  "latestTaskRevisionId": "102",
+  "latestTaskRevisionNo": 2,
+  "taskRevisionUpdateAvailable": true
+}
+```
+
+这里区分两组信息：
+
+```text
+固定状态：taskRevisionId / taskRevisionNo
+发现状态：latestTaskRevisionId / latestTaskRevisionNo
+```
+
+发现新版本不会改变固定状态。
+
+## Workflow UI
+
+### 任务选择器
+
+Stage 5 的数据开发资产由“只展示、不可选择”改为可添加。
+
+列表继续显示：
+
+```text
+今天统计                         已发布 v2
+```
+
+新节点第一次保存时固定选择时对应的 published revision。
+
+### 节点 Inspector
+
+TaskAsset 节点新增“任务版本”区域：
+
+```text
+任务版本
+
+当前固定    v1
+资产最新    v2
+资产状态    已上线
+
+[升级到 v2]
+```
+
+没有新版本时：
+
+```text
+当前固定    v2
+资产最新    v2
+当前固定版本已是最新版本
+```
+
+升级成功后提示重新发布 Workflow 后才会影响 active version。
+
+## Workflow JSON 持久化
+
+Stage 6 不新增 Workflow DB migration。
+
+现有 Workflow definition/version 已将 `WorkflowNodeSpec` 作为 JSON 持久化，因此新增：
+
+```text
+taskAssetId
+taskRevisionId
+taskRevisionNo
+```
+
+会自然进入 draft/version JSON。
+
+Legacy Workflow 节点仍然保持：
+
+```text
+taskId = 原 TaskRegistry ID
+```
+
+并继续走原有兼容路径。
+
+## 生命周期
+
+### Data Development 发布新版本
+
+只推进：
+
+```text
+TaskAsset.currentRevision
+```
+
+不扫描、不修改 Workflow。
+
+### TaskAsset OFFLINE
+
+新的 Workflow discovery 不再展示该资产。
+
+已有 Workflow 的固定 Revision 信息仍然保留，因此历史 WorkflowVersion 可继续保持可解释、可审计。
+
+Stage 6 禁止把 OFFLINE 资产显式升级到最新版本。
+
+### TaskAsset 重命名
+
+Workflow 的逻辑绑定不变：
+
+```text
+taskAssetId + taskRevisionId
+```
+
+界面展示名称可读取 Catalog 当前 metadata，不影响执行版本。
+
+## 测试重点
+
+新增测试覆盖以下不变量：
+
+1. Workflow draft 固定 TaskAsset v1；
+2. Workflow 发布 v1 后保存不可变 snapshot；
+3. TaskAsset currentRevision 推进到 v2 时，Workflow 仍固定 v1；
+4. API 返回 `updateAvailable=true`；
+5. 用户显式升级后只改变 draft，不改变 active WorkflowVersion；
+6. 重新发布后产生 Workflow v2，并固定 TaskRevision v2。
+
+## Runtime 边界
+
+Stage 6 完成的是 **Workflow binding / version reproducibility**，不是新的执行后端。
+
+Stage 4 已经支持 Data Development 中 SQL 手动真实执行，但当前 Workflow `TaskExecutionGateway` 尚未注册 SQL `TaskExecutor`。
+
+因此本阶段可以完成：
+
+```text
+SQL TaskAsset
+  -> 添加 Workflow
+  -> 固定 SQL TaskRevision
+  -> 保存/发布 WorkflowVersion
+  -> 检测/显式升级 Revision
+```
+
+但 SQL 节点进入 Workflow test-run / run 时，仍需要后续阶段把 SQL runtime 正式接入 `TaskExecutionGateway`。
+
+本阶段不通过临时旁路执行 SQL，避免 Workflow 和 Data Development 出现两套执行语义。
+
+## 后续建议
+
+下一阶段可以聚焦统一执行层：
+
+```text
+TaskVersionSnapshot
+        ↓
+TaskExecutionGateway
+        ↓
+SQL TaskExecutor
+        ↓
+DataSource execution / session
+        ↓
+TaskExecution status + output
+```
+
+在这一层完成后，`TaskAsset -> immutable Revision -> WorkflowVersion -> Runtime` 就形成完整闭环。

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/DevelopmentTaskRevisionRepository.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/DevelopmentTaskRevisionRepository.java
@@ -18,6 +18,8 @@ public interface DevelopmentTaskRevisionRepository {
       TaskDefinition definition,
       String checksum);
 
+  Optional<DevelopmentTaskRevision> findById(Long revisionId);
+
   Optional<DevelopmentTaskRevision> findLatestByNodeId(Long nodeId);
 
   Optional<DevelopmentTaskRevision> findByRevisionNo(Long nodeId, int revisionNo);

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/DevelopmentTaskRevisionRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/DevelopmentTaskRevisionRepositoryAdapter.java
@@ -50,6 +50,12 @@ public class DevelopmentTaskRevisionRepositoryAdapter
   }
 
   @Override
+  public Optional<DevelopmentTaskRevision> findById(Long revisionId) {
+    if (revisionId == null || revisionId <= 0L) return Optional.empty();
+    return Optional.ofNullable(mapper.selectById(revisionId)).map(this::toDomain);
+  }
+
+  @Override
   public Optional<DevelopmentTaskRevision> findLatestByNodeId(Long nodeId) {
     return Optional.ofNullable(mapper.selectOne(
             new LambdaQueryWrapper<DevelopmentTaskRevisionPO>()

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DataDevelopmentTaskRevisionProvider.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DataDevelopmentTaskRevisionProvider.java
@@ -1,0 +1,55 @@
+package io.yak.ops.business.development.service;
+
+import io.yak.ops.business.development.domain.DevelopmentTaskRevision;
+import io.yak.ops.business.development.repository.DevelopmentTaskRevisionRepository;
+import io.yak.ops.business.taskcatalog.spi.TaskAssetRevisionProvider;
+import io.yak.ops.business.taskcatalog.spi.TaskSourceRevision;
+import io.yak.ops.spi.task.model.TaskAssetSource;
+import java.util.Optional;
+import org.springframework.stereotype.Component;
+
+/** Resolves Data Development immutable revisions for source-neutral Task Catalog consumers. */
+@Component
+public class DataDevelopmentTaskRevisionProvider implements TaskAssetRevisionProvider {
+
+  private final DevelopmentTaskRevisionRepository revisionRepository;
+
+  public DataDevelopmentTaskRevisionProvider(
+      DevelopmentTaskRevisionRepository revisionRepository) {
+    this.revisionRepository = revisionRepository;
+  }
+
+  @Override
+  public TaskAssetSource source() {
+    return TaskAssetSource.DATA_DEVELOPMENT;
+  }
+
+  @Override
+  public Optional<TaskSourceRevision> resolve(String sourceRef, long revisionId) {
+    Long nodeId = parseNodeId(sourceRef);
+    return revisionRepository.findById(revisionId)
+        .filter(revision -> nodeId.equals(revision.nodeId()))
+        .map(this::toSourceRevision);
+  }
+
+  private TaskSourceRevision toSourceRevision(DevelopmentTaskRevision revision) {
+    return new TaskSourceRevision(
+        revision.id(),
+        revision.revisionNo(),
+        revision.definition(),
+        revision.checksum());
+  }
+
+  private Long parseNodeId(String sourceRef) {
+    if (sourceRef == null || sourceRef.isBlank()) {
+      throw new IllegalArgumentException("Data Development sourceRef 不能为空");
+    }
+    try {
+      long value = Long.parseLong(sourceRef.trim());
+      if (value <= 0L) throw new NumberFormatException("not positive");
+      return value;
+    } catch (NumberFormatException exception) {
+      throw new IllegalArgumentException("非法 Data Development sourceRef：" + sourceRef, exception);
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/DataDevelopmentTaskRevisionProviderTest.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/DataDevelopmentTaskRevisionProviderTest.java
@@ -1,0 +1,36 @@
+package io.yak.ops.business.development.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.development.domain.DevelopmentTaskRevision;
+import io.yak.ops.business.development.repository.DevelopmentTaskRevisionRepository;
+import io.yak.ops.spi.task.model.TaskAssetSource;
+import io.yak.ops.spi.task.model.TaskDefinition;
+import java.time.Instant;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class DataDevelopmentTaskRevisionProviderTest {
+
+  @Test
+  void resolvesOnlyRevisionOwnedByRequestedDevelopmentNode() {
+    DevelopmentTaskRevisionRepository repository = mock(DevelopmentTaskRevisionRepository.class);
+    DataDevelopmentTaskRevisionProvider provider = new DataDevelopmentTaskRevisionProvider(repository);
+    DevelopmentTaskRevision revision = new DevelopmentTaskRevision(
+        101L,
+        12L,
+        3,
+        7L,
+        new TaskDefinition("SQL", 1, "select 1", "{}"),
+        "checksum",
+        Instant.parse("2026-08-12T00:00:00Z"));
+    when(repository.findById(101L)).thenReturn(Optional.of(revision));
+
+    assertEquals(TaskAssetSource.DATA_DEVELOPMENT, provider.source());
+    assertEquals(3, provider.resolve("12", 101L).orElseThrow().revisionNo());
+    assertTrue(provider.resolve("13", 101L).isEmpty());
+  }
+}

--- a/yak-ops-business/yak-ops-business-task-catalog/src/main/java/io/yak/ops/business/taskcatalog/controller/v1/TaskCatalogController.java
+++ b/yak-ops-business/yak-ops-business-task-catalog/src/main/java/io/yak/ops/business/taskcatalog/controller/v1/TaskCatalogController.java
@@ -8,6 +8,7 @@ import io.yak.ops.business.taskcatalog.domain.TaskAsset;
 import io.yak.ops.business.taskcatalog.service.TaskCatalogService;
 import java.util.List;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -32,5 +33,11 @@ public class TaskCatalogController {
       @RequestParam(value = "status", required = false, defaultValue = "ONLINE") String status,
       @RequestParam(value = "keyword", required = false) String keyword) {
     return Result.success(service.list(source, status, keyword));
+  }
+
+  @Operation(summary = "查询任务资产详情")
+  @GetMapping("/{assetId}")
+  public Result<TaskAsset> detail(@PathVariable("assetId") long assetId) {
+    return Result.success(service.get(assetId));
   }
 }

--- a/yak-ops-business/yak-ops-business-task-catalog/src/main/java/io/yak/ops/business/taskcatalog/domain/TaskAsset.java
+++ b/yak-ops-business/yak-ops-business-task-catalog/src/main/java/io/yak/ops/business/taskcatalog/domain/TaskAsset.java
@@ -1,5 +1,7 @@
 package io.yak.ops.business.taskcatalog.domain;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 import io.yak.ops.spi.task.model.TaskAssetSource;
 import io.yak.ops.spi.task.model.TaskAssetStatus;
 import io.yak.ops.spi.task.model.TaskRevisionRef;
@@ -8,10 +10,10 @@ import java.util.Objects;
 
 /** Published task asset discoverable by orchestration surfaces. */
 public record TaskAsset(
-    long id,
+    @JsonSerialize(using = ToStringSerializer.class) long id,
     TaskAssetSource source,
     String sourceRef,
-    Long projectId,
+    @JsonSerialize(using = ToStringSerializer.class) Long projectId,
     String name,
     String taskType,
     TaskAssetStatus status,

--- a/yak-ops-business/yak-ops-business-task-catalog/src/main/java/io/yak/ops/business/taskcatalog/domain/TaskAssetRevision.java
+++ b/yak-ops-business/yak-ops-business-task-catalog/src/main/java/io/yak/ops/business/taskcatalog/domain/TaskAssetRevision.java
@@ -1,0 +1,15 @@
+package io.yak.ops.business.taskcatalog.domain;
+
+import io.yak.ops.business.taskcatalog.spi.TaskSourceRevision;
+import java.util.Objects;
+
+/** A catalog asset resolved to one immutable source-owned revision. */
+public record TaskAssetRevision(
+    TaskAsset asset,
+    TaskSourceRevision revision) {
+
+  public TaskAssetRevision {
+    asset = Objects.requireNonNull(asset, "asset");
+    revision = Objects.requireNonNull(revision, "revision");
+  }
+}

--- a/yak-ops-business/yak-ops-business-task-catalog/src/main/java/io/yak/ops/business/taskcatalog/repository/JdbcTaskAssetRepository.java
+++ b/yak-ops-business/yak-ops-business-task-catalog/src/main/java/io/yak/ops/business/taskcatalog/repository/JdbcTaskAssetRepository.java
@@ -70,6 +70,15 @@ public class JdbcTaskAssetRepository implements TaskAssetRepository {
   }
 
   @Override
+  public Optional<TaskAsset> findById(long assetId) {
+    List<TaskAsset> values = jdbcTemplate.query(
+        SELECT_COLUMNS + " WHERE id = ? LIMIT 1",
+        JdbcTaskAssetRepository::mapRow,
+        assetId);
+    return values.stream().findFirst();
+  }
+
+  @Override
   public Optional<TaskAsset> findBySource(TaskAssetSource source, String sourceRef) {
     List<TaskAsset> values = jdbcTemplate.query(
         SELECT_COLUMNS + " WHERE source = ? AND source_ref = ? LIMIT 1",

--- a/yak-ops-business/yak-ops-business-task-catalog/src/main/java/io/yak/ops/business/taskcatalog/repository/TaskAssetRepository.java
+++ b/yak-ops-business/yak-ops-business-task-catalog/src/main/java/io/yak/ops/business/taskcatalog/repository/TaskAssetRepository.java
@@ -18,6 +18,8 @@ public interface TaskAssetRepository {
       long revisionId,
       int revisionNo);
 
+  Optional<TaskAsset> findById(long assetId);
+
   Optional<TaskAsset> findBySource(TaskAssetSource source, String sourceRef);
 
   List<TaskAsset> list(TaskAssetSource source, TaskAssetStatus status, String keyword);

--- a/yak-ops-business/yak-ops-business-task-catalog/src/main/java/io/yak/ops/business/taskcatalog/service/TaskCatalogService.java
+++ b/yak-ops-business/yak-ops-business-task-catalog/src/main/java/io/yak/ops/business/taskcatalog/service/TaskCatalogService.java
@@ -2,12 +2,18 @@ package io.yak.ops.business.taskcatalog.service;
 
 import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
 import io.yak.ops.business.taskcatalog.domain.TaskAsset;
+import io.yak.ops.business.taskcatalog.domain.TaskAssetRevision;
 import io.yak.ops.business.taskcatalog.repository.TaskAssetRepository;
+import io.yak.ops.business.taskcatalog.spi.TaskAssetRevisionProvider;
+import io.yak.ops.business.taskcatalog.spi.TaskSourceRevision;
 import io.yak.ops.spi.task.model.TaskAssetSource;
 import io.yak.ops.spi.task.model.TaskAssetStatus;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Optional;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 /** Application service for the published task asset catalog. */
@@ -16,9 +22,29 @@ import org.springframework.stereotype.Service;
 public class TaskCatalogService {
 
   private final TaskAssetRepository repository;
+  private final Map<TaskAssetSource, TaskAssetRevisionProvider> revisionProviders;
 
-  public TaskCatalogService(TaskAssetRepository repository) {
+  @Autowired
+  public TaskCatalogService(
+      TaskAssetRepository repository,
+      List<TaskAssetRevisionProvider> revisionProviders) {
     this.repository = repository;
+    Map<TaskAssetSource, TaskAssetRevisionProvider> discovered = new LinkedHashMap<>();
+    for (TaskAssetRevisionProvider provider : revisionProviders) {
+      TaskAssetRevisionProvider existing = discovered.putIfAbsent(provider.source(), provider);
+      if (existing != null) {
+        throw new IllegalStateException(
+            "重复的 TaskAsset revision provider：" + provider.source()
+                + " -> " + existing.getClass().getName()
+                + ", " + provider.getClass().getName());
+      }
+    }
+    this.revisionProviders = Map.copyOf(discovered);
+  }
+
+  /** Backward-compatible constructor for focused unit tests. */
+  public TaskCatalogService(TaskAssetRepository repository) {
+    this(repository, List.of());
   }
 
   public TaskAsset publish(
@@ -47,6 +73,30 @@ public class TaskCatalogService {
         parseSource(source),
         parseStatus(status),
         normalizeKeyword(keyword));
+  }
+
+  public TaskAsset get(long assetId) {
+    if (assetId <= 0L) throw new IllegalArgumentException("taskAssetId 必须大于 0");
+    return repository.findById(assetId)
+        .orElseThrow(() -> new IllegalArgumentException("任务资产不存在：" + assetId));
+  }
+
+  public TaskAssetRevision resolveRevision(long assetId, long revisionId) {
+    if (revisionId <= 0L) throw new IllegalArgumentException("taskRevisionId 必须大于 0");
+    TaskAsset asset = get(assetId);
+    TaskAssetRevisionProvider provider = revisionProviders.get(asset.source());
+    if (provider == null) {
+      throw new IllegalStateException("任务资产来源尚未接入版本解析：" + asset.source());
+    }
+    TaskSourceRevision revision = provider.resolve(asset.sourceRef(), revisionId)
+        .orElseThrow(() -> new IllegalArgumentException(
+            "任务版本不存在或不属于当前资产：asset=" + assetId + "，revision=" + revisionId));
+    if (!asset.taskType().equalsIgnoreCase(revision.definition().taskType())) {
+      throw new IllegalStateException(
+          "任务资产类型与版本类型不一致：asset=" + asset.taskType()
+              + "，revision=" + revision.definition().taskType());
+    }
+    return new TaskAssetRevision(asset, revision);
   }
 
   public Optional<TaskAsset> findBySource(TaskAssetSource source, String sourceRef) {

--- a/yak-ops-business/yak-ops-business-task-catalog/src/main/java/io/yak/ops/business/taskcatalog/spi/TaskAssetRevisionProvider.java
+++ b/yak-ops-business/yak-ops-business-task-catalog/src/main/java/io/yak/ops/business/taskcatalog/spi/TaskAssetRevisionProvider.java
@@ -1,0 +1,12 @@
+package io.yak.ops.business.taskcatalog.spi;
+
+import io.yak.ops.spi.task.model.TaskAssetSource;
+import java.util.Optional;
+
+/** Resolves immutable revisions owned by one TaskAsset source domain. */
+public interface TaskAssetRevisionProvider {
+
+  TaskAssetSource source();
+
+  Optional<TaskSourceRevision> resolve(String sourceRef, long revisionId);
+}

--- a/yak-ops-business/yak-ops-business-task-catalog/src/main/java/io/yak/ops/business/taskcatalog/spi/TaskSourceRevision.java
+++ b/yak-ops-business/yak-ops-business-task-catalog/src/main/java/io/yak/ops/business/taskcatalog/spi/TaskSourceRevision.java
@@ -1,0 +1,18 @@
+package io.yak.ops.business.taskcatalog.spi;
+
+import io.yak.ops.spi.task.model.TaskDefinition;
+import java.util.Objects;
+
+/** Source-neutral immutable revision payload returned by a task authoring domain. */
+public record TaskSourceRevision(
+    long revisionId,
+    int revisionNo,
+    TaskDefinition definition,
+    String checksum) {
+
+  public TaskSourceRevision {
+    if (revisionId <= 0L) throw new IllegalArgumentException("revisionId must be positive");
+    if (revisionNo <= 0) throw new IllegalArgumentException("revisionNo must be positive");
+    definition = Objects.requireNonNull(definition, "definition");
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/pom.xml
+++ b/yak-ops-business/yak-ops-business-workflow/pom.xml
@@ -30,6 +30,10 @@
             <artifactId>yak-ops-business-datasource</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.yak.ops</groupId>
+            <artifactId>yak-ops-business-task-catalog</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.yak.framework</groupId>
             <artifactId>yak-workflow-engine</artifactId>
         </dependency>

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/controller/v1/WorkflowDefinitionController.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/controller/v1/WorkflowDefinitionController.java
@@ -61,6 +61,14 @@ public class WorkflowDefinitionController {
     return Result.success(definitionService.update(id, request));
   }
 
+  @Operation(summary = "显式升级工作流节点到任务资产最新版本")
+  @PostMapping("/{id}/nodes/{nodeId}/upgrade-task-revision")
+  public Result<WorkflowDefinitionVO> upgradeTaskRevision(
+      @PathVariable("id") String id,
+      @PathVariable("nodeId") String nodeId) {
+    return Result.success(definitionService.upgradeTaskRevision(id, nodeId));
+  }
+
   @Operation(summary = "删除工作流定义")
   @DeleteMapping("/{id}")
   public Result<Boolean> delete(@PathVariable("id") String id) {

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/domain/WorkflowNodeSpec.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/domain/WorkflowNodeSpec.java
@@ -7,6 +7,9 @@ import java.util.Map;
 public record WorkflowNodeSpec(
     String id,
     String taskId,
+    Long taskAssetId,
+    Long taskRevisionId,
+    Integer taskRevisionNo,
     double positionX,
     double positionY,
     int maxAttempts,
@@ -18,6 +21,20 @@ public record WorkflowNodeSpec(
     String failurePolicy) {
 
   public WorkflowNodeSpec {
+    boolean hasCatalogBinding = taskAssetId != null || taskRevisionId != null || taskRevisionNo != null;
+    if (hasCatalogBinding) {
+      if (taskAssetId == null || taskRevisionId == null || taskRevisionNo == null) {
+        throw new IllegalArgumentException("工作流任务资产绑定必须同时包含 asset/revision/revisionNo");
+      }
+      if (taskAssetId <= 0L || taskRevisionId <= 0L || taskRevisionNo <= 0) {
+        throw new IllegalArgumentException("工作流任务资产绑定 ID/版本号必须大于 0");
+      }
+      taskId = catalogTaskId(taskAssetId);
+    } else if (taskId == null || taskId.isBlank()) {
+      throw new IllegalArgumentException("taskId 不能为空");
+    } else {
+      taskId = taskId.trim();
+    }
     inputMapping = inputMapping == null
         ? Map.of()
         : Map.copyOf(new LinkedHashMap<>(inputMapping));
@@ -25,5 +42,62 @@ public record WorkflowNodeSpec(
     failurePolicy = failurePolicy == null || failurePolicy.isBlank()
         ? "FAIL_WORKFLOW"
         : failurePolicy;
+  }
+
+  /** Backward-compatible constructor for legacy TaskRegistry nodes. */
+  public WorkflowNodeSpec(
+      String id,
+      String taskId,
+      double positionX,
+      double positionY,
+      int maxAttempts,
+      long retryDelaySeconds,
+      long dispatchTimeoutSeconds,
+      long executionTimeoutSeconds,
+      Map<String, String> inputMapping,
+      String triggerRule,
+      String failurePolicy) {
+    this(
+        id,
+        taskId,
+        null,
+        null,
+        null,
+        positionX,
+        positionY,
+        maxAttempts,
+        retryDelaySeconds,
+        dispatchTimeoutSeconds,
+        executionTimeoutSeconds,
+        inputMapping,
+        triggerRule,
+        failurePolicy);
+  }
+
+  public boolean catalogBound() {
+    return taskAssetId != null;
+  }
+
+  public WorkflowNodeSpec withTaskRevision(long revisionId, int revisionNo) {
+    if (!catalogBound()) throw new IllegalStateException("当前节点不是 TaskAsset 节点");
+    return new WorkflowNodeSpec(
+        id,
+        catalogTaskId(taskAssetId),
+        taskAssetId,
+        revisionId,
+        revisionNo,
+        positionX,
+        positionY,
+        maxAttempts,
+        retryDelaySeconds,
+        dispatchTimeoutSeconds,
+        executionTimeoutSeconds,
+        inputMapping,
+        triggerRule,
+        failurePolicy);
+  }
+
+  public static String catalogTaskId(long taskAssetId) {
+    return "task-asset:" + taskAssetId;
   }
 }

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowDefinitionService.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowDefinitionService.java
@@ -1,7 +1,9 @@
 package io.yak.ops.business.workflow.service;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.yak.ops.business.job.task.TaskRegistry;
 import io.yak.ops.business.job.task.TaskVersionSnapshot;
+import io.yak.ops.business.taskcatalog.service.TaskCatalogService;
 import io.yak.ops.business.workflow.domain.WorkflowEdgeSpec;
 import io.yak.ops.business.workflow.domain.WorkflowNodeSpec;
 import io.yak.ops.business.workflow.domain.WorkflowRunSpec;
@@ -10,6 +12,7 @@ import io.yak.ops.business.workflow.persistence.NoopWorkflowDefinitionPersistenc
 import io.yak.ops.business.workflow.persistence.WorkflowDefinitionPersistence;
 import io.yak.ops.business.workflow.persistence.WorkflowDefinitionPersistence.DefinitionRecord;
 import io.yak.ops.business.workflow.persistence.WorkflowDefinitionPersistence.VersionRecord;
+import io.yak.ops.business.workflow.service.WorkflowTaskBindingResolver.BindingView;
 import io.yak.ops.common.bean.dto.workflow.WorkflowDefinitionCreateDTO;
 import io.yak.ops.common.bean.dto.workflow.WorkflowDefinitionUpdateDTO;
 import io.yak.ops.common.bean.dto.workflow.WorkflowDefinitionUpdateDTO.EdgeDTO;
@@ -48,7 +51,7 @@ public class WorkflowDefinitionService {
       "CREATED", "WAITING", "READY", "SUBMITTED", "RUNNING", "PAUSING", "PAUSED", "RESUMING");
 
   private final WorkflowRuntimeService runtimeService;
-  private final TaskRegistry taskRegistry;
+  private final WorkflowTaskBindingResolver taskBindingResolver;
   private final WorkflowDefinitionPersistence persistence;
   private final ConcurrentMap<String, DefinitionState> definitions = new ConcurrentHashMap<>();
 
@@ -56,41 +59,69 @@ public class WorkflowDefinitionService {
   public WorkflowDefinitionService(
       WorkflowRuntimeService runtimeService,
       TaskRegistry taskRegistry,
+      ObjectProvider<TaskCatalogService> taskCatalogService,
+      ObjectMapper objectMapper,
       ObjectProvider<WorkflowDefinitionPersistence> persistence,
       @Value("${yak.database.enabled:true}") boolean databaseEnabled) {
-    this(runtimeService, taskRegistry, resolvePersistence(persistence, databaseEnabled));
+    this(
+        runtimeService,
+        new WorkflowTaskBindingResolver(
+            taskRegistry,
+            taskCatalogService.getIfAvailable(),
+            objectMapper),
+        resolvePersistence(persistence, databaseEnabled));
   }
 
   /** Focused tests and explicit database-disabled development retain the lightweight catalog. */
   WorkflowDefinitionService(
       WorkflowRuntimeService runtimeService,
       TaskRegistry taskRegistry) {
-    this(runtimeService, taskRegistry, NoopWorkflowDefinitionPersistence.INSTANCE);
-  }
-
-  private static WorkflowDefinitionPersistence resolvePersistence(
-      ObjectProvider<WorkflowDefinitionPersistence> provider,
-      boolean databaseEnabled) {
-    WorkflowDefinitionPersistence resolved = provider.getIfAvailable();
-    if (resolved != null) {
-      return resolved;
-    }
-    if (!databaseEnabled) {
-      return NoopWorkflowDefinitionPersistence.INSTANCE;
-    }
-    throw new IllegalStateException(
-        "Workflow durable persistence bean is missing while yak.database.enabled=true: "
-            + "WorkflowDefinitionPersistence");
+    this(
+        runtimeService,
+        new WorkflowTaskBindingResolver(taskRegistry, null, new ObjectMapper()),
+        NoopWorkflowDefinitionPersistence.INSTANCE);
   }
 
   WorkflowDefinitionService(
       WorkflowRuntimeService runtimeService,
       TaskRegistry taskRegistry,
       WorkflowDefinitionPersistence persistence) {
+    this(
+        runtimeService,
+        new WorkflowTaskBindingResolver(taskRegistry, null, new ObjectMapper()),
+        persistence);
+  }
+
+  WorkflowDefinitionService(
+      WorkflowRuntimeService runtimeService,
+      TaskRegistry taskRegistry,
+      TaskCatalogService taskCatalogService,
+      WorkflowDefinitionPersistence persistence) {
+    this(
+        runtimeService,
+        new WorkflowTaskBindingResolver(taskRegistry, taskCatalogService, new ObjectMapper()),
+        persistence);
+  }
+
+  private WorkflowDefinitionService(
+      WorkflowRuntimeService runtimeService,
+      WorkflowTaskBindingResolver taskBindingResolver,
+      WorkflowDefinitionPersistence persistence) {
     this.runtimeService = runtimeService;
-    this.taskRegistry = taskRegistry;
+    this.taskBindingResolver = taskBindingResolver;
     this.persistence = persistence;
     restoreCatalog();
+  }
+
+  private static WorkflowDefinitionPersistence resolvePersistence(
+      ObjectProvider<WorkflowDefinitionPersistence> provider,
+      boolean databaseEnabled) {
+    WorkflowDefinitionPersistence resolved = provider.getIfAvailable();
+    if (resolved != null) return resolved;
+    if (!databaseEnabled) return NoopWorkflowDefinitionPersistence.INSTANCE;
+    throw new IllegalStateException(
+        "Workflow durable persistence bean is missing while yak.database.enabled=true: "
+            + "WorkflowDefinitionPersistence");
   }
 
   public List<WorkflowDefinitionVO> list(String keyword, String status) {
@@ -176,6 +207,41 @@ public class WorkflowDefinitionService {
     }
   }
 
+  /** Explicitly advances one draft node to the TaskAsset current revision. */
+  public WorkflowDefinitionVO upgradeTaskRevision(String id, String nodeId) {
+    DefinitionState state = require(id);
+    synchronized (state) {
+      int index = -1;
+      WorkflowNodeSpec current = null;
+      for (int i = 0; i < state.nodes.size(); i++) {
+        WorkflowNodeSpec candidate = state.nodes.get(i);
+        if (candidate.id().equals(nodeId)) {
+          index = i;
+          current = candidate;
+          break;
+        }
+      }
+      if (current == null) throw new IllegalArgumentException("工作流节点不存在：" + nodeId);
+
+      WorkflowNodeSpec upgraded = taskBindingResolver.upgradeToLatest(current);
+      if (upgraded.equals(current)) return toView(state);
+
+      DefinitionStateSnapshot previous = DefinitionStateSnapshot.capture(state);
+      List<WorkflowNodeSpec> nextNodes = new ArrayList<>(state.nodes);
+      nextNodes.set(index, upgraded);
+      state.nodes = List.copyOf(nextNodes);
+      state.draftRevision++;
+      state.updateTime = Instant.now();
+      try {
+        persistence.saveDefinition(toRecord(state));
+      } catch (RuntimeException exception) {
+        previous.restore(state);
+        throw exception;
+      }
+      return toView(state);
+    }
+  }
+
   public WorkflowDefinitionVO online(String id) {
     DefinitionState state = require(id);
     synchronized (state) {
@@ -199,11 +265,8 @@ public class WorkflowDefinitionService {
         }
         state.status = "ONLINE";
         state.updateTime = Instant.now();
-        if (published == null) {
-          persistence.saveDefinition(toRecord(state));
-        } else {
-          persistence.publish(toRecord(state), toRecord(published));
-        }
+        if (published == null) persistence.saveDefinition(toRecord(state));
+        else persistence.publish(toRecord(state), toRecord(published));
       } catch (RuntimeException exception) {
         if (published != null) state.versions.remove(published);
         previous.restore(state);
@@ -217,9 +280,7 @@ public class WorkflowDefinitionService {
   public WorkflowDefinitionVO offline(String id) {
     DefinitionState state = require(id);
     synchronized (state) {
-      if (state.activeVersion == null) {
-        throw new IllegalStateException("工作流还没有已发布版本");
-      }
+      if (state.activeVersion == null) throw new IllegalStateException("工作流还没有已发布版本");
       String previousStatus = state.status;
       Instant previousUpdateTime = state.updateTime;
       state.status = "OFFLINE";
@@ -260,9 +321,7 @@ public class WorkflowDefinitionService {
     synchronized (state) {
       ensureIdle(state);
       PreparedDraft draft = prepare(state);
-      return activate(
-          state,
-          runtimeService.run(draft.spec(), draft.tasks(), null, null, true));
+      return activate(state, runtimeService.run(draft.spec(), draft.tasks(), null, null, true));
     }
   }
 
@@ -314,9 +373,7 @@ public class WorkflowDefinitionService {
     }
   }
 
-  private WorkflowDefinitionVO activate(
-      DefinitionState state,
-      WorkflowInstanceVO prepared) {
+  private WorkflowDefinitionVO activate(DefinitionState state, WorkflowInstanceVO prepared) {
     String previousExecutionId = state.latestExecutionId;
     String previousExecutionStatus = state.latestExecutionStatus;
     Instant previousUpdateTime = state.updateTime;
@@ -357,11 +414,7 @@ public class WorkflowDefinitionService {
         state.input);
     Map<String, TaskVersionSnapshot> tasks = new LinkedHashMap<>();
     for (WorkflowNodeSpec node : graph.nodes()) {
-      TaskVersionSnapshot task = taskRegistry.snapshot(node.taskId());
-      if (!"SYNC".equalsIgnoreCase(task.type())) {
-        throw new IllegalStateException("第一阶段工作流仅支持 SYNC 任务：" + node.taskId());
-      }
-      tasks.put(node.id(), task);
+      tasks.put(node.id(), taskBindingResolver.snapshot(node));
     }
     return new PreparedDraft(toRunSpec(state, graph), Map.copyOf(tasks));
   }
@@ -472,6 +525,9 @@ public class WorkflowDefinitionService {
     return new WorkflowNodeSpec(
         node.id(),
         node.taskId(),
+        node.taskAssetId(),
+        node.taskRevisionId(),
+        node.taskRevisionNo(),
         node.positionX(),
         node.positionY(),
         node.maxAttempts(),
@@ -488,9 +544,19 @@ public class WorkflowDefinitionService {
   }
 
   private NodeVO toView(WorkflowNodeSpec node) {
+    BindingView binding = taskBindingResolver.describe(node);
     return new NodeVO(
         node.id(),
         node.taskId(),
+        binding == null ? null : binding.taskAssetId(),
+        binding == null ? null : binding.taskRevisionId(),
+        binding == null ? null : binding.taskRevisionNo(),
+        binding == null ? null : binding.taskAssetName(),
+        binding == null ? null : binding.taskType(),
+        binding == null ? null : binding.taskAssetStatus(),
+        binding == null ? null : binding.latestTaskRevisionId(),
+        binding == null ? null : binding.latestTaskRevisionNo(),
+        binding != null && binding.updateAvailable(),
         node.positionX(),
         node.positionY(),
         node.maxAttempts(),

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowTaskBindingResolver.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowTaskBindingResolver.java
@@ -1,0 +1,138 @@
+package io.yak.ops.business.workflow.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.job.task.TaskRegistry;
+import io.yak.ops.business.job.task.TaskVersionSnapshot;
+import io.yak.ops.business.taskcatalog.domain.TaskAsset;
+import io.yak.ops.business.taskcatalog.domain.TaskAssetRevision;
+import io.yak.ops.business.taskcatalog.service.TaskCatalogService;
+import io.yak.ops.business.workflow.domain.WorkflowNodeSpec;
+import io.yak.ops.spi.task.model.TaskAssetStatus;
+import io.yak.ops.spi.task.model.TaskDefinition;
+import io.yak.ops.spi.task.model.TaskRevisionRef;
+
+/** Resolves legacy tasks and catalog-bound immutable revisions into one workflow snapshot contract. */
+final class WorkflowTaskBindingResolver {
+
+  private final TaskRegistry taskRegistry;
+  private final TaskCatalogService taskCatalogService;
+  private final ObjectMapper objectMapper;
+
+  WorkflowTaskBindingResolver(
+      TaskRegistry taskRegistry,
+      TaskCatalogService taskCatalogService,
+      ObjectMapper objectMapper) {
+    this.taskRegistry = taskRegistry;
+    this.taskCatalogService = taskCatalogService;
+    this.objectMapper = objectMapper;
+  }
+
+  TaskVersionSnapshot snapshot(WorkflowNodeSpec node) {
+    if (!node.catalogBound()) {
+      TaskVersionSnapshot snapshot = taskRegistry.snapshot(node.taskId());
+      if (!"SYNC".equalsIgnoreCase(snapshot.type())) {
+        throw new IllegalStateException("Legacy 工作流任务当前仅支持 SYNC：" + node.taskId());
+      }
+      return snapshot;
+    }
+
+    TaskAssetRevision resolved = requireCatalog().resolveRevision(
+        node.taskAssetId(),
+        node.taskRevisionId());
+    if (resolved.revision().revisionNo() != node.taskRevisionNo()) {
+      throw new IllegalStateException(
+          "工作流固定任务版本号不匹配：node=" + node.id()
+              + "，expected=v" + node.taskRevisionNo()
+              + "，actual=v" + resolved.revision().revisionNo());
+    }
+
+    TaskDefinition definition = resolved.revision().definition();
+    return new TaskVersionSnapshot(
+        WorkflowNodeSpec.catalogTaskId(resolved.asset().id()),
+        resolved.asset().name(),
+        definition.taskType(),
+        resolved.revision().revisionNo(),
+        resolved.revision().checksum(),
+        definitionJson(definition),
+        definition.configJson());
+  }
+
+  BindingView describe(WorkflowNodeSpec node) {
+    if (!node.catalogBound()) return null;
+    if (taskCatalogService == null) {
+      return BindingView.unresolved(node);
+    }
+    try {
+      TaskAsset asset = taskCatalogService.get(node.taskAssetId());
+      TaskRevisionRef latest = asset.currentRevision();
+      return new BindingView(
+          node.taskAssetId(),
+          node.taskRevisionId(),
+          node.taskRevisionNo(),
+          asset.name(),
+          asset.taskType(),
+          asset.status().name(),
+          latest.taskRevisionId(),
+          latest.revisionNo(),
+          latest.revisionNo() > node.taskRevisionNo());
+    } catch (RuntimeException ignored) {
+      return BindingView.unresolved(node);
+    }
+  }
+
+  WorkflowNodeSpec upgradeToLatest(WorkflowNodeSpec node) {
+    if (!node.catalogBound()) {
+      throw new IllegalStateException("当前节点不是 TaskAsset 节点，不能升级任务版本");
+    }
+    TaskAsset asset = requireCatalog().get(node.taskAssetId());
+    if (asset.status() != TaskAssetStatus.ONLINE) {
+      throw new IllegalStateException("任务资产已下线，不能升级到新版本：" + asset.name());
+    }
+    TaskRevisionRef latest = asset.currentRevision();
+    if (latest.revisionNo() <= node.taskRevisionNo()) return node;
+    // Resolve before mutating the draft so a stale/corrupt catalog pointer cannot be persisted.
+    requireCatalog().resolveRevision(asset.id(), latest.taskRevisionId());
+    return node.withTaskRevision(latest.taskRevisionId(), latest.revisionNo());
+  }
+
+  private TaskCatalogService requireCatalog() {
+    if (taskCatalogService == null) {
+      throw new IllegalStateException("Task Catalog 未启用，无法解析工作流 TaskAsset 绑定");
+    }
+    return taskCatalogService;
+  }
+
+  private String definitionJson(TaskDefinition definition) {
+    try {
+      return objectMapper.writeValueAsString(definition);
+    } catch (JsonProcessingException exception) {
+      throw new IllegalStateException("任务版本快照序列化失败：" + definition.taskType(), exception);
+    }
+  }
+
+  record BindingView(
+      Long taskAssetId,
+      Long taskRevisionId,
+      Integer taskRevisionNo,
+      String taskAssetName,
+      String taskType,
+      String taskAssetStatus,
+      Long latestTaskRevisionId,
+      Integer latestTaskRevisionNo,
+      boolean updateAvailable) {
+
+    static BindingView unresolved(WorkflowNodeSpec node) {
+      return new BindingView(
+          node.taskAssetId(),
+          node.taskRevisionId(),
+          node.taskRevisionNo(),
+          null,
+          null,
+          "UNKNOWN",
+          null,
+          null,
+          false);
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowTaskAssetBindingTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowTaskAssetBindingTest.java
@@ -1,0 +1,147 @@
+package io.yak.ops.business.workflow.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.job.task.TaskRegistry;
+import io.yak.ops.business.taskcatalog.domain.TaskAsset;
+import io.yak.ops.business.taskcatalog.domain.TaskAssetRevision;
+import io.yak.ops.business.taskcatalog.service.TaskCatalogService;
+import io.yak.ops.business.taskcatalog.spi.TaskSourceRevision;
+import io.yak.ops.business.workflow.persistence.NoopWorkflowDefinitionPersistence;
+import io.yak.ops.common.bean.dto.workflow.WorkflowDefinitionCreateDTO;
+import io.yak.ops.common.bean.dto.workflow.WorkflowDefinitionUpdateDTO;
+import io.yak.ops.common.bean.vo.workflow.WorkflowDefinitionVO;
+import io.yak.ops.common.bean.vo.workflow.WorkflowVersionVO;
+import io.yak.ops.spi.task.model.TaskAssetSource;
+import io.yak.ops.spi.task.model.TaskAssetStatus;
+import io.yak.ops.spi.task.model.TaskDefinition;
+import io.yak.ops.spi.task.model.TaskRevisionRef;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+
+class WorkflowTaskAssetBindingTest {
+
+  @Test
+  void pinsPublishedRevisionUntilUserExplicitlyUpgradesDraft() {
+    WorkflowRuntimeService runtimeService = mock(WorkflowRuntimeService.class);
+    TaskRegistry taskRegistry = mock(TaskRegistry.class);
+    TaskCatalogService taskCatalogService = mock(TaskCatalogService.class);
+
+    TaskDefinition definitionV1 = new TaskDefinition(
+        "SQL",
+        1,
+        "select 1 as version",
+        "{\"dataSourceId\":\"1\"}");
+    TaskDefinition definitionV2 = new TaskDefinition(
+        "SQL",
+        1,
+        "select 2 as version",
+        "{\"dataSourceId\":\"1\"}");
+
+    TaskAsset assetV1 = asset(101L, 1);
+    TaskAsset assetV2 = asset(102L, 2);
+    AtomicReference<TaskAsset> currentAsset = new AtomicReference<>(assetV1);
+
+    when(taskCatalogService.get(12L)).thenAnswer(invocation -> currentAsset.get());
+    when(taskCatalogService.resolveRevision(12L, 101L)).thenReturn(new TaskAssetRevision(
+        assetV1,
+        new TaskSourceRevision(101L, 1, definitionV1, "checksum-v1")));
+    when(taskCatalogService.resolveRevision(12L, 102L)).thenReturn(new TaskAssetRevision(
+        assetV2,
+        new TaskSourceRevision(102L, 2, definitionV2, "checksum-v2")));
+
+    WorkflowDefinitionService service = new WorkflowDefinitionService(
+        runtimeService,
+        taskRegistry,
+        taskCatalogService,
+        NoopWorkflowDefinitionPersistence.INSTANCE);
+
+    WorkflowDefinitionVO created = service.create(
+        new WorkflowDefinitionCreateDTO("日报工作流", "验证固定 TaskRevision"));
+
+    WorkflowDefinitionVO draftV1 = service.update(
+        created.id(),
+        updateRequest(101L, 1));
+    assertEquals(1, draftV1.nodes().getFirst().taskRevisionNo());
+    assertEquals(1, draftV1.nodes().getFirst().latestTaskRevisionNo());
+    assertFalse(draftV1.nodes().getFirst().taskRevisionUpdateAvailable());
+
+    WorkflowDefinitionVO publishedV1 = service.online(created.id());
+    assertEquals(1, publishedV1.activeVersionNo());
+    assertFalse(publishedV1.draftChanged());
+
+    currentAsset.set(assetV2);
+
+    WorkflowDefinitionVO stillPinnedToV1 = service.get(created.id());
+    assertEquals(1, stillPinnedToV1.nodes().getFirst().taskRevisionNo());
+    assertEquals(2, stillPinnedToV1.nodes().getFirst().latestTaskRevisionNo());
+    assertTrue(stillPinnedToV1.nodes().getFirst().taskRevisionUpdateAvailable());
+    assertEquals(1, stillPinnedToV1.activeVersionNo());
+    assertFalse(stillPinnedToV1.draftChanged());
+
+    WorkflowDefinitionVO upgradedDraft = service.upgradeTaskRevision(created.id(), "task-node-1");
+    assertEquals(2, upgradedDraft.nodes().getFirst().taskRevisionNo());
+    assertEquals(2, upgradedDraft.nodes().getFirst().latestTaskRevisionNo());
+    assertFalse(upgradedDraft.nodes().getFirst().taskRevisionUpdateAvailable());
+    assertEquals(1, upgradedDraft.activeVersionNo());
+    assertTrue(upgradedDraft.draftChanged());
+
+    WorkflowDefinitionVO publishedV2 = service.online(created.id());
+    assertEquals(2, publishedV2.activeVersionNo());
+    assertFalse(publishedV2.draftChanged());
+
+    WorkflowVersionVO latestVersion = service.versions(created.id()).getFirst();
+    assertEquals(2, latestVersion.versionNo());
+    assertEquals(2L, latestVersion.taskBindings().getFirst().taskVersion());
+    assertEquals("task-asset:12", latestVersion.taskBindings().getFirst().taskId());
+  }
+
+  private static WorkflowDefinitionUpdateDTO updateRequest(long revisionId, int revisionNo) {
+    WorkflowDefinitionUpdateDTO.NodeDTO node = new WorkflowDefinitionUpdateDTO.NodeDTO(
+        "task-node-1",
+        "task-asset:12",
+        12L,
+        revisionId,
+        revisionNo,
+        160D,
+        120D,
+        1,
+        0L,
+        0L,
+        0L,
+        Map.of(),
+        "ALL_SUCCESS",
+        "FAIL_WORKFLOW");
+    return new WorkflowDefinitionUpdateDTO(
+        "日报工作流",
+        "验证固定 TaskRevision",
+        List.of(node),
+        List.of(),
+        Map.of(),
+        Map.of(),
+        0L,
+        "CONTINUE_INDEPENDENT_BRANCHES");
+  }
+
+  private static TaskAsset asset(long revisionId, int revisionNo) {
+    Instant now = Instant.parse("2026-08-12T00:00:00Z");
+    return new TaskAsset(
+        12L,
+        TaskAssetSource.DATA_DEVELOPMENT,
+        "10001",
+        7L,
+        "今天统计",
+        "SQL",
+        TaskAssetStatus.ONLINE,
+        new TaskRevisionRef(12L, revisionId, revisionNo),
+        now,
+        now);
+  }
+}

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/dto/workflow/WorkflowDefinitionUpdateDTO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/dto/workflow/WorkflowDefinitionUpdateDTO.java
@@ -49,6 +49,9 @@ public record WorkflowDefinitionUpdateDTO(
   public record NodeDTO(
       @NotBlank String id,
       @NotBlank String taskId,
+      Long taskAssetId,
+      Long taskRevisionId,
+      @Min(1) Integer taskRevisionNo,
       Double positionX,
       Double positionY,
       @Min(1) Integer maxAttempts,
@@ -66,6 +69,16 @@ public record WorkflowDefinitionUpdateDTO(
       String failurePolicy) {
 
     public NodeDTO {
+      boolean hasCatalogBinding = taskAssetId != null || taskRevisionId != null || taskRevisionNo != null;
+      if (hasCatalogBinding) {
+        if (taskAssetId == null || taskRevisionId == null || taskRevisionNo == null) {
+          throw new IllegalArgumentException("任务资产绑定必须同时包含 taskAssetId/taskRevisionId/taskRevisionNo");
+        }
+        if (taskAssetId <= 0L || taskRevisionId <= 0L || taskRevisionNo <= 0) {
+          throw new IllegalArgumentException("任务资产绑定 ID/版本号必须大于 0");
+        }
+        taskId = "task-asset:" + taskAssetId;
+      }
       positionX = positionX == null ? 0D : positionX;
       positionY = positionY == null ? 0D : positionY;
       maxAttempts = maxAttempts == null ? 1 : maxAttempts;
@@ -79,6 +92,36 @@ public record WorkflowDefinitionUpdateDTO(
       failurePolicy = failurePolicy == null || failurePolicy.isBlank()
           ? "FAIL_WORKFLOW"
           : failurePolicy;
+    }
+
+    /** Backward-compatible constructor for existing legacy task callers/tests. */
+    public NodeDTO(
+        String id,
+        String taskId,
+        Double positionX,
+        Double positionY,
+        Integer maxAttempts,
+        Long retryDelaySeconds,
+        Long dispatchTimeoutSeconds,
+        Long executionTimeoutSeconds,
+        Map<String, String> inputMapping,
+        String triggerRule,
+        String failurePolicy) {
+      this(
+          id,
+          taskId,
+          null,
+          null,
+          null,
+          positionX,
+          positionY,
+          maxAttempts,
+          retryDelaySeconds,
+          dispatchTimeoutSeconds,
+          executionTimeoutSeconds,
+          inputMapping,
+          triggerRule,
+          failurePolicy);
     }
   }
 

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/vo/workflow/WorkflowDefinitionVO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/vo/workflow/WorkflowDefinitionVO.java
@@ -1,5 +1,7 @@
 package io.yak.ops.common.bean.vo.workflow;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
@@ -30,6 +32,15 @@ public record WorkflowDefinitionVO(
   public record NodeVO(
       String id,
       String taskId,
+      @JsonSerialize(using = ToStringSerializer.class) Long taskAssetId,
+      @JsonSerialize(using = ToStringSerializer.class) Long taskRevisionId,
+      Integer taskRevisionNo,
+      String taskAssetName,
+      String taskType,
+      String taskAssetStatus,
+      @JsonSerialize(using = ToStringSerializer.class) Long latestTaskRevisionId,
+      Integer latestTaskRevisionNo,
+      boolean taskRevisionUpdateAvailable,
       double positionX,
       double positionY,
       int maxAttempts,

--- a/yak-ops-spi/src/main/java/io/yak/ops/spi/task/model/TaskRevisionRef.java
+++ b/yak-ops-spi/src/main/java/io/yak/ops/spi/task/model/TaskRevisionRef.java
@@ -1,8 +1,11 @@
 package io.yak.ops.spi.task.model;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+
 /** Stable reference to one immutable published task revision. */
 public record TaskRevisionRef(
-    Long assetId,
-    Long revisionId,
+    @JsonSerialize(using = ToStringSerializer.class) Long taskAssetId,
+    @JsonSerialize(using = ToStringSerializer.class) Long taskRevisionId,
     int revisionNo) {
 }

--- a/yak-ops-ui/src/pages/workflow/definition/canvas/WorkflowCanvasTools.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/WorkflowCanvasTools.tsx
@@ -13,6 +13,7 @@ import {
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useNodesInitialized, useReactFlow, useViewport } from 'reactflow';
 import WorkflowNodeIcon from './node/icons/WorkflowNodeIcon';
+import { resolveWorkflowTaskOption } from './taskOptions';
 import WorkflowTaskPicker from './WorkflowTaskPicker';
 import type { WorkflowCanvasTaskOption } from './types';
 import type { WorkflowCanvasHistoryEntry } from './useWorkflowCanvasHistory';
@@ -74,7 +75,7 @@ const WorkflowCanvasTools = <T,>({
   onClearHistory,
 }: WorkflowCanvasToolsProps<T>) => {
   const [historyOpen, setHistoryOpen] = useState(false);
-  const [candidateTaskId, setCandidateTaskId] = useState<string>();
+  const [candidateTask, setCandidateTask] = useState<WorkflowCanvasTaskOption>();
   const [candidatePointer, setCandidatePointer] = useState<CandidatePointer>();
   const lastPointerRef = useRef<CandidatePointer>({ x: 0, y: 0 });
   const reactFlow = useReactFlow();
@@ -82,27 +83,27 @@ const WorkflowCanvasTools = <T,>({
   const nodesInitialized = useNodesInitialized();
   const initialFitDoneRef = useRef(false);
 
-  const candidateTask = taskOptions.find((task) => task.id === candidateTaskId);
-
   const cancelCandidate = useCallback(() => {
-    setCandidateTaskId(undefined);
+    setCandidateTask(undefined);
     setCandidatePointer(undefined);
   }, []);
 
   const beginCandidate = useCallback((taskId: string) => {
     if (locked) return;
-    setHistoryOpen(false);
-    onModeChange('pointer');
-    setCandidateTaskId(taskId);
-    setCandidatePointer(lastPointerRef.current.x || lastPointerRef.current.y
-      ? { ...lastPointerRef.current }
-      : undefined);
-  }, [locked, onModeChange]);
+    void resolveWorkflowTaskOption(taskId, taskOptions).then((task) => {
+      if (!task) return;
+      setHistoryOpen(false);
+      onModeChange('pointer');
+      setCandidateTask(task);
+      setCandidatePointer(lastPointerRef.current.x || lastPointerRef.current.y
+        ? { ...lastPointerRef.current }
+        : undefined);
+    });
+  }, [locked, onModeChange, taskOptions]);
 
   useEffect(() => {
     if (!nodesInitialized || initialFitDoneRef.current) return;
     initialFitDoneRef.current = true;
-
     const frame = window.requestAnimationFrame(() => {
       void reactFlow.fitView({ padding: 0.18, maxZoom: 0.9, duration: 0 });
     });
@@ -118,8 +119,7 @@ const WorkflowCanvasTools = <T,>({
   }, []);
 
   useEffect(() => {
-    if (!candidateTaskId) return;
-
+    if (!candidateTask) return;
     const previousCursor = document.body.style.cursor;
     document.body.style.cursor = 'crosshair';
 
@@ -135,7 +135,7 @@ const WorkflowCanvasTools = <T,>({
         ? event.target
         : document.elementFromPoint(event.clientX, event.clientY);
       const flowRoot = target?.closest('.react-flow');
-      if (!flowRoot || !candidateTask) return;
+      if (!flowRoot) return;
 
       event.preventDefault();
       event.stopPropagation();
@@ -146,9 +146,11 @@ const WorkflowCanvasTools = <T,>({
           id: candidateTask.id,
           name: candidateTask.label,
           type: candidateTask.taskType || 'SYNC',
+          taskAssetId: candidateTask.taskAssetId,
+          taskRevisionId: candidateTask.taskRevisionId,
+          taskRevisionNo: candidateTask.taskRevisionNo,
         }));
         dataTransfer.effectAllowed = 'move';
-
         flowRoot.dispatchEvent(new DragEvent('drop', {
           bubbles: true,
           cancelable: true,
@@ -157,10 +159,8 @@ const WorkflowCanvasTools = <T,>({
           dataTransfer,
         }));
       } catch {
-        // Older browser fallback: preserve the previous add behavior instead of losing the action.
         onAddTask(candidateTask.id);
       }
-
       cancelCandidate();
     };
 
@@ -168,7 +168,6 @@ const WorkflowCanvasTools = <T,>({
       event.preventDefault();
       cancelCandidate();
     };
-
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key !== 'Escape') return;
       event.preventDefault();
@@ -179,7 +178,6 @@ const WorkflowCanvasTools = <T,>({
     window.addEventListener('click', handleClick, true);
     window.addEventListener('contextmenu', handleContextMenu, true);
     window.addEventListener('keydown', handleKeyDown, true);
-
     return () => {
       document.body.style.cursor = previousCursor;
       window.removeEventListener('pointermove', handlePointerMove);
@@ -187,7 +185,7 @@ const WorkflowCanvasTools = <T,>({
       window.removeEventListener('contextmenu', handleContextMenu, true);
       window.removeEventListener('keydown', handleKeyDown, true);
     };
-  }, [candidateTask, candidateTaskId, cancelCandidate, onAddTask]);
+  }, [candidateTask, cancelCandidate, onAddTask]);
 
   useEffect(() => {
     if (!locked) return;
@@ -196,8 +194,7 @@ const WorkflowCanvasTools = <T,>({
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (locked || candidateTaskId || isEditableTarget(event.target)) return;
-
+      if (locked || candidateTask || isEditableTarget(event.target)) return;
       const modifier = event.metaKey || event.ctrlKey;
       if (modifier && event.key.toLowerCase() === 'z') {
         event.preventDefault();
@@ -215,78 +212,43 @@ const WorkflowCanvasTools = <T,>({
         if (event.key.toLowerCase() === 'h') onModeChange('hand');
       }
     };
-
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [candidateTaskId, locked, onModeChange, onRedo, onUndo]);
+  }, [candidateTask, locked, onModeChange, onRedo, onUndo]);
 
   const historyContent = (
     <div className="w-[320px] overflow-hidden rounded-xl border border-[#e4e7ec] bg-white shadow-[0_12px_36px_rgba(22,24,35,.14)]">
       <div className="flex h-11 items-center justify-between px-3.5">
         <div className="text-[14px] font-medium text-[#344054]">变更历史</div>
-        <button
-          type="button"
-          aria-label="关闭变更历史"
-          className="flex h-7 w-7 items-center justify-center rounded-md border-0 bg-transparent text-[#667085] hover:bg-[#f2f4f7]"
-          onClick={() => setHistoryOpen(false)}
-        >
+        <button type="button" aria-label="关闭变更历史" className="flex h-7 w-7 items-center justify-center rounded-md border-0 bg-transparent text-[#667085] hover:bg-[#f2f4f7]" onClick={() => setHistoryOpen(false)}>
           <X size={15} />
         </button>
       </div>
-
       <div className="max-h-[360px] overflow-y-auto px-2 pb-2">
         {historyEntries.length <= 1 ? (
           <div className="py-10 text-center text-[12px] text-[#98a2b3]">暂无变更记录</div>
         ) : (
-          [...historyEntries]
-            .map((entry, index) => ({ entry, index }))
-            .reverse()
-            .map(({ entry, index }) => {
-              const diff = index - currentHistoryIndex;
-              const stepText = diff === 0
-                ? '当前状态'
-                : diff < 0
-                  ? `${Math.abs(diff)} 步后退`
-                  : `${diff} 步前进`;
-
-              return (
-                <button
-                  key={entry.id}
-                  type="button"
-                  className={[
-                    'mb-0.5 flex w-full items-center rounded-lg border-0 px-2.5 py-2 text-left transition-colors',
-                    diff === 0 ? 'bg-[#f2f4f7]' : 'bg-transparent hover:bg-[#f7f8fa]',
-                  ].join(' ')}
-                  onClick={() => {
-                    onJumpToHistory(index);
-                    setHistoryOpen(false);
-                  }}
-                >
-                  <div className="min-w-0 flex-1">
-                    <div className="truncate text-[12px] font-medium text-[#475467]">{entry.label}</div>
-                    <div className="mt-0.5 text-[10px] text-[#98a2b3]">{stepText}</div>
-                  </div>
-                </button>
-              );
-            })
+          [...historyEntries].map((entry, index) => ({ entry, index })).reverse().map(({ entry, index }) => {
+            const diff = index - currentHistoryIndex;
+            const stepText = diff === 0 ? '当前状态' : diff < 0 ? `${Math.abs(diff)} 步后退` : `${diff} 步前进`;
+            return (
+              <button key={entry.id} type="button" className={['mb-0.5 flex w-full items-center rounded-lg border-0 px-2.5 py-2 text-left transition-colors', diff === 0 ? 'bg-[#f2f4f7]' : 'bg-transparent hover:bg-[#f7f8fa]'].join(' ')} onClick={() => { onJumpToHistory(index); setHistoryOpen(false); }}>
+                <div className="min-w-0 flex-1">
+                  <div className="truncate text-[12px] font-medium text-[#475467]">{entry.label}</div>
+                  <div className="mt-0.5 text-[10px] text-[#98a2b3]">{stepText}</div>
+                </div>
+              </button>
+            );
+          })
         )}
       </div>
-
       {historyEntries.length > 1 ? (
         <div className="border-t border-[#f0f1f3] px-2 py-1.5">
-          <button
-            type="button"
-            className="flex w-full rounded-lg border-0 bg-transparent px-2.5 py-2 text-left text-[12px] font-medium text-[#475467] hover:bg-[#f7f8fa]"
-            onClick={() => {
-              onClearHistory();
-              setHistoryOpen(false);
-            }}
-          >
+          <button type="button" className="flex w-full rounded-lg border-0 bg-transparent px-2.5 py-2 text-left text-[12px] font-medium text-[#475467] hover:bg-[#f7f8fa]" onClick={() => { onClearHistory(); setHistoryOpen(false); }}>
             清除历史记录
           </button>
         </div>
       ) : null}
-
       <div className="border-t border-[#f0f1f3] px-3.5 py-3 text-[10px] leading-[18px] text-[#98a2b3]">
         <div className="mb-1 font-medium text-[#667085]">提示</div>
         编辑历史仅保存在当前浏览器会话中，用于撤销、重做和快速回到之前的编辑状态。
@@ -297,55 +259,27 @@ const WorkflowCanvasTools = <T,>({
   return (
     <>
       <style>{`
-        .react-flow__controls {
-          display: none !important;
-        }
-        .react-flow__minimap {
-          right: 12px !important;
-          bottom: 12px !important;
-          transition: right 180ms ease;
-        }
-        div:has(> aside) > .react-flow .react-flow__minimap {
-          right: 424px !important;
-        }
+        .react-flow__controls { display: none !important; }
+        .react-flow__minimap { right: 12px !important; bottom: 12px !important; transition: right 180ms ease; }
+        div:has(> aside) > .react-flow .react-flow__minimap { right: 424px !important; }
       `}</style>
 
       {candidateTask && candidatePointer ? (
-        <div
-          className="pointer-events-none fixed z-[1000] w-60"
-          style={{
-            left: candidatePointer.x,
-            top: candidatePointer.y,
-            transform: `scale(${zoom})`,
-            transformOrigin: '0 0',
-          }}
-        >
+        <div className="pointer-events-none fixed z-[1000] w-60" style={{ left: candidatePointer.x, top: candidatePointer.y, transform: `scale(${zoom})`, transformOrigin: '0 0' }}>
           <div className="rounded-[15px] border border-[#d7d9de] bg-white px-3 py-3 shadow-[0_8px_24px_rgba(22,24,35,.14)] opacity-95">
             <div className="flex min-h-9 items-center gap-2.5">
               <WorkflowNodeIcon taskType={candidateTask.taskType} />
-              <div className="min-w-0 flex-1 truncate text-[14px] font-semibold leading-5 text-[#161823]">
-                {candidateTask.label}
-              </div>
+              <div className="min-w-0 flex-1 truncate text-[14px] font-semibold leading-5 text-[#161823]">{candidateTask.label}</div>
             </div>
           </div>
         </div>
       ) : null}
 
       <div className="pointer-events-auto absolute left-3 top-1/2 z-10 flex -translate-y-1/2 flex-col items-center rounded-lg border border-[#e4e7ec] bg-white p-0.5 shadow-[0_4px_14px_rgba(22,24,35,.08)]">
-        <WorkflowTaskPicker
-          options={taskOptions}
-          disabled={locked || !taskOptions.length}
-          placement="rightTop"
-          onSelect={beginCandidate}
-        >
+        <WorkflowTaskPicker options={taskOptions} disabled={locked} placement="rightTop" onSelect={beginCandidate}>
           <span>
             <Tooltip title="新增节点" placement="right">
-              <button
-                type="button"
-                aria-label="新增节点"
-                disabled={locked || !taskOptions.length}
-                className={`${iconButtonClass(Boolean(candidateTaskId))} ${disabledButtonClass}`}
-              >
+              <button type="button" aria-label="新增节点" disabled={locked} className={`${iconButtonClass(Boolean(candidateTask))} ${disabledButtonClass}`}>
                 <CirclePlus size={16} strokeWidth={1.9} />
               </button>
             </Tooltip>
@@ -353,52 +287,24 @@ const WorkflowCanvasTools = <T,>({
         </WorkflowTaskPicker>
 
         <Tooltip title="添加注释" placement="right">
-          <button
-            type="button"
-            aria-label="添加注释"
-            disabled={locked}
-            className={`${iconButtonClass()} ${disabledButtonClass}`}
-            onClick={onAddNote}
-          >
+          <button type="button" aria-label="添加注释" disabled={locked} className={`${iconButtonClass()} ${disabledButtonClass}`} onClick={onAddNote}>
             <StickyNote size={16} strokeWidth={1.9} />
           </button>
         </Tooltip>
-
         <div className="my-1 h-px w-5 bg-[#eceef1]" />
-
         <Tooltip title="选择模式（V）" placement="right">
-          <button
-            type="button"
-            aria-label="选择模式"
-            disabled={locked}
-            className={`${iconButtonClass(mode === 'pointer')} ${disabledButtonClass}`}
-            onClick={() => onModeChange('pointer')}
-          >
+          <button type="button" aria-label="选择模式" disabled={locked} className={`${iconButtonClass(mode === 'pointer')} ${disabledButtonClass}`} onClick={() => onModeChange('pointer')}>
             <MousePointer2 size={16} strokeWidth={1.9} />
           </button>
         </Tooltip>
-
         <Tooltip title="画布拖拽模式（H）" placement="right">
-          <button
-            type="button"
-            aria-label="画布拖拽模式"
-            disabled={locked}
-            className={`${iconButtonClass(mode === 'hand')} ${disabledButtonClass}`}
-            onClick={() => onModeChange('hand')}
-          >
+          <button type="button" aria-label="画布拖拽模式" disabled={locked} className={`${iconButtonClass(mode === 'hand')} ${disabledButtonClass}`} onClick={() => onModeChange('hand')}>
             <Hand size={16} strokeWidth={1.9} />
           </button>
         </Tooltip>
-
         <div className="my-1 h-px w-5 bg-[#eceef1]" />
-
         <Tooltip title="适应画布" placement="right">
-          <button
-            type="button"
-            aria-label="适应画布"
-            className={iconButtonClass()}
-            onClick={() => void reactFlow.fitView({ padding: 0.18, maxZoom: 1, duration: 250 })}
-          >
+          <button type="button" aria-label="适应画布" className={iconButtonClass()} onClick={() => void reactFlow.fitView({ padding: 0.18, maxZoom: 1, duration: 250 })}>
             <Maximize2 size={15} strokeWidth={1.9} />
           </button>
         </Tooltip>
@@ -406,47 +312,19 @@ const WorkflowCanvasTools = <T,>({
 
       <div className="pointer-events-auto absolute bottom-2 left-1/2 z-10 flex -translate-x-1/2 items-center rounded-lg border border-[#e4e7ec] bg-white p-0.5 shadow-[0_4px_14px_rgba(22,24,35,.08)]">
         <Tooltip title="撤销（Ctrl/Cmd + Z）">
-          <button
-            type="button"
-            aria-label="撤销"
-            disabled={locked || !canUndo}
-            className={`${iconButtonClass()} ${disabledButtonClass}`}
-            onClick={onUndo}
-          >
+          <button type="button" aria-label="撤销" disabled={locked || !canUndo} className={`${iconButtonClass()} ${disabledButtonClass}`} onClick={onUndo}>
             <Undo2 size={16} strokeWidth={1.9} />
           </button>
         </Tooltip>
-
         <Tooltip title="重做（Ctrl/Cmd + Shift + Z）">
-          <button
-            type="button"
-            aria-label="重做"
-            disabled={locked || !canRedo}
-            className={`${iconButtonClass()} ${disabledButtonClass}`}
-            onClick={onRedo}
-          >
+          <button type="button" aria-label="重做" disabled={locked || !canRedo} className={`${iconButtonClass()} ${disabledButtonClass}`} onClick={onRedo}>
             <Redo2 size={16} strokeWidth={1.9} />
           </button>
         </Tooltip>
-
         <div className="mx-1 h-4 w-px bg-[#e4e7ec]" />
-
-        <Popover
-          open={historyOpen}
-          onOpenChange={(open) => !locked && setHistoryOpen(open)}
-          trigger="click"
-          placement="top"
-          arrow={false}
-          content={historyContent}
-          overlayInnerStyle={{ padding: 0, background: 'transparent', boxShadow: 'none' }}
-        >
+        <Popover open={historyOpen} onOpenChange={(open) => !locked && setHistoryOpen(open)} trigger="click" placement="top" arrow={false} content={historyContent} overlayInnerStyle={{ padding: 0, background: 'transparent', boxShadow: 'none' }}>
           <Tooltip title="变更历史">
-            <button
-              type="button"
-              aria-label="变更历史"
-              disabled={locked}
-              className={`${iconButtonClass(historyOpen)} ${disabledButtonClass}`}
-            >
+            <button type="button" aria-label="变更历史" disabled={locked} className={`${iconButtonClass(historyOpen)} ${disabledButtonClass}`}>
               <History size={16} strokeWidth={1.9} />
             </button>
           </Tooltip>

--- a/yak-ops-ui/src/pages/workflow/definition/canvas/WorkflowNodeInspectorSettings.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/WorkflowNodeInspectorSettings.tsx
@@ -2,8 +2,15 @@ import type {
   WorkflowNodeFailurePolicy,
   WorkflowTriggerRule,
 } from '@/services/workflow';
-import { Input, InputNumber, Select, Slider, Switch, Tooltip } from 'antd';
-import { ChevronDown, CircleHelp } from 'lucide-react';
+import {
+  getWorkflowDefinition,
+  upgradeWorkflowNodeTaskRevision,
+  type WorkflowDefinitionNode,
+} from '@/services/workflow/definitions';
+import { useParams } from '@umijs/max';
+import { Button, Input, InputNumber, Select, Slider, Switch, Tooltip, message } from 'antd';
+import { ChevronDown, CircleHelp, RefreshCw } from 'lucide-react';
+import { useEffect, useState } from 'react';
 import type { Node } from 'reactflow';
 import WorkflowNextStep from './WorkflowNextStep';
 import type { WorkflowCanvasTaskOption, WorkflowNodeData } from './types';
@@ -62,6 +69,10 @@ const WorkflowNodeInspectorSettings = ({
   onChange,
   onAppend,
 }: WorkflowNodeInspectorSettingsProps) => {
+  const { id: workflowId = '' } = useParams<{ id: string }>();
+  const [boundNode, setBoundNode] = useState<WorkflowDefinitionNode>();
+  const [versionBusy, setVersionBusy] = useState(false);
+  const catalogBound = node.data.taskId.startsWith('task-asset:');
   const retryTimes = Math.max(0, (node.data.maxAttempts || 1) - 1);
   const retryEnabled = retryTimes > 0;
   const mappingText = node.data.inputMappingText?.trim() || '{}';
@@ -70,13 +81,54 @@ const WorkflowNodeInspectorSettings = ({
     || (node.data.executionTimeoutSeconds || 0) > 0
     || (mappingText !== '{}' && mappingText !== '');
 
+  const refreshVersion = async (showMessage = false) => {
+    if (!catalogBound || !workflowId) return;
+    setVersionBusy(true);
+    try {
+      const definition = await getWorkflowDefinition(workflowId);
+      const current = definition.nodes.find((item) => item.id === node.id);
+      setBoundNode(current);
+      if (showMessage) {
+        if (!current?.taskRevisionNo) message.info('请先保存工作流草稿，再检查任务版本');
+        else if (current.taskRevisionUpdateAvailable) message.info(`发现新版本 v${current.latestTaskRevisionNo}`);
+        else message.success('当前已是最新任务版本');
+      }
+    } catch (error) {
+      if (showMessage) message.error(error instanceof Error ? error.message : '检查任务版本失败');
+    } finally {
+      setVersionBusy(false);
+    }
+  };
+
+  useEffect(() => {
+    setBoundNode(undefined);
+    if (catalogBound) void refreshVersion(false);
+    // 节点切换时读取一次服务端固定版本；不会因为 Catalog 发布新版本而自动修改草稿。
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [catalogBound, node.id, workflowId]);
+
+  const handleUpgrade = async () => {
+    if (!workflowId || !boundNode?.taskRevisionUpdateAvailable) return;
+    setVersionBusy(true);
+    try {
+      const definition = await upgradeWorkflowNodeTaskRevision(workflowId, node.id);
+      const current = definition.nodes.find((item) => item.id === node.id);
+      setBoundNode(current);
+      message.success(current?.taskRevisionNo
+        ? `已固定到任务 v${current.taskRevisionNo}，重新发布工作流后生效`
+        : '任务版本已升级');
+    } catch (error) {
+      message.error(error instanceof Error ? error.message : '升级任务版本失败');
+    } finally {
+      setVersionBusy(false);
+    }
+  };
+
   const handleRetryEnabledChange = (checked: boolean) => {
     if (!checked) {
       onChange({ maxAttempts: 1 });
       return;
     }
-
-    // maxAttempts 包含首次执行；默认开启后为“首次执行 + 3 次重试”。
     onChange({ maxAttempts: Math.max(node.data.maxAttempts || 1, 4) });
   };
 
@@ -87,70 +139,90 @@ const WorkflowNodeInspectorSettings = ({
 
   return (
     <div className="pb-6">
+      {catalogBound ? (
+        <>
+          <section className="px-4 py-4">
+            <div className="mb-3 flex items-center justify-between">
+              <div>
+                <SectionTitle>任务版本</SectionTitle>
+                <div className="text-[10px] text-[rgba(22,24,35,.42)]">工作流固定不可变 Revision，不会自动追随最新版本</div>
+              </div>
+              <Tooltip title="检查最新版本">
+                <button
+                  type="button"
+                  disabled={versionBusy}
+                  className="flex h-7 w-7 items-center justify-center rounded-md border-0 bg-transparent text-[#667085] hover:bg-[#f5f6f7] disabled:opacity-50"
+                  onClick={() => void refreshVersion(true)}
+                >
+                  <RefreshCw size={13} className={versionBusy ? 'animate-spin' : undefined} />
+                </button>
+              </Tooltip>
+            </div>
+
+            <div className="rounded-lg border border-[#e4e7ec] bg-[#fafafa] px-3 py-2.5">
+              <div className="flex items-center justify-between text-[11px]">
+                <span className="text-[#667085]">当前固定</span>
+                <span className="font-semibold text-[#344054]">
+                  {boundNode?.taskRevisionNo ? `v${boundNode.taskRevisionNo}` : '保存草稿后固定'}
+                </span>
+              </div>
+              <div className="mt-2 flex items-center justify-between text-[11px]">
+                <span className="text-[#667085]">资产最新</span>
+                <span className={boundNode?.taskRevisionUpdateAvailable ? 'font-semibold text-[#fe2c55]' : 'font-medium text-[#475467]'}>
+                  {boundNode?.latestTaskRevisionNo ? `v${boundNode.latestTaskRevisionNo}` : '--'}
+                </span>
+              </div>
+              {boundNode?.taskAssetStatus ? (
+                <div className="mt-2 flex items-center justify-between text-[11px]">
+                  <span className="text-[#667085]">资产状态</span>
+                  <span className="font-medium text-[#475467]">{boundNode.taskAssetStatus === 'ONLINE' ? '已上线' : boundNode.taskAssetStatus}</span>
+                </div>
+              ) : null}
+            </div>
+
+            {boundNode?.taskRevisionUpdateAvailable ? (
+              <Button
+                block
+                size="small"
+                className="mt-3"
+                loading={versionBusy}
+                disabled={locked}
+                onClick={() => void handleUpgrade()}
+              >
+                升级到 v{boundNode.latestTaskRevisionNo}
+              </Button>
+            ) : boundNode?.taskRevisionNo ? (
+              <div className="mt-2 text-center text-[10px] text-[#98a2b3]">当前固定版本已是最新版本</div>
+            ) : null}
+          </section>
+          <Divider />
+        </>
+      ) : null}
+
       <section className="py-2">
         <div className="flex min-h-12 items-center justify-between px-4 py-2">
           <div className="flex items-center">
             <div className="text-[12px] font-semibold text-[#344054]">失败时重试</div>
             <HelpTip title="节点执行失败后自动再次尝试；开启后会在画布节点中实时显示重试次数。" />
           </div>
-          <Switch
-            size="small"
-            disabled={locked}
-            checked={retryEnabled}
-            onChange={handleRetryEnabledChange}
-          />
+          <Switch size="small" disabled={locked} checked={retryEnabled} onChange={handleRetryEnabledChange} />
         </div>
 
         {retryEnabled ? (
           <div className="space-y-3 px-4 pb-4 pt-1">
             <div className="flex items-center gap-3">
               <div className="w-[88px] shrink-0 text-[11px] font-medium text-[#667085]">重试次数</div>
-              <Slider
-                className="m-0 min-w-0 flex-1"
-                min={1}
-                max={MAX_RETRY_TIMES}
-                tooltip={{ open: false }}
-                disabled={locked}
-                value={retryTimes}
-                onChange={(value) => handleRetryTimesChange(value)}
-              />
+              <Slider className="m-0 min-w-0 flex-1" min={1} max={MAX_RETRY_TIMES} tooltip={{ open: false }} disabled={locked} value={retryTimes} onChange={(value) => handleRetryTimesChange(value)} />
               <div className="flex w-[82px] shrink-0 items-center gap-1">
-                <InputNumber
-                  size="small"
-                  controls={false}
-                  disabled={locked}
-                  min={1}
-                  max={MAX_RETRY_TIMES}
-                  value={retryTimes}
-                  className="!w-[58px]"
-                  onChange={handleRetryTimesChange}
-                />
+                <InputNumber size="small" controls={false} disabled={locked} min={1} max={MAX_RETRY_TIMES} value={retryTimes} className="!w-[58px]" onChange={handleRetryTimesChange} />
                 <span className="text-[10px] text-[rgba(22,24,35,.42)]">次</span>
               </div>
             </div>
-
             <div className="flex items-center gap-3">
               <div className="w-[88px] shrink-0 text-[11px] font-medium text-[#667085]">重试间隔</div>
-              <Slider
-                className="m-0 min-w-0 flex-1"
-                min={0}
-                max={MAX_RETRY_DELAY_SECONDS}
-                tooltip={{ open: false }}
-                disabled={locked}
-                value={Math.min(node.data.retryDelaySeconds || 0, MAX_RETRY_DELAY_SECONDS)}
-                onChange={(value) => onChange({ retryDelaySeconds: value })}
-              />
+              <Slider className="m-0 min-w-0 flex-1" min={0} max={MAX_RETRY_DELAY_SECONDS} tooltip={{ open: false }} disabled={locked} value={Math.min(node.data.retryDelaySeconds || 0, MAX_RETRY_DELAY_SECONDS)} onChange={(value) => onChange({ retryDelaySeconds: value })} />
               <div className="flex w-[82px] shrink-0 items-center gap-1">
-                <InputNumber
-                  size="small"
-                  controls={false}
-                  disabled={locked}
-                  min={0}
-                  max={MAX_RETRY_DELAY_SECONDS}
-                  value={node.data.retryDelaySeconds}
-                  className="!w-[58px]"
-                  onChange={(value) => onChange({ retryDelaySeconds: Number(value || 0) })}
-                />
+                <InputNumber size="small" controls={false} disabled={locked} min={0} max={MAX_RETRY_DELAY_SECONDS} value={node.data.retryDelaySeconds} className="!w-[58px]" onChange={(value) => onChange({ retryDelaySeconds: Number(value || 0) })} />
                 <span className="text-[10px] text-[rgba(22,24,35,.42)]">秒</span>
               </div>
             </div>
@@ -165,14 +237,7 @@ const WorkflowNodeInspectorSettings = ({
           <div className="text-[12px] font-semibold text-[#344054]">异常处理</div>
           <HelpTip title="节点最终仍然失败时的处理方式。“无”表示按默认方式使工作流失败。" />
         </div>
-        <Select
-          disabled={locked}
-          size="small"
-          className="w-[142px] shrink-0"
-          value={node.data.failurePolicy}
-          options={NODE_FAILURE_OPTIONS}
-          onChange={(value) => onChange({ failurePolicy: value as WorkflowNodeFailurePolicy })}
-        />
+        <Select disabled={locked} size="small" className="w-[142px] shrink-0" value={node.data.failurePolicy} options={NODE_FAILURE_OPTIONS} onChange={(value) => onChange({ failurePolicy: value as WorkflowNodeFailurePolicy })} />
       </section>
 
       <Divider />
@@ -181,77 +246,30 @@ const WorkflowNodeInspectorSettings = ({
         <summary className="flex cursor-pointer list-none items-center justify-between rounded-lg px-0 py-1 text-[12px] font-semibold text-[#344054] [&::-webkit-details-marker]:hidden">
           <div className="flex items-center">
             高级运行设置
-            {hasAdvancedConfig ? (
-              <span className="ml-2 rounded bg-[#fff1f3] px-1.5 py-0.5 text-[9px] font-medium text-[#d92d50]">已配置</span>
-            ) : null}
+            {hasAdvancedConfig ? <span className="ml-2 rounded bg-[#fff1f3] px-1.5 py-0.5 text-[9px] font-medium text-[#d92d50]">已配置</span> : null}
           </div>
           <ChevronDown size={14} className="text-[#98a2b3] transition-transform group-open:rotate-180" />
         </summary>
-
         <div className="mt-3 space-y-4 rounded-lg bg-[#fafafa] p-3">
           <div>
-            <div className="mb-1.5 flex items-center text-[11px] font-medium text-[#667085]">
-              触发规则
-              <HelpTip title="多个前置节点汇聚时，决定当前节点何时满足调度条件。" />
-            </div>
-            <Select
-              disabled={locked}
-              size="small"
-              className="w-full"
-              value={node.data.triggerRule}
-              options={NODE_TRIGGER_OPTIONS}
-              onChange={(value) => onChange({ triggerRule: value as WorkflowTriggerRule })}
-            />
+            <div className="mb-1.5 flex items-center text-[11px] font-medium text-[#667085]">触发规则<HelpTip title="多个前置节点汇聚时，决定当前节点何时满足调度条件。" /></div>
+            <Select disabled={locked} size="small" className="w-full" value={node.data.triggerRule} options={NODE_TRIGGER_OPTIONS} onChange={(value) => onChange({ triggerRule: value as WorkflowTriggerRule })} />
           </div>
-
           <div className="grid grid-cols-2 gap-3">
             <div>
               <div className="mb-1.5 text-[11px] font-medium text-[#667085]">调度超时</div>
-              <InputNumber
-                size="small"
-                controls={false}
-                disabled={locked}
-                min={0}
-                max={MAX_TIMEOUT_SECONDS}
-                value={node.data.dispatchTimeoutSeconds}
-                className="!w-full"
-                addonAfter="秒"
-                onChange={(value) => onChange({ dispatchTimeoutSeconds: Number(value || 0) })}
-              />
+              <InputNumber size="small" controls={false} disabled={locked} min={0} max={MAX_TIMEOUT_SECONDS} value={node.data.dispatchTimeoutSeconds} className="!w-full" addonAfter="秒" onChange={(value) => onChange({ dispatchTimeoutSeconds: Number(value || 0) })} />
               <div className="mt-1 text-[9px] text-[#98a2b3]">0 表示不限制等待调度时间</div>
             </div>
-
             <div>
               <div className="mb-1.5 text-[11px] font-medium text-[#667085]">执行超时</div>
-              <InputNumber
-                size="small"
-                controls={false}
-                disabled={locked}
-                min={0}
-                max={MAX_TIMEOUT_SECONDS}
-                value={node.data.executionTimeoutSeconds}
-                className="!w-full"
-                addonAfter="秒"
-                onChange={(value) => onChange({ executionTimeoutSeconds: Number(value || 0) })}
-              />
+              <InputNumber size="small" controls={false} disabled={locked} min={0} max={MAX_TIMEOUT_SECONDS} value={node.data.executionTimeoutSeconds} className="!w-full" addonAfter="秒" onChange={(value) => onChange({ executionTimeoutSeconds: Number(value || 0) })} />
               <div className="mt-1 text-[9px] text-[#98a2b3]">0 表示不限制节点运行时间</div>
             </div>
           </div>
-
           <div>
-            <div className="mb-1.5 flex items-center text-[11px] font-medium text-[#667085]">
-              输入映射
-              <HelpTip title="JSON 对象；将工作流输入或前置节点输出映射为当前节点输入。" />
-            </div>
-            <Input.TextArea
-              disabled={locked}
-              autoSize={{ minRows: 3, maxRows: 8 }}
-              spellCheck={false}
-              value={node.data.inputMappingText}
-              placeholder={'{\n  "requestId": "$workflow.requestId"\n}'}
-              className="font-mono !text-[10px]"
-              onChange={(event) => onChange({ inputMappingText: event.target.value })}
-            />
+            <div className="mb-1.5 flex items-center text-[11px] font-medium text-[#667085]">输入映射<HelpTip title="JSON 对象；将工作流输入或前置节点输出映射为当前节点输入。" /></div>
+            <Input.TextArea disabled={locked} autoSize={{ minRows: 3, maxRows: 8 }} spellCheck={false} value={node.data.inputMappingText} placeholder={'{\n  "requestId": "$workflow.requestId"\n}'} className="font-mono !text-[10px]" onChange={(event) => onChange({ inputMappingText: event.target.value })} />
           </div>
         </div>
       </details>
@@ -261,13 +279,7 @@ const WorkflowNodeInspectorSettings = ({
       <section className="px-4 py-4">
         <SectionTitle>下一步</SectionTitle>
         <div className="mb-3 text-[10px] leading-4 text-[rgba(22,24,35,.38)]">添加此工作流程中的下一个节点</div>
-        <WorkflowNextStep
-          currentIcon={<WorkflowNodeIcon taskType={node.data.taskType} size="sm" />}
-          nextNodes={nextNodes}
-          appendOptions={appendOptions}
-          locked={locked}
-          onAppend={onAppend}
-        />
+        <WorkflowNextStep currentIcon={<WorkflowNodeIcon taskType={node.data.taskType} size="sm" />} nextNodes={nextNodes} appendOptions={appendOptions} locked={locked} onAppend={onAppend} />
       </section>
     </div>
   );

--- a/yak-ops-ui/src/pages/workflow/definition/canvas/WorkflowTaskPicker.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/WorkflowTaskPicker.tsx
@@ -1,11 +1,11 @@
-import { API_SUCCESS_CODE, type ApiResponse } from '@/services/http/response';
-import { request } from '@umijs/max';
-import { Input, Popover, Tooltip } from 'antd';
+import { listTaskCatalogAssets } from '@/services/taskCatalog';
+import { Input, Popover, Spin } from 'antd';
 import type { PopoverProps } from 'antd';
 import { Search } from 'lucide-react';
 import type { ReactElement } from 'react';
 import { useEffect, useMemo, useState } from 'react';
 import WorkflowNodeIcon from './node/icons/WorkflowNodeIcon';
+import { taskCatalogOption } from './taskOptions';
 import type { WorkflowCanvasTaskOption } from './types';
 
 export type WorkflowTaskCategory = 'sync' | 'development' | 'quality';
@@ -21,32 +21,7 @@ interface WorkflowTaskPickerProps {
   defaultCategory?: WorkflowTaskCategory;
 }
 
-interface TaskCatalogRevisionRef {
-  taskAssetId: string | number;
-  taskRevisionId: string | number;
-  revisionNo: number;
-}
-
-interface TaskCatalogAsset {
-  id: string | number;
-  source: string;
-  sourceRef: string;
-  name: string;
-  taskType: string;
-  status: string;
-  currentRevision: TaskCatalogRevisionRef;
-}
-
-type PickerTaskOption = WorkflowCanvasTaskOption & {
-  disabled?: boolean;
-  disabledReason?: string;
-  meta?: string;
-};
-
-const CATEGORY_META: Array<{
-  key: WorkflowTaskCategory;
-  label: string;
-}> = [
+const CATEGORY_META: Array<{ key: WorkflowTaskCategory; label: string }> = [
   { key: 'sync', label: '数据同步' },
   { key: 'development', label: '数据开发' },
   { key: 'quality', label: '数据质量' },
@@ -58,24 +33,17 @@ const resolveTaskCategory = (option: WorkflowCanvasTaskOption): WorkflowTaskCate
   if (option.typeLabel.includes('开发')) return 'development';
 
   const normalized = (option.taskType || option.typeLabel || '').trim().toUpperCase();
-
   if (
     normalized.includes('QUALITY')
     || normalized.includes('CHECK')
     || normalized.includes('VALIDATE')
     || normalized.includes('VERIFY')
-  ) {
-    return 'quality';
-  }
-
+  ) return 'quality';
   if (
     normalized.includes('SYNC')
     || normalized.includes('CDC')
     || normalized.includes('REPLICATION')
-  ) {
-    return 'sync';
-  }
-
+  ) return 'sync';
   return 'development';
 };
 
@@ -91,16 +59,6 @@ const createSearchState = (): Record<WorkflowTaskCategory, string> => ({
   quality: '',
 });
 
-const catalogOption = (asset: TaskCatalogAsset): PickerTaskOption => ({
-  id: `task-asset:${asset.id}`,
-  label: asset.name,
-  typeLabel: '数据开发',
-  taskType: asset.taskType,
-  disabled: true,
-  disabledReason: `已发布 v${asset.currentRevision.revisionNo}；固定版本引用将在下一阶段接入后开放添加到工作流`,
-  meta: `已发布 v${asset.currentRevision.revisionNo}`,
-});
-
 const WorkflowTaskPicker = ({
   options,
   onSelect,
@@ -114,7 +72,7 @@ const WorkflowTaskPicker = ({
   const [innerOpen, setInnerOpen] = useState(false);
   const [activeCategory, setActiveCategory] = useState<WorkflowTaskCategory>(defaultCategory);
   const [searchText, setSearchText] = useState(createSearchState);
-  const [catalogOptions, setCatalogOptions] = useState<PickerTaskOption[]>([]);
+  const [catalogOptions, setCatalogOptions] = useState<WorkflowCanvasTaskOption[]>([]);
   const [catalogLoading, setCatalogLoading] = useState(false);
   const open = controlledOpen ?? innerOpen;
 
@@ -125,23 +83,12 @@ const WorkflowTaskPicker = ({
   };
 
   useEffect(() => {
-    if (!open) return undefined;
+    if (!open) return;
     let active = true;
     setCatalogLoading(true);
-
-    void request<ApiResponse<TaskCatalogAsset[]>>('/api/v1/task-catalog/assets', {
-      params: {
-        source: 'DATA_DEVELOPMENT',
-        status: 'ONLINE',
-      },
-    })
-      .then((response) => {
-        if (!active) return;
-        if (response.code !== API_SUCCESS_CODE || !Array.isArray(response.data)) {
-          setCatalogOptions([]);
-          return;
-        }
-        setCatalogOptions(response.data.map(catalogOption));
+    void listTaskCatalogAssets({ source: 'DATA_DEVELOPMENT', status: 'ONLINE' })
+      .then((assets) => {
+        if (active) setCatalogOptions(assets.map(taskCatalogOption));
       })
       .catch(() => {
         if (active) setCatalogOptions([]);
@@ -149,28 +96,25 @@ const WorkflowTaskPicker = ({
       .finally(() => {
         if (active) setCatalogLoading(false);
       });
-
-    return () => {
-      active = false;
-    };
+    return () => { active = false; };
   }, [open]);
 
+  const allOptions = useMemo(() => {
+    const merged = new Map<string, WorkflowCanvasTaskOption>();
+    options.forEach((option) => merged.set(option.id, option));
+    catalogOptions.forEach((option) => merged.set(option.id, option));
+    return Array.from(merged.values());
+  }, [catalogOptions, options]);
+
   const groupedOptions = useMemo(() => {
-    const grouped: Record<WorkflowTaskCategory, PickerTaskOption[]> = {
+    const grouped: Record<WorkflowTaskCategory, WorkflowCanvasTaskOption[]> = {
       sync: [],
       development: [],
       quality: [],
     };
-
-    options.forEach((option) => {
-      grouped[resolveTaskCategory(option)].push(option);
-    });
-    catalogOptions.forEach((option) => {
-      grouped[resolveTaskCategory(option)].push(option);
-    });
-
+    allOptions.forEach((option) => grouped[resolveTaskCategory(option)].push(option));
     return grouped;
-  }, [catalogOptions, options]);
+  }, [allOptions]);
 
   const activeMeta = CATEGORY_META.find((item) => item.key === activeCategory) ?? CATEGORY_META[0];
   const keyword = searchText[activeCategory].trim().toLowerCase();
@@ -198,9 +142,7 @@ const WorkflowTaskPicker = ({
               onClick={() => setActiveCategory(item.key)}
             >
               {item.label}
-              {active ? (
-                <span className="absolute inset-x-3 bottom-0 h-0.5 rounded-full bg-[#fe2c55]" />
-              ) : null}
+              {active ? <span className="absolute inset-x-3 bottom-0 h-0.5 rounded-full bg-[#fe2c55]" /> : null}
             </button>
           );
         })}
@@ -226,59 +168,29 @@ const WorkflowTaskPicker = ({
 
       <div className="border-t border-[#f0f1f3]">
         <div className="max-h-[420px] overflow-y-auto p-1">
-          {filteredOptions.length ? filteredOptions.map((option) => {
-            const optionDisabled = Boolean(option.disabled);
-            const button = (
-              <button
-                type="button"
-                disabled={optionDisabled}
-                className={[
-                  'flex h-9 w-full items-center rounded-lg border-0 bg-transparent px-3 text-left transition-colors focus:outline-none',
-                  optionDisabled
-                    ? 'cursor-not-allowed text-[#98a2b3]'
-                    : 'hover:bg-[#f5f6f7] focus:bg-[#f5f6f7]',
-                ].join(' ')}
-                onClick={() => {
-                  if (optionDisabled) return;
-                  onSelect(option.id);
-                  handleOpenChange(false);
-                }}
-              >
-                <span className={optionDisabled ? 'opacity-55' : undefined}>
-                  <WorkflowNodeIcon taskType={resolveIconTaskType(option)} size="xs" />
-                </span>
-                <span
-                  className={[
-                    'ml-2 min-w-0 flex-1 truncate text-[13px] font-medium',
-                    optionDisabled ? 'text-[#667085]' : 'text-[#475467]',
-                  ].join(' ')}
-                >
-                  {option.label}
-                </span>
-                {option.meta ? (
-                  <span className="ml-2 shrink-0 text-[10px] font-medium text-[#98a2b3]">
-                    {option.meta}
-                  </span>
-                ) : null}
-              </button>
-            );
-
-            return (
-              <Tooltip
-                key={option.id}
-                title={optionDisabled ? option.disabledReason : undefined}
-                placement="right"
-              >
-                <span className="block">{button}</span>
-              </Tooltip>
-            );
-          }) : (
+          {catalogLoading && activeCategory === 'development' && !filteredOptions.length ? (
+            <div className="flex h-16 items-center justify-center"><Spin size="small" /></div>
+          ) : filteredOptions.length ? filteredOptions.map((option) => (
+            <button
+              key={option.id}
+              type="button"
+              className="flex h-10 w-full items-center rounded-lg border-0 bg-transparent px-3 text-left transition-colors hover:bg-[#f5f6f7] focus:bg-[#f5f6f7] focus:outline-none"
+              onClick={() => {
+                onSelect(option.id);
+                handleOpenChange(false);
+              }}
+            >
+              <WorkflowNodeIcon taskType={resolveIconTaskType(option)} size="xs" />
+              <span className="ml-2 min-w-0 flex-1 truncate text-[13px] font-medium text-[#475467]">
+                {option.label}
+              </span>
+              {option.meta ? (
+                <span className="ml-3 shrink-0 text-[10px] font-medium text-[#98a2b3]">{option.meta}</span>
+              ) : null}
+            </button>
+          )) : (
             <div className="flex h-16 items-center justify-center text-[11px] text-[#98a2b3]">
-              {catalogLoading && activeCategory === 'development'
-                ? '正在加载已发布任务...'
-                : keyword
-                  ? '没有匹配的任务'
-                  : `暂无${activeMeta.label}任务`}
+              {keyword ? '没有匹配的任务' : `暂无${activeMeta.label}任务`}
             </div>
           )}
         </div>

--- a/yak-ops-ui/src/pages/workflow/definition/canvas/taskOptions.ts
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/taskOptions.ts
@@ -1,0 +1,34 @@
+import {
+  getTaskCatalogAsset,
+  type TaskCatalogAsset,
+} from '@/services/taskCatalog';
+import type { WorkflowCanvasTaskOption } from './types';
+
+export const TASK_ASSET_ID_PREFIX = 'task-asset:';
+
+export const taskCatalogOption = (asset: TaskCatalogAsset): WorkflowCanvasTaskOption => ({
+  id: `${TASK_ASSET_ID_PREFIX}${asset.id}`,
+  label: asset.name,
+  typeLabel: '数据开发',
+  taskType: asset.taskType,
+  taskAssetId: asset.id,
+  taskRevisionId: asset.currentRevision.taskRevisionId,
+  taskRevisionNo: asset.currentRevision.revisionNo,
+  meta: `已发布 v${asset.currentRevision.revisionNo}`,
+});
+
+export const taskAssetIdFromTaskId = (taskId: string) =>
+  taskId.startsWith(TASK_ASSET_ID_PREFIX)
+    ? taskId.slice(TASK_ASSET_ID_PREFIX.length).trim()
+    : undefined;
+
+export const resolveWorkflowTaskOption = async (
+  taskId: string,
+  knownOptions: WorkflowCanvasTaskOption[],
+): Promise<WorkflowCanvasTaskOption | undefined> => {
+  const known = knownOptions.find((option) => option.id === taskId);
+  if (known) return known;
+  const assetId = taskAssetIdFromTaskId(taskId);
+  if (!assetId) return undefined;
+  return taskCatalogOption(await getTaskCatalogAsset(assetId));
+};

--- a/yak-ops-ui/src/pages/workflow/definition/canvas/types.ts
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/types.ts
@@ -8,6 +8,10 @@ export interface WorkflowCanvasTaskOption {
   label: string;
   typeLabel: string;
   taskType?: string;
+  meta?: string;
+  taskAssetId?: string;
+  taskRevisionId?: string;
+  taskRevisionNo?: number;
 }
 
 /**
@@ -30,6 +34,13 @@ export interface WorkflowNodeData {
   taskId: string;
   taskType: string;
   typeLabel: string;
+  taskAssetId?: string;
+  taskRevisionId?: string;
+  taskRevisionNo?: number;
+  taskAssetStatus?: string;
+  latestTaskRevisionId?: string;
+  latestTaskRevisionNo?: number;
+  taskRevisionUpdateAvailable?: boolean;
   triggerRule: WorkflowTriggerRule;
   failurePolicy: WorkflowNodeFailurePolicy;
   maxAttempts: number;

--- a/yak-ops-ui/src/services/taskCatalog/index.ts
+++ b/yak-ops-ui/src/services/taskCatalog/index.ts
@@ -1,0 +1,45 @@
+import type { ApiResponse } from '@/services/http/response';
+import { request } from '@umijs/max';
+
+export interface TaskCatalogRevisionRef {
+  taskAssetId: string;
+  taskRevisionId: string;
+  revisionNo: number;
+}
+
+export interface TaskCatalogAsset {
+  id: string;
+  source: string;
+  sourceRef: string;
+  projectId?: string;
+  name: string;
+  taskType: string;
+  status: string;
+  currentRevision: TaskCatalogRevisionRef;
+}
+
+const assetCache = new Map<string, TaskCatalogAsset>();
+const remember = (asset: TaskCatalogAsset) => {
+  assetCache.set(String(asset.id), asset);
+  return asset;
+};
+
+export const getCachedTaskCatalogAsset = (assetId: string) => assetCache.get(String(assetId));
+
+export const listTaskCatalogAssets = async (params?: {
+  source?: string;
+  status?: string;
+  keyword?: string;
+}) => {
+  const response = await request<ApiResponse<TaskCatalogAsset[]>>('/api/v1/task-catalog/assets', {
+    params,
+  });
+  return (response.data || []).map(remember);
+};
+
+export const getTaskCatalogAsset = async (assetId: string) => {
+  const response = await request<ApiResponse<TaskCatalogAsset>>(
+    `/api/v1/task-catalog/assets/${encodeURIComponent(assetId)}`,
+  );
+  return remember(response.data);
+};

--- a/yak-ops-ui/src/services/workflow/definitions.ts
+++ b/yak-ops-ui/src/services/workflow/definitions.ts
@@ -1,4 +1,8 @@
 import type { ApiResponse } from '@/services/http/response';
+import {
+  getCachedTaskCatalogAsset,
+  getTaskCatalogAsset,
+} from '@/services/taskCatalog';
 import { request } from '@umijs/max';
 import type {
   WorkflowFailureStrategy,
@@ -11,6 +15,15 @@ export type WorkflowDefinitionStatus = 'DRAFT' | 'ONLINE' | 'OFFLINE';
 export interface WorkflowDefinitionNode {
   id: string;
   taskId: string;
+  taskAssetId?: string;
+  taskRevisionId?: string;
+  taskRevisionNo?: number;
+  taskAssetName?: string;
+  taskType?: string;
+  taskAssetStatus?: string;
+  latestTaskRevisionId?: string;
+  latestTaskRevisionNo?: number;
+  taskRevisionUpdateAvailable?: boolean;
   positionX: number;
   positionY: number;
   maxAttempts: number;
@@ -36,9 +49,7 @@ export interface WorkflowDefinition {
   edgeCount: number;
   nodes: WorkflowDefinitionNode[];
   edges: WorkflowDefinitionEdge[];
-  /** 仅运行时输入；不再包含 ReactFlow/Start/Note 编辑信息。 */
   input: Record<string, unknown>;
-  /** 仅编辑器使用；不会进入工作流运行 input。 */
   editorMeta: Record<string, unknown>;
   workflowTimeoutSeconds: number;
   failureStrategy: WorkflowFailureStrategy;
@@ -85,12 +96,58 @@ export interface WorkflowDefinitionUpdatePayload {
   failureStrategy: WorkflowFailureStrategy;
 }
 
+interface PinnedBinding {
+  taskAssetId: string;
+  taskRevisionId: string;
+  taskRevisionNo: number;
+}
+
+const bindingCache = new Map<string, PinnedBinding>();
+const bindingKey = (workflowId: string, nodeId: string) => `${workflowId}::${nodeId}`;
+const taskAssetIdFromTaskId = (taskId: string) =>
+  taskId.startsWith('task-asset:') ? taskId.slice('task-asset:'.length).trim() : undefined;
+
+const rememberDefinitionBindings = (definition: WorkflowDefinition) => {
+  definition.nodes.forEach((node) => {
+    if (!node.taskAssetId || !node.taskRevisionId || !node.taskRevisionNo) return;
+    bindingCache.set(bindingKey(definition.id, node.id), {
+      taskAssetId: node.taskAssetId,
+      taskRevisionId: node.taskRevisionId,
+      taskRevisionNo: node.taskRevisionNo,
+    });
+  });
+  return definition;
+};
+
+const pinCatalogNode = async (
+  workflowId: string,
+  node: WorkflowDefinitionNode,
+): Promise<WorkflowDefinitionNode> => {
+  if (node.taskAssetId && node.taskRevisionId && node.taskRevisionNo) return node;
+  const assetId = taskAssetIdFromTaskId(node.taskId);
+  if (!assetId) return node;
+
+  const pinned = bindingCache.get(bindingKey(workflowId, node.id));
+  if (pinned && pinned.taskAssetId === assetId) {
+    return { ...node, ...pinned, taskId: `task-asset:${assetId}` };
+  }
+
+  const asset = getCachedTaskCatalogAsset(assetId) || await getTaskCatalogAsset(assetId);
+  return {
+    ...node,
+    taskId: `task-asset:${asset.id}`,
+    taskAssetId: asset.id,
+    taskRevisionId: asset.currentRevision.taskRevisionId,
+    taskRevisionNo: asset.currentRevision.revisionNo,
+  };
+};
+
 const definitionAction = async (id: string, action: string) => {
   const response = await request<ApiResponse<WorkflowDefinition>>(
     `/api/v1/workflows/definitions/${encodeURIComponent(id)}/${action}`,
     { method: 'POST' },
   );
-  return response.data;
+  return rememberDefinitionBindings(response.data);
 };
 
 export const listWorkflowDefinitions = async (params?: {
@@ -104,32 +161,39 @@ export const listWorkflowDefinitions = async (params?: {
   return response.data || [];
 };
 
-export const createWorkflowDefinition = async (
-  payload: WorkflowDefinitionCreatePayload,
-) => {
+export const createWorkflowDefinition = async (payload: WorkflowDefinitionCreatePayload) => {
   const response = await request<ApiResponse<WorkflowDefinition>>(
     '/api/v1/workflows/definitions',
     { method: 'POST', data: payload },
   );
-  return response.data;
+  return rememberDefinitionBindings(response.data);
 };
 
 export const getWorkflowDefinition = async (id: string) => {
   const response = await request<ApiResponse<WorkflowDefinition>>(
     `/api/v1/workflows/definitions/${encodeURIComponent(id)}`,
   );
-  return response.data;
+  return rememberDefinitionBindings(response.data);
 };
 
 export const updateWorkflowDefinition = async (
   id: string,
   payload: WorkflowDefinitionUpdatePayload,
 ) => {
+  const nodes = await Promise.all(payload.nodes.map((node) => pinCatalogNode(id, node)));
   const response = await request<ApiResponse<WorkflowDefinition>>(
     `/api/v1/workflows/definitions/${encodeURIComponent(id)}`,
-    { method: 'PUT', data: payload },
+    { method: 'PUT', data: { ...payload, nodes } },
   );
-  return response.data;
+  return rememberDefinitionBindings(response.data);
+};
+
+export const upgradeWorkflowNodeTaskRevision = async (id: string, nodeId: string) => {
+  const response = await request<ApiResponse<WorkflowDefinition>>(
+    `/api/v1/workflows/definitions/${encodeURIComponent(id)}/nodes/${encodeURIComponent(nodeId)}/upgrade-task-revision`,
+    { method: 'POST' },
+  );
+  return rememberDefinitionBindings(response.data);
 };
 
 export const deleteWorkflowDefinition = async (id: string) => {
@@ -137,6 +201,9 @@ export const deleteWorkflowDefinition = async (id: string) => {
     `/api/v1/workflows/definitions/${encodeURIComponent(id)}`,
     { method: 'DELETE' },
   );
+  for (const key of Array.from(bindingCache.keys())) {
+    if (key.startsWith(`${id}::`)) bindingCache.delete(key);
+  }
 };
 
 export const onlineWorkflowDefinition = (id: string) => definitionAction(id, 'online');

--- a/yak-ops-ui/src/services/workflow/index.ts
+++ b/yak-ops-ui/src/services/workflow/index.ts
@@ -1,5 +1,6 @@
-import { request } from '@umijs/max';
 import type { ApiResponse } from '@/services/http/response';
+import { listTaskCatalogAssets } from '@/services/taskCatalog';
+import { request } from '@umijs/max';
 
 export type WorkflowFailureStrategy =
   | 'FAIL_FAST'
@@ -20,6 +21,9 @@ export interface WorkflowTaskDefinition {
   id: string;
   name: string;
   type: string;
+  taskAssetId?: string;
+  taskRevisionId?: string;
+  taskRevisionNo?: number;
 }
 
 export interface WorkflowNodePayload {
@@ -128,8 +132,21 @@ export const isWorkflowTerminal = (status?: string) =>
   Boolean(status && TERMINAL_STATUSES.has(status));
 
 export const getWorkflowTasks = async () => {
-  const response = await request<ApiResponse<WorkflowTaskDefinition[]>>('/api/v1/tasks');
-  return response.data;
+  const [response, assets] = await Promise.all([
+    request<ApiResponse<WorkflowTaskDefinition[]>>('/api/v1/tasks'),
+    listTaskCatalogAssets({ source: 'DATA_DEVELOPMENT', status: 'ONLINE' }).catch(() => []),
+  ]);
+  const merged = new Map<string, WorkflowTaskDefinition>();
+  (response.data || []).forEach((task) => merged.set(task.id, task));
+  assets.forEach((asset) => merged.set(`task-asset:${asset.id}`, {
+    id: `task-asset:${asset.id}`,
+    name: asset.name,
+    type: asset.taskType,
+    taskAssetId: asset.id,
+    taskRevisionId: asset.currentRevision.taskRevisionId,
+    taskRevisionNo: asset.currentRevision.revisionNo,
+  }));
+  return Array.from(merged.values());
 };
 
 export const runWorkflow = async (payload: WorkflowRunPayload) => {
@@ -259,10 +276,7 @@ const openWorkflowEventSubscription = (
   };
   source.addEventListener('workflow', handleWorkflowEvent);
   source.onopen = () => stopFallbackPolling();
-  source.onerror = () => {
-    // EventSource 会自行重连；重连期间用低频 authenticated request 保证状态不会停住。
-    startFallbackPolling();
-  };
+  source.onerror = () => startFallbackPolling();
 
   function cleanupActive() {
     if (activeClosed) return;
@@ -274,7 +288,6 @@ const openWorkflowEventSubscription = (
   }
 
   subscription.closeActive = cleanupActive;
-  // 首帧主动读取一次，随后以 SSE 为主；不会再在健康连接下每 500ms 打接口。
   void poll();
 };
 


### PR DESCRIPTION
## 背景

Stage 5 已经完成 `TaskAsset / Task Catalog`，数据开发发布后的任务可以被 Workflow 发现。本 PR 完成 Stage 6：**Workflow 节点正式绑定 `TaskAsset + immutable TaskRevision`**，保证已发布工作流不会因为任务资产发布新版本而静默改变执行语义。

## 核心语义

```text
今天统计 v1
  ↓ publish
TaskAsset #12 -> currentRevision v1
  ↓ 添加到 Workflow
Workflow Node
  taskAssetId = 12
  taskRevisionId = 101
  taskRevisionNo = 1
  ↓ publish
Workflow v1 固定 TaskRevision v1

随后 今天统计 发布 v2：
TaskAsset #12 -> currentRevision v2
Workflow v1 仍然固定 v1

用户显式点击「升级到 v2」
  ↓
只修改 Workflow draft
  ↓ 重新发布
Workflow v2 固定 TaskRevision v2
```

## 1. Source-neutral immutable Revision Resolver

Task Catalog 新增：

```text
TaskAssetRevisionProvider
TaskSourceRevision
TaskAssetRevision
```

Task Catalog 根据 `TaskAsset.source + sourceRef + revisionId` 解析来源域拥有的不可变 Revision，自身不依赖 Data Development 表结构。

当前接入：

```text
DATA_DEVELOPMENT
  -> DataDevelopmentTaskRevisionProvider
  -> DevelopmentTaskRevisionRepository.findById(...)
```

并校验 Revision 必须属于当前 sourceRef，避免跨任务错误绑定。

后续 `DATA_INTEGRATION / DATA_QUALITY / INTERNAL` 可以实现同一 SPI。

## 2. Workflow Node 正式持久化固定版本

`WorkflowNodeSpec` / DTO / VO 增加：

```text
taskAssetId
taskRevisionId
taskRevisionNo
```

Catalog 节点稳定逻辑 ID：

```text
taskId = task-asset:<taskAssetId>
```

Legacy TaskRegistry 节点继续兼容原来的 `taskId`，不做破坏式迁移。

Workflow definition/version 本身已经 JSON 持久化节点规格，因此 Stage 6 不需要新增 Workflow DB migration。

## 3. 发布时冻结 immutable TaskVersionSnapshot

Workflow 发布/测试准备阶段不再对 Catalog 节点读取 `TaskAsset.currentRevision` 作为执行版本，而是解析节点已经固定的：

```text
taskAssetId + taskRevisionId + taskRevisionNo
```

然后构造现有 `TaskVersionSnapshot`：

```text
name
taskType
revisionNo
checksum
TaskDefinition snapshot
execution config snapshot
```

因此 WorkflowVersion 一旦发布，就不受后续 TaskAsset latest revision 变化影响。

## 4. 不自动升级，只显式升级 Draft

Workflow Node VO 同时返回：

```text
当前固定：taskRevisionId / taskRevisionNo
资产最新：latestTaskRevisionId / latestTaskRevisionNo
是否可升级：taskRevisionUpdateAvailable
```

新增接口：

```http
POST /api/v1/workflows/definitions/{workflowId}/nodes/{nodeId}/upgrade-task-revision
```

约束：

- 普通保存不会静默升级；
- TaskAsset 发布 v2/v3 不扫描、不修改 Workflow；
- 显式升级只修改 Workflow draft；
- 当前 active WorkflowVersion 保持旧版本；
- 需要重新发布 Workflow 后，新 Revision 才成为 active version；
- OFFLINE TaskAsset 不允许升级到新版本。

## 5. Workflow UI 开放数据开发任务添加

Stage 5 的数据开发 Catalog Task 从「只展示」升级为可选择：

```text
数据开发
  今天统计                         已发布 v2
```

支持通过现有画布新增节点入口添加。

前端在新 Catalog 节点首次保存时固定当前 published revision；已有节点后续普通保存优先保留服务端已固定 binding，避免因为 Catalog 缓存刷新发生隐式升级。

## 6. 节点 Inspector 增加任务版本区域

TaskAsset 节点新增：

```text
任务版本

当前固定    v1
资产最新    v2
资产状态    已上线

[升级到 v2]
```

支持手动刷新最新版本；升级完成后明确提示「重新发布工作流后生效」。

## 7. Task Catalog API 补强

新增：

```http
GET /api/v1/task-catalog/assets/{assetId}
```

同时 TaskAsset / TaskRevision Long ID 对前端按字符串序列化，避免 JavaScript Number 精度问题。

## 8. Tests

新增测试覆盖：

- Data Development Revision Provider 只解析属于指定 source node 的 Revision；
- Workflow 固定 TaskAsset v1；
- 发布 Workflow v1 后 TaskAsset 推进到 v2，Workflow 仍保持 v1；
- `taskRevisionUpdateAvailable=true`；
- 显式升级只改变 draft，active version 仍为 Workflow v1；
- 重新发布后生成 Workflow v2，并固定 TaskRevision v2。

## 9. 文档

新增：

```text
docs/workflow-task-revision-stage-6.md
```

记录绑定模型、Resolver SPI、版本生命周期、UI、API 和 Runtime 边界。

## Runtime 边界

本阶段完成的是 **Workflow binding / version reproducibility**。

Stage 4 已支持 Data Development 中 SQL 手动真实执行，但当前 Workflow `TaskExecutionGateway` 还没有注册 SQL `TaskExecutor`。因此 Stage 6 可以完成：

```text
SQL TaskAsset
  -> 添加 Workflow
  -> 固定 SQL TaskRevision
  -> 保存/发布 WorkflowVersion
  -> 检测新版本
  -> 显式升级 Revision
```

但 SQL 节点真正进入 Workflow `test-run / run`，仍需要下一阶段把 SQL runtime 正式接入 `TaskExecutionGateway`。

本 PR 不通过临时旁路执行 SQL，避免形成两套执行语义。

## Validation

分支已重新基于 Stage 5 合并后的当前 `main` 整理，并确认：

```text
ahead 1
behind 0
```

同时排除了 Stage 5 合并期间 `main` 上首页/导航的无关变化，本 PR diff 只保留 Stage 6 相关文件。

本次通过 GitHub connector 直接完成代码修改，没有完整本地 checkout，因此 **尚未实际执行 Maven / npm 构建**。合并前建议执行：

```bash
mvn -pl yak-ops-business/yak-ops-business-task-catalog -am test
mvn -pl yak-ops-business/yak-ops-business-data-development -am test
mvn -pl yak-ops-business/yak-ops-business-workflow -am test
mvn -pl yak-ops-boot -am package -DskipTests

cd yak-ops-ui
npm run tsc
npm run build
```

建议浏览器回归：新增数据开发 TaskAsset 节点、保存固定 v1、来源发布 v2 后刷新版本、显式升级、重新发布 Workflow。

## Next

Stage 7 建议进入统一 Runtime：给 `TaskExecutionGateway` 接入 SQL `TaskExecutor`，让 Stage 4 的 SQL 执行能力与 Workflow immutable `TaskVersionSnapshot` 真正闭环。