### PR TITLE
feat(data-service): add API management center

### DIFF
--- a/yak-ops-ui/src/pages/data-service/DataServiceDetailDrawer.tsx
+++ b/yak-ops-ui/src/pages/data-service/DataServiceDetailDrawer.tsx
@@ -1,0 +1,420 @@
+import {
+  Button,
+  Drawer,
+  Empty,
+  Space,
+  Spin,
+  Table,
+  Tabs,
+  Tag,
+  Tooltip,
+  message,
+  type TableColumnsType,
+} from 'antd';
+import {
+  Activity,
+  Braces,
+  Copy,
+  FileText,
+  Gauge,
+  KeyRound,
+  Pencil,
+  RefreshCw,
+  ServerCog,
+} from 'lucide-react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import DataServiceAccessModal from './DataServiceAccessModal';
+import DataServiceDocsModal from './DataServiceDocsModal';
+import DataServiceRuntimeModal from './DataServiceRuntimeModal';
+import {
+  fetchDataServiceDocumentation,
+  fetchDataServiceKeys,
+  fetchDataServiceLogs,
+  fetchDataServiceRuntime,
+  type DataServiceApi,
+  type DataServiceApiKey,
+  type DataServiceCallLog,
+  type DataServiceDocumentation,
+  type DataServiceRuntimeStatus,
+  type DataSourceOption,
+} from './service';
+
+interface DataServiceDetailDrawerProps {
+  open: boolean;
+  service?: DataServiceApi;
+  dataSources: DataSourceOption[];
+  onClose: () => void;
+  onEdit: (service: DataServiceApi) => void;
+  onChanged: () => Promise<void> | void;
+}
+
+const formatTime = (value?: string | null) => value ? value.replace('T', ' ').slice(0, 19) : '-';
+const percent = (value?: number) => `${Math.round((value || 0) * 1000) / 10}%`;
+
+const callerLabel = (record: DataServiceCallLog) => {
+  if (record.callerType === 'CONSOLE') return '控制台测试';
+  if (record.callerType === 'API_KEY') return record.apiKeyName || 'API Key';
+  if (record.callerType === 'PUBLIC') return '公开调用';
+  return '历史调用';
+};
+
+const Metric = ({ label, value }: { label: string; value: string | number }) => (
+  <div className="border-r border-[#edf0f2] px-4 last:border-r-0 first:pl-0">
+    <div className="text-[11px] text-[#98a2b3]">{label}</div>
+    <div className="mt-1 text-[18px] font-semibold text-[#1d2939]">{value}</div>
+  </div>
+);
+
+const SectionTitle = ({ children }: { children: React.ReactNode }) => (
+  <div className="mb-3 text-[12px] font-semibold text-[#344054]">{children}</div>
+);
+
+export default function DataServiceDetailDrawer({
+  open,
+  service,
+  dataSources,
+  onClose,
+  onEdit,
+  onChanged,
+}: DataServiceDetailDrawerProps) {
+  const [activeTab, setActiveTab] = useState('overview');
+  const [loading, setLoading] = useState(false);
+  const [documentation, setDocumentation] = useState<DataServiceDocumentation>();
+  const [runtime, setRuntime] = useState<DataServiceRuntimeStatus>();
+  const [keys, setKeys] = useState<DataServiceApiKey[]>([]);
+  const [logs, setLogs] = useState<DataServiceCallLog[]>([]);
+  const [docsOpen, setDocsOpen] = useState(false);
+  const [accessOpen, setAccessOpen] = useState(false);
+  const [runtimeOpen, setRuntimeOpen] = useState(false);
+
+  const dataSourceName = useMemo(() => {
+    if (!service?.dataSourceId) return '-';
+    return dataSources.find((item) => String(item.value) === String(service.dataSourceId))?.label
+      || `#${service.dataSourceId}`;
+  }, [dataSources, service?.dataSourceId]);
+
+  const serviceLogs = useMemo(
+    () => logs.filter((item) => item.apiId === service?.id).slice(0, 50),
+    [logs, service?.id],
+  );
+
+  const activeKeys = useMemo(
+    () => keys.filter((item) => item.enabled).length,
+    [keys],
+  );
+
+  const loadDetail = useCallback(async () => {
+    if (!service?.id) return;
+    setLoading(true);
+    try {
+      const [docsResponse, runtimeResponse, keyResponse, logResponse] = await Promise.all([
+        fetchDataServiceDocumentation(service.id),
+        fetchDataServiceRuntime(service.id),
+        fetchDataServiceKeys(service.id),
+        fetchDataServiceLogs(),
+      ]);
+      setDocumentation(docsResponse.data);
+      setRuntime(runtimeResponse.data);
+      setKeys(keyResponse.data || []);
+      setLogs(logResponse.data || []);
+    } catch (error: any) {
+      message.error(error?.message || '加载 API 管理信息失败');
+    } finally {
+      setLoading(false);
+    }
+  }, [service?.id]);
+
+  useEffect(() => {
+    if (!open || !service) return;
+    setActiveTab('overview');
+    void loadDetail();
+  }, [loadDetail, open, service]);
+
+  const copy = async (value: string) => {
+    try {
+      await navigator.clipboard.writeText(value);
+      message.success('Endpoint 已复制');
+    } catch {
+      message.warning('复制失败，请手动复制');
+    }
+  };
+
+  if (!service) return null;
+
+  const logColumns: TableColumnsType<DataServiceCallLog> = [
+    {
+      title: '调用方',
+      key: 'caller',
+      width: 150,
+      render: (_, record) => (
+        <div>
+          <div className="text-[#475467]">{callerLabel(record)}</div>
+          {record.apiKeyPrefix ? (
+            <div className="mt-0.5 font-mono text-[10px] text-[#98a2b3]">{record.apiKeyPrefix}••••</div>
+          ) : null}
+        </div>
+      ),
+    },
+    {
+      title: '状态',
+      dataIndex: 'success',
+      width: 76,
+      render: (value: boolean) => value
+        ? <Tag bordered={false}>成功</Tag>
+        : <Tag bordered={false}>失败</Tag>,
+    },
+    { title: '耗时', dataIndex: 'durationMs', width: 88, render: (value) => `${value ?? 0} ms` },
+    { title: '行数', dataIndex: 'rowCount', width: 70 },
+    {
+      title: '错误',
+      dataIndex: 'errorMessage',
+      ellipsis: true,
+      render: (value) => value
+        ? <Tooltip title={value}><span className="text-[#b42318]">{value}</span></Tooltip>
+        : <span className="text-black/20">-</span>,
+    },
+    { title: '时间', dataIndex: 'createTime', width: 150, render: formatTime },
+  ];
+
+  const overview = (
+    <div className="space-y-6">
+      <div>
+        <SectionTitle>接口</SectionTitle>
+        <div className="border border-[#e5e7eb] bg-[#fafafa] px-4 py-3">
+          <div className="flex items-center justify-between gap-3">
+            <div className="min-w-0">
+              <div className="flex items-center gap-2">
+                <Tag bordered={false}>GET</Tag>
+                <span className="truncate font-mono text-[12px] text-[#344054]">{service.runtimePath}</span>
+              </div>
+              {service.description ? (
+                <div className="mt-2 text-[12px] leading-5 text-[#667085]">{service.description}</div>
+              ) : null}
+            </div>
+            <Button size="small" icon={<Copy size={14} />} onClick={() => void copy(service.runtimePath)}>复制</Button>
+          </div>
+        </div>
+      </div>
+
+      <div>
+        <SectionTitle>来源</SectionTitle>
+        <div className="grid grid-cols-2 border border-[#e5e7eb] text-[12px]">
+          <div className="border-b border-r border-[#edf0f2] px-4 py-3">
+            <div className="text-[#98a2b3]">来源类型</div>
+            <div className="mt-1 font-medium text-[#344054]">
+              {service.sourceType === 'DATA_DEVELOPMENT_RELEASE' ? '数据开发 · SQL' : 'Legacy 手工服务'}
+            </div>
+          </div>
+          <div className="border-b border-[#edf0f2] px-4 py-3">
+            <div className="text-[#98a2b3]">来源版本</div>
+            <div className="mt-1 font-medium text-[#344054]">
+              {service.sourceType ? `SQL v${service.sourceRevisionNo || '-'}` : '-'}
+            </div>
+          </div>
+          <div className="border-r border-[#edf0f2] px-4 py-3">
+            <div className="text-[#98a2b3]">数据源</div>
+            <div className="mt-1 font-medium text-[#344054]">{dataSourceName}</div>
+          </div>
+          <div className="px-4 py-3">
+            <div className="text-[#98a2b3]">Source / Revision</div>
+            <div className="mt-1 font-mono text-[11px] text-[#475467]">
+              {service.sourceType ? `#${service.sourceRef || '-'} / #${service.sourceRevisionId || '-'}` : '-'}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div>
+        <SectionTitle>服务配置</SectionTitle>
+        <div className="grid grid-cols-4 border-y border-[#edf0f2] py-3">
+          <Metric label="最大返回" value={`${service.maxRows} 行`} />
+          <Metric label="超时" value={`${service.timeoutSeconds}s`} />
+          <Metric label="请求参数" value={service.parameterNames?.length || 0} />
+          <Metric label="访问模式" value={service.authMode === 'API_KEY' ? 'API Key' : 'Public'} />
+        </div>
+      </div>
+
+      <div className="flex items-center justify-between border-t border-[#edf0f2] pt-4 text-[12px] text-[#667085]">
+        <div>创建 {formatTime(service.createTime)} · 更新 {formatTime(service.updateTime)}</div>
+        <Button icon={<Pencil size={14} />} onClick={() => onEdit(service)}>编辑服务配置</Button>
+      </div>
+    </div>
+  );
+
+  const docs = (
+    <div className="space-y-5">
+      <div className="flex items-center justify-between">
+        <div>
+          <div className="text-[13px] font-medium text-[#344054]">API 文档与在线调试</div>
+          <div className="mt-1 text-[12px] text-[#667085]">维护请求参数、响应 Schema、OpenAPI，并使用真实数据源调试。</div>
+        </div>
+        <Button icon={<FileText size={14} />} onClick={() => setDocsOpen(true)}>打开文档</Button>
+      </div>
+      <div className="grid grid-cols-3 border-y border-[#edf0f2] py-3">
+        <Metric label="文档状态" value={documentation?.documented ? '已维护' : '未维护'} />
+        <Metric label="请求参数" value={documentation?.parameters?.length || service.parameterNames?.length || 0} />
+        <Metric label="响应字段" value={documentation?.responseFields?.length || 0} />
+      </div>
+      {documentation?.schemaStale ? (
+        <div className="border border-[#fecdca] bg-[#fffbfa] px-3 py-2.5 text-[12px] leading-5 text-[#b42318]">
+          SQL 已发生变化，当前响应 Schema 已过期。请重新在线调试并保存文档后再对外使用最新契约。
+        </div>
+      ) : null}
+      <div className="border border-[#e5e7eb] px-4 py-3 text-[12px] leading-5 text-[#667085]">
+        <div className="flex items-center gap-2 font-medium text-[#344054]"><Braces size={14} /> 参数</div>
+        <div className="mt-2">
+          {service.parameterNames?.length
+            ? service.parameterNames.map((name) => `:${name}`).join(' · ')
+            : '当前 SQL 无请求参数'}
+        </div>
+      </div>
+    </div>
+  );
+
+  const access = (
+    <div className="space-y-5">
+      <div className="flex items-center justify-between">
+        <div>
+          <div className="text-[13px] font-medium text-[#344054]">访问控制</div>
+          <div className="mt-1 text-[12px] text-[#667085]">控制外部调用身份、API Key 生命周期与每分钟限流。</div>
+        </div>
+        <Button icon={<KeyRound size={14} />} onClick={() => setAccessOpen(true)}>管理访问</Button>
+      </div>
+      <div className="grid grid-cols-3 border-y border-[#edf0f2] py-3">
+        <Metric label="当前模式" value={service.authMode === 'API_KEY' ? 'API Key' : 'Public'} />
+        <Metric label="API Keys" value={keys.length} />
+        <Metric label="启用 Key" value={activeKeys} />
+      </div>
+      <div className="border border-[#e5e7eb] bg-[#fafafa] px-4 py-3 text-[12px] leading-5 text-[#667085]">
+        {service.authMode === 'API_KEY'
+          ? '外部调用必须携带 X-API-Key。每个 Key 可以独立配置调用方名称、过期时间和每分钟限流。'
+          : '当前接口允许公开调用。生产或跨系统调用建议切换到 API Key 模式。'}
+      </div>
+    </div>
+  );
+
+  const runtimeTab = (
+    <div className="space-y-5">
+      <div className="flex items-center justify-between">
+        <div>
+          <div className="text-[13px] font-medium text-[#344054]">Runtime</div>
+          <div className="mt-1 text-[12px] text-[#667085]">查看运行指标，并管理缓存与熔断策略。</div>
+        </div>
+        <Space size={6}>
+          <Button icon={<RefreshCw size={14} />} onClick={() => void loadDetail()}>刷新</Button>
+          <Button icon={<Gauge size={14} />} onClick={() => setRuntimeOpen(true)}>Runtime 配置</Button>
+        </Space>
+      </div>
+      <div className="grid grid-cols-4 border-y border-[#edf0f2] py-3">
+        <Metric label="调用总数" value={runtime?.totalCalls || 0} />
+        <Metric label="成功率" value={percent(runtime?.successRate)} />
+        <Metric label="平均耗时" value={`${runtime?.averageDurationMs || 0} ms`} />
+        <Metric label="P95" value={`${runtime?.p95DurationMs || 0} ms`} />
+      </div>
+      <div className="grid grid-cols-2 gap-3">
+        <div className="border border-[#e5e7eb] px-4 py-3">
+          <div className="flex items-center gap-2 text-[12px] font-medium text-[#344054]"><Activity size={14} /> 结果缓存</div>
+          <div className="mt-3 text-[12px] leading-6 text-[#667085]">
+            <div>状态：{runtime?.cacheEnabled ? '启用' : '关闭'}</div>
+            <div>命中率：{percent(runtime?.cacheHitRate)}</div>
+            <div>当前条目：{runtime?.cacheEntries || 0}</div>
+          </div>
+        </div>
+        <div className="border border-[#e5e7eb] px-4 py-3">
+          <div className="flex items-center gap-2 text-[12px] font-medium text-[#344054]"><ServerCog size={14} /> 熔断器</div>
+          <div className="mt-3 text-[12px] leading-6 text-[#667085]">
+            <div>状态：{runtime?.circuitState || 'DISABLED'}</div>
+            <div>拒绝次数：{runtime?.circuitRejected || 0}</div>
+            <div>最近失败：{formatTime(runtime?.lastFailureAt)}</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+
+  const logTab = (
+    <div>
+      <div className="mb-3 flex items-center justify-between">
+        <div>
+          <div className="text-[13px] font-medium text-[#344054]">最近调用</div>
+          <div className="mt-1 text-[12px] text-[#667085]">展示最近 200 条全局审计记录中属于当前 API 的最多 50 条。</div>
+        </div>
+        <Button icon={<RefreshCw size={14} />} onClick={() => void loadDetail()}>刷新</Button>
+      </div>
+      {serviceLogs.length ? (
+        <Table<DataServiceCallLog>
+          rowKey="id"
+          size="small"
+          columns={logColumns}
+          dataSource={serviceLogs}
+          pagination={false}
+          scroll={{ x: 720, y: 430 }}
+        />
+      ) : <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="暂无调用记录" />}
+    </div>
+  );
+
+  return (
+    <>
+      <Drawer
+        open={open}
+        onClose={onClose}
+        width={900}
+        destroyOnHidden
+        title={(
+          <div className="min-w-0">
+            <div className="flex items-center gap-2">
+              <span className="truncate text-[15px] font-semibold text-[#161823]">{service.name}</span>
+              <Tag bordered={false}>GET</Tag>
+              <Tag bordered={false}>{service.enabled ? '运行中' : '已停用'}</Tag>
+            </div>
+            <div className="mt-1 truncate font-mono text-[11px] font-normal text-[#98a2b3]">{service.runtimePath}</div>
+          </div>
+        )}
+        extra={<Button size="small" icon={<Pencil size={13} />} onClick={() => onEdit(service)}>编辑</Button>}
+      >
+        <Spin spinning={loading}>
+          <Tabs
+            activeKey={activeTab}
+            onChange={setActiveTab}
+            items={[
+              { key: 'overview', label: '概览', children: overview },
+              { key: 'docs', label: '文档', children: docs },
+              { key: 'access', label: '访问控制', children: access },
+              { key: 'runtime', label: 'Runtime', children: runtimeTab },
+              { key: 'logs', label: '调用记录', children: logTab },
+            ]}
+          />
+        </Spin>
+      </Drawer>
+
+      <DataServiceDocsModal
+        open={docsOpen}
+        service={service}
+        onCancel={() => {
+          setDocsOpen(false);
+          void loadDetail();
+        }}
+      />
+
+      <DataServiceAccessModal
+        open={accessOpen}
+        service={service}
+        onCancel={() => setAccessOpen(false)}
+        onChanged={async () => {
+          await onChanged();
+          await loadDetail();
+        }}
+      />
+
+      <DataServiceRuntimeModal
+        open={runtimeOpen}
+        service={service}
+        onCancel={() => {
+          setRuntimeOpen(false);
+          void loadDetail();
+        }}
+      />
+    </>
+  );
+}

--- a/yak-ops-ui/src/pages/data-service/index.tsx
+++ b/yak-ops-ui/src/pages/data-service/index.tsx
@@ -1,10 +1,10 @@
 import {
   Button,
+  Dropdown,
   Form,
   Input,
   InputNumber,
   Modal,
-  Popconfirm,
   Select,
   Space,
   Switch,
@@ -14,12 +14,20 @@ import {
   message,
   type TableColumnsType,
 } from 'antd';
-import { Activity, Copy, FileText, Pencil, Plus, RefreshCw, Search, ShieldCheck, Trash2 } from 'lucide-react';
+import {
+  Copy,
+  Eye,
+  MoreHorizontal,
+  Pencil,
+  Plus,
+  Power,
+  RefreshCw,
+  Search,
+  Trash2,
+} from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import CreateDataServiceModal from './CreateDataServiceModal';
-import DataServiceAccessModal from './DataServiceAccessModal';
-import DataServiceDocsModal from './DataServiceDocsModal';
-import DataServiceRuntimeModal from './DataServiceRuntimeModal';
+import DataServiceDetailDrawer from './DataServiceDetailDrawer';
 import {
   deleteDataService,
   fetchDataServices,
@@ -39,12 +47,10 @@ export default function DataServicePage() {
   const [loading, setLoading] = useState(false);
   const [keyword, setKeyword] = useState('');
   const [createOpen, setCreateOpen] = useState(false);
+  const [detailTarget, setDetailTarget] = useState<DataServiceApi>();
   const [editing, setEditing] = useState<DataServiceApi>();
   const [editorOpen, setEditorOpen] = useState(false);
   const [saving, setSaving] = useState(false);
-  const [docsTarget, setDocsTarget] = useState<DataServiceApi>();
-  const [accessTarget, setAccessTarget] = useState<DataServiceApi>();
-  const [runtimeTarget, setRuntimeTarget] = useState<DataServiceApi>();
   const [form] = Form.useForm<DataServiceSavePayload>();
   const sourceManaged = Boolean(editing?.sourceType);
 
@@ -58,12 +64,9 @@ export default function DataServicePage() {
       const nextServices = serviceResponse.data || [];
       setServices(nextServices);
       setDataSources(dataSourceResponse.data || []);
-      const refreshTarget = (current?: DataServiceApi) => current
-        ? nextServices.find((item) => item.id === current.id) || current
-        : undefined;
-      setDocsTarget(refreshTarget);
-      setAccessTarget(refreshTarget);
-      setRuntimeTarget(refreshTarget);
+      setDetailTarget((current) => current
+        ? nextServices.find((item) => item.id === current.id)
+        : undefined);
     } catch (error: any) {
       message.error(error?.message || '加载数据服务失败');
     } finally {
@@ -77,7 +80,7 @@ export default function DataServicePage() {
     const value = keyword.trim().toLowerCase();
     if (!value) return services;
     return services.filter((item) =>
-      [item.name, item.path, item.runtimePath, item.description]
+      [item.name, item.path, item.runtimePath, item.description, item.sourceRef]
         .filter(Boolean)
         .some((text) => String(text).toLowerCase().includes(value)));
   }, [keyword, services]);
@@ -125,9 +128,10 @@ export default function DataServicePage() {
     }
   };
 
-  const remove = async (id: number) => {
+  const remove = async (record: DataServiceApi) => {
     try {
-      await deleteDataService(id);
+      await deleteDataService(record.id);
+      if (detailTarget?.id === record.id) setDetailTarget(undefined);
       message.success('已删除');
       await load();
     } catch (error: any) {
@@ -135,12 +139,23 @@ export default function DataServicePage() {
     }
   };
 
-  const toggleEnabled = async (record: DataServiceApi, enabled: boolean) => {
+  const confirmRemove = (record: DataServiceApi) => {
+    Modal.confirm({
+      title: '删除 API 服务',
+      content: `确认删除「${record.name}」？API Key、Runtime 状态和相关文档也会随服务一起移除。`,
+      okText: '删除',
+      okButtonProps: { danger: true },
+      cancelText: '取消',
+      onOk: () => remove(record),
+    });
+  };
+
+  const toggleEnabled = async (record: DataServiceApi) => {
+    const enabled = !record.enabled;
     try {
       await setDataServiceEnabled(record.id, enabled);
-      setServices((items) => items.map((item) =>
-        item.id === record.id ? { ...item, enabled } : item));
       message.success(enabled ? '服务已启用' : '服务已停用');
+      await load();
     } catch (error: any) {
       message.error(error?.message || '状态更新失败');
     }
@@ -159,92 +174,107 @@ export default function DataServicePage() {
     {
       title: 'API 服务',
       dataIndex: 'name',
-      minWidth: 280,
+      minWidth: 240,
       render: (_, record) => (
-        <div className="py-1">
+        <div className="py-1.5">
           <div className="flex items-center gap-2">
             <span className="font-medium text-[#161823]">{record.name}</span>
             <Tag bordered={false}>GET</Tag>
-            {record.sourceType === 'DATA_DEVELOPMENT_RELEASE' ? (
-              <Tag bordered={false}>数据开发 v{record.sourceRevisionNo || '-'}</Tag>
-            ) : (
-              <Tag bordered={false}>Legacy</Tag>
-            )}
           </div>
-          <div className="mt-1 flex items-center gap-1 text-xs text-black/45">
-            <span className="font-mono">{record.runtimePath}</span>
-            <Tooltip title="复制调用路径">
-              <Button type="text" size="small" icon={<Copy size={13} />} onClick={() => void copyPath(record.runtimePath)} />
-            </Tooltip>
+          <div className="mt-1 line-clamp-1 text-xs text-black/40">
+            {record.description || '暂无说明'}
           </div>
         </div>
       ),
     },
     {
-      title: '数据源',
-      dataIndex: 'dataSourceId',
-      width: 190,
-      render: (value) => dataSourceName(value),
+      title: 'Endpoint',
+      dataIndex: 'runtimePath',
+      minWidth: 290,
+      render: (value: string) => (
+        <div className="flex items-center gap-1">
+          <span className="truncate font-mono text-xs text-black/55">{value}</span>
+          <Tooltip title="复制 Endpoint">
+            <Button type="text" size="small" icon={<Copy size={13} />} onClick={() => void copyPath(value)} />
+          </Tooltip>
+        </div>
+      ),
     },
     {
-      title: '参数',
-      dataIndex: 'parameterNames',
-      width: 180,
-      render: (values: string[]) => values?.length
-        ? <span className="text-black/65">{values.map((item) => `:${item}`).join(' · ')}</span>
-        : <span className="text-black/35">无参数</span>,
+      title: '来源',
+      key: 'source',
+      width: 190,
+      render: (_, record) => record.sourceType === 'DATA_DEVELOPMENT_RELEASE' ? (
+        <div>
+          <div className="font-medium text-[#475467]">数据开发 · SQL v{record.sourceRevisionNo || '-'}</div>
+          <div className="mt-1 text-[11px] text-black/35">{dataSourceName(record.dataSourceId)} · Source #{record.sourceRef}</div>
+        </div>
+      ) : (
+        <div>
+          <Tag bordered={false}>Legacy</Tag>
+          <div className="mt-1 text-[11px] text-black/35">{dataSourceName(record.dataSourceId)}</div>
+        </div>
+      ),
     },
     {
       title: '访问控制',
       dataIndex: 'authMode',
-      width: 120,
+      width: 110,
       render: (value) => value === 'API_KEY'
-        ? <Tag bordered={false}>API Key</Tag>
-        : <span className="text-black/40">公开</span>,
-    },
-    {
-      title: '运行限制',
-      width: 150,
-      render: (_, record) => (
-        <span className="text-black/55">{record.maxRows} 行 · {record.timeoutSeconds}s</span>
-      ),
-    },
-    {
-      title: '更新时间',
-      dataIndex: 'updateTime',
-      width: 170,
-      render: formatTime,
+        ? <span className="text-black/65">API Key</span>
+        : <span className="text-black/40">Public</span>,
     },
     {
       title: '状态',
       dataIndex: 'enabled',
       width: 90,
-      render: (_, record) => (
-        <Switch size="small" checked={record.enabled} onChange={(checked) => void toggleEnabled(record, checked)} />
-      ),
+      render: (value: boolean) => value
+        ? <Tag bordered={false}>运行中</Tag>
+        : <Tag bordered={false}>已停用</Tag>,
+    },
+    {
+      title: '更新时间',
+      dataIndex: 'updateTime',
+      width: 160,
+      render: formatTime,
     },
     {
       title: '操作',
       key: 'actions',
-      width: 220,
+      width: 140,
       fixed: 'right',
       render: (_, record) => (
-        <Space size={2}>
-          <Tooltip title="API 文档 / 在线调试">
-            <Button type="text" size="small" icon={<FileText size={15} />} onClick={() => setDocsTarget(record)} />
-          </Tooltip>
-          <Tooltip title="Runtime">
-            <Button type="text" size="small" icon={<Activity size={15} />} onClick={() => setRuntimeTarget(record)} />
-          </Tooltip>
-          <Tooltip title="访问控制">
-            <Button type="text" size="small" icon={<ShieldCheck size={15} />} onClick={() => setAccessTarget(record)} />
-          </Tooltip>
-          <Tooltip title="编辑">
-            <Button type="text" size="small" icon={<Pencil size={15} />} onClick={() => openEdit(record)} />
-          </Tooltip>
-          <Popconfirm title="确认删除这个数据服务？" onConfirm={() => void remove(record.id)}>
-            <Tooltip title="删除"><Button type="text" size="small" danger icon={<Trash2 size={15} />} /></Tooltip>
-          </Popconfirm>
+        <Space size={4}>
+          <Button
+            type="link"
+            size="small"
+            icon={<Eye size={14} />}
+            onClick={() => setDetailTarget(record)}
+          >
+            查看
+          </Button>
+          <Dropdown
+            trigger={['click']}
+            menu={{
+              items: [
+                { key: 'edit', icon: <Pencil size={14} />, label: '编辑服务配置' },
+                {
+                  key: 'toggle',
+                  icon: <Power size={14} />,
+                  label: record.enabled ? '停用服务' : '启用服务',
+                },
+                { type: 'divider' },
+                { key: 'delete', danger: true, icon: <Trash2 size={14} />, label: '删除服务' },
+              ],
+              onClick: ({ key }) => {
+                if (key === 'edit') openEdit(record);
+                if (key === 'toggle') void toggleEnabled(record);
+                if (key === 'delete') confirmRemove(record);
+              },
+            }}
+          >
+            <Button type="text" size="small" icon={<MoreHorizontal size={16} />} />
+          </Dropdown>
         </Space>
       ),
     },
@@ -255,7 +285,7 @@ export default function DataServicePage() {
       <div className="mb-5 flex items-start justify-between gap-4">
         <div>
           <h1 className="m-0 text-xl font-semibold text-[#161823]">API 服务</h1>
-          <p className="mb-0 mt-1 text-sm text-black/45">将数据开发中已发布的 SQL 转换为可调用、可鉴权、可缓存、可熔断、可文档化的 GET REST API。</p>
+          <p className="mb-0 mt-1 text-sm text-black/45">管理由数据开发发布的 API Endpoint、访问控制、运行状态、文档和调用审计。</p>
         </div>
         <Button type="primary" icon={<Plus size={16} />} onClick={() => setCreateOpen(true)}>新建 API</Button>
       </div>
@@ -266,8 +296,8 @@ export default function DataServicePage() {
           value={keyword}
           onChange={(event) => setKeyword(event.target.value)}
           prefix={<Search size={15} className="text-black/30" />}
-          placeholder="搜索名称或路径"
-          className="max-w-[320px]"
+          placeholder="搜索 API、Endpoint 或来源"
+          className="max-w-[340px]"
         />
         <Button icon={<RefreshCw size={15} />} onClick={() => void load()}>刷新</Button>
       </div>
@@ -279,7 +309,7 @@ export default function DataServicePage() {
         dataSource={filtered}
         columns={columns}
         pagination={false}
-        scroll={{ x: 1360 }}
+        scroll={{ x: 1220 }}
       />
 
       <CreateDataServiceModal
@@ -289,23 +319,13 @@ export default function DataServicePage() {
         onCreated={load}
       />
 
-      <DataServiceDocsModal
-        open={Boolean(docsTarget)}
-        service={docsTarget}
-        onCancel={() => setDocsTarget(undefined)}
-      />
-
-      <DataServiceAccessModal
-        open={Boolean(accessTarget)}
-        service={accessTarget}
-        onCancel={() => setAccessTarget(undefined)}
+      <DataServiceDetailDrawer
+        open={Boolean(detailTarget)}
+        service={detailTarget}
+        dataSources={dataSources}
+        onClose={() => setDetailTarget(undefined)}
+        onEdit={openEdit}
         onChanged={load}
-      />
-
-      <DataServiceRuntimeModal
-        open={Boolean(runtimeTarget)}
-        service={runtimeTarget}
-        onCancel={() => setRuntimeTarget(undefined)}
       />
 
       <Modal


### PR DESCRIPTION
## Summary

Complete phase 4 of the Data Development -> Data Service convergence by turning the Data Service list into a lightweight API catalog and moving detailed operational capabilities into one focused API management center.

The page is no longer a row of independent action icons. The new interaction is:

```text
API service list
  -> View
  -> API management drawer
     - Overview
     - Documentation
     - Access control
     - Runtime
     - Call logs
```

## API service list

The list is simplified to the information needed to identify and operate a service:

- API name / method
- Runtime endpoint
- published source revision
- datasource
- access mode
- enabled state
- update time

The former per-row action cluster for Docs / Runtime / Access / Edit / Delete is replaced with:

```text
View   ...
```

`View` opens the management center. The overflow menu keeps only service-level operations:

- edit service-facing settings
- enable / disable
- delete

This keeps the list readable and makes it behave like an API service catalog instead of a toolbar collection.

## API management drawer

Adds `DataServiceDetailDrawer.tsx`, a right-side management workspace with five tabs.

### Overview

Shows the stable runtime identity and source provenance in one place:

- GET Runtime Endpoint with copy action
- description
- source type
- SQL source revision
- datasource
- sourceRef / sourceRevisionId
- max rows
- timeout
- request parameter count
- access mode
- create/update time

Source-backed APIs remain read-only with respect to SQL/datasource. The existing edit flow continues to manage only service-facing settings.

### Documentation

Provides a compact documentation status summary:

- documented / undocumented
- request parameter count
- response field count
- schema stale warning
- current SQL parameter names

The existing API Documentation / online-debugging modal is reused for full editing and testing. No documentation logic is duplicated.

### Access control

Summarizes:

- Public vs API Key mode
- total API Keys
- enabled API Keys

The existing Access Control modal is reused for auth-mode changes, key creation/rotation, expiration and rate limiting.

### Runtime

Shows the most important process-local metrics directly in the management center:

- total calls
- success rate
- average latency
- P95
- cache enabled / hit rate / entries
- circuit state / rejected calls / last failure

The existing Runtime modal remains the editing surface for cache and circuit-breaker policy.

### Call logs

Reuses the existing recent-call audit API. The drawer filters the global recent 200 records by `apiId` and shows up to 50 calls for the selected service with:

- caller identity
- status
- latency
- row count
- error
- call time

The standalone global Call Logs page remains available for cross-service operations views.

## Reuse instead of duplication

This phase deliberately does not rewrite existing Data Service capabilities. It composes the current components and APIs:

- `DataServiceDocsModal`
- `DataServiceAccessModal`
- `DataServiceRuntimeModal`
- documentation API
- API Key API
- Runtime status API
- recent call log API

The management drawer is an information architecture layer over the capabilities already built in earlier phases.

## Compatibility

- no backend changes
- no Flyway changes
- no Runtime behavior changes
- no API Key behavior changes
- no OpenAPI behavior changes
- no Data Development changes
- Legacy manual services remain editable with the existing compatibility SQL/datasource fields
- the global Call Logs page is retained

## Files

This PR is intentionally frontend-only and scoped to two files:

- `yak-ops-ui/src/pages/data-service/DataServiceDetailDrawer.tsx` (new)
- `yak-ops-ui/src/pages/data-service/index.tsx`

## Validation

- based on merged phase 3 PR #420
- final compare: 2 frontend files, behind 0
- verified Runtime percentage formatting matches the existing Runtime modal semantics
- verified Access modal already loads API Keys for both Public and API Key modes
- verified detail call logs use existing `apiId` audit identity and do not alter the backend endpoint
- verified source-managed edit behavior still preserves the immutable SQL/datasource snapshot
- verified delete / enable / disable remain explicit service operations outside specialized management tabs

A full local frontend build was not executed from this connector environment. CI/local TypeScript build should be treated as the executable validation source before marking the PR ready.