### PR TITLE
fix(workflow): preserve serial semantics across execution retry

### DIFF
--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/controller/v1/WorkflowController.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/controller/v1/WorkflowController.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.yak.framework.common.Result;
 import io.yak.ops.business.workflow.domain.WorkflowTriggerContext;
+import io.yak.ops.business.workflow.service.WorkflowExecutionReactivationService;
 import io.yak.ops.business.workflow.service.WorkflowLaunchService;
 import io.yak.ops.business.workflow.service.WorkflowRuntimeService;
 import io.yak.ops.common.bean.dto.workflow.WorkflowRunDTO;
@@ -27,12 +28,15 @@ public class WorkflowController {
 
   private final WorkflowRuntimeService workflowRuntimeService;
   private final WorkflowLaunchService workflowLaunchService;
+  private final WorkflowExecutionReactivationService workflowReactivationService;
 
   public WorkflowController(
       WorkflowRuntimeService workflowRuntimeService,
-      WorkflowLaunchService workflowLaunchService) {
+      WorkflowLaunchService workflowLaunchService,
+      WorkflowExecutionReactivationService workflowReactivationService) {
     this.workflowRuntimeService = workflowRuntimeService;
     this.workflowLaunchService = workflowLaunchService;
+    this.workflowReactivationService = workflowReactivationService;
   }
 
   @Operation(summary = "创建工作流运行实例")
@@ -75,7 +79,7 @@ public class WorkflowController {
   public Result<WorkflowInstanceVO> continueAfterFailure(
       @PathVariable("executionId") String executionId,
       @PathVariable("nodeId") String nodeId) {
-    return Result.success(workflowRuntimeService.continueAfterFailure(executionId, nodeId));
+    return Result.success(workflowReactivationService.continueAfterFailure(executionId, nodeId));
   }
 
   @Operation(summary = "重新执行当前失败节点")
@@ -83,14 +87,14 @@ public class WorkflowController {
   public Result<WorkflowInstanceVO> retryFailedNode(
       @PathVariable("executionId") String executionId,
       @PathVariable("nodeId") String nodeId) {
-    return Result.success(workflowRuntimeService.retryFailedNode(executionId, nodeId));
+    return Result.success(workflowReactivationService.retryFailedNode(executionId, nodeId));
   }
 
   @Operation(summary = "重试实例中的失败节点")
   @PostMapping("/instances/{executionId}/retry-failed")
   public Result<WorkflowInstanceVO> retryFailedNodes(
       @PathVariable("executionId") String executionId) {
-    return Result.success(workflowRuntimeService.retryFailedNodes(executionId));
+    return Result.success(workflowReactivationService.retryFailedNodes(executionId));
   }
 
   @Operation(summary = "重新运行整个工作流")

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/impl/WorkflowScheduleTriggerDaoImpl.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/impl/WorkflowScheduleTriggerDaoImpl.java
@@ -17,7 +17,8 @@ import org.springframework.stereotype.Repository;
 @DependsOn("workflowFlyway")
 @ConditionalOnProperty(prefix = "yak.database", name = "enabled", havingValue = "true", matchIfMissing = true)
 public class WorkflowScheduleTriggerDaoImpl implements WorkflowScheduleTriggerDao {
-  private static final List<String> PENDING = List.of("RECEIVED", "WAITING", "LAUNCHING", "RUNNING");
+  private static final List<String> PENDING =
+      List.of("RECEIVED", "WAITING", "LAUNCHING", "REACTIVATING", "RUNNING");
   private final WorkflowScheduleTriggerMapper mapper;
 
   @Override

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/mapper/WorkflowScheduleTriggerMapper.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/mapper/WorkflowScheduleTriggerMapper.java
@@ -51,11 +51,12 @@ public interface WorkflowScheduleTriggerMapper extends BaseMapper<WorkflowSchedu
       """)
   long countActiveExecutions(@Param("workflowId") String workflowId);
 
+  /** LAUNCHING 与 REACTIVATING 都是尚未由 Execution DB 完整体现的 durable 并发占位。 */
   @Select("""
       SELECT COUNT(*)
       FROM yak_workflow_schedule_trigger
       WHERE workflow_id = #{workflowId}
-        AND status = 'LAUNCHING'
+        AND status IN ('LAUNCHING', 'REACTIVATING')
       """)
   long countLaunchingTriggers(@Param("workflowId") String workflowId);
 

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowBackfillQuery.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowBackfillQuery.java
@@ -50,7 +50,7 @@ public class WorkflowBackfillQuery {
   public WorkflowBackfillVO view(WorkflowBackfillPO value) {
     List<WorkflowScheduleTriggerPO> items = triggers.selectByBackfillId(value.getId());
     int waiting = count(items, "RECEIVED") + count(items, "WAITING");
-    int running = count(items, "LAUNCHING") + count(items, "RUNNING");
+    int running = count(items, "LAUNCHING") + count(items, "REACTIVATING") + count(items, "RUNNING");
     int succeeded = count(items, "SUCCEEDED");
     int failed = count(items, "FAILED");
     int canceled = count(items, "CANCELED");

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowExecutionReactivationService.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowExecutionReactivationService.java
@@ -1,0 +1,66 @@
+package io.yak.ops.business.workflow.service;
+
+import io.yak.ops.common.bean.vo.workflow.WorkflowInstanceVO;
+import java.util.function.Supplier;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.stereotype.Service;
+
+/**
+ * 同一个 WorkflowExecution 的人工恢复入口。
+ *
+ * <p>retry / continue 与 restart 不同：它们不会创建新的 WorkflowExecution，而是可能把一个已经终态的
+ * Execution 重新拉回 RUNNING。数据库模式下必须先经过 Trigger Ledger 协调，避免绕过 SERIAL_WAIT /
+ * SERIAL_DISCARD 的工作流级并发语义；database-disabled 的 focused/dev 模式保持 Runtime 直连。</p>
+ */
+@Service
+public class WorkflowExecutionReactivationService {
+  private final WorkflowRuntimeService runtime;
+  private final ObjectProvider<WorkflowScheduleTriggerCoordinator> coordinator;
+
+  public WorkflowExecutionReactivationService(
+      WorkflowRuntimeService runtime,
+      ObjectProvider<WorkflowScheduleTriggerCoordinator> coordinator) {
+    this.runtime = runtime;
+    this.coordinator = coordinator;
+  }
+
+  public WorkflowInstanceVO continueAfterFailure(String executionId, String nodeId) {
+    String id = required(executionId, "工作流实例 ID 不能为空");
+    String node = required(nodeId, "工作流节点 ID 不能为空");
+    return reactivate(
+        id,
+        "CONTINUE_AFTER_FAILURE",
+        () -> runtime.continueAfterFailure(id, node));
+  }
+
+  public WorkflowInstanceVO retryFailedNode(String executionId, String nodeId) {
+    String id = required(executionId, "工作流实例 ID 不能为空");
+    String node = required(nodeId, "工作流节点 ID 不能为空");
+    return reactivate(
+        id,
+        "RETRY_FAILED_NODE",
+        () -> runtime.retryFailedNode(id, node));
+  }
+
+  public WorkflowInstanceVO retryFailedNodes(String executionId) {
+    String id = required(executionId, "工作流实例 ID 不能为空");
+    return reactivate(
+        id,
+        "RETRY_FAILED_NODES",
+        () -> runtime.retryFailedNodes(id));
+  }
+
+  private WorkflowInstanceVO reactivate(
+      String executionId,
+      String operation,
+      Supplier<WorkflowInstanceVO> action) {
+    WorkflowScheduleTriggerCoordinator value = coordinator.getIfAvailable();
+    if (value == null) return action.get();
+    return value.reactivateExecution(executionId, operation, action);
+  }
+
+  private String required(String value, String message) {
+    if (value == null || value.isBlank()) throw new IllegalArgumentException(message);
+    return value.trim();
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowInstanceOperationsService.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowInstanceOperationsService.java
@@ -28,6 +28,7 @@ public class WorkflowInstanceOperationsService {
   private static final int MAX_BATCH_RETRY = 100;
 
   private final WorkflowRuntimeService runtime;
+  private final WorkflowExecutionReactivationService reactivation;
   private final ObjectProvider<WorkflowRuntimePersistence> runtimePersistence;
   private final ObjectProvider<WorkflowDefinitionRepository> definitionRepository;
   private final ObjectProvider<WorkflowScheduleTriggerDao> triggerDao;
@@ -35,11 +36,13 @@ public class WorkflowInstanceOperationsService {
 
   public WorkflowInstanceOperationsService(
       WorkflowRuntimeService runtime,
+      WorkflowExecutionReactivationService reactivation,
       ObjectProvider<WorkflowRuntimePersistence> runtimePersistence,
       ObjectProvider<WorkflowDefinitionRepository> definitionRepository,
       ObjectProvider<WorkflowScheduleTriggerDao> triggerDao,
       ObjectProvider<WorkflowBackfillService> backfillService) {
     this.runtime = runtime;
+    this.reactivation = reactivation;
     this.runtimePersistence = runtimePersistence;
     this.definitionRepository = definitionRepository;
     this.triggerDao = triggerDao;
@@ -119,7 +122,7 @@ public class WorkflowInstanceOperationsService {
     int accepted = 0;
     for (String id : ids) {
       try {
-        WorkflowInstanceVO result = runtime.retryFailedNodes(id);
+        WorkflowInstanceVO result = reactivation.retryFailedNodes(id);
         accepted++;
         items.add(new ItemVO(id, true, result.status(), "已重新调度失败/阻断节点"));
       } catch (RuntimeException exception) {

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowScheduleTriggerAdmission.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowScheduleTriggerAdmission.java
@@ -11,7 +11,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-/** Trigger Ledger 的短事务准入、绑定和队首预留。实际 Workflow 启动不在这里执行。 */
+/** Trigger Ledger 的短事务准入、绑定、人工恢复预留和队首推进。实际 Workflow 启动不在这里执行。 */
 @Component
 @ConditionalOnProperty(prefix = "yak.database", name = "enabled", havingValue = "true", matchIfMissing = true)
 public class WorkflowScheduleTriggerAdmission {
@@ -109,6 +109,132 @@ public class WorkflowScheduleTriggerAdmission {
     return reserveNextLocked(trigger.getWorkflowId());
   }
 
+  /**
+   * 对同一个终态 WorkflowExecution 做 retry/continue 前先占住工作流串行槽位。
+   *
+   * <p>终态提交时 SERIAL_WAIT 可能已经推进了后续 Trigger，因此人工恢复不能直接把旧 Execution
+   * 拉回 RUNNING。REACTIVATING 是一个 durable reservation：新 Cron/Backfill 会把它视为启动占位，
+   * 应用在 Runtime 真正恢复之前宕机时也能由 recoverPending 根据 Execution 的 durable 状态收敛。</p>
+   *
+   * @return true 表示本次操作持有 Trigger Ledger 恢复预留；false 表示实例没有 Ledger，或实例本来就非终态。
+   */
+  @Transactional(transactionManager = "yakBusinessTransactionManager")
+  public boolean reserveReactivation(String executionId, String operation) {
+    WorkflowScheduleTriggerPO trigger = ledger.selectByExecutionId(executionId);
+    if (trigger == null) return false;
+
+    ledger.lockWorkflow(trigger.getWorkflowId());
+    trigger = ledger.selectByExecutionId(executionId);
+    if (trigger == null) return false;
+
+    WorkflowExecutionPO execution = executions.selectExecution(executionId);
+    if (execution == null) {
+      throw new IllegalArgumentException("WorkflowExecution 不存在：" + executionId);
+    }
+    if (!isExecutionTerminal(execution.getStatus())) {
+      return false;
+    }
+
+    String strategy = trigger.getExecutionStrategy();
+    if (!"PARALLEL".equals(strategy)) {
+      long active = ledger.countActiveExecutions(trigger.getWorkflowId());
+      long launching = ledger.countLaunchingTriggers(trigger.getWorkflowId());
+      long waiting = ledger.countWaitingTriggers(trigger.getWorkflowId());
+      if (active > 0L || launching > 0L || waiting > 0L) {
+        throw new IllegalStateException(
+            "工作流串行槽位已由后续实例占用或排队，不能原地恢复旧 WorkflowExecution；"
+                + "请等待队列清空后重试，或使用重新运行创建新实例");
+      }
+    }
+
+    trigger.setStatus("REACTIVATING");
+    trigger.setExecutionStatus(execution.getStatus());
+    trigger.setMessage("WorkflowExecution 人工恢复已获得执行准入：" + safeOperation(operation));
+    trigger.setErrorMessage(null);
+    trigger.setCompletedAt(null);
+    touch(trigger);
+    save(trigger);
+    return true;
+  }
+
+  /** Runtime 人工恢复调用返回后，以 durable Execution 状态收敛 Ledger。 */
+  @Transactional(transactionManager = "yakBusinessTransactionManager")
+  public AdmissionResult finishReactivation(String executionId) {
+    WorkflowScheduleTriggerPO trigger = ledger.selectByExecutionId(executionId);
+    if (trigger == null) return AdmissionResult.none();
+
+    ledger.lockWorkflow(trigger.getWorkflowId());
+    trigger = ledger.selectByExecutionId(executionId);
+    if (trigger == null || !"REACTIVATING".equals(trigger.getStatus())) {
+      // 极快工作流可能已在 Runtime 调用内部再次进入终态，并由 AFTER_COMMIT listener 完成 Ledger。
+      return AdmissionResult.none();
+    }
+
+    WorkflowExecutionPO execution = executions.selectExecution(executionId);
+    if (execution == null) {
+      trigger.setStatus("FAILED");
+      trigger.setExecutionStatus(null);
+      trigger.setMessage("人工恢复完成检查时 WorkflowExecution 已不存在");
+      trigger.setCompletedAt(Instant.now());
+      touch(trigger);
+      save(trigger);
+      return reserveNextLocked(trigger.getWorkflowId());
+    }
+
+    trigger.setExecutionStatus(execution.getStatus());
+    if (isExecutionTerminal(execution.getStatus())) {
+      markTerminal(trigger, execution.getStatus(), execution.getEndedAt());
+      return reserveNextLocked(trigger.getWorkflowId());
+    }
+
+    trigger.setStatus("RUNNING");
+    trigger.setMessage("WorkflowExecution 已通过人工恢复重新进入运行态");
+    trigger.setErrorMessage(null);
+    trigger.setCompletedAt(null);
+    touch(trigger);
+    save(trigger);
+    return AdmissionResult.none();
+  }
+
+  /** Runtime 人工恢复抛错时释放 REACTIVATING；若 Execution 已恢复成功，则仍以真实状态为准。 */
+  @Transactional(transactionManager = "yakBusinessTransactionManager")
+  public AdmissionResult failReactivation(String executionId, Throwable error) {
+    WorkflowScheduleTriggerPO trigger = ledger.selectByExecutionId(executionId);
+    if (trigger == null) return AdmissionResult.none();
+
+    ledger.lockWorkflow(trigger.getWorkflowId());
+    trigger = ledger.selectByExecutionId(executionId);
+    if (trigger == null || !"REACTIVATING".equals(trigger.getStatus())) {
+      return AdmissionResult.none();
+    }
+
+    WorkflowExecutionPO execution = executions.selectExecution(executionId);
+    if (execution != null && !isExecutionTerminal(execution.getStatus())) {
+      trigger.setStatus("RUNNING");
+      trigger.setExecutionStatus(execution.getStatus());
+      trigger.setMessage("人工恢复调用抛错，但 WorkflowExecution 已进入活动状态，以 durable 状态为准");
+      trigger.setErrorMessage(safeMessage(error));
+      trigger.setCompletedAt(null);
+      touch(trigger);
+      save(trigger);
+      return AdmissionResult.none();
+    }
+
+    if (execution != null) {
+      trigger.setErrorMessage(safeMessage(error));
+      markTerminal(trigger, execution.getStatus(), execution.getEndedAt());
+    } else {
+      trigger.setStatus("FAILED");
+      trigger.setExecutionStatus(null);
+      trigger.setMessage("人工恢复失败且 WorkflowExecution 已不存在");
+      trigger.setErrorMessage(safeMessage(error));
+      trigger.setCompletedAt(Instant.now());
+      touch(trigger);
+      save(trigger);
+    }
+    return reserveNextLocked(trigger.getWorkflowId());
+  }
+
   /** WorkflowExecution 终态提交后，完成 Ledger 并在同一短事务中预留下一条等待 Trigger。 */
   @Transactional(transactionManager = "yakBusinessTransactionManager")
   public AdmissionResult completeExecution(String executionId, String executionStatus, Instant endedAt) {
@@ -128,7 +254,7 @@ public class WorkflowScheduleTriggerAdmission {
     return reserveNextLocked(workflowId);
   }
 
-  /** 恢复已绑定的 RUNNING/LAUNCHING Ledger；返回值可能是新预留的队首。 */
+  /** 恢复已绑定的 RUNNING/LAUNCHING/REACTIVATING Ledger；返回值可能是新预留的队首。 */
   @Transactional(transactionManager = "yakBusinessTransactionManager")
   public AdmissionResult recoverBound(WorkflowScheduleTriggerPO candidate, String executionId) {
     WorkflowScheduleTriggerPO trigger = current(candidate);
@@ -153,6 +279,7 @@ public class WorkflowScheduleTriggerAdmission {
     }
     trigger.setStatus("RUNNING");
     trigger.setMessage("启动恢复已重新绑定 WorkflowExecution");
+    trigger.setCompletedAt(null);
     touch(trigger);
     save(trigger);
     return new AdmissionResult(trigger, false, false);
@@ -182,12 +309,12 @@ public class WorkflowScheduleTriggerAdmission {
     boolean busy = active > 0L || launching > 0L || waiting > 0L;
 
     if ("SERIAL_DISCARD".equals(strategy) && busy) {
-      markSkipped(trigger, "已有运行、启动或排队中的 WorkflowExecution，按 SERIAL_DISCARD 跳过");
+      markSkipped(trigger, "已有运行、启动、恢复或排队中的 WorkflowExecution，按 SERIAL_DISCARD 跳过");
       return new AdmissionResult(trigger, false, false);
     }
     if ("SERIAL_WAIT".equals(strategy) && busy) {
       trigger.setStatus("WAITING");
-      trigger.setMessage("已有运行、启动或排队中的 WorkflowExecution，进入串行等待队列");
+      trigger.setMessage("已有运行、启动、恢复或排队中的 WorkflowExecution，进入串行等待队列");
       touch(trigger);
       save(trigger);
       return new AdmissionResult(trigger, false, false);
@@ -282,6 +409,12 @@ public class WorkflowScheduleTriggerAdmission {
 
   private void save(WorkflowScheduleTriggerPO trigger) {
     if (ledger.update(trigger) != 1) throw new IllegalStateException("更新 Trigger Ledger 失败：" + trigger.getId());
+  }
+
+  private String safeOperation(String operation) {
+    if (operation == null || operation.isBlank()) return "MANUAL_REACTIVATION";
+    String value = operation.trim();
+    return value.length() <= 80 ? value : value.substring(0, 80);
   }
 
   private String safeMessage(Throwable error) {

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowScheduleTriggerCoordinator.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowScheduleTriggerCoordinator.java
@@ -16,8 +16,10 @@ import java.time.ZoneId;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
+import java.util.function.Supplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -112,7 +114,9 @@ public class WorkflowScheduleTriggerCoordinator {
     for (WorkflowScheduleTriggerPO trigger : pending) {
       String executionId = trigger.getWorkflowExecutionId();
       if ((executionId == null || executionId.isBlank())
-          && ("LAUNCHING".equals(trigger.getStatus()) || "RUNNING".equals(trigger.getStatus()))) {
+          && ("LAUNCHING".equals(trigger.getStatus())
+              || "REACTIVATING".equals(trigger.getStatus())
+              || "RUNNING".equals(trigger.getStatus()))) {
         executionId = ledger.selectExecutionIdByTrigger(trigger.getTriggerId());
       }
 
@@ -160,6 +164,57 @@ public class WorkflowScheduleTriggerCoordinator {
   /** WorkflowExecution 终态事务提交后调用，完成 Ledger 并推进 SERIAL_WAIT。 */
   public void completeExecution(String executionId, String executionStatus, Instant endedAt) {
     launchReserved(admission.completeExecution(executionId, executionStatus, endedAt));
+  }
+
+  /**
+   * 对同一个 Execution 做人工 retry/continue：先持久化 REACTIVATING 占位，再调用 Runtime。
+   *
+   * <p>如果该实例没有 Trigger Ledger（例如 AdHoc / 草稿测试），直接执行 Runtime 操作；如果它原本就是
+   * 非终态，也不需要重新占位。对于 SERIAL_WAIT / SERIAL_DISCARD，终态后如果串行槽位已经交给后续
+   * 实例或队列，本次原地恢复会被明确拒绝，不允许悄悄制造并发。</p>
+   */
+  public WorkflowInstanceVO reactivateExecution(
+      String executionId,
+      String operation,
+      Supplier<WorkflowInstanceVO> action) {
+    Objects.requireNonNull(action, "workflow reactivation action");
+    boolean reserved = admission.reserveReactivation(executionId, operation);
+    if (!reserved) return action.get();
+
+    log.info(
+        "[workflow-schedule-ledger] reactivation reserved execution={}, operation={}",
+        executionId,
+        operation);
+    try {
+      WorkflowInstanceVO result = action.get();
+      advanceAfterReactivation(admission.finishReactivation(executionId), executionId, operation);
+      return result;
+    } catch (RuntimeException exception) {
+      AdmissionResult next = admission.failReactivation(executionId, exception);
+      try {
+        advanceAfterReactivation(next, executionId, operation);
+      } catch (RuntimeException queueFailure) {
+        exception.addSuppressed(queueFailure);
+      }
+      throw exception;
+    }
+  }
+
+  private void advanceAfterReactivation(
+      AdmissionResult result,
+      String executionId,
+      String operation) {
+    if (result == null || !result.launchNow()) return;
+    try {
+      launchReserved(result);
+    } catch (RuntimeException exception) {
+      // 人工恢复本身已经完成；后续 SERIAL_WAIT 启动失败会由其 Ledger 记录，不反向污染本次 API 结果。
+      log.warn(
+          "[workflow-schedule-ledger] post-reactivation queue advance failed execution={}, operation={}, message={}",
+          executionId,
+          operation,
+          exception.getMessage());
+    }
   }
 
   private String launchReserved(AdmissionResult initial) {

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowExecutionReactivationServiceTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowExecutionReactivationServiceTest.java
@@ -1,0 +1,77 @@
+package io.yak.ops.business.workflow.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.common.bean.vo.workflow.WorkflowInstanceVO;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.ObjectProvider;
+
+@ExtendWith(MockitoExtension.class)
+class WorkflowExecutionReactivationServiceTest {
+  @Mock private WorkflowRuntimeService runtime;
+  @Mock private ObjectProvider<WorkflowScheduleTriggerCoordinator> coordinatorProvider;
+  @Mock private WorkflowScheduleTriggerCoordinator coordinator;
+
+  @Test
+  void shouldRouteScheduledRetryThroughTriggerCoordinator() {
+    WorkflowExecutionReactivationService service =
+        new WorkflowExecutionReactivationService(runtime, coordinatorProvider);
+    WorkflowInstanceVO expected = instance("execution-1", "RUNNING");
+    when(coordinatorProvider.getIfAvailable()).thenReturn(coordinator);
+    when(coordinator.reactivateExecution(
+        eq("execution-1"), eq("RETRY_FAILED_NODES"), any()))
+        .thenReturn(expected);
+
+    WorkflowInstanceVO result = service.retryFailedNodes("execution-1");
+
+    assertThat(result).isSameAs(expected);
+    verify(coordinator).reactivateExecution(
+        eq("execution-1"), eq("RETRY_FAILED_NODES"), any());
+  }
+
+  @Test
+  void shouldKeepDatabaseDisabledFallbackOnRuntime() {
+    WorkflowExecutionReactivationService service =
+        new WorkflowExecutionReactivationService(runtime, coordinatorProvider);
+    WorkflowInstanceVO expected = instance("execution-1", "RUNNING");
+    when(coordinatorProvider.getIfAvailable()).thenReturn(null);
+    when(runtime.retryFailedNode("execution-1", "node-1")).thenReturn(expected);
+
+    WorkflowInstanceVO result = service.retryFailedNode("execution-1", "node-1");
+
+    assertThat(result).isSameAs(expected);
+    verify(runtime).retryFailedNode("execution-1", "node-1");
+  }
+
+  private WorkflowInstanceVO instance(String id, String status) {
+    Instant now = Instant.parse("2026-08-14T04:00:00Z");
+    return new WorkflowInstanceVO(
+        id,
+        "workflow-version-1",
+        null,
+        "订单同步",
+        status,
+        "CONTINUE_INDEPENDENT_BRANCHES",
+        now,
+        now,
+        null,
+        0L,
+        Map.of(),
+        1,
+        0,
+        List.of(),
+        "workflow-version-1",
+        1,
+        false);
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowInstanceOperationsServiceTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowInstanceOperationsServiceTest.java
@@ -25,6 +25,7 @@ import org.springframework.beans.factory.ObjectProvider;
 @ExtendWith(MockitoExtension.class)
 class WorkflowInstanceOperationsServiceTest {
   @Mock private WorkflowRuntimeService runtime;
+  @Mock private WorkflowExecutionReactivationService reactivation;
   @Mock private ObjectProvider<WorkflowRuntimePersistence> runtimePersistence;
   @Mock private ObjectProvider<WorkflowDefinitionRepository> definitionProvider;
   @Mock private ObjectProvider<WorkflowScheduleTriggerDao> triggerProvider;
@@ -39,6 +40,7 @@ class WorkflowInstanceOperationsServiceTest {
   void setUp() {
     service = new WorkflowInstanceOperationsService(
         runtime,
+        reactivation,
         runtimePersistence,
         definitionProvider,
         triggerProvider,
@@ -76,8 +78,9 @@ class WorkflowInstanceOperationsServiceTest {
   @Test
   void shouldIsolateFailuresWhenBatchRetryingInstances() {
     WorkflowInstanceVO accepted = instance("execution-a", "RUNNING");
-    when(runtime.retryFailedNodes("execution-a")).thenReturn(accepted);
-    when(runtime.retryFailedNodes("execution-b")).thenThrow(new IllegalStateException("no retryable nodes"));
+    when(reactivation.retryFailedNodes("execution-a")).thenReturn(accepted);
+    when(reactivation.retryFailedNodes("execution-b"))
+        .thenThrow(new IllegalStateException("serial slot already occupied"));
 
     var result = service.batchRetryFailed(new WorkflowBatchRetryDTO(
         List.of("execution-a", "execution-b", "execution-a")));
@@ -87,7 +90,7 @@ class WorkflowInstanceOperationsServiceTest {
     assertThat(result.failedCount()).isEqualTo(1);
     assertThat(result.items()).hasSize(2);
     assertThat(result.items().get(0).accepted()).isTrue();
-    assertThat(result.items().get(1).message()).contains("no retryable nodes");
+    assertThat(result.items().get(1).message()).contains("serial slot already occupied");
   }
 
   private WorkflowInstanceVO instance(String id, String status) {

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowScheduleTriggerAdmissionTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowScheduleTriggerAdmissionTest.java
@@ -1,12 +1,14 @@
 package io.yak.ops.business.workflow.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.yak.ops.business.workflow.dao.WorkflowExecutionDao;
 import io.yak.ops.business.workflow.dao.WorkflowScheduleTriggerDao;
+import io.yak.ops.common.bean.po.workflow.WorkflowExecutionPO;
 import io.yak.ops.common.bean.po.workflow.WorkflowSchedulePO;
 import io.yak.ops.common.bean.po.workflow.WorkflowScheduleTriggerPO;
 import java.time.Instant;
@@ -159,6 +161,78 @@ class WorkflowScheduleTriggerAdmissionTest {
     assertThat(waiting.getStatus()).isEqualTo("LAUNCHING");
   }
 
+  @Test
+  void shouldReserveSerialExecutionBeforeReactivatingTerminalInstance() {
+    WorkflowScheduleTriggerPO trigger = trigger("FAILED");
+    trigger.setWorkflowExecutionId("execution-1");
+    WorkflowExecutionPO execution = execution("execution-1", "FAILED");
+    when(ledger.selectByExecutionId("execution-1")).thenReturn(trigger, trigger);
+    when(executions.selectExecution("execution-1")).thenReturn(execution);
+    when(ledger.countActiveExecutions("workflow-1")).thenReturn(0L);
+    when(ledger.countLaunchingTriggers("workflow-1")).thenReturn(0L);
+    when(ledger.countWaitingTriggers("workflow-1")).thenReturn(0L);
+    when(ledger.update(trigger)).thenReturn(1);
+
+    boolean reserved = admission.reserveReactivation("execution-1", "RETRY_FAILED_NODES");
+
+    assertThat(reserved).isTrue();
+    assertThat(trigger.getStatus()).isEqualTo("REACTIVATING");
+    assertThat(trigger.getCompletedAt()).isNull();
+    assertThat(trigger.getMessage()).contains("RETRY_FAILED_NODES");
+  }
+
+  @Test
+  void shouldRejectSerialReactivationAfterSlotMovedToLaterExecution() {
+    WorkflowScheduleTriggerPO trigger = trigger("FAILED");
+    trigger.setWorkflowExecutionId("execution-1");
+    WorkflowExecutionPO execution = execution("execution-1", "FAILED");
+    when(ledger.selectByExecutionId("execution-1")).thenReturn(trigger, trigger);
+    when(executions.selectExecution("execution-1")).thenReturn(execution);
+    when(ledger.countActiveExecutions("workflow-1")).thenReturn(1L);
+    when(ledger.countLaunchingTriggers("workflow-1")).thenReturn(0L);
+    when(ledger.countWaitingTriggers("workflow-1")).thenReturn(0L);
+
+    assertThatThrownBy(() -> admission.reserveReactivation("execution-1", "RETRY_FAILED_NODES"))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("串行槽位");
+
+    verify(ledger, never()).update(trigger);
+  }
+
+  @Test
+  void shouldAllowParallelReactivationEvenWhenOtherExecutionsAreActive() {
+    WorkflowScheduleTriggerPO trigger = trigger("FAILED");
+    trigger.setExecutionStrategy("PARALLEL");
+    trigger.setWorkflowExecutionId("execution-1");
+    WorkflowExecutionPO execution = execution("execution-1", "FAILED");
+    when(ledger.selectByExecutionId("execution-1")).thenReturn(trigger, trigger);
+    when(executions.selectExecution("execution-1")).thenReturn(execution);
+    when(ledger.update(trigger)).thenReturn(1);
+
+    boolean reserved = admission.reserveReactivation("execution-1", "RETRY_FAILED_NODE");
+
+    assertThat(reserved).isTrue();
+    assertThat(trigger.getStatus()).isEqualTo("REACTIVATING");
+    verify(ledger, never()).countActiveExecutions("workflow-1");
+  }
+
+  @Test
+  void shouldReturnReactivatedLedgerToRunningUsingDurableExecutionStatus() {
+    WorkflowScheduleTriggerPO trigger = trigger("REACTIVATING");
+    trigger.setWorkflowExecutionId("execution-1");
+    WorkflowExecutionPO execution = execution("execution-1", "RUNNING");
+    when(ledger.selectByExecutionId("execution-1")).thenReturn(trigger, trigger);
+    when(executions.selectExecution("execution-1")).thenReturn(execution);
+    when(ledger.update(trigger)).thenReturn(1);
+
+    var result = admission.finishReactivation("execution-1");
+
+    assertThat(result.launchNow()).isFalse();
+    assertThat(trigger.getStatus()).isEqualTo("RUNNING");
+    assertThat(trigger.getExecutionStatus()).isEqualTo("RUNNING");
+    assertThat(trigger.getCompletedAt()).isNull();
+  }
+
   private WorkflowSchedulePO schedule(String strategy) {
     WorkflowSchedulePO value = new WorkflowSchedulePO();
     value.setId("schedule-1");
@@ -175,6 +249,7 @@ class WorkflowScheduleTriggerAdmissionTest {
     value.setScheduleId("schedule-1");
     value.setWorkflowId("workflow-1");
     value.setTriggerId("trigger-1");
+    value.setDedupeKey("schedule-1|SCHEDULE|1786672800000");
     value.setPlannedFireTime(Instant.parse("2026-08-14T02:00:00Z"));
     value.setActualFireTime(Instant.parse("2026-08-14T02:00:01Z"));
     value.setExecutionStrategy("SERIAL_WAIT");
@@ -182,6 +257,15 @@ class WorkflowScheduleTriggerAdmissionTest {
     value.setStatus(status);
     value.setCreateTime(Instant.parse("2026-08-14T02:00:01Z"));
     value.setUpdateTime(Instant.parse("2026-08-14T02:00:01Z"));
+    value.setCompletedAt(Instant.parse("2026-08-14T02:10:00Z"));
+    return value;
+  }
+
+  private WorkflowExecutionPO execution(String id, String status) {
+    WorkflowExecutionPO value = new WorkflowExecutionPO();
+    value.setId(id);
+    value.setStatus(status);
+    value.setEndedAt(status.equals("RUNNING") ? null : Instant.parse("2026-08-14T02:10:00Z"));
     return value;
   }
 }

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowScheduleTriggerCoordinatorTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowScheduleTriggerCoordinatorTest.java
@@ -1,6 +1,7 @@
 package io.yak.ops.business.workflow.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
@@ -13,6 +14,7 @@ import io.yak.ops.business.workflow.service.WorkflowScheduleTriggerAdmission.Adm
 import io.yak.ops.common.bean.po.workflow.WorkflowSchedulePO;
 import io.yak.ops.common.bean.po.workflow.WorkflowScheduleTriggerPO;
 import io.yak.ops.common.bean.vo.workflow.WorkflowDefinitionVO;
+import io.yak.ops.common.bean.vo.workflow.WorkflowInstanceVO;
 import java.time.Instant;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
@@ -81,6 +83,40 @@ class WorkflowScheduleTriggerCoordinatorTest {
     verify(launchService).runScheduledPublished(
         eq("workflow-1"), any(WorkflowTriggerContext.class), eq(Map.of()));
     verify(admission).bindLaunch(reserved, "execution-1");
+  }
+
+  @Test
+  void shouldReserveLedgerBeforeInPlaceReactivationAndSettleAfterRuntimeReturns() {
+    WorkflowInstanceVO expected = org.mockito.Mockito.mock(WorkflowInstanceVO.class);
+    when(admission.reserveReactivation("execution-1", "RETRY_FAILED_NODES")).thenReturn(true);
+    when(admission.finishReactivation("execution-1"))
+        .thenReturn(new AdmissionResult(null, false, false));
+
+    WorkflowInstanceVO result = coordinator.reactivateExecution(
+        "execution-1",
+        "RETRY_FAILED_NODES",
+        () -> expected);
+
+    assertThat(result).isSameAs(expected);
+    verify(admission).reserveReactivation("execution-1", "RETRY_FAILED_NODES");
+    verify(admission).finishReactivation("execution-1");
+  }
+
+  @Test
+  void shouldReleaseReactivationReservationWhenRuntimeRejectsRetry() {
+    RuntimeException failure = new IllegalStateException("no retryable nodes");
+    when(admission.reserveReactivation("execution-1", "RETRY_FAILED_NODES")).thenReturn(true);
+    when(admission.failReactivation("execution-1", failure))
+        .thenReturn(new AdmissionResult(null, false, false));
+
+    assertThatThrownBy(() -> coordinator.reactivateExecution(
+        "execution-1",
+        "RETRY_FAILED_NODES",
+        () -> { throw failure; }))
+        .isSameAs(failure);
+
+    verify(admission).failReactivation("execution-1", failure);
+    verify(admission, never()).finishReactivation("execution-1");
   }
 
   private WorkflowSchedulePO schedule() {

--- a/yak-ops-ui/src/pages/workflow/schedules/TriggerLedgerDrawer.tsx
+++ b/yak-ops-ui/src/pages/workflow/schedules/TriggerLedgerDrawer.tsx
@@ -20,6 +20,7 @@ const STATUS_LABEL: Record<WorkflowScheduleTriggerStatus, string> = {
   RECEIVED: '已接收',
   WAITING: '等待中',
   LAUNCHING: '启动中',
+  REACTIVATING: '恢复中',
   RUNNING: '运行中',
   SUCCEEDED: '成功',
   FAILED: '失败',
@@ -109,8 +110,8 @@ const TriggerLedgerDrawer = ({
     >
       <div className="mb-3 rounded-sm bg-[#f8f9fb] px-3 py-2 text-[11px] leading-5 text-[#667085]">
         {backfillId
-          ? 'Backfill / businessDate 运维补跑都使用逻辑计划时间；不同批次可重新执行同一天，同一批次仍由 dedupeKey 保证幂等。'
-          : 'SERIAL_WAIT 会先进入 WAITING，前序 WorkflowExecution 终态提交后自动推进；SERIAL_DISCARD 会记为 SKIPPED；Misfire 同样保留审计记录。'}
+          ? 'Backfill / businessDate 运维补跑都使用逻辑计划时间；不同批次可重新执行同一天，同一批次仍由 dedupeKey 保证幂等。人工恢复终态实例时会短暂进入 REACTIVATING，并继续占用串行槽位。'
+          : 'SERIAL_WAIT 会先进入 WAITING，前序 WorkflowExecution 终态提交后自动推进；人工 retry/continue 会先进入 REACTIVATING 重新占住串行槽位；SERIAL_DISCARD 会记为 SKIPPED；Misfire 同样保留审计记录。'}
       </div>
       <Table
         rowKey="id"

--- a/yak-ops-ui/src/services/workflow/schedules.ts
+++ b/yak-ops-ui/src/services/workflow/schedules.ts
@@ -140,120 +140,56 @@ export interface WorkflowSchedulePayload {
   input: Record<string, unknown>;
 }
 
-export interface WorkflowScheduleTriggerQuery {
+export const listWorkflowSchedules = async (params?: {
+  workflowId?: string;
+  status?: WorkflowScheduleStatus;
+}) => {
+  const response = await request<ApiResponse<WorkflowSchedule[]>>(
+    '/api/v1/workflows/schedules',
+    { params },
+  );
+  return response.data || [];
+};
+
+export const listWorkflowScheduleTriggers = async (params?: {
   scheduleId?: string;
   workflowId?: string;
   backfillId?: string;
   status?: WorkflowScheduleTriggerStatus;
   limit?: number;
-}
+}) => {
+  const response = await request<ApiResponse<WorkflowScheduleTrigger[]>>(
+    '/api/v1/workflows/schedules/triggers',
+    { params },
+  );
+  return response.data || [];
+};
 
-export interface WorkflowBackfillQuery {
+export const previewWorkflowBackfill = async (payload: WorkflowBackfillPayload) => {
+  const response = await request<ApiResponse<WorkflowBackfillPreview>>(
+    '/api/v1/workflows/backfills/preview',
+    { method: 'POST', data: payload },
+  );
+  return response.data;
+};
+
+export const createWorkflowBackfill = async (payload: WorkflowBackfillPayload) => {
+  const response = await request<ApiResponse<WorkflowBackfill>>(
+    '/api/v1/workflows/backfills',
+    { method: 'POST', data: payload },
+  );
+  return response.data;
+};
+
+export const listWorkflowBackfills = async (params?: {
   workflowId?: string;
   scheduleId?: string;
   status?: WorkflowBackfillStatus;
-}
-
-export const listWorkflowSchedules = async (workflowId?: string) => {
-  const response = await request<ApiResponse<WorkflowSchedule[]>>('/api/v1/workflows/schedules', {
-    params: workflowId ? { workflowId } : undefined,
-  });
-  return response.data || [];
-};
-
-export const getWorkflowSchedule = async (id: string) => {
-  const response = await request<ApiResponse<WorkflowSchedule>>(
-    `/api/v1/workflows/schedules/${encodeURIComponent(id)}`,
+}) => {
+  const response = await request<ApiResponse<WorkflowBackfill[]>>(
+    '/api/v1/workflows/backfills',
+    { params },
   );
-  return response.data;
-};
-
-export const createWorkflowSchedule = async (
-  workflowId: string,
-  payload: WorkflowSchedulePayload,
-) => {
-  const response = await request<ApiResponse<WorkflowSchedule>>(
-    `/api/v1/workflows/${encodeURIComponent(workflowId)}/schedules`,
-    { method: 'POST', data: payload },
-  );
-  return response.data;
-};
-
-export const updateWorkflowSchedule = async (
-  id: string,
-  payload: WorkflowSchedulePayload,
-) => {
-  const response = await request<ApiResponse<WorkflowSchedule>>(
-    `/api/v1/workflows/schedules/${encodeURIComponent(id)}`,
-    { method: 'PUT', data: payload },
-  );
-  return response.data;
-};
-
-export const onlineWorkflowSchedule = async (id: string) => {
-  const response = await request<ApiResponse<WorkflowSchedule>>(
-    `/api/v1/workflows/schedules/${encodeURIComponent(id)}/online`,
-    { method: 'POST' },
-  );
-  return response.data;
-};
-
-export const offlineWorkflowSchedule = async (id: string) => {
-  const response = await request<ApiResponse<WorkflowSchedule>>(
-    `/api/v1/workflows/schedules/${encodeURIComponent(id)}/offline`,
-    { method: 'POST' },
-  );
-  return response.data;
-};
-
-export const runWorkflowScheduleNow = async (id: string) => {
-  const response = await request<ApiResponse<WorkflowSchedule>>(
-    `/api/v1/workflows/schedules/${encodeURIComponent(id)}/run`,
-    { method: 'POST' },
-  );
-  return response.data;
-};
-
-export const removeWorkflowSchedule = async (id: string) => {
-  await request<ApiResponse<void>>(`/api/v1/workflows/schedules/${encodeURIComponent(id)}`, {
-    method: 'DELETE',
-  });
-};
-
-export const listWorkflowScheduleTriggers = async (query: WorkflowScheduleTriggerQuery = {}) => {
-  const response = await request<ApiResponse<WorkflowScheduleTrigger[]>>(
-    '/api/v1/workflows/schedules/triggers',
-    { params: query },
-  );
-  return response.data || [];
-};
-
-export const previewWorkflowBackfill = async (
-  scheduleId: string,
-  payload: Pick<WorkflowBackfillPayload, 'startBusinessDate' | 'endBusinessDate'>,
-) => {
-  const response = await request<ApiResponse<WorkflowBackfillPreview>>(
-    `/api/v1/workflows/schedules/${encodeURIComponent(scheduleId)}/backfills/preview`,
-    { method: 'POST', data: payload },
-  );
-  return response.data;
-};
-
-export const createWorkflowBackfill = async (
-  scheduleId: string,
-  payload: WorkflowBackfillPayload,
-) => {
-  const response = await request<ApiResponse<WorkflowBackfill>>(
-    `/api/v1/workflows/schedules/${encodeURIComponent(scheduleId)}/backfills`,
-    { method: 'POST', data: payload },
-  );
-  return response.data;
-};
-
-export const listWorkflowBackfills = async (query: WorkflowBackfillQuery = {}) => {
-  const response = await request<ApiResponse<WorkflowBackfill[]>>('/api/v1/workflows/backfills', {
-    params: query,
-  });
   return response.data || [];
 };
 
@@ -270,4 +206,44 @@ export const cancelWorkflowBackfill = async (id: string) => {
     { method: 'POST' },
   );
   return response.data;
+};
+
+export const createWorkflowSchedule = async (
+  workflowId: string,
+  payload: WorkflowSchedulePayload,
+) => {
+  const response = await request<ApiResponse<WorkflowSchedule>>(
+    '/api/v1/workflows/schedules',
+    { method: 'POST', data: { workflowId, ...payload } },
+  );
+  return response.data;
+};
+
+export const updateWorkflowSchedule = async (
+  id: string,
+  payload: WorkflowSchedulePayload,
+) => {
+  const response = await request<ApiResponse<WorkflowSchedule>>(
+    `/api/v1/workflows/schedules/${encodeURIComponent(id)}`,
+    { method: 'PUT', data: payload },
+  );
+  return response.data;
+};
+
+const scheduleAction = async (id: string, action: 'online' | 'offline') => {
+  const response = await request<ApiResponse<WorkflowSchedule>>(
+    `/api/v1/workflows/schedules/${encodeURIComponent(id)}/${action}`,
+    { method: 'POST' },
+  );
+  return response.data;
+};
+
+export const onlineWorkflowSchedule = (id: string) => scheduleAction(id, 'online');
+export const offlineWorkflowSchedule = (id: string) => scheduleAction(id, 'offline');
+
+export const deleteWorkflowSchedule = async (id: string) => {
+  await request<ApiResponse<boolean>>(
+    `/api/v1/workflows/schedules/${encodeURIComponent(id)}`,
+    { method: 'DELETE' },
+  );
 };

--- a/yak-ops-ui/src/services/workflow/schedules.ts
+++ b/yak-ops-ui/src/services/workflow/schedules.ts
@@ -11,6 +11,7 @@ export type WorkflowScheduleTriggerStatus =
   | 'RECEIVED'
   | 'WAITING'
   | 'LAUNCHING'
+  | 'REACTIVATING'
   | 'RUNNING'
   | 'SUCCEEDED'
   | 'FAILED'
@@ -139,56 +140,120 @@ export interface WorkflowSchedulePayload {
   input: Record<string, unknown>;
 }
 
-export const listWorkflowSchedules = async (params?: {
-  workflowId?: string;
-  status?: WorkflowScheduleStatus;
-}) => {
-  const response = await request<ApiResponse<WorkflowSchedule[]>>(
-    '/api/v1/workflows/schedules',
-    { params },
-  );
-  return response.data || [];
-};
-
-export const listWorkflowScheduleTriggers = async (params?: {
+export interface WorkflowScheduleTriggerQuery {
   scheduleId?: string;
   workflowId?: string;
   backfillId?: string;
   status?: WorkflowScheduleTriggerStatus;
   limit?: number;
-}) => {
+}
+
+export interface WorkflowBackfillQuery {
+  workflowId?: string;
+  scheduleId?: string;
+  status?: WorkflowBackfillStatus;
+}
+
+export const listWorkflowSchedules = async (workflowId?: string) => {
+  const response = await request<ApiResponse<WorkflowSchedule[]>>('/api/v1/workflows/schedules', {
+    params: workflowId ? { workflowId } : undefined,
+  });
+  return response.data || [];
+};
+
+export const getWorkflowSchedule = async (id: string) => {
+  const response = await request<ApiResponse<WorkflowSchedule>>(
+    `/api/v1/workflows/schedules/${encodeURIComponent(id)}`,
+  );
+  return response.data;
+};
+
+export const createWorkflowSchedule = async (
+  workflowId: string,
+  payload: WorkflowSchedulePayload,
+) => {
+  const response = await request<ApiResponse<WorkflowSchedule>>(
+    `/api/v1/workflows/${encodeURIComponent(workflowId)}/schedules`,
+    { method: 'POST', data: payload },
+  );
+  return response.data;
+};
+
+export const updateWorkflowSchedule = async (
+  id: string,
+  payload: WorkflowSchedulePayload,
+) => {
+  const response = await request<ApiResponse<WorkflowSchedule>>(
+    `/api/v1/workflows/schedules/${encodeURIComponent(id)}`,
+    { method: 'PUT', data: payload },
+  );
+  return response.data;
+};
+
+export const onlineWorkflowSchedule = async (id: string) => {
+  const response = await request<ApiResponse<WorkflowSchedule>>(
+    `/api/v1/workflows/schedules/${encodeURIComponent(id)}/online`,
+    { method: 'POST' },
+  );
+  return response.data;
+};
+
+export const offlineWorkflowSchedule = async (id: string) => {
+  const response = await request<ApiResponse<WorkflowSchedule>>(
+    `/api/v1/workflows/schedules/${encodeURIComponent(id)}/offline`,
+    { method: 'POST' },
+  );
+  return response.data;
+};
+
+export const runWorkflowScheduleNow = async (id: string) => {
+  const response = await request<ApiResponse<WorkflowSchedule>>(
+    `/api/v1/workflows/schedules/${encodeURIComponent(id)}/run`,
+    { method: 'POST' },
+  );
+  return response.data;
+};
+
+export const removeWorkflowSchedule = async (id: string) => {
+  await request<ApiResponse<void>>(`/api/v1/workflows/schedules/${encodeURIComponent(id)}`, {
+    method: 'DELETE',
+  });
+};
+
+export const listWorkflowScheduleTriggers = async (query: WorkflowScheduleTriggerQuery = {}) => {
   const response = await request<ApiResponse<WorkflowScheduleTrigger[]>>(
     '/api/v1/workflows/schedules/triggers',
-    { params },
+    { params: query },
   );
   return response.data || [];
 };
 
-export const previewWorkflowBackfill = async (payload: WorkflowBackfillPayload) => {
+export const previewWorkflowBackfill = async (
+  scheduleId: string,
+  payload: Pick<WorkflowBackfillPayload, 'startBusinessDate' | 'endBusinessDate'>,
+) => {
   const response = await request<ApiResponse<WorkflowBackfillPreview>>(
-    '/api/v1/workflows/backfills/preview',
+    `/api/v1/workflows/schedules/${encodeURIComponent(scheduleId)}/backfills/preview`,
     { method: 'POST', data: payload },
   );
   return response.data;
 };
 
-export const createWorkflowBackfill = async (payload: WorkflowBackfillPayload) => {
+export const createWorkflowBackfill = async (
+  scheduleId: string,
+  payload: WorkflowBackfillPayload,
+) => {
   const response = await request<ApiResponse<WorkflowBackfill>>(
-    '/api/v1/workflows/backfills',
+    `/api/v1/workflows/schedules/${encodeURIComponent(scheduleId)}/backfills`,
     { method: 'POST', data: payload },
   );
   return response.data;
 };
 
-export const listWorkflowBackfills = async (params?: {
-  workflowId?: string;
-  scheduleId?: string;
-  status?: WorkflowBackfillStatus;
-}) => {
-  const response = await request<ApiResponse<WorkflowBackfill[]>>(
-    '/api/v1/workflows/backfills',
-    { params },
-  );
+export const listWorkflowBackfills = async (query: WorkflowBackfillQuery = {}) => {
+  const response = await request<ApiResponse<WorkflowBackfill[]>>('/api/v1/workflows/backfills', {
+    params: query,
+  });
   return response.data || [];
 };
 
@@ -205,44 +270,4 @@ export const cancelWorkflowBackfill = async (id: string) => {
     { method: 'POST' },
   );
   return response.data;
-};
-
-export const createWorkflowSchedule = async (
-  workflowId: string,
-  payload: WorkflowSchedulePayload,
-) => {
-  const response = await request<ApiResponse<WorkflowSchedule>>(
-    '/api/v1/workflows/schedules',
-    { method: 'POST', data: { workflowId, ...payload } },
-  );
-  return response.data;
-};
-
-export const updateWorkflowSchedule = async (
-  id: string,
-  payload: WorkflowSchedulePayload,
-) => {
-  const response = await request<ApiResponse<WorkflowSchedule>>(
-    `/api/v1/workflows/schedules/${encodeURIComponent(id)}`,
-    { method: 'PUT', data: payload },
-  );
-  return response.data;
-};
-
-const scheduleAction = async (id: string, action: 'online' | 'offline') => {
-  const response = await request<ApiResponse<WorkflowSchedule>>(
-    `/api/v1/workflows/schedules/${encodeURIComponent(id)}/${action}`,
-    { method: 'POST' },
-  );
-  return response.data;
-};
-
-export const onlineWorkflowSchedule = (id: string) => scheduleAction(id, 'online');
-export const offlineWorkflowSchedule = (id: string) => scheduleAction(id, 'offline');
-
-export const deleteWorkflowSchedule = async (id: string) => {
-  await request<ApiResponse<boolean>>(
-    `/api/v1/workflows/schedules/${encodeURIComponent(id)}`,
-    { method: 'DELETE' },
-  );
 };


### PR DESCRIPTION
## 背景

这是 Workflow Hardening 的第二批正确性加固，承接 #388，聚焦 **同一个 WorkflowExecution 从终态被 retry / continue 拉回 RUNNING 时，Trigger Ledger 与 SERIAL_WAIT / SERIAL_DISCARD / PARALLEL 的生命周期一致性**。

Yak Framework 的 `retryFailedNode`、`retryFailedNodes`、`continueAfterFailure` 都可能把原有终态 WorkflowExecution 重新转换为 `RUNNING`。而 Yak Ops 在该实例第一次进入 FAILED / CANCELED / TIMED_OUT 等终态时，Trigger Ledger 已经完成终态结算，并可能立即推进下一条 SERIAL_WAIT Trigger。

如果此时直接对旧 Execution 执行 retry，就可能出现：旧 Execution 又 RUNNING，同时下一条串行实例也已经 RUNNING，导致 SERIAL_WAIT 语义被人工恢复操作绕过。

## 本批方案

### 1. 新增 durable `REACTIVATING` 预留态

对有 Trigger Ledger 的终态 Execution 做以下原地恢复操作前：

- `continueAfterFailure`
- `retryFailedNode`
- `retryFailedNodes`
- 批量失败实例重试

先在工作流锁保护下把原 Ledger 从终态切到 `REACTIVATING`，再调用 Yak Framework Runtime。

`REACTIVATING` 是一个短生命周期的 durable reservation：

- 新的 SERIAL_WAIT Trigger 会看到它并进入 WAITING
- 新的 SERIAL_DISCARD Trigger 会看到它并 SKIPPED
- PARALLEL Trigger 仍可正常并行
- Runtime 真正把 Execution 拉回活动态后，Ledger 收敛为 RUNNING
- Runtime 如果仍然/再次进入终态，则 Ledger 按 durable Execution 状态重新结算

不新增表，也不需要 Flyway migration：Trigger Ledger 的 `status` 本身是 `VARCHAR(32)`。

### 2. 防止旧终态实例抢回已经释放的串行槽位

对于 `SERIAL_WAIT` / `SERIAL_DISCARD` 来源实例，人工原地恢复前会检查当前 workflow 是否已经存在：

- active WorkflowExecution
- LAUNCHING / REACTIVATING reservation
- WAITING backlog

如果串行槽位已经交给后续实例或队列，本次旧 Execution 的原地 retry / continue 会明确拒绝，并提示等待队列清空后再试，或使用“重新运行”创建新实例。

这里有意 **不实现“把人工 retry 请求再排入一个 durable 队列”**：单节点 retry、全部失败节点 retry、continue 三种操作需要额外持久化 operation payload，属于下一层运维任务模型。本批选择 fail-safe，不允许 retry 插队。

PARALLEL 来源实例不会因为其它 Execution 活跃而被拒绝。

### 3. 所有原地恢复入口统一经过协调层

新增 `WorkflowExecutionReactivationService`：

- 数据库模式：进入 Trigger Ledger Coordinator
- database-disabled / focused dev 模式：保持 Runtime 直连兼容

`WorkflowController` 的 continue / 单节点 retry / retry-failed 全部改走该服务。

`WorkflowInstanceOperationsService.batchRetryFailed` 同样改走该服务，避免批量重试绕开 Ledger。

`restart` / `rerunFromNode` 不属于本批：它们创建新的 WorkflowExecution，已经由统一 Launch 生命周期负责。

### 4. 崩溃恢复闭环

启动恢复查询增加 `REACTIVATING`：

- Execution 已是活动态 -> Ledger 恢复 RUNNING
- Execution 已终态 -> Ledger 按真实终态结算并继续推进 SERIAL_WAIT
- Execution 丢失 -> 回到已有 Trigger recovery 流程

`countLaunchingTriggers` 将 `LAUNCHING + REACTIVATING` 都视为 durable reservation，覆盖“Ledger 已占位但 Execution DB 尚未重新体现 RUNNING”的临界窗口。

### 5. Backfill / UI 可观测性

- Backfill `runningCount` 计入 `REACTIVATING`
- Trigger Ledger Drawer 新增“恢复中”状态
- UI 文案说明人工 retry / continue 会临时占用串行槽位

## 并发语义

| 原 Trigger 策略 | 人工恢复时其它实例/队列存在 | 行为 |
| --- | --- | --- |
| `SERIAL_WAIT` | 是 | 拒绝旧实例原地恢复，避免插队 |
| `SERIAL_DISCARD` | 是 | 拒绝旧实例原地恢复，避免并发 |
| `PARALLEL` | 是 | 允许恢复 |
| 任意策略 | 否 | `REACTIVATING -> RUNNING / terminal` |

新的 Cron / Backfill 在 `REACTIVATING` 窗口内仍严格遵守各自 SERIAL_WAIT / SERIAL_DISCARD / PARALLEL 策略。

## 测试

新增/扩展 focused tests，覆盖：

- 原地 retry 统一路由到 Reactivation Coordinator
- database-disabled 模式保持 Runtime fallback
- SERIAL_WAIT 无占用时成功预留 `REACTIVATING`
- 串行槽位已经被后续 Execution 占用时拒绝旧实例恢复
- PARALLEL 在其它 Execution 活跃时仍允许恢复
- Runtime 恢复后 Ledger 根据 durable Execution 回到 RUNNING
- Coordinator 的 reserve -> Runtime -> finish 生命周期
- Runtime 拒绝 retry 时释放/收敛 reactivation reservation
- 批量失败重试同样走协调入口且继续保持逐实例失败隔离

## 与 yak-framework 的关系

本 PR 不修改 `weifuwan/yak-framework`。Framework 允许终态 Execution 通过 retry / continue 回到 RUNNING 是合理的 Engine 能力；本次是在 Yak Ops 调度层补齐该状态变化对应的业务并发契约。

## 本 PR 不包含

继续留给后续 hardening：

- 将人工 retry/continue 本身持久化成可排队、可恢复的 Operation Task
- TaskExecutor 跨进程 durable idempotency contract
- Workflow Runtime 多副本 ownership / distributed single-master
- Workflow OFFLINE -> Schedule OFFLINE 即时联动
- Pause 能力与前端语义进一步收敛
