### PR TITLE
fix: ensure task catalog Flyway creates yak_task_asset

### DIFF
--- a/yak-ops-business/yak-ops-business-task-catalog/src/main/java/io/yak/ops/business/taskcatalog/config/TaskCatalogPersistenceConfiguration.java
+++ b/yak-ops-business/yak-ops-business-task-catalog/src/main/java/io/yak/ops/business/taskcatalog/config/TaskCatalogPersistenceConfiguration.java
@@ -5,6 +5,7 @@ import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
 import io.yak.ops.business.datasource.config.DataSourceProperties;
 import javax.sql.DataSource;
 import org.flywaydb.core.Flyway;
+import org.flywaydb.core.api.MigrationVersion;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -25,6 +26,7 @@ public class TaskCatalogPersistenceConfiguration {
         .dataSource(dataSource)
         .locations("classpath:db/migration/yak-task-catalog")
         .table("flyway_schema_history_task_catalog")
+        .baselineVersion(MigrationVersion.fromVersion("0"))
         .baselineOnMigrate(true)
         .load();
   }

--- a/yak-ops-business/yak-ops-business-task-catalog/src/main/resources/db/migration/yak-task-catalog/V2__ensure_task_asset_catalog.sql
+++ b/yak-ops-business/yak-ops-business-task-catalog/src/main/resources/db/migration/yak-task-catalog/V2__ensure_task_asset_catalog.sql
@@ -1,0 +1,21 @@
+-- Compatibility migration for environments that were previously baselined at V1.
+-- The original V1 may have been skipped when the shared business schema was non-empty.
+
+CREATE TABLE IF NOT EXISTS yak_task_asset (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    source VARCHAR(32) NOT NULL,
+    source_ref VARCHAR(128) NOT NULL,
+    project_id BIGINT NULL,
+    name VARCHAR(200) NOT NULL,
+    task_type VARCHAR(64) NOT NULL,
+    status VARCHAR(32) NOT NULL,
+    current_revision_id BIGINT NOT NULL,
+    current_revision_no INT NOT NULL,
+    create_time DATETIME(6) NOT NULL,
+    update_time DATETIME(6) NOT NULL,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_yak_task_asset_source_ref (source, source_ref),
+    KEY idx_yak_task_asset_catalog (status, source, task_type),
+    KEY idx_yak_task_asset_project (project_id, status),
+    KEY idx_yak_task_asset_update (update_time)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;


### PR DESCRIPTION
## 问题

`yak-ops-business-task-catalog` 使用独立 Flyway history，但与其他业务模块共享已有的业务数据库。当前配置启用了 `baselineOnMigrate(true)`，却没有指定 baseline version。

当业务 schema 已经非空、task catalog 第一次启用时，Flyway 可能直接以 V1 作为 baseline，导致 `V1__create_task_asset_catalog.sql` 被跳过，因此 `yak_task_asset` 不会自动创建。

## 修复

- 在 `TaskCatalogPersistenceConfiguration` 中增加 `baselineVersion(MigrationVersion.fromVersion("0"))`
  - 新环境会从 0 baseline，然后正常执行 V1
  - 与数据开发模块的 Flyway 配置保持一致
- 新增 `V2__ensure_task_asset_catalog.sql` 兼容迁移
  - 使用 `CREATE TABLE IF NOT EXISTS`
  - 对已经错误 baseline 到 V1 的现有数据库，下一次启动时会执行 V2 并自动补建 `yak_task_asset`
  - 对正常执行过 V1 的环境，V2 为幂等 no-op

## 预期结果

无需手工删除 `flyway_schema_history_task_catalog`。应用升级并重新启动后：

- 新环境：V1 正常创建 `yak_task_asset`
- 已错误 baseline 到 V1 的环境：V2 自动补建 `yak_task_asset`
- 已存在 `yak_task_asset` 的环境：不会重复建表或报错

## 范围

仅修改 task catalog 的 Flyway 配置和迁移 SQL，不涉及业务逻辑、前端或其他模块。