### PR TITLE
feat: 补充数据分析菜单页面

### DIFF
--- a/yak-ops-ui/src/config/navigation.ts
+++ b/yak-ops-ui/src/config/navigation.ts
@@ -39,6 +39,8 @@ export const appRoutes: readonly NavigationRoute[] = [
   { id: 'home', mode: 'public', path: '/home', title: '首页', component: './home', iconKey: 'home', order: 0 },
   { id: 'data-source', mode: 'one', permission: 'resource:data-source:read', path: '/data-source', title: '数据源管理', component: './data-source', iconKey: 'database', order: 10 },
   { id: 'dashboard', mode: 'public', path: '/dashboard', title: '仪表盘', component: './dashboard', iconKey: 'insight', menuGroup: 'data-analysis', order: 10 },
+  { id: 'data-analysis-chart', mode: 'public', path: '/data-analysis/chart-analysis', title: '图表分析', component: './data-analysis/chart-analysis', iconKey: 'report', menuGroup: 'data-analysis', order: 20 },
+  { id: 'data-analysis-catalog', mode: 'public', path: '/data-analysis/data-catalog', title: '数据目录', component: './data-analysis/data-catalog', iconKey: 'database', menuGroup: 'data-analysis', order: 30 },
   { id: 'settings', mode: 'public', path: '/settings', title: '设置', component: './settings', hidden: true, order: 30 },
   {
     id: 'batch-link-up', mode: 'one', permission: 'task:batch:read',

--- a/yak-ops-ui/src/pages/data-analysis/chart-analysis/index.tsx
+++ b/yak-ops-ui/src/pages/data-analysis/chart-analysis/index.tsx
@@ -1,0 +1,3 @@
+const ChartAnalysisPage = () => <div />;
+
+export default ChartAnalysisPage;

--- a/yak-ops-ui/src/pages/data-analysis/data-catalog/index.tsx
+++ b/yak-ops-ui/src/pages/data-analysis/data-catalog/index.tsx
@@ -1,0 +1,3 @@
+const DataCatalogPage = () => <div />;
+
+export default DataCatalogPage;


### PR DESCRIPTION
## 变更说明
- 在「数据分析」菜单下补充「图表分析」和「数据目录」两个入口
- 新增对应空白页面骨架，当前仅完成路由与页面占位，不实现具体业务内容
- 保持现有「仪表盘」入口与页面实现不变

## 菜单结构
- 数据分析
  - 仪表盘
  - 图表分析
  - 数据目录

## 路由
- `/dashboard`
- `/data-analysis/chart-analysis`
- `/data-analysis/data-catalog`

## 验证
- 分支基于最新 `main`
- 当前仅 3 个文件变更：1 个导航配置、2 个空白页面
- 未运行本地 UI 构建/自动化测试