### PR TITLE
fix(data-service): register MyBatis mappers after module extraction

### DIFF
--- a/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/config/DataServiceMybatisConfiguration.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/config/DataServiceMybatisConfiguration.java
@@ -1,0 +1,15 @@
+package io.yak.ops.business.dataservice.config;
+
+import io.yak.ops.business.dataservice.dao.mapper.DataServiceApiMapper;
+import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
+import org.mybatis.spring.annotation.MapperScan;
+import org.springframework.context.annotation.Configuration;
+
+/** Data Service MyBatis mapper registration on the shared Yak business SQL session. */
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnDataSourceEnabled
+@MapperScan(
+    basePackageClasses = DataServiceApiMapper.class,
+    sqlSessionTemplateRef = "yakBusinessSqlSessionTemplate")
+public class DataServiceMybatisConfiguration {
+}


### PR DESCRIPTION
## Summary

Fix Yak Ops startup after extracting Data Service into `yak-ops-business-data-service`.

The Data Service Spring components are discovered correctly, but its MyBatis mapper interfaces are no longer registered after moving to the standalone module. Startup therefore fails while creating `DataServiceService` because `DataServiceApiMapper` is missing.

## Root cause

The module extraction moved the Data Service mapper package from `yak-ops-business-datasource` into its own JAR. Spring component scanning still discovers `DataServiceController` / services, but MyBatis mapper registration requires its own mapper scan and does not follow ordinary component scanning automatically.

The mapper interfaces already carry `@Mapper`; the missing piece is the module-level mapper scanner bound to Yak Ops' shared business `SqlSessionTemplate`.

## Fix

Add `DataServiceMybatisConfiguration` inside the Data Service module:

```java
@Configuration(proxyBeanMethods = false)
@ConditionalOnDataSourceEnabled
@MapperScan(
    basePackageClasses = DataServiceApiMapper.class,
    sqlSessionTemplateRef = "yakBusinessSqlSessionTemplate")
public class DataServiceMybatisConfiguration {
}
```

This registers the complete `io.yak.ops.business.dataservice.dao.mapper` package, including:

- `DataServiceApiMapper`
- `DataServiceApiKeyMapper`
- `DataServiceCallLogMapper`
- `DataServiceDocumentationMapper`

It reuses the existing shared business MyBatis infrastructure from the datasource module rather than creating another datasource/session/transaction stack.

## Architecture

Dependency direction remains unchanged:

```text
data-development
      ↓
data-service
      ↓
datasource
```

The fix is intentionally owned by `data-service`; datasource does not need to know the upper-level Data Service package.

## Scope

- no API changes
- no database changes
- no Flyway changes
- no frontend changes
- no Data Service runtime behavior changes
- no broad/global mapper scan added to `yak-ops-boot`

## Validation

- traced the supplied startup failure to the missing `DataServiceApiMapper` bean
- verified the shared bean name is `yakBusinessSqlSessionTemplate` in `BusinessDatabaseConfiguration`
- verified the fix scans the Data Service mapper package through a type-safe `basePackageClasses` marker
- branch is one commit ahead of current `main` and changes only this 15-line module configuration

A full local Maven/startup run was not executed from this repository environment; the reported failure came from a real local Yak Ops startup, and CI should be treated as the executable validation source here.