### PR TITLE
refactor: 收敛数据消费导航与入口

### DIFF
--- a/yak-ops-ui/src/config/navigation.test.ts
+++ b/yak-ops-ui/src/config/navigation.test.ts
@@ -24,11 +24,13 @@ describe('permission-aware navigation', () => {
     expect(getMainNavigationGroups([]).map((group) => group.id)).toEqual([
       'development',
       'workflow',
+      'data-analysis',
     ]);
     expect(getMainNavigationGroups(batchRead).map((group) => group.id)).toEqual([
       'integration',
       'development',
       'workflow',
+      'data-analysis',
     ]);
     expect(getQuickCreateRoutes(batchRead)).toEqual([]);
     expect(getQuickCreateRoutes([...batchRead, 'task:batch:create']).map((route) => route.id)).toEqual(['batch-link-up']);
@@ -42,6 +44,7 @@ describe('permission-aware navigation', () => {
       'workflow',
       'resources',
       'data-quality',
+      'data-analysis',
       'system',
     ]);
     expect(groups.map((group) => group.section)).toEqual([
@@ -50,18 +53,30 @@ describe('permission-aware navigation', () => {
       'task',
       'management',
       'management',
+      'management',
       'system',
     ]);
+  });
+
+  it('keeps data consumption focused on dashboard and catalog while preserving the legacy chart route', () => {
+    const dataConsumption = getMainNavigationGroups([]).find(
+      (group) => group.id === 'data-analysis',
+    );
+    expect(dataConsumption?.title).toBe('数据消费');
+    expect(dataConsumption?.routes.map((route) => route.id)).toEqual([
+      'dashboard',
+      'data-analysis-catalog',
+    ]);
+    expect(getActiveNavigationId('/dashboard', [])).toBe('dashboard');
+    expect(getActiveNavigationId('/data-analysis/chart-analysis', [])).toBe('dashboard');
   });
 
   it('registers home before other standalone navigation', () => {
     expect(getStandaloneNavigationRoutes(['security:root']).map((route) => route.id)).toEqual([
       'home',
       'data-source',
-      'dashboard',
     ]);
     expect(getActiveNavigationId('/home', [])).toBe('home');
-    expect(getActiveNavigationId('/dashboard', [])).toBe('dashboard');
   });
 
   it('keeps the personal settings page addressable without exposing it in the main sidebar', () => {

--- a/yak-ops-ui/src/config/navigation.ts
+++ b/yak-ops-ui/src/config/navigation.ts
@@ -31,7 +31,7 @@ export const navigationGroups: readonly NavigationGroup[] = [
   { id: 'workflow', title: '工作流', iconKey: 'workflow', section: 'task', order: 30 },
   { id: 'resources', title: '资源管理', iconKey: 'database', section: 'management', order: 20 },
   { id: 'data-quality', title: '数据质量', iconKey: 'quality', section: 'management', order: 30 },
-  { id: 'data-analysis', title: '数据分析', iconKey: 'insight', section: 'management', order: 40 },
+  { id: 'data-analysis', title: '数据消费', iconKey: 'insight', section: 'management', order: 40 },
   { id: 'system', title: '系统管理', iconKey: 'system', section: 'system', order: 40 },
 ];
 
@@ -39,8 +39,8 @@ export const appRoutes: readonly NavigationRoute[] = [
   { id: 'home', mode: 'public', path: '/home', title: '首页', component: './home', iconKey: 'home', order: 0 },
   { id: 'data-source', mode: 'one', permission: 'resource:data-source:read', path: '/data-source', title: '数据源管理', component: './data-source', iconKey: 'database', order: 10 },
   { id: 'dashboard', mode: 'public', path: '/dashboard', title: '仪表盘', component: './dashboard', iconKey: 'insight', menuGroup: 'data-analysis', order: 10 },
-  { id: 'data-analysis-chart', mode: 'public', path: '/data-analysis/chart-analysis', title: '图表分析', component: './data-analysis/chart-analysis', iconKey: 'report', menuGroup: 'data-analysis', order: 20 },
-  { id: 'data-analysis-catalog', mode: 'public', path: '/data-analysis/data-catalog', title: '数据目录', component: './data-analysis/data-catalog', iconKey: 'database', menuGroup: 'data-analysis', order: 30 },
+  { id: 'data-analysis-catalog', mode: 'public', path: '/data-analysis/data-catalog', title: '数据目录', component: './data-analysis/data-catalog', iconKey: 'database', menuGroup: 'data-analysis', order: 20 },
+  { id: 'data-analysis-chart', path: '/data-analysis/chart-analysis', title: '图表分析', component: './data-analysis/chart-analysis-redirect', hidden: true, parentId: 'dashboard' },
   { id: 'settings', mode: 'public', path: '/settings', title: '设置', component: './settings', hidden: true, order: 30 },
   {
     id: 'batch-link-up', mode: 'one', permission: 'task:batch:read',

--- a/yak-ops-ui/src/pages/data-analysis/chart-analysis-redirect.tsx
+++ b/yak-ops-ui/src/pages/data-analysis/chart-analysis-redirect.tsx
@@ -1,0 +1,12 @@
+import { history } from '@umijs/max';
+import { useEffect } from 'react';
+
+const LegacyChartAnalysisRedirect = () => {
+  useEffect(() => {
+    history.replace(`/dashboard${window.location.search}`);
+  }, []);
+
+  return null;
+};
+
+export default LegacyChartAnalysisRedirect;


### PR DESCRIPTION
## Summary

- 将原「数据分析」导航收敛为「数据消费」
- 数据消费主导航仅保留「仪表盘」和「数据目录」两个入口
- 移除独立「图表分析」的主导航入口
- 保留 `/data-analysis/chart-analysis` 旧地址作为隐藏兼容路由，并统一重定向到仪表盘
- 重定向时保留原查询参数，为后续 Dashboard 内嵌 Chart Editor / Dataset 上下文接入留好兼容口
- 补充导航测试，锁定 V1 的数据消费信息架构

## Scope

这是 BI 瘦身计划的 PR1，只做「导航与入口收敛」。

本 PR **不删除**：
- 现有 Chart Analysis 页面代码
- Analysis API / Domain
- Dataset Query Runtime
- Dashboard Designer 现有能力

Dashboard Core Canvas 瘦身和 Chart Editor 内嵌会分别放到后续 PR2 / PR3。

## Result

数据消费的主路径收敛为：

`Dataset → 数据目录 → 仪表盘 → 图表`

独立 Chart Analysis 不再作为用户可见的一级产品概念，但旧链接仍可安全过渡到 Dashboard。

## Verification

- 导航配置测试覆盖「数据消费 = 仪表盘 + 数据目录」
- 旧 `/data-analysis/chart-analysis` 路由继承 Dashboard 导航状态并通过兼容页重定向
- 分支相对 `main` 仅 1 个提交、3 个文件变更