### PR TITLE
refactor: redesign datasource create/edit as drawer

### DIFF
--- a/yak-ops-ui/src/pages/data-source/components/AddOrEditDataSourceModal.tsx
+++ b/yak-ops-ui/src/pages/data-source/components/AddOrEditDataSourceModal.tsx
@@ -1,6 +1,6 @@
 import { API_SUCCESS_CODE } from "@/services/http/response";
 import { useIntl } from "@umijs/max";
-import { Button, Form, message, Modal } from "antd";
+import { Button, Drawer, Form, message } from "antd";
 import { forwardRef, useImperativeHandle, useRef, useState } from "react";
 
 import { dataSourceGroupList } from "../constants";
@@ -20,6 +20,9 @@ import { DataSourceOperateType } from "../types";
 import { buildSubmitPayload, parseOriginalJson } from "../utils";
 import DataSourceTypeSelector from "./DataSourceTypeSelector";
 import DynamicDataSourceForm from "./DynamicDataSourceForm";
+import "./DataSourceEditorDrawer.less";
+
+const DRAWER_WIDTH = 620;
 
 const AddOrEditDataSourceModal = forwardRef<DataSourceModalRef>((_, ref) => {
   const intl = useIntl();
@@ -39,7 +42,7 @@ const AddOrEditDataSourceModal = forwardRef<DataSourceModalRef>((_, ref) => {
   const isEditMode = operateType === DataSourceOperateType.Edit;
   const busy = testing || submitting;
 
-  const resetModalState = () => {
+  const resetEditorState = () => {
     setCurrentRecord(undefined);
     setSelectedDbType("");
     setShowFormStep(false);
@@ -54,7 +57,12 @@ const AddOrEditDataSourceModal = forwardRef<DataSourceModalRef>((_, ref) => {
   const handleClose = () => {
     if (busy) return;
     setOpen(false);
-    resetModalState();
+  };
+
+  const handleAfterOpenChange = (visible: boolean) => {
+    if (!visible) {
+      resetEditorState();
+    }
   };
 
   const initializeEditForm = (record: DataSourceRecord) => {
@@ -73,9 +81,8 @@ const AddOrEditDataSourceModal = forwardRef<DataSourceModalRef>((_, ref) => {
       dbType,
       hideBack,
     }: DataSourceModalOpenPayload) => {
-      resetModalState();
+      resetEditorState();
       successCallbackRef.current = onSuccess;
-      setOpen(true);
       setOperateType(nextOperateType);
       setCurrentRecord(nextRecord);
 
@@ -84,19 +91,13 @@ const AddOrEditDataSourceModal = forwardRef<DataSourceModalRef>((_, ref) => {
         setShowFormStep(true);
         setHideBackButton(true);
         initializeEditForm(nextRecord);
-        return;
-      }
-
-      if (nextOperateType === DataSourceOperateType.Create && dbType) {
+      } else if (nextOperateType === DataSourceOperateType.Create && dbType) {
         setSelectedDbType(dbType);
         setShowFormStep(true);
         setHideBackButton(Boolean(hideBack));
-        return;
       }
 
-      setSelectedDbType("");
-      setShowFormStep(false);
-      setHideBackButton(false);
+      setOpen(true);
     },
     close: handleClose,
   }));
@@ -120,6 +121,7 @@ const AddOrEditDataSourceModal = forwardRef<DataSourceModalRef>((_, ref) => {
 
   const handleTestConnection = async () => {
     if (testing || submitting) return;
+
     try {
       setTesting(true);
       const connectionValues = await configForm.validateFields();
@@ -146,6 +148,7 @@ const AddOrEditDataSourceModal = forwardRef<DataSourceModalRef>((_, ref) => {
 
   const handleSubmit = async () => {
     if (submitting || testing) return;
+
     try {
       setSubmitting(true);
       const basicValues = await basicForm.validateFields();
@@ -153,21 +156,20 @@ const AddOrEditDataSourceModal = forwardRef<DataSourceModalRef>((_, ref) => {
       const payload = buildSubmitPayload(
         selectedDbType,
         basicValues,
-        connectionValues
+        connectionValues,
       );
 
       const response = isCreateMode
         ? await createDataSource(payload)
         : currentRecord?.id
-        ? await updateDataSource(currentRecord.id, payload)
-        : undefined;
+          ? await updateDataSource(currentRecord.id, payload)
+          : undefined;
+
       if (!response || response.code !== API_SUCCESS_CODE) return;
 
       const successCallback = successCallbackRef.current;
       message.success(isCreateMode ? "数据源创建成功" : "数据源更新成功");
-      setSubmitting(false);
       setOpen(false);
-      resetModalState();
       successCallback?.();
     } catch (error) {
       if (error && typeof error === "object" && "errorFields" in error) {
@@ -178,116 +180,122 @@ const AddOrEditDataSourceModal = forwardRef<DataSourceModalRef>((_, ref) => {
     }
   };
 
-  const modalActionText = isEditMode
+  const actionText = isEditMode
     ? intl.formatMessage({
         id: "pages.datasource.modal.title.edit",
-        defaultMessage: "Edit",
+        defaultMessage: "编辑",
       })
     : intl.formatMessage({
         id: "pages.datasource.modal.title.add",
-        defaultMessage: "Add",
+        defaultMessage: "新建",
       });
 
+  const drawerTitle = `${actionText}${intl.formatMessage({
+    id: "pages.datasource.common.title",
+    defaultMessage: "数据源",
+  })}`;
+
+  const subtitle = selectedDbType
+    ? `${selectedDbType} · ${isEditMode ? "修改连接与基础信息" : "配置连接与基础信息"}`
+    : "选择数据源类型后继续配置连接信息";
+
+  const renderFooter = () => {
+    if (!showFormStep) {
+      return (
+        <div className="flex justify-end">
+          <Button disabled={busy} onClick={handleClose}>
+            取消
+          </Button>
+        </div>
+      );
+    }
+
+    return (
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          {isCreateMode && !hideBackButton ? (
+            <Button disabled={busy} onClick={handleBackToTypeSelection}>
+              上一步
+            </Button>
+          ) : (
+            <Button disabled={busy} onClick={handleClose}>
+              取消
+            </Button>
+          )}
+        </div>
+
+        <div className="flex items-center gap-2">
+          <Button
+            loading={testing}
+            disabled={submitting}
+            onClick={() => void handleTestConnection()}
+          >
+            连接测试
+          </Button>
+
+          <Button
+            type="primary"
+            loading={submitting}
+            disabled={testing}
+            onClick={() => void handleSubmit()}
+          >
+            {isCreateMode ? "创建数据源" : "保存修改"}
+          </Button>
+        </div>
+      </div>
+    );
+  };
+
   return (
-    <Modal
-      width="min(960px, calc(100vw - 32px))"
+    <Drawer
+      className="datasource-editor-drawer"
+      width={DRAWER_WIDTH}
+      placement="right"
       open={open}
-      centered
       maskClosable={false}
       closable={!busy}
       keyboard={!busy}
-      onCancel={handleClose}
+      onClose={handleClose}
+      afterOpenChange={handleAfterOpenChange}
       destroyOnClose
       styles={{
         header: {
-          padding: "16px 20px 12px",
+          padding: "15px 20px",
           borderBottom: "1px solid #EEF0F3",
-          marginBottom: 0,
         },
         body: {
-          padding: "14px 20px 18px",
+          padding: 0,
+          overflow: "hidden",
           background: "#FFFFFF",
-          maxHeight: "calc(100vh - 190px)",
-          overflowY: "auto",
         },
         footer: {
-          padding: "11px 20px 14px",
+          padding: "12px 20px",
           borderTop: "1px solid #EEF0F3",
           background: "#FFFFFF",
-          marginTop: 0,
-        },
-        content: {
-          padding: 0,
-          borderRadius: 12,
-          overflow: "hidden",
         },
       }}
       title={
-        <div className="flex min-w-0 items-center gap-2.5 pr-6">
-          <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-[#F2F4F7]">
-            <DatabaseIcons dbType={selectedDbType} width="17" height="17" />
+        <div className="flex min-w-0 items-center gap-3 pr-3">
+          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-[#EAECF0] bg-[#F7F8FA]">
+            <DatabaseIcons dbType={selectedDbType} width="18" height="18" />
           </div>
 
           <div className="min-w-0">
-            <div className="truncate text-base font-semibold leading-6 text-[#161823]">
-              {modalActionText}
-              {intl.formatMessage({
-                id: "pages.datasource.common.title",
-                defaultMessage: " Data Source",
-              })}
+            <div className="truncate text-[15px] font-semibold leading-6 text-[#161823]">
+              {drawerTitle}
             </div>
-
-            <div className="truncate text-xs leading-5 text-[#8A8F99]">
-              {selectedDbType
-                ? `当前类型：${selectedDbType}`
-                : "选择需要创建的数据源类型"}
+            <div className="mt-0.5 truncate text-xs font-normal leading-5 text-[#8A8F99]">
+              {subtitle}
             </div>
           </div>
         </div>
       }
-      footer={
-        <div className="flex items-center justify-between gap-3">
-          <div>
-            {showFormStep && isCreateMode && !hideBackButton ? (
-              <Button disabled={busy} onClick={handleBackToTypeSelection}>
-                上一步
-              </Button>
-            ) : (
-              <Button disabled={busy} onClick={handleClose}>
-                取消
-              </Button>
-            )}
-          </div>
-
-          {showFormStep && (
-            <div className="flex items-center gap-2">
-              <Button
-                loading={testing}
-                disabled={submitting}
-                onClick={() => void handleTestConnection()}
-              >
-                连接测试
-              </Button>
-
-              <Button
-                type="primary"
-                loading={submitting}
-                disabled={testing}
-                onClick={() => void handleSubmit()}
-              >
-                完成
-              </Button>
-            </div>
-          )}
-        </div>
-      }
+      footer={renderFooter()}
     >
-      <div style={{ height: "65vh" }}>
-        {showFormStep ? (
+      {showFormStep ? (
+        <div className="datasource-editor-drawer__body datasource-editor-drawer__form h-full overflow-y-auto px-5 py-5">
           <DynamicDataSourceForm
-            key={`${operateType}-${selectedDbType}-${
-              currentRecord?.id || "create"
-            }`}
+            key={`${operateType}-${selectedDbType}-${currentRecord?.id || "create"}`}
             dbType={selectedDbType}
             form={basicForm}
             configForm={configForm}
@@ -298,14 +306,16 @@ const AddOrEditDataSourceModal = forwardRef<DataSourceModalRef>((_, ref) => {
                 : undefined
             }
           />
-        ) : (
+        </div>
+      ) : (
+        <div className="datasource-editor-drawer__body h-full min-h-0 px-5 py-4">
           <DataSourceTypeSelector
             dataSourceGroups={dataSourceGroupList}
             onSelect={handleSelectDbType}
           />
-        )}
-      </div>
-    </Modal>
+        </div>
+      )}
+    </Drawer>
   );
 });
 

--- a/yak-ops-ui/src/pages/data-source/components/DataSourceEditorDrawer.less
+++ b/yak-ops-ui/src/pages/data-source/components/DataSourceEditorDrawer.less
@@ -1,0 +1,110 @@
+.datasource-editor-drawer {
+  .ant-drawer-content {
+    box-shadow: -10px 0 30px rgba(22, 24, 35, 0.08);
+  }
+
+  .ant-drawer-header-title {
+    min-width: 0;
+    align-items: center;
+  }
+
+  .ant-drawer-title {
+    min-width: 0;
+  }
+
+  .ant-drawer-close {
+    color: rgba(22, 24, 35, 0.46);
+
+    &:hover {
+      color: #161823;
+      background: #f5f6f7;
+    }
+  }
+
+  .datasource-editor-drawer__body {
+    overscroll-behavior: contain;
+    scrollbar-gutter: stable;
+  }
+}
+
+.datasource-editor-drawer__form {
+  > .bg-white {
+    background: transparent !important;
+  }
+
+  > .bg-white > section {
+    position: relative;
+  }
+
+  > .bg-white > section:first-child {
+    padding-bottom: 20px;
+  }
+
+  > .bg-white > section:last-child {
+    margin-top: 0 !important;
+    padding-top: 20px !important;
+    border-top: 1px solid #eef0f3 !important;
+  }
+
+  .ant-form-item-label {
+    padding-bottom: 5px;
+  }
+
+  .ant-form-item-label > label {
+    height: auto;
+    color: #475467;
+    font-size: 12px;
+    font-weight: 500;
+    line-height: 20px;
+  }
+
+  .ant-form-item-required::before {
+    margin-inline-end: 3px !important;
+  }
+
+  .ant-input,
+  .ant-input-affix-wrapper,
+  .ant-input-number,
+  .ant-select-selector {
+    border-radius: 8px !important;
+  }
+
+  .ant-input:not(textarea),
+  .ant-input-affix-wrapper,
+  .ant-input-number {
+    min-height: 36px;
+  }
+
+  .ant-input-number-input {
+    height: 34px;
+  }
+
+  .ant-select-single {
+    height: 36px;
+  }
+
+  .ant-select-single .ant-select-selector {
+    height: 36px !important;
+    align-items: center;
+  }
+
+  textarea.ant-input {
+    min-height: 68px;
+    resize: vertical;
+  }
+
+  .ant-form-item-explain-error {
+    padding-top: 3px;
+    font-size: 11px;
+    line-height: 16px;
+  }
+}
+
+@media (max-width: 720px) {
+  .datasource-editor-drawer {
+    .ant-drawer-content-wrapper {
+      width: calc(100vw - 16px) !important;
+      max-width: 620px;
+    }
+  }
+}

--- a/yak-ops-ui/src/pages/data-source/components/DataSourceTypeSelector.tsx
+++ b/yak-ops-ui/src/pages/data-source/components/DataSourceTypeSelector.tsx
@@ -1,5 +1,5 @@
 import { SearchOutlined } from '@ant-design/icons';
-import { Button, Empty, Input } from 'antd';
+import { Empty, Input } from 'antd';
 import { useMemo, useState } from 'react';
 
 import { COMMON_DB_OPTIONS } from '../constants';
@@ -21,278 +21,231 @@ const DataSourceTypeSelector = ({
 
   const keyword = query.trim().toLowerCase();
 
-  const totalDatasourceCount = useMemo(() => {
-    return dataSourceGroups.reduce(
-      (total, group) => total + group.datasourceList.length,
-      0,
-    );
-  }, [dataSourceGroups]);
+  const totalDatasourceCount = useMemo(
+    () =>
+      dataSourceGroups.reduce(
+        (total, group) => total + group.datasourceList.length,
+        0,
+      ),
+    [dataSourceGroups],
+  );
 
-  const flatDatasourceList = useMemo(() => {
-    return dataSourceGroups.flatMap((group) =>
-      group.datasourceList.map((item) => ({
-        ...item,
-        groupName: group.groupName,
-        searchText: [
-          item.dbType,
-          item.connectorType,
-          item.type,
-          group.groupName,
-        ]
-          .filter(Boolean)
-          .join(' ')
-          .toLowerCase(),
-      })),
-    );
-  }, [dataSourceGroups]);
+  const flatDatasourceList = useMemo(
+    () =>
+      dataSourceGroups.flatMap((group) =>
+        group.datasourceList.map((item) => ({
+          ...item,
+          groupName: group.groupName,
+          searchText: [
+            item.dbType,
+            item.connectorType,
+            item.type,
+            group.groupName,
+          ]
+            .filter(Boolean)
+            .join(' ')
+            .toLowerCase(),
+        })),
+      ),
+    [dataSourceGroups],
+  );
 
-  const filteredDatasourceList = useMemo(() => {
-    return flatDatasourceList.filter((item) => {
-      const matchGroup =
-        selectedGroupName === null ||
-        item.groupName === selectedGroupName;
+  const filteredDatasourceList = useMemo(
+    () =>
+      flatDatasourceList.filter((item) => {
+        const matchGroup =
+          selectedGroupName === null || item.groupName === selectedGroupName;
+        const matchKeyword = !keyword || item.searchText.includes(keyword);
+        return matchGroup && matchKeyword;
+      }),
+    [flatDatasourceList, keyword, selectedGroupName],
+  );
 
-      const matchKeyword =
-        !keyword || item.searchText.includes(keyword);
+  const suggestedDatasourceList = useMemo(
+    () =>
+      COMMON_DB_OPTIONS.map((common) => {
+        const matched = flatDatasourceList.find((item) => {
+          const dbType = item.dbType?.toLowerCase();
+          const value = common.value?.toLowerCase();
+          const label = common.label?.toLowerCase();
+          return dbType === value || dbType === label;
+        });
 
-      return matchGroup && matchKeyword;
-    });
-  }, [flatDatasourceList, keyword, selectedGroupName]);
-
-  const suggestedDatasourceList = useMemo(() => {
-    return COMMON_DB_OPTIONS.map((common) => {
-      const matched = flatDatasourceList.find((item) => {
-        const dbType = item.dbType?.toLowerCase();
-        const value = common.value?.toLowerCase();
-        const label = common.label?.toLowerCase();
-
-        return dbType === value || dbType === label;
-      });
-
-      return {
-        ...common,
-        dbType: matched?.dbType || common.value,
-        groupName: matched?.groupName,
-      };
-    })
-      .filter((item) => Boolean(item.dbType))
-      .slice(0, 3);
-  }, [flatDatasourceList]);
+        return {
+          ...common,
+          dbType: matched?.dbType || common.value,
+        };
+      })
+        .filter((item) => Boolean(item.dbType))
+        .slice(0, 3),
+    [flatDatasourceList],
+  );
 
   const showSuggested =
-    !keyword &&
-    selectedGroupName === null &&
-    suggestedDatasourceList.length > 0;
+    !keyword && selectedGroupName === null && suggestedDatasourceList.length > 0;
 
-  const renderCount = (count: number, active: boolean) => {
-    return (
+  const renderSourceItem = (
+    item: (typeof filteredDatasourceList)[number],
+  ) => (
+    <button
+      key={[item.groupName, item.dbType, item.connectorType || item.type || ''].join(
+        '-',
+      )}
+      type="button"
+      disabled={item.disabled}
+      className={[
+        'group flex min-h-[50px] min-w-0 items-center gap-3 rounded-lg',
+        'border border-[#E8EAED] bg-white px-3 py-2.5 text-left',
+        'transition-all duration-150',
+        'hover:border-[var(--ant-color-primary-border)] hover:bg-[var(--ant-color-primary-bg)]',
+        'disabled:cursor-not-allowed disabled:opacity-45',
+      ].join(' ')}
+      onClick={() => onSelect(item.dbType)}
+    >
       <span
         className={[
-          'ml-1 inline-flex min-w-[16px] justify-center rounded-full px-1',
-          'text-[10px] leading-4',
-          active
-            ? 'bg-white/20 text-white'
-            : 'bg-[#f2f4f7] text-[#8a8f99]',
+          'flex h-8 w-8 shrink-0 items-center justify-center rounded-lg',
+          'border border-[#EEF0F3] bg-[#F7F8FA]',
+          'transition-colors duration-150',
+          'group-hover:border-[var(--ant-color-primary-border)]',
         ].join(' ')}
       >
-        {count}
+        <DatabaseIcons dbType={item.dbType} width="16px" height="16px" />
       </span>
-    );
-  };
+
+      <span className="min-w-0 flex-1">
+        <span
+          className={[
+            'block truncate text-[13px] font-medium leading-5 text-[#344054]',
+            'transition-colors group-hover:text-[var(--ant-color-primary)]',
+          ].join(' ')}
+          title={item.dbType}
+        >
+          {item.dbType}
+        </span>
+        <span className="mt-0.5 block truncate text-[11px] leading-4 text-[#98A2B3]">
+          {item.groupName}
+        </span>
+      </span>
+    </button>
+  );
 
   return (
-    <div className="flex flex-col gap-3">
-      <div>
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="shrink-0">
+        <div className="mb-3">
+          <div className="text-sm font-semibold leading-6 text-[#161823]">
+            选择数据源类型
+          </div>
+          <div className="mt-0.5 text-xs leading-5 text-[#8A8F99]">
+            选择一个连接器，下一步配置连接地址、账号和运行环境。
+          </div>
+        </div>
+
         <Input
           allowClear
           variant="filled"
-          prefix={<SearchOutlined className="text-[#98a2b3]" />}
+          prefix={<SearchOutlined className="text-[#98A2B3]" />}
           placeholder="搜索 MySQL、PostgreSQL、Oracle..."
           value={query}
-          className="!h-8 !rounded-lg"
+          className="!h-9 !rounded-lg"
           onChange={(event) => setQuery(event.target.value)}
         />
 
-        <div className="mt-2.5 flex min-w-0 items-center gap-2">
-          <span className="shrink-0 text-xs font-medium text-[#667085]">
-            类型
-          </span>
+        <div className="mt-3 flex items-center gap-2 overflow-x-auto pb-1">
+          <button
+            type="button"
+            className={[
+              'h-7 shrink-0 rounded-md px-2.5 text-xs font-medium transition-colors',
+              selectedGroupName === null
+                ? 'bg-[#161823] text-white'
+                : 'bg-[#F2F4F7] text-[#667085] hover:bg-[#EAECF0]',
+            ].join(' ')}
+            onClick={() => setSelectedGroupName(null)}
+          >
+            全部 {totalDatasourceCount}
+          </button>
 
-          <div className="flex min-w-0 flex-1 items-center gap-1.5 overflow-x-auto pb-0.5">
-            <Button
-              type={selectedGroupName === null ? 'primary' : 'default'}
-              size="small"
-              className="!h-7 shrink-0 !rounded-md !px-2.5 !text-xs"
-              onClick={() => setSelectedGroupName(null)}
-            >
-              全部
-              {renderCount(
-                totalDatasourceCount,
-                selectedGroupName === null,
-              )}
-            </Button>
-
-            {dataSourceGroups.map((group) => {
-              const active = selectedGroupName === group.groupName;
-
-              return (
-                <Button
-                  key={group.groupName}
-                  type={active ? 'primary' : 'default'}
-                  size="small"
-                  className="!h-7 shrink-0 !rounded-md !px-2.5 !text-xs"
-                  onClick={() =>
-                    setSelectedGroupName((previous) =>
-                      previous === group.groupName
-                        ? null
-                        : group.groupName,
-                    )
-                  }
-                >
-                  {group.groupName}
-                  {renderCount(group.datasourceList.length, active)}
-                </Button>
-              );
-            })}
-          </div>
+          {dataSourceGroups.map((group) => {
+            const active = selectedGroupName === group.groupName;
+            return (
+              <button
+                key={group.groupName}
+                type="button"
+                className={[
+                  'h-7 shrink-0 rounded-md px-2.5 text-xs font-medium transition-colors',
+                  active
+                    ? 'bg-[#161823] text-white'
+                    : 'bg-[#F2F4F7] text-[#667085] hover:bg-[#EAECF0]',
+                ].join(' ')}
+                onClick={() =>
+                  setSelectedGroupName((previous) =>
+                    previous === group.groupName ? null : group.groupName,
+                  )
+                }
+              >
+                {group.groupName} {group.datasourceList.length}
+              </button>
+            );
+          })}
         </div>
       </div>
 
       {showSuggested && (
-        <section>
-          <div className="mb-1.5 flex items-center justify-between">
-            <span className="text-xs font-semibold text-[#161823]">
-              常用数据源
-            </span>
-
-            <span className="text-[11px] text-[#98a2b3]">
-              点击直接创建
-            </span>
+        <section className="mt-4 shrink-0 border-b border-[#EEF0F3] pb-4">
+          <div className="mb-2 flex items-center justify-between">
+            <span className="text-xs font-semibold text-[#161823]">常用数据源</span>
+            <span className="text-[11px] text-[#98A2B3]">点击直接配置</span>
           </div>
 
-          <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
+          <div className="grid grid-cols-3 gap-2">
             {suggestedDatasourceList.map((item) => (
               <button
                 key={item.dbType}
                 type="button"
                 className={[
-                  'group flex h-[42px] min-w-0 items-center gap-2',
-                  'rounded-lg border border-[#e8e9ec] bg-white px-2.5',
-                  'text-left transition-colors duration-150',
-                  'hover:border-[var(--ant-color-primary-border)]',
+                  'group flex min-w-0 items-center gap-2 rounded-lg border',
+                  'border-[#E8EAED] bg-white px-2.5 py-2 text-left',
+                  'transition-colors hover:border-[var(--ant-color-primary-border)]',
                   'hover:bg-[var(--ant-color-primary-bg)]',
                 ].join(' ')}
                 onClick={() => onSelect(item.dbType)}
               >
-                <div
-                  className={[
-                    'flex h-[26px] w-[26px] shrink-0 items-center justify-center',
-                    'rounded-md border border-[#eef0f3] bg-[#f5f6f7]',
-                    'transition-colors duration-150',
-                    'group-hover:border-[var(--ant-color-primary-border)]',
-                    'group-hover:bg-[var(--ant-color-primary-bg)]',
-                  ].join(' ')}
-                >
+                <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-[#F7F8FA]">
                   <DatabaseIcons
                     dbType={item.dbType}
-                    width="13px"
-                    height="13px"
+                    width="14px"
+                    height="14px"
                   />
-                </div>
-
-                <div
-                  className={[
-                    'min-w-0 flex-1 truncate text-xs font-semibold',
-                    'text-[#344054] transition-colors duration-150',
-                    'group-hover:text-[var(--ant-color-primary)]',
-                  ].join(' ')}
-                  title={item.label}
-                >
+                </span>
+                <span className="min-w-0 flex-1 truncate text-xs font-medium text-[#344054] group-hover:text-[var(--ant-color-primary)]">
                   {item.label}
-                </div>
+                </span>
               </button>
             ))}
           </div>
         </section>
       )}
 
-      <section className="min-h-0">
-        <div className="mb-1.5 flex items-center justify-between">
-          <span className="text-xs font-semibold text-[#161823]">
-            数据源类型
-          </span>
-
-          <span className="text-[11px] text-[#98a2b3]">
-            {filteredDatasourceList.length} 个连接器
+      <section className="mt-4 flex min-h-0 flex-1 flex-col">
+        <div className="mb-2 flex shrink-0 items-center justify-between">
+          <span className="text-xs font-semibold text-[#161823]">全部连接器</span>
+          <span className="text-[11px] text-[#98A2B3]">
+            {filteredDatasourceList.length} 个
           </span>
         </div>
 
         {filteredDatasourceList.length === 0 ? (
-          <div className="rounded-lg border border-dashed border-[#d0d5dd] bg-[#fcfcfd] px-5 py-6">
+          <div className="flex min-h-0 flex-1 items-center justify-center rounded-lg border border-dashed border-[#D0D5DD] bg-[#FCFCFD] px-5 py-8">
             <Empty
               image={Empty.PRESENTED_IMAGE_SIMPLE}
               description="未找到匹配的数据源类型"
             />
           </div>
         ) : (
-          <div className="max-h-[260px] overflow-y-auto pr-1">
-            <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">
-              {filteredDatasourceList.map((item) => (
-                <button
-                  key={[
-                    item.groupName,
-                    item.dbType,
-                    item.connectorType || item.type || '',
-                  ].join('-')}
-                  type="button"
-                  className={[
-                    'group flex h-[42px] min-w-0 items-center gap-2',
-                    'rounded-lg border border-[#e8e9ec] bg-white px-2.5',
-                    'text-left transition-colors duration-150',
-                    'hover:border-[var(--ant-color-primary-border)]',
-                    'hover:bg-[var(--ant-color-primary-bg)]',
-                  ].join(' ')}
-                  onClick={() => onSelect(item.dbType)}
-                >
-                  <div
-                    className={[
-                      'flex h-[26px] w-[26px] shrink-0 items-center justify-center',
-                      'rounded-md border border-[#eef0f3] bg-[#f5f6f7]',
-                      'transition-colors duration-150',
-                      'group-hover:border-[var(--ant-color-primary-border)]',
-                      'group-hover:bg-[var(--ant-color-primary-bg)]',
-                    ].join(' ')}
-                  >
-                    <DatabaseIcons
-                      dbType={item.dbType}
-                      width="13px"
-                      height="13px"
-                    />
-                  </div>
-
-                  <div
-                    className={[
-                      'min-w-0 flex-1 truncate text-xs font-medium',
-                      'text-[#344054] transition-colors duration-150',
-                      'group-hover:text-[var(--ant-color-primary)]',
-                    ].join(' ')}
-                    title={item.dbType}
-                  >
-                    {item.dbType}
-                  </div>
-
-                  <span
-                    className={[
-                      'max-w-[76px] shrink-0 truncate rounded-md',
-                      'bg-[#f2f4f7] px-2 py-0.5',
-                      'text-[10px] leading-4 text-[#667085]',
-                    ].join(' ')}
-                    title={item.groupName}
-                  >
-                    {item.groupName}
-                  </span>
-                </button>
-              ))}
+          <div className="min-h-0 flex-1 overflow-y-auto pr-1">
+            <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+              {filteredDatasourceList.map(renderSourceItem)}
             </div>
           </div>
         )}


### PR DESCRIPTION
## 变更说明

- 将数据源新增/编辑交互从居中 Modal 调整为右侧 Drawer，保留原有创建、编辑、连接测试和成功回调逻辑。
- 重构 Drawer 头部、全高滚动区域和固定底部操作区，使交互与当前 Yak Ops 的白底、浅灰边框、紧凑表单风格保持一致。
- 对表单区域统一标签、输入控件、分区和错误提示样式，强化“基础信息 / 连接参数”的层级。
- 重构数据源类型选择页，适配 Drawer 纵向空间：增加说明、搜索与分类筛选，常用数据源保留快捷入口，连接器列表改为两列自适应并占满剩余高度。
- 编辑模式直接进入配置；新建模式保持“选择类型 → 配置连接”的流程，支持返回上一步。

## 影响范围

仅涉及数据源管理前端交互与样式，不修改数据源 API、请求参数和后端逻辑。

## 检查

- 已确认分支仅包含 3 个数据源 UI 文件变更。
- 已对比 `main`，分支 ahead 3 commits / behind 0。
- 当前执行环境无法拉取完整仓库依赖，因此未本地执行 `npm run tsc`/build；建议由仓库 CI 完成最终类型与构建校验。