### PR TITLE
feat(dataset): Stage 2 Dataset Query Runtime

### DIFF
--- a/yak-ops-business/yak-ops-business-dataset/pom.xml
+++ b/yak-ops-business/yak-ops-business-dataset/pom.xml
@@ -14,7 +14,7 @@
     <artifactId>yak-ops-business-dataset</artifactId>
 
     <name>Yak Ops Business Dataset</name>
-    <description>BI dataset contracts, immutable versions and publication lifecycle</description>
+    <description>BI dataset contracts, immutable versions, publication lifecycle and query runtime</description>
 
     <dependencies>
         <dependency>
@@ -28,6 +28,10 @@
         <dependency>
             <groupId>io.yak.ops</groupId>
             <artifactId>yak-ops-business-datasource</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.yak.ops</groupId>
+            <artifactId>yak-ops-plugin-datasource-api</artifactId>
         </dependency>
         <dependency>
             <groupId>io.yak.ops</groupId>

--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetController.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetController.java
@@ -4,6 +4,8 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.yak.framework.common.Result;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.util.List;
@@ -20,9 +22,11 @@ import org.springframework.web.bind.annotation.RestController;
 public class DatasetController {
 
   private final DatasetService service;
+  private final DatasetQueryService queryService;
 
-  public DatasetController(DatasetService service) {
+  public DatasetController(DatasetService service, DatasetQueryService queryService) {
     this.service = service;
+    this.queryService = queryService;
   }
 
   @Operation(summary = "查询 Dataset 列表")
@@ -57,6 +61,14 @@ public class DatasetController {
         request == null ? List.of() : toFieldSpecs(request.fields())));
   }
 
+  @Operation(summary = "通过 Dataset Query Runtime 查询当前或指定不可变版本")
+  @PostMapping("/{datasetId}/query")
+  public Result<DatasetQueryResult> query(
+      @PathVariable("datasetId") long datasetId,
+      @Valid @RequestBody(required = false) QueryDatasetRequest request) {
+    return Result.success(queryService.query(datasetId, toQueryRequest(request)));
+  }
+
   @Operation(summary = "上线 Dataset")
   @PostMapping("/{datasetId}/online")
   public Result<DatasetDetail> online(@PathVariable("datasetId") long datasetId) {
@@ -67,6 +79,27 @@ public class DatasetController {
   @PostMapping("/{datasetId}/offline")
   public Result<DatasetDetail> offline(@PathVariable("datasetId") long datasetId) {
     return Result.success(service.offline(datasetId));
+  }
+
+  private static DatasetQueryRequest toQueryRequest(QueryDatasetRequest request) {
+    if (request == null) return null;
+    List<DatasetMetricBinding> metrics = request.metrics() == null ? List.of() : request.metrics().stream()
+        .map(value -> new DatasetMetricBinding(value.fieldId(), value.aggregation()))
+        .toList();
+    List<DatasetFilter> filters = request.filters() == null ? List.of() : request.filters().stream()
+        .map(value -> new DatasetFilter(value.fieldId(), value.operator(), value.value(), value.values()))
+        .toList();
+    List<DatasetSort> sorts = request.sorts() == null ? List.of() : request.sorts().stream()
+        .map(value -> new DatasetSort(value.fieldId(), value.aggregation(), value.direction()))
+        .toList();
+    return new DatasetQueryRequest(
+        request.versionNo(),
+        request.dimensions(),
+        metrics,
+        filters,
+        sorts,
+        request.limit(),
+        request.timeoutSeconds());
   }
 
   private static List<DatasetService.FieldSpec> toFieldSpecs(List<DatasetFieldRequest> fields) {
@@ -101,5 +134,33 @@ public class DatasetController {
       boolean nullable,
       @Size(max = 1000) String description,
       DatasetFieldRole defaultRole) {
+  }
+
+  public record QueryDatasetRequest(
+      @Min(1) Integer versionNo,
+      List<@Size(max = 64) String> dimensions,
+      List<@Valid QueryMetricRequest> metrics,
+      List<@Valid QueryFilterRequest> filters,
+      List<@Valid QuerySortRequest> sorts,
+      @Min(1) @Max(1000) Integer limit,
+      @Min(1) @Max(120) Integer timeoutSeconds) {
+  }
+
+  public record QueryMetricRequest(
+      @NotNull @Size(max = 64) String fieldId,
+      @NotNull DatasetAggregation aggregation) {
+  }
+
+  public record QueryFilterRequest(
+      @NotNull @Size(max = 64) String fieldId,
+      @NotNull DatasetFilterOperator operator,
+      Object value,
+      @Size(max = 100) List<Object> values) {
+  }
+
+  public record QuerySortRequest(
+      @NotNull @Size(max = 64) String fieldId,
+      DatasetAggregation aggregation,
+      DatasetSortDirection direction) {
   }
 }

--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetQueryCompiler.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetQueryCompiler.java
@@ -23,10 +23,7 @@ final class DatasetQueryCompiler {
   private static final int MAX_VALUE_LENGTH = 4000;
   private static final Pattern SAFE_IDENTIFIER = Pattern.compile("[A-Za-z_][A-Za-z0-9_$]*");
 
-  CompiledQuery compile(
-      String baseSql,
-      List<DatasetField> fields,
-      DatasetQueryRequest request) {
+  CompiledQuery compile(String baseSql, List<DatasetField> fields, DatasetQueryRequest request) {
     String safeBaseSql = DatasetSqlSafety.requireReadOnlyQuery(baseSql);
     DatasetQueryRequest normalized = request == null
         ? new DatasetQueryRequest(null, List.of(), List.of(), List.of(), List.of(), null, null)
@@ -38,7 +35,6 @@ final class DatasetQueryCompiler {
     List<DatasetSort> sorts = copy(normalized.sorts());
     int limit = normalizeLimit(normalized.limit());
     int fetchRows = Math.min(MAX_LIMIT + 1, limit + 1);
-
     if (filters.size() > MAX_FILTERS) throw new IllegalArgumentException("Dataset 查询过滤条件不能超过 50 个");
 
     Map<String, DatasetField> fieldMap = new LinkedHashMap<>();
@@ -91,7 +87,7 @@ final class DatasetQueryCompiler {
         projections.add(metricExpression(field, metric.aggregation()) + " AS " + alias);
         metricAliases.put(metricKey, alias);
         bindings.add(new DatasetQueryColumnBinding(
-            alias, field.fieldId(), field.displayName(), field.dataType(), metric.aggregation()));
+            alias, field.fieldId(), field.displayName(), metricResultType(field, metric.aggregation()), metric.aggregation()));
       }
     }
 
@@ -99,9 +95,7 @@ final class DatasetQueryCompiler {
         .append(String.join(", ", projections))
         .append(" FROM (").append(safeBaseSql).append(") yak_dataset_source");
 
-    List<String> where = filters.stream()
-        .map(filter -> compileFilter(fieldMap, filter))
-        .toList();
+    List<String> where = filters.stream().map(filter -> compileFilter(fieldMap, filter)).toList();
     if (!where.isEmpty()) sql.append(" WHERE ").append(String.join(" AND ", where));
     if (!groupBy.isEmpty()) sql.append(" GROUP BY ").append(String.join(", ", groupBy));
 
@@ -141,12 +135,8 @@ final class DatasetQueryCompiler {
     return switch (filter.operator()) {
       case IS_NULL -> expression + " IS NULL";
       case IS_NOT_NULL -> expression + " IS NOT NULL";
-      case EQ -> filter.value() == null
-          ? expression + " IS NULL"
-          : expression + " = " + literal(filter.value());
-      case NE -> filter.value() == null
-          ? expression + " IS NOT NULL"
-          : expression + " <> " + literal(filter.value());
+      case EQ -> filter.value() == null ? expression + " IS NULL" : expression + " = " + literal(filter.value());
+      case NE -> filter.value() == null ? expression + " IS NOT NULL" : expression + " <> " + literal(filter.value());
       case GT -> expression + " > " + literalRequired(filter.value());
       case GTE -> expression + " >= " + literalRequired(filter.value());
       case LT -> expression + " < " + literalRequired(filter.value());
@@ -158,8 +148,7 @@ final class DatasetQueryCompiler {
       case BETWEEN -> {
         List<Object> values = filter.values() == null ? List.of() : filter.values();
         if (values.size() != 2) throw new IllegalArgumentException("BETWEEN 必须提供两个 values");
-        yield expression + " BETWEEN " + literalRequired(values.get(0))
-            + " AND " + literalRequired(values.get(1));
+        yield expression + " BETWEEN " + literalRequired(values.get(0)) + " AND " + literalRequired(values.get(1));
       }
     };
   }
@@ -180,8 +169,8 @@ final class DatasetQueryCompiler {
     if (value == null) return "NULL";
     if (value instanceof Boolean bool) return bool ? "TRUE" : "FALSE";
     if (value instanceof Number number) {
-      if (number instanceof Double d && (!Double.isFinite(d))) throw new IllegalArgumentException("过滤数值非法");
-      if (number instanceof Float f && (!Float.isFinite(f))) throw new IllegalArgumentException("过滤数值非法");
+      if (number instanceof Double d && !Double.isFinite(d)) throw new IllegalArgumentException("过滤数值非法");
+      if (number instanceof Float f && !Float.isFinite(f)) throw new IllegalArgumentException("过滤数值非法");
       try {
         return new BigDecimal(number.toString()).toPlainString();
       } catch (NumberFormatException exception) {
@@ -190,7 +179,8 @@ final class DatasetQueryCompiler {
     }
     if (value instanceof String text) {
       if (text.length() > MAX_VALUE_LENGTH) throw new IllegalArgumentException("单个过滤值不能超过 4000 个字符");
-      return "'" + text.replace("'", "''") + "'";
+      String escaped = text.replace("\\", "\\\\").replace("'", "''");
+      return "'" + escaped + "'";
     }
     throw new IllegalArgumentException("过滤值仅支持 string / number / boolean / null");
   }
@@ -204,6 +194,13 @@ final class DatasetQueryCompiler {
       case COUNT_DISTINCT -> "COUNT(DISTINCT " + value + ")";
       case MAX -> "MAX(" + value + ")";
       case MIN -> "MIN(" + value + ")";
+    };
+  }
+
+  private DatasetFieldDataType metricResultType(DatasetField field, DatasetAggregation aggregation) {
+    return switch (aggregation) {
+      case SUM, AVG, COUNT, COUNT_DISTINCT -> DatasetFieldDataType.NUMBER;
+      case MAX, MIN -> field.dataType();
     };
   }
 
@@ -239,10 +236,6 @@ final class DatasetQueryCompiler {
     return values == null ? List.of() : List.copyOf(values);
   }
 
-  record CompiledQuery(
-      String sql,
-      List<DatasetQueryColumnBinding> bindings,
-      int limit,
-      int fetchRows) {
+  record CompiledQuery(String sql, List<DatasetQueryColumnBinding> bindings, int limit, int fetchRows) {
   }
 }

--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetQueryCompiler.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetQueryCompiler.java
@@ -1,0 +1,248 @@
+package io.yak.ops.business.dataset;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+import org.springframework.stereotype.Component;
+
+/** Compiles semantic Dataset bindings into a read-only SQL query over one immutable source query. */
+@Component
+final class DatasetQueryCompiler {
+
+  static final int DEFAULT_LIMIT = 200;
+  static final int MAX_LIMIT = 1000;
+  private static final int MAX_FILTERS = 50;
+  private static final int MAX_FILTER_VALUES = 100;
+  private static final int MAX_VALUE_LENGTH = 4000;
+  private static final Pattern SAFE_IDENTIFIER = Pattern.compile("[A-Za-z_][A-Za-z0-9_$]*");
+
+  CompiledQuery compile(
+      String baseSql,
+      List<DatasetField> fields,
+      DatasetQueryRequest request) {
+    String safeBaseSql = DatasetSqlSafety.requireReadOnlyQuery(baseSql);
+    DatasetQueryRequest normalized = request == null
+        ? new DatasetQueryRequest(null, List.of(), List.of(), List.of(), List.of(), null, null)
+        : request;
+
+    List<String> dimensions = copy(normalized.dimensions());
+    List<DatasetMetricBinding> metrics = copy(normalized.metrics());
+    List<DatasetFilter> filters = copy(normalized.filters());
+    List<DatasetSort> sorts = copy(normalized.sorts());
+    int limit = normalizeLimit(normalized.limit());
+    int fetchRows = Math.min(MAX_LIMIT + 1, limit + 1);
+
+    if (filters.size() > MAX_FILTERS) throw new IllegalArgumentException("Dataset 查询过滤条件不能超过 50 个");
+
+    Map<String, DatasetField> fieldMap = new LinkedHashMap<>();
+    for (DatasetField field : fields == null ? List.<DatasetField>of() : fields) {
+      if (field == null || field.fieldId() == null || field.fieldId().isBlank()) continue;
+      validateIdentifier(field.physicalName());
+      fieldMap.put(field.fieldId(), field);
+    }
+
+    boolean rawMode = dimensions.isEmpty() && metrics.isEmpty();
+    if (fieldMap.isEmpty() && (!filters.isEmpty() || !sorts.isEmpty() || !rawMode)) {
+      throw new IllegalArgumentException("当前 DatasetVersion 尚未定义字段 schema，暂不能使用语义查询条件");
+    }
+
+    List<DatasetQueryColumnBinding> bindings = new ArrayList<>();
+    List<String> projections = new ArrayList<>();
+    List<String> groupBy = new ArrayList<>();
+    Map<String, String> dimensionAliases = new HashMap<>();
+    Map<String, String> metricAliases = new HashMap<>();
+    Set<String> seenDimensions = new HashSet<>();
+    Set<String> seenMetrics = new HashSet<>();
+
+    if (rawMode) {
+      projections.add("yak_dataset_source.*");
+    } else {
+      for (String fieldId : dimensions) {
+        DatasetField field = requireField(fieldMap, fieldId);
+        if (!seenDimensions.add(field.fieldId())) {
+          throw new IllegalArgumentException("维度字段重复：" + field.fieldId());
+        }
+        String alias = "d" + bindings.size();
+        String expression = ref(field);
+        projections.add(expression + " AS " + alias);
+        groupBy.add(expression);
+        dimensionAliases.put(field.fieldId(), alias);
+        bindings.add(new DatasetQueryColumnBinding(
+            alias, field.fieldId(), field.displayName(), field.dataType(), null));
+      }
+
+      for (DatasetMetricBinding metric : metrics) {
+        if (metric == null || metric.aggregation() == null) {
+          throw new IllegalArgumentException("指标聚合方式不能为空");
+        }
+        DatasetField field = requireField(fieldMap, metric.fieldId());
+        String metricKey = metricKey(field.fieldId(), metric.aggregation());
+        if (!seenMetrics.add(metricKey)) {
+          throw new IllegalArgumentException("指标重复：" + field.fieldId() + "/" + metric.aggregation());
+        }
+        String alias = "m" + bindings.size();
+        projections.add(metricExpression(field, metric.aggregation()) + " AS " + alias);
+        metricAliases.put(metricKey, alias);
+        bindings.add(new DatasetQueryColumnBinding(
+            alias, field.fieldId(), field.displayName(), field.dataType(), metric.aggregation()));
+      }
+    }
+
+    StringBuilder sql = new StringBuilder("SELECT ")
+        .append(String.join(", ", projections))
+        .append(" FROM (").append(safeBaseSql).append(") yak_dataset_source");
+
+    List<String> where = filters.stream()
+        .map(filter -> compileFilter(fieldMap, filter))
+        .toList();
+    if (!where.isEmpty()) sql.append(" WHERE ").append(String.join(" AND ", where));
+    if (!groupBy.isEmpty()) sql.append(" GROUP BY ").append(String.join(", ", groupBy));
+
+    if (!sorts.isEmpty()) {
+      List<String> orderBy = new ArrayList<>();
+      for (DatasetSort sort : sorts) {
+        if (sort == null) throw new IllegalArgumentException("排序条件不能为空");
+        DatasetField field = requireField(fieldMap, sort.fieldId());
+        DatasetSortDirection direction = sort.direction() == null ? DatasetSortDirection.ASC : sort.direction();
+        String expression;
+        if (rawMode) {
+          expression = ref(field);
+        } else if (sort.aggregation() != null) {
+          expression = metricAliases.get(metricKey(field.fieldId(), sort.aggregation()));
+          if (expression == null) {
+            throw new IllegalArgumentException("排序指标必须先出现在 metrics 中：" + field.fieldId());
+          }
+        } else {
+          expression = dimensionAliases.get(field.fieldId());
+          if (expression == null) {
+            throw new IllegalArgumentException("排序维度必须先出现在 dimensions 中：" + field.fieldId());
+          }
+        }
+        orderBy.add(expression + " " + direction.name());
+      }
+      sql.append(" ORDER BY ").append(String.join(", ", orderBy));
+    }
+
+    sql.append(" LIMIT ").append(fetchRows);
+    return new CompiledQuery(sql.toString(), List.copyOf(bindings), limit, fetchRows);
+  }
+
+  private String compileFilter(Map<String, DatasetField> fieldMap, DatasetFilter filter) {
+    if (filter == null || filter.operator() == null) throw new IllegalArgumentException("过滤条件和操作符不能为空");
+    DatasetField field = requireField(fieldMap, filter.fieldId());
+    String expression = ref(field);
+    return switch (filter.operator()) {
+      case IS_NULL -> expression + " IS NULL";
+      case IS_NOT_NULL -> expression + " IS NOT NULL";
+      case EQ -> filter.value() == null
+          ? expression + " IS NULL"
+          : expression + " = " + literal(filter.value());
+      case NE -> filter.value() == null
+          ? expression + " IS NOT NULL"
+          : expression + " <> " + literal(filter.value());
+      case GT -> expression + " > " + literalRequired(filter.value());
+      case GTE -> expression + " >= " + literalRequired(filter.value());
+      case LT -> expression + " < " + literalRequired(filter.value());
+      case LTE -> expression + " <= " + literalRequired(filter.value());
+      case LIKE -> expression + " LIKE " + literalRequired(filter.value());
+      case NOT_LIKE -> expression + " NOT LIKE " + literalRequired(filter.value());
+      case IN -> expression + " IN (" + literals(filter.values()) + ")";
+      case NOT_IN -> expression + " NOT IN (" + literals(filter.values()) + ")";
+      case BETWEEN -> {
+        List<Object> values = filter.values() == null ? List.of() : filter.values();
+        if (values.size() != 2) throw new IllegalArgumentException("BETWEEN 必须提供两个 values");
+        yield expression + " BETWEEN " + literalRequired(values.get(0))
+            + " AND " + literalRequired(values.get(1));
+      }
+    };
+  }
+
+  private String literals(List<Object> values) {
+    List<Object> normalized = values == null ? List.of() : values;
+    if (normalized.isEmpty()) throw new IllegalArgumentException("IN / NOT_IN 的 values 不能为空");
+    if (normalized.size() > MAX_FILTER_VALUES) throw new IllegalArgumentException("单个 IN 条件最多支持 100 个值");
+    return normalized.stream().map(this::literalRequired).reduce((a, b) -> a + ", " + b).orElseThrow();
+  }
+
+  private String literalRequired(Object value) {
+    if (value == null) throw new IllegalArgumentException("当前过滤操作符不接受 null");
+    return literal(value);
+  }
+
+  private String literal(Object value) {
+    if (value == null) return "NULL";
+    if (value instanceof Boolean bool) return bool ? "TRUE" : "FALSE";
+    if (value instanceof Number number) {
+      if (number instanceof Double d && (!Double.isFinite(d))) throw new IllegalArgumentException("过滤数值非法");
+      if (number instanceof Float f && (!Float.isFinite(f))) throw new IllegalArgumentException("过滤数值非法");
+      try {
+        return new BigDecimal(number.toString()).toPlainString();
+      } catch (NumberFormatException exception) {
+        throw new IllegalArgumentException("过滤数值非法", exception);
+      }
+    }
+    if (value instanceof String text) {
+      if (text.length() > MAX_VALUE_LENGTH) throw new IllegalArgumentException("单个过滤值不能超过 4000 个字符");
+      return "'" + text.replace("'", "''") + "'";
+    }
+    throw new IllegalArgumentException("过滤值仅支持 string / number / boolean / null");
+  }
+
+  private String metricExpression(DatasetField field, DatasetAggregation aggregation) {
+    String value = ref(field);
+    return switch (aggregation) {
+      case SUM -> "SUM(" + value + ")";
+      case AVG -> "AVG(" + value + ")";
+      case COUNT -> "COUNT(" + value + ")";
+      case COUNT_DISTINCT -> "COUNT(DISTINCT " + value + ")";
+      case MAX -> "MAX(" + value + ")";
+      case MIN -> "MIN(" + value + ")";
+    };
+  }
+
+  private DatasetField requireField(Map<String, DatasetField> fieldMap, String fieldId) {
+    if (fieldId == null || fieldId.isBlank()) throw new IllegalArgumentException("fieldId 不能为空");
+    DatasetField field = fieldMap.get(fieldId.trim());
+    if (field == null) throw new IllegalArgumentException("Dataset 字段不存在：" + fieldId);
+    return field;
+  }
+
+  private String ref(DatasetField field) {
+    validateIdentifier(field.physicalName());
+    return "yak_dataset_source." + field.physicalName();
+  }
+
+  private void validateIdentifier(String value) {
+    if (value == null || !SAFE_IDENTIFIER.matcher(value).matches()) {
+      throw new IllegalArgumentException("Stage 2 仅支持安全的简单物理字段名：[A-Za-z_][A-Za-z0-9_$]*，当前=" + value);
+    }
+  }
+
+  private String metricKey(String fieldId, DatasetAggregation aggregation) {
+    return fieldId + "|" + aggregation.name().toUpperCase(Locale.ROOT);
+  }
+
+  private int normalizeLimit(Integer value) {
+    if (value == null) return DEFAULT_LIMIT;
+    if (value < 1 || value > MAX_LIMIT) throw new IllegalArgumentException("limit 必须在 1~1000 之间");
+    return value;
+  }
+
+  private static <T> List<T> copy(List<T> values) {
+    return values == null ? List.of() : List.copyOf(values);
+  }
+
+  record CompiledQuery(
+      String sql,
+      List<DatasetQueryColumnBinding> bindings,
+      int limit,
+      int fetchRows) {
+  }
+}

--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetQueryResult.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetQueryResult.java
@@ -1,0 +1,91 @@
+package io.yak.ops.business.dataset;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import io.yak.ops.spi.datasource.execution.DataSourceSqlColumn;
+import java.util.List;
+
+/** Result returned to Dashboard/Chart consumers by the Dataset query runtime. */
+public record DatasetQueryResult(
+    @JsonSerialize(using = ToStringSerializer.class) long datasetId,
+    @JsonSerialize(using = ToStringSerializer.class) long datasetVersionId,
+    int datasetVersionNo,
+    List<DatasetQueryColumnBinding> bindings,
+    List<DataSourceSqlColumn> columns,
+    List<List<Object>> rows,
+    int returnedRows,
+    boolean truncated,
+    long elapsedMillis) {
+
+  public DatasetQueryResult {
+    bindings = bindings == null ? List.of() : List.copyOf(bindings);
+    columns = columns == null ? List.of() : List.copyOf(columns);
+    rows = rows == null ? List.of() : rows.stream().map(List::copyOf).toList();
+  }
+}
+
+record DatasetQueryRequest(
+    Integer versionNo,
+    List<String> dimensions,
+    List<DatasetMetricBinding> metrics,
+    List<DatasetFilter> filters,
+    List<DatasetSort> sorts,
+    Integer limit,
+    Integer timeoutSeconds) {
+}
+
+enum DatasetAggregation {
+  SUM,
+  AVG,
+  COUNT,
+  COUNT_DISTINCT,
+  MAX,
+  MIN
+}
+
+enum DatasetFilterOperator {
+  EQ,
+  NE,
+  GT,
+  GTE,
+  LT,
+  LTE,
+  IN,
+  NOT_IN,
+  LIKE,
+  NOT_LIKE,
+  BETWEEN,
+  IS_NULL,
+  IS_NOT_NULL
+}
+
+enum DatasetSortDirection {
+  ASC,
+  DESC
+}
+
+record DatasetMetricBinding(
+    String fieldId,
+    DatasetAggregation aggregation) {
+}
+
+record DatasetFilter(
+    String fieldId,
+    DatasetFilterOperator operator,
+    Object value,
+    List<Object> values) {
+}
+
+record DatasetSort(
+    String fieldId,
+    DatasetAggregation aggregation,
+    DatasetSortDirection direction) {
+}
+
+record DatasetQueryColumnBinding(
+    String key,
+    String fieldId,
+    String displayName,
+    DatasetFieldDataType dataType,
+    DatasetAggregation aggregation) {
+}

--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetQueryResult.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetQueryResult.java
@@ -3,6 +3,8 @@ package io.yak.ops.business.dataset;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 import io.yak.ops.spi.datasource.execution.DataSourceSqlColumn;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /** Result returned to Dashboard/Chart consumers by the Dataset query runtime. */
@@ -20,7 +22,17 @@ public record DatasetQueryResult(
   public DatasetQueryResult {
     bindings = bindings == null ? List.of() : List.copyOf(bindings);
     columns = columns == null ? List.of() : List.copyOf(columns);
-    rows = rows == null ? List.of() : rows.stream().map(List::copyOf).toList();
+    rows = immutableRows(rows);
+  }
+
+  private static List<List<Object>> immutableRows(List<List<Object>> values) {
+    if (values == null || values.isEmpty()) return List.of();
+    List<List<Object>> copied = new ArrayList<>(values.size());
+    for (List<Object> row : values) {
+      List<Object> cells = row == null ? new ArrayList<>() : new ArrayList<>(row);
+      copied.add(Collections.unmodifiableList(cells));
+    }
+    return Collections.unmodifiableList(copied);
   }
 }
 

--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetQueryService.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetQueryService.java
@@ -1,0 +1,61 @@
+package io.yak.ops.business.dataset;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.springframework.stereotype.Service;
+
+/** Application entry point used by Dashboard/Chart consumers. */
+@Service
+public class DatasetQueryService {
+
+  private final DatasetRepository repository;
+  private final Map<DatasetSourceType, DatasetSourceQueryAdapter> adapters;
+
+  DatasetQueryService(
+      DatasetRepository repository,
+      List<DatasetSourceQueryAdapter> adapters) {
+    this.repository = repository;
+    Map<DatasetSourceType, DatasetSourceQueryAdapter> discovered = new LinkedHashMap<>();
+    for (DatasetSourceQueryAdapter adapter : adapters) {
+      DatasetSourceQueryAdapter existing = discovered.putIfAbsent(adapter.sourceType(), adapter);
+      if (existing != null) {
+        throw new IllegalStateException("重复的 Dataset query adapter：" + adapter.sourceType());
+      }
+    }
+    this.adapters = Map.copyOf(discovered);
+  }
+
+  public DatasetQueryResult query(long datasetId, DatasetQueryRequest request) {
+    if (datasetId <= 0L) throw new IllegalArgumentException("datasetId 必须大于 0");
+    Dataset dataset = repository.findDataset(datasetId)
+        .orElseThrow(() -> new IllegalArgumentException("Dataset 不存在：" + datasetId));
+    if (dataset.status() != DatasetStatus.ONLINE) {
+      throw new IllegalArgumentException("只有 ONLINE Dataset 可以查询：" + datasetId);
+    }
+
+    DatasetVersion version = resolveVersion(dataset, request == null ? null : request.versionNo());
+    List<DatasetField> fields = repository.listFields(version.id());
+    DatasetSourceQueryAdapter adapter = adapters.get(version.sourceType());
+    if (adapter == null) {
+      throw new IllegalStateException("Dataset sourceType 尚未接入 Query Runtime：" + version.sourceType());
+    }
+    return adapter.execute(dataset, version, fields, request);
+  }
+
+  private DatasetVersion resolveVersion(Dataset dataset, Integer versionNo) {
+    if (versionNo == null) {
+      if (dataset.currentVersionId() == null) {
+        throw new IllegalStateException("Dataset 尚未建立当前版本：" + dataset.id());
+      }
+      return repository.findVersion(dataset.currentVersionId())
+          .orElseThrow(() -> new IllegalStateException("Dataset 当前版本不存在：" + dataset.currentVersionId()));
+    }
+    if (versionNo <= 0) throw new IllegalArgumentException("versionNo 必须大于 0");
+    return repository.listVersions(dataset.id()).stream()
+        .filter(version -> version.versionNo() == versionNo)
+        .findFirst()
+        .orElseThrow(() -> new IllegalArgumentException(
+            "DatasetVersion 不存在：datasetId=" + dataset.id() + ", versionNo=" + versionNo));
+  }
+}

--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetSchemaDiscoveryService.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetSchemaDiscoveryService.java
@@ -1,0 +1,151 @@
+package io.yak.ops.business.dataset;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.taskcatalog.domain.TaskAsset;
+import io.yak.ops.business.taskcatalog.domain.TaskAssetRevision;
+import io.yak.ops.business.taskcatalog.service.TaskCatalogService;
+import io.yak.ops.spi.datasource.execution.DataSourceExecutionProvider;
+import io.yak.ops.spi.datasource.execution.DataSourceSqlColumn;
+import io.yak.ops.spi.datasource.execution.DataSourceSqlExecutor;
+import io.yak.ops.spi.datasource.execution.DataSourceSqlRequest;
+import io.yak.ops.spi.datasource.execution.DataSourceSqlResult;
+import io.yak.ops.spi.task.model.TaskDefinition;
+import java.nio.charset.StandardCharsets;
+import java.sql.Types;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.UUID;
+import java.util.regex.Pattern;
+import org.springframework.stereotype.Service;
+
+/** Discovers and freezes QUERY_REVISION output schema while a DatasetVersion is being created. */
+@Service
+final class DatasetSchemaDiscoveryService {
+
+  private static final int DEFAULT_TIMEOUT_SECONDS = 30;
+  private static final int MAX_DISCOVERY_TIMEOUT_SECONDS = 30;
+  private static final Pattern SAFE_IDENTIFIER = Pattern.compile("[A-Za-z_][A-Za-z0-9_$]*");
+
+  private final TaskCatalogService taskCatalogService;
+  private final DataSourceExecutionProvider dataSourceExecutionProvider;
+  private final ObjectMapper objectMapper;
+
+  DatasetSchemaDiscoveryService(
+      TaskCatalogService taskCatalogService,
+      DataSourceExecutionProvider dataSourceExecutionProvider,
+      ObjectMapper objectMapper) {
+    this.taskCatalogService = taskCatalogService;
+    this.dataSourceExecutionProvider = dataSourceExecutionProvider;
+    this.objectMapper = objectMapper;
+  }
+
+  List<DatasetService.FieldSpec> discover(long datasetId, TaskAsset asset) {
+    TaskAssetRevision resolved = taskCatalogService.resolveRevision(
+        asset.id(), asset.currentRevision().taskRevisionId());
+    if (resolved.revision().revisionId() != asset.currentRevision().taskRevisionId()
+        || resolved.revision().revisionNo() != asset.currentRevision().revisionNo()) {
+      throw new IllegalStateException("Schema discovery 解析到的 TaskRevision 与发布快照不一致");
+    }
+
+    TaskDefinition definition = resolved.revision().definition();
+    if (!"SQL".equalsIgnoreCase(definition.taskType())) {
+      throw new IllegalArgumentException("Schema discovery 仅支持 SQL TaskRevision");
+    }
+    String baseSql = DatasetSqlSafety.requireReadOnlyQuery(definition.content());
+    SourceConfig config = sourceConfig(definition.configJson());
+    String discoverySql = "SELECT yak_dataset_source.* FROM (" + baseSql
+        + ") yak_dataset_source LIMIT 1";
+
+    DataSourceSqlResult result;
+    try (DataSourceSqlExecutor executor = dataSourceExecutionProvider.open(config.dataSourceId())) {
+      result = executor.execute(new DataSourceSqlRequest(discoverySql, 1, config.timeoutSeconds()));
+    }
+    if (!result.resultSet()) {
+      throw new IllegalStateException("Dataset schema discovery 没有返回结果集");
+    }
+    if (result.columns().isEmpty()) {
+      throw new IllegalArgumentException("Dataset 来源查询没有可发现的输出字段");
+    }
+    return toFields(datasetId, result.columns());
+  }
+
+  private List<DatasetService.FieldSpec> toFields(long datasetId, List<DataSourceSqlColumn> columns) {
+    List<DatasetService.FieldSpec> fields = new ArrayList<>(columns.size());
+    Set<String> names = new HashSet<>();
+    for (DataSourceSqlColumn column : columns) {
+      String physicalName = column.label();
+      if (physicalName == null || physicalName.isBlank()) physicalName = column.name();
+      if (physicalName == null || physicalName.isBlank()) {
+        throw new IllegalArgumentException("Dataset 来源查询存在无名称字段，请在 SQL 中显式设置别名");
+      }
+      physicalName = physicalName.trim();
+      if (!SAFE_IDENTIFIER.matcher(physicalName).matches()) {
+        throw new IllegalArgumentException(
+            "Dataset 输出字段必须使用简单安全别名 [A-Za-z_][A-Za-z0-9_$]*：" + physicalName);
+      }
+      String normalized = physicalName.toLowerCase(Locale.ROOT);
+      if (!names.add(normalized)) {
+        throw new IllegalArgumentException("Dataset 来源查询存在重复输出字段：" + physicalName);
+      }
+
+      DatasetFieldDataType dataType = dataType(column.jdbcType());
+      DatasetFieldRole role = dataType == DatasetFieldDataType.NUMBER
+          ? DatasetFieldRole.MEASURE : DatasetFieldRole.DIMENSION;
+      String fieldId = UUID.nameUUIDFromBytes(
+          ("dataset:" + datasetId + ":" + normalized).getBytes(StandardCharsets.UTF_8)).toString();
+      fields.add(new DatasetService.FieldSpec(
+          fieldId,
+          physicalName,
+          physicalName,
+          dataType,
+          column.nullable(),
+          null,
+          role));
+    }
+    return List.copyOf(fields);
+  }
+
+  private DatasetFieldDataType dataType(int jdbcType) {
+    return switch (jdbcType) {
+      case Types.BOOLEAN, Types.BIT -> DatasetFieldDataType.BOOLEAN;
+      case Types.TINYINT, Types.SMALLINT, Types.INTEGER, Types.BIGINT,
+          Types.FLOAT, Types.REAL, Types.DOUBLE, Types.NUMERIC, Types.DECIMAL -> DatasetFieldDataType.NUMBER;
+      case Types.DATE -> DatasetFieldDataType.DATE;
+      case Types.TIME, Types.TIME_WITH_TIMEZONE, Types.TIMESTAMP, Types.TIMESTAMP_WITH_TIMEZONE ->
+          DatasetFieldDataType.DATETIME;
+      case Types.CHAR, Types.VARCHAR, Types.LONGVARCHAR,
+          Types.NCHAR, Types.NVARCHAR, Types.LONGNVARCHAR, Types.CLOB, Types.NCLOB -> DatasetFieldDataType.STRING;
+      default -> DatasetFieldDataType.UNKNOWN;
+    };
+  }
+
+  private SourceConfig sourceConfig(String configJson) {
+    String raw = configJson == null || configJson.isBlank() ? "{}" : configJson.trim();
+    try {
+      JsonNode root = objectMapper.readTree(raw);
+      if (root == null || !root.isObject()) throw new IllegalArgumentException("SQL configJson 必须是 JSON 对象");
+      JsonNode dataSourceNode = root.get("dataSourceId");
+      String dataSourceId = dataSourceNode == null || dataSourceNode.isNull()
+          ? null : dataSourceNode.asText();
+      if (dataSourceId == null || dataSourceId.isBlank()) {
+        throw new IllegalArgumentException("SQL TaskRevision 缺少 dataSourceId，无法发现 Dataset schema");
+      }
+      int sourceTimeout = root.path("timeoutSeconds").asInt(DEFAULT_TIMEOUT_SECONDS);
+      if (sourceTimeout < 1) sourceTimeout = DEFAULT_TIMEOUT_SECONDS;
+      return new SourceConfig(
+          dataSourceId.trim(),
+          Math.min(sourceTimeout, MAX_DISCOVERY_TIMEOUT_SECONDS));
+    } catch (IllegalArgumentException exception) {
+      throw exception;
+    } catch (Exception exception) {
+      throw new IllegalArgumentException("SQL TaskRevision configJson 非法", exception);
+    }
+  }
+
+  private record SourceConfig(String dataSourceId, int timeoutSeconds) {
+  }
+}

--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetService.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetService.java
@@ -13,30 +13,40 @@ import java.util.Locale;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-/**
- * Dataset publication service.
- *
- * <p>A Dataset is a BI data contract, not an executable development task. Stage 1 only accepts
- * the immutable current revision of an ONLINE SQL TaskAsset and snapshots that reference into an
- * immutable DatasetVersion.</p>
- */
+/** Dataset publication/lifecycle service. Dataset is a data contract, not an executable task. */
 @Service
 public class DatasetService {
 
   private final DatasetRepository repository;
   private final TaskCatalogService taskCatalogService;
   private final ObjectMapper objectMapper;
+  private final DatasetSchemaDiscoveryService schemaDiscoveryService;
 
+  @Autowired
   public DatasetService(
+      DatasetRepository repository,
+      TaskCatalogService taskCatalogService,
+      ObjectMapper objectMapper,
+      DatasetSchemaDiscoveryService schemaDiscoveryService) {
+    this.repository = repository;
+    this.taskCatalogService = taskCatalogService;
+    this.objectMapper = objectMapper;
+    this.schemaDiscoveryService = schemaDiscoveryService;
+  }
+
+  /** Backward-compatible constructor for focused unit tests that do not need live schema discovery. */
+  DatasetService(
       DatasetRepository repository,
       TaskCatalogService taskCatalogService,
       ObjectMapper objectMapper) {
     this.repository = repository;
     this.taskCatalogService = taskCatalogService;
     this.objectMapper = objectMapper;
+    this.schemaDiscoveryService = null;
   }
 
   @Transactional("yakBusinessTransactionManager")
@@ -45,9 +55,10 @@ public class DatasetService {
     TaskAsset asset = requirePublishableAsset(command.sourceTaskAssetId());
     String name = normalizeName(command.name(), asset.name());
     String description = normalizeDescription(command.description());
-    List<FieldSpec> fields = normalizeFields(command.fields());
+    List<FieldSpec> requestedFields = normalizeFields(command.fields());
 
     long datasetId = repository.insertDataset(name, description);
+    List<FieldSpec> fields = resolveFields(datasetId, asset, requestedFields);
     long versionId = appendVersion(datasetId, asset, fields, false);
     repository.updateCurrentVersion(datasetId, versionId);
     return get(datasetId);
@@ -68,6 +79,7 @@ public class DatasetService {
     }
 
     List<FieldSpec> normalizedFields = normalizeFields(fields);
+    normalizedFields = resolveFields(datasetId, asset, normalizedFields);
     long versionId = appendVersion(datasetId, asset, normalizedFields, true);
     repository.updateCurrentVersion(datasetId, versionId);
     return get(datasetId);
@@ -112,6 +124,15 @@ public class DatasetService {
     return get(datasetId);
   }
 
+  private List<FieldSpec> resolveFields(
+      long datasetId,
+      TaskAsset asset,
+      List<FieldSpec> requestedFields) {
+    if (requestedFields != null && !requestedFields.isEmpty()) return requestedFields;
+    if (schemaDiscoveryService == null) return List.of();
+    return normalizeFields(schemaDiscoveryService.discover(datasetId, asset));
+  }
+
   private long appendVersion(
       long datasetId,
       TaskAsset asset,
@@ -145,7 +166,7 @@ public class DatasetService {
       throw new IllegalArgumentException("只有 ONLINE 的 TaskAsset 可以发布/更新 Dataset：" + assetId);
     }
     if (!"SQL".equalsIgnoreCase(asset.taskType())) {
-      throw new IllegalArgumentException("Stage 1 仅支持 SQL TaskAsset 发布为 QUERY_REVISION Dataset");
+      throw new IllegalArgumentException("当前仅支持 SQL TaskAsset 发布为 QUERY_REVISION Dataset");
     }
     if (asset.currentRevision() == null
         || asset.currentRevision().taskRevisionId() <= 0L

--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetSourceQueryAdapter.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetSourceQueryAdapter.java
@@ -1,0 +1,15 @@
+package io.yak.ops.business.dataset;
+
+import java.util.List;
+
+/** Runtime strategy per Dataset source type. TABLE/VIEW adapters can be added without changing consumers. */
+interface DatasetSourceQueryAdapter {
+
+  DatasetSourceType sourceType();
+
+  DatasetQueryResult execute(
+      Dataset dataset,
+      DatasetVersion version,
+      List<DatasetField> fields,
+      DatasetQueryRequest request);
+}

--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetSqlSafety.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetSqlSafety.java
@@ -1,0 +1,157 @@
+package io.yak.ops.business.dataset;
+
+import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/** Conservative guard for SQL used as a QUERY_REVISION Dataset source. */
+final class DatasetSqlSafety {
+
+  private static final int MAX_SQL_LENGTH = 500_000;
+  private static final Pattern FIRST_KEYWORD = Pattern.compile("(?i)\\b([a-z]+)\\b");
+  private static final Pattern FORBIDDEN = Pattern.compile(
+      "(?i)\\b(INSERT|UPDATE|DELETE|MERGE|ALTER|DROP|CREATE|TRUNCATE|REPLACE|CALL|EXEC|EXECUTE|"
+          + "GRANT|REVOKE|LOAD|COPY|LOCK|UNLOCK|SET|USE|INTO)\\b");
+  private static final Pattern FOR_UPDATE = Pattern.compile("(?i)\\bFOR\\s+UPDATE\\b");
+
+  private DatasetSqlSafety() {
+  }
+
+  static String requireReadOnlyQuery(String sql) {
+    if (sql == null || sql.isBlank()) {
+      throw new IllegalArgumentException("Dataset 来源 SQL 不能为空");
+    }
+    String normalized = sql.trim();
+    if (normalized.length() > MAX_SQL_LENGTH) {
+      throw new IllegalArgumentException("Dataset 来源 SQL 过长");
+    }
+
+    String visible = visibleSql(normalized);
+    int last = lastNonWhitespace(visible);
+    if (last >= 0 && visible.charAt(last) == ';') {
+      visible = visible.substring(0, last);
+      normalized = normalized.substring(0, Math.min(last, normalized.length())).trim();
+    }
+    if (visible.indexOf(';') >= 0) {
+      throw new IllegalArgumentException("Dataset 仅允许单条只读查询，不能包含多语句");
+    }
+
+    Matcher first = FIRST_KEYWORD.matcher(visible);
+    if (!first.find()) throw new IllegalArgumentException("Dataset 来源 SQL 无法识别查询语句");
+    String keyword = first.group(1).toUpperCase(Locale.ROOT);
+    if (!"SELECT".equals(keyword) && !"WITH".equals(keyword)) {
+      throw new IllegalArgumentException("Dataset 仅允许 SELECT / WITH 查询");
+    }
+    if (FORBIDDEN.matcher(visible).find() || FOR_UPDATE.matcher(visible).find()) {
+      throw new IllegalArgumentException("Dataset 来源 SQL 必须是无副作用的只读查询");
+    }
+    return normalized;
+  }
+
+  private static int lastNonWhitespace(String value) {
+    for (int i = value.length() - 1; i >= 0; i--) {
+      if (!Character.isWhitespace(value.charAt(i))) return i;
+    }
+    return -1;
+  }
+
+  /** Replaces comments and quoted content with spaces so validation only sees executable tokens. */
+  private static String visibleSql(String sql) {
+    StringBuilder out = new StringBuilder(sql.length());
+    State state = State.NORMAL;
+    for (int i = 0; i < sql.length(); i++) {
+      char c = sql.charAt(i);
+      char next = i + 1 < sql.length() ? sql.charAt(i + 1) : '\0';
+      switch (state) {
+        case NORMAL -> {
+          if (c == '\'' ) {
+            state = State.SINGLE_QUOTE;
+            out.append(' ');
+          } else if (c == '"') {
+            state = State.DOUBLE_QUOTE;
+            out.append(' ');
+          } else if (c == '`') {
+            state = State.BACKTICK;
+            out.append(' ');
+          } else if (c == '-' && next == '-') {
+            state = State.LINE_COMMENT;
+            out.append("  ");
+            i++;
+          } else if (c == '#') {
+            state = State.LINE_COMMENT;
+            out.append(' ');
+          } else if (c == '/' && next == '*') {
+            state = State.BLOCK_COMMENT;
+            out.append("  ");
+            i++;
+          } else {
+            out.append(c);
+          }
+        }
+        case SINGLE_QUOTE -> {
+          out.append(' ');
+          if (c == '\\' && next != '\0') {
+            out.append(' ');
+            i++;
+          } else if (c == '\'' && next == '\'') {
+            out.append(' ');
+            i++;
+          } else if (c == '\'') {
+            state = State.NORMAL;
+          }
+        }
+        case DOUBLE_QUOTE -> {
+          out.append(' ');
+          if (c == '\\' && next != '\0') {
+            out.append(' ');
+            i++;
+          } else if (c == '"' && next == '"') {
+            out.append(' ');
+            i++;
+          } else if (c == '"') {
+            state = State.NORMAL;
+          }
+        }
+        case BACKTICK -> {
+          out.append(' ');
+          if (c == '`' && next == '`') {
+            out.append(' ');
+            i++;
+          } else if (c == '`') {
+            state = State.NORMAL;
+          }
+        }
+        case LINE_COMMENT -> {
+          if (c == '\n' || c == '\r') {
+            state = State.NORMAL;
+            out.append(c);
+          } else {
+            out.append(' ');
+          }
+        }
+        case BLOCK_COMMENT -> {
+          out.append(' ');
+          if (c == '*' && next == '/') {
+            out.append(' ');
+            i++;
+            state = State.NORMAL;
+          }
+        }
+      }
+    }
+    if (state == State.SINGLE_QUOTE || state == State.DOUBLE_QUOTE
+        || state == State.BACKTICK || state == State.BLOCK_COMMENT) {
+      throw new IllegalArgumentException("Dataset 来源 SQL 包含未闭合的字符串、标识符或注释");
+    }
+    return out.toString();
+  }
+
+  private enum State {
+    NORMAL,
+    SINGLE_QUOTE,
+    DOUBLE_QUOTE,
+    BACKTICK,
+    LINE_COMMENT,
+    BLOCK_COMMENT
+  }
+}

--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/QueryRevisionDatasetSourceAdapter.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/QueryRevisionDatasetSourceAdapter.java
@@ -1,0 +1,124 @@
+package io.yak.ops.business.dataset;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.taskcatalog.domain.TaskAssetRevision;
+import io.yak.ops.business.taskcatalog.service.TaskCatalogService;
+import io.yak.ops.spi.datasource.execution.DataSourceExecutionProvider;
+import io.yak.ops.spi.datasource.execution.DataSourceSqlExecutor;
+import io.yak.ops.spi.datasource.execution.DataSourceSqlRequest;
+import io.yak.ops.spi.datasource.execution.DataSourceSqlResult;
+import io.yak.ops.spi.task.model.TaskDefinition;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+/** Executes QUERY_REVISION Dataset versions without invoking DevelopmentTask execution semantics. */
+@Component
+final class QueryRevisionDatasetSourceAdapter implements DatasetSourceQueryAdapter {
+
+  private static final int DEFAULT_TIMEOUT_SECONDS = 30;
+  private static final int MAX_TIMEOUT_SECONDS = 120;
+
+  private final TaskCatalogService taskCatalogService;
+  private final DataSourceExecutionProvider dataSourceExecutionProvider;
+  private final ObjectMapper objectMapper;
+  private final DatasetQueryCompiler compiler;
+
+  QueryRevisionDatasetSourceAdapter(
+      TaskCatalogService taskCatalogService,
+      DataSourceExecutionProvider dataSourceExecutionProvider,
+      ObjectMapper objectMapper,
+      DatasetQueryCompiler compiler) {
+    this.taskCatalogService = taskCatalogService;
+    this.dataSourceExecutionProvider = dataSourceExecutionProvider;
+    this.objectMapper = objectMapper;
+    this.compiler = compiler;
+  }
+
+  @Override
+  public DatasetSourceType sourceType() {
+    return DatasetSourceType.QUERY_REVISION;
+  }
+
+  @Override
+  public DatasetQueryResult execute(
+      Dataset dataset,
+      DatasetVersion version,
+      List<DatasetField> fields,
+      DatasetQueryRequest request) {
+    TaskAssetRevision resolved = taskCatalogService.resolveRevision(
+        version.sourceTaskAssetId(), version.sourceTaskRevisionId());
+    if (resolved.revision().revisionId() != version.sourceTaskRevisionId()
+        || resolved.revision().revisionNo() != version.sourceTaskRevisionNo()) {
+      throw new IllegalStateException("DatasetVersion 与来源 TaskRevision 快照不一致");
+    }
+
+    TaskDefinition definition = resolved.revision().definition();
+    if (!"SQL".equalsIgnoreCase(definition.taskType())) {
+      throw new IllegalStateException("QUERY_REVISION Dataset 来源必须是 SQL TaskRevision");
+    }
+
+    SourceConfig sourceConfig = sourceConfig(definition.configJson());
+    DatasetQueryCompiler.CompiledQuery compiled = compiler.compile(definition.content(), fields, request);
+    int timeoutSeconds = queryTimeout(request, sourceConfig.timeoutSeconds());
+    long startedAt = System.nanoTime();
+
+    DataSourceSqlResult result;
+    try (DataSourceSqlExecutor executor = dataSourceExecutionProvider.open(sourceConfig.dataSourceId())) {
+      result = executor.execute(new DataSourceSqlRequest(
+          compiled.sql(), compiled.fetchRows(), timeoutSeconds));
+    }
+    if (!result.resultSet()) {
+      throw new IllegalStateException("Dataset Query Runtime 只接受结果集查询");
+    }
+
+    boolean overflow = result.rows().size() > compiled.limit();
+    List<List<Object>> rows = overflow
+        ? result.rows().subList(0, compiled.limit())
+        : result.rows();
+    long elapsedMillis = (System.nanoTime() - startedAt) / 1_000_000L;
+    return new DatasetQueryResult(
+        dataset.id(),
+        version.id(),
+        version.versionNo(),
+        compiled.bindings(),
+        result.columns(),
+        rows,
+        rows.size(),
+        result.truncated() || overflow,
+        elapsedMillis);
+  }
+
+  private SourceConfig sourceConfig(String configJson) {
+    String raw = configJson == null || configJson.isBlank() ? "{}" : configJson.trim();
+    try {
+      JsonNode root = objectMapper.readTree(raw);
+      if (root == null || !root.isObject()) throw new IllegalArgumentException("SQL configJson 必须是 JSON 对象");
+      JsonNode dataSourceNode = root.get("dataSourceId");
+      String dataSourceId = dataSourceNode == null || dataSourceNode.isNull()
+          ? null : dataSourceNode.asText();
+      if (dataSourceId == null || dataSourceId.isBlank()) {
+        throw new IllegalArgumentException("SQL TaskRevision 缺少 dataSourceId，无法执行 Dataset 查询");
+      }
+      int sourceTimeout = root.path("timeoutSeconds").asInt(DEFAULT_TIMEOUT_SECONDS);
+      if (sourceTimeout < 1) sourceTimeout = DEFAULT_TIMEOUT_SECONDS;
+      return new SourceConfig(dataSourceId.trim(), Math.min(sourceTimeout, MAX_TIMEOUT_SECONDS));
+    } catch (IllegalArgumentException exception) {
+      throw exception;
+    } catch (Exception exception) {
+      throw new IllegalArgumentException("SQL TaskRevision configJson 非法", exception);
+    }
+  }
+
+  private int queryTimeout(DatasetQueryRequest request, int sourceTimeout) {
+    Integer requested = request == null ? null : request.timeoutSeconds();
+    if (requested == null) return Math.max(1, Math.min(sourceTimeout, MAX_TIMEOUT_SECONDS));
+    if (requested < 1 || requested > MAX_TIMEOUT_SECONDS) {
+      throw new IllegalArgumentException("timeoutSeconds 必须在 1~120 之间");
+    }
+    return requested;
+  }
+
+  private record SourceConfig(String dataSourceId, int timeoutSeconds) {
+  }
+}

--- a/yak-ops-business/yak-ops-business-dataset/src/test/java/io/yak/ops/business/dataset/DatasetQueryCompilerTest.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/test/java/io/yak/ops/business/dataset/DatasetQueryCompilerTest.java
@@ -1,0 +1,70 @@
+package io.yak.ops.business.dataset;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class DatasetQueryCompilerTest {
+
+  private final DatasetQueryCompiler compiler = new DatasetQueryCompiler();
+
+  @Test
+  void compilesDimensionMetricFilterAndSort() {
+    List<DatasetField> fields = List.of(
+        field("region", "region", DatasetFieldDataType.STRING, DatasetFieldRole.DIMENSION),
+        field("amount", "amount", DatasetFieldDataType.NUMBER, DatasetFieldRole.MEASURE));
+    DatasetQueryRequest request = new DatasetQueryRequest(
+        null,
+        List.of("region"),
+        List.of(new DatasetMetricBinding("amount", DatasetAggregation.SUM)),
+        List.of(new DatasetFilter("region", DatasetFilterOperator.EQ, "East'Asia", null)),
+        List.of(new DatasetSort("amount", DatasetAggregation.SUM, DatasetSortDirection.DESC)),
+        100,
+        null);
+
+    DatasetQueryCompiler.CompiledQuery compiled = compiler.compile(
+        "SELECT region, amount FROM sales", fields, request);
+
+    assertTrue(compiled.sql().contains("yak_dataset_source.region AS d0"));
+    assertTrue(compiled.sql().contains("SUM(yak_dataset_source.amount) AS m1"));
+    assertTrue(compiled.sql().contains("yak_dataset_source.region = 'East''Asia'"));
+    assertTrue(compiled.sql().contains("GROUP BY yak_dataset_source.region"));
+    assertTrue(compiled.sql().contains("ORDER BY m1 DESC"));
+    assertTrue(compiled.sql().endsWith("LIMIT 101"));
+    assertEquals(2, compiled.bindings().size());
+  }
+
+  @Test
+  void rawPreviewWorksWithoutSchema() {
+    DatasetQueryCompiler.CompiledQuery compiled = compiler.compile(
+        "SELECT * FROM sales", List.of(), null);
+    assertTrue(compiled.sql().startsWith("SELECT yak_dataset_source.* FROM (SELECT * FROM sales)"));
+    assertTrue(compiled.bindings().isEmpty());
+  }
+
+  @Test
+  void rejectsMutationAndMultiStatementSources() {
+    assertThrows(IllegalArgumentException.class, () ->
+        compiler.compile("DELETE FROM sales", List.of(), null));
+    assertThrows(IllegalArgumentException.class, () ->
+        compiler.compile("SELECT * FROM sales; DROP TABLE sales", List.of(), null));
+  }
+
+  @Test
+  void mutationWordsInsideStringAndCommentDoNotCauseFalsePositive() {
+    DatasetQueryCompiler.CompiledQuery compiled = compiler.compile(
+        "SELECT 'delete from x' AS note /* drop table y */", List.of(), null);
+    assertTrue(compiled.sql().contains("'delete from x'"));
+  }
+
+  private DatasetField field(
+      String id,
+      String physicalName,
+      DatasetFieldDataType dataType,
+      DatasetFieldRole role) {
+    return new DatasetField(id, 1L, physicalName, physicalName, dataType, true, null, role, 1);
+  }
+}

--- a/yak-ops-business/yak-ops-business-dataset/src/test/java/io/yak/ops/business/dataset/DatasetSchemaDiscoveryServiceTest.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/test/java/io/yak/ops/business/dataset/DatasetSchemaDiscoveryServiceTest.java
@@ -1,0 +1,68 @@
+package io.yak.ops.business.dataset;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.taskcatalog.domain.TaskAsset;
+import io.yak.ops.business.taskcatalog.domain.TaskAssetRevision;
+import io.yak.ops.business.taskcatalog.service.TaskCatalogService;
+import io.yak.ops.business.taskcatalog.spi.TaskSourceRevision;
+import io.yak.ops.spi.datasource.execution.DataSourceExecutionProvider;
+import io.yak.ops.spi.datasource.execution.DataSourceSqlColumn;
+import io.yak.ops.spi.datasource.execution.DataSourceSqlExecutor;
+import io.yak.ops.spi.datasource.execution.DataSourceSqlResult;
+import io.yak.ops.spi.task.model.TaskAssetSource;
+import io.yak.ops.spi.task.model.TaskAssetStatus;
+import io.yak.ops.spi.task.model.TaskDefinition;
+import io.yak.ops.spi.task.model.TaskRevisionRef;
+import java.sql.Types;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class DatasetSchemaDiscoveryServiceTest {
+
+  @Test
+  void discoversStableFieldsFromPinnedRevision() {
+    TaskCatalogService catalog = mock(TaskCatalogService.class);
+    DataSourceExecutionProvider provider = mock(DataSourceExecutionProvider.class);
+    DataSourceSqlExecutor executor = mock(DataSourceSqlExecutor.class);
+    TaskAsset asset = new TaskAsset(
+        11L,
+        TaskAssetSource.DATA_DEVELOPMENT,
+        "101",
+        null,
+        "sales.sql",
+        "SQL",
+        TaskAssetStatus.ONLINE,
+        new TaskRevisionRef(11L, 71L, 3),
+        Instant.EPOCH,
+        Instant.EPOCH);
+    TaskSourceRevision revision = new TaskSourceRevision(
+        71L,
+        3,
+        new TaskDefinition("SQL", 1, "SELECT region, amount FROM sales", "{\"dataSourceId\":\"9\"}"),
+        "checksum");
+    when(catalog.resolveRevision(11L, 71L)).thenReturn(new TaskAssetRevision(asset, revision));
+    when(provider.open("9")).thenReturn(executor);
+    when(executor.execute(any())).thenReturn(DataSourceSqlResult.query(
+        List.of(
+            new DataSourceSqlColumn("region", "region", "VARCHAR", Types.VARCHAR, true),
+            new DataSourceSqlColumn("amount", "amount", "DECIMAL", Types.DECIMAL, true)),
+        List.of(),
+        false));
+
+    DatasetSchemaDiscoveryService service = new DatasetSchemaDiscoveryService(catalog, provider, new ObjectMapper());
+    List<DatasetService.FieldSpec> fields = service.discover(21L, asset);
+
+    assertEquals(2, fields.size());
+    assertEquals(DatasetFieldDataType.STRING, fields.get(0).dataType());
+    assertEquals(DatasetFieldRole.DIMENSION, fields.get(0).defaultRole());
+    assertEquals(DatasetFieldDataType.NUMBER, fields.get(1).dataType());
+    assertEquals(DatasetFieldRole.MEASURE, fields.get(1).defaultRole());
+    assertEquals(fields.get(0).fieldId(), service.discover(21L, asset).get(0).fieldId());
+  }
+}

--- a/yak-ops-business/yak-ops-business-dataset/src/test/java/io/yak/ops/business/dataset/QueryRevisionDatasetSourceAdapterTest.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/test/java/io/yak/ops/business/dataset/QueryRevisionDatasetSourceAdapterTest.java
@@ -1,0 +1,88 @@
+package io.yak.ops.business.dataset;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.taskcatalog.domain.TaskAsset;
+import io.yak.ops.business.taskcatalog.domain.TaskAssetRevision;
+import io.yak.ops.business.taskcatalog.service.TaskCatalogService;
+import io.yak.ops.business.taskcatalog.spi.TaskSourceRevision;
+import io.yak.ops.spi.datasource.execution.DataSourceExecutionProvider;
+import io.yak.ops.spi.datasource.execution.DataSourceSqlColumn;
+import io.yak.ops.spi.datasource.execution.DataSourceSqlExecutor;
+import io.yak.ops.spi.datasource.execution.DataSourceSqlRequest;
+import io.yak.ops.spi.datasource.execution.DataSourceSqlResult;
+import io.yak.ops.spi.task.model.TaskAssetSource;
+import io.yak.ops.spi.task.model.TaskAssetStatus;
+import io.yak.ops.spi.task.model.TaskDefinition;
+import io.yak.ops.spi.task.model.TaskRevisionRef;
+import java.sql.Types;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class QueryRevisionDatasetSourceAdapterTest {
+
+  @Test
+  void executesPinnedRevisionThroughDatasourceProviderAndTrimsOverflowRow() {
+    TaskCatalogService catalog = mock(TaskCatalogService.class);
+    DataSourceExecutionProvider provider = mock(DataSourceExecutionProvider.class);
+    DataSourceSqlExecutor executor = mock(DataSourceSqlExecutor.class);
+    TaskAsset asset = new TaskAsset(
+        11L,
+        TaskAssetSource.DATA_DEVELOPMENT,
+        "101",
+        null,
+        "sales.sql",
+        "SQL",
+        TaskAssetStatus.ONLINE,
+        new TaskRevisionRef(11L, 99L, 5),
+        Instant.EPOCH,
+        Instant.EPOCH);
+    TaskSourceRevision revision = new TaskSourceRevision(
+        71L,
+        3,
+        new TaskDefinition("SQL", 1, "SELECT region, amount FROM sales", "{\"dataSourceId\":\"9\"}"),
+        "checksum-v3");
+    when(catalog.resolveRevision(11L, 71L)).thenReturn(new TaskAssetRevision(asset, revision));
+    when(provider.open("9")).thenReturn(executor);
+    when(executor.execute(any())).thenReturn(DataSourceSqlResult.query(
+        List.of(
+            new DataSourceSqlColumn("region", "region", "VARCHAR", Types.VARCHAR, true),
+            new DataSourceSqlColumn("amount", "amount", "DECIMAL", Types.DECIMAL, true)),
+        List.of(
+            List.of("east", 10),
+            List.of("west", 20),
+            List.of("north", 30)),
+        false));
+
+    QueryRevisionDatasetSourceAdapter adapter = new QueryRevisionDatasetSourceAdapter(
+        catalog, provider, new ObjectMapper(), new DatasetQueryCompiler());
+    Dataset dataset = new Dataset(21L, "sales", null, DatasetStatus.ONLINE, 31L, Instant.EPOCH, Instant.EPOCH);
+    DatasetVersion version = new DatasetVersion(
+        31L, 21L, 1, DatasetSourceType.QUERY_REVISION, 11L, 71L, 3, "[]", Instant.EPOCH);
+    List<DatasetField> fields = List.of(
+        new DatasetField("region", 31L, "region", "region", DatasetFieldDataType.STRING, true, null, DatasetFieldRole.DIMENSION, 1),
+        new DatasetField("amount", 31L, "amount", "amount", DatasetFieldDataType.NUMBER, true, null, DatasetFieldRole.MEASURE, 2));
+    DatasetQueryRequest request = new DatasetQueryRequest(
+        null, List.of(), List.of(), List.of(), List.of(), 2, 15);
+
+    DatasetQueryResult result = adapter.execute(dataset, version, fields, request);
+
+    verify(catalog).resolveRevision(11L, 71L);
+    ArgumentCaptor<DataSourceSqlRequest> captor = ArgumentCaptor.forClass(DataSourceSqlRequest.class);
+    verify(executor).execute(captor.capture());
+    assertTrue(captor.getValue().sql().contains("FROM (SELECT region, amount FROM sales) yak_dataset_source"));
+    assertEquals(3, captor.getValue().maxRows());
+    assertEquals(15, captor.getValue().timeoutSeconds());
+    assertEquals(2, result.returnedRows());
+    assertTrue(result.truncated());
+    assertEquals(1, result.datasetVersionNo());
+  }
+}


### PR DESCRIPTION
## 背景

Stage 1 已经建立独立的 Dataset / DatasetVersion / DatasetField 领域与发布链路。本 PR 完成 Stage 2：让 Dashboard、Chart 等消费端通过稳定的 Dataset Query Runtime 查询数据，而不是直接调用数据开发任务的“运行”接口。

核心链路：

```text
Dashboard / Chart
      ↓
DatasetQueryService
      ↓
DatasetVersion（固定不可变版本）
      ↓
DatasetSourceQueryAdapter
      ↓
QUERY_REVISION Adapter
      ↓
TaskCatalogService.resolveRevision(assetId, pinnedRevisionId)
      ↓
DataSourceExecutionProvider
      ↓
Datasource SQL Executor
```

`Dataset Query` 是数据消费语义，`DevelopmentTask Run` 是开发/执行语义，两者保持解耦。

## 本 PR 实现

### 1. Dataset Query Runtime

新增：

```text
POST /api/v1/datasets/{datasetId}/query
```

支持：

- 默认查询 Dataset 当前版本
- 指定 `versionNo` 查询历史不可变 DatasetVersion
- 原始数据预览
- Dimensions
- Metrics
- SUM / AVG / COUNT / COUNT_DISTINCT / MAX / MIN
- EQ / NE / GT / GTE / LT / LTE
- IN / NOT_IN
- LIKE / NOT_LIKE
- BETWEEN
- IS_NULL / IS_NOT_NULL
- 排序
- limit
- timeout

### 2. 真正使用 DatasetVersion 固定 Revision

Runtime 不读取 TaskAsset 当前 Revision 来决定查询内容，而是使用 DatasetVersion 中冻结的：

```text
sourceTaskAssetId
sourceTaskRevisionId
sourceTaskRevisionNo
```

然后通过：

```java
TaskCatalogService.resolveRevision(assetId, pinnedRevisionId)
```

解析不可变 SQL Revision。

因此即使上游 TaskAsset 后续从 V3 发布到 V5，或者发生回滚，已有 DatasetVersion 的查询结果定义也不会静默漂移。

### 3. 独立 Source Adapter

新增：

```text
DatasetSourceQueryAdapter
└── QueryRevisionDatasetSourceAdapter
```

Stage 2 实现 `QUERY_REVISION`。

后续可以继续扩展：

```text
TABLE
VIEW
```

而 Dashboard / DatasetQueryService 无需修改调用方式。

### 4. 不复用 DevelopmentTask Run

`QUERY_REVISION` Runtime 直接复用现有：

```text
DataSourceExecutionProvider
    ↓
DataSourceSqlExecutor
```

数据源账号密码仍由 DataSource domain 内部解析，Dataset Runtime 只持有数据源 ID，不接触连接凭证。

不会创建 DevelopmentTask execution record，也不会引入调度、任务运行状态等开发态语义。

### 5. Read-only SQL Guard

Dataset 来源 SQL 必须是单条只读查询：

- 仅允许 `SELECT` / `WITH`
- 拒绝多语句
- 拒绝 INSERT / UPDATE / DELETE / MERGE
- 拒绝 CREATE / ALTER / DROP / TRUNCATE
- 拒绝 INTO / FOR UPDATE 等副作用语义
- SQL token 检查会忽略字符串、标识符和注释内容，降低误判

查询请求本身不能传任意 SQL / expression；字段只能引用 DatasetField，并对物理字段名做安全白名单检查。

### 6. Semantic Query Compiler

Runtime 会把 ChartSpec 风格的查询转换为：

```sql
SELECT
  dimension,
  SUM(metric)
FROM (
  <immutable source SELECT>
) yak_dataset_source
WHERE ...
GROUP BY ...
ORDER BY ...
LIMIT ...
```

查询端只传稳定 `fieldId`，不会直接拼接用户提供的列名。

### 7. Dataset Schema 自动发现

Stage 1 的发布中心允许不手工填写 DatasetField。Stage 2 增加自动 schema discovery：

```text
发布 Dataset / 新建 DatasetVersion
      ↓
resolve immutable TaskRevision
      ↓
只读执行 SELECT * FROM (<source sql>) LIMIT 1
      ↓
读取 JDBC column metadata
      ↓
冻结 DatasetField + schemaSnapshot
```

字段类型映射：

- JDBC 数值 -> NUMBER
- DATE -> DATE
- TIME / TIMESTAMP -> DATETIME
- VARCHAR / CHAR / CLOB -> STRING
- BOOLEAN / BIT -> BOOLEAN
- 其他 -> UNKNOWN

默认角色：

- NUMBER -> MEASURE
- 其他 -> DIMENSION

同一个 Dataset 中，相同物理字段名称会生成确定性的稳定 `fieldId`，后续 DatasetVersion 可以继续复用 Dashboard 的字段绑定。

### 8. 查询保护

- Dataset 必须为 ONLINE 才能查询
- 默认 limit = 200
- 最大 limit = 1000
- Runtime 实际读取 `limit + 1` 判断是否 truncated
- timeout 最大 120 秒
- schema discovery 最大 30 秒、最多取 1 行
- 单次最多 50 个 filter
- IN / NOT_IN 单条件最多 100 个值
- SQL NULL 单元格正常透传

## Query 示例

```json
{
  "dimensions": ["region-field-id"],
  "metrics": [
    {
      "fieldId": "amount-field-id",
      "aggregation": "SUM"
    }
  ],
  "filters": [
    {
      "fieldId": "region-field-id",
      "operator": "IN",
      "values": ["华东", "华南"]
    }
  ],
  "sorts": [
    {
      "fieldId": "amount-field-id",
      "aggregation": "SUM",
      "direction": "DESC"
    }
  ],
  "limit": 200
}
```

不传 body 时，可作为当前 DatasetVersion 的原始数据预览。

## 测试覆盖

新增测试覆盖：

- Dimensions + Metrics + Filter + Sort SQL 编译
- SQL 字符串转义
- 原始预览
- DML / 多语句拒绝
- SQL 注释、字符串关键字误判保护
- JDBC Schema 自动发现与字段类型映射
- 稳定 fieldId
- DatasetVersion 固定 Revision 查询
- TaskAsset current revision 已变化时仍查询 DatasetVersion pinned revision
- limit + 1 / truncated 行为

## 有意不放在 Stage 2 的内容

- TABLE / VIEW Query Adapter
- Query Cache / Result Cache
- 预聚合
- 跨 Dataset Join
- 自定义 SQL Expression / HAVING
- 可复用 Metric Center
- Dataset 级行列权限模型
- 异步 Query / Cancel API
- Dashboard 前端正式接入 Runtime

这些能力可以建立在本 PR 的 `DatasetQueryService + DatasetSourceQueryAdapter` 边界上继续演进。