### PR TITLE
feat(dashboard): complete stage 1 editor experience

### DIFF
--- a/yak-ops-ui/src/pages/dashboard/editor.tsx
+++ b/yak-ops-ui/src/pages/dashboard/editor.tsx
@@ -47,7 +47,8 @@ export default function DashboardEditorPage() {
   const addChart = () => designer.addWidget('bar');
 
   const saveDashboard = useCallback(async () => {
-    if (designer.dashboardSaving) return;
+    const persisted = /^\d+$/.test(designer.dashboard.id);
+    if (designer.dashboardSaving || (persisted && !designer.dirty)) return;
     const persistedId = await designer.save();
     if (!dashboardId && persistedId) history.replace(`/dashboard/${persistedId}`);
   }, [dashboardId, designer]);
@@ -102,7 +103,18 @@ export default function DashboardEditorPage() {
 
       if (modifier && key === 's') {
         event.preventDefault();
-        if (!designer.dashboardSaving) void saveDashboard();
+        void saveDashboard();
+        return;
+      }
+
+      if (
+        modifier
+        && key === 'd'
+        && designer.selectedId
+        && !isEditableTarget(event.target)
+      ) {
+        event.preventDefault();
+        designer.duplicateWidget(designer.selectedId);
         return;
       }
 

--- a/yak-ops-ui/src/pages/dashboard/editor.tsx
+++ b/yak-ops-ui/src/pages/dashboard/editor.tsx
@@ -1,17 +1,24 @@
 import { history, useParams } from '@umijs/max';
 import { BRAND_CSS_VARIABLES } from '@/styles/brand';
-import { Button } from 'antd';
+import { Button, Modal } from 'antd';
 import { BarChart3 } from 'lucide-react';
 import ReactGridLayout, { useContainerWidth } from 'react-grid-layout';
 import 'react-grid-layout/css/styles.css';
 import 'react-resizable/css/styles.css';
-import { useMemo } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import { ChartEditor } from './chart-editor';
 import { DashboardGlobalFilterBar } from './global-filter-bar';
 import { GRID_COLUMNS, GRID_ROW_HEIGHT } from './helpers';
 import { DashboardToolbar } from './toolbar';
 import { useDashboardDesigner } from './use-dashboard';
 import { WidgetShell } from './widget';
+
+const isEditableTarget = (target: EventTarget | null) => {
+  if (!(target instanceof HTMLElement)) return false;
+  return target.isContentEditable
+    || ['INPUT', 'TEXTAREA', 'SELECT'].includes(target.tagName)
+    || Boolean(target.closest('.monaco-editor'));
+};
 
 export default function DashboardEditorPage() {
   const { id } = useParams<{ id?: string }>();
@@ -37,25 +44,86 @@ export default function DashboardEditorPage() {
     canvasMinHeight = 'min-h-[calc(100vh-156px)]';
   }
 
-  const syncLayout = (
-    nextLayout: readonly { i: string; x: number; y: number; w: number; h: number }[],
-  ) => {
-    const nextMap = new Map(nextLayout.map((item) => [item.i, item]));
-    designer.setDashboard((current) => ({
-      ...current,
-      widgets: current.widgets.map((widget) => {
-        const next = nextMap.get(widget.id);
-        return next ? { ...widget, x: next.x, y: next.y, w: next.w, h: next.h } : widget;
-      }),
-    }));
-  };
-
   const addChart = () => designer.addWidget('bar');
 
-  const saveDashboard = async () => {
+  const saveDashboard = useCallback(async () => {
+    if (designer.dashboardSaving) return;
     const persistedId = await designer.save();
     if (!dashboardId && persistedId) history.replace(`/dashboard/${persistedId}`);
+  }, [dashboardId, designer]);
+
+  const leaveDashboard = () => {
+    if (!designer.dirty) {
+      history.push('/dashboard');
+      return;
+    }
+    Modal.confirm({
+      title: '有未保存修改',
+      content: '当前仪表盘还有未保存的修改，离开后这些修改会丢失。',
+      okText: '放弃修改并离开',
+      cancelText: '继续编辑',
+      okButtonProps: { danger: true },
+      onOk: () => history.push('/dashboard'),
+    });
   };
+
+  const changeVersion = (versionNo: number) => {
+    if (!designer.dirty) {
+      void designer.activateVersion(versionNo);
+      return;
+    }
+    Modal.confirm({
+      title: '切换历史版本？',
+      content: '当前修改尚未保存。切换版本会放弃这些修改并加载所选版本。',
+      okText: '放弃修改并切换',
+      cancelText: '继续编辑',
+      onOk: () => designer.activateVersion(versionNo),
+    });
+  };
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (designer.preview) return;
+      const key = event.key.toLowerCase();
+      const modifier = event.metaKey || event.ctrlKey;
+
+      if (modifier && key === 'z') {
+        event.preventDefault();
+        if (event.shiftKey) designer.redo();
+        else designer.undo();
+        return;
+      }
+
+      if (modifier && key === 'y') {
+        event.preventDefault();
+        designer.redo();
+        return;
+      }
+
+      if (modifier && key === 's') {
+        event.preventDefault();
+        if (!designer.dashboardSaving) void saveDashboard();
+        return;
+      }
+
+      if (event.key === 'Escape' && designer.selectedId) {
+        designer.setSelectedId(undefined);
+        return;
+      }
+
+      if (
+        (event.key === 'Delete' || event.key === 'Backspace')
+        && designer.selectedId
+        && !isEditableTarget(event.target)
+      ) {
+        event.preventDefault();
+        designer.deleteWidget(designer.selectedId);
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [designer, saveDashboard]);
 
   return (
     <div
@@ -69,10 +137,16 @@ export default function DashboardEditorPage() {
         versions={designer.dashboardVersions}
         saving={designer.dashboardSaving}
         preview={designer.preview}
+        dirty={designer.dirty}
+        canUndo={designer.canUndo}
+        canRedo={designer.canRedo}
         canAddChart={Boolean(designer.activeDataset) && !designer.datasetsLoading}
-        onName={(name) => designer.setDashboard((current) => ({ ...current, name }))}
+        onBack={leaveDashboard}
+        onName={designer.updateDashboardName}
+        onUndo={designer.undo}
+        onRedo={designer.redo}
         onAddChart={addChart}
-        onVersion={(versionNo) => void designer.activateVersion(versionNo)}
+        onVersion={changeVersion}
         onPreview={() => {
           designer.setPreview((current) => !current);
           designer.setSelectedId(undefined);
@@ -118,7 +192,7 @@ export default function DashboardEditorPage() {
                     handle: '.dashboard-widget__drag-handle',
                   }}
                   resizeConfig={{ enabled: !designer.preview }}
-                  onLayoutChange={syncLayout}
+                  onLayoutChange={designer.updateLayout}
                 >
                   {designer.widgets.map((widget) => {
                     const analysis = widget.analysisId
@@ -193,10 +267,8 @@ export default function DashboardEditorPage() {
               designer.updateWidget(designer.selectedWidget!.id, patch)}
             updateInlineAnalysis={(patch) =>
               designer.updateInlineAnalysis(designer.selectedWidget!.id, patch)}
-            changeDataset={(datasetId) => {
-              designer.setDashboard((current) => ({ ...current, activeDatasetId: datasetId }));
-              designer.changeWidgetDataset(designer.selectedWidget!.id, datasetId);
-            }}
+            changeDataset={(datasetId) =>
+              designer.changeWidgetDataset(designer.selectedWidget!.id, datasetId)}
             detachAnalysis={() =>
               designer.detachAnalysis(designer.selectedWidget!.id)}
             close={() => designer.setSelectedId(undefined)}

--- a/yak-ops-ui/src/pages/dashboard/toolbar.tsx
+++ b/yak-ops-ui/src/pages/dashboard/toolbar.tsx
@@ -1,6 +1,14 @@
-import { history } from '@umijs/max';
-import { Button, Input, Select } from 'antd';
-import { BarChart3, ChevronLeft, Eye, History, Save, X } from 'lucide-react';
+import { Button, Input, Select, Tooltip } from 'antd';
+import {
+  BarChart3,
+  ChevronLeft,
+  Eye,
+  History,
+  Redo2,
+  Save,
+  Undo2,
+  X,
+} from 'lucide-react';
 import type { DashboardVersionSummary } from './model';
 
 export function DashboardToolbar({
@@ -10,8 +18,14 @@ export function DashboardToolbar({
   versions,
   saving,
   preview,
+  dirty,
+  canUndo,
+  canRedo,
   canAddChart,
+  onBack,
   onName,
+  onUndo,
+  onRedo,
   onAddChart,
   onVersion,
   onPreview,
@@ -23,14 +37,21 @@ export function DashboardToolbar({
   versions: DashboardVersionSummary[];
   saving: boolean;
   preview: boolean;
+  dirty: boolean;
+  canUndo: boolean;
+  canRedo: boolean;
   canAddChart: boolean;
+  onBack: () => void;
   onName: (name: string) => void;
+  onUndo: () => void;
+  onRedo: () => void;
   onAddChart: () => void;
   onVersion: (versionNo: number) => void;
   onPreview: () => void;
   onSave: () => void;
 }) {
   const persisted = /^\d+$/.test(dashboardId);
+  const saveDisabled = persisted && !dirty;
 
   return (
     <header className="flex h-12 shrink-0 items-center justify-between border-b border-[#dfe3e8] bg-white px-3">
@@ -40,7 +61,7 @@ export function DashboardToolbar({
           type="text"
           icon={<ChevronLeft size={14} />}
           disabled={preview}
-          onClick={() => history.push('/dashboard')}
+          onClick={onBack}
         >
           仪表盘
         </Button>
@@ -55,18 +76,49 @@ export function DashboardToolbar({
         <span className="rounded-[3px] bg-[#f5f6f7] px-2 py-0.5 text-[10px] text-[#667085]">
           {currentVersionNo ? `V${currentVersionNo}` : '未保存'}
         </span>
+        {dirty ? (
+          <span className="flex shrink-0 items-center gap-1.5 text-[10px] text-[#667085]">
+            <span className="h-1.5 w-1.5 rounded-full bg-[#98a2b3]" />
+            有未保存修改
+          </span>
+        ) : null}
       </div>
 
       <div className="flex items-center gap-2">
         {!preview ? (
-          <Button
-            size="small"
-            disabled={!canAddChart}
-            icon={<BarChart3 size={13} />}
-            onClick={onAddChart}
-          >
-            添加图表
-          </Button>
+          <>
+            <div className="flex items-center rounded-[5px] border border-[#e5e7eb] bg-white p-0.5">
+              <Tooltip title="撤销 Ctrl/Cmd + Z">
+                <Button
+                  size="small"
+                  type="text"
+                  className="h-6 w-7 px-0"
+                  icon={<Undo2 size={13} />}
+                  disabled={!canUndo || saving}
+                  onClick={onUndo}
+                />
+              </Tooltip>
+              <Tooltip title="重做 Ctrl/Cmd + Shift + Z">
+                <Button
+                  size="small"
+                  type="text"
+                  className="h-6 w-7 px-0"
+                  icon={<Redo2 size={13} />}
+                  disabled={!canRedo || saving}
+                  onClick={onRedo}
+                />
+              </Tooltip>
+            </div>
+            <span className="h-5 w-px bg-[#e5e7eb]" />
+            <Button
+              size="small"
+              disabled={!canAddChart}
+              icon={<BarChart3 size={13} />}
+              onClick={onAddChart}
+            >
+              添加图表
+            </Button>
+          </>
         ) : null}
         {persisted && versions.length ? (
           <Select
@@ -90,15 +142,20 @@ export function DashboardToolbar({
           {preview ? '退出预览' : '预览'}
         </Button>
         {!preview ? (
-          <Button
-            size="small"
-            type="primary"
-            loading={saving}
-            icon={<Save size={13} />}
-            onClick={onSave}
-          >
-            保存
-          </Button>
+          <Tooltip title={saveDisabled ? '当前没有需要保存的修改' : '保存 Ctrl/Cmd + S'}>
+            <span>
+              <Button
+                size="small"
+                type="primary"
+                loading={saving}
+                disabled={saveDisabled}
+                icon={<Save size={13} />}
+                onClick={onSave}
+              >
+                保存
+              </Button>
+            </span>
+          </Tooltip>
         ) : null}
       </div>
     </header>

--- a/yak-ops-ui/src/pages/dashboard/use-dashboard.ts
+++ b/yak-ops-ui/src/pages/dashboard/use-dashboard.ts
@@ -6,7 +6,7 @@ import type {
   Scalar,
 } from '@/components/analysis/model';
 import { message } from 'antd';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { DEFAULT_DASHBOARD } from './defaults';
 import {
   activateDashboardVersion,
@@ -35,6 +35,9 @@ import type {
 } from './model';
 import { fetchDashboardDatasets } from './service';
 
+const HISTORY_LIMIT = 50;
+const HISTORY_MERGE_WINDOW = 500;
+
 const assetSpec = (analysis: AnalysisAsset): AnalysisSpec => ({
   type: analysis.type,
   datasetId: analysis.datasetId,
@@ -57,8 +60,28 @@ const runtimeDefaults = (filters: DashboardGlobalFilter[]) => Object.fromEntries
 const hasOwn = (value: Record<string, Scalar | undefined>, key: string) =>
   Object.prototype.hasOwnProperty.call(value, key);
 
+const dashboardFingerprint = (dashboard: DashboardDocument) => JSON.stringify({
+  name: dashboard.name,
+  description: dashboard.description,
+  activeDatasetId: dashboard.activeDatasetId,
+  widgets: dashboard.widgets,
+  globalFilters: dashboard.globalFilters,
+  interactions: dashboard.interactions,
+});
+
+const trimHistory = (items: DashboardDocument[]) => (
+  items.length > HISTORY_LIMIT ? items.slice(items.length - HISTORY_LIMIT) : items
+);
+
 export function useDashboardDesigner(dashboardId?: string) {
-  const [dashboard, setDashboard] = useState<DashboardDocument>(() => cloneDashboard(DEFAULT_DASHBOARD));
+  const initialDashboard = useMemo(() => cloneDashboard(DEFAULT_DASHBOARD), []);
+  const [dashboard, setDashboardState] = useState<DashboardDocument>(initialDashboard);
+  const dashboardRef = useRef<DashboardDocument>(initialDashboard);
+  const savedFingerprintRef = useRef(dashboardFingerprint(initialDashboard));
+  const undoStackRef = useRef<DashboardDocument[]>([]);
+  const redoStackRef = useRef<DashboardDocument[]>([]);
+  const lastHistoryRef = useRef<{ key: string; at: number }>();
+
   const [datasets, setDatasets] = useState<PublishedDataset[]>([]);
   const [datasetsLoading, setDatasetsLoading] = useState(true);
   const [analyses, setAnalyses] = useState<AnalysisAsset[]>([]);
@@ -74,6 +97,80 @@ export function useDashboardDesigner(dashboardId?: string) {
     () => findDataset(datasets, dashboard.activeDatasetId),
     [dashboard.activeDatasetId, datasets],
   );
+  const dirty = dashboardFingerprint(dashboard) !== savedFingerprintRef.current;
+  const canUndo = undoStackRef.current.length > 0;
+  const canRedo = redoStackRef.current.length > 0;
+
+  const setDashboardWithoutHistory = useCallback((next: DashboardDocument) => {
+    const cloned = cloneDashboard(next);
+    dashboardRef.current = cloned;
+    setDashboardState(cloned);
+    setSelectedId((current) => (
+      current && cloned.widgets.some((widget) => widget.id === current) ? current : undefined
+    ));
+  }, []);
+
+  const resetDashboardState = useCallback((next: DashboardDocument, markSaved = true) => {
+    const cloned = cloneDashboard(next);
+    dashboardRef.current = cloned;
+    undoStackRef.current = [];
+    redoStackRef.current = [];
+    lastHistoryRef.current = undefined;
+    if (markSaved) savedFingerprintRef.current = dashboardFingerprint(cloned);
+    setDashboardState(cloned);
+    setSelectedId(undefined);
+  }, []);
+
+  const commitDashboard = useCallback((
+    updater: DashboardDocument | ((current: DashboardDocument) => DashboardDocument),
+    historyKey: string,
+  ) => {
+    const current = dashboardRef.current;
+    const next = typeof updater === 'function' ? updater(current) : updater;
+    if (dashboardFingerprint(current) === dashboardFingerprint(next)) return;
+
+    const now = Date.now();
+    const last = lastHistoryRef.current;
+    const mergeWithPrevious = Boolean(
+      last
+      && last.key === historyKey
+      && now - last.at <= HISTORY_MERGE_WINDOW,
+    );
+
+    if (!mergeWithPrevious) {
+      undoStackRef.current = trimHistory([
+        ...undoStackRef.current,
+        cloneDashboard(current),
+      ]);
+    }
+    redoStackRef.current = [];
+    lastHistoryRef.current = { key: historyKey, at: now };
+    setDashboardWithoutHistory(next);
+  }, [setDashboardWithoutHistory]);
+
+  const undo = useCallback(() => {
+    const previous = undoStackRef.current.at(-1);
+    if (!previous) return;
+    undoStackRef.current = undoStackRef.current.slice(0, -1);
+    redoStackRef.current = trimHistory([
+      ...redoStackRef.current,
+      cloneDashboard(dashboardRef.current),
+    ]);
+    lastHistoryRef.current = undefined;
+    setDashboardWithoutHistory(previous);
+  }, [setDashboardWithoutHistory]);
+
+  const redo = useCallback(() => {
+    const next = redoStackRef.current.at(-1);
+    if (!next) return;
+    redoStackRef.current = redoStackRef.current.slice(0, -1);
+    undoStackRef.current = trimHistory([
+      ...undoStackRef.current,
+      cloneDashboard(dashboardRef.current),
+    ]);
+    lastHistoryRef.current = undefined;
+    setDashboardWithoutHistory(next);
+  }, [setDashboardWithoutHistory]);
 
   const loadDatasets = useCallback(async () => {
     setDatasetsLoading(true);
@@ -97,14 +194,13 @@ export function useDashboardDesigner(dashboardId?: string) {
   const openDashboard = useCallback(async (targetDashboardId: string) => {
     try {
       const detail = await fetchDashboard(targetDashboardId);
-      setDashboard(toDashboardDocument(detail));
+      resetDashboardState(toDashboardDocument(detail));
       setDashboardVersions(detail.versions);
-      setSelectedId(undefined);
       window.localStorage.removeItem(STORAGE_KEY);
     } catch (error) {
       message.error(error instanceof Error ? error.message : '加载 Dashboard 失败');
     }
-  }, []);
+  }, [resetDashboardState]);
 
   useEffect(() => {
     void loadDatasets();
@@ -116,33 +212,72 @@ export function useDashboardDesigner(dashboardId?: string) {
       void openDashboard(dashboardId);
       return;
     }
-    setDashboard(cloneDashboard(DEFAULT_DASHBOARD));
+    resetDashboardState(cloneDashboard(DEFAULT_DASHBOARD));
     setDashboardVersions([]);
-    setSelectedId(undefined);
     setRuntimeFilterValues({});
-  }, [dashboardId, openDashboard]);
+  }, [dashboardId, openDashboard, resetDashboardState]);
 
   useEffect(() => {
     if (!datasets.length) return;
-    setDashboard((current) => reconcileDashboard(current, datasets));
-  }, [datasets]);
+    const current = dashboardRef.current;
+    const next = reconcileDashboard(current, datasets);
+    if (dashboardFingerprint(current) === dashboardFingerprint(next)) return;
+
+    const wasClean = dashboardFingerprint(current) === savedFingerprintRef.current;
+    if (wasClean) savedFingerprintRef.current = dashboardFingerprint(next);
+    setDashboardWithoutHistory(next);
+  }, [datasets, setDashboardWithoutHistory]);
 
   useEffect(() => {
     setRuntimeFilterValues(runtimeDefaults(dashboard.globalFilters));
   }, [dashboard.id, dashboard.currentVersionId]);
 
-  const updateWidget = (id: string, patch: Partial<DashboardWidget>) => setDashboard((current) => ({
-    ...current,
-    widgets: current.widgets.map((widget) => widget.id === id ? { ...widget, ...patch } : widget),
-  }));
+  useEffect(() => {
+    if (!dirty) return undefined;
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      event.preventDefault();
+      event.returnValue = '';
+    };
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    return () => window.removeEventListener('beforeunload', handleBeforeUnload);
+  }, [dirty]);
 
-  const updateInlineAnalysis = (id: string, patch: Partial<AnalysisSpec>) => setDashboard((current) => ({
-    ...current,
-    widgets: current.widgets.map((widget) => {
-      if (widget.id !== id || widget.analysisId || !widget.inlineAnalysis) return widget;
-      return { ...widget, inlineAnalysis: { ...widget.inlineAnalysis, ...patch } };
+  const updateDashboardName = (name: string) => commitDashboard(
+    (current) => ({ ...current, name }),
+    'dashboard:name',
+  );
+
+  const updateLayout = (
+    nextLayout: readonly { i: string; x: number; y: number; w: number; h: number }[],
+  ) => {
+    const nextMap = new Map(nextLayout.map((item) => [item.i, item]));
+    commitDashboard((current) => ({
+      ...current,
+      widgets: current.widgets.map((widget) => {
+        const next = nextMap.get(widget.id);
+        return next ? { ...widget, x: next.x, y: next.y, w: next.w, h: next.h } : widget;
+      }),
+    }), 'dashboard:layout');
+  };
+
+  const updateWidget = (id: string, patch: Partial<DashboardWidget>) => commitDashboard(
+    (current) => ({
+      ...current,
+      widgets: current.widgets.map((widget) => widget.id === id ? { ...widget, ...patch } : widget),
     }),
-  }));
+    `widget:${id}:${Object.keys(patch).sort().join(',')}`,
+  );
+
+  const updateInlineAnalysis = (id: string, patch: Partial<AnalysisSpec>) => commitDashboard(
+    (current) => ({
+      ...current,
+      widgets: current.widgets.map((widget) => {
+        if (widget.id !== id || widget.analysisId || !widget.inlineAnalysis) return widget;
+        return { ...widget, inlineAnalysis: { ...widget.inlineAnalysis, ...patch } };
+      }),
+    }),
+    `widget:${id}:analysis:${Object.keys(patch).sort().join(',')}`,
+  );
 
   const setRuntimeFilterValue = (filterId: string, value: Scalar | undefined) => {
     setRuntimeFilterValues((current) => ({ ...current, [filterId]: value }));
@@ -183,30 +318,40 @@ export function useDashboardDesigner(dashboardId?: string) {
     });
   }, [dashboard.interactions]);
 
-  const maxY = () => widgets.reduce((value, widget) => Math.max(value, widget.y + widget.h), 0);
+  const maxY = () => dashboardRef.current.widgets.reduce(
+    (value, widget) => Math.max(value, widget.y + widget.h),
+    0,
+  );
 
   const addWidget = (type: ChartType) => {
     if (!activeDataset) return void message.info('请先发布一个 ONLINE Dataset');
     const next = createWidget(type, activeDataset, maxY());
-    setDashboard((current) => ({ ...current, widgets: [...current.widgets, next] }));
+    commitDashboard(
+      (current) => ({ ...current, widgets: [...current.widgets, next] }),
+      `widget:add:${next.id}`,
+    );
     setSelectedId(next.id);
   };
 
   const detachAnalysis = (id: string) => {
-    const widget = widgets.find((item) => item.id === id);
+    const widget = dashboardRef.current.widgets.find((item) => item.id === id);
     if (!widget?.analysisId) return;
     const analysis = analyses.find((item) => item.id === widget.analysisId);
     if (!analysis) return void message.warning('引用的 Analysis 已不可用，无法生成独立副本');
-    updateWidget(id, {
-      analysisId: undefined,
-      title: analysis.name,
-      inlineAnalysis: assetSpec(analysis),
-    });
+    commitDashboard((current) => ({
+      ...current,
+      widgets: current.widgets.map((item) => item.id === id ? {
+        ...item,
+        analysisId: undefined,
+        title: analysis.name,
+        inlineAnalysis: assetSpec(analysis),
+      } : item),
+    }), `widget:${id}:detach`);
     message.success('已解除 Analysis 引用，当前组件已复制为 Dashboard 本地图表');
   };
 
   const duplicateWidget = (id: string) => {
-    const source = widgets.find((widget) => widget.id === id);
+    const source = dashboardRef.current.widgets.find((widget) => widget.id === id);
     if (!source) return;
     const next: DashboardWidget = {
       ...source,
@@ -216,12 +361,15 @@ export function useDashboardDesigner(dashboardId?: string) {
         ? JSON.parse(JSON.stringify(source.inlineAnalysis)) as AnalysisSpec
         : undefined,
     };
-    setDashboard((current) => ({ ...current, widgets: [...current.widgets, next] }));
+    commitDashboard(
+      (current) => ({ ...current, widgets: [...current.widgets, next] }),
+      `widget:duplicate:${id}`,
+    );
     setSelectedId(next.id);
   };
 
   const deleteWidget = (id: string) => {
-    setDashboard((current) => ({
+    commitDashboard((current) => ({
       ...current,
       widgets: current.widgets.filter((widget) => widget.id !== id),
       globalFilters: current.globalFilters.map((filter) => ({
@@ -229,18 +377,19 @@ export function useDashboardDesigner(dashboardId?: string) {
         bindings: filter.bindings.filter((binding) => binding.widgetId !== id),
       })),
       interactions: current.interactions.filter((interaction) => interaction.sourceWidgetId !== id),
-    }));
+    }), `widget:delete:${id}`);
     setSelectedId((current) => current === id ? undefined : current);
   };
 
   const changeWidgetDataset = (id: string, datasetId: string) => {
-    const widget = widgets.find((item) => item.id === id);
+    const widget = dashboardRef.current.widgets.find((item) => item.id === id);
     if (widget?.analysisId) return void message.info('该组件引用历史共享图表，请先复制为可编辑图表');
     if (!widget?.inlineAnalysis) return;
     const dataset = findDataset(datasets, datasetId);
     if (!dataset) return;
-    setDashboard((current) => ({
+    commitDashboard((current) => ({
       ...current,
+      activeDatasetId: datasetId,
       widgets: current.widgets.map((item) => item.id === id
         ? { ...item, inlineAnalysis: createInlineAnalysis(item.inlineAnalysis!.type, dataset) }
         : item),
@@ -249,21 +398,22 @@ export function useDashboardDesigner(dashboardId?: string) {
         bindings: filter.bindings.filter((binding) => binding.widgetId !== id),
       })),
       interactions: current.interactions.filter((interaction) => interaction.sourceWidgetId !== id),
-    }));
+    }), `widget:${id}:dataset`);
   };
 
   const save = async (): Promise<string | undefined> => {
-    if (!dashboard.name.trim()) {
+    const currentDashboard = dashboardRef.current;
+    if (!currentDashboard.name.trim()) {
       message.warning('请输入仪表盘名称');
       return undefined;
     }
     setDashboardSaving(true);
     try {
-      const detail = isPersistedDashboard(dashboard.id)
-        ? await saveDashboardVersion(dashboard.id, dashboard)
-        : await createDashboard(dashboard);
+      const detail = isPersistedDashboard(currentDashboard.id)
+        ? await saveDashboardVersion(currentDashboard.id, currentDashboard)
+        : await createDashboard(currentDashboard);
       const document = toDashboardDocument(detail);
-      setDashboard(document);
+      resetDashboardState(document);
       setDashboardVersions(detail.versions);
       window.localStorage.removeItem(STORAGE_KEY);
       message.success(`仪表盘已保存为 V${detail.dashboard.currentVersionNo}`);
@@ -277,13 +427,13 @@ export function useDashboardDesigner(dashboardId?: string) {
   };
 
   const activateVersion = async (versionNo: number) => {
-    if (!isPersistedDashboard(dashboard.id) || versionNo === dashboard.currentVersionNo) return;
+    const currentDashboard = dashboardRef.current;
+    if (!isPersistedDashboard(currentDashboard.id) || versionNo === currentDashboard.currentVersionNo) return;
     setDashboardSaving(true);
     try {
-      const detail = await activateDashboardVersion(dashboard.id, versionNo);
-      setDashboard(toDashboardDocument(detail));
+      const detail = await activateDashboardVersion(currentDashboard.id, versionNo);
+      resetDashboardState(toDashboardDocument(detail));
       setDashboardVersions(detail.versions);
-      setSelectedId(undefined);
       message.success(`已切换到 Dashboard V${versionNo}`);
     } catch (error) {
       message.error(error instanceof Error ? error.message : '切换 DashboardVersion 失败');
@@ -305,9 +455,13 @@ export function useDashboardDesigner(dashboardId?: string) {
     activeDataset,
     selectedId,
     preview,
-    setDashboard,
+    dirty,
+    canUndo,
+    canRedo,
     setSelectedId,
     setPreview,
+    updateDashboardName,
+    updateLayout,
     updateWidget,
     updateInlineAnalysis,
     setRuntimeFilterValue,
@@ -319,6 +473,8 @@ export function useDashboardDesigner(dashboardId?: string) {
     duplicateWidget,
     deleteWidget,
     changeWidgetDataset,
+    undo,
+    redo,
     save,
     activateVersion,
   };

--- a/yak-ops-ui/src/pages/dashboard/widget.tsx
+++ b/yak-ops-ui/src/pages/dashboard/widget.tsx
@@ -1,6 +1,6 @@
 import { AnalysisPreview } from '@/components/analysis/AnalysisPreview';
-import { Empty, Tooltip } from 'antd';
-import { Copy, GripVertical, Trash2 } from 'lucide-react';
+import { Dropdown, Empty, Tooltip } from 'antd';
+import { Copy, GripVertical, MoreHorizontal, Trash2 } from 'lucide-react';
 import type {
   AnalysisAsset,
   AnalysisSelection,
@@ -41,16 +41,24 @@ export function WidgetShell({
     <div
       onMouseDown={onSelect}
       className={[
-        'group relative flex h-full min-h-0 flex-col overflow-hidden bg-white',
+        'group relative flex h-full min-h-0 flex-col overflow-hidden bg-white transition-[border-color,box-shadow] duration-150',
         preview
           ? 'border border-[#e7eaf0]'
           : selected
             ? 'border border-[var(--yak-brand-color)] shadow-[0_0_0_1px_var(--yak-brand-color-soft)]'
-            : 'border border-[#e3e7ed] hover:border-[#cbd2dc]',
+            : 'border border-[#e3e7ed] hover:border-[#d2d7df] hover:shadow-[0_2px_8px_rgba(16,24,40,.06)]',
       ].join(' ')}
     >
       <div className="dashboard-widget__drag-handle flex h-9 shrink-0 cursor-move items-center border-b border-[#f0f2f5] px-3">
-        {!preview ? <GripVertical size={13} className="mr-1 text-[#98a2b3]" /> : null}
+        {!preview ? (
+          <GripVertical
+            size={13}
+            className={[
+              'mr-1 text-[#98a2b3] transition-opacity duration-150',
+              selected ? 'opacity-100' : 'opacity-45 group-hover:opacity-100',
+            ].join(' ')}
+          />
+        ) : null}
         <span className="min-w-0 flex-1 truncate text-[12px] font-medium text-[#344054]">
           {title}
         </span>
@@ -58,36 +66,47 @@ export function WidgetShell({
         {!preview ? (
           <div
             className={[
-              'flex items-center gap-0.5 transition-opacity',
+              'flex items-center transition-opacity duration-150',
               selected ? 'opacity-100' : 'opacity-0 group-hover:opacity-100',
             ].join(' ')}
           >
-            <Tooltip title="复制">
-              <button
-                type="button"
-                onMouseDown={(event) => event.stopPropagation()}
-                onClick={(event) => {
-                  event.stopPropagation();
-                  onDuplicate();
-                }}
-                className="flex h-6 w-6 items-center justify-center border-0 bg-transparent text-[#667085] hover:bg-[#f5f6f7]"
-              >
-                <Copy size={12} />
-              </button>
-            </Tooltip>
-            <Tooltip title="删除">
-              <button
-                type="button"
-                onMouseDown={(event) => event.stopPropagation()}
-                onClick={(event) => {
-                  event.stopPropagation();
-                  onDelete();
-                }}
-                className="flex h-6 w-6 items-center justify-center border-0 bg-transparent text-[#667085] hover:bg-[#fff1f2] hover:text-[#d92d20]"
-              >
-                <Trash2 size={12} />
-              </button>
-            </Tooltip>
+            <Dropdown
+              trigger={['click']}
+              placement="bottomRight"
+              menu={{
+                items: [
+                  {
+                    key: 'duplicate',
+                    label: '复制组件',
+                    icon: <Copy size={13} />,
+                  },
+                  { type: 'divider' },
+                  {
+                    key: 'delete',
+                    label: '删除组件',
+                    icon: <Trash2 size={13} />,
+                    danger: true,
+                  },
+                ],
+                onClick: ({ key, domEvent }) => {
+                  domEvent.stopPropagation();
+                  if (key === 'duplicate') onDuplicate();
+                  if (key === 'delete') onDelete();
+                },
+              }}
+            >
+              <Tooltip title="更多操作">
+                <button
+                  type="button"
+                  aria-label="组件操作"
+                  onMouseDown={(event) => event.stopPropagation()}
+                  onClick={(event) => event.stopPropagation()}
+                  className="flex h-6 w-6 items-center justify-center rounded-[4px] border-0 bg-transparent text-[#667085] transition-colors hover:bg-[#f5f6f7] hover:text-[#344054]"
+                >
+                  <MoreHorizontal size={13} />
+                </button>
+              </Tooltip>
+            </Dropdown>
           </div>
         ) : null}
       </div>


### PR DESCRIPTION
## Summary

完成 Dashboard 路线图的 Stage 1：不扩展新的 BI Domain，专注把现有 Canvas + Chart Editor 打磨成更完整、可恢复、可放心编辑的设计器体验。

本阶段保持现有 Dataset / Analysis / DashboardVersion / Filter / Interaction 协议不变，仅调整 Dashboard 前端编辑态。

## 1. Dirty state

Dashboard 现在会区分“当前已保存基线”和“正在编辑的 Definition”：

- 修改名称、图表、布局、Dataset、维度/指标/样式后显示「有未保存修改」
- Runtime filter value、当前选中 Widget、预览开关不会污染 Dirty 状态
- 保存成功、打开 Dashboard、切换历史版本后重新建立保存基线
- 已保存 Dashboard 没有修改时禁用重复保存，快捷键保存也不会制造无意义版本
- 浏览器刷新/关闭时，如果存在未保存修改会触发 beforeunload 保护

## 2. Undo / Redo

新增 Dashboard Definition 级历史栈：

- 最多保留 50 个历史快照
- 支持名称修改、Chart Editor 配置、Dataset 切换、Widget 新增/复制/删除、拖拽和 Resize
- 连续文本输入 / 连续布局变化会按短时间窗口合并，避免逐字符产生 Undo 记录
- Undo / Redo 不记录 Runtime Filter、Preview、Selection 等运行态
- 保存或切换 Dashboard/Version 后清空旧编辑历史，避免跨 DashboardVersion 恢复错误元数据

顶部工具栏新增明确的 Undo / Redo 按钮。

快捷键：

- `Ctrl/Cmd + Z`：撤销
- `Ctrl/Cmd + Shift + Z` / `Ctrl + Y`：重做
- `Ctrl/Cmd + S`：保存
- `Ctrl/Cmd + D`：复制当前选中组件
- `Delete / Backspace`：删除当前选中组件（输入控件聚焦时不会触发）
- `Esc`：取消当前组件选中 / 关闭 Chart Editor

## 3. Unsaved-change guards

补齐容易误丢编辑内容的两个入口：

- 返回仪表盘列表前，如果有未保存修改会二次确认
- 切换 DashboardVersion 前，如果有未保存修改会二次确认

这部分只保护编辑态，不改变当前 Version activate 的后端语义；Draft / Publish 会留到 Stage 2 单独重构。

## 4. Widget interaction polish

收敛 Widget 顶部操作区：

- 默认保持干净，只在 Hover / Selected 时显示操作入口
- 原来的复制 / 删除两个常驻图标收进 `...` 更多菜单
- Hover 增加非常轻的 border / shadow 反馈
- Drag handle 默认弱化，Hover / Selected 时增强
- Selected 状态继续保留 Yak brand border，避免改变现有 Canvas 选择语义

复制和删除现在都进入 Undo/Redo 历史，因此误删组件可以直接撤销恢复。

## Scope

本 PR 只修改 4 个 Dashboard 前端文件：

- `dashboard/use-dashboard.ts`
- `dashboard/editor.tsx`
- `dashboard/toolbar.tsx`
- `dashboard/widget.tsx`

不修改：

- Dashboard 后端协议
- DashboardVersion 数据结构
- Dataset Query Runtime
- Analysis Domain
- Global Filter / Interaction Domain
- Chart 类型与 Query 能力
- Draft / Publish 模型（Stage 2）

## Stage 1 result

主编辑路径现在收敛为：

`编辑 → Dirty feedback → Undo/Redo → Preview → Save`

并为下一阶段 Draft / Publish 生命周期保留现有 DashboardVersion 边界。

## Verification

- 分支基于创建时最新 `main`：`df603b59a5abbfbaedfe305229b14776e05977da`
- 当前 branch 相对 main 保持 only-ahead，无基线落后
- diff 限定在 4 个 Dashboard 前端文件
- 已静态复核 RGL layout、Chart Editor 更新、保存/版本切换、Widget CRUD 都统一进入 Definition history
- GitHub 当前未返回 PR workflow run / commit status；当前 connector 环境也没有本地仓库依赖，因此未宣称 `npm run lint / tsc / build` 已通过
