### PR TITLE
refactor: tighten data development and workflow boundaries

### DIFF
--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/domain/DevelopmentNodeType.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/domain/DevelopmentNodeType.java
@@ -30,6 +30,19 @@ public enum DevelopmentNodeType {
     return category == DevelopmentNodeCategory.OUTPUT;
   }
 
+  /**
+   * Explicit authoring boundary for mutable draft -> immutable task revision -> Task Catalog.
+   *
+   * <p>Do not derive this from PROCESSING/OUTPUT at call sites. New node types must opt in here
+   * before they can enter the executable task lifecycle.
+   */
+  public boolean supportsTaskLifecycle() {
+    return switch (this) {
+      case SQL, SHELL, HTTP, PYTHON -> true;
+      case DATASET, DATA_SERVICE -> false;
+    };
+  }
+
   public static Optional<DevelopmentNodeType> tryParse(String value) {
     if (value == null || value.isBlank()) return Optional.empty();
     try {

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentTaskService.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentTaskService.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.yak.ops.business.development.domain.DevelopmentNode;
+import io.yak.ops.business.development.domain.DevelopmentNodeType;
 import io.yak.ops.business.development.domain.DevelopmentTaskDraft;
 import io.yak.ops.business.development.domain.DevelopmentTaskRevision;
 import io.yak.ops.business.development.domain.DevelopmentTaskRevisionSummary;
@@ -54,7 +55,7 @@ public class DevelopmentTaskService {
   }
 
   public DevelopmentTaskDraft getDraft(Long nodeId) {
-    DevelopmentNode node = requireNode(nodeId);
+    DevelopmentNode node = requireTaskNode(nodeId);
     return draftRepository.findByNodeId(nodeId)
         .orElseGet(() -> emptyDraft(node));
   }
@@ -67,7 +68,7 @@ public class DevelopmentTaskService {
       String content,
       String configJson,
       Long baseRevision) {
-    DevelopmentNode node = requireNode(nodeId);
+    DevelopmentNode node = requireTaskNode(nodeId);
     TaskDefinition definition = normalizeDefinition(
         node,
         taskType,
@@ -85,7 +86,7 @@ public class DevelopmentTaskService {
 
   @Transactional(transactionManager = "yakBusinessTransactionManager", rollbackFor = Exception.class)
   public DevelopmentTaskRevision publish(Long nodeId, long expectedDraftRevision) {
-    DevelopmentNode node = requireNode(nodeId);
+    DevelopmentNode node = requireTaskNode(nodeId);
     DevelopmentTaskDraft draft = draftRepository.findByNodeIdForUpdate(nodeId)
         .orElseThrow(() -> new IllegalArgumentException("节点尚未保存草稿：" + nodeId));
 
@@ -135,22 +136,29 @@ public class DevelopmentTaskService {
   }
 
   public List<DevelopmentTaskRevisionSummary> listRevisions(Long nodeId) {
-    requireNode(nodeId);
+    requireTaskNode(nodeId);
     return revisionRepository.listByNodeId(nodeId);
   }
 
   public DevelopmentTaskRevision getRevision(Long nodeId, int revisionNo) {
-    requireNode(nodeId);
+    requireTaskNode(nodeId);
     if (revisionNo <= 0) throw new IllegalArgumentException("revisionNo 必须大于 0");
     return revisionRepository.findByRevisionNo(nodeId, revisionNo)
         .orElseThrow(() -> new IllegalArgumentException(
             "发布版本不存在：nodeId=" + nodeId + ", revisionNo=" + revisionNo));
   }
 
-  private DevelopmentNode requireNode(Long nodeId) {
+  private DevelopmentNode requireTaskNode(Long nodeId) {
     if (nodeId == null || nodeId <= 0L) throw new IllegalArgumentException("节点 ID 非法");
-    return nodeRepository.findById(nodeId)
+    DevelopmentNode node = nodeRepository.findById(nodeId)
         .orElseThrow(() -> new IllegalArgumentException("节点不存在：" + nodeId));
+    DevelopmentNodeType nodeType = DevelopmentNodeType.tryParse(node.type())
+        .orElseThrow(() -> new IllegalArgumentException("未知数据开发节点类型：" + node.type()));
+    if (!nodeType.supportsTaskLifecycle()) {
+      throw new IllegalArgumentException(
+          "当前节点不是可执行开发任务，不能进入草稿/发布生命周期：" + node.type());
+    }
+    return node;
   }
 
   private DevelopmentTaskDraft emptyDraft(DevelopmentNode node) {

--- a/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/domain/DevelopmentNodeModelTest.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/domain/DevelopmentNodeModelTest.java
@@ -19,6 +19,16 @@ class DevelopmentNodeModelTest {
   }
 
   @Test
+  void taskLifecycleIsAnExplicitCapability() {
+    assertTrue(DevelopmentNodeType.SQL.supportsTaskLifecycle());
+    assertTrue(DevelopmentNodeType.SHELL.supportsTaskLifecycle());
+    assertTrue(DevelopmentNodeType.HTTP.supportsTaskLifecycle());
+    assertTrue(DevelopmentNodeType.PYTHON.supportsTaskLifecycle());
+    assertFalse(DevelopmentNodeType.DATASET.supportsTaskLifecycle());
+    assertFalse(DevelopmentNodeType.DATA_SERVICE.supportsTaskLifecycle());
+  }
+
+  @Test
   void keepsOutputNodesOutsideProcessingLifecycle() {
     assertTrue(DevelopmentNodeType.SQL.isProcessing());
     assertTrue(DevelopmentNodeType.SHELL.isProcessing());

--- a/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/DevelopmentTaskServiceTest.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/DevelopmentTaskServiceTest.java
@@ -56,6 +56,10 @@ class DevelopmentTaskServiceTest {
     Instant now = Instant.parse("2026-08-12T00:00:00Z");
     when(nodeRepository.findById(1L)).thenReturn(Optional.of(
         new DevelopmentNode(1L, "今天统计", "SQL", null, null, false, now, now)));
+    when(nodeRepository.findById(2L)).thenReturn(Optional.of(
+        new DevelopmentNode(2L, "销售数据集", "DATASET", null, null, false, now, now)));
+    when(nodeRepository.findById(3L)).thenReturn(Optional.of(
+        new DevelopmentNode(3L, "订单查询 API", "DATA_SERVICE", null, null, false, now, now)));
   }
 
   @Test
@@ -82,6 +86,21 @@ class DevelopmentTaskServiceTest {
     assertThrows(
         DevelopmentDraftConflictException.class,
         () -> service.saveDraft(1L, "SQL", 1, "select 2", "{}", 2L));
+  }
+
+  @Test
+  void outputResourcesCannotEnterTaskDraftOrPublishLifecycle() {
+    for (long nodeId : List.of(2L, 3L)) {
+      IllegalArgumentException draftException = assertThrows(
+          IllegalArgumentException.class,
+          () -> service.getDraft(nodeId));
+      assertTrue(draftException.getMessage().contains("不是可执行开发任务"));
+
+      IllegalArgumentException publishException = assertThrows(
+          IllegalArgumentException.class,
+          () -> service.publish(nodeId, 1L));
+      assertTrue(publishException.getMessage().contains("不是可执行开发任务"));
+    }
   }
 
   @Test

--- a/yak-ops-business/yak-ops-business-task-catalog/src/main/java/io/yak/ops/business/taskcatalog/service/TaskCatalogService.java
+++ b/yak-ops-business/yak-ops-business-task-catalog/src/main/java/io/yak/ops/business/taskcatalog/service/TaskCatalogService.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -20,6 +21,12 @@ import org.springframework.stereotype.Service;
 @Service
 @ConditionalOnDataSourceEnabled
 public class TaskCatalogService {
+
+  private static final Set<String> DATA_DEVELOPMENT_TASK_TYPES = Set.of(
+      "SQL",
+      "SHELL",
+      "HTTP",
+      "PYTHON");
 
   private final TaskAssetRepository repository;
   private final Map<TaskAssetSource, TaskAssetRevisionProvider> revisionProviders;
@@ -58,12 +65,14 @@ public class TaskCatalogService {
     if (source == null) throw new IllegalArgumentException("任务资产来源不能为空");
     if (revisionId <= 0L) throw new IllegalArgumentException("任务版本 ID 必须大于 0");
     if (revisionNo <= 0) throw new IllegalArgumentException("任务版本号必须大于 0");
+    String normalizedTaskType = normalizeTaskType(taskType);
+    requirePublishableTaskType(source, normalizedTaskType);
     return repository.upsertPublished(
         source,
         normalizeSourceRef(sourceRef),
         normalizeProjectId(projectId),
         normalizeName(name),
-        normalizeTaskType(taskType),
+        normalizedTaskType,
         revisionId,
         revisionNo);
   }
@@ -177,5 +186,12 @@ public class TaskCatalogService {
     String normalized = value.trim();
     if (normalized.length() > 200) throw new IllegalArgumentException("搜索关键字不能超过 200 个字符");
     return normalized;
+  }
+
+  private void requirePublishableTaskType(TaskAssetSource source, String taskType) {
+    if (source != TaskAssetSource.DATA_DEVELOPMENT) return;
+    if (DATA_DEVELOPMENT_TASK_TYPES.contains(taskType)) return;
+    throw new IllegalArgumentException(
+        "数据开发输出资源不能发布到 Task Catalog：taskType=" + taskType);
   }
 }

--- a/yak-ops-business/yak-ops-business-task-catalog/src/test/java/io/yak/ops/business/taskcatalog/service/TaskCatalogServiceTest.java
+++ b/yak-ops-business/yak-ops-business-task-catalog/src/test/java/io/yak/ops/business/taskcatalog/service/TaskCatalogServiceTest.java
@@ -1,6 +1,8 @@
 package io.yak.ops.business.taskcatalog.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -42,6 +44,26 @@ class TaskCatalogServiceTest {
 
     assertEquals(expected, result);
     assertEquals(2, result.currentRevision().revisionNo());
+  }
+
+  @Test
+  void dataDevelopmentOutputResourcesCannotEnterTaskCatalog() {
+    TaskAssetRepository repository = mock(TaskAssetRepository.class);
+    TaskCatalogService service = new TaskCatalogService(repository);
+
+    for (String taskType : List.of("DATASET", "DATA_SERVICE")) {
+      IllegalArgumentException exception = assertThrows(
+          IllegalArgumentException.class,
+          () -> service.publish(
+              TaskAssetSource.DATA_DEVELOPMENT,
+              "12",
+              7L,
+              "输出资源",
+              taskType,
+              101L,
+              1));
+      assertTrue(exception.getMessage().contains("不能发布到 Task Catalog"));
+    }
   }
 
   @Test

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowTaskBindingResolver.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowTaskBindingResolver.java
@@ -37,6 +37,8 @@ final class WorkflowTaskBindingResolver {
       return snapshot;
     }
 
+    TaskAsset asset = requireCatalog().get(node.taskAssetId());
+    WorkflowTaskEligibilityPolicy.requireEligible(asset);
     TaskAssetRevision resolved = requireCatalog().resolveRevision(
         node.taskAssetId(),
         node.taskRevisionId());
@@ -86,6 +88,7 @@ final class WorkflowTaskBindingResolver {
       throw new IllegalStateException("当前节点不是 TaskAsset 节点，不能升级任务版本");
     }
     TaskAsset asset = requireCatalog().get(node.taskAssetId());
+    WorkflowTaskEligibilityPolicy.requireEligible(asset);
     if (asset.status() != TaskAssetStatus.ONLINE) {
       throw new IllegalStateException("任务资产已下线，不能升级到新版本：" + asset.name());
     }

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowTaskEligibilityPolicy.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowTaskEligibilityPolicy.java
@@ -1,0 +1,37 @@
+package io.yak.ops.business.workflow.service;
+
+import io.yak.ops.business.taskcatalog.domain.TaskAsset;
+import io.yak.ops.spi.task.model.TaskAssetSource;
+import java.util.Locale;
+import java.util.Set;
+
+/** Fail-closed orchestration policy for published Data Development task assets. */
+final class WorkflowTaskEligibilityPolicy {
+
+  private static final Set<String> DATA_DEVELOPMENT_TASK_TYPES = Set.of(
+      "SQL",
+      "SHELL",
+      "HTTP",
+      "PYTHON");
+
+  private WorkflowTaskEligibilityPolicy() {}
+
+  static void requireEligible(TaskAsset asset) {
+    if (asset == null) throw new IllegalArgumentException("工作流任务资产不能为空");
+    if (asset.source() != TaskAssetSource.DATA_DEVELOPMENT) return;
+
+    String taskType = normalize(asset.taskType());
+    if (!DATA_DEVELOPMENT_TASK_TYPES.contains(taskType)) {
+      throw new IllegalArgumentException(
+          "数据开发资产不能进入工作流编排：assetId=" + asset.id() + "，taskType=" + taskType);
+    }
+  }
+
+  static boolean supportsDataDevelopmentTaskType(String taskType) {
+    return DATA_DEVELOPMENT_TASK_TYPES.contains(normalize(taskType));
+  }
+
+  private static String normalize(String taskType) {
+    return taskType == null ? "" : taskType.trim().toUpperCase(Locale.ROOT);
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowTaskAssetBindingTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowTaskAssetBindingTest.java
@@ -2,6 +2,7 @@ package io.yak.ops.business.workflow.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -103,6 +104,32 @@ class WorkflowTaskAssetBindingTest {
     assertEquals("task-asset:12", latestVersion.taskBindings().getFirst().taskId());
   }
 
+  @Test
+  void rejectsDataDevelopmentOutputAssetsAtWorkflowPublishBoundary() {
+    WorkflowRuntimeService runtimeService = mock(WorkflowRuntimeService.class);
+    TaskRegistry taskRegistry = mock(TaskRegistry.class);
+    TaskCatalogService taskCatalogService = mock(TaskCatalogService.class);
+    WorkflowDefinitionService service = new WorkflowDefinitionService(
+        runtimeService,
+        taskRegistry,
+        taskCatalogService,
+        NoopWorkflowDefinitionPersistence.INSTANCE);
+
+    WorkflowDefinitionVO created = service.create(
+        new WorkflowDefinitionCreateDTO("边界工作流", "输出资源不能参与编排"));
+
+    for (String taskType : List.of("DATASET", "DATA_SERVICE")) {
+      when(taskCatalogService.get(12L)).thenReturn(asset(taskType, 101L, 1));
+      service.update(created.id(), updateRequest(101L, 1));
+
+      IllegalArgumentException exception = assertThrows(
+          IllegalArgumentException.class,
+          () -> service.online(created.id()));
+
+      assertTrue(exception.getMessage().contains("不能进入工作流编排"));
+    }
+  }
+
   private static WorkflowDefinitionUpdateDTO updateRequest(long revisionId, int revisionNo) {
     WorkflowDefinitionUpdateDTO.NodeDTO node = new WorkflowDefinitionUpdateDTO.NodeDTO(
         "task-node-1",
@@ -131,6 +158,10 @@ class WorkflowTaskAssetBindingTest {
   }
 
   private static TaskAsset asset(long revisionId, int revisionNo) {
+    return asset("SQL", revisionId, revisionNo);
+  }
+
+  private static TaskAsset asset(String taskType, long revisionId, int revisionNo) {
     Instant now = Instant.parse("2026-08-12T00:00:00Z");
     return new TaskAsset(
         12L,
@@ -138,7 +169,7 @@ class WorkflowTaskAssetBindingTest {
         "10001",
         7L,
         "今天统计",
-        "SQL",
+        taskType,
         TaskAssetStatus.ONLINE,
         new TaskRevisionRef(12L, revisionId, revisionNo),
         now,

--- a/yak-ops-ui/src/pages/workflow/definition/canvas/WorkflowTaskPicker.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/WorkflowTaskPicker.tsx
@@ -5,7 +5,10 @@ import { Search } from 'lucide-react';
 import type { ReactElement } from 'react';
 import { useEffect, useMemo, useState } from 'react';
 import WorkflowNodeIcon from './node/icons/WorkflowNodeIcon';
-import { taskCatalogOption } from './taskOptions';
+import {
+  isWorkflowEligibleTaskCatalogAsset,
+  taskCatalogOption,
+} from './taskOptions';
 import type { WorkflowCanvasTaskOption } from './types';
 
 export type WorkflowTaskCategory = 'sync' | 'development' | 'quality';
@@ -88,7 +91,11 @@ const WorkflowTaskPicker = ({
     setCatalogLoading(true);
     void listTaskCatalogAssets({ source: 'DATA_DEVELOPMENT', status: 'ONLINE' })
       .then((assets) => {
-        if (active) setCatalogOptions(assets.map(taskCatalogOption));
+        if (active) {
+          setCatalogOptions(
+            assets.filter(isWorkflowEligibleTaskCatalogAsset).map(taskCatalogOption),
+          );
+        }
       })
       .catch(() => {
         if (active) setCatalogOptions([]);

--- a/yak-ops-ui/src/pages/workflow/definition/canvas/taskOptions.test.ts
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/taskOptions.test.ts
@@ -1,0 +1,36 @@
+import type { TaskCatalogAsset } from '@/services/taskCatalog';
+import {
+  isWorkflowEligibleTaskCatalogAsset,
+  taskCatalogOption,
+} from './taskOptions';
+
+const asset = (taskType: string): TaskCatalogAsset => ({
+  id: '12',
+  source: 'DATA_DEVELOPMENT',
+  sourceRef: '10001',
+  projectId: '7',
+  name: '测试资产',
+  taskType,
+  status: 'ONLINE',
+  currentRevision: {
+    taskAssetId: '12',
+    taskRevisionId: '101',
+    revisionNo: 1,
+  },
+});
+
+describe('workflow task catalog options', () => {
+  test('allows executable data development tasks', () => {
+    expect(isWorkflowEligibleTaskCatalogAsset(asset('SQL'))).toBe(true);
+    expect(isWorkflowEligibleTaskCatalogAsset(asset('PYTHON'))).toBe(true);
+    expect(isWorkflowEligibleTaskCatalogAsset(asset('SHELL'))).toBe(true);
+    expect(isWorkflowEligibleTaskCatalogAsset(asset('HTTP'))).toBe(true);
+  });
+
+  test('rejects output resources from workflow orchestration', () => {
+    expect(isWorkflowEligibleTaskCatalogAsset(asset('DATASET'))).toBe(false);
+    expect(isWorkflowEligibleTaskCatalogAsset(asset('DATA_SERVICE'))).toBe(false);
+    expect(() => taskCatalogOption(asset('DATASET'))).toThrow('不能进入工作流编排');
+    expect(() => taskCatalogOption(asset('DATA_SERVICE'))).toThrow('不能进入工作流编排');
+  });
+});

--- a/yak-ops-ui/src/pages/workflow/definition/canvas/taskOptions.ts
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/taskOptions.ts
@@ -6,16 +6,35 @@ import type { WorkflowCanvasTaskOption } from './types';
 
 export const TASK_ASSET_ID_PREFIX = 'task-asset:';
 
-export const taskCatalogOption = (asset: TaskCatalogAsset): WorkflowCanvasTaskOption => ({
-  id: `${TASK_ASSET_ID_PREFIX}${asset.id}`,
-  label: asset.name,
-  typeLabel: '数据开发',
-  taskType: asset.taskType,
-  taskAssetId: asset.id,
-  taskRevisionId: asset.currentRevision.taskRevisionId,
-  taskRevisionNo: asset.currentRevision.revisionNo,
-  meta: `已发布 v${asset.currentRevision.revisionNo}`,
-});
+const WORKFLOW_ELIGIBLE_DATA_DEVELOPMENT_TASK_TYPES = new Set([
+  'SQL',
+  'SHELL',
+  'HTTP',
+  'PYTHON',
+]);
+
+export const isWorkflowEligibleTaskCatalogAsset = (asset: TaskCatalogAsset) => {
+  const source = (asset.source || '').trim().toUpperCase();
+  const taskType = (asset.taskType || '').trim().toUpperCase();
+  if (source !== 'DATA_DEVELOPMENT') return true;
+  return WORKFLOW_ELIGIBLE_DATA_DEVELOPMENT_TASK_TYPES.has(taskType);
+};
+
+export const taskCatalogOption = (asset: TaskCatalogAsset): WorkflowCanvasTaskOption => {
+  if (!isWorkflowEligibleTaskCatalogAsset(asset)) {
+    throw new Error(`数据开发资产 ${asset.taskType || '-'} 不能进入工作流编排`);
+  }
+  return {
+    id: `${TASK_ASSET_ID_PREFIX}${asset.id}`,
+    label: asset.name,
+    typeLabel: '数据开发',
+    taskType: asset.taskType,
+    taskAssetId: asset.id,
+    taskRevisionId: asset.currentRevision.taskRevisionId,
+    taskRevisionNo: asset.currentRevision.revisionNo,
+    meta: `已发布 v${asset.currentRevision.revisionNo}`,
+  };
+};
 
 export const taskAssetIdFromTaskId = (taskId: string) =>
   taskId.startsWith(TASK_ASSET_ID_PREFIX)


### PR DESCRIPTION
## 背景

这次只做我们刚刚确定的 **Phase 1：领域边界收口**，不继续扩功能，也不重新引入任何数据开发 DAG。

目标保持简单：

- 数据开发负责开发独立节点
- 只有明确的可执行开发任务进入 Task Catalog / Workflow
- Dataset / Data Service 是独立资源节点，不进入 Workflow 编排
- 当前 SQL / Shell / HTTP / Python 行为保持兼容

## 本次改动

### 1. 数据开发 Task 生命周期改为显式能力

`DevelopmentNodeType` 新增 `supportsTaskLifecycle()`，当前明确允许：

- SQL
- SHELL
- HTTP
- PYTHON

明确禁止：

- DATASET
- DATA_SERVICE

`DevelopmentTaskService` 不再只判断节点是否存在；读取草稿、保存草稿、发布 Revision、读取版本前都会先确认节点具备 Task 生命周期能力。

这样 Dataset / Data Service 即使以后误接 Task Plugin，也不会进入 `Draft -> Revision -> Task Catalog` 链路。

### 2. Task Catalog 增加第二层边界

`TaskCatalogService.publish()` 对 `DATA_DEVELOPMENT` 来源增加显式白名单。

当前只有 SQL / Shell / HTTP / Python 可以发布为 TaskAsset；Dataset / Data Service 无法写入 Task Catalog。

后续增加 Flink SQL 时，需要显式加入白名单，避免新类型默认进入编排体系。

### 3. Workflow 增加服务端 fail-closed 策略

新增 `WorkflowTaskEligibilityPolicy`。

Workflow 在解析 TaskAsset Revision、升级到最新 Revision 时再次检查数据开发资产类型。即使历史数据或其他入口意外产生了 `DATASET / DATA_SERVICE` TaskAsset，也无法发布/运行到 Workflow。

原有不可变 Revision 绑定语义保持不变。

### 4. Workflow 前端 Picker 同步过滤

数据开发任务选择器只展示明确可编排的 TaskAsset：

- SQL
- Shell
- HTTP
- Python

Dataset / Data Service 不展示，并且 `taskCatalogOption` 自身也增加兜底校验，避免通过其他前端调用路径误转成 Workflow Node。

### 5. DAG 残留检查

基于当前 main 搜索了：

- `DevelopmentGraph`
- `yak_dev_graph`
- `ConnectionPolicy`
- `DAG 画布`

#425 已经清理干净，本 PR 不再制造额外删除改动。

## 测试覆盖

新增 / 扩展测试覆盖：

- DevelopmentNode Task 生命周期显式能力
- Dataset / Data Service 无法读取 Task Draft / 发布 Task Revision
- Dataset / Data Service 无法进入 Data Development Task Catalog
- Workflow 发布边界拒绝 Dataset / Data Service TaskAsset
- Workflow 前端过滤 Dataset / Data Service

另外对新增/修改的 TypeScript / TSX 做了 TypeScript `transpileModule` 语法检查，结果通过。

当前执行环境没有可用的仓库 checkout / Maven 与前端依赖，无法在本地执行完整 Maven/Jest/TS 类型检查；以 GitHub Checks 作为最终集成校验。

## 明确不做

- 不新增 Flink SQL
- 不实现 Python 编辑器
- 不迁移 Data Service Node 生命周期
- 不删除 SQL -> Dataset / API 的 legacy 入口（留到 Phase 2）
- 不改变 Workflow DAG / 调度 / Revision pinning 机制
- 不重新引入数据开发 DAG

## 下一阶段

Phase 2 再处理产品路径收口：移除 SQL Toolbar 上的 Dataset / API 双轨发布入口，让 Dataset 回 Dataset Node、Data Service 回 Data Service Node。