### PR TITLE
refactor: move data service authoring into development workbench

### DIFF
--- a/yak-ops-ui/src/pages/data-development/components/DevelopmentEditorWorkspace.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/DevelopmentEditorWorkspace.tsx
@@ -8,7 +8,6 @@ import type {
   DevelopmentId,
   DevelopmentResourceNode,
 } from '../types';
-import DataServiceNodeEditor from './data-service/DataServiceNodeEditor';
 import DatasetNodeEditor from './dataset/DatasetNodeEditor';
 import DevelopmentWorkbench from './workbench/DevelopmentWorkbench';
 
@@ -29,7 +28,7 @@ interface ResourceEditorBoundaryState {
   error?: string;
 }
 
-/** Prevents one standalone resource editor from blanking the whole Data Development workspace. */
+/** Prevents one resource editor from blanking the whole Data Development workspace. */
 class ResourceEditorBoundary extends Component<
   ResourceEditorBoundaryProps,
   ResourceEditorBoundaryState
@@ -83,7 +82,10 @@ export default function DevelopmentEditorWorkspace({
     () => nodes.find((node) => node.id === selectedNodeId),
     [nodes, selectedNodeId],
   );
-  const taskNodes = useMemo(() => nodes.filter(isDevelopmentTaskNode), [nodes]);
+  const workbenchNodes = useMemo(
+    () => nodes.filter((node) => isDevelopmentTaskNode(node) || node.type === 'DATA_SERVICE'),
+    [nodes],
+  );
 
   if (!selectedResource) {
     return (
@@ -111,27 +113,17 @@ export default function DevelopmentEditorWorkspace({
     );
   }
 
-  if (selectedResource.type === 'DATA_SERVICE') {
+  if (isDevelopmentTaskNode(selectedResource) || selectedResource.type === 'DATA_SERVICE') {
     return (
-      <main className="flex min-w-0 flex-1 flex-col overflow-hidden bg-white">
-        <ResourceEditorBoundary resourceKey={selectedResource.id}>
-          <DataServiceNodeEditor node={selectedResource} onSaved={onNodesChanged} />
-        </ResourceEditorBoundary>
-      </main>
-    );
-  }
-
-  if (isDevelopmentTaskNode(selectedResource)) {
-    return (
-      <main className="flex min-w-0 flex-1 flex-col overflow-hidden bg-white">
+      <ResourceEditorBoundary resourceKey={selectedResource.id}>
         <DevelopmentWorkbench
-          nodes={taskNodes}
+          nodes={workbenchNodes}
           directories={directories}
           selectedNodeId={selectedResource.id}
           onNodeFocus={onNodeFocus}
           onNodesChanged={onNodesChanged}
         />
-      </main>
+      </ResourceEditorBoundary>
     );
   }
 

--- a/yak-ops-ui/src/pages/data-development/components/data-service/DataServiceNodeEditor.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/data-service/DataServiceNodeEditor.tsx
@@ -1,18 +1,31 @@
 import { history } from '@umijs/max';
+import { API_SUCCESS_CODE } from '@/services/http/response';
 import {
   Button,
+  Empty,
   Input,
   InputNumber,
   Select,
   Spin,
-  Switch,
   Table,
   Tag,
+  Tooltip,
   message,
   type TableColumnsType,
 } from 'antd';
-import { ExternalLink, Network, RefreshCw, Rocket, Save } from 'lucide-react';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  Braces,
+  ExternalLink,
+  FileText,
+  History,
+  Network,
+  Play,
+  RefreshCw,
+  Rocket,
+  Save,
+  Settings2,
+} from 'lucide-react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import {
   getDevelopmentDataServiceNode,
@@ -24,7 +37,6 @@ import {
   type DevelopmentDataServiceNodeContext,
   type DevelopmentDataServiceParameter,
   type DevelopmentDataServiceResponseField,
-  type DevelopmentDataServiceRevisionSummary,
   type DevelopmentDataServiceSource,
 } from '../../data-service-node-service';
 import {
@@ -33,20 +45,30 @@ import {
   syncDataServiceRuntime,
   type DataServicePublicationState,
 } from '../../data-service-runtime-publication';
+import { getDevelopmentTaskRevision } from '../../service';
 import type { DevelopmentId, DevelopmentResourceNode } from '../../types';
+import SqlMonacoEditor from '../../editors/sql/components/SqlMonacoEditor';
 
 interface DataServiceNodeEditorProps {
   node: DevelopmentResourceNode;
   onSaved?: () => void | Promise<void>;
+  onOpenSourceNode?: (nodeId: DevelopmentId) => void;
+  onDirtyChange?: (dirty: boolean) => void;
 }
 
-const contractTypeOptions: { label: string; value: DataServiceContractType }[] = [
+type RightPanelKey = 'properties' | 'request' | 'response' | 'versions' | 'deployment';
+
+const requestTypeOptions: { label: string; value: DataServiceContractType }[] = [
   { label: 'STRING', value: 'STRING' },
   { label: 'INTEGER', value: 'INTEGER' },
   { label: 'NUMBER', value: 'NUMBER' },
   { label: 'BOOLEAN', value: 'BOOLEAN' },
   { label: 'DATE', value: 'DATE' },
   { label: 'DATETIME', value: 'DATETIME' },
+];
+
+const responseTypeOptions: { label: string; value: DataServiceContractType }[] = [
+  ...requestTypeOptions,
   { label: 'OBJECT', value: 'OBJECT' },
 ];
 
@@ -58,11 +80,6 @@ const normalizeId = (value: unknown): DevelopmentId => {
 const safeArray = <T,>(value: T[] | null | undefined): T[] =>
   Array.isArray(value) ? value.filter(Boolean) : [];
 
-/**
- * Data Service Node is a resource editor, so one malformed/older API payload must never crash the
- * whole Data Development workspace. Keep a complete local authoring shape even while wire contracts
- * evolve across releases.
- */
 const normalizeContext = (
   raw: DevelopmentDataServiceNodeContext,
   node: DevelopmentResourceNode,
@@ -102,10 +119,34 @@ const normalizeContext = (
   };
 };
 
+const parseDataSourceId = (configJson?: string) => {
+  if (!configJson) return undefined;
+  try {
+    const value = JSON.parse(configJson) as Record<string, unknown>;
+    const id = value?.dataSourceId;
+    return id === undefined || id === null || String(id).trim() === '' ? undefined : String(id);
+  } catch {
+    return undefined;
+  }
+};
+
+const panelItems: Array<{ key: RightPanelKey; label: string; icon: typeof Settings2 }> = [
+  { key: 'properties', label: '属性', icon: Settings2 },
+  { key: 'request', label: '请求参数', icon: Braces },
+  { key: 'response', label: '返回参数', icon: FileText },
+  { key: 'versions', label: '版本', icon: History },
+  { key: 'deployment', label: '部署', icon: Rocket },
+];
+
 export default function DataServiceNodeEditor({
   node,
   onSaved,
+  onOpenSourceNode,
+  onDirtyChange,
 }: DataServiceNodeEditorProps) {
+  const dirtyChangeRef = useRef(onDirtyChange);
+  useEffect(() => { dirtyChangeRef.current = onDirtyChange; }, [onDirtyChange]);
+
   const [context, setContext] = useState<DevelopmentDataServiceNodeContext>();
   const [selectedSourceId, setSelectedSourceId] = useState<DevelopmentId>();
   const [selectedRevisionId, setSelectedRevisionId] = useState<DevelopmentId>();
@@ -126,6 +167,20 @@ export default function DataServiceNodeEditor({
   const [publicationError, setPublicationError] = useState<string>();
   const [publicationLoading, setPublicationLoading] = useState(false);
   const [deploying, setDeploying] = useState(false);
+  const [sqlText, setSqlText] = useState('');
+  const [sqlConfigJson, setSqlConfigJson] = useState('{}');
+  const [sqlLoading, setSqlLoading] = useState(false);
+  const [sqlError, setSqlError] = useState<string>();
+  const [rightPanelKey, setRightPanelKey] = useState<RightPanelKey>('properties');
+  const [rightPanelOpen, setRightPanelOpen] = useState(true);
+
+  const setDirtyState = useCallback((next: boolean) => {
+    setDirty(next);
+    dirtyChangeRef.current?.(next);
+  }, []);
+  const markDirty = useCallback(() => setDirtyState(true), [setDirtyState]);
+
+  useEffect(() => () => dirtyChangeRef.current?.(false), []);
 
   const applyContext = useCallback((raw: DevelopmentDataServiceNodeContext) => {
     const next = normalizeContext(raw, node);
@@ -144,9 +199,9 @@ export default function DataServiceNodeEditor({
     setDescription(definition.description || '');
     setParameters(safeArray(definition.parameters));
     setResponseFields(safeArray(definition.responseFields));
-    setDirty(false);
+    setDirtyState(false);
     return next;
-  }, [node]);
+  }, [node, setDirtyState]);
 
   const loadPublicationState = useCallback(async (
     hasPublishedRevision: boolean,
@@ -205,7 +260,7 @@ export default function DataServiceNodeEditor({
       .map((source) => ({
         value: source.taskAssetId,
         disabled: source.status !== 'ONLINE',
-        label: `${source.nodeName || 'SQL'} · SQL R${source.currentRevisionNo || source.revisionNo || '-'} · ${source.status || 'UNKNOWN'}`,
+        label: `${source.nodeName || 'SQL'} · SQL R${source.currentRevisionNo || source.revisionNo || '-'}${source.status === 'ONLINE' ? '' : ` · ${source.status || 'UNKNOWN'}`}`,
       }));
   }, [availableSources, context?.selectedSource]);
 
@@ -235,7 +290,35 @@ export default function DataServiceNodeEditor({
       && activeSource.currentRevisionId !== selectedRevisionId,
   );
 
-  const markDirty = () => setDirty(true);
+  const loadSqlRevision = useCallback(async () => {
+    if (!activeSource?.nodeId || !selectedRevisionNo) {
+      setSqlText('');
+      setSqlConfigJson('{}');
+      setSqlError(undefined);
+      return;
+    }
+
+    setSqlLoading(true);
+    setSqlError(undefined);
+    try {
+      const response = await getDevelopmentTaskRevision(activeSource.nodeId, selectedRevisionNo);
+      if (response?.code !== API_SUCCESS_CODE || !response.data) {
+        throw new Error(response?.message || response?.msg || '加载固定 SQL Revision 失败');
+      }
+      setSqlText(response.data.definition?.content || '');
+      setSqlConfigJson(response.data.definition?.configJson || '{}');
+    } catch (error) {
+      setSqlText('');
+      setSqlConfigJson('{}');
+      setSqlError(error instanceof Error ? error.message : '加载固定 SQL Revision 失败');
+    } finally {
+      setSqlLoading(false);
+    }
+  }, [activeSource?.nodeId, selectedRevisionNo]);
+
+  useEffect(() => {
+    void loadSqlRevision();
+  }, [loadSqlRevision]);
 
   const changeSource = (taskAssetId: DevelopmentId) => {
     const source = availableSources.find((item) => item.taskAssetId === taskAssetId);
@@ -276,11 +359,11 @@ export default function DataServiceNodeEditor({
         const previous = oldParameters.get(item.name.toLowerCase());
         return previous ? {
           ...item,
-          type: previous.type,
-          required: previous.required,
+          type: previous.type === 'OBJECT' ? 'STRING' : previous.type,
+          required: true,
           description: previous.description,
           example: previous.example,
-        } : item;
+        } : { ...item, required: true };
       }));
       setResponseFields(nextResponses.map((item) => {
         const previous = oldResponses.get(item.name.toLowerCase());
@@ -318,6 +401,7 @@ export default function DataServiceNodeEditor({
         method: 'GET',
         parameters: parameters.map((item) => ({
           ...item,
+          required: true,
           description: item.description?.trim() || undefined,
           example: item.example?.trim() || undefined,
         })),
@@ -333,7 +417,7 @@ export default function DataServiceNodeEditor({
       });
       applyContext(next);
       await onSaved?.();
-      message.success(`Data Service 草稿已保存 · Draft #${next?.draft?.draftRevision || '-'}`);
+      message.success(`草稿已保存 · Draft #${next?.draft?.draftRevision || '-'}`);
     } catch (error) {
       message.error(error instanceof Error ? error.message : '保存 Data Service Node 草稿失败');
     } finally {
@@ -343,8 +427,9 @@ export default function DataServiceNodeEditor({
 
   const publish = async () => {
     const draftRevision = context?.draft?.draftRevision || 0;
-    if (!draftRevision || dirty || publishing) {
-      if (dirty) message.warning('请先保存当前 Data Service Node 草稿');
+    if (!draftRevision || publishing) return;
+    if (dirty) {
+      message.warning('当前有未保存修改，请先保存草稿再发布版本');
       return;
     }
     setPublishing(true);
@@ -352,7 +437,7 @@ export default function DataServiceNodeEditor({
       const revision = await publishDevelopmentDataServiceNode(node.id, draftRevision);
       await load();
       await onSaved?.();
-      message.success(`Data Service Node 已发布 · DS R${revision.revisionNo}`);
+      message.success(`已发布 DS R${revision.revisionNo}`);
     } catch (error) {
       message.error(error instanceof Error ? error.message : '发布 Data Service Node 失败');
     } finally {
@@ -362,10 +447,10 @@ export default function DataServiceNodeEditor({
 
   const deployOrSync = async () => {
     const latestPublished = context?.latestPublishedRevision;
-    if (!latestPublished || !publicationState || deploying) return;
+    if (!latestPublished || deploying) return;
     setDeploying(true);
     try {
-      if (publicationState.published) {
+      if (publicationState?.published) {
         const apiId = publicationState.detail?.id;
         if (!apiId) throw new Error('Runtime API 身份缺失，请刷新同步状态后重试');
         await syncDataServiceRuntime(apiId);
@@ -387,7 +472,7 @@ export default function DataServiceNodeEditor({
     patch: Partial<DevelopmentDataServiceParameter>,
   ) => {
     setParameters((current) => current.map((item, itemIndex) =>
-      itemIndex === index ? { ...item, ...patch } : item,
+      itemIndex === index ? { ...item, ...patch, required: true } : item,
     ));
     markDirty();
   };
@@ -404,23 +489,21 @@ export default function DataServiceNodeEditor({
 
   const parameterColumns = useMemo<TableColumnsType<DevelopmentDataServiceParameter>>(() => [
     {
-      title: '参数',
+      title: '参数名称',
       dataIndex: 'name',
-      width: 170,
-      render: (value: string) => (
-        <span className="font-mono text-[12px] text-[#344054]">{value}</span>
-      ),
+      width: 130,
+      render: (value: string) => <span className="font-mono text-[11px] text-[#344054]">{value}</span>,
     },
     {
       title: '类型',
       dataIndex: 'type',
-      width: 130,
+      width: 112,
       render: (value: DataServiceContractType, _record, index) => (
         <Select
           size="small"
-          value={value}
-          options={contractTypeOptions.filter((item) => item.value !== 'OBJECT')}
-          className="w-full"
+          value={value === 'OBJECT' ? 'STRING' : value}
+          options={requestTypeOptions}
+          className="w-[100px]"
           onChange={(next) => updateParameter(index, { type: next })}
         />
       ),
@@ -428,23 +511,17 @@ export default function DataServiceNodeEditor({
     {
       title: '必填',
       dataIndex: 'required',
-      width: 72,
-      render: (value: boolean, _record, index) => (
-        <Switch
-          size="small"
-          checked={value}
-          onChange={(next) => updateParameter(index, { required: next })}
-        />
-      ),
+      width: 58,
+      render: () => <Tag bordered={false}>是</Tag>,
     },
     {
       title: '描述',
       dataIndex: 'description',
+      width: 170,
       render: (value: string | null | undefined, _record, index) => (
         <Input
           size="small"
           value={value || ''}
-          maxLength={1000}
           placeholder="参数说明"
           onChange={(event) => updateParameter(index, { description: event.target.value })}
         />
@@ -453,38 +530,35 @@ export default function DataServiceNodeEditor({
     {
       title: '示例',
       dataIndex: 'example',
-      width: 180,
+      width: 140,
       render: (value: string | null | undefined, _record, index) => (
         <Input
           size="small"
           value={value || ''}
-          maxLength={1000}
-          placeholder="例如：PAID"
+          placeholder="示例值"
           onChange={(event) => updateParameter(index, { example: event.target.value })}
         />
       ),
     },
-  ], []);
+  ], [markDirty]);
 
   const responseColumns = useMemo<TableColumnsType<DevelopmentDataServiceResponseField>>(() => [
     {
       title: '字段',
       dataIndex: 'name',
-      width: 170,
-      render: (value: string) => (
-        <span className="font-mono text-[12px] text-[#344054]">{value}</span>
-      ),
+      width: 130,
+      render: (value: string) => <span className="font-mono text-[11px] text-[#344054]">{value}</span>,
     },
     {
       title: '类型',
       dataIndex: 'type',
-      width: 130,
+      width: 112,
       render: (value: DataServiceContractType, _record, index) => (
         <Select
           size="small"
           value={value}
-          options={contractTypeOptions}
-          className="w-full"
+          options={responseTypeOptions}
+          className="w-[100px]"
           onChange={(next) => updateResponseField(index, { type: next })}
         />
       ),
@@ -492,19 +566,17 @@ export default function DataServiceNodeEditor({
     {
       title: '可空',
       dataIndex: 'nullable',
-      width: 72,
-      render: (value: boolean) => (
-        <span className="text-[12px] text-[#667085]">{value ? '是' : '否'}</span>
-      ),
+      width: 58,
+      render: (value: boolean) => <Tag bordered={false}>{value ? '是' : '否'}</Tag>,
     },
     {
       title: '描述',
       dataIndex: 'description',
+      width: 170,
       render: (value: string | null | undefined, _record, index) => (
         <Input
           size="small"
           value={value || ''}
-          maxLength={1000}
           placeholder="字段说明"
           onChange={(event) => updateResponseField(index, { description: event.target.value })}
         />
@@ -513,44 +585,230 @@ export default function DataServiceNodeEditor({
     {
       title: '示例',
       dataIndex: 'example',
-      width: 180,
+      width: 140,
       render: (value: string | null | undefined, _record, index) => (
         <Input
           size="small"
           value={value || ''}
-          maxLength={1000}
-          placeholder="可选"
+          placeholder="示例值"
           onChange={(event) => updateResponseField(index, { example: event.target.value })}
         />
       ),
     },
-  ], []);
+  ], [markDirty]);
 
-  const revisionColumns = useMemo<TableColumnsType<DevelopmentDataServiceRevisionSummary>>(() => [
-    {
-      title: '版本',
-      dataIndex: 'revisionNo',
-      width: 90,
-      render: (value: number) => <span className="font-medium">DS R{value}</span>,
-    },
-    {
-      title: '来源 SQL',
-      dataIndex: 'sourceTaskRevisionNo',
-      width: 120,
-      render: (value: number) => `SQL R${value}`,
-    },
-    {
-      title: 'Draft',
-      dataIndex: 'sourceDraftRevision',
-      width: 100,
-      render: (value: number) => `#${value}`,
-    },
-    {
-      title: '发布时间',
-      dataIndex: 'createTime',
-      render: (value?: string) => formatTime(value),
-    },
-  ], []);
+  const latestPublished = context?.latestPublishedRevision;
+  const runtimeRevisionNo = publicationState?.detail?.sourceRevisionNo;
+  const runtimeStatus = !latestPublished
+    ? '等待发布 DS Revision'
+    : publicationLoading
+      ? '正在查询 Runtime'
+      : publicationError
+        ? 'Runtime 状态不可用'
+        : !publicationState?.published
+          ? '尚未部署'
+          : publicationState.updateAvailable
+            ? `Runtime DS R${runtimeRevisionNo || '-'} · 待同步`
+            : publicationState.detail?.enabled
+              ? `Runtime DS R${runtimeRevisionNo || '-'} · 运行中`
+              : `Runtime DS R${runtimeRevisionNo || '-'} · 已停用`;
+  const dataSourceId = parseDataSourceId(sqlConfigJson);
+
+  const propertiesPanel = (
+    <div className="space-y-5">
+      <div>
+        <div className="text-[13px] font-semibold text-[#344054]">API 属性</div>
+        <div className="mt-1 text-[11px] leading-5 text-[#98a2b3]">
+          Data Service Node 定义 API Contract；SQL 实现来自固定的已发布 SQL Revision。
+        </div>
+      </div>
+
+      <div className="space-y-4">
+        <div>
+          <div className="mb-1.5 text-[11px] font-medium text-[#667085]">API 名称</div>
+          <Input
+            size="small"
+            value={serviceName}
+            maxLength={200}
+            onChange={(event) => { setServiceName(event.target.value); markDirty(); }}
+          />
+        </div>
+        <div>
+          <div className="mb-1.5 text-[11px] font-medium text-[#667085]">API Path</div>
+          <Input
+            size="small"
+            addonBefore="GET"
+            value={path}
+            maxLength={255}
+            onChange={(event) => { setPath(event.target.value); markDirty(); }}
+          />
+        </div>
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <div className="mb-1.5 text-[11px] font-medium text-[#667085]">最大返回行数</div>
+            <InputNumber
+              size="small"
+              min={1}
+              max={10000}
+              value={maxRows}
+              className="w-full"
+              onChange={(value) => { setMaxRows(Number(value || 1000)); markDirty(); }}
+            />
+          </div>
+          <div>
+            <div className="mb-1.5 text-[11px] font-medium text-[#667085]">超时时间（秒）</div>
+            <InputNumber
+              size="small"
+              min={1}
+              max={3600}
+              value={timeoutSeconds}
+              className="w-full"
+              onChange={(value) => { setTimeoutSeconds(Number(value || 30)); markDirty(); }}
+            />
+          </div>
+        </div>
+        <div>
+          <div className="mb-1.5 text-[11px] font-medium text-[#667085]">描述</div>
+          <Input.TextArea
+            rows={4}
+            maxLength={2000}
+            value={description}
+            placeholder="说明这个数据服务提供什么能力"
+            onChange={(event) => { setDescription(event.target.value); markDirty(); }}
+          />
+        </div>
+      </div>
+
+      <div className="border-t border-[#eef0f2] pt-4 text-[11px] leading-6 text-[#667085]">
+        <div className="flex justify-between"><span>Draft</span><span>#{context?.draft?.draftRevision || 0}</span></div>
+        <div className="flex justify-between"><span>最新 DS Revision</span><span>{latestPublished ? `R${latestPublished.revisionNo}` : '尚未发布'}</span></div>
+        <div className="flex justify-between"><span>来源 SQL</span><span>{selectedRevisionNo ? `R${selectedRevisionNo}` : '-'}</span></div>
+        <div className="flex justify-between"><span>数据源 ID</span><span>{dataSourceId || '-'}</span></div>
+      </div>
+    </div>
+  );
+
+  const requestPanel = (
+    <div className="space-y-3">
+      <div>
+        <div className="text-[13px] font-semibold text-[#344054]">请求参数</div>
+        <div className="mt-1 text-[11px] leading-5 text-[#98a2b3]">
+          参数来自 SQL 中的 <span className="font-mono">:name</span> 命名参数。v1 统一为必填参数。
+        </div>
+      </div>
+      <Table<DevelopmentDataServiceParameter>
+        rowKey="name"
+        size="small"
+        pagination={false}
+        dataSource={parameters}
+        columns={parameterColumns}
+        scroll={{ x: 610 }}
+        locale={{ emptyText: '预览 Contract 后自动发现请求参数' }}
+      />
+    </div>
+  );
+
+  const responsePanel = (
+    <div className="space-y-3">
+      <div>
+        <div className="text-[13px] font-semibold text-[#344054]">返回参数</div>
+        <div className="mt-1 text-[11px] leading-5 text-[#98a2b3]">
+          通过真实数据源预览发现字段类型，可补充描述与示例后固化到 DS Revision。
+        </div>
+      </div>
+      <Table<DevelopmentDataServiceResponseField>
+        rowKey={(record, index) => `${record.name}-${index}`}
+        size="small"
+        pagination={false}
+        dataSource={responseFields}
+        columns={responseColumns}
+        scroll={{ x: 610 }}
+        locale={{ emptyText: '预览 Contract 后自动发现返回字段' }}
+      />
+    </div>
+  );
+
+  const versionsPanel = (
+    <div>
+      <div className="text-[13px] font-semibold text-[#344054]">版本</div>
+      <div className="mt-1 text-[11px] leading-5 text-[#98a2b3]">
+        发布只生成不可变 DS Revision，不会自动更新 Runtime。
+      </div>
+      <div className="mt-4 space-y-2">
+        {context?.revisions?.length ? context.revisions.map((revision) => (
+          <div key={revision.id} className="border border-[#e5e7eb] px-3 py-2.5">
+            <div className="flex items-center justify-between gap-2">
+              <div className="flex items-center gap-2">
+                <span className="text-[12px] font-semibold text-[#344054]">DS R{revision.revisionNo}</span>
+                {latestPublished?.id === revision.id ? <Tag bordered={false}>最新</Tag> : null}
+              </div>
+              <span className="text-[10px] text-[#98a2b3]">{formatTime(revision.createTime)}</span>
+            </div>
+            <div className="mt-1 text-[11px] text-[#667085]">
+              SQL R{revision.sourceTaskRevisionNo} · Draft #{revision.sourceDraftRevision}
+            </div>
+          </div>
+        )) : (
+          <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="尚未发布 DS Revision" />
+        )}
+      </div>
+    </div>
+  );
+
+  const deploymentPanel = (
+    <div className="space-y-4">
+      <div>
+        <div className="text-[13px] font-semibold text-[#344054]">Runtime 部署</div>
+        <div className="mt-1 text-[11px] leading-5 text-[#98a2b3]">
+          发布与部署分离。先生成 DS Revision，再显式部署或同步到数据服务 Runtime。
+        </div>
+      </div>
+
+      <div className="border border-[#e5e7eb] bg-[#fafafa] px-3 py-3 text-[11px] leading-6 text-[#667085]">
+        <div className="flex justify-between"><span>最新发布</span><span>{latestPublished ? `DS R${latestPublished.revisionNo}` : '尚未发布'}</span></div>
+        <div className="flex justify-between"><span>Runtime</span><span className="text-right text-[#344054]">{runtimeStatus}</span></div>
+        {publicationState?.detail?.runtimePath ? (
+          <div className="flex justify-between gap-3"><span>Endpoint</span><span className="truncate font-mono text-[#344054]">{publicationState.detail.runtimePath}</span></div>
+        ) : null}
+      </div>
+
+      <Button
+        block
+        type="primary"
+        icon={<Rocket size={14} />}
+        disabled={!latestPublished}
+        loading={deploying}
+        onClick={() => void deployOrSync()}
+      >
+        {publicationState?.published ? '同步最新 Revision' : '部署 Runtime'}
+      </Button>
+      {publicationState?.published ? (
+        <Button block icon={<ExternalLink size={14} />} onClick={() => history.push('/data-service')}>
+          打开 API 服务
+        </Button>
+      ) : null}
+      {publicationError ? (
+        <div className="text-[11px] leading-5 text-[#b42318]">{publicationError}</div>
+      ) : null}
+    </div>
+  );
+
+  const panelContent: Record<RightPanelKey, React.ReactNode> = {
+    properties: propertiesPanel,
+    request: requestPanel,
+    response: responsePanel,
+    versions: versionsPanel,
+    deployment: deploymentPanel,
+  };
+
+  const selectRightPanel = (key: RightPanelKey) => {
+    if (rightPanelKey === key && rightPanelOpen) {
+      setRightPanelOpen(false);
+      return;
+    }
+    setRightPanelKey(key);
+    setRightPanelOpen(true);
+  };
 
   if (loading) {
     return (
@@ -560,17 +818,12 @@ export default function DataServiceNodeEditor({
     );
   }
 
-  if (!context) {
+  if (loadError || !context) {
     return (
       <div className="flex min-h-0 flex-1 items-center justify-center bg-white px-6">
         <div className="max-w-[520px] text-center">
-          <div className="mx-auto flex h-10 w-10 items-center justify-center rounded-lg bg-[#f5f5f6] text-[#667085]">
-            <Network size={18} />
-          </div>
-          <div className="mt-3 text-[14px] font-semibold text-[#344054]">Data Service Node 加载失败</div>
-          <div className="mt-1 text-[12px] leading-5 text-[#98a2b3]">
-            {loadError || '节点上下文暂时不可用。编辑器已阻止异常数据继续渲染，避免工作区白屏。'}
-          </div>
+          <div className="text-[14px] font-semibold text-[#344054]">Data Service Node 加载失败</div>
+          <div className="mt-2 text-[12px] leading-5 text-[#98a2b3]">{loadError || '未返回有效编辑上下文'}</div>
           <Button className="mt-4" size="small" icon={<RefreshCw size={13} />} onClick={() => void load()}>
             重新加载
           </Button>
@@ -579,63 +832,17 @@ export default function DataServiceNodeEditor({
     );
   }
 
-  const draftRevision = context?.draft?.draftRevision || 0;
-  const latestPublished = context?.latestPublishedRevision;
-  const canSave = Boolean(
-    selectedSourceId
-      && selectedRevisionId
-      && serviceName.trim()
-      && path.trim(),
-  );
-  const canPublish = Boolean(
-    draftRevision > 0
-      && !dirty
-      && responseFields.length > 0,
-  );
-  const runtimeRevisionNo = publicationState?.detail?.sourceRevisionNo;
-  const runtimeStatusLabel = !latestPublished
-    ? '等待发布 DS Revision'
-    : publicationError
-      ? 'Runtime 状态不可用'
-      : publicationLoading && !publicationState
-        ? '正在查询 Runtime'
-        : !publicationState
-          ? 'Runtime 状态未知'
-          : !publicationState.published
-            ? '未部署'
-            : publicationState.updateAvailable
-              ? '待同步'
-              : publicationState.detail?.enabled
-                ? '已同步 · 运行中'
-                : '已同步 · 已停用';
-  const showDeployAction = Boolean(
-    latestPublished
-      && publicationState
-      && (!publicationState.published || publicationState.updateAvailable),
-  );
-
   return (
     <div className="flex min-h-0 flex-1 flex-col overflow-hidden bg-white">
-      <div className="flex h-12 shrink-0 items-center justify-between border-b border-[#e4e7ec] px-4">
-        <div className="flex min-w-0 items-center gap-2.5">
-          <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-[#f5f5f6] text-[#475467]">
-            <Network size={15} />
-          </span>
-          <div className="min-w-0">
-            <div className="truncate text-[13px] font-semibold text-[#161823]">{node.name}</div>
-            <div className="text-[10px] text-[#98a2b3]">
-              Data Service Node
-              {draftRevision ? ` · Draft #${draftRevision}` : ' · 尚未保存'}
-              {latestPublished ? ` · 已发布 DS R${latestPublished.revisionNo}` : ''}
-              {dirty ? ' · 有未保存更改' : ''}
-            </div>
-          </div>
-        </div>
-
-        <div className="flex items-center gap-2">
+      <div className="flex h-10 shrink-0 items-center justify-between border-b border-[#e8e9ec] bg-white px-2.5">
+        <div className="flex items-center gap-1">
+          <Button type="text" size="small" icon={<RefreshCw size={14} />} onClick={() => void load()}>
+            刷新
+          </Button>
           <Button
+            type="text"
             size="small"
-            icon={<RefreshCw size={13} />}
+            icon={<Play size={14} />}
             loading={previewing}
             disabled={!selectedSourceId || !selectedRevisionId}
             onClick={() => void preview()}
@@ -643,296 +850,170 @@ export default function DataServiceNodeEditor({
             预览 Contract
           </Button>
           <Button
+            type="text"
             size="small"
-            icon={<Save size={13} />}
+            icon={<Save size={14} />}
             loading={saving}
-            disabled={!canSave}
+            disabled={!selectedSourceId || !selectedRevisionId || !dirty}
             onClick={() => void save()}
           >
             保存草稿
           </Button>
           <Button
+            type="text"
             size="small"
-            type="primary"
-            icon={<Rocket size={13} />}
+            icon={<Rocket size={14} />}
             loading={publishing}
-            disabled={!canPublish}
+            disabled={!context.draft.draftRevision || dirty}
             onClick={() => void publish()}
           >
             发布版本
           </Button>
+          {latestPublished ? (
+            <Button
+              type="text"
+              size="small"
+              icon={<Network size={14} />}
+              loading={deploying}
+              onClick={() => void deployOrSync()}
+            >
+              {publicationState?.published ? '同步 Runtime' : '部署 Runtime'}
+            </Button>
+          ) : null}
+        </div>
+
+        <div className="flex min-w-0 items-center gap-2 text-[10px] text-[#98a2b3]">
+          <span>Draft #{context.draft.draftRevision || 0}</span>
+          <span className="text-[#d0d5dd]">|</span>
+          <span>{latestPublished ? `DS R${latestPublished.revisionNo}` : '尚未发布'}</span>
+          <span className="text-[#d0d5dd]">|</span>
+          <span className={publicationState?.updateAvailable ? 'text-[#b54708]' : ''}>{runtimeStatus}</span>
         </div>
       </div>
 
-      <div className="min-h-0 flex-1 overflow-y-auto">
-        <section className="border-b border-[#eef0f2] px-4 py-3">
-          <div className="mb-2 flex items-center justify-between gap-3">
-            <div>
-              <div className="text-[11px] font-semibold text-[#344054]">Runtime 部署</div>
-              <div className="mt-0.5 text-[10px] text-[#98a2b3]">
-                Data Development 负责发布不可变 DS Revision；这里仅显式部署/同步，运行策略仍在“数据服务”模块管理。
-              </div>
-            </div>
-            <div className="flex items-center gap-2">
-              <Tag className="!m-0" bordered={false}>{runtimeStatusLabel}</Tag>
-              {latestPublished ? (
-                <Button
-                  size="small"
-                  type="text"
-                  icon={<RefreshCw size={12} />}
-                  loading={publicationLoading}
-                  onClick={() => void loadPublicationState(true, true)}
-                >
-                  刷新
-                </Button>
-              ) : null}
-            </div>
-          </div>
-
-          <div className="flex max-w-[980px] flex-wrap items-center justify-between gap-3 border border-[#e5e7eb] bg-[#fafafa] px-3 py-2.5">
-            <div className="flex min-w-0 flex-wrap items-center gap-x-5 gap-y-1 text-[11px] text-[#667085]">
-              <span>
-                最新发布：
-                <b className="font-medium text-[#344054]">
-                  {latestPublished ? `DS R${latestPublished.revisionNo}` : '尚未发布'}
-                </b>
-              </span>
-              <span>
-                Runtime：
-                <b className="font-medium text-[#344054]">
-                  {publicationState?.published ? `DS R${runtimeRevisionNo || '-'}` : '未部署'}
-                </b>
-              </span>
-              {publicationState?.detail?.runtimePath ? (
-                <span className="max-w-[360px] truncate font-mono text-[#475467]">
-                  {publicationState.detail.runtimePath}
-                </span>
-              ) : null}
-              {publicationState?.updateAvailable ? (
-                <span className="font-medium text-[#b54708]">
-                  Runtime 仍为 DS R{runtimeRevisionNo || '-'}，需显式同步到 DS R{latestPublished?.revisionNo}
-                </span>
-              ) : null}
-              {publicationError ? (
-                <span className="text-[#b42318]">{publicationError}</span>
-              ) : null}
-            </div>
-            <div className="flex shrink-0 items-center gap-2">
-              {showDeployAction ? (
-                <Button
-                  size="small"
-                  type="primary"
-                  icon={<Rocket size={13} />}
-                  loading={deploying}
-                  onClick={() => void deployOrSync()}
-                >
-                  {publicationState?.published ? '同步最新 Revision' : '部署 Runtime'}
-                </Button>
-              ) : null}
-              {publicationState?.published ? (
-                <Button
-                  size="small"
-                  icon={<ExternalLink size={13} />}
-                  onClick={() => history.push('/data-service')}
-                >
-                  打开 API 服务
-                </Button>
-              ) : null}
-            </div>
-          </div>
-
-          {latestPublished && publicationState && !publicationState.published ? (
-            <div className="mt-1.5 text-[10px] text-[#98a2b3]">
-              首次部署默认保持停用，部署完成后请到“数据服务”配置访问控制并显式启用。
-            </div>
-          ) : null}
-        </section>
-
-        <section className="border-b border-[#eef0f2] px-4 py-3">
-          <div className="mb-2 text-[11px] font-semibold text-[#344054]">来源 SQL Revision</div>
-          <div className="grid max-w-[980px] grid-cols-[110px_minmax(0,1fr)] items-start gap-y-2">
-            <span className="pt-1.5 text-[11px] text-[#667085]">SQL 节点</span>
-            <Select
-              showSearch
-              optionFilterProp="label"
-              value={selectedSourceId}
-              options={sourceOptions}
-              placeholder="选择同项目中已发布的 ONLINE SQL"
-              className="w-full"
-              onChange={(value) => changeSource(String(value))}
-            />
-          </div>
-
-          <div className="ml-[110px] mt-1.5 text-[10px] leading-5 text-[#98a2b3]">
-            Data Service Draft 固定精确 SQL Revision。SQL 后续发布新版本时不会自动漂移，需要显式升级来源。
-          </div>
-
-          {!availableSources.length ? (
-            <div className="mt-2 rounded-md border border-[#e4e7ec] bg-[#fafafa] px-2.5 py-2 text-[11px] text-[#667085]">
-              当前项目暂无可选的 ONLINE SQL，请先在数据开发发布一个 SQL 节点。
-            </div>
-          ) : null}
-
-          {activeSource && selectedRevisionId ? (
-            <div className="mt-2 flex flex-wrap items-center gap-2 text-[11px] text-[#667085]">
-              <span>{activeSource.nodeName}</span>
-              <Tag className="!m-0">SQL R{selectedRevisionNo || '-'}</Tag>
-              <span className="text-[#98a2b3]">Revision #{selectedRevisionId}</span>
-              {sourceUpdateAvailable ? (
-                <>
-                  <span className="font-medium text-[#b54708]">
-                    SQL R{activeSource.currentRevisionNo} 可更新
-                  </span>
-                  <Button size="small" onClick={upgradeSource}>
-                    更新来源
-                  </Button>
-                </>
-              ) : (
-                <span className="text-[#667085]">已固定当前 Revision</span>
-              )}
-            </div>
-          ) : null}
-        </section>
-
-        <section className="border-b border-[#eef0f2] px-4 py-3">
-          <div className="mb-2 text-[11px] font-semibold text-[#344054]">接口定义</div>
-          <div className="grid max-w-[980px] grid-cols-[110px_minmax(0,1fr)_110px_minmax(0,1fr)] items-start gap-x-4 gap-y-2">
-            <span className="pt-1.5 text-[11px] text-[#667085]">服务名称</span>
-            <Input
-              size="small"
-              value={serviceName}
-              maxLength={200}
-              onChange={(event) => {
-                setServiceName(event.target.value);
-                markDirty();
-              }}
-            />
-            <span className="pt-1.5 text-[11px] text-[#667085]">请求路径</span>
-            <Input
-              size="small"
-              addonBefore="GET"
-              value={path}
-              maxLength={255}
-              placeholder="/orders"
-              onChange={(event) => {
-                setPath(event.target.value);
-                markDirty();
-              }}
-            />
-
-            <span className="pt-1.5 text-[11px] text-[#667085]">最大行数</span>
-            <InputNumber
-              size="small"
-              min={1}
-              max={10000}
-              value={maxRows}
-              className="w-full"
-              onChange={(value) => {
-                setMaxRows(Number(value || 1000));
-                markDirty();
-              }}
-            />
-            <span className="pt-1.5 text-[11px] text-[#667085]">超时时间</span>
-            <InputNumber
-              size="small"
-              min={1}
-              max={3600}
-              value={timeoutSeconds}
-              addonAfter="秒"
-              className="w-full"
-              onChange={(value) => {
-                setTimeoutSeconds(Number(value || 30));
-                markDirty();
-              }}
-            />
-
-            <span className="pt-1.5 text-[11px] text-[#667085]">说明</span>
-            <div className="col-span-3">
-              <Input.TextArea
-                value={description}
-                maxLength={2000}
-                autoSize={{ minRows: 2, maxRows: 4 }}
-                placeholder="说明这个数据服务提供什么能力"
-                onChange={(event) => {
-                  setDescription(event.target.value);
-                  markDirty();
-                }}
+      <div className="flex min-h-0 flex-1 overflow-hidden">
+        <section className="flex min-w-0 flex-1 flex-col overflow-hidden bg-white">
+          <div className="shrink-0 border-b border-[#eef0f2] px-4 py-3">
+            <div className="flex items-center gap-3">
+              <div className="w-[92px] shrink-0 text-[12px] font-medium text-[#344054]">来源 SQL</div>
+              <Select
+                value={selectedSourceId}
+                options={sourceOptions}
+                placeholder="选择同项目中已发布的 ONLINE SQL"
+                className="min-w-0 flex-1"
+                size="small"
+                showSearch
+                optionFilterProp="label"
+                onChange={changeSource}
               />
+              {selectedRevisionNo ? <Tag bordered={false}>SQL R{selectedRevisionNo}</Tag> : null}
+              {sourceUpdateAvailable ? (
+                <Button size="small" onClick={upgradeSource}>
+                  更新到 R{activeSource?.currentRevisionNo || '-'}
+                </Button>
+              ) : null}
+              <Tooltip title={activeSource?.nodeId ? '在同一个开发工作台中打开来源 SQL 节点' : '来源 SQL 节点不可用'}>
+                <Button
+                  size="small"
+                  disabled={!activeSource?.nodeId}
+                  icon={<ExternalLink size={13} />}
+                  onClick={() => activeSource?.nodeId && onOpenSourceNode?.(activeSource.nodeId)}
+                >
+                  打开来源 SQL
+                </Button>
+              </Tooltip>
             </div>
+            <div className="ml-[104px] mt-1.5 text-[10px] text-[#98a2b3]">
+              Data Service 固定精确 SQL Revision；修改 SQL 请在来源节点发布新版本后，再显式更新这里的来源。
+            </div>
+          </div>
+
+          <div className="flex h-9 shrink-0 items-center justify-between border-b border-[#eef0f2] px-3">
+            <div className="text-[12px] font-semibold text-[#344054]">查询 SQL</div>
+            <div className="flex items-center gap-2 text-[10px] text-[#98a2b3]">
+              {dataSourceId ? <span>DataSource #{dataSourceId}</span> : null}
+              <span>固定 Revision · 只读</span>
+            </div>
+          </div>
+
+          <div className="relative min-h-0 flex-1 overflow-hidden bg-white">
+            {sqlLoading ? (
+              <div className="absolute inset-0 z-10 flex items-center justify-center bg-white/70"><Spin size="small" /></div>
+            ) : null}
+            {sqlError ? (
+              <div className="flex h-full items-center justify-center px-6 text-center">
+                <div>
+                  <div className="text-[12px] font-medium text-[#b42318]">SQL Revision 加载失败</div>
+                  <div className="mt-1 text-[11px] text-[#98a2b3]">{sqlError}</div>
+                  <Button className="mt-3" size="small" onClick={() => void loadSqlRevision()}>重试</Button>
+                </div>
+              </div>
+            ) : sqlText ? (
+              <SqlMonacoEditor
+                id={`data-service-${node.id}-${selectedRevisionId || 'empty'}`}
+                value={sqlText}
+                onChange={() => undefined}
+                readOnly
+              />
+            ) : (
+              <div className="flex h-full items-center justify-center text-center">
+                <div>
+                  <div className="text-[12px] font-medium text-[#667085]">选择来源 SQL Revision</div>
+                  <div className="mt-1 text-[11px] text-[#98a2b3]">选择后将在这里展示固定版本的查询 SQL</div>
+                </div>
+              </div>
+            )}
+          </div>
+
+          <div className="flex h-6 shrink-0 items-center justify-between border-t border-[#eef0f2] bg-[#fafafa] px-3 text-[10px] text-[#7b808a]">
+            <div className="flex min-w-0 items-center gap-3">
+              <span className="font-medium text-[#7f56d9]">DATA SERVICE</span>
+              <span className="truncate">{serviceName || node.name}</span>
+              {dirty ? (
+                <span className="inline-flex items-center gap-1 text-[#667085]">
+                  <span className="h-1.5 w-1.5 rounded-full bg-[#667085]" />未保存
+                </span>
+              ) : null}
+            </div>
+            <div>{selectedRevisionNo ? `SQL R${selectedRevisionNo}` : '未选择 SQL'}</div>
           </div>
         </section>
 
-        <section className="border-b border-[#eef0f2] px-4 py-3">
-          <div className="mb-2 flex items-center justify-between">
-            <div>
-              <div className="text-[11px] font-semibold text-[#344054]">请求参数 Contract</div>
-              <div className="mt-0.5 text-[10px] text-[#98a2b3]">
-                参数名来自 SQL 中的 :name 命名参数；类型、必填、描述和示例属于 Data Service Node。
-              </div>
+        <aside
+          className={[
+            'flex shrink-0 border-l border-[#e8e9ec] bg-white transition-[width] duration-150',
+            rightPanelOpen ? 'w-[470px]' : 'w-10',
+          ].join(' ')}
+        >
+          {rightPanelOpen ? (
+            <div className="min-w-0 flex-1 overflow-auto p-4">
+              {panelContent[rightPanelKey]}
             </div>
-            <span className="text-[10px] text-[#98a2b3]">{parameters.length} 个参数</span>
+          ) : null}
+          <div className="flex w-10 shrink-0 flex-col items-stretch border-l border-[#eef0f2] bg-[#fafafa]">
+            {panelItems.map((item) => {
+              const Icon = item.icon;
+              const active = rightPanelOpen && rightPanelKey === item.key;
+              return (
+                <Tooltip key={item.key} title={item.label} placement="left">
+                  <button
+                    type="button"
+                    onClick={() => selectRightPanel(item.key)}
+                    className={[
+                      'flex h-[86px] flex-col items-center justify-center gap-1 border-b border-[#eef0f2] text-[10px] transition-colors',
+                      active
+                        ? 'bg-white text-[rgba(254,44,85,1)]'
+                        : 'text-[#667085] hover:bg-white hover:text-[#344054]',
+                    ].join(' ')}
+                  >
+                    <Icon size={14} strokeWidth={1.8} />
+                    <span style={{ writingMode: 'vertical-rl' }}>{item.label}</span>
+                  </button>
+                </Tooltip>
+              );
+            })}
           </div>
-          <Table<DevelopmentDataServiceParameter>
-            size="small"
-            pagination={false}
-            rowKey="name"
-            dataSource={parameters}
-            columns={parameterColumns}
-            locale={{
-              emptyText: selectedRevisionId
-                ? '点击“预览 Contract”发现 SQL 请求参数'
-                : '先选择一个 SQL Revision',
-            }}
-            scroll={{ x: 880 }}
-          />
-        </section>
-
-        <section className="border-b border-[#eef0f2] px-4 py-3">
-          <div className="mb-2 flex items-center justify-between">
-            <div>
-              <div className="text-[11px] font-semibold text-[#344054]">响应字段 Contract</div>
-              <div className="mt-0.5 text-[10px] text-[#98a2b3]">
-                响应字段和基础类型通过只读 Preview 自动发现；描述和示例随 Data Service Revision 冻结。
-              </div>
-            </div>
-            <span className="text-[10px] text-[#98a2b3]">{responseFields.length} 个字段</span>
-          </div>
-          <Table<DevelopmentDataServiceResponseField>
-            size="small"
-            pagination={false}
-            rowKey="name"
-            dataSource={responseFields}
-            columns={responseColumns}
-            locale={{
-              emptyText: selectedRevisionId
-                ? '点击“预览 Contract”发现响应字段'
-                : '先选择一个 SQL Revision',
-            }}
-            scroll={{ x: 880 }}
-          />
-        </section>
-
-        <section className="px-4 py-3">
-          <div className="mb-2 flex items-center justify-between">
-            <div>
-              <div className="text-[11px] font-semibold text-[#344054]">发布历史</div>
-              <div className="mt-0.5 text-[10px] text-[#98a2b3]">
-                发布只生成不可变 DS Revision；新版本不会自动改变线上 Runtime，需要在上方显式部署或同步。
-              </div>
-            </div>
-            <Tag className="!m-0">
-              {latestPublished ? `最新 DS R${latestPublished.revisionNo}` : '尚未发布'}
-            </Tag>
-          </div>
-          <Table<DevelopmentDataServiceRevisionSummary>
-            size="small"
-            pagination={false}
-            rowKey="id"
-            dataSource={context?.revisions || []}
-            columns={revisionColumns}
-            locale={{ emptyText: '保存草稿并发布后，这里会出现 DS Revision' }}
-          />
-        </section>
+        </aside>
       </div>
     </div>
   );

--- a/yak-ops-ui/src/pages/data-development/components/workbench/DevelopmentWorkbench.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/workbench/DevelopmentWorkbench.tsx
@@ -13,6 +13,7 @@ import {
   prepareDevelopmentTaskDefinition,
   restoreDevelopmentTaskOriginal,
 } from '../../editors/taskPersistence';
+import { isDevelopmentTaskNode } from '../../node-model';
 import {
   getDevelopmentTaskDraft,
   publishDevelopmentTask,
@@ -23,9 +24,11 @@ import type {
   DevelopmentDirectory,
   DevelopmentId,
   DevelopmentNode,
+  DevelopmentResourceNode,
   DevelopmentTaskDraft,
   DevelopmentTaskRunResult,
 } from '../../types';
+import DataServiceNodeEditor from '../data-service/DataServiceNodeEditor';
 import EditorHost from './EditorHost';
 import EditorTabs, { type EditorTabAction } from './EditorTabs';
 import EditorToolbar from './EditorToolbar';
@@ -33,7 +36,7 @@ import RightPanel from './RightPanel';
 import RunResultPanel from './RunResultPanel';
 
 interface DevelopmentWorkbenchProps {
-  nodes: DevelopmentNode[];
+  nodes: DevelopmentResourceNode[];
   directories: DevelopmentDirectory[];
   selectedNodeId?: DevelopmentId;
   onNodeFocus: (nodeId?: DevelopmentId) => void;
@@ -44,6 +47,48 @@ interface PendingCloseRequest {
   nodeIds: DevelopmentId[];
   dirtyNodeIds: DevelopmentId[];
 }
+
+interface DataServiceWorkbenchEditorProps {
+  node: DevelopmentResourceNode;
+  active: boolean;
+  onSaved?: () => void | Promise<void>;
+  onOpenSourceNode: (nodeId: DevelopmentId) => void;
+  onDirtyChange: (dirty: boolean) => void;
+}
+
+/**
+ * Keep the authoring node identity stable while the directory tree refreshes. A save in another tab
+ * may recreate the node list; that must not force a hidden Data Service editor to reload and discard
+ * its unsaved local form state.
+ */
+const DataServiceWorkbenchEditor = ({
+  node,
+  active,
+  onSaved,
+  onOpenSourceNode,
+  onDirtyChange,
+}: DataServiceWorkbenchEditorProps) => {
+  const stableNode = useMemo(
+    () => node,
+    [node.id, node.name],
+  );
+
+  return (
+    <div
+      className={[
+        'min-h-0 flex-1 overflow-hidden',
+        active ? 'flex' : 'hidden',
+      ].join(' ')}
+    >
+      <DataServiceNodeEditor
+        node={stableNode}
+        onSaved={onSaved}
+        onOpenSourceNode={onOpenSourceNode}
+        onDirtyChange={onDirtyChange}
+      />
+    </div>
+  );
+};
 
 const responseData = <T,>(
   response: { code?: number; data?: T; msg?: string; message?: string },
@@ -74,6 +119,7 @@ const DevelopmentWorkbench = ({
   const [publishing, setPublishing] = useState(false);
   const [closeSaving, setCloseSaving] = useState(false);
   const [versionsRefreshKey, setVersionsRefreshKey] = useState(0);
+  const [dataServiceDirtyNodeIds, setDataServiceDirtyNodeIds] = useState<DevelopmentId[]>([]);
 
   const nodeMap = useMemo(
     () => new Map(nodes.map((node) => [node.id, node])),
@@ -97,12 +143,13 @@ const DevelopmentWorkbench = ({
     setActiveNodeId((current) =>
       current && nodeMap.has(current) ? current : undefined,
     );
+    setDataServiceDirtyNodeIds((current) => current.filter((nodeId) => nodeMap.has(nodeId)));
   }, [nodeMap]);
 
   useEffect(() => {
     if (!activeNodeId) return;
     const node = nodeMap.get(activeNodeId);
-    if (!node) return;
+    if (!node || !isDevelopmentTaskNode(node)) return;
 
     let active = true;
     getDevelopmentTaskDraft(node.id)
@@ -121,24 +168,46 @@ const DevelopmentWorkbench = ({
     };
   }, [activeNodeId, nodeMap]);
 
-  const activeNode = activeNodeId ? nodeMap.get(activeNodeId) : undefined;
-  const activeDirectory = activeNode?.directoryId
-    ? directoryMap.get(activeNode.directoryId)
+  const activeResource = activeNodeId ? nodeMap.get(activeNodeId) : undefined;
+  const activeTaskNode = activeResource && isDevelopmentTaskNode(activeResource)
+    ? activeResource
     : undefined;
-  const activeRunning = activeNode
-    ? runningNodeIds.includes(activeNode.id)
+  const activeDirectory = activeResource?.directoryId
+    ? directoryMap.get(activeResource.directoryId)
+    : undefined;
+  const activeRunning = activeTaskNode
+    ? runningNodeIds.includes(activeTaskNode.id)
     : false;
+  const openDataServiceNodes = useMemo(
+    () => openNodeIds
+      .map((nodeId) => nodeMap.get(nodeId))
+      .filter((node): node is DevelopmentResourceNode => Boolean(node && node.type === 'DATA_SERVICE')),
+    [nodeMap, openNodeIds],
+  );
 
   const focusNode = (nodeId: DevelopmentId) => {
+    const target = nodeMap.get(nodeId);
+    if (!target) return;
+    setOpenNodeIds((current) => current.includes(nodeId) ? current : [...current, nodeId]);
     setActiveNodeId(nodeId);
+    if (target.type === 'DATA_SERVICE') setRunPanelOpen(false);
     onNodeFocus(nodeId);
   };
 
-  const persistDraft = async (nodeId: DevelopmentId): Promise<DevelopmentTaskDraft> => {
-    const node = nodeMap.get(nodeId);
-    if (!node) throw new Error(`节点不存在：${nodeId}`);
+  const updateDataServiceDirty = (nodeId: DevelopmentId, dirty: boolean) => {
+    setDataServiceDirtyNodeIds((current) => {
+      if (dirty) return current.includes(nodeId) ? current : [...current, nodeId];
+      return current.filter((id) => id !== nodeId);
+    });
+  };
 
-    const definition = prepareDevelopmentTaskDefinition(node);
+  const persistDraft = async (nodeId: DevelopmentId): Promise<DevelopmentTaskDraft> => {
+    const resource = nodeMap.get(nodeId);
+    if (!resource || !isDevelopmentTaskNode(resource)) {
+      throw new Error(`当前节点不是可执行任务：${nodeId}`);
+    }
+
+    const definition = prepareDevelopmentTaskDefinition(resource);
     const session = getEditorSession(nodeId);
     const draft = responseData(
       await saveDevelopmentTaskDraft(nodeId, {
@@ -154,10 +223,10 @@ const DevelopmentWorkbench = ({
   };
 
   const saveActiveDraft = async () => {
-    if (!activeNode) return;
+    if (!activeTaskNode) return;
     setSaving(true);
     try {
-      const draft = await persistDraft(activeNode.id);
+      const draft = await persistDraft(activeTaskNode.id);
       message.success(`草稿已保存 · Draft #${draft.draftRevision}`);
     } catch (error) {
       message.error(error instanceof Error ? error.message : '保存草稿失败');
@@ -167,8 +236,8 @@ const DevelopmentWorkbench = ({
   };
 
   const runActiveTask = async (contentOverride?: string) => {
-    if (!activeNode || runningNodeIds.includes(activeNode.id)) return;
-    const node = activeNode;
+    if (!activeTaskNode || runningNodeIds.includes(activeTaskNode.id)) return;
+    const node = activeTaskNode;
     const startedAt = Date.now();
     setRunPanelOpen(true);
     setRunningNodeIds((current) => [...current, node.id]);
@@ -214,21 +283,21 @@ const DevelopmentWorkbench = ({
   };
 
   const publishActiveTask = async () => {
-    if (!activeNode) return;
+    if (!activeTaskNode) return;
     setPublishing(true);
     try {
-      prepareDevelopmentTaskDefinition(activeNode);
-      let session = getEditorSession(activeNode.id);
+      prepareDevelopmentTaskDefinition(activeTaskNode);
+      let session = getEditorSession(activeTaskNode.id);
       if (!session || session.dirty || !session.draftRevision) {
-        await persistDraft(activeNode.id);
-        session = getEditorSession(activeNode.id);
+        await persistDraft(activeTaskNode.id);
+        session = getEditorSession(activeTaskNode.id);
       }
       if (!session?.draftRevision) {
         throw new Error('发布前请先保存草稿');
       }
 
       const published = responseData(
-        await publishDevelopmentTask(activeNode.id, session.draftRevision),
+        await publishDevelopmentTask(activeTaskNode.id, session.draftRevision),
         '发布任务失败',
       );
       setVersionsRefreshKey((current) => current + 1);
@@ -247,6 +316,7 @@ const DevelopmentWorkbench = ({
     const currentIndex = activeNodeId ? openNodeIds.indexOf(activeNodeId) : -1;
     const next = openNodeIds.filter((id) => !closeSet.has(id));
     setOpenNodeIds(next);
+    setDataServiceDirtyNodeIds((current) => current.filter((id) => !closeSet.has(id)));
 
     if (!activeNodeId || !closeSet.has(activeNodeId)) return;
 
@@ -255,16 +325,33 @@ const DevelopmentWorkbench = ({
       next[next.length - 1];
     setActiveNodeId(nextActiveId);
     onNodeFocus(nextActiveId);
-    if (!nextActiveId) setRunPanelOpen(false);
+    if (!nextActiveId || nodeMap.get(nextActiveId)?.type === 'DATA_SERVICE') {
+      setRunPanelOpen(false);
+    }
   };
 
   const requestCloseNodes = (nodeIds: DevelopmentId[]) => {
     const targetNodeIds = openNodeIds.filter((nodeId) => nodeIds.includes(nodeId));
     if (!targetNodeIds.length) return;
 
-    const dirtyNodeIds = targetNodeIds.filter(
-      (nodeId) => getEditorSession(nodeId)?.dirty,
-    );
+    const dirtyDataServiceNodes = targetNodeIds
+      .filter((nodeId) => dataServiceDirtyNodeIds.includes(nodeId))
+      .map((nodeId) => nodeMap.get(nodeId))
+      .filter((node): node is DevelopmentResourceNode => Boolean(node));
+    if (dirtyDataServiceNodes.length) {
+      const firstName = dirtyDataServiceNodes[0]?.name || 'Data Service';
+      message.warning(
+        dirtyDataServiceNodes.length === 1
+          ? `「${firstName}」有未保存修改，请先保存草稿后再关闭`
+          : `有 ${dirtyDataServiceNodes.length} 个 Data Service 编辑器尚未保存，请先保存草稿`,
+      );
+      return;
+    }
+
+    const dirtyNodeIds = targetNodeIds.filter((nodeId) => {
+      const node = nodeMap.get(nodeId);
+      return Boolean(node && isDevelopmentTaskNode(node) && getEditorSession(nodeId)?.dirty);
+    });
 
     if (!dirtyNodeIds.length) {
       closeNodes(targetNodeIds);
@@ -297,7 +384,7 @@ const DevelopmentWorkbench = ({
     } else {
       pendingClose.dirtyNodeIds.forEach((nodeId) => {
         const node = nodeMap.get(nodeId);
-        if (node) restoreDevelopmentTaskOriginal(node);
+        if (node && isDevelopmentTaskNode(node)) restoreDevelopmentTaskOriginal(node);
       });
     }
 
@@ -334,11 +421,11 @@ const DevelopmentWorkbench = ({
 
   const pendingDirtyNodes = pendingClose?.dirtyNodeIds
     .map((nodeId) => nodeMap.get(nodeId))
-    .filter((node): node is DevelopmentNode => Boolean(node));
+    .filter((node): node is DevelopmentNode => Boolean(node && isDevelopmentTaskNode(node)));
   const pendingDirtyCount = pendingDirtyNodes?.length || 0;
   const pendingDirtyName = pendingDirtyNodes?.[0]?.name || '当前编辑器';
 
-  if (!openNodeIds.length || !activeNode) {
+  if (!openNodeIds.length || !activeResource) {
     return (
       <main className="flex min-w-0 flex-1 items-center justify-center overflow-hidden bg-white">
         <div className="text-center">
@@ -346,14 +433,14 @@ const DevelopmentWorkbench = ({
             选择左侧开发节点
           </div>
           <div className="mt-1 text-[12px] text-[#98a2b3]">
-            点击 SQL 或 Shell 节点后进入编辑工作区
+            SQL、Shell 和 Data Service 会在同一个开发工作台中打开
           </div>
         </div>
       </main>
     );
   }
 
-  const definition = getEditorDefinition(activeNode.type);
+  const definition = activeTaskNode ? getEditorDefinition(activeTaskNode.type) : undefined;
 
   return (
     <main className="flex min-w-0 flex-1 flex-col overflow-hidden bg-white">
@@ -361,48 +448,66 @@ const DevelopmentWorkbench = ({
         nodeMap={nodeMap}
         openNodeIds={openNodeIds}
         activeNodeId={activeNodeId}
+        dirtyNodeIds={dataServiceDirtyNodeIds}
         onFocus={focusNode}
         onClose={(nodeId) => requestCloseNodes([nodeId])}
         onAction={handleTabAction}
       />
 
-      <EditorToolbar
-        node={activeNode}
-        directory={activeDirectory}
-        definition={definition}
-        onRun={() => void runActiveTask()}
-        onSave={() => void saveActiveDraft()}
-        onPublish={() => void publishActiveTask()}
-        running={activeRunning}
-        saving={saving}
-        publishing={publishing}
-      />
-
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-        <div className="flex min-h-0 flex-1 overflow-hidden">
-          <EditorHost
-            node={activeNode}
-            directory={activeDirectory}
-            definition={definition}
-            onRunContent={(content) => void runActiveTask(content)}
-            running={activeRunning}
-          />
-          <RightPanel
-            node={activeNode}
-            directory={activeDirectory}
-            definition={definition}
-            versionsRefreshKey={versionsRefreshKey}
-          />
-        </div>
+        {activeTaskNode && definition ? (
+          <>
+            <EditorToolbar
+              node={activeTaskNode}
+              directory={activeDirectory}
+              definition={definition}
+              onRun={() => void runActiveTask()}
+              onSave={() => void saveActiveDraft()}
+              onPublish={() => void publishActiveTask()}
+              running={activeRunning}
+              saving={saving}
+              publishing={publishing}
+            />
 
-        <RunResultPanel
-          open={runPanelOpen}
-          node={activeNode}
-          directory={activeDirectory}
-          definition={definition}
-          result={runResults[activeNode.id]}
-          onClose={() => setRunPanelOpen(false)}
-        />
+            <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+              <div className="flex min-h-0 flex-1 overflow-hidden">
+                <EditorHost
+                  node={activeTaskNode}
+                  directory={activeDirectory}
+                  definition={definition}
+                  onRunContent={(content) => void runActiveTask(content)}
+                  running={activeRunning}
+                />
+                <RightPanel
+                  node={activeTaskNode}
+                  directory={activeDirectory}
+                  definition={definition}
+                  versionsRefreshKey={versionsRefreshKey}
+                />
+              </div>
+
+              <RunResultPanel
+                open={runPanelOpen}
+                node={activeTaskNode}
+                directory={activeDirectory}
+                definition={definition}
+                result={runResults[activeTaskNode.id]}
+                onClose={() => setRunPanelOpen(false)}
+              />
+            </div>
+          </>
+        ) : null}
+
+        {openDataServiceNodes.map((dataServiceNode) => (
+          <DataServiceWorkbenchEditor
+            key={dataServiceNode.id}
+            node={dataServiceNode}
+            active={activeNodeId === dataServiceNode.id}
+            onSaved={onNodesChanged}
+            onOpenSourceNode={focusNode}
+            onDirtyChange={(dirty) => updateDataServiceDirty(dataServiceNode.id, dirty)}
+          />
+        ))}
       </div>
 
       <Modal

--- a/yak-ops-ui/src/pages/data-development/components/workbench/EditorTabs.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/workbench/EditorTabs.tsx
@@ -2,12 +2,15 @@ import { Dropdown, Tooltip } from 'antd';
 import { Check, MoreHorizontal, X } from 'lucide-react';
 import { useEffect, useMemo, useRef } from 'react';
 
-import { getEditorDefinition } from '../../editors/registry';
+import { getEditorAppearance } from '../../editors/registry';
 import {
   getEditorSession,
   useEditorSessionVersion,
 } from '../../editors/session/editorSessionStore';
-import type { DevelopmentId, DevelopmentNode } from '../../types';
+import type {
+  DevelopmentId,
+  DevelopmentResourceNode,
+} from '../../types';
 
 export type EditorTabAction =
   | 'close-current'
@@ -17,9 +20,10 @@ export type EditorTabAction =
   | 'close-all';
 
 interface EditorTabsProps {
-  nodeMap: Map<DevelopmentId, DevelopmentNode>;
+  nodeMap: Map<DevelopmentId, DevelopmentResourceNode>;
   openNodeIds: DevelopmentId[];
   activeNodeId?: DevelopmentId;
+  dirtyNodeIds?: DevelopmentId[];
   onFocus: (nodeId: DevelopmentId) => void;
   onClose: (nodeId: DevelopmentId) => void;
   onAction: (action: EditorTabAction) => void;
@@ -29,12 +33,14 @@ const EditorTabs = ({
   nodeMap,
   openNodeIds,
   activeNodeId,
+  dirtyNodeIds = [],
   onFocus,
   onClose,
   onAction,
 }: EditorTabsProps) => {
   const tabRefs = useRef(new Map<DevelopmentId, HTMLDivElement>());
   const sessionVersion = useEditorSessionVersion();
+  const dirtySet = useMemo(() => new Set(dirtyNodeIds), [dirtyNodeIds]);
 
   useEffect(() => {
     if (!activeNodeId) return;
@@ -48,6 +54,9 @@ const EditorTabs = ({
     return () => window.cancelAnimationFrame(frame);
   }, [activeNodeId]);
 
+  const isDirty = (nodeId: DevelopmentId) =>
+    Boolean(getEditorSession(nodeId)?.dirty || dirtySet.has(nodeId));
+
   const menuItems = useMemo(
     () => [
       {
@@ -56,14 +65,13 @@ const EditorTabs = ({
         children: openNodeIds.map((nodeId) => {
           const node = nodeMap.get(nodeId);
           const active = nodeId === activeNodeId;
-          const definition = node ? getEditorDefinition(node.type) : undefined;
-          const session = getEditorSession(nodeId);
-          const Icon = definition?.icon;
+          const appearance = node ? getEditorAppearance(node.type) : undefined;
+          const Icon = appearance?.icon;
 
           return {
             key: `focus:${nodeId}`,
             icon: Icon ? (
-              <span className={definition?.iconClassName}>
+              <span className={appearance?.iconClassName}>
                 <Icon size={13} strokeWidth={1.8} />
               </span>
             ) : undefined,
@@ -73,7 +81,7 @@ const EditorTabs = ({
                   <span className="max-w-[200px] truncate">
                     {node?.name || nodeId}
                   </span>
-                  {session?.dirty ? (
+                  {isDirty(nodeId) ? (
                     <span
                       className="h-1.5 w-1.5 shrink-0 rounded-full bg-[#667085]"
                       title="未保存"
@@ -109,7 +117,7 @@ const EditorTabs = ({
       },
       { key: 'close-all', label: '全部关闭' },
     ],
-    [activeNodeId, nodeMap, openNodeIds, sessionVersion],
+    [activeNodeId, dirtySet, nodeMap, openNodeIds, sessionVersion],
   );
 
   return (
@@ -120,9 +128,8 @@ const EditorTabs = ({
             const node = nodeMap.get(nodeId);
             if (!node) return null;
             const active = nodeId === activeNodeId;
-            const definition = getEditorDefinition(node.type);
-            const session = getEditorSession(nodeId);
-            const Icon = definition.icon;
+            const appearance = getEditorAppearance(node.type);
+            const Icon = appearance.icon;
 
             return (
               <div
@@ -143,7 +150,7 @@ const EditorTabs = ({
               >
                 <button
                   type="button"
-                  title={node.name}
+                  title={`${appearance.label} · ${node.name}`}
                   aria-current={active ? 'page' : undefined}
                   onClick={() => onFocus(nodeId)}
                   className="flex h-full min-w-0 flex-1 items-center gap-2 bg-transparent pl-3 pr-1 text-left outline-none"
@@ -151,7 +158,7 @@ const EditorTabs = ({
                   <span
                     className={[
                       'flex h-5 w-4 shrink-0 items-center justify-center',
-                      definition.iconClassName,
+                      appearance.iconClassName,
                     ].join(' ')}
                   >
                     <Icon size={13} strokeWidth={1.8} />
@@ -164,7 +171,7 @@ const EditorTabs = ({
                   >
                     {node.name}
                   </span>
-                  {session?.dirty ? (
+                  {isDirty(nodeId) ? (
                     <span
                       className="h-1.5 w-1.5 shrink-0 rounded-full bg-[#667085]"
                       title="未保存"

--- a/yak-ops-ui/src/pages/data-development/editors/registry.tsx
+++ b/yak-ops-ui/src/pages/data-development/editors/registry.tsx
@@ -1,6 +1,6 @@
-import { Code2, TerminalSquare } from 'lucide-react';
+import { Braces, Code2, DatabaseZap, Network, TerminalSquare } from 'lucide-react';
 
-import type { DevelopmentTaskType } from '../types';
+import type { DevelopmentNodeType, DevelopmentTaskType } from '../types';
 import { ShellEditor, ShellRunConfig, ShellRunResult } from './shell/ShellEditor';
 import { SqlEditor, SqlRunConfig, SqlRunResult } from './sql/SqlEditor';
 import SqlToolbar from './sql/SqlToolbar';
@@ -94,5 +94,48 @@ export const getEditorDefinition = (
     iconClassName: 'text-[#667085]',
     capabilities: commonCapabilities,
     Editor: UnsupportedEditor,
+  };
+};
+
+/**
+ * Visual metadata for every resource that may appear in the shared development tab strip.
+ * This is deliberately broader than the task editor registry: DATA_SERVICE can share the
+ * workbench UI without entering the task Draft / TaskRevision lifecycle.
+ */
+export const getEditorAppearance = (type: DevelopmentNodeType) => {
+  if (type === 'DATA_SERVICE') {
+    return {
+      label: 'Data Service',
+      icon: Network,
+      iconClassName: 'text-[#7f56d9]',
+    };
+  }
+  if (type === 'DATASET') {
+    return {
+      label: 'Dataset',
+      icon: DatabaseZap,
+      iconClassName: 'text-[#12b76a]',
+    };
+  }
+  if (type === 'HTTP') {
+    return {
+      label: 'HTTP',
+      icon: Braces,
+      iconClassName: 'text-[#2e90fa]',
+    };
+  }
+  if (type === 'PYTHON') {
+    return {
+      label: 'Python',
+      icon: Code2,
+      iconClassName: 'text-[#667085]',
+    };
+  }
+
+  const definition = getEditorDefinition(type);
+  return {
+    label: definition.label,
+    icon: definition.icon,
+    iconClassName: definition.iconClassName,
   };
 };

--- a/yak-ops-ui/src/pages/data-development/editors/sql/components/SqlMonacoEditor.tsx
+++ b/yak-ops-ui/src/pages/data-development/editors/sql/components/SqlMonacoEditor.tsx
@@ -38,6 +38,7 @@ interface SqlMonacoEditorProps {
   onChange: (value: string) => void;
   onRunStatement?: (sql: string) => void;
   running?: boolean;
+  readOnly?: boolean;
   onPositionChange?: (position: SqlEditorPosition) => void;
   onViewStateChange?: (viewState: DevelopmentEditorViewState) => void;
 }
@@ -57,6 +58,7 @@ const SqlMonacoEditor = ({
   onChange,
   onRunStatement,
   running,
+  readOnly = false,
   onPositionChange,
   onViewStateChange,
 }: SqlMonacoEditorProps) => {
@@ -102,6 +104,8 @@ const SqlMonacoEditor = ({
     const editor = monaco.editor.create(containerRef.current, {
       model,
       ...editorOptionsFromSettings(initialSettings),
+      readOnly,
+      domReadOnly: readOnly,
       automaticLayout: true,
       tabSize: 2,
       insertSpaces: true,
@@ -110,7 +114,7 @@ const SqlMonacoEditor = ({
       cursorSmoothCaretAnimation: 'on',
       cursorBlinking: 'smooth',
       showFoldingControls: 'always',
-      glyphMargin: true,
+      glyphMargin: !readOnly,
       lineNumbersMinChars: 3,
       overviewRulerLanes: 0,
       hideCursorInOverviewRuler: true,
@@ -151,10 +155,12 @@ const SqlMonacoEditor = ({
     const refreshStatementDecorations = () => {
       statementRanges = getSqlStatementRanges(model.getValue());
       runDecorations.set(
-        statementRanges.map((statement) => ({
-          range: new monaco.Range(statement.startLine, 1, statement.startLine, 1),
-          options: { glyphMarginClassName: 'yak-sql-run-glyph' },
-        })),
+        readOnly
+          ? []
+          : statementRanges.map((statement) => ({
+              range: new monaco.Range(statement.startLine, 1, statement.startLine, 1),
+              options: { glyphMarginClassName: 'yak-sql-run-glyph' },
+            })),
       );
     };
     refreshStatementDecorations();
@@ -164,7 +170,7 @@ const SqlMonacoEditor = ({
     const commandBinding = registerSqlEditorCommandHandler(id, async (command) => {
       editor.focus();
       if (command === 'undo' || command === 'redo') {
-        editor.trigger('yak-sql-toolbar', command, null);
+        if (!readOnly) editor.trigger('yak-sql-toolbar', command, null);
         return;
       }
       if (command === 'find') {
@@ -172,7 +178,7 @@ const SqlMonacoEditor = ({
         return;
       }
       if (command === 'suggest') {
-        await editor.getAction('editor.action.triggerSuggest')?.run();
+        if (!readOnly) await editor.getAction('editor.action.triggerSuggest')?.run();
         return;
       }
       if (command === 'toggle-word-wrap') {
@@ -185,7 +191,7 @@ const SqlMonacoEditor = ({
         editor.updateOptions({ minimap: { enabled: minimapEnabled } });
         return;
       }
-      if (command === 'format') {
+      if (command === 'format' && !readOnly) {
         const formatted = formatSqlText(model.getValue());
         if (formatted === model.getValue()) return;
         editor.pushUndoStop();
@@ -223,10 +229,11 @@ const SqlMonacoEditor = ({
 
     const contentDisposable = model.onDidChangeContent(() => {
       refreshStatementDecorations();
-      onChangeRef.current(model.getValue());
+      if (!readOnly) onChangeRef.current(model.getValue());
     });
     const gutterDisposable = editor.onMouseDown((event) => {
       if (
+        readOnly ||
         event.target.type !== monaco.editor.MouseTargetType.GUTTER_GLYPH_MARGIN ||
         runningRef.current ||
         !onRunStatementRef.current
@@ -264,7 +271,7 @@ const SqlMonacoEditor = ({
       editorRef.current = undefined;
       modelRef.current = undefined;
     };
-  }, [id]);
+  }, [id, readOnly]);
 
   useEffect(() => {
     const model = modelRef.current;


### PR DESCRIPTION
## 背景

当前 Data Service Node 的领域生命周期已经稳定，但开发体验仍然更像一张资源配置表单，与数据开发中的 SQL 工作台割裂。

这个 PR 参考 DataWorks 数据服务开发体验做前端重构：**Data Service 仍然是独立资源资产，但进入与 SQL/Shell 相同的开发工作台和 Tab 体系。**

核心原则不变：

```text
SQL Revision
   ↓ pin
Data Service Draft
   ↓
DS Revision
   ↓ explicit deploy / sync
Runtime
```

本 PR 只改变 authoring UX，不把 DATA_SERVICE 重新变成 Task Catalog / Workflow task。

## 1. Data Service 注册进统一开发 Tab

SQL、Shell、Data Service 现在可以同时在同一套编辑 Tab 中打开和切换。

- 左侧点击 Data Service Node 后直接新增/聚焦编辑 Tab
- Tab 使用独立 Data Service 图标
- Data Service 未保存时显示 dirty 状态
- 有未保存 Data Service 修改时禁止直接关闭 Tab，避免丢失 Draft
- 保存其他 SQL/Shell 后目录刷新不会覆盖隐藏 Data Service Tab 中尚未保存的本地状态

Dataset 仍保持独立资源编辑器，不进入任务工作台。

## 2. Data Service 开发页改成 SQL Workbench

原来的纵向大表单被重构为更接近 DataWorks 的开发布局：

```text
Tab
────────────────────────────────────────────
刷新  预览 Contract  保存草稿  发布版本  部署/同步

来源 SQL  [订单查询.sql · SQL R3] [打开来源 SQL]
────────────────────────────────────────────
查询 SQL                               固定 Revision · 只读
┌───────────────────────────────┬──────────┐
│                               │ 属性     │
│        Monaco SQL             │ 请求参数 │
│                               │ 返回参数 │
│                               │ 版本     │
│                               │ 部署     │
└───────────────────────────────┴──────────┘
```

中间 SQL 区域直接复用现有 SQL Monaco 编辑器，因此视觉、主题、查找、滚动等体验与 SQL 开发保持一致。

## 3. 精确 SQL Revision 仍然是唯一来源

为了不产生第二份 SQL 真相，中间展示的是 Data Service Draft 当前固定的 **精确 SQL Revision**，默认只读。

- Data Service 不直接修改 SQL Task
- 点击「打开来源 SQL」会在同一个工作台中打开来源 SQL Tab
- SQL 发布新 Revision 后，Data Service 明确显示“更新到 Rn”
- 只有用户显式更新来源后，Data Service Draft 才迁移到新 SQL Revision

这样既获得 DataWorks 类似的开发体验，又保持此前已经建立的不可变版本关系。

## 4. 右侧改成 DataWorks 风格的竖向面板

第一版只保留真正需要的 5 个入口：

- 属性
- 请求参数
- 返回参数
- 版本
- 部署

### 属性
维护 API 名称、GET Path、maxRows、timeout 和描述，同时展示 Draft / DS Revision / SQL Revision / DataSource 信息。

### 请求参数
参数来自 SQL `:name` 命名参数；当前 v1 固定为必填，并且不提供 OBJECT 请求类型，和 Runtime 发布校验保持一致。

### 返回参数
保留字段类型、nullable、描述和示例，继续通过 Preview Contract 从真实数据源发现。

### 版本
轻量展示 DS Revision、固定的 SQL Revision、来源 Draft 和发布时间。

### 部署
展示当前 Runtime Revision / 状态 / Endpoint，并提供部署或同步入口。

## 5. Monaco 支持只读 Revision 展示

现有 `SqlMonacoEditor` 增加轻量 `readOnly` 模式：

- 继续复用当前 SQL 编辑器主题与查看体验
- 禁止修改、格式化、补全触发和 gutter 执行
- 不显示 SQL 运行 glyph
- 不改变正常 SQL 节点现有行为

## 不改变的边界

本 PR 不修改：

- Data Service 后端 Draft / Revision 模型
- Task Catalog
- Workflow
- Runtime 发布模型
- 数据库表结构
- SQL Task 生命周期
- Data Service v1 GET-only 范围

## 验证

- 基于最新 `main`
- 最终 diff 为 1 commit / 6 frontend files
- 对 Workbench 的 task-only API 调用增加显式类型守卫，DATA_SERVICE 不会调用 Task Draft/Run/Publish API
- 检查 Data Service Tab dirty/关闭保护及目录刷新后的状态保持逻辑
- 检查固定 SQL Revision 的解析路径仍使用现有 `/nodes/{sqlNodeId}/revisions/{revisionNo}` API
- 仓库当前环境未提供可直接执行的完整前端依赖安装，因此未声称本地全量 TypeScript build 已通过

这一轮的目标是让 Data Service **像一个真正的开发节点**，而不是把已经稳定的领域模型重新做重。