### PR TITLE
feat(data-service): add phase 1 SQL-to-REST API

### DIFF
--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/dataservice/controller/v1/DataServiceController.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/dataservice/controller/v1/DataServiceController.java
@@ -1,0 +1,95 @@
+package io.yak.ops.business.dataservice.controller.v1;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.yak.framework.common.Result;
+import io.yak.ops.business.dataservice.dao.model.DataServiceCallLogPO;
+import io.yak.ops.business.dataservice.service.DataServiceService;
+import io.yak.ops.business.dataservice.service.DataServiceService.ApiInput;
+import io.yak.ops.business.dataservice.service.DataServiceService.ApiView;
+import io.yak.ops.business.dataservice.service.DataServiceService.QueryResponse;
+import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/** 数据服务第一阶段接口：SELECT SQL -> GET REST API。 */
+@Tag(name = "数据服务")
+@RestController
+@ConditionalOnDataSourceEnabled
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/data-service")
+public class DataServiceController {
+
+  private final DataServiceService dataServiceService;
+
+  @Operation(summary = "查询 API 服务列表")
+  @GetMapping
+  public Result<List<ApiView>> list() {
+    return Result.success(dataServiceService.list());
+  }
+
+  @Operation(summary = "查询 API 服务详情")
+  @GetMapping("/{id}")
+  public Result<ApiView> detail(@PathVariable("id") Long id) {
+    return Result.success(dataServiceService.get(id));
+  }
+
+  @Operation(summary = "创建 API 服务")
+  @PostMapping
+  public Result<ApiView> create(@RequestBody ApiInput input) {
+    return Result.success(dataServiceService.save(null, input));
+  }
+
+  @Operation(summary = "更新 API 服务")
+  @PutMapping("/{id}")
+  public Result<ApiView> update(@PathVariable("id") Long id, @RequestBody ApiInput input) {
+    return Result.success(dataServiceService.save(id, input));
+  }
+
+  @Operation(summary = "删除 API 服务")
+  @DeleteMapping("/{id}")
+  public Result<Boolean> delete(@PathVariable("id") Long id) {
+    dataServiceService.delete(id);
+    return Result.success(Boolean.TRUE);
+  }
+
+  @Operation(summary = "启用或停用 API 服务")
+  @PutMapping("/{id}/enabled")
+  public Result<ApiView> setEnabled(
+      @PathVariable("id") Long id,
+      @RequestParam("enabled") boolean enabled) {
+    return Result.success(dataServiceService.setEnabled(id, enabled));
+  }
+
+  @Operation(summary = "测试 API 服务")
+  @PostMapping("/{id}/test")
+  public Result<QueryResponse> test(
+      @PathVariable("id") Long id,
+      @RequestBody(required = false) Map<String, String> parameters) {
+    return Result.success(dataServiceService.test(id, parameters));
+  }
+
+  @Operation(summary = "查询最近调用记录")
+  @GetMapping("/logs/recent")
+  public Result<List<DataServiceCallLogPO>> logs() {
+    return Result.success(dataServiceService.logs());
+  }
+
+  @Operation(summary = "调用已发布的数据服务")
+  @GetMapping("/runtime/{*servicePath}")
+  public Result<QueryResponse> invoke(
+      @PathVariable("servicePath") String servicePath,
+      @RequestParam Map<String, String> parameters) {
+    return Result.success(dataServiceService.invoke(servicePath, parameters));
+  }
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/dataservice/dao/mapper/DataServiceApiMapper.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/dataservice/dao/mapper/DataServiceApiMapper.java
@@ -1,0 +1,8 @@
+package io.yak.ops.business.dataservice.dao.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import io.yak.ops.business.dataservice.dao.model.DataServiceApiPO;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface DataServiceApiMapper extends BaseMapper<DataServiceApiPO> {}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/dataservice/dao/mapper/DataServiceCallLogMapper.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/dataservice/dao/mapper/DataServiceCallLogMapper.java
@@ -1,0 +1,8 @@
+package io.yak.ops.business.dataservice.dao.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import io.yak.ops.business.dataservice.dao.model.DataServiceCallLogPO;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface DataServiceCallLogMapper extends BaseMapper<DataServiceCallLogPO> {}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/dataservice/dao/model/DataServiceApiPO.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/dataservice/dao/model/DataServiceApiPO.java
@@ -1,0 +1,26 @@
+package io.yak.ops.business.dataservice.dao.model;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import java.time.LocalDateTime;
+import lombok.Data;
+
+/** 数据服务 API 持久化对象。 */
+@Data
+@TableName("yak_ops_data_service_api")
+public class DataServiceApiPO {
+
+  @TableId(type = IdType.AUTO)
+  private Long id;
+  private String name;
+  private String path;
+  private Long dataSourceId;
+  private String sqlText;
+  private Integer maxRows;
+  private Integer timeoutSeconds;
+  private Boolean enabled;
+  private String description;
+  private LocalDateTime createTime;
+  private LocalDateTime updateTime;
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/dataservice/dao/model/DataServiceCallLogPO.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/dataservice/dao/model/DataServiceCallLogPO.java
@@ -1,0 +1,25 @@
+package io.yak.ops.business.dataservice.dao.model;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import java.time.LocalDateTime;
+import lombok.Data;
+
+/** 数据服务调用日志持久化对象。 */
+@Data
+@TableName("yak_ops_data_service_call_log")
+public class DataServiceCallLogPO {
+
+  @TableId(type = IdType.AUTO)
+  private Long id;
+  private Long apiId;
+  private String serviceName;
+  private String servicePath;
+  private String paramsJson;
+  private Boolean success;
+  private Long durationMs;
+  private Integer rowCount;
+  private String errorMessage;
+  private LocalDateTime createTime;
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/dataservice/service/DataServiceService.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/dataservice/service/DataServiceService.java
@@ -1,0 +1,291 @@
+package io.yak.ops.business.dataservice.service;
+
+import com.baomidou.mybatisplus.core.toolkit.Wrappers;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.dataservice.dao.mapper.DataServiceApiMapper;
+import io.yak.ops.business.dataservice.dao.mapper.DataServiceCallLogMapper;
+import io.yak.ops.business.dataservice.dao.model.DataServiceApiPO;
+import io.yak.ops.business.dataservice.dao.model.DataServiceCallLogPO;
+import io.yak.ops.business.dataservice.service.support.DataServiceSqlCompiler;
+import io.yak.ops.business.datasource.service.support.BusinessDataSourceExecutionProvider;
+import io.yak.ops.spi.datasource.execution.DataSourceSqlColumn;
+import io.yak.ops.spi.datasource.execution.DataSourceSqlExecutor;
+import io.yak.ops.spi.datasource.execution.DataSourceSqlRequest;
+import io.yak.ops.spi.datasource.execution.DataSourceSqlResult;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+/** Phase-1 data service: persist SELECT definitions and expose them through a safe REST runtime. */
+@Service
+@RequiredArgsConstructor
+public class DataServiceService {
+
+  private static final int DEFAULT_MAX_ROWS = 1_000;
+  private static final int DEFAULT_TIMEOUT_SECONDS = 30;
+  private static final String RUNTIME_PREFIX = "/api/v1/data-service/runtime";
+
+  private final DataServiceApiMapper apiMapper;
+  private final DataServiceCallLogMapper callLogMapper;
+  private final BusinessDataSourceExecutionProvider executionProvider;
+  private final DataServiceSqlCompiler sqlCompiler;
+  private final ObjectMapper objectMapper;
+
+  public List<ApiView> list() {
+    return apiMapper.selectList(
+            Wrappers.<DataServiceApiPO>lambdaQuery()
+                .orderByDesc(DataServiceApiPO::getUpdateTime)
+                .orderByDesc(DataServiceApiPO::getId))
+        .stream()
+        .map(this::toView)
+        .toList();
+  }
+
+  public ApiView get(Long id) {
+    return toView(requireApi(id));
+  }
+
+  @Transactional
+  public ApiView save(Long id, ApiInput input) {
+    validateInput(input);
+    String path = normalizePath(input.path());
+    Long duplicateCount = apiMapper.selectCount(
+        Wrappers.<DataServiceApiPO>lambdaQuery()
+            .eq(DataServiceApiPO::getPath, path)
+            .ne(id != null, DataServiceApiPO::getId, id));
+    if (duplicateCount != null && duplicateCount > 0) {
+      throw new IllegalArgumentException("服务路径已存在：" + path);
+    }
+
+    LocalDateTime now = LocalDateTime.now();
+    DataServiceApiPO api = id == null ? new DataServiceApiPO() : requireApi(id);
+    api.setName(input.name().trim());
+    api.setPath(path);
+    api.setDataSourceId(input.dataSourceId());
+    api.setSqlText(input.sql().trim());
+    api.setMaxRows(normalizeMaxRows(input.maxRows()));
+    api.setTimeoutSeconds(normalizeTimeout(input.timeoutSeconds()));
+    api.setEnabled(input.enabled() == null ? Boolean.FALSE : input.enabled());
+    api.setDescription(StringUtils.hasText(input.description()) ? input.description().trim() : null);
+    api.setUpdateTime(now);
+    if (id == null) {
+      api.setCreateTime(now);
+      apiMapper.insert(api);
+    } else {
+      apiMapper.updateById(api);
+    }
+    return toView(api);
+  }
+
+  @Transactional
+  public void delete(Long id) {
+    if (apiMapper.deleteById(id) == 0) {
+      throw new IllegalArgumentException("数据服务不存在：" + id);
+    }
+  }
+
+  @Transactional
+  public ApiView setEnabled(Long id, boolean enabled) {
+    DataServiceApiPO api = requireApi(id);
+    api.setEnabled(enabled);
+    api.setUpdateTime(LocalDateTime.now());
+    apiMapper.updateById(api);
+    return toView(api);
+  }
+
+  public QueryResponse test(Long id, Map<String, String> parameters) {
+    return execute(requireApi(id), parameters, true);
+  }
+
+  public QueryResponse invoke(String servicePath, Map<String, String> parameters) {
+    String normalizedPath = normalizePath(servicePath);
+    DataServiceApiPO api = apiMapper.selectOne(
+        Wrappers.<DataServiceApiPO>lambdaQuery()
+            .eq(DataServiceApiPO::getPath, normalizedPath)
+            .last("LIMIT 1"));
+    if (api == null) {
+      throw new IllegalArgumentException("数据服务不存在：" + normalizedPath);
+    }
+    if (!Boolean.TRUE.equals(api.getEnabled())) {
+      throw new IllegalStateException("数据服务未启用：" + normalizedPath);
+    }
+    return execute(api, parameters, true);
+  }
+
+  public List<DataServiceCallLogPO> logs() {
+    return callLogMapper.selectList(
+        Wrappers.<DataServiceCallLogPO>lambdaQuery()
+            .orderByDesc(DataServiceCallLogPO::getCreateTime)
+            .orderByDesc(DataServiceCallLogPO::getId)
+            .last("LIMIT 200"));
+  }
+
+  private QueryResponse execute(
+      DataServiceApiPO api, Map<String, String> parameters, boolean writeLog) {
+    long started = System.nanoTime();
+    try {
+      DataServiceSqlCompiler.CompiledSql compiled = sqlCompiler.compile(api.getSqlText(), parameters);
+      DataSourceSqlResult result;
+      try (DataSourceSqlExecutor executor = executionProvider.open(String.valueOf(api.getDataSourceId()))) {
+        result = executor.execute(
+            new DataSourceSqlRequest(
+                compiled.sql(), api.getMaxRows(), api.getTimeoutSeconds(), compiled.parameters()));
+      }
+      if (!result.resultSet()) {
+        throw new IllegalStateException("数据服务仅允许返回 SELECT 查询结果");
+      }
+      long durationMs = elapsedMs(started);
+      QueryResponse response = toResponse(result, durationMs);
+      if (writeLog) saveLog(api, parameters, true, durationMs, response.rowCount(), null);
+      return response;
+    } catch (RuntimeException exception) {
+      long durationMs = elapsedMs(started);
+      if (writeLog) saveLog(api, parameters, false, durationMs, 0, safeMessage(exception));
+      throw exception;
+    }
+  }
+
+  private QueryResponse toResponse(DataSourceSqlResult result, long durationMs) {
+    List<String> columns = result.columns().stream().map(DataSourceSqlColumn::label).toList();
+    List<Map<String, Object>> rows = new ArrayList<>(result.rows().size());
+    for (List<Object> values : result.rows()) {
+      Map<String, Object> row = new LinkedHashMap<>();
+      for (int index = 0; index < columns.size(); index++) {
+        row.put(columns.get(index), index < values.size() ? values.get(index) : null);
+      }
+      rows.add(row);
+    }
+    return new QueryResponse(columns, rows, result.truncated(), rows.size(), durationMs);
+  }
+
+  private void saveLog(
+      DataServiceApiPO api,
+      Map<String, String> parameters,
+      boolean success,
+      long durationMs,
+      int rowCount,
+      String errorMessage) {
+    DataServiceCallLogPO log = new DataServiceCallLogPO();
+    log.setApiId(api.getId());
+    log.setServiceName(api.getName());
+    log.setServicePath(api.getPath());
+    log.setParamsJson(limit(json(parameters == null ? Map.of() : parameters), 4_000));
+    log.setSuccess(success);
+    log.setDurationMs(durationMs);
+    log.setRowCount(rowCount);
+    log.setErrorMessage(limit(errorMessage, 1_000));
+    log.setCreateTime(LocalDateTime.now());
+    callLogMapper.insert(log);
+  }
+
+  private ApiView toView(DataServiceApiPO api) {
+    if (api == null) return null;
+    return new ApiView(
+        api.getId(), api.getName(), api.getPath(), RUNTIME_PREFIX + api.getPath(),
+        api.getDataSourceId(), api.getSqlText(), sqlCompiler.parameterNames(api.getSqlText()),
+        api.getMaxRows(), api.getTimeoutSeconds(), Boolean.TRUE.equals(api.getEnabled()),
+        api.getDescription(), api.getCreateTime(), api.getUpdateTime());
+  }
+
+  private DataServiceApiPO requireApi(Long id) {
+    DataServiceApiPO api = id == null ? null : apiMapper.selectById(id);
+    if (api == null) throw new IllegalArgumentException("数据服务不存在：" + id);
+    return api;
+  }
+
+  private void validateInput(ApiInput input) {
+    if (input == null) throw new IllegalArgumentException("数据服务配置不能为空");
+    if (!StringUtils.hasText(input.name())) throw new IllegalArgumentException("服务名称不能为空");
+    if (input.dataSourceId() == null || input.dataSourceId() <= 0) {
+      throw new IllegalArgumentException("请选择数据源");
+    }
+    sqlCompiler.validateSelectOnly(input.sql());
+    normalizePath(input.path());
+    normalizeMaxRows(input.maxRows());
+    normalizeTimeout(input.timeoutSeconds());
+  }
+
+  private String normalizePath(String path) {
+    if (!StringUtils.hasText(path)) throw new IllegalArgumentException("服务路径不能为空");
+    String value = path.trim();
+    if (!value.startsWith("/")) value = "/" + value;
+    value = value.replaceAll("/{2,}", "/");
+    if (value.length() > 1 && value.endsWith("/")) value = value.substring(0, value.length() - 1);
+    if (!value.matches("/[A-Za-z0-9._~/-]+")) {
+      throw new IllegalArgumentException("服务路径仅支持字母、数字、-、_、. 和 /：" + value);
+    }
+    return value;
+  }
+
+  private int normalizeMaxRows(Integer value) {
+    int result = value == null ? DEFAULT_MAX_ROWS : value;
+    if (result < 1 || result > 10_000) throw new IllegalArgumentException("最大返回行数必须在 1~10000 之间");
+    return result;
+  }
+
+  private int normalizeTimeout(Integer value) {
+    int result = value == null ? DEFAULT_TIMEOUT_SECONDS : value;
+    if (result < 1 || result > 3_600) throw new IllegalArgumentException("超时时间必须在 1~3600 秒之间");
+    return result;
+  }
+
+  private long elapsedMs(long started) {
+    return Math.max(0L, (System.nanoTime() - started) / 1_000_000L);
+  }
+
+  private String json(Object value) {
+    try {
+      return objectMapper.writeValueAsString(value);
+    } catch (Exception ignored) {
+      return "{}";
+    }
+  }
+
+  private String safeMessage(Throwable throwable) {
+    String message = throwable == null ? null : throwable.getMessage();
+    return StringUtils.hasText(message) ? message : "数据服务调用失败";
+  }
+
+  private String limit(String value, int maxLength) {
+    if (value == null || value.length() <= maxLength) return value;
+    return value.substring(0, maxLength);
+  }
+
+  public record ApiInput(
+      String name,
+      String path,
+      Long dataSourceId,
+      String sql,
+      Integer maxRows,
+      Integer timeoutSeconds,
+      Boolean enabled,
+      String description) {}
+
+  public record ApiView(
+      Long id,
+      String name,
+      String path,
+      String runtimePath,
+      Long dataSourceId,
+      String sql,
+      List<String> parameterNames,
+      Integer maxRows,
+      Integer timeoutSeconds,
+      Boolean enabled,
+      String description,
+      LocalDateTime createTime,
+      LocalDateTime updateTime) {}
+
+  public record QueryResponse(
+      List<String> columns,
+      List<Map<String, Object>> rows,
+      boolean truncated,
+      int rowCount,
+      long durationMs) {}
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/dataservice/service/DataServiceService.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/dataservice/service/DataServiceService.java
@@ -7,6 +7,7 @@ import io.yak.ops.business.dataservice.dao.mapper.DataServiceCallLogMapper;
 import io.yak.ops.business.dataservice.dao.model.DataServiceApiPO;
 import io.yak.ops.business.dataservice.dao.model.DataServiceCallLogPO;
 import io.yak.ops.business.dataservice.service.support.DataServiceSqlCompiler;
+import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
 import io.yak.ops.business.datasource.service.support.BusinessDataSourceExecutionProvider;
 import io.yak.ops.spi.datasource.execution.DataSourceSqlColumn;
 import io.yak.ops.spi.datasource.execution.DataSourceSqlExecutor;
@@ -24,6 +25,7 @@ import org.springframework.util.StringUtils;
 
 /** Phase-1 data service: persist SELECT definitions and expose them through a safe REST runtime. */
 @Service
+@ConditionalOnDataSourceEnabled
 @RequiredArgsConstructor
 public class DataServiceService {
 

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/dataservice/service/support/DataServiceSqlCompiler.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/dataservice/service/support/DataServiceSqlCompiler.java
@@ -1,0 +1,54 @@
+package io.yak.ops.business.dataservice.service.support;
+
+import java.util.List;
+import java.util.Map;
+import net.sf.jsqlparser.parser.CCJSqlParserUtil;
+import net.sf.jsqlparser.statement.Statements;
+import net.sf.jsqlparser.statement.select.Select;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterUtils;
+import org.springframework.jdbc.core.namedparam.ParsedSql;
+import org.springframework.stereotype.Component;
+
+/** Validates read-only service SQL and compiles named parameters to JDBC placeholders. */
+@Component
+public class DataServiceSqlCompiler {
+
+  public CompiledSql compile(String sql, Map<String, ?> parameters) {
+    validateSelectOnly(sql);
+    MapSqlParameterSource source = new MapSqlParameterSource(parameters == null ? Map.of() : parameters);
+    ParsedSql parsed = NamedParameterUtils.parseSqlStatement(sql);
+    for (String name : parsed.getParameterNames()) {
+      if (!source.hasValue(name)) {
+        throw new IllegalArgumentException("缺少请求参数：" + name);
+      }
+    }
+    String jdbcSql = NamedParameterUtils.substituteNamedParameters(parsed, source);
+    Object[] values = NamedParameterUtils.buildValueArray(parsed, source, null);
+    return new CompiledSql(jdbcSql, List.of(values));
+  }
+
+  public List<String> parameterNames(String sql) {
+    validateSelectOnly(sql);
+    return NamedParameterUtils.parseSqlStatement(sql).getParameterNames().stream().distinct().toList();
+  }
+
+  public void validateSelectOnly(String sql) {
+    if (sql == null || sql.isBlank()) {
+      throw new IllegalArgumentException("SQL 不能为空");
+    }
+    try {
+      Statements statements = CCJSqlParserUtil.parseStatements(sql);
+      if (statements.getStatements().size() != 1
+          || !(statements.getStatements().get(0) instanceof Select)) {
+        throw new IllegalArgumentException("数据服务第一阶段仅支持单条 SELECT 查询");
+      }
+    } catch (IllegalArgumentException exception) {
+      throw exception;
+    } catch (Exception exception) {
+      throw new IllegalArgumentException("SQL 解析失败：" + exception.getMessage(), exception);
+    }
+  }
+
+  public record CompiledSql(String sql, List<Object> parameters) {}
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/dataservice/service/support/DataServiceSqlCompiler.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/dataservice/service/support/DataServiceSqlCompiler.java
@@ -1,7 +1,10 @@
 package io.yak.ops.business.dataservice.service.support;
 
+import java.util.Arrays;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import net.sf.jsqlparser.parser.CCJSqlParserUtil;
 import net.sf.jsqlparser.statement.Statements;
 import net.sf.jsqlparser.statement.select.Select;
@@ -16,21 +19,96 @@ public class DataServiceSqlCompiler {
 
   public CompiledSql compile(String sql, Map<String, ?> parameters) {
     validateSelectOnly(sql);
-    MapSqlParameterSource source = new MapSqlParameterSource(parameters == null ? Map.of() : parameters);
-    ParsedSql parsed = NamedParameterUtils.parseSqlStatement(sql);
-    for (String name : parsed.getParameterNames()) {
-      if (!source.hasValue(name)) {
+    Map<String, ?> values = parameters == null ? Map.of() : parameters;
+    for (String name : parameterNames(sql)) {
+      if (!values.containsKey(name)) {
         throw new IllegalArgumentException("缺少请求参数：" + name);
       }
     }
-    String jdbcSql = NamedParameterUtils.substituteNamedParameters(parsed, source);
-    Object[] values = NamedParameterUtils.buildValueArray(parsed, source, null);
-    return new CompiledSql(jdbcSql, List.of(values));
+    try {
+      MapSqlParameterSource source = new MapSqlParameterSource(values);
+      ParsedSql parsed = NamedParameterUtils.parseSqlStatement(sql);
+      String jdbcSql = NamedParameterUtils.substituteNamedParameters(parsed, source);
+      Object[] boundValues = NamedParameterUtils.buildValueArray(parsed, source, null);
+      return new CompiledSql(
+          jdbcSql,
+          boundValues == null ? List.of() : Arrays.asList(boundValues));
+    } catch (RuntimeException exception) {
+      throw new IllegalArgumentException("SQL 参数绑定失败：" + exception.getMessage(), exception);
+    }
   }
 
+  /**
+   * Discovers :name parameters for the editor without relying on ParsedSql's package-private
+   * metadata. Quoted strings/identifiers and SQL comments are ignored; PostgreSQL :: casts are
+   * preserved.
+   */
   public List<String> parameterNames(String sql) {
     validateSelectOnly(sql);
-    return NamedParameterUtils.parseSqlStatement(sql).getParameterNames().stream().distinct().toList();
+    Set<String> names = new LinkedHashSet<>();
+    boolean singleQuote = false;
+    boolean doubleQuote = false;
+    boolean backtick = false;
+    boolean lineComment = false;
+    boolean blockComment = false;
+
+    for (int index = 0; index < sql.length(); index++) {
+      char current = sql.charAt(index);
+      char next = index + 1 < sql.length() ? sql.charAt(index + 1) : '\0';
+
+      if (lineComment) {
+        if (current == '\n' || current == '\r') lineComment = false;
+        continue;
+      }
+      if (blockComment) {
+        if (current == '*' && next == '/') {
+          blockComment = false;
+          index++;
+        }
+        continue;
+      }
+      if (!singleQuote && !doubleQuote && !backtick) {
+        if (current == '-' && next == '-') {
+          lineComment = true;
+          index++;
+          continue;
+        }
+        if (current == '/' && next == '*') {
+          blockComment = true;
+          index++;
+          continue;
+        }
+      }
+      if (!doubleQuote && !backtick && current == '\'') {
+        if (singleQuote && next == '\'') {
+          index++;
+          continue;
+        }
+        singleQuote = !singleQuote;
+        continue;
+      }
+      if (!singleQuote && !backtick && current == '"') {
+        doubleQuote = !doubleQuote;
+        continue;
+      }
+      if (!singleQuote && !doubleQuote && current == '`') {
+        backtick = !backtick;
+        continue;
+      }
+      if (singleQuote || doubleQuote || backtick || current != ':') continue;
+      if (next == ':' || (index > 0 && sql.charAt(index - 1) == ':')) continue;
+      if (!(Character.isLetter(next) || next == '_')) continue;
+
+      int end = index + 2;
+      while (end < sql.length()) {
+        char candidate = sql.charAt(end);
+        if (!(Character.isLetterOrDigit(candidate) || candidate == '_')) break;
+        end++;
+      }
+      names.add(sql.substring(index + 1, end));
+      index = end - 1;
+    }
+    return List.copyOf(names);
   }
 
   public void validateSelectOnly(String sql) {

--- a/yak-ops-business/yak-ops-business-datasource/src/main/resources/db/migration/yak-datasource/V3__create_data_service_tables.sql
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/resources/db/migration/yak-datasource/V3__create_data_service_tables.sql
@@ -1,0 +1,43 @@
+-- Yak Ops 数据服务第一阶段：API 定义与调用日志。
+CREATE TABLE IF NOT EXISTS yak_ops_data_service_api (
+    id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT COMMENT '主键',
+    name VARCHAR(128) NOT NULL COMMENT '服务名称',
+    path VARCHAR(255) NOT NULL COMMENT '服务相对路径',
+    data_source_id BIGINT UNSIGNED NOT NULL COMMENT 'Yak Ops 数据源 ID',
+    sql_text LONGTEXT NOT NULL COMMENT '只读 SELECT SQL，支持 :name 命名参数',
+    max_rows INT NOT NULL DEFAULT 1000 COMMENT '最大返回行数',
+    timeout_seconds INT NOT NULL DEFAULT 30 COMMENT '查询超时秒数',
+    enabled TINYINT(1) NOT NULL DEFAULT 0 COMMENT '是否启用',
+    description VARCHAR(500) DEFAULT NULL COMMENT '说明',
+    create_time DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) COMMENT '创建时间',
+    update_time DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3)
+        ON UPDATE CURRENT_TIMESTAMP(3) COMMENT '更新时间',
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_yak_ops_data_service_path (path),
+    KEY idx_yak_ops_data_service_ds (data_source_id),
+    KEY idx_yak_ops_data_service_enabled (enabled),
+    KEY idx_yak_ops_data_service_update_time (update_time)
+) ENGINE=InnoDB
+  DEFAULT CHARSET=utf8mb4
+  COLLATE=utf8mb4_unicode_ci
+  COMMENT='Yak Ops 数据服务 API 定义';
+
+CREATE TABLE IF NOT EXISTS yak_ops_data_service_call_log (
+    id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT COMMENT '主键',
+    api_id BIGINT UNSIGNED NOT NULL COMMENT '数据服务 API ID',
+    service_name VARCHAR(128) NOT NULL COMMENT '调用时服务名称快照',
+    service_path VARCHAR(255) NOT NULL COMMENT '调用时路径快照',
+    params_json TEXT DEFAULT NULL COMMENT '请求参数 JSON',
+    success TINYINT(1) NOT NULL DEFAULT 0 COMMENT '是否成功',
+    duration_ms BIGINT NOT NULL DEFAULT 0 COMMENT '执行耗时毫秒',
+    row_count INT NOT NULL DEFAULT 0 COMMENT '返回行数',
+    error_message VARCHAR(1000) DEFAULT NULL COMMENT '失败原因',
+    create_time DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) COMMENT '调用时间',
+    PRIMARY KEY (id),
+    KEY idx_yak_ops_data_service_log_api (api_id),
+    KEY idx_yak_ops_data_service_log_time (create_time),
+    KEY idx_yak_ops_data_service_log_success (success)
+) ENGINE=InnoDB
+  DEFAULT CHARSET=utf8mb4
+  COLLATE=utf8mb4_unicode_ci
+  COMMENT='Yak Ops 数据服务调用日志';

--- a/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/dataservice/service/support/DataServiceSqlCompilerTest.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/dataservice/service/support/DataServiceSqlCompilerTest.java
@@ -1,0 +1,47 @@
+package io.yak.ops.business.dataservice.service.support;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class DataServiceSqlCompilerTest {
+
+  private final DataServiceSqlCompiler compiler = new DataServiceSqlCompiler();
+
+  @Test
+  void compilesNamedParametersToJdbcPlaceholders() {
+    DataServiceSqlCompiler.CompiledSql compiled =
+        compiler.compile(
+            "select id, name from sys_user where department = :department and status = :status",
+            Map.of("department", "研发部", "status", "ACTIVE"));
+
+    assertThat(compiled.sql()).contains("department = ?").contains("status = ?");
+    assertThat(compiled.parameters()).containsExactly("研发部", "ACTIVE");
+  }
+
+  @Test
+  void rejectsMissingNamedParameter() {
+    assertThatThrownBy(
+            () -> compiler.compile("select * from sys_user where id = :id", Map.of()))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void rejectsNonSelectAndMultipleStatements() {
+    assertThatThrownBy(() -> compiler.compile("delete from sys_user", Map.of()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("SELECT");
+
+    assertThatThrownBy(() -> compiler.compile("select 1; select 2", Map.of()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("SELECT");
+  }
+
+  @Test
+  void discoversDistinctParameterNames() {
+    assertThat(compiler.parameterNames("select * from t where a = :id or b = :id and c = :name"))
+        .containsExactly("id", "name");
+  }
+}

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-api/src/main/java/io/yak/ops/spi/datasource/execution/DataSourceSqlRequest.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-api/src/main/java/io/yak/ops/spi/datasource/execution/DataSourceSqlRequest.java
@@ -1,10 +1,18 @@
 package io.yak.ops.spi.datasource.execution;
 
+import java.util.List;
+
 /** Immutable SQL execution request shared by task plugins and datasource plugins. */
 public record DataSourceSqlRequest(
     String sql,
     int maxRows,
-    int timeoutSeconds) {
+    int timeoutSeconds,
+    List<Object> parameters) {
+
+  /** Backward-compatible constructor for callers that execute SQL without bind parameters. */
+  public DataSourceSqlRequest(String sql, int maxRows, int timeoutSeconds) {
+    this(sql, maxRows, timeoutSeconds, List.of());
+  }
 
   public DataSourceSqlRequest {
     if (sql == null || sql.isBlank()) {
@@ -17,5 +25,6 @@ public record DataSourceSqlRequest(
     if (timeoutSeconds < 1 || timeoutSeconds > 3_600) {
       throw new IllegalArgumentException("timeoutSeconds must be between 1 and 3600");
     }
+    parameters = parameters == null ? List.of() : List.copyOf(parameters);
   }
 }

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/JdbcDataSourceSqlExecutor.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/JdbcDataSourceSqlExecutor.java
@@ -10,6 +10,7 @@ import java.sql.Blob;
 import java.sql.Clob;
 import java.sql.Connection;
 import java.sql.DriverManager;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLFeatureNotSupportedException;
@@ -57,33 +58,14 @@ public final class JdbcDataSourceSqlExecutor implements DataSourceSqlExecutor {
     }
 
     try {
-      try (Connection opened =
-          connectionProvider.open(connection, connectionTimeoutSeconds)) {
+      try (Connection opened = connectionProvider.open(connection, connectionTimeoutSeconds)) {
         activeConnection.set(opened);
         if (cancelled.get()) {
           throw executionError("SQL 执行已取消", null);
         }
-
-        try (Statement statement = opened.createStatement()) {
-          activeStatement.set(statement);
-          try {
-            statement.setQueryTimeout(request.timeoutSeconds());
-          } catch (SQLFeatureNotSupportedException ignored) {
-            // Some JDBC drivers do not implement query timeout. Cancellation still remains available.
-          }
-          statement.setMaxRows(Math.min(Integer.MAX_VALUE - 1, request.maxRows() + 1));
-
-          boolean hasResultSet = statement.execute(request.sql());
-          if (!hasResultSet) {
-            return DataSourceSqlResult.update(statement.getUpdateCount());
-          }
-
-          try (ResultSet resultSet = statement.getResultSet()) {
-            return readResultSet(resultSet, request.maxRows());
-          }
-        } finally {
-          activeStatement.set(null);
-        }
+        return request.parameters().isEmpty()
+            ? executePlain(opened, request)
+            : executePrepared(opened, request);
       } finally {
         activeConnection.set(null);
       }
@@ -93,6 +75,53 @@ public final class JdbcDataSourceSqlExecutor implements DataSourceSqlExecutor {
       throw executionError("数据库驱动未安装：" + connection.driverClassName(), exception);
     } catch (Exception exception) {
       throw executionError(safeMessage(exception), exception);
+    }
+  }
+
+  private DataSourceSqlResult executePlain(Connection connection, DataSourceSqlRequest request)
+      throws Exception {
+    try (Statement statement = connection.createStatement()) {
+      activeStatement.set(statement);
+      configureStatement(statement, request);
+      boolean hasResultSet = statement.execute(request.sql());
+      return readStatementResult(statement, hasResultSet, request.maxRows());
+    } finally {
+      activeStatement.set(null);
+    }
+  }
+
+  private DataSourceSqlResult executePrepared(Connection connection, DataSourceSqlRequest request)
+      throws Exception {
+    try (PreparedStatement statement = connection.prepareStatement(request.sql())) {
+      activeStatement.set(statement);
+      configureStatement(statement, request);
+      for (int index = 0; index < request.parameters().size(); index++) {
+        statement.setObject(index + 1, request.parameters().get(index));
+      }
+      boolean hasResultSet = statement.execute();
+      return readStatementResult(statement, hasResultSet, request.maxRows());
+    } finally {
+      activeStatement.set(null);
+    }
+  }
+
+  private void configureStatement(Statement statement, DataSourceSqlRequest request)
+      throws Exception {
+    try {
+      statement.setQueryTimeout(request.timeoutSeconds());
+    } catch (SQLFeatureNotSupportedException ignored) {
+      // Some JDBC drivers do not implement query timeout. Cancellation still remains available.
+    }
+    statement.setMaxRows(Math.min(Integer.MAX_VALUE - 1, request.maxRows() + 1));
+  }
+
+  private DataSourceSqlResult readStatementResult(
+      Statement statement, boolean hasResultSet, int maxRows) throws Exception {
+    if (!hasResultSet) {
+      return DataSourceSqlResult.update(statement.getUpdateCount());
+    }
+    try (ResultSet resultSet = statement.getResultSet()) {
+      return readResultSet(resultSet, maxRows);
     }
   }
 
@@ -237,8 +266,7 @@ public final class JdbcDataSourceSqlExecutor implements DataSourceSqlExecutor {
     if (message == null || message.isBlank()) {
       return throwable == null ? "SQL 执行失败" : throwable.getClass().getSimpleName();
     }
-    String sanitized =
-        message.replaceAll("(?i)(password|pwd)=([^;&\\s]+)", "$1=******");
+    String sanitized = message.replaceAll("(?i)(password|pwd)=([^;&\\s]+)", "$1=******");
     return sanitized.length() > 500 ? sanitized.substring(0, 500) : sanitized;
   }
 }

--- a/yak-ops-ui/src/config/navigation.ts
+++ b/yak-ops-ui/src/config/navigation.ts
@@ -32,6 +32,7 @@ export const navigationGroups: readonly NavigationGroup[] = [
   { id: 'resources', title: '资源管理', iconKey: 'database', section: 'management', order: 20 },
   { id: 'data-quality', title: '数据质量', iconKey: 'quality', section: 'management', order: 30 },
   { id: 'data-analysis', title: '数据消费', iconKey: 'insight', section: 'management', order: 40 },
+  { id: 'data-service', title: '数据服务', iconKey: 'api', section: 'management', order: 50 },
   { id: 'system', title: '系统管理', iconKey: 'system', section: 'system', order: 40 },
 ];
 
@@ -42,6 +43,8 @@ export const appRoutes: readonly NavigationRoute[] = [
   { id: 'dashboard-editor', path: '/dashboard/:id', title: '仪表盘编辑', component: './dashboard/editor', hidden: true, parentId: 'dashboard' },
   { id: 'data-analysis-catalog', mode: 'public', path: '/data-analysis/data-catalog', title: '数据目录', component: './data-analysis/data-catalog', iconKey: 'database', menuGroup: 'data-analysis', order: 20 },
   { id: 'data-analysis-chart', path: '/data-analysis/chart-analysis', title: '图表分析', component: './data-analysis/chart-analysis-redirect', hidden: true, parentId: 'dashboard' },
+  { id: 'data-service-api', mode: 'public', path: '/data-service', title: 'API 服务', component: './data-service', iconKey: 'api', menuGroup: 'data-service', order: 10 },
+  { id: 'data-service-logs', mode: 'public', path: '/data-service/logs', title: '调用记录', component: './data-service/logs', iconKey: 'report', menuGroup: 'data-service', order: 20 },
   { id: 'settings', mode: 'public', path: '/settings', title: '设置', component: './settings', hidden: true, order: 30 },
   {
     id: 'batch-link-up', mode: 'one', permission: 'task:batch:read',

--- a/yak-ops-ui/src/pages/data-service/index.tsx
+++ b/yak-ops-ui/src/pages/data-service/index.tsx
@@ -1,0 +1,386 @@
+import {
+  Button,
+  Form,
+  Input,
+  InputNumber,
+  Modal,
+  Popconfirm,
+  Select,
+  Space,
+  Switch,
+  Table,
+  Tag,
+  Tooltip,
+  message,
+  type TableColumnsType,
+} from 'antd';
+import { Copy, Pencil, Play, Plus, RefreshCw, Search, Trash2 } from 'lucide-react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  createDataService,
+  deleteDataService,
+  fetchDataServices,
+  fetchDataSourceOptions,
+  setDataServiceEnabled,
+  testDataService,
+  updateDataService,
+  type DataServiceApi,
+  type DataServiceQueryResult,
+  type DataServiceSavePayload,
+  type DataSourceOption,
+} from './service';
+
+const formatTime = (value?: string) => value ? value.replace('T', ' ').slice(0, 19) : '-';
+
+export default function DataServicePage() {
+  const [services, setServices] = useState<DataServiceApi[]>([]);
+  const [dataSources, setDataSources] = useState<DataSourceOption[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [keyword, setKeyword] = useState('');
+  const [editing, setEditing] = useState<DataServiceApi>();
+  const [editorOpen, setEditorOpen] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [testing, setTesting] = useState<DataServiceApi>();
+  const [testLoading, setTestLoading] = useState(false);
+  const [testResult, setTestResult] = useState<DataServiceQueryResult>();
+  const [form] = Form.useForm<DataServiceSavePayload>();
+  const [testForm] = Form.useForm<Record<string, string>>();
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const [serviceResponse, dataSourceResponse] = await Promise.all([
+        fetchDataServices(),
+        fetchDataSourceOptions(),
+      ]);
+      setServices(serviceResponse.data || []);
+      setDataSources(dataSourceResponse.data || []);
+    } catch (error: any) {
+      message.error(error?.message || '加载数据服务失败');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { void load(); }, [load]);
+
+  const filtered = useMemo(() => {
+    const value = keyword.trim().toLowerCase();
+    if (!value) return services;
+    return services.filter((item) =>
+      [item.name, item.path, item.runtimePath, item.description]
+        .filter(Boolean)
+        .some((text) => String(text).toLowerCase().includes(value)));
+  }, [keyword, services]);
+
+  const openCreate = () => {
+    setEditing(undefined);
+    form.resetFields();
+    form.setFieldsValue({ maxRows: 1000, timeoutSeconds: 30, enabled: false });
+    setEditorOpen(true);
+  };
+
+  const openEdit = (record: DataServiceApi) => {
+    setEditing(record);
+    form.setFieldsValue({
+      name: record.name,
+      path: record.path,
+      dataSourceId: record.dataSourceId,
+      sql: record.sql,
+      maxRows: record.maxRows,
+      timeoutSeconds: record.timeoutSeconds,
+      enabled: record.enabled,
+      description: record.description,
+    });
+    setEditorOpen(true);
+  };
+
+  const save = async () => {
+    const values = await form.validateFields();
+    setSaving(true);
+    try {
+      if (editing) await updateDataService(editing.id, values);
+      else await createDataService(values);
+      message.success(editing ? '数据服务已更新' : '数据服务已创建');
+      setEditorOpen(false);
+      await load();
+    } catch (error: any) {
+      message.error(error?.message || '保存数据服务失败');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const remove = async (id: number) => {
+    try {
+      await deleteDataService(id);
+      message.success('已删除');
+      await load();
+    } catch (error: any) {
+      message.error(error?.message || '删除失败');
+    }
+  };
+
+  const toggleEnabled = async (record: DataServiceApi, enabled: boolean) => {
+    try {
+      await setDataServiceEnabled(record.id, enabled);
+      setServices((items) => items.map((item) =>
+        item.id === record.id ? { ...item, enabled } : item));
+      message.success(enabled ? '服务已启用' : '服务已停用');
+    } catch (error: any) {
+      message.error(error?.message || '状态更新失败');
+    }
+  };
+
+  const openTest = (record: DataServiceApi) => {
+    setTesting(record);
+    setTestResult(undefined);
+    testForm.resetFields();
+  };
+
+  const runTest = async () => {
+    if (!testing) return;
+    const parameters = await testForm.validateFields();
+    setTestLoading(true);
+    try {
+      const response = await testDataService(testing.id, parameters);
+      setTestResult(response.data);
+    } catch (error: any) {
+      message.error(error?.message || '测试调用失败');
+    } finally {
+      setTestLoading(false);
+    }
+  };
+
+  const copyPath = async (path: string) => {
+    try {
+      await navigator.clipboard.writeText(path);
+      message.success('调用路径已复制');
+    } catch {
+      message.warning('复制失败，请手动复制');
+    }
+  };
+
+  const columns: TableColumnsType<DataServiceApi> = [
+    {
+      title: 'API 服务',
+      dataIndex: 'name',
+      minWidth: 260,
+      render: (_, record) => (
+        <div className="py-1">
+          <div className="flex items-center gap-2">
+            <span className="font-medium text-[#161823]">{record.name}</span>
+            <Tag bordered={false}>GET</Tag>
+          </div>
+          <div className="mt-1 flex items-center gap-1 text-xs text-black/45">
+            <span className="font-mono">{record.runtimePath}</span>
+            <Tooltip title="复制调用路径">
+              <Button type="text" size="small" icon={<Copy size={13} />} onClick={() => void copyPath(record.runtimePath)} />
+            </Tooltip>
+          </div>
+        </div>
+      ),
+    },
+    {
+      title: '数据源',
+      dataIndex: 'dataSourceId',
+      width: 190,
+      render: (value) => dataSources.find((item) => String(item.value) === String(value))?.label || `#${value}`,
+    },
+    {
+      title: '参数',
+      dataIndex: 'parameterNames',
+      width: 190,
+      render: (values: string[]) => values?.length
+        ? <span className="text-black/65">{values.map((item) => `:${item}`).join(' · ')}</span>
+        : <span className="text-black/35">无参数</span>,
+    },
+    {
+      title: '运行限制',
+      width: 160,
+      render: (_, record) => (
+        <span className="text-black/55">{record.maxRows} 行 · {record.timeoutSeconds}s</span>
+      ),
+    },
+    {
+      title: '更新时间',
+      dataIndex: 'updateTime',
+      width: 170,
+      render: formatTime,
+    },
+    {
+      title: '状态',
+      dataIndex: 'enabled',
+      width: 100,
+      render: (_, record) => (
+        <Switch size="small" checked={record.enabled} onChange={(checked) => void toggleEnabled(record, checked)} />
+      ),
+    },
+    {
+      title: '操作',
+      key: 'actions',
+      width: 160,
+      fixed: 'right',
+      render: (_, record) => (
+        <Space size={2}>
+          <Tooltip title="测试">
+            <Button type="text" size="small" icon={<Play size={15} />} onClick={() => openTest(record)} />
+          </Tooltip>
+          <Tooltip title="编辑">
+            <Button type="text" size="small" icon={<Pencil size={15} />} onClick={() => openEdit(record)} />
+          </Tooltip>
+          <Popconfirm title="确认删除这个数据服务？" onConfirm={() => void remove(record.id)}>
+            <Tooltip title="删除"><Button type="text" size="small" danger icon={<Trash2 size={15} />} /></Tooltip>
+          </Popconfirm>
+        </Space>
+      ),
+    },
+  ];
+
+  const resultColumns = (testResult?.columns || []).map((name) => ({
+    title: name,
+    dataIndex: name,
+    key: name,
+    minWidth: 140,
+    ellipsis: true,
+  }));
+
+  return (
+    <div className="h-full bg-white px-6 py-5">
+      <div className="mb-5 flex items-start justify-between gap-4">
+        <div>
+          <h1 className="m-0 text-xl font-semibold text-[#161823]">API 服务</h1>
+          <p className="mb-0 mt-1 text-sm text-black/45">将只读 SQL 发布为可调用的 GET REST API。</p>
+        </div>
+        <Button type="primary" icon={<Plus size={16} />} onClick={openCreate}>新建 API</Button>
+      </div>
+
+      <div className="mb-3 flex items-center justify-between gap-3">
+        <Input
+          allowClear
+          value={keyword}
+          onChange={(event) => setKeyword(event.target.value)}
+          prefix={<Search size={15} className="text-black/30" />}
+          placeholder="搜索名称或路径"
+          className="max-w-[320px]"
+        />
+        <Button icon={<RefreshCw size={15} />} onClick={() => void load()}>刷新</Button>
+      </div>
+
+      <Table<DataServiceApi>
+        rowKey="id"
+        size="small"
+        loading={loading}
+        dataSource={filtered}
+        columns={columns}
+        pagination={false}
+        scroll={{ x: 1180 }}
+      />
+
+      <Modal
+        title={editing ? '编辑 API 服务' : '新建 API 服务'}
+        open={editorOpen}
+        onCancel={() => setEditorOpen(false)}
+        onOk={() => void save()}
+        okText="保存"
+        confirmLoading={saving}
+        width={760}
+        destroyOnHidden
+      >
+        <Form form={form} layout="vertical" className="pt-3">
+          <div className="grid grid-cols-2 gap-x-4">
+            <Form.Item name="name" label="服务名称" rules={[{ required: true, message: '请输入服务名称' }]}>
+              <Input placeholder="例如：用户查询 API" />
+            </Form.Item>
+            <Form.Item name="path" label="服务路径" rules={[{ required: true, message: '请输入服务路径' }]}>
+              <Input addonBefore="GET" placeholder="/users" />
+            </Form.Item>
+          </div>
+          <Form.Item name="dataSourceId" label="数据源" rules={[{ required: true, message: '请选择数据源' }]}>
+            <Select
+              showSearch
+              optionFilterProp="label"
+              placeholder="选择已有数据源"
+              options={dataSources.map((item) => ({ ...item, value: Number(item.value) || item.value }))}
+            />
+          </Form.Item>
+          <Form.Item
+            name="sql"
+            label="SELECT SQL"
+            extra="使用 :参数名 声明请求参数，例如 WHERE department = :department。第一阶段仅允许单条 SELECT。"
+            rules={[{ required: true, message: '请输入 SQL' }]}
+          >
+            <Input.TextArea
+              rows={10}
+              spellCheck={false}
+              placeholder={'SELECT id, username\nFROM sys_user\nWHERE department = :department'}
+              style={{ fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace' }}
+            />
+          </Form.Item>
+          <div className="grid grid-cols-3 gap-x-4">
+            <Form.Item name="maxRows" label="最大返回行数" rules={[{ required: true }]}>
+              <InputNumber min={1} max={10000} className="w-full" />
+            </Form.Item>
+            <Form.Item name="timeoutSeconds" label="超时时间（秒）" rules={[{ required: true }]}>
+              <InputNumber min={1} max={3600} className="w-full" />
+            </Form.Item>
+            <Form.Item name="enabled" label="发布状态" valuePropName="checked">
+              <Switch checkedChildren="启用" unCheckedChildren="停用" />
+            </Form.Item>
+          </div>
+          <Form.Item name="description" label="说明">
+            <Input.TextArea rows={2} maxLength={500} placeholder="可选" />
+          </Form.Item>
+        </Form>
+      </Modal>
+
+      <Modal
+        title={testing ? `测试 · ${testing.name}` : '测试 API'}
+        open={Boolean(testing)}
+        onCancel={() => { setTesting(undefined); setTestResult(undefined); }}
+        footer={null}
+        width={900}
+        destroyOnHidden
+      >
+        {testing && (
+          <div className="pt-3">
+            <div className="mb-4 rounded-md bg-black/[0.025] px-3 py-2 font-mono text-sm text-black/65">
+              GET {testing.runtimePath}
+            </div>
+            <Form form={testForm} layout="vertical">
+              {testing.parameterNames.length > 0 ? (
+                <div className="grid grid-cols-2 gap-x-4">
+                  {testing.parameterNames.map((name) => (
+                    <Form.Item key={name} name={name} label={name} rules={[{ required: true, message: `请输入 ${name}` }]}>
+                      <Input placeholder={`:${name}`} />
+                    </Form.Item>
+                  ))}
+                </div>
+              ) : <div className="mb-4 text-sm text-black/40">当前 SQL 没有请求参数。</div>}
+              <Button type="primary" icon={<Play size={15} />} loading={testLoading} onClick={() => void runTest()}>发送请求</Button>
+            </Form>
+
+            {testResult && (
+              <div className="mt-5 border-t border-black/[0.06] pt-4">
+                <div className="mb-3 flex items-center gap-4 text-sm text-black/55">
+                  <span>200 OK</span>
+                  <span>{testResult.durationMs} ms</span>
+                  <span>{testResult.rowCount} 行</span>
+                  {testResult.truncated && <Tag>结果已截断</Tag>}
+                </div>
+                <Table
+                  rowKey={(_, index) => String(index)}
+                  size="small"
+                  dataSource={testResult.rows}
+                  columns={resultColumns}
+                  pagination={false}
+                  scroll={{ x: 'max-content', y: 360 }}
+                />
+              </div>
+            )}
+          </div>
+        )}
+      </Modal>
+    </div>
+  );
+}

--- a/yak-ops-ui/src/pages/data-service/logs/index.tsx
+++ b/yak-ops-ui/src/pages/data-service/logs/index.tsx
@@ -1,0 +1,103 @@
+import { Button, Input, Table, Tag, Tooltip, message, type TableColumnsType } from 'antd';
+import { RefreshCw, Search } from 'lucide-react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { fetchDataServiceLogs, type DataServiceCallLog } from '../service';
+
+const formatTime = (value?: string) => value ? value.replace('T', ' ').slice(0, 19) : '-';
+
+export default function DataServiceLogsPage() {
+  const [logs, setLogs] = useState<DataServiceCallLog[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [keyword, setKeyword] = useState('');
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const response = await fetchDataServiceLogs();
+      setLogs(response.data || []);
+    } catch (error: any) {
+      message.error(error?.message || '加载调用记录失败');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { void load(); }, [load]);
+
+  const filtered = useMemo(() => {
+    const value = keyword.trim().toLowerCase();
+    if (!value) return logs;
+    return logs.filter((item) =>
+      [item.serviceName, item.servicePath, item.paramsJson, item.errorMessage]
+        .filter(Boolean)
+        .some((text) => String(text).toLowerCase().includes(value)));
+  }, [keyword, logs]);
+
+  const columns: TableColumnsType<DataServiceCallLog> = [
+    {
+      title: 'API 服务',
+      dataIndex: 'serviceName',
+      minWidth: 220,
+      render: (_, record) => (
+        <div className="py-1">
+          <div className="font-medium text-[#161823]">{record.serviceName}</div>
+          <div className="mt-1 font-mono text-xs text-black/40">{record.servicePath}</div>
+        </div>
+      ),
+    },
+    {
+      title: '状态',
+      dataIndex: 'success',
+      width: 100,
+      render: (value: boolean) => value
+        ? <Tag bordered={false}>成功</Tag>
+        : <Tag bordered={false}>失败</Tag>,
+    },
+    { title: '耗时', dataIndex: 'durationMs', width: 110, render: (value) => `${value ?? 0} ms` },
+    { title: '返回行数', dataIndex: 'rowCount', width: 110 },
+    {
+      title: '请求参数',
+      dataIndex: 'paramsJson',
+      minWidth: 240,
+      ellipsis: true,
+      render: (value) => <Tooltip title={value}><span className="font-mono text-xs text-black/55">{value || '{}'}</span></Tooltip>,
+    },
+    {
+      title: '错误信息',
+      dataIndex: 'errorMessage',
+      minWidth: 220,
+      ellipsis: true,
+      render: (value) => value ? <Tooltip title={value}><span>{value}</span></Tooltip> : <span className="text-black/25">-</span>,
+    },
+    { title: '调用时间', dataIndex: 'createTime', width: 170, render: formatTime },
+  ];
+
+  return (
+    <div className="h-full bg-white px-6 py-5">
+      <div className="mb-5">
+        <h1 className="m-0 text-xl font-semibold text-[#161823]">调用记录</h1>
+        <p className="mb-0 mt-1 text-sm text-black/45">查看最近 200 次数据服务测试和运行调用。</p>
+      </div>
+      <div className="mb-3 flex items-center justify-between gap-3">
+        <Input
+          allowClear
+          value={keyword}
+          onChange={(event) => setKeyword(event.target.value)}
+          prefix={<Search size={15} className="text-black/30" />}
+          placeholder="搜索服务、路径或错误信息"
+          className="max-w-[320px]"
+        />
+        <Button icon={<RefreshCw size={15} />} onClick={() => void load()}>刷新</Button>
+      </div>
+      <Table<DataServiceCallLog>
+        rowKey="id"
+        size="small"
+        loading={loading}
+        dataSource={filtered}
+        columns={columns}
+        pagination={false}
+        scroll={{ x: 1200, y: 'calc(100vh - 250px)' }}
+      />
+    </div>
+  );
+}

--- a/yak-ops-ui/src/pages/data-service/service.ts
+++ b/yak-ops-ui/src/pages/data-service/service.ts
@@ -1,0 +1,88 @@
+import HttpUtils from '@/utils/HttpUtils';
+
+export interface CommonApiResponse<T> {
+  code: number;
+  data: T;
+  msg?: string;
+  message?: string;
+}
+
+export interface DataSourceOption {
+  label: string;
+  value: string;
+  dbType?: string;
+}
+
+export interface DataServiceApi {
+  id: number;
+  name: string;
+  path: string;
+  runtimePath: string;
+  dataSourceId: number;
+  sql: string;
+  parameterNames: string[];
+  maxRows: number;
+  timeoutSeconds: number;
+  enabled: boolean;
+  description?: string;
+  createTime?: string;
+  updateTime?: string;
+}
+
+export interface DataServiceSavePayload {
+  name: string;
+  path: string;
+  dataSourceId: number;
+  sql: string;
+  maxRows?: number;
+  timeoutSeconds?: number;
+  enabled?: boolean;
+  description?: string;
+}
+
+export interface DataServiceQueryResult {
+  columns: string[];
+  rows: Record<string, unknown>[];
+  truncated: boolean;
+  rowCount: number;
+  durationMs: number;
+}
+
+export interface DataServiceCallLog {
+  id: number;
+  apiId: number;
+  serviceName: string;
+  servicePath: string;
+  paramsJson?: string;
+  success: boolean;
+  durationMs: number;
+  rowCount: number;
+  errorMessage?: string;
+  createTime?: string;
+}
+
+const PREFIX = '/api/v1/data-service';
+
+export const fetchDataServices = () =>
+  HttpUtils.get<DataServiceApi[]>(PREFIX) as Promise<CommonApiResponse<DataServiceApi[]>>;
+
+export const createDataService = (payload: DataServiceSavePayload) =>
+  HttpUtils.post<DataServiceApi>(PREFIX, payload) as Promise<CommonApiResponse<DataServiceApi>>;
+
+export const updateDataService = (id: number, payload: DataServiceSavePayload) =>
+  HttpUtils.put<DataServiceApi>(`${PREFIX}/${id}`, payload) as Promise<CommonApiResponse<DataServiceApi>>;
+
+export const deleteDataService = (id: number) =>
+  HttpUtils.delete<boolean>(`${PREFIX}/${id}`) as Promise<CommonApiResponse<boolean>>;
+
+export const setDataServiceEnabled = (id: number, enabled: boolean) =>
+  HttpUtils.put<DataServiceApi>(`${PREFIX}/${id}/enabled?enabled=${enabled}`, {}) as Promise<CommonApiResponse<DataServiceApi>>;
+
+export const testDataService = (id: number, parameters: Record<string, string>) =>
+  HttpUtils.post<DataServiceQueryResult>(`${PREFIX}/${id}/test`, parameters) as Promise<CommonApiResponse<DataServiceQueryResult>>;
+
+export const fetchDataServiceLogs = () =>
+  HttpUtils.get<DataServiceCallLog[]>(`${PREFIX}/logs/recent`) as Promise<CommonApiResponse<DataServiceCallLog[]>>;
+
+export const fetchDataSourceOptions = () =>
+  HttpUtils.get<DataSourceOption[]>('/api/v1/data-source/option') as Promise<CommonApiResponse<DataSourceOption[]>>;


### PR DESCRIPTION
## Summary

Introduce Phase 1 of Yak Ops Data Service: publish read-only SQL as a GET REST endpoint while reusing the existing datasource plugin/runtime.

## Included

- API service definition CRUD and enable/disable
- Reuse existing `dataSourceId`; no secondary connection configuration
- SELECT-only validation with JSqlParser
- `:name` named parameters compiled to JDBC placeholders
- Backward-compatible bound-parameter support in `DataSourceSqlRequest`
- JDBC `PreparedStatement` execution for parameterized queries
- Reuse existing datasource executor controls for max rows and query timeout
- Runtime endpoint under `/api/v1/data-service/runtime/**`
- Online test endpoint and UI
- Recent call logs with success state, duration, row count, parameters and errors
- `API 服务` / `调用记录` frontend pages and navigation
- Flyway migration and SQL compiler tests

## Example

SQL:

```sql
SELECT id, username, department
FROM sys_user
WHERE department = :department
```

Runtime:

```text
GET /api/v1/data-service/runtime/users?department=研发部
```

## Scope intentionally deferred

- API key / dedicated authentication policy
- Rate limiting / cache / circuit breaking
- Arbitrary top-level public route publishing / gateway
- API versions / OpenAPI SDK
- Data Development `发布为数据服务`
- MCP

## Architecture note

Phase 1 lives in the existing datasource business module under a separate `dataservice` package. This keeps the first implementation small while directly reusing Yak Ops datasource resolution and plugin execution, instead of introducing a second connection layer. A dedicated Maven module can be extracted later when the data-service boundary grows.

## Validation

- Added `DataServiceSqlCompilerTest` for named parameters, missing parameters and SELECT-only constraints
- Performed branch diff/static review to ensure changes are scoped to Phase 1
- Full local Maven/UI build was not run because this execution environment cannot clone the repository through its network proxy. PR CI should be treated as the source of truth for full compilation/test status.
