### PR TITLE
fix(workflow): harden launch lifecycle and execution admission

### DIFF
--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/WorkflowExecutionDao.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/WorkflowExecutionDao.java
@@ -25,7 +25,7 @@ public interface WorkflowExecutionDao {
 
   List<String> selectRecoverableExecutionIds();
 
-  long countActiveExecutions(String workflowId);
+  long countActiveExecutions(String workflowId, String latestExecutionId);
 
   String selectEffectiveRuntimeMetadata(String executionId);
 

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/WorkflowExecutionDao.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/WorkflowExecutionDao.java
@@ -25,6 +25,8 @@ public interface WorkflowExecutionDao {
 
   List<String> selectRecoverableExecutionIds();
 
+  long countActiveExecutions(String workflowId);
+
   String selectEffectiveRuntimeMetadata(String executionId);
 
   WorkflowNodeAttemptPO selectAttempt(String attemptId);

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/WorkflowExecutionDao.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/WorkflowExecutionDao.java
@@ -25,7 +25,7 @@ public interface WorkflowExecutionDao {
 
   List<String> selectRecoverableExecutionIds();
 
-  long countActiveExecutions(String workflowId, String latestExecutionId);
+  long countActiveExecutions(String workflowId);
 
   String selectEffectiveRuntimeMetadata(String executionId);
 

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/WorkflowScheduleTriggerDao.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/WorkflowScheduleTriggerDao.java
@@ -23,7 +23,7 @@ public interface WorkflowScheduleTriggerDao {
   }
 
   int update(WorkflowScheduleTriggerPO trigger);
-  int bindPreparedExecution(String triggerId, String executionId);
+  int bindPreparedExecution(String triggerId, String executionId, String executionStatus);
   void lockWorkflow(String workflowId);
   long countActiveExecutions(String workflowId);
   long countLaunchingTriggers(String workflowId);

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/impl/WorkflowExecutionDaoImpl.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/impl/WorkflowExecutionDaoImpl.java
@@ -81,8 +81,8 @@ public class WorkflowExecutionDaoImpl implements WorkflowExecutionDao {
   }
 
   @Override
-  public long countActiveExecutions(String workflowId, String latestExecutionId) {
-    return executionMapper.countActiveExecutions(workflowId, latestExecutionId);
+  public long countActiveExecutions(String workflowId) {
+    return executionMapper.countActiveExecutions(workflowId);
   }
 
   @Override

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/impl/WorkflowExecutionDaoImpl.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/impl/WorkflowExecutionDaoImpl.java
@@ -81,8 +81,8 @@ public class WorkflowExecutionDaoImpl implements WorkflowExecutionDao {
   }
 
   @Override
-  public long countActiveExecutions(String workflowId) {
-    return executionMapper.countActiveExecutions(workflowId);
+  public long countActiveExecutions(String workflowId, String latestExecutionId) {
+    return executionMapper.countActiveExecutions(workflowId, latestExecutionId);
   }
 
   @Override

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/impl/WorkflowExecutionDaoImpl.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/impl/WorkflowExecutionDaoImpl.java
@@ -81,6 +81,11 @@ public class WorkflowExecutionDaoImpl implements WorkflowExecutionDao {
   }
 
   @Override
+  public long countActiveExecutions(String workflowId) {
+    return executionMapper.countActiveExecutions(workflowId);
+  }
+
+  @Override
   public String selectEffectiveRuntimeMetadata(String executionId) {
     return executionMapper.selectEffectiveRuntimeMetadata(executionId);
   }

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/impl/WorkflowScheduleTriggerDaoImpl.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/impl/WorkflowScheduleTriggerDaoImpl.java
@@ -127,8 +127,11 @@ public class WorkflowScheduleTriggerDaoImpl implements WorkflowScheduleTriggerDa
   }
 
   @Override
-  public int bindPreparedExecution(String triggerId, String executionId) {
-    return mapper.bindPreparedExecution(triggerId, executionId);
+  public int bindPreparedExecution(
+      String triggerId,
+      String executionId,
+      String executionStatus) {
+    return mapper.bindPreparedExecution(triggerId, executionId, executionStatus);
   }
 
   @Override

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/mapper/WorkflowExecutionMapper.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/mapper/WorkflowExecutionMapper.java
@@ -13,9 +13,7 @@ public interface WorkflowExecutionMapper extends BaseMapper<WorkflowExecutionPO>
 
   List<String> selectRecoverableExecutionIds();
 
-  long countActiveExecutions(
-      @Param("workflowId") String workflowId,
-      @Param("latestExecutionId") String latestExecutionId);
+  long countActiveExecutions(@Param("workflowId") String workflowId);
 
   String selectEffectiveRuntimeMetadata(@Param("executionId") String executionId);
 }

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/mapper/WorkflowExecutionMapper.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/mapper/WorkflowExecutionMapper.java
@@ -13,7 +13,9 @@ public interface WorkflowExecutionMapper extends BaseMapper<WorkflowExecutionPO>
 
   List<String> selectRecoverableExecutionIds();
 
-  long countActiveExecutions(@Param("workflowId") String workflowId);
+  long countActiveExecutions(
+      @Param("workflowId") String workflowId,
+      @Param("latestExecutionId") String latestExecutionId);
 
   String selectEffectiveRuntimeMetadata(@Param("executionId") String executionId);
 }

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/mapper/WorkflowExecutionMapper.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/mapper/WorkflowExecutionMapper.java
@@ -13,5 +13,7 @@ public interface WorkflowExecutionMapper extends BaseMapper<WorkflowExecutionPO>
 
   List<String> selectRecoverableExecutionIds();
 
+  long countActiveExecutions(@Param("workflowId") String workflowId);
+
   String selectEffectiveRuntimeMetadata(@Param("executionId") String executionId);
 }

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/mapper/WorkflowScheduleTriggerMapper.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/mapper/WorkflowScheduleTriggerMapper.java
@@ -27,8 +27,8 @@ public interface WorkflowScheduleTriggerMapper extends BaseMapper<WorkflowSchedu
   @Update("""
       UPDATE yak_workflow_schedule_trigger
       SET workflow_execution_id = #{executionId},
-          execution_status = 'CREATED',
-          message = 'WorkflowExecution 已持久化，等待激活',
+          execution_status = #{executionStatus},
+          message = 'WorkflowExecution 已首次持久化',
           update_time = CURRENT_TIMESTAMP(3)
       WHERE trigger_id = #{triggerId}
         AND status = 'LAUNCHING'
@@ -36,7 +36,8 @@ public interface WorkflowScheduleTriggerMapper extends BaseMapper<WorkflowSchedu
       """)
   int bindPreparedExecution(
       @Param("triggerId") String triggerId,
-      @Param("executionId") String executionId);
+      @Param("executionId") String executionId,
+      @Param("executionStatus") String executionStatus);
 
   @Select("SELECT id FROM yak_workflow_definition WHERE id = #{workflowId} FOR UPDATE")
   String lockWorkflow(@Param("workflowId") String workflowId);

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/persistence/WorkflowExecutionRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/persistence/WorkflowExecutionRepositoryAdapter.java
@@ -51,8 +51,11 @@ public class WorkflowExecutionRepositoryAdapter implements ExecutionRepository {
   @Transactional(transactionManager = "yakBusinessTransactionManager")
   public void save(WorkflowExecution execution) {
     WorkflowExecutionSnapshot snapshot = execution.snapshot();
+    // Yak Framework transitions a new execution to RUNNING before its first repository save.
+    // Detect the first durable write from database existence instead of relying on CREATED.
+    boolean firstPersistence = executionDao.selectExecution(snapshot.id()) == null;
     executionDao.upsertExecution(toPO(snapshot));
-    bindPreparedScheduledExecution(snapshot);
+    bindFirstScheduledExecution(snapshot, firstPersistence);
     for (NodeExecutionSnapshot node : snapshot.nodes()) {
       executionDao.upsertNodeExecution(toPO(node));
       for (NodeAttemptSnapshot attempt : node.attempts()) {
@@ -65,12 +68,17 @@ public class WorkflowExecutionRepositoryAdapter implements ExecutionRepository {
     }
   }
 
-  private void bindPreparedScheduledExecution(WorkflowExecutionSnapshot snapshot) {
-    if (snapshot.status() != WorkflowExecutionStatus.CREATED) return;
+  private void bindFirstScheduledExecution(
+      WorkflowExecutionSnapshot snapshot,
+      boolean firstPersistence) {
+    if (!firstPersistence) return;
     String triggerId = WorkflowScheduleLaunchBindingScope.currentTriggerId();
     if (triggerId == null) return;
 
-    int bound = scheduleTriggerDao.bindPreparedExecution(triggerId, snapshot.id());
+    int bound = scheduleTriggerDao.bindPreparedExecution(
+        triggerId,
+        snapshot.id(),
+        snapshot.status().name());
     if (bound == 1) return;
 
     String existingExecutionId = scheduleTriggerDao.selectExecutionIdByTrigger(triggerId);

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/persistence/WorkflowExecutionRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/persistence/WorkflowExecutionRepositoryAdapter.java
@@ -52,10 +52,12 @@ public class WorkflowExecutionRepositoryAdapter implements ExecutionRepository {
   public void save(WorkflowExecution execution) {
     WorkflowExecutionSnapshot snapshot = execution.snapshot();
     // Yak Framework transitions a new execution to RUNNING before its first repository save.
-    // Detect the first durable write from database existence instead of relying on CREATED.
-    boolean firstPersistence = executionDao.selectExecution(snapshot.id()) == null;
+    // Only scheduled launches need the existence lookup; normal runtime saves stay on the hot upsert path.
+    String launchTriggerId = WorkflowScheduleLaunchBindingScope.currentTriggerId();
+    boolean firstScheduledPersistence = launchTriggerId != null
+        && executionDao.selectExecution(snapshot.id()) == null;
     executionDao.upsertExecution(toPO(snapshot));
-    bindFirstScheduledExecution(snapshot, firstPersistence);
+    bindFirstScheduledExecution(snapshot, launchTriggerId, firstScheduledPersistence);
     for (NodeExecutionSnapshot node : snapshot.nodes()) {
       executionDao.upsertNodeExecution(toPO(node));
       for (NodeAttemptSnapshot attempt : node.attempts()) {
@@ -70,10 +72,9 @@ public class WorkflowExecutionRepositoryAdapter implements ExecutionRepository {
 
   private void bindFirstScheduledExecution(
       WorkflowExecutionSnapshot snapshot,
-      boolean firstPersistence) {
-    if (!firstPersistence) return;
-    String triggerId = WorkflowScheduleLaunchBindingScope.currentTriggerId();
-    if (triggerId == null) return;
+      String triggerId,
+      boolean firstScheduledPersistence) {
+    if (!firstScheduledPersistence || triggerId == null) return;
 
     int bound = scheduleTriggerDao.bindPreparedExecution(
         triggerId,

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowDefinitionService.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowDefinitionService.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.yak.ops.business.job.task.TaskRegistry;
 import io.yak.ops.business.job.task.TaskVersionSnapshot;
 import io.yak.ops.business.taskcatalog.service.TaskCatalogService;
+import io.yak.ops.business.workflow.dao.WorkflowExecutionDao;
 import io.yak.ops.business.workflow.domain.WorkflowEdgeSpec;
 import io.yak.ops.business.workflow.domain.WorkflowNodeSpec;
 import io.yak.ops.business.workflow.domain.WorkflowRunSpec;
@@ -53,6 +54,7 @@ public class WorkflowDefinitionService {
   private final WorkflowRuntimeService runtimeService;
   private final WorkflowTaskBindingResolver taskBindingResolver;
   private final WorkflowDefinitionPersistence persistence;
+  private final WorkflowExecutionDao executionDao;
   private final ConcurrentMap<String, DefinitionState> definitions = new ConcurrentHashMap<>();
 
   @Autowired
@@ -62,6 +64,7 @@ public class WorkflowDefinitionService {
       ObjectProvider<TaskCatalogService> taskCatalogService,
       ObjectMapper objectMapper,
       ObjectProvider<WorkflowDefinitionPersistence> persistence,
+      ObjectProvider<WorkflowExecutionDao> executionDao,
       @Value("${yak.database.enabled:true}") boolean databaseEnabled) {
     this(
         runtimeService,
@@ -69,7 +72,8 @@ public class WorkflowDefinitionService {
             taskRegistry,
             taskCatalogService.getIfAvailable(),
             objectMapper),
-        resolvePersistence(persistence, databaseEnabled));
+        resolvePersistence(persistence, databaseEnabled),
+        resolveExecutionDao(executionDao, databaseEnabled));
   }
 
   /** Focused tests and explicit database-disabled development retain the lightweight catalog. */
@@ -79,7 +83,8 @@ public class WorkflowDefinitionService {
     this(
         runtimeService,
         new WorkflowTaskBindingResolver(taskRegistry, null, new ObjectMapper()),
-        NoopWorkflowDefinitionPersistence.INSTANCE);
+        NoopWorkflowDefinitionPersistence.INSTANCE,
+        null);
   }
 
   WorkflowDefinitionService(
@@ -89,7 +94,20 @@ public class WorkflowDefinitionService {
     this(
         runtimeService,
         new WorkflowTaskBindingResolver(taskRegistry, null, new ObjectMapper()),
-        persistence);
+        persistence,
+        null);
+  }
+
+  WorkflowDefinitionService(
+      WorkflowRuntimeService runtimeService,
+      TaskRegistry taskRegistry,
+      WorkflowDefinitionPersistence persistence,
+      WorkflowExecutionDao executionDao) {
+    this(
+        runtimeService,
+        new WorkflowTaskBindingResolver(taskRegistry, null, new ObjectMapper()),
+        persistence,
+        executionDao);
   }
 
   WorkflowDefinitionService(
@@ -100,16 +118,19 @@ public class WorkflowDefinitionService {
     this(
         runtimeService,
         new WorkflowTaskBindingResolver(taskRegistry, taskCatalogService, new ObjectMapper()),
-        persistence);
+        persistence,
+        null);
   }
 
   private WorkflowDefinitionService(
       WorkflowRuntimeService runtimeService,
       WorkflowTaskBindingResolver taskBindingResolver,
-      WorkflowDefinitionPersistence persistence) {
+      WorkflowDefinitionPersistence persistence,
+      WorkflowExecutionDao executionDao) {
     this.runtimeService = runtimeService;
     this.taskBindingResolver = taskBindingResolver;
     this.persistence = persistence;
+    this.executionDao = executionDao;
     restoreCatalog();
   }
 
@@ -122,6 +143,16 @@ public class WorkflowDefinitionService {
     throw new IllegalStateException(
         "Workflow durable persistence bean is missing while yak.database.enabled=true: "
             + "WorkflowDefinitionPersistence");
+  }
+
+  private static WorkflowExecutionDao resolveExecutionDao(
+      ObjectProvider<WorkflowExecutionDao> provider,
+      boolean databaseEnabled) {
+    WorkflowExecutionDao resolved = provider.getIfAvailable();
+    if (resolved != null) return resolved;
+    if (!databaseEnabled) return null;
+    throw new IllegalStateException(
+        "Workflow durable execution DAO is missing while yak.database.enabled=true: WorkflowExecutionDao");
   }
 
   public List<WorkflowDefinitionVO> list(String keyword, String status) {
@@ -370,8 +401,7 @@ public class WorkflowDefinitionService {
   public void delete(String id) {
     DefinitionState state = require(id);
     synchronized (state) {
-      refresh(state);
-      if (isActive(state.latestExecutionStatus)) {
+      if (hasActiveExecution(state)) {
         throw new IllegalStateException("工作流正在运行，不能删除");
       }
       if ("ONLINE".equals(state.status)) {
@@ -408,10 +438,21 @@ public class WorkflowDefinitionService {
   }
 
   private void ensureIdle(DefinitionState state) {
-    refresh(state);
-    if (isActive(state.latestExecutionStatus)) {
+    if (hasActiveExecution(state)) {
       throw new IllegalStateException("工作流已有运行中的执行实例");
     }
+  }
+
+  /**
+   * 生产环境以 durable WorkflowExecution 为并发事实源；latestExecution 只保留最近实例展示语义。
+   * database-disabled 的 focused test/development 才回退到历史 latest 状态判断。
+   */
+  private boolean hasActiveExecution(DefinitionState state) {
+    if (executionDao != null) {
+      return executionDao.countActiveExecutions(state.id) > 0L;
+    }
+    refresh(state);
+    return isActive(state.latestExecutionStatus);
   }
 
   private PreparedDraft prepare(DefinitionState state) {

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowLaunchService.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowLaunchService.java
@@ -147,45 +147,60 @@ public class WorkflowLaunchService {
         WorkflowDefinitionVO::latestExecutionId);
   }
 
-  /** 兼容直接提交 DAG 的底层运行接口，同时纳入统一 Trigger 入口。 */
+  /** 兼容直接提交 DAG 的底层运行接口，同时纳入统一 Trigger 入口并真正激活实例。 */
   public WorkflowInstanceVO runAdHoc(
       WorkflowRunDTO request,
       WorkflowTriggerContext triggerContext) {
     Objects.requireNonNull(request, "workflow run request");
-    return launch(
+    return launchPrepared(
         "AD_HOC",
         request.name(),
         triggerContext,
-        () -> runtimeService.run(request),
-        WorkflowInstanceVO::id);
+        () -> runtimeService.run(request));
   }
 
-  /** 整实例重新运行会创建新的 WorkflowExecution，因此也经过 Launch。 */
+  /** 整实例重新运行会创建并激活新的 WorkflowExecution，因此也经过 Launch。 */
   public WorkflowInstanceVO restart(
       String executionId,
       WorkflowTriggerContext triggerContext) {
     String id = required(executionId, "工作流实例 ID 不能为空");
-    return launch(
+    return launchPrepared(
         "RESTART",
         id,
         triggerContext,
-        () -> runtimeService.restart(id),
-        WorkflowInstanceVO::id);
+        () -> runtimeService.restart(id));
   }
 
-  /** 从指定节点重跑会创建新的 WorkflowExecution，因此也经过 Launch。 */
+  /** 从指定节点重跑会创建并激活新的 WorkflowExecution，因此也经过 Launch。 */
   public WorkflowInstanceVO rerunFromNode(
       String executionId,
       String nodeId,
       WorkflowTriggerContext triggerContext) {
     String safeExecutionId = required(executionId, "工作流实例 ID 不能为空");
     String safeNodeId = required(nodeId, "工作流节点 ID 不能为空");
-    return launch(
+    return launchPrepared(
         "RERUN_FROM_NODE",
         safeExecutionId + "/" + safeNodeId,
         triggerContext,
-        () -> runtimeService.rerunFromNode(safeExecutionId, safeNodeId),
-        WorkflowInstanceVO::id);
+        () -> runtimeService.rerunFromNode(safeExecutionId, safeNodeId));
+  }
+
+  /**
+   * Runtime 的 engine.start 会先生成 RUNNING 快照，但 Yak Ops 仍需 activate 才会 drain NodeDispatch。
+   * 先记录 Trigger，再激活，保证任何对外返回的 RUNNING 实例都已经进入真实执行生命周期。
+   */
+  private WorkflowInstanceVO launchPrepared(
+      String mode,
+      String target,
+      WorkflowTriggerContext triggerContext,
+      Supplier<WorkflowInstanceVO> prepare) {
+    return launch(
+        mode,
+        target,
+        triggerContext,
+        prepare,
+        WorkflowInstanceVO::id,
+        prepared -> runtimeService.activate(prepared.id()));
   }
 
   private <T> T launch(
@@ -194,6 +209,16 @@ public class WorkflowLaunchService {
       WorkflowTriggerContext triggerContext,
       Supplier<T> action,
       Function<T, String> executionIdExtractor) {
+    return launch(mode, target, triggerContext, action, executionIdExtractor, Function.identity());
+  }
+
+  private <T> T launch(
+      String mode,
+      String target,
+      WorkflowTriggerContext triggerContext,
+      Supplier<T> action,
+      Function<T, String> executionIdExtractor,
+      Function<T, T> afterRecord) {
     Objects.requireNonNull(triggerContext, "workflow trigger context");
     log.info(
         "[workflow-launch] start mode={}, target={}, triggerType={}, triggerId={}, scheduleId={}, backfillId={}, plannedFireTime={}",
@@ -205,8 +230,8 @@ public class WorkflowLaunchService {
         triggerContext.backfillId(),
         triggerContext.plannedFireTime());
     try {
-      T result = action.get();
-      String executionId = result == null ? null : executionIdExtractor.apply(result);
+      T prepared = action.get();
+      String executionId = prepared == null ? null : executionIdExtractor.apply(prepared);
       triggerRecorder.record(executionId, triggerContext);
       log.info(
           "[workflow-launch] created mode={}, target={}, triggerType={}, triggerId={}, execution={}",
@@ -215,7 +240,7 @@ public class WorkflowLaunchService {
           triggerContext.triggerType(),
           triggerContext.triggerId(),
           executionId);
-      return result;
+      return prepared == null ? null : afterRecord.apply(prepared);
     } catch (RuntimeException exception) {
       log.warn(
           "[workflow-launch] failed mode={}, target={}, triggerType={}, triggerId={}, message={}",

--- a/yak-ops-business/yak-ops-business-workflow/src/main/resources/mapper/workflow/WorkflowExecutionMapper.xml
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/resources/mapper/workflow/WorkflowExecutionMapper.xml
@@ -38,8 +38,11 @@
   <select id="countActiveExecutions" resultType="long">
     SELECT COUNT(*)
     FROM yak_workflow_execution e
-    INNER JOIN yak_workflow_version v ON v.id = e.definition_id
-    WHERE v.workflow_id = #{workflowId}
+    LEFT JOIN yak_workflow_version v ON v.id = e.definition_id
+    WHERE (
+        v.workflow_id = #{workflowId}
+        OR (#{latestExecutionId} IS NOT NULL AND e.id = #{latestExecutionId})
+      )
       AND e.status IN ('CREATED', 'RUNNING', 'PAUSING', 'PAUSED', 'RESUMING')
   </select>
 

--- a/yak-ops-business/yak-ops-business-workflow/src/main/resources/mapper/workflow/WorkflowExecutionMapper.xml
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/resources/mapper/workflow/WorkflowExecutionMapper.xml
@@ -35,6 +35,14 @@
     ORDER BY e.created_at
   </select>
 
+  <select id="countActiveExecutions" resultType="long">
+    SELECT COUNT(*)
+    FROM yak_workflow_execution e
+    INNER JOIN yak_workflow_version v ON v.id = e.definition_id
+    WHERE v.workflow_id = #{workflowId}
+      AND e.status IN ('CREATED', 'RUNNING', 'PAUSING', 'PAUSED', 'RESUMING')
+  </select>
+
   <select id="selectEffectiveRuntimeMetadata" resultType="java.lang.String">
     SELECT COALESCE(e.runtime_metadata_json, v.runtime_metadata_json)
     FROM yak_workflow_execution e

--- a/yak-ops-business/yak-ops-business-workflow/src/main/resources/mapper/workflow/WorkflowExecutionMapper.xml
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/resources/mapper/workflow/WorkflowExecutionMapper.xml
@@ -39,9 +39,10 @@
     SELECT COUNT(*)
     FROM yak_workflow_execution e
     LEFT JOIN yak_workflow_version v ON v.id = e.definition_id
+    LEFT JOIN yak_workflow_definition d ON d.id = #{workflowId}
     WHERE (
         v.workflow_id = #{workflowId}
-        OR (#{latestExecutionId} IS NOT NULL AND e.id = #{latestExecutionId})
+        OR e.id = d.latest_execution_id
       )
       AND e.status IN ('CREATED', 'RUNNING', 'PAUSING', 'PAUSED', 'RESUMING')
   </select>

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/persistence/WorkflowExecutionRepositoryAdapterTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/persistence/WorkflowExecutionRepositoryAdapterTest.java
@@ -1,0 +1,94 @@
+package io.yak.ops.business.workflow.persistence;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.framework.workflow.engine.execution.WorkflowExecution;
+import io.yak.framework.workflow.engine.execution.WorkflowExecutionSnapshot;
+import io.yak.framework.workflow.engine.state.WorkflowExecutionStatus;
+import io.yak.ops.business.workflow.dao.WorkflowExecutionDao;
+import io.yak.ops.business.workflow.dao.WorkflowScheduleTriggerDao;
+import io.yak.ops.business.workflow.domain.WorkflowScheduleLaunchBindingScope;
+import io.yak.ops.business.workflow.persistence.support.WorkflowJsonCodec;
+import io.yak.ops.common.bean.po.workflow.WorkflowExecutionPO;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+@ExtendWith(MockitoExtension.class)
+class WorkflowExecutionRepositoryAdapterTest {
+
+  @Mock private WorkflowExecutionDao executionDao;
+  @Mock private WorkflowScheduleTriggerDao scheduleTriggerDao;
+  @Mock private ApplicationEventPublisher eventPublisher;
+  @Mock private WorkflowExecution execution;
+
+  @Test
+  void shouldBindRunningExecutionOnFirstDurableSave() {
+    WorkflowExecutionRepositoryAdapter repository = repository();
+    WorkflowExecutionSnapshot snapshot = runningSnapshot("execution-1");
+    when(execution.snapshot()).thenReturn(snapshot);
+    when(executionDao.selectExecution("execution-1")).thenReturn(null);
+    when(scheduleTriggerDao.bindPreparedExecution(
+        "trigger-1", "execution-1", "RUNNING")).thenReturn(1);
+
+    try (var ignored = WorkflowScheduleLaunchBindingScope.open("trigger-1")) {
+      repository.save(execution);
+    }
+
+    InOrder order = inOrder(executionDao, scheduleTriggerDao);
+    order.verify(executionDao).upsertExecution(any(WorkflowExecutionPO.class));
+    order.verify(scheduleTriggerDao).bindPreparedExecution(
+        "trigger-1", "execution-1", "RUNNING");
+  }
+
+  @Test
+  void shouldNotRebindTriggerAfterExecutionAlreadyExists() {
+    WorkflowExecutionRepositoryAdapter repository = repository();
+    when(execution.snapshot()).thenReturn(runningSnapshot("execution-2"));
+    when(executionDao.selectExecution("execution-2")).thenReturn(new WorkflowExecutionPO());
+
+    try (var ignored = WorkflowScheduleLaunchBindingScope.open("trigger-2")) {
+      repository.save(execution);
+    }
+
+    verify(scheduleTriggerDao, never()).bindPreparedExecution(any(), any(), any());
+  }
+
+  private WorkflowExecutionRepositoryAdapter repository() {
+    return new WorkflowExecutionRepositoryAdapter(
+        executionDao,
+        scheduleTriggerDao,
+        new WorkflowJsonCodec(new ObjectMapper()),
+        eventPublisher);
+  }
+
+  private WorkflowExecutionSnapshot runningSnapshot(String executionId) {
+    Instant now = Instant.parse("2026-08-14T02:00:00Z");
+    return new WorkflowExecutionSnapshot(
+        executionId,
+        "workflow-version-1",
+        null,
+        Map.of(),
+        List.of(),
+        now,
+        WorkflowExecutionStatus.RUNNING,
+        false,
+        now,
+        null,
+        Duration.ZERO,
+        now,
+        null);
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowDefinitionActiveExecutionAdmissionTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowDefinitionActiveExecutionAdmissionTest.java
@@ -1,0 +1,138 @@
+package io.yak.ops.business.workflow.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.job.task.TaskRegistry;
+import io.yak.ops.business.job.task.TaskVersionSnapshot;
+import io.yak.ops.business.workflow.dao.WorkflowExecutionDao;
+import io.yak.ops.business.workflow.persistence.NoopWorkflowDefinitionPersistence;
+import io.yak.ops.common.bean.dto.workflow.WorkflowDefinitionCreateDTO;
+import io.yak.ops.common.bean.dto.workflow.WorkflowDefinitionUpdateDTO;
+import io.yak.ops.common.bean.dto.workflow.WorkflowDefinitionUpdateDTO.NodeDTO;
+import io.yak.ops.common.bean.vo.workflow.WorkflowDefinitionVO;
+import io.yak.ops.common.bean.vo.workflow.WorkflowInstanceVO;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class WorkflowDefinitionActiveExecutionAdmissionTest {
+
+  @Mock private WorkflowRuntimeService runtimeService;
+  @Mock private TaskRegistry taskRegistry;
+  @Mock private WorkflowExecutionDao executionDao;
+
+  private WorkflowDefinitionService service;
+
+  @BeforeEach
+  void setUp() {
+    service = new WorkflowDefinitionService(
+        runtimeService,
+        taskRegistry,
+        NoopWorkflowDefinitionPersistence.INSTANCE,
+        executionDao);
+  }
+
+  @Test
+  void shouldRejectManualRunWhenExecutionTableReportsActiveInstance() {
+    WorkflowDefinitionVO definition = publishConfiguredWorkflow();
+    when(executionDao.countActiveExecutions(definition.id())).thenReturn(1L);
+
+    assertThatThrownBy(() -> service.run(definition.id()))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("运行中的执行实例");
+
+    verify(runtimeService, never()).run(any(), any(), any(), any(), anyBoolean());
+  }
+
+  @Test
+  void shouldNotUseLatestExecutionStatusAsConcurrencyFact() {
+    WorkflowDefinitionVO definition = publishConfiguredWorkflow();
+    when(executionDao.countActiveExecutions(definition.id())).thenReturn(0L);
+
+    WorkflowInstanceVO prepared1 = instance("execution-1", "RUNNING");
+    WorkflowInstanceVO running1 = instance("execution-1", "RUNNING");
+    WorkflowInstanceVO prepared2 = instance("execution-2", "RUNNING");
+    WorkflowInstanceVO running2 = instance("execution-2", "RUNNING");
+    when(runtimeService.run(any(), any(), any(), any(), anyBoolean()))
+        .thenReturn(prepared1, prepared2);
+    when(runtimeService.activate("execution-1")).thenReturn(running1);
+    when(runtimeService.activate("execution-2")).thenReturn(running2);
+    when(runtimeService.getInstance("execution-1")).thenReturn(running1);
+    when(runtimeService.getInstance("execution-2")).thenReturn(running2);
+
+    WorkflowDefinitionVO first = service.run(definition.id());
+    WorkflowDefinitionVO second = service.run(definition.id());
+
+    assertThat(first.latestExecutionStatus()).isEqualTo("RUNNING");
+    assertThat(second.latestExecutionId()).isEqualTo("execution-2");
+  }
+
+  private WorkflowDefinitionVO publishConfiguredWorkflow() {
+    WorkflowDefinitionVO created = service.create(
+        new WorkflowDefinitionCreateDTO("订单同步", "active execution admission"));
+    WorkflowDefinitionVO configured = service.update(
+        created.id(),
+        new WorkflowDefinitionUpdateDTO(
+            created.name(),
+            created.description(),
+            List.of(new NodeDTO(
+                "node-1",
+                "sync-1",
+                120D,
+                80D,
+                1,
+                0L,
+                0L,
+                0L,
+                Map.of(),
+                "ALL_SUCCESS",
+                "FAIL_WORKFLOW")),
+            List.of(),
+            Map.of(),
+            0L,
+            "CONTINUE_INDEPENDENT_BRANCHES"));
+    when(taskRegistry.snapshot("sync-1")).thenReturn(new TaskVersionSnapshot(
+        "sync-1",
+        "同步订单",
+        "SYNC",
+        1L,
+        "digest-1",
+        "{\"definitionVersion\":1}",
+        "{\"jobSpecVersion\":1}"));
+    return service.online(configured.id());
+  }
+
+  private WorkflowInstanceVO instance(String id, String status) {
+    Instant now = Instant.parse("2026-08-14T02:00:00Z");
+    return new WorkflowInstanceVO(
+        id,
+        "workflow-version-1",
+        null,
+        "订单同步",
+        status,
+        "CONTINUE_INDEPENDENT_BRANCHES",
+        now,
+        now,
+        null,
+        0L,
+        Map.of(),
+        1,
+        0,
+        List.of(),
+        "workflow-version-1",
+        1,
+        false);
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowDefinitionActiveExecutionAdmissionTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowDefinitionActiveExecutionAdmissionTest.java
@@ -124,15 +124,12 @@ class WorkflowDefinitionActiveExecutionAdmissionTest {
         status,
         "CONTINUE_INDEPENDENT_BRANCHES",
         now,
-        now,
+        null,
         null,
         0L,
         Map.of(),
         1,
         0,
-        List.of(),
-        "workflow-version-1",
-        1,
-        false);
+        List.of());
   }
 }

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowLaunchServiceTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowLaunchServiceTest.java
@@ -1,6 +1,7 @@
 package io.yak.ops.business.workflow.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -17,6 +18,7 @@ import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -78,7 +80,7 @@ class WorkflowLaunchServiceTest {
         Instant.parse("2026-08-14T02:00:00Z"),
         "Asia/Shanghai");
     WorkflowDefinitionVO current = definition("latest-normal", "workflow-version-6", 6);
-    WorkflowInstanceVO expected = instance("execution-v5");
+    WorkflowInstanceVO expected = instance("execution-v5", "RUNNING");
     when(definitionService.get("workflow-1")).thenReturn(current);
     when(publishedVersionRunner.run("workflow-1", "workflow-version-5")).thenReturn(expected);
 
@@ -94,21 +96,59 @@ class WorkflowLaunchServiceTest {
   }
 
   @Test
-  void shouldRouteAdHocApiRunAndRecordTriggerContext() {
+  void shouldRecordAdHocTriggerBeforeActivatingPreparedExecution() {
     WorkflowRunDTO request = new WorkflowRunDTO(
         "临时工作流",
         List.of(new NodeDTO("node-1", "task-1")),
         List.of(),
         Map.of());
     WorkflowTriggerContext trigger = WorkflowTriggerContext.api();
-    WorkflowInstanceVO expected = instance("execution-api");
-    when(runtimeService.run(request)).thenReturn(expected);
+    WorkflowInstanceVO prepared = instance("execution-api", "RUNNING");
+    WorkflowInstanceVO activated = instance("execution-api", "RUNNING");
+    when(runtimeService.run(request)).thenReturn(prepared);
+    when(runtimeService.activate("execution-api")).thenReturn(activated);
 
     WorkflowInstanceVO actual = service.runAdHoc(request, trigger);
 
-    assertThat(actual).isSameAs(expected);
-    verify(runtimeService).run(request);
-    verify(triggerRecorder).record("execution-api", trigger);
+    assertThat(actual).isSameAs(activated);
+    InOrder order = inOrder(runtimeService, triggerRecorder);
+    order.verify(runtimeService).run(request);
+    order.verify(triggerRecorder).record("execution-api", trigger);
+    order.verify(runtimeService).activate("execution-api");
+  }
+
+  @Test
+  void shouldActivateRestartBeforeReturningRunningInstance() {
+    WorkflowTriggerContext trigger = WorkflowTriggerContext.manual();
+    WorkflowInstanceVO prepared = instance("execution-restart", "RUNNING");
+    WorkflowInstanceVO activated = instance("execution-restart", "RUNNING");
+    when(runtimeService.restart("execution-source")).thenReturn(prepared);
+    when(runtimeService.activate("execution-restart")).thenReturn(activated);
+
+    WorkflowInstanceVO actual = service.restart("execution-source", trigger);
+
+    assertThat(actual).isSameAs(activated);
+    InOrder order = inOrder(runtimeService, triggerRecorder);
+    order.verify(runtimeService).restart("execution-source");
+    order.verify(triggerRecorder).record("execution-restart", trigger);
+    order.verify(runtimeService).activate("execution-restart");
+  }
+
+  @Test
+  void shouldActivateNodeRerunBeforeReturningRunningInstance() {
+    WorkflowTriggerContext trigger = WorkflowTriggerContext.manual();
+    WorkflowInstanceVO prepared = instance("execution-rerun", "RUNNING");
+    WorkflowInstanceVO activated = instance("execution-rerun", "RUNNING");
+    when(runtimeService.rerunFromNode("execution-source", "node-2")).thenReturn(prepared);
+    when(runtimeService.activate("execution-rerun")).thenReturn(activated);
+
+    WorkflowInstanceVO actual = service.rerunFromNode("execution-source", "node-2", trigger);
+
+    assertThat(actual).isSameAs(activated);
+    InOrder order = inOrder(runtimeService, triggerRecorder);
+    order.verify(runtimeService).rerunFromNode("execution-source", "node-2");
+    order.verify(triggerRecorder).record("execution-rerun", trigger);
+    order.verify(runtimeService).activate("execution-rerun");
   }
 
   private WorkflowDefinitionVO definition(
@@ -139,14 +179,14 @@ class WorkflowLaunchServiceTest {
         now);
   }
 
-  private WorkflowInstanceVO instance(String executionId) {
+  private WorkflowInstanceVO instance(String executionId, String status) {
     Instant now = Instant.parse("2026-08-13T12:00:00Z");
     return new WorkflowInstanceVO(
         executionId,
         "runtime-definition",
         null,
         "临时工作流",
-        "CREATED",
+        status,
         "CONTINUE_INDEPENDENT_BRANCHES",
         now,
         null,


### PR DESCRIPTION
## 背景

这次 PR 是 Workflow Review 后的第一批正确性加固，不新增 Stage 7 功能，重点修复 Yak Ops 与 `yak-framework` Workflow Engine 生命周期之间的三处契约偏差。

Yak Framework 在创建 WorkflowExecution 时会先将状态切换为 `RUNNING`，然后进行第一次 ExecutionRepository.save；Yak Ops 之前按 `CREATED` 做 Trigger early binding，因此这个保护实际上不会在首次持久化时触发。同时，AdHoc / restart / rerunFromNode 会得到 Framework 的 RUNNING 快照，但 Yak Ops Runtime 仍需要 activate 才会真正 drain NodeDispatch。并发判断也仍以 Definition 上的 latestExecutionStatus 为主要事实，在 PARALLEL 场景下可能遗漏更早仍在运行的发布实例。

## 变更

### 1. 修复 Trigger -> WorkflowExecution early binding

- 不再依赖 `WorkflowExecutionStatus.CREATED`
- 在 ExecutionRepository.save 中通过数据库是否已经存在 executionId 判断“第一次 durable persistence”
- 第一次 `yak_workflow_execution` 落库后，立即在同一个 business transaction 中绑定 Trigger Ledger
- Ledger 的 `execution_status` 使用 Framework 当前真实状态（通常为 `RUNNING`），不再写死 `CREATED`
- 保留已有 triggerId -> executionId 冲突保护

这样对齐 `yak-framework` 当前 `createAndStartExecution` 的真实生命周期，并缩小 Execution 已创建但 Trigger Ledger 尚未绑定的崩溃窗口。

### 2. 统一 AdHoc / restart / rerunFromNode 的 RUNNING 语义

- `runAdHoc`
- `restart`
- `rerunFromNode`

现在统一执行：

`prepare WorkflowExecution -> record Trigger -> activate execution -> return`

因此 API 返回 `RUNNING` 时，实例已经进入 Yak Ops Runtime 的真实执行生命周期，而不是只产生 pending NodeDispatch 等待后续显式 `/activate`。

Trigger 仍然在 activate 前记录，避免节点真正派发后才补写启动来源。

### 3. durable Execution 成为并发准入事实来源

- `WorkflowDefinitionService.ensureIdle()` 不再以 `latestExecutionStatus` 判断是否空闲
- 新增 WorkflowExecution DAO 查询，直接统计该 workflow 下所有活跃发布实例
- `latestExecutionId/latestExecutionStatus` 保留“最近一次实例”的 UI 展示语义
- 当前未发布草稿 `testRun` 没有 workflowVersionId，因此查询同时通过 `yak_workflow_definition.latest_execution_id` 兼容当前草稿实例；执行状态仍来自 `yak_workflow_execution`
- delete 的运行中保护同步使用 durable active-execution 查询

活跃状态保持：`CREATED / RUNNING / PAUSING / PAUSED / RESUMING`。

## 测试

新增/扩展 focused tests：

- 首次持久化为 RUNNING 时仍能 early bind Trigger Ledger
- Execution 已存在时不会重复 early bind
- AdHoc 启动顺序：run -> record Trigger -> activate
- restart 启动顺序：restart -> record Trigger -> activate
- rerunFromNode 启动顺序：rerun -> record Trigger -> activate
- durable Execution 查询报告 active 时拒绝手工启动
- latestExecutionStatus 即使显示 RUNNING，也不再覆盖 durable active-execution 查询结果

## 与 yak-framework 的关系

本 PR 不修改 `weifuwan/yak-framework`。Framework 当前 `engine.start` 的语义本身保持不变，本次只让 Yak Ops 适配层与它的真实状态机对齐。

## 本 PR 不包含

以下 Review 项目继续留在下一批 hardening，不混入本 PR：

- Retry 后 Trigger Ledger 重新进入 RUNNING / SERIAL_WAIT 的全生命周期协调
- TaskExecutor 跨进程 durable idempotency contract
- Workflow Runtime single-master / distributed ownership
- Workflow OFFLINE -> Schedule OFFLINE 即时联动
- Pause UI/能力语义优化
