### PR TITLE
feat(data-development): add Dataset and Data Service DAG node shells

### DIFF
--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/controller/v1/DevelopmentGraphController.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/controller/v1/DevelopmentGraphController.java
@@ -1,0 +1,51 @@
+package io.yak.ops.business.development.controller.v1;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.yak.framework.common.Result;
+import io.yak.ops.business.development.domain.DevelopmentGraph;
+import io.yak.ops.business.development.domain.DevelopmentGraph.Edge;
+import io.yak.ops.business.development.domain.DevelopmentGraph.NodeLayout;
+import io.yak.ops.business.development.service.DevelopmentGraphService;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Project-scoped data-development DAG layout and topology endpoints. */
+@Tag(name = "数据开发 DAG 接口")
+@RestController
+@RequestMapping("/api/v1/data-development/graph")
+public class DevelopmentGraphController {
+
+  private final DevelopmentGraphService service;
+
+  public DevelopmentGraphController(DevelopmentGraphService service) {
+    this.service = service;
+  }
+
+  @Operation(summary = "读取数据开发 DAG")
+  @GetMapping
+  public Result<DevelopmentGraph> get(@RequestParam(required = false) Long projectId) {
+    return Result.success(service.get(projectId));
+  }
+
+  @Operation(summary = "保存数据开发 DAG")
+  @PutMapping
+  public Result<DevelopmentGraph> save(@Valid @RequestBody SaveRequest request) {
+    return Result.success(service.save(request.projectId(), request.nodes(), request.edges()));
+  }
+
+  public record SaveRequest(
+      @Min(0) Long projectId,
+      @NotNull @Size(max = 2000) List<NodeLayout> nodes,
+      @NotNull @Size(max = 4000) List<Edge> edges) {
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/domain/DevelopmentGraph.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/domain/DevelopmentGraph.java
@@ -1,0 +1,34 @@
+package io.yak.ops.business.development.domain;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import java.time.Instant;
+import java.util.List;
+
+/** Project-scoped graph document containing only canvas layout and dependency topology. */
+public record DevelopmentGraph(
+    @JsonSerialize(using = ToStringSerializer.class) Long projectId,
+    List<NodeLayout> nodes,
+    List<Edge> edges,
+    Instant updateTime) {
+
+  public DevelopmentGraph {
+    nodes = nodes == null ? List.of() : List.copyOf(nodes);
+    edges = edges == null ? List.of() : List.copyOf(edges);
+  }
+
+  public static DevelopmentGraph empty(Long projectId) {
+    return new DevelopmentGraph(projectId, List.of(), List.of(), null);
+  }
+
+  public record NodeLayout(
+      @JsonSerialize(using = ToStringSerializer.class) Long nodeId,
+      double x,
+      double y) {
+  }
+
+  public record Edge(
+      @JsonSerialize(using = ToStringSerializer.class) Long sourceNodeId,
+      @JsonSerialize(using = ToStringSerializer.class) Long targetNodeId) {
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/DevelopmentGraphRepository.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/DevelopmentGraphRepository.java
@@ -1,0 +1,91 @@
+package io.yak.ops.business.development.repository;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.development.domain.DevelopmentGraph;
+import io.yak.ops.business.development.domain.DevelopmentGraph.Edge;
+import io.yak.ops.business.development.domain.DevelopmentGraph.NodeLayout;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+/** Durable repository for the lightweight project-scoped DAG document. */
+@Repository
+public class DevelopmentGraphRepository {
+
+  private static final long DEFAULT_PROJECT_ID = 0L;
+
+  private final JdbcTemplate jdbcTemplate;
+  private final ObjectMapper objectMapper;
+
+  public DevelopmentGraphRepository(JdbcTemplate jdbcTemplate, ObjectMapper objectMapper) {
+    this.jdbcTemplate = jdbcTemplate;
+    this.objectMapper = objectMapper;
+  }
+
+  public Optional<DevelopmentGraph> findByProjectId(Long projectId) {
+    List<DevelopmentGraph> values = jdbcTemplate.query(
+        "SELECT project_id, graph_json, update_time FROM yak_dev_graph WHERE project_id = ?",
+        (rs, rowNum) -> {
+          GraphPayload payload = readPayload(rs.getString("graph_json"));
+          Timestamp updateTime = rs.getTimestamp("update_time");
+          return new DevelopmentGraph(
+              fromStoredProjectId(rs.getLong("project_id")),
+              payload.nodes(),
+              payload.edges(),
+              updateTime == null ? null : updateTime.toInstant());
+        },
+        toStoredProjectId(projectId));
+    return values.stream().findFirst();
+  }
+
+  public DevelopmentGraph save(DevelopmentGraph graph) {
+    long storedProjectId = toStoredProjectId(graph.projectId());
+    Instant now = Instant.now();
+    String graphJson = writePayload(graph);
+    jdbcTemplate.update(
+        "INSERT INTO yak_dev_graph(project_id, graph_json, create_time, update_time) "
+            + "VALUES (?, ?, ?, ?) ON DUPLICATE KEY UPDATE graph_json = VALUES(graph_json), "
+            + "update_time = VALUES(update_time)",
+        storedProjectId,
+        graphJson,
+        Timestamp.from(now),
+        Timestamp.from(now));
+    return new DevelopmentGraph(graph.projectId(), graph.nodes(), graph.edges(), now);
+  }
+
+  private String writePayload(DevelopmentGraph graph) {
+    try {
+      return objectMapper.writeValueAsString(new GraphPayload(graph.nodes(), graph.edges()));
+    } catch (JsonProcessingException exception) {
+      throw new IllegalStateException("序列化数据开发 DAG 失败", exception);
+    }
+  }
+
+  private GraphPayload readPayload(String value) {
+    if (value == null || value.isBlank()) return new GraphPayload(List.of(), List.of());
+    try {
+      return objectMapper.readValue(value, GraphPayload.class);
+    } catch (JsonProcessingException exception) {
+      throw new IllegalStateException("读取数据开发 DAG 失败", exception);
+    }
+  }
+
+  private long toStoredProjectId(Long projectId) {
+    return projectId == null || projectId <= 0L ? DEFAULT_PROJECT_ID : projectId;
+  }
+
+  private Long fromStoredProjectId(long projectId) {
+    return projectId == DEFAULT_PROJECT_ID ? null : projectId;
+  }
+
+  private record GraphPayload(List<NodeLayout> nodes, List<Edge> edges) {
+    private GraphPayload {
+      nodes = nodes == null ? List.of() : List.copyOf(nodes);
+      edges = edges == null ? List.of() : List.copyOf(edges);
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentGraphService.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentGraphService.java
@@ -1,0 +1,242 @@
+package io.yak.ops.business.development.service;
+
+import io.yak.ops.business.development.domain.DevelopmentGraph;
+import io.yak.ops.business.development.domain.DevelopmentGraph.Edge;
+import io.yak.ops.business.development.domain.DevelopmentGraph.NodeLayout;
+import io.yak.ops.business.development.domain.DevelopmentNode;
+import io.yak.ops.business.development.domain.DevelopmentNodeConnectionPolicy;
+import io.yak.ops.business.development.domain.DevelopmentNodeType;
+import io.yak.ops.business.development.repository.DevelopmentGraphRepository;
+import io.yak.ops.business.development.repository.DevelopmentNodeRepository;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Queue;
+import java.util.Set;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/** Owns the lightweight data-development DAG layout and topology lifecycle. */
+@Service
+public class DevelopmentGraphService {
+
+  private final DevelopmentGraphRepository graphRepository;
+  private final DevelopmentNodeRepository nodeRepository;
+
+  public DevelopmentGraphService(
+      DevelopmentGraphRepository graphRepository,
+      DevelopmentNodeRepository nodeRepository) {
+    this.graphRepository = graphRepository;
+    this.nodeRepository = nodeRepository;
+  }
+
+  public DevelopmentGraph get(Long projectId) {
+    Long scopeProjectId = normalizeProjectId(projectId);
+    DevelopmentGraph graph = graphRepository.findByProjectId(scopeProjectId)
+        .orElseGet(() -> DevelopmentGraph.empty(scopeProjectId));
+    return sanitize(scopeProjectId, graph);
+  }
+
+  @Transactional(transactionManager = "yakBusinessTransactionManager", rollbackFor = Exception.class)
+  public DevelopmentGraph save(
+      Long projectId,
+      List<NodeLayout> layouts,
+      List<Edge> edges) {
+    Long scopeProjectId = normalizeProjectId(projectId);
+    List<NodeLayout> normalizedLayouts = normalizeLayouts(
+        scopeProjectId,
+        layouts == null ? List.of() : layouts);
+    List<Edge> normalizedEdges = normalizeEdges(
+        scopeProjectId,
+        normalizedLayouts,
+        edges == null ? List.of() : edges);
+    ensureAcyclic(normalizedLayouts, normalizedEdges);
+    return graphRepository.save(
+        new DevelopmentGraph(scopeProjectId, normalizedLayouts, normalizedEdges, null));
+  }
+
+  private DevelopmentGraph sanitize(Long projectId, DevelopmentGraph graph) {
+    Map<Long, DevelopmentNode> availableNodes = nodesForProject(projectId);
+    Map<Long, NodeLayout> layoutByNodeId = new LinkedHashMap<>();
+    for (NodeLayout layout : graph.nodes()) {
+      if (!validLayout(layout) || !availableNodes.containsKey(layout.nodeId())) continue;
+      layoutByNodeId.putIfAbsent(layout.nodeId(), layout);
+    }
+
+    List<Edge> acceptedEdges = new ArrayList<>();
+    Set<String> edgeKeys = new HashSet<>();
+    for (Edge edge : graph.edges()) {
+      if (!validEdgeShape(edge)) continue;
+      if (!layoutByNodeId.containsKey(edge.sourceNodeId())
+          || !layoutByNodeId.containsKey(edge.targetNodeId())) {
+        continue;
+      }
+      DevelopmentNode source = availableNodes.get(edge.sourceNodeId());
+      DevelopmentNode target = availableNodes.get(edge.targetNodeId());
+      if (!connectionAllowed(source, target)) continue;
+      String key = edgeKey(edge);
+      if (!edgeKeys.add(key)) continue;
+      List<Edge> candidate = new ArrayList<>(acceptedEdges);
+      candidate.add(edge);
+      if (hasCycle(layoutByNodeId.keySet(), candidate)) continue;
+      acceptedEdges.add(edge);
+    }
+
+    List<NodeLayout> sanitizedLayouts = layoutByNodeId.values().stream()
+        .sorted(Comparator.comparing(NodeLayout::nodeId))
+        .toList();
+    List<Edge> sanitizedEdges = acceptedEdges.stream()
+        .sorted(Comparator
+            .comparing(Edge::sourceNodeId)
+            .thenComparing(Edge::targetNodeId))
+        .toList();
+    return new DevelopmentGraph(projectId, sanitizedLayouts, sanitizedEdges, graph.updateTime());
+  }
+
+  private List<NodeLayout> normalizeLayouts(
+      Long projectId,
+      List<NodeLayout> layouts) {
+    Map<Long, DevelopmentNode> availableNodes = nodesForProject(projectId);
+    Map<Long, NodeLayout> normalized = new LinkedHashMap<>();
+    for (NodeLayout layout : layouts) {
+      if (!validLayout(layout)) {
+        throw new IllegalArgumentException("DAG 节点布局无效");
+      }
+      if (!availableNodes.containsKey(layout.nodeId())) {
+        throw new IllegalArgumentException("DAG 节点不存在或不属于当前项目：" + layout.nodeId());
+      }
+      if (normalized.putIfAbsent(layout.nodeId(), layout) != null) {
+        throw new IllegalArgumentException("DAG 节点布局重复：" + layout.nodeId());
+      }
+    }
+    return normalized.values().stream()
+        .sorted(Comparator.comparing(NodeLayout::nodeId))
+        .toList();
+  }
+
+  private List<Edge> normalizeEdges(
+      Long projectId,
+      List<NodeLayout> layouts,
+      List<Edge> edges) {
+    Map<Long, DevelopmentNode> availableNodes = nodesForProject(projectId);
+    Set<Long> layoutNodeIds = layouts.stream()
+        .map(NodeLayout::nodeId)
+        .collect(java.util.stream.Collectors.toSet());
+    Set<String> edgeKeys = new HashSet<>();
+    List<Edge> normalized = new ArrayList<>();
+
+    for (Edge edge : edges) {
+      if (!validEdgeShape(edge)) {
+        throw new IllegalArgumentException("DAG 连线无效");
+      }
+      if (!layoutNodeIds.contains(edge.sourceNodeId())
+          || !layoutNodeIds.contains(edge.targetNodeId())) {
+        throw new IllegalArgumentException("DAG 连线端点不在当前画布中");
+      }
+      DevelopmentNode source = availableNodes.get(edge.sourceNodeId());
+      DevelopmentNode target = availableNodes.get(edge.targetNodeId());
+      if (source == null || target == null) {
+        throw new IllegalArgumentException("DAG 连线节点不存在或不属于当前项目");
+      }
+      if (!connectionAllowed(source, target)) {
+        throw new IllegalArgumentException(
+            "不允许的数据开发 DAG 连线：" + source.type() + " -> " + target.type());
+      }
+      if (!edgeKeys.add(edgeKey(edge))) {
+        throw new IllegalArgumentException("DAG 连线重复");
+      }
+      normalized.add(edge);
+    }
+
+    return normalized.stream()
+        .sorted(Comparator
+            .comparing(Edge::sourceNodeId)
+            .thenComparing(Edge::targetNodeId))
+        .toList();
+  }
+
+  private Map<Long, DevelopmentNode> nodesForProject(Long projectId) {
+    Map<Long, DevelopmentNode> result = new HashMap<>();
+    for (DevelopmentNode node : nodeRepository.list()) {
+      if (Objects.equals(normalizeProjectId(node.projectId()), projectId)) {
+        result.put(node.id(), node);
+      }
+    }
+    return result;
+  }
+
+  private boolean connectionAllowed(DevelopmentNode source, DevelopmentNode target) {
+    if (source == null || target == null || Objects.equals(source.id(), target.id())) return false;
+    DevelopmentNodeType sourceType = DevelopmentNodeType.tryParse(source.type()).orElse(null);
+    DevelopmentNodeType targetType = DevelopmentNodeType.tryParse(target.type()).orElse(null);
+    return DevelopmentNodeConnectionPolicy.canConnect(sourceType, targetType);
+  }
+
+  private boolean validLayout(NodeLayout layout) {
+    return layout != null
+        && layout.nodeId() != null
+        && layout.nodeId() > 0L
+        && Double.isFinite(layout.x())
+        && Double.isFinite(layout.y());
+  }
+
+  private boolean validEdgeShape(Edge edge) {
+    return edge != null
+        && edge.sourceNodeId() != null
+        && edge.sourceNodeId() > 0L
+        && edge.targetNodeId() != null
+        && edge.targetNodeId() > 0L
+        && !Objects.equals(edge.sourceNodeId(), edge.targetNodeId());
+  }
+
+  private String edgeKey(Edge edge) {
+    return edge.sourceNodeId() + "->" + edge.targetNodeId();
+  }
+
+  private void ensureAcyclic(
+      List<NodeLayout> layouts,
+      List<Edge> edges) {
+    Set<Long> nodeIds = layouts.stream()
+        .map(NodeLayout::nodeId)
+        .collect(java.util.stream.Collectors.toSet());
+    if (hasCycle(nodeIds, edges)) {
+      throw new IllegalArgumentException("数据开发 DAG 不能形成循环依赖");
+    }
+  }
+
+  private boolean hasCycle(Set<Long> nodeIds, List<Edge> edges) {
+    Map<Long, Integer> indegree = new HashMap<>();
+    Map<Long, List<Long>> outgoing = new HashMap<>();
+    nodeIds.forEach(nodeId -> indegree.put(nodeId, 0));
+    for (Edge edge : edges) {
+      outgoing.computeIfAbsent(edge.sourceNodeId(), ignored -> new ArrayList<>())
+          .add(edge.targetNodeId());
+      indegree.computeIfPresent(edge.targetNodeId(), (ignored, value) -> value + 1);
+    }
+
+    Queue<Long> queue = new ArrayDeque<>();
+    indegree.forEach((nodeId, value) -> {
+      if (value == 0) queue.add(nodeId);
+    });
+    int visited = 0;
+    while (!queue.isEmpty()) {
+      Long source = queue.remove();
+      visited++;
+      for (Long target : outgoing.getOrDefault(source, List.of())) {
+        Integer next = indegree.computeIfPresent(target, (ignored, value) -> value - 1);
+        if (next != null && next == 0) queue.add(target);
+      }
+    }
+    return visited != nodeIds.size();
+  }
+
+  private Long normalizeProjectId(Long projectId) {
+    return projectId == null || projectId <= 0L ? null : projectId;
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentNodeService.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentNodeService.java
@@ -72,12 +72,14 @@ public class DevelopmentNodeService {
     }
     DevelopmentNode renamed = repository.findById(id)
         .orElseThrow(() -> new IllegalStateException("节点重命名成功但无法重新读取：" + id));
-    taskCatalogService.updateSourceMetadata(
-        TaskAssetSource.DATA_DEVELOPMENT,
-        String.valueOf(renamed.id()),
-        renamed.projectId(),
-        renamed.name(),
-        renamed.type());
+    if (isProcessingType(renamed.type())) {
+      taskCatalogService.updateSourceMetadata(
+          TaskAssetSource.DATA_DEVELOPMENT,
+          String.valueOf(renamed.id()),
+          renamed.projectId(),
+          renamed.name(),
+          renamed.type());
+    }
     return renamed;
   }
 
@@ -100,9 +102,11 @@ public class DevelopmentNodeService {
     if (!repository.deleteById(id)) {
       throw new IllegalStateException("节点删除失败：" + id);
     }
-    taskCatalogService.offlineSource(
-        TaskAssetSource.DATA_DEVELOPMENT,
-        String.valueOf(current.id()));
+    if (isProcessingType(current.type())) {
+      taskCatalogService.offlineSource(
+          TaskAssetSource.DATA_DEVELOPMENT,
+          String.valueOf(current.id()));
+    }
   }
 
   private String normalizeName(String name) {
@@ -120,10 +124,15 @@ public class DevelopmentNodeService {
   private String normalizeType(String type) {
     if (type == null || type.isBlank()) throw new IllegalArgumentException("节点类型不能为空");
     String normalized = type.trim().toUpperCase(java.util.Locale.ROOT);
-    DevelopmentNodeType nodeType = DevelopmentNodeType.tryParse(normalized)
-        .filter(DevelopmentNodeType::isProcessing)
-        .orElseThrow(() -> new IllegalArgumentException("不支持的数据开发节点类型：" + normalized));
-    return nodeType.name();
+    return DevelopmentNodeType.tryParse(normalized)
+        .orElseThrow(() -> new IllegalArgumentException("不支持的数据开发节点类型：" + normalized))
+        .name();
+  }
+
+  private boolean isProcessingType(String type) {
+    return DevelopmentNodeType.tryParse(type)
+        .map(DevelopmentNodeType::isProcessing)
+        .orElse(false);
   }
 
   private Long normalizeProjectId(Long projectId) {

--- a/yak-ops-business/yak-ops-business-data-development/src/main/resources/db/migration/yak-data-development/V9__add_development_graph.sql
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/resources/db/migration/yak-data-development/V9__add_development_graph.sql
@@ -1,0 +1,8 @@
+-- Lightweight canvas document for data-development DAG topology and layout.
+CREATE TABLE IF NOT EXISTS yak_dev_graph (
+    project_id BIGINT NOT NULL DEFAULT 0,
+    graph_json LONGTEXT NOT NULL,
+    create_time DATETIME(6) NOT NULL,
+    update_time DATETIME(6) NOT NULL,
+    PRIMARY KEY (project_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/DevelopmentGraphServiceTest.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/DevelopmentGraphServiceTest.java
@@ -1,0 +1,99 @@
+package io.yak.ops.business.development.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.development.domain.DevelopmentGraph;
+import io.yak.ops.business.development.domain.DevelopmentGraph.Edge;
+import io.yak.ops.business.development.domain.DevelopmentGraph.NodeLayout;
+import io.yak.ops.business.development.domain.DevelopmentNode;
+import io.yak.ops.business.development.repository.DevelopmentGraphRepository;
+import io.yak.ops.business.development.repository.DevelopmentNodeRepository;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class DevelopmentGraphServiceTest {
+
+  @Test
+  void savesAllowedSqlDatasetAndDataServiceTopology() {
+    DevelopmentGraphRepository graphs = mock(DevelopmentGraphRepository.class);
+    DevelopmentNodeRepository nodes = mock(DevelopmentNodeRepository.class);
+    when(nodes.list()).thenReturn(List.of(
+        node(1L, "SQL"), node(2L, "DATASET"), node(3L, "DATA_SERVICE")));
+    when(graphs.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+    DevelopmentGraphService service = new DevelopmentGraphService(graphs, nodes);
+
+    DevelopmentGraph saved = service.save(
+        9L,
+        List.of(layout(1L, 10, 20), layout(2L, 300, 20), layout(3L, 590, 20)),
+        List.of(edge(1L, 2L), edge(2L, 3L)));
+
+    assertEquals(3, saved.nodes().size());
+    assertEquals(2, saved.edges().size());
+  }
+
+  @Test
+  void rejectsConnectionThatViolatesNodePolicy() {
+    DevelopmentGraphRepository graphs = mock(DevelopmentGraphRepository.class);
+    DevelopmentNodeRepository nodes = mock(DevelopmentNodeRepository.class);
+    when(nodes.list()).thenReturn(List.of(node(1L, "SQL"), node(2L, "DATASET")));
+    DevelopmentGraphService service = new DevelopmentGraphService(graphs, nodes);
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> service.save(
+            9L,
+            List.of(layout(1L, 0, 0), layout(2L, 200, 0)),
+            List.of(edge(2L, 1L))));
+  }
+
+  @Test
+  void rejectsCyclesEvenWhenEveryIndividualEdgeIsAllowed() {
+    DevelopmentGraphRepository graphs = mock(DevelopmentGraphRepository.class);
+    DevelopmentNodeRepository nodes = mock(DevelopmentNodeRepository.class);
+    when(nodes.list()).thenReturn(List.of(node(1L, "SQL"), node(2L, "SQL")));
+    DevelopmentGraphService service = new DevelopmentGraphService(graphs, nodes);
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> service.save(
+            9L,
+            List.of(layout(1L, 0, 0), layout(2L, 200, 0)),
+            List.of(edge(1L, 2L), edge(2L, 1L))));
+  }
+
+  @Test
+  void ignoresStaleGraphEntriesWhenAResourceWasDeleted() {
+    DevelopmentGraphRepository graphs = mock(DevelopmentGraphRepository.class);
+    DevelopmentNodeRepository nodes = mock(DevelopmentNodeRepository.class);
+    when(nodes.list()).thenReturn(List.of(node(1L, "SQL")));
+    when(graphs.findByProjectId(9L)).thenReturn(Optional.of(new DevelopmentGraph(
+        9L,
+        List.of(layout(1L, 0, 0), layout(2L, 200, 0)),
+        List.of(edge(1L, 2L)),
+        Instant.now())));
+    DevelopmentGraphService service = new DevelopmentGraphService(graphs, nodes);
+
+    DevelopmentGraph hydrated = service.get(9L);
+    assertEquals(List.of(layout(1L, 0, 0)), hydrated.nodes());
+    assertEquals(List.of(), hydrated.edges());
+  }
+
+  private DevelopmentNode node(Long id, String type) {
+    Instant now = Instant.now();
+    return new DevelopmentNode(id, type + " " + id, type, 9L, null, false, now, now, null, false);
+  }
+
+  private NodeLayout layout(Long id, double x, double y) {
+    return new NodeLayout(id, x, y);
+  }
+
+  private Edge edge(Long source, Long target) {
+    return new Edge(source, target);
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/DevelopmentOutputNodeReservationTest.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/DevelopmentOutputNodeReservationTest.java
@@ -1,27 +1,55 @@
 package io.yak.ops.business.development.service;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import io.yak.ops.business.development.domain.DevelopmentNode;
 import io.yak.ops.business.development.repository.DevelopmentDirectoryRepository;
 import io.yak.ops.business.development.repository.DevelopmentNodeRepository;
 import io.yak.ops.business.taskcatalog.service.TaskCatalogService;
+import io.yak.ops.spi.task.model.TaskAssetSource;
+import java.time.Instant;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
+/** Phase 2 intentionally lifts the Phase-1 output-node reservation. */
 class DevelopmentOutputNodeReservationTest {
 
   @Test
-  void outputNodeTypesStayReservedUntilTheirNodeLifecycleIsImplemented() {
-    DevelopmentNodeService service = new DevelopmentNodeService(
-        mock(DevelopmentNodeRepository.class),
-        mock(DevelopmentDirectoryRepository.class),
-        mock(TaskCatalogService.class));
+  void outputNodeTypesBecomeCreatableWithoutEnteringTaskCatalogLifecycle() {
+    DevelopmentNodeRepository nodes = mock(DevelopmentNodeRepository.class);
+    DevelopmentDirectoryRepository directories = mock(DevelopmentDirectoryRepository.class);
+    TaskCatalogService catalog = mock(TaskCatalogService.class);
+    DevelopmentNodeService service = new DevelopmentNodeService(nodes, directories, catalog);
 
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> service.create("订单数据集", "DATASET", null, null));
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> service.create("订单查询 API", "DATA_SERVICE", null, null));
+    when(nodes.existsByName(any(), any())).thenReturn(false);
+    when(nodes.insert(any(), any(), any(), any(), anyBoolean())).thenAnswer(invocation ->
+        node(10L,
+            invocation.getArgument(0),
+            invocation.getArgument(1),
+            invocation.getArgument(2)));
+
+    DevelopmentNode dataset = service.create("订单数据集", "dataset", 7L, null);
+    DevelopmentNode dataService = service.create("订单查询 API", "data_service", 7L, null);
+
+    assertEquals("DATASET", dataset.type());
+    assertEquals("DATA_SERVICE", dataService.type());
+
+    when(nodes.findById(10L)).thenReturn(Optional.of(dataset));
+    when(nodes.deleteById(10L)).thenReturn(true);
+    service.delete(10L);
+    verify(catalog, never()).offlineSource(eq(TaskAssetSource.DATA_DEVELOPMENT), any());
+  }
+
+  private DevelopmentNode node(Long id, String name, String type, Long projectId) {
+    Instant now = Instant.now();
+    return new DevelopmentNode(
+        id, name, type, projectId, null, false, now, now, "tester", false);
   }
 }

--- a/yak-ops-ui/src/pages/data-development/components/DevelopmentEditorWorkspace.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/DevelopmentEditorWorkspace.tsx
@@ -1,1 +1,110 @@
-export { default } from './workbench/DevelopmentWorkbench';
+import { Button, Segmented } from 'antd';
+import { GitFork, PanelTop } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+
+import { isDevelopmentTaskNode } from '../node-model';
+import type {
+  DevelopmentDirectory,
+  DevelopmentId,
+  DevelopmentResourceNode,
+} from '../types';
+import DevelopmentDagCanvas from './dag/DevelopmentDagCanvas';
+import DevelopmentWorkbench from './workbench/DevelopmentWorkbench';
+
+interface DevelopmentEditorWorkspaceProps {
+  nodes: DevelopmentResourceNode[];
+  directories: DevelopmentDirectory[];
+  selectedNodeId?: DevelopmentId;
+  onNodeFocus: (nodeId?: DevelopmentId) => void;
+  onNodesChanged?: () => void | Promise<void>;
+}
+
+type WorkspaceView = 'dag' | 'editor';
+
+export default function DevelopmentEditorWorkspace({
+  nodes,
+  directories,
+  selectedNodeId,
+  onNodeFocus,
+  onNodesChanged,
+}: DevelopmentEditorWorkspaceProps) {
+  const [view, setView] = useState<WorkspaceView>('dag');
+  const selectedResource = useMemo(
+    () => nodes.find((node) => node.id === selectedNodeId),
+    [nodes, selectedNodeId],
+  );
+  const taskNodes = useMemo(() => nodes.filter(isDevelopmentTaskNode), [nodes]);
+  const selectedTaskId = selectedResource && isDevelopmentTaskNode(selectedResource)
+    ? selectedResource.id
+    : undefined;
+
+  useEffect(() => {
+    if (!selectedResource) return;
+    setView(isDevelopmentTaskNode(selectedResource) ? 'editor' : 'dag');
+  }, [selectedResource]);
+
+  const openEditor = (nodeId: DevelopmentId) => {
+    onNodeFocus(nodeId);
+    setView('editor');
+  };
+
+  return (
+    <main className="flex min-w-0 flex-1 flex-col overflow-hidden bg-white">
+      <div className="flex h-9 shrink-0 items-center justify-between border-b border-[#e4e7ec] bg-[#fafafa] px-2.5">
+        <Segmented
+          size="small"
+          value={view}
+          options={[
+            {
+              label: (
+                <span className="inline-flex items-center gap-1.5">
+                  <GitFork size={12} /> DAG 画布
+                </span>
+              ),
+              value: 'dag',
+            },
+            {
+              label: (
+                <span className="inline-flex items-center gap-1.5">
+                  <PanelTop size={12} /> 节点编辑
+                </span>
+              ),
+              value: 'editor',
+              disabled: !selectedTaskId,
+            },
+          ]}
+          onChange={(value) => setView(value as WorkspaceView)}
+        />
+        {view === 'editor' && selectedTaskId ? (
+          <Button
+            type="text"
+            size="small"
+            icon={<GitFork size={12} />}
+            onClick={() => setView('dag')}
+            className="!text-[11px] !text-[#667085]"
+          >
+            返回 DAG
+          </Button>
+        ) : null}
+      </div>
+
+      {view === 'dag' ? (
+        <DevelopmentDagCanvas
+          resources={nodes}
+          directories={directories}
+          selectedNodeId={selectedNodeId}
+          onNodeOpen={openEditor}
+          onResourcesChanged={onNodesChanged}
+        />
+      ) : (
+        <DevelopmentWorkbench
+          nodes={taskNodes}
+          directories={directories}
+          selectedNodeId={selectedTaskId}
+          onNodeFocus={onNodeFocus}
+          onNodesChanged={onNodesChanged}
+        />
+      )}
+    </main>
+  );
+}

--- a/yak-ops-ui/src/pages/data-development/components/dag/DevelopmentDagCanvas.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/dag/DevelopmentDagCanvas.tsx
@@ -1,0 +1,473 @@
+import { API_SUCCESS_CODE } from '@/services/http/response';
+import { useSecurityProject } from '@/contexts/SecurityProjectContext';
+import { Button, Input, Modal, Select, Spin, Tooltip, message } from 'antd';
+import { Braces, Database, Network, Save } from 'lucide-react';
+import type { DragEvent } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import ReactFlow, {
+  Background,
+  Controls,
+  MiniMap,
+  addEdge,
+  type Connection,
+  type Edge,
+  type EdgeChange,
+  type Node,
+  type NodeChange,
+  type ReactFlowInstance,
+  useEdgesState,
+  useNodesState,
+} from 'reactflow';
+import 'reactflow/dist/style.css';
+
+import { canConnectNodes, isDevelopmentTaskNodeType } from '../../node-model';
+import {
+  createDevelopmentNode,
+  deleteDevelopmentNode,
+  getDevelopmentGraph,
+  saveDevelopmentGraph,
+} from '../../service';
+import type {
+  DevelopmentDirectory,
+  DevelopmentId,
+  DevelopmentNodeType,
+  DevelopmentResourceNode,
+} from '../../types';
+import DevelopmentDagNode, { type DevelopmentDagNodeData } from './DevelopmentDagNode';
+import { defaultDagPosition, wouldCreateCycle } from './dag-model';
+
+const NODE_DRAG_TYPE = 'application/yak-development-node-type';
+type DagFlowNode = Node<DevelopmentDagNodeData>;
+
+interface DevelopmentDagCanvasProps {
+  resources: DevelopmentResourceNode[];
+  directories: DevelopmentDirectory[];
+  selectedNodeId?: DevelopmentId;
+  onNodeOpen: (nodeId: DevelopmentId) => void;
+  onResourcesChanged?: () => void | Promise<void>;
+}
+
+interface PendingCreate {
+  type: 'SQL' | 'DATASET' | 'DATA_SERVICE';
+  position: { x: number; y: number };
+}
+
+const responseData = <T,>(
+  response: { code?: number; data?: T; msg?: string; message?: string },
+  fallback: string,
+): T => {
+  if (response?.code !== API_SUCCESS_CODE || response.data === undefined) {
+    throw new Error(response?.message || response?.msg || fallback);
+  }
+  return response.data;
+};
+
+const palette = [
+  { title: '数据处理', items: [{ type: 'SQL' as const, label: 'SQL', icon: <Braces size={15} /> }] },
+  {
+    title: '数据输出',
+    items: [
+      { type: 'DATASET' as const, label: '数据集', icon: <Database size={15} /> },
+      { type: 'DATA_SERVICE' as const, label: '数据服务', icon: <Network size={15} /> },
+    ],
+  },
+];
+
+const resourceInProject = (
+  resource: DevelopmentResourceNode,
+  projectId?: DevelopmentId,
+) => {
+  const resourceProjectId = resource.projectId ? String(resource.projectId) : undefined;
+  return projectId ? resourceProjectId === projectId : !resourceProjectId;
+};
+
+const typeLabel = (type: DevelopmentNodeType) => {
+  if (type === 'DATASET') return '数据集';
+  if (type === 'DATA_SERVICE') return '数据服务';
+  return type;
+};
+
+export default function DevelopmentDagCanvas({
+  resources,
+  directories,
+  selectedNodeId,
+  onNodeOpen,
+  onResourcesChanged,
+}: DevelopmentDagCanvasProps) {
+  const { currentProject } = useSecurityProject();
+  const projectId = currentProject?.id ? String(currentProject.id) : undefined;
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const draftPositionRef = useRef(new Map<DevelopmentId, { x: number; y: number }>());
+  const savedPositionRef = useRef(new Map<DevelopmentId, { x: number; y: number }>());
+  const [reactFlowInstance, setReactFlowInstance] = useState<ReactFlowInstance>();
+  const [flowNodes, setFlowNodes, onNodesChange] = useNodesState<DevelopmentDagNodeData>([]);
+  const [edges, setEdges, onEdgesChange] = useEdgesState([]);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [dirty, setDirty] = useState(false);
+  const [pendingCreate, setPendingCreate] = useState<PendingCreate>();
+  const [createName, setCreateName] = useState('');
+  const [createDirectoryId, setCreateDirectoryId] = useState<DevelopmentId>();
+  const [creating, setCreating] = useState(false);
+
+  const scopedResources = useMemo(
+    () => resources.filter((resource) => resourceInProject(resource, projectId)),
+    [projectId, resources],
+  );
+  const resourceMap = useMemo(
+    () => new Map(scopedResources.map((resource) => [resource.id, resource])),
+    [scopedResources],
+  );
+
+  const removeResource = useCallback((nodeId: DevelopmentId) => {
+    const resource = resourceMap.get(nodeId);
+    if (!resource) return;
+    Modal.confirm({
+      title: `删除${typeLabel(resource.type)}节点`,
+      content: `确认删除“${resource.name}”吗？相关 DAG 连线会一并从画布移除。`,
+      okText: '删除',
+      cancelText: '取消',
+      okButtonProps: { danger: true },
+      onOk: async () => {
+        responseData(await deleteDevelopmentNode(nodeId), '删除节点失败');
+        setFlowNodes((current) => current.filter((node) => node.id !== nodeId));
+        setEdges((current) => current.filter(
+          (edge) => edge.source !== nodeId && edge.target !== nodeId,
+        ));
+        setDirty(true);
+        await onResourcesChanged?.();
+        message.success('节点已删除');
+      },
+    });
+  }, [onResourcesChanged, resourceMap, setEdges, setFlowNodes]);
+
+  const toFlowNode = useCallback((
+    resource: DevelopmentResourceNode,
+    index: number,
+    existing?: DagFlowNode,
+  ): DagFlowNode => ({
+    id: resource.id,
+    type: 'development',
+    position:
+      existing?.position
+      || draftPositionRef.current.get(resource.id)
+      || savedPositionRef.current.get(resource.id)
+      || defaultDagPosition(index),
+    selected: selectedNodeId === resource.id,
+    deletable: false,
+    data: { resource, onDelete: removeResource },
+  }), [removeResource, selectedNodeId]);
+
+  useEffect(() => {
+    let active = true;
+    setLoading(true);
+    getDevelopmentGraph(projectId)
+      .then((response) => {
+        if (!active) return;
+        const graph = responseData(response, '加载数据开发 DAG 失败');
+        savedPositionRef.current = new Map(
+          graph.nodes.map((item) => [item.nodeId, { x: item.x, y: item.y }]),
+        );
+        setEdges(graph.edges.map((edge) => ({
+          id: `edge-${edge.sourceNodeId}-${edge.targetNodeId}`,
+          source: edge.sourceNodeId,
+          target: edge.targetNodeId,
+          type: 'smoothstep',
+        })));
+        setFlowNodes((current) => current.map((node) => {
+          const savedPosition = savedPositionRef.current.get(node.id);
+          return savedPosition ? { ...node, position: savedPosition } : node;
+        }));
+        setDirty(false);
+      })
+      .catch((error) => {
+        if (!active) return;
+        savedPositionRef.current = new Map();
+        setEdges([]);
+        message.error(error instanceof Error ? error.message : '加载数据开发 DAG 失败');
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [projectId, setEdges, setFlowNodes]);
+
+  useEffect(() => {
+    setFlowNodes((current) => {
+      const currentMap = new Map(current.map((node) => [node.id, node]));
+      return scopedResources.map((resource, index) =>
+        toFlowNode(resource, index, currentMap.get(resource.id)),
+      );
+    });
+    const ids = new Set(scopedResources.map((resource) => resource.id));
+    setEdges((current) => current.filter(
+      (edge) => ids.has(edge.source) && ids.has(edge.target),
+    ));
+  }, [scopedResources, setEdges, setFlowNodes, toFlowNode]);
+
+  useEffect(() => {
+    if (!selectedNodeId || !reactFlowInstance || !resourceMap.has(selectedNodeId)) return;
+    const node = flowNodes.find((item) => item.id === selectedNodeId);
+    if (!node) return;
+    reactFlowInstance.setCenter(node.position.x + 120, node.position.y + 45, {
+      zoom: Math.min(reactFlowInstance.getZoom(), 1),
+      duration: 220,
+    });
+  }, [flowNodes, reactFlowInstance, resourceMap, selectedNodeId]);
+
+  const handleNodesChange = useCallback((changes: NodeChange[]) => {
+    if (changes.some((change) => change.type === 'position')) setDirty(true);
+    onNodesChange(changes);
+  }, [onNodesChange]);
+
+  const handleEdgesChange = useCallback((changes: EdgeChange[]) => {
+    if (changes.some((change) => change.type === 'remove')) setDirty(true);
+    onEdgesChange(changes);
+  }, [onEdgesChange]);
+
+  const handleConnect = useCallback((connection: Connection) => {
+    if (!connection.source || !connection.target) return;
+    const source = resourceMap.get(connection.source);
+    const target = resourceMap.get(connection.target);
+    if (!source || !target) return;
+    if (!canConnectNodes(source.type, target.type)) {
+      message.warning(`暂不支持 ${typeLabel(source.type)} → ${typeLabel(target.type)} 的连接`);
+      return;
+    }
+    if (edges.some(
+      (edge) => edge.source === connection.source && edge.target === connection.target,
+    )) {
+      message.info('这条依赖关系已经存在');
+      return;
+    }
+    if (wouldCreateCycle(edges, connection.source, connection.target)) {
+      message.warning('数据开发 DAG 不能形成循环依赖');
+      return;
+    }
+    setEdges((current) => addEdge({
+      ...connection,
+      id: `edge-${connection.source}-${connection.target}`,
+      type: 'smoothstep',
+    }, current));
+    setDirty(true);
+  }, [edges, resourceMap, setEdges]);
+
+  const saveGraph = async () => {
+    setSaving(true);
+    try {
+      const saved = responseData(
+        await saveDevelopmentGraph({
+          projectId,
+          nodes: flowNodes.map((node) => ({
+            nodeId: node.id,
+            x: node.position.x,
+            y: node.position.y,
+          })),
+          edges: edges.map((edge) => ({
+            sourceNodeId: edge.source,
+            targetNodeId: edge.target,
+          })),
+        }),
+        '保存数据开发 DAG 失败',
+      );
+      savedPositionRef.current = new Map(
+        saved.nodes.map((item) => [item.nodeId, { x: item.x, y: item.y }]),
+      );
+      setDirty(false);
+      message.success('DAG 已保存');
+    } catch (error) {
+      message.error(error instanceof Error ? error.message : '保存数据开发 DAG 失败');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const onDragStart = (
+    event: DragEvent<HTMLDivElement>,
+    type: PendingCreate['type'],
+  ) => {
+    event.dataTransfer.setData(NODE_DRAG_TYPE, type);
+    event.dataTransfer.effectAllowed = 'copy';
+  };
+
+  const onDrop = (event: DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    if (!reactFlowInstance || !wrapperRef.current) return;
+    const type = event.dataTransfer.getData(NODE_DRAG_TYPE) as PendingCreate['type'];
+    if (!['SQL', 'DATASET', 'DATA_SERVICE'].includes(type)) return;
+    const bounds = wrapperRef.current.getBoundingClientRect();
+    const position = reactFlowInstance.project({
+      x: event.clientX - bounds.left,
+      y: event.clientY - bounds.top,
+    });
+    setPendingCreate({ type, position });
+    setCreateName('');
+    setCreateDirectoryId(undefined);
+  };
+
+  const createNode = async () => {
+    if (!pendingCreate || !createName.trim() || creating) return;
+    setCreating(true);
+    try {
+      const created = responseData(
+        await createDevelopmentNode({
+          name: createName.trim(),
+          type: pendingCreate.type,
+          projectId,
+          directoryId: createDirectoryId,
+        }),
+        '创建 DAG 节点失败',
+      );
+      draftPositionRef.current.set(created.id, pendingCreate.position);
+      setPendingCreate(undefined);
+      setCreateName('');
+      setDirty(true);
+      await onResourcesChanged?.();
+      message.success(`${typeLabel(created.type)}节点已创建`);
+    } catch (error) {
+      message.error(error instanceof Error ? error.message : '创建 DAG 节点失败');
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const nodeTypes = useMemo(() => ({ development: DevelopmentDagNode }), []);
+
+  return (
+    <div className="flex min-h-0 flex-1 overflow-hidden bg-white">
+      <aside className="w-[190px] shrink-0 border-r border-[#e4e7ec] bg-[#fafafa] px-3 py-3">
+        <div className="mb-3 text-[12px] font-semibold text-[#344054]">节点</div>
+        {palette.map((section) => (
+          <div key={section.title} className="mb-4">
+            <div className="mb-1.5 px-1 text-[10px] font-medium uppercase tracking-wide text-[#98a2b3]">
+              {section.title}
+            </div>
+            <div className="space-y-1.5">
+              {section.items.map((item) => (
+                <div
+                  key={item.type}
+                  draggable
+                  onDragStart={(event) => onDragStart(event, item.type)}
+                  className="flex cursor-grab items-center gap-2 rounded-lg border border-[#e4e7ec] bg-white px-2.5 py-2 text-[12px] text-[#344054] shadow-[0_1px_1px_rgba(16,24,40,.02)] transition hover:border-[#d0d5dd] hover:shadow-sm active:cursor-grabbing"
+                >
+                  <span className="text-[#667085]">{item.icon}</span>
+                  <span>{item.label}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        ))}
+        <div className="mt-5 rounded-lg bg-white px-2.5 py-2 text-[10px] leading-5 text-[#98a2b3]">
+          拖到画布创建节点。双击处理节点进入编辑器。
+        </div>
+      </aside>
+
+      <section className="flex min-w-0 flex-1 flex-col">
+        <div className="flex h-10 shrink-0 items-center justify-between border-b border-[#e4e7ec] px-3">
+          <div className="flex items-center gap-2 text-[12px] text-[#667085]">
+            <span className="font-medium text-[#344054]">DAG 画布</span>
+            <span>·</span>
+            <span>{flowNodes.length} 个节点</span>
+            <span>·</span>
+            <span>{edges.length} 条依赖</span>
+            {dirty ? <span className="text-[#f79009]">未保存</span> : null}
+          </div>
+          <Tooltip title={dirty ? '保存节点位置和依赖关系' : '当前 DAG 已保存'}>
+            <Button
+              size="small"
+              type="primary"
+              icon={<Save size={13} />}
+              loading={saving}
+              disabled={!dirty}
+              onClick={() => void saveGraph()}
+            >
+              保存 DAG
+            </Button>
+          </Tooltip>
+        </div>
+
+        <div
+          ref={wrapperRef}
+          className="relative min-h-0 flex-1"
+          onDragOver={(event) => {
+            event.preventDefault();
+            event.dataTransfer.dropEffect = 'copy';
+          }}
+          onDrop={onDrop}
+        >
+          <Spin spinning={loading} wrapperClassName="block h-full [&_.ant-spin-container]:h-full">
+            <ReactFlow
+              nodes={flowNodes}
+              edges={edges}
+              nodeTypes={nodeTypes}
+              onInit={setReactFlowInstance}
+              onNodesChange={handleNodesChange}
+              onEdgesChange={handleEdgesChange}
+              onConnect={handleConnect}
+              onNodeDoubleClick={(_, node) => {
+                if (isDevelopmentTaskNodeType(node.data.resource.type)) {
+                  onNodeOpen(node.id);
+                }
+              }}
+              fitView
+              fitViewOptions={{ padding: 0.2, maxZoom: 1 }}
+              minZoom={0.35}
+              maxZoom={1.5}
+              deleteKeyCode={['Backspace', 'Delete']}
+              defaultEdgeOptions={{ type: 'smoothstep' }}
+              className="bg-[#fcfcfd]"
+            >
+              <Background gap={20} size={1} color="#eceef1" />
+              <Controls showInteractive={false} />
+              <MiniMap pannable zoomable nodeStrokeWidth={1} />
+            </ReactFlow>
+          </Spin>
+        </div>
+      </section>
+
+      <Modal
+        open={Boolean(pendingCreate)}
+        title={`新建${pendingCreate ? typeLabel(pendingCreate.type) : ''}节点`}
+        okText="创建"
+        cancelText="取消"
+        confirmLoading={creating}
+        okButtonProps={{ disabled: !createName.trim() }}
+        maskClosable={!creating}
+        closable={!creating}
+        onCancel={() => {
+          if (!creating) setPendingCreate(undefined);
+        }}
+        onOk={() => void createNode()}
+      >
+        <div className="space-y-3 pt-2">
+          <div>
+            <div className="mb-1.5 text-[12px] text-[#475467]">名称</div>
+            <Input
+              autoFocus
+              maxLength={128}
+              value={createName}
+              placeholder={pendingCreate?.type === 'DATASET' ? '例如：用户分析数据集' : pendingCreate?.type === 'DATA_SERVICE' ? '例如：用户查询 API' : '例如：用户查询 SQL'}
+              onChange={(event) => setCreateName(event.target.value)}
+              onPressEnter={() => void createNode()}
+            />
+          </div>
+          <div>
+            <div className="mb-1.5 text-[12px] text-[#475467]">开发目录</div>
+            <Select
+              allowClear
+              showSearch
+              optionFilterProp="label"
+              className="w-full"
+              placeholder="根目录"
+              value={createDirectoryId}
+              options={directories.map((directory) => ({ value: directory.id, label: directory.path }))}
+              onChange={(value) => setCreateDirectoryId(value)}
+            />
+          </div>
+        </div>
+      </Modal>
+    </div>
+  );
+}

--- a/yak-ops-ui/src/pages/data-development/components/dag/DevelopmentDagNode.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/dag/DevelopmentDagNode.tsx
@@ -1,0 +1,120 @@
+import { Button, Tooltip } from 'antd';
+import {
+  Braces,
+  Database,
+  Network,
+  SquareTerminal,
+  Trash2,
+} from 'lucide-react';
+import type { ReactNode } from 'react';
+import { Handle, Position, type NodeProps } from 'reactflow';
+
+import { getNodeCategory } from '../../node-model';
+import type { DevelopmentResourceNode } from '../../types';
+
+export interface DevelopmentDagNodeData {
+  resource: DevelopmentResourceNode;
+  onDelete: (nodeId: string) => void;
+}
+
+const nodeIcon = (type: DevelopmentResourceNode['type']): ReactNode => {
+  if (type === 'DATASET') return <Database size={17} strokeWidth={1.8} />;
+  if (type === 'DATA_SERVICE') return <Network size={17} strokeWidth={1.8} />;
+  if (type === 'SHELL') return <SquareTerminal size={17} strokeWidth={1.8} />;
+  return <Braces size={17} strokeWidth={1.8} />;
+};
+
+const nodeTypeLabel = (type: DevelopmentResourceNode['type']) => {
+  if (type === 'DATASET') return '数据集';
+  if (type === 'DATA_SERVICE') return '数据服务';
+  if (type === 'SHELL') return 'Shell';
+  if (type === 'PYTHON') return 'Python';
+  if (type === 'HTTP') return 'HTTP';
+  return 'SQL';
+};
+
+const statusLabel = (resource: DevelopmentResourceNode) => {
+  if (resource.type === 'DATASET') return '未配置';
+  if (resource.type === 'DATA_SERVICE') return '未发布';
+  return resource.configured ? '已配置' : '未配置';
+};
+
+const canReceive = (type: DevelopmentResourceNode['type']) =>
+  type === 'SQL' || type === 'DATASET' || type === 'DATA_SERVICE';
+
+const canEmit = (type: DevelopmentResourceNode['type']) =>
+  type === 'SQL' || type === 'DATASET';
+
+export default function DevelopmentDagNode({
+  data,
+  selected,
+}: NodeProps<DevelopmentDagNodeData>) {
+  const { resource } = data;
+  const category = getNodeCategory(resource.type);
+
+  return (
+    <div className="group relative w-[242px]">
+      {canReceive(resource.type) ? (
+        <Handle
+          type="target"
+          position={Position.Left}
+          className="!h-2.5 !w-2.5 !border-2 !border-white !bg-[#98a2b3]"
+        />
+      ) : null}
+
+      <div
+        className={[
+          'rounded-xl border bg-white px-3.5 py-3 shadow-[0_1px_2px_rgba(16,24,40,.05)]',
+          'transition-[border-color,box-shadow] duration-150',
+          selected
+            ? 'border-[#fe2c55] shadow-[0_0_0_2px_rgba(254,44,85,.06)]'
+            : 'border-[#e4e7ec] group-hover:border-[#d0d5dd] group-hover:shadow-[0_5px_16px_rgba(16,24,40,.08)]',
+        ].join(' ')}
+      >
+        <div className="flex items-start gap-2.5">
+          <div className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-[#f5f5f6] text-[#475467]">
+            {nodeIcon(resource.type)}
+          </div>
+
+          <div className="min-w-0 flex-1">
+            <div className="truncate text-[13px] font-semibold leading-5 text-[#161823]">
+              {resource.name}
+            </div>
+            <div className="mt-0.5 flex items-center gap-1.5 text-[11px] text-[#98a2b3]">
+              <span>{nodeTypeLabel(resource.type)}</span>
+              <span>·</span>
+              <span>{category === 'OUTPUT' ? '数据输出' : '数据处理'}</span>
+            </div>
+          </div>
+
+          <Tooltip title="删除节点">
+            <Button
+              type="text"
+              size="small"
+              aria-label={`删除 ${resource.name}`}
+              icon={<Trash2 size={13} strokeWidth={1.8} />}
+              onClick={(event) => {
+                event.stopPropagation();
+                data.onDelete(resource.id);
+              }}
+              className="nodrag !-mr-1 !-mt-1 !hidden !h-7 !w-7 !items-center !justify-center !p-0 !text-[#98a2b3] group-hover:!flex hover:!bg-[#f5f5f6] hover:!text-[#475467]"
+            />
+          </Tooltip>
+        </div>
+
+        <div className="mt-3 flex items-center justify-between border-t border-[#f0f1f3] pt-2 text-[10px]">
+          <span className="text-[#98a2b3]">{resource.type}</span>
+          <span className="text-[#667085]">{statusLabel(resource)}</span>
+        </div>
+      </div>
+
+      {canEmit(resource.type) ? (
+        <Handle
+          type="source"
+          position={Position.Right}
+          className="!h-2.5 !w-2.5 !border-2 !border-white !bg-[#667085]"
+        />
+      ) : null}
+    </div>
+  );
+}

--- a/yak-ops-ui/src/pages/data-development/components/dag/dag-model.test.ts
+++ b/yak-ops-ui/src/pages/data-development/components/dag/dag-model.test.ts
@@ -1,0 +1,18 @@
+import { defaultDagPosition, wouldCreateCycle } from './dag-model';
+
+describe('data-development DAG helpers', () => {
+  it('detects a cycle before an edge is appended', () => {
+    const edges = [
+      { source: 'sql-1', target: 'sql-2' },
+      { source: 'sql-2', target: 'dataset-1' },
+    ];
+
+    expect(wouldCreateCycle(edges, 'dataset-1', 'sql-1')).toBe(true);
+    expect(wouldCreateCycle(edges, 'dataset-1', 'service-1')).toBe(false);
+  });
+
+  it('lays new resources out on a stable three-column grid', () => {
+    expect(defaultDagPosition(0)).toEqual({ x: 80, y: 80 });
+    expect(defaultDagPosition(3)).toEqual({ x: 80, y: 230 });
+  });
+});

--- a/yak-ops-ui/src/pages/data-development/components/dag/dag-model.ts
+++ b/yak-ops-ui/src/pages/data-development/components/dag/dag-model.ts
@@ -1,0 +1,30 @@
+import type { Edge } from 'reactflow';
+
+export const defaultDagPosition = (index: number) => ({
+  x: 80 + (index % 3) * 300,
+  y: 80 + Math.floor(index / 3) * 150,
+});
+
+/** Returns true if source -> target would make the current directed graph cyclic. */
+export const wouldCreateCycle = (
+  edges: Pick<Edge, 'source' | 'target'>[],
+  source: string,
+  target: string,
+): boolean => {
+  if (source === target) return true;
+  const outgoing = new Map<string, string[]>();
+  edges.forEach((edge) => {
+    outgoing.set(edge.source, [...(outgoing.get(edge.source) || []), edge.target]);
+  });
+
+  const pending = [target];
+  const visited = new Set<string>();
+  while (pending.length) {
+    const current = pending.pop();
+    if (!current || visited.has(current)) continue;
+    if (current === source) return true;
+    visited.add(current);
+    pending.push(...(outgoing.get(current) || []));
+  }
+  return false;
+};

--- a/yak-ops-ui/src/pages/data-development/index.tsx
+++ b/yak-ops-ui/src/pages/data-development/index.tsx
@@ -27,7 +27,7 @@ import {
 import type {
   DevelopmentDirectory,
   DevelopmentId,
-  DevelopmentNode,
+  DevelopmentResourceNode,
   DevelopmentTaskType,
 } from './types';
 
@@ -72,7 +72,7 @@ const responseData = <T,>(
 export default function DataDevelopmentPage() {
   const { currentProject } = useSecurityProject();
   const [directories, setDirectories] = useState<DevelopmentDirectory[]>([]);
-  const [nodes, setNodes] = useState<DevelopmentNode[]>([]);
+  const [nodes, setNodes] = useState<DevelopmentResourceNode[]>([]);
   const [treeLoading, setTreeLoading] = useState(false);
   const [treeKeyword, setTreeKeyword] = useState('');
   const [selectedNodeKey, setSelectedNodeKey] = useState<TreeNodeKey>();
@@ -403,6 +403,7 @@ export default function DataDevelopmentPage() {
             onNodeFocus={(nodeId) =>
               setSelectedNodeKey(nodeId ? nodeKey(nodeId) : undefined)
             }
+            onNodesChanged={loadTree}
           />
         </div>
 

--- a/yak-ops-ui/src/pages/data-development/node-model.ts
+++ b/yak-ops-ui/src/pages/data-development/node-model.ts
@@ -1,18 +1,15 @@
-import type { DevelopmentTaskType } from './types';
+import type {
+  DevelopmentNode,
+  DevelopmentNodeType,
+  DevelopmentOutputNodeType,
+  DevelopmentResourceNode,
+  DevelopmentTaskType,
+} from './types';
 
 /** High-level responsibility of a node inside the data-development DAG. */
 export type NodeCategory = 'PROCESSING' | 'OUTPUT';
-
-/** Output nodes are reserved in phase 1 and become creatable DAG nodes in phase 2. */
-export type DevelopmentOutputNodeType = 'DATASET' | 'DATA_SERVICE';
-
-/**
- * Domain-level node type used by the data-development DAG.
- *
- * Existing authoring task types remain processing nodes. Dataset and Data Service are modeled now,
- * but this phase intentionally does not expose them in the node palette or persistence workflow.
- */
-export type NodeType = DevelopmentTaskType | DevelopmentOutputNodeType;
+export type NodeType = DevelopmentNodeType;
+export type { DevelopmentOutputNodeType };
 
 export const NODE_CATEGORY_BY_TYPE = {
   SQL: 'PROCESSING',
@@ -23,10 +20,7 @@ export const NODE_CATEGORY_BY_TYPE = {
   DATA_SERVICE: 'OUTPUT',
 } as const satisfies Record<NodeType, NodeCategory>;
 
-/**
- * Phase-1 DAG contract. Only product-approved edges are declared here; unsupported edges fail closed.
- * Additional processing-node edges can be added when their DAG semantics are explicitly designed.
- */
+/** Product-approved DAG edges. Unsupported combinations fail closed. */
 export const NODE_CONNECTIONS = {
   SQL: ['SQL', 'DATASET', 'DATA_SERVICE'],
   SHELL: [],
@@ -36,7 +30,16 @@ export const NODE_CONNECTIONS = {
   DATA_SERVICE: [],
 } as const satisfies Record<NodeType, readonly NodeType[]>;
 
+const TASK_NODE_TYPES = new Set<NodeType>(['SQL', 'SHELL', 'HTTP', 'PYTHON']);
+
 export const getNodeCategory = (type: NodeType): NodeCategory => NODE_CATEGORY_BY_TYPE[type];
 
 export const canConnectNodes = (source: NodeType, target: NodeType): boolean =>
   (NODE_CONNECTIONS[source] as readonly NodeType[]).includes(target);
+
+export const isDevelopmentTaskNodeType = (type: NodeType): type is DevelopmentTaskType =>
+  TASK_NODE_TYPES.has(type);
+
+export const isDevelopmentTaskNode = (
+  node: DevelopmentResourceNode,
+): node is DevelopmentNode => isDevelopmentTaskNodeType(node.type);

--- a/yak-ops-ui/src/pages/data-development/service.ts
+++ b/yak-ops-ui/src/pages/data-development/service.ts
@@ -6,12 +6,13 @@ import type {
   CreateDevelopmentDirectoryPayload,
   CreateDevelopmentNodePayload,
   DevelopmentDirectory,
+  DevelopmentGraph,
   DevelopmentId,
-  DevelopmentNode,
   DevelopmentReleaseDetail,
   DevelopmentReleasePage,
   DevelopmentReleaseQuery,
   DevelopmentReleaseSummary,
+  DevelopmentResourceNode,
   DevelopmentTaskDefinition,
   DevelopmentTaskDraft,
   DevelopmentTaskExecutionDetail,
@@ -20,12 +21,14 @@ import type {
   DevelopmentTaskRevision,
   DevelopmentTaskRevisionSummary,
   DevelopmentTaskRunResult,
+  SaveDevelopmentGraphPayload,
   SaveDevelopmentTaskDraftPayload,
 } from './types';
 
 const DATA_DEVELOPMENT_API = '/api/v1/data-development';
 const DIRECTORY_API = `${DATA_DEVELOPMENT_API}/directories`;
 const NODE_API = `${DATA_DEVELOPMENT_API}/nodes`;
+const GRAPH_API = `${DATA_DEVELOPMENT_API}/graph`;
 const EXECUTION_API = `${DATA_DEVELOPMENT_API}/executions`;
 const RELEASE_API = `${DATA_DEVELOPMENT_API}/releases`;
 const EDITOR_SETTINGS_API = `${DATA_DEVELOPMENT_API}/editor-settings`;
@@ -48,23 +51,35 @@ export const deleteDevelopmentDirectory = (
   id: DevelopmentId,
 ): Promise<ApiResponse<boolean>> => HttpUtils.delete<boolean>(`${DIRECTORY_API}/${id}`);
 
-export const listDevelopmentNodes = (): Promise<ApiResponse<DevelopmentNode[]>> =>
-  HttpUtils.get<DevelopmentNode[]>(NODE_API);
+export const listDevelopmentNodes = (): Promise<ApiResponse<DevelopmentResourceNode[]>> =>
+  HttpUtils.get<DevelopmentResourceNode[]>(NODE_API);
 
 export const createDevelopmentNode = (
   payload: CreateDevelopmentNodePayload,
-): Promise<ApiResponse<DevelopmentNode>> =>
-  HttpUtils.post<DevelopmentNode>(NODE_API, payload);
+): Promise<ApiResponse<DevelopmentResourceNode>> =>
+  HttpUtils.post<DevelopmentResourceNode>(NODE_API, payload);
 
 export const renameDevelopmentNode = (
   id: DevelopmentId,
   name: string,
-): Promise<ApiResponse<DevelopmentNode>> =>
-  HttpUtils.put<DevelopmentNode>(`${NODE_API}/${id}/name`, { name });
+): Promise<ApiResponse<DevelopmentResourceNode>> =>
+  HttpUtils.put<DevelopmentResourceNode>(`${NODE_API}/${id}/name`, { name });
 
 export const deleteDevelopmentNode = (
   id: DevelopmentId,
 ): Promise<ApiResponse<boolean>> => HttpUtils.delete<boolean>(`${NODE_API}/${id}`);
+
+export const getDevelopmentGraph = (
+  projectId?: DevelopmentId,
+): Promise<ApiResponse<DevelopmentGraph>> =>
+  HttpUtils.get<DevelopmentGraph>(
+    `${GRAPH_API}${projectId ? `?projectId=${encodeURIComponent(projectId)}` : ''}`,
+  );
+
+export const saveDevelopmentGraph = (
+  payload: SaveDevelopmentGraphPayload,
+): Promise<ApiResponse<DevelopmentGraph>> =>
+  HttpUtils.put<DevelopmentGraph>(GRAPH_API, payload);
 
 export const getDevelopmentTaskDraft = (
   nodeId: DevelopmentId,

--- a/yak-ops-ui/src/pages/data-development/types.ts
+++ b/yak-ops-ui/src/pages/data-development/types.ts
@@ -1,4 +1,6 @@
 export type DevelopmentTaskType = 'SQL' | 'SHELL' | 'HTTP' | 'PYTHON';
+export type DevelopmentOutputNodeType = 'DATASET' | 'DATA_SERVICE';
+export type DevelopmentNodeType = DevelopmentTaskType | DevelopmentOutputNodeType;
 export type DevelopmentId = string;
 
 export interface DevelopmentDirectory {
@@ -15,10 +17,9 @@ export interface CreateDevelopmentDirectoryPayload {
   name: string;
 }
 
-export interface DevelopmentNode {
+export interface DevelopmentResourceNodeBase {
   id: DevelopmentId;
   name: string;
-  type: DevelopmentTaskType;
   projectId?: DevelopmentId | null;
   directoryId?: DevelopmentId | null;
   configured: boolean;
@@ -28,12 +29,48 @@ export interface DevelopmentNode {
   pendingPublish?: boolean;
 }
 
+/** Authoring/executable node managed by the existing task editor lifecycle. */
+export interface DevelopmentNode extends DevelopmentResourceNodeBase {
+  type: DevelopmentTaskType;
+}
+
+/** Phase-2 output node shell. Business configuration arrives in later phases. */
+export interface DevelopmentOutputNode extends DevelopmentResourceNodeBase {
+  type: DevelopmentOutputNodeType;
+}
+
+export type DevelopmentResourceNode = DevelopmentNode | DevelopmentOutputNode;
+
 export interface CreateDevelopmentNodePayload {
   name: string;
-  type: DevelopmentTaskType;
+  type: DevelopmentNodeType;
   projectId?: DevelopmentId;
   /** 省略表示数据开发根目录。 */
   directoryId?: DevelopmentId;
+}
+
+export interface DevelopmentGraphNodeLayout {
+  nodeId: DevelopmentId;
+  x: number;
+  y: number;
+}
+
+export interface DevelopmentGraphEdge {
+  sourceNodeId: DevelopmentId;
+  targetNodeId: DevelopmentId;
+}
+
+export interface DevelopmentGraph {
+  projectId?: DevelopmentId | null;
+  nodes: DevelopmentGraphNodeLayout[];
+  edges: DevelopmentGraphEdge[];
+  updateTime?: string | null;
+}
+
+export interface SaveDevelopmentGraphPayload {
+  projectId?: DevelopmentId;
+  nodes: DevelopmentGraphNodeLayout[];
+  edges: DevelopmentGraphEdge[];
 }
 
 export interface DevelopmentTaskDefinition {


### PR DESCRIPTION
## 背景

这是数据开发领域重构的 **Phase 2 / 7**。Phase 1 已经建立 Processing / Output 节点职责模型和 DAG 连接白名单；本阶段把 `Dataset Node / Data Service Node` 真正提升为数据开发 DAG 的一级节点，但仍只实现“节点壳子”，不提前迁移业务能力。

## 本次改动

### 1. Dataset / Data Service 解除 reserved 状态

`DevelopmentNodeService` 现在允许创建：

- `DATASET`
- `DATA_SERVICE`

它们仍然只是 Output Resource Node，不进入现有 Task Draft / Task Revision / TaskCatalog 生命周期。SQL / SHELL / HTTP / PYTHON 原有处理节点行为保持不变。

### 2. 新增数据开发 DAG 画布

数据开发工作区新增 `DAG 画布 / 节点编辑` 两种视图。

画布左侧节点栏：

```text
数据处理
────────
SQL

数据输出
────────
数据集
数据服务
```

支持：

- 拖入 SQL / Dataset / Data Service
- 创建节点
- 删除节点
- 移动节点
- 创建 / 删除连线
- 保存 DAG
- 刷新 / 重新打开后恢复节点位置和依赖关系
- 双击 Processing Node 返回现有节点编辑器

### 3. 轻量 Graph Document 持久化

新增 `yak_dev_graph`，只保存：

- Node Layout：`nodeId / x / y`
- DAG Edge：`sourceNodeId / targetNodeId`

不保存 Dataset 配置，不保存 Data Service 发布配置，避免 Phase 2 提前侵入后续领域模型。

Graph 按 Project 作用域保存；读取时会自动清理已删除节点留下的陈旧布局/边。

### 4. DAG 连接约束真正落地

前后端都使用 Phase 1 定义的规则：

- `SQL -> SQL` ✅
- `SQL -> DATASET` ✅
- `SQL -> DATA_SERVICE` ✅
- `DATASET -> DATA_SERVICE` ✅（预留）
- `DATASET -> SQL` ❌
- `DATA_SERVICE -> SQL` ❌
- `DATA_SERVICE -> DATASET` ❌

此外增加真正的 DAG 校验：

- 禁止自连接
- 禁止重复边
- 禁止形成循环依赖
- 校验节点必须属于当前 Project

客户端先做交互校验，服务端再次兜底。

### 5. 保持现有业务双轨运行

本阶段 **没有** 删除或迁移 SQL 现有能力：

- SQL 发布数据集：保留 ✅
- SQL 发布数据服务：保留 ✅
- Dataset 现有领域表/服务：不改 ✅
- Data Service 发布后端：不改 ✅

因此旧路径仍可继续使用，新 DAG 路径目前只是结构和交互底座。

## 测试 / 校验

新增测试覆盖：

- Output Node 在 Phase 2 可创建
- Output Node 不进入 TaskCatalog 生命周期
- `SQL -> Dataset -> Data Service` 合法拓扑
- 非法连接拒绝
- SQL 循环依赖拒绝
- 删除资源后的陈旧 Graph 数据自动清理
- 前端循环依赖判断和默认布局

另外对新增 TypeScript 文件做了 TypeScript `transpileModule` 语法检查，无语法错误。

当前执行环境没有仓库完整 checkout / node_modules / Maven 依赖，因此没有声明本地全量 `npm lint` / Maven test 已通过；PR 创建后以仓库 GitHub Checks 为最终集成校验依据。

## 明确不做

- 不实现 Dataset 字段/Schema 配置
- 不创建 Dataset Asset / Revision
- 不让 Data Service Node 调用现有 PublicationService
- 不迁移 SQL 当前发布按钮
- 不实现发布状态 / 有更新 / 回滚

这些分别留给 Phase 3、4、5、6。

## 下一阶段

Phase 3：实现 `SQL -> Dataset Node` MVP，让 Dataset 从“DAG 节点壳子”升级为真正的结构化数据资产，并优先绑定 SQL Revision。