### PR TITLE
feat: add dashboard list management

### DIFF
--- a/yak-ops-ui/src/config/navigation.test.ts
+++ b/yak-ops-ui/src/config/navigation.test.ts
@@ -58,7 +58,7 @@ describe('permission-aware navigation', () => {
     ]);
   });
 
-  it('keeps data consumption focused on dashboard and catalog while preserving the legacy chart route', () => {
+  it('keeps data consumption focused on dashboard and catalog while preserving dashboard editor routes', () => {
     const dataConsumption = getMainNavigationGroups([]).find(
       (group) => group.id === 'data-analysis',
     );
@@ -68,6 +68,8 @@ describe('permission-aware navigation', () => {
       'data-analysis-catalog',
     ]);
     expect(getActiveNavigationId('/dashboard', [])).toBe('dashboard');
+    expect(getActiveNavigationId('/dashboard/new', [])).toBe('dashboard');
+    expect(getActiveNavigationId('/dashboard/42', [])).toBe('dashboard');
     expect(getActiveNavigationId('/data-analysis/chart-analysis', [])).toBe('dashboard');
   });
 

--- a/yak-ops-ui/src/config/navigation.ts
+++ b/yak-ops-ui/src/config/navigation.ts
@@ -39,6 +39,7 @@ export const appRoutes: readonly NavigationRoute[] = [
   { id: 'home', mode: 'public', path: '/home', title: '首页', component: './home', iconKey: 'home', order: 0 },
   { id: 'data-source', mode: 'one', permission: 'resource:data-source:read', path: '/data-source', title: '数据源管理', component: './data-source', iconKey: 'database', order: 10 },
   { id: 'dashboard', mode: 'public', path: '/dashboard', title: '仪表盘', component: './dashboard', iconKey: 'insight', menuGroup: 'data-analysis', order: 10 },
+  { id: 'dashboard-editor', path: '/dashboard/:id', title: '仪表盘编辑', component: './dashboard/editor', hidden: true, parentId: 'dashboard' },
   { id: 'data-analysis-catalog', mode: 'public', path: '/data-analysis/data-catalog', title: '数据目录', component: './data-analysis/data-catalog', iconKey: 'database', menuGroup: 'data-analysis', order: 20 },
   { id: 'data-analysis-chart', path: '/data-analysis/chart-analysis', title: '图表分析', component: './data-analysis/chart-analysis-redirect', hidden: true, parentId: 'dashboard' },
   { id: 'settings', mode: 'public', path: '/settings', title: '设置', component: './settings', hidden: true, order: 30 },

--- a/yak-ops-ui/src/pages/dashboard/editor.tsx
+++ b/yak-ops-ui/src/pages/dashboard/editor.tsx
@@ -1,0 +1,235 @@
+import { history, useParams } from '@umijs/max';
+import { BRAND_CSS_VARIABLES } from '@/styles/brand';
+import { Button } from 'antd';
+import { BarChart3 } from 'lucide-react';
+import ReactGridLayout, { useContainerWidth } from 'react-grid-layout';
+import 'react-grid-layout/css/styles.css';
+import 'react-resizable/css/styles.css';
+import { useMemo } from 'react';
+import { ChartEditor } from './chart-editor';
+import { DashboardGlobalFilterBar } from './global-filter-bar';
+import { GRID_COLUMNS, GRID_ROW_HEIGHT } from './helpers';
+import { DashboardToolbar } from './toolbar';
+import { useDashboardDesigner } from './use-dashboard';
+import { WidgetShell } from './widget';
+
+export default function DashboardEditorPage() {
+  const { id } = useParams<{ id?: string }>();
+  const dashboardId = id && id !== 'new' ? id : undefined;
+  const designer = useDashboardDesigner(dashboardId);
+  const { width, containerRef, mounted } = useContainerWidth();
+  const layout = useMemo(() => designer.widgets.map((widget) => ({
+    i: widget.id,
+    x: widget.x,
+    y: widget.y,
+    w: widget.w,
+    h: widget.h,
+    minW: widget.minW,
+    minH: widget.minH,
+  })), [designer.widgets]);
+  const hasGlobalFilters = designer.dashboard.globalFilters.length > 0;
+  let canvasMinHeight = 'min-h-[calc(100vh-120px)]';
+  if (designer.preview) {
+    canvasMinHeight = hasGlobalFilters
+      ? 'min-h-[calc(100vh-172px)]'
+      : 'min-h-[calc(100vh-136px)]';
+  } else if (hasGlobalFilters) {
+    canvasMinHeight = 'min-h-[calc(100vh-156px)]';
+  }
+
+  const syncLayout = (
+    nextLayout: readonly { i: string; x: number; y: number; w: number; h: number }[],
+  ) => {
+    const nextMap = new Map(nextLayout.map((item) => [item.i, item]));
+    designer.setDashboard((current) => ({
+      ...current,
+      widgets: current.widgets.map((widget) => {
+        const next = nextMap.get(widget.id);
+        return next ? { ...widget, x: next.x, y: next.y, w: next.w, h: next.h } : widget;
+      }),
+    }));
+  };
+
+  const addChart = () => designer.addWidget('bar');
+
+  const saveDashboard = async () => {
+    const persistedId = await designer.save();
+    if (!dashboardId && persistedId) history.replace(`/dashboard/${persistedId}`);
+  };
+
+  return (
+    <div
+      className="flex h-[calc(100vh-48px)] min-h-[640px] flex-col overflow-hidden bg-[#f4f6f8]"
+      style={BRAND_CSS_VARIABLES}
+    >
+      <DashboardToolbar
+        name={designer.dashboard.name}
+        dashboardId={designer.dashboard.id}
+        currentVersionNo={designer.dashboard.currentVersionNo}
+        versions={designer.dashboardVersions}
+        saving={designer.dashboardSaving}
+        preview={designer.preview}
+        canAddChart={Boolean(designer.activeDataset) && !designer.datasetsLoading}
+        onName={(name) => designer.setDashboard((current) => ({ ...current, name }))}
+        onAddChart={addChart}
+        onVersion={(versionNo) => void designer.activateVersion(versionNo)}
+        onPreview={() => {
+          designer.setPreview((current) => !current);
+          designer.setSelectedId(undefined);
+        }}
+        onSave={() => void saveDashboard()}
+      />
+
+      <DashboardGlobalFilterBar
+        filters={designer.dashboard.globalFilters}
+        runtimeValues={designer.runtimeFilterValues}
+        onRuntimeValue={designer.setRuntimeFilterValue}
+        onReset={designer.resetRuntimeFilters}
+      />
+
+      <div className="flex min-h-0 flex-1 overflow-hidden">
+        <main className="min-w-0 flex-1 overflow-auto">
+          <div className={designer.preview ? 'min-h-full p-5' : 'min-h-full p-3'}>
+            <div
+              ref={containerRef}
+              className={[
+                'mx-auto min-w-[760px] bg-white',
+                canvasMinHeight,
+                designer.preview
+                  ? 'max-w-[1500px] shadow-[0_1px_5px_rgba(16,24,40,.08)]'
+                  : 'dashboard-grid-canvas border border-[#dfe3e8]',
+              ].join(' ')}
+              onMouseDown={(event) => {
+                if (event.target === event.currentTarget) designer.setSelectedId(undefined);
+              }}
+            >
+              {mounted && width > 0 ? (
+                <ReactGridLayout
+                  width={width}
+                  layout={layout}
+                  gridConfig={{
+                    cols: GRID_COLUMNS,
+                    rowHeight: GRID_ROW_HEIGHT,
+                    margin: [8, 8],
+                    containerPadding: [8, 8],
+                  }}
+                  dragConfig={{
+                    enabled: !designer.preview,
+                    handle: '.dashboard-widget__drag-handle',
+                  }}
+                  resizeConfig={{ enabled: !designer.preview }}
+                  onLayoutChange={syncLayout}
+                >
+                  {designer.widgets.map((widget) => {
+                    const analysis = widget.analysisId
+                      ? designer.analyses.find((item) => item.id === widget.analysisId)
+                      : undefined;
+                    const spec = analysis ?? widget.inlineAnalysis;
+                    const dataset = spec
+                      ? designer.datasets.find((item) => item.id === spec.datasetId)
+                      : undefined;
+
+                    return (
+                      <div key={widget.id}>
+                        <WidgetShell
+                          widget={widget}
+                          analysis={analysis}
+                          dataset={dataset}
+                          runtimeFilters={designer.runtimeFiltersForWidget(widget.id)}
+                          selected={designer.selectedId === widget.id}
+                          preview={designer.preview}
+                          onSelect={() => {
+                            if (!designer.preview) designer.setSelectedId(widget.id);
+                          }}
+                          onDataSelect={(selection) =>
+                            designer.handleWidgetSelection(widget.id, selection)}
+                          onDuplicate={() => designer.duplicateWidget(widget.id)}
+                          onDelete={() => designer.deleteWidget(widget.id)}
+                        />
+                      </div>
+                    );
+                  })}
+                </ReactGridLayout>
+              ) : null}
+
+              {!designer.widgets.length && !designer.datasetsLoading ? (
+                <div className="flex min-h-[420px] items-center justify-center px-6 text-center">
+                  <div className="max-w-[340px]">
+                    <div className="mx-auto flex h-10 w-10 items-center justify-center rounded-[8px] bg-[#f5f6f7] text-[#667085]">
+                      <BarChart3 size={18} />
+                    </div>
+                    <div className="mt-3 text-[14px] font-medium text-[#344054]">
+                      {designer.activeDataset ? '从一个图表开始' : '暂无可用数据集'}
+                    </div>
+                    <div className="mt-1 text-[11px] leading-5 text-[#98a2b3]">
+                      {designer.activeDataset
+                        ? '添加图表后，在右侧选择数据集、维度和指标即可完成配置。'
+                        : '请先在数据开发发布中心发布并上线 Dataset。'}
+                    </div>
+                    {designer.activeDataset ? (
+                      <Button
+                        size="small"
+                        type="primary"
+                        className="mt-4"
+                        icon={<BarChart3 size={13} />}
+                        onClick={addChart}
+                      >
+                        添加图表
+                      </Button>
+                    ) : null}
+                  </div>
+                </div>
+              ) : null}
+            </div>
+          </div>
+        </main>
+
+        {!designer.preview && designer.selectedWidget ? (
+          <ChartEditor
+            widget={designer.selectedWidget}
+            datasets={designer.datasets}
+            analyses={designer.analyses}
+            updateWidget={(patch) =>
+              designer.updateWidget(designer.selectedWidget!.id, patch)}
+            updateInlineAnalysis={(patch) =>
+              designer.updateInlineAnalysis(designer.selectedWidget!.id, patch)}
+            changeDataset={(datasetId) => {
+              designer.setDashboard((current) => ({ ...current, activeDatasetId: datasetId }));
+              designer.changeWidgetDataset(designer.selectedWidget!.id, datasetId);
+            }}
+            detachAnalysis={() =>
+              designer.detachAnalysis(designer.selectedWidget!.id)}
+            close={() => designer.setSelectedId(undefined)}
+          />
+        ) : null}
+      </div>
+
+      <style>{`
+        .dashboard-grid-canvas {
+          background-color: #fff;
+          background-image:
+            linear-gradient(to right, rgba(15,23,42,.035) 1px, transparent 1px),
+            linear-gradient(to bottom, rgba(15,23,42,.035) 1px, transparent 1px);
+          background-size: calc(100% / 24) 36px;
+        }
+        .react-grid-item.react-grid-placeholder {
+          background: var(--yak-brand-color-soft) !important;
+          border: 1px dashed var(--yak-brand-color) !important;
+          opacity: 1 !important;
+        }
+        .react-grid-item > .react-resizable-handle::after {
+          border-color: #98a2b3 !important;
+          border-width: 0 1px 1px 0 !important;
+          height: 6px !important;
+          width: 6px !important;
+        }
+        .chart-editor-more > .ant-collapse-item > .ant-collapse-header {
+          padding: 10px 0 !important;
+        }
+        .chart-editor-more .ant-collapse-content-box {
+          padding: 2px 0 0 !important;
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/yak-ops-ui/src/pages/dashboard/index.tsx
+++ b/yak-ops-ui/src/pages/dashboard/index.tsx
@@ -1,231 +1,275 @@
-import { BRAND_CSS_VARIABLES } from '@/styles/brand';
-import { Button } from 'antd';
-import { BarChart3 } from 'lucide-react';
-import ReactGridLayout, { useContainerWidth } from 'react-grid-layout';
-import 'react-grid-layout/css/styles.css';
-import 'react-resizable/css/styles.css';
-import { useMemo } from 'react';
-import { ChartEditor } from './chart-editor';
-import { DashboardGlobalFilterBar } from './global-filter-bar';
-import { GRID_COLUMNS, GRID_ROW_HEIGHT } from './helpers';
-import { DashboardToolbar } from './toolbar';
-import { useDashboardDesigner } from './use-dashboard';
-import { WidgetShell } from './widget';
+import { history } from '@umijs/max';
+import {
+  Button,
+  Input,
+  Modal,
+  Pagination,
+  Popconfirm,
+  Table,
+  message,
+  type TableColumnsType,
+} from 'antd';
+import { LayoutDashboard, Pencil, Plus, RefreshCw, Search, Trash2 } from 'lucide-react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  deleteDashboard,
+  fetchDashboard,
+  fetchDashboards,
+  saveDashboardVersion,
+  toDashboardDocument,
+} from './dashboard-service';
+import type { DashboardSummary } from './model';
 
-export default function DashboardPage() {
-  const designer = useDashboardDesigner();
-  const { width, containerRef, mounted } = useContainerWidth();
-  const layout = useMemo(() => designer.widgets.map((widget) => ({
-    i: widget.id,
-    x: widget.x,
-    y: widget.y,
-    w: widget.w,
-    h: widget.h,
-    minW: widget.minW,
-    minH: widget.minH,
-  })), [designer.widgets]);
-  const hasGlobalFilters = designer.dashboard.globalFilters.length > 0;
-  let canvasMinHeight = 'min-h-[calc(100vh-120px)]';
-  if (designer.preview) {
-    canvasMinHeight = hasGlobalFilters
-      ? 'min-h-[calc(100vh-172px)]'
-      : 'min-h-[calc(100vh-136px)]';
-  } else if (hasGlobalFilters) {
-    canvasMinHeight = 'min-h-[calc(100vh-156px)]';
-  }
+const formatTime = (value?: string) => value ? value.replace('T', ' ').slice(0, 19) : '-';
 
-  const syncLayout = (
-    nextLayout: readonly { i: string; x: number; y: number; w: number; h: number }[],
-  ) => {
-    const nextMap = new Map(nextLayout.map((item) => [item.i, item]));
-    designer.setDashboard((current) => ({
-      ...current,
-      widgets: current.widgets.map((widget) => {
-        const next = nextMap.get(widget.id);
-        return next ? { ...widget, x: next.x, y: next.y, w: next.w, h: next.h } : widget;
-      }),
-    }));
+export default function DashboardListPage() {
+  const [dashboards, setDashboards] = useState<DashboardSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [keyword, setKeyword] = useState('');
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(10);
+  const [renameTarget, setRenameTarget] = useState<DashboardSummary>();
+  const [renameValue, setRenameValue] = useState('');
+  const [renaming, setRenaming] = useState(false);
+
+  const loadDashboards = useCallback(async () => {
+    setLoading(true);
+    try {
+      setDashboards(await fetchDashboards());
+    } catch (error) {
+      setDashboards([]);
+      message.error(error instanceof Error ? error.message : '加载仪表盘失败');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadDashboards();
+  }, [loadDashboards]);
+
+  useEffect(() => {
+    setPage(1);
+  }, [keyword]);
+
+  const filteredDashboards = useMemo(() => {
+    const value = keyword.trim().toLowerCase();
+    if (!value) return dashboards;
+    return dashboards.filter((dashboard) => [dashboard.name, dashboard.description, dashboard.id]
+      .some((field) => String(field || '').toLowerCase().includes(value)));
+  }, [dashboards, keyword]);
+
+  const pageCount = Math.max(1, Math.ceil(filteredDashboards.length / pageSize));
+  const currentPage = Math.min(page, pageCount);
+  const pageItems = useMemo(() => {
+    const start = (currentPage - 1) * pageSize;
+    return filteredDashboards.slice(start, start + pageSize);
+  }, [currentPage, filteredDashboards, pageSize]);
+
+  const openRename = (dashboard: DashboardSummary) => {
+    setRenameTarget(dashboard);
+    setRenameValue(dashboard.name);
   };
 
-  const addChart = () => designer.addWidget('bar');
+  const renameDashboard = async () => {
+    const name = renameValue.trim();
+    if (!renameTarget || !name) return void message.warning('请输入仪表盘名称');
+    if (name === renameTarget.name) {
+      setRenameTarget(undefined);
+      return;
+    }
+
+    setRenaming(true);
+    try {
+      const detail = await fetchDashboard(renameTarget.id);
+      const document = toDashboardDocument(detail);
+      await saveDashboardVersion(renameTarget.id, { ...document, name });
+      message.success('仪表盘名称已更新');
+      setRenameTarget(undefined);
+      await loadDashboards();
+    } catch (error) {
+      message.error(error instanceof Error ? error.message : '重命名仪表盘失败');
+    } finally {
+      setRenaming(false);
+    }
+  };
+
+  const removeDashboard = async (dashboard: DashboardSummary) => {
+    try {
+      await deleteDashboard(dashboard.id);
+      message.success('仪表盘已删除');
+      await loadDashboards();
+    } catch (error) {
+      message.error(error instanceof Error ? error.message : '删除仪表盘失败');
+    }
+  };
+
+  const columns: TableColumnsType<DashboardSummary> = [
+    {
+      title: '仪表盘',
+      dataIndex: 'name',
+      minWidth: 320,
+      render: (_, record) => (
+        <div className="min-w-0 py-0.5">
+          <button
+            type="button"
+            className="max-w-full truncate border-0 bg-transparent p-0 text-left text-[13px] font-medium text-[#161823] hover:underline"
+            onClick={() => history.push(`/dashboard/${record.id}`)}
+          >
+            {record.name}
+          </button>
+          <div className="mt-1 max-w-[520px] truncate text-[11px] text-[#98a2b3]">
+            {record.description || '暂无描述'}
+          </div>
+        </div>
+      ),
+    },
+    {
+      title: '当前版本',
+      dataIndex: 'currentVersionNo',
+      width: 120,
+      render: (value: number) => (
+        <span className="rounded-[3px] bg-[#f5f6f7] px-2 py-0.5 text-[11px] text-[#667085]">
+          {value ? `V${value}` : '未保存'}
+        </span>
+      ),
+    },
+    {
+      title: '更新时间',
+      dataIndex: 'updateTime',
+      width: 180,
+      render: (value?: string) => <span className="text-[12px] text-[#667085]">{formatTime(value)}</span>,
+    },
+    {
+      title: '创建时间',
+      dataIndex: 'createTime',
+      width: 180,
+      render: (value?: string) => <span className="text-[12px] text-[#667085]">{formatTime(value)}</span>,
+    },
+    {
+      title: '操作',
+      key: 'action',
+      width: 220,
+      fixed: 'right',
+      render: (_, record) => (
+        <div className="flex items-center gap-1">
+          <Button
+            size="small"
+            type="text"
+            icon={<Pencil size={12} />}
+            onClick={() => history.push(`/dashboard/${record.id}`)}
+          >
+            编辑
+          </Button>
+          <Button size="small" type="text" onClick={() => openRename(record)}>
+            重命名
+          </Button>
+          <Popconfirm
+            title="删除仪表盘"
+            description={`确认删除“${record.name}”？此操作不可恢复。`}
+            okText="删除"
+            cancelText="取消"
+            okButtonProps={{ danger: true }}
+            onConfirm={() => void removeDashboard(record)}
+          >
+            <Button size="small" type="text" danger icon={<Trash2 size={12} />}>
+              删除
+            </Button>
+          </Popconfirm>
+        </div>
+      ),
+    },
+  ];
 
   return (
-    <div
-      className="flex h-[calc(100vh-48px)] min-h-[640px] flex-col overflow-hidden bg-[#f4f6f8]"
-      style={BRAND_CSS_VARIABLES}
-    >
-      <DashboardToolbar
-        name={designer.dashboard.name}
-        dashboardId={designer.dashboard.id}
-        currentVersionNo={designer.dashboard.currentVersionNo}
-        dashboards={designer.dashboardAssets}
-        versions={designer.dashboardVersions}
-        loading={designer.dashboardsLoading}
-        saving={designer.dashboardSaving}
-        preview={designer.preview}
-        canAddChart={Boolean(designer.activeDataset) && !designer.datasetsLoading}
-        onName={(name) => designer.setDashboard((current) => ({ ...current, name }))}
-        onDashboard={(dashboardId) => void designer.openDashboard(dashboardId)}
-        onNew={designer.newDashboard}
-        onAddChart={addChart}
-        onVersion={(versionNo) => void designer.activateVersion(versionNo)}
-        onPreview={() => {
-          designer.setPreview((current) => !current);
-          designer.setSelectedId(undefined);
-        }}
-        onSave={() => void designer.save()}
-      />
-
-      <DashboardGlobalFilterBar
-        filters={designer.dashboard.globalFilters}
-        runtimeValues={designer.runtimeFilterValues}
-        onRuntimeValue={designer.setRuntimeFilterValue}
-        onReset={designer.resetRuntimeFilters}
-      />
-
-      <div className="flex min-h-0 flex-1 overflow-hidden">
-        <main className="min-w-0 flex-1 overflow-auto">
-          <div className={designer.preview ? 'min-h-full p-5' : 'min-h-full p-3'}>
-            <div
-              ref={containerRef}
-              className={[
-                'mx-auto min-w-[760px] bg-white',
-                canvasMinHeight,
-                designer.preview
-                  ? 'max-w-[1500px] shadow-[0_1px_5px_rgba(16,24,40,.08)]'
-                  : 'dashboard-grid-canvas border border-[#dfe3e8]',
-              ].join(' ')}
-              onMouseDown={(event) => {
-                if (event.target === event.currentTarget) designer.setSelectedId(undefined);
-              }}
-            >
-              {mounted && width > 0 ? (
-                <ReactGridLayout
-                  width={width}
-                  layout={layout}
-                  gridConfig={{
-                    cols: GRID_COLUMNS,
-                    rowHeight: GRID_ROW_HEIGHT,
-                    margin: [8, 8],
-                    containerPadding: [8, 8],
-                  }}
-                  dragConfig={{
-                    enabled: !designer.preview,
-                    handle: '.dashboard-widget__drag-handle',
-                  }}
-                  resizeConfig={{ enabled: !designer.preview }}
-                  onLayoutChange={syncLayout}
-                >
-                  {designer.widgets.map((widget) => {
-                    const analysis = widget.analysisId
-                      ? designer.analyses.find((item) => item.id === widget.analysisId)
-                      : undefined;
-                    const spec = analysis ?? widget.inlineAnalysis;
-                    const dataset = spec
-                      ? designer.datasets.find((item) => item.id === spec.datasetId)
-                      : undefined;
-
-                    return (
-                      <div key={widget.id}>
-                        <WidgetShell
-                          widget={widget}
-                          analysis={analysis}
-                          dataset={dataset}
-                          runtimeFilters={designer.runtimeFiltersForWidget(widget.id)}
-                          selected={designer.selectedId === widget.id}
-                          preview={designer.preview}
-                          onSelect={() => {
-                            if (!designer.preview) designer.setSelectedId(widget.id);
-                          }}
-                          onDataSelect={(selection) =>
-                            designer.handleWidgetSelection(widget.id, selection)}
-                          onDuplicate={() => designer.duplicateWidget(widget.id)}
-                          onDelete={() => designer.deleteWidget(widget.id)}
-                        />
-                      </div>
-                    );
-                  })}
-                </ReactGridLayout>
-              ) : null}
-
-              {!designer.widgets.length && !designer.datasetsLoading ? (
-                <div className="flex min-h-[420px] items-center justify-center px-6 text-center">
-                  <div className="max-w-[340px]">
-                    <div className="mx-auto flex h-10 w-10 items-center justify-center rounded-[8px] bg-[#f5f6f7] text-[#667085]">
-                      <BarChart3 size={18} />
-                    </div>
-                    <div className="mt-3 text-[14px] font-medium text-[#344054]">
-                      {designer.activeDataset ? '从一个图表开始' : '暂无可用数据集'}
-                    </div>
-                    <div className="mt-1 text-[11px] leading-5 text-[#98a2b3]">
-                      {designer.activeDataset
-                        ? '添加图表后，在右侧选择数据集、维度和指标即可完成配置。'
-                        : '请先在数据开发发布中心发布并上线 Dataset。'}
-                    </div>
-                    {designer.activeDataset ? (
-                      <Button
-                        size="small"
-                        type="primary"
-                        className="mt-4"
-                        icon={<BarChart3 size={13} />}
-                        onClick={addChart}
-                      >
-                        添加图表
-                      </Button>
-                    ) : null}
-                  </div>
-                </div>
-              ) : null}
-            </div>
+    <div className="min-h-[calc(100vh-48px)] bg-white px-5 py-4">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <div className="flex items-center gap-2 text-[16px] font-semibold text-[#161823]">
+            <LayoutDashboard size={17} />
+            仪表盘
           </div>
-        </main>
-
-        {!designer.preview && designer.selectedWidget ? (
-          <ChartEditor
-            widget={designer.selectedWidget}
-            datasets={designer.datasets}
-            analyses={designer.analyses}
-            updateWidget={(patch) =>
-              designer.updateWidget(designer.selectedWidget!.id, patch)}
-            updateInlineAnalysis={(patch) =>
-              designer.updateInlineAnalysis(designer.selectedWidget!.id, patch)}
-            changeDataset={(datasetId) => {
-              designer.setDashboard((current) => ({ ...current, activeDatasetId: datasetId }));
-              designer.changeWidgetDataset(designer.selectedWidget!.id, datasetId);
-            }}
-            detachAnalysis={() =>
-              designer.detachAnalysis(designer.selectedWidget!.id)}
-            close={() => designer.setSelectedId(undefined)}
-          />
-        ) : null}
+          <div className="mt-1 text-[11px] text-[#98a2b3]">
+            管理数据消费仪表盘，进入画布后完成图表配置与排版。
+          </div>
+        </div>
+        <Button
+          type="primary"
+          size="small"
+          icon={<Plus size={13} />}
+          onClick={() => history.push('/dashboard/new')}
+        >
+          新建仪表盘
+        </Button>
       </div>
 
-      <style>{`
-        .dashboard-grid-canvas {
-          background-color: #fff;
-          background-image:
-            linear-gradient(to right, rgba(15,23,42,.035) 1px, transparent 1px),
-            linear-gradient(to bottom, rgba(15,23,42,.035) 1px, transparent 1px);
-          background-size: calc(100% / 24) 36px;
-        }
-        .react-grid-item.react-grid-placeholder {
-          background: var(--yak-brand-color-soft) !important;
-          border: 1px dashed var(--yak-brand-color) !important;
-          opacity: 1 !important;
-        }
-        .react-grid-item > .react-resizable-handle::after {
-          border-color: #98a2b3 !important;
-          border-width: 0 1px 1px 0 !important;
-          height: 6px !important;
-          width: 6px !important;
-        }
-        .chart-editor-more > .ant-collapse-item > .ant-collapse-header {
-          padding: 10px 0 !important;
-        }
-        .chart-editor-more .ant-collapse-content-box {
-          padding: 2px 0 0 !important;
-        }
-      `}</style>
+      <div className="mt-4 flex items-center justify-between gap-3 border-y border-[#edf0f3] py-2.5">
+        <Input
+          allowClear
+          size="small"
+          className="w-[320px]"
+          prefix={<Search size={13} className="text-[#98a2b3]" />}
+          placeholder="搜索仪表盘名称、描述或 ID"
+          value={keyword}
+          onChange={(event) => setKeyword(event.target.value)}
+        />
+        <Button
+          size="small"
+          type="text"
+          icon={<RefreshCw size={13} />}
+          loading={loading}
+          onClick={() => void loadDashboards()}
+        >
+          刷新
+        </Button>
+      </div>
+
+      <Table<DashboardSummary>
+        rowKey="id"
+        size="small"
+        pagination={false}
+        loading={loading}
+        dataSource={pageItems}
+        columns={columns}
+        scroll={{ x: 1050 }}
+        className="mt-3"
+        locale={{ emptyText: keyword ? '没有匹配的仪表盘' : '暂无仪表盘，点击右上角新建' }}
+      />
+
+      <div className="mt-3 flex items-center justify-between border-t border-[#edf0f3] pt-3">
+        <span className="text-[11px] text-[#98a2b3]">共 {filteredDashboards.length} 个仪表盘</span>
+        <Pagination
+          size="small"
+          current={currentPage}
+          pageSize={pageSize}
+          total={filteredDashboards.length}
+          showSizeChanger
+          pageSizeOptions={[10, 20, 50]}
+          onChange={(nextPage, nextPageSize) => {
+            setPage(nextPageSize === pageSize ? nextPage : 1);
+            setPageSize(nextPageSize);
+          }}
+        />
+      </div>
+
+      <Modal
+        title="重命名仪表盘"
+        open={Boolean(renameTarget)}
+        okText="保存"
+        cancelText="取消"
+        confirmLoading={renaming}
+        onOk={() => void renameDashboard()}
+        onCancel={() => !renaming && setRenameTarget(undefined)}
+      >
+        <Input
+          autoFocus
+          maxLength={128}
+          value={renameValue}
+          placeholder="请输入仪表盘名称"
+          onChange={(event) => setRenameValue(event.target.value)}
+          onPressEnter={() => void renameDashboard()}
+        />
+      </Modal>
     </div>
   );
 }

--- a/yak-ops-ui/src/pages/dashboard/toolbar.tsx
+++ b/yak-ops-ui/src/pages/dashboard/toolbar.tsx
@@ -1,21 +1,17 @@
 import { history } from '@umijs/max';
-import { Button, Input, Select, Tooltip } from 'antd';
-import { BarChart3, ChevronLeft, Eye, History, Plus, Save, X } from 'lucide-react';
-import type { DashboardSummary, DashboardVersionSummary } from './model';
+import { Button, Input, Select } from 'antd';
+import { BarChart3, ChevronLeft, Eye, History, Save, X } from 'lucide-react';
+import type { DashboardVersionSummary } from './model';
 
 export function DashboardToolbar({
   name,
   dashboardId,
   currentVersionNo,
-  dashboards,
   versions,
-  loading,
   saving,
   preview,
   canAddChart,
   onName,
-  onDashboard,
-  onNew,
   onAddChart,
   onVersion,
   onPreview,
@@ -24,15 +20,11 @@ export function DashboardToolbar({
   name: string;
   dashboardId: string;
   currentVersionNo?: number;
-  dashboards: DashboardSummary[];
   versions: DashboardVersionSummary[];
-  loading: boolean;
   saving: boolean;
   preview: boolean;
   canAddChart: boolean;
   onName: (name: string) => void;
-  onDashboard: (dashboardId: string) => void;
-  onNew: () => void;
   onAddChart: () => void;
   onVersion: (versionNo: number) => void;
   onPreview: () => void;
@@ -48,37 +40,17 @@ export function DashboardToolbar({
           type="text"
           icon={<ChevronLeft size={14} />}
           disabled={preview}
-          onClick={() => history.push('/data-analysis/data-catalog')}
+          onClick={() => history.push('/dashboard')}
         >
-          数据目录
+          仪表盘
         </Button>
-        <span className="h-5 w-px bg-[#e5e7eb]" />
-        <Select
-          size="small"
-          className="w-[190px]"
-          loading={loading}
-          disabled={preview}
-          placeholder="选择仪表盘"
-          value={persisted ? dashboardId : undefined}
-          options={dashboards.map((item) => ({ label: item.name, value: item.id }))}
-          onChange={onDashboard}
-        />
-        <Tooltip title="新建仪表盘">
-          <Button
-            size="small"
-            type="text"
-            icon={<Plus size={13} />}
-            disabled={preview}
-            onClick={onNew}
-          />
-        </Tooltip>
         <span className="h-5 w-px bg-[#e5e7eb]" />
         <Input
           variant="borderless"
           value={name}
           disabled={preview}
           onChange={(event) => onName(event.target.value)}
-          className="w-[220px] px-1 text-[13px] font-semibold text-[#161823]"
+          className="w-[260px] px-1 text-[13px] font-semibold text-[#161823]"
         />
         <span className="rounded-[3px] bg-[#f5f6f7] px-2 py-0.5 text-[10px] text-[#667085]">
           {currentVersionNo ? `V${currentVersionNo}` : '未保存'}

--- a/yak-ops-ui/src/pages/dashboard/use-dashboard.ts
+++ b/yak-ops-ui/src/pages/dashboard/use-dashboard.ts
@@ -6,13 +6,12 @@ import type {
   Scalar,
 } from '@/components/analysis/model';
 import { message } from 'antd';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { DEFAULT_DASHBOARD } from './defaults';
 import {
   activateDashboardVersion,
   createDashboard,
   fetchDashboard,
-  fetchDashboards,
   saveDashboardVersion,
   toDashboardDocument,
 } from './dashboard-service';
@@ -22,7 +21,6 @@ import {
   createWidget,
   findDataset,
   isPersistedDashboard,
-  loadDashboard,
   reconcileDashboard,
   STORAGE_KEY,
 } from './helpers';
@@ -31,7 +29,6 @@ import type {
   ChartType,
   DashboardDocument,
   DashboardGlobalFilter,
-  DashboardSummary,
   DashboardVersionSummary,
   DashboardWidget,
   PublishedDataset,
@@ -60,19 +57,16 @@ const runtimeDefaults = (filters: DashboardGlobalFilter[]) => Object.fromEntries
 const hasOwn = (value: Record<string, Scalar | undefined>, key: string) =>
   Object.prototype.hasOwnProperty.call(value, key);
 
-export function useDashboardDesigner() {
-  const [dashboard, setDashboard] = useState<DashboardDocument>(loadDashboard);
+export function useDashboardDesigner(dashboardId?: string) {
+  const [dashboard, setDashboard] = useState<DashboardDocument>(() => cloneDashboard(DEFAULT_DASHBOARD));
   const [datasets, setDatasets] = useState<PublishedDataset[]>([]);
   const [datasetsLoading, setDatasetsLoading] = useState(true);
   const [analyses, setAnalyses] = useState<AnalysisAsset[]>([]);
-  const [dashboardAssets, setDashboardAssets] = useState<DashboardSummary[]>([]);
   const [dashboardVersions, setDashboardVersions] = useState<DashboardVersionSummary[]>([]);
-  const [dashboardsLoading, setDashboardsLoading] = useState(true);
   const [dashboardSaving, setDashboardSaving] = useState(false);
   const [runtimeFilterValues, setRuntimeFilterValues] = useState<Record<string, Scalar | undefined>>({});
   const [selectedId, setSelectedId] = useState<string>();
   const [preview, setPreview] = useState(false);
-  const didAutoOpen = useRef(false);
 
   const widgets = dashboard.widgets;
   const selectedWidget = widgets.find((widget) => widget.id === selectedId);
@@ -100,21 +94,9 @@ export function useDashboardDesigner() {
     }
   }, []);
 
-  const loadDashboardAssets = useCallback(async () => {
-    setDashboardsLoading(true);
+  const openDashboard = useCallback(async (targetDashboardId: string) => {
     try {
-      setDashboardAssets(await fetchDashboards());
-    } catch (error) {
-      setDashboardAssets([]);
-      message.error(error instanceof Error ? error.message : '加载 Dashboard 列表失败');
-    } finally {
-      setDashboardsLoading(false);
-    }
-  }, []);
-
-  const openDashboard = useCallback(async (dashboardId: string) => {
-    try {
-      const detail = await fetchDashboard(dashboardId);
+      const detail = await fetchDashboard(targetDashboardId);
       setDashboard(toDashboardDocument(detail));
       setDashboardVersions(detail.versions);
       setSelectedId(undefined);
@@ -127,23 +109,18 @@ export function useDashboardDesigner() {
   useEffect(() => {
     void loadDatasets();
     void loadAnalyses();
-    void loadDashboardAssets();
-  }, [loadDatasets, loadAnalyses, loadDashboardAssets]);
+  }, [loadDatasets, loadAnalyses]);
 
   useEffect(() => {
-    if (didAutoOpen.current || dashboardsLoading) return;
-    didAutoOpen.current = true;
-    const hasLegacyDraft = !isPersistedDashboard(dashboard.id)
-      && (dashboard.widgets.length > 0 || dashboard.name !== DEFAULT_DASHBOARD.name);
-    if (!hasLegacyDraft && dashboardAssets.length) void openDashboard(dashboardAssets[0].id);
-  }, [
-    dashboard.id,
-    dashboard.name,
-    dashboard.widgets.length,
-    dashboardAssets,
-    dashboardsLoading,
-    openDashboard,
-  ]);
+    if (dashboardId) {
+      void openDashboard(dashboardId);
+      return;
+    }
+    setDashboard(cloneDashboard(DEFAULT_DASHBOARD));
+    setDashboardVersions([]);
+    setSelectedId(undefined);
+    setRuntimeFilterValues({});
+  }, [dashboardId, openDashboard]);
 
   useEffect(() => {
     if (!datasets.length) return;
@@ -275,8 +252,11 @@ export function useDashboardDesigner() {
     }));
   };
 
-  const save = async () => {
-    if (!dashboard.name.trim()) return void message.warning('请输入仪表盘名称');
+  const save = async (): Promise<string | undefined> => {
+    if (!dashboard.name.trim()) {
+      message.warning('请输入仪表盘名称');
+      return undefined;
+    }
     setDashboardSaving(true);
     try {
       const detail = isPersistedDashboard(dashboard.id)
@@ -285,14 +265,12 @@ export function useDashboardDesigner() {
       const document = toDashboardDocument(detail);
       setDashboard(document);
       setDashboardVersions(detail.versions);
-      setDashboardAssets((current) => [
-        detail.dashboard,
-        ...current.filter((item) => item.id !== detail.dashboard.id),
-      ]);
       window.localStorage.removeItem(STORAGE_KEY);
       message.success(`仪表盘已保存为 V${detail.dashboard.currentVersionNo}`);
+      return detail.dashboard.id;
     } catch (error) {
       message.error(error instanceof Error ? error.message : '保存 Dashboard 失败');
+      return undefined;
     } finally {
       setDashboardSaving(false);
     }
@@ -305,9 +283,6 @@ export function useDashboardDesigner() {
       const detail = await activateDashboardVersion(dashboard.id, versionNo);
       setDashboard(toDashboardDocument(detail));
       setDashboardVersions(detail.versions);
-      setDashboardAssets((current) => current.map((item) => (
-        item.id === detail.dashboard.id ? detail.dashboard : item
-      )));
       setSelectedId(undefined);
       message.success(`已切换到 Dashboard V${versionNo}`);
     } catch (error) {
@@ -317,24 +292,13 @@ export function useDashboardDesigner() {
     }
   };
 
-  const newDashboard = () => {
-    const next = reconcileDashboard(cloneDashboard(DEFAULT_DASHBOARD), datasets);
-    setDashboard(next);
-    setDashboardVersions([]);
-    setSelectedId(undefined);
-    setRuntimeFilterValues({});
-    window.localStorage.removeItem(STORAGE_KEY);
-  };
-
   return {
     dashboard,
     widgets,
     datasets,
     datasetsLoading,
     analyses,
-    dashboardAssets,
     dashboardVersions,
-    dashboardsLoading,
     dashboardSaving,
     runtimeFilterValues,
     selectedWidget,
@@ -357,7 +321,5 @@ export function useDashboardDesigner() {
     changeWidgetDataset,
     save,
     activateVersion,
-    newDashboard,
-    openDashboard,
   };
 }


### PR DESCRIPTION
## Summary

新增仪表盘资产列表页，并把原 Dashboard Canvas 从菜单入口拆成独立编辑页。整体布局参考现有「离线同步」列表页：页面标题、一行搜索/操作区、Table、底部分页。

新的用户路径：

`仪表盘列表 → 新建 / 选择仪表盘 → Dashboard Canvas → Chart Editor`

## Dashboard list

`/dashboard` 现在作为仪表盘管理列表，直接使用现有真实 Dashboard API：

- 仪表盘列表加载
- 名称 / 描述 / ID 搜索
- 客户端分页与 page size
- 手动刷新
- 当前版本、更新时间、创建时间展示
- 点击名称或「编辑」进入画布
- 「重命名」通过现有 DashboardVersion 保存机制生成新版本
- 「删除」调用真实 delete Dashboard API，并带二次确认
- 「新建仪表盘」进入 `/dashboard/new`

## Editor route

原 `/dashboard` Canvas 内容迁移到 `dashboard/editor.tsx`：

- `/dashboard/new`：新建未保存 Dashboard
- `/dashboard/:id`：加载指定 Dashboard 进入编辑
- 首次保存新 Dashboard 后，自动 replace 到真实 `/dashboard/{id}`
- 编辑器返回按钮改为回到仪表盘列表
- 移除编辑器顶部原有的 Dashboard 下拉切换和「新建」按钮，资产切换职责统一回到列表页

路由使用隐藏子路由 `/dashboard/:id`，因此 `/dashboard/new` 和 `/dashboard/42` 都继续继承「仪表盘」菜单高亮。

## State boundary

`useDashboardDesigner` 改成面向单个编辑上下文：

- 接收可选 `dashboardId`
- 编辑已有资产时只加载指定 Dashboard
- 新建时从 `DEFAULT_DASHBOARD` 开始
- 不再自动加载 Dashboard 列表并自动打开第一项
- 保存返回持久化 Dashboard ID，供新建页切换到正式 URL
- Dataset、历史 Analysis 兼容、Widget CRUD、版本、筛选运行态保持不变

## Scope

本 PR 不修改 Dashboard 后端协议，也不新增 mock 数据。CRUD 直接复用现有：

- `fetchDashboards`
- `fetchDashboard`
- `createDashboard`
- `saveDashboardVersion`
- `deleteDashboard`

Chart Editor、Dataset Query Runtime、DashboardVersion 数据结构均保持不变。

## Verification

- 基于 PR #401 合并后的最新 `main`
- 分支相对 `main`：1 commit / 6 files changed
- navigation test 增加 `/dashboard/new` 与 `/dashboard/:id` 的父级高亮覆盖
- 复核现有 Dashboard API，列表/详情/创建/版本保存/删除均为真实接口
- 当前执行环境无法拉取仓库依赖，因此完整 UI `tsc / lint / build` 仍以仓库 CI 为准
