### PR TITLE
feat(data-service): create APIs from published SQL releases

### DIFF
--- a/yak-ops-ui/src/pages/data-service/CreateDataServiceModal.tsx
+++ b/yak-ops-ui/src/pages/data-service/CreateDataServiceModal.tsx
@@ -1,0 +1,185 @@
+import { Form, Input, InputNumber, Modal, Select, Switch, Tag, message } from 'antd';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  DATA_DEVELOPMENT_RELEASE_SOURCE,
+  fetchDataServiceSources,
+  publishDataService,
+  type DataServicePublishPayload,
+  type DataServiceSource,
+  type DataSourceOption,
+} from './service';
+
+interface CreateDataServiceModalProps {
+  open: boolean;
+  dataSources: DataSourceOption[];
+  onCancel: () => void;
+  onCreated: () => Promise<void> | void;
+}
+
+type CreateFormValues = Omit<DataServicePublishPayload, 'sourceType'>;
+
+const formatTime = (value?: string) => value ? value.replace('T', ' ').slice(0, 19) : '-';
+
+export default function CreateDataServiceModal({
+  open,
+  dataSources,
+  onCancel,
+  onCreated,
+}: CreateDataServiceModalProps) {
+  const [form] = Form.useForm<CreateFormValues>();
+  const [sources, setSources] = useState<DataServiceSource[]>([]);
+  const [sourceLoading, setSourceLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [selectedRef, setSelectedRef] = useState<string>();
+
+  const selectedSource = useMemo(
+    () => sources.find((item) => item.sourceRef === selectedRef),
+    [selectedRef, sources],
+  );
+
+  const dataSourceName = useMemo(() => {
+    if (!selectedSource) return '-';
+    return dataSources.find((item) => String(item.value) === String(selectedSource.dataSourceId))?.label
+      || `#${selectedSource.dataSourceId}`;
+  }, [dataSources, selectedSource]);
+
+  const loadSources = useCallback(async (keyword?: string) => {
+    setSourceLoading(true);
+    try {
+      const response = await fetchDataServiceSources({
+        sourceType: DATA_DEVELOPMENT_RELEASE_SOURCE,
+        pageNo: 1,
+        pageSize: 100,
+        keyword: keyword?.trim() || undefined,
+      });
+      setSources(response.data?.records || []);
+    } catch (error: any) {
+      message.error(error?.message || '加载可发布 SQL 失败');
+    } finally {
+      setSourceLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+    form.resetFields();
+    form.setFieldsValue({ maxRows: 1000, timeoutSeconds: 30, enabled: false });
+    setSelectedRef(undefined);
+    void loadSources();
+  }, [form, loadSources, open]);
+
+  const selectSource = (sourceRef?: string) => {
+    setSelectedRef(sourceRef);
+    if (!sourceRef) return;
+    const source = sources.find((item) => item.sourceRef === sourceRef);
+    if (!source) return;
+    form.setFieldsValue({
+      sourceRef,
+      name: `${source.name} API`,
+      path: source.defaultPath,
+      maxRows: 1000,
+      timeoutSeconds: source.timeoutSeconds || 30,
+      enabled: false,
+    });
+  };
+
+  const save = async () => {
+    const values = await form.validateFields();
+    setSaving(true);
+    try {
+      await publishDataService({
+        sourceType: DATA_DEVELOPMENT_RELEASE_SOURCE,
+        ...values,
+      });
+      message.success('数据服务已创建');
+      onCancel();
+      await onCreated();
+    } catch (error: any) {
+      message.error(error?.message || '创建数据服务失败');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Modal
+      title="新建 API 服务"
+      open={open}
+      onCancel={onCancel}
+      onOk={() => void save()}
+      okText="创建 API"
+      confirmLoading={saving}
+      width={720}
+      destroyOnHidden
+    >
+      <Form form={form} layout="vertical" className="pt-3">
+        <div className="mb-4 text-[13px] leading-5 text-black/45">
+          选择数据开发中已上线的 SQL 发布版本。SQL 与数据源由来源版本管理，这里只配置 API 的服务侧参数。
+        </div>
+
+        <Form.Item
+          name="sourceRef"
+          label="来源 SQL"
+          rules={[{ required: true, message: '请选择已发布 SQL' }]}
+          extra="仅展示数据开发中 ONLINE 的 SQL 发布版本。"
+        >
+          <Select
+            allowClear
+            showSearch
+            filterOption={false}
+            loading={sourceLoading}
+            placeholder="搜索并选择已发布 SQL"
+            notFoundContent={sourceLoading ? '加载中...' : '暂无可发布 SQL，请先在数据开发完成 SQL 发布'}
+            onSearch={(value) => void loadSources(value)}
+            onChange={selectSource}
+            options={sources.map((item) => ({
+              value: item.sourceRef,
+              label: `${item.name} · v${item.sourceRevisionNo || '-'}`,
+            }))}
+          />
+        </Form.Item>
+
+        {selectedSource ? (
+          <div className="mb-5 border border-[#e5e7eb] bg-[#fafafa] px-4 py-3">
+            <div className="flex items-center gap-2">
+              <span className="font-medium text-[#161823]">{selectedSource.name}</span>
+              <Tag bordered={false}>SQL</Tag>
+              <Tag bordered={false}>v{selectedSource.sourceRevisionNo || '-'}</Tag>
+            </div>
+            <div className="mt-2 grid grid-cols-2 gap-x-6 gap-y-1 text-xs text-black/45">
+              <div>数据源：<span className="text-black/65">{dataSourceName}</span></div>
+              <div>更新时间：<span className="text-black/65">{formatTime(selectedSource.updateTime)}</span></div>
+              <div>来源：<span className="text-black/65">数据开发 · 已发布</span></div>
+              <div>Revision：<span className="text-black/65">#{selectedSource.sourceRevisionId}</span></div>
+            </div>
+          </div>
+        ) : null}
+
+        <div className="grid grid-cols-2 gap-x-4">
+          <Form.Item name="name" label="服务名称" rules={[{ required: true, message: '请输入服务名称' }]}>
+            <Input placeholder="例如：用户查询 API" />
+          </Form.Item>
+          <Form.Item name="path" label="服务路径" rules={[{ required: true, message: '请输入服务路径' }]}>
+            <Input addonBefore="GET" placeholder="/users" />
+          </Form.Item>
+        </div>
+
+        <div className="grid grid-cols-3 gap-x-4">
+          <Form.Item name="maxRows" label="最大返回行数" rules={[{ required: true }]}>
+            <InputNumber min={1} max={10000} className="w-full" />
+          </Form.Item>
+          <Form.Item name="timeoutSeconds" label="超时时间（秒）" rules={[{ required: true }]}>
+            <InputNumber min={1} max={3600} className="w-full" />
+          </Form.Item>
+          <Form.Item name="enabled" label="发布状态" valuePropName="checked">
+            <Switch checkedChildren="启用" unCheckedChildren="停用" />
+          </Form.Item>
+        </div>
+
+        <Form.Item name="description" label="说明">
+          <Input.TextArea rows={2} maxLength={500} placeholder="可选" />
+        </Form.Item>
+      </Form>
+    </Modal>
+  );
+}

--- a/yak-ops-ui/src/pages/data-service/CreateDataServiceModal.tsx
+++ b/yak-ops-ui/src/pages/data-service/CreateDataServiceModal.tsx
@@ -2,9 +2,9 @@ import { Form, Input, InputNumber, Modal, Select, Switch, Tag, message } from 'a
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   DATA_DEVELOPMENT_RELEASE_SOURCE,
+  fetchDataServices,
   fetchDataServiceSources,
   publishDataService,
-  type DataServiceApi,
   type DataServicePublishPayload,
   type DataServiceSource,
   type DataSourceOption,
@@ -12,7 +12,6 @@ import {
 
 interface CreateDataServiceModalProps {
   open: boolean;
-  services: DataServiceApi[];
   dataSources: DataSourceOption[];
   onCancel: () => void;
   onCreated: () => Promise<void> | void;
@@ -24,22 +23,16 @@ const formatTime = (value?: string) => value ? value.replace('T', ' ').slice(0, 
 
 export default function CreateDataServiceModal({
   open,
-  services,
   dataSources,
   onCancel,
   onCreated,
 }: CreateDataServiceModalProps) {
   const [form] = Form.useForm<CreateFormValues>();
   const [sources, setSources] = useState<DataServiceSource[]>([]);
+  const [publishedRefs, setPublishedRefs] = useState<Set<string>>(new Set());
   const [sourceLoading, setSourceLoading] = useState(false);
   const [saving, setSaving] = useState(false);
   const [selectedRef, setSelectedRef] = useState<string>();
-
-  const publishedRefs = useMemo(() => new Set(
-    services
-      .filter((item) => item.sourceType === DATA_DEVELOPMENT_RELEASE_SOURCE && item.sourceRef)
-      .map((item) => item.sourceRef as string),
-  ), [services]);
 
   const selectedSource = useMemo(
     () => sources.find((item) => item.sourceRef === selectedRef),
@@ -69,13 +62,26 @@ export default function CreateDataServiceModal({
     }
   }, []);
 
+  const loadPublishedRefs = useCallback(async () => {
+    try {
+      const response = await fetchDataServices();
+      setPublishedRefs(new Set(
+        (response.data || [])
+          .filter((item) => item.sourceType === DATA_DEVELOPMENT_RELEASE_SOURCE && item.sourceRef)
+          .map((item) => item.sourceRef as string),
+      ));
+    } catch (error: any) {
+      message.error(error?.message || '加载已发布 API 状态失败');
+    }
+  }, []);
+
   useEffect(() => {
     if (!open) return;
     form.resetFields();
     form.setFieldsValue({ maxRows: 1000, timeoutSeconds: 30, enabled: false });
     setSelectedRef(undefined);
-    void loadSources();
-  }, [form, loadSources, open]);
+    void Promise.all([loadSources(), loadPublishedRefs()]);
+  }, [form, loadPublishedRefs, loadSources, open]);
 
   const selectSource = (sourceRef?: string) => {
     setSelectedRef(sourceRef);

--- a/yak-ops-ui/src/pages/data-service/CreateDataServiceModal.tsx
+++ b/yak-ops-ui/src/pages/data-service/CreateDataServiceModal.tsx
@@ -4,6 +4,7 @@ import {
   DATA_DEVELOPMENT_RELEASE_SOURCE,
   fetchDataServiceSources,
   publishDataService,
+  type DataServiceApi,
   type DataServicePublishPayload,
   type DataServiceSource,
   type DataSourceOption,
@@ -11,6 +12,7 @@ import {
 
 interface CreateDataServiceModalProps {
   open: boolean;
+  services: DataServiceApi[];
   dataSources: DataSourceOption[];
   onCancel: () => void;
   onCreated: () => Promise<void> | void;
@@ -22,6 +24,7 @@ const formatTime = (value?: string) => value ? value.replace('T', ' ').slice(0, 
 
 export default function CreateDataServiceModal({
   open,
+  services,
   dataSources,
   onCancel,
   onCreated,
@@ -31,6 +34,12 @@ export default function CreateDataServiceModal({
   const [sourceLoading, setSourceLoading] = useState(false);
   const [saving, setSaving] = useState(false);
   const [selectedRef, setSelectedRef] = useState<string>();
+
+  const publishedRefs = useMemo(() => new Set(
+    services
+      .filter((item) => item.sourceType === DATA_DEVELOPMENT_RELEASE_SOURCE && item.sourceRef)
+      .map((item) => item.sourceRef as string),
+  ), [services]);
 
   const selectedSource = useMemo(
     () => sources.find((item) => item.sourceRef === selectedRef),
@@ -72,7 +81,7 @@ export default function CreateDataServiceModal({
     setSelectedRef(sourceRef);
     if (!sourceRef) return;
     const source = sources.find((item) => item.sourceRef === sourceRef);
-    if (!source) return;
+    if (!source || publishedRefs.has(sourceRef)) return;
     form.setFieldsValue({
       sourceRef,
       name: `${source.name} API`,
@@ -85,6 +94,10 @@ export default function CreateDataServiceModal({
 
   const save = async () => {
     const values = await form.validateFields();
+    if (publishedRefs.has(values.sourceRef)) {
+      message.warning('该 SQL 已发布为数据服务，请从已有 API 或数据开发执行更新');
+      return;
+    }
     setSaving(true);
     try {
       await publishDataService({
@@ -121,7 +134,7 @@ export default function CreateDataServiceModal({
           name="sourceRef"
           label="来源 SQL"
           rules={[{ required: true, message: '请选择已发布 SQL' }]}
-          extra="仅展示数据开发中 ONLINE 的 SQL 发布版本。"
+          extra="仅展示数据开发中 ONLINE 的 SQL 发布版本；已创建 API 的来源会保留展示但不可重复选择。"
         >
           <Select
             allowClear
@@ -132,10 +145,14 @@ export default function CreateDataServiceModal({
             notFoundContent={sourceLoading ? '加载中...' : '暂无可发布 SQL，请先在数据开发完成 SQL 发布'}
             onSearch={(value) => void loadSources(value)}
             onChange={selectSource}
-            options={sources.map((item) => ({
-              value: item.sourceRef,
-              label: `${item.name} · v${item.sourceRevisionNo || '-'}`,
-            }))}
+            options={sources.map((item) => {
+              const published = publishedRefs.has(item.sourceRef);
+              return {
+                value: item.sourceRef,
+                disabled: published,
+                label: `${item.name} · v${item.sourceRevisionNo || '-'}${published ? ' · 已发布' : ''}`,
+              };
+            })}
           />
         </Form.Item>
 

--- a/yak-ops-ui/src/pages/data-service/index.tsx
+++ b/yak-ops-ui/src/pages/data-service/index.tsx
@@ -16,11 +16,11 @@ import {
 } from 'antd';
 import { Activity, Copy, FileText, Pencil, Plus, RefreshCw, Search, ShieldCheck, Trash2 } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import CreateDataServiceModal from './CreateDataServiceModal';
 import DataServiceAccessModal from './DataServiceAccessModal';
 import DataServiceDocsModal from './DataServiceDocsModal';
 import DataServiceRuntimeModal from './DataServiceRuntimeModal';
 import {
-  createDataService,
   deleteDataService,
   fetchDataServices,
   fetchDataSourceOptions,
@@ -38,6 +38,7 @@ export default function DataServicePage() {
   const [dataSources, setDataSources] = useState<DataSourceOption[]>([]);
   const [loading, setLoading] = useState(false);
   const [keyword, setKeyword] = useState('');
+  const [createOpen, setCreateOpen] = useState(false);
   const [editing, setEditing] = useState<DataServiceApi>();
   const [editorOpen, setEditorOpen] = useState(false);
   const [saving, setSaving] = useState(false);
@@ -81,15 +82,14 @@ export default function DataServicePage() {
         .some((text) => String(text).toLowerCase().includes(value)));
   }, [keyword, services]);
 
-  const openCreate = () => {
-    setEditing(undefined);
-    form.resetFields();
-    form.setFieldsValue({ maxRows: 1000, timeoutSeconds: 30, enabled: false });
-    setEditorOpen(true);
-  };
+  const dataSourceName = useCallback((dataSourceId?: number) => {
+    if (!dataSourceId) return '-';
+    return dataSources.find((item) => String(item.value) === String(dataSourceId))?.label || `#${dataSourceId}`;
+  }, [dataSources]);
 
   const openEdit = (record: DataServiceApi) => {
     setEditing(record);
+    form.resetFields();
     form.setFieldsValue({
       name: record.name,
       path: record.path,
@@ -103,14 +103,20 @@ export default function DataServicePage() {
     setEditorOpen(true);
   };
 
-  const save = async () => {
+  const saveEdit = async () => {
+    if (!editing) return;
     const values = await form.validateFields();
+    const payload: DataServiceSavePayload = {
+      ...values,
+      dataSourceId: sourceManaged ? editing.dataSourceId : values.dataSourceId,
+      sql: sourceManaged ? editing.sql : values.sql,
+    };
     setSaving(true);
     try {
-      if (editing) await updateDataService(editing.id, values);
-      else await createDataService(values);
-      message.success(editing ? '数据服务已更新' : '数据服务已创建');
+      await updateDataService(editing.id, payload);
+      message.success('数据服务已更新');
       setEditorOpen(false);
+      setEditing(undefined);
       await load();
     } catch (error: any) {
       message.error(error?.message || '保存数据服务失败');
@@ -161,7 +167,9 @@ export default function DataServicePage() {
             <Tag bordered={false}>GET</Tag>
             {record.sourceType === 'DATA_DEVELOPMENT_RELEASE' ? (
               <Tag bordered={false}>数据开发 v{record.sourceRevisionNo || '-'}</Tag>
-            ) : null}
+            ) : (
+              <Tag bordered={false}>Legacy</Tag>
+            )}
           </div>
           <div className="mt-1 flex items-center gap-1 text-xs text-black/45">
             <span className="font-mono">{record.runtimePath}</span>
@@ -176,7 +184,7 @@ export default function DataServicePage() {
       title: '数据源',
       dataIndex: 'dataSourceId',
       width: 190,
-      render: (value) => dataSources.find((item) => String(item.value) === String(value))?.label || `#${value}`,
+      render: (value) => dataSourceName(value),
     },
     {
       title: '参数',
@@ -247,9 +255,9 @@ export default function DataServicePage() {
       <div className="mb-5 flex items-start justify-between gap-4">
         <div>
           <h1 className="m-0 text-xl font-semibold text-[#161823]">API 服务</h1>
-          <p className="mb-0 mt-1 text-sm text-black/45">将只读 SQL 发布为可调用、可鉴权、可缓存、可熔断、可文档化的 GET REST API。</p>
+          <p className="mb-0 mt-1 text-sm text-black/45">将数据开发中已发布的 SQL 转换为可调用、可鉴权、可缓存、可熔断、可文档化的 GET REST API。</p>
         </div>
-        <Button type="primary" icon={<Plus size={16} />} onClick={openCreate}>新建 API</Button>
+        <Button type="primary" icon={<Plus size={16} />} onClick={() => setCreateOpen(true)}>新建 API</Button>
       </div>
 
       <div className="mb-3 flex items-center justify-between gap-3">
@@ -274,6 +282,13 @@ export default function DataServicePage() {
         scroll={{ x: 1360 }}
       />
 
+      <CreateDataServiceModal
+        open={createOpen}
+        dataSources={dataSources}
+        onCancel={() => setCreateOpen(false)}
+        onCreated={load}
+      />
+
       <DataServiceDocsModal
         open={Boolean(docsTarget)}
         service={docsTarget}
@@ -294,10 +309,13 @@ export default function DataServicePage() {
       />
 
       <Modal
-        title={editing ? '编辑 API 服务' : '新建 API 服务'}
+        title="编辑 API 服务"
         open={editorOpen}
-        onCancel={() => setEditorOpen(false)}
-        onOk={() => void save()}
+        onCancel={() => {
+          setEditorOpen(false);
+          setEditing(undefined);
+        }}
+        onOk={() => void saveEdit()}
         okText="保存"
         confirmLoading={saving}
         width={760}
@@ -305,10 +323,17 @@ export default function DataServicePage() {
       >
         <Form form={form} layout="vertical" className="pt-3">
           {sourceManaged ? (
-            <div className="mb-4 border border-[#e5e7eb] bg-[#fafafa] px-3 py-2.5 text-[12px] leading-5 text-[#667085]">
-              来源：数据开发 SQL v{editing?.sourceRevisionNo || '-'}。SQL 与数据源由来源版本管理；如需更新执行逻辑，请回到数据开发重新发布数据服务。
+            <div className="mb-4 border border-[#e5e7eb] bg-[#fafafa] px-4 py-3 text-[12px] leading-5 text-[#667085]">
+              <div className="font-medium text-[#344054]">来源：数据开发 SQL · v{editing?.sourceRevisionNo || '-'}</div>
+              <div className="mt-1">数据源：{dataSourceName(editing?.dataSourceId)} · Source #{editing?.sourceRef || '-'}</div>
+              <div className="mt-1">SQL 与数据源由上游发布版本管理；需要修改执行逻辑时，请回到数据开发发布新 Revision。</div>
             </div>
-          ) : null}
+          ) : (
+            <div className="mb-4 border border-[#e5e7eb] bg-[#fafafa] px-4 py-3 text-[12px] leading-5 text-[#667085]">
+              这是旧版手工创建的数据服务，当前继续保留 SQL 与数据源编辑能力用于兼容。新的 API 请从数据开发已发布 SQL 创建。
+            </div>
+          )}
+
           <div className="grid grid-cols-2 gap-x-4">
             <Form.Item name="name" label="服务名称" rules={[{ required: true, message: '请输入服务名称' }]}>
               <Input placeholder="例如：用户查询 API" />
@@ -317,36 +342,37 @@ export default function DataServicePage() {
               <Input addonBefore="GET" placeholder="/users" />
             </Form.Item>
           </div>
-          <Form.Item
-            name="dataSourceId"
-            label="数据源"
-            extra={sourceManaged ? '由数据开发 SQL 发布版本继承，不支持在这里修改。' : undefined}
-            rules={[{ required: true, message: '请选择数据源' }]}
-          >
-            <Select
-              disabled={sourceManaged}
-              showSearch
-              optionFilterProp="label"
-              placeholder="选择已有数据源"
-              options={dataSources.map((item) => ({ ...item, value: Number(item.value) || item.value }))}
-            />
-          </Form.Item>
-          <Form.Item
-            name="sql"
-            label="SELECT SQL"
-            extra={sourceManaged
-              ? 'SQL 固定继承数据开发的发布版本；新 SQL 版本发布后，请从数据开发执行“发布为数据服务”完成更新。'
-              : '使用 :参数名 声明请求参数，例如 WHERE department = :department。仅允许单条 SELECT。'}
-            rules={[{ required: true, message: '请输入 SQL' }]}
-          >
-            <Input.TextArea
-              disabled={sourceManaged}
-              rows={10}
-              spellCheck={false}
-              placeholder={'SELECT id, username\nFROM sys_user\nWHERE department = :department'}
-              style={{ fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace' }}
-            />
-          </Form.Item>
+
+          {!sourceManaged ? (
+            <>
+              <Form.Item
+                name="dataSourceId"
+                label="数据源"
+                rules={[{ required: true, message: '请选择数据源' }]}
+              >
+                <Select
+                  showSearch
+                  optionFilterProp="label"
+                  placeholder="选择已有数据源"
+                  options={dataSources.map((item) => ({ ...item, value: Number(item.value) || item.value }))}
+                />
+              </Form.Item>
+              <Form.Item
+                name="sql"
+                label="SELECT SQL"
+                extra="Legacy 兼容模式。新的 SQL 开发请统一在数据开发中完成。"
+                rules={[{ required: true, message: '请输入 SQL' }]}
+              >
+                <Input.TextArea
+                  rows={10}
+                  spellCheck={false}
+                  placeholder={'SELECT id, username\nFROM sys_user\nWHERE department = :department'}
+                  style={{ fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace' }}
+                />
+              </Form.Item>
+            </>
+          ) : null}
+
           <div className="grid grid-cols-3 gap-x-4">
             <Form.Item name="maxRows" label="最大返回行数" rules={[{ required: true }]}>
               <InputNumber min={1} max={10000} className="w-full" />

--- a/yak-ops-ui/src/pages/data-service/service.ts
+++ b/yak-ops-ui/src/pages/data-service/service.ts
@@ -13,6 +13,47 @@ export interface DataSourceOption {
   dbType?: string;
 }
 
+export const DATA_DEVELOPMENT_RELEASE_SOURCE = 'DATA_DEVELOPMENT_RELEASE' as const;
+
+export interface DataServiceSource {
+  sourceType: string;
+  sourceRef: string;
+  name: string;
+  sourceKind: string;
+  status: string;
+  sourceRevisionId: number;
+  sourceRevisionNo: number;
+  dataSourceId: number;
+  timeoutSeconds?: number;
+  defaultPath: string;
+  updateTime?: string;
+}
+
+export interface DataServiceSourcePage {
+  records: DataServiceSource[];
+  total: number;
+  pageNo: number;
+  pageSize: number;
+}
+
+export interface DataServiceSourceQuery {
+  sourceType: string;
+  pageNo?: number;
+  pageSize?: number;
+  keyword?: string;
+}
+
+export interface DataServicePublishPayload {
+  sourceType: string;
+  sourceRef: string;
+  name?: string;
+  path?: string;
+  maxRows?: number;
+  timeoutSeconds?: number;
+  enabled?: boolean;
+  description?: string;
+}
+
 export type DataServiceAuthMode = 'NONE' | 'API_KEY';
 export type DataServiceSchemaType =
   | 'STRING'
@@ -174,6 +215,25 @@ const PREFIX = '/api/v1/data-service';
 export const fetchDataServices = () =>
   HttpUtils.get<DataServiceApi[]>(PREFIX) as Promise<CommonApiResponse<DataServiceApi[]>>;
 
+export const fetchDataServiceSources = ({
+  sourceType,
+  pageNo = 1,
+  pageSize = 100,
+  keyword,
+}: DataServiceSourceQuery) => {
+  const query = [
+    `sourceType=${encodeURIComponent(sourceType)}`,
+    `pageNo=${pageNo}`,
+    `pageSize=${pageSize}`,
+    keyword ? `keyword=${encodeURIComponent(keyword)}` : undefined,
+  ].filter(Boolean).join('&');
+  return HttpUtils.get<DataServiceSourcePage>(`${PREFIX}/sources?${query}`) as Promise<CommonApiResponse<DataServiceSourcePage>>;
+};
+
+export const publishDataService = (payload: DataServicePublishPayload) =>
+  HttpUtils.post<DataServiceApi>(`${PREFIX}/publish`, payload) as Promise<CommonApiResponse<DataServiceApi>>;
+
+/** Legacy manual SQL creation path retained for historical services during the migration period. */
 export const createDataService = (payload: DataServiceSavePayload) =>
   HttpUtils.post<DataServiceApi>(PREFIX, payload) as Promise<CommonApiResponse<DataServiceApi>>;
 


### PR DESCRIPTION
## Summary

Complete the second Data Service convergence phase by replacing the standalone SQL authoring flow in **New API Service** with a published-SQL source selector backed by the unified publication API introduced in #418.

The new product flow is now:

```text
Data Development
  -> publish immutable SQL Revision
  -> Data Service / New API
  -> choose published SQL
  -> configure API-facing settings only
  -> create Data Service
```

## New API flow

The create dialog no longer contains:

- datasource selector
- SELECT SQL textarea

Instead it contains:

- published SQL source selector
- read-only source summary
- service name
- GET path
- max rows
- timeout
- enabled state
- description

Only `ONLINE` SQL releases returned by:

```text
GET /api/v1/data-service/sources?sourceType=DATA_DEVELOPMENT_RELEASE
```

are available for selection.

## Source summary

After selecting a SQL release the dialog shows the authoritative upstream metadata:

- data-development task name
- SQL revision number
- datasource name
- immutable revision id
- source update time

The service name/path/timeout are initialized from the selected source but remain service-facing settings that can be adjusted before creation.

## Publication contract

Creation now calls:

```text
POST /api/v1/data-service/publish
```

The frontend sends only source identity and API-facing settings. It never sends SQL or `dataSourceId` for the new flow.

Executable SQL and datasource identity continue to be resolved server-side from the immutable release by the backend publication model.

## Duplicate-source protection

`POST /publish` intentionally preserves one stable Data Service identity per source, so using it from a create dialog against an already-published source could otherwise look like a new API while actually refreshing an existing one.

To prevent that confusing behavior, the create modal also loads existing Data Services and marks already-published SQL sources as:

```text
已发布
```

Those options are disabled and cannot be selected from the create path. Updating an existing source-backed API remains an explicit republish/data-development action.

## Editing existing APIs

Source-backed APIs no longer show a disabled duplicate SQL editor during normal edit. Their edit dialog now shows a compact read-only source summary and only allows service-facing settings to change.

Legacy manually-created APIs still retain datasource + SQL editing for compatibility during the migration period. They are clearly labeled as legacy in the UI; removal/migration of that compatibility path remains a later phase.

## Page copy

The API Service page description now reflects the actual model: Data Service publishes SQL that was already developed and released in Data Development, rather than authoring SQL again.

## Files

This PR is intentionally frontend-only and scoped to three files:

- `CreateDataServiceModal.tsx` (new)
- `data-service/index.tsx`
- `data-service/service.ts`

## Compatibility

- no backend changes
- no Flyway changes
- no Runtime changes
- no API Key/cache/circuit/OpenAPI changes
- existing Data Development -> Data Service publication remains unchanged
- existing manual Data Services remain editable for now

## Validation

- branch is based on merged #418
- final compare: 3 frontend files, behind 0
- checked create flow against `/sources` and `/publish` response/request models from #418
- checked source-backed edit behavior still supplies the unchanged SQL/datasource snapshot required by the existing update endpoint
- checked already-published sources cannot silently update an existing API through the create dialog

A full local TypeScript/build run was not executed from this connector environment. CI/local frontend build should be treated as the executable validation source before marking the PR ready.