### PR TITLE
refactor(data-service): enforce source-owned runtime definitions

### DIFF
--- a/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/controller/v1/DataServiceController.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/controller/v1/DataServiceController.java
@@ -86,16 +86,30 @@ public class DataServiceController {
     return Result.success(dataServiceService.get(id));
   }
 
-  @Operation(summary = "创建 API 服务（兼容旧版手工模式）")
-  @PostMapping
-  public Result<ApiView> create(@RequestBody ApiInput input) {
-    return Result.success(dataServiceService.save(null, input));
-  }
-
-  @Operation(summary = "更新 API 服务")
+  /**
+   * Updates only service-facing settings.
+   *
+   * <p>SQL and datasource identity are server-owned Runtime snapshot fields. They are deliberately
+   * absent from the public update contract and can only change through source publication/republish.
+   * This also freezes execution logic for historical Legacy services while keeping them runnable.
+   */
+  @Operation(summary = "更新 API 服务侧配置")
   @PutMapping("/{id}")
-  public Result<ApiView> update(@PathVariable("id") Long id, @RequestBody ApiInput input) {
-    return Result.success(dataServiceService.save(id, input));
+  public Result<ApiView> update(
+      @PathVariable("id") Long id,
+      @RequestBody UpdateDataServiceRequest input) {
+    ApiView current = dataServiceService.get(id);
+    return Result.success(dataServiceService.save(
+        id,
+        new ApiInput(
+            input.name(),
+            input.path(),
+            current.dataSourceId(),
+            current.sql(),
+            input.maxRows(),
+            input.timeoutSeconds(),
+            input.enabled(),
+            input.description())));
   }
 
   @Operation(summary = "按当前上游 Revision 重新发布数据服务")
@@ -250,6 +264,14 @@ public class DataServiceController {
   public record PublishDataServiceRequest(
       String sourceType,
       String sourceRef,
+      String name,
+      String path,
+      Integer maxRows,
+      Integer timeoutSeconds,
+      Boolean enabled,
+      String description) {}
+
+  public record UpdateDataServiceRequest(
       String name,
       String path,
       Integer maxRows,

--- a/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/controller/v1/DataServiceController.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/controller/v1/DataServiceController.java
@@ -17,10 +17,10 @@ import io.yak.ops.business.dataservice.service.DataServicePublicationService.Pub
 import io.yak.ops.business.dataservice.service.DataServicePublicationService.PublishRequest;
 import io.yak.ops.business.dataservice.service.DataServiceRuntimeService.RuntimeSnapshot;
 import io.yak.ops.business.dataservice.service.DataServiceService;
-import io.yak.ops.business.dataservice.service.DataServiceService.ApiInput;
 import io.yak.ops.business.dataservice.service.DataServiceService.ApiView;
 import io.yak.ops.business.dataservice.service.DataServiceService.QueryResponse;
 import io.yak.ops.business.dataservice.service.DataServiceService.RuntimeConfigInput;
+import io.yak.ops.business.dataservice.service.DataServiceService.ServiceSettingsInput;
 import io.yak.ops.business.dataservice.service.source.DataServiceSourceProvider.SourcePage;
 import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
 import java.util.List;
@@ -86,26 +86,16 @@ public class DataServiceController {
     return Result.success(dataServiceService.get(id));
   }
 
-  /**
-   * Updates only service-facing settings.
-   *
-   * <p>SQL and datasource identity are server-owned Runtime snapshot fields. They are deliberately
-   * absent from the public update contract and can only change through source publication/republish.
-   * This also freezes execution logic for historical Legacy services while keeping them runnable.
-   */
   @Operation(summary = "更新 API 服务侧配置")
   @PutMapping("/{id}")
   public Result<ApiView> update(
       @PathVariable("id") Long id,
       @RequestBody UpdateDataServiceRequest input) {
-    ApiView current = dataServiceService.get(id);
-    return Result.success(dataServiceService.save(
+    return Result.success(dataServiceService.updateSettings(
         id,
-        new ApiInput(
+        new ServiceSettingsInput(
             input.name(),
             input.path(),
-            current.dataSourceId(),
-            current.sql(),
             input.maxRows(),
             input.timeoutSeconds(),
             input.enabled(),

--- a/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/service/DataServicePublicationService.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/service/DataServicePublicationService.java
@@ -1,7 +1,8 @@
 package io.yak.ops.business.dataservice.service;
 
-import io.yak.ops.business.dataservice.service.DataServiceService.ApiInput;
 import io.yak.ops.business.dataservice.service.DataServiceService.ApiView;
+import io.yak.ops.business.dataservice.service.DataServiceService.RuntimeDefinition;
+import io.yak.ops.business.dataservice.service.DataServiceService.ServiceSettingsInput;
 import io.yak.ops.business.dataservice.service.DataServiceService.SourceSnapshot;
 import io.yak.ops.business.dataservice.service.source.DataServiceSourceProvider;
 import io.yak.ops.business.dataservice.service.source.DataServiceSourceProvider.ResolvedSource;
@@ -102,11 +103,10 @@ public class DataServicePublicationService {
             identity.sourceRef(),
             source.sourceRevisionId(),
             source.sourceRevisionNo()),
-        new ApiInput(
+        new RuntimeDefinition(source.dataSourceId(), resolved.sql()),
+        new ServiceSettingsInput(
             name,
             path,
-            source.dataSourceId(),
-            resolved.sql(),
             maxRows,
             timeoutSeconds,
             enabled,

--- a/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/service/DataServiceService.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/service/DataServiceService.java
@@ -20,7 +20,6 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -73,31 +72,58 @@ public class DataServiceService {
     return Optional.ofNullable(api).map(this::toView);
   }
 
+  /** Updates only service-facing settings; executable SQL and datasource are never accepted here. */
   @Transactional
-  public ApiView save(Long id, ApiInput input) {
-    return saveInternal(id, input, false);
+  public ApiView updateSettings(Long id, ServiceSettingsInput input) {
+    DataServiceApiPO api = requireApi(id);
+    ServiceSettingsInput normalized = normalizeSettings(input, api);
+    ensurePathAvailable(id, normalized.path());
+    applySettings(api, normalized);
+    api.setUpdateTime(LocalDateTime.now());
+    apiMapper.updateById(api);
+    runtimeService.invalidate(api.getId());
+    return toView(api);
   }
 
   /**
-   * Creates or updates the stable Data Service bound to one upstream asset.
+   * Creates or refreshes the stable Data Service bound to one upstream asset.
    *
-   * <p>The executable SQL/dataSource values are copied into the service definition, so runtime calls
-   * remain a snapshot and never follow mutable authoring state implicitly. Access-control and Runtime
-   * policies are intentionally preserved across source refreshes.
+   * <p>This is the only write path that accepts executable SQL and datasource identity. Those values
+   * are copied from a server-resolved immutable source release and become the Runtime snapshot. Access
+   * control and Runtime policies are intentionally preserved across source refreshes.
    */
   @Transactional
-  public ApiView saveFromSource(SourceSnapshot source, ApiInput input) {
-    SourceSnapshot normalized = normalizeSource(source);
-    Optional<ApiView> existing = findBySource(normalized.sourceType(), normalized.sourceRef());
-    ApiView saved = saveInternal(existing.map(ApiView::id).orElse(null), input, true);
+  public ApiView saveFromSource(
+      SourceSnapshot source,
+      RuntimeDefinition runtimeDefinition,
+      ServiceSettingsInput settings) {
+    SourceSnapshot normalizedSource = normalizeSource(source);
+    RuntimeDefinition normalizedRuntime = normalizeRuntimeDefinition(runtimeDefinition);
+    Optional<ApiView> existing = findBySource(
+        normalizedSource.sourceType(), normalizedSource.sourceRef());
+    Long id = existing.map(ApiView::id).orElse(null);
+    boolean creating = id == null;
+    DataServiceApiPO api = creating ? new DataServiceApiPO() : requireApi(id);
+    ServiceSettingsInput normalizedSettings = normalizeSettings(settings, creating ? null : api);
+    ensurePathAvailable(id, normalizedSettings.path());
 
-    DataServiceApiPO api = requireApi(saved.id());
-    api.setSourceType(normalized.sourceType());
-    api.setSourceRef(normalized.sourceRef());
-    api.setSourceRevisionId(normalized.sourceRevisionId());
-    api.setSourceRevisionNo(normalized.sourceRevisionNo());
+    applySettings(api, normalizedSettings);
+    api.setDataSourceId(normalizedRuntime.dataSourceId());
+    api.setSqlText(normalizedRuntime.sql());
+    if (!StringUtils.hasText(api.getAuthMode())) api.setAuthMode("NONE");
+    initializeRuntimeDefaults(api, creating);
+    api.setSourceType(normalizedSource.sourceType());
+    api.setSourceRef(normalizedSource.sourceRef());
+    api.setSourceRevisionId(normalizedSource.sourceRevisionId());
+    api.setSourceRevisionNo(normalizedSource.sourceRevisionNo());
     api.setUpdateTime(LocalDateTime.now());
-    apiMapper.updateById(api);
+
+    if (creating) {
+      api.setCreateTime(api.getUpdateTime());
+      apiMapper.insert(api);
+    } else {
+      apiMapper.updateById(api);
+    }
     runtimeService.invalidate(api.getId());
     return toView(api);
   }
@@ -193,9 +219,7 @@ public class DataServiceService {
             .last("LIMIT 200"));
   }
 
-  private ApiView saveInternal(Long id, ApiInput input, boolean sourceRefresh) {
-    validateInput(input);
-    String path = normalizePath(input.path());
+  private void ensurePathAvailable(Long id, String path) {
     Long duplicateCount = apiMapper.selectCount(
         Wrappers.<DataServiceApiPO>lambdaQuery()
             .eq(DataServiceApiPO::getPath, path)
@@ -203,38 +227,49 @@ public class DataServiceService {
     if (duplicateCount != null && duplicateCount > 0) {
       throw new IllegalArgumentException("服务路径已存在：" + path);
     }
+  }
 
-    LocalDateTime now = LocalDateTime.now();
-    boolean creating = id == null;
-    DataServiceApiPO api = creating ? new DataServiceApiPO() : requireApi(id);
-    if (!sourceRefresh && StringUtils.hasText(api.getSourceType())) {
-      String sql = input.sql().trim();
-      if (!Objects.equals(api.getDataSourceId(), input.dataSourceId())
-          || !Objects.equals(api.getSqlText(), sql)) {
-        throw new IllegalArgumentException(
-            "来源数据服务的 SQL 和数据源由发布来源管理，请从来源版本重新发布");
-      }
-    }
+  private void applySettings(DataServiceApiPO api, ServiceSettingsInput input) {
+    api.setName(input.name());
+    api.setPath(input.path());
+    api.setMaxRows(input.maxRows());
+    api.setTimeoutSeconds(input.timeoutSeconds());
+    api.setEnabled(input.enabled());
+    api.setDescription(input.description());
+  }
 
-    api.setName(input.name().trim());
-    api.setPath(path);
-    api.setDataSourceId(input.dataSourceId());
-    api.setSqlText(input.sql().trim());
-    api.setMaxRows(normalizeMaxRows(input.maxRows()));
-    api.setTimeoutSeconds(normalizeTimeout(input.timeoutSeconds()));
-    api.setEnabled(input.enabled() == null ? Boolean.FALSE : input.enabled());
-    if (!StringUtils.hasText(api.getAuthMode())) api.setAuthMode("NONE");
-    initializeRuntimeDefaults(api, creating);
-    api.setDescription(StringUtils.hasText(input.description()) ? input.description().trim() : null);
-    api.setUpdateTime(now);
-    if (creating) {
-      api.setCreateTime(now);
-      apiMapper.insert(api);
-    } else {
-      apiMapper.updateById(api);
+  private ServiceSettingsInput normalizeSettings(
+      ServiceSettingsInput input,
+      DataServiceApiPO existing) {
+    if (input == null) throw new IllegalArgumentException("数据服务配置不能为空");
+    if (!StringUtils.hasText(input.name())) throw new IllegalArgumentException("服务名称不能为空");
+    String path = normalizePath(input.path());
+    int maxRows = input.maxRows() == null && existing != null && existing.getMaxRows() != null
+        ? existing.getMaxRows()
+        : normalizeMaxRows(input.maxRows());
+    int timeoutSeconds = input.timeoutSeconds() == null
+        && existing != null
+        && existing.getTimeoutSeconds() != null
+            ? existing.getTimeoutSeconds()
+            : normalizeTimeout(input.timeoutSeconds());
+    boolean enabled = input.enabled() == null
+        ? existing != null && Boolean.TRUE.equals(existing.getEnabled())
+        : input.enabled();
+    String description = StringUtils.hasText(input.description()) ? input.description().trim() : null;
+    return new ServiceSettingsInput(
+        input.name().trim(), path, maxRows, timeoutSeconds, enabled, description);
+  }
+
+  private RuntimeDefinition normalizeRuntimeDefinition(RuntimeDefinition runtimeDefinition) {
+    if (runtimeDefinition == null) throw new IllegalArgumentException("Runtime 定义不能为空");
+    if (runtimeDefinition.dataSourceId() == null || runtimeDefinition.dataSourceId() <= 0) {
+      throw new IllegalArgumentException("发布来源缺少有效的数据源");
     }
-    runtimeService.invalidate(api.getId());
-    return toView(api);
+    if (!StringUtils.hasText(runtimeDefinition.sql())) {
+      throw new IllegalArgumentException("发布来源 SQL 不能为空");
+    }
+    sqlCompiler.validateSelectOnly(runtimeDefinition.sql());
+    return new RuntimeDefinition(runtimeDefinition.dataSourceId(), runtimeDefinition.sql().trim());
   }
 
   private QueryResponse execute(
@@ -334,18 +369,6 @@ public class DataServiceService {
     DataServiceApiPO api = id == null ? null : apiMapper.selectById(id);
     if (api == null) throw new IllegalArgumentException("数据服务不存在：" + id);
     return api;
-  }
-
-  private void validateInput(ApiInput input) {
-    if (input == null) throw new IllegalArgumentException("数据服务配置不能为空");
-    if (!StringUtils.hasText(input.name())) throw new IllegalArgumentException("服务名称不能为空");
-    if (input.dataSourceId() == null || input.dataSourceId() <= 0) {
-      throw new IllegalArgumentException("请选择数据源");
-    }
-    sqlCompiler.validateSelectOnly(input.sql());
-    normalizePath(input.path());
-    normalizeMaxRows(input.maxRows());
-    normalizeTimeout(input.timeoutSeconds());
   }
 
   private void initializeRuntimeDefaults(DataServiceApiPO api, boolean creating) {
@@ -452,15 +475,15 @@ public class DataServiceService {
     return value.substring(0, maxLength);
   }
 
-  public record ApiInput(
+  public record ServiceSettingsInput(
       String name,
       String path,
-      Long dataSourceId,
-      String sql,
       Integer maxRows,
       Integer timeoutSeconds,
       Boolean enabled,
       String description) {}
+
+  public record RuntimeDefinition(Long dataSourceId, String sql) {}
 
   public record RuntimeConfigInput(
       Boolean cacheEnabled,

--- a/yak-ops-business/yak-ops-business-data-service/src/test/java/io/yak/ops/business/dataservice/controller/v1/DataServiceControllerTest.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/test/java/io/yak/ops/business/dataservice/controller/v1/DataServiceControllerTest.java
@@ -1,0 +1,76 @@
+package io.yak.ops.business.dataservice.controller.v1;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.dataservice.controller.v1.DataServiceController.UpdateDataServiceRequest;
+import io.yak.ops.business.dataservice.service.DataServiceAccessService;
+import io.yak.ops.business.dataservice.service.DataServiceDocumentationService;
+import io.yak.ops.business.dataservice.service.DataServicePublicationService;
+import io.yak.ops.business.dataservice.service.DataServiceService;
+import io.yak.ops.business.dataservice.service.DataServiceService.ApiInput;
+import io.yak.ops.business.dataservice.service.DataServiceService.ApiView;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class DataServiceControllerTest {
+
+  @Test
+  void updatePreservesServerOwnedSqlAndDatasourceSnapshot() {
+    DataServiceService dataServiceService = mock(DataServiceService.class);
+    DataServiceController controller = new DataServiceController(
+        dataServiceService,
+        mock(DataServicePublicationService.class),
+        mock(DataServiceAccessService.class),
+        mock(DataServiceDocumentationService.class));
+
+    ApiView current = new ApiView(
+        9L,
+        "历史订单 API",
+        "/legacy/orders",
+        "/api/v1/data-service/runtime/legacy/orders",
+        42L,
+        "select id from orders where status = :status",
+        List.of("status"),
+        1000,
+        30,
+        true,
+        "NONE",
+        "legacy service",
+        null,
+        null,
+        null,
+        null,
+        null,
+        null);
+    when(dataServiceService.get(9L)).thenReturn(current);
+    when(dataServiceService.save(org.mockito.ArgumentMatchers.eq(9L), org.mockito.ArgumentMatchers.any(ApiInput.class)))
+        .thenReturn(current);
+
+    controller.update(
+        9L,
+        new UpdateDataServiceRequest(
+            "订单查询 API",
+            "/orders",
+            500,
+            20,
+            false,
+            "只修改服务侧配置"));
+
+    ArgumentCaptor<ApiInput> inputCaptor = ArgumentCaptor.forClass(ApiInput.class);
+    verify(dataServiceService).save(org.mockito.ArgumentMatchers.eq(9L), inputCaptor.capture());
+    ApiInput input = inputCaptor.getValue();
+
+    assertThat(input.name()).isEqualTo("订单查询 API");
+    assertThat(input.path()).isEqualTo("/orders");
+    assertThat(input.maxRows()).isEqualTo(500);
+    assertThat(input.timeoutSeconds()).isEqualTo(20);
+    assertThat(input.enabled()).isFalse();
+    assertThat(input.description()).isEqualTo("只修改服务侧配置");
+    assertThat(input.dataSourceId()).isEqualTo(42L);
+    assertThat(input.sql()).isEqualTo("select id from orders where status = :status");
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-service/src/test/java/io/yak/ops/business/dataservice/controller/v1/DataServiceControllerTest.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/test/java/io/yak/ops/business/dataservice/controller/v1/DataServiceControllerTest.java
@@ -1,6 +1,8 @@
 package io.yak.ops.business.dataservice.controller.v1;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -10,8 +12,9 @@ import io.yak.ops.business.dataservice.service.DataServiceAccessService;
 import io.yak.ops.business.dataservice.service.DataServiceDocumentationService;
 import io.yak.ops.business.dataservice.service.DataServicePublicationService;
 import io.yak.ops.business.dataservice.service.DataServiceService;
-import io.yak.ops.business.dataservice.service.DataServiceService.ApiInput;
 import io.yak.ops.business.dataservice.service.DataServiceService.ApiView;
+import io.yak.ops.business.dataservice.service.DataServiceService.ServiceSettingsInput;
+import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -19,36 +22,31 @@ import org.mockito.ArgumentCaptor;
 class DataServiceControllerTest {
 
   @Test
-  void updatePreservesServerOwnedSqlAndDatasourceSnapshot() {
+  void updateContractContainsOnlyServiceFacingSettings() {
+    List<String> components = Arrays.stream(UpdateDataServiceRequest.class.getRecordComponents())
+        .map(component -> component.getName())
+        .toList();
+
+    assertThat(components).containsExactly(
+        "name",
+        "path",
+        "maxRows",
+        "timeoutSeconds",
+        "enabled",
+        "description");
+    assertThat(components).doesNotContain("sql", "dataSourceId");
+  }
+
+  @Test
+  void updateDelegatesOnlyServiceFacingSettings() {
     DataServiceService dataServiceService = mock(DataServiceService.class);
     DataServiceController controller = new DataServiceController(
         dataServiceService,
         mock(DataServicePublicationService.class),
         mock(DataServiceAccessService.class),
         mock(DataServiceDocumentationService.class));
-
-    ApiView current = new ApiView(
-        9L,
-        "历史订单 API",
-        "/legacy/orders",
-        "/api/v1/data-service/runtime/legacy/orders",
-        42L,
-        "select id from orders where status = :status",
-        List.of("status"),
-        1000,
-        30,
-        true,
-        "NONE",
-        "legacy service",
-        null,
-        null,
-        null,
-        null,
-        null,
-        null);
-    when(dataServiceService.get(9L)).thenReturn(current);
-    when(dataServiceService.save(org.mockito.ArgumentMatchers.eq(9L), org.mockito.ArgumentMatchers.any(ApiInput.class)))
-        .thenReturn(current);
+    when(dataServiceService.updateSettings(eq(9L), any(ServiceSettingsInput.class)))
+        .thenReturn(mock(ApiView.class));
 
     controller.update(
         9L,
@@ -60,9 +58,10 @@ class DataServiceControllerTest {
             false,
             "只修改服务侧配置"));
 
-    ArgumentCaptor<ApiInput> inputCaptor = ArgumentCaptor.forClass(ApiInput.class);
-    verify(dataServiceService).save(org.mockito.ArgumentMatchers.eq(9L), inputCaptor.capture());
-    ApiInput input = inputCaptor.getValue();
+    ArgumentCaptor<ServiceSettingsInput> inputCaptor =
+        ArgumentCaptor.forClass(ServiceSettingsInput.class);
+    verify(dataServiceService).updateSettings(eq(9L), inputCaptor.capture());
+    ServiceSettingsInput input = inputCaptor.getValue();
 
     assertThat(input.name()).isEqualTo("订单查询 API");
     assertThat(input.path()).isEqualTo("/orders");
@@ -70,7 +69,5 @@ class DataServiceControllerTest {
     assertThat(input.timeoutSeconds()).isEqualTo(20);
     assertThat(input.enabled()).isFalse();
     assertThat(input.description()).isEqualTo("只修改服务侧配置");
-    assertThat(input.dataSourceId()).isEqualTo(42L);
-    assertThat(input.sql()).isEqualTo("select id from orders where status = :status");
   }
 }

--- a/yak-ops-business/yak-ops-business-data-service/src/test/java/io/yak/ops/business/dataservice/service/DataServicePublicationServiceTest.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/test/java/io/yak/ops/business/dataservice/service/DataServicePublicationServiceTest.java
@@ -9,8 +9,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.yak.ops.business.dataservice.service.DataServicePublicationService.PublishRequest;
-import io.yak.ops.business.dataservice.service.DataServiceService.ApiInput;
 import io.yak.ops.business.dataservice.service.DataServiceService.ApiView;
+import io.yak.ops.business.dataservice.service.DataServiceService.RuntimeDefinition;
+import io.yak.ops.business.dataservice.service.DataServiceService.ServiceSettingsInput;
 import io.yak.ops.business.dataservice.service.DataServiceService.SourceSnapshot;
 import io.yak.ops.business.dataservice.service.source.DataServiceSourceProvider;
 import io.yak.ops.business.dataservice.service.source.DataServiceSourceProvider.ResolvedSource;
@@ -42,10 +43,14 @@ class DataServicePublicationServiceTest {
   void publishAlwaysCopiesSqlAndDatasourceFromResolvedSource() {
     when(provider.resolve("88")).thenReturn(resolved("ONLINE", 102L, 2));
     when(dataServiceService.findBySource(SOURCE_TYPE, "88")).thenReturn(Optional.empty());
-    when(dataServiceService.saveFromSource(any(SourceSnapshot.class), any(ApiInput.class)))
+    when(dataServiceService.saveFromSource(
+        any(SourceSnapshot.class),
+        any(RuntimeDefinition.class),
+        any(ServiceSettingsInput.class)))
         .thenAnswer(invocation -> view(
             9L,
             invocation.getArgument(1),
+            invocation.getArgument(2),
             invocation.getArgument(0)));
 
     ApiView result = service.publish(new PublishRequest(
@@ -59,16 +64,24 @@ class DataServicePublicationServiceTest {
         "供运营系统查询"));
 
     ArgumentCaptor<SourceSnapshot> sourceCaptor = ArgumentCaptor.forClass(SourceSnapshot.class);
-    ArgumentCaptor<ApiInput> inputCaptor = ArgumentCaptor.forClass(ApiInput.class);
-    verify(dataServiceService).saveFromSource(sourceCaptor.capture(), inputCaptor.capture());
+    ArgumentCaptor<RuntimeDefinition> runtimeCaptor =
+        ArgumentCaptor.forClass(RuntimeDefinition.class);
+    ArgumentCaptor<ServiceSettingsInput> settingsCaptor =
+        ArgumentCaptor.forClass(ServiceSettingsInput.class);
+    verify(dataServiceService).saveFromSource(
+        sourceCaptor.capture(),
+        runtimeCaptor.capture(),
+        settingsCaptor.capture());
 
     assertThat(sourceCaptor.getValue().sourceType()).isEqualTo(SOURCE_TYPE);
     assertThat(sourceCaptor.getValue().sourceRef()).isEqualTo("88");
     assertThat(sourceCaptor.getValue().sourceRevisionId()).isEqualTo(102L);
     assertThat(sourceCaptor.getValue().sourceRevisionNo()).isEqualTo(2);
-    assertThat(inputCaptor.getValue().dataSourceId()).isEqualTo(42L);
-    assertThat(inputCaptor.getValue().sql())
+    assertThat(runtimeCaptor.getValue().dataSourceId()).isEqualTo(42L);
+    assertThat(runtimeCaptor.getValue().sql())
         .isEqualTo("select id, amount from orders where status = :status");
+    assertThat(settingsCaptor.getValue().name()).isEqualTo("订单查询 API");
+    assertThat(settingsCaptor.getValue().path()).isEqualTo("/orders");
     assertThat(result.id()).isEqualTo(9L);
   }
 
@@ -81,18 +94,17 @@ class DataServicePublicationServiceTest {
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("ONLINE");
 
-    verify(dataServiceService, never()).saveFromSource(any(), any());
+    verify(dataServiceService, never()).saveFromSource(any(), any(), any());
   }
 
   @Test
   void republishRefreshesSameServiceIdentityAndPreservesOperationalSettings() {
     ApiView existing = view(
         9L,
-        new ApiInput(
+        new RuntimeDefinition(42L, "select old_sql from orders"),
+        new ServiceSettingsInput(
             "订单查询 API",
             "/orders",
-            42L,
-            "select old_sql from orders",
             500,
             20,
             false,
@@ -101,10 +113,14 @@ class DataServicePublicationServiceTest {
     when(dataServiceService.get(9L)).thenReturn(existing);
     when(provider.resolve("88")).thenReturn(resolved("ONLINE", 103L, 3));
     when(dataServiceService.findBySource(SOURCE_TYPE, "88")).thenReturn(Optional.of(existing));
-    when(dataServiceService.saveFromSource(any(SourceSnapshot.class), any(ApiInput.class)))
+    when(dataServiceService.saveFromSource(
+        any(SourceSnapshot.class),
+        any(RuntimeDefinition.class),
+        any(ServiceSettingsInput.class)))
         .thenAnswer(invocation -> view(
             9L,
             invocation.getArgument(1),
+            invocation.getArgument(2),
             invocation.getArgument(0)));
 
     ApiView refreshed = service.republish(9L, null);
@@ -117,6 +133,9 @@ class DataServicePublicationServiceTest {
     assertThat(refreshed.timeoutSeconds()).isEqualTo(20);
     assertThat(refreshed.enabled()).isFalse();
     assertThat(refreshed.description()).isEqualTo("运营查询");
+    assertThat(refreshed.dataSourceId()).isEqualTo(42L);
+    assertThat(refreshed.sql())
+        .isEqualTo("select id, amount from orders where status = :status");
   }
 
   private ResolvedSource resolved(String status, Long revisionId, int revisionNo) {
@@ -137,20 +156,24 @@ class DataServicePublicationServiceTest {
         "select id, amount from orders where status = :status");
   }
 
-  private ApiView view(Long id, ApiInput input, SourceSnapshot source) {
+  private ApiView view(
+      Long id,
+      RuntimeDefinition runtime,
+      ServiceSettingsInput settings,
+      SourceSnapshot source) {
     return new ApiView(
         id,
-        input.name(),
-        input.path(),
-        "/api/v1/data-service/runtime" + input.path(),
-        input.dataSourceId(),
-        input.sql(),
+        settings.name(),
+        settings.path(),
+        "/api/v1/data-service/runtime" + settings.path(),
+        runtime.dataSourceId(),
+        runtime.sql(),
         List.of("status"),
-        input.maxRows(),
-        input.timeoutSeconds(),
-        Boolean.TRUE.equals(input.enabled()),
+        settings.maxRows(),
+        settings.timeoutSeconds(),
+        Boolean.TRUE.equals(settings.enabled()),
         "NONE",
-        input.description(),
+        settings.description(),
         source.sourceType(),
         source.sourceRef(),
         source.sourceRevisionId(),

--- a/yak-ops-business/yak-ops-business-data-service/src/test/java/io/yak/ops/business/dataservice/service/DataServiceServiceSourceTest.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/test/java/io/yak/ops/business/dataservice/service/DataServiceServiceSourceTest.java
@@ -1,7 +1,6 @@
 package io.yak.ops.business.dataservice.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -11,8 +10,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.yak.ops.business.dataservice.dao.mapper.DataServiceApiMapper;
 import io.yak.ops.business.dataservice.dao.mapper.DataServiceCallLogMapper;
 import io.yak.ops.business.dataservice.dao.model.DataServiceApiPO;
-import io.yak.ops.business.dataservice.service.DataServiceService.ApiInput;
 import io.yak.ops.business.dataservice.service.DataServiceService.ApiView;
+import io.yak.ops.business.dataservice.service.DataServiceService.RuntimeDefinition;
+import io.yak.ops.business.dataservice.service.DataServiceService.ServiceSettingsInput;
+import io.yak.ops.business.dataservice.service.DataServiceService.SourceSnapshot;
 import io.yak.ops.business.dataservice.service.support.DataServiceSqlCompiler;
 import io.yak.ops.business.datasource.service.support.BusinessDataSourceExecutionProvider;
 import java.time.LocalDateTime;
@@ -39,76 +40,28 @@ class DataServiceServiceSourceTest {
         mock(DataServiceAccessService.class),
         runtimeService);
 
-    sourceManaged = new DataServiceApiPO();
-    sourceManaged.setId(9L);
-    sourceManaged.setName("订单查询");
-    sourceManaged.setPath("/orders");
-    sourceManaged.setDataSourceId(42L);
-    sourceManaged.setSqlText("select id from orders where status = :status");
-    sourceManaged.setMaxRows(1000);
-    sourceManaged.setTimeoutSeconds(30);
-    sourceManaged.setEnabled(true);
-    sourceManaged.setAuthMode("NONE");
-    sourceManaged.setCacheEnabled(false);
-    sourceManaged.setCacheTtlSeconds(60);
-    sourceManaged.setCacheMaxEntries(200);
-    sourceManaged.setCircuitBreakerEnabled(false);
-    sourceManaged.setCircuitFailureThreshold(5);
-    sourceManaged.setCircuitRecoverySeconds(30);
+    sourceManaged = api(
+        9L,
+        "订单查询",
+        "/orders",
+        42L,
+        "select id from orders where status = :status");
     sourceManaged.setSourceType("DATA_DEVELOPMENT_RELEASE");
     sourceManaged.setSourceRef("88");
     sourceManaged.setSourceRevisionId(102L);
     sourceManaged.setSourceRevisionNo(2);
-    sourceManaged.setCreateTime(LocalDateTime.now());
-    sourceManaged.setUpdateTime(LocalDateTime.now());
 
     when(apiMapper.selectById(9L)).thenReturn(sourceManaged);
     when(apiMapper.selectCount(any())).thenReturn(0L);
   }
 
   @Test
-  void manualEditCannotChangeDatasourceOfSourceManagedService() {
-    assertThatThrownBy(() -> service.save(
+  void sourceManagedSettingsUpdatePreservesRuntimeDefinition() {
+    ApiView updated = service.updateSettings(
         9L,
-        new ApiInput(
-            "订单查询",
-            "/orders",
-            43L,
-            sourceManaged.getSqlText(),
-            1000,
-            30,
-            true,
-            null)))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("发布来源");
-  }
-
-  @Test
-  void manualEditCannotChangeSqlOfSourceManagedService() {
-    assertThatThrownBy(() -> service.save(
-        9L,
-        new ApiInput(
-            "订单查询",
-            "/orders",
-            42L,
-            "select id, amount from orders where status = :status",
-            1000,
-            30,
-            true,
-            null)))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("发布来源");
-  }
-
-  @Test
-  void manualEditMayChangeOperationalMetadataWithoutLosingRuntimePolicy() {
-    ApiView updated = service.save(
-        9L,
-        new ApiInput(
+        new ServiceSettingsInput(
             "订单查询 API",
             "/orders/v1",
-            42L,
-            sourceManaged.getSqlText(),
             500,
             20,
             false,
@@ -118,11 +71,93 @@ class DataServiceServiceSourceTest {
     assertThat(updated.path()).isEqualTo("/orders/v1");
     assertThat(updated.maxRows()).isEqualTo(500);
     assertThat(updated.enabled()).isFalse();
-    assertThat(updated.authMode()).isEqualTo("NONE");
+    assertThat(updated.dataSourceId()).isEqualTo(42L);
+    assertThat(updated.sql()).isEqualTo("select id from orders where status = :status");
     assertThat(updated.sourceRevisionNo()).isEqualTo(2);
     assertThat(sourceManaged.getCacheEnabled()).isFalse();
     assertThat(sourceManaged.getCircuitBreakerEnabled()).isFalse();
     verify(apiMapper).updateById(sourceManaged);
     verify(runtimeService).invalidate(9L);
+  }
+
+  @Test
+  void legacySettingsUpdateAlsoPreservesRuntimeDefinition() {
+    DataServiceApiPO legacy = api(
+        10L,
+        "历史 API",
+        "/legacy",
+        77L,
+        "select id from legacy_orders");
+    when(apiMapper.selectById(10L)).thenReturn(legacy);
+
+    ApiView updated = service.updateSettings(
+        10L,
+        new ServiceSettingsInput(
+            "历史订单 API",
+            "/legacy/orders",
+            300,
+            15,
+            true,
+            "继续运行但执行快照冻结"));
+
+    assertThat(updated.dataSourceId()).isEqualTo(77L);
+    assertThat(updated.sql()).isEqualTo("select id from legacy_orders");
+    assertThat(updated.sourceType()).isNull();
+    assertThat(updated.name()).isEqualTo("历史订单 API");
+    assertThat(updated.path()).isEqualTo("/legacy/orders");
+  }
+
+  @Test
+  void sourceRepublishIsTheOnlyPathThatRefreshesRuntimeDefinition() {
+    when(apiMapper.selectOne(any())).thenReturn(sourceManaged);
+
+    ApiView refreshed = service.saveFromSource(
+        new SourceSnapshot("DATA_DEVELOPMENT_RELEASE", "88", 103L, 3),
+        new RuntimeDefinition(
+            43L,
+            "select id, amount from orders where status = :status"),
+        new ServiceSettingsInput(
+            "订单查询 API",
+            "/orders",
+            1000,
+            30,
+            true,
+            "新版查询"));
+
+    assertThat(refreshed.id()).isEqualTo(9L);
+    assertThat(refreshed.dataSourceId()).isEqualTo(43L);
+    assertThat(refreshed.sql())
+        .isEqualTo("select id, amount from orders where status = :status");
+    assertThat(refreshed.sourceRevisionId()).isEqualTo(103L);
+    assertThat(refreshed.sourceRevisionNo()).isEqualTo(3);
+    assertThat(sourceManaged.getCacheEnabled()).isFalse();
+    assertThat(sourceManaged.getCircuitBreakerEnabled()).isFalse();
+  }
+
+  private DataServiceApiPO api(
+      Long id,
+      String name,
+      String path,
+      Long dataSourceId,
+      String sql) {
+    DataServiceApiPO api = new DataServiceApiPO();
+    api.setId(id);
+    api.setName(name);
+    api.setPath(path);
+    api.setDataSourceId(dataSourceId);
+    api.setSqlText(sql);
+    api.setMaxRows(1000);
+    api.setTimeoutSeconds(30);
+    api.setEnabled(true);
+    api.setAuthMode("NONE");
+    api.setCacheEnabled(false);
+    api.setCacheTtlSeconds(60);
+    api.setCacheMaxEntries(200);
+    api.setCircuitBreakerEnabled(false);
+    api.setCircuitFailureThreshold(5);
+    api.setCircuitRecoverySeconds(30);
+    api.setCreateTime(LocalDateTime.now());
+    api.setUpdateTime(LocalDateTime.now());
+    return api;
   }
 }

--- a/yak-ops-ui/src/pages/data-service/index.tsx
+++ b/yak-ops-ui/src/pages/data-service/index.tsx
@@ -5,7 +5,6 @@ import {
   Input,
   InputNumber,
   Modal,
-  Select,
   Space,
   Switch,
   Table,
@@ -35,7 +34,7 @@ import {
   setDataServiceEnabled,
   updateDataService,
   type DataServiceApi,
-  type DataServiceSavePayload,
+  type DataServiceUpdatePayload,
   type DataSourceOption,
 } from './service';
 
@@ -51,8 +50,7 @@ export default function DataServicePage() {
   const [editing, setEditing] = useState<DataServiceApi>();
   const [editorOpen, setEditorOpen] = useState(false);
   const [saving, setSaving] = useState(false);
-  const [form] = Form.useForm<DataServiceSavePayload>();
-  const sourceManaged = Boolean(editing?.sourceType);
+  const [form] = Form.useForm<DataServiceUpdatePayload>();
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -96,8 +94,6 @@ export default function DataServicePage() {
     form.setFieldsValue({
       name: record.name,
       path: record.path,
-      dataSourceId: record.dataSourceId,
-      sql: record.sql,
       maxRows: record.maxRows,
       timeoutSeconds: record.timeoutSeconds,
       enabled: record.enabled,
@@ -109,15 +105,10 @@ export default function DataServicePage() {
   const saveEdit = async () => {
     if (!editing) return;
     const values = await form.validateFields();
-    const payload: DataServiceSavePayload = {
-      ...values,
-      dataSourceId: sourceManaged ? editing.dataSourceId : values.dataSourceId,
-      sql: sourceManaged ? editing.sql : values.sql,
-    };
     setSaving(true);
     try {
-      await updateDataService(editing.id, payload);
-      message.success('数据服务已更新');
+      await updateDataService(editing.id, values);
+      message.success('数据服务配置已更新');
       setEditorOpen(false);
       setEditing(undefined);
       await load();
@@ -338,19 +329,23 @@ export default function DataServicePage() {
         onOk={() => void saveEdit()}
         okText="保存"
         confirmLoading={saving}
-        width={760}
+        width={680}
         destroyOnHidden
       >
         <Form form={form} layout="vertical" className="pt-3">
-          {sourceManaged ? (
+          {editing?.sourceType === 'DATA_DEVELOPMENT_RELEASE' ? (
             <div className="mb-4 border border-[#e5e7eb] bg-[#fafafa] px-4 py-3 text-[12px] leading-5 text-[#667085]">
-              <div className="font-medium text-[#344054]">来源：数据开发 SQL · v{editing?.sourceRevisionNo || '-'}</div>
-              <div className="mt-1">数据源：{dataSourceName(editing?.dataSourceId)} · Source #{editing?.sourceRef || '-'}</div>
-              <div className="mt-1">SQL 与数据源由上游发布版本管理；需要修改执行逻辑时，请回到数据开发发布新 Revision。</div>
+              <div className="font-medium text-[#344054]">来源：数据开发 SQL · v{editing.sourceRevisionNo || '-'}</div>
+              <div className="mt-1">数据源：{dataSourceName(editing.dataSourceId)} · Source #{editing.sourceRef || '-'}</div>
+              <div className="mt-1">SQL 与数据源属于上游 Runtime Snapshot；修改执行逻辑请回到数据开发发布新的 ONLINE Revision，再显式更新 API。</div>
             </div>
           ) : (
-            <div className="mb-4 border border-[#e5e7eb] bg-[#fafafa] px-4 py-3 text-[12px] leading-5 text-[#667085]">
-              这是旧版手工创建的数据服务，当前继续保留 SQL 与数据源编辑能力用于兼容。新的 API 请从数据开发已发布 SQL 创建。
+            <div className="mb-4 border border-[#fecdca] bg-[#fffbfa] px-4 py-3 text-[12px] leading-5 text-[#b42318]">
+              <div className="font-medium">Legacy 手工数据服务</div>
+              <div className="mt-1 text-[#667085]">
+                当前 SQL 与数据源快照已冻结并继续用于 Runtime。Data Service 不再提供 SQL 编辑能力；如需修改查询逻辑，请在数据开发中创建并发布 SQL，再创建新的 API 服务。
+              </div>
+              <div className="mt-1 text-[#667085]">当前数据源：{dataSourceName(editing?.dataSourceId)}</div>
             </div>
           )}
 
@@ -362,36 +357,6 @@ export default function DataServicePage() {
               <Input addonBefore="GET" placeholder="/users" />
             </Form.Item>
           </div>
-
-          {!sourceManaged ? (
-            <>
-              <Form.Item
-                name="dataSourceId"
-                label="数据源"
-                rules={[{ required: true, message: '请选择数据源' }]}
-              >
-                <Select
-                  showSearch
-                  optionFilterProp="label"
-                  placeholder="选择已有数据源"
-                  options={dataSources.map((item) => ({ ...item, value: Number(item.value) || item.value }))}
-                />
-              </Form.Item>
-              <Form.Item
-                name="sql"
-                label="SELECT SQL"
-                extra="Legacy 兼容模式。新的 SQL 开发请统一在数据开发中完成。"
-                rules={[{ required: true, message: '请输入 SQL' }]}
-              >
-                <Input.TextArea
-                  rows={10}
-                  spellCheck={false}
-                  placeholder={'SELECT id, username\nFROM sys_user\nWHERE department = :department'}
-                  style={{ fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace' }}
-                />
-              </Form.Item>
-            </>
-          ) : null}
 
           <div className="grid grid-cols-3 gap-x-4">
             <Form.Item name="maxRows" label="最大返回行数" rules={[{ required: true }]}>

--- a/yak-ops-ui/src/pages/data-service/service.ts
+++ b/yak-ops-ui/src/pages/data-service/service.ts
@@ -54,6 +54,15 @@ export interface DataServicePublishPayload {
   description?: string;
 }
 
+export interface DataServiceUpdatePayload {
+  name: string;
+  path: string;
+  maxRows?: number;
+  timeoutSeconds?: number;
+  enabled?: boolean;
+  description?: string;
+}
+
 export type DataServiceAuthMode = 'NONE' | 'API_KEY';
 export type DataServiceSchemaType =
   | 'STRING'
@@ -83,17 +92,6 @@ export interface DataServiceApi {
   sourceRevisionNo?: number;
   createTime?: string;
   updateTime?: string;
-}
-
-export interface DataServiceSavePayload {
-  name: string;
-  path: string;
-  dataSourceId: number;
-  sql: string;
-  maxRows?: number;
-  timeoutSeconds?: number;
-  enabled?: boolean;
-  description?: string;
 }
 
 export interface DataServiceRuntimeConfig {
@@ -233,11 +231,7 @@ export const fetchDataServiceSources = ({
 export const publishDataService = (payload: DataServicePublishPayload) =>
   HttpUtils.post<DataServiceApi>(`${PREFIX}/publish`, payload) as Promise<CommonApiResponse<DataServiceApi>>;
 
-/** Legacy manual SQL creation path retained for historical services during the migration period. */
-export const createDataService = (payload: DataServiceSavePayload) =>
-  HttpUtils.post<DataServiceApi>(PREFIX, payload) as Promise<CommonApiResponse<DataServiceApi>>;
-
-export const updateDataService = (id: number, payload: DataServiceSavePayload) =>
+export const updateDataService = (id: number, payload: DataServiceUpdatePayload) =>
   HttpUtils.put<DataServiceApi>(`${PREFIX}/${id}`, payload) as Promise<CommonApiResponse<DataServiceApi>>;
 
 export const deleteDataService = (id: number) =>


### PR DESCRIPTION
## Summary

Complete phase 5 of the Data Development -> Data Service convergence by removing the remaining duplicate SQL-authoring path and enforcing the authoring/serving boundary in code and API contracts.

The final model is now:

```text
Data Development
  -> SQL / datasource authoring
  -> immutable ONLINE Revision
  -> Data Service publication
  -> Runtime Snapshot

Data Service management
  -> name / path / limits / enabled / description
  -> docs / access / runtime policy / audit
  -> never edits SQL or datasource
```

## Public management contract

`PUT /api/v1/data-service/{id}` is now settings-only.

The request contains only:

```text
name
path
maxRows
timeoutSeconds
enabled
description
```

`sql` and `dataSourceId` are deliberately absent from the public update DTO.

The former legacy manual creation endpoint:

```text
POST /api/v1/data-service
```

has been removed. New Data Services must be created through the source publication flow:

```text
POST /api/v1/data-service/publish
```

This means the backend contract itself now prevents creation of a second independently-authored SQL definition.

## Service-layer boundary

`DataServiceService` no longer exposes the old generic `save(ApiInput)` method.

It now has two explicit write paths:

```text
updateSettings(id, ServiceSettingsInput)
  -> service-facing metadata only

saveFromSource(source, RuntimeDefinition, ServiceSettingsInput)
  -> the only path allowed to write SQL + datasource
```

`RuntimeDefinition` contains only the server-resolved executable snapshot:

```text
dataSourceId
sql
```

`DataServicePublicationService` resolves these values from the authoritative immutable source release and is therefore the sole owner of Runtime definition changes.

## Legacy services

Existing manually-created Legacy APIs are not deleted or migrated destructively.

They continue to:

- run with their existing SQL/datasource snapshot
- be enabled/disabled
- update name/path/max rows/timeout/description
- use API Key, Runtime policies, docs and audit

Their SQL and datasource are now frozen. The Data Service UI no longer offers a datasource selector or SQL editor for Legacy services.

The edit UI explains that changing query logic now requires creating/publishing SQL in Data Development and creating a source-backed API.

## Frontend cleanup

Removed the remaining duplicate authoring code from Data Service management:

- datasource selector from edit modal
- SELECT SQL textarea from edit modal
- `DataServiceSavePayload` with SQL/datasource
- legacy `createDataService()` helper
- edit logic that re-sent SQL/datasource snapshots

Added a smaller `DataServiceUpdatePayload` containing only service-facing fields.

Source-backed APIs and Legacy APIs now share the same settings-only edit surface; only the provenance notice differs.

## Runtime / documentation compatibility

The persisted Runtime Snapshot is intentionally retained in storage and `ApiView` because existing Runtime execution and documentation/schema fingerprinting still read it.

This PR removes **authoring/mutation**, not the runtime snapshot itself.

No behavior changes to:

- Runtime invocation
- cache / circuit breaker
- API Key / rate limiting
- OpenAPI / documentation
- call audit
- source revision snapshot semantics

## Tests

Added/updated tests to lock the boundary:

- public update DTO has no `sql` or `dataSourceId`
- controller delegates only `ServiceSettingsInput`
- source-backed settings updates preserve SQL/datasource
- Legacy settings updates preserve SQL/datasource
- source republish is the path that can refresh RuntimeDefinition + Revision
- publication always obtains SQL/datasource from resolved source
- republish preserves API identity and service-facing settings

## Scope

8 changed files:

- Data Service controller
- Data Service service/publication boundary
- 3 backend test files
- Data Service list/edit UI
- Data Service frontend API types

No Flyway migration is required and no persisted service data is modified by this refactor.

## Validation

- based on merged phase 4 PR #421
- final compare is behind `main` by 0 commits
- Data Development compatibility facade was checked and depends only on `DataServicePublicationService`
- documentation/access/runtime tests do not reference the removed generic write API
- no migration or runtime/auth/docs implementation changes

A full Maven/frontend build was not executed from this connector environment. CI/local build and application startup should be treated as the executable validation source before marking this PR ready.