### PR TITLE
feat(data-development): add persisted SQL editor settings panel

### DIFF
--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/controller/v1/DevelopmentEditorSettingsController.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/controller/v1/DevelopmentEditorSettingsController.java
@@ -1,0 +1,44 @@
+package io.yak.ops.business.development.controller.v1;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.yak.framework.common.Result;
+import io.yak.ops.business.development.service.DevelopmentEditorSettingsService;
+import java.security.Principal;
+import java.util.Map;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** SQL editor preference APIs for the data-development workbench. */
+@Tag(name = "数据开发编辑器设置接口")
+@RestController
+@RequestMapping("/api/v1/data-development/editor-settings")
+public class DevelopmentEditorSettingsController {
+
+  private final DevelopmentEditorSettingsService service;
+
+  public DevelopmentEditorSettingsController(DevelopmentEditorSettingsService service) {
+    this.service = service;
+  }
+
+  @Operation(summary = "读取当前用户编辑器设置")
+  @GetMapping
+  public Result<Map<String, Object>> get(Principal principal) {
+    return Result.success(service.get(userKey(principal)));
+  }
+
+  @Operation(summary = "保存当前用户编辑器设置")
+  @PutMapping
+  public Result<Map<String, Object>> save(
+      Principal principal,
+      @RequestBody Map<String, Object> settings) {
+    return Result.success(service.save(userKey(principal), settings));
+  }
+
+  private String userKey(Principal principal) {
+    return principal == null ? "default" : principal.getName();
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentEditorSettingsService.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentEditorSettingsService.java
@@ -1,0 +1,112 @@
+package io.yak.ops.business.development.service;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/** Stores per-user SQL editor preferences for the data-development workbench. */
+@Service
+public class DevelopmentEditorSettingsService {
+
+  private static final TypeReference<Map<String, Object>> MAP_TYPE = new TypeReference<>() {};
+
+  private final JdbcTemplate jdbcTemplate;
+  private final ObjectMapper objectMapper;
+
+  public DevelopmentEditorSettingsService(JdbcTemplate jdbcTemplate, ObjectMapper objectMapper) {
+    this.jdbcTemplate = jdbcTemplate;
+    this.objectMapper = objectMapper;
+  }
+
+  public Map<String, Object> get(String userKey) {
+    List<String> values = jdbcTemplate.query(
+        "SELECT setting_json FROM yak_dev_editor_setting WHERE user_key = ? LIMIT 1",
+        (rs, rowNum) -> rs.getString(1),
+        normalizeUserKey(userKey));
+    if (values.isEmpty()) {
+      return defaults();
+    }
+    try {
+      Map<String, Object> stored = objectMapper.readValue(values.get(0), MAP_TYPE);
+      Map<String, Object> result = defaults();
+      result.putAll(stored);
+      return result;
+    } catch (Exception ex) {
+      throw new IllegalStateException("Invalid persisted editor settings", ex);
+    }
+  }
+
+  @Transactional
+  public Map<String, Object> save(String userKey, Map<String, Object> settings) {
+    Map<String, Object> normalized = defaults();
+    if (settings != null) {
+      normalized.putAll(settings);
+    }
+    normalized.put("theme", normalizeTheme(normalized.get("theme")));
+    normalized.put("fontSize", clampInt(normalized.get("fontSize"), 10, 32, 14));
+    normalized.put("lineHeight", clampDouble(normalized.get("lineHeight"), 1.0, 3.0, 1.6));
+
+    try {
+      String json = objectMapper.writeValueAsString(normalized);
+      jdbcTemplate.update(
+          "INSERT INTO yak_dev_editor_setting (user_key, setting_json, create_time, update_time) "
+              + "VALUES (?, ?, NOW(6), NOW(6)) "
+              + "ON DUPLICATE KEY UPDATE setting_json = VALUES(setting_json), update_time = NOW(6)",
+          normalizeUserKey(userKey), json);
+      return normalized;
+    } catch (Exception ex) {
+      throw new IllegalStateException("Failed to persist editor settings", ex);
+    }
+  }
+
+  private String normalizeUserKey(String userKey) {
+    String value = userKey == null ? "" : userKey.trim();
+    return value.isEmpty() ? "default" : value.substring(0, Math.min(value.length(), 128));
+  }
+
+  private String normalizeTheme(Object value) {
+    String theme = value == null ? "Yak-Light" : String.valueOf(value).trim();
+    return theme.isEmpty() ? "Yak-Light" : theme;
+  }
+
+  private int clampInt(Object value, int min, int max, int fallback) {
+    try {
+      int parsed = value instanceof Number number ? number.intValue() : Integer.parseInt(String.valueOf(value));
+      return Math.max(min, Math.min(max, parsed));
+    } catch (Exception ignored) {
+      return fallback;
+    }
+  }
+
+  private double clampDouble(Object value, double min, double max, double fallback) {
+    try {
+      double parsed = value instanceof Number number ? number.doubleValue() : Double.parseDouble(String.valueOf(value));
+      return Math.max(min, Math.min(max, parsed));
+    } catch (Exception ignored) {
+      return fallback;
+    }
+  }
+
+  private Map<String, Object> defaults() {
+    Map<String, Object> result = new LinkedHashMap<>();
+    result.put("theme", "Yak-Light");
+    result.put("fontSize", 14);
+    result.put("fontFamily", "Monaco");
+    result.put("customFontFamily", "");
+    result.put("lineHeight", 1.6);
+    result.put("showLineNumber", true);
+    result.put("showMinimap", false);
+    result.put("wordWrap", true);
+    result.put("folding", true);
+    result.put("renderLineHighlight", "line");
+    result.put("keywordCase", "lower");
+    result.put("sqlCompletionFQN", "none");
+    result.put("renderWhitespace", "none");
+    return result;
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/resources/db/migration/yak-data-development/V2__add_editor_settings.sql
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/resources/db/migration/yak-data-development/V2__add_editor_settings.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS yak_dev_editor_setting (
+    user_key VARCHAR(128) NOT NULL,
+    setting_json LONGTEXT NOT NULL,
+    create_time DATETIME(6) NOT NULL,
+    update_time DATETIME(6) NOT NULL,
+    PRIMARY KEY (user_key),
+    KEY idx_yak_dev_editor_setting_update (update_time)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/yak-ops-ui/src/pages/data-development/components/workbench/EditorSettingsPanel.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/workbench/EditorSettingsPanel.tsx
@@ -1,0 +1,219 @@
+import { Button, Input, InputNumber, Radio, Select, Spin, message } from 'antd';
+import { useEffect, useRef, useState } from 'react';
+
+import {
+  DEFAULT_YAK_EDITOR_SETTINGS,
+  YAK_EDITOR_FONTS,
+  YAK_EDITOR_THEMES,
+  setYakEditorSettings,
+  type YakEditorSettings,
+} from '../../editors/sql/editorSettings';
+import {
+  getDevelopmentEditorSettings,
+  saveDevelopmentEditorSettings,
+} from '../../service';
+
+const labelClassName = 'mb-1.5 block text-[12px] font-medium text-[#344054]';
+const rowClassName = 'grid grid-cols-1 gap-4 sm:grid-cols-2';
+
+const EditorSettingsPanel = () => {
+  const [settings, setSettings] = useState<YakEditorSettings>(DEFAULT_YAK_EDITOR_SETTINGS);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const saveTimer = useRef<ReturnType<typeof setTimeout>>();
+
+  useEffect(() => {
+    let active = true;
+    getDevelopmentEditorSettings()
+      .then((response) => {
+        if (!active) return;
+        const next = { ...DEFAULT_YAK_EDITOR_SETTINGS, ...(response.data || {}) };
+        setSettings(next);
+        setYakEditorSettings(next);
+      })
+      .catch(() => message.warning('编辑器设置读取失败，已使用默认设置'))
+      .finally(() => active && setLoading(false));
+    return () => {
+      active = false;
+      if (saveTimer.current) clearTimeout(saveTimer.current);
+    };
+  }, []);
+
+  const persist = (next: YakEditorSettings) => {
+    setSettings(next);
+    setYakEditorSettings(next);
+    if (saveTimer.current) clearTimeout(saveTimer.current);
+    saveTimer.current = setTimeout(async () => {
+      setSaving(true);
+      try {
+        const response = await saveDevelopmentEditorSettings(next);
+        const saved = { ...DEFAULT_YAK_EDITOR_SETTINGS, ...(response.data || next) };
+        setSettings(saved);
+        setYakEditorSettings(saved);
+      } catch {
+        message.error('编辑器设置保存失败');
+      } finally {
+        setSaving(false);
+      }
+    }, 450);
+  };
+
+  const patch = <K extends keyof YakEditorSettings>(key: K, value: YakEditorSettings[K]) =>
+    persist({ ...settings, [key]: value });
+
+  const booleanRadio = (key: keyof YakEditorSettings, enabledText = '显示', disabledText = '隐藏') => (
+    <Radio.Group
+      size="small"
+      value={settings[key] as boolean}
+      onChange={(event) => patch(key, event.target.value as never)}
+    >
+      <Radio value>{enabledText}</Radio>
+      <Radio value={false}>{disabledText}</Radio>
+    </Radio.Group>
+  );
+
+  if (loading) {
+    return <div className="flex h-40 items-center justify-center"><Spin size="small" /></div>;
+  }
+
+  return (
+    <div className="pb-6 text-[12px] text-[#344054]">
+      <div className="mb-5 flex items-center justify-between border-b border-[#eaecf0] pb-3">
+        <div>
+          <div className="font-semibold text-[#1d2939]">SQL 编辑器设置</div>
+          <div className="mt-1 text-[11px] text-[#98a2b3]">修改后实时生效，并自动保存到后端</div>
+        </div>
+        <span className="text-[11px] text-[#98a2b3]">{saving ? '保存中…' : '已同步'}</span>
+      </div>
+
+      <div className="space-y-5">
+        <div>
+          <label className={labelClassName}>编辑器主题</label>
+          <Select
+            className="w-full"
+            size="small"
+            value={settings.theme}
+            options={YAK_EDITOR_THEMES.map((theme) => ({ label: theme.name, value: theme.name }))}
+            onChange={(value) => patch('theme', value)}
+          />
+        </div>
+
+        <div className={rowClassName}>
+          <div>
+            <label className={labelClassName}>编辑器字体</label>
+            <Select
+              className="w-full"
+              size="small"
+              value={settings.fontFamily}
+              options={YAK_EDITOR_FONTS.map((font) => ({ label: font, value: font }))}
+              onChange={(value) => patch('fontFamily', value)}
+            />
+          </div>
+          <div>
+            <label className={labelClassName}>自定义字体</label>
+            <Input
+              size="small"
+              value={settings.customFontFamily}
+              placeholder="例如 Cascadia Code"
+              onChange={(event) => patch('customFontFamily', event.target.value)}
+            />
+          </div>
+        </div>
+
+        <div className={rowClassName}>
+          <div>
+            <label className={labelClassName}>字体大小</label>
+            <InputNumber
+              className="w-full"
+              size="small"
+              min={10}
+              max={32}
+              addonAfter="px"
+              value={settings.fontSize}
+              onChange={(value) => patch('fontSize', value || 14)}
+            />
+          </div>
+          <div>
+            <label className={labelClassName}>行高</label>
+            <InputNumber
+              className="w-full"
+              size="small"
+              min={1}
+              max={3}
+              step={0.1}
+              value={settings.lineHeight}
+              onChange={(value) => patch('lineHeight', value || 1.6)}
+            />
+          </div>
+        </div>
+
+        <div><label className={labelClassName}>显示行号</label>{booleanRadio('showLineNumber')}</div>
+        <div><label className={labelClassName}>显示缩略图</label>{booleanRadio('showMinimap')}</div>
+        <div><label className={labelClassName}>自动换行</label>{booleanRadio('wordWrap', '启用', '禁用')}</div>
+        <div><label className={labelClassName}>代码折叠</label>{booleanRadio('folding')}</div>
+
+        <div>
+          <label className={labelClassName}>行高亮</label>
+          <Select
+            className="w-full"
+            size="small"
+            value={settings.renderLineHighlight}
+            options={[
+              { label: 'LINE', value: 'line' },
+              { label: 'GUTTER', value: 'gutter' },
+              { label: 'ALL', value: 'all' },
+              { label: 'NONE', value: 'none' },
+            ]}
+            onChange={(value) => patch('renderLineHighlight', value)}
+          />
+        </div>
+
+        <div>
+          <label className={labelClassName}>关键字大小写</label>
+          <Radio.Group size="small" value={settings.keywordCase} onChange={(event) => patch('keywordCase', event.target.value)}>
+            <Radio value="upper">大写</Radio>
+            <Radio value="lower">小写</Radio>
+          </Radio.Group>
+        </div>
+
+        <div>
+          <label className={labelClassName}>全限定补全</label>
+          <Select
+            className="w-full"
+            size="small"
+            value={settings.sqlCompletionFQN}
+            options={[
+              { label: '不补全限定名', value: 'none' },
+              { label: '补全表名', value: 'table' },
+              { label: '补全完整限定名', value: 'all' },
+            ]}
+            onChange={(value) => patch('sqlCompletionFQN', value)}
+          />
+        </div>
+
+        <div>
+          <label className={labelClassName}>空白字符显示</label>
+          <Select
+            className="w-full"
+            size="small"
+            value={settings.renderWhitespace}
+            options={[
+              { label: '不显示', value: 'none' },
+              { label: '边界', value: 'boundary' },
+              { label: '选中区域', value: 'selection' },
+              { label: '行尾', value: 'trailing' },
+              { label: '全部', value: 'all' },
+            ]}
+            onChange={(value) => patch('renderWhitespace', value)}
+          />
+        </div>
+
+        <Button size="small" onClick={() => persist(DEFAULT_YAK_EDITOR_SETTINGS)}>
+          恢复默认设置
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default EditorSettingsPanel;

--- a/yak-ops-ui/src/pages/data-development/components/workbench/RightPanel.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/workbench/RightPanel.tsx
@@ -9,6 +9,7 @@ import type {
   DevelopmentEditorPanelKey,
 } from '../../editors/types';
 import type { DevelopmentDirectory, DevelopmentNode } from '../../types';
+import EditorSettingsPanel from './EditorSettingsPanel';
 import TaskVersionsPanel from './TaskVersionsPanel';
 
 interface RightPanelProps {
@@ -37,12 +38,13 @@ const initialWidth = () => {
 const allItems: Array<{
   key: DevelopmentEditorPanelKey;
   label: string;
-  capability: keyof DevelopmentEditorDefinition['capabilities'];
+  capability?: keyof DevelopmentEditorDefinition['capabilities'];
 }> = [
   { key: 'properties', label: '属性', capability: 'properties' },
   { key: 'run-config', label: '运行配置', capability: 'runConfig' },
   { key: 'schedule-config', label: '调度配置', capability: 'scheduleConfig' },
   { key: 'versions', label: '版本', capability: 'versions' },
+  { key: 'editor-settings', label: '编辑器设置' },
 ];
 
 const RightPanel = ({
@@ -58,7 +60,9 @@ const RightPanel = ({
 
   const items = useMemo(
     () =>
-      allItems.filter((item) => Boolean(definition.capabilities[item.capability])),
+      allItems.filter(
+        (item) => !item.capability || Boolean(definition.capabilities[item.capability]),
+      ),
     [definition],
   );
   const activeItem = items.find((item) => item.key === activeTab);
@@ -99,6 +103,10 @@ const RightPanel = ({
 
   const renderContent = () => {
     if (!activeTab) return null;
+
+    if (activeTab === 'editor-settings') {
+      return <EditorSettingsPanel />;
+    }
 
     if (activeTab === 'versions') {
       return (
@@ -182,21 +190,23 @@ const RightPanel = ({
                 {activeItem?.label}
               </span>
               <div className="flex items-center gap-1">
-                <button
-                  type="button"
-                  title="刷新"
-                  onClick={() => {
-                    if (activeTab === 'versions') {
-                      setManualRefreshKey((current) => current + 1);
-                    } else {
-                      message.info(`${activeItem?.label || ''}刷新能力将在后续阶段接入`);
-                    }
-                  }}
-                  className="flex h-7 items-center gap-1 rounded-[3px] px-2 text-[11px] text-[#475467] transition-colors hover:bg-[#f5f5f6]"
-                >
-                  <RefreshCw size={13} strokeWidth={1.8} />
-                  刷新
-                </button>
+                {activeTab !== 'editor-settings' ? (
+                  <button
+                    type="button"
+                    title="刷新"
+                    onClick={() => {
+                      if (activeTab === 'versions') {
+                        setManualRefreshKey((current) => current + 1);
+                      } else {
+                        message.info(`${activeItem?.label || ''}刷新能力将在后续阶段接入`);
+                      }
+                    }}
+                    className="flex h-7 items-center gap-1 rounded-[3px] px-2 text-[11px] text-[#475467] transition-colors hover:bg-[#f5f5f6]"
+                  >
+                    <RefreshCw size={13} strokeWidth={1.8} />
+                    刷新
+                  </button>
+                ) : null}
                 <button
                   type="button"
                   title="关闭"

--- a/yak-ops-ui/src/pages/data-development/editors/sql/SqlToolbar.tsx
+++ b/yak-ops-ui/src/pages/data-development/editors/sql/SqlToolbar.tsx
@@ -1,4 +1,4 @@
-import { Dropdown, Tooltip, message } from 'antd';
+import { Tooltip, message } from 'antd';
 import {
   LoaderCircle,
   Play,
@@ -6,7 +6,6 @@ import {
   Rocket,
   Save,
   Search,
-  Settings,
   Sparkles,
   Undo2,
   Wand2,
@@ -64,103 +63,33 @@ const SqlToolbar = ({
   return (
     <div className="flex h-full w-full min-w-0 items-center justify-between gap-3">
       <div className="flex shrink-0 items-center gap-0.5">
-        <ToolbarButton
-          title={running ? 'SQL 运行中' : '运行当前 SQL'}
-          disabled={running}
-          onClick={onRun}
-        >
-          {running ? (
-            <LoaderCircle size={15} className="animate-spin" />
-          ) : (
-            <Play size={15} strokeWidth={1.8} />
-          )}
+        <ToolbarButton title={running ? 'SQL 运行中' : '运行当前 SQL'} disabled={running} onClick={onRun}>
+          {running ? <LoaderCircle size={15} className="animate-spin" /> : <Play size={15} strokeWidth={1.8} />}
         </ToolbarButton>
-
         <ToolbarDivider />
-
-        <ToolbarButton
-          title="保存草稿"
-          disabled={saving || publishing || running}
-          onClick={onSave}
-        >
-          {saving ? (
-            <LoaderCircle size={15} className="animate-spin" />
-          ) : (
-            <Save size={15} strokeWidth={1.8} />
-          )}
+        <ToolbarButton title="保存草稿" disabled={saving || publishing || running} onClick={onSave}>
+          {saving ? <LoaderCircle size={15} className="animate-spin" /> : <Save size={15} strokeWidth={1.8} />}
         </ToolbarButton>
-        <ToolbarButton
-          title="发布版本"
-          disabled={saving || publishing || running}
-          onClick={onPublish}
-        >
-          {publishing ? (
-            <LoaderCircle size={15} className="animate-spin" />
-          ) : (
-            <Rocket size={15} strokeWidth={1.8} />
-          )}
+        <ToolbarButton title="发布版本" disabled={saving || publishing || running} onClick={onPublish}>
+          {publishing ? <LoaderCircle size={15} className="animate-spin" /> : <Rocket size={15} strokeWidth={1.8} />}
         </ToolbarButton>
-        <ToolbarButton
-          title="撤销"
-          disabled={running}
-          onClick={() => execute('undo', 'SQL 编辑器尚未就绪')}
-        >
+        <ToolbarButton title="撤销" disabled={running} onClick={() => execute('undo', 'SQL 编辑器尚未就绪')}>
           <Undo2 size={15} strokeWidth={1.8} />
         </ToolbarButton>
-        <ToolbarButton
-          title="重做"
-          disabled={running}
-          onClick={() => execute('redo', 'SQL 编辑器尚未就绪')}
-        >
+        <ToolbarButton title="重做" disabled={running} onClick={() => execute('redo', 'SQL 编辑器尚未就绪')}>
           <Redo2 size={15} strokeWidth={1.8} />
         </ToolbarButton>
-        <ToolbarButton
-          title="查找"
-          onClick={() => execute('find', 'SQL 编辑器尚未就绪')}
-        >
+        <ToolbarButton title="查找" onClick={() => execute('find', 'SQL 编辑器尚未就绪')}>
           <Search size={15} strokeWidth={1.8} />
         </ToolbarButton>
-
         <ToolbarDivider />
-
-        <ToolbarButton
-          title="格式化 SQL"
-          disabled={running}
-          onClick={() => execute('format', 'SQL 编辑器尚未就绪')}
-        >
+        <ToolbarButton title="格式化 SQL" disabled={running} onClick={() => execute('format', 'SQL 编辑器尚未就绪')}>
           <Wand2 size={15} strokeWidth={1.8} />
         </ToolbarButton>
-        <ToolbarButton
-          title="触发智能提示"
-          onClick={() => execute('suggest', 'SQL 编辑器尚未就绪')}
-        >
+        <ToolbarButton title="触发智能提示" onClick={() => execute('suggest', 'SQL 编辑器尚未就绪')}>
           <Sparkles size={15} strokeWidth={1.8} />
         </ToolbarButton>
-
-        <Dropdown
-          trigger={['click']}
-          placement="bottomLeft"
-          menu={{
-            items: [
-              { key: 'toggle-word-wrap', label: '切换自动换行' },
-              { key: 'toggle-minimap', label: '切换缩略图' },
-            ],
-            onClick: ({ key }) =>
-              execute(key as SqlEditorCommand, 'SQL 编辑器尚未就绪'),
-          }}
-        >
-          <Tooltip title="编辑器设置" mouseEnterDelay={0.35}>
-            <button
-              type="button"
-              aria-label="编辑器设置"
-              className={iconButtonClassName}
-            >
-              <Settings size={15} strokeWidth={1.8} />
-            </button>
-          </Tooltip>
-        </Dropdown>
       </div>
-
       <SqlMetadataContextToolbar nodeId={node.id} />
     </div>
   );

--- a/yak-ops-ui/src/pages/data-development/editors/sql/components/SqlMonacoEditor.tsx
+++ b/yak-ops-ui/src/pages/data-development/editors/sql/components/SqlMonacoEditor.tsx
@@ -15,6 +15,12 @@ import {
 } from '../completion/registerSqlMetadataCompletion';
 import { acquireSqlSnippetCompletionProvider } from '../completion/registerSqlSnippetCompletion';
 import { bindSqlDiagnostics } from '../diagnostics/bindSqlDiagnostics';
+import {
+  YAK_EDITOR_THEMES,
+  editorOptionsFromSettings,
+  getYakEditorSettings,
+  subscribeYakEditorSettings,
+} from '../editorSettings';
 import { formatSqlText } from '../formatting/formatSqlText';
 import { setupMonacoEnvironment } from '../monaco/setupMonacoEnvironment';
 import { getSqlStatementRanges } from '../monaco/sqlStatementRanges';
@@ -36,34 +42,12 @@ interface SqlMonacoEditorProps {
   onViewStateChange?: (viewState: DevelopmentEditorViewState) => void;
 }
 
-let themeRegistered = false;
+let themesRegistered = false;
 
-const ensureYakSqlTheme = () => {
-  if (themeRegistered) return;
-  themeRegistered = true;
-
-  monaco.editor.defineTheme('yak-sql-light', {
-    base: 'vs',
-    inherit: true,
-    rules: [
-      { token: 'keyword.sql', foreground: '245BDB', fontStyle: 'bold' },
-      { token: 'string.sql', foreground: '027A48' },
-      { token: 'number.sql', foreground: 'B54708' },
-      { token: 'comment.sql', foreground: '98A2B3', fontStyle: 'italic' },
-    ],
-    colors: {
-      'editor.background': '#ffffff',
-      'editor.foreground': '#344054',
-      'editorLineNumber.foreground': '#b0b7c3',
-      'editorLineNumber.activeForeground': '#667085',
-      'editorCursor.foreground': '#344054',
-      'editor.selectionBackground': '#dbeafe',
-      'editor.inactiveSelectionBackground': '#eef4ff',
-      'editor.lineHighlightBackground': '#fafafa',
-      'editorIndentGuide.background1': '#f0f1f3',
-      'editorIndentGuide.activeBackground1': '#d0d5dd',
-    },
-  });
+const ensureYakThemes = () => {
+  if (themesRegistered) return;
+  themesRegistered = true;
+  YAK_EDITOR_THEMES.forEach((theme) => monaco.editor.defineTheme(theme.name, theme.data));
 };
 
 const SqlMonacoEditor = ({
@@ -85,31 +69,17 @@ const SqlMonacoEditor = ({
   const onPositionChangeRef = useRef(onPositionChange);
   const onViewStateChangeRef = useRef(onViewStateChange);
 
-  useEffect(() => {
-    onChangeRef.current = onChange;
-  }, [onChange]);
-
-  useEffect(() => {
-    onRunStatementRef.current = onRunStatement;
-  }, [onRunStatement]);
-
-  useEffect(() => {
-    runningRef.current = running;
-  }, [running]);
-
-  useEffect(() => {
-    onPositionChangeRef.current = onPositionChange;
-  }, [onPositionChange]);
-
-  useEffect(() => {
-    onViewStateChangeRef.current = onViewStateChange;
-  }, [onViewStateChange]);
+  useEffect(() => { onChangeRef.current = onChange; }, [onChange]);
+  useEffect(() => { onRunStatementRef.current = onRunStatement; }, [onRunStatement]);
+  useEffect(() => { runningRef.current = running; }, [running]);
+  useEffect(() => { onPositionChangeRef.current = onPositionChange; }, [onPositionChange]);
+  useEffect(() => { onViewStateChangeRef.current = onViewStateChange; }, [onViewStateChange]);
 
   useEffect(() => {
     if (!containerRef.current) return undefined;
 
     setupMonacoEnvironment();
-    ensureYakSqlTheme();
+    ensureYakThemes();
     const builtinCompletionProvider = acquireSqlBuiltinCompletionProvider();
     const metadataCompletionProvider = acquireSqlMetadataCompletionProvider();
     const snippetCompletionProvider = acquireSqlSnippetCompletionProvider();
@@ -119,39 +89,26 @@ const SqlMonacoEditor = ({
       provideFoldingRanges: (foldingModel) =>
         getSqlStatementRanges(foldingModel.getValue())
           .filter((statement) => statement.endLine > statement.startLine)
-          .map((statement) => ({
-            start: statement.startLine,
-            end: statement.endLine,
-          })),
+          .map((statement) => ({ start: statement.startLine, end: statement.endLine })),
     });
 
-    const uri = monaco.Uri.parse(
-      `inmemory://yak-ops/data-development/sql/${encodeURIComponent(id)}.sql`,
-    );
+    const uri = monaco.Uri.parse(`inmemory://yak-ops/data-development/sql/${encodeURIComponent(id)}.sql`);
     monaco.editor.getModel(uri)?.dispose();
 
     const model = monaco.editor.createModel(value, 'sql', uri);
     const metadataModelBinding = bindSqlMetadataModel(model.uri.toString(), id);
     const diagnosticsBinding = bindSqlDiagnostics(model);
+    const initialSettings = getYakEditorSettings();
     const editor = monaco.editor.create(containerRef.current, {
       model,
-      theme: 'yak-sql-light',
+      ...editorOptionsFromSettings(initialSettings),
       automaticLayout: true,
-      minimap: { enabled: false },
-      fontSize: 13,
-      lineHeight: 22,
-      fontFamily:
-        "'JetBrains Mono', 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace",
       tabSize: 2,
       insertSpaces: true,
       scrollBeyondLastLine: false,
       smoothScrolling: true,
       cursorSmoothCaretAnimation: 'on',
       cursorBlinking: 'smooth',
-      renderLineHighlight: 'line',
-      renderWhitespace: 'selection',
-      wordWrap: 'off',
-      folding: true,
       showFoldingControls: 'always',
       glyphMargin: true,
       lineNumbersMinChars: 3,
@@ -159,11 +116,7 @@ const SqlMonacoEditor = ({
       hideCursorInOverviewRuler: true,
       fixedOverflowWidgets: true,
       padding: { top: 12, bottom: 12 },
-      quickSuggestions: {
-        other: true,
-        comments: false,
-        strings: false,
-      },
+      quickSuggestions: { other: true, comments: false, strings: false },
       suggestOnTriggerCharacters: true,
       acceptSuggestionOnEnter: 'on',
       tabCompletion: 'on',
@@ -188,6 +141,11 @@ const SqlMonacoEditor = ({
     editorRef.current = editor;
     modelRef.current = model;
 
+    const unsubscribeSettings = subscribeYakEditorSettings((settings) => {
+      monaco.editor.setTheme(settings.theme);
+      editor.updateOptions(editorOptionsFromSettings(settings));
+    });
+
     let statementRanges = getSqlStatementRanges(model.getValue());
     const runDecorations = editor.createDecorationsCollection();
     const refreshStatementDecorations = () => {
@@ -195,19 +153,16 @@ const SqlMonacoEditor = ({
       runDecorations.set(
         statementRanges.map((statement) => ({
           range: new monaco.Range(statement.startLine, 1, statement.startLine, 1),
-          options: {
-            glyphMarginClassName: 'yak-sql-run-glyph',
-          },
+          options: { glyphMarginClassName: 'yak-sql-run-glyph' },
         })),
       );
     };
     refreshStatementDecorations();
 
-    let wordWrapEnabled = false;
-    let minimapEnabled = false;
+    let wordWrapEnabled = initialSettings.wordWrap;
+    let minimapEnabled = initialSettings.showMinimap;
     const commandBinding = registerSqlEditorCommandHandler(id, async (command) => {
       editor.focus();
-
       if (command === 'undo' || command === 'redo') {
         editor.trigger('yak-sql-toolbar', command, null);
         return;
@@ -233,28 +188,15 @@ const SqlMonacoEditor = ({
       if (command === 'format') {
         const formatted = formatSqlText(model.getValue());
         if (formatted === model.getValue()) return;
-
         editor.pushUndoStop();
-        editor.executeEdits('yak-sql-format', [
-          {
-            range: model.getFullModelRange(),
-            text: formatted,
-            forceMoveMarkers: true,
-          },
-        ]);
+        editor.executeEdits('yak-sql-format', [{ range: model.getFullModelRange(), text: formatted, forceMoveMarkers: true }]);
         editor.pushUndoStop();
       }
     });
 
     if (initialViewState) {
-      if (initialViewState.selection) {
-        editor.setSelection(initialViewState.selection);
-      } else {
-        editor.setPosition({
-          lineNumber: initialViewState.lineNumber,
-          column: initialViewState.column,
-        });
-      }
+      if (initialViewState.selection) editor.setSelection(initialViewState.selection);
+      else editor.setPosition({ lineNumber: initialViewState.lineNumber, column: initialViewState.column });
       editor.setScrollTop(initialViewState.scrollTop);
       editor.setScrollLeft(initialViewState.scrollLeft);
     }
@@ -263,27 +205,17 @@ const SqlMonacoEditor = ({
       const position = editor.getPosition();
       const selection = editor.getSelection();
       if (!position) return;
-
-      const selectionLength = selection
-        ? model.getValueInRange(selection).length
-        : 0;
-      onPositionChangeRef.current?.({
-        lineNumber: position.lineNumber,
-        column: position.column,
-        selectionLength,
-      });
-
+      const selectionLength = selection ? model.getValueInRange(selection).length : 0;
+      onPositionChangeRef.current?.({ lineNumber: position.lineNumber, column: position.column, selectionLength });
       onViewStateChangeRef.current?.({
         lineNumber: position.lineNumber,
         column: position.column,
-        selection: selection
-          ? {
-              startLineNumber: selection.startLineNumber,
-              startColumn: selection.startColumn,
-              endLineNumber: selection.endLineNumber,
-              endColumn: selection.endColumn,
-            }
-          : undefined,
+        selection: selection ? {
+          startLineNumber: selection.startLineNumber,
+          startColumn: selection.startColumn,
+          endLineNumber: selection.endLineNumber,
+          endColumn: selection.endColumn,
+        } : undefined,
         scrollTop: editor.getScrollTop(),
         scrollLeft: editor.getScrollLeft(),
       });
@@ -298,15 +230,10 @@ const SqlMonacoEditor = ({
         event.target.type !== monaco.editor.MouseTargetType.GUTTER_GLYPH_MARGIN ||
         runningRef.current ||
         !onRunStatementRef.current
-      ) {
-        return;
-      }
-
+      ) return;
       const lineNumber = event.target.position?.lineNumber;
       if (!lineNumber) return;
-      const statement = statementRanges.find(
-        (candidate) => candidate.startLine === lineNumber,
-      );
+      const statement = statementRanges.find((candidate) => candidate.startLine === lineNumber);
       if (statement) onRunStatementRef.current(statement.sql);
     });
     const cursorDisposable = editor.onDidChangeCursorPosition(emitEditorState);
@@ -317,6 +244,7 @@ const SqlMonacoEditor = ({
 
     return () => {
       emitEditorState();
+      unsubscribeSettings();
       contentDisposable.dispose();
       gutterDisposable.dispose();
       cursorDisposable.dispose();
@@ -341,12 +269,7 @@ const SqlMonacoEditor = ({
   useEffect(() => {
     const model = modelRef.current;
     if (!model || model.getValue() === value) return;
-
-    model.pushEditOperations(
-      [],
-      [{ range: model.getFullModelRange(), text: value }],
-      () => null,
-    );
+    model.pushEditOperations([], [{ range: model.getFullModelRange(), text: value }], () => null);
   }, [value]);
 
   return <div ref={containerRef} className="h-full min-h-0 w-full" />;

--- a/yak-ops-ui/src/pages/data-development/editors/sql/editorSettings.ts
+++ b/yak-ops-ui/src/pages/data-development/editors/sql/editorSettings.ts
@@ -92,7 +92,7 @@ const dark = (background: string, foreground: string, keyword: string): monaco.e
   },
 });
 
-// Theme set follows the familiar SQL-editor presets from Chat2DB; Chat2DB-specific branding is replaced by Yak.
+// Theme set follows familiar SQL-editor presets; Chat2DB-specific branding is replaced by Yak.
 export const YAK_EDITOR_THEMES: YakEditorTheme[] = [
   { name: 'Yak-Light', dark: false, data: light('#FFFFFF', '#344054', '#245BDB') },
   { name: 'Yak-Dark', dark: true, data: dark('#17181C', '#D0D5DD', '#7AA2F7') },
@@ -112,8 +112,6 @@ const listeners = new Set<(settings: YakEditorSettings) => void>();
 let currentSettings = DEFAULT_YAK_EDITOR_SETTINGS;
 let loadPromise: Promise<YakEditorSettings> | undefined;
 
-export const getYakEditorSettings = () => currentSettings;
-
 export const setYakEditorSettings = (settings: YakEditorSettings) => {
   currentSettings = { ...DEFAULT_YAK_EDITOR_SETTINGS, ...settings };
   listeners.forEach((listener) => listener(currentSettings));
@@ -132,9 +130,17 @@ export const ensureYakEditorSettingsLoaded = () => {
         setYakEditorSettings(settings);
         return settings;
       })
-      .catch(() => currentSettings);
+      .catch(() => {
+        loadPromise = undefined;
+        return currentSettings;
+      });
   }
   return loadPromise;
+};
+
+export const getYakEditorSettings = () => {
+  if (!loadPromise) void ensureYakEditorSettingsLoaded();
+  return currentSettings;
 };
 
 export const editorOptionsFromSettings = (settings: YakEditorSettings): monaco.editor.IStandaloneEditorConstructionOptions => ({
@@ -149,5 +155,3 @@ export const editorOptionsFromSettings = (settings: YakEditorSettings): monaco.e
   renderLineHighlight: settings.renderLineHighlight,
   renderWhitespace: settings.renderWhitespace,
 });
-
-void ensureYakEditorSettingsLoaded();

--- a/yak-ops-ui/src/pages/data-development/editors/sql/editorSettings.ts
+++ b/yak-ops-ui/src/pages/data-development/editors/sql/editorSettings.ts
@@ -1,0 +1,135 @@
+import type * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
+
+export type YakEditorLineHighlight = 'line' | 'none' | 'gutter' | 'all';
+export type YakSqlCompletionFqn = 'none' | 'table' | 'all';
+export type YakRenderWhitespace = 'none' | 'boundary' | 'selection' | 'trailing' | 'all';
+
+export interface YakEditorSettings {
+  theme: string;
+  fontSize: number;
+  fontFamily: string;
+  customFontFamily: string;
+  lineHeight: number;
+  showLineNumber: boolean;
+  showMinimap: boolean;
+  wordWrap: boolean;
+  folding: boolean;
+  renderLineHighlight: YakEditorLineHighlight;
+  keywordCase: 'lower' | 'upper';
+  sqlCompletionFQN: YakSqlCompletionFqn;
+  renderWhitespace: YakRenderWhitespace;
+}
+
+export const DEFAULT_YAK_EDITOR_SETTINGS: YakEditorSettings = {
+  theme: 'Yak-Light',
+  fontSize: 14,
+  fontFamily: 'Monaco',
+  customFontFamily: '',
+  lineHeight: 1.6,
+  showLineNumber: true,
+  showMinimap: false,
+  wordWrap: true,
+  folding: true,
+  renderLineHighlight: 'line',
+  keywordCase: 'lower',
+  sqlCompletionFQN: 'none',
+  renderWhitespace: 'none',
+};
+
+export const YAK_EDITOR_FONTS = [
+  'Monaco',
+  'JetBrains Mono',
+  'Consolas',
+  'Menlo',
+  'Fira Code',
+  'Source Code Pro',
+  'Courier New',
+];
+
+export interface YakEditorTheme {
+  name: string;
+  dark: boolean;
+  data: monaco.editor.IStandaloneThemeData;
+}
+
+const light = (background: string, foreground: string, keyword: string): monaco.editor.IStandaloneThemeData => ({
+  base: 'vs',
+  inherit: true,
+  rules: [
+    { token: 'keyword.sql', foreground: keyword.replace('#', ''), fontStyle: 'bold' },
+    { token: 'string.sql', foreground: '067D68' },
+    { token: 'number.sql', foreground: 'B54708' },
+    { token: 'comment.sql', foreground: '98A2B3', fontStyle: 'italic' },
+  ],
+  colors: {
+    'editor.background': background,
+    'editor.foreground': foreground,
+    'editorLineNumber.foreground': '#A4ABB8',
+    'editorLineNumber.activeForeground': foreground,
+    'editor.lineHighlightBackground': '#00000008',
+    'editor.selectionBackground': '#BFD7FF88',
+  },
+});
+
+const dark = (background: string, foreground: string, keyword: string): monaco.editor.IStandaloneThemeData => ({
+  base: 'vs-dark',
+  inherit: true,
+  rules: [
+    { token: 'keyword.sql', foreground: keyword.replace('#', ''), fontStyle: 'bold' },
+    { token: 'string.sql', foreground: '9ECE6A' },
+    { token: 'number.sql', foreground: 'FF9E64' },
+    { token: 'comment.sql', foreground: '6B7280', fontStyle: 'italic' },
+  ],
+  colors: {
+    'editor.background': background,
+    'editor.foreground': foreground,
+    'editorLineNumber.foreground': '#667085',
+    'editorLineNumber.activeForeground': foreground,
+    'editor.lineHighlightBackground': '#FFFFFF08',
+    'editor.selectionBackground': '#365A7A99',
+  },
+});
+
+// Theme set follows Chat2DB's editor-setting presets; Chat2DB-specific names are branded as Yak.
+export const YAK_EDITOR_THEMES: YakEditorTheme[] = [
+  { name: 'Yak-Light', dark: false, data: light('#FFFFFF', '#344054', '#245BDB') },
+  { name: 'Yak-Dark', dark: true, data: dark('#17181C', '#D0D5DD', '#7AA2F7') },
+  { name: 'Darcula', dark: true, data: dark('#2B2B2B', '#A9B7C6', '#CC7832') },
+  { name: 'Erlang-Dark', dark: true, data: dark('#1F1F1F', '#D6D6D6', '#F08D49') },
+  { name: 'GitHub', dark: false, data: light('#FFFFFF', '#24292F', '#CF222E') },
+  { name: 'Material', dark: true, data: dark('#263238', '#EEFFFF', '#C792EA') },
+  { name: 'Night-Owl', dark: true, data: dark('#011627', '#D6DEEB', '#C792EA') },
+  { name: 'One-Dark-Pro', dark: true, data: dark('#282C34', '#ABB2BF', '#C678DD') },
+  { name: 'Solarized-Dark', dark: true, data: dark('#002B36', '#839496', '#B58900') },
+  { name: 'Solarized-Light', dark: false, data: light('#FDF6E3', '#657B83', '#B58900') },
+  { name: 'Tomorrow', dark: false, data: light('#FFFFFF', '#4D4D4C', '#8959A8') },
+  { name: 'Twilight', dark: true, data: dark('#141414', '#F8F8F8', '#CDA869') },
+];
+
+const listeners = new Set<(settings: YakEditorSettings) => void>();
+let currentSettings = DEFAULT_YAK_EDITOR_SETTINGS;
+
+export const getYakEditorSettings = () => currentSettings;
+
+export const setYakEditorSettings = (settings: YakEditorSettings) => {
+  currentSettings = { ...DEFAULT_YAK_EDITOR_SETTINGS, ...settings };
+  listeners.forEach((listener) => listener(currentSettings));
+};
+
+export const subscribeYakEditorSettings = (listener: (settings: YakEditorSettings) => void) => {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+};
+
+export const editorOptionsFromSettings = (settings: YakEditorSettings): monaco.editor.IStandaloneEditorConstructionOptions => ({
+  theme: settings.theme,
+  fontSize: settings.fontSize,
+  lineHeight: Math.max(16, Math.round(settings.fontSize * settings.lineHeight)),
+  fontFamily: settings.customFontFamily.trim() || settings.fontFamily,
+  lineNumbers: settings.showLineNumber ? 'on' : 'off',
+  minimap: { enabled: settings.showMinimap },
+  wordWrap: settings.wordWrap ? 'on' : 'off',
+  folding: settings.folding,
+  renderLineHighlight: settings.renderLineHighlight,
+  renderWhitespace: settings.renderWhitespace,
+});

--- a/yak-ops-ui/src/pages/data-development/editors/sql/editorSettings.ts
+++ b/yak-ops-ui/src/pages/data-development/editors/sql/editorSettings.ts
@@ -1,3 +1,5 @@
+import type { ApiResponse } from '@/services/http/response';
+import HttpUtils from '@/utils/HttpUtils';
 import type * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
 
 export type YakEditorLineHighlight = 'line' | 'none' | 'gutter' | 'all';
@@ -90,7 +92,7 @@ const dark = (background: string, foreground: string, keyword: string): monaco.e
   },
 });
 
-// Theme set follows Chat2DB's editor-setting presets; Chat2DB-specific names are branded as Yak.
+// Theme set follows the familiar SQL-editor presets from Chat2DB; Chat2DB-specific branding is replaced by Yak.
 export const YAK_EDITOR_THEMES: YakEditorTheme[] = [
   { name: 'Yak-Light', dark: false, data: light('#FFFFFF', '#344054', '#245BDB') },
   { name: 'Yak-Dark', dark: true, data: dark('#17181C', '#D0D5DD', '#7AA2F7') },
@@ -108,6 +110,7 @@ export const YAK_EDITOR_THEMES: YakEditorTheme[] = [
 
 const listeners = new Set<(settings: YakEditorSettings) => void>();
 let currentSettings = DEFAULT_YAK_EDITOR_SETTINGS;
+let loadPromise: Promise<YakEditorSettings> | undefined;
 
 export const getYakEditorSettings = () => currentSettings;
 
@@ -119,6 +122,19 @@ export const setYakEditorSettings = (settings: YakEditorSettings) => {
 export const subscribeYakEditorSettings = (listener: (settings: YakEditorSettings) => void) => {
   listeners.add(listener);
   return () => listeners.delete(listener);
+};
+
+export const ensureYakEditorSettingsLoaded = () => {
+  if (!loadPromise) {
+    loadPromise = HttpUtils.get<YakEditorSettings>('/api/v1/data-development/editor-settings')
+      .then((response: ApiResponse<YakEditorSettings>) => {
+        const settings = { ...DEFAULT_YAK_EDITOR_SETTINGS, ...(response.data || {}) };
+        setYakEditorSettings(settings);
+        return settings;
+      })
+      .catch(() => currentSettings);
+  }
+  return loadPromise;
 };
 
 export const editorOptionsFromSettings = (settings: YakEditorSettings): monaco.editor.IStandaloneEditorConstructionOptions => ({
@@ -133,3 +149,5 @@ export const editorOptionsFromSettings = (settings: YakEditorSettings): monaco.e
   renderLineHighlight: settings.renderLineHighlight,
   renderWhitespace: settings.renderWhitespace,
 });
+
+void ensureYakEditorSettingsLoaded();

--- a/yak-ops-ui/src/pages/data-development/editors/types.ts
+++ b/yak-ops-ui/src/pages/data-development/editors/types.ts
@@ -12,7 +12,8 @@ export type DevelopmentEditorPanelKey =
   | 'properties'
   | 'run-config'
   | 'schedule-config'
-  | 'versions';
+  | 'versions'
+  | 'editor-settings';
 
 export interface DevelopmentEditorContext {
   node: DevelopmentNode;

--- a/yak-ops-ui/src/pages/data-development/service.ts
+++ b/yak-ops-ui/src/pages/data-development/service.ts
@@ -1,6 +1,7 @@
 import type { ApiResponse } from '@/services/http/response';
 import HttpUtils from '@/utils/HttpUtils';
 
+import type { YakEditorSettings } from './editors/sql/editorSettings';
 import type {
   CreateDevelopmentDirectoryPayload,
   CreateDevelopmentNodePayload,
@@ -18,6 +19,7 @@ import type {
 const DATA_DEVELOPMENT_API = '/api/v1/data-development';
 const DIRECTORY_API = `${DATA_DEVELOPMENT_API}/directories`;
 const NODE_API = `${DATA_DEVELOPMENT_API}/nodes`;
+const EDITOR_SETTINGS_API = `${DATA_DEVELOPMENT_API}/editor-settings`;
 
 export const listDevelopmentDirectories = (): Promise<ApiResponse<DevelopmentDirectory[]>> =>
   HttpUtils.get<DevelopmentDirectory[]>(DIRECTORY_API);
@@ -93,3 +95,11 @@ export const getDevelopmentTaskRevision = (
   HttpUtils.get<DevelopmentTaskRevision>(
     `${NODE_API}/${nodeId}/revisions/${revisionNo}`,
   );
+
+export const getDevelopmentEditorSettings = (): Promise<ApiResponse<YakEditorSettings>> =>
+  HttpUtils.get<YakEditorSettings>(EDITOR_SETTINGS_API);
+
+export const saveDevelopmentEditorSettings = (
+  settings: YakEditorSettings,
+): Promise<ApiResponse<YakEditorSettings>> =>
+  HttpUtils.put<YakEditorSettings>(EDITOR_SETTINGS_API, settings);


### PR DESCRIPTION
## 变更说明

在数据开发工作台右侧新增「编辑器设置」Tab，按现有 Yak-Ops 右侧属性/运行配置/调度配置/版本的交互方式集成，不再使用 SQL 顶部工具栏的齿轮入口。

### 前端
- 新增右侧「编辑器设置」Tab，配置修改后实时作用于 Monaco Editor，并自动持久化。
- 支持主题、字体、自定义字体、字体大小、行高、行号、缩略图、自动换行、代码折叠、行高亮、关键字大小写、全限定补全、空白字符显示。
- 提供 Yak-Light / Yak-Dark，以及 Darcula、Erlang-Dark、GitHub、Material、Night-Owl、One-Dark-Pro、Solarized-Dark、Solarized-Light、Tomorrow、Twilight 等主题预设。
- 原 Chat2DB 品牌主题命名改为 Yak-Light / Yak-Dark；实现采用 Yak-Ops 自有代码与 Monaco theme 配置，没有直接复制 Chat2DB 当前受限许可版本的源码。
- 删除 SQL 顶部工具栏的「编辑器设置」齿轮/下拉入口。

### 后端
- 新增 `GET /api/v1/data-development/editor-settings`。
- 新增 `PUT /api/v1/data-development/editor-settings`。
- 新增 `yak_dev_editor_setting` 表，按当前 Principal 用户名持久化；未接入 Principal 的环境回退到 `default`。
- 服务端合并默认值，并对字体大小、行高等关键数值做基础归一化。

### 数据库
- 新增 Flyway migration：`V2__add_editor_settings.sql`。

### 备注
设计与配置项参考了 Chat2DB 的编辑器设置体验，但按 Yak-Ops 当前工作台结构重新实现，设置入口收口到右侧 Tab。