### PR TITLE
feat: improve data development tree metadata

### DIFF
--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/controller/v1/DevelopmentNodeController.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/controller/v1/DevelopmentNodeController.java
@@ -8,6 +8,7 @@ import io.yak.ops.business.development.api.DevelopmentNodeApi.RenameRequest;
 import io.yak.ops.business.development.domain.DevelopmentNode;
 import io.yak.ops.business.development.service.DevelopmentNodeService;
 import jakarta.validation.Valid;
+import java.security.Principal;
 import java.util.List;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -38,20 +39,25 @@ public class DevelopmentNodeController {
 
   @Operation(summary = "新建数据开发节点")
   @PostMapping
-  public Result<DevelopmentNode> create(@Valid @RequestBody CreateRequest request) {
-    return Result.success(service.create(
+  public Result<DevelopmentNode> create(
+      @Valid @RequestBody CreateRequest request,
+      Principal principal) {
+    DevelopmentNode created = service.create(
         request.name(),
         request.type(),
         request.projectId(),
-        request.directoryId()));
+        request.directoryId());
+    return Result.success(service.recordUpdater(created.id(), operatorName(principal)));
   }
 
   @Operation(summary = "重命名数据开发节点")
   @PutMapping("/{id}/name")
   public Result<DevelopmentNode> rename(
       @PathVariable("id") Long id,
-      @Valid @RequestBody RenameRequest request) {
-    return Result.success(service.rename(id, request.name()));
+      @Valid @RequestBody RenameRequest request,
+      Principal principal) {
+    DevelopmentNode renamed = service.rename(id, request.name());
+    return Result.success(service.recordUpdater(renamed.id(), operatorName(principal)));
   }
 
   @Operation(summary = "删除数据开发节点")
@@ -59,5 +65,9 @@ public class DevelopmentNodeController {
   public Result<Boolean> delete(@PathVariable("id") Long id) {
     service.delete(id);
     return Result.success(Boolean.TRUE);
+  }
+
+  private String operatorName(Principal principal) {
+    return principal == null ? "unknown" : principal.getName();
   }
 }

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/controller/v1/DevelopmentTaskController.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/controller/v1/DevelopmentTaskController.java
@@ -10,6 +10,7 @@ import io.yak.ops.business.development.domain.DevelopmentTaskDraft;
 import io.yak.ops.business.development.domain.DevelopmentTaskRevision;
 import io.yak.ops.business.development.domain.DevelopmentTaskRevisionSummary;
 import io.yak.ops.business.development.domain.DevelopmentTaskRunResult;
+import io.yak.ops.business.development.service.DevelopmentNodeService;
 import io.yak.ops.business.development.service.DevelopmentTaskRunService;
 import io.yak.ops.business.development.service.DevelopmentTaskService;
 import jakarta.validation.Valid;
@@ -31,12 +32,15 @@ public class DevelopmentTaskController {
 
   private final DevelopmentTaskService service;
   private final DevelopmentTaskRunService runService;
+  private final DevelopmentNodeService nodeService;
 
   public DevelopmentTaskController(
       DevelopmentTaskService service,
-      DevelopmentTaskRunService runService) {
+      DevelopmentTaskRunService runService,
+      DevelopmentNodeService nodeService) {
     this.service = service;
     this.runService = runService;
+    this.nodeService = nodeService;
   }
 
   @Operation(summary = "读取节点草稿")
@@ -49,15 +53,17 @@ public class DevelopmentTaskController {
   @PutMapping("/{nodeId}/draft")
   public Result<DevelopmentTaskDraft> saveDraft(
       @PathVariable("nodeId") Long nodeId,
-      @Valid @RequestBody SaveDraftRequest request) {
-    return Result.success(
-        service.saveDraft(
-            nodeId,
-            request.taskType(),
-            request.schemaVersion(),
-            request.content(),
-            request.configJson(),
-            request.baseRevision()));
+      @Valid @RequestBody SaveDraftRequest request,
+      Principal principal) {
+    DevelopmentTaskDraft saved = service.saveDraft(
+        nodeId,
+        request.taskType(),
+        request.schemaVersion(),
+        request.content(),
+        request.configJson(),
+        request.baseRevision());
+    nodeService.recordUpdater(nodeId, operatorName(principal));
+    return Result.success(saved);
   }
 
   @Operation(summary = "运行当前编辑器任务")
@@ -73,7 +79,7 @@ public class DevelopmentTaskController {
             request.schemaVersion(),
             request.content(),
             request.configJson(),
-            principal == null ? "unknown" : principal.getName()));
+            operatorName(principal)));
   }
 
   @Operation(summary = "发布节点版本")
@@ -97,5 +103,9 @@ public class DevelopmentTaskController {
       @PathVariable("nodeId") Long nodeId,
       @PathVariable("revisionNo") int revisionNo) {
     return Result.success(service.getRevision(nodeId, revisionNo));
+  }
+
+  private String operatorName(Principal principal) {
+    return principal == null ? "unknown" : principal.getName();
   }
 }

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/domain/DevelopmentNode.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/domain/DevelopmentNode.java
@@ -13,5 +13,20 @@ public record DevelopmentNode(
     @JsonSerialize(using = ToStringSerializer.class) Long directoryId,
     boolean configured,
     Instant createTime,
-    Instant updateTime) {
+    Instant updateTime,
+    String updatedBy,
+    boolean pendingPublish) {
+
+  /** Keeps existing callers source-compatible while tree metadata is populated by persistence. */
+  public DevelopmentNode(
+      Long id,
+      String name,
+      String type,
+      Long projectId,
+      Long directoryId,
+      boolean configured,
+      Instant createTime,
+      Instant updateTime) {
+    this(id, name, type, projectId, directoryId, configured, createTime, updateTime, null, false);
+  }
 }

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/DevelopmentNodeRepository.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/DevelopmentNodeRepository.java
@@ -26,5 +26,10 @@ public interface DevelopmentNodeRepository {
 
   boolean updateConfigured(Long id, boolean configured);
 
+  /** Stores the last editor without forcing all existing repository test doubles to implement it. */
+  default boolean updateUpdatedBy(Long id, String updatedBy) {
+    return false;
+  }
+
   boolean deleteById(Long id);
 }

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/DevelopmentNodeRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/DevelopmentNodeRepositoryAdapter.java
@@ -8,6 +8,7 @@ import io.yak.ops.common.bean.po.development.DevelopmentNodePO;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
 
 /** MyBatis adapter for data-development tree node metadata. */
@@ -17,9 +18,11 @@ public class DevelopmentNodeRepositoryAdapter implements DevelopmentNodeReposito
   private static final long ROOT_DIRECTORY_ID = 0L;
 
   private final DevelopmentNodeMapper mapper;
+  private final JdbcTemplate jdbcTemplate;
 
-  public DevelopmentNodeRepositoryAdapter(DevelopmentNodeMapper mapper) {
+  public DevelopmentNodeRepositoryAdapter(DevelopmentNodeMapper mapper, JdbcTemplate jdbcTemplate) {
     this.mapper = mapper;
+    this.jdbcTemplate = jdbcTemplate;
   }
 
   @Override
@@ -40,12 +43,13 @@ public class DevelopmentNodeRepositoryAdapter implements DevelopmentNodeReposito
     po.setCreateTime(now);
     po.setUpdateTime(now);
     mapper.insert(po);
-    return toDomain(po);
+    return toDomain(po, false);
   }
 
   @Override
   public Optional<DevelopmentNode> findById(Long id) {
-    return Optional.ofNullable(mapper.selectById(id)).map(this::toDomain);
+    return Optional.ofNullable(mapper.selectById(id))
+        .map(po -> toDomain(po, hasUnpublishedChanges(po.getId())));
   }
 
   @Override
@@ -55,7 +59,7 @@ public class DevelopmentNodeRepositoryAdapter implements DevelopmentNodeReposito
                 .orderByAsc(DevelopmentNodePO::getName)
                 .orderByAsc(DevelopmentNodePO::getId))
         .stream()
-        .map(this::toDomain)
+        .map(po -> toDomain(po, hasUnpublishedChanges(po.getId())))
         .toList();
   }
 
@@ -99,6 +103,16 @@ public class DevelopmentNodeRepositoryAdapter implements DevelopmentNodeReposito
   }
 
   @Override
+  public boolean updateUpdatedBy(Long id, String updatedBy) {
+    return mapper.update(
+            null,
+            new LambdaUpdateWrapper<DevelopmentNodePO>()
+                .eq(DevelopmentNodePO::getId, id)
+                .set(DevelopmentNodePO::getUpdatedBy, updatedBy))
+        > 0;
+  }
+
+  @Override
   public boolean deleteById(Long id) {
     return mapper.deleteById(id) > 0;
   }
@@ -107,7 +121,21 @@ public class DevelopmentNodeRepositoryAdapter implements DevelopmentNodeReposito
     return directoryId == null || directoryId <= 0L ? ROOT_DIRECTORY_ID : directoryId;
   }
 
-  private DevelopmentNode toDomain(DevelopmentNodePO po) {
+  private boolean hasUnpublishedChanges(Long nodeId) {
+    Long draftRevision = jdbcTemplate.queryForObject(
+        "SELECT MAX(draft_revision) FROM yak_dev_task_draft WHERE node_id = ?",
+        Long.class,
+        nodeId);
+    if (draftRevision == null) return false;
+
+    Long publishedDraftRevision = jdbcTemplate.queryForObject(
+        "SELECT MAX(source_draft_revision) FROM yak_dev_task_revision WHERE node_id = ?",
+        Long.class,
+        nodeId);
+    return publishedDraftRevision == null || draftRevision > publishedDraftRevision;
+  }
+
+  private DevelopmentNode toDomain(DevelopmentNodePO po, boolean pendingPublish) {
     Long directoryId = po.getDirectoryId() == null || po.getDirectoryId() == ROOT_DIRECTORY_ID
         ? null
         : po.getDirectoryId();
@@ -119,6 +147,8 @@ public class DevelopmentNodeRepositoryAdapter implements DevelopmentNodeReposito
         directoryId,
         Boolean.TRUE.equals(po.getConfigured()),
         po.getCreateTime(),
-        po.getUpdateTime());
+        po.getUpdateTime(),
+        po.getUpdatedBy(),
+        pendingPublish);
   }
 }

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/DevelopmentNodeRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/DevelopmentNodeRepositoryAdapter.java
@@ -6,7 +6,9 @@ import io.yak.ops.business.development.dao.mapper.DevelopmentNodeMapper;
 import io.yak.ops.business.development.domain.DevelopmentNode;
 import io.yak.ops.common.bean.po.development.DevelopmentNodePO;
 import java.time.Instant;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
@@ -54,12 +56,13 @@ public class DevelopmentNodeRepositoryAdapter implements DevelopmentNodeReposito
 
   @Override
   public List<DevelopmentNode> list() {
-    return mapper.selectList(
-            new LambdaQueryWrapper<DevelopmentNodePO>()
-                .orderByAsc(DevelopmentNodePO::getName)
-                .orderByAsc(DevelopmentNodePO::getId))
-        .stream()
-        .map(po -> toDomain(po, hasUnpublishedChanges(po.getId())))
+    List<DevelopmentNodePO> nodes = mapper.selectList(
+        new LambdaQueryWrapper<DevelopmentNodePO>()
+            .orderByAsc(DevelopmentNodePO::getName)
+            .orderByAsc(DevelopmentNodePO::getId));
+    Map<Long, Boolean> pendingPublishByNodeId = loadPendingPublishByNodeId();
+    return nodes.stream()
+        .map(po -> toDomain(po, Boolean.TRUE.equals(pendingPublishByNodeId.get(po.getId()))))
         .toList();
   }
 
@@ -119,6 +122,23 @@ public class DevelopmentNodeRepositoryAdapter implements DevelopmentNodeReposito
 
   private Long toStoredDirectoryId(Long directoryId) {
     return directoryId == null || directoryId <= 0L ? ROOT_DIRECTORY_ID : directoryId;
+  }
+
+  private Map<Long, Boolean> loadPendingPublishByNodeId() {
+    Map<Long, Boolean> result = new HashMap<>();
+    jdbcTemplate.query(
+        "SELECT d.node_id, d.draft_revision, MAX(r.source_draft_revision) AS published_draft_revision "
+            + "FROM yak_dev_task_draft d "
+            + "LEFT JOIN yak_dev_task_revision r ON r.node_id = d.node_id "
+            + "GROUP BY d.node_id, d.draft_revision",
+        rs -> {
+          long nodeId = rs.getLong("node_id");
+          long draftRevision = rs.getLong("draft_revision");
+          long publishedDraftRevision = rs.getLong("published_draft_revision");
+          boolean hasPublishedRevision = !rs.wasNull();
+          result.put(nodeId, !hasPublishedRevision || draftRevision > publishedDraftRevision);
+        });
+    return result;
   }
 
   private boolean hasUnpublishedChanges(Long nodeId) {

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentNodeService.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentNodeService.java
@@ -84,6 +84,18 @@ public class DevelopmentNodeService {
     return renamed;
   }
 
+  /** Records the human who most recently changed this node and returns refreshed tree metadata. */
+  @Transactional(transactionManager = "yakBusinessTransactionManager", rollbackFor = Exception.class)
+  public DevelopmentNode recordUpdater(Long id, String operatorName) {
+    DevelopmentNode current = repository.findById(id)
+        .orElseThrow(() -> new IllegalArgumentException("节点不存在：" + id));
+    String normalizedOperator = normalizeOperator(operatorName);
+    if (!repository.updateUpdatedBy(id, normalizedOperator)) {
+      return current;
+    }
+    return repository.findById(id).orElse(current);
+  }
+
   @Transactional(transactionManager = "yakBusinessTransactionManager", rollbackFor = Exception.class)
   public void delete(Long id) {
     DevelopmentNode current = repository.findById(id)
@@ -123,5 +135,11 @@ public class DevelopmentNodeService {
 
   private Long normalizeDirectoryId(Long directoryId) {
     return directoryId == null || directoryId <= 0L ? null : directoryId;
+  }
+
+  private String normalizeOperator(String operatorName) {
+    if (operatorName == null || operatorName.isBlank()) return "unknown";
+    String normalized = operatorName.trim();
+    return normalized.length() <= 128 ? normalized : normalized.substring(0, 128);
   }
 }

--- a/yak-ops-business/yak-ops-business-data-development/src/main/resources/db/migration/yak-data-development/V4__add_node_updater.sql
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/resources/db/migration/yak-data-development/V4__add_node_updater.sql
@@ -1,2 +1,0 @@
-ALTER TABLE yak_dev_node
-    ADD COLUMN updated_by VARCHAR(128) NULL AFTER deleted;

--- a/yak-ops-business/yak-ops-business-data-development/src/main/resources/db/migration/yak-data-development/V4__add_node_updater.sql
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/resources/db/migration/yak-data-development/V4__add_node_updater.sql
@@ -1,0 +1,2 @@
+ALTER TABLE yak_dev_node
+    ADD COLUMN updated_by VARCHAR(128) NULL AFTER deleted;

--- a/yak-ops-business/yak-ops-business-data-development/src/main/resources/db/migration/yak-data-development/V8__add_node_updater.sql
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/resources/db/migration/yak-data-development/V8__add_node_updater.sql
@@ -1,0 +1,2 @@
+ALTER TABLE yak_dev_node
+    ADD COLUMN updated_by VARCHAR(128) NULL AFTER deleted;

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/development/DevelopmentNodePO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/development/DevelopmentNodePO.java
@@ -19,6 +19,7 @@ public class DevelopmentNodePO {
   private Long directoryId;
   private Boolean configured;
   @TableLogic private Boolean deleted;
+  private String updatedBy;
   private Instant createTime;
   private Instant updateTime;
 }

--- a/yak-ops-ui/src/pages/data-development/components/DevelopmentTreePane.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/DevelopmentTreePane.tsx
@@ -16,8 +16,12 @@ import {
   Search,
   TerminalSquare,
   Trash2,
+  Upload,
 } from 'lucide-react';
 import type { PointerEvent as ReactPointerEvent } from 'react';
+import { useEffect, useState } from 'react';
+
+import { listDevelopmentNodes } from '../service';
 
 export type DevelopmentTreeNodeType = 'directory' | 'node';
 export type DevelopmentNodeCreateType = 'SQL' | 'SHELL';
@@ -60,10 +64,28 @@ interface DevelopmentTreePaneProps {
   onCollapsedChange: (collapsed: boolean) => void;
 }
 
+type NodeMetadata = {
+  updatedBy?: string | null;
+  updateTime?: string;
+  pendingPublish?: boolean;
+};
+
 const nodeTypeIconClassName = (taskType?: string) => {
   if (taskType === 'SHELL') return 'text-[#6172f3]';
   if (taskType === 'SQL') return 'text-[#f79009]';
   return 'text-[#667085]';
+};
+
+const padTimePart = (value: number) => String(value).padStart(2, '0');
+
+const formatUpdateTime = (value?: string) => {
+  if (!value) return '';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return [
+    `${date.getFullYear()}-${padTimePart(date.getMonth() + 1)}-${padTimePart(date.getDate())}`,
+    `${padTimePart(date.getHours())}:${padTimePart(date.getMinutes())}:${padTimePart(date.getSeconds())}`,
+  ].join(' ');
 };
 
 const DevelopmentTreePane = ({
@@ -81,6 +103,34 @@ const DevelopmentTreePane = ({
   onResizeStart,
   onCollapsedChange,
 }: DevelopmentTreePaneProps) => {
+  const [metadataById, setMetadataById] = useState<Map<string, NodeMetadata>>(new Map());
+
+  useEffect(() => {
+    let active = true;
+    void listDevelopmentNodes()
+      .then((response) => {
+        if (!active || !Array.isArray(response.data)) return;
+        setMetadataById(
+          new Map(
+            response.data.map((node) => [
+              node.id,
+              {
+                updatedBy: node.updatedBy,
+                updateTime: node.updateTime,
+                pendingPublish: node.pendingPublish,
+              },
+            ]),
+          ),
+        );
+      })
+      .catch(() => {
+        // The parent tree request already owns page-level error feedback.
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
   const createMenuItems: MenuProps['items'] = [
     {
       key: 'node',
@@ -90,24 +140,12 @@ const DevelopmentTreePane = ({
         {
           key: 'node-sql',
           label: 'SQL 节点',
-          icon: (
-            <Code2
-              size={14}
-              strokeWidth={1.8}
-              className="text-[#f79009]"
-            />
-          ),
+          icon: <Code2 size={14} strokeWidth={1.8} className="text-[#f79009]" />,
         },
         {
           key: 'node-shell',
           label: 'Shell 节点',
-          icon: (
-            <TerminalSquare
-              size={14}
-              strokeWidth={1.8}
-              className="text-[#6172f3]"
-            />
-          ),
+          icon: <TerminalSquare size={14} strokeWidth={1.8} className="text-[#6172f3]" />,
         },
       ],
     },
@@ -154,24 +192,12 @@ const DevelopmentTreePane = ({
           {
             key: 'create-sql',
             label: 'SQL 节点',
-            icon: (
-              <Code2
-                size={14}
-                strokeWidth={1.8}
-                className="text-[#f79009]"
-              />
-            ),
+            icon: <Code2 size={14} strokeWidth={1.8} className="text-[#f79009]" />,
           },
           {
             key: 'create-shell',
             label: 'Shell 节点',
-            icon: (
-              <TerminalSquare
-                size={14}
-                strokeWidth={1.8}
-                className="text-[#6172f3]"
-              />
-            ),
+            icon: <TerminalSquare size={14} strokeWidth={1.8} className="text-[#6172f3]" />,
           },
         ],
       },
@@ -188,6 +214,12 @@ const DevelopmentTreePane = ({
   const renderTitle: TreeProps['titleRender'] = (rawNode) => {
     const node = rawNode as DevelopmentTreeNode;
     const isNode = node.nodeType === 'node';
+    const metadata = isNode ? metadataById.get(node.resourceId) : undefined;
+    const updateTime = formatUpdateTime(metadata?.updateTime);
+    const modifier = metadata?.updatedBy && metadata.updatedBy !== 'unknown'
+      ? metadata.updatedBy
+      : '';
+    const updateMeta = [modifier ? `${modifier}修改` : '', updateTime].filter(Boolean).join(' ');
 
     return (
       <Dropdown
@@ -197,11 +229,21 @@ const DevelopmentTreePane = ({
           triggerSubMenuAction: 'hover',
           subMenuOpenDelay: 0.05,
           subMenuCloseDelay: 0.1,
-          onClick: ({ key }) =>
-            onResourceAction(key as DevelopmentTreeAction, node),
+          onClick: ({ key }) => onResourceAction(key as DevelopmentTreeAction, node),
         }}
       >
-        <div className="flex min-w-0 flex-1 items-center gap-2" title={node.title}>
+        <div
+          className="flex min-w-0 flex-1 items-center gap-1.5"
+          title={[node.title, updateMeta].filter(Boolean).join('  ')}
+        >
+          {isNode && metadata?.pendingPublish ? (
+            <Tooltip title="待发布">
+              <span className="inline-flex shrink-0 items-center text-[#98a2b3]">
+                <Upload size={12} strokeWidth={1.8} />
+              </span>
+            </Tooltip>
+          ) : null}
+
           {isNode ? (
             node.taskType === 'SHELL' ? (
               <TerminalSquare
@@ -217,26 +259,26 @@ const DevelopmentTreePane = ({
               />
             )
           ) : (
-            <Folder
-              size={14}
-              strokeWidth={1.8}
-              className="shrink-0 text-[#98a2b3]"
-            />
+            <Folder size={14} strokeWidth={1.8} className="shrink-0 text-[#98a2b3]" />
           )}
 
           <span
             className={[
-              'min-w-0 flex-1 truncate text-[13px] leading-8',
-              isNode ? 'font-normal text-[#344054]' : 'font-medium text-[#1f2937]',
+              'min-w-[36px] truncate text-[13px] leading-8',
+              isNode ? 'font-normal text-[#344054]' : 'flex-1 font-medium text-[#1f2937]',
             ].join(' ')}
           >
             {node.title}
           </span>
 
-          {isNode && node.taskType ? (
-            <span className="shrink-0 text-[10px] text-[#98a2b3]">
-              {node.taskType}
+          {isNode && updateMeta ? (
+            <span className="min-w-0 flex-1 truncate text-[11px] text-[#98a2b3]">
+              {updateMeta}
             </span>
+          ) : null}
+
+          {isNode && node.taskType ? (
+            <span className="shrink-0 text-[10px] text-[#98a2b3]">{node.taskType}</span>
           ) : null}
         </div>
       </Dropdown>
@@ -246,21 +288,12 @@ const DevelopmentTreePane = ({
   return (
     <>
       <aside
-        className={[
-          'group relative shrink-0 overflow-hidden bg-white',
-          'transition-[width] duration-200 ease-out',
-        ].join(' ')}
+        className="group relative shrink-0 overflow-hidden bg-white transition-[width] duration-200 ease-out"
         style={{ width: collapsed ? 0 : leftWidth }}
       >
-        <div
-          className="flex h-full flex-col overflow-hidden"
-          style={{ width: leftWidth }}
-        >
+        <div className="flex h-full flex-col overflow-hidden" style={{ width: leftWidth }}>
           <div className="flex h-9 shrink-0 items-center justify-between border-b border-[#e5e7eb] bg-[#f7f7f8] px-3">
-            <span className="text-[13px] font-semibold text-[#30323b]">
-              开发目录
-            </span>
-
+            <span className="text-[13px] font-semibold text-[#30323b]">开发目录</span>
             <Dropdown
               trigger={['click']}
               placement="bottomRight"
@@ -319,11 +352,7 @@ const DevelopmentTreePane = ({
                 <YakEmpty
                   compact
                   title={searchValue.trim() ? '未找到匹配节点' : '暂无开发节点'}
-                  description={
-                    searchValue.trim()
-                      ? '换个关键词试试'
-                      : '点击右上角 + 创建目录或节点'
-                  }
+                  description={searchValue.trim() ? '换个关键词试试' : '点击右上角 + 创建目录或节点'}
                 />
               )}
             </Spin>
@@ -347,34 +376,25 @@ const DevelopmentTreePane = ({
             collapsed ? 'cursor-default' : 'cursor-col-resize',
           ].join(' ')}
         />
-
         <div
           className={[
-            'pointer-events-none absolute inset-y-0 left-0',
-            'w-px bg-[#dfe3e8]',
+            'pointer-events-none absolute inset-y-0 left-0 w-px bg-[#dfe3e8]',
             'transition-[width,background-color] duration-150',
             !collapsed
               ? 'group-hover:w-[2px] group-hover:bg-[rgba(254,44,85,.55)] group-active:bg-[rgba(254,44,85,1)]'
               : '',
           ].join(' ')}
         />
-
         <button
           type="button"
           aria-label={collapsed ? '展开开发目录面板' : '收起开发目录面板'}
           onPointerDown={(event) => event.stopPropagation()}
           onClick={() => onCollapsedChange(!collapsed)}
           className={[
-            'absolute left-px top-1/2 z-20',
-            'flex h-7 w-3 -translate-y-1/2',
-            'items-center justify-center rounded-r-[3px]',
-            'border border-l-0 border-[#dfe3e8] bg-white text-[#7b808a]',
-            'shadow-[0_1px_2px_rgba(16,24,40,0.04)]',
-            'opacity-0 transition-[opacity,color,border-color,box-shadow] duration-150',
-            'group-hover:opacity-100 focus:opacity-100',
-            'hover:border-[#cfd4dc] hover:text-[#344054]',
-            'focus:outline-none focus-visible:ring-2',
-            'focus-visible:ring-[rgba(254,44,85,.16)]',
+            'absolute left-px top-1/2 z-20 flex h-7 w-3 -translate-y-1/2 items-center justify-center rounded-r-[3px]',
+            'border border-l-0 border-[#dfe3e8] bg-white text-[#7b808a] shadow-[0_1px_2px_rgba(16,24,40,0.04)]',
+            'opacity-0 transition-[opacity,color,border-color,box-shadow] duration-150 group-hover:opacity-100 focus:opacity-100',
+            'hover:border-[#cfd4dc] hover:text-[#344054] focus:outline-none focus-visible:ring-2 focus-visible:ring-[rgba(254,44,85,.16)]',
           ].join(' ')}
         >
           {collapsed ? <ChevronRight size={11} /> : <ChevronLeft size={11} />}

--- a/yak-ops-ui/src/pages/data-development/types.ts
+++ b/yak-ops-ui/src/pages/data-development/types.ts
@@ -24,6 +24,8 @@ export interface DevelopmentNode {
   configured: boolean;
   createTime?: string;
   updateTime?: string;
+  updatedBy?: string | null;
+  pendingPublish?: boolean;
 }
 
 export interface CreateDevelopmentNodePayload {


### PR DESCRIPTION
## 变更说明

- 数据开发左侧树节点新增“待发布”上传标识：草稿版本领先于最近发布版本时展示，已发布节点不展示。
- 节点名称后展示最后修改人和修改时间，样式保持弱提示，不抢占节点名称与 SQL/SHELL 类型标识。
- 后端节点接口补充 `updatedBy`、`pendingPublish` 元数据，并继续复用现有 `updateTime`。
- 新增节点、重命名、保存草稿时记录当前登录用户（沿用现有 `Principal` 取用户名的方式）。
- 新增 Flyway V8 迁移，为 `yak_dev_node` 增加 `updated_by` 字段。

## 待发布判定

存在草稿，且草稿 `draft_revision` 大于该节点已发布版本中的最大 `source_draft_revision` 时，标记为待发布；没有草稿或草稿已发布时不显示标识。

## 验证

已检查分支与 `main` 的变更范围；CI 状态待 GitHub Actions 返回。