### PR TITLE
feat(dataset): Stage 1 数据集领域模型与发布链路

### DIFF
--- a/yak-ops-boot/pom.xml
+++ b/yak-ops-boot/pom.xml
@@ -34,6 +34,11 @@
         </dependency>
         <dependency>
             <groupId>io.yak.ops</groupId>
+            <artifactId>yak-ops-business-dataset</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.yak.ops</groupId>
             <artifactId>yak-ops-business-resource</artifactId>
         </dependency>
         <dependency>

--- a/yak-ops-business/pom.xml
+++ b/yak-ops-business/pom.xml
@@ -22,6 +22,7 @@
         <module>yak-ops-business-job</module>
         <module>yak-ops-business-task-catalog</module>
         <module>yak-ops-business-data-development</module>
+        <module>yak-ops-business-dataset</module>
         <module>yak-ops-business-resource</module>
         <module>yak-ops-business-sync</module>
         <module>yak-ops-business-quality</module>

--- a/yak-ops-business/yak-ops-business-dataset/pom.xml
+++ b/yak-ops-business/yak-ops-business-dataset/pom.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.yak.ops</groupId>
+        <artifactId>yak-ops-business</artifactId>
+        <version>1.0.0</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>yak-ops-business-dataset</artifactId>
+
+    <name>Yak Ops Business Dataset</name>
+    <description>BI dataset contracts, immutable versions and publication lifecycle</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.yak.ops</groupId>
+            <artifactId>yak-ops-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.yak.ops</groupId>
+            <artifactId>yak-ops-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.yak.ops</groupId>
+            <artifactId>yak-ops-business-datasource</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.yak.ops</groupId>
+            <artifactId>yak-ops-business-task-catalog</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-jdbc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-mysql</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/Dataset.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/Dataset.java
@@ -1,0 +1,73 @@
+package io.yak.ops.business.dataset;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import java.time.Instant;
+import java.util.List;
+
+/** Stable BI-consumption asset. Task execution remains owned by the upstream source domain. */
+public record Dataset(
+    @JsonSerialize(using = ToStringSerializer.class) long id,
+    String name,
+    String description,
+    DatasetStatus status,
+    @JsonSerialize(using = ToStringSerializer.class) Long currentVersionId,
+    Instant createTime,
+    Instant updateTime) {
+}
+
+enum DatasetStatus {
+  ONLINE,
+  OFFLINE
+}
+
+enum DatasetSourceType {
+  QUERY_REVISION,
+  TABLE,
+  VIEW
+}
+
+enum DatasetFieldDataType {
+  STRING,
+  NUMBER,
+  DATE,
+  DATETIME,
+  BOOLEAN,
+  UNKNOWN
+}
+
+enum DatasetFieldRole {
+  DIMENSION,
+  MEASURE
+}
+
+record DatasetVersion(
+    @JsonSerialize(using = ToStringSerializer.class) long id,
+    @JsonSerialize(using = ToStringSerializer.class) long datasetId,
+    int versionNo,
+    DatasetSourceType sourceType,
+    @JsonSerialize(using = ToStringSerializer.class) long sourceTaskAssetId,
+    @JsonSerialize(using = ToStringSerializer.class) long sourceTaskRevisionId,
+    int sourceTaskRevisionNo,
+    String schemaSnapshot,
+    Instant createTime) {
+}
+
+record DatasetField(
+    String fieldId,
+    @JsonSerialize(using = ToStringSerializer.class) long versionId,
+    String physicalName,
+    String displayName,
+    DatasetFieldDataType dataType,
+    boolean nullable,
+    String description,
+    DatasetFieldRole defaultRole,
+    int sortOrder) {
+}
+
+record DatasetDetail(
+    Dataset dataset,
+    DatasetVersion currentVersion,
+    List<DatasetVersion> versions,
+    List<DatasetField> fields) {
+}

--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetController.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetController.java
@@ -1,0 +1,105 @@
+package io.yak.ops.business.dataset;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.yak.framework.common.Result;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "BI 数据集接口")
+@RestController
+@RequestMapping("/api/v1/datasets")
+public class DatasetController {
+
+  private final DatasetService service;
+
+  public DatasetController(DatasetService service) {
+    this.service = service;
+  }
+
+  @Operation(summary = "查询 Dataset 列表")
+  @GetMapping
+  public Result<List<Dataset>> list() {
+    return Result.success(service.list());
+  }
+
+  @Operation(summary = "查询 Dataset 详情、当前版本与版本历史")
+  @GetMapping("/{datasetId}")
+  public Result<DatasetDetail> get(@PathVariable("datasetId") long datasetId) {
+    return Result.success(service.get(datasetId));
+  }
+
+  @Operation(summary = "把 ONLINE SQL TaskAsset 的当前不可变版本发布为 Dataset")
+  @PostMapping
+  public Result<DatasetDetail> publish(@Valid @RequestBody PublishDatasetRequest request) {
+    return Result.success(service.publish(new DatasetService.PublishCommand(
+        request.sourceTaskAssetId(),
+        request.name(),
+        request.description(),
+        toFieldSpecs(request.fields()))));
+  }
+
+  @Operation(summary = "把来源 TaskAsset 的当前版本发布为新的 DatasetVersion")
+  @PostMapping("/{datasetId}/versions")
+  public Result<DatasetDetail> createVersion(
+      @PathVariable("datasetId") long datasetId,
+      @Valid @RequestBody(required = false) CreateDatasetVersionRequest request) {
+    return Result.success(service.createVersion(
+        datasetId,
+        request == null ? List.of() : toFieldSpecs(request.fields())));
+  }
+
+  @Operation(summary = "上线 Dataset")
+  @PostMapping("/{datasetId}/online")
+  public Result<DatasetDetail> online(@PathVariable("datasetId") long datasetId) {
+    return Result.success(service.online(datasetId));
+  }
+
+  @Operation(summary = "下线 Dataset")
+  @PostMapping("/{datasetId}/offline")
+  public Result<DatasetDetail> offline(@PathVariable("datasetId") long datasetId) {
+    return Result.success(service.offline(datasetId));
+  }
+
+  private static List<DatasetService.FieldSpec> toFieldSpecs(List<DatasetFieldRequest> fields) {
+    if (fields == null || fields.isEmpty()) return List.of();
+    return fields.stream()
+        .map(field -> new DatasetService.FieldSpec(
+            field.fieldId(),
+            field.physicalName(),
+            field.displayName(),
+            field.dataType(),
+            field.nullable(),
+            field.description(),
+            field.defaultRole()))
+        .toList();
+  }
+
+  public record PublishDatasetRequest(
+      @NotNull Long sourceTaskAssetId,
+      @Size(max = 200) String name,
+      @Size(max = 2000) String description,
+      List<@Valid DatasetFieldRequest> fields) {
+  }
+
+  public record CreateDatasetVersionRequest(List<@Valid DatasetFieldRequest> fields) {
+  }
+
+  public record DatasetFieldRequest(
+      @Size(max = 64) String fieldId,
+      @NotNull @Size(max = 128) String physicalName,
+      @Size(max = 200) String displayName,
+      DatasetFieldDataType dataType,
+      boolean nullable,
+      @Size(max = 1000) String description,
+      DatasetFieldRole defaultRole) {
+  }
+}

--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetPersistenceConfiguration.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetPersistenceConfiguration.java
@@ -1,0 +1,31 @@
+package io.yak.ops.business.dataset;
+
+import io.yak.ops.business.datasource.config.BusinessDatabaseConfiguration;
+import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
+import io.yak.ops.business.datasource.config.DataSourceProperties;
+import javax.sql.DataSource;
+import org.flywaydb.core.Flyway;
+import org.flywaydb.core.api.MigrationVersion;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnDataSourceEnabled
+@EnableConfigurationProperties(DataSourceProperties.class)
+@Import(BusinessDatabaseConfiguration.class)
+public class DatasetPersistenceConfiguration {
+
+  @Bean(name = "yakDatasetFlyway", initMethod = "migrate")
+  public Flyway datasetFlyway(@Qualifier("yakBusinessDataSource") DataSource dataSource) {
+    return Flyway.configure()
+        .dataSource(dataSource)
+        .locations("classpath:db/migration/yak-dataset")
+        .table("flyway_schema_history_dataset")
+        .baselineVersion(MigrationVersion.fromVersion("0"))
+        .baselineOnMigrate(true)
+        .load();
+  }
+}

--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetReleaseController.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetReleaseController.java
@@ -1,0 +1,42 @@
+package io.yak.ops.business.dataset;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.yak.framework.common.Result;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Release-center shortcut for the explicit "publish as Dataset" domain transition. */
+@Tag(name = "数据开发发布中心 Dataset 接口")
+@RestController
+@RequestMapping("/api/v1/data-development/releases")
+public class DatasetReleaseController {
+
+  private final DatasetService service;
+
+  public DatasetReleaseController(DatasetService service) {
+    this.service = service;
+  }
+
+  @Operation(summary = "将已上线 SQL 任务的当前版本发布为 Dataset")
+  @PostMapping("/{assetId}/dataset")
+  public Result<DatasetDetail> publishAsDataset(
+      @PathVariable("assetId") long assetId,
+      @Valid @RequestBody(required = false) ReleaseDatasetRequest request) {
+    String name = request == null ? null : request.name();
+    String description = request == null ? null : request.description();
+    return Result.success(service.publish(
+        new DatasetService.PublishCommand(assetId, name, description, List.of())));
+  }
+
+  public record ReleaseDatasetRequest(
+      @Size(max = 200) String name,
+      @Size(max = 2000) String description) {
+  }
+}

--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetRepository.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetRepository.java
@@ -1,0 +1,36 @@
+package io.yak.ops.business.dataset;
+
+import java.util.List;
+import java.util.Optional;
+
+interface DatasetRepository {
+
+  long insertDataset(String name, String description);
+
+  long insertVersion(
+      long datasetId,
+      int versionNo,
+      DatasetSourceType sourceType,
+      long sourceTaskAssetId,
+      long sourceTaskRevisionId,
+      int sourceTaskRevisionNo,
+      String schemaSnapshot);
+
+  void insertFields(long versionId, List<DatasetService.FieldSpec> fields);
+
+  void updateCurrentVersion(long datasetId, long versionId);
+
+  void updateStatus(long datasetId, DatasetStatus status);
+
+  Optional<Dataset> findDataset(long datasetId);
+
+  List<Dataset> listDatasets();
+
+  Optional<DatasetVersion> findVersion(long versionId);
+
+  List<DatasetVersion> listVersions(long datasetId);
+
+  List<DatasetField> listFields(long versionId);
+
+  int nextVersionNo(long datasetId);
+}

--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetService.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetService.java
@@ -1,0 +1,251 @@
+package io.yak.ops.business.dataset;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.taskcatalog.domain.TaskAsset;
+import io.yak.ops.business.taskcatalog.service.TaskCatalogService;
+import io.yak.ops.spi.task.model.TaskAssetSource;
+import io.yak.ops.spi.task.model.TaskAssetStatus;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Dataset publication service.
+ *
+ * <p>A Dataset is a BI data contract, not an executable development task. Stage 1 only accepts
+ * the immutable current revision of an ONLINE SQL TaskAsset and snapshots that reference into an
+ * immutable DatasetVersion.</p>
+ */
+@Service
+public class DatasetService {
+
+  private final DatasetRepository repository;
+  private final TaskCatalogService taskCatalogService;
+  private final ObjectMapper objectMapper;
+
+  public DatasetService(
+      DatasetRepository repository,
+      TaskCatalogService taskCatalogService,
+      ObjectMapper objectMapper) {
+    this.repository = repository;
+    this.taskCatalogService = taskCatalogService;
+    this.objectMapper = objectMapper;
+  }
+
+  @Transactional("yakBusinessTransactionManager")
+  public DatasetDetail publish(PublishCommand command) {
+    Objects.requireNonNull(command, "command");
+    TaskAsset asset = requirePublishableAsset(command.sourceTaskAssetId());
+    String name = normalizeName(command.name(), asset.name());
+    String description = normalizeDescription(command.description());
+    List<FieldSpec> fields = normalizeFields(command.fields());
+
+    long datasetId = repository.insertDataset(name, description);
+    long versionId = appendVersion(datasetId, asset, fields, false);
+    repository.updateCurrentVersion(datasetId, versionId);
+    return get(datasetId);
+  }
+
+  @Transactional("yakBusinessTransactionManager")
+  public DatasetDetail createVersion(long datasetId, List<FieldSpec> fields) {
+    DatasetDetail current = get(datasetId);
+    DatasetVersion currentVersion = current.currentVersion();
+    if (currentVersion == null) {
+      throw new IllegalStateException("Dataset 尚未建立当前版本：" + datasetId);
+    }
+
+    TaskAsset asset = requirePublishableAsset(currentVersion.sourceTaskAssetId());
+    if (asset.currentRevision().taskRevisionId() == currentVersion.sourceTaskRevisionId()) {
+      throw new IllegalArgumentException(
+          "当前 TaskRevision 已经是 Dataset 的当前版本：V" + currentVersion.versionNo());
+    }
+
+    List<FieldSpec> normalizedFields = normalizeFields(fields);
+    long versionId = appendVersion(datasetId, asset, normalizedFields, true);
+    repository.updateCurrentVersion(datasetId, versionId);
+    return get(datasetId);
+  }
+
+  public List<Dataset> list() {
+    return repository.listDatasets();
+  }
+
+  public DatasetDetail get(long datasetId) {
+    if (datasetId <= 0L) throw new IllegalArgumentException("datasetId 必须大于 0");
+    Dataset dataset = repository.findDataset(datasetId)
+        .orElseThrow(() -> new IllegalArgumentException("Dataset 不存在：" + datasetId));
+
+    DatasetVersion currentVersion = null;
+    List<DatasetField> fields = List.of();
+    if (dataset.currentVersionId() != null) {
+      currentVersion = repository.findVersion(dataset.currentVersionId())
+          .orElseThrow(() -> new IllegalStateException(
+              "Dataset 当前版本不存在：datasetId=" + datasetId
+                  + ", versionId=" + dataset.currentVersionId()));
+      fields = repository.listFields(currentVersion.id());
+    }
+    return new DatasetDetail(dataset, currentVersion, repository.listVersions(datasetId), fields);
+  }
+
+  @Transactional("yakBusinessTransactionManager")
+  public DatasetDetail online(long datasetId) {
+    Dataset dataset = get(datasetId).dataset();
+    if (dataset.status() != DatasetStatus.ONLINE) {
+      repository.updateStatus(datasetId, DatasetStatus.ONLINE);
+    }
+    return get(datasetId);
+  }
+
+  @Transactional("yakBusinessTransactionManager")
+  public DatasetDetail offline(long datasetId) {
+    Dataset dataset = get(datasetId).dataset();
+    if (dataset.status() != DatasetStatus.OFFLINE) {
+      repository.updateStatus(datasetId, DatasetStatus.OFFLINE);
+    }
+    return get(datasetId);
+  }
+
+  private long appendVersion(
+      long datasetId,
+      TaskAsset asset,
+      List<FieldSpec> fields,
+      boolean requireExistingDataset) {
+    if (requireExistingDataset) {
+      repository.findDataset(datasetId)
+          .orElseThrow(() -> new IllegalArgumentException("Dataset 不存在：" + datasetId));
+    }
+
+    int versionNo = repository.nextVersionNo(datasetId);
+    String schemaSnapshot = schemaSnapshot(fields);
+    long versionId = repository.insertVersion(
+        datasetId,
+        versionNo,
+        DatasetSourceType.QUERY_REVISION,
+        asset.id(),
+        asset.currentRevision().taskRevisionId(),
+        asset.currentRevision().revisionNo(),
+        schemaSnapshot);
+    repository.insertFields(versionId, fields);
+    return versionId;
+  }
+
+  private TaskAsset requirePublishableAsset(long assetId) {
+    TaskAsset asset = taskCatalogService.get(assetId);
+    if (asset.source() != TaskAssetSource.DATA_DEVELOPMENT) {
+      throw new IllegalArgumentException("只有数据开发 TaskAsset 可以发布为 Dataset：" + assetId);
+    }
+    if (asset.status() != TaskAssetStatus.ONLINE) {
+      throw new IllegalArgumentException("只有 ONLINE 的 TaskAsset 可以发布/更新 Dataset：" + assetId);
+    }
+    if (!"SQL".equalsIgnoreCase(asset.taskType())) {
+      throw new IllegalArgumentException("Stage 1 仅支持 SQL TaskAsset 发布为 QUERY_REVISION Dataset");
+    }
+    if (asset.currentRevision() == null
+        || asset.currentRevision().taskRevisionId() <= 0L
+        || asset.currentRevision().revisionNo() <= 0) {
+      throw new IllegalStateException("TaskAsset 缺少有效的当前不可变版本：" + assetId);
+    }
+    return asset;
+  }
+
+  private String normalizeName(String value, String fallback) {
+    String normalized = value == null || value.isBlank() ? fallback : value.trim();
+    if (normalized == null || normalized.isBlank()) throw new IllegalArgumentException("Dataset 名称不能为空");
+    if (normalized.length() > 200) throw new IllegalArgumentException("Dataset 名称不能超过 200 个字符");
+    return normalized;
+  }
+
+  private String normalizeDescription(String value) {
+    if (value == null || value.isBlank()) return null;
+    String normalized = value.trim();
+    if (normalized.length() > 2000) throw new IllegalArgumentException("Dataset 描述不能超过 2000 个字符");
+    return normalized;
+  }
+
+  private List<FieldSpec> normalizeFields(List<FieldSpec> values) {
+    if (values == null || values.isEmpty()) return List.of();
+
+    List<FieldSpec> normalized = new ArrayList<>(values.size());
+    Set<String> physicalNames = new HashSet<>();
+    Set<String> fieldIds = new HashSet<>();
+    for (FieldSpec value : values) {
+      if (value == null) throw new IllegalArgumentException("Dataset 字段不能为空");
+      String physicalName = required(value.physicalName(), "physicalName", 128);
+      String physicalKey = physicalName.toLowerCase(Locale.ROOT);
+      if (!physicalNames.add(physicalKey)) {
+        throw new IllegalArgumentException("Dataset 字段重复：" + physicalName);
+      }
+
+      String fieldId = value.fieldId();
+      if (fieldId == null || fieldId.isBlank()) fieldId = UUID.randomUUID().toString();
+      fieldId = fieldId.trim();
+      if (fieldId.length() > 64) throw new IllegalArgumentException("fieldId 不能超过 64 个字符");
+      if (!fieldIds.add(fieldId)) throw new IllegalArgumentException("fieldId 重复：" + fieldId);
+
+      String displayName = value.displayName();
+      if (displayName == null || displayName.isBlank()) displayName = physicalName;
+      displayName = displayName.trim();
+      if (displayName.length() > 200) throw new IllegalArgumentException("displayName 不能超过 200 个字符");
+
+      String description = value.description();
+      if (description != null) {
+        description = description.trim();
+        if (description.isBlank()) description = null;
+        if (description != null && description.length() > 1000) {
+          throw new IllegalArgumentException("字段描述不能超过 1000 个字符");
+        }
+      }
+
+      normalized.add(new FieldSpec(
+          fieldId,
+          physicalName,
+          displayName,
+          value.dataType() == null ? DatasetFieldDataType.UNKNOWN : value.dataType(),
+          value.nullable(),
+          description,
+          value.defaultRole() == null ? DatasetFieldRole.DIMENSION : value.defaultRole()));
+    }
+    return List.copyOf(normalized);
+  }
+
+  private String schemaSnapshot(List<FieldSpec> fields) {
+    try {
+      return objectMapper.writeValueAsString(fields);
+    } catch (JsonProcessingException exception) {
+      throw new IllegalStateException("Dataset schemaSnapshot 序列化失败", exception);
+    }
+  }
+
+  private String required(String value, String fieldName, int maxLength) {
+    if (value == null || value.isBlank()) throw new IllegalArgumentException(fieldName + " 不能为空");
+    String normalized = value.trim();
+    if (normalized.length() > maxLength) {
+      throw new IllegalArgumentException(fieldName + " 不能超过 " + maxLength + " 个字符");
+    }
+    return normalized;
+  }
+
+  public record PublishCommand(
+      long sourceTaskAssetId,
+      String name,
+      String description,
+      List<FieldSpec> fields) {
+  }
+
+  public record FieldSpec(
+      String fieldId,
+      String physicalName,
+      String displayName,
+      DatasetFieldDataType dataType,
+      boolean nullable,
+      String description,
+      DatasetFieldRole defaultRole) {
+  }
+}

--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/JdbcDatasetRepository.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/JdbcDatasetRepository.java
@@ -1,0 +1,230 @@
+package io.yak.ops.business.dataset;
+
+import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import javax.sql.DataSource;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.support.GeneratedKeyHolder;
+import org.springframework.jdbc.support.KeyHolder;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@DependsOn("yakDatasetFlyway")
+@ConditionalOnDataSourceEnabled
+class JdbcDatasetRepository implements DatasetRepository {
+
+  private static final String DATASET_COLUMNS =
+      "SELECT id, name, description, status, current_version_id, create_time, update_time "
+          + "FROM yak_dataset";
+
+  private static final String VERSION_COLUMNS =
+      "SELECT id, dataset_id, version_no, source_type, source_task_asset_id, "
+          + "source_task_revision_id, source_task_revision_no, schema_snapshot, create_time "
+          + "FROM yak_dataset_version";
+
+  private final JdbcTemplate jdbcTemplate;
+
+  JdbcDatasetRepository(@Qualifier("yakBusinessDataSource") DataSource dataSource) {
+    this.jdbcTemplate = new JdbcTemplate(dataSource);
+  }
+
+  @Override
+  public long insertDataset(String name, String description) {
+    KeyHolder keyHolder = new GeneratedKeyHolder();
+    jdbcTemplate.update(connection -> {
+      PreparedStatement statement = connection.prepareStatement(
+          """
+          INSERT INTO yak_dataset
+            (name, description, status, current_version_id, create_time, update_time)
+          VALUES (?, ?, 'ONLINE', NULL, NOW(6), NOW(6))
+          """,
+          Statement.RETURN_GENERATED_KEYS);
+      statement.setString(1, name);
+      statement.setString(2, description);
+      return statement;
+    }, keyHolder);
+    Number key = keyHolder.getKey();
+    if (key == null) throw new IllegalStateException("创建 Dataset 后未返回主键");
+    return key.longValue();
+  }
+
+  @Override
+  public long insertVersion(
+      long datasetId,
+      int versionNo,
+      DatasetSourceType sourceType,
+      long sourceTaskAssetId,
+      long sourceTaskRevisionId,
+      int sourceTaskRevisionNo,
+      String schemaSnapshot) {
+    KeyHolder keyHolder = new GeneratedKeyHolder();
+    jdbcTemplate.update(connection -> {
+      PreparedStatement statement = connection.prepareStatement(
+          """
+          INSERT INTO yak_dataset_version
+            (dataset_id, version_no, source_type, source_task_asset_id,
+             source_task_revision_id, source_task_revision_no, schema_snapshot, create_time)
+          VALUES (?, ?, ?, ?, ?, ?, ?, NOW(6))
+          """,
+          Statement.RETURN_GENERATED_KEYS);
+      statement.setLong(1, datasetId);
+      statement.setInt(2, versionNo);
+      statement.setString(3, sourceType.name());
+      statement.setLong(4, sourceTaskAssetId);
+      statement.setLong(5, sourceTaskRevisionId);
+      statement.setInt(6, sourceTaskRevisionNo);
+      statement.setString(7, schemaSnapshot);
+      return statement;
+    }, keyHolder);
+    Number key = keyHolder.getKey();
+    if (key == null) throw new IllegalStateException("创建 DatasetVersion 后未返回主键");
+    return key.longValue();
+  }
+
+  @Override
+  public void insertFields(long versionId, List<DatasetService.FieldSpec> fields) {
+    for (int index = 0; index < fields.size(); index++) {
+      DatasetService.FieldSpec field = fields.get(index);
+      jdbcTemplate.update(
+          """
+          INSERT INTO yak_dataset_field
+            (field_id, version_id, physical_name, display_name, data_type, nullable,
+             description, default_role, sort_order)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+          """,
+          field.fieldId(),
+          versionId,
+          field.physicalName(),
+          field.displayName(),
+          field.dataType().name(),
+          field.nullable(),
+          field.description(),
+          field.defaultRole().name(),
+          index + 1);
+    }
+  }
+
+  @Override
+  public void updateCurrentVersion(long datasetId, long versionId) {
+    int updated = jdbcTemplate.update(
+        "UPDATE yak_dataset SET current_version_id = ?, update_time = NOW(6) WHERE id = ?",
+        versionId,
+        datasetId);
+    if (updated != 1) throw new IllegalArgumentException("Dataset 不存在：" + datasetId);
+  }
+
+  @Override
+  public void updateStatus(long datasetId, DatasetStatus status) {
+    int updated = jdbcTemplate.update(
+        "UPDATE yak_dataset SET status = ?, update_time = NOW(6) WHERE id = ?",
+        status.name(),
+        datasetId);
+    if (updated != 1) throw new IllegalArgumentException("Dataset 不存在：" + datasetId);
+  }
+
+  @Override
+  public Optional<Dataset> findDataset(long datasetId) {
+    return jdbcTemplate.query(
+        DATASET_COLUMNS + " WHERE id = ? LIMIT 1",
+        JdbcDatasetRepository::mapDataset,
+        datasetId).stream().findFirst();
+  }
+
+  @Override
+  public List<Dataset> listDatasets() {
+    return jdbcTemplate.query(
+        DATASET_COLUMNS + " ORDER BY update_time DESC, id DESC",
+        JdbcDatasetRepository::mapDataset);
+  }
+
+  @Override
+  public Optional<DatasetVersion> findVersion(long versionId) {
+    return jdbcTemplate.query(
+        VERSION_COLUMNS + " WHERE id = ? LIMIT 1",
+        JdbcDatasetRepository::mapVersion,
+        versionId).stream().findFirst();
+  }
+
+  @Override
+  public List<DatasetVersion> listVersions(long datasetId) {
+    return jdbcTemplate.query(
+        VERSION_COLUMNS + " WHERE dataset_id = ? ORDER BY version_no DESC",
+        JdbcDatasetRepository::mapVersion,
+        datasetId);
+  }
+
+  @Override
+  public List<DatasetField> listFields(long versionId) {
+    return jdbcTemplate.query(
+        """
+        SELECT field_id, version_id, physical_name, display_name, data_type, nullable,
+               description, default_role, sort_order
+        FROM yak_dataset_field
+        WHERE version_id = ?
+        ORDER BY sort_order ASC, physical_name ASC
+        """,
+        JdbcDatasetRepository::mapField,
+        versionId);
+  }
+
+  @Override
+  public int nextVersionNo(long datasetId) {
+    Integer value = jdbcTemplate.queryForObject(
+        "SELECT COALESCE(MAX(version_no), 0) + 1 FROM yak_dataset_version WHERE dataset_id = ?",
+        Integer.class,
+        datasetId);
+    return value == null ? 1 : value;
+  }
+
+  private static Dataset mapDataset(ResultSet rs, int rowNum) throws SQLException {
+    Object currentValue = rs.getObject("current_version_id");
+    Long currentVersionId = currentValue == null ? null : rs.getLong("current_version_id");
+    return new Dataset(
+        rs.getLong("id"),
+        rs.getString("name"),
+        rs.getString("description"),
+        DatasetStatus.valueOf(rs.getString("status")),
+        currentVersionId,
+        instant(rs.getTimestamp("create_time")),
+        instant(rs.getTimestamp("update_time")));
+  }
+
+  private static DatasetVersion mapVersion(ResultSet rs, int rowNum) throws SQLException {
+    return new DatasetVersion(
+        rs.getLong("id"),
+        rs.getLong("dataset_id"),
+        rs.getInt("version_no"),
+        DatasetSourceType.valueOf(rs.getString("source_type")),
+        rs.getLong("source_task_asset_id"),
+        rs.getLong("source_task_revision_id"),
+        rs.getInt("source_task_revision_no"),
+        rs.getString("schema_snapshot"),
+        instant(rs.getTimestamp("create_time")));
+  }
+
+  private static DatasetField mapField(ResultSet rs, int rowNum) throws SQLException {
+    return new DatasetField(
+        rs.getString("field_id"),
+        rs.getLong("version_id"),
+        rs.getString("physical_name"),
+        rs.getString("display_name"),
+        DatasetFieldDataType.valueOf(rs.getString("data_type")),
+        rs.getBoolean("nullable"),
+        rs.getString("description"),
+        DatasetFieldRole.valueOf(rs.getString("default_role")),
+        rs.getInt("sort_order"));
+  }
+
+  private static Instant instant(Timestamp value) {
+    return value == null ? null : value.toInstant();
+  }
+}

--- a/yak-ops-business/yak-ops-business-dataset/src/main/resources/db/migration/yak-dataset/V1__create_dataset_domain.sql
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/resources/db/migration/yak-dataset/V1__create_dataset_domain.sql
@@ -1,0 +1,47 @@
+-- Stage 1 BI foundation: Dataset is a data contract, independent from executable TaskAsset state.
+CREATE TABLE IF NOT EXISTS yak_dataset (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    name VARCHAR(200) NOT NULL,
+    description VARCHAR(2000) NULL,
+    status VARCHAR(32) NOT NULL,
+    current_version_id BIGINT NULL,
+    create_time DATETIME(6) NOT NULL,
+    update_time DATETIME(6) NOT NULL,
+    PRIMARY KEY (id),
+    KEY idx_yak_dataset_status_update (status, update_time),
+    KEY idx_yak_dataset_current_version (current_version_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS yak_dataset_version (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    dataset_id BIGINT NOT NULL,
+    version_no INT NOT NULL,
+    source_type VARCHAR(32) NOT NULL,
+    source_task_asset_id BIGINT NOT NULL,
+    source_task_revision_id BIGINT NOT NULL,
+    source_task_revision_no INT NOT NULL,
+    schema_snapshot JSON NULL,
+    create_time DATETIME(6) NOT NULL,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_yak_dataset_version_no (dataset_id, version_no),
+    KEY idx_yak_dataset_version_source (source_task_asset_id, source_task_revision_id),
+    CONSTRAINT fk_yak_dataset_version_dataset
+        FOREIGN KEY (dataset_id) REFERENCES yak_dataset(id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS yak_dataset_field (
+    field_id VARCHAR(64) NOT NULL,
+    version_id BIGINT NOT NULL,
+    physical_name VARCHAR(128) NOT NULL,
+    display_name VARCHAR(200) NOT NULL,
+    data_type VARCHAR(32) NOT NULL,
+    nullable TINYINT(1) NOT NULL DEFAULT 1,
+    description VARCHAR(1000) NULL,
+    default_role VARCHAR(32) NOT NULL,
+    sort_order INT NOT NULL DEFAULT 0,
+    PRIMARY KEY (version_id, field_id),
+    UNIQUE KEY uk_yak_dataset_field_physical_name (version_id, physical_name),
+    KEY idx_yak_dataset_field_role (version_id, default_role),
+    CONSTRAINT fk_yak_dataset_field_version
+        FOREIGN KEY (version_id) REFERENCES yak_dataset_version(id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/yak-ops-business/yak-ops-business-dataset/src/test/java/io/yak/ops/business/dataset/DatasetServiceTest.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/test/java/io/yak/ops/business/dataset/DatasetServiceTest.java
@@ -1,0 +1,103 @@
+package io.yak.ops.business.dataset;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.taskcatalog.domain.TaskAsset;
+import io.yak.ops.business.taskcatalog.service.TaskCatalogService;
+import io.yak.ops.spi.task.model.TaskAssetSource;
+import io.yak.ops.spi.task.model.TaskAssetStatus;
+import io.yak.ops.spi.task.model.TaskRevisionRef;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class DatasetServiceTest {
+
+  @Test
+  void publishSnapshotsCurrentTaskRevisionWithoutOwningTaskExecution() {
+    DatasetRepository repository = mock(DatasetRepository.class);
+    TaskCatalogService catalog = mock(TaskCatalogService.class);
+    DatasetService service = new DatasetService(repository, catalog, new ObjectMapper());
+
+    TaskAsset asset = taskAsset(11L, TaskAssetStatus.ONLINE, "SQL", 71L, 3);
+    when(catalog.get(11L)).thenReturn(asset);
+    when(repository.insertDataset("sales", "sales dataset")).thenReturn(21L);
+    when(repository.nextVersionNo(21L)).thenReturn(1);
+    when(repository.insertVersion(
+        eq(21L),
+        eq(1),
+        eq(DatasetSourceType.QUERY_REVISION),
+        eq(11L),
+        eq(71L),
+        eq(3),
+        eq("[]"))).thenReturn(31L);
+    when(repository.findDataset(21L)).thenReturn(Optional.of(new Dataset(
+        21L, "sales", "sales dataset", DatasetStatus.ONLINE, 31L, Instant.EPOCH, Instant.EPOCH)));
+    DatasetVersion version = new DatasetVersion(
+        31L, 21L, 1, DatasetSourceType.QUERY_REVISION, 11L, 71L, 3, "[]", Instant.EPOCH);
+    when(repository.findVersion(31L)).thenReturn(Optional.of(version));
+    when(repository.listVersions(21L)).thenReturn(List.of(version));
+    when(repository.listFields(31L)).thenReturn(List.of());
+
+    DatasetDetail result = service.publish(new DatasetService.PublishCommand(
+        11L, "sales", "sales dataset", List.of()));
+
+    assertEquals(71L, result.currentVersion().sourceTaskRevisionId());
+    assertEquals(3, result.currentVersion().sourceTaskRevisionNo());
+    verify(repository).updateCurrentVersion(21L, 31L);
+    verify(repository).insertFields(eq(31L), anyList());
+  }
+
+  @Test
+  void publishRejectsOfflineAsset() {
+    DatasetRepository repository = mock(DatasetRepository.class);
+    TaskCatalogService catalog = mock(TaskCatalogService.class);
+    DatasetService service = new DatasetService(repository, catalog, new ObjectMapper());
+    when(catalog.get(11L)).thenReturn(taskAsset(11L, TaskAssetStatus.OFFLINE, "SQL", 71L, 3));
+
+    IllegalArgumentException error = assertThrows(
+        IllegalArgumentException.class,
+        () -> service.publish(new DatasetService.PublishCommand(11L, "sales", null, List.of())));
+
+    assertEquals("只有 ONLINE 的 TaskAsset 可以发布/更新 Dataset：11", error.getMessage());
+  }
+
+  @Test
+  void publishRejectsNonSqlTask() {
+    DatasetRepository repository = mock(DatasetRepository.class);
+    TaskCatalogService catalog = mock(TaskCatalogService.class);
+    DatasetService service = new DatasetService(repository, catalog, new ObjectMapper());
+    when(catalog.get(11L)).thenReturn(taskAsset(11L, TaskAssetStatus.ONLINE, "SHELL", 71L, 3));
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> service.publish(new DatasetService.PublishCommand(11L, "sales", null, List.of())));
+  }
+
+  private static TaskAsset taskAsset(
+      long assetId,
+      TaskAssetStatus status,
+      String taskType,
+      long revisionId,
+      int revisionNo) {
+    return new TaskAsset(
+        assetId,
+        TaskAssetSource.DATA_DEVELOPMENT,
+        "101",
+        null,
+        "sales.sql",
+        taskType,
+        status,
+        new TaskRevisionRef(assetId, revisionId, revisionNo),
+        Instant.EPOCH,
+        Instant.EPOCH);
+  }
+}


### PR DESCRIPTION
## 背景

这是 Yak-Ops BI 路线的 Stage 1：先建立独立 Dataset 领域和发布契约，不把 Dataset 混入 SQL/开发任务节点体系。

核心边界：

```text
DevelopmentTask
  -> immutable TaskRevision
  -> TaskAsset ONLINE
  -> 发布为数据集
  -> immutable DatasetVersion
  -> DatasetField / schema snapshot
```

`TaskAsset = Execution Contract`，`Dataset = Data Contract`。Dataset 生命周期和版本指针独立于 TaskAsset，后续 TaskAsset 发布/回滚不会静默改变已有 DatasetVersion。

## 本 PR 实现

- 新增独立 `yak-ops-business-dataset` 业务模块并接入 Boot
- 新增 `yak_dataset`、`yak_dataset_version`、`yak_dataset_field` 三张表及独立 Flyway history
- 新增 Dataset 状态：`ONLINE / OFFLINE`
- DatasetSourceType 预留 `QUERY_REVISION / TABLE / VIEW`，Stage 1 只允许 `QUERY_REVISION`
- 仅允许 `DATA_DEVELOPMENT + ONLINE + SQL` 的 TaskAsset 发布 Dataset
- 发布时快照当前不可变 `taskRevisionId + revisionNo`，不引用可漂移的 current pointer
- DatasetVersion 不可变，新 TaskRevision 需要显式创建新的 DatasetVersion
- Dataset 可独立上线/下线，不反向修改 TaskAsset 状态
- DatasetField 支持 `physicalName / displayName / dataType / nullable / description / defaultRole`
- 保存 `schemaSnapshot`，字段 schema 可随每个 DatasetVersion 独立冻结
- 增加发布中心 `发布为数据集` 后端转换入口
- 增加服务层单测覆盖：ONLINE SQL 发布、OFFLINE 拒绝、非 SQL 拒绝

## API

```text
GET  /api/v1/datasets
GET  /api/v1/datasets/{datasetId}
POST /api/v1/datasets
POST /api/v1/datasets/{datasetId}/versions
POST /api/v1/datasets/{datasetId}/online
POST /api/v1/datasets/{datasetId}/offline

POST /api/v1/data-development/releases/{assetId}/dataset
```

发布入口使用 `sourceTaskAssetId` / `assetId`，服务端只读取当时 ONLINE TaskAsset 的当前不可变 Revision 并写入 DatasetVersion。

## 版本语义

```text
TaskRevision:     V1  V2  V3  V4  V5
                   \      \       \
DatasetVersion:    DV1    DV2      DV3
```

TaskAsset 后续切换/回滚 currentRevision，不会自动改变已有 DatasetVersion。需要显式调用创建 DatasetVersion，才能移动 Dataset 自己的 currentVersion 指针。

## 有意不在 Stage 1 做的事情

- 不做 DatasetQueryService / 查询 SQL 生成（Stage 2）
- 不在 Dataset 域执行 DevelopmentTask
- 不做 SQL schema 猜测/解析；API 已支持字段 schema 快照，自动字段发现留给 Stage 2 runtime
- 不做 TABLE/VIEW runtime
- 不改 Dashboard / Chart 查询链路
- 不引入 Metric Center / AI BI
- 本 PR 先打通后端领域与发布链路，发布中心按钮交互可在后续 UI 迭代接这个稳定 API

## 设计说明

本阶段保持 Dataset 与 Data Development 解耦：数据开发负责“怎么生产”，Dataset 负责“下游消费什么”。一个 SQL TaskAsset 可以发布多个 Dataset；已有 Dataset 的版本不会跟随 TaskAsset currentRevision 自动漂移。