### PR TITLE
feat(dashboard): add global filters and widget linkage

### DIFF
--- a/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/DashboardAsset.java
+++ b/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/DashboardAsset.java
@@ -42,9 +42,49 @@ record DashboardWidgetSnapshot(
     int sortOrder) {
 }
 
+enum DashboardGlobalFilterOperator {
+  EQ,
+  NE,
+  CONTAINS,
+  GT,
+  GTE,
+  LT,
+  LTE
+}
+
+record DashboardGlobalFilterBindingSnapshot(
+    String widgetKey,
+    String fieldId,
+    int sortOrder) {
+}
+
+record DashboardGlobalFilterSnapshot(
+    String filterKey,
+    String name,
+    DashboardGlobalFilterOperator operator,
+    Object defaultValue,
+    List<DashboardGlobalFilterBindingSnapshot> bindings,
+    int sortOrder) {
+}
+
+enum DashboardInteractionEvent {
+  SELECT
+}
+
+record DashboardInteractionSnapshot(
+    String interactionKey,
+    DashboardInteractionEvent event,
+    String sourceWidgetKey,
+    String sourceFieldId,
+    String targetFilterKey,
+    int sortOrder) {
+}
+
 record DashboardDetail(
     DashboardAsset dashboard,
     DashboardVersion currentVersion,
     List<DashboardVersion> versions,
-    List<DashboardWidgetSnapshot> widgets) {
+    List<DashboardWidgetSnapshot> widgets,
+    List<DashboardGlobalFilterSnapshot> globalFilters,
+    List<DashboardInteractionSnapshot> interactions) {
 }

--- a/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/DashboardController.java
+++ b/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/DashboardController.java
@@ -77,20 +77,37 @@ public class DashboardController {
   }
 
   private DashboardService.SaveCommand toCommand(SaveDashboardRequest request) {
+    List<DashboardService.WidgetSpec> widgets = request.widgets() == null ? List.of() : request.widgets().stream()
+        .map(widget -> new DashboardService.WidgetSpec(
+            widget.widgetKey(), widget.analysisId(), widget.title(), widget.inlineAnalysis(),
+            widget.x(), widget.y(), widget.w(), widget.h(), widget.minW(), widget.minH()))
+        .toList();
+    List<DashboardService.GlobalFilterSpec> filters = request.globalFilters() == null ? List.of()
+        : request.globalFilters().stream()
+            .map(filter -> new DashboardService.GlobalFilterSpec(
+                filter.filterKey(), filter.name(), filter.operator(), filter.defaultValue(),
+                filter.bindings() == null ? List.of() : filter.bindings().stream()
+                    .map(binding -> new DashboardService.FilterBindingSpec(binding.widgetKey(), binding.fieldId()))
+                    .toList()))
+            .toList();
+    List<DashboardService.InteractionSpec> interactions = request.interactions() == null ? List.of()
+        : request.interactions().stream()
+            .map(interaction -> new DashboardService.InteractionSpec(
+                interaction.interactionKey(), interaction.event(), interaction.sourceWidgetKey(),
+                interaction.sourceFieldId(), interaction.targetFilterKey()))
+            .toList();
     return new DashboardService.SaveCommand(
-        request.name(), request.description(), request.activeDatasetId(),
-        request.widgets() == null ? List.of() : request.widgets().stream()
-            .map(widget -> new DashboardService.WidgetSpec(
-                widget.widgetKey(), widget.analysisId(), widget.title(), widget.inlineAnalysis(),
-                widget.x(), widget.y(), widget.w(), widget.h(), widget.minW(), widget.minH()))
-            .toList());
+        request.name(), request.description(), request.activeDatasetId(), widgets, filters, interactions);
   }
 
   public record SaveDashboardRequest(
       @NotBlank @Size(max = 200) String name,
       @Size(max = 2000) String description,
       @Min(1) Long activeDatasetId,
-      @Size(max = 200) List<@Valid WidgetRequest> widgets) {}
+      @Size(max = 200) List<@Valid WidgetRequest> widgets,
+      @Size(max = 20) List<@Valid GlobalFilterRequest> globalFilters,
+      @Size(max = 100) List<@Valid InteractionRequest> interactions) {
+  }
 
   public record WidgetRequest(
       @NotBlank @Size(max = 64) String widgetKey,
@@ -102,5 +119,27 @@ public class DashboardController {
       @Min(1) @Max(24) int w,
       @Min(1) @Max(60) int h,
       @Min(1) @Max(24) Integer minW,
-      @Min(1) @Max(60) Integer minH) {}
+      @Min(1) @Max(60) Integer minH) {
+  }
+
+  public record GlobalFilterRequest(
+      @NotBlank @Size(max = 64) String filterKey,
+      @NotBlank @Size(max = 200) String name,
+      @NotNull DashboardGlobalFilterOperator operator,
+      Object defaultValue,
+      @Size(max = 200) List<@Valid FilterBindingRequest> bindings) {
+  }
+
+  public record FilterBindingRequest(
+      @NotBlank @Size(max = 64) String widgetKey,
+      @NotBlank @Size(max = 64) String fieldId) {
+  }
+
+  public record InteractionRequest(
+      @NotBlank @Size(max = 64) String interactionKey,
+      @NotNull DashboardInteractionEvent event,
+      @NotBlank @Size(max = 64) String sourceWidgetKey,
+      @NotBlank @Size(max = 64) String sourceFieldId,
+      @NotBlank @Size(max = 64) String targetFilterKey) {
+  }
 }

--- a/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/DashboardRepository.java
+++ b/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/DashboardRepository.java
@@ -7,6 +7,8 @@ interface DashboardRepository {
   long insertDashboard(String name, String description);
   long insertVersion(long dashboardId, int versionNo, String name, String description, Long activeDatasetId);
   void insertWidgets(long versionId, List<DashboardService.WidgetSpec> widgets, List<String> inlineJson);
+  void insertGlobalFilters(long versionId, List<DashboardService.GlobalFilterSpec> filters, List<String> defaultValueJson);
+  void insertInteractions(long versionId, List<DashboardService.InteractionSpec> interactions);
   void updateCurrentVersion(long dashboardId, long versionId, int versionNo, String name, String description);
   Optional<DashboardAsset> findDashboard(long dashboardId);
   List<DashboardAsset> listDashboards();
@@ -14,6 +16,8 @@ interface DashboardRepository {
   Optional<DashboardVersion> findVersionByNo(long dashboardId, int versionNo);
   List<DashboardVersion> listVersions(long dashboardId);
   List<DashboardWidgetSnapshot> listWidgets(long versionId);
+  List<DashboardGlobalFilterSnapshot> listGlobalFilters(long versionId);
+  List<DashboardInteractionSnapshot> listInteractions(long versionId);
   int nextVersionNo(long dashboardId);
   void deleteDashboard(long dashboardId);
 }

--- a/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/DashboardService.java
+++ b/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/DashboardService.java
@@ -13,12 +13,16 @@ import java.util.Set;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-/** Owns Dashboard identity, immutable versions and layout. Analysis owns reusable ChartSpec definitions. */
+/** Owns Dashboard identity, immutable versions, layout and dashboard-level interaction definitions. */
 @Service
 public class DashboardService {
 
   private static final int MAX_WIDGETS = 200;
   private static final int MAX_INLINE_JSON = 65535;
+  private static final int MAX_GLOBAL_FILTERS = 20;
+  private static final int MAX_FILTER_BINDINGS = 200;
+  private static final int MAX_INTERACTIONS = 100;
+  private static final int MAX_DEFAULT_VALUE_JSON = 4000;
 
   private final DashboardRepository repository;
   private final AnalysisReferenceService analysisReferences;
@@ -43,12 +47,22 @@ public class DashboardService {
         .orElseThrow(() -> new IllegalArgumentException("Dashboard 不存在：" + dashboardId));
     DashboardVersion currentVersion = null;
     List<DashboardWidgetSnapshot> widgets = List.of();
+    List<DashboardGlobalFilterSnapshot> filters = List.of();
+    List<DashboardInteractionSnapshot> interactions = List.of();
     if (dashboard.currentVersionId() != null) {
       currentVersion = repository.findVersion(dashboard.currentVersionId())
           .orElseThrow(() -> new IllegalStateException("Dashboard 当前版本不存在：" + dashboard.currentVersionId()));
       widgets = repository.listWidgets(currentVersion.id());
+      filters = repository.listGlobalFilters(currentVersion.id());
+      interactions = repository.listInteractions(currentVersion.id());
     }
-    return new DashboardDetail(dashboard, currentVersion, repository.listVersions(dashboardId), widgets);
+    return new DashboardDetail(
+        dashboard,
+        currentVersion,
+        repository.listVersions(dashboardId),
+        widgets,
+        filters,
+        interactions);
   }
 
   public List<DashboardVersion> versions(long dashboardId) {
@@ -94,6 +108,8 @@ public class DashboardService {
     long versionId = repository.insertVersion(
         dashboardId, versionNo, normalized.name(), normalized.description(), normalized.activeDatasetId());
     repository.insertWidgets(versionId, normalized.widgets(), normalized.inlineJson());
+    repository.insertGlobalFilters(versionId, normalized.globalFilters(), normalized.defaultValueJson());
+    repository.insertInteractions(versionId, normalized.interactions());
     repository.updateCurrentVersion(
         dashboardId, versionId, versionNo, normalized.name(), normalized.description());
   }
@@ -105,8 +121,28 @@ public class DashboardService {
     Long activeDatasetId = command.activeDatasetId();
     if (activeDatasetId != null && activeDatasetId <= 0L) activeDatasetId = null;
 
-    List<WidgetSpec> source = command.widgets() == null ? List.of() : command.widgets();
-    if (source.size() > MAX_WIDGETS) throw new IllegalArgumentException("Dashboard 组件不能超过 " + MAX_WIDGETS + " 个");
+    WidgetNormalization widgetNormalization = normalizeWidgets(command.widgets());
+    FilterNormalization filterNormalization = normalizeGlobalFilters(
+        command.globalFilters(), widgetNormalization.widgetKeys());
+    List<InteractionSpec> interactions = normalizeInteractions(
+        command.interactions(), widgetNormalization.widgetKeys(), filterNormalization.filterKeys());
+
+    return new Normalized(
+        name,
+        description,
+        activeDatasetId,
+        widgetNormalization.widgets(),
+        widgetNormalization.inlineJson(),
+        filterNormalization.filters(),
+        filterNormalization.defaultValueJson(),
+        interactions);
+  }
+
+  private WidgetNormalization normalizeWidgets(List<WidgetSpec> values) {
+    List<WidgetSpec> source = values == null ? List.of() : values;
+    if (source.size() > MAX_WIDGETS) {
+      throw new IllegalArgumentException("Dashboard 组件不能超过 " + MAX_WIDGETS + " 个");
+    }
     List<WidgetSpec> widgets = new ArrayList<>(source.size());
     List<String> inlineJson = new ArrayList<>(source.size());
     Set<String> widgetKeys = new HashSet<>();
@@ -134,12 +170,93 @@ public class DashboardService {
           value.x(), value.y(), value.w(), value.h(), value.minW(), value.minH()));
       inlineJson.add(json);
     }
-    return new Normalized(
-        name,
-        description,
-        activeDatasetId,
+    return new WidgetNormalization(
         List.copyOf(widgets),
-        Collections.unmodifiableList(new ArrayList<>(inlineJson)));
+        Collections.unmodifiableList(new ArrayList<>(inlineJson)),
+        Set.copyOf(widgetKeys));
+  }
+
+  private FilterNormalization normalizeGlobalFilters(
+      List<GlobalFilterSpec> values,
+      Set<String> widgetKeys) {
+    List<GlobalFilterSpec> source = values == null ? List.of() : values;
+    if (source.size() > MAX_GLOBAL_FILTERS) {
+      throw new IllegalArgumentException("Dashboard 全局筛选器不能超过 " + MAX_GLOBAL_FILTERS + " 个");
+    }
+
+    List<GlobalFilterSpec> filters = new ArrayList<>(source.size());
+    List<String> defaultValueJson = new ArrayList<>(source.size());
+    Set<String> filterKeys = new HashSet<>();
+    int bindingCount = 0;
+
+    for (GlobalFilterSpec value : source) {
+      if (value == null) throw new IllegalArgumentException("Dashboard 全局筛选器不能为空");
+      String filterKey = required(value.filterKey(), "filterKey", 64);
+      if (!filterKeys.add(filterKey)) throw new IllegalArgumentException("filterKey 重复：" + filterKey);
+      String filterName = required(value.name(), "筛选器名称", 200);
+      DashboardGlobalFilterOperator operator = Objects.requireNonNull(value.operator(), "筛选器 operator");
+
+      List<FilterBindingSpec> sourceBindings = value.bindings() == null ? List.of() : value.bindings();
+      List<FilterBindingSpec> bindings = new ArrayList<>(sourceBindings.size());
+      Set<String> boundWidgets = new HashSet<>();
+      for (FilterBindingSpec binding : sourceBindings) {
+        if (binding == null) throw new IllegalArgumentException("筛选器绑定不能为空：" + filterKey);
+        String widgetKey = required(binding.widgetKey(), "筛选器 widgetKey", 64);
+        if (!widgetKeys.contains(widgetKey)) {
+          throw new IllegalArgumentException("筛选器绑定的 Widget 不存在：" + widgetKey);
+        }
+        if (!boundWidgets.add(widgetKey)) {
+          throw new IllegalArgumentException("同一筛选器对单个 Widget 只能绑定一个字段：" + widgetKey);
+        }
+        String fieldId = required(binding.fieldId(), "筛选器 fieldId", 64);
+        bindings.add(new FilterBindingSpec(widgetKey, fieldId));
+        bindingCount++;
+        if (bindingCount > MAX_FILTER_BINDINGS) {
+          throw new IllegalArgumentException("Dashboard 筛选器字段映射不能超过 " + MAX_FILTER_BINDINGS + " 个");
+        }
+      }
+
+      filters.add(new GlobalFilterSpec(
+          filterKey, filterName, operator, value.defaultValue(), List.copyOf(bindings)));
+      defaultValueJson.add(scalarJson(value.defaultValue(), filterKey));
+    }
+
+    return new FilterNormalization(
+        List.copyOf(filters),
+        Collections.unmodifiableList(new ArrayList<>(defaultValueJson)),
+        Set.copyOf(filterKeys));
+  }
+
+  private List<InteractionSpec> normalizeInteractions(
+      List<InteractionSpec> values,
+      Set<String> widgetKeys,
+      Set<String> filterKeys) {
+    List<InteractionSpec> source = values == null ? List.of() : values;
+    if (source.size() > MAX_INTERACTIONS) {
+      throw new IllegalArgumentException("Dashboard 联动规则不能超过 " + MAX_INTERACTIONS + " 个");
+    }
+    List<InteractionSpec> result = new ArrayList<>(source.size());
+    Set<String> interactionKeys = new HashSet<>();
+    for (InteractionSpec value : source) {
+      if (value == null) throw new IllegalArgumentException("Dashboard 联动规则不能为空");
+      String interactionKey = required(value.interactionKey(), "interactionKey", 64);
+      if (!interactionKeys.add(interactionKey)) {
+        throw new IllegalArgumentException("interactionKey 重复：" + interactionKey);
+      }
+      DashboardInteractionEvent event = Objects.requireNonNull(value.event(), "联动 event");
+      String sourceWidgetKey = required(value.sourceWidgetKey(), "联动 sourceWidgetKey", 64);
+      if (!widgetKeys.contains(sourceWidgetKey)) {
+        throw new IllegalArgumentException("联动来源 Widget 不存在：" + sourceWidgetKey);
+      }
+      String sourceFieldId = required(value.sourceFieldId(), "联动 sourceFieldId", 64);
+      String targetFilterKey = required(value.targetFilterKey(), "联动 targetFilterKey", 64);
+      if (!filterKeys.contains(targetFilterKey)) {
+        throw new IllegalArgumentException("联动目标筛选器不存在：" + targetFilterKey);
+      }
+      result.add(new InteractionSpec(
+          interactionKey, event, sourceWidgetKey, sourceFieldId, targetFilterKey));
+    }
+    return List.copyOf(result);
   }
 
   private void validateLayout(WidgetSpec value, String widgetKey) {
@@ -168,6 +285,23 @@ public class DashboardService {
     }
   }
 
+  private String scalarJson(Object value, String filterKey) {
+    if (value == null) return null;
+    JsonNode node = objectMapper.valueToTree(value);
+    if (!node.isValueNode()) {
+      throw new IllegalArgumentException("全局筛选器默认值必须是标量：" + filterKey);
+    }
+    try {
+      String json = objectMapper.writeValueAsString(value);
+      if (json.length() > MAX_DEFAULT_VALUE_JSON) {
+        throw new IllegalArgumentException("全局筛选器默认值过大：" + filterKey);
+      }
+      return json;
+    } catch (JsonProcessingException exception) {
+      throw new IllegalArgumentException("全局筛选器默认值无法序列化：" + filterKey, exception);
+    }
+  }
+
   private String required(String value, String label, int maxLength) {
     if (value == null || value.isBlank()) throw new IllegalArgumentException(label + "不能为空");
     String normalized = value.trim();
@@ -182,7 +316,14 @@ public class DashboardService {
     return normalized;
   }
 
-  public record SaveCommand(String name, String description, Long activeDatasetId, List<WidgetSpec> widgets) {}
+  public record SaveCommand(
+      String name,
+      String description,
+      Long activeDatasetId,
+      List<WidgetSpec> widgets,
+      List<GlobalFilterSpec> globalFilters,
+      List<InteractionSpec> interactions) {
+  }
 
   public record WidgetSpec(
       String widgetKey,
@@ -190,12 +331,48 @@ public class DashboardService {
       String title,
       Object inlineAnalysis,
       int x, int y, int w, int h,
-      Integer minW, Integer minH) {}
+      Integer minW, Integer minH) {
+  }
+
+  public record GlobalFilterSpec(
+      String filterKey,
+      String name,
+      DashboardGlobalFilterOperator operator,
+      Object defaultValue,
+      List<FilterBindingSpec> bindings) {
+  }
+
+  public record FilterBindingSpec(String widgetKey, String fieldId) {
+  }
+
+  public record InteractionSpec(
+      String interactionKey,
+      DashboardInteractionEvent event,
+      String sourceWidgetKey,
+      String sourceFieldId,
+      String targetFilterKey) {
+  }
+
+  private record WidgetNormalization(
+      List<WidgetSpec> widgets,
+      List<String> inlineJson,
+      Set<String> widgetKeys) {
+  }
+
+  private record FilterNormalization(
+      List<GlobalFilterSpec> filters,
+      List<String> defaultValueJson,
+      Set<String> filterKeys) {
+  }
 
   private record Normalized(
       String name,
       String description,
       Long activeDatasetId,
       List<WidgetSpec> widgets,
-      List<String> inlineJson) {}
+      List<String> inlineJson,
+      List<GlobalFilterSpec> globalFilters,
+      List<String> defaultValueJson,
+      List<InteractionSpec> interactions) {
+  }
 }

--- a/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/JdbcDashboardRepository.java
+++ b/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/JdbcDashboardRepository.java
@@ -95,6 +95,46 @@ class JdbcDashboardRepository implements DashboardRepository {
   }
 
   @Override
+  public void insertGlobalFilters(
+      long versionId,
+      List<DashboardService.GlobalFilterSpec> filters,
+      List<String> defaultValueJson) {
+    for (int index = 0; index < filters.size(); index++) {
+      DashboardService.GlobalFilterSpec filter = filters.get(index);
+      jdbcTemplate.update(
+          "INSERT INTO yak_dashboard_filter (dashboard_version_id, filter_key, name, operator, default_value_json, sort_order) VALUES (?, ?, ?, ?, ?, ?)",
+          versionId,
+          filter.filterKey(),
+          filter.name(),
+          filter.operator().name(),
+          defaultValueJson.get(index),
+          index + 1);
+      for (int bindingIndex = 0; bindingIndex < filter.bindings().size(); bindingIndex++) {
+        DashboardService.FilterBindingSpec binding = filter.bindings().get(bindingIndex);
+        jdbcTemplate.update(
+            "INSERT INTO yak_dashboard_filter_binding (dashboard_version_id, filter_key, widget_key, field_id, sort_order) VALUES (?, ?, ?, ?, ?)",
+            versionId, filter.filterKey(), binding.widgetKey(), binding.fieldId(), bindingIndex + 1);
+      }
+    }
+  }
+
+  @Override
+  public void insertInteractions(long versionId, List<DashboardService.InteractionSpec> interactions) {
+    for (int index = 0; index < interactions.size(); index++) {
+      DashboardService.InteractionSpec interaction = interactions.get(index);
+      jdbcTemplate.update(
+          "INSERT INTO yak_dashboard_interaction (dashboard_version_id, interaction_key, event_type, source_widget_key, source_field_id, target_filter_key, sort_order) VALUES (?, ?, ?, ?, ?, ?, ?)",
+          versionId,
+          interaction.interactionKey(),
+          interaction.event().name(),
+          interaction.sourceWidgetKey(),
+          interaction.sourceFieldId(),
+          interaction.targetFilterKey(),
+          index + 1);
+    }
+  }
+
+  @Override
   public void updateCurrentVersion(long dashboardId, long versionId, int versionNo, String name, String description) {
     int updated = jdbcTemplate.update(
         "UPDATE yak_dashboard SET current_version_id = ?, current_version_no = ?, name = ?, description = ?, update_time = NOW(6) WHERE id = ?",
@@ -146,6 +186,44 @@ class JdbcDashboardRepository implements DashboardRepository {
   }
 
   @Override
+  public List<DashboardGlobalFilterSnapshot> listGlobalFilters(long versionId) {
+    List<FilterHeader> headers = jdbcTemplate.query(
+        "SELECT filter_key, name, operator, default_value_json, sort_order FROM yak_dashboard_filter WHERE dashboard_version_id = ? ORDER BY sort_order ASC, id ASC",
+        (rs, rowNum) -> new FilterHeader(
+            rs.getString("filter_key"),
+            rs.getString("name"),
+            DashboardGlobalFilterOperator.valueOf(rs.getString("operator")),
+            rs.getString("default_value_json"),
+            rs.getInt("sort_order")),
+        versionId);
+    return headers.stream().map(header -> new DashboardGlobalFilterSnapshot(
+        header.filterKey(),
+        header.name(),
+        header.operator(),
+        parseJson(header.defaultValueJson()),
+        jdbcTemplate.query(
+            "SELECT widget_key, field_id, sort_order FROM yak_dashboard_filter_binding WHERE dashboard_version_id = ? AND filter_key = ? ORDER BY sort_order ASC",
+            (rs, rowNum) -> new DashboardGlobalFilterBindingSnapshot(
+                rs.getString("widget_key"), rs.getString("field_id"), rs.getInt("sort_order")),
+            versionId, header.filterKey()),
+        header.sortOrder())).toList();
+  }
+
+  @Override
+  public List<DashboardInteractionSnapshot> listInteractions(long versionId) {
+    return jdbcTemplate.query(
+        "SELECT interaction_key, event_type, source_widget_key, source_field_id, target_filter_key, sort_order FROM yak_dashboard_interaction WHERE dashboard_version_id = ? ORDER BY sort_order ASC, id ASC",
+        (rs, rowNum) -> new DashboardInteractionSnapshot(
+            rs.getString("interaction_key"),
+            DashboardInteractionEvent.valueOf(rs.getString("event_type")),
+            rs.getString("source_widget_key"),
+            rs.getString("source_field_id"),
+            rs.getString("target_filter_key"),
+            rs.getInt("sort_order")),
+        versionId);
+  }
+
+  @Override
   public int nextVersionNo(long dashboardId) {
     Integer value = jdbcTemplate.queryForObject(
         "SELECT COALESCE(MAX(version_no), 0) + 1 FROM yak_dashboard_version WHERE dashboard_id = ?",
@@ -190,11 +268,19 @@ class JdbcDashboardRepository implements DashboardRepository {
     try {
       return objectMapper.readValue(value, Object.class);
     } catch (JsonProcessingException exception) {
-      throw new IllegalStateException("Dashboard inlineAnalysis 反序列化失败", exception);
+      throw new IllegalStateException("Dashboard JSON 反序列化失败", exception);
     }
   }
 
   private static Instant instant(Timestamp value) {
     return value == null ? null : value.toInstant();
+  }
+
+  private record FilterHeader(
+      String filterKey,
+      String name,
+      DashboardGlobalFilterOperator operator,
+      String defaultValueJson,
+      int sortOrder) {
   }
 }

--- a/yak-ops-business/yak-ops-business-dashboard/src/main/resources/db/migration/yak-dashboard/V2__dashboard_filters_and_interactions.sql
+++ b/yak-ops-business/yak-ops-business-dashboard/src/main/resources/db/migration/yak-dashboard/V2__dashboard_filters_and_interactions.sql
@@ -1,0 +1,54 @@
+-- Dashboard runtime interaction definitions are versioned with the composition snapshot.
+CREATE TABLE IF NOT EXISTS yak_dashboard_filter (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    dashboard_version_id BIGINT NOT NULL,
+    filter_key VARCHAR(64) NOT NULL,
+    name VARCHAR(200) NOT NULL,
+    operator VARCHAR(32) NOT NULL,
+    default_value_json JSON NULL,
+    sort_order INT NOT NULL DEFAULT 0,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_yak_dashboard_filter_key (dashboard_version_id, filter_key),
+    CONSTRAINT fk_yak_dashboard_filter_version
+        FOREIGN KEY (dashboard_version_id) REFERENCES yak_dashboard_version(id)
+        ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS yak_dashboard_filter_binding (
+    dashboard_version_id BIGINT NOT NULL,
+    filter_key VARCHAR(64) NOT NULL,
+    widget_key VARCHAR(64) NOT NULL,
+    field_id VARCHAR(64) NOT NULL,
+    sort_order INT NOT NULL DEFAULT 0,
+    PRIMARY KEY (dashboard_version_id, filter_key, widget_key),
+    CONSTRAINT fk_yak_dashboard_filter_binding_filter
+        FOREIGN KEY (dashboard_version_id, filter_key)
+        REFERENCES yak_dashboard_filter(dashboard_version_id, filter_key)
+        ON DELETE CASCADE,
+    CONSTRAINT fk_yak_dashboard_filter_binding_widget
+        FOREIGN KEY (dashboard_version_id, widget_key)
+        REFERENCES yak_dashboard_widget(dashboard_version_id, widget_key)
+        ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS yak_dashboard_interaction (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    dashboard_version_id BIGINT NOT NULL,
+    interaction_key VARCHAR(64) NOT NULL,
+    event_type VARCHAR(32) NOT NULL,
+    source_widget_key VARCHAR(64) NOT NULL,
+    source_field_id VARCHAR(64) NOT NULL,
+    target_filter_key VARCHAR(64) NOT NULL,
+    sort_order INT NOT NULL DEFAULT 0,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_yak_dashboard_interaction_key (dashboard_version_id, interaction_key),
+    KEY idx_yak_dashboard_interaction_source (dashboard_version_id, source_widget_key),
+    CONSTRAINT fk_yak_dashboard_interaction_widget
+        FOREIGN KEY (dashboard_version_id, source_widget_key)
+        REFERENCES yak_dashboard_widget(dashboard_version_id, widget_key)
+        ON DELETE CASCADE,
+    CONSTRAINT fk_yak_dashboard_interaction_filter
+        FOREIGN KEY (dashboard_version_id, target_filter_key)
+        REFERENCES yak_dashboard_filter(dashboard_version_id, filter_key)
+        ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/yak-ops-business/yak-ops-business-dashboard/src/test/java/io/yak/ops/business/dashboard/DashboardServiceTest.java
+++ b/yak-ops-business/yak-ops-business-dashboard/src/test/java/io/yak/ops/business/dashboard/DashboardServiceTest.java
@@ -25,11 +25,19 @@ class DashboardServiceTest {
 
     DashboardDetail detail = service.create(new DashboardService.SaveCommand(
         "销售驾驶舱", "核心销售分析", 12L,
-        List.of(new DashboardService.WidgetSpec("w1", 99L, null, null, 0, 0, 10, 7, 6, 5))));
+        List.of(new DashboardService.WidgetSpec("w1", 99L, null, null, 0, 0, 10, 7, 6, 5)),
+        List.of(new DashboardService.GlobalFilterSpec(
+            "region", "区域", DashboardGlobalFilterOperator.EQ, "华南",
+            List.of(new DashboardService.FilterBindingSpec("w1", "region-field")))),
+        List.of(new DashboardService.InteractionSpec(
+            "link-region", DashboardInteractionEvent.SELECT, "w1", "region-field", "region"))));
 
     assertEquals(1, detail.dashboard().currentVersionNo());
     assertEquals(1, detail.versions().size());
     assertEquals(1, detail.widgets().size());
+    assertEquals(1, detail.globalFilters().size());
+    assertEquals("华南", detail.globalFilters().get(0).defaultValue());
+    assertEquals(1, detail.interactions().size());
     verify(analysisReferences).requireExists(99L);
   }
 
@@ -37,12 +45,12 @@ class DashboardServiceTest {
   void manualSaveCreatesImmutableNextVersion() {
     FakeRepository repository = new FakeRepository();
     DashboardService service = new DashboardService(repository, mock(AnalysisReferenceService.class), new ObjectMapper());
-    DashboardDetail created = service.create(new DashboardService.SaveCommand(
-        "A", null, null,
+    DashboardDetail created = service.create(command(
+        "A",
         List.of(new DashboardService.WidgetSpec("w1", null, "临时", Map.of("type", "bar"), 0, 0, 10, 7, 6, 5))));
 
-    DashboardDetail saved = service.saveVersion(created.dashboard().id(), new DashboardService.SaveCommand(
-        "A2", null, null,
+    DashboardDetail saved = service.saveVersion(created.dashboard().id(), command(
+        "A2",
         List.of(new DashboardService.WidgetSpec("w1", null, "临时", Map.of("type", "line"), 1, 1, 10, 7, 6, 5))));
 
     assertEquals(2, saved.dashboard().currentVersionNo());
@@ -54,9 +62,38 @@ class DashboardServiceTest {
   void widgetCannotCarryLinkedAndInlineDefinitionsTogether() {
     DashboardService service = new DashboardService(
         new FakeRepository(), mock(AnalysisReferenceService.class), new ObjectMapper());
-    assertThrows(IllegalArgumentException.class, () -> service.create(new DashboardService.SaveCommand(
-        "bad", null, null,
+    assertThrows(IllegalArgumentException.class, () -> service.create(command(
+        "bad",
         List.of(new DashboardService.WidgetSpec("w1", 9L, null, Map.of("type", "bar"), 0, 0, 10, 7, 6, 5)))));
+  }
+
+  @Test
+  void globalFilterCannotBindUnknownWidget() {
+    DashboardService service = new DashboardService(
+        new FakeRepository(), mock(AnalysisReferenceService.class), new ObjectMapper());
+    assertThrows(IllegalArgumentException.class, () -> service.create(new DashboardService.SaveCommand(
+        "bad-filter", null, null,
+        List.of(new DashboardService.WidgetSpec("w1", null, "临时", Map.of("type", "bar"), 0, 0, 10, 7, 6, 5)),
+        List.of(new DashboardService.GlobalFilterSpec(
+            "region", "区域", DashboardGlobalFilterOperator.EQ, null,
+            List.of(new DashboardService.FilterBindingSpec("missing", "region-field")))),
+        List.of())));
+  }
+
+  @Test
+  void interactionMustTargetExistingFilter() {
+    DashboardService service = new DashboardService(
+        new FakeRepository(), mock(AnalysisReferenceService.class), new ObjectMapper());
+    assertThrows(IllegalArgumentException.class, () -> service.create(new DashboardService.SaveCommand(
+        "bad-link", null, null,
+        List.of(new DashboardService.WidgetSpec("w1", null, "临时", Map.of("type", "bar"), 0, 0, 10, 7, 6, 5)),
+        List.of(),
+        List.of(new DashboardService.InteractionSpec(
+            "link", DashboardInteractionEvent.SELECT, "w1", "region", "missing")))));
+  }
+
+  private DashboardService.SaveCommand command(String name, List<DashboardService.WidgetSpec> widgets) {
+    return new DashboardService.SaveCommand(name, null, null, widgets, List.of(), List.of());
   }
 
   private static final class FakeRepository implements DashboardRepository {
@@ -65,35 +102,72 @@ class DashboardServiceTest {
     private final Map<Long, DashboardAsset> dashboards = new LinkedHashMap<>();
     private final Map<Long, DashboardVersion> versions = new LinkedHashMap<>();
     private final Map<Long, List<DashboardWidgetSnapshot>> widgets = new LinkedHashMap<>();
+    private final Map<Long, List<DashboardGlobalFilterSnapshot>> filters = new LinkedHashMap<>();
+    private final Map<Long, List<DashboardInteractionSnapshot>> interactions = new LinkedHashMap<>();
 
     @Override public long insertDashboard(String name, String description) {
       long id = nextDashboardId++;
       dashboards.put(id, new DashboardAsset(id, name, description, null, 0, Instant.now(), Instant.now()));
       return id;
     }
+
     @Override public long insertVersion(long dashboardId, int versionNo, String name, String description, Long activeDatasetId) {
       long id = nextVersionId++;
       versions.put(id, new DashboardVersion(id, dashboardId, versionNo, name, description, activeDatasetId, Instant.now()));
       return id;
     }
+
     @Override public void insertWidgets(long versionId, List<DashboardService.WidgetSpec> specs, List<String> json) {
       List<DashboardWidgetSnapshot> rows = new ArrayList<>();
       for (int i = 0; i < specs.size(); i++) {
         DashboardService.WidgetSpec value = specs.get(i);
-        rows.add(new DashboardWidgetSnapshot(i + 1L, versionId, value.widgetKey(), value.analysisId(), value.title(), value.inlineAnalysis(), value.x(), value.y(), value.w(), value.h(), value.minW(), value.minH(), i + 1));
+        rows.add(new DashboardWidgetSnapshot(
+            i + 1L, versionId, value.widgetKey(), value.analysisId(), value.title(), value.inlineAnalysis(),
+            value.x(), value.y(), value.w(), value.h(), value.minW(), value.minH(), i + 1));
       }
       widgets.put(versionId, rows);
     }
+
+    @Override public void insertGlobalFilters(long versionId, List<DashboardService.GlobalFilterSpec> specs, List<String> json) {
+      List<DashboardGlobalFilterSnapshot> rows = new ArrayList<>();
+      for (int i = 0; i < specs.size(); i++) {
+        DashboardService.GlobalFilterSpec value = specs.get(i);
+        List<DashboardGlobalFilterBindingSnapshot> bindings = new ArrayList<>();
+        for (int j = 0; j < value.bindings().size(); j++) {
+          DashboardService.FilterBindingSpec binding = value.bindings().get(j);
+          bindings.add(new DashboardGlobalFilterBindingSnapshot(binding.widgetKey(), binding.fieldId(), j + 1));
+        }
+        rows.add(new DashboardGlobalFilterSnapshot(
+            value.filterKey(), value.name(), value.operator(), value.defaultValue(), bindings, i + 1));
+      }
+      filters.put(versionId, rows);
+    }
+
+    @Override public void insertInteractions(long versionId, List<DashboardService.InteractionSpec> specs) {
+      List<DashboardInteractionSnapshot> rows = new ArrayList<>();
+      for (int i = 0; i < specs.size(); i++) {
+        DashboardService.InteractionSpec value = specs.get(i);
+        rows.add(new DashboardInteractionSnapshot(
+            value.interactionKey(), value.event(), value.sourceWidgetKey(), value.sourceFieldId(),
+            value.targetFilterKey(), i + 1));
+      }
+      interactions.put(versionId, rows);
+    }
+
     @Override public void updateCurrentVersion(long dashboardId, long versionId, int versionNo, String name, String description) {
       DashboardAsset old = dashboards.get(dashboardId);
-      dashboards.put(dashboardId, new DashboardAsset(dashboardId, name, description, versionId, versionNo, old.createTime(), Instant.now()));
+      dashboards.put(dashboardId, new DashboardAsset(
+          dashboardId, name, description, versionId, versionNo, old.createTime(), Instant.now()));
     }
+
     @Override public Optional<DashboardAsset> findDashboard(long id) { return Optional.ofNullable(dashboards.get(id)); }
     @Override public List<DashboardAsset> listDashboards() { return new ArrayList<>(dashboards.values()); }
     @Override public Optional<DashboardVersion> findVersion(long id) { return Optional.ofNullable(versions.get(id)); }
     @Override public Optional<DashboardVersion> findVersionByNo(long dashboardId, int versionNo) { return versions.values().stream().filter(v -> v.dashboardId() == dashboardId && v.versionNo() == versionNo).findFirst(); }
     @Override public List<DashboardVersion> listVersions(long dashboardId) { return versions.values().stream().filter(v -> v.dashboardId() == dashboardId).sorted((a,b) -> Integer.compare(b.versionNo(), a.versionNo())).toList(); }
     @Override public List<DashboardWidgetSnapshot> listWidgets(long versionId) { return widgets.getOrDefault(versionId, List.of()); }
+    @Override public List<DashboardGlobalFilterSnapshot> listGlobalFilters(long versionId) { return filters.getOrDefault(versionId, List.of()); }
+    @Override public List<DashboardInteractionSnapshot> listInteractions(long versionId) { return interactions.getOrDefault(versionId, List.of()); }
     @Override public int nextVersionNo(long dashboardId) { return listVersions(dashboardId).stream().mapToInt(DashboardVersion::versionNo).max().orElse(0) + 1; }
     @Override public void deleteDashboard(long dashboardId) { dashboards.remove(dashboardId); }
   }

--- a/yak-ops-ui/src/components/analysis/AnalysisPreview.tsx
+++ b/yak-ops-ui/src/components/analysis/AnalysisPreview.tsx
@@ -4,6 +4,8 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { queryAnalysisDataset } from './dataset-service';
 import type {
   Aggregation,
+  AnalysisFilter,
+  AnalysisSelection,
   AnalysisSpec,
   DatasetField,
   DatasetQueryPayload,
@@ -49,9 +51,10 @@ const filterValue = (field: DatasetField | undefined, value: string): Scalar => 
 export const buildDatasetQueryPayload = (
   spec: AnalysisSpec,
   dataset: PublishedDataset,
+  runtimeFilters: AnalysisFilter[] = [],
 ): DatasetQueryPayload => {
   const operators: Record<
-    AnalysisSpec['filters'][number]['operator'],
+    AnalysisFilter['operator'],
     DatasetQueryPayload['filters'][number]['operator']
   > = {
     eq: 'EQ',
@@ -62,7 +65,7 @@ export const buildDatasetQueryPayload = (
     lt: 'LT',
     lte: 'LTE',
   };
-  const filters = spec.filters
+  const filters = [...spec.filters, ...runtimeFilters]
     .filter((filter) => filter.field && filter.value !== '')
     .map((filter) => {
       const field = getAnalysisField(dataset, filter.field);
@@ -101,14 +104,19 @@ export const canQueryAnalysis = (spec: AnalysisSpec) => {
   return spec.dimensions.length > 0 && spec.metrics.length > 0;
 };
 
-function useAnalysisQuery(spec: AnalysisSpec, dataset?: PublishedDataset) {
+function useAnalysisQuery(
+  spec: AnalysisSpec,
+  dataset?: PublishedDataset,
+  runtimeFilters: AnalysisFilter[] = [],
+) {
   const [result, setResult] = useState<DatasetQueryResult>();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
   const sequence = useRef(0);
+  const runtimeFilterKey = useMemo(() => JSON.stringify(runtimeFilters), [runtimeFilters]);
   const payload = useMemo(
-    () => dataset ? buildDatasetQueryPayload(spec, dataset) : undefined,
-    [dataset, spec],
+    () => dataset ? buildDatasetQueryPayload(spec, dataset, runtimeFilters) : undefined,
+    [dataset, spec, runtimeFilterKey],
   );
   const payloadKey = useMemo(() => JSON.stringify(payload), [payload]);
 
@@ -175,6 +183,25 @@ const numericCell = (
 
 const rowLabel = (result: DatasetQueryResult, row: Scalar[], dimensions: string[]) =>
   dimensions.map((fieldId) => String(cell(result, row, fieldId) ?? '')).join(' / ');
+
+const selectionForRow = (
+  spec: AnalysisSpec,
+  dataset: PublishedDataset,
+  result: DatasetQueryResult,
+  rowIndex: number,
+): AnalysisSelection | undefined => {
+  const fieldId = spec.dimensions[0];
+  const row = result.rows[rowIndex];
+  if (!fieldId || !row) return undefined;
+  const value = cell(result, row, fieldId);
+  if (value === null) return undefined;
+  return {
+    fieldId,
+    value,
+    label: `${getAnalysisField(dataset, fieldId)?.label ?? fieldId}: ${String(value)}`,
+    rowIndex,
+  };
+};
 
 const chartOptionFor = (
   spec: AnalysisSpec,
@@ -254,10 +281,12 @@ function EChartAnalysis({
   spec,
   dataset,
   result,
+  onSelect,
 }: {
   spec: AnalysisSpec;
   dataset: PublishedDataset;
   result: DatasetQueryResult;
+  onSelect?: (selection: AnalysisSelection) => void;
 }) {
   const containerRef = useRef<HTMLDivElement>(null);
   const option = useMemo(() => chartOptionFor(spec, dataset, result), [spec, dataset, result]);
@@ -266,13 +295,19 @@ function EChartAnalysis({
     if (!containerRef.current || !option) return undefined;
     const chart = echarts.init(containerRef.current);
     chart.setOption(option, true);
+    const click = (params: any) => {
+      const selection = selectionForRow(spec, dataset, result, Number(params?.dataIndex));
+      if (selection) onSelect?.(selection);
+    };
+    chart.on('click', click);
     const observer = new ResizeObserver(() => chart.resize());
     observer.observe(containerRef.current);
     return () => {
       observer.disconnect();
+      chart.off('click', click);
       chart.dispose();
     };
-  }, [option]);
+  }, [option, onSelect, spec, dataset, result]);
 
   if (!option) {
     return <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="请配置维度和指标" className="mt-8" />;
@@ -311,10 +346,12 @@ function TableAnalysis({
   spec,
   dataset,
   result,
+  onSelect,
 }: {
   spec: AnalysisSpec;
   dataset: PublishedDataset;
   result: DatasetQueryResult;
+  onSelect?: (selection: AnalysisSelection) => void;
 }) {
   const dimensions = spec.dimensions.map((field) => getAnalysisField(dataset, field)).filter(Boolean);
   return (
@@ -336,7 +373,14 @@ function TableAnalysis({
         </thead>
         <tbody>
           {result.rows.map((row, rowIndex) => (
-            <tr key={rowIndex} className="hover:bg-[#fafbfc]">
+            <tr
+              key={rowIndex}
+              className={onSelect && spec.dimensions.length ? 'cursor-pointer hover:bg-[#f7f8fa]' : 'hover:bg-[#fafbfc]'}
+              onClick={() => {
+                const selection = selectionForRow(spec, dataset, result, rowIndex);
+                if (selection) onSelect?.(selection);
+              }}
+            >
               {spec.dimensions.map((field) => (
                 <td key={field} className="border-b border-[#f0f2f5] px-3 py-2 text-[#344054]">
                   {String(cell(result, row, field) ?? '')}
@@ -361,13 +405,17 @@ function TableAnalysis({
 export function AnalysisPreview({
   spec,
   dataset,
+  runtimeFilters = [],
+  onSelect,
   className = 'h-full min-h-0',
 }: {
   spec: AnalysisSpec;
   dataset?: PublishedDataset;
+  runtimeFilters?: AnalysisFilter[];
+  onSelect?: (selection: AnalysisSelection) => void;
   className?: string;
 }) {
-  const { result, loading, error } = useAnalysisQuery(spec, dataset);
+  const { result, loading, error } = useAnalysisQuery(spec, dataset, runtimeFilters);
   if (!dataset) {
     return <div className={className}><Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="Dataset 不存在或已下线" className="mt-8" /></div>;
   }
@@ -386,9 +434,9 @@ export function AnalysisPreview({
     <div className={`relative ${className}`}>
       {loading ? <Spin size="small" className="absolute right-3 top-3 z-20" /> : null}
       {spec.type === 'metric' ? <MetricAnalysis spec={spec} dataset={dataset} result={result} /> : null}
-      {spec.type === 'table' ? <TableAnalysis spec={spec} dataset={dataset} result={result} /> : null}
+      {spec.type === 'table' ? <TableAnalysis spec={spec} dataset={dataset} result={result} onSelect={onSelect} /> : null}
       {spec.type !== 'metric' && spec.type !== 'table'
-        ? <EChartAnalysis spec={spec} dataset={dataset} result={result} />
+        ? <EChartAnalysis spec={spec} dataset={dataset} result={result} onSelect={onSelect} />
         : null}
     </div>
   );

--- a/yak-ops-ui/src/components/analysis/model.ts
+++ b/yak-ops-ui/src/components/analysis/model.ts
@@ -74,6 +74,14 @@ export interface AnalysisAsset extends AnalysisSpec {
   updatedAt?: string;
 }
 
+/** Semantic selection emitted by a chart/table for Dashboard interaction routing. */
+export interface AnalysisSelection {
+  fieldId: string;
+  value: Scalar;
+  label: string;
+  rowIndex: number;
+}
+
 export interface DatasetQueryMetric {
   fieldId: string;
   aggregation: Aggregation;

--- a/yak-ops-ui/src/pages/dashboard/dashboard-service.ts
+++ b/yak-ops-ui/src/pages/dashboard/dashboard-service.ts
@@ -1,13 +1,16 @@
+import type { AnalysisSpec, Scalar } from '@/components/analysis/model';
 import type { ApiResponse } from '@/services/http/response';
 import { API_SUCCESS_CODE } from '@/services/http/response';
 import HttpUtils from '@/utils/HttpUtils';
-import type { AnalysisSpec } from '@/components/analysis/model';
 import type {
   DashboardDocument,
+  DashboardGlobalFilter,
+  DashboardInteraction,
   DashboardServerDetail,
   DashboardSummary,
   DashboardVersionSummary,
   DashboardWidget,
+  FilterOperator,
 } from './model';
 
 const DASHBOARD_API = '/api/v1/dashboards';
@@ -48,11 +51,31 @@ interface DashboardWidgetWire {
   sortOrder: number;
 }
 
+interface DashboardGlobalFilterWire {
+  filterKey: string;
+  name: string;
+  operator: 'EQ' | 'NE' | 'CONTAINS' | 'GT' | 'GTE' | 'LT' | 'LTE';
+  defaultValue?: Scalar;
+  bindings: Array<{ widgetKey: string; fieldId: string; sortOrder: number }>;
+  sortOrder: number;
+}
+
+interface DashboardInteractionWire {
+  interactionKey: string;
+  event: 'SELECT';
+  sourceWidgetKey: string;
+  sourceFieldId: string;
+  targetFilterKey: string;
+  sortOrder: number;
+}
+
 interface DashboardDetailWire {
   dashboard: DashboardAssetWire;
   currentVersion?: DashboardVersionWire | null;
   versions: DashboardVersionWire[];
   widgets: DashboardWidgetWire[];
+  globalFilters?: DashboardGlobalFilterWire[];
+  interactions?: DashboardInteractionWire[];
 }
 
 const unwrap = <T,>(response: ApiResponse<T>, fallback: string): T => {
@@ -95,11 +118,52 @@ const widget = (value: DashboardWidgetWire): DashboardWidget => ({
   minH: value.minH ?? undefined,
 });
 
+const operatorFromWire = (value: DashboardGlobalFilterWire['operator']): FilterOperator => ({
+  EQ: 'eq',
+  NE: 'neq',
+  CONTAINS: 'contains',
+  GT: 'gt',
+  GTE: 'gte',
+  LT: 'lt',
+  LTE: 'lte',
+}[value] as FilterOperator);
+
+const operatorToWire = (value: FilterOperator): DashboardGlobalFilterWire['operator'] => ({
+  eq: 'EQ',
+  neq: 'NE',
+  contains: 'CONTAINS',
+  gt: 'GT',
+  gte: 'GTE',
+  lt: 'LT',
+  lte: 'LTE',
+}[value] as DashboardGlobalFilterWire['operator']);
+
+const globalFilter = (value: DashboardGlobalFilterWire): DashboardGlobalFilter => ({
+  id: value.filterKey,
+  name: value.name,
+  operator: operatorFromWire(value.operator),
+  defaultValue: value.defaultValue,
+  bindings: (value.bindings || []).map((binding) => ({
+    widgetId: binding.widgetKey,
+    field: binding.fieldId,
+  })),
+});
+
+const interaction = (value: DashboardInteractionWire): DashboardInteraction => ({
+  id: value.interactionKey,
+  event: 'select',
+  sourceWidgetId: value.sourceWidgetKey,
+  sourceField: value.sourceFieldId,
+  targetFilterId: value.targetFilterKey,
+});
+
 export const toDashboardServerDetail = (value: DashboardDetailWire): DashboardServerDetail => ({
   dashboard: summary(value.dashboard),
   currentVersion: value.currentVersion ? version(value.currentVersion) : undefined,
   versions: (value.versions || []).map(version),
   widgets: (value.widgets || []).map(widget),
+  globalFilters: (value.globalFilters || []).map(globalFilter),
+  interactions: (value.interactions || []).map(interaction),
 });
 
 export const toDashboardDocument = (detail: DashboardServerDetail): DashboardDocument => ({
@@ -109,6 +173,8 @@ export const toDashboardDocument = (detail: DashboardServerDetail): DashboardDoc
   description: detail.currentVersion?.description || detail.dashboard.description,
   activeDatasetId: detail.currentVersion?.activeDatasetId || '',
   widgets: detail.widgets,
+  globalFilters: detail.globalFilters,
+  interactions: detail.interactions,
   currentVersionNo: detail.dashboard.currentVersionNo,
   currentVersionId: detail.dashboard.currentVersionId,
   updatedAt: detail.dashboard.updateTime,
@@ -129,6 +195,23 @@ const payload = (document: DashboardDocument) => ({
     h: item.h,
     minW: item.minW,
     minH: item.minH,
+  })),
+  globalFilters: document.globalFilters.map((filter) => ({
+    filterKey: filter.id,
+    name: filter.name,
+    operator: operatorToWire(filter.operator),
+    defaultValue: filter.defaultValue,
+    bindings: filter.bindings.map((binding) => ({
+      widgetKey: binding.widgetId,
+      fieldId: binding.field,
+    })),
+  })),
+  interactions: document.interactions.map((item) => ({
+    interactionKey: item.id,
+    event: 'SELECT',
+    sourceWidgetKey: item.sourceWidgetId,
+    sourceFieldId: item.sourceField,
+    targetFilterKey: item.targetFilterId,
   })),
 });
 

--- a/yak-ops-ui/src/pages/dashboard/defaults.ts
+++ b/yak-ops-ui/src/pages/dashboard/defaults.ts
@@ -8,4 +8,6 @@ export const DEFAULT_DASHBOARD: DashboardDocument = {
   description: '',
   activeDatasetId: '',
   widgets: [],
+  globalFilters: [],
+  interactions: [],
 };

--- a/yak-ops-ui/src/pages/dashboard/global-filter-bar.tsx
+++ b/yak-ops-ui/src/pages/dashboard/global-filter-bar.tsx
@@ -1,0 +1,351 @@
+import type { AnalysisSpec } from '@/components/analysis/model';
+import { Button, Drawer, Empty, Input, Select, Tooltip } from 'antd';
+import { Plus, RefreshCw, SlidersHorizontal, Trash2, Workflow } from 'lucide-react';
+import { useMemo, useState } from 'react';
+import { FILTER_OPERATOR_OPTIONS } from './helpers';
+import type {
+  AnalysisAsset,
+  DashboardGlobalFilter,
+  DashboardInteraction,
+  DashboardWidget,
+  FilterOperator,
+  PublishedDataset,
+  Scalar,
+} from './model';
+
+const OPERATOR_LABELS: Record<FilterOperator, string> = {
+  eq: '等于',
+  neq: '不等于',
+  contains: '包含',
+  gt: '大于',
+  gte: '大于等于',
+  lt: '小于',
+  lte: '小于等于',
+};
+
+const own = (value: Record<string, Scalar | undefined>, key: string) =>
+  Object.prototype.hasOwnProperty.call(value, key);
+
+const id = (prefix: string) => `${prefix}-${Date.now()}-${Math.round(Math.random() * 10000)}`;
+
+export function DashboardGlobalFilterBar({
+  filters,
+  interactions,
+  widgets,
+  analyses,
+  datasets,
+  runtimeValues,
+  preview,
+  onFiltersChange,
+  onInteractionsChange,
+  onRuntimeValue,
+  onReset,
+}: {
+  filters: DashboardGlobalFilter[];
+  interactions: DashboardInteraction[];
+  widgets: DashboardWidget[];
+  analyses: AnalysisAsset[];
+  datasets: PublishedDataset[];
+  runtimeValues: Record<string, Scalar | undefined>;
+  preview: boolean;
+  onFiltersChange: (filters: DashboardGlobalFilter[]) => void;
+  onInteractionsChange: (interactions: DashboardInteraction[]) => void;
+  onRuntimeValue: (filterId: string, value: Scalar | undefined) => void;
+  onReset: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const analysisMap = useMemo(() => new Map(analyses.map((item) => [item.id, item])), [analyses]);
+  const datasetMap = useMemo(() => new Map(datasets.map((item) => [item.id, item])), [datasets]);
+
+  const specForWidget = (widget?: DashboardWidget): AnalysisSpec | undefined => {
+    if (!widget) return undefined;
+    return widget.analysisId ? analysisMap.get(widget.analysisId) : widget.inlineAnalysis;
+  };
+
+  const widgetLabel = (widget: DashboardWidget) => {
+    if (widget.analysisId) return analysisMap.get(widget.analysisId)?.name ?? `Analysis #${widget.analysisId}`;
+    return widget.title || '未命名图表';
+  };
+
+  const fieldOptions = (widgetId?: string) => {
+    const widget = widgets.find((item) => item.id === widgetId);
+    const spec = specForWidget(widget);
+    const dataset = spec ? datasetMap.get(spec.datasetId) : undefined;
+    return dataset?.fields.map((field) => ({ label: field.label, value: field.key })) ?? [];
+  };
+
+  const sourceDimensionOptions = (widgetId?: string) => {
+    const widget = widgets.find((item) => item.id === widgetId);
+    const spec = specForWidget(widget);
+    const dataset = spec ? datasetMap.get(spec.datasetId) : undefined;
+    if (!spec || !dataset || !spec.dimensions.length) return [];
+    // AnalysisPreview emits the primary visible category. Multi-dimension linkage can be expanded later.
+    const primary = spec.dimensions[0];
+    const field = dataset.fields.find((item) => item.key === primary);
+    return field ? [{ label: field.label, value: field.key }] : [];
+  };
+
+  const widgetOptions = widgets.map((widget) => ({ label: widgetLabel(widget), value: widget.id }));
+  const sourceWidgetOptions = widgets
+    .filter((widget) => sourceDimensionOptions(widget.id).length > 0)
+    .map((widget) => ({ label: widgetLabel(widget), value: widget.id }));
+
+  const replaceFilter = (filterId: string, patch: Partial<DashboardGlobalFilter>) => {
+    onFiltersChange(filters.map((filter) => filter.id === filterId ? { ...filter, ...patch } : filter));
+  };
+
+  const removeFilter = (filterId: string) => {
+    onFiltersChange(filters.filter((filter) => filter.id !== filterId));
+    onInteractionsChange(interactions.filter((item) => item.targetFilterId !== filterId));
+  };
+
+  const addFilter = () => onFiltersChange([
+    ...filters,
+    {
+      id: id('filter'),
+      name: `筛选器 ${filters.length + 1}`,
+      operator: 'eq',
+      defaultValue: '',
+      bindings: [],
+    },
+  ]);
+
+  const addBinding = (filter: DashboardGlobalFilter) => {
+    const used = new Set(filter.bindings.map((item) => item.widgetId));
+    const widget = widgets.find((item) => !used.has(item.id) && fieldOptions(item.id).length > 0);
+    if (!widget) return;
+    const field = fieldOptions(widget.id)[0];
+    replaceFilter(filter.id, {
+      bindings: [...filter.bindings, { widgetId: widget.id, field: String(field.value) }],
+    });
+  };
+
+  const updateBinding = (
+    filter: DashboardGlobalFilter,
+    index: number,
+    patch: Partial<DashboardGlobalFilter['bindings'][number]>,
+  ) => {
+    replaceFilter(filter.id, {
+      bindings: filter.bindings.map((binding, bindingIndex) => (
+        bindingIndex === index ? { ...binding, ...patch } : binding
+      )),
+    });
+  };
+
+  const addInteraction = () => {
+    const sourceWidget = sourceWidgetOptions[0]?.value;
+    const targetFilter = filters[0]?.id;
+    if (!sourceWidget || !targetFilter) return;
+    const sourceField = sourceDimensionOptions(sourceWidget)[0]?.value;
+    if (!sourceField) return;
+    onInteractionsChange([
+      ...interactions,
+      {
+        id: id('interaction'),
+        event: 'select',
+        sourceWidgetId: String(sourceWidget),
+        sourceField: String(sourceField),
+        targetFilterId: targetFilter,
+      },
+    ]);
+  };
+
+  const updateInteraction = (interactionId: string, patch: Partial<DashboardInteraction>) => {
+    onInteractionsChange(interactions.map((item) => item.id === interactionId ? { ...item, ...patch } : item));
+  };
+
+  if (preview && !filters.length) return null;
+
+  return (
+    <>
+      <div className="flex min-h-10 shrink-0 items-center gap-2 border-b border-[#e5e7eb] bg-white px-3 py-1.5">
+        <div className="flex shrink-0 items-center gap-1.5 text-[11px] font-medium text-[#475467]">
+          <SlidersHorizontal size={13} /> 全局筛选
+        </div>
+        <div className="flex min-w-0 flex-1 items-center gap-2 overflow-x-auto">
+          {filters.map((filter) => {
+            const current = own(runtimeValues, filter.id) ? runtimeValues[filter.id] : filter.defaultValue;
+            return (
+              <div key={filter.id} className="flex shrink-0 items-center rounded-[4px] border border-[#e5e7eb] bg-[#fafbfc] pl-2">
+                <span className="mr-1.5 text-[10px] text-[#667085]">{filter.name}</span>
+                <span className="mr-1 text-[9px] text-[#98a2b3]">{OPERATOR_LABELS[filter.operator]}</span>
+                <Input
+                  variant="borderless"
+                  size="small"
+                  allowClear
+                  className="w-[128px] text-[11px]"
+                  placeholder="全部"
+                  value={current === undefined || current === null ? '' : String(current)}
+                  onChange={(event) => onRuntimeValue(filter.id, event.target.value)}
+                />
+              </div>
+            );
+          })}
+          {!filters.length ? <span className="text-[10px] text-[#98a2b3]">暂无全局筛选器</span> : null}
+        </div>
+        {filters.length ? (
+          <Tooltip title="恢复默认值">
+            <Button size="small" type="text" icon={<RefreshCw size={12} />} onClick={onReset} />
+          </Tooltip>
+        ) : null}
+        {!preview ? (
+          <Button size="small" icon={<SlidersHorizontal size={12} />} onClick={() => setOpen(true)}>
+            管理筛选与联动
+          </Button>
+        ) : null}
+      </div>
+
+      <Drawer
+        title="全局筛选器与组件联动"
+        width={520}
+        open={open}
+        onClose={() => setOpen(false)}
+        extra={<span className="text-[10px] text-[#98a2b3]">配置随下一次 Dashboard 保存进入新版本</span>}
+      >
+        <div className="mb-4 rounded-[5px] bg-[#f7f8fa] px-3 py-2 text-[11px] leading-5 text-[#667085]">
+          全局筛选器通过 fieldId 映射到不同 Widget；运行时输入值只影响当前浏览。联动规则会把图表点击的分类值写入目标筛选器，从而驱动所有绑定 Widget 一起刷新。
+        </div>
+
+        <div className="mb-2 flex items-center justify-between">
+          <div className="text-[12px] font-semibold text-[#344054]">全局筛选器</div>
+          <Button size="small" icon={<Plus size={12} />} onClick={addFilter}>新增筛选器</Button>
+        </div>
+
+        {!filters.length ? (
+          <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="先创建一个全局筛选器" />
+        ) : filters.map((filter) => (
+          <div key={filter.id} className="mb-3 rounded-[6px] border border-[#e5e7eb] bg-white p-3">
+            <div className="flex items-center gap-2">
+              <Input
+                size="small"
+                value={filter.name}
+                placeholder="筛选器名称"
+                onChange={(event) => replaceFilter(filter.id, { name: event.target.value })}
+              />
+              <Select
+                size="small"
+                className="w-[120px] shrink-0"
+                value={filter.operator}
+                options={FILTER_OPERATOR_OPTIONS}
+                onChange={(operator: FilterOperator) => replaceFilter(filter.id, { operator })}
+              />
+              <Tooltip title="删除筛选器">
+                <Button size="small" type="text" danger icon={<Trash2 size={12} />} onClick={() => removeFilter(filter.id)} />
+              </Tooltip>
+            </div>
+            <div className="mt-2">
+              <div className="mb-1 text-[10px] text-[#98a2b3]">默认值（可留空）</div>
+              <Input
+                size="small"
+                allowClear
+                value={filter.defaultValue === undefined || filter.defaultValue === null ? '' : String(filter.defaultValue)}
+                onChange={(event) => replaceFilter(filter.id, { defaultValue: event.target.value })}
+              />
+            </div>
+            <div className="mb-1 mt-3 flex items-center justify-between">
+              <span className="text-[10px] font-medium text-[#667085]">影响组件 / 字段映射</span>
+              <Button size="small" type="text" icon={<Plus size={11} />} onClick={() => addBinding(filter)}>添加映射</Button>
+            </div>
+            <div className="space-y-2">
+              {filter.bindings.map((binding, bindingIndex) => {
+                const used = new Set(filter.bindings.filter((_, index) => index !== bindingIndex).map((item) => item.widgetId));
+                const targetWidgetOptions = widgetOptions.filter((item) => !used.has(String(item.value)));
+                return (
+                  <div key={`${filter.id}-${bindingIndex}`} className="grid grid-cols-[1fr_1fr_28px] gap-2">
+                    <Select
+                      size="small"
+                      value={binding.widgetId}
+                      options={targetWidgetOptions}
+                      placeholder="目标组件"
+                      onChange={(widgetId: string) => updateBinding(filter, bindingIndex, {
+                        widgetId,
+                        field: String(fieldOptions(widgetId)[0]?.value ?? ''),
+                      })}
+                    />
+                    <Select
+                      size="small"
+                      value={binding.field || undefined}
+                      options={fieldOptions(binding.widgetId)}
+                      placeholder="目标字段"
+                      onChange={(field: string) => updateBinding(filter, bindingIndex, { field })}
+                    />
+                    <Button
+                      size="small"
+                      type="text"
+                      danger
+                      icon={<Trash2 size={11} />}
+                      onClick={() => replaceFilter(filter.id, {
+                        bindings: filter.bindings.filter((_, index) => index !== bindingIndex),
+                      })}
+                    />
+                  </div>
+                );
+              })}
+              {!filter.bindings.length ? (
+                <div className="rounded-[4px] border border-dashed border-[#e5e7eb] px-2 py-2 text-[10px] text-[#98a2b3]">
+                  尚未绑定 Widget；该筛选器暂时不会影响查询。
+                </div>
+              ) : null}
+            </div>
+          </div>
+        ))}
+
+        <div className="mb-2 mt-6 flex items-center justify-between border-t border-[#edf0f3] pt-4">
+          <div className="flex items-center gap-1.5 text-[12px] font-semibold text-[#344054]"><Workflow size={13} />组件联动</div>
+          <Button size="small" icon={<Plus size={12} />} disabled={!filters.length || !sourceWidgetOptions.length} onClick={addInteraction}>
+            新增联动
+          </Button>
+        </div>
+
+        {!interactions.length ? (
+          <div className="rounded-[5px] bg-[#f7f8fa] px-3 py-3 text-[10px] leading-5 text-[#98a2b3]">
+            配置后，点击来源图表的分类值，会自动写入目标全局筛选器并刷新所有绑定组件。
+          </div>
+        ) : (
+          <div className="space-y-2">
+            {interactions.map((interaction) => (
+              <div key={interaction.id} className="rounded-[5px] border border-[#e5e7eb] p-2.5">
+                <div className="grid grid-cols-[1fr_1fr_30px] gap-2">
+                  <Select
+                    size="small"
+                    value={interaction.sourceWidgetId}
+                    options={sourceWidgetOptions}
+                    placeholder="来源组件"
+                    onChange={(sourceWidgetId: string) => updateInteraction(interaction.id, {
+                      sourceWidgetId,
+                      sourceField: String(sourceDimensionOptions(sourceWidgetId)[0]?.value ?? ''),
+                    })}
+                  />
+                  <Select
+                    size="small"
+                    value={interaction.sourceField || undefined}
+                    options={sourceDimensionOptions(interaction.sourceWidgetId)}
+                    placeholder="点击维度"
+                    onChange={(sourceField: string) => updateInteraction(interaction.id, { sourceField })}
+                  />
+                  <Button
+                    size="small"
+                    type="text"
+                    danger
+                    icon={<Trash2 size={11} />}
+                    onClick={() => onInteractionsChange(interactions.filter((item) => item.id !== interaction.id))}
+                  />
+                </div>
+                <div className="mt-2 flex items-center gap-2">
+                  <span className="text-[10px] text-[#98a2b3]">点击后写入</span>
+                  <Select
+                    size="small"
+                    className="flex-1"
+                    value={interaction.targetFilterId}
+                    options={filters.map((filter) => ({ label: filter.name, value: filter.id }))}
+                    onChange={(targetFilterId: string) => updateInteraction(interaction.id, { targetFilterId })}
+                  />
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </Drawer>
+    </>
+  );
+}

--- a/yak-ops-ui/src/pages/dashboard/helpers.tsx
+++ b/yak-ops-ui/src/pages/dashboard/helpers.tsx
@@ -88,6 +88,8 @@ export const loadDashboard = (): DashboardDocument => {
       currentVersionId: undefined,
       currentVersionNo: undefined,
       widgets: parsed.widgets.map(legacyWidgetToCurrent),
+      globalFilters: Array.isArray(parsed.globalFilters) ? parsed.globalFilters : [],
+      interactions: Array.isArray(parsed.interactions) ? parsed.interactions : [],
     };
   } catch {
     return cloneDashboard(DEFAULT_DASHBOARD);

--- a/yak-ops-ui/src/pages/dashboard/index.tsx
+++ b/yak-ops-ui/src/pages/dashboard/index.tsx
@@ -3,6 +3,7 @@ import ReactGridLayout, { useContainerWidth } from 'react-grid-layout';
 import 'react-grid-layout/css/styles.css';
 import 'react-resizable/css/styles.css';
 import { useMemo } from 'react';
+import { DashboardGlobalFilterBar } from './global-filter-bar';
 import { GRID_COLUMNS, GRID_ROW_HEIGHT } from './helpers';
 import { LeftPanel } from './left-panel';
 import { SelectedConfig } from './selected-config';
@@ -53,6 +54,20 @@ export default function DashboardPage() {
         onSave={() => void designer.save()}
       />
 
+      <DashboardGlobalFilterBar
+        filters={designer.dashboard.globalFilters}
+        interactions={designer.dashboard.interactions}
+        widgets={designer.widgets}
+        analyses={designer.analyses}
+        datasets={designer.datasets}
+        runtimeValues={designer.runtimeFilterValues}
+        preview={designer.preview}
+        onFiltersChange={designer.setGlobalFilters}
+        onInteractionsChange={designer.setInteractions}
+        onRuntimeValue={designer.setRuntimeFilterValue}
+        onReset={designer.resetRuntimeFilters}
+      />
+
       <div className="flex min-h-0 flex-1 overflow-hidden">
         {!designer.preview ? (
           <LeftPanel
@@ -78,7 +93,7 @@ export default function DashboardPage() {
             <div
               ref={containerRef}
               className={[
-                'mx-auto min-h-[calc(100vh-92px)] min-w-[760px] bg-white',
+                'mx-auto min-h-[calc(100vh-132px)] min-w-[760px] bg-white',
                 designer.preview ? 'max-w-[1500px] shadow-[0_1px_5px_rgba(16,24,40,.08)]' : 'dashboard-grid-canvas border border-[#dfe3e8]',
               ].join(' ')}
               onMouseDown={(event) => { if (event.target === event.currentTarget) designer.setSelectedId(undefined); }}
@@ -106,9 +121,11 @@ export default function DashboardPage() {
                           widget={widget}
                           analysis={analysis}
                           dataset={dataset}
+                          runtimeFilters={designer.runtimeFiltersForWidget(widget.id)}
                           selected={designer.selectedId === widget.id}
                           preview={designer.preview}
                           onSelect={() => { if (!designer.preview) designer.setSelectedId(widget.id); }}
+                          onDataSelect={(selection) => designer.handleWidgetSelection(widget.id, selection)}
                           onSaveAsAnalysis={() => void designer.saveWidgetAsAnalysis(widget.id)}
                           onDuplicate={() => designer.duplicateWidget(widget.id)}
                           onDelete={() => designer.deleteWidget(widget.id)}
@@ -121,7 +138,7 @@ export default function DashboardPage() {
               {!designer.widgets.length && !designer.datasetsLoading ? (
                 <div className="flex min-h-[360px] items-center justify-center px-6 text-center text-[12px] text-[#98a2b3]">
                   {designer.activeDataset
-                    ? '从左侧复用 Analysis，或新建图表开始分析；点击保存后会生成服务端 DashboardVersion'
+                    ? '从左侧复用 Analysis，或新建图表开始分析；可在顶部配置全局筛选与组件联动'
                     : '暂无可用 Dataset，请先在数据开发发布中心发布数据集'}
                 </div>
               ) : null}

--- a/yak-ops-ui/src/pages/dashboard/model.ts
+++ b/yak-ops-ui/src/pages/dashboard/model.ts
@@ -1,9 +1,14 @@
-import type { AnalysisSpec } from '@/components/analysis/model';
+import type {
+  AnalysisSpec,
+  FilterOperator,
+  Scalar,
+} from '@/components/analysis/model';
 
 export type {
   Aggregation,
   AnalysisAsset,
   AnalysisFilter as DashboardFilter,
+  AnalysisSelection,
   AnalysisSort as DashboardSort,
   AnalysisVisualConfig as DashboardWidgetStyle,
   ChartType,
@@ -40,6 +45,29 @@ export interface DashboardWidget {
 
 export type DashboardWidgetEditorModel = DashboardWidget & AnalysisSpec & { title: string };
 
+export interface DashboardGlobalFilterBinding {
+  widgetId: string;
+  field: string;
+}
+
+/** Versioned Dashboard filter definition. Current user-entered values are runtime-only. */
+export interface DashboardGlobalFilter {
+  id: string;
+  name: string;
+  operator: FilterOperator;
+  defaultValue?: Scalar;
+  bindings: DashboardGlobalFilterBinding[];
+}
+
+/** Versioned routing rule: selecting a source dimension writes into a global filter. */
+export interface DashboardInteraction {
+  id: string;
+  event: 'select';
+  sourceWidgetId: string;
+  sourceField: string;
+  targetFilterId: string;
+}
+
 export interface DashboardDocument {
   version: 1;
   id: string;
@@ -47,6 +75,8 @@ export interface DashboardDocument {
   description?: string;
   activeDatasetId: string;
   widgets: DashboardWidget[];
+  globalFilters: DashboardGlobalFilter[];
+  interactions: DashboardInteraction[];
   currentVersionNo?: number;
   currentVersionId?: string;
   updatedAt?: string;
@@ -77,4 +107,6 @@ export interface DashboardServerDetail {
   currentVersion?: DashboardVersionSummary;
   versions: DashboardVersionSummary[];
   widgets: DashboardWidget[];
+  globalFilters: DashboardGlobalFilter[];
+  interactions: DashboardInteraction[];
 }

--- a/yak-ops-ui/src/pages/dashboard/use-dashboard.ts
+++ b/yak-ops-ui/src/pages/dashboard/use-dashboard.ts
@@ -1,5 +1,10 @@
 import { createAnalysis, fetchAnalyses } from '@/components/analysis/analysis-service';
-import type { AnalysisSpec } from '@/components/analysis/model';
+import type {
+  AnalysisFilter,
+  AnalysisSelection,
+  AnalysisSpec,
+  Scalar,
+} from '@/components/analysis/model';
 import { message } from 'antd';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { DEFAULT_DASHBOARD } from './defaults';
@@ -25,6 +30,8 @@ import type {
   AnalysisAsset,
   ChartType,
   DashboardDocument,
+  DashboardGlobalFilter,
+  DashboardInteraction,
   DashboardSummary,
   DashboardVersionSummary,
   DashboardWidget,
@@ -56,6 +63,13 @@ const assetSpec = (analysis: AnalysisAsset): AnalysisSpec => ({
   timeoutSeconds: analysis.timeoutSeconds,
 });
 
+const runtimeDefaults = (filters: DashboardGlobalFilter[]) => Object.fromEntries(
+  filters.map((filter) => [filter.id, filter.defaultValue]),
+) as Record<string, Scalar | undefined>;
+
+const hasOwn = (value: Record<string, Scalar | undefined>, key: string) =>
+  Object.prototype.hasOwnProperty.call(value, key);
+
 export function useDashboardDesigner() {
   const [dashboard, setDashboard] = useState<DashboardDocument>(loadDashboard);
   const [datasets, setDatasets] = useState<PublishedDataset[]>([]);
@@ -68,6 +82,7 @@ export function useDashboardDesigner() {
   const [dashboardVersions, setDashboardVersions] = useState<DashboardVersionSummary[]>([]);
   const [dashboardsLoading, setDashboardsLoading] = useState(true);
   const [dashboardSaving, setDashboardSaving] = useState(false);
+  const [runtimeFilterValues, setRuntimeFilterValues] = useState<Record<string, Scalar | undefined>>({});
   const [selectedId, setSelectedId] = useState<string>();
   const [preview, setPreview] = useState(false);
   const didAutoOpen = useRef(false);
@@ -149,6 +164,11 @@ export function useDashboardDesigner() {
     setDashboard((current) => reconcileDashboard(current, datasets));
   }, [datasets]);
 
+  /** Switching/opening a persisted DashboardVersion resets runtime values to its saved defaults. */
+  useEffect(() => {
+    setRuntimeFilterValues(runtimeDefaults(dashboard.globalFilters));
+  }, [dashboard.id, dashboard.currentVersionId]);
+
   const updateWidget = (id: string, patch: Partial<DashboardWidget>) => setDashboard((current) => ({
     ...current,
     widgets: current.widgets.map((widget) => widget.id === id ? { ...widget, ...patch } : widget),
@@ -161,6 +181,66 @@ export function useDashboardDesigner() {
       return { ...widget, inlineAnalysis: { ...widget.inlineAnalysis, ...patch } };
     }),
   }));
+
+  const setGlobalFilters = (filters: DashboardGlobalFilter[]) => {
+    const filterIds = new Set(filters.map((filter) => filter.id));
+    setDashboard((current) => ({
+      ...current,
+      globalFilters: filters,
+      interactions: current.interactions.filter((item) => filterIds.has(item.targetFilterId)),
+    }));
+    setRuntimeFilterValues((current) => {
+      const next: Record<string, Scalar | undefined> = {};
+      filters.forEach((filter) => {
+        next[filter.id] = hasOwn(current, filter.id) ? current[filter.id] : filter.defaultValue;
+      });
+      return next;
+    });
+  };
+
+  const setInteractions = (interactions: DashboardInteraction[]) => setDashboard((current) => ({
+    ...current,
+    interactions,
+  }));
+
+  const setRuntimeFilterValue = (filterId: string, value: Scalar | undefined) => {
+    setRuntimeFilterValues((current) => ({ ...current, [filterId]: value }));
+  };
+
+  const resetRuntimeFilters = () => setRuntimeFilterValues(runtimeDefaults(dashboard.globalFilters));
+
+  const runtimeFiltersForWidget = useCallback((widgetId: string): AnalysisFilter[] => (
+    dashboard.globalFilters.flatMap((filter) => {
+      const binding = filter.bindings.find((item) => item.widgetId === widgetId);
+      if (!binding) return [];
+      const value = hasOwn(runtimeFilterValues, filter.id)
+        ? runtimeFilterValues[filter.id]
+        : filter.defaultValue;
+      if (value === undefined || value === null || value === '') return [];
+      return [{
+        id: `dashboard-${filter.id}`,
+        field: binding.field,
+        operator: filter.operator,
+        value: String(value),
+      }];
+    })
+  ), [dashboard.globalFilters, runtimeFilterValues]);
+
+  const handleWidgetSelection = useCallback((widgetId: string, selection: AnalysisSelection) => {
+    const matched = dashboard.interactions.filter((interaction) => (
+      interaction.event === 'select'
+      && interaction.sourceWidgetId === widgetId
+      && interaction.sourceField === selection.fieldId
+    ));
+    if (!matched.length) return;
+    setRuntimeFilterValues((current) => {
+      const next = { ...current };
+      matched.forEach((interaction) => {
+        next[interaction.targetFilterId] = selection.value;
+      });
+      return next;
+    });
+  }, [dashboard.interactions]);
 
   const maxY = () => widgets.reduce((value, widget) => Math.max(value, widget.y + widget.h), 0);
 
@@ -225,7 +305,15 @@ export function useDashboardDesigner() {
   };
 
   const deleteWidget = (id: string) => {
-    setDashboard((current) => ({ ...current, widgets: current.widgets.filter((widget) => widget.id !== id) }));
+    setDashboard((current) => ({
+      ...current,
+      widgets: current.widgets.filter((widget) => widget.id !== id),
+      globalFilters: current.globalFilters.map((filter) => ({
+        ...filter,
+        bindings: filter.bindings.filter((binding) => binding.widgetId !== id),
+      })),
+      interactions: current.interactions.filter((interaction) => interaction.sourceWidgetId !== id),
+    }));
     setSelectedId((current) => current === id ? undefined : current);
   };
 
@@ -235,7 +323,17 @@ export function useDashboardDesigner() {
     if (!widget?.inlineAnalysis) return;
     const dataset = findDataset(datasets, datasetId);
     if (!dataset) return;
-    updateWidget(id, { inlineAnalysis: createInlineAnalysis(widget.inlineAnalysis.type, dataset) });
+    setDashboard((current) => ({
+      ...current,
+      widgets: current.widgets.map((item) => item.id === id
+        ? { ...item, inlineAnalysis: createInlineAnalysis(item.inlineAnalysis!.type, dataset) }
+        : item),
+      globalFilters: current.globalFilters.map((filter) => ({
+        ...filter,
+        bindings: filter.bindings.filter((binding) => binding.widgetId !== id),
+      })),
+      interactions: current.interactions.filter((interaction) => interaction.sourceWidgetId !== id),
+    }));
   };
 
   const addField = (field: DatasetField) => {
@@ -309,6 +407,7 @@ export function useDashboardDesigner() {
     setDashboard(next);
     setDashboardVersions([]);
     setSelectedId(undefined);
+    setRuntimeFilterValues({});
     window.localStorage.removeItem(STORAGE_KEY);
   };
 
@@ -325,6 +424,7 @@ export function useDashboardDesigner() {
     dashboardVersions,
     dashboardsLoading,
     dashboardSaving,
+    runtimeFilterValues,
     selectedWidget,
     activeDataset,
     selectedId,
@@ -334,6 +434,12 @@ export function useDashboardDesigner() {
     setPreview,
     updateWidget,
     updateInlineAnalysis,
+    setGlobalFilters,
+    setInteractions,
+    setRuntimeFilterValue,
+    resetRuntimeFilters,
+    runtimeFiltersForWidget,
+    handleWidgetSelection,
     addWidget,
     addAnalysis,
     saveWidgetAsAnalysis,

--- a/yak-ops-ui/src/pages/dashboard/widget.tsx
+++ b/yak-ops-ui/src/pages/dashboard/widget.tsx
@@ -1,15 +1,23 @@
 import { AnalysisPreview } from '@/components/analysis/AnalysisPreview';
 import { Empty, Tooltip } from 'antd';
 import { Copy, GripVertical, Link2, Save, Trash2 } from 'lucide-react';
-import type { AnalysisAsset, DashboardWidget, PublishedDataset } from './model';
+import type {
+  AnalysisAsset,
+  AnalysisSelection,
+  DashboardFilter,
+  DashboardWidget,
+  PublishedDataset,
+} from './model';
 
 export function WidgetShell({
   widget,
   analysis,
   dataset,
+  runtimeFilters,
   selected,
   preview,
   onSelect,
+  onDataSelect,
   onDuplicate,
   onDelete,
   onSaveAsAnalysis,
@@ -17,9 +25,11 @@ export function WidgetShell({
   widget: DashboardWidget;
   analysis?: AnalysisAsset;
   dataset?: PublishedDataset;
+  runtimeFilters: DashboardFilter[];
   selected: boolean;
   preview: boolean;
   onSelect: () => void;
+  onDataSelect: (selection: AnalysisSelection) => void;
   onDuplicate: () => void;
   onDelete: () => void;
   onSaveAsAnalysis: () => void;
@@ -47,6 +57,7 @@ export function WidgetShell({
           </Tooltip>
         ) : null}
         <span className="min-w-0 flex-1 truncate text-[12px] font-medium text-[#344054]">{title}</span>
+        {runtimeFilters.length ? <span className="mr-2 text-[9px] text-[#667085]">筛选 {runtimeFilters.length}</span> : null}
         {dataset ? <span className="mr-2 text-[9px] text-[#b0b7c3]">DV{dataset.currentVersionNo ?? '-'}</span> : null}
         {!preview ? (
           <div className={['flex items-center gap-0.5 transition-opacity', selected ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'].join(' ')}>
@@ -87,7 +98,12 @@ export function WidgetShell({
       </div>
       <div className="min-h-0 flex-1 overflow-hidden">
         {spec ? (
-          <AnalysisPreview spec={spec} dataset={dataset} />
+          <AnalysisPreview
+            spec={spec}
+            dataset={dataset}
+            runtimeFilters={runtimeFilters}
+            onSelect={onDataSelect}
+          />
         ) : (
           <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="Analysis 引用已失效" className="mt-8" />
         )}


### PR DESCRIPTION
## 背景

前面 BI 主链已经完成：

```text
Data Development
  -> Dataset / DatasetVersion
  -> Dataset Query Runtime
  -> Analysis
  -> Dashboard / DashboardVersion
```

Dashboard 已经具备真实 Dataset 查询、可复用 Analysis、服务端持久化和不可变版本，本 PR 继续补齐交互分析能力：**Dashboard 全局筛选器 + Widget 联动**。

本阶段不做权限和 AI，重点把 BI 的运行时交互层做扎实。

## 核心边界

本 PR 坚持：

```text
Analysis = 可复用分析定义
DashboardFilter = Dashboard 运行时查询上下文
DashboardInteraction = Widget selection -> Filter 的路由规则
```

全局筛选不会修改 Analysis 自己保存的 dimensions / metrics / filters / visualConfig。

同一个 Analysis 放在不同 Dashboard 中，可以接受不同的 Dashboard 全局筛选上下文。

## 1. DashboardVersion 持久化全局筛选定义

DashboardVersion 新增版本化配置：

```text
DashboardVersion
├── Widget[]
├── GlobalFilter[]
│    └── Binding[]
└── Interaction[]
```

新增 Flyway V2：

```text
yak_dashboard_filter
yak_dashboard_filter_binding
yak_dashboard_interaction
```

`DashboardVersion` 会冻结：

- 筛选器名称
- 操作符
- 默认值
- Filter -> Widget/fieldId 映射
- Widget selection -> Filter 联动规则

但是用户当前临时输入的筛选值不持久化，也不会因为浏览/点击自动产生 DashboardVersion。

## 2. Filter 与 Binding 模型

一个全局筛选器定义：

```text
GlobalFilter
├── filterKey
├── name
├── operator
├── defaultValue
└── bindings[]
     ├── widgetKey
     └── fieldId
```

例如“区域”筛选器可以：

```text
区域 Filter
  ├── 销售趋势 Widget -> region_id
  ├── 订单排行 Widget -> area_code
  └── 客户分布 Widget -> region
```

因此即使 Widget 来自不同 Dataset，也可以通过显式 fieldId 映射共享同一个 Dashboard 筛选器。

同一个 Filter 对同一个 Widget 最多绑定一个目标字段，避免一个筛选值在单个 Widget 内被隐式 AND 到多个字段造成歧义。

## 3. 支持的全局筛选操作符

当前支持：

```text
EQ
NE
CONTAINS
GT
GTE
LT
LTE
```

前端保持语义操作符：

```text
eq / neq / contains / gt / gte / lt / lte
```

真正查询时仍由 AnalysisPreview / Dataset Runtime 适配到查询协议，不把 SQL 细节泄漏给 Dashboard。

## 4. Runtime value 与保存定义分离

这是本 PR 的关键设计：

```text
DashboardVersion
  -> 保存 Filter definition/defaultValue

浏览器当前会话
  -> runtimeFilterValues
```

用户在顶部输入：

```text
区域 = 华南
```

只会：

```text
runtimeFilterValues.region = 华南
    ↓
所有绑定 Widget 重新查询
```

不会：

```text
x 修改 Analysis
x 自动保存 DashboardVersion
x 把用户临时浏览状态写回默认值
```

切换 Dashboard / DashboardVersion 时，runtime values 会恢复为该版本保存的 defaultValue。

## 5. AnalysisPreview 支持外部 Runtime Filters

共享分析运行层新增：

```text
AnalysisPreview
  spec
  dataset
  runtimeFilters
```

最终请求：

```text
Analysis 自有 filters
        +
Dashboard runtime filters
        ↓
Dataset Query Runtime
```

Dashboard 不重新实现 SQL、过滤、浏览器本地聚合。

所有 Widget 仍然只通过已有 Dataset Query Runtime 查询真实数据。

## 6. Widget 联动模型

联动规则：

```text
Interaction
├── interactionKey
├── event = SELECT
├── sourceWidgetKey
├── sourceFieldId
└── targetFilterKey
```

运行链路：

```text
用户点击柱状图「华南」
        ↓
AnalysisPreview emits selection
        ↓
Dashboard Interaction Router
        ↓
目标 Filter = 华南
        ↓
所有绑定该 Filter 的 Widget
        ↓
重新调用 Dataset Query Runtime
```

所以可以实现典型 BI 场景：

```text
点击「区域销售额」中的 华南
       ↓
订单趋势
客户分布
商品排行
指标卡
       ↓
全部刷新为华南数据
```

## 7. Selection 不污染 Analysis

AnalysisPreview 只向上抛出语义 selection：

```text
fieldId
value
label
rowIndex
```

它不知道：

- 当前是不是 Dashboard
- 要联动哪个 Widget
- 要写哪个 Filter

这些路由关系全部由 DashboardInteraction 决定。

因此 AnalysisPreview 仍然可以独立用于“图表分析”页面。

## 8. 支持的来源组件

当前 SELECT 联动支持：

- 柱状图
- 折线图
- 饼图
- 表格行点击

指标卡没有分类维度，因此不作为 SELECT 联动来源。

当前设计器先暴露 Analysis 的主可见分类维度作为来源字段，后续可以在不改变 Interaction 模型的前提下扩展多维 selection、下钻和更多事件类型。

## 9. Dashboard 顶部全局筛选条

Dashboard Toolbar 下新增紧凑的全局筛选条：

```text
全局筛选 | 区域 = [华南] | 时间 >= [2026-01-01] | ... | 恢复默认 | 管理筛选与联动
```

- 编辑模式：可以打开管理抽屉
- 预览模式：保留可用的运行时筛选器，隐藏设计入口
- 没有筛选器时，预览模式不额外占空间

## 10. 筛选/联动设计器

新增 Drawer：

```text
全局筛选器与组件联动
```

支持：

### 全局筛选器

- 新建 / 删除
- 名称
- 操作符
- 默认值
- 添加多个 Widget 映射
- 每个 Widget 独立选择 fieldId

### 组件联动

- 来源 Widget
- 点击维度
- 目标全局 Filter
- 新建 / 删除联动规则

所有字段选项来自真实 Dataset schema / stable fieldId。

## 11. 删除 Widget / 切换 Dataset 的引用清理

如果删除 Widget：

- 自动移除所有指向它的 Filter binding
- 自动移除以它为 source 的 Interaction

如果 Dashboard-local Widget 切换 Dataset：

- 原 fieldId 映射可能已经失效
- 自动清除该 Widget 的 Filter binding / Interaction

避免保存出明显悬空配置。

## 12. 服务端完整性校验

DashboardService 增加约束：

```text
GlobalFilter <= 20
全部 Filter bindings <= 200
Interaction <= 100
```

并校验：

- filterKey 唯一
- interactionKey 唯一
- Filter binding 的 Widget 必须存在于当前 DashboardVersion
- 同一 Filter 对单 Widget 只能绑定一个 fieldId
- Interaction source Widget 必须存在
- Interaction target Filter 必须存在
- defaultValue 必须是 JSON scalar
- defaultValue 大小限制

数据库层同时通过版本内 FK 约束：

```text
FilterBinding -> Filter
FilterBinding -> Widget
Interaction -> source Widget
Interaction -> target Filter
```

避免 DashboardVersion 内出现悬空关系。

## 13. DashboardVersion 语义

保存：

```text
Dashboard V1
  filters / bindings / interactions

修改设计后点击保存
        ↓
Dashboard V2
  新的一份 filters / bindings / interactions
```

切回 V1 时：

- 恢复 V1 的筛选定义
- 恢复 V1 的映射
- 恢复 V1 的联动规则
- runtime value 重置为 V1 defaultValue

历史版本本身保持不可变。

## 14. 测试

DashboardServiceTest 新增/扩展覆盖：

- V1 保存 Filter + Binding + Interaction
- 默认值可正确恢复
- Analysis 引用继续校验
- 再次保存仍创建不可变下一个 DashboardVersion
- Filter 不能绑定不存在的 Widget
- Interaction 不能指向不存在的 Filter
- linked/inline Widget 互斥约束保持不变

## 本 PR 暂不做

按照当前阶段重点，本 PR 不做：

- 权限 / owner / sharing
- AI 分析
- Filter distinct values 自动枚举接口
- 多选 / 日期范围 / 数值范围等富筛选控件
- 级联筛选器
- 下钻 / 跳转
- 多维 selection
- 复杂交互图的循环检测/传播策略
- 用户个人 Saved View
- AnalysisVersion

这些可以在当前 `Filter definition -> runtime context -> Interaction routing` 边界稳定后继续扩展。

## 基线说明

开发过程中 `main` 又合并了 Workflow instance operations 相关提交。已确认这些提交与 Dashboard / Analysis 文件无重叠，并已将本分支重放到最新 `main`：当前分支 `ahead=1 / behind=0`，PR diff 只包含本阶段 Dashboard/Analysis 交互能力。