### PR TITLE
feat: 新增数据分析菜单并调整仪表盘入口

### DIFF
--- a/yak-ops-ui/src/config/navigation.ts
+++ b/yak-ops-ui/src/config/navigation.ts
@@ -31,13 +31,14 @@ export const navigationGroups: readonly NavigationGroup[] = [
   { id: 'workflow', title: '工作流', iconKey: 'workflow', section: 'task', order: 30 },
   { id: 'resources', title: '资源管理', iconKey: 'database', section: 'management', order: 20 },
   { id: 'data-quality', title: '数据质量', iconKey: 'quality', section: 'management', order: 30 },
+  { id: 'data-analysis', title: '数据分析', iconKey: 'insight', section: 'management', order: 40 },
   { id: 'system', title: '系统管理', iconKey: 'system', section: 'system', order: 40 },
 ];
 
 export const appRoutes: readonly NavigationRoute[] = [
   { id: 'home', mode: 'public', path: '/home', title: '首页', component: './home', iconKey: 'home', order: 0 },
   { id: 'data-source', mode: 'one', permission: 'resource:data-source:read', path: '/data-source', title: '数据源管理', component: './data-source', iconKey: 'database', order: 10 },
-  { id: 'dashboard', mode: 'public', path: '/dashboard', title: '仪表盘', component: './dashboard', iconKey: 'insight', order: 20 },
+  { id: 'dashboard', mode: 'public', path: '/dashboard', title: '仪表盘', component: './dashboard', iconKey: 'insight', menuGroup: 'data-analysis', order: 10 },
   { id: 'settings', mode: 'public', path: '/settings', title: '设置', component: './settings', hidden: true, order: 30 },
   {
     id: 'batch-link-up', mode: 'one', permission: 'task:batch:read',


### PR DESCRIPTION
## 变更说明
- 在侧边栏「数据质量」下方新增「数据分析」菜单分组
- 将原顶层「仪表盘」移动到「数据分析」分组下
- 保持仪表盘原有 `/dashboard` 路由和页面实现不变

## 影响范围
- 仅调整前端导航配置：`yak-ops-ui/src/config/navigation.ts`

## 验证
- 已检查提交 diff，当前仅 1 个文件变更，共 3 行调整
- 未运行本地 UI 构建/自动化测试