### PR TITLE
feat(workflow): add instance operations and rerun tooling

### DIFF
--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/controller/v1/WorkflowInstanceOperationsController.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/controller/v1/WorkflowInstanceOperationsController.java
@@ -1,0 +1,52 @@
+package io.yak.ops.business.workflow.controller.v1;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.yak.framework.common.Result;
+import io.yak.ops.business.workflow.service.WorkflowInstanceOperationsService;
+import io.yak.ops.common.bean.dto.workflow.WorkflowBatchRetryDTO;
+import io.yak.ops.common.bean.dto.workflow.WorkflowBusinessDateRerunDTO;
+import io.yak.ops.common.bean.vo.workflow.WorkflowBackfillVO;
+import io.yak.ops.common.bean.vo.workflow.WorkflowBatchRetryVO;
+import io.yak.ops.common.bean.vo.workflow.WorkflowInstanceOperationsVO;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** 工作流实例运维与补跑接口。 */
+@Tag(name = "工作流实例运维")
+@RestController
+@RequestMapping("/api/v1/workflows/instances")
+public class WorkflowInstanceOperationsController {
+  private final WorkflowInstanceOperationsService operations;
+
+  public WorkflowInstanceOperationsController(WorkflowInstanceOperationsService operations) {
+    this.operations = operations;
+  }
+
+  @Operation(summary = "查询实例运维上下文与运行 DAG 拓扑")
+  @GetMapping("/{executionId}/operations")
+  public Result<WorkflowInstanceOperationsVO> describe(
+      @PathVariable("executionId") String executionId) {
+    return Result.success(operations.describe(executionId));
+  }
+
+  @Operation(summary = "按指定 businessDate 重跑来源实例的固定发布版本")
+  @PostMapping("/{executionId}/rerun-business-date")
+  public Result<WorkflowBackfillVO> rerunBusinessDate(
+      @PathVariable("executionId") String executionId,
+      @Valid @RequestBody WorkflowBusinessDateRerunDTO request) {
+    return Result.success(operations.rerunBusinessDate(executionId, request));
+  }
+
+  @Operation(summary = "批量重试失败工作流实例")
+  @PostMapping("/batch-retry-failed")
+  public Result<WorkflowBatchRetryVO> batchRetryFailed(
+      @Valid @RequestBody WorkflowBatchRetryDTO request) {
+    return Result.success(operations.batchRetryFailed(request));
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/domain/WorkflowTriggerContext.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/domain/WorkflowTriggerContext.java
@@ -6,7 +6,7 @@ import java.util.UUID;
 /**
  * 工作流启动上下文。
  *
- * <p>Definition、调度、补数和 API 最终都通过同一个 Launch 入口进入 Runtime，
+ * <p>Definition、调度、补数、运维补跑和 API 最终都通过同一个 Launch 入口进入 Runtime，
  * 该上下文只描述“为什么启动”，不参与 DAG 本身的编排语义。</p>
  */
 public record WorkflowTriggerContext(
@@ -106,6 +106,22 @@ public record WorkflowTriggerContext(
         required(scheduleId, "补数 scheduleId 不能为空"),
         required(backfillId, "补数 backfillId 不能为空"),
         required(plannedFireTime, "补数 plannedFireTime 不能为空"),
+        timezone);
+  }
+
+  /** Stage 6：指定 businessDate 的人工运维补跑。 */
+  public static WorkflowTriggerContext rerun(
+      String triggerId,
+      String scheduleId,
+      String backfillId,
+      Instant plannedFireTime,
+      String timezone) {
+    return new WorkflowTriggerContext(
+        WorkflowTriggerType.RERUN,
+        triggerId,
+        required(scheduleId, "补跑 scheduleId 不能为空"),
+        required(backfillId, "补跑 batchId 不能为空"),
+        required(plannedFireTime, "补跑 plannedFireTime 不能为空"),
         timezone);
   }
 

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/domain/WorkflowTriggerType.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/domain/WorkflowTriggerType.java
@@ -5,5 +5,6 @@ public enum WorkflowTriggerType {
   MANUAL,
   SCHEDULE,
   BACKFILL,
+  RERUN,
   API
 }

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowBackfillQuery.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowBackfillQuery.java
@@ -66,6 +66,8 @@ public class WorkflowBackfillQuery {
         value.getScheduleName(),
         value.getName(),
         status,
+        value.getOperationType() == null ? "BACKFILL" : value.getOperationType(),
+        value.getSourceExecutionId(),
         value.getStartBusinessDate(),
         value.getEndBusinessDate(),
         value.getCronExpression(),

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowBackfillService.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowBackfillService.java
@@ -6,14 +6,18 @@ import io.yak.ops.business.workflow.persistence.support.WorkflowJsonCodec;
 import io.yak.ops.business.workflow.service.WorkflowBackfillPlanner.Occurrence;
 import io.yak.ops.business.workflow.service.WorkflowBackfillPlanner.Plan;
 import io.yak.ops.common.bean.dto.workflow.WorkflowBackfillCreateDTO;
+import io.yak.ops.common.bean.dto.workflow.WorkflowBusinessDateRerunDTO;
 import io.yak.ops.common.bean.po.workflow.WorkflowBackfillPO;
 import io.yak.ops.common.bean.po.workflow.WorkflowSchedulePO;
 import io.yak.ops.common.bean.po.workflow.WorkflowScheduleTriggerPO;
 import io.yak.ops.common.bean.vo.workflow.WorkflowBackfillPreviewVO;
 import io.yak.ops.common.bean.vo.workflow.WorkflowBackfillVO;
+import io.yak.ops.common.bean.vo.workflow.WorkflowInstanceVO;
 import java.time.Instant;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import org.slf4j.Logger;
@@ -21,12 +25,27 @@ import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
 
-/** Backfill 批次创建、预览、取消与 Trigger Ledger 分发。 */
+/** Backfill 批次创建、运维补跑、预览、取消与 Trigger Ledger 分发。 */
 @Service
 @ConditionalOnProperty(prefix = "yak.database", name = "enabled", havingValue = "true", matchIfMissing = true)
 public class WorkflowBackfillService {
   private static final Logger log = LoggerFactory.getLogger(WorkflowBackfillService.class);
   private static final Set<String> STRATEGIES = Set.of("SERIAL_WAIT", "PARALLEL");
+  private static final Set<String> TERMINAL = Set.of(
+      "SUCCESS", "SUCCESS_WITH_WARNINGS", "FAILED", "WARNING", "CANCELED", "TIMED_OUT");
+  private static final Set<String> SYSTEM_INPUT_KEYS = Set.of(
+      "businessDate",
+      "scheduleTime",
+      "scheduleTimezone",
+      "plannedFireTime",
+      "triggerType",
+      "triggerId",
+      "scheduleId",
+      "backfillId",
+      "cronExpression",
+      "workflowVersionId",
+      "workflowVersionNo",
+      WorkflowScheduleParameterResolver.NAMESPACE);
 
   private final WorkflowScheduleQuery schedules;
   private final WorkflowDefinitionService definitions;
@@ -91,48 +110,82 @@ public class WorkflowBackfillService {
       throw new IllegalStateException("工作流需要先发布并上线，才能执行 Backfill");
     }
 
-    String strategy = strategy(request.executionStrategy());
+    String executionStrategy = strategy(request.executionStrategy());
     Plan plan = planner.plan(
         schedule.getCronExpression(),
         schedule.getTimezone(),
         request.startBusinessDate(),
         request.endBusinessDate());
 
-    Instant now = Instant.now();
-    WorkflowBackfillPO backfill = new WorkflowBackfillPO();
-    backfill.setId("workflow-backfill-" + UUID.randomUUID());
-    backfill.setWorkflowId(schedule.getWorkflowId());
-    backfill.setWorkflowVersionId(workflow.activeVersionId());
-    backfill.setWorkflowVersionNo(workflow.activeVersionNo());
-    backfill.setScheduleId(schedule.getId());
-    backfill.setScheduleName(schedule.getName());
-    backfill.setName(name(request, schedule));
-    backfill.setStatus("RUNNING");
-    backfill.setStartBusinessDate(request.startBusinessDate());
-    backfill.setEndBusinessDate(request.endBusinessDate());
-    backfill.setCronExpression(plan.cronExpression());
-    backfill.setTimezone(plan.timezone());
-    backfill.setExecutionStrategy(strategy);
-    backfill.setScheduleInputJson(schedule.getInputJson());
-    backfill.setInputJson(json.write(request.input()));
-    backfill.setTotalCount(plan.occurrences().size());
-    backfill.setCreateTime(now);
-    backfill.setUpdateTime(now);
-    if (dao.insert(backfill) != 1) throw new IllegalStateException("创建 Backfill 批次失败");
+    WorkflowBackfillPO backfill = base(
+        schedule.getWorkflowId(),
+        workflow.activeVersionId(),
+        workflow.activeVersionNo(),
+        schedule.getId(),
+        schedule.getName(),
+        name(request, schedule),
+        "BACKFILL",
+        null,
+        request.startBusinessDate(),
+        request.endBusinessDate(),
+        plan,
+        executionStrategy,
+        schedule.getInputJson(),
+        json.write(request.input()));
+    persistAndDispatch(backfill, plan.occurrences());
+    return query.get(backfill.getId());
+  }
 
-    for (Occurrence occurrence : plan.occurrences()) {
-      try {
-        coordinator.submitBackfill(backfill, occurrence);
-      } catch (RuntimeException exception) {
-        // 单个逻辑日期启动失败已经写入 Ledger；批次继续创建其余日期，最终由汇总状态反映失败。
-        log.warn(
-            "[workflow-backfill] dispatch failed backfill={}, businessDate={}, scheduleTime={}, message={}",
-            backfill.getId(),
-            occurrence.businessDate(),
-            occurrence.scheduleTime(),
-            exception.getMessage());
-      }
+  /**
+   * Stage 6：按来源实例的不可变发布版本与调度语义，对指定 businessDate 创建运维补跑。
+   * 旧实例的系统调度参数会被剥离，再由 Stage 5 参数解析器根据新的逻辑计划时间重新注入。
+   */
+  public WorkflowBackfillVO createBusinessDateRerun(
+      String sourceExecutionId,
+      WorkflowInstanceVO source,
+      WorkflowBusinessDateRerunDTO request) {
+    if (source == null || request == null) throw new IllegalArgumentException("指定日期补跑参数不能为空");
+    if (!source.id().equals(sourceExecutionId)) throw new IllegalArgumentException("来源实例 ID 不匹配");
+    if (!TERMINAL.contains(source.status())) throw new IllegalStateException("仅终态实例支持指定 businessDate 重跑");
+    if (source.workflowVersionId() == null || source.workflowVersionNo() == null) {
+      throw new IllegalStateException("来源实例没有不可变发布版本，不能执行 businessDate 重跑");
     }
+
+    Map<String, Object> sourceInput = source.input() == null ? Map.of() : source.input();
+    String scheduleId = text(sourceInput.get("scheduleId"));
+    String cron = text(sourceInput.get("cronExpression"));
+    String timezone = text(sourceInput.get("scheduleTimezone"));
+    if (scheduleId == null || cron == null || timezone == null) {
+      throw new IllegalStateException("来源实例缺少 scheduleId / cronExpression / scheduleTimezone 调度血缘");
+    }
+
+    String workflowId = triggers.selectWorkflowIdByExecution(sourceExecutionId);
+    if (workflowId == null || workflowId.isBlank()) {
+      throw new IllegalStateException("无法从来源实例解析工作流 ID：" + sourceExecutionId);
+    }
+
+    Plan plan = planner.plan(cron, timezone, request.businessDate(), request.businessDate());
+    Map<String, Object> inheritedInput = userInput(sourceInput);
+    String scheduleName = scheduleName(scheduleId);
+    String executionStrategy = strategy(request.executionStrategy());
+    String batchName = scheduleName + " · 运维补跑 " + request.businessDate();
+
+    WorkflowBackfillPO backfill = base(
+        workflowId,
+        source.workflowVersionId(),
+        source.workflowVersionNo(),
+        scheduleId,
+        scheduleName,
+        batchName,
+        "BUSINESS_DATE_RERUN",
+        sourceExecutionId,
+        request.businessDate(),
+        request.businessDate(),
+        plan,
+        executionStrategy,
+        json.write(inheritedInput),
+        json.write(request.input()));
+    persistAndDispatch(backfill, plan.occurrences());
     return query.get(backfill.getId());
   }
 
@@ -146,10 +199,90 @@ public class WorkflowBackfillService {
     }
     for (WorkflowScheduleTriggerPO trigger : triggers.selectByBackfillId(backfill.getId())) {
       if ("RECEIVED".equals(trigger.getStatus()) || "WAITING".equals(trigger.getStatus())) {
-        admission.skip(trigger, "Backfill 批次已取消，尚未启动的 Trigger 跳过");
+        admission.skip(trigger, "Backfill/运维补跑批次已取消，尚未启动的 Trigger 跳过");
       }
     }
     return query.get(backfill.getId());
+  }
+
+  private WorkflowBackfillPO base(
+      String workflowId,
+      String workflowVersionId,
+      Integer workflowVersionNo,
+      String scheduleId,
+      String scheduleName,
+      String name,
+      String operationType,
+      String sourceExecutionId,
+      java.time.LocalDate startBusinessDate,
+      java.time.LocalDate endBusinessDate,
+      Plan plan,
+      String executionStrategy,
+      String scheduleInputJson,
+      String inputJson) {
+    Instant now = Instant.now();
+    WorkflowBackfillPO backfill = new WorkflowBackfillPO();
+    backfill.setId("workflow-backfill-" + UUID.randomUUID());
+    backfill.setWorkflowId(workflowId);
+    backfill.setWorkflowVersionId(workflowVersionId);
+    backfill.setWorkflowVersionNo(workflowVersionNo);
+    backfill.setScheduleId(scheduleId);
+    backfill.setScheduleName(scheduleName);
+    backfill.setName(name);
+    backfill.setStatus("RUNNING");
+    backfill.setOperationType(operationType);
+    backfill.setSourceExecutionId(sourceExecutionId);
+    backfill.setStartBusinessDate(startBusinessDate);
+    backfill.setEndBusinessDate(endBusinessDate);
+    backfill.setCronExpression(plan.cronExpression());
+    backfill.setTimezone(plan.timezone());
+    backfill.setExecutionStrategy(executionStrategy);
+    backfill.setScheduleInputJson(scheduleInputJson);
+    backfill.setInputJson(inputJson);
+    backfill.setTotalCount(plan.occurrences().size());
+    backfill.setCreateTime(now);
+    backfill.setUpdateTime(now);
+    return backfill;
+  }
+
+  private void persistAndDispatch(WorkflowBackfillPO backfill, List<Occurrence> occurrences) {
+    if (dao.insert(backfill) != 1) throw new IllegalStateException("创建 Backfill/补跑批次失败");
+    for (Occurrence occurrence : occurrences) {
+      try {
+        coordinator.submitBackfill(backfill, occurrence);
+      } catch (RuntimeException exception) {
+        log.warn(
+            "[workflow-backfill] dispatch failed batch={}, operation={}, businessDate={}, scheduleTime={}, message={}",
+            backfill.getId(),
+            backfill.getOperationType(),
+            occurrence.businessDate(),
+            occurrence.scheduleTime(),
+            exception.getMessage());
+      }
+    }
+  }
+
+  private Map<String, Object> userInput(Map<String, Object> sourceInput) {
+    Map<String, Object> result = new LinkedHashMap<>();
+    sourceInput.forEach((key, value) -> {
+      if (!SYSTEM_INPUT_KEYS.contains(key)) result.put(key, value);
+    });
+    return Map.copyOf(result);
+  }
+
+  private String scheduleName(String scheduleId) {
+    try {
+      WorkflowSchedulePO schedule = schedules.require(scheduleId);
+      return schedule.getName();
+    } catch (IllegalArgumentException missing) {
+      return scheduleId;
+    }
+  }
+
+  private String text(Object value) {
+    if (value == null) return null;
+    String result = String.valueOf(value).trim();
+    return result.isEmpty() ? null : result;
   }
 
   private String strategy(String value) {
@@ -157,7 +290,7 @@ public class WorkflowBackfillService {
         ? "SERIAL_WAIT"
         : value.trim().toUpperCase(Locale.ROOT);
     if (!STRATEGIES.contains(normalized)) {
-      throw new IllegalArgumentException("Backfill 仅支持 SERIAL_WAIT 或 PARALLEL：" + normalized);
+      throw new IllegalArgumentException("补数/补跑仅支持 SERIAL_WAIT 或 PARALLEL：" + normalized);
     }
     return normalized;
   }

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowBackfillService.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowBackfillService.java
@@ -45,6 +45,8 @@ public class WorkflowBackfillService {
       "cronExpression",
       "workflowVersionId",
       "workflowVersionNo",
+      "operationType",
+      "sourceExecutionId",
       WorkflowScheduleParameterResolver.NAMESPACE);
 
   private final WorkflowScheduleQuery schedules;
@@ -138,7 +140,7 @@ public class WorkflowBackfillService {
 
   /**
    * Stage 6：按来源实例的不可变发布版本与调度语义，对指定 businessDate 创建运维补跑。
-   * 旧实例的系统调度参数会被剥离，再由 Stage 5 参数解析器根据新的逻辑计划时间重新注入。
+   * 旧实例的系统调度参数和旧运维血缘会被剥离，再根据新的逻辑计划时间重新注入。
    */
   public WorkflowBackfillVO createBusinessDateRerun(
       String sourceExecutionId,

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowInstanceOperationsService.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowInstanceOperationsService.java
@@ -1,0 +1,221 @@
+package io.yak.ops.business.workflow.service;
+
+import io.yak.framework.workflow.engine.definition.EdgeDefinition;
+import io.yak.framework.workflow.engine.spi.WorkflowDefinitionRepository;
+import io.yak.ops.business.workflow.dao.WorkflowScheduleTriggerDao;
+import io.yak.ops.business.workflow.persistence.WorkflowRuntimePersistence;
+import io.yak.ops.business.workflow.persistence.WorkflowRuntimePersistence.RuntimeMetadataRecord;
+import io.yak.ops.common.bean.dto.workflow.WorkflowBatchRetryDTO;
+import io.yak.ops.common.bean.dto.workflow.WorkflowBusinessDateRerunDTO;
+import io.yak.ops.common.bean.vo.workflow.WorkflowBackfillVO;
+import io.yak.ops.common.bean.vo.workflow.WorkflowBatchRetryVO;
+import io.yak.ops.common.bean.vo.workflow.WorkflowBatchRetryVO.ItemVO;
+import io.yak.ops.common.bean.vo.workflow.WorkflowInstanceOperationsVO;
+import io.yak.ops.common.bean.vo.workflow.WorkflowInstanceOperationsVO.EdgeVO;
+import io.yak.ops.common.bean.vo.workflow.WorkflowInstanceVO;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.stereotype.Service;
+
+/** Stage 6 工作流实例运维编排：查询血缘、批量失败恢复和指定 businessDate 补跑。 */
+@Service
+public class WorkflowInstanceOperationsService {
+  private static final int MAX_BATCH_RETRY = 100;
+
+  private final WorkflowRuntimeService runtime;
+  private final ObjectProvider<WorkflowRuntimePersistence> runtimePersistence;
+  private final ObjectProvider<WorkflowDefinitionRepository> definitionRepository;
+  private final ObjectProvider<WorkflowScheduleTriggerDao> triggerDao;
+  private final ObjectProvider<WorkflowBackfillService> backfillService;
+
+  public WorkflowInstanceOperationsService(
+      WorkflowRuntimeService runtime,
+      ObjectProvider<WorkflowRuntimePersistence> runtimePersistence,
+      ObjectProvider<WorkflowDefinitionRepository> definitionRepository,
+      ObjectProvider<WorkflowScheduleTriggerDao> triggerDao,
+      ObjectProvider<WorkflowBackfillService> backfillService) {
+    this.runtime = runtime;
+    this.runtimePersistence = runtimePersistence;
+    this.definitionRepository = definitionRepository;
+    this.triggerDao = triggerDao;
+    this.backfillService = backfillService;
+  }
+
+  public WorkflowInstanceOperationsVO describe(String executionId) {
+    WorkflowInstanceVO instance = runtime.getInstance(required(executionId, "实例 ID 不能为空"));
+    Map<String, Object> input = instance.input() == null ? Map.of() : instance.input();
+    RuntimeMetadataRecord metadata = metadata(instance.id());
+
+    String workflowId = workflowId(instance.id());
+    String triggerType = first(text(input.get("triggerType")), metadata == null ? null : metadata.triggerType());
+    String triggerId = first(text(input.get("triggerId")), metadata == null ? null : metadata.triggerId());
+    String scheduleId = first(text(input.get("scheduleId")), metadata == null ? null : metadata.scheduleId());
+    String backfillId = text(input.get("backfillId"));
+    String scheduleTimezone = text(input.get("scheduleTimezone"));
+    String scheduleTime = text(input.get("scheduleTime"));
+    String cronExpression = text(input.get("cronExpression"));
+    LocalDate businessDate = date(input.get("businessDate"));
+    Instant plannedFireTime = instant(input.get("plannedFireTime"));
+    if (plannedFireTime == null && metadata != null) plannedFireTime = metadata.plannedFireTime();
+
+    String unavailable = businessDateRerunUnavailableReason(
+        instance, workflowId, scheduleId, cronExpression, scheduleTimezone);
+    return new WorkflowInstanceOperationsVO(
+        instance.id(),
+        workflowId,
+        triggerType,
+        triggerId,
+        scheduleId,
+        backfillId,
+        businessDate,
+        scheduleTime,
+        scheduleTimezone,
+        plannedFireTime,
+        cronExpression,
+        unavailable == null,
+        unavailable,
+        edges(instance.definitionId()));
+  }
+
+  public WorkflowBackfillVO rerunBusinessDate(
+      String executionId,
+      WorkflowBusinessDateRerunDTO request) {
+    String id = required(executionId, "实例 ID 不能为空");
+    WorkflowInstanceVO instance = runtime.getInstance(id);
+    WorkflowInstanceOperationsVO operations = describe(id);
+    if (!operations.businessDateRerunSupported()) {
+      throw new IllegalStateException(operations.businessDateRerunUnavailableReason());
+    }
+    WorkflowBackfillService service = backfillService.getIfAvailable();
+    if (service == null) throw new IllegalStateException("当前运行模式不支持 durable businessDate 补跑");
+    return service.createBusinessDateRerun(id, instance, request);
+  }
+
+  /** 每个实例独立处理；其中一条失败不会回滚已经成功恢复的其它实例。 */
+  public WorkflowBatchRetryVO batchRetryFailed(WorkflowBatchRetryDTO request) {
+    if (request == null || request.executionIds() == null || request.executionIds().isEmpty()) {
+      throw new IllegalArgumentException("请选择需要重试的失败实例");
+    }
+    LinkedHashSet<String> ids = new LinkedHashSet<>();
+    for (String value : request.executionIds()) {
+      if (value != null && !value.isBlank()) ids.add(value.trim());
+    }
+    if (ids.isEmpty()) throw new IllegalArgumentException("请选择需要重试的失败实例");
+    if (ids.size() > MAX_BATCH_RETRY) {
+      throw new IllegalArgumentException("单次最多批量重试 " + MAX_BATCH_RETRY + " 个实例");
+    }
+
+    List<ItemVO> items = new ArrayList<>();
+    int accepted = 0;
+    for (String id : ids) {
+      try {
+        WorkflowInstanceVO result = runtime.retryFailedNodes(id);
+        accepted++;
+        items.add(new ItemVO(id, true, result.status(), "已重新调度失败/阻断节点"));
+      } catch (RuntimeException exception) {
+        items.add(new ItemVO(id, false, null, safeMessage(exception)));
+      }
+    }
+    return new WorkflowBatchRetryVO(ids.size(), accepted, ids.size() - accepted, items);
+  }
+
+  private String businessDateRerunUnavailableReason(
+      WorkflowInstanceVO instance,
+      String workflowId,
+      String scheduleId,
+      String cronExpression,
+      String scheduleTimezone) {
+    if (!terminal(instance.status())) return "仅终态实例支持指定 businessDate 重跑";
+    if (instance.workflowVersionId() == null || instance.workflowVersionNo() == null) {
+      return "实例没有不可变发布版本，测试/临时 DAG 不能按 businessDate 重跑";
+    }
+    if (workflowId == null) return "无法解析实例所属工作流";
+    if (scheduleId == null) return "实例没有 Schedule 调度血缘";
+    if (cronExpression == null) return "实例缺少创建时 Cron 快照";
+    if (scheduleTimezone == null) return "实例缺少创建时调度时区";
+    if (backfillService.getIfAvailable() == null) return "当前运行模式未启用 durable Backfill";
+    return null;
+  }
+
+  private List<EdgeVO> edges(String definitionId) {
+    WorkflowDefinitionRepository repository = definitionRepository.getIfAvailable();
+    if (repository == null || definitionId == null) return List.of();
+    return repository.findById(definitionId)
+        .map(definition -> definition.edges().stream().map(this::edge).toList())
+        .orElse(List.of());
+  }
+
+  private EdgeVO edge(EdgeDefinition edge) {
+    return new EdgeVO(edge.fromNodeId(), edge.toNodeId());
+  }
+
+  private RuntimeMetadataRecord metadata(String executionId) {
+    WorkflowRuntimePersistence persistence = runtimePersistence.getIfAvailable();
+    return persistence == null ? null : persistence.findMetadata(executionId).orElse(null);
+  }
+
+  private String workflowId(String executionId) {
+    WorkflowScheduleTriggerDao dao = triggerDao.getIfAvailable();
+    if (dao == null) return null;
+    return dao.selectWorkflowIdByExecution(executionId);
+  }
+
+  private boolean terminal(String status) {
+    return "SUCCESS".equals(status)
+        || "SUCCESS_WITH_WARNINGS".equals(status)
+        || "FAILED".equals(status)
+        || "WARNING".equals(status)
+        || "CANCELED".equals(status)
+        || "TIMED_OUT".equals(status);
+  }
+
+  private LocalDate date(Object value) {
+    String text = text(value);
+    if (text == null) return null;
+    try {
+      return LocalDate.parse(text);
+    } catch (RuntimeException ignored) {
+      return null;
+    }
+  }
+
+  private Instant instant(Object value) {
+    String text = text(value);
+    if (text == null) return null;
+    try {
+      return Instant.parse(text);
+    } catch (RuntimeException ignored) {
+      return null;
+    }
+  }
+
+  private String text(Object value) {
+    if (value == null) return null;
+    String result = String.valueOf(value).trim();
+    return result.isEmpty() ? null : result;
+  }
+
+  private String first(String preferred, String fallback) {
+    return preferred == null ? fallback : preferred;
+  }
+
+  private String required(String value, String message) {
+    if (value == null || value.isBlank()) throw new IllegalArgumentException(message);
+    return value.trim();
+  }
+
+  private String safeMessage(Throwable error) {
+    Throwable current = error;
+    while (current.getCause() != null && current.getCause() != current) current = current.getCause();
+    String message = current.getMessage();
+    String value = message == null || message.isBlank()
+        ? current.getClass().getSimpleName()
+        : message;
+    return value.length() <= 1000 ? value : value.substring(0, 1000);
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowInstanceOperationsService.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowInstanceOperationsService.java
@@ -52,10 +52,13 @@ public class WorkflowInstanceOperationsService {
     RuntimeMetadataRecord metadata = metadata(instance.id());
 
     String workflowId = workflowId(instance.id());
-    String triggerType = first(text(input.get("triggerType")), metadata == null ? null : metadata.triggerType());
-    String triggerId = first(text(input.get("triggerId")), metadata == null ? null : metadata.triggerId());
+    // Launch metadata 描述“本次为什么启动”；input 保留原调度血缘，两者不能混淆。
+    String triggerType = first(metadata == null ? null : metadata.triggerType(), text(input.get("triggerType")));
+    String triggerId = first(metadata == null ? null : metadata.triggerId(), text(input.get("triggerId")));
     String scheduleId = first(text(input.get("scheduleId")), metadata == null ? null : metadata.scheduleId());
     String backfillId = text(input.get("backfillId"));
+    String operationType = text(input.get("operationType"));
+    String sourceExecutionId = first(text(input.get("sourceExecutionId")), instance.sourceExecutionId());
     String scheduleTimezone = text(input.get("scheduleTimezone"));
     String scheduleTime = text(input.get("scheduleTime"));
     String cronExpression = text(input.get("cronExpression"));
@@ -72,6 +75,8 @@ public class WorkflowInstanceOperationsService {
         triggerId,
         scheduleId,
         backfillId,
+        operationType,
+        sourceExecutionId,
         businessDate,
         scheduleTime,
         scheduleTimezone,

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowLaunchService.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowLaunchService.java
@@ -65,9 +65,7 @@ public class WorkflowLaunchService {
     return runScheduledPublished(workflowId, triggerContext, Map.of());
   }
 
-  /**
-   * 正常调度始终 FOLLOW_ACTIVE；运行参数只覆盖本次 engine.start，不修改发布版本。
-   */
+  /** 正常调度始终 FOLLOW_ACTIVE；运行参数只覆盖本次 engine.start，不修改发布版本。 */
   public WorkflowDefinitionVO runScheduledPublished(
       String workflowId,
       WorkflowTriggerContext triggerContext,
@@ -86,7 +84,7 @@ public class WorkflowLaunchService {
 
   /**
    * Backfill 执行创建批次时固定的不可变发布版本，而不是跟随之后变更的 activeVersion。
-   * 工作流下线仍阻止新的补数实例启动，但重新发布 V6 不会把 V5 补数批次切换到 V6。
+   * 工作流下线仍阻止新的普通补数实例启动。
    */
   public WorkflowInstanceVO runBackfillPublished(
       String workflowId,
@@ -99,16 +97,39 @@ public class WorkflowLaunchService {
     if (!"ONLINE".equals(current.status())) {
       throw new IllegalStateException("工作流已下线，不能启动新的 Backfill 实例");
     }
+    return runPinnedVersion("BACKFILL_PUBLISHED", id, versionId, triggerContext, runtimeInput);
+  }
+
+  /**
+   * Stage 6 运维补跑：显式人工操作允许执行来源实例固定的不可变版本。
+   * 与正常 Cron/Backfill 不同，这里不跟随当前 activeVersion，也不以当前 ONLINE 状态作为历史恢复门槛。
+   */
+  public WorkflowInstanceVO runOperationalPublished(
+      String workflowId,
+      String workflowVersionId,
+      WorkflowTriggerContext triggerContext,
+      Map<String, Object> runtimeInput) {
+    String id = required(workflowId, "工作流 ID 不能为空");
+    String versionId = required(workflowVersionId, "运维补跑 workflowVersionId 不能为空");
+    return runPinnedVersion("OPERATIONAL_RERUN", id, versionId, triggerContext, runtimeInput);
+  }
+
+  private WorkflowInstanceVO runPinnedVersion(
+      String mode,
+      String workflowId,
+      String workflowVersionId,
+      WorkflowTriggerContext triggerContext,
+      Map<String, Object> runtimeInput) {
     if (publishedVersionRunner == null) {
       throw new IllegalStateException("WorkflowPublishedVersionRunner 不可用");
     }
     try (var binding = WorkflowScheduleLaunchBindingScope.open(triggerContext.triggerId());
          var input = WorkflowRunInputScope.open(runtimeInput)) {
       return launch(
-          "BACKFILL_PUBLISHED",
-          id + "@" + versionId,
+          mode,
+          workflowId + "@" + workflowVersionId,
           triggerContext,
-          () -> publishedVersionRunner.run(id, versionId),
+          () -> publishedVersionRunner.run(workflowId, workflowVersionId),
           WorkflowInstanceVO::id);
     }
   }

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowScheduleParameterResolver.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowScheduleParameterResolver.java
@@ -15,7 +15,7 @@ import org.springframework.stereotype.Component;
 /**
  * 将调度/补数上下文转换为 Workflow input。
  *
- * <p>合并优先级：WorkflowVersion input &lt; Schedule input &lt; Backfill input &lt; 系统保留参数。</p>
+ * <p>合并优先级：WorkflowVersion input &lt; Schedule input &lt; Backfill/运维补跑 input &lt; 系统保留参数。</p>
  */
 @Component
 public class WorkflowScheduleParameterResolver {
@@ -38,6 +38,8 @@ public class WorkflowScheduleParameterResolver {
         schedule.getTimezone(),
         schedule.getCronExpression(),
         null,
+        null,
+        null,
         null);
     return Map.copyOf(result);
   }
@@ -54,7 +56,9 @@ public class WorkflowScheduleParameterResolver {
         backfill.getTimezone(),
         backfill.getCronExpression(),
         backfill.getWorkflowVersionId(),
-        backfill.getWorkflowVersionNo());
+        backfill.getWorkflowVersionNo(),
+        backfill.getOperationType(),
+        backfill.getSourceExecutionId());
     return Map.copyOf(result);
   }
 
@@ -64,7 +68,9 @@ public class WorkflowScheduleParameterResolver {
       String timezone,
       String cronExpression,
       String workflowVersionId,
-      Integer workflowVersionNo) {
+      Integer workflowVersionNo,
+      String operationType,
+      String sourceExecutionId) {
     if (context == null || context.plannedFireTime() == null) {
       throw new IllegalArgumentException("调度参数缺少逻辑计划时间");
     }
@@ -84,6 +90,10 @@ public class WorkflowScheduleParameterResolver {
     if (cronExpression != null) system.put("cronExpression", cronExpression);
     if (workflowVersionId != null) system.put("workflowVersionId", workflowVersionId);
     if (workflowVersionNo != null) system.put("workflowVersionNo", workflowVersionNo);
+    if (operationType != null && !operationType.isBlank()) system.put("operationType", operationType);
+    if (sourceExecutionId != null && !sourceExecutionId.isBlank()) {
+      system.put("sourceExecutionId", sourceExecutionId);
+    }
 
     // 顶层别名方便 SQL/同步任务直接使用；系统参数始终覆盖用户同名参数。
     system.forEach(target::put);

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowScheduleTriggerCoordinator.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowScheduleTriggerCoordinator.java
@@ -24,11 +24,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
-/** Trigger Ledger、幂等、Backfill 与 WorkflowExecution 并发策略统一协调器。 */
+/** Trigger Ledger、幂等、Backfill、运维补跑与 WorkflowExecution 并发策略统一协调器。 */
 @Component
 @ConditionalOnProperty(prefix = "yak.database", name = "enabled", havingValue = "true", matchIfMissing = true)
 public class WorkflowScheduleTriggerCoordinator {
   private static final Logger log = LoggerFactory.getLogger(WorkflowScheduleTriggerCoordinator.class);
+  private static final String BUSINESS_DATE_RERUN = "BUSINESS_DATE_RERUN";
 
   private final WorkflowScheduleTriggerDao ledger;
   private final WorkflowScheduleQuery schedules;
@@ -78,7 +79,11 @@ public class WorkflowScheduleTriggerCoordinator {
       WorkflowBackfillPO backfill,
       Occurrence occurrence) {
     AdmissionResult result = admission.admitNew(newBackfillTrigger(backfill, occurrence));
-    return handleAdmission(result, "Backfill Trigger 已获得执行准入");
+    return handleAdmission(
+        result,
+        isOperationalRerun(backfill)
+            ? "businessDate 运维补跑 Trigger 已获得执行准入"
+            : "Backfill Trigger 已获得执行准入");
   }
 
   private ScheduleExecutionResult handleAdmission(AdmissionResult result, String acceptedMessage) {
@@ -99,7 +104,7 @@ public class WorkflowScheduleTriggerCoordinator {
     return submit(schedule, triggerId, plannedFireTime, actualFireTime, "MISFIRE_RECOVERY");
   }
 
-  /** 应用重启后修复 Ledger 中间态，并恢复 SERIAL_WAIT / Backfill 队列。 */
+  /** 应用重启后修复 Ledger 中间态，并恢复 SERIAL_WAIT / Backfill / 运维补跑队列。 */
   public void recoverPending() {
     List<WorkflowScheduleTriggerPO> pending = ledger.selectPending();
     Set<String> waitingWorkflows = new LinkedHashSet<>();
@@ -132,7 +137,7 @@ public class WorkflowScheduleTriggerCoordinator {
       }
 
       if (!runnable(trigger)) {
-        admission.skip(trigger, "调度/Backfill 已不可继续，启动恢复时跳过未启动 Trigger");
+        admission.skip(trigger, "调度/Backfill/运维补跑已不可继续，启动恢复时跳过未启动 Trigger");
         continue;
       }
       if ("WAITING".equals(trigger.getStatus())) {
@@ -165,7 +170,7 @@ public class WorkflowScheduleTriggerCoordinator {
     while (current != null && current.launchNow() && current.trigger() != null) {
       WorkflowScheduleTriggerPO trigger = current.trigger();
       if (!runnable(trigger)) {
-        admission.skip(trigger, "获得执行准入后调度/Backfill 已不可继续，本次 Trigger 跳过");
+        admission.skip(trigger, "获得执行准入后调度/Backfill/运维补跑已不可继续，本次 Trigger 跳过");
         current = admission.reserveNext(trigger.getWorkflowId());
         continue;
       }
@@ -225,18 +230,26 @@ public class WorkflowScheduleTriggerCoordinator {
   private WorkflowInstanceVO launchBackfill(WorkflowScheduleTriggerPO trigger) {
     if (backfills == null) throw new IllegalStateException("Backfill 查询服务不可用");
     WorkflowBackfillPO backfill = backfills.require(trigger.getBackfillId());
-    WorkflowTriggerContext context = WorkflowTriggerContext.backfill(
-        trigger.getTriggerId(),
-        backfill.getScheduleId(),
-        backfill.getId(),
-        trigger.getPlannedFireTime(),
-        backfill.getTimezone());
+    boolean operational = isOperationalRerun(backfill);
+    WorkflowTriggerContext context = operational
+        ? WorkflowTriggerContext.rerun(
+            trigger.getTriggerId(),
+            backfill.getScheduleId(),
+            backfill.getId(),
+            trigger.getPlannedFireTime(),
+            backfill.getTimezone())
+        : WorkflowTriggerContext.backfill(
+            trigger.getTriggerId(),
+            backfill.getScheduleId(),
+            backfill.getId(),
+            trigger.getPlannedFireTime(),
+            backfill.getTimezone());
     Map<String, Object> input = parameters == null ? Map.of() : parameters.forBackfill(backfill, context);
-    return launchService.runBackfillPublished(
-        backfill.getWorkflowId(),
-        backfill.getWorkflowVersionId(),
-        context,
-        input);
+    return operational
+        ? launchService.runOperationalPublished(
+            backfill.getWorkflowId(), backfill.getWorkflowVersionId(), context, input)
+        : launchService.runBackfillPublished(
+            backfill.getWorkflowId(), backfill.getWorkflowVersionId(), context, input);
   }
 
   private WorkflowScheduleTriggerPO newScheduleTrigger(
@@ -273,15 +286,17 @@ public class WorkflowScheduleTriggerCoordinator {
     if (backfill == null || occurrence == null) throw new IllegalArgumentException("Backfill Trigger 参数不能为空");
     Instant planned = occurrence.scheduleInstant();
     Instant now = Instant.now();
+    boolean operational = isOperationalRerun(backfill);
     WorkflowScheduleTriggerPO value = new WorkflowScheduleTriggerPO();
     value.setId("workflow-trigger-ledger-" + UUID.randomUUID());
     value.setScheduleId(backfill.getScheduleId());
     value.setWorkflowId(backfill.getWorkflowId());
     value.setBackfillId(backfill.getId());
-    value.setTriggerId("workflow-backfill-" + backfill.getId() + "-" + planned.toEpochMilli());
+    value.setTriggerId((operational ? "workflow-rerun-" : "workflow-backfill-")
+        + backfill.getId() + "-" + planned.toEpochMilli());
     value.setDedupeKey(WorkflowScheduleTriggerIdentity.backfill(
         backfill.getScheduleId(), backfill.getId(), planned));
-    value.setTriggerSource("BACKFILL");
+    value.setTriggerSource(operational ? BUSINESS_DATE_RERUN : "BACKFILL");
     value.setPlannedFireTime(planned);
     value.setActualFireTime(now);
     value.setBusinessDate(occurrence.businessDate());
@@ -310,6 +325,10 @@ public class WorkflowScheduleTriggerCoordinator {
 
   private boolean isBackfill(WorkflowScheduleTriggerPO trigger) {
     return trigger.getBackfillId() != null && !trigger.getBackfillId().isBlank();
+  }
+
+  private boolean isOperationalRerun(WorkflowBackfillPO backfill) {
+    return backfill != null && BUSINESS_DATE_RERUN.equals(backfill.getOperationType());
   }
 
   private WorkflowSchedulePO safeSchedule(String scheduleId) {

--- a/yak-ops-business/yak-ops-business-workflow/src/main/resources/db/migration/yak-workflow/V5__workflow_instance_operations.sql
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/resources/db/migration/yak-workflow/V5__workflow_instance_operations.sql
@@ -1,0 +1,5 @@
+ALTER TABLE yak_workflow_backfill
+    ADD COLUMN operation_type VARCHAR(32) NOT NULL DEFAULT 'BACKFILL' AFTER status,
+    ADD COLUMN source_execution_id VARCHAR(80) NULL AFTER operation_type,
+    ADD KEY idx_yak_workflow_backfill_operation (operation_type, create_time),
+    ADD KEY idx_yak_workflow_backfill_source_execution (source_execution_id);

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowBusinessDateRerunCoordinatorTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowBusinessDateRerunCoordinatorTest.java
@@ -1,0 +1,91 @@
+package io.yak.ops.business.workflow.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.workflow.dao.WorkflowScheduleTriggerDao;
+import io.yak.ops.business.workflow.domain.WorkflowTriggerContext;
+import io.yak.ops.business.workflow.service.WorkflowBackfillPlanner.Occurrence;
+import io.yak.ops.business.workflow.service.WorkflowScheduleTriggerAdmission.AdmissionResult;
+import io.yak.ops.common.bean.po.workflow.WorkflowBackfillPO;
+import io.yak.ops.common.bean.po.workflow.WorkflowScheduleTriggerPO;
+import io.yak.ops.common.bean.vo.workflow.WorkflowInstanceVO;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class WorkflowBusinessDateRerunCoordinatorTest {
+  @Mock private WorkflowScheduleTriggerDao ledger;
+  @Mock private WorkflowScheduleQuery schedules;
+  @Mock private WorkflowLaunchService launchService;
+  @Mock private WorkflowScheduleTriggerAdmission admission;
+  @Mock private WorkflowBackfillQuery backfills;
+  @Mock private WorkflowScheduleParameterResolver parameters;
+  @Mock private WorkflowInstanceVO launched;
+
+  private WorkflowScheduleTriggerCoordinator coordinator;
+
+  @BeforeEach
+  void setUp() {
+    coordinator = new WorkflowScheduleTriggerCoordinator(
+        ledger, schedules, launchService, admission, backfills, parameters);
+  }
+
+  @Test
+  void shouldUseOperationalPinnedLaunchAndRerunTriggerSource() {
+    WorkflowBackfillPO batch = new WorkflowBackfillPO();
+    batch.setId("batch-rerun-1");
+    batch.setWorkflowId("workflow-1");
+    batch.setWorkflowVersionId("workflow-version-5");
+    batch.setWorkflowVersionNo(5);
+    batch.setScheduleId("schedule-1");
+    batch.setTimezone("Asia/Shanghai");
+    batch.setCronExpression("0 0 2 * * ?");
+    batch.setExecutionStrategy("SERIAL_WAIT");
+    batch.setOperationType("BUSINESS_DATE_RERUN");
+    batch.setSourceExecutionId("execution-source");
+
+    Occurrence occurrence = new Occurrence(
+        LocalDate.of(2026, 8, 10),
+        Instant.parse("2026-08-09T18:00:00Z"),
+        "2026-08-10T02:00:00+08:00");
+
+    when(admission.admitNew(any(WorkflowScheduleTriggerPO.class)))
+        .thenAnswer(invocation -> new AdmissionResult(invocation.getArgument(0), true, false));
+    when(backfills.require("batch-rerun-1")).thenReturn(batch);
+    when(parameters.forBackfill(eq(batch), any(WorkflowTriggerContext.class)))
+        .thenReturn(Map.of("businessDate", "2026-08-10"));
+    when(launchService.runOperationalPublished(
+        eq("workflow-1"),
+        eq("workflow-version-5"),
+        any(WorkflowTriggerContext.class),
+        any()))
+        .thenReturn(launched);
+    when(launched.id()).thenReturn("execution-rerun");
+    when(admission.bindLaunch(any(WorkflowScheduleTriggerPO.class), eq("execution-rerun")))
+        .thenAnswer(invocation -> new AdmissionResult(invocation.getArgument(0), false, false));
+
+    var result = coordinator.submitBackfill(batch, occurrence);
+
+    ArgumentCaptor<WorkflowScheduleTriggerPO> trigger =
+        ArgumentCaptor.forClass(WorkflowScheduleTriggerPO.class);
+    verify(admission).admitNew(trigger.capture());
+    assertThat(trigger.getValue().getTriggerSource()).isEqualTo("BUSINESS_DATE_RERUN");
+    assertThat(trigger.getValue().getBusinessDate()).isEqualTo(LocalDate.of(2026, 8, 10));
+    assertThat(result.businessExecutionId()).isEqualTo("execution-rerun");
+    verify(launchService).runOperationalPublished(
+        eq("workflow-1"), eq("workflow-version-5"), any(WorkflowTriggerContext.class), any());
+    verify(launchService, never()).runBackfillPublished(any(), any(), any(), any());
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowBusinessDateRerunTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowBusinessDateRerunTest.java
@@ -1,0 +1,118 @@
+package io.yak.ops.business.workflow.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.workflow.dao.WorkflowBackfillDao;
+import io.yak.ops.business.workflow.dao.WorkflowScheduleTriggerDao;
+import io.yak.ops.business.workflow.persistence.support.WorkflowJsonCodec;
+import io.yak.ops.common.bean.dto.workflow.WorkflowBusinessDateRerunDTO;
+import io.yak.ops.common.bean.po.workflow.WorkflowBackfillPO;
+import io.yak.ops.common.bean.po.workflow.WorkflowSchedulePO;
+import io.yak.ops.common.bean.vo.workflow.WorkflowInstanceVO;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class WorkflowBusinessDateRerunTest {
+  @Mock private WorkflowScheduleQuery schedules;
+  @Mock private WorkflowDefinitionService definitions;
+  @Mock private WorkflowBackfillDao dao;
+  @Mock private WorkflowBackfillQuery query;
+  @Mock private WorkflowScheduleTriggerDao triggers;
+  @Mock private WorkflowScheduleTriggerAdmission admission;
+  @Mock private WorkflowScheduleTriggerCoordinator coordinator;
+
+  private WorkflowJsonCodec json;
+  private WorkflowBackfillService service;
+
+  @BeforeEach
+  void setUp() {
+    json = new WorkflowJsonCodec(new ObjectMapper());
+    service = new WorkflowBackfillService(
+        schedules,
+        definitions,
+        new WorkflowBackfillPlanner(),
+        dao,
+        query,
+        triggers,
+        admission,
+        coordinator,
+        json);
+  }
+
+  @Test
+  void shouldPinSourceVersionAndReplaceOldSchedulingParameters() {
+    WorkflowSchedulePO schedule = new WorkflowSchedulePO();
+    schedule.setId("schedule-1");
+    schedule.setName("每日订单同步");
+    when(schedules.require("schedule-1")).thenReturn(schedule);
+    when(triggers.selectWorkflowIdByExecution("execution-source")).thenReturn("workflow-1");
+    when(dao.insert(any(WorkflowBackfillPO.class))).thenReturn(1);
+
+    WorkflowInstanceVO source = new WorkflowInstanceVO(
+        "execution-source",
+        "workflow-version-5",
+        null,
+        "订单同步",
+        "FAILED",
+        "CONTINUE_INDEPENDENT_BRANCHES",
+        Instant.parse("2026-08-09T18:00:00Z"),
+        Instant.parse("2026-08-09T18:00:01Z"),
+        Instant.parse("2026-08-09T18:10:00Z"),
+        0L,
+        Map.ofEntries(
+            Map.entry("tenant", "hospital-a"),
+            Map.entry("businessDate", "2026-08-09"),
+            Map.entry("scheduleTime", "2026-08-09T02:00:00+08:00"),
+            Map.entry("scheduleTimezone", "Asia/Shanghai"),
+            Map.entry("plannedFireTime", "2026-08-08T18:00:00Z"),
+            Map.entry("triggerType", "SCHEDULE"),
+            Map.entry("triggerId", "old-trigger"),
+            Map.entry("scheduleId", "schedule-1"),
+            Map.entry("cronExpression", "0 0 2 * * ?"),
+            Map.entry("__schedule", Map.of("businessDate", "2026-08-09"))),
+        1,
+        0,
+        List.of(),
+        "workflow-version-5",
+        5,
+        false);
+
+    service.createBusinessDateRerun(
+        "execution-source",
+        source,
+        new WorkflowBusinessDateRerunDTO(
+            LocalDate.of(2026, 8, 10),
+            "SERIAL_WAIT",
+            Map.of("force", true)));
+
+    ArgumentCaptor<WorkflowBackfillPO> captor = ArgumentCaptor.forClass(WorkflowBackfillPO.class);
+    verify(dao).insert(captor.capture());
+    WorkflowBackfillPO batch = captor.getValue();
+    assertThat(batch.getOperationType()).isEqualTo("BUSINESS_DATE_RERUN");
+    assertThat(batch.getSourceExecutionId()).isEqualTo("execution-source");
+    assertThat(batch.getWorkflowId()).isEqualTo("workflow-1");
+    assertThat(batch.getWorkflowVersionId()).isEqualTo("workflow-version-5");
+    assertThat(batch.getWorkflowVersionNo()).isEqualTo(5);
+    assertThat(batch.getStartBusinessDate()).isEqualTo(LocalDate.of(2026, 8, 10));
+    assertThat(batch.getEndBusinessDate()).isEqualTo(LocalDate.of(2026, 8, 10));
+    assertThat(batch.getTotalCount()).isEqualTo(1);
+    assertThat(json.readMap(batch.getScheduleInputJson()))
+        .containsEntry("tenant", "hospital-a")
+        .doesNotContainKeys("businessDate", "scheduleTime", "triggerId", "__schedule");
+    assertThat(json.readMap(batch.getInputJson())).containsEntry("force", true);
+    verify(coordinator).submitBackfill(any(WorkflowBackfillPO.class), any());
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowInstanceOperationsServiceTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowInstanceOperationsServiceTest.java
@@ -1,0 +1,121 @@
+package io.yak.ops.business.workflow.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import io.yak.framework.workflow.engine.definition.EdgeDefinition;
+import io.yak.framework.workflow.engine.definition.WorkflowDefinition;
+import io.yak.framework.workflow.engine.definition.WorkflowFailureStrategy;
+import io.yak.framework.workflow.engine.spi.WorkflowDefinitionRepository;
+import io.yak.ops.business.workflow.dao.WorkflowScheduleTriggerDao;
+import io.yak.ops.business.workflow.persistence.WorkflowRuntimePersistence;
+import io.yak.ops.common.bean.dto.workflow.WorkflowBatchRetryDTO;
+import io.yak.ops.common.bean.vo.workflow.WorkflowInstanceVO;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.ObjectProvider;
+
+@ExtendWith(MockitoExtension.class)
+class WorkflowInstanceOperationsServiceTest {
+  @Mock private WorkflowRuntimeService runtime;
+  @Mock private ObjectProvider<WorkflowRuntimePersistence> runtimePersistence;
+  @Mock private ObjectProvider<WorkflowDefinitionRepository> definitionProvider;
+  @Mock private ObjectProvider<WorkflowScheduleTriggerDao> triggerProvider;
+  @Mock private ObjectProvider<WorkflowBackfillService> backfillProvider;
+  @Mock private WorkflowDefinitionRepository definitionRepository;
+  @Mock private WorkflowScheduleTriggerDao triggerDao;
+  @Mock private WorkflowBackfillService backfillService;
+
+  private WorkflowInstanceOperationsService service;
+
+  @BeforeEach
+  void setUp() {
+    service = new WorkflowInstanceOperationsService(
+        runtime,
+        runtimePersistence,
+        definitionProvider,
+        triggerProvider,
+        backfillProvider);
+  }
+
+  @Test
+  void shouldDescribeImmutableRuntimeDagAndSchedulingLineage() {
+    WorkflowInstanceVO instance = instance("execution-1", "FAILED");
+    when(runtime.getInstance("execution-1")).thenReturn(instance);
+    when(runtimePersistence.getIfAvailable()).thenReturn(null);
+    when(triggerProvider.getIfAvailable()).thenReturn(triggerDao);
+    when(triggerDao.selectWorkflowIdByExecution("execution-1")).thenReturn("workflow-1");
+    when(definitionProvider.getIfAvailable()).thenReturn(definitionRepository);
+    when(backfillProvider.getIfAvailable()).thenReturn(backfillService);
+    WorkflowDefinition definition = new WorkflowDefinition(
+        "workflow-version-5",
+        "订单同步",
+        WorkflowFailureStrategy.CONTINUE_INDEPENDENT_BRANCHES,
+        List.of(),
+        List.of(new EdgeDefinition("extract", "load")));
+    when(definitionRepository.findById("workflow-version-5")).thenReturn(Optional.of(definition));
+
+    var result = service.describe("execution-1");
+
+    assertThat(result.workflowId()).isEqualTo("workflow-1");
+    assertThat(result.triggerType()).isEqualTo("SCHEDULE");
+    assertThat(result.scheduleId()).isEqualTo("schedule-1");
+    assertThat(result.businessDate()).hasToString("2026-08-10");
+    assertThat(result.businessDateRerunSupported()).isTrue();
+    assertThat(result.edges()).containsExactly(
+        new io.yak.ops.common.bean.vo.workflow.WorkflowInstanceOperationsVO.EdgeVO("extract", "load"));
+  }
+
+  @Test
+  void shouldIsolateFailuresWhenBatchRetryingInstances() {
+    WorkflowInstanceVO accepted = instance("execution-a", "RUNNING");
+    when(runtime.retryFailedNodes("execution-a")).thenReturn(accepted);
+    when(runtime.retryFailedNodes("execution-b")).thenThrow(new IllegalStateException("no retryable nodes"));
+
+    var result = service.batchRetryFailed(new WorkflowBatchRetryDTO(
+        List.of("execution-a", "execution-b", "execution-a")));
+
+    assertThat(result.requestedCount()).isEqualTo(2);
+    assertThat(result.acceptedCount()).isEqualTo(1);
+    assertThat(result.failedCount()).isEqualTo(1);
+    assertThat(result.items()).hasSize(2);
+    assertThat(result.items().get(0).accepted()).isTrue();
+    assertThat(result.items().get(1).message()).contains("no retryable nodes");
+  }
+
+  private WorkflowInstanceVO instance(String id, String status) {
+    return new WorkflowInstanceVO(
+        id,
+        "workflow-version-5",
+        null,
+        "订单同步",
+        status,
+        "CONTINUE_INDEPENDENT_BRANCHES",
+        Instant.parse("2026-08-10T01:00:00Z"),
+        Instant.parse("2026-08-10T01:00:01Z"),
+        status.equals("RUNNING") ? null : Instant.parse("2026-08-10T01:10:00Z"),
+        0L,
+        Map.of(
+            "businessDate", "2026-08-10",
+            "scheduleTime", "2026-08-10T02:00:00+08:00",
+            "scheduleTimezone", "Asia/Shanghai",
+            "plannedFireTime", "2026-08-09T18:00:00Z",
+            "triggerType", "SCHEDULE",
+            "triggerId", "trigger-1",
+            "scheduleId", "schedule-1",
+            "cronExpression", "0 0 2 * * ?"),
+        2,
+        1,
+        List.of(),
+        "workflow-version-5",
+        5,
+        false);
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowOperationalLaunchTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowOperationalLaunchTest.java
@@ -1,0 +1,50 @@
+package io.yak.ops.business.workflow.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.workflow.domain.WorkflowTriggerContext;
+import io.yak.ops.business.workflow.persistence.WorkflowExecutionTriggerRecorder;
+import io.yak.ops.common.bean.vo.workflow.WorkflowInstanceVO;
+import java.time.Instant;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class WorkflowOperationalLaunchTest {
+  @Mock private WorkflowDefinitionService definitions;
+  @Mock private WorkflowRuntimeService runtime;
+  @Mock private WorkflowExecutionTriggerRecorder recorder;
+  @Mock private WorkflowPublishedVersionRunner publishedVersionRunner;
+  @Mock private WorkflowInstanceVO launched;
+
+  @Test
+  void shouldRunPinnedHistoricalVersionWithoutFollowingCurrentDefinitionState() {
+    WorkflowLaunchService service = new WorkflowLaunchService(
+        definitions, runtime, recorder, publishedVersionRunner);
+    WorkflowTriggerContext context = WorkflowTriggerContext.rerun(
+        "rerun-trigger-1",
+        "schedule-1",
+        "rerun-batch-1",
+        Instant.parse("2026-08-09T18:00:00Z"),
+        "Asia/Shanghai");
+    when(publishedVersionRunner.run("workflow-1", "workflow-version-5")).thenReturn(launched);
+    when(launched.id()).thenReturn("execution-rerun");
+
+    WorkflowInstanceVO result = service.runOperationalPublished(
+        "workflow-1",
+        "workflow-version-5",
+        context,
+        Map.of("businessDate", "2026-08-10"));
+
+    assertThat(result).isSameAs(launched);
+    verifyNoInteractions(definitions);
+    verify(publishedVersionRunner).run("workflow-1", "workflow-version-5");
+    verify(recorder).record("execution-rerun", context);
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowScheduleParameterResolverTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowScheduleParameterResolverTest.java
@@ -73,4 +73,35 @@ class WorkflowScheduleParameterResolverTest {
     assertThat(input.get("workflowVersionId")).isEqualTo("workflow-version-5");
     assertThat(input.get("workflowVersionNo")).isEqualTo(5);
   }
+
+  @Test
+  void shouldExposeBusinessDateRerunOperationLineageAsReservedParameters() {
+    WorkflowBackfillPO rerun = new WorkflowBackfillPO();
+    rerun.setId("rerun-batch-1");
+    rerun.setScheduleId("schedule-1");
+    rerun.setTimezone("Asia/Shanghai");
+    rerun.setCronExpression("0 0 2 * * ?");
+    rerun.setWorkflowVersionId("workflow-version-5");
+    rerun.setWorkflowVersionNo(5);
+    rerun.setOperationType("BUSINESS_DATE_RERUN");
+    rerun.setSourceExecutionId("execution-source");
+    rerun.setScheduleInputJson("{\"sourceExecutionId\":\"wrong\"}");
+    rerun.setInputJson("{\"operationType\":\"wrong\"}");
+    WorkflowTriggerContext context = WorkflowTriggerContext.rerun(
+        "rerun-trigger-1",
+        "schedule-1",
+        "rerun-batch-1",
+        Instant.parse("2026-08-09T18:00:00Z"),
+        "Asia/Shanghai");
+
+    Map<String, Object> input = resolver.forBackfill(rerun, context);
+
+    assertThat(input.get("triggerType")).isEqualTo("RERUN");
+    assertThat(input.get("operationType")).isEqualTo("BUSINESS_DATE_RERUN");
+    assertThat(input.get("sourceExecutionId")).isEqualTo("execution-source");
+    @SuppressWarnings("unchecked")
+    Map<String, Object> system = (Map<String, Object>) input.get(WorkflowScheduleParameterResolver.NAMESPACE);
+    assertThat(system).containsEntry("operationType", "BUSINESS_DATE_RERUN");
+    assertThat(system).containsEntry("sourceExecutionId", "execution-source");
+  }
 }

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/dto/workflow/WorkflowBatchRetryDTO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/dto/workflow/WorkflowBatchRetryDTO.java
@@ -1,0 +1,14 @@
+package io.yak.ops.common.bean.dto.workflow;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+
+/** 批量恢复失败工作流实例。 */
+public record WorkflowBatchRetryDTO(
+    @NotEmpty @Size(max = 100) List<String> executionIds) {
+
+  public WorkflowBatchRetryDTO {
+    executionIds = executionIds == null ? List.of() : List.copyOf(executionIds);
+  }
+}

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/dto/workflow/WorkflowBusinessDateRerunDTO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/dto/workflow/WorkflowBusinessDateRerunDTO.java
@@ -1,0 +1,16 @@
+package io.yak.ops.common.bean.dto.workflow;
+
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+import java.util.Map;
+
+/** 从历史实例的调度血缘按指定 businessDate 创建运维补跑。 */
+public record WorkflowBusinessDateRerunDTO(
+    @NotNull LocalDate businessDate,
+    String executionStrategy,
+    Map<String, Object> input) {
+
+  public WorkflowBusinessDateRerunDTO {
+    input = input == null ? Map.of() : Map.copyOf(input);
+  }
+}

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/workflow/WorkflowBackfillPO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/workflow/WorkflowBackfillPO.java
@@ -20,6 +20,8 @@ public class WorkflowBackfillPO {
   private String scheduleName;
   private String name;
   private String status;
+  private String operationType;
+  private String sourceExecutionId;
   private LocalDate startBusinessDate;
   private LocalDate endBusinessDate;
   private String cronExpression;

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/vo/workflow/WorkflowBackfillVO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/vo/workflow/WorkflowBackfillVO.java
@@ -14,6 +14,8 @@ public record WorkflowBackfillVO(
     String scheduleName,
     String name,
     String status,
+    String operationType,
+    String sourceExecutionId,
     LocalDate startBusinessDate,
     LocalDate endBusinessDate,
     String cronExpression,

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/vo/workflow/WorkflowBatchRetryVO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/vo/workflow/WorkflowBatchRetryVO.java
@@ -1,0 +1,22 @@
+package io.yak.ops.common.bean.vo.workflow;
+
+import java.util.List;
+
+/** 批量失败实例重试结果；单条失败不会回滚整批。 */
+public record WorkflowBatchRetryVO(
+    int requestedCount,
+    int acceptedCount,
+    int failedCount,
+    List<ItemVO> items) {
+
+  public WorkflowBatchRetryVO {
+    items = items == null ? List.of() : List.copyOf(items);
+  }
+
+  public record ItemVO(
+      String executionId,
+      boolean accepted,
+      String status,
+      String message) {
+  }
+}

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/vo/workflow/WorkflowInstanceOperationsVO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/vo/workflow/WorkflowInstanceOperationsVO.java
@@ -1,0 +1,30 @@
+package io.yak.ops.common.bean.vo.workflow;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+
+/** 工作流实例运维上下文与不可变运行 DAG 拓扑。 */
+public record WorkflowInstanceOperationsVO(
+    String executionId,
+    String workflowId,
+    String triggerType,
+    String triggerId,
+    String scheduleId,
+    String backfillId,
+    LocalDate businessDate,
+    String scheduleTime,
+    String scheduleTimezone,
+    Instant plannedFireTime,
+    String cronExpression,
+    boolean businessDateRerunSupported,
+    String businessDateRerunUnavailableReason,
+    List<EdgeVO> edges) {
+
+  public WorkflowInstanceOperationsVO {
+    edges = edges == null ? List.of() : List.copyOf(edges);
+  }
+
+  public record EdgeVO(String source, String target) {
+  }
+}

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/vo/workflow/WorkflowInstanceOperationsVO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/vo/workflow/WorkflowInstanceOperationsVO.java
@@ -12,6 +12,8 @@ public record WorkflowInstanceOperationsVO(
     String triggerId,
     String scheduleId,
     String backfillId,
+    String operationType,
+    String sourceExecutionId,
     LocalDate businessDate,
     String scheduleTime,
     String scheduleTimezone,

--- a/yak-ops-ui/src/pages/workflow/instances/InstanceDetailDrawer.tsx
+++ b/yak-ops-ui/src/pages/workflow/instances/InstanceDetailDrawer.tsx
@@ -1,0 +1,491 @@
+import {
+  activateWorkflowInstance,
+  cancelWorkflowInstance,
+  getWorkflowInstance,
+  getWorkflowInstanceOperations,
+  isWorkflowTerminal,
+  pauseWorkflowInstance,
+  rerunWorkflowBusinessDate,
+  rerunWorkflowFromNode,
+  restartWorkflowInstance,
+  resumeWorkflowInstance,
+  retryWorkflowFailedNode,
+  retryWorkflowFailedNodes,
+  subscribeWorkflowEvents,
+  type WorkflowAttempt,
+  type WorkflowInstance,
+  type WorkflowInstanceOperations,
+  type WorkflowNodeInstance,
+} from '@/services/workflow';
+import {
+  Button,
+  DatePicker,
+  Drawer,
+  Input,
+  Modal,
+  Popconfirm,
+  Select,
+  Table,
+  Tooltip,
+  message,
+} from 'antd';
+import type { ColumnsType } from 'antd/es/table';
+import dayjs from 'dayjs';
+import {
+  CalendarDays,
+  Pause,
+  Play,
+  RefreshCw,
+  RotateCcw,
+  Square,
+} from 'lucide-react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import WorkflowDagView from './WorkflowDagView';
+
+interface Props {
+  open: boolean;
+  executionId?: string;
+  initial?: WorkflowInstance;
+  onClose: () => void;
+  onChanged?: (instance?: WorkflowInstance) => void;
+}
+
+const statusLabel: Record<string, string> = {
+  CREATED: '已创建',
+  RUNNING: '运行中',
+  PAUSING: '暂停中',
+  PAUSED: '已暂停',
+  RESUMING: '恢复中',
+  SUCCESS: '成功',
+  SUCCESS_WITH_WARNINGS: '完成（有告警）',
+  FAILED: '失败',
+  WARNING: '告警',
+  CANCELED: '已取消',
+  TIMED_OUT: '已超时',
+  WAITING: '等待中',
+  READY: '就绪',
+  SUBMITTED: '已提交',
+  UPSTREAM_FAILED: '已阻断',
+  SKIPPED: '已跳过',
+};
+
+const failureReasonLabel: Record<string, string> = {
+  EXECUTOR_FAILURE: '执行器失败',
+  DISPATCH_TIMEOUT: '派发超时',
+  EXECUTION_TIMEOUT: '执行超时',
+};
+
+const statusClassName = (status: string) => {
+  if (status === 'FAILED' || status === 'TIMED_OUT') return 'text-[#d92d20]';
+  if (status === 'RUNNING' || status === 'RESUMING' || status === 'SUBMITTED' || status === 'READY') {
+    return 'font-medium text-[#344054]';
+  }
+  return 'text-[#667085]';
+};
+
+const formatTime = (value?: string) =>
+  value ? dayjs(value).format('YYYY-MM-DD HH:mm:ss') : '-';
+
+const JsonBlock = ({ value }: { value?: unknown }) => (
+  <pre className="m-0 max-h-[220px] overflow-auto rounded-md bg-[#f7f7f8] p-2.5 text-[11px] leading-5 text-[rgba(22,24,35,.72)]">
+    {JSON.stringify(value ?? {}, null, 2)}
+  </pre>
+);
+
+const InstanceDetailDrawer = ({
+  open,
+  executionId,
+  initial,
+  onClose,
+  onChanged,
+}: Props) => {
+  const streamRef = useRef<(() => void) | null>(null);
+  const [detail, setDetail] = useState<WorkflowInstance>();
+  const [operations, setOperations] = useState<WorkflowInstanceOperations>();
+  const [loading, setLoading] = useState(false);
+  const [actionLoading, setActionLoading] = useState<string>();
+  const [selectedNodeId, setSelectedNodeId] = useState<string>();
+  const [rerunOpen, setRerunOpen] = useState(false);
+  const [rerunDate, setRerunDate] = useState(dayjs());
+  const [rerunStrategy, setRerunStrategy] = useState<'SERIAL_WAIT' | 'PARALLEL'>('SERIAL_WAIT');
+  const [rerunInput, setRerunInput] = useState('{}');
+
+  const applySnapshot = useCallback((snapshot: WorkflowInstance) => {
+    setDetail(snapshot);
+    onChanged?.(snapshot);
+  }, [onChanged]);
+
+  const attachStream = useCallback((snapshot: WorkflowInstance) => {
+    streamRef.current?.();
+    streamRef.current = null;
+    if (!isWorkflowTerminal(snapshot.status)) {
+      streamRef.current = subscribeWorkflowEvents(snapshot.id, applySnapshot);
+    }
+  }, [applySnapshot]);
+
+  const load = useCallback(async () => {
+    if (!open || !executionId) return;
+    setLoading(true);
+    try {
+      const [instance, ops] = await Promise.all([
+        getWorkflowInstance(executionId),
+        getWorkflowInstanceOperations(executionId),
+      ]);
+      applySnapshot(instance);
+      setOperations(ops);
+      setRerunDate(dayjs(ops.businessDate || undefined));
+      attachStream(instance);
+    } catch (error) {
+      message.error(error instanceof Error ? error.message : '实例运维详情加载失败');
+    } finally {
+      setLoading(false);
+    }
+  }, [applySnapshot, attachStream, executionId, open]);
+
+  useEffect(() => {
+    if (!open) return;
+    setDetail(initial);
+    setOperations(undefined);
+    setSelectedNodeId(undefined);
+    void load();
+    return () => {
+      streamRef.current?.();
+      streamRef.current = null;
+    };
+  }, [initial, load, open]);
+
+  const runAction = useCallback(async (
+    key: string,
+    operation: () => Promise<WorkflowInstance>,
+    success: string,
+  ) => {
+    if (actionLoading) return;
+    setActionLoading(key);
+    try {
+      const snapshot = await operation();
+      applySnapshot(snapshot);
+      attachStream(snapshot);
+      message.success(success);
+    } catch (error) {
+      message.error(error instanceof Error ? error.message : '工作流运维操作失败');
+    } finally {
+      setActionLoading(undefined);
+    }
+  }, [actionLoading, applySnapshot, attachStream]);
+
+  const activatePrepared = useCallback(async (prepared: WorkflowInstance, messageText: string) => {
+    const activated = await activateWorkflowInstance(prepared.id);
+    onChanged?.(activated);
+    message.success(`${messageText}：${activated.id}`);
+  }, [onChanged]);
+
+  const handleRestart = async () => {
+    if (!detail || actionLoading) return;
+    setActionLoading('restart');
+    try {
+      await activatePrepared(await restartWorkflowInstance(detail.id), '已创建完整重跑实例');
+    } catch (error) {
+      message.error(error instanceof Error ? error.message : '整体重跑失败');
+    } finally {
+      setActionLoading(undefined);
+    }
+  };
+
+  const handleRerunFromNode = async (nodeId: string) => {
+    if (!detail || actionLoading) return;
+    setActionLoading(`rerun:${nodeId}`);
+    try {
+      await activatePrepared(
+        await rerunWorkflowFromNode(detail.id, nodeId),
+        `已从节点「${nodeId}」创建重跑实例`,
+      );
+    } catch (error) {
+      message.error(error instanceof Error ? error.message : '从指定节点重跑失败');
+    } finally {
+      setActionLoading(undefined);
+    }
+  };
+
+  const handleRetryNode = async (nodeId: string) => {
+    if (!detail) return;
+    await runAction(
+      `retryNode:${nodeId}`,
+      () => retryWorkflowFailedNode(detail.id, nodeId),
+      `失败节点「${nodeId}」已在原实例重新调度`,
+    );
+  };
+
+  const handleBusinessDateRerun = async () => {
+    if (!detail || !rerunDate || actionLoading) return;
+    let input: Record<string, unknown> = {};
+    try {
+      input = rerunInput.trim() ? JSON.parse(rerunInput) : {};
+    } catch {
+      message.error('补跑参数必须是合法 JSON');
+      return;
+    }
+    setActionLoading('businessDate');
+    try {
+      const batch = await rerunWorkflowBusinessDate(detail.id, {
+        businessDate: rerunDate.format('YYYY-MM-DD'),
+        executionStrategy: rerunStrategy,
+        input,
+      });
+      message.success(`businessDate 补跑批次已创建，共 ${batch.totalCount} 个逻辑实例`);
+      setRerunOpen(false);
+    } catch (error) {
+      message.error(error instanceof Error ? error.message : '指定 businessDate 重跑失败');
+    } finally {
+      setActionLoading(undefined);
+    }
+  };
+
+  const attemptColumns = useMemo<ColumnsType<WorkflowAttempt>>(() => [
+    { title: '#', dataIndex: 'attemptNumber', width: 48 },
+    { title: '状态', dataIndex: 'status', width: 105, render: (value: string) => statusLabel[value] || value },
+    {
+      title: '失败原因', dataIndex: 'failureReason', width: 120,
+      render: (value?: string) => value ? failureReasonLabel[value] || value : '-',
+    },
+    {
+      title: 'Attempt ID', dataIndex: 'id',
+      render: (value: string) => <span className="font-mono text-[10px] text-[#667085]">{value}</span>,
+    },
+    { title: '开始', dataIndex: 'startedAt', width: 155, render: formatTime },
+    { title: '结束', dataIndex: 'endedAt', width: 155, render: formatTime },
+  ], []);
+
+  const renderNodeDetail = (record: WorkflowNodeInstance) => (
+    <div className="space-y-4 bg-[#fafafa] p-3">
+      {record.errorMessage ? (
+        <div className="rounded-md border border-[#fecdca] bg-[#fff6f5] px-3 py-2 text-[11px] text-[#b42318]">
+          {record.errorMessage}
+        </div>
+      ) : null}
+      <div className="grid grid-cols-2 gap-x-6 gap-y-2 text-[11px] text-[#667085]">
+        <div>当前 Attempt：<span className="font-mono">{record.currentAttemptId || '-'}</span></div>
+        <div>Retry：{record.retryMaxAttempts} 次 / 延迟 {record.retryDelaySeconds}s</div>
+        <div>派发超时：{record.dispatchTimeoutSeconds > 0 ? `${record.dispatchTimeoutSeconds}s` : '-'}</div>
+        <div>执行超时：{record.executionTimeoutSeconds > 0 ? `${record.executionTimeoutSeconds}s` : '-'}</div>
+      </div>
+      <div className="grid grid-cols-2 gap-3">
+        <div><div className="mb-1.5 text-[11px] font-medium text-[#344054]">Input Mapping</div><JsonBlock value={record.inputMapping} /></div>
+        <div><div className="mb-1.5 text-[11px] font-medium text-[#344054]">Resolved Node Input</div><JsonBlock value={record.input} /></div>
+        <div><div className="mb-1.5 text-[11px] font-medium text-[#344054]">Predecessor Outputs</div><JsonBlock value={record.predecessorOutputs} /></div>
+        <div><div className="mb-1.5 text-[11px] font-medium text-[#344054]">Node Output</div><JsonBlock value={record.output} /></div>
+      </div>
+      <div>
+        <div className="mb-1.5 text-[11px] font-medium text-[#344054]">Attempt History</div>
+        <Table<WorkflowAttempt>
+          rowKey="id"
+          size="small"
+          pagination={false}
+          dataSource={record.attempts}
+          columns={attemptColumns}
+          scroll={{ x: 780 }}
+        />
+      </div>
+    </div>
+  );
+
+  const nodeColumns = useMemo<ColumnsType<WorkflowNodeInstance>>(() => [
+    {
+      title: '节点', dataIndex: 'name', minWidth: 190,
+      render: (_: unknown, record) => (
+        <div>
+          <div className="font-medium text-[#344054]">{record.name}</div>
+          <div className="mt-0.5 text-[11px] text-[#98a2b3]">{record.type} · {record.id}</div>
+        </div>
+      ),
+    },
+    {
+      title: '状态', dataIndex: 'status', width: 115,
+      render: (value: string) => <span className={statusClassName(value)}>{statusLabel[value] || value}</span>,
+    },
+    {
+      title: 'Attempt', width: 95,
+      render: (_: unknown, record) => <span className="text-[12px] text-[#667085]">{record.currentAttemptNumber || 0} / {record.retryMaxAttempts}</span>,
+    },
+    {
+      title: '失败原因', dataIndex: 'failureReason', width: 125,
+      render: (value?: string, record?: WorkflowNodeInstance) => record?.status === 'UPSTREAM_FAILED' ? '未执行' : value ? failureReasonLabel[value] || value : '-',
+    },
+    {
+      title: '运维操作', width: 220, fixed: 'right',
+      render: (_: unknown, record) => {
+        if (!detail || !isWorkflowTerminal(detail.status)) return '-';
+        return (
+          <div className="flex items-center gap-1">
+            {record.status === 'FAILED' ? (
+              <Button
+                type="link"
+                size="small"
+                className="!px-1 !text-[12px]"
+                loading={actionLoading === `retryNode:${record.id}`}
+                onClick={() => void handleRetryNode(record.id)}
+              >
+                重试失败节点
+              </Button>
+            ) : null}
+            <Button
+              type="link"
+              size="small"
+              className="!px-1 !text-[12px]"
+              loading={actionLoading === `rerun:${record.id}`}
+              onClick={() => void handleRerunFromNode(record.id)}
+            >
+              从此节点重跑
+            </Button>
+          </div>
+        );
+      },
+    },
+  ], [actionLoading, detail]);
+
+  const canRetryFailed = Boolean(
+    detail &&
+    isWorkflowTerminal(detail.status) &&
+    detail.status !== 'SUCCESS' &&
+    detail.nodes.some((node) => ['FAILED', 'UPSTREAM_FAILED', 'CANCELED', 'SKIPPED'].includes(node.status)),
+  );
+
+  return (
+    <>
+      <Drawer
+        open={open}
+        width={1120}
+        loading={loading}
+        title={detail ? `${detail.name} · 实例运维` : '实例运维'}
+        onClose={() => {
+          streamRef.current?.();
+          streamRef.current = null;
+          onClose();
+        }}
+        extra={detail ? (
+          <div className="flex items-center gap-2">
+            {detail.status === 'RUNNING' ? (
+              <Button size="small" icon={<Pause size={13} />} loading={actionLoading === 'pause'} onClick={() => void runAction('pause', () => pauseWorkflowInstance(detail.id), '已请求暂停工作流')}>暂停</Button>
+            ) : null}
+            {detail.status === 'PAUSED' ? (
+              <Button size="small" icon={<Play size={13} />} loading={actionLoading === 'resume'} onClick={() => void runAction('resume', () => resumeWorkflowInstance(detail.id), '已请求恢复工作流')}>恢复</Button>
+            ) : null}
+            {!isWorkflowTerminal(detail.status) ? (
+              <Popconfirm title="取消当前工作流？" onConfirm={() => void runAction('cancel', () => cancelWorkflowInstance(detail.id), '工作流已取消')}>
+                <Button danger size="small" icon={<Square size={12} />} loading={actionLoading === 'cancel'}>取消</Button>
+              </Popconfirm>
+            ) : null}
+            {canRetryFailed ? (
+              <Button size="small" icon={<RefreshCw size={12} />} loading={actionLoading === 'retryFailed'} onClick={() => void runAction('retryFailed', () => retryWorkflowFailedNodes(detail.id), '已在原实例重新调度失败/阻断节点')}>
+                重试失败节点
+              </Button>
+            ) : null}
+            {operations?.businessDateRerunSupported ? (
+              <Button size="small" icon={<CalendarDays size={12} />} onClick={() => setRerunOpen(true)}>
+                指定日期重跑
+              </Button>
+            ) : operations ? (
+              <Tooltip title={operations.businessDateRerunUnavailableReason}>
+                <span><Button disabled size="small" icon={<CalendarDays size={12} />}>指定日期重跑</Button></span>
+              </Tooltip>
+            ) : null}
+            {isWorkflowTerminal(detail.status) ? (
+              <Button size="small" icon={<RotateCcw size={12} />} loading={actionLoading === 'restart'} onClick={() => void handleRestart()}>
+                整体重跑
+              </Button>
+            ) : null}
+          </div>
+        ) : null}
+      >
+        {detail ? (
+          <div className="space-y-5">
+            <div className="grid grid-cols-4 gap-x-6 gap-y-3 rounded-lg border border-[#eaecf0] bg-[#fcfcfd] px-4 py-3 text-[12px]">
+              <div className="col-span-2"><span className="text-[#98a2b3]">实例 ID：</span><span className="font-mono text-[#344054]">{detail.id}</span></div>
+              <div><span className="text-[#98a2b3]">状态：</span><span className={statusClassName(detail.status)}>{statusLabel[detail.status] || detail.status}</span></div>
+              <div><span className="text-[#98a2b3]">版本：</span><span>V{detail.workflowVersionNo || '-'}</span></div>
+              <div><span className="text-[#98a2b3]">触发来源：</span><span>{operations?.triggerType || '-'}</span></div>
+              <div><span className="text-[#98a2b3]">businessDate：</span><span>{operations?.businessDate || '-'}</span></div>
+              <div><span className="text-[#98a2b3]">scheduleTime：</span><span>{operations?.scheduleTime ? formatTime(operations.scheduleTime) : '-'}</span></div>
+              <div><span className="text-[#98a2b3]">时区：</span><span>{operations?.scheduleTimezone || '-'}</span></div>
+              <div><span className="text-[#98a2b3]">创建：</span><span>{formatTime(detail.startedAt)}</span></div>
+              <div><span className="text-[#98a2b3]">结束：</span><span>{formatTime(detail.endedAt)}</span></div>
+              {detail.sourceExecutionId ? (
+                <div className="col-span-2"><span className="text-[#98a2b3]">来源实例：</span><span className="font-mono text-[#667085]">{detail.sourceExecutionId}</span></div>
+              ) : null}
+            </div>
+
+            <div>
+              <div className="mb-2 flex items-center justify-between">
+                <div className="text-[13px] font-medium text-[#344054]">运行实例 DAG</div>
+                <div className="text-[11px] text-[#98a2b3]">点击节点可定位下方节点详情</div>
+              </div>
+              <WorkflowDagView
+                instance={detail}
+                operations={operations}
+                selectedNodeId={selectedNodeId}
+                onSelectNode={setSelectedNodeId}
+              />
+            </div>
+
+            <div>
+              <div className="mb-2 text-[13px] font-medium text-[#344054]">节点运行明细</div>
+              <Table<WorkflowNodeInstance>
+                rowKey="id"
+                size="small"
+                bordered
+                pagination={false}
+                dataSource={detail.nodes}
+                columns={nodeColumns}
+                rowClassName={(record) => record.id === selectedNodeId ? '!bg-[#f8f9fb]' : ''}
+                expandable={{ expandedRowRender: renderNodeDetail, rowExpandable: () => true }}
+                scroll={{ x: 820 }}
+              />
+            </div>
+
+            <div>
+              <div className="mb-2 text-[13px] font-medium text-[#344054]">Workflow Input</div>
+              <JsonBlock value={detail.input} />
+            </div>
+          </div>
+        ) : null}
+      </Drawer>
+
+      <Modal
+        open={rerunOpen}
+        title="指定 businessDate 重跑"
+        okText="创建补跑"
+        cancelText="取消"
+        confirmLoading={actionLoading === 'businessDate'}
+        onCancel={() => setRerunOpen(false)}
+        onOk={() => void handleBusinessDateRerun()}
+      >
+        <div className="mb-4 rounded-md bg-[#f8f9fb] px-3 py-2 text-[11px] leading-5 text-[#667085]">
+          使用来源实例固定的 Workflow Version、Cron 和时区生成新的历史逻辑时间；不会修改旧实例，也不会跟随当前 activeVersion。
+        </div>
+        <div className="space-y-4">
+          <div>
+            <div className="mb-1.5 text-[12px] text-[#667085]">businessDate</div>
+            <DatePicker className="w-full" value={rerunDate} onChange={(value) => value && setRerunDate(value)} />
+          </div>
+          <div>
+            <div className="mb-1.5 text-[12px] text-[#667085]">执行策略</div>
+            <Select
+              className="w-full"
+              value={rerunStrategy}
+              onChange={setRerunStrategy}
+              options={[
+                { value: 'SERIAL_WAIT', label: '串行等待（推荐）' },
+                { value: 'PARALLEL', label: '允许并行' },
+              ]}
+            />
+          </div>
+          <div>
+            <div className="mb-1.5 text-[12px] text-[#667085]">覆盖参数 JSON</div>
+            <Input.TextArea rows={6} spellCheck={false} className="font-mono text-[12px]" value={rerunInput} onChange={(event) => setRerunInput(event.target.value)} />
+          </div>
+        </div>
+      </Modal>
+    </>
+  );
+};
+
+export default InstanceDetailDrawer;

--- a/yak-ops-ui/src/pages/workflow/instances/InstanceDetailDrawer.tsx
+++ b/yak-ops-ui/src/pages/workflow/instances/InstanceDetailDrawer.tsx
@@ -39,7 +39,7 @@ import {
   RotateCcw,
   Square,
 } from 'lucide-react';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, type Key } from 'react';
 import WorkflowDagView from './WorkflowDagView';
 
 interface Props {
@@ -83,8 +83,12 @@ const statusClassName = (status: string) => {
   return 'text-[#667085]';
 };
 
-const formatTime = (value?: string) =>
-  value ? dayjs(value).format('YYYY-MM-DD HH:mm:ss') : '-';
+const formatTime = (value?: string) => value ? dayjs(value).format('YYYY-MM-DD HH:mm:ss') : '-';
+
+const formatScheduleTime = (value?: string) => {
+  if (!value) return '-';
+  return value.replace('T', ' ');
+};
 
 const JsonBlock = ({ value }: { value?: unknown }) => (
   <pre className="m-0 max-h-[220px] overflow-auto rounded-md bg-[#f7f7f8] p-2.5 text-[11px] leading-5 text-[rgba(22,24,35,.72)]">
@@ -92,19 +96,14 @@ const JsonBlock = ({ value }: { value?: unknown }) => (
   </pre>
 );
 
-const InstanceDetailDrawer = ({
-  open,
-  executionId,
-  initial,
-  onClose,
-  onChanged,
-}: Props) => {
+const InstanceDetailDrawer = ({ open, executionId, initial, onClose, onChanged }: Props) => {
   const streamRef = useRef<(() => void) | null>(null);
   const [detail, setDetail] = useState<WorkflowInstance>();
   const [operations, setOperations] = useState<WorkflowInstanceOperations>();
   const [loading, setLoading] = useState(false);
   const [actionLoading, setActionLoading] = useState<string>();
   const [selectedNodeId, setSelectedNodeId] = useState<string>();
+  const [expandedNodeIds, setExpandedNodeIds] = useState<Key[]>([]);
   const [rerunOpen, setRerunOpen] = useState(false);
   const [rerunDate, setRerunDate] = useState(dayjs());
   const [rerunStrategy, setRerunStrategy] = useState<'SERIAL_WAIT' | 'PARALLEL'>('SERIAL_WAIT');
@@ -147,6 +146,7 @@ const InstanceDetailDrawer = ({
     setDetail(initial);
     setOperations(undefined);
     setSelectedNodeId(undefined);
+    setExpandedNodeIds([]);
     void load();
     return () => {
       streamRef.current?.();
@@ -173,10 +173,10 @@ const InstanceDetailDrawer = ({
     }
   }, [actionLoading, applySnapshot, attachStream]);
 
-  const activatePrepared = useCallback(async (prepared: WorkflowInstance, messageText: string) => {
+  const activatePrepared = useCallback(async (prepared: WorkflowInstance, success: string) => {
     const activated = await activateWorkflowInstance(prepared.id);
     onChanged?.(activated);
-    message.success(`${messageText}：${activated.id}`);
+    message.success(`${success}：${activated.id}`);
   }, [onChanged]);
 
   const handleRestart = async () => {
@@ -238,6 +238,11 @@ const InstanceDetailDrawer = ({
     } finally {
       setActionLoading(undefined);
     }
+  };
+
+  const selectDagNode = (nodeId: string) => {
+    setSelectedNodeId(nodeId);
+    setExpandedNodeIds((current) => current.includes(nodeId) ? current : [...current, nodeId]);
   };
 
   const attemptColumns = useMemo<ColumnsType<WorkflowAttempt>>(() => [
@@ -343,11 +348,15 @@ const InstanceDetailDrawer = ({
   ], [actionLoading, detail]);
 
   const canRetryFailed = Boolean(
-    detail &&
-    isWorkflowTerminal(detail.status) &&
-    detail.status !== 'SUCCESS' &&
-    detail.nodes.some((node) => ['FAILED', 'UPSTREAM_FAILED', 'CANCELED', 'SKIPPED'].includes(node.status)),
+    detail
+    && isWorkflowTerminal(detail.status)
+    && detail.status !== 'SUCCESS'
+    && detail.nodes.some((node) => ['FAILED', 'UPSTREAM_FAILED', 'CANCELED', 'SKIPPED'].includes(node.status)),
   );
+
+  const sourceExecutionId = detail
+    ? String(detail.input?.sourceExecutionId || detail.sourceExecutionId || '')
+    : '';
 
   return (
     <>
@@ -404,25 +413,25 @@ const InstanceDetailDrawer = ({
               <div><span className="text-[#98a2b3]">版本：</span><span>V{detail.workflowVersionNo || '-'}</span></div>
               <div><span className="text-[#98a2b3]">触发来源：</span><span>{operations?.triggerType || '-'}</span></div>
               <div><span className="text-[#98a2b3]">businessDate：</span><span>{operations?.businessDate || '-'}</span></div>
-              <div><span className="text-[#98a2b3]">scheduleTime：</span><span>{operations?.scheduleTime ? formatTime(operations.scheduleTime) : '-'}</span></div>
+              <div><span className="text-[#98a2b3]">scheduleTime：</span><span>{formatScheduleTime(operations?.scheduleTime)}</span></div>
               <div><span className="text-[#98a2b3]">时区：</span><span>{operations?.scheduleTimezone || '-'}</span></div>
               <div><span className="text-[#98a2b3]">创建：</span><span>{formatTime(detail.startedAt)}</span></div>
               <div><span className="text-[#98a2b3]">结束：</span><span>{formatTime(detail.endedAt)}</span></div>
-              {detail.sourceExecutionId ? (
-                <div className="col-span-2"><span className="text-[#98a2b3]">来源实例：</span><span className="font-mono text-[#667085]">{detail.sourceExecutionId}</span></div>
+              {sourceExecutionId ? (
+                <div className="col-span-2"><span className="text-[#98a2b3]">来源实例：</span><span className="font-mono text-[#667085]">{sourceExecutionId}</span></div>
               ) : null}
             </div>
 
             <div>
               <div className="mb-2 flex items-center justify-between">
                 <div className="text-[13px] font-medium text-[#344054]">运行实例 DAG</div>
-                <div className="text-[11px] text-[#98a2b3]">点击节点可定位下方节点详情</div>
+                <div className="text-[11px] text-[#98a2b3]">点击节点会定位并展开下方运行明细</div>
               </div>
               <WorkflowDagView
                 instance={detail}
                 operations={operations}
                 selectedNodeId={selectedNodeId}
-                onSelectNode={setSelectedNodeId}
+                onSelectNode={selectDagNode}
               />
             </div>
 
@@ -436,7 +445,12 @@ const InstanceDetailDrawer = ({
                 dataSource={detail.nodes}
                 columns={nodeColumns}
                 rowClassName={(record) => record.id === selectedNodeId ? '!bg-[#f8f9fb]' : ''}
-                expandable={{ expandedRowRender: renderNodeDetail, rowExpandable: () => true }}
+                expandable={{
+                  expandedRowRender: renderNodeDetail,
+                  rowExpandable: () => true,
+                  expandedRowKeys: expandedNodeIds,
+                  onExpandedRowsChange: (keys) => setExpandedNodeIds([...keys]),
+                }}
                 scroll={{ x: 820 }}
               />
             </div>

--- a/yak-ops-ui/src/pages/workflow/instances/WorkflowDagView.tsx
+++ b/yak-ops-ui/src/pages/workflow/instances/WorkflowDagView.tsx
@@ -1,0 +1,221 @@
+import type {
+  WorkflowInstance,
+  WorkflowInstanceOperations,
+  WorkflowNodeInstance,
+} from '@/services/workflow';
+import { useMemo } from 'react';
+
+interface Props {
+  instance: WorkflowInstance;
+  operations?: WorkflowInstanceOperations;
+  selectedNodeId?: string;
+  onSelectNode?: (nodeId: string) => void;
+}
+
+const NODE_WIDTH = 196;
+const NODE_HEIGHT = 76;
+const COLUMN_GAP = 66;
+const ROW_GAP = 28;
+const PADDING = 24;
+
+const statusLabel: Record<string, string> = {
+  CREATED: '已创建',
+  WAITING: '等待中',
+  READY: '就绪',
+  SUBMITTED: '已提交',
+  RUNNING: '运行中',
+  SUCCESS: '成功',
+  SUCCESS_WITH_WARNINGS: '成功（告警）',
+  FAILED: '失败',
+  UPSTREAM_FAILED: '上游阻断',
+  SKIPPED: '已跳过',
+  CANCELED: '已取消',
+  PAUSED: '已暂停',
+};
+
+const nodeClassName = (status: string, selected: boolean) => {
+  const common = 'absolute rounded-lg border bg-white px-3 py-2.5 text-left transition-shadow';
+  if (status === 'FAILED') {
+    return `${common} border-[#fda29b] bg-[#fff7f6] ${selected ? 'ring-2 ring-[#fda29b]/40' : ''}`;
+  }
+  if (status === 'RUNNING' || status === 'SUBMITTED' || status === 'READY') {
+    return `${common} border-[#98a2b3] ${selected ? 'ring-2 ring-[#98a2b3]/30' : ''}`;
+  }
+  if (status === 'SUCCESS' || status === 'SUCCESS_WITH_WARNINGS') {
+    return `${common} border-[#d0d5dd] ${selected ? 'ring-2 ring-[#d0d5dd]/50' : ''}`;
+  }
+  return `${common} border-[#eaecf0] bg-[#fafafa] ${selected ? 'ring-2 ring-[#d0d5dd]/50' : ''}`;
+};
+
+const statusTextClassName = (status: string) => {
+  if (status === 'FAILED') return 'text-[#d92d20]';
+  if (status === 'RUNNING' || status === 'SUBMITTED' || status === 'READY') {
+    return 'font-medium text-[#344054]';
+  }
+  return 'text-[#667085]';
+};
+
+const WorkflowDagView = ({
+  instance,
+  operations,
+  selectedNodeId,
+  onSelectNode,
+}: Props) => {
+  const layout = useMemo(() => {
+    const nodes = instance.nodes || [];
+    const nodeIds = new Set(nodes.map((node) => node.id));
+    const edges = (operations?.edges || []).filter(
+      (edge) => nodeIds.has(edge.source) && nodeIds.has(edge.target),
+    );
+    const predecessors = new Map<string, string[]>();
+    const successors = new Map<string, string[]>();
+    const indegree = new Map<string, number>();
+    nodes.forEach((node) => {
+      predecessors.set(node.id, []);
+      successors.set(node.id, []);
+      indegree.set(node.id, 0);
+    });
+    edges.forEach((edge) => {
+      predecessors.get(edge.target)?.push(edge.source);
+      successors.get(edge.source)?.push(edge.target);
+      indegree.set(edge.target, (indegree.get(edge.target) || 0) + 1);
+    });
+
+    const queue = nodes
+      .filter((node) => (indegree.get(node.id) || 0) === 0)
+      .map((node) => node.id);
+    const level = new Map<string, number>();
+    queue.forEach((id) => level.set(id, 0));
+    let cursor = 0;
+    while (cursor < queue.length) {
+      const current = queue[cursor++];
+      const currentLevel = level.get(current) || 0;
+      (successors.get(current) || []).forEach((next) => {
+        level.set(next, Math.max(level.get(next) || 0, currentLevel + 1));
+        const nextDegree = (indegree.get(next) || 0) - 1;
+        indegree.set(next, nextDegree);
+        if (nextDegree === 0) queue.push(next);
+      });
+    }
+
+    // 防御异常拓扑：未被拓扑排序覆盖的节点放到最后一列，不阻塞运维页面。
+    const fallbackLevel = Math.max(0, ...Array.from(level.values())) + 1;
+    nodes.forEach((node) => {
+      if (!level.has(node.id)) level.set(node.id, fallbackLevel);
+    });
+
+    const columns = new Map<number, WorkflowNodeInstance[]>();
+    nodes.forEach((node) => {
+      const value = level.get(node.id) || 0;
+      const column = columns.get(value) || [];
+      column.push(node);
+      columns.set(value, column);
+    });
+
+    const positions = new Map<string, { x: number; y: number }>();
+    let maxRows = 1;
+    columns.forEach((column, columnIndex) => {
+      maxRows = Math.max(maxRows, column.length);
+      column.forEach((node, rowIndex) => {
+        positions.set(node.id, {
+          x: PADDING + columnIndex * (NODE_WIDTH + COLUMN_GAP),
+          y: PADDING + rowIndex * (NODE_HEIGHT + ROW_GAP),
+        });
+      });
+    });
+
+    const maxLevel = Math.max(0, ...Array.from(level.values()));
+    return {
+      positions,
+      edges,
+      width: PADDING * 2 + (maxLevel + 1) * NODE_WIDTH + maxLevel * COLUMN_GAP,
+      height: PADDING * 2 + maxRows * NODE_HEIGHT + (maxRows - 1) * ROW_GAP,
+    };
+  }, [instance.nodes, operations?.edges]);
+
+  if (!instance.nodes.length) {
+    return <div className="py-10 text-center text-[12px] text-[#98a2b3]">当前实例没有运行节点</div>;
+  }
+
+  return (
+    <div className="overflow-x-auto rounded-lg border border-[#eaecf0] bg-[#fcfcfd]">
+      <div
+        className="relative"
+        style={{ width: Math.max(layout.width, 520), height: Math.max(layout.height, 124) }}
+      >
+        <svg
+          className="pointer-events-none absolute inset-0 h-full w-full"
+          width={Math.max(layout.width, 520)}
+          height={Math.max(layout.height, 124)}
+          aria-hidden="true"
+        >
+          <defs>
+            <marker
+              id="workflow-dag-arrow"
+              markerWidth="8"
+              markerHeight="8"
+              refX="7"
+              refY="4"
+              orient="auto"
+            >
+              <path d="M0,0 L8,4 L0,8 z" fill="#c7cdd6" />
+            </marker>
+          </defs>
+          {layout.edges.map((edge) => {
+            const source = layout.positions.get(edge.source);
+            const target = layout.positions.get(edge.target);
+            if (!source || !target) return null;
+            const x1 = source.x + NODE_WIDTH;
+            const y1 = source.y + NODE_HEIGHT / 2;
+            const x2 = target.x;
+            const y2 = target.y + NODE_HEIGHT / 2;
+            const mid = x1 + Math.max(20, (x2 - x1) / 2);
+            return (
+              <path
+                key={`${edge.source}->${edge.target}`}
+                d={`M ${x1} ${y1} C ${mid} ${y1}, ${mid} ${y2}, ${x2 - 8} ${y2}`}
+                fill="none"
+                stroke="#d0d5dd"
+                strokeWidth="1.4"
+                markerEnd="url(#workflow-dag-arrow)"
+              />
+            );
+          })}
+        </svg>
+
+        {instance.nodes.map((node) => {
+          const position = layout.positions.get(node.id) || { x: PADDING, y: PADDING };
+          return (
+            <button
+              key={node.id}
+              type="button"
+              className={nodeClassName(node.status, selectedNodeId === node.id)}
+              style={{
+                left: position.x,
+                top: position.y,
+                width: NODE_WIDTH,
+                height: NODE_HEIGHT,
+              }}
+              onClick={() => onSelectNode?.(node.id)}
+            >
+              <div className="truncate text-[12px] font-medium text-[#344054]" title={node.name}>
+                {node.name || node.id}
+              </div>
+              <div className="mt-1 flex items-center justify-between gap-2 text-[11px]">
+                <span className={statusTextClassName(node.status)}>
+                  {statusLabel[node.status] || node.status}
+                </span>
+                <span className="text-[#98a2b3]">Attempt {node.attemptCount}</span>
+              </div>
+              <div className="mt-1 truncate font-mono text-[10px] text-[#b0b7c3]" title={node.id}>
+                {node.id}
+              </div>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default WorkflowDagView;

--- a/yak-ops-ui/src/pages/workflow/instances/index.tsx
+++ b/yak-ops-ui/src/pages/workflow/instances/index.tsx
@@ -1,22 +1,11 @@
 import {
-  activateWorkflowInstance,
-  cancelWorkflowInstance,
-  getWorkflowInstance,
+  batchRetryWorkflowInstances,
   getWorkflowInstances,
   isWorkflowTerminal,
-  pauseWorkflowInstance,
-  rerunWorkflowFromNode,
-  restartWorkflowInstance,
-  resumeWorkflowInstance,
-  retryWorkflowFailedNodes,
-  subscribeWorkflowEvents,
-  type WorkflowAttempt,
   type WorkflowInstance,
-  type WorkflowNodeInstance,
 } from '@/services/workflow';
 import {
   CopyOutlined,
-  FilterOutlined,
   ReloadOutlined,
   SearchOutlined,
 } from '@ant-design/icons';
@@ -24,13 +13,10 @@ import {
   Button,
   ConfigProvider,
   DatePicker,
-  Divider,
-  Drawer,
   Empty,
   Input,
+  Modal,
   Pagination,
-  Popconfirm,
-  Popover,
   Select,
   Table,
   Tooltip,
@@ -39,14 +25,9 @@ import {
 import type { ColumnsType } from 'antd/es/table';
 import type { Dayjs } from 'dayjs';
 import dayjs from 'dayjs';
-import {
-  Pause,
-  Play,
-  RefreshCw,
-  RotateCcw,
-  Square,
-} from 'lucide-react';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { RefreshCw } from 'lucide-react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import InstanceDetailDrawer from './InstanceDetailDrawer';
 
 const { RangePicker } = DatePicker;
 
@@ -62,53 +43,14 @@ const statusLabel: Record<string, string> = {
   WARNING: '告警',
   CANCELED: '已取消',
   TIMED_OUT: '已超时',
-  WAITING: '等待中',
-  READY: '就绪',
-  SUBMITTED: '已提交',
-  UPSTREAM_FAILED: '已阻断',
-  SKIPPED: '已跳过',
 };
 
-const failureReasonLabel: Record<string, string> = {
-  EXECUTOR_FAILURE: '执行器失败',
-  DISPATCH_TIMEOUT: '派发超时',
-  EXECUTION_TIMEOUT: '执行超时',
-};
-
-const RUNNING_STATUSES = new Set([
-  'CREATED',
-  'RUNNING',
-  'PAUSING',
-  'PAUSED',
-  'RESUMING',
-  'WAITING',
-  'READY',
-  'SUBMITTED',
-]);
-
-const COMPLETED_STATUSES = new Set([
-  'SUCCESS',
-  'SUCCESS_WITH_WARNINGS',
-  'WARNING',
-  'CANCELED',
-]);
-
+const RUNNING_STATUSES = new Set(['CREATED', 'RUNNING', 'PAUSING', 'PAUSED', 'RESUMING']);
+const COMPLETED_STATUSES = new Set(['SUCCESS', 'SUCCESS_WITH_WARNINGS', 'WARNING', 'CANCELED']);
 const FAILED_STATUSES = new Set(['FAILED', 'TIMED_OUT']);
+const RETRYABLE_NODE_STATUSES = new Set(['FAILED', 'UPSTREAM_FAILED', 'SKIPPED', 'CANCELED']);
 
 type StatusGroup = 'ALL' | 'RUNNING' | 'COMPLETED' | 'FAILED';
-
-interface FilterState {
-  keyword?: string;
-  instanceId?: string;
-  definitionId?: string;
-  testRun?: 'true' | 'false';
-  startedAt?: Dayjs[];
-}
-
-interface PaginationState {
-  current: number;
-  pageSize: number;
-}
 
 const statusTabs: Array<{ label: string; value: StatusGroup }> = [
   { label: '全部实例', value: 'ALL' },
@@ -117,1137 +59,290 @@ const statusTabs: Array<{ label: string; value: StatusGroup }> = [
   { label: '失败', value: 'FAILED' },
 ];
 
-const PAGE_SIZE_OPTIONS = [10, 20, 50];
-
-const statusClassName = (status: string) => {
-  if (status === 'FAILED' || status === 'TIMED_OUT') {
-    return 'text-[#d92d20]';
-  }
-  if (status === 'UPSTREAM_FAILED' || status === 'PAUSED' || status === 'PAUSING') {
-    return 'text-[rgba(22,24,35,.46)]';
-  }
-  if (
-    status === 'RUNNING' ||
-    status === 'RESUMING' ||
-    status === 'SUBMITTED' ||
-    status === 'READY'
-  ) {
-    return 'font-medium text-[#161823]';
-  }
-  return 'text-[rgba(22,24,35,.58)]';
-};
-
-const statusBadgeClassName = (status: string) => {
-  if (FAILED_STATUSES.has(status)) {
-    return 'border-[#ffd6d6] bg-[#fff5f5] text-[#d92d20]';
-  }
-  if (status === 'RUNNING' || status === 'RESUMING') {
-    return 'border-[#e4e7ec] bg-[#f5f5f6] text-[#344054]';
-  }
-  if (status === 'PAUSED' || status === 'PAUSING') {
-    return 'border-[#eaecf0] bg-[#f8f9fb] text-[#667085]';
-  }
-  return 'border-[#eaecf0] bg-[#fafafa] text-[#667085]';
-};
-
-const formatTime = (value?: string) =>
-  value ? dayjs(value).format('YYYY-MM-DD HH:mm:ss') : '-';
+const formatTime = (value?: string) => value ? dayjs(value).format('YYYY-MM-DD HH:mm:ss') : '-';
 
 const formatDuration = (record: WorkflowInstance) => {
   if (!record.startedAt) return '-';
-  const start = dayjs(record.startedAt);
-  const end = record.endedAt ? dayjs(record.endedAt) : dayjs();
-  const seconds = Math.max(0, end.diff(start, 'second'));
+  const seconds = Math.max(0, dayjs(record.endedAt || undefined).diff(dayjs(record.startedAt), 'second'));
   if (seconds < 60) return `${seconds} 秒`;
   const minutes = Math.floor(seconds / 60);
   if (minutes < 60) return `${minutes} 分 ${seconds % 60} 秒`;
-  const hours = Math.floor(minutes / 60);
-  return `${hours} 小时 ${minutes % 60} 分`;
+  return `${Math.floor(minutes / 60)} 小时 ${minutes % 60} 分`;
 };
 
-const matchesStatusGroup = (status: string, group: StatusGroup) => {
-  if (group === 'ALL') return true;
-  if (group === 'RUNNING') return RUNNING_STATUSES.has(status);
-  if (group === 'COMPLETED') return COMPLETED_STATUSES.has(status);
-  return FAILED_STATUSES.has(status);
+const statusBadgeClassName = (status: string) => {
+  if (FAILED_STATUSES.has(status)) return 'border-[#ffd6d6] bg-[#fff5f5] text-[#d92d20]';
+  if (status === 'RUNNING' || status === 'RESUMING') return 'border-[#d0d5dd] bg-[#f8f9fb] text-[#344054]';
+  return 'border-[#eaecf0] bg-[#fafafa] text-[#667085]';
 };
 
-const JsonBlock = ({ value }: { value?: unknown }) => (
-  <pre className="m-0 max-h-[220px] overflow-auto rounded-md bg-[#f7f7f8] p-2.5 text-[11px] leading-5 text-[rgba(22,24,35,.72)]">
-    {JSON.stringify(value ?? {}, null, 2)}
-  </pre>
-);
-
-interface ListPaginationProps {
-  total: number;
-  current: number;
-  pageSize: number;
-  onChange: (page: number, pageSize: number) => void;
-}
-
-const ListPagination = ({
-  total,
-  current,
-  pageSize,
-  onChange,
-}: ListPaginationProps) => (
-  <div className="flex items-center gap-3 text-[13px] text-[#667085]">
-    <Pagination
-      size="small"
-      total={total}
-      current={current}
-      pageSize={pageSize}
-      showSizeChanger={false}
-      showQuickJumper={false}
-      onChange={(page) => onChange(page, pageSize)}
-    />
-    <span className="whitespace-nowrap">每页显示：</span>
-    <Select
-      size="small"
-      value={pageSize}
-      options={PAGE_SIZE_OPTIONS.map((value) => ({ label: value, value }))}
-      onChange={(nextPageSize) => onChange(1, nextPageSize)}
-      className="w-[64px]"
-    />
-    <span className="whitespace-nowrap text-[#344054]">总 {total} 行</span>
-  </div>
-);
+const isRetryableInstance = (instance: WorkflowInstance) =>
+  isWorkflowTerminal(instance.status)
+  && instance.status !== 'SUCCESS'
+  && instance.nodes.some((node) => RETRYABLE_NODE_STATUSES.has(node.status));
 
 const WorkflowInstancesPage = () => {
-  const detailStreamRef = useRef<(() => void) | null>(null);
   const [instances, setInstances] = useState<WorkflowInstance[]>([]);
   const [loading, setLoading] = useState(false);
-  const [detailOpen, setDetailOpen] = useState(false);
-  const [detail, setDetail] = useState<WorkflowInstance>();
-  const [detailLoading, setDetailLoading] = useState(false);
-  const [actionLoading, setActionLoading] = useState<string>();
   const [statusGroup, setStatusGroup] = useState<StatusGroup>('ALL');
-  const [filterDraft, setFilterDraft] = useState<FilterState>({});
-  const [filters, setFilters] = useState<FilterState>({});
-  const [advancedOpen, setAdvancedOpen] = useState(false);
-  const [pagination, setPagination] = useState<PaginationState>({
-    current: 1,
-    pageSize: 10,
-  });
+  const [keyword, setKeyword] = useState('');
+  const [dateRange, setDateRange] = useState<Dayjs[]>();
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(10);
+  const [selectedKeys, setSelectedKeys] = useState<React.Key[]>([]);
+  const [detailId, setDetailId] = useState<string>();
+  const [detailInitial, setDetailInitial] = useState<WorkflowInstance>();
+  const [batchLoading, setBatchLoading] = useState(false);
 
-  const loadInstances = useCallback(async (showLoading = false) => {
+  const load = useCallback(async (showLoading = false) => {
     if (showLoading) setLoading(true);
     try {
       setInstances(await getWorkflowInstances());
     } catch (error) {
-      if (showLoading) {
-        message.error(error instanceof Error ? error.message : '工作流实例加载失败');
-      }
+      if (showLoading) message.error(error instanceof Error ? error.message : '工作流实例加载失败');
     } finally {
       if (showLoading) setLoading(false);
     }
   }, []);
 
   useEffect(() => {
-    void loadInstances(true);
-    const timer = window.setInterval(() => void loadInstances(false), 2000);
-    return () => {
-      window.clearInterval(timer);
-      detailStreamRef.current?.();
-    };
-  }, [loadInstances]);
+    void load(true);
+    const timer = window.setInterval(() => void load(false), 2500);
+    return () => window.clearInterval(timer);
+  }, [load]);
 
-  const applyDetailSnapshot = useCallback((snapshot: WorkflowInstance) => {
-    setDetail(snapshot);
-    setInstances((current) => {
-      const exists = current.some((item) => item.id === snapshot.id);
-      return exists
-        ? current.map((item) => (item.id === snapshot.id ? snapshot : item))
-        : [snapshot, ...current];
-    });
-  }, []);
-
-  const attachDetailStream = useCallback((instance: WorkflowInstance) => {
-    detailStreamRef.current?.();
-    detailStreamRef.current = null;
-    if (!isWorkflowTerminal(instance.status)) {
-      detailStreamRef.current = subscribeWorkflowEvents(
-        instance.id,
-        applyDetailSnapshot,
-      );
-    }
-  }, [applyDetailSnapshot]);
-
-  const openDetail = useCallback(async (record: WorkflowInstance) => {
-    detailStreamRef.current?.();
-    detailStreamRef.current = null;
-    setDetail(record);
-    setDetailOpen(true);
-    setDetailLoading(true);
-    try {
-      const current = await getWorkflowInstance(record.id);
-      applyDetailSnapshot(current);
-      attachDetailStream(current);
-    } catch (error) {
-      message.error(error instanceof Error ? error.message : '实例详情加载失败');
-    } finally {
-      setDetailLoading(false);
-    }
-  }, [applyDetailSnapshot, attachDetailStream]);
-
-  const closeDetail = () => {
-    detailStreamRef.current?.();
-    detailStreamRef.current = null;
-    setDetailOpen(false);
+  const matchesGroup = (status: string) => {
+    if (statusGroup === 'ALL') return true;
+    if (statusGroup === 'RUNNING') return RUNNING_STATUSES.has(status);
+    if (statusGroup === 'COMPLETED') return COMPLETED_STATUSES.has(status);
+    return FAILED_STATUSES.has(status);
   };
 
-  const runAction = useCallback(async (
-    action: string,
-    operation: () => Promise<WorkflowInstance>,
-    successMessage: string,
-  ) => {
-    if (actionLoading) return;
-    setActionLoading(action);
-    try {
-      const snapshot = await operation();
-      applyDetailSnapshot(snapshot);
-      attachDetailStream(snapshot);
-      message.success(successMessage);
-    } catch (error) {
-      message.error(error instanceof Error ? error.message : '工作流操作失败');
-    } finally {
-      setActionLoading(undefined);
-    }
-  }, [actionLoading, applyDetailSnapshot, attachDetailStream]);
+  const filtered = useMemo(() => {
+    const q = keyword.trim().toLowerCase();
+    const [start, end] = dateRange || [];
+    return instances.filter((record) => {
+      if (!matchesGroup(record.status)) return false;
+      if (q && ![record.name, record.id, record.definitionId, String(record.input?.businessDate || '')]
+        .some((value) => value?.toLowerCase().includes(q))) return false;
+      if (start && dayjs(record.startedAt).isBefore(start.startOf('day'))) return false;
+      if (end && dayjs(record.startedAt).isAfter(end.endOf('day'))) return false;
+      return true;
+    });
+  }, [dateRange, instances, keyword, statusGroup]);
 
-  const activateNewExecution = useCallback(async (
-    prepared: WorkflowInstance,
-    successMessage: string,
-  ) => {
-    applyDetailSnapshot(prepared);
-    attachDetailStream(prepared);
-    const activated = await activateWorkflowInstance(prepared.id);
-    applyDetailSnapshot(activated);
-    message.success(successMessage);
-  }, [applyDetailSnapshot, attachDetailStream]);
+  useEffect(() => {
+    const maxPage = Math.max(1, Math.ceil(filtered.length / pageSize));
+    if (page > maxPage) setPage(maxPage);
+  }, [filtered.length, page, pageSize]);
 
-  const copyToClipboard = useCallback(async (value: string) => {
+  const pageData = useMemo(() => {
+    const offset = (page - 1) * pageSize;
+    return filtered.slice(offset, offset + pageSize);
+  }, [filtered, page, pageSize]);
+
+  const openDetail = (record: WorkflowInstance) => {
+    setDetailInitial(record);
+    setDetailId(record.id);
+  };
+
+  const copyId = async (value: string) => {
     try {
-      if (navigator.clipboard && window.isSecureContext) {
-        await navigator.clipboard.writeText(value);
-      } else {
-        const textarea = document.createElement('textarea');
-        textarea.value = value;
-        textarea.style.position = 'fixed';
-        textarea.style.opacity = '0';
-        document.body.appendChild(textarea);
-        textarea.focus();
-        textarea.select();
-        document.execCommand('copy');
-        document.body.removeChild(textarea);
-      }
+      await navigator.clipboard.writeText(value);
       message.success('实例 ID 已复制');
     } catch {
       message.error('复制失败，请手动复制');
     }
-  }, []);
-
-  const applyFilters = useCallback((nextFilters: FilterState) => {
-    setFilterDraft(nextFilters);
-    setFilters(nextFilters);
-    setPagination((previous) => ({ ...previous, current: 1 }));
-  }, []);
-
-  const handleSearch = () => {
-    applyFilters({ ...filterDraft });
   };
 
-  const handleStatusChange = (value: StatusGroup) => {
-    setStatusGroup(value);
-    setPagination((previous) => ({ ...previous, current: 1 }));
-  };
-
-  const updateFilterDraft = (
-    field: keyof FilterState,
-    value: FilterState[keyof FilterState],
-  ) => {
-    setFilterDraft((previous) => ({ ...previous, [field]: value }));
-  };
-
-  const handleAdvancedReset = () => {
-    const nextFilters: FilterState = {
-      ...filterDraft,
-      instanceId: undefined,
-      definitionId: undefined,
-      testRun: undefined,
-    };
-    applyFilters(nextFilters);
-  };
-
-  const advancedFilterCount = [
-    filterDraft.instanceId,
-    filterDraft.definitionId,
-    filterDraft.testRun,
-  ].filter(Boolean).length;
-
-  const filteredInstances = useMemo(() => {
-    const keyword = filters.keyword?.trim().toLowerCase();
-    const instanceId = filters.instanceId?.trim().toLowerCase();
-    const definitionId = filters.definitionId?.trim().toLowerCase();
-    const [rangeStart, rangeEnd] = filters.startedAt || [];
-
-    return instances.filter((record) => {
-      if (!matchesStatusGroup(record.status, statusGroup)) return false;
-
-      if (
-        keyword &&
-        !record.name.toLowerCase().includes(keyword) &&
-        !record.id.toLowerCase().includes(keyword)
-      ) {
-        return false;
-      }
-
-      if (instanceId && !record.id.toLowerCase().includes(instanceId)) {
-        return false;
-      }
-
-      if (
-        definitionId &&
-        !record.definitionId?.toLowerCase().includes(definitionId)
-      ) {
-        return false;
-      }
-
-      if (
-        filters.testRun &&
-        String(record.testRun) !== filters.testRun
-      ) {
-        return false;
-      }
-
-      if (rangeStart || rangeEnd) {
-        const startedAt = dayjs(record.startedAt);
-        if (rangeStart && startedAt.isBefore(rangeStart.startOf('day'))) {
-          return false;
-        }
-        if (rangeEnd && startedAt.isAfter(rangeEnd.endOf('day'))) {
-          return false;
-        }
-      }
-
-      return true;
+  const handleSnapshot = useCallback((snapshot?: WorkflowInstance) => {
+    if (!snapshot) {
+      void load(false);
+      return;
+    }
+    setInstances((current) => {
+      const found = current.some((item) => item.id === snapshot.id);
+      return found
+        ? current.map((item) => item.id === snapshot.id ? snapshot : item)
+        : [snapshot, ...current];
     });
-  }, [filters, instances, statusGroup]);
+  }, [load]);
 
-  useEffect(() => {
-    const maxPage = Math.max(
-      1,
-      Math.ceil(filteredInstances.length / pagination.pageSize),
-    );
-    if (pagination.current > maxPage) {
-      setPagination((previous) => ({ ...previous, current: maxPage }));
-    }
-  }, [filteredInstances.length, pagination.current, pagination.pageSize]);
-
-  const pageInstances = useMemo(() => {
-    const start = (pagination.current - 1) * pagination.pageSize;
-    return filteredInstances.slice(start, start + pagination.pageSize);
-  }, [filteredInstances, pagination.current, pagination.pageSize]);
-
-  const columns = useMemo<ColumnsType<WorkflowInstance>>(
-    () => [
-      {
-        title: '名称 / ID',
-        dataIndex: 'name',
-        width: 320,
-        render: (_, record) => (
-          <div className="min-w-0 py-0.5">
-            <div
-              className="truncate text-[13px] font-medium leading-5 text-[#344054]"
-              title={record.name}
-            >
-              {record.name || '-'}
-            </div>
-            <div className="mt-0.5 flex h-5 items-center gap-1 text-[11px] leading-5 text-[#98a2b3]">
-              <span className="truncate">ID：{record.id}</span>
-              <Tooltip title="复制实例 ID">
-                <Button
-                  type="text"
-                  size="small"
-                  icon={<CopyOutlined className="text-[11px]" />}
-                  className="!flex !h-5 !w-5 !min-w-0 !items-center !justify-center !p-0 !text-[#98a2b3] hover:!bg-[#f2f4f7] hover:!text-[#475467]"
-                  onClick={(event) => {
-                    event.stopPropagation();
-                    void copyToClipboard(record.id);
-                  }}
-                />
-              </Tooltip>
-            </div>
-            <div
-              className="truncate text-[11px] leading-5 text-[#b0b7c3]"
-              title={record.definitionId}
-            >
-              工作流：{record.definitionId || '-'}
-            </div>
-          </div>
-        ),
-      },
-      {
-        title: '状态',
-        dataIndex: 'status',
-        width: 120,
-        align: 'center',
-        render: (status: string) => (
-          <span
-            className={[
-              'inline-flex min-h-6 items-center rounded-md border px-2 text-[12px] font-medium',
-              statusBadgeClassName(status),
-            ].join(' ')}
-          >
-            {statusLabel[status] || status}
-          </span>
-        ),
-      },
-      {
-        title: '执行概况',
-        width: 210,
-        render: (_, record) => (
-          <div className="text-[12px] leading-5 text-[#667085]">
-            <div>
-              <span className="text-[#98a2b3]">节点 / 连线：</span>
-              <span className="text-[#475467]">
-                {record.nodeCount} / {record.edgeCount}
-              </span>
-            </div>
-            <div>
-              <span className="text-[#98a2b3]">运行时长：</span>
-              <span className="text-[#475467]">{formatDuration(record)}</span>
-            </div>
-          </div>
-        ),
-      },
-      {
-        title: '工作流超时',
-        dataIndex: 'workflowTimeoutSeconds',
-        width: 130,
-        render: (value: number) => (
-          <span className="text-[12px] text-[#667085]">
-            {value > 0 ? `${value}s` : '-'}
-          </span>
-        ),
-      },
-      {
-        title: '开始时间',
-        dataIndex: 'startedAt',
-        width: 175,
-        render: (value?: string) => (
-          <span className="whitespace-nowrap text-[12px] text-[#98a2b3]">
-            {formatTime(value)}
-          </span>
-        ),
-      },
-      {
-        title: '结束时间',
-        dataIndex: 'endedAt',
-        width: 175,
-        render: (value?: string) => (
-          <span className="whitespace-nowrap text-[12px] text-[#98a2b3]">
-            {formatTime(value)}
-          </span>
-        ),
-      },
-      {
-        title: '操作',
-        width: 100,
-        fixed: 'right',
-        render: (_, record) => (
-          <Button
-            type="link"
-            className="!h-7 !px-0 !text-[12px] !text-[#ff4d4f]"
-            onClick={() => openDetail(record)}
-          >
-            查看
-          </Button>
-        ),
-      },
-    ],
-    [copyToClipboard, openDetail],
-  );
-
-  const handleRerunFromNode = useCallback(async (nodeId: string) => {
-    if (!detail || actionLoading) return;
-    setActionLoading(`rerun:${nodeId}`);
+  const batchRetry = async () => {
+    if (!selectedKeys.length || batchLoading) return;
+    setBatchLoading(true);
     try {
-      const prepared = await rerunWorkflowFromNode(detail.id, nodeId);
-      await activateNewExecution(prepared, `已从节点「${nodeId}」创建新的运行实例`);
-    } catch (error) {
-      message.error(error instanceof Error ? error.message : '从节点重跑失败');
-    } finally {
-      setActionLoading(undefined);
-    }
-  }, [actionLoading, activateNewExecution, detail]);
-
-  const nodeColumns = useMemo<ColumnsType<WorkflowNodeInstance>>(
-    () => [
-      {
-        title: '节点',
-        dataIndex: 'name',
-        minWidth: 200,
-        render: (_, record) => (
-          <div>
-            <div className="font-medium text-[#161823]">{record.name}</div>
-            <div className="mt-0.5 text-[11px] text-[rgba(22,24,35,.42)]">
-              {record.type} · {record.id}
+      const result = await batchRetryWorkflowInstances(selectedKeys.map(String));
+      setSelectedKeys([]);
+      await load(false);
+      if (result.failedCount === 0) {
+        message.success(`已重新调度 ${result.acceptedCount} 个失败实例`);
+      } else {
+        Modal.info({
+          title: `批量重试完成：成功 ${result.acceptedCount}，失败 ${result.failedCount}`,
+          width: 680,
+          content: (
+            <div className="mt-3 max-h-[320px] overflow-auto space-y-2">
+              {result.items.filter((item) => !item.accepted).map((item) => (
+                <div key={item.executionId} className="rounded-md border border-[#fecdca] bg-[#fff6f5] px-3 py-2 text-[12px]">
+                  <div className="font-mono text-[#b42318]">{item.executionId}</div>
+                  <div className="mt-1 text-[#667085]">{item.message || '重试失败'}</div>
+                </div>
+              ))}
             </div>
-          </div>
-        ),
-      },
-      {
-        title: '状态',
-        dataIndex: 'status',
-        width: 110,
-        render: (status: string) => (
-          <span className={statusClassName(status)}>
-            {statusLabel[status] || status}
-          </span>
-        ),
-      },
-      {
-        title: 'Attempt',
-        width: 100,
-        render: (_, record) => (
-          <span className="text-[12px] text-[rgba(22,24,35,.62)]">
-            {record.currentAttemptNumber
-              ? `${record.currentAttemptNumber} / ${record.retryMaxAttempts}`
-              : `0 / ${record.retryMaxAttempts}`}
-          </span>
-        ),
-      },
-      {
-        title: '失败原因',
-        dataIndex: 'failureReason',
-        width: 120,
-        render: (value?: string, record?: WorkflowNodeInstance) => {
-          if (record?.status === 'UPSTREAM_FAILED') return '未执行';
-          return value ? failureReasonLabel[value] || value : '-';
-        },
-      },
-      {
-        title: '操作',
-        width: 110,
-        render: (_, record) => (
-          detail && isWorkflowTerminal(detail.status) ? (
-            <Button
-              type="link"
-              className="!px-0 !text-[12px]"
-              loading={actionLoading === `rerun:${record.id}`}
-              onClick={() => void handleRerunFromNode(record.id)}
-            >
-              从此节点重跑
-            </Button>
-          ) : '-'
-        ),
-      },
-    ],
-    [actionLoading, detail, handleRerunFromNode],
-  );
+          ),
+        });
+      }
+    } catch (error) {
+      message.error(error instanceof Error ? error.message : '批量重试失败');
+    } finally {
+      setBatchLoading(false);
+    }
+  };
 
-  const attemptColumns = useMemo<ColumnsType<WorkflowAttempt>>(
-    () => [
-      { title: '#', dataIndex: 'attemptNumber', width: 48 },
-      {
-        title: '状态',
-        dataIndex: 'status',
-        width: 100,
-        render: (status: string) => statusLabel[status] || status,
-      },
-      {
-        title: '失败原因',
-        dataIndex: 'failureReason',
-        width: 120,
-        render: (value?: string) => value ? failureReasonLabel[value] || value : '-',
-      },
-      {
-        title: 'Attempt ID',
-        dataIndex: 'id',
-        render: (value: string) => (
-          <span className="font-mono text-[10px] text-[rgba(22,24,35,.56)]">
-            {value}
-          </span>
-        ),
-      },
-      {
-        title: '开始',
-        dataIndex: 'startedAt',
-        width: 155,
-        render: formatTime,
-      },
-      {
-        title: '结束',
-        dataIndex: 'endedAt',
-        width: 155,
-        render: formatTime,
-      },
-    ],
-    [],
-  );
-
-  const renderNodeDetail = (record: WorkflowNodeInstance) => (
-    <div className="space-y-4 bg-[#fafafa] p-3">
-      <div className="grid grid-cols-2 gap-x-6 gap-y-2 text-[11px]">
-        <div>
-          <span className="text-[rgba(22,24,35,.42)]">当前 Attempt：</span>
-          <span className="font-mono text-[rgba(22,24,35,.68)]">
-            {record.currentAttemptId || '-'}
-          </span>
-        </div>
-        <div>
-          <span className="text-[rgba(22,24,35,.42)]">Retry：</span>
-          <span>{record.retryMaxAttempts} 次 / 延迟 {record.retryDelaySeconds}s</span>
-        </div>
-        <div>
-          <span className="text-[rgba(22,24,35,.42)]">派发超时：</span>
-          <span>
-            {record.dispatchTimeoutSeconds > 0
-              ? `${record.dispatchTimeoutSeconds}s`
-              : '-'}
-          </span>
-        </div>
-        <div>
-          <span className="text-[rgba(22,24,35,.42)]">执行超时：</span>
-          <span>
-            {record.executionTimeoutSeconds > 0
-              ? `${record.executionTimeoutSeconds}s`
-              : '-'}
-          </span>
-        </div>
-      </div>
-
-      <div className="grid grid-cols-2 gap-3">
-        <div>
-          <div className="mb-1.5 text-[11px] font-medium text-[#161823]">
-            Input Mapping
+  const columns = useMemo<ColumnsType<WorkflowInstance>>(() => [
+    {
+      title: '名称 / ID', dataIndex: 'name', width: 315,
+      render: (_: unknown, record) => (
+        <div className="min-w-0 py-0.5">
+          <div className="truncate text-[13px] font-medium text-[#344054]">{record.name || '-'}</div>
+          <div className="mt-0.5 flex items-center gap-1 text-[11px] text-[#98a2b3]">
+            <span className="truncate">{record.id}</span>
+            <Tooltip title="复制实例 ID">
+              <Button type="text" size="small" icon={<CopyOutlined />} className="!h-5 !w-5 !min-w-0 !p-0" onClick={(event) => { event.stopPropagation(); void copyId(record.id); }} />
+            </Tooltip>
           </div>
-          <JsonBlock value={record.inputMapping} />
+          <div className="truncate text-[11px] text-[#b0b7c3]">definition：{record.definitionId || '-'}</div>
         </div>
-        <div>
-          <div className="mb-1.5 text-[11px] font-medium text-[#161823]">
-            Resolved Node Input
-          </div>
-          <JsonBlock value={record.input} />
+      ),
+    },
+    {
+      title: '状态', dataIndex: 'status', width: 120, align: 'center',
+      render: (status: string) => (
+        <span className={`inline-flex min-h-6 items-center rounded-md border px-2 text-[12px] font-medium ${statusBadgeClassName(status)}`}>
+          {statusLabel[status] || status}
+        </span>
+      ),
+    },
+    {
+      title: '调度上下文', width: 190,
+      render: (_: unknown, record) => (
+        <div className="text-[11px] leading-5 text-[#667085]">
+          <div><span className="text-[#98a2b3]">businessDate：</span>{String(record.input?.businessDate || '-')}</div>
+          <div><span className="text-[#98a2b3]">trigger：</span>{String(record.input?.triggerType || (record.testRun ? 'TEST' : 'MANUAL'))}</div>
+          <div><span className="text-[#98a2b3]">version：</span>{record.workflowVersionNo ? `V${record.workflowVersionNo}` : '-'}</div>
         </div>
-        <div>
-          <div className="mb-1.5 text-[11px] font-medium text-[#161823]">
-            Direct Predecessor Outputs
-          </div>
-          <JsonBlock value={record.predecessorOutputs} />
+      ),
+    },
+    {
+      title: '执行概况', width: 175,
+      render: (_: unknown, record) => (
+        <div className="text-[12px] leading-5 text-[#667085]">
+          <div>节点 / 连线：{record.nodeCount} / {record.edgeCount}</div>
+          <div>运行时长：{formatDuration(record)}</div>
         </div>
-        <div>
-          <div className="mb-1.5 text-[11px] font-medium text-[#161823]">
-            Node Output
-          </div>
-          <JsonBlock value={record.output} />
-        </div>
-      </div>
-
-      <div>
-        <div className="mb-1.5 text-[11px] font-medium text-[#161823]">
-          Attempt History
-        </div>
-        <Table<WorkflowAttempt>
-          rowKey="id"
-          size="small"
-          pagination={false}
-          dataSource={record.attempts}
-          columns={attemptColumns}
-          scroll={{ x: 780 }}
-        />
-      </div>
-    </div>
-  );
-
-  const canRetryFailed = Boolean(
-    detail &&
-    isWorkflowTerminal(detail.status) &&
-    detail.status !== 'SUCCESS' &&
-    detail.nodes.some((node) =>
-      node.status === 'FAILED' ||
-      node.status === 'UPSTREAM_FAILED' ||
-      node.status === 'CANCELED',
-    ),
-  );
+      ),
+    },
+    { title: '开始时间', dataIndex: 'startedAt', width: 170, render: formatTime },
+    { title: '结束时间', dataIndex: 'endedAt', width: 170, render: formatTime },
+    {
+      title: '操作', width: 88, fixed: 'right',
+      render: (_: unknown, record) => <Button type="link" size="small" className="!px-0 !text-[12px]" onClick={() => openDetail(record)}>运维</Button>,
+    },
+  ], []);
 
   return (
-    <ConfigProvider
-      theme={{
-        token: {
-          borderRadius: 10,
-          colorBorder: '#f0f0f0',
-          colorBgContainer: '#ffffff',
-        },
-        components: {
-          Button: {
-            borderRadius: 8,
-          },
-          Input: {
-            activeShadow: 'none',
-          },
-          Select: {
-            activeOutlineColor: 'transparent',
-          },
-        },
-      }}
-    >
-      <div className="flex min-h-[calc(100vh-64px)] flex-col bg-white px-5 pt-4">
-        <h1 className="m-0 text-[17px] font-semibold text-[#161823]">
-          工作流实例
-        </h1>
-
-        <div className="mx-auto flex w-full max-w-full flex-1 flex-col">
-          <div className="mb-3">
-            <div className="border-b border-[#f0f0f0]">
-              <div className="flex min-h-[54px] items-center justify-between gap-4 py-2">
-                <div className="flex shrink-0 items-center gap-1 rounded-lg bg-[#f5f5f6] p-1">
-                  {statusTabs.map((item) => {
-                    const active = statusGroup === item.value;
-                    return (
-                      <button
-                        key={item.value}
-                        type="button"
-                        onClick={() => handleStatusChange(item.value)}
-                        className={[
-                          'h-8 rounded-md px-3.5 text-[13px] font-medium transition-all',
-                          active
-                            ? 'bg-white text-[#ff4d4f] shadow-[0_1px_4px_rgba(16,24,40,0.08)]'
-                            : 'text-[#667085] hover:bg-white/70 hover:text-[#344054]',
-                        ].join(' ')}
-                      >
-                        {item.label}
-                      </button>
-                    );
-                  })}
-                </div>
-
-                <div className="flex min-w-0 flex-1 items-center justify-end gap-2 overflow-x-auto">
-                  <Input
-                    allowClear
-                    variant="filled"
-                    value={filterDraft.keyword}
-                    prefix={<SearchOutlined className="text-[#98a2b3]" />}
-                    placeholder="搜索工作流名称 / 实例 ID"
-                    className="!h-9 !w-[260px] !min-w-[220px]"
-                    onChange={(event) =>
-                      updateFilterDraft(
-                        'keyword',
-                        event.target.value || undefined,
-                      )
-                    }
-                    onPressEnter={handleSearch}
-                  />
-
-                  <RangePicker
-                    allowClear
-                    variant="filled"
-                    value={filterDraft.startedAt as any}
-                    format="YYYY-MM-DD"
-                    placeholder={['开始日期', '结束日期']}
-                    className="!h-9 !w-[250px] !min-w-[230px]"
-                    onChange={(value) => {
-                      const nextFilters = {
-                        ...filterDraft,
-                        startedAt: value
-                          ? (value as unknown as Dayjs[])
-                          : undefined,
-                      };
-                      applyFilters(nextFilters);
-                    }}
-                  />
-
-                  <Button
-                    size="small"
-                    className="!h-9 !px-4"
-                    onClick={handleSearch}
-                  >
-                    查询
-                  </Button>
-
-                  <Popover
-                    trigger="click"
-                    placement="bottomRight"
-                    open={advancedOpen}
-                    onOpenChange={setAdvancedOpen}
-                    content={
-                      <div className="w-[430px]">
-                        <div className="mb-4">
-                          <div className="text-[14px] font-semibold text-[#101828]">
-                            高级搜索
-                          </div>
-                          <div className="mt-1 text-[12px] text-[#98a2b3]">
-                            按实例标识、工作流定义和运行类型进一步筛选
-                          </div>
-                        </div>
-
-                        <div className="grid grid-cols-2 gap-x-3 gap-y-4">
-                          <div>
-                            <div className="mb-1.5 text-[12px] text-[#667085]">
-                              实例 ID
-                            </div>
-                            <Input
-                              allowClear
-                              variant="filled"
-                              value={filterDraft.instanceId}
-                              placeholder="请输入实例 ID"
-                              onChange={(event) =>
-                                updateFilterDraft(
-                                  'instanceId',
-                                  event.target.value || undefined,
-                                )
-                              }
-                              onPressEnter={() => {
-                                handleSearch();
-                                setAdvancedOpen(false);
-                              }}
-                            />
-                          </div>
-
-                          <div>
-                            <div className="mb-1.5 text-[12px] text-[#667085]">
-                              工作流定义 ID
-                            </div>
-                            <Input
-                              allowClear
-                              variant="filled"
-                              value={filterDraft.definitionId}
-                              placeholder="请输入工作流定义 ID"
-                              onChange={(event) =>
-                                updateFilterDraft(
-                                  'definitionId',
-                                  event.target.value || undefined,
-                                )
-                              }
-                              onPressEnter={() => {
-                                handleSearch();
-                                setAdvancedOpen(false);
-                              }}
-                            />
-                          </div>
-
-                          <div>
-                            <div className="mb-1.5 text-[12px] text-[#667085]">
-                              运行类型
-                            </div>
-                            <Select
-                              allowClear
-                              variant="filled"
-                              value={filterDraft.testRun}
-                              placeholder="全部运行"
-                              className="w-full"
-                              options={[
-                                { label: '正式运行', value: 'false' },
-                                { label: '测试运行', value: 'true' },
-                              ]}
-                              onChange={(value) =>
-                                updateFilterDraft('testRun', value)
-                              }
-                            />
-                          </div>
-                        </div>
-
-                        <div className="mt-5 flex items-center justify-end gap-2 border-t border-[#f0f0f0] pt-4">
-                          <Button
-                            size="small"
-                            className="!h-8"
-                            onClick={handleAdvancedReset}
-                          >
-                            重置
-                          </Button>
-                          <Button
-                            danger
-                            type="primary"
-                            size="small"
-                            className="!h-8"
-                            onClick={() => {
-                              handleSearch();
-                              setAdvancedOpen(false);
-                            }}
-                          >
-                            应用筛选
-                          </Button>
-                        </div>
-                      </div>
-                    }
-                  >
-                    <Button
-                      size="small"
-                      icon={<FilterOutlined />}
-                      className={[
-                        '!h-9 !px-3',
-                        advancedFilterCount > 0
-                          ? '!border-[#ffccc7] !bg-[#fff1f0] !text-[#ff4d4f]'
-                          : '',
-                      ].join(' ')}
-                    >
-                      高级搜索
-                      {advancedFilterCount > 0 && (
-                        <span className="ml-1.5 inline-flex h-[18px] min-w-[18px] items-center justify-center rounded-full bg-[#ff4d4f] px-1 text-[10px] leading-[18px] text-white">
-                          {advancedFilterCount}
-                        </span>
-                      )}
-                    </Button>
-                  </Popover>
-                </div>
-              </div>
-            </div>
-
-            <div className="flex min-h-[48px] items-center justify-between">
-              <div className="text-[12px] text-[#98a2b3]">
-                当前筛选结果 {filteredInstances.length} 条
-              </div>
-              <Button
-                size="small"
-                icon={<ReloadOutlined spin={loading} />}
-                className="!h-8"
-                loading={loading}
-                onClick={() => void loadInstances(true)}
-              >
-                刷新
+    <ConfigProvider theme={{ token: { borderRadius: 9, colorBorder: '#eaecf0' }, components: { Input: { activeShadow: 'none' } } }}>
+      <div className="flex min-h-[calc(100vh-64px)] flex-col bg-white px-5 pt-4 text-[#161823]">
+        <div className="flex items-start justify-between">
+          <div>
+            <h1 className="m-0 text-[17px] font-semibold leading-8">工作流实例</h1>
+            <div className="text-[11px] text-[#98a2b3]">运行实例 DAG、失败恢复、节点重跑与 businessDate 运维补跑</div>
+          </div>
+          <div className="flex items-center gap-2">
+            {selectedKeys.length > 0 ? (
+              <Button icon={<RefreshCw size={13} />} loading={batchLoading} onClick={() => void batchRetry()}>
+                批量重试失败实例（{selectedKeys.length}）
               </Button>
-            </div>
-
-            <div className="flex min-h-9 items-center rounded-sm bg-[#fff7e6] px-3 text-[12px] text-[#475467]">
-              <span className="mr-2 text-[14px] text-[#faad14]">▲</span>
-              <span className="font-medium text-[#344054]">【提示】</span>
-              <span>
-                运行中的实例会自动刷新；进入详情后可执行暂停、恢复、取消、重试和重跑等操作。
-              </span>
-            </div>
+            ) : null}
+            <Button icon={<ReloadOutlined spin={loading} />} loading={loading} onClick={() => void load(true)}>刷新</Button>
           </div>
+        </div>
 
-          <Divider style={{ marginTop: 4, marginBottom: 16 }} />
-
-          <div className="flex-1">
-            <Table<WorkflowInstance>
-              rowKey="id"
-              bordered
-              size="small"
-              pagination={false}
-              loading={loading}
-              dataSource={pageInstances}
-              columns={columns}
-              scroll={{ x: 'max-content' }}
-              className={[
-                'compact-workflow-instance-table',
-                '[&_.ant-table]:!text-[13px]',
-                '[&_.ant-table-container]:!border-[#eaecf0]',
-                '[&_.ant-table-cell]:!align-middle',
-                '[&_.ant-table-thead>tr>th]:!h-10',
-                '[&_.ant-table-thead>tr>th]:!bg-[#f8f9fb]',
-                '[&_.ant-table-thead>tr>th]:!px-4',
-                '[&_.ant-table-thead>tr>th]:!py-2',
-                '[&_.ant-table-thead>tr>th]:!text-[12px]',
-                '[&_.ant-table-thead>tr>th]:!font-medium',
-                '[&_.ant-table-thead>tr>th]:!text-[#667085]',
-                '[&_.ant-table-thead>tr>th]:!border-[#eaecf0]',
-                '[&_.ant-table-tbody>tr>td]:!px-4',
-                '[&_.ant-table-tbody>tr>td]:!py-2.5',
-                '[&_.ant-table-tbody>tr>td]:!border-[#f0f2f5]',
-                '[&_.ant-table-tbody>tr>td]:!text-[#667085]',
-                '[&_.ant-table-tbody>tr:hover>td]:!bg-[#fafbfc]',
-                '[&_.ant-table-cell-fix-right]:!bg-white',
-                '[&_.ant-table-tbody>tr:hover_.ant-table-cell-fix-right]:!bg-[#fafbfc]',
-                '[&_.ant-table-placeholder>td]:!h-[240px]',
-              ].join(' ')}
-              locale={{
-                emptyText: (
-                  <Empty
-                    image={Empty.PRESENTED_IMAGE_SIMPLE}
-                    description={
-                      <span className="text-[12px] text-[#98a2b3]">
-                        暂无工作流实例
-                      </span>
-                    }
-                  />
-                ),
-              }}
+        <div className="mt-4 flex min-h-[52px] items-center justify-between gap-3 border-y border-[#f0f0f0]">
+          <div className="flex shrink-0 items-center gap-1 rounded-lg bg-[#f5f5f6] p-1">
+            {statusTabs.map((item) => (
+              <button
+                key={item.value}
+                type="button"
+                onClick={() => { setStatusGroup(item.value); setPage(1); setSelectedKeys([]); }}
+                className={`h-8 rounded-md px-3.5 text-[13px] font-medium ${statusGroup === item.value ? 'bg-white text-[#ff4d4f] shadow-[0_1px_4px_rgba(16,24,40,.08)]' : 'text-[#667085] hover:bg-white/70'}`}
+              >
+                {item.label}
+              </button>
+            ))}
+          </div>
+          <div className="flex items-center gap-2">
+            <Input
+              allowClear
+              variant="filled"
+              prefix={<SearchOutlined className="text-[#98a2b3]" />}
+              placeholder="名称 / 实例 ID / businessDate"
+              className="!w-[280px]"
+              value={keyword}
+              onChange={(event) => { setKeyword(event.target.value); setPage(1); }}
             />
-          </div>
-
-          <div className="sticky bottom-0 z-20 mt-auto flex min-h-[56px] items-center justify-end border border-t-0 border-[#e5e7eb] bg-white px-5 py-3 shadow-[0_-4px_12px_rgba(16,24,40,0.04)]">
-            <ListPagination
-              total={filteredInstances.length}
-              current={pagination.current}
-              pageSize={pagination.pageSize}
-              onChange={(current, pageSize) =>
-                setPagination({ current, pageSize })
-              }
+            <RangePicker
+              allowClear
+              variant="filled"
+              value={dateRange as any}
+              onChange={(value) => { setDateRange(value ? value as unknown as Dayjs[] : undefined); setPage(1); }}
             />
           </div>
         </div>
 
-        <Drawer
-          title={detail ? `${detail.name} · 实例详情` : '实例详情'}
-          width={980}
-          open={detailOpen}
-          loading={detailLoading}
-          onClose={closeDetail}
-          extra={detail ? (
-            <div className="flex items-center gap-2">
-              {detail.status === 'RUNNING' ? (
-                <Button
-                  size="small"
-                  icon={<Pause size={13} />}
-                  loading={actionLoading === 'pause'}
-                  onClick={() => void runAction(
-                    'pause',
-                    () => pauseWorkflowInstance(detail.id),
-                    '已请求暂停工作流',
-                  )}
-                >
-                  暂停
-                </Button>
-              ) : null}
-              {detail.status === 'PAUSED' ? (
-                <Button
-                  size="small"
-                  icon={<Play size={13} />}
-                  loading={actionLoading === 'resume'}
-                  onClick={() => void runAction(
-                    'resume',
-                    () => resumeWorkflowInstance(detail.id),
-                    '已请求恢复工作流',
-                  )}
-                >
-                  恢复
-                </Button>
-              ) : null}
-              {!isWorkflowTerminal(detail.status) ? (
-                <Popconfirm
-                  title="取消当前工作流？"
-                  onConfirm={() => void runAction(
-                    'cancel',
-                    () => cancelWorkflowInstance(detail.id),
-                    '工作流已取消',
-                  )}
-                >
-                  <Button
-                    size="small"
-                    danger
-                    icon={<Square size={12} />}
-                    loading={actionLoading === 'cancel'}
-                  >
-                    取消
-                  </Button>
-                </Popconfirm>
-              ) : null}
-              {canRetryFailed ? (
-                <Button
-                  size="small"
-                  icon={<RefreshCw size={12} />}
-                  loading={actionLoading === 'retryFailed'}
-                  onClick={() => void runAction(
-                    'retryFailed',
-                    () => retryWorkflowFailedNodes(detail.id),
-                    '已重新调度失败/阻断节点',
-                  )}
-                >
-                  重试失败节点
-                </Button>
-              ) : null}
-              {isWorkflowTerminal(detail.status) ? (
-                <Button
-                  size="small"
-                  icon={<RotateCcw size={12} />}
-                  loading={actionLoading === 'restart'}
-                  onClick={() => void (async () => {
-                    if (actionLoading) return;
-                    setActionLoading('restart');
-                    try {
-                      const prepared = await restartWorkflowInstance(detail.id);
-                      await activateNewExecution(
-                        prepared,
-                        '已创建并启动新的完整运行实例',
-                      );
-                    } catch (error) {
-                      message.error(
-                        error instanceof Error ? error.message : '整体重跑失败',
-                      );
-                    } finally {
-                      setActionLoading(undefined);
-                    }
-                  })()}
-                >
-                  整体重跑
-                </Button>
-              ) : null}
-            </div>
-          ) : null}
-        >
-          {detail ? (
-            <>
-              <div className="mb-4 grid grid-cols-3 gap-x-8 gap-y-3 text-[12px]">
-                <div className="col-span-2">
-                  <span className="text-[rgba(22,24,35,.45)]">实例 ID：</span>
-                  <span className="font-mono text-[#161823]">{detail.id}</span>
-                </div>
-                <div>
-                  <span className="text-[rgba(22,24,35,.45)]">状态：</span>
-                  <span className={statusClassName(detail.status)}>
-                    {statusLabel[detail.status] || detail.status}
-                  </span>
-                </div>
-                <div>
-                  <span className="text-[rgba(22,24,35,.45)]">创建：</span>
-                  <span>{formatTime(detail.startedAt)}</span>
-                </div>
-                <div>
-                  <span className="text-[rgba(22,24,35,.45)]">
-                    当前运行段：
-                  </span>
-                  <span>{formatTime(detail.runStartedAt)}</span>
-                </div>
-                <div>
-                  <span className="text-[rgba(22,24,35,.45)]">结束：</span>
-                  <span>{formatTime(detail.endedAt)}</span>
-                </div>
-                <div>
-                  <span className="text-[rgba(22,24,35,.45)]">
-                    工作流超时：
-                  </span>
-                  <span>
-                    {detail.workflowTimeoutSeconds > 0
-                      ? `${detail.workflowTimeoutSeconds}s`
-                      : '-'}
-                  </span>
-                </div>
-                {detail.sourceExecutionId ? (
-                  <div className="col-span-2">
-                    <span className="text-[rgba(22,24,35,.45)]">
-                      来源实例：
-                    </span>
-                    <span className="font-mono text-[rgba(22,24,35,.68)]">
-                      {detail.sourceExecutionId}
-                    </span>
-                  </div>
-                ) : null}
-              </div>
+        <div className="mt-3 flex min-h-9 items-center rounded-sm bg-[#f8f9fb] px-3 text-[12px] text-[#475467]">
+          <span><b>【实例运维】</b> 单节点 Retry 在原实例恢复；“从此节点重跑”创建新实例并复用成功祖先结果；指定 businessDate 重跑固定来源发布版本。</span>
+        </div>
 
-              <div className="mb-4">
-                <div className="mb-1.5 text-[11px] font-medium text-[#161823]">
-                  Workflow Input
-                </div>
-                <JsonBlock value={detail.input} />
-              </div>
+        <div className="mt-4 flex-1">
+          <Table<WorkflowInstance>
+            rowKey="id"
+            bordered
+            size="small"
+            pagination={false}
+            loading={loading}
+            dataSource={pageData}
+            columns={columns}
+            rowSelection={{
+              selectedRowKeys: selectedKeys,
+              onChange: setSelectedKeys,
+              getCheckboxProps: (record) => ({
+                disabled: !isRetryableInstance(record),
+                title: isRetryableInstance(record) ? '加入批量失败恢复' : '当前实例没有可批量恢复的失败/阻断节点',
+              }),
+            }}
+            scroll={{ x: 1260 }}
+            locale={{ emptyText: <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="暂无工作流实例" /> }}
+            className="[&_.ant-table-thead>tr>th]:!bg-[#f8f9fb] [&_.ant-table-thead>tr>th]:!text-[12px] [&_.ant-table-thead>tr>th]:!text-[#667085] [&_.ant-table-tbody>tr>td]:!py-2.5"
+          />
+        </div>
 
-              <Table<WorkflowNodeInstance>
-                rowKey="id"
-                size="small"
-                pagination={false}
-                dataSource={detail.nodes}
-                columns={nodeColumns}
-                scroll={{ x: 760 }}
-                expandable={{
-                  expandedRowRender: renderNodeDetail,
-                  rowExpandable: () => true,
-                }}
-              />
-            </>
-          ) : null}
-        </Drawer>
+        <div className="mt-auto flex min-h-[56px] items-center justify-between border-t border-[#eaecf0] bg-white py-3">
+          <div className="text-[12px] text-[#98a2b3]">当前筛选 {filtered.length} 条 · 可批量恢复 {filtered.filter(isRetryableInstance).length} 条</div>
+          <div className="flex items-center gap-3">
+            <Pagination size="small" total={filtered.length} current={page} pageSize={pageSize} showSizeChanger={false} onChange={setPage} />
+            <Select size="small" value={pageSize} className="w-[78px]" onChange={(value) => { setPageSize(value); setPage(1); }} options={[10, 20, 50].map((value) => ({ value, label: `${value} / 页` }))} />
+          </div>
+        </div>
+
+        <InstanceDetailDrawer
+          open={Boolean(detailId)}
+          executionId={detailId}
+          initial={detailInitial}
+          onClose={() => { setDetailId(undefined); setDetailInitial(undefined); }}
+          onChanged={handleSnapshot}
+        />
       </div>
     </ConfigProvider>
   );

--- a/yak-ops-ui/src/pages/workflow/instances/index.tsx
+++ b/yak-ops-ui/src/pages/workflow/instances/index.tsx
@@ -17,6 +17,7 @@ import {
   Input,
   Modal,
   Pagination,
+  Popover,
   Select,
   Table,
   Tooltip,
@@ -25,8 +26,8 @@ import {
 import type { ColumnsType } from 'antd/es/table';
 import type { Dayjs } from 'dayjs';
 import dayjs from 'dayjs';
-import { RefreshCw } from 'lucide-react';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { RefreshCw, SlidersHorizontal } from 'lucide-react';
+import { useCallback, useEffect, useMemo, useState, type Key } from 'react';
 import InstanceDetailDrawer from './InstanceDetailDrawer';
 
 const { RangePicker } = DatePicker;
@@ -51,6 +52,7 @@ const FAILED_STATUSES = new Set(['FAILED', 'TIMED_OUT']);
 const RETRYABLE_NODE_STATUSES = new Set(['FAILED', 'UPSTREAM_FAILED', 'SKIPPED', 'CANCELED']);
 
 type StatusGroup = 'ALL' | 'RUNNING' | 'COMPLETED' | 'FAILED';
+type TestRunFilter = 'ALL' | 'TRUE' | 'FALSE';
 
 const statusTabs: Array<{ label: string; value: StatusGroup }> = [
   { label: '全部实例', value: 'ALL' },
@@ -87,9 +89,12 @@ const WorkflowInstancesPage = () => {
   const [statusGroup, setStatusGroup] = useState<StatusGroup>('ALL');
   const [keyword, setKeyword] = useState('');
   const [dateRange, setDateRange] = useState<Dayjs[]>();
+  const [instanceIdFilter, setInstanceIdFilter] = useState('');
+  const [definitionIdFilter, setDefinitionIdFilter] = useState('');
+  const [testRunFilter, setTestRunFilter] = useState<TestRunFilter>('ALL');
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState(10);
-  const [selectedKeys, setSelectedKeys] = useState<React.Key[]>([]);
+  const [selectedKeys, setSelectedKeys] = useState<Key[]>([]);
   const [detailId, setDetailId] = useState<string>();
   const [detailInitial, setDetailInitial] = useState<WorkflowInstance>();
   const [batchLoading, setBatchLoading] = useState(false);
@@ -120,16 +125,22 @@ const WorkflowInstancesPage = () => {
 
   const filtered = useMemo(() => {
     const q = keyword.trim().toLowerCase();
+    const instanceId = instanceIdFilter.trim().toLowerCase();
+    const definitionId = definitionIdFilter.trim().toLowerCase();
     const [start, end] = dateRange || [];
     return instances.filter((record) => {
       if (!matchesGroup(record.status)) return false;
       if (q && ![record.name, record.id, record.definitionId, String(record.input?.businessDate || '')]
         .some((value) => value?.toLowerCase().includes(q))) return false;
+      if (instanceId && !record.id.toLowerCase().includes(instanceId)) return false;
+      if (definitionId && !record.definitionId?.toLowerCase().includes(definitionId)) return false;
+      if (testRunFilter === 'TRUE' && !record.testRun) return false;
+      if (testRunFilter === 'FALSE' && record.testRun) return false;
       if (start && dayjs(record.startedAt).isBefore(start.startOf('day'))) return false;
       if (end && dayjs(record.startedAt).isAfter(end.endOf('day'))) return false;
       return true;
     });
-  }, [dateRange, instances, keyword, statusGroup]);
+  }, [dateRange, definitionIdFilter, instanceIdFilter, instances, keyword, statusGroup, testRunFilter]);
 
   useEffect(() => {
     const maxPage = Math.max(1, Math.ceil(filtered.length / pageSize));
@@ -140,6 +151,19 @@ const WorkflowInstancesPage = () => {
     const offset = (page - 1) * pageSize;
     return filtered.slice(offset, offset + pageSize);
   }, [filtered, page, pageSize]);
+
+  const advancedFilterCount = [
+    instanceIdFilter.trim(),
+    definitionIdFilter.trim(),
+    testRunFilter === 'ALL' ? '' : testRunFilter,
+  ].filter(Boolean).length;
+
+  const resetAdvancedFilters = () => {
+    setInstanceIdFilter('');
+    setDefinitionIdFilter('');
+    setTestRunFilter('ALL');
+    setPage(1);
+  };
 
   const openDetail = (record: WorkflowInstance) => {
     setDetailInitial(record);
@@ -182,7 +206,7 @@ const WorkflowInstancesPage = () => {
           title: `批量重试完成：成功 ${result.acceptedCount}，失败 ${result.failedCount}`,
           width: 680,
           content: (
-            <div className="mt-3 max-h-[320px] overflow-auto space-y-2">
+            <div className="mt-3 max-h-[320px] space-y-2 overflow-auto">
               {result.items.filter((item) => !item.accepted).map((item) => (
                 <div key={item.executionId} className="rounded-md border border-[#fecdca] bg-[#fff6f5] px-3 py-2 text-[12px]">
                   <div className="font-mono text-[#b42318]">{item.executionId}</div>
@@ -251,6 +275,36 @@ const WorkflowInstancesPage = () => {
     },
   ], []);
 
+  const advancedFilters = (
+    <div className="w-[310px] space-y-3">
+      <div>
+        <div className="mb-1 text-[11px] text-[#667085]">实例 ID</div>
+        <Input allowClear size="small" value={instanceIdFilter} onChange={(event) => { setInstanceIdFilter(event.target.value); setPage(1); }} placeholder="精确定位运行实例" />
+      </div>
+      <div>
+        <div className="mb-1 text-[11px] text-[#667085]">Definition ID</div>
+        <Input allowClear size="small" value={definitionIdFilter} onChange={(event) => { setDefinitionIdFilter(event.target.value); setPage(1); }} placeholder="Workflow Version / Runtime Definition" />
+      </div>
+      <div>
+        <div className="mb-1 text-[11px] text-[#667085]">运行类型</div>
+        <Select
+          size="small"
+          className="w-full"
+          value={testRunFilter}
+          onChange={(value) => { setTestRunFilter(value); setPage(1); }}
+          options={[
+            { value: 'ALL', label: '全部' },
+            { value: 'FALSE', label: '正式运行' },
+            { value: 'TRUE', label: '测试运行' },
+          ]}
+        />
+      </div>
+      <div className="flex justify-end border-t border-[#f0f0f0] pt-2">
+        <Button size="small" disabled={advancedFilterCount === 0} onClick={resetAdvancedFilters}>重置</Button>
+      </div>
+    </div>
+  );
+
   return (
     <ConfigProvider theme={{ token: { borderRadius: 9, colorBorder: '#eaecf0' }, components: { Input: { activeShadow: 'none' } } }}>
       <div className="flex min-h-[calc(100vh-64px)] flex-col bg-white px-5 pt-4 text-[#161823]">
@@ -288,7 +342,7 @@ const WorkflowInstancesPage = () => {
               variant="filled"
               prefix={<SearchOutlined className="text-[#98a2b3]" />}
               placeholder="名称 / 实例 ID / businessDate"
-              className="!w-[280px]"
+              className="!w-[260px]"
               value={keyword}
               onChange={(event) => { setKeyword(event.target.value); setPage(1); }}
             />
@@ -298,6 +352,11 @@ const WorkflowInstancesPage = () => {
               value={dateRange as any}
               onChange={(value) => { setDateRange(value ? value as unknown as Dayjs[] : undefined); setPage(1); }}
             />
+            <Popover placement="bottomRight" trigger="click" content={advancedFilters}>
+              <Button icon={<SlidersHorizontal size={13} />}>
+                高级筛选{advancedFilterCount > 0 ? ` · ${advancedFilterCount}` : ''}
+              </Button>
+            </Popover>
           </div>
         </div>
 

--- a/yak-ops-ui/src/pages/workflow/schedules/BackfillHistoryDrawer.tsx
+++ b/yak-ops-ui/src/pages/workflow/schedules/BackfillHistoryDrawer.tsx
@@ -26,6 +26,11 @@ const STATUS_LABEL: Record<WorkflowBackfillStatus, string> = {
   CANCELED: '已取消',
 };
 
+const OPERATION_LABEL: Record<string, string> = {
+  BACKFILL: '历史补数',
+  BUSINESS_DATE_RERUN: '实例运维补跑',
+};
+
 const formatTime = (value?: string) => {
   if (!value) return '-';
   const date = new Date(value);
@@ -49,7 +54,7 @@ const BackfillHistoryDrawer = ({
     try {
       setRecords(await listWorkflowBackfills({ workflowId, scheduleId, status }));
     } catch (error) {
-      message.error(error instanceof Error ? error.message : '补数批次加载失败');
+      message.error(error instanceof Error ? error.message : '补数/补跑批次加载失败');
     } finally {
       setLoading(false);
     }
@@ -62,18 +67,18 @@ const BackfillHistoryDrawer = ({
   const cancel = (record: WorkflowBackfill) => {
     Modal.confirm({
       centered: true,
-      title: '确认取消补数批次吗？',
-      content: '尚未启动的补数实例会被标记为已跳过；已经运行中的 WorkflowExecution 会继续完成。',
-      okText: '取消补数',
+      title: '确认取消批次吗？',
+      content: '尚未启动的计划会被标记为已跳过；已经运行中的 WorkflowExecution 会继续完成。',
+      okText: '取消批次',
       cancelText: '关闭',
       okButtonProps: { danger: true },
       async onOk() {
         try {
           await cancelWorkflowBackfill(record.id);
-          message.success('补数批次已取消');
+          message.success('批次已取消');
           await load();
         } catch (error) {
-          message.error(error instanceof Error ? error.message : '取消补数失败');
+          message.error(error instanceof Error ? error.message : '取消批次失败');
         }
       },
     });
@@ -82,15 +87,15 @@ const BackfillHistoryDrawer = ({
   return (
     <Drawer
       open={open}
-      width={1160}
+      width={1240}
       destroyOnClose
       title={
         <div>
           <div className="flex items-center gap-2 text-[14px] font-semibold text-[#344054]">
-            <History size={15} /> 补数记录
+            <History size={15} /> 补数 / 运维补跑记录
           </div>
           <div className="mt-0.5 text-[11px] font-normal text-[#98a2b3]">
-            Backfill 批次、固定工作流版本与 Trigger Ledger 运行进度
+            Backfill 与指定 businessDate 重跑共享 Trigger Ledger，但保留独立 operationType 和来源实例血缘
           </div>
         </div>
       }
@@ -115,18 +120,35 @@ const BackfillHistoryDrawer = ({
         bordered
         loading={loading}
         dataSource={records}
-        scroll={{ x: 1500 }}
+        scroll={{ x: 1710 }}
         pagination={{ pageSize: 15, showSizeChanger: false, showTotal: (total) => `共 ${total} 个批次` }}
         columns={[
           {
-            title: '补数批次',
+            title: '批次',
             dataIndex: 'name',
-            width: 220,
+            width: 235,
             fixed: 'left',
             render: (value: string, record: WorkflowBackfill) => (
               <div>
                 <div className="font-medium text-[#344054]">{value}</div>
                 <div className="mt-1 text-[10px] text-[#98a2b3]">{record.id}</div>
+              </div>
+            ),
+          },
+          {
+            title: '类型 / 来源',
+            width: 215,
+            render: (_: unknown, record: WorkflowBackfill) => (
+              <div>
+                <div className="text-[12px] font-medium text-[#475467]">
+                  {OPERATION_LABEL[record.operationType] || record.operationType}
+                </div>
+                <div
+                  className="mt-1 max-w-[190px] truncate font-mono text-[10px] text-[#98a2b3]"
+                  title={record.sourceExecutionId}
+                >
+                  {record.sourceExecutionId ? `source: ${record.sourceExecutionId}` : '普通 Backfill'}
+                </div>
               </div>
             ),
           },

--- a/yak-ops-ui/src/pages/workflow/schedules/TriggerLedgerDrawer.tsx
+++ b/yak-ops-ui/src/pages/workflow/schedules/TriggerLedgerDrawer.tsx
@@ -32,6 +32,7 @@ const SOURCE_LABEL: Record<string, string> = {
   MANUAL: '手动触发',
   MISFIRE_RECOVERY: 'Misfire 恢复',
   BACKFILL: 'Backfill',
+  BUSINESS_DATE_RERUN: 'businessDate 补跑',
 };
 
 const formatTime = (value?: string) => {
@@ -83,10 +84,10 @@ const TriggerLedgerDrawer = ({
       title={
         <div>
           <div className="text-[14px] font-semibold text-[#344054]">
-            {backfillId ? 'Backfill Trigger 明细' : 'Trigger 记录'}
+            {backfillId ? '补数 / 运维补跑 Trigger 明细' : 'Trigger 记录'}
           </div>
           <div className="mt-0.5 text-[11px] font-normal text-[#98a2b3]">
-            {backfillName || schedule?.name || '-'} · {backfillId ? '按补数批次隔离幂等' : '每个正常计划时间最多产生一条 Ledger 记录'}
+            {backfillName || schedule?.name || '-'} · {backfillId ? '按批次隔离幂等' : '每个正常计划时间最多产生一条 Ledger 记录'}
           </div>
         </div>
       }
@@ -108,7 +109,7 @@ const TriggerLedgerDrawer = ({
     >
       <div className="mb-3 rounded-sm bg-[#f8f9fb] px-3 py-2 text-[11px] leading-5 text-[#667085]">
         {backfillId
-          ? 'Backfill 的 businessDate / scheduleTime 来自历史逻辑计划时间；不同 Backfill 批次可重新执行同一天，同一批次仍由 dedupeKey 保证幂等。'
+          ? 'Backfill / businessDate 运维补跑都使用逻辑计划时间；不同批次可重新执行同一天，同一批次仍由 dedupeKey 保证幂等。'
           : 'SERIAL_WAIT 会先进入 WAITING，前序 WorkflowExecution 终态提交后自动推进；SERIAL_DISCARD 会记为 SKIPPED；Misfire 同样保留审计记录。'}
       </div>
       <Table
@@ -150,7 +151,7 @@ const TriggerLedgerDrawer = ({
           {
             title: '来源',
             dataIndex: 'triggerSource',
-            width: 105,
+            width: 135,
             render: (value: string) => (
               <span className="text-[12px] text-[#667085]">{SOURCE_LABEL[value] || value}</span>
             ),

--- a/yak-ops-ui/src/services/workflow/index.ts
+++ b/yak-ops-ui/src/services/workflow/index.ts
@@ -1,6 +1,10 @@
 import type { ApiResponse } from '@/services/http/response';
 import { listTaskCatalogAssets } from '@/services/taskCatalog';
 import { request } from '@umijs/max';
+import type {
+  WorkflowBackfill,
+  WorkflowBackfillExecutionStrategy,
+} from './schedules';
 
 export type WorkflowFailureStrategy =
   | 'FAIL_FAST'
@@ -110,6 +114,48 @@ export interface WorkflowInstance {
   testRun: boolean;
 }
 
+export interface WorkflowInstanceEdge {
+  source: string;
+  target: string;
+}
+
+export interface WorkflowInstanceOperations {
+  executionId: string;
+  workflowId?: string;
+  triggerType?: string;
+  triggerId?: string;
+  scheduleId?: string;
+  backfillId?: string;
+  businessDate?: string;
+  scheduleTime?: string;
+  scheduleTimezone?: string;
+  plannedFireTime?: string;
+  cronExpression?: string;
+  businessDateRerunSupported: boolean;
+  businessDateRerunUnavailableReason?: string;
+  edges: WorkflowInstanceEdge[];
+}
+
+export interface WorkflowBusinessDateRerunPayload {
+  businessDate: string;
+  executionStrategy: WorkflowBackfillExecutionStrategy;
+  input: Record<string, unknown>;
+}
+
+export interface WorkflowBatchRetryItem {
+  executionId: string;
+  accepted: boolean;
+  status?: string;
+  message?: string;
+}
+
+export interface WorkflowBatchRetryResult {
+  requestedCount: number;
+  acceptedCount: number;
+  failedCount: number;
+  items: WorkflowBatchRetryItem[];
+}
+
 interface WorkflowEventSubscription {
   onSnapshot: (instance: WorkflowInstance) => void;
   lastSignature: string;
@@ -195,6 +241,32 @@ export const rerunWorkflowFromNode = async (executionId: string, nodeId: string)
   const response = await request<ApiResponse<WorkflowInstance>>(
     `/api/v1/workflows/instances/${encodeURIComponent(executionId)}/nodes/${encodeURIComponent(nodeId)}/rerun`,
     { method: 'POST' },
+  );
+  return response.data;
+};
+
+export const getWorkflowInstanceOperations = async (executionId: string) => {
+  const response = await request<ApiResponse<WorkflowInstanceOperations>>(
+    `/api/v1/workflows/instances/${encodeURIComponent(executionId)}/operations`,
+  );
+  return response.data;
+};
+
+export const rerunWorkflowBusinessDate = async (
+  executionId: string,
+  payload: WorkflowBusinessDateRerunPayload,
+) => {
+  const response = await request<ApiResponse<WorkflowBackfill>>(
+    `/api/v1/workflows/instances/${encodeURIComponent(executionId)}/rerun-business-date`,
+    { method: 'POST', data: payload },
+  );
+  return response.data;
+};
+
+export const batchRetryWorkflowInstances = async (executionIds: string[]) => {
+  const response = await request<ApiResponse<WorkflowBatchRetryResult>>(
+    '/api/v1/workflows/instances/batch-retry-failed',
+    { method: 'POST', data: { executionIds } },
   );
   return response.data;
 };

--- a/yak-ops-ui/src/services/workflow/schedules.ts
+++ b/yak-ops-ui/src/services/workflow/schedules.ts
@@ -24,6 +24,7 @@ export type WorkflowBackfillStatus =
   | 'FAILED'
   | 'CANCELED';
 export type WorkflowBackfillExecutionStrategy = 'SERIAL_WAIT' | 'PARALLEL';
+export type WorkflowBackfillOperationType = 'BACKFILL' | 'BUSINESS_DATE_RERUN';
 
 export interface WorkflowSchedule {
   id: string;
@@ -50,7 +51,13 @@ export interface WorkflowScheduleTrigger {
   workflowId: string;
   backfillId?: string;
   triggerId: string;
-  triggerSource: 'CRON' | 'MANUAL' | 'MISFIRE_RECOVERY' | 'BACKFILL' | string;
+  triggerSource:
+    | 'CRON'
+    | 'MANUAL'
+    | 'MISFIRE_RECOVERY'
+    | 'BACKFILL'
+    | 'BUSINESS_DATE_RERUN'
+    | string;
   businessDate?: string;
   plannedFireTime: string;
   actualFireTime: string;
@@ -102,6 +109,8 @@ export interface WorkflowBackfill {
   scheduleName: string;
   name: string;
   status: WorkflowBackfillStatus;
+  operationType: WorkflowBackfillOperationType;
+  sourceExecutionId?: string;
   startBusinessDate: string;
   endBusinessDate: string;
   cronExpression: string;


### PR DESCRIPTION
## 背景

Stage 6：在 Stage 1~5 已具备的统一 Launch、Schedule、Quartz、Trigger Ledger、并发/Misfire、businessDate/Backfill/Pinned Version 基础上，补齐工作流运行后的 **实例运维与故障恢复能力**。

本 PR 不修改 Yak Workflow Engine。引擎已经原生具备单节点 retry、批量 retry-failed、restart、rerun-from-node 等语义，Stage 6 的目标是把这些底层能力产品化，并把 businessDate 历史恢复接入 Stage 5 的 Backfill / Trigger Ledger 体系。

## 核心语义

```text
失败节点 Retry
  -> 原 WorkflowExecution 内恢复
  -> FAILED 节点重新调度
  -> UPSTREAM_FAILED 下游重新参与调度

Retry Failed
  -> 原 WorkflowExecution 内批量恢复
  -> FAILED / UPSTREAM_FAILED / SKIPPED / CANCELED 重置

Restart
  -> 创建新的 WorkflowExecution
  -> 使用来源实例 input

Rerun From Node
  -> 创建新的 WorkflowExecution
  -> 成功祖先节点结果直接复用
  -> 目标节点及其后代重新运行
  -> 无关分支 SKIPPED

businessDate Rerun
  -> 创建单日 Operational Backfill
  -> 固定来源 Workflow Version
  -> 复用 Trigger Ledger / SERIAL_WAIT / PARALLEL / Recovery
```

## 1. 实例运维上下文

新增：

`GET /api/v1/workflows/instances/{executionId}/operations`

返回：

- workflowId
- 本次真实 triggerType / triggerId
- scheduleId / backfillId
- operationType / sourceExecutionId
- businessDate
- scheduleTime / scheduleTimezone
- plannedFireTime / cronExpression
- businessDateRerunSupported
- businessDateRerunUnavailableReason
- 当前 execution 不可变 Workflow Definition 的 DAG edges

Launch metadata 描述“本次为什么启动”，Workflow input 保留“原调度血缘”，避免 restart/rerun 复制旧 input 后把本次人工运维错误显示成 SCHEDULE。

## 2. 失败节点重试

实例运维 Drawer 中：

- 单个 FAILED 节点可以在原实例中「重试失败节点」
- 实例级「重试失败节点」调用 engine `retryFailedNodes`
- Attempt History、失败原因、Resolved Input、Predecessor Outputs、Node Output 均可直接查看

单节点 Retry 不创建新 WorkflowExecution；这是“恢复当前失败实例”，不是重新跑一遍工作流。

## 3. 从指定节点开始重跑

每个终态节点支持「从此节点重跑」。

复用 Yak Workflow Engine 原生 `rerunFromNode`：

- 创建新的 WorkflowExecution
- `sourceExecutionId` 指向来源实例
- 成功祖先直接复制历史 output
- 目标节点及其 descendants 重新执行
- 不相关分支标记 SKIPPED
- 如果目标节点存在未成功祖先，拒绝启动，避免用不完整历史数据重跑下游

新实例创建后由前端显式 activate。

## 4. 指定 businessDate 重跑

新增：

`POST /api/v1/workflows/instances/{executionId}/rerun-business-date`

请求：

```json
{
  "businessDate": "2026-08-10",
  "executionStrategy": "SERIAL_WAIT",
  "input": {}
}
```

实现不是修改旧 WorkflowExecution，而是创建一个 **单日 Operational Backfill**：

```text
Source WorkflowExecution
        ↓
source WorkflowVersion (PINNED)
        ↓
source Cron + timezone
        ↓
target businessDate
        ↓
WorkflowBackfillPlanner
        ↓
Trigger Ledger
        ↓
SERIAL_WAIT / PARALLEL
        ↓
Pinned Workflow Version
        ↓
new WorkflowExecution
```

### 参数安全

来源实例的自定义 input 会继承，但以下旧系统参数会先清除：

- businessDate
- scheduleTime
- scheduleTimezone
- plannedFireTime
- triggerType / triggerId
- scheduleId / backfillId
- cronExpression
- workflowVersionId / workflowVersionNo
- operationType / sourceExecutionId
- `__schedule`

然后 Stage 5 参数解析器根据新的逻辑计划时间重新注入。

因此选择 2026-08-10 重跑，不会把来源实例 2026-08-09 的 businessDate / scheduleTime 偷带进新实例。

### 版本语义

businessDate 运维重跑固定来源实例的不可变 Workflow Version。

例如来源实例是 V5，即使当前 active 已经是 V7，运维恢复仍执行 V5，保证历史数据可重复。

普通 Backfill 仍要求 Workflow 当前 ONLINE；显式运维恢复不跟随当前 activeVersion，也不会因为工作流后来下线而失去历史恢复能力。

## 5. 运维审计血缘

`yak_workflow_backfill` 新增：

- `operation_type`
- `source_execution_id`

普通历史补数：

```text
operationType = BACKFILL
```

指定日期运维补跑：

```text
operationType = BUSINESS_DATE_RERUN
sourceExecutionId = 来源 WorkflowExecution
```

Trigger source 同时记录：

```text
BUSINESS_DATE_RERUN
```

Backfill 历史页面现在会明确区分“历史补数”和“实例运维补跑”，并显示来源实例。

## 6. 批量失败实例重试

新增：

`POST /api/v1/workflows/instances/batch-retry-failed`

- 单次最多 100 个实例
- 自动去重 executionId
- 每个 WorkflowExecution 独立调用 `retryFailedNodes`
- 单条失败不会回滚整批已经成功恢复的实例
- 返回 requested / accepted / failed 与逐条结果

前端只有真正存在可恢复节点的终态实例可以勾选。

可恢复节点状态与 Yak Workflow Engine 保持一致：

- FAILED
- UPSTREAM_FAILED
- SKIPPED
- CANCELED

## 7. 运行实例 DAG 状态可视化

新增 `WorkflowDagView`：

- DAG edges 直接来自该 execution 对应的不可变 Workflow Definition
- 不依赖编辑器保存的坐标
- 使用拓扑排序自动做左到右布局
- SVG 曲线展示依赖关系
- 节点展示真实 Runtime 状态与 Attempt 数
- 点击 DAG 节点自动定位并展开下方节点运行明细
- 宽 DAG 使用局部横向滚动，不影响整个页面

因此看到的是“这个实例真正执行的 DAG”，而不是当前草稿或后来修改后的工作流图。

## 8. 实例运维工作台

工作流实例页面升级为运维视角：

- 全部 / 运行中 / 已完成 / 失败
- 名称 / 实例 ID / businessDate 搜索
- 时间范围
- 高级筛选继续保留原有能力：实例 ID / Definition ID / 正式运行 / 测试运行
- 可恢复实例多选 + 批量失败重试
- 调度上下文列：businessDate / trigger / Workflow Version
- 详情 Drawer 实时 SSE 更新
- DAG + Node / Attempt 详情
- Pause / Resume / Cancel
- Retry Failed
- 单失败节点 Retry
- Rerun From Node
- Restart
- businessDate Rerun

## 9. 宕机恢复

businessDate 运维补跑复用 Stage 5 Backfill Batch + Trigger Ledger，因此自动继承：

- batch materialization reconcile
- dedupeKey
- SERIAL_WAIT 队列恢复
- early execution binding
- Trigger -> WorkflowExecution 终态回写

等待中的 Operational Backfill 不重新依赖 Schedule ONLINE；Schedule 后续停用不会误取消已经明确创建的运维恢复批次。

## 测试覆盖

新增/扩展测试覆盖：

- 实例 operations context 与真实 DAG edges
- 批量失败实例重试去重与逐条故障隔离
- businessDate rerun 固定来源 V5
- 清除旧 businessDate / scheduleTime / trigger / `__schedule`
- 保留来源实例自定义业务 input
- 运维补跑 Trigger source = BUSINESS_DATE_RERUN
- 运维补跑进入 Trigger Ledger
- operational pinned launch 不依赖当前 Workflow ONLINE 状态
- operationType / sourceExecutionId 系统参数覆盖用户同名字段
- Stage 5 Schedule / Backfill 参数语义回归

## Stage 6 边界

本 PR 不包含：

- 分布式 Scheduler Master / Worker
- SERIAL_PRIORITY / 优先级队列
- Workflow dependency / Dataset ready / Event trigger
- 自动故障决策 / 自动选择重跑节点
- 跨实例批次最大并发控制
- 自定义交易日历 / T-1 businessDate offset

这些继续留给后续平台化阶段。

## 验证说明

已完成 GitHub 分支级静态审计及针对 Stage 6 语义的单元测试代码补充。

当前执行环境无法解析 `github.com`，实际尝试 clone / Maven test 时返回：

```text
Could not resolve host: github.com
```

因此本 PR 不宣称本地 Maven / 前端完整构建已通过；待仓库 CI 或可联网开发环境执行完整 build/test。