### PR TITLE
refactor: filter datasources by environment tabs

### DIFF
--- a/yak-ops-ui/src/pages/data-source/index.tsx
+++ b/yak-ops-ui/src/pages/data-source/index.tsx
@@ -56,11 +56,6 @@ import { DataSourceOperateType } from './types';
 
 const { confirm } = Modal;
 
-type DataSourceFilterKey =
-  | 'all'
-  | 'connected'
-  | 'disconnected'
-  | 'unknown';
 type DataSourceViewMode = 'grid' | 'list';
 
 const EMPTY_SUMMARY: DataSourceSummary = {
@@ -75,9 +70,6 @@ const ENVIRONMENT_FILTER_OPTIONS = ENVIRONMENT_OPTIONS.map((item) => ({
   ...item,
   label: environmentTagConfigMap[item.value]?.text || item.label,
 }));
-
-const statusForFilter = (filter: DataSourceFilterKey) =>
-  filter === 'all' ? undefined : filter.toUpperCase();
 
 const recordKey = (id?: DataSourceId) => String(id ?? '');
 
@@ -99,8 +91,6 @@ const DataSourcePage = () => {
     PAGE_DEFAULT_PAGINATION,
   );
   const [searchKeyword, setSearchKeyword] = useState('');
-  const [activeFilter, setActiveFilter] =
-    useState<DataSourceFilterKey>('all');
   const [dbTypeFilter, setDbTypeFilter] = useState<string | undefined>();
   const [environmentFilter, setEnvironmentFilter] = useState<
     string | undefined
@@ -111,10 +101,7 @@ const DataSourcePage = () => {
   const [editingId, setEditingId] = useState('');
 
   const hasActiveFilters = Boolean(
-    searchKeyword.trim() ||
-      activeFilter !== 'all' ||
-      dbTypeFilter ||
-      environmentFilter,
+    searchKeyword.trim() || dbTypeFilter || environmentFilter,
   );
 
   const resetPage = useCallback(() => {
@@ -130,7 +117,6 @@ const DataSourcePage = () => {
       pageNo: pagination.pageNo,
       pageSize: pagination.pageSize,
       keyword: searchKeyword.trim() || undefined,
-      connStatus: statusForFilter(activeFilter),
       dbType: dbTypeFilter,
       environment: environmentFilter,
     };
@@ -176,7 +162,6 @@ const DataSourcePage = () => {
       if (requestSeq === requestSeqRef.current) setLoading(false);
     }
   }, [
-    activeFilter,
     dbTypeFilter,
     environmentFilter,
     pagination.pageNo,
@@ -199,7 +184,6 @@ const DataSourcePage = () => {
 
   const handleResetFilters = useCallback(() => {
     setSearchKeyword('');
-    setActiveFilter('all');
     setDbTypeFilter(undefined);
     setEnvironmentFilter(undefined);
     resetPage();
@@ -283,18 +267,22 @@ const DataSourcePage = () => {
     }
   };
 
-  const filterTabs = useMemo(
+  const environmentTabs = useMemo(
     () => [
-      { key: 'all' as const, label: '全部数据源', count: summary.total },
-      { key: 'connected' as const, label: '已连接', count: summary.connected },
       {
-        key: 'disconnected' as const,
-        label: '连接异常',
-        count: summary.disconnected,
+        key: 'all',
+        label: '全部数据源',
+        value: undefined,
+        count: summary.total,
       },
-      { key: 'unknown' as const, label: '待检测', count: summary.unknown },
+      ...ENVIRONMENT_FILTER_OPTIONS.map((item) => ({
+        key: item.value,
+        label: item.label,
+        value: item.value,
+        count: undefined,
+      })),
     ],
-    [summary],
+    [summary.total],
   );
 
   const renderDataSourceCard = (record: DataSourceRecord) => {
@@ -480,20 +468,23 @@ const DataSourcePage = () => {
             className="datasource-workbench"
           >
             <div className="datasource-workbench__tabs">
-              {filterTabs.map((item) => (
-                <button
-                  type="button"
-                  key={item.key}
-                  className={activeFilter === item.key ? 'is-active' : ''}
-                  onClick={() => {
-                    setActiveFilter(item.key);
-                    resetPage();
-                  }}
-                >
-                  {item.label}
-                  <span>{item.count}</span>
-                </button>
-              ))}
+              {environmentTabs.map((item) => {
+                const isActive = (environmentFilter || 'all') === item.key;
+                return (
+                  <button
+                    type="button"
+                    key={item.key}
+                    className={isActive ? 'is-active' : ''}
+                    onClick={() => {
+                      setEnvironmentFilter(item.value);
+                      resetPage();
+                    }}
+                  >
+                    {item.label}
+                    {typeof item.count === 'number' && <span>{item.count}</span>}
+                  </button>
+                );
+              })}
             </div>
 
             <div className="datasource-workbench__tools">
@@ -506,19 +497,6 @@ const DataSourcePage = () => {
                 popupMatchSelectWidth={180}
                 onChange={(value) => {
                   setDbTypeFilter(value);
-                  resetPage();
-                }}
-              />
-
-              <Select
-                allowClear
-                value={environmentFilter}
-                style={{ width: 116 }}
-                placeholder="运行环境"
-                options={ENVIRONMENT_FILTER_OPTIONS}
-                popupMatchSelectWidth={140}
-                onChange={(value) => {
-                  setEnvironmentFilter(value);
                   resetPage();
                 }}
               />
@@ -628,7 +606,7 @@ const DataSourcePage = () => {
                 </h3>
                 <p>
                   {hasActiveFilters
-                    ? '可以调整类型、环境、状态或搜索条件后重试。'
+                    ? '可以调整运行环境、数据源类型或搜索条件后重试。'
                     : '创建第一个数据源，开始配置数据同步与运行任务。'}
                 </p>
                 {hasActiveFilters ? (


### PR DESCRIPTION
## 数据源管理：筛选维度改为运行环境

按页面反馈，将低频的连接状态 Tab（已连接 / 连接异常 / 待检测）替换为更常用的运行环境筛选。

### 主要调整

- 左侧筛选 Tab 调整为：
  - 全部数据源
  - 开发
  - 测试
  - 生产
- 删除右侧重复的“运行环境”下拉选择器，避免同一个筛选条件出现两套入口。
- Tab 直接驱动现有 `environment` 查询参数：
  - 开发 → `DEVELOP`
  - 测试 → `TEST`
  - 生产 → `PROD`
- 删除原页面 `activeFilter / statusForFilter / connStatus` 连接状态筛选逻辑。
- “重置筛选”统一恢复到全部运行环境，同时清空数据源类型和搜索条件。
- 空数据提示同步去掉“状态”筛选文案，改为“运行环境、数据源类型或搜索条件”。

### 保留能力

- 顶部数据概览中的连接正常 / 连接异常指标继续保留，用于快速了解数据源健康情况；这里只移除列表筛选中的低频连接状态维度。
- 数据源类型筛选、搜索、刷新、卡片/列表切换保持不变。
- 后端接口无需调整，继续使用已有 `environment` 分页查询参数。

### Diff / 验证

- 仅修改 `yak-ops-ui/src/pages/data-source/index.tsx`；
- 当前分支相对 `main`：ahead 1 / behind 0；
- diff：+31 / -53；
- 已静态检查环境 Tab、分页重置、筛选重置和请求参数链路；
- 当前执行环境未运行完整前端依赖构建，建议由仓库 CI / 本地环境做最终编译验证。