### PR TITLE
feat: add standard SSH tunnel capability for datasources

### DIFF
--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/util/DataSourceSecretCodec.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/util/DataSourceSecretCodec.java
@@ -27,7 +27,17 @@ public class DataSourceSecretCodec {
   public static final String MASKED_VALUE = "******";
 
   private static final Set<String> COMMON_SECRET_KEYS =
-      Set.of("password", "pwd", "secret", "secretkey", "accesstoken", "token");
+      Set.of(
+          "password",
+          "pwd",
+          "secret",
+          "secretkey",
+          "accesstoken",
+          "token",
+          "privatekey",
+          "privatekeycontent",
+          "passphrase",
+          "privatekeypassphrase");
 
   private final ObjectMapper objectMapper;
 
@@ -179,7 +189,9 @@ public class DataSourceSecretCodec {
         || configuredKeys.contains(normalized)
         || normalized.endsWith("password")
         || normalized.endsWith("secret")
-        || normalized.endsWith("token");
+        || normalized.endsWith("token")
+        || normalized.endsWith("privatekey")
+        || normalized.endsWith("passphrase");
   }
 
   private String normalizeKey(String key) {

--- a/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/util/DataSourceSecretCodecTest.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/util/DataSourceSecretCodecTest.java
@@ -41,6 +41,28 @@ class DataSourceSecretCodecTest {
   }
 
   @Test
+  void shouldMaskNestedSshCredentials() throws Exception {
+    DataSourcePlugin plugin = pluginWithPasswordField();
+
+    String masked =
+        codec.maskConnectionJson(
+            plugin,
+            "{\"sshTunnel\":{\"enabled\":true,\"host\":\"bastion\","
+                + "\"password\":\"ssh-password\",\"privateKey\":\"private-key\","
+                + "\"passphrase\":\"key-passphrase\"}}"
+        );
+    JsonNode ssh = objectMapper.readTree(masked).path("sshTunnel");
+
+    assertThat(ssh.path("password").asText())
+        .isEqualTo(DataSourceSecretCodec.MASKED_VALUE);
+    assertThat(ssh.path("privateKey").asText())
+        .isEqualTo(DataSourceSecretCodec.MASKED_VALUE);
+    assertThat(ssh.path("passphrase").asText())
+        .isEqualTo(DataSourceSecretCodec.MASKED_VALUE);
+    assertThat(ssh.path("host").asText()).isEqualTo("bastion");
+  }
+
+  @Test
   void shouldReuseStoredPasswordWhenEditSubmitsMask() throws Exception {
     DataSourcePlugin plugin = pluginWithPasswordField();
 
@@ -58,6 +80,28 @@ class DataSourceSecretCodecTest {
     assertThat(root.get("password").asText()).isEqualTo("top-secret");
     assertThat(root.path("properties").path("accessToken").asText())
         .isEqualTo("nested-secret");
+  }
+
+  @Test
+  void shouldReuseStoredSshSecretsWhenEditSubmitsMask() throws Exception {
+    DataSourcePlugin plugin = pluginWithPasswordField();
+
+    String merged =
+        codec.mergeStoredSecrets(
+            plugin,
+            "{\"sshTunnel\":{\"enabled\":true,\"host\":\"new-bastion\","
+                + "\"password\":\"******\",\"privateKey\":\"******\","
+                + "\"passphrase\":\"******\"}}",
+            "{\"sshTunnel\":{\"enabled\":true,\"host\":\"old-bastion\","
+                + "\"password\":\"ssh-password\",\"privateKey\":\"private-key\","
+                + "\"passphrase\":\"key-passphrase\"}}"
+        );
+    JsonNode ssh = objectMapper.readTree(merged).path("sshTunnel");
+
+    assertThat(ssh.path("host").asText()).isEqualTo("new-bastion");
+    assertThat(ssh.path("password").asText()).isEqualTo("ssh-password");
+    assertThat(ssh.path("privateKey").asText()).isEqualTo("private-key");
+    assertThat(ssh.path("passphrase").asText()).isEqualTo("key-passphrase");
   }
 
   @Test

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/vo/datasource/DataSourcePluginConfigVO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/vo/datasource/DataSourcePluginConfigVO.java
@@ -67,8 +67,8 @@ public class DataSourcePluginConfigVO {
     /**
      * 标准字段组件类型。
      *
-     * <p>支持 INPUT、PASSWORD、SELECT、NUMBER、SWITCH、TEXTAREA、CUSTOM_SELECT 和 DRIVER；
-     * DRIVER 由前端标准驱动管理组件负责渲染，不应再通过特定字段 key 触发。
+     * <p>支持 INPUT、PASSWORD、SELECT、NUMBER、SWITCH、TEXTAREA、CUSTOM_SELECT、DRIVER 和 SSH；
+     * DRIVER 与 SSH 均由前端标准组件负责渲染，不应再通过特定字段 key 触发。
      */
     private String type;
 

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-doris/src/main/java/io/yak/ops/plugin/database/doris/DorisDataSourcePlugin.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-doris/src/main/java/io/yak/ops/plugin/database/doris/DorisDataSourcePlugin.java
@@ -62,7 +62,7 @@ public final class DorisDataSourcePlugin extends AbstractJdbcDataSourcePlugin {
   protected DataSourceCatalog createJdbcCatalog(
       JdbcConnectionProperties connection,
       int timeoutSeconds) {
-    return new DorisJdbcCatalog(connection, timeoutSeconds);
+    return new DorisJdbcCatalog(connection, timeoutSeconds, this::openJdbcConnection);
   }
 
   @Override

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-doris/src/main/java/io/yak/ops/plugin/database/doris/DorisJdbcCatalog.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-doris/src/main/java/io/yak/ops/plugin/database/doris/DorisJdbcCatalog.java
@@ -2,6 +2,7 @@ package io.yak.ops.plugin.database.doris;
 
 import io.yak.ops.plugin.database.jdbc.GenericJdbcCatalog;
 import io.yak.ops.plugin.database.jdbc.JdbcConnectionProperties;
+import io.yak.ops.plugin.database.jdbc.JdbcConnectionProvider;
 import io.yak.ops.spi.datasource.catalog.DataSourceCatalogQuery;
 import io.yak.ops.spi.datasource.metadata.DataSourceTable;
 import java.sql.Connection;
@@ -14,8 +15,23 @@ import java.util.List;
 /** Doris 专用 Catalog，实现 SHOW DATABASES / SHOW FULL TABLES 元数据发现。 */
 public final class DorisJdbcCatalog extends GenericJdbcCatalog {
 
-  public DorisJdbcCatalog(JdbcConnectionProperties connection, int timeoutSeconds) {
+  private final JdbcConnectionProperties connection;
+  private final int timeoutSeconds;
+  private final JdbcConnectionProvider connectionProvider;
+
+  public DorisJdbcCatalog(
+      JdbcConnectionProperties connection,
+      int timeoutSeconds,
+      JdbcConnectionProvider connectionProvider) {
     super(connection, timeoutSeconds);
+    this.connection = connection;
+    this.timeoutSeconds = Math.max(1, timeoutSeconds);
+    this.connectionProvider = connectionProvider;
+  }
+
+  @Override
+  protected Connection openConnection() throws Exception {
+    return connectionProvider.open(connection, timeoutSeconds);
   }
 
   @Override

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/pom.xml
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/pom.xml
@@ -26,6 +26,11 @@
             <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.github.mwiede</groupId>
+            <artifactId>jsch</artifactId>
+            <version>2.28.6</version>
+        </dependency>
+        <dependency>
             <groupId>com.mysql</groupId>
             <artifactId>mysql-connector-j</artifactId>
             <scope>runtime</scope>

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/AbstractJdbcDataSourcePlugin.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/AbstractJdbcDataSourcePlugin.java
@@ -21,10 +21,11 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
 
-/** JDBC 数据源插件基座，统一负责参数解析、表单配置、连接测试和 SQL 执行。 */
+/** JDBC 数据源插件基座，统一负责参数解析、表单配置、连接测试、SSH 隧道和 SQL 执行。 */
 public abstract class AbstractJdbcDataSourcePlugin implements DataSourcePlugin {
 
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
@@ -89,6 +90,16 @@ public abstract class AbstractJdbcDataSourcePlugin implements DataSourcePlugin {
             null,
             Collections.emptyList()));
 
+    List<FormFieldVO> sshFields = new ArrayList<>();
+    sshFields.add(
+        field(
+            "sshTunnel",
+            "SSH 隧道",
+            "SSH",
+            null,
+            sshDefaultValue(),
+            Collections.emptyList()));
+
     List<FormFieldVO> driverFields = new ArrayList<>();
     driverFields.add(
         field(
@@ -121,6 +132,14 @@ public abstract class AbstractJdbcDataSourcePlugin implements DataSourcePlugin {
             connectionFields));
     sections.add(
         section(
+            "ssh",
+            "SSH 隧道",
+            "数据库无法直接访问时，可通过堡垒机或跳板机建立本地端口转发。",
+            true,
+            false,
+            sshFields));
+    sections.add(
+        section(
             "driver",
             "驱动配置",
             "查看或调整当前数据源使用的 JDBC Driver Class。",
@@ -138,7 +157,7 @@ public abstract class AbstractJdbcDataSourcePlugin implements DataSourcePlugin {
               advancedFields));
     }
 
-    // 同时保留 formFields，兼容尚未升级到 sections 协议的前端版本。
+    // 旧版 formFields 不下发 SSH 对象字段，避免旧前端把复合配置误渲染为普通 Input。
     List<FormFieldVO> fields = new ArrayList<>();
     fields.addAll(connectionFields);
     fields.addAll(driverFields);
@@ -172,9 +191,15 @@ public abstract class AbstractJdbcDataSourcePlugin implements DataSourcePlugin {
           defaultIfBlank(
               firstText(root, "driverClassName", "driver"),
               defaultDriverClassName());
+      SshTunnelConfig sshTunnel = parseSshTunnel(root);
 
       if (isBlank(username)) {
         throw parameterError("username 不能为空", null);
+      }
+      if (sshTunnel.enabled() && !isBlank(explicitUrl)) {
+        throw parameterError(
+            "启用 SSH 隧道时请使用 host、port、database 参数，不支持自定义 JDBC 地址",
+            null);
       }
 
       String jdbcUrl = explicitUrl;
@@ -212,10 +237,13 @@ public abstract class AbstractJdbcDataSourcePlugin implements DataSourcePlugin {
       normalized.put("driverClassName", driver);
       ObjectNode propertiesNode = normalized.putObject("properties");
       properties.forEach(propertiesNode::put);
+      writeSshTunnel(normalized, sshTunnel);
       appendNormalizedFields(root, normalized);
 
       return new JdbcConnectionProperties(
           dbType(),
+          trimToNull(host),
+          port,
           jdbcUrl,
           driver,
           username.trim(),
@@ -223,6 +251,7 @@ public abstract class AbstractJdbcDataSourcePlugin implements DataSourcePlugin {
           trimToNull(database),
           trimToNull(schema),
           properties,
+          sshTunnel,
           OBJECT_MAPPER.writeValueAsString(normalized));
     } catch (DataSourcePluginException exception) {
       throw exception;
@@ -234,16 +263,9 @@ public abstract class AbstractJdbcDataSourcePlugin implements DataSourcePlugin {
   @Override
   public void testConnection(DataSourceConnection connection, int timeoutSeconds) {
     JdbcConnectionProperties jdbcConnection = requireJdbcConnection(connection);
-    try {
-      Class.forName(jdbcConnection.driverClassName());
-      DriverManager.setLoginTimeout(Math.max(1, timeoutSeconds));
-      try (Connection opened =
-          DriverManager.getConnection(
-              jdbcConnection.jdbcUrl(),
-              connectionProperties(jdbcConnection))) {
-        if (opened == null || opened.isClosed()) {
-          throw new DataSourcePluginException(Operation.CONNECTIVITY, "数据库连接不可用");
-        }
+    try (Connection opened = openJdbcConnection(jdbcConnection, timeoutSeconds)) {
+      if (opened == null || opened.isClosed()) {
+        throw new DataSourcePluginException(Operation.CONNECTIVITY, "数据库连接不可用");
       }
     } catch (DataSourcePluginException exception) {
       throw exception;
@@ -271,13 +293,59 @@ public abstract class AbstractJdbcDataSourcePlugin implements DataSourcePlugin {
       int connectionTimeoutSeconds) {
     return new JdbcDataSourceSqlExecutor(
         requireJdbcConnection(connection),
-        Math.max(1, connectionTimeoutSeconds));
+        Math.max(1, connectionTimeoutSeconds),
+        this::openJdbcConnection);
   }
 
   protected DataSourceCatalog createJdbcCatalog(
       JdbcConnectionProperties connection,
       int timeoutSeconds) {
-    return new GenericJdbcCatalog(connection, timeoutSeconds);
+    return new GenericJdbcCatalog(connection, timeoutSeconds) {
+      @Override
+      protected Connection openConnection() throws Exception {
+        return openJdbcConnection(connection, timeoutSeconds);
+      }
+    };
+  }
+
+  protected Connection openJdbcConnection(
+      JdbcConnectionProperties connection,
+      int timeoutSeconds)
+      throws Exception {
+    Class.forName(connection.driverClassName());
+    int safeTimeout = Math.max(1, timeoutSeconds);
+    DriverManager.setLoginTimeout(safeTimeout);
+
+    SshTunnelConfig sshTunnel = connection.sshTunnel();
+    if (!sshTunnel.enabled()) {
+      return DriverManager.getConnection(
+          connection.jdbcUrl(),
+          connectionProperties(connection));
+    }
+
+    SshTunnel tunnel =
+        SshTunnel.open(
+            sshTunnel,
+            connection.host(),
+            connection.port(),
+            safeTimeout);
+    try {
+      JsonNode normalized = OBJECT_MAPPER.readTree(connection.normalizedJson());
+      String tunneledJdbcUrl =
+          buildJdbcUrl(
+              "127.0.0.1",
+              tunnel.localPort(),
+              connection.database(),
+              normalized);
+      Connection opened =
+          DriverManager.getConnection(
+              tunneledJdbcUrl,
+              connectionProperties(connection));
+      return SshTunneledConnection.wrap(opened, tunnel);
+    } catch (Exception exception) {
+      tunnel.close();
+      throw exception;
+    }
   }
 
   protected abstract int defaultPort();
@@ -392,6 +460,103 @@ public abstract class AbstractJdbcDataSourcePlugin implements DataSourcePlugin {
         RuleVO.builder().required(true).min(min).max(max).message(message).build());
   }
 
+  private Map<String, Object> sshDefaultValue() {
+    Map<String, Object> defaults = new LinkedHashMap<>();
+    defaults.put("enabled", false);
+    defaults.put("port", 22);
+    defaults.put("authType", SshTunnelConfig.AuthType.PASSWORD.name());
+    defaults.put("strictHostKeyChecking", false);
+    return defaults;
+  }
+
+  private SshTunnelConfig parseSshTunnel(JsonNode root) {
+    JsonNode node = root.get("sshTunnel");
+    if (node == null || node.isNull()) {
+      node = root.get("ssh");
+    }
+    if (node == null || node.isNull()) {
+      return SshTunnelConfig.disabled();
+    }
+    if (!node.isObject()) {
+      throw parameterError("sshTunnel 必须是 JSON 对象", null);
+    }
+
+    boolean enabled = booleanValue(node, false, "enabled");
+    if (!enabled) {
+      return SshTunnelConfig.disabled();
+    }
+
+    String host = trimToNull(firstText(node, "host", "sshHost"));
+    int port = intValue(node, 22, "port");
+    String username = trimToNull(firstText(node, "username", "user"));
+    String authValue =
+        defaultIfBlank(firstText(node, "authType", "authenticationType"), "PASSWORD")
+            .toUpperCase(Locale.ROOT);
+    SshTunnelConfig.AuthType authType;
+    try {
+      authType = SshTunnelConfig.AuthType.valueOf(authValue);
+    } catch (IllegalArgumentException exception) {
+      throw parameterError("SSH 认证方式仅支持 PASSWORD 或 PRIVATE_KEY", exception);
+    }
+
+    String sshPassword = firstText(node, "password");
+    String privateKey = firstText(node, "privateKey", "privateKeyContent");
+    String passphrase = firstText(node, "passphrase", "privateKeyPassphrase");
+    boolean strictHostKeyChecking =
+        booleanValue(node, false, "strictHostKeyChecking");
+    String knownHosts = firstText(node, "knownHosts", "knownHostsContent");
+
+    if (isBlank(host)) {
+      throw parameterError("SSH host 不能为空", null);
+    }
+    if (isBlank(username)) {
+      throw parameterError("SSH username 不能为空", null);
+    }
+    if (authType == SshTunnelConfig.AuthType.PASSWORD && isBlank(sshPassword)) {
+      throw parameterError("SSH password 不能为空", null);
+    }
+    if (authType == SshTunnelConfig.AuthType.PRIVATE_KEY && isBlank(privateKey)) {
+      throw parameterError("SSH privateKey 不能为空", null);
+    }
+    if (strictHostKeyChecking && isBlank(knownHosts)) {
+      throw parameterError("开启 SSH 严格主机校验后 knownHosts 不能为空", null);
+    }
+
+    return new SshTunnelConfig(
+        true,
+        host,
+        port,
+        username,
+        authType,
+        sshPassword,
+        privateKey,
+        passphrase,
+        strictHostKeyChecking,
+        knownHosts);
+  }
+
+  private void writeSshTunnel(ObjectNode normalized, SshTunnelConfig config) {
+    ObjectNode node = normalized.putObject("sshTunnel");
+    node.put("enabled", config.enabled());
+    node.put("port", config.port());
+    node.put("authType", config.authType().name());
+    node.put("strictHostKeyChecking", config.strictHostKeyChecking());
+    if (!config.enabled()) return;
+
+    putIfText(node, "host", config.host());
+    putIfText(node, "username", config.username());
+    if (config.password() != null) {
+      node.put("password", config.password());
+    }
+    if (config.privateKey() != null) {
+      node.put("privateKey", config.privateKey());
+    }
+    if (config.passphrase() != null) {
+      node.put("passphrase", config.passphrase());
+    }
+    putIfText(node, "knownHosts", config.knownHosts());
+  }
+
   private void validateDeclaredType(JsonNode root) {
     String declaredType = firstText(root, "dbType", "type", "pluginType");
     if (isBlank(declaredType)) {
@@ -441,9 +606,20 @@ public abstract class AbstractJdbcDataSourcePlugin implements DataSourcePlugin {
     }
     int port = value.asInt(-1);
     if (port < 1 || port > 65535) {
-      throw parameterError("port 必须在 1 到 65535 之间", null);
+      throw parameterError(key + " 必须在 1 到 65535 之间", null);
     }
     return port;
+  }
+
+  private boolean booleanValue(JsonNode root, boolean defaultValue, String key) {
+    JsonNode value = root.get(key);
+    if (value == null || value.isNull() || isBlank(value.asText())) {
+      return defaultValue;
+    }
+    if (value.isBoolean()) {
+      return value.asBoolean();
+    }
+    return Boolean.parseBoolean(value.asText());
   }
 
   private String firstText(JsonNode node, String... keys) {

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/JdbcConnectionProperties.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/JdbcConnectionProperties.java
@@ -10,6 +10,8 @@ import java.util.Map;
 public final class JdbcConnectionProperties implements DataSourceConnection {
 
   private final DataSourceDbType dbType;
+  private final String host;
+  private final int port;
   private final String jdbcUrl;
   private final String driverClassName;
   private final String username;
@@ -17,8 +19,10 @@ public final class JdbcConnectionProperties implements DataSourceConnection {
   private final String database;
   private final String schema;
   private final Map<String, String> properties;
+  private final SshTunnelConfig sshTunnel;
   private final String normalizedJson;
 
+  /** 保留原构造器，兼容现有插件或测试代码的直接构造。 */
   public JdbcConnectionProperties(
       DataSourceDbType dbType,
       String jdbcUrl,
@@ -29,7 +33,37 @@ public final class JdbcConnectionProperties implements DataSourceConnection {
       String schema,
       Map<String, String> properties,
       String normalizedJson) {
+    this(
+        dbType,
+        null,
+        0,
+        jdbcUrl,
+        driverClassName,
+        username,
+        password,
+        database,
+        schema,
+        properties,
+        SshTunnelConfig.disabled(),
+        normalizedJson);
+  }
+
+  public JdbcConnectionProperties(
+      DataSourceDbType dbType,
+      String host,
+      int port,
+      String jdbcUrl,
+      String driverClassName,
+      String username,
+      String password,
+      String database,
+      String schema,
+      Map<String, String> properties,
+      SshTunnelConfig sshTunnel,
+      String normalizedJson) {
     this.dbType = dbType;
+    this.host = host;
+    this.port = port;
     this.jdbcUrl = jdbcUrl;
     this.driverClassName = driverClassName;
     this.username = username;
@@ -37,12 +71,21 @@ public final class JdbcConnectionProperties implements DataSourceConnection {
     this.database = database;
     this.schema = schema;
     this.properties = Collections.unmodifiableMap(new LinkedHashMap<>(properties));
+    this.sshTunnel = sshTunnel == null ? SshTunnelConfig.disabled() : sshTunnel;
     this.normalizedJson = normalizedJson;
   }
 
   @Override
   public DataSourceDbType dbType() {
     return dbType;
+  }
+
+  public String host() {
+    return host;
+  }
+
+  public int port() {
+    return port;
   }
 
   @Override
@@ -78,6 +121,10 @@ public final class JdbcConnectionProperties implements DataSourceConnection {
   @Override
   public Map<String, String> properties() {
     return properties;
+  }
+
+  public SshTunnelConfig sshTunnel() {
+    return sshTunnel;
   }
 
   @Override

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/JdbcConnectionProvider.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/JdbcConnectionProvider.java
@@ -1,0 +1,10 @@
+package io.yak.ops.plugin.database.jdbc;
+
+import java.sql.Connection;
+
+/** JDBC Catalog / SQL Executor 共用的连接创建入口。 */
+@FunctionalInterface
+public interface JdbcConnectionProvider {
+
+  Connection open(JdbcConnectionProperties connection, int timeoutSeconds) throws Exception;
+}

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/JdbcDataSourceSqlExecutor.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/JdbcDataSourceSqlExecutor.java
@@ -30,6 +30,7 @@ public final class JdbcDataSourceSqlExecutor implements DataSourceSqlExecutor {
 
   private final JdbcConnectionProperties connection;
   private final int connectionTimeoutSeconds;
+  private final JdbcConnectionProvider connectionProvider;
   private final AtomicBoolean cancelled = new AtomicBoolean(false);
   private final AtomicReference<Connection> activeConnection = new AtomicReference<>();
   private final AtomicReference<Statement> activeStatement = new AtomicReference<>();
@@ -37,8 +38,16 @@ public final class JdbcDataSourceSqlExecutor implements DataSourceSqlExecutor {
   public JdbcDataSourceSqlExecutor(
       JdbcConnectionProperties connection,
       int connectionTimeoutSeconds) {
+    this(connection, connectionTimeoutSeconds, JdbcDataSourceSqlExecutor::openDirectConnection);
+  }
+
+  public JdbcDataSourceSqlExecutor(
+      JdbcConnectionProperties connection,
+      int connectionTimeoutSeconds,
+      JdbcConnectionProvider connectionProvider) {
     this.connection = connection;
     this.connectionTimeoutSeconds = Math.max(1, connectionTimeoutSeconds);
+    this.connectionProvider = connectionProvider;
   }
 
   @Override
@@ -48,10 +57,8 @@ public final class JdbcDataSourceSqlExecutor implements DataSourceSqlExecutor {
     }
 
     try {
-      Class.forName(connection.driverClassName());
-      DriverManager.setLoginTimeout(connectionTimeoutSeconds);
       try (Connection opened =
-          DriverManager.getConnection(connection.jdbcUrl(), connectionProperties())) {
+          connectionProvider.open(connection, connectionTimeoutSeconds)) {
         activeConnection.set(opened);
         if (cancelled.get()) {
           throw executionError("SQL 执行已取消", null);
@@ -105,7 +112,7 @@ public final class JdbcDataSourceSqlExecutor implements DataSourceSqlExecutor {
       try {
         opened.close();
       } catch (Exception ignored) {
-        // Best effort cancellation.
+        // Best effort cancellation. SSH tunnel is also released by Connection.close().
       }
     }
   }
@@ -197,7 +204,16 @@ public final class JdbcDataSourceSqlExecutor implements DataSourceSqlExecutor {
     return value.substring(0, MAX_TEXT_CHARS) + "…";
   }
 
-  private Properties connectionProperties() {
+  private static Connection openDirectConnection(
+      JdbcConnectionProperties connection,
+      int timeoutSeconds)
+      throws Exception {
+    Class.forName(connection.driverClassName());
+    DriverManager.setLoginTimeout(Math.max(1, timeoutSeconds));
+    return DriverManager.getConnection(connection.jdbcUrl(), connectionProperties(connection));
+  }
+
+  private static Properties connectionProperties(JdbcConnectionProperties connection) {
     Properties properties = new Properties();
     properties.putAll(connection.properties());
     if (connection.username() != null && !connection.username().isBlank()) {

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/SshTunnel.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/SshTunnel.java
@@ -1,0 +1,84 @@
+package io.yak.ops.plugin.database.jdbc;
+
+import com.jcraft.jsch.JSch;
+import com.jcraft.jsch.JSchException;
+import com.jcraft.jsch.Session;
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+
+/** 单次 JDBC 连接使用的 SSH 本地端口转发，会随 JDBC Connection 一起释放。 */
+final class SshTunnel implements AutoCloseable {
+
+  private final Session session;
+  private final int localPort;
+
+  private SshTunnel(Session session, int localPort) {
+    this.session = session;
+    this.localPort = localPort;
+  }
+
+  static SshTunnel open(
+      SshTunnelConfig config,
+      String targetHost,
+      int targetPort,
+      int timeoutSeconds)
+      throws JSchException {
+    JSch jsch = new JSch();
+    configureHostKeys(jsch, config);
+    configureIdentity(jsch, config);
+
+    Session session = jsch.getSession(config.username(), config.host(), config.port());
+    if (config.authType() == SshTunnelConfig.AuthType.PASSWORD) {
+      session.setPassword(config.password().getBytes(StandardCharsets.UTF_8));
+      session.setConfig("PreferredAuthentications", "password,keyboard-interactive");
+    } else {
+      session.setConfig("PreferredAuthentications", "publickey");
+    }
+    session.setConfig(
+        "StrictHostKeyChecking",
+        config.strictHostKeyChecking() ? "yes" : "no");
+
+    int timeoutMillis = Math.max(1, timeoutSeconds) * 1000;
+    try {
+      session.connect(timeoutMillis);
+      int localPort =
+          session.setPortForwardingL("127.0.0.1", 0, targetHost, targetPort);
+      return new SshTunnel(session, localPort);
+    } catch (JSchException exception) {
+      session.disconnect();
+      throw exception;
+    }
+  }
+
+  int localPort() {
+    return localPort;
+  }
+
+  @Override
+  public void close() {
+    if (session.isConnected()) {
+      session.disconnect();
+    }
+  }
+
+  private static void configureHostKeys(JSch jsch, SshTunnelConfig config)
+      throws JSchException {
+    if (!config.strictHostKeyChecking()) return;
+    jsch.setKnownHosts(
+        new ByteArrayInputStream(config.knownHosts().getBytes(StandardCharsets.UTF_8)));
+  }
+
+  private static void configureIdentity(JSch jsch, SshTunnelConfig config)
+      throws JSchException {
+    if (config.authType() != SshTunnelConfig.AuthType.PRIVATE_KEY) return;
+    byte[] passphrase =
+        config.passphrase() == null || config.passphrase().isEmpty()
+            ? null
+            : config.passphrase().getBytes(StandardCharsets.UTF_8);
+    jsch.addIdentity(
+        "yak-ops-datasource",
+        config.privateKey().getBytes(StandardCharsets.UTF_8),
+        null,
+        passphrase);
+  }
+}

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/SshTunnelConfig.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/SshTunnelConfig.java
@@ -1,0 +1,34 @@
+package io.yak.ops.plugin.database.jdbc;
+
+/** JDBC 数据源可选的 SSH 隧道配置。 */
+public record SshTunnelConfig(
+    boolean enabled,
+    String host,
+    int port,
+    String username,
+    AuthType authType,
+    String password,
+    String privateKey,
+    String passphrase,
+    boolean strictHostKeyChecking,
+    String knownHosts) {
+
+  public enum AuthType {
+    PASSWORD,
+    PRIVATE_KEY
+  }
+
+  public static SshTunnelConfig disabled() {
+    return new SshTunnelConfig(
+        false,
+        null,
+        22,
+        null,
+        AuthType.PASSWORD,
+        null,
+        null,
+        null,
+        false,
+        null);
+  }
+}

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/SshTunneledConnection.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/SshTunneledConnection.java
@@ -1,0 +1,48 @@
+package io.yak.ops.plugin.database.jdbc;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/** 将 SSH Session 生命周期绑定到 JDBC Connection.close()。 */
+final class SshTunneledConnection {
+
+  private SshTunneledConnection() {
+  }
+
+  static Connection wrap(Connection delegate, SshTunnel tunnel) {
+    AtomicBoolean closed = new AtomicBoolean(false);
+    return (Connection)
+        Proxy.newProxyInstance(
+            SshTunneledConnection.class.getClassLoader(),
+            new Class<?>[] {Connection.class},
+            (proxy, method, args) -> invoke(delegate, tunnel, closed, method, args));
+  }
+
+  private static Object invoke(
+      Connection delegate,
+      SshTunnel tunnel,
+      AtomicBoolean closed,
+      Method method,
+      Object[] args)
+      throws Throwable {
+    if ("close".equals(method.getName()) && method.getParameterCount() == 0) {
+      if (closed.compareAndSet(false, true)) {
+        try {
+          delegate.close();
+        } finally {
+          tunnel.close();
+        }
+      }
+      return null;
+    }
+
+    try {
+      return method.invoke(delegate, args);
+    } catch (InvocationTargetException exception) {
+      throw exception.getCause();
+    }
+  }
+}

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/test/java/io/yak/ops/plugin/database/jdbc/mysql/MySqlDataSourcePluginTest.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/test/java/io/yak/ops/plugin/database/jdbc/mysql/MySqlDataSourcePluginTest.java
@@ -1,10 +1,14 @@
 package io.yak.ops.plugin.database.jdbc.mysql;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.yak.ops.common.bean.vo.datasource.DataSourcePluginConfigVO;
 import io.yak.ops.common.bean.vo.datasource.DataSourcePluginConfigVO.FormSectionVO;
+import io.yak.ops.plugin.database.jdbc.JdbcConnectionProperties;
+import io.yak.ops.plugin.database.jdbc.SshTunnelConfig;
 import io.yak.ops.spi.datasource.DataSourceConnection;
+import io.yak.ops.spi.datasource.DataSourcePluginException;
 import org.junit.jupiter.api.Test;
 
 class MySqlDataSourcePluginTest {
@@ -30,13 +34,59 @@ class MySqlDataSourcePluginTest {
 
     assertThat(config.getSections())
         .extracting(FormSectionVO::getKey)
-        .containsExactly("connection", "driver", "advanced");
+        .containsExactly("connection", "ssh", "driver", "advanced");
     assertThat(config.getSections().get(0).getCollapsible()).isFalse();
     assertThat(config.getSections().get(1).getCollapsible()).isTrue();
-    assertThat(config.getSections().get(1).getDefaultExpanded()).isTrue();
-    assertThat(config.getSections().get(2).getDefaultExpanded()).isFalse();
+    assertThat(config.getSections().get(1).getDefaultExpanded()).isFalse();
+    assertThat(config.getSections().get(1).getFields())
+        .singleElement()
+        .satisfies(
+            field -> {
+              assertThat(field.getKey()).isEqualTo("sshTunnel");
+              assertThat(field.getType()).isEqualTo("SSH");
+            });
+    assertThat(config.getSections().get(2).getDefaultExpanded()).isTrue();
+    assertThat(config.getSections().get(3).getDefaultExpanded()).isFalse();
 
-    // 旧版前端仍可继续消费扁平 formFields。
+    // 旧版前端仍可继续消费扁平 formFields，SSH 复合字段只通过新版 sections 下发。
     assertThat(config.getFormFields()).hasSize(9);
+  }
+
+  @Test
+  void shouldParseStandardSshTunnelConfig() {
+    JdbcConnectionProperties connection =
+        (JdbcConnectionProperties)
+            new MySqlDataSourcePlugin()
+                .parseConnection(
+                    "{\"dbType\":\"MYSQL\",\"host\":\"db.internal\","
+                        + "\"port\":3306,\"database\":\"demo\",\"username\":\"root\","
+                        + "\"sshTunnel\":{\"enabled\":true,\"host\":\"bastion.example.com\","
+                        + "\"port\":22,\"username\":\"ops\",\"authType\":\"PASSWORD\","
+                        + "\"password\":\"secret\"}}}");
+
+    assertThat(connection.host()).isEqualTo("db.internal");
+    assertThat(connection.port()).isEqualTo(3306);
+    assertThat(connection.sshTunnel().enabled()).isTrue();
+    assertThat(connection.sshTunnel().host()).isEqualTo("bastion.example.com");
+    assertThat(connection.sshTunnel().port()).isEqualTo(22);
+    assertThat(connection.sshTunnel().username()).isEqualTo("ops");
+    assertThat(connection.sshTunnel().authType())
+        .isEqualTo(SshTunnelConfig.AuthType.PASSWORD);
+    assertThat(connection.normalizedJson()).contains("\"sshTunnel\"");
+  }
+
+  @Test
+  void shouldRejectCustomJdbcUrlWhenSshTunnelIsEnabled() {
+    assertThatThrownBy(
+            () ->
+                new MySqlDataSourcePlugin()
+                    .parseConnection(
+                        "{\"dbType\":\"MYSQL\",\"host\":\"db.internal\","
+                            + "\"database\":\"demo\",\"username\":\"root\","
+                            + "\"jdbcUrl\":\"jdbc:mysql://db.internal:3306/demo\","
+                            + "\"sshTunnel\":{\"enabled\":true,\"host\":\"bastion.example.com\","
+                            + "\"username\":\"ops\",\"password\":\"secret\"}}}"))
+        .isInstanceOf(DataSourcePluginException.class)
+        .hasMessageContaining("启用 SSH 隧道时");
   }
 }

--- a/yak-ops-ui/src/pages/data-source/components/DynamicDataSourceForm/index.tsx
+++ b/yak-ops-ui/src/pages/data-source/components/DynamicDataSourceForm/index.tsx
@@ -27,6 +27,9 @@ import type {
 } from '../../types';
 import { DataSourceOperateType } from '../../types';
 import DriverManager from '../DriverManager';
+import SshTunnelManager, {
+  getSshTunnelValidationMessage,
+} from '../SshTunnelManager';
 import CustomKVList from './components/CustomKVList';
 import {
   flattenFormSectionFields,
@@ -231,6 +234,8 @@ const DynamicDataSourceForm = ({
     switch (field.type) {
       case 'DRIVER':
         return <DriverManager dbType={dbType} placeholder={field.placeholder} />;
+      case 'SSH':
+        return <SshTunnelManager />;
       case 'PASSWORD':
         return (
           <Input.Password
@@ -279,6 +284,19 @@ const DynamicDataSourceForm = ({
     }
   };
 
+  const fieldRules = (field: DynamicFormField) => {
+    const rules = transformRules(field.rules, field.type);
+    if (field.type === 'SSH') {
+      rules.push({
+        validator: async (_rule, value) => {
+          const validationMessage = getSshTunnelValidationMessage(value);
+          if (validationMessage) throw new Error(validationMessage);
+        },
+      });
+    }
+    return rules;
+  };
+
   const renderFields = (fields: DynamicFormField[]) => (
     <div className="grid grid-cols-1 gap-x-4 md:grid-cols-2">
       {fields.map((field) => {
@@ -290,14 +308,17 @@ const DynamicDataSourceForm = ({
           );
         }
 
-        const fullWidth = field.type === 'TEXTAREA' || field.type === 'DRIVER';
+        const fullWidth =
+          field.type === 'TEXTAREA' ||
+          field.type === 'DRIVER' ||
+          field.type === 'SSH';
         return (
           <Form.Item
             key={field.key}
             label={field.label}
             name={field.key}
             valuePropName={field.type === 'SWITCH' ? 'checked' : 'value'}
-            rules={transformRules(field.rules, field.type)}
+            rules={fieldRules(field)}
             validateTrigger={['onChange', 'onBlur']}
             className={['!mb-3', fullWidth ? 'md:col-span-2' : '']
               .filter(Boolean)

--- a/yak-ops-ui/src/pages/data-source/components/SshTunnelManager/index.tsx
+++ b/yak-ops-ui/src/pages/data-source/components/SshTunnelManager/index.tsx
@@ -1,0 +1,246 @@
+import { Input, InputNumber, Select, Switch } from 'antd';
+import { KeyRound, Network, ShieldCheck } from 'lucide-react';
+
+import type { SshTunnelConfigValue } from '../../types';
+
+const DEFAULT_VALUE: SshTunnelConfigValue = {
+  enabled: false,
+  host: '',
+  port: 22,
+  username: '',
+  authType: 'PASSWORD',
+  password: '',
+  privateKey: '',
+  passphrase: '',
+  strictHostKeyChecking: false,
+  knownHosts: '',
+};
+
+export interface SshTunnelManagerProps {
+  value?: SshTunnelConfigValue;
+  onChange?: (value: SshTunnelConfigValue) => void;
+  disabled?: boolean;
+}
+
+export const getSshTunnelValidationMessage = (
+  value?: SshTunnelConfigValue,
+): string | undefined => {
+  if (!value?.enabled) return undefined;
+  if (!value.host?.trim()) return '请输入 SSH 主机地址';
+  if (!value.port || value.port < 1 || value.port > 65535) {
+    return 'SSH 端口必须在 1 到 65535 之间';
+  }
+  if (!value.username?.trim()) return '请输入 SSH 用户名';
+
+  const authType = value.authType || 'PASSWORD';
+  if (authType === 'PASSWORD' && !value.password) {
+    return '请输入 SSH 密码';
+  }
+  if (authType === 'PRIVATE_KEY' && !value.privateKey?.trim()) {
+    return '请输入 SSH 私钥';
+  }
+  if (value.strictHostKeyChecking && !value.knownHosts?.trim()) {
+    return '开启严格主机校验后，请提供 known_hosts 内容';
+  }
+  return undefined;
+};
+
+/**
+ * 标准 SSH 隧道配置组件。
+ *
+ * 仅通过 value/onChange 与表单交互，不依赖 FormInstance 或特定字段 key，
+ * 可以被动态 Schema、普通表单及后续独立连接配置复用。
+ */
+const SshTunnelManager = ({
+  value,
+  onChange,
+  disabled = false,
+}: SshTunnelManagerProps) => {
+  const current: SshTunnelConfigValue = {
+    ...DEFAULT_VALUE,
+    ...(value || {}),
+  };
+
+  const patch = (next: Partial<SshTunnelConfigValue>) => {
+    onChange?.({
+      ...current,
+      ...next,
+    });
+  };
+
+  return (
+    <div className="overflow-hidden rounded-lg border border-[#e8eaed] bg-white">
+      <div className="flex items-center justify-between gap-4 px-3.5 py-3">
+        <div className="flex min-w-0 items-center gap-2.5">
+          <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-[#f5f6f7] text-[#667085]">
+            <Network size={15} />
+          </span>
+          <div className="min-w-0">
+            <div className="text-[13px] font-medium leading-5 text-[#344054]">
+              启用 SSH 隧道
+            </div>
+            <div className="text-[11px] leading-4 text-[#98a2b3]">
+              通过堡垒机或跳板机访问目标数据库
+            </div>
+          </div>
+        </div>
+        <Switch
+          size="small"
+          checked={current.enabled}
+          disabled={disabled}
+          onChange={(enabled) => patch({ enabled })}
+        />
+      </div>
+
+      {current.enabled && (
+        <div className="border-t border-[#eef0f3] bg-[#fcfcfd] px-3.5 py-3.5">
+          <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+            <div>
+              <div className="mb-1.5 text-xs font-medium text-[#475467]">
+                SSH 主机
+              </div>
+              <Input
+                variant="filled"
+                value={current.host}
+                disabled={disabled}
+                placeholder="例如 bastion.example.com"
+                onChange={(event) => patch({ host: event.target.value })}
+              />
+            </div>
+
+            <div>
+              <div className="mb-1.5 text-xs font-medium text-[#475467]">
+                SSH 端口
+              </div>
+              <InputNumber
+                variant="filled"
+                className="!w-full"
+                min={1}
+                max={65535}
+                value={current.port}
+                disabled={disabled}
+                placeholder="22"
+                onChange={(port) => patch({ port: port ?? 22 })}
+              />
+            </div>
+
+            <div>
+              <div className="mb-1.5 text-xs font-medium text-[#475467]">
+                SSH 用户名
+              </div>
+              <Input
+                variant="filled"
+                value={current.username}
+                disabled={disabled}
+                placeholder="请输入 SSH 用户名"
+                onChange={(event) => patch({ username: event.target.value })}
+              />
+            </div>
+
+            <div>
+              <div className="mb-1.5 text-xs font-medium text-[#475467]">
+                认证方式
+              </div>
+              <Select
+                variant="filled"
+                className="w-full"
+                value={current.authType}
+                disabled={disabled}
+                options={[
+                  { label: '密码认证', value: 'PASSWORD' },
+                  { label: '私钥认证', value: 'PRIVATE_KEY' },
+                ]}
+                onChange={(authType) => patch({ authType })}
+              />
+            </div>
+          </div>
+
+          {current.authType === 'PRIVATE_KEY' ? (
+            <div className="mt-3 grid grid-cols-1 gap-3">
+              <div>
+                <div className="mb-1.5 flex items-center gap-1.5 text-xs font-medium text-[#475467]">
+                  <KeyRound size={13} />
+                  SSH 私钥
+                </div>
+                <Input.TextArea
+                  variant="filled"
+                  rows={4}
+                  value={current.privateKey}
+                  disabled={disabled}
+                  placeholder="粘贴 OpenSSH / PEM 私钥内容"
+                  className="font-mono text-xs"
+                  onChange={(event) => patch({ privateKey: event.target.value })}
+                />
+              </div>
+              <div>
+                <div className="mb-1.5 text-xs font-medium text-[#475467]">
+                  私钥口令
+                </div>
+                <Input.Password
+                  variant="filled"
+                  value={current.passphrase}
+                  disabled={disabled}
+                  placeholder="私钥未加密时可留空"
+                  onChange={(event) => patch({ passphrase: event.target.value })}
+                />
+              </div>
+            </div>
+          ) : (
+            <div className="mt-3">
+              <div className="mb-1.5 text-xs font-medium text-[#475467]">
+                SSH 密码
+              </div>
+              <Input.Password
+                variant="filled"
+                value={current.password}
+                disabled={disabled}
+                placeholder="请输入 SSH 密码"
+                onChange={(event) => patch({ password: event.target.value })}
+              />
+            </div>
+          )}
+
+          <div className="mt-3 rounded-md border border-[#eaecf0] bg-white px-3 py-2.5">
+            <div className="flex items-center justify-between gap-3">
+              <div className="flex items-center gap-2">
+                <ShieldCheck size={14} className="text-[#667085]" />
+                <div>
+                  <div className="text-xs font-medium text-[#475467]">
+                    严格主机校验
+                  </div>
+                  <div className="text-[11px] leading-4 text-[#98a2b3]">
+                    开启后仅信任提供的 known_hosts 主机密钥
+                  </div>
+                </div>
+              </div>
+              <Switch
+                size="small"
+                checked={current.strictHostKeyChecking}
+                disabled={disabled}
+                onChange={(strictHostKeyChecking) =>
+                  patch({ strictHostKeyChecking })
+                }
+              />
+            </div>
+
+            {current.strictHostKeyChecking && (
+              <div className="mt-2.5 border-t border-[#f0f1f3] pt-2.5">
+                <Input.TextArea
+                  variant="filled"
+                  rows={3}
+                  value={current.knownHosts}
+                  disabled={disabled}
+                  placeholder="粘贴 known_hosts 中对应主机的公钥记录"
+                  className="font-mono text-xs"
+                  onChange={(event) => patch({ knownHosts: event.target.value })}
+                />
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default SshTunnelManager;

--- a/yak-ops-ui/src/pages/data-source/types.ts
+++ b/yak-ops-ui/src/pages/data-source/types.ts
@@ -113,6 +113,22 @@ export interface DynamicFormFieldRule {
   message: string;
 }
 
+export type SshAuthType = 'PASSWORD' | 'PRIVATE_KEY';
+
+/** 标准 SSH 隧道配置值，由 SSH Schema 组件统一消费。 */
+export interface SshTunnelConfigValue {
+  enabled?: boolean;
+  host?: string;
+  port?: number;
+  username?: string;
+  authType?: SshAuthType;
+  password?: string;
+  privateKey?: string;
+  passphrase?: string;
+  strictHostKeyChecking?: boolean;
+  knownHosts?: string;
+}
+
 export type DynamicFormFieldType =
   | 'INPUT'
   | 'PASSWORD'
@@ -121,7 +137,8 @@ export type DynamicFormFieldType =
   | 'SWITCH'
   | 'TEXTAREA'
   | 'CUSTOM_SELECT'
-  | 'DRIVER';
+  | 'DRIVER'
+  | 'SSH';
 
 export interface DynamicFormField {
   key: string;


### PR DESCRIPTION
## P0：SSH 标准能力

这次不是只给数据源表单增加 SSH 字段，而是把 SSH Tunnel 做成一套前后端都能复用的标准能力，并真正接入 JDBC 连接链路。

### 前端标准组件

- 新增 `SshTunnelManager`，使用标准 `value / onChange` 受控协议，不依赖 `FormInstance` 或具体字段 key。
- 动态 Schema 新增标准字段类型 `SSH`，插件只需要声明 `type=SSH` 即可复用。
- 支持：
  - SSH 启用/关闭
  - Host / Port（默认 22）
  - 用户名
  - 密码认证
  - 私钥认证 + 私钥口令
  - 可选严格 HostKey 校验 + `known_hosts`
- SSH 组件默认独占整行，保持当前数据源 Drawer 的白底、浅灰边框、紧凑布局。
- 启用 SSH 后增加联动校验，缺少主机、用户、认证凭据等信息时无法提交/连接测试。

### 后端真实 SSH Tunnel

- JDBC 基座统一增加 `sshTunnel` 标准配置，并自动提供可折叠的“SSH 隧道”配置区块。
- 引入维护中的 JSch 实现本地端口转发：
  - `127.0.0.1:随机本地端口 -> SSH Server -> 数据库 host:port`
- 新增统一 `JdbcConnectionProvider`，让以下能力共用同一个 SSH-aware 连接入口：
  - 数据源连接测试
  - Catalog / 元数据读取
  - SQL 执行
- JDBC Connection 关闭或 SQL 取消时同步释放 SSH Session，避免隧道资源泄漏。
- Doris 自定义 Catalog 同步接入统一连接 Provider，不会绕开 SSH。

### 安全处理

- SSH `password / privateKey / passphrase` 纳入现有递归脱敏机制，详情接口只返回 `******`。
- 编辑已有数据源时，前端继续传 `******` 或空值会自动沿用已保存 SSH 密钥。
- 严格 HostKey 校验开启后必须提供 `known_hosts`。
- 启用 SSH 时不允许使用自定义 `jdbcUrl`，必须通过结构化 `host / port / database` 建立目标路由，避免自定义 URL 绕过 SSH 目标解析。

### 兼容性

- 未启用 SSH 时仍走原有 JDBC 连接路径。
- 保留 `JdbcConnectionProperties` 原构造器，降低现有插件/测试源码兼容风险。
- 旧版 `formFields` 仍保持原来的扁平字段数量；SSH 复合对象仅通过新版 `sections` Schema 下发，避免旧前端误渲染。
- 当前 JDBC 插件统一继承该能力，无需 MySQL / PostgreSQL / Oracle / 达梦 / Kingbase 等分别复制 SSH 字段和连接代码。

### 测试与检查

- 增加 MySQL JDBC 插件单测：SSH Schema、密码认证配置解析、自定义 JDBC URL + SSH 冲突校验。
- 增加 SecretCodec 单测：SSH 密码、私钥、私钥口令脱敏及编辑时密钥恢复。
- 分支已重新整理到最新 `main`：ahead 1 / behind 0，SSH 改动压为单一提交。
- 当前执行容器无法解析 `github.com`，无法 clone 完整仓库，因此未在本地运行 Maven / `npm run tsc`；建议由仓库 CI 或本地环境完成最终编译验证。