### PR TITLE
feat(dashboard): persist Dashboard assets with immutable versions

### DIFF
--- a/yak-ops-boot/pom.xml
+++ b/yak-ops-boot/pom.xml
@@ -16,83 +16,25 @@
     <description>Yak Ops application assembly and Spring Boot entry module</description>
 
     <dependencies>
-        <dependency>
-            <groupId>io.yak.ops</groupId>
-            <artifactId>yak-ops-business-datasource</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.yak.ops</groupId>
-            <artifactId>yak-ops-business-job</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.yak.ops</groupId>
-            <artifactId>yak-ops-business-task-catalog</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.yak.ops</groupId>
-            <artifactId>yak-ops-business-data-development</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.yak.ops</groupId>
-            <artifactId>yak-ops-business-dataset</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.yak.ops</groupId>
-            <artifactId>yak-ops-business-analysis</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.yak.ops</groupId>
-            <artifactId>yak-ops-business-resource</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.yak.ops</groupId>
-            <artifactId>yak-ops-business-sync-offline</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.yak.ops</groupId>
-            <artifactId>yak-ops-business-quality</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.yak.ops</groupId>
-            <artifactId>yak-ops-business-workflow</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.yak.ops</groupId>
-            <artifactId>yak-ops-plugin-datasource-all</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.yak.ops</groupId>
-            <artifactId>yak-ops-plugin-storage-all</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.yak.ops</groupId>
-            <artifactId>yak-ops-plugin-task-all</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.yak.framework</groupId>
-            <artifactId>yak-security-spring-boot-starter</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.yak.framework</groupId>
-            <artifactId>yak-schedule-core</artifactId>
-            <version>${yak-framework.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.yak.framework</groupId>
-            <artifactId>yak-schedule-plugin-quartz</artifactId>
-            <version>${yak-framework.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
-            <scope>test</scope>
-        </dependency>
+        <dependency><groupId>io.yak.ops</groupId><artifactId>yak-ops-business-datasource</artifactId></dependency>
+        <dependency><groupId>io.yak.ops</groupId><artifactId>yak-ops-business-job</artifactId></dependency>
+        <dependency><groupId>io.yak.ops</groupId><artifactId>yak-ops-business-task-catalog</artifactId></dependency>
+        <dependency><groupId>io.yak.ops</groupId><artifactId>yak-ops-business-data-development</artifactId></dependency>
+        <dependency><groupId>io.yak.ops</groupId><artifactId>yak-ops-business-dataset</artifactId><version>${project.version}</version></dependency>
+        <dependency><groupId>io.yak.ops</groupId><artifactId>yak-ops-business-analysis</artifactId><version>${project.version}</version></dependency>
+        <dependency><groupId>io.yak.ops</groupId><artifactId>yak-ops-business-dashboard</artifactId><version>${project.version}</version></dependency>
+        <dependency><groupId>io.yak.ops</groupId><artifactId>yak-ops-business-resource</artifactId></dependency>
+        <dependency><groupId>io.yak.ops</groupId><artifactId>yak-ops-business-sync-offline</artifactId></dependency>
+        <dependency><groupId>io.yak.ops</groupId><artifactId>yak-ops-business-quality</artifactId></dependency>
+        <dependency><groupId>io.yak.ops</groupId><artifactId>yak-ops-business-workflow</artifactId></dependency>
+        <dependency><groupId>io.yak.ops</groupId><artifactId>yak-ops-plugin-datasource-all</artifactId></dependency>
+        <dependency><groupId>io.yak.ops</groupId><artifactId>yak-ops-plugin-storage-all</artifactId></dependency>
+        <dependency><groupId>io.yak.ops</groupId><artifactId>yak-ops-plugin-task-all</artifactId></dependency>
+        <dependency><groupId>io.yak.framework</groupId><artifactId>yak-security-spring-boot-starter</artifactId></dependency>
+        <dependency><groupId>io.yak.framework</groupId><artifactId>yak-schedule-core</artifactId><version>${yak-framework.version}</version></dependency>
+        <dependency><groupId>io.yak.framework</groupId><artifactId>yak-schedule-plugin-quartz</artifactId><version>${yak-framework.version}</version></dependency>
+        <dependency><groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-web</artifactId></dependency>
+        <dependency><groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-test</artifactId><scope>test</scope></dependency>
     </dependencies>
 
     <build>
@@ -100,9 +42,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <configuration>
-                    <mainClass>io.yak.ops.boot.YakOpsApplication</mainClass>
-                </configuration>
+                <configuration><mainClass>io.yak.ops.boot.YakOpsApplication</mainClass></configuration>
             </plugin>
         </plugins>
     </build>

--- a/yak-ops-boot/pom.xml
+++ b/yak-ops-boot/pom.xml
@@ -16,25 +16,88 @@
     <description>Yak Ops application assembly and Spring Boot entry module</description>
 
     <dependencies>
-        <dependency><groupId>io.yak.ops</groupId><artifactId>yak-ops-business-datasource</artifactId></dependency>
-        <dependency><groupId>io.yak.ops</groupId><artifactId>yak-ops-business-job</artifactId></dependency>
-        <dependency><groupId>io.yak.ops</groupId><artifactId>yak-ops-business-task-catalog</artifactId></dependency>
-        <dependency><groupId>io.yak.ops</groupId><artifactId>yak-ops-business-data-development</artifactId></dependency>
-        <dependency><groupId>io.yak.ops</groupId><artifactId>yak-ops-business-dataset</artifactId><version>${project.version}</version></dependency>
-        <dependency><groupId>io.yak.ops</groupId><artifactId>yak-ops-business-analysis</artifactId><version>${project.version}</version></dependency>
-        <dependency><groupId>io.yak.ops</groupId><artifactId>yak-ops-business-dashboard</artifactId><version>${project.version}</version></dependency>
-        <dependency><groupId>io.yak.ops</groupId><artifactId>yak-ops-business-resource</artifactId></dependency>
-        <dependency><groupId>io.yak.ops</groupId><artifactId>yak-ops-business-sync-offline</artifactId></dependency>
-        <dependency><groupId>io.yak.ops</groupId><artifactId>yak-ops-business-quality</artifactId></dependency>
-        <dependency><groupId>io.yak.ops</groupId><artifactId>yak-ops-business-workflow</artifactId></dependency>
-        <dependency><groupId>io.yak.ops</groupId><artifactId>yak-ops-plugin-datasource-all</artifactId></dependency>
-        <dependency><groupId>io.yak.ops</groupId><artifactId>yak-ops-plugin-storage-all</artifactId></dependency>
-        <dependency><groupId>io.yak.ops</groupId><artifactId>yak-ops-plugin-task-all</artifactId></dependency>
-        <dependency><groupId>io.yak.framework</groupId><artifactId>yak-security-spring-boot-starter</artifactId></dependency>
-        <dependency><groupId>io.yak.framework</groupId><artifactId>yak-schedule-core</artifactId><version>${yak-framework.version}</version></dependency>
-        <dependency><groupId>io.yak.framework</groupId><artifactId>yak-schedule-plugin-quartz</artifactId><version>${yak-framework.version}</version></dependency>
-        <dependency><groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-web</artifactId></dependency>
-        <dependency><groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-test</artifactId><scope>test</scope></dependency>
+        <dependency>
+            <groupId>io.yak.ops</groupId>
+            <artifactId>yak-ops-business-datasource</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.yak.ops</groupId>
+            <artifactId>yak-ops-business-job</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.yak.ops</groupId>
+            <artifactId>yak-ops-business-task-catalog</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.yak.ops</groupId>
+            <artifactId>yak-ops-business-data-development</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.yak.ops</groupId>
+            <artifactId>yak-ops-business-dataset</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.yak.ops</groupId>
+            <artifactId>yak-ops-business-analysis</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.yak.ops</groupId>
+            <artifactId>yak-ops-business-dashboard</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.yak.ops</groupId>
+            <artifactId>yak-ops-business-resource</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.yak.ops</groupId>
+            <artifactId>yak-ops-business-sync-offline</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.yak.ops</groupId>
+            <artifactId>yak-ops-business-quality</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.yak.ops</groupId>
+            <artifactId>yak-ops-business-workflow</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.yak.ops</groupId>
+            <artifactId>yak-ops-plugin-datasource-all</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.yak.ops</groupId>
+            <artifactId>yak-ops-plugin-storage-all</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.yak.ops</groupId>
+            <artifactId>yak-ops-plugin-task-all</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.yak.framework</groupId>
+            <artifactId>yak-security-spring-boot-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.yak.framework</groupId>
+            <artifactId>yak-schedule-core</artifactId>
+            <version>${yak-framework.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.yak.framework</groupId>
+            <artifactId>yak-schedule-plugin-quartz</artifactId>
+            <version>${yak-framework.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -42,7 +105,9 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <configuration><mainClass>io.yak.ops.boot.YakOpsApplication</mainClass></configuration>
+                <configuration>
+                    <mainClass>io.yak.ops.boot.YakOpsApplication</mainClass>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/yak-ops-business/pom.xml
+++ b/yak-ops-business/pom.xml
@@ -24,6 +24,7 @@
         <module>yak-ops-business-data-development</module>
         <module>yak-ops-business-dataset</module>
         <module>yak-ops-business-analysis</module>
+        <module>yak-ops-business-dashboard</module>
         <module>yak-ops-business-resource</module>
         <module>yak-ops-business-sync</module>
         <module>yak-ops-business-quality</module>

--- a/yak-ops-business/yak-ops-business-analysis/src/main/java/io/yak/ops/business/analysis/AnalysisReferenceService.java
+++ b/yak-ops-business/yak-ops-business-analysis/src/main/java/io/yak/ops/business/analysis/AnalysisReferenceService.java
@@ -1,0 +1,18 @@
+package io.yak.ops.business.analysis;
+
+import org.springframework.stereotype.Service;
+
+/** Narrow cross-domain port for assets that only need to hold a stable Analysis reference. */
+@Service
+public class AnalysisReferenceService {
+
+  private final AnalysisService analysisService;
+
+  public AnalysisReferenceService(AnalysisService analysisService) {
+    this.analysisService = analysisService;
+  }
+
+  public void requireExists(long analysisId) {
+    analysisService.get(analysisId);
+  }
+}

--- a/yak-ops-business/yak-ops-business-dashboard/pom.xml
+++ b/yak-ops-business/yak-ops-business-dashboard/pom.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.yak.ops</groupId>
+        <artifactId>yak-ops-business</artifactId>
+        <version>1.0.0</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <artifactId>yak-ops-business-dashboard</artifactId>
+    <name>Yak Ops Business Dashboard</name>
+    <description>Persistent versioned dashboards composed from reusable Analysis assets</description>
+    <dependencies>
+        <dependency><groupId>io.yak.ops</groupId><artifactId>yak-ops-common</artifactId></dependency>
+        <dependency><groupId>io.yak.ops</groupId><artifactId>yak-ops-business-datasource</artifactId></dependency>
+        <dependency><groupId>io.yak.ops</groupId><artifactId>yak-ops-business-analysis</artifactId><version>${project.version}</version></dependency>
+        <dependency><groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-web</artifactId></dependency>
+        <dependency><groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-validation</artifactId></dependency>
+        <dependency><groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-jdbc</artifactId></dependency>
+        <dependency><groupId>org.springdoc</groupId><artifactId>springdoc-openapi-starter-webmvc-ui</artifactId></dependency>
+        <dependency><groupId>org.flywaydb</groupId><artifactId>flyway-core</artifactId></dependency>
+        <dependency><groupId>org.flywaydb</groupId><artifactId>flyway-mysql</artifactId></dependency>
+        <dependency><groupId>com.mysql</groupId><artifactId>mysql-connector-j</artifactId><scope>runtime</scope></dependency>
+        <dependency><groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-test</artifactId><scope>test</scope></dependency>
+    </dependencies>
+</project>

--- a/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/DashboardAsset.java
+++ b/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/DashboardAsset.java
@@ -1,0 +1,50 @@
+package io.yak.ops.business.dashboard;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import java.time.Instant;
+import java.util.List;
+
+/** Stable Dashboard identity. Layout/query composition lives in immutable versions. */
+public record DashboardAsset(
+    @JsonSerialize(using = ToStringSerializer.class) long id,
+    String name,
+    String description,
+    @JsonSerialize(using = ToStringSerializer.class) Long currentVersionId,
+    int currentVersionNo,
+    Instant createTime,
+    Instant updateTime) {
+}
+
+record DashboardVersion(
+    @JsonSerialize(using = ToStringSerializer.class) long id,
+    @JsonSerialize(using = ToStringSerializer.class) long dashboardId,
+    int versionNo,
+    String name,
+    String description,
+    @JsonSerialize(using = ToStringSerializer.class) Long activeDatasetId,
+    Instant createTime) {
+}
+
+record DashboardWidgetSnapshot(
+    @JsonSerialize(using = ToStringSerializer.class) long id,
+    @JsonSerialize(using = ToStringSerializer.class) long dashboardVersionId,
+    String widgetKey,
+    @JsonSerialize(using = ToStringSerializer.class) Long analysisId,
+    String title,
+    Object inlineAnalysis,
+    int x,
+    int y,
+    int w,
+    int h,
+    Integer minW,
+    Integer minH,
+    int sortOrder) {
+}
+
+record DashboardDetail(
+    DashboardAsset dashboard,
+    DashboardVersion currentVersion,
+    List<DashboardVersion> versions,
+    List<DashboardWidgetSnapshot> widgets) {
+}

--- a/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/DashboardController.java
+++ b/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/DashboardController.java
@@ -1,0 +1,106 @@
+package io.yak.ops.business.dashboard;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.yak.framework.common.Result;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "BI 仪表盘接口")
+@RestController
+@RequestMapping("/api/v1/dashboards")
+public class DashboardController {
+
+  private final DashboardService service;
+
+  public DashboardController(DashboardService service) {
+    this.service = service;
+  }
+
+  @Operation(summary = "查询 Dashboard 列表")
+  @GetMapping
+  public Result<List<DashboardAsset>> list() {
+    return Result.success(service.list());
+  }
+
+  @Operation(summary = "查询 Dashboard 当前版本和历史版本")
+  @GetMapping("/{dashboardId}")
+  public Result<DashboardDetail> get(@PathVariable("dashboardId") long dashboardId) {
+    return Result.success(service.get(dashboardId));
+  }
+
+  @Operation(summary = "查询 Dashboard 版本历史")
+  @GetMapping("/{dashboardId}/versions")
+  public Result<List<DashboardVersion>> versions(@PathVariable("dashboardId") long dashboardId) {
+    return Result.success(service.versions(dashboardId));
+  }
+
+  @Operation(summary = "创建 Dashboard，并产生 V1")
+  @PostMapping
+  public Result<DashboardDetail> create(@Valid @RequestBody SaveDashboardRequest request) {
+    return Result.success(service.create(toCommand(request)));
+  }
+
+  @Operation(summary = "保存 Dashboard 新版本")
+  @PostMapping("/{dashboardId}/versions")
+  public Result<DashboardDetail> saveVersion(
+      @PathVariable("dashboardId") long dashboardId,
+      @Valid @RequestBody SaveDashboardRequest request) {
+    return Result.success(service.saveVersion(dashboardId, toCommand(request)));
+  }
+
+  @Operation(summary = "激活历史 DashboardVersion")
+  @PostMapping("/{dashboardId}/activate/{versionNo}")
+  public Result<DashboardDetail> activateVersion(
+      @PathVariable("dashboardId") long dashboardId,
+      @PathVariable("versionNo") int versionNo) {
+    return Result.success(service.activateVersion(dashboardId, versionNo));
+  }
+
+  @Operation(summary = "删除 Dashboard 及其历史版本")
+  @DeleteMapping("/{dashboardId}")
+  public Result<Boolean> delete(@PathVariable("dashboardId") long dashboardId) {
+    service.delete(dashboardId);
+    return Result.success(Boolean.TRUE);
+  }
+
+  private DashboardService.SaveCommand toCommand(SaveDashboardRequest request) {
+    return new DashboardService.SaveCommand(
+        request.name(), request.description(), request.activeDatasetId(),
+        request.widgets() == null ? List.of() : request.widgets().stream()
+            .map(widget -> new DashboardService.WidgetSpec(
+                widget.widgetKey(), widget.analysisId(), widget.title(), widget.inlineAnalysis(),
+                widget.x(), widget.y(), widget.w(), widget.h(), widget.minW(), widget.minH()))
+            .toList());
+  }
+
+  public record SaveDashboardRequest(
+      @NotBlank @Size(max = 200) String name,
+      @Size(max = 2000) String description,
+      @Min(1) Long activeDatasetId,
+      @Size(max = 200) List<@Valid WidgetRequest> widgets) {}
+
+  public record WidgetRequest(
+      @NotBlank @Size(max = 64) String widgetKey,
+      @Min(1) Long analysisId,
+      @Size(max = 200) String title,
+      Object inlineAnalysis,
+      @Min(0) @Max(23) int x,
+      @Min(0) int y,
+      @Min(1) @Max(24) int w,
+      @Min(1) @Max(60) int h,
+      @Min(1) @Max(24) Integer minW,
+      @Min(1) @Max(60) Integer minH) {}
+}

--- a/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/DashboardPersistenceConfiguration.java
+++ b/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/DashboardPersistenceConfiguration.java
@@ -1,0 +1,33 @@
+package io.yak.ops.business.dashboard;
+
+import io.yak.ops.business.datasource.config.BusinessDatabaseConfiguration;
+import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
+import io.yak.ops.business.datasource.config.DataSourceProperties;
+import javax.sql.DataSource;
+import org.flywaydb.core.Flyway;
+import org.flywaydb.core.api.MigrationVersion;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.context.annotation.Import;
+
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnDataSourceEnabled
+@EnableConfigurationProperties(DataSourceProperties.class)
+@Import(BusinessDatabaseConfiguration.class)
+public class DashboardPersistenceConfiguration {
+
+  @Bean(name = "yakDashboardFlyway", initMethod = "migrate")
+  @DependsOn("yakAnalysisFlyway")
+  public Flyway dashboardFlyway(@Qualifier("yakBusinessDataSource") DataSource dataSource) {
+    return Flyway.configure()
+        .dataSource(dataSource)
+        .locations("classpath:db/migration/yak-dashboard")
+        .table("flyway_schema_history_dashboard")
+        .baselineVersion(MigrationVersion.fromVersion("0"))
+        .baselineOnMigrate(true)
+        .load();
+  }
+}

--- a/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/DashboardRepository.java
+++ b/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/DashboardRepository.java
@@ -1,0 +1,19 @@
+package io.yak.ops.business.dashboard;
+
+import java.util.List;
+import java.util.Optional;
+
+interface DashboardRepository {
+  long insertDashboard(String name, String description);
+  long insertVersion(long dashboardId, int versionNo, String name, String description, Long activeDatasetId);
+  void insertWidgets(long versionId, List<DashboardService.WidgetSpec> widgets, List<String> inlineJson);
+  void updateCurrentVersion(long dashboardId, long versionId, int versionNo, String name, String description);
+  Optional<DashboardAsset> findDashboard(long dashboardId);
+  List<DashboardAsset> listDashboards();
+  Optional<DashboardVersion> findVersion(long versionId);
+  Optional<DashboardVersion> findVersionByNo(long dashboardId, int versionNo);
+  List<DashboardVersion> listVersions(long dashboardId);
+  List<DashboardWidgetSnapshot> listWidgets(long versionId);
+  int nextVersionNo(long dashboardId);
+  void deleteDashboard(long dashboardId);
+}

--- a/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/DashboardService.java
+++ b/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/DashboardService.java
@@ -3,7 +3,7 @@ package io.yak.ops.business.dashboard;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.yak.ops.business.analysis.AnalysisService;
+import io.yak.ops.business.analysis.AnalysisReferenceService;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -21,12 +21,15 @@ public class DashboardService {
   private static final int MAX_INLINE_JSON = 65535;
 
   private final DashboardRepository repository;
-  private final AnalysisService analysisService;
+  private final AnalysisReferenceService analysisReferences;
   private final ObjectMapper objectMapper;
 
-  public DashboardService(DashboardRepository repository, AnalysisService analysisService, ObjectMapper objectMapper) {
+  public DashboardService(
+      DashboardRepository repository,
+      AnalysisReferenceService analysisReferences,
+      ObjectMapper objectMapper) {
     this.repository = repository;
-    this.analysisService = analysisService;
+    this.analysisReferences = analysisReferences;
     this.objectMapper = objectMapper;
   }
 
@@ -121,7 +124,7 @@ public class DashboardService {
       }
       if (linked) {
         if (value.analysisId() <= 0L) throw new IllegalArgumentException("analysisId 必须大于 0");
-        analysisService.get(value.analysisId());
+        analysisReferences.requireExists(value.analysisId());
       }
 
       validateLayout(value, widgetKey);

--- a/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/DashboardService.java
+++ b/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/DashboardService.java
@@ -1,0 +1,198 @@
+package io.yak.ops.business.dashboard;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.analysis.AnalysisService;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/** Owns Dashboard identity, immutable versions and layout. Analysis owns reusable ChartSpec definitions. */
+@Service
+public class DashboardService {
+
+  private static final int MAX_WIDGETS = 200;
+  private static final int MAX_INLINE_JSON = 65535;
+
+  private final DashboardRepository repository;
+  private final AnalysisService analysisService;
+  private final ObjectMapper objectMapper;
+
+  public DashboardService(DashboardRepository repository, AnalysisService analysisService, ObjectMapper objectMapper) {
+    this.repository = repository;
+    this.analysisService = analysisService;
+    this.objectMapper = objectMapper;
+  }
+
+  public List<DashboardAsset> list() {
+    return repository.listDashboards();
+  }
+
+  public DashboardDetail get(long dashboardId) {
+    if (dashboardId <= 0L) throw new IllegalArgumentException("dashboardId 必须大于 0");
+    DashboardAsset dashboard = repository.findDashboard(dashboardId)
+        .orElseThrow(() -> new IllegalArgumentException("Dashboard 不存在：" + dashboardId));
+    DashboardVersion currentVersion = null;
+    List<DashboardWidgetSnapshot> widgets = List.of();
+    if (dashboard.currentVersionId() != null) {
+      currentVersion = repository.findVersion(dashboard.currentVersionId())
+          .orElseThrow(() -> new IllegalStateException("Dashboard 当前版本不存在：" + dashboard.currentVersionId()));
+      widgets = repository.listWidgets(currentVersion.id());
+    }
+    return new DashboardDetail(dashboard, currentVersion, repository.listVersions(dashboardId), widgets);
+  }
+
+  public List<DashboardVersion> versions(long dashboardId) {
+    get(dashboardId);
+    return repository.listVersions(dashboardId);
+  }
+
+  @Transactional("yakBusinessTransactionManager")
+  public DashboardDetail create(SaveCommand command) {
+    Normalized normalized = normalize(command);
+    long dashboardId = repository.insertDashboard(normalized.name(), normalized.description());
+    appendVersion(dashboardId, 1, normalized);
+    return get(dashboardId);
+  }
+
+  @Transactional("yakBusinessTransactionManager")
+  public DashboardDetail saveVersion(long dashboardId, SaveCommand command) {
+    get(dashboardId);
+    Normalized normalized = normalize(command);
+    int versionNo = repository.nextVersionNo(dashboardId);
+    appendVersion(dashboardId, versionNo, normalized);
+    return get(dashboardId);
+  }
+
+  @Transactional("yakBusinessTransactionManager")
+  public DashboardDetail activateVersion(long dashboardId, int versionNo) {
+    get(dashboardId);
+    if (versionNo <= 0) throw new IllegalArgumentException("versionNo 必须大于 0");
+    DashboardVersion version = repository.findVersionByNo(dashboardId, versionNo)
+        .orElseThrow(() -> new IllegalArgumentException("DashboardVersion 不存在：V" + versionNo));
+    repository.updateCurrentVersion(
+        dashboardId, version.id(), version.versionNo(), version.name(), version.description());
+    return get(dashboardId);
+  }
+
+  @Transactional("yakBusinessTransactionManager")
+  public void delete(long dashboardId) {
+    get(dashboardId);
+    repository.deleteDashboard(dashboardId);
+  }
+
+  private void appendVersion(long dashboardId, int versionNo, Normalized normalized) {
+    long versionId = repository.insertVersion(
+        dashboardId, versionNo, normalized.name(), normalized.description(), normalized.activeDatasetId());
+    repository.insertWidgets(versionId, normalized.widgets(), normalized.inlineJson());
+    repository.updateCurrentVersion(
+        dashboardId, versionId, versionNo, normalized.name(), normalized.description());
+  }
+
+  private Normalized normalize(SaveCommand command) {
+    Objects.requireNonNull(command, "command");
+    String name = required(command.name(), "Dashboard 名称", 200);
+    String description = optional(command.description(), "Dashboard 描述", 2000);
+    Long activeDatasetId = command.activeDatasetId();
+    if (activeDatasetId != null && activeDatasetId <= 0L) activeDatasetId = null;
+
+    List<WidgetSpec> source = command.widgets() == null ? List.of() : command.widgets();
+    if (source.size() > MAX_WIDGETS) throw new IllegalArgumentException("Dashboard 组件不能超过 " + MAX_WIDGETS + " 个");
+    List<WidgetSpec> widgets = new ArrayList<>(source.size());
+    List<String> inlineJson = new ArrayList<>(source.size());
+    Set<String> widgetKeys = new HashSet<>();
+
+    for (WidgetSpec value : source) {
+      if (value == null) throw new IllegalArgumentException("DashboardWidget 不能为空");
+      String widgetKey = required(value.widgetKey(), "widgetKey", 64);
+      if (!widgetKeys.add(widgetKey)) throw new IllegalArgumentException("widgetKey 重复：" + widgetKey);
+      String title = optional(value.title(), "Widget 标题", 200);
+
+      boolean linked = value.analysisId() != null;
+      boolean inline = value.inlineAnalysis() != null;
+      if (linked == inline) {
+        throw new IllegalArgumentException("Widget 必须且只能选择 analysisId 或 inlineAnalysis：" + widgetKey);
+      }
+      if (linked) {
+        if (value.analysisId() <= 0L) throw new IllegalArgumentException("analysisId 必须大于 0");
+        analysisService.get(value.analysisId());
+      }
+
+      validateLayout(value, widgetKey);
+      String json = inline ? inlineJson(value.inlineAnalysis(), widgetKey) : null;
+      widgets.add(new WidgetSpec(
+          widgetKey, value.analysisId(), title, value.inlineAnalysis(),
+          value.x(), value.y(), value.w(), value.h(), value.minW(), value.minH()));
+      inlineJson.add(json);
+    }
+    return new Normalized(
+        name,
+        description,
+        activeDatasetId,
+        List.copyOf(widgets),
+        Collections.unmodifiableList(new ArrayList<>(inlineJson)));
+  }
+
+  private void validateLayout(WidgetSpec value, String widgetKey) {
+    if (value.x() < 0 || value.x() >= 24) throw new IllegalArgumentException("Widget x 必须在 0~23：" + widgetKey);
+    if (value.y() < 0) throw new IllegalArgumentException("Widget y 不能小于 0：" + widgetKey);
+    if (value.w() <= 0 || value.w() > 24) throw new IllegalArgumentException("Widget w 必须在 1~24：" + widgetKey);
+    if (value.h() <= 0 || value.h() > 60) throw new IllegalArgumentException("Widget h 必须在 1~60：" + widgetKey);
+    if (value.x() + value.w() > 24) throw new IllegalArgumentException("Widget 超出 24 栅格：" + widgetKey);
+    if (value.minW() != null && (value.minW() <= 0 || value.minW() > value.w())) {
+      throw new IllegalArgumentException("Widget minW 必须大于 0 且不能超过 w：" + widgetKey);
+    }
+    if (value.minH() != null && (value.minH() <= 0 || value.minH() > value.h())) {
+      throw new IllegalArgumentException("Widget minH 必须大于 0 且不能超过 h：" + widgetKey);
+    }
+  }
+
+  private String inlineJson(Object value, String widgetKey) {
+    JsonNode node = objectMapper.valueToTree(value);
+    if (!node.isObject()) throw new IllegalArgumentException("inlineAnalysis 必须是 JSON 对象：" + widgetKey);
+    try {
+      String json = objectMapper.writeValueAsString(value);
+      if (json.length() > MAX_INLINE_JSON) throw new IllegalArgumentException("inlineAnalysis 配置过大：" + widgetKey);
+      return json;
+    } catch (JsonProcessingException exception) {
+      throw new IllegalArgumentException("inlineAnalysis 无法序列化：" + widgetKey, exception);
+    }
+  }
+
+  private String required(String value, String label, int maxLength) {
+    if (value == null || value.isBlank()) throw new IllegalArgumentException(label + "不能为空");
+    String normalized = value.trim();
+    if (normalized.length() > maxLength) throw new IllegalArgumentException(label + "不能超过 " + maxLength + " 个字符");
+    return normalized;
+  }
+
+  private String optional(String value, String label, int maxLength) {
+    if (value == null || value.isBlank()) return null;
+    String normalized = value.trim();
+    if (normalized.length() > maxLength) throw new IllegalArgumentException(label + "不能超过 " + maxLength + " 个字符");
+    return normalized;
+  }
+
+  public record SaveCommand(String name, String description, Long activeDatasetId, List<WidgetSpec> widgets) {}
+
+  public record WidgetSpec(
+      String widgetKey,
+      Long analysisId,
+      String title,
+      Object inlineAnalysis,
+      int x, int y, int w, int h,
+      Integer minW, Integer minH) {}
+
+  private record Normalized(
+      String name,
+      String description,
+      Long activeDatasetId,
+      List<WidgetSpec> widgets,
+      List<String> inlineJson) {}
+}

--- a/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/JdbcDashboardRepository.java
+++ b/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/JdbcDashboardRepository.java
@@ -1,0 +1,200 @@
+package io.yak.ops.business.dashboard;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import javax.sql.DataSource;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.support.GeneratedKeyHolder;
+import org.springframework.jdbc.support.KeyHolder;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@DependsOn("yakDashboardFlyway")
+@ConditionalOnDataSourceEnabled
+class JdbcDashboardRepository implements DashboardRepository {
+
+  private static final String DASHBOARD_COLUMNS =
+      "SELECT id, name, description, current_version_id, current_version_no, create_time, update_time FROM yak_dashboard";
+  private static final String VERSION_COLUMNS =
+      "SELECT id, dashboard_id, version_no, name_snapshot, description_snapshot, active_dataset_id, create_time FROM yak_dashboard_version";
+
+  private final JdbcTemplate jdbcTemplate;
+  private final ObjectMapper objectMapper;
+
+  JdbcDashboardRepository(
+      @Qualifier("yakBusinessDataSource") DataSource dataSource,
+      ObjectMapper objectMapper) {
+    this.jdbcTemplate = new JdbcTemplate(dataSource);
+    this.objectMapper = objectMapper;
+  }
+
+  @Override
+  public long insertDashboard(String name, String description) {
+    KeyHolder keyHolder = new GeneratedKeyHolder();
+    jdbcTemplate.update(connection -> {
+      PreparedStatement statement = connection.prepareStatement(
+          "INSERT INTO yak_dashboard (name, description, current_version_id, current_version_no, create_time, update_time) VALUES (?, ?, NULL, 0, NOW(6), NOW(6))",
+          Statement.RETURN_GENERATED_KEYS);
+      statement.setString(1, name);
+      statement.setString(2, description);
+      return statement;
+    }, keyHolder);
+    Number key = keyHolder.getKey();
+    if (key == null) throw new IllegalStateException("创建 Dashboard 后未返回主键");
+    return key.longValue();
+  }
+
+  @Override
+  public long insertVersion(long dashboardId, int versionNo, String name, String description, Long activeDatasetId) {
+    KeyHolder keyHolder = new GeneratedKeyHolder();
+    jdbcTemplate.update(connection -> {
+      PreparedStatement statement = connection.prepareStatement(
+          "INSERT INTO yak_dashboard_version (dashboard_id, version_no, name_snapshot, description_snapshot, active_dataset_id, create_time) VALUES (?, ?, ?, ?, ?, NOW(6))",
+          Statement.RETURN_GENERATED_KEYS);
+      statement.setLong(1, dashboardId);
+      statement.setInt(2, versionNo);
+      statement.setString(3, name);
+      statement.setString(4, description);
+      if (activeDatasetId == null) statement.setObject(5, null); else statement.setLong(5, activeDatasetId);
+      return statement;
+    }, keyHolder);
+    Number key = keyHolder.getKey();
+    if (key == null) throw new IllegalStateException("创建 DashboardVersion 后未返回主键");
+    return key.longValue();
+  }
+
+  @Override
+  public void insertWidgets(long versionId, List<DashboardService.WidgetSpec> widgets, List<String> inlineJson) {
+    for (int index = 0; index < widgets.size(); index++) {
+      DashboardService.WidgetSpec widget = widgets.get(index);
+      jdbcTemplate.update(
+          """
+          INSERT INTO yak_dashboard_widget
+            (dashboard_version_id, widget_key, analysis_id, title, inline_analysis_json,
+             grid_x, grid_y, grid_w, grid_h, min_w, min_h, sort_order)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          """,
+          versionId,
+          widget.widgetKey(),
+          widget.analysisId(),
+          widget.title(),
+          inlineJson.get(index),
+          widget.x(), widget.y(), widget.w(), widget.h(), widget.minW(), widget.minH(), index + 1);
+    }
+  }
+
+  @Override
+  public void updateCurrentVersion(long dashboardId, long versionId, int versionNo, String name, String description) {
+    int updated = jdbcTemplate.update(
+        "UPDATE yak_dashboard SET current_version_id = ?, current_version_no = ?, name = ?, description = ?, update_time = NOW(6) WHERE id = ?",
+        versionId, versionNo, name, description, dashboardId);
+    if (updated != 1) throw new IllegalArgumentException("Dashboard 不存在：" + dashboardId);
+  }
+
+  @Override
+  public Optional<DashboardAsset> findDashboard(long dashboardId) {
+    return jdbcTemplate.query(DASHBOARD_COLUMNS + " WHERE id = ? LIMIT 1", JdbcDashboardRepository::mapDashboard, dashboardId)
+        .stream().findFirst();
+  }
+
+  @Override
+  public List<DashboardAsset> listDashboards() {
+    return jdbcTemplate.query(DASHBOARD_COLUMNS + " ORDER BY update_time DESC, id DESC", JdbcDashboardRepository::mapDashboard);
+  }
+
+  @Override
+  public Optional<DashboardVersion> findVersion(long versionId) {
+    return jdbcTemplate.query(VERSION_COLUMNS + " WHERE id = ? LIMIT 1", JdbcDashboardRepository::mapVersion, versionId)
+        .stream().findFirst();
+  }
+
+  @Override
+  public Optional<DashboardVersion> findVersionByNo(long dashboardId, int versionNo) {
+    return jdbcTemplate.query(
+        VERSION_COLUMNS + " WHERE dashboard_id = ? AND version_no = ? LIMIT 1",
+        JdbcDashboardRepository::mapVersion, dashboardId, versionNo).stream().findFirst();
+  }
+
+  @Override
+  public List<DashboardVersion> listVersions(long dashboardId) {
+    return jdbcTemplate.query(
+        VERSION_COLUMNS + " WHERE dashboard_id = ? ORDER BY version_no DESC",
+        JdbcDashboardRepository::mapVersion, dashboardId);
+  }
+
+  @Override
+  public List<DashboardWidgetSnapshot> listWidgets(long versionId) {
+    return jdbcTemplate.query(
+        """
+        SELECT id, dashboard_version_id, widget_key, analysis_id, title, inline_analysis_json,
+               grid_x, grid_y, grid_w, grid_h, min_w, min_h, sort_order
+        FROM yak_dashboard_widget WHERE dashboard_version_id = ? ORDER BY sort_order ASC, id ASC
+        """,
+        this::mapWidget,
+        versionId);
+  }
+
+  @Override
+  public int nextVersionNo(long dashboardId) {
+    Integer value = jdbcTemplate.queryForObject(
+        "SELECT COALESCE(MAX(version_no), 0) + 1 FROM yak_dashboard_version WHERE dashboard_id = ?",
+        Integer.class, dashboardId);
+    return value == null ? 1 : value;
+  }
+
+  @Override
+  public void deleteDashboard(long dashboardId) {
+    int deleted = jdbcTemplate.update("DELETE FROM yak_dashboard WHERE id = ?", dashboardId);
+    if (deleted != 1) throw new IllegalArgumentException("Dashboard 不存在：" + dashboardId);
+  }
+
+  private static DashboardAsset mapDashboard(ResultSet rs, int rowNum) throws SQLException {
+    Long currentVersionId = rs.getObject("current_version_id") == null ? null : rs.getLong("current_version_id");
+    return new DashboardAsset(
+        rs.getLong("id"), rs.getString("name"), rs.getString("description"), currentVersionId,
+        rs.getInt("current_version_no"), instant(rs.getTimestamp("create_time")), instant(rs.getTimestamp("update_time")));
+  }
+
+  private static DashboardVersion mapVersion(ResultSet rs, int rowNum) throws SQLException {
+    Long activeDatasetId = rs.getObject("active_dataset_id") == null ? null : rs.getLong("active_dataset_id");
+    return new DashboardVersion(
+        rs.getLong("id"), rs.getLong("dashboard_id"), rs.getInt("version_no"),
+        rs.getString("name_snapshot"), rs.getString("description_snapshot"), activeDatasetId,
+        instant(rs.getTimestamp("create_time")));
+  }
+
+  private DashboardWidgetSnapshot mapWidget(ResultSet rs, int rowNum) throws SQLException {
+    Long analysisId = rs.getObject("analysis_id") == null ? null : rs.getLong("analysis_id");
+    Integer minW = rs.getObject("min_w") == null ? null : rs.getInt("min_w");
+    Integer minH = rs.getObject("min_h") == null ? null : rs.getInt("min_h");
+    String inlineJson = rs.getString("inline_analysis_json");
+    return new DashboardWidgetSnapshot(
+        rs.getLong("id"), rs.getLong("dashboard_version_id"), rs.getString("widget_key"), analysisId,
+        rs.getString("title"), parseJson(inlineJson), rs.getInt("grid_x"), rs.getInt("grid_y"),
+        rs.getInt("grid_w"), rs.getInt("grid_h"), minW, minH, rs.getInt("sort_order"));
+  }
+
+  private Object parseJson(String value) {
+    if (value == null || value.isBlank()) return null;
+    try {
+      return objectMapper.readValue(value, Object.class);
+    } catch (JsonProcessingException exception) {
+      throw new IllegalStateException("Dashboard inlineAnalysis 反序列化失败", exception);
+    }
+  }
+
+  private static Instant instant(Timestamp value) {
+    return value == null ? null : value.toInstant();
+  }
+}

--- a/yak-ops-business/yak-ops-business-dashboard/src/main/resources/db/migration/yak-dashboard/V1__create_dashboard_domain.sql
+++ b/yak-ops-business/yak-ops-business-dashboard/src/main/resources/db/migration/yak-dashboard/V1__create_dashboard_domain.sql
@@ -1,0 +1,52 @@
+-- Dashboard is a stable asset. Manual saves create immutable DashboardVersion snapshots.
+CREATE TABLE IF NOT EXISTS yak_dashboard (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    name VARCHAR(200) NOT NULL,
+    description VARCHAR(2000) NULL,
+    current_version_id BIGINT NULL,
+    current_version_no INT NOT NULL DEFAULT 0,
+    create_time DATETIME(6) NOT NULL,
+    update_time DATETIME(6) NOT NULL,
+    PRIMARY KEY (id),
+    KEY idx_yak_dashboard_update (update_time),
+    KEY idx_yak_dashboard_current_version (current_version_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS yak_dashboard_version (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    dashboard_id BIGINT NOT NULL,
+    version_no INT NOT NULL,
+    name_snapshot VARCHAR(200) NOT NULL,
+    description_snapshot VARCHAR(2000) NULL,
+    active_dataset_id BIGINT NULL,
+    create_time DATETIME(6) NOT NULL,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_yak_dashboard_version_no (dashboard_id, version_no),
+    CONSTRAINT fk_yak_dashboard_version_dashboard
+        FOREIGN KEY (dashboard_id) REFERENCES yak_dashboard(id)
+        ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS yak_dashboard_widget (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    dashboard_version_id BIGINT NOT NULL,
+    widget_key VARCHAR(64) NOT NULL,
+    analysis_id BIGINT NULL,
+    title VARCHAR(200) NULL,
+    inline_analysis_json JSON NULL,
+    grid_x INT NOT NULL,
+    grid_y INT NOT NULL,
+    grid_w INT NOT NULL,
+    grid_h INT NOT NULL,
+    min_w INT NULL,
+    min_h INT NULL,
+    sort_order INT NOT NULL DEFAULT 0,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_yak_dashboard_widget_key (dashboard_version_id, widget_key),
+    KEY idx_yak_dashboard_widget_analysis (analysis_id),
+    CONSTRAINT fk_yak_dashboard_widget_version
+        FOREIGN KEY (dashboard_version_id) REFERENCES yak_dashboard_version(id)
+        ON DELETE CASCADE,
+    CONSTRAINT fk_yak_dashboard_widget_analysis
+        FOREIGN KEY (analysis_id) REFERENCES yak_analysis(id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/yak-ops-business/yak-ops-business-dashboard/src/test/java/io/yak/ops/business/dashboard/DashboardServiceTest.java
+++ b/yak-ops-business/yak-ops-business-dashboard/src/test/java/io/yak/ops/business/dashboard/DashboardServiceTest.java
@@ -6,7 +6,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.yak.ops.business.analysis.AnalysisService;
+import io.yak.ops.business.analysis.AnalysisReferenceService;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -20,8 +20,8 @@ class DashboardServiceTest {
   @Test
   void createPersistsV1AndValidatesAnalysisReference() {
     FakeRepository repository = new FakeRepository();
-    AnalysisService analysisService = mock(AnalysisService.class);
-    DashboardService service = new DashboardService(repository, analysisService, new ObjectMapper());
+    AnalysisReferenceService analysisReferences = mock(AnalysisReferenceService.class);
+    DashboardService service = new DashboardService(repository, analysisReferences, new ObjectMapper());
 
     DashboardDetail detail = service.create(new DashboardService.SaveCommand(
         "销售驾驶舱", "核心销售分析", 12L,
@@ -30,13 +30,13 @@ class DashboardServiceTest {
     assertEquals(1, detail.dashboard().currentVersionNo());
     assertEquals(1, detail.versions().size());
     assertEquals(1, detail.widgets().size());
-    verify(analysisService).get(99L);
+    verify(analysisReferences).requireExists(99L);
   }
 
   @Test
   void manualSaveCreatesImmutableNextVersion() {
     FakeRepository repository = new FakeRepository();
-    DashboardService service = new DashboardService(repository, mock(AnalysisService.class), new ObjectMapper());
+    DashboardService service = new DashboardService(repository, mock(AnalysisReferenceService.class), new ObjectMapper());
     DashboardDetail created = service.create(new DashboardService.SaveCommand(
         "A", null, null,
         List.of(new DashboardService.WidgetSpec("w1", null, "临时", Map.of("type", "bar"), 0, 0, 10, 7, 6, 5))));
@@ -52,7 +52,8 @@ class DashboardServiceTest {
 
   @Test
   void widgetCannotCarryLinkedAndInlineDefinitionsTogether() {
-    DashboardService service = new DashboardService(new FakeRepository(), mock(AnalysisService.class), new ObjectMapper());
+    DashboardService service = new DashboardService(
+        new FakeRepository(), mock(AnalysisReferenceService.class), new ObjectMapper());
     assertThrows(IllegalArgumentException.class, () -> service.create(new DashboardService.SaveCommand(
         "bad", null, null,
         List.of(new DashboardService.WidgetSpec("w1", 9L, null, Map.of("type", "bar"), 0, 0, 10, 7, 6, 5)))));

--- a/yak-ops-business/yak-ops-business-dashboard/src/test/java/io/yak/ops/business/dashboard/DashboardServiceTest.java
+++ b/yak-ops-business/yak-ops-business-dashboard/src/test/java/io/yak/ops/business/dashboard/DashboardServiceTest.java
@@ -1,0 +1,99 @@
+package io.yak.ops.business.dashboard;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.analysis.AnalysisService;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class DashboardServiceTest {
+
+  @Test
+  void createPersistsV1AndValidatesAnalysisReference() {
+    FakeRepository repository = new FakeRepository();
+    AnalysisService analysisService = mock(AnalysisService.class);
+    DashboardService service = new DashboardService(repository, analysisService, new ObjectMapper());
+
+    DashboardDetail detail = service.create(new DashboardService.SaveCommand(
+        "销售驾驶舱", "核心销售分析", 12L,
+        List.of(new DashboardService.WidgetSpec("w1", 99L, null, null, 0, 0, 10, 7, 6, 5))));
+
+    assertEquals(1, detail.dashboard().currentVersionNo());
+    assertEquals(1, detail.versions().size());
+    assertEquals(1, detail.widgets().size());
+    verify(analysisService).get(99L);
+  }
+
+  @Test
+  void manualSaveCreatesImmutableNextVersion() {
+    FakeRepository repository = new FakeRepository();
+    DashboardService service = new DashboardService(repository, mock(AnalysisService.class), new ObjectMapper());
+    DashboardDetail created = service.create(new DashboardService.SaveCommand(
+        "A", null, null,
+        List.of(new DashboardService.WidgetSpec("w1", null, "临时", Map.of("type", "bar"), 0, 0, 10, 7, 6, 5))));
+
+    DashboardDetail saved = service.saveVersion(created.dashboard().id(), new DashboardService.SaveCommand(
+        "A2", null, null,
+        List.of(new DashboardService.WidgetSpec("w1", null, "临时", Map.of("type", "line"), 1, 1, 10, 7, 6, 5))));
+
+    assertEquals(2, saved.dashboard().currentVersionNo());
+    assertEquals(2, saved.versions().size());
+    assertEquals("A", saved.versions().get(1).name());
+  }
+
+  @Test
+  void widgetCannotCarryLinkedAndInlineDefinitionsTogether() {
+    DashboardService service = new DashboardService(new FakeRepository(), mock(AnalysisService.class), new ObjectMapper());
+    assertThrows(IllegalArgumentException.class, () -> service.create(new DashboardService.SaveCommand(
+        "bad", null, null,
+        List.of(new DashboardService.WidgetSpec("w1", 9L, null, Map.of("type", "bar"), 0, 0, 10, 7, 6, 5)))));
+  }
+
+  private static final class FakeRepository implements DashboardRepository {
+    private long nextDashboardId = 1;
+    private long nextVersionId = 100;
+    private final Map<Long, DashboardAsset> dashboards = new LinkedHashMap<>();
+    private final Map<Long, DashboardVersion> versions = new LinkedHashMap<>();
+    private final Map<Long, List<DashboardWidgetSnapshot>> widgets = new LinkedHashMap<>();
+
+    @Override public long insertDashboard(String name, String description) {
+      long id = nextDashboardId++;
+      dashboards.put(id, new DashboardAsset(id, name, description, null, 0, Instant.now(), Instant.now()));
+      return id;
+    }
+    @Override public long insertVersion(long dashboardId, int versionNo, String name, String description, Long activeDatasetId) {
+      long id = nextVersionId++;
+      versions.put(id, new DashboardVersion(id, dashboardId, versionNo, name, description, activeDatasetId, Instant.now()));
+      return id;
+    }
+    @Override public void insertWidgets(long versionId, List<DashboardService.WidgetSpec> specs, List<String> json) {
+      List<DashboardWidgetSnapshot> rows = new ArrayList<>();
+      for (int i = 0; i < specs.size(); i++) {
+        DashboardService.WidgetSpec value = specs.get(i);
+        rows.add(new DashboardWidgetSnapshot(i + 1L, versionId, value.widgetKey(), value.analysisId(), value.title(), value.inlineAnalysis(), value.x(), value.y(), value.w(), value.h(), value.minW(), value.minH(), i + 1));
+      }
+      widgets.put(versionId, rows);
+    }
+    @Override public void updateCurrentVersion(long dashboardId, long versionId, int versionNo, String name, String description) {
+      DashboardAsset old = dashboards.get(dashboardId);
+      dashboards.put(dashboardId, new DashboardAsset(dashboardId, name, description, versionId, versionNo, old.createTime(), Instant.now()));
+    }
+    @Override public Optional<DashboardAsset> findDashboard(long id) { return Optional.ofNullable(dashboards.get(id)); }
+    @Override public List<DashboardAsset> listDashboards() { return new ArrayList<>(dashboards.values()); }
+    @Override public Optional<DashboardVersion> findVersion(long id) { return Optional.ofNullable(versions.get(id)); }
+    @Override public Optional<DashboardVersion> findVersionByNo(long dashboardId, int versionNo) { return versions.values().stream().filter(v -> v.dashboardId() == dashboardId && v.versionNo() == versionNo).findFirst(); }
+    @Override public List<DashboardVersion> listVersions(long dashboardId) { return versions.values().stream().filter(v -> v.dashboardId() == dashboardId).sorted((a,b) -> Integer.compare(b.versionNo(), a.versionNo())).toList(); }
+    @Override public List<DashboardWidgetSnapshot> listWidgets(long versionId) { return widgets.getOrDefault(versionId, List.of()); }
+    @Override public int nextVersionNo(long dashboardId) { return listVersions(dashboardId).stream().mapToInt(DashboardVersion::versionNo).max().orElse(0) + 1; }
+    @Override public void deleteDashboard(long dashboardId) { dashboards.remove(dashboardId); }
+  }
+}

--- a/yak-ops-ui/src/pages/dashboard/dashboard-service.ts
+++ b/yak-ops-ui/src/pages/dashboard/dashboard-service.ts
@@ -1,0 +1,170 @@
+import type { ApiResponse } from '@/services/http/response';
+import { API_SUCCESS_CODE } from '@/services/http/response';
+import HttpUtils from '@/utils/HttpUtils';
+import type { AnalysisSpec } from '@/components/analysis/model';
+import type {
+  DashboardDocument,
+  DashboardServerDetail,
+  DashboardSummary,
+  DashboardVersionSummary,
+  DashboardWidget,
+} from './model';
+
+const DASHBOARD_API = '/api/v1/dashboards';
+
+interface DashboardAssetWire {
+  id: string;
+  name: string;
+  description?: string | null;
+  currentVersionId?: string | null;
+  currentVersionNo: number;
+  createTime?: string;
+  updateTime?: string;
+}
+
+interface DashboardVersionWire {
+  id: string;
+  dashboardId: string;
+  versionNo: number;
+  name: string;
+  description?: string | null;
+  activeDatasetId?: string | null;
+  createTime?: string;
+}
+
+interface DashboardWidgetWire {
+  id: string;
+  dashboardVersionId: string;
+  widgetKey: string;
+  analysisId?: string | null;
+  title?: string | null;
+  inlineAnalysis?: AnalysisSpec | null;
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+  minW?: number | null;
+  minH?: number | null;
+  sortOrder: number;
+}
+
+interface DashboardDetailWire {
+  dashboard: DashboardAssetWire;
+  currentVersion?: DashboardVersionWire | null;
+  versions: DashboardVersionWire[];
+  widgets: DashboardWidgetWire[];
+}
+
+const unwrap = <T,>(response: ApiResponse<T>, fallback: string): T => {
+  if (response?.code !== API_SUCCESS_CODE || response.data === undefined) {
+    throw new Error(response?.message || response?.msg || fallback);
+  }
+  return response.data;
+};
+
+const summary = (value: DashboardAssetWire): DashboardSummary => ({
+  id: String(value.id),
+  name: value.name,
+  description: value.description || '',
+  currentVersionId: value.currentVersionId ? String(value.currentVersionId) : undefined,
+  currentVersionNo: value.currentVersionNo || 0,
+  createTime: value.createTime,
+  updateTime: value.updateTime,
+});
+
+const version = (value: DashboardVersionWire): DashboardVersionSummary => ({
+  id: String(value.id),
+  dashboardId: String(value.dashboardId),
+  versionNo: value.versionNo,
+  name: value.name,
+  description: value.description || '',
+  activeDatasetId: value.activeDatasetId ? String(value.activeDatasetId) : undefined,
+  createTime: value.createTime,
+});
+
+const widget = (value: DashboardWidgetWire): DashboardWidget => ({
+  id: value.widgetKey,
+  analysisId: value.analysisId ? String(value.analysisId) : undefined,
+  title: value.title || undefined,
+  inlineAnalysis: value.inlineAnalysis || undefined,
+  x: value.x,
+  y: value.y,
+  w: value.w,
+  h: value.h,
+  minW: value.minW ?? undefined,
+  minH: value.minH ?? undefined,
+});
+
+export const toDashboardServerDetail = (value: DashboardDetailWire): DashboardServerDetail => ({
+  dashboard: summary(value.dashboard),
+  currentVersion: value.currentVersion ? version(value.currentVersion) : undefined,
+  versions: (value.versions || []).map(version),
+  widgets: (value.widgets || []).map(widget),
+});
+
+export const toDashboardDocument = (detail: DashboardServerDetail): DashboardDocument => ({
+  version: 1,
+  id: detail.dashboard.id,
+  name: detail.currentVersion?.name || detail.dashboard.name,
+  description: detail.currentVersion?.description || detail.dashboard.description,
+  activeDatasetId: detail.currentVersion?.activeDatasetId || '',
+  widgets: detail.widgets,
+  currentVersionNo: detail.dashboard.currentVersionNo,
+  currentVersionId: detail.dashboard.currentVersionId,
+  updatedAt: detail.dashboard.updateTime,
+});
+
+const payload = (document: DashboardDocument) => ({
+  name: document.name,
+  description: document.description || undefined,
+  activeDatasetId: document.activeDatasetId || undefined,
+  widgets: document.widgets.map((item) => ({
+    widgetKey: item.id,
+    analysisId: item.analysisId,
+    title: item.title,
+    inlineAnalysis: item.inlineAnalysis,
+    x: item.x,
+    y: item.y,
+    w: item.w,
+    h: item.h,
+    minW: item.minW,
+    minH: item.minH,
+  })),
+});
+
+export const fetchDashboards = async (): Promise<DashboardSummary[]> => {
+  const values = unwrap(await HttpUtils.get<DashboardAssetWire[]>(DASHBOARD_API), '查询 Dashboard 列表失败');
+  return (values || []).map(summary);
+};
+
+export const fetchDashboard = async (dashboardId: string): Promise<DashboardServerDetail> =>
+  toDashboardServerDetail(unwrap(
+    await HttpUtils.get<DashboardDetailWire>(`${DASHBOARD_API}/${dashboardId}`),
+    '查询 Dashboard 详情失败',
+  ));
+
+export const createDashboard = async (document: DashboardDocument): Promise<DashboardServerDetail> =>
+  toDashboardServerDetail(unwrap(
+    await HttpUtils.post<DashboardDetailWire>(DASHBOARD_API, payload(document)),
+    '创建 Dashboard 失败',
+  ));
+
+export const saveDashboardVersion = async (
+  dashboardId: string,
+  document: DashboardDocument,
+): Promise<DashboardServerDetail> => toDashboardServerDetail(unwrap(
+  await HttpUtils.post<DashboardDetailWire>(`${DASHBOARD_API}/${dashboardId}/versions`, payload(document)),
+  '保存 DashboardVersion 失败',
+));
+
+export const activateDashboardVersion = async (
+  dashboardId: string,
+  versionNo: number,
+): Promise<DashboardServerDetail> => toDashboardServerDetail(unwrap(
+  await HttpUtils.post<DashboardDetailWire>(`${DASHBOARD_API}/${dashboardId}/activate/${versionNo}`, {}),
+  '切换 DashboardVersion 失败',
+));
+
+export const deleteDashboard = async (dashboardId: string): Promise<void> => {
+  unwrap(await HttpUtils.delete<boolean>(`${DASHBOARD_API}/${dashboardId}`), '删除 Dashboard 失败');
+};

--- a/yak-ops-ui/src/pages/dashboard/defaults.ts
+++ b/yak-ops-ui/src/pages/dashboard/defaults.ts
@@ -1,10 +1,11 @@
 import type { DashboardDocument } from './model';
 
-/** Dashboard V1 shell with no fake dataset IDs. Real Dataset assets are attached after loading. */
+/** Unsaved shell. The first explicit save creates a server-side Dashboard V1. */
 export const DEFAULT_DASHBOARD: DashboardDocument = {
   version: 1,
-  id: 'dashboard-local',
+  id: 'dashboard-new',
   name: '未命名仪表盘',
+  description: '',
   activeDatasetId: '',
   widgets: [],
 };

--- a/yak-ops-ui/src/pages/dashboard/helpers.tsx
+++ b/yak-ops-ui/src/pages/dashboard/helpers.tsx
@@ -11,6 +11,7 @@ import type {
   PublishedDataset,
 } from './model';
 
+/** Legacy key is read only for one-time migration into the server-side Dashboard domain. */
 export const STORAGE_KEY = 'yak-dashboard-designer.v2';
 export const GRID_COLUMNS = 24;
 export const GRID_ROW_HEIGHT = 28;
@@ -56,12 +57,7 @@ const legacyWidgetToCurrent = (value: any): DashboardWidget => {
     metrics: Array.isArray(value.metrics) ? value.metrics : [],
     filters: Array.isArray(value.filters) ? value.filters : [],
     sort: value.sort,
-    style: value.style ?? {
-      showLegend: false,
-      showDataLabels: false,
-      smooth: false,
-      showGrid: false,
-    },
+    style: value.style ?? { showLegend: false, showDataLabels: false, smooth: false, showGrid: false },
     limit: value.limit,
     timeoutSeconds: value.timeoutSeconds,
   };
@@ -85,24 +81,30 @@ export const loadDashboard = (): DashboardDocument => {
     if (!stored) return cloneDashboard(DEFAULT_DASHBOARD);
     const parsed = JSON.parse(stored) as DashboardDocument;
     if (parsed?.version !== 1 || !Array.isArray(parsed.widgets)) return cloneDashboard(DEFAULT_DASHBOARD);
-    return { ...parsed, widgets: parsed.widgets.map(legacyWidgetToCurrent) };
+    return {
+      ...cloneDashboard(DEFAULT_DASHBOARD),
+      ...parsed,
+      id: 'dashboard-new',
+      currentVersionId: undefined,
+      currentVersionNo: undefined,
+      widgets: parsed.widgets.map(legacyWidgetToCurrent),
+    };
   } catch {
     return cloneDashboard(DEFAULT_DASHBOARD);
   }
 };
 
+export const isPersistedDashboard = (value?: string) => Boolean(value && /^\d+$/.test(value));
+
 export const findDataset = (datasets: PublishedDataset[], id?: string) =>
   datasets.find((dataset) => dataset.id === id) ?? datasets[0];
 
 export const defaultBindings = (dataset: PublishedDataset) => ({
-  dimensions: dataset.fields
-    .filter((field) => field.role === 'dimension')
-    .slice(0, 1)
-    .map((field) => field.key),
-  metrics: dataset.fields
-    .filter((field) => field.role === 'metric')
-    .slice(0, 1)
-    .map((field) => ({ field: field.key, aggregation: 'SUM' as Aggregation })),
+  dimensions: dataset.fields.filter((field) => field.role === 'dimension').slice(0, 1).map((field) => field.key),
+  metrics: dataset.fields.filter((field) => field.role === 'metric').slice(0, 1).map((field) => ({
+    field: field.key,
+    aggregation: 'SUM' as Aggregation,
+  })),
 });
 
 export const createInlineAnalysis = (type: ChartType, dataset: PublishedDataset): AnalysisSpec => {
@@ -124,45 +126,31 @@ export const createInlineAnalysis = (type: ChartType, dataset: PublishedDataset)
   };
 };
 
-export const createWidget = (type: ChartType, dataset: PublishedDataset, y: number): DashboardWidget => {
-  const base: DashboardWidget = {
-    id: `${type}-${Date.now()}-${Math.round(Math.random() * 1000)}`,
-    title: `新增${CHART_META[type].label}`,
-    inlineAnalysis: createInlineAnalysis(type, dataset),
-    x: 0,
-    y,
-    w: type === 'metric' ? 6 : type === 'table' ? 16 : 10,
-    h: type === 'metric' ? 4 : type === 'table' ? 8 : 7,
-    minW: type === 'metric' ? 4 : type === 'table' ? 8 : 6,
-    minH: type === 'metric' ? 3 : type === 'table' ? 6 : 5,
-  };
-  return base;
-};
+export const createWidget = (type: ChartType, dataset: PublishedDataset, y: number): DashboardWidget => ({
+  id: `widget-${Date.now()}-${Math.round(Math.random() * 1000)}`,
+  title: `新增${CHART_META[type].label}`,
+  inlineAnalysis: createInlineAnalysis(type, dataset),
+  x: 0,
+  y,
+  w: type === 'metric' ? 6 : type === 'table' ? 16 : 10,
+  h: type === 'metric' ? 4 : type === 'table' ? 8 : 7,
+  minW: type === 'metric' ? 4 : type === 'table' ? 8 : 6,
+  minH: type === 'metric' ? 3 : type === 'table' ? 6 : 5,
+});
 
 const rebindInlineAnalysis = (spec: AnalysisSpec, dataset: PublishedDataset): AnalysisSpec => {
   const bindings = defaultBindings(dataset);
   const fieldMap = new Map(dataset.fields.map((field) => [field.key, field]));
   const sameDataset = spec.datasetId === dataset.id;
-  const validDimensions = sameDataset
-    ? spec.dimensions.filter((field) => fieldMap.get(field)?.role === 'dimension')
-    : [];
-  const validMetrics = sameDataset
-    ? spec.metrics.filter((metric) => fieldMap.get(metric.field)?.role === 'metric')
-    : [];
-  const dimensions = spec.type === 'metric'
-    ? []
-    : validDimensions.length ? validDimensions : bindings.dimensions;
+  const validDimensions = sameDataset ? spec.dimensions.filter((field) => fieldMap.get(field)?.role === 'dimension') : [];
+  const validMetrics = sameDataset ? spec.metrics.filter((metric) => fieldMap.get(metric.field)?.role === 'metric') : [];
+  const dimensions = spec.type === 'metric' ? [] : validDimensions.length ? validDimensions : bindings.dimensions;
   const metrics = validMetrics.length ? validMetrics : bindings.metrics;
-  const filters = sameDataset
-    ? spec.filters.filter((filter) => fieldMap.has(filter.field))
-    : [];
-  const sort = sameDataset && spec.sort && fieldMap.has(spec.sort.field)
-    ? spec.sort
-    : undefined;
+  const filters = sameDataset ? spec.filters.filter((filter) => fieldMap.has(filter.field)) : [];
+  const sort = sameDataset && spec.sort && fieldMap.has(spec.sort.field) ? spec.sort : undefined;
   return { ...spec, datasetId: dataset.id, dimensions, metrics, filters, sort };
 };
 
-/** Migrates/reconciles temporary inline analyses only. Linked widgets are resolved from Analysis API. */
 export const reconcileDashboard = (
   dashboard: DashboardDocument,
   datasets: PublishedDataset[],
@@ -172,10 +160,10 @@ export const reconcileDashboard = (
   return {
     ...dashboard,
     activeDatasetId: activeDataset.id,
-    widgets: dashboard.widgets.map((widget) => {
-      if (widget.analysisId || !widget.inlineAnalysis) return widget;
-      const widgetDataset = datasets.find((dataset) => dataset.id === widget.inlineAnalysis?.datasetId) ?? activeDataset;
-      return { ...widget, inlineAnalysis: rebindInlineAnalysis(widget.inlineAnalysis, widgetDataset) };
+    widgets: dashboard.widgets.map((item) => {
+      if (item.analysisId || !item.inlineAnalysis) return item;
+      const widgetDataset = datasets.find((dataset) => dataset.id === item.inlineAnalysis?.datasetId) ?? activeDataset;
+      return { ...item, inlineAnalysis: rebindInlineAnalysis(item.inlineAnalysis, widgetDataset) };
     }),
   };
 };

--- a/yak-ops-ui/src/pages/dashboard/index.tsx
+++ b/yak-ops-ui/src/pages/dashboard/index.tsx
@@ -38,11 +38,19 @@ export default function DashboardPage() {
     <div className="flex h-[calc(100vh-48px)] min-h-[640px] flex-col overflow-hidden bg-[#f4f6f8]" style={BRAND_CSS_VARIABLES}>
       <DashboardToolbar
         name={designer.dashboard.name}
+        dashboardId={designer.dashboard.id}
+        currentVersionNo={designer.dashboard.currentVersionNo}
+        dashboards={designer.dashboardAssets}
+        versions={designer.dashboardVersions}
+        loading={designer.dashboardsLoading}
+        saving={designer.dashboardSaving}
         preview={designer.preview}
         onName={(name) => designer.setDashboard((current) => ({ ...current, name }))}
-        onReset={designer.reset}
+        onDashboard={(dashboardId) => void designer.openDashboard(dashboardId)}
+        onNew={designer.newDashboard}
+        onVersion={(versionNo) => void designer.activateVersion(versionNo)}
         onPreview={() => { designer.setPreview((current) => !current); designer.setSelectedId(undefined); }}
-        onSave={designer.save}
+        onSave={() => void designer.save()}
       />
 
       <div className="flex min-h-0 flex-1 overflow-hidden">
@@ -113,7 +121,7 @@ export default function DashboardPage() {
               {!designer.widgets.length && !designer.datasetsLoading ? (
                 <div className="flex min-h-[360px] items-center justify-center px-6 text-center text-[12px] text-[#98a2b3]">
                   {designer.activeDataset
-                    ? '从左侧复用 Analysis，或新建图表开始分析'
+                    ? '从左侧复用 Analysis，或新建图表开始分析；点击保存后会生成服务端 DashboardVersion'
                     : '暂无可用 Dataset，请先在数据开发发布中心发布数据集'}
                 </div>
               ) : null}

--- a/yak-ops-ui/src/pages/dashboard/model.ts
+++ b/yak-ops-ui/src/pages/dashboard/model.ts
@@ -24,10 +24,7 @@ export type {
   SortDirection,
 } from '@/components/analysis/model';
 
-/**
- * Dashboard only owns placement and a reference (or a temporary inline analysis draft).
- * Reusable query/visual definitions live in Analysis assets.
- */
+/** Dashboard owns placement plus an Analysis reference or a dashboard-local inline analysis. */
 export interface DashboardWidget {
   id: string;
   analysisId?: string;
@@ -41,14 +38,43 @@ export interface DashboardWidget {
   minH?: number;
 }
 
-/** UI-only flattened view used by the legacy Dashboard configuration controls. */
 export type DashboardWidgetEditorModel = DashboardWidget & AnalysisSpec & { title: string };
 
 export interface DashboardDocument {
   version: 1;
   id: string;
   name: string;
+  description?: string;
   activeDatasetId: string;
   widgets: DashboardWidget[];
+  currentVersionNo?: number;
+  currentVersionId?: string;
   updatedAt?: string;
+}
+
+export interface DashboardSummary {
+  id: string;
+  name: string;
+  description: string;
+  currentVersionId?: string;
+  currentVersionNo: number;
+  createTime?: string;
+  updateTime?: string;
+}
+
+export interface DashboardVersionSummary {
+  id: string;
+  dashboardId: string;
+  versionNo: number;
+  name: string;
+  description: string;
+  activeDatasetId?: string;
+  createTime?: string;
+}
+
+export interface DashboardServerDetail {
+  dashboard: DashboardSummary;
+  currentVersion?: DashboardVersionSummary;
+  versions: DashboardVersionSummary[];
+  widgets: DashboardWidget[];
 }

--- a/yak-ops-ui/src/pages/dashboard/toolbar.tsx
+++ b/yak-ops-ui/src/pages/dashboard/toolbar.tsx
@@ -1,34 +1,89 @@
-import { Button, Input, Tooltip } from 'antd';
-import { ChevronLeft, Eye, RefreshCw, Save, X } from 'lucide-react';
+import { Button, Input, Select, Tooltip } from 'antd';
+import { ChevronLeft, Eye, History, Plus, Save, X } from 'lucide-react';
+import type { DashboardSummary, DashboardVersionSummary } from './model';
 
 export function DashboardToolbar({
   name,
+  dashboardId,
+  currentVersionNo,
+  dashboards,
+  versions,
+  loading,
+  saving,
   preview,
   onName,
-  onReset,
+  onDashboard,
+  onNew,
+  onVersion,
   onPreview,
   onSave,
 }: {
   name: string;
+  dashboardId: string;
+  currentVersionNo?: number;
+  dashboards: DashboardSummary[];
+  versions: DashboardVersionSummary[];
+  loading: boolean;
+  saving: boolean;
   preview: boolean;
   onName: (name: string) => void;
-  onReset: () => void;
+  onDashboard: (dashboardId: string) => void;
+  onNew: () => void;
+  onVersion: (versionNo: number) => void;
   onPreview: () => void;
   onSave: () => void;
 }) {
+  const persisted = /^\d+$/.test(dashboardId);
   return (
     <header className="flex h-12 shrink-0 items-center justify-between border-b border-[#dfe3e8] bg-white px-3">
       <div className="flex min-w-0 items-center gap-2">
         <Button size="small" type="text" icon={<ChevronLeft size={14} />} disabled={preview}>数据分析</Button>
         <span className="h-5 w-px bg-[#e5e7eb]" />
-        <Input variant="borderless" value={name} disabled={preview} onChange={(event) => onName(event.target.value)} className="w-[220px] px-1 text-[13px] font-semibold text-[#161823]" />
-        <span className="hidden rounded-[3px] bg-[#f5f6f7] px-2 py-0.5 text-[10px] text-[#667085] xl:inline">草稿</span>
+        <Select
+          size="small"
+          className="w-[190px]"
+          loading={loading}
+          disabled={preview}
+          placeholder="选择仪表盘"
+          value={persisted ? dashboardId : undefined}
+          options={dashboards.map((item) => ({ label: item.name, value: item.id }))}
+          onChange={onDashboard}
+        />
+        <Tooltip title="新建仪表盘">
+          <Button size="small" type="text" icon={<Plus size={13} />} disabled={preview} onClick={onNew} />
+        </Tooltip>
+        <span className="h-5 w-px bg-[#e5e7eb]" />
+        <Input
+          variant="borderless"
+          value={name}
+          disabled={preview}
+          onChange={(event) => onName(event.target.value)}
+          className="w-[220px] px-1 text-[13px] font-semibold text-[#161823]"
+        />
+        <span className="rounded-[3px] bg-[#f5f6f7] px-2 py-0.5 text-[10px] text-[#667085]">
+          {currentVersionNo ? `V${currentVersionNo}` : '未保存'}
+        </span>
       </div>
       <div className="flex items-center gap-2">
-        {!preview ? <span className="hidden text-[10px] text-[#98a2b3] xl:inline">数据开发发布数据集 · 24 栅格</span> : null}
-        {!preview ? <Tooltip title="恢复示例"><Button size="small" type="text" icon={<RefreshCw size={13} />} onClick={onReset} /></Tooltip> : null}
-        <Button size="small" icon={preview ? <X size={13} /> : <Eye size={13} />} onClick={onPreview}>{preview ? '退出预览' : '预览'}</Button>
-        {!preview ? <Button size="small" type="primary" icon={<Save size={13} />} onClick={onSave}>保存</Button> : null}
+        {persisted && versions.length ? (
+          <Select
+            size="small"
+            className="w-[104px]"
+            suffixIcon={<History size={12} />}
+            disabled={preview || saving}
+            value={currentVersionNo}
+            options={versions.map((item) => ({ label: `版本 V${item.versionNo}`, value: item.versionNo }))}
+            onChange={onVersion}
+          />
+        ) : null}
+        <Button size="small" icon={preview ? <X size={13} /> : <Eye size={13} />} onClick={onPreview}>
+          {preview ? '退出预览' : '预览'}
+        </Button>
+        {!preview ? (
+          <Button size="small" type="primary" loading={saving} icon={<Save size={13} />} onClick={onSave}>
+            保存
+          </Button>
+        ) : null}
       </div>
     </header>
   );

--- a/yak-ops-ui/src/pages/dashboard/use-dashboard.ts
+++ b/yak-ops-ui/src/pages/dashboard/use-dashboard.ts
@@ -1,13 +1,22 @@
 import { createAnalysis, fetchAnalyses } from '@/components/analysis/analysis-service';
 import type { AnalysisSpec } from '@/components/analysis/model';
 import { message } from 'antd';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { DEFAULT_DASHBOARD } from './defaults';
+import {
+  activateDashboardVersion,
+  createDashboard,
+  fetchDashboard,
+  fetchDashboards,
+  saveDashboardVersion,
+  toDashboardDocument,
+} from './dashboard-service';
 import {
   cloneDashboard,
   createInlineAnalysis,
   createWidget,
   findDataset,
+  isPersistedDashboard,
   loadDashboard,
   reconcileDashboard,
   STORAGE_KEY,
@@ -16,6 +25,8 @@ import type {
   AnalysisAsset,
   ChartType,
   DashboardDocument,
+  DashboardSummary,
+  DashboardVersionSummary,
   DashboardWidget,
   DatasetField,
   PublishedDataset,
@@ -38,10 +49,7 @@ const assetSpec = (analysis: AnalysisAsset): AnalysisSpec => ({
   datasetId: analysis.datasetId,
   dimensions: [...analysis.dimensions],
   metrics: analysis.metrics.map((metric) => ({ ...metric })),
-  filters: analysis.filters.map((filter, index) => ({
-    ...filter,
-    id: `detached-${analysis.id}-${index}`,
-  })),
+  filters: analysis.filters.map((filter, index) => ({ ...filter, id: `detached-${analysis.id}-${index}` })),
   sort: analysis.sort ? { ...analysis.sort } : undefined,
   style: { ...analysis.style },
   limit: analysis.limit,
@@ -56,8 +64,13 @@ export function useDashboardDesigner() {
   const [analyses, setAnalyses] = useState<AnalysisAsset[]>([]);
   const [analysesLoading, setAnalysesLoading] = useState(true);
   const [analysesError, setAnalysesError] = useState('');
+  const [dashboardAssets, setDashboardAssets] = useState<DashboardSummary[]>([]);
+  const [dashboardVersions, setDashboardVersions] = useState<DashboardVersionSummary[]>([]);
+  const [dashboardsLoading, setDashboardsLoading] = useState(true);
+  const [dashboardSaving, setDashboardSaving] = useState(false);
   const [selectedId, setSelectedId] = useState<string>();
   const [preview, setPreview] = useState(false);
+  const didAutoOpen = useRef(false);
   const widgets = dashboard.widgets;
   const selectedWidget = widgets.find((widget) => widget.id === selectedId);
   const activeDataset = useMemo(
@@ -84,8 +97,7 @@ export function useDashboardDesigner() {
     setAnalysesLoading(true);
     setAnalysesError('');
     try {
-      const values = await fetchAnalyses();
-      setAnalyses(values);
+      setAnalyses(await fetchAnalyses());
     } catch (error) {
       setAnalyses([]);
       setAnalysesError(error instanceof Error ? error.message : '加载 Analysis 失败');
@@ -94,10 +106,43 @@ export function useDashboardDesigner() {
     }
   }, []);
 
+  const refreshDashboardAssets = useCallback(async () => {
+    setDashboardsLoading(true);
+    try {
+      setDashboardAssets(await fetchDashboards());
+    } catch (error) {
+      setDashboardAssets([]);
+      message.error(error instanceof Error ? error.message : '加载 Dashboard 列表失败');
+    } finally {
+      setDashboardsLoading(false);
+    }
+  }, []);
+
+  const openDashboard = useCallback(async (dashboardId: string) => {
+    try {
+      const detail = await fetchDashboard(dashboardId);
+      setDashboard(toDashboardDocument(detail));
+      setDashboardVersions(detail.versions);
+      setSelectedId(undefined);
+      window.localStorage.removeItem(STORAGE_KEY);
+    } catch (error) {
+      message.error(error instanceof Error ? error.message : '加载 Dashboard 失败');
+    }
+  }, []);
+
   useEffect(() => {
     void refreshDatasets();
     void refreshAnalyses();
-  }, [refreshDatasets, refreshAnalyses]);
+    void refreshDashboardAssets();
+  }, [refreshDatasets, refreshAnalyses, refreshDashboardAssets]);
+
+  useEffect(() => {
+    if (didAutoOpen.current || dashboardsLoading) return;
+    didAutoOpen.current = true;
+    const hasLegacyDraft = !isPersistedDashboard(dashboard.id)
+      && (dashboard.widgets.length > 0 || dashboard.name !== DEFAULT_DASHBOARD.name);
+    if (!hasLegacyDraft && dashboardAssets.length) void openDashboard(dashboardAssets[0].id);
+  }, [dashboard.id, dashboard.name, dashboard.widgets.length, dashboardAssets, dashboardsLoading, openDashboard]);
 
   useEffect(() => {
     if (!datasets.length) return;
@@ -133,11 +178,7 @@ export function useDashboardDesigner() {
     if (!dataset) return void message.warning('Analysis 依赖的 Dataset 已下线或不可用');
     const base = createWidget(analysis.type, dataset, maxY());
     const next = linkWidget(base, analysis.id);
-    setDashboard((current) => ({
-      ...current,
-      activeDatasetId: analysis.datasetId,
-      widgets: [...current.widgets, next],
-    }));
+    setDashboard((current) => ({ ...current, activeDatasetId: analysis.datasetId, widgets: [...current.widgets, next] }));
     setSelectedId(next.id);
   };
 
@@ -164,12 +205,8 @@ export function useDashboardDesigner() {
     if (!widget?.analysisId) return;
     const analysis = analyses.find((item) => item.id === widget.analysisId);
     if (!analysis) return void message.warning('引用的 Analysis 已不可用，无法生成独立副本');
-    updateWidget(id, {
-      analysisId: undefined,
-      title: analysis.name,
-      inlineAnalysis: assetSpec(analysis),
-    });
-    message.success('已解除 Analysis 引用，当前组件已复制为独立分析');
+    updateWidget(id, { analysisId: undefined, title: analysis.name, inlineAnalysis: assetSpec(analysis) });
+    message.success('已解除 Analysis 引用，当前组件已复制为 Dashboard 本地分析');
   };
 
   const duplicateWidget = (id: string) => {
@@ -198,8 +235,7 @@ export function useDashboardDesigner() {
     if (!widget?.inlineAnalysis) return;
     const dataset = findDataset(datasets, datasetId);
     if (!dataset) return;
-    const nextSpec = createInlineAnalysis(widget.inlineAnalysis.type, dataset);
-    updateWidget(id, { inlineAnalysis: nextSpec });
+    updateWidget(id, { inlineAnalysis: createInlineAnalysis(widget.inlineAnalysis.type, dataset) });
   };
 
   const addField = (field: DatasetField) => {
@@ -228,19 +264,52 @@ export function useDashboardDesigner() {
     }
   };
 
-  const save = () => {
-    const next = { ...dashboard, updatedAt: new Date().toISOString() };
-    setDashboard(next);
-    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
-    message.success('仪表盘草稿已保存');
+  const save = async () => {
+    if (!dashboard.name.trim()) return void message.warning('请输入仪表盘名称');
+    setDashboardSaving(true);
+    try {
+      const detail = isPersistedDashboard(dashboard.id)
+        ? await saveDashboardVersion(dashboard.id, dashboard)
+        : await createDashboard(dashboard);
+      const document = toDashboardDocument(detail);
+      setDashboard(document);
+      setDashboardVersions(detail.versions);
+      setDashboardAssets((current) => [
+        detail.dashboard,
+        ...current.filter((item) => item.id !== detail.dashboard.id),
+      ]);
+      window.localStorage.removeItem(STORAGE_KEY);
+      message.success(`仪表盘已保存为 V${detail.dashboard.currentVersionNo}`);
+    } catch (error) {
+      message.error(error instanceof Error ? error.message : '保存 Dashboard 失败');
+    } finally {
+      setDashboardSaving(false);
+    }
   };
 
-  const reset = () => {
+  const activateVersion = async (versionNo: number) => {
+    if (!isPersistedDashboard(dashboard.id) || versionNo === dashboard.currentVersionNo) return;
+    setDashboardSaving(true);
+    try {
+      const detail = await activateDashboardVersion(dashboard.id, versionNo);
+      setDashboard(toDashboardDocument(detail));
+      setDashboardVersions(detail.versions);
+      setDashboardAssets((current) => current.map((item) => item.id === detail.dashboard.id ? detail.dashboard : item));
+      setSelectedId(undefined);
+      message.success(`已切换到 Dashboard V${versionNo}`);
+    } catch (error) {
+      message.error(error instanceof Error ? error.message : '切换 DashboardVersion 失败');
+    } finally {
+      setDashboardSaving(false);
+    }
+  };
+
+  const newDashboard = () => {
     const next = reconcileDashboard(cloneDashboard(DEFAULT_DASHBOARD), datasets);
     setDashboard(next);
+    setDashboardVersions([]);
     setSelectedId(undefined);
     window.localStorage.removeItem(STORAGE_KEY);
-    message.success('已恢复空白仪表盘');
   };
 
   return {
@@ -252,6 +321,10 @@ export function useDashboardDesigner() {
     analyses,
     analysesLoading,
     analysesError,
+    dashboardAssets,
+    dashboardVersions,
+    dashboardsLoading,
+    dashboardSaving,
     selectedWidget,
     activeDataset,
     selectedId,
@@ -270,8 +343,11 @@ export function useDashboardDesigner() {
     changeWidgetDataset,
     addField,
     save,
-    reset,
+    activateVersion,
+    newDashboard,
+    openDashboard,
     refreshDatasets,
     refreshAnalyses,
+    refreshDashboardAssets,
   };
 }


### PR DESCRIPTION
## 背景

前面 BI 主链已经完成：

```text
Data Development
  -> Dataset / DatasetVersion
  -> Dataset Query Runtime
  -> Analysis
  -> Dashboard Widget = analysisId + layout
```

上一阶段 Dashboard 仍然只是浏览器 `localStorage` 草稿，本 PR 将 Dashboard 正式升级为服务端领域资产，并加入手工保存触发的不可变版本体系。

## 目标模型

```text
Dashboard
  id / name / description
  currentVersionId
  currentVersionNo
        |
        v
DashboardVersion Vn   (immutable)
  nameSnapshot
  descriptionSnapshot
  activeDatasetId
        |
        v
DashboardWidget[]
  widgetKey
  analysisId        -- shared reusable Analysis
       OR
  inlineAnalysis    -- dashboard-local analysis
  x / y / w / h
  minW / minH
```

DashboardVersion 是“Dashboard 组合 / 布局版本”。它冻结某次保存时引用了哪些 Analysis、哪些本地图表以及布局，但不会复制共享 Analysis 的 ChartSpec；Analysis 仍然是独立可更新资产。

## 1. 新增 Dashboard 后端领域模块

新增：

```text
yak-ops-business-dashboard
```

并接入：

- `yak-ops-business` reactor
- `yak-ops-boot`
- Analysis 域引用校验
- 独立 Flyway

Dashboard 域不执行 Dataset Query、不理解 SQL，也不拥有 Analysis ChartSpec。

## 2. 数据库模型

新增三张表：

```text
yak_dashboard
yak_dashboard_version
yak_dashboard_widget
```

`yak_dashboard` 只维护稳定身份和当前版本指针；每次用户明确点击“保存”才生成新的 `DashboardVersion`。

不会因为拖拽、缩放、输入标题等编辑动作自动制造版本。

Flyway：

```text
flyway_schema_history_dashboard
```

并通过 `@DependsOn("yakAnalysisFlyway")` 保证 Analysis 表先创建。

## 3. Dashboard API

新增：

```text
GET    /api/v1/dashboards
GET    /api/v1/dashboards/{dashboardId}
GET    /api/v1/dashboards/{dashboardId}/versions

POST   /api/v1/dashboards
POST   /api/v1/dashboards/{dashboardId}/versions
POST   /api/v1/dashboards/{dashboardId}/activate/{versionNo}

DELETE /api/v1/dashboards/{dashboardId}
```

语义：

```text
首次保存
  -> Dashboard + V1

再次保存
  -> V2 / V3 / ...
  -> currentVersion 指向新版本

历史版本切换
  -> 只移动 currentVersion 指针
  -> 不修改旧 DashboardVersion

从历史 V1 修改后再保存
  -> 使用 MAX(versionNo) + 1
  -> 例如已有 V1/V2，回到 V1 后保存会创建 V3
```

## 4. DashboardWidget 与 Analysis 的引用完整性

Linked Widget 仍然保持上一阶段的严格边界：

```text
DashboardWidget
  -> analysisId + layout
```

不会再复制：

```text
x datasetId
x dimensions
x metrics
x filters
x sorts
x visualConfig
```

数据库 `analysis_id` 外键指向 `yak_analysis`，历史 DashboardVersion 只要仍引用某 Analysis，就不会允许该 Analysis 被数据库层静默删除，避免 Dashboard 历史版本出现悬空引用。

同时新增很薄的跨域端口：

```text
AnalysisReferenceService.requireExists(analysisId)
```

Dashboard 域只依赖“Analysis 引用是否有效”，不依赖 Analysis 完整 CRUD。

## 5. Dashboard-local inlineAnalysis

并不是所有临时图表都必须先发布为共享 Analysis。

Dashboard 允许 Widget 二选一：

```text
analysisId
OR
inlineAnalysis
```

服务端强制“必须且只能存在一种”。

因此可以：

```text
快速探索 -> Dashboard-local inlineAnalysis
需要复用 -> 保存为 Analysis -> Widget 改为 analysisId
```

inlineAnalysis 作为 JSON 快照跟随 DashboardVersion 保存，不会成为全局可复用资产。

## 6. Dashboard 布局校验

服务端统一校验：

- Dashboard 最多 200 个 Widget
- `widgetKey` 唯一
- x 在 0~23
- w 在 1~24
- `x + w <= 24`
- y >= 0
- h 在 1~60
- minW/minH 不能超过当前尺寸
- linked / inline 定义互斥
- inlineAnalysis 必须是 JSON Object，并限制大小

避免只依赖前端画布约束。

## 7. 前端从 localStorage 正式迁移到服务端

原来的：

```text
点击保存
  -> localStorage
```

现在变成：

```text
首次保存
  -> POST /api/v1/dashboards
  -> Dashboard V1

后续保存
  -> POST /api/v1/dashboards/{id}/versions
  -> V2 / V3 / ...
```

`localStorage` 只保留为一次性兼容迁移入口：

- 老版本已有本地 Dashboard 草稿仍能读取
- 老 Widget 结构仍能迁移成 inlineAnalysis
- 第一次点击保存后创建服务端 Dashboard V1
- 保存成功后删除旧 localStorage key
- 后续不再把 localStorage 当 Dashboard 正式数据源

## 8. 多 Dashboard 管理

Dashboard 顶部工具栏新增：

- Dashboard 下拉选择
- 新建 Dashboard
- 当前版本标识
- 历史版本选择
- 保存
- 预览

进入页面时：

- 如果存在旧 localStorage 草稿，优先让用户保存迁移，不覆盖
- 如果没有本地草稿且已有服务端 Dashboard，自动打开最近更新的 Dashboard
- 新建 Dashboard 为未保存状态

## 9. DashboardVersion 历史切换

工具栏可以直接选择：

```text
版本 V1
版本 V2
版本 V3
```

切换会调用服务端 `activate/{versionNo}`，恢复该版本的：

- Dashboard 名称快照
- activeDatasetId
- Analysis 引用集合
- dashboard-local inlineAnalysis
- 24 栅格布局

旧版本自身保持不可变。

## 10. 与 Analysis 的版本边界

本 PR 刻意不把 Analysis ChartSpec 复制进 linked DashboardWidget。

所以：

```text
DashboardVersion = composition/layout snapshot
Analysis          = reusable analysis definition
```

如果 Analysis A 被更新，所有仍引用 Analysis A 的 Dashboard（包括历史组合版本）都会使用 Analysis 当前定义。这是为了保持单一真相，不制造 Dashboard 内隐藏的第二份 Analysis 配置。

如果未来需要“完全可重放”的 BI 发布包，应在 Analysis 自己拥有 AnalysisVersion 后，让 DashboardVersion 引用 `analysisVersionId`，而不是现在提前复制 ChartSpec。

## 11. 测试

新增 `DashboardServiceTest`，覆盖：

- 创建 Dashboard 时产生 V1
- linked Widget 会通过 AnalysisReferenceService 校验引用
- 手工再次保存产生不可变 V2
- 历史版本仍保留
- Widget 不能同时包含 analysisId 和 inlineAnalysis

## 本 PR 暂不做

- Dashboard owner / sharing / permissions
- Dashboard 发布 / 草稿双状态
- Dashboard 全局 Filter
- Widget 联动 / 下钻 / 跳转
- Dashboard 收藏 / 最近访问
- AnalysisVersion
- 完全可重放的深度 BI snapshot
- 查询缓存 / 预聚合

这些能力都可以继续建立在本 PR 的正式 `Dashboard -> DashboardVersion -> DashboardWidget -> Analysis` 关系上。

## 验证说明

已基于当前最新 `main`（包含上一阶段 Analysis PR #384）开发，分支当前仅领先主干、未落后。执行环境无法直接解析 github.com，因此无法本地 clone 后运行 Maven/前端构建；PR 创建后继续检查 GitHub mergeability 与可用 status checks。