### PR TITLE
fix: prevent data service node editor crash on initial render

### DIFF
--- a/yak-ops-ui/src/pages/data-development/components/data-service/DataServiceNodeEditor.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/data-service/DataServiceNodeEditor.tsx
@@ -212,7 +212,7 @@ export default function DataServiceNodeEditor({
   const activeSource = useMemo(
     () => availableSources.find((source) => source.taskAssetId === selectedSourceId)
       || (context?.selectedSource?.taskAssetId === selectedSourceId
-        ? context.selectedSource
+        ? context?.selectedSource
         : undefined),
     [availableSources, context?.selectedSource, selectedSourceId],
   );
@@ -717,7 +717,6 @@ export default function DataServiceNodeEditor({
                 <span className="text-[#b42318]">{publicationError}</span>
               ) : null}
             </div>
-
             <div className="flex shrink-0 items-center gap-2">
               {showDeployAction ? (
                 <Button


### PR DESCRIPTION
## 问题
新增 `DATA_SERVICE` 节点后，编辑器首次渲染时 `context` 和 `selectedSourceId` 都尚未初始化。`activeSource` 的判断中，`context?.selectedSource?.taskAssetId === selectedSourceId` 会得到 `undefined === undefined`，条件意外成立，随后执行 `context.selectedSource`，触发：

`Cannot read properties of undefined (reading 'selectedSource')`

## 修复
- 保持 `selectedSource` 回退分支为空值安全访问。
- 首次渲染期间即使上下文尚未加载，也不会再因为回退来源解析导致资源编辑器异常。

## 验证
- 已核对变更分支与 `main` 的差异，核心修复仅作用于 Data Service Node 的来源解析逻辑。
- 建议回归：新建 Data Service 节点后应先显示加载态，随后正常进入编辑器，不再出现“资源编辑器加载异常”。