### PR TITLE
refactor: simplify data service publish and online ux

### DIFF
--- a/yak-ops-ui/src/pages/data-development/components/data-service/DataServiceNodeEditor.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/data-service/DataServiceNodeEditor.tsx
@@ -42,9 +42,8 @@ import {
   type DevelopmentDataServiceResponseField,
 } from '../../data-service-node-service';
 import {
-  deployDataServiceRuntime,
+  bringDataServiceOnline,
   fetchDataServicePublicationState,
-  syncDataServiceRuntime,
   type DataServicePublicationState,
 } from '../../data-service-runtime-publication';
 import {
@@ -69,7 +68,7 @@ interface DataServiceNodeEditorProps {
   onDirtyChange?: (dirty: boolean) => void;
 }
 
-type RightPanelKey = 'properties' | 'request' | 'response' | 'versions' | 'deployment';
+type RightPanelKey = 'properties' | 'request' | 'response' | 'versions' | 'online';
 
 const requestTypeOptions: { label: string; value: DataServiceContractType }[] = [
   { label: 'STRING', value: 'STRING' },
@@ -90,7 +89,7 @@ const panelItems: Array<{ key: RightPanelKey; label: string }> = [
   { key: 'request', label: '请求参数' },
   { key: 'response', label: '返回参数' },
   { key: 'versions', label: '版本' },
-  { key: 'deployment', label: '部署' },
+  { key: 'online', label: '上线' },
 ];
 
 const DEFAULT_PANEL_WIDTH = 380;
@@ -227,7 +226,7 @@ export default function DataServiceNodeEditor({
   const [publicationState, setPublicationState] = useState<DataServicePublicationState>();
   const [publicationError, setPublicationError] = useState<string>();
   const [publicationLoading, setPublicationLoading] = useState(false);
-  const [deploying, setDeploying] = useState(false);
+  const [goingOnline, setGoingOnline] = useState(false);
   const [activePanel, setActivePanel] = useState<RightPanelKey>();
   const [panelWidth, setPanelWidth] = useState(initialPanelWidth);
   const [resizing, setResizing] = useState(false);
@@ -287,7 +286,7 @@ export default function DataServiceNodeEditor({
     try {
       setPublicationState(await fetchDataServicePublicationState(node.id));
     } catch (error) {
-      const text = error instanceof Error ? error.message : '查询 Runtime 同步状态失败';
+      const text = error instanceof Error ? error.message : '查询服务状态失败';
       setPublicationState(undefined);
       setPublicationError(text);
       if (notifyOnError) message.error(text);
@@ -457,7 +456,8 @@ export default function DataServiceNodeEditor({
       const revision = await publishDevelopmentDataServiceNode(node.id, draftRevision);
       await load();
       await onSaved?.();
-      message.success(`已发布 DS R${revision.revisionNo}`);
+      setActivePanel('online');
+      message.success(`已发布 DS R${revision.revisionNo} · 可继续上线 API`);
     } catch (error) {
       message.error(error instanceof Error ? error.message : '发布 Data Service Node 失败');
     } finally {
@@ -465,26 +465,56 @@ export default function DataServiceNodeEditor({
     }
   };
 
-  const deployOrSync = async () => {
-    const latestPublished = context?.latestPublishedRevision;
-    if (!latestPublished || deploying) return;
+  const latestPublished = context?.latestPublishedRevision;
+  const onlineRevisionNo = publicationState?.detail?.sourceRevisionNo;
+  const serviceStatus = !latestPublished
+    ? '等待发布版本'
+    : publicationLoading
+      ? '正在查询服务状态'
+      : publicationError
+        ? '服务状态不可用'
+        : !publicationState?.published
+          ? '尚未上线'
+          : publicationState.updateAvailable
+            ? `线上 DS R${onlineRevisionNo || '-'} · 有新版本待上线`
+            : publicationState.detail?.enabled
+              ? `DS R${onlineRevisionNo || '-'} · 运行中`
+              : `DS R${onlineRevisionNo || '-'} · 已停用`;
 
-    setDeploying(true);
+  const onlineActionLabel = !publicationState?.published
+    ? '上线 API'
+    : publicationState.updateAvailable
+      ? '更新上线'
+      : publicationState.detail?.enabled
+        ? '已上线'
+        : '重新上线';
+
+  const onlineActionDisabled = !latestPublished
+    || publicationLoading
+    || Boolean(publicationError)
+    || Boolean(
+      publicationState?.published
+      && !publicationState.updateAvailable
+      && publicationState.detail?.enabled,
+    );
+
+  const goOnline = async () => {
+    if (!latestPublished || goingOnline || publicationError) return;
+
+    const updating = Boolean(publicationState?.published && publicationState.updateAvailable);
+    setGoingOnline(true);
     try {
-      if (publicationState?.published) {
-        const apiId = publicationState.detail?.id;
-        if (!apiId) throw new Error('Runtime API 身份缺失，请刷新同步状态后重试');
-        await syncDataServiceRuntime(apiId);
-        message.success(`Runtime 已同步到 DS R${latestPublished.revisionNo}`);
-      } else {
-        await deployDataServiceRuntime(node.id);
-        message.success(`Runtime 已部署 · DS R${latestPublished.revisionNo} · 默认停用`);
-      }
+      await bringDataServiceOnline(node.id, publicationState);
       await loadPublicationState(true, true);
+      message.success(
+        updating
+          ? `DS R${latestPublished.revisionNo} 已更新上线`
+          : `API 已上线 · DS R${latestPublished.revisionNo}`,
+      );
     } catch (error) {
-      message.error(error instanceof Error ? error.message : '部署 Data Service Runtime 失败');
+      message.error(error instanceof Error ? error.message : 'Data Service API 上线失败');
     } finally {
-      setDeploying(false);
+      setGoingOnline(false);
     }
   };
 
@@ -618,22 +648,6 @@ export default function DataServiceNodeEditor({
     },
   ], []);
 
-  const latestPublished = context?.latestPublishedRevision;
-  const runtimeRevisionNo = publicationState?.detail?.sourceRevisionNo;
-  const runtimeStatus = !latestPublished
-    ? '等待发布 DS Revision'
-    : publicationLoading
-      ? '正在查询 Runtime'
-      : publicationError
-        ? 'Runtime 状态不可用'
-        : !publicationState?.published
-          ? '尚未部署'
-          : publicationState.updateAvailable
-            ? `Runtime DS R${runtimeRevisionNo || '-'} · 待同步`
-            : publicationState.detail?.enabled
-              ? `Runtime DS R${runtimeRevisionNo || '-'} · 运行中`
-              : `Runtime DS R${runtimeRevisionNo || '-'} · 已停用`;
-
   const propertiesPanel = (
     <div className="text-[12px] leading-5">
       <div className="grid grid-cols-[88px_minmax(0,1fr)] items-center gap-x-4 gap-y-4">
@@ -761,15 +775,25 @@ export default function DataServiceNodeEditor({
     </div>
   );
 
-  const deploymentPanel = (
+  const onlinePanel = (
     <div className="text-[12px] leading-5">
+      <div className="mb-4 text-[11px] leading-5 text-[#98a2b3]">
+        发布用于生成稳定版本；需要对外提供服务时点击“上线”。后续发布新版本后使用“更新上线”。
+      </div>
+
       <dl className="m-0 grid grid-cols-[88px_minmax(0,1fr)] gap-x-4 gap-y-4">
-        <dt className="text-[#667085]">最新发布：</dt>
+        <dt className="text-[#667085]">最新版本：</dt>
         <dd className="m-0 text-[#344054]">{latestPublished ? `DS R${latestPublished.revisionNo}` : '尚未发布'}</dd>
-        <dt className="text-[#667085]">Runtime：</dt>
-        <dd className="m-0 text-[#344054]">{runtimeStatus}</dd>
+        <dt className="text-[#667085]">线上版本：</dt>
+        <dd className="m-0 text-[#344054]">
+          {publicationState?.published ? `DS R${onlineRevisionNo || '-'}` : '-'}
+        </dd>
+        <dt className="text-[#667085]">服务状态：</dt>
+        <dd className="m-0 text-[#344054]">{serviceStatus}</dd>
         <dt className="text-[#667085]">Endpoint：</dt>
-        <dd className="m-0 break-all font-mono text-[11px] text-[#344054]">{publicationState?.detail?.runtimePath || '-'}</dd>
+        <dd className="m-0 break-all font-mono text-[11px] text-[#344054]">
+          {publicationState?.detail?.runtimePath || '-'}
+        </dd>
       </dl>
 
       <div className="mt-5 border-t border-[#eef0f2] pt-4">
@@ -777,11 +801,11 @@ export default function DataServiceNodeEditor({
           block
           type="primary"
           icon={<Rocket size={14} />}
-          disabled={!latestPublished}
-          loading={deploying}
-          onClick={() => void deployOrSync()}
+          disabled={onlineActionDisabled}
+          loading={goingOnline}
+          onClick={() => void goOnline()}
         >
-          {publicationState?.published ? '同步最新 Revision' : '部署 Runtime'}
+          {onlineActionLabel}
         </Button>
         {publicationState?.published ? (
           <Button
@@ -805,11 +829,11 @@ export default function DataServiceNodeEditor({
     request: requestPanel,
     response: responsePanel,
     versions: versionsPanel,
-    deployment: deploymentPanel,
+    online: onlinePanel,
   };
 
   const refreshActivePanel = () => {
-    if (activePanel === 'deployment') {
+    if (activePanel === 'online') {
       void loadPublicationState(Boolean(latestPublished), true);
       return;
     }

--- a/yak-ops-ui/src/pages/data-development/data-service-runtime-publication.ts
+++ b/yak-ops-ui/src/pages/data-development/data-service-runtime-publication.ts
@@ -55,26 +55,53 @@ export const fetchDataServicePublicationState = async (
   await HttpUtils.get<DataServicePublicationState>(
     `${DATA_SERVICE_API}/publication/state?sourceType=${encodeURIComponent(DATA_SERVICE_NODE_SOURCE)}&sourceRef=${encodeURIComponent(nodeId)}`,
   ),
-  '查询 Data Service Runtime 同步状态失败',
+  '查询 Data Service 服务状态失败',
 );
 
-export const deployDataServiceRuntime = async (
+/**
+ * Product-level "online" action.
+ *
+ * Runtime publish / republish / enable stay as implementation details so the
+ * Data Development UI only needs to expose 上线 / 更新上线.
+ */
+export const bringDataServiceOnline = async (
   nodeId: DevelopmentId,
-): Promise<DataServiceRuntimeApiSnapshot> => unwrap(
-  await HttpUtils.post<DataServiceRuntimeApiSnapshot>(`${DATA_SERVICE_API}/publish`, {
-    sourceType: DATA_SERVICE_NODE_SOURCE,
-    sourceRef: nodeId,
-    enabled: false,
-  }),
-  '部署 Data Service Runtime 失败',
-);
+  state?: DataServicePublicationState,
+): Promise<DataServiceRuntimeApiSnapshot> => {
+  if (!state?.published) {
+    return unwrap(
+      await HttpUtils.post<DataServiceRuntimeApiSnapshot>(`${DATA_SERVICE_API}/publish`, {
+        sourceType: DATA_SERVICE_NODE_SOURCE,
+        sourceRef: nodeId,
+        enabled: true,
+      }),
+      '上线 Data Service API 失败',
+    );
+  }
 
-export const syncDataServiceRuntime = async (
-  apiId: number | string,
-): Promise<DataServiceRuntimeApiSnapshot> => unwrap(
-  await HttpUtils.post<DataServiceRuntimeApiSnapshot>(
-    `${DATA_SERVICE_API}/${apiId}/republish`,
-    {},
-  ),
-  '同步 Data Service Runtime 失败',
-);
+  const apiId = state.detail?.id;
+  if (!apiId) throw new Error('线上 API 身份缺失，请刷新服务状态后重试');
+
+  let detail = state.detail;
+  if (state.updateAvailable) {
+    detail = unwrap(
+      await HttpUtils.post<DataServiceRuntimeApiSnapshot>(
+        `${DATA_SERVICE_API}/${apiId}/republish`,
+        {},
+      ),
+      '更新上线失败',
+    );
+  }
+
+  if (!detail?.enabled) {
+    detail = unwrap(
+      await HttpUtils.put<DataServiceRuntimeApiSnapshot>(
+        `${DATA_SERVICE_API}/${apiId}/enabled?enabled=true`,
+        {},
+      ),
+      '启用 Data Service API 失败',
+    );
+  }
+
+  return detail;
+};

--- a/yak-ops-ui/src/pages/data-service/index.tsx
+++ b/yak-ops-ui/src/pages/data-service/index.tsx
@@ -15,13 +15,11 @@ import {
   Copy,
   Eye,
   MoreHorizontal,
-  Plus,
   RefreshCw,
   Search,
   Trash2,
 } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import CreateDataServiceModal from './CreateDataServiceModal';
 import DataServiceDetailDrawer from './DataServiceDetailDrawer';
 import {
   DATA_SERVICE_NODE_SOURCE,
@@ -39,7 +37,6 @@ export default function DataServicePage() {
   const [dataSources, setDataSources] = useState<DataSourceOption[]>([]);
   const [loading, setLoading] = useState(false);
   const [keyword, setKeyword] = useState('');
-  const [createOpen, setCreateOpen] = useState(false);
   const [detailTarget, setDetailTarget] = useState<DataServiceApi>();
 
   const load = useCallback(async () => {
@@ -238,16 +235,11 @@ export default function DataServicePage() {
 
   return (
     <div className="h-full bg-white px-6 py-5">
-      <div className="mb-5 flex items-start justify-between gap-4">
-        <div>
-          <h1 className="m-0 text-xl font-semibold text-[#161823]">API 服务</h1>
-          <p className="mb-0 mt-1 text-sm text-black/45">
-            运行已发布的 Data Service，管理启停、API Key、Runtime、OpenAPI 和调用记录。
-          </p>
-        </div>
-        <Button type="primary" icon={<Plus size={16} />} onClick={() => setCreateOpen(true)}>
-          部署 API
-        </Button>
+      <div className="mb-5">
+        <h1 className="m-0 text-xl font-semibold text-[#161823]">API 服务</h1>
+        <p className="mb-0 mt-1 text-sm text-black/45">
+          管理已上线的 Data Service，查看启停、API Key、Runtime、OpenAPI 和调用记录。
+        </p>
       </div>
 
       <div className="mb-3 flex items-center justify-between gap-3">
@@ -270,13 +262,6 @@ export default function DataServicePage() {
         columns={columns}
         pagination={false}
         scroll={{ x: 1050 }}
-      />
-
-      <CreateDataServiceModal
-        open={createOpen}
-        dataSources={dataSources}
-        onCancel={() => setCreateOpen(false)}
-        onCreated={load}
       />
 
       <DataServiceDetailDrawer


### PR DESCRIPTION
## 背景

Data Service 的底层生命周期已经比较清楚，但前端如果直接暴露「发布 DS Revision / 部署 Runtime / 同步 Runtime / 启用 API」，第一次使用仍然需要理解太多实现细节。

这个 PR 只做产品层收口：**保留底层 Published Revision 与 Runtime 的分离，但前端只表达“发布”和“上线”。**

用户现在只需要理解：

```text
开发
  ↓ 保存
草稿
  ↓ 发布
DS Revision
  ↓ 上线
API 运行中
```

后续则是：

```text
发布 R2 → 更新上线
停用 API → 重新上线
```

## 1. Data Service 编辑器隐藏 Runtime 部署语义

右侧最后一个入口从：

- 部署

改成：

- 上线

面板不再展示：

- 部署 Runtime
- 同步 Runtime
- Runtime DS Rn
- 待同步

改为更直接的：

- 最新版本
- 线上版本
- 服务状态
- Endpoint
- 上线 API / 更新上线 / 重新上线 / 已上线

## 2. “上线”成为一个产品级动作

新增前端 `bringDataServiceOnline(...)`，把 Runtime 细节封装在 publication client 内部。

### 第一次上线

用户点击「上线 API」：

```text
内部 publish Runtime Snapshot
+ enabled = true
```

用户不需要知道部署动作。

### 新版本更新上线

例如线上是 R1，开发侧发布 R2 后：

```text
最新版本  DS R2
线上版本  DS R1
状态      有新版本待上线

[更新上线]
```

内部执行 republish，并确保 API 为 enabled。

### 已停用服务

Revision 已经是最新但 API 被停用时只显示：

`重新上线`

内部只恢复 enabled 状态。

## 3. 发布后自然引导到“上线”

发布 DS Revision 后自动展开右侧「上线」面板，并提示：

`已发布 DS Rn · 可继续上线 API`

因此第一次使用的流程自然变成：

```text
预览 → 保存 → 发布 → 上线
```

而不是理解「发布之后为什么还要部署 Runtime」。

## 4. API 服务页面删除“部署 API”入口

「API 服务」页面现在只负责管理已经上线过的数据服务：

- 启停
- API Key
- Runtime 配置
- OpenAPI
- 调用记录

删除顶部「部署 API」按钮和 CreateDataServiceModal 入口，避免形成第二条创建/部署路径。

Data Service 的正式入口统一回到：

`数据开发 → Data Service Node → 发布 → 上线`

## 5. 不修改底层架构

本 PR 不修改：

- Data Service Draft / Revision 模型
- 后端 PublicationService
- Runtime Snapshot 数据结构
- Workflow
- Task Catalog
- 数据库结构

也就是说，代码层仍然保持：

```text
Draft → DS Revision → Runtime Snapshot → enabled
```

只是产品层不再把这些内部步骤全部暴露给使用者。

## 变更范围

最终 diff：**1 commit / 3 frontend files**

- `DataServiceNodeEditor.tsx`
- `data-service-runtime-publication.ts`
- `data-service/index.tsx`

## 检查

- 分支基于最新 `main`（包含 #435 Workbench 样式统一）
- 使用 TypeScript 5.8.3 `transpileModule` 检查 3 个修改文件，parser-level 无语法错误
- 检查修改文件已无用户可见的「部署 Runtime / 同步 Runtime / 同步最新 Revision」文案
- 当前环境无法通过 DNS clone GitHub，因此没有声称完整 npm project build 已通过；继续以 GitHub reported checks 为准

这一轮的核心就是：**架构保持分层，产品体验只保留“发布”和“上线”。**