### PR TITLE
feat(workflow): harden scheduling with durable trigger ledger

### DIFF
--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/controller/v1/WorkflowScheduleQueryController.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/controller/v1/WorkflowScheduleQueryController.java
@@ -4,6 +4,8 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.yak.framework.common.Result;
 import io.yak.ops.business.workflow.service.WorkflowScheduleQuery;
+import io.yak.ops.business.workflow.service.WorkflowScheduleTriggerQuery;
+import io.yak.ops.common.bean.vo.workflow.WorkflowScheduleTriggerVO;
 import io.yak.ops.common.bean.vo.workflow.WorkflowScheduleVO;
 import java.util.List;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -13,16 +15,20 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-/** 工作流调度定义查询接口。 */
+/** 工作流调度定义与 Trigger Ledger 查询接口。 */
 @Tag(name = "工作流调度接口")
 @RestController
 @RequestMapping("/api/v1/workflows/schedules")
 @ConditionalOnProperty(prefix = "yak.database", name = "enabled", havingValue = "true", matchIfMissing = true)
 public class WorkflowScheduleQueryController {
   private final WorkflowScheduleQuery query;
+  private final WorkflowScheduleTriggerQuery triggerQuery;
 
-  public WorkflowScheduleQueryController(WorkflowScheduleQuery query) {
+  public WorkflowScheduleQueryController(
+      WorkflowScheduleQuery query,
+      WorkflowScheduleTriggerQuery triggerQuery) {
     this.query = query;
+    this.triggerQuery = triggerQuery;
   }
 
   @Operation(summary = "查询工作流调度定义")
@@ -31,6 +37,16 @@ public class WorkflowScheduleQueryController {
       @RequestParam(value = "workflowId", required = false) String workflowId,
       @RequestParam(value = "status", required = false) String status) {
     return Result.success(query.list(workflowId, status));
+  }
+
+  @Operation(summary = "查询工作流调度 Trigger Ledger")
+  @GetMapping("/triggers")
+  public Result<List<WorkflowScheduleTriggerVO>> triggers(
+      @RequestParam(value = "scheduleId", required = false) String scheduleId,
+      @RequestParam(value = "workflowId", required = false) String workflowId,
+      @RequestParam(value = "status", required = false) String status,
+      @RequestParam(value = "limit", required = false, defaultValue = "100") Integer limit) {
+    return Result.success(triggerQuery.list(scheduleId, workflowId, status, limit));
   }
 
   @Operation(summary = "查询工作流调度详情")

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/WorkflowScheduleTriggerDao.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/WorkflowScheduleTriggerDao.java
@@ -11,6 +11,7 @@ public interface WorkflowScheduleTriggerDao {
   WorkflowScheduleTriggerPO selectByExecutionId(String executionId);
   WorkflowScheduleTriggerPO selectNextWaiting(String workflowId);
   List<WorkflowScheduleTriggerPO> selectPending();
+  List<WorkflowScheduleTriggerPO> selectQueuedBySchedule(String scheduleId);
   List<WorkflowScheduleTriggerPO> selectTriggers(String scheduleId, String workflowId, String status, int limit);
   int update(WorkflowScheduleTriggerPO trigger);
   void lockWorkflow(String workflowId);

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/WorkflowScheduleTriggerDao.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/WorkflowScheduleTriggerDao.java
@@ -1,0 +1,31 @@
+package io.yak.ops.business.workflow.dao;
+
+import io.yak.ops.common.bean.po.workflow.WorkflowScheduleTriggerPO;
+import java.time.Instant;
+import java.util.List;
+
+/** 工作流调度 Trigger Ledger 数据访问接口。 */
+public interface WorkflowScheduleTriggerDao {
+  WorkflowScheduleTriggerPO claim(WorkflowScheduleTriggerPO trigger);
+
+  WorkflowScheduleTriggerPO selectBySchedulePlan(String scheduleId, Instant plannedFireTime);
+
+  WorkflowScheduleTriggerPO selectByExecutionId(String executionId);
+
+  WorkflowScheduleTriggerPO selectNextWaiting(String workflowId);
+
+  List<WorkflowScheduleTriggerPO> selectPending();
+
+  List<WorkflowScheduleTriggerPO> selectTriggers(
+      String scheduleId, String workflowId, String status, int limit);
+
+  int update(WorkflowScheduleTriggerPO trigger);
+
+  void lockWorkflow(String workflowId);
+
+  long countActiveExecutions(String workflowId);
+
+  String selectWorkflowIdByExecution(String executionId);
+
+  String selectExecutionIdByTrigger(String triggerId);
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/WorkflowScheduleTriggerDao.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/WorkflowScheduleTriggerDao.java
@@ -14,6 +14,7 @@ public interface WorkflowScheduleTriggerDao {
   List<WorkflowScheduleTriggerPO> selectQueuedBySchedule(String scheduleId);
   List<WorkflowScheduleTriggerPO> selectTriggers(String scheduleId, String workflowId, String status, int limit);
   int update(WorkflowScheduleTriggerPO trigger);
+  int bindPreparedExecution(String triggerId, String executionId);
   void lockWorkflow(String workflowId);
   long countActiveExecutions(String workflowId);
   long countLaunchingTriggers(String workflowId);

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/WorkflowScheduleTriggerDao.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/WorkflowScheduleTriggerDao.java
@@ -25,6 +25,8 @@ public interface WorkflowScheduleTriggerDao {
 
   long countActiveExecutions(String workflowId);
 
+  long countLaunchingTriggers(String workflowId);
+
   String selectWorkflowIdByExecution(String executionId);
 
   String selectExecutionIdByTrigger(String triggerId);

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/WorkflowScheduleTriggerDao.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/WorkflowScheduleTriggerDao.java
@@ -7,27 +7,16 @@ import java.util.List;
 /** 工作流调度 Trigger Ledger 数据访问接口。 */
 public interface WorkflowScheduleTriggerDao {
   WorkflowScheduleTriggerPO claim(WorkflowScheduleTriggerPO trigger);
-
   WorkflowScheduleTriggerPO selectBySchedulePlan(String scheduleId, Instant plannedFireTime);
-
   WorkflowScheduleTriggerPO selectByExecutionId(String executionId);
-
   WorkflowScheduleTriggerPO selectNextWaiting(String workflowId);
-
   List<WorkflowScheduleTriggerPO> selectPending();
-
-  List<WorkflowScheduleTriggerPO> selectTriggers(
-      String scheduleId, String workflowId, String status, int limit);
-
+  List<WorkflowScheduleTriggerPO> selectTriggers(String scheduleId, String workflowId, String status, int limit);
   int update(WorkflowScheduleTriggerPO trigger);
-
   void lockWorkflow(String workflowId);
-
   long countActiveExecutions(String workflowId);
-
   long countLaunchingTriggers(String workflowId);
-
+  long countWaitingTriggers(String workflowId);
   String selectWorkflowIdByExecution(String executionId);
-
   String selectExecutionIdByTrigger(String triggerId);
 }

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/impl/WorkflowScheduleTriggerDaoImpl.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/impl/WorkflowScheduleTriggerDaoImpl.java
@@ -1,0 +1,122 @@
+package io.yak.ops.business.workflow.dao.impl;
+
+import com.baomidou.mybatisplus.core.toolkit.Wrappers;
+import io.yak.ops.business.workflow.dao.WorkflowScheduleTriggerDao;
+import io.yak.ops.business.workflow.dao.mapper.WorkflowScheduleTriggerMapper;
+import io.yak.ops.common.bean.po.workflow.WorkflowScheduleTriggerPO;
+import java.time.Instant;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.stereotype.Repository;
+
+/** 基于 MyBatis-Plus 的工作流调度 Trigger Ledger DAO。 */
+@Repository
+@RequiredArgsConstructor
+@DependsOn("workflowFlyway")
+@ConditionalOnProperty(
+    prefix = "yak.database",
+    name = "enabled",
+    havingValue = "true",
+    matchIfMissing = true)
+public class WorkflowScheduleTriggerDaoImpl implements WorkflowScheduleTriggerDao {
+  private static final List<String> PENDING = List.of("RECEIVED", "WAITING", "LAUNCHING", "RUNNING");
+
+  private final WorkflowScheduleTriggerMapper mapper;
+
+  @Override
+  public WorkflowScheduleTriggerPO claim(WorkflowScheduleTriggerPO trigger) {
+    mapper.insertIgnore(trigger);
+    WorkflowScheduleTriggerPO stored = selectBySchedulePlan(
+        trigger.getScheduleId(), trigger.getPlannedFireTime());
+    if (stored == null) {
+      throw new IllegalStateException(
+          "Trigger Ledger 幂等记录保存失败：" + trigger.getScheduleId() + "@" + trigger.getPlannedFireTime());
+    }
+    return stored;
+  }
+
+  @Override
+  public WorkflowScheduleTriggerPO selectBySchedulePlan(String scheduleId, Instant plannedFireTime) {
+    return mapper.selectOne(
+        Wrappers.<WorkflowScheduleTriggerPO>lambdaQuery()
+            .eq(WorkflowScheduleTriggerPO::getScheduleId, scheduleId)
+            .eq(WorkflowScheduleTriggerPO::getPlannedFireTime, plannedFireTime));
+  }
+
+  @Override
+  public WorkflowScheduleTriggerPO selectByExecutionId(String executionId) {
+    if (executionId == null || executionId.isBlank()) return null;
+    return mapper.selectOne(
+        Wrappers.<WorkflowScheduleTriggerPO>lambdaQuery()
+            .eq(WorkflowScheduleTriggerPO::getWorkflowExecutionId, executionId)
+            .last("LIMIT 1"));
+  }
+
+  @Override
+  public WorkflowScheduleTriggerPO selectNextWaiting(String workflowId) {
+    return mapper.selectOne(
+        Wrappers.<WorkflowScheduleTriggerPO>lambdaQuery()
+            .eq(WorkflowScheduleTriggerPO::getWorkflowId, workflowId)
+            .eq(WorkflowScheduleTriggerPO::getStatus, "WAITING")
+            .orderByAsc(WorkflowScheduleTriggerPO::getPlannedFireTime)
+            .orderByAsc(WorkflowScheduleTriggerPO::getCreateTime)
+            .last("LIMIT 1"));
+  }
+
+  @Override
+  public List<WorkflowScheduleTriggerPO> selectPending() {
+    return mapper.selectList(
+        Wrappers.<WorkflowScheduleTriggerPO>lambdaQuery()
+            .in(WorkflowScheduleTriggerPO::getStatus, PENDING)
+            .orderByAsc(WorkflowScheduleTriggerPO::getPlannedFireTime));
+  }
+
+  @Override
+  public List<WorkflowScheduleTriggerPO> selectTriggers(
+      String scheduleId, String workflowId, String status, int limit) {
+    var query = Wrappers.<WorkflowScheduleTriggerPO>lambdaQuery();
+    if (scheduleId != null && !scheduleId.isBlank()) {
+      query.eq(WorkflowScheduleTriggerPO::getScheduleId, scheduleId.trim());
+    }
+    if (workflowId != null && !workflowId.isBlank()) {
+      query.eq(WorkflowScheduleTriggerPO::getWorkflowId, workflowId.trim());
+    }
+    if (status != null && !status.isBlank()) {
+      query.eq(WorkflowScheduleTriggerPO::getStatus, status.trim().toUpperCase());
+    }
+    int safeLimit = Math.max(1, Math.min(limit, 500));
+    return mapper.selectList(
+        query.orderByDesc(WorkflowScheduleTriggerPO::getPlannedFireTime)
+            .last("LIMIT " + safeLimit));
+  }
+
+  @Override
+  public int update(WorkflowScheduleTriggerPO trigger) {
+    return mapper.updateById(trigger);
+  }
+
+  @Override
+  public void lockWorkflow(String workflowId) {
+    String locked = mapper.lockWorkflow(workflowId);
+    if (locked == null) {
+      throw new IllegalArgumentException("工作流不存在：" + workflowId);
+    }
+  }
+
+  @Override
+  public long countActiveExecutions(String workflowId) {
+    return mapper.countActiveExecutions(workflowId);
+  }
+
+  @Override
+  public String selectWorkflowIdByExecution(String executionId) {
+    return mapper.selectWorkflowIdByExecution(executionId);
+  }
+
+  @Override
+  public String selectExecutionIdByTrigger(String triggerId) {
+    return mapper.selectExecutionIdByTrigger(triggerId);
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/impl/WorkflowScheduleTriggerDaoImpl.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/impl/WorkflowScheduleTriggerDaoImpl.java
@@ -15,113 +15,65 @@ import org.springframework.stereotype.Repository;
 @Repository
 @RequiredArgsConstructor
 @DependsOn("workflowFlyway")
-@ConditionalOnProperty(
-    prefix = "yak.database",
-    name = "enabled",
-    havingValue = "true",
-    matchIfMissing = true)
+@ConditionalOnProperty(prefix = "yak.database", name = "enabled", havingValue = "true", matchIfMissing = true)
 public class WorkflowScheduleTriggerDaoImpl implements WorkflowScheduleTriggerDao {
   private static final List<String> PENDING = List.of("RECEIVED", "WAITING", "LAUNCHING", "RUNNING");
-
   private final WorkflowScheduleTriggerMapper mapper;
 
-  @Override
-  public WorkflowScheduleTriggerPO claim(WorkflowScheduleTriggerPO trigger) {
+  @Override public WorkflowScheduleTriggerPO claim(WorkflowScheduleTriggerPO trigger) {
     mapper.insertIgnore(trigger);
-    WorkflowScheduleTriggerPO stored = selectBySchedulePlan(
-        trigger.getScheduleId(), trigger.getPlannedFireTime());
-    if (stored == null) {
-      throw new IllegalStateException(
-          "Trigger Ledger 幂等记录保存失败：" + trigger.getScheduleId() + "@" + trigger.getPlannedFireTime());
-    }
+    WorkflowScheduleTriggerPO stored = selectBySchedulePlan(trigger.getScheduleId(), trigger.getPlannedFireTime());
+    if (stored == null) throw new IllegalStateException(
+        "Trigger Ledger 幂等记录保存失败：" + trigger.getScheduleId() + "@" + trigger.getPlannedFireTime());
     return stored;
   }
 
-  @Override
-  public WorkflowScheduleTriggerPO selectBySchedulePlan(String scheduleId, Instant plannedFireTime) {
-    return mapper.selectOne(
-        Wrappers.<WorkflowScheduleTriggerPO>lambdaQuery()
-            .eq(WorkflowScheduleTriggerPO::getScheduleId, scheduleId)
-            .eq(WorkflowScheduleTriggerPO::getPlannedFireTime, plannedFireTime));
+  @Override public WorkflowScheduleTriggerPO selectBySchedulePlan(String scheduleId, Instant plannedFireTime) {
+    return mapper.selectOne(Wrappers.<WorkflowScheduleTriggerPO>lambdaQuery()
+        .eq(WorkflowScheduleTriggerPO::getScheduleId, scheduleId)
+        .eq(WorkflowScheduleTriggerPO::getPlannedFireTime, plannedFireTime));
   }
 
-  @Override
-  public WorkflowScheduleTriggerPO selectByExecutionId(String executionId) {
+  @Override public WorkflowScheduleTriggerPO selectByExecutionId(String executionId) {
     if (executionId == null || executionId.isBlank()) return null;
-    return mapper.selectOne(
-        Wrappers.<WorkflowScheduleTriggerPO>lambdaQuery()
-            .eq(WorkflowScheduleTriggerPO::getWorkflowExecutionId, executionId)
-            .last("LIMIT 1"));
+    return mapper.selectOne(Wrappers.<WorkflowScheduleTriggerPO>lambdaQuery()
+        .eq(WorkflowScheduleTriggerPO::getWorkflowExecutionId, executionId).last("LIMIT 1"));
   }
 
-  @Override
-  public WorkflowScheduleTriggerPO selectNextWaiting(String workflowId) {
-    return mapper.selectOne(
-        Wrappers.<WorkflowScheduleTriggerPO>lambdaQuery()
-            .eq(WorkflowScheduleTriggerPO::getWorkflowId, workflowId)
-            .eq(WorkflowScheduleTriggerPO::getStatus, "WAITING")
-            .orderByAsc(WorkflowScheduleTriggerPO::getPlannedFireTime)
-            .orderByAsc(WorkflowScheduleTriggerPO::getCreateTime)
-            .last("LIMIT 1"));
+  @Override public WorkflowScheduleTriggerPO selectNextWaiting(String workflowId) {
+    return mapper.selectOne(Wrappers.<WorkflowScheduleTriggerPO>lambdaQuery()
+        .eq(WorkflowScheduleTriggerPO::getWorkflowId, workflowId)
+        .eq(WorkflowScheduleTriggerPO::getStatus, "WAITING")
+        .orderByAsc(WorkflowScheduleTriggerPO::getPlannedFireTime)
+        .orderByAsc(WorkflowScheduleTriggerPO::getCreateTime).last("LIMIT 1"));
   }
 
-  @Override
-  public List<WorkflowScheduleTriggerPO> selectPending() {
-    return mapper.selectList(
-        Wrappers.<WorkflowScheduleTriggerPO>lambdaQuery()
-            .in(WorkflowScheduleTriggerPO::getStatus, PENDING)
-            .orderByAsc(WorkflowScheduleTriggerPO::getPlannedFireTime));
+  @Override public List<WorkflowScheduleTriggerPO> selectPending() {
+    return mapper.selectList(Wrappers.<WorkflowScheduleTriggerPO>lambdaQuery()
+        .in(WorkflowScheduleTriggerPO::getStatus, PENDING)
+        .orderByAsc(WorkflowScheduleTriggerPO::getPlannedFireTime));
   }
 
-  @Override
-  public List<WorkflowScheduleTriggerPO> selectTriggers(
+  @Override public List<WorkflowScheduleTriggerPO> selectTriggers(
       String scheduleId, String workflowId, String status, int limit) {
     var query = Wrappers.<WorkflowScheduleTriggerPO>lambdaQuery();
-    if (scheduleId != null && !scheduleId.isBlank()) {
-      query.eq(WorkflowScheduleTriggerPO::getScheduleId, scheduleId.trim());
-    }
-    if (workflowId != null && !workflowId.isBlank()) {
-      query.eq(WorkflowScheduleTriggerPO::getWorkflowId, workflowId.trim());
-    }
-    if (status != null && !status.isBlank()) {
-      query.eq(WorkflowScheduleTriggerPO::getStatus, status.trim().toUpperCase());
-    }
+    if (scheduleId != null && !scheduleId.isBlank()) query.eq(WorkflowScheduleTriggerPO::getScheduleId, scheduleId.trim());
+    if (workflowId != null && !workflowId.isBlank()) query.eq(WorkflowScheduleTriggerPO::getWorkflowId, workflowId.trim());
+    if (status != null && !status.isBlank()) query.eq(WorkflowScheduleTriggerPO::getStatus, status.trim().toUpperCase());
     int safeLimit = Math.max(1, Math.min(limit, 500));
-    return mapper.selectList(
-        query.orderByDesc(WorkflowScheduleTriggerPO::getPlannedFireTime)
-            .last("LIMIT " + safeLimit));
+    return mapper.selectList(query.orderByDesc(WorkflowScheduleTriggerPO::getPlannedFireTime).last("LIMIT " + safeLimit));
   }
 
-  @Override
-  public int update(WorkflowScheduleTriggerPO trigger) {
-    return mapper.updateById(trigger);
-  }
+  @Override public int update(WorkflowScheduleTriggerPO trigger) { return mapper.updateById(trigger); }
 
-  @Override
-  public void lockWorkflow(String workflowId) {
+  @Override public void lockWorkflow(String workflowId) {
     String locked = mapper.lockWorkflow(workflowId);
-    if (locked == null) {
-      throw new IllegalArgumentException("工作流不存在：" + workflowId);
-    }
+    if (locked == null) throw new IllegalArgumentException("工作流不存在：" + workflowId);
   }
 
-  @Override
-  public long countActiveExecutions(String workflowId) {
-    return mapper.countActiveExecutions(workflowId);
-  }
-
-  @Override
-  public long countLaunchingTriggers(String workflowId) {
-    return mapper.countLaunchingTriggers(workflowId);
-  }
-
-  @Override
-  public String selectWorkflowIdByExecution(String executionId) {
-    return mapper.selectWorkflowIdByExecution(executionId);
-  }
-
-  @Override
-  public String selectExecutionIdByTrigger(String triggerId) {
-    return mapper.selectExecutionIdByTrigger(triggerId);
-  }
+  @Override public long countActiveExecutions(String workflowId) { return mapper.countActiveExecutions(workflowId); }
+  @Override public long countLaunchingTriggers(String workflowId) { return mapper.countLaunchingTriggers(workflowId); }
+  @Override public long countWaitingTriggers(String workflowId) { return mapper.countWaitingTriggers(workflowId); }
+  @Override public String selectWorkflowIdByExecution(String executionId) { return mapper.selectWorkflowIdByExecution(executionId); }
+  @Override public String selectExecutionIdByTrigger(String triggerId) { return mapper.selectExecutionIdByTrigger(triggerId); }
 }

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/impl/WorkflowScheduleTriggerDaoImpl.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/impl/WorkflowScheduleTriggerDaoImpl.java
@@ -54,6 +54,13 @@ public class WorkflowScheduleTriggerDaoImpl implements WorkflowScheduleTriggerDa
         .orderByAsc(WorkflowScheduleTriggerPO::getPlannedFireTime));
   }
 
+  @Override public List<WorkflowScheduleTriggerPO> selectQueuedBySchedule(String scheduleId) {
+    return mapper.selectList(Wrappers.<WorkflowScheduleTriggerPO>lambdaQuery()
+        .eq(WorkflowScheduleTriggerPO::getScheduleId, scheduleId)
+        .in(WorkflowScheduleTriggerPO::getStatus, List.of("RECEIVED", "WAITING"))
+        .orderByAsc(WorkflowScheduleTriggerPO::getPlannedFireTime));
+  }
+
   @Override public List<WorkflowScheduleTriggerPO> selectTriggers(
       String scheduleId, String workflowId, String status, int limit) {
     var query = Wrappers.<WorkflowScheduleTriggerPO>lambdaQuery();

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/impl/WorkflowScheduleTriggerDaoImpl.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/impl/WorkflowScheduleTriggerDaoImpl.java
@@ -111,6 +111,11 @@ public class WorkflowScheduleTriggerDaoImpl implements WorkflowScheduleTriggerDa
   }
 
   @Override
+  public long countLaunchingTriggers(String workflowId) {
+    return mapper.countLaunchingTriggers(workflowId);
+  }
+
+  @Override
   public String selectWorkflowIdByExecution(String executionId) {
     return mapper.selectWorkflowIdByExecution(executionId);
   }

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/impl/WorkflowScheduleTriggerDaoImpl.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/impl/WorkflowScheduleTriggerDaoImpl.java
@@ -72,6 +72,9 @@ public class WorkflowScheduleTriggerDaoImpl implements WorkflowScheduleTriggerDa
   }
 
   @Override public int update(WorkflowScheduleTriggerPO trigger) { return mapper.updateById(trigger); }
+  @Override public int bindPreparedExecution(String triggerId, String executionId) {
+    return mapper.bindPreparedExecution(triggerId, executionId);
+  }
 
   @Override public void lockWorkflow(String workflowId) {
     String locked = mapper.lockWorkflow(workflowId);

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/mapper/WorkflowScheduleTriggerMapper.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/mapper/WorkflowScheduleTriggerMapper.java
@@ -36,6 +36,14 @@ public interface WorkflowScheduleTriggerMapper extends BaseMapper<WorkflowSchedu
   long countActiveExecutions(@Param("workflowId") String workflowId);
 
   @Select("""
+      SELECT COUNT(*)
+      FROM yak_workflow_schedule_trigger
+      WHERE workflow_id = #{workflowId}
+        AND status = 'LAUNCHING'
+      """)
+  long countLaunchingTriggers(@Param("workflowId") String workflowId);
+
+  @Select("""
       SELECT v.workflow_id
       FROM yak_workflow_execution e
       INNER JOIN yak_workflow_version v ON v.id = e.definition_id

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/mapper/WorkflowScheduleTriggerMapper.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/mapper/WorkflowScheduleTriggerMapper.java
@@ -76,13 +76,19 @@ public interface WorkflowScheduleTriggerMapper extends BaseMapper<WorkflowSchedu
   String selectWorkflowIdByExecution(@Param("executionId") String executionId);
 
   @Select("""
-      SELECT e.id
-      FROM yak_workflow_execution e
-      WHERE e.runtime_metadata_json IS NOT NULL
-        AND JSON_VALID(e.runtime_metadata_json)
-        AND JSON_UNQUOTE(JSON_EXTRACT(e.runtime_metadata_json, '$.triggerId')) = #{triggerId}
-      ORDER BY e.created_at DESC
-      LIMIT 1
+      SELECT COALESCE(
+        (SELECT t.workflow_execution_id
+         FROM yak_workflow_schedule_trigger t
+         WHERE t.trigger_id = #{triggerId}
+         LIMIT 1),
+        (SELECT e.id
+         FROM yak_workflow_execution e
+         WHERE e.runtime_metadata_json IS NOT NULL
+           AND JSON_VALID(e.runtime_metadata_json)
+           AND JSON_UNQUOTE(JSON_EXTRACT(e.runtime_metadata_json, '$.triggerId')) = #{triggerId}
+         ORDER BY e.created_at DESC
+         LIMIT 1)
+      )
       """)
   String selectExecutionIdByTrigger(@Param("triggerId") String triggerId);
 }

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/mapper/WorkflowScheduleTriggerMapper.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/mapper/WorkflowScheduleTriggerMapper.java
@@ -5,6 +5,7 @@ import io.yak.ops.common.bean.po.workflow.WorkflowScheduleTriggerPO;
 import org.apache.ibatis.annotations.Insert;
 import org.apache.ibatis.annotations.Param;
 import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.annotations.Update;
 
 /** 工作流调度 Trigger Ledger Mapper。 */
 public interface WorkflowScheduleTriggerMapper extends BaseMapper<WorkflowScheduleTriggerPO> {
@@ -22,6 +23,20 @@ public interface WorkflowScheduleTriggerMapper extends BaseMapper<WorkflowSchedu
          #{launchedAt}, #{completedAt}, #{createTime}, #{updateTime})
       """)
   int insertIgnore(WorkflowScheduleTriggerPO trigger);
+
+  @Update("""
+      UPDATE yak_workflow_schedule_trigger
+      SET workflow_execution_id = #{executionId},
+          execution_status = 'CREATED',
+          message = 'WorkflowExecution 已持久化，等待激活',
+          update_time = CURRENT_TIMESTAMP(3)
+      WHERE trigger_id = #{triggerId}
+        AND status = 'LAUNCHING'
+        AND workflow_execution_id IS NULL
+      """)
+  int bindPreparedExecution(
+      @Param("triggerId") String triggerId,
+      @Param("executionId") String executionId);
 
   @Select("SELECT id FROM yak_workflow_definition WHERE id = #{workflowId} FOR UPDATE")
   String lockWorkflow(@Param("workflowId") String workflowId);

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/mapper/WorkflowScheduleTriggerMapper.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/mapper/WorkflowScheduleTriggerMapper.java
@@ -44,6 +44,14 @@ public interface WorkflowScheduleTriggerMapper extends BaseMapper<WorkflowSchedu
   long countLaunchingTriggers(@Param("workflowId") String workflowId);
 
   @Select("""
+      SELECT COUNT(*)
+      FROM yak_workflow_schedule_trigger
+      WHERE workflow_id = #{workflowId}
+        AND status = 'WAITING'
+      """)
+  long countWaitingTriggers(@Param("workflowId") String workflowId);
+
+  @Select("""
       SELECT v.workflow_id
       FROM yak_workflow_execution e
       INNER JOIN yak_workflow_version v ON v.id = e.definition_id

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/mapper/WorkflowScheduleTriggerMapper.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/mapper/WorkflowScheduleTriggerMapper.java
@@ -1,0 +1,57 @@
+package io.yak.ops.business.workflow.dao.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import io.yak.ops.common.bean.po.workflow.WorkflowScheduleTriggerPO;
+import org.apache.ibatis.annotations.Insert;
+import org.apache.ibatis.annotations.Param;
+import org.apache.ibatis.annotations.Select;
+
+/** 工作流调度 Trigger Ledger Mapper。 */
+public interface WorkflowScheduleTriggerMapper extends BaseMapper<WorkflowScheduleTriggerPO> {
+
+  @Insert("""
+      INSERT IGNORE INTO yak_workflow_schedule_trigger
+        (id, schedule_id, workflow_id, trigger_id, trigger_source,
+         planned_fire_time, actual_fire_time, execution_strategy, misfire_strategy,
+         status, workflow_execution_id, execution_status, message, error_message,
+         launched_at, completed_at, create_time, update_time)
+      VALUES
+        (#{id}, #{scheduleId}, #{workflowId}, #{triggerId}, #{triggerSource},
+         #{plannedFireTime}, #{actualFireTime}, #{executionStrategy}, #{misfireStrategy},
+         #{status}, #{workflowExecutionId}, #{executionStatus}, #{message}, #{errorMessage},
+         #{launchedAt}, #{completedAt}, #{createTime}, #{updateTime})
+      """)
+  int insertIgnore(WorkflowScheduleTriggerPO trigger);
+
+  @Select("SELECT id FROM yak_workflow_definition WHERE id = #{workflowId} FOR UPDATE")
+  String lockWorkflow(@Param("workflowId") String workflowId);
+
+  @Select("""
+      SELECT COUNT(*)
+      FROM yak_workflow_execution e
+      INNER JOIN yak_workflow_version v ON v.id = e.definition_id
+      WHERE v.workflow_id = #{workflowId}
+        AND e.status IN ('CREATED', 'RUNNING', 'PAUSING', 'PAUSED', 'RESUMING')
+      """)
+  long countActiveExecutions(@Param("workflowId") String workflowId);
+
+  @Select("""
+      SELECT v.workflow_id
+      FROM yak_workflow_execution e
+      INNER JOIN yak_workflow_version v ON v.id = e.definition_id
+      WHERE e.id = #{executionId}
+      LIMIT 1
+      """)
+  String selectWorkflowIdByExecution(@Param("executionId") String executionId);
+
+  @Select("""
+      SELECT e.id
+      FROM yak_workflow_execution e
+      WHERE e.runtime_metadata_json IS NOT NULL
+        AND JSON_VALID(e.runtime_metadata_json)
+        AND JSON_UNQUOTE(JSON_EXTRACT(e.runtime_metadata_json, '$.triggerId')) = #{triggerId}
+      ORDER BY e.created_at DESC
+      LIMIT 1
+      """)
+  String selectExecutionIdByTrigger(@Param("triggerId") String triggerId);
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/domain/WorkflowExecutionTerminalEvent.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/domain/WorkflowExecutionTerminalEvent.java
@@ -1,0 +1,10 @@
+package io.yak.ops.business.workflow.domain;
+
+import java.time.Instant;
+
+/** WorkflowExecution 进入终态后的事务提交事件。 */
+public record WorkflowExecutionTerminalEvent(
+    String executionId,
+    String executionStatus,
+    Instant endedAt) {
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/domain/WorkflowScheduleLaunchBindingScope.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/domain/WorkflowScheduleLaunchBindingScope.java
@@ -1,0 +1,35 @@
+package io.yak.ops.business.workflow.domain;
+
+/**
+ * 调度启动调用栈内的 Trigger 绑定作用域。
+ *
+ * <p>只用于把 engine.start 刚持久化的 WorkflowExecution ID 在同一事务里提前写回
+ * Trigger Ledger；作用域由 WorkflowLaunchService 使用 try-with-resources 严格清理。</p>
+ */
+public final class WorkflowScheduleLaunchBindingScope {
+  private static final ThreadLocal<String> TRIGGER_ID = new ThreadLocal<>();
+
+  private WorkflowScheduleLaunchBindingScope() {
+  }
+
+  public static Scope open(String triggerId) {
+    if (triggerId == null || triggerId.isBlank()) {
+      throw new IllegalArgumentException("调度 triggerId 不能为空");
+    }
+    if (TRIGGER_ID.get() != null) {
+      throw new IllegalStateException("当前线程已经存在工作流调度启动绑定作用域");
+    }
+    TRIGGER_ID.set(triggerId.trim());
+    return TRIGGER_ID::remove;
+  }
+
+  public static String currentTriggerId() {
+    return TRIGGER_ID.get();
+  }
+
+  @FunctionalInterface
+  public interface Scope extends AutoCloseable {
+    @Override
+    void close();
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/domain/WorkflowScheduleLaunchBindingScope.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/domain/WorkflowScheduleLaunchBindingScope.java
@@ -1,13 +1,18 @@
 package io.yak.ops.business.workflow.domain;
 
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.Objects;
+
 /**
  * 调度启动调用栈内的 Trigger 绑定作用域。
  *
  * <p>只用于把 engine.start 刚持久化的 WorkflowExecution ID 在同一事务里提前写回
- * Trigger Ledger；作用域由 WorkflowLaunchService 使用 try-with-resources 严格清理。</p>
+ * Trigger Ledger。使用栈支持“超快实例终态 -> 立即推进下一条 SERIAL_WAIT”的嵌套启动。</p>
  */
 public final class WorkflowScheduleLaunchBindingScope {
-  private static final ThreadLocal<String> TRIGGER_ID = new ThreadLocal<>();
+  private static final ThreadLocal<Deque<String>> TRIGGER_IDS =
+      ThreadLocal.withInitial(ArrayDeque::new);
 
   private WorkflowScheduleLaunchBindingScope() {
   }
@@ -16,15 +21,26 @@ public final class WorkflowScheduleLaunchBindingScope {
     if (triggerId == null || triggerId.isBlank()) {
       throw new IllegalArgumentException("调度 triggerId 不能为空");
     }
-    if (TRIGGER_ID.get() != null) {
-      throw new IllegalStateException("当前线程已经存在工作流调度启动绑定作用域");
-    }
-    TRIGGER_ID.set(triggerId.trim());
-    return TRIGGER_ID::remove;
+    String normalized = triggerId.trim();
+    TRIGGER_IDS.get().push(normalized);
+    return () -> close(normalized);
   }
 
   public static String currentTriggerId() {
-    return TRIGGER_ID.get();
+    Deque<String> values = TRIGGER_IDS.get();
+    String current = values.peek();
+    if (values.isEmpty()) TRIGGER_IDS.remove();
+    return current;
+  }
+
+  private static void close(String expected) {
+    Deque<String> values = TRIGGER_IDS.get();
+    String actual = values.poll();
+    if (values.isEmpty()) TRIGGER_IDS.remove();
+    if (!Objects.equals(expected, actual)) {
+      throw new IllegalStateException(
+          "工作流调度启动绑定作用域关闭顺序异常：expected=" + expected + ", actual=" + actual);
+    }
   }
 
   @FunctionalInterface

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/persistence/WorkflowExecutionRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/persistence/WorkflowExecutionRepositoryAdapter.java
@@ -11,6 +11,7 @@ import io.yak.framework.workflow.engine.state.NodeAttemptStatus;
 import io.yak.framework.workflow.engine.state.NodeExecutionStatus;
 import io.yak.framework.workflow.engine.state.WorkflowExecutionStatus;
 import io.yak.ops.business.workflow.dao.WorkflowExecutionDao;
+import io.yak.ops.business.workflow.domain.WorkflowExecutionTerminalEvent;
 import io.yak.ops.business.workflow.persistence.support.WorkflowJsonCodec;
 import io.yak.ops.common.bean.po.workflow.WorkflowExecutionPO;
 import io.yak.ops.common.bean.po.workflow.WorkflowNodeAttemptPO;
@@ -23,6 +24,7 @@ import java.util.Map;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.DependsOn;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
@@ -39,6 +41,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class WorkflowExecutionRepositoryAdapter implements ExecutionRepository {
   private final WorkflowExecutionDao executionDao;
   private final WorkflowJsonCodec json;
+  private final ApplicationEventPublisher eventPublisher;
 
   @Override
   @Transactional(transactionManager = "yakBusinessTransactionManager")
@@ -50,6 +53,10 @@ public class WorkflowExecutionRepositoryAdapter implements ExecutionRepository {
       for (NodeAttemptSnapshot attempt : node.attempts()) {
         executionDao.upsertNodeAttempt(toPO(snapshot.id(), node, attempt));
       }
+    }
+    if (snapshot.status().isTerminal()) {
+      eventPublisher.publishEvent(new WorkflowExecutionTerminalEvent(
+          snapshot.id(), snapshot.status().name(), snapshot.endedAt()));
     }
   }
 

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/persistence/WorkflowExecutionRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/persistence/WorkflowExecutionRepositoryAdapter.java
@@ -11,7 +11,9 @@ import io.yak.framework.workflow.engine.state.NodeAttemptStatus;
 import io.yak.framework.workflow.engine.state.NodeExecutionStatus;
 import io.yak.framework.workflow.engine.state.WorkflowExecutionStatus;
 import io.yak.ops.business.workflow.dao.WorkflowExecutionDao;
+import io.yak.ops.business.workflow.dao.WorkflowScheduleTriggerDao;
 import io.yak.ops.business.workflow.domain.WorkflowExecutionTerminalEvent;
+import io.yak.ops.business.workflow.domain.WorkflowScheduleLaunchBindingScope;
 import io.yak.ops.business.workflow.persistence.support.WorkflowJsonCodec;
 import io.yak.ops.common.bean.po.workflow.WorkflowExecutionPO;
 import io.yak.ops.common.bean.po.workflow.WorkflowNodeAttemptPO;
@@ -21,6 +23,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -40,6 +43,7 @@ import org.springframework.transaction.annotation.Transactional;
     matchIfMissing = true)
 public class WorkflowExecutionRepositoryAdapter implements ExecutionRepository {
   private final WorkflowExecutionDao executionDao;
+  private final WorkflowScheduleTriggerDao scheduleTriggerDao;
   private final WorkflowJsonCodec json;
   private final ApplicationEventPublisher eventPublisher;
 
@@ -48,6 +52,7 @@ public class WorkflowExecutionRepositoryAdapter implements ExecutionRepository {
   public void save(WorkflowExecution execution) {
     WorkflowExecutionSnapshot snapshot = execution.snapshot();
     executionDao.upsertExecution(toPO(snapshot));
+    bindPreparedScheduledExecution(snapshot);
     for (NodeExecutionSnapshot node : snapshot.nodes()) {
       executionDao.upsertNodeExecution(toPO(node));
       for (NodeAttemptSnapshot attempt : node.attempts()) {
@@ -57,6 +62,22 @@ public class WorkflowExecutionRepositoryAdapter implements ExecutionRepository {
     if (snapshot.status().isTerminal()) {
       eventPublisher.publishEvent(new WorkflowExecutionTerminalEvent(
           snapshot.id(), snapshot.status().name(), snapshot.endedAt()));
+    }
+  }
+
+  private void bindPreparedScheduledExecution(WorkflowExecutionSnapshot snapshot) {
+    if (snapshot.status() != WorkflowExecutionStatus.CREATED) return;
+    String triggerId = WorkflowScheduleLaunchBindingScope.currentTriggerId();
+    if (triggerId == null) return;
+
+    int bound = scheduleTriggerDao.bindPreparedExecution(triggerId, snapshot.id());
+    if (bound == 1) return;
+
+    String existingExecutionId = scheduleTriggerDao.selectExecutionIdByTrigger(triggerId);
+    if (!Objects.equals(existingExecutionId, snapshot.id())) {
+      throw new IllegalStateException(
+          "调度 Trigger 无法原子绑定 WorkflowExecution：triggerId="
+              + triggerId + ", executionId=" + snapshot.id());
     }
   }
 

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowDefinitionService.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowDefinitionService.java
@@ -297,12 +297,21 @@ public class WorkflowDefinitionService {
   }
 
   public WorkflowDefinitionVO run(String id) {
+    return runPublished(id, false);
+  }
+
+  /** 调度并行策略专用：并发准入由 Trigger Ledger 协调器负责。 */
+  WorkflowDefinitionVO runConcurrent(String id) {
+    return runPublished(id, true);
+  }
+
+  private WorkflowDefinitionVO runPublished(String id, boolean allowConcurrent) {
     DefinitionState state = require(id);
     synchronized (state) {
       if (!"ONLINE".equals(state.status) || state.activeVersion == null) {
         throw new IllegalStateException("工作流没有启用的发布版本，不能正式执行");
       }
-      ensureIdle(state);
+      if (!allowConcurrent) ensureIdle(state);
       WorkflowVersion version = state.activeVersion;
       return activate(
           state,

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowLaunchService.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowLaunchService.java
@@ -1,5 +1,6 @@
 package io.yak.ops.business.workflow.service;
 
+import io.yak.ops.business.workflow.domain.WorkflowScheduleLaunchBindingScope;
 import io.yak.ops.business.workflow.domain.WorkflowTriggerContext;
 import io.yak.ops.business.workflow.persistence.WorkflowExecutionTriggerRecorder;
 import io.yak.ops.common.bean.dto.workflow.WorkflowRunDTO;
@@ -46,19 +47,22 @@ public class WorkflowLaunchService {
   /**
    * 调度协调器专用的发布版本启动入口。
    *
-   * <p>并发准入已经由 Trigger Ledger + workflow 行锁完成，因此这里允许创建并行
-   * WorkflowExecution；普通手工运行不会调用该入口。</p>
+   * <p>并发准入已经由 Trigger Ledger + workflow 行锁完成。作用域会让 ExecutionRepository
+   * 在 engine.start 首次持久化 CREATED 实例时就把 executionId 写回 Ledger，随后才进入 activate，
+   * 从而让宕机恢复能够识别“已经创建但尚未完成 Launch 返回”的实例。</p>
    */
   public WorkflowDefinitionVO runScheduledPublished(
       String workflowId,
       WorkflowTriggerContext triggerContext) {
     String id = required(workflowId, "工作流 ID 不能为空");
-    return launch(
-        "SCHEDULED_PUBLISHED",
-        id,
-        triggerContext,
-        () -> definitionService.runConcurrent(id),
-        WorkflowDefinitionVO::latestExecutionId);
+    try (var ignored = WorkflowScheduleLaunchBindingScope.open(triggerContext.triggerId())) {
+      return launch(
+          "SCHEDULED_PUBLISHED",
+          id,
+          triggerContext,
+          () -> definitionService.runConcurrent(id),
+          WorkflowDefinitionVO::latestExecutionId);
+    }
   }
 
   /** 测试执行当前草稿，不改变已发布版本。 */
@@ -133,6 +137,7 @@ public class WorkflowLaunchService {
     try {
       T result = action.get();
       String executionId = result == null ? null : executionIdExtractor.apply(result);
+      // Ledger 的 executionId 已在首次 CREATED 持久化时提前绑定；这里继续记录通用 runtime trigger metadata。
       triggerRecorder.record(executionId, triggerContext);
       log.info(
           "[workflow-launch] created mode={}, target={}, triggerType={}, triggerId={}, execution={}",

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowLaunchService.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowLaunchService.java
@@ -30,7 +30,7 @@ public class WorkflowLaunchService {
     this.triggerRecorder = triggerRecorder;
   }
 
-  /** 正式执行当前启用的已发布版本。 */
+  /** 正式执行当前启用的已发布版本；手工/API 启动仍保持单实例安全默认。 */
   public WorkflowDefinitionVO runPublished(
       String workflowId,
       WorkflowTriggerContext triggerContext) {
@@ -40,6 +40,24 @@ public class WorkflowLaunchService {
         id,
         triggerContext,
         () -> definitionService.run(id),
+        WorkflowDefinitionVO::latestExecutionId);
+  }
+
+  /**
+   * 调度协调器专用的发布版本启动入口。
+   *
+   * <p>并发准入已经由 Trigger Ledger + workflow 行锁完成，因此这里允许创建并行
+   * WorkflowExecution；普通手工运行不会调用该入口。</p>
+   */
+  public WorkflowDefinitionVO runScheduledPublished(
+      String workflowId,
+      WorkflowTriggerContext triggerContext) {
+    String id = required(workflowId, "工作流 ID 不能为空");
+    return launch(
+        "SCHEDULED_PUBLISHED",
+        id,
+        triggerContext,
+        () -> definitionService.runConcurrent(id),
         WorkflowDefinitionVO::latestExecutionId);
   }
 

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowRecoveryService.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowRecoveryService.java
@@ -32,7 +32,8 @@ public class WorkflowRecoveryService {
   @Order(10)
   @EventListener(ApplicationReadyEvent.class)
   public void recover() {
-    // 先恢复全部非终态 WorkflowExecution，再由 Schedule Reconciler 恢复 Trigger Ledger。
+    // Register executions as active before reconciliation. This does not execute a node by itself;
+    // it only guarantees that a recovered SUBMITTED dispatch drains immediately when reconstructed.
     for (String executionId : runtimePersistence.findRecoverableExecutionIds()) {
       try {
         runtimeService.activate(executionId);

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowRecoveryService.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowRecoveryService.java
@@ -6,6 +6,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.event.EventListener;
+import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Service;
 
 /** Rebuilds non-terminal workflow runtime state after Yak Ops has fully started. */
@@ -28,10 +29,10 @@ public class WorkflowRecoveryService {
     this.runtimePersistence = runtimePersistence;
   }
 
+  @Order(10)
   @EventListener(ApplicationReadyEvent.class)
   public void recover() {
-    // Register executions as active before reconciliation. This does not execute a node by itself;
-    // it only guarantees that a recovered SUBMITTED dispatch drains immediately when reconstructed.
+    // 先恢复全部非终态 WorkflowExecution，再由 Schedule Reconciler 恢复 Trigger Ledger。
     for (String executionId : runtimePersistence.findRecoverableExecutionIds()) {
       try {
         runtimeService.activate(executionId);

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowScheduleExecutionListener.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowScheduleExecutionListener.java
@@ -1,0 +1,26 @@
+package io.yak.ops.business.workflow.service;
+
+import io.yak.ops.business.workflow.domain.WorkflowExecutionTerminalEvent;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+/** WorkflowExecution 终态提交后完成 Trigger Ledger，并推进 SERIAL_WAIT 队首。 */
+@Component
+@ConditionalOnProperty(prefix = "yak.database", name = "enabled", havingValue = "true", matchIfMissing = true)
+public class WorkflowScheduleExecutionListener {
+  private final WorkflowScheduleTriggerCoordinator coordinator;
+
+  public WorkflowScheduleExecutionListener(WorkflowScheduleTriggerCoordinator coordinator) {
+    this.coordinator = coordinator;
+  }
+
+  @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
+  public void onTerminal(WorkflowExecutionTerminalEvent event) {
+    coordinator.completeExecution(
+        event.executionId(),
+        event.executionStatus(),
+        event.endedAt());
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowScheduleLifecycle.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowScheduleLifecycle.java
@@ -8,7 +8,7 @@ import java.time.Instant;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
-/** 工作流调度定义启停生命周期，并同步 Yak Schedule 引擎状态。 */
+/** 工作流调度定义启停生命周期，并同步 Yak Schedule 引擎与 Trigger Ledger 状态。 */
 @Component
 @ConditionalOnProperty(prefix = "yak.database", name = "enabled", havingValue = "true", matchIfMissing = true)
 public class WorkflowScheduleLifecycle {
@@ -17,18 +17,21 @@ public class WorkflowScheduleLifecycle {
   private final WorkflowScheduleDao dao;
   private final WorkflowScheduleEngineBridge engine;
   private final WorkflowScheduleRuntimeState runtimeState;
+  private final WorkflowSchedulePendingTriggerCancellation pendingCancellation;
 
   public WorkflowScheduleLifecycle(
       WorkflowDefinitionService definitions,
       WorkflowScheduleQuery query,
       WorkflowScheduleDao dao,
       WorkflowScheduleEngineBridge engine,
-      WorkflowScheduleRuntimeState runtimeState) {
+      WorkflowScheduleRuntimeState runtimeState,
+      WorkflowSchedulePendingTriggerCancellation pendingCancellation) {
     this.definitions = definitions;
     this.query = query;
     this.dao = dao;
     this.engine = engine;
     this.runtimeState = runtimeState;
+    this.pendingCancellation = pendingCancellation;
   }
 
   public WorkflowScheduleVO online(String id) {
@@ -63,6 +66,8 @@ public class WorkflowScheduleLifecycle {
   public WorkflowScheduleVO offline(String id) {
     WorkflowSchedulePO value = query.require(id);
     engine.pauseIfPresent(value.getId());
+    pendingCancellation.cancel(
+        value.getId(), value.getWorkflowId(), "调度已停用，取消尚未启动的等待 Trigger");
     value.setStatus("OFFLINE");
     value.setNextFireTime(null);
     value.setUpdateTime(Instant.now());
@@ -74,6 +79,8 @@ public class WorkflowScheduleLifecycle {
   WorkflowScheduleVO expire(String id, Instant fireTime) {
     WorkflowSchedulePO value = query.require(id);
     engine.pauseIfPresent(value.getId());
+    pendingCancellation.cancel(
+        value.getId(), value.getWorkflowId(), "调度已超过生效时间，取消尚未启动的等待 Trigger");
     value.setStatus("OFFLINE");
     value.setLastFireTime(fireTime);
     value.setNextFireTime(null);
@@ -87,6 +94,8 @@ public class WorkflowScheduleLifecycle {
     if ("ONLINE".equals(value.getStatus())) {
       throw new IllegalStateException("已启用的调度请先下线后再删除");
     }
+    pendingCancellation.cancel(
+        value.getId(), value.getWorkflowId(), "调度定义已删除，取消尚未启动的等待 Trigger");
     engine.deleteIfPresent(value.getId());
     if (dao.deleteSchedule(value.getId()) != 1) {
       throw new IllegalStateException("删除工作流调度失败：" + value.getId());

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowScheduleLifecycle.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowScheduleLifecycle.java
@@ -66,12 +66,12 @@ public class WorkflowScheduleLifecycle {
   public WorkflowScheduleVO offline(String id) {
     WorkflowSchedulePO value = query.require(id);
     engine.pauseIfPresent(value.getId());
-    pendingCancellation.cancel(
-        value.getId(), value.getWorkflowId(), "调度已停用，取消尚未启动的等待 Trigger");
     value.setStatus("OFFLINE");
     value.setNextFireTime(null);
     value.setUpdateTime(Instant.now());
     save(value);
+    pendingCancellation.cancel(
+        value.getId(), value.getWorkflowId(), "调度已停用，取消尚未启动的等待 Trigger");
     return query.view(value);
   }
 
@@ -79,13 +79,13 @@ public class WorkflowScheduleLifecycle {
   WorkflowScheduleVO expire(String id, Instant fireTime) {
     WorkflowSchedulePO value = query.require(id);
     engine.pauseIfPresent(value.getId());
-    pendingCancellation.cancel(
-        value.getId(), value.getWorkflowId(), "调度已超过生效时间，取消尚未启动的等待 Trigger");
     value.setStatus("OFFLINE");
     value.setLastFireTime(fireTime);
     value.setNextFireTime(null);
     value.setUpdateTime(Instant.now());
     save(value);
+    pendingCancellation.cancel(
+        value.getId(), value.getWorkflowId(), "调度已超过生效时间，取消尚未启动的等待 Trigger");
     return query.view(value);
   }
 

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowScheduleMisfireRecovery.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowScheduleMisfireRecovery.java
@@ -7,7 +7,6 @@ import java.time.Instant;
 import java.util.UUID;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 /**
  * 基于业务表中持久化 nextFireTime 的启动期 Misfire 恢复。
@@ -36,7 +35,6 @@ public class WorkflowScheduleMisfireRecovery {
     coordinator.recoverMisfire(schedule, missedFireTime, recoveredAt);
   }
 
-  @Transactional(transactionManager = "yakBusinessTransactionManager")
   public void recordSkipped(
       WorkflowSchedulePO schedule,
       Instant missedFireTime,

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowScheduleMisfireRecovery.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowScheduleMisfireRecovery.java
@@ -1,0 +1,63 @@
+package io.yak.ops.business.workflow.service;
+
+import io.yak.ops.business.workflow.dao.WorkflowScheduleTriggerDao;
+import io.yak.ops.common.bean.po.workflow.WorkflowSchedulePO;
+import io.yak.ops.common.bean.po.workflow.WorkflowScheduleTriggerPO;
+import java.time.Instant;
+import java.util.UUID;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 基于业务表中持久化 nextFireTime 的启动期 Misfire 恢复。
+ *
+ * <p>FIRE_ONCE 合并为一次补触发；SKIP 也写入 Ledger，保证错过的计划可审计。</p>
+ */
+@Component
+@ConditionalOnProperty(prefix = "yak.database", name = "enabled", havingValue = "true", matchIfMissing = true)
+public class WorkflowScheduleMisfireRecovery {
+  private final WorkflowScheduleTriggerCoordinator coordinator;
+  private final WorkflowScheduleTriggerDao ledger;
+
+  public WorkflowScheduleMisfireRecovery(
+      WorkflowScheduleTriggerCoordinator coordinator,
+      WorkflowScheduleTriggerDao ledger) {
+    this.coordinator = coordinator;
+    this.ledger = ledger;
+  }
+
+  public void recover(WorkflowSchedulePO schedule, Instant missedFireTime, Instant recoveredAt) {
+    if (schedule == null || missedFireTime == null) return;
+    if ("SKIP".equals(schedule.getMisfireStrategy())) {
+      recordSkipped(schedule, missedFireTime, recoveredAt);
+      return;
+    }
+    coordinator.recoverMisfire(schedule, missedFireTime, recoveredAt);
+  }
+
+  @Transactional(transactionManager = "yakBusinessTransactionManager")
+  public void recordSkipped(
+      WorkflowSchedulePO schedule,
+      Instant missedFireTime,
+      Instant recoveredAt) {
+    Instant now = recoveredAt == null ? Instant.now() : recoveredAt;
+    WorkflowScheduleTriggerPO value = new WorkflowScheduleTriggerPO();
+    value.setId("workflow-trigger-ledger-" + UUID.randomUUID());
+    value.setScheduleId(schedule.getId());
+    value.setWorkflowId(schedule.getWorkflowId());
+    value.setTriggerId(
+        "workflow-misfire-skip-" + schedule.getId() + "-" + missedFireTime.toEpochMilli());
+    value.setTriggerSource("MISFIRE_RECOVERY");
+    value.setPlannedFireTime(missedFireTime);
+    value.setActualFireTime(now);
+    value.setExecutionStrategy(schedule.getExecutionStrategy());
+    value.setMisfireStrategy(schedule.getMisfireStrategy());
+    value.setStatus("SKIPPED");
+    value.setMessage("服务恢复时发现错过计划，按 SKIP 策略跳过");
+    value.setCompletedAt(now);
+    value.setCreateTime(now);
+    value.setUpdateTime(now);
+    ledger.claim(value);
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowSchedulePendingTriggerCancellation.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowSchedulePendingTriggerCancellation.java
@@ -1,0 +1,38 @@
+package io.yak.ops.business.workflow.service;
+
+import io.yak.ops.business.workflow.dao.WorkflowScheduleTriggerDao;
+import io.yak.ops.common.bean.po.workflow.WorkflowScheduleTriggerPO;
+import java.time.Instant;
+import java.util.Set;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/** 调度停用时清理尚未创建 WorkflowExecution 的 Trigger。 */
+@Component
+@ConditionalOnProperty(prefix = "yak.database", name = "enabled", havingValue = "true", matchIfMissing = true)
+public class WorkflowSchedulePendingTriggerCancellation {
+  private static final Set<String> QUEUED = Set.of("RECEIVED", "WAITING");
+
+  private final WorkflowScheduleTriggerDao ledger;
+
+  public WorkflowSchedulePendingTriggerCancellation(WorkflowScheduleTriggerDao ledger) {
+    this.ledger = ledger;
+  }
+
+  @Transactional(transactionManager = "yakBusinessTransactionManager")
+  public void cancel(String scheduleId, String workflowId, String reason) {
+    ledger.lockWorkflow(workflowId);
+    Instant now = Instant.now();
+    for (WorkflowScheduleTriggerPO trigger : ledger.selectTriggers(scheduleId, workflowId, null, 500)) {
+      if (!QUEUED.contains(trigger.getStatus())) continue;
+      trigger.setStatus("SKIPPED");
+      trigger.setMessage(reason == null || reason.isBlank() ? "调度已停用，取消等待 Trigger" : reason);
+      trigger.setCompletedAt(now);
+      trigger.setUpdateTime(now);
+      if (ledger.update(trigger) != 1) {
+        throw new IllegalStateException("取消等待 Trigger 失败：" + trigger.getId());
+      }
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowSchedulePendingTriggerCancellation.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowSchedulePendingTriggerCancellation.java
@@ -3,17 +3,14 @@ package io.yak.ops.business.workflow.service;
 import io.yak.ops.business.workflow.dao.WorkflowScheduleTriggerDao;
 import io.yak.ops.common.bean.po.workflow.WorkflowScheduleTriggerPO;
 import java.time.Instant;
-import java.util.Set;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-/** 调度停用时清理尚未创建 WorkflowExecution 的 Trigger。 */
+/** 调度停用时清理全部尚未创建 WorkflowExecution 的 Trigger。 */
 @Component
 @ConditionalOnProperty(prefix = "yak.database", name = "enabled", havingValue = "true", matchIfMissing = true)
 public class WorkflowSchedulePendingTriggerCancellation {
-  private static final Set<String> QUEUED = Set.of("RECEIVED", "WAITING");
-
   private final WorkflowScheduleTriggerDao ledger;
 
   public WorkflowSchedulePendingTriggerCancellation(WorkflowScheduleTriggerDao ledger) {
@@ -24,8 +21,7 @@ public class WorkflowSchedulePendingTriggerCancellation {
   public void cancel(String scheduleId, String workflowId, String reason) {
     ledger.lockWorkflow(workflowId);
     Instant now = Instant.now();
-    for (WorkflowScheduleTriggerPO trigger : ledger.selectTriggers(scheduleId, workflowId, null, 500)) {
-      if (!QUEUED.contains(trigger.getStatus())) continue;
+    for (WorkflowScheduleTriggerPO trigger : ledger.selectQueuedBySchedule(scheduleId)) {
       trigger.setStatus("SKIPPED");
       trigger.setMessage(reason == null || reason.isBlank() ? "调度已停用，取消等待 Trigger" : reason);
       trigger.setCompletedAt(now);

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowScheduleReconciler.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowScheduleReconciler.java
@@ -76,6 +76,7 @@ public class WorkflowScheduleReconciler {
     Instant now = Instant.now();
     for (WorkflowSchedulePO schedule : schedules) {
       if (!"ONLINE".equals(schedule.getStatus())) continue;
+      Instant missedFireTime = null;
       try {
         var workflow = definitions.get(schedule.getWorkflowId());
         boolean workflowReady = "ONLINE".equals(workflow.status()) && workflow.activeVersionId() != null;
@@ -87,20 +88,12 @@ public class WorkflowScheduleReconciler {
         }
 
         Instant persistedNextFireTime = schedule.getNextFireTime();
-        Instant missedFireTime = persistedNextFireTime != null && !persistedNextFireTime.isAfter(now)
+        missedFireTime = persistedNextFireTime != null && !persistedNextFireTime.isAfter(now)
             ? persistedNextFireTime
             : null;
 
         var snapshot = engine.save(schedule);
         runtimeState.syncSnapshot(schedule, snapshot);
-
-        if (missedFireTime != null) {
-          misfireRecovery.recover(schedule, missedFireTime, now);
-          log.info(
-              "[workflow-schedule] recovered misfire schedule={}, planned={}, policy={}",
-              schedule.getId(), missedFireTime, schedule.getMisfireStrategy());
-        }
-
         log.info(
             "[workflow-schedule] reconciled schedule={}, workflow={}, nextFireTime={}",
             schedule.getId(),
@@ -114,6 +107,24 @@ public class WorkflowScheduleReconciler {
             schedule.getWorkflowId(),
             exception.getMessage(),
             exception);
+        continue;
+      }
+
+      if (missedFireTime != null) {
+        try {
+          misfireRecovery.recover(schedule, missedFireTime, now);
+          log.info(
+              "[workflow-schedule] recovered misfire schedule={}, planned={}, policy={}",
+              schedule.getId(), missedFireTime, schedule.getMisfireStrategy());
+        } catch (RuntimeException exception) {
+          log.error(
+              "[workflow-schedule] misfire recovery failed schedule={}, planned={}, policy={}, message={}",
+              schedule.getId(),
+              missedFireTime,
+              schedule.getMisfireStrategy(),
+              exception.getMessage(),
+              exception);
+        }
       }
     }
 

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowScheduleReconciler.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowScheduleReconciler.java
@@ -11,12 +11,13 @@ import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.event.EventListener;
+import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
 /**
- * 应用启动后以 yak_workflow_schedule 为事实来源，对 Yak Schedule/Quartz 做一次对账恢复。
+ * 应用启动后以 yak_workflow_schedule 为事实来源，对 Yak Schedule/Quartz 与 Trigger Ledger 做对账恢复。
  *
- * <p>因此即便 Quartz 使用 memory store，Yak Ops 重启后 ONLINE 计划也会自动恢复。</p>
+ * <p>即便 Quartz 使用 memory store，ONLINE 计划、错过触发和串行等待队列都可从业务数据库恢复。</p>
  */
 @Component
 @ConditionalOnProperty(prefix = "yak.database", name = "enabled", havingValue = "true", matchIfMissing = true)
@@ -27,18 +28,25 @@ public class WorkflowScheduleReconciler {
   private final WorkflowDefinitionService definitions;
   private final WorkflowScheduleEngineBridge engine;
   private final WorkflowScheduleRuntimeState runtimeState;
+  private final WorkflowScheduleMisfireRecovery misfireRecovery;
+  private final WorkflowScheduleTriggerCoordinator coordinator;
 
   public WorkflowScheduleReconciler(
       WorkflowScheduleDao dao,
       WorkflowDefinitionService definitions,
       WorkflowScheduleEngineBridge engine,
-      WorkflowScheduleRuntimeState runtimeState) {
+      WorkflowScheduleRuntimeState runtimeState,
+      WorkflowScheduleMisfireRecovery misfireRecovery,
+      WorkflowScheduleTriggerCoordinator coordinator) {
     this.dao = dao;
     this.definitions = definitions;
     this.engine = engine;
     this.runtimeState = runtimeState;
+    this.misfireRecovery = misfireRecovery;
+    this.coordinator = coordinator;
   }
 
+  @Order(20)
   @EventListener(ApplicationReadyEvent.class)
   public void reconcile() {
     if (!engine.available()) {
@@ -78,8 +86,21 @@ public class WorkflowScheduleReconciler {
           continue;
         }
 
+        Instant persistedNextFireTime = schedule.getNextFireTime();
+        Instant missedFireTime = persistedNextFireTime != null && !persistedNextFireTime.isAfter(now)
+            ? persistedNextFireTime
+            : null;
+
         var snapshot = engine.save(schedule);
         runtimeState.syncSnapshot(schedule, snapshot);
+
+        if (missedFireTime != null) {
+          misfireRecovery.recover(schedule, missedFireTime, now);
+          log.info(
+              "[workflow-schedule] recovered misfire schedule={}, planned={}, policy={}",
+              schedule.getId(), missedFireTime, schedule.getMisfireStrategy());
+        }
+
         log.info(
             "[workflow-schedule] reconciled schedule={}, workflow={}, nextFireTime={}",
             schedule.getId(),
@@ -94,6 +115,15 @@ public class WorkflowScheduleReconciler {
             exception.getMessage(),
             exception);
       }
+    }
+
+    try {
+      coordinator.recoverPending();
+    } catch (RuntimeException exception) {
+      log.error(
+          "[workflow-schedule] trigger ledger recovery failed message={}",
+          exception.getMessage(),
+          exception);
     }
   }
 

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowScheduleTriggerAdmission.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowScheduleTriggerAdmission.java
@@ -1,0 +1,307 @@
+package io.yak.ops.business.workflow.service;
+
+import io.yak.ops.business.workflow.dao.WorkflowExecutionDao;
+import io.yak.ops.business.workflow.dao.WorkflowScheduleTriggerDao;
+import io.yak.ops.common.bean.po.workflow.WorkflowExecutionPO;
+import io.yak.ops.common.bean.po.workflow.WorkflowSchedulePO;
+import io.yak.ops.common.bean.po.workflow.WorkflowScheduleTriggerPO;
+import java.time.Instant;
+import java.util.List;
+import java.util.Set;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/** Trigger Ledger 的短事务准入、绑定和队首预留。实际 Workflow 启动不在这里执行。 */
+@Component
+@ConditionalOnProperty(prefix = "yak.database", name = "enabled", havingValue = "true", matchIfMissing = true)
+public class WorkflowScheduleTriggerAdmission {
+  private static final Set<String> EXECUTION_TERMINAL = Set.of(
+      "SUCCESS", "SUCCESS_WITH_WARNINGS", "FAILED", "CANCELED", "TIMED_OUT");
+  private static final Set<String> LEDGER_TERMINAL = Set.of(
+      "SUCCEEDED", "FAILED", "CANCELED", "SKIPPED");
+
+  private final WorkflowScheduleTriggerDao ledger;
+  private final WorkflowScheduleQuery schedules;
+  private final WorkflowExecutionDao executions;
+
+  public WorkflowScheduleTriggerAdmission(
+      WorkflowScheduleTriggerDao ledger,
+      WorkflowScheduleQuery schedules,
+      WorkflowExecutionDao executions) {
+    this.ledger = ledger;
+    this.schedules = schedules;
+    this.executions = executions;
+  }
+
+  @Transactional(transactionManager = "yakBusinessTransactionManager")
+  public AdmissionResult admitNew(
+      WorkflowSchedulePO schedule,
+      WorkflowScheduleTriggerPO candidate) {
+    WorkflowScheduleTriggerPO trigger = ledger.claim(candidate);
+    if (!"RECEIVED".equals(trigger.getStatus())) {
+      return new AdmissionResult(trigger, false, true);
+    }
+    ledger.lockWorkflow(schedule.getWorkflowId());
+    return decideLocked(schedule, trigger, false);
+  }
+
+  /** 启动恢复时重新处理 RECEIVED/无绑定 LAUNCHING 中间态。 */
+  @Transactional(transactionManager = "yakBusinessTransactionManager")
+  public AdmissionResult readmit(
+      WorkflowSchedulePO schedule,
+      WorkflowScheduleTriggerPO candidate) {
+    ledger.lockWorkflow(schedule.getWorkflowId());
+    WorkflowScheduleTriggerPO trigger = current(candidate);
+    if (LEDGER_TERMINAL.contains(trigger.getStatus()) || "RUNNING".equals(trigger.getStatus())) {
+      return new AdmissionResult(trigger, false, true);
+    }
+    trigger.setStatus("RECEIVED");
+    trigger.setWorkflowExecutionId(null);
+    trigger.setExecutionStatus(null);
+    trigger.setMessage("启动恢复重新执行 Trigger 准入");
+    trigger.setErrorMessage(null);
+    touch(trigger);
+    save(trigger);
+    return decideLocked(schedule, trigger, true);
+  }
+
+  /** 启动完成后绑定业务实例；若实例已同步终态，同时预留下一条 SERIAL_WAIT。 */
+  @Transactional(transactionManager = "yakBusinessTransactionManager")
+  public AdmissionResult bindLaunch(
+      WorkflowScheduleTriggerPO candidate,
+      String executionId) {
+    WorkflowScheduleTriggerPO trigger = current(candidate);
+    ledger.lockWorkflow(trigger.getWorkflowId());
+    trigger = current(trigger);
+    trigger.setWorkflowExecutionId(executionId);
+    WorkflowExecutionPO execution = executionId == null ? null : executions.selectExecution(executionId);
+    String status = execution == null ? null : execution.getStatus();
+    trigger.setExecutionStatus(status);
+    if (isExecutionTerminal(status)) {
+      markTerminal(trigger, status, execution.getEndedAt());
+      return reserveNextLocked(trigger.getWorkflowId());
+    }
+    trigger.setStatus("RUNNING");
+    trigger.setMessage("WorkflowExecution 已创建");
+    touch(trigger);
+    save(trigger);
+    return new AdmissionResult(trigger, false, false);
+  }
+
+  /** 启动失败释放 LAUNCHING 占位，并立即尝试推进等待队列。 */
+  @Transactional(transactionManager = "yakBusinessTransactionManager")
+  public AdmissionResult failLaunch(
+      WorkflowScheduleTriggerPO candidate,
+      Throwable error) {
+    WorkflowScheduleTriggerPO trigger = current(candidate);
+    ledger.lockWorkflow(trigger.getWorkflowId());
+    trigger = current(trigger);
+    trigger.setStatus("FAILED");
+    trigger.setMessage("创建 WorkflowExecution 失败");
+    trigger.setErrorMessage(safeMessage(error));
+    trigger.setCompletedAt(Instant.now());
+    touch(trigger);
+    save(trigger);
+    return reserveNextLocked(trigger.getWorkflowId());
+  }
+
+  /** WorkflowExecution 终态提交后，完成 Ledger 并在同一短事务中预留下一条等待 Trigger。 */
+  @Transactional(transactionManager = "yakBusinessTransactionManager")
+  public AdmissionResult completeExecution(
+      String executionId,
+      String executionStatus,
+      Instant endedAt) {
+    WorkflowScheduleTriggerPO trigger = ledger.selectByExecutionId(executionId);
+    String workflowId = trigger == null
+        ? ledger.selectWorkflowIdByExecution(executionId)
+        : trigger.getWorkflowId();
+    if (workflowId == null || workflowId.isBlank()) return AdmissionResult.none();
+
+    ledger.lockWorkflow(workflowId);
+    if (trigger != null) {
+      trigger = ledger.selectByExecutionId(executionId);
+      if (trigger != null && !LEDGER_TERMINAL.contains(trigger.getStatus())) {
+        markTerminal(trigger, executionStatus, endedAt);
+      }
+    }
+    return reserveNextLocked(workflowId);
+  }
+
+  /** 恢复已绑定的 RUNNING/LAUNCHING Ledger；返回值可能是新预留的队首。 */
+  @Transactional(transactionManager = "yakBusinessTransactionManager")
+  public AdmissionResult recoverBound(
+      WorkflowScheduleTriggerPO candidate,
+      String executionId) {
+    WorkflowScheduleTriggerPO trigger = current(candidate);
+    ledger.lockWorkflow(trigger.getWorkflowId());
+    trigger = current(trigger);
+    WorkflowExecutionPO execution = executionId == null ? null : executions.selectExecution(executionId);
+    if (execution == null) return new AdmissionResult(trigger, false, false);
+
+    trigger.setWorkflowExecutionId(executionId);
+    trigger.setExecutionStatus(execution.getStatus());
+    if (isExecutionTerminal(execution.getStatus())) {
+      markTerminal(trigger, execution.getStatus(), execution.getEndedAt());
+      return reserveNextLocked(trigger.getWorkflowId());
+    }
+    trigger.setStatus("RUNNING");
+    trigger.setMessage("启动恢复已重新绑定 WorkflowExecution");
+    touch(trigger);
+    save(trigger);
+    return new AdmissionResult(trigger, false, false);
+  }
+
+  @Transactional(transactionManager = "yakBusinessTransactionManager")
+  public AdmissionResult reserveNext(String workflowId) {
+    ledger.lockWorkflow(workflowId);
+    return reserveNextLocked(workflowId);
+  }
+
+  @Transactional(transactionManager = "yakBusinessTransactionManager")
+  public void skip(WorkflowScheduleTriggerPO candidate, String message) {
+    WorkflowScheduleTriggerPO trigger = current(candidate);
+    if (LEDGER_TERMINAL.contains(trigger.getStatus()) || "RUNNING".equals(trigger.getStatus())) return;
+    ledger.lockWorkflow(trigger.getWorkflowId());
+    trigger = current(trigger);
+    if (LEDGER_TERMINAL.contains(trigger.getStatus()) || "RUNNING".equals(trigger.getStatus())) return;
+    markSkipped(trigger, message);
+  }
+
+  private AdmissionResult decideLocked(
+      WorkflowSchedulePO schedule,
+      WorkflowScheduleTriggerPO trigger,
+      boolean recoveringCurrentLaunchReservation) {
+    String strategy = schedule.getExecutionStrategy();
+    long active = ledger.countActiveExecutions(schedule.getWorkflowId());
+    long launching = ledger.countLaunchingTriggers(schedule.getWorkflowId());
+    if (recoveringCurrentLaunchReservation && "LAUNCHING".equals(trigger.getStatus())) {
+      launching = Math.max(0L, launching - 1L);
+    }
+    boolean busy = active > 0L || launching > 0L;
+
+    if ("SERIAL_DISCARD".equals(strategy) && busy) {
+      markSkipped(trigger, "已有运行或启动中的 WorkflowExecution，按 SERIAL_DISCARD 跳过");
+      return new AdmissionResult(trigger, false, false);
+    }
+
+    if ("SERIAL_WAIT".equals(strategy) && busy) {
+      trigger.setStatus("WAITING");
+      trigger.setMessage("已有运行或启动中的 WorkflowExecution，进入串行等待队列");
+      touch(trigger);
+      save(trigger);
+      return new AdmissionResult(trigger, false, false);
+    }
+
+    reserveLaunch(trigger);
+    return new AdmissionResult(trigger, true, false);
+  }
+
+  private AdmissionResult reserveNextLocked(String workflowId) {
+    if (ledger.countActiveExecutions(workflowId) > 0L
+        || ledger.countLaunchingTriggers(workflowId) > 0L) {
+      return AdmissionResult.none();
+    }
+
+    while (true) {
+      WorkflowScheduleTriggerPO waiting = ledger.selectNextWaiting(workflowId);
+      if (waiting == null) return AdmissionResult.none();
+      WorkflowSchedulePO schedule = safeSchedule(waiting.getScheduleId());
+      if (schedule == null || !"ONLINE".equals(schedule.getStatus())) {
+        markSkipped(waiting, "等待期间调度已停用或删除");
+        continue;
+      }
+      if (!"SERIAL_WAIT".equals(schedule.getExecutionStrategy())) {
+        markSkipped(waiting, "等待期间执行策略已变更，旧 Trigger 不再推进");
+        continue;
+      }
+      reserveLaunch(waiting);
+      return new AdmissionResult(waiting, true, false);
+    }
+  }
+
+  private void reserveLaunch(WorkflowScheduleTriggerPO trigger) {
+    trigger.setStatus("LAUNCHING");
+    trigger.setMessage("Trigger 已获得执行准入，等待创建 WorkflowExecution");
+    trigger.setLaunchedAt(Instant.now());
+    trigger.setErrorMessage(null);
+    touch(trigger);
+    save(trigger);
+  }
+
+  private void markSkipped(WorkflowScheduleTriggerPO trigger, String message) {
+    trigger.setStatus("SKIPPED");
+    trigger.setMessage(message);
+    trigger.setCompletedAt(Instant.now());
+    touch(trigger);
+    save(trigger);
+  }
+
+  private void markTerminal(
+      WorkflowScheduleTriggerPO trigger,
+      String executionStatus,
+      Instant endedAt) {
+    trigger.setExecutionStatus(executionStatus);
+    trigger.setStatus(ledgerStatus(executionStatus));
+    trigger.setMessage("WorkflowExecution 已进入终态：" + executionStatus);
+    trigger.setCompletedAt(endedAt == null ? Instant.now() : endedAt);
+    touch(trigger);
+    save(trigger);
+  }
+
+  private String ledgerStatus(String executionStatus) {
+    if ("SUCCESS".equals(executionStatus) || "SUCCESS_WITH_WARNINGS".equals(executionStatus)) {
+      return "SUCCEEDED";
+    }
+    if ("CANCELED".equals(executionStatus)) return "CANCELED";
+    return "FAILED";
+  }
+
+  private boolean isExecutionTerminal(String status) {
+    return status != null && EXECUTION_TERMINAL.contains(status);
+  }
+
+  private WorkflowScheduleTriggerPO current(WorkflowScheduleTriggerPO candidate) {
+    WorkflowScheduleTriggerPO current = ledger.selectBySchedulePlan(
+        candidate.getScheduleId(), candidate.getPlannedFireTime());
+    if (current == null) throw new IllegalArgumentException("Trigger Ledger 不存在：" + candidate.getId());
+    return current;
+  }
+
+  private WorkflowSchedulePO safeSchedule(String scheduleId) {
+    try {
+      return schedules.require(scheduleId);
+    } catch (IllegalArgumentException missing) {
+      return null;
+    }
+  }
+
+  private void touch(WorkflowScheduleTriggerPO trigger) {
+    trigger.setUpdateTime(Instant.now());
+  }
+
+  private void save(WorkflowScheduleTriggerPO trigger) {
+    if (ledger.update(trigger) != 1) {
+      throw new IllegalStateException("更新 Trigger Ledger 失败：" + trigger.getId());
+    }
+  }
+
+  private String safeMessage(Throwable error) {
+    Throwable current = error;
+    while (current.getCause() != null && current.getCause() != current) current = current.getCause();
+    String message = current.getMessage();
+    String value = message == null || message.isBlank()
+        ? current.getClass().getSimpleName()
+        : current.getClass().getSimpleName() + ": " + message;
+    return value.length() <= 2000 ? value : value.substring(0, 2000);
+  }
+
+  public record AdmissionResult(
+      WorkflowScheduleTriggerPO trigger,
+      boolean launchNow,
+      boolean duplicate) {
+    static AdmissionResult none() {
+      return new AdmissionResult(null, false, false);
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowScheduleTriggerAdmission.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowScheduleTriggerAdmission.java
@@ -36,7 +36,9 @@ public class WorkflowScheduleTriggerAdmission {
   @Transactional(transactionManager = "yakBusinessTransactionManager")
   public AdmissionResult admitNew(WorkflowSchedulePO schedule, WorkflowScheduleTriggerPO candidate) {
     WorkflowScheduleTriggerPO trigger = ledger.claim(candidate);
-    if (!"RECEIVED".equals(trigger.getStatus())) {
+    // INSERT IGNORE 后只有 candidate 自己的 id 与落库行一致时才拥有首次准入权。
+    // 即使两个相同 plannedFireTime 并发请求都读到 RECEIVED，第二个也会作为 duplicate 返回。
+    if (!candidate.getId().equals(trigger.getId()) || !"RECEIVED".equals(trigger.getStatus())) {
       return new AdmissionResult(trigger, false, true);
     }
     ledger.lockWorkflow(schedule.getWorkflowId());

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowScheduleTriggerAdmission.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowScheduleTriggerAdmission.java
@@ -6,7 +6,6 @@ import io.yak.ops.common.bean.po.workflow.WorkflowExecutionPO;
 import io.yak.ops.common.bean.po.workflow.WorkflowSchedulePO;
 import io.yak.ops.common.bean.po.workflow.WorkflowScheduleTriggerPO;
 import java.time.Instant;
-import java.util.List;
 import java.util.Set;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
@@ -35,22 +34,18 @@ public class WorkflowScheduleTriggerAdmission {
   }
 
   @Transactional(transactionManager = "yakBusinessTransactionManager")
-  public AdmissionResult admitNew(
-      WorkflowSchedulePO schedule,
-      WorkflowScheduleTriggerPO candidate) {
+  public AdmissionResult admitNew(WorkflowSchedulePO schedule, WorkflowScheduleTriggerPO candidate) {
     WorkflowScheduleTriggerPO trigger = ledger.claim(candidate);
     if (!"RECEIVED".equals(trigger.getStatus())) {
       return new AdmissionResult(trigger, false, true);
     }
     ledger.lockWorkflow(schedule.getWorkflowId());
-    return decideLocked(schedule, trigger, false);
+    return decideLocked(schedule, trigger);
   }
 
   /** 启动恢复时重新处理 RECEIVED/无绑定 LAUNCHING 中间态。 */
   @Transactional(transactionManager = "yakBusinessTransactionManager")
-  public AdmissionResult readmit(
-      WorkflowSchedulePO schedule,
-      WorkflowScheduleTriggerPO candidate) {
+  public AdmissionResult readmit(WorkflowSchedulePO schedule, WorkflowScheduleTriggerPO candidate) {
     ledger.lockWorkflow(schedule.getWorkflowId());
     WorkflowScheduleTriggerPO trigger = current(candidate);
     if (LEDGER_TERMINAL.contains(trigger.getStatus()) || "RUNNING".equals(trigger.getStatus())) {
@@ -63,14 +58,12 @@ public class WorkflowScheduleTriggerAdmission {
     trigger.setErrorMessage(null);
     touch(trigger);
     save(trigger);
-    return decideLocked(schedule, trigger, true);
+    return decideLocked(schedule, trigger);
   }
 
   /** 启动完成后绑定业务实例；若实例已同步终态，同时预留下一条 SERIAL_WAIT。 */
   @Transactional(transactionManager = "yakBusinessTransactionManager")
-  public AdmissionResult bindLaunch(
-      WorkflowScheduleTriggerPO candidate,
-      String executionId) {
+  public AdmissionResult bindLaunch(WorkflowScheduleTriggerPO candidate, String executionId) {
     WorkflowScheduleTriggerPO trigger = current(candidate);
     ledger.lockWorkflow(trigger.getWorkflowId());
     trigger = current(trigger);
@@ -91,9 +84,7 @@ public class WorkflowScheduleTriggerAdmission {
 
   /** 启动失败释放 LAUNCHING 占位，并立即尝试推进等待队列。 */
   @Transactional(transactionManager = "yakBusinessTransactionManager")
-  public AdmissionResult failLaunch(
-      WorkflowScheduleTriggerPO candidate,
-      Throwable error) {
+  public AdmissionResult failLaunch(WorkflowScheduleTriggerPO candidate, Throwable error) {
     WorkflowScheduleTriggerPO trigger = current(candidate);
     ledger.lockWorkflow(trigger.getWorkflowId());
     trigger = current(trigger);
@@ -108,10 +99,7 @@ public class WorkflowScheduleTriggerAdmission {
 
   /** WorkflowExecution 终态提交后，完成 Ledger 并在同一短事务中预留下一条等待 Trigger。 */
   @Transactional(transactionManager = "yakBusinessTransactionManager")
-  public AdmissionResult completeExecution(
-      String executionId,
-      String executionStatus,
-      Instant endedAt) {
+  public AdmissionResult completeExecution(String executionId, String executionStatus, Instant endedAt) {
     WorkflowScheduleTriggerPO trigger = ledger.selectByExecutionId(executionId);
     String workflowId = trigger == null
         ? ledger.selectWorkflowIdByExecution(executionId)
@@ -130,14 +118,20 @@ public class WorkflowScheduleTriggerAdmission {
 
   /** 恢复已绑定的 RUNNING/LAUNCHING Ledger；返回值可能是新预留的队首。 */
   @Transactional(transactionManager = "yakBusinessTransactionManager")
-  public AdmissionResult recoverBound(
-      WorkflowScheduleTriggerPO candidate,
-      String executionId) {
+  public AdmissionResult recoverBound(WorkflowScheduleTriggerPO candidate, String executionId) {
     WorkflowScheduleTriggerPO trigger = current(candidate);
     ledger.lockWorkflow(trigger.getWorkflowId());
     trigger = current(trigger);
     WorkflowExecutionPO execution = executionId == null ? null : executions.selectExecution(executionId);
-    if (execution == null) return new AdmissionResult(trigger, false, false);
+    if (execution == null) {
+      trigger.setStatus("RECEIVED");
+      trigger.setWorkflowExecutionId(null);
+      trigger.setExecutionStatus(null);
+      trigger.setMessage("启动恢复未找到原 WorkflowExecution，等待重新准入");
+      touch(trigger);
+      save(trigger);
+      return new AdmissionResult(trigger, false, false);
+    }
 
     trigger.setWorkflowExecutionId(executionId);
     trigger.setExecutionStatus(execution.getStatus());
@@ -168,26 +162,20 @@ public class WorkflowScheduleTriggerAdmission {
     markSkipped(trigger, message);
   }
 
-  private AdmissionResult decideLocked(
-      WorkflowSchedulePO schedule,
-      WorkflowScheduleTriggerPO trigger,
-      boolean recoveringCurrentLaunchReservation) {
+  private AdmissionResult decideLocked(WorkflowSchedulePO schedule, WorkflowScheduleTriggerPO trigger) {
     String strategy = schedule.getExecutionStrategy();
     long active = ledger.countActiveExecutions(schedule.getWorkflowId());
     long launching = ledger.countLaunchingTriggers(schedule.getWorkflowId());
-    if (recoveringCurrentLaunchReservation && "LAUNCHING".equals(trigger.getStatus())) {
-      launching = Math.max(0L, launching - 1L);
-    }
-    boolean busy = active > 0L || launching > 0L;
+    long waiting = ledger.countWaitingTriggers(schedule.getWorkflowId());
+    boolean busy = active > 0L || launching > 0L || waiting > 0L;
 
     if ("SERIAL_DISCARD".equals(strategy) && busy) {
-      markSkipped(trigger, "已有运行或启动中的 WorkflowExecution，按 SERIAL_DISCARD 跳过");
+      markSkipped(trigger, "已有运行、启动或排队中的 WorkflowExecution，按 SERIAL_DISCARD 跳过");
       return new AdmissionResult(trigger, false, false);
     }
-
     if ("SERIAL_WAIT".equals(strategy) && busy) {
       trigger.setStatus("WAITING");
-      trigger.setMessage("已有运行或启动中的 WorkflowExecution，进入串行等待队列");
+      trigger.setMessage("已有运行、启动或排队中的 WorkflowExecution，进入串行等待队列");
       touch(trigger);
       save(trigger);
       return new AdmissionResult(trigger, false, false);
@@ -202,7 +190,6 @@ public class WorkflowScheduleTriggerAdmission {
         || ledger.countLaunchingTriggers(workflowId) > 0L) {
       return AdmissionResult.none();
     }
-
     while (true) {
       WorkflowScheduleTriggerPO waiting = ledger.selectNextWaiting(workflowId);
       if (waiting == null) return AdmissionResult.none();
@@ -237,10 +224,7 @@ public class WorkflowScheduleTriggerAdmission {
     save(trigger);
   }
 
-  private void markTerminal(
-      WorkflowScheduleTriggerPO trigger,
-      String executionStatus,
-      Instant endedAt) {
+  private void markTerminal(WorkflowScheduleTriggerPO trigger, String executionStatus, Instant endedAt) {
     trigger.setExecutionStatus(executionStatus);
     trigger.setStatus(ledgerStatus(executionStatus));
     trigger.setMessage("WorkflowExecution 已进入终态：" + executionStatus);
@@ -250,9 +234,7 @@ public class WorkflowScheduleTriggerAdmission {
   }
 
   private String ledgerStatus(String executionStatus) {
-    if ("SUCCESS".equals(executionStatus) || "SUCCESS_WITH_WARNINGS".equals(executionStatus)) {
-      return "SUCCEEDED";
-    }
+    if ("SUCCESS".equals(executionStatus) || "SUCCESS_WITH_WARNINGS".equals(executionStatus)) return "SUCCEEDED";
     if ("CANCELED".equals(executionStatus)) return "CANCELED";
     return "FAILED";
   }
@@ -262,8 +244,7 @@ public class WorkflowScheduleTriggerAdmission {
   }
 
   private WorkflowScheduleTriggerPO current(WorkflowScheduleTriggerPO candidate) {
-    WorkflowScheduleTriggerPO current = ledger.selectBySchedulePlan(
-        candidate.getScheduleId(), candidate.getPlannedFireTime());
+    WorkflowScheduleTriggerPO current = ledger.selectBySchedulePlan(candidate.getScheduleId(), candidate.getPlannedFireTime());
     if (current == null) throw new IllegalArgumentException("Trigger Ledger 不存在：" + candidate.getId());
     return current;
   }
@@ -276,14 +257,10 @@ public class WorkflowScheduleTriggerAdmission {
     }
   }
 
-  private void touch(WorkflowScheduleTriggerPO trigger) {
-    trigger.setUpdateTime(Instant.now());
-  }
+  private void touch(WorkflowScheduleTriggerPO trigger) { trigger.setUpdateTime(Instant.now()); }
 
   private void save(WorkflowScheduleTriggerPO trigger) {
-    if (ledger.update(trigger) != 1) {
-      throw new IllegalStateException("更新 Trigger Ledger 失败：" + trigger.getId());
-    }
+    if (ledger.update(trigger) != 1) throw new IllegalStateException("更新 Trigger Ledger 失败：" + trigger.getId());
   }
 
   private String safeMessage(Throwable error) {
@@ -296,12 +273,7 @@ public class WorkflowScheduleTriggerAdmission {
     return value.length() <= 2000 ? value : value.substring(0, 2000);
   }
 
-  public record AdmissionResult(
-      WorkflowScheduleTriggerPO trigger,
-      boolean launchNow,
-      boolean duplicate) {
-    static AdmissionResult none() {
-      return new AdmissionResult(null, false, false);
-    }
+  public record AdmissionResult(WorkflowScheduleTriggerPO trigger, boolean launchNow, boolean duplicate) {
+    static AdmissionResult none() { return new AdmissionResult(null, false, false); }
   }
 }

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowScheduleTriggerCoordinator.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowScheduleTriggerCoordinator.java
@@ -17,11 +17,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
-/**
- * Trigger Ledger、幂等与 WorkflowExecution 并发策略的统一协调器。
- *
- * <p>准入由短事务完成；真正创建 WorkflowExecution 时不持有工作流行锁。</p>
- */
+/** Trigger Ledger、幂等与 WorkflowExecution 并发策略统一协调器。 */
 @Component
 @ConditionalOnProperty(prefix = "yak.database", name = "enabled", havingValue = "true", matchIfMissing = true)
 public class WorkflowScheduleTriggerCoordinator {
@@ -54,11 +50,8 @@ public class WorkflowScheduleTriggerCoordinator {
         newTrigger(schedule, triggerId, plannedFireTime, actualFireTime, triggerSource));
     if (result.duplicate()) return duplicateResult(result.trigger());
     if (!result.launchNow()) {
-      return ScheduleExecutionResult.accepted(
-          result.trigger().getWorkflowExecutionId(),
-          result.trigger().getMessage());
+      return ScheduleExecutionResult.accepted(result.trigger().getWorkflowExecutionId(), result.trigger().getMessage());
     }
-
     String executionId = launchReserved(result);
     return ScheduleExecutionResult.accepted(executionId, "工作流调度 Trigger 已获得执行准入");
   }
@@ -68,12 +61,7 @@ public class WorkflowScheduleTriggerCoordinator {
       Instant plannedFireTime,
       Instant actualFireTime) {
     String triggerId = "workflow-misfire-" + schedule.getId() + "-" + plannedFireTime.toEpochMilli();
-    return submit(
-        schedule,
-        triggerId,
-        plannedFireTime,
-        actualFireTime,
-        "MISFIRE_RECOVERY");
+    return submit(schedule, triggerId, plannedFireTime, actualFireTime, "MISFIRE_RECOVERY");
   }
 
   /** 应用重启后修复 Ledger 中间态，并恢复 SERIAL_WAIT 队列。 */
@@ -89,8 +77,23 @@ public class WorkflowScheduleTriggerCoordinator {
       }
 
       if (executionId != null && !executionId.isBlank()) {
-        AdmissionResult next = admission.recoverBound(trigger, executionId);
-        launchReserved(next);
+        AdmissionResult recovered = admission.recoverBound(trigger, executionId);
+        if (recovered.launchNow()) {
+          launchReserved(recovered);
+          continue;
+        }
+        if (recovered.trigger() != null && "RECEIVED".equals(recovered.trigger().getStatus())) {
+          WorkflowSchedulePO schedule = safeSchedule(trigger.getScheduleId());
+          if (schedule == null || !"ONLINE".equals(schedule.getStatus())) {
+            admission.skip(recovered.trigger(), "原 WorkflowExecution 已不存在且调度已停用，恢复时跳过");
+          } else {
+            AdmissionResult readmitted = admission.readmit(schedule, recovered.trigger());
+            if (readmitted.launchNow()) launchReserved(readmitted);
+            else if (readmitted.trigger() != null && "WAITING".equals(readmitted.trigger().getStatus())) {
+              waitingWorkflows.add(trigger.getWorkflowId());
+            }
+          }
+        }
         continue;
       }
 
@@ -99,16 +102,14 @@ public class WorkflowScheduleTriggerCoordinator {
         admission.skip(trigger, "调度已停用或删除，启动恢复时跳过未启动 Trigger");
         continue;
       }
-
       if ("WAITING".equals(trigger.getStatus())) {
         waitingWorkflows.add(trigger.getWorkflowId());
         continue;
       }
 
       AdmissionResult readmitted = admission.readmit(schedule, trigger);
-      if (readmitted.launchNow()) {
-        launchReserved(readmitted);
-      } else if ("WAITING".equals(readmitted.trigger().getStatus())) {
+      if (readmitted.launchNow()) launchReserved(readmitted);
+      else if (readmitted.trigger() != null && "WAITING".equals(readmitted.trigger().getStatus())) {
         waitingWorkflows.add(trigger.getWorkflowId());
       }
     }
@@ -141,27 +142,21 @@ public class WorkflowScheduleTriggerCoordinator {
         WorkflowDefinitionVO launched = launchService.runScheduledPublished(
             schedule.getWorkflowId(),
             WorkflowTriggerContext.scheduled(
-                trigger.getTriggerId(),
-                schedule.getId(),
-                trigger.getPlannedFireTime()));
+                trigger.getTriggerId(), schedule.getId(), trigger.getPlannedFireTime()));
         String executionId = launched.latestExecutionId();
+        if (executionId == null || executionId.isBlank()) {
+          throw new IllegalStateException("工作流启动成功但未返回 WorkflowExecution ID");
+        }
         if (firstExecutionId == null) firstExecutionId = executionId;
         log.info(
             "[workflow-schedule-ledger] launched trigger={}, schedule={}, workflow={}, execution={}, strategy={}",
-            trigger.getId(),
-            schedule.getId(),
-            schedule.getWorkflowId(),
-            executionId,
-            schedule.getExecutionStrategy());
+            trigger.getId(), schedule.getId(), schedule.getWorkflowId(), executionId, schedule.getExecutionStrategy());
         current = admission.bindLaunch(trigger, executionId);
       } catch (RuntimeException exception) {
         if (firstFailure == null) firstFailure = exception;
         log.warn(
             "[workflow-schedule-ledger] launch failed trigger={}, schedule={}, workflow={}, message={}",
-            trigger.getId(),
-            trigger.getScheduleId(),
-            trigger.getWorkflowId(),
-            exception.getMessage());
+            trigger.getId(), trigger.getScheduleId(), trigger.getWorkflowId(), exception.getMessage());
         current = admission.failLaunch(trigger, exception);
       }
     }
@@ -197,8 +192,9 @@ public class WorkflowScheduleTriggerCoordinator {
   }
 
   private ScheduleExecutionResult duplicateResult(WorkflowScheduleTriggerPO trigger) {
-    String message = "重复计划触发已由 Trigger Ledger 幂等拦截，复用状态 " + trigger.getStatus();
-    return ScheduleExecutionResult.accepted(trigger.getWorkflowExecutionId(), message);
+    return ScheduleExecutionResult.accepted(
+        trigger.getWorkflowExecutionId(),
+        "重复计划触发已由 Trigger Ledger 幂等拦截，复用状态 " + trigger.getStatus());
   }
 
   private WorkflowSchedulePO safeSchedule(String scheduleId) {

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowScheduleTriggerCoordinator.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowScheduleTriggerCoordinator.java
@@ -1,0 +1,359 @@
+package io.yak.ops.business.workflow.service;
+
+import io.yak.framework.schedule.api.ScheduleExecutionResult;
+import io.yak.ops.business.workflow.dao.WorkflowExecutionDao;
+import io.yak.ops.business.workflow.dao.WorkflowScheduleTriggerDao;
+import io.yak.ops.business.workflow.domain.WorkflowTriggerContext;
+import io.yak.ops.common.bean.po.workflow.WorkflowExecutionPO;
+import io.yak.ops.common.bean.po.workflow.WorkflowSchedulePO;
+import io.yak.ops.common.bean.po.workflow.WorkflowScheduleTriggerPO;
+import io.yak.ops.common.bean.vo.workflow.WorkflowDefinitionVO;
+import java.time.Instant;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Trigger Ledger、幂等与 WorkflowExecution 并发策略的统一协调器。
+ *
+ * <p>Yak Schedule 只负责“到点通知”；是否立即创建 WorkflowExecution 由这里决定。</p>
+ */
+@Component
+@ConditionalOnProperty(prefix = "yak.database", name = "enabled", havingValue = "true", matchIfMissing = true)
+public class WorkflowScheduleTriggerCoordinator {
+  private static final Logger log = LoggerFactory.getLogger(WorkflowScheduleTriggerCoordinator.class);
+  private static final Set<String> TERMINAL = Set.of(
+      "SUCCESS", "SUCCESS_WITH_WARNINGS", "FAILED", "CANCELED", "TIMED_OUT");
+
+  private final WorkflowScheduleTriggerDao ledger;
+  private final WorkflowScheduleQuery schedules;
+  private final WorkflowLaunchService launchService;
+  private final WorkflowExecutionDao executions;
+
+  public WorkflowScheduleTriggerCoordinator(
+      WorkflowScheduleTriggerDao ledger,
+      WorkflowScheduleQuery schedules,
+      WorkflowLaunchService launchService,
+      WorkflowExecutionDao executions) {
+    this.ledger = ledger;
+    this.schedules = schedules;
+    this.launchService = launchService;
+    this.executions = executions;
+  }
+
+  @Transactional(transactionManager = "yakBusinessTransactionManager")
+  public ScheduleExecutionResult submit(
+      WorkflowSchedulePO schedule,
+      String triggerId,
+      Instant plannedFireTime,
+      Instant actualFireTime,
+      String triggerSource) {
+    WorkflowScheduleTriggerPO claimed = ledger.claim(newTrigger(
+        schedule,
+        triggerId,
+        plannedFireTime,
+        actualFireTime,
+        triggerSource));
+
+    if (!"RECEIVED".equals(claimed.getStatus())) {
+      return duplicateResult(claimed);
+    }
+
+    ledger.lockWorkflow(schedule.getWorkflowId());
+    return decideAndLaunch(schedule, claimed);
+  }
+
+  @Transactional(transactionManager = "yakBusinessTransactionManager")
+  public ScheduleExecutionResult recoverMisfire(
+      WorkflowSchedulePO schedule,
+      Instant plannedFireTime,
+      Instant actualFireTime) {
+    String triggerId = "workflow-misfire-" + schedule.getId() + "-" + plannedFireTime.toEpochMilli();
+    WorkflowScheduleTriggerPO claimed = ledger.claim(newTrigger(
+        schedule,
+        triggerId,
+        plannedFireTime,
+        actualFireTime,
+        "MISFIRE_RECOVERY"));
+    if (!"RECEIVED".equals(claimed.getStatus())) return duplicateResult(claimed);
+    ledger.lockWorkflow(schedule.getWorkflowId());
+    return decideAndLaunch(schedule, claimed);
+  }
+
+  /** 应用重启后修复 Ledger 中间态，并继续可恢复的 Trigger。 */
+  @Transactional(transactionManager = "yakBusinessTransactionManager")
+  public void recoverPending() {
+    List<WorkflowScheduleTriggerPO> pending = ledger.selectPending();
+    Set<String> workflowsToDrain = new LinkedHashSet<>();
+
+    for (WorkflowScheduleTriggerPO trigger : pending) {
+      WorkflowSchedulePO schedule = safeSchedule(trigger.getScheduleId());
+      if (schedule == null || !"ONLINE".equals(schedule.getStatus())) {
+        markSkipped(trigger, "调度已停用或删除，启动恢复时跳过");
+        continue;
+      }
+
+      if ("RUNNING".equals(trigger.getStatus()) && trigger.getWorkflowExecutionId() != null) {
+        WorkflowExecutionPO execution = executions.selectExecution(trigger.getWorkflowExecutionId());
+        if (execution != null && isTerminal(execution.getStatus())) {
+          markTerminal(trigger, execution.getStatus(), execution.getEndedAt());
+        } else {
+          workflowsToDrain.add(trigger.getWorkflowId());
+        }
+        continue;
+      }
+
+      if ("LAUNCHING".equals(trigger.getStatus()) || "RUNNING".equals(trigger.getStatus())) {
+        String executionId = trigger.getWorkflowExecutionId();
+        if (executionId == null || executionId.isBlank()) {
+          executionId = ledger.selectExecutionIdByTrigger(trigger.getTriggerId());
+        }
+        if (executionId != null && !executionId.isBlank()) {
+          trigger.setWorkflowExecutionId(executionId);
+          WorkflowExecutionPO execution = executions.selectExecution(executionId);
+          if (execution != null && isTerminal(execution.getStatus())) {
+            markTerminal(trigger, execution.getStatus(), execution.getEndedAt());
+          } else {
+            trigger.setStatus("RUNNING");
+            trigger.setExecutionStatus(execution == null ? null : execution.getStatus());
+            trigger.setMessage("启动恢复已重新绑定 WorkflowExecution");
+            touch(trigger);
+            save(trigger);
+          }
+          workflowsToDrain.add(trigger.getWorkflowId());
+          continue;
+        }
+        trigger.setStatus("RECEIVED");
+        trigger.setMessage("启动恢复未发现已创建实例，重新执行准入判断");
+        touch(trigger);
+        save(trigger);
+      }
+
+      if ("RECEIVED".equals(trigger.getStatus())) {
+        ledger.lockWorkflow(trigger.getWorkflowId());
+        decideAndLaunch(schedule, trigger);
+      } else if ("WAITING".equals(trigger.getStatus())) {
+        workflowsToDrain.add(trigger.getWorkflowId());
+      }
+    }
+
+    for (String workflowId : workflowsToDrain) {
+      ledger.lockWorkflow(workflowId);
+      drainWaitingLocked(workflowId);
+    }
+  }
+
+  /** WorkflowExecution 终态事务提交后调用，完成 Ledger 并推进等待队列。 */
+  @Transactional(transactionManager = "yakBusinessTransactionManager")
+  public void completeExecution(String executionId, String executionStatus, Instant endedAt) {
+    WorkflowScheduleTriggerPO trigger = ledger.selectByExecutionId(executionId);
+    if (trigger != null && !isLedgerTerminal(trigger.getStatus())) {
+      markTerminal(trigger, executionStatus, endedAt);
+    }
+
+    String workflowId = trigger == null
+        ? ledger.selectWorkflowIdByExecution(executionId)
+        : trigger.getWorkflowId();
+    if (workflowId == null || workflowId.isBlank()) return;
+
+    ledger.lockWorkflow(workflowId);
+    drainWaitingLocked(workflowId);
+  }
+
+  private ScheduleExecutionResult decideAndLaunch(
+      WorkflowSchedulePO schedule,
+      WorkflowScheduleTriggerPO trigger) {
+    String strategy = schedule.getExecutionStrategy();
+    long active = ledger.countActiveExecutions(schedule.getWorkflowId());
+
+    if ("SERIAL_DISCARD".equals(strategy) && active > 0L) {
+      markSkipped(trigger, "已有运行中的 WorkflowExecution，按 SERIAL_DISCARD 跳过");
+      return ScheduleExecutionResult.accepted(null, trigger.getMessage());
+    }
+
+    if ("SERIAL_WAIT".equals(strategy) && active > 0L) {
+      trigger.setStatus("WAITING");
+      trigger.setMessage("已有运行中的 WorkflowExecution，进入串行等待队列");
+      touch(trigger);
+      save(trigger);
+      return ScheduleExecutionResult.accepted(null, trigger.getMessage());
+    }
+
+    return launch(schedule, trigger);
+  }
+
+  private ScheduleExecutionResult launch(
+      WorkflowSchedulePO schedule,
+      WorkflowScheduleTriggerPO trigger) {
+    trigger.setStatus("LAUNCHING");
+    trigger.setMessage("Trigger 已获得执行准入，正在创建 WorkflowExecution");
+    trigger.setLaunchedAt(Instant.now());
+    touch(trigger);
+    save(trigger);
+
+    try {
+      WorkflowDefinitionVO launched = launchService.runScheduledPublished(
+          schedule.getWorkflowId(),
+          WorkflowTriggerContext.scheduled(
+              trigger.getTriggerId(),
+              schedule.getId(),
+              trigger.getPlannedFireTime()));
+      String executionId = launched.latestExecutionId();
+      trigger.setWorkflowExecutionId(executionId);
+      trigger.setExecutionStatus(launched.latestExecutionStatus());
+
+      WorkflowExecutionPO execution = executionId == null ? null : executions.selectExecution(executionId);
+      String executionStatus = execution == null
+          ? launched.latestExecutionStatus()
+          : execution.getStatus();
+      if (isTerminal(executionStatus)) {
+        markTerminal(trigger, executionStatus, execution == null ? Instant.now() : execution.getEndedAt());
+      } else {
+        trigger.setStatus("RUNNING");
+        trigger.setExecutionStatus(executionStatus);
+        trigger.setMessage("WorkflowExecution 已创建");
+        touch(trigger);
+        save(trigger);
+      }
+
+      log.info(
+          "[workflow-schedule-ledger] launched trigger={}, schedule={}, workflow={}, execution={}, strategy={}",
+          trigger.getId(), schedule.getId(), schedule.getWorkflowId(), executionId, schedule.getExecutionStrategy());
+      return ScheduleExecutionResult.accepted(executionId, trigger.getMessage());
+    } catch (RuntimeException exception) {
+      trigger.setStatus("FAILED");
+      trigger.setErrorMessage(safeMessage(exception));
+      trigger.setMessage("创建 WorkflowExecution 失败");
+      trigger.setCompletedAt(Instant.now());
+      touch(trigger);
+      save(trigger);
+      throw exception;
+    }
+  }
+
+  private void drainWaitingLocked(String workflowId) {
+    if (ledger.countActiveExecutions(workflowId) > 0L) return;
+
+    while (true) {
+      WorkflowScheduleTriggerPO waiting = ledger.selectNextWaiting(workflowId);
+      if (waiting == null) return;
+      WorkflowSchedulePO schedule = safeSchedule(waiting.getScheduleId());
+      if (schedule == null || !"ONLINE".equals(schedule.getStatus())) {
+        markSkipped(waiting, "等待期间调度已停用或删除");
+        continue;
+      }
+      if (!"SERIAL_WAIT".equals(schedule.getExecutionStrategy())) {
+        markSkipped(waiting, "等待期间执行策略已变更，旧 Trigger 不再推进");
+        continue;
+      }
+      launch(schedule, waiting);
+      return;
+    }
+  }
+
+  private WorkflowScheduleTriggerPO newTrigger(
+      WorkflowSchedulePO schedule,
+      String triggerId,
+      Instant plannedFireTime,
+      Instant actualFireTime,
+      String triggerSource) {
+    if (schedule == null) throw new IllegalArgumentException("调度定义不能为空");
+    if (plannedFireTime == null) throw new IllegalArgumentException("plannedFireTime 不能为空");
+    Instant actual = actualFireTime == null ? Instant.now() : actualFireTime;
+    Instant now = Instant.now();
+    WorkflowScheduleTriggerPO value = new WorkflowScheduleTriggerPO();
+    value.setId("workflow-trigger-ledger-" + UUID.randomUUID());
+    value.setScheduleId(schedule.getId());
+    value.setWorkflowId(schedule.getWorkflowId());
+    value.setTriggerId(required(triggerId, "triggerId 不能为空"));
+    value.setTriggerSource(triggerSource == null || triggerSource.isBlank() ? "CRON" : triggerSource.trim());
+    value.setPlannedFireTime(plannedFireTime);
+    value.setActualFireTime(actual);
+    value.setExecutionStrategy(schedule.getExecutionStrategy());
+    value.setMisfireStrategy(schedule.getMisfireStrategy());
+    value.setStatus("RECEIVED");
+    value.setCreateTime(now);
+    value.setUpdateTime(now);
+    return value;
+  }
+
+  private ScheduleExecutionResult duplicateResult(WorkflowScheduleTriggerPO trigger) {
+    String message = "重复计划触发已由 Trigger Ledger 幂等拦截，复用状态 " + trigger.getStatus();
+    return ScheduleExecutionResult.accepted(trigger.getWorkflowExecutionId(), message);
+  }
+
+  private void markSkipped(WorkflowScheduleTriggerPO trigger, String message) {
+    trigger.setStatus("SKIPPED");
+    trigger.setMessage(message);
+    trigger.setCompletedAt(Instant.now());
+    touch(trigger);
+    save(trigger);
+  }
+
+  private void markTerminal(
+      WorkflowScheduleTriggerPO trigger,
+      String executionStatus,
+      Instant endedAt) {
+    trigger.setExecutionStatus(executionStatus);
+    trigger.setStatus(ledgerStatus(executionStatus));
+    trigger.setMessage("WorkflowExecution 已进入终态：" + executionStatus);
+    trigger.setCompletedAt(endedAt == null ? Instant.now() : endedAt);
+    touch(trigger);
+    save(trigger);
+  }
+
+  private String ledgerStatus(String executionStatus) {
+    if ("SUCCESS".equals(executionStatus) || "SUCCESS_WITH_WARNINGS".equals(executionStatus)) {
+      return "SUCCEEDED";
+    }
+    if ("CANCELED".equals(executionStatus)) return "CANCELED";
+    return "FAILED";
+  }
+
+  private boolean isTerminal(String status) {
+    return status != null && TERMINAL.contains(status);
+  }
+
+  private boolean isLedgerTerminal(String status) {
+    return List.of("SUCCEEDED", "FAILED", "CANCELED", "SKIPPED").contains(status);
+  }
+
+  private WorkflowSchedulePO safeSchedule(String scheduleId) {
+    try {
+      return schedules.require(scheduleId);
+    } catch (IllegalArgumentException missing) {
+      return null;
+    }
+  }
+
+  private void touch(WorkflowScheduleTriggerPO trigger) {
+    trigger.setUpdateTime(Instant.now());
+  }
+
+  private void save(WorkflowScheduleTriggerPO trigger) {
+    if (ledger.update(trigger) != 1) {
+      throw new IllegalStateException("更新 Trigger Ledger 失败：" + trigger.getId());
+    }
+  }
+
+  private String required(String value, String message) {
+    if (value == null || value.isBlank()) throw new IllegalArgumentException(message);
+    return value.trim();
+  }
+
+  private String safeMessage(Throwable error) {
+    Throwable current = error;
+    while (current.getCause() != null && current.getCause() != current) current = current.getCause();
+    String message = current.getMessage();
+    String value = message == null || message.isBlank()
+        ? current.getClass().getSimpleName()
+        : current.getClass().getSimpleName() + ": " + message;
+    return value.length() <= 2000 ? value : value.substring(0, 2000);
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowScheduleTriggerCoordinator.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowScheduleTriggerCoordinator.java
@@ -1,10 +1,9 @@
 package io.yak.ops.business.workflow.service;
 
 import io.yak.framework.schedule.api.ScheduleExecutionResult;
-import io.yak.ops.business.workflow.dao.WorkflowExecutionDao;
 import io.yak.ops.business.workflow.dao.WorkflowScheduleTriggerDao;
 import io.yak.ops.business.workflow.domain.WorkflowTriggerContext;
-import io.yak.ops.common.bean.po.workflow.WorkflowExecutionPO;
+import io.yak.ops.business.workflow.service.WorkflowScheduleTriggerAdmission.AdmissionResult;
 import io.yak.ops.common.bean.po.workflow.WorkflowSchedulePO;
 import io.yak.ops.common.bean.po.workflow.WorkflowScheduleTriggerPO;
 import io.yak.ops.common.bean.vo.workflow.WorkflowDefinitionVO;
@@ -17,244 +16,158 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Trigger Ledger、幂等与 WorkflowExecution 并发策略的统一协调器。
  *
- * <p>Yak Schedule 只负责“到点通知”；是否立即创建 WorkflowExecution 由这里决定。</p>
+ * <p>准入由短事务完成；真正创建 WorkflowExecution 时不持有工作流行锁。</p>
  */
 @Component
 @ConditionalOnProperty(prefix = "yak.database", name = "enabled", havingValue = "true", matchIfMissing = true)
 public class WorkflowScheduleTriggerCoordinator {
   private static final Logger log = LoggerFactory.getLogger(WorkflowScheduleTriggerCoordinator.class);
-  private static final Set<String> TERMINAL = Set.of(
-      "SUCCESS", "SUCCESS_WITH_WARNINGS", "FAILED", "CANCELED", "TIMED_OUT");
 
   private final WorkflowScheduleTriggerDao ledger;
   private final WorkflowScheduleQuery schedules;
   private final WorkflowLaunchService launchService;
-  private final WorkflowExecutionDao executions;
+  private final WorkflowScheduleTriggerAdmission admission;
 
   public WorkflowScheduleTriggerCoordinator(
       WorkflowScheduleTriggerDao ledger,
       WorkflowScheduleQuery schedules,
       WorkflowLaunchService launchService,
-      WorkflowExecutionDao executions) {
+      WorkflowScheduleTriggerAdmission admission) {
     this.ledger = ledger;
     this.schedules = schedules;
     this.launchService = launchService;
-    this.executions = executions;
+    this.admission = admission;
   }
 
-  @Transactional(transactionManager = "yakBusinessTransactionManager")
   public ScheduleExecutionResult submit(
       WorkflowSchedulePO schedule,
       String triggerId,
       Instant plannedFireTime,
       Instant actualFireTime,
       String triggerSource) {
-    WorkflowScheduleTriggerPO claimed = ledger.claim(newTrigger(
+    AdmissionResult result = admission.admitNew(
         schedule,
-        triggerId,
-        plannedFireTime,
-        actualFireTime,
-        triggerSource));
-
-    if (!"RECEIVED".equals(claimed.getStatus())) {
-      return duplicateResult(claimed);
+        newTrigger(schedule, triggerId, plannedFireTime, actualFireTime, triggerSource));
+    if (result.duplicate()) return duplicateResult(result.trigger());
+    if (!result.launchNow()) {
+      return ScheduleExecutionResult.accepted(
+          result.trigger().getWorkflowExecutionId(),
+          result.trigger().getMessage());
     }
 
-    ledger.lockWorkflow(schedule.getWorkflowId());
-    return decideAndLaunch(schedule, claimed);
+    String executionId = launchReserved(result);
+    return ScheduleExecutionResult.accepted(executionId, "工作流调度 Trigger 已获得执行准入");
   }
 
-  @Transactional(transactionManager = "yakBusinessTransactionManager")
   public ScheduleExecutionResult recoverMisfire(
       WorkflowSchedulePO schedule,
       Instant plannedFireTime,
       Instant actualFireTime) {
     String triggerId = "workflow-misfire-" + schedule.getId() + "-" + plannedFireTime.toEpochMilli();
-    WorkflowScheduleTriggerPO claimed = ledger.claim(newTrigger(
+    return submit(
         schedule,
         triggerId,
         plannedFireTime,
         actualFireTime,
-        "MISFIRE_RECOVERY"));
-    if (!"RECEIVED".equals(claimed.getStatus())) return duplicateResult(claimed);
-    ledger.lockWorkflow(schedule.getWorkflowId());
-    return decideAndLaunch(schedule, claimed);
+        "MISFIRE_RECOVERY");
   }
 
-  /** 应用重启后修复 Ledger 中间态，并继续可恢复的 Trigger。 */
-  @Transactional(transactionManager = "yakBusinessTransactionManager")
+  /** 应用重启后修复 Ledger 中间态，并恢复 SERIAL_WAIT 队列。 */
   public void recoverPending() {
     List<WorkflowScheduleTriggerPO> pending = ledger.selectPending();
-    Set<String> workflowsToDrain = new LinkedHashSet<>();
+    Set<String> waitingWorkflows = new LinkedHashSet<>();
 
     for (WorkflowScheduleTriggerPO trigger : pending) {
+      String executionId = trigger.getWorkflowExecutionId();
+      if ((executionId == null || executionId.isBlank())
+          && ("LAUNCHING".equals(trigger.getStatus()) || "RUNNING".equals(trigger.getStatus()))) {
+        executionId = ledger.selectExecutionIdByTrigger(trigger.getTriggerId());
+      }
+
+      if (executionId != null && !executionId.isBlank()) {
+        AdmissionResult next = admission.recoverBound(trigger, executionId);
+        launchReserved(next);
+        continue;
+      }
+
       WorkflowSchedulePO schedule = safeSchedule(trigger.getScheduleId());
       if (schedule == null || !"ONLINE".equals(schedule.getStatus())) {
-        markSkipped(trigger, "调度已停用或删除，启动恢复时跳过");
+        admission.skip(trigger, "调度已停用或删除，启动恢复时跳过未启动 Trigger");
         continue;
       }
 
-      if ("RUNNING".equals(trigger.getStatus()) && trigger.getWorkflowExecutionId() != null) {
-        WorkflowExecutionPO execution = executions.selectExecution(trigger.getWorkflowExecutionId());
-        if (execution != null && isTerminal(execution.getStatus())) {
-          markTerminal(trigger, execution.getStatus(), execution.getEndedAt());
-        } else {
-          workflowsToDrain.add(trigger.getWorkflowId());
-        }
+      if ("WAITING".equals(trigger.getStatus())) {
+        waitingWorkflows.add(trigger.getWorkflowId());
         continue;
       }
 
-      if ("LAUNCHING".equals(trigger.getStatus()) || "RUNNING".equals(trigger.getStatus())) {
-        String executionId = trigger.getWorkflowExecutionId();
-        if (executionId == null || executionId.isBlank()) {
-          executionId = ledger.selectExecutionIdByTrigger(trigger.getTriggerId());
-        }
-        if (executionId != null && !executionId.isBlank()) {
-          trigger.setWorkflowExecutionId(executionId);
-          WorkflowExecutionPO execution = executions.selectExecution(executionId);
-          if (execution != null && isTerminal(execution.getStatus())) {
-            markTerminal(trigger, execution.getStatus(), execution.getEndedAt());
-          } else {
-            trigger.setStatus("RUNNING");
-            trigger.setExecutionStatus(execution == null ? null : execution.getStatus());
-            trigger.setMessage("启动恢复已重新绑定 WorkflowExecution");
-            touch(trigger);
-            save(trigger);
-          }
-          workflowsToDrain.add(trigger.getWorkflowId());
-          continue;
-        }
-        trigger.setStatus("RECEIVED");
-        trigger.setMessage("启动恢复未发现已创建实例，重新执行准入判断");
-        touch(trigger);
-        save(trigger);
-      }
-
-      if ("RECEIVED".equals(trigger.getStatus())) {
-        ledger.lockWorkflow(trigger.getWorkflowId());
-        decideAndLaunch(schedule, trigger);
-      } else if ("WAITING".equals(trigger.getStatus())) {
-        workflowsToDrain.add(trigger.getWorkflowId());
+      AdmissionResult readmitted = admission.readmit(schedule, trigger);
+      if (readmitted.launchNow()) {
+        launchReserved(readmitted);
+      } else if ("WAITING".equals(readmitted.trigger().getStatus())) {
+        waitingWorkflows.add(trigger.getWorkflowId());
       }
     }
 
-    for (String workflowId : workflowsToDrain) {
-      ledger.lockWorkflow(workflowId);
-      drainWaitingLocked(workflowId);
+    for (String workflowId : waitingWorkflows) {
+      launchReserved(admission.reserveNext(workflowId));
     }
   }
 
-  /** WorkflowExecution 终态事务提交后调用，完成 Ledger 并推进等待队列。 */
-  @Transactional(transactionManager = "yakBusinessTransactionManager")
+  /** WorkflowExecution 终态事务提交后调用，完成 Ledger 并推进 SERIAL_WAIT。 */
   public void completeExecution(String executionId, String executionStatus, Instant endedAt) {
-    WorkflowScheduleTriggerPO trigger = ledger.selectByExecutionId(executionId);
-    if (trigger != null && !isLedgerTerminal(trigger.getStatus())) {
-      markTerminal(trigger, executionStatus, endedAt);
-    }
-
-    String workflowId = trigger == null
-        ? ledger.selectWorkflowIdByExecution(executionId)
-        : trigger.getWorkflowId();
-    if (workflowId == null || workflowId.isBlank()) return;
-
-    ledger.lockWorkflow(workflowId);
-    drainWaitingLocked(workflowId);
+    launchReserved(admission.completeExecution(executionId, executionStatus, endedAt));
   }
 
-  private ScheduleExecutionResult decideAndLaunch(
-      WorkflowSchedulePO schedule,
-      WorkflowScheduleTriggerPO trigger) {
-    String strategy = schedule.getExecutionStrategy();
-    long active = ledger.countActiveExecutions(schedule.getWorkflowId());
+  private String launchReserved(AdmissionResult initial) {
+    AdmissionResult current = initial;
+    String firstExecutionId = null;
+    RuntimeException firstFailure = null;
 
-    if ("SERIAL_DISCARD".equals(strategy) && active > 0L) {
-      markSkipped(trigger, "已有运行中的 WorkflowExecution，按 SERIAL_DISCARD 跳过");
-      return ScheduleExecutionResult.accepted(null, trigger.getMessage());
-    }
-
-    if ("SERIAL_WAIT".equals(strategy) && active > 0L) {
-      trigger.setStatus("WAITING");
-      trigger.setMessage("已有运行中的 WorkflowExecution，进入串行等待队列");
-      touch(trigger);
-      save(trigger);
-      return ScheduleExecutionResult.accepted(null, trigger.getMessage());
-    }
-
-    return launch(schedule, trigger);
-  }
-
-  private ScheduleExecutionResult launch(
-      WorkflowSchedulePO schedule,
-      WorkflowScheduleTriggerPO trigger) {
-    trigger.setStatus("LAUNCHING");
-    trigger.setMessage("Trigger 已获得执行准入，正在创建 WorkflowExecution");
-    trigger.setLaunchedAt(Instant.now());
-    touch(trigger);
-    save(trigger);
-
-    try {
-      WorkflowDefinitionVO launched = launchService.runScheduledPublished(
-          schedule.getWorkflowId(),
-          WorkflowTriggerContext.scheduled(
-              trigger.getTriggerId(),
-              schedule.getId(),
-              trigger.getPlannedFireTime()));
-      String executionId = launched.latestExecutionId();
-      trigger.setWorkflowExecutionId(executionId);
-      trigger.setExecutionStatus(launched.latestExecutionStatus());
-
-      WorkflowExecutionPO execution = executionId == null ? null : executions.selectExecution(executionId);
-      String executionStatus = execution == null
-          ? launched.latestExecutionStatus()
-          : execution.getStatus();
-      if (isTerminal(executionStatus)) {
-        markTerminal(trigger, executionStatus, execution == null ? Instant.now() : execution.getEndedAt());
-      } else {
-        trigger.setStatus("RUNNING");
-        trigger.setExecutionStatus(executionStatus);
-        trigger.setMessage("WorkflowExecution 已创建");
-        touch(trigger);
-        save(trigger);
-      }
-
-      log.info(
-          "[workflow-schedule-ledger] launched trigger={}, schedule={}, workflow={}, execution={}, strategy={}",
-          trigger.getId(), schedule.getId(), schedule.getWorkflowId(), executionId, schedule.getExecutionStrategy());
-      return ScheduleExecutionResult.accepted(executionId, trigger.getMessage());
-    } catch (RuntimeException exception) {
-      trigger.setStatus("FAILED");
-      trigger.setErrorMessage(safeMessage(exception));
-      trigger.setMessage("创建 WorkflowExecution 失败");
-      trigger.setCompletedAt(Instant.now());
-      touch(trigger);
-      save(trigger);
-      throw exception;
-    }
-  }
-
-  private void drainWaitingLocked(String workflowId) {
-    if (ledger.countActiveExecutions(workflowId) > 0L) return;
-
-    while (true) {
-      WorkflowScheduleTriggerPO waiting = ledger.selectNextWaiting(workflowId);
-      if (waiting == null) return;
-      WorkflowSchedulePO schedule = safeSchedule(waiting.getScheduleId());
+    while (current != null && current.launchNow() && current.trigger() != null) {
+      WorkflowScheduleTriggerPO trigger = current.trigger();
+      WorkflowSchedulePO schedule = safeSchedule(trigger.getScheduleId());
       if (schedule == null || !"ONLINE".equals(schedule.getStatus())) {
-        markSkipped(waiting, "等待期间调度已停用或删除");
+        admission.skip(trigger, "获得执行准入后调度已停用或删除，本次 Trigger 跳过");
+        current = admission.reserveNext(trigger.getWorkflowId());
         continue;
       }
-      if (!"SERIAL_WAIT".equals(schedule.getExecutionStrategy())) {
-        markSkipped(waiting, "等待期间执行策略已变更，旧 Trigger 不再推进");
-        continue;
+
+      try {
+        WorkflowDefinitionVO launched = launchService.runScheduledPublished(
+            schedule.getWorkflowId(),
+            WorkflowTriggerContext.scheduled(
+                trigger.getTriggerId(),
+                schedule.getId(),
+                trigger.getPlannedFireTime()));
+        String executionId = launched.latestExecutionId();
+        if (firstExecutionId == null) firstExecutionId = executionId;
+        log.info(
+            "[workflow-schedule-ledger] launched trigger={}, schedule={}, workflow={}, execution={}, strategy={}",
+            trigger.getId(),
+            schedule.getId(),
+            schedule.getWorkflowId(),
+            executionId,
+            schedule.getExecutionStrategy());
+        current = admission.bindLaunch(trigger, executionId);
+      } catch (RuntimeException exception) {
+        if (firstFailure == null) firstFailure = exception;
+        log.warn(
+            "[workflow-schedule-ledger] launch failed trigger={}, schedule={}, workflow={}, message={}",
+            trigger.getId(),
+            trigger.getScheduleId(),
+            trigger.getWorkflowId(),
+            exception.getMessage());
+        current = admission.failLaunch(trigger, exception);
       }
-      launch(schedule, waiting);
-      return;
     }
+
+    if (firstFailure != null) throw firstFailure;
+    return firstExecutionId;
   }
 
   private WorkflowScheduleTriggerPO newTrigger(
@@ -288,42 +201,6 @@ public class WorkflowScheduleTriggerCoordinator {
     return ScheduleExecutionResult.accepted(trigger.getWorkflowExecutionId(), message);
   }
 
-  private void markSkipped(WorkflowScheduleTriggerPO trigger, String message) {
-    trigger.setStatus("SKIPPED");
-    trigger.setMessage(message);
-    trigger.setCompletedAt(Instant.now());
-    touch(trigger);
-    save(trigger);
-  }
-
-  private void markTerminal(
-      WorkflowScheduleTriggerPO trigger,
-      String executionStatus,
-      Instant endedAt) {
-    trigger.setExecutionStatus(executionStatus);
-    trigger.setStatus(ledgerStatus(executionStatus));
-    trigger.setMessage("WorkflowExecution 已进入终态：" + executionStatus);
-    trigger.setCompletedAt(endedAt == null ? Instant.now() : endedAt);
-    touch(trigger);
-    save(trigger);
-  }
-
-  private String ledgerStatus(String executionStatus) {
-    if ("SUCCESS".equals(executionStatus) || "SUCCESS_WITH_WARNINGS".equals(executionStatus)) {
-      return "SUCCEEDED";
-    }
-    if ("CANCELED".equals(executionStatus)) return "CANCELED";
-    return "FAILED";
-  }
-
-  private boolean isTerminal(String status) {
-    return status != null && TERMINAL.contains(status);
-  }
-
-  private boolean isLedgerTerminal(String status) {
-    return List.of("SUCCEEDED", "FAILED", "CANCELED", "SKIPPED").contains(status);
-  }
-
   private WorkflowSchedulePO safeSchedule(String scheduleId) {
     try {
       return schedules.require(scheduleId);
@@ -332,28 +209,8 @@ public class WorkflowScheduleTriggerCoordinator {
     }
   }
 
-  private void touch(WorkflowScheduleTriggerPO trigger) {
-    trigger.setUpdateTime(Instant.now());
-  }
-
-  private void save(WorkflowScheduleTriggerPO trigger) {
-    if (ledger.update(trigger) != 1) {
-      throw new IllegalStateException("更新 Trigger Ledger 失败：" + trigger.getId());
-    }
-  }
-
   private String required(String value, String message) {
     if (value == null || value.isBlank()) throw new IllegalArgumentException(message);
     return value.trim();
-  }
-
-  private String safeMessage(Throwable error) {
-    Throwable current = error;
-    while (current.getCause() != null && current.getCause() != current) current = current.getCause();
-    String message = current.getMessage();
-    String value = message == null || message.isBlank()
-        ? current.getClass().getSimpleName()
-        : current.getClass().getSimpleName() + ": " + message;
-    return value.length() <= 2000 ? value : value.substring(0, 2000);
   }
 }

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowScheduleTriggerHandler.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowScheduleTriggerHandler.java
@@ -3,20 +3,19 @@ package io.yak.ops.business.workflow.service;
 import io.yak.framework.schedule.api.ScheduleExecutionContext;
 import io.yak.framework.schedule.api.ScheduleExecutionResult;
 import io.yak.framework.schedule.api.ScheduleHandler;
-import io.yak.ops.business.workflow.domain.WorkflowTriggerContext;
 import io.yak.ops.common.bean.po.workflow.WorkflowSchedulePO;
 import io.yak.ops.common.bean.vo.workflow.WorkflowDefinitionVO;
 import java.time.Instant;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
-/** Yak Schedule 的工作流业务 Handler：只负责把时间触发转换成统一 Workflow Launch。 */
+/** Yak Schedule 工作流 Handler：校验调度窗口后统一进入 Trigger Ledger 协调器。 */
 @Component(WorkflowScheduleEngineBridge.HANDLER)
 @ConditionalOnProperty(prefix = "yak.database", name = "enabled", havingValue = "true", matchIfMissing = true)
 public class WorkflowScheduleTriggerHandler implements ScheduleHandler {
   private final WorkflowScheduleQuery schedules;
   private final WorkflowDefinitionService definitions;
-  private final WorkflowLaunchService launchService;
+  private final WorkflowScheduleTriggerCoordinator coordinator;
   private final WorkflowScheduleLifecycle lifecycle;
   private final WorkflowScheduleEngineBridge engine;
   private final WorkflowScheduleRuntimeState runtimeState;
@@ -24,13 +23,13 @@ public class WorkflowScheduleTriggerHandler implements ScheduleHandler {
   public WorkflowScheduleTriggerHandler(
       WorkflowScheduleQuery schedules,
       WorkflowDefinitionService definitions,
-      WorkflowLaunchService launchService,
+      WorkflowScheduleTriggerCoordinator coordinator,
       WorkflowScheduleLifecycle lifecycle,
       WorkflowScheduleEngineBridge engine,
       WorkflowScheduleRuntimeState runtimeState) {
     this.schedules = schedules;
     this.definitions = definitions;
-    this.launchService = launchService;
+    this.coordinator = coordinator;
     this.lifecycle = lifecycle;
     this.engine = engine;
     this.runtimeState = runtimeState;
@@ -81,15 +80,12 @@ public class WorkflowScheduleTriggerHandler implements ScheduleHandler {
     }
 
     try {
-      WorkflowDefinitionVO launched = launchService.runPublished(
-          schedule.getWorkflowId(),
-          WorkflowTriggerContext.scheduled(
-              context.triggerId(),
-              scheduleId,
-              plannedFireTime));
-      return ScheduleExecutionResult.accepted(
-          launched.latestExecutionId(),
-          "工作流调度触发已提交");
+      return coordinator.submit(
+          schedule,
+          context.triggerId(),
+          plannedFireTime,
+          actualFireTime,
+          context.manual() ? "MANUAL" : "CRON");
     } finally {
       refreshFireState(schedule, actualFireTime);
     }

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowScheduleTriggerQuery.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowScheduleTriggerQuery.java
@@ -1,0 +1,62 @@
+package io.yak.ops.business.workflow.service;
+
+import io.yak.ops.business.workflow.dao.WorkflowScheduleTriggerDao;
+import io.yak.ops.common.bean.po.workflow.WorkflowScheduleTriggerPO;
+import io.yak.ops.common.bean.vo.workflow.WorkflowScheduleTriggerVO;
+import java.util.List;
+import java.util.Set;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+/** Trigger Ledger 查询服务。 */
+@Component
+@ConditionalOnProperty(prefix = "yak.database", name = "enabled", havingValue = "true", matchIfMissing = true)
+public class WorkflowScheduleTriggerQuery {
+  private static final Set<String> STATUSES = Set.of(
+      "RECEIVED", "WAITING", "LAUNCHING", "RUNNING",
+      "SUCCEEDED", "FAILED", "CANCELED", "SKIPPED");
+
+  private final WorkflowScheduleTriggerDao dao;
+
+  public WorkflowScheduleTriggerQuery(WorkflowScheduleTriggerDao dao) {
+    this.dao = dao;
+  }
+
+  public List<WorkflowScheduleTriggerVO> list(
+      String scheduleId, String workflowId, String status, Integer limit) {
+    String state = normalize(status);
+    if (state != null && !STATUSES.contains(state)) {
+      throw new IllegalArgumentException("不支持的 Trigger 状态：" + state);
+    }
+    int safeLimit = limit == null ? 100 : limit;
+    return dao.selectTriggers(scheduleId, workflowId, state, safeLimit)
+        .stream().map(this::view).toList();
+  }
+
+  WorkflowScheduleTriggerVO view(WorkflowScheduleTriggerPO value) {
+    return new WorkflowScheduleTriggerVO(
+        value.getId(),
+        value.getScheduleId(),
+        value.getWorkflowId(),
+        value.getTriggerId(),
+        value.getTriggerSource(),
+        value.getPlannedFireTime(),
+        value.getActualFireTime(),
+        value.getExecutionStrategy(),
+        value.getMisfireStrategy(),
+        value.getStatus(),
+        value.getWorkflowExecutionId(),
+        value.getExecutionStatus(),
+        value.getMessage(),
+        value.getErrorMessage(),
+        value.getLaunchedAt(),
+        value.getCompletedAt(),
+        value.getCreateTime(),
+        value.getUpdateTime());
+  }
+
+  private String normalize(String value) {
+    if (value == null || value.isBlank()) return null;
+    return value.trim().toUpperCase();
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/main/resources/db/migration/yak-workflow/V3__workflow_schedule_trigger_ledger.sql
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/resources/db/migration/yak-workflow/V3__workflow_schedule_trigger_ledger.sql
@@ -1,0 +1,31 @@
+CREATE TABLE IF NOT EXISTS yak_workflow_schedule_trigger (
+    id VARCHAR(80) NOT NULL,
+    schedule_id VARCHAR(80) NOT NULL,
+    workflow_id VARCHAR(80) NOT NULL,
+    trigger_id VARCHAR(160) NOT NULL,
+    trigger_source VARCHAR(32) NOT NULL DEFAULT 'CRON',
+    planned_fire_time DATETIME(3) NOT NULL,
+    actual_fire_time DATETIME(3) NOT NULL,
+    execution_strategy VARCHAR(32) NOT NULL,
+    misfire_strategy VARCHAR(32) NOT NULL,
+    status VARCHAR(32) NOT NULL,
+    workflow_execution_id VARCHAR(80) NULL,
+    execution_status VARCHAR(32) NULL,
+    message VARCHAR(1000) NULL,
+    error_message TEXT NULL,
+    launched_at DATETIME(3) NULL,
+    completed_at DATETIME(3) NULL,
+    create_time DATETIME(3) NOT NULL,
+    update_time DATETIME(3) NOT NULL,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_yak_workflow_schedule_trigger_plan (schedule_id, planned_fire_time),
+    UNIQUE KEY uk_yak_workflow_schedule_trigger_id (trigger_id),
+    KEY idx_yak_workflow_schedule_trigger_workflow (workflow_id, status, planned_fire_time),
+    KEY idx_yak_workflow_schedule_trigger_execution (workflow_execution_id),
+    KEY idx_yak_workflow_schedule_trigger_schedule (schedule_id, create_time),
+    CONSTRAINT fk_yak_workflow_schedule_trigger_schedule
+      FOREIGN KEY (schedule_id) REFERENCES yak_workflow_schedule(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+ALTER TABLE yak_workflow_execution
+    ADD KEY idx_yak_workflow_execution_definition_status (definition_id, status, created_at);

--- a/yak-ops-business/yak-ops-business-workflow/src/main/resources/db/migration/yak-workflow/V3__workflow_schedule_trigger_ledger.sql
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/resources/db/migration/yak-workflow/V3__workflow_schedule_trigger_ledger.sql
@@ -22,10 +22,10 @@ CREATE TABLE IF NOT EXISTS yak_workflow_schedule_trigger (
     UNIQUE KEY uk_yak_workflow_schedule_trigger_id (trigger_id),
     KEY idx_yak_workflow_schedule_trigger_workflow (workflow_id, status, planned_fire_time),
     KEY idx_yak_workflow_schedule_trigger_execution (workflow_execution_id),
-    KEY idx_yak_workflow_schedule_trigger_schedule (schedule_id, create_time),
-    CONSTRAINT fk_yak_workflow_schedule_trigger_schedule
-      FOREIGN KEY (schedule_id) REFERENCES yak_workflow_schedule(id) ON DELETE CASCADE
+    KEY idx_yak_workflow_schedule_trigger_schedule (schedule_id, create_time)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
+-- Trigger Ledger 是审计事实，Schedule 删除后仍保留历史记录，因此不建立级联外键。
+-- Published WorkflowExecution 通过 definition_id -> yak_workflow_version.workflow_id 查询工作流归属。
 ALTER TABLE yak_workflow_execution
     ADD KEY idx_yak_workflow_execution_definition_status (definition_id, status, created_at);

--- a/yak-ops-business/yak-ops-business-workflow/src/main/resources/mapper/workflow/WorkflowExecutionMapper.xml
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/resources/mapper/workflow/WorkflowExecutionMapper.xml
@@ -31,8 +31,6 @@
   <select id="selectRecoverableExecutionIds" resultType="java.lang.String">
     SELECT e.id
     FROM yak_workflow_execution e
-    INNER JOIN yak_workflow_definition d
-      ON d.latest_execution_id = e.id
     WHERE e.status IN ('CREATED', 'RUNNING', 'PAUSING', 'PAUSED', 'RESUMING')
     ORDER BY e.created_at
   </select>

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/domain/WorkflowScheduleLaunchBindingScopeTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/domain/WorkflowScheduleLaunchBindingScopeTest.java
@@ -1,0 +1,23 @@
+package io.yak.ops.business.workflow.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class WorkflowScheduleLaunchBindingScopeTest {
+
+  @Test
+  void shouldRestoreOuterTriggerAfterNestedLaunch() {
+    assertThat(WorkflowScheduleLaunchBindingScope.currentTriggerId()).isNull();
+
+    try (var outer = WorkflowScheduleLaunchBindingScope.open("trigger-outer")) {
+      assertThat(WorkflowScheduleLaunchBindingScope.currentTriggerId()).isEqualTo("trigger-outer");
+      try (var inner = WorkflowScheduleLaunchBindingScope.open("trigger-inner")) {
+        assertThat(WorkflowScheduleLaunchBindingScope.currentTriggerId()).isEqualTo("trigger-inner");
+      }
+      assertThat(WorkflowScheduleLaunchBindingScope.currentTriggerId()).isEqualTo("trigger-outer");
+    }
+
+    assertThat(WorkflowScheduleLaunchBindingScope.currentTriggerId()).isNull();
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowLaunchServiceTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowLaunchServiceTest.java
@@ -52,6 +52,22 @@ class WorkflowLaunchServiceTest {
   }
 
   @Test
+  void shouldUseConcurrentDefinitionEntryForScheduledAdmission() {
+    WorkflowTriggerContext trigger = WorkflowTriggerContext.scheduled(
+        "trigger-parallel",
+        "schedule-1",
+        Instant.parse("2026-08-14T02:00:00Z"));
+    WorkflowDefinitionVO expected = definition("execution-parallel");
+    when(definitionService.runConcurrent("workflow-1")).thenReturn(expected);
+
+    WorkflowDefinitionVO actual = service.runScheduledPublished("workflow-1", trigger);
+
+    assertThat(actual).isSameAs(expected);
+    verify(definitionService).runConcurrent("workflow-1");
+    verify(triggerRecorder).record("execution-parallel", trigger);
+  }
+
+  @Test
   void shouldRouteAdHocApiRunAndRecordTriggerContext() {
     WorkflowRunDTO request = new WorkflowRunDTO(
         "临时工作流",

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowScheduleMisfireRecoveryTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowScheduleMisfireRecoveryTest.java
@@ -1,0 +1,69 @@
+package io.yak.ops.business.workflow.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.workflow.dao.WorkflowScheduleTriggerDao;
+import io.yak.ops.common.bean.po.workflow.WorkflowSchedulePO;
+import io.yak.ops.common.bean.po.workflow.WorkflowScheduleTriggerPO;
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class WorkflowScheduleMisfireRecoveryTest {
+  @Mock private WorkflowScheduleTriggerCoordinator coordinator;
+  @Mock private WorkflowScheduleTriggerDao ledger;
+
+  private WorkflowScheduleMisfireRecovery recovery;
+
+  @BeforeEach
+  void setUp() {
+    recovery = new WorkflowScheduleMisfireRecovery(coordinator, ledger);
+  }
+
+  @Test
+  void shouldFireOnceThroughCoordinator() {
+    WorkflowSchedulePO schedule = schedule("FIRE_ONCE");
+    Instant missed = Instant.parse("2026-08-14T01:00:00Z");
+    Instant recovered = Instant.parse("2026-08-14T03:00:00Z");
+
+    recovery.recover(schedule, missed, recovered);
+
+    verify(coordinator).recoverMisfire(schedule, missed, recovered);
+  }
+
+  @Test
+  void shouldPersistSkippedMisfireInLedger() {
+    WorkflowSchedulePO schedule = schedule("SKIP");
+    Instant missed = Instant.parse("2026-08-14T01:00:00Z");
+    Instant recovered = Instant.parse("2026-08-14T03:00:00Z");
+    when(ledger.claim(org.mockito.ArgumentMatchers.any()))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    recovery.recover(schedule, missed, recovered);
+
+    ArgumentCaptor<WorkflowScheduleTriggerPO> captor =
+        ArgumentCaptor.forClass(WorkflowScheduleTriggerPO.class);
+    verify(ledger).claim(captor.capture());
+    WorkflowScheduleTriggerPO trigger = captor.getValue();
+    assertThat(trigger.getStatus()).isEqualTo("SKIPPED");
+    assertThat(trigger.getTriggerSource()).isEqualTo("MISFIRE_RECOVERY");
+    assertThat(trigger.getPlannedFireTime()).isEqualTo(missed);
+    assertThat(trigger.getCompletedAt()).isEqualTo(recovered);
+  }
+
+  private WorkflowSchedulePO schedule(String misfire) {
+    WorkflowSchedulePO value = new WorkflowSchedulePO();
+    value.setId("schedule-1");
+    value.setWorkflowId("workflow-1");
+    value.setExecutionStrategy("SERIAL_WAIT");
+    value.setMisfireStrategy(misfire);
+    return value;
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowScheduleTriggerAdmissionTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowScheduleTriggerAdmissionTest.java
@@ -1,0 +1,148 @@
+package io.yak.ops.business.workflow.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.workflow.dao.WorkflowExecutionDao;
+import io.yak.ops.business.workflow.dao.WorkflowScheduleTriggerDao;
+import io.yak.ops.common.bean.po.workflow.WorkflowSchedulePO;
+import io.yak.ops.common.bean.po.workflow.WorkflowScheduleTriggerPO;
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class WorkflowScheduleTriggerAdmissionTest {
+  @Mock private WorkflowScheduleTriggerDao ledger;
+  @Mock private WorkflowScheduleQuery schedules;
+  @Mock private WorkflowExecutionDao executions;
+
+  private WorkflowScheduleTriggerAdmission admission;
+
+  @BeforeEach
+  void setUp() {
+    admission = new WorkflowScheduleTriggerAdmission(ledger, schedules, executions);
+  }
+
+  @Test
+  void shouldReturnExistingLedgerWithoutSecondAdmission() {
+    WorkflowSchedulePO schedule = schedule("SERIAL_WAIT");
+    WorkflowScheduleTriggerPO existing = trigger("RUNNING");
+    existing.setWorkflowExecutionId("execution-1");
+    when(ledger.claim(existing)).thenReturn(existing);
+
+    var result = admission.admitNew(schedule, existing);
+
+    assertThat(result.duplicate()).isTrue();
+    assertThat(result.launchNow()).isFalse();
+    assertThat(result.trigger().getWorkflowExecutionId()).isEqualTo("execution-1");
+    verify(ledger, never()).lockWorkflow("workflow-1");
+  }
+
+  @Test
+  void shouldQueueSerialWaitWhenWorkflowIsBusy() {
+    WorkflowSchedulePO schedule = schedule("SERIAL_WAIT");
+    WorkflowScheduleTriggerPO trigger = trigger("RECEIVED");
+    when(ledger.claim(trigger)).thenReturn(trigger);
+    when(ledger.countActiveExecutions("workflow-1")).thenReturn(1L);
+    when(ledger.countLaunchingTriggers("workflow-1")).thenReturn(0L);
+    when(ledger.update(trigger)).thenReturn(1);
+
+    var result = admission.admitNew(schedule, trigger);
+
+    assertThat(result.launchNow()).isFalse();
+    assertThat(trigger.getStatus()).isEqualTo("WAITING");
+    assertThat(trigger.getMessage()).contains("串行等待");
+  }
+
+  @Test
+  void shouldSkipSerialDiscardWhenWorkflowIsBusy() {
+    WorkflowSchedulePO schedule = schedule("SERIAL_DISCARD");
+    WorkflowScheduleTriggerPO trigger = trigger("RECEIVED");
+    when(ledger.claim(trigger)).thenReturn(trigger);
+    when(ledger.countActiveExecutions("workflow-1")).thenReturn(1L);
+    when(ledger.countLaunchingTriggers("workflow-1")).thenReturn(0L);
+    when(ledger.update(trigger)).thenReturn(1);
+
+    var result = admission.admitNew(schedule, trigger);
+
+    assertThat(result.launchNow()).isFalse();
+    assertThat(trigger.getStatus()).isEqualTo("SKIPPED");
+    assertThat(trigger.getCompletedAt()).isNotNull();
+  }
+
+  @Test
+  void shouldReserveParallelLaunchEvenWhenWorkflowIsBusy() {
+    WorkflowSchedulePO schedule = schedule("PARALLEL");
+    WorkflowScheduleTriggerPO trigger = trigger("RECEIVED");
+    when(ledger.claim(trigger)).thenReturn(trigger);
+    when(ledger.countActiveExecutions("workflow-1")).thenReturn(3L);
+    when(ledger.countLaunchingTriggers("workflow-1")).thenReturn(2L);
+    when(ledger.update(trigger)).thenReturn(1);
+
+    var result = admission.admitNew(schedule, trigger);
+
+    assertThat(result.launchNow()).isTrue();
+    assertThat(trigger.getStatus()).isEqualTo("LAUNCHING");
+    assertThat(trigger.getLaunchedAt()).isNotNull();
+  }
+
+  @Test
+  void shouldReserveOldestWaitingTriggerAfterExecutionCompletes() {
+    WorkflowScheduleTriggerPO completed = trigger("RUNNING");
+    completed.setWorkflowExecutionId("execution-1");
+    WorkflowScheduleTriggerPO waiting = trigger("WAITING");
+    waiting.setId("ledger-2");
+    waiting.setScheduleId("schedule-2");
+    waiting.setPlannedFireTime(Instant.parse("2026-08-14T03:00:00Z"));
+    WorkflowSchedulePO waitingSchedule = schedule("SERIAL_WAIT");
+    waitingSchedule.setId("schedule-2");
+
+    when(ledger.selectByExecutionId("execution-1")).thenReturn(completed, completed);
+    when(ledger.update(completed)).thenReturn(1);
+    when(ledger.countActiveExecutions("workflow-1")).thenReturn(0L);
+    when(ledger.countLaunchingTriggers("workflow-1")).thenReturn(0L);
+    when(ledger.selectNextWaiting("workflow-1")).thenReturn(waiting);
+    when(schedules.require("schedule-2")).thenReturn(waitingSchedule);
+    when(ledger.update(waiting)).thenReturn(1);
+
+    var result = admission.completeExecution(
+        "execution-1", "SUCCESS", Instant.parse("2026-08-14T02:30:00Z"));
+
+    assertThat(completed.getStatus()).isEqualTo("SUCCEEDED");
+    assertThat(result.launchNow()).isTrue();
+    assertThat(result.trigger()).isSameAs(waiting);
+    assertThat(waiting.getStatus()).isEqualTo("LAUNCHING");
+  }
+
+  private WorkflowSchedulePO schedule(String strategy) {
+    WorkflowSchedulePO value = new WorkflowSchedulePO();
+    value.setId("schedule-1");
+    value.setWorkflowId("workflow-1");
+    value.setStatus("ONLINE");
+    value.setExecutionStrategy(strategy);
+    value.setMisfireStrategy("FIRE_ONCE");
+    return value;
+  }
+
+  private WorkflowScheduleTriggerPO trigger(String status) {
+    WorkflowScheduleTriggerPO value = new WorkflowScheduleTriggerPO();
+    value.setId("ledger-1");
+    value.setScheduleId("schedule-1");
+    value.setWorkflowId("workflow-1");
+    value.setTriggerId("trigger-1");
+    value.setPlannedFireTime(Instant.parse("2026-08-14T02:00:00Z"));
+    value.setActualFireTime(Instant.parse("2026-08-14T02:00:01Z"));
+    value.setExecutionStrategy("SERIAL_WAIT");
+    value.setMisfireStrategy("FIRE_ONCE");
+    value.setStatus(status);
+    value.setCreateTime(Instant.parse("2026-08-14T02:00:01Z"));
+    value.setUpdateTime(Instant.parse("2026-08-14T02:00:01Z"));
+    return value;
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowScheduleTriggerAdmissionTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowScheduleTriggerAdmissionTest.java
@@ -51,6 +51,7 @@ class WorkflowScheduleTriggerAdmissionTest {
     when(ledger.claim(trigger)).thenReturn(trigger);
     when(ledger.countActiveExecutions("workflow-1")).thenReturn(1L);
     when(ledger.countLaunchingTriggers("workflow-1")).thenReturn(0L);
+    when(ledger.countWaitingTriggers("workflow-1")).thenReturn(0L);
     when(ledger.update(trigger)).thenReturn(1);
 
     var result = admission.admitNew(schedule, trigger);
@@ -61,12 +62,30 @@ class WorkflowScheduleTriggerAdmissionTest {
   }
 
   @Test
+  void shouldNotLetNewSerialWaitJumpAheadOfExistingBacklog() {
+    WorkflowSchedulePO schedule = schedule("SERIAL_WAIT");
+    WorkflowScheduleTriggerPO trigger = trigger("RECEIVED");
+    when(ledger.claim(trigger)).thenReturn(trigger);
+    when(ledger.countActiveExecutions("workflow-1")).thenReturn(0L);
+    when(ledger.countLaunchingTriggers("workflow-1")).thenReturn(0L);
+    when(ledger.countWaitingTriggers("workflow-1")).thenReturn(2L);
+    when(ledger.update(trigger)).thenReturn(1);
+
+    var result = admission.admitNew(schedule, trigger);
+
+    assertThat(result.launchNow()).isFalse();
+    assertThat(trigger.getStatus()).isEqualTo("WAITING");
+    assertThat(trigger.getMessage()).contains("排队");
+  }
+
+  @Test
   void shouldSkipSerialDiscardWhenWorkflowIsBusy() {
     WorkflowSchedulePO schedule = schedule("SERIAL_DISCARD");
     WorkflowScheduleTriggerPO trigger = trigger("RECEIVED");
     when(ledger.claim(trigger)).thenReturn(trigger);
     when(ledger.countActiveExecutions("workflow-1")).thenReturn(1L);
     when(ledger.countLaunchingTriggers("workflow-1")).thenReturn(0L);
+    when(ledger.countWaitingTriggers("workflow-1")).thenReturn(0L);
     when(ledger.update(trigger)).thenReturn(1);
 
     var result = admission.admitNew(schedule, trigger);
@@ -83,6 +102,7 @@ class WorkflowScheduleTriggerAdmissionTest {
     when(ledger.claim(trigger)).thenReturn(trigger);
     when(ledger.countActiveExecutions("workflow-1")).thenReturn(3L);
     when(ledger.countLaunchingTriggers("workflow-1")).thenReturn(2L);
+    when(ledger.countWaitingTriggers("workflow-1")).thenReturn(4L);
     when(ledger.update(trigger)).thenReturn(1);
 
     var result = admission.admitNew(schedule, trigger);

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowScheduleTriggerAdmissionTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowScheduleTriggerAdmissionTest.java
@@ -32,15 +32,34 @@ class WorkflowScheduleTriggerAdmissionTest {
   @Test
   void shouldReturnExistingLedgerWithoutSecondAdmission() {
     WorkflowSchedulePO schedule = schedule("SERIAL_WAIT");
+    WorkflowScheduleTriggerPO candidate = trigger("RECEIVED");
+    candidate.setId("candidate-ledger");
     WorkflowScheduleTriggerPO existing = trigger("RUNNING");
+    existing.setId("existing-ledger");
     existing.setWorkflowExecutionId("execution-1");
-    when(ledger.claim(existing)).thenReturn(existing);
+    when(ledger.claim(candidate)).thenReturn(existing);
 
-    var result = admission.admitNew(schedule, existing);
+    var result = admission.admitNew(schedule, candidate);
 
     assertThat(result.duplicate()).isTrue();
     assertThat(result.launchNow()).isFalse();
     assertThat(result.trigger().getWorkflowExecutionId()).isEqualTo("execution-1");
+    verify(ledger, never()).lockWorkflow("workflow-1");
+  }
+
+  @Test
+  void shouldRejectConcurrentDuplicateEvenWhileStoredRowIsStillReceived() {
+    WorkflowSchedulePO schedule = schedule("PARALLEL");
+    WorkflowScheduleTriggerPO candidate = trigger("RECEIVED");
+    candidate.setId("candidate-ledger");
+    WorkflowScheduleTriggerPO existing = trigger("RECEIVED");
+    existing.setId("existing-ledger");
+    when(ledger.claim(candidate)).thenReturn(existing);
+
+    var result = admission.admitNew(schedule, candidate);
+
+    assertThat(result.duplicate()).isTrue();
+    assertThat(result.launchNow()).isFalse();
     verify(ledger, never()).lockWorkflow("workflow-1");
   }
 

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowScheduleTriggerCoordinatorTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowScheduleTriggerCoordinatorTest.java
@@ -1,0 +1,106 @@
+package io.yak.ops.business.workflow.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.workflow.dao.WorkflowScheduleTriggerDao;
+import io.yak.ops.business.workflow.domain.WorkflowTriggerContext;
+import io.yak.ops.business.workflow.service.WorkflowScheduleTriggerAdmission.AdmissionResult;
+import io.yak.ops.common.bean.po.workflow.WorkflowSchedulePO;
+import io.yak.ops.common.bean.po.workflow.WorkflowScheduleTriggerPO;
+import io.yak.ops.common.bean.vo.workflow.WorkflowDefinitionVO;
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class WorkflowScheduleTriggerCoordinatorTest {
+  @Mock private WorkflowScheduleTriggerDao ledger;
+  @Mock private WorkflowScheduleQuery schedules;
+  @Mock private WorkflowLaunchService launchService;
+  @Mock private WorkflowScheduleTriggerAdmission admission;
+
+  private WorkflowScheduleTriggerCoordinator coordinator;
+
+  @BeforeEach
+  void setUp() {
+    coordinator = new WorkflowScheduleTriggerCoordinator(ledger, schedules, launchService, admission);
+  }
+
+  @Test
+  void shouldNotLaunchDuplicatePlannedFire() {
+    WorkflowSchedulePO schedule = schedule();
+    WorkflowScheduleTriggerPO existing = trigger("RUNNING");
+    existing.setWorkflowExecutionId("execution-existing");
+    when(admission.admitNew(eq(schedule), any()))
+        .thenReturn(new AdmissionResult(existing, false, true));
+
+    var result = coordinator.submit(
+        schedule,
+        "quartz-trigger-2",
+        Instant.parse("2026-08-14T02:00:00Z"),
+        Instant.parse("2026-08-14T02:00:01Z"),
+        "CRON");
+
+    assertThat(result.businessExecutionId()).isEqualTo("execution-existing");
+    assertThat(result.message()).contains("幂等拦截");
+    verify(launchService, never()).runScheduledPublished(any(), any());
+  }
+
+  @Test
+  void shouldLaunchOnlyAfterAdmissionReservation() {
+    WorkflowSchedulePO schedule = schedule();
+    WorkflowScheduleTriggerPO reserved = trigger("LAUNCHING");
+    WorkflowDefinitionVO launched = org.mockito.Mockito.mock(WorkflowDefinitionVO.class);
+    when(admission.admitNew(eq(schedule), any()))
+        .thenReturn(new AdmissionResult(reserved, true, false));
+    when(schedules.require("schedule-1")).thenReturn(schedule);
+    when(launchService.runScheduledPublished(eq("workflow-1"), any(WorkflowTriggerContext.class)))
+        .thenReturn(launched);
+    when(launched.latestExecutionId()).thenReturn("execution-1");
+    when(admission.bindLaunch(reserved, "execution-1"))
+        .thenReturn(new AdmissionResult(reserved, false, false));
+
+    var result = coordinator.submit(
+        schedule,
+        "quartz-trigger-1",
+        Instant.parse("2026-08-14T02:00:00Z"),
+        Instant.parse("2026-08-14T02:00:01Z"),
+        "CRON");
+
+    assertThat(result.businessExecutionId()).isEqualTo("execution-1");
+    verify(launchService).runScheduledPublished(eq("workflow-1"), any(WorkflowTriggerContext.class));
+    verify(admission).bindLaunch(reserved, "execution-1");
+  }
+
+  private WorkflowSchedulePO schedule() {
+    WorkflowSchedulePO value = new WorkflowSchedulePO();
+    value.setId("schedule-1");
+    value.setWorkflowId("workflow-1");
+    value.setStatus("ONLINE");
+    value.setExecutionStrategy("SERIAL_WAIT");
+    value.setMisfireStrategy("FIRE_ONCE");
+    return value;
+  }
+
+  private WorkflowScheduleTriggerPO trigger(String status) {
+    WorkflowScheduleTriggerPO value = new WorkflowScheduleTriggerPO();
+    value.setId("ledger-1");
+    value.setScheduleId("schedule-1");
+    value.setWorkflowId("workflow-1");
+    value.setTriggerId("quartz-trigger-1");
+    value.setPlannedFireTime(Instant.parse("2026-08-14T02:00:00Z"));
+    value.setActualFireTime(Instant.parse("2026-08-14T02:00:01Z"));
+    value.setExecutionStrategy("SERIAL_WAIT");
+    value.setMisfireStrategy("FIRE_ONCE");
+    value.setStatus(status);
+    return value;
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowScheduleTriggerHandlerTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowScheduleTriggerHandlerTest.java
@@ -9,7 +9,6 @@ import static org.mockito.Mockito.when;
 import io.yak.framework.schedule.api.ScheduleExecutionContext;
 import io.yak.framework.schedule.api.ScheduleExecutionResult;
 import io.yak.framework.schedule.api.ScheduleKey;
-import io.yak.ops.business.workflow.domain.WorkflowTriggerContext;
 import io.yak.ops.common.bean.po.workflow.WorkflowSchedulePO;
 import io.yak.ops.common.bean.vo.workflow.WorkflowDefinitionVO;
 import java.time.Instant;
@@ -18,7 +17,6 @@ import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -26,7 +24,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class WorkflowScheduleTriggerHandlerTest {
   @Mock private WorkflowScheduleQuery schedules;
   @Mock private WorkflowDefinitionService definitions;
-  @Mock private WorkflowLaunchService launchService;
+  @Mock private WorkflowScheduleTriggerCoordinator coordinator;
   @Mock private WorkflowScheduleLifecycle lifecycle;
   @Mock private WorkflowScheduleEngineBridge engine;
   @Mock private WorkflowScheduleRuntimeState runtimeState;
@@ -36,34 +34,28 @@ class WorkflowScheduleTriggerHandlerTest {
   @BeforeEach
   void setUp() {
     handler = new WorkflowScheduleTriggerHandler(
-        schedules, definitions, launchService, lifecycle, engine, runtimeState);
+        schedules, definitions, coordinator, lifecycle, engine, runtimeState);
   }
 
   @Test
-  void shouldConvertQuartzFireIntoScheduledWorkflowLaunch() {
+  void shouldRouteQuartzFireIntoDurableTriggerCoordinator() {
     Instant planned = Instant.parse("2026-08-14T02:00:00Z");
     Instant actual = planned.plusSeconds(1);
     WorkflowSchedulePO schedule = schedule();
     WorkflowDefinitionVO workflow = org.mockito.Mockito.mock(WorkflowDefinitionVO.class);
-    WorkflowDefinitionVO launched = org.mockito.Mockito.mock(WorkflowDefinitionVO.class);
     when(workflow.status()).thenReturn("ONLINE");
     when(workflow.activeVersionId()).thenReturn("workflow-version-1");
-    when(launched.latestExecutionId()).thenReturn("execution-1");
     when(schedules.require("schedule-1")).thenReturn(schedule);
     when(definitions.get("workflow-1")).thenReturn(workflow);
-    when(launchService.runPublished(any(), any())).thenReturn(launched);
+    when(coordinator.submit(schedule, "trigger-1", planned, actual, "CRON"))
+        .thenReturn(ScheduleExecutionResult.accepted("execution-1"));
     when(engine.snapshot("schedule-1")).thenReturn(Optional.empty());
 
     ScheduleExecutionResult result = handler.execute(context(planned));
 
     assertThat(result.accepted()).isTrue();
     assertThat(result.businessExecutionId()).isEqualTo("execution-1");
-    ArgumentCaptor<WorkflowTriggerContext> trigger =
-        ArgumentCaptor.forClass(WorkflowTriggerContext.class);
-    verify(launchService).runPublished(org.mockito.ArgumentMatchers.eq("workflow-1"), trigger.capture());
-    assertThat(trigger.getValue().triggerId()).isEqualTo("trigger-1");
-    assertThat(trigger.getValue().scheduleId()).isEqualTo("schedule-1");
-    assertThat(trigger.getValue().plannedFireTime()).isEqualTo(planned);
+    verify(coordinator).submit(schedule, "trigger-1", planned, actual, "CRON");
     verify(runtimeState).recordFire("schedule-1", actual, null);
   }
 
@@ -80,7 +72,7 @@ class WorkflowScheduleTriggerHandlerTest {
 
     assertThat(result.accepted()).isTrue();
     assertThat(result.businessExecutionId()).isNull();
-    verify(launchService, never()).runPublished(any(), any());
+    verify(coordinator, never()).submit(any(), any(), any(), any(), any());
     verify(runtimeState).recordFire("schedule-1", actual, null);
   }
 

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/workflow/WorkflowScheduleTriggerPO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/workflow/WorkflowScheduleTriggerPO.java
@@ -1,0 +1,32 @@
+package io.yak.ops.common.bean.po.workflow;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import java.time.Instant;
+import lombok.Data;
+
+/** 工作流调度 Trigger Ledger 持久化对象。 */
+@Data
+@TableName("yak_workflow_schedule_trigger")
+public class WorkflowScheduleTriggerPO {
+  @TableId(type = IdType.INPUT)
+  private String id;
+  private String scheduleId;
+  private String workflowId;
+  private String triggerId;
+  private String triggerSource;
+  private Instant plannedFireTime;
+  private Instant actualFireTime;
+  private String executionStrategy;
+  private String misfireStrategy;
+  private String status;
+  private String workflowExecutionId;
+  private String executionStatus;
+  private String message;
+  private String errorMessage;
+  private Instant launchedAt;
+  private Instant completedAt;
+  private Instant createTime;
+  private Instant updateTime;
+}

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/vo/workflow/WorkflowScheduleTriggerVO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/vo/workflow/WorkflowScheduleTriggerVO.java
@@ -1,0 +1,25 @@
+package io.yak.ops.common.bean.vo.workflow;
+
+import java.time.Instant;
+
+/** 工作流调度 Trigger Ledger 视图。 */
+public record WorkflowScheduleTriggerVO(
+    String id,
+    String scheduleId,
+    String workflowId,
+    String triggerId,
+    String triggerSource,
+    Instant plannedFireTime,
+    Instant actualFireTime,
+    String executionStrategy,
+    String misfireStrategy,
+    String status,
+    String workflowExecutionId,
+    String executionStatus,
+    String message,
+    String errorMessage,
+    Instant launchedAt,
+    Instant completedAt,
+    Instant createTime,
+    Instant updateTime) {
+}

--- a/yak-ops-ui/src/pages/workflow/schedules/ScheduleEditorDrawer.tsx
+++ b/yak-ops-ui/src/pages/workflow/schedules/ScheduleEditorDrawer.tsx
@@ -132,7 +132,7 @@ const ScheduleEditorDrawer = ({
         <Form.Item
           name="cronExpression"
           label="Cron 表达式"
-          extra="Stage 2 保存调度定义；Stage 3 接入 Scheduler 后才会按表达式自动触发。"
+          extra="调度启用后由 Yak Schedule / Quartz 按 Cron 与时区触发；每次计划时间都会进入 Trigger Ledger。"
           rules={[{ required: true, message: '请输入 Cron 表达式' }]}
         >
           <Input variant="filled" placeholder="0 0 2 * * ?" />
@@ -154,7 +154,12 @@ const ScheduleEditorDrawer = ({
         </div>
 
         <div className="grid grid-cols-2 gap-4">
-          <Form.Item name="executionStrategy" label="实例并发策略" rules={[{ required: true }]}>
+          <Form.Item
+            name="executionStrategy"
+            label="实例并发策略"
+            extra="等待：排队到前序终态；跳过：已有实例时记为 SKIPPED；并行：允许同时创建实例。"
+            rules={[{ required: true }]}
+          >
             <Select
               options={[
                 { value: 'SERIAL_WAIT', label: '等待上一次完成（推荐）' },
@@ -163,7 +168,12 @@ const ScheduleEditorDrawer = ({
               ]}
             />
           </Form.Item>
-          <Form.Item name="misfireStrategy" label="错过调度策略" rules={[{ required: true }]}>
+          <Form.Item
+            name="misfireStrategy"
+            label="错过调度策略"
+            extra="服务恢复时 FIRE_ONCE 合并补跑一次；SKIP 会跳过并保留 Ledger 审计记录。"
+            rules={[{ required: true }]}
+          >
             <Select
               options={[
                 { value: 'FIRE_ONCE', label: '恢复后补跑一次' },

--- a/yak-ops-ui/src/pages/workflow/schedules/TriggerLedgerDrawer.tsx
+++ b/yak-ops-ui/src/pages/workflow/schedules/TriggerLedgerDrawer.tsx
@@ -1,0 +1,173 @@
+import {
+  listWorkflowScheduleTriggers,
+  type WorkflowSchedule,
+  type WorkflowScheduleTrigger,
+  type WorkflowScheduleTriggerStatus,
+} from '@/services/workflow/schedules';
+import { ReloadOutlined } from '@ant-design/icons';
+import { Button, Drawer, Select, Table, message } from 'antd';
+import { useCallback, useEffect, useState } from 'react';
+
+interface TriggerLedgerDrawerProps {
+  open: boolean;
+  schedule?: WorkflowSchedule;
+  onClose: () => void;
+}
+
+const STATUS_LABEL: Record<WorkflowScheduleTriggerStatus, string> = {
+  RECEIVED: '已接收',
+  WAITING: '等待中',
+  LAUNCHING: '启动中',
+  RUNNING: '运行中',
+  SUCCEEDED: '成功',
+  FAILED: '失败',
+  CANCELED: '已取消',
+  SKIPPED: '已跳过',
+};
+
+const SOURCE_LABEL: Record<string, string> = {
+  CRON: 'Cron',
+  MANUAL: '手动触发',
+  MISFIRE_RECOVERY: 'Misfire 恢复',
+};
+
+const formatTime = (value?: string) => {
+  if (!value) return '-';
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? value : date.toLocaleString();
+};
+
+const TriggerLedgerDrawer = ({ open, schedule, onClose }: TriggerLedgerDrawerProps) => {
+  const [records, setRecords] = useState<WorkflowScheduleTrigger[]>([]);
+  const [status, setStatus] = useState<WorkflowScheduleTriggerStatus>();
+  const [loading, setLoading] = useState(false);
+
+  const load = useCallback(async () => {
+    if (!open || !schedule?.id) return;
+    setLoading(true);
+    try {
+      setRecords(await listWorkflowScheduleTriggers({
+        scheduleId: schedule.id,
+        status,
+        limit: 200,
+      }));
+    } catch (error) {
+      message.error(error instanceof Error ? error.message : 'Trigger Ledger 加载失败');
+    } finally {
+      setLoading(false);
+    }
+  }, [open, schedule?.id, status]);
+
+  useEffect(() => {
+    if (open) void load();
+  }, [load, open]);
+
+  return (
+    <Drawer
+      open={open}
+      width={980}
+      title={
+        <div>
+          <div className="text-[14px] font-semibold text-[#344054]">Trigger 记录</div>
+          <div className="mt-0.5 text-[11px] font-normal text-[#98a2b3]">
+            {schedule?.name || '-'} · 每个计划时间最多产生一条 Ledger 记录
+          </div>
+        </div>
+      }
+      onClose={onClose}
+      destroyOnClose
+      extra={
+        <div className="flex items-center gap-2">
+          <Select
+            allowClear
+            placeholder="全部状态"
+            className="w-[120px]"
+            value={status}
+            onChange={(value) => setStatus(value)}
+            options={Object.entries(STATUS_LABEL).map(([value, label]) => ({ value, label }))}
+          />
+          <Button icon={<ReloadOutlined spin={loading} />} onClick={() => void load()} />
+        </div>
+      }
+    >
+      <div className="mb-3 rounded-sm bg-[#f8f9fb] px-3 py-2 text-[11px] leading-5 text-[#667085]">
+        SERIAL_WAIT 会先进入 WAITING，前序 WorkflowExecution 终态提交后自动推进；
+        SERIAL_DISCARD 会记为 SKIPPED；Misfire 的 FIRE_ONCE / SKIP 同样保留审计记录。
+      </div>
+      <Table
+        rowKey="id"
+        size="small"
+        bordered
+        loading={loading}
+        dataSource={records}
+        scroll={{ x: 1280 }}
+        pagination={{ pageSize: 20, showSizeChanger: false, showTotal: (total) => `共 ${total} 条` }}
+        columns={[
+          {
+            title: '状态',
+            dataIndex: 'status',
+            width: 90,
+            fixed: 'left',
+            render: (value: WorkflowScheduleTriggerStatus) => (
+              <span className="text-[12px] font-medium text-[#475467]">{STATUS_LABEL[value] || value}</span>
+            ),
+          },
+          {
+            title: '计划 / 实际触发',
+            width: 205,
+            render: (_: unknown, record: WorkflowScheduleTrigger) => (
+              <div className="text-[11px] leading-5 text-[#667085]">
+                <div>计划：{formatTime(record.plannedFireTime)}</div>
+                <div>实际：{formatTime(record.actualFireTime)}</div>
+              </div>
+            ),
+          },
+          {
+            title: '来源',
+            dataIndex: 'triggerSource',
+            width: 105,
+            render: (value: string) => (
+              <span className="text-[12px] text-[#667085]">{SOURCE_LABEL[value] || value}</span>
+            ),
+          },
+          {
+            title: '实例策略',
+            dataIndex: 'executionStrategy',
+            width: 120,
+            render: (value: string) => <code className="text-[11px] text-[#475467]">{value}</code>,
+          },
+          {
+            title: 'WorkflowExecution',
+            dataIndex: 'workflowExecutionId',
+            width: 230,
+            render: (value?: string, record?: WorkflowScheduleTrigger) => (
+              value
+                ? <div><code className="text-[11px] text-[#475467]">{value}</code><div className="mt-1 text-[11px] text-[#98a2b3]">{record?.executionStatus || '-'}</div></div>
+                : <span className="text-[11px] text-[#98a2b3]">尚未创建</span>
+            ),
+          },
+          {
+            title: '说明',
+            dataIndex: 'message',
+            width: 280,
+            render: (value?: string, record?: WorkflowScheduleTrigger) => (
+              <div className="text-[11px] leading-5 text-[#667085]">
+                <div>{value || '-'}</div>
+                {record?.errorMessage ? <div className="mt-1 text-[#b42318]">{record.errorMessage}</div> : null}
+              </div>
+            ),
+          },
+          {
+            title: '完成时间',
+            dataIndex: 'completedAt',
+            width: 165,
+            render: (value?: string) => <span className="text-[11px] text-[#98a2b3]">{formatTime(value)}</span>,
+          },
+        ]}
+        className="[&_.ant-table-thead>tr>th]:!bg-[#f8f9fb] [&_.ant-table-thead>tr>th]:!text-[12px] [&_.ant-table-thead>tr>th]:!text-[#667085]"
+      />
+    </Drawer>
+  );
+};
+
+export default TriggerLedgerDrawer;

--- a/yak-ops-ui/src/pages/workflow/schedules/index.tsx
+++ b/yak-ops-ui/src/pages/workflow/schedules/index.tsx
@@ -8,9 +8,10 @@ import {
 } from '@/services/workflow/schedules';
 import { ReloadOutlined, SearchOutlined } from '@ant-design/icons';
 import { Button, ConfigProvider, Input, Modal, Select, Table, Tooltip, message } from 'antd';
-import { CalendarClock, Pencil, Power, PowerOff, Trash2 } from 'lucide-react';
+import { CalendarClock, History, Pencil, Power, PowerOff, Trash2 } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import ScheduleEditorDrawer from './ScheduleEditorDrawer';
+import TriggerLedgerDrawer from './TriggerLedgerDrawer';
 
 type StatusFilter = 'ALL' | 'ONLINE' | 'OFFLINE';
 
@@ -35,6 +36,8 @@ const WorkflowSchedulesPage = () => {
   const [status, setStatus] = useState<StatusFilter>('ALL');
   const [editorOpen, setEditorOpen] = useState(false);
   const [editing, setEditing] = useState<WorkflowSchedule>();
+  const [ledgerOpen, setLedgerOpen] = useState(false);
+  const [ledgerSchedule, setLedgerSchedule] = useState<WorkflowSchedule>();
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -92,7 +95,7 @@ const WorkflowSchedulesPage = () => {
     Modal.confirm({
       centered: true,
       title: '确认删除调度吗？',
-      content: `即将删除「${schedule.name}」，删除后无法恢复。`,
+      content: `即将删除「${schedule.name}」。调度定义会删除，历史 Trigger Ledger 会保留用于审计。`,
       okText: '删除',
       cancelText: '取消',
       okButtonProps: { danger: true },
@@ -167,12 +170,20 @@ const WorkflowSchedulesPage = () => {
       render: (value?: string) => <span className="text-[12px] text-[#98a2b3]">{formatTime(value)}</span>,
     },
     {
-      title: '操作', dataIndex: 'operate', width: 220, fixed: 'right' as const,
+      title: '操作', dataIndex: 'operate', width: 300, fixed: 'right' as const,
       render: (_: unknown, record: WorkflowSchedule) => {
         const workflowOnline = workflowMap.get(record.workflowId)?.status === 'ONLINE';
         const online = record.status === 'ONLINE';
         return (
           <div className="flex items-center gap-0.5 whitespace-nowrap">
+            <Button
+              type="text"
+              size="small"
+              icon={<History size={13} />}
+              onClick={() => { setLedgerSchedule(record); setLedgerOpen(true); }}
+            >
+              触发记录
+            </Button>
             <Tooltip title={online ? '已启用调度请先停用后再修改配置' : undefined}>
               <span>
                 <Button
@@ -214,7 +225,7 @@ const WorkflowSchedulesPage = () => {
         <div className="flex items-center justify-between">
           <div>
             <h1 className="m-0 text-[17px] font-semibold leading-8">调度管理</h1>
-            <div className="text-[11px] text-[#98a2b3]">Yak Schedule / Quartz · Cron、时区、生效区间与实例策略</div>
+            <div className="text-[11px] text-[#98a2b3]">Yak Schedule / Quartz · Trigger Ledger、并发策略与恢复</div>
           </div>
           <Button danger type="primary" size="small" icon={<CalendarClock size={14} />} onClick={() => { setEditing(undefined); setEditorOpen(true); }}>
             新建调度
@@ -248,9 +259,8 @@ const WorkflowSchedulesPage = () => {
           </div>
         </div>
 
-        <div className="mt-3 flex min-h-9 items-center rounded-sm bg-[#fff7e6] px-3 text-[12px] text-[#475467]">
-          <span className="mr-2 text-[#faad14]">▲</span>
-          <span><b>【提示】</b> 启用后计划会注册到 Yak Schedule，并由 Quartz 按 Cron 与时区自动触发；应用重启后会从工作流调度表自动恢复 ONLINE 计划。</span>
+        <div className="mt-3 flex min-h-9 items-center rounded-sm bg-[#f8f9fb] px-3 text-[12px] text-[#475467]">
+          <span><b>【生产调度】</b> Trigger Ledger 保证同一计划时间幂等；串行等待/跳过、并行执行与 Misfire 恢复均保留可审计记录。</span>
         </div>
 
         <div className="mt-4 flex-1">
@@ -261,7 +271,7 @@ const WorkflowSchedulesPage = () => {
             loading={loading}
             columns={columns as any}
             dataSource={filtered}
-            scroll={{ x: 1550 }}
+            scroll={{ x: 1630 }}
             pagination={{ pageSize: 10, showSizeChanger: true, pageSizeOptions: [10, 20, 50], showTotal: (total) => `共 ${total} 条` }}
             className="[&_.ant-table-thead>tr>th]:!bg-[#f8f9fb] [&_.ant-table-thead>tr>th]:!text-[12px] [&_.ant-table-thead>tr>th]:!text-[#667085] [&_.ant-table-tbody>tr>td]:!py-2.5"
           />
@@ -274,6 +284,11 @@ const WorkflowSchedulesPage = () => {
           workflowId={workflowId}
           onClose={() => { setEditorOpen(false); setEditing(undefined); }}
           onSaved={load}
+        />
+        <TriggerLedgerDrawer
+          open={ledgerOpen}
+          schedule={ledgerSchedule}
+          onClose={() => { setLedgerOpen(false); setLedgerSchedule(undefined); }}
         />
       </div>
     </ConfigProvider>

--- a/yak-ops-ui/src/services/workflow/schedules.ts
+++ b/yak-ops-ui/src/services/workflow/schedules.ts
@@ -7,6 +7,15 @@ export type WorkflowScheduleExecutionStrategy =
   | 'SERIAL_WAIT'
   | 'SERIAL_DISCARD';
 export type WorkflowScheduleMisfireStrategy = 'SKIP' | 'FIRE_ONCE';
+export type WorkflowScheduleTriggerStatus =
+  | 'RECEIVED'
+  | 'WAITING'
+  | 'LAUNCHING'
+  | 'RUNNING'
+  | 'SUCCEEDED'
+  | 'FAILED'
+  | 'CANCELED'
+  | 'SKIPPED';
 
 export interface WorkflowSchedule {
   id: string;
@@ -23,6 +32,27 @@ export interface WorkflowSchedule {
   input: Record<string, unknown>;
   lastFireTime?: string;
   nextFireTime?: string;
+  createTime: string;
+  updateTime: string;
+}
+
+export interface WorkflowScheduleTrigger {
+  id: string;
+  scheduleId: string;
+  workflowId: string;
+  triggerId: string;
+  triggerSource: 'CRON' | 'MANUAL' | 'MISFIRE_RECOVERY' | string;
+  plannedFireTime: string;
+  actualFireTime: string;
+  executionStrategy: WorkflowScheduleExecutionStrategy;
+  misfireStrategy: WorkflowScheduleMisfireStrategy;
+  status: WorkflowScheduleTriggerStatus;
+  workflowExecutionId?: string;
+  executionStatus?: string;
+  message?: string;
+  errorMessage?: string;
+  launchedAt?: string;
+  completedAt?: string;
   createTime: string;
   updateTime: string;
 }
@@ -44,6 +74,19 @@ export const listWorkflowSchedules = async (params?: {
 }) => {
   const response = await request<ApiResponse<WorkflowSchedule[]>>(
     '/api/v1/workflows/schedules',
+    { params },
+  );
+  return response.data || [];
+};
+
+export const listWorkflowScheduleTriggers = async (params?: {
+  scheduleId?: string;
+  workflowId?: string;
+  status?: WorkflowScheduleTriggerStatus;
+  limit?: number;
+}) => {
+  const response = await request<ApiResponse<WorkflowScheduleTrigger[]>>(
+    '/api/v1/workflows/schedules/triggers',
     { params },
   );
   return response.data || [];


### PR DESCRIPTION
## 背景

Stage 4：把 Stage 3 已经可用的 Cron 自动触发升级为可长期运行的生产调度链路，重点解决计划幂等、实例重叠、串行等待、跳过策略、并行执行以及服务重启后的 Misfire / Trigger 中间态恢复。

本 PR 继续沿用现有架构：Yak Schedule / Quartz 只负责“到点通知”，真正是否创建 WorkflowExecution 由 Yak Ops 的 Trigger Ledger 与准入协调器决定。

## 架构

```text
Yak Schedule / Quartz
        ↓
WorkflowScheduleTriggerHandler
        ↓
yak_workflow_schedule_trigger
        ↓
WorkflowScheduleTriggerAdmission
        ↓
SERIAL_WAIT / SERIAL_DISCARD / PARALLEL
        ↓
WorkflowScheduleTriggerCoordinator
        ↓
WorkflowLaunchService
        ↓
WorkflowExecution
        ↓
terminal event
        ↓
推进下一条 WAITING Trigger
```

## Trigger Ledger / 幂等

新增 `yak_workflow_schedule_trigger`：

- `UNIQUE(schedule_id, planned_fire_time)`：计划时间级数据库幂等边界
- `UNIQUE(trigger_id)`：Trigger ID 唯一
- 状态：`RECEIVED / WAITING / LAUNCHING / RUNNING / SUCCEEDED / FAILED / CANCELED / SKIPPED`
- 记录 planned/actual fire time、执行策略、Misfire 策略、WorkflowExecution ID/status、错误和完成时间
- Schedule 删除后 Ledger 历史仍保留用于审计，不做级联删除

并发重复到达时，不只依赖状态判断，还比较 candidate Ledger ID 与实际落库 ID；只有真正 INSERT 成功的 candidate 才拥有首次准入权，即使两个请求同时看到 RECEIVED，第二个也会直接按 duplicate 返回。

## 短事务准入

并发判断只在短事务里完成：

1. Trigger Ledger claim
2. 锁定 `yak_workflow_definition` 行
3. 查询当前 Workflow 的 active executions / LAUNCHING reservations / WAITING backlog
4. 决定 WAITING、SKIPPED 或 LAUNCHING
5. 提交事务
6. 事务外真正创建 WorkflowExecution

`LAUNCHING` 是持久化的执行预留位，因此不需要拿着数据库行锁执行 DAG，同时后续串行 Trigger 仍能看到“已有实例正在启动”。

## 执行策略

### SERIAL_WAIT

- 有 RUNNING/LAUNCHING/WAITING 时进入 WAITING
- 按 `planned_fire_time + create_time` FIFO 排队
- 新 Trigger 不允许插队已有 WAITING backlog
- 前序 WorkflowExecution 进入终态并提交后自动预留并启动队首
- 调度停用/过期/删除时，尚未启动的 RECEIVED/WAITING 统一标记 SKIPPED

### SERIAL_DISCARD

- 发现已有 active execution、LAUNCHING reservation 或 WAITING backlog 时直接标记 SKIPPED
- 不创建 WorkflowExecution
- Ledger 中保留跳过原因

### PARALLEL

- 不受 active/LAUNCHING/WAITING 数量限制
- 使用调度专用 `runScheduledPublished` / `runConcurrent` 创建并行 WorkflowExecution
- 手工运行仍保持原有单实例安全默认，不改变现有 API 行为

## WorkflowExecution 终态推进

`WorkflowExecutionRepositoryAdapter` 在 Execution 进入终态时发布 `WorkflowExecutionTerminalEvent`。

`WorkflowScheduleExecutionListener` 在事务 AFTER_COMMIT 后：

- 将对应 Ledger 标记为 SUCCEEDED / FAILED / CANCELED
- 释放串行占位
- 自动推进下一条 SERIAL_WAIT

## Prepared Execution early binding

为缩小“Execution 已创建但 Trigger 尚未绑定时进程崩溃”的重复启动窗口：

- `WorkflowLaunchService.runScheduledPublished` 打开 scoped binding context
- `engine.start` 首次持久化 CREATED WorkflowExecution 时
- `WorkflowExecutionRepositoryAdapter` 在同一事务里把 executionId 提前写回 LAUNCHING Ledger
- 之后才进入 Workflow activate
- scope 使用栈支持“超快实例终态 -> 立即推进下一条 WAITING”的嵌套启动，并通过 try-with-resources 自动恢复/清理
- Launch 完成后仍保留原有 runtime trigger metadata，用于通用执行追踪和兼容恢复

## Misfire / 重启恢复

启动恢复顺序：

1. Workflow Runtime `@Order(10)` 按原有机制恢复全部非终态 WorkflowExecution
2. `WorkflowExecutionMapper.selectRecoverableExecutionIds` 已从 latest execution 扩展为全部非终态 execution，支持 PARALLEL 重启恢复
3. Workflow Schedule Reconciler `@Order(20)` 恢复 Quartz ONLINE plans
4. 使用持久化 `nextFireTime` 判断停机期间是否错过一次计划
5. `FIRE_ONCE`：通过同一 Trigger Ledger/Coordinator 合并补触发一次
6. `SKIP`：写入一条 MISFIRE_RECOVERY + SKIPPED Ledger，保证可审计
7. 恢复 RECEIVED / WAITING / LAUNCHING / RUNNING Ledger 中间态并继续等待队列

当前 Quartz `triggerRetries` 仍保持 0，避免调度引擎层重试与业务 Ledger 恢复机制互相叠加。

## 可观测性

调度管理页面新增「触发记录」Drawer，可直接查看：

- Ledger 状态
- 计划时间 / 实际触发时间
- CRON / MANUAL / MISFIRE_RECOVERY 来源
- 执行策略
- WorkflowExecution ID / 状态
- WAIT / SKIP / FAIL 原因
- 完成时间

并同步更新 Schedule 编辑器中 SERIAL_WAIT / SERIAL_DISCARD / PARALLEL 与 FIRE_ONCE / SKIP 的说明。

## 测试覆盖

新增/更新测试覆盖：

- plan-time duplicate 不二次准入
- 并发 duplicate 在 RECEIVED 竞态窗口仍被拦截
- SERIAL_WAIT busy -> WAITING
- 已有 WAITING backlog 时不插队
- SERIAL_DISCARD busy -> SKIPPED
- PARALLEL busy -> LAUNCHING
- WorkflowExecution 终态后预留最早 WAITING
- Coordinator duplicate 不调用 WorkflowLaunchService
- FIRE_ONCE / SKIP Misfire 恢复
- scheduled concurrent launch entry
- nested launch binding scope push/pop
- Trigger Handler -> Coordinator 链路

## Stage 4 边界

本 PR 不包含：

- Stage 5 的 businessDate / scheduleTime 参数注入
- 历史日期区间 Backfill / 补数
- 从节点重跑等补数编排能力
- 分布式 Scheduler Master / Worker
- Quartz JDBC Cluster

这些继续留给后续阶段，避免 Stage 4 扩大成完整 DolphinScheduler 复制工程。