### PR TITLE
refactor(workflow): move definition editor into fullscreen workspace

### DIFF
--- a/yak-ops-ui/config/routes.ts
+++ b/yak-ops-ui/config/routes.ts
@@ -3,6 +3,7 @@ import { appRoutes } from '../src/config/navigation';
 const fullscreenRouteIds = new Set([
   'dashboard-new',
   'dashboard-editor',
+  'workflow-definition-editor',
 ]);
 
 const toProtectedRoute = ({
@@ -29,8 +30,8 @@ const siteRoutes = appRoutes
   .map(toProtectedRoute);
 
 /**
- * 普通业务页面进入自定义 SiteLayout；Dashboard Editor 则使用独立的
- * fullscreen workspace，不继承 Yak 左侧菜单和全局 Header。
+ * 普通业务页面进入自定义 SiteLayout；需要沉浸式创作空间的编辑器则使用
+ * 独立 fullscreen workspace，不继承 Yak 左侧菜单和全局 Header。
  */
 export default [
   {

--- a/yak-ops-ui/src/pages/workflow/definition/index.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/index.tsx
@@ -1,1 +1,28 @@
-export { default } from './WorkflowDefinitionEditor';
+import WorkflowDefinitionEditor from './WorkflowDefinitionEditor';
+
+/**
+ * Workflow Definition uses its own workspace chrome (workflow sidebar + toolbar +
+ * ReactFlow canvas), so it should consume the whole browser viewport when the
+ * route is mounted outside SiteLayout.
+ *
+ * Keep the sizing override here instead of coupling the large orchestration
+ * component to a specific application shell. This also keeps the existing
+ * editor behavior intact while allowing immersive routes to own 100vh.
+ */
+export default function WorkflowDefinitionFullscreenPage() {
+  return (
+    <div className="workflow-definition-fullscreen-shell h-screen overflow-hidden bg-[#f2f4f7]">
+      <WorkflowDefinitionEditor />
+      <style>{`
+        .workflow-definition-fullscreen-shell > div:first-child {
+          height: 100vh !important;
+          min-height: 100vh !important;
+        }
+
+        .workflow-definition-fullscreen-shell .workflow-editor-toolbar {
+          height: 52px !important;
+        }
+      `}</style>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

延续 Dashboard Editor 的沉浸式工作区模式，把 **工作流定义编辑页** 从普通 Yak `SiteLayout` 中拆出来，改成真正的 fullscreen workspace。

这次不调整工作流编排领域逻辑，也不改节点、连线、测试运行、发布、版本等能力；只解决页面层级问题：进入 `/workflow/definition/:id` 后，不再同时看到 Yak 左侧主导航和顶部全局 Header，让工作流自己的 Workspace Sidebar、Toolbar 和 ReactFlow Canvas 成为页面主体。

## 页面结构

```text
/workflow/definitions
  工作流定义列表（SiteLayout）
       ↓ 编辑

/workflow/definition/:id
  Fullscreen Workflow Workspace
  ├── Workflow Workspace Sidebar
  ├── Workflow Toolbar
  └── ReactFlow Canvas / Inspector
```

## 1. Workflow Editor 脱离 SiteLayout

`config/routes.ts` 将 `workflow-definition-editor` 加入现有 `fullscreenRouteIds`。

因此进入工作流编排后：

- 不挂载 Yak 左侧全局导航
- 不挂载 Yak 顶部全局 Header
- 不通过 fixed / z-index 伪装全屏
- 仍保留 `isAuthenticated` + `RouteAccessBoundary`
- 返回「工作流定义」、进入「运行记录」后会自然回到普通 SiteLayout 页面

## 2. Workspace 真正占满 100vh

现有 `WorkflowDefinitionEditor` 原本基于 SiteLayout 的 48px Header 使用：

```text
height: calc(100vh - 48px)
```

本 PR 在 `workflow/definition/index.tsx` 增加轻量 fullscreen shell，让现有编排组件不需要高风险重写即可完整占满浏览器视口：

```text
100vh
├── Workflow Workspace Sidebar
├── Workflow Toolbar
└── ReactFlow Canvas
```

同时将 Workflow Toolbar 在 fullscreen shell 中统一到 52px，与左侧 Workspace Sidebar 顶部区域对齐，避免进入独立工作区后出现 4px 的横向层级错位。

## Scope

仅修改：

- `yak-ops-ui/config/routes.ts`
- `yak-ops-ui/src/pages/workflow/definition/index.tsx`

明确不改：

- WorkflowDefinitionEditor 编排逻辑
- 节点 / 连线 / 开始节点 / 注释
- Undo / Redo / 历史记录
- 测试运行及实时状态
- 草稿保存 / 发布 / 停用 / 版本
- Inspector / Task Picker
- 后端 API / DB / 调度 Runtime

## Verification

- 基于当前 `main`: `e38096a5c99be534a40fb1fc127f494556262a0f`
- branch 相对 main：ahead 2 / behind 0
- diff 仅 2 个前端文件
- fullscreen route 继续经过现有认证和路由权限边界
- 工作流自身已有返回定义列表入口与运行记录入口，因此脱离 SiteLayout 后仍具备完整退出路径
- 当前 connector 环境没有本地 Node 依赖执行环境，因此不宣称 `npm run tsc` / `npm run build` 已通过；Draft 阶段继续以仓库 CI/status 为准
