### PR TITLE
feat: link JDBC URL with datasource connection fields

### DIFF
--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/vo/datasource/DataSourcePluginConfigVO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/vo/datasource/DataSourcePluginConfigVO.java
@@ -67,8 +67,8 @@ public class DataSourcePluginConfigVO {
     /**
      * 标准字段组件类型。
      *
-     * <p>支持 INPUT、PASSWORD、SELECT、NUMBER、SWITCH、TEXTAREA、CUSTOM_SELECT、DRIVER 和 SSH；
-     * DRIVER 与 SSH 均由前端标准组件负责渲染，不应再通过特定字段 key 触发。
+     * <p>支持 INPUT、PASSWORD、SELECT、NUMBER、SWITCH、TEXTAREA、CUSTOM_SELECT、DRIVER、SSH 和 JDBC_URL；
+     * DRIVER、SSH 与 JDBC_URL 均由前端标准组件负责渲染，不应再通过特定字段 key 触发。
      */
     private String type;
 
@@ -92,6 +92,33 @@ public class DataSourcePluginConfigVO {
      */
     @Builder.Default
     private List<VisibilityConditionVO> visibleWhen = new ArrayList<>();
+
+    /** JDBC_URL 标准组件的 Host / Port / Database 双向联动描述。 */
+    private JdbcUrlLinkageVO urlLinkage;
+  }
+
+  /** JDBC URL 联动配置。 */
+  @Data
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class JdbcUrlLinkageVO {
+
+    /** 例如 jdbc:mysql://{host}:{port}/{database}。 */
+    private String template;
+
+    @Builder.Default
+    private String hostField = "host";
+
+    @Builder.Default
+    private String portField = "port";
+
+    @Builder.Default
+    private String databaseField = "database";
+
+    /** 是否在结构化字段变化时保留 ?query / ;properties 尾部参数。 */
+    @Builder.Default
+    private Boolean preserveSuffix = true;
   }
 
   /** 动态字段显示条件。 */

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-doris/src/main/java/io/yak/ops/plugin/database/doris/DorisDataSourcePlugin.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-doris/src/main/java/io/yak/ops/plugin/database/doris/DorisDataSourcePlugin.java
@@ -2,10 +2,12 @@ package io.yak.ops.plugin.database.doris;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.yak.ops.common.bean.vo.datasource.DataSourcePluginConfigVO;
 import io.yak.ops.common.bean.vo.datasource.DataSourcePluginConfigVO.FormFieldVO;
 import io.yak.ops.common.enums.datasource.DataSourceDbType;
 import io.yak.ops.plugin.database.jdbc.AbstractJdbcDataSourcePlugin;
 import io.yak.ops.plugin.database.jdbc.JdbcConnectionProperties;
+import io.yak.ops.plugin.database.jdbc.JdbcUrlSchemaSupport;
 import io.yak.ops.spi.datasource.DataSourceCatalog;
 import java.util.Collections;
 import java.util.List;
@@ -16,6 +18,13 @@ public final class DorisDataSourcePlugin extends AbstractJdbcDataSourcePlugin {
   @Override
   public DataSourceDbType dbType() {
     return DataSourceDbType.DORIS;
+  }
+
+  @Override
+  public DataSourcePluginConfigVO pluginConfig() {
+    return JdbcUrlSchemaSupport.apply(
+        super.pluginConfig(),
+        "jdbc:mysql://{host}:{port}/{database}");
   }
 
   @Override

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/JdbcUrlSchemaSupport.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/JdbcUrlSchemaSupport.java
@@ -1,0 +1,84 @@
+package io.yak.ops.plugin.database.jdbc;
+
+import io.yak.ops.common.bean.vo.datasource.DataSourcePluginConfigVO;
+import io.yak.ops.common.bean.vo.datasource.DataSourcePluginConfigVO.FormFieldVO;
+import io.yak.ops.common.bean.vo.datasource.DataSourcePluginConfigVO.FormSectionVO;
+import io.yak.ops.common.bean.vo.datasource.DataSourcePluginConfigVO.JdbcUrlLinkageVO;
+import io.yak.ops.common.bean.vo.datasource.DataSourcePluginConfigVO.VisibilityConditionVO;
+import java.util.ArrayList;
+import java.util.List;
+
+/** JDBC URL Schema 标准能力：由插件声明模板，前端统一完成 Host / Port / Database 双向联动。 */
+public final class JdbcUrlSchemaSupport {
+
+  private static final String JDBC_URL_FIELD = "jdbcUrl";
+  private static final String SSH_FIELD = "sshTunnel";
+  private static final String SSH_ENABLED_FIELD = "sshTunnel.enabled";
+
+  private JdbcUrlSchemaSupport() {
+  }
+
+  public static DataSourcePluginConfigVO apply(
+      DataSourcePluginConfigVO config,
+      String template) {
+    if (config == null || template == null || template.trim().isEmpty()) {
+      return config;
+    }
+
+    if (config.getSections() != null) {
+      for (FormSectionVO section : config.getSections()) {
+        if (section == null || section.getFields() == null) continue;
+        section.getFields().forEach(field -> configureField(field, template));
+      }
+    }
+    if (config.getFormFields() != null) {
+      config.getFormFields().forEach(field -> configureField(field, template));
+    }
+    return config;
+  }
+
+  private static void configureField(FormFieldVO field, String template) {
+    if (field == null || !JDBC_URL_FIELD.equals(field.getKey())) return;
+
+    field.setType("JDBC_URL");
+    field.setPlaceholder("根据主机、端口和数据库自动生成，也可以直接修改");
+    field.setUrlLinkage(
+        JdbcUrlLinkageVO.builder()
+            .template(template.trim())
+            .hostField("host")
+            .portField("port")
+            .databaseField("database")
+            .preserveSuffix(true)
+            .build());
+
+    List<String> dependencies =
+        field.getDependsOn() == null
+            ? new ArrayList<>()
+            : new ArrayList<>(field.getDependsOn());
+    // SSH 是一个复合对象字段；监听父字段可确保开关变化一定触发前端重新计算可见性。
+    if (!dependencies.contains(SSH_FIELD)) {
+      dependencies.add(SSH_FIELD);
+    }
+    field.setDependsOn(dependencies);
+
+    List<VisibilityConditionVO> conditions =
+        field.getVisibleWhen() == null
+            ? new ArrayList<>()
+            : new ArrayList<>(field.getVisibleWhen());
+    boolean hasSshVisibilityRule =
+        conditions.stream()
+            .anyMatch(
+                condition ->
+                    condition != null
+                        && SSH_ENABLED_FIELD.equals(condition.getField())
+                        && "FALSY".equalsIgnoreCase(condition.getOperator()));
+    if (!hasSshVisibilityRule) {
+      conditions.add(
+          VisibilityConditionVO.builder()
+              .field(SSH_ENABLED_FIELD)
+              .operator("FALSY")
+              .build());
+    }
+    field.setVisibleWhen(conditions);
+  }
+}

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/dameng/DamengDataSourcePlugin.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/dameng/DamengDataSourcePlugin.java
@@ -1,8 +1,10 @@
 package io.yak.ops.plugin.database.jdbc.dameng;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import io.yak.ops.common.bean.vo.datasource.DataSourcePluginConfigVO;
 import io.yak.ops.common.enums.datasource.DataSourceDbType;
 import io.yak.ops.plugin.database.jdbc.AbstractJdbcDataSourcePlugin;
+import io.yak.ops.plugin.database.jdbc.JdbcUrlSchemaSupport;
 
 /** 达梦 JDBC 数据源插件。 */
 public final class DamengDataSourcePlugin extends AbstractJdbcDataSourcePlugin {
@@ -10,6 +12,13 @@ public final class DamengDataSourcePlugin extends AbstractJdbcDataSourcePlugin {
   @Override
   public DataSourceDbType dbType() {
     return DataSourceDbType.DAMENG;
+  }
+
+  @Override
+  public DataSourcePluginConfigVO pluginConfig() {
+    return JdbcUrlSchemaSupport.apply(
+        super.pluginConfig(),
+        "jdbc:dm://{host}:{port}/{database}");
   }
 
   @Override

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/kingbase/KingbaseDataSourcePlugin.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/kingbase/KingbaseDataSourcePlugin.java
@@ -1,8 +1,10 @@
 package io.yak.ops.plugin.database.jdbc.kingbase;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import io.yak.ops.common.bean.vo.datasource.DataSourcePluginConfigVO;
 import io.yak.ops.common.enums.datasource.DataSourceDbType;
 import io.yak.ops.plugin.database.jdbc.AbstractJdbcDataSourcePlugin;
+import io.yak.ops.plugin.database.jdbc.JdbcUrlSchemaSupport;
 
 /** KingbaseES JDBC 数据源插件。 */
 public final class KingbaseDataSourcePlugin extends AbstractJdbcDataSourcePlugin {
@@ -10,6 +12,13 @@ public final class KingbaseDataSourcePlugin extends AbstractJdbcDataSourcePlugin
   @Override
   public DataSourceDbType dbType() {
     return DataSourceDbType.KINGBASE;
+  }
+
+  @Override
+  public DataSourcePluginConfigVO pluginConfig() {
+    return JdbcUrlSchemaSupport.apply(
+        super.pluginConfig(),
+        "jdbc:kingbase8://{host}:{port}/{database}");
   }
 
   @Override

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/mysql/MySqlDataSourcePlugin.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/mysql/MySqlDataSourcePlugin.java
@@ -1,8 +1,10 @@
 package io.yak.ops.plugin.database.jdbc.mysql;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import io.yak.ops.common.bean.vo.datasource.DataSourcePluginConfigVO;
 import io.yak.ops.common.enums.datasource.DataSourceDbType;
 import io.yak.ops.plugin.database.jdbc.AbstractJdbcDataSourcePlugin;
+import io.yak.ops.plugin.database.jdbc.JdbcUrlSchemaSupport;
 
 /** MySQL JDBC 数据源插件。 */
 public final class MySqlDataSourcePlugin extends AbstractJdbcDataSourcePlugin {
@@ -10,6 +12,13 @@ public final class MySqlDataSourcePlugin extends AbstractJdbcDataSourcePlugin {
   @Override
   public DataSourceDbType dbType() {
     return DataSourceDbType.MYSQL;
+  }
+
+  @Override
+  public DataSourcePluginConfigVO pluginConfig() {
+    return JdbcUrlSchemaSupport.apply(
+        super.pluginConfig(),
+        "jdbc:mysql://{host}:{port}/{database}");
   }
 
   @Override

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/oracle/OracleDataSourcePlugin.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/oracle/OracleDataSourcePlugin.java
@@ -1,8 +1,10 @@
 package io.yak.ops.plugin.database.jdbc.oracle;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import io.yak.ops.common.bean.vo.datasource.DataSourcePluginConfigVO;
 import io.yak.ops.common.enums.datasource.DataSourceDbType;
 import io.yak.ops.plugin.database.jdbc.AbstractJdbcDataSourcePlugin;
+import io.yak.ops.plugin.database.jdbc.JdbcUrlSchemaSupport;
 
 /** Oracle JDBC 数据源插件。 */
 public final class OracleDataSourcePlugin extends AbstractJdbcDataSourcePlugin {
@@ -10,6 +12,13 @@ public final class OracleDataSourcePlugin extends AbstractJdbcDataSourcePlugin {
   @Override
   public DataSourceDbType dbType() {
     return DataSourceDbType.ORACLE;
+  }
+
+  @Override
+  public DataSourcePluginConfigVO pluginConfig() {
+    return JdbcUrlSchemaSupport.apply(
+        super.pluginConfig(),
+        "jdbc:oracle:thin:@//{host}:{port}/{database}");
   }
 
   @Override

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/postgresql/PostgreSqlDataSourcePlugin.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/postgresql/PostgreSqlDataSourcePlugin.java
@@ -1,8 +1,10 @@
 package io.yak.ops.plugin.database.jdbc.postgresql;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import io.yak.ops.common.bean.vo.datasource.DataSourcePluginConfigVO;
 import io.yak.ops.common.enums.datasource.DataSourceDbType;
 import io.yak.ops.plugin.database.jdbc.AbstractJdbcDataSourcePlugin;
+import io.yak.ops.plugin.database.jdbc.JdbcUrlSchemaSupport;
 
 /** PostgreSQL JDBC 数据源插件。 */
 public final class PostgreSqlDataSourcePlugin extends AbstractJdbcDataSourcePlugin {
@@ -10,6 +12,13 @@ public final class PostgreSqlDataSourcePlugin extends AbstractJdbcDataSourcePlug
   @Override
   public DataSourceDbType dbType() {
     return DataSourceDbType.POSTGRE_SQL;
+  }
+
+  @Override
+  public DataSourcePluginConfigVO pluginConfig() {
+    return JdbcUrlSchemaSupport.apply(
+        super.pluginConfig(),
+        "jdbc:postgresql://{host}:{port}/{database}");
   }
 
   @Override

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/test/java/io/yak/ops/plugin/database/jdbc/mysql/MySqlDataSourcePluginTest.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/test/java/io/yak/ops/plugin/database/jdbc/mysql/MySqlDataSourcePluginTest.java
@@ -49,6 +49,28 @@ class MySqlDataSourcePluginTest {
     assertThat(config.getSections().get(2).getDefaultExpanded()).isTrue();
     assertThat(config.getSections().get(3).getDefaultExpanded()).isFalse();
 
+    FormFieldVO jdbcUrlField =
+        config.getSections().get(0).getFields().stream()
+            .filter(field -> "jdbcUrl".equals(field.getKey()))
+            .findFirst()
+            .orElseThrow();
+    assertThat(jdbcUrlField.getType()).isEqualTo("JDBC_URL");
+    assertThat(jdbcUrlField.getUrlLinkage()).isNotNull();
+    assertThat(jdbcUrlField.getUrlLinkage().getTemplate())
+        .isEqualTo("jdbc:mysql://{host}:{port}/{database}");
+    assertThat(jdbcUrlField.getUrlLinkage().getHostField()).isEqualTo("host");
+    assertThat(jdbcUrlField.getUrlLinkage().getPortField()).isEqualTo("port");
+    assertThat(jdbcUrlField.getUrlLinkage().getDatabaseField()).isEqualTo("database");
+    assertThat(jdbcUrlField.getUrlLinkage().getPreserveSuffix()).isTrue();
+    assertThat(jdbcUrlField.getDependsOn()).contains("sshTunnel");
+    assertThat(jdbcUrlField.getVisibleWhen())
+        .singleElement()
+        .satisfies(
+            condition -> {
+              assertThat(condition.getField()).isEqualTo("sshTunnel.enabled");
+              assertThat(condition.getOperator()).isEqualTo("FALSY");
+            });
+
     FormFieldVO propertiesField =
         config.getSections().get(3).getFields().stream()
             .filter(field -> "properties".equals(field.getKey()))

--- a/yak-ops-ui/src/pages/data-source/components/DynamicDataSourceForm/index.tsx
+++ b/yak-ops-ui/src/pages/data-source/components/DynamicDataSourceForm/index.tsx
@@ -29,6 +29,7 @@ import type {
 } from '../../types';
 import { DataSourceOperateType } from '../../types';
 import DriverManager from '../DriverManager';
+import JdbcUrlField from '../JdbcUrlField';
 import SshTunnelManager, {
   getSshTunnelValidationMessage,
 } from '../SshTunnelManager';
@@ -275,6 +276,14 @@ const DynamicDataSourceForm = ({
         return <DriverManager dbType={dbType} placeholder={field.placeholder} />;
       case 'SSH':
         return <SshTunnelManager />;
+      case 'JDBC_URL':
+        return (
+          <JdbcUrlField
+            form={configForm}
+            linkage={field.urlLinkage}
+            placeholder={field.placeholder}
+          />
+        );
       case 'PASSWORD':
         return (
           <Input.Password
@@ -354,7 +363,8 @@ const DynamicDataSourceForm = ({
             '!mb-3',
             field.type === 'TEXTAREA' ||
             field.type === 'DRIVER' ||
-            field.type === 'SSH'
+            field.type === 'SSH' ||
+            field.type === 'JDBC_URL'
               ? 'md:col-span-2'
               : '',
           ]

--- a/yak-ops-ui/src/pages/data-source/components/JdbcUrlField/index.tsx
+++ b/yak-ops-ui/src/pages/data-source/components/JdbcUrlField/index.tsx
@@ -1,0 +1,165 @@
+import { Form, Input, Tooltip } from 'antd';
+import type { FormInstance } from 'antd';
+import { Link2 } from 'lucide-react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+
+import type { DynamicFormJdbcUrlLinkage } from '../../types';
+import {
+  buildJdbcUrlFromTemplate,
+  parseJdbcUrlByTemplate,
+  type JdbcUrlStructuredValue,
+} from './utils';
+
+const toNamePath = (field?: string, fallback?: string) =>
+  (field?.trim() || fallback || '').split('.').filter(Boolean);
+
+const sourceSignature = (value: JdbcUrlStructuredValue) =>
+  JSON.stringify([value.host || '', value.port || '', value.database || '']);
+
+export interface JdbcUrlFieldProps {
+  value?: string;
+  onChange?: (value: string) => void;
+  form: FormInstance;
+  linkage?: DynamicFormJdbcUrlLinkage;
+  placeholder?: string;
+  disabled?: boolean;
+}
+
+/**
+ * JDBC URL 标准联动组件。
+ *
+ * - Host / Port / Database 变化时自动生成 URL；
+ * - URL 可被模板识别时反向回填结构化字段；
+ * - 编辑历史数据时可由现有 URL 补齐结构化字段；
+ * - 手工 URL 不可识别时保持原值，不强行覆盖；
+ * - 自动生成时尽量保留已有 ?query / ;properties 尾部参数。
+ */
+const JdbcUrlField = ({
+  value,
+  onChange,
+  form,
+  linkage,
+  placeholder,
+  disabled = false,
+}: JdbcUrlFieldProps) => {
+  const hostPath = useMemo(
+    () => toNamePath(linkage?.hostField, 'host'),
+    [linkage?.hostField],
+  );
+  const portPath = useMemo(
+    () => toNamePath(linkage?.portField, 'port'),
+    [linkage?.portField],
+  );
+  const databasePath = useMemo(
+    () => toNamePath(linkage?.databaseField, 'database'),
+    [linkage?.databaseField],
+  );
+
+  const host = Form.useWatch(hostPath, form) as string | undefined;
+  const port = Form.useWatch(portPath, form) as number | undefined;
+  const database = Form.useWatch(databasePath, form) as string | undefined;
+
+  const currentValueRef = useRef(value);
+  const previousSourceRef = useRef<string>();
+  const ignoreSourceSignatureRef = useRef<string>();
+  currentValueRef.current = value;
+
+  const applyParsedFields = useCallback(
+    (parsed: JdbcUrlStructuredValue) => {
+      ignoreSourceSignatureRef.current = sourceSignature(parsed);
+      form.setFields([
+        { name: hostPath, value: parsed.host, errors: [] },
+        { name: portPath, value: parsed.port, errors: [] },
+        { name: databasePath, value: parsed.database, errors: [] },
+      ]);
+    },
+    [databasePath, form, hostPath, portPath],
+  );
+
+  useEffect(() => {
+    if (!linkage?.template) return;
+
+    const source = { host, port, database };
+    const signature = sourceSignature(source);
+
+    if (ignoreSourceSignatureRef.current === signature) {
+      ignoreSourceSignatureRef.current = undefined;
+      previousSourceRef.current = signature;
+      return;
+    }
+
+    if (previousSourceRef.current === undefined) {
+      previousSourceRef.current = signature;
+      const existingUrl = currentValueRef.current?.trim();
+      if (existingUrl) {
+        const parsed = parseJdbcUrlByTemplate(linkage, existingUrl);
+        if (parsed && sourceSignature(parsed) !== signature) {
+          applyParsedFields(parsed);
+        }
+        return;
+      }
+    } else if (previousSourceRef.current === signature) {
+      return;
+    } else {
+      previousSourceRef.current = signature;
+    }
+
+    const currentParsed = parseJdbcUrlByTemplate(
+      linkage,
+      currentValueRef.current,
+    );
+    const nextUrl = buildJdbcUrlFromTemplate(linkage, {
+      ...source,
+      suffix:
+        linkage.preserveSuffix === false ? undefined : currentParsed?.suffix,
+    });
+
+    if (nextUrl && nextUrl !== currentValueRef.current) {
+      currentValueRef.current = nextUrl;
+      onChange?.(nextUrl);
+    }
+  }, [
+    applyParsedFields,
+    database,
+    host,
+    linkage,
+    onChange,
+    port,
+  ]);
+
+  const handleChange = (nextValue: string) => {
+    currentValueRef.current = nextValue;
+    onChange?.(nextValue);
+
+    if (!linkage?.template) return;
+    const parsed = parseJdbcUrlByTemplate(linkage, nextValue);
+    if (!parsed) return;
+    applyParsedFields(parsed);
+  };
+
+  return (
+    <div>
+      <Input
+        variant="filled"
+        value={value}
+        disabled={disabled}
+        placeholder={placeholder}
+        onChange={(event) => handleChange(event.target.value)}
+        suffix={
+          linkage?.template ? (
+            <Tooltip title="Host、Port、Database 与 JDBC URL 已启用双向联动">
+              <Link2 size={14} className="text-[#98a2b3]" />
+            </Tooltip>
+          ) : undefined
+        }
+      />
+      {linkage?.template && (
+        <div className="mt-1 text-[11px] leading-4 text-[#98a2b3]">
+          修改主机、端口或数据库会自动生成 URL；修改可识别的 URL 会同步回填连接参数。
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default JdbcUrlField;

--- a/yak-ops-ui/src/pages/data-source/components/JdbcUrlField/utils.test.ts
+++ b/yak-ops-ui/src/pages/data-source/components/JdbcUrlField/utils.test.ts
@@ -1,0 +1,90 @@
+import type { DynamicFormJdbcUrlLinkage } from '../../types';
+import { buildJdbcUrlFromTemplate, parseJdbcUrlByTemplate } from './utils';
+
+const MYSQL_LINKAGE: DynamicFormJdbcUrlLinkage = {
+  template: 'jdbc:mysql://{host}:{port}/{database}',
+  preserveSuffix: true,
+};
+
+const ORACLE_LINKAGE: DynamicFormJdbcUrlLinkage = {
+  template: 'jdbc:oracle:thin:@//{host}:{port}/{database}',
+};
+
+describe('JDBC URL linkage codec', () => {
+  it('builds URL from structured connection fields', () => {
+    expect(
+      buildJdbcUrlFromTemplate(MYSQL_LINKAGE, {
+        host: 'db.internal',
+        port: 3306,
+        database: 'yak',
+      }),
+    ).toBe('jdbc:mysql://db.internal:3306/yak');
+  });
+
+  it('parses URL back into host, port and database', () => {
+    expect(
+      parseJdbcUrlByTemplate(
+        MYSQL_LINKAGE,
+        'jdbc:mysql://db.internal:3307/yak_test',
+      ),
+    ).toEqual({
+      host: 'db.internal',
+      port: 3307,
+      database: 'yak_test',
+    });
+  });
+
+  it('preserves query or property suffix when rebuilding URL', () => {
+    const parsed = parseJdbcUrlByTemplate(
+      MYSQL_LINKAGE,
+      'jdbc:mysql://db.internal:3306/yak?useSSL=false&serverTimezone=UTC',
+    );
+
+    expect(parsed?.suffix).toBe('?useSSL=false&serverTimezone=UTC');
+    expect(
+      buildJdbcUrlFromTemplate(MYSQL_LINKAGE, {
+        host: 'db-new.internal',
+        port: 3306,
+        database: 'yak',
+        suffix: parsed?.suffix,
+      }),
+    ).toBe(
+      'jdbc:mysql://db-new.internal:3306/yak?useSSL=false&serverTimezone=UTC',
+    );
+  });
+
+  it('supports Oracle thin URL templates', () => {
+    const url = buildJdbcUrlFromTemplate(ORACLE_LINKAGE, {
+      host: 'oracle.internal',
+      port: 1521,
+      database: 'ORCL',
+    });
+    expect(url).toBe('jdbc:oracle:thin:@//oracle.internal:1521/ORCL');
+    expect(parseJdbcUrlByTemplate(ORACLE_LINKAGE, url)).toEqual({
+      host: 'oracle.internal',
+      port: 1521,
+      database: 'ORCL',
+    });
+  });
+
+  it('normalizes IPv6 host brackets', () => {
+    const url = buildJdbcUrlFromTemplate(MYSQL_LINKAGE, {
+      host: '2001:db8::10',
+      port: 3306,
+      database: 'yak',
+    });
+    expect(url).toBe('jdbc:mysql://[2001:db8::10]:3306/yak');
+    expect(parseJdbcUrlByTemplate(MYSQL_LINKAGE, url)?.host).toBe(
+      '2001:db8::10',
+    );
+  });
+
+  it('keeps unsupported custom URL editable without false parsing', () => {
+    expect(
+      parseJdbcUrlByTemplate(
+        MYSQL_LINKAGE,
+        'jdbc:mysql:loadbalance://db-a,db-b/yak',
+      ),
+    ).toBeUndefined();
+  });
+});

--- a/yak-ops-ui/src/pages/data-source/components/JdbcUrlField/utils.ts
+++ b/yak-ops-ui/src/pages/data-source/components/JdbcUrlField/utils.ts
@@ -1,0 +1,114 @@
+import type { DynamicFormJdbcUrlLinkage } from '../../types';
+
+export interface JdbcUrlStructuredValue {
+  host?: string;
+  port?: number;
+  database?: string;
+  suffix?: string;
+}
+
+const PLACEHOLDER_PATTERN = /\{(host|port|database)\}/g;
+
+const escapeRegExp = (value: string) =>
+  value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+const normalizeHostForUrl = (host: string) => {
+  const value = host.trim();
+  if (!value) return value;
+  if (value.startsWith('[') && value.endsWith(']')) return value;
+  return value.includes(':') ? `[${value}]` : value;
+};
+
+const normalizeParsedHost = (host: string) => {
+  const value = host.trim();
+  if (value.startsWith('[') && value.endsWith(']')) {
+    return value.slice(1, -1);
+  }
+  return value;
+};
+
+const buildTemplateMatcher = (template: string) => {
+  const fieldOrder: Array<'host' | 'port' | 'database'> = [];
+  let source = '^';
+  let lastIndex = 0;
+
+  for (const match of template.matchAll(PLACEHOLDER_PATTERN)) {
+    const index = match.index ?? 0;
+    source += escapeRegExp(template.slice(lastIndex, index));
+    const field = match[1] as 'host' | 'port' | 'database';
+    fieldOrder.push(field);
+
+    if (field === 'host') {
+      // 用户名密码写进 URL 时保持为“手工自定义 URL”，不要误识别成 host。
+      source += '(\\[[^\\]]+\\]|[^@/?;]+?)';
+    } else if (field === 'port') {
+      source += '(\\d{1,5})';
+    } else {
+      source += '([^?;]+)';
+    }
+    lastIndex = index + match[0].length;
+  }
+
+  source += escapeRegExp(template.slice(lastIndex));
+  source += '([?;].*)?$';
+  return {
+    pattern: new RegExp(source),
+    fieldOrder,
+  };
+};
+
+export const buildJdbcUrlFromTemplate = (
+  linkage: DynamicFormJdbcUrlLinkage,
+  value: JdbcUrlStructuredValue,
+): string | undefined => {
+  const template = linkage.template?.trim();
+  const host = value.host?.trim();
+  const port = Number(value.port);
+  const database = value.database?.trim();
+
+  if (!template || !host || !database || !Number.isInteger(port)) return undefined;
+  if (port < 1 || port > 65535) return undefined;
+
+  let url = template
+    .replaceAll('{host}', normalizeHostForUrl(host))
+    .replaceAll('{port}', String(port))
+    .replaceAll('{database}', database);
+
+  if (linkage.preserveSuffix !== false && value.suffix) {
+    url += value.suffix;
+  }
+  return url;
+};
+
+export const parseJdbcUrlByTemplate = (
+  linkage: DynamicFormJdbcUrlLinkage,
+  url?: string,
+): JdbcUrlStructuredValue | undefined => {
+  const template = linkage.template?.trim();
+  const value = url?.trim();
+  if (!template || !value) return undefined;
+
+  const { pattern, fieldOrder } = buildTemplateMatcher(template);
+  const match = value.match(pattern);
+  if (!match) return undefined;
+
+  const parsed: JdbcUrlStructuredValue = {};
+  fieldOrder.forEach((field, index) => {
+    const matchedValue = match[index + 1];
+    if (field === 'host') {
+      parsed.host = normalizeParsedHost(matchedValue);
+    } else if (field === 'port') {
+      const port = Number(matchedValue);
+      if (!Number.isInteger(port) || port < 1 || port > 65535) return;
+      parsed.port = port;
+    } else {
+      parsed.database = matchedValue.trim();
+    }
+  });
+
+  const suffix = match[fieldOrder.length + 1];
+  if (suffix) parsed.suffix = suffix;
+
+  if (!parsed.host || !parsed.port || !parsed.database) return undefined;
+  return parsed;
+};

--- a/yak-ops-ui/src/pages/data-source/types.ts
+++ b/yak-ops-ui/src/pages/data-source/types.ts
@@ -132,6 +132,17 @@ export interface DynamicFormVisibilityCondition {
   values?: unknown[];
 }
 
+/** JDBC URL 与结构化 Host / Port / Database 字段之间的双向联动描述。 */
+export interface DynamicFormJdbcUrlLinkage {
+  /** 例如 jdbc:mysql://{host}:{port}/{database}。 */
+  template: string;
+  hostField?: string;
+  portField?: string;
+  databaseField?: string;
+  /** 默认保留 URL 尾部的 ?query 或 ;properties。 */
+  preserveSuffix?: boolean;
+}
+
 export type SshAuthType = 'PASSWORD' | 'PRIVATE_KEY';
 
 /** 标准 SSH 隧道配置值，由 SSH Schema 组件统一消费。 */
@@ -157,7 +168,8 @@ export type DynamicFormFieldType =
   | 'TEXTAREA'
   | 'CUSTOM_SELECT'
   | 'DRIVER'
-  | 'SSH';
+  | 'SSH'
+  | 'JDBC_URL';
 
 export interface DynamicFormField {
   key: string;
@@ -173,6 +185,8 @@ export interface DynamicFormField {
   visibleWhen?:
     | DynamicFormVisibilityCondition
     | DynamicFormVisibilityCondition[];
+  /** JDBC_URL 标准组件使用的双向联动元数据。 */
+  urlLinkage?: DynamicFormJdbcUrlLinkage;
 }
 
 /**


### PR DESCRIPTION
## P1：Host / Port / Database / JDBC URL 自动联动

这次把 JDBC URL 从普通输入框提升成标准 Schema 能力，由插件声明 URL 模板，前端统一完成 Host / Port / Database 与 URL 的双向联动。

### Schema / 架构

- 新增标准字段类型 `JDBC_URL`。
- 新增 `urlLinkage` 元数据，支持：
  - `template`
  - `hostField`
  - `portField`
  - `databaseField`
  - `preserveSuffix`
- URL 模板使用 `{host}` / `{port}` / `{database}` 占位符。
- 新增 `JdbcUrlSchemaSupport`，统一装饰 JDBC 插件 Schema，前端不需要维护 dbType -> URL 格式硬编码。
- 同时兼容新版 `sections` 和旧版 `formFields`，Schema helper 做了 null-safe + 幂等处理。

### 前端双向联动

新增标准 `JdbcUrlField`：

- 修改 Host / Port / Database -> 自动生成 JDBC URL。
- 修改可识别的 JDBC URL -> 自动反向回填 Host / Port / Database。
- 编辑历史数据时，如果已有 URL 与结构化字段不一致或结构化字段缺失，会从 URL 自动补齐。
- 自动重建 URL 时保留已有 `?query` / `;properties` 尾部参数。
- 支持 IPv6 Host，生成 URL 时自动补 `[]`，反向解析时自动去除。
- 无法由模板识别的自定义 URL 保持用户输入，不强制覆盖。
- URL 中携带用户名密码等非标准形式时不误解析成 Host。
- 使用签名/ref 避免 URL -> 字段 -> URL 的循环更新。

### 当前插件支持

- MySQL：`jdbc:mysql://{host}:{port}/{database}`
- PostgreSQL：`jdbc:postgresql://{host}:{port}/{database}`
- Oracle：`jdbc:oracle:thin:@//{host}:{port}/{database}`
- 达梦：`jdbc:dm://{host}:{port}/{database}`
- Kingbase：`jdbc:kingbase8://{host}:{port}/{database}`
- Doris：`jdbc:mysql://{host}:{port}/{database}`

后续新增 JDBC 插件只需要声明模板，不需要再复制 React 联动代码。

### 与 SSH 能力兼容

- `jdbcUrl` 依赖 `sshTunnel` 父字段，并通过 `visibleWhen: sshTunnel.enabled = FALSY` 控制显示。
- 开启 SSH 后，复用现有动态字段隐藏逻辑自动隐藏并清除 `jdbcUrl`。
- SSH 场景继续以 Host / Port / Database 为权威配置，避免和现有后端“SSH 不允许自定义 JDBC URL”的安全约束冲突。

### 测试与检查

- 新增前端 URL codec Jest 测试：
  - 结构化字段生成 URL
  - URL 反向解析
  - query/property suffix 保留
  - Oracle Thin URL
  - IPv6
  - 不支持的自定义 URL 不误解析
- MySQL 插件测试增加 `JDBC_URL / urlLinkage / SSH visibleWhen` Schema 契约断言。
- 已确认前端 TypeScript target 为 `esnext`，`matchAll / replaceAll` 可用。
- Doris 模块本身已依赖 JDBC 模块，无需新增 Maven 模块依赖。
- 分支已整理为单一提交，当前相对 `main` 为 ahead 1 / behind 0。

### 验证说明

当前执行容器仍无法解析 `github.com`，因此无法 clone 完整仓库，本轮未实际执行 Maven、`npm run tsc` 和 Jest；建议由仓库 CI 或本地开发环境完成最终编译与测试验证。