### PR TITLE
feat(data-service): add resilient high-performance runtime

### DIFF
--- a/yak-ops-business/yak-ops-business-datasource/pom.xml
+++ b/yak-ops-business/yak-ops-business-datasource/pom.xml
@@ -52,6 +52,10 @@
             <artifactId>mybatis-plus-jsqlparser-4.9</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
         </dependency>

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/dataservice/controller/v1/DataServiceController.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/dataservice/controller/v1/DataServiceController.java
@@ -9,10 +9,12 @@ import io.yak.ops.business.dataservice.service.DataServiceAccessService.ApiKeyIn
 import io.yak.ops.business.dataservice.service.DataServiceAccessService.ApiKeyUpdate;
 import io.yak.ops.business.dataservice.service.DataServiceAccessService.ApiKeyView;
 import io.yak.ops.business.dataservice.service.DataServiceAccessService.CreatedApiKey;
+import io.yak.ops.business.dataservice.service.DataServiceRuntimeService.RuntimeSnapshot;
 import io.yak.ops.business.dataservice.service.DataServiceService;
 import io.yak.ops.business.dataservice.service.DataServiceService.ApiInput;
 import io.yak.ops.business.dataservice.service.DataServiceService.ApiView;
 import io.yak.ops.business.dataservice.service.DataServiceService.QueryResponse;
+import io.yak.ops.business.dataservice.service.DataServiceService.RuntimeConfigInput;
 import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
 import java.util.List;
 import java.util.Map;
@@ -28,7 +30,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-/** 数据服务管理、访问控制与 Runtime 接口。 */
+/** 数据服务管理、访问控制、Runtime 策略与调用接口。 */
 @Tag(name = "数据服务")
 @RestController
 @ConditionalOnDataSourceEnabled
@@ -76,6 +78,20 @@ public class DataServiceController {
       @PathVariable("id") Long id,
       @RequestParam("enabled") boolean enabled) {
     return Result.success(dataServiceService.setEnabled(id, enabled));
+  }
+
+  @Operation(summary = "查询数据服务 Runtime 状态与指标")
+  @GetMapping("/{id}/runtime")
+  public Result<RuntimeSnapshot> runtimeStatus(@PathVariable("id") Long id) {
+    return Result.success(dataServiceService.runtimeStatus(id));
+  }
+
+  @Operation(summary = "更新数据服务 Runtime 缓存与熔断策略")
+  @PutMapping("/{id}/runtime")
+  public Result<RuntimeSnapshot> updateRuntime(
+      @PathVariable("id") Long id,
+      @RequestBody RuntimeConfigInput input) {
+    return Result.success(dataServiceService.updateRuntimeConfig(id, input));
   }
 
   @Operation(summary = "设置数据服务访问控制模式")

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/dataservice/dao/model/DataServiceApiPO.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/dataservice/dao/model/DataServiceApiPO.java
@@ -21,6 +21,12 @@ public class DataServiceApiPO {
   private Integer timeoutSeconds;
   private Boolean enabled;
   private String authMode;
+  private Boolean cacheEnabled;
+  private Integer cacheTtlSeconds;
+  private Integer cacheMaxEntries;
+  private Boolean circuitBreakerEnabled;
+  private Integer circuitFailureThreshold;
+  private Integer circuitRecoverySeconds;
   private String description;
   private String sourceType;
   private String sourceRef;

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/dataservice/service/DataServiceCircuitOpenException.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/dataservice/service/DataServiceCircuitOpenException.java
@@ -1,0 +1,13 @@
+package io.yak.ops.business.dataservice.service;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/** Raised when a Data Service circuit breaker is open and the datasource is temporarily protected. */
+@ResponseStatus(HttpStatus.SERVICE_UNAVAILABLE)
+public class DataServiceCircuitOpenException extends RuntimeException {
+
+  public DataServiceCircuitOpenException(String message) {
+    super(message);
+  }
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/dataservice/service/DataServiceRuntimeService.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/dataservice/service/DataServiceRuntimeService.java
@@ -15,6 +15,7 @@ import java.util.HexFormat;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
 import org.springframework.stereotype.Service;
@@ -55,14 +56,37 @@ public class DataServiceRuntimeService {
     RuntimeState state = states.computeIfAbsent(api.getId(), ignored -> new RuntimeState());
     state.ensurePolicy(policy);
 
-    if (policy.cacheEnabled()) {
-      QueryResponse cached = state.cache().getIfPresent(cacheKey);
-      if (cached != null) {
-        state.metrics.recordSuccess(0L, true, clock.instant());
-        return copyWithDuration(cached, 0L);
-      }
+    if (!policy.cacheEnabled()) {
+      return executeProtected(state, policy, loader);
     }
 
+    long requestStarted = System.nanoTime();
+    QueryResponse cached = state.cache().getIfPresent(cacheKey);
+    if (cached != null) {
+      long durationMs = elapsedMs(requestStarted);
+      state.metrics.recordSuccess(durationMs, true, clock.instant());
+      return copyWithDuration(cached, durationMs);
+    }
+
+    // Caffeine get(key, loader) coalesces concurrent misses for the same parameter set. Only the
+    // thread whose mapping function actually runs reaches the datasource; followers reuse that value.
+    AtomicBoolean loadedByThisCall = new AtomicBoolean(false);
+    QueryResponse response = state.cache().get(cacheKey, ignored -> {
+      loadedByThisCall.set(true);
+      return executeProtected(state, policy, loader);
+    });
+    if (!loadedByThisCall.get()) {
+      long durationMs = elapsedMs(requestStarted);
+      state.metrics.recordSuccess(durationMs, true, clock.instant());
+      return copyWithDuration(response, durationMs);
+    }
+    return response;
+  }
+
+  private QueryResponse executeProtected(
+      RuntimeState state,
+      RuntimePolicy policy,
+      Supplier<QueryResponse> loader) {
     CircuitDecision decision = state.circuit.beforeCall(policy, clock.instant());
     if (!decision.allowed()) {
       state.metrics.recordCircuitRejected(clock.instant());
@@ -76,9 +100,6 @@ public class DataServiceRuntimeService {
       long durationMs = elapsedMs(started);
       state.circuit.onSuccess();
       state.metrics.recordSuccess(durationMs, false, clock.instant());
-      if (policy.cacheEnabled()) {
-        state.cache().put(cacheKey, copyWithDuration(response, durationMs));
-      }
       return copyWithDuration(response, durationMs);
     } catch (RuntimeException exception) {
       long durationMs = elapsedMs(started);

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/dataservice/service/DataServiceRuntimeService.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/dataservice/service/DataServiceRuntimeService.java
@@ -1,0 +1,372 @@
+package io.yak.ops.business.dataservice.service;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import io.yak.ops.business.dataservice.dao.model.DataServiceApiPO;
+import io.yak.ops.business.dataservice.service.DataServiceService.QueryResponse;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
+import org.springframework.stereotype.Service;
+
+/**
+ * Lightweight single-node Runtime resilience layer.
+ *
+ * <p>It deliberately stays local to the process: bounded result cache, per-service circuit breaker and
+ * rolling runtime metrics. The API boundary is intentionally small so these implementations can later
+ * be replaced by Redis/gateway/metrics backends without changing Data Service publication semantics.
+ */
+@Service
+public class DataServiceRuntimeService {
+
+  private static final int DEFAULT_CACHE_TTL_SECONDS = 60;
+  private static final int DEFAULT_CACHE_MAX_ENTRIES = 200;
+  private static final int DEFAULT_FAILURE_THRESHOLD = 5;
+  private static final int DEFAULT_RECOVERY_SECONDS = 30;
+  private static final int DURATION_SAMPLE_SIZE = 256;
+
+  private final Clock clock;
+  private final ConcurrentHashMap<Long, RuntimeState> states = new ConcurrentHashMap<>();
+
+  public DataServiceRuntimeService() {
+    this(Clock.systemUTC());
+  }
+
+  DataServiceRuntimeService(Clock clock) {
+    this.clock = Objects.requireNonNull(clock, "clock");
+  }
+
+  public QueryResponse execute(
+      DataServiceApiPO api,
+      String cacheKey,
+      Supplier<QueryResponse> loader) {
+    if (api == null || api.getId() == null) throw new IllegalArgumentException("数据服务 Runtime 缺少 API ID");
+    RuntimePolicy policy = policy(api);
+    RuntimeState state = states.computeIfAbsent(api.getId(), ignored -> new RuntimeState());
+    state.ensurePolicy(policy);
+
+    if (policy.cacheEnabled()) {
+      QueryResponse cached = state.cache().getIfPresent(cacheKey);
+      if (cached != null) {
+        state.metrics.recordSuccess(0L, true, clock.instant());
+        return copyWithDuration(cached, 0L);
+      }
+    }
+
+    CircuitDecision decision = state.circuit.beforeCall(policy, clock.instant());
+    if (!decision.allowed()) {
+      state.metrics.recordCircuitRejected(clock.instant());
+      throw new DataServiceCircuitOpenException(
+          "数据服务下游暂时不可用，熔断保护中，请在 " + decision.retryAfterSeconds() + " 秒后重试");
+    }
+
+    long started = System.nanoTime();
+    try {
+      QueryResponse response = loader.get();
+      long durationMs = elapsedMs(started);
+      state.circuit.onSuccess();
+      state.metrics.recordSuccess(durationMs, false, clock.instant());
+      if (policy.cacheEnabled()) {
+        state.cache().put(cacheKey, copyWithDuration(response, durationMs));
+      }
+      return copyWithDuration(response, durationMs);
+    } catch (RuntimeException exception) {
+      long durationMs = elapsedMs(started);
+      state.circuit.onFailure(policy, clock.instant());
+      state.metrics.recordFailure(durationMs, clock.instant());
+      throw exception;
+    }
+  }
+
+  /** Builds a stable cache key from the executable SQL snapshot and ordered JDBC bindings. */
+  public String cacheKey(String compiledSql, List<Object> bindings) {
+    StringBuilder raw = new StringBuilder(compiledSql == null ? "" : compiledSql).append('\u001f');
+    if (bindings != null) {
+      for (Object value : bindings) {
+        raw.append(value == null ? "<null>" : value.getClass().getName() + ':' + value).append('\u001e');
+      }
+    }
+    try {
+      MessageDigest digest = MessageDigest.getInstance("SHA-256");
+      return HexFormat.of().formatHex(digest.digest(raw.toString().getBytes(StandardCharsets.UTF_8)));
+    } catch (Exception exception) {
+      throw new IllegalStateException("无法生成数据服务缓存 Key", exception);
+    }
+  }
+
+  public RuntimeSnapshot snapshot(DataServiceApiPO api) {
+    RuntimePolicy policy = policy(api);
+    RuntimeState state = states.computeIfAbsent(api.getId(), ignored -> new RuntimeState());
+    state.ensurePolicy(policy);
+    return state.snapshot(api.getId(), policy, clock.instant());
+  }
+
+  /** Invalidates query cache/circuit state while keeping process-lifetime metrics for observability. */
+  public void invalidate(Long apiId) {
+    RuntimeState state = apiId == null ? null : states.get(apiId);
+    if (state != null) state.invalidateOperationalState();
+  }
+
+  public void remove(Long apiId) {
+    if (apiId != null) states.remove(apiId);
+  }
+
+  private RuntimePolicy policy(DataServiceApiPO api) {
+    return new RuntimePolicy(
+        Boolean.TRUE.equals(api.getCacheEnabled()),
+        positive(api.getCacheTtlSeconds(), DEFAULT_CACHE_TTL_SECONDS),
+        positive(api.getCacheMaxEntries(), DEFAULT_CACHE_MAX_ENTRIES),
+        Boolean.TRUE.equals(api.getCircuitBreakerEnabled()),
+        positive(api.getCircuitFailureThreshold(), DEFAULT_FAILURE_THRESHOLD),
+        positive(api.getCircuitRecoverySeconds(), DEFAULT_RECOVERY_SECONDS));
+  }
+
+  private int positive(Integer value, int fallback) {
+    return value == null || value <= 0 ? fallback : value;
+  }
+
+  private QueryResponse copyWithDuration(QueryResponse response, long durationMs) {
+    return new QueryResponse(
+        response.columns(), response.rows(), response.truncated(), response.rowCount(), durationMs);
+  }
+
+  private long elapsedMs(long started) {
+    return Math.max(0L, (System.nanoTime() - started) / 1_000_000L);
+  }
+
+  public record RuntimePolicy(
+      boolean cacheEnabled,
+      int cacheTtlSeconds,
+      int cacheMaxEntries,
+      boolean circuitBreakerEnabled,
+      int failureThreshold,
+      int recoverySeconds) {}
+
+  public record RuntimeSnapshot(
+      Long apiId,
+      boolean cacheEnabled,
+      int cacheTtlSeconds,
+      int cacheMaxEntries,
+      long cacheEntries,
+      boolean circuitBreakerEnabled,
+      int failureThreshold,
+      int recoverySeconds,
+      String circuitState,
+      Instant circuitOpenUntil,
+      long totalCalls,
+      long successCalls,
+      long failureCalls,
+      long cacheHits,
+      long circuitRejected,
+      double successRate,
+      double cacheHitRate,
+      long averageDurationMs,
+      long p95DurationMs,
+      Instant lastSuccessAt,
+      Instant lastFailureAt) {}
+
+  private static final class RuntimeState {
+
+    private volatile RuntimePolicy policy;
+    private volatile Cache<String, QueryResponse> cache;
+    private final CircuitBreaker circuit = new CircuitBreaker();
+    private final RuntimeMetrics metrics = new RuntimeMetrics();
+
+    synchronized void ensurePolicy(RuntimePolicy next) {
+      if (Objects.equals(policy, next) && cache != null) return;
+      RuntimePolicy previous = policy;
+      policy = next;
+      if (cache != null) cache.invalidateAll();
+      cache = Caffeine.newBuilder()
+          .maximumSize(next.cacheMaxEntries())
+          .expireAfterWrite(Duration.ofSeconds(next.cacheTtlSeconds()))
+          .build();
+      if (previous != null
+          && (previous.circuitBreakerEnabled() != next.circuitBreakerEnabled()
+              || previous.failureThreshold() != next.failureThreshold()
+              || previous.recoverySeconds() != next.recoverySeconds())) {
+        circuit.reset();
+      }
+    }
+
+    Cache<String, QueryResponse> cache() {
+      return cache;
+    }
+
+    synchronized void invalidateOperationalState() {
+      if (cache != null) cache.invalidateAll();
+      circuit.reset();
+    }
+
+    RuntimeSnapshot snapshot(Long apiId, RuntimePolicy policy, Instant now) {
+      RuntimeMetrics.MetricSnapshot metric = metrics.snapshot();
+      CircuitBreaker.CircuitSnapshot breaker = circuit.snapshot(policy, now);
+      long entries = cache == null ? 0L : cache.estimatedSize();
+      return new RuntimeSnapshot(
+          apiId,
+          policy.cacheEnabled(),
+          policy.cacheTtlSeconds(),
+          policy.cacheMaxEntries(),
+          entries,
+          policy.circuitBreakerEnabled(),
+          policy.failureThreshold(),
+          policy.recoverySeconds(),
+          breaker.state(),
+          breaker.openUntil(),
+          metric.totalCalls(),
+          metric.successCalls(),
+          metric.failureCalls(),
+          metric.cacheHits(),
+          metric.circuitRejected(),
+          metric.successRate(),
+          metric.cacheHitRate(),
+          metric.averageDurationMs(),
+          metric.p95DurationMs(),
+          metric.lastSuccessAt(),
+          metric.lastFailureAt());
+    }
+  }
+
+  private static final class CircuitBreaker {
+
+    private int consecutiveFailures;
+    private Instant openUntil;
+    private boolean halfOpenProbeInFlight;
+
+    synchronized CircuitDecision beforeCall(RuntimePolicy policy, Instant now) {
+      if (!policy.circuitBreakerEnabled()) return new CircuitDecision(true, 0L);
+      if (openUntil == null) return new CircuitDecision(true, 0L);
+      if (now.isBefore(openUntil)) {
+        return new CircuitDecision(false, Math.max(1L, Duration.between(now, openUntil).toSeconds()));
+      }
+      if (halfOpenProbeInFlight) return new CircuitDecision(false, 1L);
+      halfOpenProbeInFlight = true;
+      return new CircuitDecision(true, 0L);
+    }
+
+    synchronized void onSuccess() {
+      consecutiveFailures = 0;
+      openUntil = null;
+      halfOpenProbeInFlight = false;
+    }
+
+    synchronized void onFailure(RuntimePolicy policy, Instant now) {
+      if (!policy.circuitBreakerEnabled()) return;
+      halfOpenProbeInFlight = false;
+      consecutiveFailures++;
+      if (openUntil != null || consecutiveFailures >= policy.failureThreshold()) {
+        openUntil = now.plusSeconds(policy.recoverySeconds());
+      }
+    }
+
+    synchronized void reset() {
+      consecutiveFailures = 0;
+      openUntil = null;
+      halfOpenProbeInFlight = false;
+    }
+
+    synchronized CircuitSnapshot snapshot(RuntimePolicy policy, Instant now) {
+      if (!policy.circuitBreakerEnabled()) return new CircuitSnapshot("DISABLED", null);
+      if (openUntil == null) return new CircuitSnapshot("CLOSED", null);
+      if (now.isBefore(openUntil)) return new CircuitSnapshot("OPEN", openUntil);
+      return new CircuitSnapshot("HALF_OPEN", openUntil);
+    }
+
+    record CircuitSnapshot(String state, Instant openUntil) {}
+  }
+
+  private static final class RuntimeMetrics {
+
+    private final AtomicLong totalCalls = new AtomicLong();
+    private final AtomicLong successCalls = new AtomicLong();
+    private final AtomicLong failureCalls = new AtomicLong();
+    private final AtomicLong cacheHits = new AtomicLong();
+    private final AtomicLong circuitRejected = new AtomicLong();
+    private final AtomicLong totalDurationMs = new AtomicLong();
+    private final ArrayDeque<Long> durations = new ArrayDeque<>();
+    private volatile Instant lastSuccessAt;
+    private volatile Instant lastFailureAt;
+
+    void recordSuccess(long durationMs, boolean cacheHit, Instant now) {
+      totalCalls.incrementAndGet();
+      successCalls.incrementAndGet();
+      if (cacheHit) cacheHits.incrementAndGet();
+      totalDurationMs.addAndGet(Math.max(0L, durationMs));
+      lastSuccessAt = now;
+      addDuration(durationMs);
+    }
+
+    void recordFailure(long durationMs, Instant now) {
+      totalCalls.incrementAndGet();
+      failureCalls.incrementAndGet();
+      totalDurationMs.addAndGet(Math.max(0L, durationMs));
+      lastFailureAt = now;
+      addDuration(durationMs);
+    }
+
+    void recordCircuitRejected(Instant now) {
+      totalCalls.incrementAndGet();
+      failureCalls.incrementAndGet();
+      circuitRejected.incrementAndGet();
+      lastFailureAt = now;
+      addDuration(0L);
+    }
+
+    private synchronized void addDuration(long durationMs) {
+      if (durations.size() >= DURATION_SAMPLE_SIZE) durations.removeFirst();
+      durations.addLast(Math.max(0L, durationMs));
+    }
+
+    synchronized MetricSnapshot snapshot() {
+      long total = totalCalls.get();
+      long success = successCalls.get();
+      long failures = failureCalls.get();
+      long hits = cacheHits.get();
+      List<Long> sorted = new ArrayList<>(durations);
+      sorted.sort(Long::compareTo);
+      long p95 = sorted.isEmpty()
+          ? 0L
+          : sorted.get(Math.min(sorted.size() - 1, (int) Math.ceil(sorted.size() * 0.95) - 1));
+      long average = total == 0 ? 0L : totalDurationMs.get() / total;
+      double successRate = total == 0 ? 1D : (double) success / total;
+      double cacheHitRate = total == 0 ? 0D : (double) hits / total;
+      return new MetricSnapshot(
+          total,
+          success,
+          failures,
+          hits,
+          circuitRejected.get(),
+          successRate,
+          cacheHitRate,
+          average,
+          p95,
+          lastSuccessAt,
+          lastFailureAt);
+    }
+
+    record MetricSnapshot(
+        long totalCalls,
+        long successCalls,
+        long failureCalls,
+        long cacheHits,
+        long circuitRejected,
+        double successRate,
+        double cacheHitRate,
+        long averageDurationMs,
+        long p95DurationMs,
+        Instant lastSuccessAt,
+        Instant lastFailureAt) {}
+  }
+
+  private record CircuitDecision(boolean allowed, long retryAfterSeconds) {}
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/dataservice/service/DataServiceService.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/dataservice/service/DataServiceService.java
@@ -7,6 +7,7 @@ import io.yak.ops.business.dataservice.dao.mapper.DataServiceCallLogMapper;
 import io.yak.ops.business.dataservice.dao.model.DataServiceApiPO;
 import io.yak.ops.business.dataservice.dao.model.DataServiceCallLogPO;
 import io.yak.ops.business.dataservice.service.DataServiceAccessService.AccessContext;
+import io.yak.ops.business.dataservice.service.DataServiceRuntimeService.RuntimeSnapshot;
 import io.yak.ops.business.dataservice.service.support.DataServiceSqlCompiler;
 import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
 import io.yak.ops.business.datasource.service.support.BusinessDataSourceExecutionProvider;
@@ -34,6 +35,10 @@ public class DataServiceService {
 
   private static final int DEFAULT_MAX_ROWS = 1_000;
   private static final int DEFAULT_TIMEOUT_SECONDS = 30;
+  private static final int DEFAULT_CACHE_TTL_SECONDS = 60;
+  private static final int DEFAULT_CACHE_MAX_ENTRIES = 200;
+  private static final int DEFAULT_CIRCUIT_FAILURE_THRESHOLD = 5;
+  private static final int DEFAULT_CIRCUIT_RECOVERY_SECONDS = 30;
   private static final String RUNTIME_PREFIX = "/api/v1/data-service/runtime";
 
   private final DataServiceApiMapper apiMapper;
@@ -42,6 +47,7 @@ public class DataServiceService {
   private final DataServiceSqlCompiler sqlCompiler;
   private final ObjectMapper objectMapper;
   private final DataServiceAccessService accessService;
+  private final DataServiceRuntimeService runtimeService;
 
   public List<ApiView> list() {
     return apiMapper.selectList(
@@ -76,8 +82,8 @@ public class DataServiceService {
    * Creates or updates the stable Data Service bound to one upstream asset.
    *
    * <p>The executable SQL/dataSource values are copied into the service definition, so runtime calls
-   * remain a snapshot and never follow mutable authoring state implicitly. Access-control settings are
-   * intentionally preserved across source refreshes.
+   * remain a snapshot and never follow mutable authoring state implicitly. Access-control and Runtime
+   * policies are intentionally preserved across source refreshes.
    */
   @Transactional
   public ApiView saveFromSource(SourceSnapshot source, ApiInput input) {
@@ -92,6 +98,7 @@ public class DataServiceService {
     api.setSourceRevisionNo(normalized.sourceRevisionNo());
     api.setUpdateTime(LocalDateTime.now());
     apiMapper.updateById(api);
+    runtimeService.invalidate(api.getId());
     return toView(api);
   }
 
@@ -102,6 +109,7 @@ public class DataServiceService {
     if (apiMapper.deleteById(id) == 0) {
       throw new IllegalArgumentException("数据服务不存在：" + id);
     }
+    runtimeService.remove(id);
   }
 
   @Transactional
@@ -110,12 +118,33 @@ public class DataServiceService {
     api.setEnabled(enabled);
     api.setUpdateTime(LocalDateTime.now());
     apiMapper.updateById(api);
+    if (!enabled) runtimeService.invalidate(id);
     return toView(api);
   }
 
-  /** Console tests bypass external API-Key auth, but are still marked distinctly in the audit log. */
+  public RuntimeSnapshot runtimeStatus(Long id) {
+    return runtimeService.snapshot(requireApi(id));
+  }
+
+  @Transactional
+  public RuntimeSnapshot updateRuntimeConfig(Long id, RuntimeConfigInput input) {
+    DataServiceApiPO api = requireApi(id);
+    RuntimeConfigInput normalized = normalizeRuntimeConfig(input);
+    api.setCacheEnabled(normalized.cacheEnabled());
+    api.setCacheTtlSeconds(normalized.cacheTtlSeconds());
+    api.setCacheMaxEntries(normalized.cacheMaxEntries());
+    api.setCircuitBreakerEnabled(normalized.circuitBreakerEnabled());
+    api.setCircuitFailureThreshold(normalized.failureThreshold());
+    api.setCircuitRecoverySeconds(normalized.recoverySeconds());
+    api.setUpdateTime(LocalDateTime.now());
+    apiMapper.updateById(api);
+    runtimeService.invalidate(id);
+    return runtimeService.snapshot(api);
+  }
+
+  /** Console tests intentionally bypass external cache/circuit behavior to validate the live datasource. */
   public QueryResponse test(Long id, Map<String, String> parameters) {
-    return execute(requireApi(id), parameters, true, AccessContext.console());
+    return execute(requireApi(id), parameters, true, AccessContext.console(), false);
   }
 
   /** Backward-compatible call path; API_KEY services will reject because no key is supplied. */
@@ -153,7 +182,7 @@ public class DataServiceService {
           AccessContext.rejectedApiKey());
       throw exception;
     }
-    return execute(api, parameters, true, access);
+    return execute(api, parameters, true, access, true);
   }
 
   public List<DataServiceCallLogPO> logs() {
@@ -176,7 +205,8 @@ public class DataServiceService {
     }
 
     LocalDateTime now = LocalDateTime.now();
-    DataServiceApiPO api = id == null ? new DataServiceApiPO() : requireApi(id);
+    boolean creating = id == null;
+    DataServiceApiPO api = creating ? new DataServiceApiPO() : requireApi(id);
     if (!sourceRefresh && StringUtils.hasText(api.getSourceType())) {
       String sql = input.sql().trim();
       if (!Objects.equals(api.getDataSourceId(), input.dataSourceId())
@@ -194,14 +224,16 @@ public class DataServiceService {
     api.setTimeoutSeconds(normalizeTimeout(input.timeoutSeconds()));
     api.setEnabled(input.enabled() == null ? Boolean.FALSE : input.enabled());
     if (!StringUtils.hasText(api.getAuthMode())) api.setAuthMode("NONE");
+    initializeRuntimeDefaults(api, creating);
     api.setDescription(StringUtils.hasText(input.description()) ? input.description().trim() : null);
     api.setUpdateTime(now);
-    if (id == null) {
+    if (creating) {
       api.setCreateTime(now);
       apiMapper.insert(api);
     } else {
       apiMapper.updateById(api);
     }
+    runtimeService.invalidate(api.getId());
     return toView(api);
   }
 
@@ -209,28 +241,43 @@ public class DataServiceService {
       DataServiceApiPO api,
       Map<String, String> parameters,
       boolean writeLog,
-      AccessContext access) {
+      AccessContext access,
+      boolean resilientRuntime) {
     long started = System.nanoTime();
     try {
       DataServiceSqlCompiler.CompiledSql compiled = sqlCompiler.compile(api.getSqlText(), parameters);
-      DataSourceSqlResult result;
-      try (DataSourceSqlExecutor executor = executionProvider.open(String.valueOf(api.getDataSourceId()))) {
-        result = executor.execute(
-            new DataSourceSqlRequest(
-                compiled.sql(), api.getMaxRows(), api.getTimeoutSeconds(), compiled.parameters()));
+      QueryResponse response;
+      if (resilientRuntime) {
+        String cacheKey = runtimeService.cacheKey(compiled.sql(), compiled.parameters());
+        response = runtimeService.execute(api, cacheKey, () -> executeDatabase(api, compiled));
+      } else {
+        response = executeDatabase(api, compiled);
       }
-      if (!result.resultSet()) {
-        throw new IllegalStateException("数据服务仅允许返回 SELECT 查询结果");
+      if (writeLog) {
+        saveLog(api, parameters, true, response.durationMs(), response.rowCount(), null, access);
       }
-      long durationMs = elapsedMs(started);
-      QueryResponse response = toResponse(result, durationMs);
-      if (writeLog) saveLog(api, parameters, true, durationMs, response.rowCount(), null, access);
       return response;
     } catch (RuntimeException exception) {
       long durationMs = elapsedMs(started);
       if (writeLog) saveLog(api, parameters, false, durationMs, 0, safeMessage(exception), access);
       throw exception;
     }
+  }
+
+  private QueryResponse executeDatabase(
+      DataServiceApiPO api,
+      DataServiceSqlCompiler.CompiledSql compiled) {
+    long started = System.nanoTime();
+    DataSourceSqlResult result;
+    try (DataSourceSqlExecutor executor = executionProvider.open(String.valueOf(api.getDataSourceId()))) {
+      result = executor.execute(
+          new DataSourceSqlRequest(
+              compiled.sql(), api.getMaxRows(), api.getTimeoutSeconds(), compiled.parameters()));
+    }
+    if (!result.resultSet()) {
+      throw new IllegalStateException("数据服务仅允许返回 SELECT 查询结果");
+    }
+    return toResponse(result, elapsedMs(started));
   }
 
   private QueryResponse toResponse(DataSourceSqlResult result, long durationMs) {
@@ -299,6 +346,41 @@ public class DataServiceService {
     normalizePath(input.path());
     normalizeMaxRows(input.maxRows());
     normalizeTimeout(input.timeoutSeconds());
+  }
+
+  private void initializeRuntimeDefaults(DataServiceApiPO api, boolean creating) {
+    if (api.getCacheEnabled() == null) api.setCacheEnabled(Boolean.FALSE);
+    if (api.getCacheTtlSeconds() == null) api.setCacheTtlSeconds(DEFAULT_CACHE_TTL_SECONDS);
+    if (api.getCacheMaxEntries() == null) api.setCacheMaxEntries(DEFAULT_CACHE_MAX_ENTRIES);
+    if (api.getCircuitBreakerEnabled() == null) api.setCircuitBreakerEnabled(creating);
+    if (api.getCircuitFailureThreshold() == null) {
+      api.setCircuitFailureThreshold(DEFAULT_CIRCUIT_FAILURE_THRESHOLD);
+    }
+    if (api.getCircuitRecoverySeconds() == null) {
+      api.setCircuitRecoverySeconds(DEFAULT_CIRCUIT_RECOVERY_SECONDS);
+    }
+  }
+
+  private RuntimeConfigInput normalizeRuntimeConfig(RuntimeConfigInput input) {
+    if (input == null) throw new IllegalArgumentException("Runtime 配置不能为空");
+    boolean cacheEnabled = Boolean.TRUE.equals(input.cacheEnabled());
+    boolean circuitEnabled = Boolean.TRUE.equals(input.circuitBreakerEnabled());
+    int ttl = range(input.cacheTtlSeconds(), DEFAULT_CACHE_TTL_SECONDS, 1, 3_600, "缓存 TTL");
+    int maxEntries = range(input.cacheMaxEntries(), DEFAULT_CACHE_MAX_ENTRIES, 1, 5_000, "缓存最大条目数");
+    int failureThreshold = range(
+        input.failureThreshold(), DEFAULT_CIRCUIT_FAILURE_THRESHOLD, 1, 20, "熔断失败阈值");
+    int recoverySeconds = range(
+        input.recoverySeconds(), DEFAULT_CIRCUIT_RECOVERY_SECONDS, 1, 300, "熔断恢复时间");
+    return new RuntimeConfigInput(
+        cacheEnabled, ttl, maxEntries, circuitEnabled, failureThreshold, recoverySeconds);
+  }
+
+  private int range(Integer value, int fallback, int min, int max, String name) {
+    int normalized = value == null ? fallback : value;
+    if (normalized < min || normalized > max) {
+      throw new IllegalArgumentException(name + " 必须在 " + min + "~" + max + " 之间");
+    }
+    return normalized;
   }
 
   private SourceSnapshot normalizeSource(SourceSnapshot source) {
@@ -379,6 +461,14 @@ public class DataServiceService {
       Integer timeoutSeconds,
       Boolean enabled,
       String description) {}
+
+  public record RuntimeConfigInput(
+      Boolean cacheEnabled,
+      Integer cacheTtlSeconds,
+      Integer cacheMaxEntries,
+      Boolean circuitBreakerEnabled,
+      Integer failureThreshold,
+      Integer recoverySeconds) {}
 
   public record SourceSnapshot(
       String sourceType,

--- a/yak-ops-business/yak-ops-business-datasource/src/main/resources/db/migration/yak-datasource/V6__add_data_service_runtime_resilience.sql
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/resources/db/migration/yak-datasource/V6__add_data_service_runtime_resilience.sql
@@ -1,0 +1,9 @@
+-- 数据服务第四阶段：本机结果缓存、熔断保护与运行时策略。
+-- 历史服务保持缓存/熔断关闭，避免升级后改变既有线上行为；新建服务由应用层启用保守熔断默认值。
+ALTER TABLE yak_ops_data_service_api
+    ADD COLUMN cache_enabled TINYINT(1) NOT NULL DEFAULT 0 COMMENT '是否启用本机结果缓存' AFTER auth_mode,
+    ADD COLUMN cache_ttl_seconds INT NOT NULL DEFAULT 60 COMMENT '缓存 TTL（秒）' AFTER cache_enabled,
+    ADD COLUMN cache_max_entries INT NOT NULL DEFAULT 200 COMMENT '单服务最大缓存条目数' AFTER cache_ttl_seconds,
+    ADD COLUMN circuit_breaker_enabled TINYINT(1) NOT NULL DEFAULT 0 COMMENT '是否启用熔断保护' AFTER cache_max_entries,
+    ADD COLUMN circuit_failure_threshold INT NOT NULL DEFAULT 5 COMMENT '连续失败触发熔断阈值' AFTER circuit_breaker_enabled,
+    ADD COLUMN circuit_recovery_seconds INT NOT NULL DEFAULT 30 COMMENT '熔断恢复等待秒数' AFTER circuit_failure_threshold;

--- a/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/dataservice/service/DataServiceRuntimeServiceTest.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/dataservice/service/DataServiceRuntimeServiceTest.java
@@ -36,8 +36,8 @@ class DataServiceRuntimeServiceTest {
     });
 
     assertThat(first.rowCount()).isEqualTo(1);
-    assertThat(second.durationMs()).isZero();
-    assertThat(loads).hasValue(1);
+    assertThat(second.durationMs()).isGreaterThanOrEqualTo(0L);
+    assertThat(loads.get()).isEqualTo(1);
     RuntimeSnapshot snapshot = service.snapshot(api);
     assertThat(snapshot.totalCalls()).isEqualTo(2);
     assertThat(snapshot.cacheHits()).isEqualTo(1);
@@ -103,7 +103,7 @@ class DataServiceRuntimeServiceTest {
   private static QueryResponse response() {
     return new QueryResponse(
         List.of("id"),
-        List.of(Map.of("id", 1)),
+        List.of(Map.<String, Object>of("id", 1)),
         false,
         1,
         15L);

--- a/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/dataservice/service/DataServiceRuntimeServiceTest.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/dataservice/service/DataServiceRuntimeServiceTest.java
@@ -1,0 +1,143 @@
+package io.yak.ops.business.dataservice.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.yak.ops.business.dataservice.dao.model.DataServiceApiPO;
+import io.yak.ops.business.dataservice.service.DataServiceRuntimeService.RuntimeSnapshot;
+import io.yak.ops.business.dataservice.service.DataServiceService.QueryResponse;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+class DataServiceRuntimeServiceTest {
+
+  @Test
+  void cacheReusesSuccessfulQueryAndTracksHitRate() {
+    MutableClock clock = new MutableClock(Instant.parse("2026-08-15T13:00:00Z"));
+    DataServiceRuntimeService service = new DataServiceRuntimeService(clock);
+    DataServiceApiPO api = api(1L);
+    api.setCacheEnabled(true);
+    api.setCircuitBreakerEnabled(false);
+    AtomicInteger loads = new AtomicInteger();
+
+    QueryResponse first = service.execute(api, "same-query", () -> {
+      loads.incrementAndGet();
+      return response();
+    });
+    QueryResponse second = service.execute(api, "same-query", () -> {
+      loads.incrementAndGet();
+      return response();
+    });
+
+    assertThat(first.rowCount()).isEqualTo(1);
+    assertThat(second.durationMs()).isZero();
+    assertThat(loads).hasValue(1);
+    RuntimeSnapshot snapshot = service.snapshot(api);
+    assertThat(snapshot.totalCalls()).isEqualTo(2);
+    assertThat(snapshot.cacheHits()).isEqualTo(1);
+    assertThat(snapshot.cacheEntries()).isEqualTo(1);
+    assertThat(snapshot.cacheHitRate()).isEqualTo(0.5D);
+  }
+
+  @Test
+  void circuitOpensAfterConsecutiveDatasourceFailures() {
+    MutableClock clock = new MutableClock(Instant.parse("2026-08-15T13:00:00Z"));
+    DataServiceRuntimeService service = new DataServiceRuntimeService(clock);
+    DataServiceApiPO api = api(2L);
+    api.setCircuitBreakerEnabled(true);
+    api.setCircuitFailureThreshold(2);
+    api.setCircuitRecoverySeconds(30);
+
+    assertThatThrownBy(() -> service.execute(api, "a", () -> failure("db down")))
+        .isInstanceOf(IllegalStateException.class);
+    assertThatThrownBy(() -> service.execute(api, "b", () -> failure("db down")))
+        .isInstanceOf(IllegalStateException.class);
+    assertThatThrownBy(() -> service.execute(api, "c", DataServiceRuntimeServiceTest::response))
+        .isInstanceOf(DataServiceCircuitOpenException.class)
+        .hasMessageContaining("熔断");
+
+    RuntimeSnapshot snapshot = service.snapshot(api);
+    assertThat(snapshot.circuitState()).isEqualTo("OPEN");
+    assertThat(snapshot.failureCalls()).isEqualTo(3);
+    assertThat(snapshot.circuitRejected()).isEqualTo(1);
+  }
+
+  @Test
+  void halfOpenProbeClosesCircuitAfterRecoveryWindow() {
+    MutableClock clock = new MutableClock(Instant.parse("2026-08-15T13:00:00Z"));
+    DataServiceRuntimeService service = new DataServiceRuntimeService(clock);
+    DataServiceApiPO api = api(3L);
+    api.setCircuitBreakerEnabled(true);
+    api.setCircuitFailureThreshold(1);
+    api.setCircuitRecoverySeconds(10);
+
+    assertThatThrownBy(() -> service.execute(api, "a", () -> failure("db down")))
+        .isInstanceOf(IllegalStateException.class);
+    assertThat(service.snapshot(api).circuitState()).isEqualTo("OPEN");
+
+    clock.advanceSeconds(11);
+    QueryResponse recovered = service.execute(api, "b", DataServiceRuntimeServiceTest::response);
+
+    assertThat(recovered.rowCount()).isEqualTo(1);
+    assertThat(service.snapshot(api).circuitState()).isEqualTo("CLOSED");
+  }
+
+  private static DataServiceApiPO api(Long id) {
+    DataServiceApiPO api = new DataServiceApiPO();
+    api.setId(id);
+    api.setCacheEnabled(false);
+    api.setCacheTtlSeconds(60);
+    api.setCacheMaxEntries(10);
+    api.setCircuitBreakerEnabled(false);
+    api.setCircuitFailureThreshold(5);
+    api.setCircuitRecoverySeconds(30);
+    return api;
+  }
+
+  private static QueryResponse response() {
+    return new QueryResponse(
+        List.of("id"),
+        List.of(Map.of("id", 1)),
+        false,
+        1,
+        15L);
+  }
+
+  private static QueryResponse failure(String message) {
+    throw new IllegalStateException(message);
+  }
+
+  private static final class MutableClock extends Clock {
+
+    private Instant instant;
+
+    private MutableClock(Instant instant) {
+      this.instant = instant;
+    }
+
+    void advanceSeconds(long seconds) {
+      instant = instant.plusSeconds(seconds);
+    }
+
+    @Override
+    public ZoneId getZone() {
+      return ZoneOffset.UTC;
+    }
+
+    @Override
+    public Clock withZone(ZoneId zone) {
+      return this;
+    }
+
+    @Override
+    public Instant instant() {
+      return instant;
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/dataservice/service/DataServiceServiceSourceTest.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/dataservice/service/DataServiceServiceSourceTest.java
@@ -22,19 +22,22 @@ import org.junit.jupiter.api.Test;
 class DataServiceServiceSourceTest {
 
   private DataServiceApiMapper apiMapper;
+  private DataServiceRuntimeService runtimeService;
   private DataServiceService service;
   private DataServiceApiPO sourceManaged;
 
   @BeforeEach
   void setUp() {
     apiMapper = mock(DataServiceApiMapper.class);
+    runtimeService = mock(DataServiceRuntimeService.class);
     service = new DataServiceService(
         apiMapper,
         mock(DataServiceCallLogMapper.class),
         mock(BusinessDataSourceExecutionProvider.class),
         new DataServiceSqlCompiler(),
         new ObjectMapper(),
-        mock(DataServiceAccessService.class));
+        mock(DataServiceAccessService.class),
+        runtimeService);
 
     sourceManaged = new DataServiceApiPO();
     sourceManaged.setId(9L);
@@ -46,6 +49,12 @@ class DataServiceServiceSourceTest {
     sourceManaged.setTimeoutSeconds(30);
     sourceManaged.setEnabled(true);
     sourceManaged.setAuthMode("NONE");
+    sourceManaged.setCacheEnabled(false);
+    sourceManaged.setCacheTtlSeconds(60);
+    sourceManaged.setCacheMaxEntries(200);
+    sourceManaged.setCircuitBreakerEnabled(false);
+    sourceManaged.setCircuitFailureThreshold(5);
+    sourceManaged.setCircuitRecoverySeconds(30);
     sourceManaged.setSourceType("DATA_DEVELOPMENT_RELEASE");
     sourceManaged.setSourceRef("88");
     sourceManaged.setSourceRevisionId(102L);
@@ -92,7 +101,7 @@ class DataServiceServiceSourceTest {
   }
 
   @Test
-  void manualEditMayChangeOperationalMetadata() {
+  void manualEditMayChangeOperationalMetadataWithoutLosingRuntimePolicy() {
     ApiView updated = service.save(
         9L,
         new ApiInput(
@@ -111,6 +120,9 @@ class DataServiceServiceSourceTest {
     assertThat(updated.enabled()).isFalse();
     assertThat(updated.authMode()).isEqualTo("NONE");
     assertThat(updated.sourceRevisionNo()).isEqualTo(2);
+    assertThat(sourceManaged.getCacheEnabled()).isFalse();
+    assertThat(sourceManaged.getCircuitBreakerEnabled()).isFalse();
     verify(apiMapper).updateById(sourceManaged);
+    verify(runtimeService).invalidate(9L);
   }
 }

--- a/yak-ops-ui/src/pages/data-service/DataServiceRuntimeModal.tsx
+++ b/yak-ops-ui/src/pages/data-service/DataServiceRuntimeModal.tsx
@@ -1,0 +1,223 @@
+import { Button, InputNumber, Modal, Spin, Switch, Tag, message } from 'antd';
+import { RefreshCw } from 'lucide-react';
+import { useCallback, useEffect, useState } from 'react';
+
+import {
+  fetchDataServiceRuntime,
+  updateDataServiceRuntime,
+  type DataServiceApi,
+  type DataServiceRuntimeConfig,
+  type DataServiceRuntimeStatus,
+} from './service';
+
+interface DataServiceRuntimeModalProps {
+  open: boolean;
+  service?: DataServiceApi;
+  onCancel: () => void;
+}
+
+const percent = (value?: number) => `${Math.round((value || 0) * 1000) / 10}%`;
+
+const circuitLabel: Record<DataServiceRuntimeStatus['circuitState'], string> = {
+  DISABLED: '未启用',
+  CLOSED: '正常',
+  OPEN: '已熔断',
+  HALF_OPEN: '恢复探测',
+};
+
+const DataServiceRuntimeModal = ({ open, service, onCancel }: DataServiceRuntimeModalProps) => {
+  const [status, setStatus] = useState<DataServiceRuntimeStatus>();
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [config, setConfig] = useState<DataServiceRuntimeConfig>({
+    cacheEnabled: false,
+    cacheTtlSeconds: 60,
+    cacheMaxEntries: 200,
+    circuitBreakerEnabled: true,
+    failureThreshold: 5,
+    recoverySeconds: 30,
+  });
+
+  const load = useCallback(async () => {
+    if (!service) return;
+    setLoading(true);
+    try {
+      const response = await fetchDataServiceRuntime(service.id);
+      const next = response.data;
+      if (!next) throw new Error(response.message || response.msg || '加载 Runtime 状态失败');
+      setStatus(next);
+      setConfig({
+        cacheEnabled: next.cacheEnabled,
+        cacheTtlSeconds: next.cacheTtlSeconds,
+        cacheMaxEntries: next.cacheMaxEntries,
+        circuitBreakerEnabled: next.circuitBreakerEnabled,
+        failureThreshold: next.failureThreshold,
+        recoverySeconds: next.recoverySeconds,
+      });
+    } catch (error) {
+      message.error(error instanceof Error ? error.message : '加载 Runtime 状态失败');
+    } finally {
+      setLoading(false);
+    }
+  }, [service]);
+
+  useEffect(() => {
+    if (open) void load();
+  }, [load, open]);
+
+  const save = async () => {
+    if (!service) return;
+    setSaving(true);
+    try {
+      const response = await updateDataServiceRuntime(service.id, config);
+      if (!response.data) throw new Error(response.message || response.msg || '保存 Runtime 配置失败');
+      setStatus(response.data);
+      message.success('Runtime 配置已更新，旧缓存与熔断状态已重置');
+    } catch (error) {
+      message.error(error instanceof Error ? error.message : '保存 Runtime 配置失败');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Modal
+      open={open}
+      title={service ? `Runtime · ${service.name}` : 'Runtime'}
+      width={760}
+      centered
+      destroyOnHidden
+      onCancel={onCancel}
+      footer={[
+        <Button key="refresh" icon={<RefreshCw size={14} />} onClick={() => void load()} disabled={loading || saving}>
+          刷新指标
+        </Button>,
+        <Button key="cancel" onClick={onCancel}>关闭</Button>,
+        <Button key="save" type="primary" loading={saving} onClick={() => void save()}>
+          保存配置
+        </Button>,
+      ]}
+    >
+      <Spin spinning={loading}>
+        <div className="space-y-5 py-2">
+          <div>
+            <div className="mb-2 text-[12px] font-medium text-[#344054]">运行指标</div>
+            <div className="grid grid-cols-4 gap-2">
+              <Metric label="总调用" value={String(status?.totalCalls || 0)} />
+              <Metric label="成功率" value={percent(status?.successRate)} />
+              <Metric label="平均耗时" value={`${status?.averageDurationMs || 0} ms`} />
+              <Metric label="P95" value={`${status?.p95DurationMs || 0} ms`} />
+              <Metric label="缓存命中" value={String(status?.cacheHits || 0)} />
+              <Metric label="命中率" value={percent(status?.cacheHitRate)} />
+              <Metric label="失败" value={String(status?.failureCalls || 0)} />
+              <Metric label="熔断拒绝" value={String(status?.circuitRejected || 0)} />
+            </div>
+          </div>
+
+          <div className="border border-[#e5e7eb]">
+            <div className="flex items-center justify-between border-b border-[#eef0f2] bg-[#fafafa] px-3 py-2.5">
+              <div>
+                <div className="text-[12px] font-medium text-[#344054]">结果缓存</div>
+                <div className="mt-0.5 text-[10px] text-[#98a2b3]">仅缓存外部 Runtime 的成功 SELECT 结果；控制台测试始终访问真实数据源。</div>
+              </div>
+              <Switch
+                size="small"
+                checked={config.cacheEnabled}
+                onChange={(value) => setConfig((current) => ({ ...current, cacheEnabled: value }))}
+              />
+            </div>
+            <div className="grid grid-cols-3 gap-3 px-3 py-3">
+              <Field label="TTL（秒）">
+                <InputNumber
+                  className="w-full"
+                  min={1}
+                  max={3600}
+                  disabled={!config.cacheEnabled}
+                  value={config.cacheTtlSeconds}
+                  onChange={(value) => setConfig((current) => ({ ...current, cacheTtlSeconds: value || 60 }))}
+                />
+              </Field>
+              <Field label="最大条目数">
+                <InputNumber
+                  className="w-full"
+                  min={1}
+                  max={5000}
+                  disabled={!config.cacheEnabled}
+                  value={config.cacheMaxEntries}
+                  onChange={(value) => setConfig((current) => ({ ...current, cacheMaxEntries: value || 200 }))}
+                />
+              </Field>
+              <Field label="当前条目">
+                <div className="flex h-8 items-center text-[12px] text-[#475467]">{status?.cacheEntries || 0}</div>
+              </Field>
+            </div>
+          </div>
+
+          <div className="border border-[#e5e7eb]">
+            <div className="flex items-center justify-between border-b border-[#eef0f2] bg-[#fafafa] px-3 py-2.5">
+              <div>
+                <div className="flex items-center gap-2 text-[12px] font-medium text-[#344054]">
+                  熔断保护
+                  {status ? <Tag bordered={false}>{circuitLabel[status.circuitState]}</Tag> : null}
+                </div>
+                <div className="mt-0.5 text-[10px] text-[#98a2b3]">连续执行失败后短暂停止访问下游，恢复窗口结束后放行一次探测请求。</div>
+              </div>
+              <Switch
+                size="small"
+                checked={config.circuitBreakerEnabled}
+                onChange={(value) => setConfig((current) => ({ ...current, circuitBreakerEnabled: value }))}
+              />
+            </div>
+            <div className="grid grid-cols-3 gap-3 px-3 py-3">
+              <Field label="连续失败阈值">
+                <InputNumber
+                  className="w-full"
+                  min={1}
+                  max={20}
+                  disabled={!config.circuitBreakerEnabled}
+                  value={config.failureThreshold}
+                  onChange={(value) => setConfig((current) => ({ ...current, failureThreshold: value || 5 }))}
+                />
+              </Field>
+              <Field label="恢复等待（秒）">
+                <InputNumber
+                  className="w-full"
+                  min={1}
+                  max={300}
+                  disabled={!config.circuitBreakerEnabled}
+                  value={config.recoverySeconds}
+                  onChange={(value) => setConfig((current) => ({ ...current, recoverySeconds: value || 30 }))}
+                />
+              </Field>
+              <Field label="当前状态">
+                <div className="flex h-8 items-center text-[12px] text-[#475467]">
+                  {status ? circuitLabel[status.circuitState] : '-'}
+                </div>
+              </Field>
+            </div>
+          </div>
+
+          <div className="bg-[#f8f9fb] px-3 py-2.5 text-[11px] leading-5 text-[#667085]">
+            当前缓存和熔断均为单实例 Runtime 能力。SQL 重新发布、服务编辑或 Runtime 配置变更会立即清空旧缓存并重置熔断状态；后续多实例部署可将相同接口替换为 Redis / API Gateway 实现。
+          </div>
+        </div>
+      </Spin>
+    </Modal>
+  );
+};
+
+const Metric = ({ label, value }: { label: string; value: string }) => (
+  <div className="border border-[#e5e7eb] bg-[#fafbfc] px-3 py-2.5">
+    <div className="text-[10px] text-[#98a2b3]">{label}</div>
+    <div className="mt-1 text-[14px] font-medium text-[#344054]">{value}</div>
+  </div>
+);
+
+const Field = ({ label, children }: { label: string; children: React.ReactNode }) => (
+  <div>
+    <div className="mb-1.5 text-[11px] font-medium text-[#475467]">{label}</div>
+    {children}
+  </div>
+);
+
+export default DataServiceRuntimeModal;

--- a/yak-ops-ui/src/pages/data-service/DataServiceRuntimeModal.tsx
+++ b/yak-ops-ui/src/pages/data-service/DataServiceRuntimeModal.tsx
@@ -1,6 +1,6 @@
 import { Button, InputNumber, Modal, Spin, Switch, Tag, message } from 'antd';
 import { RefreshCw } from 'lucide-react';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState, type ReactNode } from 'react';
 
 import {
   fetchDataServiceRuntime,
@@ -213,7 +213,7 @@ const Metric = ({ label, value }: { label: string; value: string }) => (
   </div>
 );
 
-const Field = ({ label, children }: { label: string; children: React.ReactNode }) => (
+const Field = ({ label, children }: { label: string; children: ReactNode }) => (
   <div>
     <div className="mb-1.5 text-[11px] font-medium text-[#475467]">{label}</div>
     {children}

--- a/yak-ops-ui/src/pages/data-service/index.tsx
+++ b/yak-ops-ui/src/pages/data-service/index.tsx
@@ -14,9 +14,10 @@ import {
   message,
   type TableColumnsType,
 } from 'antd';
-import { Copy, Pencil, Play, Plus, RefreshCw, Search, ShieldCheck, Trash2 } from 'lucide-react';
+import { Activity, Copy, Pencil, Play, Plus, RefreshCw, Search, ShieldCheck, Trash2 } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import DataServiceAccessModal from './DataServiceAccessModal';
+import DataServiceRuntimeModal from './DataServiceRuntimeModal';
 import {
   createDataService,
   deleteDataService,
@@ -43,6 +44,7 @@ export default function DataServicePage() {
   const [saving, setSaving] = useState(false);
   const [testing, setTesting] = useState<DataServiceApi>();
   const [accessTarget, setAccessTarget] = useState<DataServiceApi>();
+  const [runtimeTarget, setRuntimeTarget] = useState<DataServiceApi>();
   const [testLoading, setTestLoading] = useState(false);
   const [testResult, setTestResult] = useState<DataServiceQueryResult>();
   const [form] = Form.useForm<DataServiceSavePayload>();
@@ -60,6 +62,9 @@ export default function DataServicePage() {
       setServices(nextServices);
       setDataSources(dataSourceResponse.data || []);
       setAccessTarget((current) => current
+        ? nextServices.find((item) => item.id === current.id) || current
+        : undefined);
+      setRuntimeTarget((current) => current
         ? nextServices.find((item) => item.id === current.id) || current
         : undefined);
     } catch (error: any) {
@@ -237,12 +242,15 @@ export default function DataServicePage() {
     {
       title: '操作',
       key: 'actions',
-      width: 190,
+      width: 220,
       fixed: 'right',
       render: (_, record) => (
         <Space size={2}>
           <Tooltip title="测试">
             <Button type="text" size="small" icon={<Play size={15} />} onClick={() => openTest(record)} />
+          </Tooltip>
+          <Tooltip title="Runtime">
+            <Button type="text" size="small" icon={<Activity size={15} />} onClick={() => setRuntimeTarget(record)} />
           </Tooltip>
           <Tooltip title="访问控制">
             <Button type="text" size="small" icon={<ShieldCheck size={15} />} onClick={() => setAccessTarget(record)} />
@@ -271,7 +279,7 @@ export default function DataServicePage() {
       <div className="mb-5 flex items-start justify-between gap-4">
         <div>
           <h1 className="m-0 text-xl font-semibold text-[#161823]">API 服务</h1>
-          <p className="mb-0 mt-1 text-sm text-black/45">将只读 SQL 发布为可调用、可鉴权、可审计的 GET REST API。</p>
+          <p className="mb-0 mt-1 text-sm text-black/45">将只读 SQL 发布为可调用、可鉴权、可缓存、可熔断、可审计的 GET REST API。</p>
         </div>
         <Button type="primary" icon={<Plus size={16} />} onClick={openCreate}>新建 API</Button>
       </div>
@@ -295,7 +303,7 @@ export default function DataServicePage() {
         dataSource={filtered}
         columns={columns}
         pagination={false}
-        scroll={{ x: 1320 }}
+        scroll={{ x: 1360 }}
       />
 
       <DataServiceAccessModal
@@ -303,6 +311,12 @@ export default function DataServicePage() {
         service={accessTarget}
         onCancel={() => setAccessTarget(undefined)}
         onChanged={load}
+      />
+
+      <DataServiceRuntimeModal
+        open={Boolean(runtimeTarget)}
+        service={runtimeTarget}
+        onCancel={() => setRuntimeTarget(undefined)}
       />
 
       <Modal
@@ -389,11 +403,12 @@ export default function DataServicePage() {
             <div className="mb-4 rounded-md bg-black/[0.025] px-3 py-2 font-mono text-sm text-black/65">
               GET {testing.runtimePath}
             </div>
-            {testing.authMode === 'API_KEY' ? (
-              <div className="mb-4 border border-[#e5e7eb] bg-[#fafafa] px-3 py-2 text-[11px] text-[#667085]">
-                当前 Runtime 已启用 API Key。这里属于管理控制台测试，会绕过外部鉴权；真实调用请携带 <span className="font-mono">X-API-Key</span>。
-              </div>
-            ) : null}
+            <div className="mb-4 border border-[#e5e7eb] bg-[#fafafa] px-3 py-2 text-[11px] text-[#667085]">
+              管理控制台测试始终直连真实数据源，不读取 Runtime 结果缓存，也不受熔断状态影响，便于确认当前 SQL 与数据源是否真实可用。
+              {testing.authMode === 'API_KEY' ? (
+                <> 真实外部调用仍需携带 <span className="font-mono">X-API-Key</span>。</>
+              ) : null}
+            </div>
             <Form form={testForm} layout="vertical">
               {testing.parameterNames.length > 0 ? (
                 <div className="grid grid-cols-2 gap-x-4">

--- a/yak-ops-ui/src/pages/data-service/service.ts
+++ b/yak-ops-ui/src/pages/data-service/service.ts
@@ -47,6 +47,33 @@ export interface DataServiceSavePayload {
   description?: string;
 }
 
+export interface DataServiceRuntimeConfig {
+  cacheEnabled: boolean;
+  cacheTtlSeconds: number;
+  cacheMaxEntries: number;
+  circuitBreakerEnabled: boolean;
+  failureThreshold: number;
+  recoverySeconds: number;
+}
+
+export interface DataServiceRuntimeStatus extends DataServiceRuntimeConfig {
+  apiId: number;
+  cacheEntries: number;
+  circuitState: 'DISABLED' | 'CLOSED' | 'OPEN' | 'HALF_OPEN';
+  circuitOpenUntil?: string | null;
+  totalCalls: number;
+  successCalls: number;
+  failureCalls: number;
+  cacheHits: number;
+  circuitRejected: number;
+  successRate: number;
+  cacheHitRate: number;
+  averageDurationMs: number;
+  p95DurationMs: number;
+  lastSuccessAt?: string | null;
+  lastFailureAt?: string | null;
+}
+
 export interface DataServiceApiKey {
   id: number;
   apiId: number;
@@ -116,6 +143,12 @@ export const deleteDataService = (id: number) =>
 
 export const setDataServiceEnabled = (id: number, enabled: boolean) =>
   HttpUtils.put<DataServiceApi>(`${PREFIX}/${id}/enabled?enabled=${enabled}`, {}) as Promise<CommonApiResponse<DataServiceApi>>;
+
+export const fetchDataServiceRuntime = (id: number) =>
+  HttpUtils.get<DataServiceRuntimeStatus>(`${PREFIX}/${id}/runtime`) as Promise<CommonApiResponse<DataServiceRuntimeStatus>>;
+
+export const updateDataServiceRuntime = (id: number, payload: DataServiceRuntimeConfig) =>
+  HttpUtils.put<DataServiceRuntimeStatus>(`${PREFIX}/${id}/runtime`, payload) as Promise<CommonApiResponse<DataServiceRuntimeStatus>>;
 
 export const setDataServiceAuthMode = (id: number, mode: DataServiceAuthMode) =>
   HttpUtils.put<DataServiceAuthMode>(`${PREFIX}/${id}/auth-mode?mode=${mode}`, {}) as Promise<CommonApiResponse<DataServiceAuthMode>>;


### PR DESCRIPTION
## Summary

Complete the next Data Service Runtime phase by adding lightweight local caching, circuit breaking and runtime observability on top of the existing SQL -> REST -> API Key flow.

## Runtime flow

1. Authenticate / rate-limit the caller (Phase 3)
2. Compile and bind SQL parameters
3. Check the bounded per-service result cache
4. Coalesce concurrent misses for the same SQL + bindings so only one request hits the datasource
5. If no cached value is available, apply the per-service circuit breaker
6. Execute against the existing datasource runtime
7. Record rolling runtime metrics and the existing invocation audit log

## Included

### Result cache

- Caffeine-based in-process cache, isolated per Data Service
- Disabled by default so existing services do not change behavior after upgrade
- Configurable TTL: 1-3600 seconds
- Configurable maximum entries per service: 1-5000
- Cache key is derived from the compiled SQL snapshot plus ordered JDBC bindings
- Only successful external Runtime SELECT results are cached
- Management-console test calls always bypass cache and hit the live datasource
- Concurrent misses for the same parameter set are coalesced by Caffeine `get(key, loader)` to reduce cache stampedes
- Cached data can still be served while the downstream circuit is open
- Service edits, SQL re-publication and Runtime policy changes invalidate old cache state

### Circuit breaker

- Lightweight per-service CLOSED / OPEN / HALF_OPEN state machine
- New services default to conservative protection: 5 consecutive execution failures, 30-second recovery window
- Existing services migrate with circuit breaking disabled for backward compatibility
- Only datasource/execution failures affect the breaker; API-Key failures, rate limits and SQL parameter validation do not count as datasource failures
- OPEN services return HTTP 503 for uncached requests
- After the recovery window, a single half-open probe is allowed; success closes the circuit, failure reopens it
- Disabling a service resets operational cache/circuit state

### Runtime metrics

New runtime status endpoint exposes in-process rolling metrics per service:

- total / success / failure calls
- success rate
- average latency
- rolling P95 latency (last 256 observations)
- cache hits and cache-hit rate
- circuit-breaker rejection count
- current cache entry count
- circuit state / open-until timestamp
- last success / failure timestamps

Endpoints:

- `GET /api/v1/data-service/{id}/runtime`
- `PUT /api/v1/data-service/{id}/runtime`

### UI

- Adds a focused **Runtime** action to the API Service list
- Runtime panel shows the key metrics without adding more columns/cards to the main list
- Cache toggle + TTL + maximum entries
- Circuit-breaker toggle + failure threshold + recovery window
- Explicit note that the current implementation is single-instance and can later be replaced behind the same boundary by Redis / API Gateway / metrics backends
- Console test copy now makes it explicit that tests bypass Runtime cache/circuit behavior

## Persistence / compatibility

Flyway `V6__add_data_service_runtime_resilience.sql` adds Runtime policy columns to `yak_ops_data_service_api`.

Compatibility rules:

- existing services: cache OFF, circuit breaker OFF after migration
- new services: cache OFF, circuit breaker ON with conservative defaults
- Data Development -> Data Service re-publication preserves Runtime policy
- source-managed SQL/datasource provenance from Phase 2 remains unchanged
- API Key auth/rate limiting from Phase 3 remains unchanged

## Tests

`DataServiceRuntimeServiceTest` covers:

- successful cache reuse and cache-hit metrics
- circuit opening after consecutive execution failures
- HTTP-Runtime circuit rejection semantics at the service layer
- half-open recovery and closing the circuit after a successful probe

`DataServiceServiceSourceTest` was updated to verify Runtime policy survives ordinary source-managed service edits and that runtime state is invalidated when the executable service definition changes.

## Validation

- Compared `main...feat/data-service-runtime-resilience`; final diff is scoped to 12 Runtime-phase files
- Spring Boot parent is `3.3.13` / Java 21, so Caffeine is covered by Spring Boot dependency management and the Java APIs used here are compatible
- Performed static review of Java records, Runtime endpoint/route shape, source-publication compatibility and TypeScript response-field alignment
- Attempted a full checkout for Maven / TypeScript execution, but the execution container still cannot resolve `github.com` (`Could not resolve host: github.com`). Full CI/build results should therefore be treated as the executable source of truth.

## Deferred

- Redis/distributed cache for multi-instance deployments
- distributed/global circuit state
- Prometheus/Micrometer export and long-term metric persistence
- stale-while-revalidate / stale-if-error policies
- cache invalidation from upstream CDC/table-change events
- gateway-level retries, bulkheads and concurrency limits
