### PR TITLE
refactor: define data development node responsibilities

### DIFF
--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/domain/DevelopmentNodeCategory.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/domain/DevelopmentNodeCategory.java
@@ -1,0 +1,7 @@
+package io.yak.ops.business.development.domain;
+
+/** High-level responsibility of a node inside the data-development DAG. */
+public enum DevelopmentNodeCategory {
+  PROCESSING,
+  OUTPUT
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/domain/DevelopmentNodeConnectionPolicy.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/domain/DevelopmentNodeConnectionPolicy.java
@@ -1,0 +1,24 @@
+package io.yak.ops.business.development.domain;
+
+import java.util.Map;
+import java.util.Set;
+
+/** Explicit, fail-closed connection policy for the data-development DAG. */
+public final class DevelopmentNodeConnectionPolicy {
+
+  private static final Map<DevelopmentNodeType, Set<DevelopmentNodeType>> ALLOWED_TARGETS = Map.of(
+      DevelopmentNodeType.SQL,
+      Set.of(
+          DevelopmentNodeType.SQL,
+          DevelopmentNodeType.DATASET,
+          DevelopmentNodeType.DATA_SERVICE),
+      DevelopmentNodeType.DATASET,
+      Set.of(DevelopmentNodeType.DATA_SERVICE));
+
+  private DevelopmentNodeConnectionPolicy() {}
+
+  public static boolean canConnect(DevelopmentNodeType source, DevelopmentNodeType target) {
+    if (source == null || target == null) return false;
+    return ALLOWED_TARGETS.getOrDefault(source, Set.of()).contains(target);
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/domain/DevelopmentNodeType.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/domain/DevelopmentNodeType.java
@@ -1,0 +1,41 @@
+package io.yak.ops.business.development.domain;
+
+import java.util.Locale;
+import java.util.Optional;
+
+/** Domain-level node types for data development. */
+public enum DevelopmentNodeType {
+  SQL(DevelopmentNodeCategory.PROCESSING),
+  SHELL(DevelopmentNodeCategory.PROCESSING),
+  HTTP(DevelopmentNodeCategory.PROCESSING),
+  PYTHON(DevelopmentNodeCategory.PROCESSING),
+  DATASET(DevelopmentNodeCategory.OUTPUT),
+  DATA_SERVICE(DevelopmentNodeCategory.OUTPUT);
+
+  private final DevelopmentNodeCategory category;
+
+  DevelopmentNodeType(DevelopmentNodeCategory category) {
+    this.category = category;
+  }
+
+  public DevelopmentNodeCategory category() {
+    return category;
+  }
+
+  public boolean isProcessing() {
+    return category == DevelopmentNodeCategory.PROCESSING;
+  }
+
+  public boolean isOutput() {
+    return category == DevelopmentNodeCategory.OUTPUT;
+  }
+
+  public static Optional<DevelopmentNodeType> tryParse(String value) {
+    if (value == null || value.isBlank()) return Optional.empty();
+    try {
+      return Optional.of(valueOf(value.trim().toUpperCase(Locale.ROOT)));
+    } catch (IllegalArgumentException ignored) {
+      return Optional.empty();
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentNodeService.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentNodeService.java
@@ -1,21 +1,18 @@
 package io.yak.ops.business.development.service;
 
 import io.yak.ops.business.development.domain.DevelopmentNode;
+import io.yak.ops.business.development.domain.DevelopmentNodeType;
 import io.yak.ops.business.development.repository.DevelopmentDirectoryRepository;
 import io.yak.ops.business.development.repository.DevelopmentNodeRepository;
 import io.yak.ops.business.taskcatalog.service.TaskCatalogService;
 import io.yak.ops.spi.task.model.TaskAssetSource;
 import java.util.List;
-import java.util.Locale;
-import java.util.Set;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 /** Application service for lightweight data-development resource nodes. */
 @Service
 public class DevelopmentNodeService {
-
-  private static final Set<String> SUPPORTED_TYPES = Set.of("SQL", "SHELL", "HTTP", "PYTHON");
 
   private final DevelopmentNodeRepository repository;
   private final DevelopmentDirectoryRepository directoryRepository;
@@ -122,11 +119,11 @@ public class DevelopmentNodeService {
 
   private String normalizeType(String type) {
     if (type == null || type.isBlank()) throw new IllegalArgumentException("节点类型不能为空");
-    String normalized = type.trim().toUpperCase(Locale.ROOT);
-    if (!SUPPORTED_TYPES.contains(normalized)) {
-      throw new IllegalArgumentException("不支持的数据开发节点类型：" + normalized);
-    }
-    return normalized;
+    String normalized = type.trim().toUpperCase(java.util.Locale.ROOT);
+    DevelopmentNodeType nodeType = DevelopmentNodeType.tryParse(normalized)
+        .filter(DevelopmentNodeType::isProcessing)
+        .orElseThrow(() -> new IllegalArgumentException("不支持的数据开发节点类型：" + normalized));
+    return nodeType.name();
   }
 
   private Long normalizeProjectId(Long projectId) {

--- a/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/domain/DevelopmentNodeModelTest.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/domain/DevelopmentNodeModelTest.java
@@ -1,0 +1,53 @@
+package io.yak.ops.business.development.domain;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class DevelopmentNodeModelTest {
+
+  @Test
+  void classifiesProcessingAndOutputResponsibilities() {
+    assertEquals(DevelopmentNodeCategory.PROCESSING, DevelopmentNodeType.SQL.category());
+    assertEquals(DevelopmentNodeCategory.PROCESSING, DevelopmentNodeType.SHELL.category());
+    assertEquals(DevelopmentNodeCategory.PROCESSING, DevelopmentNodeType.HTTP.category());
+    assertEquals(DevelopmentNodeCategory.PROCESSING, DevelopmentNodeType.PYTHON.category());
+    assertEquals(DevelopmentNodeCategory.OUTPUT, DevelopmentNodeType.DATASET.category());
+    assertEquals(DevelopmentNodeCategory.OUTPUT, DevelopmentNodeType.DATA_SERVICE.category());
+  }
+
+  @Test
+  void allowsOnlyThePhaseOneDagContract() {
+    assertTrue(DevelopmentNodeConnectionPolicy.canConnect(
+        DevelopmentNodeType.SQL, DevelopmentNodeType.SQL));
+    assertTrue(DevelopmentNodeConnectionPolicy.canConnect(
+        DevelopmentNodeType.SQL, DevelopmentNodeType.DATASET));
+    assertTrue(DevelopmentNodeConnectionPolicy.canConnect(
+        DevelopmentNodeType.SQL, DevelopmentNodeType.DATA_SERVICE));
+    assertTrue(DevelopmentNodeConnectionPolicy.canConnect(
+        DevelopmentNodeType.DATASET, DevelopmentNodeType.DATA_SERVICE));
+
+    assertFalse(DevelopmentNodeConnectionPolicy.canConnect(
+        DevelopmentNodeType.DATASET, DevelopmentNodeType.SQL));
+    assertFalse(DevelopmentNodeConnectionPolicy.canConnect(
+        DevelopmentNodeType.DATASET, DevelopmentNodeType.DATASET));
+    assertFalse(DevelopmentNodeConnectionPolicy.canConnect(
+        DevelopmentNodeType.DATA_SERVICE, DevelopmentNodeType.SQL));
+    assertFalse(DevelopmentNodeConnectionPolicy.canConnect(
+        DevelopmentNodeType.DATA_SERVICE, DevelopmentNodeType.DATASET));
+    assertFalse(DevelopmentNodeConnectionPolicy.canConnect(
+        DevelopmentNodeType.DATA_SERVICE, DevelopmentNodeType.DATA_SERVICE));
+  }
+
+  @Test
+  void leavesUnspecifiedProcessingEdgesClosed() {
+    assertFalse(DevelopmentNodeConnectionPolicy.canConnect(
+        DevelopmentNodeType.SHELL, DevelopmentNodeType.DATASET));
+    assertFalse(DevelopmentNodeConnectionPolicy.canConnect(
+        DevelopmentNodeType.HTTP, DevelopmentNodeType.DATA_SERVICE));
+    assertFalse(DevelopmentNodeConnectionPolicy.canConnect(
+        DevelopmentNodeType.PYTHON, DevelopmentNodeType.SQL));
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/DevelopmentOutputNodeReservationTest.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/DevelopmentOutputNodeReservationTest.java
@@ -1,0 +1,27 @@
+package io.yak.ops.business.development.service;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+import io.yak.ops.business.development.repository.DevelopmentDirectoryRepository;
+import io.yak.ops.business.development.repository.DevelopmentNodeRepository;
+import io.yak.ops.business.taskcatalog.service.TaskCatalogService;
+import org.junit.jupiter.api.Test;
+
+class DevelopmentOutputNodeReservationTest {
+
+  @Test
+  void outputNodeTypesStayReservedUntilTheirNodeLifecycleIsImplemented() {
+    DevelopmentNodeService service = new DevelopmentNodeService(
+        mock(DevelopmentNodeRepository.class),
+        mock(DevelopmentDirectoryRepository.class),
+        mock(TaskCatalogService.class));
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> service.create("订单数据集", "DATASET", null, null));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> service.create("订单查询 API", "DATA_SERVICE", null, null));
+  }
+}

--- a/yak-ops-ui/src/pages/data-development/node-model.test.ts
+++ b/yak-ops-ui/src/pages/data-development/node-model.test.ts
@@ -1,0 +1,44 @@
+import {
+  NODE_CATEGORY_BY_TYPE,
+  canConnectNodes,
+  getNodeCategory,
+  type NodeType,
+} from './node-model';
+
+describe('data-development node model', () => {
+  it('classifies authoring nodes as processing and output nodes as output', () => {
+    expect(NODE_CATEGORY_BY_TYPE).toEqual({
+      SQL: 'PROCESSING',
+      SHELL: 'PROCESSING',
+      HTTP: 'PROCESSING',
+      PYTHON: 'PROCESSING',
+      DATASET: 'OUTPUT',
+      DATA_SERVICE: 'OUTPUT',
+    });
+    expect(getNodeCategory('SQL')).toBe('PROCESSING');
+    expect(getNodeCategory('DATASET')).toBe('OUTPUT');
+    expect(getNodeCategory('DATA_SERVICE')).toBe('OUTPUT');
+  });
+
+  it.each<[NodeType, NodeType]>([
+    ['SQL', 'SQL'],
+    ['SQL', 'DATASET'],
+    ['SQL', 'DATA_SERVICE'],
+    ['DATASET', 'DATA_SERVICE'],
+  ])('allows %s -> %s', (source, target) => {
+    expect(canConnectNodes(source, target)).toBe(true);
+  });
+
+  it.each<[NodeType, NodeType]>([
+    ['DATASET', 'SQL'],
+    ['DATASET', 'DATASET'],
+    ['DATA_SERVICE', 'SQL'],
+    ['DATA_SERVICE', 'DATASET'],
+    ['DATA_SERVICE', 'DATA_SERVICE'],
+    ['SHELL', 'DATASET'],
+    ['HTTP', 'DATA_SERVICE'],
+    ['PYTHON', 'SQL'],
+  ])('rejects undeclared %s -> %s edges', (source, target) => {
+    expect(canConnectNodes(source, target)).toBe(false);
+  });
+});

--- a/yak-ops-ui/src/pages/data-development/node-model.ts
+++ b/yak-ops-ui/src/pages/data-development/node-model.ts
@@ -1,0 +1,42 @@
+import type { DevelopmentTaskType } from './types';
+
+/** High-level responsibility of a node inside the data-development DAG. */
+export type NodeCategory = 'PROCESSING' | 'OUTPUT';
+
+/** Output nodes are reserved in phase 1 and become creatable DAG nodes in phase 2. */
+export type DevelopmentOutputNodeType = 'DATASET' | 'DATA_SERVICE';
+
+/**
+ * Domain-level node type used by the data-development DAG.
+ *
+ * Existing authoring task types remain processing nodes. Dataset and Data Service are modeled now,
+ * but this phase intentionally does not expose them in the node palette or persistence workflow.
+ */
+export type NodeType = DevelopmentTaskType | DevelopmentOutputNodeType;
+
+export const NODE_CATEGORY_BY_TYPE = {
+  SQL: 'PROCESSING',
+  SHELL: 'PROCESSING',
+  HTTP: 'PROCESSING',
+  PYTHON: 'PROCESSING',
+  DATASET: 'OUTPUT',
+  DATA_SERVICE: 'OUTPUT',
+} as const satisfies Record<NodeType, NodeCategory>;
+
+/**
+ * Phase-1 DAG contract. Only product-approved edges are declared here; unsupported edges fail closed.
+ * Additional processing-node edges can be added when their DAG semantics are explicitly designed.
+ */
+export const NODE_CONNECTIONS = {
+  SQL: ['SQL', 'DATASET', 'DATA_SERVICE'],
+  SHELL: [],
+  HTTP: [],
+  PYTHON: [],
+  DATASET: ['DATA_SERVICE'],
+  DATA_SERVICE: [],
+} as const satisfies Record<NodeType, readonly NodeType[]>;
+
+export const getNodeCategory = (type: NodeType): NodeCategory => NODE_CATEGORY_BY_TYPE[type];
+
+export const canConnectNodes = (source: NodeType, target: NodeType): boolean =>
+  (NODE_CONNECTIONS[source] as readonly NodeType[]).includes(target);


### PR DESCRIPTION
## 背景

这是数据开发领域重构的 **Phase 1 / 7**：先建立新的节点职责模型，再迁移旧能力，最后删除旧逻辑。

本阶段只打地基，不改变现有业务流程。

## 本次改动

### 1. 建立统一节点职责模型

- `PROCESSING`
  - `SQL`
  - 现有 `SHELL / HTTP / PYTHON` 继续保留并归入 Processing
- `OUTPUT`
  - `DATASET`
  - `DATA_SERVICE`

前后端均建立同一套领域概念；`DATASET / DATA_SERVICE` 在本阶段仅预留，不开放创建。

### 2. 固化 DAG 连接约束

采用显式白名单、默认拒绝：

- `SQL -> SQL` ✅
- `SQL -> DATASET` ✅
- `SQL -> DATA_SERVICE` ✅
- `DATASET -> DATA_SERVICE` ✅（预留）
- `DATASET -> SQL` ❌
- `DATA_SERVICE -> SQL` ❌
- `DATA_SERVICE -> DATASET` ❌

当前没有明确产品语义的 `SHELL / HTTP / PYTHON` DAG 边暂时保持关闭，后续按节点语义单独开放，避免默认放通。

### 3. 保持现有业务兼容

`DevelopmentNodeService` 改为使用新的领域节点类型做校验，但当前创建入口仍只接受 `PROCESSING` 节点，因此现有 `SQL / SHELL / HTTP / PYTHON` 行为保持不变，输出节点不会在 Phase 1 被提前启用。

### 4. 增加模型测试

覆盖：

- Processing / Output 分类
- 允许的 DAG 边
- 禁止的 DAG 边
- `DATASET / DATA_SERVICE` 在当前节点创建生命周期中仍处于 reserved 状态

## 明确不做

- 不创建 Dataset 表 / 新 migration
- 不迁移 Dataset 业务
- 不修改 Data Service 后端发布逻辑
- 不在数据开发画布/节点栏中展示 Dataset / Data Service
- 不删除 SQL 页面现有“发布数据集 / 发布数据服务”能力
- 不改变现有数据开发业务流程

## 下一阶段

Phase 2 再把 `Dataset Node / Data Service Node` 作为 DAG 一级节点壳子放进画布，先支持创建、删除、移动、连线和持久化，不提前迁移业务能力。
