### PR TITLE
refactor: 内嵌 Dashboard Chart Editor

### DIFF
--- a/yak-ops-ui/src/pages/dashboard/chart-editor.tsx
+++ b/yak-ops-ui/src/pages/dashboard/chart-editor.tsx
@@ -1,0 +1,353 @@
+import type { AnalysisSpec } from '@/components/analysis/model';
+import { Button, Collapse, Input, Select, Switch } from 'antd';
+import { ChevronDown, SlidersHorizontal, X } from 'lucide-react';
+import { ConfigData } from './config-data';
+import { MetricAggregations } from './config-metrics';
+import { QueryControls } from './config-query';
+import { CHART_META, findDataset } from './helpers';
+import type {
+  Aggregation,
+  AnalysisAsset,
+  ChartType,
+  DashboardWidget,
+  FilterOperator,
+  MetricBinding,
+  PublishedDataset,
+  SortDirection,
+} from './model';
+
+export function ChartEditor({
+  widget,
+  datasets,
+  analyses,
+  updateWidget,
+  updateInlineAnalysis,
+  changeDataset,
+  detachAnalysis,
+  close,
+}: {
+  widget: DashboardWidget;
+  datasets: PublishedDataset[];
+  analyses: AnalysisAsset[];
+  updateWidget: (patch: Partial<DashboardWidget>) => void;
+  updateInlineAnalysis: (patch: Partial<AnalysisSpec>) => void;
+  changeDataset: (datasetId: string) => void;
+  detachAnalysis: () => void;
+  close: () => void;
+}) {
+  if (widget.analysisId) {
+    const analysis = analyses.find((item) => item.id === widget.analysisId);
+    const dataset = analysis
+      ? datasets.find((item) => item.id === analysis.datasetId)
+      : undefined;
+
+    return (
+      <aside className="flex w-[368px] shrink-0 flex-col border-l border-[#e5e7eb] bg-white">
+        <EditorHeader onClose={close} />
+        <div className="p-4">
+          <div className="rounded-[6px] border border-[#e5e7eb] bg-[#fafbfc] p-3">
+            <div className="truncate text-[12px] font-medium text-[#344054]">
+              {analysis?.name ?? '历史图表'}
+            </div>
+            <div className="mt-1 text-[10px] text-[#98a2b3]">
+              历史共享图表 · {dataset?.name ?? '数据来源不可用'}
+            </div>
+          </div>
+          <div className="mt-3 text-[11px] leading-5 text-[#667085]">
+            这个图表来自旧版共享资产。复制为当前仪表盘图表后，即可使用新的 Chart Editor 编辑数据和样式。
+          </div>
+          {!analysis ? (
+            <div className="mt-3 rounded-[4px] border border-[#fecdca] bg-[#fffbfa] px-2.5 py-2 text-[10px] text-[#b42318]">
+              图表数据来源已删除或当前不可访问。
+            </div>
+          ) : null}
+          <Button
+            block
+            size="small"
+            type="primary"
+            className="mt-4"
+            disabled={!analysis}
+            onClick={detachAnalysis}
+          >
+            复制为可编辑图表
+          </Button>
+        </div>
+      </aside>
+    );
+  }
+
+  const spec = widget.inlineAnalysis;
+  if (!spec) return null;
+  const dataset = findDataset(datasets, spec.datasetId);
+  if (!dataset) return null;
+
+  const dimensionOptions = dataset.fields
+    .filter((field) => field.role === 'dimension')
+    .map((field) => ({ label: field.label, value: field.key }));
+  const metricOptions = dataset.fields
+    .filter((field) => field.role === 'metric')
+    .map((field) => ({ label: field.label, value: field.key }));
+  const filterOptions = dataset.fields.map((field) => ({
+    label: field.label,
+    value: field.key,
+  }));
+  const selectedFields = new Set([
+    ...spec.dimensions,
+    ...spec.metrics.map((metric) => metric.field),
+  ]);
+  const sortOptions = dataset.fields
+    .filter((field) => selectedFields.has(field.key))
+    .map((field) => ({ label: field.label, value: field.key }));
+  const metricLabels = Object.fromEntries(
+    dataset.fields.map((field) => [field.key, field.label]),
+  );
+  const filter = spec.filters[0];
+
+  const changeType = (type: ChartType) => {
+    const dimensionLimit = type === 'table' ? 3 : 1;
+    const metricLimit = ['bar', 'line', 'table'].includes(type) ? 3 : 1;
+    updateInlineAnalysis({
+      type,
+      dimensions: type === 'metric' ? [] : spec.dimensions.slice(0, dimensionLimit),
+      metrics: spec.metrics.slice(0, metricLimit),
+      sort: undefined,
+      style: {
+        ...spec.style,
+        showLegend: type === 'pie' ? true : spec.style.showLegend,
+        smooth: type === 'line' ? spec.style.smooth : false,
+        showGrid: type === 'line' || type === 'bar' ? spec.style.showGrid : false,
+      },
+      limit: type === 'table' ? 200 : 500,
+    });
+  };
+
+  const onDimensions = (dimensions: string[]) => {
+    const nextSort = spec.sort
+      && !dimensions.includes(spec.sort.field)
+      && !spec.metrics.some((metric) => metric.field === spec.sort?.field)
+      ? undefined
+      : spec.sort;
+    updateInlineAnalysis({ dimensions, sort: nextSort });
+  };
+
+  const onMetrics = (fields: string[]) => {
+    const previous = new Map(spec.metrics.map((metric) => [metric.field, metric]));
+    const metrics: MetricBinding[] = fields.map(
+      (field) => previous.get(field) ?? { field, aggregation: 'SUM' },
+    );
+    const nextSort = spec.sort
+      && !spec.dimensions.includes(spec.sort.field)
+      && !metrics.some((metric) => metric.field === spec.sort?.field)
+      ? undefined
+      : spec.sort;
+    updateInlineAnalysis({ metrics, sort: nextSort });
+  };
+
+  const updateStyle = (patch: Partial<AnalysisSpec['style']>) =>
+    updateInlineAnalysis({ style: { ...spec.style, ...patch } });
+
+  return (
+    <aside className="flex w-[368px] shrink-0 flex-col border-l border-[#e5e7eb] bg-white">
+      <EditorHeader onClose={close} />
+
+      <div className="min-h-0 flex-1 overflow-y-auto px-4 py-3">
+        <label className="mb-1 block text-[11px] font-medium text-[#667085]">
+          图表标题
+        </label>
+        <Input
+          size="small"
+          value={widget.title || ''}
+          placeholder="未命名图表"
+          onChange={(event) => updateWidget({ title: event.target.value })}
+        />
+
+        <div className="mt-4 border-t border-[#edf0f3] pt-4">
+          <div className="mb-1 text-[11px] font-medium text-[#667085]">数据集</div>
+          <Select
+            size="small"
+            className="w-full"
+            value={spec.datasetId}
+            options={datasets.map((item) => ({ label: item.name, value: item.id }))}
+            onChange={changeDataset}
+          />
+        </div>
+
+        <div className="mt-4">
+          <div className="mb-2 text-[11px] font-medium text-[#667085]">图表类型</div>
+          <div className="grid grid-cols-5 gap-1.5">
+            {(Object.keys(CHART_META) as ChartType[]).map((type) => {
+              const active = spec.type === type;
+              return (
+                <button
+                  key={type}
+                  type="button"
+                  onClick={() => changeType(type)}
+                  className={[
+                    'flex min-w-0 flex-col items-center justify-center gap-1 rounded-[5px] border px-1 py-2 text-[10px] transition-colors',
+                    active
+                      ? 'border-[#cfd4dc] bg-[#f5f6f7] font-medium text-[#161823]'
+                      : 'border-[#edf0f3] bg-white text-[#667085] hover:bg-[#fafbfc]',
+                  ].join(' ')}
+                >
+                  <span className={active ? 'text-[#344054]' : 'text-[#98a2b3]'}>
+                    {CHART_META[type].icon}
+                  </span>
+                  <span className="truncate">{CHART_META[type].label}</span>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        <div className="mt-4 border-t border-[#edf0f3] pt-4">
+          <ConfigData
+            spec={spec}
+            dimensionOptions={dimensionOptions}
+            metricOptions={metricOptions}
+            onDimensions={onDimensions}
+            onMetrics={onMetrics}
+          />
+          <MetricAggregations
+            metrics={spec.metrics}
+            labels={metricLabels}
+            onChange={(field: string, aggregation: Aggregation) =>
+              updateInlineAnalysis({
+                metrics: spec.metrics.map((metric) =>
+                  metric.field === field ? { ...metric, aggregation } : metric),
+              })}
+          />
+        </div>
+
+        <Collapse
+          ghost
+          className="chart-editor-more mt-3 border-t border-[#edf0f3] pt-1"
+          expandIconPosition="end"
+          expandIcon={({ isActive }) => (
+            <ChevronDown
+              size={13}
+              className={isActive ? 'rotate-180 text-[#667085]' : 'text-[#98a2b3]'}
+            />
+          )}
+          items={[
+            {
+              key: 'advanced',
+              label: (
+                <span className="flex items-center gap-1.5 text-[11px] font-medium text-[#667085]">
+                  <SlidersHorizontal size={12} />
+                  更多设置
+                </span>
+              ),
+              children: (
+                <div className="pb-2">
+                  <div className="space-y-3 text-[11px] text-[#475467]">
+                    {spec.type !== 'metric' && spec.type !== 'table' ? (
+                      <label className="flex items-center justify-between">
+                        <span>显示图例</span>
+                        <Switch
+                          size="small"
+                          checked={spec.style.showLegend}
+                          onChange={(showLegend) => updateStyle({ showLegend })}
+                        />
+                      </label>
+                    ) : null}
+                    {spec.type !== 'metric' && spec.type !== 'table' ? (
+                      <label className="flex items-center justify-between">
+                        <span>显示数据标签</span>
+                        <Switch
+                          size="small"
+                          checked={spec.style.showDataLabels}
+                          onChange={(showDataLabels) => updateStyle({ showDataLabels })}
+                        />
+                      </label>
+                    ) : null}
+                    {spec.type === 'line' ? (
+                      <label className="flex items-center justify-between">
+                        <span>平滑曲线</span>
+                        <Switch
+                          size="small"
+                          checked={spec.style.smooth}
+                          onChange={(smooth) => updateStyle({ smooth })}
+                        />
+                      </label>
+                    ) : null}
+                    {spec.type === 'line' || spec.type === 'bar' ? (
+                      <label className="flex items-center justify-between">
+                        <span>显示网格线</span>
+                        <Switch
+                          size="small"
+                          checked={spec.style.showGrid}
+                          onChange={(showGrid) => updateStyle({ showGrid })}
+                        />
+                      </label>
+                    ) : null}
+                  </div>
+
+                  <QueryControls
+                    sortOptions={sortOptions}
+                    filterOptions={filterOptions}
+                    sortField={spec.sort?.field}
+                    sortDirection={spec.sort?.direction ?? 'asc'}
+                    filterField={filter?.field}
+                    filterOperator={filter?.operator ?? 'eq'}
+                    filterValue={filter?.value ?? ''}
+                    onSortField={(field?: string) =>
+                      updateInlineAnalysis({
+                        sort: field
+                          ? { field, direction: spec.sort?.direction ?? 'asc' }
+                          : undefined,
+                      })}
+                    onSortDirection={(direction: SortDirection) =>
+                      spec.sort
+                      && updateInlineAnalysis({ sort: { ...spec.sort, direction } })}
+                    onFilterField={(field?: string) =>
+                      updateInlineAnalysis({
+                        filters: field
+                          ? [{
+                            id: filter?.id ?? 'filter-main',
+                            field,
+                            operator: filter?.operator ?? 'eq',
+                            value: filter?.value ?? '',
+                          }]
+                          : [],
+                      })}
+                    onFilterOperator={(operator: FilterOperator) =>
+                      filter
+                      && updateInlineAnalysis({ filters: [{ ...filter, operator }] })}
+                    onFilterValue={(value) =>
+                      filter
+                      && updateInlineAnalysis({ filters: [{ ...filter, value }] })}
+                  />
+                </div>
+              ),
+            },
+          ]}
+        />
+      </div>
+
+      <div className="shrink-0 border-t border-[#edf0f3] p-3">
+        <Button block size="small" type="primary" onClick={close}>
+          完成
+        </Button>
+      </div>
+    </aside>
+  );
+}
+
+function EditorHeader({ onClose }: { onClose: () => void }) {
+  return (
+    <div className="flex h-12 shrink-0 items-center justify-between border-b border-[#edf0f3] px-4">
+      <div>
+        <div className="text-[12px] font-semibold text-[#344054]">图表编辑</div>
+        <div className="mt-0.5 text-[9px] text-[#98a2b3]">选择数据与字段，图表会即时更新</div>
+      </div>
+      <button
+        type="button"
+        onClick={onClose}
+        className="flex h-7 w-7 items-center justify-center rounded-[4px] border-0 bg-transparent text-[#667085] hover:bg-[#f5f6f7]"
+        aria-label="关闭图表编辑"
+      >
+        <X size={14} />
+      </button>
+    </div>
+  );
+}

--- a/yak-ops-ui/src/pages/dashboard/index.tsx
+++ b/yak-ops-ui/src/pages/dashboard/index.tsx
@@ -1,12 +1,13 @@
 import { BRAND_CSS_VARIABLES } from '@/styles/brand';
+import { Button } from 'antd';
+import { BarChart3 } from 'lucide-react';
 import ReactGridLayout, { useContainerWidth } from 'react-grid-layout';
 import 'react-grid-layout/css/styles.css';
 import 'react-resizable/css/styles.css';
 import { useMemo } from 'react';
+import { ChartEditor } from './chart-editor';
 import { DashboardGlobalFilterBar } from './global-filter-bar';
 import { GRID_COLUMNS, GRID_ROW_HEIGHT } from './helpers';
-import { LeftPanel } from './left-panel';
-import { SelectedConfig } from './selected-config';
 import { DashboardToolbar } from './toolbar';
 import { useDashboardDesigner } from './use-dashboard';
 import { WidgetShell } from './widget';
@@ -33,7 +34,9 @@ export default function DashboardPage() {
     canvasMinHeight = 'min-h-[calc(100vh-156px)]';
   }
 
-  const syncLayout = (nextLayout: readonly { i: string; x: number; y: number; w: number; h: number }[]) => {
+  const syncLayout = (
+    nextLayout: readonly { i: string; x: number; y: number; w: number; h: number }[],
+  ) => {
     const nextMap = new Map(nextLayout.map((item) => [item.i, item]));
     designer.setDashboard((current) => ({
       ...current,
@@ -43,6 +46,8 @@ export default function DashboardPage() {
       }),
     }));
   };
+
+  const addChart = () => designer.addWidget('bar');
 
   return (
     <div
@@ -58,9 +63,11 @@ export default function DashboardPage() {
         loading={designer.dashboardsLoading}
         saving={designer.dashboardSaving}
         preview={designer.preview}
+        canAddChart={Boolean(designer.activeDataset) && !designer.datasetsLoading}
         onName={(name) => designer.setDashboard((current) => ({ ...current, name }))}
         onDashboard={(dashboardId) => void designer.openDashboard(dashboardId)}
         onNew={designer.newDashboard}
+        onAddChart={addChart}
         onVersion={(versionNo) => void designer.activateVersion(versionNo)}
         onPreview={() => {
           designer.setPreview((current) => !current);
@@ -77,19 +84,6 @@ export default function DashboardPage() {
       />
 
       <div className="flex min-h-0 flex-1 overflow-hidden">
-        {!designer.preview ? (
-          <LeftPanel
-            datasets={designer.datasets}
-            activeDataset={designer.activeDataset}
-            datasetsLoading={designer.datasetsLoading}
-            datasetsError={designer.datasetsError}
-            onDatasetChange={(activeDatasetId) =>
-              designer.setDashboard((current) => ({ ...current, activeDatasetId }))}
-            onRefreshDatasets={() => void designer.refreshDatasets()}
-            onAddChart={designer.addWidget}
-          />
-        ) : null}
-
         <main className="min-w-0 flex-1 overflow-auto">
           <div className={designer.preview ? 'min-h-full p-5' : 'min-h-full p-3'}>
             <div
@@ -155,16 +149,30 @@ export default function DashboardPage() {
               ) : null}
 
               {!designer.widgets.length && !designer.datasetsLoading ? (
-                <div className="flex min-h-[360px] items-center justify-center px-6 text-center">
-                  <div>
-                    <div className="text-[14px] font-medium text-[#475467]">
-                      {designer.activeDataset ? '添加第一个图表' : '暂无可用数据集'}
+                <div className="flex min-h-[420px] items-center justify-center px-6 text-center">
+                  <div className="max-w-[340px]">
+                    <div className="mx-auto flex h-10 w-10 items-center justify-center rounded-[8px] bg-[#f5f6f7] text-[#667085]">
+                      <BarChart3 size={18} />
                     </div>
-                    <div className="mt-1 text-[12px] text-[#98a2b3]">
+                    <div className="mt-3 text-[14px] font-medium text-[#344054]">
+                      {designer.activeDataset ? '从一个图表开始' : '暂无可用数据集'}
+                    </div>
+                    <div className="mt-1 text-[11px] leading-5 text-[#98a2b3]">
                       {designer.activeDataset
-                        ? '从左侧选择图表类型，添加后在右侧完成数据与样式配置'
-                        : '请先在数据开发发布中心发布并上线 Dataset'}
+                        ? '添加图表后，在右侧选择数据集、维度和指标即可完成配置。'
+                        : '请先在数据开发发布中心发布并上线 Dataset。'}
                     </div>
+                    {designer.activeDataset ? (
+                      <Button
+                        size="small"
+                        type="primary"
+                        className="mt-4"
+                        icon={<BarChart3 size={13} />}
+                        onClick={addChart}
+                      >
+                        添加图表
+                      </Button>
+                    ) : null}
                   </div>
                 </div>
               ) : null}
@@ -173,7 +181,7 @@ export default function DashboardPage() {
         </main>
 
         {!designer.preview && designer.selectedWidget ? (
-          <SelectedConfig
+          <ChartEditor
             widget={designer.selectedWidget}
             datasets={designer.datasets}
             analyses={designer.analyses}
@@ -181,8 +189,10 @@ export default function DashboardPage() {
               designer.updateWidget(designer.selectedWidget!.id, patch)}
             updateInlineAnalysis={(patch) =>
               designer.updateInlineAnalysis(designer.selectedWidget!.id, patch)}
-            changeDataset={(datasetId) =>
-              designer.changeWidgetDataset(designer.selectedWidget!.id, datasetId)}
+            changeDataset={(datasetId) => {
+              designer.setDashboard((current) => ({ ...current, activeDatasetId: datasetId }));
+              designer.changeWidgetDataset(designer.selectedWidget!.id, datasetId);
+            }}
             detachAnalysis={() =>
               designer.detachAnalysis(designer.selectedWidget!.id)}
             close={() => designer.setSelectedId(undefined)}
@@ -209,13 +219,11 @@ export default function DashboardPage() {
           height: 6px !important;
           width: 6px !important;
         }
-        .dashboard-config-tabs > .ant-tabs-nav {
-          margin: 0 !important;
-          padding: 0 12px;
+        .chart-editor-more > .ant-collapse-item > .ant-collapse-header {
+          padding: 10px 0 !important;
         }
-        .dashboard-config-tabs .ant-tabs-tab {
-          padding: 9px 0 !important;
-          font-size: 12px;
+        .chart-editor-more .ant-collapse-content-box {
+          padding: 2px 0 0 !important;
         }
       `}</style>
     </div>

--- a/yak-ops-ui/src/pages/dashboard/toolbar.tsx
+++ b/yak-ops-ui/src/pages/dashboard/toolbar.tsx
@@ -1,6 +1,6 @@
 import { history } from '@umijs/max';
 import { Button, Input, Select, Tooltip } from 'antd';
-import { ChevronLeft, Eye, History, Plus, Save, X } from 'lucide-react';
+import { BarChart3, ChevronLeft, Eye, History, Plus, Save, X } from 'lucide-react';
 import type { DashboardSummary, DashboardVersionSummary } from './model';
 
 export function DashboardToolbar({
@@ -12,9 +12,11 @@ export function DashboardToolbar({
   loading,
   saving,
   preview,
+  canAddChart,
   onName,
   onDashboard,
   onNew,
+  onAddChart,
   onVersion,
   onPreview,
   onSave,
@@ -27,9 +29,11 @@ export function DashboardToolbar({
   loading: boolean;
   saving: boolean;
   preview: boolean;
+  canAddChart: boolean;
   onName: (name: string) => void;
   onDashboard: (dashboardId: string) => void;
   onNew: () => void;
+  onAddChart: () => void;
   onVersion: (versionNo: number) => void;
   onPreview: () => void;
   onSave: () => void;
@@ -82,6 +86,16 @@ export function DashboardToolbar({
       </div>
 
       <div className="flex items-center gap-2">
+        {!preview ? (
+          <Button
+            size="small"
+            disabled={!canAddChart}
+            icon={<BarChart3 size={13} />}
+            onClick={onAddChart}
+          >
+            添加图表
+          </Button>
+        ) : null}
         {persisted && versions.length ? (
           <Select
             size="small"


### PR DESCRIPTION
## Summary

PR3 将 Chart Editor 正式内嵌到 Dashboard，完成 BI V1 从“设计器工作台”向“仪表盘内直接做图”的主流程切换。

新的核心路径：

`仪表盘 → 添加图表 → 选择数据集 → 选择图表类型 → 选择维度 / 指标 → 完成`

### Dashboard entry

- 移除 Dashboard 对常驻左侧 `LeftPanel` 的依赖
- 顶部工具栏增加明确的「添加图表」入口
- 空画布增加「添加图表」主按钮
- 新建图表默认以柱状图进入编辑状态，随后可在 Chart Editor 中即时切换图表类型
- 用户在 Chart Editor 中切换 Dataset 时，同步更新当前 Dashboard 的 activeDataset，后续新增图表继续使用最近选择的数据集

### Embedded Chart Editor

新增 `chart-editor.tsx`，作为 Dashboard 内统一的图表创建 / 编辑入口：

基础区只暴露 V1 必要能力：

- 图表标题
- Dataset
- 图表类型：指标卡 / 柱状图 / 折线图 / 饼图 / 明细表
- 维度
- 指标
- 指标聚合方式

图表配置实时写回 Dashboard Widget / inlineAnalysis，画布即时刷新。

### Advanced settings

将低频能力统一收进「更多设置」，默认不占据用户注意力：

- 图例
- 数据标签
- 折线平滑
- 网格线
- 排序
- 单字段过滤

不再在主编辑区暴露 X / Y / Width / Height 等布局参数，布局继续由 Canvas 拖拽和 Resize 负责。

### Legacy compatibility

- 历史 `analysisId` Widget 保持可渲染
- 历史共享图表在新的 Chart Editor 中以兼容态展示
- 支持「复制为可编辑图表」，继续复用现有 detachAnalysis 能力
- 本 PR 不删除 Analysis API / Domain，也不删除旧 ConfigPanel / SelectedConfig / LeftPanel 文件，统一留到 PR4 做死代码清理

## Scope

这是 BI 瘦身计划的 PR3，只完成 **Chart Editor 内嵌与主流程切换**。

本 PR不删除：

- Dataset Query Runtime
- Dashboard 保存 / 版本
- React Grid Layout 拖拽 / Resize
- DashboardGlobalFilter 运行态
- Analysis 历史兼容能力
- 旧 Dashboard 配置组件源码（PR4 清理）

## Verification

- 基于 PR2 合并后的最新 `main`
- 分支相对 `main` 仅 1 个提交、3 个文件变更
- 使用 TypeScript 5.8 对新增 / 修改 TSX 做静态解析，未发现语法级错误
- 当前执行环境未安装 yak-ops-ui 项目依赖，因此完整 `npm run tsc` / `npm run lint` 仍以仓库 CI 为准