### PR TITLE
feat: support sectioned datasource form schema

### DIFF
--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/vo/datasource/DataSourcePluginConfigVO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/vo/datasource/DataSourcePluginConfigVO.java
@@ -16,6 +16,15 @@ public class DataSourcePluginConfigVO {
 
   private String pluginType;
 
+  /**
+   * 新版分区表单配置。
+   *
+   * <p>存在有效 sections 时前端优先按分区渲染；formFields 保留用于兼容旧插件。
+   */
+  @Builder.Default
+  private List<FormSectionVO> sections = new ArrayList<>();
+
+  /** 旧版扁平动态表单字段，保留兼容能力。 */
   @Builder.Default
   private List<FormFieldVO> formFields = new ArrayList<>();
 
@@ -23,6 +32,27 @@ public class DataSourcePluginConfigVO {
   private Boolean installRequired = false;
 
   private String installHint;
+
+  /** 动态表单分区。 */
+  @Data
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class FormSectionVO {
+
+    private String key;
+    private String title;
+    private String description;
+
+    @Builder.Default
+    private Boolean collapsible = false;
+
+    @Builder.Default
+    private Boolean defaultExpanded = true;
+
+    @Builder.Default
+    private List<FormFieldVO> fields = new ArrayList<>();
+  }
 
   /** 动态表单字段。 */
   @Data

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/AbstractJdbcDataSourcePlugin.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/AbstractJdbcDataSourcePlugin.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.yak.ops.common.bean.vo.datasource.DataSourcePluginConfigVO;
 import io.yak.ops.common.bean.vo.datasource.DataSourcePluginConfigVO.FormFieldVO;
+import io.yak.ops.common.bean.vo.datasource.DataSourcePluginConfigVO.FormSectionVO;
 import io.yak.ops.common.bean.vo.datasource.DataSourcePluginConfigVO.RuleVO;
 import io.yak.ops.common.enums.datasource.DataSourceDbType;
 import io.yak.ops.spi.datasource.DataSourceCatalog;
@@ -30,8 +31,8 @@ public abstract class AbstractJdbcDataSourcePlugin implements DataSourcePlugin {
 
   @Override
   public DataSourcePluginConfigVO pluginConfig() {
-    List<FormFieldVO> fields = new ArrayList<>();
-    fields.add(
+    List<FormFieldVO> connectionFields = new ArrayList<>();
+    connectionFields.add(
         field(
             "host",
             "主机地址",
@@ -39,7 +40,7 @@ public abstract class AbstractJdbcDataSourcePlugin implements DataSourcePlugin {
             "请输入数据库主机地址",
             "127.0.0.1",
             required("请输入主机地址")));
-    fields.add(
+    connectionFields.add(
         field(
             "port",
             "端口",
@@ -47,7 +48,7 @@ public abstract class AbstractJdbcDataSourcePlugin implements DataSourcePlugin {
             "请输入数据库端口",
             defaultPort(),
             rangeRule(1, 65535, "端口必须在 1 到 65535 之间")));
-    fields.add(
+    connectionFields.add(
         field(
             "database",
             databaseLabel(),
@@ -55,7 +56,7 @@ public abstract class AbstractJdbcDataSourcePlugin implements DataSourcePlugin {
             "请输入数据库名称",
             null,
             required("请输入数据库名称")));
-    fields.add(
+    connectionFields.add(
         field(
             "schema",
             "Schema",
@@ -63,7 +64,7 @@ public abstract class AbstractJdbcDataSourcePlugin implements DataSourcePlugin {
             "可选；不填写时使用数据库默认 Schema",
             null,
             Collections.emptyList()));
-    fields.add(
+    connectionFields.add(
         field(
             "username",
             "用户名",
@@ -71,7 +72,7 @@ public abstract class AbstractJdbcDataSourcePlugin implements DataSourcePlugin {
             "请输入数据库用户名",
             null,
             required("请输入数据库用户名")));
-    fields.add(
+    connectionFields.add(
         field(
             "password",
             "密码",
@@ -79,7 +80,7 @@ public abstract class AbstractJdbcDataSourcePlugin implements DataSourcePlugin {
             "请输入数据库密码",
             null,
             Collections.emptyList()));
-    fields.add(
+    connectionFields.add(
         field(
             "jdbcUrl",
             "JDBC 地址",
@@ -87,7 +88,9 @@ public abstract class AbstractJdbcDataSourcePlugin implements DataSourcePlugin {
             "可选；留空时由插件根据主机、端口和数据库生成",
             null,
             Collections.emptyList()));
-    fields.add(
+
+    List<FormFieldVO> driverFields = new ArrayList<>();
+    driverFields.add(
         field(
             "driverClassName",
             "驱动类",
@@ -95,7 +98,9 @@ public abstract class AbstractJdbcDataSourcePlugin implements DataSourcePlugin {
             "请输入 JDBC Driver Class",
             defaultDriverClassName(),
             required("请输入 JDBC 驱动类")));
-    fields.add(
+
+    List<FormFieldVO> advancedFields = new ArrayList<>();
+    advancedFields.add(
         field(
             "properties",
             "扩展属性",
@@ -103,9 +108,45 @@ public abstract class AbstractJdbcDataSourcePlugin implements DataSourcePlugin {
             "可选；请输入 JSON 对象，例如 {\"useSSL\":\"false\"}",
             null,
             Collections.emptyList()));
-    appendFormFields(fields);
+    appendFormFields(advancedFields);
+
+    List<FormSectionVO> sections = new ArrayList<>();
+    sections.add(
+        section(
+            "connection",
+            "连接参数",
+            "配置数据库地址、认证信息与默认访问范围。",
+            false,
+            true,
+            connectionFields));
+    sections.add(
+        section(
+            "driver",
+            "驱动配置",
+            "查看或调整当前数据源使用的 JDBC Driver Class。",
+            true,
+            true,
+            driverFields));
+    if (!advancedFields.isEmpty()) {
+      sections.add(
+          section(
+              "advanced",
+              "高级配置",
+              "按需补充驱动属性和插件扩展参数。",
+              true,
+              false,
+              advancedFields));
+    }
+
+    // 同时保留 formFields，兼容尚未升级到 sections 协议的前端版本。
+    List<FormFieldVO> fields = new ArrayList<>();
+    fields.addAll(connectionFields);
+    fields.addAll(driverFields);
+    fields.addAll(advancedFields);
+
     return DataSourcePluginConfigVO.builder()
         .pluginType(dbType().name())
+        .sections(sections)
         .formFields(fields)
         .installRequired(false)
         .build();
@@ -321,6 +362,23 @@ public abstract class AbstractJdbcDataSourcePlugin implements DataSourcePlugin {
         .placeholder(placeholder)
         .defaultValue(defaultValue)
         .rules(rules)
+        .build();
+  }
+
+  protected FormSectionVO section(
+      String key,
+      String title,
+      String description,
+      boolean collapsible,
+      boolean defaultExpanded,
+      List<FormFieldVO> fields) {
+    return FormSectionVO.builder()
+        .key(key)
+        .title(title)
+        .description(description)
+        .collapsible(collapsible)
+        .defaultExpanded(defaultExpanded)
+        .fields(fields)
         .build();
   }
 

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/test/java/io/yak/ops/plugin/database/jdbc/mysql/MySqlDataSourcePluginTest.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/test/java/io/yak/ops/plugin/database/jdbc/mysql/MySqlDataSourcePluginTest.java
@@ -2,6 +2,8 @@ package io.yak.ops.plugin.database.jdbc.mysql;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.yak.ops.common.bean.vo.datasource.DataSourcePluginConfigVO;
+import io.yak.ops.common.bean.vo.datasource.DataSourcePluginConfigVO.FormSectionVO;
 import io.yak.ops.spi.datasource.DataSourceConnection;
 import org.junit.jupiter.api.Test;
 
@@ -20,5 +22,21 @@ class MySqlDataSourcePluginTest {
     assertThat(new MySqlDataSourcePlugin().acceptsUrl(connection.jdbcUrl())).isTrue();
     assertThat(new MySqlDataSourcePlugin().acceptsUrl("jdbc:mariadb://127.0.0.1/demo"))
         .isFalse();
+  }
+
+  @Test
+  void shouldExposeSectionedFormSchemaAndKeepLegacyFields() {
+    DataSourcePluginConfigVO config = new MySqlDataSourcePlugin().pluginConfig();
+
+    assertThat(config.getSections())
+        .extracting(FormSectionVO::getKey)
+        .containsExactly("connection", "driver", "advanced");
+    assertThat(config.getSections().get(0).getCollapsible()).isFalse();
+    assertThat(config.getSections().get(1).getCollapsible()).isTrue();
+    assertThat(config.getSections().get(1).getDefaultExpanded()).isTrue();
+    assertThat(config.getSections().get(2).getDefaultExpanded()).isFalse();
+
+    // 旧版前端仍可继续消费扁平 formFields。
+    assertThat(config.getFormFields()).hasSize(9);
   }
 }

--- a/yak-ops-ui/src/pages/data-source/components/DataSourceEditorDrawer.less
+++ b/yak-ops-ui/src/pages/data-source/components/DataSourceEditorDrawer.less
@@ -32,18 +32,55 @@
     background: transparent !important;
   }
 
-  > .bg-white > section {
-    position: relative;
-  }
-
-  > .bg-white > section:first-child {
+  .datasource-editor-base-section {
     padding-bottom: 20px;
   }
 
-  > .bg-white > section:last-child {
-    margin-top: 0 !important;
-    padding-top: 20px !important;
-    border-top: 1px solid #eef0f3 !important;
+  .datasource-schema-sections {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding-top: 18px;
+    border-top: 1px solid #eef0f3;
+  }
+
+  .datasource-schema-section {
+    min-width: 0;
+  }
+
+  .datasource-schema-collapse {
+    overflow: hidden;
+    border: 1px solid #e9ebef;
+    border-radius: 9px;
+    background: #fff;
+
+    > .ant-collapse-item {
+      border-bottom: 0;
+    }
+
+    .ant-collapse-header {
+      min-height: 42px;
+      padding: 9px 12px !important;
+      align-items: center !important;
+      background: #fbfbfc;
+    }
+
+    .ant-collapse-expand-icon {
+      color: #667085;
+    }
+
+    .ant-collapse-header-text {
+      min-width: 0;
+    }
+
+    .ant-collapse-content {
+      border-top: 1px solid #eef0f3;
+      background: #fff;
+    }
+
+    .ant-collapse-content-box {
+      padding: 12px 12px 0 !important;
+    }
   }
 
   .ant-form-item-label {

--- a/yak-ops-ui/src/pages/data-source/components/DynamicDataSourceForm/index.tsx
+++ b/yak-ops-ui/src/pages/data-source/components/DynamicDataSourceForm/index.tsx
@@ -6,6 +6,7 @@ import {
 import { useIntl } from '@umijs/max';
 import {
   Button,
+  Collapse,
   Form,
   Input,
   InputNumber,
@@ -35,12 +36,15 @@ import {
 import type {
   DynamicDataSourceFormProps,
   DynamicFormField,
+  DynamicFormSection,
 } from '../../types';
 import { DataSourceOperateType } from '../../types';
 import CustomKVList from './components/CustomKVList';
 import DriverLocationField from './components/DriverLocationField';
 import {
+  flattenFormSectionFields,
   getConfigInitialValues,
+  normalizeFormSections,
   transformRules,
 } from './utils/formUtils';
 
@@ -153,9 +157,7 @@ const DynamicDataSourceForm = ({
 }: DynamicDataSourceFormProps) => {
   const intl = useIntl();
 
-  const [formConfig, setFormConfig] = useState<
-    DynamicFormField[]
-  >([]);
+  const [formSections, setFormSections] = useState<DynamicFormSection[]>([]);
   const [loading, setLoading] = useState(false);
   const [needInstall, setNeedInstall] =
     useState(false);
@@ -224,7 +226,7 @@ const DynamicDataSourceForm = ({
       setLoading(true);
       setNeedInstall(false);
       setLoadErrMsg('');
-      setFormConfig([]);
+      setFormSections([]);
 
       configForm.resetFields();
 
@@ -266,10 +268,10 @@ const DynamicDataSourceForm = ({
           return;
         }
 
-        const fields =
-          data.formFields || [];
+        const sections = normalizeFormSections(data);
+        const fields = flattenFormSectionFields(sections);
 
-        setFormConfig(fields);
+        setFormSections(sections);
 
         const defaults =
           getConfigInitialValues(fields);
@@ -317,7 +319,7 @@ const DynamicDataSourceForm = ({
     if (!dbType) {
       requestSeqRef.current += 1;
 
-      setFormConfig([]);
+      setFormSections([]);
       setNeedInstall(false);
       setLoadErrMsg('');
       setLoading(false);
@@ -452,6 +454,101 @@ const DynamicDataSourceForm = ({
     }
   };
 
+  const renderFields = (fields: DynamicFormField[]) => (
+    <div className="grid grid-cols-1 gap-x-4 md:grid-cols-2">
+      {fields.map((field) => {
+        if (field.type === 'CUSTOM_SELECT') {
+          return (
+            <div
+              key={field.key}
+              className="md:col-span-2"
+            >
+              <CustomKVList
+                intl={intl}
+                field={field}
+              />
+            </div>
+          );
+        }
+
+        const fullWidth =
+          field.type === 'TEXTAREA' ||
+          field.key === 'driverLocation';
+
+        return (
+          <Form.Item
+            key={field.key}
+            label={field.label}
+            name={field.key}
+            valuePropName={
+              field.type === 'SWITCH'
+                ? 'checked'
+                : 'value'
+            }
+            rules={transformRules(
+              field.rules,
+              field.type,
+            )}
+            validateTrigger={[
+              'onChange',
+              'onBlur',
+            ]}
+            className={[
+              '!mb-3',
+              fullWidth ? 'md:col-span-2' : '',
+            ]
+              .filter(Boolean)
+              .join(' ')}
+          >
+            {renderFormItem(field)}
+          </Form.Item>
+        );
+      })}
+    </div>
+  );
+
+  const renderSectionHeader = (section: DynamicFormSection) => (
+    <div className="min-w-0">
+      <h3 className={sectionTitleClass}>{section.title}</h3>
+      {section.description && (
+        <p className={sectionDescriptionClass}>{section.description}</p>
+      )}
+    </div>
+  );
+
+  const renderSchemaSection = (section: DynamicFormSection) => {
+    if (section.collapsible) {
+      return (
+        <Collapse
+          key={section.key}
+          className="datasource-schema-collapse"
+          bordered={false}
+          defaultActiveKey={section.defaultExpanded === false ? [] : [section.key]}
+          items={[
+            {
+              key: section.key,
+              label: renderSectionHeader(section),
+              children: renderFields(section.fields),
+              forceRender: true,
+            },
+          ]}
+        />
+      );
+    }
+
+    return (
+      <section
+        key={section.key}
+        className="datasource-schema-section"
+      >
+        <div className="mb-3">
+          {renderSectionHeader(section)}
+        </div>
+        {renderFields(section.fields)}
+      </section>
+    );
+  };
+
   if (loading) {
     return (
       <div
@@ -472,13 +569,12 @@ const DynamicDataSourceForm = ({
 
   return (
     <div className="bg-white">
-      <section>
+      <section className="datasource-editor-base-section">
         <div className="mb-3 flex items-end justify-between gap-4">
           <div>
             <h3 className={sectionTitleClass}>
               基础信息
             </h3>
-
           </div>
 
           <div className="flex items-center gap-1.5 text-xs text-[#8a8f99]">
@@ -627,14 +723,7 @@ const DynamicDataSourceForm = ({
         </div>
       )}
 
-      <section className="mt-4 border-t border-[#eef0f3] pt-4">
-        <div className="mb-3">
-          <h3 className={sectionTitleClass}>
-            连接参数
-          </h3>
-
-        </div>
-
+      {formSections.length > 0 && (
         <Form
           form={configForm}
           component={false}
@@ -642,66 +731,11 @@ const DynamicDataSourceForm = ({
           colon={false}
           requiredMark
         >
-          <div className="grid grid-cols-1 gap-x-4 md:grid-cols-2">
-            {formConfig.map((field) => {
-              if (
-                field.type ===
-                'CUSTOM_SELECT'
-              ) {
-                return (
-                  <div
-                    key={field.key}
-                    className="md:col-span-2"
-                  >
-                    <CustomKVList
-                      intl={intl}
-                      field={field}
-                    />
-                  </div>
-                );
-              }
-
-              const fullWidth =
-                field.type ===
-                  'TEXTAREA' ||
-                field.key ===
-                  'driverLocation';
-
-              return (
-                <Form.Item
-                  key={field.key}
-                  label={field.label}
-                  name={field.key}
-                  valuePropName={
-                    field.type ===
-                    'SWITCH'
-                      ? 'checked'
-                      : 'value'
-                  }
-                  rules={transformRules(
-                    field.rules,
-                    field.type,
-                  )}
-                  validateTrigger={[
-                    'onChange',
-                    'onBlur',
-                  ]}
-                  className={[
-                    '!mb-3',
-                    fullWidth
-                      ? 'md:col-span-2'
-                      : '',
-                  ]
-                    .filter(Boolean)
-                    .join(' ')}
-                >
-                  {renderFormItem(field)}
-                </Form.Item>
-              );
-            })}
+          <div className="datasource-schema-sections">
+            {formSections.map(renderSchemaSection)}
           </div>
         </Form>
-      </section>
+      )}
     </div>
   );
 };

--- a/yak-ops-ui/src/pages/data-source/components/DynamicDataSourceForm/utils/formUtils.ts
+++ b/yak-ops-ui/src/pages/data-source/components/DynamicDataSourceForm/utils/formUtils.ts
@@ -1,6 +1,11 @@
 import type { Rule } from 'antd/es/form';
 
-import type { DynamicFormField, DynamicFormFieldRule } from '../../../types';
+import type {
+  DynamicFormField,
+  DynamicFormFieldRule,
+  DynamicFormSchemaResponse,
+  DynamicFormSection,
+} from '../../../types';
 
 export const transformRules = (
   rules: DynamicFormFieldRule[] | undefined,
@@ -61,6 +66,46 @@ const parseDefaultValueByType = (field: DynamicFormField) => {
       return value;
   }
 };
+
+/**
+ * 将新版 sections 和旧版 formFields 统一归一成分区结构。
+ *
+ * 新插件优先使用 sections；旧插件无需迁移，扁平 formFields 会自动落到
+ * 一个始终展开的“连接参数”分区中。
+ */
+export const normalizeFormSections = (
+  schema?: Pick<DynamicFormSchemaResponse, 'sections' | 'formFields'>,
+): DynamicFormSection[] => {
+  const sections = (schema?.sections || [])
+    .filter((section) => Array.isArray(section?.fields) && section.fields.length > 0)
+    .map((section, index) => ({
+      ...section,
+      key: section.key?.trim() || `section-${index + 1}`,
+      title: section.title?.trim() || '连接参数',
+      collapsible: section.collapsible === true,
+      defaultExpanded: section.defaultExpanded !== false,
+      fields: [...section.fields],
+    }));
+
+  if (sections.length > 0) return sections;
+
+  const legacyFields = schema?.formFields || [];
+  if (legacyFields.length === 0) return [];
+
+  return [
+    {
+      key: 'connection',
+      title: '连接参数',
+      collapsible: false,
+      defaultExpanded: true,
+      fields: [...legacyFields],
+    },
+  ];
+};
+
+export const flattenFormSectionFields = (
+  sections: DynamicFormSection[],
+): DynamicFormField[] => sections.flatMap((section) => section.fields || []);
 
 /** 只给当前为空的字段补默认值。 */
 export const patchEmptyWithDefaults = (

--- a/yak-ops-ui/src/pages/data-source/types.ts
+++ b/yak-ops-ui/src/pages/data-source/types.ts
@@ -130,9 +130,27 @@ export interface DynamicFormField {
   rules?: DynamicFormFieldRule[];
 }
 
+/**
+ * 插件动态表单分区。
+ *
+ * collapsible=false 时直接展示；collapsible=true 时由前端渲染为 Collapse。
+ * defaultExpanded 仅对可折叠分区生效，未配置时默认展开，避免必填字段被静默隐藏。
+ */
+export interface DynamicFormSection {
+  key: string;
+  title: string;
+  description?: string;
+  collapsible?: boolean;
+  defaultExpanded?: boolean;
+  fields: DynamicFormField[];
+}
+
 export interface DynamicFormSchemaResponse {
   pluginType?: string;
-  formFields: DynamicFormField[];
+  /** 新版分区 Schema，存在有效分区时优先使用。 */
+  sections?: DynamicFormSection[];
+  /** 兼容旧插件的扁平字段列表。 */
+  formFields?: DynamicFormField[];
   installRequired?: boolean;
   installHint?: string;
 }


### PR DESCRIPTION
## 变更说明

- 数据源动态 Schema 新增 `sections`，支持 `key / title / description / collapsible / defaultExpanded / fields`。
- 前端统一将新版 `sections` 与旧版 `formFields` 归一成分区结构：存在有效 `sections` 时优先渲染，否则自动回退到默认“连接参数”分区。
- Drawer 内新增 Section / Collapse 渲染能力，可折叠分区使用当前 Yak Ops 白底、浅灰边框和紧凑表单风格。
- 默认值、编辑回填、字段校验仍会对所有 Section 字段统一处理，创建/编辑/连接测试 payload 不变。
- JDBC 插件基座开始实际下发 3 个分区：`连接参数`、`驱动配置`、`高级配置`；驱动默认展开，高级配置默认收起。
- 后端继续同步返回原 `formFields`，兼容尚未升级的旧前端；新前端也继续兼容尚未迁移的旧插件。
- 补充 MySQL 插件测试，覆盖 Section 顺序、折叠配置以及 legacy `formFields` 兼容性。

## 兼容策略

- 新前端 + 新插件：优先消费 `sections`。
- 新前端 + 旧插件：自动将 `formFields` 包装成不可折叠的“连接参数” Section。
- 旧前端 + 新插件：后端仍返回完整 `formFields`，无需同步发布。

## 影响范围

仅升级数据源插件表单描述协议和 Drawer 动态表单渲染，不修改数据源保存结构、连接参数 JSON、连接测试接口和 Catalog/SQL 执行逻辑。

## 检查

- 分支基于最新 `main`，当前 ahead 7 / behind 0。
- 已静态检查前后端字段命名、默认值归一化和 JDBC 字段完整性。
- 当前执行环境未拉取完整仓库依赖，因此未本地执行 Maven/TypeScript 构建；建议由仓库 CI 做最终编译校验。