### PR TITLE
feat(data-development): publish SQL releases as Dataset

### DIFF
--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetReleaseController.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetReleaseController.java
@@ -6,6 +6,8 @@ import io.yak.framework.common.Result;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Size;
 import java.util.List;
+import java.util.Optional;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -24,19 +26,31 @@ public class DatasetReleaseController {
     this.service = service;
   }
 
-  @Operation(summary = "将已上线 SQL 任务的当前版本发布为 Dataset")
+  @Operation(summary = "查询已发布 SQL 任务关联的 Dataset 状态")
+  @GetMapping("/{assetId}/dataset")
+  public Result<ReleaseDatasetState> getReleaseDataset(@PathVariable("assetId") long assetId) {
+    Optional<DatasetDetail> detail = service.findBySourceTaskAssetId(assetId);
+    return Result.success(new ReleaseDatasetState(detail.isPresent(), detail.orElse(null)));
+  }
+
+  @Operation(summary = "将已上线 SQL 任务发布或更新为 Dataset")
   @PostMapping("/{assetId}/dataset")
   public Result<DatasetDetail> publishAsDataset(
       @PathVariable("assetId") long assetId,
       @Valid @RequestBody(required = false) ReleaseDatasetRequest request) {
     String name = request == null ? null : request.name();
     String description = request == null ? null : request.description();
-    return Result.success(service.publish(
+    return Result.success(service.publishFromRelease(
         new DatasetService.PublishCommand(assetId, name, description, List.of())));
   }
 
   public record ReleaseDatasetRequest(
       @Size(max = 200) String name,
       @Size(max = 2000) String description) {
+  }
+
+  public record ReleaseDatasetState(
+      boolean published,
+      DatasetDetail detail) {
   }
 }

--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetReleaseController.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetReleaseController.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.yak.framework.common.Result;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import java.util.List;
 import java.util.Optional;
@@ -33,6 +34,14 @@ public class DatasetReleaseController {
     return Result.success(new ReleaseDatasetState(detail.isPresent(), detail.orElse(null)));
   }
 
+  @Operation(summary = "预览已上线 SQL 当前版本的 Dataset 输出字段")
+  @PostMapping("/{assetId}/dataset/preview")
+  public Result<List<ReleaseDatasetField>> previewDataset(@PathVariable("assetId") long assetId) {
+    return Result.success(service.previewReleaseFields(assetId).stream()
+        .map(DatasetReleaseController::toReleaseField)
+        .toList());
+  }
+
   @Operation(summary = "将已上线 SQL 任务发布或更新为 Dataset")
   @PostMapping("/{assetId}/dataset")
   public Result<DatasetDetail> publishAsDataset(
@@ -40,13 +49,49 @@ public class DatasetReleaseController {
       @Valid @RequestBody(required = false) ReleaseDatasetRequest request) {
     String name = request == null ? null : request.name();
     String description = request == null ? null : request.description();
+    List<DatasetService.FieldSpec> fields = request == null || request.fields() == null
+        ? List.of()
+        : request.fields().stream().map(DatasetReleaseController::toFieldSpec).toList();
     return Result.success(service.publishFromRelease(
-        new DatasetService.PublishCommand(assetId, name, description, List.of())));
+        new DatasetService.PublishCommand(assetId, name, description, fields)));
+  }
+
+  private static DatasetService.FieldSpec toFieldSpec(ReleaseDatasetField field) {
+    return new DatasetService.FieldSpec(
+        field.fieldId(),
+        field.physicalName(),
+        field.displayName(),
+        field.dataType(),
+        field.nullable(),
+        field.description(),
+        field.defaultRole());
+  }
+
+  private static ReleaseDatasetField toReleaseField(DatasetService.FieldSpec field) {
+    return new ReleaseDatasetField(
+        field.fieldId(),
+        field.physicalName(),
+        field.displayName(),
+        field.dataType(),
+        field.nullable(),
+        field.description(),
+        field.defaultRole());
   }
 
   public record ReleaseDatasetRequest(
       @Size(max = 200) String name,
-      @Size(max = 2000) String description) {
+      @Size(max = 2000) String description,
+      List<@Valid ReleaseDatasetField> fields) {
+  }
+
+  public record ReleaseDatasetField(
+      @Size(max = 64) String fieldId,
+      @NotBlank @Size(max = 128) String physicalName,
+      @Size(max = 200) String displayName,
+      DatasetFieldDataType dataType,
+      boolean nullable,
+      @Size(max = 1000) String description,
+      DatasetFieldRole defaultRole) {
   }
 
   public record ReleaseDatasetState(

--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetRepository.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetRepository.java
@@ -24,6 +24,8 @@ interface DatasetRepository {
 
   Optional<Dataset> findDataset(long datasetId);
 
+  Optional<Dataset> findDatasetBySourceTaskAssetId(long sourceTaskAssetId);
+
   List<Dataset> listDatasets();
 
   Optional<DatasetVersion> findVersion(long versionId);

--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetSchemaDiscoveryService.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetSchemaDiscoveryService.java
@@ -44,6 +44,15 @@ final class DatasetSchemaDiscoveryService {
   }
 
   List<DatasetService.FieldSpec> discover(long datasetId, TaskAsset asset) {
+    return toFields(datasetId, discoverColumns(asset));
+  }
+
+  /** Preview uses no persistent fieldId; DatasetService assigns stable ids when the version is saved. */
+  List<DatasetService.FieldSpec> preview(TaskAsset asset) {
+    return toPreviewFields(discoverColumns(asset));
+  }
+
+  private List<DataSourceSqlColumn> discoverColumns(TaskAsset asset) {
     TaskAssetRevision resolved = taskCatalogService.resolveRevision(
         asset.id(), asset.currentRevision().taskRevisionId());
     if (resolved.revision().revisionId() != asset.currentRevision().taskRevisionId()
@@ -70,10 +79,24 @@ final class DatasetSchemaDiscoveryService {
     if (result.columns().isEmpty()) {
       throw new IllegalArgumentException("Dataset 来源查询没有可发现的输出字段");
     }
-    return toFields(datasetId, result.columns());
+    return result.columns();
   }
 
   private List<DatasetService.FieldSpec> toFields(long datasetId, List<DataSourceSqlColumn> columns) {
+    List<DatasetService.FieldSpec> preview = toPreviewFields(columns);
+    return preview.stream()
+        .map(field -> new DatasetService.FieldSpec(
+            stableFieldId(datasetId, field.physicalName()),
+            field.physicalName(),
+            field.displayName(),
+            field.dataType(),
+            field.nullable(),
+            field.description(),
+            field.defaultRole()))
+        .toList();
+  }
+
+  private List<DatasetService.FieldSpec> toPreviewFields(List<DataSourceSqlColumn> columns) {
     List<DatasetService.FieldSpec> fields = new ArrayList<>(columns.size());
     Set<String> names = new HashSet<>();
     for (DataSourceSqlColumn column : columns) {
@@ -95,10 +118,8 @@ final class DatasetSchemaDiscoveryService {
       DatasetFieldDataType dataType = dataType(column.jdbcType());
       DatasetFieldRole role = dataType == DatasetFieldDataType.NUMBER
           ? DatasetFieldRole.MEASURE : DatasetFieldRole.DIMENSION;
-      String fieldId = UUID.nameUUIDFromBytes(
-          ("dataset:" + datasetId + ":" + normalized).getBytes(StandardCharsets.UTF_8)).toString();
       fields.add(new DatasetService.FieldSpec(
-          fieldId,
+          null,
           physicalName,
           physicalName,
           dataType,
@@ -107,6 +128,12 @@ final class DatasetSchemaDiscoveryService {
           role));
     }
     return List.copyOf(fields);
+  }
+
+  private String stableFieldId(long datasetId, String physicalName) {
+    String normalized = physicalName.trim().toLowerCase(Locale.ROOT);
+    return UUID.nameUUIDFromBytes(
+        ("dataset:" + datasetId + ":" + normalized).getBytes(StandardCharsets.UTF_8)).toString();
   }
 
   private DatasetFieldDataType dataType(int jdbcType) {

--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetService.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetService.java
@@ -6,11 +6,14 @@ import io.yak.ops.business.taskcatalog.domain.TaskAsset;
 import io.yak.ops.business.taskcatalog.service.TaskCatalogService;
 import io.yak.ops.spi.task.model.TaskAssetSource;
 import io.yak.ops.spi.task.model.TaskAssetStatus;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -62,8 +65,8 @@ public class DatasetService {
    * Data-development release shortcut.
    *
    * <p>The first publish creates a stable Dataset identity. Later SQL TaskRevision publishes append
-   * a new DatasetVersion to that same Dataset. Re-publishing the already bound TaskRevision is
-   * idempotent so a double click never creates duplicate Dataset assets.
+   * a new DatasetVersion to that same Dataset. Re-publishing an already-bound TaskRevision is
+   * idempotent after the first Dataset has been committed.
    */
   @Transactional("yakBusinessTransactionManager")
   public DatasetDetail publishFromRelease(PublishCommand command) {
@@ -77,8 +80,7 @@ public class DatasetService {
     DatasetDetail current = get(existing.get().id());
     DatasetVersion currentVersion = current.currentVersion();
     if (currentVersion == null) {
-      List<FieldSpec> requestedFields = normalizeFields(command.fields());
-      List<FieldSpec> fields = resolveFields(existing.get().id(), asset, requestedFields);
+      List<FieldSpec> fields = resolveFields(existing.get().id(), asset, command.fields());
       long versionId = appendVersion(existing.get().id(), asset, fields, true);
       repository.updateCurrentVersion(existing.get().id(), versionId);
       return get(existing.get().id());
@@ -93,11 +95,18 @@ public class DatasetService {
       return current;
     }
 
-    List<FieldSpec> requestedFields = normalizeFields(command.fields());
-    List<FieldSpec> fields = resolveFields(existing.get().id(), asset, requestedFields);
+    List<FieldSpec> fields = resolveFields(existing.get().id(), asset, command.fields());
     long versionId = appendVersion(existing.get().id(), asset, fields, true);
     repository.updateCurrentVersion(existing.get().id(), versionId);
     return get(existing.get().id());
+  }
+
+  public List<FieldSpec> previewReleaseFields(long sourceTaskAssetId) {
+    TaskAsset asset = requirePublishableAsset(sourceTaskAssetId);
+    if (schemaDiscoveryService == null) {
+      throw new IllegalStateException("Dataset schema discovery 未启用");
+    }
+    return schemaDiscoveryService.preview(asset);
   }
 
   @Transactional("yakBusinessTransactionManager")
@@ -114,8 +123,7 @@ public class DatasetService {
           "当前 TaskRevision 已经是 Dataset 的当前版本：V" + currentVersion.versionNo());
     }
 
-    List<FieldSpec> normalizedFields = normalizeFields(fields);
-    normalizedFields = resolveFields(datasetId, asset, normalizedFields);
+    List<FieldSpec> normalizedFields = resolveFields(datasetId, asset, fields);
     long versionId = appendVersion(datasetId, asset, normalizedFields, true);
     repository.updateCurrentVersion(datasetId, versionId);
     return get(datasetId);
@@ -196,10 +204,9 @@ public class DatasetService {
   private DatasetDetail createDataset(TaskAsset asset, PublishCommand command) {
     String name = normalizeName(command.name(), asset.name());
     String description = normalizeDescription(command.description());
-    List<FieldSpec> requestedFields = normalizeFields(command.fields());
 
     long datasetId = repository.insertDataset(name, description);
-    List<FieldSpec> fields = resolveFields(datasetId, asset, requestedFields);
+    List<FieldSpec> fields = resolveFields(datasetId, asset, command.fields());
     long versionId = appendVersion(datasetId, asset, fields, false);
     repository.updateCurrentVersion(datasetId, versionId);
     return get(datasetId);
@@ -209,9 +216,11 @@ public class DatasetService {
       long datasetId,
       TaskAsset asset,
       List<FieldSpec> requestedFields) {
-    if (requestedFields != null && !requestedFields.isEmpty()) return requestedFields;
+    if (requestedFields != null && !requestedFields.isEmpty()) {
+      return normalizeFields(datasetId, requestedFields);
+    }
     if (schemaDiscoveryService == null) return List.of();
-    return normalizeFields(schemaDiscoveryService.discover(datasetId, asset));
+    return normalizeFields(datasetId, schemaDiscoveryService.discover(datasetId, asset));
   }
 
   private long appendVersion(
@@ -271,9 +280,10 @@ public class DatasetService {
     return normalized;
   }
 
-  private List<FieldSpec> normalizeFields(List<FieldSpec> values) {
+  private List<FieldSpec> normalizeFields(long datasetId, List<FieldSpec> values) {
     if (values == null || values.isEmpty()) return List.of();
 
+    Map<String, String> existingFieldIds = existingFieldIds(datasetId);
     List<FieldSpec> normalized = new ArrayList<>(values.size());
     Set<String> physicalNames = new HashSet<>();
     Set<String> fieldIds = new HashSet<>();
@@ -286,7 +296,9 @@ public class DatasetService {
       }
 
       String fieldId = value.fieldId();
-      if (fieldId == null || fieldId.isBlank()) fieldId = UUID.randomUUID().toString();
+      if (fieldId == null || fieldId.isBlank()) {
+        fieldId = existingFieldIds.getOrDefault(physicalKey, stableFieldId(datasetId, physicalKey));
+      }
       fieldId = fieldId.trim();
       if (fieldId.length() > 64) throw new IllegalArgumentException("fieldId 不能超过 64 个字符");
       if (!fieldIds.add(fieldId)) throw new IllegalArgumentException("fieldId 重复：" + fieldId);
@@ -315,6 +327,21 @@ public class DatasetService {
           value.defaultRole() == null ? DatasetFieldRole.DIMENSION : value.defaultRole()));
     }
     return List.copyOf(normalized);
+  }
+
+  private Map<String, String> existingFieldIds(long datasetId) {
+    Map<String, String> result = new HashMap<>();
+    repository.findDataset(datasetId).ifPresent(dataset -> {
+      if (dataset.currentVersionId() == null) return;
+      repository.listFields(dataset.currentVersionId()).forEach(field ->
+          result.put(field.physicalName().toLowerCase(Locale.ROOT), field.fieldId()));
+    });
+    return result;
+  }
+
+  private String stableFieldId(long datasetId, String physicalKey) {
+    return UUID.nameUUIDFromBytes(
+        ("dataset:" + datasetId + ":" + physicalKey).getBytes(StandardCharsets.UTF_8)).toString();
   }
 
   private String schemaSnapshot(List<FieldSpec> fields) {

--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetService.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetService.java
@@ -12,6 +12,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -54,15 +55,49 @@ public class DatasetService {
   public DatasetDetail publish(PublishCommand command) {
     Objects.requireNonNull(command, "command");
     TaskAsset asset = requirePublishableAsset(command.sourceTaskAssetId());
-    String name = normalizeName(command.name(), asset.name());
-    String description = normalizeDescription(command.description());
-    List<FieldSpec> requestedFields = normalizeFields(command.fields());
+    return createDataset(asset, command);
+  }
 
-    long datasetId = repository.insertDataset(name, description);
-    List<FieldSpec> fields = resolveFields(datasetId, asset, requestedFields);
-    long versionId = appendVersion(datasetId, asset, fields, false);
-    repository.updateCurrentVersion(datasetId, versionId);
-    return get(datasetId);
+  /**
+   * Data-development release shortcut.
+   *
+   * <p>The first publish creates a stable Dataset identity. Later SQL TaskRevision publishes append
+   * a new DatasetVersion to that same Dataset. Re-publishing the already bound TaskRevision is
+   * idempotent so a double click never creates duplicate Dataset assets.
+   */
+  @Transactional("yakBusinessTransactionManager")
+  public DatasetDetail publishFromRelease(PublishCommand command) {
+    Objects.requireNonNull(command, "command");
+    TaskAsset asset = requirePublishableAsset(command.sourceTaskAssetId());
+    Optional<Dataset> existing = repository.findDatasetBySourceTaskAssetId(asset.id());
+    if (existing.isEmpty()) {
+      return createDataset(asset, command);
+    }
+
+    DatasetDetail current = get(existing.get().id());
+    DatasetVersion currentVersion = current.currentVersion();
+    if (currentVersion == null) {
+      List<FieldSpec> requestedFields = normalizeFields(command.fields());
+      List<FieldSpec> fields = resolveFields(existing.get().id(), asset, requestedFields);
+      long versionId = appendVersion(existing.get().id(), asset, fields, true);
+      repository.updateCurrentVersion(existing.get().id(), versionId);
+      return get(existing.get().id());
+    }
+    if (currentVersion.sourceTaskAssetId() != asset.id()) {
+      throw new IllegalStateException(
+          "Dataset 来源 TaskAsset 不一致：datasetId=" + existing.get().id()
+              + ", expected=" + currentVersion.sourceTaskAssetId()
+              + ", actual=" + asset.id());
+    }
+    if (currentVersion.sourceTaskRevisionId() == asset.currentRevision().taskRevisionId()) {
+      return current;
+    }
+
+    List<FieldSpec> requestedFields = normalizeFields(command.fields());
+    List<FieldSpec> fields = resolveFields(existing.get().id(), asset, requestedFields);
+    long versionId = appendVersion(existing.get().id(), asset, fields, true);
+    repository.updateCurrentVersion(existing.get().id(), versionId);
+    return get(existing.get().id());
   }
 
   @Transactional("yakBusinessTransactionManager")
@@ -107,6 +142,14 @@ public class DatasetService {
     return new DatasetDetail(dataset, currentVersion, repository.listVersions(datasetId), fields);
   }
 
+  public Optional<DatasetDetail> findBySourceTaskAssetId(long sourceTaskAssetId) {
+    if (sourceTaskAssetId <= 0L) {
+      throw new IllegalArgumentException("sourceTaskAssetId 必须大于 0");
+    }
+    return repository.findDatasetBySourceTaskAssetId(sourceTaskAssetId)
+        .map(dataset -> get(dataset.id()));
+  }
+
   /**
    * Cross-domain validation boundary used by reusable Analysis assets.
    *
@@ -147,6 +190,18 @@ public class DatasetService {
     if (dataset.status() != DatasetStatus.OFFLINE) {
       repository.updateStatus(datasetId, DatasetStatus.OFFLINE);
     }
+    return get(datasetId);
+  }
+
+  private DatasetDetail createDataset(TaskAsset asset, PublishCommand command) {
+    String name = normalizeName(command.name(), asset.name());
+    String description = normalizeDescription(command.description());
+    List<FieldSpec> requestedFields = normalizeFields(command.fields());
+
+    long datasetId = repository.insertDataset(name, description);
+    List<FieldSpec> fields = resolveFields(datasetId, asset, requestedFields);
+    long versionId = appendVersion(datasetId, asset, fields, false);
+    repository.updateCurrentVersion(datasetId, versionId);
     return get(datasetId);
   }
 

--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/JdbcDatasetRepository.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/JdbcDatasetRepository.java
@@ -140,6 +140,22 @@ class JdbcDatasetRepository implements DatasetRepository {
   }
 
   @Override
+  public Optional<Dataset> findDatasetBySourceTaskAssetId(long sourceTaskAssetId) {
+    return jdbcTemplate.query(
+        """
+        SELECT DISTINCT d.id, d.name, d.description, d.status, d.current_version_id,
+               d.create_time, d.update_time
+        FROM yak_dataset d
+        INNER JOIN yak_dataset_version v ON v.dataset_id = d.id
+        WHERE v.source_task_asset_id = ?
+        ORDER BY d.update_time DESC, d.id DESC
+        LIMIT 1
+        """,
+        JdbcDatasetRepository::mapDataset,
+        sourceTaskAssetId).stream().findFirst();
+  }
+
+  @Override
   public List<Dataset> listDatasets() {
     return jdbcTemplate.query(
         DATASET_COLUMNS + " ORDER BY update_time DESC, id DESC",

--- a/yak-ops-business/yak-ops-business-dataset/src/test/java/io/yak/ops/business/dataset/DatasetServiceTest.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/test/java/io/yak/ops/business/dataset/DatasetServiceTest.java
@@ -3,6 +3,8 @@ package io.yak.ops.business.dataset;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -127,6 +129,82 @@ class DatasetServiceTest {
     assertEquals(4, result.currentVersion().sourceTaskRevisionNo());
     verify(repository).updateCurrentVersion(21L, 32L);
     verify(repository).insertFields(eq(32L), anyList());
+  }
+
+  @Test
+  void publishFromReleasePreservesFieldIdAcrossCustomizedVersion() {
+    DatasetRepository repository = mock(DatasetRepository.class);
+    TaskCatalogService catalog = mock(TaskCatalogService.class);
+    DatasetService service = new DatasetService(repository, catalog, new ObjectMapper());
+
+    TaskAsset asset = taskAsset(11L, TaskAssetStatus.ONLINE, "SQL", 72L, 4);
+    Dataset before = new Dataset(
+        21L, "sales", "sales dataset", DatasetStatus.ONLINE, 31L, Instant.EPOCH, Instant.EPOCH);
+    Dataset after = new Dataset(
+        21L, "sales", "sales dataset", DatasetStatus.ONLINE, 32L, Instant.EPOCH, Instant.EPOCH);
+    DatasetVersion version1 = new DatasetVersion(
+        31L, 21L, 1, DatasetSourceType.QUERY_REVISION, 11L, 71L, 3, "[]", Instant.EPOCH);
+    DatasetVersion version2 = new DatasetVersion(
+        32L, 21L, 2, DatasetSourceType.QUERY_REVISION, 11L, 72L, 4, "[]", Instant.EPOCH);
+    DatasetField oldField = new DatasetField(
+        "field-sales-amount",
+        31L,
+        "sales_amount",
+        "销售额",
+        DatasetFieldDataType.NUMBER,
+        true,
+        null,
+        DatasetFieldRole.MEASURE,
+        1);
+    DatasetField newField = new DatasetField(
+        "field-sales-amount",
+        32L,
+        "sales_amount",
+        "销售金额",
+        DatasetFieldDataType.NUMBER,
+        true,
+        null,
+        DatasetFieldRole.MEASURE,
+        1);
+
+    when(catalog.get(11L)).thenReturn(asset);
+    when(repository.findDatasetBySourceTaskAssetId(11L)).thenReturn(Optional.of(before));
+    when(repository.findDataset(21L)).thenReturn(
+        Optional.of(before),
+        Optional.of(before),
+        Optional.of(before),
+        Optional.of(after));
+    when(repository.findVersion(31L)).thenReturn(Optional.of(version1));
+    when(repository.findVersion(32L)).thenReturn(Optional.of(version2));
+    when(repository.listVersions(21L)).thenReturn(List.of(version1), List.of(version2, version1));
+    when(repository.listFields(31L)).thenReturn(List.of(oldField));
+    when(repository.listFields(32L)).thenReturn(List.of(newField));
+    when(repository.nextVersionNo(21L)).thenReturn(2);
+    when(repository.insertVersion(
+        eq(21L),
+        eq(2),
+        eq(DatasetSourceType.QUERY_REVISION),
+        eq(11L),
+        eq(72L),
+        eq(4),
+        anyString())).thenReturn(32L);
+
+    DatasetDetail result = service.publishFromRelease(new DatasetService.PublishCommand(
+        11L,
+        null,
+        null,
+        List.of(new DatasetService.FieldSpec(
+            null,
+            "sales_amount",
+            "销售金额",
+            DatasetFieldDataType.NUMBER,
+            true,
+            null,
+            DatasetFieldRole.MEASURE))));
+
+    assertEquals("field-sales-amount", result.fields().get(0).fieldId());
+    verify(repository).insertFields(eq(32L), argThat(fields ->
+        fields.size() == 1 && "field-sales-amount".equals(fields.get(0).fieldId())));
   }
 
   @Test

--- a/yak-ops-business/yak-ops-business-dataset/src/test/java/io/yak/ops/business/dataset/DatasetServiceTest.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/test/java/io/yak/ops/business/dataset/DatasetServiceTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -54,6 +55,78 @@ class DatasetServiceTest {
     assertEquals(3, result.currentVersion().sourceTaskRevisionNo());
     verify(repository).updateCurrentVersion(21L, 31L);
     verify(repository).insertFields(eq(31L), anyList());
+  }
+
+  @Test
+  void publishFromReleaseIsIdempotentForCurrentTaskRevision() {
+    DatasetRepository repository = mock(DatasetRepository.class);
+    TaskCatalogService catalog = mock(TaskCatalogService.class);
+    DatasetService service = new DatasetService(repository, catalog, new ObjectMapper());
+
+    TaskAsset asset = taskAsset(11L, TaskAssetStatus.ONLINE, "SQL", 71L, 3);
+    Dataset dataset = new Dataset(
+        21L, "sales", "sales dataset", DatasetStatus.ONLINE, 31L, Instant.EPOCH, Instant.EPOCH);
+    DatasetVersion version = new DatasetVersion(
+        31L, 21L, 1, DatasetSourceType.QUERY_REVISION, 11L, 71L, 3, "[]", Instant.EPOCH);
+    when(catalog.get(11L)).thenReturn(asset);
+    when(repository.findDatasetBySourceTaskAssetId(11L)).thenReturn(Optional.of(dataset));
+    when(repository.findDataset(21L)).thenReturn(Optional.of(dataset));
+    when(repository.findVersion(31L)).thenReturn(Optional.of(version));
+    when(repository.listVersions(21L)).thenReturn(List.of(version));
+    when(repository.listFields(31L)).thenReturn(List.of());
+
+    DatasetDetail result = service.publishFromRelease(new DatasetService.PublishCommand(
+        11L, "ignored", "ignored", List.of()));
+
+    assertEquals(1, result.currentVersion().versionNo());
+    verify(repository, never()).insertDataset("ignored", "ignored");
+    verify(repository, never()).updateCurrentVersion(eq(21L), eq(31L));
+  }
+
+  @Test
+  void publishFromReleaseAppendsDatasetVersionForNewTaskRevision() {
+    DatasetRepository repository = mock(DatasetRepository.class);
+    TaskCatalogService catalog = mock(TaskCatalogService.class);
+    DatasetService service = new DatasetService(repository, catalog, new ObjectMapper());
+
+    TaskAsset asset = taskAsset(11L, TaskAssetStatus.ONLINE, "SQL", 72L, 4);
+    Dataset before = new Dataset(
+        21L, "sales", "sales dataset", DatasetStatus.ONLINE, 31L, Instant.EPOCH, Instant.EPOCH);
+    Dataset after = new Dataset(
+        21L, "sales", "sales dataset", DatasetStatus.ONLINE, 32L, Instant.EPOCH, Instant.EPOCH);
+    DatasetVersion version1 = new DatasetVersion(
+        31L, 21L, 1, DatasetSourceType.QUERY_REVISION, 11L, 71L, 3, "[]", Instant.EPOCH);
+    DatasetVersion version2 = new DatasetVersion(
+        32L, 21L, 2, DatasetSourceType.QUERY_REVISION, 11L, 72L, 4, "[]", Instant.EPOCH);
+
+    when(catalog.get(11L)).thenReturn(asset);
+    when(repository.findDatasetBySourceTaskAssetId(11L)).thenReturn(Optional.of(before));
+    when(repository.findDataset(21L)).thenReturn(
+        Optional.of(before),
+        Optional.of(before),
+        Optional.of(after));
+    when(repository.findVersion(31L)).thenReturn(Optional.of(version1));
+    when(repository.findVersion(32L)).thenReturn(Optional.of(version2));
+    when(repository.listVersions(21L)).thenReturn(List.of(version1), List.of(version2, version1));
+    when(repository.listFields(31L)).thenReturn(List.of());
+    when(repository.listFields(32L)).thenReturn(List.of());
+    when(repository.nextVersionNo(21L)).thenReturn(2);
+    when(repository.insertVersion(
+        eq(21L),
+        eq(2),
+        eq(DatasetSourceType.QUERY_REVISION),
+        eq(11L),
+        eq(72L),
+        eq(4),
+        eq("[]"))).thenReturn(32L);
+
+    DatasetDetail result = service.publishFromRelease(new DatasetService.PublishCommand(
+        11L, null, null, List.of()));
+
+    assertEquals(2, result.currentVersion().versionNo());
+    assertEquals(4, result.currentVersion().sourceTaskRevisionNo());
+    verify(repository).updateCurrentVersion(21L, 32L);
+    verify(repository).insertFields(eq(32L), anyList());
   }
 
   @Test

--- a/yak-ops-ui/src/pages/data-development/components/workbench/DevelopmentWorkbench.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/workbench/DevelopmentWorkbench.tsx
@@ -3,6 +3,11 @@ import { Button, Modal, message } from 'antd';
 import { TriangleAlert } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 
+import {
+  fetchDevelopmentDatasetContext,
+  publishDevelopmentReleaseDataset,
+  type DevelopmentDatasetContext,
+} from '../../dataset-service';
 import { getEditorDefinition } from '../../editors/registry';
 import {
   getEditorSession,
@@ -29,6 +34,7 @@ import type {
 import EditorHost from './EditorHost';
 import EditorTabs, { type EditorTabAction } from './EditorTabs';
 import EditorToolbar from './EditorToolbar';
+import PublishDatasetModal from './PublishDatasetModal';
 import RightPanel from './RightPanel';
 import RunResultPanel from './RunResultPanel';
 
@@ -74,6 +80,11 @@ const DevelopmentWorkbench = ({
   const [publishing, setPublishing] = useState(false);
   const [closeSaving, setCloseSaving] = useState(false);
   const [versionsRefreshKey, setVersionsRefreshKey] = useState(0);
+  const [datasetRefreshKey, setDatasetRefreshKey] = useState(0);
+  const [datasetContext, setDatasetContext] = useState<DevelopmentDatasetContext>({});
+  const [datasetLoading, setDatasetLoading] = useState(false);
+  const [datasetPublishing, setDatasetPublishing] = useState(false);
+  const [datasetModalOpen, setDatasetModalOpen] = useState(false);
 
   const nodeMap = useMemo(
     () => new Map(nodes.map((node) => [node.id, node])),
@@ -128,6 +139,43 @@ const DevelopmentWorkbench = ({
   const activeRunning = activeNode
     ? runningNodeIds.includes(activeNode.id)
     : false;
+
+  useEffect(() => {
+    if (!activeNode || activeNode.type !== 'SQL') {
+      setDatasetContext({});
+      setDatasetLoading(false);
+      setDatasetModalOpen(false);
+      return;
+    }
+
+    let active = true;
+    setDatasetLoading(true);
+    fetchDevelopmentDatasetContext(activeNode.id, activeNode.name)
+      .then((context) => {
+        if (active) setDatasetContext(context);
+      })
+      .catch((error) => {
+        if (!active) return;
+        setDatasetContext({});
+        message.error(error instanceof Error ? error.message : '加载 Dataset 状态失败');
+      })
+      .finally(() => {
+        if (active) setDatasetLoading(false);
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [activeNode?.id, activeNode?.name, activeNode?.type, datasetRefreshKey]);
+
+  const datasetVersion = datasetContext.datasetState?.detail?.currentVersion || undefined;
+  const datasetToolbarState = datasetContext.release ? {
+    releaseRevisionNo: datasetContext.release.currentRevisionNo,
+    datasetId: datasetContext.datasetState?.detail?.dataset.id,
+    datasetVersionNo: datasetVersion?.versionNo,
+    datasetSourceRevisionNo: datasetVersion?.sourceTaskRevisionNo,
+    datasetStatus: datasetContext.datasetState?.detail?.dataset.status,
+  } : undefined;
 
   const focusNode = (nodeId: DevelopmentId) => {
     setActiveNodeId(nodeId);
@@ -232,11 +280,41 @@ const DevelopmentWorkbench = ({
         '发布任务失败',
       );
       setVersionsRefreshKey((current) => current + 1);
-      message.success(`已发布 v${published.revisionNo}`);
+      if (activeNode.type === 'SQL') setDatasetRefreshKey((current) => current + 1);
+      message.success(
+        activeNode.type === 'SQL'
+          ? `已发布 v${published.revisionNo} · 可继续发布/更新 Dataset`
+          : `已发布 v${published.revisionNo}`,
+      );
     } catch (error) {
       message.error(error instanceof Error ? error.message : '发布任务失败');
     } finally {
       setPublishing(false);
+    }
+  };
+
+  const publishActiveDataset = async (payload: { name?: string; description?: string }) => {
+    const release = datasetContext.release;
+    if (!activeNode || activeNode.type !== 'SQL' || !release) return;
+    const wasPublished = Boolean(datasetContext.datasetState?.published);
+    setDatasetPublishing(true);
+    try {
+      const detail = await publishDevelopmentReleaseDataset(release.assetId, payload);
+      setDatasetContext((current) => ({
+        ...current,
+        datasetState: { published: true, detail },
+      }));
+      setDatasetModalOpen(false);
+      setDatasetRefreshKey((current) => current + 1);
+      message.success(
+        wasPublished
+          ? `Dataset 已更新至 DV${detail.currentVersion?.versionNo || '-'}`
+          : `Dataset 已发布 · DV${detail.currentVersion?.versionNo || 1}`,
+      );
+    } catch (error) {
+      message.error(error instanceof Error ? error.message : '发布 Dataset 失败');
+    } finally {
+      setDatasetPublishing(false);
     }
   };
 
@@ -373,6 +451,10 @@ const DevelopmentWorkbench = ({
         onRun={() => void runActiveTask()}
         onSave={() => void saveActiveDraft()}
         onPublish={() => void publishActiveTask()}
+        onPublishDataset={activeNode.type === 'SQL' ? () => setDatasetModalOpen(true) : undefined}
+        datasetState={activeNode.type === 'SQL' ? datasetToolbarState : undefined}
+        datasetLoading={activeNode.type === 'SQL' && datasetLoading}
+        datasetPublishing={activeNode.type === 'SQL' && datasetPublishing}
         running={activeRunning}
         saving={saving}
         publishing={publishing}
@@ -404,6 +486,20 @@ const DevelopmentWorkbench = ({
           onClose={() => setRunPanelOpen(false)}
         />
       </div>
+
+      {activeNode.type === 'SQL' ? (
+        <PublishDatasetModal
+          open={datasetModalOpen}
+          nodeName={activeNode.name}
+          release={datasetContext.release}
+          datasetState={datasetContext.datasetState}
+          publishing={datasetPublishing}
+          onCancel={() => {
+            if (!datasetPublishing) setDatasetModalOpen(false);
+          }}
+          onPublish={(payload) => void publishActiveDataset(payload)}
+        />
+      ) : null}
 
       <Modal
         open={Boolean(pendingClose)}

--- a/yak-ops-ui/src/pages/data-development/components/workbench/DevelopmentWorkbench.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/workbench/DevelopmentWorkbench.tsx
@@ -171,6 +171,7 @@ const DevelopmentWorkbench = ({
   const datasetVersion = datasetContext.datasetState?.detail?.currentVersion || undefined;
   const datasetToolbarState = datasetContext.release ? {
     releaseRevisionNo: datasetContext.release.currentRevisionNo,
+    releaseStatus: datasetContext.release.status,
     datasetId: datasetContext.datasetState?.detail?.dataset.id,
     datasetVersionNo: datasetVersion?.versionNo,
     datasetSourceRevisionNo: datasetVersion?.sourceTaskRevisionNo,

--- a/yak-ops-ui/src/pages/data-development/components/workbench/DevelopmentWorkbench.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/workbench/DevelopmentWorkbench.tsx
@@ -5,8 +5,11 @@ import { useEffect, useMemo, useState } from 'react';
 
 import {
   fetchDevelopmentDatasetContext,
+  previewDevelopmentReleaseDataset,
   publishDevelopmentReleaseDataset,
   type DevelopmentDatasetContext,
+  type DevelopmentDatasetFieldDraft,
+  type PublishDevelopmentDatasetPayload,
 } from '../../dataset-service';
 import { getEditorDefinition } from '../../editors/registry';
 import {
@@ -85,6 +88,9 @@ const DevelopmentWorkbench = ({
   const [datasetLoading, setDatasetLoading] = useState(false);
   const [datasetPublishing, setDatasetPublishing] = useState(false);
   const [datasetModalOpen, setDatasetModalOpen] = useState(false);
+  const [datasetPreviewFields, setDatasetPreviewFields] = useState<DevelopmentDatasetFieldDraft[]>([]);
+  const [datasetPreviewLoading, setDatasetPreviewLoading] = useState(false);
+  const [datasetPreviewError, setDatasetPreviewError] = useState('');
 
   const nodeMap = useMemo(
     () => new Map(nodes.map((node) => [node.id, node])),
@@ -145,6 +151,8 @@ const DevelopmentWorkbench = ({
       setDatasetContext({});
       setDatasetLoading(false);
       setDatasetModalOpen(false);
+      setDatasetPreviewFields([]);
+      setDatasetPreviewError('');
       return;
     }
 
@@ -294,7 +302,23 @@ const DevelopmentWorkbench = ({
     }
   };
 
-  const publishActiveDataset = async (payload: { name?: string; description?: string }) => {
+  const openDatasetModal = async () => {
+    const release = datasetContext.release;
+    if (!activeNode || activeNode.type !== 'SQL' || !release) return;
+    setDatasetModalOpen(true);
+    setDatasetPreviewFields([]);
+    setDatasetPreviewError('');
+    setDatasetPreviewLoading(true);
+    try {
+      setDatasetPreviewFields(await previewDevelopmentReleaseDataset(release.assetId));
+    } catch (error) {
+      setDatasetPreviewError(error instanceof Error ? error.message : '发现 Dataset 字段失败');
+    } finally {
+      setDatasetPreviewLoading(false);
+    }
+  };
+
+  const publishActiveDataset = async (payload: PublishDevelopmentDatasetPayload) => {
     const release = datasetContext.release;
     if (!activeNode || activeNode.type !== 'SQL' || !release) return;
     const wasPublished = Boolean(datasetContext.datasetState?.published);
@@ -306,6 +330,7 @@ const DevelopmentWorkbench = ({
         datasetState: { published: true, detail },
       }));
       setDatasetModalOpen(false);
+      setDatasetPreviewFields([]);
       setDatasetRefreshKey((current) => current + 1);
       message.success(
         wasPublished
@@ -452,7 +477,7 @@ const DevelopmentWorkbench = ({
         onRun={() => void runActiveTask()}
         onSave={() => void saveActiveDraft()}
         onPublish={() => void publishActiveTask()}
-        onPublishDataset={activeNode.type === 'SQL' ? () => setDatasetModalOpen(true) : undefined}
+        onPublishDataset={activeNode.type === 'SQL' ? () => void openDatasetModal() : undefined}
         datasetState={activeNode.type === 'SQL' ? datasetToolbarState : undefined}
         datasetLoading={activeNode.type === 'SQL' && datasetLoading}
         datasetPublishing={activeNode.type === 'SQL' && datasetPublishing}
@@ -494,6 +519,9 @@ const DevelopmentWorkbench = ({
           nodeName={activeNode.name}
           release={datasetContext.release}
           datasetState={datasetContext.datasetState}
+          previewFields={datasetPreviewFields}
+          previewLoading={datasetPreviewLoading}
+          previewError={datasetPreviewError}
           publishing={datasetPublishing}
           onCancel={() => {
             if (!datasetPublishing) setDatasetModalOpen(false);

--- a/yak-ops-ui/src/pages/data-development/components/workbench/EditorToolbar.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/workbench/EditorToolbar.tsx
@@ -1,7 +1,10 @@
 import { Tooltip } from 'antd';
 import { LoaderCircle, Play, Rocket, Save } from 'lucide-react';
 
-import type { DevelopmentEditorDefinition } from '../../editors/types';
+import type {
+  DevelopmentDatasetToolbarState,
+  DevelopmentEditorDefinition,
+} from '../../editors/types';
 import type { DevelopmentDirectory, DevelopmentNode } from '../../types';
 
 interface EditorToolbarProps {
@@ -11,6 +14,10 @@ interface EditorToolbarProps {
   onRun: () => void;
   onSave: () => void;
   onPublish: () => void;
+  onPublishDataset?: () => void;
+  datasetState?: DevelopmentDatasetToolbarState;
+  datasetLoading?: boolean;
+  datasetPublishing?: boolean;
   running: boolean;
   saving: boolean;
   publishing: boolean;
@@ -26,6 +33,10 @@ const EditorToolbar = ({
   onRun,
   onSave,
   onPublish,
+  onPublishDataset,
+  datasetState,
+  datasetLoading,
+  datasetPublishing,
   running,
   saving,
   publishing,
@@ -43,6 +54,10 @@ const EditorToolbar = ({
             onRun={onRun}
             onSave={onSave}
             onPublish={onPublish}
+            onPublishDataset={onPublishDataset}
+            datasetState={datasetState}
+            datasetLoading={datasetLoading}
+            datasetPublishing={datasetPublishing}
             running={running}
             saving={saving}
             publishing={publishing}

--- a/yak-ops-ui/src/pages/data-development/components/workbench/PublishDatasetModal.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/workbench/PublishDatasetModal.tsx
@@ -1,9 +1,11 @@
-import { Input, Modal } from 'antd';
+import { Input, Modal, Select, Spin } from 'antd';
 import { Database, GitBranch, Info, Layers3 } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 
 import type {
+  DevelopmentDatasetFieldDraft,
   DevelopmentReleaseDatasetState,
+  PublishDevelopmentDatasetPayload,
 } from '../../dataset-service';
 import type { DevelopmentReleaseSummary } from '../../types';
 
@@ -12,18 +14,33 @@ interface PublishDatasetModalProps {
   nodeName: string;
   release?: DevelopmentReleaseSummary;
   datasetState?: DevelopmentReleaseDatasetState;
+  previewFields: DevelopmentDatasetFieldDraft[];
+  previewLoading: boolean;
+  previewError?: string;
   publishing: boolean;
   onCancel: () => void;
-  onPublish: (payload: { name?: string; description?: string }) => void;
+  onPublish: (payload: PublishDevelopmentDatasetPayload) => void;
 }
 
 const stripSqlSuffix = (value: string) => value.replace(/\.sql$/i, '');
+
+const fieldTypeLabel: Record<DevelopmentDatasetFieldDraft['dataType'], string> = {
+  STRING: '字符串',
+  NUMBER: '数值',
+  DATE: '日期',
+  DATETIME: '日期时间',
+  BOOLEAN: '布尔',
+  UNKNOWN: '未知',
+};
 
 const PublishDatasetModal = ({
   open,
   nodeName,
   release,
   datasetState,
+  previewFields,
+  previewLoading,
+  previewError,
   publishing,
   onCancel,
   onPublish,
@@ -36,6 +53,7 @@ const PublishDatasetModal = ({
   );
   const [name, setName] = useState(stripSqlSuffix(nodeName));
   const [description, setDescription] = useState('');
+  const [fields, setFields] = useState<DevelopmentDatasetFieldDraft[]>([]);
 
   useEffect(() => {
     if (!open) return;
@@ -43,12 +61,28 @@ const PublishDatasetModal = ({
     setDescription(detail?.dataset.description || '');
   }, [detail?.dataset.description, detail?.dataset.name, nodeName, open]);
 
+  useEffect(() => {
+    if (!open) return;
+    const currentByPhysicalName = new Map(
+      (detail?.fields || []).map((field) => [field.physicalName.toLowerCase(), field]),
+    );
+    setFields(previewFields.map((field) => {
+      const current = currentByPhysicalName.get(field.physicalName.toLowerCase());
+      return {
+        ...field,
+        fieldId: current?.fieldId || field.fieldId,
+        displayName: current?.displayName || field.displayName,
+        description: current?.description || field.description,
+        defaultRole: current?.defaultRole || field.defaultRole,
+      };
+    }));
+  }, [detail?.fields, open, previewFields]);
+
   const fieldSummary = useMemo(() => {
-    const fields = detail?.fields || [];
     const dimensions = fields.filter((field) => field.defaultRole === 'DIMENSION').length;
     const measures = fields.filter((field) => field.defaultRole === 'MEASURE').length;
     return { total: fields.length, dimensions, measures };
-  }, [detail?.fields]);
+  }, [fields]);
 
   const nextVersionNo = (currentVersion?.versionNo || 0) + 1;
   const confirmText = !alreadyPublished
@@ -56,24 +90,39 @@ const PublishDatasetModal = ({
     : needsUpdate
       ? `更新至 DV${nextVersionNo}`
       : '已是最新版本';
+  const canPublish = Boolean(
+    release
+      && release.status === 'ONLINE'
+      && needsUpdate
+      && !previewLoading
+      && !previewError
+      && fields.length
+      && (alreadyPublished || name.trim()),
+  );
+
+  const updateField = (
+    physicalName: string,
+    patch: Partial<DevelopmentDatasetFieldDraft>,
+  ) => setFields((current) => current.map((field) => (
+    field.physicalName === physicalName ? { ...field, ...patch } : field
+  )));
 
   return (
     <Modal
       open={open}
-      width={560}
+      width={760}
       centered
       destroyOnHidden
       title={alreadyPublished ? '更新 Dataset' : '发布为 Dataset'}
       okText={confirmText}
       cancelText="取消"
       confirmLoading={publishing}
-      okButtonProps={{
-        disabled: !release || !needsUpdate || (!alreadyPublished && !name.trim()),
-      }}
+      okButtonProps={{ disabled: !canPublish }}
       onCancel={onCancel}
       onOk={() => onPublish({
         name: alreadyPublished ? undefined : name.trim(),
         description: alreadyPublished ? undefined : description.trim() || undefined,
+        fields,
       })}
     >
       <div className="space-y-4 py-2">
@@ -97,7 +146,7 @@ const PublishDatasetModal = ({
         </div>
 
         {!alreadyPublished ? (
-          <>
+          <div className="grid grid-cols-2 gap-3">
             <div>
               <div className="mb-1.5 text-[12px] font-medium text-[#344054]">数据集名称</div>
               <Input
@@ -109,47 +158,90 @@ const PublishDatasetModal = ({
             </div>
             <div>
               <div className="mb-1.5 text-[12px] font-medium text-[#344054]">描述</div>
-              <Input.TextArea
+              <Input
                 value={description}
                 maxLength={2000}
-                autoSize={{ minRows: 3, maxRows: 5 }}
-                placeholder="说明这个 Dataset 的业务口径和使用场景（可选）"
+                placeholder="业务口径或使用场景（可选）"
                 onChange={(event) => setDescription(event.target.value)}
               />
             </div>
-          </>
+          </div>
         ) : (
-          <div className="border border-[#e5e7eb] px-3 py-3">
-            <div className="flex items-center gap-2">
-              <Database size={15} className="text-[#667085]" />
-              <div className="min-w-0 flex-1">
-                <div className="truncate text-[13px] font-medium text-[#344054]">{detail?.dataset.name}</div>
-                <div className="mt-0.5 text-[11px] text-[#98a2b3]">
-                  Dataset #{detail?.dataset.id} · {detail?.dataset.status === 'OFFLINE' ? '已下线' : '已上线'}
-                </div>
+          <div className="flex items-center gap-2 border border-[#e5e7eb] px-3 py-2.5">
+            <Database size={15} className="text-[#667085]" />
+            <div className="min-w-0 flex-1">
+              <div className="truncate text-[13px] font-medium text-[#344054]">{detail?.dataset.name}</div>
+              <div className="mt-0.5 text-[11px] text-[#98a2b3]">
+                Dataset #{detail?.dataset.id} · {detail?.dataset.status === 'OFFLINE' ? '已下线' : '已上线'}
               </div>
             </div>
-            <div className="mt-3 grid grid-cols-3 gap-2 text-center">
-              <div className="bg-[#f8f9fb] px-2 py-2">
-                <div className="text-[13px] font-medium text-[#344054]">{fieldSummary.total}</div>
-                <div className="text-[10px] text-[#98a2b3]">当前字段</div>
-              </div>
-              <div className="bg-[#f8f9fb] px-2 py-2">
-                <div className="text-[13px] font-medium text-[#344054]">{fieldSummary.dimensions}</div>
-                <div className="text-[10px] text-[#98a2b3]">维度</div>
-              </div>
-              <div className="bg-[#f8f9fb] px-2 py-2">
-                <div className="text-[13px] font-medium text-[#344054]">{fieldSummary.measures}</div>
-                <div className="text-[10px] text-[#98a2b3]">指标</div>
-              </div>
+            <div className="text-[11px] text-[#667085]">
+              {fieldSummary.total} 字段 · {fieldSummary.dimensions} 维度 · {fieldSummary.measures} 指标
             </div>
           </div>
         )}
 
+        <div>
+          <div className="mb-2 flex items-center justify-between">
+            <div>
+              <div className="text-[12px] font-medium text-[#344054]">输出字段</div>
+              <div className="mt-0.5 text-[10px] text-[#98a2b3]">自动发现字段类型，可调整显示名称和维度/指标角色</div>
+            </div>
+            {!previewLoading && fields.length ? (
+              <div className="text-[10px] text-[#98a2b3]">
+                {fieldSummary.total} 字段 · {fieldSummary.dimensions} 维度 · {fieldSummary.measures} 指标
+              </div>
+            ) : null}
+          </div>
+
+          <div className="max-h-[300px] overflow-auto border border-[#e5e7eb]">
+            <div className="sticky top-0 z-10 grid grid-cols-[1.25fr_.7fr_1.25fr_.8fr] gap-2 border-b border-[#e5e7eb] bg-[#fafafa] px-3 py-2 text-[10px] font-medium text-[#667085]">
+              <span>物理字段</span>
+              <span>类型</span>
+              <span>显示名称</span>
+              <span>角色</span>
+            </div>
+            {previewLoading ? (
+              <div className="flex h-28 items-center justify-center gap-2 text-[11px] text-[#98a2b3]">
+                <Spin size="small" /> 正在发现 SQL 输出字段
+              </div>
+            ) : previewError ? (
+              <div className="px-4 py-8 text-center text-[11px] text-[#b42318]">{previewError}</div>
+            ) : fields.length ? fields.map((field) => (
+              <div
+                key={field.physicalName}
+                className="grid grid-cols-[1.25fr_.7fr_1.25fr_.8fr] items-center gap-2 border-b border-[#f0f1f3] px-3 py-2 last:border-b-0"
+              >
+                <div className="min-w-0 truncate text-[11px] font-medium text-[#344054]" title={field.physicalName}>
+                  {field.physicalName}
+                </div>
+                <div className="text-[10px] text-[#667085]">{fieldTypeLabel[field.dataType]}</div>
+                <Input
+                  size="small"
+                  value={field.displayName}
+                  maxLength={200}
+                  onChange={(event) => updateField(field.physicalName, { displayName: event.target.value })}
+                />
+                <Select
+                  size="small"
+                  value={field.defaultRole}
+                  options={[
+                    { label: '维度', value: 'DIMENSION' },
+                    { label: '指标', value: 'MEASURE' },
+                  ]}
+                  onChange={(value) => updateField(field.physicalName, { defaultRole: value })}
+                />
+              </div>
+            )) : (
+              <div className="px-4 py-8 text-center text-[11px] text-[#98a2b3]">暂无可发布字段</div>
+            )}
+          </div>
+        </div>
+
         <div className="flex gap-2 bg-[#f8f9fb] px-3 py-2.5 text-[11px] leading-5 text-[#667085]">
           <Info size={14} className="mt-0.5 shrink-0" />
           <div>
-            发布时会基于 SQL 当前线上不可变版本自动发现结果字段；数值字段默认识别为指标，其他字段默认识别为维度。后续 SQL 发布新版本时，只会追加新的 DatasetVersion，不会创建新的 Dataset。
+            数值字段默认识别为指标，其他字段默认识别为维度。后续 SQL 发布新版本时，只追加 DatasetVersion；同名物理字段会保持稳定 fieldId，避免已有 Analysis 因版本升级失去字段绑定。
           </div>
         </div>
 

--- a/yak-ops-ui/src/pages/data-development/components/workbench/PublishDatasetModal.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/workbench/PublishDatasetModal.tsx
@@ -1,0 +1,171 @@
+import { Input, Modal } from 'antd';
+import { Database, GitBranch, Info, Layers3 } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+
+import type {
+  DevelopmentReleaseDatasetState,
+} from '../../dataset-service';
+import type { DevelopmentReleaseSummary } from '../../types';
+
+interface PublishDatasetModalProps {
+  open: boolean;
+  nodeName: string;
+  release?: DevelopmentReleaseSummary;
+  datasetState?: DevelopmentReleaseDatasetState;
+  publishing: boolean;
+  onCancel: () => void;
+  onPublish: (payload: { name?: string; description?: string }) => void;
+}
+
+const stripSqlSuffix = (value: string) => value.replace(/\.sql$/i, '');
+
+const PublishDatasetModal = ({
+  open,
+  nodeName,
+  release,
+  datasetState,
+  publishing,
+  onCancel,
+  onPublish,
+}: PublishDatasetModalProps) => {
+  const detail = datasetState?.detail || undefined;
+  const currentVersion = detail?.currentVersion || undefined;
+  const alreadyPublished = Boolean(datasetState?.published && detail);
+  const needsUpdate = Boolean(
+    release && (!currentVersion || currentVersion.sourceTaskRevisionNo !== release.currentRevisionNo),
+  );
+  const [name, setName] = useState(stripSqlSuffix(nodeName));
+  const [description, setDescription] = useState('');
+
+  useEffect(() => {
+    if (!open) return;
+    setName(detail?.dataset.name || stripSqlSuffix(nodeName));
+    setDescription(detail?.dataset.description || '');
+  }, [detail?.dataset.description, detail?.dataset.name, nodeName, open]);
+
+  const fieldSummary = useMemo(() => {
+    const fields = detail?.fields || [];
+    const dimensions = fields.filter((field) => field.defaultRole === 'DIMENSION').length;
+    const measures = fields.filter((field) => field.defaultRole === 'MEASURE').length;
+    return { total: fields.length, dimensions, measures };
+  }, [detail?.fields]);
+
+  const nextVersionNo = (currentVersion?.versionNo || 0) + 1;
+  const confirmText = !alreadyPublished
+    ? '发布数据集'
+    : needsUpdate
+      ? `更新至 DV${nextVersionNo}`
+      : '已是最新版本';
+
+  return (
+    <Modal
+      open={open}
+      width={560}
+      centered
+      destroyOnHidden
+      title={alreadyPublished ? '更新 Dataset' : '发布为 Dataset'}
+      okText={confirmText}
+      cancelText="取消"
+      confirmLoading={publishing}
+      okButtonProps={{
+        disabled: !release || !needsUpdate || (!alreadyPublished && !name.trim()),
+      }}
+      onCancel={onCancel}
+      onOk={() => onPublish({
+        name: alreadyPublished ? undefined : name.trim(),
+        description: alreadyPublished ? undefined : description.trim() || undefined,
+      })}
+    >
+      <div className="space-y-4 py-2">
+        <div className="grid grid-cols-2 gap-2">
+          <div className="border border-[#e5e7eb] bg-[#fafbfc] px-3 py-2.5">
+            <div className="flex items-center gap-1.5 text-[11px] text-[#98a2b3]">
+              <GitBranch size={13} /> SQL 发布版本
+            </div>
+            <div className="mt-1 text-[13px] font-medium text-[#344054]">
+              {release ? `v${release.currentRevisionNo}` : '尚未发布'}
+            </div>
+          </div>
+          <div className="border border-[#e5e7eb] bg-[#fafbfc] px-3 py-2.5">
+            <div className="flex items-center gap-1.5 text-[11px] text-[#98a2b3]">
+              <Layers3 size={13} /> Dataset 版本
+            </div>
+            <div className="mt-1 text-[13px] font-medium text-[#344054]">
+              {currentVersion ? `DV${currentVersion.versionNo}` : '未发布'}
+            </div>
+          </div>
+        </div>
+
+        {!alreadyPublished ? (
+          <>
+            <div>
+              <div className="mb-1.5 text-[12px] font-medium text-[#344054]">数据集名称</div>
+              <Input
+                value={name}
+                maxLength={200}
+                placeholder="请输入数据集名称"
+                onChange={(event) => setName(event.target.value)}
+              />
+            </div>
+            <div>
+              <div className="mb-1.5 text-[12px] font-medium text-[#344054]">描述</div>
+              <Input.TextArea
+                value={description}
+                maxLength={2000}
+                autoSize={{ minRows: 3, maxRows: 5 }}
+                placeholder="说明这个 Dataset 的业务口径和使用场景（可选）"
+                onChange={(event) => setDescription(event.target.value)}
+              />
+            </div>
+          </>
+        ) : (
+          <div className="border border-[#e5e7eb] px-3 py-3">
+            <div className="flex items-center gap-2">
+              <Database size={15} className="text-[#667085]" />
+              <div className="min-w-0 flex-1">
+                <div className="truncate text-[13px] font-medium text-[#344054]">{detail?.dataset.name}</div>
+                <div className="mt-0.5 text-[11px] text-[#98a2b3]">
+                  Dataset #{detail?.dataset.id} · {detail?.dataset.status === 'OFFLINE' ? '已下线' : '已上线'}
+                </div>
+              </div>
+            </div>
+            <div className="mt-3 grid grid-cols-3 gap-2 text-center">
+              <div className="bg-[#f8f9fb] px-2 py-2">
+                <div className="text-[13px] font-medium text-[#344054]">{fieldSummary.total}</div>
+                <div className="text-[10px] text-[#98a2b3]">当前字段</div>
+              </div>
+              <div className="bg-[#f8f9fb] px-2 py-2">
+                <div className="text-[13px] font-medium text-[#344054]">{fieldSummary.dimensions}</div>
+                <div className="text-[10px] text-[#98a2b3]">维度</div>
+              </div>
+              <div className="bg-[#f8f9fb] px-2 py-2">
+                <div className="text-[13px] font-medium text-[#344054]">{fieldSummary.measures}</div>
+                <div className="text-[10px] text-[#98a2b3]">指标</div>
+              </div>
+            </div>
+          </div>
+        )}
+
+        <div className="flex gap-2 bg-[#f8f9fb] px-3 py-2.5 text-[11px] leading-5 text-[#667085]">
+          <Info size={14} className="mt-0.5 shrink-0" />
+          <div>
+            发布时会基于 SQL 当前线上不可变版本自动发现结果字段；数值字段默认识别为指标，其他字段默认识别为维度。后续 SQL 发布新版本时，只会追加新的 DatasetVersion，不会创建新的 Dataset。
+          </div>
+        </div>
+
+        {alreadyPublished && !needsUpdate ? (
+          <div className="text-[11px] text-[#667085]">
+            当前 Dataset 已经同步到 SQL v{release?.currentRevisionNo}，无需重复发布。
+          </div>
+        ) : null}
+        {detail?.dataset.status === 'OFFLINE' && needsUpdate ? (
+          <div className="text-[11px] text-[#b54708]">
+            当前 Dataset 已下线。更新版本不会自动重新上线，仍需在 Dataset 生命周期中显式上线。
+          </div>
+        ) : null}
+      </div>
+    </Modal>
+  );
+};
+
+export default PublishDatasetModal;

--- a/yak-ops-ui/src/pages/data-development/dataset-service.ts
+++ b/yak-ops-ui/src/pages/data-development/dataset-service.ts
@@ -54,6 +54,16 @@ export interface DevelopmentDatasetField {
   sortOrder: number;
 }
 
+export interface DevelopmentDatasetFieldDraft {
+  fieldId?: string | null;
+  physicalName: string;
+  displayName: string;
+  dataType: DevelopmentDatasetFieldType;
+  nullable: boolean;
+  description?: string | null;
+  defaultRole: DevelopmentDatasetFieldRole;
+}
+
 export interface DevelopmentDatasetDetail {
   dataset: DevelopmentDatasetSummary;
   currentVersion?: DevelopmentDatasetVersion | null;
@@ -71,6 +81,12 @@ export interface DevelopmentDatasetContext {
   datasetState?: DevelopmentReleaseDatasetState;
 }
 
+export interface PublishDevelopmentDatasetPayload {
+  name?: string;
+  description?: string;
+  fields?: DevelopmentDatasetFieldDraft[];
+}
+
 const unwrap = <T,>(response: ApiResponse<T>, fallback: string): T => {
   if (response?.code !== API_SUCCESS_CODE || response.data === undefined) {
     throw new Error(response?.message || response?.msg || fallback);
@@ -85,9 +101,16 @@ export const getDevelopmentReleaseDataset = async (
   '查询 Dataset 状态失败',
 );
 
+export const previewDevelopmentReleaseDataset = async (
+  assetId: DevelopmentId,
+): Promise<DevelopmentDatasetFieldDraft[]> => unwrap(
+  await HttpUtils.post<DevelopmentDatasetFieldDraft[]>(`${RELEASE_API}/${assetId}/dataset/preview`, {}),
+  '发现 Dataset 字段失败',
+);
+
 export const publishDevelopmentReleaseDataset = async (
   assetId: DevelopmentId,
-  payload: { name?: string; description?: string },
+  payload: PublishDevelopmentDatasetPayload,
 ): Promise<DevelopmentDatasetDetail> => unwrap(
   await HttpUtils.post<DevelopmentDatasetDetail>(`${RELEASE_API}/${assetId}/dataset`, payload),
   '发布 Dataset 失败',

--- a/yak-ops-ui/src/pages/data-development/dataset-service.ts
+++ b/yak-ops-ui/src/pages/data-development/dataset-service.ts
@@ -1,0 +1,115 @@
+import type { ApiResponse } from '@/services/http/response';
+import { API_SUCCESS_CODE } from '@/services/http/response';
+import HttpUtils from '@/utils/HttpUtils';
+
+import { listDevelopmentReleases } from './service';
+import type {
+  DevelopmentId,
+  DevelopmentReleaseSummary,
+} from './types';
+
+const RELEASE_API = '/api/v1/data-development/releases';
+
+export type DevelopmentDatasetStatus = 'ONLINE' | 'OFFLINE';
+export type DevelopmentDatasetFieldRole = 'DIMENSION' | 'MEASURE';
+export type DevelopmentDatasetFieldType =
+  | 'STRING'
+  | 'NUMBER'
+  | 'DATE'
+  | 'DATETIME'
+  | 'BOOLEAN'
+  | 'UNKNOWN';
+
+export interface DevelopmentDatasetSummary {
+  id: string;
+  name: string;
+  description?: string | null;
+  status: DevelopmentDatasetStatus;
+  currentVersionId?: string | null;
+  createTime?: string;
+  updateTime?: string;
+}
+
+export interface DevelopmentDatasetVersion {
+  id: string;
+  datasetId: string;
+  versionNo: number;
+  sourceType: 'QUERY_REVISION' | 'TABLE' | 'VIEW';
+  sourceTaskAssetId: string;
+  sourceTaskRevisionId: string;
+  sourceTaskRevisionNo: number;
+  schemaSnapshot?: string | null;
+  createTime?: string;
+}
+
+export interface DevelopmentDatasetField {
+  fieldId: string;
+  versionId: string;
+  physicalName: string;
+  displayName: string;
+  dataType: DevelopmentDatasetFieldType;
+  nullable: boolean;
+  description?: string | null;
+  defaultRole: DevelopmentDatasetFieldRole;
+  sortOrder: number;
+}
+
+export interface DevelopmentDatasetDetail {
+  dataset: DevelopmentDatasetSummary;
+  currentVersion?: DevelopmentDatasetVersion | null;
+  versions: DevelopmentDatasetVersion[];
+  fields: DevelopmentDatasetField[];
+}
+
+export interface DevelopmentReleaseDatasetState {
+  published: boolean;
+  detail?: DevelopmentDatasetDetail | null;
+}
+
+export interface DevelopmentDatasetContext {
+  release?: DevelopmentReleaseSummary;
+  datasetState?: DevelopmentReleaseDatasetState;
+}
+
+const unwrap = <T,>(response: ApiResponse<T>, fallback: string): T => {
+  if (response?.code !== API_SUCCESS_CODE || response.data === undefined) {
+    throw new Error(response?.message || response?.msg || fallback);
+  }
+  return response.data;
+};
+
+export const getDevelopmentReleaseDataset = async (
+  assetId: DevelopmentId,
+): Promise<DevelopmentReleaseDatasetState> => unwrap(
+  await HttpUtils.get<DevelopmentReleaseDatasetState>(`${RELEASE_API}/${assetId}/dataset`),
+  '查询 Dataset 状态失败',
+);
+
+export const publishDevelopmentReleaseDataset = async (
+  assetId: DevelopmentId,
+  payload: { name?: string; description?: string },
+): Promise<DevelopmentDatasetDetail> => unwrap(
+  await HttpUtils.post<DevelopmentDatasetDetail>(`${RELEASE_API}/${assetId}/dataset`, payload),
+  '发布 Dataset 失败',
+);
+
+export const fetchDevelopmentDatasetContext = async (
+  nodeId: DevelopmentId,
+  nodeName: string,
+): Promise<DevelopmentDatasetContext> => {
+  const page = unwrap(
+    await listDevelopmentReleases({
+      pageNo: 1,
+      pageSize: 100,
+      keyword: nodeName,
+      taskType: 'SQL',
+    }),
+    '查询 SQL 发布状态失败',
+  );
+  const release = page.records.find((item) => item.nodeId === nodeId);
+  if (!release) return {};
+  return {
+    release,
+    datasetState: await getDevelopmentReleaseDataset(release.assetId),
+  };
+};

--- a/yak-ops-ui/src/pages/data-development/editors/sql/SqlToolbar.tsx
+++ b/yak-ops-ui/src/pages/data-development/editors/sql/SqlToolbar.tsx
@@ -1,5 +1,6 @@
 import { Tooltip, message } from 'antd';
 import {
+  Database,
   LoaderCircle,
   Play,
   Redo2,
@@ -45,11 +46,29 @@ const ToolbarButton = ({ title, onClick, disabled, children }: ToolbarButtonProp
 
 const ToolbarDivider = () => <span className="mx-1 h-4 w-px shrink-0 bg-[#e5e7eb]" />;
 
+const datasetTooltip = (
+  state: DevelopmentEditorToolbarContext['datasetState'],
+  loading?: boolean,
+) => {
+  if (loading) return '正在读取 Dataset 状态';
+  if (!state) return '请先发布 SQL 版本，再发布为 Dataset';
+  if (!state.datasetId || !state.datasetVersionNo) return `发布 SQL v${state.releaseRevisionNo} 为 Dataset`;
+  if (state.datasetSourceRevisionNo !== state.releaseRevisionNo) {
+    return `更新 Dataset · DV${state.datasetVersionNo} → SQL v${state.releaseRevisionNo}`;
+  }
+  const status = state.datasetStatus === 'OFFLINE' ? ' · 已下线' : '';
+  return `Dataset DV${state.datasetVersionNo} 已同步 SQL v${state.releaseRevisionNo}${status}`;
+};
+
 const SqlToolbar = ({
   node,
   onRun,
   onSave,
   onPublish,
+  onPublishDataset,
+  datasetState,
+  datasetLoading,
+  datasetPublishing,
   running,
   saving,
   publishing,
@@ -59,6 +78,10 @@ const SqlToolbar = ({
       message.info(fallback);
     }
   };
+  const datasetNeedsUpdate = Boolean(
+    datasetState?.datasetId
+      && datasetState.datasetSourceRevisionNo !== datasetState.releaseRevisionNo,
+  );
 
   return (
     <div className="flex h-full w-full min-w-0 items-center justify-between gap-3">
@@ -73,6 +96,22 @@ const SqlToolbar = ({
         <ToolbarButton title="发布版本" disabled={saving || publishing || running} onClick={onPublish}>
           {publishing ? <LoaderCircle size={15} className="animate-spin" /> : <Rocket size={15} strokeWidth={1.8} />}
         </ToolbarButton>
+        <ToolbarButton
+          title={datasetTooltip(datasetState, datasetLoading)}
+          disabled={!onPublishDataset || !datasetState || datasetLoading || datasetPublishing || saving || publishing || running}
+          onClick={() => onPublishDataset?.()}
+        >
+          {datasetLoading || datasetPublishing ? (
+            <LoaderCircle size={15} className="animate-spin" />
+          ) : (
+            <Database
+              size={15}
+              strokeWidth={1.8}
+              className={datasetNeedsUpdate ? 'text-[var(--yak-brand-color)]' : undefined}
+            />
+          )}
+        </ToolbarButton>
+        <ToolbarDivider />
         <ToolbarButton title="撤销" disabled={running} onClick={() => execute('undo', 'SQL 编辑器尚未就绪')}>
           <Undo2 size={15} strokeWidth={1.8} />
         </ToolbarButton>

--- a/yak-ops-ui/src/pages/data-development/editors/sql/SqlToolbar.tsx
+++ b/yak-ops-ui/src/pages/data-development/editors/sql/SqlToolbar.tsx
@@ -88,6 +88,9 @@ const SqlToolbar = ({
   const datasetReleaseUnavailable = Boolean(
     datasetState && datasetState.releaseStatus !== 'ONLINE',
   );
+  const datasetStateLabel = datasetState?.datasetVersionNo
+    ? `DV${datasetState.datasetVersionNo}${datasetNeedsUpdate ? ' · 待更新' : datasetState.datasetStatus === 'OFFLINE' ? ' · 已下线' : ''}`
+    : undefined;
 
   return (
     <div className="flex h-full w-full min-w-0 items-center justify-between gap-3">
@@ -117,6 +120,20 @@ const SqlToolbar = ({
             />
           )}
         </ToolbarButton>
+        {datasetStateLabel ? (
+          <span
+            className={[
+              'mr-1 text-[10px] font-medium',
+              datasetNeedsUpdate
+                ? 'text-[var(--yak-brand-color)]'
+                : datasetState?.datasetStatus === 'OFFLINE'
+                  ? 'text-[#b54708]'
+                  : 'text-[#667085]',
+            ].join(' ')}
+          >
+            {datasetStateLabel}
+          </span>
+        ) : null}
         <ToolbarDivider />
         <ToolbarButton title="撤销" disabled={running} onClick={() => execute('undo', 'SQL 编辑器尚未就绪')}>
           <Undo2 size={15} strokeWidth={1.8} />

--- a/yak-ops-ui/src/pages/data-development/editors/sql/SqlToolbar.tsx
+++ b/yak-ops-ui/src/pages/data-development/editors/sql/SqlToolbar.tsx
@@ -52,6 +52,9 @@ const datasetTooltip = (
 ) => {
   if (loading) return '正在读取 Dataset 状态';
   if (!state) return '请先发布 SQL 版本，再发布为 Dataset';
+  if (state.releaseStatus !== 'ONLINE') {
+    return 'SQL 发布任务当前未上线，请先在发布中心上线后再发布 Dataset';
+  }
   if (!state.datasetId || !state.datasetVersionNo) return `发布 SQL v${state.releaseRevisionNo} 为 Dataset`;
   if (state.datasetSourceRevisionNo !== state.releaseRevisionNo) {
     return `更新 Dataset · DV${state.datasetVersionNo} → SQL v${state.releaseRevisionNo}`;
@@ -82,6 +85,9 @@ const SqlToolbar = ({
     datasetState?.datasetId
       && datasetState.datasetSourceRevisionNo !== datasetState.releaseRevisionNo,
   );
+  const datasetReleaseUnavailable = Boolean(
+    datasetState && datasetState.releaseStatus !== 'ONLINE',
+  );
 
   return (
     <div className="flex h-full w-full min-w-0 items-center justify-between gap-3">
@@ -98,7 +104,7 @@ const SqlToolbar = ({
         </ToolbarButton>
         <ToolbarButton
           title={datasetTooltip(datasetState, datasetLoading)}
-          disabled={!onPublishDataset || !datasetState || datasetLoading || datasetPublishing || saving || publishing || running}
+          disabled={!onPublishDataset || !datasetState || datasetReleaseUnavailable || datasetLoading || datasetPublishing || saving || publishing || running}
           onClick={() => onPublishDataset?.()}
         >
           {datasetLoading || datasetPublishing ? (

--- a/yak-ops-ui/src/pages/data-development/editors/types.ts
+++ b/yak-ops-ui/src/pages/data-development/editors/types.ts
@@ -16,6 +16,7 @@ export type DevelopmentEditorPanelKey =
 
 export interface DevelopmentDatasetToolbarState {
   releaseRevisionNo: number;
+  releaseStatus: 'ONLINE' | 'OFFLINE' | 'DISABLED';
   datasetId?: string;
   datasetVersionNo?: number;
   datasetSourceRevisionNo?: number;

--- a/yak-ops-ui/src/pages/data-development/editors/types.ts
+++ b/yak-ops-ui/src/pages/data-development/editors/types.ts
@@ -14,6 +14,14 @@ export type DevelopmentEditorPanelKey =
   | 'schedule-config'
   | 'versions';
 
+export interface DevelopmentDatasetToolbarState {
+  releaseRevisionNo: number;
+  datasetId?: string;
+  datasetVersionNo?: number;
+  datasetSourceRevisionNo?: number;
+  datasetStatus?: 'ONLINE' | 'OFFLINE';
+}
+
 export interface DevelopmentEditorContext {
   node: DevelopmentNode;
   directory?: DevelopmentDirectory;
@@ -26,6 +34,10 @@ export interface DevelopmentEditorToolbarContext
   onRun: () => void;
   onSave: () => void;
   onPublish: () => void;
+  onPublishDataset?: () => void;
+  datasetState?: DevelopmentDatasetToolbarState;
+  datasetLoading?: boolean;
+  datasetPublishing?: boolean;
   running: boolean;
   saving: boolean;
   publishing: boolean;


### PR DESCRIPTION
## What changed

Completes phase 1 of the Data Development → Dataset flow.

- adds a Dataset action next to SQL publish in the data-development toolbar
- shows the linked Dataset version/status directly in the SQL toolbar (`DVx`, pending update, offline)
- loads the SQL release state and its linked Dataset state
- adds a publish/update Dataset dialog with SQL revision and Dataset version context
- previews the current immutable SQL revision schema before publication
- auto-detects field types and defaults numeric fields to measures, other fields to dimensions
- allows users to adjust field display names and dimension/measure roles before publishing
- preserves stable field IDs for unchanged physical fields across DatasetVersion upgrades
- blocks Dataset publication when the SQL release is not ONLINE
- keeps Dataset identity stable: first publish creates the Dataset, later SQL revisions append DatasetVersion records
- makes repeated publication of an already-bound SQL revision idempotent after the Dataset exists
- exposes release-linked Dataset state through `GET /api/v1/data-development/releases/{assetId}/dataset`
- exposes schema preview through `POST /api/v1/data-development/releases/{assetId}/dataset/preview`
- adds focused DatasetService tests for idempotent re-publish and DatasetVersion advancement

## User flow

1. Develop and validate SQL.
2. Publish the SQL revision.
3. Use the Dataset action next to SQL publish.
4. Review the auto-discovered output fields and adjust display names / dimension-measure roles.
5. First publish creates a stable Dataset + DatasetVersion.
6. Publish a newer SQL revision; the toolbar marks the Dataset as pending update.
7. Reopen the dialog, review the new schema, and publish the next DatasetVersion on the same Dataset identity.

Dataset lifecycle status remains independent, so updating an OFFLINE Dataset does not implicitly bring it online.

## Why

Data Development already owns SQL authoring/versioning, while Dataset/Analysis/Dashboard are downstream BI domains. The missing piece was the explicit transition from an ONLINE immutable SQL TaskAsset revision into a stable, reviewable Dataset contract.

This PR keeps those boundaries intact: SQL remains executable development logic, Dataset becomes the stable BI consumption contract.

## Validation

- added DatasetService unit coverage for release publication idempotency and version advancement
- reviewed the complete branch diff against `main`; GitHub currently reports the PR as mergeable
- the repository currently reports no status checks or workflow runs for the PR head
- this execution environment does not provide a local authenticated checkout/Maven toolchain, so a full local build was not run here
