### PR TITLE
refactor: reorder datasource driver and advanced properties

### DIFF
--- a/yak-ops-ui/src/pages/data-source/components/AddOrEditDataSourceModal.tsx
+++ b/yak-ops-ui/src/pages/data-source/components/AddOrEditDataSourceModal.tsx
@@ -17,7 +17,11 @@ import type {
   DataSourceRecord,
 } from "../types";
 import { DataSourceOperateType } from "../types";
-import { buildSubmitPayload, parseOriginalJson } from "../utils";
+import {
+  buildSubmitPayload,
+  normalizeConnectionFormValues,
+  parseOriginalJson,
+} from "../utils";
 import DataSourceTypeSelector from "./DataSourceTypeSelector";
 import DynamicDataSourceForm from "./DynamicDataSourceForm";
 import "./DataSourceEditorDrawer.less";
@@ -124,7 +128,9 @@ const AddOrEditDataSourceModal = forwardRef<DataSourceModalRef>((_, ref) => {
 
     try {
       setTesting(true);
-      const connectionValues = await configForm.validateFields();
+      const connectionValues = normalizeConnectionFormValues(
+        await configForm.validateFields(),
+      );
       const response = await testDataSourceConnectionWithParams({
         dataSourceId: isEditMode ? currentRecord?.id : undefined,
         dbType: selectedDbType,

--- a/yak-ops-ui/src/pages/data-source/components/DynamicDataSourceForm/components/CustomKVList.tsx
+++ b/yak-ops-ui/src/pages/data-source/components/DynamicDataSourceForm/components/CustomKVList.tsx
@@ -1,110 +1,133 @@
-import {MinusCircleOutlined, PlusOutlined} from "@ant-design/icons";
-import {Button, Form, Input} from "antd";
+import { DeleteOutlined, PlusOutlined } from '@ant-design/icons';
+import { Button, Form, Input } from 'antd';
+import type { Rule } from 'antd/es/form';
 
-export default function CustomKVList(props: { intl: any; field: any }) {
-  const {intl, field} = props;
+const CustomKVList = ({ intl, field }: any) => {
+  const form = Form.useFormInstance();
+  const maxRows = field?.maxRows ?? 50;
+
+  const keyRules = (currentIndex: number): Rule[] => [
+    { required: true, message: '请输入参数名' },
+    {
+      validator: async (_rule, value) => {
+        const normalized = String(value ?? '').trim();
+        if (normalized.length > 128) {
+          throw new Error('参数名不能超过 128 个字符');
+        }
+        if (!normalized) return;
+
+        const rows = form.getFieldValue(field.key) || [];
+        const duplicated = rows.some(
+          (row: any, index: number) =>
+            index !== currentIndex &&
+            String(row?.key ?? '').trim() === normalized,
+        );
+        if (duplicated) {
+          throw new Error('参数名不能重复');
+        }
+      },
+    },
+  ];
+
+  const valueRules: Rule[] = [
+    {
+      validator: async (_rule, value) => {
+        if (value !== undefined && value !== null && String(value).length > 1024) {
+          throw new Error('参数值不能超过 1024 个字符');
+        }
+      },
+    },
+  ];
 
   return (
-    <Form.Item label={field.label} style={{marginBottom: 18}}>
-      <Form.List name={field.key}>
-        {(fields, {add, remove}) => (
-          <div style={{width: "100%"}}>
-            <div
-              style={{
-                display: "flex",
-                flexDirection: "column",
-                gap: 10,
-              }}
-            >
-              {fields.map(({key, name, ...restField}) => (
-                <div
-                  key={key}
-                  style={{
-                    display: "grid",
-                    gridTemplateColumns: "1fr 1fr 28px",
-                    gap: 10,
-                    alignItems: "center",
-                  }}
-                >
-                  <Form.Item
-                    {...restField}
-                    name={[name, "key"]}
-                    style={{marginBottom: 0}}
-                    rules={[
-                      {
-                        required: true,
-                        message: intl.formatMessage({
-                          id: "pages.datasource.form.other.keyRequired",
-                          defaultMessage: "key can not be null",
-                        }),
-                      },
-                    ]}
-                  >
-                    <Input
-                      placeholder={intl.formatMessage({
-                        id: "pages.datasource.form.other.keyPlaceholder",
-                        defaultMessage: "key",
-                      })}
-                    />
-                  </Form.Item>
-
-                  <Form.Item
-                    {...restField}
-                    name={[name, "value"]}
-                    style={{marginBottom: 0}}
-                    rules={[
-                      {
-                        required: true,
-                        message: intl.formatMessage({
-                          id: "pages.datasource.form.other.valueRequired",
-                          defaultMessage: "value can not be null",
-                        }),
-                      },
-                    ]}
-                  >
-                    <Input
-                      placeholder={intl.formatMessage({
-                        id: "pages.datasource.form.other.valuePlaceholder",
-                        defaultMessage: "value",
-                      })}
-                    />
-                  </Form.Item>
-
-                  <div
-                    style={{
-                      display: "flex",
-                      justifyContent: "center",
-                      alignItems: "center",
-                      color: "#98A2B3",
-                      cursor: "pointer",
-                      fontSize: 16,
-                    }}
-                    onClick={() => remove(name)}
-                  >
-                    <MinusCircleOutlined/>
-                  </div>
-                </div>
-              ))}
-            </div>
-
-            <Form.Item style={{marginBottom: 0, marginTop: 12}}>
-              <Button
-                type="dashed"
-                onClick={() => add({key: "", value: ""})}
-                block
-                icon={<PlusOutlined/>}
-                style={{borderRadius: 16}}
-                className="h-8 rounded-[10px] border-[#D0D5DD] bg-[#FCFCFD] text-[#475467] transition-all duration-200 hover:border-[hsl(231 48% 48%)] hover:bg-[hsl(231 48% 48%)] hover:text-[hsl(231 48% 48%)] active:border-[#98A2B3] active:bg-[#F2F4F7]"
-              >
-                {intl.formatMessage({
-                  id: "pages.datasource.form.other.addConnSetting",
-                  defaultMessage: "Add Database Connection Settings",
-                })}
-              </Button>
-            </Form.Item>
+    <div className="mb-3">
+      <div className="mb-2">
+        <div className="text-[13px] font-medium leading-5 text-[#344054]">
+          {field.label}
+        </div>
+        {field.placeholder && (
+          <div className="mt-0.5 text-[11px] leading-4 text-[#98a2b3]">
+            {field.placeholder}
           </div>
         )}
+      </div>
+
+      <Form.List name={field.key}>
+        {(fields, { add, remove }) => {
+          const canAdd = fields.length < maxRows;
+          return (
+            <div className="overflow-hidden rounded-lg border border-[#e7e9ed] bg-white">
+              <div className="grid grid-cols-[minmax(0,1fr)_minmax(0,1fr)_36px] items-center gap-2 border-b border-[#eef0f3] bg-[#fafbfc] px-3 py-2 text-[11px] font-medium text-[#667085]">
+                <span>参数名</span>
+                <span>参数值</span>
+                <span />
+              </div>
+
+              {fields.length > 0 ? (
+                <div className="divide-y divide-[#f0f1f3]">
+                  {fields.map(({ key, name, ...restField }) => (
+                    <div
+                      key={key}
+                      className="grid grid-cols-[minmax(0,1fr)_minmax(0,1fr)_36px] items-start gap-2 px-3 py-2"
+                    >
+                      <Form.Item
+                        {...restField}
+                        name={[name, 'key']}
+                        rules={keyRules(name)}
+                        className="!mb-0"
+                      >
+                        <Input variant="filled" placeholder="例如：useSSL" />
+                      </Form.Item>
+
+                      <Form.Item
+                        {...restField}
+                        name={[name, 'value']}
+                        rules={valueRules}
+                        className="!mb-0"
+                      >
+                        <Input variant="filled" placeholder="例如：false" />
+                      </Form.Item>
+
+                      <Button
+                        type="text"
+                        size="small"
+                        danger
+                        className="!h-8 !w-8 !px-0"
+                        icon={<DeleteOutlined />}
+                        aria-label="删除扩展参数"
+                        onClick={() => remove(name)}
+                      />
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <div className="px-3 py-5 text-center text-xs text-[#98a2b3]">
+                  暂无扩展参数
+                </div>
+              )}
+
+              <div className="flex justify-end border-t border-[#eef0f3] bg-[#fcfcfd] px-3 py-2">
+                <Button
+                  type="text"
+                  size="small"
+                  icon={<PlusOutlined />}
+                  disabled={!canAdd}
+                  onClick={() => add({ key: '', value: '' })}
+                >
+                  {canAdd
+                    ? intl.formatMessage({
+                        id: 'pages.datasource.form.other.addConnSetting',
+                        defaultMessage: '新增参数',
+                      })
+                    : `最多 ${maxRows} 条`}
+                </Button>
+              </div>
+            </div>
+          );
+        }}
       </Form.List>
-    </Form.Item>
+    </div>
   );
-}
+};
+
+export default CustomKVList;

--- a/yak-ops-ui/src/pages/data-source/components/DynamicDataSourceForm/hooks/usePluginFormConfig.ts
+++ b/yak-ops-ui/src/pages/data-source/components/DynamicDataSourceForm/hooks/usePluginFormConfig.ts
@@ -16,6 +16,7 @@ import type { DynamicFormField } from '../../../types';
 import {
   flattenFormSectionFields,
   getConfigInitialValues,
+  normalizeConfigValuesForForm,
   normalizeFormSections,
   patchEmptyWithDefaults,
 } from '../utils/formUtils';
@@ -98,12 +99,15 @@ export function usePluginFormConfig(params: {
       if (resetOnLoad) {
         configForm.setFieldsValue({
           ...defaults,
-          ...(initialConfig || {}),
+          ...normalizeConfigValuesForForm(fields, initialConfig),
         });
       } else {
-        const current = configForm.getFieldsValue(true);
+        const current = normalizeConfigValuesForForm(
+          fields,
+          configForm.getFieldsValue(true),
+        );
         const patch = patchEmptyWithDefaults(current, defaults);
-        if (Object.keys(patch).length > 0) configForm.setFieldsValue(patch);
+        configForm.setFieldsValue({ ...current, ...patch });
       }
 
       dispatch({ type: 'LOAD_SUCCESS', sections });

--- a/yak-ops-ui/src/pages/data-source/components/DynamicDataSourceForm/utils/formUtils.test.ts
+++ b/yak-ops-ui/src/pages/data-source/components/DynamicDataSourceForm/utils/formUtils.test.ts
@@ -3,7 +3,9 @@ import {
   getConfigInitialValues,
   getFieldDependencies,
   isDynamicFieldVisible,
+  normalizeConfigValuesForForm,
   normalizeFormSections,
+  toKeyValueRows,
   transformRules,
 } from './formUtils';
 
@@ -58,6 +60,20 @@ describe('dynamic data source form utils', () => {
         },
       ]),
     ).toEqual({ port: 3306 });
+  });
+
+  it('converts object properties into key value rows for editing', () => {
+    expect(toKeyValueRows({ useSSL: false, serverTimezone: 'UTC' })).toEqual([
+      { key: 'useSSL', value: 'false' },
+      { key: 'serverTimezone', value: 'UTC' },
+    ]);
+
+    expect(
+      normalizeConfigValuesForForm(
+        [field({ key: 'properties', type: 'CUSTOM_SELECT' })],
+        { properties: { useSSL: 'false' } },
+      ),
+    ).toEqual({ properties: [{ key: 'useSSL', value: 'false' }] });
   });
 
   it('maps visibleWhen conditions to dependsOn and evaluates equals', () => {
@@ -149,5 +165,41 @@ describe('dynamic data source form utils', () => {
     expect(sections[0].fields[0].visibleWhen).toEqual([
       { field: 'enabled', operator: 'TRUTHY' },
     ]);
+  });
+
+  it('orders standard capability sections and upgrades legacy properties textarea', () => {
+    const sections = normalizeFormSections({
+      sections: [
+        {
+          key: 'connection',
+          title: '连接参数',
+          fields: [field({ key: 'host' })],
+        },
+        {
+          key: 'ssh',
+          title: 'SSH 隧道',
+          fields: [field({ key: 'sshTunnel', type: 'SSH' })],
+        },
+        {
+          key: 'driver',
+          title: '驱动配置',
+          fields: [field({ key: 'driverClassName' })],
+        },
+        {
+          key: 'advanced',
+          title: '高级配置',
+          fields: [field({ key: 'properties', type: 'TEXTAREA' })],
+        },
+      ],
+    });
+
+    expect(sections.map((section) => section.key)).toEqual([
+      'connection',
+      'driver',
+      'ssh',
+      'advanced',
+    ]);
+    expect(sections[3].fields[0].type).toBe('CUSTOM_SELECT');
+    expect(sections[3].fields[0].placeholder).toContain('useSSL = false');
   });
 });

--- a/yak-ops-ui/src/pages/data-source/components/DynamicDataSourceForm/utils/formUtils.ts
+++ b/yak-ops-ui/src/pages/data-source/components/DynamicDataSourceForm/utils/formUtils.ts
@@ -9,6 +9,11 @@ import type {
   DynamicFormVisibilityOperator,
 } from '../../../types';
 
+export interface DynamicKeyValueRow {
+  key: string;
+  value: string;
+}
+
 export const transformRules = (
   rules: DynamicFormFieldRule[] | undefined,
   fieldType?: DynamicFormField['type'],
@@ -34,6 +39,40 @@ export const transformRules = (
   });
 };
 
+/** 将历史 JSON 对象或 JSON 字符串统一转换成 Key / Value 行数据。 */
+export const toKeyValueRows = (value: unknown): DynamicKeyValueRow[] => {
+  if (value === undefined || value === null || value === '') return [];
+
+  if (Array.isArray(value)) {
+    return value
+      .filter((item) => item && typeof item === 'object')
+      .map((item) => {
+        const row = item as Record<string, unknown>;
+        return {
+          key: String(row.key ?? ''),
+          value: String(row.value ?? ''),
+        };
+      });
+  }
+
+  if (typeof value === 'string') {
+    try {
+      return toKeyValueRows(JSON.parse(value));
+    } catch {
+      return [];
+    }
+  }
+
+  if (typeof value === 'object') {
+    return Object.entries(value as Record<string, unknown>).map(([key, rowValue]) => ({
+      key,
+      value: rowValue === undefined || rowValue === null ? '' : String(rowValue),
+    }));
+  }
+
+  return [];
+};
+
 export const getConfigInitialValues = (fields: DynamicFormField[]) => {
   const initialValues: Record<string, unknown> = {};
   fields.forEach((field) => {
@@ -54,19 +93,28 @@ export const getFieldDefaultValue = (field: DynamicFormField) => {
     case 'SWITCH':
       return typeof value === 'boolean' ? value : value === 'true';
     case 'CUSTOM_SELECT':
-      if (Array.isArray(value)) return value;
-      if (typeof value === 'string') {
-        try {
-          const parsed = JSON.parse(value);
-          return Array.isArray(parsed) ? parsed : [];
-        } catch {
-          return [];
-        }
-      }
-      return [];
+      return toKeyValueRows(value);
     default:
       return value;
   }
+};
+
+/**
+ * 将详情接口中保存的 JSON 对象转换成动态表单组件需要的值形态。
+ * CUSTOM_SELECT 在编辑态使用行数据，但保存协议仍保持 JSON 对象。
+ */
+export const normalizeConfigValuesForForm = (
+  fields: DynamicFormField[],
+  values?: Record<string, unknown>,
+): Record<string, unknown> => {
+  if (!values) return {};
+  const normalized = { ...values };
+  fields.forEach((field) => {
+    if (field.type === 'CUSTOM_SELECT' && field.key in normalized) {
+      normalized[field.key] = toKeyValueRows(normalized[field.key]);
+    }
+  });
+  return normalized;
 };
 
 const normalizeOperator = (
@@ -167,8 +215,9 @@ export const isDynamicFieldVisible = (
 };
 
 /**
- * 兼容旧插件历史约定：driverLocation 曾经以普通 INPUT 字段下发，
- * 新版统一提升为 DRIVER 标准组件。插件升级后应直接声明 type=DRIVER。
+ * 兼容历史 Schema：
+ * - driverLocation 曾经以普通 INPUT 字段下发，统一提升为 DRIVER。
+ * - JDBC properties 曾经以 TEXTAREA 下发，统一提升为 Key / Value 编辑器。
  */
 const normalizeFormField = (field: DynamicFormField): DynamicFormField => {
   const normalized: DynamicFormField = {
@@ -179,12 +228,32 @@ const normalizeFormField = (field: DynamicFormField): DynamicFormField => {
   if (field.key === 'driverLocation' && field.type !== 'DRIVER') {
     normalized.type = 'DRIVER';
   }
+  if (field.key === 'properties' && field.type === 'TEXTAREA') {
+    normalized.type = 'CUSTOM_SELECT';
+    normalized.placeholder = '按键值对添加 JDBC 扩展参数，例如 useSSL = false';
+  }
   return normalized;
+};
+
+/** 只把 Driver 移到 SSH 前面，不改变插件其它自定义分区的相对顺序。 */
+const moveDriverBeforeSsh = (
+  sections: DynamicFormSection[],
+): DynamicFormSection[] => {
+  const driverIndex = sections.findIndex((section) => section.key === 'driver');
+  const sshIndex = sections.findIndex((section) => section.key === 'ssh');
+  if (driverIndex < 0 || sshIndex < 0 || driverIndex < sshIndex) return sections;
+
+  const reordered = [...sections];
+  const [driverSection] = reordered.splice(driverIndex, 1);
+  const nextSshIndex = reordered.findIndex((section) => section.key === 'ssh');
+  reordered.splice(nextSshIndex, 0, driverSection);
+  return reordered;
 };
 
 /**
  * 将新版 sections 和旧版 formFields 统一归一成分区结构。
  *
+ * 标准能力区确保驱动配置位于 SSH 隧道之前；其它插件自定义 Section 保持原顺序。
  * 新插件优先使用 sections；旧插件无需迁移，扁平 formFields 会自动落到
  * 一个始终展开的“连接参数”分区中。
  */
@@ -202,7 +271,7 @@ export const normalizeFormSections = (
       fields: section.fields.map(normalizeFormField),
     }));
 
-  if (sections.length > 0) return sections;
+  if (sections.length > 0) return moveDriverBeforeSsh(sections);
 
   const legacyFields = schema?.formFields || [];
   if (legacyFields.length === 0) return [];

--- a/yak-ops-ui/src/pages/data-source/utils.test.ts
+++ b/yak-ops-ui/src/pages/data-source/utils.test.ts
@@ -1,4 +1,9 @@
-import { buildSubmitPayload, parseOriginalJson } from './utils';
+import {
+  buildSubmitPayload,
+  normalizeConnectionFormValues,
+  parseOriginalJson,
+  serializeKeyValueRows,
+} from './utils';
 
 describe('datasource utils', () => {
   it('builds the backend connection parameter contract', () => {
@@ -27,6 +32,51 @@ describe('datasource utils', () => {
         password: '******',
         dbType: 'MYSQL',
       }),
+    });
+  });
+
+  it('serializes advanced property rows back into the plugin object contract', () => {
+    expect(
+      serializeKeyValueRows([
+        { key: ' useSSL ', value: 'false' },
+        { key: 'serverTimezone', value: 'UTC' },
+        { key: '', value: 'ignored' },
+      ]),
+    ).toEqual({
+      useSSL: 'false',
+      serverTimezone: 'UTC',
+    });
+
+    expect(
+      normalizeConnectionFormValues({
+        host: '127.0.0.1',
+        properties: [{ key: 'useSSL', value: 'false' }],
+      }),
+    ).toEqual({
+      host: '127.0.0.1',
+      properties: { useSSL: 'false' },
+    });
+  });
+
+  it('keeps advanced properties as a JSON object in submit payload', () => {
+    const payload = buildSubmitPayload(
+      'MYSQL',
+      { name: 'mysql', environment: 'DEVELOP' },
+      {
+        host: '127.0.0.1',
+        properties: [
+          { key: 'useSSL', value: 'false' },
+          { key: 'serverTimezone', value: 'UTC' },
+        ],
+      },
+    );
+
+    expect(JSON.parse(payload.connectionParams)).toMatchObject({
+      dbType: 'MYSQL',
+      properties: {
+        useSSL: 'false',
+        serverTimezone: 'UTC',
+      },
     });
   });
 

--- a/yak-ops-ui/src/pages/data-source/utils.ts
+++ b/yak-ops-ui/src/pages/data-source/utils.ts
@@ -29,6 +29,49 @@ export function filterDataSourceList(
   });
 }
 
+interface KeyValueRow {
+  key?: unknown;
+  value?: unknown;
+}
+
+/** 将高级配置编辑器的行数据恢复成后端沿用的 JSON 对象协议。 */
+export function serializeKeyValueRows(value: unknown): Record<string, string> {
+  if (!Array.isArray(value)) {
+    if (value && typeof value === 'object') {
+      return Object.fromEntries(
+        Object.entries(value as Record<string, unknown>).map(([key, itemValue]) => [
+          key,
+          itemValue === undefined || itemValue === null ? '' : String(itemValue),
+        ]),
+      );
+    }
+    return {};
+  }
+
+  const result: Record<string, string> = {};
+  value.forEach((item) => {
+    if (!item || typeof item !== 'object') return;
+    const row = item as KeyValueRow;
+    const key = String(row.key ?? '').trim();
+    if (!key) return;
+    result[key] = row.value === undefined || row.value === null ? '' : String(row.value);
+  });
+  return result;
+}
+
+/**
+ * 动态表单内部可以使用更适合 UI 的值形态，但发给数据源插件的连接协议保持稳定。
+ */
+export function normalizeConnectionFormValues(
+  connectionValues: DataSourceConnectionFormValues,
+): DataSourceConnectionFormValues {
+  const normalized = { ...connectionValues };
+  if ('properties' in normalized) {
+    normalized.properties = serializeKeyValueRows(normalized.properties);
+  }
+  return normalized;
+}
+
 export function buildSubmitPayload(
   dbType: string,
   basicValues: DataSourceFormValues,
@@ -38,7 +81,7 @@ export function buildSubmitPayload(
     dbType,
     ...basicValues,
     connectionParams: JSON.stringify({
-      ...connectionValues,
+      ...normalizeConnectionFormValues(connectionValues),
       dbType,
     }),
   };


### PR DESCRIPTION
## 数据源编辑器：驱动顺序 + 高级配置重构

这次针对编辑/新建数据源 Drawer 收敛两个交互问题：驱动配置与 SSH 的顺序，以及高级配置中 `properties` 对象被普通 TextArea 渲染成 `[object Object]` 的问题。

### 1. 驱动配置调整到 SSH 前面

- 连接参数主区域仍保持在顶部，不改变核心连接信息的填写顺序。
- 标准能力区调整为：**驱动配置 → SSH 隧道 → 高级配置**。
- Schema 归一化只定向移动 `driver` 到 `ssh` 前面，不会重新排序其它插件自定义 Section，避免影响后续 Connector 扩展。
- 驱动配置继续保持默认展开，SSH / 高级配置继续按原配置折叠。

### 2. 高级配置改成 Key / Value 参数编辑器

参考 Chat2DB `ConnectionEdit` 的 ExtendInfo Name / Value 表格交互，将 Yak Ops 现有 `CustomKVList` 重构为紧凑的参数表：

- 表头：参数名 / 参数值 / 操作；
- 支持新增参数、删除参数；
- 参数名必填，禁止重复；
- 参数名最大 128 字符，参数值最大 1024 字符；
- 最多 50 条扩展参数；
- 空数据展示“暂无扩展参数”；
- 使用现有白灰、紧凑 Drawer 风格，不复制 Chat2DB 的大 Modal 结构。

### 3. 修复历史 `[object Object]` 回显

当前 JDBC Schema 历史上将 `properties` 下发为 `TEXTAREA`，而详情中的实际值是 JSON Object，因此编辑时会被 React/Input 转成 `[object Object]`。

本次增加兼容归一化：

- `key=properties + type=TEXTAREA` 自动升级为现有标准 `CUSTOM_SELECT` Key/Value 编辑器；
- 历史 JSON Object / JSON String / 行数组都能统一转成 `{ key, value }[]` 用于编辑；
- 主编辑器和保留的旧 `usePluginFormConfig` 入口都执行同一套转换。

### 4. 保存协议保持不变

UI 内部使用 Key/Value 行数据，但不会修改 JDBC 插件现有连接参数协议：

- 编辑回显：JSON Object → Key/Value Rows；
- 连接测试：Key/Value Rows → `properties: { key: value }`；
- 保存/更新：Key/Value Rows → `properties: { key: value }`；
- 后端 `Map<String, String>` / JSON Object 解析逻辑无需调整。

例如页面编辑：

```text
useSSL          false
serverTimezone  UTC
```

提交仍然是：

```json
{
  "properties": {
    "useSSL": "false",
    "serverTimezone": "UTC"
  }
}
```

### 测试

补充前端单测覆盖：

- 历史 properties Object → Key/Value Rows；
- Driver / SSH 标准 Section 顺序；
- 历史 `TEXTAREA properties` 自动升级为 `CUSTOM_SELECT`；
- Key/Value Rows → JSON Object；
- `buildSubmitPayload` 中 properties 仍保持对象协议。

### 兼容性

- 不修改数据源后端运行时和 JDBC 连接执行逻辑；
- 不修改 Driver / SSH / JDBC URL / dependsOn / visibleWhen 现有能力；
- 不修改创建、编辑、连接测试接口结构；
- 兼容旧数据源详情和旧插件 Schema。

### Diff / 验证

- 最终 7 个文件，1 个干净提交；
- 当前分支相对 `main`：ahead 1 / behind 0；
- 已进行 Schema 顺序、编辑回填、连接测试、保存序列化和旧入口兼容的静态检查；
- 当前执行环境无法通过 `github.com` clone 完整仓库，因此未实际执行 `npm run tsc` / Jest，建议由仓库 CI 或本地开发环境完成最终编译验证。