### PR TITLE
refactor(task-runtime): unify manual SQL execution

### DIFF
--- a/docs/workflow-sql-runtime-stage-7.md
+++ b/docs/workflow-sql-runtime-stage-7.md
@@ -1,17 +1,49 @@
-# Workflow SQL Runtime · Stage 7
+# Unified Task Runtime · Stage 7
 
 ## 目标
 
-Stage 7 将 Workflow 的通用 `TaskExecutionGateway` 与 Stage 4 已落地的 SQL Task Plugin Runtime 接通，使 Workflow 的 `run / test-run` 可以执行 Stage 6 固定下来的 SQL `TaskVersionSnapshot`。
-
-核心约束只有一条：**运行时只消费工作流已经固定的不可变任务快照，禁止重新读取 Data Development 草稿、TaskAsset 当前版本或最新 TaskRevision。**
-
-## 执行链路
+Stage 7 将 Manual Run、Workflow Run 和后续 Schedule Run 收敛到同一个 `TaskExecutionGateway`，由 Runtime 根据任务类型路由到具体 `TaskExecutor`，再进入对应 `TaskPlugin`。
 
 ```text
-WorkflowVersion / test-run
-  -> TaskVersionSnapshot(SQL)
-  -> TaskExecutionGateway
+Manual Run   ─┐
+Workflow Run ─┼─> TaskExecutionGateway
+Schedule Run ─┘          |
+                         v
+                   TaskExecutor
+                         |
+                         v
+                     TaskPlugin
+```
+
+本阶段先完成 SQL 任务的统一入口，不扩展 Shell / Python，也不改变现有前端手动运行接口。
+
+## 统一触发来源
+
+Runtime 的启动入口现在显式携带 `TaskExecutionTrigger`：
+
+- `MANUAL`：Data Development 编辑器手动运行；
+- `WORKFLOW`：Workflow 节点运行，旧的 `start(...)` 入口默认保持该语义；
+- `SCHEDULE`：为后续调度入口预留统一语义。
+
+`SqlTaskExecutorAdapter` 不再把 trigger 固定为 `WORKFLOW`，而是将 Runtime 收到的 trigger 原样传入 `TaskExecutionContext`。
+
+## Manual Run
+
+Data Development 手动运行不再直接调用：
+
+```text
+DevelopmentTaskRunService
+  -> TaskPluginRegistry
+  -> SqlTaskPlugin
+```
+
+现在统一为：
+
+```text
+DevelopmentTaskRunService
+  -> 当前编辑器 TaskDefinition
+  -> 临时 TaskVersionSnapshot(version = 0)
+  -> TaskExecutionGateway(trigger = MANUAL)
   -> SqlTaskExecutorAdapter
   -> TaskPluginRegistry
   -> SqlTaskPlugin / SqlTaskExecutor
@@ -19,27 +51,32 @@ WorkflowVersion / test-run
   -> JDBC
 ```
 
-`WorkflowRuntimeService` 仍然只依赖通用 `TaskExecutionGateway`，SQL 特有逻辑不会进入 Workflow Engine。
+这里的 `version = 0` 明确表示“当前未发布草稿的运行时快照”，不会污染 Task Catalog，也不会伪装成已发布 TaskRevision。
 
-## 快照语义
+手动运行 API 仍保持原来的同步返回体验：Runtime 内部异步执行，`DevelopmentTaskRunService` 通过统一 `status` 接口等待终态后映射回现有 `DevelopmentTaskRunResult`。
 
-Stage 6 在工作流保存/发布时已经将具体 `TaskRevision` 解析成 `TaskVersionSnapshot`，其中 `definitionSnapshotJson` 保存完整的 `TaskDefinition`。
+## Workflow Run
 
-Stage 7 的 `SqlTaskExecutorAdapter`：
+Workflow 继续消费 Stage 6 已经固定的不可变 `TaskVersionSnapshot`：
 
-- 只反序列化 `definitionSnapshotJson` 创建 SQL Plugin Executor；
-- 不依赖 Data Development Repository；
-- 不依赖 Task Catalog Service；
-- 不查询“当前草稿”或“最新版本”；
-- 快照缺失时直接失败，不提供 fallback。
+```text
+WorkflowVersion / test-run
+  -> TaskVersionSnapshot(SQL)
+  -> TaskExecutionGateway(trigger = WORKFLOW)
+  -> SqlTaskExecutorAdapter
+  -> TaskPluginRegistry
+  -> SqlTaskPlugin / SqlTaskExecutor
+```
+
+核心约束保持不变：**工作流运行时只消费已经固定的不可变任务快照，禁止重新读取 Data Development 草稿、TaskAsset 当前版本或最新 TaskRevision。**
 
 因此：工作流 v1 固定 SQL v1 后，即使任务资产已经发布 SQL v2，工作流 v1 后续运行仍执行 SQL v1。只有显式升级工作流草稿中的 TaskRevision 并重新发布，才会切换到 v2。
 
 ## 生命周期映射
 
-SQL Plugin 的执行状态统一映射到 Workflow Task Runtime：
+SQL Plugin 的执行状态统一映射到 Task Runtime：
 
-| Task Plugin | TaskExecutionGateway |
+| Task Plugin | TaskExecution |
 | --- | --- |
 | `PENDING` | `PENDING` |
 | `RUNNING` | `RUNNING` |
@@ -48,24 +85,29 @@ SQL Plugin 的执行状态统一映射到 Workflow Task Runtime：
 | `CANCELLED` | `CANCELED` |
 | `TIMEOUT` | `TIMED_OUT` |
 
-SQL Adapter 使用虚拟线程异步执行插件，`start` 返回后 Workflow 延续现有轮询模型；`cancel` 继续调用插件的取消能力，最终由 Stage 4 的 JDBC SQL Executor 向底层 Statement 传播取消。
+SQL Adapter 使用虚拟线程异步执行插件；`start`、`status`、`cancel` 均由同一 Runtime 抽象对外提供。取消仍调用插件执行器的取消能力，并最终向 JDBC Statement 传播。
 
 ## 幂等
 
-Workflow 使用当前 node attemptId 作为 `idempotencyKey`。SQL Adapter 对同一个 key 重复 `start` 返回同一个 SQL execution，避免恢复/重复提交时产生第二次物理 SQL 执行。
+Workflow 使用当前 node attemptId 作为 `idempotencyKey`，同一个 attempt 重复 `start` 返回同一个 SQL execution，避免恢复或重复提交时产生第二次物理 SQL 执行。
 
-## 与现有能力的边界
+Manual Run 不传固定 `idempotencyKey`，每次用户点击运行都会创建一次新的物理执行，符合编辑器调试语义。
 
-- SYNC：保持现有 `SyncTaskExecutorAdapter` 不变；
-- SQL 手动运行：继续使用 Stage 4 的 `DevelopmentTaskRunService -> TaskPluginRegistry`；
-- SQL Workflow 运行：通过本阶段新增的 `SqlTaskExecutorAdapter -> TaskPluginRegistry`；
-- 两条入口最终复用同一个 `SqlTaskPlugin / SqlTaskExecutor / DataSourceExecutionProvider`，不维护两套 SQL 实现。
+## 边界
+
+- SQL：Manual / Workflow 已统一进入 `TaskExecutionGateway -> SqlTaskExecutorAdapter -> TaskPlugin`；
+- SYNC：保持现有 `SyncTaskExecutorAdapter`，通过兼容入口继续工作；
+- Schedule：Runtime 已具备 `SCHEDULE` trigger 入口，具体调度接线可在后续阶段使用同一 Gateway；
+- 本阶段不新增 Shell / Python；
+- 本阶段不引入持久化 `TaskExecution` 表，当前执行句柄仍由具体 Runtime Adapter 管理。
 
 ## 回归重点
 
+- Manual Run 必须以 `MANUAL` trigger 进入 SQL Plugin；
+- Workflow 旧入口必须继续默认使用 `WORKFLOW` trigger；
 - 固定 SQL v1 后发布 SQL v2，旧 Workflow 仍执行 v1；
 - 缺失 `definitionSnapshotJson` 时直接失败，不能回读最新任务定义；
-- SQL 成功输出（columns / rows / affectedRows 等）原样进入 Workflow node output；
-- SQL FAILED / TIMEOUT / CANCELLED 正确映射为 Workflow 可识别状态；
+- SQL 成功输出原样进入调用方 output；
+- SQL FAILED / TIMEOUT / CANCELLED 正确映射到统一状态；
 - 同一个 Workflow attempt 重复启动不会产生重复 SQL execution；
 - SYNC 任务执行路径不受影响。

--- a/yak-ops-business/yak-ops-business-data-development/pom.xml
+++ b/yak-ops-business/yak-ops-business-data-development/pom.xml
@@ -45,6 +45,10 @@
             <groupId>io.yak.ops</groupId>
             <artifactId>yak-ops-business-task-catalog</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.yak.ops</groupId>
+            <artifactId>yak-ops-business-job</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentTaskRunService.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentTaskRunService.java
@@ -6,41 +6,32 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.yak.ops.business.development.domain.DevelopmentNode;
 import io.yak.ops.business.development.domain.DevelopmentTaskRunResult;
 import io.yak.ops.business.development.repository.DevelopmentNodeRepository;
-import io.yak.ops.core.plugin.task.TaskPluginRegistry;
-import io.yak.ops.plugin.task.api.TaskExecutionContext;
-import io.yak.ops.plugin.task.api.TaskExecutionResult;
-import io.yak.ops.plugin.task.api.TaskExecutor;
-import io.yak.ops.plugin.task.api.TaskPlugin;
+import io.yak.ops.business.job.task.TaskExecution;
+import io.yak.ops.business.job.task.TaskExecutionGateway;
+import io.yak.ops.business.job.task.TaskVersionSnapshot;
 import io.yak.ops.plugin.task.api.TaskValidationIssue;
-import io.yak.ops.plugin.task.api.TaskValidationResult;
-import io.yak.ops.spi.datasource.execution.DataSourceExecutionProvider;
 import io.yak.ops.spi.task.model.TaskDefinition;
 import io.yak.ops.spi.task.model.TaskExecutionStatus;
 import io.yak.ops.spi.task.model.TaskExecutionTrigger;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Optional;
-import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.stereotype.Service;
 
-/** Executes the current editor definition through the platform TaskPlugin contract. */
+/** Executes the current editor definition through the shared Task Runtime. */
 @Service
 public class DevelopmentTaskRunService {
 
   private final DevelopmentNodeRepository nodeRepository;
-  private final TaskPluginRegistry pluginRegistry;
-  private final ObjectProvider<DataSourceExecutionProvider> dataSourceExecutionProvider;
+  private final TaskExecutionGateway taskExecutionGateway;
   private final ObjectMapper objectMapper;
 
   public DevelopmentTaskRunService(
       DevelopmentNodeRepository nodeRepository,
-      TaskPluginRegistry pluginRegistry,
-      ObjectProvider<DataSourceExecutionProvider> dataSourceExecutionProvider,
+      TaskExecutionGateway taskExecutionGateway,
       ObjectMapper objectMapper) {
     this.nodeRepository = nodeRepository;
-    this.pluginRegistry = pluginRegistry;
-    this.dataSourceExecutionProvider = dataSourceExecutionProvider;
+    this.taskExecutionGateway = taskExecutionGateway;
     this.objectMapper = objectMapper;
   }
 
@@ -53,45 +44,41 @@ public class DevelopmentTaskRunService {
     DevelopmentNode node = requireNode(nodeId);
     TaskDefinition definition =
         normalizeDefinition(node, taskType, schemaVersion, content, configJson);
-    TaskPlugin plugin =
-        pluginRegistry
-            .find(definition.taskType())
-            .orElseThrow(
-                () ->
-                    new DevelopmentTaskValidationException(
-                        "当前未安装 " + definition.taskType() + " Task Plugin，无法运行",
-                        List.of(
-                            new TaskValidationIssue(
-                                "TASK_PLUGIN_NOT_INSTALLED",
-                                "taskType",
-                                "Task plugin is not installed: " + definition.taskType()))));
-    if (!plugin.descriptor().executable()) {
+    if (!taskExecutionGateway.supports(definition.taskType())) {
       throw new DevelopmentTaskValidationException(
-          definition.taskType() + " Task Plugin 暂不支持执行",
+          "当前未安装 " + definition.taskType() + " Task Runtime，无法运行",
           List.of(
               new TaskValidationIssue(
-                  "TASK_PLUGIN_NOT_EXECUTABLE",
+                  "TASK_RUNTIME_NOT_INSTALLED",
                   "taskType",
-                  "Task plugin is not executable: " + definition.taskType())));
+                  "Task runtime is not installed: " + definition.taskType())));
     }
-    validate(plugin, definition);
 
     long started = System.nanoTime();
     try {
-      TaskExecutor executor =
-          plugin.createExecutor(
-              definition,
-              new ManualExecutionContext(
-                  nodeId,
-                  dataSourceExecutionProvider.getIfAvailable()));
-      TaskExecutionResult result = executor.execute();
+      TaskVersionSnapshot snapshot = currentDraftSnapshot(node, definition);
+      TaskExecution execution =
+          taskExecutionGateway.start(
+              snapshot,
+              TaskExecutionTrigger.MANUAL,
+              null,
+              Map.of("nodeId", String.valueOf(nodeId)));
+      TaskExecution completed = awaitTerminal(snapshot.type(), execution);
       return new DevelopmentTaskRunResult(
-          result.status(),
-          result.message(),
+          mapStatus(completed),
+          completed.errorMessage(),
           elapsedMillis(started),
-          result.output());
+          completed.output());
     } catch (DevelopmentTaskValidationException exception) {
       throw exception;
+    } catch (IllegalArgumentException exception) {
+      throw new DevelopmentTaskValidationException(
+          safeMessage(exception),
+          List.of(
+              new TaskValidationIssue(
+                  "TASK_RUNTIME_VALIDATION_FAILED",
+                  "definition",
+                  safeMessage(exception))));
     } catch (Exception exception) {
       String message = safeMessage(exception);
       return new DevelopmentTaskRunResult(
@@ -102,16 +89,54 @@ public class DevelopmentTaskRunService {
     }
   }
 
-  private void validate(TaskPlugin plugin, TaskDefinition definition) {
-    TaskValidationResult validation = plugin.validate(definition);
-    if (validation.valid()) return;
-    String summary =
-        validation.issues().stream()
-            .map(TaskValidationIssue::message)
-            .limit(3)
-            .reduce((left, right) -> left + "；" + right)
-            .orElse("任务定义校验失败");
-    throw new DevelopmentTaskValidationException(summary, validation.issues());
+  private TaskVersionSnapshot currentDraftSnapshot(
+      DevelopmentNode node,
+      TaskDefinition definition) {
+    try {
+      return new TaskVersionSnapshot(
+          "development:" + node.id(),
+          node.name(),
+          definition.taskType(),
+          0L,
+          null,
+          objectMapper.writeValueAsString(definition),
+          definition.configJson());
+    } catch (JsonProcessingException exception) {
+      throw new IllegalArgumentException("当前任务定义无法序列化为运行时快照", exception);
+    }
+  }
+
+  private TaskExecution awaitTerminal(String taskType, TaskExecution execution) {
+    TaskExecution current = execution;
+    while (!current.terminal()) {
+      try {
+        Thread.sleep(10L);
+      } catch (InterruptedException exception) {
+        Thread.currentThread().interrupt();
+        try {
+          taskExecutionGateway.cancel(taskType, current.executionId());
+        } catch (RuntimeException ignored) {
+          // Preserve the original interruption as the manual-run result.
+        }
+        throw new IllegalStateException("等待任务执行结果时被中断", exception);
+      }
+      current = taskExecutionGateway.status(taskType, current.executionId());
+    }
+    return current;
+  }
+
+  private TaskExecutionStatus mapStatus(TaskExecution execution) {
+    String status = execution.status() == null
+        ? ""
+        : execution.status().trim().toUpperCase(Locale.ROOT);
+    return switch (status) {
+      case "PENDING" -> TaskExecutionStatus.PENDING;
+      case "RUNNING" -> TaskExecutionStatus.RUNNING;
+      case "SUCCEEDED" -> TaskExecutionStatus.SUCCESS;
+      case "CANCELED" -> TaskExecutionStatus.CANCELLED;
+      case "TIMED_OUT" -> TaskExecutionStatus.TIMEOUT;
+      default -> TaskExecutionStatus.FAILED;
+    };
   }
 
   private DevelopmentNode requireNode(Long nodeId) {
@@ -166,30 +191,5 @@ public class DevelopmentTaskRunService {
       return throwable == null ? "任务执行失败" : throwable.getClass().getSimpleName();
     }
     return message.length() > 500 ? message.substring(0, 500) : message;
-  }
-
-  private record ManualExecutionContext(
-      Long nodeId,
-      DataSourceExecutionProvider dataSourceExecutionProvider)
-      implements TaskExecutionContext {
-
-    @Override
-    public TaskExecutionTrigger trigger() {
-      return TaskExecutionTrigger.MANUAL;
-    }
-
-    @Override
-    public Map<String, Object> parameters() {
-      return Map.of("nodeId", String.valueOf(nodeId));
-    }
-
-    @Override
-    public <T> Optional<T> capability(Class<T> capabilityType) {
-      if (dataSourceExecutionProvider != null
-          && capabilityType.isInstance(dataSourceExecutionProvider)) {
-        return Optional.of(capabilityType.cast(dataSourceExecutionProvider));
-      }
-      return Optional.empty();
-    }
   }
 }

--- a/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/DevelopmentTaskRunServiceTest.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/DevelopmentTaskRunServiceTest.java
@@ -2,7 +2,6 @@ package io.yak.ops.business.development.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -10,27 +9,23 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.yak.ops.business.development.domain.DevelopmentNode;
 import io.yak.ops.business.development.domain.DevelopmentTaskRunResult;
 import io.yak.ops.business.development.repository.DevelopmentNodeRepository;
-import io.yak.ops.core.plugin.task.TaskPluginRegistry;
-import io.yak.ops.plugin.task.api.TaskExecutionContext;
-import io.yak.ops.plugin.task.api.TaskExecutionResult;
-import io.yak.ops.plugin.task.api.TaskExecutor;
-import io.yak.ops.plugin.task.api.TaskPlugin;
-import io.yak.ops.plugin.task.api.TaskPluginDescriptor;
-import io.yak.ops.plugin.task.api.TaskValidationResult;
-import io.yak.ops.spi.datasource.execution.DataSourceExecutionProvider;
-import io.yak.ops.spi.task.model.TaskDefinition;
+import io.yak.ops.business.job.task.TaskExecution;
+import io.yak.ops.business.job.task.TaskExecutionGateway;
+import io.yak.ops.business.job.task.TaskExecutor;
+import io.yak.ops.business.job.task.TaskVersionSnapshot;
 import io.yak.ops.spi.task.model.TaskExecutionStatus;
+import io.yak.ops.spi.task.model.TaskExecutionTrigger;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.ObjectProvider;
 
 class DevelopmentTaskRunServiceTest {
 
   private DevelopmentTaskRunService service;
+  private RecordingRuntimeExecutor runtimeExecutor;
 
   @BeforeEach
   void setUp() {
@@ -41,48 +36,68 @@ class DevelopmentTaskRunServiceTest {
             Optional.of(
                 new DevelopmentNode(1L, "今天统计", "SQL", null, null, true, now, now)));
 
-    @SuppressWarnings("unchecked")
-    ObjectProvider<DataSourceExecutionProvider> provider = mock(ObjectProvider.class);
+    runtimeExecutor = new RecordingRuntimeExecutor();
     service =
         new DevelopmentTaskRunService(
             nodeRepository,
-            TaskPluginRegistry.from(List.of(new TestExecutablePlugin())),
-            provider,
+            new TaskExecutionGateway(List.of(runtimeExecutor)),
             new ObjectMapper());
   }
 
   @Test
-  void runsCurrentDefinitionWithoutDraftOrRevisionDependency() {
+  void runsCurrentDefinitionThroughSharedRuntimeWithManualTrigger() {
     DevelopmentTaskRunResult result =
         service.run(1L, "sql", 1, "select 42", "{\"dataSourceId\":\"7\"}");
 
     assertEquals(TaskExecutionStatus.SUCCESS, result.status());
-    assertEquals("select 42", result.output().get("sql"));
     assertEquals("MANUAL", result.output().get("trigger"));
+    assertTrue(String.valueOf(result.output().get("definition")).contains("select 42"));
+    assertEquals(TaskExecutionTrigger.MANUAL, runtimeExecutor.lastTrigger);
+    assertEquals("development:1", runtimeExecutor.lastSnapshot.taskId());
+    assertEquals(0L, runtimeExecutor.lastSnapshot.version());
     assertTrue(result.durationMs() >= 0L);
   }
 
-  private static final class TestExecutablePlugin implements TaskPlugin {
+  private static final class RecordingRuntimeExecutor implements TaskExecutor {
+    private TaskExecutionTrigger lastTrigger;
+    private TaskVersionSnapshot lastSnapshot;
 
     @Override
-    public TaskPluginDescriptor descriptor() {
-      return new TaskPluginDescriptor("SQL", "SQL", "test", "1.0.0", 1, true, false);
+    public String taskType() {
+      return "SQL";
     }
 
     @Override
-    public TaskValidationResult validate(TaskDefinition definition) {
-      return TaskValidationResult.ok();
+    public TaskExecution start(
+        TaskVersionSnapshot snapshot,
+        String idempotencyKey,
+        Map<String, Object> input) {
+      return start(snapshot, TaskExecutionTrigger.WORKFLOW, idempotencyKey, input);
     }
 
     @Override
-    public TaskExecutor createExecutor(
-        TaskDefinition definition,
-        TaskExecutionContext context) {
-      return () ->
-          TaskExecutionResult.success(
-              Map.of(
-                  "sql", definition.content(),
-                  "trigger", context.trigger().name()));
+    public TaskExecution start(
+        TaskVersionSnapshot snapshot,
+        TaskExecutionTrigger trigger,
+        String idempotencyKey,
+        Map<String, Object> input) {
+      this.lastTrigger = trigger;
+      this.lastSnapshot = snapshot;
+      return new TaskExecution(
+          "manual-1",
+          "SUCCEEDED",
+          null,
+          Map.of(
+              "trigger", trigger.name(),
+              "definition", snapshot.definitionSnapshotJson()));
     }
+
+    @Override
+    public TaskExecution status(String executionId) {
+      return new TaskExecution(executionId, "SUCCEEDED", null, Map.of());
+    }
+
+    @Override
+    public void cancel(String executionId) {}
   }
 }

--- a/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/task/SqlTaskExecutorAdapter.java
+++ b/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/task/SqlTaskExecutorAdapter.java
@@ -26,7 +26,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.stereotype.Service;
 
-/** Executes workflow-pinned SQL revisions through the same TaskPlugin runtime as manual SQL runs. */
+/** Executes SQL revisions through the shared Task Runtime and TaskPlugin contract. */
 @Service
 public class SqlTaskExecutorAdapter implements TaskExecutor {
 
@@ -53,11 +53,22 @@ public class SqlTaskExecutorAdapter implements TaskExecutor {
   }
 
   @Override
-  public synchronized TaskExecution start(
+  public TaskExecution start(
       TaskVersionSnapshot snapshot,
       String idempotencyKey,
       Map<String, Object> input) {
+    return start(snapshot, TaskExecutionTrigger.WORKFLOW, idempotencyKey, input);
+  }
+
+  @Override
+  public synchronized TaskExecution start(
+      TaskVersionSnapshot snapshot,
+      TaskExecutionTrigger trigger,
+      String idempotencyKey,
+      Map<String, Object> input) {
     requireSqlSnapshot(snapshot);
+    TaskExecutionTrigger safeTrigger =
+        trigger == null ? TaskExecutionTrigger.WORKFLOW : trigger;
     String safeIdempotencyKey = normalizeIdempotencyKey(idempotencyKey);
     if (safeIdempotencyKey != null) {
       String existingExecutionId = idempotencyIndex.get(safeIdempotencyKey);
@@ -74,7 +85,7 @@ public class SqlTaskExecutorAdapter implements TaskExecutor {
     validate(plugin, definition);
 
     DataSourceExecutionProvider provider = dataSourceExecutionProvider.getIfAvailable();
-    SqlExecutionContext context = new SqlExecutionContext(input, provider);
+    SqlExecutionContext context = new SqlExecutionContext(safeTrigger, input, provider);
     io.yak.ops.plugin.task.api.TaskExecutor pluginExecutor =
         plugin.createExecutor(definition, context);
 
@@ -214,19 +225,16 @@ public class SqlTaskExecutorAdapter implements TaskExecutor {
   }
 
   private record SqlExecutionContext(
+      TaskExecutionTrigger trigger,
       Map<String, Object> input,
       DataSourceExecutionProvider dataSourceExecutionProvider)
       implements TaskExecutionContext {
 
     private SqlExecutionContext {
+      trigger = trigger == null ? TaskExecutionTrigger.WORKFLOW : trigger;
       input = input == null
           ? Map.of()
           : Collections.unmodifiableMap(new LinkedHashMap<>(input));
-    }
-
-    @Override
-    public TaskExecutionTrigger trigger() {
-      return TaskExecutionTrigger.WORKFLOW;
     }
 
     @Override

--- a/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/task/TaskExecutionGateway.java
+++ b/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/task/TaskExecutionGateway.java
@@ -1,5 +1,6 @@
 package io.yak.ops.business.job.task;
 
+import io.yak.ops.spi.task.model.TaskExecutionTrigger;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -35,13 +36,23 @@ public class TaskExecutionGateway {
       TaskVersionSnapshot snapshot,
       String idempotencyKey,
       Map<String, Object> input) {
+    return start(snapshot, TaskExecutionTrigger.WORKFLOW, idempotencyKey, input);
+  }
+
+  public TaskExecution start(
+      TaskVersionSnapshot snapshot,
+      TaskExecutionTrigger trigger,
+      String idempotencyKey,
+      Map<String, Object> input) {
     if (snapshot == null) {
       throw new IllegalArgumentException("任务版本快照不能为空");
     }
+    TaskExecutionTrigger safeTrigger =
+        trigger == null ? TaskExecutionTrigger.WORKFLOW : trigger;
     Map<String, Object> safeInput = input == null
         ? Map.of()
         : Collections.unmodifiableMap(new LinkedHashMap<>(input));
-    return require(snapshot.type()).start(snapshot, idempotencyKey, safeInput);
+    return require(snapshot.type()).start(snapshot, safeTrigger, idempotencyKey, safeInput);
   }
 
   public TaskExecution status(String taskType, String executionId) {

--- a/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/task/TaskExecutor.java
+++ b/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/task/TaskExecutor.java
@@ -1,5 +1,6 @@
 package io.yak.ops.business.job.task;
 
+import io.yak.ops.spi.task.model.TaskExecutionTrigger;
 import java.util.Map;
 
 /**
@@ -16,6 +17,21 @@ public interface TaskExecutor {
       TaskVersionSnapshot snapshot,
       String idempotencyKey,
       Map<String, Object> input);
+
+  /**
+   * Trigger-aware runtime entry used by manual, workflow and schedule callers.
+   *
+   * <p>The default keeps existing executors source-compatible. Executors that need trigger-specific
+   * behavior can override this method while the legacy start method continues to represent a
+   * workflow-triggered execution.</p>
+   */
+  default TaskExecution start(
+      TaskVersionSnapshot snapshot,
+      TaskExecutionTrigger trigger,
+      String idempotencyKey,
+      Map<String, Object> input) {
+    return start(snapshot, idempotencyKey, input);
+  }
 
   TaskExecution status(String executionId);
 

--- a/yak-ops-business/yak-ops-business-job/src/test/java/io/yak/ops/business/job/task/SqlTaskExecutorAdapterTest.java
+++ b/yak-ops-business/yak-ops-business-job/src/test/java/io/yak/ops/business/job/task/SqlTaskExecutorAdapterTest.java
@@ -16,6 +16,7 @@ import io.yak.ops.plugin.task.api.TaskPluginDescriptor;
 import io.yak.ops.plugin.task.api.TaskValidationResult;
 import io.yak.ops.spi.datasource.execution.DataSourceExecutionProvider;
 import io.yak.ops.spi.task.model.TaskDefinition;
+import io.yak.ops.spi.task.model.TaskExecutionTrigger;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
@@ -65,6 +66,38 @@ class SqlTaskExecutorAdapterTest {
     assertEquals("v1", completed.output().get("version"));
     assertEquals("select 1 as version", plugin.definition.get().content());
     assertEquals("2026-08-12", plugin.context.get().parameters().get("bizDate"));
+    assertEquals(TaskExecutionTrigger.WORKFLOW, plugin.context.get().trigger());
+  }
+
+  @Test
+  void propagatesManualTriggerToPluginContext() throws Exception {
+    ObjectMapper objectMapper = new ObjectMapper();
+    RecordingSqlPlugin plugin = new RecordingSqlPlugin(
+        TaskExecutionResult.success(Map.of("ok", true)));
+    adapter = new SqlTaskExecutorAdapter(
+        TaskPluginRegistry.from(List.of(plugin)),
+        emptyDataSourceProvider(),
+        objectMapper);
+    TaskDefinition definition = new TaskDefinition("SQL", 1, "select 1", "{}");
+    TaskVersionSnapshot snapshot = new TaskVersionSnapshot(
+        "development:1",
+        "手动运行",
+        "SQL",
+        0L,
+        null,
+        objectMapper.writeValueAsString(definition),
+        definition.configJson());
+
+    TaskExecution started = adapter.start(
+        snapshot,
+        TaskExecutionTrigger.MANUAL,
+        null,
+        Map.of("nodeId", "1"));
+    TaskExecution completed = awaitTerminal(started.executionId());
+
+    assertTrue(completed.successful());
+    assertEquals(TaskExecutionTrigger.MANUAL, plugin.context.get().trigger());
+    assertEquals("1", plugin.context.get().parameters().get("nodeId"));
   }
 
   @Test

--- a/yak-ops-business/yak-ops-business-job/src/test/java/io/yak/ops/business/job/task/TaskExecutionGatewayTest.java
+++ b/yak-ops-business/yak-ops-business-job/src/test/java/io/yak/ops/business/job/task/TaskExecutionGatewayTest.java
@@ -3,6 +3,7 @@ package io.yak.ops.business.job.task;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import io.yak.ops.spi.task.model.TaskExecutionTrigger;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -10,16 +11,30 @@ import org.junit.jupiter.api.Test;
 class TaskExecutionGatewayTest {
 
   @Test
-  void shouldRouteByTaskType() {
-    TaskExecutionGateway gateway = new TaskExecutionGateway(List.of(new FakeExecutor("SQL")));
+  void shouldRouteByTaskTypeAndDefaultWorkflowTrigger() {
+    FakeExecutor executor = new FakeExecutor("SQL");
+    TaskExecutionGateway gateway = new TaskExecutionGateway(List.of(executor));
     TaskVersionSnapshot snapshot =
         new TaskVersionSnapshot("SQL:1", "demo", "sql", 1L, "digest", "{}", "{}");
 
     TaskExecution execution = gateway.start(snapshot, "attempt-1", Map.of("biz_date", "2026-08-10"));
 
     assertThat(execution.executionId()).isEqualTo("SQL-1");
+    assertThat(executor.lastTrigger).isEqualTo(TaskExecutionTrigger.WORKFLOW);
     assertThat(gateway.supports("sql")).isTrue();
     assertThat(gateway.status("SQL", execution.executionId()).successful()).isTrue();
+  }
+
+  @Test
+  void shouldPropagateManualTrigger() {
+    FakeExecutor executor = new FakeExecutor("SQL");
+    TaskExecutionGateway gateway = new TaskExecutionGateway(List.of(executor));
+    TaskVersionSnapshot snapshot =
+        new TaskVersionSnapshot("SQL:1", "demo", "sql", 0L, null, "{}", "{}");
+
+    gateway.start(snapshot, TaskExecutionTrigger.MANUAL, null, Map.of());
+
+    assertThat(executor.lastTrigger).isEqualTo(TaskExecutionTrigger.MANUAL);
   }
 
   @Test
@@ -32,6 +47,7 @@ class TaskExecutionGatewayTest {
 
   private static final class FakeExecutor implements TaskExecutor {
     private final String type;
+    private TaskExecutionTrigger lastTrigger;
 
     private FakeExecutor(String type) {
       this.type = type;
@@ -47,6 +63,16 @@ class TaskExecutionGatewayTest {
         TaskVersionSnapshot snapshot,
         String idempotencyKey,
         Map<String, Object> input) {
+      return start(snapshot, TaskExecutionTrigger.WORKFLOW, idempotencyKey, input);
+    }
+
+    @Override
+    public TaskExecution start(
+        TaskVersionSnapshot snapshot,
+        TaskExecutionTrigger trigger,
+        String idempotencyKey,
+        Map<String, Object> input) {
+      this.lastTrigger = trigger;
       return new TaskExecution("SQL-1", "SUCCEEDED", null, input);
     }
 


### PR DESCRIPTION
## Summary

- route Data Development manual SQL runs through the shared `TaskExecutionGateway`
- add trigger-aware runtime entry for `MANUAL` / `WORKFLOW` / `SCHEDULE`
- propagate the actual trigger into `SqlTaskExecutorAdapter` and the SQL `TaskExecutionContext`
- preserve the existing synchronous manual-run API by waiting on the unified runtime status
- keep Workflow's legacy `start(...)` behavior defaulting to `WORKFLOW`
- add regression coverage for gateway trigger routing, SQL trigger propagation, and manual runtime execution
- update Stage 7 documentation to describe the unified runtime path

## Why

Stage 7 previously unified Workflow SQL execution, but Data Development manual runs still bypassed Task Runtime and called `TaskPluginRegistry` directly. That left two execution entry paths and made status / cancellation / trigger semantics harder to extend consistently.

This change closes that gap so the target architecture becomes:

```text
Manual Run   ─┐
Workflow Run ─┼─> TaskExecutionGateway -> TaskExecutor -> TaskPlugin
Schedule Run ─┘
```

## Scope

- SQL manual/workflow runtime convergence only
- no frontend API changes
- no Shell/Python task implementation
- no persistent `TaskExecution` storage in this PR
- existing SYNC executor remains source-compatible

## Validation

Added/updated unit coverage for:

- default Workflow trigger behavior
- explicit Manual trigger propagation
- SQL plugin receiving the correct trigger
- Data Development manual run creating a draft runtime snapshot and using `MANUAL`

GitHub Actions should provide the final repository-level build/test result for this branch.