### PR TITLE
feat(dashboard): complete stage 2 draft publish lifecycle

### DIFF
--- a/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/DashboardAsset.java
+++ b/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/DashboardAsset.java
@@ -5,13 +5,16 @@ import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 import java.time.Instant;
 import java.util.List;
 
-/** Stable Dashboard identity. Layout/query composition lives in immutable versions. */
+/** Stable Dashboard identity. The current version is the editable draft; published version is reader-facing. */
 public record DashboardAsset(
     @JsonSerialize(using = ToStringSerializer.class) long id,
     String name,
     String description,
     @JsonSerialize(using = ToStringSerializer.class) Long currentVersionId,
     int currentVersionNo,
+    @JsonSerialize(using = ToStringSerializer.class) Long publishedVersionId,
+    int publishedVersionNo,
+    Instant publishedTime,
     Instant createTime,
     Instant updateTime) {
 }
@@ -84,6 +87,15 @@ record DashboardDetail(
     DashboardAsset dashboard,
     DashboardVersion currentVersion,
     List<DashboardVersion> versions,
+    List<DashboardWidgetSnapshot> widgets,
+    List<DashboardGlobalFilterSnapshot> globalFilters,
+    List<DashboardInteractionSnapshot> interactions) {
+}
+
+/** Exact immutable version snapshot, used for history preview and published reads. */
+record DashboardVersionDetail(
+    DashboardAsset dashboard,
+    DashboardVersion version,
     List<DashboardWidgetSnapshot> widgets,
     List<DashboardGlobalFilterSnapshot> globalFilters,
     List<DashboardInteractionSnapshot> interactions) {

--- a/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/DashboardController.java
+++ b/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/DashboardController.java
@@ -35,7 +35,7 @@ public class DashboardController {
     return Result.success(service.list());
   }
 
-  @Operation(summary = "查询 Dashboard 当前版本和历史版本")
+  @Operation(summary = "查询 Dashboard 当前草稿和历史版本")
   @GetMapping("/{dashboardId}")
   public Result<DashboardDetail> get(@PathVariable("dashboardId") long dashboardId) {
     return Result.success(service.get(dashboardId));
@@ -47,13 +47,27 @@ public class DashboardController {
     return Result.success(service.versions(dashboardId));
   }
 
-  @Operation(summary = "创建 Dashboard，并产生 V1")
+  @Operation(summary = "查看指定 DashboardVersion 快照")
+  @GetMapping("/{dashboardId}/versions/{versionNo}")
+  public Result<DashboardVersionDetail> version(
+      @PathVariable("dashboardId") long dashboardId,
+      @PathVariable("versionNo") int versionNo) {
+    return Result.success(service.version(dashboardId, versionNo));
+  }
+
+  @Operation(summary = "查询 Dashboard 当前已发布快照")
+  @GetMapping("/{dashboardId}/published")
+  public Result<DashboardVersionDetail> published(@PathVariable("dashboardId") long dashboardId) {
+    return Result.success(service.published(dashboardId));
+  }
+
+  @Operation(summary = "创建 Dashboard，并保存草稿 V1")
   @PostMapping
   public Result<DashboardDetail> create(@Valid @RequestBody SaveDashboardRequest request) {
     return Result.success(service.create(toCommand(request)));
   }
 
-  @Operation(summary = "保存 Dashboard 新版本")
+  @Operation(summary = "保存 Dashboard 新草稿版本")
   @PostMapping("/{dashboardId}/versions")
   public Result<DashboardDetail> saveVersion(
       @PathVariable("dashboardId") long dashboardId,
@@ -61,7 +75,22 @@ public class DashboardController {
     return Result.success(service.saveVersion(dashboardId, toCommand(request)));
   }
 
-  @Operation(summary = "激活历史 DashboardVersion")
+  @Operation(summary = "发布当前 Dashboard 草稿")
+  @PostMapping("/{dashboardId}/publish")
+  public Result<DashboardDetail> publish(@PathVariable("dashboardId") long dashboardId) {
+    return Result.success(service.publish(dashboardId));
+  }
+
+  @Operation(summary = "将历史 DashboardVersion 恢复为新的草稿版本")
+  @PostMapping("/{dashboardId}/restore/{versionNo}")
+  public Result<DashboardDetail> restoreVersion(
+      @PathVariable("dashboardId") long dashboardId,
+      @PathVariable("versionNo") int versionNo) {
+    return Result.success(service.restoreVersion(dashboardId, versionNo));
+  }
+
+  @Deprecated
+  @Operation(summary = "兼容旧版激活接口：恢复历史版本为新草稿")
   @PostMapping("/{dashboardId}/activate/{versionNo}")
   public Result<DashboardDetail> activateVersion(
       @PathVariable("dashboardId") long dashboardId,

--- a/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/DashboardRepository.java
+++ b/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/DashboardRepository.java
@@ -10,6 +10,7 @@ interface DashboardRepository {
   void insertGlobalFilters(long versionId, List<DashboardService.GlobalFilterSpec> filters, List<String> defaultValueJson);
   void insertInteractions(long versionId, List<DashboardService.InteractionSpec> interactions);
   void updateCurrentVersion(long dashboardId, long versionId, int versionNo, String name, String description);
+  void updatePublishedVersion(long dashboardId, long versionId, int versionNo);
   Optional<DashboardAsset> findDashboard(long dashboardId);
   List<DashboardAsset> listDashboards();
   Optional<DashboardVersion> findVersion(long versionId);

--- a/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/DashboardService.java
+++ b/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/DashboardService.java
@@ -13,7 +13,7 @@ import java.util.Set;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-/** Owns Dashboard identity, immutable versions, layout and dashboard-level interaction definitions. */
+/** Owns Dashboard identity, immutable draft versions, published pointer, layout and dashboard interactions. */
 @Service
 public class DashboardService {
 
@@ -42,16 +42,14 @@ public class DashboardService {
   }
 
   public DashboardDetail get(long dashboardId) {
-    if (dashboardId <= 0L) throw new IllegalArgumentException("dashboardId 必须大于 0");
-    DashboardAsset dashboard = repository.findDashboard(dashboardId)
-        .orElseThrow(() -> new IllegalArgumentException("Dashboard 不存在：" + dashboardId));
+    DashboardAsset dashboard = requireDashboard(dashboardId);
     DashboardVersion currentVersion = null;
     List<DashboardWidgetSnapshot> widgets = List.of();
     List<DashboardGlobalFilterSnapshot> filters = List.of();
     List<DashboardInteractionSnapshot> interactions = List.of();
     if (dashboard.currentVersionId() != null) {
       currentVersion = repository.findVersion(dashboard.currentVersionId())
-          .orElseThrow(() -> new IllegalStateException("Dashboard 当前版本不存在：" + dashboard.currentVersionId()));
+          .orElseThrow(() -> new IllegalStateException("Dashboard 当前草稿版本不存在：" + dashboard.currentVersionId()));
       widgets = repository.listWidgets(currentVersion.id());
       filters = repository.listGlobalFilters(currentVersion.id());
       interactions = repository.listInteractions(currentVersion.id());
@@ -66,8 +64,29 @@ public class DashboardService {
   }
 
   public List<DashboardVersion> versions(long dashboardId) {
-    get(dashboardId);
+    requireDashboard(dashboardId);
     return repository.listVersions(dashboardId);
+  }
+
+  /** Reads one exact immutable historical snapshot without changing the editable draft pointer. */
+  public DashboardVersionDetail version(long dashboardId, int versionNo) {
+    DashboardAsset dashboard = requireDashboard(dashboardId);
+    if (versionNo <= 0) throw new IllegalArgumentException("versionNo 必须大于 0");
+    DashboardVersion version = repository.findVersionByNo(dashboardId, versionNo)
+        .orElseThrow(() -> new IllegalArgumentException("DashboardVersion 不存在：V" + versionNo));
+    return versionDetail(dashboard, version);
+  }
+
+  /** Reader-facing snapshot. Editing and saving drafts never changes this result until publish is called. */
+  public DashboardVersionDetail published(long dashboardId) {
+    DashboardAsset dashboard = requireDashboard(dashboardId);
+    if (dashboard.publishedVersionId() == null) {
+      throw new IllegalStateException("Dashboard 尚未发布：" + dashboardId);
+    }
+    DashboardVersion version = repository.findVersion(dashboard.publishedVersionId())
+        .orElseThrow(() -> new IllegalStateException(
+            "Dashboard 已发布版本不存在：" + dashboard.publishedVersionId()));
+    return versionDetail(dashboard, version);
   }
 
   @Transactional("yakBusinessTransactionManager")
@@ -78,30 +97,97 @@ public class DashboardService {
     return get(dashboardId);
   }
 
+  /** Saves an immutable draft snapshot only. It does not affect the published pointer. */
   @Transactional("yakBusinessTransactionManager")
   public DashboardDetail saveVersion(long dashboardId, SaveCommand command) {
-    get(dashboardId);
+    requireDashboard(dashboardId);
     Normalized normalized = normalize(command);
     int versionNo = repository.nextVersionNo(dashboardId);
     appendVersion(dashboardId, versionNo, normalized);
     return get(dashboardId);
   }
 
+  /** Publishes the current saved draft. Publishing is idempotent and does not create another version. */
+  @Transactional("yakBusinessTransactionManager")
+  public DashboardDetail publish(long dashboardId) {
+    DashboardAsset dashboard = requireDashboard(dashboardId);
+    if (dashboard.currentVersionId() == null || dashboard.currentVersionNo() <= 0) {
+      throw new IllegalStateException("Dashboard 没有可发布的草稿：" + dashboardId);
+    }
+    if (Objects.equals(dashboard.currentVersionId(), dashboard.publishedVersionId())) {
+      return get(dashboardId);
+    }
+    DashboardVersion draft = repository.findVersion(dashboard.currentVersionId())
+        .orElseThrow(() -> new IllegalStateException("Dashboard 当前草稿版本不存在：" + dashboard.currentVersionId()));
+    repository.updatePublishedVersion(dashboardId, draft.id(), draft.versionNo());
+    return get(dashboardId);
+  }
+
+  /**
+   * Restores an historical snapshot as a new editable draft version.
+   * The historical version remains immutable and the published pointer is deliberately unchanged.
+   */
+  @Transactional("yakBusinessTransactionManager")
+  public DashboardDetail restoreVersion(long dashboardId, int versionNo) {
+    DashboardVersionDetail source = version(dashboardId, versionNo);
+    Normalized normalized = normalize(commandFromVersion(source));
+    appendVersion(dashboardId, repository.nextVersionNo(dashboardId), normalized);
+    return get(dashboardId);
+  }
+
+  /** @deprecated Historical activation now restores the snapshot as a new draft instead of moving a pointer backwards. */
+  @Deprecated
   @Transactional("yakBusinessTransactionManager")
   public DashboardDetail activateVersion(long dashboardId, int versionNo) {
-    get(dashboardId);
-    if (versionNo <= 0) throw new IllegalArgumentException("versionNo 必须大于 0");
-    DashboardVersion version = repository.findVersionByNo(dashboardId, versionNo)
-        .orElseThrow(() -> new IllegalArgumentException("DashboardVersion 不存在：V" + versionNo));
-    repository.updateCurrentVersion(
-        dashboardId, version.id(), version.versionNo(), version.name(), version.description());
-    return get(dashboardId);
+    return restoreVersion(dashboardId, versionNo);
   }
 
   @Transactional("yakBusinessTransactionManager")
   public void delete(long dashboardId) {
-    get(dashboardId);
+    requireDashboard(dashboardId);
     repository.deleteDashboard(dashboardId);
+  }
+
+  private DashboardAsset requireDashboard(long dashboardId) {
+    if (dashboardId <= 0L) throw new IllegalArgumentException("dashboardId 必须大于 0");
+    return repository.findDashboard(dashboardId)
+        .orElseThrow(() -> new IllegalArgumentException("Dashboard 不存在：" + dashboardId));
+  }
+
+  private DashboardVersionDetail versionDetail(DashboardAsset dashboard, DashboardVersion version) {
+    return new DashboardVersionDetail(
+        dashboard,
+        version,
+        repository.listWidgets(version.id()),
+        repository.listGlobalFilters(version.id()),
+        repository.listInteractions(version.id()));
+  }
+
+  private SaveCommand commandFromVersion(DashboardVersionDetail detail) {
+    List<WidgetSpec> widgets = detail.widgets().stream()
+        .map(widget -> new WidgetSpec(
+            widget.widgetKey(), widget.analysisId(), widget.title(), widget.inlineAnalysis(),
+            widget.x(), widget.y(), widget.w(), widget.h(), widget.minW(), widget.minH()))
+        .toList();
+    List<GlobalFilterSpec> filters = detail.globalFilters().stream()
+        .map(filter -> new GlobalFilterSpec(
+            filter.filterKey(), filter.name(), filter.operator(), filter.defaultValue(),
+            filter.bindings().stream()
+                .map(binding -> new FilterBindingSpec(binding.widgetKey(), binding.fieldId()))
+                .toList()))
+        .toList();
+    List<InteractionSpec> interactions = detail.interactions().stream()
+        .map(interaction -> new InteractionSpec(
+            interaction.interactionKey(), interaction.event(), interaction.sourceWidgetKey(),
+            interaction.sourceFieldId(), interaction.targetFilterKey()))
+        .toList();
+    return new SaveCommand(
+        detail.version().name(),
+        detail.version().description(),
+        detail.version().activeDatasetId(),
+        widgets,
+        filters,
+        interactions);
   }
 
   private void appendVersion(long dashboardId, int versionNo, Normalized normalized) {

--- a/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/JdbcDashboardRepository.java
+++ b/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/JdbcDashboardRepository.java
@@ -25,7 +25,7 @@ import org.springframework.stereotype.Repository;
 class JdbcDashboardRepository implements DashboardRepository {
 
   private static final String DASHBOARD_COLUMNS =
-      "SELECT id, name, description, current_version_id, current_version_no, create_time, update_time FROM yak_dashboard";
+      "SELECT id, name, description, current_version_id, current_version_no, published_version_id, published_version_no, published_time, create_time, update_time FROM yak_dashboard";
   private static final String VERSION_COLUMNS =
       "SELECT id, dashboard_id, version_no, name_snapshot, description_snapshot, active_dataset_id, create_time FROM yak_dashboard_version";
 
@@ -44,7 +44,7 @@ class JdbcDashboardRepository implements DashboardRepository {
     KeyHolder keyHolder = new GeneratedKeyHolder();
     jdbcTemplate.update(connection -> {
       PreparedStatement statement = connection.prepareStatement(
-          "INSERT INTO yak_dashboard (name, description, current_version_id, current_version_no, create_time, update_time) VALUES (?, ?, NULL, 0, NOW(6), NOW(6))",
+          "INSERT INTO yak_dashboard (name, description, current_version_id, current_version_no, published_version_id, published_version_no, published_time, create_time, update_time) VALUES (?, ?, NULL, 0, NULL, 0, NULL, NOW(6), NOW(6))",
           Statement.RETURN_GENERATED_KEYS);
       statement.setString(1, name);
       statement.setString(2, description);
@@ -139,6 +139,14 @@ class JdbcDashboardRepository implements DashboardRepository {
     int updated = jdbcTemplate.update(
         "UPDATE yak_dashboard SET current_version_id = ?, current_version_no = ?, name = ?, description = ?, update_time = NOW(6) WHERE id = ?",
         versionId, versionNo, name, description, dashboardId);
+    if (updated != 1) throw new IllegalArgumentException("Dashboard 不存在：" + dashboardId);
+  }
+
+  @Override
+  public void updatePublishedVersion(long dashboardId, long versionId, int versionNo) {
+    int updated = jdbcTemplate.update(
+        "UPDATE yak_dashboard SET published_version_id = ?, published_version_no = ?, published_time = NOW(6), update_time = NOW(6) WHERE id = ?",
+        versionId, versionNo, dashboardId);
     if (updated != 1) throw new IllegalArgumentException("Dashboard 不存在：" + dashboardId);
   }
 
@@ -239,9 +247,18 @@ class JdbcDashboardRepository implements DashboardRepository {
 
   private static DashboardAsset mapDashboard(ResultSet rs, int rowNum) throws SQLException {
     Long currentVersionId = rs.getObject("current_version_id") == null ? null : rs.getLong("current_version_id");
+    Long publishedVersionId = rs.getObject("published_version_id") == null ? null : rs.getLong("published_version_id");
     return new DashboardAsset(
-        rs.getLong("id"), rs.getString("name"), rs.getString("description"), currentVersionId,
-        rs.getInt("current_version_no"), instant(rs.getTimestamp("create_time")), instant(rs.getTimestamp("update_time")));
+        rs.getLong("id"),
+        rs.getString("name"),
+        rs.getString("description"),
+        currentVersionId,
+        rs.getInt("current_version_no"),
+        publishedVersionId,
+        rs.getInt("published_version_no"),
+        instant(rs.getTimestamp("published_time")),
+        instant(rs.getTimestamp("create_time")),
+        instant(rs.getTimestamp("update_time")));
   }
 
   private static DashboardVersion mapVersion(ResultSet rs, int rowNum) throws SQLException {

--- a/yak-ops-business/yak-ops-business-dashboard/src/main/resources/db/migration/yak-dashboard/V3__dashboard_draft_publish.sql
+++ b/yak-ops-business/yak-ops-business-dashboard/src/main/resources/db/migration/yak-dashboard/V3__dashboard_draft_publish.sql
@@ -1,0 +1,15 @@
+-- Stage 2: separate editable draft pointer from reader-facing published pointer.
+ALTER TABLE yak_dashboard
+    ADD COLUMN published_version_id BIGINT NULL AFTER current_version_no,
+    ADD COLUMN published_version_no INT NOT NULL DEFAULT 0 AFTER published_version_id,
+    ADD COLUMN published_time DATETIME(6) NULL AFTER published_version_no,
+    ADD KEY idx_yak_dashboard_published_version (published_version_id);
+
+-- Existing Dashboard versions were previously both the editable and reader-facing state.
+-- Backfill them as published so the migration does not silently unpublish existing assets.
+UPDATE yak_dashboard
+SET published_version_id = current_version_id,
+    published_version_no = current_version_no,
+    published_time = update_time
+WHERE current_version_id IS NOT NULL
+  AND published_version_id IS NULL;

--- a/yak-ops-business/yak-ops-business-dashboard/src/test/java/io/yak/ops/business/dashboard/DashboardServiceTest.java
+++ b/yak-ops-business/yak-ops-business-dashboard/src/test/java/io/yak/ops/business/dashboard/DashboardServiceTest.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.Test;
 class DashboardServiceTest {
 
   @Test
-  void createPersistsV1AndValidatesAnalysisReference() {
+  void createPersistsDraftV1AndValidatesAnalysisReference() {
     FakeRepository repository = new FakeRepository();
     AnalysisReferenceService analysisReferences = mock(AnalysisReferenceService.class);
     DashboardService service = new DashboardService(repository, analysisReferences, new ObjectMapper());
@@ -33,6 +33,7 @@ class DashboardServiceTest {
             "link-region", DashboardInteractionEvent.SELECT, "w1", "region-field", "region"))));
 
     assertEquals(1, detail.dashboard().currentVersionNo());
+    assertEquals(0, detail.dashboard().publishedVersionNo());
     assertEquals(1, detail.versions().size());
     assertEquals(1, detail.widgets().size());
     assertEquals(1, detail.globalFilters().size());
@@ -42,20 +43,79 @@ class DashboardServiceTest {
   }
 
   @Test
-  void manualSaveCreatesImmutableNextVersion() {
+  void publishPointsToCurrentDraftWithoutCreatingAnotherVersion() {
     FakeRepository repository = new FakeRepository();
     DashboardService service = new DashboardService(repository, mock(AnalysisReferenceService.class), new ObjectMapper());
     DashboardDetail created = service.create(command(
         "A",
         List.of(new DashboardService.WidgetSpec("w1", null, "临时", Map.of("type", "bar"), 0, 0, 10, 7, 6, 5))));
 
+    DashboardDetail published = service.publish(created.dashboard().id());
+
+    assertEquals(1, published.dashboard().currentVersionNo());
+    assertEquals(1, published.dashboard().publishedVersionNo());
+    assertEquals(published.dashboard().currentVersionId(), published.dashboard().publishedVersionId());
+    assertEquals(1, published.versions().size());
+    assertEquals(1, service.published(created.dashboard().id()).version().versionNo());
+  }
+
+  @Test
+  void savingDraftAfterPublishDoesNotMovePublishedPointer() {
+    FakeRepository repository = new FakeRepository();
+    DashboardService service = new DashboardService(repository, mock(AnalysisReferenceService.class), new ObjectMapper());
+    DashboardDetail created = service.create(command(
+        "A",
+        List.of(new DashboardService.WidgetSpec("w1", null, "临时", Map.of("type", "bar"), 0, 0, 10, 7, 6, 5))));
+    service.publish(created.dashboard().id());
+
     DashboardDetail saved = service.saveVersion(created.dashboard().id(), command(
         "A2",
         List.of(new DashboardService.WidgetSpec("w1", null, "临时", Map.of("type", "line"), 1, 1, 10, 7, 6, 5))));
 
     assertEquals(2, saved.dashboard().currentVersionNo());
+    assertEquals(1, saved.dashboard().publishedVersionNo());
     assertEquals(2, saved.versions().size());
-    assertEquals("A", saved.versions().get(1).name());
+    assertEquals("A", service.published(created.dashboard().id()).version().name());
+  }
+
+  @Test
+  void restoreHistoricalVersionCreatesNewDraftAndKeepsPublishedVersion() {
+    FakeRepository repository = new FakeRepository();
+    DashboardService service = new DashboardService(repository, mock(AnalysisReferenceService.class), new ObjectMapper());
+    DashboardDetail created = service.create(command(
+        "A",
+        List.of(new DashboardService.WidgetSpec("w1", null, "临时", Map.of("type", "bar"), 0, 0, 10, 7, 6, 5))));
+    service.publish(created.dashboard().id());
+    service.saveVersion(created.dashboard().id(), command(
+        "A2",
+        List.of(new DashboardService.WidgetSpec("w1", null, "临时", Map.of("type", "line"), 1, 1, 10, 7, 6, 5))));
+
+    DashboardDetail restored = service.restoreVersion(created.dashboard().id(), 1);
+
+    assertEquals(3, restored.dashboard().currentVersionNo());
+    assertEquals(1, restored.dashboard().publishedVersionNo());
+    assertEquals("A", restored.currentVersion().name());
+    assertEquals("bar", ((Map<?, ?>) restored.widgets().get(0).inlineAnalysis()).get("type"));
+    assertEquals(3, restored.versions().size());
+  }
+
+  @Test
+  void versionDetailReadsHistoricalSnapshotWithoutChangingDraftPointer() {
+    FakeRepository repository = new FakeRepository();
+    DashboardService service = new DashboardService(repository, mock(AnalysisReferenceService.class), new ObjectMapper());
+    DashboardDetail created = service.create(command(
+        "A",
+        List.of(new DashboardService.WidgetSpec("w1", null, "临时", Map.of("type", "bar"), 0, 0, 10, 7, 6, 5))));
+    service.saveVersion(created.dashboard().id(), command(
+        "A2",
+        List.of(new DashboardService.WidgetSpec("w1", null, "临时", Map.of("type", "line"), 2, 3, 10, 7, 6, 5))));
+
+    DashboardVersionDetail v1 = service.version(created.dashboard().id(), 1);
+
+    assertEquals(1, v1.version().versionNo());
+    assertEquals("A", v1.version().name());
+    assertEquals(0, v1.widgets().get(0).x());
+    assertEquals(2, service.get(created.dashboard().id()).dashboard().currentVersionNo());
   }
 
   @Test
@@ -107,7 +167,8 @@ class DashboardServiceTest {
 
     @Override public long insertDashboard(String name, String description) {
       long id = nextDashboardId++;
-      dashboards.put(id, new DashboardAsset(id, name, description, null, 0, Instant.now(), Instant.now()));
+      dashboards.put(id, new DashboardAsset(
+          id, name, description, null, 0, null, 0, null, Instant.now(), Instant.now()));
       return id;
     }
 
@@ -157,7 +218,31 @@ class DashboardServiceTest {
     @Override public void updateCurrentVersion(long dashboardId, long versionId, int versionNo, String name, String description) {
       DashboardAsset old = dashboards.get(dashboardId);
       dashboards.put(dashboardId, new DashboardAsset(
-          dashboardId, name, description, versionId, versionNo, old.createTime(), Instant.now()));
+          dashboardId,
+          name,
+          description,
+          versionId,
+          versionNo,
+          old.publishedVersionId(),
+          old.publishedVersionNo(),
+          old.publishedTime(),
+          old.createTime(),
+          Instant.now()));
+    }
+
+    @Override public void updatePublishedVersion(long dashboardId, long versionId, int versionNo) {
+      DashboardAsset old = dashboards.get(dashboardId);
+      dashboards.put(dashboardId, new DashboardAsset(
+          dashboardId,
+          old.name(),
+          old.description(),
+          old.currentVersionId(),
+          old.currentVersionNo(),
+          versionId,
+          versionNo,
+          Instant.now(),
+          old.createTime(),
+          Instant.now()));
     }
 
     @Override public Optional<DashboardAsset> findDashboard(long id) { return Optional.ofNullable(dashboards.get(id)); }

--- a/yak-ops-ui/src/pages/dashboard/dashboard-service.ts
+++ b/yak-ops-ui/src/pages/dashboard/dashboard-service.ts
@@ -8,6 +8,7 @@ import type {
   DashboardInteraction,
   DashboardServerDetail,
   DashboardSummary,
+  DashboardVersionDetail,
   DashboardVersionSummary,
   DashboardWidget,
   FilterOperator,
@@ -21,6 +22,9 @@ interface DashboardAssetWire {
   description?: string | null;
   currentVersionId?: string | null;
   currentVersionNo: number;
+  publishedVersionId?: string | null;
+  publishedVersionNo?: number;
+  publishedTime?: string | null;
   createTime?: string;
   updateTime?: string;
 }
@@ -78,6 +82,14 @@ interface DashboardDetailWire {
   interactions?: DashboardInteractionWire[];
 }
 
+interface DashboardVersionDetailWire {
+  dashboard: DashboardAssetWire;
+  version: DashboardVersionWire;
+  widgets: DashboardWidgetWire[];
+  globalFilters?: DashboardGlobalFilterWire[];
+  interactions?: DashboardInteractionWire[];
+}
+
 const unwrap = <T,>(response: ApiResponse<T>, fallback: string): T => {
   if (response?.code !== API_SUCCESS_CODE || response.data === undefined) {
     throw new Error(response?.message || response?.msg || fallback);
@@ -91,6 +103,9 @@ const summary = (value: DashboardAssetWire): DashboardSummary => ({
   description: value.description || '',
   currentVersionId: value.currentVersionId ? String(value.currentVersionId) : undefined,
   currentVersionNo: value.currentVersionNo || 0,
+  publishedVersionId: value.publishedVersionId ? String(value.publishedVersionId) : undefined,
+  publishedVersionNo: value.publishedVersionNo || 0,
+  publishedTime: value.publishedTime || undefined,
   createTime: value.createTime,
   updateTime: value.updateTime,
 });
@@ -166,6 +181,14 @@ export const toDashboardServerDetail = (value: DashboardDetailWire): DashboardSe
   interactions: (value.interactions || []).map(interaction),
 });
 
+const toDashboardVersionDetail = (value: DashboardVersionDetailWire): DashboardVersionDetail => ({
+  dashboard: summary(value.dashboard),
+  version: version(value.version),
+  widgets: (value.widgets || []).map(widget),
+  globalFilters: (value.globalFilters || []).map(globalFilter),
+  interactions: (value.interactions || []).map(interaction),
+});
+
 export const toDashboardDocument = (detail: DashboardServerDetail): DashboardDocument => ({
   version: 1,
   id: detail.dashboard.id,
@@ -177,6 +200,9 @@ export const toDashboardDocument = (detail: DashboardServerDetail): DashboardDoc
   interactions: detail.interactions,
   currentVersionNo: detail.dashboard.currentVersionNo,
   currentVersionId: detail.dashboard.currentVersionId,
+  publishedVersionNo: detail.dashboard.publishedVersionNo,
+  publishedVersionId: detail.dashboard.publishedVersionId,
+  publishedAt: detail.dashboard.publishedTime,
   updatedAt: detail.dashboard.updateTime,
 });
 
@@ -226,6 +252,21 @@ export const fetchDashboard = async (dashboardId: string): Promise<DashboardServ
     '查询 Dashboard 详情失败',
   ));
 
+export const fetchDashboardVersion = async (
+  dashboardId: string,
+  versionNo: number,
+): Promise<DashboardVersionDetail> => toDashboardVersionDetail(unwrap(
+  await HttpUtils.get<DashboardVersionDetailWire>(`${DASHBOARD_API}/${dashboardId}/versions/${versionNo}`),
+  '查询 DashboardVersion 详情失败',
+));
+
+export const fetchPublishedDashboard = async (
+  dashboardId: string,
+): Promise<DashboardVersionDetail> => toDashboardVersionDetail(unwrap(
+  await HttpUtils.get<DashboardVersionDetailWire>(`${DASHBOARD_API}/${dashboardId}/published`),
+  '查询已发布 Dashboard 失败',
+));
+
 export const createDashboard = async (document: DashboardDocument): Promise<DashboardServerDetail> =>
   toDashboardServerDetail(unwrap(
     await HttpUtils.post<DashboardDetailWire>(DASHBOARD_API, payload(document)),
@@ -237,16 +278,26 @@ export const saveDashboardVersion = async (
   document: DashboardDocument,
 ): Promise<DashboardServerDetail> => toDashboardServerDetail(unwrap(
   await HttpUtils.post<DashboardDetailWire>(`${DASHBOARD_API}/${dashboardId}/versions`, payload(document)),
-  '保存 DashboardVersion 失败',
+  '保存 Dashboard 草稿失败',
 ));
 
-export const activateDashboardVersion = async (
+export const publishDashboard = async (
+  dashboardId: string,
+): Promise<DashboardServerDetail> => toDashboardServerDetail(unwrap(
+  await HttpUtils.post<DashboardDetailWire>(`${DASHBOARD_API}/${dashboardId}/publish`, {}),
+  '发布 Dashboard 失败',
+));
+
+export const restoreDashboardVersion = async (
   dashboardId: string,
   versionNo: number,
 ): Promise<DashboardServerDetail> => toDashboardServerDetail(unwrap(
-  await HttpUtils.post<DashboardDetailWire>(`${DASHBOARD_API}/${dashboardId}/activate/${versionNo}`, {}),
-  '切换 DashboardVersion 失败',
+  await HttpUtils.post<DashboardDetailWire>(`${DASHBOARD_API}/${dashboardId}/restore/${versionNo}`, {}),
+  '恢复 DashboardVersion 失败',
 ));
+
+/** Compatibility helper for callers that still reference the old API name. */
+export const activateDashboardVersion = restoreDashboardVersion;
 
 export const deleteDashboard = async (dashboardId: string): Promise<void> => {
   unwrap(await HttpUtils.delete<boolean>(`${DASHBOARD_API}/${dashboardId}`), '删除 Dashboard 失败');

--- a/yak-ops-ui/src/pages/dashboard/editor.tsx
+++ b/yak-ops-ui/src/pages/dashboard/editor.tsx
@@ -5,12 +5,13 @@ import { BarChart3 } from 'lucide-react';
 import ReactGridLayout, { useContainerWidth } from 'react-grid-layout';
 import 'react-grid-layout/css/styles.css';
 import 'react-resizable/css/styles.css';
-import { useCallback, useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { ChartEditor } from './chart-editor';
 import { DashboardGlobalFilterBar } from './global-filter-bar';
 import { GRID_COLUMNS, GRID_ROW_HEIGHT } from './helpers';
 import { DashboardToolbar } from './toolbar';
 import { useDashboardDesigner } from './use-dashboard';
+import { DashboardVersionHistoryDrawer } from './version-history-drawer';
 import { WidgetShell } from './widget';
 
 const isEditableTarget = (target: EventTarget | null) => {
@@ -25,6 +26,7 @@ export default function DashboardEditorPage() {
   const dashboardId = id && id !== 'new' ? id : undefined;
   const designer = useDashboardDesigner(dashboardId);
   const { width, containerRef, mounted } = useContainerWidth();
+  const [historyOpen, setHistoryOpen] = useState(false);
   const layout = useMemo(() => designer.widgets.map((widget) => ({
     i: widget.id,
     x: widget.x,
@@ -48,9 +50,28 @@ export default function DashboardEditorPage() {
 
   const saveDashboard = useCallback(async () => {
     const persisted = /^\d+$/.test(designer.dashboard.id);
-    if (designer.dashboardSaving || (persisted && !designer.dirty)) return;
-    const persistedId = await designer.save();
+    if (designer.dashboardSaving || designer.dashboardPublishing || (persisted && !designer.dirty)) return;
+    const persistedId = await designer.saveDraft();
     if (!dashboardId && persistedId) history.replace(`/dashboard/${persistedId}`);
+  }, [dashboardId, designer]);
+
+  const publishDashboard = useCallback(() => {
+    if (!designer.canPublish || designer.dashboardSaving || designer.dashboardPublishing) return;
+    const firstPublish = !designer.hasPublishedVersion;
+    Modal.confirm({
+      title: firstPublish ? '发布仪表盘？' : '发布当前草稿？',
+      content: designer.dirty
+        ? '当前还有未保存修改。系统会先保存为新的草稿版本，再将该版本发布。'
+        : firstPublish
+          ? `草稿 V${designer.dashboard.currentVersionNo || 1} 将成为首个正式发布版本。`
+          : `草稿 V${designer.dashboard.currentVersionNo} 将替换当前已发布的 V${designer.dashboard.publishedVersionNo}。`,
+      okText: firstPublish ? '发布' : '发布更新',
+      cancelText: '取消',
+      onOk: async () => {
+        const persistedId = await designer.publish();
+        if (!dashboardId && persistedId) history.replace(`/dashboard/${persistedId}`);
+      },
+    });
   }, [dashboardId, designer]);
 
   const leaveDashboard = () => {
@@ -60,7 +81,7 @@ export default function DashboardEditorPage() {
     }
     Modal.confirm({
       title: '有未保存修改',
-      content: '当前仪表盘还有未保存的修改，离开后这些修改会丢失。',
+      content: '当前仪表盘还有未保存到草稿的修改，离开后这些本地修改会丢失。',
       okText: '放弃修改并离开',
       cancelText: '继续编辑',
       okButtonProps: { danger: true },
@@ -68,17 +89,21 @@ export default function DashboardEditorPage() {
     });
   };
 
-  const changeVersion = (versionNo: number) => {
+  const restoreVersion = (versionNo: number) => {
+    const restore = async () => {
+      await designer.restoreVersion(versionNo);
+      setHistoryOpen(false);
+    };
     if (!designer.dirty) {
-      void designer.activateVersion(versionNo);
+      void restore();
       return;
     }
     Modal.confirm({
-      title: '切换历史版本？',
-      content: '当前修改尚未保存。切换版本会放弃这些修改并加载所选版本。',
-      okText: '放弃修改并切换',
+      title: `恢复 V${versionNo} 为草稿？`,
+      content: '当前还有未保存到草稿的修改。继续恢复会放弃这些本地修改，并基于历史版本生成一个新的草稿版本。',
+      okText: '放弃修改并恢复',
       cancelText: '继续编辑',
-      onOk: () => designer.activateVersion(versionNo),
+      onOk: restore,
     });
   };
 
@@ -146,24 +171,29 @@ export default function DashboardEditorPage() {
         name={designer.dashboard.name}
         dashboardId={designer.dashboard.id}
         currentVersionNo={designer.dashboard.currentVersionNo}
-        versions={designer.dashboardVersions}
+        publishedVersionNo={designer.dashboard.publishedVersionNo}
         saving={designer.dashboardSaving}
+        publishing={designer.dashboardPublishing}
         preview={designer.preview}
         dirty={designer.dirty}
         canUndo={designer.canUndo}
         canRedo={designer.canRedo}
         canAddChart={Boolean(designer.activeDataset) && !designer.datasetsLoading}
+        canPublish={designer.canPublish}
+        hasPublishedVersion={designer.hasPublishedVersion}
+        hasUnpublishedDraft={designer.hasUnpublishedDraft}
         onBack={leaveDashboard}
         onName={designer.updateDashboardName}
         onUndo={designer.undo}
         onRedo={designer.redo}
         onAddChart={addChart}
-        onVersion={changeVersion}
+        onHistory={() => setHistoryOpen(true)}
         onPreview={() => {
           designer.setPreview((current) => !current);
           designer.setSelectedId(undefined);
         }}
-        onSave={() => void saveDashboard()}
+        onSaveDraft={() => void saveDashboard()}
+        onPublish={publishDashboard}
       />
 
       <DashboardGlobalFilterBar
@@ -287,6 +317,19 @@ export default function DashboardEditorPage() {
           />
         ) : null}
       </div>
+
+      {designer.persisted ? (
+        <DashboardVersionHistoryDrawer
+          open={historyOpen}
+          dashboardId={designer.dashboard.id}
+          versions={designer.dashboardVersions}
+          currentVersionNo={designer.dashboard.currentVersionNo}
+          publishedVersionNo={designer.dashboard.publishedVersionNo}
+          busy={designer.dashboardSaving || designer.dashboardPublishing}
+          onClose={() => setHistoryOpen(false)}
+          onRestore={restoreVersion}
+        />
+      ) : null}
 
       <style>{`
         .dashboard-grid-canvas {

--- a/yak-ops-ui/src/pages/dashboard/index.tsx
+++ b/yak-ops-ui/src/pages/dashboard/index.tsx
@@ -12,7 +12,6 @@ import {
 import {
   CalendarDays,
   ChevronDown,
-  Divide,
   LayoutDashboard,
   Pencil,
   Plus,
@@ -30,7 +29,7 @@ import {
 } from './dashboard-service';
 import type { DashboardSummary } from './model';
 
-type DashboardStatus = 'all' | 'configured' | 'unsaved';
+type DashboardStatus = 'all' | 'published' | 'draft' | 'unpublished';
 type TimeRange = 'all' | '7d' | '30d';
 
 const formatTime = (value?: string) =>
@@ -41,37 +40,39 @@ const formatDate = (value?: string) =>
 
 const getTime = (value?: string) => {
   if (!value) return 0;
-
   const time = new Date(value).getTime();
-
   return Number.isNaN(time) ? 0 : time;
+};
+
+const lifecycleOf = (dashboard: DashboardSummary) => {
+  const published = Number(dashboard.publishedVersionNo) > 0;
+  const hasDraft = published && dashboard.currentVersionId !== dashboard.publishedVersionId;
+  return {
+    published,
+    hasDraft,
+    state: !published ? 'unpublished' as const : hasDraft ? 'draft' as const : 'published' as const,
+  };
 };
 
 export default function DashboardListPage() {
   const [dashboards, setDashboards] = useState<DashboardSummary[]>([]);
   const [loading, setLoading] = useState(true);
-
   const [keyword, setKeyword] = useState('');
   const [status, setStatus] = useState<DashboardStatus>('all');
   const [timeRange, setTimeRange] = useState<TimeRange>('all');
-
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState(10);
-
   const [renameTarget, setRenameTarget] = useState<DashboardSummary>();
   const [renameValue, setRenameValue] = useState('');
   const [renaming, setRenaming] = useState(false);
 
   const loadDashboards = useCallback(async () => {
     setLoading(true);
-
     try {
       setDashboards(await fetchDashboards());
     } catch (error) {
       setDashboards([]);
-      message.error(
-        error instanceof Error ? error.message : '加载仪表盘失败',
-      );
+      message.error(error instanceof Error ? error.message : '加载仪表盘失败');
     } finally {
       setLoading(false);
     }
@@ -85,15 +86,13 @@ export default function DashboardListPage() {
     setPage(1);
   }, [keyword, status, timeRange]);
 
-  const configuredCount = useMemo(
-    () =>
-      dashboards.filter(
-        (item) => Number(item.currentVersionNo) > 0,
-      ).length,
-    [dashboards],
-  );
-
-  const unsavedCount = dashboards.length - configuredCount;
+  const lifecycleCounts = useMemo(() => dashboards.reduce(
+    (result, item) => {
+      result[lifecycleOf(item).state] += 1;
+      return result;
+    },
+    { published: 0, draft: 0, unpublished: 0 },
+  ), [dashboards]);
 
   const filteredDashboards = useMemo(() => {
     const value = keyword.trim().toLowerCase();
@@ -102,63 +101,31 @@ export default function DashboardListPage() {
     return dashboards.filter((dashboard) => {
       if (
         value &&
-        ![
-          dashboard.name,
-          dashboard.description,
-          dashboard.id,
-        ].some((field) =>
-          String(field || '')
-            .toLowerCase()
-            .includes(value),
+        ![dashboard.name, dashboard.description, dashboard.id].some((field) =>
+          String(field || '').toLowerCase().includes(value),
         )
       ) {
         return false;
       }
 
-      const hasVersion =
-        Number(dashboard.currentVersionNo) > 0;
-
-      if (status === 'configured' && !hasVersion) {
-        return false;
-      }
-
-      if (status === 'unsaved' && hasVersion) {
-        return false;
-      }
+      if (status !== 'all' && lifecycleOf(dashboard).state !== status) return false;
 
       if (timeRange !== 'all') {
         const updateTime = getTime(dashboard.updateTime);
-
-        if (!updateTime) {
-          return false;
-        }
-
+        if (!updateTime) return false;
         const days = timeRange === '7d' ? 7 : 30;
-        const range = days * 24 * 60 * 60 * 1000;
-
-        if (now - updateTime > range) {
-          return false;
-        }
+        if (now - updateTime > days * 24 * 60 * 60 * 1000) return false;
       }
 
       return true;
     });
   }, [dashboards, keyword, status, timeRange]);
 
-  const pageCount = Math.max(
-    1,
-    Math.ceil(filteredDashboards.length / pageSize),
-  );
-
+  const pageCount = Math.max(1, Math.ceil(filteredDashboards.length / pageSize));
   const currentPage = Math.min(page, pageCount);
-
   const pageItems = useMemo(() => {
     const start = (currentPage - 1) * pageSize;
-
-    return filteredDashboards.slice(
-      start,
-      start + pageSize,
-    );
+    return filteredDashboards.slice(start, start + pageSize);
   }, [currentPage, filteredDashboards, pageSize]);
 
   const openRename = (dashboard: DashboardSummary) => {
@@ -168,95 +135,53 @@ export default function DashboardListPage() {
 
   const renameDashboard = async () => {
     const name = renameValue.trim();
-
     if (!renameTarget || !name) {
       message.warning('请输入仪表盘名称');
       return;
     }
-
     if (name === renameTarget.name) {
       setRenameTarget(undefined);
       return;
     }
 
     setRenaming(true);
-
     try {
       const detail = await fetchDashboard(renameTarget.id);
       const document = toDashboardDocument(detail);
-
-      await saveDashboardVersion(renameTarget.id, {
-        ...document,
-        name,
-      });
-
-      message.success('仪表盘名称已更新');
-
+      await saveDashboardVersion(renameTarget.id, { ...document, name });
+      message.success('名称已保存到新草稿版本');
       setRenameTarget(undefined);
-
       await loadDashboards();
     } catch (error) {
-      message.error(
-        error instanceof Error
-          ? error.message
-          : '重命名仪表盘失败',
-      );
+      message.error(error instanceof Error ? error.message : '重命名仪表盘失败');
     } finally {
       setRenaming(false);
     }
   };
 
-  const removeDashboard = async (
-    dashboard: DashboardSummary,
-  ) => {
+  const removeDashboard = async (dashboard: DashboardSummary) => {
     try {
       await deleteDashboard(dashboard.id);
-
       message.success('仪表盘已删除');
-
       await loadDashboards();
     } catch (error) {
-      message.error(
-        error instanceof Error
-          ? error.message
-          : '删除仪表盘失败',
-      );
+      message.error(error instanceof Error ? error.message : '删除仪表盘失败');
     }
   };
 
-  const statusItems: Array<{
-    key: DashboardStatus;
-    label: string;
-    count?: number;
-  }> = [
-    {
-      key: 'all',
-      label: '全部',
-      count: dashboards.length,
-    },
-    {
-      key: 'configured',
-      label: '已配置',
-      count: configuredCount,
-    },
-    {
-      key: 'unsaved',
-      label: '未保存',
-      count: unsavedCount,
-    },
+  const statusItems: Array<{ key: DashboardStatus; label: string; count: number }> = [
+    { key: 'all', label: '全部', count: dashboards.length },
+    { key: 'published', label: '已发布', count: lifecycleCounts.published },
+    { key: 'draft', label: '有草稿', count: lifecycleCounts.draft },
+    { key: 'unpublished', label: '未发布', count: lifecycleCounts.unpublished },
   ];
 
   return (
     <div className="min-h-[calc(100vh-48px)] bg-[#f6f7f8]">
       <div className="min-h-[calc(100vh-64px)] rounded-[10px] bg-white px-6 py-5">
-        {/* 页面标题 */}
-        <div className="text-[18px] font-semibold leading-7 text-[#161823]">
-          仪表盘管理
-        </div>
+        <div className="text-[18px] font-semibold leading-7 text-[#161823]">仪表盘管理</div>
 
-        {/* 顶部筛选区域 */}
-        <div className="mt-2 flex min-h-[48px] items-center justify-between gap-5 ">
-          {/* 左侧分类 */}
+        <div className="mt-2 flex min-h-[48px] items-center justify-between gap-5">
           <div className="flex shrink-0 items-center gap-2">
             <button
               type="button"
@@ -266,12 +191,10 @@ export default function DashboardListPage() {
             </button>
           </div>
 
-          {/* 右侧筛选 */}
           <div className="flex min-w-0 flex-1 items-center justify-end gap-2">
             <div className="mr-1 flex shrink-0 items-center">
               {statusItems.map((item) => {
                 const active = status === item.key;
-
                 return (
                   <button
                     key={item.key}
@@ -285,6 +208,9 @@ export default function DashboardListPage() {
                     ].join(' ')}
                   >
                     {item.label}
+                    {item.key !== 'all' && item.count ? (
+                      <span className="ml-1 text-[10px] font-normal text-[#b0b5bd]">{item.count}</span>
+                    ) : null}
                   </button>
                 );
               })}
@@ -293,46 +219,23 @@ export default function DashboardListPage() {
             <Select<TimeRange>
               value={timeRange}
               onChange={setTimeRange}
-              suffixIcon={
-                <ChevronDown size={14} />
-              }
+              suffixIcon={<ChevronDown size={14} />}
               options={[
-                {
-                  value: 'all',
-                  label: '所有时间',
-                },
-                {
-                  value: '7d',
-                  label: '最近 7 天',
-                },
-                {
-                  value: '30d',
-                  label: '最近 30 天',
-                },
+                { value: 'all', label: '所有时间' },
+                { value: '7d', label: '最近 7 天' },
+                { value: '30d', label: '最近 30 天' },
               ]}
               className="w-[122px]"
               size="middle"
               variant="filled"
-              prefix={
-                <CalendarDays
-                  size={13}
-                  className="text-[#667085]"
-                />
-              }
+              prefix={<CalendarDays size={13} className="text-[#667085]" />}
             />
 
             <Input
               allowClear
               value={keyword}
-              onChange={(event) =>
-                setKeyword(event.target.value)
-              }
-              prefix={
-                <Search
-                  size={15}
-                  className="text-[#8a9099]"
-                />
-              }
+              onChange={(event) => setKeyword(event.target.value)}
+              prefix={<Search size={15} className="text-[#8a9099]" />}
               placeholder="搜索仪表盘"
               className="w-[180px]"
               size="middle"
@@ -354,259 +257,131 @@ export default function DashboardListPage() {
               type="primary"
               size="middle"
               icon={<Plus size={15} />}
-              onClick={() =>
-                history.push('/dashboard/new')
-              }
+              onClick={() => history.push('/dashboard/new')}
             >
               新建仪表盘
             </Button>
           </div>
         </div>
 
-        <Divider style={{padding:0, margin: "12px 0"}}/>
+        <Divider style={{ padding: 0, margin: '12px 0' }} />
 
-        {/* 仪表盘列表 */}
         <div className="relative">
           {loading && dashboards.length === 0 ? (
             <div className="flex h-[300px] items-center justify-center text-[13px] text-[#98a2b3]">
               正在加载仪表盘...
             </div>
           ) : pageItems.length === 0 ? (
-            /* 空状态 */
             <div className="flex h-[360px] flex-col items-center justify-center">
               <div className="flex h-12 w-12 items-center justify-center rounded-[12px] bg-[#f5f6f7] text-[#98a2b3]">
-                <LayoutDashboard
-                  size={22}
-                  strokeWidth={1.7}
-                />
+                <LayoutDashboard size={22} strokeWidth={1.7} />
               </div>
-
               <div className="mt-3 text-[13px] font-medium text-[#667085]">
-                {keyword ||
-                status !== 'all' ||
-                timeRange !== 'all'
+                {keyword || status !== 'all' || timeRange !== 'all'
                   ? '没有匹配的仪表盘'
                   : '暂无仪表盘'}
               </div>
-
-              {!keyword &&
-                status === 'all' &&
-                timeRange === 'all' && (
-                  <Button
-                    type="link"
-                    className="mt-1 px-0 text-[12px]"
-                    onClick={() =>
-                      history.push('/dashboard/new')
-                    }
-                  >
-                    创建第一个仪表盘
-                  </Button>
-                )}
+              {!keyword && status === 'all' && timeRange === 'all' ? (
+                <Button
+                  type="link"
+                  className="mt-1 px-0 text-[12px]"
+                  onClick={() => history.push('/dashboard/new')}
+                >
+                  创建第一个仪表盘
+                </Button>
+              ) : null}
             </div>
           ) : (
             <>
               <div>
                 {pageItems.map((dashboard) => {
-                  const hasVersion =
-                    Number(
-                      dashboard.currentVersionNo,
-                    ) > 0;
+                  const lifecycle = lifecycleOf(dashboard);
+                  const statusLabel = lifecycle.state === 'published'
+                    ? `已发布 V${dashboard.publishedVersionNo}`
+                    : lifecycle.state === 'draft'
+                      ? `有草稿 V${dashboard.currentVersionNo}`
+                      : `未发布 · 草稿 V${dashboard.currentVersionNo}`;
+                  const statusClass = lifecycle.state === 'published'
+                    ? 'text-[#20a464]'
+                    : lifecycle.state === 'draft'
+                      ? 'text-[#667085]'
+                      : 'text-[#98a2b3]';
 
                   return (
                     <div
                       key={dashboard.id}
-                      className="
-                        group
-                        relative
-                        -mx-3
-                        flex
-                        min-h-[200px]
-                        gap-4
-                        rounded-[8px]
-                        border-b
-                        border-[#f0f1f2]
-                        px-3
-                        py-5
-                        transition-[background-color,box-shadow]
-                        duration-150
-                        ease-out
-                        hover:z-[1]
-                        hover:bg-[#f8f9fa]
-                        hover:shadow-[inset_0_0_0_1px_rgba(22,24,35,0.035)]
-                        last:border-b-0
-                      "
+                      className="group relative -mx-3 flex min-h-[200px] gap-4 rounded-[8px] border-b border-[#f0f1f2] px-3 py-5 transition-[background-color,box-shadow] duration-150 ease-out hover:z-[1] hover:bg-[#f8f9fa] hover:shadow-[inset_0_0_0_1px_rgba(22,24,35,0.035)] last:border-b-0"
                     >
-                      {/* 左侧仪表盘缩略图 */}
                       <button
                         type="button"
-                        onClick={() =>
-                          history.push(
-                            `/dashboard/${dashboard.id}`,
-                          )
-                        }
-                        className="
-                          relative
-                          h-[160px]
-                          w-[120px]
-                          shrink-0
-                          overflow-hidden
-                          rounded-[6px]
-                          border
-                          border-[#e6e8eb]
-                          bg-gradient-to-b
-                          from-[#fafafa]
-                          to-[#eceef1]
-                          p-0
-                          text-left
-                          transition-[border-color,box-shadow]
-                          duration-150
-                          ease-out
-                          group-hover:border-[#d9dce1]
-                          group-hover:shadow-[0_2px_8px_rgba(22,24,35,0.05)]
-                        "
+                        onClick={() => history.push(`/dashboard/${dashboard.id}`)}
+                        className="relative h-[160px] w-[120px] shrink-0 overflow-hidden rounded-[6px] border border-[#e6e8eb] bg-gradient-to-b from-[#fafafa] to-[#eceef1] p-0 text-left transition-[border-color,box-shadow] duration-150 ease-out group-hover:border-[#d9dce1] group-hover:shadow-[0_2px_8px_rgba(22,24,35,0.05)]"
                       >
-                        {/* 图表模拟 */}
                         <div className="absolute left-3 right-3 top-4 flex h-[62px] items-end gap-1.5">
                           <span className="h-8 flex-1 rounded-[2px] bg-white shadow-[0_1px_2px_rgba(0,0,0,0.04)]" />
                           <span className="h-[46px] flex-1 rounded-[2px] bg-white shadow-[0_1px_2px_rgba(0,0,0,0.04)]" />
                           <span className="h-7 flex-1 rounded-[2px] bg-white shadow-[0_1px_2px_rgba(0,0,0,0.04)]" />
                           <span className="h-[54px] flex-1 rounded-[2px] bg-white shadow-[0_1px_2px_rgba(0,0,0,0.04)]" />
                         </div>
-
-                        {/* 文本模拟 */}
                         <div className="absolute bottom-4 left-3 right-3 rounded-[5px] bg-white px-2 py-[10px] shadow-[0_1px_4px_rgba(0,0,0,0.04)]">
                           <div className="h-[4px] w-[72%] rounded-full bg-[#d5d9de]" />
                           <div className="mt-2 h-[4px] w-[48%] rounded-full bg-[#e1e4e8]" />
                         </div>
-
-                        {/* 版本号 */}
                         <div className="absolute right-2 top-2 flex h-[18px] min-w-[24px] items-center justify-center rounded-[3px] bg-[rgba(22,24,35,0.62)] px-1.5 text-[10px] font-medium text-white">
-                          V
-                          {dashboard.currentVersionNo ||
-                            0}
+                          V{dashboard.currentVersionNo || 0}
                         </div>
                       </button>
 
-                      {/* 中间内容 */}
                       <div className="flex min-h-[160px] min-w-0 flex-1 flex-col pr-[300px]">
-                        {/* 标题 */}
                         <div className="flex items-center gap-2">
                           <button
                             type="button"
-                            onClick={() =>
-                              history.push(
-                                `/dashboard/${dashboard.id}`,
-                              )
-                            }
-                            className="
-                              max-w-[620px]
-                              truncate
-                              border-0
-                              bg-transparent
-                              p-0
-                              text-left
-                              text-[14px]
-                              font-semibold
-                              leading-5
-                              text-[#161823]
-                              transition-colors
-                              hover:text-[#111318]
-                              hover:underline
-                            "
+                            onClick={() => history.push(`/dashboard/${dashboard.id}`)}
+                            className="max-w-[620px] truncate border-0 bg-transparent p-0 text-left text-[14px] font-semibold leading-5 text-[#161823] transition-colors hover:text-[#111318] hover:underline"
                           >
                             {dashboard.name}
                           </button>
-
-                          <span
-                            className={[
-                              'shrink-0 text-[12px] leading-5',
-                              hasVersion
-                                ? 'text-[#20a464]'
-                                : 'text-[#98a2b3]',
-                            ].join(' ')}
-                          >
-                            {hasVersion
-                              ? '已配置'
-                              : '未保存'}
+                          <span className={`shrink-0 text-[12px] leading-5 ${statusClass}`}>
+                            {statusLabel}
                           </span>
                         </div>
 
-                        {/* 时间 + 描述 */}
                         <div className="mt-1 flex min-w-0 items-center gap-2 text-[12px] leading-5 text-[#8a9099]">
-                          <span>
-                            {formatTime(
-                              dashboard.updateTime,
-                            )}
-                          </span>
-
-                          <span className="text-[#d7dade]">
-                            |
-                          </span>
-
-                          <span className="max-w-[560px] truncate">
-                            {dashboard.description ||
-                              '暂无描述'}
-                          </span>
+                          <span>{formatTime(dashboard.updateTime)}</span>
+                          <span className="text-[#d7dade]">|</span>
+                          <span className="max-w-[560px] truncate">{dashboard.description || '暂无描述'}</span>
                         </div>
 
-                        {/* 底部指标 */}
                         <div className="mt-auto flex h-[44px] items-start">
-                          {/* 当前版本 */}
                           <div className="w-[116px] shrink-0">
-                            <div className="text-[12px] leading-[18px] text-[#a3a8b0]">
-                              当前版本
-                            </div>
-
+                            <div className="text-[12px] leading-[18px] text-[#a3a8b0]">草稿版本</div>
                             <div className="mt-[2px] text-[14px] font-semibold leading-5 text-[#161823]">
-                              {hasVersion
-                                ? `V${dashboard.currentVersionNo}`
-                                : '-'}
+                              {dashboard.currentVersionNo ? `V${dashboard.currentVersionNo}` : '-'}
                             </div>
                           </div>
-
                           <div className="mx-5 mt-[3px] h-6 w-px shrink-0 bg-[#e5e7eb]" />
 
-                          {/* 创建日期 */}
                           <div className="w-[122px] shrink-0">
-                            <div className="text-[12px] leading-[18px] text-[#a3a8b0]">
-                              创建日期
-                            </div>
-
+                            <div className="text-[12px] leading-[18px] text-[#a3a8b0]">发布版本</div>
                             <div className="mt-[2px] text-[14px] font-semibold leading-5 text-[#161823]">
-                              {formatDate(
-                                dashboard.createTime,
-                              )}
+                              {lifecycle.published ? `V${dashboard.publishedVersionNo}` : '-'}
                             </div>
                           </div>
-
                           <div className="mx-5 mt-[3px] h-6 w-px shrink-0 bg-[#e5e7eb]" />
 
-                          {/* 更新日期 */}
                           <div className="w-[122px] shrink-0">
-                            <div className="text-[12px] leading-[18px] text-[#a3a8b0]">
-                              更新日期
-                            </div>
-
+                            <div className="text-[12px] leading-[18px] text-[#a3a8b0]">创建日期</div>
                             <div className="mt-[2px] text-[14px] font-semibold leading-5 text-[#161823]">
-                              {formatDate(
-                                dashboard.updateTime,
-                              )}
+                              {formatDate(dashboard.createTime)}
                             </div>
                           </div>
-
                           <div className="mx-5 mt-[3px] h-6 w-px shrink-0 bg-[#e5e7eb]" />
 
-                          {/* ID */}
                           <div className="min-w-0 flex-1">
-                            <div className="text-[12px] leading-[18px] text-[#a3a8b0]">
-                              仪表盘 ID
-                            </div>
-
+                            <div className="text-[12px] leading-[18px] text-[#a3a8b0]">仪表盘 ID</div>
                             <div
                               className="mt-[2px] max-w-[180px] truncate text-[14px] font-semibold leading-5 text-[#161823]"
-                              title={String(
-                                dashboard.id,
-                              )}
+                              title={String(dashboard.id)}
                             >
                               {dashboard.id}
                             </div>
@@ -614,70 +389,37 @@ export default function DashboardListPage() {
                         </div>
                       </div>
 
-                      {/* 右侧操作 */}
-                      <div
-                        className="
-                          absolute
-                          right-3
-                          top-5
-                          flex
-                          items-center
-                          gap-0
-                          text-[12px]
-                          opacity-80
-                          transition-opacity
-                          duration-150
-                          group-hover:opacity-100
-                        "
-                      >
+                      <div className="absolute right-3 top-5 flex items-center gap-0 text-[12px] opacity-80 transition-opacity duration-150 group-hover:opacity-100">
                         <Button
                           type="text"
                           size="small"
-                          icon={
-                            <Pencil size={12} />
-                          }
+                          icon={<Pencil size={12} />}
                           className="h-7 px-1.5 text-[#667085]"
-                          onClick={() =>
-                            history.push(
-                              `/dashboard/${dashboard.id}`,
-                            )
-                          }
+                          onClick={() => history.push(`/dashboard/${dashboard.id}`)}
                         >
                           编辑仪表盘
                         </Button>
-
                         <Button
                           type="text"
                           size="small"
                           className="h-7 px-1.5 text-[#667085]"
-                          onClick={() =>
-                            openRename(dashboard)
-                          }
+                          onClick={() => openRename(dashboard)}
                         >
                           重命名
                         </Button>
-
                         <Popconfirm
                           title="删除仪表盘"
-                          description={`确认删除“${dashboard.name}”？此操作不可恢复。`}
+                          description={`确认删除“${dashboard.name}”？草稿和已发布版本都会被删除，此操作不可恢复。`}
                           okText="删除"
                           cancelText="取消"
-                          okButtonProps={{
-                            danger: true,
-                          }}
-                          onConfirm={() =>
-                            void removeDashboard(
-                              dashboard,
-                            )
-                          }
+                          okButtonProps={{ danger: true }}
+                          onConfirm={() => void removeDashboard(dashboard)}
                         >
                           <Button
                             type="text"
                             size="small"
                             danger
-                            icon={
-                              <Trash2 size={12} />
-                            }
+                            icon={<Trash2 size={12} />}
                             className="h-7 px-1.5"
                           >
                             删除
@@ -689,45 +431,21 @@ export default function DashboardListPage() {
                 })}
               </div>
 
-              {/* 分页 / 没有更多 */}
-              {filteredDashboards.length <=
-              pageSize ? (
-                <div className="py-10 text-center text-[13px] text-[#8a9099]">
-                  没有更多仪表盘
-                </div>
+              {filteredDashboards.length <= pageSize ? (
+                <div className="py-10 text-center text-[13px] text-[#8a9099]">没有更多仪表盘</div>
               ) : (
                 <div className="flex items-center justify-between border-t border-[#f0f1f2] py-4">
-                  <span className="text-[12px] text-[#98a2b3]">
-                    共 {filteredDashboards.length}{' '}
-                    个仪表盘
-                  </span>
-
+                  <span className="text-[12px] text-[#98a2b3]">共 {filteredDashboards.length} 个仪表盘</span>
                   <Pagination
                     size="small"
                     current={currentPage}
                     pageSize={pageSize}
-                    total={
-                      filteredDashboards.length
-                    }
+                    total={filteredDashboards.length}
                     showSizeChanger
-                    pageSizeOptions={[
-                      10,
-                      20,
-                      50,
-                    ]}
-                    onChange={(
-                      nextPage,
-                      nextPageSize,
-                    ) => {
-                      setPage(
-                        nextPageSize === pageSize
-                          ? nextPage
-                          : 1,
-                      );
-
-                      setPageSize(
-                        nextPageSize,
-                      );
+                    pageSizeOptions={[10, 20, 50]}
+                    onChange={(nextPage, nextPageSize) => {
+                      setPage(nextPageSize === pageSize ? nextPage : 1);
+                      setPageSize(nextPageSize);
                     }}
                   />
                 </div>
@@ -737,35 +455,28 @@ export default function DashboardListPage() {
         </div>
       </div>
 
-      {/* 重命名 */}
       <Modal
         title="重命名仪表盘"
         open={Boolean(renameTarget)}
-        okText="保存"
+        okText="保存为草稿"
         cancelText="取消"
         confirmLoading={renaming}
-        onOk={() =>
-          void renameDashboard()
-        }
-        onCancel={() =>
-          !renaming &&
-          setRenameTarget(undefined)
-        }
+        onOk={() => void renameDashboard()}
+        onCancel={() => !renaming && setRenameTarget(undefined)}
       >
         <Input
           autoFocus
           maxLength={128}
           value={renameValue}
           placeholder="请输入仪表盘名称"
-          onChange={(event) =>
-            setRenameValue(
-              event.target.value,
-            )
-          }
-          onPressEnter={() =>
-            void renameDashboard()
-          }
+          onChange={(event) => setRenameValue(event.target.value)}
+          onPressEnter={() => void renameDashboard()}
         />
+        {renameTarget?.publishedVersionNo ? (
+          <div className="mt-2 text-[11px] leading-5 text-[#98a2b3]">
+            重命名会生成新的草稿版本，不会立即修改当前已发布版本。
+          </div>
+        ) : null}
       </Modal>
     </div>
   );

--- a/yak-ops-ui/src/pages/dashboard/model.ts
+++ b/yak-ops-ui/src/pages/dashboard/model.ts
@@ -77,8 +77,13 @@ export interface DashboardDocument {
   widgets: DashboardWidget[];
   globalFilters: DashboardGlobalFilter[];
   interactions: DashboardInteraction[];
+  /** Current immutable server-side draft snapshot. */
   currentVersionNo?: number;
   currentVersionId?: string;
+  /** Reader-facing published snapshot. It changes only when Publish is invoked. */
+  publishedVersionNo?: number;
+  publishedVersionId?: string;
+  publishedAt?: string;
   updatedAt?: string;
 }
 
@@ -88,6 +93,9 @@ export interface DashboardSummary {
   description: string;
   currentVersionId?: string;
   currentVersionNo: number;
+  publishedVersionId?: string;
+  publishedVersionNo: number;
+  publishedTime?: string;
   createTime?: string;
   updateTime?: string;
 }
@@ -106,6 +114,14 @@ export interface DashboardServerDetail {
   dashboard: DashboardSummary;
   currentVersion?: DashboardVersionSummary;
   versions: DashboardVersionSummary[];
+  widgets: DashboardWidget[];
+  globalFilters: DashboardGlobalFilter[];
+  interactions: DashboardInteraction[];
+}
+
+export interface DashboardVersionDetail {
+  dashboard: DashboardSummary;
+  version: DashboardVersionSummary;
   widgets: DashboardWidget[];
   globalFilters: DashboardGlobalFilter[];
   interactions: DashboardInteraction[];

--- a/yak-ops-ui/src/pages/dashboard/toolbar.tsx
+++ b/yak-ops-ui/src/pages/dashboard/toolbar.tsx
@@ -1,4 +1,4 @@
-import { Button, Input, Select, Tooltip } from 'antd';
+import { Button, Input, Tooltip } from 'antd';
 import {
   BarChart3,
   ChevronLeft,
@@ -6,52 +6,86 @@ import {
   History,
   Redo2,
   Save,
+  Send,
   Undo2,
   X,
 } from 'lucide-react';
-import type { DashboardVersionSummary } from './model';
 
 export function DashboardToolbar({
   name,
   dashboardId,
   currentVersionNo,
-  versions,
+  publishedVersionNo,
   saving,
+  publishing,
   preview,
   dirty,
   canUndo,
   canRedo,
   canAddChart,
+  canPublish,
+  hasPublishedVersion,
+  hasUnpublishedDraft,
   onBack,
   onName,
   onUndo,
   onRedo,
   onAddChart,
-  onVersion,
+  onHistory,
   onPreview,
-  onSave,
+  onSaveDraft,
+  onPublish,
 }: {
   name: string;
   dashboardId: string;
   currentVersionNo?: number;
-  versions: DashboardVersionSummary[];
+  publishedVersionNo?: number;
   saving: boolean;
+  publishing: boolean;
   preview: boolean;
   dirty: boolean;
   canUndo: boolean;
   canRedo: boolean;
   canAddChart: boolean;
+  canPublish: boolean;
+  hasPublishedVersion: boolean;
+  hasUnpublishedDraft: boolean;
   onBack: () => void;
   onName: (name: string) => void;
   onUndo: () => void;
   onRedo: () => void;
   onAddChart: () => void;
-  onVersion: (versionNo: number) => void;
+  onHistory: () => void;
   onPreview: () => void;
-  onSave: () => void;
+  onSaveDraft: () => void;
+  onPublish: () => void;
 }) {
   const persisted = /^\d+$/.test(dashboardId);
   const saveDisabled = persisted && !dirty;
+  const busy = saving || publishing;
+
+  const lifecycle = (() => {
+    if (!persisted || !currentVersionNo) {
+      return <span className="rounded-[3px] bg-[#f5f6f7] px-2 py-0.5 text-[10px] text-[#667085]">未保存</span>;
+    }
+    if (hasPublishedVersion && !hasUnpublishedDraft) {
+      return (
+        <span className="rounded-[3px] bg-[#f0f9f4] px-2 py-0.5 text-[10px] font-medium text-[#1d7a4b]">
+          已发布 V{publishedVersionNo}
+        </span>
+      );
+    }
+    return (
+      <div className="flex shrink-0 items-center gap-1.5">
+        <span className="rounded-[3px] bg-[#f5f6f7] px-2 py-0.5 text-[10px] font-medium text-[#475467]">
+          草稿 V{currentVersionNo}
+        </span>
+        <span className="text-[10px] text-[#98a2b3]">
+          {hasPublishedVersion ? `已发布 V${publishedVersionNo}` : '未发布'}
+        </span>
+      </div>
+    );
+  })();
 
   return (
     <header className="flex h-12 shrink-0 items-center justify-between border-b border-[#dfe3e8] bg-white px-3">
@@ -60,7 +94,7 @@ export function DashboardToolbar({
           size="small"
           type="text"
           icon={<ChevronLeft size={14} />}
-          disabled={preview}
+          disabled={preview || busy}
           onClick={onBack}
         >
           仪表盘
@@ -69,13 +103,11 @@ export function DashboardToolbar({
         <Input
           variant="borderless"
           value={name}
-          disabled={preview}
+          disabled={preview || busy}
           onChange={(event) => onName(event.target.value)}
           className="w-[260px] px-1 text-[13px] font-semibold text-[#161823]"
         />
-        <span className="rounded-[3px] bg-[#f5f6f7] px-2 py-0.5 text-[10px] text-[#667085]">
-          {currentVersionNo ? `V${currentVersionNo}` : '未保存'}
-        </span>
+        {lifecycle}
         {dirty ? (
           <span className="flex shrink-0 items-center gap-1.5 text-[10px] text-[#667085]">
             <span className="h-1.5 w-1.5 rounded-full bg-[#98a2b3]" />
@@ -94,7 +126,7 @@ export function DashboardToolbar({
                   type="text"
                   className="h-6 w-7 px-0"
                   icon={<Undo2 size={13} />}
-                  disabled={!canUndo || saving}
+                  disabled={!canUndo || busy}
                   onClick={onUndo}
                 />
               </Tooltip>
@@ -104,7 +136,7 @@ export function DashboardToolbar({
                   type="text"
                   className="h-6 w-7 px-0"
                   icon={<Redo2 size={13} />}
-                  disabled={!canRedo || saving}
+                  disabled={!canRedo || busy}
                   onClick={onRedo}
                 />
               </Tooltip>
@@ -112,7 +144,7 @@ export function DashboardToolbar({
             <span className="h-5 w-px bg-[#e5e7eb]" />
             <Button
               size="small"
-              disabled={!canAddChart}
+              disabled={!canAddChart || busy}
               icon={<BarChart3 size={13} />}
               onClick={onAddChart}
             >
@@ -120,42 +152,57 @@ export function DashboardToolbar({
             </Button>
           </>
         ) : null}
-        {persisted && versions.length ? (
-          <Select
+
+        {persisted && currentVersionNo ? (
+          <Button
             size="small"
-            className="w-[104px]"
-            suffixIcon={<History size={12} />}
-            disabled={preview || saving}
-            value={currentVersionNo}
-            options={versions.map((item) => ({
-              label: `版本 V${item.versionNo}`,
-              value: item.versionNo,
-            }))}
-            onChange={onVersion}
-          />
+            disabled={busy}
+            icon={<History size={13} />}
+            onClick={onHistory}
+          >
+            历史版本
+          </Button>
         ) : null}
+
         <Button
           size="small"
+          disabled={busy}
           icon={preview ? <X size={13} /> : <Eye size={13} />}
           onClick={onPreview}
         >
           {preview ? '退出预览' : '预览'}
         </Button>
+
         {!preview ? (
-          <Tooltip title={saveDisabled ? '当前没有需要保存的修改' : '保存 Ctrl/Cmd + S'}>
-            <span>
-              <Button
-                size="small"
-                type="primary"
-                loading={saving}
-                disabled={saveDisabled}
-                icon={<Save size={13} />}
-                onClick={onSave}
-              >
-                保存
-              </Button>
-            </span>
-          </Tooltip>
+          <>
+            <Tooltip title={saveDisabled ? '当前没有需要保存到草稿的修改' : '保存草稿 Ctrl/Cmd + S'}>
+              <span>
+                <Button
+                  size="small"
+                  loading={saving}
+                  disabled={saveDisabled || publishing}
+                  icon={<Save size={13} />}
+                  onClick={onSaveDraft}
+                >
+                  保存草稿
+                </Button>
+              </span>
+            </Tooltip>
+            <Tooltip title={!canPublish ? '当前草稿已经是已发布版本' : undefined}>
+              <span>
+                <Button
+                  size="small"
+                  type="primary"
+                  loading={publishing}
+                  disabled={!canPublish || saving}
+                  icon={<Send size={13} />}
+                  onClick={onPublish}
+                >
+                  {hasPublishedVersion ? '发布更新' : '发布'}
+                </Button>
+              </span>
+            </Tooltip>
+          </>
         ) : null}
       </div>
     </header>

--- a/yak-ops-ui/src/pages/dashboard/use-dashboard.ts
+++ b/yak-ops-ui/src/pages/dashboard/use-dashboard.ts
@@ -9,9 +9,10 @@ import { message } from 'antd';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { DEFAULT_DASHBOARD } from './defaults';
 import {
-  activateDashboardVersion,
   createDashboard,
   fetchDashboard,
+  publishDashboard,
+  restoreDashboardVersion,
   saveDashboardVersion,
   toDashboardDocument,
 } from './dashboard-service';
@@ -29,6 +30,7 @@ import type {
   ChartType,
   DashboardDocument,
   DashboardGlobalFilter,
+  DashboardServerDetail,
   DashboardVersionSummary,
   DashboardWidget,
   PublishedDataset,
@@ -87,6 +89,7 @@ export function useDashboardDesigner(dashboardId?: string) {
   const [analyses, setAnalyses] = useState<AnalysisAsset[]>([]);
   const [dashboardVersions, setDashboardVersions] = useState<DashboardVersionSummary[]>([]);
   const [dashboardSaving, setDashboardSaving] = useState(false);
+  const [dashboardPublishing, setDashboardPublishing] = useState(false);
   const [runtimeFilterValues, setRuntimeFilterValues] = useState<Record<string, Scalar | undefined>>({});
   const [selectedId, setSelectedId] = useState<string>();
   const [preview, setPreview] = useState(false);
@@ -100,6 +103,13 @@ export function useDashboardDesigner(dashboardId?: string) {
   const dirty = dashboardFingerprint(dashboard) !== savedFingerprintRef.current;
   const canUndo = undoStackRef.current.length > 0;
   const canRedo = redoStackRef.current.length > 0;
+  const persisted = isPersistedDashboard(dashboard.id);
+  const hasPublishedVersion = Boolean(dashboard.publishedVersionId);
+  const hasUnpublishedDraft = Boolean(
+    dashboard.currentVersionId
+    && dashboard.currentVersionId !== dashboard.publishedVersionId,
+  );
+  const canPublish = !persisted || dirty || hasUnpublishedDraft || !hasPublishedVersion;
 
   const setDashboardWithoutHistory = useCallback((next: DashboardDocument) => {
     const cloned = cloneDashboard(next);
@@ -120,6 +130,14 @@ export function useDashboardDesigner(dashboardId?: string) {
     setDashboardState(cloned);
     setSelectedId(undefined);
   }, []);
+
+  const applyServerDetail = useCallback((detail: DashboardServerDetail) => {
+    const document = toDashboardDocument(detail);
+    resetDashboardState(document);
+    setDashboardVersions(detail.versions);
+    window.localStorage.removeItem(STORAGE_KEY);
+    return document;
+  }, [resetDashboardState]);
 
   const commitDashboard = useCallback((
     updater: DashboardDocument | ((current: DashboardDocument) => DashboardDocument),
@@ -193,14 +211,11 @@ export function useDashboardDesigner(dashboardId?: string) {
 
   const openDashboard = useCallback(async (targetDashboardId: string) => {
     try {
-      const detail = await fetchDashboard(targetDashboardId);
-      resetDashboardState(toDashboardDocument(detail));
-      setDashboardVersions(detail.versions);
-      window.localStorage.removeItem(STORAGE_KEY);
+      applyServerDetail(await fetchDashboard(targetDashboardId));
     } catch (error) {
       message.error(error instanceof Error ? error.message : '加载 Dashboard 失败');
     }
-  }, [resetDashboardState]);
+  }, [applyServerDetail]);
 
   useEffect(() => {
     void loadDatasets();
@@ -401,42 +416,68 @@ export function useDashboardDesigner(dashboardId?: string) {
     }), `widget:${id}:dataset`);
   };
 
-  const save = async (): Promise<string | undefined> => {
+  const persistCurrentDraft = async (): Promise<DashboardServerDetail | undefined> => {
     const currentDashboard = dashboardRef.current;
     if (!currentDashboard.name.trim()) {
       message.warning('请输入仪表盘名称');
       return undefined;
     }
+    return isPersistedDashboard(currentDashboard.id)
+      ? saveDashboardVersion(currentDashboard.id, currentDashboard)
+      : createDashboard(currentDashboard);
+  };
+
+  const saveDraft = async (): Promise<string | undefined> => {
+    const currentDashboard = dashboardRef.current;
+    if (isPersistedDashboard(currentDashboard.id) && !dirty) return currentDashboard.id;
     setDashboardSaving(true);
     try {
-      const detail = isPersistedDashboard(currentDashboard.id)
-        ? await saveDashboardVersion(currentDashboard.id, currentDashboard)
-        : await createDashboard(currentDashboard);
-      const document = toDashboardDocument(detail);
-      resetDashboardState(document);
-      setDashboardVersions(detail.versions);
-      window.localStorage.removeItem(STORAGE_KEY);
-      message.success(`仪表盘已保存为 V${detail.dashboard.currentVersionNo}`);
+      const detail = await persistCurrentDraft();
+      if (!detail) return undefined;
+      applyServerDetail(detail);
+      message.success(`草稿已保存为 V${detail.dashboard.currentVersionNo}`);
       return detail.dashboard.id;
     } catch (error) {
-      message.error(error instanceof Error ? error.message : '保存 Dashboard 失败');
+      message.error(error instanceof Error ? error.message : '保存 Dashboard 草稿失败');
       return undefined;
     } finally {
       setDashboardSaving(false);
     }
   };
 
-  const activateVersion = async (versionNo: number) => {
+  const publish = async (): Promise<string | undefined> => {
+    if (!canPublish || dashboardPublishing) return dashboardRef.current.id;
+    setDashboardPublishing(true);
+    try {
+      let dashboardIdToPublish = dashboardRef.current.id;
+      if (!isPersistedDashboard(dashboardIdToPublish) || dirty) {
+        const draftDetail = await persistCurrentDraft();
+        if (!draftDetail) return undefined;
+        applyServerDetail(draftDetail);
+        dashboardIdToPublish = draftDetail.dashboard.id;
+      }
+      const detail = await publishDashboard(dashboardIdToPublish);
+      applyServerDetail(detail);
+      message.success(`仪表盘已发布 V${detail.dashboard.publishedVersionNo}`);
+      return detail.dashboard.id;
+    } catch (error) {
+      message.error(error instanceof Error ? error.message : '发布 Dashboard 失败');
+      return undefined;
+    } finally {
+      setDashboardPublishing(false);
+    }
+  };
+
+  const restoreVersion = async (versionNo: number) => {
     const currentDashboard = dashboardRef.current;
-    if (!isPersistedDashboard(currentDashboard.id) || versionNo === currentDashboard.currentVersionNo) return;
+    if (!isPersistedDashboard(currentDashboard.id)) return;
     setDashboardSaving(true);
     try {
-      const detail = await activateDashboardVersion(currentDashboard.id, versionNo);
-      resetDashboardState(toDashboardDocument(detail));
-      setDashboardVersions(detail.versions);
-      message.success(`已切换到 Dashboard V${versionNo}`);
+      const detail = await restoreDashboardVersion(currentDashboard.id, versionNo);
+      applyServerDetail(detail);
+      message.success(`V${versionNo} 已恢复为草稿 V${detail.dashboard.currentVersionNo}`);
     } catch (error) {
-      message.error(error instanceof Error ? error.message : '切换 DashboardVersion 失败');
+      message.error(error instanceof Error ? error.message : '恢复 DashboardVersion 失败');
     } finally {
       setDashboardSaving(false);
     }
@@ -450,6 +491,7 @@ export function useDashboardDesigner(dashboardId?: string) {
     analyses,
     dashboardVersions,
     dashboardSaving,
+    dashboardPublishing,
     runtimeFilterValues,
     selectedWidget,
     activeDataset,
@@ -458,6 +500,10 @@ export function useDashboardDesigner(dashboardId?: string) {
     dirty,
     canUndo,
     canRedo,
+    persisted,
+    hasPublishedVersion,
+    hasUnpublishedDraft,
+    canPublish,
     setSelectedId,
     setPreview,
     updateDashboardName,
@@ -475,7 +521,8 @@ export function useDashboardDesigner(dashboardId?: string) {
     changeWidgetDataset,
     undo,
     redo,
-    save,
-    activateVersion,
+    saveDraft,
+    publish,
+    restoreVersion,
   };
 }

--- a/yak-ops-ui/src/pages/dashboard/version-history-drawer.tsx
+++ b/yak-ops-ui/src/pages/dashboard/version-history-drawer.tsx
@@ -1,0 +1,200 @@
+import { Button, Drawer, Empty, Spin } from 'antd';
+import { RotateCcw } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+import { fetchDashboardVersion } from './dashboard-service';
+import type { DashboardVersionDetail, DashboardVersionSummary } from './model';
+
+const formatTime = (value?: string) => value ? value.replace('T', ' ').slice(0, 19) : '-';
+
+export function DashboardVersionHistoryDrawer({
+  open,
+  dashboardId,
+  versions,
+  currentVersionNo,
+  publishedVersionNo,
+  busy,
+  onClose,
+  onRestore,
+}: {
+  open: boolean;
+  dashboardId: string;
+  versions: DashboardVersionSummary[];
+  currentVersionNo?: number;
+  publishedVersionNo?: number;
+  busy: boolean;
+  onClose: () => void;
+  onRestore: (versionNo: number) => void;
+}) {
+  const [selectedVersionNo, setSelectedVersionNo] = useState<number>();
+  const [detail, setDetail] = useState<DashboardVersionDetail>();
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    setSelectedVersionNo(currentVersionNo ?? versions[0]?.versionNo);
+  }, [currentVersionNo, open, versions]);
+
+  useEffect(() => {
+    if (!open || !selectedVersionNo) {
+      setDetail(undefined);
+      return;
+    }
+    let active = true;
+    setLoading(true);
+    void fetchDashboardVersion(dashboardId, selectedVersionNo)
+      .then((value) => {
+        if (active) setDetail(value);
+      })
+      .catch(() => {
+        if (active) setDetail(undefined);
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [dashboardId, open, selectedVersionNo]);
+
+  const selectedVersion = useMemo(
+    () => versions.find((item) => item.versionNo === selectedVersionNo),
+    [selectedVersionNo, versions],
+  );
+
+  return (
+    <Drawer
+      title="历史版本"
+      width={680}
+      open={open}
+      onClose={onClose}
+      destroyOnClose
+      styles={{ body: { padding: 0 } }}
+    >
+      <div className="flex h-full min-h-[520px]">
+        <div className="w-[190px] shrink-0 overflow-y-auto border-r border-[#edf0f3] bg-[#fafbfc] p-2">
+          {versions.map((item) => {
+            const selected = item.versionNo === selectedVersionNo;
+            const current = item.versionNo === currentVersionNo;
+            const published = item.versionNo === publishedVersionNo;
+            return (
+              <button
+                key={item.id}
+                type="button"
+                onClick={() => setSelectedVersionNo(item.versionNo)}
+                className={[
+                  'mb-1 w-full rounded-[6px] border-0 px-3 py-2.5 text-left transition-colors',
+                  selected ? 'bg-white shadow-[0_0_0_1px_#e1e5ea]' : 'bg-transparent hover:bg-white',
+                ].join(' ')}
+              >
+                <div className="flex items-center justify-between gap-2">
+                  <span className="text-[12px] font-semibold text-[#344054]">V{item.versionNo}</span>
+                  <div className="flex items-center gap-1">
+                    {current ? (
+                      <span className="rounded-[3px] bg-[#f2f4f7] px-1.5 py-0.5 text-[9px] text-[#475467]">
+                        当前草稿
+                      </span>
+                    ) : null}
+                    {published ? (
+                      <span className="rounded-[3px] bg-[#ecfdf3] px-1.5 py-0.5 text-[9px] text-[#1d7a4b]">
+                        已发布
+                      </span>
+                    ) : null}
+                  </div>
+                </div>
+                <div className="mt-1 truncate text-[10px] text-[#667085]">{item.name}</div>
+                <div className="mt-1 text-[9px] text-[#98a2b3]">{formatTime(item.createTime)}</div>
+              </button>
+            );
+          })}
+        </div>
+
+        <div className="min-w-0 flex-1 overflow-y-auto p-5">
+          {loading ? (
+            <div className="flex h-[360px] items-center justify-center">
+              <Spin size="small" />
+            </div>
+          ) : detail && selectedVersion ? (
+            <>
+              <div className="flex items-start justify-between gap-4">
+                <div className="min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span className="text-[15px] font-semibold text-[#161823]">V{selectedVersion.versionNo}</span>
+                    {selectedVersion.versionNo === publishedVersionNo ? (
+                      <span className="rounded-[3px] bg-[#ecfdf3] px-2 py-0.5 text-[10px] text-[#1d7a4b]">已发布</span>
+                    ) : null}
+                  </div>
+                  <div className="mt-1 truncate text-[12px] text-[#475467]">{detail.version.name}</div>
+                  <div className="mt-1 text-[10px] text-[#98a2b3]">
+                    创建于 {formatTime(detail.version.createTime)}
+                  </div>
+                </div>
+
+                <Button
+                  size="small"
+                  icon={<RotateCcw size={12} />}
+                  disabled={busy || selectedVersion.versionNo === currentVersionNo}
+                  onClick={() => onRestore(selectedVersion.versionNo)}
+                >
+                  {selectedVersion.versionNo === currentVersionNo ? '当前草稿' : '恢复为草稿'}
+                </Button>
+              </div>
+
+              <div className="mt-5 grid grid-cols-4 gap-2">
+                <Metric label="组件" value={detail.widgets.length} />
+                <Metric label="筛选器" value={detail.globalFilters.length} />
+                <Metric label="联动" value={detail.interactions.length} />
+                <Metric label="Dataset" value={detail.version.activeDatasetId || '-'} />
+              </div>
+
+              <div className="mt-5">
+                <div className="mb-2 text-[11px] font-medium text-[#667085]">布局快照</div>
+                <div
+                  className="grid h-[190px] overflow-hidden rounded-[7px] border border-[#e5e7eb] bg-[#fafbfc] p-2"
+                  style={{
+                    gridTemplateColumns: 'repeat(24, minmax(0, 1fr))',
+                    gridAutoRows: '6px',
+                    gap: '2px',
+                  }}
+                >
+                  {detail.widgets.map((widget) => (
+                    <div
+                      key={widget.id}
+                      title={widget.title || '图表'}
+                      className="overflow-hidden rounded-[3px] border border-[#dfe3e8] bg-white px-1.5 py-1 text-[9px] text-[#667085] shadow-[0_1px_2px_rgba(16,24,40,.03)]"
+                      style={{
+                        gridColumn: `${widget.x + 1} / span ${widget.w}`,
+                        gridRow: `${widget.y + 1} / span ${Math.max(widget.h, 1)}`,
+                      }}
+                    >
+                      <span className="block truncate">{widget.title || '未命名图表'}</span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              <div className="mt-5 border-t border-[#edf0f3] pt-4">
+                <div className="text-[11px] font-medium text-[#667085]">版本说明</div>
+                <div className="mt-1 text-[11px] leading-5 text-[#98a2b3]">
+                  历史版本只读。恢复时会复制该快照并生成新的草稿版本，不会修改旧版本，也不会改变当前已发布版本。
+                </div>
+              </div>
+            </>
+          ) : (
+            <div className="flex h-[360px] items-center justify-center">
+              <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="版本详情加载失败" />
+            </div>
+          )}
+        </div>
+      </div>
+    </Drawer>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div className="rounded-[6px] border border-[#edf0f3] bg-white px-3 py-2.5">
+      <div className="text-[9px] text-[#98a2b3]">{label}</div>
+      <div className="mt-1 truncate text-[12px] font-semibold text-[#344054]" title={String(value)}>{value}</div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

完成 Dashboard 路线图 Stage 2：把原来“每次保存即切换当前版本”的工程版本模型，正式收敛成用户可理解的 **草稿 / 发布 / 历史版本** 生命周期。

新的产品语义：

```text
编辑
  ↓
保存草稿 Vn
  ↓
发布
  ↓
Published Vn

继续编辑
  ↓
保存草稿 Vn+1
  ↓
已发布版本仍保持 Vn
```

历史版本只读；恢复历史版本时会复制快照生成新的草稿版本，不再把 current pointer 直接倒退到旧版本。

## 1. Dashboard lifecycle model

`yak_dashboard.current_version_*` 继续保留，但从 Stage 2 开始明确表示 **当前保存的草稿快照**。

新增：

- `published_version_id`
- `published_version_no`
- `published_time`

因此 Dashboard 同时拥有：

```text
currentVersion   = 当前草稿
publishedVersion = 当前正式发布版本
```

保存草稿只移动 current pointer；只有显式 Publish 才移动 published pointer。

## 2. Migration compatibility

新增 Flyway V3：`V3__dashboard_draft_publish.sql`。

为避免升级后把已有 Dashboard 静默变成“未发布”，迁移会把升级前的 `current_version_*` 回填为初始 `published_version_*`。

因此旧 Dashboard 的现有可见语义保持不变，新建 Dashboard 才从“草稿未发布”开始。

## 3. Draft / Publish API

新增：

```text
GET  /api/v1/dashboards/{id}/versions/{versionNo}
GET  /api/v1/dashboards/{id}/published
POST /api/v1/dashboards/{id}/publish
POST /api/v1/dashboards/{id}/restore/{versionNo}
```

语义：

- `POST /dashboards`：创建 Dashboard + 草稿 V1，不自动发布
- `POST /{id}/versions`：保存新的不可变草稿版本，不影响 Published
- `POST /{id}/publish`：发布当前已保存草稿，不额外制造版本
- `GET /{id}/published`：读取稳定的 reader-facing 已发布快照，为后续分享 / 嵌入保留清晰边界
- `GET /{id}/versions/{versionNo}`：只读查看精确历史快照
- `POST /{id}/restore/{versionNo}`：复制历史快照为新的 V(max+1) 草稿，Published 保持不变

旧 `/activate/{versionNo}` 保留兼容入口，但语义收敛为 restore-as-new-draft，不再直接把 current pointer 指回旧版本。

## 4. Editor lifecycle UX

顶部工具栏从原来的：

```text
V3  [历史版本选择] [预览] [保存]
```

调整为：

```text
草稿 V4 · 已发布 V3

撤销 / 重做
添加图表
历史版本
预览
保存草稿
发布更新
```

状态区分：

- `未保存`
- `草稿 V1 · 未发布`
- `已发布 V3`
- `草稿 V4 · 已发布 V3`
- 本地编辑继续独立显示 `有未保存修改`

`Ctrl/Cmd + S` 现在明确保存草稿。

如果点击发布时仍有本地未保存修改，会先自动保存为新的草稿版本，再发布该版本，避免用户需要机械执行“保存 -> 发布”两次操作。

## 5. Version history drawer

移除“选择历史版本即激活”的交互，新增独立历史版本 Drawer：

- 版本时间线
- `当前草稿` 标识
- `已发布` 标识
- 精确版本详情加载
- Widget / Filter / Interaction / Dataset 摘要
- 轻量 24 栅格布局快照
- `恢复为草稿`

历史版本查看不会改变当前编辑状态。

恢复历史版本：

```text
当前 V5
已发布 V4
查看历史 V2
    ↓
恢复为草稿
    ↓
生成 V6（内容来自 V2）
已发布仍然是 V4
```

## 6. Dashboard list lifecycle

仪表盘资产列表同步切换到生命周期视角：

筛选：

- 全部
- 已发布
- 有草稿
- 未发布

每条资产展示：

- 草稿版本
- 发布版本
- 生命周期状态
- 创建日期
- 更新时间

已发布 Dashboard 在列表中重命名时只生成新的草稿版本，不会偷偷修改正式发布版本。

## Backend tests

扩展 `DashboardServiceTest` 覆盖：

- 新建 Dashboard 产生 Draft V1，但 publishedVersionNo = 0
- Publish 指向当前 Draft 且不创建额外版本
- Publish V1 后保存 Draft V2，Published 仍保持 V1
- 恢复历史 V1 会生成新的 Draft V3，Published 仍保持 V1
- 历史版本详情读取不会改变当前 Draft pointer
- 原有 Widget / Filter / Interaction 完整性校验继续保留

## Scope

Stage 2 本次不包含：

- 发布审批
- 定时发布
- 多人协作
- 分享 / 公共链接
- 权限 / Owner
- Embed
- Template
- Unpublish
- Stage 3 Global Filter 配置 UI
- Drill Down / Jump

这些继续保持后续阶段边界。

## Verification

- 基于 Stage 1 合并后的 `main`：`d1ea07544400deb13a5ee42c0799d640d18953f6`
- 创建分支时与 main 同步
- 当前改动集中在 Dashboard domain、V3 migration、Dashboard frontend lifecycle
- 已静态复核 Draft -> Publish -> New Draft -> Restore 的 pointer 语义以及历史版本只读边界
- 当前 connector 环境没有本地 Maven / Node 依赖执行环境，因此不宣称本地 `mvn test`、`npm run tsc` 或 `npm run build` 已通过；Draft 阶段继续以仓库 CI/status 为准
