### PR TITLE
refactor(data-service): unify source publication model

### DIFF
--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentDataServiceService.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentDataServiceService.java
@@ -1,158 +1,53 @@
 package io.yak.ops.business.development.service;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.yak.ops.business.dataservice.service.DataServiceService;
-import io.yak.ops.business.dataservice.service.DataServiceService.ApiInput;
+import io.yak.ops.business.dataservice.service.DataServicePublicationService;
+import io.yak.ops.business.dataservice.service.DataServicePublicationService.PublicationState;
+import io.yak.ops.business.dataservice.service.DataServicePublicationService.PublishRequest;
 import io.yak.ops.business.dataservice.service.DataServiceService.ApiView;
-import io.yak.ops.business.dataservice.service.DataServiceService.SourceSnapshot;
-import io.yak.ops.business.development.domain.DevelopmentReleaseDetail;
-import io.yak.ops.business.development.domain.DevelopmentTaskRevision;
 import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
-import io.yak.ops.spi.task.model.TaskAssetStatus;
-import io.yak.ops.spi.task.model.TaskDefinition;
-import java.util.Objects;
-import java.util.Optional;
 import org.springframework.stereotype.Service;
-import org.springframework.util.StringUtils;
 
-/** Explicit transition from an immutable ONLINE SQL release to a Data Service snapshot. */
+/**
+ * Backward-compatible Data Development facade.
+ *
+ * <p>The actual publish transition now lives in Data Service so every entry point uses the same
+ * server-side source resolution and snapshot rules.
+ */
 @Service
 @ConditionalOnDataSourceEnabled
 public class DevelopmentDataServiceService {
 
-  static final String SOURCE_TYPE = "DATA_DEVELOPMENT_RELEASE";
-  private static final int DEFAULT_MAX_ROWS = 1_000;
-  private static final int DEFAULT_TIMEOUT_SECONDS = 30;
+  static final String SOURCE_TYPE = DevelopmentDataServiceSourceProvider.SOURCE_TYPE;
 
-  private final DevelopmentReleaseService releaseService;
-  private final DataServiceService dataServiceService;
-  private final ObjectMapper objectMapper;
+  private final DataServicePublicationService publicationService;
 
-  public DevelopmentDataServiceService(
-      DevelopmentReleaseService releaseService,
-      DataServiceService dataServiceService,
-      ObjectMapper objectMapper) {
-    this.releaseService = releaseService;
-    this.dataServiceService = dataServiceService;
-    this.objectMapper = objectMapper;
+  public DevelopmentDataServiceService(DataServicePublicationService publicationService) {
+    this.publicationService = publicationService;
   }
 
   public ReleaseDataServiceState state(long assetId) {
-    DevelopmentReleaseDetail release = requireSqlRelease(assetId, false);
-    Optional<ApiView> service = findService(assetId);
-    boolean updateAvailable = service
-        .map(value -> !Objects.equals(
-            value.sourceRevisionId(), release.currentRevision().id()))
-        .orElse(false);
+    PublicationState state = publicationService.state(SOURCE_TYPE, Long.toString(assetId));
     return new ReleaseDataServiceState(
-        service.isPresent(),
-        updateAvailable,
-        release.release().currentRevisionNo(),
-        release.release().status().name(),
-        service.orElse(null));
+        state.published(),
+        state.updateAvailable(),
+        state.source().sourceRevisionNo(),
+        state.source().status(),
+        state.detail());
   }
 
   public ApiView publish(long assetId, PublishCommand command) {
-    DevelopmentReleaseDetail release = requireSqlRelease(assetId, true);
-    DevelopmentTaskRevision revision = release.currentRevision();
-    TaskDefinition definition = revision.definition();
-    SourceConfig source = sourceConfig(definition.configJson());
-    Optional<ApiView> existing = findService(assetId);
-    PublishCommand request = command == null ? new PublishCommand(null, null, null, null, null, null) : command;
-
-    String name = firstText(
+    PublishCommand request = command == null
+        ? new PublishCommand(null, null, null, null, null, null)
+        : command;
+    return publicationService.publish(new PublishRequest(
+        SOURCE_TYPE,
+        Long.toString(assetId),
         request.name(),
-        existing.map(ApiView::name).orElse(null),
-        release.release().taskName());
-    String path = firstText(
         request.path(),
-        existing.map(ApiView::path).orElse(null),
-        "/query/" + assetId);
-    Integer maxRows = request.maxRows() != null
-        ? request.maxRows()
-        : existing.map(ApiView::maxRows).orElse(DEFAULT_MAX_ROWS);
-    Integer timeoutSeconds = request.timeoutSeconds() != null
-        ? request.timeoutSeconds()
-        : existing.map(ApiView::timeoutSeconds).orElse(source.timeoutSeconds());
-    Boolean enabled = request.enabled() != null
-        ? request.enabled()
-        : existing.map(ApiView::enabled).orElse(Boolean.TRUE);
-    String description = request.description() != null
-        ? request.description()
-        : existing.map(ApiView::description).orElse(null);
-
-    return dataServiceService.saveFromSource(
-        new SourceSnapshot(
-            SOURCE_TYPE,
-            Long.toString(assetId),
-            revision.id(),
-            revision.revisionNo()),
-        new ApiInput(
-            name,
-            path,
-            source.dataSourceId(),
-            definition.content(),
-            maxRows,
-            timeoutSeconds,
-            enabled,
-            description));
-  }
-
-  private Optional<ApiView> findService(long assetId) {
-    return dataServiceService.findBySource(SOURCE_TYPE, Long.toString(assetId));
-  }
-
-  private DevelopmentReleaseDetail requireSqlRelease(long assetId, boolean requireOnline) {
-    DevelopmentReleaseDetail detail = releaseService.get(assetId);
-    TaskDefinition definition = detail.currentRevision().definition();
-    if (!"SQL".equalsIgnoreCase(definition.taskType())) {
-      throw new IllegalArgumentException("当前仅支持 SQL 发布版本发布为数据服务");
-    }
-    if (requireOnline && detail.release().status() != TaskAssetStatus.ONLINE) {
-      throw new IllegalArgumentException("只有 ONLINE 的 SQL 发布版本可以发布/更新数据服务");
-    }
-    return detail;
-  }
-
-  private SourceConfig sourceConfig(String configJson) {
-    String raw = StringUtils.hasText(configJson) ? configJson.trim() : "{}";
-    try {
-      JsonNode root = objectMapper.readTree(raw);
-      if (root == null || !root.isObject()) {
-        throw new IllegalArgumentException("SQL configJson 必须是 JSON Object");
-      }
-      String reference = root.path("dataSourceId").asText(null);
-      if (!StringUtils.hasText(reference)) {
-        throw new IllegalArgumentException("SQL 发布版本缺少 dataSourceId，无法发布数据服务");
-      }
-      long dataSourceId;
-      try {
-        dataSourceId = Long.parseLong(reference.trim());
-      } catch (NumberFormatException exception) {
-        throw new IllegalArgumentException("SQL 发布版本 dataSourceId 非法：" + reference, exception);
-      }
-      if (dataSourceId <= 0L) {
-        throw new IllegalArgumentException("SQL 发布版本 dataSourceId 必须大于 0");
-      }
-
-      int timeoutSeconds = root.path("timeoutSeconds").asInt(DEFAULT_TIMEOUT_SECONDS);
-      if (timeoutSeconds < 1 || timeoutSeconds > 3_600) {
-        timeoutSeconds = DEFAULT_TIMEOUT_SECONDS;
-      }
-      return new SourceConfig(dataSourceId, timeoutSeconds);
-    } catch (IllegalArgumentException exception) {
-      throw exception;
-    } catch (Exception exception) {
-      throw new IllegalArgumentException("SQL 发布版本 configJson 非法，无法发布数据服务", exception);
-    }
-  }
-
-  private String firstText(String... values) {
-    for (String value : values) {
-      if (StringUtils.hasText(value)) return value.trim();
-    }
-    return null;
+        request.maxRows(),
+        request.timeoutSeconds(),
+        request.enabled(),
+        request.description()));
   }
 
   public record PublishCommand(
@@ -169,6 +64,4 @@ public class DevelopmentDataServiceService {
       int releaseRevisionNo,
       String releaseStatus,
       ApiView detail) {}
-
-  private record SourceConfig(Long dataSourceId, Integer timeoutSeconds) {}
 }

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentDataServiceSourceProvider.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentDataServiceSourceProvider.java
@@ -1,0 +1,120 @@
+package io.yak.ops.business.development.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.dataservice.service.source.DataServiceSourceProvider;
+import io.yak.ops.business.development.domain.DevelopmentReleaseDetail;
+import io.yak.ops.business.development.domain.DevelopmentReleasePage;
+import io.yak.ops.business.development.domain.DevelopmentReleaseSummary;
+import io.yak.ops.business.development.domain.DevelopmentTaskRevision;
+import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
+import io.yak.ops.spi.task.model.TaskDefinition;
+import java.util.List;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+/** Exposes immutable Data Development SQL releases through the generic Data Service source port. */
+@Component
+@ConditionalOnDataSourceEnabled
+public class DevelopmentDataServiceSourceProvider implements DataServiceSourceProvider {
+
+  public static final String SOURCE_TYPE = "DATA_DEVELOPMENT_RELEASE";
+  private static final int DEFAULT_TIMEOUT_SECONDS = 30;
+
+  private final DevelopmentReleaseService releaseService;
+  private final ObjectMapper objectMapper;
+
+  public DevelopmentDataServiceSourceProvider(
+      DevelopmentReleaseService releaseService,
+      ObjectMapper objectMapper) {
+    this.releaseService = releaseService;
+    this.objectMapper = objectMapper;
+  }
+
+  @Override
+  public String sourceType() {
+    return SOURCE_TYPE;
+  }
+
+  @Override
+  public SourcePage list(int pageNo, int pageSize, String keyword) {
+    DevelopmentReleasePage page = releaseService.page(pageNo, pageSize, "ONLINE", "SQL", keyword);
+    List<SourceDescriptor> records = page.records().stream()
+        .map(summary -> resolve(Long.toString(summary.assetId())).descriptor())
+        .toList();
+    return new SourcePage(records, page.total(), page.pageNo(), page.pageSize());
+  }
+
+  @Override
+  public ResolvedSource resolve(String sourceRef) {
+    long assetId = parseAssetId(sourceRef);
+    DevelopmentReleaseDetail release = releaseService.get(assetId);
+    DevelopmentTaskRevision revision = release.currentRevision();
+    TaskDefinition definition = revision.definition();
+    if (!"SQL".equalsIgnoreCase(definition.taskType())) {
+      throw new IllegalArgumentException("当前仅支持 SQL 发布版本发布为数据服务");
+    }
+
+    SourceConfig config = sourceConfig(definition.configJson());
+    DevelopmentReleaseSummary summary = release.release();
+    SourceDescriptor descriptor = new SourceDescriptor(
+        SOURCE_TYPE,
+        Long.toString(assetId),
+        summary.taskName(),
+        definition.taskType(),
+        summary.status().name(),
+        revision.id(),
+        revision.revisionNo(),
+        config.dataSourceId(),
+        config.timeoutSeconds(),
+        "/query/" + assetId,
+        summary.updateTime());
+    return new ResolvedSource(descriptor, definition.content());
+  }
+
+  private long parseAssetId(String sourceRef) {
+    if (!StringUtils.hasText(sourceRef)) throw new IllegalArgumentException("sourceRef 不能为空");
+    try {
+      long value = Long.parseLong(sourceRef.trim());
+      if (value <= 0L) throw new NumberFormatException("not positive");
+      return value;
+    } catch (NumberFormatException exception) {
+      throw new IllegalArgumentException("数据开发发布来源 sourceRef 必须是有效 assetId：" + sourceRef, exception);
+    }
+  }
+
+  private SourceConfig sourceConfig(String configJson) {
+    String raw = StringUtils.hasText(configJson) ? configJson.trim() : "{}";
+    try {
+      JsonNode root = objectMapper.readTree(raw);
+      if (root == null || !root.isObject()) {
+        throw new IllegalArgumentException("SQL configJson 必须是 JSON Object");
+      }
+      String reference = root.path("dataSourceId").asText(null);
+      if (!StringUtils.hasText(reference)) {
+        throw new IllegalArgumentException("SQL 发布版本缺少 dataSourceId，无法发布数据服务");
+      }
+      long dataSourceId;
+      try {
+        dataSourceId = Long.parseLong(reference.trim());
+      } catch (NumberFormatException exception) {
+        throw new IllegalArgumentException("SQL 发布版本 dataSourceId 非法：" + reference, exception);
+      }
+      if (dataSourceId <= 0L) {
+        throw new IllegalArgumentException("SQL 发布版本 dataSourceId 必须大于 0");
+      }
+
+      int timeoutSeconds = root.path("timeoutSeconds").asInt(DEFAULT_TIMEOUT_SECONDS);
+      if (timeoutSeconds < 1 || timeoutSeconds > 3_600) {
+        timeoutSeconds = DEFAULT_TIMEOUT_SECONDS;
+      }
+      return new SourceConfig(dataSourceId, timeoutSeconds);
+    } catch (IllegalArgumentException exception) {
+      throw exception;
+    } catch (Exception exception) {
+      throw new IllegalArgumentException("SQL 发布版本 configJson 非法，无法发布数据服务", exception);
+    }
+  }
+
+  private record SourceConfig(Long dataSourceId, Integer timeoutSeconds) {}
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/DevelopmentDataServiceServiceTest.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/DevelopmentDataServiceServiceTest.java
@@ -1,58 +1,37 @@
 package io.yak.ops.business.development.service;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.yak.ops.business.dataservice.service.DataServiceService;
-import io.yak.ops.business.dataservice.service.DataServiceService.ApiInput;
+import io.yak.ops.business.dataservice.service.DataServicePublicationService;
+import io.yak.ops.business.dataservice.service.DataServicePublicationService.PublicationState;
+import io.yak.ops.business.dataservice.service.DataServicePublicationService.PublishRequest;
 import io.yak.ops.business.dataservice.service.DataServiceService.ApiView;
-import io.yak.ops.business.dataservice.service.DataServiceService.SourceSnapshot;
-import io.yak.ops.business.development.domain.DevelopmentReleaseDetail;
-import io.yak.ops.business.development.domain.DevelopmentReleaseSummary;
-import io.yak.ops.business.development.domain.DevelopmentTaskRevision;
-import io.yak.ops.spi.task.model.TaskAssetStatus;
-import io.yak.ops.spi.task.model.TaskDefinition;
+import io.yak.ops.business.dataservice.service.source.DataServiceSourceProvider.SourceDescriptor;
 import java.time.Instant;
 import java.util.List;
-import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 class DevelopmentDataServiceServiceTest {
 
-  private DevelopmentReleaseService releaseService;
-  private DataServiceService dataServiceService;
+  private DataServicePublicationService publicationService;
   private DevelopmentDataServiceService service;
 
   @BeforeEach
   void setUp() {
-    releaseService = mock(DevelopmentReleaseService.class);
-    dataServiceService = mock(DataServiceService.class);
-    service = new DevelopmentDataServiceService(
-        releaseService,
-        dataServiceService,
-        new ObjectMapper());
+    publicationService = mock(DataServicePublicationService.class);
+    service = new DevelopmentDataServiceService(publicationService);
   }
 
   @Test
-  void publishCopiesImmutableSqlRevisionAndDatasourceIntoStableService() {
-    when(releaseService.get(88L)).thenReturn(release(TaskAssetStatus.ONLINE, 2));
-    when(dataServiceService.findBySource(
-        DevelopmentDataServiceService.SOURCE_TYPE, "88"))
-        .thenReturn(Optional.empty());
-    when(dataServiceService.saveFromSource(any(SourceSnapshot.class), any(ApiInput.class)))
-        .thenAnswer(invocation -> {
-          SourceSnapshot source = invocation.getArgument(0);
-          ApiInput input = invocation.getArgument(1);
-          return view(9L, input, source);
-        });
+  void publishDelegatesToUnifiedPublicationService() {
+    ApiView published = view(9L, 2);
+    when(publicationService.publish(any(PublishRequest.class))).thenReturn(published);
 
     ApiView result = service.publish(
         88L,
@@ -64,115 +43,61 @@ class DevelopmentDataServiceServiceTest {
             true,
             "供运营系统查询"));
 
-    assertEquals(9L, result.id());
-    assertEquals(42L, result.dataSourceId());
-    assertEquals("select id, amount from orders where status = :status", result.sql());
-    assertEquals(2, result.sourceRevisionNo());
-
-    ArgumentCaptor<SourceSnapshot> sourceCaptor = ArgumentCaptor.forClass(SourceSnapshot.class);
-    ArgumentCaptor<ApiInput> inputCaptor = ArgumentCaptor.forClass(ApiInput.class);
-    verify(dataServiceService).saveFromSource(sourceCaptor.capture(), inputCaptor.capture());
-    assertEquals("DATA_DEVELOPMENT_RELEASE", sourceCaptor.getValue().sourceType());
-    assertEquals("88", sourceCaptor.getValue().sourceRef());
-    assertEquals(102L, sourceCaptor.getValue().sourceRevisionId());
-    assertEquals(2, sourceCaptor.getValue().sourceRevisionNo());
-    assertEquals(42L, inputCaptor.getValue().dataSourceId());
-    assertEquals("/orders", inputCaptor.getValue().path());
+    ArgumentCaptor<PublishRequest> captor = ArgumentCaptor.forClass(PublishRequest.class);
+    verify(publicationService).publish(captor.capture());
+    assertThat(captor.getValue().sourceType())
+        .isEqualTo(DevelopmentDataServiceSourceProvider.SOURCE_TYPE);
+    assertThat(captor.getValue().sourceRef()).isEqualTo("88");
+    assertThat(captor.getValue().name()).isEqualTo("订单查询");
+    assertThat(captor.getValue().path()).isEqualTo("/orders");
+    assertThat(result).isSameAs(published);
   }
 
   @Test
-  void stateMarksExistingServiceWhenActiveSqlRevisionChanged() {
-    when(releaseService.get(88L)).thenReturn(release(TaskAssetStatus.ONLINE, 3));
-    ApiView existing = new ApiView(
-        9L,
+  void stateMapsGenericPublicationStateForExistingFrontendContract() {
+    SourceDescriptor source = new SourceDescriptor(
+        DevelopmentDataServiceSourceProvider.SOURCE_TYPE,
+        "88",
+        "订单查询",
+        "SQL",
+        "ONLINE",
+        103L,
+        3,
+        42L,
+        30,
+        "/query/88",
+        Instant.parse("2026-08-16T01:00:00Z"));
+    when(publicationService.state(
+        DevelopmentDataServiceSourceProvider.SOURCE_TYPE,
+        "88"))
+        .thenReturn(new PublicationState(true, true, source, view(9L, 2)));
+
+    DevelopmentDataServiceService.ReleaseDataServiceState state = service.state(88L);
+
+    assertThat(state.published()).isTrue();
+    assertThat(state.updateAvailable()).isTrue();
+    assertThat(state.releaseRevisionNo()).isEqualTo(3);
+    assertThat(state.releaseStatus()).isEqualTo("ONLINE");
+  }
+
+  private ApiView view(Long id, int revisionNo) {
+    return new ApiView(
+        id,
         "订单查询",
         "/orders",
         "/api/v1/data-service/runtime/orders",
         42L,
-        "select 1",
-        List.of(),
+        "select id from orders where status = :status",
+        List.of("status"),
         500,
         20,
         true,
         "NONE",
         null,
-        DevelopmentDataServiceService.SOURCE_TYPE,
+        DevelopmentDataServiceSourceProvider.SOURCE_TYPE,
         "88",
-        102L,
-        2,
-        null,
-        null);
-    when(dataServiceService.findBySource(
-        DevelopmentDataServiceService.SOURCE_TYPE, "88"))
-        .thenReturn(Optional.of(existing));
-
-    DevelopmentDataServiceService.ReleaseDataServiceState state = service.state(88L);
-
-    assertTrue(state.published());
-    assertTrue(state.updateAvailable());
-    assertEquals(3, state.releaseRevisionNo());
-  }
-
-  @Test
-  void publishRejectsOfflineSqlRelease() {
-    when(releaseService.get(88L)).thenReturn(release(TaskAssetStatus.OFFLINE, 2));
-
-    IllegalArgumentException error = assertThrows(
-        IllegalArgumentException.class,
-        () -> service.publish(88L, null));
-
-    assertTrue(error.getMessage().contains("ONLINE"));
-  }
-
-  private DevelopmentReleaseDetail release(TaskAssetStatus status, int revisionNo) {
-    Instant now = Instant.parse("2026-08-15T10:00:00Z");
-    TaskDefinition definition = new TaskDefinition(
-        "SQL",
-        1,
-        "select id, amount from orders where status = :status",
-        "{\"dataSourceId\":\"42\",\"timeoutSeconds\":30}");
-    DevelopmentTaskRevision revision = new DevelopmentTaskRevision(
         100L + revisionNo,
-        7L,
         revisionNo,
-        revisionNo,
-        definition,
-        "checksum-" + revisionNo,
-        now);
-    DevelopmentReleaseSummary summary = new DevelopmentReleaseSummary(
-        88L,
-        7L,
-        "订单查询",
-        "SQL",
-        status,
-        revision.id(),
-        revisionNo,
-        revisionNo,
-        false,
-        revision.checksum(),
-        now,
-        now);
-    return new DevelopmentReleaseDetail(summary, revision, List.of());
-  }
-
-  private ApiView view(Long id, ApiInput input, SourceSnapshot source) {
-    return new ApiView(
-        id,
-        input.name(),
-        input.path(),
-        "/api/v1/data-service/runtime" + input.path(),
-        input.dataSourceId(),
-        input.sql(),
-        List.of("status"),
-        input.maxRows(),
-        input.timeoutSeconds(),
-        input.enabled(),
-        "NONE",
-        input.description(),
-        source.sourceType(),
-        source.sourceRef(),
-        source.sourceRevisionId(),
-        source.sourceRevisionNo(),
         null,
         null);
   }

--- a/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/DevelopmentDataServiceSourceProviderTest.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/DevelopmentDataServiceSourceProviderTest.java
@@ -1,0 +1,111 @@
+package io.yak.ops.business.development.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.dataservice.service.source.DataServiceSourceProvider.ResolvedSource;
+import io.yak.ops.business.development.domain.DevelopmentReleaseDetail;
+import io.yak.ops.business.development.domain.DevelopmentReleaseSummary;
+import io.yak.ops.business.development.domain.DevelopmentTaskRevision;
+import io.yak.ops.spi.task.model.TaskAssetStatus;
+import io.yak.ops.spi.task.model.TaskDefinition;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class DevelopmentDataServiceSourceProviderTest {
+
+  private DevelopmentReleaseService releaseService;
+  private DevelopmentDataServiceSourceProvider provider;
+
+  @BeforeEach
+  void setUp() {
+    releaseService = mock(DevelopmentReleaseService.class);
+    provider = new DevelopmentDataServiceSourceProvider(releaseService, new ObjectMapper());
+  }
+
+  @Test
+  void resolveCopiesImmutableSqlRevisionAndDatasource() {
+    when(releaseService.get(88L)).thenReturn(release(TaskAssetStatus.ONLINE, 2));
+
+    ResolvedSource resolved = provider.resolve("88");
+
+    assertThat(resolved.descriptor().sourceType())
+        .isEqualTo(DevelopmentDataServiceSourceProvider.SOURCE_TYPE);
+    assertThat(resolved.descriptor().sourceRef()).isEqualTo("88");
+    assertThat(resolved.descriptor().sourceRevisionId()).isEqualTo(102L);
+    assertThat(resolved.descriptor().sourceRevisionNo()).isEqualTo(2);
+    assertThat(resolved.descriptor().dataSourceId()).isEqualTo(42L);
+    assertThat(resolved.descriptor().status()).isEqualTo("ONLINE");
+    assertThat(resolved.descriptor().defaultPath()).isEqualTo("/query/88");
+    assertThat(resolved.sql())
+        .isEqualTo("select id, amount from orders where status = :status");
+  }
+
+  @Test
+  void resolveKeepsOfflineStateForManagementInspection() {
+    when(releaseService.get(88L)).thenReturn(release(TaskAssetStatus.OFFLINE, 2));
+
+    ResolvedSource resolved = provider.resolve("88");
+
+    assertThat(resolved.descriptor().status()).isEqualTo("OFFLINE");
+  }
+
+  @Test
+  void resolveRejectsReleaseWithoutDatasource() {
+    when(releaseService.get(88L)).thenReturn(releaseWithConfig("{}"));
+
+    assertThatThrownBy(() -> provider.resolve("88"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("dataSourceId");
+  }
+
+  private DevelopmentReleaseDetail release(TaskAssetStatus status, int revisionNo) {
+    return release(
+        status,
+        revisionNo,
+        "{\"dataSourceId\":\"42\",\"timeoutSeconds\":30}");
+  }
+
+  private DevelopmentReleaseDetail releaseWithConfig(String configJson) {
+    return release(TaskAssetStatus.ONLINE, 2, configJson);
+  }
+
+  private DevelopmentReleaseDetail release(
+      TaskAssetStatus status,
+      int revisionNo,
+      String configJson) {
+    Instant now = Instant.parse("2026-08-16T01:00:00Z");
+    TaskDefinition definition = new TaskDefinition(
+        "SQL",
+        1,
+        "select id, amount from orders where status = :status",
+        configJson);
+    DevelopmentTaskRevision revision = new DevelopmentTaskRevision(
+        100L + revisionNo,
+        7L,
+        revisionNo,
+        revisionNo,
+        definition,
+        "checksum-" + revisionNo,
+        now);
+    DevelopmentReleaseSummary summary = new DevelopmentReleaseSummary(
+        88L,
+        7L,
+        "订单查询",
+        "SQL",
+        status,
+        revision.id(),
+        revisionNo,
+        revisionNo,
+        false,
+        revision.checksum(),
+        now,
+        now);
+    return new DevelopmentReleaseDetail(summary, revision, List.of());
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/controller/v1/DataServiceController.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/controller/v1/DataServiceController.java
@@ -14,7 +14,6 @@ import io.yak.ops.business.dataservice.service.DataServiceDocumentationService.A
 import io.yak.ops.business.dataservice.service.DataServiceDocumentationService.DocumentationInput;
 import io.yak.ops.business.dataservice.service.DataServicePublicationService;
 import io.yak.ops.business.dataservice.service.DataServicePublicationService.PublicationSettings;
-import io.yak.ops.business.dataservice.service.DataServicePublicationService.PublicationState;
 import io.yak.ops.business.dataservice.service.DataServicePublicationService.PublishRequest;
 import io.yak.ops.business.dataservice.service.DataServiceRuntimeService.RuntimeSnapshot;
 import io.yak.ops.business.dataservice.service.DataServiceService;
@@ -24,10 +23,6 @@ import io.yak.ops.business.dataservice.service.DataServiceService.QueryResponse;
 import io.yak.ops.business.dataservice.service.DataServiceService.RuntimeConfigInput;
 import io.yak.ops.business.dataservice.service.source.DataServiceSourceProvider.SourcePage;
 import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.Size;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
@@ -73,7 +68,7 @@ public class DataServiceController {
 
   @Operation(summary = "从已发布来源创建或更新数据服务")
   @PostMapping("/publish")
-  public Result<ApiView> publish(@Valid @RequestBody PublishDataServiceRequest request) {
+  public Result<ApiView> publish(@RequestBody PublishDataServiceRequest request) {
     return Result.success(publicationService.publish(new PublishRequest(
         request.sourceType(),
         request.sourceRef(),
@@ -107,7 +102,7 @@ public class DataServiceController {
   @PostMapping("/{id}/republish")
   public Result<ApiView> republish(
       @PathVariable("id") Long id,
-      @Valid @RequestBody(required = false) RepublishDataServiceRequest request) {
+      @RequestBody(required = false) RepublishDataServiceRequest request) {
     RepublishDataServiceRequest values = request == null
         ? new RepublishDataServiceRequest(null, null, null, null, null, null)
         : request;
@@ -253,20 +248,20 @@ public class DataServiceController {
   }
 
   public record PublishDataServiceRequest(
-      @Size(max = 64) String sourceType,
-      @Size(max = 255) String sourceRef,
-      @Size(max = 200) String name,
-      @Size(max = 255) String path,
-      @Min(1) @Max(10_000) Integer maxRows,
-      @Min(1) @Max(3_600) Integer timeoutSeconds,
+      String sourceType,
+      String sourceRef,
+      String name,
+      String path,
+      Integer maxRows,
+      Integer timeoutSeconds,
       Boolean enabled,
-      @Size(max = 2000) String description) {}
+      String description) {}
 
   public record RepublishDataServiceRequest(
-      @Size(max = 200) String name,
-      @Size(max = 255) String path,
-      @Min(1) @Max(10_000) Integer maxRows,
-      @Min(1) @Max(3_600) Integer timeoutSeconds,
+      String name,
+      String path,
+      Integer maxRows,
+      Integer timeoutSeconds,
       Boolean enabled,
-      @Size(max = 2000) String description) {}
+      String description) {}
 }

--- a/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/controller/v1/DataServiceController.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/controller/v1/DataServiceController.java
@@ -12,13 +12,22 @@ import io.yak.ops.business.dataservice.service.DataServiceAccessService.CreatedA
 import io.yak.ops.business.dataservice.service.DataServiceDocumentationService;
 import io.yak.ops.business.dataservice.service.DataServiceDocumentationService.ApiDocumentation;
 import io.yak.ops.business.dataservice.service.DataServiceDocumentationService.DocumentationInput;
+import io.yak.ops.business.dataservice.service.DataServicePublicationService;
+import io.yak.ops.business.dataservice.service.DataServicePublicationService.PublicationSettings;
+import io.yak.ops.business.dataservice.service.DataServicePublicationService.PublicationState;
+import io.yak.ops.business.dataservice.service.DataServicePublicationService.PublishRequest;
 import io.yak.ops.business.dataservice.service.DataServiceRuntimeService.RuntimeSnapshot;
 import io.yak.ops.business.dataservice.service.DataServiceService;
 import io.yak.ops.business.dataservice.service.DataServiceService.ApiInput;
 import io.yak.ops.business.dataservice.service.DataServiceService.ApiView;
 import io.yak.ops.business.dataservice.service.DataServiceService.QueryResponse;
 import io.yak.ops.business.dataservice.service.DataServiceService.RuntimeConfigInput;
+import io.yak.ops.business.dataservice.service.source.DataServiceSourceProvider.SourcePage;
 import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Size;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
@@ -33,7 +42,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-/** 数据服务管理、文档、访问控制、Runtime 策略与调用接口。 */
+/** 数据服务管理、发布、文档、访问控制、Runtime 策略与调用接口。 */
 @Tag(name = "数据服务")
 @RestController
 @ConditionalOnDataSourceEnabled
@@ -42,6 +51,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class DataServiceController {
 
   private final DataServiceService dataServiceService;
+  private final DataServicePublicationService publicationService;
   private final DataServiceAccessService accessService;
   private final DataServiceDocumentationService documentationService;
 
@@ -51,13 +61,37 @@ public class DataServiceController {
     return Result.success(dataServiceService.list());
   }
 
+  @Operation(summary = "查询可发布的数据服务来源")
+  @GetMapping("/sources")
+  public Result<SourcePage> sources(
+      @RequestParam("sourceType") String sourceType,
+      @RequestParam(value = "pageNo", defaultValue = "1") int pageNo,
+      @RequestParam(value = "pageSize", defaultValue = "50") int pageSize,
+      @RequestParam(value = "keyword", required = false) String keyword) {
+    return Result.success(publicationService.sources(sourceType, pageNo, pageSize, keyword));
+  }
+
+  @Operation(summary = "从已发布来源创建或更新数据服务")
+  @PostMapping("/publish")
+  public Result<ApiView> publish(@Valid @RequestBody PublishDataServiceRequest request) {
+    return Result.success(publicationService.publish(new PublishRequest(
+        request.sourceType(),
+        request.sourceRef(),
+        request.name(),
+        request.path(),
+        request.maxRows(),
+        request.timeoutSeconds(),
+        request.enabled(),
+        request.description())));
+  }
+
   @Operation(summary = "查询 API 服务详情")
   @GetMapping("/{id}")
   public Result<ApiView> detail(@PathVariable("id") Long id) {
     return Result.success(dataServiceService.get(id));
   }
 
-  @Operation(summary = "创建 API 服务")
+  @Operation(summary = "创建 API 服务（兼容旧版手工模式）")
   @PostMapping
   public Result<ApiView> create(@RequestBody ApiInput input) {
     return Result.success(dataServiceService.save(null, input));
@@ -67,6 +101,25 @@ public class DataServiceController {
   @PutMapping("/{id}")
   public Result<ApiView> update(@PathVariable("id") Long id, @RequestBody ApiInput input) {
     return Result.success(dataServiceService.save(id, input));
+  }
+
+  @Operation(summary = "按当前上游 Revision 重新发布数据服务")
+  @PostMapping("/{id}/republish")
+  public Result<ApiView> republish(
+      @PathVariable("id") Long id,
+      @Valid @RequestBody(required = false) RepublishDataServiceRequest request) {
+    RepublishDataServiceRequest values = request == null
+        ? new RepublishDataServiceRequest(null, null, null, null, null, null)
+        : request;
+    return Result.success(publicationService.republish(
+        id,
+        new PublicationSettings(
+            values.name(),
+            values.path(),
+            values.maxRows(),
+            values.timeoutSeconds(),
+            values.enabled(),
+            values.description())));
   }
 
   @Operation(summary = "删除 API 服务")
@@ -198,4 +251,22 @@ public class DataServiceController {
       @RequestParam Map<String, String> parameters) {
     return Result.success(dataServiceService.invoke(servicePath, parameters, apiKey));
   }
+
+  public record PublishDataServiceRequest(
+      @Size(max = 64) String sourceType,
+      @Size(max = 255) String sourceRef,
+      @Size(max = 200) String name,
+      @Size(max = 255) String path,
+      @Min(1) @Max(10_000) Integer maxRows,
+      @Min(1) @Max(3_600) Integer timeoutSeconds,
+      Boolean enabled,
+      @Size(max = 2000) String description) {}
+
+  public record RepublishDataServiceRequest(
+      @Size(max = 200) String name,
+      @Size(max = 255) String path,
+      @Min(1) @Max(10_000) Integer maxRows,
+      @Min(1) @Max(3_600) Integer timeoutSeconds,
+      Boolean enabled,
+      @Size(max = 2000) String description) {}
 }

--- a/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/service/DataServicePublicationService.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/service/DataServicePublicationService.java
@@ -1,0 +1,225 @@
+package io.yak.ops.business.dataservice.service;
+
+import io.yak.ops.business.dataservice.service.DataServiceService.ApiInput;
+import io.yak.ops.business.dataservice.service.DataServiceService.ApiView;
+import io.yak.ops.business.dataservice.service.DataServiceService.SourceSnapshot;
+import io.yak.ops.business.dataservice.service.source.DataServiceSourceProvider;
+import io.yak.ops.business.dataservice.service.source.DataServiceSourceProvider.ResolvedSource;
+import io.yak.ops.business.dataservice.service.source.DataServiceSourceProvider.SourceDescriptor;
+import io.yak.ops.business.dataservice.service.source.DataServiceSourceProvider.SourcePage;
+import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+/**
+ * Single backend transition from an immutable upstream release to a Data Service runtime snapshot.
+ *
+ * <p>Clients only submit source identity and service-facing settings. SQL and datasource identity are
+ * always resolved server-side by the owning {@link DataServiceSourceProvider}.
+ */
+@Service
+@ConditionalOnDataSourceEnabled
+public class DataServicePublicationService {
+
+  private static final int DEFAULT_MAX_ROWS = 1_000;
+  private static final int DEFAULT_TIMEOUT_SECONDS = 30;
+  private static final int MAX_SOURCE_PAGE_SIZE = 100;
+
+  private final DataServiceService dataServiceService;
+  private final Map<String, DataServiceSourceProvider> providers;
+
+  public DataServicePublicationService(
+      DataServiceService dataServiceService,
+      List<DataServiceSourceProvider> sourceProviders) {
+    this.dataServiceService = dataServiceService;
+    Map<String, DataServiceSourceProvider> discovered = new LinkedHashMap<>();
+    for (DataServiceSourceProvider provider : sourceProviders == null ? List.<DataServiceSourceProvider>of() : sourceProviders) {
+      String type = normalizeSourceType(provider.sourceType());
+      DataServiceSourceProvider duplicate = discovered.putIfAbsent(type, provider);
+      if (duplicate != null) {
+        throw new IllegalStateException("数据服务发布来源类型重复：" + type);
+      }
+    }
+    this.providers = Map.copyOf(discovered);
+  }
+
+  public SourcePage sources(String sourceType, int pageNo, int pageSize, String keyword) {
+    int normalizedPageNo = Math.max(1, pageNo);
+    int normalizedPageSize = Math.max(1, Math.min(MAX_SOURCE_PAGE_SIZE, pageSize));
+    return provider(sourceType).list(normalizedPageNo, normalizedPageSize, normalizeKeyword(keyword));
+  }
+
+  public PublicationState state(String sourceType, String sourceRef) {
+    SourceIdentity identity = normalizeIdentity(sourceType, sourceRef);
+    ResolvedSource resolved = requireResolvedSource(provider(identity.sourceType()), identity.sourceRef());
+    SourceDescriptor source = resolved.descriptor();
+    Optional<ApiView> existing = dataServiceService.findBySource(identity.sourceType(), identity.sourceRef());
+    boolean updateAvailable = existing
+        .map(api -> !Objects.equals(api.sourceRevisionId(), source.sourceRevisionId()))
+        .orElse(false);
+    return new PublicationState(existing.isPresent(), updateAvailable, source, existing.orElse(null));
+  }
+
+  public ApiView publish(PublishRequest request) {
+    if (request == null) throw new IllegalArgumentException("发布配置不能为空");
+    SourceIdentity identity = normalizeIdentity(request.sourceType(), request.sourceRef());
+    ResolvedSource resolved = requireResolvedSource(provider(identity.sourceType()), identity.sourceRef());
+    SourceDescriptor source = resolved.descriptor();
+    requirePublishable(source);
+
+    Optional<ApiView> existing = dataServiceService.findBySource(identity.sourceType(), identity.sourceRef());
+    String name = firstText(
+        request.name(),
+        existing.map(ApiView::name).orElse(null),
+        source.name());
+    String path = firstText(
+        request.path(),
+        existing.map(ApiView::path).orElse(null),
+        source.defaultPath());
+    Integer maxRows = request.maxRows() != null
+        ? request.maxRows()
+        : existing.map(ApiView::maxRows).orElse(DEFAULT_MAX_ROWS);
+    Integer timeoutSeconds = request.timeoutSeconds() != null
+        ? request.timeoutSeconds()
+        : existing.map(ApiView::timeoutSeconds)
+            .orElse(source.timeoutSeconds() == null ? DEFAULT_TIMEOUT_SECONDS : source.timeoutSeconds());
+    Boolean enabled = request.enabled() != null
+        ? request.enabled()
+        : existing.map(ApiView::enabled).orElse(Boolean.TRUE);
+    String description = request.description() != null
+        ? request.description()
+        : existing.map(ApiView::description).orElse(null);
+
+    return dataServiceService.saveFromSource(
+        new SourceSnapshot(
+            identity.sourceType(),
+            identity.sourceRef(),
+            source.sourceRevisionId(),
+            source.sourceRevisionNo()),
+        new ApiInput(
+            name,
+            path,
+            source.dataSourceId(),
+            resolved.sql(),
+            maxRows,
+            timeoutSeconds,
+            enabled,
+            description));
+  }
+
+  /** Refreshes only the source snapshot of an existing source-managed service. */
+  public ApiView republish(Long apiId, PublicationSettings settings) {
+    ApiView current = dataServiceService.get(apiId);
+    if (!StringUtils.hasText(current.sourceType()) || !StringUtils.hasText(current.sourceRef())) {
+      throw new IllegalArgumentException("旧版手工数据服务没有发布来源，不能执行重新发布");
+    }
+    PublicationSettings values = settings == null
+        ? new PublicationSettings(null, null, null, null, null, null)
+        : settings;
+    ApiView refreshed = publish(new PublishRequest(
+        current.sourceType(),
+        current.sourceRef(),
+        values.name(),
+        values.path(),
+        values.maxRows(),
+        values.timeoutSeconds(),
+        values.enabled(),
+        values.description()));
+    if (!Objects.equals(current.id(), refreshed.id())) {
+      throw new IllegalStateException("重新发布没有更新原数据服务，请检查来源唯一性：" + apiId);
+    }
+    return refreshed;
+  }
+
+  private DataServiceSourceProvider provider(String sourceType) {
+    String normalized = normalizeSourceType(sourceType);
+    DataServiceSourceProvider provider = providers.get(normalized);
+    if (provider == null) {
+      throw new IllegalArgumentException("不支持的数据服务发布来源：" + normalized);
+    }
+    return provider;
+  }
+
+  private ResolvedSource requireResolvedSource(DataServiceSourceProvider provider, String sourceRef) {
+    ResolvedSource resolved = provider.resolve(sourceRef);
+    if (resolved == null || resolved.descriptor() == null) {
+      throw new IllegalStateException("发布来源解析结果为空：" + provider.sourceType() + "/" + sourceRef);
+    }
+    SourceDescriptor source = resolved.descriptor();
+    SourceIdentity descriptorIdentity = normalizeIdentity(source.sourceType(), source.sourceRef());
+    SourceIdentity requestedIdentity = normalizeIdentity(provider.sourceType(), sourceRef);
+    if (!descriptorIdentity.equals(requestedIdentity)) {
+      throw new IllegalStateException("发布来源返回了不匹配的来源标识：" + source.sourceType() + "/" + source.sourceRef());
+    }
+    return resolved;
+  }
+
+  private void requirePublishable(SourceDescriptor source) {
+    if (!"ONLINE".equalsIgnoreCase(source.status())) {
+      throw new IllegalArgumentException("只有 ONLINE 的发布来源可以发布/更新数据服务");
+    }
+    if (source.sourceRevisionId() == null || source.sourceRevisionId() <= 0L
+        || source.sourceRevisionNo() == null || source.sourceRevisionNo() <= 0) {
+      throw new IllegalArgumentException("发布来源缺少有效的不可变 Revision");
+    }
+    if (source.dataSourceId() == null || source.dataSourceId() <= 0L) {
+      throw new IllegalArgumentException("发布来源缺少有效的数据源");
+    }
+  }
+
+  private SourceIdentity normalizeIdentity(String sourceType, String sourceRef) {
+    String type = normalizeSourceType(sourceType);
+    if (!StringUtils.hasText(sourceRef)) throw new IllegalArgumentException("sourceRef 不能为空");
+    return new SourceIdentity(type, sourceRef.trim());
+  }
+
+  private String normalizeSourceType(String sourceType) {
+    if (!StringUtils.hasText(sourceType)) throw new IllegalArgumentException("sourceType 不能为空");
+    String normalized = sourceType.trim().toUpperCase(Locale.ROOT);
+    if (normalized.length() > 64) throw new IllegalArgumentException("sourceType 不能超过 64 个字符");
+    return normalized;
+  }
+
+  private String normalizeKeyword(String keyword) {
+    return StringUtils.hasText(keyword) ? keyword.trim() : null;
+  }
+
+  private String firstText(String... values) {
+    for (String value : values) {
+      if (StringUtils.hasText(value)) return value.trim();
+    }
+    return null;
+  }
+
+  public record PublishRequest(
+      String sourceType,
+      String sourceRef,
+      String name,
+      String path,
+      Integer maxRows,
+      Integer timeoutSeconds,
+      Boolean enabled,
+      String description) {}
+
+  public record PublicationSettings(
+      String name,
+      String path,
+      Integer maxRows,
+      Integer timeoutSeconds,
+      Boolean enabled,
+      String description) {}
+
+  public record PublicationState(
+      boolean published,
+      boolean updateAvailable,
+      SourceDescriptor source,
+      ApiView detail) {}
+
+  private record SourceIdentity(String sourceType, String sourceRef) {}
+}

--- a/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/service/source/DataServiceSourceProvider.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/service/source/DataServiceSourceProvider.java
@@ -1,0 +1,45 @@
+package io.yak.ops.business.dataservice.service.source;
+
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * Supplies immutable, publishable query sources to Data Service without coupling the module to a
+ * concrete authoring domain such as Data Development.
+ */
+public interface DataServiceSourceProvider {
+
+  String sourceType();
+
+  SourcePage list(int pageNo, int pageSize, String keyword);
+
+  /** Resolves the source currently selected by its upstream release/catalog pointer. */
+  ResolvedSource resolve(String sourceRef);
+
+  record SourcePage(
+      List<SourceDescriptor> records,
+      long total,
+      int pageNo,
+      int pageSize) {
+    public SourcePage {
+      records = records == null ? List.of() : List.copyOf(records);
+    }
+  }
+
+  /** Management-facing source metadata. Executable SQL is intentionally not exposed here. */
+  record SourceDescriptor(
+      String sourceType,
+      String sourceRef,
+      String name,
+      String sourceKind,
+      String status,
+      Long sourceRevisionId,
+      Integer sourceRevisionNo,
+      Long dataSourceId,
+      Integer timeoutSeconds,
+      String defaultPath,
+      Instant updateTime) {}
+
+  /** Server-only material used to create the immutable Data Service runtime snapshot. */
+  record ResolvedSource(SourceDescriptor descriptor, String sql) {}
+}

--- a/yak-ops-business/yak-ops-business-data-service/src/test/java/io/yak/ops/business/dataservice/service/DataServicePublicationServiceTest.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/test/java/io/yak/ops/business/dataservice/service/DataServicePublicationServiceTest.java
@@ -1,0 +1,161 @@
+package io.yak.ops.business.dataservice.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.dataservice.service.DataServicePublicationService.PublishRequest;
+import io.yak.ops.business.dataservice.service.DataServiceService.ApiInput;
+import io.yak.ops.business.dataservice.service.DataServiceService.ApiView;
+import io.yak.ops.business.dataservice.service.DataServiceService.SourceSnapshot;
+import io.yak.ops.business.dataservice.service.source.DataServiceSourceProvider;
+import io.yak.ops.business.dataservice.service.source.DataServiceSourceProvider.ResolvedSource;
+import io.yak.ops.business.dataservice.service.source.DataServiceSourceProvider.SourceDescriptor;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class DataServicePublicationServiceTest {
+
+  private static final String SOURCE_TYPE = "DATA_DEVELOPMENT_RELEASE";
+
+  private DataServiceService dataServiceService;
+  private DataServiceSourceProvider provider;
+  private DataServicePublicationService service;
+
+  @BeforeEach
+  void setUp() {
+    dataServiceService = mock(DataServiceService.class);
+    provider = mock(DataServiceSourceProvider.class);
+    when(provider.sourceType()).thenReturn(SOURCE_TYPE);
+    service = new DataServicePublicationService(dataServiceService, List.of(provider));
+  }
+
+  @Test
+  void publishAlwaysCopiesSqlAndDatasourceFromResolvedSource() {
+    when(provider.resolve("88")).thenReturn(resolved("ONLINE", 102L, 2));
+    when(dataServiceService.findBySource(SOURCE_TYPE, "88")).thenReturn(Optional.empty());
+    when(dataServiceService.saveFromSource(any(SourceSnapshot.class), any(ApiInput.class)))
+        .thenAnswer(invocation -> view(
+            9L,
+            invocation.getArgument(1),
+            invocation.getArgument(0)));
+
+    ApiView result = service.publish(new PublishRequest(
+        SOURCE_TYPE,
+        "88",
+        "订单查询 API",
+        "/orders",
+        500,
+        20,
+        true,
+        "供运营系统查询"));
+
+    ArgumentCaptor<SourceSnapshot> sourceCaptor = ArgumentCaptor.forClass(SourceSnapshot.class);
+    ArgumentCaptor<ApiInput> inputCaptor = ArgumentCaptor.forClass(ApiInput.class);
+    verify(dataServiceService).saveFromSource(sourceCaptor.capture(), inputCaptor.capture());
+
+    assertThat(sourceCaptor.getValue().sourceType()).isEqualTo(SOURCE_TYPE);
+    assertThat(sourceCaptor.getValue().sourceRef()).isEqualTo("88");
+    assertThat(sourceCaptor.getValue().sourceRevisionId()).isEqualTo(102L);
+    assertThat(sourceCaptor.getValue().sourceRevisionNo()).isEqualTo(2);
+    assertThat(inputCaptor.getValue().dataSourceId()).isEqualTo(42L);
+    assertThat(inputCaptor.getValue().sql())
+        .isEqualTo("select id, amount from orders where status = :status");
+    assertThat(result.id()).isEqualTo(9L);
+  }
+
+  @Test
+  void publishRejectsSourceThatIsNotOnline() {
+    when(provider.resolve("88")).thenReturn(resolved("OFFLINE", 102L, 2));
+
+    assertThatThrownBy(() -> service.publish(new PublishRequest(
+        SOURCE_TYPE, "88", null, null, null, null, null, null)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("ONLINE");
+
+    verify(dataServiceService, never()).saveFromSource(any(), any());
+  }
+
+  @Test
+  void republishRefreshesSameServiceIdentityAndPreservesOperationalSettings() {
+    ApiView existing = view(
+        9L,
+        new ApiInput(
+            "订单查询 API",
+            "/orders",
+            42L,
+            "select old_sql from orders",
+            500,
+            20,
+            false,
+            "运营查询"),
+        new SourceSnapshot(SOURCE_TYPE, "88", 102L, 2));
+    when(dataServiceService.get(9L)).thenReturn(existing);
+    when(provider.resolve("88")).thenReturn(resolved("ONLINE", 103L, 3));
+    when(dataServiceService.findBySource(SOURCE_TYPE, "88")).thenReturn(Optional.of(existing));
+    when(dataServiceService.saveFromSource(any(SourceSnapshot.class), any(ApiInput.class)))
+        .thenAnswer(invocation -> view(
+            9L,
+            invocation.getArgument(1),
+            invocation.getArgument(0)));
+
+    ApiView refreshed = service.republish(9L, null);
+
+    assertThat(refreshed.id()).isEqualTo(9L);
+    assertThat(refreshed.sourceRevisionNo()).isEqualTo(3);
+    assertThat(refreshed.name()).isEqualTo("订单查询 API");
+    assertThat(refreshed.path()).isEqualTo("/orders");
+    assertThat(refreshed.maxRows()).isEqualTo(500);
+    assertThat(refreshed.timeoutSeconds()).isEqualTo(20);
+    assertThat(refreshed.enabled()).isFalse();
+    assertThat(refreshed.description()).isEqualTo("运营查询");
+  }
+
+  private ResolvedSource resolved(String status, Long revisionId, int revisionNo) {
+    SourceDescriptor descriptor = new SourceDescriptor(
+        SOURCE_TYPE,
+        "88",
+        "订单查询",
+        "SQL",
+        status,
+        revisionId,
+        revisionNo,
+        42L,
+        30,
+        "/query/88",
+        Instant.parse("2026-08-16T01:00:00Z"));
+    return new ResolvedSource(
+        descriptor,
+        "select id, amount from orders where status = :status");
+  }
+
+  private ApiView view(Long id, ApiInput input, SourceSnapshot source) {
+    return new ApiView(
+        id,
+        input.name(),
+        input.path(),
+        "/api/v1/data-service/runtime" + input.path(),
+        input.dataSourceId(),
+        input.sql(),
+        List.of("status"),
+        input.maxRows(),
+        input.timeoutSeconds(),
+        Boolean.TRUE.equals(input.enabled()),
+        "NONE",
+        input.description(),
+        source.sourceType(),
+        source.sourceRef(),
+        source.sourceRevisionId(),
+        source.sourceRevisionNo(),
+        null,
+        null);
+  }
+}


### PR DESCRIPTION
## Summary

Complete the first backend-convergence phase for Data Service by making immutable upstream releases the authoritative publication source and centralizing the transition into one Data Service publication layer.

This phase deliberately does **not** redesign the frontend yet. Existing Data Development UI/API remains compatible, while the backend is prepared for the next phase where Data Service creation will choose an already-published SQL instead of editing SQL again.

## Architecture

```text
Data Development ONLINE SQL Revision
        ↓
DevelopmentDataServiceSourceProvider
        ↓
DataServicePublicationService
        ↓
DataServiceService.saveFromSource
        ↓
immutable Runtime Snapshot
```

The dependency direction stays one-way:

```text
data-development
      ↓
data-service
      ↓
datasource
```

`data-service` defines the generic `DataServiceSourceProvider` port. Data Development implements it, so Data Service does not depend back on the authoring module.

## Unified publication API

Adds management endpoints:

```text
GET  /api/v1/data-service/sources
POST /api/v1/data-service/publish
POST /api/v1/data-service/{id}/republish
```

### `GET /sources`

Lists publishable upstream assets through a source provider. The first provider is:

```text
sourceType = DATA_DEVELOPMENT_RELEASE
```

Only ONLINE SQL releases are listed. Metadata contains source/ref, current immutable revision, datasource id, timeout, suggested API path and update time. Executable SQL is intentionally not returned by this listing endpoint.

### `POST /publish`

The client supplies only:

- `sourceType`
- `sourceRef`
- API name/path
- max rows / timeout
- enabled state
- description

The request has **no SQL field and no datasource field**. SQL and `dataSourceId` are resolved server-side from the current immutable upstream revision before the Data Service snapshot is created or refreshed.

### `POST /{id}/republish`

Refreshes an existing source-managed Data Service from its currently bound upstream asset. The service identity stays stable and existing operational settings are preserved unless explicitly overridden.

Legacy manual services have no source binding and are rejected by this endpoint with an explicit compatibility message.

## Data Development compatibility

The existing endpoints remain unchanged for the current frontend:

```text
GET  /api/v1/data-development/releases/{assetId}/data-service
POST /api/v1/data-development/releases/{assetId}/data-service
```

`DevelopmentDataServiceService` is now only a backward-compatible facade. It delegates state/publish operations to `DataServicePublicationService` instead of parsing SQL configuration and calling `saveFromSource` itself.

This means both the old Data Development entry point and the new generic Data Service entry point use the same backend publication rules.

## Snapshot semantics preserved

- SQL draft changes do not affect an API
- publishing a new SQL Revision does not silently affect an API
- only explicit publish/republish refreshes the Data Service snapshot
- SQL + datasource always come from the selected immutable release
- `sourceType/sourceRef/sourceRevisionId/sourceRevisionNo` continue to identify provenance
- API Key, Runtime cache/circuit settings, documentation and API identity remain preserved across source refreshes

## Legacy compatibility

The existing `POST /api/v1/data-service` manual SQL API is kept for now and is explicitly documented as the legacy/manual compatibility path. No existing Data Service rows or Flyway migrations are changed in this phase.

The frontend removal of manual SQL/datasource authoring belongs to the next product phase.

## Tests

Adds/updates tests for:

- publication copies SQL and datasource only from the resolved source
- non-ONLINE sources cannot be published
- republish keeps the same Data Service identity and existing operational settings
- Data Development provider extracts immutable Revision SQL, datasource and provenance correctly
- invalid release datasource configuration is rejected
- existing Data Development publish/state contract delegates to the unified publication service

## Scope

- backend only
- no Flyway changes
- no frontend changes
- no Runtime execution changes
- no API Key/cache/circuit/OpenAPI behavior changes

## Validation

- branch is based on the latest `main` after the Data Service module/MyBatis fixes
- final compare is scoped to 8 backend/test files
- verified `data-development -> data-service -> datasource` dependency direction remains acyclic
- verified the standalone Data Service module does not gain a new validation dependency; publication input is validated by the existing service/runtime rules
- performed static review of source identity normalization, ONLINE enforcement, snapshot preservation, legacy behavior and endpoint routing

A full local Maven/Spring startup run was not executed in this connector environment. CI/local Maven should be treated as the executable validation source before marking the PR ready.