### PR TITLE
fix(data-development): bind execution and updater to current user

### DIFF
--- a/yak-ops-business/yak-ops-business-data-development/pom.xml
+++ b/yak-ops-business/yak-ops-business-data-development/pom.xml
@@ -49,6 +49,10 @@
             <groupId>io.yak.ops</groupId>
             <artifactId>yak-ops-business-job</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.yak.framework</groupId>
+            <artifactId>yak-security-spring-boot-starter</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/controller/v1/DevelopmentNodeController.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/controller/v1/DevelopmentNodeController.java
@@ -3,12 +3,13 @@ package io.yak.ops.business.development.controller.v1;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.yak.framework.common.Result;
+import io.yak.framework.security.extend.CurrentUserProvider;
 import io.yak.ops.business.development.api.DevelopmentNodeApi.CreateRequest;
 import io.yak.ops.business.development.api.DevelopmentNodeApi.RenameRequest;
 import io.yak.ops.business.development.domain.DevelopmentNode;
 import io.yak.ops.business.development.service.DevelopmentNodeService;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
-import java.security.Principal;
 import java.util.List;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -26,9 +27,13 @@ import org.springframework.web.bind.annotation.RestController;
 public class DevelopmentNodeController {
 
   private final DevelopmentNodeService service;
+  private final CurrentUserProvider currentUserProvider;
 
-  public DevelopmentNodeController(DevelopmentNodeService service) {
+  public DevelopmentNodeController(
+      DevelopmentNodeService service,
+      CurrentUserProvider currentUserProvider) {
     this.service = service;
+    this.currentUserProvider = currentUserProvider;
   }
 
   @Operation(summary = "查询数据开发节点")
@@ -41,13 +46,13 @@ public class DevelopmentNodeController {
   @PostMapping
   public Result<DevelopmentNode> create(
       @Valid @RequestBody CreateRequest request,
-      Principal principal) {
+      HttpServletRequest servletRequest) {
     DevelopmentNode created = service.create(
         request.name(),
         request.type(),
         request.projectId(),
         request.directoryId());
-    return Result.success(service.recordUpdater(created.id(), operatorName(principal)));
+    return Result.success(service.recordUpdater(created.id(), operatorName(servletRequest)));
   }
 
   @Operation(summary = "重命名数据开发节点")
@@ -55,9 +60,9 @@ public class DevelopmentNodeController {
   public Result<DevelopmentNode> rename(
       @PathVariable("id") Long id,
       @Valid @RequestBody RenameRequest request,
-      Principal principal) {
+      HttpServletRequest servletRequest) {
     DevelopmentNode renamed = service.rename(id, request.name());
-    return Result.success(service.recordUpdater(renamed.id(), operatorName(principal)));
+    return Result.success(service.recordUpdater(renamed.id(), operatorName(servletRequest)));
   }
 
   @Operation(summary = "删除数据开发节点")
@@ -67,7 +72,8 @@ public class DevelopmentNodeController {
     return Result.success(Boolean.TRUE);
   }
 
-  private String operatorName(Principal principal) {
-    return principal == null ? "unknown" : principal.getName();
+  private String operatorName(HttpServletRequest request) {
+    String operatorName = currentUserProvider.getCurrentUser(request);
+    return operatorName == null ? "unknown" : operatorName;
   }
 }

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/controller/v1/DevelopmentTaskController.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/controller/v1/DevelopmentTaskController.java
@@ -3,6 +3,7 @@ package io.yak.ops.business.development.controller.v1;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.yak.framework.common.Result;
+import io.yak.framework.security.extend.CurrentUserProvider;
 import io.yak.ops.business.development.api.DevelopmentTaskApi.PublishRequest;
 import io.yak.ops.business.development.api.DevelopmentTaskApi.RunRequest;
 import io.yak.ops.business.development.api.DevelopmentTaskApi.SaveDraftRequest;
@@ -13,8 +14,8 @@ import io.yak.ops.business.development.domain.DevelopmentTaskRunResult;
 import io.yak.ops.business.development.service.DevelopmentNodeService;
 import io.yak.ops.business.development.service.DevelopmentTaskRunService;
 import io.yak.ops.business.development.service.DevelopmentTaskService;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
-import java.security.Principal;
 import java.util.List;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -33,14 +34,17 @@ public class DevelopmentTaskController {
   private final DevelopmentTaskService service;
   private final DevelopmentTaskRunService runService;
   private final DevelopmentNodeService nodeService;
+  private final CurrentUserProvider currentUserProvider;
 
   public DevelopmentTaskController(
       DevelopmentTaskService service,
       DevelopmentTaskRunService runService,
-      DevelopmentNodeService nodeService) {
+      DevelopmentNodeService nodeService,
+      CurrentUserProvider currentUserProvider) {
     this.service = service;
     this.runService = runService;
     this.nodeService = nodeService;
+    this.currentUserProvider = currentUserProvider;
   }
 
   @Operation(summary = "读取节点草稿")
@@ -54,7 +58,7 @@ public class DevelopmentTaskController {
   public Result<DevelopmentTaskDraft> saveDraft(
       @PathVariable("nodeId") Long nodeId,
       @Valid @RequestBody SaveDraftRequest request,
-      Principal principal) {
+      HttpServletRequest servletRequest) {
     DevelopmentTaskDraft saved = service.saveDraft(
         nodeId,
         request.taskType(),
@@ -62,7 +66,7 @@ public class DevelopmentTaskController {
         request.content(),
         request.configJson(),
         request.baseRevision());
-    nodeService.recordUpdater(nodeId, operatorName(principal));
+    nodeService.recordUpdater(nodeId, operatorName(servletRequest));
     return Result.success(saved);
   }
 
@@ -71,7 +75,7 @@ public class DevelopmentTaskController {
   public Result<DevelopmentTaskRunResult> run(
       @PathVariable("nodeId") Long nodeId,
       @Valid @RequestBody RunRequest request,
-      Principal principal) {
+      HttpServletRequest servletRequest) {
     return Result.success(
         runService.run(
             nodeId,
@@ -79,7 +83,7 @@ public class DevelopmentTaskController {
             request.schemaVersion(),
             request.content(),
             request.configJson(),
-            operatorName(principal)));
+            operatorName(servletRequest)));
   }
 
   @Operation(summary = "发布节点版本")
@@ -105,7 +109,8 @@ public class DevelopmentTaskController {
     return Result.success(service.getRevision(nodeId, revisionNo));
   }
 
-  private String operatorName(Principal principal) {
-    return principal == null ? "unknown" : principal.getName();
+  private String operatorName(HttpServletRequest request) {
+    String operatorName = currentUserProvider.getCurrentUser(request);
+    return operatorName == null ? "unknown" : operatorName;
   }
 }


### PR DESCRIPTION
## 背景

数据开发运行记录中的执行人一直显示 `unknown`，同时开发目录中的节点修改信息无法展示操作人。

根因是数据开发控制器通过 Spring MVC 的 `Principal` 获取当前用户，而 Yak Security 的登录态实际维护在服务端 Session 中，并通过 `CurrentUserProvider` 暴露给业务模块。当前请求没有对应的 Spring `Principal`，因此原逻辑最终回退成了 `unknown`。

## 修改内容

- 数据开发任务运行改为通过 `CurrentUserProvider` 从服务端 Session 获取当前登录用户名
- 保存草稿时使用当前登录用户名更新节点 `updatedBy`
- 新建、重命名数据开发节点时同步记录真实操作人
- 数据开发模块显式依赖 `yak-security-spring-boot-starter`，使用安全模块提供的 `CurrentUserProvider`
- 保留未登录/无用户上下文时的 `unknown` 兜底行为

## 修复后的链路

- 当前登录用户 -> 运行 SQL -> `yak_dev_task_execution.operator_name` 写入真实用户名 -> 运行记录展示真实执行人
- 当前登录用户 -> 保存/新建/重命名节点 -> `updatedBy` 写入真实用户名 -> 开发目录展示修改人

## 说明

历史已经写入数据库的 `unknown` 记录不会自动回填；本次修复后新产生的运行记录和节点修改记录会正常绑定当前登录用户。