### PR TITLE
style(workflow): unify editor toolbar with Yak workspace language

### DIFF
--- a/yak-ops-ui/src/pages/workflow/definition/canvas/WorkflowToolbar.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/WorkflowToolbar.tsx
@@ -4,7 +4,17 @@ import {
   type WorkflowDefinition,
   type WorkflowVersionSummary,
 } from '@/services/workflow/definitions';
-import { Button, InputNumber, Popover, Select, Spin, Tooltip, message } from 'antd';
+import {
+  Button,
+  Dropdown,
+  InputNumber,
+  Modal,
+  Popover,
+  Select,
+  Spin,
+  Tooltip,
+  message,
+} from 'antd';
 import {
   ChevronDown,
   CircleStop,
@@ -54,8 +64,11 @@ const formatDateTime = (value?: string) => {
 const WorkflowToolbar = (props: WorkflowToolbarProps) => {
   const {
     definition,
+    name,
     workflowTimeoutSeconds,
     failureStrategy,
+    nodesCount,
+    edgesCount,
     locked,
     saving,
     testing,
@@ -67,7 +80,6 @@ const WorkflowToolbar = (props: WorkflowToolbarProps) => {
     onOnline,
     onOffline,
   } = props;
-  const [publishOpen, setPublishOpen] = useState(false);
   const [versionOpen, setVersionOpen] = useState(false);
   const [runtimeSettingsOpen, setRuntimeSettingsOpen] = useState(false);
   const [versions, setVersions] = useState<WorkflowVersionSummary[]>([]);
@@ -80,18 +92,22 @@ const WorkflowToolbar = (props: WorkflowToolbarProps) => {
   const hasPublished = Boolean(activeVersionNo);
   const hasRuntimeOverrides = workflowTimeoutSeconds > 0
     || failureStrategy !== 'CONTINUE_INDEPENDENT_BRANCHES';
+  const canPublish = !hasPublished || draftChanged || status === 'OFFLINE';
+  const busy = saving || statusAction;
+
   const lifecycleText = !hasPublished
-    ? '尚未发布'
+    ? '草稿 · 尚未发布'
     : status === 'OFFLINE'
       ? `已停用 v${activeVersionNo}${draftChanged ? ' · 有草稿修改' : ''}`
-      : `已发布 v${activeVersionNo}${draftChanged ? ' · 有草稿修改' : ''}`;
-  const primaryPublishText = !hasPublished
-    ? '发布 v1'
-    : draftChanged
-      ? `发布 v${nextVersionNo}`
-      : status === 'OFFLINE'
-        ? `重新启用 v${activeVersionNo}`
-        : `v${activeVersionNo} 已发布`;
+      : draftChanged
+        ? `草稿 · 已发布 v${activeVersionNo} · 有草稿修改`
+        : `已发布 v${activeVersionNo}`;
+
+  const publishButtonText = !canPublish
+    ? '已发布'
+    : status === 'OFFLINE' && hasPublished && !draftChanged
+      ? '重新启用'
+      : '发布';
 
   const loadVersions = async () => {
     if (!definition?.id) return;
@@ -105,23 +121,59 @@ const WorkflowToolbar = (props: WorkflowToolbarProps) => {
     }
   };
 
+  const confirmPublish = () => {
+    if (!canPublish || testing || busy) return;
+
+    const reenable = status === 'OFFLINE' && hasPublished && !draftChanged;
+    const targetVersionNo = hasPublished && draftChanged ? nextVersionNo : activeVersionNo || 1;
+
+    Modal.confirm({
+      centered: true,
+      title: reenable
+        ? `重新启用工作流 v${targetVersionNo}？`
+        : `发布工作流 v${targetVersionNo}？`,
+      content: reenable
+        ? `将重新启用已发布的 v${targetVersionNo}，不会创建新的发布版本。`
+        : `当前草稿将形成不可变的 v${targetVersionNo}，已有运行实例不会受到影响。`,
+      okText: reenable ? '重新启用' : '发布',
+      cancelText: '取消',
+      onOk: onOnline,
+    });
+  };
+
+  const confirmOffline = () => {
+    if (testing || busy || status !== 'ONLINE' || !hasPublished) return;
+    Modal.confirm({
+      centered: true,
+      title: `停用工作流 v${activeVersionNo}？`,
+      content: '停用后将关闭正式运行入口，当前草稿仍可继续编辑和测试。',
+      okText: '停用',
+      cancelText: '取消',
+      okButtonProps: { danger: true },
+      onOk: onOffline,
+    });
+  };
+
   const versionContent = useMemo(() => (
-    <div className="w-[330px] overflow-hidden rounded-xl border border-[#e4e7ec] bg-white shadow-[0_12px_32px_rgba(22,24,35,.14)]">
+    <div className="w-[320px] overflow-hidden rounded-[10px] border border-[#e4e7ec] bg-white shadow-[0_10px_28px_rgba(22,24,35,.12)]">
       <div className="flex h-11 items-center justify-between border-b border-[#f0f1f3] px-3.5">
-        <div className="text-[13px] font-semibold text-[#344054]">发布版本</div>
-        <span className="text-[10px] text-[#98a2b3]">{lifecycleText}</span>
+        <div className="text-[12px] font-semibold text-[#344054]">发布版本</div>
+        <span className="text-[9px] text-[#98a2b3]">{hasPublished ? `当前 v${activeVersionNo}` : '尚未发布'}</span>
       </div>
       <div className="max-h-[360px] overflow-auto p-2.5">
         {versionsLoading ? (
           <div className="flex h-24 items-center justify-center"><Spin size="small" /></div>
         ) : versions.length ? versions.map((version) => (
-          <div key={version.id} className="mb-1.5 rounded-lg border border-[#eaecf0] bg-white px-3 py-2.5 last:mb-0">
+          <div
+            key={version.id}
+            className="mb-1.5 rounded-[8px] border border-[#eaecf0] bg-white px-3 py-2.5 last:mb-0"
+          >
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-1.5 text-[12px] font-semibold text-[#344054]">
                 <GitCommitHorizontal size={13} />
                 v{version.versionNo}
                 {version.active ? (
-                  <span className="rounded bg-[#fff1f3] px-1.5 py-0.5 text-[9px] font-medium text-[#d92d50]">当前</span>
+                  <span className="rounded-[4px] bg-[#f4f5f6] px-1.5 py-0.5 text-[9px] font-medium text-[#475467]">当前</span>
                 ) : null}
               </div>
               <span className="text-[9px] text-[#98a2b3]">{formatDateTime(version.publishedAt)}</span>
@@ -138,17 +190,17 @@ const WorkflowToolbar = (props: WorkflowToolbarProps) => {
         )}
       </div>
     </div>
-  ), [lifecycleText, versions, versionsLoading]);
+  ), [activeVersionNo, hasPublished, versions, versionsLoading]);
 
   const runtimeSettingsContent = (
-    <div className="w-[320px] overflow-hidden rounded-xl border border-[#e4e7ec] bg-white shadow-[0_12px_32px_rgba(22,24,35,.14)]">
+    <div className="w-[300px] overflow-hidden rounded-[10px] border border-[#e4e7ec] bg-white shadow-[0_10px_28px_rgba(22,24,35,.12)]">
       <div className="border-b border-[#f0f1f3] px-4 py-3">
-        <div className="text-[13px] font-semibold text-[#344054]">运行设置</div>
-        <div className="mt-1 text-[10px] leading-4 text-[#98a2b3]">这些参数会进入发布版本和测试运行，不再作为隐藏配置生效。</div>
+        <div className="text-[12px] font-semibold text-[#344054]">运行设置</div>
+        <div className="mt-1 text-[9px] leading-4 text-[#98a2b3]">运行参数会进入草稿、测试运行和后续发布版本。</div>
       </div>
       <div className="space-y-4 p-4">
         <div>
-          <div className="mb-1.5 text-[11px] font-medium text-[#667085]">失败策略</div>
+          <div className="mb-1.5 text-[10px] font-medium text-[#667085]">失败策略</div>
           <Select
             size="small"
             disabled={locked}
@@ -160,7 +212,7 @@ const WorkflowToolbar = (props: WorkflowToolbarProps) => {
           <div className="mt-1 text-[9px] leading-4 text-[#98a2b3]">默认继续执行与失败节点无依赖的独立分支。</div>
         </div>
         <div>
-          <div className="mb-1.5 text-[11px] font-medium text-[#667085]">工作流整体超时</div>
+          <div className="mb-1.5 text-[10px] font-medium text-[#667085]">工作流整体超时</div>
           <InputNumber
             size="small"
             controls={false}
@@ -178,142 +230,148 @@ const WorkflowToolbar = (props: WorkflowToolbarProps) => {
     </div>
   );
 
-  const canPublish = !hasPublished || draftChanged || status === 'OFFLINE';
-  const publishContent = (
-    <div className="w-[330px] overflow-hidden rounded-xl border border-[#e4e7ec] bg-white shadow-[0_12px_32px_rgba(22,24,35,.14)]">
-      <div className="px-4 pb-3 pt-4">
-        <div className="text-[12px] text-[#667085]">{lifecycleText}</div>
-        <div className="mt-1 text-[13px] font-semibold leading-5 text-[#344054]">
-          {draftChanged
-            ? `当前草稿将形成不可变的 v${nextVersionNo}，已有运行不会受影响`
-            : status === 'OFFLINE'
-              ? `重新启用已发布的 v${activeVersionNo}`
-              : '当前草稿与已发布版本一致'}
-        </div>
-      </div>
-      <div className="space-y-2 border-t border-[#f0f1f3] p-4">
-        {canPublish ? (
-          <Button
-            block
-            type="primary"
-            disabled={testing}
-            loading={statusAction || saving}
-            icon={<Rocket size={14} />}
-            onClick={() => { onOnline(); setPublishOpen(false); }}
-            className="!h-9 !rounded-lg !font-medium"
-          >
-            {primaryPublishText}
-          </Button>
-        ) : null}
-        <Button
-          block
-          disabled={testing}
-          loading={saving}
-          icon={<Save size={14} />}
-          onClick={() => { onSave(); setPublishOpen(false); }}
-          className="!h-9 !rounded-lg"
-        >
-          保存草稿
-        </Button>
-        {status === 'ONLINE' && hasPublished ? (
-          <Button
-            block
-            disabled={testing}
-            loading={statusAction}
-            icon={<CircleStop size={14} />}
-            onClick={() => { onOffline(); setPublishOpen(false); }}
-            className="!h-9 !rounded-lg"
-          >
-            停用正式运行入口
-          </Button>
-        ) : null}
-      </div>
-    </div>
-  );
+  const publishMoreItems = status === 'ONLINE' && hasPublished
+    ? [{
+      key: 'offline',
+      label: <span className="text-[#b42318]">停用正式运行入口</span>,
+      icon: <CircleStop size={13} className="text-[#b42318]" />,
+    }]
+    : [];
 
   return (
-    <header className="workflow-editor-toolbar flex h-[48px] shrink-0 items-center border-b border-[#ebecef] bg-white px-3">
-      <span className="mr-auto inline-flex h-6 items-center rounded-[7px] border border-[rgba(22,24,35,.06)] bg-[#fafafa] px-2.5 text-[10px] font-medium text-[#667085]">
-        {lifecycleText}
-      </span>
-
-      <div className="flex items-center gap-1.5">
-        <Popover
-          open={runtimeSettingsOpen}
-          onOpenChange={setRuntimeSettingsOpen}
-          trigger="click"
-          placement="bottomRight"
-          arrow={false}
-          content={runtimeSettingsContent}
-          overlayInnerStyle={{ padding: 0, background: 'transparent', boxShadow: 'none' }}
+    <header className="workflow-editor-toolbar flex h-[52px] shrink-0 items-center justify-between border-b border-[#e8eaee] bg-white px-4">
+      <div className="min-w-0">
+        <div
+          className="max-w-[420px] truncate text-[13px] font-semibold leading-5 text-[#161823]"
+          title={name || '未命名工作流'}
         >
-          <Tooltip title="运行设置">
-            <Button
-              size="small"
-              aria-label="运行设置"
-              icon={<SlidersHorizontal size={14} />}
-              className="relative !h-8 !rounded-lg !border-[#dfe2e7] !px-2.5 !text-[#667085] shadow-none"
-            >
-              {hasRuntimeOverrides ? <span className="absolute right-1 top-1 h-1.5 w-1.5 rounded-full bg-[#fe2c55]" /> : null}
-            </Button>
-          </Tooltip>
-        </Popover>
+          {name || '未命名工作流'}
+        </div>
+        <div className="mt-0.5 flex h-4 items-center gap-2 text-[9px] leading-4 text-[#98a2b3]">
+          <span>{lifecycleText}</span>
+          <span className="h-1 w-1 rounded-full bg-[#d0d5dd]" />
+          <span>{nodesCount} 节点 · {edgesCount} 连线</span>
+        </div>
+      </div>
+
+      <div className="flex shrink-0 items-center gap-1.5">
+        <div className="flex items-center gap-0.5">
+          <Popover
+            open={runtimeSettingsOpen}
+            onOpenChange={setRuntimeSettingsOpen}
+            trigger="click"
+            placement="bottomRight"
+            arrow={false}
+            content={runtimeSettingsContent}
+            overlayInnerStyle={{ padding: 0, background: 'transparent', boxShadow: 'none' }}
+          >
+            <Tooltip title="运行设置">
+              <Button
+                type="text"
+                aria-label="运行设置"
+                disabled={busy}
+                icon={<SlidersHorizontal size={14} />}
+                className="relative !flex !h-8 !w-8 !min-w-0 !items-center !justify-center !rounded-[7px] !p-0 !text-[#667085] hover:!bg-[#f5f6f7] hover:!text-[#344054]"
+              >
+                {hasRuntimeOverrides ? (
+                  <span className="absolute right-[5px] top-[5px] h-1.5 w-1.5 rounded-full bg-[#fe2c55] ring-2 ring-white" />
+                ) : null}
+              </Button>
+            </Tooltip>
+          </Popover>
+
+          <Popover
+            open={versionOpen}
+            onOpenChange={(open) => {
+              setVersionOpen(open);
+              if (open) void loadVersions();
+            }}
+            trigger="click"
+            placement="bottomRight"
+            arrow={false}
+            content={versionContent}
+            overlayInnerStyle={{ padding: 0, background: 'transparent', boxShadow: 'none' }}
+          >
+            <Tooltip title="发布版本">
+              <Button
+                type="text"
+                aria-label="发布版本"
+                disabled={!definition?.id || busy}
+                icon={<History size={14} />}
+                className="!flex !h-8 !w-8 !min-w-0 !items-center !justify-center !rounded-[7px] !p-0 !text-[#667085] hover:!bg-[#f5f6f7] hover:!text-[#344054]"
+              />
+            </Tooltip>
+          </Popover>
+        </div>
+
+        <span className="mx-1 h-5 w-px bg-[#eceef1]" />
 
         <Tooltip title="保存当前草稿并按草稿配置测试，不影响已发布版本">
           <Button
             size="small"
             loading={testing}
-            disabled={!definition?.id || saving || statusAction}
-            icon={<Play size={14} />}
+            disabled={!definition?.id || busy}
+            icon={<Play size={13} />}
             onClick={onTestRun}
-            className="!h-8 !rounded-lg !border-[#dfe2e7] !px-3 !text-[12px] !font-medium !text-[#344054] shadow-none"
+            className="!h-8 !rounded-[7px] !border-[#e4e7ec] !px-3 !text-[11px] !font-medium !text-[#344054] !shadow-none"
           >
             {testing ? '测试运行中' : '测试运行'}
           </Button>
         </Tooltip>
 
-        <Popover
-          open={publishOpen}
-          onOpenChange={(open) => { if (!testing) setPublishOpen(open); }}
-          trigger="click"
-          placement="bottomRight"
-          arrow={false}
-          content={publishContent}
-          overlayInnerStyle={{ padding: 0, background: 'transparent', boxShadow: 'none' }}
+        <Button
+          size="small"
+          loading={saving}
+          disabled={testing || statusAction}
+          icon={<Save size={13} />}
+          onClick={onSave}
+          className="!h-8 !rounded-[7px] !border-[#e4e7ec] !px-3 !text-[11px] !font-medium !text-[#344054] !shadow-none"
         >
-          <Button
-            type="primary"
-            size="small"
-            disabled={testing}
-            icon={<Rocket size={14} />}
-            className="!h-8 !rounded-lg !px-3.5 !text-[12px] !font-medium"
-          >
-            发布
-            <ChevronDown size={13} className="ml-1" />
-          </Button>
-        </Popover>
+          保存草稿
+        </Button>
 
-        <Popover
-          open={versionOpen}
-          onOpenChange={(open) => {
-            setVersionOpen(open);
-            if (open) void loadVersions();
-          }}
-          trigger="click"
-          placement="bottomRight"
-          arrow={false}
-          content={versionContent}
-          overlayInnerStyle={{ padding: 0, background: 'transparent', boxShadow: 'none' }}
-        >
-          <Tooltip title="发布版本">
-            <Button
-              size="small"
-              aria-label="发布版本"
-              icon={<History size={15} />}
-              className="!h-8 !rounded-lg !border-[#dfe2e7] !px-2.5 !text-[#667085] shadow-none"
-            />
+        <div className="flex items-center">
+          <Tooltip title={!canPublish ? '当前草稿与已发布版本一致' : undefined}>
+            <span>
+              <Button
+                type="primary"
+                size="small"
+                loading={statusAction}
+                disabled={testing || saving || !canPublish}
+                icon={<Rocket size={13} />}
+                onClick={confirmPublish}
+                className={[
+                  '!h-8 !rounded-[7px] !px-3.5 !text-[11px] !font-medium !shadow-none',
+                  publishMoreItems.length ? '!rounded-r-[4px]' : '',
+                ].join(' ')}
+              >
+                {publishButtonText}
+              </Button>
+            </span>
           </Tooltip>
-        </Popover>
+
+          {publishMoreItems.length ? (
+            <Dropdown
+              trigger={['click']}
+              placement="bottomRight"
+              menu={{
+                items: publishMoreItems,
+                onClick: ({ key }) => {
+                  if (key === 'offline') confirmOffline();
+                },
+              }}
+            >
+              <Button
+                type="primary"
+                size="small"
+                aria-label="更多发布操作"
+                disabled={testing || busy}
+                icon={<ChevronDown size={12} />}
+                className="!-ml-px !h-8 !w-7 !min-w-0 !rounded-[4px] !rounded-r-[7px] !border-l-[rgba(255,255,255,.28)] !p-0 !shadow-none"
+              />
+            </Dropdown>
+          ) : null}
+        </div>
       </div>
     </header>
   );

--- a/yak-ops-ui/src/pages/workflow/definition/canvas/WorkflowToolbar.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/WorkflowToolbar.tsx
@@ -367,7 +367,7 @@ const WorkflowToolbar = (props: WorkflowToolbarProps) => {
                 aria-label="更多发布操作"
                 disabled={testing || busy}
                 icon={<ChevronDown size={12} />}
-                className="!-ml-px !h-8 !w-7 !min-w-0 !rounded-[4px] !rounded-r-[7px] !border-l-[rgba(255,255,255,.28)] !p-0 !shadow-none"
+                className="!-ml-px !h-8 !w-7 !min-w-0 !rounded-[4px] !rounded-r-[7px] !border-l-white/30 !p-0 !shadow-none"
               />
             </Dropdown>
           ) : null}


### PR DESCRIPTION
## Summary

重新设计 Workflow Toolbar，不再继续沿用 Dify 式“工具按钮堆叠 + 发布 Popover”结构，而是统一到 Yak 当前 Dashboard Fullscreen Editor 的工作区设计语言：**左侧表达当前工作流身份与生命周期，右侧明确区分工具操作和生命周期操作**。

本 PR 只优化 Workflow Toolbar 的视觉层级与操作编排，不修改工作流编排、执行、发布版本或后端逻辑。

## 新的 Toolbar 结构

```text
工作流名称
草稿 · 已发布 v3 · 有草稿修改 · 6 节点 · 5 连线

                         运行设置  历史版本  │  测试运行  保存草稿  发布 ▼
```

核心原则：

- Canvas 负责复杂度，Toolbar 只负责“我是谁 + 生命周期”
- 工具操作降级，生命周期操作前置
- 保存草稿不再藏在发布 Popover 中
- 发布保持唯一主操作
- 停用属于发布的次级危险动作，不与保存/测试混在一起

## 1. 左侧改为工作流身份区

移除原来孤立的 lifecycle Tag，改为：

- 工作流名称：13px / semibold
- 生命周期：灰色弱提示文本
- 节点 / 连线数量：与状态放在同一信息层

示例：

```text
订单同步工作流
草稿 · 已发布 v3 · 有草稿修改  ·  8 节点 · 7 连线
```

避免 Toolbar 只剩右侧一排按钮、中间大量空白的割裂感。

## 2. 工具操作与生命周期操作分组

右侧调整为三级视觉层级：

```text
弱操作
运行设置 / 历史版本

普通操作
测试运行 / 保存草稿

核心操作
发布
```

运行设置和历史版本改成 32x32 text/ghost icon button，并通过 divider 与测试/保存/发布分开。

## 3. 保存草稿变成一级可见动作

原来的“保存草稿”位于发布 Popover 内，用户必须先理解“发布”再寻找“保存”。

现在直接变为：

```text
测试运行   保存草稿   发布
```

更符合工作流编辑过程：

```text
编辑 -> 保存草稿 -> 测试运行 -> 发布
```

## 4. 发布交互瘦身

移除原来的大块发布 Popover。

现在点击主按钮直接进入轻量确认：

```text
发布工作流 v4？

当前草稿将形成不可变的 v4，
已有运行实例不会受到影响。

取消 / 发布
```

如果工作流已停用且草稿未变化，则明确展示“重新启用”。

如果当前工作流在线，发布按钮右侧保留小型 split dropdown，仅承载：

- 停用正式运行入口

停用动作使用独立二次确认，不再和保存草稿、发布新版本混在同一个 Popover 中。

## 5. Popover 视觉降噪

运行设置和版本历史保留现有能力，但统一：

- 300~320px 宽度
- 10px 圆角
- 更轻的 shadow
- 更弱的辅助说明
- 当前版本标识改为灰阶，不再使用高饱和红色 Tag

## Scope

仅修改：

- `yak-ops-ui/src/pages/workflow/definition/canvas/WorkflowToolbar.tsx`

明确不改：

- WorkflowDefinitionEditor 编排逻辑
- ReactFlow Node / Edge / Inspector
- Undo / Redo / History Canvas
- 测试运行实现
- 草稿保存 API
- 发布 / 停用 API
- Workflow Version 数据模型
- 后端 / DB / Scheduler Runtime

## Verification

- 基于当前 `main`: `6a57c63321e863ebd1a427209c905bc56ea3e779`
- branch 相对 main：ahead 2 / behind 0
- diff 仅 1 个 Workflow Toolbar 前端文件
- 复用现有 `onSave / onTestRun / onOnline / onOffline`，未改变调用边界
- 保留现有运行设置与版本历史查询
- 当前 connector 环境没有本地 Node 依赖执行环境，因此不宣称 `tsc/build` 已通过；Draft 阶段继续以仓库 CI/status 为准
