### PR TITLE
refactor: harden data service v1 flow

### DIFF
--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/domain/DevelopmentDataServiceDefinition.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/domain/DevelopmentDataServiceDefinition.java
@@ -23,6 +23,35 @@ public record DevelopmentDataServiceDefinition(
     responseFields = responseFields == null ? List.of() : List.copyOf(responseFields);
   }
 
+  /**
+   * Lightweight v1 publish invariant.
+   *
+   * <p>A published Data Service Revision must be directly deployable by the current Runtime. Drafts
+   * may still be edited freely; this validation is applied only when an immutable revision is
+   * persisted.
+   */
+  public void validatePublishable() {
+    if (!"GET".equalsIgnoreCase(method)) {
+      throw new IllegalArgumentException("当前 Data Service Runtime 仅支持 GET");
+    }
+    if (responseFields.isEmpty()) {
+      throw new IllegalArgumentException("发布前请先预览并确认响应字段 Contract");
+    }
+    for (ParameterContract parameter : parameters) {
+      if (parameter == null) {
+        throw new IllegalArgumentException("请求参数 Contract 不能为空");
+      }
+      if (!parameter.required()) {
+        throw new IllegalArgumentException(
+            "第一版 Runtime 仅支持必填请求参数，请将参数设为必填：" + parameter.name());
+      }
+      if ("OBJECT".equalsIgnoreCase(parameter.type())) {
+        throw new IllegalArgumentException(
+            "第一版 Runtime 请求参数暂不支持 OBJECT：" + parameter.name());
+      }
+    }
+  }
+
   public record ParameterContract(
       String name,
       String type,

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/DevelopmentDataServiceRevisionRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/DevelopmentDataServiceRevisionRepositoryAdapter.java
@@ -41,6 +41,11 @@ public class DevelopmentDataServiceRevisionRepositoryAdapter
       long sourceDraftRevision,
       DevelopmentDataServiceDefinition definition,
       String checksum) {
+    if (definition == null) {
+      throw new IllegalArgumentException("Data Service Node 发布定义不能为空");
+    }
+    definition.validatePublishable();
+
     DevelopmentDataServiceRevisionPO po = new DevelopmentDataServiceRevisionPO();
     po.setNodeId(nodeId);
     po.setRevisionNo(revisionNo);

--- a/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/domain/DevelopmentDataServiceDefinitionTest.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/domain/DevelopmentDataServiceDefinitionTest.java
@@ -1,0 +1,61 @@
+package io.yak.ops.business.development.domain;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class DevelopmentDataServiceDefinitionTest {
+
+  @Test
+  void publishableDefinitionMatchesCurrentRuntimeCapabilities() {
+    DevelopmentDataServiceDefinition definition = definition(
+        new DevelopmentDataServiceDefinition.ParameterContract(
+            "status", "STRING", true, null, null));
+
+    assertDoesNotThrow(definition::validatePublishable);
+  }
+
+  @Test
+  void publishRejectsOptionalRequestParameter() {
+    DevelopmentDataServiceDefinition definition = definition(
+        new DevelopmentDataServiceDefinition.ParameterContract(
+            "status", "STRING", false, null, null));
+
+    IllegalArgumentException error =
+        assertThrows(IllegalArgumentException.class, definition::validatePublishable);
+
+    assertTrue(error.getMessage().contains("必填"));
+  }
+
+  @Test
+  void publishRejectsObjectRequestParameter() {
+    DevelopmentDataServiceDefinition definition = definition(
+        new DevelopmentDataServiceDefinition.ParameterContract(
+            "filter", "OBJECT", true, null, null));
+
+    IllegalArgumentException error =
+        assertThrows(IllegalArgumentException.class, definition::validatePublishable);
+
+    assertTrue(error.getMessage().contains("OBJECT"));
+  }
+
+  private DevelopmentDataServiceDefinition definition(
+      DevelopmentDataServiceDefinition.ParameterContract parameter) {
+    return new DevelopmentDataServiceDefinition(
+        300L,
+        401L,
+        3,
+        "订单查询 API",
+        "/orders",
+        "GET",
+        List.of(parameter),
+        List.of(new DevelopmentDataServiceDefinition.ResponseFieldContract(
+            "id", "INTEGER", false, null, null)),
+        1000,
+        30,
+        null);
+  }
+}

--- a/yak-ops-ui/src/pages/data-service/CreateDataServiceModal.tsx
+++ b/yak-ops-ui/src/pages/data-service/CreateDataServiceModal.tsx
@@ -1,4 +1,4 @@
-import { Form, Modal, Select, Switch, Tag, message } from 'antd';
+import { Form, Modal, Select, Tag, message } from 'antd';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   DATA_SERVICE_NODE_SOURCE,
@@ -18,10 +18,7 @@ interface CreateDataServiceModalProps {
 
 interface DeployFormValues {
   sourceRef: string;
-  enabled: boolean;
 }
-
-const formatTime = (value?: string) => value ? value.replace('T', ' ').slice(0, 19) : '-';
 
 export default function CreateDataServiceModal({
   open,
@@ -80,7 +77,6 @@ export default function CreateDataServiceModal({
   useEffect(() => {
     if (!open) return;
     form.resetFields();
-    form.setFieldsValue({ enabled: false });
     setSelectedRef(undefined);
     void Promise.all([loadSources(), loadPublishedRefs()]);
   }, [form, loadPublishedRefs, loadSources, open]);
@@ -96,14 +92,15 @@ export default function CreateDataServiceModal({
       message.warning('该 Data Service Node 已部署，请在已有 API 中同步最新 Revision');
       return;
     }
+
     setSaving(true);
     try {
       await publishDataService({
         sourceType: DATA_SERVICE_NODE_SOURCE,
         sourceRef: values.sourceRef,
-        enabled: values.enabled,
+        enabled: false,
       });
-      message.success('Runtime 已从 Data Service Node Revision 部署');
+      message.success('API 已部署，当前保持停用');
       onCancel();
       await onCreated();
     } catch (error: any) {
@@ -115,33 +112,33 @@ export default function CreateDataServiceModal({
 
   return (
     <Modal
-      title="部署 API Runtime"
+      title="部署 API"
       open={open}
       onCancel={onCancel}
       onOk={() => void save()}
-      okText="部署 Runtime"
+      okText="部署"
       confirmLoading={saving}
-      width={720}
+      width={680}
       destroyOnHidden
     >
       <Form form={form} layout="vertical" className="pt-3">
         <div className="mb-4 text-[13px] leading-5 text-black/45">
-          选择数据开发中已经发布的 Data Service Node。接口名称、Path、Contract、返回限制与超时来自不可变 DS Revision；这里仅创建 Runtime Snapshot。
+          选择数据开发中已经发布的 Data Service Node。API 定义直接来自最新 DS Revision。
         </div>
 
         <Form.Item
           name="sourceRef"
           label="Data Service Node"
           rules={[{ required: true, message: '请选择已发布 Data Service Node' }]}
-          extra="同一个 Data Service Node 只对应一个 Runtime API；后续发布 DS Rn 后在已有 API 中显式同步。"
+          extra="同一个节点只部署一个 API；后续发布新 DS Revision 后直接同步即可。"
         >
           <Select
             allowClear
             showSearch
             filterOption={false}
             loading={sourceLoading}
-            placeholder="搜索并选择已发布 Data Service Node"
-            notFoundContent={sourceLoading ? '加载中...' : '暂无可部署节点，请先在数据开发发布 Data Service Revision'}
+            placeholder="搜索已发布 Data Service Node"
+            notFoundContent={sourceLoading ? '加载中...' : '暂无可部署节点'}
             onSearch={(value) => void loadSources(value)}
             onChange={selectSource}
             options={sources.map((item) => {
@@ -156,34 +153,29 @@ export default function CreateDataServiceModal({
         </Form.Item>
 
         {selectedSource ? (
-          <div className="mb-5 border border-[#e5e7eb] bg-[#fafafa] px-4 py-3">
+          <div className="mb-4 border border-[#e5e7eb] bg-[#fafafa] px-4 py-3">
             <div className="flex items-center gap-2">
               <span className="font-medium text-[#161823]">{selectedSource.name}</span>
-              <Tag bordered={false}>Data Service</Tag>
               <Tag bordered={false}>DS R{selectedSource.sourceRevisionNo || '-'}</Tag>
             </div>
-            <div className="mt-3 grid grid-cols-2 gap-x-6 gap-y-2 text-xs text-black/45">
-              <div>Endpoint：<span className="font-mono text-black/65">GET {selectedSource.defaultPath}</span></div>
-              <div>数据源：<span className="text-black/65">{dataSourceName}</span></div>
-              <div>最大返回：<span className="text-black/65">{selectedSource.maxRows || 1000} 行</span></div>
-              <div>超时：<span className="text-black/65">{selectedSource.timeoutSeconds || 30}s</span></div>
-              <div>Node：<span className="font-mono text-black/65">#{selectedSource.sourceRef}</span></div>
-              <div>发布时间：<span className="text-black/65">{formatTime(selectedSource.updateTime)}</span></div>
-            </div>
-            {selectedSource.description ? (
-              <div className="mt-3 border-t border-[#eceff2] pt-3 text-xs leading-5 text-black/45">
-                {selectedSource.description}
+            <div className="mt-3 space-y-2 text-xs text-black/45">
+              <div>
+                Endpoint：
+                <span className="font-mono text-black/65">GET {selectedSource.defaultPath}</span>
               </div>
-            ) : null}
+              <div>
+                数据源：<span className="text-black/65">{dataSourceName}</span>
+                <span className="mx-2 text-black/15">·</span>
+                最大返回：<span className="text-black/65">{selectedSource.maxRows || 1000} 行</span>
+                <span className="mx-2 text-black/15">·</span>
+                超时：<span className="text-black/65">{selectedSource.timeoutSeconds || 30}s</span>
+              </div>
+            </div>
           </div>
         ) : null}
 
-        <Form.Item name="enabled" label="部署后状态" valuePropName="checked">
-          <Switch checkedChildren="立即启用" unCheckedChildren="保持停用" />
-        </Form.Item>
-
         <div className="border border-[#e5e7eb] bg-white px-4 py-3 text-[12px] leading-5 text-[#667085]">
-          Runtime 不会重新解释 SQL，也不会修改接口定义。它只消费 DS Revision 冻结的定义与精确 SQL Revision，并负责启停、鉴权、限流、缓存、熔断和调用观测。
+          部署后默认保持停用。确认接口后，可直接在 API 列表中启用；API Key、Runtime 和调用记录在详情中管理。
         </div>
       </Form>
     </Modal>

--- a/yak-ops-ui/src/pages/data-service/DataServiceDetailDrawer.tsx
+++ b/yak-ops-ui/src/pages/data-service/DataServiceDetailDrawer.tsx
@@ -13,12 +13,10 @@ import {
 } from 'antd';
 import {
   Activity,
-  Braces,
   Copy,
   FileText,
   Gauge,
   KeyRound,
-  Pencil,
   RefreshCw,
   ServerCog,
 } from 'lucide-react';
@@ -29,7 +27,6 @@ import DataServiceRuntimeModal from './DataServiceRuntimeModal';
 import {
   DATA_SERVICE_NODE_SOURCE,
   LEGACY_DATA_DEVELOPMENT_RELEASE_SOURCE,
-  fetchDataServiceDocumentation,
   fetchDataServiceKeys,
   fetchDataServiceLogs,
   fetchDataServiceRuntime,
@@ -37,7 +34,6 @@ import {
   type DataServiceApi,
   type DataServiceApiKey,
   type DataServiceCallLog,
-  type DataServiceDocumentation,
   type DataServiceRuntimeStatus,
   type DataSourceOption,
 } from './service';
@@ -47,7 +43,6 @@ interface DataServiceDetailDrawerProps {
   service?: DataServiceApi;
   dataSources: DataSourceOption[];
   onClose: () => void;
-  onEdit: (service: DataServiceApi) => void;
   onChanged: () => Promise<void> | void;
 }
 
@@ -59,6 +54,12 @@ const callerLabel = (record: DataServiceCallLog) => {
   if (record.callerType === 'API_KEY') return record.apiKeyName || 'API Key';
   if (record.callerType === 'PUBLIC') return '公开调用';
   return '历史调用';
+};
+
+const latestActivity = (runtime?: DataServiceRuntimeStatus) => {
+  const values = [runtime?.lastSuccessAt, runtime?.lastFailureAt].filter(Boolean) as string[];
+  if (!values.length) return '-';
+  return formatTime(values.sort((a, b) => new Date(b).getTime() - new Date(a).getTime())[0]);
 };
 
 const Metric = ({ label, value }: { label: string; value: string | number }) => (
@@ -77,13 +78,11 @@ export default function DataServiceDetailDrawer({
   service,
   dataSources,
   onClose,
-  onEdit,
   onChanged,
 }: DataServiceDetailDrawerProps) {
   const [activeTab, setActiveTab] = useState('overview');
   const [loading, setLoading] = useState(false);
   const [republishing, setRepublishing] = useState(false);
-  const [documentation, setDocumentation] = useState<DataServiceDocumentation>();
   const [runtime, setRuntime] = useState<DataServiceRuntimeStatus>();
   const [keys, setKeys] = useState<DataServiceApiKey[]>([]);
   const [logs, setLogs] = useState<DataServiceCallLog[]>([]);
@@ -114,18 +113,16 @@ export default function DataServiceDetailDrawer({
     if (!service?.id) return;
     setLoading(true);
     try {
-      const [docsResponse, runtimeResponse, keyResponse, logResponse] = await Promise.all([
-        fetchDataServiceDocumentation(service.id),
+      const [runtimeResponse, keyResponse, logResponse] = await Promise.all([
         fetchDataServiceRuntime(service.id),
         fetchDataServiceKeys(service.id),
         fetchDataServiceLogs(),
       ]);
-      setDocumentation(docsResponse.data);
       setRuntime(runtimeResponse.data);
       setKeys(keyResponse.data || []);
       setLogs(logResponse.data || []);
     } catch (error: any) {
-      message.error(error?.message || '加载 API 管理信息失败');
+      message.error(error?.message || '加载 API 运行信息失败');
     } finally {
       setLoading(false);
     }
@@ -165,10 +162,10 @@ export default function DataServiceDetailDrawer({
   if (!service) return null;
 
   const sourceTypeLabel = sourceManaged
-    ? '数据开发 · Data Service Node'
+    ? 'Data Service Node'
     : legacySqlRelease
-      ? 'Legacy · SQL Release（冻结）'
-      : 'Legacy 手工服务';
+      ? 'Legacy SQL Release'
+      : 'Legacy';
   const sourceRevisionLabel = sourceManaged
     ? `DS R${service.sourceRevisionNo || '-'}`
     : legacySqlRelease
@@ -213,7 +210,7 @@ export default function DataServiceDetailDrawer({
   const overview = (
     <div className="space-y-6">
       <div>
-        <SectionTitle>接口</SectionTitle>
+        <SectionTitle>Endpoint</SectionTitle>
         <div className="border border-[#e5e7eb] bg-[#fafafa] px-4 py-3">
           <div className="flex items-center justify-between gap-3">
             <div className="min-w-0">
@@ -225,98 +222,62 @@ export default function DataServiceDetailDrawer({
                 <div className="mt-2 text-[12px] leading-5 text-[#667085]">{service.description}</div>
               ) : null}
             </div>
-            <Button size="small" icon={<Copy size={14} />} onClick={() => void copy(service.runtimePath)}>复制</Button>
+            <Space size={6}>
+              <Button size="small" icon={<Copy size={14} />} onClick={() => void copy(service.runtimePath)}>复制</Button>
+              <Button size="small" icon={<FileText size={14} />} onClick={() => setDocsOpen(true)}>
+                OpenAPI / 调试
+              </Button>
+            </Space>
           </div>
+        </div>
+      </div>
+
+      <div>
+        <SectionTitle>运行概览</SectionTitle>
+        <div className="grid grid-cols-4 border-y border-[#edf0f2] py-3">
+          <Metric label="调用次数" value={runtime?.totalCalls || 0} />
+          <Metric label="成功率" value={percent(runtime?.successRate)} />
+          <Metric label="平均耗时" value={`${runtime?.averageDurationMs || 0} ms`} />
+          <Metric label="最近调用" value={latestActivity(runtime)} />
         </div>
       </div>
 
       <div>
         <SectionTitle>来源</SectionTitle>
-        <div className="grid grid-cols-2 border border-[#e5e7eb] text-[12px]">
-          <div className="border-b border-r border-[#edf0f2] px-4 py-3">
-            <div className="text-[#98a2b3]">来源类型</div>
+        <div className="grid grid-cols-3 border border-[#e5e7eb] text-[12px]">
+          <div className="border-r border-[#edf0f2] px-4 py-3">
+            <div className="text-[#98a2b3]">来源</div>
             <div className="mt-1 font-medium text-[#344054]">{sourceTypeLabel}</div>
           </div>
-          <div className="border-b border-[#edf0f2] px-4 py-3">
-            <div className="text-[#98a2b3]">来源版本</div>
+          <div className="border-r border-[#edf0f2] px-4 py-3">
+            <div className="text-[#98a2b3]">版本</div>
             <div className="mt-1 font-medium text-[#344054]">{sourceRevisionLabel}</div>
           </div>
-          <div className="border-r border-[#edf0f2] px-4 py-3">
+          <div className="px-4 py-3">
             <div className="text-[#98a2b3]">数据源</div>
             <div className="mt-1 font-medium text-[#344054]">{dataSourceName}</div>
           </div>
-          <div className="px-4 py-3">
-            <div className="text-[#98a2b3]">{sourceManaged ? 'Node / DS Revision' : 'Source / Revision'}</div>
-            <div className="mt-1 font-mono text-[11px] text-[#475467]">
-              {service.sourceType ? `#${service.sourceRef || '-'} / #${service.sourceRevisionId || '-'}` : '-'}
-            </div>
-          </div>
         </div>
+
         {sourceManaged ? (
           <div className="mt-3 flex items-center justify-between border border-[#e5e7eb] bg-[#fafafa] px-4 py-3 text-[12px] text-[#667085]">
-            <div>接口定义与 Contract 来自数据开发的不可变 DS Revision；Runtime 只保存运行快照。</div>
-            <Button size="small" icon={<RefreshCw size={13} />} loading={republishing} onClick={() => void syncLatestRevision()}>
+            <div>
+              Node #{service.sourceRef} · {service.maxRows} 行 · {service.timeoutSeconds}s · {service.parameterNames?.length || 0} 个参数
+            </div>
+            <Button
+              size="small"
+              icon={<RefreshCw size={13} />}
+              loading={republishing}
+              onClick={() => void syncLatestRevision()}
+            >
               同步最新 Revision
             </Button>
           </div>
         ) : legacySqlRelease ? (
           <div className="mt-3 border border-[#fedf89] bg-[#fffaeb] px-4 py-3 text-[12px] leading-5 text-[#93370d]">
-            历史 SQL Release 来源已冻结：现有 Runtime Snapshot 可以继续运行，但不再支持从原 SQL 来源重新发布。新的服务请通过 Data Service Node 部署。
+            历史 SQL Release 来源已冻结，现有 Runtime Snapshot 可以继续运行，但不再支持重新发布。
           </div>
         ) : null}
-      </div>
-
-      <div>
-        <SectionTitle>服务配置</SectionTitle>
-        <div className="grid grid-cols-4 border-y border-[#edf0f2] py-3">
-          <Metric label="最大返回" value={`${service.maxRows} 行`} />
-          <Metric label="超时" value={`${service.timeoutSeconds}s`} />
-          <Metric label="请求参数" value={service.parameterNames?.length || 0} />
-          <Metric label="访问模式" value={service.authMode === 'API_KEY' ? 'API Key' : 'Public'} />
-        </div>
-      </div>
-
-      <div className="flex items-center justify-between border-t border-[#edf0f2] pt-4 text-[12px] text-[#667085]">
-        <div>创建 {formatTime(service.createTime)} · 更新 {formatTime(service.updateTime)}</div>
-        {sourceManaged ? (
-          <span>定义修改请回到数据开发 Data Service Node</span>
-        ) : (
-          <Button icon={<Pencil size={14} />} onClick={() => onEdit(service)}>编辑 Legacy 配置</Button>
-        )}
-      </div>
-    </div>
-  );
-
-  const docs = (
-    <div className="space-y-5">
-      <div className="flex items-center justify-between">
-        <div>
-          <div className="text-[13px] font-medium text-[#344054]">API 文档与在线调试</div>
-          <div className="mt-1 text-[12px] text-[#667085]">
-            {sourceManaged
-              ? '参数与响应 Contract 来自 DS Revision，在 Runtime 中只读；可查看 OpenAPI 并在线调试。'
-              : '维护请求参数、响应 Schema、OpenAPI，并使用真实数据源调试。'}
-          </div>
-        </div>
-        <Button icon={<FileText size={14} />} onClick={() => setDocsOpen(true)}>{sourceManaged ? '查看文档' : '打开文档'}</Button>
-      </div>
-      <div className="grid grid-cols-3 border-y border-[#edf0f2] py-3">
-        <Metric label="文档状态" value={documentation?.documented ? '已同步' : '未维护'} />
-        <Metric label="请求参数" value={documentation?.parameters?.length || service.parameterNames?.length || 0} />
-        <Metric label="响应字段" value={documentation?.responseFields?.length || 0} />
-      </div>
-      {documentation?.schemaStale ? (
-        <div className="border border-[#fecdca] bg-[#fffbfa] px-3 py-2.5 text-[12px] leading-5 text-[#b42318]">
-          当前 Runtime SQL 与已同步 Contract 不一致，请从最新 Data Service Revision 重新发布 Runtime。
-        </div>
-      ) : null}
-      <div className="border border-[#e5e7eb] px-4 py-3 text-[12px] leading-5 text-[#667085]">
-        <div className="flex items-center gap-2 font-medium text-[#344054]"><Braces size={14} /> 参数</div>
-        <div className="mt-2">
-          {service.parameterNames?.length
-            ? service.parameterNames.map((name) => `:${name}`).join(' · ')
-            : '当前 SQL 无请求参数'}
-        </div>
       </div>
     </div>
   );
@@ -325,20 +286,15 @@ export default function DataServiceDetailDrawer({
     <div className="space-y-5">
       <div className="flex items-center justify-between">
         <div>
-          <div className="text-[13px] font-medium text-[#344054]">访问控制</div>
-          <div className="mt-1 text-[12px] text-[#667085]">控制外部调用身份、API Key 生命周期与每分钟限流。</div>
+          <div className="text-[13px] font-medium text-[#344054]">API Key</div>
+          <div className="mt-1 text-[12px] text-[#667085]">管理访问模式、API Key 和每分钟限流。</div>
         </div>
-        <Button icon={<KeyRound size={14} />} onClick={() => setAccessOpen(true)}>管理访问</Button>
+        <Button icon={<KeyRound size={14} />} onClick={() => setAccessOpen(true)}>管理 API Key</Button>
       </div>
       <div className="grid grid-cols-3 border-y border-[#edf0f2] py-3">
-        <Metric label="当前模式" value={service.authMode === 'API_KEY' ? 'API Key' : 'Public'} />
+        <Metric label="访问模式" value={service.authMode === 'API_KEY' ? 'API Key' : 'Public'} />
         <Metric label="API Keys" value={keys.length} />
         <Metric label="启用 Key" value={activeKeys} />
-      </div>
-      <div className="border border-[#e5e7eb] bg-[#fafafa] px-4 py-3 text-[12px] leading-5 text-[#667085]">
-        {service.authMode === 'API_KEY'
-          ? '外部调用必须携带 X-API-Key。每个 Key 可以独立配置调用方名称、过期时间和每分钟限流。'
-          : '当前接口允许公开调用。生产或跨系统调用建议切换到 API Key 模式。'}
       </div>
     </div>
   );
@@ -348,22 +304,26 @@ export default function DataServiceDetailDrawer({
       <div className="flex items-center justify-between">
         <div>
           <div className="text-[13px] font-medium text-[#344054]">Runtime</div>
-          <div className="mt-1 text-[12px] text-[#667085]">查看运行指标，并管理缓存与熔断策略。</div>
+          <div className="mt-1 text-[12px] text-[#667085]">轻量管理缓存、熔断和运行指标。</div>
         </div>
         <Space size={6}>
           <Button icon={<RefreshCw size={14} />} onClick={() => void loadDetail()}>刷新</Button>
           <Button icon={<Gauge size={14} />} onClick={() => setRuntimeOpen(true)}>Runtime 配置</Button>
         </Space>
       </div>
+
       <div className="grid grid-cols-4 border-y border-[#edf0f2] py-3">
         <Metric label="调用总数" value={runtime?.totalCalls || 0} />
         <Metric label="成功率" value={percent(runtime?.successRate)} />
         <Metric label="平均耗时" value={`${runtime?.averageDurationMs || 0} ms`} />
         <Metric label="P95" value={`${runtime?.p95DurationMs || 0} ms`} />
       </div>
+
       <div className="grid grid-cols-2 gap-3">
         <div className="border border-[#e5e7eb] px-4 py-3">
-          <div className="flex items-center gap-2 text-[12px] font-medium text-[#344054]"><Activity size={14} /> 结果缓存</div>
+          <div className="flex items-center gap-2 text-[12px] font-medium text-[#344054]">
+            <Activity size={14} /> 结果缓存
+          </div>
           <div className="mt-3 text-[12px] leading-6 text-[#667085]">
             <div>状态：{runtime?.cacheEnabled ? '启用' : '关闭'}</div>
             <div>命中率：{percent(runtime?.cacheHitRate)}</div>
@@ -371,7 +331,9 @@ export default function DataServiceDetailDrawer({
           </div>
         </div>
         <div className="border border-[#e5e7eb] px-4 py-3">
-          <div className="flex items-center gap-2 text-[12px] font-medium text-[#344054]"><ServerCog size={14} /> 熔断器</div>
+          <div className="flex items-center gap-2 text-[12px] font-medium text-[#344054]">
+            <ServerCog size={14} /> 熔断器
+          </div>
           <div className="mt-3 text-[12px] leading-6 text-[#667085]">
             <div>状态：{runtime?.circuitState || 'DISABLED'}</div>
             <div>拒绝次数：{runtime?.circuitRejected || 0}</div>
@@ -386,11 +348,12 @@ export default function DataServiceDetailDrawer({
     <div>
       <div className="mb-3 flex items-center justify-between">
         <div>
-          <div className="text-[13px] font-medium text-[#344054]">最近调用</div>
-          <div className="mt-1 text-[12px] text-[#667085]">展示最近 200 条全局审计记录中属于当前 API 的最多 50 条。</div>
+          <div className="text-[13px] font-medium text-[#344054]">调用记录</div>
+          <div className="mt-1 text-[12px] text-[#667085]">展示当前 API 最近的调用结果、耗时和错误。</div>
         </div>
         <Button icon={<RefreshCw size={14} />} onClick={() => void loadDetail()}>刷新</Button>
       </div>
+
       {serviceLogs.length ? (
         <Table<DataServiceCallLog>
           rowKey="id"
@@ -409,7 +372,7 @@ export default function DataServiceDetailDrawer({
       <Drawer
         open={open}
         onClose={onClose}
-        width={900}
+        width={860}
         destroyOnHidden
         title={(
           <div className="min-w-0">
@@ -419,13 +382,10 @@ export default function DataServiceDetailDrawer({
               <Tag bordered={false}>{service.enabled ? '运行中' : '已停用'}</Tag>
               {sourceManaged ? <Tag bordered={false}>DS R{service.sourceRevisionNo || '-'}</Tag> : null}
             </div>
-            <div className="mt-1 truncate font-mono text-[11px] font-normal text-[#98a2b3]">{service.runtimePath}</div>
+            <div className="mt-1 truncate font-mono text-[11px] font-normal text-[#98a2b3]">
+              {service.runtimePath}
+            </div>
           </div>
-        )}
-        extra={sourceManaged ? (
-          <Button size="small" icon={<RefreshCw size={13} />} loading={republishing} onClick={() => void syncLatestRevision()}>同步 Revision</Button>
-        ) : (
-          <Button size="small" icon={<Pencil size={13} />} onClick={() => onEdit(service)}>编辑</Button>
         )}
       >
         <Spin spinning={loading}>
@@ -434,8 +394,7 @@ export default function DataServiceDetailDrawer({
             onChange={setActiveTab}
             items={[
               { key: 'overview', label: '概览', children: overview },
-              { key: 'docs', label: '文档', children: docs },
-              { key: 'access', label: '访问控制', children: access },
+              { key: 'access', label: 'API Key', children: access },
               { key: 'runtime', label: 'Runtime', children: runtimeTab },
               { key: 'logs', label: '调用记录', children: logTab },
             ]}
@@ -447,10 +406,7 @@ export default function DataServiceDetailDrawer({
         open={docsOpen}
         service={service}
         readOnly={sourceManaged}
-        onCancel={() => {
-          setDocsOpen(false);
-          void loadDetail();
-        }}
+        onCancel={() => setDocsOpen(false)}
       />
 
       <DataServiceAccessModal

--- a/yak-ops-ui/src/pages/data-service/index.tsx
+++ b/yak-ops-ui/src/pages/data-service/index.tsx
@@ -1,9 +1,7 @@
 import {
   Button,
   Dropdown,
-  Form,
   Input,
-  InputNumber,
   Modal,
   Space,
   Switch,
@@ -17,9 +15,7 @@ import {
   Copy,
   Eye,
   MoreHorizontal,
-  Pencil,
   Plus,
-  Power,
   RefreshCw,
   Search,
   Trash2,
@@ -34,13 +30,9 @@ import {
   fetchDataServices,
   fetchDataSourceOptions,
   setDataServiceEnabled,
-  updateDataService,
   type DataServiceApi,
-  type DataServiceUpdatePayload,
   type DataSourceOption,
 } from './service';
-
-const formatTime = (value?: string) => value ? value.replace('T', ' ').slice(0, 19) : '-';
 
 export default function DataServicePage() {
   const [services, setServices] = useState<DataServiceApi[]>([]);
@@ -49,10 +41,6 @@ export default function DataServicePage() {
   const [keyword, setKeyword] = useState('');
   const [createOpen, setCreateOpen] = useState(false);
   const [detailTarget, setDetailTarget] = useState<DataServiceApi>();
-  const [editing, setEditing] = useState<DataServiceApi>();
-  const [editorOpen, setEditorOpen] = useState(false);
-  const [saving, setSaving] = useState(false);
-  const [form] = Form.useForm<DataServiceUpdatePayload>();
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -87,43 +75,9 @@ export default function DataServicePage() {
 
   const dataSourceName = useCallback((dataSourceId?: number) => {
     if (!dataSourceId) return '-';
-    return dataSources.find((item) => String(item.value) === String(dataSourceId))?.label || `#${dataSourceId}`;
+    return dataSources.find((item) => String(item.value) === String(dataSourceId))?.label
+      || `#${dataSourceId}`;
   }, [dataSources]);
-
-  const openEdit = (record: DataServiceApi) => {
-    if (record.sourceType === DATA_SERVICE_NODE_SOURCE) {
-      message.info('接口定义由数据开发 Data Service Node 管理，请发布新 DS Revision 后在详情中同步 Runtime');
-      return;
-    }
-    setEditing(record);
-    form.resetFields();
-    form.setFieldsValue({
-      name: record.name,
-      path: record.path,
-      maxRows: record.maxRows,
-      timeoutSeconds: record.timeoutSeconds,
-      enabled: record.enabled,
-      description: record.description,
-    });
-    setEditorOpen(true);
-  };
-
-  const saveEdit = async () => {
-    if (!editing) return;
-    const values = await form.validateFields();
-    setSaving(true);
-    try {
-      await updateDataService(editing.id, values);
-      message.success('数据服务配置已更新');
-      setEditorOpen(false);
-      setEditing(undefined);
-      await load();
-    } catch (error: any) {
-      message.error(error?.message || '保存数据服务失败');
-    } finally {
-      setSaving(false);
-    }
-  };
 
   const remove = async (record: DataServiceApi) => {
     try {
@@ -138,8 +92,8 @@ export default function DataServicePage() {
 
   const confirmRemove = (record: DataServiceApi) => {
     Modal.confirm({
-      title: '删除 API 服务',
-      content: `确认删除「${record.name}」？API Key、Runtime 状态和相关文档也会随服务一起移除。`,
+      title: '删除 API',
+      content: `确认删除「${record.name}」？API Key、Runtime 状态和相关文档也会一起移除。`,
       okText: '删除',
       okButtonProps: { danger: true },
       cancelText: '取消',
@@ -147,11 +101,10 @@ export default function DataServicePage() {
     });
   };
 
-  const toggleEnabled = async (record: DataServiceApi) => {
-    const enabled = !record.enabled;
+  const toggleEnabled = async (record: DataServiceApi, enabled: boolean) => {
     try {
       await setDataServiceEnabled(record.id, enabled);
-      message.success(enabled ? '服务已启用' : '服务已停用');
+      message.success(enabled ? 'API 已启用' : 'API 已停用');
       await load();
     } catch (error: any) {
       message.error(error?.message || '状态更新失败');
@@ -161,7 +114,7 @@ export default function DataServicePage() {
   const copyPath = async (path: string) => {
     try {
       await navigator.clipboard.writeText(path);
-      message.success('调用路径已复制');
+      message.success('Endpoint 已复制');
     } catch {
       message.warning('复制失败，请手动复制');
     }
@@ -169,9 +122,9 @@ export default function DataServicePage() {
 
   const columns: TableColumnsType<DataServiceApi> = [
     {
-      title: 'API 服务',
+      title: 'API',
       dataIndex: 'name',
-      minWidth: 240,
+      minWidth: 230,
       render: (_, record) => (
         <div className="py-1.5">
           <div className="flex items-center gap-2">
@@ -187,12 +140,17 @@ export default function DataServicePage() {
     {
       title: 'Endpoint',
       dataIndex: 'runtimePath',
-      minWidth: 290,
+      minWidth: 300,
       render: (value: string) => (
         <div className="flex items-center gap-1">
           <span className="truncate font-mono text-xs text-black/55">{value}</span>
           <Tooltip title="复制 Endpoint">
-            <Button type="text" size="small" icon={<Copy size={13} />} onClick={() => void copyPath(value)} />
+            <Button
+              type="text"
+              size="small"
+              icon={<Copy size={13} />}
+              onClick={() => void copyPath(value)}
+            />
           </Tooltip>
         </div>
       ),
@@ -206,7 +164,9 @@ export default function DataServicePage() {
           return (
             <div>
               <div className="font-medium text-[#475467]">Data Service · DS R{record.sourceRevisionNo || '-'}</div>
-              <div className="mt-1 text-[11px] text-black/35">{dataSourceName(record.dataSourceId)} · Node #{record.sourceRef}</div>
+              <div className="mt-1 text-[11px] text-black/35">
+                {dataSourceName(record.dataSourceId)} · Node #{record.sourceRef}
+              </div>
             </div>
           );
         }
@@ -227,69 +187,52 @@ export default function DataServicePage() {
       },
     },
     {
-      title: '访问控制',
-      dataIndex: 'authMode',
-      width: 110,
-      render: (value) => value === 'API_KEY'
-        ? <span className="text-black/65">API Key</span>
-        : <span className="text-black/40">Public</span>,
-    },
-    {
       title: '状态',
       dataIndex: 'enabled',
-      width: 90,
-      render: (value: boolean) => value
-        ? <Tag bordered={false}>运行中</Tag>
-        : <Tag bordered={false}>已停用</Tag>,
-    },
-    {
-      title: '更新时间',
-      dataIndex: 'updateTime',
-      width: 160,
-      render: formatTime,
+      width: 145,
+      render: (enabled: boolean, record) => (
+        <div className="flex items-center gap-2">
+          <Switch
+            size="small"
+            checked={enabled}
+            onChange={(next) => void toggleEnabled(record, next)}
+          />
+          <span className={enabled ? 'text-[#344054]' : 'text-black/35'}>
+            {enabled ? '运行中' : '已停用'}
+          </span>
+        </div>
+      ),
     },
     {
       title: '操作',
       key: 'actions',
-      width: 140,
+      width: 130,
       fixed: 'right',
-      render: (_, record) => {
-        const sourceManaged = record.sourceType === DATA_SERVICE_NODE_SOURCE;
-        return (
-          <Space size={4}>
-            <Button
-              type="link"
-              size="small"
-              icon={<Eye size={14} />}
-              onClick={() => setDetailTarget(record)}
-            >
-              查看
-            </Button>
-            <Dropdown
-              trigger={['click']}
-              menu={{
-                items: [
-                  ...(!sourceManaged ? [{ key: 'edit', icon: <Pencil size={14} />, label: '编辑服务配置' }] : []),
-                  {
-                    key: 'toggle',
-                    icon: <Power size={14} />,
-                    label: record.enabled ? '停用服务' : '启用服务',
-                  },
-                  { type: 'divider' as const },
-                  { key: 'delete', danger: true, icon: <Trash2 size={14} />, label: '删除服务' },
-                ],
-                onClick: ({ key }) => {
-                  if (key === 'edit') openEdit(record);
-                  if (key === 'toggle') void toggleEnabled(record);
-                  if (key === 'delete') confirmRemove(record);
-                },
-              }}
-            >
-              <Button type="text" size="small" icon={<MoreHorizontal size={16} />} />
-            </Dropdown>
-          </Space>
-        );
-      },
+      render: (_, record) => (
+        <Space size={4}>
+          <Button
+            type="link"
+            size="small"
+            icon={<Eye size={14} />}
+            onClick={() => setDetailTarget(record)}
+          >
+            查看
+          </Button>
+          <Dropdown
+            trigger={['click']}
+            menu={{
+              items: [
+                { key: 'delete', danger: true, icon: <Trash2 size={14} />, label: '删除 API' },
+              ],
+              onClick: ({ key }) => {
+                if (key === 'delete') confirmRemove(record);
+              },
+            }}
+          >
+            <Button type="text" size="small" icon={<MoreHorizontal size={16} />} />
+          </Dropdown>
+        </Space>
+      ),
     },
   ];
 
@@ -298,9 +241,13 @@ export default function DataServicePage() {
       <div className="mb-5 flex items-start justify-between gap-4">
         <div>
           <h1 className="m-0 text-xl font-semibold text-[#161823]">API 服务</h1>
-          <p className="mb-0 mt-1 text-sm text-black/45">部署数据开发已发布的 Data Service 资产，并管理启停、访问控制、Runtime 策略、文档投影和调用审计。</p>
+          <p className="mb-0 mt-1 text-sm text-black/45">
+            运行已发布的 Data Service，管理启停、API Key、Runtime、OpenAPI 和调用记录。
+          </p>
         </div>
-        <Button type="primary" icon={<Plus size={16} />} onClick={() => setCreateOpen(true)}>部署 API</Button>
+        <Button type="primary" icon={<Plus size={16} />} onClick={() => setCreateOpen(true)}>
+          部署 API
+        </Button>
       </div>
 
       <div className="mb-3 flex items-center justify-between gap-3">
@@ -322,7 +269,7 @@ export default function DataServicePage() {
         dataSource={filtered}
         columns={columns}
         pagination={false}
-        scroll={{ x: 1240 }}
+        scroll={{ x: 1050 }}
       />
 
       <CreateDataServiceModal
@@ -337,57 +284,8 @@ export default function DataServicePage() {
         service={detailTarget}
         dataSources={dataSources}
         onClose={() => setDetailTarget(undefined)}
-        onEdit={openEdit}
         onChanged={load}
       />
-
-      <Modal
-        title="编辑 Legacy API 服务"
-        open={editorOpen}
-        onCancel={() => {
-          setEditorOpen(false);
-          setEditing(undefined);
-        }}
-        onOk={() => void saveEdit()}
-        okText="保存"
-        confirmLoading={saving}
-        width={680}
-        destroyOnHidden
-      >
-        <Form form={form} layout="vertical" className="pt-3">
-          <div className="mb-4 border border-[#fecdca] bg-[#fffbfa] px-4 py-3 text-[12px] leading-5 text-[#667085]">
-            <div className="font-medium text-[#b42318]">Legacy Runtime Snapshot</div>
-            <div className="mt-1">
-              该 API 不属于新的 Data Service Node 发布链路，仅保留兼容编辑。新的 API 定义请在数据开发 Data Service Node 中维护。
-            </div>
-            <div className="mt-1">当前数据源：{dataSourceName(editing?.dataSourceId)}</div>
-          </div>
-
-          <div className="grid grid-cols-2 gap-x-4">
-            <Form.Item name="name" label="服务名称" rules={[{ required: true, message: '请输入服务名称' }]}>
-              <Input placeholder="例如：用户查询 API" />
-            </Form.Item>
-            <Form.Item name="path" label="服务路径" rules={[{ required: true, message: '请输入服务路径' }]}>
-              <Input addonBefore="GET" placeholder="/users" />
-            </Form.Item>
-          </div>
-
-          <div className="grid grid-cols-3 gap-x-4">
-            <Form.Item name="maxRows" label="最大返回行数" rules={[{ required: true }]}>
-              <InputNumber min={1} max={10000} className="w-full" />
-            </Form.Item>
-            <Form.Item name="timeoutSeconds" label="超时时间（秒）" rules={[{ required: true }]}>
-              <InputNumber min={1} max={3600} className="w-full" />
-            </Form.Item>
-            <Form.Item name="enabled" label="发布状态" valuePropName="checked">
-              <Switch checkedChildren="启用" unCheckedChildren="停用" />
-            </Form.Item>
-          </div>
-          <Form.Item name="description" label="说明">
-            <Input.TextArea rows={2} maxLength={500} placeholder="可选" />
-          </Form.Item>
-        </Form>
-      </Modal>
     </div>
   );
 }


### PR DESCRIPTION
## 背景

Data Service 三阶段生命周期已经完成，这个 PR 不再扩能力，只做 v1 收口：**补一层发布兜底校验，并继续给 Runtime Console 做减法。**

目标仍然是这条轻量主链：

```text
数据开发
SQL
  ↓
Data Service Node
  ↓
预览
  ↓
保存 Draft
  ↓
发布 DS Revision
  ↓
部署 / 同步

数据服务
API 列表
  ↓
启停
  ↓
API Key
  ↓
简单 Runtime 配置
  ↓
OpenAPI / 在线调试
  ↓
调用记录 / 基础指标
```

## 1. Published DS Revision 增加轻量部署校验

不增加复杂规则，只保证一个原则：

> 能写入 immutable DS Revision 的定义，必须能被当前 v1 Runtime 直接部署。

发布 Revision 的最后持久化边界会校验：

- 当前只支持 `GET`
- 已确认响应 Contract
- SQL 命名请求参数必须为必填
- 请求参数暂不允许 `OBJECT`

Draft 仍可以自由编辑；校验只作用于不可变 Revision 发布。

新增领域测试覆盖：

- 当前 Runtime 能力范围内的定义可以发布
- 可选请求参数拒绝发布
- `OBJECT` 请求参数拒绝发布

## 2. 部署弹窗继续做减法

“部署 API”现在只做一件事：选择已发布 Data Service Node 并部署。

移除“部署后是否立即启用”的选择，统一：

```text
部署 -> 默认停用 -> 在 API 列表确认后显式启用
```

保留必要预览：

- DS Revision
- Endpoint
- 数据源
- maxRows
- timeout

不再展示 Node ID、发布时间等次要信息。

## 3. API 列表简化

列表从原来的多列管理页收成：

```text
API
Endpoint
来源 / DS Revision
状态（直接启停）
操作
```

删除：

- 访问控制列
- 更新时间列
- Legacy 编辑表单
- Legacy 编辑入口

历史 Runtime Snapshot 仍可查看、启停和删除，只是不再继续扩展旧编辑模型。

## 4. 详情页简化为 Runtime Console

详情一级 Tab 从 5 个减到 4 个：

```text
概览
API Key
Runtime
调用记录
```

原“文档”一级 Tab 删除，OpenAPI / 在线调试放到概览 Endpoint 区域，通过现有 Docs Modal 打开，能力没有删除。

### 概览优先展示运行信息

```text
调用次数
成功率
平均耗时
最近调用
```

来源区域只保留：

- Data Service Node / Legacy
- DS Revision
- 数据源
- 同步最新 Revision

### API Key

只保留访问模式、Key 数量、启用 Key 数量和管理入口。

### Runtime

继续保留现有轻量能力：

- 基础指标
- Cache
- Circuit Breaker
- Runtime 配置

### 调用记录

继续使用现有调用审计，不增加新的 Observability 基础设施。

## 5. 明确不做

本 PR 不做：

- 多环境
- 灰度 / 回滚
- Redis Runtime
- 分布式限流
- Gateway
- POST / CRUD API
- Workflow 变更
- Task Catalog 变更
- 数据库表结构变更
- SPI 重构

## 验证

- 前端修改文件已使用 TypeScript 5.8.3 `transpileModule` 做语法检查
- Java 修改做了 `javac -proc:none` parser-level 检查；缺少完整项目 classpath，因此未声称本地 Maven 全量构建通过
- 分支基于最新 `main`（包含 #431 白屏修复）
- 最终 diff：1 commit / 6 files

这一轮的重点不是把 Data Service 做得更重，而是让第一个版本更清楚、更少选择、更难进入不可部署状态。