### PR TITLE
feat(workflow): add backfill and scheduling parameters

### DIFF
--- a/yak-ops-business/yak-ops-business-workflow/pom.xml
+++ b/yak-ops-business/yak-ops-business-workflow/pom.xml
@@ -43,6 +43,10 @@
             <version>${yak-framework.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.quartz-scheduler</groupId>
+            <artifactId>quartz</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/controller/v1/WorkflowBackfillController.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/controller/v1/WorkflowBackfillController.java
@@ -1,0 +1,72 @@
+package io.yak.ops.business.workflow.controller.v1;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.yak.framework.common.Result;
+import io.yak.ops.business.workflow.service.WorkflowBackfillQuery;
+import io.yak.ops.business.workflow.service.WorkflowBackfillService;
+import io.yak.ops.common.bean.dto.workflow.WorkflowBackfillCreateDTO;
+import io.yak.ops.common.bean.vo.workflow.WorkflowBackfillPreviewVO;
+import io.yak.ops.common.bean.vo.workflow.WorkflowBackfillVO;
+import jakarta.validation.Valid;
+import java.util.List;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/** 工作流历史补数 / Backfill API。 */
+@Tag(name = "工作流补数接口")
+@RestController
+@RequestMapping("/api/v1/workflows/backfills")
+@ConditionalOnProperty(prefix = "yak.database", name = "enabled", havingValue = "true", matchIfMissing = true)
+public class WorkflowBackfillController {
+  private final WorkflowBackfillService service;
+  private final WorkflowBackfillQuery query;
+
+  public WorkflowBackfillController(
+      WorkflowBackfillService service,
+      WorkflowBackfillQuery query) {
+    this.service = service;
+    this.query = query;
+  }
+
+  @Operation(summary = "预览 Backfill 将生成的逻辑计划时间")
+  @PostMapping("/preview")
+  public Result<WorkflowBackfillPreviewVO> preview(
+      @Valid @RequestBody WorkflowBackfillCreateDTO request) {
+    return Result.success(service.preview(request));
+  }
+
+  @Operation(summary = "创建并提交 Backfill 批次")
+  @PostMapping
+  public Result<WorkflowBackfillVO> create(
+      @Valid @RequestBody WorkflowBackfillCreateDTO request) {
+    return Result.success(service.create(request));
+  }
+
+  @Operation(summary = "查询 Backfill 批次")
+  @GetMapping
+  public Result<List<WorkflowBackfillVO>> list(
+      @RequestParam(value = "workflowId", required = false) String workflowId,
+      @RequestParam(value = "scheduleId", required = false) String scheduleId,
+      @RequestParam(value = "status", required = false) String status) {
+    return Result.success(query.list(workflowId, scheduleId, status));
+  }
+
+  @Operation(summary = "查询 Backfill 批次详情")
+  @GetMapping("/{id}")
+  public Result<WorkflowBackfillVO> detail(@PathVariable("id") String id) {
+    return Result.success(query.get(id));
+  }
+
+  @Operation(summary = "取消 Backfill 中尚未启动的计划")
+  @PostMapping("/{id}/cancel")
+  public Result<WorkflowBackfillVO> cancel(@PathVariable("id") String id) {
+    return Result.success(service.cancel(id));
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/controller/v1/WorkflowScheduleQueryController.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/controller/v1/WorkflowScheduleQueryController.java
@@ -44,9 +44,10 @@ public class WorkflowScheduleQueryController {
   public Result<List<WorkflowScheduleTriggerVO>> triggers(
       @RequestParam(value = "scheduleId", required = false) String scheduleId,
       @RequestParam(value = "workflowId", required = false) String workflowId,
+      @RequestParam(value = "backfillId", required = false) String backfillId,
       @RequestParam(value = "status", required = false) String status,
       @RequestParam(value = "limit", required = false, defaultValue = "100") Integer limit) {
-    return Result.success(triggerQuery.list(scheduleId, workflowId, status, limit));
+    return Result.success(triggerQuery.list(scheduleId, workflowId, backfillId, status, limit));
   }
 
   @Operation(summary = "查询工作流调度详情")

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/WorkflowBackfillDao.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/WorkflowBackfillDao.java
@@ -1,0 +1,12 @@
+package io.yak.ops.business.workflow.dao;
+
+import io.yak.ops.common.bean.po.workflow.WorkflowBackfillPO;
+import java.util.List;
+
+/** 工作流 Backfill 批次数据访问接口。 */
+public interface WorkflowBackfillDao {
+  int insert(WorkflowBackfillPO backfill);
+  int update(WorkflowBackfillPO backfill);
+  WorkflowBackfillPO select(String id);
+  List<WorkflowBackfillPO> selectList(String workflowId, String scheduleId);
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/WorkflowScheduleTriggerDao.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/WorkflowScheduleTriggerDao.java
@@ -7,12 +7,21 @@ import java.util.List;
 /** 工作流调度 Trigger Ledger 数据访问接口。 */
 public interface WorkflowScheduleTriggerDao {
   WorkflowScheduleTriggerPO claim(WorkflowScheduleTriggerPO trigger);
+  WorkflowScheduleTriggerPO selectByDedupeKey(String dedupeKey);
   WorkflowScheduleTriggerPO selectBySchedulePlan(String scheduleId, Instant plannedFireTime);
   WorkflowScheduleTriggerPO selectByExecutionId(String executionId);
   WorkflowScheduleTriggerPO selectNextWaiting(String workflowId);
   List<WorkflowScheduleTriggerPO> selectPending();
   List<WorkflowScheduleTriggerPO> selectQueuedBySchedule(String scheduleId);
-  List<WorkflowScheduleTriggerPO> selectTriggers(String scheduleId, String workflowId, String status, int limit);
+  List<WorkflowScheduleTriggerPO> selectByBackfillId(String backfillId);
+  List<WorkflowScheduleTriggerPO> selectTriggers(
+      String scheduleId, String workflowId, String backfillId, String status, int limit);
+
+  default List<WorkflowScheduleTriggerPO> selectTriggers(
+      String scheduleId, String workflowId, String status, int limit) {
+    return selectTriggers(scheduleId, workflowId, null, status, limit);
+  }
+
   int update(WorkflowScheduleTriggerPO trigger);
   int bindPreparedExecution(String triggerId, String executionId);
   void lockWorkflow(String workflowId);

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/impl/WorkflowBackfillDaoImpl.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/impl/WorkflowBackfillDaoImpl.java
@@ -1,0 +1,47 @@
+package io.yak.ops.business.workflow.dao.impl;
+
+import com.baomidou.mybatisplus.core.toolkit.Wrappers;
+import io.yak.ops.business.workflow.dao.WorkflowBackfillDao;
+import io.yak.ops.business.workflow.dao.mapper.WorkflowBackfillMapper;
+import io.yak.ops.common.bean.po.workflow.WorkflowBackfillPO;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.stereotype.Repository;
+
+/** 基于 MyBatis-Plus 的 Backfill 批次 DAO。 */
+@Repository
+@RequiredArgsConstructor
+@DependsOn("workflowFlyway")
+@ConditionalOnProperty(prefix = "yak.database", name = "enabled", havingValue = "true", matchIfMissing = true)
+public class WorkflowBackfillDaoImpl implements WorkflowBackfillDao {
+  private final WorkflowBackfillMapper mapper;
+
+  @Override
+  public int insert(WorkflowBackfillPO backfill) {
+    return mapper.insert(backfill);
+  }
+
+  @Override
+  public int update(WorkflowBackfillPO backfill) {
+    return mapper.updateById(backfill);
+  }
+
+  @Override
+  public WorkflowBackfillPO select(String id) {
+    return mapper.selectById(id);
+  }
+
+  @Override
+  public List<WorkflowBackfillPO> selectList(String workflowId, String scheduleId) {
+    var query = Wrappers.<WorkflowBackfillPO>lambdaQuery();
+    if (workflowId != null && !workflowId.isBlank()) {
+      query.eq(WorkflowBackfillPO::getWorkflowId, workflowId.trim());
+    }
+    if (scheduleId != null && !scheduleId.isBlank()) {
+      query.eq(WorkflowBackfillPO::getScheduleId, scheduleId.trim());
+    }
+    return mapper.selectList(query.orderByDesc(WorkflowBackfillPO::getCreateTime));
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/impl/WorkflowScheduleTriggerDaoImpl.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/impl/WorkflowScheduleTriggerDaoImpl.java
@@ -22,6 +22,14 @@ public class WorkflowScheduleTriggerDaoImpl implements WorkflowScheduleTriggerDa
 
   @Override
   public WorkflowScheduleTriggerPO claim(WorkflowScheduleTriggerPO trigger) {
+    // Stage 4 历史记录没有原生 dedupeKey 语义；先按旧事实键匹配，避免迁移时数据库时区
+    // 影响 DATETIME -> epoch 的字符串结果。Backfill 必须跳过此兼容查询，才能重补同一逻辑时间。
+    if (trigger.getBackfillId() == null || trigger.getBackfillId().isBlank()) {
+      WorkflowScheduleTriggerPO legacy = selectBySchedulePlan(
+          trigger.getScheduleId(), trigger.getPlannedFireTime());
+      if (legacy != null) return legacy;
+    }
+
     mapper.insertIgnore(trigger);
     WorkflowScheduleTriggerPO stored = selectByDedupeKey(trigger.getDedupeKey());
     if (stored == null) {

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/impl/WorkflowScheduleTriggerDaoImpl.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/impl/WorkflowScheduleTriggerDaoImpl.java
@@ -20,27 +20,42 @@ public class WorkflowScheduleTriggerDaoImpl implements WorkflowScheduleTriggerDa
   private static final List<String> PENDING = List.of("RECEIVED", "WAITING", "LAUNCHING", "RUNNING");
   private final WorkflowScheduleTriggerMapper mapper;
 
-  @Override public WorkflowScheduleTriggerPO claim(WorkflowScheduleTriggerPO trigger) {
+  @Override
+  public WorkflowScheduleTriggerPO claim(WorkflowScheduleTriggerPO trigger) {
     mapper.insertIgnore(trigger);
-    WorkflowScheduleTriggerPO stored = selectBySchedulePlan(trigger.getScheduleId(), trigger.getPlannedFireTime());
-    if (stored == null) throw new IllegalStateException(
-        "Trigger Ledger 幂等记录保存失败：" + trigger.getScheduleId() + "@" + trigger.getPlannedFireTime());
+    WorkflowScheduleTriggerPO stored = selectByDedupeKey(trigger.getDedupeKey());
+    if (stored == null) {
+      throw new IllegalStateException("Trigger Ledger 幂等记录保存失败：" + trigger.getDedupeKey());
+    }
     return stored;
   }
 
-  @Override public WorkflowScheduleTriggerPO selectBySchedulePlan(String scheduleId, Instant plannedFireTime) {
+  @Override
+  public WorkflowScheduleTriggerPO selectByDedupeKey(String dedupeKey) {
+    if (dedupeKey == null || dedupeKey.isBlank()) return null;
     return mapper.selectOne(Wrappers.<WorkflowScheduleTriggerPO>lambdaQuery()
-        .eq(WorkflowScheduleTriggerPO::getScheduleId, scheduleId)
-        .eq(WorkflowScheduleTriggerPO::getPlannedFireTime, plannedFireTime));
+        .eq(WorkflowScheduleTriggerPO::getDedupeKey, dedupeKey.trim()));
   }
 
-  @Override public WorkflowScheduleTriggerPO selectByExecutionId(String executionId) {
+  /** 兼容 Stage 4 查询，只返回正常计划/Misfire，不把 Backfill 混进来。 */
+  @Override
+  public WorkflowScheduleTriggerPO selectBySchedulePlan(String scheduleId, Instant plannedFireTime) {
+    return mapper.selectOne(Wrappers.<WorkflowScheduleTriggerPO>lambdaQuery()
+        .eq(WorkflowScheduleTriggerPO::getScheduleId, scheduleId)
+        .eq(WorkflowScheduleTriggerPO::getPlannedFireTime, plannedFireTime)
+        .isNull(WorkflowScheduleTriggerPO::getBackfillId)
+        .last("LIMIT 1"));
+  }
+
+  @Override
+  public WorkflowScheduleTriggerPO selectByExecutionId(String executionId) {
     if (executionId == null || executionId.isBlank()) return null;
     return mapper.selectOne(Wrappers.<WorkflowScheduleTriggerPO>lambdaQuery()
         .eq(WorkflowScheduleTriggerPO::getWorkflowExecutionId, executionId).last("LIMIT 1"));
   }
 
-  @Override public WorkflowScheduleTriggerPO selectNextWaiting(String workflowId) {
+  @Override
+  public WorkflowScheduleTriggerPO selectNextWaiting(String workflowId) {
     return mapper.selectOne(Wrappers.<WorkflowScheduleTriggerPO>lambdaQuery()
         .eq(WorkflowScheduleTriggerPO::getWorkflowId, workflowId)
         .eq(WorkflowScheduleTriggerPO::getStatus, "WAITING")
@@ -48,35 +63,68 @@ public class WorkflowScheduleTriggerDaoImpl implements WorkflowScheduleTriggerDa
         .orderByAsc(WorkflowScheduleTriggerPO::getCreateTime).last("LIMIT 1"));
   }
 
-  @Override public List<WorkflowScheduleTriggerPO> selectPending() {
+  @Override
+  public List<WorkflowScheduleTriggerPO> selectPending() {
     return mapper.selectList(Wrappers.<WorkflowScheduleTriggerPO>lambdaQuery()
         .in(WorkflowScheduleTriggerPO::getStatus, PENDING)
         .orderByAsc(WorkflowScheduleTriggerPO::getPlannedFireTime));
   }
 
-  @Override public List<WorkflowScheduleTriggerPO> selectQueuedBySchedule(String scheduleId) {
+  /** Schedule 停用只取消正常 Cron/Misfire 队列，Backfill 批次独立继续。 */
+  @Override
+  public List<WorkflowScheduleTriggerPO> selectQueuedBySchedule(String scheduleId) {
     return mapper.selectList(Wrappers.<WorkflowScheduleTriggerPO>lambdaQuery()
         .eq(WorkflowScheduleTriggerPO::getScheduleId, scheduleId)
+        .isNull(WorkflowScheduleTriggerPO::getBackfillId)
         .in(WorkflowScheduleTriggerPO::getStatus, List.of("RECEIVED", "WAITING"))
         .orderByAsc(WorkflowScheduleTriggerPO::getPlannedFireTime));
   }
 
-  @Override public List<WorkflowScheduleTriggerPO> selectTriggers(
-      String scheduleId, String workflowId, String status, int limit) {
-    var query = Wrappers.<WorkflowScheduleTriggerPO>lambdaQuery();
-    if (scheduleId != null && !scheduleId.isBlank()) query.eq(WorkflowScheduleTriggerPO::getScheduleId, scheduleId.trim());
-    if (workflowId != null && !workflowId.isBlank()) query.eq(WorkflowScheduleTriggerPO::getWorkflowId, workflowId.trim());
-    if (status != null && !status.isBlank()) query.eq(WorkflowScheduleTriggerPO::getStatus, status.trim().toUpperCase());
-    int safeLimit = Math.max(1, Math.min(limit, 500));
-    return mapper.selectList(query.orderByDesc(WorkflowScheduleTriggerPO::getPlannedFireTime).last("LIMIT " + safeLimit));
+  @Override
+  public List<WorkflowScheduleTriggerPO> selectByBackfillId(String backfillId) {
+    if (backfillId == null || backfillId.isBlank()) return List.of();
+    return mapper.selectList(Wrappers.<WorkflowScheduleTriggerPO>lambdaQuery()
+        .eq(WorkflowScheduleTriggerPO::getBackfillId, backfillId.trim())
+        .orderByAsc(WorkflowScheduleTriggerPO::getPlannedFireTime));
   }
 
-  @Override public int update(WorkflowScheduleTriggerPO trigger) { return mapper.updateById(trigger); }
-  @Override public int bindPreparedExecution(String triggerId, String executionId) {
+  @Override
+  public List<WorkflowScheduleTriggerPO> selectTriggers(
+      String scheduleId,
+      String workflowId,
+      String backfillId,
+      String status,
+      int limit) {
+    var query = Wrappers.<WorkflowScheduleTriggerPO>lambdaQuery();
+    if (scheduleId != null && !scheduleId.isBlank()) {
+      query.eq(WorkflowScheduleTriggerPO::getScheduleId, scheduleId.trim());
+    }
+    if (workflowId != null && !workflowId.isBlank()) {
+      query.eq(WorkflowScheduleTriggerPO::getWorkflowId, workflowId.trim());
+    }
+    if (backfillId != null && !backfillId.isBlank()) {
+      query.eq(WorkflowScheduleTriggerPO::getBackfillId, backfillId.trim());
+    }
+    if (status != null && !status.isBlank()) {
+      query.eq(WorkflowScheduleTriggerPO::getStatus, status.trim().toUpperCase());
+    }
+    int safeLimit = Math.max(1, Math.min(limit, 1000));
+    return mapper.selectList(
+        query.orderByDesc(WorkflowScheduleTriggerPO::getPlannedFireTime).last("LIMIT " + safeLimit));
+  }
+
+  @Override
+  public int update(WorkflowScheduleTriggerPO trigger) {
+    return mapper.updateById(trigger);
+  }
+
+  @Override
+  public int bindPreparedExecution(String triggerId, String executionId) {
     return mapper.bindPreparedExecution(triggerId, executionId);
   }
 
-  @Override public void lockWorkflow(String workflowId) {
+  @Override
+  public void lockWorkflow(String workflowId) {
     String locked = mapper.lockWorkflow(workflowId);
     if (locked == null) throw new IllegalArgumentException("工作流不存在：" + workflowId);
   }

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/mapper/WorkflowBackfillMapper.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/mapper/WorkflowBackfillMapper.java
@@ -1,0 +1,8 @@
+package io.yak.ops.business.workflow.dao.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import io.yak.ops.common.bean.po.workflow.WorkflowBackfillPO;
+
+/** 工作流 Backfill 批次 Mapper。 */
+public interface WorkflowBackfillMapper extends BaseMapper<WorkflowBackfillPO> {
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/mapper/WorkflowScheduleTriggerMapper.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/mapper/WorkflowScheduleTriggerMapper.java
@@ -12,13 +12,13 @@ public interface WorkflowScheduleTriggerMapper extends BaseMapper<WorkflowSchedu
 
   @Insert("""
       INSERT IGNORE INTO yak_workflow_schedule_trigger
-        (id, schedule_id, workflow_id, trigger_id, trigger_source,
-         planned_fire_time, actual_fire_time, execution_strategy, misfire_strategy,
+        (id, schedule_id, workflow_id, backfill_id, trigger_id, dedupe_key, trigger_source,
+         planned_fire_time, actual_fire_time, business_date, execution_strategy, misfire_strategy,
          status, workflow_execution_id, execution_status, message, error_message,
          launched_at, completed_at, create_time, update_time)
       VALUES
-        (#{id}, #{scheduleId}, #{workflowId}, #{triggerId}, #{triggerSource},
-         #{plannedFireTime}, #{actualFireTime}, #{executionStrategy}, #{misfireStrategy},
+        (#{id}, #{scheduleId}, #{workflowId}, #{backfillId}, #{triggerId}, #{dedupeKey}, #{triggerSource},
+         #{plannedFireTime}, #{actualFireTime}, #{businessDate}, #{executionStrategy}, #{misfireStrategy},
          #{status}, #{workflowExecutionId}, #{executionStatus}, #{message}, #{errorMessage},
          #{launchedAt}, #{completedAt}, #{createTime}, #{updateTime})
       """)

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/domain/WorkflowRunInputScope.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/domain/WorkflowRunInputScope.java
@@ -1,0 +1,43 @@
+package io.yak.ops.business.workflow.domain;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * 单次 Launch 调用栈内的 Workflow input 覆盖层。
+ *
+ * <p>调度/Backfill 参数只影响本次 engine.start，不修改不可变 WorkflowVersion。</p>
+ */
+public final class WorkflowRunInputScope {
+  private static final ThreadLocal<Deque<Map<String, Object>>> STACK =
+      ThreadLocal.withInitial(ArrayDeque::new);
+
+  private WorkflowRunInputScope() {
+  }
+
+  public static Scope open(Map<String, Object> overrides) {
+    Map<String, Object> value = overrides == null
+        ? Map.of()
+        : Map.copyOf(new LinkedHashMap<>(overrides));
+    Deque<Map<String, Object>> stack = STACK.get();
+    stack.push(value);
+    return () -> {
+      Deque<Map<String, Object>> current = STACK.get();
+      if (!current.isEmpty()) current.pop();
+      if (current.isEmpty()) STACK.remove();
+    };
+  }
+
+  public static Map<String, Object> current() {
+    Deque<Map<String, Object>> stack = STACK.get();
+    return stack.isEmpty() ? Map.of() : stack.peek();
+  }
+
+  @FunctionalInterface
+  public interface Scope extends AutoCloseable {
+    @Override
+    void close();
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/domain/WorkflowRunSpec.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/domain/WorkflowRunSpec.java
@@ -21,4 +21,17 @@ public record WorkflowRunSpec(
         ? "CONTINUE_INDEPENDENT_BRANCHES"
         : failureStrategy;
   }
+
+  /**
+   * 不修改发布版本本身；仅在统一 Launch 调用栈内把 Schedule/Backfill 参数覆盖到运行 input。
+   * Runtime 最终仍通过 engine.start(definitionId, request.input()) 获取一次不可变输入快照。
+   */
+  @Override
+  public Map<String, Object> input() {
+    Map<String, Object> overrides = WorkflowRunInputScope.current();
+    if (overrides.isEmpty()) return input;
+    Map<String, Object> merged = new LinkedHashMap<>(input);
+    merged.putAll(overrides);
+    return Map.copyOf(merged);
+  }
 }

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/domain/WorkflowScheduleTriggerIdentity.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/domain/WorkflowScheduleTriggerIdentity.java
@@ -1,0 +1,36 @@
+package io.yak.ops.business.workflow.domain;
+
+import java.time.Instant;
+
+/** Trigger Ledger 数据库幂等键。正常计划/Misfire 共用键，Backfill 按批次隔离。 */
+public final class WorkflowScheduleTriggerIdentity {
+  private WorkflowScheduleTriggerIdentity() {
+  }
+
+  public static String scheduled(String scheduleId, Instant plannedFireTime) {
+    return required(scheduleId, "scheduleId 不能为空")
+        + "|SCHEDULE|"
+        + required(plannedFireTime).toEpochMilli();
+  }
+
+  public static String backfill(
+      String scheduleId,
+      String backfillId,
+      Instant plannedFireTime) {
+    return required(scheduleId, "scheduleId 不能为空")
+        + "|BACKFILL|"
+        + required(backfillId, "backfillId 不能为空")
+        + "|"
+        + required(plannedFireTime).toEpochMilli();
+  }
+
+  private static String required(String value, String message) {
+    if (value == null || value.isBlank()) throw new IllegalArgumentException(message);
+    return value.trim();
+  }
+
+  private static Instant required(Instant value) {
+    if (value == null) throw new IllegalArgumentException("plannedFireTime 不能为空");
+    return value;
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/domain/WorkflowTriggerContext.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/domain/WorkflowTriggerContext.java
@@ -13,7 +13,9 @@ public record WorkflowTriggerContext(
     WorkflowTriggerType triggerType,
     String triggerId,
     String scheduleId,
-    Instant plannedFireTime) {
+    String backfillId,
+    Instant plannedFireTime,
+    String timezone) {
 
   public WorkflowTriggerContext {
     if (triggerType == null) {
@@ -21,12 +23,25 @@ public record WorkflowTriggerContext(
     }
     triggerId = required(triggerId, "工作流 triggerId 不能为空");
     scheduleId = trimToNull(scheduleId);
+    backfillId = trimToNull(backfillId);
+    timezone = trimToNull(timezone);
+  }
+
+  /** Stage 1-4 兼容构造器。 */
+  public WorkflowTriggerContext(
+      WorkflowTriggerType triggerType,
+      String triggerId,
+      String scheduleId,
+      Instant plannedFireTime) {
+    this(triggerType, triggerId, scheduleId, null, plannedFireTime, null);
   }
 
   public static WorkflowTriggerContext manual() {
     return new WorkflowTriggerContext(
         WorkflowTriggerType.MANUAL,
         generatedId("manual"),
+        null,
+        null,
         null,
         null);
   }
@@ -36,6 +51,8 @@ public record WorkflowTriggerContext(
         WorkflowTriggerType.API,
         generatedId("api"),
         null,
+        null,
+        null,
         null);
   }
 
@@ -43,6 +60,14 @@ public record WorkflowTriggerContext(
       String triggerId,
       String scheduleId,
       Instant plannedFireTime) {
+    return scheduled(triggerId, scheduleId, plannedFireTime, null);
+  }
+
+  public static WorkflowTriggerContext scheduled(
+      String triggerId,
+      String scheduleId,
+      Instant plannedFireTime,
+      String timezone) {
     String safeScheduleId = required(scheduleId, "工作流 scheduleId 不能为空");
     if (plannedFireTime == null) {
       throw new IllegalArgumentException("调度 plannedFireTime 不能为空");
@@ -51,21 +76,37 @@ public record WorkflowTriggerContext(
         WorkflowTriggerType.SCHEDULE,
         triggerId,
         safeScheduleId,
-        plannedFireTime);
+        null,
+        plannedFireTime,
+        timezone);
   }
 
   public static WorkflowTriggerContext backfill(
       String triggerId,
       String scheduleId,
       Instant plannedFireTime) {
-    if (plannedFireTime == null) {
-      throw new IllegalArgumentException("补数 plannedFireTime 不能为空");
-    }
     return new WorkflowTriggerContext(
         WorkflowTriggerType.BACKFILL,
         triggerId,
         scheduleId,
-        plannedFireTime);
+        null,
+        required(plannedFireTime, "补数 plannedFireTime 不能为空"),
+        null);
+  }
+
+  public static WorkflowTriggerContext backfill(
+      String triggerId,
+      String scheduleId,
+      String backfillId,
+      Instant plannedFireTime,
+      String timezone) {
+    return new WorkflowTriggerContext(
+        WorkflowTriggerType.BACKFILL,
+        triggerId,
+        required(scheduleId, "补数 scheduleId 不能为空"),
+        required(backfillId, "补数 backfillId 不能为空"),
+        required(plannedFireTime, "补数 plannedFireTime 不能为空"),
+        timezone);
   }
 
   private static String generatedId(String prefix) {
@@ -76,6 +117,11 @@ public record WorkflowTriggerContext(
     String normalized = trimToNull(value);
     if (normalized == null) throw new IllegalArgumentException(message);
     return normalized;
+  }
+
+  private static Instant required(Instant value, String message) {
+    if (value == null) throw new IllegalArgumentException(message);
+    return value;
   }
 
   private static String trimToNull(String value) {

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowBackfillPlanner.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowBackfillPlanner.java
@@ -1,0 +1,106 @@
+package io.yak.ops.business.workflow.service;
+
+import java.text.ParseException;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.TimeZone;
+import org.quartz.CronExpression;
+import org.springframework.stereotype.Component;
+
+/** 使用与 Stage 3 Quartz 相同的 Cron 语义生成历史补数逻辑计划时间。 */
+@Component
+public class WorkflowBackfillPlanner {
+  public static final int MAX_OCCURRENCES = 1000;
+  private static final long MAX_RANGE_DAYS = 3660L;
+
+  public Plan plan(
+      String cronExpression,
+      String timezone,
+      LocalDate startBusinessDate,
+      LocalDate endBusinessDate) {
+    if (startBusinessDate == null || endBusinessDate == null) {
+      throw new IllegalArgumentException("补数开始和结束业务日期不能为空");
+    }
+    if (endBusinessDate.isBefore(startBusinessDate)) {
+      throw new IllegalArgumentException("补数结束业务日期不能早于开始业务日期");
+    }
+    long days = ChronoUnit.DAYS.between(startBusinessDate, endBusinessDate) + 1L;
+    if (days > MAX_RANGE_DAYS) {
+      throw new IllegalArgumentException("单次补数业务日期跨度不能超过 " + MAX_RANGE_DAYS + " 天");
+    }
+
+    ZoneId zone = ZoneId.of(required(timezone, "补数时区不能为空"));
+    CronExpression cron = parseCron(cronExpression, zone);
+    Instant rangeStart = startBusinessDate.atStartOfDay(zone).toInstant();
+    Instant rangeEndExclusive = endBusinessDate.plusDays(1).atStartOfDay(zone).toInstant();
+
+    List<Occurrence> occurrences = new ArrayList<>();
+    Date cursor = Date.from(rangeStart.minusMillis(1));
+    while (true) {
+      Date next = cron.getNextValidTimeAfter(cursor);
+      if (next == null) break;
+      Instant instant = next.toInstant();
+      if (!instant.isBefore(rangeEndExclusive)) break;
+      if (!instant.isBefore(rangeStart)) {
+        ZonedDateTime local = instant.atZone(zone);
+        occurrences.add(new Occurrence(
+            local.toLocalDate(),
+            instant,
+            DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(local)));
+        if (occurrences.size() > MAX_OCCURRENCES) {
+          throw new IllegalArgumentException(
+              "单次补数最多生成 " + MAX_OCCURRENCES + " 个计划实例，请缩小日期范围");
+        }
+      }
+      cursor = next;
+    }
+
+    if (occurrences.isEmpty()) {
+      throw new IllegalArgumentException("当前 Cron 在所选业务日期范围内没有可执行计划时间");
+    }
+    return new Plan(zone.getId(), normalizeCron(cronExpression), List.copyOf(occurrences));
+  }
+
+  private CronExpression parseCron(String expression, ZoneId zone) {
+    String normalized = normalizeCron(expression);
+    try {
+      CronExpression cron = new CronExpression(normalized);
+      cron.setTimeZone(TimeZone.getTimeZone(zone));
+      return cron;
+    } catch (ParseException exception) {
+      throw new IllegalArgumentException("补数无法解析 Cron 表达式：" + normalized, exception);
+    }
+  }
+
+  private String normalizeCron(String expression) {
+    String cron = required(expression, "Cron 表达式不能为空").replaceAll("\\s+", " ");
+    String[] fields = cron.split(" ");
+    if (fields.length == 5) return "0 " + cron;
+    if (fields.length == 6 || fields.length == 7) return cron;
+    throw new IllegalArgumentException("Backfill 仅支持 5、6 或 7 字段 Cron 表达式");
+  }
+
+  private String required(String value, String message) {
+    if (value == null || value.isBlank()) throw new IllegalArgumentException(message);
+    return value.trim();
+  }
+
+  public record Plan(
+      String timezone,
+      String cronExpression,
+      List<Occurrence> occurrences) {
+  }
+
+  public record Occurrence(
+      LocalDate businessDate,
+      Instant scheduleInstant,
+      String scheduleTime) {
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowBackfillPlanner.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowBackfillPlanner.java
@@ -37,7 +37,8 @@ public class WorkflowBackfillPlanner {
     }
 
     ZoneId zone = ZoneId.of(required(timezone, "补数时区不能为空"));
-    CronExpression cron = parseCron(cronExpression, zone);
+    String normalizedCron = normalizeCron(cronExpression);
+    CronExpression cron = parseCron(normalizedCron, zone);
     Instant rangeStart = startBusinessDate.atStartOfDay(zone).toInstant();
     Instant rangeEndExclusive = endBusinessDate.plusDays(1).atStartOfDay(zone).toInstant();
 
@@ -65,11 +66,10 @@ public class WorkflowBackfillPlanner {
     if (occurrences.isEmpty()) {
       throw new IllegalArgumentException("当前 Cron 在所选业务日期范围内没有可执行计划时间");
     }
-    return new Plan(zone.getId(), normalizeCron(cronExpression), List.copyOf(occurrences));
+    return new Plan(zone.getId(), normalizedCron, List.copyOf(occurrences));
   }
 
-  private CronExpression parseCron(String expression, ZoneId zone) {
-    String normalized = normalizeCron(expression);
+  private CronExpression parseCron(String normalized, ZoneId zone) {
     try {
       CronExpression cron = new CronExpression(normalized);
       cron.setTimeZone(TimeZone.getTimeZone(zone));
@@ -82,7 +82,22 @@ public class WorkflowBackfillPlanner {
   private String normalizeCron(String expression) {
     String cron = required(expression, "Cron 表达式不能为空").replaceAll("\\s+", " ");
     String[] fields = cron.split(" ");
-    if (fields.length == 5) return "0 " + cron;
+    if (fields.length == 5) {
+      String minute = fields[0];
+      String hour = fields[1];
+      String dayOfMonth = fields[2];
+      String month = fields[3];
+      String dayOfWeek = fields[4];
+      boolean monthDaySpecified = !"*".equals(dayOfMonth) && !"?".equals(dayOfMonth);
+      boolean weekDaySpecified = !"*".equals(dayOfWeek) && !"?".equals(dayOfWeek);
+      if (monthDaySpecified && weekDaySpecified) {
+        throw new IllegalArgumentException(
+            "5 字段 Cron 同时指定日和周时与 Quartz 语义不等价，请改为 6/7 字段 Quartz Cron");
+      }
+      if (weekDaySpecified) dayOfMonth = "?";
+      else dayOfWeek = "?";
+      return String.join(" ", "0", minute, hour, dayOfMonth, month, dayOfWeek);
+    }
     if (fields.length == 6 || fields.length == 7) return cron;
     throw new IllegalArgumentException("Backfill 仅支持 5、6 或 7 字段 Cron 表达式");
   }

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowBackfillQuery.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowBackfillQuery.java
@@ -1,0 +1,113 @@
+package io.yak.ops.business.workflow.service;
+
+import io.yak.ops.business.workflow.dao.WorkflowBackfillDao;
+import io.yak.ops.business.workflow.dao.WorkflowScheduleTriggerDao;
+import io.yak.ops.business.workflow.persistence.support.WorkflowJsonCodec;
+import io.yak.ops.common.bean.po.workflow.WorkflowBackfillPO;
+import io.yak.ops.common.bean.po.workflow.WorkflowScheduleTriggerPO;
+import io.yak.ops.common.bean.vo.workflow.WorkflowBackfillVO;
+import java.util.List;
+import java.util.Locale;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+/** Backfill 批次查询；运行进度直接以 Trigger Ledger 为事实来源。 */
+@Component
+@ConditionalOnProperty(prefix = "yak.database", name = "enabled", havingValue = "true", matchIfMissing = true)
+public class WorkflowBackfillQuery {
+  private final WorkflowBackfillDao dao;
+  private final WorkflowScheduleTriggerDao triggers;
+  private final WorkflowJsonCodec json;
+
+  public WorkflowBackfillQuery(
+      WorkflowBackfillDao dao,
+      WorkflowScheduleTriggerDao triggers,
+      WorkflowJsonCodec json) {
+    this.dao = dao;
+    this.triggers = triggers;
+    this.json = json;
+  }
+
+  public List<WorkflowBackfillVO> list(String workflowId, String scheduleId, String status) {
+    String state = normalize(status);
+    return dao.selectList(workflowId, scheduleId).stream()
+        .map(this::view)
+        .filter(value -> state == null || state.equals(value.status()))
+        .toList();
+  }
+
+  public WorkflowBackfillVO get(String id) {
+    return view(require(id));
+  }
+
+  public WorkflowBackfillPO require(String id) {
+    if (id == null || id.isBlank()) throw new IllegalArgumentException("Backfill ID 不能为空");
+    WorkflowBackfillPO value = dao.select(id.trim());
+    if (value == null) throw new IllegalArgumentException("Backfill 批次不存在：" + id);
+    return value;
+  }
+
+  public WorkflowBackfillVO view(WorkflowBackfillPO value) {
+    List<WorkflowScheduleTriggerPO> items = triggers.selectByBackfillId(value.getId());
+    int waiting = count(items, "RECEIVED") + count(items, "WAITING");
+    int running = count(items, "LAUNCHING") + count(items, "RUNNING");
+    int succeeded = count(items, "SUCCEEDED");
+    int failed = count(items, "FAILED");
+    int canceled = count(items, "CANCELED");
+    int skipped = count(items, "SKIPPED");
+    String status = deriveStatus(value, waiting, running, succeeded, failed, canceled, skipped);
+
+    return new WorkflowBackfillVO(
+        value.getId(),
+        value.getWorkflowId(),
+        value.getWorkflowVersionId(),
+        value.getWorkflowVersionNo(),
+        value.getScheduleId(),
+        value.getScheduleName(),
+        value.getName(),
+        status,
+        value.getStartBusinessDate(),
+        value.getEndBusinessDate(),
+        value.getCronExpression(),
+        value.getTimezone(),
+        value.getExecutionStrategy(),
+        json.readMap(value.getInputJson()),
+        value.getTotalCount() == null ? items.size() : value.getTotalCount(),
+        waiting,
+        running,
+        succeeded,
+        failed,
+        canceled,
+        skipped,
+        value.getCreateTime(),
+        value.getUpdateTime());
+  }
+
+  private String deriveStatus(
+      WorkflowBackfillPO value,
+      int waiting,
+      int running,
+      int succeeded,
+      int failed,
+      int canceled,
+      int skipped) {
+    if ("CANCELED".equals(value.getStatus())) return "CANCELED";
+    if (waiting > 0 || running > 0) return "RUNNING";
+    int total = value.getTotalCount() == null ? 0 : value.getTotalCount();
+    if (total <= 0) return "CREATED";
+    if (succeeded == total) return "SUCCEEDED";
+    if (failed == total) return "FAILED";
+    if (succeeded > 0 && failed + canceled + skipped > 0) return "PARTIAL_SUCCESS";
+    if (failed > 0) return "FAILED";
+    if (canceled + skipped >= total) return "CANCELED";
+    return "PARTIAL_SUCCESS";
+  }
+
+  private int count(List<WorkflowScheduleTriggerPO> values, String status) {
+    return (int) values.stream().filter(value -> status.equals(value.getStatus())).count();
+  }
+
+  private String normalize(String value) {
+    return value == null || value.isBlank() ? null : value.trim().toUpperCase(Locale.ROOT);
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowBackfillReconciler.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowBackfillReconciler.java
@@ -1,0 +1,70 @@
+package io.yak.ops.business.workflow.service;
+
+import io.yak.ops.business.workflow.dao.WorkflowBackfillDao;
+import io.yak.ops.common.bean.po.workflow.WorkflowBackfillPO;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+/**
+ * 启动期恢复 Backfill 批次物化。
+ *
+ * <p>批次定义先持久化，Trigger 再逐条通过 Ledger 提交；如果进程中途退出，
+ * 这里重新按批次快照生成全部 occurrence。已存在 Trigger 由 dedupeKey 幂等拦截，缺失项自动补齐。</p>
+ */
+@Component
+@ConditionalOnProperty(prefix = "yak.database", name = "enabled", havingValue = "true", matchIfMissing = true)
+public class WorkflowBackfillReconciler {
+  private static final Logger log = LoggerFactory.getLogger(WorkflowBackfillReconciler.class);
+
+  private final WorkflowBackfillDao dao;
+  private final WorkflowBackfillPlanner planner;
+  private final WorkflowScheduleTriggerCoordinator coordinator;
+
+  public WorkflowBackfillReconciler(
+      WorkflowBackfillDao dao,
+      WorkflowBackfillPlanner planner,
+      WorkflowScheduleTriggerCoordinator coordinator) {
+    this.dao = dao;
+    this.planner = planner;
+    this.coordinator = coordinator;
+  }
+
+  @Order(15)
+  @EventListener(ApplicationReadyEvent.class)
+  public void reconcile() {
+    List<WorkflowBackfillPO> batches = dao.selectList(null, null).stream()
+        .filter(value -> "RUNNING".equals(value.getStatus()))
+        .toList();
+    for (WorkflowBackfillPO backfill : batches) {
+      try {
+        var plan = planner.plan(
+            backfill.getCronExpression(),
+            backfill.getTimezone(),
+            backfill.getStartBusinessDate(),
+            backfill.getEndBusinessDate());
+        for (var occurrence : plan.occurrences()) {
+          try {
+            coordinator.submitBackfill(backfill, occurrence);
+          } catch (RuntimeException exception) {
+            log.warn(
+                "[workflow-backfill] reconcile occurrence failed backfill={}, businessDate={}, message={}",
+                backfill.getId(), occurrence.businessDate(), exception.getMessage());
+          }
+        }
+        log.info(
+            "[workflow-backfill] reconciled batch={}, occurrences={}",
+            backfill.getId(), plan.occurrences().size());
+      } catch (RuntimeException exception) {
+        log.error(
+            "[workflow-backfill] reconcile batch failed backfill={}, message={}",
+            backfill.getId(), exception.getMessage(), exception);
+      }
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowBackfillService.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowBackfillService.java
@@ -1,0 +1,173 @@
+package io.yak.ops.business.workflow.service;
+
+import io.yak.ops.business.workflow.dao.WorkflowBackfillDao;
+import io.yak.ops.business.workflow.dao.WorkflowScheduleTriggerDao;
+import io.yak.ops.business.workflow.persistence.support.WorkflowJsonCodec;
+import io.yak.ops.business.workflow.service.WorkflowBackfillPlanner.Occurrence;
+import io.yak.ops.business.workflow.service.WorkflowBackfillPlanner.Plan;
+import io.yak.ops.common.bean.dto.workflow.WorkflowBackfillCreateDTO;
+import io.yak.ops.common.bean.po.workflow.WorkflowBackfillPO;
+import io.yak.ops.common.bean.po.workflow.WorkflowSchedulePO;
+import io.yak.ops.common.bean.po.workflow.WorkflowScheduleTriggerPO;
+import io.yak.ops.common.bean.vo.workflow.WorkflowBackfillPreviewVO;
+import io.yak.ops.common.bean.vo.workflow.WorkflowBackfillVO;
+import java.time.Instant;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Service;
+
+/** Backfill 批次创建、预览、取消与 Trigger Ledger 分发。 */
+@Service
+@ConditionalOnProperty(prefix = "yak.database", name = "enabled", havingValue = "true", matchIfMissing = true)
+public class WorkflowBackfillService {
+  private static final Logger log = LoggerFactory.getLogger(WorkflowBackfillService.class);
+  private static final Set<String> STRATEGIES = Set.of("SERIAL_WAIT", "PARALLEL");
+
+  private final WorkflowScheduleQuery schedules;
+  private final WorkflowDefinitionService definitions;
+  private final WorkflowBackfillPlanner planner;
+  private final WorkflowBackfillDao dao;
+  private final WorkflowBackfillQuery query;
+  private final WorkflowScheduleTriggerDao triggers;
+  private final WorkflowScheduleTriggerAdmission admission;
+  private final WorkflowScheduleTriggerCoordinator coordinator;
+  private final WorkflowJsonCodec json;
+
+  public WorkflowBackfillService(
+      WorkflowScheduleQuery schedules,
+      WorkflowDefinitionService definitions,
+      WorkflowBackfillPlanner planner,
+      WorkflowBackfillDao dao,
+      WorkflowBackfillQuery query,
+      WorkflowScheduleTriggerDao triggers,
+      WorkflowScheduleTriggerAdmission admission,
+      WorkflowScheduleTriggerCoordinator coordinator,
+      WorkflowJsonCodec json) {
+    this.schedules = schedules;
+    this.definitions = definitions;
+    this.planner = planner;
+    this.dao = dao;
+    this.query = query;
+    this.triggers = triggers;
+    this.admission = admission;
+    this.coordinator = coordinator;
+    this.json = json;
+  }
+
+  public WorkflowBackfillPreviewVO preview(WorkflowBackfillCreateDTO request) {
+    if (request == null) throw new IllegalArgumentException("Backfill 参数不能为空");
+    WorkflowSchedulePO schedule = schedules.require(request.scheduleId());
+    Plan plan = planner.plan(
+        schedule.getCronExpression(),
+        schedule.getTimezone(),
+        request.startBusinessDate(),
+        request.endBusinessDate());
+    List<WorkflowBackfillPreviewVO.OccurrenceVO> visible = plan.occurrences().stream()
+        .limit(100)
+        .map(value -> new WorkflowBackfillPreviewVO.OccurrenceVO(
+            value.businessDate(), value.scheduleInstant(), value.scheduleTime()))
+        .toList();
+    return new WorkflowBackfillPreviewVO(
+        schedule.getId(),
+        plan.cronExpression(),
+        plan.timezone(),
+        request.startBusinessDate(),
+        request.endBusinessDate(),
+        plan.occurrences().size(),
+        plan.occurrences().size() > visible.size(),
+        visible);
+  }
+
+  public WorkflowBackfillVO create(WorkflowBackfillCreateDTO request) {
+    if (request == null) throw new IllegalArgumentException("Backfill 参数不能为空");
+    WorkflowSchedulePO schedule = schedules.require(request.scheduleId());
+    var workflow = definitions.get(schedule.getWorkflowId());
+    if (!"ONLINE".equals(workflow.status()) || workflow.activeVersionId() == null) {
+      throw new IllegalStateException("工作流需要先发布并上线，才能执行 Backfill");
+    }
+
+    String strategy = strategy(request.executionStrategy());
+    Plan plan = planner.plan(
+        schedule.getCronExpression(),
+        schedule.getTimezone(),
+        request.startBusinessDate(),
+        request.endBusinessDate());
+
+    Instant now = Instant.now();
+    WorkflowBackfillPO backfill = new WorkflowBackfillPO();
+    backfill.setId("workflow-backfill-" + UUID.randomUUID());
+    backfill.setWorkflowId(schedule.getWorkflowId());
+    backfill.setWorkflowVersionId(workflow.activeVersionId());
+    backfill.setWorkflowVersionNo(workflow.activeVersionNo());
+    backfill.setScheduleId(schedule.getId());
+    backfill.setScheduleName(schedule.getName());
+    backfill.setName(name(request, schedule));
+    backfill.setStatus("RUNNING");
+    backfill.setStartBusinessDate(request.startBusinessDate());
+    backfill.setEndBusinessDate(request.endBusinessDate());
+    backfill.setCronExpression(plan.cronExpression());
+    backfill.setTimezone(plan.timezone());
+    backfill.setExecutionStrategy(strategy);
+    backfill.setScheduleInputJson(schedule.getInputJson());
+    backfill.setInputJson(json.write(request.input()));
+    backfill.setTotalCount(plan.occurrences().size());
+    backfill.setCreateTime(now);
+    backfill.setUpdateTime(now);
+    if (dao.insert(backfill) != 1) throw new IllegalStateException("创建 Backfill 批次失败");
+
+    for (Occurrence occurrence : plan.occurrences()) {
+      try {
+        coordinator.submitBackfill(backfill, occurrence);
+      } catch (RuntimeException exception) {
+        // 单个逻辑日期启动失败已经写入 Ledger；批次继续创建其余日期，最终由汇总状态反映失败。
+        log.warn(
+            "[workflow-backfill] dispatch failed backfill={}, businessDate={}, scheduleTime={}, message={}",
+            backfill.getId(),
+            occurrence.businessDate(),
+            occurrence.scheduleTime(),
+            exception.getMessage());
+      }
+    }
+    return query.get(backfill.getId());
+  }
+
+  /** 取消只阻止尚未启动的补数 Trigger，已经 RUNNING 的 WorkflowExecution 继续完成。 */
+  public WorkflowBackfillVO cancel(String id) {
+    WorkflowBackfillPO backfill = query.require(id);
+    if (!"CANCELED".equals(backfill.getStatus())) {
+      backfill.setStatus("CANCELED");
+      backfill.setUpdateTime(Instant.now());
+      if (dao.update(backfill) != 1) throw new IllegalStateException("取消 Backfill 批次失败：" + id);
+    }
+    for (WorkflowScheduleTriggerPO trigger : triggers.selectByBackfillId(backfill.getId())) {
+      if ("RECEIVED".equals(trigger.getStatus()) || "WAITING".equals(trigger.getStatus())) {
+        admission.skip(trigger, "Backfill 批次已取消，尚未启动的 Trigger 跳过");
+      }
+    }
+    return query.get(backfill.getId());
+  }
+
+  private String strategy(String value) {
+    String normalized = value == null || value.isBlank()
+        ? "SERIAL_WAIT"
+        : value.trim().toUpperCase(Locale.ROOT);
+    if (!STRATEGIES.contains(normalized)) {
+      throw new IllegalArgumentException("Backfill 仅支持 SERIAL_WAIT 或 PARALLEL：" + normalized);
+    }
+    return normalized;
+  }
+
+  private String name(WorkflowBackfillCreateDTO request, WorkflowSchedulePO schedule) {
+    if (request.name() != null && !request.name().isBlank()) {
+      String value = request.name().trim();
+      if (value.length() > 120) throw new IllegalArgumentException("Backfill 名称不能超过 120 个字符");
+      return value;
+    }
+    return schedule.getName() + " · " + request.startBusinessDate() + " ~ " + request.endBusinessDate();
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowLaunchService.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowLaunchService.java
@@ -13,6 +13,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 /** 工作流统一启动入口：Trigger -> Launch -> Definition/Runtime。 */
@@ -23,14 +24,26 @@ public class WorkflowLaunchService {
   private final WorkflowDefinitionService definitionService;
   private final WorkflowRuntimeService runtimeService;
   private final WorkflowExecutionTriggerRecorder triggerRecorder;
+  private final WorkflowPublishedVersionRunner publishedVersionRunner;
 
+  @Autowired
   public WorkflowLaunchService(
       WorkflowDefinitionService definitionService,
       WorkflowRuntimeService runtimeService,
-      WorkflowExecutionTriggerRecorder triggerRecorder) {
+      WorkflowExecutionTriggerRecorder triggerRecorder,
+      WorkflowPublishedVersionRunner publishedVersionRunner) {
     this.definitionService = definitionService;
     this.runtimeService = runtimeService;
     this.triggerRecorder = triggerRecorder;
+    this.publishedVersionRunner = publishedVersionRunner;
+  }
+
+  /** Focused tests retain the Stage 4 constructor. */
+  WorkflowLaunchService(
+      WorkflowDefinitionService definitionService,
+      WorkflowRuntimeService runtimeService,
+      WorkflowExecutionTriggerRecorder triggerRecorder) {
+    this(definitionService, runtimeService, triggerRecorder, null);
   }
 
   /** 正式执行当前启用的已发布版本；手工/API 启动仍保持单实例安全默认。 */
@@ -53,10 +66,7 @@ public class WorkflowLaunchService {
   }
 
   /**
-   * 调度协调器专用的发布版本启动入口。
-   *
-   * <p>Trigger Ledger 负责并发准入；WorkflowRunInputScope 只覆盖本次 engine.start 的 input，
-   * 不修改不可变发布版本。Execution 创建时仍通过 binding scope 提前绑定 Ledger。</p>
+   * 正常调度始终 FOLLOW_ACTIVE；运行参数只覆盖本次 engine.start，不修改发布版本。
    */
   public WorkflowDefinitionVO runScheduledPublished(
       String workflowId,
@@ -75,30 +85,31 @@ public class WorkflowLaunchService {
   }
 
   /**
-   * Backfill 运行入口。批次保存创建时 activeVersion 快照；若发布版本已经切换则拒绝继续，
-   * 防止同一补数批次前后使用不同版本。
+   * Backfill 执行创建批次时固定的不可变发布版本，而不是跟随之后变更的 activeVersion。
+   * 工作流下线仍阻止新的补数实例启动，但重新发布 V6 不会把 V5 补数批次切换到 V6。
    */
-  public WorkflowDefinitionVO runBackfillPublished(
+  public WorkflowInstanceVO runBackfillPublished(
       String workflowId,
-      String expectedWorkflowVersionId,
+      String workflowVersionId,
       WorkflowTriggerContext triggerContext,
       Map<String, Object> runtimeInput) {
     String id = required(workflowId, "工作流 ID 不能为空");
-    String versionId = required(expectedWorkflowVersionId, "Backfill workflowVersionId 不能为空");
+    String versionId = required(workflowVersionId, "Backfill workflowVersionId 不能为空");
     WorkflowDefinitionVO current = definitionService.get(id);
-    if (!versionId.equals(current.activeVersionId())) {
-      throw new IllegalStateException(
-          "Backfill 固定的工作流版本已不是当前激活版本：expected="
-              + versionId + ", active=" + current.activeVersionId());
+    if (!"ONLINE".equals(current.status())) {
+      throw new IllegalStateException("工作流已下线，不能启动新的 Backfill 实例");
+    }
+    if (publishedVersionRunner == null) {
+      throw new IllegalStateException("WorkflowPublishedVersionRunner 不可用");
     }
     try (var binding = WorkflowScheduleLaunchBindingScope.open(triggerContext.triggerId());
          var input = WorkflowRunInputScope.open(runtimeInput)) {
       return launch(
           "BACKFILL_PUBLISHED",
-          id,
+          id + "@" + versionId,
           triggerContext,
-          () -> definitionService.runConcurrent(id),
-          WorkflowDefinitionVO::latestExecutionId);
+          () -> publishedVersionRunner.run(id, versionId),
+          WorkflowInstanceVO::id);
     }
   }
 

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowLaunchService.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowLaunchService.java
@@ -1,11 +1,13 @@
 package io.yak.ops.business.workflow.service;
 
+import io.yak.ops.business.workflow.domain.WorkflowRunInputScope;
 import io.yak.ops.business.workflow.domain.WorkflowScheduleLaunchBindingScope;
 import io.yak.ops.business.workflow.domain.WorkflowTriggerContext;
 import io.yak.ops.business.workflow.persistence.WorkflowExecutionTriggerRecorder;
 import io.yak.ops.common.bean.dto.workflow.WorkflowRunDTO;
 import io.yak.ops.common.bean.vo.workflow.WorkflowDefinitionVO;
 import io.yak.ops.common.bean.vo.workflow.WorkflowInstanceVO;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -44,20 +46,55 @@ public class WorkflowLaunchService {
         WorkflowDefinitionVO::latestExecutionId);
   }
 
-  /**
-   * 调度协调器专用的发布版本启动入口。
-   *
-   * <p>并发准入已经由 Trigger Ledger + workflow 行锁完成。作用域会让 ExecutionRepository
-   * 在 engine.start 首次持久化 CREATED 实例时就把 executionId 写回 Ledger，随后才进入 activate，
-   * 从而让宕机恢复能够识别“已经创建但尚未完成 Launch 返回”的实例。</p>
-   */
   public WorkflowDefinitionVO runScheduledPublished(
       String workflowId,
       WorkflowTriggerContext triggerContext) {
+    return runScheduledPublished(workflowId, triggerContext, Map.of());
+  }
+
+  /**
+   * 调度协调器专用的发布版本启动入口。
+   *
+   * <p>Trigger Ledger 负责并发准入；WorkflowRunInputScope 只覆盖本次 engine.start 的 input，
+   * 不修改不可变发布版本。Execution 创建时仍通过 binding scope 提前绑定 Ledger。</p>
+   */
+  public WorkflowDefinitionVO runScheduledPublished(
+      String workflowId,
+      WorkflowTriggerContext triggerContext,
+      Map<String, Object> runtimeInput) {
     String id = required(workflowId, "工作流 ID 不能为空");
-    try (var ignored = WorkflowScheduleLaunchBindingScope.open(triggerContext.triggerId())) {
+    try (var binding = WorkflowScheduleLaunchBindingScope.open(triggerContext.triggerId());
+         var input = WorkflowRunInputScope.open(runtimeInput)) {
       return launch(
           "SCHEDULED_PUBLISHED",
+          id,
+          triggerContext,
+          () -> definitionService.runConcurrent(id),
+          WorkflowDefinitionVO::latestExecutionId);
+    }
+  }
+
+  /**
+   * Backfill 运行入口。批次保存创建时 activeVersion 快照；若发布版本已经切换则拒绝继续，
+   * 防止同一补数批次前后使用不同版本。
+   */
+  public WorkflowDefinitionVO runBackfillPublished(
+      String workflowId,
+      String expectedWorkflowVersionId,
+      WorkflowTriggerContext triggerContext,
+      Map<String, Object> runtimeInput) {
+    String id = required(workflowId, "工作流 ID 不能为空");
+    String versionId = required(expectedWorkflowVersionId, "Backfill workflowVersionId 不能为空");
+    WorkflowDefinitionVO current = definitionService.get(id);
+    if (!versionId.equals(current.activeVersionId())) {
+      throw new IllegalStateException(
+          "Backfill 固定的工作流版本已不是当前激活版本：expected="
+              + versionId + ", active=" + current.activeVersionId());
+    }
+    try (var binding = WorkflowScheduleLaunchBindingScope.open(triggerContext.triggerId());
+         var input = WorkflowRunInputScope.open(runtimeInput)) {
+      return launch(
+          "BACKFILL_PUBLISHED",
           id,
           triggerContext,
           () -> definitionService.runConcurrent(id),
@@ -127,17 +164,17 @@ public class WorkflowLaunchService {
       Function<T, String> executionIdExtractor) {
     Objects.requireNonNull(triggerContext, "workflow trigger context");
     log.info(
-        "[workflow-launch] start mode={}, target={}, triggerType={}, triggerId={}, scheduleId={}, plannedFireTime={}",
+        "[workflow-launch] start mode={}, target={}, triggerType={}, triggerId={}, scheduleId={}, backfillId={}, plannedFireTime={}",
         mode,
         target,
         triggerContext.triggerType(),
         triggerContext.triggerId(),
         triggerContext.scheduleId(),
+        triggerContext.backfillId(),
         triggerContext.plannedFireTime());
     try {
       T result = action.get();
       String executionId = result == null ? null : executionIdExtractor.apply(result);
-      // Ledger 的 executionId 已在首次 CREATED 持久化时提前绑定；这里继续记录通用 runtime trigger metadata。
       triggerRecorder.record(executionId, triggerContext);
       log.info(
           "[workflow-launch] created mode={}, target={}, triggerType={}, triggerId={}, execution={}",

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowPublishedVersionRunner.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowPublishedVersionRunner.java
@@ -1,0 +1,48 @@
+package io.yak.ops.business.workflow.service;
+
+import io.yak.ops.business.workflow.persistence.WorkflowDefinitionPersistence;
+import io.yak.ops.business.workflow.persistence.WorkflowDefinitionPersistence.VersionRecord;
+import io.yak.ops.common.bean.vo.workflow.WorkflowInstanceVO;
+import org.springframework.stereotype.Service;
+
+/**
+ * 直接执行指定不可变发布版本。
+ *
+ * <p>正常 Cron 始终 FOLLOW_ACTIVE；Backfill 在创建批次时固定 workflowVersionId，
+ * 因此后续发布新版本不会改变已经创建的补数批次语义。</p>
+ */
+@Service
+public class WorkflowPublishedVersionRunner {
+  private final WorkflowRuntimeService runtimeService;
+  private final WorkflowDefinitionPersistence persistence;
+
+  public WorkflowPublishedVersionRunner(
+      WorkflowRuntimeService runtimeService,
+      WorkflowDefinitionPersistence persistence) {
+    this.runtimeService = runtimeService;
+    this.persistence = persistence;
+  }
+
+  public WorkflowInstanceVO run(String workflowId, String workflowVersionId) {
+    String id = required(workflowId, "工作流 ID 不能为空");
+    String versionId = required(workflowVersionId, "工作流版本 ID 不能为空");
+    VersionRecord version = persistence.loadVersions(id).stream()
+        .filter(candidate -> versionId.equals(candidate.id()))
+        .findFirst()
+        .orElseThrow(() -> new IllegalArgumentException(
+            "Backfill 固定的工作流发布版本不存在：" + versionId));
+
+    WorkflowInstanceVO prepared = runtimeService.run(
+        version.runSpec(),
+        version.taskVersionsByNode(),
+        version.id(),
+        version.versionNo(),
+        false);
+    return runtimeService.activate(prepared.id());
+  }
+
+  private String required(String value, String message) {
+    if (value == null || value.isBlank()) throw new IllegalArgumentException(message);
+    return value.trim();
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowPublishedVersionRunner.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowPublishedVersionRunner.java
@@ -3,6 +3,7 @@ package io.yak.ops.business.workflow.service;
 import io.yak.ops.business.workflow.persistence.WorkflowDefinitionPersistence;
 import io.yak.ops.business.workflow.persistence.WorkflowDefinitionPersistence.VersionRecord;
 import io.yak.ops.common.bean.vo.workflow.WorkflowInstanceVO;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.stereotype.Service;
 
 /**
@@ -14,11 +15,11 @@ import org.springframework.stereotype.Service;
 @Service
 public class WorkflowPublishedVersionRunner {
   private final WorkflowRuntimeService runtimeService;
-  private final WorkflowDefinitionPersistence persistence;
+  private final ObjectProvider<WorkflowDefinitionPersistence> persistence;
 
   public WorkflowPublishedVersionRunner(
       WorkflowRuntimeService runtimeService,
-      WorkflowDefinitionPersistence persistence) {
+      ObjectProvider<WorkflowDefinitionPersistence> persistence) {
     this.runtimeService = runtimeService;
     this.persistence = persistence;
   }
@@ -26,7 +27,11 @@ public class WorkflowPublishedVersionRunner {
   public WorkflowInstanceVO run(String workflowId, String workflowVersionId) {
     String id = required(workflowId, "工作流 ID 不能为空");
     String versionId = required(workflowVersionId, "工作流版本 ID 不能为空");
-    VersionRecord version = persistence.loadVersions(id).stream()
+    WorkflowDefinitionPersistence catalog = persistence.getIfAvailable();
+    if (catalog == null) {
+      throw new IllegalStateException("Backfill 固定版本执行需要 durable WorkflowDefinitionPersistence");
+    }
+    VersionRecord version = catalog.loadVersions(id).stream()
         .filter(candidate -> versionId.equals(candidate.id()))
         .findFirst()
         .orElseThrow(() -> new IllegalArgumentException(

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowScheduleMisfireRecovery.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowScheduleMisfireRecovery.java
@@ -1,9 +1,11 @@
 package io.yak.ops.business.workflow.service;
 
 import io.yak.ops.business.workflow.dao.WorkflowScheduleTriggerDao;
+import io.yak.ops.business.workflow.domain.WorkflowScheduleTriggerIdentity;
 import io.yak.ops.common.bean.po.workflow.WorkflowSchedulePO;
 import io.yak.ops.common.bean.po.workflow.WorkflowScheduleTriggerPO;
 import java.time.Instant;
+import java.time.ZoneId;
 import java.util.UUID;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
@@ -46,9 +48,12 @@ public class WorkflowScheduleMisfireRecovery {
     value.setWorkflowId(schedule.getWorkflowId());
     value.setTriggerId(
         "workflow-misfire-skip-" + schedule.getId() + "-" + missedFireTime.toEpochMilli());
+    value.setDedupeKey(WorkflowScheduleTriggerIdentity.scheduled(schedule.getId(), missedFireTime));
     value.setTriggerSource("MISFIRE_RECOVERY");
     value.setPlannedFireTime(missedFireTime);
     value.setActualFireTime(now);
+    value.setBusinessDate(
+        missedFireTime.atZone(ZoneId.of(schedule.getTimezone())).toLocalDate());
     value.setExecutionStrategy(schedule.getExecutionStrategy());
     value.setMisfireStrategy(schedule.getMisfireStrategy());
     value.setStatus("SKIPPED");

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowScheduleParameterResolver.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowScheduleParameterResolver.java
@@ -1,0 +1,92 @@
+package io.yak.ops.business.workflow.service;
+
+import io.yak.ops.business.workflow.domain.WorkflowTriggerContext;
+import io.yak.ops.business.workflow.persistence.support.WorkflowJsonCodec;
+import io.yak.ops.common.bean.po.workflow.WorkflowBackfillPO;
+import io.yak.ops.common.bean.po.workflow.WorkflowSchedulePO;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.springframework.stereotype.Component;
+
+/**
+ * 将调度/补数上下文转换为 Workflow input。
+ *
+ * <p>合并优先级：WorkflowVersion input &lt; Schedule input &lt; Backfill input &lt; 系统保留参数。</p>
+ */
+@Component
+public class WorkflowScheduleParameterResolver {
+  public static final String NAMESPACE = "__schedule";
+
+  private final WorkflowJsonCodec json;
+
+  public WorkflowScheduleParameterResolver(WorkflowJsonCodec json) {
+    this.json = json;
+  }
+
+  public Map<String, Object> forSchedule(
+      WorkflowSchedulePO schedule,
+      WorkflowTriggerContext context) {
+    if (schedule == null) throw new IllegalArgumentException("调度定义不能为空");
+    Map<String, Object> result = new LinkedHashMap<>(json.readMap(schedule.getInputJson()));
+    applySystem(
+        result,
+        context,
+        schedule.getTimezone(),
+        schedule.getCronExpression(),
+        null,
+        null);
+    return Map.copyOf(result);
+  }
+
+  public Map<String, Object> forBackfill(
+      WorkflowBackfillPO backfill,
+      WorkflowTriggerContext context) {
+    if (backfill == null) throw new IllegalArgumentException("Backfill 批次不能为空");
+    Map<String, Object> result = new LinkedHashMap<>(json.readMap(backfill.getScheduleInputJson()));
+    result.putAll(json.readMap(backfill.getInputJson()));
+    applySystem(
+        result,
+        context,
+        backfill.getTimezone(),
+        backfill.getCronExpression(),
+        backfill.getWorkflowVersionId(),
+        backfill.getWorkflowVersionNo());
+    return Map.copyOf(result);
+  }
+
+  private void applySystem(
+      Map<String, Object> target,
+      WorkflowTriggerContext context,
+      String timezone,
+      String cronExpression,
+      String workflowVersionId,
+      Integer workflowVersionNo) {
+    if (context == null || context.plannedFireTime() == null) {
+      throw new IllegalArgumentException("调度参数缺少逻辑计划时间");
+    }
+    ZoneId zone = ZoneId.of(timezone == null || timezone.isBlank() ? "UTC" : timezone.trim());
+    Instant planned = context.plannedFireTime();
+    ZonedDateTime local = planned.atZone(zone);
+
+    Map<String, Object> system = new LinkedHashMap<>();
+    system.put("businessDate", local.toLocalDate().toString());
+    system.put("scheduleTime", DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(local));
+    system.put("scheduleTimezone", zone.getId());
+    system.put("plannedFireTime", planned.toString());
+    system.put("triggerType", context.triggerType().name());
+    system.put("triggerId", context.triggerId());
+    system.put("scheduleId", context.scheduleId());
+    if (context.backfillId() != null) system.put("backfillId", context.backfillId());
+    if (cronExpression != null) system.put("cronExpression", cronExpression);
+    if (workflowVersionId != null) system.put("workflowVersionId", workflowVersionId);
+    if (workflowVersionNo != null) system.put("workflowVersionNo", workflowVersionNo);
+
+    // 顶层别名方便 SQL/同步任务直接使用；系统参数始终覆盖用户同名参数。
+    system.forEach(target::put);
+    target.put(NAMESPACE, Map.copyOf(system));
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowScheduleTriggerAdmission.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowScheduleTriggerAdmission.java
@@ -33,22 +33,32 @@ public class WorkflowScheduleTriggerAdmission {
     this.executions = executions;
   }
 
+  /** Stage 4 兼容入口；策略事实已经固化到 candidate，不再依赖当前 Schedule 配置。 */
   @Transactional(transactionManager = "yakBusinessTransactionManager")
   public AdmissionResult admitNew(WorkflowSchedulePO schedule, WorkflowScheduleTriggerPO candidate) {
+    return admitNew(candidate);
+  }
+
+  @Transactional(transactionManager = "yakBusinessTransactionManager")
+  public AdmissionResult admitNew(WorkflowScheduleTriggerPO candidate) {
     WorkflowScheduleTriggerPO trigger = ledger.claim(candidate);
-    // INSERT IGNORE 后只有 candidate 自己的 id 与落库行一致时才拥有首次准入权。
-    // 即使两个相同 plannedFireTime 并发请求都读到 RECEIVED，第二个也会作为 duplicate 返回。
     if (!candidate.getId().equals(trigger.getId()) || !"RECEIVED".equals(trigger.getStatus())) {
       return new AdmissionResult(trigger, false, true);
     }
-    ledger.lockWorkflow(schedule.getWorkflowId());
-    return decideLocked(schedule, trigger);
+    ledger.lockWorkflow(trigger.getWorkflowId());
+    return decideLocked(trigger);
+  }
+
+  /** Stage 4 兼容入口。 */
+  @Transactional(transactionManager = "yakBusinessTransactionManager")
+  public AdmissionResult readmit(WorkflowSchedulePO schedule, WorkflowScheduleTriggerPO candidate) {
+    return readmit(candidate);
   }
 
   /** 启动恢复时重新处理 RECEIVED/无绑定 LAUNCHING 中间态。 */
   @Transactional(transactionManager = "yakBusinessTransactionManager")
-  public AdmissionResult readmit(WorkflowSchedulePO schedule, WorkflowScheduleTriggerPO candidate) {
-    ledger.lockWorkflow(schedule.getWorkflowId());
+  public AdmissionResult readmit(WorkflowScheduleTriggerPO candidate) {
+    ledger.lockWorkflow(candidate.getWorkflowId());
     WorkflowScheduleTriggerPO trigger = current(candidate);
     if (LEDGER_TERMINAL.contains(trigger.getStatus()) || "RUNNING".equals(trigger.getStatus())) {
       return new AdmissionResult(trigger, false, true);
@@ -60,7 +70,7 @@ public class WorkflowScheduleTriggerAdmission {
     trigger.setErrorMessage(null);
     touch(trigger);
     save(trigger);
-    return decideLocked(schedule, trigger);
+    return decideLocked(trigger);
   }
 
   /** 启动完成后绑定业务实例；若实例已同步终态，同时预留下一条 SERIAL_WAIT。 */
@@ -164,11 +174,11 @@ public class WorkflowScheduleTriggerAdmission {
     markSkipped(trigger, message);
   }
 
-  private AdmissionResult decideLocked(WorkflowSchedulePO schedule, WorkflowScheduleTriggerPO trigger) {
-    String strategy = schedule.getExecutionStrategy();
-    long active = ledger.countActiveExecutions(schedule.getWorkflowId());
-    long launching = ledger.countLaunchingTriggers(schedule.getWorkflowId());
-    long waiting = ledger.countWaitingTriggers(schedule.getWorkflowId());
+  private AdmissionResult decideLocked(WorkflowScheduleTriggerPO trigger) {
+    String strategy = trigger.getExecutionStrategy();
+    long active = ledger.countActiveExecutions(trigger.getWorkflowId());
+    long launching = ledger.countLaunchingTriggers(trigger.getWorkflowId());
+    long waiting = ledger.countWaitingTriggers(trigger.getWorkflowId());
     boolean busy = active > 0L || launching > 0L || waiting > 0L;
 
     if ("SERIAL_DISCARD".equals(strategy) && busy) {
@@ -195,18 +205,25 @@ public class WorkflowScheduleTriggerAdmission {
     while (true) {
       WorkflowScheduleTriggerPO waiting = ledger.selectNextWaiting(workflowId);
       if (waiting == null) return AdmissionResult.none();
-      WorkflowSchedulePO schedule = safeSchedule(waiting.getScheduleId());
-      if (schedule == null || !"ONLINE".equals(schedule.getStatus())) {
-        markSkipped(waiting, "等待期间调度已停用或删除");
-        continue;
+
+      if (!isBackfill(waiting)) {
+        WorkflowSchedulePO schedule = safeSchedule(waiting.getScheduleId());
+        if (schedule == null || !"ONLINE".equals(schedule.getStatus())) {
+          markSkipped(waiting, "等待期间调度已停用或删除");
+          continue;
+        }
       }
-      if (!"SERIAL_WAIT".equals(schedule.getExecutionStrategy())) {
-        markSkipped(waiting, "等待期间执行策略已变更，旧 Trigger 不再推进");
+      if (!"SERIAL_WAIT".equals(waiting.getExecutionStrategy())) {
+        markSkipped(waiting, "等待期间执行策略不是 SERIAL_WAIT，旧 Trigger 不再推进");
         continue;
       }
       reserveLaunch(waiting);
       return new AdmissionResult(waiting, true, false);
     }
+  }
+
+  private boolean isBackfill(WorkflowScheduleTriggerPO trigger) {
+    return trigger.getBackfillId() != null && !trigger.getBackfillId().isBlank();
   }
 
   private void reserveLaunch(WorkflowScheduleTriggerPO trigger) {
@@ -246,7 +263,7 @@ public class WorkflowScheduleTriggerAdmission {
   }
 
   private WorkflowScheduleTriggerPO current(WorkflowScheduleTriggerPO candidate) {
-    WorkflowScheduleTriggerPO current = ledger.selectBySchedulePlan(candidate.getScheduleId(), candidate.getPlannedFireTime());
+    WorkflowScheduleTriggerPO current = ledger.selectByDedupeKey(candidate.getDedupeKey());
     if (current == null) throw new IllegalArgumentException("Trigger Ledger 不存在：" + candidate.getId());
     return current;
   }
@@ -259,7 +276,9 @@ public class WorkflowScheduleTriggerAdmission {
     }
   }
 
-  private void touch(WorkflowScheduleTriggerPO trigger) { trigger.setUpdateTime(Instant.now()); }
+  private void touch(WorkflowScheduleTriggerPO trigger) {
+    trigger.setUpdateTime(Instant.now());
+  }
 
   private void save(WorkflowScheduleTriggerPO trigger) {
     if (ledger.update(trigger) != 1) throw new IllegalStateException("更新 Trigger Ledger 失败：" + trigger.getId());
@@ -276,6 +295,8 @@ public class WorkflowScheduleTriggerAdmission {
   }
 
   public record AdmissionResult(WorkflowScheduleTriggerPO trigger, boolean launchNow, boolean duplicate) {
-    static AdmissionResult none() { return new AdmissionResult(null, false, false); }
+    static AdmissionResult none() {
+      return new AdmissionResult(null, false, false);
+    }
   }
 }

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowScheduleTriggerCoordinator.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowScheduleTriggerCoordinator.java
@@ -2,22 +2,28 @@ package io.yak.ops.business.workflow.service;
 
 import io.yak.framework.schedule.api.ScheduleExecutionResult;
 import io.yak.ops.business.workflow.dao.WorkflowScheduleTriggerDao;
+import io.yak.ops.business.workflow.domain.WorkflowScheduleTriggerIdentity;
 import io.yak.ops.business.workflow.domain.WorkflowTriggerContext;
+import io.yak.ops.business.workflow.service.WorkflowBackfillPlanner.Occurrence;
 import io.yak.ops.business.workflow.service.WorkflowScheduleTriggerAdmission.AdmissionResult;
+import io.yak.ops.common.bean.po.workflow.WorkflowBackfillPO;
 import io.yak.ops.common.bean.po.workflow.WorkflowSchedulePO;
 import io.yak.ops.common.bean.po.workflow.WorkflowScheduleTriggerPO;
 import io.yak.ops.common.bean.vo.workflow.WorkflowDefinitionVO;
 import java.time.Instant;
+import java.time.ZoneId;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
-/** Trigger Ledger、幂等与 WorkflowExecution 并发策略统一协调器。 */
+/** Trigger Ledger、幂等、Backfill 与 WorkflowExecution 并发策略统一协调器。 */
 @Component
 @ConditionalOnProperty(prefix = "yak.database", name = "enabled", havingValue = "true", matchIfMissing = true)
 public class WorkflowScheduleTriggerCoordinator {
@@ -27,16 +33,32 @@ public class WorkflowScheduleTriggerCoordinator {
   private final WorkflowScheduleQuery schedules;
   private final WorkflowLaunchService launchService;
   private final WorkflowScheduleTriggerAdmission admission;
+  private final WorkflowBackfillQuery backfills;
+  private final WorkflowScheduleParameterResolver parameters;
 
+  @Autowired
   public WorkflowScheduleTriggerCoordinator(
       WorkflowScheduleTriggerDao ledger,
       WorkflowScheduleQuery schedules,
       WorkflowLaunchService launchService,
-      WorkflowScheduleTriggerAdmission admission) {
+      WorkflowScheduleTriggerAdmission admission,
+      WorkflowBackfillQuery backfills,
+      WorkflowScheduleParameterResolver parameters) {
     this.ledger = ledger;
     this.schedules = schedules;
     this.launchService = launchService;
     this.admission = admission;
+    this.backfills = backfills;
+    this.parameters = parameters;
+  }
+
+  /** Focused Stage 4 tests retain the original constructor shape. */
+  WorkflowScheduleTriggerCoordinator(
+      WorkflowScheduleTriggerDao ledger,
+      WorkflowScheduleQuery schedules,
+      WorkflowLaunchService launchService,
+      WorkflowScheduleTriggerAdmission admission) {
+    this(ledger, schedules, launchService, admission, null, null);
   }
 
   public ScheduleExecutionResult submit(
@@ -47,13 +69,25 @@ public class WorkflowScheduleTriggerCoordinator {
       String triggerSource) {
     AdmissionResult result = admission.admitNew(
         schedule,
-        newTrigger(schedule, triggerId, plannedFireTime, actualFireTime, triggerSource));
+        newScheduleTrigger(schedule, triggerId, plannedFireTime, actualFireTime, triggerSource));
+    return handleAdmission(result, "工作流调度 Trigger 已获得执行准入");
+  }
+
+  public ScheduleExecutionResult submitBackfill(
+      WorkflowBackfillPO backfill,
+      Occurrence occurrence) {
+    AdmissionResult result = admission.admitNew(newBackfillTrigger(backfill, occurrence));
+    return handleAdmission(result, "Backfill Trigger 已获得执行准入");
+  }
+
+  private ScheduleExecutionResult handleAdmission(AdmissionResult result, String acceptedMessage) {
     if (result.duplicate()) return duplicateResult(result.trigger());
     if (!result.launchNow()) {
-      return ScheduleExecutionResult.accepted(result.trigger().getWorkflowExecutionId(), result.trigger().getMessage());
+      return ScheduleExecutionResult.accepted(
+          result.trigger().getWorkflowExecutionId(), result.trigger().getMessage());
     }
     String executionId = launchReserved(result);
-    return ScheduleExecutionResult.accepted(executionId, "工作流调度 Trigger 已获得执行准入");
+    return ScheduleExecutionResult.accepted(executionId, acceptedMessage);
   }
 
   public ScheduleExecutionResult recoverMisfire(
@@ -64,7 +98,7 @@ public class WorkflowScheduleTriggerCoordinator {
     return submit(schedule, triggerId, plannedFireTime, actualFireTime, "MISFIRE_RECOVERY");
   }
 
-  /** 应用重启后修复 Ledger 中间态，并恢复 SERIAL_WAIT 队列。 */
+  /** 应用重启后修复 Ledger 中间态，并恢复 SERIAL_WAIT / Backfill 队列。 */
   public void recoverPending() {
     List<WorkflowScheduleTriggerPO> pending = ledger.selectPending();
     Set<String> waitingWorkflows = new LinkedHashSet<>();
@@ -83,11 +117,10 @@ public class WorkflowScheduleTriggerCoordinator {
           continue;
         }
         if (recovered.trigger() != null && "RECEIVED".equals(recovered.trigger().getStatus())) {
-          WorkflowSchedulePO schedule = safeSchedule(trigger.getScheduleId());
-          if (schedule == null || !"ONLINE".equals(schedule.getStatus())) {
-            admission.skip(recovered.trigger(), "原 WorkflowExecution 已不存在且调度已停用，恢复时跳过");
+          if (!runnable(recovered.trigger())) {
+            admission.skip(recovered.trigger(), "原 WorkflowExecution 已不存在且触发来源不可继续，恢复时跳过");
           } else {
-            AdmissionResult readmitted = admission.readmit(schedule, recovered.trigger());
+            AdmissionResult readmitted = admission.readmit(recovered.trigger());
             if (readmitted.launchNow()) launchReserved(readmitted);
             else if (readmitted.trigger() != null && "WAITING".equals(readmitted.trigger().getStatus())) {
               waitingWorkflows.add(trigger.getWorkflowId());
@@ -97,9 +130,8 @@ public class WorkflowScheduleTriggerCoordinator {
         continue;
       }
 
-      WorkflowSchedulePO schedule = safeSchedule(trigger.getScheduleId());
-      if (schedule == null || !"ONLINE".equals(schedule.getStatus())) {
-        admission.skip(trigger, "调度已停用或删除，启动恢复时跳过未启动 Trigger");
+      if (!runnable(trigger)) {
+        admission.skip(trigger, "调度/Backfill 已不可继续，启动恢复时跳过未启动 Trigger");
         continue;
       }
       if ("WAITING".equals(trigger.getStatus())) {
@@ -107,7 +139,7 @@ public class WorkflowScheduleTriggerCoordinator {
         continue;
       }
 
-      AdmissionResult readmitted = admission.readmit(schedule, trigger);
+      AdmissionResult readmitted = admission.readmit(trigger);
       if (readmitted.launchNow()) launchReserved(readmitted);
       else if (readmitted.trigger() != null && "WAITING".equals(readmitted.trigger().getStatus())) {
         waitingWorkflows.add(trigger.getWorkflowId());
@@ -131,32 +163,41 @@ public class WorkflowScheduleTriggerCoordinator {
 
     while (current != null && current.launchNow() && current.trigger() != null) {
       WorkflowScheduleTriggerPO trigger = current.trigger();
-      WorkflowSchedulePO schedule = safeSchedule(trigger.getScheduleId());
-      if (schedule == null || !"ONLINE".equals(schedule.getStatus())) {
-        admission.skip(trigger, "获得执行准入后调度已停用或删除，本次 Trigger 跳过");
+      if (!runnable(trigger)) {
+        admission.skip(trigger, "获得执行准入后调度/Backfill 已不可继续，本次 Trigger 跳过");
         current = admission.reserveNext(trigger.getWorkflowId());
         continue;
       }
 
       try {
-        WorkflowDefinitionVO launched = launchService.runScheduledPublished(
-            schedule.getWorkflowId(),
-            WorkflowTriggerContext.scheduled(
-                trigger.getTriggerId(), schedule.getId(), trigger.getPlannedFireTime()));
+        WorkflowDefinitionVO launched = isBackfill(trigger)
+            ? launchBackfill(trigger)
+            : launchSchedule(trigger);
         String executionId = launched.latestExecutionId();
         if (executionId == null || executionId.isBlank()) {
           throw new IllegalStateException("工作流启动成功但未返回 WorkflowExecution ID");
         }
         if (firstExecutionId == null) firstExecutionId = executionId;
         log.info(
-            "[workflow-schedule-ledger] launched trigger={}, schedule={}, workflow={}, execution={}, strategy={}",
-            trigger.getId(), schedule.getId(), schedule.getWorkflowId(), executionId, schedule.getExecutionStrategy());
+            "[workflow-schedule-ledger] launched trigger={}, source={}, schedule={}, backfill={}, workflow={}, execution={}, strategy={}, businessDate={}",
+            trigger.getId(),
+            trigger.getTriggerSource(),
+            trigger.getScheduleId(),
+            trigger.getBackfillId(),
+            trigger.getWorkflowId(),
+            executionId,
+            trigger.getExecutionStrategy(),
+            trigger.getBusinessDate());
         current = admission.bindLaunch(trigger, executionId);
       } catch (RuntimeException exception) {
         if (firstFailure == null) firstFailure = exception;
         log.warn(
-            "[workflow-schedule-ledger] launch failed trigger={}, schedule={}, workflow={}, message={}",
-            trigger.getId(), trigger.getScheduleId(), trigger.getWorkflowId(), exception.getMessage());
+            "[workflow-schedule-ledger] launch failed trigger={}, schedule={}, backfill={}, workflow={}, message={}",
+            trigger.getId(),
+            trigger.getScheduleId(),
+            trigger.getBackfillId(),
+            trigger.getWorkflowId(),
+            exception.getMessage());
         current = admission.failLaunch(trigger, exception);
       }
     }
@@ -165,7 +206,35 @@ public class WorkflowScheduleTriggerCoordinator {
     return firstExecutionId;
   }
 
-  private WorkflowScheduleTriggerPO newTrigger(
+  private WorkflowDefinitionVO launchSchedule(WorkflowScheduleTriggerPO trigger) {
+    WorkflowSchedulePO schedule = schedules.require(trigger.getScheduleId());
+    WorkflowTriggerContext context = WorkflowTriggerContext.scheduled(
+        trigger.getTriggerId(),
+        schedule.getId(),
+        trigger.getPlannedFireTime(),
+        schedule.getTimezone());
+    Map<String, Object> input = parameters == null ? Map.of() : parameters.forSchedule(schedule, context);
+    return launchService.runScheduledPublished(schedule.getWorkflowId(), context, input);
+  }
+
+  private WorkflowDefinitionVO launchBackfill(WorkflowScheduleTriggerPO trigger) {
+    if (backfills == null) throw new IllegalStateException("Backfill 查询服务不可用");
+    WorkflowBackfillPO backfill = backfills.require(trigger.getBackfillId());
+    WorkflowTriggerContext context = WorkflowTriggerContext.backfill(
+        trigger.getTriggerId(),
+        backfill.getScheduleId(),
+        backfill.getId(),
+        trigger.getPlannedFireTime(),
+        backfill.getTimezone());
+    Map<String, Object> input = parameters == null ? Map.of() : parameters.forBackfill(backfill, context);
+    return launchService.runBackfillPublished(
+        backfill.getWorkflowId(),
+        backfill.getWorkflowVersionId(),
+        context,
+        input);
+  }
+
+  private WorkflowScheduleTriggerPO newScheduleTrigger(
       WorkflowSchedulePO schedule,
       String triggerId,
       Instant plannedFireTime,
@@ -180,11 +249,39 @@ public class WorkflowScheduleTriggerCoordinator {
     value.setScheduleId(schedule.getId());
     value.setWorkflowId(schedule.getWorkflowId());
     value.setTriggerId(required(triggerId, "triggerId 不能为空"));
+    value.setDedupeKey(WorkflowScheduleTriggerIdentity.scheduled(schedule.getId(), plannedFireTime));
     value.setTriggerSource(triggerSource == null || triggerSource.isBlank() ? "CRON" : triggerSource.trim());
     value.setPlannedFireTime(plannedFireTime);
     value.setActualFireTime(actual);
+    value.setBusinessDate(plannedFireTime.atZone(ZoneId.of(schedule.getTimezone())).toLocalDate());
     value.setExecutionStrategy(schedule.getExecutionStrategy());
     value.setMisfireStrategy(schedule.getMisfireStrategy());
+    value.setStatus("RECEIVED");
+    value.setCreateTime(now);
+    value.setUpdateTime(now);
+    return value;
+  }
+
+  private WorkflowScheduleTriggerPO newBackfillTrigger(
+      WorkflowBackfillPO backfill,
+      Occurrence occurrence) {
+    if (backfill == null || occurrence == null) throw new IllegalArgumentException("Backfill Trigger 参数不能为空");
+    Instant planned = occurrence.scheduleInstant();
+    Instant now = Instant.now();
+    WorkflowScheduleTriggerPO value = new WorkflowScheduleTriggerPO();
+    value.setId("workflow-trigger-ledger-" + UUID.randomUUID());
+    value.setScheduleId(backfill.getScheduleId());
+    value.setWorkflowId(backfill.getWorkflowId());
+    value.setBackfillId(backfill.getId());
+    value.setTriggerId("workflow-backfill-" + backfill.getId() + "-" + planned.toEpochMilli());
+    value.setDedupeKey(WorkflowScheduleTriggerIdentity.backfill(
+        backfill.getScheduleId(), backfill.getId(), planned));
+    value.setTriggerSource("BACKFILL");
+    value.setPlannedFireTime(planned);
+    value.setActualFireTime(now);
+    value.setBusinessDate(occurrence.businessDate());
+    value.setExecutionStrategy(backfill.getExecutionStrategy());
+    value.setMisfireStrategy("FIRE_ONCE");
     value.setStatus("RECEIVED");
     value.setCreateTime(now);
     value.setUpdateTime(now);
@@ -197,9 +294,31 @@ public class WorkflowScheduleTriggerCoordinator {
         "重复计划触发已由 Trigger Ledger 幂等拦截，复用状态 " + trigger.getStatus());
   }
 
+  private boolean runnable(WorkflowScheduleTriggerPO trigger) {
+    if (isBackfill(trigger)) {
+      WorkflowBackfillPO value = safeBackfill(trigger.getBackfillId());
+      return value != null && !"CANCELED".equals(value.getStatus());
+    }
+    WorkflowSchedulePO schedule = safeSchedule(trigger.getScheduleId());
+    return schedule != null && "ONLINE".equals(schedule.getStatus());
+  }
+
+  private boolean isBackfill(WorkflowScheduleTriggerPO trigger) {
+    return trigger.getBackfillId() != null && !trigger.getBackfillId().isBlank();
+  }
+
   private WorkflowSchedulePO safeSchedule(String scheduleId) {
     try {
       return schedules.require(scheduleId);
+    } catch (IllegalArgumentException missing) {
+      return null;
+    }
+  }
+
+  private WorkflowBackfillPO safeBackfill(String backfillId) {
+    if (backfills == null) return null;
+    try {
+      return backfills.require(backfillId);
     } catch (IllegalArgumentException missing) {
       return null;
     }

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowScheduleTriggerCoordinator.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowScheduleTriggerCoordinator.java
@@ -10,6 +10,7 @@ import io.yak.ops.common.bean.po.workflow.WorkflowBackfillPO;
 import io.yak.ops.common.bean.po.workflow.WorkflowSchedulePO;
 import io.yak.ops.common.bean.po.workflow.WorkflowScheduleTriggerPO;
 import io.yak.ops.common.bean.vo.workflow.WorkflowDefinitionVO;
+import io.yak.ops.common.bean.vo.workflow.WorkflowInstanceVO;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.util.LinkedHashSet;
@@ -170,10 +171,14 @@ public class WorkflowScheduleTriggerCoordinator {
       }
 
       try {
-        WorkflowDefinitionVO launched = isBackfill(trigger)
-            ? launchBackfill(trigger)
-            : launchSchedule(trigger);
-        String executionId = launched.latestExecutionId();
+        String executionId;
+        if (isBackfill(trigger)) {
+          WorkflowInstanceVO launched = launchBackfill(trigger);
+          executionId = launched.id();
+        } else {
+          WorkflowDefinitionVO launched = launchSchedule(trigger);
+          executionId = launched.latestExecutionId();
+        }
         if (executionId == null || executionId.isBlank()) {
           throw new IllegalStateException("工作流启动成功但未返回 WorkflowExecution ID");
         }
@@ -217,7 +222,7 @@ public class WorkflowScheduleTriggerCoordinator {
     return launchService.runScheduledPublished(schedule.getWorkflowId(), context, input);
   }
 
-  private WorkflowDefinitionVO launchBackfill(WorkflowScheduleTriggerPO trigger) {
+  private WorkflowInstanceVO launchBackfill(WorkflowScheduleTriggerPO trigger) {
     if (backfills == null) throw new IllegalStateException("Backfill 查询服务不可用");
     WorkflowBackfillPO backfill = backfills.require(trigger.getBackfillId());
     WorkflowTriggerContext context = WorkflowTriggerContext.backfill(

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowScheduleTriggerQuery.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowScheduleTriggerQuery.java
@@ -23,14 +23,24 @@ public class WorkflowScheduleTriggerQuery {
   }
 
   public List<WorkflowScheduleTriggerVO> list(
-      String scheduleId, String workflowId, String status, Integer limit) {
+      String scheduleId,
+      String workflowId,
+      String backfillId,
+      String status,
+      Integer limit) {
     String state = normalize(status);
     if (state != null && !STATUSES.contains(state)) {
       throw new IllegalArgumentException("不支持的 Trigger 状态：" + state);
     }
     int safeLimit = limit == null ? 100 : limit;
-    return dao.selectTriggers(scheduleId, workflowId, state, safeLimit)
+    return dao.selectTriggers(scheduleId, workflowId, backfillId, state, safeLimit)
         .stream().map(this::view).toList();
+  }
+
+  /** Stage 4 兼容入口。 */
+  public List<WorkflowScheduleTriggerVO> list(
+      String scheduleId, String workflowId, String status, Integer limit) {
+    return list(scheduleId, workflowId, null, status, limit);
   }
 
   WorkflowScheduleTriggerVO view(WorkflowScheduleTriggerPO value) {
@@ -38,8 +48,10 @@ public class WorkflowScheduleTriggerQuery {
         value.getId(),
         value.getScheduleId(),
         value.getWorkflowId(),
+        value.getBackfillId(),
         value.getTriggerId(),
         value.getTriggerSource(),
+        value.getBusinessDate(),
         value.getPlannedFireTime(),
         value.getActualFireTime(),
         value.getExecutionStrategy(),

--- a/yak-ops-business/yak-ops-business-workflow/src/main/resources/db/migration/yak-workflow/V4__workflow_backfill_parameters.sql
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/resources/db/migration/yak-workflow/V4__workflow_backfill_parameters.sql
@@ -1,0 +1,46 @@
+CREATE TABLE IF NOT EXISTS yak_workflow_backfill (
+    id VARCHAR(80) NOT NULL,
+    workflow_id VARCHAR(80) NOT NULL,
+    workflow_version_id VARCHAR(80) NOT NULL,
+    workflow_version_no INT NOT NULL,
+    schedule_id VARCHAR(80) NOT NULL,
+    schedule_name VARCHAR(100) NOT NULL,
+    name VARCHAR(120) NOT NULL,
+    status VARCHAR(32) NOT NULL,
+    start_business_date DATE NOT NULL,
+    end_business_date DATE NOT NULL,
+    cron_expression VARCHAR(160) NOT NULL,
+    timezone VARCHAR(80) NOT NULL,
+    execution_strategy VARCHAR(32) NOT NULL,
+    schedule_input_json TEXT NULL,
+    input_json TEXT NULL,
+    total_count INT NOT NULL DEFAULT 0,
+    create_time DATETIME(3) NOT NULL,
+    update_time DATETIME(3) NOT NULL,
+    PRIMARY KEY (id),
+    KEY idx_yak_workflow_backfill_workflow (workflow_id, create_time),
+    KEY idx_yak_workflow_backfill_schedule (schedule_id, create_time),
+    KEY idx_yak_workflow_backfill_status (status, create_time)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+ALTER TABLE yak_workflow_schedule_trigger
+    ADD COLUMN backfill_id VARCHAR(80) NULL AFTER workflow_id,
+    ADD COLUMN dedupe_key VARCHAR(320) NULL AFTER trigger_id,
+    ADD COLUMN business_date DATE NULL AFTER actual_fire_time;
+
+-- Stage 4 的 schedule + plannedFireTime 唯一键只能表达“正常计划幂等”，
+-- Stage 5 需要允许不同 Backfill 批次对同一个逻辑时间重新执行。
+-- 先为历史 Ledger 生成与 Java 侧完全一致的 SCHEDULE dedupe key，再替换唯一索引。
+UPDATE yak_workflow_schedule_trigger
+SET dedupe_key = CONCAT(
+    schedule_id,
+    '|SCHEDULE|',
+    CAST(ROUND(UNIX_TIMESTAMP(planned_fire_time) * 1000) AS CHAR))
+WHERE dedupe_key IS NULL;
+
+ALTER TABLE yak_workflow_schedule_trigger
+    MODIFY COLUMN dedupe_key VARCHAR(320) NOT NULL,
+    DROP INDEX uk_yak_workflow_schedule_trigger_plan,
+    ADD UNIQUE KEY uk_yak_workflow_schedule_trigger_dedupe (dedupe_key),
+    ADD KEY idx_yak_workflow_schedule_trigger_backfill (backfill_id, status, planned_fire_time),
+    ADD KEY idx_yak_workflow_schedule_trigger_business_date (workflow_id, business_date);

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/domain/WorkflowRunInputScopeTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/domain/WorkflowRunInputScopeTest.java
@@ -1,0 +1,44 @@
+package io.yak.ops.business.workflow.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class WorkflowRunInputScopeTest {
+
+  @Test
+  void shouldOverlayRuntimeInputWithoutMutatingPublishedRunSpec() {
+    WorkflowRunSpec spec = new WorkflowRunSpec(
+        "workflow",
+        List.of(),
+        List.of(),
+        Map.of("tenant", "base", "keep", 1),
+        0L,
+        "CONTINUE_INDEPENDENT_BRANCHES");
+
+    assertThat(spec.input()).containsEntry("tenant", "base");
+
+    try (var ignored = WorkflowRunInputScope.open(
+        Map.of("tenant", "schedule", "businessDate", "2026-08-14"))) {
+      assertThat(spec.input())
+          .containsEntry("tenant", "schedule")
+          .containsEntry("businessDate", "2026-08-14")
+          .containsEntry("keep", 1);
+
+      try (var nested = WorkflowRunInputScope.open(Map.of("tenant", "backfill"))) {
+        assertThat(spec.input())
+            .containsEntry("tenant", "backfill")
+            .doesNotContainKey("businessDate")
+            .containsEntry("keep", 1);
+      }
+
+      assertThat(spec.input()).containsEntry("tenant", "schedule");
+    }
+
+    assertThat(spec.input())
+        .containsEntry("tenant", "base")
+        .doesNotContainKey("businessDate");
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/domain/WorkflowScheduleTriggerIdentityTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/domain/WorkflowScheduleTriggerIdentityTest.java
@@ -1,0 +1,25 @@
+package io.yak.ops.business.workflow.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+
+class WorkflowScheduleTriggerIdentityTest {
+
+  @Test
+  void shouldKeepNormalScheduleIdempotentAndIsolateBackfillBatches() {
+    Instant planned = Instant.parse("2026-08-14T02:00:00Z");
+
+    String scheduled = WorkflowScheduleTriggerIdentity.scheduled("schedule-1", planned);
+    String scheduledAgain = WorkflowScheduleTriggerIdentity.scheduled("schedule-1", planned);
+    String backfillOne = WorkflowScheduleTriggerIdentity.backfill("schedule-1", "backfill-1", planned);
+    String backfillOneAgain = WorkflowScheduleTriggerIdentity.backfill("schedule-1", "backfill-1", planned);
+    String backfillTwo = WorkflowScheduleTriggerIdentity.backfill("schedule-1", "backfill-2", planned);
+
+    assertThat(scheduledAgain).isEqualTo(scheduled);
+    assertThat(backfillOneAgain).isEqualTo(backfillOne);
+    assertThat(backfillOne).isNotEqualTo(scheduled);
+    assertThat(backfillTwo).isNotEqualTo(backfillOne);
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowBackfillPlannerTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowBackfillPlannerTest.java
@@ -1,0 +1,53 @@
+package io.yak.ops.business.workflow.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import org.junit.jupiter.api.Test;
+
+class WorkflowBackfillPlannerTest {
+  private final WorkflowBackfillPlanner planner = new WorkflowBackfillPlanner();
+
+  @Test
+  void shouldGenerateHistoricalOccurrencesInScheduleTimezone() {
+    var plan = planner.plan(
+        "0 0 2 * * ?",
+        "Asia/Shanghai",
+        LocalDate.of(2026, 8, 1),
+        LocalDate.of(2026, 8, 3));
+
+    assertThat(plan.timezone()).isEqualTo("Asia/Shanghai");
+    assertThat(plan.occurrences()).hasSize(3);
+    assertThat(plan.occurrences().get(0).businessDate()).isEqualTo(LocalDate.of(2026, 8, 1));
+    assertThat(plan.occurrences().get(0).scheduleInstant())
+        .isEqualTo(Instant.parse("2026-07-31T18:00:00Z"));
+    assertThat(plan.occurrences().get(0).scheduleTime())
+        .isEqualTo("2026-08-01T02:00:00+08:00");
+    assertThat(plan.occurrences().get(2).businessDate()).isEqualTo(LocalDate.of(2026, 8, 3));
+  }
+
+  @Test
+  void shouldNormalizeFiveFieldCronToQuartzSecondsField() {
+    var plan = planner.plan(
+        "0 2 * * *",
+        "Asia/Shanghai",
+        LocalDate.of(2026, 8, 1),
+        LocalDate.of(2026, 8, 1));
+
+    assertThat(plan.cronExpression()).isEqualTo("0 0 2 * * *");
+    assertThat(plan.occurrences()).hasSize(1);
+  }
+
+  @Test
+  void shouldRejectRangesThatProduceTooManyOccurrences() {
+    assertThatThrownBy(() -> planner.plan(
+        "0 * * * * ?",
+        "UTC",
+        LocalDate.of(2026, 8, 1),
+        LocalDate.of(2026, 8, 2)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("最多生成");
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowBackfillPlannerTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowBackfillPlannerTest.java
@@ -29,21 +29,32 @@ class WorkflowBackfillPlannerTest {
   }
 
   @Test
-  void shouldNormalizeFiveFieldCronToQuartzSecondsField() {
+  void shouldNormalizeFiveFieldCronToQuartzDaySemantics() {
     var plan = planner.plan(
         "0 2 * * *",
         "Asia/Shanghai",
         LocalDate.of(2026, 8, 1),
         LocalDate.of(2026, 8, 1));
 
-    assertThat(plan.cronExpression()).isEqualTo("0 0 2 * * *");
+    assertThat(plan.cronExpression()).isEqualTo("0 0 2 * * ?");
     assertThat(plan.occurrences()).hasSize(1);
+  }
+
+  @Test
+  void shouldRejectAmbiguousFiveFieldDayAndWeekCombination() {
+    assertThatThrownBy(() -> planner.plan(
+        "0 2 1 * MON",
+        "Asia/Shanghai",
+        LocalDate.of(2026, 8, 1),
+        LocalDate.of(2026, 8, 31)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("语义不等价");
   }
 
   @Test
   void shouldRejectRangesThatProduceTooManyOccurrences() {
     assertThatThrownBy(() -> planner.plan(
-        "0 * * * * ?",
+        "* * * * * ?",
         "UTC",
         LocalDate.of(2026, 8, 1),
         LocalDate.of(2026, 8, 2)))

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowBackfillReconcilerTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowBackfillReconcilerTest.java
@@ -1,0 +1,62 @@
+package io.yak.ops.business.workflow.service;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.workflow.dao.WorkflowBackfillDao;
+import io.yak.ops.business.workflow.service.WorkflowBackfillPlanner.Occurrence;
+import io.yak.ops.business.workflow.service.WorkflowBackfillPlanner.Plan;
+import io.yak.ops.common.bean.po.workflow.WorkflowBackfillPO;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class WorkflowBackfillReconcilerTest {
+  @Mock private WorkflowBackfillDao dao;
+  @Mock private WorkflowBackfillPlanner planner;
+  @Mock private WorkflowScheduleTriggerCoordinator coordinator;
+
+  private WorkflowBackfillReconciler reconciler;
+
+  @BeforeEach
+  void setUp() {
+    reconciler = new WorkflowBackfillReconciler(dao, planner, coordinator);
+  }
+
+  @Test
+  void shouldReplayAllOccurrencesForRunningBatchAndRelyOnLedgerDedupe() {
+    WorkflowBackfillPO backfill = new WorkflowBackfillPO();
+    backfill.setId("backfill-1");
+    backfill.setStatus("RUNNING");
+    backfill.setCronExpression("0 0 2 * * ?");
+    backfill.setTimezone("Asia/Shanghai");
+    backfill.setStartBusinessDate(LocalDate.of(2026, 8, 1));
+    backfill.setEndBusinessDate(LocalDate.of(2026, 8, 2));
+    Occurrence first = new Occurrence(
+        LocalDate.of(2026, 8, 1),
+        Instant.parse("2026-07-31T18:00:00Z"),
+        "2026-08-01T02:00:00+08:00");
+    Occurrence second = new Occurrence(
+        LocalDate.of(2026, 8, 2),
+        Instant.parse("2026-08-01T18:00:00Z"),
+        "2026-08-02T02:00:00+08:00");
+    when(dao.selectList(null, null)).thenReturn(List.of(backfill));
+    when(planner.plan(
+        backfill.getCronExpression(),
+        backfill.getTimezone(),
+        backfill.getStartBusinessDate(),
+        backfill.getEndBusinessDate()))
+        .thenReturn(new Plan("Asia/Shanghai", "0 0 2 * * ?", List.of(first, second)));
+
+    reconciler.reconcile();
+
+    verify(coordinator).submitBackfill(backfill, first);
+    verify(coordinator).submitBackfill(backfill, second);
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowBackfillTriggerCoordinatorTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowBackfillTriggerCoordinatorTest.java
@@ -1,0 +1,103 @@
+package io.yak.ops.business.workflow.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.workflow.dao.WorkflowScheduleTriggerDao;
+import io.yak.ops.business.workflow.domain.WorkflowTriggerContext;
+import io.yak.ops.business.workflow.service.WorkflowBackfillPlanner.Occurrence;
+import io.yak.ops.business.workflow.service.WorkflowScheduleTriggerAdmission.AdmissionResult;
+import io.yak.ops.common.bean.po.workflow.WorkflowBackfillPO;
+import io.yak.ops.common.bean.po.workflow.WorkflowScheduleTriggerPO;
+import io.yak.ops.common.bean.vo.workflow.WorkflowInstanceVO;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class WorkflowBackfillTriggerCoordinatorTest {
+  @Mock private WorkflowScheduleTriggerDao ledger;
+  @Mock private WorkflowScheduleQuery schedules;
+  @Mock private WorkflowLaunchService launchService;
+  @Mock private WorkflowScheduleTriggerAdmission admission;
+  @Mock private WorkflowBackfillQuery backfills;
+  @Mock private WorkflowScheduleParameterResolver parameters;
+
+  private WorkflowScheduleTriggerCoordinator coordinator;
+
+  @BeforeEach
+  void setUp() {
+    coordinator = new WorkflowScheduleTriggerCoordinator(
+        ledger, schedules, launchService, admission, backfills, parameters);
+  }
+
+  @Test
+  void shouldCreateBatchScopedLedgerAndLaunchPinnedVersion() {
+    WorkflowBackfillPO backfill = backfill();
+    Occurrence occurrence = new Occurrence(
+        LocalDate.of(2026, 8, 10),
+        Instant.parse("2026-08-09T18:00:00Z"),
+        "2026-08-10T02:00:00+08:00");
+    WorkflowInstanceVO launched = org.mockito.Mockito.mock(WorkflowInstanceVO.class);
+    when(admission.admitNew(any(WorkflowScheduleTriggerPO.class)))
+        .thenAnswer(invocation -> {
+          WorkflowScheduleTriggerPO trigger = invocation.getArgument(0);
+          trigger.setStatus("LAUNCHING");
+          return new AdmissionResult(trigger, true, false);
+        });
+    when(backfills.require("backfill-1")).thenReturn(backfill);
+    when(parameters.forBackfill(eq(backfill), any(WorkflowTriggerContext.class)))
+        .thenReturn(Map.of("businessDate", "2026-08-10"));
+    when(launchService.runBackfillPublished(
+        eq("workflow-1"),
+        eq("workflow-version-5"),
+        any(WorkflowTriggerContext.class),
+        eq(Map.of("businessDate", "2026-08-10"))))
+        .thenReturn(launched);
+    when(launched.id()).thenReturn("execution-v5-20260810");
+    when(admission.bindLaunch(any(WorkflowScheduleTriggerPO.class), eq("execution-v5-20260810")))
+        .thenReturn(AdmissionResult.none());
+
+    var result = coordinator.submitBackfill(backfill, occurrence);
+
+    assertThat(result.businessExecutionId()).isEqualTo("execution-v5-20260810");
+    ArgumentCaptor<WorkflowScheduleTriggerPO> triggerCaptor =
+        ArgumentCaptor.forClass(WorkflowScheduleTriggerPO.class);
+    verify(admission).admitNew(triggerCaptor.capture());
+    WorkflowScheduleTriggerPO trigger = triggerCaptor.getValue();
+    assertThat(trigger.getBackfillId()).isEqualTo("backfill-1");
+    assertThat(trigger.getTriggerSource()).isEqualTo("BACKFILL");
+    assertThat(trigger.getBusinessDate()).isEqualTo(LocalDate.of(2026, 8, 10));
+    assertThat(trigger.getDedupeKey())
+        .startsWith("schedule-1|BACKFILL|backfill-1|");
+    verify(launchService).runBackfillPublished(
+        eq("workflow-1"),
+        eq("workflow-version-5"),
+        any(WorkflowTriggerContext.class),
+        eq(Map.of("businessDate", "2026-08-10")));
+  }
+
+  private WorkflowBackfillPO backfill() {
+    WorkflowBackfillPO value = new WorkflowBackfillPO();
+    value.setId("backfill-1");
+    value.setWorkflowId("workflow-1");
+    value.setWorkflowVersionId("workflow-version-5");
+    value.setWorkflowVersionNo(5);
+    value.setScheduleId("schedule-1");
+    value.setScheduleName("每日订单同步");
+    value.setStatus("RUNNING");
+    value.setTimezone("Asia/Shanghai");
+    value.setCronExpression("0 0 2 * * ?");
+    value.setExecutionStrategy("SERIAL_WAIT");
+    return value;
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowLaunchServiceTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowLaunchServiceTest.java
@@ -26,12 +26,14 @@ class WorkflowLaunchServiceTest {
   @Mock private WorkflowDefinitionService definitionService;
   @Mock private WorkflowRuntimeService runtimeService;
   @Mock private WorkflowExecutionTriggerRecorder triggerRecorder;
+  @Mock private WorkflowPublishedVersionRunner publishedVersionRunner;
 
   private WorkflowLaunchService service;
 
   @BeforeEach
   void setUp() {
-    service = new WorkflowLaunchService(definitionService, runtimeService, triggerRecorder);
+    service = new WorkflowLaunchService(
+        definitionService, runtimeService, triggerRecorder, publishedVersionRunner);
   }
 
   @Test
@@ -41,7 +43,7 @@ class WorkflowLaunchServiceTest {
         "schedule-trigger-20260814T020000",
         "schedule-1",
         Instant.parse("2026-08-14T02:00:00Z"));
-    WorkflowDefinitionVO expected = definition("execution-1");
+    WorkflowDefinitionVO expected = definition("execution-1", "workflow-version-1", 1);
     when(definitionService.run("workflow-1")).thenReturn(expected);
 
     WorkflowDefinitionVO actual = service.runPublished("workflow-1", trigger);
@@ -57,7 +59,7 @@ class WorkflowLaunchServiceTest {
         "trigger-parallel",
         "schedule-1",
         Instant.parse("2026-08-14T02:00:00Z"));
-    WorkflowDefinitionVO expected = definition("execution-parallel");
+    WorkflowDefinitionVO expected = definition("execution-parallel", "workflow-version-1", 1);
     when(definitionService.runConcurrent("workflow-1")).thenReturn(expected);
 
     WorkflowDefinitionVO actual = service.runScheduledPublished("workflow-1", trigger);
@@ -65,6 +67,30 @@ class WorkflowLaunchServiceTest {
     assertThat(actual).isSameAs(expected);
     verify(definitionService).runConcurrent("workflow-1");
     verify(triggerRecorder).record("execution-parallel", trigger);
+  }
+
+  @Test
+  void shouldKeepBackfillPinnedToRequestedVersionAfterActiveVersionChanges() {
+    WorkflowTriggerContext trigger = WorkflowTriggerContext.backfill(
+        "backfill-trigger-1",
+        "schedule-1",
+        "backfill-1",
+        Instant.parse("2026-08-14T02:00:00Z"),
+        "Asia/Shanghai");
+    WorkflowDefinitionVO current = definition("latest-normal", "workflow-version-6", 6);
+    WorkflowInstanceVO expected = instance("execution-v5");
+    when(definitionService.get("workflow-1")).thenReturn(current);
+    when(publishedVersionRunner.run("workflow-1", "workflow-version-5")).thenReturn(expected);
+
+    WorkflowInstanceVO actual = service.runBackfillPublished(
+        "workflow-1",
+        "workflow-version-5",
+        trigger,
+        Map.of("businessDate", "2026-08-14"));
+
+    assertThat(actual).isSameAs(expected);
+    verify(publishedVersionRunner).run("workflow-1", "workflow-version-5");
+    verify(triggerRecorder).record("execution-v5", trigger);
   }
 
   @Test
@@ -85,7 +111,10 @@ class WorkflowLaunchServiceTest {
     verify(triggerRecorder).record("execution-api", trigger);
   }
 
-  private WorkflowDefinitionVO definition(String executionId) {
+  private WorkflowDefinitionVO definition(
+      String executionId,
+      String activeVersionId,
+      int activeVersionNo) {
     Instant now = Instant.parse("2026-08-13T12:00:00Z");
     return new WorkflowDefinitionVO(
         "workflow-1",
@@ -100,9 +129,9 @@ class WorkflowLaunchServiceTest {
         Map.of(),
         0L,
         "CONTINUE_INDEPENDENT_BRANCHES",
-        "workflow-version-1",
-        1,
-        1,
+        activeVersionId,
+        activeVersionNo,
+        activeVersionNo,
         false,
         executionId,
         "RUNNING",

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowPublishedVersionRunnerTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowPublishedVersionRunnerTest.java
@@ -1,0 +1,59 @@
+package io.yak.ops.business.workflow.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.job.task.TaskVersionSnapshot;
+import io.yak.ops.business.workflow.domain.WorkflowRunSpec;
+import io.yak.ops.business.workflow.persistence.WorkflowDefinitionPersistence;
+import io.yak.ops.business.workflow.persistence.WorkflowDefinitionPersistence.VersionRecord;
+import io.yak.ops.common.bean.vo.workflow.WorkflowInstanceVO;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.ObjectProvider;
+
+@ExtendWith(MockitoExtension.class)
+class WorkflowPublishedVersionRunnerTest {
+  @Mock private WorkflowRuntimeService runtimeService;
+  @Mock private WorkflowDefinitionPersistence persistence;
+  @Mock private ObjectProvider<WorkflowDefinitionPersistence> provider;
+
+  @Test
+  void shouldRunRequestedImmutableVersionInsteadOfCurrentActiveVersion() {
+    WorkflowRunSpec spec = new WorkflowRunSpec(
+        "历史版本 V5", List.of(), List.of(), Map.of("base", "v5"), 0L,
+        "CONTINUE_INDEPENDENT_BRANCHES");
+    Map<String, TaskVersionSnapshot> tasks = Map.of();
+    VersionRecord version = new VersionRecord(
+        "workflow-version-5",
+        "workflow-1",
+        5,
+        10L,
+        spec,
+        Map.of(),
+        tasks,
+        Instant.parse("2026-08-01T00:00:00Z"));
+    WorkflowInstanceVO prepared = org.mockito.Mockito.mock(WorkflowInstanceVO.class);
+    WorkflowInstanceVO activated = org.mockito.Mockito.mock(WorkflowInstanceVO.class);
+    when(provider.getIfAvailable()).thenReturn(persistence);
+    when(persistence.loadVersions("workflow-1")).thenReturn(List.of(version));
+    when(runtimeService.run(spec, tasks, "workflow-version-5", 5, false)).thenReturn(prepared);
+    when(prepared.id()).thenReturn("execution-v5");
+    when(runtimeService.activate("execution-v5")).thenReturn(activated);
+
+    WorkflowPublishedVersionRunner runner = new WorkflowPublishedVersionRunner(runtimeService, provider);
+    WorkflowInstanceVO result = runner.run("workflow-1", "workflow-version-5");
+
+    assertThat(result).isSameAs(activated);
+    verify(persistence).loadVersions("workflow-1");
+    verify(runtimeService).run(eq(spec), eq(tasks), eq("workflow-version-5"), eq(5), eq(false));
+    verify(runtimeService).activate("execution-v5");
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowScheduleMisfireRecoveryTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowScheduleMisfireRecoveryTest.java
@@ -8,6 +8,7 @@ import io.yak.ops.business.workflow.dao.WorkflowScheduleTriggerDao;
 import io.yak.ops.common.bean.po.workflow.WorkflowSchedulePO;
 import io.yak.ops.common.bean.po.workflow.WorkflowScheduleTriggerPO;
 import java.time.Instant;
+import java.time.LocalDate;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -55,6 +56,8 @@ class WorkflowScheduleMisfireRecoveryTest {
     assertThat(trigger.getStatus()).isEqualTo("SKIPPED");
     assertThat(trigger.getTriggerSource()).isEqualTo("MISFIRE_RECOVERY");
     assertThat(trigger.getPlannedFireTime()).isEqualTo(missed);
+    assertThat(trigger.getDedupeKey()).isEqualTo("schedule-1|SCHEDULE|1786678800000");
+    assertThat(trigger.getBusinessDate()).isEqualTo(LocalDate.of(2026, 8, 14));
     assertThat(trigger.getCompletedAt()).isEqualTo(recovered);
   }
 
@@ -62,6 +65,7 @@ class WorkflowScheduleMisfireRecoveryTest {
     WorkflowSchedulePO value = new WorkflowSchedulePO();
     value.setId("schedule-1");
     value.setWorkflowId("workflow-1");
+    value.setTimezone("Asia/Shanghai");
     value.setExecutionStrategy("SERIAL_WAIT");
     value.setMisfireStrategy(misfire);
     return value;

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowScheduleMisfireRecoveryTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowScheduleMisfireRecoveryTest.java
@@ -56,7 +56,7 @@ class WorkflowScheduleMisfireRecoveryTest {
     assertThat(trigger.getStatus()).isEqualTo("SKIPPED");
     assertThat(trigger.getTriggerSource()).isEqualTo("MISFIRE_RECOVERY");
     assertThat(trigger.getPlannedFireTime()).isEqualTo(missed);
-    assertThat(trigger.getDedupeKey()).isEqualTo("schedule-1|SCHEDULE|1786678800000");
+    assertThat(trigger.getDedupeKey()).isEqualTo("schedule-1|SCHEDULE|1786669200000");
     assertThat(trigger.getBusinessDate()).isEqualTo(LocalDate.of(2026, 8, 14));
     assertThat(trigger.getCompletedAt()).isEqualTo(recovered);
   }

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowScheduleParameterResolverTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowScheduleParameterResolverTest.java
@@ -1,0 +1,76 @@
+package io.yak.ops.business.workflow.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.workflow.domain.WorkflowTriggerContext;
+import io.yak.ops.business.workflow.persistence.support.WorkflowJsonCodec;
+import io.yak.ops.common.bean.po.workflow.WorkflowBackfillPO;
+import io.yak.ops.common.bean.po.workflow.WorkflowSchedulePO;
+import java.time.Instant;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class WorkflowScheduleParameterResolverTest {
+  private final WorkflowScheduleParameterResolver resolver =
+      new WorkflowScheduleParameterResolver(new WorkflowJsonCodec(new ObjectMapper()));
+
+  @Test
+  void shouldInjectLogicalScheduleParametersAndOverrideReservedNames() {
+    WorkflowSchedulePO schedule = new WorkflowSchedulePO();
+    schedule.setId("schedule-1");
+    schedule.setTimezone("Asia/Shanghai");
+    schedule.setCronExpression("0 0 2 * * ?");
+    schedule.setInputJson("{\"tenant\":\"schedule\",\"businessDate\":\"wrong\"}");
+    WorkflowTriggerContext context = WorkflowTriggerContext.scheduled(
+        "trigger-1",
+        "schedule-1",
+        Instant.parse("2026-08-14T18:00:00Z"),
+        "Asia/Shanghai");
+
+    Map<String, Object> input = resolver.forSchedule(schedule, context);
+
+    assertThat(input.get("tenant")).isEqualTo("schedule");
+    assertThat(input.get("businessDate")).isEqualTo("2026-08-15");
+    assertThat(input.get("scheduleTime")).isEqualTo("2026-08-15T02:00:00+08:00");
+    assertThat(input.get("scheduleTimezone")).isEqualTo("Asia/Shanghai");
+    assertThat(input.get("triggerType")).isEqualTo("SCHEDULE");
+    assertThat(input.get("scheduleId")).isEqualTo("schedule-1");
+    assertThat(input).containsKey(WorkflowScheduleParameterResolver.NAMESPACE);
+    @SuppressWarnings("unchecked")
+    Map<String, Object> system =
+        (Map<String, Object>) input.get(WorkflowScheduleParameterResolver.NAMESPACE);
+    assertThat(system.get("businessDate")).isEqualTo("2026-08-15");
+    assertThat(system.get("plannedFireTime")).isEqualTo("2026-08-14T18:00:00Z");
+  }
+
+  @Test
+  void shouldOverlayBackfillInputAndExposeBatchVersionMetadata() {
+    WorkflowBackfillPO backfill = new WorkflowBackfillPO();
+    backfill.setId("backfill-1");
+    backfill.setScheduleId("schedule-1");
+    backfill.setTimezone("Asia/Shanghai");
+    backfill.setCronExpression("0 0 2 * * ?");
+    backfill.setWorkflowVersionId("workflow-version-5");
+    backfill.setWorkflowVersionNo(5);
+    backfill.setScheduleInputJson("{\"tenant\":\"schedule\",\"region\":\"cn\"}");
+    backfill.setInputJson("{\"tenant\":\"backfill\",\"limit\":200}");
+    WorkflowTriggerContext context = WorkflowTriggerContext.backfill(
+        "backfill-trigger-1",
+        "schedule-1",
+        "backfill-1",
+        Instant.parse("2026-08-09T18:00:00Z"),
+        "Asia/Shanghai");
+
+    Map<String, Object> input = resolver.forBackfill(backfill, context);
+
+    assertThat(input.get("tenant")).isEqualTo("backfill");
+    assertThat(input.get("region")).isEqualTo("cn");
+    assertThat(input.get("limit")).isEqualTo(200);
+    assertThat(input.get("businessDate")).isEqualTo("2026-08-10");
+    assertThat(input.get("triggerType")).isEqualTo("BACKFILL");
+    assertThat(input.get("backfillId")).isEqualTo("backfill-1");
+    assertThat(input.get("workflowVersionId")).isEqualTo("workflow-version-5");
+    assertThat(input.get("workflowVersionNo")).isEqualTo(5);
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowScheduleTriggerCoordinatorTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowScheduleTriggerCoordinatorTest.java
@@ -14,6 +14,7 @@ import io.yak.ops.common.bean.po.workflow.WorkflowSchedulePO;
 import io.yak.ops.common.bean.po.workflow.WorkflowScheduleTriggerPO;
 import io.yak.ops.common.bean.vo.workflow.WorkflowDefinitionVO;
 import java.time.Instant;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -51,7 +52,7 @@ class WorkflowScheduleTriggerCoordinatorTest {
 
     assertThat(result.businessExecutionId()).isEqualTo("execution-existing");
     assertThat(result.message()).contains("幂等拦截");
-    verify(launchService, never()).runScheduledPublished(any(), any());
+    verify(launchService, never()).runScheduledPublished(any(), any(), any());
   }
 
   @Test
@@ -62,7 +63,8 @@ class WorkflowScheduleTriggerCoordinatorTest {
     when(admission.admitNew(eq(schedule), any()))
         .thenReturn(new AdmissionResult(reserved, true, false));
     when(schedules.require("schedule-1")).thenReturn(schedule);
-    when(launchService.runScheduledPublished(eq("workflow-1"), any(WorkflowTriggerContext.class)))
+    when(launchService.runScheduledPublished(
+        eq("workflow-1"), any(WorkflowTriggerContext.class), eq(Map.of())))
         .thenReturn(launched);
     when(launched.latestExecutionId()).thenReturn("execution-1");
     when(admission.bindLaunch(reserved, "execution-1"))
@@ -76,7 +78,8 @@ class WorkflowScheduleTriggerCoordinatorTest {
         "CRON");
 
     assertThat(result.businessExecutionId()).isEqualTo("execution-1");
-    verify(launchService).runScheduledPublished(eq("workflow-1"), any(WorkflowTriggerContext.class));
+    verify(launchService).runScheduledPublished(
+        eq("workflow-1"), any(WorkflowTriggerContext.class), eq(Map.of()));
     verify(admission).bindLaunch(reserved, "execution-1");
   }
 
@@ -85,6 +88,7 @@ class WorkflowScheduleTriggerCoordinatorTest {
     value.setId("schedule-1");
     value.setWorkflowId("workflow-1");
     value.setStatus("ONLINE");
+    value.setTimezone("Asia/Shanghai");
     value.setExecutionStrategy("SERIAL_WAIT");
     value.setMisfireStrategy("FIRE_ONCE");
     return value;
@@ -96,6 +100,7 @@ class WorkflowScheduleTriggerCoordinatorTest {
     value.setScheduleId("schedule-1");
     value.setWorkflowId("workflow-1");
     value.setTriggerId("quartz-trigger-1");
+    value.setDedupeKey("schedule-1|SCHEDULE|1786672800000");
     value.setPlannedFireTime(Instant.parse("2026-08-14T02:00:00Z"));
     value.setActualFireTime(Instant.parse("2026-08-14T02:00:01Z"));
     value.setExecutionStrategy("SERIAL_WAIT");

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/dto/workflow/WorkflowBackfillCreateDTO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/dto/workflow/WorkflowBackfillCreateDTO.java
@@ -1,0 +1,20 @@
+package io.yak.ops.common.bean.dto.workflow;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+import java.util.Map;
+
+/** 创建工作流历史补数批次。 */
+public record WorkflowBackfillCreateDTO(
+    @NotBlank String scheduleId,
+    String name,
+    @NotNull LocalDate startBusinessDate,
+    @NotNull LocalDate endBusinessDate,
+    String executionStrategy,
+    Map<String, Object> input) {
+
+  public WorkflowBackfillCreateDTO {
+    input = input == null ? Map.of() : Map.copyOf(input);
+  }
+}

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/workflow/WorkflowBackfillPO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/workflow/WorkflowBackfillPO.java
@@ -1,0 +1,33 @@
+package io.yak.ops.common.bean.po.workflow;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import java.time.Instant;
+import java.time.LocalDate;
+import lombok.Data;
+
+/** 工作流历史补数批次持久化对象。 */
+@Data
+@TableName("yak_workflow_backfill")
+public class WorkflowBackfillPO {
+  @TableId(type = IdType.INPUT)
+  private String id;
+  private String workflowId;
+  private String workflowVersionId;
+  private Integer workflowVersionNo;
+  private String scheduleId;
+  private String scheduleName;
+  private String name;
+  private String status;
+  private LocalDate startBusinessDate;
+  private LocalDate endBusinessDate;
+  private String cronExpression;
+  private String timezone;
+  private String executionStrategy;
+  private String scheduleInputJson;
+  private String inputJson;
+  private Integer totalCount;
+  private Instant createTime;
+  private Instant updateTime;
+}

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/workflow/WorkflowScheduleTriggerPO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/workflow/WorkflowScheduleTriggerPO.java
@@ -4,6 +4,7 @@ import com.baomidou.mybatisplus.annotation.IdType;
 import com.baomidou.mybatisplus.annotation.TableId;
 import com.baomidou.mybatisplus.annotation.TableName;
 import java.time.Instant;
+import java.time.LocalDate;
 import lombok.Data;
 
 /** 工作流调度 Trigger Ledger 持久化对象。 */
@@ -14,10 +15,13 @@ public class WorkflowScheduleTriggerPO {
   private String id;
   private String scheduleId;
   private String workflowId;
+  private String backfillId;
   private String triggerId;
+  private String dedupeKey;
   private String triggerSource;
   private Instant plannedFireTime;
   private Instant actualFireTime;
+  private LocalDate businessDate;
   private String executionStrategy;
   private String misfireStrategy;
   private String status;

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/vo/workflow/WorkflowBackfillPreviewVO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/vo/workflow/WorkflowBackfillPreviewVO.java
@@ -1,0 +1,27 @@
+package io.yak.ops.common.bean.vo.workflow;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+
+/** Backfill 创建前的逻辑计划预览。 */
+public record WorkflowBackfillPreviewVO(
+    String scheduleId,
+    String cronExpression,
+    String timezone,
+    LocalDate startBusinessDate,
+    LocalDate endBusinessDate,
+    int totalCount,
+    boolean truncated,
+    List<OccurrenceVO> occurrences) {
+
+  public WorkflowBackfillPreviewVO {
+    occurrences = occurrences == null ? List.of() : List.copyOf(occurrences);
+  }
+
+  public record OccurrenceVO(
+      LocalDate businessDate,
+      Instant scheduleInstant,
+      String scheduleTime) {
+  }
+}

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/vo/workflow/WorkflowBackfillVO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/vo/workflow/WorkflowBackfillVO.java
@@ -1,0 +1,36 @@
+package io.yak.ops.common.bean.vo.workflow;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.Map;
+
+/** 工作流历史补数批次及 Trigger Ledger 汇总。 */
+public record WorkflowBackfillVO(
+    String id,
+    String workflowId,
+    String workflowVersionId,
+    Integer workflowVersionNo,
+    String scheduleId,
+    String scheduleName,
+    String name,
+    String status,
+    LocalDate startBusinessDate,
+    LocalDate endBusinessDate,
+    String cronExpression,
+    String timezone,
+    String executionStrategy,
+    Map<String, Object> input,
+    int totalCount,
+    int waitingCount,
+    int runningCount,
+    int succeededCount,
+    int failedCount,
+    int canceledCount,
+    int skippedCount,
+    Instant createTime,
+    Instant updateTime) {
+
+  public WorkflowBackfillVO {
+    input = input == null ? Map.of() : Map.copyOf(input);
+  }
+}

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/vo/workflow/WorkflowScheduleTriggerVO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/vo/workflow/WorkflowScheduleTriggerVO.java
@@ -1,14 +1,17 @@
 package io.yak.ops.common.bean.vo.workflow;
 
 import java.time.Instant;
+import java.time.LocalDate;
 
 /** 工作流调度 Trigger Ledger 视图。 */
 public record WorkflowScheduleTriggerVO(
     String id,
     String scheduleId,
     String workflowId,
+    String backfillId,
     String triggerId,
     String triggerSource,
+    LocalDate businessDate,
     Instant plannedFireTime,
     Instant actualFireTime,
     String executionStrategy,

--- a/yak-ops-ui/src/pages/workflow/schedules/BackfillDrawer.tsx
+++ b/yak-ops-ui/src/pages/workflow/schedules/BackfillDrawer.tsx
@@ -1,0 +1,200 @@
+import {
+  createWorkflowBackfill,
+  previewWorkflowBackfill,
+  type WorkflowBackfillPayload,
+  type WorkflowBackfillPreview,
+  type WorkflowSchedule,
+} from '@/services/workflow/schedules';
+import { Button, DatePicker, Drawer, Form, Input, Select, Table, message } from 'antd';
+import type { Dayjs } from 'dayjs';
+import dayjs from 'dayjs';
+import { DatabaseBackup, Eye } from 'lucide-react';
+import { useEffect, useState } from 'react';
+
+interface BackfillFormValues {
+  name?: string;
+  businessDateRange: [Dayjs, Dayjs];
+  executionStrategy: 'SERIAL_WAIT' | 'PARALLEL';
+  inputJson: string;
+}
+
+interface BackfillDrawerProps {
+  open: boolean;
+  schedule?: WorkflowSchedule;
+  onClose: () => void;
+  onCreated: () => Promise<void> | void;
+}
+
+const BackfillDrawer = ({ open, schedule, onClose, onCreated }: BackfillDrawerProps) => {
+  const [form] = Form.useForm<BackfillFormValues>();
+  const [preview, setPreview] = useState<WorkflowBackfillPreview>();
+  const [previewing, setPreviewing] = useState(false);
+  const [creating, setCreating] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    setPreview(undefined);
+    form.setFieldsValue({
+      name: '',
+      executionStrategy: 'SERIAL_WAIT',
+      inputJson: '{}',
+      businessDateRange: [dayjs().subtract(1, 'day'), dayjs().subtract(1, 'day')],
+    });
+  }, [form, open, schedule?.id]);
+
+  const buildPayload = async (): Promise<WorkflowBackfillPayload | undefined> => {
+    if (!schedule) return undefined;
+    const values = await form.validateFields();
+    let input: Record<string, unknown> = {};
+    try {
+      input = values.inputJson?.trim() ? JSON.parse(values.inputJson) : {};
+    } catch {
+      message.error('补数参数必须是合法 JSON');
+      return undefined;
+    }
+    return {
+      scheduleId: schedule.id,
+      name: values.name?.trim() || undefined,
+      startBusinessDate: values.businessDateRange[0].format('YYYY-MM-DD'),
+      endBusinessDate: values.businessDateRange[1].format('YYYY-MM-DD'),
+      executionStrategy: values.executionStrategy,
+      input,
+    };
+  };
+
+  const handlePreview = async () => {
+    try {
+      const payload = await buildPayload();
+      if (!payload) return;
+      setPreviewing(true);
+      const data = await previewWorkflowBackfill(payload);
+      setPreview(data);
+    } catch (error: any) {
+      if (error?.errorFields) return;
+      message.error(error instanceof Error ? error.message : '补数计划预览失败');
+    } finally {
+      setPreviewing(false);
+    }
+  };
+
+  const handleCreate = async () => {
+    try {
+      const payload = await buildPayload();
+      if (!payload) return;
+      setCreating(true);
+      const result = await createWorkflowBackfill(payload);
+      message.success(`补数批次已创建，共 ${result?.totalCount ?? preview?.totalCount ?? 0} 个逻辑实例`);
+      await onCreated();
+      onClose();
+    } catch (error: any) {
+      if (error?.errorFields) return;
+      message.error(error instanceof Error ? error.message : '创建补数批次失败');
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  return (
+    <Drawer
+      open={open}
+      width={680}
+      destroyOnClose
+      title={
+        <div>
+          <div className="text-[14px] font-semibold text-[#344054]">历史补数 / Backfill</div>
+          <div className="mt-0.5 text-[11px] font-normal text-[#98a2b3]">
+            {schedule?.name || '-'} · {schedule?.cronExpression || '-'} · {schedule?.timezone || '-'}
+          </div>
+        </div>
+      }
+      onClose={onClose}
+      extra={
+        <div className="flex gap-2">
+          <Button icon={<Eye size={14} />} loading={previewing} onClick={() => void handlePreview()}>
+            预览计划
+          </Button>
+          <Button type="primary" icon={<DatabaseBackup size={14} />} loading={creating} onClick={() => void handleCreate()}>
+            创建补数
+          </Button>
+        </div>
+      }
+    >
+      <div className="mb-4 rounded-md border border-[#eaecf0] bg-[#f8f9fb] px-3 py-2 text-[11px] leading-5 text-[#667085]">
+        按调度 Cron 与时区重新生成历史逻辑计划。每个实例自动注入 <code>businessDate</code>、
+        <code> scheduleTime</code>、<code>scheduleTimezone</code>、<code>triggerType</code>、
+        <code>backfillId</code>，完整系统参数同时位于 <code>__schedule</code> 命名空间。
+      </div>
+
+      <Form form={form} layout="vertical" requiredMark="optional">
+        <Form.Item name="name" label="补数批次名称" rules={[{ max: 120 }]}>
+          <Input variant="filled" placeholder="不填则自动使用 调度名称 + 日期区间" />
+        </Form.Item>
+
+        <Form.Item
+          name="businessDateRange"
+          label="业务日期范围"
+          rules={[{ required: true, message: '请选择需要补数的业务日期范围' }]}
+          extra="业务日期按调度时区计算；计划时间不是当前点击创建的时间。"
+        >
+          <DatePicker.RangePicker className="w-full" allowClear={false} />
+        </Form.Item>
+
+        <Form.Item
+          name="executionStrategy"
+          label="补数执行策略"
+          rules={[{ required: true }]}
+        >
+          <Select
+            options={[
+              { value: 'SERIAL_WAIT', label: '串行补数（推荐，按逻辑计划时间依次执行）' },
+              { value: 'PARALLEL', label: '并行补数（允许多个历史实例同时运行）' },
+            ]}
+          />
+        </Form.Item>
+
+        <Form.Item
+          name="inputJson"
+          label="补数参数 JSON"
+          extra="覆盖调度定义中的同名自定义参数；businessDate / scheduleTime 等系统保留参数始终由平台生成。"
+        >
+          <Input.TextArea rows={6} spellCheck={false} className="font-mono text-[12px]" />
+        </Form.Item>
+      </Form>
+
+      {preview ? (
+        <div className="mt-2">
+          <div className="mb-2 flex items-center justify-between">
+            <div className="text-[12px] font-medium text-[#344054]">计划预览</div>
+            <div className="text-[11px] text-[#667085]">
+              共 <b>{preview.totalCount}</b> 个实例{preview.truncated ? '，下表仅展示前 100 条' : ''}
+            </div>
+          </div>
+          <Table
+            rowKey={(record) => `${record.businessDate}-${record.scheduleInstant}`}
+            size="small"
+            bordered
+            pagination={false}
+            scroll={{ y: 280 }}
+            dataSource={preview.occurrences}
+            columns={[
+              {
+                title: 'businessDate',
+                dataIndex: 'businessDate',
+                width: 130,
+                render: (value: string) => <code className="text-[12px] text-[#344054]">{value}</code>,
+              },
+              {
+                title: 'scheduleTime',
+                dataIndex: 'scheduleTime',
+                render: (value: string) => <code className="text-[11px] text-[#667085]">{value}</code>,
+              },
+            ]}
+            className="[&_.ant-table-thead>tr>th]:!bg-[#f8f9fb] [&_.ant-table-thead>tr>th]:!text-[11px]"
+          />
+        </div>
+      ) : null}
+    </Drawer>
+  );
+};
+
+export default BackfillDrawer;

--- a/yak-ops-ui/src/pages/workflow/schedules/BackfillHistoryDrawer.tsx
+++ b/yak-ops-ui/src/pages/workflow/schedules/BackfillHistoryDrawer.tsx
@@ -1,0 +1,219 @@
+import {
+  cancelWorkflowBackfill,
+  listWorkflowBackfills,
+  type WorkflowBackfill,
+  type WorkflowBackfillStatus,
+} from '@/services/workflow/schedules';
+import { ReloadOutlined } from '@ant-design/icons';
+import { Button, Drawer, Modal, Select, Table, message } from 'antd';
+import { History, ListTree, XCircle } from 'lucide-react';
+import { useCallback, useEffect, useState } from 'react';
+
+interface BackfillHistoryDrawerProps {
+  open: boolean;
+  workflowId?: string;
+  scheduleId?: string;
+  onClose: () => void;
+  onOpenTriggers: (backfill: WorkflowBackfill) => void;
+}
+
+const STATUS_LABEL: Record<WorkflowBackfillStatus, string> = {
+  CREATED: '已创建',
+  RUNNING: '运行中',
+  SUCCEEDED: '成功',
+  PARTIAL_SUCCESS: '部分成功',
+  FAILED: '失败',
+  CANCELED: '已取消',
+};
+
+const formatTime = (value?: string) => {
+  if (!value) return '-';
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? value : date.toLocaleString();
+};
+
+const BackfillHistoryDrawer = ({
+  open,
+  workflowId,
+  scheduleId,
+  onClose,
+  onOpenTriggers,
+}: BackfillHistoryDrawerProps) => {
+  const [records, setRecords] = useState<WorkflowBackfill[]>([]);
+  const [status, setStatus] = useState<WorkflowBackfillStatus>();
+  const [loading, setLoading] = useState(false);
+
+  const load = useCallback(async () => {
+    if (!open) return;
+    setLoading(true);
+    try {
+      setRecords(await listWorkflowBackfills({ workflowId, scheduleId, status }));
+    } catch (error) {
+      message.error(error instanceof Error ? error.message : '补数批次加载失败');
+    } finally {
+      setLoading(false);
+    }
+  }, [open, scheduleId, status, workflowId]);
+
+  useEffect(() => {
+    if (open) void load();
+  }, [load, open]);
+
+  const cancel = (record: WorkflowBackfill) => {
+    Modal.confirm({
+      centered: true,
+      title: '确认取消补数批次吗？',
+      content: '尚未启动的补数实例会被标记为已跳过；已经运行中的 WorkflowExecution 会继续完成。',
+      okText: '取消补数',
+      cancelText: '关闭',
+      okButtonProps: { danger: true },
+      async onOk() {
+        try {
+          await cancelWorkflowBackfill(record.id);
+          message.success('补数批次已取消');
+          await load();
+        } catch (error) {
+          message.error(error instanceof Error ? error.message : '取消补数失败');
+        }
+      },
+    });
+  };
+
+  return (
+    <Drawer
+      open={open}
+      width={1160}
+      destroyOnClose
+      title={
+        <div>
+          <div className="flex items-center gap-2 text-[14px] font-semibold text-[#344054]">
+            <History size={15} /> 补数记录
+          </div>
+          <div className="mt-0.5 text-[11px] font-normal text-[#98a2b3]">
+            Backfill 批次、固定工作流版本与 Trigger Ledger 运行进度
+          </div>
+        </div>
+      }
+      onClose={onClose}
+      extra={
+        <div className="flex items-center gap-2">
+          <Select
+            allowClear
+            placeholder="全部状态"
+            className="w-[130px]"
+            value={status}
+            onChange={setStatus}
+            options={Object.entries(STATUS_LABEL).map(([value, label]) => ({ value, label }))}
+          />
+          <Button icon={<ReloadOutlined spin={loading} />} onClick={() => void load()} />
+        </div>
+      }
+    >
+      <Table
+        rowKey="id"
+        size="small"
+        bordered
+        loading={loading}
+        dataSource={records}
+        scroll={{ x: 1500 }}
+        pagination={{ pageSize: 15, showSizeChanger: false, showTotal: (total) => `共 ${total} 个批次` }}
+        columns={[
+          {
+            title: '补数批次',
+            dataIndex: 'name',
+            width: 220,
+            fixed: 'left',
+            render: (value: string, record: WorkflowBackfill) => (
+              <div>
+                <div className="font-medium text-[#344054]">{value}</div>
+                <div className="mt-1 text-[10px] text-[#98a2b3]">{record.id}</div>
+              </div>
+            ),
+          },
+          {
+            title: '状态',
+            dataIndex: 'status',
+            width: 100,
+            render: (value: WorkflowBackfillStatus) => (
+              <span className="text-[12px] font-medium text-[#475467]">{STATUS_LABEL[value] || value}</span>
+            ),
+          },
+          {
+            title: '业务日期',
+            width: 190,
+            render: (_: unknown, record: WorkflowBackfill) => (
+              <div className="text-[11px] text-[#667085]">
+                {record.startBusinessDate} ~ {record.endBusinessDate}
+              </div>
+            ),
+          },
+          {
+            title: '工作流版本',
+            dataIndex: 'workflowVersionNo',
+            width: 125,
+            render: (value: number, record: WorkflowBackfill) => (
+              <div>
+                <div className="text-[12px] text-[#475467]">V{value}</div>
+                <div className="mt-1 max-w-[105px] truncate text-[10px] text-[#98a2b3]" title={record.workflowVersionId}>
+                  {record.workflowVersionId}
+                </div>
+              </div>
+            ),
+          },
+          {
+            title: '执行策略',
+            dataIndex: 'executionStrategy',
+            width: 115,
+            render: (value: string) => <code className="text-[11px] text-[#475467]">{value}</code>,
+          },
+          {
+            title: '进度',
+            width: 250,
+            render: (_: unknown, record: WorkflowBackfill) => (
+              <div className="text-[11px] leading-5 text-[#667085]">
+                <div>总数 {record.totalCount} · 等待 {record.waitingCount} · 运行 {record.runningCount}</div>
+                <div>成功 {record.succeededCount} · 失败 {record.failedCount} · 跳过 {record.skippedCount}</div>
+              </div>
+            ),
+          },
+          {
+            title: 'Cron / 时区',
+            width: 180,
+            render: (_: unknown, record: WorkflowBackfill) => (
+              <div>
+                <code className="text-[11px] text-[#475467]">{record.cronExpression}</code>
+                <div className="mt-1 text-[10px] text-[#98a2b3]">{record.timezone}</div>
+              </div>
+            ),
+          },
+          {
+            title: '创建时间',
+            dataIndex: 'createTime',
+            width: 165,
+            render: (value: string) => <span className="text-[11px] text-[#98a2b3]">{formatTime(value)}</span>,
+          },
+          {
+            title: '操作',
+            width: 170,
+            fixed: 'right',
+            render: (_: unknown, record: WorkflowBackfill) => (
+              <div className="flex items-center gap-1 whitespace-nowrap">
+                <Button type="text" size="small" icon={<ListTree size={13} />} onClick={() => onOpenTriggers(record)}>
+                  明细
+                </Button>
+                {record.status === 'RUNNING' ? (
+                  <Button danger type="text" size="small" icon={<XCircle size={13} />} onClick={() => cancel(record)}>
+                    取消
+                  </Button>
+                ) : null}
+              </div>
+            ),
+          },
+        ]}
+        className="[&_.ant-table-thead>tr>th]:!bg-[#f8f9fb] [&_.ant-table-thead>tr>th]:!text-[12px] [&_.ant-table-thead>tr>th]:!text-[#667085]"
+      />
+    </Drawer>
+  );
+};
+
+export default BackfillHistoryDrawer;

--- a/yak-ops-ui/src/pages/workflow/schedules/ScheduleEditorDrawer.tsx
+++ b/yak-ops-ui/src/pages/workflow/schedules/ScheduleEditorDrawer.tsx
@@ -183,7 +183,11 @@ const ScheduleEditorDrawer = ({
           </Form.Item>
         </div>
 
-        <Form.Item name="inputJson" label="运行参数 JSON">
+        <Form.Item
+          name="inputJson"
+          label="调度运行参数 JSON"
+          extra="运行时合并顺序：工作流版本参数 < 调度参数 < Backfill 参数 < 系统参数。系统会按逻辑计划时间注入 businessDate、scheduleTime、scheduleTimezone、triggerType、scheduleId，并在 __schedule 中保留完整副本。"
+        >
           <Input.TextArea rows={7} spellCheck={false} className="font-mono text-[12px]" />
         </Form.Item>
       </Form>

--- a/yak-ops-ui/src/pages/workflow/schedules/TriggerLedgerDrawer.tsx
+++ b/yak-ops-ui/src/pages/workflow/schedules/TriggerLedgerDrawer.tsx
@@ -11,6 +11,8 @@ import { useCallback, useEffect, useState } from 'react';
 interface TriggerLedgerDrawerProps {
   open: boolean;
   schedule?: WorkflowSchedule;
+  backfillId?: string;
+  backfillName?: string;
   onClose: () => void;
 }
 
@@ -29,6 +31,7 @@ const SOURCE_LABEL: Record<string, string> = {
   CRON: 'Cron',
   MANUAL: '手动触发',
   MISFIRE_RECOVERY: 'Misfire 恢复',
+  BACKFILL: 'Backfill',
 };
 
 const formatTime = (value?: string) => {
@@ -37,40 +40,52 @@ const formatTime = (value?: string) => {
   return Number.isNaN(date.getTime()) ? value : date.toLocaleString();
 };
 
-const TriggerLedgerDrawer = ({ open, schedule, onClose }: TriggerLedgerDrawerProps) => {
+const TriggerLedgerDrawer = ({
+  open,
+  schedule,
+  backfillId,
+  backfillName,
+  onClose,
+}: TriggerLedgerDrawerProps) => {
   const [records, setRecords] = useState<WorkflowScheduleTrigger[]>([]);
   const [status, setStatus] = useState<WorkflowScheduleTriggerStatus>();
   const [loading, setLoading] = useState(false);
 
   const load = useCallback(async () => {
-    if (!open || !schedule?.id) return;
+    if (!open || (!schedule?.id && !backfillId)) return;
     setLoading(true);
     try {
       setRecords(await listWorkflowScheduleTriggers({
-        scheduleId: schedule.id,
+        scheduleId: schedule?.id,
+        backfillId,
         status,
-        limit: 200,
+        limit: backfillId ? 1000 : 200,
       }));
     } catch (error) {
       message.error(error instanceof Error ? error.message : 'Trigger Ledger 加载失败');
     } finally {
       setLoading(false);
     }
-  }, [open, schedule?.id, status]);
+  }, [backfillId, open, schedule?.id, status]);
 
   useEffect(() => {
-    if (open) void load();
+    if (open) {
+      setStatus(undefined);
+      void load();
+    }
   }, [load, open]);
 
   return (
     <Drawer
       open={open}
-      width={980}
+      width={1040}
       title={
         <div>
-          <div className="text-[14px] font-semibold text-[#344054]">Trigger 记录</div>
+          <div className="text-[14px] font-semibold text-[#344054]">
+            {backfillId ? 'Backfill Trigger 明细' : 'Trigger 记录'}
+          </div>
           <div className="mt-0.5 text-[11px] font-normal text-[#98a2b3]">
-            {schedule?.name || '-'} · 每个计划时间最多产生一条 Ledger 记录
+            {backfillName || schedule?.name || '-'} · {backfillId ? '按补数批次隔离幂等' : '每个正常计划时间最多产生一条 Ledger 记录'}
           </div>
         </div>
       }
@@ -91,8 +106,9 @@ const TriggerLedgerDrawer = ({ open, schedule, onClose }: TriggerLedgerDrawerPro
       }
     >
       <div className="mb-3 rounded-sm bg-[#f8f9fb] px-3 py-2 text-[11px] leading-5 text-[#667085]">
-        SERIAL_WAIT 会先进入 WAITING，前序 WorkflowExecution 终态提交后自动推进；
-        SERIAL_DISCARD 会记为 SKIPPED；Misfire 的 FIRE_ONCE / SKIP 同样保留审计记录。
+        {backfillId
+          ? 'Backfill 的 businessDate / scheduleTime 来自历史逻辑计划时间；不同 Backfill 批次可重新执行同一天，同一批次仍由 dedupeKey 保证幂等。'
+          : 'SERIAL_WAIT 会先进入 WAITING，前序 WorkflowExecution 终态提交后自动推进；SERIAL_DISCARD 会记为 SKIPPED；Misfire 同样保留审计记录。'}
       </div>
       <Table
         rowKey="id"
@@ -100,7 +116,7 @@ const TriggerLedgerDrawer = ({ open, schedule, onClose }: TriggerLedgerDrawerPro
         bordered
         loading={loading}
         dataSource={records}
-        scroll={{ x: 1280 }}
+        scroll={{ x: 1430 }}
         pagination={{ pageSize: 20, showSizeChanger: false, showTotal: (total) => `共 ${total} 条` }}
         columns={[
           {
@@ -110,6 +126,14 @@ const TriggerLedgerDrawer = ({ open, schedule, onClose }: TriggerLedgerDrawerPro
             fixed: 'left',
             render: (value: WorkflowScheduleTriggerStatus) => (
               <span className="text-[12px] font-medium text-[#475467]">{STATUS_LABEL[value] || value}</span>
+            ),
+          },
+          {
+            title: 'businessDate',
+            dataIndex: 'businessDate',
+            width: 115,
+            render: (value?: string) => (
+              <code className="text-[11px] text-[#475467]">{value || '-'}</code>
             ),
           },
           {

--- a/yak-ops-ui/src/pages/workflow/schedules/TriggerLedgerDrawer.tsx
+++ b/yak-ops-ui/src/pages/workflow/schedules/TriggerLedgerDrawer.tsx
@@ -69,10 +69,11 @@ const TriggerLedgerDrawer = ({
   }, [backfillId, open, schedule?.id, status]);
 
   useEffect(() => {
-    if (open) {
-      setStatus(undefined);
-      void load();
-    }
+    if (open) setStatus(undefined);
+  }, [backfillId, open, schedule?.id]);
+
+  useEffect(() => {
+    if (open) void load();
   }, [load, open]);
 
   return (

--- a/yak-ops-ui/src/pages/workflow/schedules/index.tsx
+++ b/yak-ops-ui/src/pages/workflow/schedules/index.tsx
@@ -4,12 +4,15 @@ import {
   listWorkflowSchedules,
   offlineWorkflowSchedule,
   onlineWorkflowSchedule,
+  type WorkflowBackfill,
   type WorkflowSchedule,
 } from '@/services/workflow/schedules';
 import { ReloadOutlined, SearchOutlined } from '@ant-design/icons';
 import { Button, ConfigProvider, Input, Modal, Select, Table, Tooltip, message } from 'antd';
-import { CalendarClock, History, Pencil, Power, PowerOff, Trash2 } from 'lucide-react';
+import { CalendarClock, DatabaseBackup, History, Pencil, Power, PowerOff, Trash2 } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import BackfillDrawer from './BackfillDrawer';
+import BackfillHistoryDrawer from './BackfillHistoryDrawer';
 import ScheduleEditorDrawer from './ScheduleEditorDrawer';
 import TriggerLedgerDrawer from './TriggerLedgerDrawer';
 
@@ -38,6 +41,10 @@ const WorkflowSchedulesPage = () => {
   const [editing, setEditing] = useState<WorkflowSchedule>();
   const [ledgerOpen, setLedgerOpen] = useState(false);
   const [ledgerSchedule, setLedgerSchedule] = useState<WorkflowSchedule>();
+  const [ledgerBackfill, setLedgerBackfill] = useState<WorkflowBackfill>();
+  const [backfillOpen, setBackfillOpen] = useState(false);
+  const [backfillSchedule, setBackfillSchedule] = useState<WorkflowSchedule>();
+  const [backfillHistoryOpen, setBackfillHistoryOpen] = useState(false);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -95,7 +102,7 @@ const WorkflowSchedulesPage = () => {
     Modal.confirm({
       centered: true,
       title: '确认删除调度吗？',
-      content: `即将删除「${schedule.name}」。调度定义会删除，历史 Trigger Ledger 会保留用于审计。`,
+      content: `即将删除「${schedule.name}」。调度定义会删除，历史 Trigger Ledger 与已创建 Backfill 批次会保留用于审计。`,
       okText: '删除',
       cancelText: '取消',
       okButtonProps: { danger: true },
@@ -109,6 +116,18 @@ const WorkflowSchedulesPage = () => {
         }
       },
     });
+  };
+
+  const openNormalLedger = (schedule: WorkflowSchedule) => {
+    setLedgerBackfill(undefined);
+    setLedgerSchedule(schedule);
+    setLedgerOpen(true);
+  };
+
+  const openBackfillLedger = (backfill: WorkflowBackfill) => {
+    setLedgerBackfill(backfill);
+    setLedgerSchedule(schedules.find((item) => item.id === backfill.scheduleId));
+    setLedgerOpen(true);
   };
 
   const columns = [
@@ -170,17 +189,30 @@ const WorkflowSchedulesPage = () => {
       render: (value?: string) => <span className="text-[12px] text-[#98a2b3]">{formatTime(value)}</span>,
     },
     {
-      title: '操作', dataIndex: 'operate', width: 300, fixed: 'right' as const,
+      title: '操作', dataIndex: 'operate', width: 380, fixed: 'right' as const,
       render: (_: unknown, record: WorkflowSchedule) => {
         const workflowOnline = workflowMap.get(record.workflowId)?.status === 'ONLINE';
         const online = record.status === 'ONLINE';
         return (
           <div className="flex items-center gap-0.5 whitespace-nowrap">
+            <Tooltip title={!workflowOnline ? '工作流需先上线；调度本身可以处于停用状态' : undefined}>
+              <span>
+                <Button
+                  type="text"
+                  size="small"
+                  disabled={!workflowOnline}
+                  icon={<DatabaseBackup size={13} />}
+                  onClick={() => { setBackfillSchedule(record); setBackfillOpen(true); }}
+                >
+                  补数
+                </Button>
+              </span>
+            </Tooltip>
             <Button
               type="text"
               size="small"
               icon={<History size={13} />}
-              onClick={() => { setLedgerSchedule(record); setLedgerOpen(true); }}
+              onClick={() => openNormalLedger(record)}
             >
               触发记录
             </Button>
@@ -225,11 +257,16 @@ const WorkflowSchedulesPage = () => {
         <div className="flex items-center justify-between">
           <div>
             <h1 className="m-0 text-[17px] font-semibold leading-8">调度管理</h1>
-            <div className="text-[11px] text-[#98a2b3]">Yak Schedule / Quartz · Trigger Ledger、并发策略与恢复</div>
+            <div className="text-[11px] text-[#98a2b3]">Yak Schedule / Quartz · Trigger Ledger、Backfill、调度参数与恢复</div>
           </div>
-          <Button danger type="primary" size="small" icon={<CalendarClock size={14} />} onClick={() => { setEditing(undefined); setEditorOpen(true); }}>
-            新建调度
-          </Button>
+          <div className="flex items-center gap-2">
+            <Button size="small" icon={<History size={14} />} onClick={() => setBackfillHistoryOpen(true)}>
+              补数记录
+            </Button>
+            <Button danger type="primary" size="small" icon={<CalendarClock size={14} />} onClick={() => { setEditing(undefined); setEditorOpen(true); }}>
+              新建调度
+            </Button>
+          </div>
         </div>
 
         <div className="mt-4 flex min-h-[52px] items-center justify-between gap-3 border-y border-[#f0f0f0]">
@@ -260,7 +297,7 @@ const WorkflowSchedulesPage = () => {
         </div>
 
         <div className="mt-3 flex min-h-9 items-center rounded-sm bg-[#f8f9fb] px-3 text-[12px] text-[#475467]">
-          <span><b>【生产调度】</b> Trigger Ledger 保证同一计划时间幂等；串行等待/跳过、并行执行与 Misfire 恢复均保留可审计记录。</span>
+          <span><b>【调度参数】</b> Cron 与 Backfill 均按逻辑计划时间注入 businessDate / scheduleTime；历史补数复用 Trigger Ledger 幂等、串行等待与并行执行。</span>
         </div>
 
         <div className="mt-4 flex-1">
@@ -271,7 +308,7 @@ const WorkflowSchedulesPage = () => {
             loading={loading}
             columns={columns as any}
             dataSource={filtered}
-            scroll={{ x: 1630 }}
+            scroll={{ x: 1740 }}
             pagination={{ pageSize: 10, showSizeChanger: true, pageSizeOptions: [10, 20, 50], showTotal: (total) => `共 ${total} 条` }}
             className="[&_.ant-table-thead>tr>th]:!bg-[#f8f9fb] [&_.ant-table-thead>tr>th]:!text-[12px] [&_.ant-table-thead>tr>th]:!text-[#667085] [&_.ant-table-tbody>tr>td]:!py-2.5"
           />
@@ -285,10 +322,31 @@ const WorkflowSchedulesPage = () => {
           onClose={() => { setEditorOpen(false); setEditing(undefined); }}
           onSaved={load}
         />
+        <BackfillDrawer
+          open={backfillOpen}
+          schedule={backfillSchedule}
+          onClose={() => { setBackfillOpen(false); setBackfillSchedule(undefined); }}
+          onCreated={async () => {
+            await load();
+            setBackfillHistoryOpen(true);
+          }}
+        />
+        <BackfillHistoryDrawer
+          open={backfillHistoryOpen}
+          workflowId={workflowId}
+          onClose={() => setBackfillHistoryOpen(false)}
+          onOpenTriggers={openBackfillLedger}
+        />
         <TriggerLedgerDrawer
           open={ledgerOpen}
           schedule={ledgerSchedule}
-          onClose={() => { setLedgerOpen(false); setLedgerSchedule(undefined); }}
+          backfillId={ledgerBackfill?.id}
+          backfillName={ledgerBackfill?.name}
+          onClose={() => {
+            setLedgerOpen(false);
+            setLedgerSchedule(undefined);
+            setLedgerBackfill(undefined);
+          }}
         />
       </div>
     </ConfigProvider>

--- a/yak-ops-ui/src/services/workflow/schedules.ts
+++ b/yak-ops-ui/src/services/workflow/schedules.ts
@@ -16,6 +16,14 @@ export type WorkflowScheduleTriggerStatus =
   | 'FAILED'
   | 'CANCELED'
   | 'SKIPPED';
+export type WorkflowBackfillStatus =
+  | 'CREATED'
+  | 'RUNNING'
+  | 'SUCCEEDED'
+  | 'PARTIAL_SUCCESS'
+  | 'FAILED'
+  | 'CANCELED';
+export type WorkflowBackfillExecutionStrategy = 'SERIAL_WAIT' | 'PARALLEL';
 
 export interface WorkflowSchedule {
   id: string;
@@ -40,8 +48,10 @@ export interface WorkflowScheduleTrigger {
   id: string;
   scheduleId: string;
   workflowId: string;
+  backfillId?: string;
   triggerId: string;
-  triggerSource: 'CRON' | 'MANUAL' | 'MISFIRE_RECOVERY' | string;
+  triggerSource: 'CRON' | 'MANUAL' | 'MISFIRE_RECOVERY' | 'BACKFILL' | string;
+  businessDate?: string;
   plannedFireTime: string;
   actualFireTime: string;
   executionStrategy: WorkflowScheduleExecutionStrategy;
@@ -53,6 +63,58 @@ export interface WorkflowScheduleTrigger {
   errorMessage?: string;
   launchedAt?: string;
   completedAt?: string;
+  createTime: string;
+  updateTime: string;
+}
+
+export interface WorkflowBackfillPayload {
+  scheduleId: string;
+  name?: string;
+  startBusinessDate: string;
+  endBusinessDate: string;
+  executionStrategy: WorkflowBackfillExecutionStrategy;
+  input: Record<string, unknown>;
+}
+
+export interface WorkflowBackfillPreviewOccurrence {
+  businessDate: string;
+  scheduleInstant: string;
+  scheduleTime: string;
+}
+
+export interface WorkflowBackfillPreview {
+  scheduleId: string;
+  cronExpression: string;
+  timezone: string;
+  startBusinessDate: string;
+  endBusinessDate: string;
+  totalCount: number;
+  truncated: boolean;
+  occurrences: WorkflowBackfillPreviewOccurrence[];
+}
+
+export interface WorkflowBackfill {
+  id: string;
+  workflowId: string;
+  workflowVersionId: string;
+  workflowVersionNo: number;
+  scheduleId: string;
+  scheduleName: string;
+  name: string;
+  status: WorkflowBackfillStatus;
+  startBusinessDate: string;
+  endBusinessDate: string;
+  cronExpression: string;
+  timezone: string;
+  executionStrategy: WorkflowBackfillExecutionStrategy;
+  input: Record<string, unknown>;
+  totalCount: number;
+  waitingCount: number;
+  runningCount: number;
+  succeededCount: number;
+  failedCount: number;
+  canceledCount: number;
+  skippedCount: number;
   createTime: string;
   updateTime: string;
 }
@@ -82,6 +144,7 @@ export const listWorkflowSchedules = async (params?: {
 export const listWorkflowScheduleTriggers = async (params?: {
   scheduleId?: string;
   workflowId?: string;
+  backfillId?: string;
   status?: WorkflowScheduleTriggerStatus;
   limit?: number;
 }) => {
@@ -90,6 +153,49 @@ export const listWorkflowScheduleTriggers = async (params?: {
     { params },
   );
   return response.data || [];
+};
+
+export const previewWorkflowBackfill = async (payload: WorkflowBackfillPayload) => {
+  const response = await request<ApiResponse<WorkflowBackfillPreview>>(
+    '/api/v1/workflows/backfills/preview',
+    { method: 'POST', data: payload },
+  );
+  return response.data;
+};
+
+export const createWorkflowBackfill = async (payload: WorkflowBackfillPayload) => {
+  const response = await request<ApiResponse<WorkflowBackfill>>(
+    '/api/v1/workflows/backfills',
+    { method: 'POST', data: payload },
+  );
+  return response.data;
+};
+
+export const listWorkflowBackfills = async (params?: {
+  workflowId?: string;
+  scheduleId?: string;
+  status?: WorkflowBackfillStatus;
+}) => {
+  const response = await request<ApiResponse<WorkflowBackfill[]>>(
+    '/api/v1/workflows/backfills',
+    { params },
+  );
+  return response.data || [];
+};
+
+export const getWorkflowBackfill = async (id: string) => {
+  const response = await request<ApiResponse<WorkflowBackfill>>(
+    `/api/v1/workflows/backfills/${encodeURIComponent(id)}`,
+  );
+  return response.data;
+};
+
+export const cancelWorkflowBackfill = async (id: string) => {
+  const response = await request<ApiResponse<WorkflowBackfill>>(
+    `/api/v1/workflows/backfills/${encodeURIComponent(id)}/cancel`,
+    { method: 'POST' },
+  );
+  return response.data;
 };
 
 export const createWorkflowSchedule = async (


### PR DESCRIPTION
## 背景

Stage 5：在 Stage 4 已具备的 Trigger Ledger / 幂等 / SERIAL_WAIT / PARALLEL / Misfire 恢复基础上，补齐数据调度场景最关键的 **历史补数（Backfill）与调度参数体系**。

本 PR 的核心原则仍然是不创建第二套执行引擎：Backfill 只负责生成历史逻辑计划，真正的执行继续复用 Stage 4 的 `Trigger Ledger -> Admission -> Launch -> WorkflowExecution -> Terminal Event` 链路。

## 整体链路

```text
WorkflowVersion input
        ↓
Schedule input
        ↓
Backfill input
        ↓
System scheduling parameters
        ↓
WorkflowRunInputScope
        ↓
WorkflowRunSpec.input
        ↓
engine.start

历史业务日期区间
        ↓
WorkflowBackfillPlanner (Quartz Cron + timezone)
        ↓
Backfill Batch
        ↓
Trigger Ledger
        ↓
SERIAL_WAIT / PARALLEL
        ↓
Pinned Workflow Version
        ↓
WorkflowExecution
```

## 调度参数体系

正常 Cron 与 Backfill 都按照 **逻辑计划时间 plannedFireTime** 生成参数，而不是按照实际启动时间。因此即使实例排队、Misfire 恢复或服务重启，业务日期仍保持稳定。

系统自动注入：

- `businessDate`
- `scheduleTime`
- `scheduleTimezone`
- `plannedFireTime`
- `triggerType`
- `triggerId`
- `scheduleId`
- `backfillId`（Backfill）
- `cronExpression`
- `workflowVersionId / workflowVersionNo`（Backfill）

同一份系统参数也保留在 `__schedule` 命名空间，可通过例如 `$workflow.__schedule.businessDate` 使用。

参数优先级：

```text
WorkflowVersion input
    < Schedule input
    < Backfill input
    < System reserved parameters
```

Schedule 编辑器原有的运行参数 JSON 在 Stage 5 开始真正进入 Workflow Runtime，不再只是配置字段。

## Backfill 批次

新增 `yak_workflow_backfill`，一个 Backfill 批次保存：

- workflow / schedule
- 创建时的 workflow version ID / version no
- schedule name / Cron / timezone 快照
- Schedule input 快照
- Backfill input
- 业务日期范围
- 执行策略
- 计划实例总数

Backfill 明细不再新建第二张实例表，而是直接复用 `yak_workflow_schedule_trigger`。

## Quartz 历史计划生成

新增 `WorkflowBackfillPlanner`，使用与 Stage 3 相同的 Quartz `CronExpression` 语义，根据：

```text
Cron + timezone + businessDate range
```

重新生成历史逻辑计划时间。

例如：

```text
Cron: 0 0 2 * * ?
Timezone: Asia/Shanghai
Business Date: 2026-08-01 ~ 2026-08-03

=>
2026-08-01 / 2026-08-01T02:00:00+08:00
2026-08-02 / 2026-08-02T02:00:00+08:00
2026-08-03 / 2026-08-03T02:00:00+08:00
```

单批次最多生成 1000 个逻辑实例，并限制过大的日期跨度。

5 字段 Unix Cron 会安全转换为 Quartz Cron；如果同时指定 day-of-month 与 day-of-week、两种 Cron 方言语义不等价，则明确拒绝而不是静默生成错误日期。

## Trigger Ledger 幂等升级

Stage 4 的唯一键：

```text
(schedule_id, planned_fire_time)
```

无法支持“正常 Cron 已经执行过该日期，但现在要重新补数”。

Stage 5 新增 `dedupe_key`：

正常 Cron / Misfire：

```text
scheduleId | SCHEDULE | plannedEpochMillis
```

Backfill：

```text
scheduleId | BACKFILL | backfillId | plannedEpochMillis
```

因此：

- 同一个正常计划仍然只能执行一次
- 同一个 Backfill 批次重放仍然幂等
- 不同 Backfill 批次可以重新补同一个业务日期
- Backfill 可以补已经被正常 Cron 执行过的计划时间

同时保留 Stage 4 `(scheduleId, plannedFireTime)` 的历史兼容查询，避免 V4 迁移时数据库时区影响历史 Ledger 的幂等识别。

## Pinned Published Version

正常 Cron：

```text
FOLLOW_ACTIVE
```

每次触发执行当前 active WorkflowVersion。

Backfill：

```text
PINNED_VERSION
```

批次创建时固定当前已发布版本，并直接从不可变版本库加载该版本的：

- `WorkflowRunSpec`
- `TaskVersionSnapshot`
- workflow version ID / no

例如 Backfill 创建时固定 V5，即使补数过程中正常发布了 V6，剩余历史实例仍然继续执行 V5，不会前半批 V5、后半批 V6。

## Backfill 执行策略

Stage 5 支持：

### SERIAL_WAIT

默认 / 推荐。历史实例进入 Stage 4 全局串行队列，按逻辑计划时间等待前序 WorkflowExecution 进入终态后推进。

### PARALLEL

允许多个历史计划实例并行创建 WorkflowExecution。

Stage 5 暂不开放 Backfill `SERIAL_DISCARD`，避免历史补数因为已有实例而永久缺日期。

## Schedule 与 Backfill 生命周期隔离

Schedule 下线表示停止未来 Cron，因此：

- Schedule 下线会取消正常 Cron/Misfire 的 WAITING Trigger
- 已创建的 Backfill 批次不会因为 Schedule 下线/删除而被一起取消
- Backfill 使用创建批次时保存的 Cron / timezone / input / version 快照
- 工作流本身下线仍阻止新的 Backfill WorkflowExecution 启动

Backfill 显式取消时：

- `RECEIVED / WAITING` -> `SKIPPED`
- 已经 RUNNING 的 WorkflowExecution 继续完成

## Backfill 宕机恢复

Backfill 批次定义先持久化，再逐个生成 Trigger，不使用“1000 个实例 + Workflow 启动”的巨型数据库事务。

为处理“批次已经保存，但进程只生成了一部分 Trigger 就退出”的窗口，新增 `WorkflowBackfillReconciler`：

1. Runtime execution recovery `@Order(10)`
2. Backfill batch reconcile `@Order(15)`
3. Schedule / Trigger Ledger reconcile `@Order(20)`

启动时重新根据 Backfill 快照生成完整 occurrence 列表并逐条 submit：

- 已存在 Trigger -> dedupeKey 拦截
- 缺失 Trigger -> 自动补齐
- WAITING / LAUNCHING / RUNNING -> Stage 4 Ledger recovery 继续恢复

## API

新增 `/api/v1/workflows/backfills`：

- `POST /preview`：预览逻辑计划时间
- `POST /`：创建 Backfill
- `GET /`：查询 Backfill 批次
- `GET /{id}`：批次详情
- `POST /{id}/cancel`：取消尚未启动的补数计划

Trigger Ledger 查询增加 `backfillId` 过滤。

## 前端

调度管理页新增：

- 每条 Schedule 的「补数」入口
- Backfill 日期范围
- SERIAL_WAIT / PARALLEL
- Backfill JSON 参数
- 「预览计划」：展示 businessDate / scheduleTime 与实例总数
- 顶部「补数记录」
- 批次进度：等待 / 运行 / 成功 / 失败 / 跳过
- 固定 Workflow Version 展示
- Backfill 取消
- 下钻 Backfill 专属 Trigger Ledger
- Trigger Ledger 新增 businessDate / BACKFILL source

## 测试覆盖

新增/更新测试覆盖：

- Quartz 时区下的历史 occurrence 生成
- 5 字段 Cron 安全转换与歧义拒绝
- 单批次 occurrence 上限
- Schedule 参数注入
- Backfill 参数覆盖优先级
- system reserved parameters 不被用户覆盖
- `__schedule` 命名空间
- WorkflowRunInputScope 嵌套恢复
- Schedule / Backfill dedupe scope
- 不同 Backfill 批次可补同一计划时间
- Misfire V4 dedupe / businessDate 兼容
- Backfill Trigger -> Ledger -> pinned launch
- V5 Backfill 在 active 已变 V6 后仍执行 V5
- pinned WorkflowRunSpec / TaskVersionSnapshot
- Backfill 批次物化的启动恢复
- Stage 4 Coordinator 回归

## Stage 5 边界

本 PR 不包含：

- 从指定节点开始的历史补跑 / partial DAG Backfill
- SERIAL_PRIORITY / Backfill 优先级队列
- businessDate offset / T-1 / 自定义交易日历
- Backfill 批次超过 1000 个实例的自动分片
- 分布式 Scheduler Master / Quartz JDBC Cluster

这些可以继续作为后续阶段演进，Stage 5 先把数据调度最关键的“逻辑时间 + 参数 + 历史补数 + 可重复执行”闭环做完整。