### PR TITLE
feat(dashboard): complete stage 4 drill and internal navigation

### DIFF
--- a/yak-ops-ui/src/pages/dashboard/chart-editor.tsx
+++ b/yak-ops-ui/src/pages/dashboard/chart-editor.tsx
@@ -11,6 +11,7 @@ import type {
   AnalysisAsset,
   ChartType,
   DashboardGlobalFilter,
+  DashboardInlineAnalysisSpec,
   DashboardInteraction,
   DashboardWidget,
   FilterOperator,
@@ -18,8 +19,10 @@ import type {
   PublishedDataset,
   SortDirection,
 } from './model';
+import { DashboardWidgetActionEditor } from './widget-action-editor';
 
 export function ChartEditor({
+  currentDashboardId,
   widget,
   datasets,
   analyses,
@@ -32,13 +35,14 @@ export function ChartEditor({
   detachAnalysis,
   close,
 }: {
+  currentDashboardId: string;
   widget: DashboardWidget;
   datasets: PublishedDataset[];
   analyses: AnalysisAsset[];
   globalFilters: DashboardGlobalFilter[];
   interactions: DashboardInteraction[];
   updateWidget: (patch: Partial<DashboardWidget>) => void;
-  updateInlineAnalysis: (patch: Partial<AnalysisSpec>) => void;
+  updateInlineAnalysis: (patch: Partial<DashboardInlineAnalysisSpec>) => void;
   updateInteractions: (interactions: DashboardInteraction[]) => void;
   changeDataset: (datasetId: string) => void;
   detachAnalysis: () => void;
@@ -63,7 +67,7 @@ export function ChartEditor({
             </div>
           </div>
           <div className="mt-3 text-[11px] leading-5 text-[#667085]">
-            这个图表来自旧版共享资产。复制为当前仪表盘图表后，即可使用新的 Chart Editor 编辑数据和样式。
+            这个图表来自旧版共享资产。复制为当前仪表盘图表后，即可使用新的 Chart Editor 编辑数据、样式与交互。
           </div>
           {!analysis ? (
             <div className="mt-3 rounded-[4px] border border-[#fecdca] bg-[#fffbfa] px-2.5 py-2 text-[10px] text-[#b42318]">
@@ -235,6 +239,15 @@ export function ChartEditor({
             filters={globalFilters}
             interactions={interactions}
             onChange={updateInteractions}
+          />
+        </div>
+
+        <div className="mt-4 border-t border-[#edf0f3] pt-4">
+          <DashboardWidgetActionEditor
+            currentDashboardId={currentDashboardId}
+            spec={spec}
+            dataset={dataset}
+            onChange={(dashboardBehavior) => updateInlineAnalysis({ dashboardBehavior })}
           />
         </div>
 

--- a/yak-ops-ui/src/pages/dashboard/editor.tsx
+++ b/yak-ops-ui/src/pages/dashboard/editor.tsx
@@ -25,19 +25,10 @@ const isEditableTarget = (target: EventTarget | null) => {
 export default function DashboardEditorPage() {
   const { id } = useParams<{ id?: string }>();
   const dashboardId = id && id !== 'new' ? id : undefined;
-  const routeMode = useMemo(() => {
-    const params = new URLSearchParams(window.location.search);
-    const publishedView = params.get('published') === '1';
-    return {
-      publishedView,
-      initialPreview: publishedView || params.get('preview') === '1',
-    };
-  }, [dashboardId]);
-  const designer = useDashboardDesigner(
-    dashboardId,
-    routeMode.initialPreview,
-    routeMode.publishedView,
-  );
+  const routeParams = new URLSearchParams(window.location.search);
+  const publishedView = routeParams.get('published') === '1';
+  const initialPreview = publishedView || routeParams.get('preview') === '1';
+  const designer = useDashboardDesigner(dashboardId, initialPreview, publishedView);
   const { width, containerRef, mounted } = useContainerWidth();
   const [historyOpen, setHistoryOpen] = useState(false);
   const [filterConfigOpen, setFilterConfigOpen] = useState(false);
@@ -285,7 +276,11 @@ export default function DashboardEditorPage() {
                             if (!designer.preview) designer.setSelectedId(widget.id);
                           }}
                           onDataSelect={(selection) => {
-                            const target = designer.handleWidgetSelection(widget.id, selection);
+                            const target = designer.handleWidgetSelection(
+                              widget.id,
+                              selection,
+                              designer.preview,
+                            );
                             if (target) history.push(target);
                           }}
                           onDrillBack={(depth) => designer.drillBack(widget.id, depth)}

--- a/yak-ops-ui/src/pages/dashboard/editor.tsx
+++ b/yak-ops-ui/src/pages/dashboard/editor.tsx
@@ -25,11 +25,19 @@ const isEditableTarget = (target: EventTarget | null) => {
 export default function DashboardEditorPage() {
   const { id } = useParams<{ id?: string }>();
   const dashboardId = id && id !== 'new' ? id : undefined;
-  const initialPreview = useMemo(
-    () => new URLSearchParams(window.location.search).get('preview') === '1',
-    [dashboardId],
+  const routeMode = useMemo(() => {
+    const params = new URLSearchParams(window.location.search);
+    const publishedView = params.get('published') === '1';
+    return {
+      publishedView,
+      initialPreview: publishedView || params.get('preview') === '1',
+    };
+  }, [dashboardId]);
+  const designer = useDashboardDesigner(
+    dashboardId,
+    routeMode.initialPreview,
+    routeMode.publishedView,
   );
-  const designer = useDashboardDesigner(dashboardId, initialPreview);
   const { width, containerRef, mounted } = useContainerWidth();
   const [historyOpen, setHistoryOpen] = useState(false);
   const [filterConfigOpen, setFilterConfigOpen] = useState(false);
@@ -82,7 +90,7 @@ export default function DashboardEditorPage() {
   }, [dashboardId, designer]);
 
   const leaveDashboard = () => {
-    if (!designer.dirty) {
+    if (!designer.dirty || designer.publishedView) {
       history.push('/dashboard');
       return;
     }
@@ -196,6 +204,10 @@ export default function DashboardEditorPage() {
         onAddChart={addChart}
         onHistory={() => setHistoryOpen(true)}
         onPreview={() => {
+          if (designer.publishedView) {
+            history.push(`/dashboard/${designer.dashboard.id}`);
+            return;
+          }
           designer.setPreview((current) => !current);
           designer.setSelectedId(undefined);
         }}
@@ -350,7 +362,7 @@ export default function DashboardEditorPage() {
         onClose={() => setFilterConfigOpen(false)}
       />
 
-      {designer.persisted ? (
+      {designer.persisted && !designer.publishedView ? (
         <DashboardVersionHistoryDrawer
           open={historyOpen}
           dashboardId={designer.dashboard.id}

--- a/yak-ops-ui/src/pages/dashboard/editor.tsx
+++ b/yak-ops-ui/src/pages/dashboard/editor.tsx
@@ -25,7 +25,11 @@ const isEditableTarget = (target: EventTarget | null) => {
 export default function DashboardEditorPage() {
   const { id } = useParams<{ id?: string }>();
   const dashboardId = id && id !== 'new' ? id : undefined;
-  const designer = useDashboardDesigner(dashboardId);
+  const initialPreview = useMemo(
+    () => new URLSearchParams(window.location.search).get('preview') === '1',
+    [dashboardId],
+  );
+  const designer = useDashboardDesigner(dashboardId, initialPreview);
   const { width, containerRef, mounted } = useContainerWidth();
   const [historyOpen, setHistoryOpen] = useState(false);
   const [filterConfigOpen, setFilterConfigOpen] = useState(false);
@@ -248,25 +252,31 @@ export default function DashboardEditorPage() {
                     const analysis = widget.analysisId
                       ? designer.analyses.find((item) => item.id === widget.analysisId)
                       : undefined;
-                    const spec = analysis ?? widget.inlineAnalysis;
-                    const dataset = spec
-                      ? designer.datasets.find((item) => item.id === spec.datasetId)
+                    const runtimeSpec = designer.runtimeSpecForWidget(widget.id);
+                    const dataset = runtimeSpec
+                      ? designer.datasets.find((item) => item.id === runtimeSpec.datasetId)
                       : undefined;
+                    const drillPath = designer.drillPathForWidget(widget.id);
 
                     return (
                       <div key={widget.id}>
                         <WidgetShell
                           widget={widget}
                           analysis={analysis}
+                          runtimeSpec={runtimeSpec}
                           dataset={dataset}
                           runtimeFilters={designer.runtimeFiltersForWidget(widget.id)}
+                          drillPath={drillPath}
                           selected={designer.selectedId === widget.id}
                           preview={designer.preview}
                           onSelect={() => {
                             if (!designer.preview) designer.setSelectedId(widget.id);
                           }}
-                          onDataSelect={(selection) =>
-                            designer.handleWidgetSelection(widget.id, selection)}
+                          onDataSelect={(selection) => {
+                            const target = designer.handleWidgetSelection(widget.id, selection);
+                            if (target) history.push(target);
+                          }}
+                          onDrillBack={(depth) => designer.drillBack(widget.id, depth)}
                           onDuplicate={() => designer.duplicateWidget(widget.id)}
                           onDelete={() => designer.deleteWidget(widget.id)}
                         />
@@ -310,6 +320,7 @@ export default function DashboardEditorPage() {
 
         {!designer.preview && designer.selectedWidget ? (
           <ChartEditor
+            currentDashboardId={designer.dashboard.id}
             widget={designer.selectedWidget}
             datasets={designer.datasets}
             analyses={designer.analyses}

--- a/yak-ops-ui/src/pages/dashboard/editor.tsx
+++ b/yak-ops-ui/src/pages/dashboard/editor.tsx
@@ -276,11 +276,8 @@ export default function DashboardEditorPage() {
                             if (!designer.preview) designer.setSelectedId(widget.id);
                           }}
                           onDataSelect={(selection) => {
-                            const target = designer.handleWidgetSelection(
-                              widget.id,
-                              selection,
-                              designer.preview,
-                            );
+                            if (!designer.preview) return;
+                            const target = designer.handleWidgetSelection(widget.id, selection);
                             if (target) history.push(target);
                           }}
                           onDrillBack={(depth) => designer.drillBack(widget.id, depth)}

--- a/yak-ops-ui/src/pages/dashboard/model.ts
+++ b/yak-ops-ui/src/pages/dashboard/model.ts
@@ -29,12 +29,43 @@ export type {
   SortDirection,
 } from '@/components/analysis/model';
 
+export type DashboardWidgetClickAction = 'none' | 'drill' | 'dashboard' | 'yak';
+
+/** Dashboard-only behavior persisted together with the inline Analysis snapshot. */
+export interface DashboardWidgetBehavior {
+  clickAction?: DashboardWidgetClickAction;
+  /** Ordered hierarchy, e.g. province -> city -> store. */
+  drillFields?: string[];
+  /** Dashboard asset id used by dashboard-to-dashboard navigation. */
+  targetDashboardId?: string;
+  /** Yak internal route such as /workflow/instances. */
+  targetPath?: string;
+  /** Query-string key used by Yak page navigation. */
+  queryParam?: string;
+}
+
+/**
+ * Dashboard inline analyses intentionally extend the reusable AnalysisSpec with
+ * dashboard-local interaction metadata. The backend already versions this JSON
+ * blob as part of the immutable DashboardWidget snapshot.
+ */
+export interface DashboardInlineAnalysisSpec extends AnalysisSpec {
+  dashboardBehavior?: DashboardWidgetBehavior;
+}
+
+/** Runtime-only drill breadcrumb entry. It never participates in Dirty state. */
+export interface DashboardDrillStep {
+  field: string;
+  value: Scalar;
+  label: string;
+}
+
 /** Dashboard owns placement plus an Analysis reference or a dashboard-local inline analysis. */
 export interface DashboardWidget {
   id: string;
   analysisId?: string;
   title?: string;
-  inlineAnalysis?: AnalysisSpec;
+  inlineAnalysis?: DashboardInlineAnalysisSpec;
   x: number;
   y: number;
   w: number;

--- a/yak-ops-ui/src/pages/dashboard/use-dashboard.ts
+++ b/yak-ops-ui/src/pages/dashboard/use-dashboard.ts
@@ -10,6 +10,7 @@ import { DEFAULT_DASHBOARD } from './defaults';
 import {
   createDashboard,
   fetchDashboard,
+  fetchPublishedDashboard,
   publishDashboard,
   restoreDashboardVersion,
   saveDashboardVersion,
@@ -33,6 +34,7 @@ import type {
   DashboardInlineAnalysisSpec,
   DashboardInteraction,
   DashboardServerDetail,
+  DashboardVersionDetail,
   DashboardVersionSummary,
   DashboardWidget,
   PublishedDataset,
@@ -77,7 +79,28 @@ const trimHistory = (items: DashboardDocument[]) => (
   items.length > HISTORY_LIMIT ? items.slice(items.length - HISTORY_LIMIT) : items
 );
 
-export function useDashboardDesigner(dashboardId?: string, initialPreview = false) {
+const publishedDocument = (detail: DashboardVersionDetail): DashboardDocument => ({
+  version: 1,
+  id: detail.dashboard.id,
+  name: detail.version.name,
+  description: detail.version.description,
+  activeDatasetId: detail.version.activeDatasetId || '',
+  widgets: detail.widgets,
+  globalFilters: detail.globalFilters,
+  interactions: detail.interactions,
+  currentVersionNo: detail.version.versionNo,
+  currentVersionId: detail.version.id,
+  publishedVersionNo: detail.dashboard.publishedVersionNo,
+  publishedVersionId: detail.dashboard.publishedVersionId,
+  publishedAt: detail.dashboard.publishedTime,
+  updatedAt: detail.dashboard.updateTime,
+});
+
+export function useDashboardDesigner(
+  dashboardId?: string,
+  initialPreview = false,
+  publishedView = false,
+) {
   const initialDashboard = useMemo(() => cloneDashboard(DEFAULT_DASHBOARD), []);
   const [dashboard, setDashboardState] = useState<DashboardDocument>(initialDashboard);
   const dashboardRef = useRef<DashboardDocument>(initialDashboard);
@@ -95,7 +118,7 @@ export function useDashboardDesigner(dashboardId?: string, initialPreview = fals
   const [runtimeFilterValues, setRuntimeFilterValues] = useState<Record<string, Scalar | undefined>>({});
   const [drillPaths, setDrillPaths] = useState<Record<string, DashboardDrillStep[]>>({});
   const [selectedId, setSelectedId] = useState<string>();
-  const [preview, setPreview] = useState(initialPreview);
+  const [preview, setPreview] = useState(initialPreview || publishedView);
 
   const widgets = dashboard.widgets;
   const selectedWidget = widgets.find((widget) => widget.id === selectedId);
@@ -215,11 +238,18 @@ export function useDashboardDesigner(dashboardId?: string, initialPreview = fals
 
   const openDashboard = useCallback(async (targetDashboardId: string) => {
     try {
+      if (publishedView) {
+        const detail = await fetchPublishedDashboard(targetDashboardId);
+        resetDashboardState(publishedDocument(detail));
+        setDashboardVersions([]);
+        window.localStorage.removeItem(STORAGE_KEY);
+        return;
+      }
       applyServerDetail(await fetchDashboard(targetDashboardId));
     } catch (error) {
       message.error(error instanceof Error ? error.message : '加载 Dashboard 失败');
     }
-  }, [applyServerDetail]);
+  }, [applyServerDetail, publishedView, resetDashboardState]);
 
   useEffect(() => {
     void loadDatasets();
@@ -227,7 +257,7 @@ export function useDashboardDesigner(dashboardId?: string, initialPreview = fals
   }, [loadDatasets, loadAnalyses]);
 
   useEffect(() => {
-    setPreview(initialPreview);
+    setPreview(initialPreview || publishedView);
     if (dashboardId) {
       void openDashboard(dashboardId);
       return;
@@ -235,7 +265,7 @@ export function useDashboardDesigner(dashboardId?: string, initialPreview = fals
     resetDashboardState(cloneDashboard(DEFAULT_DASHBOARD));
     setDashboardVersions([]);
     setRuntimeFilterValues({});
-  }, [dashboardId, initialPreview, openDashboard, resetDashboardState]);
+  }, [dashboardId, initialPreview, openDashboard, publishedView, resetDashboardState]);
 
   useEffect(() => {
     if (!datasets.length) return;
@@ -272,14 +302,14 @@ export function useDashboardDesigner(dashboardId?: string, initialPreview = fals
   }, [dashboard.id, dashboard.currentVersionId, dashboard.globalFilters]);
 
   useEffect(() => {
-    if (!dirty) return undefined;
+    if (!dirty || publishedView) return undefined;
     const handleBeforeUnload = (event: BeforeUnloadEvent) => {
       event.preventDefault();
       event.returnValue = '';
     };
     window.addEventListener('beforeunload', handleBeforeUnload);
     return () => window.removeEventListener('beforeunload', handleBeforeUnload);
-  }, [dirty]);
+  }, [dirty, publishedView]);
 
   const updateDashboardName = (name: string) => commitDashboard(
     (current) => ({ ...current, name }),
@@ -353,7 +383,7 @@ export function useDashboardDesigner(dashboardId?: string, initialPreview = fals
     if (!base || widget.analysisId) return base;
     const behavior = widget.inlineAnalysis?.dashboardBehavior;
     const hierarchy = behavior?.clickAction === 'drill' ? behavior.drillFields || [] : [];
-    if (hierarchy.length < 2) return base;
+    if (hierarchy.length < 2 || hierarchy[0] !== base.dimensions[0]) return base;
     const path = drillPaths[widgetId] || [];
     const currentField = hierarchy[Math.min(path.length, hierarchy.length - 1)];
     if (!currentField) return base;
@@ -427,7 +457,7 @@ export function useDashboardDesigner(dashboardId?: string, initialPreview = fals
 
     if (behavior.clickAction === 'drill') {
       const hierarchy = behavior.drillFields || [];
-      if (hierarchy.length < 2) return undefined;
+      if (hierarchy.length < 2 || hierarchy[0] !== widget.inlineAnalysis?.dimensions[0]) return undefined;
       setDrillPaths((current) => {
         const path = current[widgetId] || [];
         const currentField = hierarchy[path.length];
@@ -450,6 +480,7 @@ export function useDashboardDesigner(dashboardId?: string, initialPreview = fals
     if (behavior.clickAction === 'dashboard' && behavior.targetDashboardId) {
       const params = new URLSearchParams({
         preview: '1',
+        published: '1',
         df: selection.fieldId,
         dv: String(selection.value),
       });
@@ -640,6 +671,7 @@ export function useDashboardDesigner(dashboardId?: string, initialPreview = fals
     canUndo,
     canRedo,
     persisted,
+    publishedView,
     hasPublishedVersion,
     hasUnpublishedDraft,
     canPublish,

--- a/yak-ops-ui/src/pages/dashboard/use-dashboard.ts
+++ b/yak-ops-ui/src/pages/dashboard/use-dashboard.ts
@@ -2,7 +2,6 @@ import { fetchAnalyses } from '@/components/analysis/analysis-service';
 import type {
   AnalysisFilter,
   AnalysisSelection,
-  AnalysisSpec,
   Scalar,
 } from '@/components/analysis/model';
 import { message } from 'antd';
@@ -29,7 +28,9 @@ import type {
   AnalysisAsset,
   ChartType,
   DashboardDocument,
+  DashboardDrillStep,
   DashboardGlobalFilter,
+  DashboardInlineAnalysisSpec,
   DashboardInteraction,
   DashboardServerDetail,
   DashboardVersionSummary,
@@ -41,7 +42,7 @@ import { fetchDashboardDatasets } from './service';
 const HISTORY_LIMIT = 50;
 const HISTORY_MERGE_WINDOW = 500;
 
-const assetSpec = (analysis: AnalysisAsset): AnalysisSpec => ({
+const assetSpec = (analysis: AnalysisAsset): DashboardInlineAnalysisSpec => ({
   type: analysis.type,
   datasetId: analysis.datasetId,
   dimensions: [...analysis.dimensions],
@@ -76,7 +77,7 @@ const trimHistory = (items: DashboardDocument[]) => (
   items.length > HISTORY_LIMIT ? items.slice(items.length - HISTORY_LIMIT) : items
 );
 
-export function useDashboardDesigner(dashboardId?: string) {
+export function useDashboardDesigner(dashboardId?: string, initialPreview = false) {
   const initialDashboard = useMemo(() => cloneDashboard(DEFAULT_DASHBOARD), []);
   const [dashboard, setDashboardState] = useState<DashboardDocument>(initialDashboard);
   const dashboardRef = useRef<DashboardDocument>(initialDashboard);
@@ -92,8 +93,9 @@ export function useDashboardDesigner(dashboardId?: string) {
   const [dashboardSaving, setDashboardSaving] = useState(false);
   const [dashboardPublishing, setDashboardPublishing] = useState(false);
   const [runtimeFilterValues, setRuntimeFilterValues] = useState<Record<string, Scalar | undefined>>({});
+  const [drillPaths, setDrillPaths] = useState<Record<string, DashboardDrillStep[]>>({});
   const [selectedId, setSelectedId] = useState<string>();
-  const [preview, setPreview] = useState(false);
+  const [preview, setPreview] = useState(initialPreview);
 
   const widgets = dashboard.widgets;
   const selectedWidget = widgets.find((widget) => widget.id === selectedId);
@@ -130,6 +132,7 @@ export function useDashboardDesigner(dashboardId?: string) {
     if (markSaved) savedFingerprintRef.current = dashboardFingerprint(cloned);
     setDashboardState(cloned);
     setSelectedId(undefined);
+    setDrillPaths({});
   }, []);
 
   const applyServerDetail = useCallback((detail: DashboardServerDetail) => {
@@ -224,6 +227,7 @@ export function useDashboardDesigner(dashboardId?: string) {
   }, [loadDatasets, loadAnalyses]);
 
   useEffect(() => {
+    setPreview(initialPreview);
     if (dashboardId) {
       void openDashboard(dashboardId);
       return;
@@ -231,7 +235,7 @@ export function useDashboardDesigner(dashboardId?: string) {
     resetDashboardState(cloneDashboard(DEFAULT_DASHBOARD));
     setDashboardVersions([]);
     setRuntimeFilterValues({});
-  }, [dashboardId, openDashboard, resetDashboardState]);
+  }, [dashboardId, initialPreview, openDashboard, resetDashboardState]);
 
   useEffect(() => {
     if (!datasets.length) return;
@@ -246,7 +250,26 @@ export function useDashboardDesigner(dashboardId?: string) {
 
   useEffect(() => {
     setRuntimeFilterValues(runtimeDefaults(dashboard.globalFilters));
+    setDrillPaths({});
   }, [dashboard.id, dashboard.currentVersionId]);
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const field = params.get('df');
+    const value = params.get('dv');
+    if (!field || value === null) return;
+    const targetIds = dashboard.globalFilters
+      .filter((filter) => filter.bindings.some((binding) => binding.field === field))
+      .map((filter) => filter.id);
+    if (!targetIds.length) return;
+    setRuntimeFilterValues((current) => {
+      const next = { ...current };
+      targetIds.forEach((filterId) => {
+        next[filterId] = value;
+      });
+      return next;
+    });
+  }, [dashboard.id, dashboard.currentVersionId, dashboard.globalFilters]);
 
   useEffect(() => {
     if (!dirty) return undefined;
@@ -284,7 +307,7 @@ export function useDashboardDesigner(dashboardId?: string) {
     `widget:${id}:${Object.keys(patch).sort().join(',')}`,
   );
 
-  const updateInlineAnalysis = (id: string, patch: Partial<AnalysisSpec>) => commitDashboard(
+  const updateInlineAnalysis = (id: string, patch: Partial<DashboardInlineAnalysisSpec>) => commitDashboard(
     (current) => ({
       ...current,
       widgets: current.widgets.map((widget) => {
@@ -321,8 +344,42 @@ export function useDashboardDesigner(dashboardId?: string) {
 
   const resetRuntimeFilters = () => setRuntimeFilterValues(runtimeDefaults(dashboard.globalFilters));
 
-  const runtimeFiltersForWidget = useCallback((widgetId: string): AnalysisFilter[] => (
-    dashboard.globalFilters.flatMap((filter) => {
+  const runtimeSpecForWidget = useCallback((widgetId: string): DashboardInlineAnalysisSpec | AnalysisAsset | undefined => {
+    const widget = dashboard.widgets.find((item) => item.id === widgetId);
+    if (!widget) return undefined;
+    const base = widget.analysisId
+      ? analyses.find((analysis) => analysis.id === widget.analysisId)
+      : widget.inlineAnalysis;
+    if (!base || widget.analysisId) return base;
+    const behavior = widget.inlineAnalysis?.dashboardBehavior;
+    const hierarchy = behavior?.clickAction === 'drill' ? behavior.drillFields || [] : [];
+    if (hierarchy.length < 2) return base;
+    const path = drillPaths[widgetId] || [];
+    const currentField = hierarchy[Math.min(path.length, hierarchy.length - 1)];
+    if (!currentField) return base;
+    const otherDimensions = base.dimensions.filter((field) => !hierarchy.includes(field));
+    return {
+      ...base,
+      dimensions: [currentField, ...otherDimensions],
+    };
+  }, [analyses, dashboard.widgets, drillPaths]);
+
+  const drillPathForWidget = useCallback(
+    (widgetId: string) => drillPaths[widgetId] || [],
+    [drillPaths],
+  );
+
+  const drillBack = useCallback((widgetId: string, depth: number) => {
+    setDrillPaths((current) => {
+      const path = current[widgetId] || [];
+      const nextPath = path.slice(0, Math.max(0, depth));
+      if (nextPath.length === path.length) return current;
+      return { ...current, [widgetId]: nextPath };
+    });
+  }, []);
+
+  const runtimeFiltersForWidget = useCallback((widgetId: string): AnalysisFilter[] => {
+    const globalFilters = dashboard.globalFilters.flatMap((filter) => {
       const binding = filter.bindings.find((item) => item.widgetId === widgetId);
       if (!binding) return [];
       const value = hasOwn(runtimeFilterValues, filter.id)
@@ -334,9 +391,19 @@ export function useDashboardDesigner(dashboardId?: string) {
         field: binding.field,
         operator: filter.operator,
         value: String(value),
-      }];
-    })
-  ), [dashboard.globalFilters, runtimeFilterValues]);
+      } satisfies AnalysisFilter];
+    });
+    const drillFilters = (drillPaths[widgetId] || []).flatMap((step, index) => {
+      if (step.value === undefined || step.value === null || step.value === '') return [];
+      return [{
+        id: `dashboard-drill-${widgetId}-${index}`,
+        field: step.field,
+        operator: 'eq',
+        value: String(step.value),
+      } satisfies AnalysisFilter];
+    });
+    return [...globalFilters, ...drillFilters];
+  }, [dashboard.globalFilters, drillPaths, runtimeFilterValues]);
 
   const handleWidgetSelection = useCallback((widgetId: string, selection: AnalysisSelection) => {
     const matched = dashboard.interactions.filter((interaction) => (
@@ -344,15 +411,59 @@ export function useDashboardDesigner(dashboardId?: string) {
       && interaction.sourceWidgetId === widgetId
       && interaction.sourceField === selection.fieldId
     ));
-    if (!matched.length) return;
-    setRuntimeFilterValues((current) => {
-      const next = { ...current };
-      matched.forEach((interaction) => {
-        next[interaction.targetFilterId] = selection.value;
+    if (matched.length) {
+      setRuntimeFilterValues((current) => {
+        const next = { ...current };
+        matched.forEach((interaction) => {
+          next[interaction.targetFilterId] = selection.value;
+        });
+        return next;
       });
-      return next;
-    });
-  }, [dashboard.interactions]);
+    }
+
+    const widget = dashboard.widgets.find((item) => item.id === widgetId);
+    const behavior = widget?.inlineAnalysis?.dashboardBehavior;
+    if (!behavior || !behavior.clickAction || behavior.clickAction === 'none') return undefined;
+
+    if (behavior.clickAction === 'drill') {
+      const hierarchy = behavior.drillFields || [];
+      if (hierarchy.length < 2) return undefined;
+      setDrillPaths((current) => {
+        const path = current[widgetId] || [];
+        const currentField = hierarchy[path.length];
+        if (selection.fieldId !== currentField || path.length >= hierarchy.length - 1) return current;
+        return {
+          ...current,
+          [widgetId]: [
+            ...path,
+            {
+              field: selection.fieldId,
+              value: selection.value,
+              label: String(selection.value),
+            },
+          ],
+        };
+      });
+      return undefined;
+    }
+
+    if (behavior.clickAction === 'dashboard' && behavior.targetDashboardId) {
+      const params = new URLSearchParams({
+        preview: '1',
+        df: selection.fieldId,
+        dv: String(selection.value),
+      });
+      return `/dashboard/${behavior.targetDashboardId}?${params.toString()}`;
+    }
+
+    if (behavior.clickAction === 'yak' && behavior.targetPath) {
+      const params = new URLSearchParams();
+      params.set(behavior.queryParam?.trim() || selection.fieldId, String(selection.value));
+      return `${behavior.targetPath}?${params.toString()}`;
+    }
+
+    return undefined;
+  }, [dashboard.interactions, dashboard.widgets]);
 
   const maxY = () => dashboardRef.current.widgets.reduce(
     (value, widget) => Math.max(value, widget.y + widget.h),
@@ -394,7 +505,7 @@ export function useDashboardDesigner(dashboardId?: string) {
       id: `widget-${Date.now()}-${Math.round(Math.random() * 1000)}`,
       y: maxY(),
       inlineAnalysis: source.inlineAnalysis
-        ? JSON.parse(JSON.stringify(source.inlineAnalysis)) as AnalysisSpec
+        ? JSON.parse(JSON.stringify(source.inlineAnalysis)) as DashboardInlineAnalysisSpec
         : undefined,
     };
     commitDashboard(
@@ -415,6 +526,11 @@ export function useDashboardDesigner(dashboardId?: string) {
       interactions: current.interactions.filter((interaction) => interaction.sourceWidgetId !== id),
     }), `widget:delete:${id}`);
     setSelectedId((current) => current === id ? undefined : current);
+    setDrillPaths((current) => {
+      const next = { ...current };
+      delete next[id];
+      return next;
+    });
   };
 
   const changeWidgetDataset = (id: string, datasetId: string) => {
@@ -435,6 +551,7 @@ export function useDashboardDesigner(dashboardId?: string) {
       })),
       interactions: current.interactions.filter((interaction) => interaction.sourceWidgetId !== id),
     }), `widget:${id}:dataset`);
+    setDrillPaths((current) => ({ ...current, [id]: [] }));
   };
 
   const persistCurrentDraft = async (): Promise<DashboardServerDetail | undefined> => {
@@ -514,6 +631,7 @@ export function useDashboardDesigner(dashboardId?: string) {
     dashboardSaving,
     dashboardPublishing,
     runtimeFilterValues,
+    drillPaths,
     selectedWidget,
     activeDataset,
     selectedId,
@@ -535,7 +653,10 @@ export function useDashboardDesigner(dashboardId?: string) {
     updateInteractions,
     setRuntimeFilterValue,
     resetRuntimeFilters,
+    runtimeSpecForWidget,
     runtimeFiltersForWidget,
+    drillPathForWidget,
+    drillBack,
     handleWidgetSelection,
     addWidget,
     detachAnalysis,

--- a/yak-ops-ui/src/pages/dashboard/widget-action-editor.tsx
+++ b/yak-ops-ui/src/pages/dashboard/widget-action-editor.tsx
@@ -1,0 +1,227 @@
+import { appRoutes } from '@/config/navigation';
+import { Input, Select } from 'antd';
+import {
+  ArrowRight,
+  GitBranch,
+  LayoutDashboard,
+  MousePointerClick,
+  Workflow,
+} from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+import { fetchDashboards } from './dashboard-service';
+import type {
+  DashboardInlineAnalysisSpec,
+  DashboardSummary,
+  DashboardWidgetBehavior,
+  DashboardWidgetClickAction,
+  PublishedDataset,
+} from './model';
+
+const YAK_TARGET_IDS = new Set([
+  'data-source',
+  'batch-link-up',
+  'data-development-execution',
+  'workflow-definition',
+  'workflow-schedules',
+  'workflow-instances',
+  'data-quality-table-config',
+  'data-quality-execution',
+]);
+
+const ACTION_OPTIONS: Array<{
+  label: string;
+  value: DashboardWidgetClickAction;
+}> = [
+  { label: '无额外操作', value: 'none' },
+  { label: '下钻', value: 'drill' },
+  { label: '跳转仪表盘', value: 'dashboard' },
+  { label: '跳转 Yak 页面', value: 'yak' },
+];
+
+export function DashboardWidgetActionEditor({
+  currentDashboardId,
+  spec,
+  dataset,
+  onChange,
+}: {
+  currentDashboardId: string;
+  spec: DashboardInlineAnalysisSpec;
+  dataset: PublishedDataset;
+  onChange: (behavior: DashboardWidgetBehavior | undefined) => void;
+}) {
+  const behavior = spec.dashboardBehavior || {};
+  const action = behavior.clickAction || 'none';
+  const [dashboards, setDashboards] = useState<DashboardSummary[]>([]);
+
+  useEffect(() => {
+    let active = true;
+    void fetchDashboards()
+      .then((items) => {
+        if (active) setDashboards(items);
+      })
+      .catch(() => {
+        if (active) setDashboards([]);
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const dimensionOptions = dataset.fields
+    .filter((field) => field.role === 'dimension')
+    .map((field) => ({ label: `${field.label} · ${field.dataType}`, value: field.key }));
+  const firstDimension = spec.dimensions[0];
+  const drillFields = behavior.drillFields?.length
+    ? behavior.drillFields
+    : firstDimension
+      ? [firstDimension]
+      : [];
+  const dashboardOptions = dashboards
+    .filter((item) => item.id !== currentDashboardId && item.publishedVersionNo > 0)
+    .map((item) => ({
+      label: `${item.name} · 已发布 V${item.publishedVersionNo}`,
+      value: item.id,
+    }));
+  const yakOptions = useMemo(() => appRoutes
+    .filter((route) => YAK_TARGET_IDS.has(route.id))
+    .map((route) => ({ label: route.title, value: route.path })), []);
+
+  const patch = (next: Partial<DashboardWidgetBehavior>) => {
+    const value: DashboardWidgetBehavior = { ...behavior, ...next };
+    onChange(value.clickAction && value.clickAction !== 'none' ? value : undefined);
+  };
+
+  const changeAction = (clickAction: DashboardWidgetClickAction) => {
+    if (clickAction === 'none') {
+      onChange(undefined);
+      return;
+    }
+    if (clickAction === 'drill') {
+      patch({
+        clickAction,
+        drillFields: drillFields.length ? drillFields : firstDimension ? [firstDimension] : [],
+        targetDashboardId: undefined,
+        targetPath: undefined,
+        queryParam: undefined,
+      });
+      return;
+    }
+    if (clickAction === 'dashboard') {
+      patch({
+        clickAction,
+        drillFields: undefined,
+        targetPath: undefined,
+        queryParam: undefined,
+        targetDashboardId: behavior.targetDashboardId || dashboardOptions[0]?.value,
+      });
+      return;
+    }
+    patch({
+      clickAction,
+      drillFields: undefined,
+      targetDashboardId: undefined,
+      targetPath: behavior.targetPath || yakOptions[0]?.value,
+    });
+  };
+
+  return (
+    <div>
+      <div className="flex items-center gap-1.5 text-[11px] font-medium text-[#667085]">
+        <MousePointerClick size={12} />
+        点击行为
+      </div>
+      <div className="mt-1 text-[9px] leading-4 text-[#98a2b3]">
+        这是图表的主要点击动作；Stage 3 的筛选联动仍可同时执行。
+      </div>
+
+      <Select
+        size="small"
+        className="mt-2 w-full"
+        value={action}
+        options={ACTION_OPTIONS}
+        onChange={changeAction}
+      />
+
+      {action === 'drill' ? (
+        <div className="mt-2 rounded-[6px] border border-[#edf0f3] bg-[#fafbfc] p-2.5">
+          <div className="flex items-center gap-1.5 text-[10px] font-medium text-[#475467]">
+            <GitBranch size={11} />
+            下钻层级
+          </div>
+          <Select
+            mode="multiple"
+            size="small"
+            className="mt-2 w-full"
+            placeholder="选择下钻字段"
+            value={drillFields}
+            options={dimensionOptions}
+            maxTagCount="responsive"
+            onChange={(fields) => {
+              const next = firstDimension
+                ? [firstDimension, ...fields.filter((field) => field !== firstDimension)]
+                : fields;
+              patch({ drillFields: next });
+            }}
+          />
+          <div className="mt-2 flex items-start gap-1.5 text-[9px] leading-4 text-[#98a2b3]">
+            <ArrowRight size={10} className="mt-[3px] shrink-0" />
+            第一层固定为当前图表主维度，后续按选择顺序进入下一层。至少配置 2 个维度才会触发下钻。
+          </div>
+        </div>
+      ) : null}
+
+      {action === 'dashboard' ? (
+        <div className="mt-2 rounded-[6px] border border-[#edf0f3] bg-[#fafbfc] p-2.5">
+          <div className="flex items-center gap-1.5 text-[10px] font-medium text-[#475467]">
+            <LayoutDashboard size={11} />
+            目标仪表盘
+          </div>
+          <Select
+            size="small"
+            showSearch
+            optionFilterProp="label"
+            className="mt-2 w-full"
+            placeholder="选择已发布仪表盘"
+            value={behavior.targetDashboardId}
+            options={dashboardOptions}
+            onChange={(targetDashboardId) => patch({ targetDashboardId })}
+          />
+          <div className="mt-2 text-[9px] leading-4 text-[#98a2b3]">
+            跳转时会携带当前点击字段和值；目标仪表盘中绑定同名字段的全局筛选器会自动接收该值。
+          </div>
+        </div>
+      ) : null}
+
+      {action === 'yak' ? (
+        <div className="mt-2 rounded-[6px] border border-[#edf0f3] bg-[#fafbfc] p-2.5">
+          <div className="flex items-center gap-1.5 text-[10px] font-medium text-[#475467]">
+            <Workflow size={11} />
+            Yak 内部页面
+          </div>
+          <Select
+            size="small"
+            showSearch
+            optionFilterProp="label"
+            className="mt-2 w-full"
+            placeholder="选择页面"
+            value={behavior.targetPath}
+            options={yakOptions}
+            onChange={(targetPath) => patch({ targetPath })}
+          />
+          <div className="mt-2 text-[9px] text-[#667085]">查询参数名</div>
+          <Input
+            size="small"
+            allowClear
+            className="mt-1"
+            value={behavior.queryParam || ''}
+            placeholder="留空时使用当前字段名"
+            onChange={(event) => patch({ queryParam: event.target.value || undefined })}
+          />
+          <div className="mt-2 text-[9px] leading-4 text-[#98a2b3]">
+            例如点击 FAILED 后跳转工作流实例，可将参数名配置为 status，最终进入 /workflow/instances?status=FAILED。
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/yak-ops-ui/src/pages/dashboard/widget-action-editor.tsx
+++ b/yak-ops-ui/src/pages/dashboard/widget-action-editor.tsx
@@ -71,11 +71,10 @@ export function DashboardWidgetActionEditor({
     .filter((field) => field.role === 'dimension')
     .map((field) => ({ label: `${field.label} · ${field.dataType}`, value: field.key }));
   const firstDimension = spec.dimensions[0];
-  const drillFields = behavior.drillFields?.length
-    ? behavior.drillFields
-    : firstDimension
-      ? [firstDimension]
-      : [];
+  const configuredDrillFields = behavior.drillFields || [];
+  const drillFields = firstDimension
+    ? [firstDimension, ...configuredDrillFields.filter((field) => field !== firstDimension)]
+    : configuredDrillFields;
   const dashboardOptions = dashboards
     .filter((item) => item.id !== currentDashboardId && item.publishedVersionNo > 0)
     .map((item) => ({

--- a/yak-ops-ui/src/pages/dashboard/widget.tsx
+++ b/yak-ops-ui/src/pages/dashboard/widget.tsx
@@ -1,10 +1,19 @@
 import { AnalysisPreview } from '@/components/analysis/AnalysisPreview';
 import { Dropdown, Empty, Tooltip } from 'antd';
-import { Copy, GripVertical, MoreHorizontal, Trash2 } from 'lucide-react';
+import {
+  ChevronRight,
+  Copy,
+  GripVertical,
+  MoreHorizontal,
+  RotateCcw,
+  Trash2,
+} from 'lucide-react';
 import type {
   AnalysisAsset,
   AnalysisSelection,
+  DashboardDrillStep,
   DashboardFilter,
+  DashboardInlineAnalysisSpec,
   DashboardWidget,
   PublishedDataset,
 } from './model';
@@ -12,27 +21,33 @@ import type {
 export function WidgetShell({
   widget,
   analysis,
+  runtimeSpec,
   dataset,
   runtimeFilters,
+  drillPath,
   selected,
   preview,
   onSelect,
   onDataSelect,
+  onDrillBack,
   onDuplicate,
   onDelete,
 }: {
   widget: DashboardWidget;
   analysis?: AnalysisAsset;
+  runtimeSpec?: DashboardInlineAnalysisSpec | AnalysisAsset;
   dataset?: PublishedDataset;
   runtimeFilters: DashboardFilter[];
+  drillPath: DashboardDrillStep[];
   selected: boolean;
   preview: boolean;
   onSelect: () => void;
   onDataSelect: (selection: AnalysisSelection) => void;
+  onDrillBack: (depth: number) => void;
   onDuplicate: () => void;
   onDelete: () => void;
 }) {
-  const spec = widget.analysisId ? analysis : widget.inlineAnalysis;
+  const spec = runtimeSpec ?? (widget.analysisId ? analysis : widget.inlineAnalysis);
   const title = widget.analysisId
     ? analysis?.name ?? '历史图表'
     : widget.title ?? '未命名图表';
@@ -110,6 +125,41 @@ export function WidgetShell({
           </div>
         ) : null}
       </div>
+
+      {drillPath.length ? (
+        <div
+          className="flex h-7 shrink-0 items-center gap-0.5 border-b border-[#f0f2f5] bg-[#fafbfc] px-2.5 text-[9px] text-[#667085]"
+          onMouseDown={(event) => event.stopPropagation()}
+        >
+          <button
+            type="button"
+            className="flex h-5 items-center gap-1 rounded-[4px] border-0 bg-transparent px-1 text-[#667085] hover:bg-[#f0f2f5] hover:text-[#344054]"
+            onClick={(event) => {
+              event.stopPropagation();
+              onDrillBack(0);
+            }}
+          >
+            <RotateCcw size={9} />
+            全部
+          </button>
+          {drillPath.map((step, index) => (
+            <span key={`${step.field}-${index}`} className="flex min-w-0 items-center gap-0.5">
+              <ChevronRight size={9} className="shrink-0 text-[#b1b6bf]" />
+              <button
+                type="button"
+                className="max-w-[120px] truncate rounded-[4px] border-0 bg-transparent px-1 py-0.5 text-[#475467] hover:bg-[#f0f2f5]"
+                title={step.label}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  onDrillBack(index + 1);
+                }}
+              >
+                {step.label}
+              </button>
+            </span>
+          ))}
+        </div>
+      ) : null}
 
       <div className="min-h-0 flex-1 overflow-hidden">
         {spec ? (


### PR DESCRIPTION
## Summary

完成 Dashboard 路线图 Stage 4：在 Stage 3 的筛选 / 联动基础上补齐 **下钻、Dashboard 跳转、Yak 内部页面跳转**，让图表从“联动刷新”进一步具备“继续分析 / 进入下一层页面”的能力。

```text
Widget selection（预览态）
   ├─ Stage 3 linkage -> GlobalFilter -> 刷新关联图表
   └─ Stage 4 primary action
        ├─ Drill Down
        ├─ Dashboard Jump
        └─ Yak Page Jump
```

配置仍然发生在当前 Widget 的 Chart Editor 内，不恢复大型全局交互工作台。

## 1. Widget 点击行为

Chart Editor 新增轻量「点击行为」：

- 无额外操作
- 下钻
- 跳转仪表盘
- 跳转 Yak 页面

Stage 4 主点击动作只在 Preview / published view 执行，避免用户编辑图表时误触跳转。Stage 3 的配置模型保持不变。

Dashboard-local 行为保存在 `inlineAnalysis.dashboardBehavior`，继续跟随现有 immutable DashboardVersion snapshot 持久化。后端本来就版本化 `inlineAnalysis` JSON，因此无需新增表或修改 Dashboard API。

## 2. Drill Down

支持有序层级：

```text
省份 -> 城市 -> 门店
```

规则：

- 第一层固定为当前图表主维度
- 后续层级从当前 Dataset dimension 字段选择
- 至少 2 层才触发下钻
- drill path 属于 runtime-only 状态，不进入 Dirty / DashboardVersion

运行时：

```text
点击 广东
  -> province = 广东
  -> dimension 切换 city

点击 深圳
  -> province = 广东
  -> city = 深圳
  -> dimension 切换 store
```

Widget 顶部展示轻量 breadcrumb：

```text
全部 > 广东 > 深圳
```

可以回到全部或任意历史层级。

## 3. Dashboard Jump：严格读取 Published Snapshot

目标列表只提供已经发布的 Dashboard。

跳转 URL：

```text
/dashboard/{targetId}?preview=1&published=1&df=region&dv=华南
```

关键语义：

- `published=1` 会调用 Stage 2 已有 `GET /api/v1/dashboards/{id}/published`
- 因此目标展示的是稳定的 **Published Snapshot**，不会把目标 Dashboard 未发布草稿暴露给阅读者
- `df / dv` 作为 runtime context 传入
- 目标 Dashboard 自动查找绑定相同 `fieldId` 的 GlobalFilter 并写入 runtimeFilterValues
- 参数不会修改目标 Dashboard Definition，也不会生成版本
- 从 Published Preview 点击“退出预览”时，回到该 Dashboard 正常草稿编辑入口，而不是把 published snapshot 直接切成可编辑状态

例如：

```text
销售总览
  点击 华南
      ↓
区域销售分析（Published）
  region = 华南
```

## 4. Yak Internal Page Jump

支持将图表点击路由到 Yak-Ops 内部页面。当前目标保持克制，覆盖后续 Observe -> Act 最有价值的入口：

- 数据源管理
- 离线同步
- 数据开发运行记录
- 工作流定义
- 调度管理
- 工作流实例
- 数据表监控
- 数据质量运行记录

可以配置 query parameter 名称；留空时默认使用当前 `fieldId`。

例如：

```text
失败任务图
  点击 FAILED
      ↓
/workflow/instances?status=FAILED
```

Stage 4 负责稳定生成站内路由与上下文参数；目标业务页是否消费该 query 参数仍由目标页面自身筛选能力决定，本 PR 不静默改造其它业务模块。

## 5. Runtime / Definition 边界

Definition：

- `dashboardBehavior.clickAction`
- `drillFields`
- `targetDashboardId`
- `targetPath`
- `queryParam`

自动继承 Dirty / Undo / Redo / Save Draft / Publish / Version History / Restore。

Runtime-only：

- 当前 drill breadcrumb/path
- drill parent filters
- Dashboard Jump 的 `df / dv`

这些不会把 Dashboard 标成 Dirty，也不会创建 DashboardVersion。

## 6. Files / Scope

本次只修改 Dashboard 前端：

- `dashboard/model.ts`
- `dashboard/use-dashboard.ts`
- `dashboard/editor.tsx`
- `dashboard/chart-editor.tsx`
- `dashboard/widget.tsx`
- 新增 `dashboard/widget-action-editor.tsx`

不修改 Dashboard 表结构、Dashboard backend controller/service、Analysis Domain 或 Dataset Query Runtime。

本 Stage 4 刻意不做：

- 外部 URL Jump
- 新窗口 / target 配置
- 多参数映射器
- 独立 Viewer route（当前复用 `/dashboard/:id` + published view mode）
- 下钻层级中心
- Interaction 循环传播
- 全平台统一 URL Filter Protocol
- Stage 5 System Widget / action API

## Verification

- 基于 Stage 3 合并后的 `main`: `df6ff47a39026a64751dc7fb22880e6e89063b85`
- branch 相对 main only-ahead，未混入其它模块改动
- 已静态复核 drill hierarchy -> parent runtime filters -> dimension replacement -> breadcrumb back
- 已静态复核 Dashboard jump -> Published Snapshot -> incoming context -> target GlobalFilter
- 已静态复核 Yak route -> configurable query parameter
- `dashboardBehavior` 继续由现有 inlineAnalysis JSON snapshot 保存，历史版本 restore/publish 无需额外迁移
- 当前 connector 环境没有本地 Node 依赖执行环境，因此不宣称 `npm run tsc` / `npm run build` 已通过；Draft 阶段继续以仓库 CI/status 为准
