### PR TITLE
feat: support datasource field dependencies and visibility

### DIFF
--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/vo/datasource/DataSourcePluginConfigVO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/vo/datasource/DataSourcePluginConfigVO.java
@@ -80,6 +80,37 @@ public class DataSourcePluginConfigVO {
 
     @Builder.Default
     private List<RuleVO> rules = new ArrayList<>();
+
+    /**
+     * 字段联动依赖。visibleWhen 中显式声明的 field 也会被前端自动加入依赖集合。
+     */
+    @Builder.Default
+    private List<String> dependsOn = new ArrayList<>();
+
+    /**
+     * 字段显示条件；多个条件使用 AND 语义。condition.field 为空时按顺序映射 dependsOn。
+     */
+    @Builder.Default
+    private List<VisibilityConditionVO> visibleWhen = new ArrayList<>();
+  }
+
+  /** 动态字段显示条件。 */
+  @Data
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class VisibilityConditionVO {
+
+    /** 可选；为空时使用 FormFieldVO.dependsOn 中同位置的字段。 */
+    private String field;
+
+    /** 支持 EQUALS、NOT_EQUALS、IN、NOT_IN、TRUTHY、FALSY。 */
+    private String operator;
+
+    private Object value;
+
+    @Builder.Default
+    private List<Object> values = new ArrayList<>();
   }
 
   /** 下拉选项。 */

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/AbstractJdbcDataSourcePlugin.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/AbstractJdbcDataSourcePlugin.java
@@ -7,6 +7,7 @@ import io.yak.ops.common.bean.vo.datasource.DataSourcePluginConfigVO;
 import io.yak.ops.common.bean.vo.datasource.DataSourcePluginConfigVO.FormFieldVO;
 import io.yak.ops.common.bean.vo.datasource.DataSourcePluginConfigVO.FormSectionVO;
 import io.yak.ops.common.bean.vo.datasource.DataSourcePluginConfigVO.RuleVO;
+import io.yak.ops.common.bean.vo.datasource.DataSourcePluginConfigVO.VisibilityConditionVO;
 import io.yak.ops.common.enums.datasource.DataSourceDbType;
 import io.yak.ops.spi.datasource.DataSourceCatalog;
 import io.yak.ops.spi.datasource.DataSourceConnection;
@@ -111,14 +112,19 @@ public abstract class AbstractJdbcDataSourcePlugin implements DataSourcePlugin {
             required("请输入 JDBC 驱动类")));
 
     List<FormFieldVO> advancedFields = new ArrayList<>();
-    advancedFields.add(
+    FormFieldVO propertiesField =
         field(
             "properties",
             "扩展属性",
             "TEXTAREA",
             "可选；请输入 JSON 对象，例如 {\"useSSL\":\"false\"}",
             null,
-            Collections.emptyList()));
+            Collections.emptyList());
+    propertiesField.setDependsOn(Collections.singletonList("driverClassName"));
+    propertiesField.setVisibleWhen(
+        Collections.singletonList(
+            VisibilityConditionVO.builder().operator("TRUTHY").build()));
+    advancedFields.add(propertiesField);
     appendFormFields(advancedFields);
 
     List<FormSectionVO> sections = new ArrayList<>();

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/test/java/io/yak/ops/plugin/database/jdbc/mysql/MySqlDataSourcePluginTest.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/test/java/io/yak/ops/plugin/database/jdbc/mysql/MySqlDataSourcePluginTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.yak.ops.common.bean.vo.datasource.DataSourcePluginConfigVO;
+import io.yak.ops.common.bean.vo.datasource.DataSourcePluginConfigVO.FormFieldVO;
 import io.yak.ops.common.bean.vo.datasource.DataSourcePluginConfigVO.FormSectionVO;
 import io.yak.ops.plugin.database.jdbc.JdbcConnectionProperties;
 import io.yak.ops.plugin.database.jdbc.SshTunnelConfig;
@@ -47,6 +48,20 @@ class MySqlDataSourcePluginTest {
             });
     assertThat(config.getSections().get(2).getDefaultExpanded()).isTrue();
     assertThat(config.getSections().get(3).getDefaultExpanded()).isFalse();
+
+    FormFieldVO propertiesField =
+        config.getSections().get(3).getFields().stream()
+            .filter(field -> "properties".equals(field.getKey()))
+            .findFirst()
+            .orElseThrow();
+    assertThat(propertiesField.getDependsOn()).containsExactly("driverClassName");
+    assertThat(propertiesField.getVisibleWhen())
+        .singleElement()
+        .satisfies(
+            condition -> {
+              assertThat(condition.getField()).isNull();
+              assertThat(condition.getOperator()).isEqualTo("TRUTHY");
+            });
 
     // 旧版前端仍可继续消费扁平 formFields，SSH 复合字段只通过新版 sections 下发。
     assertThat(config.getFormFields()).hasSize(9);

--- a/yak-ops-ui/src/pages/data-source/components/DynamicDataSourceForm/index.tsx
+++ b/yak-ops-ui/src/pages/data-source/components/DynamicDataSourceForm/index.tsx
@@ -12,7 +12,9 @@ import {
   Switch,
   Tooltip,
 } from 'antd';
+import type { FormInstance } from 'antd';
 import { Code2, FlaskConical, ShieldCheck } from 'lucide-react';
+import type { ReactNode } from 'react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import DatabaseIcons from '../../icon/DatabaseIcons';
@@ -34,6 +36,9 @@ import CustomKVList from './components/CustomKVList';
 import {
   flattenFormSectionFields,
   getConfigInitialValues,
+  getFieldDefaultValue,
+  getFieldDependencies,
+  isDynamicFieldVisible,
   normalizeFormSections,
   transformRules,
 } from './utils/formUtils';
@@ -102,6 +107,40 @@ const pickRandomPreset = (values: string[]) =>
 
 const isEmptyValue = (value: unknown) =>
   value === undefined || value === null || value === '';
+
+/** 字段进入隐藏态时清除历史值和校验错误，确保不会被提交。 */
+const HiddenFieldCleaner = ({
+  form,
+  fieldKey,
+}: {
+  form: FormInstance;
+  fieldKey: string;
+}) => {
+  useEffect(() => {
+    form.setFields([{ name: fieldKey, value: undefined, errors: [] }]);
+  }, [fieldKey, form]);
+  return null;
+};
+
+/** 字段重新显示时，如果当前没有值，则恢复 Schema 默认值。 */
+const VisibleFieldInitializer = ({
+  form,
+  field,
+  children,
+}: {
+  form: FormInstance;
+  field: DynamicFormField;
+  children: ReactNode;
+}) => {
+  useEffect(() => {
+    if (form.getFieldValue(field.key) !== undefined) return;
+    const defaultValue = getFieldDefaultValue(field);
+    if (defaultValue !== undefined) {
+      form.setFieldValue(field.key, defaultValue);
+    }
+  }, [field, form]);
+  return <>{children}</>;
+};
 
 const DynamicDataSourceForm = ({
   dbType,
@@ -297,37 +336,77 @@ const DynamicDataSourceForm = ({
     return rules;
   };
 
+  const renderVisibleField = (field: DynamicFormField) => {
+    const content =
+      field.type === 'CUSTOM_SELECT' ? (
+        <div className="md:col-span-2">
+          <CustomKVList intl={intl} field={field} />
+        </div>
+      ) : (
+        <Form.Item
+          label={field.label}
+          name={field.key}
+          preserve={false}
+          valuePropName={field.type === 'SWITCH' ? 'checked' : 'value'}
+          rules={fieldRules(field)}
+          validateTrigger={['onChange', 'onBlur']}
+          className={[
+            '!mb-3',
+            field.type === 'TEXTAREA' ||
+            field.type === 'DRIVER' ||
+            field.type === 'SSH'
+              ? 'md:col-span-2'
+              : '',
+          ]
+            .filter(Boolean)
+            .join(' ')}
+        >
+          {renderFormControl(field)}
+        </Form.Item>
+      );
+
+    return (
+      <VisibleFieldInitializer
+        key={field.key}
+        form={configForm}
+        field={field}
+      >
+        {content}
+      </VisibleFieldInitializer>
+    );
+  };
+
+  const renderField = (field: DynamicFormField) => {
+    const hasVisibilityRule = Array.isArray(field.visibleWhen)
+      ? field.visibleWhen.length > 0
+      : Boolean(field.visibleWhen);
+    if (!hasVisibilityRule) return renderVisibleField(field);
+
+    const dependencies = getFieldDependencies(field);
+    return (
+      <Form.Item
+        key={`visibility-${field.key}`}
+        noStyle
+        dependencies={dependencies.map((dependency) => dependency.split('.'))}
+      >
+        {({ getFieldsValue }) => {
+          const visible = isDynamicFieldVisible(
+            field,
+            getFieldsValue(true) as Record<string, unknown>,
+          );
+          return visible ? (
+            renderVisibleField(field)
+          ) : (
+            <HiddenFieldCleaner form={configForm} fieldKey={field.key} />
+          );
+        }}
+      </Form.Item>
+    );
+  };
+
   const renderFields = (fields: DynamicFormField[]) => (
     <div className="grid grid-cols-1 gap-x-4 md:grid-cols-2">
-      {fields.map((field) => {
-        if (field.type === 'CUSTOM_SELECT') {
-          return (
-            <div key={field.key} className="md:col-span-2">
-              <CustomKVList intl={intl} field={field} />
-            </div>
-          );
-        }
-
-        const fullWidth =
-          field.type === 'TEXTAREA' ||
-          field.type === 'DRIVER' ||
-          field.type === 'SSH';
-        return (
-          <Form.Item
-            key={field.key}
-            label={field.label}
-            name={field.key}
-            valuePropName={field.type === 'SWITCH' ? 'checked' : 'value'}
-            rules={fieldRules(field)}
-            validateTrigger={['onChange', 'onBlur']}
-            className={['!mb-3', fullWidth ? 'md:col-span-2' : '']
-              .filter(Boolean)
-              .join(' ')}
-          >
-            {renderFormControl(field)}
-          </Form.Item>
-        );
-      })}
+      {fields.map(renderField)}
     </div>
   );
 

--- a/yak-ops-ui/src/pages/data-source/components/DynamicDataSourceForm/utils/formUtils.test.ts
+++ b/yak-ops-ui/src/pages/data-source/components/DynamicDataSourceForm/utils/formUtils.test.ts
@@ -1,4 +1,20 @@
-import { getConfigInitialValues, transformRules } from './formUtils';
+import type { DynamicFormField } from '../../../types';
+import {
+  getConfigInitialValues,
+  getFieldDependencies,
+  isDynamicFieldVisible,
+  normalizeFormSections,
+  transformRules,
+} from './formUtils';
+
+const field = (
+  overrides: Partial<DynamicFormField> = {},
+): DynamicFormField => ({
+  key: 'target',
+  label: '目标字段',
+  type: 'INPUT',
+  ...overrides,
+});
 
 describe('dynamic data source form utils', () => {
   it('marks number field rules as numeric validation rules', () => {
@@ -42,5 +58,96 @@ describe('dynamic data source form utils', () => {
         },
       ]),
     ).toEqual({ port: 3306 });
+  });
+
+  it('maps visibleWhen conditions to dependsOn and evaluates equals', () => {
+    const target = field({
+      dependsOn: ['mode'],
+      visibleWhen: [{ operator: 'EQUALS', value: 'ADVANCED' }],
+    });
+
+    expect(getFieldDependencies(target)).toEqual(['mode']);
+    expect(isDynamicFieldVisible(target, { mode: 'ADVANCED' })).toBe(true);
+    expect(isDynamicFieldVisible(target, { mode: 'BASIC' })).toBe(false);
+  });
+
+  it('merges explicit and inferred dependencies without duplicates', () => {
+    const target = field({
+      dependsOn: ['enabled'],
+      visibleWhen: [
+        { field: 'enabled', operator: 'TRUTHY' },
+        { field: 'mode', operator: 'IN', values: ['A', 'B'] },
+      ],
+    });
+
+    expect(getFieldDependencies(target)).toEqual(['enabled', 'mode']);
+  });
+
+  it('uses AND semantics for multiple visibility conditions', () => {
+    const target = field({
+      visibleWhen: [
+        { field: 'enabled', operator: 'TRUTHY' },
+        { field: 'mode', operator: 'IN', values: ['A', 'B'] },
+      ],
+    });
+
+    expect(isDynamicFieldVisible(target, { enabled: true, mode: 'A' })).toBe(true);
+    expect(isDynamicFieldVisible(target, { enabled: false, mode: 'A' })).toBe(false);
+    expect(isDynamicFieldVisible(target, { enabled: true, mode: 'C' })).toBe(false);
+  });
+
+  it('supports not-equals, not-in, falsy and nested dependency paths', () => {
+    expect(
+      isDynamicFieldVisible(
+        field({
+          visibleWhen: {
+            field: 'auth.type',
+            operator: 'NOT_EQUALS',
+            value: 'PASSWORD',
+          },
+        }),
+        { auth: { type: 'PRIVATE_KEY' } },
+      ),
+    ).toBe(true);
+
+    expect(
+      isDynamicFieldVisible(
+        field({
+          visibleWhen: {
+            field: 'mode',
+            operator: 'NOT_IN',
+            values: ['A', 'B'],
+          },
+        }),
+        { mode: 'C' },
+      ),
+    ).toBe(true);
+
+    expect(
+      isDynamicFieldVisible(
+        field({
+          visibleWhen: { field: 'disabled', operator: 'FALSY' },
+        }),
+        { disabled: false },
+      ),
+    ).toBe(true);
+  });
+
+  it('keeps legacy schemas compatible while normalizing dependency metadata', () => {
+    const sections = normalizeFormSections({
+      formFields: [
+        field({
+          key: 'legacy',
+          dependsOn: ['enabled'],
+          visibleWhen: [{ operator: 'TRUTHY' }],
+        }),
+      ],
+    });
+
+    expect(sections).toHaveLength(1);
+    expect(sections[0].fields[0].dependsOn).toEqual(['enabled']);
+    expect(sections[0].fields[0].visibleWhen).toEqual([
+      { field: 'enabled', operator: 'TRUTHY' },
+    ]);
   });
 });

--- a/yak-ops-ui/src/pages/data-source/components/DynamicDataSourceForm/utils/formUtils.ts
+++ b/yak-ops-ui/src/pages/data-source/components/DynamicDataSourceForm/utils/formUtils.ts
@@ -5,6 +5,8 @@ import type {
   DynamicFormFieldRule,
   DynamicFormSchemaResponse,
   DynamicFormSection,
+  DynamicFormVisibilityCondition,
+  DynamicFormVisibilityOperator,
 } from '../../../types';
 
 export const transformRules = (
@@ -35,12 +37,12 @@ export const transformRules = (
 export const getConfigInitialValues = (fields: DynamicFormField[]) => {
   const initialValues: Record<string, unknown> = {};
   fields.forEach((field) => {
-    initialValues[field.key] = parseDefaultValueByType(field);
+    initialValues[field.key] = getFieldDefaultValue(field);
   });
   return initialValues;
 };
 
-const parseDefaultValueByType = (field: DynamicFormField) => {
+export const getFieldDefaultValue = (field: DynamicFormField) => {
   const value = field.defaultValue;
   if (value === undefined || value === null || value === '') {
     return field.type === 'CUSTOM_SELECT' ? [] : value;
@@ -67,18 +69,117 @@ const parseDefaultValueByType = (field: DynamicFormField) => {
   }
 };
 
+const normalizeOperator = (
+  operator?: DynamicFormVisibilityOperator | string,
+  condition?: DynamicFormVisibilityCondition,
+): DynamicFormVisibilityOperator => {
+  const value = operator?.trim().toUpperCase();
+  if (
+    value === 'EQUALS' ||
+    value === 'NOT_EQUALS' ||
+    value === 'IN' ||
+    value === 'NOT_IN' ||
+    value === 'TRUTHY' ||
+    value === 'FALSY'
+  ) {
+    return value;
+  }
+  return condition && 'value' in condition ? 'EQUALS' : 'TRUTHY';
+};
+
+const normalizeVisibilityConditions = (
+  field: DynamicFormField,
+): DynamicFormVisibilityCondition[] => {
+  const raw = field.visibleWhen;
+  if (!raw) return [];
+  const conditions = Array.isArray(raw) ? raw : [raw];
+  const dependencies = field.dependsOn || [];
+
+  return conditions.map((condition, index) => ({
+    ...condition,
+    field:
+      condition.field?.trim() || dependencies[index]?.trim() || dependencies[0]?.trim(),
+    operator: normalizeOperator(condition.operator, condition),
+  }));
+};
+
+/**
+ * 归一字段联动依赖：显式 dependsOn 与 visibleWhen 中引用的字段会合并去重。
+ */
+export const getFieldDependencies = (field: DynamicFormField): string[] => {
+  const conditions = normalizeVisibilityConditions(field);
+  return Array.from(
+    new Set(
+      [...(field.dependsOn || []), ...conditions.map((condition) => condition.field)]
+        .map((value) => value?.trim())
+        .filter((value): value is string => Boolean(value)),
+    ),
+  );
+};
+
+const getValueByPath = (values: Record<string, unknown>, path?: string): unknown => {
+  if (!path) return undefined;
+  return path.split('.').reduce<unknown>((current, segment) => {
+    if (!current || typeof current !== 'object') return undefined;
+    return (current as Record<string, unknown>)[segment];
+  }, values);
+};
+
+const equals = (left: unknown, right: unknown) => Object.is(left, right);
+
+const matchVisibilityCondition = (
+  condition: DynamicFormVisibilityCondition,
+  values: Record<string, unknown>,
+) => {
+  const actual = getValueByPath(values, condition.field);
+  const operator = normalizeOperator(condition.operator, condition);
+  const candidates = condition.values || (Array.isArray(condition.value) ? condition.value : []);
+
+  switch (operator) {
+    case 'NOT_EQUALS':
+      return !equals(actual, condition.value);
+    case 'IN':
+      return candidates.some((candidate) => equals(actual, candidate));
+    case 'NOT_IN':
+      return !candidates.some((candidate) => equals(actual, candidate));
+    case 'TRUTHY':
+      return Boolean(actual);
+    case 'FALSY':
+      return !actual;
+    case 'EQUALS':
+    default:
+      return equals(actual, condition.value);
+  }
+};
+
+/**
+ * 判断动态字段当前是否可见。未配置 visibleWhen 时始终显示；多条件使用 AND 语义。
+ */
+export const isDynamicFieldVisible = (
+  field: DynamicFormField,
+  values: Record<string, unknown>,
+) => {
+  const conditions = normalizeVisibilityConditions(field);
+  if (conditions.length === 0) return true;
+  return conditions.every(
+    (condition) => Boolean(condition.field) && matchVisibilityCondition(condition, values),
+  );
+};
+
 /**
  * 兼容旧插件历史约定：driverLocation 曾经以普通 INPUT 字段下发，
  * 新版统一提升为 DRIVER 标准组件。插件升级后应直接声明 type=DRIVER。
  */
 const normalizeFormField = (field: DynamicFormField): DynamicFormField => {
+  const normalized: DynamicFormField = {
+    ...field,
+    dependsOn: getFieldDependencies(field),
+    visibleWhen: normalizeVisibilityConditions(field),
+  };
   if (field.key === 'driverLocation' && field.type !== 'DRIVER') {
-    return {
-      ...field,
-      type: 'DRIVER',
-    };
+    normalized.type = 'DRIVER';
   }
-  return { ...field };
+  return normalized;
 };
 
 /**

--- a/yak-ops-ui/src/pages/data-source/types.ts
+++ b/yak-ops-ui/src/pages/data-source/types.ts
@@ -113,6 +113,25 @@ export interface DynamicFormFieldRule {
   message: string;
 }
 
+export type DynamicFormVisibilityOperator =
+  | 'EQUALS'
+  | 'NOT_EQUALS'
+  | 'IN'
+  | 'NOT_IN'
+  | 'TRUTHY'
+  | 'FALSY';
+
+/**
+ * 动态字段显示条件。field 可省略，此时按 visibleWhen 顺序映射到 dependsOn。
+ * 多个条件默认使用 AND 语义。
+ */
+export interface DynamicFormVisibilityCondition {
+  field?: string;
+  operator?: DynamicFormVisibilityOperator;
+  value?: unknown;
+  values?: unknown[];
+}
+
 export type SshAuthType = 'PASSWORD' | 'PRIVATE_KEY';
 
 /** 标准 SSH 隧道配置值，由 SSH Schema 组件统一消费。 */
@@ -148,6 +167,12 @@ export interface DynamicFormField {
   options?: Array<{ label: string; value: string | number }>;
   defaultValue?: unknown;
   rules?: DynamicFormFieldRule[];
+  /** 声明联动依赖；条件中显式引用的字段会自动补充到此列表。 */
+  dependsOn?: string[];
+  /** 字段显示条件；支持单条件或多条件，多条件按 AND 计算。 */
+  visibleWhen?:
+    | DynamicFormVisibilityCondition
+    | DynamicFormVisibilityCondition[];
 }
 
 /**


### PR DESCRIPTION
## P0：dependsOn / visibleWhen 字段联动

### Schema 能力

- 动态字段新增 `dependsOn` + `visibleWhen` 标准协议。
- `visibleWhen` 支持：
  - `EQUALS`
  - `NOT_EQUALS`
  - `IN`
  - `NOT_IN`
  - `TRUTHY`
  - `FALSY`
- 多个 `visibleWhen` 条件采用 AND 语义。
- `condition.field` 可省略，此时按顺序映射到 `dependsOn`；显式引用的字段也会自动合并到依赖集合。
- 支持 `auth.type` 这类 dotted path 嵌套字段依赖。

### 动态表单引擎

- 基于 AntD Form `dependencies` 精准响应依赖字段变化，不需要插件自己写联动 React 逻辑。
- 字段进入隐藏态时：
  - 自动跳过校验；
  - 清理历史校验错误；
  - 清理旧值，避免不可见配置继续进入 `connectionParams`。
- 字段重新显示时，如果当前没有值，会恢复 Schema 声明的默认值。
- DRIVER / SSH / Section / Collapse 等现有能力保持不变。
- 旧版扁平 `formFields` 继续兼容。

### 实际落地示例

- JDBC `properties` 字段声明：
  - `dependsOn = [driverClassName]`
  - `visibleWhen = TRUTHY`
- 这样本 PR 合并后即可看到真实字段联动，而不是只增加一套未使用的协议。
- 不改变现有 JDBC 创建、编辑、连接测试和执行语义。

### 测试

- 前端 `formUtils.test.ts` 补充联动逻辑测试：
  - equals / notEquals
  - in / notIn
  - truthy / falsy
  - 多条件 AND
  - 自动依赖合并
  - dotted path
  - legacy formFields 兼容
- MySQL 插件测试增加 `dependsOn / visibleWhen` Schema 契约断言。
- 分支已整理到最新 `main`：ahead 1 / behind 0，全部改动压为单一提交。

### 验证说明

当前执行环境此前无法通过 `github.com` clone 完整仓库，因此本轮未在本地完整执行 Maven / `npm run tsc`；建议由仓库 CI 或本地开发环境完成最终编译验证。