### PR TITLE
feat(dashboard): complete stage 3 filters and widget linkage

### DIFF
--- a/yak-ops-ui/src/pages/dashboard/chart-editor.tsx
+++ b/yak-ops-ui/src/pages/dashboard/chart-editor.tsx
@@ -5,10 +5,13 @@ import { ConfigData } from './config-data';
 import { MetricAggregations } from './config-metrics';
 import { QueryControls } from './config-query';
 import { CHART_META, findDataset } from './helpers';
+import { DashboardInteractionEditor } from './interaction-editor';
 import type {
   Aggregation,
   AnalysisAsset,
   ChartType,
+  DashboardGlobalFilter,
+  DashboardInteraction,
   DashboardWidget,
   FilterOperator,
   MetricBinding,
@@ -20,8 +23,11 @@ export function ChartEditor({
   widget,
   datasets,
   analyses,
+  globalFilters,
+  interactions,
   updateWidget,
   updateInlineAnalysis,
+  updateInteractions,
   changeDataset,
   detachAnalysis,
   close,
@@ -29,8 +35,11 @@ export function ChartEditor({
   widget: DashboardWidget;
   datasets: PublishedDataset[];
   analyses: AnalysisAsset[];
+  globalFilters: DashboardGlobalFilter[];
+  interactions: DashboardInteraction[];
   updateWidget: (patch: Partial<DashboardWidget>) => void;
   updateInlineAnalysis: (patch: Partial<AnalysisSpec>) => void;
+  updateInteractions: (interactions: DashboardInteraction[]) => void;
   changeDataset: (datasetId: string) => void;
   detachAnalysis: () => void;
   close: () => void;
@@ -215,6 +224,17 @@ export function ChartEditor({
                 metrics: spec.metrics.map((metric) =>
                   metric.field === field ? { ...metric, aggregation } : metric),
               })}
+          />
+        </div>
+
+        <div className="mt-4 border-t border-[#edf0f3] pt-4">
+          <DashboardInteractionEditor
+            widget={widget}
+            spec={spec}
+            dataset={dataset}
+            filters={globalFilters}
+            interactions={interactions}
+            onChange={updateInteractions}
           />
         </div>
 

--- a/yak-ops-ui/src/pages/dashboard/editor.tsx
+++ b/yak-ops-ui/src/pages/dashboard/editor.tsx
@@ -8,6 +8,7 @@ import 'react-resizable/css/styles.css';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { ChartEditor } from './chart-editor';
 import { DashboardGlobalFilterBar } from './global-filter-bar';
+import { DashboardGlobalFilterConfig } from './global-filter-config';
 import { GRID_COLUMNS, GRID_ROW_HEIGHT } from './helpers';
 import { DashboardToolbar } from './toolbar';
 import { useDashboardDesigner } from './use-dashboard';
@@ -27,6 +28,7 @@ export default function DashboardEditorPage() {
   const designer = useDashboardDesigner(dashboardId);
   const { width, containerRef, mounted } = useContainerWidth();
   const [historyOpen, setHistoryOpen] = useState(false);
+  const [filterConfigOpen, setFilterConfigOpen] = useState(false);
   const layout = useMemo(() => designer.widgets.map((widget) => ({
     i: widget.id,
     x: widget.x,
@@ -37,12 +39,13 @@ export default function DashboardEditorPage() {
     minH: widget.minH,
   })), [designer.widgets]);
   const hasGlobalFilters = designer.dashboard.globalFilters.length > 0;
+  const hasFilterBar = !designer.preview || hasGlobalFilters;
   let canvasMinHeight = 'min-h-[calc(100vh-120px)]';
   if (designer.preview) {
-    canvasMinHeight = hasGlobalFilters
+    canvasMinHeight = hasFilterBar
       ? 'min-h-[calc(100vh-172px)]'
       : 'min-h-[calc(100vh-136px)]';
-  } else if (hasGlobalFilters) {
+  } else if (hasFilterBar) {
     canvasMinHeight = 'min-h-[calc(100vh-156px)]';
   }
 
@@ -199,8 +202,13 @@ export default function DashboardEditorPage() {
       <DashboardGlobalFilterBar
         filters={designer.dashboard.globalFilters}
         runtimeValues={designer.runtimeFilterValues}
+        widgets={designer.widgets}
+        datasets={designer.datasets}
+        analyses={designer.analyses}
+        editable={!designer.preview}
         onRuntimeValue={designer.setRuntimeFilterValue}
         onReset={designer.resetRuntimeFilters}
+        onManage={() => setFilterConfigOpen(true)}
       />
 
       <div className="flex min-h-0 flex-1 overflow-hidden">
@@ -305,10 +313,13 @@ export default function DashboardEditorPage() {
             widget={designer.selectedWidget}
             datasets={designer.datasets}
             analyses={designer.analyses}
+            globalFilters={designer.dashboard.globalFilters}
+            interactions={designer.dashboard.interactions}
             updateWidget={(patch) =>
               designer.updateWidget(designer.selectedWidget!.id, patch)}
             updateInlineAnalysis={(patch) =>
               designer.updateInlineAnalysis(designer.selectedWidget!.id, patch)}
+            updateInteractions={designer.updateInteractions}
             changeDataset={(datasetId) =>
               designer.changeWidgetDataset(designer.selectedWidget!.id, datasetId)}
             detachAnalysis={() =>
@@ -317,6 +328,16 @@ export default function DashboardEditorPage() {
           />
         ) : null}
       </div>
+
+      <DashboardGlobalFilterConfig
+        open={filterConfigOpen}
+        filters={designer.dashboard.globalFilters}
+        widgets={designer.widgets}
+        datasets={designer.datasets}
+        analyses={designer.analyses}
+        onChange={designer.updateGlobalFilters}
+        onClose={() => setFilterConfigOpen(false)}
+      />
 
       {designer.persisted ? (
         <DashboardVersionHistoryDrawer

--- a/yak-ops-ui/src/pages/dashboard/filter-utils.ts
+++ b/yak-ops-ui/src/pages/dashboard/filter-utils.ts
@@ -1,0 +1,66 @@
+import type {
+  AnalysisAsset,
+  DashboardGlobalFilter,
+  DashboardWidget,
+  DatasetField,
+  DatasetFieldType,
+  PublishedDataset,
+} from './model';
+
+export const isDateFieldType = (type?: DatasetFieldType) =>
+  type === 'date' || type === 'datetime';
+
+export const resolveWidgetDataset = (
+  widget: DashboardWidget,
+  datasets: PublishedDataset[],
+  analyses: AnalysisAsset[],
+): PublishedDataset | undefined => {
+  const datasetId = widget.analysisId
+    ? analyses.find((analysis) => analysis.id === widget.analysisId)?.datasetId
+    : widget.inlineAnalysis?.datasetId;
+  return datasetId ? datasets.find((dataset) => dataset.id === datasetId) : undefined;
+};
+
+export const resolveBindingField = (
+  widgetId: string,
+  fieldId: string,
+  widgets: DashboardWidget[],
+  datasets: PublishedDataset[],
+  analyses: AnalysisAsset[],
+): DatasetField | undefined => {
+  const widget = widgets.find((item) => item.id === widgetId);
+  if (!widget) return undefined;
+  return resolveWidgetDataset(widget, datasets, analyses)?.fields.find((field) => field.key === fieldId);
+};
+
+export const resolveFilterFieldType = (
+  filter: DashboardGlobalFilter,
+  widgets: DashboardWidget[],
+  datasets: PublishedDataset[],
+  analyses: AnalysisAsset[],
+): DatasetFieldType | undefined => {
+  for (const binding of filter.bindings) {
+    const field = resolveBindingField(
+      binding.widgetId,
+      binding.field,
+      widgets,
+      datasets,
+      analyses,
+    );
+    if (field) return field.dataType;
+  }
+  return undefined;
+};
+
+/**
+ * Stage 3 keeps the persisted filter domain small. Date controls are inferred from
+ * their bound Dataset field; the date-filter prefix preserves intent while a new
+ * date filter is being configured before all bindings are complete.
+ */
+export const isDateFilter = (
+  filter: DashboardGlobalFilter,
+  widgets: DashboardWidget[],
+  datasets: PublishedDataset[],
+  analyses: AnalysisAsset[],
+) => filter.id.startsWith('date-filter-')
+  || isDateFieldType(resolveFilterFieldType(filter, widgets, datasets, analyses));

--- a/yak-ops-ui/src/pages/dashboard/global-filter-bar.tsx
+++ b/yak-ops-ui/src/pages/dashboard/global-filter-bar.tsx
@@ -1,8 +1,13 @@
-import { Button, Input, Tooltip } from 'antd';
-import { RefreshCw, SlidersHorizontal } from 'lucide-react';
+import { Button, DatePicker, Input, Tooltip } from 'antd';
+import dayjs from 'dayjs';
+import { Plus, RefreshCw, Settings2, SlidersHorizontal } from 'lucide-react';
+import { isDateFilter, resolveBindingField } from './filter-utils';
 import type {
+  AnalysisAsset,
   DashboardGlobalFilter,
+  DashboardWidget,
   FilterOperator,
+  PublishedDataset,
   Scalar,
 } from './model';
 
@@ -22,15 +27,25 @@ const own = (value: Record<string, Scalar | undefined>, key: string) =>
 export function DashboardGlobalFilterBar({
   filters,
   runtimeValues,
+  widgets,
+  datasets,
+  analyses,
+  editable,
   onRuntimeValue,
   onReset,
+  onManage,
 }: {
   filters: DashboardGlobalFilter[];
   runtimeValues: Record<string, Scalar | undefined>;
+  widgets: DashboardWidget[];
+  datasets: PublishedDataset[];
+  analyses: AnalysisAsset[];
+  editable: boolean;
   onRuntimeValue: (filterId: string, value: Scalar | undefined) => void;
   onReset: () => void;
+  onManage: () => void;
 }) {
-  if (!filters.length) return null;
+  if (!filters.length && !editable) return null;
 
   return (
     <div className="flex min-h-9 shrink-0 items-center gap-2 border-b border-[#e5e7eb] bg-white px-3 py-1">
@@ -40,10 +55,25 @@ export function DashboardGlobalFilterBar({
       </div>
 
       <div className="flex min-w-0 flex-1 items-center gap-1.5 overflow-x-auto">
-        {filters.map((filter) => {
+        {filters.length ? filters.map((filter) => {
           const current = own(runtimeValues, filter.id)
             ? runtimeValues[filter.id]
             : filter.defaultValue;
+          const dateFilter = isDateFilter(filter, widgets, datasets, analyses);
+          const firstBinding = filter.bindings[0];
+          const firstField = firstBinding
+            ? resolveBindingField(
+                firstBinding.widgetId,
+                firstBinding.field,
+                widgets,
+                datasets,
+                analyses,
+              )
+            : undefined;
+          const dateTime = firstField?.dataType === 'datetime';
+          const dateValue = current === undefined || current === null || current === ''
+            ? null
+            : dayjs(String(current));
 
           return (
             <div
@@ -56,28 +86,62 @@ export function DashboardGlobalFilterBar({
               <span className="mr-1 text-[9px] text-[#98a2b3]">
                 {OPERATOR_LABELS[filter.operator]}
               </span>
-              <Input
-                variant="borderless"
-                size="small"
-                allowClear
-                className="w-[112px] text-[10px]"
-                placeholder="全部"
-                value={current === undefined || current === null ? '' : String(current)}
-                onChange={(event) => onRuntimeValue(filter.id, event.target.value)}
-              />
+              {dateFilter ? (
+                <DatePicker
+                  variant="borderless"
+                  size="small"
+                  allowClear
+                  showTime={dateTime ? { format: 'HH:mm:ss' } : false}
+                  format={dateTime ? 'YYYY-MM-DD HH:mm:ss' : 'YYYY-MM-DD'}
+                  className="w-[156px] text-[10px]"
+                  placeholder="全部"
+                  value={dateValue?.isValid() ? dateValue : null}
+                  onChange={(value) => onRuntimeValue(
+                    filter.id,
+                    value
+                      ? value.format(dateTime ? 'YYYY-MM-DD HH:mm:ss' : 'YYYY-MM-DD')
+                      : undefined,
+                  )}
+                />
+              ) : (
+                <Input
+                  variant="borderless"
+                  size="small"
+                  allowClear
+                  className="w-[112px] text-[10px]"
+                  placeholder="全部"
+                  value={current === undefined || current === null ? '' : String(current)}
+                  onChange={(event) => onRuntimeValue(filter.id, event.target.value || undefined)}
+                />
+              )}
             </div>
           );
-        })}
+        }) : (
+          <span className="text-[10px] text-[#98a2b3]">暂无筛选条件</span>
+        )}
       </div>
 
-      <Tooltip title="恢复默认筛选">
+      {filters.length ? (
+        <Tooltip title="恢复默认筛选">
+          <Button
+            size="small"
+            type="text"
+            icon={<RefreshCw size={12} />}
+            onClick={onReset}
+          />
+        </Tooltip>
+      ) : null}
+
+      {editable ? (
         <Button
           size="small"
           type="text"
-          icon={<RefreshCw size={12} />}
-          onClick={onReset}
-        />
-      </Tooltip>
+          icon={filters.length ? <Settings2 size={12} /> : <Plus size={12} />}
+          onClick={onManage}
+        >
+          {filters.length ? '管理' : '添加筛选'}
+        </Button>
+      ) : null}
     </div>
   );
 }

--- a/yak-ops-ui/src/pages/dashboard/global-filter-config.tsx
+++ b/yak-ops-ui/src/pages/dashboard/global-filter-config.tsx
@@ -1,0 +1,299 @@
+import { Button, DatePicker, Drawer, Empty, Input, Select, Switch, Tooltip, message } from 'antd';
+import dayjs from 'dayjs';
+import { CalendarDays, Plus, SlidersHorizontal, Trash2 } from 'lucide-react';
+import { isDateFieldType, isDateFilter, resolveWidgetDataset } from './filter-utils';
+import type {
+  AnalysisAsset,
+  DashboardGlobalFilter,
+  DashboardWidget,
+  FilterOperator,
+  PublishedDataset,
+} from './model';
+
+const TEXT_OPERATORS: Array<{ label: string; value: FilterOperator }> = [
+  { label: '等于', value: 'eq' },
+  { label: '不等于', value: 'neq' },
+  { label: '包含', value: 'contains' },
+  { label: '大于', value: 'gt' },
+  { label: '大于等于', value: 'gte' },
+  { label: '小于', value: 'lt' },
+  { label: '小于等于', value: 'lte' },
+];
+
+const DATE_OPERATORS: Array<{ label: string; value: FilterOperator }> = [
+  { label: '等于', value: 'eq' },
+  { label: '不等于', value: 'neq' },
+  { label: '晚于', value: 'gt' },
+  { label: '晚于或等于', value: 'gte' },
+  { label: '早于', value: 'lt' },
+  { label: '早于或等于', value: 'lte' },
+];
+
+const createId = (prefix: string) => `${prefix}-${Date.now()}-${Math.round(Math.random() * 1000)}`;
+
+export function DashboardGlobalFilterConfig({
+  open,
+  filters,
+  widgets,
+  datasets,
+  analyses,
+  onChange,
+  onClose,
+}: {
+  open: boolean;
+  filters: DashboardGlobalFilter[];
+  widgets: DashboardWidget[];
+  datasets: PublishedDataset[];
+  analyses: AnalysisAsset[];
+  onChange: (filters: DashboardGlobalFilter[]) => void;
+  onClose: () => void;
+}) {
+  const widgetContext = widgets.map((widget) => ({
+    widget,
+    dataset: resolveWidgetDataset(widget, datasets, analyses),
+  }));
+
+  const patchFilter = (filterId: string, patch: Partial<DashboardGlobalFilter>) => {
+    onChange(filters.map((filter) => filter.id === filterId ? { ...filter, ...patch } : filter));
+  };
+
+  const removeFilter = (filterId: string) => {
+    onChange(filters.filter((filter) => filter.id !== filterId));
+  };
+
+  const addTextFilter = () => {
+    const context = widgetContext.find((item) => item.dataset?.fields.length);
+    const field = context?.dataset?.fields[0];
+    const filter: DashboardGlobalFilter = {
+      id: createId('filter'),
+      name: field?.label || '筛选条件',
+      operator: 'eq',
+      bindings: context && field ? [{ widgetId: context.widget.id, field: field.key }] : [],
+    };
+    onChange([...filters, filter]);
+  };
+
+  const addDateFilter = () => {
+    const context = widgetContext.find((item) =>
+      item.dataset?.fields.some((field) => isDateFieldType(field.dataType)));
+    const field = context?.dataset?.fields.find((item) => isDateFieldType(item.dataType));
+    if (!context || !field) {
+      message.info('当前仪表盘没有可用于日期筛选的 date / datetime 字段');
+      return;
+    }
+    const filter: DashboardGlobalFilter = {
+      id: createId('date-filter'),
+      name: field.label || '日期',
+      operator: 'eq',
+      bindings: [{ widgetId: context.widget.id, field: field.key }],
+    };
+    onChange([...filters, filter]);
+  };
+
+  return (
+    <Drawer
+      title={(
+        <div>
+          <div className="text-[13px] font-semibold text-[#344054]">全局筛选</div>
+          <div className="mt-0.5 text-[10px] font-normal text-[#98a2b3]">
+            一个筛选器可以映射到多个图表的不同字段
+          </div>
+        </div>
+      )}
+      width={500}
+      open={open}
+      onClose={onClose}
+      extra={(
+        <div className="flex items-center gap-1.5">
+          <Button size="small" icon={<Plus size={12} />} onClick={addTextFilter}>
+            筛选
+          </Button>
+          <Button size="small" icon={<CalendarDays size={12} />} onClick={addDateFilter}>
+            日期
+          </Button>
+        </div>
+      )}
+    >
+      {!filters.length ? (
+        <div className="flex min-h-[360px] items-center justify-center">
+          <Empty
+            image={Empty.PRESENTED_IMAGE_SIMPLE}
+            description={(
+              <div className="text-[11px] text-[#98a2b3]">
+                添加一个全局筛选器，再选择它要作用的图表字段
+              </div>
+            )}
+          />
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {filters.map((filter, index) => {
+            const dateFilter = isDateFilter(filter, widgets, datasets, analyses);
+            const firstBinding = filter.bindings[0];
+            const firstContext = firstBinding
+              ? widgetContext.find((item) => item.widget.id === firstBinding.widgetId)
+              : undefined;
+            const firstField = firstContext?.dataset?.fields.find((field) => field.key === firstBinding?.field);
+            const dateTime = firstField?.dataType === 'datetime';
+            const defaultDate = filter.defaultValue === undefined || filter.defaultValue === null
+              ? null
+              : dayjs(String(filter.defaultValue));
+
+            return (
+              <div key={filter.id} className="rounded-[8px] border border-[#e5e7eb] bg-white p-3">
+                <div className="flex items-center justify-between gap-3">
+                  <div className="flex min-w-0 items-center gap-2">
+                    <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-[6px] bg-[#f5f6f7] text-[#667085]">
+                      {dateFilter ? <CalendarDays size={13} /> : <SlidersHorizontal size={13} />}
+                    </div>
+                    <div className="min-w-0">
+                      <div className="truncate text-[11px] font-medium text-[#344054]">
+                        {filter.name || `筛选器 ${index + 1}`}
+                      </div>
+                      <div className="mt-0.5 text-[9px] text-[#98a2b3]">
+                        {dateFilter ? '日期筛选' : '字段筛选'} · 已作用 {filter.bindings.length} 个图表
+                      </div>
+                    </div>
+                  </div>
+                  <Tooltip title="删除筛选器">
+                    <Button
+                      size="small"
+                      type="text"
+                      danger
+                      icon={<Trash2 size={12} />}
+                      onClick={() => removeFilter(filter.id)}
+                    />
+                  </Tooltip>
+                </div>
+
+                <div className="mt-3 grid grid-cols-[1fr_132px] gap-2">
+                  <div>
+                    <div className="mb-1 text-[10px] text-[#667085]">名称</div>
+                    <Input
+                      size="small"
+                      value={filter.name}
+                      maxLength={200}
+                      onChange={(event) => patchFilter(filter.id, { name: event.target.value })}
+                    />
+                  </div>
+                  <div>
+                    <div className="mb-1 text-[10px] text-[#667085]">条件</div>
+                    <Select
+                      size="small"
+                      className="w-full"
+                      value={filter.operator}
+                      options={dateFilter ? DATE_OPERATORS : TEXT_OPERATORS}
+                      onChange={(operator) => patchFilter(filter.id, { operator })}
+                    />
+                  </div>
+                </div>
+
+                <div className="mt-2">
+                  <div className="mb-1 text-[10px] text-[#667085]">默认值</div>
+                  {dateFilter ? (
+                    <DatePicker
+                      size="small"
+                      allowClear
+                      showTime={dateTime ? { format: 'HH:mm:ss' } : false}
+                      format={dateTime ? 'YYYY-MM-DD HH:mm:ss' : 'YYYY-MM-DD'}
+                      value={defaultDate?.isValid() ? defaultDate : null}
+                      className="w-full"
+                      placeholder="默认不筛选"
+                      onChange={(value) => patchFilter(filter.id, {
+                        defaultValue: value
+                          ? value.format(dateTime ? 'YYYY-MM-DD HH:mm:ss' : 'YYYY-MM-DD')
+                          : undefined,
+                      })}
+                    />
+                  ) : (
+                    <Input
+                      size="small"
+                      allowClear
+                      placeholder="默认不筛选"
+                      value={filter.defaultValue === undefined || filter.defaultValue === null
+                        ? ''
+                        : String(filter.defaultValue)}
+                      onChange={(event) => patchFilter(filter.id, {
+                        defaultValue: event.target.value || undefined,
+                      })}
+                    />
+                  )}
+                </div>
+
+                <div className="mt-3 border-t border-[#edf0f3] pt-3">
+                  <div className="mb-2 flex items-center justify-between">
+                    <span className="text-[10px] font-medium text-[#667085]">作用图表</span>
+                    <span className="text-[9px] text-[#98a2b3]">每个图表显式映射一个字段</span>
+                  </div>
+
+                  {!widgetContext.length ? (
+                    <div className="rounded-[5px] bg-[#fafbfc] px-2.5 py-2 text-[10px] text-[#98a2b3]">
+                      先添加图表，再配置筛选字段映射。
+                    </div>
+                  ) : (
+                    <div className="space-y-1.5">
+                      {widgetContext.map(({ widget, dataset }) => {
+                        const binding = filter.bindings.find((item) => item.widgetId === widget.id);
+                        const fieldOptions = (dataset?.fields || [])
+                          .filter((field) => !dateFilter || isDateFieldType(field.dataType))
+                          .map((field) => ({
+                            label: `${field.label} · ${field.dataType}`,
+                            value: field.key,
+                          }));
+                        const enabled = Boolean(binding);
+
+                        return (
+                          <div
+                            key={widget.id}
+                            className="flex min-h-9 items-center gap-2 rounded-[5px] bg-[#fafbfc] px-2"
+                          >
+                            <Switch
+                              size="small"
+                              checked={enabled}
+                              disabled={!fieldOptions.length}
+                              onChange={(checked) => {
+                                if (!checked) {
+                                  patchFilter(filter.id, {
+                                    bindings: filter.bindings.filter((item) => item.widgetId !== widget.id),
+                                  });
+                                  return;
+                                }
+                                const first = fieldOptions[0]?.value;
+                                if (!first) return;
+                                patchFilter(filter.id, {
+                                  bindings: [
+                                    ...filter.bindings.filter((item) => item.widgetId !== widget.id),
+                                    { widgetId: widget.id, field: first },
+                                  ],
+                                });
+                              }}
+                            />
+                            <div className="min-w-0 flex-1 truncate text-[10px] text-[#475467]">
+                              {widget.title || '未命名图表'}
+                            </div>
+                            <Select
+                              size="small"
+                              className="w-[190px]"
+                              placeholder={fieldOptions.length ? '选择字段' : dateFilter ? '无日期字段' : '无可用字段'}
+                              disabled={!enabled || !fieldOptions.length}
+                              value={binding?.field}
+                              options={fieldOptions}
+                              onChange={(field) => patchFilter(filter.id, {
+                                bindings: filter.bindings.map((item) =>
+                                  item.widgetId === widget.id ? { ...item, field } : item),
+                              })}
+                            />
+                          </div>
+                        );
+                      })}
+                    </div>
+                  )}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </Drawer>
+  );
+}

--- a/yak-ops-ui/src/pages/dashboard/interaction-editor.tsx
+++ b/yak-ops-ui/src/pages/dashboard/interaction-editor.tsx
@@ -1,7 +1,7 @@
+import type { AnalysisSpec } from '@/components/analysis/model';
 import { Button, Select, Tooltip } from 'antd';
 import { Link2, Plus, Trash2 } from 'lucide-react';
 import type {
-  AnalysisSpec,
   DashboardGlobalFilter,
   DashboardInteraction,
   DashboardWidget,

--- a/yak-ops-ui/src/pages/dashboard/interaction-editor.tsx
+++ b/yak-ops-ui/src/pages/dashboard/interaction-editor.tsx
@@ -1,0 +1,148 @@
+import { Button, Select, Tooltip } from 'antd';
+import { Link2, Plus, Trash2 } from 'lucide-react';
+import type {
+  AnalysisSpec,
+  DashboardGlobalFilter,
+  DashboardInteraction,
+  DashboardWidget,
+  PublishedDataset,
+} from './model';
+
+const createInteractionId = () => `interaction-${Date.now()}-${Math.round(Math.random() * 1000)}`;
+
+export function DashboardInteractionEditor({
+  widget,
+  spec,
+  dataset,
+  filters,
+  interactions,
+  onChange,
+}: {
+  widget: DashboardWidget;
+  spec: AnalysisSpec;
+  dataset: PublishedDataset;
+  filters: DashboardGlobalFilter[];
+  interactions: DashboardInteraction[];
+  onChange: (interactions: DashboardInteraction[]) => void;
+}) {
+  const rules = interactions.filter((item) => item.sourceWidgetId === widget.id);
+  const sourceOptions = spec.dimensions.map((fieldId) => {
+    const field = dataset.fields.find((item) => item.key === fieldId);
+    return {
+      label: field?.label || fieldId,
+      value: fieldId,
+    };
+  });
+  const targetOptions = filters
+    .filter((filter) => filter.bindings.length > 0)
+    .map((filter) => ({
+      label: `${filter.name} · ${filter.bindings.length} 个图表`,
+      value: filter.id,
+    }));
+
+  const updateRule = (id: string, patch: Partial<DashboardInteraction>) => {
+    onChange(interactions.map((item) => item.id === id ? { ...item, ...patch } : item));
+  };
+
+  const removeRule = (id: string) => {
+    onChange(interactions.filter((item) => item.id !== id));
+  };
+
+  const addRule = () => {
+    const sourceField = sourceOptions[0]?.value;
+    const targetFilterId = targetOptions[0]?.value;
+    if (!sourceField || !targetFilterId) return;
+    onChange([
+      ...interactions,
+      {
+        id: createInteractionId(),
+        event: 'select',
+        sourceWidgetId: widget.id,
+        sourceField,
+        targetFilterId,
+      },
+    ]);
+  };
+
+  return (
+    <div>
+      <div className="flex items-center justify-between gap-2">
+        <div>
+          <div className="flex items-center gap-1.5 text-[11px] font-medium text-[#667085]">
+            <Link2 size={12} />
+            图表联动
+          </div>
+          <div className="mt-1 text-[9px] leading-4 text-[#98a2b3]">
+            点击当前图表的分类值后，写入目标筛选器并刷新它绑定的图表。
+          </div>
+        </div>
+        <Button
+          size="small"
+          type="text"
+          icon={<Plus size={12} />}
+          disabled={!sourceOptions.length || !targetOptions.length}
+          onClick={addRule}
+        >
+          添加
+        </Button>
+      </div>
+
+      {!filters.length ? (
+        <div className="mt-2 rounded-[5px] bg-[#fafbfc] px-2.5 py-2 text-[10px] text-[#98a2b3]">
+          先在画布顶部添加全局筛选器，再配置图表联动。
+        </div>
+      ) : !sourceOptions.length ? (
+        <div className="mt-2 rounded-[5px] bg-[#fafbfc] px-2.5 py-2 text-[10px] text-[#98a2b3]">
+          当前图表没有维度字段，暂时不能作为联动来源。
+        </div>
+      ) : !targetOptions.length ? (
+        <div className="mt-2 rounded-[5px] bg-[#fafbfc] px-2.5 py-2 text-[10px] text-[#98a2b3]">
+          当前筛选器还没有绑定图表字段，完成字段映射后即可联动。
+        </div>
+      ) : rules.length ? (
+        <div className="mt-2 space-y-2">
+          {rules.map((rule) => (
+            <div key={rule.id} className="rounded-[6px] border border-[#edf0f3] bg-[#fafbfc] p-2">
+              <div className="grid grid-cols-[1fr_1fr_28px] items-end gap-1.5">
+                <div>
+                  <div className="mb-1 text-[9px] text-[#98a2b3]">点击维度</div>
+                  <Select
+                    size="small"
+                    className="w-full"
+                    value={rule.sourceField}
+                    options={sourceOptions}
+                    onChange={(sourceField) => updateRule(rule.id, { sourceField })}
+                  />
+                </div>
+                <div>
+                  <div className="mb-1 text-[9px] text-[#98a2b3]">更新筛选器</div>
+                  <Select
+                    size="small"
+                    className="w-full"
+                    value={rule.targetFilterId}
+                    options={targetOptions}
+                    onChange={(targetFilterId) => updateRule(rule.id, { targetFilterId })}
+                  />
+                </div>
+                <Tooltip title="删除联动">
+                  <Button
+                    size="small"
+                    type="text"
+                    danger
+                    className="w-7 px-0"
+                    icon={<Trash2 size={12} />}
+                    onClick={() => removeRule(rule.id)}
+                  />
+                </Tooltip>
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className="mt-2 rounded-[5px] bg-[#fafbfc] px-2.5 py-2 text-[10px] text-[#98a2b3]">
+          暂无联动。点击“添加”后选择来源维度和目标筛选器。
+        </div>
+      )}
+    </div>
+  );
+}

--- a/yak-ops-ui/src/pages/dashboard/interaction-editor.tsx
+++ b/yak-ops-ui/src/pages/dashboard/interaction-editor.tsx
@@ -39,6 +39,14 @@ export function DashboardInteractionEditor({
       label: `${filter.name} · ${filter.bindings.length} 个图表`,
       value: filter.id,
     }));
+  const nextPair = sourceOptions.flatMap((source) =>
+    targetOptions.map((target) => ({
+      sourceField: source.value,
+      targetFilterId: target.value,
+    })))
+    .find((pair) => !rules.some((rule) =>
+      rule.sourceField === pair.sourceField
+      && rule.targetFilterId === pair.targetFilterId));
 
   const updateRule = (id: string, patch: Partial<DashboardInteraction>) => {
     onChange(interactions.map((item) => item.id === id ? { ...item, ...patch } : item));
@@ -49,17 +57,15 @@ export function DashboardInteractionEditor({
   };
 
   const addRule = () => {
-    const sourceField = sourceOptions[0]?.value;
-    const targetFilterId = targetOptions[0]?.value;
-    if (!sourceField || !targetFilterId) return;
+    if (!nextPair) return;
     onChange([
       ...interactions,
       {
         id: createInteractionId(),
         event: 'select',
         sourceWidgetId: widget.id,
-        sourceField,
-        targetFilterId,
+        sourceField: nextPair.sourceField,
+        targetFilterId: nextPair.targetFilterId,
       },
     ]);
   };
@@ -80,7 +86,7 @@ export function DashboardInteractionEditor({
           size="small"
           type="text"
           icon={<Plus size={12} />}
-          disabled={!sourceOptions.length || !targetOptions.length}
+          disabled={!nextPair}
           onClick={addRule}
         >
           添加

--- a/yak-ops-ui/src/pages/dashboard/use-dashboard.ts
+++ b/yak-ops-ui/src/pages/dashboard/use-dashboard.ts
@@ -30,6 +30,7 @@ import type {
   ChartType,
   DashboardDocument,
   DashboardGlobalFilter,
+  DashboardInteraction,
   DashboardServerDetail,
   DashboardVersionSummary,
   DashboardWidget,
@@ -294,6 +295,26 @@ export function useDashboardDesigner(dashboardId?: string) {
     `widget:${id}:analysis:${Object.keys(patch).sort().join(',')}`,
   );
 
+  const updateGlobalFilters = (filters: DashboardGlobalFilter[]) => {
+    const filterIds = new Set(filters.map((filter) => filter.id));
+    commitDashboard((current) => ({
+      ...current,
+      globalFilters: filters,
+      interactions: current.interactions.filter((interaction) => filterIds.has(interaction.targetFilterId)),
+    }), 'dashboard:global-filters');
+    setRuntimeFilterValues((current) => Object.fromEntries(
+      filters.map((filter) => [
+        filter.id,
+        hasOwn(current, filter.id) ? current[filter.id] : filter.defaultValue,
+      ]),
+    ));
+  };
+
+  const updateInteractions = (interactions: DashboardInteraction[]) => commitDashboard(
+    (current) => ({ ...current, interactions }),
+    'dashboard:interactions',
+  );
+
   const setRuntimeFilterValue = (filterId: string, value: Scalar | undefined) => {
     setRuntimeFilterValues((current) => ({ ...current, [filterId]: value }));
   };
@@ -510,6 +531,8 @@ export function useDashboardDesigner(dashboardId?: string) {
     updateLayout,
     updateWidget,
     updateInlineAnalysis,
+    updateGlobalFilters,
+    updateInteractions,
     setRuntimeFilterValue,
     resetRuntimeFilters,
     runtimeFiltersForWidget,


### PR DESCRIPTION
## Summary

完成 Dashboard 路线图 Stage 3：在不扩大 BI Domain 的前提下，把已经存在的 `DashboardGlobalFilter / DashboardInteraction / runtimeFilterValues` 真正产品化为轻量的配置交互。

本阶段重点是：

```text
全局筛选配置
  -> 字段映射
  -> 运行时筛选

日期字段
  -> DatePicker / DateTimePicker
  -> 继续复用 Dataset Query Runtime

Widget 点击
  -> DashboardInteraction
  -> 写入目标 GlobalFilter
  -> 所有绑定 Widget 刷新
```

## 1. 轻量全局筛选设计器

新增 `DashboardGlobalFilterConfig` Drawer，但保持配置上下文化，不恢复旧版复杂 BI 工作台。

支持：

- 新建普通字段筛选
- 新建日期筛选
- 修改筛选名称
- EQ / NE / CONTAINS / GT / GTE / LT / LTE 条件
- 设置默认值
- 一个筛选器显式绑定多个 Widget
- 每个 Widget 单独映射真实 Dataset fieldId
- 删除筛选器时自动清理指向它的 Widget Interaction

筛选器继续沿用已有 DashboardVersion 持久化结构，没有新造 Query Domain。

## 2. 日期筛选

日期筛选直接基于 Dataset schema 的 `date / datetime` 字段识别：

- `date` 使用 `YYYY-MM-DD` DatePicker
- `datetime` 使用 `YYYY-MM-DD HH:mm:ss` DateTimePicker
- 日期默认值继续作为 DashboardVersion filter defaultValue 保存
- Preview / 编辑态都使用同一套 runtime filter value
- 最终仍转换为已有 Analysis runtime filter，交给 Dataset Query Runtime 执行

Stage 3 没有引入新的日期查询协议，也没有在浏览器侧做数据过滤。

## 3. Filter Bar 产品化

原来顶部 Filter Bar 只有文本 Input，本次调整为：

- 编辑态即使暂无筛选，也显示轻量「添加筛选」入口
- 有筛选后展示「管理」入口
- date / datetime 自动使用日期控件
- 普通字段继续保持紧凑 Input
- 保留恢复默认值
- Preview 模式隐藏设计入口，只保留真正可用的运行时筛选器

## 4. Widget 联动配置 UI

Chart Editor 增加当前 Widget 上下文内的「图表联动」区域，不增加全局大型联动管理页。

每条规则只需要配置：

```text
点击维度
   ↓
更新筛选器
```

例如：

```text
区域销售额图
  点击 华南
      ↓
区域筛选 = 华南
      ↓
订单趋势 / 客户分布 / 商品排行刷新
```

来源字段只使用当前图表已经配置的维度；目标只选择已经完成 Widget 字段映射的全局筛选器。

## 5. 继续复用已有 Runtime

本 PR 没有重写 Stage 0 已有运行链路：

```text
AnalysisPreview selection
  -> DashboardInteraction
  -> runtimeFilterValues
  -> runtimeFiltersForWidget
  -> AnalysisPreview
  -> Dataset Query Runtime
```

也就是说，本阶段主要补齐 UI 和编辑闭环，而不是再造一套筛选执行逻辑。

## 6. 与 Stage 1 / Stage 2 集成

筛选和联动配置现在都是 Dashboard Definition 的一部分，因此自动继承：

- Dirty state
- Undo / Redo
- Save Draft
- Publish
- DashboardVersion history
- Restore as new draft

运行时临时筛选值仍然不会进入 Dirty state，也不会自动制造 DashboardVersion。

## Scope

本 Stage 3 刻意不做：

- 独立大型「筛选与联动管理中心」
- Filter distinct values 自动枚举接口
- 级联筛选
- 多选筛选
- 日期范围 / 相对日期预设
- 多维 Selection
- Interaction 循环传播
- Drill Down
- Dashboard / Yak Page Jump

这些继续留给后续分析能力阶段，避免把 V1 再次做重。

## Files

本次只修改 Dashboard 前端编辑链路：

- `dashboard/editor.tsx`
- `dashboard/use-dashboard.ts`
- `dashboard/chart-editor.tsx`
- `dashboard/global-filter-bar.tsx`
- 新增 `dashboard/global-filter-config.tsx`
- 新增 `dashboard/interaction-editor.tsx`
- 新增 `dashboard/filter-utils.ts`

不修改 Dashboard 后端协议、DashboardVersion 表结构、Analysis Domain 或 Dataset Query Runtime。

## Verification

- 基于 Stage 2 合并后的 `main`: `810d35001757c4bbec59c3a68afbdc989bcf0cb1`
- 创建分支时与 main 同步
- 当前 branch 相对 main only-ahead，未混入其它模块变更
- 已静态复核筛选创建 / 字段映射 / 日期控件 / runtime filter / interaction routing / 删除清理链路
- 当前 connector 环境没有本地 Node 依赖执行环境，因此不宣称 `npm run tsc` / `npm run build` 已通过；Draft 阶段继续以仓库 CI/status 为准
