### PR TITLE
refactor: 瘦身 Dashboard Core Canvas

### DIFF
--- a/yak-ops-ui/src/pages/dashboard/global-filter-bar.tsx
+++ b/yak-ops-ui/src/pages/dashboard/global-filter-bar.tsx
@@ -1,15 +1,8 @@
-import type { AnalysisSpec } from '@/components/analysis/model';
-import { Button, Drawer, Empty, Input, Select, Tooltip } from 'antd';
-import { Plus, RefreshCw, SlidersHorizontal, Trash2, Workflow } from 'lucide-react';
-import { useMemo, useState } from 'react';
-import { FILTER_OPERATOR_OPTIONS } from './helpers';
+import { Button, Input, Tooltip } from 'antd';
+import { RefreshCw, SlidersHorizontal } from 'lucide-react';
 import type {
-  AnalysisAsset,
   DashboardGlobalFilter,
-  DashboardInteraction,
-  DashboardWidget,
   FilterOperator,
-  PublishedDataset,
   Scalar,
 } from './model';
 
@@ -26,326 +19,65 @@ const OPERATOR_LABELS: Record<FilterOperator, string> = {
 const own = (value: Record<string, Scalar | undefined>, key: string) =>
   Object.prototype.hasOwnProperty.call(value, key);
 
-const id = (prefix: string) => `${prefix}-${Date.now()}-${Math.round(Math.random() * 10000)}`;
-
 export function DashboardGlobalFilterBar({
   filters,
-  interactions,
-  widgets,
-  analyses,
-  datasets,
   runtimeValues,
-  preview,
-  onFiltersChange,
-  onInteractionsChange,
   onRuntimeValue,
   onReset,
 }: {
   filters: DashboardGlobalFilter[];
-  interactions: DashboardInteraction[];
-  widgets: DashboardWidget[];
-  analyses: AnalysisAsset[];
-  datasets: PublishedDataset[];
   runtimeValues: Record<string, Scalar | undefined>;
-  preview: boolean;
-  onFiltersChange: (filters: DashboardGlobalFilter[]) => void;
-  onInteractionsChange: (interactions: DashboardInteraction[]) => void;
   onRuntimeValue: (filterId: string, value: Scalar | undefined) => void;
   onReset: () => void;
 }) {
-  const [open, setOpen] = useState(false);
-  const analysisMap = useMemo(() => new Map(analyses.map((item) => [item.id, item])), [analyses]);
-  const datasetMap = useMemo(() => new Map(datasets.map((item) => [item.id, item])), [datasets]);
-
-  const specForWidget = (widget?: DashboardWidget): AnalysisSpec | undefined => {
-    if (!widget) return undefined;
-    return widget.analysisId ? analysisMap.get(widget.analysisId) : widget.inlineAnalysis;
-  };
-
-  const widgetLabel = (widget: DashboardWidget) => {
-    if (widget.analysisId) return analysisMap.get(widget.analysisId)?.name ?? `Analysis #${widget.analysisId}`;
-    return widget.title || '未命名图表';
-  };
-
-  const fieldOptions = (widgetId?: string) => {
-    const widget = widgets.find((item) => item.id === widgetId);
-    const spec = specForWidget(widget);
-    const dataset = spec ? datasetMap.get(spec.datasetId) : undefined;
-    return dataset?.fields.map((field) => ({ label: field.label, value: field.key })) ?? [];
-  };
-
-  const sourceDimensionOptions = (widgetId?: string) => {
-    const widget = widgets.find((item) => item.id === widgetId);
-    const spec = specForWidget(widget);
-    const dataset = spec ? datasetMap.get(spec.datasetId) : undefined;
-    if (!spec || !dataset || !spec.dimensions.length) return [];
-    // AnalysisPreview emits the primary visible category. Multi-dimension linkage can be expanded later.
-    const primary = spec.dimensions[0];
-    const field = dataset.fields.find((item) => item.key === primary);
-    return field ? [{ label: field.label, value: field.key }] : [];
-  };
-
-  const widgetOptions = widgets.map((widget) => ({ label: widgetLabel(widget), value: widget.id }));
-  const sourceWidgetOptions = widgets
-    .filter((widget) => sourceDimensionOptions(widget.id).length > 0)
-    .map((widget) => ({ label: widgetLabel(widget), value: widget.id }));
-
-  const replaceFilter = (filterId: string, patch: Partial<DashboardGlobalFilter>) => {
-    onFiltersChange(filters.map((filter) => filter.id === filterId ? { ...filter, ...patch } : filter));
-  };
-
-  const removeFilter = (filterId: string) => {
-    onFiltersChange(filters.filter((filter) => filter.id !== filterId));
-    onInteractionsChange(interactions.filter((item) => item.targetFilterId !== filterId));
-  };
-
-  const addFilter = () => onFiltersChange([
-    ...filters,
-    {
-      id: id('filter'),
-      name: `筛选器 ${filters.length + 1}`,
-      operator: 'eq',
-      defaultValue: '',
-      bindings: [],
-    },
-  ]);
-
-  const addBinding = (filter: DashboardGlobalFilter) => {
-    const used = new Set(filter.bindings.map((item) => item.widgetId));
-    const widget = widgets.find((item) => !used.has(item.id) && fieldOptions(item.id).length > 0);
-    if (!widget) return;
-    const field = fieldOptions(widget.id)[0];
-    replaceFilter(filter.id, {
-      bindings: [...filter.bindings, { widgetId: widget.id, field: String(field.value) }],
-    });
-  };
-
-  const updateBinding = (
-    filter: DashboardGlobalFilter,
-    index: number,
-    patch: Partial<DashboardGlobalFilter['bindings'][number]>,
-  ) => {
-    replaceFilter(filter.id, {
-      bindings: filter.bindings.map((binding, bindingIndex) => (
-        bindingIndex === index ? { ...binding, ...patch } : binding
-      )),
-    });
-  };
-
-  const addInteraction = () => {
-    const sourceWidget = sourceWidgetOptions[0]?.value;
-    const targetFilter = filters[0]?.id;
-    if (!sourceWidget || !targetFilter) return;
-    const sourceField = sourceDimensionOptions(sourceWidget)[0]?.value;
-    if (!sourceField) return;
-    onInteractionsChange([
-      ...interactions,
-      {
-        id: id('interaction'),
-        event: 'select',
-        sourceWidgetId: String(sourceWidget),
-        sourceField: String(sourceField),
-        targetFilterId: targetFilter,
-      },
-    ]);
-  };
-
-  const updateInteraction = (interactionId: string, patch: Partial<DashboardInteraction>) => {
-    onInteractionsChange(interactions.map((item) => item.id === interactionId ? { ...item, ...patch } : item));
-  };
-
-  if (preview && !filters.length) return null;
+  if (!filters.length) return null;
 
   return (
-    <>
-      <div className="flex min-h-10 shrink-0 items-center gap-2 border-b border-[#e5e7eb] bg-white px-3 py-1.5">
-        <div className="flex shrink-0 items-center gap-1.5 text-[11px] font-medium text-[#475467]">
-          <SlidersHorizontal size={13} /> 全局筛选
-        </div>
-        <div className="flex min-w-0 flex-1 items-center gap-2 overflow-x-auto">
-          {filters.map((filter) => {
-            const current = own(runtimeValues, filter.id) ? runtimeValues[filter.id] : filter.defaultValue;
-            return (
-              <div key={filter.id} className="flex shrink-0 items-center rounded-[4px] border border-[#e5e7eb] bg-[#fafbfc] pl-2">
-                <span className="mr-1.5 text-[10px] text-[#667085]">{filter.name}</span>
-                <span className="mr-1 text-[9px] text-[#98a2b3]">{OPERATOR_LABELS[filter.operator]}</span>
-                <Input
-                  variant="borderless"
-                  size="small"
-                  allowClear
-                  className="w-[128px] text-[11px]"
-                  placeholder="全部"
-                  value={current === undefined || current === null ? '' : String(current)}
-                  onChange={(event) => onRuntimeValue(filter.id, event.target.value)}
-                />
-              </div>
-            );
-          })}
-          {!filters.length ? <span className="text-[10px] text-[#98a2b3]">暂无全局筛选器</span> : null}
-        </div>
-        {filters.length ? (
-          <Tooltip title="恢复默认值">
-            <Button size="small" type="text" icon={<RefreshCw size={12} />} onClick={onReset} />
-          </Tooltip>
-        ) : null}
-        {!preview ? (
-          <Button size="small" icon={<SlidersHorizontal size={12} />} onClick={() => setOpen(true)}>
-            管理筛选与联动
-          </Button>
-        ) : null}
+    <div className="flex min-h-9 shrink-0 items-center gap-2 border-b border-[#e5e7eb] bg-white px-3 py-1">
+      <div className="flex shrink-0 items-center gap-1.5 text-[10px] font-medium text-[#667085]">
+        <SlidersHorizontal size={12} />
+        筛选
       </div>
 
-      <Drawer
-        title="全局筛选器与组件联动"
-        width={520}
-        open={open}
-        onClose={() => setOpen(false)}
-        extra={<span className="text-[10px] text-[#98a2b3]">配置随下一次 Dashboard 保存进入新版本</span>}
-      >
-        <div className="mb-4 rounded-[5px] bg-[#f7f8fa] px-3 py-2 text-[11px] leading-5 text-[#667085]">
-          全局筛选器通过 fieldId 映射到不同 Widget；运行时输入值只影响当前浏览。联动规则会把图表点击的分类值写入目标筛选器，从而驱动所有绑定 Widget 一起刷新。
-        </div>
+      <div className="flex min-w-0 flex-1 items-center gap-1.5 overflow-x-auto">
+        {filters.map((filter) => {
+          const current = own(runtimeValues, filter.id)
+            ? runtimeValues[filter.id]
+            : filter.defaultValue;
 
-        <div className="mb-2 flex items-center justify-between">
-          <div className="text-[12px] font-semibold text-[#344054]">全局筛选器</div>
-          <Button size="small" icon={<Plus size={12} />} onClick={addFilter}>新增筛选器</Button>
-        </div>
-
-        {!filters.length ? (
-          <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="先创建一个全局筛选器" />
-        ) : filters.map((filter) => (
-          <div key={filter.id} className="mb-3 rounded-[6px] border border-[#e5e7eb] bg-white p-3">
-            <div className="flex items-center gap-2">
+          return (
+            <div
+              key={filter.id}
+              className="flex h-7 shrink-0 items-center rounded-[4px] bg-[#f7f8fa] pl-2"
+            >
+              <span className="mr-1.5 text-[10px] text-[#667085]">
+                {filter.name}
+              </span>
+              <span className="mr-1 text-[9px] text-[#98a2b3]">
+                {OPERATOR_LABELS[filter.operator]}
+              </span>
               <Input
-                size="small"
-                value={filter.name}
-                placeholder="筛选器名称"
-                onChange={(event) => replaceFilter(filter.id, { name: event.target.value })}
-              />
-              <Select
-                size="small"
-                className="w-[120px] shrink-0"
-                value={filter.operator}
-                options={FILTER_OPERATOR_OPTIONS}
-                onChange={(operator: FilterOperator) => replaceFilter(filter.id, { operator })}
-              />
-              <Tooltip title="删除筛选器">
-                <Button size="small" type="text" danger icon={<Trash2 size={12} />} onClick={() => removeFilter(filter.id)} />
-              </Tooltip>
-            </div>
-            <div className="mt-2">
-              <div className="mb-1 text-[10px] text-[#98a2b3]">默认值（可留空）</div>
-              <Input
+                variant="borderless"
                 size="small"
                 allowClear
-                value={filter.defaultValue === undefined || filter.defaultValue === null ? '' : String(filter.defaultValue)}
-                onChange={(event) => replaceFilter(filter.id, { defaultValue: event.target.value })}
+                className="w-[112px] text-[10px]"
+                placeholder="全部"
+                value={current === undefined || current === null ? '' : String(current)}
+                onChange={(event) => onRuntimeValue(filter.id, event.target.value)}
               />
             </div>
-            <div className="mb-1 mt-3 flex items-center justify-between">
-              <span className="text-[10px] font-medium text-[#667085]">影响组件 / 字段映射</span>
-              <Button size="small" type="text" icon={<Plus size={11} />} onClick={() => addBinding(filter)}>添加映射</Button>
-            </div>
-            <div className="space-y-2">
-              {filter.bindings.map((binding, bindingIndex) => {
-                const used = new Set(filter.bindings.filter((_, index) => index !== bindingIndex).map((item) => item.widgetId));
-                const targetWidgetOptions = widgetOptions.filter((item) => !used.has(String(item.value)));
-                return (
-                  <div key={`${filter.id}-${bindingIndex}`} className="grid grid-cols-[1fr_1fr_28px] gap-2">
-                    <Select
-                      size="small"
-                      value={binding.widgetId}
-                      options={targetWidgetOptions}
-                      placeholder="目标组件"
-                      onChange={(widgetId: string) => updateBinding(filter, bindingIndex, {
-                        widgetId,
-                        field: String(fieldOptions(widgetId)[0]?.value ?? ''),
-                      })}
-                    />
-                    <Select
-                      size="small"
-                      value={binding.field || undefined}
-                      options={fieldOptions(binding.widgetId)}
-                      placeholder="目标字段"
-                      onChange={(field: string) => updateBinding(filter, bindingIndex, { field })}
-                    />
-                    <Button
-                      size="small"
-                      type="text"
-                      danger
-                      icon={<Trash2 size={11} />}
-                      onClick={() => replaceFilter(filter.id, {
-                        bindings: filter.bindings.filter((_, index) => index !== bindingIndex),
-                      })}
-                    />
-                  </div>
-                );
-              })}
-              {!filter.bindings.length ? (
-                <div className="rounded-[4px] border border-dashed border-[#e5e7eb] px-2 py-2 text-[10px] text-[#98a2b3]">
-                  尚未绑定 Widget；该筛选器暂时不会影响查询。
-                </div>
-              ) : null}
-            </div>
-          </div>
-        ))}
+          );
+        })}
+      </div>
 
-        <div className="mb-2 mt-6 flex items-center justify-between border-t border-[#edf0f3] pt-4">
-          <div className="flex items-center gap-1.5 text-[12px] font-semibold text-[#344054]"><Workflow size={13} />组件联动</div>
-          <Button size="small" icon={<Plus size={12} />} disabled={!filters.length || !sourceWidgetOptions.length} onClick={addInteraction}>
-            新增联动
-          </Button>
-        </div>
-
-        {!interactions.length ? (
-          <div className="rounded-[5px] bg-[#f7f8fa] px-3 py-3 text-[10px] leading-5 text-[#98a2b3]">
-            配置后，点击来源图表的分类值，会自动写入目标全局筛选器并刷新所有绑定组件。
-          </div>
-        ) : (
-          <div className="space-y-2">
-            {interactions.map((interaction) => (
-              <div key={interaction.id} className="rounded-[5px] border border-[#e5e7eb] p-2.5">
-                <div className="grid grid-cols-[1fr_1fr_30px] gap-2">
-                  <Select
-                    size="small"
-                    value={interaction.sourceWidgetId}
-                    options={sourceWidgetOptions}
-                    placeholder="来源组件"
-                    onChange={(sourceWidgetId: string) => updateInteraction(interaction.id, {
-                      sourceWidgetId,
-                      sourceField: String(sourceDimensionOptions(sourceWidgetId)[0]?.value ?? ''),
-                    })}
-                  />
-                  <Select
-                    size="small"
-                    value={interaction.sourceField || undefined}
-                    options={sourceDimensionOptions(interaction.sourceWidgetId)}
-                    placeholder="点击维度"
-                    onChange={(sourceField: string) => updateInteraction(interaction.id, { sourceField })}
-                  />
-                  <Button
-                    size="small"
-                    type="text"
-                    danger
-                    icon={<Trash2 size={11} />}
-                    onClick={() => onInteractionsChange(interactions.filter((item) => item.id !== interaction.id))}
-                  />
-                </div>
-                <div className="mt-2 flex items-center gap-2">
-                  <span className="text-[10px] text-[#98a2b3]">点击后写入</span>
-                  <Select
-                    size="small"
-                    className="flex-1"
-                    value={interaction.targetFilterId}
-                    options={filters.map((filter) => ({ label: filter.name, value: filter.id }))}
-                    onChange={(targetFilterId: string) => updateInteraction(interaction.id, { targetFilterId })}
-                  />
-                </div>
-              </div>
-            ))}
-          </div>
-        )}
-      </Drawer>
-    </>
+      <Tooltip title="恢复默认筛选">
+        <Button
+          size="small"
+          type="text"
+          icon={<RefreshCw size={12} />}
+          onClick={onReset}
+        />
+      </Tooltip>
+    </div>
   );
 }

--- a/yak-ops-ui/src/pages/dashboard/index.tsx
+++ b/yak-ops-ui/src/pages/dashboard/index.tsx
@@ -23,6 +23,15 @@ export default function DashboardPage() {
     minW: widget.minW,
     minH: widget.minH,
   })), [designer.widgets]);
+  const hasGlobalFilters = designer.dashboard.globalFilters.length > 0;
+  let canvasMinHeight = 'min-h-[calc(100vh-120px)]';
+  if (designer.preview) {
+    canvasMinHeight = hasGlobalFilters
+      ? 'min-h-[calc(100vh-172px)]'
+      : 'min-h-[calc(100vh-136px)]';
+  } else if (hasGlobalFilters) {
+    canvasMinHeight = 'min-h-[calc(100vh-156px)]';
+  }
 
   const syncLayout = (nextLayout: readonly { i: string; x: number; y: number; w: number; h: number }[]) => {
     const nextMap = new Map(nextLayout.map((item) => [item.i, item]));
@@ -36,7 +45,10 @@ export default function DashboardPage() {
   };
 
   return (
-    <div className="flex h-[calc(100vh-48px)] min-h-[640px] flex-col overflow-hidden bg-[#f4f6f8]" style={BRAND_CSS_VARIABLES}>
+    <div
+      className="flex h-[calc(100vh-48px)] min-h-[640px] flex-col overflow-hidden bg-[#f4f6f8]"
+      style={BRAND_CSS_VARIABLES}
+    >
       <DashboardToolbar
         name={designer.dashboard.name}
         dashboardId={designer.dashboard.id}
@@ -50,20 +62,16 @@ export default function DashboardPage() {
         onDashboard={(dashboardId) => void designer.openDashboard(dashboardId)}
         onNew={designer.newDashboard}
         onVersion={(versionNo) => void designer.activateVersion(versionNo)}
-        onPreview={() => { designer.setPreview((current) => !current); designer.setSelectedId(undefined); }}
+        onPreview={() => {
+          designer.setPreview((current) => !current);
+          designer.setSelectedId(undefined);
+        }}
         onSave={() => void designer.save()}
       />
 
       <DashboardGlobalFilterBar
         filters={designer.dashboard.globalFilters}
-        interactions={designer.dashboard.interactions}
-        widgets={designer.widgets}
-        analyses={designer.analyses}
-        datasets={designer.datasets}
         runtimeValues={designer.runtimeFilterValues}
-        preview={designer.preview}
-        onFiltersChange={designer.setGlobalFilters}
-        onInteractionsChange={designer.setInteractions}
         onRuntimeValue={designer.setRuntimeFilterValue}
         onReset={designer.resetRuntimeFilters}
       />
@@ -75,16 +83,10 @@ export default function DashboardPage() {
             activeDataset={designer.activeDataset}
             datasetsLoading={designer.datasetsLoading}
             datasetsError={designer.datasetsError}
-            analyses={designer.analyses}
-            analysesLoading={designer.analysesLoading}
-            analysesError={designer.analysesError}
-            selectedWidget={designer.selectedWidget}
-            onDatasetChange={(activeDatasetId) => designer.setDashboard((current) => ({ ...current, activeDatasetId }))}
+            onDatasetChange={(activeDatasetId) =>
+              designer.setDashboard((current) => ({ ...current, activeDatasetId }))}
             onRefreshDatasets={() => void designer.refreshDatasets()}
-            onRefreshAnalyses={() => void designer.refreshAnalyses()}
             onAddChart={designer.addWidget}
-            onAddAnalysis={designer.addAnalysis}
-            onAddField={designer.addField}
           />
         ) : null}
 
@@ -93,17 +95,30 @@ export default function DashboardPage() {
             <div
               ref={containerRef}
               className={[
-                'mx-auto min-h-[calc(100vh-132px)] min-w-[760px] bg-white',
-                designer.preview ? 'max-w-[1500px] shadow-[0_1px_5px_rgba(16,24,40,.08)]' : 'dashboard-grid-canvas border border-[#dfe3e8]',
+                'mx-auto min-w-[760px] bg-white',
+                canvasMinHeight,
+                designer.preview
+                  ? 'max-w-[1500px] shadow-[0_1px_5px_rgba(16,24,40,.08)]'
+                  : 'dashboard-grid-canvas border border-[#dfe3e8]',
               ].join(' ')}
-              onMouseDown={(event) => { if (event.target === event.currentTarget) designer.setSelectedId(undefined); }}
+              onMouseDown={(event) => {
+                if (event.target === event.currentTarget) designer.setSelectedId(undefined);
+              }}
             >
               {mounted && width > 0 ? (
                 <ReactGridLayout
                   width={width}
                   layout={layout}
-                  gridConfig={{ cols: GRID_COLUMNS, rowHeight: GRID_ROW_HEIGHT, margin: [8, 8], containerPadding: [8, 8] }}
-                  dragConfig={{ enabled: !designer.preview, handle: '.dashboard-widget__drag-handle' }}
+                  gridConfig={{
+                    cols: GRID_COLUMNS,
+                    rowHeight: GRID_ROW_HEIGHT,
+                    margin: [8, 8],
+                    containerPadding: [8, 8],
+                  }}
+                  dragConfig={{
+                    enabled: !designer.preview,
+                    handle: '.dashboard-widget__drag-handle',
+                  }}
                   resizeConfig={{ enabled: !designer.preview }}
                   onLayoutChange={syncLayout}
                 >
@@ -115,6 +130,7 @@ export default function DashboardPage() {
                     const dataset = spec
                       ? designer.datasets.find((item) => item.id === spec.datasetId)
                       : undefined;
+
                     return (
                       <div key={widget.id}>
                         <WidgetShell
@@ -124,9 +140,11 @@ export default function DashboardPage() {
                           runtimeFilters={designer.runtimeFiltersForWidget(widget.id)}
                           selected={designer.selectedId === widget.id}
                           preview={designer.preview}
-                          onSelect={() => { if (!designer.preview) designer.setSelectedId(widget.id); }}
-                          onDataSelect={(selection) => designer.handleWidgetSelection(widget.id, selection)}
-                          onSaveAsAnalysis={() => void designer.saveWidgetAsAnalysis(widget.id)}
+                          onSelect={() => {
+                            if (!designer.preview) designer.setSelectedId(widget.id);
+                          }}
+                          onDataSelect={(selection) =>
+                            designer.handleWidgetSelection(widget.id, selection)}
                           onDuplicate={() => designer.duplicateWidget(widget.id)}
                           onDelete={() => designer.deleteWidget(widget.id)}
                         />
@@ -135,11 +153,19 @@ export default function DashboardPage() {
                   })}
                 </ReactGridLayout>
               ) : null}
+
               {!designer.widgets.length && !designer.datasetsLoading ? (
-                <div className="flex min-h-[360px] items-center justify-center px-6 text-center text-[12px] text-[#98a2b3]">
-                  {designer.activeDataset
-                    ? '从左侧复用 Analysis，或新建图表开始分析；可在顶部配置全局筛选与组件联动'
-                    : '暂无可用 Dataset，请先在数据开发发布中心发布数据集'}
+                <div className="flex min-h-[360px] items-center justify-center px-6 text-center">
+                  <div>
+                    <div className="text-[14px] font-medium text-[#475467]">
+                      {designer.activeDataset ? '添加第一个图表' : '暂无可用数据集'}
+                    </div>
+                    <div className="mt-1 text-[12px] text-[#98a2b3]">
+                      {designer.activeDataset
+                        ? '从左侧选择图表类型，添加后在右侧完成数据与样式配置'
+                        : '请先在数据开发发布中心发布并上线 Dataset'}
+                    </div>
+                  </div>
                 </div>
               ) : null}
             </div>
@@ -151,21 +177,46 @@ export default function DashboardPage() {
             widget={designer.selectedWidget}
             datasets={designer.datasets}
             analyses={designer.analyses}
-            updateWidget={(patch) => designer.updateWidget(designer.selectedWidget!.id, patch)}
-            updateInlineAnalysis={(patch) => designer.updateInlineAnalysis(designer.selectedWidget!.id, patch)}
-            changeDataset={(datasetId) => designer.changeWidgetDataset(designer.selectedWidget!.id, datasetId)}
-            detachAnalysis={() => designer.detachAnalysis(designer.selectedWidget!.id)}
+            updateWidget={(patch) =>
+              designer.updateWidget(designer.selectedWidget!.id, patch)}
+            updateInlineAnalysis={(patch) =>
+              designer.updateInlineAnalysis(designer.selectedWidget!.id, patch)}
+            changeDataset={(datasetId) =>
+              designer.changeWidgetDataset(designer.selectedWidget!.id, datasetId)}
+            detachAnalysis={() =>
+              designer.detachAnalysis(designer.selectedWidget!.id)}
             close={() => designer.setSelectedId(undefined)}
           />
         ) : null}
       </div>
 
       <style>{`
-        .dashboard-grid-canvas { background-color: #fff; background-image: linear-gradient(to right, rgba(15,23,42,.035) 1px, transparent 1px), linear-gradient(to bottom, rgba(15,23,42,.035) 1px, transparent 1px); background-size: calc(100% / 24) 36px; }
-        .react-grid-item.react-grid-placeholder { background: var(--yak-brand-color-soft) !important; border: 1px dashed var(--yak-brand-color) !important; opacity: 1 !important; }
-        .react-grid-item > .react-resizable-handle::after { border-color: #98a2b3 !important; border-width: 0 1px 1px 0 !important; height: 6px !important; width: 6px !important; }
-        .dashboard-config-tabs > .ant-tabs-nav { margin: 0 !important; padding: 0 12px; }
-        .dashboard-config-tabs .ant-tabs-tab { padding: 9px 0 !important; font-size: 12px; }
+        .dashboard-grid-canvas {
+          background-color: #fff;
+          background-image:
+            linear-gradient(to right, rgba(15,23,42,.035) 1px, transparent 1px),
+            linear-gradient(to bottom, rgba(15,23,42,.035) 1px, transparent 1px);
+          background-size: calc(100% / 24) 36px;
+        }
+        .react-grid-item.react-grid-placeholder {
+          background: var(--yak-brand-color-soft) !important;
+          border: 1px dashed var(--yak-brand-color) !important;
+          opacity: 1 !important;
+        }
+        .react-grid-item > .react-resizable-handle::after {
+          border-color: #98a2b3 !important;
+          border-width: 0 1px 1px 0 !important;
+          height: 6px !important;
+          width: 6px !important;
+        }
+        .dashboard-config-tabs > .ant-tabs-nav {
+          margin: 0 !important;
+          padding: 0 12px;
+        }
+        .dashboard-config-tabs .ant-tabs-tab {
+          padding: 9px 0 !important;
+          font-size: 12px;
+        }
       `}</style>
     </div>
   );

--- a/yak-ops-ui/src/pages/dashboard/left-panel.tsx
+++ b/yak-ops-ui/src/pages/dashboard/left-panel.tsx
@@ -1,79 +1,33 @@
-import type { AnalysisAsset } from '@/components/analysis/model';
-import { history } from '@umijs/max';
-import { Button, Empty, Select, Spin } from 'antd';
-import { Database, FileBarChart, Hash, Layers3, Plus, RefreshCw } from 'lucide-react';
-import { CHART_META, FIELD_DRAG_MIME } from './helpers';
-import type { ChartType, DashboardWidget, DatasetField, PublishedDataset } from './model';
-
-function FieldRow({ field, onAdd }: { field: DatasetField; onAdd: () => void }) {
-  const isMetric = field.role === 'metric';
-  return (
-    <div
-      draggable
-      onDragStart={(event) => {
-        event.dataTransfer.effectAllowed = 'copy';
-        event.dataTransfer.setData(FIELD_DRAG_MIME, JSON.stringify({ field: field.key, role: field.role }));
-      }}
-      className="group flex h-8 cursor-grab items-center gap-2 rounded-[4px] px-2 text-[12px] text-[#475467] hover:bg-[#f5f6f7] active:cursor-grabbing"
-      title={field.description}
-    >
-      <span className={isMetric ? 'text-[#667085]' : 'text-[#98a2b3]'}>
-        {isMetric ? <Hash size={13} /> : <Layers3 size={13} />}
-      </span>
-      <span className="min-w-0 flex-1 truncate">{field.label}</span>
-      <span className="text-[10px] text-[#b0b7c3]">{field.dataType}</span>
-      <button
-        type="button"
-        aria-label={`添加${field.label}`}
-        onClick={onAdd}
-        className="flex h-5 w-5 items-center justify-center border-0 bg-transparent text-[#98a2b3] opacity-0 group-hover:opacity-100 hover:text-[#344054]"
-      >
-        <Plus size={12} />
-      </button>
-    </div>
-  );
-}
+import { Button, Select, Spin } from 'antd';
+import { Database, Plus, RefreshCw } from 'lucide-react';
+import { CHART_META } from './helpers';
+import type { ChartType, PublishedDataset } from './model';
 
 export function LeftPanel({
   datasets,
   activeDataset,
   datasetsLoading,
   datasetsError,
-  analyses,
-  analysesLoading,
-  analysesError,
-  selectedWidget,
   onDatasetChange,
   onRefreshDatasets,
-  onRefreshAnalyses,
   onAddChart,
-  onAddAnalysis,
-  onAddField,
 }: {
   datasets: PublishedDataset[];
   activeDataset?: PublishedDataset;
   datasetsLoading: boolean;
   datasetsError: string;
-  analyses: AnalysisAsset[];
-  analysesLoading: boolean;
-  analysesError: string;
-  selectedWidget?: DashboardWidget;
   onDatasetChange: (datasetId: string) => void;
   onRefreshDatasets: () => void;
-  onRefreshAnalyses: () => void;
   onAddChart: (type: ChartType) => void;
-  onAddAnalysis: (analysisId: string) => void;
-  onAddField: (field: DatasetField) => void;
 }) {
-  const dimensions = activeDataset?.fields.filter((field) => field.role === 'dimension') ?? [];
-  const metrics = activeDataset?.fields.filter((field) => field.role === 'metric') ?? [];
-  const datasetMap = new Map(datasets.map((item) => [item.id, item]));
-
   return (
-    <aside className="flex w-[276px] shrink-0 flex-col border-r border-[#e5e7eb] bg-white">
+    <aside className="flex w-[244px] shrink-0 flex-col border-r border-[#e5e7eb] bg-white">
       <div className="border-b border-[#edf0f3] p-3">
         <div className="mb-2 flex items-center justify-between gap-2 text-[12px] font-semibold text-[#344054]">
-          <span className="flex items-center gap-2"><Database size={14} /> 数据集</span>
+          <span className="flex items-center gap-2">
+            <Database size={14} />
+            数据集
+          </span>
           <Button
             type="text"
             size="small"
@@ -82,6 +36,7 @@ export function LeftPanel({
             onClick={onRefreshDatasets}
           />
         </div>
+
         <Select
           size="small"
           className="w-full"
@@ -92,97 +47,57 @@ export function LeftPanel({
           options={datasets.map((item) => ({ label: item.name, value: item.id }))}
           notFoundContent={datasetsLoading ? <Spin size="small" /> : '暂无 ONLINE Dataset'}
         />
+
         {activeDataset ? (
-          <div className="mt-2 rounded-[4px] bg-[#f7f8fa] px-2.5 py-2 text-[10px] leading-4 text-[#667085]">
-            <div className="flex items-center justify-between gap-2">
-              <span className="truncate">来源：{activeDataset.sourceTaskName}</span>
-              <span className="shrink-0 text-[#98a2b3]">DV{activeDataset.currentVersionNo ?? '-'}</span>
-            </div>
-            <div className="mt-0.5 truncate text-[#98a2b3]">
-              {activeDataset.fields.length} 个字段 · {activeDataset.updatedAt || '暂无更新时间'}
+          <div className="mt-2 px-0.5 text-[10px] leading-4 text-[#98a2b3]">
+            <div className="truncate">{activeDataset.sourceTaskName || '未标记来源任务'}</div>
+            <div className="mt-0.5 truncate">
+              {activeDataset.fields.length} 个字段 · DV{activeDataset.currentVersionNo ?? '-'}
             </div>
           </div>
         ) : datasetsError ? (
-          <div className="mt-2 rounded-[4px] bg-[#f7f8fa] px-2.5 py-2 text-[10px] leading-4 text-[#98a2b3]">
+          <div className="mt-2 text-[10px] leading-4 text-[#98a2b3]">
             {datasetsError}
           </div>
         ) : null}
       </div>
 
-      <div className="min-h-0 flex-1 overflow-y-auto px-3 py-2">
-        <div className="mb-2 flex items-center justify-between border-b border-[#edf0f3] pb-2 pt-1">
-          <span className="flex items-center gap-1.5 text-[10px] font-medium uppercase tracking-wide text-[#98a2b3]">
-            <FileBarChart size={12} /> 复用分析
-          </span>
-          <div className="flex items-center gap-0.5">
-            <Button type="text" size="small" icon={<RefreshCw size={11} />} loading={analysesLoading} onClick={onRefreshAnalyses} />
-            <Button type="link" size="small" className="px-1 text-[10px]" onClick={() => history.push('/data-analysis/chart-analysis')}>管理</Button>
+      <div className="min-h-0 flex-1 overflow-y-auto p-3">
+        <div className="mb-2">
+          <div className="text-[12px] font-semibold text-[#344054]">添加图表</div>
+          <div className="mt-0.5 text-[10px] leading-4 text-[#98a2b3]">
+            选择类型后添加到画布，数据与样式在图表配置中完成
           </div>
         </div>
-        {analysesError ? <div className="mb-2 text-[10px] text-[#b42318]">{analysesError}</div> : null}
-        {!analysesLoading && !analyses.length ? (
-          <div className="mb-3 rounded-[4px] border border-dashed border-[#d8dde6] px-2.5 py-2 text-[10px] leading-4 text-[#98a2b3]">
-            暂无 Analysis，可在图表分析中创建，也可先新建图表再保存为 Analysis。
-          </div>
-        ) : null}
+
         <div className="space-y-1">
-          {analyses.map((analysis) => {
-            const source = datasetMap.get(analysis.datasetId);
-            const usable = Boolean(source);
-            return (
-              <div key={analysis.id} className="group flex items-center gap-2 rounded-[4px] px-2 py-1.5 hover:bg-[#f7f8fa]">
-                <FileBarChart size={12} className="shrink-0 text-[#667085]" />
-                <div className="min-w-0 flex-1">
-                  <div className="truncate text-[11px] text-[#475467]">{analysis.name}</div>
-                  <div className="truncate text-[9px] text-[#a0a7b2]">{source?.name ?? 'Dataset 不可用'}</div>
-                </div>
-                <button
-                  type="button"
-                  disabled={!usable}
-                  aria-label={`添加${analysis.name}`}
-                  onClick={() => onAddAnalysis(analysis.id)}
-                  className="flex h-5 w-5 items-center justify-center border-0 bg-transparent text-[#98a2b3] opacity-0 enabled:group-hover:opacity-100 enabled:hover:text-[#344054] disabled:cursor-not-allowed"
-                >
-                  <Plus size={12} />
-                </button>
-              </div>
-            );
-          })}
-        </div>
-
-        <div className="mb-1 mt-4 flex items-center justify-between border-t border-[#edf0f3] px-1 pt-4 text-[10px] font-medium uppercase tracking-wide text-[#98a2b3]">
-          <span>维度</span><span>{dimensions.length}</span>
-        </div>
-        {!activeDataset && !datasetsLoading ? (
-          <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="先发布一个 Dataset" className="my-5" />
-        ) : null}
-        {dimensions.map((field) => <FieldRow key={field.key} field={field} onAdd={() => onAddField(field)} />)}
-
-        <div className="mb-1 mt-4 flex items-center justify-between px-1 text-[10px] font-medium uppercase tracking-wide text-[#98a2b3]">
-          <span>指标</span><span>{metrics.length}</span>
-        </div>
-        {metrics.map((field) => <FieldRow key={field.key} field={field} onAdd={() => onAddField(field)} />)}
-
-        <div className="mb-2 mt-5 border-t border-[#edf0f3] pt-4 text-[10px] font-medium uppercase tracking-wide text-[#98a2b3]">
-          新建图表
-        </div>
-        <div className="grid grid-cols-2 gap-2">
           {(Object.keys(CHART_META) as ChartType[]).map((type) => (
             <button
               key={type}
               type="button"
               disabled={!activeDataset}
               onClick={() => onAddChart(type)}
-              className="flex min-h-[62px] flex-col items-start justify-center rounded-[5px] border border-[#e5e7eb] bg-white px-3 text-left enabled:hover:border-[#cbd2dc] enabled:hover:bg-[#fafbfc] disabled:cursor-not-allowed disabled:opacity-40"
+              className="group flex h-11 w-full items-center gap-2.5 rounded-[5px] border-0 bg-transparent px-2 text-left enabled:hover:bg-[#f5f6f7] disabled:cursor-not-allowed disabled:opacity-40"
             >
-              <span className="mb-1 text-[#475467]">{CHART_META[type].icon}</span>
-              <span className="text-[11px] font-medium text-[#344054]">{CHART_META[type].label}</span>
+              <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-[4px] bg-[#f5f6f7] text-[#667085] group-hover:bg-white">
+                {CHART_META[type].icon}
+              </span>
+              <span className="min-w-0 flex-1">
+                <span className="block text-[11px] font-medium text-[#344054]">
+                  {CHART_META[type].label}
+                </span>
+                <span className="mt-0.5 block truncate text-[9px] text-[#98a2b3]">
+                  {CHART_META[type].description}
+                </span>
+              </span>
+              <Plus size={12} className="shrink-0 text-[#b0b7c3]" />
             </button>
           ))}
         </div>
-        {!selectedWidget && activeDataset ? (
-          <div className="mt-4 rounded-[4px] border border-dashed border-[#d8dde6] px-3 py-2 text-[10px] leading-4 text-[#98a2b3]">
-            可直接复用 Analysis，也可新建临时图表；临时图表可以一键沉淀为可复用分析资产。
+
+        {!activeDataset && !datasetsLoading ? (
+          <div className="mt-4 border-t border-[#edf0f3] pt-3 text-[10px] leading-4 text-[#98a2b3]">
+            先选择一个已上线的数据集，再开始搭建仪表盘。
           </div>
         ) : null}
       </div>

--- a/yak-ops-ui/src/pages/dashboard/selected-config.tsx
+++ b/yak-ops-ui/src/pages/dashboard/selected-config.tsx
@@ -1,7 +1,6 @@
 import type { AnalysisSpec } from '@/components/analysis/model';
-import { history } from '@umijs/max';
 import { Button } from 'antd';
-import { Link2, PanelRight, X } from 'lucide-react';
+import { PanelRight, X } from 'lucide-react';
 import { ConfigPanel } from './config-panel';
 import { findDataset } from './helpers';
 import type {
@@ -35,38 +34,57 @@ export function SelectedConfig({
 }) {
   if (widget.analysisId) {
     const analysis = analyses.find((item) => item.id === widget.analysisId);
-    const dataset = analysis ? datasets.find((item) => item.id === analysis.datasetId) : undefined;
+    const dataset = analysis
+      ? datasets.find((item) => item.id === analysis.datasetId)
+      : undefined;
+
     return (
-      <aside className="flex w-[320px] shrink-0 flex-col border-l border-[#e5e7eb] bg-white">
+      <aside className="flex w-[304px] shrink-0 flex-col border-l border-[#e5e7eb] bg-white">
         <div className="flex h-11 shrink-0 items-center justify-between border-b border-[#edf0f3] px-3">
           <div className="flex items-center gap-2 text-[12px] font-semibold text-[#344054]">
-            <PanelRight size={14} />图表配置
+            <PanelRight size={14} />
+            图表配置
           </div>
-          <button type="button" onClick={close} className="flex h-7 w-7 items-center justify-center border-0 bg-transparent text-[#667085] hover:bg-[#f5f6f7]">
+          <button
+            type="button"
+            onClick={close}
+            className="flex h-7 w-7 items-center justify-center border-0 bg-transparent text-[#667085] hover:bg-[#f5f6f7]"
+            aria-label="关闭图表配置"
+          >
             <X size={14} />
           </button>
         </div>
+
         <div className="p-3">
-          <div className="flex items-center gap-2 rounded-[5px] border border-[#e5e7eb] bg-[#fafbfc] p-3">
-            <Link2 size={15} className="shrink-0 text-[#667085]" />
-            <div className="min-w-0 flex-1">
-              <div className="truncate text-[11px] font-medium text-[#344054]">{analysis?.name ?? `Analysis #${widget.analysisId}`}</div>
-              <div className="mt-0.5 text-[9px] text-[#98a2b3]">共享 Analysis · {dataset?.name ?? '来源不可用'}</div>
+          <div className="rounded-[5px] border border-[#e5e7eb] bg-[#fafbfc] p-3">
+            <div className="truncate text-[11px] font-medium text-[#344054]">
+              {analysis?.name ?? '历史图表'}
+            </div>
+            <div className="mt-0.5 text-[9px] text-[#98a2b3]">
+              共享图表 · {dataset?.name ?? '数据来源不可用'}
             </div>
           </div>
+
           <div className="mt-3 text-[10px] leading-5 text-[#667085]">
-            该组件只保存 analysisId 与布局。Dataset、维度、指标、过滤、排序和图表样式由 Analysis 统一维护，不在 Dashboard 中复制一份定义。
+            这是由历史共享资产创建的图表，当前保持只读引用。需要修改数据、查询或样式时，
+            可先复制为当前仪表盘的独立图表。
           </div>
+
           {!analysis ? (
             <div className="mt-3 rounded-[4px] border border-[#fecdca] bg-[#fffbfa] px-2.5 py-2 text-[10px] text-[#b42318]">
-              引用的 Analysis 已删除或当前不可访问。刷新 Analysis 库后仍不存在时，请删除此组件或恢复对应 Analysis。
+              图表数据来源已删除或当前不可访问。
             </div>
           ) : null}
-          <Button block size="small" className="mt-4" onClick={() => history.push('/data-analysis/chart-analysis')}>
-            打开图表分析
-          </Button>
-          <Button block size="small" className="mt-2" disabled={!analysis} onClick={detachAnalysis}>
-            解除引用并复制为独立图表
+
+          <Button
+            block
+            size="small"
+            type="primary"
+            className="mt-4"
+            disabled={!analysis}
+            onClick={detachAnalysis}
+          >
+            复制为可编辑图表
           </Button>
         </div>
       </aside>
@@ -78,9 +96,14 @@ export function SelectedConfig({
   const dataset = findDataset(datasets, spec.datasetId);
   if (!dataset) return null;
 
-  const dimensionOptions = dataset.fields.filter((field) => field.role === 'dimension').map((field) => ({ label: field.label, value: field.key }));
-  const metricOptions = dataset.fields.filter((field) => field.role === 'metric').map((field) => ({ label: field.label, value: field.key }));
-  const filterOptions = dataset.fields.map((field) => ({ label: field.label, value: field.key }));
+  const dimensionOptions = dataset.fields
+    .filter((field) => field.role === 'dimension')
+    .map((field) => ({ label: field.label, value: field.key }));
+  const metricOptions = dataset.fields
+    .filter((field) => field.role === 'metric')
+    .map((field) => ({ label: field.label, value: field.key }));
+  const filterOptions = dataset.fields
+    .map((field) => ({ label: field.label, value: field.key }));
   const selectedFields = new Set([
     ...spec.dimensions,
     ...spec.metrics.map((metric) => metric.field),
@@ -88,7 +111,9 @@ export function SelectedConfig({
   const sortOptions = dataset.fields
     .filter((field) => selectedFields.has(field.key))
     .map((field) => ({ label: field.label, value: field.key }));
-  const metricLabels = Object.fromEntries(dataset.fields.map((field) => [field.key, field.label]));
+  const metricLabels = Object.fromEntries(
+    dataset.fields.map((field) => [field.key, field.label]),
+  );
   const filter = spec.filters[0];
 
   return (
@@ -96,7 +121,10 @@ export function SelectedConfig({
       spec={spec}
       title={widget.title || '未命名图表'}
       widget={widget}
-      datasetOptions={datasets.map((item) => ({ label: item.name, value: item.id }))}
+      datasetOptions={datasets.map((item) => ({
+        label: item.name,
+        value: item.id,
+      }))}
       dimensionOptions={dimensionOptions}
       metricOptions={metricOptions}
       sortOptions={sortOptions}
@@ -107,38 +135,58 @@ export function SelectedConfig({
       onLayout={updateWidget}
       onDataset={changeDataset}
       onDimensions={(dimensions) => {
-        const nextSort = spec.sort && !dimensions.includes(spec.sort.field)
+        const nextSort = spec.sort
+          && !dimensions.includes(spec.sort.field)
           && !spec.metrics.some((metric) => metric.field === spec.sort?.field)
           ? undefined
           : spec.sort;
         updateInlineAnalysis({ dimensions, sort: nextSort });
       }}
       onMetrics={(fields) => {
-        const previous = new Map(spec.metrics.map((metric) => [metric.field, metric]));
-        const metrics: MetricBinding[] = fields.map((field) => previous.get(field) ?? { field, aggregation: 'SUM' });
-        const nextSort = spec.sort && !spec.dimensions.includes(spec.sort.field)
+        const previous = new Map(
+          spec.metrics.map((metric) => [metric.field, metric]),
+        );
+        const metrics: MetricBinding[] = fields.map(
+          (field) => previous.get(field) ?? { field, aggregation: 'SUM' },
+        );
+        const nextSort = spec.sort
+          && !spec.dimensions.includes(spec.sort.field)
           && !metrics.some((metric) => metric.field === spec.sort?.field)
           ? undefined
           : spec.sort;
         updateInlineAnalysis({ metrics, sort: nextSort });
       }}
-      onAggregation={(field: string, aggregation: Aggregation) => updateInlineAnalysis({
-        metrics: spec.metrics.map((metric) => metric.field === field ? { ...metric, aggregation } : metric),
-      })}
-      onSortField={(field?: string) => updateInlineAnalysis({
-        sort: field ? { field, direction: spec.sort?.direction ?? 'asc' } : undefined,
-      })}
-      onSortDirection={(direction: SortDirection) => spec.sort && updateInlineAnalysis({ sort: { ...spec.sort, direction } })}
-      onFilterField={(field?: string) => updateInlineAnalysis({
-        filters: field ? [{
-          id: filter?.id ?? 'filter-main',
-          field,
-          operator: filter?.operator ?? 'eq',
-          value: filter?.value ?? '',
-        }] : [],
-      })}
-      onFilterOperator={(operator: FilterOperator) => filter && updateInlineAnalysis({ filters: [{ ...filter, operator }] })}
-      onFilterValue={(value) => filter && updateInlineAnalysis({ filters: [{ ...filter, value }] })}
+      onAggregation={(field: string, aggregation: Aggregation) =>
+        updateInlineAnalysis({
+          metrics: spec.metrics.map((metric) =>
+            metric.field === field ? { ...metric, aggregation } : metric),
+        })}
+      onSortField={(field?: string) =>
+        updateInlineAnalysis({
+          sort: field
+            ? { field, direction: spec.sort?.direction ?? 'asc' }
+            : undefined,
+        })}
+      onSortDirection={(direction: SortDirection) =>
+        spec.sort
+        && updateInlineAnalysis({ sort: { ...spec.sort, direction } })}
+      onFilterField={(field?: string) =>
+        updateInlineAnalysis({
+          filters: field
+            ? [{
+              id: filter?.id ?? 'filter-main',
+              field,
+              operator: filter?.operator ?? 'eq',
+              value: filter?.value ?? '',
+            }]
+            : [],
+        })}
+      onFilterOperator={(operator: FilterOperator) =>
+        filter
+        && updateInlineAnalysis({ filters: [{ ...filter, operator }] })}
+      onFilterValue={(value) =>
+        filter
+        && updateInlineAnalysis({ filters: [{ ...filter, value }] })}
       onClose={close}
     />
   );

--- a/yak-ops-ui/src/pages/dashboard/toolbar.tsx
+++ b/yak-ops-ui/src/pages/dashboard/toolbar.tsx
@@ -1,3 +1,4 @@
+import { history } from '@umijs/max';
 import { Button, Input, Select, Tooltip } from 'antd';
 import { ChevronLeft, Eye, History, Plus, Save, X } from 'lucide-react';
 import type { DashboardSummary, DashboardVersionSummary } from './model';
@@ -34,10 +35,19 @@ export function DashboardToolbar({
   onSave: () => void;
 }) {
   const persisted = /^\d+$/.test(dashboardId);
+
   return (
     <header className="flex h-12 shrink-0 items-center justify-between border-b border-[#dfe3e8] bg-white px-3">
       <div className="flex min-w-0 items-center gap-2">
-        <Button size="small" type="text" icon={<ChevronLeft size={14} />} disabled={preview}>数据分析</Button>
+        <Button
+          size="small"
+          type="text"
+          icon={<ChevronLeft size={14} />}
+          disabled={preview}
+          onClick={() => history.push('/data-analysis/data-catalog')}
+        >
+          数据目录
+        </Button>
         <span className="h-5 w-px bg-[#e5e7eb]" />
         <Select
           size="small"
@@ -50,7 +60,13 @@ export function DashboardToolbar({
           onChange={onDashboard}
         />
         <Tooltip title="新建仪表盘">
-          <Button size="small" type="text" icon={<Plus size={13} />} disabled={preview} onClick={onNew} />
+          <Button
+            size="small"
+            type="text"
+            icon={<Plus size={13} />}
+            disabled={preview}
+            onClick={onNew}
+          />
         </Tooltip>
         <span className="h-5 w-px bg-[#e5e7eb]" />
         <Input
@@ -64,6 +80,7 @@ export function DashboardToolbar({
           {currentVersionNo ? `V${currentVersionNo}` : '未保存'}
         </span>
       </div>
+
       <div className="flex items-center gap-2">
         {persisted && versions.length ? (
           <Select
@@ -72,15 +89,28 @@ export function DashboardToolbar({
             suffixIcon={<History size={12} />}
             disabled={preview || saving}
             value={currentVersionNo}
-            options={versions.map((item) => ({ label: `版本 V${item.versionNo}`, value: item.versionNo }))}
+            options={versions.map((item) => ({
+              label: `版本 V${item.versionNo}`,
+              value: item.versionNo,
+            }))}
             onChange={onVersion}
           />
         ) : null}
-        <Button size="small" icon={preview ? <X size={13} /> : <Eye size={13} />} onClick={onPreview}>
+        <Button
+          size="small"
+          icon={preview ? <X size={13} /> : <Eye size={13} />}
+          onClick={onPreview}
+        >
           {preview ? '退出预览' : '预览'}
         </Button>
         {!preview ? (
-          <Button size="small" type="primary" loading={saving} icon={<Save size={13} />} onClick={onSave}>
+          <Button
+            size="small"
+            type="primary"
+            loading={saving}
+            icon={<Save size={13} />}
+            onClick={onSave}
+          >
             保存
           </Button>
         ) : null}

--- a/yak-ops-ui/src/pages/dashboard/widget.tsx
+++ b/yak-ops-ui/src/pages/dashboard/widget.tsx
@@ -1,6 +1,6 @@
 import { AnalysisPreview } from '@/components/analysis/AnalysisPreview';
 import { Empty, Tooltip } from 'antd';
-import { Copy, GripVertical, Link2, Save, Trash2 } from 'lucide-react';
+import { Copy, GripVertical, Trash2 } from 'lucide-react';
 import type {
   AnalysisAsset,
   AnalysisSelection,
@@ -20,7 +20,6 @@ export function WidgetShell({
   onDataSelect,
   onDuplicate,
   onDelete,
-  onSaveAsAnalysis,
 }: {
   widget: DashboardWidget;
   analysis?: AnalysisAsset;
@@ -32,10 +31,11 @@ export function WidgetShell({
   onDataSelect: (selection: AnalysisSelection) => void;
   onDuplicate: () => void;
   onDelete: () => void;
-  onSaveAsAnalysis: () => void;
 }) {
   const spec = widget.analysisId ? analysis : widget.inlineAnalysis;
-  const title = widget.analysisId ? analysis?.name ?? `Analysis #${widget.analysisId}` : widget.title ?? '未命名图表';
+  const title = widget.analysisId
+    ? analysis?.name ?? '历史图表'
+    : widget.title ?? '未命名图表';
 
   return (
     <div
@@ -51,33 +51,25 @@ export function WidgetShell({
     >
       <div className="dashboard-widget__drag-handle flex h-9 shrink-0 cursor-move items-center border-b border-[#f0f2f5] px-3">
         {!preview ? <GripVertical size={13} className="mr-1 text-[#98a2b3]" /> : null}
-        {widget.analysisId ? (
-          <Tooltip title={`引用 Analysis #${widget.analysisId}`}>
-            <Link2 size={11} className="mr-1.5 shrink-0 text-[#667085]" />
-          </Tooltip>
-        ) : null}
-        <span className="min-w-0 flex-1 truncate text-[12px] font-medium text-[#344054]">{title}</span>
-        {runtimeFilters.length ? <span className="mr-2 text-[9px] text-[#667085]">筛选 {runtimeFilters.length}</span> : null}
-        {dataset ? <span className="mr-2 text-[9px] text-[#b0b7c3]">DV{dataset.currentVersionNo ?? '-'}</span> : null}
+        <span className="min-w-0 flex-1 truncate text-[12px] font-medium text-[#344054]">
+          {title}
+        </span>
+
         {!preview ? (
-          <div className={['flex items-center gap-0.5 transition-opacity', selected ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'].join(' ')}>
-            {!widget.analysisId && widget.inlineAnalysis ? (
-              <Tooltip title="保存为图表分析">
-                <button
-                  type="button"
-                  onMouseDown={(event) => event.stopPropagation()}
-                  onClick={(event) => { event.stopPropagation(); onSaveAsAnalysis(); }}
-                  className="flex h-6 w-6 items-center justify-center border-0 bg-transparent text-[#667085] hover:bg-[#f5f6f7]"
-                >
-                  <Save size={12} />
-                </button>
-              </Tooltip>
-            ) : null}
+          <div
+            className={[
+              'flex items-center gap-0.5 transition-opacity',
+              selected ? 'opacity-100' : 'opacity-0 group-hover:opacity-100',
+            ].join(' ')}
+          >
             <Tooltip title="复制">
               <button
                 type="button"
                 onMouseDown={(event) => event.stopPropagation()}
-                onClick={(event) => { event.stopPropagation(); onDuplicate(); }}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  onDuplicate();
+                }}
                 className="flex h-6 w-6 items-center justify-center border-0 bg-transparent text-[#667085] hover:bg-[#f5f6f7]"
               >
                 <Copy size={12} />
@@ -87,7 +79,10 @@ export function WidgetShell({
               <button
                 type="button"
                 onMouseDown={(event) => event.stopPropagation()}
-                onClick={(event) => { event.stopPropagation(); onDelete(); }}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  onDelete();
+                }}
                 className="flex h-6 w-6 items-center justify-center border-0 bg-transparent text-[#667085] hover:bg-[#fff1f2] hover:text-[#d92d20]"
               >
                 <Trash2 size={12} />
@@ -96,6 +91,7 @@ export function WidgetShell({
           </div>
         ) : null}
       </div>
+
       <div className="min-h-0 flex-1 overflow-hidden">
         {spec ? (
           <AnalysisPreview
@@ -105,7 +101,11 @@ export function WidgetShell({
             onSelect={onDataSelect}
           />
         ) : (
-          <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="Analysis 引用已失效" className="mt-8" />
+          <Empty
+            image={Empty.PRESENTED_IMAGE_SIMPLE}
+            description="图表数据来源已失效"
+            className="mt-8"
+          />
         )}
       </div>
     </div>


### PR DESCRIPTION
## Summary

PR2 聚焦 Dashboard Core Canvas 瘦身，把仪表盘工作区从“多能力工作台”收敛成更直接的搭建流程：

`选择 Dataset → 添加图表 → 配置图表 → 拖拽排版 → 预览 / 保存`

### Core Canvas

- 左侧面板从 276px 收窄到 244px
- 移除核心工作区中的 Analysis 复用列表
- 移除维度 / 指标字段拖拽区，字段配置继续由右侧图表配置承接
- 左侧只保留 Dataset 选择与图表类型入口
- 重做空画布提示，直接引导“添加第一个图表”
- 根据预览态 / 筛选条动态调整画布最小高度

### Filter / Interaction

- 删除 Core Canvas 中复杂的“全局筛选器与组件联动”管理 Drawer
- 没有全局筛选时不再占用顶部空间
- 已存在的 DashboardGlobalFilter 仍保留轻量运行态输入与重置能力
- DashboardGlobalFilter / DashboardInteraction 数据结构、版本数据和运行逻辑不删除，历史 Dashboard 继续兼容

### Legacy Analysis compatibility

- Dashboard Widget 不再展示 Analysis 链接标识、Analysis 保存入口、DatasetVersion 等内部信息
- 历史 analysisId Widget 仍能正常渲染
- 右侧兼容态统一使用“历史共享图表”用户语言
- 历史共享图表可“复制为可编辑图表”，底层 detachAnalysis 能力继续复用

### Toolbar

- 原顶部无行为的“数据分析”返回入口调整为“数据目录”
- 返回后统一进入 `/data-analysis/data-catalog`
- 仪表盘切换、新建、版本、预览、保存能力保持不变

## Scope

这是 BI 瘦身计划的 PR2，只处理 **Dashboard Core Canvas**。

本 PR不删除：

- Analysis API / Domain
- Dataset Query Runtime
- Dashboard 保存与版本能力
- React Grid Layout 拖拽 / 缩放能力
- DashboardGlobalFilter / DashboardInteraction Domain 与历史数据兼容
- 当前右侧 ConfigPanel

Chart Editor 内嵌和右侧配置区的进一步重构留给 PR3。

## Verification

- 分支基于 PR1 合并后的最新 `main`
- 相对 `main` 仅 1 个提交、6 个 Dashboard 文件变更
- 使用 TypeScript 5.8 对改动文件做 TSX 静态解析；未发现可识别的语法、组件参数或 JSX 结构错误
- 当前执行环境没有安装 yak-ops-ui 依赖，因此未运行完整 `npm run tsc` / `npm run lint`；PR 创建后继续以仓库 CI 结果为准