### PR TITLE
feat(data-development): strengthen publish API workflow

### DIFF
--- a/yak-ops-ui/src/pages/data-development/components/workbench/PublishDataServiceModal.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/workbench/PublishDataServiceModal.tsx
@@ -1,5 +1,5 @@
 import { Input, InputNumber, Modal, Switch } from 'antd';
-import { Braces, GitBranch, Info, Link2, ServerCog } from 'lucide-react';
+import { ArrowRight, Braces, GitBranch, Info, Link2, ServerCog } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 
 import type {
@@ -32,6 +32,7 @@ const PublishDataServiceModal = ({
   const detail = dataServiceState?.detail || undefined;
   const alreadyPublished = Boolean(dataServiceState?.published && detail);
   const needsUpdate = Boolean(dataServiceState?.updateAvailable);
+  const apiRevisionNo = detail?.sourceRevisionNo;
   const [name, setName] = useState(stripSqlSuffix(nodeName));
   const [path, setPath] = useState('');
   const [maxRows, setMaxRows] = useState(1000);
@@ -77,18 +78,40 @@ const PublishDataServiceModal = ({
   );
 
   const confirmText = !alreadyPublished
-    ? '发布数据服务'
+    ? `发布 API · SQL v${release?.currentRevisionNo || '-'}`
     : needsUpdate
-      ? `更新到 SQL v${release?.currentRevisionNo || '-'}`
-      : '保存数据服务';
+      ? `更新 API · v${apiRevisionNo || '-'} → v${release?.currentRevisionNo || '-'}`
+      : '保存 API 配置';
+
+  const modalTitle = !alreadyPublished
+    ? '发布 API'
+    : needsUpdate
+      ? '更新 API'
+      : 'API 发布配置';
+
+  const statusTitle = !alreadyPublished
+    ? '未发布'
+    : needsUpdate
+      ? '待更新'
+      : detail?.enabled === false
+        ? '已同步 · 已停用'
+        : '已同步';
+
+  const statusDescription = !alreadyPublished
+    ? `本次将以当前 ONLINE SQL v${release?.currentRevisionNo || '-'} 创建稳定的 API 快照。`
+    : needsUpdate
+      ? `线上 API 仍运行 SQL v${apiRevisionNo || '-'}。只有确认更新后，Runtime 才会切换到当前 ONLINE SQL v${release?.currentRevisionNo || '-'}。`
+      : detail?.enabled === false
+        ? `API 快照已经同步 SQL v${apiRevisionNo || release?.currentRevisionNo || '-'}，但当前服务处于停用状态。`
+        : `线上 API 已经同步当前 ONLINE SQL v${apiRevisionNo || release?.currentRevisionNo || '-'}。`;
 
   return (
     <Modal
       open={open}
-      width={680}
+      width={700}
       centered
       destroyOnHidden
-      title={alreadyPublished ? '更新数据服务' : '发布为数据服务'}
+      title={modalTitle}
       okText={confirmText}
       cancelText="取消"
       confirmLoading={publishing}
@@ -104,24 +127,73 @@ const PublishDataServiceModal = ({
       })}
     >
       <div className="space-y-4 py-2">
-        <div className="grid grid-cols-2 gap-2">
+        <div className="grid grid-cols-[1fr_36px_1fr] items-stretch gap-2">
           <div className="border border-[#e5e7eb] bg-[#fafbfc] px-3 py-2.5">
             <div className="flex items-center gap-1.5 text-[11px] text-[#98a2b3]">
-              <GitBranch size={13} /> SQL 发布版本
+              <ServerCog size={13} /> 线上 API 快照
             </div>
             <div className="mt-1 text-[13px] font-medium text-[#344054]">
-              {release ? `v${release.currentRevisionNo}` : '尚未发布'}
+              {alreadyPublished ? `SQL v${apiRevisionNo || '-'}` : '未发布'}
+            </div>
+            <div className="mt-0.5 text-[10px] text-[#98a2b3]">
+              {alreadyPublished ? `API #${detail?.id}` : '尚未创建 Runtime 快照'}
             </div>
           </div>
+
+          <div className="flex items-center justify-center text-[#98a2b3]">
+            <ArrowRight
+              size={16}
+              className={needsUpdate || !alreadyPublished ? 'text-[var(--yak-brand-color)]' : undefined}
+            />
+          </div>
+
           <div className="border border-[#e5e7eb] bg-[#fafbfc] px-3 py-2.5">
             <div className="flex items-center gap-1.5 text-[11px] text-[#98a2b3]">
-              <ServerCog size={13} /> 数据服务状态
+              <GitBranch size={13} /> 当前 ONLINE SQL
             </div>
             <div className="mt-1 text-[13px] font-medium text-[#344054]">
-              {!alreadyPublished ? '未发布' : needsUpdate ? '有新 SQL 版本待更新' : '已同步'}
+              {release ? `SQL v${release.currentRevisionNo}` : '尚未发布'}
+            </div>
+            <div className="mt-0.5 text-[10px] text-[#98a2b3]">
+              {release ? `Revision #${release.currentRevisionId}` : '请先发布 SQL 版本'}
             </div>
           </div>
         </div>
+
+        <div
+          className={[
+            'flex gap-2 border px-3 py-2.5 text-[11px] leading-5',
+            needsUpdate || !alreadyPublished
+              ? 'border-[rgba(254,44,85,.18)] bg-[rgba(254,44,85,.035)] text-[#667085]'
+              : 'border-[#e5e7eb] bg-[#fafafa] text-[#667085]',
+          ].join(' ')}
+        >
+          <ServerCog
+            size={14}
+            className={[
+              'mt-0.5 shrink-0',
+              needsUpdate || !alreadyPublished ? 'text-[var(--yak-brand-color)]' : 'text-[#667085]',
+            ].join(' ')}
+          />
+          <div>
+            <div className={[
+              'font-medium',
+              needsUpdate || !alreadyPublished ? 'text-[var(--yak-brand-color)]' : 'text-[#344054]',
+            ].join(' ')}>
+              {statusTitle}
+            </div>
+            <div>{statusDescription}</div>
+          </div>
+        </div>
+
+        {release?.hasNewerRevision ? (
+          <div className="flex gap-2 border border-[#e5e7eb] bg-[#fafafa] px-3 py-2 text-[11px] leading-5 text-[#667085]">
+            <Info size={14} className="mt-0.5 shrink-0" />
+            <div>
+              数据开发还有 SQL v{release.latestRevisionNo} 尚未切换为当前 ONLINE 版本；本次 API 发布只使用 SQL v{release.currentRevisionNo}。
+            </div>
+          </div>
+        ) : null}
 
         <div className="grid grid-cols-2 gap-3">
           <div>
@@ -197,7 +269,7 @@ const PublishDataServiceModal = ({
           <div className="flex items-start gap-2 border border-[#e5e7eb] px-3 py-2.5">
             <Braces size={14} className="mt-0.5 shrink-0 text-[#667085]" />
             <div className="min-w-0 text-[11px] leading-5 text-[#667085]">
-              当前参数：{detail.parameterNames.map((name) => `:${name}`).join('、')}
+              当前线上 API 参数：{detail.parameterNames.map((parameter) => `:${parameter}`).join('、')}
             </div>
           </div>
         ) : null}
@@ -205,7 +277,7 @@ const PublishDataServiceModal = ({
         <div className="flex gap-2 bg-[#f8f9fb] px-3 py-2.5 text-[11px] leading-5 text-[#667085]">
           <Info size={14} className="mt-0.5 shrink-0" />
           <div>
-            SQL 与数据源固定继承当前 ONLINE 发布版本。后续编辑草稿或发布新的 SQL 版本不会自动改变线上 API；只有再次点击“发布为数据服务”才会更新服务快照。
+            API 的 SQL 与数据源固定继承当前 ONLINE 发布版本。编辑草稿或生成新的 SQL Revision 不会自动改变线上 API；只有明确执行“发布 API / 更新 API”才会刷新 Runtime 快照。
           </div>
         </div>
       </div>

--- a/yak-ops-ui/src/pages/data-development/editors/sql/SqlToolbar.tsx
+++ b/yak-ops-ui/src/pages/data-development/editors/sql/SqlToolbar.tsx
@@ -32,6 +32,9 @@ import SqlMetadataContextToolbar from './metadata/SqlMetadataContextToolbar';
 const iconButtonClassName =
   'flex h-7 w-7 shrink-0 items-center justify-center rounded-[3px] text-[#475467] outline-none transition-colors hover:bg-[#f5f5f6] hover:text-[#1f2937] focus-visible:ring-2 focus-visible:ring-[rgba(254,44,85,.16)] disabled:cursor-not-allowed disabled:opacity-45 disabled:hover:bg-transparent';
 
+const actionButtonClassName =
+  'flex h-7 shrink-0 items-center gap-1 rounded-[3px] px-1.5 text-[10px] font-medium text-[#667085] outline-none transition-colors hover:bg-[#f5f5f6] hover:text-[#344054] focus-visible:ring-2 focus-visible:ring-[rgba(254,44,85,.16)] disabled:cursor-not-allowed disabled:opacity-45 disabled:hover:bg-transparent';
+
 interface ToolbarButtonProps {
   title: string;
   onClick: () => void;
@@ -76,14 +79,28 @@ const dataServiceTooltip = (
   state: DevelopmentReleaseDataServiceState | undefined,
   loading?: boolean,
 ) => {
-  if (loading) return '正在读取数据服务状态';
-  if (!state) return '请先发布 SQL 版本，再发布为数据服务';
+  if (loading) return '正在读取 API 发布状态';
+  if (!state) return '请先发布 SQL 版本，再发布为 API';
   if (state.releaseStatus !== 'ONLINE') {
-    return 'SQL 发布任务当前未上线，请先在发布中心上线后再发布数据服务';
+    return 'SQL 发布任务当前未上线，请先在发布中心上线后再发布 API';
   }
-  if (!state.published) return `发布 SQL v${state.releaseRevisionNo} 为数据服务`;
-  if (state.updateAvailable) return `更新数据服务到 SQL v${state.releaseRevisionNo}`;
-  return `数据服务已同步 SQL v${state.releaseRevisionNo}${state.detail?.enabled === false ? ' · 已停用' : ''}`;
+  if (!state.published) return `发布当前 ONLINE SQL v${state.releaseRevisionNo} 为 API`;
+  const apiRevisionNo = state.detail?.sourceRevisionNo;
+  if (state.updateAvailable) {
+    return `线上 API 仍运行 SQL v${apiRevisionNo || '-'}，当前 ONLINE 为 v${state.releaseRevisionNo}；点击更新`;
+  }
+  if (state.detail?.enabled === false) {
+    return `API 已同步 SQL v${apiRevisionNo || state.releaseRevisionNo}，当前已停用`;
+  }
+  return `API 已同步当前 ONLINE SQL v${apiRevisionNo || state.releaseRevisionNo}`;
+};
+
+const dataServiceActionLabel = (state?: DevelopmentReleaseDataServiceState) => {
+  if (!state?.published) return '发布 API';
+  const apiRevisionNo = state.detail?.sourceRevisionNo || state.releaseRevisionNo;
+  if (state.updateAvailable) return `API v${apiRevisionNo} → v${state.releaseRevisionNo}`;
+  if (state.detail?.enabled === false) return `API v${apiRevisionNo} · 停用`;
+  return `API v${apiRevisionNo}`;
 };
 
 const SqlToolbar = ({
@@ -116,7 +133,7 @@ const SqlToolbar = ({
       .catch((error) => {
         if (!active) return;
         setDataServiceContext({});
-        message.error(error instanceof Error ? error.message : '加载数据服务状态失败');
+        message.error(error instanceof Error ? error.message : '加载 API 发布状态失败');
       })
       .finally(() => {
         if (active) setDataServiceLoading(false);
@@ -147,9 +164,11 @@ const SqlToolbar = ({
   const dataServiceReleaseUnavailable = Boolean(
     dataServiceState && dataServiceState.releaseStatus !== 'ONLINE',
   );
-  const dataServiceStateLabel = dataServiceState?.published
-    ? `API${dataServiceState.updateAvailable ? ' · 待更新' : dataServiceState.detail?.enabled === false ? ' · 已停用' : ' · 已同步'}`
-    : undefined;
+  const dataServiceActionRequired = Boolean(
+    dataServiceState
+      && dataServiceState.releaseStatus === 'ONLINE'
+      && (!dataServiceState.published || dataServiceState.updateAvailable),
+  );
 
   const openDataServiceModal = () => {
     if (!release || !dataServiceState || release.status !== 'ONLINE') return;
@@ -159,6 +178,7 @@ const SqlToolbar = ({
   const publishDataService = async (payload: PublishDevelopmentDataServicePayload) => {
     if (!release) return;
     const wasPublished = Boolean(dataServiceState?.published);
+    const previousRevisionNo = dataServiceState?.detail?.sourceRevisionNo;
     setDataServicePublishing(true);
     try {
       const detail = await publishDevelopmentReleaseDataService(release.assetId, payload);
@@ -174,13 +194,15 @@ const SqlToolbar = ({
       });
       setDataServiceModalOpen(false);
       setDataServiceRefreshKey((current) => current + 1);
-      message.success(
-        wasPublished
-          ? `数据服务已更新到 SQL v${release.currentRevisionNo}`
-          : `数据服务已发布 · ${detail.runtimePath}`,
-      );
+      if (!wasPublished) {
+        message.success(`API 已发布 · SQL v${release.currentRevisionNo}`);
+      } else if (previousRevisionNo && previousRevisionNo !== release.currentRevisionNo) {
+        message.success(`API 已更新 · SQL v${previousRevisionNo} → v${release.currentRevisionNo}`);
+      } else {
+        message.success('API 配置已保存');
+      }
     } catch (error) {
-      message.error(error instanceof Error ? error.message : '发布数据服务失败');
+      message.error(error instanceof Error ? error.message : '发布 API 失败');
     } finally {
       setDataServicePublishing(false);
     }
@@ -229,35 +251,31 @@ const SqlToolbar = ({
               {datasetStateLabel}
             </span>
           ) : null}
-          <ToolbarButton
-            title={dataServiceTooltip(dataServiceState, dataServiceLoading)}
-            disabled={!release || !dataServiceState || dataServiceReleaseUnavailable || dataServiceLoading || dataServicePublishing || saving || publishing || running}
-            onClick={openDataServiceModal}
-          >
-            {dataServiceLoading || dataServicePublishing ? (
-              <LoaderCircle size={15} className="animate-spin" />
-            ) : (
-              <Webhook
-                size={15}
-                strokeWidth={1.8}
-                className={dataServiceState?.updateAvailable ? 'text-[var(--yak-brand-color)]' : undefined}
-              />
-            )}
-          </ToolbarButton>
-          {dataServiceStateLabel ? (
-            <span
+          <Tooltip title={dataServiceTooltip(dataServiceState, dataServiceLoading)} mouseEnterDelay={0.35}>
+            <button
+              type="button"
+              aria-label={dataServiceTooltip(dataServiceState, dataServiceLoading)}
+              disabled={!release || !dataServiceState || dataServiceReleaseUnavailable || dataServiceLoading || dataServicePublishing || saving || publishing || running}
+              onClick={openDataServiceModal}
               className={[
-                'mr-1 text-[10px] font-medium',
-                dataServiceState?.updateAvailable
-                  ? 'text-[var(--yak-brand-color)]'
-                  : dataServiceState?.detail?.enabled === false
-                    ? 'text-[#b54708]'
-                    : 'text-[#667085]',
+                actionButtonClassName,
+                dataServiceActionRequired ? 'text-[var(--yak-brand-color)]' : '',
+                dataServiceState?.detail?.enabled === false && !dataServiceState?.updateAvailable
+                  ? 'text-[#b54708]'
+                  : '',
               ].join(' ')}
             >
-              {dataServiceStateLabel}
-            </span>
-          ) : null}
+              {dataServiceLoading || dataServicePublishing ? (
+                <LoaderCircle size={14} className="animate-spin" />
+              ) : (
+                <Webhook size={14} strokeWidth={1.8} />
+              )}
+              <span>{dataServiceLoading ? 'API 状态' : dataServiceActionLabel(dataServiceState)}</span>
+              {dataServiceState?.updateAvailable ? (
+                <span className="ml-0.5 text-[9px] font-medium">待更新</span>
+              ) : null}
+            </button>
+          </Tooltip>
           <ToolbarDivider />
           <ToolbarButton title="撤销" disabled={running} onClick={() => execute('undo', 'SQL 编辑器尚未就绪')}>
             <Undo2 size={15} strokeWidth={1.8} />


### PR DESCRIPTION
## Summary

Complete phase 3 of the Data Development -> Data Service convergence by making API publication a first-class, version-aware action directly in the SQL editor.

This PR deliberately keeps the existing publication/runtime model unchanged. It improves the authoring workflow so users can immediately understand which SQL revision the online API is running and whether an explicit API update is required.

## Product flow

```text
SQL editor
  -> save / publish SQL Revision
  -> API publication state
  -> publish API / update API
  -> stable Data Service Runtime snapshot
```

The SQL editor now answers three things clearly:

1. which SQL revision is currently ONLINE
2. which SQL revision the online API snapshot is using
3. whether the next action is Publish API, Update API, or no update is required

## SQL toolbar

The former icon + detached status text is replaced with a compact, explicit API action.

Examples:

```text
发布 API
API v3
API v3 -> v4   待更新
API v4 · 停用
```

The action is highlighted when user attention is required:

- current ONLINE SQL has never been published as an API
- the API snapshot is behind the current ONLINE SQL revision

Tooltips now explain the actual snapshot relationship, for example:

```text
线上 API 仍运行 SQL v3，当前 ONLINE 为 v4；点击更新
```

After publication/update, success feedback also includes the revision transition:

```text
API 已发布 · SQL v4
API 已更新 · SQL v3 -> v4
API 配置已保存
```

The existing state refresh after SQL publication is preserved, so publishing a new SQL revision immediately updates the API action to the correct synchronized / pending-update state.

## Publish / Update modal

The modal now treats API publication as an explicit revision transition.

It compares:

```text
线上 API 快照        当前 ONLINE SQL
SQL v3        ->      SQL v4
```

and clearly shows one of:

- 未发布
- 待更新
- 已同步
- 已同步 · 已停用

For a pending update the copy is explicit that the API is still running the old snapshot until the user confirms the update. A new SQL revision never silently changes the runtime API.

The primary action is also version-aware:

```text
发布 API · SQL v4
更新 API · v3 -> v4
保存 API 配置
```

## Release semantics

If Data Development already has a newer revision than the currently selected ONLINE revision, the modal calls that out explicitly and explains that API publication only uses the current ONLINE revision.

This keeps the mental model consistent:

```text
Draft / newer revision != online API
ONLINE revision       -> explicit API publish/update -> runtime snapshot
```

## Scope

Frontend only, intentionally limited to two Data Development files:

- `yak-ops-ui/src/pages/data-development/editors/sql/SqlToolbar.tsx`
- `yak-ops-ui/src/pages/data-development/components/workbench/PublishDataServiceModal.tsx`

No changes to:

- Data Service backend publication model
- Runtime / cache / circuit breaker
- API Key / OpenAPI
- Flyway
- Data Service management page
- SQL editor itself

## Compatibility

The existing Data Development publication endpoint is retained. Since phase 1 already delegates that endpoint to the unified `DataServicePublicationService`, this workflow continues to use the single backend source-of-truth and immutable snapshot semantics.

## Validation

- based on merged phase 2 PR #419
- final compare: 2 frontend files, behind 0
- reviewed version-state transitions for first publish, synchronized API, pending update, disabled API and SQL release unavailable states
- verified newer non-ONLINE SQL revisions are not presented as the API publication source
- no SQL authoring/editor duplication introduced

A full local frontend build was not executed from this connector environment. CI/local TypeScript build should be treated as the executable validation source before marking the PR ready.