### PR TITLE
refactor: model datasource plugin configuration states

### DIFF
--- a/yak-ops-ui/src/pages/data-source/components/DynamicDataSourceForm/hooks/pluginConfigState.test.ts
+++ b/yak-ops-ui/src/pages/data-source/components/DynamicDataSourceForm/hooks/pluginConfigState.test.ts
@@ -1,0 +1,74 @@
+import {
+  INITIAL_PLUGIN_CONFIG_STATE,
+  PLUGIN_CONFIG_STATUS,
+  pluginConfigStateReducer,
+} from './pluginConfigState';
+
+const section = {
+  key: 'connection',
+  title: '连接参数',
+  fields: [],
+};
+
+describe('datasource plugin config state model', () => {
+  it('moves from loading to ready with normalized sections', () => {
+    const loading = pluginConfigStateReducer(INITIAL_PLUGIN_CONFIG_STATE, {
+      type: 'LOAD_START',
+    });
+    expect(loading.status).toBe(PLUGIN_CONFIG_STATUS.LOADING);
+    expect(loading.sections).toEqual([]);
+
+    const ready = pluginConfigStateReducer(loading, {
+      type: 'LOAD_SUCCESS',
+      sections: [section],
+    });
+    expect(ready.status).toBe(PLUGIN_CONFIG_STATUS.READY);
+    expect(ready.sections).toEqual([section]);
+  });
+
+  it('distinguishes install required from load failure', () => {
+    const installRequired = pluginConfigStateReducer(
+      INITIAL_PLUGIN_CONFIG_STATE,
+      {
+        type: 'INSTALL_REQUIRED',
+        message: '请先安装插件',
+      },
+    );
+    expect(installRequired.status).toBe(
+      PLUGIN_CONFIG_STATUS.INSTALL_REQUIRED,
+    );
+    expect(installRequired.message).toBe('请先安装插件');
+
+    const loadFailed = pluginConfigStateReducer(INITIAL_PLUGIN_CONFIG_STATE, {
+      type: 'LOAD_FAILED',
+      message: '网络异常',
+    });
+    expect(loadFailed.status).toBe(PLUGIN_CONFIG_STATUS.LOAD_FAILED);
+    expect(loadFailed.message).toBe('网络异常');
+  });
+
+  it('keeps install failures retryable as install required', () => {
+    const installing = pluginConfigStateReducer(INITIAL_PLUGIN_CONFIG_STATE, {
+      type: 'INSTALL_START',
+    });
+    expect(installing.status).toBe(PLUGIN_CONFIG_STATUS.INSTALLING);
+
+    const failed = pluginConfigStateReducer(installing, {
+      type: 'INSTALL_FAILED',
+      message: '插件安装失败',
+    });
+    expect(failed.status).toBe(PLUGIN_CONFIG_STATUS.INSTALL_REQUIRED);
+    expect(failed.message).toBe('插件安装失败');
+  });
+
+  it('resets stale sections when a new load starts', () => {
+    const ready = pluginConfigStateReducer(INITIAL_PLUGIN_CONFIG_STATE, {
+      type: 'LOAD_SUCCESS',
+      sections: [section],
+    });
+    const loading = pluginConfigStateReducer(ready, { type: 'LOAD_START' });
+
+    expect(loading.status).toBe(PLUGIN_CONFIG_STATUS.LOADING);
+    expect(loading.sections).toEqual([]);
+  });
+});

--- a/yak-ops-ui/src/pages/data-source/components/DynamicDataSourceForm/hooks/pluginConfigState.ts
+++ b/yak-ops-ui/src/pages/data-source/components/DynamicDataSourceForm/hooks/pluginConfigState.ts
@@ -1,0 +1,77 @@
+import type { DynamicFormSection } from '../../../types';
+
+export const PLUGIN_CONFIG_STATUS = {
+  IDLE: 'IDLE',
+  LOADING: 'LOADING',
+  READY: 'READY',
+  INSTALL_REQUIRED: 'INSTALL_REQUIRED',
+  INSTALLING: 'INSTALLING',
+  LOAD_FAILED: 'LOAD_FAILED',
+} as const;
+
+export type PluginConfigStatus =
+  (typeof PLUGIN_CONFIG_STATUS)[keyof typeof PLUGIN_CONFIG_STATUS];
+
+export interface PluginConfigState {
+  status: PluginConfigStatus;
+  sections: DynamicFormSection[];
+  message?: string;
+}
+
+export type PluginConfigAction =
+  | { type: 'RESET' }
+  | { type: 'LOAD_START' }
+  | { type: 'LOAD_SUCCESS'; sections: DynamicFormSection[] }
+  | { type: 'INSTALL_REQUIRED'; message?: string }
+  | { type: 'INSTALL_START' }
+  | { type: 'INSTALL_FAILED'; message?: string }
+  | { type: 'LOAD_FAILED'; message?: string };
+
+export const INITIAL_PLUGIN_CONFIG_STATE: PluginConfigState = {
+  status: PLUGIN_CONFIG_STATUS.IDLE,
+  sections: [],
+};
+
+export const pluginConfigStateReducer = (
+  _state: PluginConfigState,
+  action: PluginConfigAction,
+): PluginConfigState => {
+  switch (action.type) {
+    case 'LOAD_START':
+      return {
+        status: PLUGIN_CONFIG_STATUS.LOADING,
+        sections: [],
+      };
+    case 'LOAD_SUCCESS':
+      return {
+        status: PLUGIN_CONFIG_STATUS.READY,
+        sections: action.sections,
+      };
+    case 'INSTALL_REQUIRED':
+      return {
+        status: PLUGIN_CONFIG_STATUS.INSTALL_REQUIRED,
+        sections: [],
+        message: action.message,
+      };
+    case 'INSTALL_START':
+      return {
+        status: PLUGIN_CONFIG_STATUS.INSTALLING,
+        sections: [],
+      };
+    case 'INSTALL_FAILED':
+      return {
+        status: PLUGIN_CONFIG_STATUS.INSTALL_REQUIRED,
+        sections: [],
+        message: action.message,
+      };
+    case 'LOAD_FAILED':
+      return {
+        status: PLUGIN_CONFIG_STATUS.LOAD_FAILED,
+        sections: [],
+        message: action.message,
+      };
+    case 'RESET':
+    default:
+      return INITIAL_PLUGIN_CONFIG_STATE;
+  }
+};

--- a/yak-ops-ui/src/pages/data-source/components/DynamicDataSourceForm/hooks/usePluginFormConfig.ts
+++ b/yak-ops-ui/src/pages/data-source/components/DynamicDataSourceForm/hooks/usePluginFormConfig.ts
@@ -1,8 +1,17 @@
 import { API_SUCCESS_CODE } from '@/services/http/response';
 import type { FormInstance } from 'antd';
-import { useEffect, useState } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useReducer,
+  useRef,
+} from 'react';
 
-import { fetchDataSourcePluginConfig } from '../../../service';
+import {
+  fetchDataSourcePluginConfig,
+  installDataSourcePlugin,
+} from '../../../service';
 import type { DynamicFormField } from '../../../types';
 import {
   flattenFormSectionFields,
@@ -10,54 +19,162 @@ import {
   normalizeFormSections,
   patchEmptyWithDefaults,
 } from '../utils/formUtils';
+import {
+  INITIAL_PLUGIN_CONFIG_STATE,
+  PLUGIN_CONFIG_STATUS,
+  pluginConfigStateReducer,
+} from './pluginConfigState';
+
+const errorMessage = (error: unknown, fallback: string) =>
+  error instanceof Error && error.message ? error.message : fallback;
 
 /**
- * 保留给仍在复用该 Hook 的旧表单入口。
- * 数据源主编辑器已经自行管理 Schema 加载，这里与主流程共享同一 service 和归一化规则。
+ * 数据源插件配置统一生命周期。
+ *
+ * 主编辑器与旧入口共享同一套加载、安装、重试、竞态保护和 Schema 归一化逻辑，
+ * 避免把 loading / needInstall / installing / loadError 等布尔状态散落在页面组件中。
  */
 export function usePluginFormConfig(params: {
   dbType: string;
   configForm: FormInstance;
+  initialConfig?: Record<string, unknown>;
+  /** 主编辑器切换数据源类型时需要清空旧配置；旧入口默认保持原行为。 */
+  resetOnLoad?: boolean;
   intl?: unknown;
 }) {
-  const { dbType, configForm } = params;
-  const [formConfig, setFormConfig] = useState<DynamicFormField[]>([]);
-  const [loading, setLoading] = useState(false);
+  const {
+    dbType,
+    configForm,
+    initialConfig,
+    resetOnLoad = false,
+  } = params;
+  const [state, dispatch] = useReducer(
+    pluginConfigStateReducer,
+    INITIAL_PLUGIN_CONFIG_STATE,
+  );
+  const requestSeqRef = useRef(0);
 
-  useEffect(() => {
-    let cancelled = false;
+  const loadFormConfig = useCallback(async () => {
+    if (!dbType) {
+      requestSeqRef.current += 1;
+      dispatch({ type: 'RESET' });
+      if (resetOnLoad) configForm.resetFields();
+      return false;
+    }
 
-    async function run() {
-      try {
-        setLoading(true);
-        const response = await fetchDataSourcePluginConfig(dbType);
-        if (cancelled) return;
+    const requestSeq = requestSeqRef.current + 1;
+    requestSeqRef.current = requestSeq;
+    dispatch({ type: 'LOAD_START' });
+    if (resetOnLoad) configForm.resetFields();
 
-        if (response?.code !== API_SUCCESS_CODE) {
-          setFormConfig([]);
-          return;
-        }
+    try {
+      const response = await fetchDataSourcePluginConfig(dbType);
+      if (requestSeq !== requestSeqRef.current) return false;
 
-        const sections = normalizeFormSections(response.data);
-        const fields = flattenFormSectionFields(sections);
-        setFormConfig(fields);
+      if (response?.code !== API_SUCCESS_CODE) {
+        dispatch({
+          type: 'LOAD_FAILED',
+          message:
+            response?.msg ||
+            response?.message ||
+            '数据源插件配置加载失败，请稍后重试',
+        });
+        return false;
+      }
 
-        const defaults = getConfigInitialValues(fields);
+      const data = response.data || { formFields: [] };
+      if (data.installRequired) {
+        dispatch({
+          type: 'INSTALL_REQUIRED',
+          message: data.installHint || '当前数据源插件尚未安装',
+        });
+        return false;
+      }
+
+      const sections = normalizeFormSections(data);
+      const fields = flattenFormSectionFields(sections);
+      const defaults = getConfigInitialValues(fields);
+
+      if (resetOnLoad) {
+        configForm.setFieldsValue({
+          ...defaults,
+          ...(initialConfig || {}),
+        });
+      } else {
         const current = configForm.getFieldsValue(true);
         const patch = patchEmptyWithDefaults(current, defaults);
         if (Object.keys(patch).length > 0) configForm.setFieldsValue(patch);
-      } catch {
-        if (!cancelled) setFormConfig([]);
-      } finally {
-        if (!cancelled) setLoading(false);
       }
+
+      dispatch({ type: 'LOAD_SUCCESS', sections });
+      return true;
+    } catch (error) {
+      if (requestSeq !== requestSeqRef.current) return false;
+      dispatch({
+        type: 'LOAD_FAILED',
+        message: errorMessage(error, '数据源插件配置加载失败，请稍后重试'),
+      });
+      return false;
+    }
+  }, [configForm, dbType, initialConfig, resetOnLoad]);
+
+  const installPlugin = useCallback(async () => {
+    if (!dbType || state.status === PLUGIN_CONFIG_STATUS.INSTALLING) {
+      return false;
     }
 
-    if (dbType) void run();
-    return () => {
-      cancelled = true;
-    };
-  }, [configForm, dbType]);
+    // 使仍在进行中的加载请求失效；切换数据源类型或卸载组件时也会推进该序号。
+    const requestSeq = requestSeqRef.current + 1;
+    requestSeqRef.current = requestSeq;
+    dispatch({ type: 'INSTALL_START' });
 
-  return { formConfig, loading };
+    try {
+      const response = await installDataSourcePlugin(dbType);
+      if (requestSeq !== requestSeqRef.current) return false;
+
+      if (response?.code !== API_SUCCESS_CODE) {
+        dispatch({
+          type: 'INSTALL_FAILED',
+          message:
+            response?.msg || response?.message || '数据源插件安装失败，请重试',
+        });
+        return false;
+      }
+
+      await loadFormConfig();
+      return true;
+    } catch (error) {
+      if (requestSeq !== requestSeqRef.current) return false;
+      dispatch({
+        type: 'INSTALL_FAILED',
+        message: errorMessage(error, '数据源插件安装失败，请重试'),
+      });
+      return false;
+    }
+  }, [dbType, loadFormConfig, state.status]);
+
+  useEffect(() => {
+    void loadFormConfig();
+    return () => {
+      requestSeqRef.current += 1;
+    };
+  }, [loadFormConfig]);
+
+  const formConfig = useMemo<DynamicFormField[]>(
+    () => flattenFormSectionFields(state.sections),
+    [state.sections],
+  );
+
+  return {
+    // 保留旧 Hook 返回值，避免影响仍在复用的入口。
+    formConfig,
+    loading: state.status === PLUGIN_CONFIG_STATUS.LOADING,
+    // 新版状态模型。
+    formSections: state.sections,
+    status: state.status,
+    message: state.message,
+    installing: state.status === PLUGIN_CONFIG_STATUS.INSTALLING,
+    reload: loadFormConfig,
+    installPlugin,
+  };
 }

--- a/yak-ops-ui/src/pages/data-source/components/DynamicDataSourceForm/index.tsx
+++ b/yak-ops-ui/src/pages/data-source/components/DynamicDataSourceForm/index.tsx
@@ -1,4 +1,3 @@
-import { API_SUCCESS_CODE } from '@/services/http/response';
 import { InfoCircleOutlined, LoadingOutlined } from '@ant-design/icons';
 import { useIntl } from '@umijs/max';
 import {
@@ -15,13 +14,9 @@ import {
 import type { FormInstance } from 'antd';
 import { Code2, FlaskConical, ShieldCheck } from 'lucide-react';
 import type { ReactNode } from 'react';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useEffect } from 'react';
 
 import DatabaseIcons from '../../icon/DatabaseIcons';
-import {
-  fetchDataSourcePluginConfig,
-  installDataSourcePlugin,
-} from '../../service';
 import type {
   DynamicDataSourceFormProps,
   DynamicFormField,
@@ -34,13 +29,12 @@ import SshTunnelManager, {
   getSshTunnelValidationMessage,
 } from '../SshTunnelManager';
 import CustomKVList from './components/CustomKVList';
+import { PLUGIN_CONFIG_STATUS } from './hooks/pluginConfigState';
+import { usePluginFormConfig } from './hooks/usePluginFormConfig';
 import {
-  flattenFormSectionFields,
-  getConfigInitialValues,
   getFieldDefaultValue,
   getFieldDependencies,
   isDynamicFieldVisible,
-  normalizeFormSections,
   transformRules,
 } from './utils/formUtils';
 
@@ -127,12 +121,18 @@ const DynamicDataSourceForm = ({
   initialConfig,
 }: DynamicDataSourceFormProps) => {
   const intl = useIntl();
-  const [formSections, setFormSections] = useState<DynamicFormSection[]>([]);
-  const [loading, setLoading] = useState(false);
-  const [needInstall, setNeedInstall] = useState(false);
-  const [installing, setInstalling] = useState(false);
-  const [loadErrMsg, setLoadErrMsg] = useState('');
-  const requestSeqRef = useRef(0);
+  const {
+    formSections,
+    status: pluginStatus,
+    message: pluginMessage,
+    reload: reloadPluginConfig,
+    installPlugin,
+  } = usePluginFormConfig({
+    dbType,
+    configForm,
+    initialConfig,
+    resetOnLoad: true,
+  });
 
   useEffect(() => {
     if (operateType !== DataSourceOperateType.Create) return;
@@ -141,90 +141,6 @@ const DynamicDataSourceForm = ({
       form.setFieldValue('environment', DEFAULT_ENVIRONMENT);
     }
   }, [form, operateType]);
-
-  const loadFormConfig = useCallback(
-    async (currentDbType: string) => {
-      const requestSeq = requestSeqRef.current + 1;
-      requestSeqRef.current = requestSeq;
-      setLoading(true);
-      setNeedInstall(false);
-      setLoadErrMsg('');
-      setFormSections([]);
-      configForm.resetFields();
-
-      try {
-        const response = await fetchDataSourcePluginConfig(currentDbType);
-        if (requestSeq !== requestSeqRef.current) return;
-
-        if (response.code !== API_SUCCESS_CODE) {
-          setNeedInstall(true);
-          setLoadErrMsg(
-            response.msg || response.message || '数据源插件配置暂不可用',
-          );
-          return;
-        }
-
-        const data = response.data || { formFields: [] };
-        if (data.installRequired) {
-          setNeedInstall(true);
-          setLoadErrMsg(data.installHint || '请先安装数据源插件');
-          return;
-        }
-
-        const sections = normalizeFormSections(data);
-        const fields = flattenFormSectionFields(sections);
-        setFormSections(sections);
-        configForm.setFieldsValue({
-          ...getConfigInitialValues(fields),
-          ...(initialConfig || {}),
-        });
-      } catch (error) {
-        if (requestSeq !== requestSeqRef.current) return;
-        setNeedInstall(true);
-        setLoadErrMsg(
-          error instanceof Error
-            ? error.message
-            : intl.formatMessage({
-                id: 'pages.datasource.form.loadConfigFail',
-                defaultMessage: '数据源配置加载失败',
-              }),
-        );
-      } finally {
-        if (requestSeq === requestSeqRef.current) setLoading(false);
-      }
-    },
-    [configForm, initialConfig, intl],
-  );
-
-  useEffect(() => {
-    if (!dbType) {
-      requestSeqRef.current += 1;
-      setFormSections([]);
-      setNeedInstall(false);
-      setLoadErrMsg('');
-      setLoading(false);
-      configForm.resetFields();
-      return undefined;
-    }
-
-    void loadFormConfig(dbType);
-    return () => {
-      requestSeqRef.current += 1;
-    };
-  }, [configForm, dbType, loadFormConfig]);
-
-  const installPlugin = async () => {
-    if (!dbType || installing) return;
-    try {
-      setInstalling(true);
-      const response = await installDataSourcePlugin(dbType);
-      if (response.code !== API_SUCCESS_CODE) return;
-      message.success('插件安装成功');
-      await loadFormConfig(dbType);
-    } finally {
-      setInstalling(false);
-    }
-  };
 
   const validateField = (key: string) => {
     window.setTimeout(() => {
@@ -419,16 +335,72 @@ const DynamicDataSourceForm = ({
     );
   };
 
-  if (loading) {
+  const renderPluginState = () => {
+    if (
+      pluginStatus === PLUGIN_CONFIG_STATUS.IDLE ||
+      pluginStatus === PLUGIN_CONFIG_STATUS.READY
+    ) {
+      return null;
+    }
+
+    if (
+      pluginStatus === PLUGIN_CONFIG_STATUS.LOADING ||
+      pluginStatus === PLUGIN_CONFIG_STATUS.INSTALLING
+    ) {
+      return (
+        <div className="mt-4 flex min-h-[96px] items-center justify-center rounded-lg border border-[#eef0f3] bg-[#fafbfc]">
+          <div className="flex items-center gap-2 text-sm text-[#667085]">
+            <LoadingOutlined />
+            <span>
+              {pluginStatus === PLUGIN_CONFIG_STATUS.INSTALLING
+                ? '正在安装数据源插件...'
+                : '正在加载数据源配置...'}
+            </span>
+          </div>
+        </div>
+      );
+    }
+
+    const installRequired =
+      pluginStatus === PLUGIN_CONFIG_STATUS.INSTALL_REQUIRED;
     return (
-      <div className="flex min-h-[160px] items-center justify-center rounded-lg border border-[#eef0f3] bg-[#fafbfc]">
-        <div className="flex items-center gap-2 text-sm text-[#8a8f99]">
-          <LoadingOutlined />
-          <span>正在加载数据源配置...</span>
+      <div className="mt-4 rounded-lg border border-[#e4e7ec] bg-[#fafafa] px-3.5 py-3">
+        <div className="flex items-center justify-between gap-4">
+          <div className="min-w-0">
+            <div className="text-[13px] font-medium leading-5 text-[#344054]">
+              {installRequired
+                ? '当前数据源插件尚未安装'
+                : '数据源插件配置加载失败'}
+            </div>
+            <div className="mt-1 text-xs leading-5 text-[#98a2b3]">
+              {pluginMessage ||
+                (installRequired
+                  ? '安装插件后即可继续配置当前数据源。'
+                  : '请检查服务状态或网络后重新加载。')}
+            </div>
+          </div>
+          <Button
+            size="small"
+            className="shrink-0"
+            onClick={() => {
+              if (installRequired) {
+                void installPlugin().then((installed) => {
+                  if (installed) message.success('插件安装成功');
+                });
+                return;
+              }
+              void reloadPluginConfig();
+            }}
+          >
+            <span className="inline-flex items-center gap-1.5">
+              {installRequired ? '安装插件' : '重新加载'}
+              <DatabaseIcons dbType={dbType} height="15" width="15" />
+            </span>
+          </Button>
         </div>
       </div>
     );
-  }
+  };
 
   return (
     <div className="bg-white">
@@ -511,33 +483,7 @@ const DynamicDataSourceForm = ({
         </Form>
       </section>
 
-      {needInstall && (
-        <div className="mt-4 rounded-lg border border-dashed border-[#d6e4ff] bg-[#f7faff] px-3.5 py-3">
-          <div className="flex items-center justify-between gap-4">
-            <div className="min-w-0">
-              <div className="text-[13px] leading-5 text-[#475467]">
-                当前插件配置暂不可用，请确认对应插件已经随服务部署。
-              </div>
-              {loadErrMsg && (
-                <div className="mt-1 truncate text-xs text-[#98a2b3]">
-                  {loadErrMsg}
-                </div>
-              )}
-            </div>
-            <Button
-              size="small"
-              loading={installing}
-              className="shrink-0"
-              onClick={() => void installPlugin()}
-            >
-              <span className="inline-flex items-center gap-1.5">
-                重新检测
-                <DatabaseIcons dbType={dbType} height="15" width="15" />
-              </span>
-            </Button>
-          </div>
-        </div>
-      )}
+      {renderPluginState()}
 
       {formSections.length > 0 && (
         <Form


### PR DESCRIPTION
## P1：插件状态模型重构

这次把数据源动态表单里的插件配置生命周期，从多个布尔状态重构成明确的状态机，解决“插件未安装”和“配置加载失败”被混为一谈的问题。

### 状态模型

新增统一状态：

- `IDLE`
- `LOADING`
- `READY`
- `INSTALL_REQUIRED`
- `INSTALLING`
- `LOAD_FAILED`

并新增纯 reducer 管理状态转换，不再由页面同时维护 `loading / needInstall / installing / loadErrMsg`。

### 统一 Hook

升级 `usePluginFormConfig`，现在统一负责：

- 插件 Schema 加载；
- `sections / formFields` 归一化；
- 默认值与编辑初始值回填；
- 插件安装；
- 加载重试；
- 请求竞态保护；
- 插件状态和错误信息输出。

同时保留原来的 `formConfig / loading` 返回值，兼容可能还在复用旧 Hook 的入口。

### 状态语义修正

之前：

- API 非成功 -> `needInstall = true`
- 请求异常 -> `needInstall = true`
- `installRequired = true` -> `needInstall = true`

三个场景最终都会展示同一个“重新检测”按钮，但该按钮实际调用的是插件安装接口。

现在：

- 后端明确返回 `installRequired` -> `INSTALL_REQUIRED` -> 展示 **安装插件**；
- HTTP/API 非成功或请求异常 -> `LOAD_FAILED` -> 展示 **重新加载**；
- 安装失败 -> 回到可重试的 `INSTALL_REQUIRED`，并展示安装失败原因；
- 安装成功 -> 自动重新加载最新 Schema。

### 竞态保护

- Schema 加载使用 request sequence 防止旧请求覆盖新数据源类型。
- 插件安装也使用同一套 sequence 保护。
- 用户在安装 A 插件期间切换到 B，A 的旧响应不会再覆盖 B 的状态。
- Drawer 卸载后未完成请求也会自动失效。

### UI 行为

- 基础信息区域始终保持可见，不再因为插件 Schema 加载而整块闪烁消失。
- 插件区域根据状态独立展示：
  - 正在加载配置；
  - 正在安装插件；
  - 当前插件尚未安装；
  - 插件配置加载失败；
  - 已就绪时正常渲染 Section / Collapse。
- 继续保持当前白灰、紧凑的数据源 Drawer 风格。

### 测试

新增 `pluginConfigState.test.ts`，覆盖：

- LOADING -> READY；
- INSTALL_REQUIRED 与 LOAD_FAILED 的语义区分；
- INSTALLING -> 安装失败后保持可重试；
- 新一轮加载会清除旧 sections，避免旧 Schema 残留。

### 兼容性

- 不修改后端 API 和插件 Schema 协议。
- 不修改创建 / 编辑 / 连接测试 / 保存 payload。
- Driver / SSH / dependsOn / visibleWhen / JDBC URL 联动保持不变。
- 分支已整理为单一提交，当前相对 `main` 为 ahead 1 / behind 0。

### 验证说明

当前执行环境仍无法通过 `github.com` clone 完整仓库，因此本轮未实际执行 `npm run tsc` / Jest；已进行 TypeScript 结构、Hook 依赖和状态转换静态自查，建议由仓库 CI 或本地开发环境完成最终编译验证。