### PR TITLE
feat: complete data service node deployment lifecycle

### DIFF
--- a/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/controller/v1/DataServicePublicationStateController.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/controller/v1/DataServicePublicationStateController.java
@@ -1,0 +1,32 @@
+package io.yak.ops.business.dataservice.controller.v1;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.yak.framework.common.Result;
+import io.yak.ops.business.dataservice.service.DataServicePublicationService;
+import io.yak.ops.business.dataservice.service.DataServicePublicationService.PublicationState;
+import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Read-only publication-state endpoint used by authoring surfaces to show Runtime drift. */
+@Tag(name = "数据服务发布状态")
+@RestController
+@ConditionalOnDataSourceEnabled
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/data-service/publication")
+public class DataServicePublicationStateController {
+
+  private final DataServicePublicationService publicationService;
+
+  @Operation(summary = "查询已发布来源与 Runtime 的同步状态")
+  @GetMapping("/state")
+  public Result<PublicationState> state(
+      @RequestParam("sourceType") String sourceType,
+      @RequestParam("sourceRef") String sourceRef) {
+    return Result.success(publicationService.state(sourceType, sourceRef));
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-service/src/test/java/io/yak/ops/business/dataservice/controller/v1/DataServicePublicationStateControllerTest.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/test/java/io/yak/ops/business/dataservice/controller/v1/DataServicePublicationStateControllerTest.java
@@ -1,0 +1,26 @@
+package io.yak.ops.business.dataservice.controller.v1;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.dataservice.service.DataServicePublicationService;
+import io.yak.ops.business.dataservice.service.DataServicePublicationService.PublicationState;
+import org.junit.jupiter.api.Test;
+
+class DataServicePublicationStateControllerTest {
+
+  @Test
+  void stateDelegatesToPublicationBoundary() {
+    DataServicePublicationService publicationService = mock(DataServicePublicationService.class);
+    PublicationState state = new PublicationState(false, false, null, null);
+    when(publicationService.state("DATA_DEVELOPMENT_DATA_SERVICE", "100")).thenReturn(state);
+
+    DataServicePublicationStateController controller =
+        new DataServicePublicationStateController(publicationService);
+
+    controller.state("DATA_DEVELOPMENT_DATA_SERVICE", "100");
+
+    verify(publicationService).state("DATA_DEVELOPMENT_DATA_SERVICE", "100");
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-service/src/test/java/io/yak/ops/business/dataservice/service/DataServicePublicationStateTest.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/test/java/io/yak/ops/business/dataservice/service/DataServicePublicationStateTest.java
@@ -1,0 +1,96 @@
+package io.yak.ops.business.dataservice.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.dataservice.service.DataServiceService.ApiView;
+import io.yak.ops.business.dataservice.service.source.DataServiceSourceProvider;
+import io.yak.ops.business.dataservice.service.source.DataServiceSourceProvider.ResolvedSource;
+import io.yak.ops.business.dataservice.service.source.DataServiceSourceProvider.SourceDescriptor;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class DataServicePublicationStateTest {
+
+  private static final String SOURCE_TYPE = "DATA_DEVELOPMENT_DATA_SERVICE";
+
+  private DataServiceService dataServiceService;
+  private DataServiceSourceProvider provider;
+  private DataServicePublicationService service;
+
+  @BeforeEach
+  void setUp() {
+    dataServiceService = mock(DataServiceService.class);
+    provider = mock(DataServiceSourceProvider.class);
+    when(provider.sourceType()).thenReturn(SOURCE_TYPE);
+    service = new DataServicePublicationService(
+        dataServiceService,
+        mock(DataServiceDocumentationService.class),
+        List.of(provider));
+  }
+
+  @Test
+  void stateDistinguishesUndeployedPendingAndSynchronizedRuntime() {
+    when(provider.resolve("100")).thenReturn(new ResolvedSource(
+        new SourceDescriptor(
+            SOURCE_TYPE,
+            "100",
+            "订单查询 API",
+            "DATA_SERVICE",
+            "ONLINE",
+            903L,
+            3,
+            42L,
+            500,
+            30,
+            "/orders",
+            null,
+            Instant.parse("2026-08-16T01:00:00Z")),
+        "select id from orders"));
+
+    when(dataServiceService.findBySource(SOURCE_TYPE, "100")).thenReturn(Optional.empty());
+    var undeployed = service.state(SOURCE_TYPE, "100");
+    assertThat(undeployed.published()).isFalse();
+    assertThat(undeployed.updateAvailable()).isFalse();
+
+    when(dataServiceService.findBySource(SOURCE_TYPE, "100"))
+        .thenReturn(Optional.of(view(902L, 2, false)));
+    var pending = service.state(SOURCE_TYPE, "100");
+    assertThat(pending.published()).isTrue();
+    assertThat(pending.updateAvailable()).isTrue();
+    assertThat(pending.detail().enabled()).isFalse();
+
+    when(dataServiceService.findBySource(SOURCE_TYPE, "100"))
+        .thenReturn(Optional.of(view(903L, 3, true)));
+    var synchronizedState = service.state(SOURCE_TYPE, "100");
+    assertThat(synchronizedState.published()).isTrue();
+    assertThat(synchronizedState.updateAvailable()).isFalse();
+    assertThat(synchronizedState.detail().enabled()).isTrue();
+  }
+
+  private ApiView view(Long revisionId, int revisionNo, boolean enabled) {
+    return new ApiView(
+        9L,
+        "订单查询 API",
+        "/orders",
+        "/api/v1/data-service/runtime/orders",
+        42L,
+        "select id from orders",
+        List.of(),
+        500,
+        30,
+        enabled,
+        "NONE",
+        null,
+        SOURCE_TYPE,
+        "100",
+        revisionId,
+        revisionNo,
+        null,
+        null);
+  }
+}

--- a/yak-ops-ui/src/pages/data-development/components/DevelopmentEditorWorkspace.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/DevelopmentEditorWorkspace.tsx
@@ -1,5 +1,6 @@
-import { Boxes } from 'lucide-react';
-import { useMemo } from 'react';
+import { Button } from 'antd';
+import { Boxes, RefreshCw } from 'lucide-react';
+import { Component, type ReactNode, useMemo } from 'react';
 
 import { isDevelopmentTaskNode } from '../node-model';
 import type {
@@ -17,6 +18,58 @@ interface DevelopmentEditorWorkspaceProps {
   selectedNodeId?: DevelopmentId;
   onNodeFocus: (nodeId?: DevelopmentId) => void;
   onNodesChanged?: () => void | Promise<void>;
+}
+
+interface ResourceEditorBoundaryProps {
+  resourceKey: DevelopmentId;
+  children: ReactNode;
+}
+
+interface ResourceEditorBoundaryState {
+  error?: string;
+}
+
+/** Prevents one standalone resource editor from blanking the whole Data Development workspace. */
+class ResourceEditorBoundary extends Component<
+  ResourceEditorBoundaryProps,
+  ResourceEditorBoundaryState
+> {
+  state: ResourceEditorBoundaryState = {};
+
+  static getDerivedStateFromError(error: unknown): ResourceEditorBoundaryState {
+    return {
+      error: error instanceof Error ? error.message : '资源编辑器发生未知错误',
+    };
+  }
+
+  componentDidUpdate(previous: ResourceEditorBoundaryProps) {
+    if (previous.resourceKey !== this.props.resourceKey && this.state.error) {
+      this.setState({ error: undefined });
+    }
+  }
+
+  render() {
+    if (!this.state.error) return this.props.children;
+    return (
+      <div className="flex min-h-0 flex-1 items-center justify-center bg-white px-6">
+        <div className="max-w-[520px] text-center">
+          <div className="mx-auto flex h-10 w-10 items-center justify-center rounded-xl bg-[#f5f5f6] text-[#98a2b3]">
+            <Boxes size={18} />
+          </div>
+          <div className="mt-3 text-[14px] font-semibold text-[#344054]">资源编辑器加载异常</div>
+          <div className="mt-1 text-[12px] leading-5 text-[#98a2b3]">{this.state.error}</div>
+          <Button
+            className="mt-4"
+            size="small"
+            icon={<RefreshCw size={13} />}
+            onClick={() => this.setState({ error: undefined })}
+          >
+            重新渲染
+          </Button>
+        </div>
+      </div>
+    );
+  }
 }
 
 export default function DevelopmentEditorWorkspace({
@@ -51,7 +104,9 @@ export default function DevelopmentEditorWorkspace({
   if (selectedResource.type === 'DATASET') {
     return (
       <main className="flex min-w-0 flex-1 flex-col overflow-hidden bg-white">
-        <DatasetNodeEditor node={selectedResource} onSaved={onNodesChanged} />
+        <ResourceEditorBoundary resourceKey={selectedResource.id}>
+          <DatasetNodeEditor node={selectedResource} onSaved={onNodesChanged} />
+        </ResourceEditorBoundary>
       </main>
     );
   }
@@ -59,7 +114,9 @@ export default function DevelopmentEditorWorkspace({
   if (selectedResource.type === 'DATA_SERVICE') {
     return (
       <main className="flex min-w-0 flex-1 flex-col overflow-hidden bg-white">
-        <DataServiceNodeEditor node={selectedResource} onSaved={onNodesChanged} />
+        <ResourceEditorBoundary resourceKey={selectedResource.id}>
+          <DataServiceNodeEditor node={selectedResource} onSaved={onNodesChanged} />
+        </ResourceEditorBoundary>
       </main>
     );
   }

--- a/yak-ops-ui/src/pages/data-development/components/data-service/DataServiceNodeEditor.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/data-service/DataServiceNodeEditor.tsx
@@ -1,3 +1,4 @@
+import { history } from '@umijs/max';
 import {
   Button,
   Input,
@@ -10,7 +11,7 @@ import {
   message,
   type TableColumnsType,
 } from 'antd';
-import { Network, RefreshCw, Rocket, Save } from 'lucide-react';
+import { ExternalLink, Network, RefreshCw, Rocket, Save } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import {
@@ -19,12 +20,19 @@ import {
   publishDevelopmentDataServiceNode,
   saveDevelopmentDataServiceDraft,
   type DataServiceContractType,
+  type DevelopmentDataServiceDefinition,
   type DevelopmentDataServiceNodeContext,
   type DevelopmentDataServiceParameter,
   type DevelopmentDataServiceResponseField,
   type DevelopmentDataServiceRevisionSummary,
   type DevelopmentDataServiceSource,
 } from '../../data-service-node-service';
+import {
+  deployDataServiceRuntime,
+  fetchDataServicePublicationState,
+  syncDataServiceRuntime,
+  type DataServicePublicationState,
+} from '../../data-service-runtime-publication';
 import type { DevelopmentId, DevelopmentResourceNode } from '../../types';
 
 interface DataServiceNodeEditorProps {
@@ -42,7 +50,57 @@ const contractTypeOptions: { label: string; value: DataServiceContractType }[] =
   { label: 'OBJECT', value: 'OBJECT' },
 ];
 
-const formatTime = (value?: string) => value ? value.replace('T', ' ').slice(0, 19) : '-';
+const formatTime = (value?: string | null) => value ? value.replace('T', ' ').slice(0, 19) : '-';
+const normalizeId = (value: unknown): DevelopmentId => {
+  if (value === undefined || value === null || String(value).trim() === '') return '0';
+  return String(value);
+};
+const safeArray = <T,>(value: T[] | null | undefined): T[] =>
+  Array.isArray(value) ? value.filter(Boolean) : [];
+
+/**
+ * Data Service Node is a resource editor, so one malformed/older API payload must never crash the
+ * whole Data Development workspace. Keep a complete local authoring shape even while wire contracts
+ * evolve across releases.
+ */
+const normalizeContext = (
+  raw: DevelopmentDataServiceNodeContext,
+  node: DevelopmentResourceNode,
+): DevelopmentDataServiceNodeContext => {
+  const rawDraft = raw?.draft;
+  const rawDefinition = rawDraft?.definition;
+  const nodeId = normalizeId(raw?.nodeId || node.id);
+  const definition: DevelopmentDataServiceDefinition = {
+    sourceTaskAssetId: normalizeId(rawDefinition?.sourceTaskAssetId),
+    sourceTaskRevisionId: normalizeId(rawDefinition?.sourceTaskRevisionId),
+    sourceTaskRevisionNo: Number(rawDefinition?.sourceTaskRevisionNo || 0),
+    serviceName: rawDefinition?.serviceName || raw?.nodeName || node.name,
+    path: rawDefinition?.path || `/query/${nodeId}`,
+    method: 'GET',
+    parameters: safeArray(rawDefinition?.parameters),
+    responseFields: safeArray(rawDefinition?.responseFields),
+    maxRows: Number(rawDefinition?.maxRows || 1000),
+    timeoutSeconds: Number(rawDefinition?.timeoutSeconds || 30),
+    description: rawDefinition?.description || undefined,
+  };
+
+  return {
+    nodeId,
+    nodeName: raw?.nodeName || node.name,
+    configured: Boolean(raw?.configured),
+    availableSources: safeArray(raw?.availableSources),
+    selectedSource: raw?.selectedSource || null,
+    draft: {
+      nodeId: normalizeId(rawDraft?.nodeId || nodeId),
+      definition,
+      draftRevision: Number(rawDraft?.draftRevision || 0),
+      createTime: rawDraft?.createTime,
+      updateTime: rawDraft?.updateTime,
+    },
+    latestPublishedRevision: raw?.latestPublishedRevision || null,
+    revisions: safeArray(raw?.revisions),
+  };
+};
 
 export default function DataServiceNodeEditor({
   node,
@@ -60,44 +118,76 @@ export default function DataServiceNodeEditor({
   const [responseFields, setResponseFields] = useState<DevelopmentDataServiceResponseField[]>([]);
   const [dirty, setDirty] = useState(false);
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string>();
   const [previewing, setPreviewing] = useState(false);
   const [saving, setSaving] = useState(false);
   const [publishing, setPublishing] = useState(false);
+  const [publicationState, setPublicationState] = useState<DataServicePublicationState>();
+  const [publicationError, setPublicationError] = useState<string>();
+  const [publicationLoading, setPublicationLoading] = useState(false);
+  const [deploying, setDeploying] = useState(false);
 
-  const applyContext = useCallback((next: DevelopmentDataServiceNodeContext) => {
+  const applyContext = useCallback((raw: DevelopmentDataServiceNodeContext) => {
+    const next = normalizeContext(raw, node);
     const definition = next.draft.definition;
     setContext(next);
     setSelectedSourceId(
-      definition.sourceTaskAssetId && definition.sourceTaskAssetId !== '0'
-        ? definition.sourceTaskAssetId
-        : undefined,
+      definition.sourceTaskAssetId !== '0' ? definition.sourceTaskAssetId : undefined,
     );
     setSelectedRevisionId(
-      definition.sourceTaskRevisionId && definition.sourceTaskRevisionId !== '0'
-        ? definition.sourceTaskRevisionId
-        : undefined,
+      definition.sourceTaskRevisionId !== '0' ? definition.sourceTaskRevisionId : undefined,
     );
     setServiceName(definition.serviceName || next.nodeName);
     setPath(definition.path || `/query/${next.nodeId}`);
     setMaxRows(definition.maxRows || 1000);
     setTimeoutSeconds(definition.timeoutSeconds || 30);
     setDescription(definition.description || '');
-    setParameters(definition.parameters || []);
-    setResponseFields(definition.responseFields || []);
+    setParameters(safeArray(definition.parameters));
+    setResponseFields(safeArray(definition.responseFields));
     setDirty(false);
-  }, []);
+    return next;
+  }, [node]);
+
+  const loadPublicationState = useCallback(async (
+    hasPublishedRevision: boolean,
+    notifyOnError = false,
+  ) => {
+    if (!hasPublishedRevision) {
+      setPublicationState(undefined);
+      setPublicationError(undefined);
+      return;
+    }
+    setPublicationLoading(true);
+    setPublicationError(undefined);
+    try {
+      setPublicationState(await fetchDataServicePublicationState(node.id));
+    } catch (error) {
+      const text = error instanceof Error ? error.message : '查询 Runtime 同步状态失败';
+      setPublicationState(undefined);
+      setPublicationError(text);
+      if (notifyOnError) message.error(text);
+    } finally {
+      setPublicationLoading(false);
+    }
+  }, [node.id]);
 
   const load = useCallback(async () => {
     setLoading(true);
+    setLoadError(undefined);
+    setPublicationState(undefined);
+    setPublicationError(undefined);
     try {
-      applyContext(await getDevelopmentDataServiceNode(node.id));
+      const next = applyContext(await getDevelopmentDataServiceNode(node.id));
+      await loadPublicationState(Boolean(next.latestPublishedRevision));
     } catch (error) {
-      message.error(error instanceof Error ? error.message : '加载 Data Service Node 失败');
+      const text = error instanceof Error ? error.message : '加载 Data Service Node 失败';
+      setLoadError(text);
       setContext(undefined);
+      message.error(text);
     } finally {
       setLoading(false);
     }
-  }, [applyContext, node.id]);
+  }, [applyContext, loadPublicationState, node.id]);
 
   useEffect(() => {
     void load();
@@ -110,11 +200,13 @@ export default function DataServiceNodeEditor({
     if (pinned && !values.some((source) => source.taskAssetId === pinned.taskAssetId)) {
       values.unshift(pinned);
     }
-    return values.map((source) => ({
-      value: source.taskAssetId,
-      disabled: source.status !== 'ONLINE',
-      label: `${source.nodeName} · SQL R${source.currentRevisionNo || source.revisionNo} · ${source.status}`,
-    }));
+    return values
+      .filter((source) => source && source.taskAssetId)
+      .map((source) => ({
+        value: source.taskAssetId,
+        disabled: source.status !== 'ONLINE',
+        label: `${source.nodeName || 'SQL'} · SQL R${source.currentRevisionNo || source.revisionNo || '-'} · ${source.status || 'UNKNOWN'}`,
+      }));
   }, [availableSources, context?.selectedSource]);
 
   const activeSource = useMemo(
@@ -171,15 +263,16 @@ export default function DataServiceNodeEditor({
         selectedSourceId,
         selectedRevisionId,
       );
-
+      const nextParameters = safeArray(result?.parameters);
+      const nextResponses = safeArray(result?.responseFields);
       const oldParameters = new Map(
-        parameters.map((item) => [item.name.toLowerCase(), item]),
+        parameters.filter((item) => item?.name).map((item) => [item.name.toLowerCase(), item]),
       );
       const oldResponses = new Map(
-        responseFields.map((item) => [item.name.toLowerCase(), item]),
+        responseFields.filter((item) => item?.name).map((item) => [item.name.toLowerCase(), item]),
       );
 
-      setParameters(result.parameters.map((item) => {
+      setParameters(nextParameters.map((item) => {
         const previous = oldParameters.get(item.name.toLowerCase());
         return previous ? {
           ...item,
@@ -189,7 +282,7 @@ export default function DataServiceNodeEditor({
           example: previous.example,
         } : item;
       }));
-      setResponseFields(result.responseFields.map((item) => {
+      setResponseFields(nextResponses.map((item) => {
         const previous = oldResponses.get(item.name.toLowerCase());
         return previous ? {
           ...item,
@@ -198,11 +291,13 @@ export default function DataServiceNodeEditor({
           example: previous.example,
         } : item;
       }));
-      setSelectedSourceId(result.source.taskAssetId);
-      setSelectedRevisionId(result.source.revisionId);
+      if (result?.source) {
+        setSelectedSourceId(normalizeId(result.source.taskAssetId));
+        setSelectedRevisionId(normalizeId(result.source.revisionId));
+      }
       markDirty();
       message.success(
-        `Contract 已发现 · ${result.parameters.length} 个参数 / ${result.responseFields.length} 个响应字段`,
+        `Contract 已发现 · ${nextParameters.length} 个参数 / ${nextResponses.length} 个响应字段`,
       );
     } catch (error) {
       message.error(error instanceof Error ? error.message : '预览 Data Service Contract 失败');
@@ -234,11 +329,11 @@ export default function DataServiceNodeEditor({
         maxRows,
         timeoutSeconds,
         description: description.trim() || undefined,
-        baseRevision: context?.draft.draftRevision || 0,
+        baseRevision: context?.draft?.draftRevision || 0,
       });
       applyContext(next);
       await onSaved?.();
-      message.success(`Data Service 草稿已保存 · Draft #${next.draft.draftRevision}`);
+      message.success(`Data Service 草稿已保存 · Draft #${next?.draft?.draftRevision || '-'}`);
     } catch (error) {
       message.error(error instanceof Error ? error.message : '保存 Data Service Node 草稿失败');
     } finally {
@@ -247,7 +342,7 @@ export default function DataServiceNodeEditor({
   };
 
   const publish = async () => {
-    const draftRevision = context?.draft.draftRevision || 0;
+    const draftRevision = context?.draft?.draftRevision || 0;
     if (!draftRevision || dirty || publishing) {
       if (dirty) message.warning('请先保存当前 Data Service Node 草稿');
       return;
@@ -262,6 +357,28 @@ export default function DataServiceNodeEditor({
       message.error(error instanceof Error ? error.message : '发布 Data Service Node 失败');
     } finally {
       setPublishing(false);
+    }
+  };
+
+  const deployOrSync = async () => {
+    const latestPublished = context?.latestPublishedRevision;
+    if (!latestPublished || !publicationState || deploying) return;
+    setDeploying(true);
+    try {
+      if (publicationState.published) {
+        const apiId = publicationState.detail?.id;
+        if (!apiId) throw new Error('Runtime API 身份缺失，请刷新同步状态后重试');
+        await syncDataServiceRuntime(apiId);
+        message.success(`Runtime 已同步到 DS R${latestPublished.revisionNo}`);
+      } else {
+        await deployDataServiceRuntime(node.id);
+        message.success(`Runtime 已部署 · DS R${latestPublished.revisionNo} · 默认停用`);
+      }
+      await loadPublicationState(true, true);
+    } catch (error) {
+      message.error(error instanceof Error ? error.message : '部署 Data Service Runtime 失败');
+    } finally {
+      setDeploying(false);
     }
   };
 
@@ -443,7 +560,26 @@ export default function DataServiceNodeEditor({
     );
   }
 
-  const draftRevision = context?.draft.draftRevision || 0;
+  if (!context) {
+    return (
+      <div className="flex min-h-0 flex-1 items-center justify-center bg-white px-6">
+        <div className="max-w-[520px] text-center">
+          <div className="mx-auto flex h-10 w-10 items-center justify-center rounded-lg bg-[#f5f5f6] text-[#667085]">
+            <Network size={18} />
+          </div>
+          <div className="mt-3 text-[14px] font-semibold text-[#344054]">Data Service Node 加载失败</div>
+          <div className="mt-1 text-[12px] leading-5 text-[#98a2b3]">
+            {loadError || '节点上下文暂时不可用。编辑器已阻止异常数据继续渲染，避免工作区白屏。'}
+          </div>
+          <Button className="mt-4" size="small" icon={<RefreshCw size={13} />} onClick={() => void load()}>
+            重新加载
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  const draftRevision = context?.draft?.draftRevision || 0;
   const latestPublished = context?.latestPublishedRevision;
   const canSave = Boolean(
     selectedSourceId
@@ -455,6 +591,27 @@ export default function DataServiceNodeEditor({
     draftRevision > 0
       && !dirty
       && responseFields.length > 0,
+  );
+  const runtimeRevisionNo = publicationState?.detail?.sourceRevisionNo;
+  const runtimeStatusLabel = !latestPublished
+    ? '等待发布 DS Revision'
+    : publicationError
+      ? 'Runtime 状态不可用'
+      : publicationLoading && !publicationState
+        ? '正在查询 Runtime'
+        : !publicationState
+          ? 'Runtime 状态未知'
+          : !publicationState.published
+            ? '未部署'
+            : publicationState.updateAvailable
+              ? '待同步'
+              : publicationState.detail?.enabled
+                ? '已同步 · 运行中'
+                : '已同步 · 已停用';
+  const showDeployAction = Boolean(
+    latestPublished
+      && publicationState
+      && (!publicationState.published || publicationState.updateAvailable),
   );
 
   return (
@@ -508,6 +665,90 @@ export default function DataServiceNodeEditor({
       </div>
 
       <div className="min-h-0 flex-1 overflow-y-auto">
+        <section className="border-b border-[#eef0f2] px-4 py-3">
+          <div className="mb-2 flex items-center justify-between gap-3">
+            <div>
+              <div className="text-[11px] font-semibold text-[#344054]">Runtime 部署</div>
+              <div className="mt-0.5 text-[10px] text-[#98a2b3]">
+                Data Development 负责发布不可变 DS Revision；这里仅显式部署/同步，运行策略仍在“数据服务”模块管理。
+              </div>
+            </div>
+            <div className="flex items-center gap-2">
+              <Tag className="!m-0" bordered={false}>{runtimeStatusLabel}</Tag>
+              {latestPublished ? (
+                <Button
+                  size="small"
+                  type="text"
+                  icon={<RefreshCw size={12} />}
+                  loading={publicationLoading}
+                  onClick={() => void loadPublicationState(true, true)}
+                >
+                  刷新
+                </Button>
+              ) : null}
+            </div>
+          </div>
+
+          <div className="flex max-w-[980px] flex-wrap items-center justify-between gap-3 border border-[#e5e7eb] bg-[#fafafa] px-3 py-2.5">
+            <div className="flex min-w-0 flex-wrap items-center gap-x-5 gap-y-1 text-[11px] text-[#667085]">
+              <span>
+                最新发布：
+                <b className="font-medium text-[#344054]">
+                  {latestPublished ? `DS R${latestPublished.revisionNo}` : '尚未发布'}
+                </b>
+              </span>
+              <span>
+                Runtime：
+                <b className="font-medium text-[#344054]">
+                  {publicationState?.published ? `DS R${runtimeRevisionNo || '-'}` : '未部署'}
+                </b>
+              </span>
+              {publicationState?.detail?.runtimePath ? (
+                <span className="max-w-[360px] truncate font-mono text-[#475467]">
+                  {publicationState.detail.runtimePath}
+                </span>
+              ) : null}
+              {publicationState?.updateAvailable ? (
+                <span className="font-medium text-[#b54708]">
+                  Runtime 仍为 DS R{runtimeRevisionNo || '-'}，需显式同步到 DS R{latestPublished?.revisionNo}
+                </span>
+              ) : null}
+              {publicationError ? (
+                <span className="text-[#b42318]">{publicationError}</span>
+              ) : null}
+            </div>
+
+            <div className="flex shrink-0 items-center gap-2">
+              {showDeployAction ? (
+                <Button
+                  size="small"
+                  type="primary"
+                  icon={<Rocket size={13} />}
+                  loading={deploying}
+                  onClick={() => void deployOrSync()}
+                >
+                  {publicationState?.published ? '同步最新 Revision' : '部署 Runtime'}
+                </Button>
+              ) : null}
+              {publicationState?.published ? (
+                <Button
+                  size="small"
+                  icon={<ExternalLink size={13} />}
+                  onClick={() => history.push('/data-service')}
+                >
+                  打开 API 服务
+                </Button>
+              ) : null}
+            </div>
+          </div>
+
+          {latestPublished && publicationState && !publicationState.published ? (
+            <div className="mt-1.5 text-[10px] text-[#98a2b3]">
+              首次部署默认保持停用，部署完成后请到“数据服务”配置访问控制并显式启用。
+            </div>
+          ) : null}
+        </section>
+
         <section className="border-b border-[#eef0f2] px-4 py-3">
           <div className="mb-2 text-[11px] font-semibold text-[#344054]">来源 SQL Revision</div>
           <div className="grid max-w-[980px] grid-cols-[110px_minmax(0,1fr)] items-start gap-y-2">
@@ -677,7 +918,7 @@ export default function DataServiceNodeEditor({
             <div>
               <div className="text-[11px] font-semibold text-[#344054]">发布历史</div>
               <div className="mt-0.5 text-[10px] text-[#98a2b3]">
-                这里发布的是数据开发域内的不可变 Data Service Node Revision，不会创建 Runtime API。
+                发布只生成不可变 DS Revision；新版本不会自动改变线上 Runtime，需要在上方显式部署或同步。
               </div>
             </div>
             <Tag className="!m-0">

--- a/yak-ops-ui/src/pages/data-development/data-service-runtime-publication.ts
+++ b/yak-ops-ui/src/pages/data-development/data-service-runtime-publication.ts
@@ -1,0 +1,80 @@
+import type { ApiResponse } from '@/services/http/response';
+import { API_SUCCESS_CODE } from '@/services/http/response';
+import HttpUtils from '@/utils/HttpUtils';
+
+import type { DevelopmentId } from './types';
+
+const DATA_SERVICE_API = '/api/v1/data-service';
+export const DATA_SERVICE_NODE_SOURCE = 'DATA_DEVELOPMENT_DATA_SERVICE' as const;
+
+export interface DataServicePublicationSource {
+  sourceType: string;
+  sourceRef: string;
+  name: string;
+  sourceKind: string;
+  status: string;
+  sourceRevisionId: number | string;
+  sourceRevisionNo: number;
+  dataSourceId: number | string;
+  maxRows?: number | null;
+  timeoutSeconds?: number | null;
+  defaultPath: string;
+  description?: string | null;
+  updateTime?: string | null;
+}
+
+export interface DataServiceRuntimeApiSnapshot {
+  id: number | string;
+  name: string;
+  path: string;
+  runtimePath: string;
+  enabled: boolean;
+  sourceType?: string | null;
+  sourceRef?: string | null;
+  sourceRevisionId?: number | string | null;
+  sourceRevisionNo?: number | null;
+}
+
+export interface DataServicePublicationState {
+  published: boolean;
+  updateAvailable: boolean;
+  source: DataServicePublicationSource;
+  detail?: DataServiceRuntimeApiSnapshot | null;
+}
+
+const unwrap = <T,>(response: ApiResponse<T>, fallback: string): T => {
+  if (response?.code !== API_SUCCESS_CODE || response.data === undefined) {
+    throw new Error(response?.message || response?.msg || fallback);
+  }
+  return response.data;
+};
+
+export const fetchDataServicePublicationState = async (
+  nodeId: DevelopmentId,
+): Promise<DataServicePublicationState> => unwrap(
+  await HttpUtils.get<DataServicePublicationState>(
+    `${DATA_SERVICE_API}/publication/state?sourceType=${encodeURIComponent(DATA_SERVICE_NODE_SOURCE)}&sourceRef=${encodeURIComponent(nodeId)}`,
+  ),
+  '查询 Data Service Runtime 同步状态失败',
+);
+
+export const deployDataServiceRuntime = async (
+  nodeId: DevelopmentId,
+): Promise<DataServiceRuntimeApiSnapshot> => unwrap(
+  await HttpUtils.post<DataServiceRuntimeApiSnapshot>(`${DATA_SERVICE_API}/publish`, {
+    sourceType: DATA_SERVICE_NODE_SOURCE,
+    sourceRef: nodeId,
+    enabled: false,
+  }),
+  '部署 Data Service Runtime 失败',
+);
+
+export const syncDataServiceRuntime = async (
+  apiId: number | string,
+): Promise<DataServiceRuntimeApiSnapshot> => unwrap(
+  await HttpUtils.post<DataServiceRuntimeApiSnapshot>(
+    `${DATA_SERVICE_API}/${apiId}/republish`,
+    {},
+  ),
+  '同步 Data Service Runtime 失败',
+);


### PR DESCRIPTION
## 背景

这是 Data Service Node 三阶段收口的 **Phase 3：Authoring / Revision / Runtime 状态闭环**，并顺便修复当前点击“数据开发 -> 数据服务节点”后可能出现的白屏问题。

前两阶段已经建立了正确边界：

```text
Phase 1
Data Service Node
  -> Draft
  -> immutable DS Revision

Phase 2
Published DS Revision
  -> Data Service Runtime Snapshot
```

Phase 3 不再扩充领域模型，而是把用户真正操作时缺少的最后一段补齐：

```text
Draft
  -> Publish DS Rn
  -> 查看 Runtime 当前 Revision
  -> 显式 Deploy / Sync
  -> Runtime 运维仍回到“数据服务”模块
```

## 1. Data Service Node 显示 Runtime 发布状态

新增只读发布状态接口：

```text
GET /api/v1/data-service/publication/state
```

输入稳定的 source identity：

- `sourceType = DATA_DEVELOPMENT_DATA_SERVICE`
- `sourceRef = Data Service Node ID`

返回：

- 最新 Published DS Revision
- 是否已经部署 Runtime
- Runtime 当前使用的 DS Revision
- 是否有新 Revision 待同步
- Runtime enabled 状态 / Endpoint

复用 Phase 2 已有的 `DataServicePublicationService.state(...)`，没有再建立第二套状态模型。

## 2. 节点编辑器形成完整版本视图

Data Service Node 现在同时展示三层状态：

```text
Draft #n
Latest Published DS Rn
Runtime DS Rm
```

典型状态：

- 尚未发布 DS Revision
- 已发布，但 Runtime 未部署
- Runtime 已同步
- Runtime 已同步但当前停用
- 新 DS Revision 已发布，Runtime 仍是旧版本，待同步
- Runtime 状态服务暂不可用

例如：

```text
Draft #6
最新发布 DS R3
Runtime DS R2
=> 待同步
```

这样可以明确区分“我已经开发/发布了什么”和“线上当前真正跑的是什么”。

## 3. 显式 Deploy / Sync，不自动漂移

### 首次部署

发布至少一个 DS Revision 后，编辑器出现：

`部署 Runtime`

首次部署：

- 使用最新 Published DS Revision
- 创建 Runtime Snapshot
- 默认保持停用
- 后续启用、Auth、API Key、缓存、熔断等仍去“数据服务”模块管理

### 后续同步

Data Development 发布 DS R2 / R3 后，**不会自动改变线上 API**。

如果 Runtime 仍在 R1，会显示：

`Runtime DS R1 -> 最新 DS R2 · 待同步`

用户显式点击：

`同步最新 Revision`

之后复用 Phase 2 的 republish 语义更新同一个 Runtime API identity，并保留运行态配置。

这保证版本升级始终可审计，不会因为开发侧发布版本而让线上逻辑偷偷漂移。

## 4. 保持领域边界

Phase 3 没有把 Runtime 管理能力搬回数据开发。

Data Service Node 只负责：

- 查询部署状态
- 首次部署
- 同步最新 Revision
- 跳转到 API 服务管理

下面这些仍只属于 Data Service Runtime：

- enable / disable
- Auth mode
- API Key / rate limit
- cache
- circuit breaker
- metrics
- call audit

因此最终边界仍然是：

```text
Data Development
= Authoring + immutable Data Service asset

Data Service
= Deployment + Runtime operations

Workflow
= 不消费 Data Service asset
```

## 5. 修复 Data Service Node 白屏

本 PR 同时消除两个会让独立资源编辑区进入白屏/空白状态的风险点。

### 5.1 Context 防御性归一化

旧实现直接假定接口一定返回完整结构，例如：

```text
context.draft.definition
availableSources
parameters
responseFields
revisions
```

如果历史数据、升级中的接口响应或异常返回出现缺失字段，编辑器很容易在初始化/渲染阶段抛异常。

现在统一做本地归一化：

- draft 缺失 -> 建立安全 Draft #0
- definition 缺失 -> 使用节点默认 Definition
- source IDs 缺失 -> `0`
- parameters / responseFields / revisions 缺失 -> `[]`
- serviceName / path / maxRows / timeout 使用稳定默认值
- 所有 Draft Revision 访问改为 nullable-safe
- Preview 返回数组同样做防御处理

### 5.2 明确错误态 + Resource Error Boundary

Authoring Context 真正加载失败时，不再继续渲染残缺状态，而显示：

- 明确错误信息
- “重新加载”按钮

同时在 standalone resource editor 宿主增加轻量 Error Boundary：

- Dataset / Data Service 单个编辑器出现 render exception 时只降级当前编辑区
- 不会再把整个 Data Development 工作区打成白屏
- 切换资源会自动重置错误状态
- 支持当前资源重新渲染

Runtime 状态接口失败也只影响“Runtime 部署”区域，不影响 Data Service Node 的 Draft/Contract 编辑。

## 6. 前端依赖方向

新增：

`data-development/data-service-runtime-publication.ts`

它只封装 Data Development 需要的 publication boundary：

- fetch publication state
- deploy runtime
- sync runtime

没有直接 import `pages/data-service/service.ts`，避免 Data Development 页面层反向依赖 Data Service 页面实现。

## 7. 测试

新增后端测试覆盖：

- publication state endpoint 正确委托给统一 Publication boundary
- `未部署` 状态
- `已部署但存在新 DS Revision` 状态
- `Runtime 已同步最新 DS Revision` 状态
- Runtime enabled 状态可以随 publication state 返回

Phase 2 原有测试继续负责：

- DS Revision 固定精确 SQL Revision
- Runtime 不追随 SQL latest
- republish 保留 Runtime enablement
- Contract 原子同步
- source-managed definition 不允许 Runtime 侧覆盖

## 明确不做

本 PR 不改：

- Workflow
- Task Catalog
- SQL / Python / Flink SQL task lifecycle
- Data Service Node Draft / Revision 表结构
- Runtime SQL executor
- Auth / API Key
- Cache / Circuit Breaker
- 数据库表结构
- 自动部署 / 自动同步

## 结果

三阶段完成后 Data Service 的完整生命周期为：

```text
SQL Revision
     ↓
Data Service Draft
     ↓
Published DS Revision
     ↓  explicit deploy/sync
Runtime Snapshot
     ↓
Auth / API Key / Cache / Circuit Breaker / Metrics / Audit
```

开发资产和运行资产之间现在有清晰、显式、可审计的发布边界。