### PR TITLE
feat(data-service): add API documentation and OpenAPI center

### DIFF
--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/dataservice/controller/v1/DataServiceController.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/dataservice/controller/v1/DataServiceController.java
@@ -9,6 +9,9 @@ import io.yak.ops.business.dataservice.service.DataServiceAccessService.ApiKeyIn
 import io.yak.ops.business.dataservice.service.DataServiceAccessService.ApiKeyUpdate;
 import io.yak.ops.business.dataservice.service.DataServiceAccessService.ApiKeyView;
 import io.yak.ops.business.dataservice.service.DataServiceAccessService.CreatedApiKey;
+import io.yak.ops.business.dataservice.service.DataServiceDocumentationService;
+import io.yak.ops.business.dataservice.service.DataServiceDocumentationService.ApiDocumentation;
+import io.yak.ops.business.dataservice.service.DataServiceDocumentationService.DocumentationInput;
 import io.yak.ops.business.dataservice.service.DataServiceRuntimeService.RuntimeSnapshot;
 import io.yak.ops.business.dataservice.service.DataServiceService;
 import io.yak.ops.business.dataservice.service.DataServiceService.ApiInput;
@@ -30,7 +33,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-/** 数据服务管理、访问控制、Runtime 策略与调用接口。 */
+/** 数据服务管理、文档、访问控制、Runtime 策略与调用接口。 */
 @Tag(name = "数据服务")
 @RestController
 @ConditionalOnDataSourceEnabled
@@ -40,6 +43,7 @@ public class DataServiceController {
 
   private final DataServiceService dataServiceService;
   private final DataServiceAccessService accessService;
+  private final DataServiceDocumentationService documentationService;
 
   @Operation(summary = "查询 API 服务列表")
   @GetMapping
@@ -69,6 +73,7 @@ public class DataServiceController {
   @DeleteMapping("/{id}")
   public Result<Boolean> delete(@PathVariable("id") Long id) {
     dataServiceService.delete(id);
+    documentationService.deleteForApi(id);
     return Result.success(Boolean.TRUE);
   }
 
@@ -78,6 +83,26 @@ public class DataServiceController {
       @PathVariable("id") Long id,
       @RequestParam("enabled") boolean enabled) {
     return Result.success(dataServiceService.setEnabled(id, enabled));
+  }
+
+  @Operation(summary = "查询 API 参数与响应文档")
+  @GetMapping("/{id}/documentation")
+  public Result<ApiDocumentation> documentation(@PathVariable("id") Long id) {
+    return Result.success(documentationService.get(id));
+  }
+
+  @Operation(summary = "保存 API 参数与响应文档")
+  @PutMapping("/{id}/documentation")
+  public Result<ApiDocumentation> saveDocumentation(
+      @PathVariable("id") Long id,
+      @RequestBody DocumentationInput input) {
+    return Result.success(documentationService.save(id, input));
+  }
+
+  @Operation(summary = "生成单个数据服务 OpenAPI 3 文档")
+  @GetMapping("/{id}/openapi")
+  public Result<Map<String, Object>> openApi(@PathVariable("id") Long id) {
+    return Result.success(documentationService.openApi(id));
   }
 
   @Operation(summary = "查询数据服务 Runtime 状态与指标")

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/dataservice/dao/mapper/DataServiceDocumentationMapper.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/dataservice/dao/mapper/DataServiceDocumentationMapper.java
@@ -1,0 +1,8 @@
+package io.yak.ops.business.dataservice.dao.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import io.yak.ops.business.dataservice.dao.model.DataServiceDocumentationPO;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface DataServiceDocumentationMapper extends BaseMapper<DataServiceDocumentationPO> {}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/dataservice/dao/model/DataServiceDocumentationPO.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/dataservice/dao/model/DataServiceDocumentationPO.java
@@ -1,0 +1,19 @@
+package io.yak.ops.business.dataservice.dao.model;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import java.time.LocalDateTime;
+import lombok.Data;
+
+/** 数据服务 API 文档元数据。 */
+@Data
+@TableName("yak_ops_data_service_documentation")
+public class DataServiceDocumentationPO {
+
+  @TableId(value = "api_id", type = IdType.INPUT)
+  private Long apiId;
+  private String parameterSchemaJson;
+  private String responseSchemaJson;
+  private LocalDateTime updateTime;
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/dataservice/dao/model/DataServiceDocumentationPO.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/dataservice/dao/model/DataServiceDocumentationPO.java
@@ -13,6 +13,7 @@ public class DataServiceDocumentationPO {
 
   @TableId(value = "api_id", type = IdType.INPUT)
   private Long apiId;
+  private String sqlHash;
   private String parameterSchemaJson;
   private String responseSchemaJson;
   private LocalDateTime updateTime;

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/dataservice/service/DataServiceDocumentationService.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/dataservice/service/DataServiceDocumentationService.java
@@ -1,0 +1,367 @@
+package io.yak.ops.business.dataservice.service;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.dataservice.dao.mapper.DataServiceDocumentationMapper;
+import io.yak.ops.business.dataservice.dao.model.DataServiceDocumentationPO;
+import io.yak.ops.business.dataservice.service.DataServiceService.ApiView;
+import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HexFormat;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+/** Parameter/response documentation and single-service OpenAPI generation. */
+@Service
+@ConditionalOnDataSourceEnabled
+@RequiredArgsConstructor
+public class DataServiceDocumentationService {
+
+  private static final Set<String> PARAMETER_TYPES =
+      Set.of("STRING", "INTEGER", "NUMBER", "BOOLEAN", "DATE", "DATETIME");
+  private static final Set<String> RESPONSE_TYPES =
+      Set.of("STRING", "INTEGER", "NUMBER", "BOOLEAN", "DATE", "DATETIME", "OBJECT");
+
+  private final DataServiceDocumentationMapper documentationMapper;
+  private final DataServiceService dataServiceService;
+  private final ObjectMapper objectMapper;
+
+  public ApiDocumentation get(Long apiId) {
+    ApiView api = dataServiceService.get(apiId);
+    DataServiceDocumentationPO stored = documentationMapper.selectById(apiId);
+    return toView(api, stored);
+  }
+
+  @Transactional
+  public ApiDocumentation save(Long apiId, DocumentationInput input) {
+    if (input == null) throw new IllegalArgumentException("API 文档配置不能为空");
+    ApiView api = dataServiceService.get(apiId);
+    List<ParameterDoc> parameters = normalizeParameters(api.parameterNames(), input.parameters());
+    List<ResponseFieldDoc> responseFields = normalizeResponseFields(input.responseFields());
+
+    DataServiceDocumentationPO po = documentationMapper.selectById(apiId);
+    boolean create = po == null;
+    if (create) {
+      po = new DataServiceDocumentationPO();
+      po.setApiId(apiId);
+    }
+    po.setSqlHash(sqlHash(api.sql()));
+    po.setParameterSchemaJson(json(parameters));
+    po.setResponseSchemaJson(json(responseFields));
+    po.setUpdateTime(LocalDateTime.now());
+    if (create) documentationMapper.insert(po);
+    else documentationMapper.updateById(po);
+    return toView(api, po);
+  }
+
+  @Transactional
+  public void deleteForApi(Long apiId) {
+    if (apiId != null) documentationMapper.deleteById(apiId);
+  }
+
+  public Map<String, Object> openApi(Long apiId) {
+    ApiDocumentation doc = get(apiId);
+    Map<String, Object> root = new LinkedHashMap<>();
+    root.put("openapi", "3.0.3");
+    root.put("info", map(
+        "title", doc.name(),
+        "version", "1.0.0",
+        "description", StringUtils.hasText(doc.description()) ? doc.description() : "Yak Ops Data Service"));
+    root.put("x-yak-documented", doc.documented());
+    root.put("x-yak-schema-stale", doc.schemaStale());
+
+    List<Map<String, Object>> parameters = new ArrayList<>();
+    for (ParameterDoc parameter : doc.parameters()) {
+      Map<String, Object> item = new LinkedHashMap<>();
+      item.put("name", parameter.name());
+      item.put("in", "query");
+      item.put("required", true);
+      if (StringUtils.hasText(parameter.description())) item.put("description", parameter.description());
+      item.put("schema", schema(parameter.type(), false));
+      if (StringUtils.hasText(parameter.example())) item.put("example", parameter.example());
+      parameters.add(item);
+    }
+
+    Map<String, Object> operation = new LinkedHashMap<>();
+    operation.put("summary", doc.name());
+    operation.put("operationId", "dataService_" + doc.apiId());
+    if (StringUtils.hasText(doc.description())) operation.put("description", doc.description());
+    operation.put("parameters", parameters);
+    if ("API_KEY".equals(doc.authMode())) {
+      operation.put("security", List.of(Map.of("ApiKeyAuth", List.of())));
+    }
+    operation.put("responses", responses(doc.responseFields()));
+    root.put("paths", Map.of(doc.runtimePath(), Map.of("get", operation)));
+
+    if ("API_KEY".equals(doc.authMode())) {
+      root.put("components", Map.of(
+          "securitySchemes", Map.of(
+              "ApiKeyAuth", map(
+                  "type", "apiKey",
+                  "in", "header",
+                  "name", "X-API-Key"))));
+    }
+    return root;
+  }
+
+  private ApiDocumentation toView(ApiView api, DataServiceDocumentationPO stored) {
+    List<ParameterDoc> savedParameters = stored == null
+        ? List.of()
+        : read(stored.getParameterSchemaJson(), new TypeReference<List<ParameterDoc>>() {});
+    List<ResponseFieldDoc> savedResponseFields = stored == null
+        ? List.of()
+        : read(stored.getResponseSchemaJson(), new TypeReference<List<ResponseFieldDoc>>() {});
+    List<ParameterDoc> parameters = mergeCurrentParameters(api.parameterNames(), savedParameters);
+    boolean documented = stored != null;
+    boolean stale = documented
+        && StringUtils.hasText(stored.getSqlHash())
+        && !stored.getSqlHash().equals(sqlHash(api.sql()));
+    return new ApiDocumentation(
+        api.id(),
+        api.name(),
+        api.runtimePath(),
+        api.authMode(),
+        api.description(),
+        documented,
+        stale,
+        parameters,
+        savedResponseFields,
+        stored == null ? null : stored.getUpdateTime());
+  }
+
+  private List<ParameterDoc> normalizeParameters(
+      List<String> currentNames,
+      List<ParameterDoc> input) {
+    List<ParameterDoc> supplied = input == null ? List.of() : input;
+    Set<String> current = new LinkedHashSet<>(currentNames == null ? List.of() : currentNames);
+    Set<String> seen = new LinkedHashSet<>();
+    Map<String, ParameterDoc> byName = new LinkedHashMap<>();
+    for (ParameterDoc parameter : supplied) {
+      if (parameter == null || !StringUtils.hasText(parameter.name())) {
+        throw new IllegalArgumentException("参数名称不能为空");
+      }
+      String name = parameter.name().trim();
+      if (!current.contains(name)) throw new IllegalArgumentException("SQL 中不存在参数：" + name);
+      if (!seen.add(name)) throw new IllegalArgumentException("参数文档重复：" + name);
+      byName.put(name, new ParameterDoc(
+          name,
+          normalizeType(parameter.type(), PARAMETER_TYPES),
+          true,
+          trim(parameter.description(), 500),
+          trim(parameter.example(), 500)));
+    }
+    List<ParameterDoc> result = new ArrayList<>();
+    for (String name : current) {
+      result.add(byName.getOrDefault(name, new ParameterDoc(name, "STRING", true, null, null)));
+    }
+    return result;
+  }
+
+  private List<ParameterDoc> mergeCurrentParameters(
+      List<String> currentNames,
+      List<ParameterDoc> saved) {
+    Map<String, ParameterDoc> savedByName = (saved == null ? List.<ParameterDoc>of() : saved)
+        .stream()
+        .filter(item -> item != null && StringUtils.hasText(item.name()))
+        .collect(Collectors.toMap(
+            item -> item.name().trim(),
+            Function.identity(),
+            (first, ignored) -> first,
+            LinkedHashMap::new));
+    List<ParameterDoc> result = new ArrayList<>();
+    for (String name : currentNames == null ? List.<String>of() : currentNames) {
+      ParameterDoc item = savedByName.get(name);
+      result.add(item == null
+          ? new ParameterDoc(name, "STRING", true, null, null)
+          : new ParameterDoc(
+              name,
+              normalizeType(item.type(), PARAMETER_TYPES),
+              true,
+              trim(item.description(), 500),
+              trim(item.example(), 500)));
+    }
+    return result;
+  }
+
+  private List<ResponseFieldDoc> normalizeResponseFields(List<ResponseFieldDoc> input) {
+    List<ResponseFieldDoc> supplied = input == null ? List.of() : input;
+    if (supplied.size() > 200) throw new IllegalArgumentException("响应字段不能超过 200 个");
+    Set<String> seen = new LinkedHashSet<>();
+    List<ResponseFieldDoc> result = new ArrayList<>();
+    for (ResponseFieldDoc field : supplied) {
+      if (field == null || !StringUtils.hasText(field.name())) {
+        throw new IllegalArgumentException("响应字段名称不能为空");
+      }
+      String name = field.name().trim();
+      if (!seen.add(name)) throw new IllegalArgumentException("响应字段重复：" + name);
+      result.add(new ResponseFieldDoc(
+          name,
+          normalizeType(field.type(), RESPONSE_TYPES),
+          field.nullable(),
+          trim(field.description(), 500),
+          trim(field.example(), 500)));
+    }
+    return result;
+  }
+
+  private Map<String, Object> responses(List<ResponseFieldDoc> fields) {
+    Map<String, Object> rowProperties = new LinkedHashMap<>();
+    for (ResponseFieldDoc field : fields == null ? List.<ResponseFieldDoc>of() : fields) {
+      Map<String, Object> fieldSchema = schema(field.type(), field.nullable());
+      if (StringUtils.hasText(field.description())) fieldSchema.put("description", field.description());
+      if (StringUtils.hasText(field.example())) fieldSchema.put("example", field.example());
+      rowProperties.put(field.name(), fieldSchema);
+    }
+
+    Map<String, Object> dataProperties = new LinkedHashMap<>();
+    dataProperties.put("columns", map("type", "array", "items", Map.of("type", "string")));
+    dataProperties.put("rows", map(
+        "type", "array",
+        "items", map("type", "object", "properties", rowProperties, "additionalProperties", true)));
+    dataProperties.put("truncated", Map.of("type", "boolean"));
+    dataProperties.put("rowCount", map("type", "integer", "format", "int32"));
+    dataProperties.put("durationMs", map("type", "integer", "format", "int64"));
+
+    Map<String, Object> envelope = map(
+        "type", "object",
+        "properties", map(
+            "code", map("type", "integer", "format", "int32"),
+            "data", map("type", "object", "properties", dataProperties),
+            "msg", Map.of("type", "string"),
+            "message", Map.of("type", "string")));
+
+    Map<String, Object> responses = new LinkedHashMap<>();
+    responses.put("200", map(
+        "description", "Success",
+        "content", Map.of("application/json", Map.of("schema", envelope))));
+    responses.put("401", Map.of("description", "Missing or invalid API Key"));
+    responses.put("429", Map.of("description", "Rate limit exceeded"));
+    responses.put("503", Map.of("description", "Runtime circuit breaker is open"));
+    return responses;
+  }
+
+  private Map<String, Object> schema(String type, boolean nullable) {
+    String normalized = normalizeType(type, RESPONSE_TYPES);
+    Map<String, Object> schema = new LinkedHashMap<>();
+    switch (normalized) {
+      case "INTEGER" -> {
+        schema.put("type", "integer");
+        schema.put("format", "int64");
+      }
+      case "NUMBER" -> {
+        schema.put("type", "number");
+        schema.put("format", "double");
+      }
+      case "BOOLEAN" -> schema.put("type", "boolean");
+      case "DATE" -> {
+        schema.put("type", "string");
+        schema.put("format", "date");
+      }
+      case "DATETIME" -> {
+        schema.put("type", "string");
+        schema.put("format", "date-time");
+      }
+      case "OBJECT" -> {
+        schema.put("type", "object");
+        schema.put("additionalProperties", true);
+      }
+      default -> schema.put("type", "string");
+    }
+    if (nullable) schema.put("nullable", true);
+    return schema;
+  }
+
+  private String normalizeType(String type, Set<String> allowed) {
+    String normalized = StringUtils.hasText(type) ? type.trim().toUpperCase() : "STRING";
+    if (!allowed.contains(normalized)) throw new IllegalArgumentException("不支持的 Schema 类型：" + normalized);
+    return normalized;
+  }
+
+  private String sqlHash(String sql) {
+    try {
+      MessageDigest digest = MessageDigest.getInstance("SHA-256");
+      return HexFormat.of().formatHex(digest.digest((sql == null ? "" : sql).getBytes(StandardCharsets.UTF_8)));
+    } catch (Exception exception) {
+      throw new IllegalStateException("无法计算 SQL 文档指纹", exception);
+    }
+  }
+
+  private String json(Object value) {
+    try {
+      return objectMapper.writeValueAsString(value);
+    } catch (Exception exception) {
+      throw new IllegalStateException("API 文档序列化失败", exception);
+    }
+  }
+
+  private <T> T read(String value, TypeReference<T> type) {
+    if (!StringUtils.hasText(value)) {
+      try {
+        return objectMapper.readValue("[]", type);
+      } catch (Exception exception) {
+        throw new IllegalStateException("API 文档初始化失败", exception);
+      }
+    }
+    try {
+      return objectMapper.readValue(value, type);
+    } catch (Exception exception) {
+      throw new IllegalStateException("API 文档内容无法解析", exception);
+    }
+  }
+
+  private String trim(String value, int maxLength) {
+    if (!StringUtils.hasText(value)) return null;
+    String result = value.trim();
+    return result.length() <= maxLength ? result : result.substring(0, maxLength);
+  }
+
+  private Map<String, Object> map(Object... values) {
+    Map<String, Object> result = new LinkedHashMap<>();
+    for (int index = 0; index + 1 < values.length; index += 2) {
+      result.put(String.valueOf(values[index]), values[index + 1]);
+    }
+    return result;
+  }
+
+  public record ParameterDoc(
+      String name,
+      String type,
+      boolean required,
+      String description,
+      String example) {}
+
+  public record ResponseFieldDoc(
+      String name,
+      String type,
+      boolean nullable,
+      String description,
+      String example) {}
+
+  public record DocumentationInput(
+      List<ParameterDoc> parameters,
+      List<ResponseFieldDoc> responseFields) {}
+
+  public record ApiDocumentation(
+      Long apiId,
+      String name,
+      String runtimePath,
+      String authMode,
+      String description,
+      boolean documented,
+      boolean schemaStale,
+      List<ParameterDoc> parameters,
+      List<ResponseFieldDoc> responseFields,
+      LocalDateTime updateTime) {}
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/dataservice/service/DataServiceDocumentationService.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/dataservice/service/DataServiceDocumentationService.java
@@ -97,12 +97,13 @@ public class DataServiceDocumentationService {
     Map<String, Object> operation = new LinkedHashMap<>();
     operation.put("summary", doc.name());
     operation.put("operationId", "dataService_" + doc.apiId());
+    operation.put("x-yak-schema-stale", doc.schemaStale());
     if (StringUtils.hasText(doc.description())) operation.put("description", doc.description());
     operation.put("parameters", parameters);
     if ("API_KEY".equals(doc.authMode())) {
       operation.put("security", List.of(Map.of("ApiKeyAuth", List.of())));
     }
-    operation.put("responses", responses(doc.responseFields()));
+    operation.put("responses", responses(doc.schemaStale() ? List.of() : doc.responseFields()));
     root.put("paths", Map.of(doc.runtimePath(), Map.of("get", operation)));
 
     if ("API_KEY".equals(doc.authMode())) {

--- a/yak-ops-business/yak-ops-business-datasource/src/main/resources/db/migration/yak-datasource/V7__add_data_service_documentation.sql
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/resources/db/migration/yak-datasource/V7__add_data_service_documentation.sql
@@ -1,6 +1,7 @@
 -- 数据服务第五阶段：参数/响应 Schema 与 OpenAPI 文档元数据。
 CREATE TABLE IF NOT EXISTS yak_ops_data_service_documentation (
     api_id BIGINT UNSIGNED NOT NULL COMMENT '数据服务 API ID',
+    sql_hash CHAR(64) DEFAULT NULL COMMENT '保存文档时的 SQL SHA-256，用于识别 Schema 漂移',
     parameter_schema_json MEDIUMTEXT DEFAULT NULL COMMENT '请求参数文档 JSON',
     response_schema_json MEDIUMTEXT DEFAULT NULL COMMENT '响应行字段文档 JSON',
     update_time DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3)

--- a/yak-ops-business/yak-ops-business-datasource/src/main/resources/db/migration/yak-datasource/V7__add_data_service_documentation.sql
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/resources/db/migration/yak-datasource/V7__add_data_service_documentation.sql
@@ -1,0 +1,12 @@
+-- 数据服务第五阶段：参数/响应 Schema 与 OpenAPI 文档元数据。
+CREATE TABLE IF NOT EXISTS yak_ops_data_service_documentation (
+    api_id BIGINT UNSIGNED NOT NULL COMMENT '数据服务 API ID',
+    parameter_schema_json MEDIUMTEXT DEFAULT NULL COMMENT '请求参数文档 JSON',
+    response_schema_json MEDIUMTEXT DEFAULT NULL COMMENT '响应行字段文档 JSON',
+    update_time DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3)
+        ON UPDATE CURRENT_TIMESTAMP(3) COMMENT '更新时间',
+    PRIMARY KEY (api_id)
+) ENGINE=InnoDB
+  DEFAULT CHARSET=utf8mb4
+  COLLATE=utf8mb4_unicode_ci
+  COMMENT='Yak Ops 数据服务 API 文档元数据';

--- a/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/dataservice/service/DataServiceDocumentationServiceTest.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/dataservice/service/DataServiceDocumentationServiceTest.java
@@ -1,0 +1,132 @@
+package io.yak.ops.business.dataservice.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.dataservice.dao.mapper.DataServiceDocumentationMapper;
+import io.yak.ops.business.dataservice.dao.model.DataServiceDocumentationPO;
+import io.yak.ops.business.dataservice.service.DataServiceDocumentationService.DocumentationInput;
+import io.yak.ops.business.dataservice.service.DataServiceDocumentationService.ParameterDoc;
+import io.yak.ops.business.dataservice.service.DataServiceDocumentationService.ResponseFieldDoc;
+import io.yak.ops.business.dataservice.service.DataServiceService.ApiView;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class DataServiceDocumentationServiceTest {
+
+  private DataServiceDocumentationMapper mapper;
+  private DataServiceService dataServiceService;
+  private DataServiceDocumentationService service;
+
+  @BeforeEach
+  void setUp() {
+    mapper = mock(DataServiceDocumentationMapper.class);
+    dataServiceService = mock(DataServiceService.class);
+    service = new DataServiceDocumentationService(mapper, dataServiceService, new ObjectMapper());
+  }
+
+  @Test
+  void currentSqlParametersAreSourceOfTruth() throws Exception {
+    ApiView api = api("select * from orders where status = :status and tenant_id = :tenantId");
+    when(dataServiceService.get(7L)).thenReturn(api);
+
+    DataServiceDocumentationPO po = new DataServiceDocumentationPO();
+    po.setApiId(7L);
+    po.setSqlHash(hash(api.sql()));
+    po.setParameterSchemaJson("[{\"name\":\"status\",\"type\":\"STRING\",\"required\":true,\"description\":\"订单状态\"},{\"name\":\"removed\",\"type\":\"STRING\",\"required\":true}]");
+    po.setResponseSchemaJson("[]");
+    when(mapper.selectById(7L)).thenReturn(po);
+
+    var result = service.get(7L);
+
+    assertThat(result.parameters()).extracting(ParameterDoc::name)
+        .containsExactly("status", "tenantId");
+    assertThat(result.parameters().get(0).description()).isEqualTo("订单状态");
+    assertThat(result.parameters().get(1).type()).isEqualTo("STRING");
+    assertThat(result.schemaStale()).isFalse();
+  }
+
+  @Test
+  void savePersistsSqlFingerprintAndOpenApiReflectsSecurityAndRowSchema() throws Exception {
+    ApiView api = api("select id, amount from orders where status = :status");
+    when(dataServiceService.get(7L)).thenReturn(api);
+    when(mapper.selectById(7L)).thenReturn(null);
+
+    var saved = service.save(
+        7L,
+        new DocumentationInput(
+            List.of(new ParameterDoc("status", "STRING", true, "订单状态", "PAID")),
+            List.of(
+                new ResponseFieldDoc("id", "INTEGER", false, "订单 ID", "1001"),
+                new ResponseFieldDoc("amount", "NUMBER", true, "订单金额", "99.50"))));
+
+    ArgumentCaptor<DataServiceDocumentationPO> captor =
+        ArgumentCaptor.forClass(DataServiceDocumentationPO.class);
+    verify(mapper).insert(captor.capture());
+    assertThat(captor.getValue().getSqlHash()).isEqualTo(hash(api.sql()));
+    assertThat(saved.documented()).isTrue();
+
+    DataServiceDocumentationPO persisted = captor.getValue();
+    when(mapper.selectById(7L)).thenReturn(persisted);
+    Map<String, Object> spec = service.openApi(7L);
+
+    assertThat(spec.get("openapi")).isEqualTo("3.0.3");
+    assertThat(spec).containsKey("components");
+    assertThat(spec.get("paths").toString()).contains(api.runtimePath()).contains("status").contains("amount");
+  }
+
+  @Test
+  void rejectsDocumentationForParameterNotPresentInSql() {
+    when(dataServiceService.get(7L)).thenReturn(api("select * from orders where status = :status"));
+
+    assertThatThrownBy(() -> service.save(
+        7L,
+        new DocumentationInput(
+            List.of(new ParameterDoc("tenantId", "STRING", true, null, null)),
+            List.of())))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("SQL 中不存在参数");
+    verify(mapper, org.mockito.Mockito.never()).insert(any());
+  }
+
+  private ApiView api(String sql) {
+    List<String> parameters = sql.contains(":tenantId")
+        ? List.of("status", "tenantId")
+        : List.of("status");
+    return new ApiView(
+        7L,
+        "订单查询",
+        "/orders",
+        "/api/v1/data-service/runtime/orders",
+        42L,
+        sql,
+        parameters,
+        1000,
+        30,
+        true,
+        "API_KEY",
+        "供订单系统查询",
+        "DATA_DEVELOPMENT_RELEASE",
+        "88",
+        102L,
+        2,
+        null,
+        null);
+  }
+
+  private String hash(String value) throws Exception {
+    return HexFormat.of().formatHex(
+        MessageDigest.getInstance("SHA-256").digest(value.getBytes(StandardCharsets.UTF_8)));
+  }
+}

--- a/yak-ops-ui/src/pages/data-service/DataServiceDocsModal.tsx
+++ b/yak-ops-ui/src/pages/data-service/DataServiceDocsModal.tsx
@@ -65,14 +65,15 @@ const DataServiceDocsModal = ({ open, service, onCancel }: DataServiceDocsModalP
         fetchDataServiceDocumentation(service.id),
         fetchDataServiceOpenApi(service.id),
       ]);
-      if (!docResponse.data) throw new Error(docResponse.message || docResponse.msg || '加载 API 文档失败');
-      setDocumentation(docResponse.data);
-      setParameters(docResponse.data.parameters || []);
-      setResponseFields(docResponse.data.responseFields || []);
+      const doc = docResponse.data;
+      if (!doc) throw new Error(docResponse.message || docResponse.msg || '加载 API 文档失败');
+      setDocumentation(doc);
+      setParameters(doc.parameters || []);
+      setResponseFields(doc.responseFields || []);
       setOpenApi(openApiResponse.data || {});
       setDebugValues((current) => {
         const next: Record<string, string> = {};
-        for (const parameter of docResponse.data.parameters || []) {
+        for (const parameter of doc.parameters || []) {
           next[parameter.name] = current[parameter.name] || parameter.example || '';
         }
         return next;
@@ -96,10 +97,11 @@ const DataServiceDocsModal = ({ open, service, onCancel }: DataServiceDocsModalP
     setSaving(true);
     try {
       const response = await saveDataServiceDocumentation(service.id, { parameters, responseFields });
-      if (!response.data) throw new Error(response.message || response.msg || '保存 API 文档失败');
-      setDocumentation(response.data);
-      setParameters(response.data.parameters || []);
-      setResponseFields(response.data.responseFields || []);
+      const doc = response.data;
+      if (!doc) throw new Error(response.message || response.msg || '保存 API 文档失败');
+      setDocumentation(doc);
+      setParameters(doc.parameters || []);
+      setResponseFields(doc.responseFields || []);
       const openApiResponse = await fetchDataServiceOpenApi(service.id);
       setOpenApi(openApiResponse.data || {});
       message.success('API 文档与 OpenAPI 已更新');
@@ -120,9 +122,10 @@ const DataServiceDocsModal = ({ open, service, onCancel }: DataServiceDocsModalP
     setTesting(true);
     try {
       const response = await testDataService(service.id, debugValues);
-      if (!response.data) throw new Error(response.message || response.msg || '在线调试失败');
-      setTestResult(response.data);
-      setResponseFields((current) => inferResponseFields(response.data, current));
+      const result = response.data;
+      if (!result) throw new Error(response.message || response.msg || '在线调试失败');
+      setTestResult(result);
+      setResponseFields((current) => inferResponseFields(result, current));
       message.success('调试成功，已根据真实结果识别响应 Schema；保存文档后生效');
     } catch (error) {
       message.error(error instanceof Error ? error.message : '在线调试失败');
@@ -142,11 +145,14 @@ const DataServiceDocsModal = ({ open, service, onCancel }: DataServiceDocsModalP
 
   const curl = useMemo(() => {
     if (!service) return '';
+    const lineBreak = ' ' + '\\' + '\n';
     const query = parameters
       .map((item) => `  --data-urlencode '${item.name}=${item.example || `<${item.name}>`}'`)
-      .join(' \\\n');
-    const auth = service.authMode === 'API_KEY' ? " \\\n  -H 'X-API-Key: <your-api-key>'" : '';
-    return `curl -G '${service.runtimePath}'${query ? ` \\\n${query}` : ''}${auth}`;
+      .join(lineBreak);
+    const auth = service.authMode === 'API_KEY'
+      ? `${lineBreak}  -H 'X-API-Key: <your-api-key>'`
+      : '';
+    return `curl -G '${service.runtimePath}'${query ? `${lineBreak}${query}` : ''}${auth}`;
   }, [parameters, service]);
 
   const resultColumns = (testResult?.columns || []).map((name) => ({
@@ -206,16 +212,16 @@ const DataServiceDocsModal = ({ open, service, onCancel }: DataServiceDocsModalP
             { title: '参数名', dataIndex: 'name', width: 150, render: (value) => <span className="font-mono text-[12px]">{value}</span> },
             {
               title: '类型', dataIndex: 'type', width: 130,
-              render: (_, row, index) => <Select size="small" className="w-full" value={row.type} options={parameterTypes.map((type) => ({ value: type, label: typeLabel[type] }))} onChange={(type) => setParameters((items) => items.map((item, i) => i === index ? { ...item, type: type as DataServiceParameterDoc['type'] } : item))} />,
+              render: (_, row, index) => <Select size="small" className="w-full" value={row.type} options={parameterTypes.map((type) => ({ value: type, label: typeLabel[type] }))} onChange={(type) => setParameters((values) => values.map((item, i) => i === index ? { ...item, type: type as DataServiceParameterDoc['type'] } : item))} />,
             },
             { title: '必填', dataIndex: 'required', width: 70, render: () => <Tag bordered={false}>是</Tag> },
             {
               title: '说明', dataIndex: 'description', minWidth: 180,
-              render: (_, row, index) => <Input size="small" value={row.description || ''} placeholder="业务含义" onChange={(event) => setParameters((items) => items.map((item, i) => i === index ? { ...item, description: event.target.value } : item))} />,
+              render: (_, row, index) => <Input size="small" value={row.description || ''} placeholder="业务含义" onChange={(event) => setParameters((values) => values.map((item, i) => i === index ? { ...item, description: event.target.value } : item))} />,
             },
             {
               title: '示例', dataIndex: 'example', width: 160,
-              render: (_, row, index) => <Input size="small" value={row.example || ''} placeholder="示例值" onChange={(event) => setParameters((items) => items.map((item, i) => i === index ? { ...item, example: event.target.value } : item))} />,
+              render: (_, row, index) => <Input size="small" value={row.example || ''} placeholder="示例值" onChange={(event) => setParameters((values) => values.map((item, i) => i === index ? { ...item, example: event.target.value } : item))} />,
             },
           ]}
           scroll={{ x: 780 }}
@@ -237,12 +243,12 @@ const DataServiceDocsModal = ({ open, service, onCancel }: DataServiceDocsModalP
               { title: '字段', dataIndex: 'name', width: 150, render: (value) => <span className="font-mono text-[12px]">{value}</span> },
               {
                 title: '类型', dataIndex: 'type', width: 130,
-                render: (_, row, index) => <Select size="small" className="w-full" value={row.type} options={responseTypes.map((type) => ({ value: type, label: typeLabel[type] }))} onChange={(type) => setResponseFields((items) => items.map((item, i) => i === index ? { ...item, type } : item))} />,
+                render: (_, row, index) => <Select size="small" className="w-full" value={row.type} options={responseTypes.map((type) => ({ value: type, label: typeLabel[type] }))} onChange={(type) => setResponseFields((values) => values.map((item, i) => i === index ? { ...item, type: type as DataServiceSchemaType } : item))} />,
               },
               { title: '可空', dataIndex: 'nullable', width: 70, render: (value) => value ? '是' : '否' },
               {
                 title: '说明', dataIndex: 'description', minWidth: 180,
-                render: (_, row, index) => <Input size="small" value={row.description || ''} placeholder="字段含义" onChange={(event) => setResponseFields((items) => items.map((item, i) => i === index ? { ...item, description: event.target.value } : item))} />,
+                render: (_, row, index) => <Input size="small" value={row.description || ''} placeholder="字段含义" onChange={(event) => setResponseFields((values) => values.map((item, i) => i === index ? { ...item, description: event.target.value } : item))} />,
               },
               { title: '示例', dataIndex: 'example', width: 160, ellipsis: true },
             ]}

--- a/yak-ops-ui/src/pages/data-service/DataServiceDocsModal.tsx
+++ b/yak-ops-ui/src/pages/data-service/DataServiceDocsModal.tsx
@@ -1,0 +1,375 @@
+import {
+  Button,
+  Input,
+  Modal,
+  Select,
+  Spin,
+  Table,
+  Tabs,
+  Tag,
+  message,
+} from 'antd';
+import { Copy, Play, RefreshCw } from 'lucide-react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import {
+  fetchDataServiceDocumentation,
+  fetchDataServiceOpenApi,
+  saveDataServiceDocumentation,
+  testDataService,
+  type DataServiceApi,
+  type DataServiceDocumentation,
+  type DataServiceParameterDoc,
+  type DataServiceQueryResult,
+  type DataServiceResponseFieldDoc,
+  type DataServiceSchemaType,
+} from './service';
+
+interface DataServiceDocsModalProps {
+  open: boolean;
+  service?: DataServiceApi;
+  onCancel: () => void;
+}
+
+const parameterTypes: DataServiceSchemaType[] = [
+  'STRING', 'INTEGER', 'NUMBER', 'BOOLEAN', 'DATE', 'DATETIME',
+];
+const responseTypes: DataServiceSchemaType[] = [...parameterTypes, 'OBJECT'];
+
+const typeLabel: Record<DataServiceSchemaType, string> = {
+  STRING: 'String',
+  INTEGER: 'Integer',
+  NUMBER: 'Number',
+  BOOLEAN: 'Boolean',
+  DATE: 'Date',
+  DATETIME: 'DateTime',
+  OBJECT: 'Object',
+};
+
+const DataServiceDocsModal = ({ open, service, onCancel }: DataServiceDocsModalProps) => {
+  const [documentation, setDocumentation] = useState<DataServiceDocumentation>();
+  const [parameters, setParameters] = useState<DataServiceParameterDoc[]>([]);
+  const [responseFields, setResponseFields] = useState<DataServiceResponseFieldDoc[]>([]);
+  const [openApi, setOpenApi] = useState<Record<string, unknown>>();
+  const [debugValues, setDebugValues] = useState<Record<string, string>>({});
+  const [testResult, setTestResult] = useState<DataServiceQueryResult>();
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [testing, setTesting] = useState(false);
+
+  const load = useCallback(async () => {
+    if (!service) return;
+    setLoading(true);
+    try {
+      const [docResponse, openApiResponse] = await Promise.all([
+        fetchDataServiceDocumentation(service.id),
+        fetchDataServiceOpenApi(service.id),
+      ]);
+      if (!docResponse.data) throw new Error(docResponse.message || docResponse.msg || '加载 API 文档失败');
+      setDocumentation(docResponse.data);
+      setParameters(docResponse.data.parameters || []);
+      setResponseFields(docResponse.data.responseFields || []);
+      setOpenApi(openApiResponse.data || {});
+      setDebugValues((current) => {
+        const next: Record<string, string> = {};
+        for (const parameter of docResponse.data.parameters || []) {
+          next[parameter.name] = current[parameter.name] || parameter.example || '';
+        }
+        return next;
+      });
+    } catch (error) {
+      message.error(error instanceof Error ? error.message : '加载 API 文档失败');
+    } finally {
+      setLoading(false);
+    }
+  }, [service]);
+
+  useEffect(() => {
+    if (open) {
+      setTestResult(undefined);
+      void load();
+    }
+  }, [load, open]);
+
+  const save = async () => {
+    if (!service) return;
+    setSaving(true);
+    try {
+      const response = await saveDataServiceDocumentation(service.id, { parameters, responseFields });
+      if (!response.data) throw new Error(response.message || response.msg || '保存 API 文档失败');
+      setDocumentation(response.data);
+      setParameters(response.data.parameters || []);
+      setResponseFields(response.data.responseFields || []);
+      const openApiResponse = await fetchDataServiceOpenApi(service.id);
+      setOpenApi(openApiResponse.data || {});
+      message.success('API 文档与 OpenAPI 已更新');
+    } catch (error) {
+      message.error(error instanceof Error ? error.message : '保存 API 文档失败');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const runTest = async () => {
+    if (!service) return;
+    const missing = parameters.find((item) => item.required && !String(debugValues[item.name] || '').trim());
+    if (missing) {
+      message.warning(`请输入参数 ${missing.name}`);
+      return;
+    }
+    setTesting(true);
+    try {
+      const response = await testDataService(service.id, debugValues);
+      if (!response.data) throw new Error(response.message || response.msg || '在线调试失败');
+      setTestResult(response.data);
+      setResponseFields((current) => inferResponseFields(response.data, current));
+      message.success('调试成功，已根据真实结果识别响应 Schema；保存文档后生效');
+    } catch (error) {
+      message.error(error instanceof Error ? error.message : '在线调试失败');
+    } finally {
+      setTesting(false);
+    }
+  };
+
+  const copy = async (value: string, success = '已复制') => {
+    try {
+      await navigator.clipboard.writeText(value);
+      message.success(success);
+    } catch {
+      message.warning('复制失败，请手动复制');
+    }
+  };
+
+  const curl = useMemo(() => {
+    if (!service) return '';
+    const query = parameters
+      .map((item) => `  --data-urlencode '${item.name}=${item.example || `<${item.name}>`}'`)
+      .join(' \\\n');
+    const auth = service.authMode === 'API_KEY' ? " \\\n  -H 'X-API-Key: <your-api-key>'" : '';
+    return `curl -G '${service.runtimePath}'${query ? ` \\\n${query}` : ''}${auth}`;
+  }, [parameters, service]);
+
+  const resultColumns = (testResult?.columns || []).map((name) => ({
+    title: name,
+    dataIndex: name,
+    key: name,
+    minWidth: 140,
+    ellipsis: true,
+  }));
+
+  const items = [
+    {
+      key: 'overview',
+      label: '概览',
+      children: (
+        <div className="space-y-4">
+          <div className="border border-[#e5e7eb] bg-[#fafbfc] px-3 py-3">
+            <div className="flex items-center justify-between gap-3">
+              <div className="min-w-0">
+                <div className="text-[11px] text-[#98a2b3]">Endpoint</div>
+                <div className="mt-1 break-all font-mono text-[12px] text-[#344054]">GET {service?.runtimePath}</div>
+              </div>
+              <Button size="small" type="text" icon={<Copy size={14} />} onClick={() => void copy(service?.runtimePath || '')} />
+            </div>
+          </div>
+          <div className="grid grid-cols-4 gap-2">
+            <Info label="Method" value="GET" />
+            <Info label="Auth" value={service?.authMode === 'API_KEY' ? 'API Key' : 'Public'} />
+            <Info label="Max Rows" value={String(service?.maxRows || '-')} />
+            <Info label="Timeout" value={`${service?.timeoutSeconds || '-'}s`} />
+          </div>
+          {documentation?.schemaStale ? (
+            <div className="border border-[#fedf89] bg-[#fffaeb] px-3 py-2.5 text-[11px] leading-5 text-[#93370d]">
+              当前 SQL 已经变化，已保存的响应 Schema 可能对应旧版本。建议重新在线调试并保存文档。
+            </div>
+          ) : null}
+          <div>
+            <div className="mb-1.5 flex items-center justify-between">
+              <span className="text-[12px] font-medium text-[#344054]">cURL</span>
+              <Button size="small" type="text" icon={<Copy size={13} />} onClick={() => void copy(curl, 'cURL 已复制')}>复制</Button>
+            </div>
+            <pre className="m-0 max-h-[180px] overflow-auto bg-[#111827] p-3 text-[11px] leading-5 text-white/85">{curl}</pre>
+          </div>
+        </div>
+      ),
+    },
+    {
+      key: 'parameters',
+      label: `参数 ${parameters.length || ''}`,
+      children: parameters.length ? (
+        <Table
+          rowKey="name"
+          size="small"
+          pagination={false}
+          dataSource={parameters}
+          columns={[
+            { title: '参数名', dataIndex: 'name', width: 150, render: (value) => <span className="font-mono text-[12px]">{value}</span> },
+            {
+              title: '类型', dataIndex: 'type', width: 130,
+              render: (_, row, index) => <Select size="small" className="w-full" value={row.type} options={parameterTypes.map((type) => ({ value: type, label: typeLabel[type] }))} onChange={(type) => setParameters((items) => items.map((item, i) => i === index ? { ...item, type: type as DataServiceParameterDoc['type'] } : item))} />,
+            },
+            { title: '必填', dataIndex: 'required', width: 70, render: () => <Tag bordered={false}>是</Tag> },
+            {
+              title: '说明', dataIndex: 'description', minWidth: 180,
+              render: (_, row, index) => <Input size="small" value={row.description || ''} placeholder="业务含义" onChange={(event) => setParameters((items) => items.map((item, i) => i === index ? { ...item, description: event.target.value } : item))} />,
+            },
+            {
+              title: '示例', dataIndex: 'example', width: 160,
+              render: (_, row, index) => <Input size="small" value={row.example || ''} placeholder="示例值" onChange={(event) => setParameters((items) => items.map((item, i) => i === index ? { ...item, example: event.target.value } : item))} />,
+            },
+          ]}
+          scroll={{ x: 780 }}
+        />
+      ) : <EmptyHint text="当前 SQL 没有命名参数。" />,
+    },
+    {
+      key: 'response',
+      label: `响应 ${responseFields.length || ''}`,
+      children: responseFields.length ? (
+        <div className="space-y-3">
+          <div className="text-[11px] text-[#667085]">字段来自最近一次在线调试结果识别；类型和业务说明可以在保存前调整。</div>
+          <Table
+            rowKey="name"
+            size="small"
+            pagination={false}
+            dataSource={responseFields}
+            columns={[
+              { title: '字段', dataIndex: 'name', width: 150, render: (value) => <span className="font-mono text-[12px]">{value}</span> },
+              {
+                title: '类型', dataIndex: 'type', width: 130,
+                render: (_, row, index) => <Select size="small" className="w-full" value={row.type} options={responseTypes.map((type) => ({ value: type, label: typeLabel[type] }))} onChange={(type) => setResponseFields((items) => items.map((item, i) => i === index ? { ...item, type } : item))} />,
+              },
+              { title: '可空', dataIndex: 'nullable', width: 70, render: (value) => value ? '是' : '否' },
+              {
+                title: '说明', dataIndex: 'description', minWidth: 180,
+                render: (_, row, index) => <Input size="small" value={row.description || ''} placeholder="字段含义" onChange={(event) => setResponseFields((items) => items.map((item, i) => i === index ? { ...item, description: event.target.value } : item))} />,
+              },
+              { title: '示例', dataIndex: 'example', width: 160, ellipsis: true },
+            ]}
+            scroll={{ x: 780 }}
+          />
+        </div>
+      ) : <EmptyHint text="还没有响应 Schema。进入“在线调试”执行一次真实查询即可自动识别。" />,
+    },
+    {
+      key: 'debug',
+      label: '在线调试',
+      children: (
+        <div>
+          <div className="mb-4 border border-[#e5e7eb] bg-[#fafafa] px-3 py-2 text-[11px] leading-5 text-[#667085]">
+            管理控制台调试始终直连真实数据源，不读取 Runtime 缓存，也不受熔断状态影响。外部 API Key 鉴权同样不会在这里阻断调试。
+          </div>
+          {parameters.length ? (
+            <div className="mb-3 grid grid-cols-2 gap-x-3">
+              {parameters.map((parameter) => (
+                <div key={parameter.name} className="mb-3">
+                  <div className="mb-1 text-[11px] font-medium text-[#475467]">{parameter.name} <span className="text-[#98a2b3]">· {typeLabel[parameter.type]}</span></div>
+                  <Input value={debugValues[parameter.name] || ''} placeholder={parameter.example || `请输入 ${parameter.name}`} onChange={(event) => setDebugValues((current) => ({ ...current, [parameter.name]: event.target.value }))} />
+                </div>
+              ))}
+            </div>
+          ) : <div className="mb-3 text-[11px] text-[#98a2b3]">当前接口无请求参数。</div>}
+          <Button type="primary" icon={<Play size={14} />} loading={testing} onClick={() => void runTest()}>发送请求</Button>
+          {testResult ? (
+            <div className="mt-4 border-t border-[#eef0f2] pt-3">
+              <div className="mb-2 flex items-center gap-4 text-[11px] text-[#667085]">
+                <span>200 OK</span><span>{testResult.durationMs} ms</span><span>{testResult.rowCount} 行</span>{testResult.truncated ? <Tag>已截断</Tag> : null}
+              </div>
+              <Table rowKey={(_, index) => String(index)} size="small" pagination={false} dataSource={testResult.rows} columns={resultColumns} scroll={{ x: 'max-content', y: 300 }} />
+            </div>
+          ) : null}
+        </div>
+      ),
+    },
+    {
+      key: 'openapi',
+      label: 'OpenAPI',
+      children: (
+        <div>
+          <div className="mb-2 flex items-center justify-between">
+            <div className="text-[11px] text-[#667085]">OpenAPI 3.0.3 · 根据当前 SQL 参数、访问控制和已保存响应 Schema 动态生成。</div>
+            <Button size="small" icon={<Copy size={13} />} onClick={() => void copy(JSON.stringify(openApi || {}, null, 2), 'OpenAPI JSON 已复制')}>复制 JSON</Button>
+          </div>
+          <pre className="m-0 max-h-[430px] overflow-auto bg-[#111827] p-3 text-[11px] leading-5 text-white/85">{JSON.stringify(openApi || {}, null, 2)}</pre>
+        </div>
+      ),
+    },
+  ];
+
+  return (
+    <Modal
+      open={open}
+      width={980}
+      centered
+      destroyOnHidden
+      title={service ? `API 文档 · ${service.name}` : 'API 文档'}
+      onCancel={onCancel}
+      footer={[
+        <Button key="refresh" icon={<RefreshCw size={14} />} disabled={loading || saving} onClick={() => void load()}>刷新</Button>,
+        <Button key="close" onClick={onCancel}>关闭</Button>,
+        <Button key="save" type="primary" loading={saving} onClick={() => void save()}>保存文档</Button>,
+      ]}
+    >
+      <Spin spinning={loading}>
+        <div className="min-h-[500px] pt-1">
+          <div className="mb-3 flex items-center gap-2 text-[11px] text-[#667085]">
+            <Tag bordered={false}>GET</Tag>
+            {service?.authMode === 'API_KEY' ? <Tag bordered={false}>API Key</Tag> : <Tag bordered={false}>Public</Tag>}
+            {documentation?.schemaStale ? <Tag color="warning">Schema 待更新</Tag> : documentation?.documented ? <Tag bordered={false}>已文档化</Tag> : <Tag bordered={false}>未保存</Tag>}
+          </div>
+          <Tabs items={items} />
+        </div>
+      </Spin>
+    </Modal>
+  );
+};
+
+const inferResponseFields = (
+  result: DataServiceQueryResult,
+  current: DataServiceResponseFieldDoc[],
+): DataServiceResponseFieldDoc[] => {
+  const existing = new Map(current.map((item) => [item.name, item]));
+  return (result.columns || []).map((name) => {
+    const values = (result.rows || []).map((row) => row[name]);
+    const sample = values.find((value) => value !== null && value !== undefined);
+    const previous = existing.get(name);
+    return {
+      name,
+      type: inferType(sample),
+      nullable: values.length === 0 || values.some((value) => value === null || value === undefined),
+      description: previous?.description || '',
+      example: sample === undefined || sample === null ? '' : stringifyExample(sample),
+    };
+  });
+};
+
+const inferType = (value: unknown): DataServiceSchemaType => {
+  if (typeof value === 'boolean') return 'BOOLEAN';
+  if (typeof value === 'number') return Number.isInteger(value) ? 'INTEGER' : 'NUMBER';
+  if (typeof value === 'object' && value !== null) return 'OBJECT';
+  if (typeof value === 'string') {
+    if (/^\d{4}-\d{2}-\d{2}$/.test(value)) return 'DATE';
+    if (/^\d{4}-\d{2}-\d{2}[T\s]\d{2}:\d{2}/.test(value)) return 'DATETIME';
+  }
+  return 'STRING';
+};
+
+const stringifyExample = (value: unknown) => {
+  if (typeof value === 'object') {
+    try { return JSON.stringify(value); } catch { return String(value); }
+  }
+  return String(value);
+};
+
+const Info = ({ label, value }: { label: string; value: string }) => (
+  <div className="border border-[#e5e7eb] px-3 py-2.5">
+    <div className="text-[10px] text-[#98a2b3]">{label}</div>
+    <div className="mt-1 text-[12px] font-medium text-[#344054]">{value}</div>
+  </div>
+);
+
+const EmptyHint = ({ text }: { text: string }) => (
+  <div className="border border-dashed border-[#d0d5dd] px-4 py-10 text-center text-[12px] text-[#98a2b3]">{text}</div>
+);
+
+export default DataServiceDocsModal;

--- a/yak-ops-ui/src/pages/data-service/index.tsx
+++ b/yak-ops-ui/src/pages/data-service/index.tsx
@@ -14,9 +14,10 @@ import {
   message,
   type TableColumnsType,
 } from 'antd';
-import { Activity, Copy, Pencil, Play, Plus, RefreshCw, Search, ShieldCheck, Trash2 } from 'lucide-react';
+import { Activity, Copy, FileText, Pencil, Plus, RefreshCw, Search, ShieldCheck, Trash2 } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import DataServiceAccessModal from './DataServiceAccessModal';
+import DataServiceDocsModal from './DataServiceDocsModal';
 import DataServiceRuntimeModal from './DataServiceRuntimeModal';
 import {
   createDataService,
@@ -24,10 +25,8 @@ import {
   fetchDataServices,
   fetchDataSourceOptions,
   setDataServiceEnabled,
-  testDataService,
   updateDataService,
   type DataServiceApi,
-  type DataServiceQueryResult,
   type DataServiceSavePayload,
   type DataSourceOption,
 } from './service';
@@ -42,13 +41,10 @@ export default function DataServicePage() {
   const [editing, setEditing] = useState<DataServiceApi>();
   const [editorOpen, setEditorOpen] = useState(false);
   const [saving, setSaving] = useState(false);
-  const [testing, setTesting] = useState<DataServiceApi>();
+  const [docsTarget, setDocsTarget] = useState<DataServiceApi>();
   const [accessTarget, setAccessTarget] = useState<DataServiceApi>();
   const [runtimeTarget, setRuntimeTarget] = useState<DataServiceApi>();
-  const [testLoading, setTestLoading] = useState(false);
-  const [testResult, setTestResult] = useState<DataServiceQueryResult>();
   const [form] = Form.useForm<DataServiceSavePayload>();
-  const [testForm] = Form.useForm<Record<string, string>>();
   const sourceManaged = Boolean(editing?.sourceType);
 
   const load = useCallback(async () => {
@@ -61,12 +57,12 @@ export default function DataServicePage() {
       const nextServices = serviceResponse.data || [];
       setServices(nextServices);
       setDataSources(dataSourceResponse.data || []);
-      setAccessTarget((current) => current
+      const refreshTarget = (current?: DataServiceApi) => current
         ? nextServices.find((item) => item.id === current.id) || current
-        : undefined);
-      setRuntimeTarget((current) => current
-        ? nextServices.find((item) => item.id === current.id) || current
-        : undefined);
+        : undefined;
+      setDocsTarget(refreshTarget);
+      setAccessTarget(refreshTarget);
+      setRuntimeTarget(refreshTarget);
     } catch (error: any) {
       message.error(error?.message || '加载数据服务失败');
     } finally {
@@ -141,26 +137,6 @@ export default function DataServicePage() {
       message.success(enabled ? '服务已启用' : '服务已停用');
     } catch (error: any) {
       message.error(error?.message || '状态更新失败');
-    }
-  };
-
-  const openTest = (record: DataServiceApi) => {
-    setTesting(record);
-    setTestResult(undefined);
-    testForm.resetFields();
-  };
-
-  const runTest = async () => {
-    if (!testing) return;
-    const parameters = await testForm.validateFields();
-    setTestLoading(true);
-    try {
-      const response = await testDataService(testing.id, parameters);
-      setTestResult(response.data);
-    } catch (error: any) {
-      message.error(error?.message || '测试调用失败');
-    } finally {
-      setTestLoading(false);
     }
   };
 
@@ -246,8 +222,8 @@ export default function DataServicePage() {
       fixed: 'right',
       render: (_, record) => (
         <Space size={2}>
-          <Tooltip title="测试">
-            <Button type="text" size="small" icon={<Play size={15} />} onClick={() => openTest(record)} />
+          <Tooltip title="API 文档 / 在线调试">
+            <Button type="text" size="small" icon={<FileText size={15} />} onClick={() => setDocsTarget(record)} />
           </Tooltip>
           <Tooltip title="Runtime">
             <Button type="text" size="small" icon={<Activity size={15} />} onClick={() => setRuntimeTarget(record)} />
@@ -266,20 +242,12 @@ export default function DataServicePage() {
     },
   ];
 
-  const resultColumns = (testResult?.columns || []).map((name) => ({
-    title: name,
-    dataIndex: name,
-    key: name,
-    minWidth: 140,
-    ellipsis: true,
-  }));
-
   return (
     <div className="h-full bg-white px-6 py-5">
       <div className="mb-5 flex items-start justify-between gap-4">
         <div>
           <h1 className="m-0 text-xl font-semibold text-[#161823]">API 服务</h1>
-          <p className="mb-0 mt-1 text-sm text-black/45">将只读 SQL 发布为可调用、可鉴权、可缓存、可熔断、可审计的 GET REST API。</p>
+          <p className="mb-0 mt-1 text-sm text-black/45">将只读 SQL 发布为可调用、可鉴权、可缓存、可熔断、可文档化的 GET REST API。</p>
         </div>
         <Button type="primary" icon={<Plus size={16} />} onClick={openCreate}>新建 API</Button>
       </div>
@@ -304,6 +272,12 @@ export default function DataServicePage() {
         columns={columns}
         pagination={false}
         scroll={{ x: 1360 }}
+      />
+
+      <DataServiceDocsModal
+        open={Boolean(docsTarget)}
+        service={docsTarget}
+        onCancel={() => setDocsTarget(undefined)}
       />
 
       <DataServiceAccessModal
@@ -388,60 +362,6 @@ export default function DataServicePage() {
             <Input.TextArea rows={2} maxLength={500} placeholder="可选" />
           </Form.Item>
         </Form>
-      </Modal>
-
-      <Modal
-        title={testing ? `测试 · ${testing.name}` : '测试 API'}
-        open={Boolean(testing)}
-        onCancel={() => { setTesting(undefined); setTestResult(undefined); }}
-        footer={null}
-        width={900}
-        destroyOnHidden
-      >
-        {testing && (
-          <div className="pt-3">
-            <div className="mb-4 rounded-md bg-black/[0.025] px-3 py-2 font-mono text-sm text-black/65">
-              GET {testing.runtimePath}
-            </div>
-            <div className="mb-4 border border-[#e5e7eb] bg-[#fafafa] px-3 py-2 text-[11px] text-[#667085]">
-              管理控制台测试始终直连真实数据源，不读取 Runtime 结果缓存，也不受熔断状态影响，便于确认当前 SQL 与数据源是否真实可用。
-              {testing.authMode === 'API_KEY' ? (
-                <> 真实外部调用仍需携带 <span className="font-mono">X-API-Key</span>。</>
-              ) : null}
-            </div>
-            <Form form={testForm} layout="vertical">
-              {testing.parameterNames.length > 0 ? (
-                <div className="grid grid-cols-2 gap-x-4">
-                  {testing.parameterNames.map((name) => (
-                    <Form.Item key={name} name={name} label={name} rules={[{ required: true, message: `请输入 ${name}` }]}>
-                      <Input placeholder={`:${name}`} />
-                    </Form.Item>
-                  ))}
-                </div>
-              ) : <div className="mb-4 text-sm text-black/40">当前 SQL 没有请求参数。</div>}
-              <Button type="primary" icon={<Play size={15} />} loading={testLoading} onClick={() => void runTest()}>发送请求</Button>
-            </Form>
-
-            {testResult && (
-              <div className="mt-5 border-t border-black/[0.06] pt-4">
-                <div className="mb-3 flex items-center gap-4 text-sm text-black/55">
-                  <span>200 OK</span>
-                  <span>{testResult.durationMs} ms</span>
-                  <span>{testResult.rowCount} 行</span>
-                  {testResult.truncated && <Tag>结果已截断</Tag>}
-                </div>
-                <Table
-                  rowKey={(_, index) => String(index)}
-                  size="small"
-                  dataSource={testResult.rows}
-                  columns={resultColumns}
-                  pagination={false}
-                  scroll={{ x: 'max-content', y: 360 }}
-                />
-              </div>
-            )}
-          </div>
-        )}
       </Modal>
     </div>
   );

--- a/yak-ops-ui/src/pages/data-service/service.ts
+++ b/yak-ops-ui/src/pages/data-service/service.ts
@@ -14,6 +14,14 @@ export interface DataSourceOption {
 }
 
 export type DataServiceAuthMode = 'NONE' | 'API_KEY';
+export type DataServiceSchemaType =
+  | 'STRING'
+  | 'INTEGER'
+  | 'NUMBER'
+  | 'BOOLEAN'
+  | 'DATE'
+  | 'DATETIME'
+  | 'OBJECT';
 
 export interface DataServiceApi {
   id: number;
@@ -72,6 +80,40 @@ export interface DataServiceRuntimeStatus extends DataServiceRuntimeConfig {
   p95DurationMs: number;
   lastSuccessAt?: string | null;
   lastFailureAt?: string | null;
+}
+
+export interface DataServiceParameterDoc {
+  name: string;
+  type: Exclude<DataServiceSchemaType, 'OBJECT'>;
+  required: boolean;
+  description?: string | null;
+  example?: string | null;
+}
+
+export interface DataServiceResponseFieldDoc {
+  name: string;
+  type: DataServiceSchemaType;
+  nullable: boolean;
+  description?: string | null;
+  example?: string | null;
+}
+
+export interface DataServiceDocumentation {
+  apiId: number;
+  name: string;
+  runtimePath: string;
+  authMode: DataServiceAuthMode;
+  description?: string | null;
+  documented: boolean;
+  schemaStale: boolean;
+  parameters: DataServiceParameterDoc[];
+  responseFields: DataServiceResponseFieldDoc[];
+  updateTime?: string | null;
+}
+
+export interface DataServiceDocumentationInput {
+  parameters: DataServiceParameterDoc[];
+  responseFields: DataServiceResponseFieldDoc[];
 }
 
 export interface DataServiceApiKey {
@@ -143,6 +185,15 @@ export const deleteDataService = (id: number) =>
 
 export const setDataServiceEnabled = (id: number, enabled: boolean) =>
   HttpUtils.put<DataServiceApi>(`${PREFIX}/${id}/enabled?enabled=${enabled}`, {}) as Promise<CommonApiResponse<DataServiceApi>>;
+
+export const fetchDataServiceDocumentation = (id: number) =>
+  HttpUtils.get<DataServiceDocumentation>(`${PREFIX}/${id}/documentation`) as Promise<CommonApiResponse<DataServiceDocumentation>>;
+
+export const saveDataServiceDocumentation = (id: number, payload: DataServiceDocumentationInput) =>
+  HttpUtils.put<DataServiceDocumentation>(`${PREFIX}/${id}/documentation`, payload) as Promise<CommonApiResponse<DataServiceDocumentation>>;
+
+export const fetchDataServiceOpenApi = (id: number) =>
+  HttpUtils.get<Record<string, unknown>>(`${PREFIX}/${id}/openapi`) as Promise<CommonApiResponse<Record<string, unknown>>>;
 
 export const fetchDataServiceRuntime = (id: number) =>
   HttpUtils.get<DataServiceRuntimeStatus>(`${PREFIX}/${id}/runtime`) as Promise<CommonApiResponse<DataServiceRuntimeStatus>>;


### PR DESCRIPTION
## Summary

Complete the next Data Service productization phase by turning the existing runtime/test capabilities into a focused API documentation center with parameter metadata, response schema discovery, online debugging and generated OpenAPI 3.0.3.

## Product flow

1. Open **API 文档** from the Data Service list
2. Review the real runtime endpoint, auth mode and cURL example
3. Enrich SQL named parameters with type / description / example metadata
4. Run the API from the integrated online debugger against the live datasource
5. Yak Ops infers row-field type, nullable state and example values from the real result
6. Add business descriptions and save the contract
7. Copy the generated OpenAPI 3.0.3 JSON for external consumers/tools
8. If the SQL later changes, the documentation is marked stale until it is re-validated and saved

## Included

### Documentation model

- New dedicated `yak_ops_data_service_documentation` table instead of expanding the runtime definition table
- Stores parameter metadata, response-row metadata and the SQL SHA-256 fingerprint used when the document was saved
- SQL named parameters remain the source of truth: documentation cannot introduce parameters that do not exist in the executable SQL
- Same-name parameter documentation is preserved automatically when Data Development republishes a new SQL revision
- Removed SQL parameters disappear from the effective documentation automatically

### Schema drift protection

- Saved documentation is fingerprinted against the executable SQL snapshot
- When SQL changes, the API documentation reports `schemaStale=true`
- Current request parameters still come from the live SQL definition
- Stale response fields are not published as the current OpenAPI row schema
- Re-running online debug and saving the documentation refreshes the SQL fingerprint and clears the stale state

### OpenAPI

- `GET /api/v1/data-service/{id}/openapi`
- Generates OpenAPI `3.0.3` dynamically per Data Service
- Includes endpoint path, query parameters, parameter types/descriptions/examples and response contract
- API-Key protected services expose an `X-API-Key` security scheme
- Adds `x-yak-documented` and `x-yak-schema-stale` extensions for tooling/consumer awareness
- Documents 200 / 401 / 429 / 503 runtime semantics

### Documentation endpoints

- `GET /api/v1/data-service/{id}/documentation`
- `PUT /api/v1/data-service/{id}/documentation`
- Documentation metadata is removed when its Data Service is deleted

### UI

- Replaces the old standalone test action with one focused **API 文档 / 在线调试** entry
- Tabs: 概览 / 参数 / 响应 / 在线调试 / OpenAPI
- Overview shows endpoint, auth, row limit, timeout and copyable cURL
- Parameter table lets users document type, business meaning and examples while keeping names/required state tied to SQL
- Online debug keeps the existing console semantics: live datasource, no result cache, no circuit-breaker blocking and no external API-Key requirement
- Successful debug automatically infers response field type, nullable state and example values in local draft state
- Response descriptions can be enriched before saving
- OpenAPI JSON is viewable and copyable directly in the UI
- Stale-schema warning is visible after SQL changes

## Persistence

Flyway `V7__add_data_service_documentation.sql` adds the dedicated API-documentation metadata table with SQL fingerprinting.

## Tests

`DataServiceDocumentationServiceTest` covers:

- live SQL parameter names remain the source of truth while saved descriptions are preserved
- removed parameters do not survive into the effective contract
- documentation save persists the SQL fingerprint
- generated OpenAPI carries API-Key security and response-row schema
- documentation cannot define a parameter that is absent from SQL

## Compatibility

- Data Development -> Data Service publication remains unchanged
- Phase-3 API Key / rate limiting remains unchanged
- Phase-4 cache / circuit breaker / runtime metrics remain unchanged
- Existing APIs require no migration-time documentation and continue to run exactly as before
- Documentation is management metadata only; it does not change runtime SQL execution semantics

## Validation

- Compared `main...feat/data-service-api-docs`; final diff is scoped to 9 documentation/productization files
- Performed static review of Spring route specificity, MyBatis document persistence, OpenAPI contract generation, SQL-fingerprint drift handling and TypeScript model alignment
- Tightened React state narrowing and cURL generation during the final review
- Full Maven/TypeScript execution was not run in the current execution container because the environment used in the previous phases cannot resolve `github.com` for a complete checkout. CI/build results should be treated as the executable source of truth.

## Deferred

- Combined OpenAPI catalog containing all Data Services
- YAML export / downloadable SDK generation
- externally hosted public developer portal
- request/response examples with multiple named scenarios
- parameter defaults / optional SQL parameters
- formal semantic versioning of API contracts
- MCP/tool-schema generation from the same contract metadata
