### PR TITLE
feat(sql-editor): add statement run gutter and folding

### DIFF
--- a/yak-ops-ui/src/global.less
+++ b/yak-ops-ui/src/global.less
@@ -146,3 +146,25 @@ ol {
 .ant-tree .ant-tree-switcher:before {
   display: none;
 }
+
+// SQL editor statement action: compact green play marker in Monaco's glyph margin.
+.yak-sql-run-glyph {
+  cursor: pointer;
+}
+
+.yak-sql-run-glyph::before {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 0;
+  height: 0;
+  border-top: 5px solid transparent;
+  border-bottom: 5px solid transparent;
+  border-left: 8px solid #22a06b;
+  content: '';
+  transform: translate(-42%, -50%);
+}
+
+.yak-sql-run-glyph:hover::before {
+  border-left-color: #138a5b;
+}

--- a/yak-ops-ui/src/pages/data-development/components/workbench/DevelopmentWorkbench.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/workbench/DevelopmentWorkbench.tsx
@@ -166,7 +166,7 @@ const DevelopmentWorkbench = ({
     }
   };
 
-  const runActiveTask = async () => {
+  const runActiveTask = async (contentOverride?: string) => {
     if (!activeNode || runningNodeIds.includes(activeNode.id)) return;
     const node = activeNode;
     const startedAt = Date.now();
@@ -184,8 +184,12 @@ const DevelopmentWorkbench = ({
 
     try {
       const definition = prepareDevelopmentTaskDefinition(node);
+      const runDefinition =
+        contentOverride === undefined
+          ? definition
+          : { ...definition, content: contentOverride };
       const result = responseData(
-        await runDevelopmentTask(node.id, definition),
+        await runDevelopmentTask(node.id, runDefinition),
         '运行任务失败',
       );
       setRunResults((current) => ({ ...current, [node.id]: result }));
@@ -380,6 +384,8 @@ const DevelopmentWorkbench = ({
             node={activeNode}
             directory={activeDirectory}
             definition={definition}
+            onRunContent={(content) => void runActiveTask(content)}
+            running={activeRunning}
           />
           <RightPanel
             node={activeNode}

--- a/yak-ops-ui/src/pages/data-development/components/workbench/EditorHost.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/workbench/EditorHost.tsx
@@ -5,14 +5,28 @@ interface EditorHostProps {
   node: DevelopmentNode;
   directory?: DevelopmentDirectory;
   definition: DevelopmentEditorDefinition;
+  onRunContent?: (content: string) => void;
+  running?: boolean;
 }
 
-const EditorHost = ({ node, directory, definition }: EditorHostProps) => {
+const EditorHost = ({
+  node,
+  directory,
+  definition,
+  onRunContent,
+  running,
+}: EditorHostProps) => {
   const Editor = definition.Editor;
 
   return (
     <section className="min-w-0 flex-1 overflow-hidden bg-white">
-      <Editor key={String(node.id)} node={node} directory={directory} />
+      <Editor
+        key={String(node.id)}
+        node={node}
+        directory={directory}
+        onRunContent={onRunContent}
+        running={running}
+      />
     </section>
   );
 };

--- a/yak-ops-ui/src/pages/data-development/editors/sql/SqlEditor.tsx
+++ b/yak-ops-ui/src/pages/data-development/editors/sql/SqlEditor.tsx
@@ -25,7 +25,11 @@ const defaultPosition: SqlEditorPosition = {
   selectionLength: 0,
 };
 
-export const SqlEditor = ({ node }: DevelopmentEditorContext) => {
+export const SqlEditor = ({
+  node,
+  onRunContent,
+  running,
+}: DevelopmentEditorContext) => {
   const session = useEditorSession(node.id, node.type);
   const metadataContext = useSqlMetadataContext(node.id);
   const [position, setPosition] = useState<SqlEditorPosition>(() => ({
@@ -62,6 +66,8 @@ export const SqlEditor = ({ node }: DevelopmentEditorContext) => {
           value={session.content}
           initialViewState={session.viewState}
           onChange={(value) => updateEditorSessionContent(node.id, value)}
+          onRunStatement={onRunContent}
+          running={running}
           onPositionChange={setPosition}
           onViewStateChange={(viewState) =>
             updateEditorSessionViewState(node.id, viewState)

--- a/yak-ops-ui/src/pages/data-development/editors/sql/components/SqlMonacoEditor.tsx
+++ b/yak-ops-ui/src/pages/data-development/editors/sql/components/SqlMonacoEditor.tsx
@@ -16,6 +16,7 @@ import { acquireSqlSnippetCompletionProvider } from '../completion/registerSqlSn
 import { bindSqlDiagnostics } from '../diagnostics/bindSqlDiagnostics';
 import { formatSqlText } from '../formatting/formatSqlText';
 import { setupMonacoEnvironment } from '../monaco/setupMonacoEnvironment';
+import { getSqlStatementRanges } from '../monaco/sqlStatementRanges';
 
 export interface SqlEditorPosition {
   lineNumber: number;
@@ -28,6 +29,8 @@ interface SqlMonacoEditorProps {
   value: string;
   initialViewState?: DevelopmentEditorViewState;
   onChange: (value: string) => void;
+  onRunStatement?: (sql: string) => void;
+  running?: boolean;
   onPositionChange?: (position: SqlEditorPosition) => void;
   onViewStateChange?: (viewState: DevelopmentEditorViewState) => void;
 }
@@ -67,6 +70,8 @@ const SqlMonacoEditor = ({
   value,
   initialViewState,
   onChange,
+  onRunStatement,
+  running,
   onPositionChange,
   onViewStateChange,
 }: SqlMonacoEditorProps) => {
@@ -74,12 +79,22 @@ const SqlMonacoEditor = ({
   const editorRef = useRef<monaco.editor.IStandaloneCodeEditor>();
   const modelRef = useRef<monaco.editor.ITextModel>();
   const onChangeRef = useRef(onChange);
+  const onRunStatementRef = useRef(onRunStatement);
+  const runningRef = useRef(running);
   const onPositionChangeRef = useRef(onPositionChange);
   const onViewStateChangeRef = useRef(onViewStateChange);
 
   useEffect(() => {
     onChangeRef.current = onChange;
   }, [onChange]);
+
+  useEffect(() => {
+    onRunStatementRef.current = onRunStatement;
+  }, [onRunStatement]);
+
+  useEffect(() => {
+    runningRef.current = running;
+  }, [running]);
 
   useEffect(() => {
     onPositionChangeRef.current = onPositionChange;
@@ -99,6 +114,15 @@ const SqlMonacoEditor = ({
     const snippetCompletionProvider = acquireSqlSnippetCompletionProvider();
     const hoverProvider = acquireSqlHoverProvider();
     const signatureHelpProvider = acquireSqlSignatureHelpProvider();
+    const foldingProvider = monaco.languages.registerFoldingRangeProvider('sql', {
+      provideFoldingRanges: (foldingModel) =>
+        getSqlStatementRanges(foldingModel.getValue())
+          .filter((statement) => statement.endLine > statement.startLine)
+          .map((statement) => ({
+            start: statement.startLine,
+            end: statement.endLine,
+          })),
+    });
 
     const uri = monaco.Uri.parse(
       `inmemory://yak-ops/data-development/sql/${encodeURIComponent(id)}.sql`,
@@ -127,7 +151,8 @@ const SqlMonacoEditor = ({
       renderWhitespace: 'selection',
       wordWrap: 'off',
       folding: true,
-      glyphMargin: false,
+      showFoldingControls: 'always',
+      glyphMargin: true,
       lineNumbersMinChars: 3,
       overviewRulerLanes: 0,
       hideCursorInOverviewRuler: true,
@@ -161,6 +186,21 @@ const SqlMonacoEditor = ({
 
     editorRef.current = editor;
     modelRef.current = model;
+
+    let statementRanges = getSqlStatementRanges(model.getValue());
+    const runDecorations = editor.createDecorationsCollection();
+    const refreshStatementDecorations = () => {
+      statementRanges = getSqlStatementRanges(model.getValue());
+      runDecorations.set(
+        statementRanges.map((statement) => ({
+          range: new monaco.Range(statement.startLine, 1, statement.startLine, 1),
+          options: {
+            glyphMarginClassName: 'yak-sql-run-glyph',
+          },
+        })),
+      );
+    };
+    refreshStatementDecorations();
 
     let wordWrapEnabled = false;
     let minimapEnabled = false;
@@ -249,7 +289,24 @@ const SqlMonacoEditor = ({
     };
 
     const contentDisposable = model.onDidChangeContent(() => {
+      refreshStatementDecorations();
       onChangeRef.current(model.getValue());
+    });
+    const gutterDisposable = editor.onMouseDown((event) => {
+      if (
+        event.target.type !== monaco.editor.MouseTargetType.GUTTER_GLYPH_MARGIN ||
+        runningRef.current ||
+        !onRunStatementRef.current
+      ) {
+        return;
+      }
+
+      const lineNumber = event.target.position?.lineNumber;
+      if (!lineNumber) return;
+      const statement = statementRanges.find(
+        (candidate) => candidate.startLine === lineNumber,
+      );
+      if (statement) onRunStatementRef.current(statement.sql);
     });
     const cursorDisposable = editor.onDidChangeCursorPosition(emitEditorState);
     const selectionDisposable = editor.onDidChangeCursorSelection(emitEditorState);
@@ -260,12 +317,14 @@ const SqlMonacoEditor = ({
     return () => {
       emitEditorState();
       contentDisposable.dispose();
+      gutterDisposable.dispose();
       cursorDisposable.dispose();
       selectionDisposable.dispose();
       scrollDisposable.dispose();
       commandBinding.dispose();
       diagnosticsBinding.dispose();
       metadataModelBinding.dispose();
+      foldingProvider.dispose();
       signatureHelpProvider.dispose();
       hoverProvider.dispose();
       snippetCompletionProvider.dispose();

--- a/yak-ops-ui/src/pages/data-development/editors/sql/components/SqlMonacoEditor.tsx
+++ b/yak-ops-ui/src/pages/data-development/editors/sql/components/SqlMonacoEditor.tsx
@@ -1,5 +1,6 @@
 import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
 import 'monaco-editor/esm/vs/basic-languages/sql/sql.contribution';
+import 'monaco-editor/esm/vs/editor/contrib/folding/browser/folding';
 import 'monaco-editor/esm/vs/editor/contrib/suggest/browser/suggestController';
 import { useEffect, useRef } from 'react';
 

--- a/yak-ops-ui/src/pages/data-development/editors/sql/monaco/sqlStatementRanges.ts
+++ b/yak-ops-ui/src/pages/data-development/editors/sql/monaco/sqlStatementRanges.ts
@@ -117,11 +117,6 @@ export const getSqlStatementRanges = (sql: string): SqlStatementRange[] => {
       index += 2;
       continue;
     }
-    if (current === '#') {
-      mode = 'line-comment';
-      index += 1;
-      continue;
-    }
     if (current === '/' && next === '*') {
       mode = 'block-comment';
       index += 2;

--- a/yak-ops-ui/src/pages/data-development/editors/sql/monaco/sqlStatementRanges.ts
+++ b/yak-ops-ui/src/pages/data-development/editors/sql/monaco/sqlStatementRanges.ts
@@ -1,0 +1,178 @@
+export interface SqlStatementRange {
+  startOffset: number;
+  endOffset: number;
+  startLine: number;
+  endLine: number;
+  sql: string;
+}
+
+type SqlScanMode =
+  | 'normal'
+  | 'single-quote'
+  | 'double-quote'
+  | 'backtick'
+  | 'bracket'
+  | 'line-comment'
+  | 'block-comment';
+
+const buildLineStarts = (sql: string) => {
+  const starts = [0];
+  for (let index = 0; index < sql.length; index += 1) {
+    if (sql[index] === '\n') starts.push(index + 1);
+  }
+  return starts;
+};
+
+const lineNumberAtOffset = (lineStarts: number[], offset: number) => {
+  let low = 0;
+  let high = lineStarts.length - 1;
+  while (low <= high) {
+    const middle = Math.floor((low + high) / 2);
+    if (lineStarts[middle] <= offset) {
+      low = middle + 1;
+    } else {
+      high = middle - 1;
+    }
+  }
+  return Math.max(1, high + 1);
+};
+
+const trimSegment = (sql: string, start: number, end: number) => {
+  let trimmedStart = start;
+  let trimmedEnd = end;
+  while (trimmedStart < trimmedEnd && /\s/.test(sql[trimmedStart])) {
+    trimmedStart += 1;
+  }
+  while (trimmedEnd > trimmedStart && /\s/.test(sql[trimmedEnd - 1])) {
+    trimmedEnd -= 1;
+  }
+  return { start: trimmedStart, end: trimmedEnd };
+};
+
+/**
+ * Split editor SQL into executable statement ranges without treating semicolons
+ * inside strings, quoted identifiers, or comments as statement delimiters.
+ */
+export const getSqlStatementRanges = (sql: string): SqlStatementRange[] => {
+  if (!sql.trim()) return [];
+
+  const segmentEnds: number[] = [];
+  let mode: SqlScanMode = 'normal';
+  let index = 0;
+
+  while (index < sql.length) {
+    const current = sql[index];
+    const next = sql[index + 1];
+
+    if (mode === 'line-comment') {
+      if (current === '\n') mode = 'normal';
+      index += 1;
+      continue;
+    }
+
+    if (mode === 'block-comment') {
+      if (current === '*' && next === '/') {
+        mode = 'normal';
+        index += 2;
+      } else {
+        index += 1;
+      }
+      continue;
+    }
+
+    if (mode === 'bracket') {
+      if (current === ']' && next === ']') {
+        index += 2;
+      } else if (current === ']') {
+        mode = 'normal';
+        index += 1;
+      } else {
+        index += 1;
+      }
+      continue;
+    }
+
+    if (
+      mode === 'single-quote' ||
+      mode === 'double-quote' ||
+      mode === 'backtick'
+    ) {
+      const quote =
+        mode === 'single-quote' ? "'" : mode === 'double-quote' ? '"' : '`';
+      if (current === '\\' && next !== undefined) {
+        index += 2;
+      } else if (current === quote && next === quote) {
+        index += 2;
+      } else if (current === quote) {
+        mode = 'normal';
+        index += 1;
+      } else {
+        index += 1;
+      }
+      continue;
+    }
+
+    if (current === '-' && next === '-') {
+      mode = 'line-comment';
+      index += 2;
+      continue;
+    }
+    if (current === '#') {
+      mode = 'line-comment';
+      index += 1;
+      continue;
+    }
+    if (current === '/' && next === '*') {
+      mode = 'block-comment';
+      index += 2;
+      continue;
+    }
+    if (current === "'") {
+      mode = 'single-quote';
+      index += 1;
+      continue;
+    }
+    if (current === '"') {
+      mode = 'double-quote';
+      index += 1;
+      continue;
+    }
+    if (current === '`') {
+      mode = 'backtick';
+      index += 1;
+      continue;
+    }
+    if (current === '[') {
+      mode = 'bracket';
+      index += 1;
+      continue;
+    }
+    if (current === ';') segmentEnds.push(index + 1);
+    index += 1;
+  }
+
+  if (!segmentEnds.length || segmentEnds[segmentEnds.length - 1] < sql.length) {
+    segmentEnds.push(sql.length);
+  }
+
+  const lineStarts = buildLineStarts(sql);
+  const ranges: SqlStatementRange[] = [];
+  let segmentStart = 0;
+
+  segmentEnds.forEach((segmentEnd) => {
+    const trimmed = trimSegment(sql, segmentStart, segmentEnd);
+    segmentStart = segmentEnd;
+    if (trimmed.start >= trimmed.end) return;
+
+    const endOffsetForLine = Math.max(trimmed.start, trimmed.end - 1);
+    ranges.push({
+      startOffset: trimmed.start,
+      endOffset: trimmed.end,
+      startLine: lineNumberAtOffset(lineStarts, trimmed.start),
+      endLine: lineNumberAtOffset(lineStarts, endOffsetForLine),
+      sql: sql.slice(trimmed.start, trimmed.end),
+    });
+  });
+
+  return ranges;
+};

--- a/yak-ops-ui/src/pages/data-development/editors/types.ts
+++ b/yak-ops-ui/src/pages/data-development/editors/types.ts
@@ -17,6 +17,8 @@ export type DevelopmentEditorPanelKey =
 export interface DevelopmentEditorContext {
   node: DevelopmentNode;
   directory?: DevelopmentDirectory;
+  onRunContent?: (content: string) => void;
+  running?: boolean;
 }
 
 export interface DevelopmentEditorToolbarContext


### PR DESCRIPTION
## What changed

- Add a compact green run action in Monaco's gutter for each SQL statement.
- Clicking a gutter run action executes only that statement through the existing task run API and reuses the current result panel; the top toolbar run action still executes the full editor content.
- Add SQL statement range parsing that ignores semicolons inside strings, quoted identifiers, and comments.
- Load Monaco's folding contribution and register statement-level folding ranges, with folding controls always visible.
- Keep statement execution transient: it does not rewrite editor content or implicitly save the draft.

## Validation

- Reviewed the branch diff against `main`; changes are limited to the SQL editor/workbench integration and gutter styling.
- The repository returned no GitHub Actions workflow runs or commit status checks for the head commit, so there is no CI result to report for this PR.
