### PR TITLE
feat: redesign workflow definition page

### DIFF
--- a/yak-ops-ui/src/pages/workflow/management/index.tsx
+++ b/yak-ops-ui/src/pages/workflow/management/index.tsx
@@ -15,13 +15,14 @@ import { history } from '@umijs/max';
 import {
   Button,
   ConfigProvider,
-  Divider,
   Drawer,
+  Dropdown,
   Empty,
   Form,
   Input,
   Modal,
-  Table,
+  Pagination,
+  Spin,
   Tooltip,
   message,
 } from 'antd';
@@ -30,7 +31,9 @@ import {
   CirclePlay,
   CloudOff,
   CloudUpload,
+  Copy,
   GitBranch,
+  MoreHorizontal,
   Pencil,
   Trash2,
 } from 'lucide-react';
@@ -134,6 +137,90 @@ const runtimeStatusClassName = (status?: string) => {
   }
 };
 
+const WorkflowTopologyPreview = ({ definition }: { definition: WorkflowDefinition }) => {
+  const nodes = definition.nodes || [];
+  const edges = definition.edges || [];
+
+  if (!nodes.length) {
+    return (
+      <div className="flex h-full min-h-[112px] flex-col items-center justify-center gap-2 rounded-[10px] border border-dashed border-[#e4e7ec] bg-white text-[#98a2b3]">
+        <GitBranch size={24} strokeWidth={1.6} />
+        <span className="text-[11px]">尚未配置节点</span>
+      </div>
+    );
+  }
+
+  const minX = Math.min(...nodes.map((node) => node.positionX || 0));
+  const maxX = Math.max(...nodes.map((node) => node.positionX || 0));
+  const minY = Math.min(...nodes.map((node) => node.positionY || 0));
+  const maxY = Math.max(...nodes.map((node) => node.positionY || 0));
+  const spanX = Math.max(maxX - minX, 1);
+  const spanY = Math.max(maxY - minY, 1);
+  const positions = new Map(
+    nodes.map((node) => [
+      node.id,
+      {
+        x: 18 + ((node.positionX - minX) / spanX) * 132,
+        y: 18 + ((node.positionY - minY) / spanY) * 60,
+      },
+    ]),
+  );
+
+  return (
+    <div className="relative h-full min-h-[112px] overflow-hidden rounded-[10px] border border-[#eaecf0] bg-white">
+      <div className="absolute left-2.5 top-2 z-10 rounded bg-[#f5f5f6] px-1.5 py-0.5 text-[10px] font-medium text-[#667085]">
+        DAG
+      </div>
+      <svg
+        viewBox="0 0 168 96"
+        className="absolute inset-0 h-full w-full"
+        role="img"
+        aria-label={`${definition.name} 工作流拓扑预览`}
+      >
+        {edges.map((edge, index) => {
+          const source = positions.get(edge.source);
+          const target = positions.get(edge.target);
+          if (!source || !target) return null;
+
+          return (
+            <line
+              key={`${edge.source}-${edge.target}-${index}`}
+              x1={source.x}
+              y1={source.y}
+              x2={target.x}
+              y2={target.y}
+              stroke="#d0d5dd"
+              strokeWidth="1.4"
+            />
+          );
+        })}
+        {nodes.map((node, index) => {
+          const position = positions.get(node.id);
+          if (!position) return null;
+
+          return (
+            <g key={node.id}>
+              <rect
+                x={position.x - 6}
+                y={position.y - 5}
+                width="12"
+                height="10"
+                rx="3"
+                fill={index === 0 ? '#fe2c55' : '#ffffff'}
+                stroke={index === 0 ? '#fe2c55' : '#98a2b3'}
+                strokeWidth="1.2"
+              />
+            </g>
+          );
+        })}
+      </svg>
+      <div className="absolute bottom-2 right-2 rounded bg-white/90 px-1.5 py-0.5 text-[10px] text-[#98a2b3]">
+        {definition.nodeCount} 节点 · {definition.edgeCount} 连线
+      </div>
+    </div>
+  );
+};
+
 const WorkflowManagementPage = () => {
   const [definitions, setDefinitions] = useState<WorkflowDefinition[]>([]);
   const [loading, setLoading] = useState(false);
@@ -141,6 +228,8 @@ const WorkflowManagementPage = () => {
   const [filter, setFilter] = useState<FilterKey>('ALL');
   const [keywordDraft, setKeywordDraft] = useState('');
   const [keyword, setKeyword] = useState('');
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(10);
   const [createOpen, setCreateOpen] = useState(false);
   const [creating, setCreating] = useState(false);
 
@@ -195,7 +284,7 @@ const WorkflowManagementPage = () => {
   );
 
   const filterTabs: Array<{ key: FilterKey; label: string }> = [
-    { key: 'ALL', label: '全部工作流' },
+    { key: 'ALL', label: '全部' },
     { key: 'ONLINE', label: '已上线' },
     { key: 'DRAFT', label: '草稿' },
     { key: 'OFFLINE', label: '已下线' },
@@ -215,6 +304,16 @@ const WorkflowManagementPage = () => {
       );
     });
   }, [definitions, filter, keyword]);
+
+  const pagedDefinitions = useMemo(() => {
+    const start = (page - 1) * pageSize;
+    return filteredDefinitions.slice(start, start + pageSize);
+  }, [filteredDefinitions, page, pageSize]);
+
+  useEffect(() => {
+    const maxPage = Math.max(1, Math.ceil(filteredDefinitions.length / pageSize));
+    if (page > maxPage) setPage(maxPage);
+  }, [filteredDefinitions.length, page, pageSize]);
 
   const executeAction = async (
     id: string,
@@ -237,10 +336,12 @@ const WorkflowManagementPage = () => {
 
   const handleSearch = () => {
     setKeyword(keywordDraft.trim());
+    setPage(1);
   };
 
   const handleTabChange = (nextFilter: FilterKey) => {
     setFilter(nextFilter);
+    setPage(1);
   };
 
   const handleCreate = async () => {
@@ -311,6 +412,38 @@ const WorkflowManagementPage = () => {
     history.push(`/workflow/definition/${record.id}?scene=edit`);
   };
 
+  const handleMoreAction = async (key: string, record: WorkflowDefinition) => {
+    if (key === 'copy-id') {
+      try {
+        await navigator.clipboard.writeText(record.id);
+        message.success('工作流 ID 已复制');
+      } catch {
+        message.warning('复制失败，请手动复制工作流 ID');
+      }
+      return;
+    }
+
+    if (key === 'online') {
+      await executeAction(
+        record.id,
+        () => onlineWorkflowDefinition(record.id),
+        '工作流已上线',
+      );
+      return;
+    }
+
+    if (key === 'offline') {
+      await executeAction(
+        record.id,
+        () => offlineWorkflowDefinition(record.id),
+        '工作流已下线',
+      );
+      return;
+    }
+
+    if (key === 'delete') handleDelete(record);
+  };
+
   const renderStatus = (status: WorkflowDefinitionStatus) => {
     const meta = DEFINITION_STATUS[status];
 
@@ -331,17 +464,53 @@ const WorkflowManagementPage = () => {
   const renderActions = (record: WorkflowDefinition) => {
     const busy = actionId === record.id;
     const runtimeStatus = record.latestExecutionStatus;
+    const active = isActiveRuntime(runtimeStatus);
     const running = isRunningRuntime(runtimeStatus);
     const paused = runtimeStatus === 'PAUSED';
-
     const actionButtonClass = [
-      '!h-7 !rounded-md !px-2',
+      '!h-8 !rounded-md !px-2.5',
       '!text-[12px] !text-[#667085]',
       'hover:!bg-[#f5f5f6] hover:!text-[#344054]',
     ].join(' ');
 
+    const moreItems = [
+      ...(record.status !== 'ONLINE'
+        ? [
+            {
+              key: 'online',
+              label: '上线工作流',
+              icon: <CloudUpload size={14} strokeWidth={1.8} />,
+              disabled: busy,
+            },
+          ]
+        : [
+            {
+              key: 'offline',
+              label: '下线工作流',
+              icon: <CloudOff size={14} strokeWidth={1.8} />,
+              disabled: busy || active,
+            },
+          ]),
+      {
+        key: 'copy-id',
+        label: '复制工作流 ID',
+        icon: <Copy size={14} strokeWidth={1.8} />,
+      },
+      ...(record.status !== 'ONLINE' && !active
+        ? [
+            { type: 'divider' as const },
+            {
+              key: 'delete',
+              label: '删除工作流',
+              danger: true,
+              icon: <Trash2 size={14} strokeWidth={1.8} />,
+            },
+          ]
+        : []),
+    ];
+
     return (
-      <div className="flex items-center gap-0.5 whitespace-nowrap">
+      <div className="flex shrink-0 items-center gap-0.5 whitespace-nowrap">
         <Button
           type="text"
           size="small"
@@ -352,54 +521,7 @@ const WorkflowManagementPage = () => {
           {record.status === 'ONLINE' ? '查看' : '编辑'}
         </Button>
 
-        {record.status !== 'ONLINE' ? (
-          <Button
-            type="text"
-            size="small"
-            loading={busy}
-            icon={<CloudUpload size={13} strokeWidth={1.9} />}
-            className={actionButtonClass}
-            onClick={() =>
-              void executeAction(
-                record.id,
-                () => onlineWorkflowDefinition(record.id),
-                '工作流已上线',
-              )
-            }
-          >
-            上线
-          </Button>
-        ) : (
-          <Tooltip
-            title={
-              isActiveRuntime(runtimeStatus)
-                ? '存在活动执行时不能下线'
-                : undefined
-            }
-          >
-            <span>
-              <Button
-                type="text"
-                size="small"
-                loading={busy}
-                disabled={isActiveRuntime(runtimeStatus)}
-                icon={<CloudOff size={13} strokeWidth={1.9} />}
-                className={actionButtonClass}
-                onClick={() =>
-                  void executeAction(
-                    record.id,
-                    () => offlineWorkflowDefinition(record.id),
-                    '工作流已下线',
-                  )
-                }
-              >
-                下线
-              </Button>
-            </span>
-          </Tooltip>
-        )}
-
-        {record.status === 'ONLINE' && !isActiveRuntime(runtimeStatus) && (
+        {record.status === 'ONLINE' && !active && (
           <Button
             type="text"
             size="small"
@@ -414,7 +536,7 @@ const WorkflowManagementPage = () => {
               )
             }
           >
-            运行
+            运行一次
           </Button>
         )}
 
@@ -456,131 +578,39 @@ const WorkflowManagementPage = () => {
           </Button>
         )}
 
-        {record.status !== 'ONLINE' && !isActiveRuntime(runtimeStatus) && (
+        <Dropdown
+          trigger={['click']}
+          placement="bottomRight"
+          menu={{
+            items: moreItems,
+            onClick: ({ key }) => void handleMoreAction(key, record),
+          }}
+        >
           <Button
-            danger
             type="text"
             size="small"
-            icon={<Trash2 size={13} strokeWidth={1.9} />}
-            className="!h-7 !rounded-md !px-2 !text-[12px]"
-            onClick={() => handleDelete(record)}
+            icon={<MoreHorizontal size={15} strokeWidth={1.9} />}
+            className={actionButtonClass}
           >
-            删除
+            更多
           </Button>
-        )}
+        </Dropdown>
       </div>
     );
   };
 
-  const columns = [
-    {
-      title: '名称 / ID',
-      dataIndex: 'name',
-      width: 260,
-      render: (_value: string, record: WorkflowDefinition) => (
-        <div className="min-w-0 py-0.5">
-          <button
-            type="button"
-            title={record.name}
-            onClick={() => goToDefinition(record)}
-            className={[
-              'block max-w-full truncate border-0 bg-transparent p-0 text-left',
-              'text-[13px] font-medium leading-5 text-[#344054]',
-              'transition-colors hover:text-[#fe2c55]',
-            ].join(' ')}
-          >
-            {record.name || '未命名工作流'}
-          </button>
-          <div
-            title={record.id}
-            className="mt-0.5 truncate text-[11px] leading-5 text-[#98a2b3]"
-          >
-            ID：{record.id}
-          </div>
-        </div>
-      ),
-    },
-    {
-      title: '描述',
-      dataIndex: 'description',
-      width: 300,
-      render: (value?: string) => (
-        <div
-          title={value || ''}
-          className="line-clamp-2 text-[12px] leading-5 text-[#667085]"
-        >
-          {value || '暂无工作流描述'}
-        </div>
-      ),
-    },
-    {
-      title: '发布状态',
-      dataIndex: 'status',
-      width: 110,
-      align: 'center' as const,
-      render: (value: WorkflowDefinitionStatus) => renderStatus(value),
-    },
-    {
-      title: '节点 / 连线',
-      dataIndex: 'topology',
-      width: 120,
-      align: 'center' as const,
-      render: (_value: unknown, record: WorkflowDefinition) => (
-        <span className="text-[12px] text-[#667085]">
-          {record.nodeCount} / {record.edgeCount}
-        </span>
-      ),
-    },
-    {
-      title: '运行状态',
-      dataIndex: 'latestExecutionStatus',
-      width: 120,
-      align: 'center' as const,
-      render: (value?: string) => (
-        <span
-          className={[
-            'text-[12px] font-medium',
-            runtimeStatusClassName(value),
-          ].join(' ')}
-        >
-          {value ? RUNTIME_LABEL[value] || value : '尚未运行'}
-        </span>
-      ),
-    },
-    {
-      title: '版本',
-      dataIndex: 'latestVersionNo',
-      width: 120,
-      render: (_value: number, record: WorkflowDefinition) => (
-        <div className="text-[12px] leading-5 text-[#667085]">
-          <div>最新 V{record.latestVersionNo || 0}</div>
-          <div className="text-[11px] text-[#98a2b3]">
-            {record.activeVersionNo
-              ? `生效 V${record.activeVersionNo}`
-              : '暂无生效版本'}
-          </div>
-        </div>
-      ),
-    },
-    {
-      title: '更新时间',
-      dataIndex: 'updateTime',
-      width: 170,
-      render: (value?: string) => (
-        <span className="whitespace-nowrap text-[12px] text-[#98a2b3]">
-          {formatTime(value)}
-        </span>
-      ),
-    },
-    {
-      title: '操作',
-      dataIndex: 'operate',
-      width: 285,
-      fixed: 'right' as const,
-      render: (_value: unknown, record: WorkflowDefinition) =>
-        renderActions(record),
-    },
-  ];
+  const renderMetric = (
+    label: string,
+    value: string | number,
+    valueClassName = 'text-[#344054]',
+  ) => (
+    <div className="min-w-0 flex-1 px-4 first:pl-0 last:pr-0">
+      <div className="text-[11px] leading-5 text-[#98a2b3]">{label}</div>
+      <div className={`mt-0.5 truncate text-[12px] font-medium leading-5 ${valueClassName}`}>
+        {value}
+      </div>
+    </div>
+  );
 
   return (
     <ConfigProvider
@@ -601,161 +631,207 @@ const WorkflowManagementPage = () => {
           工作流定义
         </h1>
 
-        <div className="mx-auto flex w-full max-w-full flex-1 flex-col">
-          <div className="mb-3">
-            <div className="border-b border-[#f0f0f0]">
-              <div className="flex min-h-[54px] items-center justify-between gap-4 py-2">
-                <div className="flex shrink-0 items-center gap-1 rounded-lg bg-[#f5f5f6] p-1">
-                  {filterTabs.map((item) => {
-                    const active = filter === item.key;
-
-                    return (
-                      <button
-                        key={item.key}
-                        type="button"
-                        onClick={() => handleTabChange(item.key)}
-                        className={[
-                          'h-8 rounded-md px-3.5 text-[13px] font-medium transition-all',
-                          active
-                            ? 'bg-white text-[#fe2c55] shadow-[0_1px_4px_rgba(16,24,40,0.08)]'
-                            : 'text-[#667085] hover:bg-white/70 hover:text-[#344054]',
-                        ].join(' ')}
-                      >
-                        {item.label}
-                        <span
-                          className={[
-                            'ml-1.5 text-[11px]',
-                            active ? 'text-[#fe2c55]' : 'text-[#98a2b3]',
-                          ].join(' ')}
-                        >
-                          {counts[item.key]}
-                        </span>
-                      </button>
-                    );
-                  })}
-                </div>
-
-                <div className="flex min-w-0 flex-1 items-center justify-end gap-2 overflow-x-auto">
-                  <Input
-                    allowClear
-                    variant="filled"
-                    value={keywordDraft}
-                    prefix={<SearchOutlined className="text-[#98a2b3]" />}
-                    placeholder="搜索工作流名称、描述或 ID"
-                    className="!h-9 !w-[300px] !min-w-[220px]"
-                    onChange={(event) =>
-                      setKeywordDraft(event.target.value)
-                    }
-                    onPressEnter={handleSearch}
-                  />
-
-                  <Button
-                    size="small"
-                    className="!h-9 !px-4"
-                    onClick={handleSearch}
-                  >
-                    查询
-                  </Button>
-
-                  <Tooltip title="刷新">
-                    <Button
-                      size="small"
-                      icon={<ReloadOutlined spin={loading} />}
-                      className="!h-9 !w-9 !px-0"
-                      disabled={loading}
-                      onClick={() => void loadDefinitions()}
-                    />
-                  </Tooltip>
-                </div>
-              </div>
-            </div>
-
-            <div className="flex min-h-[48px] items-center justify-between">
-              <div className="text-[12px] text-[#98a2b3]">
-                当前显示
-                <span className="mx-1 font-medium text-[#475467]">
-                  {filteredDefinitions.length}
-                </span>
-                个工作流
-              </div>
-
-              <Button
-                danger
-                type="primary"
-                size="small"
-                className="!h-7"
-                onClick={() => setCreateOpen(true)}
-              >
-                <span className="text-[13px]">新建工作流</span>
-              </Button>
-            </div>
-
-            <div className="flex min-h-9 items-center rounded-sm bg-[#fff7e6] px-3 text-[12px] text-[#475467]">
-              <span className="mr-2 text-[14px] text-[#faad14]">▲</span>
-              <span className="font-medium text-[#344054]">【提示】</span>
-              <span>
-                工作流需完成任务节点配置并上线后才能运行；存在活动执行时不可直接下线。
-              </span>
-            </div>
+        <div className="mt-2 flex min-h-[58px] items-center justify-between gap-5 border-b border-[#f0f0f0]">
+          <div className="flex shrink-0 items-center gap-2">
+            <button
+              type="button"
+              className="h-8 rounded-lg bg-[#f1f2f4] px-3 text-[12px] font-semibold text-[#161823]"
+            >
+              工作流 ({definitions.length})
+            </button>
           </div>
 
-          <Divider style={{ marginTop: 4, marginBottom: 16 }} />
-
-          <div className="flex-1">
-            <Table
-              columns={columns as any}
-              dataSource={filteredDefinitions}
-              rowKey="id"
-              bordered
-              size="small"
-              pagination={{
-                pageSize: 10,
-                showSizeChanger: true,
-                pageSizeOptions: [10, 20, 50],
-                showTotal: (total) => `共 ${total} 条`,
-                position: ['bottomRight'],
-              }}
-              loading={loading}
-              scroll={{ x: 1485 }}
-              className={[
-                'compact-workflow-definition-table',
-                '[&_.ant-table]:!text-[13px]',
-                '[&_.ant-table-container]:!border-[#eaecf0]',
-                '[&_.ant-table-cell]:!align-middle',
-                '[&_.ant-table-thead>tr>th]:!h-10',
-                '[&_.ant-table-thead>tr>th]:!bg-[#f8f9fb]',
-                '[&_.ant-table-thead>tr>th]:!px-4',
-                '[&_.ant-table-thead>tr>th]:!py-2',
-                '[&_.ant-table-thead>tr>th]:!text-[12px]',
-                '[&_.ant-table-thead>tr>th]:!font-medium',
-                '[&_.ant-table-thead>tr>th]:!text-[#667085]',
-                '[&_.ant-table-thead>tr>th]:!border-[#eaecf0]',
-                '[&_.ant-table-tbody>tr>td]:!px-4',
-                '[&_.ant-table-tbody>tr>td]:!py-2.5',
-                '[&_.ant-table-tbody>tr>td]:!border-[#f0f2f5]',
-                '[&_.ant-table-tbody>tr>td]:!text-[#667085]',
-                '[&_.ant-table-tbody>tr:hover>td]:!bg-[#fafbfc]',
-                '[&_.ant-table-cell-fix-right]:!bg-white',
-                '[&_.ant-table-tbody>tr:hover_.ant-table-cell-fix-right]:!bg-[#fafbfc]',
-                '[&_.ant-table-placeholder>td]:!h-[240px]',
-                '[&_.ant-pagination]:!my-4',
-              ].join(' ')}
-              locale={{
-                emptyText: (
-                  <Empty
-                    image={Empty.PRESENTED_IMAGE_SIMPLE}
-                    description={
-                      <span className="text-[12px] text-[#98a2b3]">
-                        {keyword || filter !== 'ALL'
-                          ? '暂无符合条件的工作流'
-                          : '暂无工作流定义'}
+          <div className="flex min-w-0 flex-1 items-center justify-end gap-3 overflow-x-auto py-2">
+            <div className="flex shrink-0 items-center text-[12px]">
+              {filterTabs.map((item, index) => {
+                const active = filter === item.key;
+                return (
+                  <div key={item.key} className="flex items-center">
+                    {index > 0 && <span className="mx-2 h-3 w-px bg-[#e4e7ec]" />}
+                    <button
+                      type="button"
+                      onClick={() => handleTabChange(item.key)}
+                      className={[
+                        'border-0 bg-transparent p-0 transition-colors',
+                        active
+                          ? 'font-semibold text-[#161823]'
+                          : 'font-normal text-[#98a2b3] hover:text-[#475467]',
+                      ].join(' ')}
+                    >
+                      {item.label}
+                      <span className="ml-1 text-[10px] text-[#98a2b3]">
+                        {counts[item.key]}
                       </span>
-                    }
-                  />
-                ),
-              }}
+                    </button>
+                  </div>
+                );
+              })}
+            </div>
+
+            <Input
+              allowClear
+              variant="filled"
+              value={keywordDraft}
+              prefix={<SearchOutlined className="text-[#98a2b3]" />}
+              placeholder="搜索工作流"
+              className="!h-9 !w-[240px] !min-w-[200px]"
+              onChange={(event) => setKeywordDraft(event.target.value)}
+              onPressEnter={handleSearch}
             />
+
+            <Button size="small" className="!h-9 !px-3" onClick={handleSearch}>
+              查询
+            </Button>
+
+            <Tooltip title="刷新">
+              <Button
+                size="small"
+                icon={<ReloadOutlined spin={loading} />}
+                className="!h-9 !w-9 !px-0"
+                disabled={loading}
+                onClick={() => void loadDefinitions()}
+              />
+            </Tooltip>
+
+            <Button
+              danger
+              type="primary"
+              size="small"
+              className="!h-9 !px-4"
+              onClick={() => setCreateOpen(true)}
+            >
+              新建工作流
+            </Button>
           </div>
+        </div>
+
+        <div className="flex-1 py-4">
+          <Spin spinning={loading}>
+            {pagedDefinitions.length ? (
+              <div className="space-y-3">
+                {pagedDefinitions.map((record) => (
+                  <div
+                    key={record.id}
+                    className="overflow-x-auto rounded-[12px] border border-[#eef0f2] bg-[#fcfcfd] transition-shadow hover:shadow-[0_3px_14px_rgba(16,24,40,.05)]"
+                  >
+                    <div className="flex min-w-[900px] gap-4 px-4 py-4">
+                      <div className="w-[176px] shrink-0 self-stretch">
+                        <WorkflowTopologyPreview definition={record} />
+                      </div>
+
+                      <div className="min-w-0 flex-1">
+                        <div className="flex min-h-8 items-start justify-between gap-4">
+                          <div className="min-w-0 flex-1">
+                            <div className="flex min-w-0 items-center gap-2">
+                              <button
+                                type="button"
+                                title={record.name}
+                                onClick={() => goToDefinition(record)}
+                                className="min-w-0 truncate border-0 bg-transparent p-0 text-left text-[14px] font-semibold leading-6 text-[#161823] transition-colors hover:text-[#fe2c55]"
+                              >
+                                {record.name || '未命名工作流'}
+                              </button>
+                              {renderStatus(record.status)}
+                              {record.draftChanged && (
+                                <span className="rounded bg-[#fff7e6] px-1.5 py-0.5 text-[10px] text-[#ad6800]">
+                                  有未发布变更
+                                </span>
+                              )}
+                            </div>
+
+                            <div
+                              title={record.id}
+                              className="mt-0.5 truncate text-[10px] leading-5 text-[#98a2b3]"
+                            >
+                              ID：{record.id}
+                            </div>
+                          </div>
+
+                          {renderActions(record)}
+                        </div>
+
+                        <div
+                          title={record.description || ''}
+                          className="mt-2 line-clamp-2 min-h-5 text-[12px] leading-5 text-[#667085]"
+                        >
+                          {record.description || '暂无工作流描述'}
+                        </div>
+
+                        <div className="mt-4 flex items-stretch divide-x divide-[#eaecf0] border-t border-[#f0f1f3] pt-3">
+                          {renderMetric('节点', record.nodeCount)}
+                          {renderMetric('连线', record.edgeCount)}
+                          {renderMetric('最新版本', `V${record.latestVersionNo || 0}`)}
+                          {renderMetric(
+                            '生效版本',
+                            record.activeVersionNo ? `V${record.activeVersionNo}` : '暂无',
+                            record.activeVersionNo ? 'text-[#344054]' : 'text-[#98a2b3]',
+                          )}
+                          {renderMetric(
+                            '运行状态',
+                            record.latestExecutionStatus
+                              ? RUNTIME_LABEL[record.latestExecutionStatus] || record.latestExecutionStatus
+                              : '尚未运行',
+                            runtimeStatusClassName(record.latestExecutionStatus),
+                          )}
+                          {renderMetric('更新时间', formatTime(record.updateTime), 'text-[#667085]')}
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <div className="flex min-h-[320px] items-center justify-center">
+                <Empty
+                  image={Empty.PRESENTED_IMAGE_SIMPLE}
+                  description={
+                    <span className="text-[12px] text-[#98a2b3]">
+                      {keyword || filter !== 'ALL'
+                        ? '暂无符合条件的工作流'
+                        : '暂无工作流定义'}
+                    </span>
+                  }
+                >
+                  {!keyword && filter === 'ALL' && (
+                    <Button
+                      danger
+                      type="primary"
+                      size="small"
+                      onClick={() => setCreateOpen(true)}
+                    >
+                      新建工作流
+                    </Button>
+                  )}
+                </Empty>
+              </div>
+            )}
+          </Spin>
+
+          {filteredDefinitions.length > 0 && (
+            <div className="mt-5 flex items-center justify-between border-t border-[#f5f5f5] py-4">
+              <span className="text-[11px] text-[#98a2b3]">
+                共 {filteredDefinitions.length} 个工作流
+              </span>
+              <Pagination
+                current={page}
+                pageSize={pageSize}
+                total={filteredDefinitions.length}
+                showSizeChanger
+                pageSizeOptions={[10, 20, 50]}
+                size="small"
+                onChange={(nextPage, nextPageSize) => {
+                  setPage(nextPageSize !== pageSize ? 1 : nextPage);
+                  setPageSize(nextPageSize);
+                }}
+              />
+            </div>
+          )}
+
+          {!loading && filteredDefinitions.length > 0 && filteredDefinitions.length <= pageSize && (
+            <div className="pb-6 pt-1 text-center text-[11px] text-[#b4bac3]">
+              没有更多工作流
+            </div>
+          )}
         </div>
 
         <Drawer


### PR DESCRIPTION
## 说明

重构「工作流定义」管理页，参考横向内容资产管理的布局思路，将原来的高密度表格调整为更适合工作流资产浏览的横向卡片列表。

## 主要调整

- 顶部改为更轻量的工作流数量、状态筛选、搜索、刷新和新建工作流工具栏
- 工作流列表从 Table 重构为横向资产卡片
- 基于现有 `nodes / edges / positionX / positionY` 数据生成 DAG 缩略预览，不新增后端字段
- 卡片集中展示名称、描述、发布状态、草稿变更、节点/连线、版本、运行状态和更新时间
- 保留编辑/查看、运行、暂停、恢复、上线、下线、删除等现有能力
- 将低频和危险操作收进「更多」，新增复制工作流 ID
- 保留搜索、状态筛选、自动刷新活动执行状态和分页能力
- 优化空状态与首次创建入口

## 范围

仅修改前端工作流定义管理页：
`yak-ops-ui/src/pages/workflow/management/index.tsx`

未修改接口和后端逻辑。

## 验证

- 已确认分支基于最新 `main`，当前 ahead 1 / behind 0
- GitHub 当前未返回该提交的 CI status；建议在 Draft 阶段继续做页面视觉和交互验收
