### PR TITLE
refactor: make data service sql standalone

### DIFF
--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/controller/v1/DevelopmentDataServiceNodeController.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/controller/v1/DevelopmentDataServiceNodeController.java
@@ -26,12 +26,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-/**
- * Data Service Node authoring API.
- *
- * <p>Publishing here only creates an immutable Data Development revision; it does not deploy a
- * runtime API.
- */
+/** Data Service Node authoring API. Publish creates an immutable Data Development revision only. */
 @Tag(name = "数据开发 Data Service Node 接口")
 @RestController
 @RequestMapping("/api/v1/data-development/nodes")
@@ -43,24 +38,25 @@ public class DevelopmentDataServiceNodeController {
     this.service = service;
   }
 
-  @Operation(summary = "查询 Data Service Node 草稿、SQL 来源与发布历史")
+  @Operation(summary = "查询 Data Service Node 草稿与发布历史")
   @GetMapping("/{nodeId}/data-service")
   public Result<DataServiceNodeContext> get(@PathVariable("nodeId") long nodeId) {
     return Result.success(service.get(nodeId));
   }
 
-  @Operation(summary = "基于指定 SQL Revision 预览请求参数和响应字段 Contract")
+  @Operation(summary = "基于当前数据源和查询 SQL 预览请求参数与响应字段 Contract")
   @PostMapping("/{nodeId}/data-service/preview")
   public Result<PreviewResult> preview(
       @PathVariable("nodeId") long nodeId,
       @Valid @RequestBody PreviewRequest request) {
     return Result.success(service.preview(
         nodeId,
-        request.sourceTaskAssetId(),
-        request.sourceTaskRevisionId()));
+        request.dataSourceId(),
+        request.sql(),
+        request.timeoutSeconds()));
   }
 
-  @Operation(summary = "保存 Data Service Node 草稿并固定精确 SQL Revision")
+  @Operation(summary = "保存独立 Data Service Node 草稿")
   @PutMapping("/{nodeId}/data-service/draft")
   public Result<DataServiceNodeContext> saveDraft(
       @PathVariable("nodeId") long nodeId,
@@ -68,8 +64,8 @@ public class DevelopmentDataServiceNodeController {
     return Result.success(service.saveDraft(
         nodeId,
         new SaveDraftCommand(
-            request.sourceTaskAssetId(),
-            request.sourceTaskRevisionId(),
+            request.dataSourceId(),
+            request.sql(),
             request.serviceName(),
             request.path(),
             request.method(),
@@ -114,29 +110,22 @@ public class DevelopmentDataServiceNodeController {
 
   private static ParameterContract toParameterContract(ParameterRequest request) {
     return new ParameterContract(
-        request.name(),
-        request.type(),
-        request.required(),
-        request.description(),
-        request.example());
+        request.name(), request.type(), request.required(), request.description(), request.example());
   }
 
   private static ResponseFieldContract toResponseFieldContract(ResponseFieldRequest request) {
     return new ResponseFieldContract(
-        request.name(),
-        request.type(),
-        request.nullable(),
-        request.description(),
-        request.example());
+        request.name(), request.type(), request.nullable(), request.description(), request.example());
   }
 
   public record PreviewRequest(
-      @NotNull @Min(1) Long sourceTaskAssetId,
-      @NotNull @Min(1) Long sourceTaskRevisionId) {}
+      @NotNull @Min(1) Long dataSourceId,
+      @NotBlank @Size(max = 1_000_000) String sql,
+      @Min(1) @Max(3_600) Integer timeoutSeconds) {}
 
   public record SaveDraftRequest(
-      @NotNull @Min(1) Long sourceTaskAssetId,
-      @NotNull @Min(1) Long sourceTaskRevisionId,
+      @NotNull @Min(1) Long dataSourceId,
+      @NotBlank @Size(max = 1_000_000) String sql,
       @NotBlank @Size(max = 200) String serviceName,
       @NotBlank @Size(max = 255) String path,
       @Size(max = 16) String method,
@@ -161,6 +150,5 @@ public class DevelopmentDataServiceNodeController {
       @Size(max = 1_000) String description,
       @Size(max = 1_000) String example) {}
 
-  public record PublishRequest(
-      @Min(1) long expectedDraftRevision) {}
+  public record PublishRequest(@Min(1) long expectedDraftRevision) {}
 }

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/domain/DevelopmentDataServiceDefinition.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/domain/DevelopmentDataServiceDefinition.java
@@ -16,7 +16,9 @@ public record DevelopmentDataServiceDefinition(
     List<ResponseFieldContract> responseFields,
     int maxRows,
     int timeoutSeconds,
-    String description) {
+    String description,
+    @JsonSerialize(using = ToStringSerializer.class) long dataSourceId,
+    String sql) {
 
   public DevelopmentDataServiceDefinition {
     parameters = parameters == null ? List.of() : List.copyOf(parameters);
@@ -24,15 +26,54 @@ public record DevelopmentDataServiceDefinition(
   }
 
   /**
-   * Lightweight v1 publish invariant.
+   * Backward-compatible constructor for historical revisions that pinned a SQL TaskRevision.
    *
-   * <p>A published Data Service Revision must be directly deployable by the current Runtime. Drafts
-   * may still be edited freely; this validation is applied only when an immutable revision is
-   * persisted.
+   * <p>New Data Service revisions are standalone and store their own dataSourceId + SQL. The legacy
+   * fields remain readable so already-published APIs do not break during the lightweight v1
+   * transition.
    */
+  public DevelopmentDataServiceDefinition(
+      long sourceTaskAssetId,
+      long sourceTaskRevisionId,
+      int sourceTaskRevisionNo,
+      String serviceName,
+      String path,
+      String method,
+      List<ParameterContract> parameters,
+      List<ResponseFieldContract> responseFields,
+      int maxRows,
+      int timeoutSeconds,
+      String description) {
+    this(
+        sourceTaskAssetId,
+        sourceTaskRevisionId,
+        sourceTaskRevisionNo,
+        serviceName,
+        path,
+        method,
+        parameters,
+        responseFields,
+        maxRows,
+        timeoutSeconds,
+        description,
+        0L,
+        null);
+  }
+
+  public boolean standaloneSql() {
+    return dataSourceId > 0L && sql != null && !sql.isBlank();
+  }
+
+  /** A published v1 Data Service Revision must be directly deployable by Runtime. */
   public void validatePublishable() {
     if (!"GET".equalsIgnoreCase(method)) {
       throw new IllegalArgumentException("当前 Data Service Runtime 仅支持 GET");
+    }
+    if (dataSourceId <= 0L) {
+      throw new IllegalArgumentException("发布前请选择数据源");
+    }
+    if (sql == null || sql.isBlank()) {
+      throw new IllegalArgumentException("发布前请填写查询 SQL");
     }
     if (responseFields.isEmpty()) {
       throw new IllegalArgumentException("发布前请先预览并确认响应字段 Contract");

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentDataServiceNodeService.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentDataServiceNodeService.java
@@ -23,14 +23,12 @@ import io.yak.ops.spi.datasource.execution.DataSourceSqlExecutor;
 import io.yak.ops.spi.datasource.execution.DataSourceSqlRequest;
 import io.yak.ops.spi.datasource.execution.DataSourceSqlResult;
 import io.yak.ops.spi.task.model.TaskAssetSource;
-import io.yak.ops.spi.task.model.TaskAssetStatus;
 import io.yak.ops.spi.task.model.TaskDefinition;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.sql.Types;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.HashSet;
 import java.util.HexFormat;
 import java.util.LinkedHashMap;
@@ -44,18 +42,14 @@ import java.util.regex.Pattern;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-/**
- * Owns the Data Service Node authoring lifecycle inside Data Development.
- *
- * <p>It deliberately stops at immutable DataServiceNodeRevision publication. Runtime deployment is
- * owned by the Data Service module and is connected in a later phase.
- */
+/** Owns the standalone Data Service Node authoring lifecycle inside Data Development. */
 @Service
 public class DevelopmentDataServiceNodeService {
 
   private static final int DEFAULT_MAX_ROWS = 1_000;
   private static final int DEFAULT_TIMEOUT_SECONDS = 30;
   private static final int MAX_PREVIEW_TIMEOUT_SECONDS = 30;
+  private static final int MAX_SQL_LENGTH = 1_000_000;
   private static final Pattern PARAMETER_NAME = Pattern.compile("[A-Za-z_][A-Za-z0-9_]*");
   private static final Set<String> SCHEMA_TYPES = Set.of(
       "STRING", "INTEGER", "NUMBER", "BOOLEAN", "DATE", "DATETIME", "OBJECT");
@@ -88,26 +82,22 @@ public class DevelopmentDataServiceNodeService {
   public DataServiceNodeContext get(long nodeId) {
     DevelopmentNode node = requireDataServiceNode(nodeId);
     DevelopmentDataServiceDraft draft = draftRepository.findByNodeId(nodeId)
+        .map(value -> hydrateLegacyDraft(node, value))
         .orElseGet(() -> emptyDraft(node));
-    List<DevelopmentDataServiceRevisionSummary> revisions = revisionRepository.listByNodeId(nodeId);
-    return new DataServiceNodeContext(
-        String.valueOf(node.id()),
-        node.name(),
-        node.configured() || draft.draftRevision() > 0L,
-        availableSources(node),
-        selectedSource(draft.definition()),
-        draft,
-        revisions.isEmpty() ? null : revisions.getFirst(),
-        revisions);
+    return context(node, draft);
   }
 
-  public PreviewResult preview(long nodeId, long sourceTaskAssetId, long sourceTaskRevisionId) {
-    DevelopmentNode node = requireDataServiceNode(nodeId);
-    ResolvedSqlSource source = requireSqlSource(
-        node, sourceTaskAssetId, sourceTaskRevisionId);
-    ContractPreview contract = discoverContract(source.revision().revision().definition());
+  public PreviewResult preview(long nodeId, long dataSourceId, String sql, Integer timeoutSeconds) {
+    requireDataServiceNode(nodeId);
+    long normalizedDataSourceId = requireDataSourceId(dataSourceId);
+    String normalizedSql = normalizeSql(sql);
+    sqlCompiler.validateSelectOnly(normalizedSql);
+    ContractPreview contract = discoverContract(
+        normalizedDataSourceId,
+        normalizedSql,
+        range(timeoutSeconds, DEFAULT_TIMEOUT_SECONDS, 1, 3_600, "超时时间"));
     return new PreviewResult(
-        toSourceSnapshot(source.asset(), source.sourceNode(), source.revision()),
+        String.valueOf(normalizedDataSourceId),
         contract.parameters(),
         contract.responseFields());
   }
@@ -117,14 +107,10 @@ public class DevelopmentDataServiceNodeService {
     DevelopmentNode node = requireDataServiceNode(nodeId);
     if (command == null) throw new IllegalArgumentException("Data Service Node 草稿不能为空");
 
-    ResolvedSqlSource source = requireSqlSource(
-        node, command.sourceTaskAssetId(), command.sourceTaskRevisionId());
-    TaskDefinition sqlDefinition = source.revision().revision().definition();
-    List<String> sqlParameters = sqlCompiler.parameterNames(sqlDefinition.content());
-
     DevelopmentDataServiceDefinition definition = normalizeDefinition(
         node,
-        source,
+        command.dataSourceId(),
+        command.sql(),
         command.serviceName(),
         command.path(),
         command.method(),
@@ -133,7 +119,6 @@ public class DevelopmentDataServiceNodeService {
         command.maxRows(),
         command.timeoutSeconds(),
         command.description(),
-        sqlParameters,
         false);
 
     long expectedBaseRevision = command.baseRevision() == null ? 0L : command.baseRevision();
@@ -159,14 +144,11 @@ public class DevelopmentDataServiceNodeService {
               + expectedDraftRevision + "，当前 " + draft.draftRevision());
     }
 
-    DevelopmentDataServiceDefinition current = draft.definition();
-    ResolvedSqlSource source = requireSqlSource(
-        node, current.sourceTaskAssetId(), current.sourceTaskRevisionId());
-    List<String> sqlParameters = sqlCompiler.parameterNames(
-        source.revision().revision().definition().content());
+    DevelopmentDataServiceDefinition current = hydrateLegacyDefinition(node, draft.definition());
     DevelopmentDataServiceDefinition normalized = normalizeDefinition(
         node,
-        source,
+        current.dataSourceId(),
+        current.sql(),
         current.serviceName(),
         current.path(),
         current.method(),
@@ -175,12 +157,10 @@ public class DevelopmentDataServiceNodeService {
         current.maxRows(),
         current.timeoutSeconds(),
         current.description(),
-        sqlParameters,
         true);
 
     String checksum = checksum(normalized);
-    DevelopmentDataServiceRevision latest =
-        revisionRepository.findLatestByNodeId(nodeId).orElse(null);
+    DevelopmentDataServiceRevision latest = revisionRepository.findLatestByNodeId(nodeId).orElse(null);
     if (latest != null
         && latest.sourceDraftRevision() == draft.draftRevision()
         && Objects.equals(latest.checksum(), checksum)) {
@@ -203,157 +183,39 @@ public class DevelopmentDataServiceNodeService {
   }
 
   public DevelopmentDataServiceRevision getRevision(long nodeId, int revisionNo) {
-    requireDataServiceNode(nodeId);
+    DevelopmentNode node = requireDataServiceNode(nodeId);
     if (revisionNo <= 0) throw new IllegalArgumentException("revisionNo 必须大于 0");
-    return revisionRepository.findByRevisionNo(nodeId, revisionNo)
+    DevelopmentDataServiceRevision revision = revisionRepository.findByRevisionNo(nodeId, revisionNo)
         .orElseThrow(() -> new IllegalArgumentException(
             "Data Service Node 发布版本不存在：nodeId=" + nodeId + ", revisionNo=" + revisionNo));
+    DevelopmentDataServiceDefinition hydrated = hydrateLegacyDefinition(node, revision.definition());
+    if (hydrated == revision.definition()) return revision;
+    return new DevelopmentDataServiceRevision(
+        revision.id(),
+        revision.nodeId(),
+        revision.revisionNo(),
+        revision.sourceDraftRevision(),
+        hydrated,
+        revision.checksum(),
+        revision.createTime());
   }
 
-  private DataServiceNodeContext context(
-      DevelopmentNode node,
-      DevelopmentDataServiceDraft draft) {
-    List<DevelopmentDataServiceRevisionSummary> revisions =
-        revisionRepository.listByNodeId(node.id());
+  private DataServiceNodeContext context(DevelopmentNode node, DevelopmentDataServiceDraft draft) {
+    List<DevelopmentDataServiceRevisionSummary> revisions = revisionRepository.listByNodeId(node.id());
     DevelopmentNode refreshed = nodeRepository.findById(node.id()).orElse(node);
     return new DataServiceNodeContext(
         String.valueOf(refreshed.id()),
         refreshed.name(),
         refreshed.configured() || draft.draftRevision() > 0L,
-        availableSources(refreshed),
-        selectedSource(draft.definition()),
         draft,
         revisions.isEmpty() ? null : revisions.getFirst(),
         revisions);
   }
 
-  private List<SourceSnapshot> availableSources(DevelopmentNode dataServiceNode) {
-    return taskCatalogService.list("DATA_DEVELOPMENT", "ONLINE", null).stream()
-        .filter(asset -> "SQL".equalsIgnoreCase(asset.taskType()))
-        .filter(asset -> sameProject(asset.projectId(), dataServiceNode.projectId()))
-        .map(asset -> toCurrentSourceIfValid(dataServiceNode, asset))
-        .filter(Objects::nonNull)
-        .sorted(Comparator
-            .comparing(SourceSnapshot::nodeName, String.CASE_INSENSITIVE_ORDER)
-            .thenComparing(SourceSnapshot::nodeId))
-        .toList();
-  }
-
-  private SourceSnapshot toCurrentSourceIfValid(DevelopmentNode dataServiceNode, TaskAsset asset) {
-    try {
-      DevelopmentNode sourceNode = requireSourceSqlNode(asset);
-      if (!sameProject(sourceNode.projectId(), dataServiceNode.projectId())) return null;
-      TaskAssetRevision revision = taskCatalogService.resolveRevision(
-          asset.id(), asset.currentRevision().taskRevisionId());
-      return toSourceSnapshot(asset, sourceNode, revision);
-    } catch (RuntimeException exception) {
-      return null;
-    }
-  }
-
-  private SourceSnapshot selectedSource(DevelopmentDataServiceDefinition definition) {
-    if (definition == null
-        || definition.sourceTaskAssetId() <= 0L
-        || definition.sourceTaskRevisionId() <= 0L) {
-      return null;
-    }
-    try {
-      TaskAsset asset = taskCatalogService.get(definition.sourceTaskAssetId());
-      DevelopmentNode sourceNode = nodeRepository.findById(parseSourceNodeId(asset)).orElse(null);
-      TaskAssetRevision pinned = taskCatalogService.resolveRevision(
-          asset.id(), definition.sourceTaskRevisionId());
-      String nodeId = sourceNode == null ? asset.sourceRef() : String.valueOf(sourceNode.id());
-      String nodeName = sourceNode == null ? asset.name() : sourceNode.name();
-      return new SourceSnapshot(
-          nodeId,
-          nodeName,
-          String.valueOf(asset.id()),
-          asset.status().name(),
-          String.valueOf(pinned.revision().revisionId()),
-          pinned.revision().revisionNo(),
-          String.valueOf(asset.currentRevision().taskRevisionId()),
-          asset.currentRevision().revisionNo(),
-          pinned.revision().revisionId() != asset.currentRevision().taskRevisionId());
-    } catch (RuntimeException exception) {
-      return new SourceSnapshot(
-          null,
-          "历史 SQL 来源",
-          String.valueOf(definition.sourceTaskAssetId()),
-          "UNAVAILABLE",
-          String.valueOf(definition.sourceTaskRevisionId()),
-          definition.sourceTaskRevisionNo(),
-          null,
-          null,
-          false);
-    }
-  }
-
-  private ResolvedSqlSource requireSqlSource(
-      DevelopmentNode dataServiceNode,
-      long sourceTaskAssetId,
-      long sourceTaskRevisionId) {
-    if (sourceTaskAssetId <= 0L) {
-      throw new IllegalArgumentException("sourceTaskAssetId 必须大于 0");
-    }
-    if (sourceTaskRevisionId <= 0L) {
-      throw new IllegalArgumentException("sourceTaskRevisionId 必须大于 0");
-    }
-
-    TaskAsset asset = taskCatalogService.get(sourceTaskAssetId);
-    if (asset.source() != TaskAssetSource.DATA_DEVELOPMENT) {
-      throw new IllegalArgumentException("Data Service Node 只能选择数据开发 SQL 来源");
-    }
-    if (!"SQL".equalsIgnoreCase(asset.taskType())) {
-      throw new IllegalArgumentException("Data Service Node 当前仅支持 SQL 来源");
-    }
-    if (asset.status() != TaskAssetStatus.ONLINE) {
-      throw new IllegalArgumentException("Data Service Node 只能选择 ONLINE SQL 来源");
-    }
-    if (!sameProject(asset.projectId(), dataServiceNode.projectId())) {
-      throw new IllegalArgumentException("Data Service Node 只能选择同项目的 SQL 来源");
-    }
-
-    DevelopmentNode sourceNode = requireSourceSqlNode(asset);
-    if (!sameProject(sourceNode.projectId(), dataServiceNode.projectId())) {
-      throw new IllegalArgumentException("Data Service Node 只能选择同项目的 SQL 节点");
-    }
-
-    TaskAssetRevision revision = taskCatalogService.resolveRevision(
-        sourceTaskAssetId, sourceTaskRevisionId);
-    if (revision.revision().revisionId() != sourceTaskRevisionId) {
-      throw new IllegalStateException("Data Service Node 解析到的 SQL Revision 与请求不一致");
-    }
-    if (!"SQL".equalsIgnoreCase(revision.revision().definition().taskType())) {
-      throw new IllegalArgumentException("Data Service Node 来源 Revision 不是 SQL");
-    }
-    sqlCompiler.validateSelectOnly(revision.revision().definition().content());
-    return new ResolvedSqlSource(asset, sourceNode, revision);
-  }
-
-  private DevelopmentNode requireSourceSqlNode(TaskAsset asset) {
-    long sourceNodeId = parseSourceNodeId(asset);
-    DevelopmentNode sourceNode = nodeRepository.findById(sourceNodeId)
-        .orElseThrow(() -> new IllegalStateException("SQL 来源节点不存在：" + sourceNodeId));
-    if (!DevelopmentNodeType.SQL.name().equalsIgnoreCase(sourceNode.type())) {
-      throw new IllegalStateException("TaskAsset 来源节点不是 SQL：" + sourceNodeId);
-    }
-    return sourceNode;
-  }
-
-  private long parseSourceNodeId(TaskAsset asset) {
-    try {
-      long nodeId = Long.parseLong(asset.sourceRef());
-      if (nodeId <= 0L) throw new NumberFormatException("not positive");
-      return nodeId;
-    } catch (NumberFormatException exception) {
-      throw new IllegalStateException(
-          "SQL TaskAsset sourceRef 不是有效节点 ID：" + asset.sourceRef(), exception);
-    }
-  }
-
   private DevelopmentDataServiceDefinition normalizeDefinition(
       DevelopmentNode node,
-      ResolvedSqlSource source,
+      long dataSourceId,
+      String sql,
       String serviceName,
       String path,
       String method,
@@ -362,42 +224,40 @@ public class DevelopmentDataServiceNodeService {
       Integer maxRows,
       Integer timeoutSeconds,
       String description,
-      List<String> sqlParameterNames,
       boolean requireResponseContract) {
+    long normalizedDataSourceId = requireDataSourceId(dataSourceId);
+    String normalizedSql = normalizeSql(sql);
+    sqlCompiler.validateSelectOnly(normalizedSql);
+    List<String> sqlParameterNames = sqlCompiler.parameterNames(normalizedSql);
+
     String normalizedName = text(serviceName, node.name(), "服务名称", 200);
     String normalizedPath = normalizePath(path, node.id());
     String normalizedMethod = method == null || method.isBlank()
         ? "GET" : method.trim().toUpperCase(Locale.ROOT);
     if (!"GET".equals(normalizedMethod)) {
-      throw new IllegalArgumentException("Data Service Node 第一阶段仅支持 GET");
+      throw new IllegalArgumentException("Data Service Node v1 仅支持 GET");
     }
 
-    List<ParameterContract> parameters =
-        normalizeParameters(requestedParameters, sqlParameterNames);
-    List<ResponseFieldContract> responseFields =
-        normalizeResponseFields(requestedResponseFields);
+    List<ParameterContract> parameters = normalizeParameters(requestedParameters, sqlParameterNames);
+    List<ResponseFieldContract> responseFields = normalizeResponseFields(requestedResponseFields);
     if (requireResponseContract && responseFields.isEmpty()) {
       throw new IllegalArgumentException("发布前请先预览并确认响应字段 Contract");
     }
 
-    int normalizedMaxRows = range(
-        maxRows, DEFAULT_MAX_ROWS, 1, 10_000, "最大返回行数");
-    int normalizedTimeout = range(
-        timeoutSeconds, DEFAULT_TIMEOUT_SECONDS, 1, 3_600, "超时时间");
-    String normalizedDescription = optionalText(description, 2_000, "说明");
-
     return new DevelopmentDataServiceDefinition(
-        source.asset().id(),
-        source.revision().revision().revisionId(),
-        source.revision().revision().revisionNo(),
+        0L,
+        0L,
+        0,
         normalizedName,
         normalizedPath,
         normalizedMethod,
         parameters,
         responseFields,
-        normalizedMaxRows,
-        normalizedTimeout,
-        normalizedDescription);
+        range(maxRows, DEFAULT_MAX_ROWS, 1, 10_000, "最大返回行数"),
+        range(timeoutSeconds, DEFAULT_TIMEOUT_SECONDS, 1, 3_600, "超时时间"),
+        optionalText(description, 2_000, "说明"),
+        normalizedDataSourceId,
+        normalizedSql);
   }
 
   private List<ParameterContract> normalizeParameters(
@@ -425,7 +285,7 @@ public class DevelopmentDataServiceNodeService {
       normalized.add(new ParameterContract(
           name,
           normalizeSchemaType(value == null ? "STRING" : value.type()),
-          value == null || value.required(),
+          true,
           optionalText(value == null ? null : value.description(), 1_000, "参数描述"),
           optionalText(value == null ? null : value.example(), 1_000, "参数示例")));
     }
@@ -439,8 +299,7 @@ public class DevelopmentDataServiceNodeService {
     return List.copyOf(normalized);
   }
 
-  private List<ResponseFieldContract> normalizeResponseFields(
-      List<ResponseFieldContract> values) {
+  private List<ResponseFieldContract> normalizeResponseFields(List<ResponseFieldContract> values) {
     if (values == null || values.isEmpty()) return List.of();
     List<ResponseFieldContract> normalized = new ArrayList<>();
     Set<String> names = new HashSet<>();
@@ -459,32 +318,29 @@ public class DevelopmentDataServiceNodeService {
     return List.copyOf(normalized);
   }
 
-  private ContractPreview discoverContract(TaskDefinition sqlDefinition) {
-    List<String> parameterNames = sqlCompiler.parameterNames(sqlDefinition.content());
+  private ContractPreview discoverContract(long dataSourceId, String sql, int timeoutSeconds) {
+    List<String> parameterNames = sqlCompiler.parameterNames(sql);
     List<ParameterContract> parameters = parameterNames.stream()
         .map(name -> new ParameterContract(name, "STRING", true, null, null))
         .toList();
 
     Map<String, Object> previewParameters = new LinkedHashMap<>();
     parameterNames.forEach(name -> previewParameters.put(name, null));
-    DevelopmentDataServiceSqlCompiler.CompiledSql compiled =
-        sqlCompiler.compile(sqlDefinition.content(), previewParameters);
-    SourceConfig sourceConfig = sourceConfig(sqlDefinition.configJson());
+    DevelopmentDataServiceSqlCompiler.CompiledSql compiled = sqlCompiler.compile(sql, previewParameters);
 
     DataSourceSqlResult result;
-    try (DataSourceSqlExecutor executor =
-        dataSourceExecutionProvider.open(sourceConfig.dataSourceId())) {
+    try (DataSourceSqlExecutor executor = dataSourceExecutionProvider.open(String.valueOf(dataSourceId))) {
       result = executor.execute(new DataSourceSqlRequest(
           compiled.sql(),
           1,
-          Math.min(sourceConfig.timeoutSeconds(), MAX_PREVIEW_TIMEOUT_SECONDS),
+          Math.min(timeoutSeconds, MAX_PREVIEW_TIMEOUT_SECONDS),
           compiled.parameters()));
     }
     if (!result.resultSet()) {
-      throw new IllegalStateException("Data Service Node Preview 没有返回结果集");
+      throw new IllegalStateException("Data Service Preview 没有返回结果集");
     }
     if (result.columns().isEmpty()) {
-      throw new IllegalArgumentException("Data Service Node 来源查询没有可发现的响应字段");
+      throw new IllegalArgumentException("查询 SQL 没有可发现的响应字段");
     }
 
     List<ResponseFieldContract> responseFields = result.columns().stream()
@@ -497,14 +353,10 @@ public class DevelopmentDataServiceNodeService {
     String name = column.label();
     if (name == null || name.isBlank()) name = column.name();
     if (name == null || name.isBlank()) {
-      throw new IllegalArgumentException("Data Service Node 来源查询存在无名称响应字段");
+      throw new IllegalArgumentException("查询结果存在无名称响应字段");
     }
     return new ResponseFieldContract(
-        name.trim(),
-        schemaType(column.jdbcType()),
-        column.nullable(),
-        null,
-        null);
+        name.trim(), schemaType(column.jdbcType()), column.nullable(), null, null);
   }
 
   private String schemaType(int jdbcType) {
@@ -521,6 +373,60 @@ public class DevelopmentDataServiceNodeService {
     };
   }
 
+  /**
+   * Transparently turns a historical SQL-Revision-backed definition into a standalone snapshot.
+   * New saves always persist standalone definitions; this path only keeps already-created assets usable.
+   */
+  private DevelopmentDataServiceDefinition hydrateLegacyDefinition(
+      DevelopmentNode dataServiceNode,
+      DevelopmentDataServiceDefinition definition) {
+    if (definition == null || definition.standaloneSql()) return definition;
+    if (definition.sourceTaskAssetId() <= 0L || definition.sourceTaskRevisionId() <= 0L) {
+      return definition;
+    }
+    try {
+      TaskAsset asset = taskCatalogService.get(definition.sourceTaskAssetId());
+      if (asset.source() != TaskAssetSource.DATA_DEVELOPMENT
+          || !"SQL".equalsIgnoreCase(asset.taskType())
+          || !sameProject(asset.projectId(), dataServiceNode.projectId())) {
+        return definition;
+      }
+      TaskAssetRevision resolved = taskCatalogService.resolveRevision(
+          asset.id(), definition.sourceTaskRevisionId());
+      TaskDefinition sqlDefinition = resolved.revision().definition();
+      SourceConfig sourceConfig = sourceConfig(sqlDefinition.configJson());
+      return new DevelopmentDataServiceDefinition(
+          definition.sourceTaskAssetId(),
+          definition.sourceTaskRevisionId(),
+          definition.sourceTaskRevisionNo(),
+          definition.serviceName(),
+          definition.path(),
+          definition.method(),
+          definition.parameters(),
+          definition.responseFields(),
+          definition.maxRows(),
+          definition.timeoutSeconds(),
+          definition.description(),
+          Long.parseLong(sourceConfig.dataSourceId()),
+          sqlDefinition.content());
+    } catch (RuntimeException exception) {
+      return definition;
+    }
+  }
+
+  private DevelopmentDataServiceDraft hydrateLegacyDraft(
+      DevelopmentNode node,
+      DevelopmentDataServiceDraft draft) {
+    DevelopmentDataServiceDefinition hydrated = hydrateLegacyDefinition(node, draft.definition());
+    if (hydrated == draft.definition()) return draft;
+    return new DevelopmentDataServiceDraft(
+        draft.nodeId(),
+        hydrated,
+        draft.draftRevision(),
+        draft.createTime(),
+        draft.updateTime());
+  }
+
   private SourceConfig sourceConfig(String configJson) {
     String raw = configJson == null || configJson.isBlank() ? "{}" : configJson.trim();
     try {
@@ -528,37 +434,18 @@ public class DevelopmentDataServiceNodeService {
       if (root == null || !root.isObject()) {
         throw new IllegalArgumentException("SQL configJson 必须是 JSON Object");
       }
-      JsonNode dataSourceNode = root.get("dataSourceId");
-      String dataSourceId = dataSourceNode == null || dataSourceNode.isNull()
-          ? null : dataSourceNode.asText();
+      String dataSourceId = root.path("dataSourceId").asText(null);
       if (dataSourceId == null || dataSourceId.isBlank()) {
-        throw new IllegalArgumentException(
-            "SQL TaskRevision 缺少 dataSourceId，无法预览 Data Service Contract");
+        throw new IllegalArgumentException("历史 SQL Revision 缺少 dataSourceId");
       }
-      int timeout = root.path("timeoutSeconds").asInt(DEFAULT_TIMEOUT_SECONDS);
-      if (timeout < 1 || timeout > 3_600) timeout = DEFAULT_TIMEOUT_SECONDS;
-      return new SourceConfig(dataSourceId.trim(), timeout);
+      long value = Long.parseLong(dataSourceId.trim());
+      if (value <= 0L) throw new IllegalArgumentException("历史 SQL Revision dataSourceId 必须大于 0");
+      return new SourceConfig(String.valueOf(value));
     } catch (IllegalArgumentException exception) {
       throw exception;
     } catch (Exception exception) {
-      throw new IllegalArgumentException("SQL TaskRevision configJson 非法", exception);
+      throw new IllegalArgumentException("历史 SQL Revision configJson 非法", exception);
     }
-  }
-
-  private SourceSnapshot toSourceSnapshot(
-      TaskAsset asset,
-      DevelopmentNode sourceNode,
-      TaskAssetRevision pinnedRevision) {
-    return new SourceSnapshot(
-        String.valueOf(sourceNode.id()),
-        sourceNode.name(),
-        String.valueOf(asset.id()),
-        asset.status().name(),
-        String.valueOf(pinnedRevision.revision().revisionId()),
-        pinnedRevision.revision().revisionNo(),
-        String.valueOf(asset.currentRevision().taskRevisionId()),
-        asset.currentRevision().revisionNo(),
-        pinnedRevision.revision().revisionId() != asset.currentRevision().taskRevisionId());
   }
 
   private DevelopmentNode requireDataServiceNode(long nodeId) {
@@ -586,10 +473,26 @@ public class DevelopmentDataServiceNodeService {
             List.of(),
             DEFAULT_MAX_ROWS,
             DEFAULT_TIMEOUT_SECONDS,
-            null),
+            null,
+            0L,
+            ""),
         0L,
         null,
         null);
+  }
+
+  private long requireDataSourceId(long value) {
+    if (value <= 0L) throw new IllegalArgumentException("请选择数据源");
+    return value;
+  }
+
+  private String normalizeSql(String value) {
+    if (value == null || value.isBlank()) throw new IllegalArgumentException("查询 SQL 不能为空");
+    String normalized = value.trim();
+    if (normalized.length() > MAX_SQL_LENGTH) {
+      throw new IllegalArgumentException("查询 SQL 不能超过 " + MAX_SQL_LENGTH + " 个字符");
+    }
+    return normalized;
   }
 
   private String normalizePath(String value, long nodeId) {
@@ -669,8 +572,8 @@ public class DevelopmentDataServiceNodeService {
   }
 
   public record SaveDraftCommand(
-      long sourceTaskAssetId,
-      long sourceTaskRevisionId,
+      long dataSourceId,
+      String sql,
       String serviceName,
       String path,
       String method,
@@ -681,19 +584,8 @@ public class DevelopmentDataServiceNodeService {
       String description,
       Long baseRevision) {}
 
-  public record SourceSnapshot(
-      String nodeId,
-      String nodeName,
-      String taskAssetId,
-      String status,
-      String revisionId,
-      Integer revisionNo,
-      String currentRevisionId,
-      Integer currentRevisionNo,
-      boolean updateAvailable) {}
-
   public record PreviewResult(
-      SourceSnapshot source,
+      String dataSourceId,
       List<ParameterContract> parameters,
       List<ResponseFieldContract> responseFields) {}
 
@@ -701,20 +593,13 @@ public class DevelopmentDataServiceNodeService {
       String nodeId,
       String nodeName,
       boolean configured,
-      List<SourceSnapshot> availableSources,
-      SourceSnapshot selectedSource,
       DevelopmentDataServiceDraft draft,
       DevelopmentDataServiceRevisionSummary latestPublishedRevision,
       List<DevelopmentDataServiceRevisionSummary> revisions) {}
-
-  private record ResolvedSqlSource(
-      TaskAsset asset,
-      DevelopmentNode sourceNode,
-      TaskAssetRevision revision) {}
 
   private record ContractPreview(
       List<ParameterContract> parameters,
       List<ResponseFieldContract> responseFields) {}
 
-  private record SourceConfig(String dataSourceId, int timeoutSeconds) {}
+  private record SourceConfig(String dataSourceId) {}
 }

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentDataServiceNodeSourceProvider.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentDataServiceNodeSourceProvider.java
@@ -8,6 +8,7 @@ import io.yak.ops.business.dataservice.service.source.DataServiceSourceProvider.
 import io.yak.ops.business.dataservice.service.source.DataServiceSourceProvider.ResponseFieldContract;
 import io.yak.ops.business.dataservice.service.source.DataServiceSourceProvider.SourceContract;
 import io.yak.ops.business.dataservice.service.source.DataServiceSourceProvider.SourceDescriptor;
+import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
 import io.yak.ops.business.development.domain.DevelopmentDataServiceDefinition;
 import io.yak.ops.business.development.domain.DevelopmentDataServiceRevision;
 import io.yak.ops.business.development.domain.DevelopmentNode;
@@ -17,7 +18,6 @@ import io.yak.ops.business.development.repository.DevelopmentNodeRepository;
 import io.yak.ops.business.taskcatalog.domain.TaskAsset;
 import io.yak.ops.business.taskcatalog.domain.TaskAssetRevision;
 import io.yak.ops.business.taskcatalog.service.TaskCatalogService;
-import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
 import io.yak.ops.spi.task.model.TaskAssetSource;
 import io.yak.ops.spi.task.model.TaskDefinition;
 import java.util.ArrayList;
@@ -28,13 +28,7 @@ import java.util.Objects;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
-/**
- * Exposes published Data Service Node revisions as the only new Data Development source for Runtime.
- *
- * <p>The stable source identity is the Data Service development node id. Each resolve points to the
- * latest published Data Service revision, which in turn pins one exact SQL TaskRevision. Runtime
- * never follows the SQL asset's latest pointer directly.
- */
+/** Exposes published Data Service Node revisions to Runtime. */
 @Component
 @ConditionalOnDataSourceEnabled
 public class DevelopmentDataServiceNodeSourceProvider implements DataServiceSourceProvider {
@@ -118,7 +112,10 @@ public class DevelopmentDataServiceNodeSourceProvider implements DataServiceSour
     }
     validateContract(definition);
 
-    ResolvedSqlRevision sql = resolvePinnedSql(node, definition);
+    ResolvedSql resolvedSql = definition.standaloneSql()
+        ? new ResolvedSql(definition.sql(), definition.dataSourceId())
+        : resolveLegacyPinnedSql(node, definition);
+
     SourceDescriptor descriptor = new SourceDescriptor(
         SOURCE_TYPE,
         Long.toString(nodeId),
@@ -127,7 +124,7 @@ public class DevelopmentDataServiceNodeSourceProvider implements DataServiceSour
         "ONLINE",
         dataServiceRevision.id(),
         dataServiceRevision.revisionNo(),
-        sql.dataSourceId(),
+        resolvedSql.dataSourceId(),
         definition.maxRows(),
         definition.timeoutSeconds(),
         definition.path(),
@@ -143,35 +140,35 @@ public class DevelopmentDataServiceNodeSourceProvider implements DataServiceSour
             .map(item -> new ResponseFieldContract(
                 item.name(), item.type(), item.nullable(), item.description(), item.example()))
             .toList());
-    return new ResolvedSource(descriptor, sql.definition().content(), contract);
+    return new ResolvedSource(descriptor, resolvedSql.sql(), contract);
   }
 
-  private ResolvedSqlRevision resolvePinnedSql(
+  /** Compatibility only for DS Revisions created before standalone SQL became the v1 model. */
+  private ResolvedSql resolveLegacyPinnedSql(
       DevelopmentNode dataServiceNode,
       DevelopmentDataServiceDefinition definition) {
     TaskAsset asset = taskCatalogService.get(definition.sourceTaskAssetId());
     if (asset.source() != TaskAssetSource.DATA_DEVELOPMENT) {
-      throw new IllegalStateException("Data Service Revision 的 SQL 来源不是数据开发资产");
+      throw new IllegalStateException("历史 Data Service Revision 的 SQL 来源不是数据开发资产");
     }
     if (!"SQL".equalsIgnoreCase(asset.taskType())) {
-      throw new IllegalStateException("Data Service Revision 的来源资产不是 SQL：" + asset.taskType());
+      throw new IllegalStateException("历史 Data Service Revision 的来源资产不是 SQL：" + asset.taskType());
     }
     if (!sameProject(asset.projectId(), dataServiceNode.projectId())) {
-      throw new IllegalStateException("Data Service Revision 与 SQL 来源不属于同一项目");
+      throw new IllegalStateException("历史 Data Service Revision 与 SQL 来源不属于同一项目");
     }
 
     TaskAssetRevision resolved = taskCatalogService.resolveRevision(
         asset.id(), definition.sourceTaskRevisionId());
     if (resolved.revision().revisionId() != definition.sourceTaskRevisionId()
         || resolved.revision().revisionNo() != definition.sourceTaskRevisionNo()) {
-      throw new IllegalStateException(
-          "Data Service Revision 固定的 SQL Revision 与实际解析结果不一致");
+      throw new IllegalStateException("历史 Data Service Revision 固定的 SQL Revision 与实际解析结果不一致");
     }
     TaskDefinition sqlDefinition = resolved.revision().definition();
     if (!"SQL".equalsIgnoreCase(sqlDefinition.taskType())) {
-      throw new IllegalStateException("Data Service Revision 固定的 TaskRevision 不是 SQL");
+      throw new IllegalStateException("历史 Data Service Revision 固定的 TaskRevision 不是 SQL");
     }
-    return new ResolvedSqlRevision(sqlDefinition, dataSourceId(sqlDefinition.configJson()));
+    return new ResolvedSql(sqlDefinition.content(), dataSourceId(sqlDefinition.configJson()));
   }
 
   private void validateContract(DevelopmentDataServiceDefinition definition) {
@@ -196,15 +193,15 @@ public class DevelopmentDataServiceNodeSourceProvider implements DataServiceSour
       }
       String reference = root.path("dataSourceId").asText(null);
       if (!StringUtils.hasText(reference)) {
-        throw new IllegalArgumentException("固定 SQL Revision 缺少 dataSourceId");
+        throw new IllegalArgumentException("历史固定 SQL Revision 缺少 dataSourceId");
       }
       long value = Long.parseLong(reference.trim());
-      if (value <= 0L) throw new IllegalArgumentException("固定 SQL Revision dataSourceId 必须大于 0");
+      if (value <= 0L) throw new IllegalArgumentException("历史固定 SQL Revision dataSourceId 必须大于 0");
       return value;
     } catch (IllegalArgumentException exception) {
       throw exception;
     } catch (Exception exception) {
-      throw new IllegalArgumentException("固定 SQL Revision configJson 非法", exception);
+      throw new IllegalArgumentException("历史固定 SQL Revision configJson 非法", exception);
     }
   }
 
@@ -231,5 +228,5 @@ public class DevelopmentDataServiceNodeSourceProvider implements DataServiceSour
     return Objects.equals(normalizedLeft, normalizedRight);
   }
 
-  private record ResolvedSqlRevision(TaskDefinition definition, Long dataSourceId) {}
+  private record ResolvedSql(String sql, Long dataSourceId) {}
 }

--- a/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/domain/DevelopmentDataServiceDefinitionTest.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/domain/DevelopmentDataServiceDefinitionTest.java
@@ -42,12 +42,36 @@ class DevelopmentDataServiceDefinitionTest {
     assertTrue(error.getMessage().contains("OBJECT"));
   }
 
+  @Test
+  void publishRejectsMissingStandaloneSql() {
+    DevelopmentDataServiceDefinition definition = new DevelopmentDataServiceDefinition(
+        0L,
+        0L,
+        0,
+        "订单查询 API",
+        "/orders",
+        "GET",
+        List.of(),
+        List.of(new DevelopmentDataServiceDefinition.ResponseFieldContract(
+            "id", "INTEGER", false, null, null)),
+        1000,
+        30,
+        null,
+        42L,
+        "");
+
+    IllegalArgumentException error =
+        assertThrows(IllegalArgumentException.class, definition::validatePublishable);
+
+    assertTrue(error.getMessage().contains("查询 SQL"));
+  }
+
   private DevelopmentDataServiceDefinition definition(
       DevelopmentDataServiceDefinition.ParameterContract parameter) {
     return new DevelopmentDataServiceDefinition(
-        300L,
-        401L,
-        3,
+        0L,
+        0L,
+        0,
         "订单查询 API",
         "/orders",
         "GET",
@@ -56,6 +80,8 @@ class DevelopmentDataServiceDefinitionTest {
             "id", "INTEGER", false, null, null)),
         1000,
         30,
-        null);
+        null,
+        42L,
+        "select id from orders where status = :status");
   }
 }

--- a/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/DevelopmentDataServiceNodeServiceTest.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/DevelopmentDataServiceNodeServiceTest.java
@@ -60,19 +60,16 @@ class DevelopmentDataServiceNodeServiceTest {
         new ObjectMapper());
 
     when(nodeRepository.findById(100L)).thenReturn(Optional.of(dataServiceNode(100L, 7L)));
-    when(nodeRepository.findById(200L)).thenReturn(Optional.of(sqlNode(200L, 7L)));
   }
 
   @Test
-  void saveDraftPinsExactSqlRevisionInsteadOfFollowingLatestPointer() {
-    TaskAsset asset = sqlAsset(300L, 200L, 7L, 402L, 4);
-    TaskAssetRevision pinned = sqlRevision(asset, 401L, 3);
-    when(taskCatalogService.get(300L)).thenReturn(asset);
-    when(taskCatalogService.resolveRevision(300L, 401L)).thenReturn(pinned);
-    when(sqlCompiler.parameterNames(anyString())).thenReturn(List.of("status"));
+  void saveDraftOwnsSqlAndDataSourceWithoutSqlAsset() {
+    String sql = "select id, status from orders where status = :status";
+    when(sqlCompiler.parameterNames(sql)).thenReturn(List.of("status"));
 
+    DevelopmentDataServiceDefinition persisted = standaloneDefinition(42L, sql);
     DevelopmentDataServiceDraft saved = new DevelopmentDataServiceDraft(
-        100L, definition(300L, 401L, 3), 1L, Instant.EPOCH, Instant.EPOCH);
+        100L, persisted, 1L, Instant.EPOCH, Instant.EPOCH);
     when(draftRepository.save(eq(100L), org.mockito.ArgumentMatchers.any(), eq(0L)))
         .thenReturn(Optional.of(saved));
     when(revisionRepository.listByNodeId(100L)).thenReturn(List.of());
@@ -80,45 +77,35 @@ class DevelopmentDataServiceNodeServiceTest {
     DevelopmentDataServiceNodeService.DataServiceNodeContext context = service.saveDraft(
         100L,
         new DevelopmentDataServiceNodeService.SaveDraftCommand(
-            300L, 401L, "订单查询 API", "/orders", "GET",
-            List.of(), List.of(), 1000, 30, null, 0L));
+            42L,
+            sql,
+            "订单查询 API",
+            "/orders",
+            "GET",
+            List.of(new DevelopmentDataServiceDefinition.ParameterContract(
+                "status", "STRING", true, null, null)),
+            List.of(),
+            1000,
+            30,
+            null,
+            0L));
 
-    assertEquals(401L, context.draft().definition().sourceTaskRevisionId());
-    assertEquals(3, context.draft().definition().sourceTaskRevisionNo());
+    assertEquals(42L, context.draft().definition().dataSourceId());
+    assertEquals(sql, context.draft().definition().sql());
+    assertEquals(0L, context.draft().definition().sourceTaskAssetId());
+    assertEquals(0L, context.draft().definition().sourceTaskRevisionId());
+    verify(taskCatalogService, never()).get(anyLong());
     verify(nodeRepository).updateConfigured(100L, true);
   }
 
   @Test
-  void contextKeepsPinnedRevisionAndReportsNewerSqlRevision() {
-    TaskAsset asset = sqlAsset(300L, 200L, 7L, 402L, 4);
-    DevelopmentDataServiceDraft draft = new DevelopmentDataServiceDraft(
-        100L, definition(300L, 401L, 3), 2L, Instant.EPOCH, Instant.EPOCH);
-    when(draftRepository.findByNodeId(100L)).thenReturn(Optional.of(draft));
-    when(revisionRepository.listByNodeId(100L)).thenReturn(List.of());
-    when(taskCatalogService.list("DATA_DEVELOPMENT", "ONLINE", null)).thenReturn(List.of(asset));
-    when(taskCatalogService.get(300L)).thenReturn(asset);
-    when(taskCatalogService.resolveRevision(300L, 401L)).thenReturn(sqlRevision(asset, 401L, 3));
-    when(taskCatalogService.resolveRevision(300L, 402L)).thenReturn(sqlRevision(asset, 402L, 4));
-
-    DevelopmentDataServiceNodeService.DataServiceNodeContext context = service.get(100L);
-
-    assertEquals("401", context.selectedSource().revisionId());
-    assertEquals(3, context.selectedSource().revisionNo());
-    assertEquals("402", context.selectedSource().currentRevisionId());
-    assertEquals(4, context.selectedSource().currentRevisionNo());
-    assertTrue(context.selectedSource().updateAvailable());
-  }
-
-  @Test
-  void publishCreatesResourceRevisionWithoutEnteringTaskCatalog() {
-    TaskAsset asset = sqlAsset(300L, 200L, 7L, 401L, 3);
-    DevelopmentDataServiceDefinition definition = definition(300L, 401L, 3);
+  void publishCreatesStandaloneRevisionWithoutEnteringTaskCatalog() {
+    String sql = "select id, status from orders where status = :status";
+    DevelopmentDataServiceDefinition definition = standaloneDefinition(42L, sql);
     DevelopmentDataServiceDraft draft = new DevelopmentDataServiceDraft(
         100L, definition, 5L, Instant.EPOCH, Instant.EPOCH);
     when(draftRepository.findByNodeIdForUpdate(100L)).thenReturn(Optional.of(draft));
-    when(taskCatalogService.get(300L)).thenReturn(asset);
-    when(taskCatalogService.resolveRevision(300L, 401L)).thenReturn(sqlRevision(asset, 401L, 3));
-    when(sqlCompiler.parameterNames(anyString())).thenReturn(List.of("status"));
+    when(sqlCompiler.parameterNames(sql)).thenReturn(List.of("status"));
     when(revisionRepository.findLatestByNodeId(100L)).thenReturn(Optional.empty());
     when(revisionRepository.nextRevisionNo(100L)).thenReturn(1);
 
@@ -131,7 +118,9 @@ class DevelopmentDataServiceNodeServiceTest {
     DevelopmentDataServiceRevision published = service.publish(100L, 5L);
 
     assertEquals(1, published.revisionNo());
-    assertEquals(401L, published.definition().sourceTaskRevisionId());
+    assertEquals(42L, published.definition().dataSourceId());
+    assertEquals(sql, published.definition().sql());
+    verify(taskCatalogService, never()).get(anyLong());
     verify(taskCatalogService, never()).publish(
         org.mockito.ArgumentMatchers.any(),
         anyString(),
@@ -143,24 +132,57 @@ class DevelopmentDataServiceNodeServiceTest {
   }
 
   @Test
-  void saveRejectsCrossProjectSqlSource() {
-    when(taskCatalogService.get(300L)).thenReturn(sqlAsset(300L, 200L, 9L, 401L, 3));
+  void getHydratesHistoricalPinnedSqlIntoStandaloneSnapshot() {
+    DevelopmentDataServiceDefinition legacy = legacyDefinition(300L, 401L, 3);
+    DevelopmentDataServiceDraft draft = new DevelopmentDataServiceDraft(
+        100L, legacy, 2L, Instant.EPOCH, Instant.EPOCH);
+    TaskAsset asset = sqlAsset(300L, 200L, 7L, 401L, 3);
 
+    when(draftRepository.findByNodeId(100L)).thenReturn(Optional.of(draft));
+    when(revisionRepository.listByNodeId(100L)).thenReturn(List.of());
+    when(taskCatalogService.get(300L)).thenReturn(asset);
+    when(taskCatalogService.resolveRevision(300L, 401L))
+        .thenReturn(sqlRevision(asset, 401L, 3));
+
+    DevelopmentDataServiceNodeService.DataServiceNodeContext context = service.get(100L);
+
+    assertEquals(42L, context.draft().definition().dataSourceId());
+    assertEquals(
+        "select id, status from orders where status = :status",
+        context.draft().definition().sql());
+    assertEquals(401L, context.draft().definition().sourceTaskRevisionId());
+  }
+
+  @Test
+  void saveRejectsMissingDataSource() {
     IllegalArgumentException error = assertThrows(
         IllegalArgumentException.class,
         () -> service.saveDraft(
             100L,
             new DevelopmentDataServiceNodeService.SaveDraftCommand(
-                300L, 401L, "订单查询 API", "/orders", "GET",
-                List.of(), List.of(), 1000, 30, null, 0L)));
+                0L,
+                "select 1",
+                "订单查询 API",
+                "/orders",
+                "GET",
+                List.of(),
+                List.of(),
+                1000,
+                30,
+                null,
+                0L)));
 
-    assertTrue(error.getMessage().contains("同项目"));
+    assertTrue(error.getMessage().contains("数据源"));
   }
 
   @Test
   void publishRejectsStaleDraftRevision() {
     DevelopmentDataServiceDraft draft = new DevelopmentDataServiceDraft(
-        100L, definition(300L, 401L, 3), 6L, Instant.EPOCH, Instant.EPOCH);
+        100L,
+        standaloneDefinition(42L, "select id from orders"),
+        6L,
+        Instant.EPOCH,
+        Instant.EPOCH);
     when(draftRepository.findByNodeIdForUpdate(100L)).thenReturn(Optional.of(draft));
 
     assertThrows(
@@ -171,11 +193,6 @@ class DevelopmentDataServiceNodeServiceTest {
   private static DevelopmentNode dataServiceNode(long id, long projectId) {
     return new DevelopmentNode(
         id, "订单查询 API", "DATA_SERVICE", projectId, null, false, Instant.EPOCH, Instant.EPOCH);
-  }
-
-  private static DevelopmentNode sqlNode(long id, long projectId) {
-    return new DevelopmentNode(
-        id, "订单查询.sql", "SQL", projectId, null, true, Instant.EPOCH, Instant.EPOCH);
   }
 
   private static TaskAsset sqlAsset(
@@ -207,11 +224,30 @@ class DevelopmentDataServiceNodeServiceTest {
                 "SQL",
                 1,
                 "select id, status from orders where status = :status",
-                "{\"dataSourceId\":\"1\",\"timeoutSeconds\":30}"),
+                "{\"dataSourceId\":\"42\",\"timeoutSeconds\":30}"),
             "sql-checksum"));
   }
 
-  private static DevelopmentDataServiceDefinition definition(
+  private static DevelopmentDataServiceDefinition standaloneDefinition(long dataSourceId, String sql) {
+    return new DevelopmentDataServiceDefinition(
+        0L,
+        0L,
+        0,
+        "订单查询 API",
+        "/orders",
+        "GET",
+        List.of(new DevelopmentDataServiceDefinition.ParameterContract(
+            "status", "STRING", true, null, null)),
+        List.of(new DevelopmentDataServiceDefinition.ResponseFieldContract(
+            "id", "INTEGER", false, null, null)),
+        1000,
+        30,
+        null,
+        dataSourceId,
+        sql);
+  }
+
+  private static DevelopmentDataServiceDefinition legacyDefinition(
       long assetId,
       long revisionId,
       int revisionNo) {

--- a/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/DevelopmentDataServiceNodeSourceProviderTest.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/DevelopmentDataServiceNodeSourceProviderTest.java
@@ -1,8 +1,9 @@
 package io.yak.ops.business.development.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -43,16 +44,12 @@ class DevelopmentDataServiceNodeSourceProviderTest {
   }
 
   @Test
-  void resolveUsesPublishedDataServiceRevisionAndPinnedSqlRevision() {
+  void resolveUsesSqlOwnedByPublishedDataServiceRevision() {
     DevelopmentNode node = dataServiceNode();
-    DevelopmentDataServiceRevision dsRevision = dataServiceRevision(900L, 2, 401L, 3);
-    TaskAsset sqlAsset = sqlAsset(TaskAssetStatus.OFFLINE, 402L, 4);
+    DevelopmentDataServiceRevision dsRevision = standaloneRevision(900L, 2);
 
     when(nodeRepository.findById(100L)).thenReturn(Optional.of(node));
     when(revisionRepository.findLatestByNodeId(100L)).thenReturn(Optional.of(dsRevision));
-    when(taskCatalogService.get(300L)).thenReturn(sqlAsset);
-    when(taskCatalogService.resolveRevision(300L, 401L))
-        .thenReturn(sqlRevision(sqlAsset, 401L, 3));
 
     ResolvedSource resolved = provider.resolve("100");
 
@@ -71,6 +68,7 @@ class DevelopmentDataServiceNodeSourceProviderTest {
         .isEqualTo("select id, status from orders where status = :status");
     assertThat(resolved.contract().parameters()).hasSize(1);
     assertThat(resolved.contract().responseFields()).hasSize(1);
+    verify(taskCatalogService, never()).get(org.mockito.ArgumentMatchers.anyLong());
   }
 
   @Test
@@ -80,40 +78,37 @@ class DevelopmentDataServiceNodeSourceProviderTest {
         101L, "未发布 API", "DATA_SERVICE", 7L, null, true, Instant.EPOCH, Instant.EPOCH);
     DevelopmentNode sql = new DevelopmentNode(
         200L, "orders.sql", "SQL", 7L, null, true, Instant.EPOCH, Instant.EPOCH);
-    DevelopmentDataServiceRevision dsRevision = dataServiceRevision(900L, 2, 401L, 3);
-    TaskAsset sqlAsset = sqlAsset(TaskAssetStatus.ONLINE, 401L, 3);
+    DevelopmentDataServiceRevision dsRevision = standaloneRevision(900L, 2);
 
     when(nodeRepository.list()).thenReturn(List.of(published, unpublished, sql));
     when(revisionRepository.findLatestByNodeId(100L)).thenReturn(Optional.of(dsRevision));
     when(revisionRepository.findLatestByNodeId(101L)).thenReturn(Optional.empty());
     when(nodeRepository.findById(100L)).thenReturn(Optional.of(published));
-    when(taskCatalogService.get(300L)).thenReturn(sqlAsset);
-    when(taskCatalogService.resolveRevision(300L, 401L))
-        .thenReturn(sqlRevision(sqlAsset, 401L, 3));
 
     var page = provider.list(1, 20, "订单");
 
     assertThat(page.total()).isEqualTo(1L);
-    assertThat(page.records()).singleElement()
-        .extracting(item -> item.sourceRef())
-        .isEqualTo("100");
+    assertThat(page.records()).hasSize(1);
+    assertThat(page.records().getFirst().sourceRef()).isEqualTo("100");
   }
 
   @Test
-  void resolveRejectsSqlRevisionMismatch() {
+  void resolveKeepsHistoricalPinnedSqlRevisionCompatible() {
     DevelopmentNode node = dataServiceNode();
-    DevelopmentDataServiceRevision dsRevision = dataServiceRevision(900L, 2, 401L, 3);
-    TaskAsset sqlAsset = sqlAsset(TaskAssetStatus.ONLINE, 402L, 4);
+    DevelopmentDataServiceRevision legacyRevision = legacyRevision(900L, 1, 401L, 3);
+    TaskAsset sqlAsset = sqlAsset(TaskAssetStatus.OFFLINE, 402L, 4);
 
     when(nodeRepository.findById(100L)).thenReturn(Optional.of(node));
-    when(revisionRepository.findLatestByNodeId(100L)).thenReturn(Optional.of(dsRevision));
+    when(revisionRepository.findLatestByNodeId(100L)).thenReturn(Optional.of(legacyRevision));
     when(taskCatalogService.get(300L)).thenReturn(sqlAsset);
     when(taskCatalogService.resolveRevision(300L, 401L))
-        .thenReturn(sqlRevision(sqlAsset, 401L, 4));
+        .thenReturn(sqlRevision(sqlAsset, 401L, 3));
 
-    assertThatThrownBy(() -> provider.resolve("100"))
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessageContaining("不一致");
+    ResolvedSource resolved = provider.resolve("100");
+
+    assertThat(resolved.descriptor().dataSourceId()).isEqualTo(42L);
+    assertThat(resolved.sql())
+        .isEqualTo("select id, status from orders where status = :status");
   }
 
   private static DevelopmentNode dataServiceNode() {
@@ -121,7 +116,28 @@ class DevelopmentDataServiceNodeSourceProviderTest {
         100L, "订单查询 API", "DATA_SERVICE", 7L, null, true, Instant.EPOCH, Instant.EPOCH);
   }
 
-  private static DevelopmentDataServiceRevision dataServiceRevision(
+  private static DevelopmentDataServiceRevision standaloneRevision(long revisionId, int revisionNo) {
+    DevelopmentDataServiceDefinition definition = new DevelopmentDataServiceDefinition(
+        0L,
+        0L,
+        0,
+        "订单查询 API",
+        "/orders",
+        "GET",
+        List.of(new DevelopmentDataServiceDefinition.ParameterContract(
+            "status", "STRING", true, "订单状态", "PAID")),
+        List.of(new DevelopmentDataServiceDefinition.ResponseFieldContract(
+            "id", "INTEGER", false, "订单 ID", "1")),
+        500,
+        20,
+        "供运营系统查询",
+        42L,
+        "select id, status from orders where status = :status");
+    return new DevelopmentDataServiceRevision(
+        revisionId, 100L, revisionNo, 5L, definition, "ds-checksum", Instant.EPOCH);
+  }
+
+  private static DevelopmentDataServiceRevision legacyRevision(
       long revisionId,
       int revisionNo,
       long sqlRevisionId,
@@ -141,7 +157,7 @@ class DevelopmentDataServiceNodeSourceProviderTest {
         20,
         "供运营系统查询");
     return new DevelopmentDataServiceRevision(
-        revisionId, 100L, revisionNo, 5L, definition, "ds-checksum", Instant.EPOCH);
+        revisionId, 100L, revisionNo, 5L, definition, "legacy-checksum", Instant.EPOCH);
   }
 
   private static TaskAsset sqlAsset(

--- a/yak-ops-ui/src/pages/data-development/components/data-service/DataServiceNodeEditor.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/data-service/DataServiceNodeEditor.tsx
@@ -1,5 +1,4 @@
 import { history } from '@umijs/max';
-import { API_SUCCESS_CODE } from '@/services/http/response';
 import {
   Button,
   Empty,
@@ -9,7 +8,6 @@ import {
   Spin,
   Table,
   Tag,
-  Tooltip,
   message,
   type TableColumnsType,
 } from 'antd';
@@ -37,7 +35,6 @@ import {
   type DevelopmentDataServiceNodeContext,
   type DevelopmentDataServiceParameter,
   type DevelopmentDataServiceResponseField,
-  type DevelopmentDataServiceSource,
 } from '../../data-service-node-service';
 import {
   deployDataServiceRuntime,
@@ -45,13 +42,21 @@ import {
   syncDataServiceRuntime,
   type DataServicePublicationState,
 } from '../../data-service-runtime-publication';
-import { getDevelopmentTaskRevision } from '../../service';
 import type { DevelopmentId, DevelopmentResourceNode } from '../../types';
 import SqlMonacoEditor from '../../editors/sql/components/SqlMonacoEditor';
+import {
+  hydrateSqlTaskConfig,
+  selectSqlDataSourceContext,
+} from '../../editors/sql/metadata/sqlMetadataContextStore';
+import {
+  listSqlDataSources,
+  type SqlDataSourceOption,
+} from '../../editors/sql/metadata/sqlMetadataService';
 
 interface DataServiceNodeEditorProps {
   node: DevelopmentResourceNode;
   onSaved?: () => void | Promise<void>;
+  /** Kept temporarily for Workbench compatibility; standalone Data Service no longer opens a source SQL. */
   onOpenSourceNode?: (nodeId: DevelopmentId) => void;
   onDirtyChange?: (dirty: boolean) => void;
 }
@@ -88,9 +93,11 @@ const normalizeContext = (
   const rawDefinition = rawDraft?.definition;
   const nodeId = normalizeId(raw?.nodeId || node.id);
   const definition: DevelopmentDataServiceDefinition = {
-    sourceTaskAssetId: normalizeId(rawDefinition?.sourceTaskAssetId),
-    sourceTaskRevisionId: normalizeId(rawDefinition?.sourceTaskRevisionId),
+    sourceTaskAssetId: rawDefinition?.sourceTaskAssetId,
+    sourceTaskRevisionId: rawDefinition?.sourceTaskRevisionId,
     sourceTaskRevisionNo: Number(rawDefinition?.sourceTaskRevisionNo || 0),
+    dataSourceId: normalizeId(rawDefinition?.dataSourceId),
+    sql: rawDefinition?.sql || '',
     serviceName: rawDefinition?.serviceName || raw?.nodeName || node.name,
     path: rawDefinition?.path || `/query/${nodeId}`,
     method: 'GET',
@@ -105,8 +112,6 @@ const normalizeContext = (
     nodeId,
     nodeName: raw?.nodeName || node.name,
     configured: Boolean(raw?.configured),
-    availableSources: safeArray(raw?.availableSources),
-    selectedSource: raw?.selectedSource || null,
     draft: {
       nodeId: normalizeId(rawDraft?.nodeId || nodeId),
       definition,
@@ -117,17 +122,6 @@ const normalizeContext = (
     latestPublishedRevision: raw?.latestPublishedRevision || null,
     revisions: safeArray(raw?.revisions),
   };
-};
-
-const parseDataSourceId = (configJson?: string) => {
-  if (!configJson) return undefined;
-  try {
-    const value = JSON.parse(configJson) as Record<string, unknown>;
-    const id = value?.dataSourceId;
-    return id === undefined || id === null || String(id).trim() === '' ? undefined : String(id);
-  } catch {
-    return undefined;
-  }
 };
 
 const panelItems: Array<{ key: RightPanelKey; label: string; icon: typeof Settings2 }> = [
@@ -141,15 +135,16 @@ const panelItems: Array<{ key: RightPanelKey; label: string; icon: typeof Settin
 export default function DataServiceNodeEditor({
   node,
   onSaved,
-  onOpenSourceNode,
   onDirtyChange,
 }: DataServiceNodeEditorProps) {
   const dirtyChangeRef = useRef(onDirtyChange);
   useEffect(() => { dirtyChangeRef.current = onDirtyChange; }, [onDirtyChange]);
 
   const [context, setContext] = useState<DevelopmentDataServiceNodeContext>();
-  const [selectedSourceId, setSelectedSourceId] = useState<DevelopmentId>();
-  const [selectedRevisionId, setSelectedRevisionId] = useState<DevelopmentId>();
+  const [dataSourceId, setDataSourceId] = useState<DevelopmentId>();
+  const [dataSources, setDataSources] = useState<SqlDataSourceOption[]>([]);
+  const [dataSourceLoading, setDataSourceLoading] = useState(false);
+  const [sqlText, setSqlText] = useState('');
   const [serviceName, setServiceName] = useState(node.name);
   const [path, setPath] = useState(`/query/${node.id}`);
   const [maxRows, setMaxRows] = useState(1000);
@@ -167,10 +162,6 @@ export default function DataServiceNodeEditor({
   const [publicationError, setPublicationError] = useState<string>();
   const [publicationLoading, setPublicationLoading] = useState(false);
   const [deploying, setDeploying] = useState(false);
-  const [sqlText, setSqlText] = useState('');
-  const [sqlConfigJson, setSqlConfigJson] = useState('{}');
-  const [sqlLoading, setSqlLoading] = useState(false);
-  const [sqlError, setSqlError] = useState<string>();
   const [rightPanelKey, setRightPanelKey] = useState<RightPanelKey>('properties');
   const [rightPanelOpen, setRightPanelOpen] = useState(true);
 
@@ -185,13 +176,10 @@ export default function DataServiceNodeEditor({
   const applyContext = useCallback((raw: DevelopmentDataServiceNodeContext) => {
     const next = normalizeContext(raw, node);
     const definition = next.draft.definition;
+    const nextDataSourceId = definition.dataSourceId !== '0' ? definition.dataSourceId : undefined;
     setContext(next);
-    setSelectedSourceId(
-      definition.sourceTaskAssetId !== '0' ? definition.sourceTaskAssetId : undefined,
-    );
-    setSelectedRevisionId(
-      definition.sourceTaskRevisionId !== '0' ? definition.sourceTaskRevisionId : undefined,
-    );
+    setDataSourceId(nextDataSourceId);
+    setSqlText(definition.sql || '');
     setServiceName(definition.serviceName || next.nodeName);
     setPath(definition.path || `/query/${next.nodeId}`);
     setMaxRows(definition.maxRows || 1000);
@@ -199,6 +187,10 @@ export default function DataServiceNodeEditor({
     setDescription(definition.description || '');
     setParameters(safeArray(definition.parameters));
     setResponseFields(safeArray(definition.responseFields));
+    hydrateSqlTaskConfig(
+      node.id,
+      JSON.stringify(nextDataSourceId ? { dataSourceId: nextDataSourceId } : {}),
+    );
     setDirtyState(false);
     return next;
   }, [node, setDirtyState]);
@@ -248,103 +240,75 @@ export default function DataServiceNodeEditor({
     void load();
   }, [load]);
 
-  const availableSources = context?.availableSources || [];
-  const sourceOptions = useMemo(() => {
-    const values: DevelopmentDataServiceSource[] = [...availableSources];
-    const pinned = context?.selectedSource;
-    if (pinned && !values.some((source) => source.taskAssetId === pinned.taskAssetId)) {
-      values.unshift(pinned);
-    }
-    return values
-      .filter((source) => source && source.taskAssetId)
-      .map((source) => ({
-        value: source.taskAssetId,
-        disabled: source.status !== 'ONLINE',
-        label: `${source.nodeName || 'SQL'} · SQL R${source.currentRevisionNo || source.revisionNo || '-'}${source.status === 'ONLINE' ? '' : ` · ${source.status || 'UNKNOWN'}`}`,
-      }));
-  }, [availableSources, context?.selectedSource]);
-
-  const activeSource = useMemo(
-    () => availableSources.find((source) => source.taskAssetId === selectedSourceId)
-      || (context?.selectedSource?.taskAssetId === selectedSourceId
-        ? context?.selectedSource
-        : undefined),
-    [availableSources, context?.selectedSource, selectedSourceId],
-  );
-
-  const selectedRevisionNo = useMemo(() => {
-    if (!activeSource || !selectedRevisionId) return undefined;
-    if (activeSource.revisionId === selectedRevisionId) return activeSource.revisionNo;
-    if (activeSource.currentRevisionId === selectedRevisionId) {
-      return activeSource.currentRevisionNo || undefined;
-    }
-    if (context?.selectedSource?.revisionId === selectedRevisionId) {
-      return context.selectedSource.revisionNo;
-    }
-    return undefined;
-  }, [activeSource, context?.selectedSource, selectedRevisionId]);
-
-  const sourceUpdateAvailable = Boolean(
-    activeSource?.currentRevisionId
-      && selectedRevisionId
-      && activeSource.currentRevisionId !== selectedRevisionId,
-  );
-
-  const loadSqlRevision = useCallback(async () => {
-    if (!activeSource?.nodeId || !selectedRevisionNo) {
-      setSqlText('');
-      setSqlConfigJson('{}');
-      setSqlError(undefined);
-      return;
-    }
-
-    setSqlLoading(true);
-    setSqlError(undefined);
-    try {
-      const response = await getDevelopmentTaskRevision(activeSource.nodeId, selectedRevisionNo);
-      if (response?.code !== API_SUCCESS_CODE || !response.data) {
-        throw new Error(response?.message || response?.msg || '加载固定 SQL Revision 失败');
-      }
-      setSqlText(response.data.definition?.content || '');
-      setSqlConfigJson(response.data.definition?.configJson || '{}');
-    } catch (error) {
-      setSqlText('');
-      setSqlConfigJson('{}');
-      setSqlError(error instanceof Error ? error.message : '加载固定 SQL Revision 失败');
-    } finally {
-      setSqlLoading(false);
-    }
-  }, [activeSource?.nodeId, selectedRevisionNo]);
+  useEffect(() => {
+    let active = true;
+    setDataSourceLoading(true);
+    listSqlDataSources()
+      .then((values) => {
+        if (active) setDataSources(values || []);
+      })
+      .catch((error) => {
+        if (active) message.error(error instanceof Error ? error.message : '查询数据源失败');
+      })
+      .finally(() => {
+        if (active) setDataSourceLoading(false);
+      });
+    return () => { active = false; };
+  }, []);
 
   useEffect(() => {
-    void loadSqlRevision();
-  }, [loadSqlRevision]);
+    if (!dataSourceId || !dataSources.length) return;
+    const selected = dataSources.find((item) => item.value === dataSourceId);
+    if (!selected) return;
+    selectSqlDataSourceContext(node.id, {
+      id: selected.value,
+      name: selected.label,
+      dbType: selected.dbType,
+    });
+  }, [dataSourceId, dataSources, node.id]);
 
-  const changeSource = (taskAssetId: DevelopmentId) => {
-    const source = availableSources.find((item) => item.taskAssetId === taskAssetId);
-    setSelectedSourceId(taskAssetId);
-    setSelectedRevisionId(source?.currentRevisionId || source?.revisionId);
+  const dataSourceOptions = useMemo(() => dataSources.map((item) => ({
+    value: item.value,
+    label: `${item.label}${item.dbType ? ` · ${item.dbType}` : ''}`,
+  })), [dataSources]);
+
+  const activeDataSource = useMemo(
+    () => dataSources.find((item) => item.value === dataSourceId),
+    [dataSourceId, dataSources],
+  );
+
+  const invalidateContract = useCallback(() => {
     setParameters([]);
     setResponseFields([]);
+  }, []);
+
+  const changeDataSource = (nextDataSourceId: DevelopmentId) => {
+    const selected = dataSources.find((item) => item.value === nextDataSourceId);
+    setDataSourceId(nextDataSourceId);
+    selectSqlDataSourceContext(node.id, selected ? {
+      id: selected.value,
+      name: selected.label,
+      dbType: selected.dbType,
+    } : { id: nextDataSourceId });
+    invalidateContract();
     markDirty();
   };
 
-  const upgradeSource = () => {
-    if (!activeSource?.currentRevisionId) return;
-    setSelectedRevisionId(activeSource.currentRevisionId);
-    setParameters([]);
-    setResponseFields([]);
+  const changeSql = (value: string) => {
+    setSqlText(value);
+    invalidateContract();
     markDirty();
   };
 
   const preview = async () => {
-    if (!selectedSourceId || !selectedRevisionId || previewing) return;
+    if (!dataSourceId || !sqlText.trim() || previewing) return;
     setPreviewing(true);
     try {
       const result = await previewDevelopmentDataServiceNode(
         node.id,
-        selectedSourceId,
-        selectedRevisionId,
+        dataSourceId,
+        sqlText,
+        timeoutSeconds,
       );
       const nextParameters = safeArray(result?.parameters);
       const nextResponses = safeArray(result?.responseFields);
@@ -374,10 +338,7 @@ export default function DataServiceNodeEditor({
           example: previous.example,
         } : item;
       }));
-      if (result?.source) {
-        setSelectedSourceId(normalizeId(result.source.taskAssetId));
-        setSelectedRevisionId(normalizeId(result.source.revisionId));
-      }
+      if (result?.dataSourceId) setDataSourceId(normalizeId(result.dataSourceId));
       markDirty();
       message.success(
         `Contract 已发现 · ${nextParameters.length} 个参数 / ${nextResponses.length} 个响应字段`,
@@ -390,12 +351,12 @@ export default function DataServiceNodeEditor({
   };
 
   const save = async () => {
-    if (!selectedSourceId || !selectedRevisionId || saving) return;
+    if (!dataSourceId || !sqlText.trim() || saving) return;
     setSaving(true);
     try {
       const next = await saveDevelopmentDataServiceDraft(node.id, {
-        sourceTaskAssetId: selectedSourceId,
-        sourceTaskRevisionId: selectedRevisionId,
+        dataSourceId,
+        sql: sqlText,
         serviceName: serviceName.trim(),
         path: path.trim(),
         method: 'GET',
@@ -540,7 +501,7 @@ export default function DataServiceNodeEditor({
         />
       ),
     },
-  ], [markDirty]);
+  ], []);
 
   const responseColumns = useMemo<TableColumnsType<DevelopmentDataServiceResponseField>>(() => [
     {
@@ -595,7 +556,7 @@ export default function DataServiceNodeEditor({
         />
       ),
     },
-  ], [markDirty]);
+  ], []);
 
   const latestPublished = context?.latestPublishedRevision;
   const runtimeRevisionNo = publicationState?.detail?.sourceRevisionNo;
@@ -612,14 +573,13 @@ export default function DataServiceNodeEditor({
             : publicationState.detail?.enabled
               ? `Runtime DS R${runtimeRevisionNo || '-'} · 运行中`
               : `Runtime DS R${runtimeRevisionNo || '-'} · 已停用`;
-  const dataSourceId = parseDataSourceId(sqlConfigJson);
 
   const propertiesPanel = (
     <div className="space-y-5">
       <div>
         <div className="text-[13px] font-semibold text-[#344054]">API 属性</div>
         <div className="mt-1 text-[11px] leading-5 text-[#98a2b3]">
-          Data Service Node 定义 API Contract；SQL 实现来自固定的已发布 SQL Revision。
+          Data Service Node 独立拥有数据源、查询 SQL 和 API Contract，发布时一起冻结到 DS Revision。
         </div>
       </div>
 
@@ -682,8 +642,8 @@ export default function DataServiceNodeEditor({
       <div className="border-t border-[#eef0f2] pt-4 text-[11px] leading-6 text-[#667085]">
         <div className="flex justify-between"><span>Draft</span><span>#{context?.draft?.draftRevision || 0}</span></div>
         <div className="flex justify-between"><span>最新 DS Revision</span><span>{latestPublished ? `R${latestPublished.revisionNo}` : '尚未发布'}</span></div>
-        <div className="flex justify-between"><span>来源 SQL</span><span>{selectedRevisionNo ? `R${selectedRevisionNo}` : '-'}</span></div>
-        <div className="flex justify-between"><span>数据源 ID</span><span>{dataSourceId || '-'}</span></div>
+        <div className="flex justify-between gap-3"><span>数据源</span><span className="truncate text-right">{activeDataSource?.label || (dataSourceId ? `#${dataSourceId}` : '-')}</span></div>
+        <div className="flex justify-between"><span>查询 SQL</span><span>{sqlText.trim() ? '已配置' : '未填写'}</span></div>
       </div>
     </div>
   );
@@ -693,7 +653,7 @@ export default function DataServiceNodeEditor({
       <div>
         <div className="text-[13px] font-semibold text-[#344054]">请求参数</div>
         <div className="mt-1 text-[11px] leading-5 text-[#98a2b3]">
-          参数来自 SQL 中的 <span className="font-mono">:name</span> 命名参数。v1 统一为必填参数。
+          参数来自当前 SQL 中的 <span className="font-mono">:name</span> 命名参数。v1 统一为必填参数。
         </div>
       </div>
       <Table<DevelopmentDataServiceParameter>
@@ -713,11 +673,11 @@ export default function DataServiceNodeEditor({
       <div>
         <div className="text-[13px] font-semibold text-[#344054]">返回参数</div>
         <div className="mt-1 text-[11px] leading-5 text-[#98a2b3]">
-          通过真实数据源预览发现字段类型，可补充描述与示例后固化到 DS Revision。
+          通过当前数据源真实预览发现字段类型，可补充描述与示例后固化到 DS Revision。
         </div>
       </div>
       <Table<DevelopmentDataServiceResponseField>
-        rowKey={(record, index) => `${record.name}-${index}`}
+        rowKey={(record) => record.name}
         size="small"
         pagination={false}
         dataSource={responseFields}
@@ -732,7 +692,7 @@ export default function DataServiceNodeEditor({
     <div>
       <div className="text-[13px] font-semibold text-[#344054]">版本</div>
       <div className="mt-1 text-[11px] leading-5 text-[#98a2b3]">
-        发布只生成不可变 DS Revision，不会自动更新 Runtime。
+        每个 DS Revision 都冻结当时的数据源、SQL 和 Contract；发布不会自动更新 Runtime。
       </div>
       <div className="mt-4 space-y-2">
         {context?.revisions?.length ? context.revisions.map((revision) => (
@@ -745,7 +705,7 @@ export default function DataServiceNodeEditor({
               <span className="text-[10px] text-[#98a2b3]">{formatTime(revision.createTime)}</span>
             </div>
             <div className="mt-1 text-[11px] text-[#667085]">
-              SQL R{revision.sourceTaskRevisionNo} · Draft #{revision.sourceDraftRevision}
+              Draft #{revision.sourceDraftRevision}
             </div>
           </div>
         )) : (
@@ -832,6 +792,9 @@ export default function DataServiceNodeEditor({
     );
   }
 
+  const canPreview = Boolean(dataSourceId && sqlText.trim());
+  const canSave = canPreview && dirty;
+
   return (
     <div className="flex min-h-0 flex-1 flex-col overflow-hidden bg-white">
       <div className="flex h-10 shrink-0 items-center justify-between border-b border-[#e8e9ec] bg-white px-2.5">
@@ -844,7 +807,7 @@ export default function DataServiceNodeEditor({
             size="small"
             icon={<Play size={14} />}
             loading={previewing}
-            disabled={!selectedSourceId || !selectedRevisionId}
+            disabled={!canPreview}
             onClick={() => void preview()}
           >
             预览 Contract
@@ -854,7 +817,7 @@ export default function DataServiceNodeEditor({
             size="small"
             icon={<Save size={14} />}
             loading={saving}
-            disabled={!selectedSourceId || !selectedRevisionId || !dirty}
+            disabled={!canSave}
             onClick={() => void save()}
           >
             保存草稿
@@ -895,121 +858,81 @@ export default function DataServiceNodeEditor({
         <section className="flex min-w-0 flex-1 flex-col overflow-hidden bg-white">
           <div className="shrink-0 border-b border-[#eef0f2] px-4 py-3">
             <div className="flex items-center gap-3">
-              <div className="w-[92px] shrink-0 text-[12px] font-medium text-[#344054]">来源 SQL</div>
+              <div className="w-[72px] shrink-0 text-[12px] font-medium text-[#344054]">数据源</div>
               <Select
-                value={selectedSourceId}
-                options={sourceOptions}
-                placeholder="选择同项目中已发布的 ONLINE SQL"
+                value={dataSourceId}
+                options={dataSourceOptions}
+                placeholder="选择数据源"
                 className="min-w-0 flex-1"
                 size="small"
                 showSearch
+                loading={dataSourceLoading}
                 optionFilterProp="label"
-                onChange={changeSource}
+                onChange={changeDataSource}
               />
-              {selectedRevisionNo ? <Tag bordered={false}>SQL R{selectedRevisionNo}</Tag> : null}
-              {sourceUpdateAvailable ? (
-                <Button size="small" onClick={upgradeSource}>
-                  更新到 R{activeSource?.currentRevisionNo || '-'}
-                </Button>
-              ) : null}
-              <Tooltip title={activeSource?.nodeId ? '在同一个开发工作台中打开来源 SQL 节点' : '来源 SQL 节点不可用'}>
-                <Button
-                  size="small"
-                  disabled={!activeSource?.nodeId}
-                  icon={<ExternalLink size={13} />}
-                  onClick={() => activeSource?.nodeId && onOpenSourceNode?.(activeSource.nodeId)}
-                >
-                  打开来源 SQL
-                </Button>
-              </Tooltip>
             </div>
-            <div className="ml-[104px] mt-1.5 text-[10px] text-[#98a2b3]">
-              Data Service 固定精确 SQL Revision；修改 SQL 请在来源节点发布新版本后，再显式更新这里的来源。
+            <div className="ml-[84px] mt-1.5 text-[10px] text-[#98a2b3]">
+              Data Service Node 独立持有数据源和 SQL，不再关联其他 SQL 节点。
             </div>
           </div>
 
           <div className="flex h-9 shrink-0 items-center justify-between border-b border-[#eef0f2] px-3">
             <div className="text-[12px] font-semibold text-[#344054]">查询 SQL</div>
             <div className="flex items-center gap-2 text-[10px] text-[#98a2b3]">
-              {dataSourceId ? <span>DataSource #{dataSourceId}</span> : null}
-              <span>固定 Revision · 只读</span>
+              {activeDataSource ? <span>{activeDataSource.label}</span> : dataSourceId ? <span>DataSource #{dataSourceId}</span> : null}
+              <span>可编辑</span>
             </div>
           </div>
 
-          <div className="relative min-h-0 flex-1 overflow-hidden bg-white">
-            {sqlLoading ? (
-              <div className="absolute inset-0 z-10 flex items-center justify-center bg-white/70"><Spin size="small" /></div>
-            ) : null}
-            {sqlError ? (
-              <div className="flex h-full items-center justify-center px-6 text-center">
-                <div>
-                  <div className="text-[12px] font-medium text-[#b42318]">SQL Revision 加载失败</div>
-                  <div className="mt-1 text-[11px] text-[#98a2b3]">{sqlError}</div>
-                  <Button className="mt-3" size="small" onClick={() => void loadSqlRevision()}>重试</Button>
-                </div>
-              </div>
-            ) : sqlText ? (
-              <SqlMonacoEditor
-                id={`data-service-${node.id}-${selectedRevisionId || 'empty'}`}
-                value={sqlText}
-                onChange={() => undefined}
-                readOnly
-              />
-            ) : (
-              <div className="flex h-full items-center justify-center text-center">
-                <div>
-                  <div className="text-[12px] font-medium text-[#667085]">选择来源 SQL Revision</div>
-                  <div className="mt-1 text-[11px] text-[#98a2b3]">选择后将在这里展示固定版本的查询 SQL</div>
-                </div>
-              </div>
-            )}
+          <div className="min-h-0 flex-1 overflow-hidden bg-white">
+            <SqlMonacoEditor
+              id={`data-service-${node.id}`}
+              value={sqlText}
+              onChange={changeSql}
+            />
           </div>
 
-          <div className="flex h-6 shrink-0 items-center justify-between border-t border-[#eef0f2] bg-[#fafafa] px-3 text-[10px] text-[#7b808a]">
+          <div className="flex h-6 shrink-0 items-center justify-between border-t border-[#eef0f2] bg-[#fafafa] px-2.5 text-[10px] text-[#7b808a]">
             <div className="flex min-w-0 items-center gap-3">
-              <span className="font-medium text-[#7f56d9]">DATA SERVICE</span>
-              <span className="truncate">{serviceName || node.name}</span>
+              <span className="font-medium text-[#667085]">DATA SERVICE</span>
+              <span className="truncate">{node.name}</span>
               {dirty ? (
-                <span className="inline-flex items-center gap-1 text-[#667085]">
-                  <span className="h-1.5 w-1.5 rounded-full bg-[#667085]" />未保存
+                <span className="inline-flex shrink-0 items-center gap-1 text-[#667085]">
+                  <span className="h-1.5 w-1.5 rounded-full bg-[#667085]" />
+                  未保存
                 </span>
               ) : null}
             </div>
-            <div>{selectedRevisionNo ? `SQL R${selectedRevisionNo}` : '未选择 SQL'}</div>
+            <span>{responseFields.length ? `${responseFields.length} 个响应字段` : 'Contract 待预览'}</span>
           </div>
         </section>
 
-        <aside
-          className={[
-            'flex shrink-0 border-l border-[#e8e9ec] bg-white transition-[width] duration-150',
-            rightPanelOpen ? 'w-[470px]' : 'w-10',
-          ].join(' ')}
-        >
+        <aside className="flex shrink-0 border-l border-[#e8e9ec] bg-white">
           {rightPanelOpen ? (
-            <div className="min-w-0 flex-1 overflow-auto p-4">
+            <div className="w-[380px] min-w-0 overflow-auto border-r border-[#eef0f2] p-4">
               {panelContent[rightPanelKey]}
             </div>
           ) : null}
-          <div className="flex w-10 shrink-0 flex-col items-stretch border-l border-[#eef0f2] bg-[#fafafa]">
+          <div className="flex w-9 shrink-0 flex-col items-stretch bg-[#fafafa]">
             {panelItems.map((item) => {
               const Icon = item.icon;
               const active = rightPanelOpen && rightPanelKey === item.key;
               return (
-                <Tooltip key={item.key} title={item.label} placement="left">
-                  <button
-                    type="button"
-                    onClick={() => selectRightPanel(item.key)}
-                    className={[
-                      'flex h-[86px] flex-col items-center justify-center gap-1 border-b border-[#eef0f2] text-[10px] transition-colors',
-                      active
-                        ? 'bg-white text-[rgba(254,44,85,1)]'
-                        : 'text-[#667085] hover:bg-white hover:text-[#344054]',
-                    ].join(' ')}
-                  >
-                    <Icon size={14} strokeWidth={1.8} />
-                    <span style={{ writingMode: 'vertical-rl' }}>{item.label}</span>
-                  </button>
-                </Tooltip>
+                <button
+                  key={item.key}
+                  type="button"
+                  title={item.label}
+                  onClick={() => selectRightPanel(item.key)}
+                  className={[
+                    'flex min-h-[84px] flex-col items-center justify-center gap-1.5 border-b border-[#eef0f2] text-[10px] transition-colors [writing-mode:vertical-rl]',
+                    active
+                      ? 'bg-white font-medium text-[#344054]'
+                      : 'text-[#667085] hover:bg-white hover:text-[#344054]',
+                  ].join(' ')}
+                >
+                  <Icon size={13} strokeWidth={1.8} className="[writing-mode:horizontal-tb]" />
+                  <span>{item.label}</span>
+                </button>
               );
             })}
           </div>

--- a/yak-ops-ui/src/pages/data-development/data-service-node-service.ts
+++ b/yak-ops-ui/src/pages/data-development/data-service-node-service.ts
@@ -32,9 +32,12 @@ export interface DevelopmentDataServiceResponseField {
 }
 
 export interface DevelopmentDataServiceDefinition {
-  sourceTaskAssetId: DevelopmentId;
-  sourceTaskRevisionId: DevelopmentId;
-  sourceTaskRevisionNo: number;
+  /** Legacy fields remain readable for revisions created before standalone SQL authoring. */
+  sourceTaskAssetId?: DevelopmentId;
+  sourceTaskRevisionId?: DevelopmentId;
+  sourceTaskRevisionNo?: number;
+  dataSourceId: DevelopmentId;
+  sql: string;
   serviceName: string;
   path: string;
   method: 'GET';
@@ -53,25 +56,13 @@ export interface DevelopmentDataServiceDraft {
   updateTime?: string | null;
 }
 
-export interface DevelopmentDataServiceSource {
-  nodeId?: DevelopmentId | null;
-  nodeName: string;
-  taskAssetId: DevelopmentId;
-  status: string;
-  revisionId: DevelopmentId;
-  revisionNo: number;
-  currentRevisionId?: DevelopmentId | null;
-  currentRevisionNo?: number | null;
-  updateAvailable: boolean;
-}
-
 export interface DevelopmentDataServiceRevisionSummary {
   id: DevelopmentId;
   nodeId: DevelopmentId;
   revisionNo: number;
   sourceDraftRevision: number;
-  sourceTaskRevisionId: DevelopmentId;
-  sourceTaskRevisionNo: number;
+  sourceTaskRevisionId?: DevelopmentId;
+  sourceTaskRevisionNo?: number;
   checksum: string;
   createTime?: string;
 }
@@ -90,22 +81,20 @@ export interface DevelopmentDataServiceNodeContext {
   nodeId: DevelopmentId;
   nodeName: string;
   configured: boolean;
-  availableSources: DevelopmentDataServiceSource[];
-  selectedSource?: DevelopmentDataServiceSource | null;
   draft: DevelopmentDataServiceDraft;
   latestPublishedRevision?: DevelopmentDataServiceRevisionSummary | null;
   revisions: DevelopmentDataServiceRevisionSummary[];
 }
 
 export interface PreviewDevelopmentDataServiceResult {
-  source: DevelopmentDataServiceSource;
+  dataSourceId: DevelopmentId;
   parameters: DevelopmentDataServiceParameter[];
   responseFields: DevelopmentDataServiceResponseField[];
 }
 
 export interface SaveDevelopmentDataServiceDraftPayload {
-  sourceTaskAssetId: DevelopmentId;
-  sourceTaskRevisionId: DevelopmentId;
+  dataSourceId: DevelopmentId;
+  sql: string;
   serviceName: string;
   path: string;
   method: 'GET';
@@ -133,12 +122,13 @@ export const getDevelopmentDataServiceNode = async (
 
 export const previewDevelopmentDataServiceNode = async (
   nodeId: DevelopmentId,
-  sourceTaskAssetId: DevelopmentId,
-  sourceTaskRevisionId: DevelopmentId,
+  dataSourceId: DevelopmentId,
+  sql: string,
+  timeoutSeconds = 30,
 ): Promise<PreviewDevelopmentDataServiceResult> => unwrap(
   await HttpUtils.post<PreviewDevelopmentDataServiceResult>(
     `${NODE_API}/${nodeId}/data-service/preview`,
-    { sourceTaskAssetId, sourceTaskRevisionId },
+    { dataSourceId, sql, timeoutSeconds },
   ),
   '预览 Data Service Contract 失败',
 );


### PR DESCRIPTION
## 背景

Data Service 已经进入统一的数据开发 Workbench，但当前还要求先关联一个已发布 SQL Node / SQL Revision。对第一个轻量版本来说，这层关系增加了理解和操作成本。

这个 PR 继续做减法：**Data Service Node 独立拥有数据源、查询 SQL 和 API Contract，不再要求关联来源 SQL 节点。**

新的 v1 主链变成：

```text
Data Service Node
  ├─ DataSource
  ├─ SQL
  ├─ Request Contract
  └─ Response Contract
       ↓ save Draft
Data Service Draft
       ↓ publish
DS Revision（冻结 DataSource + SQL + Contract）
       ↓ deploy / sync
Runtime
```

## 1. 删除“来源 SQL”开发心智

Data Service 编辑器不再展示或要求：

- 来源 SQL
- SQL Revision
- 打开来源 SQL
- 更新到 Rn

节点打开后直接：

1. 选择数据源
2. 在中间 Monaco 中编写查询 SQL
3. 预览 Contract
4. 保存 Draft
5. 发布 DS Revision
6. 部署 / 同步 Runtime

右侧仍保留轻量的：

- 属性
- 请求参数
- 返回参数
- 版本
- 部署

## 2. Data Service Draft / Revision 自己保存 SQL

`DevelopmentDataServiceDefinition` 新增直接持有：

```text
dataSourceId
sql
```

新保存的 Draft / Revision 不再依赖 Task Catalog 中的 SQL TaskAsset。

发布后的 DS Revision 会冻结当时的：

- dataSourceId
- SQL
- API 名称 / Path
- Request Contract
- Response Contract
- maxRows / timeout / description

因此 Runtime 可以直接从 DS Revision 构建运行快照，不再需要解析另一个 SQL Revision。

## 3. SQL / 数据源变化后自动失效旧 Contract

为了避免出现“SQL 已改，但 Contract 还是旧的”这种状态：

- 修改 SQL -> 清空当前请求/响应 Contract
- 修改数据源 -> 清空当前请求/响应 Contract
- 用户需要重新执行「预览 Contract」
- Published Revision 仍要求存在响应 Contract

这样保持流程轻量，同时保证 DS Revision 内的 SQL 与 Contract 对应同一份开发状态。

## 4. Runtime 直接消费 DS Revision

新 DS Revision 部署时直接读取自己的：

```text
dataSourceId + SQL + Contract
```

不访问 Task Catalog，不解析 SQL TaskRevision。

`sourceRef` 仍然保持 Data Service Node ID，Runtime 的部署/同步/启停/API Key/日志等逻辑不变。

## 5. 历史 DS Revision 保持兼容

为了避免已有数据服务因为模型简化突然失效，旧 Revision 中的：

```text
sourceTaskAssetId
sourceTaskRevisionId
sourceTaskRevisionNo
```

暂时保留为 legacy 兼容字段。

运行旧 Revision 时仍可以按原来的固定 SQL Revision 解析；旧 Draft 第一次重新保存后，会自然转换成新的 standalone SQL 结构。

**新 Data Service 不再使用这套关联逻辑。**

## 6. 不增加新的重量

本 PR 不做：

- 数据库迁移（Definition 本身以 JSON 保存，新字段可直接兼容）
- Workflow 修改
- Task Catalog 生命周期修改
- 多环境
- 灰度 / 回滚
- POST / CRUD API
- Gateway
- 新 Runtime 基础设施

## 测试与检查

更新/补充了：

- standalone Data Service Definition 发布约束测试
- Data Service Draft 直接持有 SQL / DataSource 测试
- 发布 Revision 不进入 Task Catalog 测试
- Runtime 直接消费 DS Revision SQL 测试
- 历史 pinned SQL Revision 兼容测试

分支基于最新 `main`，最终 diff 已 squash 为 **1 commit / 9 files**。

当前执行环境无法通过本地 GitHub clone 完成完整 Maven / npm 构建，因此没有声称本地全量构建通过；PR 创建后继续以 GitHub reported checks 为准。

这一轮的核心就是一句话：**Data Service 是独立开发节点，SQL 是它自己的实现，不再是另一个 SQL Node 的引用。**