### PR TITLE
feat(workflow): unify workflow launch entry

### DIFF
--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/controller/v1/WorkflowController.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/controller/v1/WorkflowController.java
@@ -3,6 +3,8 @@ package io.yak.ops.business.workflow.controller.v1;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.yak.framework.common.Result;
+import io.yak.ops.business.workflow.domain.WorkflowTriggerContext;
+import io.yak.ops.business.workflow.service.WorkflowLaunchService;
 import io.yak.ops.business.workflow.service.WorkflowRuntimeService;
 import io.yak.ops.common.bean.dto.workflow.WorkflowRunDTO;
 import io.yak.ops.common.bean.vo.workflow.WorkflowInstanceVO;
@@ -24,16 +26,20 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 public class WorkflowController {
 
   private final WorkflowRuntimeService workflowRuntimeService;
+  private final WorkflowLaunchService workflowLaunchService;
 
-  public WorkflowController(WorkflowRuntimeService workflowRuntimeService) {
+  public WorkflowController(
+      WorkflowRuntimeService workflowRuntimeService,
+      WorkflowLaunchService workflowLaunchService) {
     this.workflowRuntimeService = workflowRuntimeService;
+    this.workflowLaunchService = workflowLaunchService;
   }
 
   @Operation(summary = "创建工作流运行实例")
   @PostMapping("/run")
   public Result<WorkflowInstanceVO> run(
       @Valid @RequestBody WorkflowRunDTO request) {
-    return Result.success(workflowRuntimeService.run(request));
+    return Result.success(workflowLaunchService.runAdHoc(request, WorkflowTriggerContext.api()));
   }
 
   @Operation(summary = "激活工作流运行实例")
@@ -91,7 +97,8 @@ public class WorkflowController {
   @PostMapping("/instances/{executionId}/restart")
   public Result<WorkflowInstanceVO> restart(
       @PathVariable("executionId") String executionId) {
-    return Result.success(workflowRuntimeService.restart(executionId));
+    return Result.success(
+        workflowLaunchService.restart(executionId, WorkflowTriggerContext.manual()));
   }
 
   @Operation(summary = "从指定节点重新运行")
@@ -99,7 +106,11 @@ public class WorkflowController {
   public Result<WorkflowInstanceVO> rerunFromNode(
       @PathVariable("executionId") String executionId,
       @PathVariable("nodeId") String nodeId) {
-    return Result.success(workflowRuntimeService.rerunFromNode(executionId, nodeId));
+    return Result.success(
+        workflowLaunchService.rerunFromNode(
+            executionId,
+            nodeId,
+            WorkflowTriggerContext.manual()));
   }
 
   @Operation(summary = "查询工作流实例")

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/controller/v1/WorkflowDefinitionController.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/controller/v1/WorkflowDefinitionController.java
@@ -3,7 +3,9 @@ package io.yak.ops.business.workflow.controller.v1;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.yak.framework.common.Result;
+import io.yak.ops.business.workflow.domain.WorkflowTriggerContext;
 import io.yak.ops.business.workflow.service.WorkflowDefinitionService;
+import io.yak.ops.business.workflow.service.WorkflowLaunchService;
 import io.yak.ops.common.bean.dto.workflow.WorkflowDefinitionCreateDTO;
 import io.yak.ops.common.bean.dto.workflow.WorkflowDefinitionUpdateDTO;
 import io.yak.ops.common.bean.vo.workflow.WorkflowDefinitionVO;
@@ -27,9 +29,13 @@ import org.springframework.web.bind.annotation.RestController;
 public class WorkflowDefinitionController {
 
   private final WorkflowDefinitionService definitionService;
+  private final WorkflowLaunchService launchService;
 
-  public WorkflowDefinitionController(WorkflowDefinitionService definitionService) {
+  public WorkflowDefinitionController(
+      WorkflowDefinitionService definitionService,
+      WorkflowLaunchService launchService) {
     this.definitionService = definitionService;
+    this.launchService = launchService;
   }
 
   @Operation(summary = "查询工作流定义")
@@ -91,13 +97,13 @@ public class WorkflowDefinitionController {
   @Operation(summary = "执行当前启用的已发布版本")
   @PostMapping("/{id}/run")
   public Result<WorkflowDefinitionVO> run(@PathVariable("id") String id) {
-    return Result.success(definitionService.run(id));
+    return Result.success(launchService.runPublished(id, WorkflowTriggerContext.manual()));
   }
 
   @Operation(summary = "测试运行当前工作流草稿")
   @PostMapping("/{id}/test-run")
   public Result<WorkflowDefinitionVO> testRun(@PathVariable("id") String id) {
-    return Result.success(definitionService.testRun(id));
+    return Result.success(launchService.testRunDraft(id, WorkflowTriggerContext.manual()));
   }
 
   @Operation(summary = "查询工作流发布版本")

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/domain/WorkflowTriggerContext.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/domain/WorkflowTriggerContext.java
@@ -1,0 +1,86 @@
+package io.yak.ops.business.workflow.domain;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * 工作流启动上下文。
+ *
+ * <p>Definition、调度、补数和 API 最终都通过同一个 Launch 入口进入 Runtime，
+ * 该上下文只描述“为什么启动”，不参与 DAG 本身的编排语义。</p>
+ */
+public record WorkflowTriggerContext(
+    WorkflowTriggerType triggerType,
+    String triggerId,
+    String scheduleId,
+    Instant plannedFireTime) {
+
+  public WorkflowTriggerContext {
+    if (triggerType == null) {
+      throw new IllegalArgumentException("工作流 triggerType 不能为空");
+    }
+    triggerId = required(triggerId, "工作流 triggerId 不能为空");
+    scheduleId = trimToNull(scheduleId);
+  }
+
+  public static WorkflowTriggerContext manual() {
+    return new WorkflowTriggerContext(
+        WorkflowTriggerType.MANUAL,
+        generatedId("manual"),
+        null,
+        null);
+  }
+
+  public static WorkflowTriggerContext api() {
+    return new WorkflowTriggerContext(
+        WorkflowTriggerType.API,
+        generatedId("api"),
+        null,
+        null);
+  }
+
+  public static WorkflowTriggerContext scheduled(
+      String triggerId,
+      String scheduleId,
+      Instant plannedFireTime) {
+    String safeScheduleId = required(scheduleId, "工作流 scheduleId 不能为空");
+    if (plannedFireTime == null) {
+      throw new IllegalArgumentException("调度 plannedFireTime 不能为空");
+    }
+    return new WorkflowTriggerContext(
+        WorkflowTriggerType.SCHEDULE,
+        triggerId,
+        safeScheduleId,
+        plannedFireTime);
+  }
+
+  public static WorkflowTriggerContext backfill(
+      String triggerId,
+      String scheduleId,
+      Instant plannedFireTime) {
+    if (plannedFireTime == null) {
+      throw new IllegalArgumentException("补数 plannedFireTime 不能为空");
+    }
+    return new WorkflowTriggerContext(
+        WorkflowTriggerType.BACKFILL,
+        triggerId,
+        scheduleId,
+        plannedFireTime);
+  }
+
+  private static String generatedId(String prefix) {
+    return "workflow-trigger-" + prefix + "-" + UUID.randomUUID();
+  }
+
+  private static String required(String value, String message) {
+    String normalized = trimToNull(value);
+    if (normalized == null) throw new IllegalArgumentException(message);
+    return normalized;
+  }
+
+  private static String trimToNull(String value) {
+    if (value == null) return null;
+    String normalized = value.trim();
+    return normalized.isEmpty() ? null : normalized;
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/domain/WorkflowTriggerType.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/domain/WorkflowTriggerType.java
@@ -1,0 +1,9 @@
+package io.yak.ops.business.workflow.domain;
+
+/** 工作流实例的启动来源。 */
+public enum WorkflowTriggerType {
+  MANUAL,
+  SCHEDULE,
+  BACKFILL,
+  API
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/persistence/WorkflowExecutionTriggerRecorder.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/persistence/WorkflowExecutionTriggerRecorder.java
@@ -1,0 +1,40 @@
+package io.yak.ops.business.workflow.persistence;
+
+import io.yak.ops.business.workflow.domain.WorkflowTriggerContext;
+import io.yak.ops.business.workflow.persistence.WorkflowRuntimePersistence.RuntimeMetadataRecord;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.stereotype.Component;
+
+/** 将启动来源补充到新创建 Execution 的持久化 Runtime Metadata。 */
+@Component
+public class WorkflowExecutionTriggerRecorder {
+  private final ObjectProvider<WorkflowRuntimePersistence> runtimePersistence;
+
+  public WorkflowExecutionTriggerRecorder(
+      ObjectProvider<WorkflowRuntimePersistence> runtimePersistence) {
+    this.runtimePersistence = runtimePersistence;
+  }
+
+  public void record(String executionId, WorkflowTriggerContext context) {
+    if (executionId == null || executionId.isBlank() || context == null) return;
+    WorkflowRuntimePersistence persistence = runtimePersistence.getIfAvailable();
+    if (persistence == null) return;
+
+    RuntimeMetadataRecord current = persistence.findMetadata(executionId)
+        .orElseThrow(() -> new IllegalStateException("工作流运行元数据不存在：" + executionId));
+    RuntimeMetadataRecord updated = new RuntimeMetadataRecord(
+        current.name(),
+        current.edgeCount(),
+        current.workflowTimeoutSeconds(),
+        current.failureStrategy(),
+        current.workflowVersionId(),
+        current.workflowVersionNo(),
+        current.testRun(),
+        current.nodes(),
+        context.triggerType().name(),
+        context.triggerId(),
+        context.scheduleId(),
+        context.plannedFireTime());
+    persistence.saveMetadata(executionId, updated);
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/persistence/WorkflowRuntimePersistence.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/persistence/WorkflowRuntimePersistence.java
@@ -1,6 +1,7 @@
 package io.yak.ops.business.workflow.persistence;
 
 import io.yak.ops.business.job.task.TaskVersionSnapshot;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -33,10 +34,39 @@ public interface WorkflowRuntimePersistence {
       String workflowVersionId,
       Integer workflowVersionNo,
       boolean testRun,
-      Map<String, NodeMetadataRecord> nodes) {
+      Map<String, NodeMetadataRecord> nodes,
+      String triggerType,
+      String triggerId,
+      String scheduleId,
+      Instant plannedFireTime) {
 
     public RuntimeMetadataRecord {
       nodes = nodes == null ? Map.of() : Map.copyOf(nodes);
+    }
+
+    /** 兼容现有 Runtime 调用；Trigger 会在统一 Launch 边界创建实例后补充。 */
+    public RuntimeMetadataRecord(
+        String name,
+        int edgeCount,
+        long workflowTimeoutSeconds,
+        String failureStrategy,
+        String workflowVersionId,
+        Integer workflowVersionNo,
+        boolean testRun,
+        Map<String, NodeMetadataRecord> nodes) {
+      this(
+          name,
+          edgeCount,
+          workflowTimeoutSeconds,
+          failureStrategy,
+          workflowVersionId,
+          workflowVersionNo,
+          testRun,
+          nodes,
+          null,
+          null,
+          null,
+          null);
     }
   }
 

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowLaunchService.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowLaunchService.java
@@ -1,0 +1,143 @@
+package io.yak.ops.business.workflow.service;
+
+import io.yak.ops.business.workflow.domain.WorkflowTriggerContext;
+import io.yak.ops.business.workflow.persistence.WorkflowExecutionTriggerRecorder;
+import io.yak.ops.common.bean.dto.workflow.WorkflowRunDTO;
+import io.yak.ops.common.bean.vo.workflow.WorkflowDefinitionVO;
+import io.yak.ops.common.bean.vo.workflow.WorkflowInstanceVO;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+/** 工作流统一启动入口：Trigger -> Launch -> Definition/Runtime。 */
+@Service
+public class WorkflowLaunchService {
+  private static final Logger log = LoggerFactory.getLogger(WorkflowLaunchService.class);
+
+  private final WorkflowDefinitionService definitionService;
+  private final WorkflowRuntimeService runtimeService;
+  private final WorkflowExecutionTriggerRecorder triggerRecorder;
+
+  public WorkflowLaunchService(
+      WorkflowDefinitionService definitionService,
+      WorkflowRuntimeService runtimeService,
+      WorkflowExecutionTriggerRecorder triggerRecorder) {
+    this.definitionService = definitionService;
+    this.runtimeService = runtimeService;
+    this.triggerRecorder = triggerRecorder;
+  }
+
+  /** 正式执行当前启用的已发布版本。 */
+  public WorkflowDefinitionVO runPublished(
+      String workflowId,
+      WorkflowTriggerContext triggerContext) {
+    String id = required(workflowId, "工作流 ID 不能为空");
+    return launch(
+        "PUBLISHED",
+        id,
+        triggerContext,
+        () -> definitionService.run(id),
+        WorkflowDefinitionVO::latestExecutionId);
+  }
+
+  /** 测试执行当前草稿，不改变已发布版本。 */
+  public WorkflowDefinitionVO testRunDraft(
+      String workflowId,
+      WorkflowTriggerContext triggerContext) {
+    String id = required(workflowId, "工作流 ID 不能为空");
+    return launch(
+        "DRAFT_TEST",
+        id,
+        triggerContext,
+        () -> definitionService.testRun(id),
+        WorkflowDefinitionVO::latestExecutionId);
+  }
+
+  /** 兼容直接提交 DAG 的底层运行接口，同时纳入统一 Trigger 入口。 */
+  public WorkflowInstanceVO runAdHoc(
+      WorkflowRunDTO request,
+      WorkflowTriggerContext triggerContext) {
+    Objects.requireNonNull(request, "workflow run request");
+    return launch(
+        "AD_HOC",
+        request.name(),
+        triggerContext,
+        () -> runtimeService.run(request),
+        WorkflowInstanceVO::id);
+  }
+
+  /** 整实例重新运行会创建新的 WorkflowExecution，因此也经过 Launch。 */
+  public WorkflowInstanceVO restart(
+      String executionId,
+      WorkflowTriggerContext triggerContext) {
+    String id = required(executionId, "工作流实例 ID 不能为空");
+    return launch(
+        "RESTART",
+        id,
+        triggerContext,
+        () -> runtimeService.restart(id),
+        WorkflowInstanceVO::id);
+  }
+
+  /** 从指定节点重跑会创建新的 WorkflowExecution，因此也经过 Launch。 */
+  public WorkflowInstanceVO rerunFromNode(
+      String executionId,
+      String nodeId,
+      WorkflowTriggerContext triggerContext) {
+    String safeExecutionId = required(executionId, "工作流实例 ID 不能为空");
+    String safeNodeId = required(nodeId, "工作流节点 ID 不能为空");
+    return launch(
+        "RERUN_FROM_NODE",
+        safeExecutionId + "/" + safeNodeId,
+        triggerContext,
+        () -> runtimeService.rerunFromNode(safeExecutionId, safeNodeId),
+        WorkflowInstanceVO::id);
+  }
+
+  private <T> T launch(
+      String mode,
+      String target,
+      WorkflowTriggerContext triggerContext,
+      Supplier<T> action,
+      Function<T, String> executionIdExtractor) {
+    Objects.requireNonNull(triggerContext, "workflow trigger context");
+    log.info(
+        "[workflow-launch] start mode={}, target={}, triggerType={}, triggerId={}, scheduleId={}, plannedFireTime={}",
+        mode,
+        target,
+        triggerContext.triggerType(),
+        triggerContext.triggerId(),
+        triggerContext.scheduleId(),
+        triggerContext.plannedFireTime());
+    try {
+      T result = action.get();
+      String executionId = result == null ? null : executionIdExtractor.apply(result);
+      triggerRecorder.record(executionId, triggerContext);
+      log.info(
+          "[workflow-launch] created mode={}, target={}, triggerType={}, triggerId={}, execution={}",
+          mode,
+          target,
+          triggerContext.triggerType(),
+          triggerContext.triggerId(),
+          executionId);
+      return result;
+    } catch (RuntimeException exception) {
+      log.warn(
+          "[workflow-launch] failed mode={}, target={}, triggerType={}, triggerId={}, message={}",
+          mode,
+          target,
+          triggerContext.triggerType(),
+          triggerContext.triggerId(),
+          exception.getMessage());
+      throw exception;
+    }
+  }
+
+  private String required(String value, String message) {
+    if (value == null || value.isBlank()) throw new IllegalArgumentException(message);
+    return value.trim();
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowLaunchServiceTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowLaunchServiceTest.java
@@ -1,0 +1,115 @@
+package io.yak.ops.business.workflow.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.workflow.domain.WorkflowTriggerContext;
+import io.yak.ops.business.workflow.domain.WorkflowTriggerType;
+import io.yak.ops.business.workflow.persistence.WorkflowExecutionTriggerRecorder;
+import io.yak.ops.common.bean.dto.workflow.WorkflowRunDTO;
+import io.yak.ops.common.bean.dto.workflow.WorkflowRunDTO.NodeDTO;
+import io.yak.ops.common.bean.vo.workflow.WorkflowDefinitionVO;
+import io.yak.ops.common.bean.vo.workflow.WorkflowInstanceVO;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class WorkflowLaunchServiceTest {
+
+  @Mock private WorkflowDefinitionService definitionService;
+  @Mock private WorkflowRuntimeService runtimeService;
+  @Mock private WorkflowExecutionTriggerRecorder triggerRecorder;
+
+  private WorkflowLaunchService service;
+
+  @BeforeEach
+  void setUp() {
+    service = new WorkflowLaunchService(definitionService, runtimeService, triggerRecorder);
+  }
+
+  @Test
+  void shouldRunPublishedDefinitionAndRecordTriggerContext() {
+    WorkflowTriggerContext trigger = new WorkflowTriggerContext(
+        WorkflowTriggerType.SCHEDULE,
+        "schedule-trigger-20260814T020000",
+        "schedule-1",
+        Instant.parse("2026-08-14T02:00:00Z"));
+    WorkflowDefinitionVO expected = definition("execution-1");
+    when(definitionService.run("workflow-1")).thenReturn(expected);
+
+    WorkflowDefinitionVO actual = service.runPublished("workflow-1", trigger);
+
+    assertThat(actual).isSameAs(expected);
+    verify(definitionService).run("workflow-1");
+    verify(triggerRecorder).record("execution-1", trigger);
+  }
+
+  @Test
+  void shouldRouteAdHocApiRunAndRecordTriggerContext() {
+    WorkflowRunDTO request = new WorkflowRunDTO(
+        "临时工作流",
+        List.of(new NodeDTO("node-1", "task-1")),
+        List.of(),
+        Map.of());
+    WorkflowTriggerContext trigger = WorkflowTriggerContext.api();
+    WorkflowInstanceVO expected = instance("execution-api");
+    when(runtimeService.run(request)).thenReturn(expected);
+
+    WorkflowInstanceVO actual = service.runAdHoc(request, trigger);
+
+    assertThat(actual).isSameAs(expected);
+    verify(runtimeService).run(request);
+    verify(triggerRecorder).record("execution-api", trigger);
+  }
+
+  private WorkflowDefinitionVO definition(String executionId) {
+    Instant now = Instant.parse("2026-08-13T12:00:00Z");
+    return new WorkflowDefinitionVO(
+        "workflow-1",
+        "订单同步",
+        "",
+        "ONLINE",
+        0,
+        0,
+        List.of(),
+        List.of(),
+        Map.of(),
+        Map.of(),
+        0L,
+        "CONTINUE_INDEPENDENT_BRANCHES",
+        "workflow-version-1",
+        1,
+        1,
+        false,
+        executionId,
+        "RUNNING",
+        now,
+        now);
+  }
+
+  private WorkflowInstanceVO instance(String executionId) {
+    Instant now = Instant.parse("2026-08-13T12:00:00Z");
+    return new WorkflowInstanceVO(
+        executionId,
+        "runtime-definition",
+        null,
+        "临时工作流",
+        "CREATED",
+        "CONTINUE_INDEPENDENT_BRANCHES",
+        now,
+        null,
+        null,
+        0L,
+        Map.of(),
+        0,
+        0,
+        List.of());
+  }
+}


### PR DESCRIPTION
## 背景

这是 Yak Ops 工作流调度演进的 Stage 1：统一工作流启动入口。在接入 Cron、补数和事件触发之前，先把“为什么启动”和“怎么启动”从 Definition / Runtime 中抽离出来，形成稳定的 Trigger -> Launch -> Runtime 边界。

## 本次改动

- 新增 `WorkflowLaunchService`，统一承接所有会创建新 `WorkflowExecution` 的入口
  - 已发布工作流手动运行
  - 草稿测试运行
  - Ad-hoc API 运行
  - 整实例 Restart
  - 从指定节点 Rerun
- 新增 `WorkflowTriggerType` / `WorkflowTriggerContext`
  - `MANUAL`
  - `SCHEDULE`
  - `BACKFILL`
  - `API`
- `WorkflowDefinitionController` 的正式运行 / 草稿测试运行统一经过 Launch Service
- `WorkflowController` 的 Ad-hoc run / restart / rerunFromNode 统一经过 Launch Service
- Trigger 元数据复用现有 `runtime_metadata_json` 持久化，不新增调度表、不引入 Cron/Quartz，也不修改 Workflow Engine
- Trigger metadata 记录 `triggerType / triggerId / scheduleId / plannedFireTime`，为后续 Schedule / Backfill 阶段预留稳定上下文
- 数据库关闭的轻量开发/测试模式保持兼容，Trigger Recorder 自动 no-op
- 新增 `WorkflowLaunchServiceTest`，覆盖 Published 和 Ad-hoc 两条核心启动链路

## 架构边界

```text
Manual / API / Schedule / Backfill
              |
              v
     WorkflowLaunchService
              |
        +-----+------+
        |            |
 DefinitionService  RuntimeService
        |            |
        +------v-----+
        WorkflowExecution
              |
      Yak Workflow Engine
```

本 PR **不实现** Schedule CRUD、Cron、Quartz、并发策略、Misfire 或补数；这些留给后续独立阶段，避免一次性把调度复杂度带进 Runtime。

## 兼容性

- 现有 HTTP 路径和返回类型保持不变
- Definition 的草稿、发布版本、Online/Offline 语义保持不变
- Runtime DAG 编排、暂停/恢复/取消、失败节点重试逻辑保持不变
- 历史 runtime metadata 缺失 Trigger 字段时按 `null` 兼容读取

## 验证

- PR 前 compare 检查：仅 8 个 Stage 1 相关文件，无调度 schema / Cron 误改
- 新增 Launch Service 单元测试覆盖触发来源记录
- 当前 GitHub 未为分支 HEAD 返回 workflow run / commit status；Draft 阶段先提交供审阅，CI 产生后可继续跟进
