### PR TITLE
feat(data-analysis): complete Dataset to Analysis workflow

### DIFF
--- a/yak-ops-ui/src/pages/data-analysis/chart-analysis/index.tsx
+++ b/yak-ops-ui/src/pages/data-analysis/chart-analysis/index.tsx
@@ -10,6 +10,7 @@ import type {
   Aggregation,
   AnalysisAsset,
   ChartType,
+  DatasetField,
   FilterOperator,
   MetricBinding,
   PublishedDataset,
@@ -25,20 +26,33 @@ import {
   Select,
   Spin,
   Switch,
+  Tag,
+  Tooltip,
 } from 'antd';
 import {
+  ArrowLeft,
   BarChart3,
   ChartLine,
   ChartPie,
   FileBarChart,
+  GripVertical,
+  Layers3,
   Plus,
   RefreshCw,
   Save,
+  Search,
   Sigma,
   Table2,
   Trash2,
+  X,
 } from 'lucide-react';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  type DragEvent,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
 
 const CHART_OPTIONS: Array<{ label: string; value: ChartType }> = [
   { label: '指标卡', value: 'metric' },
@@ -67,6 +81,8 @@ const FILTER_OPTIONS: Array<{ label: string; value: FilterOperator }> = [
   { label: '小于等于', value: 'lte' },
 ];
 
+const FIELD_DRAG_TYPE = 'application/x-yak-analysis-field';
+
 const chartIcon = (type: ChartType) => {
   if (type === 'metric') return <Sigma size={14} />;
   if (type === 'line') return <ChartLine size={14} />;
@@ -88,7 +104,7 @@ const defaultDraft = (dataset?: PublishedDataset): AnalysisAsset => {
   const type: ChartType = dimension && metric ? 'bar' : metric ? 'metric' : 'table';
   return {
     id: '',
-    name: '未命名分析',
+    name: dataset ? `${dataset.name}分析` : '未命名分析',
     description: '',
     datasetId: dataset?.id ?? '',
     type,
@@ -104,6 +120,43 @@ const defaultDraft = (dataset?: PublishedDataset): AnalysisAsset => {
 const cloneAsset = (asset: AnalysisAsset): AnalysisAsset =>
   JSON.parse(JSON.stringify(asset)) as AnalysisAsset;
 
+const navigationContext = () => {
+  if (typeof window === 'undefined') return { datasetId: '', analysisId: '' };
+  const params = new URLSearchParams(window.location.search);
+  return {
+    datasetId: params.get('datasetId')?.trim() || '',
+    analysisId: params.get('analysisId')?.trim() || '',
+  };
+};
+
+const replaceLocation = (search: string) => {
+  if (typeof window === 'undefined') return;
+  window.history.replaceState(
+    window.history.state,
+    '',
+    `/data-analysis/chart-analysis${search ? `?${search}` : ''}`,
+  );
+};
+
+const dimensionLimit = (type: ChartType) => {
+  if (type === 'metric') return 0;
+  if (type === 'table') return 3;
+  return 1;
+};
+
+const metricLimit = (type: ChartType) => (
+  type === 'metric' || type === 'pie' ? 1 : 3
+);
+
+const fieldTypeLabel = (field: DatasetField) => {
+  if (field.dataType === 'datetime') return '时间';
+  if (field.dataType === 'date') return '日期';
+  if (field.dataType === 'number') return '数值';
+  if (field.dataType === 'boolean') return '布尔';
+  if (field.dataType === 'string') return '文本';
+  return '未知';
+};
+
 export default function ChartAnalysisPage() {
   const [datasets, setDatasets] = useState<PublishedDataset[]>([]);
   const [analyses, setAnalyses] = useState<AnalysisAsset[]>([]);
@@ -111,6 +164,8 @@ export default function ChartAnalysisPage() {
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [loadError, setLoadError] = useState('');
+  const [fieldKeyword, setFieldKeyword] = useState('');
+  const [catalogContextDatasetId, setCatalogContextDatasetId] = useState('');
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -120,14 +175,37 @@ export default function ChartAnalysisPage() {
         fetchAnalysisDatasets(),
         fetchAnalyses(),
       ]);
+      const navigation = navigationContext();
+      const requestedDataset = navigation.datasetId
+        ? datasetValues.find((item) => item.id === navigation.datasetId)
+        : undefined;
+      const requestedAnalysis = navigation.analysisId
+        ? analysisValues.find((item) => item.id === navigation.analysisId)
+        : undefined;
+
       setDatasets(datasetValues);
       setAnalyses(analysisValues);
+
+      if (navigation.datasetId) {
+        setCatalogContextDatasetId(navigation.datasetId);
+        if (!requestedDataset) {
+          setLoadError(`Dataset #${navigation.datasetId} 当前不可用于分析，请确认它已上线且存在当前版本。`);
+        }
+      }
+      if (navigation.analysisId && !requestedAnalysis) {
+        setLoadError(`Analysis #${navigation.analysisId} 不存在或已被删除。`);
+      }
+
       setDraft((current) => {
+        if (requestedDataset) return defaultDraft(requestedDataset);
+        if (requestedAnalysis) return cloneAsset(requestedAnalysis);
         if (current.id) {
           const refreshed = analysisValues.find((item) => item.id === current.id);
           if (refreshed) return cloneAsset(refreshed);
         }
-        return analysisValues[0] ? cloneAsset(analysisValues[0]) : defaultDraft(datasetValues[0]);
+        return analysisValues[0]
+          ? cloneAsset(analysisValues[0])
+          : defaultDraft(datasetValues[0]);
       });
     } catch (error) {
       setLoadError(error instanceof Error ? error.message : '加载图表分析失败');
@@ -155,10 +233,29 @@ export default function ChartAnalysisPage() {
   const sortOptions = fieldOptions.filter((option) => selectedFields.has(option.value));
   const filter = draft.filters[0];
   const datasetMap = useMemo(() => new Map(datasets.map((item) => [item.id, item])), [datasets]);
+  const normalizedFieldKeyword = fieldKeyword.trim().toLowerCase();
+  const visibleFields = useMemo(() => (
+    dataset?.fields.filter((field) => {
+      if (!normalizedFieldKeyword) return true;
+      return [field.label, field.physicalName, field.description || '', fieldTypeLabel(field)]
+        .some((value) => value.toLowerCase().includes(normalizedFieldKeyword));
+    }) ?? []
+  ), [dataset, normalizedFieldKeyword]);
+  const visibleDimensions = visibleFields.filter((field) => field.role === 'dimension');
+  const visibleMetrics = visibleFields.filter((field) => field.role === 'metric');
 
-  const selectAnalysis = (analysis: AnalysisAsset) => setDraft(cloneAsset(analysis));
+  const selectAnalysis = (analysis: AnalysisAsset) => {
+    setCatalogContextDatasetId('');
+    setDraft(cloneAsset(analysis));
+    replaceLocation(`analysisId=${encodeURIComponent(analysis.id)}`);
+  };
 
-  const createNew = () => setDraft(defaultDraft(datasets[0]));
+  const createNew = () => {
+    const source = dataset ?? datasets[0];
+    setCatalogContextDatasetId('');
+    setDraft(defaultDraft(source));
+    replaceLocation(source ? `datasetId=${encodeURIComponent(source.id)}` : '');
+  };
 
   const changeDataset = (datasetId: string) => {
     const nextDataset = datasets.find((item) => item.id === datasetId);
@@ -174,6 +271,7 @@ export default function ChartAnalysisPage() {
       sort: undefined,
       style: next.style,
     }));
+    if (!draft.id) replaceLocation(`datasetId=${encodeURIComponent(datasetId)}`);
   };
 
   const changeType = (type: ChartType) => {
@@ -181,25 +279,32 @@ export default function ChartAnalysisPage() {
     const firstMetric = draft.metrics[0] ?? (metricOptions[0]
       ? { field: metricOptions[0].value, aggregation: 'SUM' as Aggregation }
       : undefined);
+    const maxDimensions = dimensionLimit(type);
+    const maxMetrics = metricLimit(type);
     setDraft((current) => ({
       ...current,
       type,
-      dimensions: type === 'metric' ? [] : firstDimension ? [firstDimension] : [],
-      metrics: type === 'pie' || type === 'metric'
-        ? firstMetric ? [firstMetric] : []
-        : current.metrics.length ? current.metrics : firstMetric ? [firstMetric] : [],
+      dimensions: maxDimensions === 0
+        ? []
+        : (current.dimensions.length ? current.dimensions : firstDimension ? [firstDimension] : [])
+          .slice(0, maxDimensions),
+      metrics: (current.metrics.length ? current.metrics : firstMetric ? [firstMetric] : [])
+        .slice(0, maxMetrics),
       sort: undefined,
-      style: { ...defaultStyle(type), ...current.style, smooth: type === 'line' ? current.style.smooth : false },
+      style: {
+        ...defaultStyle(type),
+        ...current.style,
+        smooth: type === 'line' ? current.style.smooth : false,
+      },
       limit: type === 'table' ? 200 : 500,
     }));
   };
 
   const updateMetricFields = (fields: string[]) => {
     const previous = new Map(draft.metrics.map((metric) => [metric.field, metric]));
-    const limit = draft.type === 'pie' || draft.type === 'metric' ? 1 : 3;
-    const metrics: MetricBinding[] = fields.slice(0, limit).map((field) => (
-      previous.get(field) ?? { field, aggregation: 'SUM' }
-    ));
+    const metrics: MetricBinding[] = fields
+      .slice(0, metricLimit(draft.type))
+      .map((field) => previous.get(field) ?? { field, aggregation: 'SUM' });
     const sort = draft.sort && !draft.dimensions.includes(draft.sort.field)
       && !metrics.some((metric) => metric.field === draft.sort?.field)
       ? undefined
@@ -208,13 +313,52 @@ export default function ChartAnalysisPage() {
   };
 
   const updateDimensions = (dimensions: string[]) => {
-    const limit = draft.type === 'pie' ? 1 : draft.type === 'table' ? 3 : 1;
-    const next = dimensions.slice(0, limit);
+    const next = dimensions.slice(0, dimensionLimit(draft.type));
     const sort = draft.sort && !next.includes(draft.sort.field)
       && !draft.metrics.some((metric) => metric.field === draft.sort?.field)
       ? undefined
       : draft.sort;
     setDraft((current) => ({ ...current, dimensions: next, sort }));
+  };
+
+  const addDimension = (fieldId: string) => {
+    const field = dataset?.fields.find((item) => item.key === fieldId);
+    if (!field || field.role !== 'dimension') return;
+    const limit = dimensionLimit(draft.type);
+    if (!limit) return void message.info('指标卡不使用维度');
+    if (draft.dimensions.includes(fieldId)) return;
+    if (draft.dimensions.length >= limit) {
+      return void message.info(`当前图表最多使用 ${limit} 个维度`);
+    }
+    updateDimensions([...draft.dimensions, fieldId]);
+  };
+
+  const addMetric = (fieldId: string) => {
+    const field = dataset?.fields.find((item) => item.key === fieldId);
+    if (!field || field.role !== 'metric') return;
+    if (draft.metrics.some((item) => item.field === fieldId)) return;
+    const limit = metricLimit(draft.type);
+    if (draft.metrics.length >= limit) {
+      return void message.info(`当前图表最多使用 ${limit} 个指标`);
+    }
+    updateMetricFields([...draft.metrics.map((item) => item.field), fieldId]);
+  };
+
+  const addField = (field: DatasetField) => {
+    if (field.role === 'metric') addMetric(field.key);
+    else addDimension(field.key);
+  };
+
+  const beginFieldDrag = (event: DragEvent<HTMLButtonElement>, field: DatasetField) => {
+    event.dataTransfer.effectAllowed = 'copy';
+    event.dataTransfer.setData(FIELD_DRAG_TYPE, field.key);
+    event.dataTransfer.setData('text/plain', field.key);
+  };
+
+  const droppedFieldId = (event: DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    return event.dataTransfer.getData(FIELD_DRAG_TYPE)
+      || event.dataTransfer.getData('text/plain');
   };
 
   const save = async () => {
@@ -233,6 +377,7 @@ export default function ChartAnalysisPage() {
           : [saved, ...current];
         return [...next].sort((left, right) => (right.updatedAt || '').localeCompare(left.updatedAt || ''));
       });
+      replaceLocation(`analysisId=${encodeURIComponent(saved.id)}`);
       message.success(draft.id ? 'Analysis 已更新' : 'Analysis 已创建');
     } catch (error) {
       message.error(error instanceof Error ? error.message : '保存 Analysis 失败');
@@ -247,41 +392,91 @@ export default function ChartAnalysisPage() {
       await deleteAnalysis(draft.id);
       const next = analyses.filter((item) => item.id !== draft.id);
       setAnalyses(next);
-      setDraft(next[0] ? cloneAsset(next[0]) : defaultDraft(datasets[0]));
+      const nextDraft = next[0] ? cloneAsset(next[0]) : defaultDraft(datasets[0]);
+      setDraft(nextDraft);
+      setCatalogContextDatasetId('');
+      replaceLocation(nextDraft.id
+        ? `analysisId=${encodeURIComponent(nextDraft.id)}`
+        : nextDraft.datasetId
+          ? `datasetId=${encodeURIComponent(nextDraft.datasetId)}`
+          : '');
       message.success('Analysis 已删除');
     } catch (error) {
       message.error(error instanceof Error ? error.message : '删除 Analysis 失败');
     }
   };
 
+  const catalogDataset = datasets.find((item) => item.id === catalogContextDatasetId);
+
   return (
-    <div className="flex h-[calc(100vh-48px)] min-h-[660px] flex-col overflow-hidden bg-[#f4f6f8]" style={BRAND_CSS_VARIABLES}>
+    <div
+      className="flex h-[calc(100vh-48px)] min-h-[660px] flex-col overflow-hidden bg-[#f4f6f8]"
+      style={BRAND_CSS_VARIABLES}
+    >
       <header className="flex h-12 shrink-0 items-center gap-3 border-b border-[#e5e7eb] bg-white px-4">
+        {catalogContextDatasetId ? (
+          <Button
+            size="small"
+            type="text"
+            icon={<ArrowLeft size={13} />}
+            href="/data-analysis/data-catalog"
+          >
+            数据目录
+          </Button>
+        ) : null}
         <div className="flex min-w-0 flex-1 items-center gap-2">
           <FileBarChart size={16} className="text-[#475467]" />
           <div className="min-w-0">
-            <div className="text-[13px] font-semibold text-[#161823]">图表分析</div>
-            <div className="text-[10px] text-[#98a2b3]">独立可复用 Analysis 资产 · Dashboard 通过 analysisId 引用</div>
+            <div className="flex items-center gap-2 text-[13px] font-semibold text-[#161823]">
+              图表分析
+              {catalogDataset ? (
+                <Tag bordered={false} className="m-0 bg-[#f3f4f6] text-[10px] font-normal text-[#667085]">
+                  来自 {catalogDataset.name}
+                </Tag>
+              ) : null}
+            </div>
+            <div className="text-[10px] text-[#98a2b3]">
+              Dataset → Analysis · 保存后可被 Dashboard 通过 analysisId 复用
+            </div>
           </div>
         </div>
-        <Button size="small" icon={<RefreshCw size={12} />} onClick={() => void load()} loading={loading}>刷新</Button>
+        <Button
+          size="small"
+          icon={<RefreshCw size={12} />}
+          onClick={() => void load()}
+          loading={loading}
+        >
+          刷新
+        </Button>
         <Button size="small" icon={<Plus size={12} />} onClick={createNew}>新建</Button>
         {draft.id ? (
           <Popconfirm title="确认删除这个 Analysis？" onConfirm={() => void remove()}>
             <Button size="small" danger icon={<Trash2 size={12} />}>删除</Button>
           </Popconfirm>
         ) : null}
-        <Button type="primary" size="small" icon={<Save size={12} />} loading={saving} onClick={() => void save()}>保存</Button>
+        <Button
+          type="primary"
+          size="small"
+          icon={<Save size={12} />}
+          loading={saving}
+          onClick={() => void save()}
+        >
+          保存
+        </Button>
       </header>
 
       <div className="flex min-h-0 flex-1 overflow-hidden">
-        <aside className="flex w-[260px] shrink-0 flex-col border-r border-[#e5e7eb] bg-white">
+        <aside className="flex w-[224px] shrink-0 flex-col border-r border-[#e5e7eb] bg-white">
           <div className="border-b border-[#edf0f3] px-3 py-2 text-[11px] font-medium text-[#667085]">
             Analysis 资产 <span className="ml-1 text-[#98a2b3]">{analyses.length}</span>
           </div>
           <div className="min-h-0 flex-1 overflow-y-auto p-2">
-            {loading && !analyses.length ? <div className="flex justify-center py-8"><Spin size="small" /></div> : null}
-            {!loading && !analyses.length ? <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="暂无 Analysis" className="mt-8" /> : null}
+            {loading && !analyses.length ? (
+              <div className="flex justify-center py-8"><Spin size="small" /></div>
+            ) : null}
+            {!loading && !analyses.length ? (
+              <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="暂无 Analysis" className="mt-8" />
+            ) : null}
             {analyses.map((analysis) => {
               const active = draft.id === analysis.id;
               const source = datasetMap.get(analysis.datasetId);
@@ -298,7 +493,9 @@ export default function ChartAnalysisPage() {
                   <span className="mt-0.5 text-[#667085]">{chartIcon(analysis.type)}</span>
                   <span className="min-w-0 flex-1">
                     <span className="block truncate text-[11px] font-medium text-[#344054]">{analysis.name}</span>
-                    <span className="mt-0.5 block truncate text-[9px] text-[#98a2b3]">{source?.name ?? `Dataset #${analysis.datasetId}`}</span>
+                    <span className="mt-0.5 block truncate text-[9px] text-[#98a2b3]">
+                      {source?.name ?? `Dataset #${analysis.datasetId}`}
+                    </span>
                   </span>
                 </button>
               );
@@ -306,14 +503,131 @@ export default function ChartAnalysisPage() {
           </div>
         </aside>
 
+        <aside className="flex w-[220px] shrink-0 flex-col border-r border-[#e5e7eb] bg-[#fbfcfd]">
+          <div className="border-b border-[#edf0f3] p-2.5">
+            <div className="mb-1.5 flex items-center justify-between text-[10px] font-medium text-[#667085]">
+              <span>Dataset 字段</span>
+              {dataset ? <span className="text-[#98a2b3]">DV{dataset.currentVersionNo ?? '-'}</span> : null}
+            </div>
+            <Select
+              size="small"
+              className="w-full"
+              value={draft.datasetId || undefined}
+              placeholder="选择 ONLINE Dataset"
+              options={datasets.map((item) => ({ label: item.name, value: item.id }))}
+              onChange={changeDataset}
+            />
+            <Input
+              allowClear
+              size="small"
+              className="mt-2"
+              value={fieldKeyword}
+              prefix={<Search size={12} className="text-[#98a2b3]" />}
+              placeholder="搜索字段"
+              onChange={(event) => setFieldKeyword(event.target.value)}
+            />
+          </div>
+
+          <div className="min-h-0 flex-1 overflow-y-auto p-2">
+            {!dataset ? (
+              <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="请选择 Dataset" className="mt-8" />
+            ) : (
+              <>
+                <div className="mb-1 flex items-center justify-between px-1 text-[10px] font-medium text-[#667085]">
+                  <span>维度</span>
+                  <span className="text-[#98a2b3]">{visibleDimensions.length}</span>
+                </div>
+                {visibleDimensions.map((field) => (
+                  <Tooltip key={field.key} title={field.description || field.physicalName} placement="right">
+                    <button
+                      type="button"
+                      draggable
+                      onDragStart={(event) => beginFieldDrag(event, field)}
+                      onDoubleClick={() => addDimension(field.key)}
+                      className="group mb-0.5 flex h-8 w-full items-center gap-1.5 rounded-[4px] border-0 bg-transparent px-1.5 text-left hover:bg-white"
+                    >
+                      <GripVertical size={12} className="shrink-0 text-[#c0c4cc]" />
+                      <Layers3 size={12} className="shrink-0 text-[#667085]" />
+                      <span className="min-w-0 flex-1 truncate text-[11px] text-[#475467]">{field.label}</span>
+                      <span className="text-[9px] text-[#a0a4ac]">{fieldTypeLabel(field)}</span>
+                      <span
+                        role="button"
+                        tabIndex={0}
+                        className="hidden h-5 w-5 items-center justify-center text-[#667085] group-hover:flex"
+                        onClick={(event) => {
+                          event.stopPropagation();
+                          addDimension(field.key);
+                        }}
+                        onKeyDown={(event) => {
+                          if (event.key === 'Enter') addDimension(field.key);
+                        }}
+                      >
+                        <Plus size={12} />
+                      </span>
+                    </button>
+                  </Tooltip>
+                ))}
+
+                <div className="mb-1 mt-4 flex items-center justify-between px-1 text-[10px] font-medium text-[#667085]">
+                  <span>指标</span>
+                  <span className="text-[#98a2b3]">{visibleMetrics.length}</span>
+                </div>
+                {visibleMetrics.map((field) => (
+                  <Tooltip key={field.key} title={field.description || field.physicalName} placement="right">
+                    <button
+                      type="button"
+                      draggable
+                      onDragStart={(event) => beginFieldDrag(event, field)}
+                      onDoubleClick={() => addMetric(field.key)}
+                      className="group mb-0.5 flex h-8 w-full items-center gap-1.5 rounded-[4px] border-0 bg-transparent px-1.5 text-left hover:bg-white"
+                    >
+                      <GripVertical size={12} className="shrink-0 text-[#c0c4cc]" />
+                      <Sigma size={12} className="shrink-0 text-[#667085]" />
+                      <span className="min-w-0 flex-1 truncate text-[11px] text-[#475467]">{field.label}</span>
+                      <span className="text-[9px] text-[#a0a4ac]">{fieldTypeLabel(field)}</span>
+                      <span
+                        role="button"
+                        tabIndex={0}
+                        className="hidden h-5 w-5 items-center justify-center text-[#667085] group-hover:flex"
+                        onClick={(event) => {
+                          event.stopPropagation();
+                          addMetric(field.key);
+                        }}
+                        onKeyDown={(event) => {
+                          if (event.key === 'Enter') addMetric(field.key);
+                        }}
+                      >
+                        <Plus size={12} />
+                      </span>
+                    </button>
+                  </Tooltip>
+                ))}
+
+                {!visibleFields.length ? (
+                  <div className="py-8 text-center text-[10px] text-[#98a2b3]">没有匹配字段</div>
+                ) : null}
+                <div className="mt-4 border-t border-[#edf0f3] px-1 pt-3 text-[9px] leading-4 text-[#98a2b3]">
+                  拖拽字段到右侧维度 / 指标区域；双击字段也可以快速添加。
+                </div>
+              </>
+            )}
+          </div>
+        </aside>
+
         <main className="min-w-0 flex-1 overflow-auto p-4">
           {loadError ? (
-            <div className="mb-3 border border-[#fecdca] bg-[#fffbfa] px-3 py-2 text-[11px] text-[#b42318]">{loadError}</div>
+            <div className="mb-3 border border-[#fecdca] bg-[#fffbfa] px-3 py-2 text-[11px] text-[#b42318]">
+              {loadError}
+            </div>
           ) : null}
           <div className="mx-auto flex min-h-[520px] max-w-[1200px] flex-col border border-[#dfe3e8] bg-white">
             <div className="flex h-10 shrink-0 items-center border-b border-[#edf0f3] px-4">
-              <span className="min-w-0 flex-1 truncate text-[12px] font-medium text-[#344054]">{draft.name || '未命名分析'}</span>
-              <span className="text-[10px] text-[#98a2b3]">{dataset ? `${dataset.name} · DV${dataset.currentVersionNo ?? '-'}` : '未选择 Dataset'}</span>
+              <span className="min-w-0 flex-1 truncate text-[12px] font-medium text-[#344054]">
+                {draft.name || '未命名分析'}
+              </span>
+              <span className="text-[10px] text-[#98a2b3]">
+                {dataset ? `${dataset.name} · DV${dataset.currentVersionNo ?? '-'}` : '未选择 Dataset'}
+              </span>
             </div>
             <div className="min-h-[460px] flex-1 p-4">
               <AnalysisPreview spec={draft} dataset={dataset} className="h-full min-h-[420px]" />
@@ -321,66 +635,122 @@ export default function ChartAnalysisPage() {
           </div>
         </main>
 
-        <aside className="w-[336px] shrink-0 overflow-y-auto border-l border-[#e5e7eb] bg-white p-3">
+        <aside className="w-[320px] shrink-0 overflow-y-auto border-l border-[#e5e7eb] bg-white p-3">
           <div className="mb-2 text-[11px] font-medium text-[#667085]">基本信息</div>
-          <Input size="small" value={draft.name} placeholder="Analysis 名称" onChange={(event) => setDraft((current) => ({ ...current, name: event.target.value }))} />
-          <Input.TextArea className="mt-2" rows={2} value={draft.description} placeholder="描述（可选）" onChange={(event) => setDraft((current) => ({ ...current, description: event.target.value }))} />
+          <Input
+            size="small"
+            value={draft.name}
+            placeholder="Analysis 名称"
+            onChange={(event) => setDraft((current) => ({ ...current, name: event.target.value }))}
+          />
+          <Input.TextArea
+            className="mt-2"
+            rows={2}
+            value={draft.description}
+            placeholder="描述（可选）"
+            onChange={(event) => setDraft((current) => ({ ...current, description: event.target.value }))}
+          />
 
-          <div className="mb-2 mt-5 border-t border-[#edf0f3] pt-4 text-[11px] font-medium text-[#667085]">数据与图表</div>
+          <div className="mb-2 mt-5 border-t border-[#edf0f3] pt-4 text-[11px] font-medium text-[#667085]">
+            图表类型
+          </div>
           <Select
             size="small"
             className="w-full"
-            value={draft.datasetId || undefined}
-            placeholder="选择 ONLINE Dataset"
-            options={datasets.map((item) => ({ label: item.name, value: item.id }))}
-            onChange={changeDataset}
+            value={draft.type}
+            options={CHART_OPTIONS}
+            onChange={changeType}
           />
-          <Select size="small" className="mt-2 w-full" value={draft.type} options={CHART_OPTIONS} onChange={changeType} />
 
           {draft.type !== 'metric' ? (
             <>
-              <div className="mb-1 mt-4 text-[10px] text-[#667085]">维度</div>
-              <Select
-                mode="multiple"
-                size="small"
-                className="w-full"
-                value={draft.dimensions}
-                options={dimensionOptions}
-                onChange={updateDimensions}
-                maxTagCount="responsive"
-              />
+              <div className="mb-1 mt-4 flex items-center justify-between text-[10px] text-[#667085]">
+                <span>维度</span>
+                <span className="text-[#98a2b3]">{draft.dimensions.length}/{dimensionLimit(draft.type)}</span>
+              </div>
+              <div
+                onDragOver={(event) => {
+                  event.preventDefault();
+                  event.dataTransfer.dropEffect = 'copy';
+                }}
+                onDrop={(event) => addDimension(droppedFieldId(event))}
+                className="min-h-10 border border-dashed border-[#d9dde3] bg-[#fafbfc] p-1.5"
+              >
+                {draft.dimensions.length ? (
+                  <div className="space-y-1">
+                    {draft.dimensions.map((fieldId) => {
+                      const field = dataset?.fields.find((item) => item.key === fieldId);
+                      return (
+                        <div key={fieldId} className="flex h-7 items-center gap-1.5 bg-white px-2 text-[10px] text-[#475467] shadow-sm">
+                          <Layers3 size={11} className="text-[#667085]" />
+                          <span className="min-w-0 flex-1 truncate">{field?.label ?? fieldId}</span>
+                          <button
+                            type="button"
+                            className="border-0 bg-transparent p-0 text-[#98a2b3] hover:text-[#475467]"
+                            onClick={() => updateDimensions(draft.dimensions.filter((item) => item !== fieldId))}
+                          >
+                            <X size={11} />
+                          </button>
+                        </div>
+                      );
+                    })}
+                  </div>
+                ) : (
+                  <div className="flex h-7 items-center justify-center text-[10px] text-[#a0a4ac]">拖入维度字段</div>
+                )}
+              </div>
             </>
           ) : null}
 
-          <div className="mb-1 mt-4 text-[10px] text-[#667085]">指标</div>
-          <Select
-            mode="multiple"
-            size="small"
-            className="w-full"
-            value={draft.metrics.map((metric) => metric.field)}
-            options={metricOptions}
-            onChange={updateMetricFields}
-            maxTagCount="responsive"
-          />
-          <div className="mt-2 space-y-1.5">
-            {draft.metrics.map((metric) => (
-              <div key={metric.field} className="flex items-center gap-2 rounded-[4px] bg-[#f7f8fa] px-2 py-1">
-                <span className="min-w-0 flex-1 truncate text-[10px] text-[#475467]">
-                  {dataset?.fields.find((field) => field.key === metric.field)?.label ?? metric.field}
-                </span>
-                <Select
-                  size="small"
-                  variant="borderless"
-                  className="w-[88px]"
-                  value={metric.aggregation}
-                  options={AGGREGATION_OPTIONS}
-                  onChange={(aggregation: Aggregation) => setDraft((current) => ({
-                    ...current,
-                    metrics: current.metrics.map((item) => item.field === metric.field ? { ...item, aggregation } : item),
-                  }))}
-                />
+          <div className="mb-1 mt-4 flex items-center justify-between text-[10px] text-[#667085]">
+            <span>指标</span>
+            <span className="text-[#98a2b3]">{draft.metrics.length}/{metricLimit(draft.type)}</span>
+          </div>
+          <div
+            onDragOver={(event) => {
+              event.preventDefault();
+              event.dataTransfer.dropEffect = 'copy';
+            }}
+            onDrop={(event) => addMetric(droppedFieldId(event))}
+            className="min-h-10 border border-dashed border-[#d9dde3] bg-[#fafbfc] p-1.5"
+          >
+            {draft.metrics.length ? (
+              <div className="space-y-1">
+                {draft.metrics.map((metric) => {
+                  const field = dataset?.fields.find((item) => item.key === metric.field);
+                  return (
+                    <div key={metric.field} className="flex h-8 items-center gap-1.5 bg-white px-2 text-[10px] text-[#475467] shadow-sm">
+                      <Sigma size={11} className="text-[#667085]" />
+                      <span className="min-w-0 flex-1 truncate">{field?.label ?? metric.field}</span>
+                      <Select
+                        size="small"
+                        variant="borderless"
+                        className="w-[82px]"
+                        value={metric.aggregation}
+                        options={AGGREGATION_OPTIONS}
+                        onChange={(aggregation: Aggregation) => setDraft((current) => ({
+                          ...current,
+                          metrics: current.metrics.map((item) => (
+                            item.field === metric.field ? { ...item, aggregation } : item
+                          )),
+                        }))}
+                      />
+                      <button
+                        type="button"
+                        className="border-0 bg-transparent p-0 text-[#98a2b3] hover:text-[#475467]"
+                        onClick={() => updateMetricFields(
+                          draft.metrics.filter((item) => item.field !== metric.field).map((item) => item.field),
+                        )}
+                      >
+                        <X size={11} />
+                      </button>
+                    </div>
+                  );
+                })}
               </div>
-            ))}
+            ) : (
+              <div className="flex h-7 items-center justify-center text-[10px] text-[#a0a4ac]">拖入指标字段</div>
+            )}
           </div>
 
           <div className="mb-1 mt-4 text-[10px] text-[#667085]">排序</div>
@@ -402,7 +772,10 @@ export default function ChartAnalysisPage() {
               className="w-[78px]"
               disabled={!draft.sort}
               value={draft.sort?.direction ?? 'asc'}
-              options={[{ label: '升序', value: 'asc' }, { label: '降序', value: 'desc' }]}
+              options={[
+                { label: '升序', value: 'asc' },
+                { label: '降序', value: 'desc' },
+              ]}
               onChange={(direction: SortDirection) => setDraft((current) => ({
                 ...current,
                 sort: current.sort ? { ...current.sort, direction } : undefined,
@@ -447,16 +820,61 @@ export default function ChartAnalysisPage() {
             placeholder="过滤值"
             onChange={(event) => setDraft((current) => ({
               ...current,
-              filters: current.filters[0] ? [{ ...current.filters[0], value: event.target.value }] : [],
+              filters: current.filters[0]
+                ? [{ ...current.filters[0], value: event.target.value }]
+                : [],
             }))}
           />
 
-          <div className="mb-2 mt-5 border-t border-[#edf0f3] pt-4 text-[11px] font-medium text-[#667085]">样式</div>
+          <div className="mb-2 mt-5 border-t border-[#edf0f3] pt-4 text-[11px] font-medium text-[#667085]">
+            样式
+          </div>
           <div className="space-y-3 text-[11px] text-[#475467]">
-            <label className="flex items-center justify-between"><span>显示图例</span><Switch size="small" checked={draft.style.showLegend} onChange={(showLegend) => setDraft((current) => ({ ...current, style: { ...current.style, showLegend } }))} /></label>
-            <label className="flex items-center justify-between"><span>数据标签</span><Switch size="small" checked={draft.style.showDataLabels} onChange={(showDataLabels) => setDraft((current) => ({ ...current, style: { ...current.style, showDataLabels } }))} /></label>
-            <label className="flex items-center justify-between"><span>平滑折线</span><Switch size="small" disabled={draft.type !== 'line'} checked={draft.style.smooth} onChange={(smooth) => setDraft((current) => ({ ...current, style: { ...current.style, smooth } }))} /></label>
-            <label className="flex items-center justify-between"><span>网格线</span><Switch size="small" checked={draft.style.showGrid} onChange={(showGrid) => setDraft((current) => ({ ...current, style: { ...current.style, showGrid } }))} /></label>
+            <label className="flex items-center justify-between">
+              <span>显示图例</span>
+              <Switch
+                size="small"
+                checked={draft.style.showLegend}
+                onChange={(showLegend) => setDraft((current) => ({
+                  ...current,
+                  style: { ...current.style, showLegend },
+                }))}
+              />
+            </label>
+            <label className="flex items-center justify-between">
+              <span>数据标签</span>
+              <Switch
+                size="small"
+                checked={draft.style.showDataLabels}
+                onChange={(showDataLabels) => setDraft((current) => ({
+                  ...current,
+                  style: { ...current.style, showDataLabels },
+                }))}
+              />
+            </label>
+            <label className="flex items-center justify-between">
+              <span>平滑折线</span>
+              <Switch
+                size="small"
+                disabled={draft.type !== 'line'}
+                checked={draft.style.smooth}
+                onChange={(smooth) => setDraft((current) => ({
+                  ...current,
+                  style: { ...current.style, smooth },
+                }))}
+              />
+            </label>
+            <label className="flex items-center justify-between">
+              <span>网格线</span>
+              <Switch
+                size="small"
+                checked={draft.style.showGrid}
+                onChange={(showGrid) => setDraft((current) => ({
+                  ...current,
+                  style: { ...current.style, showGrid },
+                }))}
+              />
+            </label>
           </div>
         </aside>
       </div>

--- a/yak-ops-ui/src/pages/data-analysis/chart-analysis/index.tsx
+++ b/yak-ops-ui/src/pages/data-analysis/chart-analysis/index.tsx
@@ -121,11 +121,14 @@ const cloneAsset = (asset: AnalysisAsset): AnalysisAsset =>
   JSON.parse(JSON.stringify(asset)) as AnalysisAsset;
 
 const navigationContext = () => {
-  if (typeof window === 'undefined') return { datasetId: '', analysisId: '' };
+  if (typeof window === 'undefined') {
+    return { datasetId: '', analysisId: '', mode: '' };
+  }
   const params = new URLSearchParams(window.location.search);
   return {
     datasetId: params.get('datasetId')?.trim() || '',
     analysisId: params.get('analysisId')?.trim() || '',
+    mode: params.get('mode')?.trim() || '',
   };
 };
 
@@ -155,6 +158,26 @@ const fieldTypeLabel = (field: DatasetField) => {
   if (field.dataType === 'boolean') return '布尔';
   if (field.dataType === 'string') return '文本';
   return '未知';
+};
+
+const validateDraft = (draft: AnalysisAsset): string | undefined => {
+  if (draft.type === 'metric') {
+    return draft.metrics.length === 1 ? undefined : '指标卡需要且只能配置 1 个指标';
+  }
+  if (draft.type === 'pie') {
+    if (draft.dimensions.length !== 1) return '饼图需要且只能配置 1 个维度';
+    if (draft.metrics.length !== 1) return '饼图需要且只能配置 1 个指标';
+    return undefined;
+  }
+  if (draft.type === 'bar' || draft.type === 'line') {
+    if (!draft.dimensions.length) return '柱状图 / 折线图至少需要 1 个维度';
+    if (!draft.metrics.length) return '柱状图 / 折线图至少需要 1 个指标';
+    return undefined;
+  }
+  if (!draft.dimensions.length && !draft.metrics.length) {
+    return '表格至少需要 1 个维度或指标';
+  }
+  return undefined;
 };
 
 export default function ChartAnalysisPage() {
@@ -187,7 +210,7 @@ export default function ChartAnalysisPage() {
       setAnalyses(analysisValues);
 
       if (navigation.datasetId) {
-        setCatalogContextDatasetId(navigation.datasetId);
+        setCatalogContextDatasetId(navigation.mode === 'create' ? '' : navigation.datasetId);
         if (!requestedDataset) {
           setLoadError(`Dataset #${navigation.datasetId} 当前不可用于分析，请确认它已上线且存在当前版本。`);
         }
@@ -254,7 +277,9 @@ export default function ChartAnalysisPage() {
     const source = dataset ?? datasets[0];
     setCatalogContextDatasetId('');
     setDraft(defaultDraft(source));
-    replaceLocation(source ? `datasetId=${encodeURIComponent(source.id)}` : '');
+    replaceLocation(source
+      ? `mode=create&datasetId=${encodeURIComponent(source.id)}`
+      : 'mode=create');
   };
 
   const changeDataset = (datasetId: string) => {
@@ -271,7 +296,11 @@ export default function ChartAnalysisPage() {
       sort: undefined,
       style: next.style,
     }));
-    if (!draft.id) replaceLocation(`datasetId=${encodeURIComponent(datasetId)}`);
+    if (!draft.id) {
+      replaceLocation(catalogContextDatasetId
+        ? `datasetId=${encodeURIComponent(datasetId)}`
+        : `mode=create&datasetId=${encodeURIComponent(datasetId)}`);
+    }
   };
 
   const changeType = (type: ChartType) => {
@@ -344,11 +373,6 @@ export default function ChartAnalysisPage() {
     updateMetricFields([...draft.metrics.map((item) => item.field), fieldId]);
   };
 
-  const addField = (field: DatasetField) => {
-    if (field.role === 'metric') addMetric(field.key);
-    else addDimension(field.key);
-  };
-
   const beginFieldDrag = (event: DragEvent<HTMLButtonElement>, field: DatasetField) => {
     event.dataTransfer.effectAllowed = 'copy';
     event.dataTransfer.setData(FIELD_DRAG_TYPE, field.key);
@@ -364,6 +388,8 @@ export default function ChartAnalysisPage() {
   const save = async () => {
     if (!draft.name.trim()) return void message.warning('请填写 Analysis 名称');
     if (!draft.datasetId) return void message.warning('请选择 Dataset');
+    const validationMessage = validateDraft(draft);
+    if (validationMessage) return void message.warning(validationMessage);
     setSaving(true);
     try {
       const saved = draft.id
@@ -398,8 +424,8 @@ export default function ChartAnalysisPage() {
       replaceLocation(nextDraft.id
         ? `analysisId=${encodeURIComponent(nextDraft.id)}`
         : nextDraft.datasetId
-          ? `datasetId=${encodeURIComponent(nextDraft.datasetId)}`
-          : '');
+          ? `mode=create&datasetId=${encodeURIComponent(nextDraft.datasetId)}`
+          : 'mode=create');
       message.success('Analysis 已删除');
     } catch (error) {
       message.error(error instanceof Error ? error.message : '删除 Analysis 失败');
@@ -543,27 +569,14 @@ export default function ChartAnalysisPage() {
                       type="button"
                       draggable
                       onDragStart={(event) => beginFieldDrag(event, field)}
-                      onDoubleClick={() => addDimension(field.key)}
+                      onClick={() => addDimension(field.key)}
                       className="group mb-0.5 flex h-8 w-full items-center gap-1.5 rounded-[4px] border-0 bg-transparent px-1.5 text-left hover:bg-white"
                     >
                       <GripVertical size={12} className="shrink-0 text-[#c0c4cc]" />
                       <Layers3 size={12} className="shrink-0 text-[#667085]" />
                       <span className="min-w-0 flex-1 truncate text-[11px] text-[#475467]">{field.label}</span>
                       <span className="text-[9px] text-[#a0a4ac]">{fieldTypeLabel(field)}</span>
-                      <span
-                        role="button"
-                        tabIndex={0}
-                        className="hidden h-5 w-5 items-center justify-center text-[#667085] group-hover:flex"
-                        onClick={(event) => {
-                          event.stopPropagation();
-                          addDimension(field.key);
-                        }}
-                        onKeyDown={(event) => {
-                          if (event.key === 'Enter') addDimension(field.key);
-                        }}
-                      >
-                        <Plus size={12} />
-                      </span>
+                      <Plus size={11} className="shrink-0 text-[#a0a4ac] opacity-0 group-hover:opacity-100" />
                     </button>
                   </Tooltip>
                 ))}
@@ -578,27 +591,14 @@ export default function ChartAnalysisPage() {
                       type="button"
                       draggable
                       onDragStart={(event) => beginFieldDrag(event, field)}
-                      onDoubleClick={() => addMetric(field.key)}
+                      onClick={() => addMetric(field.key)}
                       className="group mb-0.5 flex h-8 w-full items-center gap-1.5 rounded-[4px] border-0 bg-transparent px-1.5 text-left hover:bg-white"
                     >
                       <GripVertical size={12} className="shrink-0 text-[#c0c4cc]" />
                       <Sigma size={12} className="shrink-0 text-[#667085]" />
                       <span className="min-w-0 flex-1 truncate text-[11px] text-[#475467]">{field.label}</span>
                       <span className="text-[9px] text-[#a0a4ac]">{fieldTypeLabel(field)}</span>
-                      <span
-                        role="button"
-                        tabIndex={0}
-                        className="hidden h-5 w-5 items-center justify-center text-[#667085] group-hover:flex"
-                        onClick={(event) => {
-                          event.stopPropagation();
-                          addMetric(field.key);
-                        }}
-                        onKeyDown={(event) => {
-                          if (event.key === 'Enter') addMetric(field.key);
-                        }}
-                      >
-                        <Plus size={12} />
-                      </span>
+                      <Plus size={11} className="shrink-0 text-[#a0a4ac] opacity-0 group-hover:opacity-100" />
                     </button>
                   </Tooltip>
                 ))}
@@ -607,7 +607,7 @@ export default function ChartAnalysisPage() {
                   <div className="py-8 text-center text-[10px] text-[#98a2b3]">没有匹配字段</div>
                 ) : null}
                 <div className="mt-4 border-t border-[#edf0f3] px-1 pt-3 text-[9px] leading-4 text-[#98a2b3]">
-                  拖拽字段到右侧维度 / 指标区域；双击字段也可以快速添加。
+                  拖拽字段到右侧维度 / 指标区域；点击字段也可以快速添加。
                 </div>
               </>
             )}


### PR DESCRIPTION
## What changed

Completes phase 3 of the BI flow by turning Chart Analysis into a Dataset-first analysis workspace.

- consumes the `datasetId` already passed from Data Catalog and opens a fresh Analysis draft for that exact Dataset
- keeps a visible return path and Dataset context when the user entered from Data Catalog
- adds `analysisId` URL state so saved Analysis assets can be directly selected/revisited
- changes the new-analysis default from a generic blank draft to a Dataset-aware draft with a sensible initial chart
- adds a dedicated Dataset field panel with field search, type hints, dimensions and measures
- supports native drag-and-drop from the field panel into dimension / measure shelves
- also supports one-click field addition for faster configuration
- replaces the old multi-select-only dimension/measure configuration with explicit BI-style shelves
- keeps per-metric aggregation editing directly on the measure shelf
- preserves existing chart switching, sort, filter, visual settings and live Dataset Query Runtime preview
- adds client-side validation before save so invalid chart bindings fail early with a clear message
- keeps Analysis persistence unchanged: saved assets still use the existing Analysis API and remain reusable by Dashboard through `analysisId`

## User flow

1. Open Data Analysis → Data Catalog.
2. Click `创建分析` on an ONLINE Dataset.
3. Chart Analysis opens directly on that Dataset and creates a fresh Dataset-aware draft.
4. Drag or click dimensions / measures into the analysis shelves.
5. Switch chart type, aggregation, sort, filters and visual options while the preview queries the real Dataset runtime.
6. Save the draft as a reusable Analysis asset.
7. Selecting saved Analysis assets updates the URL with `analysisId` so the editor state is addressable.

## Product boundary

This PR does not change the backend Analysis/Dataset contracts. The layering remains:

```text
Data Development
  -> Dataset / DatasetVersion / stable fieldId
  -> AnalysisSpec / AnalysisAsset
  -> Dashboard
```

The work is intentionally focused on the Analysis authoring experience and navigation contract rather than duplicating query or persistence logic in the frontend.

## Validation

- branch is based on the merged phase-2 `main` (`ahead=2`, `behind=0` at review time)
- diff is limited to the Chart Analysis page
- reviewed Dataset deep-link handling, saved Analysis URL state, drag/drop role guards, chart field limits and save-time chart requirements
- the execution environment has no local GitHub connectivity and no `gh` binary, so a local npm/TypeScript build could not be run; no build result is being claimed
