### PR TITLE
style(dashboard): polish editor layout and visual hierarchy

### DIFF
--- a/yak-ops-ui/src/pages/dashboard/chart-editor.tsx
+++ b/yak-ops-ui/src/pages/dashboard/chart-editor.tsx
@@ -1,6 +1,6 @@
 import type { AnalysisSpec } from '@/components/analysis/model';
 import { Button, Collapse, Input, Select, Switch } from 'antd';
-import { ChevronDown, SlidersHorizontal, X } from 'lucide-react';
+import { ChevronDown, MousePointerClick, SlidersHorizontal, X } from 'lucide-react';
 import { ConfigData } from './config-data';
 import { MetricAggregations } from './config-metrics';
 import { QueryControls } from './config-query';
@@ -55,11 +55,11 @@ export function ChartEditor({
       : undefined;
 
     return (
-      <aside className="flex w-[368px] shrink-0 flex-col border-l border-[#e5e7eb] bg-white">
+      <aside className="flex w-[344px] shrink-0 flex-col border-l border-[#e8eaee] bg-white">
         <EditorHeader onClose={close} />
         <div className="p-4">
-          <div className="rounded-[6px] border border-[#e5e7eb] bg-[#fafbfc] p-3">
-            <div className="truncate text-[12px] font-medium text-[#344054]">
+          <div className="rounded-[8px] border border-[#e7e9ed] bg-[#fafbfc] p-3.5">
+            <div className="truncate text-[12px] font-semibold text-[#344054]">
               {analysis?.name ?? '历史图表'}
             </div>
             <div className="mt-1 text-[10px] text-[#98a2b3]">
@@ -67,18 +67,17 @@ export function ChartEditor({
             </div>
           </div>
           <div className="mt-3 text-[11px] leading-5 text-[#667085]">
-            这个图表来自旧版共享资产。复制为当前仪表盘图表后，即可使用新的 Chart Editor 编辑数据、样式与交互。
+            这个图表来自旧版共享资产。复制为当前仪表盘图表后，即可继续编辑数据、样式与交互。
           </div>
           {!analysis ? (
-            <div className="mt-3 rounded-[4px] border border-[#fecdca] bg-[#fffbfa] px-2.5 py-2 text-[10px] text-[#b42318]">
+            <div className="mt-3 rounded-[6px] border border-[#fecdca] bg-[#fffbfa] px-2.5 py-2 text-[10px] text-[#b42318]">
               图表数据来源已删除或当前不可访问。
             </div>
           ) : null}
           <Button
             block
             size="small"
-            type="primary"
-            className="mt-4"
+            className="mt-4 !h-8 !rounded-[7px]"
             disabled={!analysis}
             onClick={detachAnalysis}
           >
@@ -160,33 +159,36 @@ export function ChartEditor({
     updateInlineAnalysis({ style: { ...spec.style, ...patch } });
 
   return (
-    <aside className="flex w-[368px] shrink-0 flex-col border-l border-[#e5e7eb] bg-white">
+    <aside className="flex w-[344px] shrink-0 flex-col border-l border-[#e8eaee] bg-white">
       <EditorHeader onClose={close} />
 
-      <div className="min-h-0 flex-1 overflow-y-auto px-4 py-3">
-        <label className="mb-1 block text-[11px] font-medium text-[#667085]">
-          图表标题
-        </label>
-        <Input
-          size="small"
-          value={widget.title || ''}
-          placeholder="未命名图表"
-          onChange={(event) => updateWidget({ title: event.target.value })}
-        />
+      <div className="min-h-0 flex-1 overflow-y-auto px-4 py-4">
+        <div className="space-y-4">
+          <div>
+            <SectionLabel>图表标题</SectionLabel>
+            <Input
+              size="small"
+              className="!h-8 !rounded-[7px]"
+              value={widget.title || ''}
+              placeholder="未命名图表"
+              onChange={(event) => updateWidget({ title: event.target.value })}
+            />
+          </div>
 
-        <div className="mt-4 border-t border-[#edf0f3] pt-4">
-          <div className="mb-1 text-[11px] font-medium text-[#667085]">数据集</div>
-          <Select
-            size="small"
-            className="w-full"
-            value={spec.datasetId}
-            options={datasets.map((item) => ({ label: item.name, value: item.id }))}
-            onChange={changeDataset}
-          />
+          <div>
+            <SectionLabel>数据集</SectionLabel>
+            <Select
+              size="small"
+              className="w-full"
+              value={spec.datasetId}
+              options={datasets.map((item) => ({ label: item.name, value: item.id }))}
+              onChange={changeDataset}
+            />
+          </div>
         </div>
 
-        <div className="mt-4">
-          <div className="mb-2 text-[11px] font-medium text-[#667085]">图表类型</div>
+        <div className="mt-5">
+          <SectionLabel>图表类型</SectionLabel>
           <div className="grid grid-cols-5 gap-1.5">
             {(Object.keys(CHART_META) as ChartType[]).map((type) => {
               const active = spec.type === type;
@@ -196,13 +198,13 @@ export function ChartEditor({
                   type="button"
                   onClick={() => changeType(type)}
                   className={[
-                    'flex min-w-0 flex-col items-center justify-center gap-1 rounded-[5px] border px-1 py-2 text-[10px] transition-colors',
+                    'flex min-w-0 flex-col items-center justify-center gap-1.5 rounded-[7px] border px-1 py-2.5 text-[10px] transition-[background-color,border-color,color]',
                     active
                       ? 'border-[#cfd4dc] bg-[#f5f6f7] font-medium text-[#161823]'
-                      : 'border-[#edf0f3] bg-white text-[#667085] hover:bg-[#fafbfc]',
+                      : 'border-[#eceef1] bg-white text-[#7a818c] hover:border-[#dfe2e6] hover:bg-[#fafbfc]',
                   ].join(' ')}
                 >
-                  <span className={active ? 'text-[#344054]' : 'text-[#98a2b3]'}>
+                  <span className={active ? 'text-[#344054]' : 'text-[#a0a6af]'}>
                     {CHART_META[type].icon}
                   </span>
                   <span className="truncate">{CHART_META[type].label}</span>
@@ -212,7 +214,8 @@ export function ChartEditor({
           </div>
         </div>
 
-        <div className="mt-4 border-t border-[#edf0f3] pt-4">
+        <div className="mt-5 rounded-[9px] bg-[#f8f9fa] p-3.5">
+          <div className="mb-3 text-[11px] font-semibold text-[#475467]">数据配置</div>
           <ConfigData
             spec={spec}
             dimensionOptions={dimensionOptions}
@@ -231,43 +234,52 @@ export function ChartEditor({
           />
         </div>
 
-        <div className="mt-4 border-t border-[#edf0f3] pt-4">
-          <DashboardInteractionEditor
-            widget={widget}
-            spec={spec}
-            dataset={dataset}
-            filters={globalFilters}
-            interactions={interactions}
-            onChange={updateInteractions}
-          />
-        </div>
-
-        <div className="mt-4 border-t border-[#edf0f3] pt-4">
-          <DashboardWidgetActionEditor
-            currentDashboardId={currentDashboardId}
-            spec={spec}
-            dataset={dataset}
-            onChange={(dashboardBehavior) => updateInlineAnalysis({ dashboardBehavior })}
-          />
-        </div>
-
         <Collapse
           ghost
-          className="chart-editor-more mt-3 border-t border-[#edf0f3] pt-1"
+          className="chart-editor-more mt-4 border-t border-[#eceef1]"
           expandIconPosition="end"
           expandIcon={({ isActive }) => (
             <ChevronDown
               size={13}
-              className={isActive ? 'rotate-180 text-[#667085]' : 'text-[#98a2b3]'}
+              className={isActive ? 'rotate-180 text-[#667085]' : 'text-[#a0a6af]'}
             />
           )}
           items={[
+            {
+              key: 'interaction',
+              label: (
+                <span className="flex items-center gap-1.5 text-[11px] font-medium text-[#667085]">
+                  <MousePointerClick size={12} />
+                  交互设置
+                </span>
+              ),
+              children: (
+                <div className="space-y-4 pb-2">
+                  <DashboardInteractionEditor
+                    widget={widget}
+                    spec={spec}
+                    dataset={dataset}
+                    filters={globalFilters}
+                    interactions={interactions}
+                    onChange={updateInteractions}
+                  />
+                  <div className="border-t border-[#eceef1] pt-4">
+                    <DashboardWidgetActionEditor
+                      currentDashboardId={currentDashboardId}
+                      spec={spec}
+                      dataset={dataset}
+                      onChange={(dashboardBehavior) => updateInlineAnalysis({ dashboardBehavior })}
+                    />
+                  </div>
+                </div>
+              ),
+            },
             {
               key: 'advanced',
               label: (
                 <span className="flex items-center gap-1.5 text-[11px] font-medium text-[#667085]">
                   <SlidersHorizontal size={12} />
-                  更多设置
+                  样式与查询
                 </span>
               ),
               children: (
@@ -276,80 +288,66 @@ export function ChartEditor({
                     {spec.type !== 'metric' && spec.type !== 'table' ? (
                       <label className="flex items-center justify-between">
                         <span>显示图例</span>
-                        <Switch
-                          size="small"
-                          checked={spec.style.showLegend}
-                          onChange={(showLegend) => updateStyle({ showLegend })}
-                        />
+                        <Switch size="small" checked={spec.style.showLegend} onChange={(showLegend) => updateStyle({ showLegend })} />
                       </label>
                     ) : null}
                     {spec.type !== 'metric' && spec.type !== 'table' ? (
                       <label className="flex items-center justify-between">
                         <span>显示数据标签</span>
-                        <Switch
-                          size="small"
-                          checked={spec.style.showDataLabels}
-                          onChange={(showDataLabels) => updateStyle({ showDataLabels })}
-                        />
+                        <Switch size="small" checked={spec.style.showDataLabels} onChange={(showDataLabels) => updateStyle({ showDataLabels })} />
                       </label>
                     ) : null}
                     {spec.type === 'line' ? (
                       <label className="flex items-center justify-between">
                         <span>平滑曲线</span>
-                        <Switch
-                          size="small"
-                          checked={spec.style.smooth}
-                          onChange={(smooth) => updateStyle({ smooth })}
-                        />
+                        <Switch size="small" checked={spec.style.smooth} onChange={(smooth) => updateStyle({ smooth })} />
                       </label>
                     ) : null}
                     {spec.type === 'line' || spec.type === 'bar' ? (
                       <label className="flex items-center justify-between">
                         <span>显示网格线</span>
-                        <Switch
-                          size="small"
-                          checked={spec.style.showGrid}
-                          onChange={(showGrid) => updateStyle({ showGrid })}
-                        />
+                        <Switch size="small" checked={spec.style.showGrid} onChange={(showGrid) => updateStyle({ showGrid })} />
                       </label>
                     ) : null}
                   </div>
 
-                  <QueryControls
-                    sortOptions={sortOptions}
-                    filterOptions={filterOptions}
-                    sortField={spec.sort?.field}
-                    sortDirection={spec.sort?.direction ?? 'asc'}
-                    filterField={filter?.field}
-                    filterOperator={filter?.operator ?? 'eq'}
-                    filterValue={filter?.value ?? ''}
-                    onSortField={(field?: string) =>
-                      updateInlineAnalysis({
-                        sort: field
-                          ? { field, direction: spec.sort?.direction ?? 'asc' }
-                          : undefined,
-                      })}
-                    onSortDirection={(direction: SortDirection) =>
-                      spec.sort
-                      && updateInlineAnalysis({ sort: { ...spec.sort, direction } })}
-                    onFilterField={(field?: string) =>
-                      updateInlineAnalysis({
-                        filters: field
-                          ? [{
-                            id: filter?.id ?? 'filter-main',
-                            field,
-                            operator: filter?.operator ?? 'eq',
-                            value: filter?.value ?? '',
-                          }]
-                          : [],
-                      })}
-                    onFilterOperator={(operator: FilterOperator) =>
-                      filter
-                      && updateInlineAnalysis({ filters: [{ ...filter, operator }] })}
-                    onFilterValue={(value) =>
-                      filter
-                      && updateInlineAnalysis({ filters: [{ ...filter, value }] })}
-                  />
+                  <div className="mt-4 border-t border-[#eceef1] pt-4">
+                    <QueryControls
+                      sortOptions={sortOptions}
+                      filterOptions={filterOptions}
+                      sortField={spec.sort?.field}
+                      sortDirection={spec.sort?.direction ?? 'asc'}
+                      filterField={filter?.field}
+                      filterOperator={filter?.operator ?? 'eq'}
+                      filterValue={filter?.value ?? ''}
+                      onSortField={(field?: string) =>
+                        updateInlineAnalysis({
+                          sort: field
+                            ? { field, direction: spec.sort?.direction ?? 'asc' }
+                            : undefined,
+                        })}
+                      onSortDirection={(direction: SortDirection) =>
+                        spec.sort
+                        && updateInlineAnalysis({ sort: { ...spec.sort, direction } })}
+                      onFilterField={(field?: string) =>
+                        updateInlineAnalysis({
+                          filters: field
+                            ? [{
+                              id: filter?.id ?? 'filter-main',
+                              field,
+                              operator: filter?.operator ?? 'eq',
+                              value: filter?.value ?? '',
+                            }]
+                            : [],
+                        })}
+                      onFilterOperator={(operator: FilterOperator) =>
+                        filter
+                        && updateInlineAnalysis({ filters: [{ ...filter, operator }] })}
+                      onFilterValue={(value) =>
+                        filter
+                        && updateInlineAnalysis({ filters: [{ ...filter, value }] })}
+                    />
+                  </div>
                 </div>
               ),
             },
@@ -357,8 +355,8 @@ export function ChartEditor({
         />
       </div>
 
-      <div className="shrink-0 border-t border-[#edf0f3] p-3">
-        <Button block size="small" type="primary" onClick={close}>
+      <div className="shrink-0 border-t border-[#eceef1] bg-[#fbfcfd] p-3">
+        <Button block size="small" className="!h-8 !rounded-[7px]" onClick={close}>
           完成
         </Button>
       </div>
@@ -366,17 +364,25 @@ export function ChartEditor({
   );
 }
 
+function SectionLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="mb-1.5 text-[10px] font-medium text-[#667085]">
+      {children}
+    </div>
+  );
+}
+
 function EditorHeader({ onClose }: { onClose: () => void }) {
   return (
-    <div className="flex h-12 shrink-0 items-center justify-between border-b border-[#edf0f3] px-4">
+    <div className="flex h-14 shrink-0 items-center justify-between border-b border-[#eceef1] px-4">
       <div>
-        <div className="text-[12px] font-semibold text-[#344054]">图表编辑</div>
-        <div className="mt-0.5 text-[9px] text-[#98a2b3]">选择数据与字段，图表会即时更新</div>
+        <div className="text-[13px] font-semibold text-[#344054]">图表设置</div>
+        <div className="mt-0.5 text-[9px] text-[#98a2b3]">数据、展示与交互配置</div>
       </div>
       <button
         type="button"
         onClick={onClose}
-        className="flex h-7 w-7 items-center justify-center rounded-[4px] border-0 bg-transparent text-[#667085] hover:bg-[#f5f6f7]"
+        className="flex h-7 w-7 items-center justify-center rounded-[6px] border-0 bg-transparent text-[#7a818c] hover:bg-[#f5f6f7] hover:text-[#344054]"
         aria-label="关闭图表编辑"
       >
         <X size={14} />

--- a/yak-ops-ui/src/pages/dashboard/editor.tsx
+++ b/yak-ops-ui/src/pages/dashboard/editor.tsx
@@ -43,13 +43,11 @@ export default function DashboardEditorPage() {
   })), [designer.widgets]);
   const hasGlobalFilters = designer.dashboard.globalFilters.length > 0;
   const hasFilterBar = !designer.preview || hasGlobalFilters;
-  let canvasMinHeight = 'min-h-[calc(100vh-120px)]';
+  let canvasMinHeight = 'min-h-[calc(100vh-154px)]';
   if (designer.preview) {
     canvasMinHeight = hasFilterBar
-      ? 'min-h-[calc(100vh-172px)]'
-      : 'min-h-[calc(100vh-136px)]';
-  } else if (hasFilterBar) {
-    canvasMinHeight = 'min-h-[calc(100vh-156px)]';
+      ? 'min-h-[calc(100vh-184px)]'
+      : 'min-h-[calc(100vh-132px)]';
   }
 
   const addChart = () => designer.addWidget('bar');
@@ -170,7 +168,7 @@ export default function DashboardEditorPage() {
 
   return (
     <div
-      className="flex h-[calc(100vh-48px)] min-h-[640px] flex-col overflow-hidden bg-[#f4f6f8]"
+      className="flex h-[calc(100vh-48px)] min-h-[640px] flex-col overflow-hidden bg-[#f6f7f9]"
       style={BRAND_CSS_VARIABLES}
     >
       <DashboardToolbar
@@ -219,16 +217,16 @@ export default function DashboardEditorPage() {
       />
 
       <div className="flex min-h-0 flex-1 overflow-hidden">
-        <main className="min-w-0 flex-1 overflow-auto">
-          <div className={designer.preview ? 'min-h-full p-5' : 'min-h-full p-3'}>
+        <main className="min-w-0 flex-1 overflow-auto bg-[#f6f7f9]">
+          <div className={designer.preview ? 'min-h-full p-5' : 'min-h-full p-4'}>
             <div
               ref={containerRef}
               className={[
-                'mx-auto min-w-[760px] bg-white',
+                'mx-auto min-w-[760px] rounded-[10px] bg-white',
                 canvasMinHeight,
                 designer.preview
-                  ? 'max-w-[1500px] shadow-[0_1px_5px_rgba(16,24,40,.08)]'
-                  : 'dashboard-grid-canvas border border-[#dfe3e8]',
+                  ? 'max-w-[1480px] border border-[#e7e9ed] shadow-[0_6px_24px_rgba(16,24,40,.055)]'
+                  : 'dashboard-grid-canvas max-w-[1540px] border border-[#e3e6ea] shadow-[0_2px_8px_rgba(16,24,40,.035)]',
               ].join(' ')}
               onMouseDown={(event) => {
                 if (event.target === event.currentTarget) designer.setSelectedId(undefined);
@@ -241,8 +239,8 @@ export default function DashboardEditorPage() {
                   gridConfig={{
                     cols: GRID_COLUMNS,
                     rowHeight: GRID_ROW_HEIGHT,
-                    margin: [8, 8],
-                    containerPadding: [8, 8],
+                    margin: [10, 10],
+                    containerPadding: [10, 10],
                   }}
                   dragConfig={{
                     enabled: !designer.preview,
@@ -293,10 +291,10 @@ export default function DashboardEditorPage() {
               {!designer.widgets.length && !designer.datasetsLoading ? (
                 <div className="flex min-h-[420px] items-center justify-center px-6 text-center">
                   <div className="max-w-[340px]">
-                    <div className="mx-auto flex h-10 w-10 items-center justify-center rounded-[8px] bg-[#f5f6f7] text-[#667085]">
+                    <div className="mx-auto flex h-11 w-11 items-center justify-center rounded-[10px] bg-[#f4f5f6] text-[#7a818c]">
                       <BarChart3 size={18} />
                     </div>
-                    <div className="mt-3 text-[14px] font-medium text-[#344054]">
+                    <div className="mt-3 text-[14px] font-semibold text-[#344054]">
                       {designer.activeDataset ? '从一个图表开始' : '暂无可用数据集'}
                     </div>
                     <div className="mt-1 text-[11px] leading-5 text-[#98a2b3]">
@@ -307,8 +305,7 @@ export default function DashboardEditorPage() {
                     {designer.activeDataset ? (
                       <Button
                         size="small"
-                        type="primary"
-                        className="mt-4"
+                        className="mt-4 !h-8 !rounded-[7px] !px-3"
                         icon={<BarChart3 size={13} />}
                         onClick={addChart}
                       >
@@ -370,27 +367,30 @@ export default function DashboardEditorPage() {
       <style>{`
         .dashboard-grid-canvas {
           background-color: #fff;
-          background-image:
-            linear-gradient(to right, rgba(15,23,42,.035) 1px, transparent 1px),
-            linear-gradient(to bottom, rgba(15,23,42,.035) 1px, transparent 1px);
+          background-image: radial-gradient(circle, rgba(15, 23, 42, .075) 1px, transparent 1px);
           background-size: calc(100% / 24) 36px;
+          background-position: 10px 10px;
         }
         .react-grid-item.react-grid-placeholder {
           background: var(--yak-brand-color-soft) !important;
           border: 1px dashed var(--yak-brand-color) !important;
+          border-radius: 9px !important;
           opacity: 1 !important;
         }
         .react-grid-item > .react-resizable-handle::after {
-          border-color: #98a2b3 !important;
+          border-color: #8e95a0 !important;
           border-width: 0 1px 1px 0 !important;
           height: 6px !important;
           width: 6px !important;
         }
+        .chart-editor-more > .ant-collapse-item {
+          border-bottom: 1px solid #eceef1 !important;
+        }
         .chart-editor-more > .ant-collapse-item > .ant-collapse-header {
-          padding: 10px 0 !important;
+          padding: 12px 0 !important;
         }
         .chart-editor-more .ant-collapse-content-box {
-          padding: 2px 0 0 !important;
+          padding: 2px 0 10px !important;
         }
       `}</style>
     </div>

--- a/yak-ops-ui/src/pages/dashboard/global-filter-bar.tsx
+++ b/yak-ops-ui/src/pages/dashboard/global-filter-bar.tsx
@@ -48,13 +48,20 @@ export function DashboardGlobalFilterBar({
   if (!filters.length && !editable) return null;
 
   return (
-    <div className="flex min-h-9 shrink-0 items-center gap-2 border-b border-[#e5e7eb] bg-white px-3 py-1">
-      <div className="flex shrink-0 items-center gap-1.5 text-[10px] font-medium text-[#667085]">
-        <SlidersHorizontal size={12} />
-        筛选
+    <div className="flex min-h-11 shrink-0 items-center gap-2 border-b border-[#eceef1] bg-[#fbfcfd] px-4 py-1.5">
+      <div className="flex shrink-0 items-center gap-1.5 text-[11px] font-medium text-[#475467]">
+        <SlidersHorizontal size={13} />
+        筛选条件
+        {filters.length ? (
+          <span className="rounded-full bg-[#eef0f2] px-1.5 py-px text-[9px] font-normal text-[#7a818c]">
+            {filters.length}
+          </span>
+        ) : null}
       </div>
 
-      <div className="flex min-w-0 flex-1 items-center gap-1.5 overflow-x-auto">
+      <div className="mx-1 h-5 w-px shrink-0 bg-[#eceef1]" />
+
+      <div className="flex min-w-0 flex-1 items-center gap-2 overflow-x-auto py-0.5">
         {filters.length ? filters.map((filter) => {
           const current = own(runtimeValues, filter.id)
             ? runtimeValues[filter.id]
@@ -78,12 +85,12 @@ export function DashboardGlobalFilterBar({
           return (
             <div
               key={filter.id}
-              className="flex h-7 shrink-0 items-center rounded-[4px] bg-[#f7f8fa] pl-2"
+              className="flex h-8 shrink-0 items-center rounded-[7px] border border-[#e7e9ed] bg-white pl-2.5 shadow-[0_1px_2px_rgba(16,24,40,.025)]"
             >
-              <span className="mr-1.5 text-[10px] text-[#667085]">
+              <span className="mr-1.5 max-w-[120px] truncate text-[10px] font-medium text-[#475467]">
                 {filter.name}
               </span>
-              <span className="mr-1 text-[9px] text-[#98a2b3]">
+              <span className="mr-0.5 text-[9px] text-[#a0a6af]">
                 {OPERATOR_LABELS[filter.operator]}
               </span>
               {dateFilter ? (
@@ -93,7 +100,7 @@ export function DashboardGlobalFilterBar({
                   allowClear
                   showTime={dateTime ? { format: 'HH:mm:ss' } : false}
                   format={dateTime ? 'YYYY-MM-DD HH:mm:ss' : 'YYYY-MM-DD'}
-                  className="w-[156px] text-[10px]"
+                  className="!h-7 w-[158px] text-[10px]"
                   placeholder="全部"
                   value={dateValue?.isValid() ? dateValue : null}
                   onChange={(value) => onRuntimeValue(
@@ -108,7 +115,7 @@ export function DashboardGlobalFilterBar({
                   variant="borderless"
                   size="small"
                   allowClear
-                  className="w-[112px] text-[10px]"
+                  className="!h-7 w-[116px] text-[10px]"
                   placeholder="全部"
                   value={current === undefined || current === null ? '' : String(current)}
                   onChange={(event) => onRuntimeValue(filter.id, event.target.value || undefined)}
@@ -117,15 +124,15 @@ export function DashboardGlobalFilterBar({
             </div>
           );
         }) : (
-          <span className="text-[10px] text-[#98a2b3]">暂无筛选条件</span>
+          <span className="text-[10px] text-[#a0a6af]">还没有筛选条件，可在这里添加全局筛选</span>
         )}
       </div>
 
       {filters.length ? (
         <Tooltip title="恢复默认筛选">
           <Button
-            size="small"
             type="text"
+            className="!h-7 !w-7 !min-w-0 !rounded-[6px] !p-0 !text-[#667085]"
             icon={<RefreshCw size={12} />}
             onClick={onReset}
           />
@@ -135,11 +142,11 @@ export function DashboardGlobalFilterBar({
       {editable ? (
         <Button
           size="small"
-          type="text"
+          className="!h-7 !rounded-[6px] !border-[#e4e7ec] !px-2.5 !text-[11px]"
           icon={filters.length ? <Settings2 size={12} /> : <Plus size={12} />}
           onClick={onManage}
         >
-          {filters.length ? '管理' : '添加筛选'}
+          {filters.length ? '管理筛选' : '添加筛选'}
         </Button>
       ) : null}
     </div>

--- a/yak-ops-ui/src/pages/dashboard/toolbar.tsx
+++ b/yak-ops-ui/src/pages/dashboard/toolbar.tsx
@@ -64,112 +64,71 @@ export function DashboardToolbar({
   const saveDisabled = persisted && !dirty;
   const busy = saving || publishing;
 
-  const lifecycle = (() => {
-    if (!persisted || !currentVersionNo) {
-      return <span className="rounded-[3px] bg-[#f5f6f7] px-2 py-0.5 text-[10px] text-[#667085]">未保存</span>;
-    }
-    if (hasPublishedVersion && !hasUnpublishedDraft) {
-      return (
-        <span className="rounded-[3px] bg-[#f0f9f4] px-2 py-0.5 text-[10px] font-medium text-[#1d7a4b]">
-          已发布 V{publishedVersionNo}
-        </span>
-      );
-    }
-    return (
-      <div className="flex shrink-0 items-center gap-1.5">
-        <span className="rounded-[3px] bg-[#f5f6f7] px-2 py-0.5 text-[10px] font-medium text-[#475467]">
-          草稿 V{currentVersionNo}
-        </span>
-        <span className="text-[10px] text-[#98a2b3]">
-          {hasPublishedVersion ? `已发布 V${publishedVersionNo}` : '未发布'}
-        </span>
-      </div>
-    );
+  const lifecycleText = (() => {
+    if (!persisted || !currentVersionNo) return '未保存';
+    if (hasPublishedVersion && !hasUnpublishedDraft) return `已发布 V${publishedVersionNo}`;
+    return hasPublishedVersion
+      ? `草稿 V${currentVersionNo} · 已发布 V${publishedVersionNo}`
+      : `草稿 V${currentVersionNo} · 未发布`;
   })();
 
   return (
-    <header className="flex h-12 shrink-0 items-center justify-between border-b border-[#dfe3e8] bg-white px-3">
-      <div className="flex min-w-0 items-center gap-2">
-        <Button
-          size="small"
-          type="text"
-          icon={<ChevronLeft size={14} />}
-          disabled={preview || busy}
-          onClick={onBack}
-        >
-          仪表盘
-        </Button>
-        <span className="h-5 w-px bg-[#e5e7eb]" />
-        <Input
-          variant="borderless"
-          value={name}
-          disabled={preview || busy}
-          onChange={(event) => onName(event.target.value)}
-          className="w-[260px] px-1 text-[13px] font-semibold text-[#161823]"
-        />
-        {lifecycle}
-        {dirty ? (
-          <span className="flex shrink-0 items-center gap-1.5 text-[10px] text-[#667085]">
-            <span className="h-1.5 w-1.5 rounded-full bg-[#98a2b3]" />
-            有未保存修改
-          </span>
-        ) : null}
+    <header className="flex h-14 shrink-0 items-center justify-between border-b border-[#e8eaee] bg-white px-4">
+      <div className="flex min-w-0 items-center gap-3">
+        <Tooltip title="返回仪表盘列表">
+          <Button
+            type="text"
+            className="!flex !h-8 !w-8 !min-w-0 !items-center !justify-center !rounded-[7px] !p-0 !text-[#667085] hover:!bg-[#f5f6f7] hover:!text-[#344054]"
+            icon={<ChevronLeft size={16} />}
+            disabled={preview || busy}
+            onClick={onBack}
+          />
+        </Tooltip>
+        <div className="h-7 w-px bg-[#eceef1]" />
+        <div className="min-w-0">
+          <Input
+            variant="borderless"
+            value={name}
+            disabled={preview || busy}
+            onChange={(event) => onName(event.target.value)}
+            className="!h-6 !w-[280px] !px-0 !text-[14px] !font-semibold !leading-6 !text-[#161823]"
+          />
+          <div className="mt-0.5 flex h-4 items-center gap-2 text-[10px] leading-4 text-[#98a2b3]">
+            <span>{lifecycleText}</span>
+            {dirty ? (
+              <>
+                <span className="h-1 w-1 rounded-full bg-[#c2c6cc]" />
+                <span className="text-[#667085]">有未保存修改</span>
+              </>
+            ) : null}
+          </div>
+        </div>
       </div>
 
-      <div className="flex items-center gap-2">
+      <div className="flex items-center gap-1.5">
         {!preview ? (
           <>
-            <div className="flex items-center rounded-[5px] border border-[#e5e7eb] bg-white p-0.5">
+            <div className="mr-1 flex items-center rounded-[7px] bg-[#f6f7f8] p-0.5">
               <Tooltip title="撤销 Ctrl/Cmd + Z">
-                <Button
-                  size="small"
-                  type="text"
-                  className="h-6 w-7 px-0"
-                  icon={<Undo2 size={13} />}
-                  disabled={!canUndo || busy}
-                  onClick={onUndo}
-                />
+                <Button type="text" className="!h-7 !w-7 !min-w-0 !rounded-[6px] !p-0" icon={<Undo2 size={13} />} disabled={!canUndo || busy} onClick={onUndo} />
               </Tooltip>
               <Tooltip title="重做 Ctrl/Cmd + Shift + Z">
-                <Button
-                  size="small"
-                  type="text"
-                  className="h-6 w-7 px-0"
-                  icon={<Redo2 size={13} />}
-                  disabled={!canRedo || busy}
-                  onClick={onRedo}
-                />
+                <Button type="text" className="!h-7 !w-7 !min-w-0 !rounded-[6px] !p-0" icon={<Redo2 size={13} />} disabled={!canRedo || busy} onClick={onRedo} />
               </Tooltip>
             </div>
-            <span className="h-5 w-px bg-[#e5e7eb]" />
-            <Button
-              size="small"
-              disabled={!canAddChart || busy}
-              icon={<BarChart3 size={13} />}
-              onClick={onAddChart}
-            >
+            <Button size="small" className="!h-8 !rounded-[7px] !border-[#e4e7ec] !px-3" disabled={!canAddChart || busy} icon={<BarChart3 size={13} />} onClick={onAddChart}>
               添加图表
             </Button>
           </>
         ) : null}
 
         {persisted && currentVersionNo ? (
-          <Button
-            size="small"
-            disabled={busy}
-            icon={<History size={13} />}
-            onClick={onHistory}
-          >
-            历史版本
-          </Button>
+          <Tooltip title="历史版本">
+            <Button type="text" className="!flex !h-8 !w-8 !min-w-0 !items-center !justify-center !rounded-[7px] !p-0 !text-[#667085] hover:!bg-[#f5f6f7]" disabled={busy} icon={<History size={14} />} onClick={onHistory} />
+          </Tooltip>
         ) : null}
 
-        <Button
-          size="small"
-          disabled={busy}
-          icon={preview ? <X size={13} /> : <Eye size={13} />}
-          onClick={onPreview}
-        >
+        <Button size="small" className="!h-8 !rounded-[7px] !border-[#e4e7ec] !px-3" disabled={busy} icon={preview ? <X size={13} /> : <Eye size={13} />} onClick={onPreview}>
           {preview ? '退出预览' : '预览'}
         </Button>
 
@@ -177,27 +136,14 @@ export function DashboardToolbar({
           <>
             <Tooltip title={saveDisabled ? '当前没有需要保存到草稿的修改' : '保存草稿 Ctrl/Cmd + S'}>
               <span>
-                <Button
-                  size="small"
-                  loading={saving}
-                  disabled={saveDisabled || publishing}
-                  icon={<Save size={13} />}
-                  onClick={onSaveDraft}
-                >
+                <Button size="small" className="!h-8 !rounded-[7px] !border-[#e4e7ec] !px-3" loading={saving} disabled={saveDisabled || publishing} icon={<Save size={13} />} onClick={onSaveDraft}>
                   保存草稿
                 </Button>
               </span>
             </Tooltip>
             <Tooltip title={!canPublish ? '当前草稿已经是已发布版本' : undefined}>
               <span>
-                <Button
-                  size="small"
-                  type="primary"
-                  loading={publishing}
-                  disabled={!canPublish || saving}
-                  icon={<Send size={13} />}
-                  onClick={onPublish}
-                >
+                <Button size="small" type="primary" className="!h-8 !rounded-[7px] !px-3.5 !shadow-none" loading={publishing} disabled={!canPublish || saving} icon={<Send size={13} />} onClick={onPublish}>
                   {hasPublishedVersion ? '发布更新' : '发布'}
                 </Button>
               </span>

--- a/yak-ops-ui/src/pages/dashboard/widget.tsx
+++ b/yak-ops-ui/src/pages/dashboard/widget.tsx
@@ -56,25 +56,25 @@ export function WidgetShell({
     <div
       onMouseDown={onSelect}
       className={[
-        'group relative flex h-full min-h-0 flex-col overflow-hidden bg-white transition-[border-color,box-shadow] duration-150',
+        'group relative flex h-full min-h-0 flex-col overflow-hidden rounded-[9px] bg-white transition-[border-color,box-shadow,transform] duration-150',
         preview
-          ? 'border border-[#e7eaf0]'
+          ? 'border border-[#e7e9ed] shadow-[0_1px_2px_rgba(16,24,40,.03)]'
           : selected
-            ? 'border border-[var(--yak-brand-color)] shadow-[0_0_0_1px_var(--yak-brand-color-soft)]'
-            : 'border border-[#e3e7ed] hover:border-[#d2d7df] hover:shadow-[0_2px_8px_rgba(16,24,40,.06)]',
+            ? 'border border-[var(--yak-brand-color)] shadow-[0_0_0_2px_var(--yak-brand-color-soft),0_4px_12px_rgba(16,24,40,.05)]'
+            : 'border border-[#e4e7ec] shadow-[0_1px_2px_rgba(16,24,40,.025)] hover:border-[#d6dae0] hover:shadow-[0_4px_12px_rgba(16,24,40,.055)]',
       ].join(' ')}
     >
-      <div className="dashboard-widget__drag-handle flex h-9 shrink-0 cursor-move items-center border-b border-[#f0f2f5] px-3">
+      <div className="dashboard-widget__drag-handle flex h-10 shrink-0 cursor-move items-center px-3.5">
         {!preview ? (
           <GripVertical
             size={13}
             className={[
-              'mr-1 text-[#98a2b3] transition-opacity duration-150',
-              selected ? 'opacity-100' : 'opacity-45 group-hover:opacity-100',
+              'mr-1.5 text-[#a8adb5] transition-opacity duration-150',
+              selected ? 'opacity-100' : 'opacity-0 group-hover:opacity-100',
             ].join(' ')}
           />
         ) : null}
-        <span className="min-w-0 flex-1 truncate text-[12px] font-medium text-[#344054]">
+        <span className="min-w-0 flex-1 truncate text-[12px] font-semibold text-[#344054]">
           {title}
         </span>
 
@@ -116,9 +116,9 @@ export function WidgetShell({
                   aria-label="组件操作"
                   onMouseDown={(event) => event.stopPropagation()}
                   onClick={(event) => event.stopPropagation()}
-                  className="flex h-6 w-6 items-center justify-center rounded-[4px] border-0 bg-transparent text-[#667085] transition-colors hover:bg-[#f5f6f7] hover:text-[#344054]"
+                  className="flex h-7 w-7 items-center justify-center rounded-[6px] border-0 bg-transparent text-[#7a818c] transition-colors hover:bg-[#f5f6f7] hover:text-[#344054]"
                 >
-                  <MoreHorizontal size={13} />
+                  <MoreHorizontal size={14} />
                 </button>
               </Tooltip>
             </Dropdown>
@@ -128,12 +128,12 @@ export function WidgetShell({
 
       {drillPath.length ? (
         <div
-          className="flex h-7 shrink-0 items-center gap-0.5 border-b border-[#f0f2f5] bg-[#fafbfc] px-2.5 text-[9px] text-[#667085]"
+          className="mx-3 flex h-7 shrink-0 items-center gap-0.5 rounded-[6px] bg-[#f7f8fa] px-2 text-[9px] text-[#667085]"
           onMouseDown={(event) => event.stopPropagation()}
         >
           <button
             type="button"
-            className="flex h-5 items-center gap-1 rounded-[4px] border-0 bg-transparent px-1 text-[#667085] hover:bg-[#f0f2f5] hover:text-[#344054]"
+            className="flex h-5 items-center gap-1 rounded-[4px] border-0 bg-transparent px-1 text-[#667085] hover:bg-[#eceef1] hover:text-[#344054]"
             onClick={(event) => {
               event.stopPropagation();
               onDrillBack(0);
@@ -147,7 +147,7 @@ export function WidgetShell({
               <ChevronRight size={9} className="shrink-0 text-[#b1b6bf]" />
               <button
                 type="button"
-                className="max-w-[120px] truncate rounded-[4px] border-0 bg-transparent px-1 py-0.5 text-[#475467] hover:bg-[#f0f2f5]"
+                className="max-w-[120px] truncate rounded-[4px] border-0 bg-transparent px-1 py-0.5 text-[#475467] hover:bg-[#eceef1]"
                 title={step.label}
                 onClick={(event) => {
                   event.stopPropagation();
@@ -161,7 +161,7 @@ export function WidgetShell({
         </div>
       ) : null}
 
-      <div className="min-h-0 flex-1 overflow-hidden">
+      <div className="min-h-0 flex-1 overflow-hidden px-1 pb-1">
         {spec ? (
           <AnalysisPreview
             spec={spec}


### PR DESCRIPTION
## Summary

在 Stage 1～4 功能稳定之后，先暂停后续 System Widget / 平台化阶段，集中收敛 Dashboard Editor 的视觉和布局。

这次不增加任何 BI 能力，也不改后端协议，目标只有一个：让当前仪表盘编辑器看起来更统一、更轻、更像 Yak-Ops 自己的产品，而不是多个功能面板拼在一起。

## 1. Toolbar 层级重构

原 Toolbar 同时展示标题、版本状态、Dirty、撤销/重做、添加图表、历史、预览、保存、发布，视觉权重比较平均。

本次调整为：

```text
返回 | 仪表盘名称
       草稿 / 发布状态 · 未保存提示

                  Undo / Redo  添加图表  历史  预览  保存草稿  发布
```

- 名称与生命周期信息组成一个整体
- 版本状态统一使用黑灰弱提示，不再使用独立绿色 Published Tag
- Undo / Redo 收敛为轻量工具组
- 历史版本改为图标级辅助操作
- Publish 保持唯一主要动作
- 按钮高度 / 圆角 / 间距统一

## 2. Global Filter Bar 统一

筛选条由“另一条工具栏”调整为轻量 secondary bar：

- 背景改为 `#fbfcfd`
- 增加筛选数量弱提示
- Filter control 改为白底细边框 chip
- 管理 / 添加筛选降低视觉权重
- 空状态改成一句轻提示，不再留一条突兀的空栏

## 3. Canvas Workspace

编辑区重新明确三层关系：

```text
Editor Chrome
   ↓
Workspace（浅灰）
   ↓
Dashboard Canvas（白色）
```

Canvas 调整：

- 外层 workspace 使用更柔和的浅灰
- Canvas 增加统一 10px 圆角与极轻阴影
- 编辑态网格从“横竖线表格感”改为低对比度 dot grid
- Widget 间距从 8px 调整为 10px
- Preview 继续使用白色阅读画布，但与编辑态保持同一视觉语言

## 4. Widget Card

Widget 做轻量卡片化，但不走重 Card 风格：

- 9px 圆角
- 更浅的默认边框
- hover 才增加轻微 shadow
- selected 继续保留品牌色边框，但弱化外发光
- Drag Handle 默认隐藏，hover / selected 时出现
- Drill breadcrumb 收进 Widget 内部的浅灰浮层，不再额外切一条硬分割线

## 5. Chart Editor 降噪

Stage 3 / 4 加入筛选联动、下钻和跳转以后，右侧编辑器信息密度明显上升。

本次重新分层：

```text
图表设置
├── 图表标题
├── 数据集
├── 图表类型
├── 数据配置
├── 交互设置（Collapse）
│   ├── 图表联动
│   └── 点击行为
└── 样式与查询（Collapse）
```

重点：

- 右侧宽度从 368px 收到 344px
- 高频配置保持直接可见
- 联动 / 下钻 / Dashboard Jump / Yak Jump 收进「交互设置」
- 样式和排序 / 本地筛选收进「样式与查询」
- 减少连续 `border-top` 带来的“表单堆叠感”
- 底部“完成”降为普通按钮，避免与全局 Publish 争抢主操作权重

## Scope

本 PR 只修改 Dashboard Editor 视觉层：

- `dashboard/editor.tsx`
- `dashboard/toolbar.tsx`
- `dashboard/global-filter-bar.tsx`
- `dashboard/widget.tsx`
- `dashboard/chart-editor.tsx`

明确不做：

- 不改 Dashboard 列表页（保留当前已经稳定的列表交互）
- 不改 Stage 1 Dirty / Undo / Redo
- 不改 Stage 2 Draft / Publish / Version
- 不改 Stage 3 Filter / Linkage Runtime
- 不改 Stage 4 Drill / Navigation Runtime
- 不做 Stage 5 / Stage 6
- 不改后端 / 数据库 / Dataset Query Runtime

## Verification

- 基于 Stage 4 合并后的 `main`: `45c70fd4bad4383740718f8149e8b92fb1f128fa`
- branch 相对 main：only-ahead，未混入其它模块变更
- 当前共修改 5 个 Dashboard 前端文件
- 已静态复核所有 Stage 1～4 handler / props / runtime 调用链保持不变，本 PR 主要是 JSX hierarchy 与 Tailwind 样式调整
- 当前 connector 环境没有本地 Node 依赖执行环境，因此不宣称 `npm run tsc` / `npm run build` 已通过；Draft 阶段以仓库 CI/status 为准
