### PR TITLE
feat(workflow): unify SQL runtime for pinned task revisions

### DIFF
--- a/docs/workflow-sql-runtime-stage-7.md
+++ b/docs/workflow-sql-runtime-stage-7.md
@@ -1,0 +1,71 @@
+# Workflow SQL Runtime · Stage 7
+
+## 目标
+
+Stage 7 将 Workflow 的通用 `TaskExecutionGateway` 与 Stage 4 已落地的 SQL Task Plugin Runtime 接通，使 Workflow 的 `run / test-run` 可以执行 Stage 6 固定下来的 SQL `TaskVersionSnapshot`。
+
+核心约束只有一条：**运行时只消费工作流已经固定的不可变任务快照，禁止重新读取 Data Development 草稿、TaskAsset 当前版本或最新 TaskRevision。**
+
+## 执行链路
+
+```text
+WorkflowVersion / test-run
+  -> TaskVersionSnapshot(SQL)
+  -> TaskExecutionGateway
+  -> SqlTaskExecutorAdapter
+  -> TaskPluginRegistry
+  -> SqlTaskPlugin / SqlTaskExecutor
+  -> DataSourceExecutionProvider
+  -> JDBC
+```
+
+`WorkflowRuntimeService` 仍然只依赖通用 `TaskExecutionGateway`，SQL 特有逻辑不会进入 Workflow Engine。
+
+## 快照语义
+
+Stage 6 在工作流保存/发布时已经将具体 `TaskRevision` 解析成 `TaskVersionSnapshot`，其中 `definitionSnapshotJson` 保存完整的 `TaskDefinition`。
+
+Stage 7 的 `SqlTaskExecutorAdapter`：
+
+- 只反序列化 `definitionSnapshotJson` 创建 SQL Plugin Executor；
+- 不依赖 Data Development Repository；
+- 不依赖 Task Catalog Service；
+- 不查询“当前草稿”或“最新版本”；
+- 快照缺失时直接失败，不提供 fallback。
+
+因此：工作流 v1 固定 SQL v1 后，即使任务资产已经发布 SQL v2，工作流 v1 后续运行仍执行 SQL v1。只有显式升级工作流草稿中的 TaskRevision 并重新发布，才会切换到 v2。
+
+## 生命周期映射
+
+SQL Plugin 的执行状态统一映射到 Workflow Task Runtime：
+
+| Task Plugin | TaskExecutionGateway |
+| --- | --- |
+| `PENDING` | `PENDING` |
+| `RUNNING` | `RUNNING` |
+| `SUCCESS` | `SUCCEEDED` |
+| `FAILED` | `FAILED` |
+| `CANCELLED` | `CANCELED` |
+| `TIMEOUT` | `TIMED_OUT` |
+
+SQL Adapter 使用虚拟线程异步执行插件，`start` 返回后 Workflow 延续现有轮询模型；`cancel` 继续调用插件的取消能力，最终由 Stage 4 的 JDBC SQL Executor 向底层 Statement 传播取消。
+
+## 幂等
+
+Workflow 使用当前 node attemptId 作为 `idempotencyKey`。SQL Adapter 对同一个 key 重复 `start` 返回同一个 SQL execution，避免恢复/重复提交时产生第二次物理 SQL 执行。
+
+## 与现有能力的边界
+
+- SYNC：保持现有 `SyncTaskExecutorAdapter` 不变；
+- SQL 手动运行：继续使用 Stage 4 的 `DevelopmentTaskRunService -> TaskPluginRegistry`；
+- SQL Workflow 运行：通过本阶段新增的 `SqlTaskExecutorAdapter -> TaskPluginRegistry`；
+- 两条入口最终复用同一个 `SqlTaskPlugin / SqlTaskExecutor / DataSourceExecutionProvider`，不维护两套 SQL 实现。
+
+## 回归重点
+
+- 固定 SQL v1 后发布 SQL v2，旧 Workflow 仍执行 v1；
+- 缺失 `definitionSnapshotJson` 时直接失败，不能回读最新任务定义；
+- SQL 成功输出（columns / rows / affectedRows 等）原样进入 Workflow node output；
+- SQL FAILED / TIMEOUT / CANCELLED 正确映射为 Workflow 可识别状态；
+- 同一个 Workflow attempt 重复启动不会产生重复 SQL execution；
+- SYNC 任务执行路径不受影响。

--- a/yak-ops-business/yak-ops-business-job/pom.xml
+++ b/yak-ops-business/yak-ops-business-job/pom.xml
@@ -23,11 +23,23 @@
         </dependency>
         <dependency>
             <groupId>io.yak.ops</groupId>
+            <artifactId>yak-ops-plugin-task-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.yak.ops</groupId>
+            <artifactId>yak-ops-plugin-datasource-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.yak.ops</groupId>
             <artifactId>yak-ops-business-sync-offline</artifactId>
         </dependency>
         <dependency>
             <groupId>io.yak.framework</groupId>
             <artifactId>yak-schedule-spring-boot-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/task/SqlTaskExecutorAdapter.java
+++ b/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/task/SqlTaskExecutorAdapter.java
@@ -1,0 +1,246 @@
+package io.yak.ops.business.job.task;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.core.plugin.task.TaskPluginRegistry;
+import io.yak.ops.plugin.task.api.TaskExecutionContext;
+import io.yak.ops.plugin.task.api.TaskExecutionResult;
+import io.yak.ops.plugin.task.api.TaskPlugin;
+import io.yak.ops.plugin.task.api.TaskValidationIssue;
+import io.yak.ops.plugin.task.api.TaskValidationResult;
+import io.yak.ops.spi.datasource.execution.DataSourceExecutionProvider;
+import io.yak.ops.spi.task.model.TaskDefinition;
+import io.yak.ops.spi.task.model.TaskExecutionStatus;
+import io.yak.ops.spi.task.model.TaskExecutionTrigger;
+import jakarta.annotation.PreDestroy;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicReference;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.stereotype.Service;
+
+/** Executes workflow-pinned SQL revisions through the same TaskPlugin runtime as manual SQL runs. */
+@Service
+public class SqlTaskExecutorAdapter implements TaskExecutor {
+
+  private final TaskPluginRegistry pluginRegistry;
+  private final ObjectProvider<DataSourceExecutionProvider> dataSourceExecutionProvider;
+  private final ObjectMapper objectMapper;
+  private final ExecutorService workerExecutor;
+  private final ConcurrentMap<String, ExecutionHandle> executions = new ConcurrentHashMap<>();
+  private final ConcurrentMap<String, String> idempotencyIndex = new ConcurrentHashMap<>();
+
+  public SqlTaskExecutorAdapter(
+      TaskPluginRegistry pluginRegistry,
+      ObjectProvider<DataSourceExecutionProvider> dataSourceExecutionProvider,
+      ObjectMapper objectMapper) {
+    this.pluginRegistry = pluginRegistry;
+    this.dataSourceExecutionProvider = dataSourceExecutionProvider;
+    this.objectMapper = objectMapper;
+    this.workerExecutor = Executors.newVirtualThreadPerTaskExecutor();
+  }
+
+  @Override
+  public String taskType() {
+    return "SQL";
+  }
+
+  @Override
+  public synchronized TaskExecution start(
+      TaskVersionSnapshot snapshot,
+      String idempotencyKey,
+      Map<String, Object> input) {
+    requireSqlSnapshot(snapshot);
+    String safeIdempotencyKey = normalizeIdempotencyKey(idempotencyKey);
+    if (safeIdempotencyKey != null) {
+      String existingExecutionId = idempotencyIndex.get(safeIdempotencyKey);
+      if (existingExecutionId != null) {
+        return status(existingExecutionId);
+      }
+    }
+
+    TaskDefinition definition = immutableDefinition(snapshot);
+    TaskPlugin plugin = pluginRegistry.require("SQL");
+    if (!plugin.descriptor().executable()) {
+      throw new IllegalStateException("SQL Task Plugin 暂不支持执行");
+    }
+    validate(plugin, definition);
+
+    DataSourceExecutionProvider provider = dataSourceExecutionProvider.getIfAvailable();
+    SqlExecutionContext context = new SqlExecutionContext(input, provider);
+    io.yak.ops.plugin.task.api.TaskExecutor pluginExecutor =
+        plugin.createExecutor(definition, context);
+
+    String executionId = "sql-" + UUID.randomUUID();
+    TaskExecution initial = new TaskExecution(executionId, "RUNNING", null, Map.of());
+    ExecutionHandle handle = new ExecutionHandle(pluginExecutor, new AtomicReference<>(initial));
+    executions.put(executionId, handle);
+    if (safeIdempotencyKey != null) {
+      idempotencyIndex.put(safeIdempotencyKey, executionId);
+    }
+
+    try {
+      workerExecutor.submit(() -> execute(executionId, handle));
+    } catch (RuntimeException exception) {
+      TaskExecution failed = new TaskExecution(
+          executionId,
+          "FAILED",
+          safeMessage(exception),
+          Map.of());
+      handle.snapshot().set(failed);
+      return failed;
+    }
+    return initial;
+  }
+
+  @Override
+  public TaskExecution status(String executionId) {
+    ExecutionHandle handle = executions.get(executionId);
+    if (handle == null) {
+      throw new IllegalArgumentException("SQL 任务执行不存在：" + executionId);
+    }
+    return handle.snapshot().get();
+  }
+
+  @Override
+  public void cancel(String executionId) {
+    ExecutionHandle handle = executions.get(executionId);
+    if (handle == null) {
+      throw new IllegalArgumentException("SQL 任务执行不存在：" + executionId);
+    }
+    TaskExecution current = handle.snapshot().get();
+    if (current.terminal()) return;
+
+    handle.executor().cancel();
+    handle.snapshot().updateAndGet(existing -> existing.terminal()
+        ? existing
+        : new TaskExecution(executionId, "CANCELED", "SQL execution cancelled", existing.output()));
+  }
+
+  @PreDestroy
+  void shutdown() {
+    workerExecutor.shutdownNow();
+  }
+
+  private void execute(String executionId, ExecutionHandle handle) {
+    try {
+      TaskExecutionResult result = handle.executor().execute();
+      TaskExecution completed = convert(executionId, result);
+      handle.snapshot().updateAndGet(current -> current.terminal() ? current : completed);
+    } catch (Exception exception) {
+      TaskExecution failed = new TaskExecution(
+          executionId,
+          "FAILED",
+          safeMessage(exception),
+          Map.of());
+      handle.snapshot().updateAndGet(current -> current.terminal() ? current : failed);
+    }
+  }
+
+  private TaskExecution convert(String executionId, TaskExecutionResult result) {
+    String status = switch (result.status()) {
+      case PENDING -> "PENDING";
+      case RUNNING -> "RUNNING";
+      case SUCCESS -> "SUCCEEDED";
+      case FAILED -> "FAILED";
+      case CANCELLED -> "CANCELED";
+      case TIMEOUT -> "TIMED_OUT";
+    };
+    String errorMessage = result.status() == TaskExecutionStatus.SUCCESS ? null : result.message();
+    return new TaskExecution(executionId, status, errorMessage, result.output());
+  }
+
+  private TaskDefinition immutableDefinition(TaskVersionSnapshot snapshot) {
+    String definitionJson = snapshot.definitionSnapshotJson();
+    if (definitionJson == null || definitionJson.isBlank()) {
+      throw new IllegalArgumentException(
+          "SQL 任务缺少不可变 definitionSnapshot，拒绝回退到当前草稿或最新版本：" + snapshot.taskId());
+    }
+    try {
+      TaskDefinition definition = objectMapper.readValue(definitionJson, TaskDefinition.class);
+      if (!"SQL".equalsIgnoreCase(definition.taskType())) {
+        throw new IllegalArgumentException(
+            "SQL 任务快照类型不匹配：snapshot=SQL, definition=" + definition.taskType());
+      }
+      return definition;
+    } catch (JsonProcessingException exception) {
+      throw new IllegalArgumentException("SQL 任务不可变 definitionSnapshot 不是合法 JSON", exception);
+    }
+  }
+
+  private void requireSqlSnapshot(TaskVersionSnapshot snapshot) {
+    if (snapshot == null) {
+      throw new IllegalArgumentException("任务版本快照不能为空");
+    }
+    if (!"SQL".equalsIgnoreCase(snapshot.type())) {
+      throw new IllegalArgumentException("SQL 执行器不能执行任务类型：" + snapshot.type());
+    }
+  }
+
+  private void validate(TaskPlugin plugin, TaskDefinition definition) {
+    TaskValidationResult validation = plugin.validate(definition);
+    if (validation.valid()) return;
+    String summary = validation.issues().stream()
+        .map(TaskValidationIssue::message)
+        .limit(3)
+        .reduce((left, right) -> left + "；" + right)
+        .orElse("SQL 任务定义校验失败");
+    throw new IllegalArgumentException(summary);
+  }
+
+  private String normalizeIdempotencyKey(String idempotencyKey) {
+    if (idempotencyKey == null || idempotencyKey.isBlank()) return null;
+    return idempotencyKey.trim();
+  }
+
+  private String safeMessage(Throwable throwable) {
+    String message = throwable == null ? null : throwable.getMessage();
+    if (message == null || message.isBlank()) {
+      return throwable == null ? "SQL execution failed" : throwable.getClass().getSimpleName();
+    }
+    return message.length() > 500 ? message.substring(0, 500) : message;
+  }
+
+  private record ExecutionHandle(
+      io.yak.ops.plugin.task.api.TaskExecutor executor,
+      AtomicReference<TaskExecution> snapshot) {
+  }
+
+  private record SqlExecutionContext(
+      Map<String, Object> input,
+      DataSourceExecutionProvider dataSourceExecutionProvider)
+      implements TaskExecutionContext {
+
+    private SqlExecutionContext {
+      input = input == null
+          ? Map.of()
+          : Collections.unmodifiableMap(new LinkedHashMap<>(input));
+    }
+
+    @Override
+    public TaskExecutionTrigger trigger() {
+      return TaskExecutionTrigger.WORKFLOW;
+    }
+
+    @Override
+    public Map<String, Object> parameters() {
+      return input;
+    }
+
+    @Override
+    public <T> Optional<T> capability(Class<T> capabilityType) {
+      if (dataSourceExecutionProvider != null
+          && capabilityType.isInstance(dataSourceExecutionProvider)) {
+        return Optional.of(capabilityType.cast(dataSourceExecutionProvider));
+      }
+      return Optional.empty();
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-job/src/test/java/io/yak/ops/business/job/task/SqlTaskExecutorAdapterTest.java
+++ b/yak-ops-business/yak-ops-business-job/src/test/java/io/yak/ops/business/job/task/SqlTaskExecutorAdapterTest.java
@@ -1,0 +1,164 @@
+package io.yak.ops.business.job.task;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.core.plugin.task.TaskPluginRegistry;
+import io.yak.ops.plugin.task.api.TaskExecutionContext;
+import io.yak.ops.plugin.task.api.TaskExecutionResult;
+import io.yak.ops.plugin.task.api.TaskPlugin;
+import io.yak.ops.plugin.task.api.TaskPluginDescriptor;
+import io.yak.ops.plugin.task.api.TaskValidationResult;
+import io.yak.ops.spi.datasource.execution.DataSourceExecutionProvider;
+import io.yak.ops.spi.task.model.TaskDefinition;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+
+class SqlTaskExecutorAdapterTest {
+
+  private SqlTaskExecutorAdapter adapter;
+
+  @AfterEach
+  void tearDown() {
+    if (adapter != null) adapter.shutdown();
+  }
+
+  @Test
+  void executesDefinitionFromImmutableSnapshot() throws Exception {
+    ObjectMapper objectMapper = new ObjectMapper();
+    RecordingSqlPlugin plugin = new RecordingSqlPlugin(
+        TaskExecutionResult.success(Map.of("version", "v1")));
+    adapter = new SqlTaskExecutorAdapter(
+        TaskPluginRegistry.from(List.of(plugin)),
+        emptyDataSourceProvider(),
+        objectMapper);
+
+    TaskDefinition frozenV1 = new TaskDefinition(
+        "SQL",
+        1,
+        "select 1 as version",
+        "{\"dataSourceId\":\"1\"}");
+    TaskVersionSnapshot snapshot = new TaskVersionSnapshot(
+        "task-asset:12",
+        "今天统计",
+        "SQL",
+        1L,
+        "checksum-v1",
+        objectMapper.writeValueAsString(frozenV1),
+        frozenV1.configJson());
+
+    TaskExecution started = adapter.start(snapshot, "attempt-1", Map.of("bizDate", "2026-08-12"));
+    TaskExecution completed = awaitTerminal(started.executionId());
+
+    assertTrue(completed.successful());
+    assertEquals("v1", completed.output().get("version"));
+    assertEquals("select 1 as version", plugin.definition.get().content());
+    assertEquals("2026-08-12", plugin.context.get().parameters().get("bizDate"));
+  }
+
+  @Test
+  void rejectsMissingImmutableSnapshotWithoutFallback() {
+    adapter = new SqlTaskExecutorAdapter(
+        TaskPluginRegistry.from(List.of(new RecordingSqlPlugin(TaskExecutionResult.success(Map.of())))),
+        emptyDataSourceProvider(),
+        new ObjectMapper());
+    TaskVersionSnapshot snapshot = new TaskVersionSnapshot(
+        "task-asset:12", "今天统计", "SQL", 1L, "checksum-v1", null, null);
+
+    IllegalArgumentException exception = assertThrows(
+        IllegalArgumentException.class,
+        () -> adapter.start(snapshot, "attempt-1", Map.of()));
+
+    assertTrue(exception.getMessage().contains("拒绝回退"));
+  }
+
+  @Test
+  void reusesExecutionForSameWorkflowAttempt() throws Exception {
+    ObjectMapper objectMapper = new ObjectMapper();
+    RecordingSqlPlugin plugin = new RecordingSqlPlugin(
+        TaskExecutionResult.success(Map.of("ok", true)));
+    adapter = new SqlTaskExecutorAdapter(
+        TaskPluginRegistry.from(List.of(plugin)),
+        emptyDataSourceProvider(),
+        objectMapper);
+    TaskDefinition definition = new TaskDefinition("SQL", 1, "select 1", "{}");
+    TaskVersionSnapshot snapshot = new TaskVersionSnapshot(
+        "task-asset:12",
+        "SQL",
+        "SQL",
+        1L,
+        "checksum-v1",
+        objectMapper.writeValueAsString(definition),
+        definition.configJson());
+
+    TaskExecution first = adapter.start(snapshot, "same-attempt", Map.of());
+    TaskExecution second = adapter.start(snapshot, "same-attempt", Map.of());
+
+    assertEquals(first.executionId(), second.executionId());
+    assertSame(plugin.definition.get(), plugin.definition.get());
+  }
+
+  private TaskExecution awaitTerminal(String executionId) throws InterruptedException {
+    Instant deadline = Instant.now().plus(Duration.ofSeconds(2));
+    TaskExecution current = adapter.status(executionId);
+    while (!current.terminal() && Instant.now().isBefore(deadline)) {
+      Thread.sleep(10L);
+      current = adapter.status(executionId);
+    }
+    assertTrue(current.terminal(), "SQL execution should become terminal");
+    return current;
+  }
+
+  @SuppressWarnings("unchecked")
+  private ObjectProvider<DataSourceExecutionProvider> emptyDataSourceProvider() {
+    ObjectProvider<DataSourceExecutionProvider> provider = mock(ObjectProvider.class);
+    when(provider.getIfAvailable()).thenReturn(null);
+    return provider;
+  }
+
+  private static final class RecordingSqlPlugin implements TaskPlugin {
+    private final TaskExecutionResult result;
+    private final AtomicReference<TaskDefinition> definition = new AtomicReference<>();
+    private final AtomicReference<TaskExecutionContext> context = new AtomicReference<>();
+
+    private RecordingSqlPlugin(TaskExecutionResult result) {
+      this.result = result;
+    }
+
+    @Override
+    public TaskPluginDescriptor descriptor() {
+      return new TaskPluginDescriptor(
+          "SQL", "SQL", "test SQL plugin", "1.0.0", 1, true, true);
+    }
+
+    @Override
+    public TaskValidationResult validate(TaskDefinition definition) {
+      return TaskValidationResult.ok();
+    }
+
+    @Override
+    public io.yak.ops.plugin.task.api.TaskExecutor createExecutor(
+        TaskDefinition definition,
+        TaskExecutionContext context) {
+      this.definition.set(definition);
+      this.context.set(context);
+      return new io.yak.ops.plugin.task.api.TaskExecutor() {
+        @Override
+        public TaskExecutionResult execute() {
+          return result;
+        }
+      };
+    }
+  }
+}


### PR DESCRIPTION
## Stage 7 · 统一 SQL Runtime

### 背景

Stage 4 已经打通 Data Development 的真实 SQL Task Plugin / DataSource JDBC 执行链路；Stage 6 又让 Workflow 固定到不可变的 `TaskRevision`。本阶段把两者正式接起来，让 Workflow 的 SQL 节点复用同一套 SQL Runtime。

### 调整内容

- 新增 `SqlTaskExecutorAdapter`，作为 `TaskExecutionGateway` 的 `SQL` 执行器
- Workflow SQL 执行链路统一为：
  - `TaskVersionSnapshot`
  - `TaskExecutionGateway`
  - `SqlTaskExecutorAdapter`
  - `TaskPluginRegistry`
  - `SqlTaskPlugin / SqlTaskExecutor`
  - `DataSourceExecutionProvider`
  - JDBC
- SQL Adapter **只读取 Stage 6 固定的 `definitionSnapshotJson`**
- 缺失 immutable definition snapshot 时直接失败，禁止 fallback 到 Data Development 草稿 / TaskAsset 最新版本 / 最新 TaskRevision
- 保持现有 SYNC `SyncTaskExecutorAdapter` 不变
- 使用虚拟线程承载本地 SQL Plugin 执行，继续适配 Workflow 现有 `start/status/cancel` 轮询模型
- 统一状态映射：
  - `SUCCESS -> SUCCEEDED`
  - `FAILED -> FAILED`
  - `CANCELLED -> CANCELED`
  - `TIMEOUT -> TIMED_OUT`
- SQL Plugin output 原样透传给 Workflow node output
- 使用 Workflow attemptId 作为幂等 key，同一个 attempt 重复 start 不会产生第二次 SQL execution
- 补充 Stage 7 设计说明与 `SqlTaskExecutorAdapterTest`

### 不变项

- 不改 Workflow Engine
- 不创建第二套 SQL/JDBC 实现
- 不改变 SQL 手动运行入口
- 不改变 SYNC Runtime
- 不在运行阶段重新解析 Task Catalog 当前版本

### Validation

- [x] 分支基于 Stage 6 已合并后的 `main`
- [x] diff 仅包含 Stage 7 SQL Runtime、依赖、单测和文档
- [x] 单测覆盖 immutable snapshot 执行
- [x] 单测覆盖 snapshot 缺失时禁止 fallback
- [x] 单测覆盖 Workflow attempt 幂等启动
- [ ] Maven 测试：当前执行环境无法直接访问 GitHub/拉取仓库，因此未在本会话中实际跑 Maven；请由本地或 CI 执行 `./mvnw -pl yak-ops-business/yak-ops-business-job -am test`

### 后续

Stage 7 完成后，Workflow 发布版本已经具备真正的 SQL 物理执行能力，后续阶段可以继续在统一 Task Runtime 上扩展 Shell / Python / HTTP 等任务类型，而不把具体执行逻辑塞进 Workflow。