### PR TITLE
feat: add data service node authoring lifecycle

### DIFF
--- a/yak-ops-business/yak-ops-business-data-development/pom.xml
+++ b/yak-ops-business/yak-ops-business-data-development/pom.xml
@@ -79,6 +79,10 @@
             <artifactId>mybatis-plus-spring-boot3-starter</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.baomidou</groupId>
+            <artifactId>mybatis-plus-jsqlparser-4.9</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
         </dependency>

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/controller/v1/DevelopmentDataServiceNodeController.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/controller/v1/DevelopmentDataServiceNodeController.java
@@ -1,0 +1,166 @@
+package io.yak.ops.business.development.controller.v1;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.yak.framework.common.Result;
+import io.yak.ops.business.development.domain.DevelopmentDataServiceDefinition.ParameterContract;
+import io.yak.ops.business.development.domain.DevelopmentDataServiceDefinition.ResponseFieldContract;
+import io.yak.ops.business.development.domain.DevelopmentDataServiceRevision;
+import io.yak.ops.business.development.domain.DevelopmentDataServiceRevisionSummary;
+import io.yak.ops.business.development.service.DevelopmentDataServiceNodeService;
+import io.yak.ops.business.development.service.DevelopmentDataServiceNodeService.DataServiceNodeContext;
+import io.yak.ops.business.development.service.DevelopmentDataServiceNodeService.PreviewResult;
+import io.yak.ops.business.development.service.DevelopmentDataServiceNodeService.SaveDraftCommand;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Data Service Node authoring API.
+ *
+ * <p>Publishing here only creates an immutable Data Development revision; it does not deploy a
+ * runtime API.
+ */
+@Tag(name = "数据开发 Data Service Node 接口")
+@RestController
+@RequestMapping("/api/v1/data-development/nodes")
+public class DevelopmentDataServiceNodeController {
+
+  private final DevelopmentDataServiceNodeService service;
+
+  public DevelopmentDataServiceNodeController(DevelopmentDataServiceNodeService service) {
+    this.service = service;
+  }
+
+  @Operation(summary = "查询 Data Service Node 草稿、SQL 来源与发布历史")
+  @GetMapping("/{nodeId}/data-service")
+  public Result<DataServiceNodeContext> get(@PathVariable("nodeId") long nodeId) {
+    return Result.success(service.get(nodeId));
+  }
+
+  @Operation(summary = "基于指定 SQL Revision 预览请求参数和响应字段 Contract")
+  @PostMapping("/{nodeId}/data-service/preview")
+  public Result<PreviewResult> preview(
+      @PathVariable("nodeId") long nodeId,
+      @Valid @RequestBody PreviewRequest request) {
+    return Result.success(service.preview(
+        nodeId,
+        request.sourceTaskAssetId(),
+        request.sourceTaskRevisionId()));
+  }
+
+  @Operation(summary = "保存 Data Service Node 草稿并固定精确 SQL Revision")
+  @PutMapping("/{nodeId}/data-service/draft")
+  public Result<DataServiceNodeContext> saveDraft(
+      @PathVariable("nodeId") long nodeId,
+      @Valid @RequestBody SaveDraftRequest request) {
+    return Result.success(service.saveDraft(
+        nodeId,
+        new SaveDraftCommand(
+            request.sourceTaskAssetId(),
+            request.sourceTaskRevisionId(),
+            request.serviceName(),
+            request.path(),
+            request.method(),
+            request.parameters() == null
+                ? List.of()
+                : request.parameters().stream()
+                    .map(DevelopmentDataServiceNodeController::toParameterContract)
+                    .toList(),
+            request.responseFields() == null
+                ? List.of()
+                : request.responseFields().stream()
+                    .map(DevelopmentDataServiceNodeController::toResponseFieldContract)
+                    .toList(),
+            request.maxRows(),
+            request.timeoutSeconds(),
+            request.description(),
+            request.baseRevision())));
+  }
+
+  @Operation(summary = "发布不可变 Data Service Node Revision")
+  @PostMapping("/{nodeId}/data-service/publish")
+  public Result<DevelopmentDataServiceRevision> publish(
+      @PathVariable("nodeId") long nodeId,
+      @Valid @RequestBody PublishRequest request) {
+    return Result.success(service.publish(nodeId, request.expectedDraftRevision()));
+  }
+
+  @Operation(summary = "查询 Data Service Node 发布历史")
+  @GetMapping("/{nodeId}/data-service/revisions")
+  public Result<List<DevelopmentDataServiceRevisionSummary>> revisions(
+      @PathVariable("nodeId") long nodeId) {
+    return Result.success(service.listRevisions(nodeId));
+  }
+
+  @Operation(summary = "查询指定 Data Service Node Revision")
+  @GetMapping("/{nodeId}/data-service/revisions/{revisionNo}")
+  public Result<DevelopmentDataServiceRevision> revision(
+      @PathVariable("nodeId") long nodeId,
+      @PathVariable("revisionNo") int revisionNo) {
+    return Result.success(service.getRevision(nodeId, revisionNo));
+  }
+
+  private static ParameterContract toParameterContract(ParameterRequest request) {
+    return new ParameterContract(
+        request.name(),
+        request.type(),
+        request.required(),
+        request.description(),
+        request.example());
+  }
+
+  private static ResponseFieldContract toResponseFieldContract(ResponseFieldRequest request) {
+    return new ResponseFieldContract(
+        request.name(),
+        request.type(),
+        request.nullable(),
+        request.description(),
+        request.example());
+  }
+
+  public record PreviewRequest(
+      @NotNull @Min(1) Long sourceTaskAssetId,
+      @NotNull @Min(1) Long sourceTaskRevisionId) {}
+
+  public record SaveDraftRequest(
+      @NotNull @Min(1) Long sourceTaskAssetId,
+      @NotNull @Min(1) Long sourceTaskRevisionId,
+      @NotBlank @Size(max = 200) String serviceName,
+      @NotBlank @Size(max = 255) String path,
+      @Size(max = 16) String method,
+      List<@Valid ParameterRequest> parameters,
+      List<@Valid ResponseFieldRequest> responseFields,
+      @Min(1) @Max(10_000) Integer maxRows,
+      @Min(1) @Max(3_600) Integer timeoutSeconds,
+      @Size(max = 2_000) String description,
+      @Min(0) Long baseRevision) {}
+
+  public record ParameterRequest(
+      @NotBlank @Size(max = 128) String name,
+      @NotBlank @Size(max = 32) String type,
+      boolean required,
+      @Size(max = 1_000) String description,
+      @Size(max = 1_000) String example) {}
+
+  public record ResponseFieldRequest(
+      @NotBlank @Size(max = 128) String name,
+      @NotBlank @Size(max = 32) String type,
+      boolean nullable,
+      @Size(max = 1_000) String description,
+      @Size(max = 1_000) String example) {}
+
+  public record PublishRequest(
+      @Min(1) long expectedDraftRevision) {}
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/dao/mapper/DevelopmentDataServiceDraftMapper.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/dao/mapper/DevelopmentDataServiceDraftMapper.java
@@ -1,0 +1,18 @@
+package io.yak.ops.business.development.dao.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import io.yak.ops.common.bean.po.development.DevelopmentDataServiceDraftPO;
+import org.apache.ibatis.annotations.Param;
+import org.apache.ibatis.annotations.Select;
+
+public interface DevelopmentDataServiceDraftMapper
+    extends BaseMapper<DevelopmentDataServiceDraftPO> {
+
+  @Select("""
+      SELECT node_id, definition_json, draft_revision, create_time, update_time
+      FROM yak_dev_data_service_draft
+      WHERE node_id = #{nodeId}
+      FOR UPDATE
+      """)
+  DevelopmentDataServiceDraftPO selectForUpdate(@Param("nodeId") Long nodeId);
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/dao/mapper/DevelopmentDataServiceRevisionMapper.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/dao/mapper/DevelopmentDataServiceRevisionMapper.java
@@ -1,0 +1,17 @@
+package io.yak.ops.business.development.dao.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import io.yak.ops.common.bean.po.development.DevelopmentDataServiceRevisionPO;
+import org.apache.ibatis.annotations.Param;
+import org.apache.ibatis.annotations.Select;
+
+public interface DevelopmentDataServiceRevisionMapper
+    extends BaseMapper<DevelopmentDataServiceRevisionPO> {
+
+  @Select("""
+      SELECT COALESCE(MAX(revision_no), 0)
+      FROM yak_dev_data_service_revision
+      WHERE node_id = #{nodeId}
+      """)
+  Integer selectMaxRevisionNo(@Param("nodeId") Long nodeId);
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/domain/DevelopmentDataServiceDefinition.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/domain/DevelopmentDataServiceDefinition.java
@@ -1,0 +1,39 @@
+package io.yak.ops.business.development.domain;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import java.util.List;
+
+/** Authoring definition owned by a DATA_SERVICE node in Data Development. */
+public record DevelopmentDataServiceDefinition(
+    @JsonSerialize(using = ToStringSerializer.class) long sourceTaskAssetId,
+    @JsonSerialize(using = ToStringSerializer.class) long sourceTaskRevisionId,
+    int sourceTaskRevisionNo,
+    String serviceName,
+    String path,
+    String method,
+    List<ParameterContract> parameters,
+    List<ResponseFieldContract> responseFields,
+    int maxRows,
+    int timeoutSeconds,
+    String description) {
+
+  public DevelopmentDataServiceDefinition {
+    parameters = parameters == null ? List.of() : List.copyOf(parameters);
+    responseFields = responseFields == null ? List.of() : List.copyOf(responseFields);
+  }
+
+  public record ParameterContract(
+      String name,
+      String type,
+      boolean required,
+      String description,
+      String example) {}
+
+  public record ResponseFieldContract(
+      String name,
+      String type,
+      boolean nullable,
+      String description,
+      String example) {}
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/domain/DevelopmentDataServiceDraft.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/domain/DevelopmentDataServiceDraft.java
@@ -1,0 +1,13 @@
+package io.yak.ops.business.development.domain;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import java.time.Instant;
+
+/** Mutable authoring draft for one DATA_SERVICE development node. */
+public record DevelopmentDataServiceDraft(
+    @JsonSerialize(using = ToStringSerializer.class) long nodeId,
+    DevelopmentDataServiceDefinition definition,
+    long draftRevision,
+    Instant createTime,
+    Instant updateTime) {}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/domain/DevelopmentDataServiceRevision.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/domain/DevelopmentDataServiceRevision.java
@@ -1,0 +1,15 @@
+package io.yak.ops.business.development.domain;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import java.time.Instant;
+
+/** Immutable published Data Service Node revision. This is not a Task Catalog revision. */
+public record DevelopmentDataServiceRevision(
+    @JsonSerialize(using = ToStringSerializer.class) long id,
+    @JsonSerialize(using = ToStringSerializer.class) long nodeId,
+    int revisionNo,
+    long sourceDraftRevision,
+    DevelopmentDataServiceDefinition definition,
+    String checksum,
+    Instant createTime) {}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/domain/DevelopmentDataServiceRevisionSummary.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/domain/DevelopmentDataServiceRevisionSummary.java
@@ -1,0 +1,16 @@
+package io.yak.ops.business.development.domain;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import java.time.Instant;
+
+/** Lightweight immutable Data Service Node revision metadata for editor history. */
+public record DevelopmentDataServiceRevisionSummary(
+    @JsonSerialize(using = ToStringSerializer.class) long id,
+    @JsonSerialize(using = ToStringSerializer.class) long nodeId,
+    int revisionNo,
+    long sourceDraftRevision,
+    @JsonSerialize(using = ToStringSerializer.class) long sourceTaskRevisionId,
+    int sourceTaskRevisionNo,
+    String checksum,
+    Instant createTime) {}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/DevelopmentDataServiceDraftRepository.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/DevelopmentDataServiceDraftRepository.java
@@ -1,0 +1,17 @@
+package io.yak.ops.business.development.repository;
+
+import io.yak.ops.business.development.domain.DevelopmentDataServiceDefinition;
+import io.yak.ops.business.development.domain.DevelopmentDataServiceDraft;
+import java.util.Optional;
+
+public interface DevelopmentDataServiceDraftRepository {
+
+  Optional<DevelopmentDataServiceDraft> findByNodeId(Long nodeId);
+
+  Optional<DevelopmentDataServiceDraft> findByNodeIdForUpdate(Long nodeId);
+
+  Optional<DevelopmentDataServiceDraft> save(
+      Long nodeId,
+      DevelopmentDataServiceDefinition definition,
+      long expectedBaseRevision);
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/DevelopmentDataServiceDraftRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/DevelopmentDataServiceDraftRepositoryAdapter.java
@@ -1,0 +1,105 @@
+package io.yak.ops.business.development.repository;
+
+import com.baomidou.mybatisplus.core.conditions.update.LambdaUpdateWrapper;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.development.dao.mapper.DevelopmentDataServiceDraftMapper;
+import io.yak.ops.business.development.domain.DevelopmentDataServiceDefinition;
+import io.yak.ops.business.development.domain.DevelopmentDataServiceDraft;
+import io.yak.ops.common.bean.po.development.DevelopmentDataServiceDraftPO;
+import java.time.Instant;
+import java.util.Optional;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.stereotype.Repository;
+
+/** MyBatis adapter for mutable Data Service Node drafts. */
+@Repository
+public class DevelopmentDataServiceDraftRepositoryAdapter
+    implements DevelopmentDataServiceDraftRepository {
+
+  private final DevelopmentDataServiceDraftMapper mapper;
+  private final ObjectMapper objectMapper;
+
+  public DevelopmentDataServiceDraftRepositoryAdapter(
+      DevelopmentDataServiceDraftMapper mapper,
+      ObjectMapper objectMapper) {
+    this.mapper = mapper;
+    this.objectMapper = objectMapper;
+  }
+
+  @Override
+  public Optional<DevelopmentDataServiceDraft> findByNodeId(Long nodeId) {
+    return Optional.ofNullable(mapper.selectById(nodeId)).map(this::toDomain);
+  }
+
+  @Override
+  public Optional<DevelopmentDataServiceDraft> findByNodeIdForUpdate(Long nodeId) {
+    return Optional.ofNullable(mapper.selectForUpdate(nodeId)).map(this::toDomain);
+  }
+
+  @Override
+  public Optional<DevelopmentDataServiceDraft> save(
+      Long nodeId,
+      DevelopmentDataServiceDefinition definition,
+      long expectedBaseRevision) {
+    DevelopmentDataServiceDraftPO current = mapper.selectById(nodeId);
+    Instant now = Instant.now();
+    String definitionJson = writeDefinition(definition);
+
+    if (current == null) {
+      if (expectedBaseRevision != 0L) return Optional.empty();
+      DevelopmentDataServiceDraftPO created = new DevelopmentDataServiceDraftPO();
+      created.setNodeId(nodeId);
+      created.setDefinitionJson(definitionJson);
+      created.setDraftRevision(1L);
+      created.setCreateTime(now);
+      created.setUpdateTime(now);
+      try {
+        mapper.insert(created);
+      } catch (DuplicateKeyException conflict) {
+        return Optional.empty();
+      }
+      return Optional.of(toDomain(created));
+    }
+
+    long currentRevision = current.getDraftRevision() == null ? 0L : current.getDraftRevision();
+    if (currentRevision != expectedBaseRevision) return Optional.empty();
+
+    long nextRevision = currentRevision + 1L;
+    int updated = mapper.update(
+        null,
+        new LambdaUpdateWrapper<DevelopmentDataServiceDraftPO>()
+            .eq(DevelopmentDataServiceDraftPO::getNodeId, nodeId)
+            .eq(DevelopmentDataServiceDraftPO::getDraftRevision, currentRevision)
+            .set(DevelopmentDataServiceDraftPO::getDefinitionJson, definitionJson)
+            .set(DevelopmentDataServiceDraftPO::getDraftRevision, nextRevision)
+            .set(DevelopmentDataServiceDraftPO::getUpdateTime, now));
+    if (updated <= 0) return Optional.empty();
+    return findByNodeId(nodeId);
+  }
+
+  private DevelopmentDataServiceDraft toDomain(DevelopmentDataServiceDraftPO po) {
+    return new DevelopmentDataServiceDraft(
+        po.getNodeId(),
+        readDefinition(po.getDefinitionJson()),
+        po.getDraftRevision() == null ? 0L : po.getDraftRevision(),
+        po.getCreateTime(),
+        po.getUpdateTime());
+  }
+
+  private String writeDefinition(DevelopmentDataServiceDefinition definition) {
+    try {
+      return objectMapper.writeValueAsString(definition);
+    } catch (JsonProcessingException exception) {
+      throw new IllegalStateException("Data Service Node definition 序列化失败", exception);
+    }
+  }
+
+  private DevelopmentDataServiceDefinition readDefinition(String json) {
+    try {
+      return objectMapper.readValue(json, DevelopmentDataServiceDefinition.class);
+    } catch (JsonProcessingException exception) {
+      throw new IllegalStateException("Data Service Node definition 反序列化失败", exception);
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/DevelopmentDataServiceRevisionRepository.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/DevelopmentDataServiceRevisionRepository.java
@@ -1,0 +1,25 @@
+package io.yak.ops.business.development.repository;
+
+import io.yak.ops.business.development.domain.DevelopmentDataServiceDefinition;
+import io.yak.ops.business.development.domain.DevelopmentDataServiceRevision;
+import io.yak.ops.business.development.domain.DevelopmentDataServiceRevisionSummary;
+import java.util.List;
+import java.util.Optional;
+
+public interface DevelopmentDataServiceRevisionRepository {
+
+  int nextRevisionNo(Long nodeId);
+
+  DevelopmentDataServiceRevision insert(
+      Long nodeId,
+      int revisionNo,
+      long sourceDraftRevision,
+      DevelopmentDataServiceDefinition definition,
+      String checksum);
+
+  Optional<DevelopmentDataServiceRevision> findLatestByNodeId(Long nodeId);
+
+  Optional<DevelopmentDataServiceRevision> findByRevisionNo(Long nodeId, int revisionNo);
+
+  List<DevelopmentDataServiceRevisionSummary> listByNodeId(Long nodeId);
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/DevelopmentDataServiceRevisionRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/DevelopmentDataServiceRevisionRepositoryAdapter.java
@@ -1,0 +1,125 @@
+package io.yak.ops.business.development.repository;
+
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.development.dao.mapper.DevelopmentDataServiceRevisionMapper;
+import io.yak.ops.business.development.domain.DevelopmentDataServiceDefinition;
+import io.yak.ops.business.development.domain.DevelopmentDataServiceRevision;
+import io.yak.ops.business.development.domain.DevelopmentDataServiceRevisionSummary;
+import io.yak.ops.common.bean.po.development.DevelopmentDataServiceRevisionPO;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.stereotype.Repository;
+
+/** MyBatis adapter for immutable Data Service Node revisions. */
+@Repository
+public class DevelopmentDataServiceRevisionRepositoryAdapter
+    implements DevelopmentDataServiceRevisionRepository {
+
+  private final DevelopmentDataServiceRevisionMapper mapper;
+  private final ObjectMapper objectMapper;
+
+  public DevelopmentDataServiceRevisionRepositoryAdapter(
+      DevelopmentDataServiceRevisionMapper mapper,
+      ObjectMapper objectMapper) {
+    this.mapper = mapper;
+    this.objectMapper = objectMapper;
+  }
+
+  @Override
+  public int nextRevisionNo(Long nodeId) {
+    Integer max = mapper.selectMaxRevisionNo(nodeId);
+    return (max == null ? 0 : max) + 1;
+  }
+
+  @Override
+  public DevelopmentDataServiceRevision insert(
+      Long nodeId,
+      int revisionNo,
+      long sourceDraftRevision,
+      DevelopmentDataServiceDefinition definition,
+      String checksum) {
+    DevelopmentDataServiceRevisionPO po = new DevelopmentDataServiceRevisionPO();
+    po.setNodeId(nodeId);
+    po.setRevisionNo(revisionNo);
+    po.setSourceDraftRevision(sourceDraftRevision);
+    po.setDefinitionJson(writeDefinition(definition));
+    po.setChecksum(checksum);
+    po.setCreateTime(Instant.now());
+    mapper.insert(po);
+    return toDomain(po);
+  }
+
+  @Override
+  public Optional<DevelopmentDataServiceRevision> findLatestByNodeId(Long nodeId) {
+    return Optional.ofNullable(mapper.selectOne(
+            new LambdaQueryWrapper<DevelopmentDataServiceRevisionPO>()
+                .eq(DevelopmentDataServiceRevisionPO::getNodeId, nodeId)
+                .orderByDesc(DevelopmentDataServiceRevisionPO::getRevisionNo)
+                .last("LIMIT 1")))
+        .map(this::toDomain);
+  }
+
+  @Override
+  public Optional<DevelopmentDataServiceRevision> findByRevisionNo(Long nodeId, int revisionNo) {
+    return Optional.ofNullable(mapper.selectOne(
+            new LambdaQueryWrapper<DevelopmentDataServiceRevisionPO>()
+                .eq(DevelopmentDataServiceRevisionPO::getNodeId, nodeId)
+                .eq(DevelopmentDataServiceRevisionPO::getRevisionNo, revisionNo)
+                .last("LIMIT 1")))
+        .map(this::toDomain);
+  }
+
+  @Override
+  public List<DevelopmentDataServiceRevisionSummary> listByNodeId(Long nodeId) {
+    return mapper.selectList(
+            new LambdaQueryWrapper<DevelopmentDataServiceRevisionPO>()
+                .eq(DevelopmentDataServiceRevisionPO::getNodeId, nodeId)
+                .orderByDesc(DevelopmentDataServiceRevisionPO::getRevisionNo))
+        .stream()
+        .map(this::toSummary)
+        .toList();
+  }
+
+  private DevelopmentDataServiceRevision toDomain(DevelopmentDataServiceRevisionPO po) {
+    return new DevelopmentDataServiceRevision(
+        po.getId(),
+        po.getNodeId(),
+        po.getRevisionNo() == null ? 0 : po.getRevisionNo(),
+        po.getSourceDraftRevision() == null ? 0L : po.getSourceDraftRevision(),
+        readDefinition(po.getDefinitionJson()),
+        po.getChecksum(),
+        po.getCreateTime());
+  }
+
+  private DevelopmentDataServiceRevisionSummary toSummary(DevelopmentDataServiceRevisionPO po) {
+    DevelopmentDataServiceDefinition definition = readDefinition(po.getDefinitionJson());
+    return new DevelopmentDataServiceRevisionSummary(
+        po.getId(),
+        po.getNodeId(),
+        po.getRevisionNo() == null ? 0 : po.getRevisionNo(),
+        po.getSourceDraftRevision() == null ? 0L : po.getSourceDraftRevision(),
+        definition.sourceTaskRevisionId(),
+        definition.sourceTaskRevisionNo(),
+        po.getChecksum(),
+        po.getCreateTime());
+  }
+
+  private String writeDefinition(DevelopmentDataServiceDefinition definition) {
+    try {
+      return objectMapper.writeValueAsString(definition);
+    } catch (JsonProcessingException exception) {
+      throw new IllegalStateException("Data Service Node revision 序列化失败", exception);
+    }
+  }
+
+  private DevelopmentDataServiceDefinition readDefinition(String json) {
+    try {
+      return objectMapper.readValue(json, DevelopmentDataServiceDefinition.class);
+    } catch (JsonProcessingException exception) {
+      throw new IllegalStateException("Data Service Node revision 反序列化失败", exception);
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentDataServiceNodeService.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentDataServiceNodeService.java
@@ -1,0 +1,720 @@
+package io.yak.ops.business.development.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.development.domain.DevelopmentDataServiceDefinition;
+import io.yak.ops.business.development.domain.DevelopmentDataServiceDefinition.ParameterContract;
+import io.yak.ops.business.development.domain.DevelopmentDataServiceDefinition.ResponseFieldContract;
+import io.yak.ops.business.development.domain.DevelopmentDataServiceDraft;
+import io.yak.ops.business.development.domain.DevelopmentDataServiceRevision;
+import io.yak.ops.business.development.domain.DevelopmentDataServiceRevisionSummary;
+import io.yak.ops.business.development.domain.DevelopmentNode;
+import io.yak.ops.business.development.domain.DevelopmentNodeType;
+import io.yak.ops.business.development.repository.DevelopmentDataServiceDraftRepository;
+import io.yak.ops.business.development.repository.DevelopmentDataServiceRevisionRepository;
+import io.yak.ops.business.development.repository.DevelopmentNodeRepository;
+import io.yak.ops.business.taskcatalog.domain.TaskAsset;
+import io.yak.ops.business.taskcatalog.domain.TaskAssetRevision;
+import io.yak.ops.business.taskcatalog.service.TaskCatalogService;
+import io.yak.ops.spi.datasource.execution.DataSourceExecutionProvider;
+import io.yak.ops.spi.datasource.execution.DataSourceSqlColumn;
+import io.yak.ops.spi.datasource.execution.DataSourceSqlExecutor;
+import io.yak.ops.spi.datasource.execution.DataSourceSqlRequest;
+import io.yak.ops.spi.datasource.execution.DataSourceSqlResult;
+import io.yak.ops.spi.task.model.TaskAssetSource;
+import io.yak.ops.spi.task.model.TaskAssetStatus;
+import io.yak.ops.spi.task.model.TaskDefinition;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.sql.Types;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.HexFormat;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.regex.Pattern;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Owns the Data Service Node authoring lifecycle inside Data Development.
+ *
+ * <p>It deliberately stops at immutable DataServiceNodeRevision publication. Runtime deployment is
+ * owned by the Data Service module and is connected in a later phase.
+ */
+@Service
+public class DevelopmentDataServiceNodeService {
+
+  private static final int DEFAULT_MAX_ROWS = 1_000;
+  private static final int DEFAULT_TIMEOUT_SECONDS = 30;
+  private static final int MAX_PREVIEW_TIMEOUT_SECONDS = 30;
+  private static final Pattern PARAMETER_NAME = Pattern.compile("[A-Za-z_][A-Za-z0-9_]*");
+  private static final Set<String> SCHEMA_TYPES = Set.of(
+      "STRING", "INTEGER", "NUMBER", "BOOLEAN", "DATE", "DATETIME", "OBJECT");
+
+  private final DevelopmentNodeRepository nodeRepository;
+  private final TaskCatalogService taskCatalogService;
+  private final DevelopmentDataServiceDraftRepository draftRepository;
+  private final DevelopmentDataServiceRevisionRepository revisionRepository;
+  private final DataSourceExecutionProvider dataSourceExecutionProvider;
+  private final DevelopmentDataServiceSqlCompiler sqlCompiler;
+  private final ObjectMapper objectMapper;
+
+  public DevelopmentDataServiceNodeService(
+      DevelopmentNodeRepository nodeRepository,
+      TaskCatalogService taskCatalogService,
+      DevelopmentDataServiceDraftRepository draftRepository,
+      DevelopmentDataServiceRevisionRepository revisionRepository,
+      DataSourceExecutionProvider dataSourceExecutionProvider,
+      DevelopmentDataServiceSqlCompiler sqlCompiler,
+      ObjectMapper objectMapper) {
+    this.nodeRepository = nodeRepository;
+    this.taskCatalogService = taskCatalogService;
+    this.draftRepository = draftRepository;
+    this.revisionRepository = revisionRepository;
+    this.dataSourceExecutionProvider = dataSourceExecutionProvider;
+    this.sqlCompiler = sqlCompiler;
+    this.objectMapper = objectMapper;
+  }
+
+  public DataServiceNodeContext get(long nodeId) {
+    DevelopmentNode node = requireDataServiceNode(nodeId);
+    DevelopmentDataServiceDraft draft = draftRepository.findByNodeId(nodeId)
+        .orElseGet(() -> emptyDraft(node));
+    List<DevelopmentDataServiceRevisionSummary> revisions = revisionRepository.listByNodeId(nodeId);
+    return new DataServiceNodeContext(
+        String.valueOf(node.id()),
+        node.name(),
+        node.configured() || draft.draftRevision() > 0L,
+        availableSources(node),
+        selectedSource(draft.definition()),
+        draft,
+        revisions.isEmpty() ? null : revisions.getFirst(),
+        revisions);
+  }
+
+  public PreviewResult preview(long nodeId, long sourceTaskAssetId, long sourceTaskRevisionId) {
+    DevelopmentNode node = requireDataServiceNode(nodeId);
+    ResolvedSqlSource source = requireSqlSource(
+        node, sourceTaskAssetId, sourceTaskRevisionId);
+    ContractPreview contract = discoverContract(source.revision().revision().definition());
+    return new PreviewResult(
+        toSourceSnapshot(source.asset(), source.sourceNode(), source.revision()),
+        contract.parameters(),
+        contract.responseFields());
+  }
+
+  @Transactional(transactionManager = "yakBusinessTransactionManager", rollbackFor = Exception.class)
+  public DataServiceNodeContext saveDraft(long nodeId, SaveDraftCommand command) {
+    DevelopmentNode node = requireDataServiceNode(nodeId);
+    if (command == null) throw new IllegalArgumentException("Data Service Node 草稿不能为空");
+
+    ResolvedSqlSource source = requireSqlSource(
+        node, command.sourceTaskAssetId(), command.sourceTaskRevisionId());
+    TaskDefinition sqlDefinition = source.revision().revision().definition();
+    List<String> sqlParameters = sqlCompiler.parameterNames(sqlDefinition.content());
+
+    DevelopmentDataServiceDefinition definition = normalizeDefinition(
+        node,
+        source,
+        command.serviceName(),
+        command.path(),
+        command.method(),
+        command.parameters(),
+        command.responseFields(),
+        command.maxRows(),
+        command.timeoutSeconds(),
+        command.description(),
+        sqlParameters,
+        false);
+
+    long expectedBaseRevision = command.baseRevision() == null ? 0L : command.baseRevision();
+    DevelopmentDataServiceDraft saved = draftRepository
+        .save(nodeId, definition, expectedBaseRevision)
+        .orElseThrow(() -> new DevelopmentDraftConflictException(
+            "Data Service Node 草稿已被其他会话更新，请刷新后重新保存（当前基线："
+                + expectedBaseRevision + "）"));
+    nodeRepository.updateConfigured(nodeId, true);
+    return context(node, saved);
+  }
+
+  @Transactional(transactionManager = "yakBusinessTransactionManager", rollbackFor = Exception.class)
+  public DevelopmentDataServiceRevision publish(long nodeId, long expectedDraftRevision) {
+    DevelopmentNode node = requireDataServiceNode(nodeId);
+    DevelopmentDataServiceDraft draft = draftRepository.findByNodeIdForUpdate(nodeId)
+        .orElseThrow(() -> new IllegalArgumentException(
+            "Data Service Node 尚未保存草稿：" + nodeId));
+
+    if (draft.draftRevision() != expectedDraftRevision) {
+      throw new DevelopmentDraftConflictException(
+          "发布失败：Data Service Node 草稿版本已变化，期望 "
+              + expectedDraftRevision + "，当前 " + draft.draftRevision());
+    }
+
+    DevelopmentDataServiceDefinition current = draft.definition();
+    ResolvedSqlSource source = requireSqlSource(
+        node, current.sourceTaskAssetId(), current.sourceTaskRevisionId());
+    List<String> sqlParameters = sqlCompiler.parameterNames(
+        source.revision().revision().definition().content());
+    DevelopmentDataServiceDefinition normalized = normalizeDefinition(
+        node,
+        source,
+        current.serviceName(),
+        current.path(),
+        current.method(),
+        current.parameters(),
+        current.responseFields(),
+        current.maxRows(),
+        current.timeoutSeconds(),
+        current.description(),
+        sqlParameters,
+        true);
+
+    String checksum = checksum(normalized);
+    DevelopmentDataServiceRevision latest =
+        revisionRepository.findLatestByNodeId(nodeId).orElse(null);
+    if (latest != null
+        && latest.sourceDraftRevision() == draft.draftRevision()
+        && Objects.equals(latest.checksum(), checksum)) {
+      return latest;
+    }
+
+    DevelopmentDataServiceRevision published = revisionRepository.insert(
+        nodeId,
+        revisionRepository.nextRevisionNo(nodeId),
+        draft.draftRevision(),
+        normalized,
+        checksum);
+    nodeRepository.updateConfigured(nodeId, true);
+    return published;
+  }
+
+  public List<DevelopmentDataServiceRevisionSummary> listRevisions(long nodeId) {
+    requireDataServiceNode(nodeId);
+    return revisionRepository.listByNodeId(nodeId);
+  }
+
+  public DevelopmentDataServiceRevision getRevision(long nodeId, int revisionNo) {
+    requireDataServiceNode(nodeId);
+    if (revisionNo <= 0) throw new IllegalArgumentException("revisionNo 必须大于 0");
+    return revisionRepository.findByRevisionNo(nodeId, revisionNo)
+        .orElseThrow(() -> new IllegalArgumentException(
+            "Data Service Node 发布版本不存在：nodeId=" + nodeId + ", revisionNo=" + revisionNo));
+  }
+
+  private DataServiceNodeContext context(
+      DevelopmentNode node,
+      DevelopmentDataServiceDraft draft) {
+    List<DevelopmentDataServiceRevisionSummary> revisions =
+        revisionRepository.listByNodeId(node.id());
+    DevelopmentNode refreshed = nodeRepository.findById(node.id()).orElse(node);
+    return new DataServiceNodeContext(
+        String.valueOf(refreshed.id()),
+        refreshed.name(),
+        refreshed.configured() || draft.draftRevision() > 0L,
+        availableSources(refreshed),
+        selectedSource(draft.definition()),
+        draft,
+        revisions.isEmpty() ? null : revisions.getFirst(),
+        revisions);
+  }
+
+  private List<SourceSnapshot> availableSources(DevelopmentNode dataServiceNode) {
+    return taskCatalogService.list("DATA_DEVELOPMENT", "ONLINE", null).stream()
+        .filter(asset -> "SQL".equalsIgnoreCase(asset.taskType()))
+        .filter(asset -> sameProject(asset.projectId(), dataServiceNode.projectId()))
+        .map(asset -> toCurrentSourceIfValid(dataServiceNode, asset))
+        .filter(Objects::nonNull)
+        .sorted(Comparator
+            .comparing(SourceSnapshot::nodeName, String.CASE_INSENSITIVE_ORDER)
+            .thenComparing(SourceSnapshot::nodeId))
+        .toList();
+  }
+
+  private SourceSnapshot toCurrentSourceIfValid(DevelopmentNode dataServiceNode, TaskAsset asset) {
+    try {
+      DevelopmentNode sourceNode = requireSourceSqlNode(asset);
+      if (!sameProject(sourceNode.projectId(), dataServiceNode.projectId())) return null;
+      TaskAssetRevision revision = taskCatalogService.resolveRevision(
+          asset.id(), asset.currentRevision().taskRevisionId());
+      return toSourceSnapshot(asset, sourceNode, revision);
+    } catch (RuntimeException exception) {
+      return null;
+    }
+  }
+
+  private SourceSnapshot selectedSource(DevelopmentDataServiceDefinition definition) {
+    if (definition == null
+        || definition.sourceTaskAssetId() <= 0L
+        || definition.sourceTaskRevisionId() <= 0L) {
+      return null;
+    }
+    try {
+      TaskAsset asset = taskCatalogService.get(definition.sourceTaskAssetId());
+      DevelopmentNode sourceNode = nodeRepository.findById(parseSourceNodeId(asset)).orElse(null);
+      TaskAssetRevision pinned = taskCatalogService.resolveRevision(
+          asset.id(), definition.sourceTaskRevisionId());
+      String nodeId = sourceNode == null ? asset.sourceRef() : String.valueOf(sourceNode.id());
+      String nodeName = sourceNode == null ? asset.name() : sourceNode.name();
+      return new SourceSnapshot(
+          nodeId,
+          nodeName,
+          String.valueOf(asset.id()),
+          asset.status().name(),
+          String.valueOf(pinned.revision().revisionId()),
+          pinned.revision().revisionNo(),
+          String.valueOf(asset.currentRevision().taskRevisionId()),
+          asset.currentRevision().revisionNo(),
+          pinned.revision().revisionId() != asset.currentRevision().taskRevisionId());
+    } catch (RuntimeException exception) {
+      return new SourceSnapshot(
+          null,
+          "历史 SQL 来源",
+          String.valueOf(definition.sourceTaskAssetId()),
+          "UNAVAILABLE",
+          String.valueOf(definition.sourceTaskRevisionId()),
+          definition.sourceTaskRevisionNo(),
+          null,
+          null,
+          false);
+    }
+  }
+
+  private ResolvedSqlSource requireSqlSource(
+      DevelopmentNode dataServiceNode,
+      long sourceTaskAssetId,
+      long sourceTaskRevisionId) {
+    if (sourceTaskAssetId <= 0L) {
+      throw new IllegalArgumentException("sourceTaskAssetId 必须大于 0");
+    }
+    if (sourceTaskRevisionId <= 0L) {
+      throw new IllegalArgumentException("sourceTaskRevisionId 必须大于 0");
+    }
+
+    TaskAsset asset = taskCatalogService.get(sourceTaskAssetId);
+    if (asset.source() != TaskAssetSource.DATA_DEVELOPMENT) {
+      throw new IllegalArgumentException("Data Service Node 只能选择数据开发 SQL 来源");
+    }
+    if (!"SQL".equalsIgnoreCase(asset.taskType())) {
+      throw new IllegalArgumentException("Data Service Node 当前仅支持 SQL 来源");
+    }
+    if (asset.status() != TaskAssetStatus.ONLINE) {
+      throw new IllegalArgumentException("Data Service Node 只能选择 ONLINE SQL 来源");
+    }
+    if (!sameProject(asset.projectId(), dataServiceNode.projectId())) {
+      throw new IllegalArgumentException("Data Service Node 只能选择同项目的 SQL 来源");
+    }
+
+    DevelopmentNode sourceNode = requireSourceSqlNode(asset);
+    if (!sameProject(sourceNode.projectId(), dataServiceNode.projectId())) {
+      throw new IllegalArgumentException("Data Service Node 只能选择同项目的 SQL 节点");
+    }
+
+    TaskAssetRevision revision = taskCatalogService.resolveRevision(
+        sourceTaskAssetId, sourceTaskRevisionId);
+    if (revision.revision().revisionId() != sourceTaskRevisionId) {
+      throw new IllegalStateException("Data Service Node 解析到的 SQL Revision 与请求不一致");
+    }
+    if (!"SQL".equalsIgnoreCase(revision.revision().definition().taskType())) {
+      throw new IllegalArgumentException("Data Service Node 来源 Revision 不是 SQL");
+    }
+    sqlCompiler.validateSelectOnly(revision.revision().definition().content());
+    return new ResolvedSqlSource(asset, sourceNode, revision);
+  }
+
+  private DevelopmentNode requireSourceSqlNode(TaskAsset asset) {
+    long sourceNodeId = parseSourceNodeId(asset);
+    DevelopmentNode sourceNode = nodeRepository.findById(sourceNodeId)
+        .orElseThrow(() -> new IllegalStateException("SQL 来源节点不存在：" + sourceNodeId));
+    if (!DevelopmentNodeType.SQL.name().equalsIgnoreCase(sourceNode.type())) {
+      throw new IllegalStateException("TaskAsset 来源节点不是 SQL：" + sourceNodeId);
+    }
+    return sourceNode;
+  }
+
+  private long parseSourceNodeId(TaskAsset asset) {
+    try {
+      long nodeId = Long.parseLong(asset.sourceRef());
+      if (nodeId <= 0L) throw new NumberFormatException("not positive");
+      return nodeId;
+    } catch (NumberFormatException exception) {
+      throw new IllegalStateException(
+          "SQL TaskAsset sourceRef 不是有效节点 ID：" + asset.sourceRef(), exception);
+    }
+  }
+
+  private DevelopmentDataServiceDefinition normalizeDefinition(
+      DevelopmentNode node,
+      ResolvedSqlSource source,
+      String serviceName,
+      String path,
+      String method,
+      List<ParameterContract> requestedParameters,
+      List<ResponseFieldContract> requestedResponseFields,
+      Integer maxRows,
+      Integer timeoutSeconds,
+      String description,
+      List<String> sqlParameterNames,
+      boolean requireResponseContract) {
+    String normalizedName = text(serviceName, node.name(), "服务名称", 200);
+    String normalizedPath = normalizePath(path, node.id());
+    String normalizedMethod = method == null || method.isBlank()
+        ? "GET" : method.trim().toUpperCase(Locale.ROOT);
+    if (!"GET".equals(normalizedMethod)) {
+      throw new IllegalArgumentException("Data Service Node 第一阶段仅支持 GET");
+    }
+
+    List<ParameterContract> parameters =
+        normalizeParameters(requestedParameters, sqlParameterNames);
+    List<ResponseFieldContract> responseFields =
+        normalizeResponseFields(requestedResponseFields);
+    if (requireResponseContract && responseFields.isEmpty()) {
+      throw new IllegalArgumentException("发布前请先预览并确认响应字段 Contract");
+    }
+
+    int normalizedMaxRows = range(
+        maxRows, DEFAULT_MAX_ROWS, 1, 10_000, "最大返回行数");
+    int normalizedTimeout = range(
+        timeoutSeconds, DEFAULT_TIMEOUT_SECONDS, 1, 3_600, "超时时间");
+    String normalizedDescription = optionalText(description, 2_000, "说明");
+
+    return new DevelopmentDataServiceDefinition(
+        source.asset().id(),
+        source.revision().revision().revisionId(),
+        source.revision().revision().revisionNo(),
+        normalizedName,
+        normalizedPath,
+        normalizedMethod,
+        parameters,
+        responseFields,
+        normalizedMaxRows,
+        normalizedTimeout,
+        normalizedDescription);
+  }
+
+  private List<ParameterContract> normalizeParameters(
+      List<ParameterContract> values,
+      List<String> sqlParameterNames) {
+    Map<String, ParameterContract> requested = new LinkedHashMap<>();
+    if (values != null) {
+      for (ParameterContract value : values) {
+        if (value == null) throw new IllegalArgumentException("请求参数 Contract 不能为空");
+        String name = requiredParameterName(value.name());
+        String key = name.toLowerCase(Locale.ROOT);
+        if (requested.putIfAbsent(key, value) != null) {
+          throw new IllegalArgumentException("请求参数重复：" + name);
+        }
+      }
+    }
+
+    List<ParameterContract> normalized = new ArrayList<>();
+    Set<String> expected = new LinkedHashSet<>();
+    for (String rawName : sqlParameterNames == null ? List.<String>of() : sqlParameterNames) {
+      String name = requiredParameterName(rawName);
+      String key = name.toLowerCase(Locale.ROOT);
+      expected.add(key);
+      ParameterContract value = requested.get(key);
+      normalized.add(new ParameterContract(
+          name,
+          normalizeSchemaType(value == null ? "STRING" : value.type()),
+          value == null || value.required(),
+          optionalText(value == null ? null : value.description(), 1_000, "参数描述"),
+          optionalText(value == null ? null : value.example(), 1_000, "参数示例")));
+    }
+
+    for (String key : requested.keySet()) {
+      if (!expected.contains(key)) {
+        throw new IllegalArgumentException(
+            "请求参数不属于 SQL 命名参数：" + requested.get(key).name());
+      }
+    }
+    return List.copyOf(normalized);
+  }
+
+  private List<ResponseFieldContract> normalizeResponseFields(
+      List<ResponseFieldContract> values) {
+    if (values == null || values.isEmpty()) return List.of();
+    List<ResponseFieldContract> normalized = new ArrayList<>();
+    Set<String> names = new HashSet<>();
+    for (ResponseFieldContract value : values) {
+      if (value == null) throw new IllegalArgumentException("响应字段 Contract 不能为空");
+      String name = text(value.name(), null, "响应字段名称", 128);
+      String key = name.toLowerCase(Locale.ROOT);
+      if (!names.add(key)) throw new IllegalArgumentException("响应字段重复：" + name);
+      normalized.add(new ResponseFieldContract(
+          name,
+          normalizeSchemaType(value.type()),
+          value.nullable(),
+          optionalText(value.description(), 1_000, "字段描述"),
+          optionalText(value.example(), 1_000, "字段示例")));
+    }
+    return List.copyOf(normalized);
+  }
+
+  private ContractPreview discoverContract(TaskDefinition sqlDefinition) {
+    List<String> parameterNames = sqlCompiler.parameterNames(sqlDefinition.content());
+    List<ParameterContract> parameters = parameterNames.stream()
+        .map(name -> new ParameterContract(name, "STRING", true, null, null))
+        .toList();
+
+    Map<String, Object> previewParameters = new LinkedHashMap<>();
+    parameterNames.forEach(name -> previewParameters.put(name, null));
+    DevelopmentDataServiceSqlCompiler.CompiledSql compiled =
+        sqlCompiler.compile(sqlDefinition.content(), previewParameters);
+    SourceConfig sourceConfig = sourceConfig(sqlDefinition.configJson());
+
+    DataSourceSqlResult result;
+    try (DataSourceSqlExecutor executor =
+        dataSourceExecutionProvider.open(sourceConfig.dataSourceId())) {
+      result = executor.execute(new DataSourceSqlRequest(
+          compiled.sql(),
+          1,
+          Math.min(sourceConfig.timeoutSeconds(), MAX_PREVIEW_TIMEOUT_SECONDS),
+          compiled.parameters()));
+    }
+    if (!result.resultSet()) {
+      throw new IllegalStateException("Data Service Node Preview 没有返回结果集");
+    }
+    if (result.columns().isEmpty()) {
+      throw new IllegalArgumentException("Data Service Node 来源查询没有可发现的响应字段");
+    }
+
+    List<ResponseFieldContract> responseFields = result.columns().stream()
+        .map(this::toResponseField)
+        .toList();
+    return new ContractPreview(parameters, responseFields);
+  }
+
+  private ResponseFieldContract toResponseField(DataSourceSqlColumn column) {
+    String name = column.label();
+    if (name == null || name.isBlank()) name = column.name();
+    if (name == null || name.isBlank()) {
+      throw new IllegalArgumentException("Data Service Node 来源查询存在无名称响应字段");
+    }
+    return new ResponseFieldContract(
+        name.trim(),
+        schemaType(column.jdbcType()),
+        column.nullable(),
+        null,
+        null);
+  }
+
+  private String schemaType(int jdbcType) {
+    return switch (jdbcType) {
+      case Types.BOOLEAN, Types.BIT -> "BOOLEAN";
+      case Types.TINYINT, Types.SMALLINT, Types.INTEGER, Types.BIGINT -> "INTEGER";
+      case Types.FLOAT, Types.REAL, Types.DOUBLE, Types.NUMERIC, Types.DECIMAL -> "NUMBER";
+      case Types.DATE -> "DATE";
+      case Types.TIME, Types.TIME_WITH_TIMEZONE, Types.TIMESTAMP, Types.TIMESTAMP_WITH_TIMEZONE ->
+          "DATETIME";
+      case Types.CHAR, Types.VARCHAR, Types.LONGVARCHAR,
+          Types.NCHAR, Types.NVARCHAR, Types.LONGNVARCHAR, Types.CLOB, Types.NCLOB -> "STRING";
+      default -> "OBJECT";
+    };
+  }
+
+  private SourceConfig sourceConfig(String configJson) {
+    String raw = configJson == null || configJson.isBlank() ? "{}" : configJson.trim();
+    try {
+      JsonNode root = objectMapper.readTree(raw);
+      if (root == null || !root.isObject()) {
+        throw new IllegalArgumentException("SQL configJson 必须是 JSON Object");
+      }
+      JsonNode dataSourceNode = root.get("dataSourceId");
+      String dataSourceId = dataSourceNode == null || dataSourceNode.isNull()
+          ? null : dataSourceNode.asText();
+      if (dataSourceId == null || dataSourceId.isBlank()) {
+        throw new IllegalArgumentException(
+            "SQL TaskRevision 缺少 dataSourceId，无法预览 Data Service Contract");
+      }
+      int timeout = root.path("timeoutSeconds").asInt(DEFAULT_TIMEOUT_SECONDS);
+      if (timeout < 1 || timeout > 3_600) timeout = DEFAULT_TIMEOUT_SECONDS;
+      return new SourceConfig(dataSourceId.trim(), timeout);
+    } catch (IllegalArgumentException exception) {
+      throw exception;
+    } catch (Exception exception) {
+      throw new IllegalArgumentException("SQL TaskRevision configJson 非法", exception);
+    }
+  }
+
+  private SourceSnapshot toSourceSnapshot(
+      TaskAsset asset,
+      DevelopmentNode sourceNode,
+      TaskAssetRevision pinnedRevision) {
+    return new SourceSnapshot(
+        String.valueOf(sourceNode.id()),
+        sourceNode.name(),
+        String.valueOf(asset.id()),
+        asset.status().name(),
+        String.valueOf(pinnedRevision.revision().revisionId()),
+        pinnedRevision.revision().revisionNo(),
+        String.valueOf(asset.currentRevision().taskRevisionId()),
+        asset.currentRevision().revisionNo(),
+        pinnedRevision.revision().revisionId() != asset.currentRevision().taskRevisionId());
+  }
+
+  private DevelopmentNode requireDataServiceNode(long nodeId) {
+    if (nodeId <= 0L) throw new IllegalArgumentException("nodeId 必须大于 0");
+    DevelopmentNode node = nodeRepository.findById(nodeId)
+        .orElseThrow(() -> new IllegalArgumentException("数据开发节点不存在：" + nodeId));
+    DevelopmentNodeType type = DevelopmentNodeType.tryParse(node.type()).orElse(null);
+    if (type != DevelopmentNodeType.DATA_SERVICE) {
+      throw new IllegalArgumentException("当前节点不是 Data Service Node：" + nodeId);
+    }
+    return node;
+  }
+
+  private DevelopmentDataServiceDraft emptyDraft(DevelopmentNode node) {
+    return new DevelopmentDataServiceDraft(
+        node.id(),
+        new DevelopmentDataServiceDefinition(
+            0L,
+            0L,
+            0,
+            node.name(),
+            "/query/" + node.id(),
+            "GET",
+            List.of(),
+            List.of(),
+            DEFAULT_MAX_ROWS,
+            DEFAULT_TIMEOUT_SECONDS,
+            null),
+        0L,
+        null,
+        null);
+  }
+
+  private String normalizePath(String value, long nodeId) {
+    String path = value == null || value.isBlank() ? "/query/" + nodeId : value.trim();
+    if (!path.startsWith("/")) path = "/" + path;
+    if (path.length() > 255) throw new IllegalArgumentException("服务路径不能超过 255 个字符");
+    if (path.contains(" ") || path.contains("?") || path.contains("#") || path.contains("//")) {
+      throw new IllegalArgumentException("服务路径格式非法：" + path);
+    }
+    return path;
+  }
+
+  private String requiredParameterName(String value) {
+    String name = text(value, null, "请求参数名称", 128);
+    if (!PARAMETER_NAME.matcher(name).matches()) {
+      throw new IllegalArgumentException(
+          "请求参数名必须匹配 [A-Za-z_][A-Za-z0-9_]*：" + name);
+    }
+    return name;
+  }
+
+  private String normalizeSchemaType(String value) {
+    String type = value == null || value.isBlank()
+        ? "STRING" : value.trim().toUpperCase(Locale.ROOT);
+    if (!SCHEMA_TYPES.contains(type)) {
+      throw new IllegalArgumentException("不支持的 Contract 类型：" + value);
+    }
+    return type;
+  }
+
+  private String text(String value, String fallback, String label, int maxLength) {
+    String normalized = value == null || value.isBlank() ? fallback : value.trim();
+    if (normalized == null || normalized.isBlank()) {
+      throw new IllegalArgumentException(label + "不能为空");
+    }
+    if (normalized.length() > maxLength) {
+      throw new IllegalArgumentException(label + "不能超过 " + maxLength + " 个字符");
+    }
+    return normalized;
+  }
+
+  private String optionalText(String value, int maxLength, String label) {
+    if (value == null || value.isBlank()) return null;
+    String normalized = value.trim();
+    if (normalized.length() > maxLength) {
+      throw new IllegalArgumentException(label + "不能超过 " + maxLength + " 个字符");
+    }
+    return normalized;
+  }
+
+  private int range(Integer value, int fallback, int min, int max, String label) {
+    int normalized = value == null ? fallback : value;
+    if (normalized < min || normalized > max) {
+      throw new IllegalArgumentException(label + "必须在 " + min + " ~ " + max + " 之间");
+    }
+    return normalized;
+  }
+
+  private boolean sameProject(Long left, Long right) {
+    return Objects.equals(normalizeProjectId(left), normalizeProjectId(right));
+  }
+
+  private Long normalizeProjectId(Long value) {
+    return value == null || value <= 0L ? null : value;
+  }
+
+  private String checksum(DevelopmentDataServiceDefinition definition) {
+    try {
+      MessageDigest digest = MessageDigest.getInstance("SHA-256");
+      digest.update(objectMapper.writeValueAsString(definition).getBytes(StandardCharsets.UTF_8));
+      return HexFormat.of().formatHex(digest.digest());
+    } catch (NoSuchAlgorithmException impossible) {
+      throw new IllegalStateException("SHA-256 is unavailable", impossible);
+    } catch (JsonProcessingException exception) {
+      throw new IllegalStateException("Data Service Node checksum 序列化失败", exception);
+    }
+  }
+
+  public record SaveDraftCommand(
+      long sourceTaskAssetId,
+      long sourceTaskRevisionId,
+      String serviceName,
+      String path,
+      String method,
+      List<ParameterContract> parameters,
+      List<ResponseFieldContract> responseFields,
+      Integer maxRows,
+      Integer timeoutSeconds,
+      String description,
+      Long baseRevision) {}
+
+  public record SourceSnapshot(
+      String nodeId,
+      String nodeName,
+      String taskAssetId,
+      String status,
+      String revisionId,
+      Integer revisionNo,
+      String currentRevisionId,
+      Integer currentRevisionNo,
+      boolean updateAvailable) {}
+
+  public record PreviewResult(
+      SourceSnapshot source,
+      List<ParameterContract> parameters,
+      List<ResponseFieldContract> responseFields) {}
+
+  public record DataServiceNodeContext(
+      String nodeId,
+      String nodeName,
+      boolean configured,
+      List<SourceSnapshot> availableSources,
+      SourceSnapshot selectedSource,
+      DevelopmentDataServiceDraft draft,
+      DevelopmentDataServiceRevisionSummary latestPublishedRevision,
+      List<DevelopmentDataServiceRevisionSummary> revisions) {}
+
+  private record ResolvedSqlSource(
+      TaskAsset asset,
+      DevelopmentNode sourceNode,
+      TaskAssetRevision revision) {}
+
+  private record ContractPreview(
+      List<ParameterContract> parameters,
+      List<ResponseFieldContract> responseFields) {}
+
+  private record SourceConfig(String dataSourceId, int timeoutSeconds) {}
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentDataServiceSqlCompiler.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentDataServiceSqlCompiler.java
@@ -1,0 +1,128 @@
+package io.yak.ops.business.development.service;
+
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import net.sf.jsqlparser.parser.CCJSqlParserUtil;
+import net.sf.jsqlparser.statement.Statements;
+import net.sf.jsqlparser.statement.select.Select;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterUtils;
+import org.springframework.jdbc.core.namedparam.ParsedSql;
+import org.springframework.stereotype.Component;
+
+/** SQL validation and named-parameter compilation owned by Data Development authoring. */
+@Component
+public class DevelopmentDataServiceSqlCompiler {
+
+  public CompiledSql compile(String sql, Map<String, ?> parameters) {
+    validateSelectOnly(sql);
+    Map<String, ?> values = parameters == null ? Map.of() : parameters;
+    for (String name : parameterNames(sql)) {
+      if (!values.containsKey(name)) {
+        throw new IllegalArgumentException("缺少请求参数：" + name);
+      }
+    }
+    try {
+      MapSqlParameterSource source = new MapSqlParameterSource(values);
+      ParsedSql parsed = NamedParameterUtils.parseSqlStatement(sql);
+      String jdbcSql = NamedParameterUtils.substituteNamedParameters(parsed, source);
+      Object[] boundValues = NamedParameterUtils.buildValueArray(parsed, source, null);
+      return new CompiledSql(
+          jdbcSql,
+          boundValues == null ? List.of() : Arrays.asList(boundValues));
+    } catch (RuntimeException exception) {
+      throw new IllegalArgumentException("SQL 参数绑定失败：" + exception.getMessage(), exception);
+    }
+  }
+
+  /** Discovers :name parameters while ignoring quoted content, comments and PostgreSQL :: casts. */
+  public List<String> parameterNames(String sql) {
+    validateSelectOnly(sql);
+    Set<String> names = new LinkedHashSet<>();
+    boolean singleQuote = false;
+    boolean doubleQuote = false;
+    boolean backtick = false;
+    boolean lineComment = false;
+    boolean blockComment = false;
+
+    for (int index = 0; index < sql.length(); index++) {
+      char current = sql.charAt(index);
+      char next = index + 1 < sql.length() ? sql.charAt(index + 1) : '\0';
+
+      if (lineComment) {
+        if (current == '\n' || current == '\r') lineComment = false;
+        continue;
+      }
+      if (blockComment) {
+        if (current == '*' && next == '/') {
+          blockComment = false;
+          index++;
+        }
+        continue;
+      }
+      if (!singleQuote && !doubleQuote && !backtick) {
+        if (current == '-' && next == '-') {
+          lineComment = true;
+          index++;
+          continue;
+        }
+        if (current == '/' && next == '*') {
+          blockComment = true;
+          index++;
+          continue;
+        }
+      }
+      if (!doubleQuote && !backtick && current == '\'') {
+        if (singleQuote && next == '\'') {
+          index++;
+          continue;
+        }
+        singleQuote = !singleQuote;
+        continue;
+      }
+      if (!singleQuote && !backtick && current == '"') {
+        doubleQuote = !doubleQuote;
+        continue;
+      }
+      if (!singleQuote && !doubleQuote && current == '`') {
+        backtick = !backtick;
+        continue;
+      }
+      if (singleQuote || doubleQuote || backtick || current != ':') continue;
+      if (next == ':' || (index > 0 && sql.charAt(index - 1) == ':')) continue;
+      if (!(Character.isLetter(next) || next == '_')) continue;
+
+      int end = index + 2;
+      while (end < sql.length()) {
+        char candidate = sql.charAt(end);
+        if (!(Character.isLetterOrDigit(candidate) || candidate == '_')) break;
+        end++;
+      }
+      names.add(sql.substring(index + 1, end));
+      index = end - 1;
+    }
+    return List.copyOf(names);
+  }
+
+  public void validateSelectOnly(String sql) {
+    if (sql == null || sql.isBlank()) {
+      throw new IllegalArgumentException("SQL 不能为空");
+    }
+    try {
+      Statements statements = CCJSqlParserUtil.parseStatements(sql);
+      if (statements.getStatements().size() != 1
+          || !(statements.getStatements().getFirst() instanceof Select)) {
+        throw new IllegalArgumentException("Data Service Node 第一阶段仅支持单条 SELECT 查询");
+      }
+    } catch (IllegalArgumentException exception) {
+      throw exception;
+    } catch (Exception exception) {
+      throw new IllegalArgumentException("SQL 解析失败：" + exception.getMessage(), exception);
+    }
+  }
+
+  public record CompiledSql(String sql, List<Object> parameters) {}
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/resources/db/migration/yak-data-development/V11__add_data_service_node_lifecycle.sql
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/resources/db/migration/yak-data-development/V11__add_data_service_node_lifecycle.sql
@@ -1,0 +1,26 @@
+-- Data Service Node authoring stays inside the Data Development domain.
+-- Runtime deployment remains owned by the Data Service module.
+
+CREATE TABLE IF NOT EXISTS yak_dev_data_service_draft (
+    node_id BIGINT NOT NULL,
+    definition_json LONGTEXT NOT NULL,
+    draft_revision BIGINT NOT NULL,
+    create_time DATETIME(6) NOT NULL,
+    update_time DATETIME(6) NOT NULL,
+    PRIMARY KEY (node_id),
+    KEY idx_yak_dev_data_service_draft_update (update_time)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS yak_dev_data_service_revision (
+    id BIGINT NOT NULL,
+    node_id BIGINT NOT NULL,
+    revision_no INT NOT NULL,
+    source_draft_revision BIGINT NOT NULL,
+    definition_json LONGTEXT NOT NULL,
+    checksum CHAR(64) NOT NULL,
+    create_time DATETIME(6) NOT NULL,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_yak_dev_data_service_revision_node_no (node_id, revision_no),
+    KEY idx_yak_dev_data_service_revision_node_time (node_id, create_time),
+    KEY idx_yak_dev_data_service_revision_checksum (node_id, checksum)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/DevelopmentDataServiceNodeServiceTest.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/DevelopmentDataServiceNodeServiceTest.java
@@ -1,0 +1,233 @@
+package io.yak.ops.business.development.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.development.domain.DevelopmentDataServiceDefinition;
+import io.yak.ops.business.development.domain.DevelopmentDataServiceDraft;
+import io.yak.ops.business.development.domain.DevelopmentDataServiceRevision;
+import io.yak.ops.business.development.domain.DevelopmentNode;
+import io.yak.ops.business.development.repository.DevelopmentDataServiceDraftRepository;
+import io.yak.ops.business.development.repository.DevelopmentDataServiceRevisionRepository;
+import io.yak.ops.business.development.repository.DevelopmentNodeRepository;
+import io.yak.ops.business.taskcatalog.domain.TaskAsset;
+import io.yak.ops.business.taskcatalog.domain.TaskAssetRevision;
+import io.yak.ops.business.taskcatalog.service.TaskCatalogService;
+import io.yak.ops.business.taskcatalog.spi.TaskSourceRevision;
+import io.yak.ops.spi.datasource.execution.DataSourceExecutionProvider;
+import io.yak.ops.spi.task.model.TaskAssetSource;
+import io.yak.ops.spi.task.model.TaskAssetStatus;
+import io.yak.ops.spi.task.model.TaskDefinition;
+import io.yak.ops.spi.task.model.TaskRevisionRef;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class DevelopmentDataServiceNodeServiceTest {
+
+  private DevelopmentNodeRepository nodeRepository;
+  private TaskCatalogService taskCatalogService;
+  private DevelopmentDataServiceDraftRepository draftRepository;
+  private DevelopmentDataServiceRevisionRepository revisionRepository;
+  private DevelopmentDataServiceSqlCompiler sqlCompiler;
+  private DevelopmentDataServiceNodeService service;
+
+  @BeforeEach
+  void setUp() {
+    nodeRepository = mock(DevelopmentNodeRepository.class);
+    taskCatalogService = mock(TaskCatalogService.class);
+    draftRepository = mock(DevelopmentDataServiceDraftRepository.class);
+    revisionRepository = mock(DevelopmentDataServiceRevisionRepository.class);
+    sqlCompiler = mock(DevelopmentDataServiceSqlCompiler.class);
+    service = new DevelopmentDataServiceNodeService(
+        nodeRepository,
+        taskCatalogService,
+        draftRepository,
+        revisionRepository,
+        mock(DataSourceExecutionProvider.class),
+        sqlCompiler,
+        new ObjectMapper());
+
+    when(nodeRepository.findById(100L)).thenReturn(Optional.of(dataServiceNode(100L, 7L)));
+    when(nodeRepository.findById(200L)).thenReturn(Optional.of(sqlNode(200L, 7L)));
+  }
+
+  @Test
+  void saveDraftPinsExactSqlRevisionInsteadOfFollowingLatestPointer() {
+    TaskAsset asset = sqlAsset(300L, 200L, 7L, 402L, 4);
+    TaskAssetRevision pinned = sqlRevision(asset, 401L, 3);
+    when(taskCatalogService.get(300L)).thenReturn(asset);
+    when(taskCatalogService.resolveRevision(300L, 401L)).thenReturn(pinned);
+    when(sqlCompiler.parameterNames(anyString())).thenReturn(List.of("status"));
+
+    DevelopmentDataServiceDraft saved = new DevelopmentDataServiceDraft(
+        100L, definition(300L, 401L, 3), 1L, Instant.EPOCH, Instant.EPOCH);
+    when(draftRepository.save(eq(100L), org.mockito.ArgumentMatchers.any(), eq(0L)))
+        .thenReturn(Optional.of(saved));
+    when(revisionRepository.listByNodeId(100L)).thenReturn(List.of());
+
+    DevelopmentDataServiceNodeService.DataServiceNodeContext context = service.saveDraft(
+        100L,
+        new DevelopmentDataServiceNodeService.SaveDraftCommand(
+            300L, 401L, "订单查询 API", "/orders", "GET",
+            List.of(), List.of(), 1000, 30, null, 0L));
+
+    assertEquals(401L, context.draft().definition().sourceTaskRevisionId());
+    assertEquals(3, context.draft().definition().sourceTaskRevisionNo());
+    verify(nodeRepository).updateConfigured(100L, true);
+  }
+
+  @Test
+  void contextKeepsPinnedRevisionAndReportsNewerSqlRevision() {
+    TaskAsset asset = sqlAsset(300L, 200L, 7L, 402L, 4);
+    DevelopmentDataServiceDraft draft = new DevelopmentDataServiceDraft(
+        100L, definition(300L, 401L, 3), 2L, Instant.EPOCH, Instant.EPOCH);
+    when(draftRepository.findByNodeId(100L)).thenReturn(Optional.of(draft));
+    when(revisionRepository.listByNodeId(100L)).thenReturn(List.of());
+    when(taskCatalogService.list("DATA_DEVELOPMENT", "ONLINE", null)).thenReturn(List.of(asset));
+    when(taskCatalogService.get(300L)).thenReturn(asset);
+    when(taskCatalogService.resolveRevision(300L, 401L)).thenReturn(sqlRevision(asset, 401L, 3));
+    when(taskCatalogService.resolveRevision(300L, 402L)).thenReturn(sqlRevision(asset, 402L, 4));
+
+    DevelopmentDataServiceNodeService.DataServiceNodeContext context = service.get(100L);
+
+    assertEquals("401", context.selectedSource().revisionId());
+    assertEquals(3, context.selectedSource().revisionNo());
+    assertEquals("402", context.selectedSource().currentRevisionId());
+    assertEquals(4, context.selectedSource().currentRevisionNo());
+    assertTrue(context.selectedSource().updateAvailable());
+  }
+
+  @Test
+  void publishCreatesResourceRevisionWithoutEnteringTaskCatalog() {
+    TaskAsset asset = sqlAsset(300L, 200L, 7L, 401L, 3);
+    DevelopmentDataServiceDefinition definition = definition(300L, 401L, 3);
+    DevelopmentDataServiceDraft draft = new DevelopmentDataServiceDraft(
+        100L, definition, 5L, Instant.EPOCH, Instant.EPOCH);
+    when(draftRepository.findByNodeIdForUpdate(100L)).thenReturn(Optional.of(draft));
+    when(taskCatalogService.get(300L)).thenReturn(asset);
+    when(taskCatalogService.resolveRevision(300L, 401L)).thenReturn(sqlRevision(asset, 401L, 3));
+    when(sqlCompiler.parameterNames(anyString())).thenReturn(List.of("status"));
+    when(revisionRepository.findLatestByNodeId(100L)).thenReturn(Optional.empty());
+    when(revisionRepository.nextRevisionNo(100L)).thenReturn(1);
+
+    DevelopmentDataServiceRevision revision = new DevelopmentDataServiceRevision(
+        900L, 100L, 1, 5L, definition, "checksum", Instant.EPOCH);
+    when(revisionRepository.insert(
+        eq(100L), eq(1), eq(5L), org.mockito.ArgumentMatchers.any(), anyString()))
+        .thenReturn(revision);
+
+    DevelopmentDataServiceRevision published = service.publish(100L, 5L);
+
+    assertEquals(1, published.revisionNo());
+    assertEquals(401L, published.definition().sourceTaskRevisionId());
+    verify(taskCatalogService, never()).publish(
+        org.mockito.ArgumentMatchers.any(),
+        anyString(),
+        org.mockito.ArgumentMatchers.any(),
+        anyString(),
+        anyString(),
+        anyLong(),
+        org.mockito.ArgumentMatchers.anyInt());
+  }
+
+  @Test
+  void saveRejectsCrossProjectSqlSource() {
+    when(taskCatalogService.get(300L)).thenReturn(sqlAsset(300L, 200L, 9L, 401L, 3));
+
+    IllegalArgumentException error = assertThrows(
+        IllegalArgumentException.class,
+        () -> service.saveDraft(
+            100L,
+            new DevelopmentDataServiceNodeService.SaveDraftCommand(
+                300L, 401L, "订单查询 API", "/orders", "GET",
+                List.of(), List.of(), 1000, 30, null, 0L)));
+
+    assertTrue(error.getMessage().contains("同项目"));
+  }
+
+  @Test
+  void publishRejectsStaleDraftRevision() {
+    DevelopmentDataServiceDraft draft = new DevelopmentDataServiceDraft(
+        100L, definition(300L, 401L, 3), 6L, Instant.EPOCH, Instant.EPOCH);
+    when(draftRepository.findByNodeIdForUpdate(100L)).thenReturn(Optional.of(draft));
+
+    assertThrows(
+        DevelopmentDraftConflictException.class,
+        () -> service.publish(100L, 5L));
+  }
+
+  private static DevelopmentNode dataServiceNode(long id, long projectId) {
+    return new DevelopmentNode(
+        id, "订单查询 API", "DATA_SERVICE", projectId, null, false, Instant.EPOCH, Instant.EPOCH);
+  }
+
+  private static DevelopmentNode sqlNode(long id, long projectId) {
+    return new DevelopmentNode(
+        id, "订单查询.sql", "SQL", projectId, null, true, Instant.EPOCH, Instant.EPOCH);
+  }
+
+  private static TaskAsset sqlAsset(
+      long assetId,
+      long sourceNodeId,
+      long projectId,
+      long currentRevisionId,
+      int currentRevisionNo) {
+    return new TaskAsset(
+        assetId,
+        TaskAssetSource.DATA_DEVELOPMENT,
+        String.valueOf(sourceNodeId),
+        projectId,
+        "订单查询.sql",
+        "SQL",
+        TaskAssetStatus.ONLINE,
+        new TaskRevisionRef(assetId, currentRevisionId, currentRevisionNo),
+        Instant.EPOCH,
+        Instant.EPOCH);
+  }
+
+  private static TaskAssetRevision sqlRevision(TaskAsset asset, long revisionId, int revisionNo) {
+    return new TaskAssetRevision(
+        asset,
+        new TaskSourceRevision(
+            revisionId,
+            revisionNo,
+            new TaskDefinition(
+                "SQL",
+                1,
+                "select id, status from orders where status = :status",
+                "{\"dataSourceId\":\"1\",\"timeoutSeconds\":30}"),
+            "sql-checksum"));
+  }
+
+  private static DevelopmentDataServiceDefinition definition(
+      long assetId,
+      long revisionId,
+      int revisionNo) {
+    return new DevelopmentDataServiceDefinition(
+        assetId,
+        revisionId,
+        revisionNo,
+        "订单查询 API",
+        "/orders",
+        "GET",
+        List.of(new DevelopmentDataServiceDefinition.ParameterContract(
+            "status", "STRING", true, null, null)),
+        List.of(new DevelopmentDataServiceDefinition.ResponseFieldContract(
+            "id", "INTEGER", false, null, null)),
+        1000,
+        30,
+        null);
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/DevelopmentDataServiceSqlCompilerTest.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/DevelopmentDataServiceSqlCompilerTest.java
@@ -1,0 +1,43 @@
+package io.yak.ops.business.development.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class DevelopmentDataServiceSqlCompilerTest {
+
+  private final DevelopmentDataServiceSqlCompiler compiler = new DevelopmentDataServiceSqlCompiler();
+
+  @Test
+  void discoversNamedParametersWithoutTreatingCastsCommentsOrStringsAsParameters() {
+    String sql = """
+        select id, ':ignored' as literal, created_at::date
+        from orders
+        where status = :status
+          and owner_id = :ownerId
+        -- :commented
+        """;
+
+    assertEquals(List.of("status", "ownerId"), compiler.parameterNames(sql));
+  }
+
+  @Test
+  void compilesNamedParametersToJdbcPlaceholdersInStableOrder() {
+    DevelopmentDataServiceSqlCompiler.CompiledSql compiled = compiler.compile(
+        "select * from orders where status = :status and owner_id = :ownerId",
+        Map.of("status", "PAID", "ownerId", 7));
+
+    assertEquals("select * from orders where status = ? and owner_id = ?", compiled.sql());
+    assertEquals(List.of("PAID", 7), compiled.parameters());
+  }
+
+  @Test
+  void rejectsNonSelectStatements() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> compiler.validateSelectOnly("delete from orders"));
+  }
+}

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/development/DevelopmentDataServiceDraftPO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/development/DevelopmentDataServiceDraftPO.java
@@ -1,0 +1,21 @@
+package io.yak.ops.common.bean.po.development;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import java.time.Instant;
+import lombok.Data;
+
+/** Mutable Data Service Node authoring draft. */
+@Data
+@TableName("yak_dev_data_service_draft")
+public class DevelopmentDataServiceDraftPO {
+
+  @TableId(type = IdType.INPUT)
+  private Long nodeId;
+
+  private String definitionJson;
+  private Long draftRevision;
+  private Instant createTime;
+  private Instant updateTime;
+}

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/development/DevelopmentDataServiceRevisionPO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/development/DevelopmentDataServiceRevisionPO.java
@@ -1,0 +1,23 @@
+package io.yak.ops.common.bean.po.development;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import java.time.Instant;
+import lombok.Data;
+
+/** Immutable published Data Service Node revision. */
+@Data
+@TableName("yak_dev_data_service_revision")
+public class DevelopmentDataServiceRevisionPO {
+
+  @TableId(type = IdType.ASSIGN_ID)
+  private Long id;
+
+  private Long nodeId;
+  private Integer revisionNo;
+  private Long sourceDraftRevision;
+  private String definitionJson;
+  private String checksum;
+  private Instant createTime;
+}

--- a/yak-ops-ui/src/pages/data-development/components/DevelopmentEditorWorkspace.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/DevelopmentEditorWorkspace.tsx
@@ -59,7 +59,7 @@ export default function DevelopmentEditorWorkspace({
   if (selectedResource.type === 'DATA_SERVICE') {
     return (
       <main className="flex min-w-0 flex-1 flex-col overflow-hidden bg-white">
-        <DataServiceNodeEditor node={selectedResource} />
+        <DataServiceNodeEditor node={selectedResource} onSaved={onNodesChanged} />
       </main>
     );
   }

--- a/yak-ops-ui/src/pages/data-development/components/data-service/DataServiceNodeEditor.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/data-service/DataServiceNodeEditor.tsx
@@ -1,37 +1,698 @@
-import { Network } from 'lucide-react';
+import {
+  Button,
+  Input,
+  InputNumber,
+  Select,
+  Spin,
+  Switch,
+  Table,
+  Tag,
+  message,
+  type TableColumnsType,
+} from 'antd';
+import { Network, RefreshCw, Rocket, Save } from 'lucide-react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
-import type { DevelopmentResourceNode } from '../../types';
+import {
+  getDevelopmentDataServiceNode,
+  previewDevelopmentDataServiceNode,
+  publishDevelopmentDataServiceNode,
+  saveDevelopmentDataServiceDraft,
+  type DataServiceContractType,
+  type DevelopmentDataServiceNodeContext,
+  type DevelopmentDataServiceParameter,
+  type DevelopmentDataServiceResponseField,
+  type DevelopmentDataServiceRevisionSummary,
+  type DevelopmentDataServiceSource,
+} from '../../data-service-node-service';
+import type { DevelopmentId, DevelopmentResourceNode } from '../../types';
 
 interface DataServiceNodeEditorProps {
   node: DevelopmentResourceNode;
+  onSaved?: () => void | Promise<void>;
 }
 
-export default function DataServiceNodeEditor({ node }: DataServiceNodeEditorProps) {
+const contractTypeOptions: { label: string; value: DataServiceContractType }[] = [
+  { label: 'STRING', value: 'STRING' },
+  { label: 'INTEGER', value: 'INTEGER' },
+  { label: 'NUMBER', value: 'NUMBER' },
+  { label: 'BOOLEAN', value: 'BOOLEAN' },
+  { label: 'DATE', value: 'DATE' },
+  { label: 'DATETIME', value: 'DATETIME' },
+  { label: 'OBJECT', value: 'OBJECT' },
+];
+
+const formatTime = (value?: string) => value ? value.replace('T', ' ').slice(0, 19) : '-';
+
+export default function DataServiceNodeEditor({
+  node,
+  onSaved,
+}: DataServiceNodeEditorProps) {
+  const [context, setContext] = useState<DevelopmentDataServiceNodeContext>();
+  const [selectedSourceId, setSelectedSourceId] = useState<DevelopmentId>();
+  const [selectedRevisionId, setSelectedRevisionId] = useState<DevelopmentId>();
+  const [serviceName, setServiceName] = useState(node.name);
+  const [path, setPath] = useState(`/query/${node.id}`);
+  const [maxRows, setMaxRows] = useState(1000);
+  const [timeoutSeconds, setTimeoutSeconds] = useState(30);
+  const [description, setDescription] = useState('');
+  const [parameters, setParameters] = useState<DevelopmentDataServiceParameter[]>([]);
+  const [responseFields, setResponseFields] = useState<DevelopmentDataServiceResponseField[]>([]);
+  const [dirty, setDirty] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [previewing, setPreviewing] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [publishing, setPublishing] = useState(false);
+
+  const applyContext = useCallback((next: DevelopmentDataServiceNodeContext) => {
+    const definition = next.draft.definition;
+    setContext(next);
+    setSelectedSourceId(
+      definition.sourceTaskAssetId && definition.sourceTaskAssetId !== '0'
+        ? definition.sourceTaskAssetId
+        : undefined,
+    );
+    setSelectedRevisionId(
+      definition.sourceTaskRevisionId && definition.sourceTaskRevisionId !== '0'
+        ? definition.sourceTaskRevisionId
+        : undefined,
+    );
+    setServiceName(definition.serviceName || next.nodeName);
+    setPath(definition.path || `/query/${next.nodeId}`);
+    setMaxRows(definition.maxRows || 1000);
+    setTimeoutSeconds(definition.timeoutSeconds || 30);
+    setDescription(definition.description || '');
+    setParameters(definition.parameters || []);
+    setResponseFields(definition.responseFields || []);
+    setDirty(false);
+  }, []);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      applyContext(await getDevelopmentDataServiceNode(node.id));
+    } catch (error) {
+      message.error(error instanceof Error ? error.message : '加载 Data Service Node 失败');
+      setContext(undefined);
+    } finally {
+      setLoading(false);
+    }
+  }, [applyContext, node.id]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const availableSources = context?.availableSources || [];
+  const sourceOptions = useMemo(() => {
+    const values: DevelopmentDataServiceSource[] = [...availableSources];
+    const pinned = context?.selectedSource;
+    if (pinned && !values.some((source) => source.taskAssetId === pinned.taskAssetId)) {
+      values.unshift(pinned);
+    }
+    return values.map((source) => ({
+      value: source.taskAssetId,
+      disabled: source.status !== 'ONLINE',
+      label: `${source.nodeName} · SQL R${source.currentRevisionNo || source.revisionNo} · ${source.status}`,
+    }));
+  }, [availableSources, context?.selectedSource]);
+
+  const activeSource = useMemo(
+    () => availableSources.find((source) => source.taskAssetId === selectedSourceId)
+      || (context?.selectedSource?.taskAssetId === selectedSourceId
+        ? context.selectedSource
+        : undefined),
+    [availableSources, context?.selectedSource, selectedSourceId],
+  );
+
+  const selectedRevisionNo = useMemo(() => {
+    if (!activeSource || !selectedRevisionId) return undefined;
+    if (activeSource.revisionId === selectedRevisionId) return activeSource.revisionNo;
+    if (activeSource.currentRevisionId === selectedRevisionId) {
+      return activeSource.currentRevisionNo || undefined;
+    }
+    if (context?.selectedSource?.revisionId === selectedRevisionId) {
+      return context.selectedSource.revisionNo;
+    }
+    return undefined;
+  }, [activeSource, context?.selectedSource, selectedRevisionId]);
+
+  const sourceUpdateAvailable = Boolean(
+    activeSource?.currentRevisionId
+      && selectedRevisionId
+      && activeSource.currentRevisionId !== selectedRevisionId,
+  );
+
+  const markDirty = () => setDirty(true);
+
+  const changeSource = (taskAssetId: DevelopmentId) => {
+    const source = availableSources.find((item) => item.taskAssetId === taskAssetId);
+    setSelectedSourceId(taskAssetId);
+    setSelectedRevisionId(source?.currentRevisionId || source?.revisionId);
+    setParameters([]);
+    setResponseFields([]);
+    markDirty();
+  };
+
+  const upgradeSource = () => {
+    if (!activeSource?.currentRevisionId) return;
+    setSelectedRevisionId(activeSource.currentRevisionId);
+    setParameters([]);
+    setResponseFields([]);
+    markDirty();
+  };
+
+  const preview = async () => {
+    if (!selectedSourceId || !selectedRevisionId || previewing) return;
+    setPreviewing(true);
+    try {
+      const result = await previewDevelopmentDataServiceNode(
+        node.id,
+        selectedSourceId,
+        selectedRevisionId,
+      );
+
+      const oldParameters = new Map(
+        parameters.map((item) => [item.name.toLowerCase(), item]),
+      );
+      const oldResponses = new Map(
+        responseFields.map((item) => [item.name.toLowerCase(), item]),
+      );
+
+      setParameters(result.parameters.map((item) => {
+        const previous = oldParameters.get(item.name.toLowerCase());
+        return previous ? {
+          ...item,
+          type: previous.type,
+          required: previous.required,
+          description: previous.description,
+          example: previous.example,
+        } : item;
+      }));
+      setResponseFields(result.responseFields.map((item) => {
+        const previous = oldResponses.get(item.name.toLowerCase());
+        return previous ? {
+          ...item,
+          type: previous.type,
+          description: previous.description,
+          example: previous.example,
+        } : item;
+      }));
+      setSelectedSourceId(result.source.taskAssetId);
+      setSelectedRevisionId(result.source.revisionId);
+      markDirty();
+      message.success(
+        `Contract 已发现 · ${result.parameters.length} 个参数 / ${result.responseFields.length} 个响应字段`,
+      );
+    } catch (error) {
+      message.error(error instanceof Error ? error.message : '预览 Data Service Contract 失败');
+    } finally {
+      setPreviewing(false);
+    }
+  };
+
+  const save = async () => {
+    if (!selectedSourceId || !selectedRevisionId || saving) return;
+    setSaving(true);
+    try {
+      const next = await saveDevelopmentDataServiceDraft(node.id, {
+        sourceTaskAssetId: selectedSourceId,
+        sourceTaskRevisionId: selectedRevisionId,
+        serviceName: serviceName.trim(),
+        path: path.trim(),
+        method: 'GET',
+        parameters: parameters.map((item) => ({
+          ...item,
+          description: item.description?.trim() || undefined,
+          example: item.example?.trim() || undefined,
+        })),
+        responseFields: responseFields.map((item) => ({
+          ...item,
+          description: item.description?.trim() || undefined,
+          example: item.example?.trim() || undefined,
+        })),
+        maxRows,
+        timeoutSeconds,
+        description: description.trim() || undefined,
+        baseRevision: context?.draft.draftRevision || 0,
+      });
+      applyContext(next);
+      await onSaved?.();
+      message.success(`Data Service 草稿已保存 · Draft #${next.draft.draftRevision}`);
+    } catch (error) {
+      message.error(error instanceof Error ? error.message : '保存 Data Service Node 草稿失败');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const publish = async () => {
+    const draftRevision = context?.draft.draftRevision || 0;
+    if (!draftRevision || dirty || publishing) {
+      if (dirty) message.warning('请先保存当前 Data Service Node 草稿');
+      return;
+    }
+    setPublishing(true);
+    try {
+      const revision = await publishDevelopmentDataServiceNode(node.id, draftRevision);
+      await load();
+      await onSaved?.();
+      message.success(`Data Service Node 已发布 · DS R${revision.revisionNo}`);
+    } catch (error) {
+      message.error(error instanceof Error ? error.message : '发布 Data Service Node 失败');
+    } finally {
+      setPublishing(false);
+    }
+  };
+
+  const updateParameter = (
+    index: number,
+    patch: Partial<DevelopmentDataServiceParameter>,
+  ) => {
+    setParameters((current) => current.map((item, itemIndex) =>
+      itemIndex === index ? { ...item, ...patch } : item,
+    ));
+    markDirty();
+  };
+
+  const updateResponseField = (
+    index: number,
+    patch: Partial<DevelopmentDataServiceResponseField>,
+  ) => {
+    setResponseFields((current) => current.map((item, itemIndex) =>
+      itemIndex === index ? { ...item, ...patch } : item,
+    ));
+    markDirty();
+  };
+
+  const parameterColumns = useMemo<TableColumnsType<DevelopmentDataServiceParameter>>(() => [
+    {
+      title: '参数',
+      dataIndex: 'name',
+      width: 170,
+      render: (value: string) => (
+        <span className="font-mono text-[12px] text-[#344054]">{value}</span>
+      ),
+    },
+    {
+      title: '类型',
+      dataIndex: 'type',
+      width: 130,
+      render: (value: DataServiceContractType, _record, index) => (
+        <Select
+          size="small"
+          value={value}
+          options={contractTypeOptions.filter((item) => item.value !== 'OBJECT')}
+          className="w-full"
+          onChange={(next) => updateParameter(index, { type: next })}
+        />
+      ),
+    },
+    {
+      title: '必填',
+      dataIndex: 'required',
+      width: 72,
+      render: (value: boolean, _record, index) => (
+        <Switch
+          size="small"
+          checked={value}
+          onChange={(next) => updateParameter(index, { required: next })}
+        />
+      ),
+    },
+    {
+      title: '描述',
+      dataIndex: 'description',
+      render: (value: string | null | undefined, _record, index) => (
+        <Input
+          size="small"
+          value={value || ''}
+          maxLength={1000}
+          placeholder="参数说明"
+          onChange={(event) => updateParameter(index, { description: event.target.value })}
+        />
+      ),
+    },
+    {
+      title: '示例',
+      dataIndex: 'example',
+      width: 180,
+      render: (value: string | null | undefined, _record, index) => (
+        <Input
+          size="small"
+          value={value || ''}
+          maxLength={1000}
+          placeholder="例如：PAID"
+          onChange={(event) => updateParameter(index, { example: event.target.value })}
+        />
+      ),
+    },
+  ], []);
+
+  const responseColumns = useMemo<TableColumnsType<DevelopmentDataServiceResponseField>>(() => [
+    {
+      title: '字段',
+      dataIndex: 'name',
+      width: 170,
+      render: (value: string) => (
+        <span className="font-mono text-[12px] text-[#344054]">{value}</span>
+      ),
+    },
+    {
+      title: '类型',
+      dataIndex: 'type',
+      width: 130,
+      render: (value: DataServiceContractType, _record, index) => (
+        <Select
+          size="small"
+          value={value}
+          options={contractTypeOptions}
+          className="w-full"
+          onChange={(next) => updateResponseField(index, { type: next })}
+        />
+      ),
+    },
+    {
+      title: '可空',
+      dataIndex: 'nullable',
+      width: 72,
+      render: (value: boolean) => (
+        <span className="text-[12px] text-[#667085]">{value ? '是' : '否'}</span>
+      ),
+    },
+    {
+      title: '描述',
+      dataIndex: 'description',
+      render: (value: string | null | undefined, _record, index) => (
+        <Input
+          size="small"
+          value={value || ''}
+          maxLength={1000}
+          placeholder="字段说明"
+          onChange={(event) => updateResponseField(index, { description: event.target.value })}
+        />
+      ),
+    },
+    {
+      title: '示例',
+      dataIndex: 'example',
+      width: 180,
+      render: (value: string | null | undefined, _record, index) => (
+        <Input
+          size="small"
+          value={value || ''}
+          maxLength={1000}
+          placeholder="可选"
+          onChange={(event) => updateResponseField(index, { example: event.target.value })}
+        />
+      ),
+    },
+  ], []);
+
+  const revisionColumns = useMemo<TableColumnsType<DevelopmentDataServiceRevisionSummary>>(() => [
+    {
+      title: '版本',
+      dataIndex: 'revisionNo',
+      width: 90,
+      render: (value: number) => <span className="font-medium">DS R{value}</span>,
+    },
+    {
+      title: '来源 SQL',
+      dataIndex: 'sourceTaskRevisionNo',
+      width: 120,
+      render: (value: number) => `SQL R${value}`,
+    },
+    {
+      title: 'Draft',
+      dataIndex: 'sourceDraftRevision',
+      width: 100,
+      render: (value: number) => `#${value}`,
+    },
+    {
+      title: '发布时间',
+      dataIndex: 'createTime',
+      render: (value?: string) => formatTime(value),
+    },
+  ], []);
+
+  if (loading) {
+    return (
+      <div className="flex min-h-0 flex-1 items-center justify-center bg-white">
+        <Spin size="small" />
+      </div>
+    );
+  }
+
+  const draftRevision = context?.draft.draftRevision || 0;
+  const latestPublished = context?.latestPublishedRevision;
+  const canSave = Boolean(
+    selectedSourceId
+      && selectedRevisionId
+      && serviceName.trim()
+      && path.trim(),
+  );
+  const canPublish = Boolean(
+    draftRevision > 0
+      && !dirty
+      && responseFields.length > 0,
+  );
+
   return (
     <div className="flex min-h-0 flex-1 flex-col overflow-hidden bg-white">
-      <div className="flex h-12 shrink-0 items-center border-b border-[#e4e7ec] px-4">
+      <div className="flex h-12 shrink-0 items-center justify-between border-b border-[#e4e7ec] px-4">
         <div className="flex min-w-0 items-center gap-2.5">
           <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-[#f5f5f6] text-[#475467]">
             <Network size={15} />
           </span>
           <div className="min-w-0">
             <div className="truncate text-[13px] font-semibold text-[#161823]">{node.name}</div>
-            <div className="text-[10px] text-[#98a2b3]">数据服务节点 · 独立资源</div>
+            <div className="text-[10px] text-[#98a2b3]">
+              Data Service Node
+              {draftRevision ? ` · Draft #${draftRevision}` : ' · 尚未保存'}
+              {latestPublished ? ` · 已发布 DS R${latestPublished.revisionNo}` : ''}
+              {dirty ? ' · 有未保存更改' : ''}
+            </div>
           </div>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <Button
+            size="small"
+            icon={<RefreshCw size={13} />}
+            loading={previewing}
+            disabled={!selectedSourceId || !selectedRevisionId}
+            onClick={() => void preview()}
+          >
+            预览 Contract
+          </Button>
+          <Button
+            size="small"
+            icon={<Save size={13} />}
+            loading={saving}
+            disabled={!canSave}
+            onClick={() => void save()}
+          >
+            保存草稿
+          </Button>
+          <Button
+            size="small"
+            type="primary"
+            icon={<Rocket size={13} />}
+            loading={publishing}
+            disabled={!canPublish}
+            onClick={() => void publish()}
+          >
+            发布版本
+          </Button>
         </div>
       </div>
 
-      <div className="flex min-h-0 flex-1 items-center justify-center px-6">
-        <div className="max-w-[560px] text-center">
-          <div className="mx-auto mb-3 flex h-10 w-10 items-center justify-center rounded-xl bg-[#f5f5f6] text-[#667085]">
-            <Network size={19} />
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        <section className="border-b border-[#eef0f2] px-4 py-3">
+          <div className="mb-2 text-[11px] font-semibold text-[#344054]">来源 SQL Revision</div>
+          <div className="grid max-w-[980px] grid-cols-[110px_minmax(0,1fr)] items-start gap-y-2">
+            <span className="pt-1.5 text-[11px] text-[#667085]">SQL 节点</span>
+            <Select
+              showSearch
+              optionFilterProp="label"
+              value={selectedSourceId}
+              options={sourceOptions}
+              placeholder="选择同项目中已发布的 ONLINE SQL"
+              className="w-full"
+              onChange={(value) => changeSource(String(value))}
+            />
           </div>
-          <div className="text-[13px] font-semibold text-[#344054]">数据服务配置归属于当前节点</div>
-          <div className="mt-2 text-[11px] leading-6 text-[#98a2b3]">
-            SQL 节点只负责 SQL 的开发与发布，不再直接创建 API。
-            数据服务的来源、接口配置与发布生命周期将在这个节点内统一管理。
+
+          <div className="ml-[110px] mt-1.5 text-[10px] leading-5 text-[#98a2b3]">
+            Data Service Draft 固定精确 SQL Revision。SQL 后续发布新版本时不会自动漂移，需要显式升级来源。
           </div>
-        </div>
+
+          {!availableSources.length ? (
+            <div className="mt-2 rounded-md border border-[#e4e7ec] bg-[#fafafa] px-2.5 py-2 text-[11px] text-[#667085]">
+              当前项目暂无可选的 ONLINE SQL，请先在数据开发发布一个 SQL 节点。
+            </div>
+          ) : null}
+
+          {activeSource && selectedRevisionId ? (
+            <div className="mt-2 flex flex-wrap items-center gap-2 text-[11px] text-[#667085]">
+              <span>{activeSource.nodeName}</span>
+              <Tag className="!m-0">SQL R{selectedRevisionNo || '-'}</Tag>
+              <span className="text-[#98a2b3]">Revision #{selectedRevisionId}</span>
+              {sourceUpdateAvailable ? (
+                <>
+                  <span className="font-medium text-[#b54708]">
+                    SQL R{activeSource.currentRevisionNo} 可更新
+                  </span>
+                  <Button size="small" onClick={upgradeSource}>
+                    更新来源
+                  </Button>
+                </>
+              ) : (
+                <span className="text-[#667085]">已固定当前 Revision</span>
+              )}
+            </div>
+          ) : null}
+        </section>
+
+        <section className="border-b border-[#eef0f2] px-4 py-3">
+          <div className="mb-2 text-[11px] font-semibold text-[#344054]">接口定义</div>
+          <div className="grid max-w-[980px] grid-cols-[110px_minmax(0,1fr)_110px_minmax(0,1fr)] items-start gap-x-4 gap-y-2">
+            <span className="pt-1.5 text-[11px] text-[#667085]">服务名称</span>
+            <Input
+              size="small"
+              value={serviceName}
+              maxLength={200}
+              onChange={(event) => {
+                setServiceName(event.target.value);
+                markDirty();
+              }}
+            />
+            <span className="pt-1.5 text-[11px] text-[#667085]">请求路径</span>
+            <Input
+              size="small"
+              addonBefore="GET"
+              value={path}
+              maxLength={255}
+              placeholder="/orders"
+              onChange={(event) => {
+                setPath(event.target.value);
+                markDirty();
+              }}
+            />
+
+            <span className="pt-1.5 text-[11px] text-[#667085]">最大行数</span>
+            <InputNumber
+              size="small"
+              min={1}
+              max={10000}
+              value={maxRows}
+              className="w-full"
+              onChange={(value) => {
+                setMaxRows(Number(value || 1000));
+                markDirty();
+              }}
+            />
+            <span className="pt-1.5 text-[11px] text-[#667085]">超时时间</span>
+            <InputNumber
+              size="small"
+              min={1}
+              max={3600}
+              value={timeoutSeconds}
+              addonAfter="秒"
+              className="w-full"
+              onChange={(value) => {
+                setTimeoutSeconds(Number(value || 30));
+                markDirty();
+              }}
+            />
+
+            <span className="pt-1.5 text-[11px] text-[#667085]">说明</span>
+            <div className="col-span-3">
+              <Input.TextArea
+                value={description}
+                maxLength={2000}
+                autoSize={{ minRows: 2, maxRows: 4 }}
+                placeholder="说明这个数据服务提供什么能力"
+                onChange={(event) => {
+                  setDescription(event.target.value);
+                  markDirty();
+                }}
+              />
+            </div>
+          </div>
+        </section>
+
+        <section className="border-b border-[#eef0f2] px-4 py-3">
+          <div className="mb-2 flex items-center justify-between">
+            <div>
+              <div className="text-[11px] font-semibold text-[#344054]">请求参数 Contract</div>
+              <div className="mt-0.5 text-[10px] text-[#98a2b3]">
+                参数名来自 SQL 中的 :name 命名参数；类型、必填、描述和示例属于 Data Service Node。
+              </div>
+            </div>
+            <span className="text-[10px] text-[#98a2b3]">{parameters.length} 个参数</span>
+          </div>
+          <Table<DevelopmentDataServiceParameter>
+            size="small"
+            pagination={false}
+            rowKey="name"
+            dataSource={parameters}
+            columns={parameterColumns}
+            locale={{
+              emptyText: selectedRevisionId
+                ? '点击“预览 Contract”发现 SQL 请求参数'
+                : '先选择一个 SQL Revision',
+            }}
+            scroll={{ x: 880 }}
+          />
+        </section>
+
+        <section className="border-b border-[#eef0f2] px-4 py-3">
+          <div className="mb-2 flex items-center justify-between">
+            <div>
+              <div className="text-[11px] font-semibold text-[#344054]">响应字段 Contract</div>
+              <div className="mt-0.5 text-[10px] text-[#98a2b3]">
+                响应字段和基础类型通过只读 Preview 自动发现；描述和示例随 Data Service Revision 冻结。
+              </div>
+            </div>
+            <span className="text-[10px] text-[#98a2b3]">{responseFields.length} 个字段</span>
+          </div>
+          <Table<DevelopmentDataServiceResponseField>
+            size="small"
+            pagination={false}
+            rowKey="name"
+            dataSource={responseFields}
+            columns={responseColumns}
+            locale={{
+              emptyText: selectedRevisionId
+                ? '点击“预览 Contract”发现响应字段'
+                : '先选择一个 SQL Revision',
+            }}
+            scroll={{ x: 880 }}
+          />
+        </section>
+
+        <section className="px-4 py-3">
+          <div className="mb-2 flex items-center justify-between">
+            <div>
+              <div className="text-[11px] font-semibold text-[#344054]">发布历史</div>
+              <div className="mt-0.5 text-[10px] text-[#98a2b3]">
+                这里发布的是数据开发域内的不可变 Data Service Node Revision，不会创建 Runtime API。
+              </div>
+            </div>
+            <Tag className="!m-0">
+              {latestPublished ? `最新 DS R${latestPublished.revisionNo}` : '尚未发布'}
+            </Tag>
+          </div>
+          <Table<DevelopmentDataServiceRevisionSummary>
+            size="small"
+            pagination={false}
+            rowKey="id"
+            dataSource={context?.revisions || []}
+            columns={revisionColumns}
+            locale={{ emptyText: '保存草稿并发布后，这里会出现 DS Revision' }}
+          />
+        </section>
       </div>
     </div>
   );

--- a/yak-ops-ui/src/pages/data-development/data-service-node-service.ts
+++ b/yak-ops-ui/src/pages/data-development/data-service-node-service.ts
@@ -1,0 +1,175 @@
+import type { ApiResponse } from '@/services/http/response';
+import { API_SUCCESS_CODE } from '@/services/http/response';
+import HttpUtils from '@/utils/HttpUtils';
+
+import type { DevelopmentId } from './types';
+
+const NODE_API = '/api/v1/data-development/nodes';
+
+export type DataServiceContractType =
+  | 'STRING'
+  | 'INTEGER'
+  | 'NUMBER'
+  | 'BOOLEAN'
+  | 'DATE'
+  | 'DATETIME'
+  | 'OBJECT';
+
+export interface DevelopmentDataServiceParameter {
+  name: string;
+  type: DataServiceContractType;
+  required: boolean;
+  description?: string | null;
+  example?: string | null;
+}
+
+export interface DevelopmentDataServiceResponseField {
+  name: string;
+  type: DataServiceContractType;
+  nullable: boolean;
+  description?: string | null;
+  example?: string | null;
+}
+
+export interface DevelopmentDataServiceDefinition {
+  sourceTaskAssetId: DevelopmentId;
+  sourceTaskRevisionId: DevelopmentId;
+  sourceTaskRevisionNo: number;
+  serviceName: string;
+  path: string;
+  method: 'GET';
+  parameters: DevelopmentDataServiceParameter[];
+  responseFields: DevelopmentDataServiceResponseField[];
+  maxRows: number;
+  timeoutSeconds: number;
+  description?: string | null;
+}
+
+export interface DevelopmentDataServiceDraft {
+  nodeId: DevelopmentId;
+  definition: DevelopmentDataServiceDefinition;
+  draftRevision: number;
+  createTime?: string | null;
+  updateTime?: string | null;
+}
+
+export interface DevelopmentDataServiceSource {
+  nodeId?: DevelopmentId | null;
+  nodeName: string;
+  taskAssetId: DevelopmentId;
+  status: string;
+  revisionId: DevelopmentId;
+  revisionNo: number;
+  currentRevisionId?: DevelopmentId | null;
+  currentRevisionNo?: number | null;
+  updateAvailable: boolean;
+}
+
+export interface DevelopmentDataServiceRevisionSummary {
+  id: DevelopmentId;
+  nodeId: DevelopmentId;
+  revisionNo: number;
+  sourceDraftRevision: number;
+  sourceTaskRevisionId: DevelopmentId;
+  sourceTaskRevisionNo: number;
+  checksum: string;
+  createTime?: string;
+}
+
+export interface DevelopmentDataServiceRevision {
+  id: DevelopmentId;
+  nodeId: DevelopmentId;
+  revisionNo: number;
+  sourceDraftRevision: number;
+  definition: DevelopmentDataServiceDefinition;
+  checksum: string;
+  createTime?: string;
+}
+
+export interface DevelopmentDataServiceNodeContext {
+  nodeId: DevelopmentId;
+  nodeName: string;
+  configured: boolean;
+  availableSources: DevelopmentDataServiceSource[];
+  selectedSource?: DevelopmentDataServiceSource | null;
+  draft: DevelopmentDataServiceDraft;
+  latestPublishedRevision?: DevelopmentDataServiceRevisionSummary | null;
+  revisions: DevelopmentDataServiceRevisionSummary[];
+}
+
+export interface PreviewDevelopmentDataServiceResult {
+  source: DevelopmentDataServiceSource;
+  parameters: DevelopmentDataServiceParameter[];
+  responseFields: DevelopmentDataServiceResponseField[];
+}
+
+export interface SaveDevelopmentDataServiceDraftPayload {
+  sourceTaskAssetId: DevelopmentId;
+  sourceTaskRevisionId: DevelopmentId;
+  serviceName: string;
+  path: string;
+  method: 'GET';
+  parameters: DevelopmentDataServiceParameter[];
+  responseFields: DevelopmentDataServiceResponseField[];
+  maxRows: number;
+  timeoutSeconds: number;
+  description?: string;
+  baseRevision: number;
+}
+
+const unwrap = <T,>(response: ApiResponse<T>, fallback: string): T => {
+  if (response?.code !== API_SUCCESS_CODE || response.data === undefined) {
+    throw new Error(response?.message || response?.msg || fallback);
+  }
+  return response.data;
+};
+
+export const getDevelopmentDataServiceNode = async (
+  nodeId: DevelopmentId,
+): Promise<DevelopmentDataServiceNodeContext> => unwrap(
+  await HttpUtils.get<DevelopmentDataServiceNodeContext>(`${NODE_API}/${nodeId}/data-service`),
+  '查询 Data Service Node 失败',
+);
+
+export const previewDevelopmentDataServiceNode = async (
+  nodeId: DevelopmentId,
+  sourceTaskAssetId: DevelopmentId,
+  sourceTaskRevisionId: DevelopmentId,
+): Promise<PreviewDevelopmentDataServiceResult> => unwrap(
+  await HttpUtils.post<PreviewDevelopmentDataServiceResult>(
+    `${NODE_API}/${nodeId}/data-service/preview`,
+    { sourceTaskAssetId, sourceTaskRevisionId },
+  ),
+  '预览 Data Service Contract 失败',
+);
+
+export const saveDevelopmentDataServiceDraft = async (
+  nodeId: DevelopmentId,
+  payload: SaveDevelopmentDataServiceDraftPayload,
+): Promise<DevelopmentDataServiceNodeContext> => unwrap(
+  await HttpUtils.put<DevelopmentDataServiceNodeContext>(
+    `${NODE_API}/${nodeId}/data-service/draft`,
+    payload,
+  ),
+  '保存 Data Service Node 草稿失败',
+);
+
+export const publishDevelopmentDataServiceNode = async (
+  nodeId: DevelopmentId,
+  expectedDraftRevision: number,
+): Promise<DevelopmentDataServiceRevision> => unwrap(
+  await HttpUtils.post<DevelopmentDataServiceRevision>(
+    `${NODE_API}/${nodeId}/data-service/publish`,
+    { expectedDraftRevision },
+  ),
+  '发布 Data Service Node 失败',
+);
+
+export const listDevelopmentDataServiceRevisions = async (
+  nodeId: DevelopmentId,
+): Promise<DevelopmentDataServiceRevisionSummary[]> => unwrap(
+  await HttpUtils.get<DevelopmentDataServiceRevisionSummary[]>(
+    `${NODE_API}/${nodeId}/data-service/revisions`,
+  ),
+  '查询 Data Service Node 版本失败',
+);


### PR DESCRIPTION
## 背景

这是 Data Service Node 接入计划的 **Phase 1：数据开发域内的 Authoring Lifecycle**。

这一阶段只解决一个问题：让 `DATA_SERVICE` 从占位节点变成真正的一等数据开发资产，拥有自己的 Draft、精确 SQL Revision 绑定、Contract Preview、不可变发布版本和版本历史。

## 领域边界

本 PR 明确保持：

- **Data Development** 拥有 Data Service Node 的开发、草稿、Contract 与 Revision
- Data Service Node **不进入 Task Catalog**
- Data Service Node **不进入 Workflow**
- 本阶段发布只生成 immutable `DataServiceNodeRevision`
- 本阶段 **不会创建/更新 Data Service Runtime API**
- 不调用 `/api/v1/data-service/publish`

后续 Phase 2 再由 Data Service 模块通过 SourceProvider 消费已发布的 Data Service Node Revision。

## 后端

### 1. 独立 Resource 生命周期

新增独立模型：

- `DevelopmentDataServiceDefinition`
- `DevelopmentDataServiceDraft`
- `DevelopmentDataServiceRevision`
- `DevelopmentDataServiceRevisionSummary`

并使用专属持久化：

- `yak_dev_data_service_draft`
- `yak_dev_data_service_revision`

没有复用 `DevelopmentTaskDraft / TaskRevision`，避免把 Data Service 重新塞回可执行 Task 生命周期。

### 2. 精确 SQL Revision Pinning

Data Service Draft 保存：

- `sourceTaskAssetId`
- `sourceTaskRevisionId`
- `sourceTaskRevisionNo`

SQL 后续从 R3 发布到 R4 时，Data Service Draft 仍固定 R3，只返回 `updateAvailable`；必须由用户显式执行“更新来源”才切换到 R4，不会自动漂移。

来源约束：

- 仅 `DATA_DEVELOPMENT` TaskAsset
- 当前仅 SQL
- 仅 ONLINE
- 必须同项目
- TaskAsset `sourceRef` 必须仍指向真实 SQL DevelopmentNode

### 3. Contract Preview

新增数据开发域自己的 `DevelopmentDataServiceSqlCompiler`：

- 只允许单条 SELECT
- 解析 `:name` 命名参数
- 忽略字符串、注释和 PostgreSQL `::` cast 中的伪参数
- 编译为 JDBC placeholder + 参数列表

Preview 基于用户选中的 **精确 SQL Revision**：

- 参数 Contract 来自 SQL `:name`
- 响应 Contract 通过只读查询 metadata 发现
- Preview 最大 1 行 / 最大 30 秒
- Contract 支持补充类型、必填、描述、示例

Authoring SQL support 放在 data-development 内，不新增对 Runtime compiler 的依赖方向。

### 4. Draft / Publish

Draft：

- `baseRevision` 乐观并发
- 并发覆盖时明确冲突

Publish：

- `FOR UPDATE` 锁定 Draft
- 校验 expectedDraftRevision
- 再次解析并验证精确 SQL Revision
- 发布前要求已确认响应 Contract
- SHA-256 checksum
- 同 Draft + 同 checksum 幂等返回最新发布版本
- 否则生成下一版 immutable DS Revision

### 5. Authoring API

新增：

- `GET /api/v1/data-development/nodes/{nodeId}/data-service`
- `POST /api/v1/data-development/nodes/{nodeId}/data-service/preview`
- `PUT /api/v1/data-development/nodes/{nodeId}/data-service/draft`
- `POST /api/v1/data-development/nodes/{nodeId}/data-service/publish`
- `GET /api/v1/data-development/nodes/{nodeId}/data-service/revisions`
- `GET /api/v1/data-development/nodes/{nodeId}/data-service/revisions/{revisionNo}`

这些接口全部属于 Data Development Authoring API。

## 前端

原 Data Service Node 占位页替换为完整编辑器：

- 选择同项目 ONLINE SQL
- 展示并固定精确 SQL Revision
- SQL 有新版本时显示“SQL Rn 可更新”
- 用户显式“更新来源”后才改变 Revision
- Preview Contract
- 请求参数 Contract 编辑
- 响应字段 Contract 编辑
- 服务名称 / GET Path / maxRows / timeout / description
- 保存 Draft
- 发布 DS Revision
- 发布历史

编辑器内明确提示：这里发布的是数据开发域的不可变 Data Service Node Revision，不会部署 Runtime API。

## 测试

新增覆盖：

- Draft 固定旧 SQL Revision，不追随 latest pointer
- SQL 新 Revision 可被检测但不会自动升级
- 发布 Data Service Resource Revision 时不会写 Task Catalog
- 跨项目 SQL 来源被拒绝
- stale Draft 发布被拒绝
- SQL named parameter 解析
- JDBC named parameter 编译
- 非 SELECT SQL 拒绝

## 明确不做

本 PR 不包含：

- `DataServiceNodeRevision -> Data Service Runtime`
- 新 Data Service SourceProvider
- 数据服务模块“新增 API”改造
- 已有 Runtime API source snapshot 迁移
- API Key / Auth / Cache / Circuit Breaker 改造
- Workflow 改造

## 下一阶段

Phase 2：

`Published Data Service Node Revision -> DevelopmentDataServiceNodeSourceProvider -> DataServicePublicationService -> Runtime Snapshot`

Runtime 只消费数据开发已经发布好的不可变 Data Service 资产。